### PR TITLE
Adding bindings for several MultibodyTree getters

### DIFF
--- a/bindings/pydrake/multibody/multibody_tree_py.cc
+++ b/bindings/pydrake/multibody/multibody_tree_py.cc
@@ -238,9 +238,26 @@ void init_module(py::module m) {
         .def("CalcRelativeTransform", &Class::CalcRelativeTransform,
              py::arg("context"), py::arg("frame_A"), py::arg("frame_B"),
              doc.MultibodyTree.CalcRelativeTransform.doc)
+        .def("num_frames", &Class::num_frames,
+             doc.MultibodyTree.num_frames.doc)
         .def("get_body", &Class::get_body, py::arg("body_index"),
               py_reference_internal,
               doc.MultibodyTree.get_body.doc)
+        .def("get_joint", &Class::get_joint, py::arg("joint_index"),
+              py_reference_internal,
+              doc.MultibodyTree.get_joint.doc)
+        .def("get_joint_actuator", &Class::get_joint_actuator,
+              py::arg("actuator_index"), py_reference_internal,
+              doc.MultibodyTree.get_joint_actuator.doc)
+        .def("get_frame", &Class::get_frame, py::arg("frame_index"),
+              py_reference_internal,
+              doc.MultibodyTree.get_frame.doc)
+        .def("GetModelInstanceName",
+              overload_cast_explicit<const string&, ModelInstanceIndex>(
+                &Class::GetModelInstanceName),
+              py::arg("model_instance"),
+              py_reference_internal,
+              doc.MultibodyTree.GetModelInstanceName.doc)
         .def("get_multibody_state_vector",
              [](const MultibodyTree<T>* self,
                 const Context<T>& context) -> Eigen::Ref<const VectorX<T>> {
@@ -469,11 +486,21 @@ void init_multibody_plant(py::module m) {
         .def("HasBodyNamed",
              overload_cast_explicit<bool, const string&>(&Class::HasBodyNamed),
              py::arg("name"), doc.MultibodyPlant.HasBodyNamed.doc)
+        .def("HasBodyNamed",
+             overload_cast_explicit<bool, const string&, ModelInstanceIndex>(
+                &Class::HasBodyNamed),
+             py::arg("name"), py::arg("model_instance"),
+             doc.MultibodyPlant.HasBodyNamed.doc_2)
         .def("HasJointNamed",
              overload_cast_explicit<bool, const string&>(
                 &Class::HasJointNamed),
              py::arg("name"),
              doc.MultibodyPlant.HasJointNamed.doc)
+        .def("HasJointNamed",
+             overload_cast_explicit<bool, const string&, ModelInstanceIndex>(
+                &Class::HasJointNamed),
+             py::arg("name"), py::arg("model_instance"),
+             doc.MultibodyPlant.HasJointNamed.doc_2)
         .def("GetFrameByName",
              overload_cast_explicit<const Frame<T>&, const string&>(
                  &Class::GetFrameByName),
@@ -502,11 +529,23 @@ void init_multibody_plant(py::module m) {
              },
              py::arg("name"), py_reference_internal,
              doc.MultibodyPlant.GetJointByName.doc)
+        .def("GetJointByName",
+             [](const Class* self, const string& name,
+                  ModelInstanceIndex model_instance) -> auto& {
+               return self->GetJointByName(name, model_instance);
+             },
+             py::arg("name"), py::arg("model_instance"), py_reference_internal,
+             doc.MultibodyPlant.GetJointByName.doc_2)
         .def("GetJointActuatorByName",
              overload_cast_explicit<const JointActuator<T>&, const string&>(
                 &Class::GetJointActuatorByName),
              py::arg("name"), py_reference_internal,
-             doc.MultibodyPlant.GetJointActuatorByName.doc);
+             doc.MultibodyPlant.GetJointActuatorByName.doc)
+        .def("GetModelInstanceByName",
+             overload_cast_explicit<ModelInstanceIndex, const string&>(
+                &Class::GetModelInstanceByName),
+             py::arg("name"), py_reference_internal,
+             doc.MultibodyPlant.GetModelInstanceByName.doc);
     // Geometry.
     cls
         .def("get_source_id", &Class::get_source_id,

--- a/bindings/pydrake/multibody/test/multibody_tree_test.py
+++ b/bindings/pydrake/multibody/test/multibody_tree_test.py
@@ -115,11 +115,17 @@ class TestMultibodyTree(unittest.TestCase):
             plant.num_actuated_dofs(), benchmark.num_actuated_dofs())
         self.assertTrue(plant.is_finalized())
         self.assertTrue(plant.HasBodyNamed(name="Link1"))
+        self.assertTrue(plant.HasBodyNamed(
+            name="Link1", model_instance=model_instance))
         self.assertTrue(plant.HasJointNamed(name="ShoulderJoint"))
+        self.assertTrue(plant.HasJointNamed(
+            name="ShoulderJoint", model_instance=model_instance))
         shoulder = plant.GetJointByName(name="ShoulderJoint")
         self._test_joint_api(shoulder)
         np.testing.assert_array_equal(shoulder.lower_limits(), [-np.inf])
         np.testing.assert_array_equal(shoulder.upper_limits(), [np.inf])
+        self.assertIs(shoulder, plant.GetJointByName(
+            name="ShoulderJoint", model_instance=model_instance))
         self._test_joint_actuator_api(
             plant.GetJointActuatorByName(name="ElbowJoint"))
         self._test_body_api(plant.GetBodyByName(name="Link1"))
@@ -130,12 +136,23 @@ class TestMultibodyTree(unittest.TestCase):
         self.assertIs(
             plant.GetFrameByName(name="Link1"),
             plant.GetFrameByName(name="Link1", model_instance=model_instance))
+        self.assertEqual(
+            model_instance, plant.GetModelInstanceByName(name="acrobot"))
         self.assertIsInstance(
             plant.get_actuation_input_port(), InputPort)
         self.assertIsInstance(
             plant.get_continuous_state_output_port(), OutputPort)
         self.assertIsInstance(
             plant.get_contact_results_output_port(), OutputPort)
+        tree = plant.tree()
+        self.assertIsInstance(tree.num_frames(), int)
+        self.assertIsInstance(tree.get_body(body_index=BodyIndex(0)), Body)
+        self.assertIs(shoulder, tree.get_joint(joint_index=JointIndex(0)))
+        self.assertIsInstance(tree.get_joint_actuator(
+            actuator_index=JointActuatorIndex(0)), JointActuator)
+        self.assertIsInstance(tree.get_frame(frame_index=FrameIndex(0)), Frame)
+        self.assertEqual("acrobot", tree.GetModelInstanceName(
+            model_instance=model_instance))
 
     def _test_multibody_tree_element_mixin(self, element):
         self.assertIsInstance(element.get_parent_tree(), MultibodyTree)


### PR DESCRIPTION
I added python bindings to expose several getter methods that are useful for pick-and-place planning.

Let me know if I missed a step in the drake code review pipeline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9592)
<!-- Reviewable:end -->
