### PR TITLE
framework: Improve error for missing abstract input model_value

### DIFF
--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -428,10 +428,13 @@ class LeafSystem : public System<T> {
     if (model_result) {
       return model_result.release();
     }
-    DRAKE_ABORT_MSG(
-        "A concrete leaf system with abstract input ports should "
-        "pass a model_value to DeclareAbstractInputPort, or else "
-        "must override DoAllocateInputAbstract");
+    throw std::logic_error(fmt::format(
+        "System::AllocateInputAbstract(): a System with abstract input ports "
+        "should pass a model_value to DeclareAbstractInputPort, or else must "
+        "override DoAllocateInputAbstract; the input port[{}] named '{}' did "
+        "not do either one (System {})",
+        input_port.get_index(), input_port.get_name(),
+        this->GetSystemPathname()));
   }
 
   /// Emits a graphviz fragment for this System. Leaf systems are visualized as

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -847,6 +847,26 @@ GTEST_TEST(ModelLeafSystemTest, ModelPortsTopology) {
   EXPECT_EQ(in4.get_random_type(), RandomDistribution::kGaussian);
 }
 
+// A system that incorrectly declares an input port.
+class MissingModelAbstractInputSystem : public LeafSystem<double> {
+ public:
+  MissingModelAbstractInputSystem() {
+    this->DeclareAbstractInputPort("no_model_input");
+  }
+};
+
+GTEST_TEST(ModelLeafSystemTest, MissingModelAbstractInput) {
+  MissingModelAbstractInputSystem dut;
+  dut.set_name("dut");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dut.AllocateInputAbstract(dut.get_input_port(0)),
+      std::exception,
+      "System::AllocateInputAbstract\\(\\): a System with abstract input "
+      "ports should pass a model_value to DeclareAbstractInputPort, or else "
+      "must override DoAllocateInputAbstract; the input port\\[0\\] named "
+      "'no_model_input' did not do either one \\(System ::dut\\)");
+}
+
 // Check that names can be assigned to the ports through all of the various
 // APIs.
 GTEST_TEST(ModelLeafSystemTest, ModelPortNames) {


### PR DESCRIPTION
The model_value was documented to be (almost always) required, but in practice many systems were omitting it.  In preparation for enforcing that it's required in #9620, we need to make the diagnostic message when its missing much more useful, so that users have some hope of isolating the new errors that will appear.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9638)
<!-- Reviewable:end -->
