### PR TITLE
Add sphinx documention of pydrake

### DIFF
--- a/bindings/pydrake/doc/BUILD.bazel
+++ b/bindings/pydrake/doc/BUILD.bazel
@@ -1,0 +1,66 @@
+# -*- python -*-
+
+package(default_visibility = ["//visibility:private"])
+
+load("@drake//tools/skylark:drake_py.bzl", "drake_py_binary")
+load("//tools/lint:lint.bzl", "add_lint_tests")
+load("//tools/skylark:drake_runfiles_binary.bzl", "drake_runfiles_binary")
+
+# We need pydrake to be in the PYTHONPATH for sphinx.ext.autodoc to generate
+# API documentation.
+# TODO(jamiesnape): Can we avoid the need to re-compile pydrake for the host
+# architecture?
+drake_py_binary(
+    name = "sphinx_build_wrapper",
+    srcs = ["sphinx_build_wrapper.py"],
+    data = ["@sphinx//:sphinx-build"],
+    deps = ["//bindings/pydrake"],
+)
+
+drake_runfiles_binary(
+    name = "sphinx_build",
+    target = ":sphinx_build_wrapper",
+)
+
+drake_py_binary(
+    name = "refresh_doc_modules",
+    srcs = ["refresh_doc_modules.py"],
+    deps = ["//bindings/pydrake"],
+)
+
+# TODO(jamiesnape): Refactor into a Starlark rule to share with with
+# //doc:sphinx.
+genrule(
+    name = "sphinx",
+    srcs = glob([
+        "**/*.rst",
+    ]) + ["conf.py"],
+    outs = ["sphinx.zip"],
+    cmd = " ".join([
+        # Run sphinx-build.
+        "$(location :sphinx_build) -b html",  # HTML output.
+        "-a -E -d $(@D)/.doctrees/",  # Don't use caching.
+        "-N -Q",  # Be very quiet.
+        "$$(dirname $(location conf.py))",  # Source dir.
+        "$(@D)/.tmpout",  # Output dir.
+        "&&",
+        # Create zipfile.
+        "( CWD=`pwd` && cd $(@D)/.tmpout && zip -q -r $$CWD/$@ ./ )",
+        "&&",
+        # Cleanup temporary files.
+        "rm -rf $(@D)/.doctrees/ $(@D)/.tmpout",
+    ]),
+    # Some (currently disabled) Sphinx extensions try to reach out to the
+    # network; we should fail-fast if someone tries to turn them on.
+    tags = ["block-network"],
+    tools = [":sphinx_build"],
+)
+
+# TODO(jamiesnape): Refactor to share logic with //doc:serve_sphinx.
+drake_py_binary(
+    name = "serve_sphinx",
+    srcs = ["serve_sphinx.py"],
+    data = [":sphinx.zip"],
+)
+
+add_lint_tests(python_lint_exclude = [":conf.py"])

--- a/bindings/pydrake/doc/README.md
+++ b/bindings/pydrake/doc/README.md
@@ -1,0 +1,12 @@
+# Python Binding Documentation
+
+To build and view documentation:
+
+    cd drake
+    bazel run //bindings/pydrake/doc:serve_sphinx
+
+To regenerate documentation modules:
+
+    cd drake
+    bazel run //bindings/pydrake/doc:refresh_doc_modules -- \
+        --pre_clean --output_dir ${PWD}/bindings/pydrake/doc

--- a/bindings/pydrake/doc/conf.py
+++ b/bindings/pydrake/doc/conf.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+#
+# Configuration file for the Sphinx documentation builder.
+#
+# This file does only contain a selection of the most common options. For a
+# full list see the documentation:
+# http://www.sphinx-doc.org/en/master/config
+
+
+# -- Project information -----------------------------------------------------
+
+project = u'pydrake'
+copyright = u''
+author = u''
+
+# The short X.Y version
+version = u''
+# The full version, including alpha/beta/rc tags
+release = u''
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.mathjax',
+    'sphinx.ext.napoleon',
+]
+
+# The suffix(es) of source filenames.
+source_suffix = '.rst'
+
+# The master toctree document.
+master_doc = 'index'
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+html_copy_source = False
+
+html_show_copyright = False
+
+html_show_sphinx = False

