### PR TITLE
vector_gen: Add fluent setters (aka "with"ers)

### DIFF
--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -596,6 +596,7 @@ drake_cc_googletest(
         "//common:essential",
         "//common:symbolic",
         "//common/test_utilities:eigen_matrix_compare",
+        "//systems/framework/test_utilities:my_vector",
     ],
 )
 

--- a/systems/framework/basic_vector.h
+++ b/systems/framework/basic_vector.h
@@ -38,7 +38,7 @@ class BasicVector : public VectorBase<T> {
       : values_(VectorX<T>::Constant(size, dummy_value<T>::get())) {}
 
   /// Constructs a BasicVector with the specified @p data.
-  explicit BasicVector(const VectorX<T>& data) : values_(data) {}
+  explicit BasicVector(VectorX<T> data) : values_(std::move(data)) {}
 
   /// Constructs a BasicVector whose elements are the elements of @p data.
   BasicVector(const std::initializer_list<T>& data)
@@ -162,6 +162,12 @@ class BasicVector : public VectorBase<T> {
     data->SetAtIndex(index++, T(constructor_arg));
   }
 
+  /// Provides const access to the element storage.
+  const VectorX<T>& values() const { return values_; }
+
+  /// Provides mutable access to the element storage.
+  VectorX<T>& values() { return values_; }
+
  private:
   // Add in multiple scaled vectors to this vector. All vectors
   // must be the same size. This function overrides the default DoPlusEqScaled()
@@ -179,7 +185,7 @@ class BasicVector : public VectorBase<T> {
   VectorX<T> values_;
   // N.B. Do not add more member fields without considering the effect on
   // subclasses.  Derived class's Clone() methods currently assume that the
-  // BasicVector(const VectorX<T>&) constructor is all that is needed.
+  // BasicVector(VectorX<T>) constructor is all that is needed.
 };
 
 // Allows a BasicVector<T> to be streamed into a string. This is useful for

--- a/systems/framework/test/basic_vector_test.cc
+++ b/systems/framework/test/basic_vector_test.cc
@@ -10,6 +10,7 @@
 #include "drake/common/eigen_types.h"
 #include "drake/common/symbolic.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/systems/framework/test_utilities/my_vector.h"
 
 namespace drake {
 namespace systems {
@@ -254,6 +255,23 @@ GTEST_TEST(BasicVectorTest, DefaultCalcInequalityConstraint) {
   EXPECT_EQ(value.size(), 0);
 }
 
+// Tests the protected `::values()` methods.
+GTEST_TEST(BasicVectorTest, ValuesAccess) {
+  MyVector<2, double> dut;
+  dut[0] = 11.0;
+  dut[1] = 22.0;
+
+  // Values are as expected.
+  ASSERT_EQ(dut.values().size(), 2);
+  EXPECT_EQ(dut.values()[0], 11.0);
+  EXPECT_EQ(dut.values()[1], 22.0);
+  dut.values()[0] = 33.0;
+
+  // The const overload is the same.
+  const auto& const_dut = dut;
+  EXPECT_EQ(&dut.values(), &const_dut.values());
+  EXPECT_EQ(const_dut.values()[0], 33.0);
+}
 
 }  // namespace
 }  // namespace systems

--- a/systems/framework/test_utilities/my_vector.h
+++ b/systems/framework/test_utilities/my_vector.h
@@ -56,6 +56,9 @@ class MyVector : public BasicVector<T> {
         BasicVector<T>::Clone());
   }
 
+  // Allow unit tests to read/write the underlying MatrixXd directly.
+  using BasicVector<T>::values;
+
  private:
   // BasicVector's Clone() method handles copying the values; DoClone() is
   // only supposed to allocate a vector of the right concrete type and size.

--- a/systems/lcm/BUILD.bazel
+++ b/systems/lcm/BUILD.bazel
@@ -49,7 +49,8 @@ drake_cc_library(
         "lcm_translator_dictionary.h",
     ],
     deps = [
-        "//systems/framework",
+        "//common:essential",
+        "//systems/framework:vector",
     ],
 )
 

--- a/tools/vector_gen/BUILD.bazel
+++ b/tools/vector_gen/BUILD.bazel
@@ -86,6 +86,7 @@ drake_cc_googletest(
         ":sample",
         "//common:autodiff",
         "//common:symbolic",
+        "//common/test_utilities",
     ],
 )
 

--- a/tools/vector_gen/lcm_vector_gen.py
+++ b/tools/vector_gen/lcm_vector_gen.py
@@ -116,7 +116,7 @@ def generate_indices_names_accessor_impl(cc, caller_context, fields):
     put(cc, INDICES_NAMES_ACCESSOR_IMPL_END % context, 2)
 
 
