### PR TITLE
better abort message on input size mismatch

### DIFF
--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -2128,9 +2128,14 @@ class System : public SystemBase {
         abstract_value->MaybeGetValue<BasicVector<T>>();
     DRAKE_DEMAND(basic_value != nullptr);
 
-    // Shouldn't have been possible to create this vector-valued port with
-    // the wrong size.
-    DRAKE_DEMAND(basic_value->size() == port.size());
+    if (basic_value->size() != port.size()) {
+      const std::string msg =
+          this->GetSystemPathname() +
+          "has a vector-valued port initialized with a basic vector with size "
+          + std::to_string(basic_value->size()) + " but the port size is " +
+          std::to_string(port.size());
+      DRAKE_ABORT_MSG(msg.c_str());
+    }
 
     return basic_value;
   }


### PR DESCRIPTION
will PR these one at a time as I improve them.  

note -- zapped the comment here, too, because it was misleading.  i hit this failure condition by passing an incorrectly sized vector into "FixInputPort" (for an input exposed through ExportInput on a Diagram).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9591)
<!-- Reviewable:end -->