--- a/bindings/pydrake/doc/index.rst
+++ b/bindings/pydrake/doc/index.rst
@@ -1,0 +1,30 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake
+=======
+
+.. toctree::
+    :maxdepth: 1
+
+    pydrake.all
+    pydrake.autodiffutils
+    pydrake.automotive
+    pydrake.common
+    pydrake.examples
+    pydrake.forwarddiff
+    pydrake.geometry
+    pydrake.lcm
+    pydrake.maliput
+    pydrake.manipulation
+    pydrake.math
+    pydrake.multibody
+    pydrake.solvers
+    pydrake.symbolic
+    pydrake.systems
+    pydrake.trajectories
+    pydrake.util
+
+
+.. automodule:: pydrake
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.all.rst
+++ b/bindings/pydrake/doc/pydrake.all.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.all
+===========
+
+.. automodule:: pydrake.all
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.autodiffutils.rst
+++ b/bindings/pydrake/doc/pydrake.autodiffutils.rst
@@ -1,0 +1,9 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.autodiffutils
+=====================
+
+.. automodule:: pydrake.autodiffutils
+    :members:
+    :imported-members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.automotive.rst
+++ b/bindings/pydrake/doc/pydrake.automotive.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.automotive
+==================
+
+.. automodule:: pydrake.automotive
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.common.all.rst
+++ b/bindings/pydrake/doc/pydrake.common.all.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.common.all
+==================
+
+.. automodule:: pydrake.common.all
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.common.rst
+++ b/bindings/pydrake/doc/pydrake.common.rst
@@ -1,0 +1,15 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.common
+==============
+
+.. toctree::
+    :maxdepth: 1
+
+    pydrake.common.all
+
+
+.. automodule:: pydrake.common
+    :members:
+    :imported-members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.examples.acrobot.rst
+++ b/bindings/pydrake/doc/pydrake.examples.acrobot.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.examples.acrobot
+========================
+
+.. automodule:: pydrake.examples.acrobot
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.examples.compass_gait.rst
+++ b/bindings/pydrake/doc/pydrake.examples.compass_gait.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.examples.compass\_gait
+==============================
+
+.. automodule:: pydrake.examples.compass_gait
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.examples.multibody.cart_pole_passive_simulation.rst
+++ b/bindings/pydrake/doc/pydrake.examples.multibody.cart_pole_passive_simulation.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.examples.multibody.cart\_pole\_passive\_simulation
+==========================================================
+
+.. automodule:: pydrake.examples.multibody.cart_pole_passive_simulation
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.examples.multibody.rst
+++ b/bindings/pydrake/doc/pydrake.examples.multibody.rst
@@ -1,0 +1,14 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.examples.multibody
+==========================
+
+.. toctree::
+    :maxdepth: 1
+
+    pydrake.examples.multibody.cart_pole_passive_simulation
+
+
+.. automodule:: pydrake.examples.multibody
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.examples.pendulum.rst
+++ b/bindings/pydrake/doc/pydrake.examples.pendulum.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.examples.pendulum
+=========================
+
+.. automodule:: pydrake.examples.pendulum
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.examples.rimless_wheel.rst
+++ b/bindings/pydrake/doc/pydrake.examples.rimless_wheel.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.examples.rimless\_wheel
+===============================
+
+.. automodule:: pydrake.examples.rimless_wheel
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.examples.rst
+++ b/bindings/pydrake/doc/pydrake.examples.rst
@@ -1,0 +1,18 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.examples
+================
+
+.. toctree::
+    :maxdepth: 1
+
+    pydrake.examples.acrobot
+    pydrake.examples.compass_gait
+    pydrake.examples.pendulum
+    pydrake.examples.rimless_wheel
+    pydrake.examples.van_der_pol
+
+
+.. automodule:: pydrake.examples
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.examples.van_der_pol.rst
+++ b/bindings/pydrake/doc/pydrake.examples.van_der_pol.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.examples.van\_der\_pol
+==============================
+
+.. automodule:: pydrake.examples.van_der_pol
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.forwarddiff.rst
+++ b/bindings/pydrake/doc/pydrake.forwarddiff.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.forwarddiff
+===================
+
+.. automodule:: pydrake.forwarddiff
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.geometry.rst
+++ b/bindings/pydrake/doc/pydrake.geometry.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.geometry
+================
+
+.. automodule:: pydrake.geometry
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.lcm.rst
+++ b/bindings/pydrake/doc/pydrake.lcm.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.lcm
+===========
+
+.. automodule:: pydrake.lcm
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.maliput.all.rst
+++ b/bindings/pydrake/doc/pydrake.maliput.all.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.maliput.all
+===================
+
+.. automodule:: pydrake.maliput.all
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.maliput.api.rst
+++ b/bindings/pydrake/doc/pydrake.maliput.api.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.maliput.api
+===================
+
+.. automodule:: pydrake.maliput.api
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.maliput.dragway.rst
+++ b/bindings/pydrake/doc/pydrake.maliput.dragway.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.maliput.dragway
+=======================
+
+.. automodule:: pydrake.maliput.dragway
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.maliput.rst
+++ b/bindings/pydrake/doc/pydrake.maliput.rst
@@ -1,0 +1,16 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.maliput
+===============
+
+.. toctree::
+    :maxdepth: 1
+
+    pydrake.maliput.all
+    pydrake.maliput.api
+    pydrake.maliput.dragway
+
+
+.. automodule:: pydrake.maliput
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.manipulation.all.rst
+++ b/bindings/pydrake/doc/pydrake.manipulation.all.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.manipulation.all
+========================
+
+.. automodule:: pydrake.manipulation.all
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.manipulation.planner.rst
+++ b/bindings/pydrake/doc/pydrake.manipulation.planner.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.manipulation.planner
+============================
+
+.. automodule:: pydrake.manipulation.planner
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.manipulation.rst
+++ b/bindings/pydrake/doc/pydrake.manipulation.rst
@@ -1,0 +1,15 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.manipulation
+====================
+
+.. toctree::
+    :maxdepth: 1
+
+    pydrake.manipulation.all
+    pydrake.manipulation.planner
+
+
+.. automodule:: pydrake.manipulation
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.math.rst
+++ b/bindings/pydrake/doc/pydrake.math.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.math
+============
+
+.. automodule:: pydrake.math
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.multibody.all.rst
+++ b/bindings/pydrake/doc/pydrake.multibody.all.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.multibody.all
+=====================
+
+.. automodule:: pydrake.multibody.all
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.multibody.benchmarks.acrobot.rst
+++ b/bindings/pydrake/doc/pydrake.multibody.benchmarks.acrobot.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.multibody.benchmarks.acrobot
+====================================
+
+.. automodule:: pydrake.multibody.benchmarks.acrobot
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.multibody.benchmarks.all.rst
+++ b/bindings/pydrake/doc/pydrake.multibody.benchmarks.all.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.multibody.benchmarks.all
+================================
+
+.. automodule:: pydrake.multibody.benchmarks.all
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.multibody.benchmarks.rst
+++ b/bindings/pydrake/doc/pydrake.multibody.benchmarks.rst
@@ -1,0 +1,15 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.multibody.benchmarks
+============================
+
+.. toctree::
+    :maxdepth: 1
+
+    pydrake.multibody.benchmarks.acrobot
+    pydrake.multibody.benchmarks.all
+
+
+.. automodule:: pydrake.multibody.benchmarks
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.multibody.collision.rst
+++ b/bindings/pydrake/doc/pydrake.multibody.collision.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.multibody.collision
+===========================
+
+.. automodule:: pydrake.multibody.collision
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.multibody.inverse_kinematics.rst
+++ b/bindings/pydrake/doc/pydrake.multibody.inverse_kinematics.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.multibody.inverse\_kinematics
+=====================================
+
+.. automodule:: pydrake.multibody.inverse_kinematics
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.multibody.joints.rst
+++ b/bindings/pydrake/doc/pydrake.multibody.joints.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.multibody.joints
+========================
+
+.. automodule:: pydrake.multibody.joints
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.multibody.multibody_tree.all.rst
+++ b/bindings/pydrake/doc/pydrake.multibody.multibody_tree.all.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.multibody.multibody\_tree.all
+=====================================
+
+.. automodule:: pydrake.multibody.multibody_tree.all
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.multibody.multibody_tree.math.rst
+++ b/bindings/pydrake/doc/pydrake.multibody.multibody_tree.math.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.multibody.multibody\_tree.math
+======================================
+
+.. automodule:: pydrake.multibody.multibody_tree.math
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.multibody.multibody_tree.multibody_plant.rst
+++ b/bindings/pydrake/doc/pydrake.multibody.multibody_tree.multibody_plant.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.multibody.multibody\_tree.multibody\_plant
+==================================================
+
+.. automodule:: pydrake.multibody.multibody_tree.multibody_plant
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.multibody.multibody_tree.parsing.rst
+++ b/bindings/pydrake/doc/pydrake.multibody.multibody_tree.parsing.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.multibody.multibody\_tree.parsing
+=========================================
+
+.. automodule:: pydrake.multibody.multibody_tree.parsing
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.multibody.multibody_tree.rst
+++ b/bindings/pydrake/doc/pydrake.multibody.multibody_tree.rst
@@ -1,0 +1,17 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.multibody.multibody\_tree
+=================================
+
+.. toctree::
+    :maxdepth: 1
+
+    pydrake.multibody.multibody_tree.all
+    pydrake.multibody.multibody_tree.math
+    pydrake.multibody.multibody_tree.multibody_plant
+    pydrake.multibody.multibody_tree.parsing
+
+
+.. automodule:: pydrake.multibody.multibody_tree
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.multibody.parsers.rst
+++ b/bindings/pydrake/doc/pydrake.multibody.parsers.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.multibody.parsers
+=========================
+
+.. automodule:: pydrake.multibody.parsers
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.multibody.rigid_body.rst
+++ b/bindings/pydrake/doc/pydrake.multibody.rigid_body.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.multibody.rigid\_body
+=============================
+
+.. automodule:: pydrake.multibody.rigid_body
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.multibody.rigid_body_plant.rst
+++ b/bindings/pydrake/doc/pydrake.multibody.rigid_body_plant.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.multibody.rigid\_body\_plant
+====================================
+
+.. automodule:: pydrake.multibody.rigid_body_plant
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.multibody.rigid_body_tree.rst
+++ b/bindings/pydrake/doc/pydrake.multibody.rigid_body_tree.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.multibody.rigid\_body\_tree
+===================================
+
+.. automodule:: pydrake.multibody.rigid_body_tree
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.multibody.rst
+++ b/bindings/pydrake/doc/pydrake.multibody.rst
@@ -1,0 +1,24 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.multibody
+=================
+
+.. toctree::
+    :maxdepth: 1
+
+    pydrake.multibody.all
+    pydrake.multibody.benchmarks
+    pydrake.multibody.collision
+    pydrake.multibody.inverse_kinematics
+    pydrake.multibody.joints
+    pydrake.multibody.multibody_tree
+    pydrake.multibody.parsers
+    pydrake.multibody.rigid_body
+    pydrake.multibody.rigid_body_plant
+    pydrake.multibody.rigid_body_tree
+    pydrake.multibody.shapes
+
+
+.. automodule:: pydrake.multibody
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.multibody.shapes.rst
+++ b/bindings/pydrake/doc/pydrake.multibody.shapes.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.multibody.shapes
+========================
+
+.. automodule:: pydrake.multibody.shapes
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.solvers.all.rst
+++ b/bindings/pydrake/doc/pydrake.solvers.all.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.solvers.all
+===================
+
+.. automodule:: pydrake.solvers.all
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.solvers.gurobi.rst
+++ b/bindings/pydrake/doc/pydrake.solvers.gurobi.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.solvers.gurobi
+======================
+
+.. automodule:: pydrake.solvers.gurobi
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.solvers.ik.rst
+++ b/bindings/pydrake/doc/pydrake.solvers.ik.rst
@@ -1,0 +1,9 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.solvers.ik
+==================
+
+.. automodule:: pydrake.solvers.ik
+    :members:
+    :imported-members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.solvers.ipopt.rst
+++ b/bindings/pydrake/doc/pydrake.solvers.ipopt.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.solvers.ipopt
+=====================
+
+.. automodule:: pydrake.solvers.ipopt
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.solvers.mathematicalprogram.rst
+++ b/bindings/pydrake/doc/pydrake.solvers.mathematicalprogram.rst
@@ -1,0 +1,9 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.solvers.mathematicalprogram
+===================================
+
+.. automodule:: pydrake.solvers.mathematicalprogram
+    :members:
+    :imported-members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.solvers.mosek.rst
+++ b/bindings/pydrake/doc/pydrake.solvers.mosek.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.solvers.mosek
+=====================
+
+.. automodule:: pydrake.solvers.mosek
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.solvers.osqp.rst
+++ b/bindings/pydrake/doc/pydrake.solvers.osqp.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.solvers.osqp
+====================
+
+.. automodule:: pydrake.solvers.osqp
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.solvers.rst
+++ b/bindings/pydrake/doc/pydrake.solvers.rst
@@ -1,0 +1,20 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.solvers
+===============
+
+.. toctree::
+    :maxdepth: 1
+
+    pydrake.solvers.all
+    pydrake.solvers.gurobi
+    pydrake.solvers.ik
+    pydrake.solvers.ipopt
+    pydrake.solvers.mathematicalprogram
+    pydrake.solvers.mosek
+    pydrake.solvers.osqp
+
+
+.. automodule:: pydrake.solvers
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.symbolic.rst
+++ b/bindings/pydrake/doc/pydrake.symbolic.rst
@@ -1,0 +1,9 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.symbolic
+================
+
+.. automodule:: pydrake.symbolic
+    :members:
+    :imported-members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.systems.all.rst
+++ b/bindings/pydrake/doc/pydrake.systems.all.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.systems.all
+===================
+
+.. automodule:: pydrake.systems.all
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.systems.analysis.rst
+++ b/bindings/pydrake/doc/pydrake.systems.analysis.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.systems.analysis
+========================
+
+.. automodule:: pydrake.systems.analysis
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.systems.controllers.rst
+++ b/bindings/pydrake/doc/pydrake.systems.controllers.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.systems.controllers
+===========================
+
+.. automodule:: pydrake.systems.controllers
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.systems.drawing.rst
+++ b/bindings/pydrake/doc/pydrake.systems.drawing.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.systems.drawing
+=======================
+
+.. automodule:: pydrake.systems.drawing
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.systems.framework.rst
+++ b/bindings/pydrake/doc/pydrake.systems.framework.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.systems.framework
+=========================
+
+.. automodule:: pydrake.systems.framework
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.systems.lcm.rst
+++ b/bindings/pydrake/doc/pydrake.systems.lcm.rst
@@ -1,0 +1,9 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.systems.lcm
+===================
+
+.. automodule:: pydrake.systems.lcm
+    :members:
+    :imported-members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.systems.primitives.rst
+++ b/bindings/pydrake/doc/pydrake.systems.primitives.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.systems.primitives
+==========================
+
+.. automodule:: pydrake.systems.primitives
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.systems.rendering.rst
+++ b/bindings/pydrake/doc/pydrake.systems.rendering.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.systems.rendering
+=========================
+
+.. automodule:: pydrake.systems.rendering
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.systems.rst
+++ b/bindings/pydrake/doc/pydrake.systems.rst
@@ -1,0 +1,23 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.systems
+===============
+
+.. toctree::
+    :maxdepth: 1
+
+    pydrake.systems.all
+    pydrake.systems.analysis
+    pydrake.systems.controllers
+    pydrake.systems.drawing
+    pydrake.systems.framework
+    pydrake.systems.lcm
+    pydrake.systems.primitives
+    pydrake.systems.rendering
+    pydrake.systems.sensors
+    pydrake.systems.trajectory_optimization
+
+
+.. automodule:: pydrake.systems
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.systems.sensors.rst
+++ b/bindings/pydrake/doc/pydrake.systems.sensors.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.systems.sensors
+=======================
+
+.. automodule:: pydrake.systems.sensors
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.systems.trajectory_optimization.rst
+++ b/bindings/pydrake/doc/pydrake.systems.trajectory_optimization.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.systems.trajectory\_optimization
+========================================
+
+.. automodule:: pydrake.systems.trajectory_optimization
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.trajectories.rst
+++ b/bindings/pydrake/doc/pydrake.trajectories.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.trajectories
+====================
+
+.. automodule:: pydrake.trajectories
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.util.all.rst
+++ b/bindings/pydrake/doc/pydrake.util.all.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.util.all
+================
+
+.. automodule:: pydrake.util.all
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.util.compatibility.rst
+++ b/bindings/pydrake/doc/pydrake.util.compatibility.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.util.compatibility
+==========================
+
+.. automodule:: pydrake.util.compatibility
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.util.containers.rst
+++ b/bindings/pydrake/doc/pydrake.util.containers.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.util.containers
+=======================
+
+.. automodule:: pydrake.util.containers
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.util.cpp_const.rst
+++ b/bindings/pydrake/doc/pydrake.util.cpp_const.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.util.cpp\_const
+=======================
+
+.. automodule:: pydrake.util.cpp_const
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.util.cpp_param.rst
+++ b/bindings/pydrake/doc/pydrake.util.cpp_param.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.util.cpp\_param
+=======================
+
+.. automodule:: pydrake.util.cpp_param
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.util.cpp_template.rst
+++ b/bindings/pydrake/doc/pydrake.util.cpp_template.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.util.cpp\_template
+==========================
+
+.. automodule:: pydrake.util.cpp_template
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.util.deprecation.rst
+++ b/bindings/pydrake/doc/pydrake.util.deprecation.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.util.deprecation
+========================
+
+.. automodule:: pydrake.util.deprecation
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.util.eigen_geometry.rst
+++ b/bindings/pydrake/doc/pydrake.util.eigen_geometry.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.util.eigen\_geometry
+============================
+
+.. automodule:: pydrake.util.eigen_geometry
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.util.pybind11_version.rst
+++ b/bindings/pydrake/doc/pydrake.util.pybind11_version.rst
@@ -1,0 +1,8 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.util.pybind11\_version
+==============================
+
+.. automodule:: pydrake.util.pybind11_version
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/pydrake.util.rst
+++ b/bindings/pydrake/doc/pydrake.util.rst
@@ -1,0 +1,22 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.util
+============
+
+.. toctree::
+    :maxdepth: 1
+
+    pydrake.util.all
+    pydrake.util.compatibility
+    pydrake.util.containers
+    pydrake.util.cpp_const
+    pydrake.util.cpp_param
+    pydrake.util.cpp_template
+    pydrake.util.deprecation
+    pydrake.util.eigen_geometry
+    pydrake.util.pybind11_version
+
+
+.. automodule:: pydrake.util
+    :members:
+    :undoc-members:

