### PR TITLE
add option to limit maximum recursion depth for sub-diagrams in graphviz output

### DIFF
--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -336,12 +336,13 @@ struct Impl {
         // Sugar.
         .def(
             "GetGraphvizString",
-            [str_py](const System<T>* self) {
+            [str_py](const System<T>* self, int max_depth) {
               // @note This is a workaround; for some reason,
               // casting this using `py::str` does not work, but directly
               // calling the Python function (`str_py`) does.
-              return str_py(self->GetGraphvizString());
-            }, doc.System.GetGraphvizString.doc)
+              return str_py(self->GetGraphvizString(max_depth));
+            }, doc.System.GetGraphvizString.doc,
+            py::arg("max_depth") = std::numeric_limits<int>::max() )
         // Events.
         .def("Publish",
              overload_cast_explicit<void, const Context<T>&>(

--- a/systems/controllers/pid_controller.cc
+++ b/systems/controllers/pid_controller.cc
@@ -122,7 +122,9 @@ void PidController<T>::CalcControl(const Context<T>& context,
 
 // Adds a simple record-based representation of the PID controller to @p dot.
 template <typename T>
-void PidController<T>::GetGraphvizFragment(std::stringstream* dot) const {
+void PidController<T>::GetGraphvizFragment(int max_depth,
+                                           std::stringstream* dot) const {
+  unused(max_depth);
   std::string name = this->get_name();
   if (name.empty()) {
     name = "PID Controller";

--- a/systems/controllers/pid_controller.h
+++ b/systems/controllers/pid_controller.h
@@ -183,7 +183,8 @@ class PidController : public StateFeedbackControllerInterface<T>,
    * controller, since the internal wiring is unimportant and hard for human
    * viewers to parse.
    */
-  void GetGraphvizFragment(std::stringstream* dot) const override;
+  void GetGraphvizFragment(int max_depth,
+                           std::stringstream* dot) const override;
 
   void DoCalcTimeDerivatives(const Context<T>& context,
                              ContinuousState<T>* derivatives) const override;

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -384,14 +384,42 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
 
   /// Returns a Graphviz fragment describing this Diagram. To obtain a complete
   /// Graphviz graph, call System<T>::GetGraphvizString.
-  void GetGraphvizFragment(std::stringstream* dot) const override {
-    // Open the Diagram.
+  void GetGraphvizFragment(int max_depth,
+                           std::stringstream* dot) const override {
     const int64_t id = this->GetGraphvizId();
+    std::string name = this->get_name();
+    if (name.empty()) name = std::to_string(id);
+
+    if (max_depth == 0) {
+      // Open the attributes and label.
+      *dot << id << " [shape=record, label=\"" << name << "|{";
+
+      // Append input ports to the label.
+      *dot << "{";
+      for (int i = 0; i < this->get_num_input_ports(); ++i) {
+        if (i != 0) *dot << "|";
+        *dot << "<u" << i << ">" << this->get_input_port(i).get_name();
+      }
+      *dot << "}";
+
+      // Append output ports to the label.
+      *dot << " | {";
+      for (int i = 0; i < this->get_num_output_ports(); ++i) {
+        if (i != 0) *dot << "|";
+        *dot << "<y" << i << ">" << this->get_output_port(i).get_name();
+      }
+      *dot << "}";
+
+      // Close the label and attributes.
+      *dot << "}\"];" << std::endl;
+
+      return;
+    }
+
+    // Open the Diagram.
     *dot << "subgraph cluster" << id << "diagram" " {" << std::endl;
     *dot << "color=black" << std::endl;
     *dot << "concentrate=true" << std::endl;
-    std::string name = this->get_name();
-    if (name.empty()) name = std::to_string(id);
     *dot << "label=\"" << name << "\";" << std::endl;
 
     // Add a cluster for the input port nodes.
@@ -401,7 +429,8 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
     *dot << "style=filled" << std::endl;
     *dot << "label=\"input ports\"" << std::endl;
     for (int i = 0; i < this->get_num_input_ports(); ++i) {
-      this->GetGraphvizInputPortToken(this->get_input_port(i), dot);
+      this->GetGraphvizInputPortToken(this->get_input_port(i), max_depth,
+                                      dot);
       *dot << "[color=blue, label=\"u" << i << "\"];" << std::endl;
     }
     *dot << "}" << std::endl;
@@ -413,7 +442,8 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
     *dot << "style=filled" << std::endl;
     *dot << "label=\"output ports\"" << std::endl;
     for (int i = 0; i < this->get_num_output_ports(); ++i) {
-      this->GetGraphvizOutputPortToken(this->get_output_port(i), dot);
+      this->GetGraphvizOutputPortToken(this->get_output_port(i), max_depth,
+                                       dot);
       *dot << "[color=green, label=\"y" << i << "\"];" << std::endl;
     }
     *dot << "}" << std::endl;
@@ -424,7 +454,7 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
     *dot << "label=\"\"" << std::endl;
     // -- Add the subsystems themselves.
     for (const auto& subsystem : registered_systems_) {
-      subsystem->GetGraphvizFragment(dot);
+      subsystem->GetGraphvizFragment(max_depth - 1, dot);
     }
     // -- Add the connections as edges.
     for (const auto& edge : connection_map_) {
@@ -433,10 +463,10 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
       const InputPortLocator& dest = edge.first;
       const System<T>* dest_sys = dest.first;
       src_sys->GetGraphvizOutputPortToken(src_sys->get_output_port(src.second),
-                                          dot);
+                                          max_depth - 1, dot);
       *dot << " -> ";
       dest_sys->GetGraphvizInputPortToken(dest_sys->get_input_port(dest.second),
-                                          dot);
+                                          max_depth - 1, dot);
       *dot << ";" << std::endl;
     }
 
@@ -445,19 +475,21 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
     //    (input) and green (output), matching the port nodes.
     for (int i = 0; i < this->get_num_input_ports(); ++i) {
       const auto& port_id = input_port_ids_[i];
-      this->GetGraphvizInputPortToken(this->get_input_port(i), dot);
+      this->GetGraphvizInputPortToken(this->get_input_port(i), max_depth,
+                                      dot);
       *dot << " -> ";
       port_id.first->GetGraphvizInputPortToken(
-          port_id.first->get_input_port(port_id.second), dot);
+          port_id.first->get_input_port(port_id.second), max_depth - 1, dot);
       *dot << " [color=blue];" << std::endl;
     }
 
     for (int i = 0; i < this->get_num_output_ports(); ++i) {
       const auto& port_id = output_port_ids_[i];
       port_id.first->GetGraphvizOutputPortToken(
-          port_id.first->get_output_port(port_id.second), dot);
+          port_id.first->get_output_port(port_id.second), max_depth - 1, dot);
       *dot << " -> ";
-      this->GetGraphvizOutputPortToken(this->get_output_port(i), dot);
+      this->GetGraphvizOutputPortToken(this->get_output_port(i),
+                                       max_depth, dot);
       *dot << " [color=green];" << std::endl;
     }
     *dot << "}" << std::endl;
@@ -467,15 +499,33 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
   }
 
   void GetGraphvizInputPortToken(const InputPort<T>& port,
-                                 std::stringstream* dot) const override {
+                                 int max_depth,
+                                 std::stringstream* dot) const final {
     DRAKE_DEMAND(port.get_system() == this);
-    *dot << "_" << this->GetGraphvizId() << "_u" << port.get_index();
+    // Note: ports are rendered in a fundamentally different way depending on
+    // max_depth.
+    if (max_depth > 0) {
+      // Ports are rendered as nodes in the "input ports" subgraph.
+      *dot << "_" << this->GetGraphvizId() << "_u" << port.get_index();
+    } else {
+      // Ports are rendered as a part of the system label.
+      *dot << this->GetGraphvizId() << ":u" << port.get_index();
+    }
   }
 
   void GetGraphvizOutputPortToken(const OutputPort<T>& port,
-                                  std::stringstream* dot) const override {
+                                  int max_depth,
+                                  std::stringstream* dot) const final {
     DRAKE_DEMAND(&port.get_system() == this);
-    *dot << "_" << this->GetGraphvizId() << "_y" << port.get_index();
+    // Note: ports are rendered in a fundamentally different way depending on
+    // max_depth.
+    if (max_depth > 0) {
+      // Ports are rendered as nodes in the "input ports" subgraph.
+      *dot << "_" << this->GetGraphvizId() << "_y" << port.get_index();
+    } else {
+      // Ports are rendered as a part of the system label.
+      *dot << this->GetGraphvizId() << ":y" << port.get_index();
+    }
   }
 
   //@}

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -449,7 +449,10 @@ class LeafSystem : public System<T> {
   /// |       | y0 |    |
   /// +-------+----+----+
   /// @endverbatim
-  void GetGraphvizFragment(std::stringstream* dot) const override {
+  void GetGraphvizFragment(int max_depth,
+                           std::stringstream* dot) const override {
+    unused(max_depth);
+
     // Use the this pointer as a unique ID for the node in the dotfile.
     const int64_t id = this->GetGraphvizId();
     std::string name = this->get_name();
@@ -481,13 +484,17 @@ class LeafSystem : public System<T> {
   }
 
   void GetGraphvizInputPortToken(const InputPort<T>& port,
+                                 int max_depth,
                                  std::stringstream *dot) const final {
+    unused(max_depth);
     DRAKE_DEMAND(port.get_system() == this);
     *dot << this->GetGraphvizId() << ":u" << port.get_index();
   }
 
   void GetGraphvizOutputPortToken(const OutputPort<T>& port,
+                                  int max_depth,
                                   std::stringstream *dot) const final {
+    unused(max_depth);
     DRAKE_DEMAND(&port.get_system() == this);
     *dot << this->GetGraphvizId() << ":y" << port.get_index();
   }

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -1238,11 +1238,16 @@ class System : public SystemBase {
   /// Returns a Graphviz string describing this System.  To render the string,
   /// use the Graphviz tool, ``dot``.
   /// http://www.graphviz.org/Documentation/dotguide.pdf
-  std::string GetGraphvizString() const {
+  ///
+  /// @param max_depth Sets a limit to the depth of nested diagrams to
+  // visualize.  Set to zero to render a diagram as a single system block.
+  std::string GetGraphvizString(
+      int max_depth = std::numeric_limits<int>::max()) const {
+    DRAKE_DEMAND(max_depth >= 0);
     std::stringstream dot;
     dot << "digraph _" << this->GetGraphvizId() << " {" << std::endl;
     dot << "rankdir=LR" << std::endl;
-    GetGraphvizFragment(&dot);
+    GetGraphvizFragment(max_depth, &dot);
     dot << "}" << std::endl;
     return dot.str();
   }
@@ -1250,22 +1255,28 @@ class System : public SystemBase {
   /// Appends a Graphviz fragment to the @p dot stream.  The fragment must be
   /// valid Graphviz when wrapped in a `digraph` or `subgraph` stanza.  Does
   /// nothing by default.
-  virtual void GetGraphvizFragment(std::stringstream* dot) const {
-    unused(dot);
+  ///
+  /// @param max_depth Sets a limit to the depth of nested diagrams to
+  // visualize.  Set to zero to render a diagram as a single system block.
+  virtual void GetGraphvizFragment(int max_depth,
+                                   std::stringstream* dot) const {
+    unused(dot, max_depth);
   }
 
   /// Appends a fragment to the @p dot stream identifying the graphviz node
   /// representing @p port. Does nothing by default.
   virtual void GetGraphvizInputPortToken(const InputPort<T>& port,
+                                         int max_depth,
                                          std::stringstream* dot) const {
-    unused(port, dot);
+    unused(port, max_depth, dot);
   }
 
   /// Appends a fragment to the @p dot stream identifying the graphviz node
   /// representing @p port. Does nothing by default.
   virtual void GetGraphvizOutputPortToken(const OutputPort<T>& port,
+                                          int max_depth,
                                           std::stringstream* dot) const {
-    unused(port, dot);
+    unused(port, max_depth, dot);
   }
 
   /// Returns an opaque integer that uniquely identifies this system in the

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -1077,6 +1077,12 @@ TEST_F(DiagramOfDiagramsTest, Graphviz) {
   const std::string id1 = std::to_string(
       reinterpret_cast<int64_t>(subdiagram1_));
   EXPECT_NE(std::string::npos, dot.find("_" + id0 + "_y0 -> _" + id1 + "_u0"));
+
+  const int max_depth = 0;
+  const std::string dot_no_depth = diagram_->GetGraphvizString(max_depth);
+  // Check that the subdiagrams no longer appear.
+  EXPECT_EQ(std::string::npos, dot_no_depth.find("label=\"subdiagram0\""));
+  EXPECT_EQ(std::string::npos, dot_no_depth.find("label=\"subdiagram1\""));
 }
 
 // Tests that a diagram composed of diagrams can be evaluated, and gives


### PR DESCRIPTION
As an example:
max_depth=0 
![station0 dot](https://user-images.githubusercontent.com/6442292/46587623-12bdd480-ca5d-11e8-9f29-b76f0c7cbd12.png)
max_depth=1
![station1 dot](https://user-images.githubusercontent.com/6442292/46587624-12bdd480-ca5d-11e8-886d-a996f8b1421f.png)
max_depth=2
![station2 dot](https://user-images.githubusercontent.com/6442292/46587625-12bdd480-ca5d-11e8-9867-e10e65fc19e1.png)
max_depth=3
![station3 dot](https://user-images.githubusercontent.com/6442292/46587626-12bdd480-ca5d-11e8-9ef7-8d3dd3df0bcd.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9611)
<!-- Reviewable:end -->