-# A second variant of a default constructor (field-by-field setting).
+# A default constructor with field-by-field setting.
 DEFAULT_CTOR_CUSTOM_BEGIN_API = """
   /// Default constructor.  Sets all rows to their default value:
 """
@@ -137,7 +137,6 @@ DEFAULT_CTOR_FIELD_UNKNOWN_DOC_UNITS = 'unknown'
 
 
 def generate_default_ctor(hh, caller_context, fields):
-    # Otherwise, emit a customized ctor.
     put(hh, DEFAULT_CTOR_CUSTOM_BEGIN_API % caller_context, 1)
     for field in fields:
         context = dict(caller_context)
@@ -162,6 +161,35 @@ def generate_default_ctor(hh, caller_context, fields):
         context.update(default_value=default_value)
         put(hh, DEFAULT_CTOR_CUSTOM_FIELD_BODY % context, 1)
     put(hh, DEFAULT_CTOR_CUSTOM_END % caller_context, 2)
+
+
+# The "rule of five methods" (but only four -- default dtor is fine).
+COPY_AND_ASSIGN = """
+  // Note: It's safe to implement copy and move because this class is final.
+
+  /// @name Implements CopyConstructible, CopyAssignable, MoveConstructible,
+  /// MoveAssignable
+  //@{
+  %(camel)s(const %(camel)s& other)
+      : drake::systems::BasicVector<T>(other.values()) {}
+  %(camel)s(%(camel)s&& other) noexcept
+      : drake::systems::BasicVector<T>(std::move(other.values())) {}
+  %(camel)s& operator=(const %(camel)s& other) {
+    this->values() = other.values();
+    return *this;
+  }
+  %(camel)s& operator=(%(camel)s&& other) noexcept {
+    this->values() = std::move(other.values());
+    other.values().resize(0);
+    return *this;
+  }
+  //@}
+"""
+
+
+def generate_copy_and_assign(hh, caller_context):
+    # Otherwise, emit a customized ctor.
+    put(hh, COPY_AND_ASSIGN % caller_context, 2)
 
 
 # SetToNamedVariables (for symbolic::Expression only).
@@ -214,9 +242,23 @@ ACCESSOR_FIELD_DOC_RANGE = """
   /// @note @c %(field)s has a limited domain of [%(min_doc)s, %(max_doc)s].
 """
 ACCESSOR_FIELD_METHODS = """
-  const T& %(field)s() const { return this->GetAtIndex(K::%(kname)s); }
+  const T& %(field)s() const {
+    ThrowIfEmpty();
+    return this->GetAtIndex(K::%(kname)s);
+  }
+  /// Setter that matches %(field)s().
   void set_%(field)s(const T& %(field)s) {
+    ThrowIfEmpty();
     this->SetAtIndex(K::%(kname)s, %(field)s);
+  }
+  /// Fluent setter that matches %(field)s().
+  /// Returns a copy of `this` with %(field)s set to a new value.
+  DRAKE_VECTOR_GEN_NODISCARD
+  %(camel)s<T>
+  with_%(field)s(const T& %(field)s) const {
+    %(camel)s<T> result(*this);
+    result.set_%(field)s(%(field)s);
+    return result;
   }
 """
 ACCESSOR_END = """
@@ -342,6 +384,7 @@ VECTOR_HH_PREAMBLE = """
 #include <stdexcept>
 #include <string>
 #include <vector>
+#include <utility>
 
 #include <Eigen/Core>
 
@@ -350,6 +393,13 @@ VECTOR_HH_PREAMBLE = """
 #include "drake/common/never_destroyed.h"
 #include "drake/common/symbolic.h"
 #include "drake/systems/framework/basic_vector.h"
+
+// TODO(jwnimmer-tri) Elevate this to drake/common.
+#if __has_cpp_attribute(nodiscard)
+#define DRAKE_VECTOR_GEN_NODISCARD [[nodiscard]]  // NOLINT(whitespace/braces)
+#else
+#define DRAKE_VECTOR_GEN_NODISCARD
+#endif
 
 %(opening_namespace)s
 """
@@ -365,11 +415,21 @@ class %(camel)s final : public drake::systems::BasicVector<T> {
 """
 
 VECTOR_CLASS_END = """
+ private:
+  void ThrowIfEmpty() const {
+    if (this->values().size() == 0) {
+      throw std::out_of_range(
+          "The %(camel)s vector has been moved-from; "
+          "accessor methods may no longer be used");
+    }
+  }
 };
 """
 
 VECTOR_HH_POSTAMBLE = """
 %(closing_namespace)s
+
+#undef DRAKE_VECTOR_GEN_NODISCARD
 """
 
 VECTOR_CC_PREAMBLE = """
