### PR TITLE
drake_visualizer: Enable --use_builtin_scripts

### DIFF
--- a/multibody/rigid_body_plant/visualization/contact_viz.py
+++ b/multibody/rigid_body_plant/visualization/contact_viz.py
@@ -1,0 +1,6 @@
+from drake.tools.workspace.drake_visualizer.plugin import show_contact
+
+# Activate the plugin if this script is run directly; store the results to keep
+# the plugin objects in scope.
+if __name__ == "__main__":
+    contact_viz = show_contact.init_visualizer()

--- a/multibody/rigid_body_plant/visualization/show_frames.py
+++ b/multibody/rigid_body_plant/visualization/show_frames.py
@@ -1,0 +1,6 @@
+from drake.tools.workspace.drake_visualizer.plugin import show_frame
+
+# Activate the plugin if this script is run directly; store the results to keep
+# the plugin objects in scope.
+if __name__ == "__main__":
+    frame_viz = show_frame.init_visualizer()

--- a/multibody/rigid_body_plant/visualization/show_time.py
+++ b/multibody/rigid_body_plant/visualization/show_time.py
@@ -1,0 +1,6 @@
+from drake.tools.workspace.drake_visualizer.plugin import show_time
+
+# Activate the plugin if this script is run directly; store the results to keep
+# the plugin objects in scope.
+if __name__ == "__main__":
+    time_viz = show_time.init_visualizer()

--- a/systems/sensors/visualization/show_images.py
+++ b/systems/sensors/visualization/show_images.py
@@ -1,0 +1,6 @@
+from drake.tools.workspace.drake_visualizer.plugin import show_image
+
+# Activate the plugin if this script is run directly; store the results to keep
+# the plugin objects in scope.
+if __name__ == "__main__":
+    image_viewer = show_image.init_visualizer()

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -5,6 +5,13 @@ load("//tools/skylark:drake_runfiles_binary.bzl", "drake_runfiles_binary")
 
 package(default_visibility = ["//visibility:public"])
 
