### PR TITLE
pydrake rbt: Add bindings for CentroidalMomentumMatrix methods

### DIFF
--- a/bindings/pydrake/multibody/rigid_body_tree_py.cc
+++ b/bindings/pydrake/multibody/rigid_body_tree_py.cc
@@ -330,7 +330,13 @@ PYBIND11_MODULE(rigid_body_tree, m) {
              RigidBodyTreeConstants::default_model_instance_id_set,
            py::arg("in_terms_of_qdot") = false,
            doc.RigidBodyTree.centerOfMassJacobian.doc)
-      // centroidalMomentumMatrix
+      .def("centroidalMomentumMatrix",
+           &RigidBodyTree<double>::centroidalMomentumMatrix<T>,
+           py::arg("cache"),
+           py::arg("model_instance_id_set") =
+             RigidBodyTreeConstants::default_model_instance_id_set,
+           py::arg("in_terms_of_qdot") = false,
+           doc.RigidBodyTree.centroidalMomentumMatrix.doc)
       // forwardKinPositionGradient
       .def("geometricJacobianDotTimesV",
            &RigidBodyTree<double>::geometricJacobianDotTimesV<T>,
@@ -345,7 +351,12 @@ PYBIND11_MODULE(rigid_body_tree, m) {
            py::arg("model_instance_id_set") =
              RigidBodyTreeConstants::default_model_instance_id_set,
            doc.RigidBodyTree.centerOfMassJacobianDotTimesV.doc)
-      // centroidalMomentumMatrixDotTimesV
+      .def("centroidalMomentumMatrixDotTimesV",
+           &RigidBodyTree<double>::centroidalMomentumMatrixDotTimesV<T>,
+           py::arg("cache"),
+           py::arg("model_instance_id_set") =
+             RigidBodyTreeConstants::default_model_instance_id_set,
+           doc.RigidBodyTree.centroidalMomentumMatrixDotTimesV.doc)
       .def("positionConstraints",
            &RigidBodyTree<double>::positionConstraints<T>,
            py::arg("cache"),
@@ -563,7 +574,7 @@ PYBIND11_MODULE(rigid_body_tree, m) {
                   doc.RigidBodyActuator.effort_limit_min_.doc)
     .def_readonly("effort_limit_max", &RigidBodyActuator::effort_limit_max_,
                   doc.RigidBodyActuator.effort_limit_max_.doc);
-}
+}  // NOLINT(readability/fn_size)
 
 }  // namespace pydrake
 }  // namespace drake

--- a/bindings/pydrake/multibody/test/rigid_body_tree_test.py
+++ b/bindings/pydrake/multibody/test/rigid_body_tree_test.py
@@ -347,8 +347,16 @@ class TestRigidBodyTree(unittest.TestCase):
         assert_sane(tau)
         # - Friction torques.
         friction_torques = tree.frictionTorques(v)
-        self.assertTrue(friction_torques.shape, (num_v,))
+        self.assertEqual(friction_torques.shape, (num_v,))
         assert_sane(friction_torques, nonzero=False)
+        # - Centroidal Momentum
+        id = set([0])
+        Ag = tree.centroidalMomentumMatrix(
+            cache=kinsol, model_instance_id_set=id, in_terms_of_qdot=False)
+        self.assertEqual(Ag.shape, (6, num_q))
+        AgDotV = tree.centroidalMomentumMatrixDotTimesV(
+            cache=kinsol, model_instance_id_set=id)
+        self.assertEqual(AgDotV.shape, (6,))
 
     def test_shapes_parsing(self):
         # TODO(gizatt) This test ought to have its reliance on


### PR DESCRIPTION
Relates: #9242

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9621)
<!-- Reviewable:end -->
