### PR TITLE
multibody_tree: Restore `CreateDefaultContext`

### DIFF
--- a/multibody/multibody_tree/multibody_tree.h
+++ b/multibody/multibody_tree/multibody_tree.h
@@ -14,6 +14,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_deprecated.h"
 #include "drake/common/drake_optional.h"
+#include "drake/common/pointer_cast.h"
 #include "drake/multibody/multibody_tree/acceleration_kinematics_cache.h"
 #include "drake/multibody/multibody_tree/body.h"
 #include "drake/multibody/multibody_tree/body_node.h"
@@ -1462,6 +1463,22 @@ class MultibodyTree {
   // TODO(amcastro-tri): Consider making this method private and calling it
   // automatically when CreateDefaultContext() is called.
   void Finalize();
+
+  /// (Advanced) Allocates a new context for this %MultibodyTree uniquely
+  /// identifying the state of the multibody system.
+  ///
+  /// @throws std::runtime_error if this is not owned by a MultibodyPlant /
+  /// MultibodyTreeSystem.
+  std::unique_ptr<systems::LeafContext<T>> CreateDefaultContext() const {
+    if (tree_system_ == nullptr) {
+      throw std::runtime_error(
+        "MultibodyTree::CreateDefaultContext(): can only be called from a "
+        "MultibodyTree that is owned by a MultibodyPlant / "
+        "MultibodyTreeSystem");
+    }
+    return dynamic_pointer_cast<systems::LeafContext<T>>(
+        tree_system_->CreateDefaultContext());
+  }
 
   /// Sets default values in the context. For mobilizers, this method sets them
   /// to their _zero_ configuration according to

--- a/multibody/multibody_tree/test/multibody_tree_test.cc
+++ b/multibody/multibody_tree/test/multibody_tree_test.cc
@@ -274,6 +274,16 @@ GTEST_TEST(MultibodyTreeSystem, CatchBadBehavior) {
       ".*MultibodyTreeSystem().*MultibodyTree was null.*");
 }
 
+GTEST_TEST(MultibodyTree, BackwardsCompatibility) {
+  auto owned_tree = std::make_unique<MultibodyTree<double>>();
+  auto* tree = owned_tree.get();
+  DRAKE_EXPECT_THROWS_MESSAGE(
+    tree->CreateDefaultContext(), std::runtime_error,
+    ".*that is owned by a MultibodyPlant.*");
+  MultibodyTreeSystem<double> system(std::move(owned_tree));
+  EXPECT_NO_THROW(tree->CreateDefaultContext());
+}
+
 // Fixture to perform a number of computational tests on a KUKA Iiwa model.
 class KukaIiwaModelTests : public ::testing::Test {
  public:


### PR DESCRIPTION
For downstream usage, specifically in Anzu.

This restores `CreateDefaultContext` so that we can permit the creation of contexts without having to propagate the `MultibodyTreeSystem` along with the `MultibodyTree` object.

\cc @amcastro-tri @jwnimmer-tri 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9565)
<!-- Reviewable:end -->