@@ -608,6 +668,7 @@ def generate_code(
             generate_indices_names_accessor_decl(hh, context)
             put(hh, VECTOR_CLASS_BEGIN % context, 2)
             generate_default_ctor(hh, context, fields)
+            generate_copy_and_assign(hh, context)
             generate_set_to_named_variables(hh, context, fields)
             generate_do_clone(hh, context, fields)
             generate_accessors(hh, context, fields)

--- a/tools/vector_gen/test/goal/lcmt_sample_t.lcm
+++ b/tools/vector_gen/test/goal/lcmt_sample_t.lcm
@@ -1,4 +1,4 @@
-// GENERATED FILE DO NOT EDIT
+// GENERATED GOAL DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
 package drake;

--- a/tools/vector_gen/test/goal/sample.cc
+++ b/tools/vector_gen/test/goal/sample.cc
@@ -1,6 +1,6 @@
 #include "drake/tools/vector_gen/test/gen/sample.h"
 
-// GENERATED FILE DO NOT EDIT
+// GENERATED GOAL DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
 namespace drake {

--- a/tools/vector_gen/test/goal/sample.h
+++ b/tools/vector_gen/test/goal/sample.h
@@ -1,11 +1,12 @@
 #pragma once
 
-// GENERATED FILE DO NOT EDIT
+// GENERATED GOAL DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
 #include <cmath>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <Eigen/Core>
@@ -15,6 +16,13 @@
 #include "drake/common/never_destroyed.h"
 #include "drake/common/symbolic.h"
 #include "drake/systems/framework/basic_vector.h"
+
+// TODO(jwnimmer-tri) Elevate this to drake/common.
+#if __has_cpp_attribute(nodiscard)
+#define DRAKE_VECTOR_GEN_NODISCARD [[nodiscard]]  // NOLINT(whitespace/braces)
+#else
+#define DRAKE_VECTOR_GEN_NODISCARD
+#endif
 
 namespace drake {
 namespace tools {
@@ -57,6 +65,26 @@ class Sample final : public drake::systems::BasicVector<T> {
     this->set_unset(drake::dummy_value<T>::get());
   }
 
+  // Note: It's safe to implement copy and move because this class is final.
+
+  /// @name Implements CopyConstructible, CopyAssignable, MoveConstructible,
+  /// MoveAssignable
+  //@{
+  Sample(const Sample& other)
+      : drake::systems::BasicVector<T>(other.values()) {}
+  Sample(Sample&& other) noexcept
+      : drake::systems::BasicVector<T>(std::move(other.values())) {}
+  Sample& operator=(const Sample& other) {
+    this->values() = other.values();
+    return *this;
+  }
+  Sample& operator=(Sample&& other) noexcept {
+    this->values() = std::move(other.values());
+    other.values().resize(0);
+    return *this;
+  }
+  //@}
+
   /// Create a symbolic::Variable for each element with the known variable
   /// name.  This is only available for T == symbolic::Expression.
   template <typename U = T>
@@ -75,21 +103,79 @@ class Sample final : public drake::systems::BasicVector<T> {
   /// Some coordinate
   /// @note @c x is expressed in units of m/s.
   /// @note @c x has a limited domain of [0.0, +Inf].
-  const T& x() const { return this->GetAtIndex(K::kX); }
-  void set_x(const T& x) { this->SetAtIndex(K::kX, x); }
+  const T& x() const {
+    ThrowIfEmpty();
+    return this->GetAtIndex(K::kX);
+  }
+  /// Setter that matches x().
+  void set_x(const T& x) {
+    ThrowIfEmpty();
+    this->SetAtIndex(K::kX, x);
+  }
+  /// Fluent setter that matches x().
+  /// Returns a copy of `this` with x set to a new value.
+  DRAKE_VECTOR_GEN_NODISCARD
+  Sample<T> with_x(const T& x) const {
+    Sample<T> result(*this);
+    result.set_x(x);
+    return result;
+  }
   /// A very long documentation string that will certainly flow across multiple
   /// lines of C++
-  const T& two_word() const { return this->GetAtIndex(K::kTwoWord); }
+  const T& two_word() const {
+    ThrowIfEmpty();
+    return this->GetAtIndex(K::kTwoWord);
+  }
+  /// Setter that matches two_word().
   void set_two_word(const T& two_word) {
+    ThrowIfEmpty();
     this->SetAtIndex(K::kTwoWord, two_word);
+  }
+  /// Fluent setter that matches two_word().
+  /// Returns a copy of `this` with two_word set to a new value.
+  DRAKE_VECTOR_GEN_NODISCARD
+  Sample<T> with_two_word(const T& two_word) const {
+    Sample<T> result(*this);
+    result.set_two_word(two_word);
+    return result;
   }
   /// A signed, normalized value
   /// @note @c absone has a limited domain of [-1.0, 1.0].
-  const T& absone() const { return this->GetAtIndex(K::kAbsone); }
-  void set_absone(const T& absone) { this->SetAtIndex(K::kAbsone, absone); }
+  const T& absone() const {
+    ThrowIfEmpty();
+    return this->GetAtIndex(K::kAbsone);
+  }
+  /// Setter that matches absone().
+  void set_absone(const T& absone) {
+    ThrowIfEmpty();
+    this->SetAtIndex(K::kAbsone, absone);
+  }
+  /// Fluent setter that matches absone().
+  /// Returns a copy of `this` with absone set to a new value.
+  DRAKE_VECTOR_GEN_NODISCARD
+  Sample<T> with_absone(const T& absone) const {
+    Sample<T> result(*this);
+    result.set_absone(absone);
+    return result;
+  }
   /// A value that is unset by default
-  const T& unset() const { return this->GetAtIndex(K::kUnset); }
-  void set_unset(const T& unset) { this->SetAtIndex(K::kUnset, unset); }
+  const T& unset() const {
+    ThrowIfEmpty();
+    return this->GetAtIndex(K::kUnset);
+  }
+  /// Setter that matches unset().
+  void set_unset(const T& unset) {
+    ThrowIfEmpty();
+    this->SetAtIndex(K::kUnset, unset);
+  }
+  /// Fluent setter that matches unset().
+  /// Returns a copy of `this` with unset set to a new value.
+  DRAKE_VECTOR_GEN_NODISCARD
+  Sample<T> with_unset(const T& unset) const {
+    Sample<T> result(*this);
+    result.set_unset(unset);
+    return result;
+  }
   //@}
 
   /// See SampleIndices::GetCoordinateNames().
@@ -118,8 +204,19 @@ class Sample final : public drake::systems::BasicVector<T> {
     (*value)[1] = absone() - T(-1.0);
     (*value)[2] = T(1.0) - absone();
   }
+
+ private:
+  void ThrowIfEmpty() const {
+    if (this->values().size() == 0) {
+      throw std::out_of_range(
+          "The Sample vector has been moved-from; "
+          "accessor methods may no longer be used");
+    }
+  }
 };
 
 }  // namespace test
 }  // namespace tools
 }  // namespace drake
+
+#undef DRAKE_VECTOR_GEN_NODISCARD

--- a/tools/vector_gen/test/goal/sample_translator.cc
+++ b/tools/vector_gen/test/goal/sample_translator.cc
@@ -1,6 +1,6 @@
 #include "drake/tools/vector_gen/test/gen/sample_translator.h"
 
-// GENERATED FILE DO NOT EDIT
+// GENERATED GOAL DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
 #include <stdexcept>

--- a/tools/vector_gen/test/goal/sample_translator.h
+++ b/tools/vector_gen/test/goal/sample_translator.h
@@ -1,6 +1,6 @@
 #pragma once
 
-// GENERATED FILE DO NOT EDIT
+// GENERATED GOAL DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
 #include <memory>

--- a/tools/vector_gen/test/lcm_vector_gen_test.sh
+++ b/tools/vector_gen/test/lcm_vector_gen_test.sh
@@ -9,13 +9,22 @@ set -ex
 find .
 
 # These are the filenames under test.
-tool_outputs="lcmt_sample_t.lcm sample.cc sample.h sample_translator.cc 
+tool_outputs="lcmt_sample_t.lcm sample.cc sample.h sample_translator.cc
   sample_translator.h"
 
 # Insist that the generated output matches the goal copy in git.
 mv tools/vector_gen/test/lcmt_sample_t.lcm tools/vector_gen/test/gen/
 for item in $tool_outputs; do
-  diff --unified=20 tools/vector_gen/test/{goal,gen}/"${item}"
+  # Tweak the magic "generated file" marker, so that changes to the goal files
+  # will show up during code review.
+  sed -e 's#GENERATED FILE#GENERATED GOAL#' \
+    tools/vector_gen/test/gen/"${item}" > \
+    "${TEST_TMPDIR}"/"${item}".generated
+
+  # Compare the tweaked generated file with the goal file from the source tree.
+  diff --unified=20 \
+    tools/vector_gen/test/goal/"${item}" \
+    "${TEST_TMPDIR}"/"${item}".generated
 done
 
 echo "PASS"


### PR DESCRIPTION
The enables by-name construction like `AcrobotInput<double>{}.with_tau(1.0)`.

Relatedly, in `systems/lcm` lighten the transitive dependencies of our generated basic vector translators.

---

This should help fluency in general, but was motivated directly by #9620 where calls to `FixInputPort` will be required to name the input type.

Credit to @sherm1 in #9437 for inspiring the prvalue trick used here to avoid copies during chaining.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9637)
<!-- Reviewable:end -->
