### PR TITLE
Add required abstract input model values

### DIFF
--- a/automotive/pure_pursuit_controller.cc
+++ b/automotive/pure_pursuit_controller.cc
@@ -20,9 +20,11 @@ template <typename T>
 PurePursuitController<T>::PurePursuitController()
     : systems::LeafSystem<T>(
           systems::SystemTypeTag<automotive::PurePursuitController>{}),
-      lane_index_{this->DeclareAbstractInputPort().get_index()},
+      lane_index_{this->DeclareAbstractInputPort(
+          systems::kUseDefaultName, systems::Value<LaneDirection>())
+              .get_index()},
       ego_pose_index_{
-          this->DeclareInputPort(systems::kVectorValued, PoseVector<T>::kSize)
+          this->DeclareVectorInputPort(PoseVector<T>{})
               .get_index()},
       steering_command_index_{
           this->DeclareVectorOutputPort(

--- a/examples/acrobot/BUILD.bazel
+++ b/examples/acrobot/BUILD.bazel
@@ -75,7 +75,10 @@ drake_cc_binary(
     srcs = ["run_lqr.cc"],
     add_test_rule = 1,
     data = [":models"],
-    test_rule_args = ["-realtime_factor=0.0"],
+    test_rule_args = [
+        "-simulation_sec=1.0",
+        "-realtime_factor=0.0",
+    ],
     deps = [
         ":acrobot_plant",
         "//attic/multibody/parsers",
@@ -94,7 +97,10 @@ drake_cc_binary(
     srcs = ["run_lqr_w_estimator.cc"],
     add_test_rule = 1,
     data = [":models"],
-    test_rule_args = ["-realtime_factor=0.0"],
+    test_rule_args = [
+        "-simulation_sec=1.0",
+        "-realtime_factor=0.0",
+    ],
     deps = [
         ":acrobot_plant",
         "//attic/multibody/joints",
@@ -119,7 +125,10 @@ drake_cc_binary(
     srcs = ["run_passive.cc"],
     add_test_rule = 1,
     data = [":models"],
-    test_rule_args = ["-realtime_factor=0.0"],
+    test_rule_args = [
+        "-simulation_sec=1.0",
+        "-realtime_factor=0.0",
+    ],
     deps = [
         ":acrobot_plant",
         "//attic/multibody/joints",
@@ -142,7 +151,11 @@ drake_cc_binary(
     ],
     add_test_rule = 1,
     data = [":models"],
-    test_rule_args = ["-realtime_factor=0.0"],
+    test_rule_args = [
+        # N.B. We can't set -simulation_sec here, because the demo program has
+        # success criteria that it asserts after the simulation expires.
+        "-realtime_factor=0.0",
+    ],
     deps = [
         ":acrobot_plant",
         "//attic/multibody/joints",
@@ -186,6 +199,10 @@ drake_cc_binary(
         "spong_controller.h",
         "spong_controller_w_lcm.cc",
     ],
+    add_test_rule = 1,
+    test_rule_args = [
+        "-time_limit_sec=1.0",
+    ],
     deps = [
         ":acrobot_lcm",
         ":acrobot_plant",
@@ -195,13 +212,19 @@ drake_cc_binary(
         "//multibody:rigid_body_tree",
         "//systems/analysis",
         "//systems/controllers:linear_quadratic_regulator",
+        "@gflags",
     ],
 )
 
 drake_cc_binary(
     name = "run_plant_w_lcm",
     srcs = ["run_plant_w_lcm.cc"],
+    add_test_rule = 1,
     data = [":models"],
+    test_rule_args = [
+        "-simulation_sec=1.0",
+        "-realtime_factor=0.0",
+    ],
     deps = [
         ":acrobot_lcm",
         ":acrobot_plant",

--- a/examples/acrobot/acrobot_lcm.cc
+++ b/examples/acrobot/acrobot_lcm.cc
@@ -16,7 +16,8 @@ static const int kNumJoints = 2;
 // methods implementation for AcrobotStateReceiver.
 
 AcrobotStateReceiver::AcrobotStateReceiver() {
-  this->DeclareAbstractInputPort("lcmt_acrobot_x");
+  this->DeclareAbstractInputPort("lcmt_acrobot_x",
+                                 systems::Value<lcmt_acrobot_x>{});
   this->DeclareVectorOutputPort("acrobot_state",
                                 &AcrobotStateReceiver::CopyStateOut);
 }
@@ -54,7 +55,8 @@ void AcrobotCommandSender::OutputCommand(const Context<double>& context,
 // methods implementation for AcrobotCommandReceiver
 
 AcrobotCommandReceiver::AcrobotCommandReceiver() {
-  this->DeclareAbstractInputPort("lcmt_acrobot_u");
+  this->DeclareAbstractInputPort("lcmt_acrobot_u",
+                                 systems::Value<lcmt_acrobot_u>());
   this->DeclareVectorOutputPort("elbow_torque", systems::BasicVector<double>(1),
                                 &AcrobotCommandReceiver::OutputCommandAsVector);
 }

--- a/examples/acrobot/run_lqr.cc
+++ b/examples/acrobot/run_lqr.cc
@@ -23,13 +23,13 @@ namespace {
 // LQR controller designed to stabilize the unstable fixed point.  Run
 // drake-visualizer to see the animated result.
 
+DEFINE_double(simulation_sec, 10.0,
+              "Number of seconds to simulate.");
 DEFINE_double(realtime_factor, 1.0,
               "Playback speed.  See documentation for "
               "Simulator::set_target_realtime_rate() for details.");
 
-int do_main(int argc, char* argv[]) {
-  gflags::ParseCommandLineFlags(&argc, &argv, true);
-
+int do_main() {
   lcm::DrakeLcm lcm;
   auto tree = std::make_unique<RigidBodyTree<double>>();
   parsers::urdf::AddModelInstanceFromUrdfFileToWorld(
@@ -65,7 +65,7 @@ int do_main(int argc, char* argv[]) {
 
   simulator.set_target_realtime_rate(FLAGS_realtime_factor);
   simulator.Initialize();
-  simulator.StepTo(10);
+  simulator.StepTo(FLAGS_simulation_sec);
   return 0;
 }
 
@@ -75,5 +75,6 @@ int do_main(int argc, char* argv[]) {
 }  // namespace drake
 
 int main(int argc, char* argv[]) {
-  return drake::examples::acrobot::do_main(argc, argv);
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  return drake::examples::acrobot::do_main();
 }

--- a/examples/acrobot/run_lqr_w_estimator.cc
+++ b/examples/acrobot/run_lqr_w_estimator.cc
@@ -30,13 +30,13 @@ namespace {
 // fixed point and a state estimator in the loop. Run drake-visualizer to
 // see the animated result.
 
+DEFINE_double(simulation_sec, 5.0,
+              "Number of seconds to simulate.");
 DEFINE_double(realtime_factor, 1.0,
               "Playback speed.  See documentation for "
               "Simulator::set_target_realtime_rate() for details.");
 
-int do_main(int argc, char* argv[]) {
-  gflags::ParseCommandLineFlags(&argc, &argv, true);
-
+int do_main() {
   // Make the robot.
   systems::DiagramBuilder<double> builder;
   auto acrobot_w_encoder = builder.AddSystem<AcrobotWEncoder<double>>(true);
@@ -136,7 +136,7 @@ int do_main(int argc, char* argv[]) {
   simulator.get_mutable_integrator()->set_maximum_step_size(0.01);
   simulator.get_mutable_integrator()->set_fixed_step_mode(true);
   simulator.Initialize();
-  simulator.StepTo(5);
+  simulator.StepTo(FLAGS_simulation_sec);
 
   // Plot the results (launch call_matlab_client to see the plots).
   using common::CallMatlab;
@@ -164,5 +164,6 @@ int do_main(int argc, char* argv[]) {
 }  // namespace drake
 
 int main(int argc, char* argv[]) {
-  return drake::examples::acrobot::do_main(argc, argv);
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  return drake::examples::acrobot::do_main();
 }

--- a/examples/acrobot/run_passive.cc
+++ b/examples/acrobot/run_passive.cc
@@ -22,13 +22,13 @@ namespace {
 // Simple example which simulates the (passive) Acrobot.  Run drake-visualizer
 // to see the animated result.
 
+DEFINE_double(simulation_sec, 10.0,
+              "Number of seconds to simulate.");
 DEFINE_double(realtime_factor, 1.0,
               "Playback speed.  See documentation for "
               "Simulator::set_target_realtime_rate() for details.");
 
-int do_main(int argc, char* argv[]) {
-  gflags::ParseCommandLineFlags(&argc, &argv, true);
-
+int do_main() {
   lcm::DrakeLcm lcm;
   auto tree = std::make_unique<RigidBodyTree<double>>();
   parsers::urdf::AddModelInstanceFromUrdfFileToWorld(
@@ -62,7 +62,7 @@ int do_main(int argc, char* argv[]) {
 
   simulator.set_target_realtime_rate(FLAGS_realtime_factor);
   simulator.Initialize();
-  simulator.StepTo(10);
+  simulator.StepTo(FLAGS_simulation_sec);
   return 0;
 }
 
@@ -72,5 +72,6 @@ int do_main(int argc, char* argv[]) {
 }  // namespace drake
 
 int main(int argc, char* argv[]) {
-  return drake::examples::acrobot::do_main(argc, argv);
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  return drake::examples::acrobot::do_main();
 }

--- a/examples/acrobot/run_plant_w_lcm.cc
+++ b/examples/acrobot/run_plant_w_lcm.cc
@@ -96,7 +96,6 @@ int DoMain() {
 
   simulator.set_target_realtime_rate(FLAGS_realtime_factor);
   simulator.Initialize();
-  // Simulate for a very long time.
   simulator.StepTo(FLAGS_simulation_sec);
 
   return 0;
@@ -106,4 +105,7 @@ int DoMain() {
 }  // namespace examples
 }  // namespace drake
 
-int main() { return drake::examples::acrobot::DoMain(); }
+int main(int argc, char* argv[]) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  return drake::examples::acrobot::DoMain();
+}

--- a/examples/acrobot/run_swing_up.cc
+++ b/examples/acrobot/run_swing_up.cc
@@ -23,13 +23,13 @@ namespace {
 // point, with a Spong swing-up controller designed to reach the unstable
 // fixed point.  Run drake-visualizer to see the animated result.
 
+DEFINE_double(simulation_sec, 10.0,
+              "Number of seconds to simulate.");
 DEFINE_double(realtime_factor, 1.0,
               "Playback speed.  See documentation for "
               "Simulator::set_target_realtime_rate() for details.");
 
-int do_main(int argc, char* argv[]) {
-  gflags::ParseCommandLineFlags(&argc, &argv, true);
-
+int do_main() {
   lcm::DrakeLcm lcm;
   auto tree = std::make_unique<RigidBodyTree<double>>();
   parsers::urdf::AddModelInstanceFromUrdfFileToWorld(
@@ -61,7 +61,7 @@ int do_main(int argc, char* argv[]) {
   state->set_theta2dot(0.02);
 
   simulator.set_target_realtime_rate(FLAGS_realtime_factor);
-  simulator.StepTo(10.);
+  simulator.StepTo(FLAGS_simulation_sec);
 
   DRAKE_DEMAND(std::abs(math::wrap_to(state->theta1(), 0., 2. * M_PI) - M_PI) <
                1e-2);
@@ -78,5 +78,6 @@ int do_main(int argc, char* argv[]) {
 }  // namespace drake
 
 int main(int argc, char* argv[]) {
-  return drake::examples::acrobot::do_main(argc, argv);
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  return drake::examples::acrobot::do_main();
 }

--- a/examples/acrobot/spong_controller_w_lcm.cc
+++ b/examples/acrobot/spong_controller_w_lcm.cc
@@ -9,7 +9,10 @@
  * LcmPublisherSystem
  *
  */
+#include <chrono>
 #include <memory>
+
+#include <gflags/gflags.h>
 
 #include "drake/examples/acrobot/acrobot_lcm.h"
 #include "drake/examples/acrobot/spong_controller.h"
@@ -20,6 +23,9 @@
 #include "drake/systems/framework/leaf_system.h"
 #include "drake/systems/lcm/lcm_publisher_system.h"
 #include "drake/systems/lcm/lcm_subscriber_system.h"
+
+DEFINE_double(time_limit_sec, std::numeric_limits<double>::infinity(),
+              "Number of seconds to run (default: infinity).");
 
 namespace drake {
 namespace examples {
@@ -58,11 +64,17 @@ int DoMain() {
 
   lcm.StartReceiveThread();
 
-  while (true) {
+  using clock = std::chrono::system_clock;
+  const auto& start_time = clock::now();
+  const auto& max_duration =
+      std::chrono::duration<double>(FLAGS_time_limit_sec);
+  while ((clock::now() - start_time) <= max_duration) {
     const systems::Context<double>& pub_context =
         diagram->GetSubsystemContext(*command_pub, *context);
     command_pub->Publish(pub_context);
   }
+
+  return 0;
 }
 
 }  // namespace
@@ -70,4 +82,7 @@ int DoMain() {
 }  // namespace examples
 }  // namespace drake
 
-int main() { return drake::examples::acrobot::DoMain(); }
+int main(int argc, char* argv[]) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  return drake::examples::acrobot::DoMain();
+}

--- a/examples/allegro_hand/allegro_lcm.cc
+++ b/examples/allegro_hand/allegro_lcm.cc
@@ -15,7 +15,9 @@ using systems::DiscreteUpdateEvent;
 
 AllegroCommandReceiver::AllegroCommandReceiver(int num_joints)
     : num_joints_(num_joints) {
-  this->DeclareAbstractInputPort();
+  this->DeclareAbstractInputPort(
+      systems::kUseDefaultName,
+      systems::Value<lcmt_allegro_command>{});
   state_output_port_ = this->DeclareVectorOutputPort(
       systems::BasicVector<double>(num_joints_ * 2),
       [this](const Context<double>& c, BasicVector<double>* o) {

--- a/examples/humanoid_controller/humanoid_plan_eval_system.cc
+++ b/examples/humanoid_controller/humanoid_plan_eval_system.cc
@@ -22,7 +22,9 @@ HumanoidPlanEvalSystem::HumanoidPlanEvalSystem(
     const std::string& alias_groups_file_name,
     const std::string& param_file_name, double dt)
     : PlanEvalBaseSystem(robot, alias_groups_file_name, param_file_name, dt) {
-  input_port_index_manip_plan_msg_ = DeclareAbstractInputPort().get_index();
+  input_port_index_manip_plan_msg_ = DeclareAbstractInputPort(
+      systems::kUseDefaultName,
+      systems::Value<robotlocomotion::robot_plan_t>{}).get_index();
 
   auto plan_as_value = systems::AbstractValue::Make<GenericPlan<double>>(
       HumanoidManipulationPlan<double>());

--- a/examples/humanoid_controller/humanoid_status_translator_system.cc
+++ b/examples/humanoid_controller/humanoid_status_translator_system.cc
@@ -15,7 +15,9 @@ RobotStateMsgToHumanoidStatusSystem::RobotStateMsgToHumanoidStatusSystem(
   alias_groups.LoadFromFile(alias_group_path);
   default_output_ = std::make_unique<HumanoidStatus>(&robot_, alias_groups);
 
-  DeclareAbstractInputPort();
+  DeclareAbstractInputPort(
+      systems::kUseDefaultName,
+      systems::Value<bot_core::robot_state_t>{});
   DeclareAbstractOutputPort<RobotStateMsgToHumanoidStatusSystem,
                             RobotKinematicState<double>>(
       *default_output_,

--- a/examples/kinova_jaco_arm/jaco_lcm.cc
+++ b/examples/kinova_jaco_arm/jaco_lcm.cc
@@ -31,7 +31,9 @@ constexpr double kFingerUrdfToSdk = 118.68 / 2.;
 JacoCommandReceiver::JacoCommandReceiver(int num_joints, int num_fingers)
     : num_joints_(num_joints),
       num_fingers_(num_fingers) {
-  this->DeclareAbstractInputPort();
+  this->DeclareAbstractInputPort(
+      systems::kUseDefaultName,
+      systems::Value<lcmt_jaco_command>{});
   this->DeclareVectorOutputPort(
       systems::BasicVector<double>((num_joints_ + num_fingers_) * 2),
       &JacoCommandReceiver::OutputCommand);
@@ -128,7 +130,9 @@ JacoStatusReceiver::JacoStatusReceiver(int num_joints, int num_fingers)
   this->DeclareVectorOutputPort(
       systems::BasicVector<double>((num_joints_ + num_fingers_) * 2),
       &JacoStatusReceiver::OutputStatus);
-  this->DeclareAbstractInputPort();
+  this->DeclareAbstractInputPort(
+      systems::kUseDefaultName,
+      systems::Value<lcmt_jaco_status>{});
   this->DeclareDiscreteState((num_joints_ + num_fingers_)* 2);
   this->DeclarePeriodicDiscreteUpdate(kJacoLcmStatusPeriod);
 }

--- a/examples/kuka_iiwa_arm/dev/pick_and_place/state_machine_system.cc
+++ b/examples/kuka_iiwa_arm/dev/pick_and_place/state_machine_system.cc
@@ -56,13 +56,23 @@ struct PickAndPlaceStateMachineSystem::InternalState {
 PickAndPlaceStateMachineSystem::PickAndPlaceStateMachineSystem(
     const pick_and_place::PlannerConfiguration& configuration, bool single_move)
     : configuration_(configuration), single_move_(single_move) {
-  input_port_iiwa_state_ = this->DeclareAbstractInputPort().get_index();
-  input_port_iiwa_base_pose_ = this->DeclareAbstractInputPort().get_index();
-  input_port_box_state_ = this->DeclareAbstractInputPort().get_index();
-  input_port_wsg_status_ = this->DeclareAbstractInputPort().get_index();
+  input_port_iiwa_state_ = this->DeclareAbstractInputPort(
+      systems::kUseDefaultName,
+      systems::Value<lcmt_iiwa_status>{}).get_index();
+  input_port_iiwa_base_pose_ = this->DeclareAbstractInputPort(
+      systems::kUseDefaultName,
+      systems::Value<Isometry3<double>>{}).get_index();
+  input_port_box_state_ = this->DeclareAbstractInputPort(
+      systems::kUseDefaultName,
+      systems::Value<robot_state_t>{}).get_index();
+  input_port_wsg_status_ = this->DeclareAbstractInputPort(
+      systems::kUseDefaultName,
+      systems::Value<lcmt_schunk_wsg_status>{}).get_index();
   input_port_table_state_.resize(this->num_tables());
   for (int i = 0; i < this->num_tables(); ++i) {
-    input_port_table_state_[i] = this->DeclareAbstractInputPort().get_index();
+    input_port_table_state_[i] = this->DeclareAbstractInputPort(
+        systems::kUseDefaultName,
+        systems::Value<Isometry3<double>>{}).get_index();
   }
 
   output_port_iiwa_plan_ =

--- a/examples/kuka_iiwa_arm/iiwa_lcm.cc
+++ b/examples/kuka_iiwa_arm/iiwa_lcm.cc
@@ -27,7 +27,9 @@ const double kIiwaLcmStatusPeriod = 0.005;
 
 IiwaCommandReceiver::IiwaCommandReceiver(int num_joints)
     : num_joints_(num_joints) {
-  this->DeclareAbstractInputPort();
+  this->DeclareAbstractInputPort(
+      systems::kUseDefaultName,
+      systems::Value<lcmt_iiwa_command>{});
   this->DeclareVectorOutputPort(
       systems::BasicVector<double>(num_joints_ * 2),
       [this](const Context<double>& c, BasicVector<double>* o) {
@@ -186,7 +188,9 @@ IiwaStatusReceiver::IiwaStatusReceiver(int num_joints)
                   systems::BasicVector<double>(num_joints_ * 3),
                   &IiwaStatusReceiver::OutputDeprecatedMeasuredPosition)
               .get_index()) {
-  this->DeclareAbstractInputPort("lcmt_iiwa_status");
+  this->DeclareAbstractInputPort(
+      "lcmt_iiwa_status",
+      systems::Value<lcmt_iiwa_status>{});
 }
 
 template <std::vector<double> drake::lcmt_iiwa_status::* field>
@@ -360,7 +364,9 @@ IiwaContactResultsToExternalTorque::IiwaContactResultsToExternalTorque(
     }
   }
 
-  this->DeclareAbstractInputPort();
+  this->DeclareAbstractInputPort(
+      systems::kUseDefaultName,
+      systems::Value<systems::ContactResults<double>>{});
 
   this->DeclareVectorOutputPort(
       systems::BasicVector<double>(length),

--- a/examples/valkyrie/robot_command_to_desired_effort_converter.cc
+++ b/examples/valkyrie/robot_command_to_desired_effort_converter.cc
@@ -9,7 +9,9 @@ namespace systems {
 
 RobotCommandToDesiredEffortConverter::RobotCommandToDesiredEffortConverter(
     const std::vector<const RigidBodyActuator*>& actuators)
-    : robot_command_port_index_(DeclareAbstractInputPort().get_index()),
+    : robot_command_port_index_(DeclareAbstractInputPort(
+          kUseDefaultName,
+          systems::Value<bot_core::atlas_command_t>{}).get_index()),
       desired_effort_port_indices_(DeclareDesiredEffortOutputPorts(actuators)) {
   set_name("RobotCommandToDesiredEffortConverter");
 }

--- a/examples/valkyrie/robot_state_decoder.cc
+++ b/examples/valkyrie/robot_state_decoder.cc
@@ -11,7 +11,9 @@ namespace systems {
 
 RobotStateDecoder::RobotStateDecoder(const RigidBodyTree<double>& tree)
     : translator_(tree),
-      robot_state_message_port_index_(DeclareAbstractInputPort().get_index()) {
+      robot_state_message_port_index_(DeclareAbstractInputPort(
+          kUseDefaultName,
+          Value<bot_core::robot_state_t>{}).get_index()) {
   DeclareAbstractOutputPort(
       KinematicsCache<double>(translator_.get_robot().CreateKinematicsCache()),
       &RobotStateDecoder::OutputKinematics);

--- a/examples/valkyrie/robot_state_encoder.cc
+++ b/examples/valkyrie/robot_state_encoder.cc
@@ -33,8 +33,12 @@ RobotStateEncoder::RobotStateEncoder(
           DeclareAbstractOutputPort(&RobotStateEncoder::MakeRobotState,
                                     &RobotStateEncoder::OutputRobotState)
               .get_index()),
-      kinematics_results_port_index_(DeclareAbstractInputPort().get_index()),
-      contact_results_port_index_(DeclareAbstractInputPort().get_index()),
+      kinematics_results_port_index_(DeclareAbstractInputPort(
+          kUseDefaultName,
+          Value<KinematicsResults<double>>{&tree}).get_index()),
+      contact_results_port_index_(DeclareAbstractInputPort(
+          kUseDefaultName,
+          Value<ContactResults<double>>{}).get_index()),
       effort_port_indices_(DeclareEffortInputPorts()),
       force_torque_sensor_info_(ft_sensor_info) {
   int sensor_idx = 0;

--- a/examples/valkyrie/valkyrie_pd_ff_controller.cc
+++ b/examples/valkyrie/valkyrie_pd_ff_controller.cc
@@ -38,7 +38,10 @@ ValkyriePDAndFeedForwardController::ValkyriePDAndFeedForwardController(
       feedforward_torque_(nominal_torque),
       Kp_(Kp),
       Kd_(Kd) {
-  input_port_index_kinematics_result_ = DeclareAbstractInputPort().get_index();
+  input_port_index_kinematics_result_ = DeclareAbstractInputPort(
+      kUseDefaultName,
+      Value<KinematicsCache<double>>(robot.CreateKinematicsCache()))
+          .get_index();
   output_port_index_atlas_command_ =
       DeclareAbstractOutputPort(
           &ValkyriePDAndFeedForwardController::OutputCommand)

--- a/manipulation/perception/optitrack_pose_extractor.cc
+++ b/manipulation/perception/optitrack_pose_extractor.cc
@@ -74,7 +74,9 @@ OptitrackPoseExtractor::OptitrackPoseExtractor(
   DeclareAbstractState(
       systems::AbstractValue::Make<Isometry3<double>>(
           Isometry3<double>::Identity()));
-  this->DeclareAbstractInputPort();
+  this->DeclareAbstractInputPort(
+      systems::kUseDefaultName,
+      systems::Value<optitrack::optitrack_frame_t>());
   // Internal state is an Isometry3d.
   this->DeclarePeriodicUnrestrictedUpdate(optitrack_lcm_status_period, 0);
 }

--- a/manipulation/perception/pose_smoother.cc
+++ b/manipulation/perception/pose_smoother.cc
@@ -110,7 +110,9 @@ PoseSmoother::PoseSmoother(double desired_max_linear_velocity,
   this->DeclareAbstractState(
       systems::AbstractValue::Make<InternalState>(
           InternalState(filter_window_size)));
-  this->DeclareAbstractInputPort();
+  this->DeclareAbstractInputPort(
+      systems::kUseDefaultName,
+      systems::Value<Isometry3d>(Isometry3d::Identity()));
   this->DeclarePeriodicUnrestrictedUpdate(period_sec, 0);
 }
 

--- a/manipulation/planner/robot_plan_interpolator.cc
+++ b/manipulation/planner/robot_plan_interpolator.cc
@@ -50,7 +50,9 @@ struct RobotPlanInterpolator::PlanData {
 RobotPlanInterpolator::RobotPlanInterpolator(
     const std::string& model_path, const InterpolatorType interp_type,
     double update_interval)
-    : plan_input_port_(this->DeclareAbstractInputPort().get_index()),
+    : plan_input_port_(this->DeclareAbstractInputPort(
+          systems::kUseDefaultName,
+          systems::Value<robot_plan_t>()).get_index()),
       interp_type_(interp_type) {
   parsers::urdf::AddModelInstanceFromUrdfFileToWorld(
       model_path, multibody::joints::kFixed, &tree_);

--- a/manipulation/schunk_wsg/schunk_wsg_lcm.cc
+++ b/manipulation/schunk_wsg/schunk_wsg_lcm.cc
@@ -29,7 +29,8 @@ SchunkWsgTrajectoryGenerator::SchunkWsgTrajectoryGenerator(int input_size,
                                      BasicVector<double>(1),
                                      &SchunkWsgTrajectoryGenerator::OutputForce)
                                  .get_index()) {
-  this->DeclareAbstractInputPort();
+  this->DeclareAbstractInputPort(systems::kUseDefaultName,
+                                 systems::Value<lcmt_schunk_wsg_command>());
   this->DeclareInputPort(systems::kVectorValued, input_size);
   // The update period below matches the polling rate from
   // drake-schunk-driver.

--- a/manipulation/util/frame_pose_tracker.cc
+++ b/manipulation/util/frame_pose_tracker.cc
@@ -85,7 +85,8 @@ FramePoseTracker::FramePoseTracker(
 
 void FramePoseTracker::Init() {
   // Abstract input port of type KinematicsResults
-  kinematics_input_port_index_ = this->DeclareAbstractInputPort().get_index();
+  kinematics_input_port_index_ = this->DeclareAbstractInputPort(
+      systems::Value<KinematicsResults<double>>(tree_)).get_index();
 
   // Make our frame ids and declare the output port.
   std::vector<geometry::FrameId> frame_ids;

--- a/perception/depth_image_to_point_cloud.cc
+++ b/perception/depth_image_to_point_cloud.cc
@@ -7,7 +7,9 @@ DepthImageToPointCloud::DepthImageToPointCloud(
     const systems::sensors::CameraInfo& camera_info)
     : camera_info_(camera_info) {
   // input port for depth image
-  input_port_depth_image_index_ = this->DeclareAbstractInputPort().get_index();
+  input_port_depth_image_index_ = this->DeclareAbstractInputPort(
+      systems::kUseDefaultName,
+      systems::Value<systems::sensors::ImageDepth32F>{}).get_index();
 
   /// output port for filtered point cloud
   this->DeclareAbstractOutputPort(

--- a/perception/point_cloud.h
+++ b/perception/point_cloud.h
@@ -86,7 +86,8 @@ class PointCloud final {
   ///   Fields that the point cloud contains.
   /// @param skip_initialize
   ///    Do not default-initialize new values.
-  explicit PointCloud(int new_size, pc_flags::Fields fields = pc_flags::kXYZs,
+  explicit PointCloud(int new_size = 0,
+                      pc_flags::Fields fields = pc_flags::kXYZs,
                       bool skip_initialize = false);
 
   /// Copies another point cloud's fields and data.

--- a/perception/rigid_body_point_cloud_filter.cc
+++ b/perception/rigid_body_point_cloud_filter.cc
@@ -11,7 +11,9 @@ RigidBodyPointCloudFilter::RigidBodyPointCloudFilter(
     RigidBodyTree<double>* tree, double collision_threshold)
     : tree_(tree), collision_threshold_(collision_threshold) {
   // Create input port for point cloud.
-  point_cloud_input_port_index_ = DeclareAbstractInputPort().get_index();
+  point_cloud_input_port_index_ = DeclareAbstractInputPort(
+      systems::kUseDefaultName,
+      systems::Value<PointCloud>{}).get_index();
 
   // Create input port for tree positions and velocities.
   state_input_port_index_ =

--- a/perception/transform_point_cloud.cc
+++ b/perception/transform_point_cloud.cc
@@ -45,7 +45,9 @@ void TransformPointCloud::ApplyTransformToPointCloud(
 
 void TransformPointCloud::CreatePorts() {
   // Create input port for point cloud.
-  point_cloud_input_port_index_ = DeclareAbstractInputPort().get_index();
+  point_cloud_input_port_index_ = DeclareAbstractInputPort(
+      systems::kUseDefaultName,
+      systems::Value<PointCloud>{}).get_index();
 
   // Create input port for state of a RigidBodyTree.
   const int q_dim = tree_.get_num_positions();

--- a/systems/controllers/plan_eval/plan_eval_base_system.cc
+++ b/systems/controllers/plan_eval/plan_eval_base_system.cc
@@ -23,7 +23,9 @@ PlanEvalBaseSystem::PlanEvalBaseSystem(
     : robot_(*robot), control_dt_(dt), alias_groups_(robot) {
   DRAKE_DEMAND(control_dt_ > 0);
 
-  input_port_index_kinematic_state_ = DeclareAbstractInputPort().get_index();
+  input_port_index_kinematic_state_ = DeclareAbstractInputPort(
+      kUseDefaultName,
+      Value<RobotKinematicState<double>>{robot}).get_index();
   output_port_index_qp_input_ =
       DeclareAbstractOutputPort(QpInput(GetDofNames(robot_)),
                                 &PlanEvalBaseSystem::CopyOutQpInput)

--- a/systems/controllers/qp_inverse_dynamics/qp_inverse_dynamics_system.cc
+++ b/systems/controllers/qp_inverse_dynamics/qp_inverse_dynamics_system.cc
@@ -26,8 +26,12 @@ ValueType& get_mutable_value(systems::State<double>* state, int index) {
 QpInverseDynamicsSystem::QpInverseDynamicsSystem(
     const RigidBodyTree<double>* robot, double dt)
     : robot_(*robot), control_dt_(dt) {
-  input_port_index_kinematic_state_ = DeclareAbstractInputPort().get_index();
-  input_port_index_qp_input_ = DeclareAbstractInputPort().get_index();
+  input_port_index_kinematic_state_ = DeclareAbstractInputPort(
+      kUseDefaultName,
+      Value<RobotKinematicState<double>>{robot}).get_index();
+  input_port_index_qp_input_ = DeclareAbstractInputPort(
+      kUseDefaultName,
+      Value<QpInput>{}).get_index();
   output_port_index_qp_output_ =
       DeclareAbstractOutputPort(QpOutput(GetDofNames(robot_)),
                                 &QpInverseDynamicsSystem::CopyOutQpOutput)

--- a/systems/controllers/qp_inverse_dynamics/qp_output_translator_system.cc
+++ b/systems/controllers/qp_inverse_dynamics/qp_output_translator_system.cc
@@ -10,7 +10,8 @@ namespace qp_inverse_dynamics {
 QpOutputTranslatorSystem::QpOutputTranslatorSystem(
     const RigidBodyTree<double>& robot)
     : robot_(robot) {
-  input_port_index_qp_output_ = DeclareAbstractInputPort().get_index();
+  input_port_index_qp_output_ = DeclareAbstractInputPort(
+      kUseDefaultName, Value<QpOutput>()).get_index();
   output_port_index_torque_ =
       DeclareVectorOutputPort(
           systems::BasicVector<double>(robot_.get_num_actuators()),

--- a/systems/lcm/lcm_publisher_system.cc
+++ b/systems/lcm/lcm_publisher_system.cc
@@ -47,7 +47,7 @@ LcmPublisherSystem::LcmPublisherSystem(
     DeclareInputPort("lcm_message", kVectorValued,
                      translator_->get_vector_size());
   } else {
-    DeclareAbstractInputPort("lcm_message");
+    DeclareAbstractInputPort("lcm_message", *serializer_->CreateDefaultValue());
   }
 
   set_name(make_name(channel_));

--- a/systems/lcm/test/lcm_driven_loop_test.cc
+++ b/systems/lcm/test/lcm_driven_loop_test.cc
@@ -35,7 +35,7 @@ class DummySys : public systems::LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DummySys);
   DummySys() {
-    DeclareAbstractInputPort();
+    DeclareAbstractInputPort("lcmt_drake_signal", Value<lcmt_drake_signal>());
     DeclareVectorOutputPort(systems::BasicVector<double>(1),
                             &DummySys::CalcTimestamp);
   }

--- a/systems/lcm/test/lcm_log_playback_test.cc
+++ b/systems/lcm/test/lcm_log_playback_test.cc
@@ -31,7 +31,7 @@ class DummySys : public LeafSystem<double> {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DummySys)
 
   DummySys() {
-    DeclareAbstractInputPort();
+    DeclareAbstractInputPort("lcmt_drake_signal", Value<lcmt_drake_signal>());
     DeclarePerStepEvent<PublishEvent<double>>(
         PublishEvent<double>(Event<double>::TriggerType::kPerStep));
   }


### PR DESCRIPTION
Almost all DeclareAbstractInputPort calls should provide a model value. Only if the system overrides DoAllocateInputAbstract may it be omitted.

This adds most missing allocators with the exception of geometry-related abstract inputs, which will require additional rework.

Relates #9669.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9670)
<!-- Reviewable:end -->
