### PR TITLE
Disable tests that are failing on Nightly Mac TSan builds

### DIFF
--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -437,7 +437,7 @@ drake_cc_googletest(
     data = [
         ":test_models",
     ],
-    tags = vtk_test_tags,
+    tags = vtk_test_tags.append("no_tsan"),
     deps = [
         ":rgbd_camera",
         "//attic/multibody/parsers",
@@ -474,7 +474,7 @@ drake_cc_googletest(
     data = [
         ":test_models",
     ],
-    tags = vtk_test_tags,
+    tags = vtk_test_tags.append("no_tsan"),
     deps = [
         ":rgbd_renderer",
         ":rgbd_renderer_test_util",


### PR DESCRIPTION
See: https://drake-cdash.csail.mit.edu/index.php?project=Drake&showfilters=1&filtercount=2&showfilters=1&filtercombine=and&field1=label&compare1=61&value1=jenkins-mac-highsierra-clang-bazel-nightly-memcheck-tsan-342&field2=buildstarttime&compare2=84&value2=now

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9577)
<!-- Reviewable:end -->
