### PR TITLE
buildifier: Prefer our own mirror

### DIFF
--- a/tools/workspace/mirrors.bzl
+++ b/tools/workspace/mirrors.bzl
@@ -25,9 +25,9 @@ DEFAULT_MIRRORS = {
         "https://s3.amazonaws.com/drake-mirror/bitbucket/{repository}/{commit}.tar.gz",  # noqa
     ],
     "buildifier": [
-        "https://github.com/bazelbuild/buildtools/releases/download/{version}/{filename}",  # noqa
         "https://drake-mirror.csail.mit.edu/github/bazelbuild/buildtools/releases/{version}/{filename}",  # noqa
         "https://s3.amazonaws.com/drake-mirror/github/bazelbuild/buildtools/releases/{version}/{filename}",  # noqa
+        "https://github.com/bazelbuild/buildtools/releases/download/{version}/{filename}",  # noqa
     ],
     "director": [
         "https://drake-packages.csail.mit.edu/director/{archive}",


### PR DESCRIPTION
Upstream has replaced their release without renumbering it.
For now, we'll prefer our own mirror.

Relates bazelbuild/buildtools#383.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9576)
<!-- Reviewable:end -->
