### PR TITLE
Method to compute bias for frame geometric Jacobians

### DIFF
--- a/multibody/multibody_tree/multibody_tree.cc
+++ b/multibody/multibody_tree/multibody_tree.cc
@@ -1126,7 +1126,7 @@ Vector6<T> MultibodyTree<T>::CalcBiasForFrameGeometricJacobianExpressedInWorld(
   const PositionKinematicsCache<T>& pc = EvalPositionKinematics(context);
   const VelocityKinematicsCache<T>& vc = EvalVelocityKinematics(context);
 
-  // For a frame F instantaneously moves with its body frame B. The spatial
+  // For a frame F moving instantaneously with its body frame B, the spatial
   // acceleration of the frame F shifted to frame Fq with origin at point Qo
   // fixed in frame F, can be computed as:
   //   A_WFq = Jv_WFq⋅v̇ + Ab_WFq,

--- a/multibody/multibody_tree/multibody_tree.h
+++ b/multibody/multibody_tree/multibody_tree.h
@@ -1823,53 +1823,84 @@ class MultibodyTree {
       const Frame<T>& frame_F,
       const Eigen::Ref<const MatrixX<T>>& p_FQ_list) const;
 
-  /// Given a frame Q with fixed origin position `p_FQo` in a frame F, this
-  /// method computes the geometric Jacobian `Jv_WQ` defined by:
+  /// Given a frame `Fq` defined by shifting a frame F from its origin `Fo` to
+  /// a new origin `Qo`, this method computes the geometric Jacobian `Jv_WFq`
+  /// for frame `Fq`. The new origin `Qo` is specified by the position vector
+  /// `p_FQo` in frame F. The frame geometric Jacobian `Jv_WFq` is defined by:
   /// <pre>
-  ///   V_WQ(q, v) = Jv_WQ(q)⋅v
+  ///   V_WFq(q, v) = Jv_WFq(q)⋅v
   /// </pre>
-  /// where `V_WQ(q, v)` is the spatial velocity of frame Q measured and
+  /// where `V_WFq(q, v)` is the spatial velocity of frame `Fq` measured and
   /// expressed in the world frame W and q and v are the vectors of generalized
-  /// position and velocity, respectively. Since the spatial velocity of frame
-  /// Q is linear in the generalized velocities, the geometric Jacobian `Jv_WQ`
-  /// is a function of the generalized coordinates q only.
+  /// position and velocity, respectively.
+  /// The geometric Jacobian `Jv_WFq(q)` is a function of the generalized
+  /// coordinates q only.
   ///
   /// @param[in] context
   ///   The context containing the state of the model. It stores the
   ///   generalized positions q.
   /// @param[in] frame_F
-  ///   The position `p_FQo` of frame Q is measured and expressed in this
+  ///   The position `p_FQo` of frame `Fq` is measured and expressed in this
   ///   frame F.
   /// @param[in] p_FQo
-  ///   The (fixed) position of the origin `Qo` of frame F as measured and
+  ///   The (fixed) position of the origin `Qo` of frame `Fq` as measured and
   ///   expressed in frame F.
-  /// @param[out] Jv_WQ
-  ///   The geometric Jacobian `Jv_WQ(q)`, function of the generalized positions
-  ///   q only. This Jacobian relates to the spatial velocity `V_WQ` of frame Q
-  ///   by: <pre>
-  ///     V_WQ(q, v) = Jv_WQ(q)⋅v
+  /// @param[out] Jv_WFq
+  ///   The geometric Jacobian `Jv_WFq(q)`, function of the generalized
+  ///   positions q only. This Jacobian relates to the spatial velocity `V_WFq`
+  ///   of frame `Fq` by: <pre>
+  ///     V_WFq(q, v) = Jv_WFq(q)⋅v
   ///   </pre>
-  ///   Therefore `Jv_WQ` is a matrix of size `6 x nv`, with `nv`
-  ///   the number of generalized velocities. On input, matrix `Jv_WQ` **must**
+  ///   Therefore `Jv_WFq` is a matrix of size `6 x nv`, with `nv`
+  ///   the number of generalized velocities. On input, matrix `Jv_WFq` **must**
   ///   have size `6 x nv` or this method throws an exception. The top rows of
-  ///   this matrix (which can be accessed with Jv_WQ.topRows<3>()) is the
-  ///   Jacobian `Hw_WQ` related to the angular velocity of Q in W by
-  ///   `w_WQ = Hw_WQ⋅v`. The bottom rows of this matrix (which can be accessed
-  ///   with Jv_WQ.bottomRows<3>()) is the Jacobian `Hv_WQ` related to the
-  ///   translational velocity of the origin `Qo` of frame Q in W by
-  ///   `v_WQo = Hv_WQ⋅v`. This ordering is consistent with the internal storage
-  ///   of the SpatialVelocity class. Therefore the following operations results
-  ///   in a valid spatial velocity: <pre>
-  ///     SpatialVelocity<double> Jv_WQ_times_v(Jv_WQ * v);
+  ///   this matrix (which can be accessed with Jv_WFq.topRows<3>()) is the
+  ///   Jacobian `Hw_WFq` related to the angular velocity of `Fq` in W by
+  ///   `w_WFq = Hw_WFq⋅v`. The bottom rows of this matrix (which can be
+  ///   accessed with Jv_WFq.bottomRows<3>()) is the Jacobian `Hv_WFq` related
+  ///   to the translational velocity of the origin `Qo` of frame `Fq` in W by
+  ///   `v_WFqo = Hv_WFq⋅v`. This ordering is consistent with the internal
+  ///   storage of the SpatialVelocity class. Therefore the following operations
+  ///   results in a valid spatial velocity: <pre>
+  ///     SpatialVelocity<double> Jv_WFq_times_v(Jv_WFq * v);
   ///   </pre>
   ///
-  /// @throws std::exception if `J_WQ` is nullptr or if it is not of size
+  /// @throws std::exception if `J_WFq` is nullptr or if it is not of size
   ///   `6 x nv`.
   void CalcFrameGeometricJacobianExpressedInWorld(
       const systems::Context<T>& context,
       const Frame<T>& frame_F, const Eigen::Ref<const Vector3<T>>& p_FQo,
-      EigenPtr<MatrixX<T>> Jv_WQ) const;
+      EigenPtr<MatrixX<T>> Jv_WFq) const;
 
