### PR TITLE
pydrake: Enable testing to pass under Python3

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -14,7 +14,7 @@
 
 try:
     import drake.lcmtypes
-    __path__.append(drake.lcmtypes.__path__[0] + "/drake")
+    __path__.append(list(drake.lcmtypes.__path__)[0] + "/drake")
     from drake.lcmtypes.drake import *
 except ImportError:
     pass

--- a/bindings/pydrake/common/test/module_test.py
+++ b/bindings/pydrake/common/test/module_test.py
@@ -2,10 +2,16 @@ from __future__ import absolute_import, division, print_function
 
 import os
 import unittest
+
+import six
+
 import pydrake.common
 
 
 class TestCommon(unittest.TestCase):
+    if six.PY2:
+        assertRegex = unittest.TestCase.assertRegexpMatches
+
     def test_drake_demand_throws(self):
         # Drake's assertion errors should turn into SystemExit by default,
         # without the user needing to do anything special.  Here, we trigger a
@@ -16,8 +22,8 @@ class TestCommon(unittest.TestCase):
             self.fail("Did not get a SystemExit")
         except SystemExit as e:
             self.assertTrue(e.code is not None)
-            self.assertRegexpMatches(
-                e.message,
+            self.assertRegex(
+                str(e),
                 ".*".join([
                     "Failure at ",
                     " trigger_an_assertion_failure",

--- a/bindings/pydrake/doc/BUILD.bazel
+++ b/bindings/pydrake/doc/BUILD.bazel
@@ -17,18 +17,12 @@ py_library(
 # TODO(jamiesnape): Can we avoid the need to re-compile pydrake for the host
 # architecture?
 drake_py_binary(
-    name = "sphinx_build_wrapper",
-    srcs = ["sphinx_build_wrapper.py"],
-    data = ["@sphinx//:sphinx-build"],
+    name = "sphinx_build",
+    srcs = ["sphinx_build.py"],
     deps = [
         ":sphinx_pydrake",
         "//bindings/pydrake",
     ],
-)
-
-drake_runfiles_binary(
-    name = "sphinx_build",
-    target = ":sphinx_build_wrapper",
 )
 
 drake_py_binary(

--- a/bindings/pydrake/doc/serve_sphinx.py
+++ b/bindings/pydrake/doc/serve_sphinx.py
@@ -2,8 +2,10 @@
 This program serves sphinx.zip for a web browser.
 
 Run this via:
-  $ bazel run //bindings/pydrake/doc:serve_sphinx
+  $ bazel run //doc:serve_sphinx
 """
+
+from __future__ import print_function
 
 import argparse
 import os
@@ -11,8 +13,9 @@ import subprocess
 import sys
 import webbrowser
 import zipfile
-from SimpleHTTPServer import SimpleHTTPRequestHandler
-from SocketServer import TCPServer
+
+from six.moves.SimpleHTTPServer import SimpleHTTPRequestHandler
+from six.moves.socketserver import TCPServer
 
 
 def str2bool(value):
@@ -25,6 +28,9 @@ parser.register('type', 'bool', str2bool)
 parser.add_argument(
     "--browser", type='bool', default=True, metavar='BOOL',
     help="Open browser. Disable this if you are frequently recompiling.")
+parser.add_argument(
+    "--port", type=int, default=8001, metavar='PORT',
+    help="Port for serving doc pages with a HTTP server.")
 args = parser.parse_args()
 
 # Unpack zipfile and chdir into it.
@@ -41,22 +47,22 @@ class Handler(SimpleHTTPRequestHandler):
 
 
 # Serve the current directory for local browsing.
-sockaddr = ("127.0.0.1", 8001)
+sockaddr = ("127.0.0.1", args.port)
 TCPServer.allow_reuse_address = True
 httpd = TCPServer(sockaddr, Handler)
 http_url = "http://%s:%s/index.html" % sockaddr
 
 # Users can click these as a backup, if the auto-open below doesn't work.
-print >>sys.stderr, "Sphinx preview docs are available at:"
-print >>sys.stderr
-print >>sys.stderr, "  " + http_url
-print >>sys.stderr
-print >>sys.stderr, "  " + file_url
-print >>sys.stderr
+print("Sphinx preview docs are available at:", file=sys.stderr)
+print("", file=sys.stderr)
+print("  " + http_url, file=sys.stderr)
+print("", file=sys.stderr)
+print("  " + file_url, file=sys.stderr)
+print("", file=sys.stderr)
 
 # Try the default browser, then wait.
 if args.browser:
-    print >>sys.stderr, "Opening webbrowser"
+    print("Opening webbrowser", file=sys.stderr)
     if sys.platform == "darwin":
         # macOS
         webbrowser.open(http_url)
@@ -64,5 +70,5 @@ if args.browser:
         # Ubuntu
         webbrowser.open("./index.html")
 
-print >>sys.stderr, "Serving and waiting ... use Ctrl-C to exit."
+print("Serving and waiting ... use Ctrl-C to exit.", file=sys.stderr)
 httpd.serve_forever()

--- a/bindings/pydrake/doc/sphinx_build.py
+++ b/bindings/pydrake/doc/sphinx_build.py
@@ -1,0 +1,13 @@
+# -*- coding: UTF-8 -*-
+
+import os
+import sys
+
+os.environ['LANG'] = 'en_US.UTF-8'
+
+try:
+    from sphinx.cmd.build import main
+    sys.exit(main(sys.argv[1:]))
+except ImportError:
+    from sphinx import main
+    sys.exit(main(sys.argv))

--- a/bindings/pydrake/multibody/multibody_tree_py.cc
+++ b/bindings/pydrake/multibody/multibody_tree_py.cc
@@ -667,6 +667,7 @@ void init_all(py::module m) {
 }  // namespace
 
 PYBIND11_MODULE(multibody_tree, m) {
+  PYDRAKE_PREVENT_PYTHON3_MODULE_REIMPORT(m);
   m.doc() = "MultibodyTree functionality.";
 
   // TODO(eric.cousineau): Split this into separate files. See discussion in

--- a/bindings/pydrake/multibody/test/multibody_tree_test.py
+++ b/bindings/pydrake/multibody/test/multibody_tree_test.py
@@ -43,6 +43,7 @@ import copy
 import math
 import unittest
 
+from six import text_type as unicode
 import numpy as np
 
 from pydrake.common import FindResourceOrThrow
@@ -60,7 +61,7 @@ def get_index_class(cls):
         Joint: JointIndex,
         JointActuator: JointActuatorIndex,
     }
-    for key_cls, index_cls in class_to_index_class_map.iteritems():
+    for key_cls, index_cls in class_to_index_class_map.items():
         if issubclass(cls, key_cls):
             return index_cls
     raise RuntimeError("Unknown class: {}".format(cls))
@@ -388,7 +389,7 @@ class TestMultibodyTree(unittest.TestCase):
         num_joints = 2
         plant = MultibodyPlant()
         instances = []
-        for i in xrange(num_joints + 1):
+        for i in range(num_joints + 1):
             instance = AddModelFromSdfFile(
                 instance_file, "instance_{}".format(i), plant)
             instances.append(instance)

--- a/bindings/pydrake/multibody/test/rigid_body_tree_test.py
+++ b/bindings/pydrake/multibody/test/rigid_body_tree_test.py
@@ -120,8 +120,8 @@ class TestRigidBodyTree(unittest.TestCase):
         # - Check QDotToVelocity and VelocityToQDot methods
         q = tree.getZeroConfiguration()
         v_real = np.zeros(num_v)
-        q_ad = np.array(map(AutoDiffXd, q))
-        v_real_ad = np.array(map(AutoDiffXd, v_real))
+        q_ad = np.array(list(map(AutoDiffXd, q)))
+        v_real_ad = np.array(list(map(AutoDiffXd, v_real)))
 
         kinsol = tree.doKinematics(q)
         kinsol_ad = tree.doKinematics(q_ad)
@@ -224,8 +224,8 @@ class TestRigidBodyTree(unittest.TestCase):
 
         q = tree.getZeroConfiguration()
         v = np.zeros(num_q)
-        q_ad = np.array(map(AutoDiffXd, q))
-        v_ad = np.array(map(AutoDiffXd, v))
+        q_ad = np.array(list(map(AutoDiffXd, q)))
+        v_ad = np.array(list(map(AutoDiffXd, v)))
         kinsol = tree.doKinematics(q, v)
         kinsol_ad = tree.doKinematics(q_ad, v_ad)
 
@@ -316,8 +316,8 @@ class TestRigidBodyTree(unittest.TestCase):
         # Update kinematics.
         kinsol = tree.doKinematics(q, v)
         # AutoDiff
-        q_ad = np.array(map(AutoDiffXd, q))
-        v_ad = np.array(map(AutoDiffXd, v))
+        q_ad = np.array(list(map(AutoDiffXd, q)))
+        v_ad = np.array(list(map(AutoDiffXd, v)))
         kinsol_ad = tree.doKinematics(q_ad, v_ad)
         # Sanity checks:
         # - Actuator map.

--- a/bindings/pydrake/pydrake_pybind.h
+++ b/bindings/pydrake/pydrake_pybind.h
@@ -310,5 +310,24 @@ struct overload_cast_impl {
 template <typename Return, typename... Args>
 constexpr auto overload_cast_explicit = overload_cast_impl<Return, Args...>{};
 
+#if PY_MAJOR_VERSION >= 3
+// The following works around pybind11 modules getting reconstructed /
+// reimported in Python3. See pybind/pybind11#1559 for more details.
+// Use this ONLY when necessary (e.g. when using a utility method which imports
+// the module, within the module itself).
+#define PYDRAKE_PREVENT_PYTHON3_MODULE_REIMPORT(variable) \
+  { \
+    static py::handle variable##_original; \
+    if (variable##_original) { \
+      variable = py::reinterpret_borrow<py::module>(variable##_original); \
+      return; \
+    } else { \
+      variable##_original = variable; \
+    } \
+  }
+#else  // PY_MAJOR_VERSION >= 3
+#define PYDRAKE_PREVENT_PYTHON3_MODULE_REIMPORT(variable)
+#endif  // PY_MAJOR_VERSION >= 3
+
 }  // namespace pydrake
 }  // namespace drake

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -3,9 +3,10 @@ from __future__ import print_function, absolute_import
 from pydrake.solvers import mathematicalprogram as mp
 from pydrake.solvers.mathematicalprogram import SolverType
 
-import numpy as np
 import unittest
 import warnings
+
+import numpy as np
 
 import pydrake
 import pydrake.symbolic as sym
@@ -377,7 +378,7 @@ class TestMathematicalProgram(unittest.TestCase):
             self.assertTrue(np.isnan(prog.GetInitialGuess(x)).all())
 
         # Test setting individual variables
-        for i in xrange(count):
+        for i in range(count):
             prog.SetInitialGuess(x[i], x0[i])
             self.assertEqual(prog.GetInitialGuess(x[i]), x0[i])
         check_and_reset()

--- a/bindings/pydrake/symbolic.py
+++ b/bindings/pydrake/symbolic.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+import functools
+
 from ._symbolic_py import *
 
 # Explicitly import private symbols
@@ -8,9 +10,9 @@ from ._symbolic_py import __logical_and, __logical_or
 
 def logical_and(*formulas):
     assert len(formulas) >= 1, "Must supply at least one operand"
-    return reduce(__logical_and, formulas)
+    return functools.reduce(__logical_and, formulas)
 
 
 def logical_or(*formulas):
     assert len(formulas) >= 1, "Must supply at least one operand"
-    return reduce(__logical_or, formulas)
+    return functools.reduce(__logical_or, formulas)

--- a/bindings/pydrake/symbolic_py.cc
+++ b/bindings/pydrake/symbolic_py.cc
@@ -339,7 +339,8 @@ PYBIND11_MODULE(_symbolic_py, m) {
     return Jacobian(f, vars);
   }, doc.Expression.Jacobian.doc);
 
-  py::class_<Formula>(m, "Formula")
+  py::class_<Formula> formula(m, "Formula", doc.Formula.doc);
+  formula
       .def("GetFreeVariables", &Formula::GetFreeVariables,
         doc.Formula.GetFreeVariables.doc)
       .def("EqualTo", &Formula::EqualTo, doc.Formula.EqualTo.doc)
@@ -376,13 +377,17 @@ PYBIND11_MODULE(_symbolic_py, m) {
            [](const Formula& self) { return std::hash<Formula>{}(self); })
       .def_static("True", &Formula::True, doc.FormulaTrue.doc)
       .def_static("False", &Formula::False, doc.FormulaFalse.doc)
+      // `True` and `False` are reserved as of Python3
+      .def_static("True_", &Formula::True, doc.FormulaTrue.doc)
+      .def_static("False_", &Formula::False, doc.FormulaFalse.doc)
       .def("__nonzero__", [](const Formula&) {
         throw std::runtime_error(
-            "You should not call `__nonzero__` on `Formula`. If you are trying "
-            "to make a map with `Variable`, `Expression`, or `Polynomial` as "
-            "keys and access the keys, please use "
-            "`pydrake.util.containers.EqualToDict`.");
+            "You should not call `__bool__` / `__nonzero__` on `Formula`. "
+            "If you are trying to make a map with `Variable`, `Expression`, "
+            "or `Polynomial` as keys (and then access the map in Python), "
+            "please use pydrake.util.containers.EqualToDict`.");
       });
+  formula.attr("__bool__") = formula.attr("__nonzero__");
 
   // Cannot overload logical operators: http://stackoverflow.com/a/471561
   // Defining custom function for clarity.

--- a/bindings/pydrake/systems/framework_py.cc
+++ b/bindings/pydrake/systems/framework_py.cc
@@ -7,6 +7,7 @@ namespace drake {
 namespace pydrake {
 
 PYBIND11_MODULE(framework, m) {
+  PYDRAKE_PREVENT_PYTHON3_MODULE_REIMPORT(m);
   m.doc() = "Bindings for the core Systems framework.";
 
   // Import autodiff and symbolic modules so that their types are declared for

--- a/bindings/pydrake/systems/scalar_conversion.py
+++ b/bindings/pydrake/systems/scalar_conversion.py
@@ -215,5 +215,6 @@ class TemplateSystem(TemplateClass):
 
             converter.Add[T, U](conversion)
 
-        map(add_captured, self._T_pairs)
+        for T_pair in self._T_pairs:
+            add_captured(T_pair)
         return converter

--- a/bindings/pydrake/systems/systems_pybind.h
+++ b/bindings/pydrake/systems/systems_pybind.h
@@ -83,8 +83,8 @@ be destroyed when it is replaced, since it is stored using `unique_ptr<>`.
   }
   py_class.def("set_value", &Class::set_value, set_value_docstring.c_str());
   // Register instantiation.
-  py::module py_module = py::module::import("pydrake.systems.framework");
-  AddTemplateClass(py_module, "Value", py_class, GetPyParam<T>());
+  py::module py_framework = py::module::import("pydrake.systems.framework");
+  AddTemplateClass(py_framework, "Value", py_class, GetPyParam<T>());
   return py_class;
 }
 

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -39,7 +39,7 @@ class CustomAdder(LeafSystem):
     # Reimplements `Adder`.
     def __init__(self, num_inputs, size):
         LeafSystem.__init__(self)
-        for i in xrange(num_inputs):
+        for i in range(num_inputs):
             self._DeclareInputPort(kUseDefaultName, PortDataType.kVectorValued,
                                    size)
         self._DeclareVectorOutputPort("sum", BasicVector(size), self._calc_sum)
@@ -49,7 +49,7 @@ class CustomAdder(LeafSystem):
         # since they are not stored densely.
         sum = sum_data.get_mutable_value()
         sum[:] = 0
-        for i in xrange(context.get_num_input_ports()):
+        for i in range(context.get_num_input_ports()):
             input_vector = self.EvalVectorInput(context, i)
             sum += input_vector.get_value()
 

--- a/bindings/pydrake/systems/test/lcm_test.py
+++ b/bindings/pydrake/systems/test/lcm_test.py
@@ -4,6 +4,7 @@ import collections
 import unittest
 
 import numpy as np
+from six import text_type as unicode
 
 from robotlocomotion import quaternion_t
 

--- a/bindings/pydrake/systems/test/sensors_test.py
+++ b/bindings/pydrake/systems/test/sensors_test.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import pydrake.systems.sensors as mut
 
 import numpy as np
@@ -76,8 +78,8 @@ class TestSensors(unittest.TestCase):
             self.assertEqual(image.data.shape, image.shape)
             self.assertEqual(image.data.dtype, ImageT.Traits.ChannelType)
 
-            w /= 2
-            h /= 2
+            w //= 2
+            h //= 2
             # WARNING: Resizing an image with an existing reference to
             # `image.data` will cause `image.data` + `image.mutable_data` to be
             # invalid.

--- a/bindings/pydrake/systems/test/value_test.py
+++ b/bindings/pydrake/systems/test/value_test.py
@@ -35,7 +35,7 @@ class TestValue(unittest.TestCase):
             for wrap in [pass_through, np.array]:
                 # Ensure that we can get vectors templated on double by
                 # reference.
-                expected_init = wrap(map(float, range(n)))
+                expected_init = wrap([float(x) for x in range(n)])
                 expected_add = wrap([x + 1 for x in expected_init])
                 expected_set = wrap([x + 10 for x in expected_init])
 
@@ -140,12 +140,12 @@ class TestValue(unittest.TestCase):
         with self.assertRaises(RuntimeError) as cm:
             value.get_value()
         self.assertTrue(all(
-            s in cm.exception.message for s in [
+            s in str(cm.exception) for s in [
                 "AbstractValue",
                 "UnknownType",
                 "get_value",
                 "AddValueInstantiation",
-            ]), cm.exception.message)
+            ]), cm.exception)
 
     def test_parameters_api(self):
 

--- a/bindings/pydrake/test/math_overloads_test.py
+++ b/bindings/pydrake/test/math_overloads_test.py
@@ -149,7 +149,7 @@ class TestMathOverloads(unittest.TestCase):
         def check_eval(functions, nargs):
             # Generate arguments.
             args_float = args_float_all[:nargs]
-            args_T = map(overload.to_type, args_float)
+            args_T = list(map(overload.to_type, args_float))
             # Check each supported function.
             for f_drake, f_builtin in functions:
                 if not overload.supports(f_drake):

--- a/bindings/pydrake/test/symbolic_test.py
+++ b/bindings/pydrake/test/symbolic_test.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 
+from copy import copy
 import unittest
+
 import numpy as np
+import six
+
 import pydrake.symbolic as sym
 from pydrake.test.algebra_test_util import ScalarAlgebra, VectorizedAlgebra
 from pydrake.util.containers import EqualToDict
-from copy import copy
-
 
 # TODO(eric.cousineau): Replace usages of `sym` math functions with the
 # overloads from `pydrake.math`.
@@ -490,7 +492,7 @@ class TestSymbolicExpression(SymbolicTestCase):
         # Ensure that we throw on `__nonzero__`.
         with self.assertRaises(RuntimeError) as cm:
             value = bool(e_x == e_x)
-        message = cm.exception.message
+        message = str(cm.exception)
         self.assertTrue(
             all([s in message for s in ["__nonzero__", "EqualToDict"]]),
             message)
@@ -506,6 +508,14 @@ class TestSymbolicExpression(SymbolicTestCase):
         # produces a DeprecationWarning, in addition to effectively garbage
         # values. For this reason, `pydrake.symbolic` will automatically
         # promote these warnings to errors.
+        if six.PY3:
+            # For some reason, something in how `unittest` tries to scope
+            # warnings causes the previous filters to be lost. Re-install
+            # here.
+            # TODO(eric.cousineau): Figure out better hook for this, or better
+            # way to restore warning filters from when everything's imported.
+            from pydrake.util.deprecation import install_numpy_warning_filters
+            install_numpy_warning_filters(force=True)
         # - All false.
         with self.assertRaises(DeprecationWarning):
             value = (e_xv == e_yv)
@@ -648,10 +658,15 @@ class TestSymbolicFormula(SymbolicTestCase):
         self.assertTrue(f1 != f3)
 
     def test_static_true_false(self):
-        tt = sym.Formula.True()
-        ff = sym.Formula.False()
+        tt = sym.Formula.True_()
+        ff = sym.Formula.False_()
         self.assertEqual(x == x, tt)
         self.assertEqual(x != x, ff)
+        if six.PY2:
+            # Use `getattr` to avoid syntax errors in Python3 since `True` and
+            # `False` are reserved keywords.
+            self.assertEqual(getattr(sym.Formula, "True")(), tt)
+            self.assertEqual(getattr(sym.Formula, "False")(), ff)
 
     def test_repr(self):
         self.assertEqual(repr(x > y), '<Formula "(x > y)">')
@@ -870,12 +885,12 @@ class TestSymbolicPolynomial(SymbolicTestCase):
         p = sym.Polynomial()
         self.assertEqualStructure(p, p)
         self.assertIsInstance(p == p, sym.Formula)
-        self.assertEqual(p == p, sym.Formula.True())
+        self.assertEqual(p == p, sym.Formula.True_())
         self.assertTrue(p.EqualTo(p))
         q = sym.Polynomial(sym.Expression(10))
         self.assertNotEqualStructure(p, q)
         self.assertIsInstance(p != q, sym.Formula)
-        self.assertEqual(p != q, sym.Formula.True())
+        self.assertEqual(p != q, sym.Formula.True_())
         self.assertFalse(p.EqualTo(q))
 
     def test_repr(self):

--- a/bindings/pydrake/test/trajectories_test.py
+++ b/bindings/pydrake/test/trajectories_test.py
@@ -55,7 +55,7 @@ class TestTrajectories(unittest.TestCase):
         self.assertEqual(pp_sub.get_number_of_segments(), 1)
         self.assertEqual(pp_sub.start_time(), 1.)
         self.assertEqual(pp_sub.end_time(), 2.)
-        values_sub = np.array(map(pp_sub.value, [1., 2.]))
+        values_sub = np.array(list(map(pp_sub.value, [1., 2.])))
         self.assertTrue((values_sub == [[[20.]], [[30.]]]).all())
         pp_sub.shiftRight(10.)
         self.assertEqual(pp_sub.start_time(), 11.)

--- a/bindings/pydrake/util/containers.py
+++ b/bindings/pydrake/util/containers.py
@@ -1,5 +1,7 @@
 """Provides extensions for containers of Drake-related objects."""
 
+import six
+
 
 class _EqualityProxyBase(object):
     # Wraps an object with a non-compliant `__eq__` operator (returns a
@@ -37,7 +39,7 @@ class _DictKeyWrap(dict):
         # sidestepped by storing the properties in a `dict`.
         self._key_wrap = key_wrap
         self._key_unwrap = key_unwrap
-        for key, value in dict_in.iteritems():
+        for key, value in six.iteritems(dict_in):
             self[key] = value
 
     def __setitem__(self, key, value):
@@ -56,7 +58,12 @@ class _DictKeyWrap(dict):
         return zip(self.keys(), self.values())
 
     def keys(self):
-        return [self._key_unwrap(key) for key in dict.iterkeys(self)]
+        # `six.iterkeys` will not constrain the call to use `dict` methods.
+        if six.PY2:
+            keys_iter = dict.iterkeys(self)
+        else:
+            keys_iter = dict.keys(self)
+        return [self._key_unwrap(key) for key in keys_iter]
 
     def iterkeys(self):
         # Non-performant, but sufficient for now.
@@ -86,6 +93,9 @@ class EqualToDict(_DictKeyWrap):
                 T = type(self.value)
                 return (isinstance(other.value, T)
                         and self.value.EqualTo(other.value))
+
+            # https://stackoverflow.com/a/1608907/7829525
+            __hash__ = _EqualityProxyBase.__hash__
 
         dict_in = dict(*args, **kwargs)
         _DictKeyWrap.__init__(self, dict_in, Proxy, Proxy._get_value)

--- a/bindings/pydrake/util/cpp_const.py
+++ b/bindings/pydrake/util/cpp_const.py
@@ -8,7 +8,9 @@ module to be robust against this situation.
 """
 
 import inspect
+import six
 from types import MethodType
+
 from pydrake.third_party.wrapt import ObjectProxy
 
 # TODO(eric.cousineau): Add mechanism for enabling / disabling const-proxying.
@@ -30,7 +32,11 @@ class _ConstClassMeta(object):
         self._owned_properties = set(owned_properties or set())
         self.mutable_methods = set(mutable_methods or set())
         # Add any decorated mutable methods.
-        methods = inspect.getmembers(cls, predicate=inspect.ismethod)
+        if six.PY2:
+            predicate = inspect.ismethod
+        else:
+            predicate = inspect.isfunction
+        methods = inspect.getmembers(cls, predicate=predicate)
         for name, method in methods:
             # TODO(eric.cousineau): Warn if there is a mix of mutable and
             # immutable methods with the same name.
@@ -174,6 +180,13 @@ class _Const(ObjectProxy):
         else:
             return out
 
+    def __str__(self):
+        T = type(self.__wrapped__)
+        if T.__str__ == object.__str__:
+            return self.__repr__()
+        else:
+            return self.__wrapped__.__str__()
+
 
 def _install_object_mutable_methods():
     # Installs methods to `_Const` that will always raise an error.
@@ -190,22 +203,31 @@ def _install_object_mutable_methods():
 
 _install_object_mutable_methods()
 
+_LITERAL_TYPES = {int, float, str, tuple, type(None)}
+if six.PY2:
+    _LITERAL_TYPES.add(unicode)
+
 
 def _is_immutable(obj):
     # Detects if a type is a immutable (or literal) type.
-    literal_types = [int, float, str, unicode, tuple, type(None)]
-    return type(obj) in literal_types
+    return type(obj) in _LITERAL_TYPES
 
 
-def _is_method_of(func, obj):
-    # Detects if `func` is a function bound to a given instance `obj`.
-    return inspect.ismethod(func) and func.im_self is obj
+if six.PY2:
+    def _is_method_of(func, obj):
+        # Detects if `func` is a function bound to a given instance `obj`.
+        return inspect.ismethod(func) and func.im_self is obj
 
+    def _rebind_method(bound, new_self):
+        # Rebinds `bound.im_self` to `new_self`.
+        # https://stackoverflow.com/a/14574713/7829525
+        return MethodType(bound.__func__, new_self, bound.im_class)
+else:
+    def _is_method_of(func, obj):
+        return getattr(func, '__self__', None) is obj
 
-def _rebind_method(bound, new_self):
-    # Rebinds `bound.im_self` to `new_self`.
-    # https://stackoverflow.com/a/14574713/7829525
-    return MethodType(bound.__func__, new_self, bound.im_class)
+    def _rebind_method(bound, new_self):
+        return MethodType(bound.__func__, new_self)
 
 
 def to_const(obj):

--- a/bindings/pydrake/util/test/containers_test.py
+++ b/bindings/pydrake/util/test/containers_test.py
@@ -8,8 +8,10 @@ class Comparison(object):
         self.lhs = lhs
         self.rhs = rhs
 
-    def __nonzero__(self):
+    def __bool__(self):
         raise ValueError("Should not be called")
+
+    __nonzero__ = __bool__
 
 
 class Item(object):
@@ -67,7 +69,9 @@ class TestEqualToDict(unittest.TestCase):
         # `dict`-inheriting types which does not have any hooks for key
         # transformations.
         raw_attempt = dict(d)
-        self.assertFalse(isinstance(raw_attempt.keys()[0], Item))
+        keys = list(raw_attempt.keys())
+        self.assertFalse(isinstance(keys[0], Item))
         # - Calling `raw()` should provide the desired behavior.
         raw = d.raw()
-        self.assertTrue(isinstance(raw.keys()[0], Item))
+        keys = list(raw.keys())
+        self.assertTrue(isinstance(keys[0], Item))

--- a/bindings/pydrake/util/test/cpp_param_pybind_test.cc
+++ b/bindings/pydrake/util/test/cpp_param_pybind_test.cc
@@ -86,6 +86,8 @@ int main(int argc, char** argv) {
   // Define custom class only once here.
   py::class_<CustomCppType>(m, "CustomCppType");
 
+  // For Python3
+  py::globals().attr("update")(m.attr("__dict__"));
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/bindings/pydrake/util/test/cpp_template_pybind_test.cc
+++ b/bindings/pydrake/util/test/cpp_template_pybind_test.cc
@@ -46,6 +46,12 @@ void CheckValue(const string& expr, const T& expected) {
   EXPECT_EQ(py::eval(expr).cast<T>(), expected);
 }
 
+// TODO(eric.cousineau): Figure out why this is necessary.
+// Necessary for Python3.
+void sync(py::module m) {
+  py::globals().attr("update")(m.attr("__dict__"));
+}
+
 GTEST_TEST(CppTemplateTest, TemplateClass) {
   py::module m("__main__");
 
@@ -54,11 +60,14 @@ GTEST_TEST(CppTemplateTest, TemplateClass) {
 
   const vector<string> expected_1 = {"int"};
   const vector<string> expected_2 = {"int", "double"};
+  sync(m);
+
   CheckValue("DefaultInst().GetNames()", expected_1);
   CheckValue("SimpleTemplate[int]().GetNames()", expected_1);
   CheckValue("SimpleTemplate[int, float]().GetNames()", expected_2);
 
   m.def("simple_func", [](const SimpleTemplate<int>&) {});
+  sync(m);
 
   // Check error message if a function is called with the incorrect arguments.
   // N.B. We use `[^\0]` because C++ regex does not have an equivalent of
@@ -85,6 +94,7 @@ GTEST_TEST(CppTemplateTest, TemplateFunction) {
 
   const vector<string> expected_1 = {"int"};
   const vector<string> expected_2 = {"int", "double"};
+  sync(m);
   CheckValue("SimpleFunction[int]()", expected_1);
   CheckValue("SimpleFunction[int, float]()", expected_2);
 }
@@ -111,6 +121,7 @@ GTEST_TEST(CppTemplateTest, TemplateMethod) {
 
   const vector<string> expected_1 = {"int"};
   const vector<string> expected_2 = {"int", "double"};
+  sync(m);
   CheckValue("SimpleType().SimpleMethod[int]()", expected_1);
   CheckValue("SimpleType().SimpleMethod[int, float]()", expected_2);
 }

--- a/bindings/pydrake/util/test/cpp_template_test.py
+++ b/bindings/pydrake/util/test/cpp_template_test.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, print_function
 
 import unittest
+import six
 from types import ModuleType
 
 import pydrake.util.cpp_template as m
@@ -171,8 +172,14 @@ class TestCppTemplate(unittest.TestCase):
         self.assertEqual(str(DummyC.method),
                          "<unbound TemplateMethod DummyC.method>")
         self.assertTrue(DummyC.method.is_instantiation(DummyC.dummy_c))
-        self.assertEqual(str(DummyC.method[int]),
-                         "<unbound method DummyC.method[int]>")
+        if six.PY2:
+            self.assertEqual(
+                str(DummyC.method[int]), "<unbound method DummyC.method[int]>")
+        else:
+            self.assertTrue(
+                str(DummyC.method[int]).startswith(
+                    "<function DummyC.method[int] at "),
+                str(DummyC.method[int]))
 
         obj = DummyC()
         self.assertTrue(

--- a/bindings/pydrake/util/test/type_safe_index_pybind_test.cc
+++ b/bindings/pydrake/util/test/type_safe_index_pybind_test.cc
@@ -34,6 +34,7 @@ GTEST_TEST(TypeSafeIndexTest, CheckCasting) {
     EXPECT_EQ(x, 10);
     return x;
   });
+  py::globals().attr("update")(m.attr("__dict__"));  // For Python3
   CheckValue("pass_thru_int(10)", 10);
   CheckValue("pass_thru_int(Index(10))", 10);
   // TypeSafeIndex<> is not implicitly constructible from an int.
@@ -46,6 +47,9 @@ GTEST_TEST(TypeSafeIndexTest, CheckCasting) {
     EXPECT_EQ(x, 10);
     return x;
   });
+
+  py::globals().attr("update")(m.attr("__dict__"));  // For Python3
+
   // TypeSafeIndex<> is not implicitly constructible from an int.
   // TODO(eric.cousineau): Consider relaxing this to *only* accept `int`s, and
   // puke if another `TypeSafeIndex<U>` is encountered.

--- a/common/test_utilities/drake_py_unittest_main.py
+++ b/common/test_utilities/drake_py_unittest_main.py
@@ -108,7 +108,9 @@ if __name__ == '__main__':
 
     if args.trace != "none":
         if args.trace == "user":
-            ignoredirs = ["/usr"]
+            # Add `sys.prefix` here, just in case we're debugging with a
+            # virtualenv.
+            ignoredirs = ["/usr", sys.prefix]
         else:
             ignoredirs = []
         tracer = trace.Trace(trace=1, count=0, ignoredirs=ignoredirs)

--- a/setup/mac/binary_distribution/requirements.txt
+++ b/setup/mac/binary_distribution/requirements.txt
@@ -3,3 +3,4 @@ matplotlib
 pip
 pydot
 PyYAML
+six

--- a/setup/ubuntu/16.04/binary_distribution/packages.txt
+++ b/setup/ubuntu/16.04/binary_distribution/packages.txt
@@ -35,6 +35,7 @@ python-matplotlib
 python-numpy
 python-pydot
 python-scipy
+python-six
 python-tk
 python-yaml
 qtbase5-dev

--- a/setup/ubuntu/18.04/binary_distribution/packages.txt
+++ b/setup/ubuntu/18.04/binary_distribution/packages.txt
@@ -35,6 +35,7 @@ python-matplotlib
 python-numpy
 python-pydot
 python-scipy
+python-six
 python-tk
 python-yaml
 qtbase5-dev


### PR DESCRIPTION
For #8352 
Towards #9614

This adds `six` as a dependency, and enables `pydrake` to pass under Python3.

Uses workaround from upstream issue: pybind/pybind11#1559

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9613)
<!-- Reviewable:end -->
