### PR TITLE
logging: Improve docs, tests, dependencies

### DIFF
--- a/bindings/pydrake/common/module_py.cc
+++ b/bindings/pydrake/common/module_py.cc
@@ -9,6 +9,7 @@
 #include "drake/common/drake_path.h"
 #include "drake/common/find_resource.h"
 #include "drake/common/temp_directory.h"
+#include "drake/common/text_logging.h"
 
 namespace drake {
 namespace pydrake {
@@ -24,6 +25,8 @@ void trigger_an_assertion_failure() {
 
 PYBIND11_MODULE(_module_py, m) {
   m.doc() = "Bindings for //common:common";
+
+  m.attr("_HAVE_SPDLOG") = logging::kHaveSpdlog;
 
   py::enum_<drake::RandomDistribution>(m, "RandomDistribution")
     .value("kUniform", drake::RandomDistribution::kUniform)

--- a/bindings/pydrake/common/test/module_test.py
+++ b/bindings/pydrake/common/test/module_test.py
@@ -38,3 +38,6 @@ class TestCommon(unittest.TestCase):
         pydrake.common.RandomDistribution.kUniform
         pydrake.common.RandomDistribution.kGaussian
         pydrake.common.RandomDistribution.kExponential
+
+    def test_logging_enabled(self):
+        self.assertTrue(pydrake.common._module_py._HAVE_SPDLOG)

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -1056,10 +1056,36 @@ drake_cc_googletest(
     ],
 )
 
+# This version of text_logging_test is compiled with HAVE_SPDLOG enabled,
+# because that is what Drake's WORKSPACE provides for the @spdlog external.
 drake_cc_googletest(
     name = "text_logging_test",
+    defines = [
+        "TEXT_LOGGING_TEST_SPDLOG=1",
+    ],
+    use_default_main = False,
     deps = [
         ":essential",
+    ],
+)
+
+# This version of text_logging_test re-compiles all source files without
+# defining HAVE_SPDLOG, to ensure that the no-op stubs behave as desired.
+drake_cc_googletest(
+    name = "text_logging_no_spdlog_test",
+    srcs = [
+        "drake_copyable.h",
+        "never_destroyed.h",
+        "test/text_logging_test.cc",
+        "text_logging.cc",
+        "text_logging.h",
+    ],
+    defines = [
+        "TEXT_LOGGING_TEST_SPDLOG=0",
+    ],
+    use_default_main = False,
+    deps = [
+        "@fmt",
     ],
 )
 
@@ -1133,7 +1159,6 @@ drake_py_unittest(
 # TODO(jwnimmer-tri) These tests are currently missing...
 # - drake_assert_test in fancy variants
 # - drake_assert_test_compile in fancy variants
-# - text_logging_test in fancy variants
 # - drake_deprecated_test in fancy variants
 # - cpplint_wrapper_test.py
 

--- a/common/test/text_logging_test.cc
+++ b/common/test/text_logging_test.cc
@@ -6,7 +6,26 @@
 
 #include <gtest/gtest.h>
 
+// The BUILD.bazel rules must supply this flag.  This test code is compiled and
+// run twice -- once with spdlog, and once without.
+#ifndef TEXT_LOGGING_TEST_SPDLOG
+#error Missing a required definition to compile this test case.
+#endif
+
+// Check for the expected HAVE_SPDLOG value.
+#if TEXT_LOGGING_TEST_SPDLOG
+  #ifndef HAVE_SPDLOG
+    #error Missing HAVE_SPDLOG.
+  #endif
+#else
+  #ifdef HAVE_SPDLOG
+    #error Unwanted HAVE_SPDLOG.
+  #endif
+#endif
+
 namespace {
+
+using drake::logging::kHaveSpdlog;
 
 class Streamable {
   template<typename ostream_like>
@@ -16,6 +35,7 @@ class Streamable {
 };
 
 // Call each API function and macro to ensure that all of them compile.
+// These should all compile and run both with and without spdlog.
 GTEST_TEST(TextLoggingTest, SmokeTest) {
   Streamable obj;
   drake::log()->trace("drake::log()->trace test: {} {}", "OK", obj);
@@ -32,55 +52,83 @@ GTEST_TEST(TextLoggingTest, SmokeTest) {
                      "OK", obj);
 }
 
-// Abuse gtest internals to verify that logging actually prints.
-#ifdef HAVE_SPDLOG
+// Check that the constexpr bool is set correctly.
+GTEST_TEST(TextLoggingTest, ConstantTest) {
+  #if TEXT_LOGGING_TEST_SPDLOG
+    EXPECT_TRUE(kHaveSpdlog);
+  #else
+    EXPECT_FALSE(kHaveSpdlog);
+  #endif
+}
+
+// Abuse gtest internals to verify that logging actually prints, when enabled.
 GTEST_TEST(TextLoggingTest, CaptureOutputTest) {
   testing::internal::CaptureStderr();
   drake::log()->info("sentinel string");
   std::string output = testing::internal::GetCapturedStderr();
-  EXPECT_TRUE(output.find("sentinel string") != std::string::npos);
+  #if TEXT_LOGGING_TEST_SPDLOG
+    EXPECT_TRUE(output.find("sentinel string") != std::string::npos);
+  #else
+    EXPECT_EQ(output, "");
+  #endif
 }
-#endif
 
-// Verify that DRAKE_SPDLOG macros succeed in avoiding evaluation of
-// their arguments. (The plain SPDLOG ones currently evaluate unconditionally
-// when expanded but we won't check that here since it could change.)
-#ifdef HAVE_SPDLOG
+// Verify that DRAKE_SPDLOG macros succeed in avoiding evaluation of their
+// arguments. (The plain SPDLOG ones currently evaluate unconditionally when
+// expanded but we won't check that here since it could change.)
 GTEST_TEST(TextLoggingTest, DrakeMacrosDontEvaluateArguments) {
   int tracearg = 0, debugarg = 0;
-  drake::log()->set_level(spdlog::level::off);
 
   // Shouldn't increment argument whether the macro expanded or not, since
   // logging is off.
+  #if TEXT_LOGGING_TEST_SPDLOG
+    drake::log()->set_level(spdlog::level::off);
+  #endif
   DRAKE_SPDLOG_TRACE(drake::log(), "tracearg={}", ++tracearg);
   DRAKE_SPDLOG_DEBUG(drake::log(), "debugarg={}", ++debugarg);
   EXPECT_EQ(tracearg, 0);
   EXPECT_EQ(debugarg, 0);
+  tracearg = 0;
+  debugarg = 0;
 
-  drake::log()->set_level(spdlog::level::trace);
   // Should increment arg only if the macro expanded.
+  #if TEXT_LOGGING_TEST_SPDLOG
+    drake::log()->set_level(spdlog::level::trace);
+  #endif
   DRAKE_SPDLOG_TRACE(drake::log(), "tracearg={}", ++tracearg);
   DRAKE_SPDLOG_DEBUG(drake::log(), "debugarg={}", ++debugarg);
   #ifndef NDEBUG
-    EXPECT_EQ(tracearg, 1);
-    EXPECT_EQ(debugarg, 1);
+    EXPECT_EQ(tracearg, kHaveSpdlog ? 1 : 0);
+    EXPECT_EQ(debugarg, kHaveSpdlog ? 1 : 0);
   #else
     EXPECT_EQ(tracearg, 0);
     EXPECT_EQ(debugarg, 0);
   #endif
+  tracearg = 0;
+  debugarg = 0;
 
-  drake::log()->set_level(spdlog::level::debug);
   // Only DEBUG should increment arg since trace is not enabled.
+  #if TEXT_LOGGING_TEST_SPDLOG
+    drake::log()->set_level(spdlog::level::debug);
+  #endif
   DRAKE_SPDLOG_TRACE(drake::log(), "tracearg={}", ++tracearg);
   DRAKE_SPDLOG_DEBUG(drake::log(), "debugarg={}", ++debugarg);
   #ifndef NDEBUG
-    EXPECT_EQ(tracearg, 1);
-    EXPECT_EQ(debugarg, 2);
+    EXPECT_EQ(tracearg, 0);
+    EXPECT_EQ(debugarg, kHaveSpdlog ? 1 : 0);
   #else
     EXPECT_EQ(tracearg, 0);
     EXPECT_EQ(debugarg, 0);
   #endif
+  tracearg = 0;
+  debugarg = 0;
 }
-#endif
 
 }  // anon namespace
+
+// To enable compiling without depending on @spdlog, we need to provide our own
+// main routine.  The default drake_cc_googletest_main depends on @spdlog.
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/common/text_logging.cc
+++ b/common/text_logging.cc
@@ -1,5 +1,6 @@
 #include "drake/common/text_logging.h"
 
+#include <memory>
 #include <mutex>
 
 #ifdef HAVE_SPDLOG

--- a/common/text_logging.h
+++ b/common/text_logging.h
@@ -36,13 +36,12 @@ to be logged:
 We suggest using the Drake versions of these macros everywhere so that you don't
 have to decide when the argument-evaluation cost is going to be excessive.
 
-The format string syntax is fmtlib; see http://fmtlib.net/3.0.0/syntax.html.
+The format string syntax is fmtlib; see http://fmtlib.net/5.1.0/syntax.html.
 In particular, any class that overloads `operator<<` for `ostream` can be
 printed without any special handling.
 */
 
-#include <memory>
-
+#ifndef DRAKE_DOXYGEN_CXX
 #ifdef HAVE_SPDLOG
 // Before including spdlog, activate the SPDLOG_DEBUG and SPDLOG_TRACE macros
 // if and only if Drake is being compiled in debug mode.  When not in debug
@@ -74,7 +73,7 @@ printed without any special handling.
 #include <spdlog/fmt/ostr.h>
 /* clang-format on */
 
-#else  /* HAVE_SPDLOG */
+#else  // HAVE_SPDLOG
 
 // We always want text_logging.h to provide fmt support to those who include
 // it, even if spdlog is disabled.
@@ -84,25 +83,34 @@ printed without any special handling.
 #include <fmt/ostream.h>
 /* clang-format on */
 
-#endif  /* HAVE_SPDLOG */
+#endif  // HAVE_SPDLOG
+#endif  // DRAKE_DOXYGEN_CXX
 
 #include "drake/common/drake_copyable.h"
 
 namespace drake {
 
 #ifdef HAVE_SPDLOG
-// If we have spdlog, just alias logger into our namespace.
 namespace logging {
-using spdlog::logger;
-}
+
+// If we have spdlog, just alias logger into our namespace.
+/// The drake::logging::logger class provides text logging methods.
+/// See the text_logging.h documentation for a short tutorial.
+using logger = spdlog::logger;
+
+/// True only if spdlog is enabled in this build.
+constexpr bool kHaveSpdlog = true;
+
+}  // namespace logging
 
 #else  // HAVE_SPDLOG
 // If we don't have spdlog, we need to stub out logger.
 
 namespace logging {
+constexpr bool kHaveSpdlog = false;
 
-/// A stubbed-out version of `spdlog::logger`.  Implements only those methods
-/// that we expect to use, as spdlog's API does change from time to time.
+// A stubbed-out version of `spdlog::logger`.  Implements only those methods
+// that we expect to use, as spdlog's API does change from time to time.
 class logger {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(logger)
@@ -140,7 +148,11 @@ class logger {
 #endif  // HAVE_SPDLOG
 
 /// Retrieve an instance of a logger to use for logging; for example:
-///   `drake::log()->info("potato!")`
+/// <pre>
+///   drake::log()->info("potato!")
+/// </pre>
+///
+/// See the text_logging.h documentation for a short tutorial.
 logging::logger* log();
 
 }  // namespace drake

--- a/doc/Doxyfile_CXX.in
+++ b/doc/Doxyfile_CXX.in
@@ -288,7 +288,7 @@ EXPAND_ONLY_PREDEF     = YES
 SEARCH_INCLUDES        = YES
 INCLUDE_PATH           =
 INCLUDE_FILE_PATTERNS  =
-PREDEFINED += DRAKE_DOXYGEN_CXX=1
+PREDEFINED += DRAKE_DOXYGEN_CXX=1 HAVE_SPDLOG=1
 # =============================================================================
 # N.B. The spelling of the macro names between common/drake_copyable.h and this
 # file must be kept in sync!

--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -162,6 +162,7 @@ cc_library(
         # The list of depended-on header-only libraries.
         "@eigen",
         "@fmt",
+        "@spdlog",
         "@stx",
     ],
 )

--- a/tools/workspace/fmt/repository.bzl
+++ b/tools/workspace/fmt/repository.bzl
@@ -8,6 +8,8 @@ def fmt_repository(
     github_archive(
         name = name,
         repository = "fmtlib/fmt",
+        # When changing the fmt version, also update the URL in the file
+        # overview docstring of drake/common/text_logging.h.
         commit = "5.1.0",
         sha256 = "73d4cab4fa8a3482643d8703de4d9522d7a56981c938eca42d929106ff474b44",  # noqa
         build_file = "@drake//tools/workspace/fmt:package.BUILD.bazel",


### PR DESCRIPTION
Noticed while reviewing #9542.

apis:
- Add kHaveSpdlog constexpr, for convenience.

docs:
- Use HAVE_SPDLOG when running Doxygen, so that we document the typical
  Drake build (with spdlog enabled).
- Add documentation for drake::logging::logger alias.
- Disable detailed Doxygen for DRAKE_SPDLOG_TRACE etc. macros.
- Update stale hyperlink to fmt syntax.

tests:
- Run the common/text_logging unit test both with and without spdlog.

pydrake:
- Add drake_shared_library missing dependency on spdlog.
- Add unit test that spdlog is enabled when compiling the bindings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9559)
<!-- Reviewable:end -->