+  /// Computes the bias term `Ab_WFq` associated with the spatial acceleration
+  /// `A_WFq` of a frame `Fq` instantaneously moving with a frame F at a fixed
+  /// positon `p_FQo`.
+  /// That is, the spatial acceleration of frame `Fq` can be computed as:
+  /// <pre>
+  ///   A_WFq = Jv_WFq(q)⋅v̇ + Ab_WFq(q, v)
+  /// </pre>
+  /// where `Ab_WFq(q, v) = J̇v_WFq(q, v)⋅v`.
+  ///
+  /// @see CalcFrameGeometricJacobianExpressedInWorld() to compute the
+  /// geometric Jacobian `Jv_WFq(q)`.
+  ///
+  /// @param[in] context
+  ///   The context containing the state of the model. It stores the
+  ///   generalized positions q and generalized velocities v.
+  /// @param[in] frame_F
+  ///   The position `p_FQo` of frame `Fq` is measured and expressed in this
+  ///   frame F.
+  /// @param[in] p_FQo
+  ///   The (fixed) position of the origin `Qo` of frame `Fq` as measured and
+  ///   expressed in frame F.
+  /// @returns Ab_WFq
+  ///   The bias term, function of the generalized positions q and the
+  ///   generalized velocities v as stored in `context`.
+  ///   The returned vector is of size 6, with the first three elements related
+  ///   to the bias in angular acceleration and the with the last three elements
+  ///   related to the bias in translational acceleration.
+  /// @note Given the ordering of the returned vector Ab_WFq,
+  /// SpatialAcceleration(Ab_WFq) forms a valid SpatialAcceleration.
   Vector6<T> CalcBiasForFrameGeometricJacobianExpressedInWorld(
       const systems::Context<T>& context,
       const Frame<T>& frame_F, const Eigen::Ref<const Vector3<T>>& p_FQo) const;

--- a/multibody/multibody_tree/multibody_tree.h
+++ b/multibody/multibody_tree/multibody_tree.h
@@ -1823,51 +1823,56 @@ class MultibodyTree {
       const Frame<T>& frame_F,
       const Eigen::Ref<const MatrixX<T>>& p_FQ_list) const;
 
