### PR TITLE
Method to compute Jacobian bias

### DIFF
--- a/multibody/multibody_tree/multibody_tree.cc
+++ b/multibody/multibody_tree/multibody_tree.cc
@@ -899,8 +899,8 @@ template <typename T>
 VectorX<T> MultibodyTree<T>::CalcBiasForPointsGeometricJacobianExpressedInWorld(
     const systems::Context<T>& context,
     const Frame<T>& frame_F,
-    const Eigen::Ref<const MatrixX<T>>& p_FQi_set) const {
-  DRAKE_THROW_UNLESS(p_FQi_set.rows() == 3);
+    const Eigen::Ref<const MatrixX<T>>& p_FQ_list) const {
+  DRAKE_THROW_UNLESS(p_FQ_list.rows() == 3);
 
   const PositionKinematicsCache<T>& pc = EvalPositionKinematics(context);
   const VelocityKinematicsCache<T>& vc = EvalVelocityKinematics(context);
@@ -937,13 +937,13 @@ VectorX<T> MultibodyTree<T>::CalcBiasForPointsGeometricJacobianExpressedInWorld(
   // Bias for body B spatial acceleration.
   const SpatialAcceleration<T>& Ab_WB = A_WB_array[body_B.node_index()];
 
-  const int num_points = p_FQi_set.cols();
+  const int num_points = p_FQ_list.cols();
 
   // Allocate output vector.
   VectorX<T> Ab_WB_array(3 * num_points);
 
   for (int ipoint = 0; ipoint < num_points; ++ipoint) {
-    const Vector3<T> p_FQi = p_FQi_set.col(ipoint);
+    const Vector3<T> p_FQi = p_FQ_list.col(ipoint);
 
     // Body B's orientation.
     const Matrix3<T>& R_WB = pc.get_X_WB(body_B.node_index()).linear();

--- a/multibody/multibody_tree/multibody_tree.cc
+++ b/multibody/multibody_tree/multibody_tree.cc
@@ -896,10 +896,12 @@ void MultibodyTree<T>::CalcPointsGeometricJacobianExpressedInWorld(
 }
 
 template <typename T>
-VectorX<T> MultibodyTree<T>::CalcPointsGeometricJacobianBiasExpressedInWorld(
+VectorX<T> MultibodyTree<T>::CalcBiasForPointsGeometricJacobianExpressedInWorld(
     const systems::Context<T>& context,
     const Frame<T>& frame_F,
     const Eigen::Ref<const MatrixX<T>>& p_FQi_set) const {
+  DRAKE_THROW_UNLESS(p_FQi_set.rows() == 3);
+
   const PositionKinematicsCache<T>& pc = EvalPositionKinematics(context);
   const VelocityKinematicsCache<T>& vc = EvalVelocityKinematics(context);
 
@@ -922,7 +924,7 @@ VectorX<T> MultibodyTree<T>::CalcPointsGeometricJacobianBiasExpressedInWorld(
   VectorX<T> Ab_WB_array(3 * num_points);
 
   for (int ipoint = 0; ipoint < num_points; ++ipoint) {
-    const auto p_FQi = p_FQi_set.col(ipoint);
+    const Vector3<T> p_FQi = p_FQi_set.col(ipoint);
 
     // Body B's orientation.
     const Matrix3<T>& R_WB = pc.get_X_WB(body_B.node_index()).linear();

--- a/multibody/multibody_tree/multibody_tree.cc
+++ b/multibody/multibody_tree/multibody_tree.cc
@@ -930,7 +930,7 @@ VectorX<T> MultibodyTree<T>::CalcBiasForPointsGeometricJacobianExpressedInWorld(
     const Matrix3<T>& R_WB = pc.get_X_WB(body_B.node_index()).linear();
 
     // We need to compute p_BQi_W, the position of Qi in B, expressed in W.
-    const Isometry3<T> X_BF = frame_F.CalcPoseInBodyFrame(context);
+    const Isometry3<T> X_BF = frame_F.GetFixedPoseInBodyFrame();
     const Vector3<T> p_BQi = X_BF * p_FQi;
     const Vector3<T> p_BQi_W = R_WB * p_BQi;
 

--- a/multibody/multibody_tree/multibody_tree.h
+++ b/multibody/multibody_tree/multibody_tree.h
@@ -1783,6 +1783,11 @@ class MultibodyTree {
       const Frame<T>& frame_B, const Eigen::Ref<const MatrixX<T>>& p_WQi_set,
       EigenPtr<MatrixX<T>> Jv_WQi) const;
 
+  VectorX<T> CalcPointsGeometricJacobianBiasExpressedInWorld(
+      const systems::Context<T>& context,
+      const Frame<T>& frame_B,
+      const Eigen::Ref<const MatrixX<T>>& p_BQi_set) const;
+
   /// Given a frame F with fixed position `p_BoFo_B` in a frame B, this method
   /// computes the geometric Jacobian `Jv_WF` defined by:
   /// <pre>

--- a/multibody/multibody_tree/multibody_tree.h
+++ b/multibody/multibody_tree/multibody_tree.h
@@ -1783,7 +1783,7 @@ class MultibodyTree {
       const Frame<T>& frame_B, const Eigen::Ref<const MatrixX<T>>& p_WQi_set,
       EigenPtr<MatrixX<T>> Jv_WQi) const;
 
-  VectorX<T> CalcPointsGeometricJacobianBiasExpressedInWorld(
+  VectorX<T> CalcBiasForPointsGeometricJacobianExpressedInWorld(
       const systems::Context<T>& context,
       const Frame<T>& frame_B,
       const Eigen::Ref<const MatrixX<T>>& p_BQi_set) const;

--- a/multibody/multibody_tree/multibody_tree.h
+++ b/multibody/multibody_tree/multibody_tree.h
@@ -1783,10 +1783,43 @@ class MultibodyTree {
       const Frame<T>& frame_B, const Eigen::Ref<const MatrixX<T>>& p_WQi_set,
       EigenPtr<MatrixX<T>> Jv_WQi) const;
 
+  /// Computes the bias term `b_WFq` associated with the translational
+  /// acceleration `a_WFq` of a point `Q` instantaneously moving with a frame F.
+  /// That is, the translational acceleration of point `Q` can be computed as:
+  /// <pre>
+  ///   a_WFq = Jv_WFq(q)⋅v̇ + b_WFq(q, v)
+  /// </pre>
+  /// where `b_WFq = J̇v_WFq(q, v)⋅v`.
+  ///
+  /// This method computes `b_WFq` for each point `Qi` defined by its position
+  /// `p_FQi` in `frame_F`.
+  ///
+  /// @see CalcPointsGeometricJacobianExpressedInWorld() to compute the
+  /// geometric Jacobian `Jv_WFq(q)`.
+  ///
+  /// @param[in] context
+  ///   The context containing the state of the model. It stores the
+  ///   generalized positions q and generalized velocities v.
+  /// @param[in] frame_F
+  ///   Points `Qi` in the set instantaneously move with this frame.
+  /// @param[in] p_FQi_set
+  ///   A matrix with the fixed position of a set of points `Qi` measured and
+  ///   expressed in `frame_F`.
+  ///   Each column of this matrix contains the position vector `p_FQi` for a
+  ///   point `Qi` measured and expressed in frame F. Therefore this input
+  ///   matrix lives in ℝ³ˣⁿᵖ with `np` the number of points in the set.
+  /// @returns b_WFq
+  ///   The bias term, function of the generalized positions q and the
+  ///   generalized velocities v as stored in `context`.
+  ///   The returned vector has size `3⋅np`, with np the number of points in
+  ///   `p_FQi_set`, and concatenates the bias terms for each point `Qi` in the
+  ///   set in the same order they are specified on input.
+  ///
+  /// @throws std::exception if `p_FQi_set` does not have 3 rows.
   VectorX<T> CalcBiasForPointsGeometricJacobianExpressedInWorld(
       const systems::Context<T>& context,
-      const Frame<T>& frame_B,
-      const Eigen::Ref<const MatrixX<T>>& p_BQi_set) const;
+      const Frame<T>& frame_F,
+      const Eigen::Ref<const MatrixX<T>>& p_FQi_set) const;
 
   /// Given a frame F with fixed position `p_BoFo_B` in a frame B, this method
   /// computes the geometric Jacobian `Jv_WF` defined by:

--- a/multibody/multibody_tree/multibody_tree.h
+++ b/multibody/multibody_tree/multibody_tree.h
@@ -1791,8 +1791,8 @@ class MultibodyTree {
   /// </pre>
   /// where `b_WFq = J̇v_WFq(q, v)⋅v`.
   ///
-  /// This method computes `b_WFq` for each point `Qi` defined by its position
-  /// `p_FQi` in `frame_F`.
+  /// This method computes `b_WFq` for each point `Q` in `p_FQ_list` defined by
+  /// its position `p_FQ` in `frame_F`.
   ///
   /// @see CalcPointsGeometricJacobianExpressedInWorld() to compute the
   /// geometric Jacobian `Jv_WFq(q)`.
@@ -1801,25 +1801,25 @@ class MultibodyTree {
   ///   The context containing the state of the model. It stores the
   ///   generalized positions q and generalized velocities v.
   /// @param[in] frame_F
-  ///   Points `Qi` in the set instantaneously move with this frame.
-  /// @param[in] p_FQi_set
-  ///   A matrix with the fixed position of a set of points `Qi` measured and
+  ///   Points `Q` in the list instantaneously move with this frame.
+  /// @param[in] p_FQ_list
+  ///   A matrix with the fixed position of a list of points `Q` measured and
   ///   expressed in `frame_F`.
-  ///   Each column of this matrix contains the position vector `p_FQi` for a
-  ///   point `Qi` measured and expressed in frame F. Therefore this input
-  ///   matrix lives in ℝ³ˣⁿᵖ with `np` the number of points in the set.
+  ///   Each column of this matrix contains the position vector `p_FQ` for a
+  ///   point `Q` measured and expressed in frame F. Therefore this input
+  ///   matrix lives in ℝ³ˣⁿᵖ with `np` the number of points in the list.
   /// @returns b_WFq
   ///   The bias term, function of the generalized positions q and the
   ///   generalized velocities v as stored in `context`.
   ///   The returned vector has size `3⋅np`, with np the number of points in
-  ///   `p_FQi_set`, and concatenates the bias terms for each point `Qi` in the
-  ///   set in the same order they are specified on input.
+  ///   `p_FQ_list`, and concatenates the bias terms for each point `Q` in the
+  ///   list in the same order they are specified on input.
   ///
-  /// @throws std::exception if `p_FQi_set` does not have 3 rows.
+  /// @throws std::exception if `p_FQ_list` does not have 3 rows.
   VectorX<T> CalcBiasForPointsGeometricJacobianExpressedInWorld(
       const systems::Context<T>& context,
       const Frame<T>& frame_F,
-      const Eigen::Ref<const MatrixX<T>>& p_FQi_set) const;
+      const Eigen::Ref<const MatrixX<T>>& p_FQ_list) const;
 
   /// Given a frame F with fixed position `p_BoFo_B` in a frame B, this method
   /// computes the geometric Jacobian `Jv_WF` defined by:

--- a/multibody/multibody_tree/test/multibody_tree_test.cc
+++ b/multibody/multibody_tree/test/multibody_tree_test.cc
@@ -293,7 +293,7 @@ GTEST_TEST(MultibodyTree, BackwardsCompatibility) {
 // Fixture to perform a number of computational tests on a KUKA Iiwa model.
 class KukaIiwaModelTests : public ::testing::Test {
  public:
-  /// Creates MultibodyTree for a KUKA Iiwa robot arm.
+  // Creates MultibodyTree for a KUKA Iiwa robot arm.
   void SetUp() override {
     {
       // We limit the scope for this MultibodyTree since it only is used for the
@@ -446,7 +446,7 @@ class KukaIiwaModelTests : public ::testing::Test {
   const Body<double>* end_effector_link_{nullptr};
   // Non-owning pointer to a fixed pose frame on the end effector link:
   const Frame<double>* frame_H_{nullptr};
-  RigidTransform<double> X_GH_{
+  const RigidTransform<double> X_GH_{
       RollPitchYaw<double>{M_PI_2, 0, M_PI_2}.ToRotationMatrix(),
       Vector3d{0, 0, 0.081}};
   // Non-owning pointers to the joints:
@@ -673,7 +673,7 @@ TEST_F(KukaIiwaModelTests, CalcBiasForPointsGeometricJacobianExpressedInWorld) {
       tree().CalcBiasForPointsGeometricJacobianExpressedInWorld(
           *context_, *frame_H_, p_HQi),
       std::exception,
-      ".* condition 'p_FQi_set.rows\\(\\) == 3' failed.");
+      ".* condition '.*.rows\\(\\) == 3' failed.");
 }
 
 // Given a set of points Pi attached to the end effector frame G, this test

--- a/multibody/multibody_tree/test/multibody_tree_test.cc
+++ b/multibody/multibody_tree/test/multibody_tree_test.cc
@@ -661,7 +661,8 @@ TEST_F(KukaIiwaModelTests, CalcBiasForPointsGeometricJacobianExpressedInWorld) {
       tree().CalcBiasForPointsGeometricJacobianExpressedInWorld(
       *context_, *frame_H_, p_HPi);
 
-  EXPECT_EQ(Ab_WHp.size(), 3 * kNumPoints);
+  // Ab_WHp is of size 3⋅kNumPoints x num_velocities. CompareMatrices() below
+  // verifies this, in addition to the numerical values of each element.
   EXPECT_TRUE(CompareMatrices(Ab_WHp, Ab_WHp_expected,
                               kTolerance, MatrixCompareType::relative));
 


### PR DESCRIPTION
Implements method to compute the bias term `b_WFq` associated with the translational acceleration `a_WFq` of a point Q moving with a frame F in the model.

cc'ing @RussTedrake, @pangtao22 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9597)
<!-- Reviewable:end -->
