### PR TITLE
Refactor internal geometry classification

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -214,6 +214,7 @@ drake_cc_library(
     deps = [
         ":geometry_ids",
         ":geometry_index",
+        ":internal_frame",
         ":materials",
         ":shape_specification",
         "//common:copyable_unique_ptr",
@@ -271,6 +272,7 @@ drake_cc_googletest(
     deps = [
         ":geometry_frame",
         "//common:essential",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/geometry/geometry_frame.h
+++ b/geometry/geometry_frame.h
@@ -38,13 +38,16 @@ class GeometryFrame {
    @param X_PF              The initial pose of this frame F, measured and
                             expressed in the _intended_ parent frame P.
    @param frame_group_id    The optional frame group identifier. If unspecified,
-                            defaults to the common, 0 group. */
+                            defaults to the common, 0 group. Must be
+                            non-negative.  */
   GeometryFrame(const std::string& frame_name, const Isometry3<double>& X_PF,
                 int frame_group_id = 0)
       : id_(FrameId::get_new_id()),
         name_(frame_name),
         X_PF_(X_PF),
-        frame_group_(frame_group_id) {}
+        frame_group_(frame_group_id) {
+    ThrowIfInvalid();
+  }
 
   /** Returns the globally unique id for this geometry specification. Every
    instantiation of %FrameInstance will contain a unique id value. The id
@@ -60,6 +63,14 @@ class GeometryFrame {
   int frame_group() const { return frame_group_; }
 
  private:
+  // Throws an exception if the GeometryFrame is ill configured.
+  void ThrowIfInvalid() const {
+    if (frame_group_ < 0) {
+      throw std::logic_error(
+          "GeometryFrame requires a non-negative frame group");
+    }
+  }
+
   // The *globally* unique identifier for this instance. It is functionally
   // const (i.e. defined in construction) but not marked const to allow for
   // default copying/assigning.

--- a/geometry/geometry_index.h
+++ b/geometry/geometry_index.h
@@ -5,14 +5,19 @@
 namespace drake {
 namespace geometry {
 
-/** Type used to locate a dynamic geometry in the geometry engine. */
+
+/** Index used to identify a geometry in the proximity engine. The same index
+ type applies to both anchored and dynamic geometries. They are distinguished
+ by which method they are passed to.  */
+using ProximityIndex = TypeSafeIndex<class ProximityTag>;
+
+/** Index into the ordered vector of all registered geometries (regardless of
+ parent frame, role, etc.)   */
 using GeometryIndex = TypeSafeIndex<class GeometryTag>;
 
-/** Type used to locate an anchored geometry in the geometry engine. */
-using AnchoredGeometryIndex = TypeSafeIndex<class AnchoredGeometryTag>;
-
-/** Type used to locate a frame pose in the geometry state. */
-using PoseIndex = TypeSafeIndex<class GeometryPoseTag>;
+/** Index into the ordered vector of all registered frames -- by convention,
+ the world frame's index is always zero.  */
+using FrameIndex = TypeSafeIndex<class GeometryTag>;
 
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/geometry_visualization.h
+++ b/geometry/geometry_visualization.h
@@ -1,6 +1,6 @@
 /** @file
  Provides a set of functions to facilitate visualization operations based on
- SceneGraph system state. */
+ SceneGraph system state.  */
 
 #pragma once
 

--- a/geometry/internal_frame.cc
+++ b/geometry/internal_frame.cc
@@ -10,15 +10,17 @@ InternalFrame::InternalFrame() {}
 
 InternalFrame::InternalFrame(SourceId source_id, FrameId frame_id,
                              const std::string& name, int frame_group,
-                             PoseIndex pose_index, FrameId parent_id,
-                             int clique)
+                             FrameIndex index, FrameId parent_id, int clique)
     : source_id_(source_id),
       id_(frame_id),
       name_(name),
       frame_group_(frame_group),
-      pose_index_(pose_index),
+      index_(index),
       clique_(clique),
-      parent_id_(parent_id) {}
+      parent_id_(parent_id) {
+  DRAKE_DEMAND(frame_group >= 0 || frame_group == world_frame_group());
+  DRAKE_DEMAND(clique >= 0 || clique == world_frame_clique());
+}
 
 bool InternalFrame::operator==(const InternalFrame& other) const {
   return id_ == other.id_;

--- a/geometry/internal_frame.h
+++ b/geometry/internal_frame.h
@@ -40,13 +40,12 @@ class InternalFrame {
    @param frame_id      The identifier of _this_ frame.
    @param name          The name of the frame.
    @param frame_group   The frame's frame group membership.
-   @param pose_index    The position in the pose vector of this frame's last
-                        known pose.
+   @param index         The index of this frame in the SceneGraph.
    @param parent_id     The id of the parent frame.
    @param clique        The clique that will be used to prevent self-collision
                         among geometries rigidly affixed to this frame.  */
-  InternalFrame(SourceId source_id, FrameId frame_id, const std::string &name,
-                int frame_group, PoseIndex pose_index, FrameId parent_id,
+  InternalFrame(SourceId source_id, FrameId frame_id, const std::string& name,
+                int frame_group, FrameIndex index, FrameId parent_id,
                 int clique);
 
   /** Compares two %InternalFrame instances for "equality". Two internal frames
@@ -74,8 +73,8 @@ class InternalFrame {
    internal significance or dependencies.  */
   int frame_group() const { return frame_group_; }
 
-  /** Returns the pose index of this frame in the full scene graph.  */
-  PoseIndex pose_index() const { return pose_index_; }
+  /** Returns the index of this frame in the full scene graph.  */
+  FrameIndex index() const { return index_; }
 
   /** Returns the clique associated with this frame.  */
   int clique() const { return clique_; }
@@ -147,6 +146,24 @@ class InternalFrame {
    world frame.  */
   static FrameId world_frame_id() { return kWorldFrame; }
 
+  /** Reports the reserved frame group for the world frame.  */
+  static int world_frame_group() {
+    // Pick a sentinel value that can't be mistaken for initialization noise.
+    // Users cannot declare geometry frames with negative frame groups
+    // so, using this value won't collide with any valid user-specified value.
+    return -1234567;
+  }
+
+  /** Reports the reserved clique for the world frame.  */
+  static int world_frame_clique() {
+    // Pick a sentinel value that can't be mistaken for initialization noise.
+    // Cliques are generated strictly internally. They start at zero and span
+    // the non-negative integers (if roll over occurs, an exception is thrown.)
+    // Therefore, a negative value here cannot collide with valid user values.
+    // Also, the world frame's clique is *not* used.
+    return -1234567;
+  }
+
  private:
   // The identifier of the source, to which this frame belongs.
   SourceId source_id_;
@@ -163,8 +180,8 @@ class InternalFrame {
   // The frame group to which this frame belongs.
   int frame_group_{0};
 
-  // The index in the pose vector where this frame's pose lives.
-  PoseIndex pose_index_;
+  // The index of this frame in the full SceneGraph.
+  FrameIndex index_;
 
   // The clique used to prevent self-collision among the geometries affixed to
   // this frame.

--- a/geometry/internal_geometry.cc
+++ b/geometry/internal_geometry.cc
@@ -4,46 +4,21 @@ namespace drake {
 namespace geometry {
 namespace internal {
 
-InternalGeometry::InternalGeometry() : InternalGeometryBase() {}
-
-InternalGeometry::InternalGeometry(std::unique_ptr<Shape> shape,
-                                   FrameId frame_id, GeometryId geometry_id,
-                                   const std::string& name,
-                                   const Isometry3<double>& X_PG,
-                                   GeometryIndex engine_index,
-                                   const optional<GeometryId>& parent_id)
-    : InternalGeometry(std::move(shape), frame_id, geometry_id, name, X_PG,
-                       engine_index, VisualMaterial(), parent_id) {}
-
-InternalGeometry::InternalGeometry(std::unique_ptr<Shape> shape,
-                                   FrameId frame_id, GeometryId geometry_id,
-                                   const std::string& name,
-                                   const Isometry3<double>& X_PG,
-                                   GeometryIndex engine_index,
-                                   const VisualMaterial& vis_material,
-                                   const optional<GeometryId>& parent_id)
-    : InternalGeometryBase(std::move(shape), geometry_id, name, X_PG,
-                           vis_material),
+InternalGeometry::InternalGeometry(
+    SourceId source_id, std::unique_ptr<Shape> shape, FrameId frame_id,
+    GeometryId geometry_id, std::string name, const Isometry3<double>& X_FG,
+    FrameIndex index, const VisualMaterial& material)
+    : shape_spec_(std::move(shape)),
+      id_(geometry_id),
+      name_(std::move(name)),
+      index_(index),
+      source_id_(source_id),
       frame_id_(frame_id),
-      engine_index_(engine_index),
-      parent_id_(parent_id) {}
+      X_PG_(X_FG),
+      X_FG_(X_FG),
+      parent_geometry_id_(nullopt),
+      visual_material_(material) {}
 
-InternalAnchoredGeometry::InternalAnchoredGeometry() : InternalGeometryBase() {}
-
-InternalAnchoredGeometry::InternalAnchoredGeometry(
-    std::unique_ptr<Shape> shape, GeometryId geometry_id,
-    const std::string& name, const Isometry3<double> X_WG,
-    AnchoredGeometryIndex engine_index)
-    : InternalAnchoredGeometry(std::move(shape), geometry_id, name, X_WG,
-                               engine_index, VisualMaterial()) {}
-
-InternalAnchoredGeometry::InternalAnchoredGeometry(
-    std::unique_ptr<Shape> shape, GeometryId geometry_id,
-    const std::string& name, const Isometry3<double> X_WG,
-    AnchoredGeometryIndex engine_index, const VisualMaterial& vis_material)
-    : InternalGeometryBase(std::move(shape), geometry_id, name, X_WG,
-                           vis_material),
-      engine_index_(engine_index) {}
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -207,7 +207,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
   SceneGraph();
 
   /** Constructor used for scalar conversions. It should only be used to convert
-   _from_ double _to_ other scalar types. */
+   _from_ double _to_ other scalar types.  */
   template <typename U>
   explicit SceneGraph(const SceneGraph<U>& other);
 
@@ -222,7 +222,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
    the inputs associated with that source. Failure to do so will be treated as
    a runtime error during the evaluation of %SceneGraph. %SceneGraph
    will detect that frames have been registered but no values have been
-   provided. */
+   provided.  */
   //@{
 
   /** Registers a new source to the geometry system. The caller must save the
@@ -242,23 +242,23 @@ class SceneGraph final : public systems::LeafSystem<T> {
   SourceId RegisterSource(const std::string& name = "");
 
   /** Reports if the given source id is registered.
-   @param id       The id of the source to query. */
+   @param id       The id of the source to query.  */
   bool SourceIsRegistered(SourceId id) const;
 
   /** Given a valid source `id`, returns a _pose_ input port associated
    with that `id`. This port is used to communicate _pose_ data for registered
    frames.
-   @throws std::logic_error if the source_id is _not_ recognized. */
+   @throws std::logic_error if the source_id is _not_ recognized.  */
   const systems::InputPort<T>& get_source_pose_port(SourceId id) const;
 
   /** Returns the output port which produces the PoseBundle for LCM
-   communication to drake visualizer. */
+   communication to drake visualizer.  */
   const systems::OutputPort<T>& get_pose_bundle_output_port() const {
     return systems::System<T>::get_output_port(bundle_port_index_);
   }
 
   /** Returns the output port which produces the QueryObject for performing
-   geometric queries. */
+   geometric queries.  */
   const systems::OutputPort<T>& get_query_output_port() const {
     return systems::System<T>::get_output_port(query_port_index_);
   }
@@ -304,7 +304,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
    @param frame         The definition of the frame to add.
    @returns  A newly allocated frame id.
    @throws std::logic_error  If the `source_id` does _not_ map to a registered
-                             source or if a context has been allocated. */
+                             source or if a context has been allocated.  */
   FrameId RegisterFrame(SourceId source_id, const GeometryFrame& frame);
 
   /** Registers a new frame F for this source. This hangs frame F on another
@@ -319,7 +319,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
                              registered source,
                              2. If the `parent_id` does _not_ map to a known
                              frame or does not belong to the source, or
-                             3. a context has been allocated. */
+                             3. a context has been allocated.  */
   FrameId RegisterFrame(SourceId source_id, FrameId parent_id,
                         const GeometryFrame& frame);
 
@@ -378,7 +378,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
 
   //@}
 
-  /** Reports the identifier for the world frame. */
+  /** Reports the identifier for the world frame.  */
   static FrameId world_frame_id() {
     return internal::InternalFrame::world_frame_id();
   }
@@ -439,7 +439,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
   // TODO(SeanCurtis-TRI) We should make the QueryObject constructor public,
   // instead of forcing users to call a SceneGraph method to obtain one.
   /** Constructs an empty QueryObject. This is intended for only only by
-   Systems to pass to DeclareAbstractInputPort as the model_value. */
+   Systems to pass to DeclareAbstractInputPort as the model_value.  */
   QueryObject<T> MakeQueryObject() const;
 
  private:

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -74,8 +74,8 @@ class SceneGraphInspector {
 
   /** Returns the visual material of the geometry indicated by the given
    `geometry_id` (if it exists).
-   @throws std::logic_error if the geometry id is invalid.  */
-  const VisualMaterial* GetVisualMaterial(GeometryId geometry_id) const {
+   @throws  std::logic_error if the geometry id is invalid.  */
+  const VisualMaterial& GetVisualMaterial(GeometryId geometry_id) const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->get_visual_material(geometry_id);
   }
@@ -104,7 +104,7 @@ class SceneGraphInspector {
                     details).
    @return The id of the queried geometry.
    @throws std::logic_error if no such geometry exists, multiple geometries have
-                            that name, or if the frame doesn't exist. */
+                            that name, or if the frame doesn't exist.  */
   // TODO(SeanCurtis-TRI): Extend to include role.
   GeometryId GetGeometryIdByName(FrameId frame_id,
                                  const std::string& name) const {

--- a/geometry/test/geometry_frame_test.cc
+++ b/geometry/test/geometry_frame_test.cc
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 
 namespace drake {
 namespace geometry {
@@ -12,6 +13,29 @@ namespace {
 
 using std::make_unique;
 using std::move;
+
+GTEST_TEST(GeometryFrameTest, Constructor) {
+  // Case: use default frame group.
+  const Isometry3<double> pose = Isometry3<double>::Identity();
+  {
+    GeometryFrame frame("frame", pose);
+    EXPECT_EQ(frame.frame_group(), 0);
+  }
+
+  // Case: user-specified, valid frame group.
+  {
+    GeometryFrame frame("frame", pose, 17);
+    EXPECT_EQ(frame.frame_group(), 17);
+  }
+
+  // Case: user-specified, invalid frame group.
+  {
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        GeometryFrame("name", pose, -1),
+        std::logic_error,
+        "GeometryFrame requires a non-negative frame group");
+  }
+}
 
 GTEST_TEST(GeometryFrameTest, IdCopies) {
   Isometry3<double> pose = Isometry3<double>::Identity();

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.h
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.h
@@ -880,7 +880,7 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   ///   The geometry::Shape used for visualization. E.g.: geometry::Sphere,
   ///   geometry::Cylinder, etc.
   /// @param[in] name
-  ///   The name for the geometry. It must satsify the requirements defined in
+  ///   The name for the geometry. It must satisfy the requirements defined in
   ///   drake::geometry::GeometryInstance.
   /// @param[in] material
   ///   The visual material to assign to the geometry.
@@ -1518,23 +1518,9 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   // 2. RegisterAsSourceForSceneGraph() was called on `this` plant.
   // 3. `scene_graph` points to the same SceneGraph instance previously
   //    passed to RegisterAsSourceForSceneGraph().
-  // 4. The body is *not* the world body.
   geometry::GeometryId RegisterGeometry(
       const Body<T>& body, const Isometry3<double>& X_BG,
       const geometry::Shape& shape,
-      const std::string& name,
-      const optional<geometry::VisualMaterial>& material,
-      geometry::SceneGraph<T>* scene_graph);
-
-  // Helper method to register anchored geometry to the world, either visual or
-  // collision. This associates a GeometryId with the world body.
-  // This assumes:
-  // 1. Finalize() was not called on `this` plant.
-  // 2. RegisterAsSourceForSceneGraph() was called on `this` plant.
-  // 3. `scene_graph` points to the same SceneGraph instance previously
-  //    passed to RegisterAsSourceForSceneGraph().
-  geometry::GeometryId RegisterAnchoredGeometry(
-      const Isometry3<double>& X_WG, const geometry::Shape& shape,
       const std::string& name,
       const optional<geometry::VisualMaterial>& material,
       geometry::SceneGraph<T>* scene_graph);

--- a/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
@@ -612,6 +612,10 @@ TEST_F(AcrobotPlantTests, VisualGeometryRegistration) {
                                 kTolerance, MatrixCompareType::relative));
   }
 
+  // TODO(SeanCurtis-TRI): These tests are no longer valid; there *is* a frame
+  // id for the world body. This test needs to be changed so that there is
+  // *another* body that doesn't have geometry.
+#if 0
   // SceneGraph does not register a FrameId for the world. We use this fact
   // to test that GetBodyFrameIdOrThrow() throws an assertion for a body with no
   // FrameId, even though in this model we register an anchored geometry to the
@@ -626,6 +630,7 @@ TEST_F(AcrobotPlantTests, VisualGeometryRegistration) {
   optional<FrameId> undefined_id =
       plant_->GetBodyFrameIdIfExists(world_index());
   EXPECT_EQ(undefined_id, nullopt);
+#endif
 }
 
 // Verifies that the right errors get invoked upon finalization.
@@ -928,9 +933,9 @@ GTEST_TEST(MultibodyPlantTest, CollectRegisteredGeometries) {
     GeometrySet set =
         plant.CollectRegisteredGeometries(
             {&scenario.mutable_plant()->world_body()});
-    EXPECT_EQ(set.num_geometries(), 1);
-    EXPECT_TRUE(set.contains(scenario.ground_id()));
-    EXPECT_EQ(set.num_frames(), 0);
+    EXPECT_EQ(set.num_frames(), 1);
+    EXPECT_EQ(set.num_geometries(), 0);
+    EXPECT_FALSE(set.contains(scenario.ground_id()));
   }
 }
 
@@ -1072,22 +1077,27 @@ GTEST_TEST(MultibodyPlantTest, VisualGeometryRegistration) {
   scene_graph.get_query_output_port().Calc(*context, state_value.get());
 
   const SceneGraphInspector<double>& inspector = query_object.inspector();
-  const VisualMaterial* test_material =
-      inspector.GetVisualMaterial(ground_id);
-  EXPECT_NE(test_material, nullptr);
-  EXPECT_TRUE(CompareMatrices(test_material->diffuse(),
-                              VisualMaterial().diffuse(), 0.0,
-                              MatrixCompareType::absolute));
+  {
+    const VisualMaterial& test_material =
+        inspector.GetVisualMaterial(ground_id);
+    EXPECT_TRUE(CompareMatrices(test_material.diffuse(),
+                                VisualMaterial().diffuse(), 0.0,
+                                MatrixCompareType::absolute));
+  }
 
-  test_material = inspector.GetVisualMaterial(sphere1_id);
-  EXPECT_NE(test_material, nullptr);
-  EXPECT_TRUE(CompareMatrices(test_material->diffuse(), sphere1_diffuse, 0.0,
-                              MatrixCompareType::absolute));
+  {
+    const VisualMaterial& test_material =
+        inspector.GetVisualMaterial(sphere1_id);
+    EXPECT_TRUE(CompareMatrices(test_material.diffuse(), sphere1_diffuse, 0.0,
+                                MatrixCompareType::absolute));
+  }
 
-  test_material = inspector.GetVisualMaterial(sphere2_id);
-  EXPECT_NE(test_material, nullptr);
-  EXPECT_TRUE(CompareMatrices(test_material->diffuse(), sphere2_diffuse, 0.0,
-                              MatrixCompareType::absolute));
+  {
+    const VisualMaterial& test_material =
+        inspector.GetVisualMaterial(sphere2_id);
+    EXPECT_TRUE(CompareMatrices(test_material.diffuse(), sphere2_diffuse, 0.0,
+                                MatrixCompareType::absolute));
+  }
 }
 
 GTEST_TEST(MultibodyPlantTest, LinearizePendulum) {


### PR DESCRIPTION
Second step in #9540.

This PR paves the way for making the SceneGraph abstraction more agnostic of how the geometry is used. The initial incarnation of SceneGraph was overly entangled with proximity queries and, as such, concepts of dynamic and anchored geometry leaked into the SceneGraph implementation and API. This undoes this mistaken entanglement. It also makes the API more expressive in that the world frame becomes a first-class citizen of SceneGraph.

1. Introduce world frame as a legitimate frame.
  - anchored geometry registered directly onto world frame
  - allows anchored geometry to be registered onto anchored geometry; previously this was only possible with dynamic geometry.
2. Combine the two "internal geometry" classes into a single class
  - clean up the interface and documentation at the same time.
3. Modify MBP to exploit the new abstraction.
  - There is now a mapping from the MBP world body to the SG world frame id
  - MBP doesn't have to distinguish whether geometry is anchored or dynamic.

```
Category            added  modified  removed  
----------------------------------------------
code                302    374       251      
comments            108    101       76       
blank               18     0         11       
----------------------------------------------
TOTAL               428    475       338 
```

Sorry for the size.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9570)
<!-- Reviewable:end -->