-  /// Given a frame F with fixed position `p_BoFo_B` in a frame B, this method
-  /// computes the geometric Jacobian `Jv_WF` defined by:
+  /// Given a frame Q with fixed origin position `p_FQo` in a frame F, this
+  /// method computes the geometric Jacobian `Jv_WQ` defined by:
   /// <pre>
-  ///   V_WF(q, v) = Jv_WF(q)⋅v
+  ///   V_WQ(q, v) = Jv_WQ(q)⋅v
   /// </pre>
-  /// where `V_WF(q, v)` is the spatial velocity of frame F measured and
+  /// where `V_WQ(q, v)` is the spatial velocity of frame Q measured and
   /// expressed in the world frame W and q and v are the vectors of generalized
   /// position and velocity, respectively. Since the spatial velocity of frame
-  /// F is linear in the generalized velocities, the geometric Jacobian `Jv_WF`
+  /// Q is linear in the generalized velocities, the geometric Jacobian `Jv_WQ`
   /// is a function of the generalized coordinates q only.
   ///
   /// @param[in] context
   ///   The context containing the state of the model. It stores the
   ///   generalized positions q.
-  /// @param[in] frame_B
-  ///   The position `p_BoFo_B` of frame F is measured and expressed in this
-  ///   frame B.
-  /// @param[in] p_BoFo_B
-  ///   The (fixed) position of frame F as measured and expressed in frame B.
-  /// @param[out] Jv_WF
-  ///   The geometric Jacobian `Jv_WF(q)`, function of the generalized positions
-  ///   q only. This Jacobian relates to the spatial velocity `V_WF` of frame F
+  /// @param[in] frame_F
+  ///   The position `p_FQo` of frame Q is measured and expressed in this
+  ///   frame F.
+  /// @param[in] p_FQo
+  ///   The (fixed) position of the origin `Qo` of frame F as measured and
+  ///   expressed in frame F.
+  /// @param[out] Jv_WQ
+  ///   The geometric Jacobian `Jv_WQ(q)`, function of the generalized positions
+  ///   q only. This Jacobian relates to the spatial velocity `V_WQ` of frame Q
   ///   by: <pre>
-  ///     V_WF(q, v) = Jv_WF(q)⋅v
+  ///     V_WQ(q, v) = Jv_WQ(q)⋅v
   ///   </pre>
-  ///   Therefore `Jv_WF` is a matrix of size `6 x nv`, with `nv`
-  ///   the number of generalized velocities. On input, matrix `Jv_WF` **must**
+  ///   Therefore `Jv_WQ` is a matrix of size `6 x nv`, with `nv`
+  ///   the number of generalized velocities. On input, matrix `Jv_WQ` **must**
   ///   have size `6 x nv` or this method throws an exception. The top rows of
-  ///   this matrix (which can be accessed with Jv_WF.topRows<3>()) is the
-  ///   Jacobian `Hw_WF` related to the angular velocity of F in W by
-  ///   `w_WF = Hw_WF⋅v`. The bottom rows of this matrix (which can be accessed
-  ///   with Jv_WF.bottomRows<3>()) is the Jacobian `Hv_WF` related to the
-  ///   translational velocity of the origin of frame F in W by
-  ///   `v_WFo = Hw_WF⋅v`. This ordering is consistent with the internal storage
-  ///   of the SpatialVector class. Therefore the following operations results
+  ///   this matrix (which can be accessed with Jv_WQ.topRows<3>()) is the
+  ///   Jacobian `Hw_WQ` related to the angular velocity of Q in W by
+  ///   `w_WQ = Hw_WQ⋅v`. The bottom rows of this matrix (which can be accessed
+  ///   with Jv_WQ.bottomRows<3>()) is the Jacobian `Hv_WQ` related to the
+  ///   translational velocity of the origin `Qo` of frame Q in W by
+  ///   `v_WQo = Hv_WQ⋅v`. This ordering is consistent with the internal storage
+  ///   of the SpatialVelocity class. Therefore the following operations results
   ///   in a valid spatial velocity: <pre>
-  ///     SpatialVelocity<double> Jv_WF_times_v(Jv_WF * v);
+  ///     SpatialVelocity<double> Jv_WQ_times_v(Jv_WQ * v);
   ///   </pre>
   ///
