### PR TITLE
add a version of the lcm publisher

### DIFF
--- a/systems/lcm/lcm_publisher_system.h
+++ b/systems/lcm/lcm_publisher_system.h
@@ -33,6 +33,9 @@ namespace lcm {
  * interface in your program, you can let %LcmPublisherSystem allocate and
  * maintain a drake::lcm::DrakeLcm object internally.
  *
+ * @system{ LcmPublisherSystem,
+ *  @input_port{lcm_message}, }
+ *
  * @ingroup message_passing
  */
 class LcmPublisherSystem : public LeafSystem<double> {
@@ -98,6 +101,25 @@ class LcmPublisherSystem : public LeafSystem<double> {
   LcmPublisherSystem(const std::string& channel,
                      const LcmAndVectorBaseTranslator& translator,
                      drake::lcm::DrakeLcmInterface* lcm);
+
+  /**
+   * Constructor that passes a unique_ptr of the LcmAndVectorBaseTranslator,
+   * for the LcmPublisherSystem to own.
+   *
+   * @param[in] channel The LCM channel on which to publish.
+   *
+   * @param[in] translator The translator that converts between LCM message
+   * objects and drake::systems::VectorBase objects.
+   *
+   * @param lcm A pointer to the LCM subsystem to use, which must
+   * remain valid for the lifetime of this object. If null, a
+   * drake::lcm::DrakeLcm object is allocated and maintained internally, but
+   * see the note in the class comments.
+   */
+  LcmPublisherSystem(
+      const std::string& channel,
+      std::unique_ptr<const LcmAndVectorBaseTranslator> translator,
+      drake::lcm::DrakeLcmInterface* lcm);
 
   /**
    * Constructor that returns a publisher System that takes vector data on
@@ -200,6 +222,8 @@ class LcmPublisherSystem : public LeafSystem<double> {
   // allocate and maintain a DrakeLcm object internally.
   LcmPublisherSystem(const std::string& channel,
                      const LcmAndVectorBaseTranslator* translator,
+                     std::unique_ptr<const LcmAndVectorBaseTranslator>
+                         owned_translator,
                      std::unique_ptr<SerializerInterface> serializer,
                      drake::lcm::DrakeLcmInterface* lcm);
 
@@ -218,6 +242,10 @@ class LcmPublisherSystem : public LeafSystem<double> {
   // Converts VectorBase objects into LCM message bytes.
   // Will be non-null iff our input port is vector-valued.
   const LcmAndVectorBaseTranslator* const translator_{};
+
+  // This will be non-null iff the unique_ptr constructor was called.
+  // Internal users should only use translator_.
+  std::unique_ptr<const LcmAndVectorBaseTranslator> const owned_translator_;
 
   // Converts Value<LcmMessage> objects into LCM message bytes.
   // Will be non-null iff our input port is abstract-valued.

--- a/systems/lcm/test/lcm_publisher_system_test.cc
+++ b/systems/lcm/test/lcm_publisher_system_test.cc
@@ -153,12 +153,9 @@ GTEST_TEST(LcmPublisherSystemTest, PublishTest) {
       "drake_system2_lcm_test_publisher_channel_name";
   LcmtDrakeSignalTranslator translator(kDim);
 
-  // Instantiates an LcmPublisherSystem that takes as input System 2.0 Vectors
-  // of type drake::systems::VectorBase and publishes LCM messages of type
+  // Instantiates an LcmPublisherSystem that takes as input of type
+  // drake::systems::VectorBase and publishes LCM messages of type
   // drake::lcmt_drake_signal.
-  //
-  // The LcmPublisherSystem is called "dut" to indicate it is the
-  // "device under test".
   LcmPublisherSystem dut(channel_name, translator, &lcm);
 
   TestPublisher(channel_name, &lcm, &dut);
@@ -178,12 +175,9 @@ GTEST_TEST(LcmPublisherSystemTest, PublishTestUsingDictionary) {
 
   EXPECT_TRUE(dictionary.HasTranslator(channel_name));
 
-  // Instantiates an LcmPublisherSystem that takes as input System 2.0 Vectors
-  // of type drake::systems::VectorBase and publishes LCM messages of type
+  // Instantiates an LcmPublisherSystem that takes as input of type
+  // drake::systems::VectorBase and publishes LCM messages of type
   // drake::lcmt_drake_signal.
-  //
-  // The LcmPublisherSystem is called "dut" to indicate it is the
-  // "device under test".
   LcmPublisherSystem dut(channel_name, dictionary, &lcm);
 
   TestPublisher(channel_name, &lcm, &dut);
@@ -245,6 +239,16 @@ GTEST_TEST(LcmPublisherSystemTest, TestPublishPeriod) {
     EXPECT_EQ(lcm.DecodeLastPublishedMessageAs<lcmt_drake_signal>(
       channel_name).timestamp, expected_time);
   }
+}
+
+GTEST_TEST(LcmPublisherSystemTest, OwnedTranslatorTest) {
+  lcm::DrakeMockLcm lcm;
+  const std::string channel_name = "my_channel";
+  auto translator = std::make_unique<LcmtDrakeSignalTranslator>(kDim);
+
+  LcmPublisherSystem dut(channel_name, std::move(translator), &lcm);
+
+  TestPublisher(channel_name, &lcm, &dut);
 }
 
 }  // namespace


### PR DESCRIPTION
...that maintains ownership of the translator.
This makes it much more compatable with the Systems framework.  (as my next few PRs will reveal)
Related to #9604

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9605)
<!-- Reviewable:end -->
