### PR TITLE
pydrake: Ensure module docstring is used, rather than ModuleShim docstring

### DIFF
--- a/bindings/pydrake/__init__.py
+++ b/bindings/pydrake/__init__.py
@@ -1,3 +1,6 @@
+"""Python bindings for Drake.
+"""
+
 from __future__ import absolute_import, division, print_function
 from os.path import abspath
 from platform import python_version_tuple

--- a/bindings/pydrake/util/deprecation.py
+++ b/bindings/pydrake/util/deprecation.py
@@ -39,6 +39,7 @@ class ModuleShim(object):
         # https://stackoverflow.com/a/16237698/7829525
         object.__setattr__(self, '_orig_module', orig_module)
         object.__setattr__(self, '_handler', handler)
+        object.__setattr__(self, '__doc__', orig_module.__doc__)
 
     def __getattr__(self, name):
         # Use the original module if possible.


### PR DESCRIPTION
Before:
> ![image](https://user-images.githubusercontent.com/26719449/46625205-07bc8000-cb01-11e8-8df3-9d0e93d4a8cf.png)

After:
> ![image](https://user-images.githubusercontent.com/26719449/46625226-17d45f80-cb01-11e8-83e3-61d4327bd1aa.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9618)
<!-- Reviewable:end -->
