### PR TITLE
pydrake cpp_template: Ensure `DefineTemplateClassWithDefault` is backwards-compatible

### DIFF
--- a/bindings/pydrake/util/cpp_template_pybind.h
+++ b/bindings/pydrake/util/cpp_template_pybind.h
@@ -79,11 +79,11 @@ inline py::object AddTemplateClass(
 template <typename Class, typename... Options>
 py::class_<Class, Options...> DefineTemplateClassWithDefault(
     py::handle scope, const std::string& default_name, py::tuple param,
-    const char* ctor_doc_string, const std::string& template_suffix = "_") {
+    const char* doc_string = "", const std::string& template_suffix = "_") {
   const std::string template_name = default_name + template_suffix;
   // Define class with temporary name.
   py::class_<Class, Options...> py_class(
-      scope, TemporaryClassName<Class>().c_str(), ctor_doc_string);
+      scope, TemporaryClassName<Class>().c_str(), doc_string);
   // Register instantiation.
   AddTemplateClass(scope, template_name, py_class, param);
   // Declare default instantiation if it does not already exist.


### PR DESCRIPTION
Should resolve shambhala failures:
https://drake-jenkins.csail.mit.edu/view/Production/job/RobotLocomotion/job/drake-shambhala/job/master/417/consoleText

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9631)
<!-- Reviewable:end -->
