### PR TITLE
python: Generalize repositories to support multiple versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,7 @@ if(APPLE)
   find_program(PYTHON_EXECUTABLE NAMES python2)
 endif()
 
+# TODO(eric.cousineau) Ensure that we can switch between supported versions.
 find_package(PythonInterp 2.7 EXACT MODULE REQUIRED)
 
 if(CMAKE_BUILD_TYPE STREQUAL Debug)

--- a/bindings/pydrake/test/all_install_test.py
+++ b/bindings/pydrake/test/all_install_test.py
@@ -17,9 +17,8 @@ class TestAllInstall(unittest.TestCase):
         # Override PYTHONPATH to only use the installed `pydrake` module.
         env_python_path = "PYTHONPATH"
         tool_env = dict(os.environ)
-        tool_env[env_python_path] = os.path.abspath(
-            os.path.join(install_dir, "lib", "python2.7", "site-packages")
-        )
+        tool_env[env_python_path] = \
+            install_test_helper.get_python_site_packages_dir(install_dir)
         # Ensure we can import all user-visible modules.
         script = "import pydrake.all"
         install_test_helper.check_call(

--- a/bindings/pydrake/test/common_install_test.py
+++ b/bindings/pydrake/test/common_install_test.py
@@ -8,14 +8,12 @@ import unittest
 class TestCommonInstall(unittest.TestCase):
     def testDrakeFindResourceOrThrowInInstall(self):
         # Override PYTHONPATH to only use the installed `pydrake` module.
+        install_dir = install_test_helper.get_install_dir()
         env_python_path = "PYTHONPATH"
         tool_env = dict(os.environ)
-        tool_env[env_python_path] = os.path.abspath(
-            os.path.join(install_test_helper.get_install_dir(),
-                         "lib", "python2.7", "site-packages")
-        )
-        data_folder = os.path.join(install_test_helper.get_install_dir(),
-                                   "share", "drake")
+        tool_env[env_python_path] = \
+            install_test_helper.get_python_site_packages_dir(install_dir)
+        data_folder = os.path.join(install_dir, "share", "drake")
         # Calling `pydrake.getDrakePath()` twice verifies that there
         # is no memory allocation issue in the C code.
         output_path = install_test_helper.check_output(

--- a/tools/install/install.bzl
+++ b/tools/install/install.bzl
@@ -8,6 +8,7 @@ load(
     "join_paths",
     "output_path",
 )
+load("@python//:version.bzl", "PYTHON_SITE_PACKAGES_RELPATH")
 
 InstallInfo = provider()
 
@@ -119,8 +120,13 @@ def _install_action(
     else:
         dest = dests
 
-    if "@WORKSPACE@" in dest:
-        dest = dest.replace("@WORKSPACE@", _workspace(ctx))
+    dest_replacements = (
+        ("@WORKSPACE@", _workspace(ctx)),
+        ("@PYTHON_SITE_PACKAGES@", PYTHON_SITE_PACKAGES_RELPATH),
+    )
+    for old, new in dest_replacements:
+        if old in dest:
+            dest = dest.replace(old, new)
 
     if type(strip_prefixes) == "dict":
         strip_prefix = strip_prefixes.get(
@@ -545,7 +551,7 @@ _install_rule = rule(
         "runtime_strip_prefix": attr.string_list(),
         "java_dest": attr.string(default = "share/java"),
         "java_strip_prefix": attr.string_list(),
-        "py_dest": attr.string(default = "lib/python2.7/site-packages"),
+        "py_dest": attr.string(default = "@PYTHON_SITE_PACKAGES@"),
         "py_strip_prefix": attr.string_list(),
         "rename": attr.string_dict(),
         "install_tests": attr.label_list(
@@ -587,9 +593,12 @@ bazel, but does not define an install) where this *is* the right thing to do,
 the ``allowed_externals`` argument may be used to specify a list of externals
 whose files it is okay to install, which will suppress the warning.
 
-Destination paths may include the placeholder ``@WORKSPACE@``, which is
-replaced with ``workspace`` (if specified) or the name of the workspace which
-invokes ``install``.
+Destination paths may include the following placeholders:
+
+* ``@WORKSPACE@``, replaced with ``workspace`` (if specified) or the name of
+  the workspace which invokes ``install``.
+* ``@PYTHON_SITE_PACKAGES``, replaced with the Python version-specific path of
+  "site-packages".
 
 Note:
     By default, headers and resource files to be installed must be explicitly
@@ -665,7 +674,7 @@ Args:
     java_dest: Destination for Java library targets (default = "share/java").
     java_strip_prefix: List of prefixes to remove from Java library paths.
     py_dest: Destination for Python targets
-        (default = "lib/python2.7/site-packages").
+        (default = "lib/python{MAJOR}.{MINOR}/site-packages").
     py_strip_prefix: List of prefixes to remove from Python paths.
     rename: Mapping of install paths to alternate file names, used to rename
       files upon installation.

--- a/tools/install/install_test_helper.py
+++ b/tools/install/install_test_helper.py
@@ -71,12 +71,12 @@ def create_temporary_dir(name='tmp'):
 def get_python_executable():
     """Use appropriate Python executable
 
-    Call python2 on MacOS to force using python brew install. Calling python
+    Call python2/3 on MacOS to force using python brew install. Calling python
     system would result in a crash since pydrake was built against brew python.
     On other systems, it will just fall-back to the current Python executable.
     """
     if sys.platform == "darwin":
-        return "python2"
+        return "python{}".format(sys.version_info.major)
     else:
         return sys.executable
 
@@ -129,3 +129,13 @@ def check_output(*args, **kwargs):
     to `/`.
     """
     return subprocess.check_output(cwd='/', *args, **kwargs)
+
+
+def get_python_site_packages_dir(install_dir):
+    return os.path.abspath(
+        os.path.join(
+            install_dir, "lib",
+            "python{}.{}".format(
+                sys.version_info.major, sys.version_info.minor),
+            "site-packages")
+    )

--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -15,6 +15,17 @@ load(
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load(":build_components.bzl", "LIBDRAKE_COMPONENTS")
 load("//tools:drake.bzl", "drake_cc_binary")
+load("@python//:version.bzl", "PYTHON_VERSION")
+
+genrule(
+    name = "drake_cps_generate",
+    srcs = ["drake.cps.in"],
+    outs = ["drake.cps"],
+    cmd = "cat \"$<\" | sed 's#@PYTHON_VERSION@#{}#g' > \"$@\"".format(
+        PYTHON_VERSION,
+    ),
+    visibility = ["//visibility:private"],
+)
 
 # TODO(eric.cousineau): Try to make the CMake target `drake-marker` private,
 # such that no downstream users can use it?

--- a/tools/install/libdrake/drake.cps.in
+++ b/tools/install/libdrake/drake.cps.in
@@ -43,6 +43,20 @@
       "Version": "2.6.1",
       "X-CMake-Find-Args": ["MODULE"]
     },
+    "PythonInterp": {
+      "Version": "@PYTHON_VERSION@",
+      "X-CMake-Find-Args": [
+        "EXACT",
+        "MODULE"
+      ]
+    },
+    "PythonLibs": {
+      "Version": "@PYTHON_VERSION@",
+      "X-CMake-Find-Args": [
+          "EXACT",
+          "MODULE"
+      ]
+    },
     "robotlocomotion-lcmtypes": {
       "Hints": ["@prefix@/lib/cmake/robotlocomotion-lcmtypes"],
       "X-CMake-Find-Args": ["CONFIG"]
@@ -103,7 +117,7 @@
     }
   },
   "X-CMake-Variables": {
-    "drake_PYTHON_DIRS": "${CMAKE_CURRENT_LIST_DIR}/../../python2.7/site-packages",
+    "drake_PYTHON_DIRS": "${CMAKE_CURRENT_LIST_DIR}/../../python@PYTHON_VERSION@/site-packages",
     "drake_RESOURCE_ROOT": "${CMAKE_CURRENT_LIST_DIR}/../../../share/drake"
   },
   "X-CMake-Variables-Init": {

--- a/tools/skylark/pybind.bzl
+++ b/tools/skylark/pybind.bzl
@@ -13,8 +13,6 @@ load(
     "drake_py_test",
 )
 
-_PY_VERSION = "2.7"
-
 def pybind_py_library(
         name,
         cc_srcs = [],
@@ -202,8 +200,7 @@ def get_pybind_package_info(base_package, sub_package = None):
     package_info = _get_package_info(base_package, sub_package)
     return struct(
         py_imports = [package_info.base_path_rel],
-        py_dest = "lib/python{}/site-packages/{}".format(
-            _PY_VERSION,
+        py_dest = "@PYTHON_SITE_PACKAGES@/{}".format(
             package_info.sub_path_rel,
         ),
     )

--- a/tools/workspace/README.md
+++ b/tools/workspace/README.md
@@ -155,6 +155,9 @@ it into Drake are roughly:
 - Edit `tools/workspace/default.bzl` to load and conditionally call the new
   `foo_repository()` macro or rule.
 
+When indicating licenses in the source, use the identifier from the
+[SPDX License List](https://spdx.org/licenses/).
+
 ## When using a library from the host operating system
 
 See `glib` for an example.

--- a/tools/workspace/drake_visualizer/drake_visualizer.py
+++ b/tools/workspace/drake_visualizer/drake_visualizer.py
@@ -51,6 +51,8 @@ if sys.platform.startswith("linux"):
     # for @vtk.
     set_path("LD_LIBRARY_PATH", "external/lcm")
     prepend_path("LD_LIBRARY_PATH", "external/vtk/lib")
+    # TODO(eric.cousineau): Ensure that Drake Visualizer works even when Bazel
+    # uses a separate version of Python.
     prepend_path("PYTHONPATH", "external/vtk/lib/python2.7/site-packages")
 elif sys.platform == "darwin":
     # Ensure that we handle DYLD_LIBRARY_PATH for @lcm.

--- a/tools/workspace/drake_visualizer/repository.bzl
+++ b/tools/workspace/drake_visualizer/repository.bzl
@@ -103,15 +103,17 @@ py_library(
     visibility = ["//visibility:public"],
 )
 
+# TODO(eric.cousineau): Ensure that Drake Visualizer works even when Bazel
+# uses a separate version of Python.
 filegroup(
     name = "drake_visualizer",
     srcs = glob([
         "lib/libPythonQt.*",
         "lib/libddApp.*",
-        "lib/python2.7/site-packages/bot_lcmgl/**/*.py",
-        "lib/python2.7/site-packages/director/**/*.py",
-        "lib/python2.7/site-packages/director/**/*.so",
-        "lib/python2.7/site-packages/urdf_parser_py/**/*.py",
+        "lib/python*.*/site-packages/bot_lcmgl/**/*.py",
+        "lib/python*.*/site-packages/director/**/*.py",
+        "lib/python*.*/site-packages/director/**/*.so",
+        "lib/python*.*/site-packages/urdf_parser_py/**/*.py",
     ]) + [
         "bin/drake-visualizer",
         "share/doc/director/LICENSE.txt",

--- a/tools/workspace/lcm/package.BUILD.bazel
+++ b/tools/workspace/lcm/package.BUILD.bazel
@@ -297,7 +297,7 @@ install(
         ":_lcm.so",
         ":lcm-python-upstream",
     ],
-    library_dest = "lib/python2.7/site-packages/lcm",
+    library_dest = "@PYTHON_SITE_PACKAGES@/lcm",
     py_strip_prefix = ["lcm-python"],
 )
 

--- a/tools/workspace/optitrack_driver/BUILD.bazel
+++ b/tools/workspace/optitrack_driver/BUILD.bazel
@@ -43,7 +43,7 @@ install(
     workspace = CMAKE_PACKAGE,
     targets = OPTITRACK_TARGETS,
     java_strip_prefix = ["**/"],
-    py_dest = "lib/python2.7/site-packages/optitrack",
+    py_dest = "@PYTHON_SITE_PACKAGES@/optitrack",
     py_strip_prefix = ["**/"],
     hdr_dest = "include",
     guess_hdrs = "PACKAGE",

--- a/tools/workspace/optitrack_driver/optitrack_client
+++ b/tools/workspace/optitrack_driver/optitrack_client
@@ -7,7 +7,9 @@ import sys
 def main():
     prefix = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     sys.path.insert(0, os.path.join(
-        prefix, 'lib', 'python2.7', 'site-packages'))
+        prefix, 'lib',
+        'python{}.{}'.format(sys.version_info.major, sys.version_info.minor),
+        'site-packages'))
 
     import optitrack.optitrack_client
 

--- a/tools/workspace/python/BUILD.bazel
+++ b/tools/workspace/python/BUILD.bazel
@@ -4,5 +4,11 @@
 # neighboring *.bzl file can be loaded elsewhere.
 
 load("//tools/lint:lint.bzl", "add_lint_tests")
+load("//tools/skylark:drake_py.bzl", "drake_py_unittest")
+
+drake_py_unittest(
+    name = "python_bin_test",
+    deps = ["@python//:bazel_python_actionenv"],
+)
 
 add_lint_tests()

--- a/tools/workspace/python/repository.bzl
+++ b/tools/workspace/python/repository.bzl
@@ -9,12 +9,14 @@ the "-undefined dynamic_lookup" linker flag, however in the rare cases that
 this would cause an undefined symbol error, a :python_direct_link target is
 provided. On Linux, these targets are identical.
 
+The Python distribution is determined by `--action_env=PYTHON_BIN_PATH=<bin>`,
+which should match Bazel's version (via `--python_path=<bin>`).
+
 Example:
     WORKSPACE:
         load("@drake//tools/workspace/python:repository.bzl", "python_repository")  # noqa
         python_repository(
             name = "foo",
-            version = "2",
         )
 
     BUILD:
@@ -26,29 +28,95 @@ Example:
 
 Arguments:
     name: A unique name for this rule.
-    version: The major or major.minor version of Python headers and libraries
-    to be found.
 """
 
-load("@drake//tools/workspace:execute.bzl", "which")
+load("@drake//tools/workspace:execute.bzl", "execute_or_fail", "which")
 load("@drake//tools/workspace:os.bzl", "determine_os")
 
+_VERSION_SUPPORT_MATRIX = {
+    "ubuntu:16.04": ["2.7"],
+    "ubuntu:18.04": ["2.7"],
+    "macos:10.13": ["2.7"],
+    "macos:10.14": ["2.7"],
+}
+
+def _repository_python_info(repository_ctx):
+    # Using `PYTHON_BIN_PATH` from the environment, determine:
+    # - `python` - binary path
+    # - `python_config` - configuration binary path
+    # - `site_packages_relpath` - relative to base of FHS
+    # - `version` - '{major}.{minor}`
+    # - `version_major` - major version
+    # - `os` - results from `determine_os(...)`
+    os_result = determine_os(repository_ctx)
+    if os_result.error != None:
+        fail(os_result.error)
+    if os_result.is_macos:
+        os_key = os_result.distribution + ":" + os_result.macos_release
+    else:
+        os_key = os_result.distribution + ":" + os_result.ubuntu_release
+    versions_supported = _VERSION_SUPPORT_MATRIX[os_key]
+
+    # Bazel does not easily expose its --python_path to repository rules (e.g.
+    # the environment is unaffected). We must use a workaround as Tensorflow
+    # does in `python_configure.bzl` (https://git.io/fx4Pp).
+    # N.B. Unfortunately, it does not seem possible to get Bazel's Python
+    # interpreter during a repository rule, thus we can only catch mismatch
+    # issues via `//tools/workspace/python:py/python_bin_test`.
+    if os_result.is_macos:
+        version_supported_major, _ = versions_supported[0].split(".")
+
+        # N.B. On Mac, `which python{major}.{minor}` may refer to the system
+        # Python, not Homebrew Python.
+        python_default = "python{}".format(version_supported_major)
+    else:
+        python_default = "python{}".format(versions_supported[0])
+    python_from_env = repository_ctx.os.environ.get(
+        "PYTHON_BIN_PATH",
+        python_default,
+    )
+    python = str(which(repository_ctx, python_from_env))
+    version = execute_or_fail(
+        repository_ctx,
+        [python, "-c", "from sys import version_info as v; print(\"{}.{}\"" +
+                       ".format(v.major, v.minor))"],
+    ).stdout.strip()
+    version_major, _ = version.split(".")
+
+    # Development Note: This should generally be the correct configuration. If
+    # you are hacking with `virtualenv` (which is officially unsupported),
+    # ensure that you manually symlink the matching `*-config` binary in your
+    # `virtualenv` installation.
+    python_config = "{}-config".format(python)
+
+    # Warn if we do not the correct platform support.
+    if version not in versions_supported:
+        print((
+            "\n\nWARNING: Python {} is not a supported / tested version for " +
+            "use with Drake.\n  Supported versions on {}: {}\n\n"
+        ).format(version, os_key, versions_supported))
+
+    site_packages_relpath = "lib/python{}/site-packages".format(version)
+    return struct(
+        python = python,
+        python_config = python_config,
+        site_packages_relpath = site_packages_relpath,
+        version = version,
+        version_major = version,
+        os = os_result,
+    )
+
 def _impl(repository_ctx):
-    python_config = which(repository_ctx, "python{}-config".format(
-        repository_ctx.attr.version,
-    ))
+    # Repository implementation.
+    py_info = _repository_python_info(
+        repository_ctx,
+    )
 
-    if not python_config:
-        fail("Could NOT find python{}-config".format(
-            repository_ctx.attr.version,
-        ))
-
-    result = repository_ctx.execute([python_config, "--includes"])
-
-    if result.return_code != 0:
-        fail("Could NOT determine Python includes", attr = result.stderr)
-
-    cflags = result.stdout.strip().split(" ")
+    # Collect includes.
+    cflags = execute_or_fail(
+        repository_ctx,
+        [py_info.python_config, "--includes"],
+    ).stdout.strip().split(" ")
     cflags = [cflag for cflag in cflags if cflag]
 
     root = repository_ctx.path("")
@@ -67,12 +135,11 @@ def _impl(repository_ctx):
                 repository_ctx.symlink(source, destination)
                 includes += [include]
 
-    result = repository_ctx.execute([python_config, "--ldflags"])
-
-    if result.return_code != 0:
-        fail("Could NOT determine Python linkopts", attr = result.stderr)
-
-    linkopts = result.stdout.strip().split(" ")
+    # Collect linker paths.
+    linkopts = execute_or_fail(
+        repository_ctx,
+        [py_info.python_config, "--ldflags"],
+    ).stdout.strip().split(" ")
     linkopts = [linkopt for linkopt in linkopts if linkopt]
 
     for i in reversed(range(len(linkopts))):
@@ -81,19 +148,38 @@ def _impl(repository_ctx):
 
     linkopts_direct_link = list(linkopts)
 
-    os_result = determine_os(repository_ctx)
-    if os_result.error != None:
-        fail(os_result.error)
-
-    if os_result.is_macos:
+    if py_info.os.is_macos:
         for i in reversed(range(len(linkopts))):
-            if linkopts[i].find("python{}".format(
-                repository_ctx.attr.version,
-            )) != -1:
+            if linkopts[i].find("python" + py_info.version_major) != -1:
                 linkopts.pop(i)
         linkopts = ["-undefined dynamic_lookup"] + linkopts
 
-    file_content = """# -*- python -*-
+    skylark_content = """
+# DO NOT EDIT: generated by python_repository()
+# WARNING: Avoid using this macro in any repository rules which require
+# `load()` at the WORKSPACE level. Instead, load these constants through
+# `BUILD.bazel` or `package.BUILD.bazel` files.
+
+PYTHON_BIN_PATH = "{bin_path}"
+PYTHON_VERSION = "{version}"
+PYTHON_SITE_PACKAGES_RELPATH = "{site_packages_relpath}"
+""".format(
+        bin_path = py_info.python,
+        version = py_info.version,
+        site_packages_relpath = py_info.site_packages_relpath,
+    )
+    repository_ctx.file(
+        "version.bzl",
+        content = skylark_content,
+        executable = False,
+    )
+    repository_ctx.file(
+        "bazel_python_actionenv.py",
+        content = skylark_content,
+        executable = False,
+    )
+
+    build_content = """# -*- python -*-
 
 # DO NOT EDIT: generated by python_repository()
 
@@ -101,8 +187,8 @@ licenses(["notice"])  # Python-2.0
 
 # Only include first level of headers included from `python_repository`
 # (`include/<destination>/*`). This should exclude third party C headers which
-# may be nested within `/usr/include/python2.7`, such as `numpy` when installed
-# via `apt` on Ubuntu.
+# may be nested within `/usr/include/python<version>`, such as `numpy` when
+# installed via `apt` on Ubuntu.
 headers = glob(
     ["include/*/*"],
     exclude_directories = 1,
@@ -128,16 +214,26 @@ cc_library(
     deps = [":python_headers"],
     visibility = ["//visibility:public"],
 )
+
+py_library(
+    name = "bazel_python_actionenv",
+    srcs = ["bazel_python_actionenv.py"],
+    imports = ["."],
+    visibility = ["//visibility:public"],
+    testonly = 1,
+)
     """.format(includes, linkopts, linkopts_direct_link)
 
     repository_ctx.file(
         "BUILD.bazel",
-        content = file_content,
+        content = build_content,
         executable = False,
     )
 
 python_repository = repository_rule(
     _impl,
-    attrs = {"version": attr.string(default = "2")},
+    environ = [
+        "PYTHON_BIN_PATH",
+    ],
     local = True,
 )

--- a/tools/workspace/python/test/python_bin_test.py
+++ b/tools/workspace/python/test/python_bin_test.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import subprocess
+import unittest
+
+from bazel_python_actionenv import PYTHON_BIN_PATH
+
+
+def get_interpreter_info(python):
+    # Do not compare paths, as we may get something like `/usr/bin/python` and
+    # `/usr/bin/python2.7`. Instead, ensure we have the same version
+    # information and prefix (which should be invariant of symlink aliases and
+    # shell forwarding scripts).
+    return subprocess.check_output([
+        python, "-c",
+        "import sys; print('prefix: {}\\nversion: {}'" +
+        ".format(sys.prefix, sys.version_info))"]).decode("utf8")
+
+
+class TestPythonBin(unittest.TestCase):
+    def test_bazel_and_env(self):
+        """Ensures that we are supplying consistent options to Bazel.
+        """
+        python_bazel = sys.executable
+        info_bazel = get_interpreter_info(python_bazel)
+        python_actionenv = PYTHON_BIN_PATH
+        info_actionenv = get_interpreter_info(python_actionenv)
+        if info_bazel != info_actionenv:
+            message = (
+                "\n\nMismatch in Python executables:\n"
+                "  bazel --python_path={}\n"
+                "  bazel --action_env=PYTHON_BIN_PATH={}\n"
+                "If you specify one of these, please ensure that you "
+                "specify both.").format(python_bazel, python_actionenv)
+            # In Python2, providing a longMessage will override the useful text
+            # comparison; as a workaround, we'll print out our debugging
+            # message beforehand.
+            print(message)
+            self.assertMultiLineEqual(info_bazel, info_actionenv)


### PR DESCRIPTION
For #8352
Toward #9614

The assumption here is that users select their Python version using `--python_path`. Everything falls out from it after that.

This enables using a separate Python version within our Skylark rules.
However, it does break downstream Bazel consumers that use `add_default_repositories`, as some of the `*.bzl` files depend on the generated `@python//:python.bzl` to get version information.
At present, I'm not sure of an easy way to query the version from Bazel's interpreter that it's using.

\cc @jamiesnape 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9649)
<!-- Reviewable:end -->
