### PR TITLE
Render __init__ docstrings in pydrake Sphinx documentation

### DIFF
--- a/bindings/pydrake/doc/conf.py
+++ b/bindings/pydrake/doc/conf.py
@@ -32,6 +32,9 @@ extensions = [
     'sphinx.ext.napoleon',
 ]
 
+# Option available in Sphinx 1.5+.
+napoleon_include_init_with_doc = True
+
 # The suffix(es) of source filenames.
 source_suffix = '.rst'
 


### PR DESCRIPTION
Fixes #9651.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9652)
<!-- Reviewable:end -->