+py_library(
+    name = "module_py",
+    srcs = ["__init__.py"],
+    visibility = [":__subpackages__"],
+    deps = ["//:module_py"],
+)
+
 # TODO(eric.cousineau): Consider using a `./run`-like script for this, rather
 # than `drake_runfiles_binary`. Then this can be renamed to `drake_visualizer`.
 py_binary(
@@ -20,6 +27,7 @@ py_binary(
     deps = [
         "//lcmtypes:lcmtypes_py",
         "//tools/workspace/drake_visualizer:stub_pydrake",
+        "//tools/workspace/drake_visualizer/plugin",
         "@drake_visualizer//:drake_visualizer_python_deps",
         "@optitrack_driver//lcmtypes:py_optitrack_lcmtypes",
     ],

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+# Empty Python module `__init__`, required to make this a module.

--- a/tools/workspace/BUILD.bazel
+++ b/tools/workspace/BUILD.bazel
@@ -8,6 +8,13 @@ load(
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
+py_library(
+    name = "module_py",
+    srcs = ["__init__.py"],
+    visibility = [":__subpackages__"],
+    deps = ["//tools:module_py"],
+)
+
 drake_py_binary(
     name = "cmake_configure_file",
     srcs = ["cmake_configure_file.py"],

--- a/tools/workspace/__init__.py
+++ b/tools/workspace/__init__.py
@@ -1,0 +1,1 @@
+# Empty Python module `__init__`, required to make this a module.

--- a/tools/workspace/drake_visualizer/BUILD.bazel
+++ b/tools/workspace/drake_visualizer/BUILD.bazel
@@ -7,6 +7,13 @@ exports_files(
     visibility = ["//tools:__pkg__"],
 )
 
+py_library(
+    name = "module_py",
+    srcs = ["__init__.py"],
+    visibility = [":__subpackages__"],
+    deps = ["//tools/workspace:module_py"],
+)
+
 # When developing within Drake, we don't want //tools:drake_visualizer to
 # depend on the entire pydrake library, because that adds a dependency on a
 # whole bunch of C++ code that is irrelevant for the visualizer.  So, here we

--- a/tools/workspace/drake_visualizer/__init__.py
+++ b/tools/workspace/drake_visualizer/__init__.py
@@ -1,0 +1,1 @@
+# Empty Python module `__init__`, required to make this a module.

--- a/tools/workspace/drake_visualizer/drake_visualizer.py
+++ b/tools/workspace/drake_visualizer/drake_visualizer.py
@@ -1,12 +1,25 @@
+from __future__ import print_function
+
+import argparse
 import os
+from os.path import exists, join
 import subprocess
 import sys
 
 
 def resolve_path(relpath):
-    abspath = os.path.join(runfiles_dir, relpath)
-    assert os.path.exists(abspath), "Path does not exist: {}".format(abspath)
-    return abspath
+    test_paths = [
+        # This is for bazel run //tools:drake_visualizer.
+        join(runfiles_dir, relpath),
+    ]
+    if not relpath.startswith("external/"):
+        # This is for bazel run @drake//tools:drake_visualizer.
+        test_paths.insert(0, join(runfiles_dir, "external/drake", relpath))
+    for p in test_paths:
+        if exists(p):
+            return p
+    assert False, (
+        "No available paths:\n{}".format("\n".join(test_paths)))
 
 
 def set_path(key, relpath):
@@ -17,6 +30,17 @@ def prepend_path(key, relpath):
     os.environ[key] = resolve_path(relpath) + ":" + os.environ.get(key, '')
 
 
+def extract_use_builtin_scripts(argv):
+    # drake-visualizer greedily consumes arguments, so we must catch them
+    # first and pass them as an environment variable.
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--use_builtin_scripts", type=str, default="all")
+    args, argv = parser.parse_known_args(argv)
+    os.environ["_DRAKE_VISUALIZER_BUILTIN_SCRIPTS"] = args.use_builtin_scripts
+    return argv
+
+
+assert __name__ == "__main__", __name__
 runfiles_dir = os.environ.get("DRAKE_BAZEL_RUNFILES")
 assert runfiles_dir, (
     "This must be called by a script generated using the " +
@@ -28,13 +52,7 @@ assert runfiles_dir, (
 # on the stub py_library, to avoid any other target accidentally pulling in the
 # stubbed pydrake onto its PYTHONPATH.  Only the visualizer, when launched via
 # this wrapper script, should employ the stub.
-stub_relpath = "tools/workspace/drake_visualizer/stub"
-if os.path.exists(os.path.join(runfiles_dir, "external/drake")):
-    # This is for bazel run @drake//tools:drake_visualizer.
-    prepend_path("PYTHONPATH", "external/drake/" + stub_relpath)
-else:
-    # This is for bazel run //tools:drake_visualizer.
-    prepend_path("PYTHONPATH", stub_relpath)
+prepend_path("PYTHONPATH", "tools/workspace/drake_visualizer/stub")
 
 # Don't use DRAKE_RESOURCE_ROOT; the stub getDrakePath should always win.  This
 # also placates the drake-visualizer logic that puts it into Director mode when
@@ -58,7 +76,10 @@ elif sys.platform == "darwin":
     # Ensure that we handle DYLD_LIBRARY_PATH for @lcm.
     set_path("DYLD_LIBRARY_PATH", "external/lcm")
 
-# Execute binary.
+# Build arguments, handling builtin scripts, and execute.
+use_builtin_scripts = resolve_path(
+    "tools/workspace/drake_visualizer/plugin/use_builtin_scripts.py")
 bin_path = resolve_path("external/drake_visualizer/bin/drake-visualizer")
-args = [bin_path] + sys.argv[1:]
+args = [bin_path] + extract_use_builtin_scripts(sys.argv[1:])
+args += ["--script", use_builtin_scripts]
 os.execv(bin_path, args)

--- a/tools/workspace/drake_visualizer/plugin/BUILD.bazel
+++ b/tools/workspace/drake_visualizer/plugin/BUILD.bazel
@@ -1,0 +1,25 @@
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+py_library(
+    name = "module_py",
+    srcs = ["__init__.py"],
+    visibility = ["//visibility:public"],
+    deps = ["//tools/workspace/drake_visualizer:module_py"],
+)
+
+py_library(
+    name = "plugin",
+    srcs = [
+        "show_contact.py",
+        "show_frame.py",
+        "show_image.py",
+        "show_time.py",
+        "use_builtin_scripts.py",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":module_py",
+    ],
+)
+
+add_lint_tests()

--- a/tools/workspace/drake_visualizer/plugin/README.md
+++ b/tools/workspace/drake_visualizer/plugin/README.md
@@ -1,0 +1,22 @@
+# Visualization
+
+Contains the following `director` scripts for `drake_visualizer`:
+
+*   `contact` - Contact visualization
+*   `frame` - Frame visualization
+*   `image` - Image visualization
+*   `time` - Simulation time and real time factor display
+
+These scripts are enabled in `//tools:drake_visualizer` by default.
+They can be toggled by supplying `--use_builtin_scripts=...` to
+`drake_visualizer`.
+
+Examples:
+
+```sh
+bazel build //tools:drake_visualizer
+
+./bazel-bin/tools/drake_visualizer [--use_builtin_scripts=all]  # All scripts
+./bazel-bin/tools/drake_visualizer --use_builtin_scripts=  # No scripts
+./bazel-bin/tools/drake_visualizer --use_builtin_scripts=image  # Image only
+```

--- a/tools/workspace/drake_visualizer/plugin/README.md
+++ b/tools/workspace/drake_visualizer/plugin/README.md
@@ -20,3 +20,22 @@ bazel build //tools:drake_visualizer
 ./bazel-bin/tools/drake_visualizer --use_builtin_scripts=  # No scripts
 ./bazel-bin/tools/drake_visualizer --use_builtin_scripts=image  # Image only
 ```
+
+## Backwards Compatibility
+
+If you update this infrastructure, please briefly ensure that the change does
+not break previous spellings of these scripts:
+
+    (
+        set -eux;
+        compatibility_scripts=$(echo "
+            multibody/rigid_body_plant/visualization/contact_viz.py
+            multibody/rigid_body_plant/visualization/show_frames.py
+            multibody/rigid_body_plant/visualization/show_time.py
+            systems/sensors/visualization/show_images.py
+            ")
+        for script in ${compatibility_scripts}; do
+            ./bazel-bin/tools/drake_visualizer --script ${script} \
+                --use_builtin_scripts=
+        done
+    )

--- a/tools/workspace/drake_visualizer/plugin/__init__.py
+++ b/tools/workspace/drake_visualizer/plugin/__init__.py
@@ -1,0 +1,28 @@
+from functools import wraps
+from warnings import warn
+import weakref
+
+
+def scoped_singleton_func(f):
+    """Decorates a function that should only be called once
+    (e.g. `init_visualization`). A weak-reference is maintained, such that the
+    lifetime of the object is not affected by this decorator.
+    """
+    state = dict(called=False, args=None, result_ref=None)
+
+    @wraps(f)
+    def wrapped(*args, **kwargs):
+        result_ref = state["result_ref"]
+        is_result_valid = result_ref and result_ref() is not None
+        if state["called"] and is_result_valid:
+            if (args, kwargs) != state["args"]:
+                warn(("Called a singleton function {} with different "
+                      "arguments!").format(f))
+            return result_ref()
+        result = f(*args, **kwargs)
+        state.update(
+            called=True, args=(args, kwargs),
+            result_ref=weakref.ref(result))
+        return result
+
+    return wrapped

--- a/tools/workspace/drake_visualizer/plugin/show_contact.py
+++ b/tools/workspace/drake_visualizer/plugin/show_contact.py
@@ -1,4 +1,4 @@
-# Note that this script runs in the main context of drake-visulizer,
+# Note that this script runs in the main context of drake-visualizer,
 # where many modules and variables already exist in the global scope.
 from director import lcmUtils
 from director import applogic
@@ -10,9 +10,10 @@ from six import iteritems
 
 import drake as lcmdrakemsg
 
+from drake.tools.workspace.drake_visualizer.plugin import scoped_singleton_func
+
 
 class ContactVisualizer(object):
-
     def __init__(self):
         self._folder_name = 'Contact Results'
         self._name = "Contact Visualizer"
@@ -98,10 +99,10 @@ class ContactVisualizer(object):
                 d.getPolyData(), str(key), parent=folder, color=[0, 1, 0])
 
 
+@scoped_singleton_func
 def init_visualizer():
     # Create a visualizer instance.
     my_visualizer = ContactVisualizer()
-
     # Adds to the "Tools" menu.
     applogic.MenuActionToggleHelper(
         'Tools', my_visualizer._name,
@@ -109,5 +110,7 @@ def init_visualizer():
     return my_visualizer
 
 
-# Creates the visualizer when this script is executed.
-contact_viz = init_visualizer()
+# Activate the plugin if this script is run directly; store the results to keep
+# the plugin objects in scope.
+if __name__ == "__main__":
+    contact_viz = init_visualizer()

--- a/tools/workspace/drake_visualizer/plugin/show_frame.py
+++ b/tools/workspace/drake_visualizer/plugin/show_frame.py
@@ -7,6 +7,8 @@ from director import objectmodel as om
 from director import visualization as vis
 import robotlocomotion as lcmrobotlocomotion
 
+from drake.tools.workspace.drake_visualizer.plugin import scoped_singleton_func
+
 
 class FrameChannel(object):
 
@@ -90,6 +92,7 @@ class FramesVisualizer(object):
         frame_channel.handle_message(msg)
 
 
+@scoped_singleton_func
 def init_visualizer():
     frame_viz = FramesVisualizer()
 
@@ -100,5 +103,7 @@ def init_visualizer():
     return frame_viz
 
 
-# Creates the visualizer when this script is executed.
-frame_viz = init_visualizer()
+# Activate the plugin if this script is run directly; store the results to keep
+# the plugin objects in scope.
+if __name__ == "__main__":
+    frame_viz = init_visualizer()

--- a/tools/workspace/drake_visualizer/plugin/show_time.py
+++ b/tools/workspace/drake_visualizer/plugin/show_time.py
@@ -1,9 +1,11 @@
-# Note that this script runs in the main context of drake-visulizer,
-# where many modules and variables already exist in the global scope.
+import time
+
+import bot_core as lcmbotcore
 from director import lcmUtils
 from director import applogic
-import bot_core as lcmbotcore
-import time
+from director.visualization import updateText
+
+from drake.tools.workspace.drake_visualizer.plugin import scoped_singleton_func
 
 
 class TimeVisualizer(object):
@@ -33,7 +35,7 @@ class TimeVisualizer(object):
 
         lcmUtils.removeSubscriber(self._subscriber)
         self._subscriber = None
-        vis.updateText('', 'text')
+        updateText('', 'text')
 
     def is_enabled(self):
         return self._subscriber is not None
@@ -62,12 +64,12 @@ class TimeVisualizer(object):
 
             my_text = my_text + ', real time factor: %.2f' % rt_ratio
 
-        vis.updateText(my_text, 'text')
+        updateText(my_text, 'text')
 
 
+@scoped_singleton_func
 def init_visualizer():
     time_viz = TimeVisualizer()
-
     # Adds to the "Tools" menu.
     applogic.MenuActionToggleHelper(
         'Tools', time_viz._name,
@@ -75,5 +77,7 @@ def init_visualizer():
     return time_viz
 
 
-# Creates the visualizer when this script is executed.
-time_viz = init_visualizer()
+# Activate the plugin if this script is run directly; store the results to keep
+# the plugin objects in scope.
+if __name__ == "__main__":
+    time_viz = init_visualizer()

--- a/tools/workspace/drake_visualizer/plugin/use_builtin_scripts.py
+++ b/tools/workspace/drake_visualizer/plugin/use_builtin_scripts.py
@@ -1,0 +1,54 @@
+"""Amalgam of visualizer scripts."""
+
+from __future__ import print_function
+
+from collections import OrderedDict
+import os
+import sys
+
+from drake.tools.workspace.drake_visualizer.plugin import (
+    show_contact,
+    show_frame,
+    show_image,
+    show_time,
+    scoped_singleton_func,
+)
+
+
+@scoped_singleton_func
+def init_visualizer():
+    available = OrderedDict((
+        ("contact", show_contact.init_visualizer),
+        ("frame", show_frame.init_visualizer),
+        ("image", show_image.init_visualizer),
+        ("time", show_time.init_visualizer),
+    ))
+    print("")
+    print("Drake Scripts:")
+    scripts_raw = os.environ["_DRAKE_VISUALIZER_BUILTIN_SCRIPTS"]
+    print("  Specified: --use_builtin_scripts={}".format(scripts_raw))
+    if scripts_raw == "all":
+        scripts = available.keys()
+    else:
+        scripts = []
+        for script in scripts_raw.split(","):
+            script = script.strip()
+            if not script:
+                continue
+            if script not in available:
+                print("\nWARNING: Invalid script: {}\n".format(script))
+                continue
+            scripts.append(script)
+    print("  Available: --use_builtin_scripts={}".format(
+        ",".join(available.keys())))
+    print("")
+    results = OrderedDict()
+    for script in scripts:
+        results[script] = available[script]()
+    return results
+
+
+# Activate the plugin if this script is run directly; store the results to keep
+# the plugin objects in scope.
+if __name__ == "__main__":
+    drake_builtin_scripts = init_visualizer()


### PR DESCRIPTION
Resolves #9608

NEW: Finalized.

---

OLD:
Here's a coarse attempt. Off by default (my strong preference), but to use it, you can just pass `--use-drake-scripts`. To verify, press F8 to open terminal, and then print `(contact_viz, frame_viz, time_viz, image_viewer)` to see if scripts are active:
```
bazel run //tools:drake_visualizer  # Nominal
bazel run //tools:drake_visualizer --use-drake-scripts
bazel run @drake//tools:drake_visualizer --use-drake-scripts
./bazel-bin/tools/drake_visualizer --use-drake-scripts
./bazel-bin/external/drake/tools/drake_visualizer --use-drake-scripts
```

Need to verify using symlinks don't break downstream Bazel projects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9653)
<!-- Reviewable:end -->
