### PR TITLE
Adds GetSubsystemByName to Diagram

### DIFF
--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -286,6 +286,20 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
     }
   }
 
+  /// Retrieves a reference to the subsystem with name @p name returned by
+  /// get_name().
+  /// @throws std::logic_error if a match cannot be found.
+  /// @see System<T>::get_name()
+  const System<T>& GetSubsystemByName(const std::string& name) const {
+    for (const auto& child : registered_systems_) {
+      if (child->get_name() == name) {
+        return *child;
+      }
+    }
+    throw std::logic_error("System " + this->GetSystemName() +
+                           " does not have a subsystem named " + name);
+  }
+
   /// Retrieves the state derivatives for a particular subsystem from the
   /// derivatives for the entire diagram. Aborts if @p subsystem is not
   /// actually a subsystem of this diagram. Returns a 0-length ContinuousState

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -812,6 +812,17 @@ TEST_F(DiagramTest, AllocateInputs) {
   }
 }
 
+TEST_F(DiagramTest, GetSubsystemByName) {
+  const System<double>& stateless = diagram_->GetSubsystemByName("stateless");
+  EXPECT_NE(
+      dynamic_cast<const analysis_test::StatelessSystem<double>*>(&stateless),
+      nullptr);
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      diagram_->GetSubsystemByName("not_a_subsystem"), std::logic_error,
+      "System .* does not have a subsystem named not_a_subsystem");
+}
+
 // Tests that ContextBase methods for affecting cache behavior propagate
 // through to subcontexts. Since leaf output ports have cache entries in their
 // corresponding subcontext, we'll pick one and check its behavior.


### PR DESCRIPTION
Give a programmatic means for retrieving a subsystem without having to store every pointer to every added system.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9668)
<!-- Reviewable:end -->
