### PR TITLE
Clean up exception specification in doxygen

### DIFF
--- a/attic/multibody/collision/model.h
+++ b/attic/multibody/collision/model.h
@@ -39,8 +39,8 @@ class Model {
 
    @return A pointer to the added element.
 
-   @throws A runtime_error if there was a problem (e.g., duplicate element id,
-   error configuring collision model, etc.) **/
+   @throws std::runtime_error if there was a problem (e.g., duplicate element
+   id, error configuring collision model, etc.) **/
   Element* AddElement(std::unique_ptr<Element> element);
 
   /** Removes a collision element from this model.

--- a/attic/multibody/global_inverse_kinematics.h
+++ b/attic/multibody/global_inverse_kinematics.h
@@ -64,9 +64,9 @@ class GlobalInverseKinematics : public solvers::MathematicalProgram {
    * with the specified index. This is the orientation of body i's frame
    * measured and expressed in the world frame.
    * @param body_index  The index of the queried body. Notice that body 0 is
-   * the world, and thus not a decision variable. Throws a runtime_error if
-   * the index is smaller than 1, or no smaller than the total number of bodies
-   * in the robot.
+   * the world, and thus not a decision variable.
+   * @throws std::runtime_error if the index is smaller than 1, or no smaller
+   * than the total number of bodies in the robot.
    */
   const solvers::MatrixDecisionVariable<3, 3>& body_rotation_matrix(
       int body_index) const;
@@ -74,9 +74,9 @@ class GlobalInverseKinematics : public solvers::MathematicalProgram {
   /** Getter for the decision variables on the position p_WBo of the body B's
    * origin measured and expressed in the world frame.
    * @param body_index The index of the queried body. Notice that body 0 is
-   * the world, and thus not a decision variable. Throws a runtime_error if
-   * the index is smaller than 1, or greater than or equal to the total number
-   * of bodies in the robot.
+   * the world, and thus not a decision variable.
+   * @throws std::runtime_error if the index is smaller than 1, or greater than
+   * or equal to the total number of bodies in the robot.
    */
   const solvers::VectorDecisionVariable<3>& body_position(int body_index) const;
 
@@ -205,13 +205,13 @@ class GlobalInverseKinematics : public solvers::MathematicalProgram {
    * 1. body_position_cost.rows() == robot->get_num_bodies(), where `robot`
    *    is the input argument in the constructor of the class.
    * 2. body_position_cost(i) is non-negative.
-   * @throw a runtime error if the precondition is not satisfied.
+   * @throws std::runtime_error if the precondition is not satisfied.
    * @param body_orientation_cost The cost for each body's orientation error.
    * @pre
    * 1. body_orientation_cost.rows() == robot->get_num_bodies() , where
    *    `robot` is the input argument in the constructor of the class.
    * 2. body_position_cost(i) is non-negative.
-   * @throw a runtime_error if the precondition is not satisfied.
+   * @throws std::runtime_error if the precondition is not satisfied.
    */
   void AddPostureCost(
       const Eigen::Ref<const Eigen::VectorXd>& q_desired,

--- a/attic/multibody/parsers/model_instance_id_table.h
+++ b/attic/multibody/parsers/model_instance_id_table.h
@@ -27,8 +27,8 @@ namespace parsers {
 typedef std::map<std::string, int> ModelInstanceIdTable;
 
 /**
- * Adds the model instances in @p source_table to @p dest_table. Throws a
- * `std::runtime_error` if there is a collision in the model names.
+ * Adds the model instances in @p source_table to @p dest_table.
+ * @throws std::runtime_error if there is a collision in the model names.
  */
 void AddModelInstancesToTable(
     const drake::parsers::ModelInstanceIdTable& source_table,

--- a/attic/multibody/parsers/parser_common.h
+++ b/attic/multibody/parsers/parser_common.h
@@ -53,7 +53,7 @@ struct FloatingJointConstants {
  *
  * @return The number of floating joint added to this rigid body tree.
  *
- * @throws A std::runtime_error if the floating_base_type is unrecognized or
+ * @throws std::runtime_error if the floating_base_type is unrecognized or
  * zero floating joints were added to the model.
  */
 int AddFloatingJoint(

--- a/attic/multibody/rigid_body_plant/compliant_material.h
+++ b/attic/multibody/rigid_body_plant/compliant_material.h
@@ -112,9 +112,9 @@ class CompliantMaterial {
   /** Reset the dissipation value to report the default value. */
   void set_dissipation_to_default() { dissipation_ = nullopt; }
 
-  /** Sets *both* coefficients of friction to the same value. Throws an
-   exception if the value is negative.  Returns a reference to `*this` so that
-   multiple invocations of `set` can be chained together. */
+  /** Sets *both* coefficients of friction to the same value.
+   @throws std::exception if the value is negative.  Returns a reference to
+   `*this` so that multiple invocations of `set` can be chained together. */
   CompliantMaterial& set_friction(double value);
 
   /** Sets the two coefficients of friction. The `dynamic_friction` values must

--- a/attic/multibody/rigid_body_plant/rigid_body_plant.h
+++ b/attic/multibody/rigid_body_plant/rigid_body_plant.h
@@ -341,10 +341,12 @@ class RigidBodyPlant : public LeafSystem<T> {
   }
 
   /// Returns the output port containing the state of a
-  /// particular model with instance ID equal to `model_instance_id`. Throws a
-  /// std::runtime_error if `model_instance_id` does not exist. This method can
-  /// only be called when this class is instantiated with constructor parameter
-  /// `export_model_instance_centric_ports` equal to `true`.
+  /// particular model with instance ID equal to `model_instance_id`.
+  /// @throws std::runtime_error if `model_instance_id` does not exist.
+  ///
+  /// This method can only be called when this class is instantiated with
+  /// constructor parameter `export_model_instance_centric_ports` equal to
+  /// `true`.
   const OutputPort<T>& model_instance_state_output_port(
       int model_instance_id) const;
 
@@ -401,7 +403,7 @@ class RigidBodyPlant : public LeafSystem<T> {
                           std::unique_ptr<const RigidBodyTree<double>> tree,
                           double timestep = 0.0);
 
-  // Evaluates the actuator command input ports and throws a runtime_error
+  // Evaluates the actuator command input ports and throws a std::runtime_error
   // exception if at least one of the ports is not connected.
   VectorX<T> EvaluateActuatorInputs(const Context<T>& context) const;
 

--- a/automotive/automotive_simulator.h
+++ b/automotive/automotive_simulator.h
@@ -265,8 +265,9 @@ class AutomotiveSimulator {
   ///
   const maliput::api::Lane* FindLane(const std::string& name) const;
 
-  /// Returns the System whose name matches @p name.  Throws an exception if no
-  /// such system has been added, or multiple such systems have been added.
+  /// Returns the System whose name matches @p name.
+  /// @throws std::exception if no such system has been added, or multiple
+  /// such systems have been added.
   //
   /// This is the builder variant of the method.  It can only be used prior to
   /// Start() being called.
@@ -274,8 +275,9 @@ class AutomotiveSimulator {
   /// @pre Start() has NOT been called.
   systems::System<T>& GetBuilderSystemByName(std::string name);
 
-  /// Returns the System whose name matches @p name.  Throws an exception if no
-  /// such system has been added, or multiple such systems have been added.
+  /// Returns the System whose name matches @p name.
+  /// @throws std::exception if no such system has been added, or multiple such
+  /// systems have been added.
   ///
   /// This is the diagram variant of the method, which can only be used after
   /// Start() is called.

--- a/automotive/curve2.h
+++ b/automotive/curve2.h
@@ -37,7 +37,7 @@ class Curve2 {
   typedef Eigen::Matrix<T, 2, 1, Eigen::DontAlign> Point2T;
 
   /// Constructor that traces through the given @p waypoints in order.
-  /// Throws an error if @p waypoints.size() == 1.
+  /// @throws std::exception if @p waypoints.size() == 1.
   explicit Curve2(const std::vector<Point2>& waypoints)
       : waypoints_(waypoints), path_length_(GetLength(waypoints_)) {
     // TODO(jwnimmer-tri) We should reject duplicate adjacent

--- a/automotive/maliput/api/basic_id_index.h
+++ b/automotive/maliput/api/basic_id_index.h
@@ -25,33 +25,34 @@ class BasicIdIndex : public RoadGeometry::IdIndex {
 
   /// Adds @p lane to the index.
   ///
-  /// @throws if @p lane's id() already exists in the index.
+  /// @throws std::exception if @p lane's id() already exists in the index.
   /// @pre @p lane is not nullptr.
   void AddLane(const Lane* lane);
 
   /// Adds @p segment to the index.
   ///
-  /// @throws if @p segment's id() already exists in the index.
+  /// @throws std::exception if @p segment's id() already exists in the index.
   /// @pre @p segment is not nullptr.
   void AddSegment(const Segment* segment);
 
   /// Adds @p junction to the index.
   ///
-  /// @throws if @p junction's id() already exists in the index.
+  /// @throws std::exception if @p junction's id() already exists in the index.
   /// @pre @p junction is not nullptr.
   void AddJunction(const Junction* junction);
 
   /// Adds @p branch_point to the index.
   ///
-  /// @throws if @p branch_point's id() already exists in the index.
+  /// @throws std::exception if @p branch_point's id() already exists in the
+  /// index.
   /// @pre @p branch_point is not nullptr.
   void AddBranchPoint(const BranchPoint* branch_point);
 
   /// Walks the object graph rooted at @p road_geometry and adds all
   /// components (Lane, Segment, Junction, BranchPoint) to the index.
   ///
-  /// @throws if the graph of @p road_geometry contains any duplicate id's,
-  ///         or if any of its id's already exist in the index.
+  /// @throws std::exception if the graph of @p road_geometry contains any
+  /// duplicate id's, or if any of its id's already exist in the index.
   /// @pre @p road_geometry is not nullptr.
   void WalkAndAddAll(const RoadGeometry* road_geometry);
 

--- a/automotive/maliput/api/rules/right_of_way_rule.h
+++ b/automotive/maliput/api/rules/right_of_way_rule.h
@@ -118,7 +118,7 @@ class RightOfWayRule final {
   /// @param controlled_zone LaneSRoute to which this rule applies
   /// @param type the static semantics of this rule
   ///
-  /// Throws a std::exception if `states` is empty or if `states` contains
+  /// @throws std::exception if `states` is empty or if `states` contains
   /// duplicate State::Id's.
   RightOfWayRule(const Id& id,
                  const LaneSRoute& zone,
@@ -155,7 +155,7 @@ class RightOfWayRule final {
   ///
   /// This is a convenience function for returning a static rule's single state.
   ///
-  /// Throws a std::exception if `is_static()` is false.
+  /// @throws std::exception if `is_static()` is false.
   const State& static_state() const {
     DRAKE_THROW_UNLESS(is_static());
     return states_.begin()->second;

--- a/automotive/maliput/api/rules/road_rulebook.h
+++ b/automotive/maliput/api/rules/road_rulebook.h
@@ -52,14 +52,14 @@ class RoadRulebook {
 
   /// Returns the RightOfWayRule with the specified `id`.
   ///
-  /// Throws std::out_of_range if `id` is unknown.
+  /// @throws std::out_of_range if `id` is unknown.
   RightOfWayRule GetRule(const RightOfWayRule::Id& id) const {
     return DoGetRule(id);
   }
 
   /// Returns the SpeedLimitRule with the specified `id`.
   ///
-  /// Throws std::out_of_range if `id` is unknown.
+  /// @throws std::out_of_range if `id` is unknown.
   SpeedLimitRule GetRule(const SpeedLimitRule::Id& id) const {
     return DoGetRule(id);
   }

--- a/automotive/maliput/api/rules/speed_limit_rule.h
+++ b/automotive/maliput/api/rules/speed_limit_rule.h
@@ -41,7 +41,7 @@ class SpeedLimitRule {
   /// @param max maximum speed
   ///
   /// `min` and `max` must be non-negative, and `min` must be less than
-  /// or equal to `max`, otherwise a runtime_error is thrown.
+  /// or equal to `max`, otherwise a std::runtime_error is thrown.
   SpeedLimitRule(const Id& id, const LaneSRange& zone, Severity severity,
                  double min, double max)
       : id_(id), zone_(zone), severity_(severity), min_(min), max_(max) {

--- a/automotive/maliput/multilane/arc_road_curve.h
+++ b/automotive/maliput/multilane/arc_road_curve.h
@@ -39,9 +39,10 @@ class ArcRoadCurve : public RoadCurve {
   /// @param computation_policy Policy to guide all computations. If geared
   /// towards speed, computations will make use of analytical expressions even
   /// if not actually correct for the curve as specified.
-  /// @throw std::runtime_error if @p radius is not a positive number.
-  /// @throw std::runtime_error if @p linear_tolerance is not a positive number.
-  /// @throw std::runtime_error if @p scale_length is not a positive number.
+  /// @throws std::runtime_error if @p radius is not a positive number.
+  /// @throws std::runtime_error if @p linear_tolerance is not a positive
+  /// number.
+  /// @throws std::runtime_error if @p scale_length is not a positive number.
   explicit ArcRoadCurve(
       const Vector2<double>& center, double radius,
       double theta0, double d_theta,

--- a/automotive/maliput/multilane/line_road_curve.h
+++ b/automotive/maliput/multilane/line_road_curve.h
@@ -38,8 +38,9 @@ class LineRoadCurve : public RoadCurve {
   /// @param computation_policy Policy to guide all computations. If geared
   /// towards speed, computations will make use of analytical expressions even
   /// if not actually correct for the curve as specified.
-  /// @throw std::runtime_error if @p linear_tolerance is not a positive number.
-  /// @throw std::runtime_error if @p scale_length is not a positive number.
+  /// @throws std::runtime_error if @p linear_tolerance is not a positive
+  /// number.
+  /// @throws std::runtime_error if @p scale_length is not a positive number.
   explicit LineRoadCurve(
       const Vector2<double>& xy0, const Vector2<double>& dxy,
       const CubicPolynomial& elevation,

--- a/automotive/maliput/multilane/road_curve.cc
+++ b/automotive/maliput/multilane/road_curve.cc
@@ -29,7 +29,7 @@ struct ArcLengthDerivativeFunction {
   // @return The arc length derivative value at the specified point.
   // @pre The given parameter vector @p k is bi-dimensional (holding r and h
   //      coordinates only).
-  // @throw std::logic_error if preconditions are not met.
+  // @throws std::logic_error if preconditions are not met.
   double operator()(const double& p, const VectorX<double>& k) const {
     if (k.size() != 2) {
       throw std::logic_error("Arc length derivative expects only r and"
@@ -62,7 +62,7 @@ struct InverseArcLengthODEFunction {
   // @return The inverse arc length derivative value at the specified point.
   // @pre The given parameter vector @p k is bi-dimensional (holding r and h
   //      coordinates only).
-  // @throw std::logic_error if preconditions are not met.
+  // @throws std::logic_error if preconditions are not met.
   double operator()(const double& s, const double& p,
                     const VectorX<double>& k) {
     unused(s);

--- a/automotive/maliput/multilane/road_curve.h
+++ b/automotive/maliput/multilane/road_curve.h
@@ -132,7 +132,7 @@ class RoadCurve {
   ///         defined for all `s` values between 0 and the total path length of
   ///         the parallel curve (and throwing for any given value outside this
   ///         interval).
-  /// @throw std::runtime_error When `r` makes the radius of curvature be a non
+  /// @throws std::runtime_error When `r` makes the radius of curvature be a non
   ///                           positive number.
   std::function<double(double)> OptimizeCalcPFromS(double r) const;
 
@@ -143,7 +143,7 @@ class RoadCurve {
   ///         curve to longitudinal position s at the specified parallel curve,
   ///         defined for all p between 0 and 1 (and throwing for any given
   ///         value outside this interval).
-  /// @throw std::runtime_error When `r` makes the radius of curvature be a non
+  /// @throws std::runtime_error When `r` makes the radius of curvature be a non
   ///                           positive number.
   std::function<double(double)> OptimizeCalcSFromP(double r) const;
 
@@ -275,7 +275,7 @@ class RoadCurve {
   /// and accuracy. Actual behavior may vary across implementations.
   /// @pre The given @p scale_length is a positive number.
   /// @pre The given @p linear_tolerance is a positive number.
-  /// @throw std::runtime_error if any of the preconditions is not met.
+  /// @throws std::runtime_error if any of the preconditions is not met.
   ///
   /// @p elevation and @p superelevation are cubic-polynomial functions which
   /// define the elevation and superelevation as a function of position along
@@ -323,7 +323,7 @@ class RoadCurve {
   // curve using numerical methods.
   // @return The path length integral of the curve composed with the elevation
   // polynomial.
-  // @throw std::runtime_error When `r` makes the radius of curvature be a non
+  // @throws std::runtime_error When `r` makes the radius of curvature be a non
   //                           positive number.
   double CalcSFromP(double p, double r) const;
 

--- a/automotive/maliput/multilane/test_utilities/multilane_brute_force_integral.h
+++ b/automotive/maliput/multilane/test_utilities/multilane_brute_force_integral.h
@@ -27,7 +27,7 @@ namespace test {
 //      the given lower integration bound @p p_0.
 // @pre Given lower integration bound @p p_0 is greater than or equal to 0.
 // @pre Given @p k_order for the linear approximation is a non-negative number.
-// @throw std::runtime_error if preconditions are not met.
+// @throws std::runtime_error if preconditions are not met.
 double BruteForcePathLengthIntegral(const RoadCurve& road_curve,
                                     double p_0, double p_1, double r,
                                     double h, int k_order,
@@ -68,7 +68,7 @@ double BruteForcePathLengthIntegral(const RoadCurve& road_curve,
 // @pre Given tolerance is a positive real number.
 // @pre If given, the order suggested by @p k_order_hint is a non-negative
 //      number.
-// @throw std::runtime_error if preconditions are not met.
+// @throws std::runtime_error if preconditions are not met.
 double AdaptiveBruteForcePathLengthIntegral(
     const RoadCurve& rc, double p_0, double p_1,
     double r, double h, double tolerance,

--- a/automotive/maliput/rndf/builder.h
+++ b/automotive/maliput/rndf/builder.h
@@ -159,8 +159,8 @@ class Builder {
   /// @param segment_id The RNDF segment ID.
   /// @param connections A collection of Connections representing each RNDF lane
   /// in the segment.
-  /// @throw std::runtime_error When @p connections is a nullptr.
-  /// @throw std::runtime_error When @p connections is an empty collection.
+  /// @throws std::runtime_error When @p connections is a nullptr.
+  /// @throws std::runtime_error When @p connections is an empty collection.
   void CreateSegmentConnections(int segment_id,
                                 std::vector<Connection>* connections);
 
@@ -176,8 +176,8 @@ class Builder {
   /// fake inner lanes' lane bounds).
   /// @param perimeter_waypoints A collection of DirectedWaypoint objects
   /// describing the zone's perimeter.
-  /// @throw std::runtime_error When @p perimeter_waypoints is a nullptr.
-  /// @throw std::runtime_error When @p perimeter_waypoints is an empty
+  /// @throws std::runtime_error When @p perimeter_waypoints is a nullptr.
+  /// @throws std::runtime_error When @p perimeter_waypoints is an empty
   /// collection.
   void CreateConnectionsForZones(
       double width, std::vector<DirectedWaypoint>* perimeter_waypoints);
@@ -188,7 +188,7 @@ class Builder {
   /// @param width The connection's width.
   /// @param exit_id The start waypoint ID of the connection.
   /// @param entry_id The end waypoint ID of the connection.
-  /// @throw std::runtime_error When neither @p exit_id nor @p entry_id are
+  /// @throws std::runtime_error When neither @p exit_id nor @p entry_id are
   /// found.
   void CreateConnection(double width, const ignition::rndf::UniqueId& exit_id,
                         const ignition::rndf::UniqueId& entry_id);
@@ -200,7 +200,7 @@ class Builder {
   /// a Lane is added to the Segment. BranchPoints are updated as needed.
   /// @param id ID of the api::RoadGeometry to be built.
   /// @return The built api::RoadGeometry.
-  /// @throw std::runtime_error When the built RoadGeometry does not satisfy
+  /// @throws std::runtime_error When the built RoadGeometry does not satisfy
   /// Maliput roads' constraints (see api::RoadGeometry::CheckInvariants()).
   std::unique_ptr<const api::RoadGeometry> Build(const api::RoadGeometryId& id);
 

--- a/automotive/maliput/rndf/loader.h
+++ b/automotive/maliput/rndf/loader.h
@@ -50,8 +50,8 @@ struct RoadCharacteristics {
 /// @param road_characteristics The common geometrical aspects to comply with
 /// when building the api::RoadGeometry.
 /// @return The built api::RoadGeometry.
-/// @throw std::runtime_error When the given file is not a valid RNDF.
-/// @throw std::runtime_error When the given RNDF doesn't have at least
+/// @throws std::runtime_error When the given file is not a valid RNDF.
+/// @throws std::runtime_error When the given RNDF doesn't have at least
 /// a single lane segment with one or more waypoints. RNDFs containing
 /// only zones are not supported.
 std::unique_ptr<const api::RoadGeometry> LoadFile(

--- a/automotive/maliput/rndf/spline_helpers.h
+++ b/automotive/maliput/rndf/spline_helpers.h
@@ -51,9 +51,9 @@ class InverseFunctionInterpolator {
   /// function image, which is inside the codomain of the direct function.
   /// @return interpolated @p derivative_order derivative
   /// @f$ x^{(derivative_order)}(y) @f$ .
-  /// @throws when @p derivative_order is a negative integer.
-  /// @throws when @p y is larger than the maximum range of the function's
-  /// codomain as described in the constructor's documentation.
+  /// @throws std::exception when @p derivative_order is a negative integer.
+  /// @throws std::exception when @p y is larger than the maximum range of the
+  /// function's codomain as described in the constructor's documentation.
   /// @throws std::runtime_error When @p y is smaller than the minimum range of
   /// the function's codomain as described in the constructor's documentation.
   double InterpolateMthDerivative(int derivative_order, double y);

--- a/automotive/maliput/simplerulebook/simple_rulebook.h
+++ b/automotive/maliput/simplerulebook/simple_rulebook.h
@@ -31,24 +31,24 @@ class SimpleRulebook : public api::rules::RoadRulebook {
 
   /// Adds a new RightOfWayRule.
   ///
-  /// Throws std::runtime_error if a rule with the same ID already exists
+  /// @throws std::runtime_error if a rule with the same ID already exists
   /// in the SimpleRulebook.
   void AddRule(const api::rules::RightOfWayRule& rule);
 
   /// Removes the RightOfWayRule labelled by `id`.
   ///
-  /// Throws std::runtime_error if no such rule exists.
+  /// @throws std::runtime_error if no such rule exists.
   void RemoveRule(const api::rules::RightOfWayRule::Id& id);
 
   /// Adds a new SpeedLimitRule.
   ///
-  /// Throws std::runtime_error if a rule with the same ID already exists
+  /// @throws std::runtime_error if a rule with the same ID already exists
   /// in the SimpleRulebook.
   void AddRule(const api::rules::SpeedLimitRule& rule);
 
   /// Removes the SpeedLimitRule labelled by `id`.
   ///
-  /// Throws std::runtime_error if no such rule exists.
+  /// @throws std::runtime_error if no such rule exists.
   void RemoveRule(const api::rules::SpeedLimitRule::Id& id);
 
  private:

--- a/automotive/maliput/simplerulebook/yaml_io.h
+++ b/automotive/maliput/simplerulebook/yaml_io.h
@@ -63,7 +63,7 @@ namespace simplerulebook {
 /// root, with an entry bearing the key "maliput_simple_rulebook_v1".
 /// Only this entry is parsed; any other content is ignored.
 ///
-/// Throws `std::runtime_error` on parse errors, or failure of `AddRule()`.
+/// @throws `std::runtime_error` on parse errors, or failure of `AddRule()`.
 /// Internally calls `YAML::Load(std::istream&)`, and thus does whatever
 /// throwing/asserting which that function does.
 // TODO(maddog@tri.global)  If/when it ever becomes ok to expose YAML::Node

--- a/automotive/pose_selector.h
+++ b/automotive/pose_selector.h
@@ -139,9 +139,9 @@ class PoseSelector {
 
   /// Extracts the vehicle's `s`-direction velocity based on its RoadOdometry @p
   /// road_odometry in the Lane coordinate frame.  Assumes the road has zero
-  /// elevation and superelevation.  Throws if any element of
-  /// `road_odometry.pos` is not within the respective bounds of
-  /// `road_odometry.lane`.
+  /// elevation and superelevation.
+  /// @throws std::exception if any element of `road_odometry.pos` is not
+  /// within the respective bounds of `road_odometry.lane`.
   ///
   /// @note This function currently only provides exact derivatives for velocity
   /// in the `s` direction when the road is straight (no yaw angle variations).

--- a/automotive/trajectory_car.h
+++ b/automotive/trajectory_car.h
@@ -66,7 +66,9 @@ class TrajectoryCar final : public systems::LeafSystem<T> {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(TrajectoryCar)
 
   /// Constructs a TrajectoryCar system that traces a given two-dimensional @p
-  /// curve.  Throws an error if the curve is empty (has a zero @p path_length).
+  /// curve.
+  /// @throws std::invalid_argument if the curve is empty (has a zero
+  /// @p path_length).
   explicit TrajectoryCar(const Curve2<double>& curve)
       : systems::LeafSystem<T>(
             systems::SystemTypeTag<automotive::TrajectoryCar>{}),

--- a/automotive/trivial_right_of_way_state_provider.h
+++ b/automotive/trivial_right_of_way_state_provider.h
@@ -21,17 +21,16 @@ class TrivialRightOfWayStateProvider final
 
   /// Adds a dynamic state to this provider.
   ///
-  /// Throws std::logic_error if a RightOfWayRule with an ID of @p id
+  /// @throws std::logic_error if a RightOfWayRule with an ID of @p id
   /// already exists in this provider.
-  ///
-  /// Throws std::runtime_error if the dynamic state failed to be added.
+  /// @throws std::runtime_error if the dynamic state failed to be added.
   void AddState(
       const maliput::api::rules::RightOfWayRule::Id& id,
       const maliput::api::rules::RightOfWayRule::State::Id& initial_state);
 
   /// Sets the dynamic state of a RightOfWayRule within this provider.
   ///
-  /// Throws std::out_of_range if no dynamic state with @p id exists in this
+  /// @throws std::out_of_range if no dynamic state with @p id exists in this
   /// provider.
   void SetState(const maliput::api::rules::RightOfWayRule::Id& id,
                 const maliput::api::rules::RightOfWayRule::State::Id& state);

--- a/common/find_resource.h
+++ b/common/find_resource.h
@@ -26,7 +26,7 @@ class FindResourceResult {
   optional<std::string> get_absolute_path() const;
 
   /// Either returns the get_absolute_path() iff the resource was found,
-  /// or else throws runtime_error.
+  /// or else throws std::runtime_error.
   std::string get_absolute_path_or_throw() const;
 
   /// Returns the error message, iff the resource was not found.
@@ -76,8 +76,8 @@ class FindResourceResult {
 /// are accumulated each time this function is called. It is searched after the
 /// path given by the environment variable but before the path that can be
 /// found with the sentinel `.drake-resource-sentinel`. This can be used to
-/// find data in installed distributions of drake (or in `pydrake`). The given
-/// path must be absolute or else throws runtime_error.
+/// find data in installed distributions of drake (or in `pydrake`).
+/// @throws std::runtime_error if the given path is not absolute.
 void AddResourceSearchPath(std::string root_directory);
 
 /// Gets current root directory value from a persistent variable.

--- a/common/pointer_cast.h
+++ b/common/pointer_cast.h
@@ -49,7 +49,7 @@ std::unique_ptr<T> dynamic_pointer_cast(std::unique_ptr<U>&& other) noexcept {
 /// transferred to the result and `other` is empty; on failure, `other` will
 /// retain its original managed value.
 ///
-/// @throw std::logic_error if the cast fails.
+/// @throws std::logic_error if the cast fails.
 ///
 /// Note that this function only supports default deleters.
 template <class T, class U>

--- a/common/polynomial.h
+++ b/common/polynomial.h
@@ -175,8 +175,8 @@ class Polynomial {
 
   /** Evaluate a univariate Polynomial at a specific point.
    *
-   * Evaluates a univariate Polynomial at the given x.  Throws an
-   * exception of this Polynomial is not univariate.
+   * Evaluates a univariate Polynomial at the given x.
+   * @throws std::runtime_error if this Polynomial is not univariate.
    *
    * x may be of any type supporting the ** and + operations (which can
    * be different from both CoefficientsType and RealScalar)
@@ -206,9 +206,9 @@ class Polynomial {
 
   /** Evaluate a multivariate Polynomial at a specific point.
    *
-   * Evaluates a Polynomial with the given values for each variable.  Throws
-   * std::out_of_range if the Polynomial contains variables for which values
-   * were not provided.
+   * Evaluates a Polynomial with the given values for each variable.
+   * @throws std::out_of_range if the Polynomial contains variables for which
+   * values were not provided.
    *
    * The provided values may be of any type which is std::is_arithmetic
    * (supporting the std::pow, *, and + operations) and need not be
@@ -275,7 +275,8 @@ class Polynomial {
   /** Takes the derivative of this (univariate) Polynomial.
    *
    * Returns a new Polynomial that is the derivative of this one in its sole
-   * variable.  Throws an exception of this Polynomial is not univariate.
+   * variable.
+   * @throws std::exception if this Polynomial is not univariate.
    *
    * If derivative_order is given, takes the nth derivative of this
    * Polynomial.
@@ -285,8 +286,9 @@ class Polynomial {
   /** Takes the integral of this (univariate, non-constant) Polynomial.
    *
    * Returns a new Polynomial that is the indefinite integral of this one in
-   * its sole variable.  Throws an exception of this Polynomial is not
-   * univariate, or if it has no variables.
+   * its sole variable.
+   * @throws std::exception if this Polynomial is not univariate, or if it has
+   * no variables.
    *
    * If integration_constant is given, adds that constant as the constant
    * term (zeroth-order coefficient) of the resulting Polynomial.
@@ -370,16 +372,16 @@ class Polynomial {
   /** Returns the roots of this (univariate) Polynomial.
    *
    * Returns the roots of a univariate Polynomial as an Eigen column vector of
-   * complex numbers whose components are of the RealScalar type.  Throws an
-   * exception of this Polynomial is not univariate.
+   * complex numbers whose components are of the RealScalar type.
+   * @throws std::exception of this Polynomial is not univariate.
    */
   RootsType Roots() const;
 
   /** Checks if a (univariate) Polynomial is approximately equal to this one.
    *
    * Checks that every coefficient of other is within tol of the
-   * corresponding coefficient of this Polynomial.  Throws an exception if
-   * either Polynomial is not univariate.
+   * corresponding coefficient of this Polynomial.
+   * @throws std::exception if either Polynomial is not univariate.
    */
   bool IsApprox(const Polynomial& other, const RealScalar& tol) const;
 

--- a/common/symbolic_decompose.h
+++ b/common/symbolic_decompose.h
@@ -11,7 +11,7 @@ namespace symbolic {
 
 /// Decomposes @p expressions into @p M * @p vars.
 ///
-/// @throws runtime_error if @p expressions is not linear in @p vars.
+/// @throws std::runtime_error if @p expressions is not linear in @p vars.
 /// @pre M.rows() == expressions.rows() && M.cols() == vars.rows().
 void DecomposeLinearExpressions(
     const Eigen::Ref<const VectorX<Expression>>& expressions,
@@ -20,7 +20,7 @@ void DecomposeLinearExpressions(
 
 /// Decomposes @p expressions into @p M * @p vars + @p v.
 ///
-/// @throws runtime_error if @p expressions is not affine in @p vars.
+/// @throws std::runtime_error if @p expressions is not affine in @p vars.
 /// @pre M.rows() == expressions.rows() && M.cols() == vars.rows().
 /// @pre v.rows() == expressions.rows().
 void DecomposeAffineExpressions(

--- a/common/symbolic_expression.h
+++ b/common/symbolic_expression.h
@@ -810,8 +810,8 @@ struct is_numeric<symbolic::Expression> {
 
 /// Returns the symbolic expression's value() as a double.
 ///
-/// @throws If it is not possible to evaluate the symbolic expression with an
-/// empty environment.
+/// @throws std::exception if it is not possible to evaluate the symbolic
+/// expression with an empty environment.
 double ExtractDoubleOrThrow(const symbolic::Expression& e);
 
 }  // namespace drake
@@ -920,7 +920,7 @@ namespace drake {
 namespace symbolic {
 
 /// Constructs a vector of variables from the vector of variable expressions.
-/// @throw std::logic_error if there is an expression in @p vec which is not a
+/// @throws std::logic_error if there is an expression in @p vec which is not a
 /// variable.
 VectorX<Variable> GetVariableVector(
     const Eigen::Ref<const VectorX<Expression>>& evec);

--- a/common/symbolic_formula.h
+++ b/common/symbolic_formula.h
@@ -164,8 +164,8 @@ class Formula {
 
   /** Evaluates under a given environment (by default, an empty environment).
    *
-   * @throws runtime_error if a variable `v` is needed for an evaluation but not
-   * provided by @p env.
+   * @throws std::runtime_error if a variable `v` is needed for an evaluation
+   * but not provided by @p env.
    */
   bool Evaluate(const Environment& env = Environment{}) const;
 

--- a/common/symbolic_rational_function.h
+++ b/common/symbolic_rational_function.h
@@ -42,7 +42,7 @@ class RationalFunction {
    * @pre None of the indeterminates in the numerator can be decision variables
    * in the denominator; similarly none of the indeterminates in the denominator
    * can be decision variables in the numerator.
-   * @throw logic_error if the precondition is not satisfied.
+   * @throws std::logic_error if the precondition is not satisfied.
    */
   RationalFunction(const Polynomial& numerator, const Polynomial& denominator);
 

--- a/common/trajectories/piecewise_polynomial.h
+++ b/common/trajectories/piecewise_polynomial.h
@@ -261,18 +261,18 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * segment will be continuous. Note that the periodic end condition does
    * not require the first and last knot to be collocated, nor does it add
    * an additional knot to connect the first and last segments. Only first
-   * and second derivative continuity is enforced. 
-   * See https://en.wikipedia.org/wiki/Spline_interpolation, 
+   * and second derivative continuity is enforced.
+   * See https://en.wikipedia.org/wiki/Spline_interpolation,
    * https://www.math.uh.edu/~jingqiu/math4364/spline.pdf, and
    * http://www.maths.lth.se/na/courses/FMN081/FMN081-06/lecture11.pdf
    * for more about cubic splines and their end conditions.
    * The MATLAB files "spline.m" and "csape.m" are also good references.
    *
-   * @p breaks and @p knots must have at least 3 elements. The "not-a-knot" 
-   * condition is ill-defined for two knots, and the "periodic" condition 
+   * @p breaks and @p knots must have at least 3 elements. The "not-a-knot"
+   * condition is ill-defined for two knots, and the "periodic" condition
    * would produce a straight line (use `FirstOrderHold` for this instead).
    *
-   * @param periodic_end_condition Determines whether the "not-a-knot" 
+   * @param periodic_end_condition Determines whether the "not-a-knot"
    * (`false`) or the periodic spline (`true`) end condition is used.
    *
    * @throws std::runtime_error if
@@ -411,8 +411,9 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
   /// Checks if a PiecewisePolynomial is approximately equal to this one.
   /**
    * Checks that every coefficient of `other` is within `tol` of the
-   * corresponding coefficient of this PiecewisePolynomial. Throws an exception
-   * if any Polynomial in either PiecewisePolynomial is not univariate.
+   * corresponding coefficient of this PiecewisePolynomial.
+   * @throws std::exception if any Polynomial in either PiecewisePolynomial is
+   * not univariate.
    */
   bool isApprox(const PiecewisePolynomial& other, double tol) const;
 
@@ -420,12 +421,13 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
   /// from current start_time() to @p other end_time().
   ///
   /// @param other PiecewisePolynomial instance to concatenate.
-  /// @throw std::runtime_error if trajectories' dimensions do not match
-  ///                           each other (either rows() or cols() does
-  ///                           not match between this and @p other).
-  /// @throw std::runtime_error if this end_time() and @p other start_time() are
-  ///                           not within PiecewiseTrajectory<T>::kEpsilonTime
-  ///                           from each other.
+  /// @throws std::runtime_error if trajectories' dimensions do not match
+  ///                            each other (either rows() or cols() does
+  ///                            not match between this and @p other).
+  /// @throws std::runtime_error if this end_time() and @p other start_time()
+  ///                            are not within
+  ///                            PiecewiseTrajectory<T>::kEpsilonTime from
+  ///                            each other.
   void ConcatenateInTime(const PiecewisePolynomial& other);
 
   void shiftRight(double offset);

--- a/examples/humanoid_controller/dev/humanoid_manipulation_plan.h
+++ b/examples/humanoid_controller/dev/humanoid_manipulation_plan.h
@@ -111,7 +111,8 @@ class HumanoidManipulationPlan
    *
    * Aborts if assumptions about `T_plan` is not valid.
    *
-   * @throws if @p plan is not of type robotlocomotion::robot_plan_t
+   * @throws std::exception if @p plan is not of type
+   * robotlocomotion::robot_plan_t
    */
   void HandlePlanGenericPlanDerived(
       const systems::controllers::qp_inverse_dynamics::RobotKinematicState<T>&

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -366,7 +366,7 @@ class GeometryState {
    @param candidate_name  The name to validate.
    @return true if the `candidate_name` can be given to a `GeometryInstance`
    assigned to the indicated frame.
-   @throws if `frame_id` does not refer to a valid frame.  */
+   @throws std::exception if `frame_id` does not refer to a valid frame.  */
   bool IsValidGeometryName(FrameId frame_id,
                            const std::string& candidate_name) const;
 

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -246,7 +246,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
   /** Given a valid source `id`, returns a _pose_ input port associated
    with that `id`. This port is used to communicate _pose_ data for registered
    frames.
-   @throws  std::logic_error if the source_id is _not_ recognized. */
+   @throws std::logic_error if the source_id is _not_ recognized. */
   const systems::InputPort<T>& get_source_pose_port(SourceId id) const;
 
   /** Returns the output port which produces the PoseBundle for LCM
@@ -382,7 +382,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
   }
 
   /** Returns an inspector on the system's *model* scene graph data.
-   @throw std::logic_error If a context has been allocated.*/
+   @throws std::logic_error If a context has been allocated.*/
   const SceneGraphInspector<T>& model_inspector() const;
 
   /** @name         Collision filtering

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -58,14 +58,14 @@ class SceneGraphInspector {
   // is defined.
 
   /** Reports the name for the given source id.
-   @throws  std::logic_error if the identifier is invalid.  */
+   @throws std::logic_error if the identifier is invalid.  */
   const std::string& GetSourceName(SourceId id) const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->get_source_name(id);
   }
 
   /** Reports the id of the frame to which the given geometry id is registered.
-   @throws  std::logic_error if the geometry id is invalid.  */
+   @throws std::logic_error if the geometry id is invalid.  */
   FrameId GetFrameId(GeometryId geometry_id) const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->GetFrameId(geometry_id);
@@ -73,7 +73,7 @@ class SceneGraphInspector {
 
   /** Returns the visual material of the geometry indicated by the given
    `geometry_id` (if it exists).
-   @throws  std::logic_error if the geometry id is invalid.  */
+   @throws std::logic_error if the geometry id is invalid.  */
   const VisualMaterial* GetVisualMaterial(GeometryId geometry_id) const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->get_visual_material(geometry_id);

--- a/lcm/drake_mock_lcm.h
+++ b/lcm/drake_mock_lcm.h
@@ -42,9 +42,10 @@ class DrakeMockLcm : public DrakeLcmInterface {
   /**
    * Obtains the most recently "published" message on a particular channel.
    * This method automatically decodes the message into an LCM message whose
-   * type is specified by the template type. Throws a std::runtime_error
-   * exception if no LCM message was published on the provided channel or if the
-   * message failed to be decoded by the provided LCM message type.
+   * type is specified by the template type.
+   * @throws std::runtime_error if no LCM message was published on the provided
+   * channel or if the message failed to be decoded by the provided LCM message
+   * type.
    *
    * @tparam T The LCM message type.
    *

--- a/manipulation/planner/differential_inverse_kinematics.h
+++ b/manipulation/planner/differential_inverse_kinematics.h
@@ -105,7 +105,7 @@ class DifferentialInverseKinematicsParameters {
   /// @{
   /**
    * Sets timestep to @p dt.
-   * @throws if dt <= 0.
+   * @throws std::exception if dt <= 0.
    */
   void set_timestep(double dt) {
     DRAKE_THROW_UNLESS(dt > 0);
@@ -115,7 +115,7 @@ class DifferentialInverseKinematicsParameters {
   /**
    * Sets the max magnitude of the velocity in the unconstrained degree of
    * freedom to @p limit.
-   * @throws if limit < 0.
+   * @throws std::exception if limit < 0.
    */
   void set_unconstrained_degrees_of_freedom_velocity_limit(double limit) {
     DRAKE_THROW_UNLESS(limit >= 0);
@@ -124,7 +124,7 @@ class DifferentialInverseKinematicsParameters {
 
   /**
    * Sets the nominal joint position.
-   * @throws if @p nominal_joint_position's dimension differs.
+   * @throws std::exception if @p nominal_joint_position's dimension differs.
    */
   void set_nominal_joint_position(
       const Eigen::Ref<const VectorX<double>>& nominal_joint_position) {
@@ -135,7 +135,8 @@ class DifferentialInverseKinematicsParameters {
   /**
    * Sets the end effector gains in the body frame. Gains can be used to
    * specify relative importance among different dimensions.
-   * @throws if any element of @p gain_E is larger than 1 or smaller than 0.
+   * @throws std::exception if any element of @p gain_E is larger than 1 or
+   * smaller than 0.
    */
   void set_end_effector_velocity_gain(const Vector6<double>& gain_E) {
     DRAKE_THROW_UNLESS((gain_E.array() >= 0).all() &&
@@ -147,9 +148,9 @@ class DifferentialInverseKinematicsParameters {
    * Sets the joint position limits.
    * @param q_bounds The first element is the lower bound, and the second is
    * the upper bound.
-   * @throws if the first or second element of @p q_bounds has the wrong
-   * dimension or any element of the second element is smaller than its
-   * corresponding part in the first element.
+   * @throws std::exception if the first or second element of @p q_bounds has
+   * the wrong dimension or any element of the second element is smaller than
+   * its corresponding part in the first element.
    */
   void set_joint_position_limits(
       const std::pair<VectorX<double>, VectorX<double>>& q_bounds) {
@@ -164,9 +165,9 @@ class DifferentialInverseKinematicsParameters {
    * Sets the joint velocity limits.
    * @param q_bounds The first element is the lower bound, and the second is
    * the upper bound.
-   * @throws if the first or second element of @p q_bounds has the wrong
-   * dimension or any element of the second element is smaller than its
-   * corresponding part in the first element.
+   * @throws std::exception if the first or second element of @p q_bounds has
+   * the wrong dimension or any element of the second element is smaller than
+   * its corresponding part in the first element.
    */
   void set_joint_velocity_limits(
       const std::pair<VectorX<double>, VectorX<double>>& v_bounds) {
@@ -181,9 +182,9 @@ class DifferentialInverseKinematicsParameters {
    * Sets the joint acceleration limits.
    * @param q_bounds The first element is the lower bound, and the second is
    * the upper bound.
-   * @throws if the first or second element of @p q_bounds has the wrong
-   * dimension or any element of the second element is smaller than its
-   * corresponding part in the first element.
+   * @throws std::exception if the first or second element of @p q_bounds has
+   * the wrong dimension or any element of the second element is smaller than
+   * its corresponding part in the first element.
    */
   void set_joint_acceleration_limits(
       const std::pair<VectorX<double>, VectorX<double>>& vd_bounds) {

--- a/manipulation/util/moving_average_filter.h
+++ b/manipulation/util/moving_average_filter.h
@@ -35,7 +35,7 @@ class MovingAverageFilter {
   /**
    * Constructs the filter with the specified `window_size`.
    * @param window_size The size of the window.
-   * @throws a std::runtime_error when window_size <= 0.
+   * @throws std::runtime_error when window_size <= 0.
    */
   explicit MovingAverageFilter(int window_size);
 

--- a/math/quadratic_form.h
+++ b/math/quadratic_form.h
@@ -19,7 +19,7 @@ namespace math {
  * @retval X. The matrix X satisfies XᵀX = Y and X.rows() = rank(Y).
  * @pre 1. Y is positive semidefinite.
  *      2. zero_tol is non-negative.
- *      @throw std::runtime_error when the pre-conditions are not satisfied.
+ * @throws std::runtime_error when the pre-conditions are not satisfied.
  */
 Eigen::MatrixXd DecomposePSDmatrixIntoXtransposeTimesX(
     const Eigen::Ref<const Eigen::MatrixXd>& Y, double zero_tol);
@@ -57,8 +57,7 @@ Eigen::MatrixXd DecomposePSDmatrixIntoXtransposeTimesX(
  *         is positive semidefinite.
  *      2. `Q` and `b` are of the correct size.
  *      3. `tol` is non-negative.
- * @throw a runtime_error if the precondition is not
- * satisfied.
+ * @throws std::runtime_error if the precondition is not satisfied.
  */
 std::pair<Eigen::MatrixXd, Eigen::MatrixXd>
 DecomposePositiveQuadraticForm(const Eigen::Ref<const Eigen::MatrixXd>& Q,

--- a/math/rotation_matrix.h
+++ b/math/rotation_matrix.h
@@ -712,8 +712,8 @@ using RotationMatrixd = RotationMatrix<double>;
 /// @param[in] angle_lb the lower bound of the rotation angle θ.
 /// @param[in] angle_ub the upper bound of the rotation angle θ.
 /// @return Rotation angle θ of the projected matrix, angle_lb <= θ <= angle_ub
-/// @throws exception std::runtime_error if M is not a 3 x 3 matrix or if
-///                   axis is the zero vector or if angle_lb > angle_ub.
+/// @throws std::runtime_error if M is not a 3 x 3 matrix or if
+///         axis is the zero vector or if angle_lb > angle_ub.
 /// @note This function is useful for reconstructing a rotation matrix for a
 /// revolute joint with joint limits.
 /// @note This can be formulated as an optimization problem

--- a/multibody/constraint/constraint_solver.h
+++ b/multibody/constraint/constraint_solver.h
@@ -345,11 +345,11 @@ class ConstraintSolver {
   ///           CalcContactForcesInContactFrames(). `cf` will be resized as
   ///           necessary.
   /// @pre Constraint data has been computed.
-  /// @throws a std::runtime_error if the constraint forces cannot be computed
+  /// @throws std::runtime_error if the constraint forces cannot be computed
   ///         (due to, e.g., the effects of roundoff error in attempting to
   ///         solve a complementarity problem); in such cases, it is
   ///         recommended to increase regularization and attempt again.
-  /// @throws a std::logic_error if `cf` is null.
+  /// @throws std::logic_error if `cf` is null.
   void SolveImpactProblem(const ConstraintVelProblemData<T>& problem_data,
                           VectorX<T>* cf) const;
 
@@ -406,9 +406,9 @@ class ConstraintSolver {
   ///           CalcContactForcesInContactFrames(). `cf` will be resized as
   ///           necessary.
   /// @pre Constraint data has been computed.
-  /// @throws a std::runtime_error if the constraint forces cannot be computed
+  /// @throws std::runtime_error if the constraint forces cannot be computed
   ///         (due to, e.g., an "inconsistent" rigid contact configuration).
-  /// @throws a std::logic_error if `cf` is null.
+  /// @throws std::logic_error if `cf` is null.
   void SolveConstraintProblem(const ConstraintAccelProblemData<T>& problem_data,
                               VectorX<T>* cf) const;
 

--- a/multibody/inverse_kinematics/angle_between_vectors_constraint.h
+++ b/multibody/inverse_kinematics/angle_between_vectors_constraint.h
@@ -23,20 +23,20 @@ class AngleBetweenVectorsConstraint : public solvers::Constraint {
   // should be alive during the lifetime of this constraint.
   // @param frameA_idx The index of frame A.
   // @param na_A The vector na_A fixed to frame A, expressed in frame A.
-  // @pre na_A should be a non-zero vector. @throw logic error if na_A is close
-  // to zero.
+  // @pre na_A should be a non-zero vector.
+  // @throws std::logic_error if na_A is close to zero.
   // @param frameB_idx The index of frame B.
   // @param nb_B The vector nb fixed to frame B, expressed in frameB.
-  // @pre nb_B should be a non-zero vector. @throw logic error if nb_B is
-  // close to zero.
+  // @pre nb_B should be a non-zero vector.
+  // @throws std::logic_error if nb_B is close to zero.
   // @param angle_lower The lower bound on the angle between na and nb. It is
   // denoted as θ_lower in the class documentation.
   // @pre angle_lower >= 0.
-  // @throw invalid_argument error if angle_lower is negative.
+  // @throws std::invalid_argument error if angle_lower is negative.
   // @param angle_upper The upper bound on the angle between na and nb. it is
   // denoted as θ_upper in the class documentation.
   // @pre angle_lower <= angle_upper <= pi.
-  // @throw invalid_argument if angle_upper is outside the bounds.
+  // @throws std::invalid_argument if angle_upper is outside the bounds.
   // @param context The Context that has been allocated for this @p tree. We
   // will update the context when evaluating the constraint. @p context should
   // be alive during the lifetime of this constraint.

--- a/multibody/inverse_kinematics/gaze_target_constraint.h
+++ b/multibody/inverse_kinematics/gaze_target_constraint.h
@@ -33,14 +33,14 @@ class GazeTargetConstraint : public solvers::Constraint {
   // @param n_A The directional vector representing the center ray of the cone,
   // expressed in frame A.
   // @pre @p n_A cannot be a zero vector.
-  // @throw invalid_argument is n_A is close to a zero vector.
+  // @throws std::invalid_argument is n_A is close to a zero vector.
   // @param frameB_idx The frame where the target point T is fixed to.
   // @param p_BT The position of the target point T, measured and expressed in
   // frame B.
   // @param cone_half_angle The half angle of the cone. We denote it as θ in the
   // class documentation. @p cone_half_angle is in radians.
   // @pre @p 0 <= cone_half_angle <= pi.
-  // @throw invalid_argument if cone_half_angle is outside of the bound.
+  // @throws std::invalid_argument if cone_half_angle is outside of the bound.
   // @param context The Context that has been allocated for this @p tree. We
   // will update the context when evaluating the constraint. @p context should
   // be alive during the lifetime of this constraint.

--- a/multibody/inverse_kinematics/inverse_kinematics.h
+++ b/multibody/inverse_kinematics/inverse_kinematics.h
@@ -99,14 +99,14 @@ class InverseKinematics {
    * @param n_A The directional vector representing the center ray of the
    * cone, expressed in frame A.
    * @pre @p n_A cannot be a zero vector.
-   * @throw invalid_argument is n_A is close to a zero vector.
+   * @throws std::invalid_argument is n_A is close to a zero vector.
    * @param frameB The frame where the target point T is fixed to.
    * @param p_BT The position of the target point T, measured and expressed in
    * frame B.
    * @param cone_half_angle The half angle of the cone. We denote it as θ in the
    * documentation. @p cone_half_angle is in radians.
    * @pre @p 0 <= cone_half_angle <= pi.
-   * @throw invalid_argument if cone_half_angle is outside of the bound.
+   * @throws std::invalid_argument if cone_half_angle is outside of the bound.
    */
   solvers::Binding<solvers::Constraint> AddGazeTargetConstraint(
       const Frame<double>& frameA,
@@ -127,20 +127,20 @@ class InverseKinematics {
    * @param frameA The frame to which na is fixed.
    * @param na_A The vector na fixed to frame A, expressed in frame A.
    * @pre na_A should be a non-zero vector.
-   * @throw invalid_argument if na_A is close to zero.
+   * @throws std::invalid_argument if na_A is close to zero.
    * @param frameB The frame to which nb is fixed.
    * @param nb_B The vector nb fixed to frame B, expressed in frame B.
    * @pre nb_B should be a non-zero vector.
-   * @throw invalid_argument if nb_B is close to zero.
+   * @throws std::invalid_argument if nb_B is close to zero.
    * @param angle_lower The lower bound on the angle between na and nb. It is
    * denoted as θ_lower in the documentation. @p angle_lower is in radians.
    * @pre angle_lower >= 0.
-   * @throw invalid_argument if angle_lower is negative.
+   * @throws std::invalid_argument if angle_lower is negative.
    * @param angle_upper The upper bound on the angle between na and nb. it is
    * denoted as θ_upper in the class documentation. @p angle_upper is in
    * radians.
    * @pre angle_lower <= angle_upper <= pi.
-   * @throw invalid_argument if angle_upper is outside the bounds.
+   * @throws std::invalid_argument if angle_upper is outside the bounds.
    */
   solvers::Binding<solvers::Constraint> AddAngleBetweenVectorsConstraint(
       const Frame<double>& frameA,

--- a/multibody/inverse_kinematics/orientation_constraint.h
+++ b/multibody/inverse_kinematics/orientation_constraint.h
@@ -45,7 +45,7 @@ class OrientationConstraint : public solvers::Constraint {
   // orientation and frame B's orientation. It is denoted as θ_bound in the
   // class documentation. @p theta_bound is in radians.
   // @pre angle_bound >= 0.
-  // @throw invalid_argument if angle_bound < 0.
+  // @throws std::invalid_argument if angle_bound < 0.
   // @param context The Context that has been allocated for this @p tree. We
   // will update the context when evaluating the constraint. @p context should
   // be alive during the lifetime of this constraint.

--- a/multibody/multibody_tree/articulated_body_inertia.h
+++ b/multibody/multibody_tree/articulated_body_inertia.h
@@ -126,7 +126,7 @@ class ArticulatedBodyInertia {
   ///                   articulated body inertia. Only the lower triangular
   ///                   region is used and the strictly upper part is ignored.
   ///
-  /// @throws an exception in Debug builds if IsPhysicallyValid() for `this`
+  /// @throws std::exception in Debug builds if IsPhysicallyValid() for `this`
   /// inertia is `false`.
   template <typename Derived>
   explicit ArticulatedBodyInertia(const Eigen::MatrixBase<Derived>& matrix) {

--- a/multibody/multibody_tree/body_node.h
+++ b/multibody/multibody_tree/body_node.h
@@ -888,7 +888,7 @@ class BodyNode : public MultibodyTreeElement<BodyNode<T>, BodyNodeIndex> {
   /// called for all the child nodes of `this` node (and, by recursive
   /// precondition, all successor nodes in the tree.)
   ///
-  /// @throws when called on the _root_ node or `abc` is nullptr.
+  /// @throws std::exception when called on the _root_ node or `abc` is nullptr.
   void CalcArticulatedBodyInertiaCache_TipToBase(
       const MultibodyTreeContext<T>& context,
       const PositionKinematicsCache<T>& pc,

--- a/multibody/multibody_tree/frame.h
+++ b/multibody/multibody_tree/frame.h
@@ -63,7 +63,7 @@ class Frame : public FrameBase<T> {
 
   /// Variant of CalcPoseInBodyFrame() that returns the fixed pose `X_BF` of
   /// `this` frame F in the body frame B associated with this frame.
-  /// Throws std::logic_error if called on a %Frame that does not have a
+  /// @throws std::logic_error if called on a %Frame that does not have a
   /// fixed offset in the body frame.
   // %Frame sub-classes that can represent the fixed pose of `this` frame F in
   // a body frame B, must override this method.
@@ -96,7 +96,7 @@ class Frame : public FrameBase<T> {
   /// Variant of CalcOffsetPoseInBody() that given the offset pose `X_FQ` of a
   /// frame Q in `this` frame F, returns the pose `X_BQ` of frame Q in the body
   /// frame B to which this frame is attached.
-  /// Throws std::logic_error if called on a %Frame that does not have a
+  /// @throws std::logic_error if called on a %Frame that does not have a
   /// fixed offset in the body frame.
   virtual Isometry3<T> GetFixedOffsetPoseInBody(
       const Isometry3<T>& X_FQ) const {

--- a/multibody/multibody_tree/joint_actuator.h
+++ b/multibody/multibody_tree/joint_actuator.h
@@ -95,9 +95,11 @@ class JointActuator final
   /// @param[out] u
   ///   The vector containing the actuation values for the entire MultibodyTree
   ///   model to which `this` actuator belongs to.
-  /// @throws if `u_instance.size() != this->joint().num_velocities()`.
-  /// @throws if u is nullptr.
-  /// @throws if `u.size() != this->get_parent_tree().num_actuated_dofs()`.
+  /// @throws std::exception if
+  ///   `u_instance.size() != this->joint().num_velocities()`.
+  /// @throws std::exception if u is nullptr.
+  /// @throws std::exception if
+  ///   `u.size() != this->get_parent_tree().num_actuated_dofs()`.
   void set_actuation_vector(
       const Eigen::Ref<const VectorX<T>>& u_instance,
       EigenPtr<VectorX<T>> u) const;

--- a/multibody/multibody_tree/mobilizer_impl.h
+++ b/multibody/multibody_tree/mobilizer_impl.h
@@ -143,7 +143,7 @@ class MobilizerImpl : public Mobilizer<T> {
 
   /// Helper method to retrieve a const reference to the MultibodyTreeContext
   /// object referenced by `context`.
-  /// @throws `std::logic_error` if `context` is not a MultibodyTreeContext
+  /// @throws std::logic_error if `context` is not a MultibodyTreeContext
   /// object.
   static const MultibodyTreeContext<T>& GetMultibodyTreeContextOrThrow(
       const systems::Context<T>& context) {
@@ -161,7 +161,7 @@ class MobilizerImpl : public Mobilizer<T> {
 
   /// Helper method to retrieve a mutable pointer to the MultibodyTreeContext
   /// object referenced by `context`.
-  /// @throws `std::logic_error` if `context` is not a MultibodyTreeContext
+  /// @throws std::logic_error if `context` is not a MultibodyTreeContext
   /// object.
   MultibodyTreeContext<T>& GetMutableMultibodyTreeContextOrThrow(
       systems::Context<T>* context) const {

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.h
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.h
@@ -467,8 +467,8 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   ///       Vector3d::UnitZ());     /* revolute axis in this case */
   /// @endcode
   ///
-  /// @throws if `this` %MultibodyPlant already contains a joint with the given
-  /// `name`.  See HasJointNamed(), Joint::name().
+  /// @throws std::exception if `this` %MultibodyPlant already contains a joint
+  /// with the given `name`.  See HasJointNamed(), Joint::name().
   ///
   /// @see The Joint class's documentation for further details on how a Joint
   /// is defined.
@@ -543,8 +543,8 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   ///   The Joint to be actuated by the new JointActuator.
   /// @returns A constant reference to the new JointActuator just added, which
   /// will remain valid for the lifetime of `this` plant.
-  /// @throws if `joint.num_velocities() > 1` since for now we only support
-  /// actuators for single dof joints.
+  /// @throws std::exception if `joint.num_velocities() > 1` since for now we
+  /// only support actuators for single dof joints.
   const JointActuator<T>& AddJointActuator(
       const std::string& name, const Joint<T>& joint) {
     DRAKE_THROW_UNLESS(joint.num_velocities() == 1);
@@ -594,7 +594,7 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   /// in @p model_instance.
   /// @see AddRigidBody().
   ///
-  /// @throws if @p model_instance is not valid for this model.
+  /// @throws std::exception if @p model_instance is not valid for this model.
   bool HasBodyNamed(
       const std::string& name, ModelInstanceIndex model_instance) const {
     return tree().HasBodyNamed(name, model_instance);
@@ -613,7 +613,7 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   /// in @p model_instance.
   /// @see AddJoint().
   ///
-  /// @throws if @p model_instance is not valid for this model.
+  /// @throws std::exception if @p model_instance is not valid for this model.
   bool HasJointNamed(
       const std::string& name, ModelInstanceIndex model_instance) const {
     return tree().HasJointNamed(name, model_instance);
@@ -633,7 +633,7 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   /// %MultibodyPlant in @p model_instance.
   /// @see AddJointActuator().
   ///
-  /// @throws if @p model_instance is not valid for this model.
+  /// @throws std::exception if @p model_instance is not valid for this model.
   bool HasJointActuatorNamed(
       const std::string& name, ModelInstanceIndex model_instance) const {
     return tree().HasJointActuatorNamed(name, model_instance);
@@ -720,7 +720,7 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   /// Returns a constant reference to the joint that is uniquely identified
   /// by the string `name` and @p model_instance in `this` %MultibodyPlant.
   /// @throws std::logic_error if there is no joint with the requested name.
-  /// @throws if @p model_instance is not valid for this model.
+  /// @throws std::exception if @p model_instance is not valid for this model.
   /// @see HasJointNamed() to query if there exists a joint in `this`
   /// %MultibodyPlant with a given specified name.
   const Joint<T>& GetJointByName(
@@ -751,7 +751,7 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   /// be a subclass of Joint.
   /// @throws std::logic_error if the named joint is not of type `JointType` or
   /// if there is no Joint with that name.
-  /// @throws if @p model_instance is not valid for this model.
+  /// @throws std::exception if @p model_instance is not valid for this model.
   /// @see HasJointNamed() to query if there exists a joint in `this`
   /// %MultibodyPlant with a given specified name.
   template <template<typename> class JointType>
@@ -775,7 +775,7 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   /// Returns a constant reference to the actuator that is uniquely identified
   /// by the string `name` and @p model_instance in `this` %MultibodyPlant.
   /// @throws std::logic_error if there is no actuator with the requested name.
-  /// @throws if @p model_instance is not valid for this model.
+  /// @throws std::exception if @p model_instance is not valid for this model.
   /// @see HasJointActuatorNamed() to query if there exists an actuator in
   /// `this` %MultibodyPlant with a given specified name.
   const JointActuator<T>& GetJointActuatorByName(
@@ -806,9 +806,9 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   ///   for further details.
   /// @returns the SourceId of `this` plant in `scene_graph`. It can also
   /// later on be retrieved with get_source_id().
-  /// @throws if called post-finalize.
-  /// @throws if `scene_graph` is the nullptr.
-  /// @throws if called more than once.
+  /// @throws std::exception if called post-finalize.
+  /// @throws std::exception if `scene_graph` is the nullptr.
+  /// @throws std::exception if called more than once.
   geometry::SourceId RegisterAsSourceForSceneGraph(
       geometry::SceneGraph<T>* scene_graph);
 
@@ -830,10 +830,10 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   /// @param[out] scene_graph
   ///   A valid non nullptr to a SceneGraph on which geometry will get
   ///   registered.
-  /// @throws if `scene_graph` is the nullptr.
-  /// @throws if called post-finalize.
-  /// @throws if `scene_graph` does not correspond to the same instance with
-  /// which RegisterAsSourceForSceneGraph() was called.
+  /// @throws std::exception if `scene_graph` is the nullptr.
+  /// @throws std::exception if called post-finalize.
+  /// @throws std::exception if `scene_graph` does not correspond to the same
+  /// instance with which RegisterAsSourceForSceneGraph() was called.
   /// @returns the id for the registered geometry.
   geometry::GeometryId RegisterVisualGeometry(
       const Body<T>& body, const Isometry3<double>& X_BG,
@@ -1007,7 +1007,7 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
 
   /// If the body with `body_index` has geometry registered with it, it returns
   /// the geometry::FrameId associated with it. Otherwise, it returns nullopt.
-  /// @throws if called pre-finalize.
+  /// @throws std::exception if called pre-finalize.
   optional<geometry::FrameId> GetBodyFrameIdIfExists(
       BodyIndex body_index) const {
     DRAKE_MBP_THROW_IF_NOT_FINALIZED();
@@ -1021,9 +1021,9 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   /// If the body with `body_index` has geometry registered with it, it returns
   /// the geometry::FrameId associated with it. Otherwise this method throws
   /// an exception.
-  /// @throws if no geometry has been registered with the body indicated by
-  /// `body_index`.
-  /// @throws if called pre-finalize.
+  /// @throws std::exception if no geometry has been registered with the body
+  /// indicated by `body_index`.
+  /// @throws std::exception if called pre-finalize.
   geometry::FrameId GetBodyFrameIdOrThrow(BodyIndex body_index) const {
     DRAKE_MBP_THROW_IF_NOT_FINALIZED();
     const auto it = body_index_to_frame_id_.find(body_index);
@@ -1049,17 +1049,17 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   /// port is a vector valued port, which can be set with
   /// JointActuator::set_actuation_vector().
   /// @pre Finalize() was already called on `this` plant.
-  /// @throws if called before Finalize(), if the model does not contain any
-  /// actuators, or if multiple model instances have actuated dofs.
+  /// @throws std::exception if called before Finalize(), if the model does not
+  /// contain any actuators, or if multiple model instances have actuated dofs.
   const systems::InputPort<T>& get_actuation_input_port() const;
 
   /// Returns a constant reference to the input port for external actuation for
   /// a specific model instance.  This input port is a vector valued port, which
   /// can be set with JointActuator::set_actuation_vector().
   /// @pre Finalize() was already called on `this` plant.
-  /// @throws if called before Finalize() or if the model instance does not
-  /// contain any actuators.
-  /// @throws if the model instance does not exist.
+  /// @throws std::exception if called before Finalize() or if the model
+  /// instance does not contain any actuators.
+  /// @throws std::exception if the model instance does not exist.
   const systems::InputPort<T>& get_actuation_input_port(
       ModelInstanceIndex model_instance) const;
 
@@ -1080,9 +1080,9 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   /// Returns a constant reference to the output port for the continuous
   /// state of a specific model instance.
   /// @pre Finalize() was already called on `this` plant.
-  /// @throws if called before Finalize() or if the model instance does not
-  /// have any state.
-  /// @throws if the model instance does not exist.
+  /// @throws std::exception if called before Finalize() or if the model
+  /// instance does not have any state.
+  /// @throws std::exception if the model instance does not exist.
   const systems::OutputPort<T>& get_continuous_state_output_port(
       ModelInstanceIndex model_instance) const;
   /// @}
@@ -1122,7 +1122,7 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
 
   /// Returns a constant reference to the underlying MultibodyTree model for
   /// `this` plant.
-  /// @throws if called pre-finalize. See Finalize().
+  /// @throws std::exception if called pre-finalize. See Finalize().
   DRAKE_DEPRECATED("Please use tree().")
   const MultibodyTree<T>& model() const {
     DRAKE_MBP_THROW_IF_NOT_FINALIZED();
@@ -1317,7 +1317,7 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
 
   /// Sets the state in `context` so that generalized positions and velocities
   /// are zero.
-  /// @throws if called pre-finalize. See Finalize().
+  /// @throws std::exception if called pre-finalize. See Finalize().
   void SetDefaultState(const systems::Context<T>& context,
                        systems::State<T>* state) const override {
     DRAKE_MBP_THROW_IF_NOT_FINALIZED();

--- a/multibody/multibody_tree/multibody_tree.h
+++ b/multibody/multibody_tree/multibody_tree.h
@@ -387,7 +387,7 @@ class MultibodyTree {
   ///
   /// @throws std::logic_error if `mobilizer` is a nullptr.
   /// @throws std::logic_error if Finalize() was already called on `this` tree.
-  /// @throws a std::runtime_error if the new mobilizer attempts to connect a
+  /// @throws std::runtime_error if the new mobilizer attempts to connect a
   /// frame with itself.
   /// @throws std::runtime_error if attempting to connect two bodies with more
   /// than one mobilizer between them.
@@ -475,7 +475,7 @@ class MultibodyTree {
   /// class).
   ///
   /// @throws std::logic_error if Finalize() was already called on `this` tree.
-  /// @throws a std::runtime_error if the new mobilizer attempts to connect a
+  /// @throws std::runtime_error if the new mobilizer attempts to connect a
   /// frame with itself.
   /// @throws std::runtime_error if attempting to connect two bodies with more
   /// than one mobilizer between them.
@@ -690,7 +690,8 @@ class MultibodyTree {
   ///       Vector3d::UnitZ());     /* revolute axis in this case */
   /// @endcode
   ///
-  /// @throws if `this` model already contains a joint with the given `name`.
+  /// @throws std::exception if `this` model already contains a joint with the
+  /// given `name`.
   /// See HasJointNamed(), Joint::name().
   ///
   /// @see The Joint class's documentation for further details on how a Joint
@@ -740,8 +741,9 @@ class MultibodyTree {
   ///   The Joint to be actuated by the new JointActuator.
   /// @returns A constant reference to the new JointActuator just added, which
   /// will remain valid for the lifetime of `this` %MultibodyTree.
-  /// @throws if `this` model already contains a joint actuator with the given
-  /// `name`. See HasJointActuatorNamed(), JointActuator::get_name().
+  /// @throws std::exception if `this` model already contains a joint actuator
+  /// with the given `name`. See HasJointActuatorNamed(),
+  /// JointActuator::get_name().
   // TODO(amcastro-tri): consider adding sugar method to declare an actuated
   // joint with a single call. Maybe MBT::AddActuatedJoint() or the like.
   const JointActuator<T>& AddJointActuator(
@@ -912,8 +914,8 @@ class MultibodyTree {
   }
 
   /// Returns a constant reference to the body with unique index `body_index`.
-  /// @throws if `body_index` does not correspond to a body in this multibody
-  /// tree.
+  /// @throws std::exception if `body_index` does not correspond to a body in
+  /// this multibody tree.
   const Body<T>& get_body(BodyIndex body_index) const {
     DRAKE_THROW_UNLESS(body_index < num_bodies());
     return *owned_bodies_[body_index];
@@ -929,8 +931,8 @@ class MultibodyTree {
 
   /// Returns a constant reference to the joint actuator with unique index
   /// `actuator_index`.
-  /// @throws if `actuator_index` does not correspond to a joint actuator in
-  /// this multibody tree.
+  /// @throws std::exception if `actuator_index` does not correspond to a joint
+  /// actuator in this multibody tree.
   const JointActuator<T>& get_joint_actuator(
       JointActuatorIndex actuator_index) const {
     DRAKE_THROW_UNLESS(actuator_index < num_actuators());
@@ -938,8 +940,8 @@ class MultibodyTree {
   }
 
   /// Returns a constant reference to the frame with unique index `frame_index`.
-  /// @throws if `frame_index` does not correspond to a frame in `this`
-  /// multibody tree.
+  /// @throws std::exception if `frame_index` does not correspond to a frame in
+  /// `this` multibody tree.
   const Frame<T>& get_frame(FrameIndex frame_index) const {
     DRAKE_THROW_UNLESS(frame_index < num_frames());
     return *frames_[frame_index];
@@ -994,7 +996,7 @@ class MultibodyTree {
   /// @returns `true` if a body named `name` was added to @p model_instance.
   /// @see AddRigidBody().
   ///
-  /// @throws if @p model_instance is not valid for this model.
+  /// @throws std::exception if @p model_instance is not valid for this model.
   bool HasBodyNamed(const std::string& name,
                     ModelInstanceIndex model_instance) const {
     DRAKE_THROW_UNLESS(model_instance < instance_name_to_index_.size());
@@ -1029,7 +1031,7 @@ class MultibodyTree {
   /// @returns `true` if a frame named `name` was added to @p model_instance.
   /// @see AddFrame().
   ///
-  /// @throws if @p model_instance is not valid for this model.
+  /// @throws std::exception if @p model_instance is not valid for this model.
   bool HasFrameNamed(const std::string& name,
                      ModelInstanceIndex model_instance) const {
     DRAKE_THROW_UNLESS(model_instance < instance_name_to_index_.size());
@@ -1060,7 +1062,7 @@ class MultibodyTree {
   /// @returns `true` if a joint named `name` was added to @p model_instance.
   /// @see AddJoint().
   ///
-  /// @throws if @p model_instance is not valid for this model.
+  /// @throws std::exception if @p model_instance is not valid for this model.
   bool HasJointNamed(const std::string& name,
                      ModelInstanceIndex model_instance) const {
     DRAKE_THROW_UNLESS(model_instance < instance_name_to_index_.size());
@@ -1092,7 +1094,7 @@ class MultibodyTree {
   /// @p model_instance.
   /// @see AddJointActuator().
   ///
-  /// @throws if @p model_instance is not valid for this model.
+  /// @throws std::exception if @p model_instance is not valid for this model.
   bool HasJointActuatorNamed(const std::string& name,
                              ModelInstanceIndex model_instance) const {
     DRAKE_THROW_UNLESS(model_instance < instance_name_to_index_.size());
@@ -1568,7 +1570,7 @@ class MultibodyTree {
   ///   `nullptr`. Vector `X_WB` is resized when needed to have size
   ///   num_bodies().
   ///
-  /// @throws if X_WB is nullptr.
+  /// @throws std::exception if X_WB is nullptr.
   void CalcAllBodyPosesInWorld(
       const systems::Context<T>& context,
       std::vector<Isometry3<T>>* X_WB) const;
@@ -1587,7 +1589,7 @@ class MultibodyTree {
   ///   `V_WB` is `nullptr`. Vector `V_WB` is resized when needed to have size
   ///   num_bodies().
   ///
-  /// /// @throws if V_WB is nullptr.
+  /// @throws std::exception if V_WB is nullptr.
   void CalcAllBodySpatialVelocitiesInWorld(
       const systems::Context<T>& context,
       std::vector<SpatialVelocity<T>>* V_WB) const;
@@ -1655,8 +1657,8 @@ class MultibodyTree {
   ///   The body B for which the pose is requested.
   /// @retval X_WB
   ///   The pose of body frame B in the world frame W.
-  /// @throws if Finalize() was not called on `this` model or if `body_B` does
-  /// not belong to this model.
+  /// @throws std::exception if Finalize() was not called on `this` model or if
+  /// `body_B` does not belong to this model.
   const Isometry3<T>& EvalBodyPoseInWorld(
       const systems::Context<T>& context,
       const Body<T>& body_B) const;
@@ -1668,8 +1670,8 @@ class MultibodyTree {
   ///   The body B for which the spatial velocity is requested.
   /// @returns V_WB
   ///   The spatial velocity of body frame B in the world frame W.
-  /// @throws if Finalize() was not called on `this` model or if `body_B` does
-  /// not belong to this model.
+  /// @throws std::exception if Finalize() was not called on `this` model or if
+  /// `body_B` does not belong to this model.
   const SpatialVelocity<T>& EvalBodySpatialVelocityInWorld(
       const systems::Context<T>& context,
       const Body<T>& body_B) const;
@@ -1727,9 +1729,9 @@ class MultibodyTree {
   ///   have size `3⋅np x nv` or this method throws a std::runtime_error
   ///   exception.
   ///
-  /// @throws an exception if the output `p_WQi_set` is nullptr or does not have
-  /// the same size as the input array `p_BQi_set`.
-  /// @throws an exception if `Jv_WQi` is nullptr or if it does not have the
+  /// @throws std::exception if the output `p_WQi_set` is nullptr or does not
+  ///  have the same size as the input array `p_BQi_set`.
+  /// @throws std::exception if `Jv_WQi` is nullptr or if it does not have the
   /// appropriate size, see documentation for `Jv_WQi` for details.
   // TODO(amcastro-tri): provide the Jacobian-times-vector operation, since for
   // most applications it is all we need and it is more efficient to compute.
@@ -1774,7 +1776,7 @@ class MultibodyTree {
   ///   have size `3⋅np x nv` or this method throws a std::runtime_error
   ///   exception.
   ///
-  /// @throws an exception if `Jv_WQi` is nullptr or if it does not have the
+  /// @throws std::exception if `Jv_WQi` is nullptr or if it does not have the
   /// appropriate size, see documentation for `Jv_WQi` for details.
   // TODO(amcastro-tri): provide the Jacobian-times-vector operation, since for
   // most applications it is all we need and it is more efficient to compute.
@@ -1860,7 +1862,8 @@ class MultibodyTree {
   ///     SpatialVelocity<double> Jv_WF_times_v(Jv_WF * v);
   ///   </pre>
   ///
-  /// @throws if `J_WF` is nullptr or if it is not of size `6 x nv`.
+  /// @throws std::exception if `J_WF` is nullptr or if it is not of size
+  ///   `6 x nv`.
   void CalcFrameGeometricJacobianExpressedInWorld(
       const systems::Context<T>& context,
       const Frame<T>& frame_B, const Eigen::Ref<const Vector3<T>>& p_BoFo_B,

--- a/multibody/multibody_tree/multibody_tree_topology.h
+++ b/multibody/multibody_tree/multibody_tree_topology.h
@@ -562,8 +562,8 @@ class MultibodyTreeTopology {
   ///
   /// @throws std::runtime_error if either `in_frame` or `out_frame` do not
   /// index frame topologies in `this` %MultibodyTreeTopology.
-  /// @throws a std::runtime_error if `in_frame == out_frame`.
-  /// @throws a std::runtime_error if `in_frame` and `out_frame` already are
+  /// @throws std::runtime_error if `in_frame == out_frame`.
+  /// @throws std::runtime_error if `in_frame` and `out_frame` already are
   /// connected by another mobilizer. More than one mobilizer between two frames
   /// is not allowed.
   /// @throws std::logic_error if Finalize() was already called on `this`

--- a/multibody/parsing/frame_cache.h
+++ b/multibody/parsing/frame_cache.h
@@ -55,14 +55,14 @@ class FrameCache {
   /// @param[in] source_frame the name of the source frame `S`. If it
   /// already exists in the cache, its transform will be updated.
   /// @param[in] X_TS the source frame `S`'s pose in the target frame.`T`.
-  /// @throw std::runtime_error if the target frame `T` is not in the cache.
+  /// @throws std::runtime_error if the target frame `T` is not in the cache.
   void Update(const std::string& target_frame,
               const std::string& source_frame,
               const Isometry3<T>& X_TS);
 
   /// Returns `X_TS`, that is the pose of the @p source_frame `S`
   /// in the @p target_frame `T`.
-  /// @throw std::runtime_error if either the target frame `T`
+  /// @throws std::runtime_error if either the target frame `T`
   /// or the source frame `S` are not in the cache.
   Isometry3<T> Transform(const std::string& target_frame,
                          const std::string& source_frame) const;

--- a/perception/transform_point_cloud.h
+++ b/perception/transform_point_cloud.h
@@ -38,7 +38,7 @@ class TransformPointCloud final : public systems::LeafSystem<double> {
   /// `src_frame_index` to the world frame. The `tree` object must remain
   /// valid for the duration of this object.
   ///
-  /// @throw std::logic_error if there is no "world" frame in `tree`.
+  /// @throws std::logic_error if there is no "world" frame in `tree`.
   TransformPointCloud(const RigidBodyTree<double>& tree, int src_frame_index);
 
   /// Returns the abstract valued input port that contains a PointCloud.

--- a/solvers/bilinear_product_util.h
+++ b/solvers/bilinear_product_util.h
@@ -17,16 +17,16 @@ namespace solvers {
  * @param e An expression potentially contains bilinear products between x and
  * y.
  * @param x The bilinear product between `x` and `y` will be replaced by the
- * corresponding term in `W`. Throws a runtime error if `x` contains duplicate
- * entries.
+ * corresponding term in `W`.
+ * @throws std::runtime_error if `x` contains duplicate entries.
  * @param y The bilinear product between `x` and `y` will be replaced by the
- * corresponding term in `W.Throws a runtime error if `y` contains duplicate
- * entries.
+ * corresponding term in `W.
+ * @throws std::runtime_error if `y` contains duplicate entries.
  * @param W Bilinear product term x(i) * y(j) will be replaced by W(i, j). If
  * W(i,j) is not a single variable, but an expression, then this expression
- * cannot contain a variable in either x or y. The program will throw a
- * runtime error, if W(i, j) is not a single variable, and also contains a
- * variable in x or y.
+ * cannot contain a variable in either x or y.
+ * @throws std::runtime_error, if W(i, j) is not a single variable, and also
+ * contains a variable in x or y.
  * @return The symbolic expression after replacing x(i) * y(j) with W(i, j).
  */
 symbolic::Expression ReplaceBilinearTerms(

--- a/solvers/branch_and_bound.h
+++ b/solvers/branch_and_bound.h
@@ -61,7 +61,7 @@ class MixedIntegerBranchAndBoundNode {
    * the map from the old variables to the new variables.
    * @pre prog should contain binary variables.
    * @pre solver_id can be either Gurobi or Scs.
-   * @throw std::runtime_error if the preconditions are not met.
+   * @throws std::runtime_error if the preconditions are not met.
    */
   static std::pair<
       std::unique_ptr<MixedIntegerBranchAndBoundNode>,
@@ -76,7 +76,7 @@ class MixedIntegerBranchAndBoundNode {
    * @param binary_variable This binary variable is fixed to either 0 or 1 in
    * the child node.
    * @pre binary_variable is in remaining_binary_variables_;
-   * @throw std::runtime_error if the preconditions are not met.
+   * @throws std::runtime_error if the preconditions are not met.
    */
   void Branch(const symbolic::Variable& binary_variable);
 
@@ -148,7 +148,7 @@ class MixedIntegerBranchAndBoundNode {
   /**
    * Getter for optimal_solution_is_integral.
    * @pre The optimization problem is solved successfully.
-   * @throws a runtime error if the precondition is not satisfied.
+   * @throws std::runtime_error if the precondition is not satisfied.
    */
   bool optimal_solution_is_integral() const;
 
@@ -306,7 +306,7 @@ class MixedIntegerBranchAndBound {
    * include the optimal cost.
    * @param nth_suboptimal_cost The n'th sub-optimal cost.
    * @pre `nth_suboptimal_cost` is between 0 and solutions().size() - 1.
-   * @throws a runtime error if the precondition is not satisfied.
+   * @throws std::runtime_error if the precondition is not satisfied.
    */
   double GetSubOptimalCost(int nth_suboptimal_cost) const;
 
@@ -319,7 +319,7 @@ class MixedIntegerBranchAndBound {
    * @param nth_best_solution. The index of the best integral solution.
    * @pre `mip_var` is a variable in the original MIP.
    * @pre `nth_best_solution` is between 0 and solutions().size().
-   * @throw runtime error if the preconditions are not satisfied.
+   * @throws std::runtime_error if the preconditions are not satisfied.
    */
   double GetSolution(const symbolic::Variable& mip_var,
                      int nth_best_solution = 0) const;
@@ -332,7 +332,7 @@ class MixedIntegerBranchAndBound {
    * @param nth_best_solution. The index of the best integral solution.
    * @pre `mip_vars` are variables in the original MIP.
    * @pre `nth_best_solution` is between 0 and solutions().size().
-   * @throw runtime error if the preconditions are not satisfied.
+   * @throws std::runtime_error if the preconditions are not satisfied.
    */
   template <typename Derived>
   typename std::enable_if<
@@ -360,7 +360,7 @@ class MixedIntegerBranchAndBound {
    * procedure.
    * @pre old_variable is a variable in the mixed-integer program, passed in the
    * constructor of this MixedIntegerBranchAndBound.
-   * @throw a runtime_error if the pre-condition fails.
+   * @throws std::runtime_error if the pre-condition fails.
    */
   const symbolic::Variable& GetNewVariable(
       const symbolic::Variable& old_variable) const;
@@ -428,7 +428,8 @@ class MixedIntegerBranchAndBound {
    * solvers/test/branch_and_bound_test.cc
    * in TestSetUserDefinedNodeSelectionFunction.
    * @note The user defined function should pick an un-fathomed leaf node for
-   * branching. @throw a runtime error if the node is not a leaf node, or it is
+   * branching.
+   * @throws std::_runtime error if the node is not a leaf node, or it is
    * fathomed.
    */
   void SetUserDefinedNodeSelectionFunction(NodeSelectFun fun) {
@@ -487,7 +488,7 @@ class MixedIntegerBranchAndBound {
   }
 
   /**
-   * The user can set a defined callback function in each node. This function is 
+   * The user can set a defined callback function in each node. This function is
    * called after the optimization is solved in each node.
    */
   void SetUserDefinedNodeCallbackFunction(NodeCallbackFun fun) {
@@ -504,7 +505,7 @@ class MixedIntegerBranchAndBound {
    * 4. All binary variables are fixed to either 0 or 1 in this node.
    * @param leaf_node A leaf node to check if it is fathomed.
    * @pre The node should be a leaf node.
-   * @throws runtime error if the precondition is not satisfied.
+   * @throws std::runtime_error if the precondition is not satisfied.
    */
   bool IsLeafNodeFathomed(
       const MixedIntegerBranchAndBoundNode& leaf_node) const;

--- a/solvers/dreal_solver.cc
+++ b/solvers/dreal_solver.cc
@@ -501,7 +501,7 @@ symbolic::Formula ExtractLinearComplementarityConstraints(
 // Extracts generic constraints in @p prog into a symbolic formula. This is a
 // helper function used in DrealSolver::Solve.
 //
-// @throw std::logic_error if there is a generic-constraint which does not
+// @throws std::logic_error if there is a generic-constraint which does not
 // provide symbolic evaluation.
 symbolic::Formula ExtractGenericConstraints(const MathematicalProgram& prog) {
   return ExtractConstraints(prog.generic_constraints());

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -556,7 +556,7 @@ class MathematicalProgram {
    * @pre `decision_variables` should not intersect with the existing variables
    * or indeterminates in the optimization program.
    * @pre Each entry in `decision_variables` should not be a dummy variable.
-   * @throw runtime_error if the preconditions are not satisfied.
+   * @throws std::runtime_error if the preconditions are not satisfied.
    */
   void AddDecisionVariables(
       const Eigen::Ref<const VectorXDecisionVariable>& decision_variables);
@@ -938,8 +938,8 @@ class MathematicalProgram {
    * Add a quadratic cost term of the form 0.5*x'*Q*x + b'*x + c.
    * Notice that in the optimization program, the constant term `c` in the cost
    * is ignored.
-   * @param e A quadratic symbolic expression. Throws a runtime error if the
-   * expression is not quadratic.
+   * @param e A quadratic symbolic expression.
+   * @throws std::runtime error if the expression is not quadratic.
    * @return The newly added cost together with the bound variables.
    */
   Binding<QuadraticCost> AddQuadraticCost(const symbolic::Expression& e);
@@ -1038,7 +1038,8 @@ class MathematicalProgram {
 
   /**
    * Adds one row of constraint lb <= e <= ub where @p e is a symbolic
-   * expression. Throws an exception if
+   * expression.
+   * @throws std::exception if
    *  1. <tt>lb <= e <= ub</tt> is a trivial constraint such as 1 <= 2 <= 3.
    *  2. <tt>lb <= e <= ub</tt> is unsatisfiable such as 1 <= -5 <= 3
    *
@@ -1218,7 +1219,8 @@ class MathematicalProgram {
 
   /**
    * Adds one row of linear constraint lb <= e <= ub where @p e is a symbolic
-   * expression. Throws an exception if
+   * expression.
+   * @throws std::exception if
    *  1. @p e is a non-linear expression.
    *  2. <tt>lb <= e <= ub</tt> is a trivial constraint such as 1 <= 2 <= 3.
    *  3. <tt>lb <= e <= ub</tt> is unsatisfiable such as 1 <= -5 <= 3
@@ -1320,7 +1322,8 @@ class MathematicalProgram {
 
   /**
    * Adds one row of linear constraint e = b where @p e is a symbolic
-   * expression. Throws an exception if
+   * expression.
+   * @throws std::exception if
    *  1. @p e is a non-linear expression.
    *  2. @p e is a constant.
    *
@@ -1347,7 +1350,8 @@ class MathematicalProgram {
 
   /**
    * Adds linear equality constraints \f$ v = b \f$, where \p v(i) is a symbolic
-   * linear expression. Throws an exception if
+   * linear expression.
+   * @throws std::exception if
    * 1. @p v(i) is a non-linear expression.
    * 2. @p v(i) is a constant.
    * @tparam DerivedV An Eigen Matrix type of Expression. A column vector.
@@ -1655,7 +1659,7 @@ class MathematicalProgram {
    *    Also the quadratic expression has to be convex, namely Q is a
    *    positive semidefinite matrix, and the quadratic expression needs
    *    to be non-negative for any x.
-   * Throws a runtime_error if the preconditions are not satisfied.
+   * @throws std::runtime_error if the preconditions are not satisfied.
    *
    * Notice this constraint is equivalent to the vector [z;y] is within a
    * Lorentz cone, where
@@ -1791,7 +1795,7 @@ class MathematicalProgram {
    *    Also the quadratic expression has to be convex, namely Q is a
    *    positive semidefinite matrix, and the quadratic expression needs
    *    to be non-negative for any x.
-   * Throws a runtime_error if the preconditions are not satisfied.
+   * @throws std::runtime_error if the preconditions are not satisfied.
    */
   Binding<RotatedLorentzConeConstraint> AddRotatedLorentzConeConstraint(
       const symbolic::Expression& linear_expression1,
@@ -1972,8 +1976,9 @@ class MathematicalProgram {
 
   /**
    * Adds a positive semidefinite constraint on a symmetric matrix.
-   * In Debug mode, @throws error if
-   * @p symmetric_matrix_var is not symmetric.
+   *
+   * @throws std::runtime_error in Debug mode if @p symmetric_matrix_var is not
+   * symmetric.
    * @param symmetric_matrix_var A symmetric MatrixDecisionVariable object.
    */
   Binding<PositiveSemidefiniteConstraint> AddPositiveSemidefiniteConstraint(
@@ -2083,8 +2088,8 @@ class MathematicalProgram {
    * @param X The matrix X. We will use 0.5(X+Xᵀ) as the "symmetric version" of
    * X.
    * @pre X(i, j) should be a linear expression of decision variables.
-   * @return M A vector of vectors of 2 x 2 symmetric matrices M. For i < j, 
-   * M[i][j] is 
+   * @return M A vector of vectors of 2 x 2 symmetric matrices M. For i < j,
+   * M[i][j] is
    * <pre>
    * [Mⁱʲ(i, i), Mⁱʲ(i, j)]
    * [Mⁱʲ(i, j), Mⁱʲ(j, j)].
@@ -2158,7 +2163,7 @@ class MathematicalProgram {
   /**
    * Gets the initial guess for a single variable.
    * @pre @p decision_variable has been registered in the optimization program.
-   * @throw runtime error if the pre condition is not satisfied.
+   * @throws std::runtime_error if the pre condition is not satisfied.
    */
   double GetInitialGuess(const symbolic::Variable& decision_variable) const;
 
@@ -2166,7 +2171,7 @@ class MathematicalProgram {
    * Gets the initial guess for some variables.
    * @pre Each variable in @p decision_variable_mat has been registered in the
    * optimization program.
-   * @throw runtime error if the pre condition is not satisfied.
+   * @throws std::runtime_error if the pre condition is not satisfied.
    */
   template <typename Derived>
   typename std::enable_if<
@@ -2191,7 +2196,7 @@ class MathematicalProgram {
   /**
    * Sets the initial guess for a single variable @p decision_variable.
    * @pre decision_variable is a registered decision variable in the program.
-   * @throw a runtime error if precondition is not satisfied.
+   * @throws std::runtime_error if precondition is not satisfied.
    */
   void SetInitialGuess(const symbolic::Variable& decision_variable,
                        double variable_guess_value);
@@ -2534,7 +2539,7 @@ class MathematicalProgram {
   /**
    * Replaces the variables in an expression with the solutions to the
    * variables, returns the expression after substitution.
-   * @throw runtime error if some variables in the expression @p e are NOT
+   * @throws std::runtime_error if some variables in the expression @p e are NOT
    * decision variables or indeterminates in the optimization program.
    * @note If the expression @p e contains both decision variables and
    * indeterminates of the optimization program, then the decision variables
@@ -2546,8 +2551,8 @@ class MathematicalProgram {
   /**
    * Replaces the decision variables in a polynomial with the solutions to the
    * variables, returns the polynomial after substitution.
-   * @throw runtime error if some decision variables in the polynomial @p p are
-   * NOT decision variables in the optimization program.
+   * @throws std::runtime_error if some decision variables in the polynomial
+   * @p p are NOT decision variables in the optimization program.
    * @note If the polynomial @p p contains both decision variables and
    * indeterminates of the optimization program, then the decision variables
    * will be substituted by its solutions in double values, but not the
@@ -2561,7 +2566,8 @@ class MathematicalProgram {
    * @param binding A Binding whose variables are decision variables in this
    * program.
    * @param prog_var_vals The value of all the decision variables in this
-   * program. @throw a logic error if the size does not match.
+   * program.
+   * @throws std::logic_error if the size does not match.
    */
   template <typename C, typename DerivedX>
   typename std::enable_if<is_eigen_vector<DerivedX>::value,
@@ -2590,7 +2596,8 @@ class MathematicalProgram {
    * MathematicalProgram.
    *
    * @param prog_var_vals The value of all the decision variables in this
-   * program. @throw a logic error if the size does not match.
+   * program.
+   * @throws std::logic_error if the size does not match.
    **/
   void EvalVisualizationCallbacks(
       const Eigen::Ref<const Eigen::VectorXd>& prog_var_vals) const {

--- a/solvers/mixed_integer_optimization_util.h
+++ b/solvers/mixed_integer_optimization_util.h
@@ -41,7 +41,7 @@ struct LogarithmicSos2NewBinaryVariables<Eigen::Dynamic> {
  * <pre>
  *   λ(0) + ... + λ(n) = 1
  *   ∀i. λ(i) ≥ 0
- *   ∃ j ∈ {0, 1, ..., n-1}, s.t λ(i) = 0 if i ≠ j and i ≠ j + 1 
+ *   ∃ j ∈ {0, 1, ..., n-1}, s.t λ(i) = 0 if i ≠ j and i ≠ j + 1
  * </pre>
  * Namely at most two entries in λ can be strictly positive, and these two
  * entries have to be adjacent. All other λ should be zero. Moreover, the
@@ -127,8 +127,8 @@ void AddSos2Constraint(
  * integer M in `codes`, then only λ(M) is positive. Namely, if
  * (y(0), ..., y(⌈log₂(n)⌉) equals to codes.row(M), then λ(M) = 1
  * @param codes A n x ⌈log₂(n)⌉ matrix. code.row(i) represents integer i.
- * No two rows of `codes` can be the same. @throws std::runtime_error if
- * @p codes has a non-binary entry (0, 1).
+ * No two rows of `codes` can be the same.
+ * @throws std::runtime_error if @p codes has a non-binary entry (0, 1).
  */
 void AddLogarithmicSos1Constraint(
     MathematicalProgram* prog,

--- a/solvers/non_convex_optimization_util.h
+++ b/solvers/non_convex_optimization_util.h
@@ -34,7 +34,8 @@ namespace solvers {
  *   DC Decomposition of Nonconvex Polynomials with Algebraic Techniques
  *     By A. A. Ahmadi and G. Hall
  *     Mathematical Programming, 2015
- * @param Q A square matrix. Throws a runtime_error if Q is not square.
+ * @param Q A square matrix.
+ * @throws std::runtime_error if Q is not square.
  * @return The optimal decomposition (Q₁, Q₂)
  * TODO(hongkai.dai): templatize this function, to avoid dynamic memory
  * allocation.

--- a/systems/analysis/dense_output.h
+++ b/systems/analysis/dense_output.h
@@ -87,7 +87,7 @@ class DenseOutput {
   /// Returns the output size (i.e. the number of elements in an
   /// output value).
   /// @pre Output is not empty i.e. is_empty() equals false.
-  /// @throw std::logic_error if any of the preconditions is not met.
+  /// @throws std::logic_error if any of the preconditions is not met.
   int size() const {
     ThrowIfOutputIsEmpty(__func__);
     return this->do_size();

--- a/systems/framework/abstract_values.h
+++ b/systems/framework/abstract_values.h
@@ -46,8 +46,8 @@ class AbstractValues {
   AbstractValue& get_mutable_value(int index);
 
   /// Copies all of the AbstractValues in @p other into this. Asserts if the
-  /// two are not equal in size. Throws if any of the elements are of
-  /// incompatible type.
+  /// two are not equal in size.
+  /// @throws std::exception if any of the elements are of incompatible type.
   void CopyFrom(const AbstractValues& other);
 
   /// Returns a deep copy of all the data in this AbstractValues. The clone

--- a/systems/framework/basic_vector.h
+++ b/systems/framework/basic_vector.h
@@ -70,7 +70,7 @@ class BasicVector : public VectorBase<T> {
 
   /// Sets the vector to the given value. After a.set_value(b.get_value()), a
   /// must be identical to b.
-  /// Throws std::out_of_range if the new value has different dimensions.
+  /// @throws std::out_of_range if the new value has different dimensions.
   void set_value(const Eigen::Ref<const VectorX<T>>& value) {
     if (value.rows() != values_.rows()) {
       throw std::out_of_range(

--- a/systems/framework/diagram_builder.h
+++ b/systems/framework/diagram_builder.h
@@ -141,10 +141,10 @@ class DiagramBuilder {
   }
 
   /// Declares that sole input port on the @p dest system is connected to sole
-  /// output port on the @p src system.  Throws an exception if the sole-port
-  /// precondition is not met (i.e., if @p dest has no input ports, or @p dest
-  /// has more than one input port, or @p src has no output ports, or @p src
-  /// has more than one output port).
+  /// output port on the @p src system.
+  /// @throws std::exception if the sole-port precondition is not met (i.e.,
+  /// if @p dest has no input ports, or @p dest has more than one input port,
+  /// or @p src has no output ports, or @p src has more than one output port).
   void Connect(const System<T>& src, const System<T>& dest) {
     DRAKE_THROW_UNLESS(src.get_num_output_ports() == 1);
     DRAKE_THROW_UNLESS(dest.get_num_input_ports() == 1);
@@ -152,10 +152,10 @@ class DiagramBuilder {
   }
 
   /// Cascades @p src and @p dest.  The sole input port on the @p dest system
-  /// is connected to sole output port on the @p src system.  Throws an
-  /// exception if the sole-port precondition is not met (i.e., if @p dest has
-  /// no input ports, or @p dest has more than one input port, or @p src has no
-  /// output ports, or @p src has more than one output port).
+  /// is connected to sole output port on the @p src system.
+  /// @throws std::exception if the sole-port precondition is not met (i.e., if
+  /// @p dest has no input ports, or @p dest has more than one input port, or
+  /// @p src has no output ports, or @p src has more than one output port).
   void Cascade(const System<T>& src, const System<T>& dest) {
     Connect(src, dest);
   }
@@ -210,16 +210,16 @@ class DiagramBuilder {
   }
 
   /// Builds the Diagram that has been described by the calls to Connect,
-  /// ExportInput, and ExportOutput. Throws std::logic_error if the graph is
-  /// not buildable.
+  /// ExportInput, and ExportOutput.
+  /// @throws std::logic_error if the graph is not buildable.
   std::unique_ptr<Diagram<T>> Build() {
     std::unique_ptr<Diagram<T>> diagram(new Diagram<T>(Compile()));
     return diagram;
   }
 
   /// Configures @p target to have the topology that has been described by
-  /// the calls to Connect, ExportInput, and ExportOutput. Throws
-  /// std::logic_error if the graph is not buildable.
+  /// the calls to Connect, ExportInput, and ExportOutput.
+  /// @throws std::logic_error if the graph is not buildable.
   ///
   /// Only Diagram subclasses should call this method. The target must not
   /// already be initialized.

--- a/systems/framework/fixed_input_port_value.h
+++ b/systems/framework/fixed_input_port_value.h
@@ -72,7 +72,8 @@ class FixedInputPortValue {
 
   /** Returns a pointer to the data inside this %FixedInputPortValue, and
   notifies the dependent input port that the value has changed, invalidating
-  downstream computations. Throws std::bad_cast if the data is not vector data.
+  downstream computations.
+  @throws std::bad_cast if the data is not vector data.
 
   To ensure invalidation notifications are delivered, callers should call this
   method every time they wish to update the stored value. In particular, callers

--- a/systems/framework/model_values.h
+++ b/systems/framework/model_values.h
@@ -60,8 +60,8 @@ class ModelValues {
   /// Returns a clone of the vector within the model value at @p index, which
   /// may be nullptr.
   ///
-  /// @throw exception if the index has a model but the model's type does not
-  /// match the given @p T
+  /// @throws std::exception if the index has a model but the model's type does
+  /// not match the given @p T
   template <typename T>
   std::unique_ptr<BasicVector<T>> CloneVectorModel(int index) const;
 

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -1170,7 +1170,8 @@ class System : public SystemBase {
 
   /// Checks that @p output is consistent with the number and size of output
   /// ports declared by the system.
-  /// @throw exception unless `output` is non-null and valid for this system.
+  /// @throws std::exception unless `output` is non-null and valid for this
+  /// system.
   void CheckValidOutput(const SystemOutput<T>* output) const {
     DRAKE_THROW_UNLESS(output != nullptr);
 
@@ -1193,7 +1194,7 @@ class System : public SystemBase {
   /// Checks that @p context is consistent for this System template. Supports
   /// any scalar type, but expects T by default.
   ///
-  /// @throw exception unless `context` is valid for this system.
+  /// @throws std::exception unless `context` is valid for this system.
   /// @tparam T1 the scalar type of the Context to check.
   // TODO(sherm1) This method needs to be unit tested.
   template <typename T1 = T>
@@ -1299,7 +1300,7 @@ class System : public SystemBase {
   /// Creates a deep copy of this System, transmogrified to use the autodiff
   /// scalar type, with a dynamic-sized vector of partial derivatives.  The
   /// result is never nullptr.
-  /// @throw exception if this System does not support autodiff
+  /// @throws std::exception if this System does not support autodiff
   ///
   /// See @ref system_scalar_conversion for detailed background and examples
   /// related to scalar-type conversion support.
@@ -1310,7 +1311,7 @@ class System : public SystemBase {
   /// Creates a deep copy of `from`, transmogrified to use the autodiff scalar
   /// type, with a dynamic-sized vector of partial derivatives.  The result is
   /// never nullptr.
-  /// @throw exception if `from` does not support autodiff
+  /// @throws std::exception if `from` does not support autodiff
   ///
   /// Usage: @code
   ///   MySystem<double> plant;
@@ -1355,7 +1356,7 @@ class System : public SystemBase {
 
   /// Creates a deep copy of this System, transmogrified to use the symbolic
   /// scalar type. The result is never nullptr.
-  /// @throw exception if this System does not support symbolic
+  /// @throws std::exception if this System does not support symbolic
   ///
   /// See @ref system_scalar_conversion for detailed background and examples
   /// related to scalar-type conversion support.
@@ -1365,7 +1366,7 @@ class System : public SystemBase {
 
   /// Creates a deep copy of `from`, transmogrified to use the symbolic scalar
   /// type. The result is never nullptr.
-  /// @throw exception if this System does not support symbolic
+  /// @throws std::exception if this System does not support symbolic
   ///
   /// Usage: @code
   ///   MySystem<double> plant;
@@ -1404,9 +1405,10 @@ class System : public SystemBase {
   //@{
 
   /// Fixes all of the input ports in @p target_context to their current values
-  /// in @p other_context, as evaluated by @p other_system. Throws an exception
-  /// unless `other_context` and `target_context` both have the same shape as
-  /// this System, and the `other_system`. Ignores disconnected inputs.
+  /// in @p other_context, as evaluated by @p other_system.
+  /// @throws std::exception unless `other_context` and `target_context` both
+  /// have the same shape as this System, and the `other_system`. Ignores
+  /// disconnected inputs.
   void FixInputPortsFrom(const System<double>& other_system,
                          const Context<double>& other_context,
                          Context<T>* target_context) const {

--- a/systems/framework/system_output.h
+++ b/systems/framework/system_output.h
@@ -49,7 +49,7 @@ class SystemOutput {
 
   /** Returns the last-saved value of output port `index` as a `BasicVector<T>`,
   although the actual concrete type is preserved from the actual output port.
-  Throws std::bad_cast if the port is not vector-valued. */
+  @throws std::bad_cast if the port is not vector-valued. */
   const BasicVector<T>* get_vector_data(int index) const {
     DRAKE_ASSERT(0 <= index && index < get_num_ports());
     return &port_values_[index]->template GetValue<BasicVector<T>>();
@@ -69,7 +69,8 @@ class SystemOutput {
   suitable for holding the value of output port `index` of the allocating
   System. The object's concrete type is preserved from the output port. Most
   users should just call `System<T>::CalcOutputs()` to get all the output
-  port values at once. Throws std::bad_cast if the port is not vector-valued. */
+  port values at once.
+  @throws std::bad_cast if the port is not vector-valued. */
   BasicVector<T>* GetMutableVectorData(int index) {
     DRAKE_ASSERT(0 <= index && index < get_num_ports());
     return &port_values_[index]

--- a/systems/framework/value_checker.h
+++ b/systems/framework/value_checker.h
@@ -22,7 +22,7 @@ namespace detail {
 /// should be used sparingly.  In particular, only a few select locations
 /// within the Systems Framework itself should likely call this function.
 ///
-/// @throw exception if invariants are violated or basic_vector is nullptr
+/// @throws std::exception if invariants are violated or basic_vector is nullptr
 template <typename T>
 void CheckBasicVectorInvariants(const BasicVector<T>* basic_vector) {
   DRAKE_THROW_UNLESS(basic_vector != nullptr);
@@ -53,7 +53,8 @@ void CheckBasicVectorInvariants(const BasicVector<T>* basic_vector) {
 /// @tparam T the supposed element type of the Value<BasicVector<T>> that has
 /// been erased into an AbstractValue
 ///
-/// @throw exception if invariants are violated or abstract_value is nullptr
+/// @throws std::exception if invariants are violated or abstract_value is
+/// nullptr
 template <typename T>
 void CheckVectorValueInvariants(const AbstractValue* abstract_value) {
   DRAKE_THROW_UNLESS(abstract_value != nullptr);

--- a/systems/framework/vector_base.h
+++ b/systems/framework/vector_base.h
@@ -37,15 +37,15 @@ class VectorBase {
   /// memory.
   virtual int size() const = 0;
 
-  /// Returns the element at the given index in the vector. Throws
-  /// std::runtime_error if the index is >= size().
+  /// Returns the element at the given index in the vector.
+  /// @throws std::runtime_error if the index is >= size().
   ///
   /// Implementations should ensure this operation is O(1) and allocates no
   /// memory.
   virtual const T& GetAtIndex(int index) const = 0;
 
-  /// Returns the element at the given index in the vector. Throws
-  /// std::runtime_error if the index is >= size().
+  /// Returns the element at the given index in the vector.
+  /// @throws std::runtime_error if the index is >= size().
   ///
   /// Implementations should ensure this operation is O(1) and allocates no
   /// memory.
@@ -54,14 +54,15 @@ class VectorBase {
   T& operator[](std::size_t idx) { return GetAtIndex(idx); }
   const T& operator[](std::size_t idx) const { return GetAtIndex(idx); }
 
-  /// Replaces the state at the given index with the value. Throws
-  /// std::runtime_error if the index is >= size().
+  /// Replaces the state at the given index with the value.
+  /// @throws std::runtime_error if the index is >= size().
   void SetAtIndex(int index, const T& value) {
     GetAtIndex(index) = value;
   }
 
-  /// Replaces the entire vector with the contents of @p value. Throws
-  /// std::runtime_error if @p value is not a column vector with size() rows.
+  /// Replaces the entire vector with the contents of @p value.
+  /// @throws std::runtime_error if @p value is not a column vector with size()
+  /// rows.
   ///
   /// Implementations should ensure this operation is O(N) in the size of the
   /// value and allocates no memory.

--- a/systems/lcm/lcm_and_vector_base_translator.h
+++ b/systems/lcm/lcm_and_vector_base_translator.h
@@ -56,8 +56,8 @@ class LcmAndVectorBaseTranslator {
    * @param[out] vector_base A pointer to where the translation of the LCM
    * message should be stored. This pointer must not be `nullptr`.
    *
-   * @throws runtime_error If a received LCM message failed to be decoded, or
-   * if the decoded LCM message is incompatible with the @p vector_base.
+   * @throws std::runtime_error If a received LCM message failed to be decoded,
+   * or if the decoded LCM message is incompatible with the @p vector_base.
    * This often occurs when the size of the @p vector_base does not equal
    * or is incompatible with the size of the decoded LCM message.
    */

--- a/systems/primitives/affine_system.h
+++ b/systems/primitives/affine_system.h
@@ -179,8 +179,8 @@ class AffineSystem : public TimeVaryingAffineSystem<T> {
   /// Creates a unique pointer to AffineSystem<T> by decomposing @p dynamics and
   /// @p outputs using @p state_vars and @p input_vars.
   ///
-  /// @throws runtime_error if either @p dynamics or @p outputs is not affine in
-  /// @p state_vars and @p input_vars.
+  /// @throws std::runtime_error if either @p dynamics or @p outputs is not
+  /// affine in @p state_vars and @p input_vars.
   static std::unique_ptr<AffineSystem<T>> MakeAffineSystem(
       const Eigen::Ref<const VectorX<symbolic::Expression>>& dynamics,
       const Eigen::Ref<const VectorX<symbolic::Expression>>& output,

--- a/systems/primitives/linear_system.h
+++ b/systems/primitives/linear_system.h
@@ -69,8 +69,8 @@ class LinearSystem : public AffineSystem<T> {
   /// Creates a unique pointer to LinearSystem<T> by decomposing @p dynamics and
   /// @p outputs using @p state_vars and @p input_vars.
   ///
-  /// @throws runtime_error if either @p dynamics or @p outputs is not linear in
-  /// @p state_vars and @p input_vars.
+  /// @throws std::runtime_error if either @p dynamics or @p outputs is not
+  /// linear in @p state_vars and @p input_vars.
   static std::unique_ptr<LinearSystem<T>> MakeLinearSystem(
       const Eigen::Ref<const VectorX<symbolic::Expression>>& dynamics,
       const Eigen::Ref<const VectorX<symbolic::Expression>>& output,

--- a/systems/trajectory_optimization/multiple_shooting.h
+++ b/systems/trajectory_optimization/multiple_shooting.h
@@ -234,10 +234,10 @@ class MultipleShooting : public solvers::MathematicalProgram {
   ///
   /// If time steps are decision variables, then the initial guess for
   /// the time steps are evenly distributed to match the duration of the
-  /// @p traj_init_u and @p traj_init_x. Throws std::runtime_error if
-  /// @p traj_init_u and @p traj_init_x are both empty, or if
-  /// @p traj_init_u and @p traj_init_x are both non-empty, and have
-  /// different start and end times.
+  /// @p traj_init_u and @p traj_init_x.
+  /// @throws std::runtime_error if @p traj_init_u and @p traj_init_x are both
+  /// empty, or if @p traj_init_u and @p traj_init_x are both non-empty, and
+  /// have different start and end times.
   // TODO(russt): Consider taking the actual breakpoints from
   // traj_init_{u,x} iff they match the number of sample times.
   void SetInitialTrajectory(


### PR DESCRIPTION
Mainly aimed at the Python documentation, but should be beneficial for the C++ docs too. FTR, the Doxygen signature of `\throws` is
```
\throws <exception-object> { exception description }
```
where `<exception-object>` is frequently missing in our docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9632)
<!-- Reviewable:end -->