--- a/bindings/pydrake/doc/refresh_doc_modules.py
+++ b/bindings/pydrake/doc/refresh_doc_modules.py
@@ -1,0 +1,128 @@
+"""Refreshes *.rst files for Python modules."""
+
+import argparse
+import glob
+import os
+from os.path import dirname, isabs, isfile, join
+import sys
+
+import pydrake.all
+# TODO(eric.cousineau): Make an optional `.all` module.
+from pydrake.examples import (
+    acrobot,
+    compass_gait,
+    pendulum,
+    rimless_wheel,
+    van_der_pol,
+)
+# TODO(eric.cousineau): Indicate these as deprecated.
+from pydrake.util import (
+    cpp_const,
+    cpp_param,
+    cpp_template,
+)
+
+EXCLUDE = [
+    "pydrake.third_party",
+]
+
+
+def get_submodules(name):
+    prefix = name + "."
+    out = []
+    for s_name in sys.modules.keys():
+        if s_name in EXCLUDE:
+            continue
+        if not s_name.startswith(prefix):
+            continue
+        sub = s_name[len(prefix):]
+        # Ensure its an immediate child.
+        if "." in sub or sub.startswith("_"):
+            continue
+        # For some reason, things like `pydrake.util` has submodules like
+        # `inspect`, etc, whose value in `sys.modules` are none. Ignore those.
+        # TODO(eric.cousineau): Figure out where these come from, and remove
+        # them.
+        if sys.modules[s_name] is None:
+            continue
+        out.append(s_name)
+    return sorted(out)
+
+
+def has_cc_imported_symbols(name):
+    # Check for `module_py`.
+    if name + "._module_py" in sys.modules:
+        return True
+    pieces = name.split(".")
+    if len(pieces) > 1:
+        sub = pieces[-1]
+        test = ".".join(pieces[:-1] + ["_{}_py".format(sub)])
+        if test in sys.modules:
+            return True
+    return False
+
+
+def write_module(f_name, name, verbose):
+    if verbose:
+        print("Write: {}".format(name))
+    subs = get_submodules(name)
+    with open(f_name, 'w') as f:
+        f.write(".. GENERATED FILE DO NOT EDIT\n")
+        f.write("\n")
+        rst_name = name.replace("_", "\\_")
+        f.write("{}\n".format(rst_name))
+        f.write("=" * len(rst_name) + "\n")
+        f.write("\n")
+        if len(subs) > 0:
+            f.write(".. toctree::\n")
+            f.write("    :maxdepth: 1\n")
+            f.write("\n")
+            for sub in subs:
+                f.write("    {}\n".format(sub))
+            f.write("\n\n")
+        f.write(".. automodule:: {}\n".format(name))
+        f.write("    :members:\n")
+        # See if there's a corresponding private CcPybind library.
+        if has_cc_imported_symbols(name):
+            f.write("    :imported-members:\n")
+        f.write("    :undoc-members:\n")
+    f_dir = dirname(f_name)
+    for sub in subs:
+        write_module(join(f_dir, sub) + ".rst", sub, verbose)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output_dir", type=str, required=True,
+        help="Output directory; must be an absolute path, and must already "
+             "exist.")
+    parser.add_argument(
+        "--pre_clean", action="store_true",
+        help="Remove `index.rst` and all `pydrake.*.rst` files before "
+             "generating.")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args()
+
+    output_dir = args.output_dir
+    if not isabs(output_dir):
+        sys.stderr.write(
+            "Please provide an absolute path.\n")
+        sys.exit(1)
+    pre_clean = args.pre_clean
+    verbose = args.verbose
+
+    index_file = join(output_dir, "index.rst")
+    if pre_clean:
+        old_files = glob.glob(join(output_dir, "pydrake.*.rst"))
+        if isfile(index_file):
+            old_files.append(index_file)
+        for old_file in sorted(old_files):
+            if verbose:
+                print("Remove: {}".format(old_file))
+            os.remove(old_file)
+    write_module(index_file, "pydrake", verbose)
+
+
+if __name__ == "__main__":
+    main()

