### PR TITLE
inverse_dynamics: Add dtor to satisfy unique_ptr fwd decl

### DIFF
--- a/systems/controllers/inverse_dynamics_controller.cc
+++ b/systems/controllers/inverse_dynamics_controller.cc
@@ -141,6 +141,11 @@ InverseDynamicsController<T>::InverseDynamicsController(
   SetUp(kp, ki, kd, *inverse_dynamics, &builder);
 }
 
+// We need this in the *.cc file so that rigid_body_tree.h does not need to be
+// included by our header file.
+template <typename T>
+InverseDynamicsController<T>::~InverseDynamicsController() = default;
+
 template class InverseDynamicsController<double>;
 // TODO(siyuan) template on autodiff.
 // template class InverseDynamicsController<AutoDiffXd>;

--- a/systems/controllers/inverse_dynamics_controller.h
+++ b/systems/controllers/inverse_dynamics_controller.h
@@ -104,6 +104,8 @@ class InverseDynamicsController : public Diagram<T>,
       const VectorX<double>& kd,
       bool has_reference_acceleration);
 
+  ~InverseDynamicsController() override;
+
   /**
    * Sets the integral part of the PidController to @p value.
    * @p value must be a column vector of the appropriate size.


### PR DESCRIPTION
Same as #9584 -- I didn't realize there were two copies of the defect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9587)
<!-- Reviewable:end -->