-  /// @throws std::exception if `J_WF` is nullptr or if it is not of size
+  /// @throws std::exception if `J_WQ` is nullptr or if it is not of size
   ///   `6 x nv`.
   void CalcFrameGeometricJacobianExpressedInWorld(
       const systems::Context<T>& context,
-      const Frame<T>& frame_B, const Eigen::Ref<const Vector3<T>>& p_BoFo_B,
-      EigenPtr<MatrixX<T>> Jv_WF) const;
+      const Frame<T>& frame_F, const Eigen::Ref<const Vector3<T>>& p_FQo,
+      EigenPtr<MatrixX<T>> Jv_WQ) const;
+
+  Vector6<T> CalcBiasForFrameGeometricJacobianExpressedInWorld(
+      const systems::Context<T>& context,
+      const Frame<T>& frame_F, const Eigen::Ref<const Vector3<T>>& p_FQo) const;
 
   /// @}
   // End of multibody Jacobian methods section.

--- a/multibody/multibody_tree/multibody_tree.h
+++ b/multibody/multibody_tree/multibody_tree.h
@@ -1824,9 +1824,9 @@ class MultibodyTree {
       const Eigen::Ref<const MatrixX<T>>& p_FQ_list) const;
 
   /// Given a frame `Fq` defined by shifting a frame F from its origin `Fo` to
-  /// a new origin `Qo`, this method computes the geometric Jacobian `Jv_WFq`
-  /// for frame `Fq`. The new origin `Qo` is specified by the position vector
-  /// `p_FQo` in frame F. The frame geometric Jacobian `Jv_WFq` is defined by:
+  /// a new origin `Q`, this method computes the geometric Jacobian `Jv_WFq`
+  /// for frame `Fq`. The new origin `Q` is specified by the position vector
+  /// `p_FQ` in frame F. The frame geometric Jacobian `Jv_WFq` is defined by:
   /// <pre>
   ///   V_WFq(q, v) = Jv_WFq(q)⋅v
   /// </pre>