--- a/bindings/pydrake/doc/serve_sphinx.py
+++ b/bindings/pydrake/doc/serve_sphinx.py
@@ -1,0 +1,68 @@
+"""
+This program serves sphinx.zip for a web browser.
+
+Run this via:
+  $ bazel run //bindings/pydrake/doc:serve_sphinx
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+import webbrowser
+import zipfile
+from SimpleHTTPServer import SimpleHTTPRequestHandler
+from SocketServer import TCPServer
+
+
+def str2bool(value):
+    # From: https://stackoverflow.com/a/19233287/7829525
+    return value.lower() in ("yes", "y", "true", "t", "1")
+
+
+parser = argparse.ArgumentParser()
+parser.register('type', 'bool', str2bool)
+parser.add_argument(
+    "--browser", type='bool', default=True, metavar='BOOL',
+    help="Open browser. Disable this if you are frequently recompiling.")
+args = parser.parse_args()
+
+# Unpack zipfile and chdir into it.
+with zipfile.ZipFile("bindings/pydrake/doc/sphinx.zip", "r") as archive:
+    archive.extractall("sphinx-tmp")
+os.chdir("sphinx-tmp")
+file_url = "file://%s/index.html " % os.path.abspath(os.getcwd())
+
+
+# An HTTP handler without logging.
+class Handler(SimpleHTTPRequestHandler):
+    def log_request(*_):
+        pass
+
+
+# Serve the current directory for local browsing.
+sockaddr = ("127.0.0.1", 8001)
+TCPServer.allow_reuse_address = True
+httpd = TCPServer(sockaddr, Handler)
+http_url = "http://%s:%s/index.html" % sockaddr
+
+# Users can click these as a backup, if the auto-open below doesn't work.
+print >>sys.stderr, "Sphinx preview docs are available at:"
+print >>sys.stderr
+print >>sys.stderr, "  " + http_url
+print >>sys.stderr
+print >>sys.stderr, "  " + file_url
+print >>sys.stderr
+
+# Try the default browser, then wait.
+if args.browser:
+    print >>sys.stderr, "Opening webbrowser"
+    if sys.platform == "darwin":
+        # macOS
+        webbrowser.open(http_url)
+    else:
+        # Ubuntu
+        webbrowser.open("./index.html")
+
+print >>sys.stderr, "Serving and waiting ... use Ctrl-C to exit."
+httpd.serve_forever()

--- a/bindings/pydrake/doc/sphinx_build_wrapper.py
+++ b/bindings/pydrake/doc/sphinx_build_wrapper.py
@@ -1,0 +1,14 @@
+# -*- coding: UTF-8 -*-
+
+import os
+import sys
+
+
+runfiles_dir = os.environ.get('DRAKE_BAZEL_RUNFILES')
+assert runfiles_dir, 'Environment variable DRAKE_BAZEL_RUNFILES is NOT set.'
+sphinx_build_path = os.path.join(runfiles_dir, 'external/sphinx/sphinx-build')
+assert os.path.exists(sphinx_build_path), \
+    'Path {} does NOT exist.'.format(sphinx_build_path)
+os.environ['LANG'] = 'en_US.UTF-8'
+argv = [sphinx_build_path] + sys.argv[1:]
+os.execv(argv[0], argv)

--- a/bindings/pydrake/util/all.py
+++ b/bindings/pydrake/util/all.py
@@ -1,5 +1,10 @@
+from .compatibility import *
+from .containers import *
 # - `cpp_const` does not offer public Drake symbols.
 # - `cpp_param` does not offer public Drake symbols.
 # - `cpp_template` does not offer public Drake symbols.
 from .eigen_geometry import *
 # - `deprecation` does not offer public Drake symbols.
+# N.B. Since this is generic and relatively scoped, we import the module as a
+# symbol.
+from . import pybind11_version

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,6 +1,6 @@
 
 .. image:: images/logo_w_text.jpg
-	:align: center   
+	:align: center
 	:width: 60%
 
 
@@ -125,7 +125,8 @@ Next steps
    installation
    gallery
    getting_help
-   Doxygen (C++) <doxygen_cxx/index.html#://>
+   API Documentation (C++) <doxygen_cxx/index.html#://>
+   API Documentation (Python) <pydrake/index.html#://>
    GitHub <https://github.com/RobotLocomotion/drake>
    developers
    credits

--- a/doc/python_bindings.rst
+++ b/doc/python_bindings.rst
@@ -177,13 +177,10 @@ explicitly refer to each symbol:
     simulator = pydrake.systems.analysis.Simulator(
         pydrake.multibody.rigid_body_plant.RigidBodyPlant(tree))
 
-Documentation
-=============
+Differences with C++ API
+========================
 
-There is not yet a comprehensive API documentation for the Python bindings
-(tracked by `#7914 <https://github.com/RobotLocomotion/drake/issues/7914>`_).
-
-In general, the Python API should be close to the
+In general, the `Python API <pydrake/index.html#://>`_ should be close to the
 `C++ API <doxygen_cxx/index.html#://>`_. There are some exceptions:
 
 C++ Template Instantiations in Python

--- a/setup/mac/source_distribution/requirements.txt
+++ b/setup/mac/source_distribution/requirements.txt
@@ -1,2 +1,3 @@
 pygame
 Sphinx
+sphinx_rtd_theme

--- a/setup/ubuntu/16.04/source_distribution/packages.txt
+++ b/setup/ubuntu/16.04/source_distribution/packages.txt
@@ -48,6 +48,7 @@ python-gtk2
 python-protobuf
 python-pygame
 python-sphinx
+python-sphinx-rtd-theme
 ruby
 unzip
 valgrind

--- a/setup/ubuntu/18.04/source_distribution/packages.txt
+++ b/setup/ubuntu/18.04/source_distribution/packages.txt
@@ -48,6 +48,7 @@ python-gtk2
 python-protobuf
 python-pygame
 python-sphinx
+python-sphinx-rtd-theme
 ruby
 unzip
 valgrind


### PR DESCRIPTION
There are a few issues at the moment. `sphinx-apidoc` cannot detect pure C extensions, so the skeleton `.rst` files have had to be hand-coded, and the pure Python documentation causes large numbers of warnings (promoted to errors) and is interspersed with Doxygen notation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9578)
<!-- Reviewable:end -->