@@ -1840,10 +1840,10 @@ class MultibodyTree {
   ///   The context containing the state of the model. It stores the
   ///   generalized positions q.
   /// @param[in] frame_F
-  ///   The position `p_FQo` of frame `Fq` is measured and expressed in this
+  ///   The position `p_FQ` of frame `Fq` is measured and expressed in this
   ///   frame F.
-  /// @param[in] p_FQo
-  ///   The (fixed) position of the origin `Qo` of frame `Fq` as measured and
+  /// @param[in] p_FQ
+  ///   The (fixed) position of the origin `Q` of frame `Fq` as measured and
   ///   expressed in frame F.
   /// @param[out] Jv_WFq
   ///   The geometric Jacobian `Jv_WFq(q)`, function of the generalized
@@ -1858,7 +1858,7 @@ class MultibodyTree {
   ///   Jacobian `Hw_WFq` related to the angular velocity of `Fq` in W by
   ///   `w_WFq = Hw_WFq⋅v`. The bottom rows of this matrix (which can be
   ///   accessed with Jv_WFq.bottomRows<3>()) is the Jacobian `Hv_WFq` related
-  ///   to the translational velocity of the origin `Qo` of frame `Fq` in W by
+  ///   to the translational velocity of the origin `Q` of frame `Fq` in W by
   ///   `v_WFqo = Hv_WFq⋅v`. This ordering is consistent with the internal
   ///   storage of the SpatialVelocity class. Therefore the following operations
   ///   results in a valid spatial velocity: <pre>
@@ -1869,13 +1869,13 @@ class MultibodyTree {
   ///   `6 x nv`.
   void CalcFrameGeometricJacobianExpressedInWorld(
       const systems::Context<T>& context,
-      const Frame<T>& frame_F, const Eigen::Ref<const Vector3<T>>& p_FQo,
+      const Frame<T>& frame_F, const Eigen::Ref<const Vector3<T>>& p_FQ,
       EigenPtr<MatrixX<T>> Jv_WFq) const;
 
   /// Given a frame `Fq` defined by shifting a frame F from its origin `Fo` to
-  /// a new origin `Qo`, this method computes the bias term `Ab_WFq` associated
+  /// a new origin `Q`, this method computes the bias term `Ab_WFq` associated
   /// with the spatial acceleration `A_WFq` a frame `Fq` instantaneously
-  /// moving with a frame F at a fixed position `p_FQo`.
+  /// moving with a frame F at a fixed position `p_FQ`.
   /// That is, the spatial acceleration of frame `Fq` can be computed as:
   /// <pre>
   ///   A_WFq = Jv_WFq(q)⋅v̇ + Ab_WFq(q, v)
@@ -1889,10 +1889,10 @@ class MultibodyTree {
   ///   The context containing the state of the model. It stores the
   ///   generalized positions q and generalized velocities v.
   /// @param[in] frame_F
-  ///   The position `p_FQo` of frame `Fq` is measured and expressed in this
+  ///   The position `p_FQ` of frame `Fq` is measured and expressed in this
   ///   frame F.
-  /// @param[in] p_FQo
-  ///   The (fixed) position of the origin `Qo` of frame `Fq` as measured and
+  /// @param[in] p_FQ
+  ///   The (fixed) position of the origin `Q` of frame `Fq` as measured and
   ///   expressed in frame F.
   /// @returns Ab_WFq
   ///   The bias term, function of the generalized positions q and the
@@ -1903,7 +1903,7 @@ class MultibodyTree {
   /// @note SpatialAcceleration(Ab_WFq) defines a valid SpatialAcceleration.
   Vector6<T> CalcBiasForFrameGeometricJacobianExpressedInWorld(
       const systems::Context<T>& context,
-      const Frame<T>& frame_F, const Eigen::Ref<const Vector3<T>>& p_FQo) const;
+      const Frame<T>& frame_F, const Eigen::Ref<const Vector3<T>>& p_FQ) const;
 
   /// @}
   // End of multibody Jacobian methods section.

--- a/multibody/multibody_tree/multibody_tree.h
+++ b/multibody/multibody_tree/multibody_tree.h
@@ -1872,9 +1872,10 @@ class MultibodyTree {
       const Frame<T>& frame_F, const Eigen::Ref<const Vector3<T>>& p_FQo,
       EigenPtr<MatrixX<T>> Jv_WFq) const;
 
-  /// Computes the bias term `Ab_WFq` associated with the spatial acceleration
-  /// `A_WFq` of a frame `Fq` instantaneously moving with a frame F at a fixed
-  /// positon `p_FQo`.
+  /// Given a frame `Fq` defined by shifting a frame F from its origin `Fo` to
+  /// a new origin `Qo`, this method computes the bias term `Ab_WFq` associated
+  /// with the spatial acceleration `A_WFq` a frame `Fq` instantaneously
+  /// moving with a frame F at a fixed position `p_FQo`.
   /// That is, the spatial acceleration of frame `Fq` can be computed as:
   /// <pre>
   ///   A_WFq = Jv_WFq(q)⋅v̇ + Ab_WFq(q, v)
@@ -1899,8 +1900,7 @@ class MultibodyTree {
   ///   The returned vector is of size 6, with the first three elements related
   ///   to the bias in angular acceleration and the with the last three elements
   ///   related to the bias in translational acceleration.
-  /// @note Given the ordering of the returned vector Ab_WFq,
-  /// SpatialAcceleration(Ab_WFq) forms a valid SpatialAcceleration.
+  /// @note SpatialAcceleration(Ab_WFq) defines a valid SpatialAcceleration.
   Vector6<T> CalcBiasForFrameGeometricJacobianExpressedInWorld(
       const systems::Context<T>& context,
       const Frame<T>& frame_F, const Eigen::Ref<const Vector3<T>>& p_FQo) const;

--- a/multibody/multibody_tree/test/multibody_tree_test.cc
+++ b/multibody/multibody_tree/test/multibody_tree_test.cc
@@ -429,7 +429,7 @@ class KukaIiwaModelTests : public ::testing::Test {
         context_on_T, frameH_on_T, p_HPi, p_WPi, Jv_WHp);
   }
 
-  // Computes the frame geometric Jacobian Jv_WHp for frame Hp which is the 
+  // Computes the frame geometric Jacobian Jv_WHp for frame Hp which is the
   // frame H (attached to the end effector, see test fixture docs) shifted to
   // have its origin at Po. Po's position p_HPo is specified in frame H.
   // See MultibodyTree::CalcFrameGeometricJacobianExpressedInWorld() for
@@ -871,7 +871,7 @@ TEST_F(KukaIiwaModelTests, CalcFrameGeometricJacobianExpressedInWorld) {
   EXPECT_TRUE(Jv_WF_times_v.IsApprox(V_WEf, kTolerance));
 }
 
-// Unit tests MBT::CalcBiasForPointsGeometricJacobianExpressedInWorld() using
+// Unit tests MBT::CalcBiasForFrameGeometricJacobianExpressedInWorld() using
 // AutoDiffXd to compute time derivatives of the geometric Jacobian to obtain a
 // reference solution.
 TEST_F(KukaIiwaModelTests, CalcBiasForFrameGeometricJacobianExpressedInWorld) {
@@ -922,7 +922,7 @@ TEST_F(KukaIiwaModelTests, CalcBiasForFrameGeometricJacobianExpressedInWorld) {
   // Po specifies the position of a new frame Hp which is the result of shifting
   // frame H from Ho to Po.
   Vector3<double> p_HPo(0.1, -0.05, 0.02);
-  
+
   // Frame geometric Jacobian for frame H shifted to frame Hp.
   MatrixX<double> Jv_WHp(6, kNumVelocities);
 

--- a/multibody/multibody_tree/test/multibody_tree_test.cc
+++ b/multibody/multibody_tree/test/multibody_tree_test.cc
@@ -429,6 +429,21 @@ class KukaIiwaModelTests : public ::testing::Test {
         context_on_T, frameH_on_T, p_HPi, p_WPi, Jv_WHp);
   }
 
+  // Computes the frame geometric Jacobian Jv_WHp for frame Hp which is the 
+  // frame H (attached to the end effector, see test fixture docs) shifted to
+  // have its origin at Po. Po's position p_HPo is specified in frame H.
+  // See MultibodyTree::CalcFrameGeometricJacobianExpressedInWorld() for
+  // details.
+  template <typename T>
+  void CalcFrameHpGeometricJacobian(
+      const MultibodyTree<T>& model_on_T,
+      const Context<T>& context_on_T,
+      const Vector3<T>& p_HPo, MatrixX<T>* Jv_WHp) const {
+    const Frame<T>& frameH_on_T = model_on_T.get_variant(*frame_H_);
+    model_on_T.CalcFrameGeometricJacobianExpressedInWorld(
+        context_on_T, frameH_on_T, p_HPo, Jv_WHp);
+  }
+
   const MultibodyTree<double>& tree() const { return system_->tree(); }
 
   const MultibodyTree<AutoDiffXd>& tree_autodiff() const {
@@ -854,6 +869,88 @@ TEST_F(KukaIiwaModelTests, CalcFrameGeometricJacobianExpressedInWorld) {
   const SpatialVelocity<double> Jv_WF_times_v(Jv_WF * v);
 
   EXPECT_TRUE(Jv_WF_times_v.IsApprox(V_WEf, kTolerance));
+}
+
+// Unit tests MBT::CalcBiasForPointsGeometricJacobianExpressedInWorld() using
+// AutoDiffXd to compute time derivatives of the geometric Jacobian to obtain a
+// reference solution.
+TEST_F(KukaIiwaModelTests, CalcBiasForFrameGeometricJacobianExpressedInWorld) {
+  // The number of generalized velocities in the Kuka iiwa robot arm model.
+  const int kNumVelocities = tree().num_velocities();
+
+  // Numerical tolerance used to verify numerical results.
+  const double kTolerance = 10 * std::numeric_limits<double>::epsilon();
+
+  // A set of values for the joint's angles chosen mainly to avoid in-plane
+  // motions.
+  VectorX<double> q, v;
+  GetArbitraryNonZeroConfiguration(&q, &v);
+
+  // Since the bias term is a function of q and v only (i.e. it is not a
+  // function of vdot), we choose a set of arbitrary values for the generalized
+  // accelerations. We do purposely set this values to be non-zero to stress
+  // the fact that the bias term is not a function of vdot.
+  VectorX<double> vdot(kNumVelocities);
+  vdot << 1, 2, 3, 4, 5, 6, 7;
+
+  // Set generalized positions and velocities.
+  int angle_index = 0;
+  for (const RevoluteJoint<double>* joint : joints_) {
+    joint->set_angle(context_.get(), q[angle_index]);
+    joint->set_angular_rate(context_.get(), v[angle_index]);
+    angle_index++;
+  }
+
+  context_autodiff_->SetTimeStateAndParametersFrom(*context_);
+
+  // Initialize q_autodiff and v_autodiff so that we differentiate with respect
+  // to time.
+  // Note: here we pass MatrixXd(v) so that the return gradient uses AutoDiffXd
+  // (for which we do have explicit instantiations) instead of
+  // AutoDiffScalar<Matrix1d>.
+  auto q_autodiff = math::initializeAutoDiffGivenGradientMatrix(q, MatrixXd(v));
+  auto v_autodiff =
+      math::initializeAutoDiffGivenGradientMatrix(v, MatrixXd(vdot));
+
+  VectorX<AutoDiffXd> x_autodiff(2 * kNumVelocities);
+  x_autodiff << q_autodiff, v_autodiff;
+
+  // Set the context for AutoDiffXd computations.
+  tree_autodiff().get_mutable_multibody_state_vector(context_autodiff_.get())
+      = x_autodiff;
+
+  // Po specifies the position of a new frame Hp which is the result of shifting
+  // frame H from Ho to Po.
+  Vector3<double> p_HPo(0.1, -0.05, 0.02);
+  
+  // Frame geometric Jacobian for frame H shifted to frame Hp.
+  MatrixX<double> Jv_WHp(6, kNumVelocities);
+
+  const Vector3<AutoDiffXd> p_HPo_autodiff = p_HPo;
+  MatrixX<AutoDiffXd> Jv_WHp_autodiff(6, kNumVelocities);
+
+  // Compute J̇_WHp using AutoDiffXd.
+  CalcFrameHpGeometricJacobian(
+      tree_autodiff(), *context_autodiff_, p_HPo_autodiff, &Jv_WHp_autodiff);
+
+  // Extract time derivatives:
+  MatrixX<double> Jv_WHp_derivs =
+      math::autoDiffToGradientMatrix(Jv_WHp_autodiff);
+  Jv_WHp_derivs.resize(6, kNumVelocities);
+
+  // Compute the expected value of the bias terms using the time derivatives
+  // computed with AutoDiffXd.
+  const VectorX<double> Ab_WHp_expected = Jv_WHp_derivs * v;
+
+  // Compute frame Hp geometric Jacobian bias.
+  const VectorX<double> Ab_WHp =
+      tree().CalcBiasForFrameGeometricJacobianExpressedInWorld(
+          *context_, *frame_H_, p_HPo);
+
+  // Ab_WHp is of size 6 x num_velocities. CompareMatrices() below
+  // verifies this, in addition to the numerical values of each element.
+  EXPECT_TRUE(CompareMatrices(Ab_WHp, Ab_WHp_expected,
+                              kTolerance, MatrixCompareType::relative));
 }
 
 // Verify that even when the input set of points and/or the Jacobian might

--- a/multibody/multibody_tree/test/multibody_tree_test.cc
+++ b/multibody/multibody_tree/test/multibody_tree_test.cc
@@ -890,8 +890,9 @@ TEST_F(KukaIiwaModelTests, CalcBiasForFrameGeometricJacobianExpressedInWorld) {
   // function of vdot), we choose a set of arbitrary values for the generalized
   // accelerations. We do purposely set this values to be non-zero to stress
   // the fact that the bias term is not a function of vdot.
-  VectorX<double> vdot(kNumVelocities);
-  vdot << 1, 2, 3, 4, 5, 6, 7;
+  const VectorX<double> vdot =
+      VectorX<double>::Constant(
+          kNumVelocities, std::numeric_limits<double>::quiet_NaN());
 
   // Set generalized positions and velocities.
   int angle_index = 0;


### PR DESCRIPTION
As requested in #9560.

Notice this PR also refactor the monogram notation used in `CalcFrameGeometricJacobianExpressedInWorld()` for consistency with all other Jacobian methods, however its functionality remains the same.

cc'in @RussTedrake, @pangtao22.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9642)
<!-- Reviewable:end -->
