### PR TITLE
Add required abstract geomery input model values

### DIFF
--- a/automotive/idm_controller.cc
+++ b/automotive/idm_controller.cc
@@ -39,7 +39,9 @@ IdmController<T>::IdmController(const RoadGeometry& road,
           this->DeclareVectorInputPort(PoseVector<T>()).get_index()),
       ego_velocity_index_(
           this->DeclareVectorInputPort(FrameVelocity<T>()).get_index()),
-      traffic_index_(this->DeclareAbstractInputPort().get_index()),
+      traffic_index_(this->DeclareAbstractInputPort(
+          systems::kUseDefaultName, systems::Value<PoseBundle<T>>())
+              .get_index()),
       acceleration_index_(
           this->DeclareVectorOutputPort(systems::BasicVector<T>(1),
                                         &IdmController::CalcAcceleration)

--- a/automotive/mobil_planner.cc
+++ b/automotive/mobil_planner.cc
@@ -40,7 +40,9 @@ MobilPlanner<T>::MobilPlanner(const RoadGeometry& road, bool initial_with_s,
           this->DeclareVectorInputPort(FrameVelocity<T>()).get_index()},
       ego_acceleration_index_{
           this->DeclareVectorInputPort(BasicVector<T>(1)).get_index()},
-      traffic_index_{this->DeclareAbstractInputPort().get_index()},
+      traffic_index_{this->DeclareAbstractInputPort(
+          systems::kUseDefaultName, systems::Value<PoseBundle<T>>())
+              .get_index()},
       lane_index_{
           this->DeclareAbstractOutputPort(&MobilPlanner::CalcLaneDirection)
               .get_index()} {

--- a/examples/scene_graph/BUILD.bazel
+++ b/examples/scene_graph/BUILD.bazel
@@ -32,6 +32,10 @@ drake_cc_library(
 drake_cc_binary(
     name = "bouncing_ball_run_dynamics",
     srcs = ["bouncing_ball_run_dynamics.cc"],
+    add_test_rule = 1,
+    test_rule_args = [
+        "--simulation_time=0.1",
+    ],
     deps = [
         ":bouncing_ball_plant",
         "//geometry:geometry_visualization",
@@ -40,6 +44,7 @@ drake_cc_binary(
         "//systems/framework:diagram",
         "//systems/primitives:constant_vector_source",
         "//systems/primitives:signal_logger",
+        "@gflags",
     ],
 )
 
@@ -71,6 +76,10 @@ drake_cc_library(
 drake_cc_binary(
     name = "solar_system_run_dynamics",
     srcs = ["solar_system_run_dynamics.cc"],
+    add_test_rule = 1,
+    test_rule_args = [
+        "--simulation_time=0.1",
+    ],
     deps = [
         ":solar_system",
         "//geometry:geometry_visualization",
@@ -79,6 +88,7 @@ drake_cc_binary(
         "//systems/framework:diagram",
         "//systems/primitives:constant_vector_source",
         "//systems/primitives:signal_logger",
+        "@gflags",
     ],
 )
 

--- a/examples/scene_graph/bouncing_ball_plant.cc
+++ b/examples/scene_graph/bouncing_ball_plant.cc
@@ -33,7 +33,10 @@ BouncingBallPlant<T>::BouncingBallPlant(SourceId source_id,
   DRAKE_DEMAND(scene_graph != nullptr);
   DRAKE_DEMAND(source_id_.is_valid());
 
-  geometry_query_port_ = this->DeclareAbstractInputPort().get_index();
+  const systems::Value<geometry::QueryObject<T>> query_object(
+      scene_graph->MakeQueryObject());
+  geometry_query_port_ = this->DeclareAbstractInputPort(
+      systems::kUseDefaultName, query_object).get_index();
   state_port_ =
       this->DeclareVectorOutputPort(BouncingBallVector<T>(),
                                     &BouncingBallPlant::CopyStateToOutput)

--- a/examples/scene_graph/bouncing_ball_run_dynamics.cc
+++ b/examples/scene_graph/bouncing_ball_run_dynamics.cc
@@ -1,6 +1,8 @@
 #include <memory>
 #include <utility>
 
+#include <gflags/gflags.h>
+
 #include "drake/examples/scene_graph/bouncing_ball_plant.h"
 #include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/geometry_visualization.h"
@@ -10,6 +12,9 @@
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram.h"
 #include "drake/systems/framework/diagram_builder.h"
+
+DEFINE_double(simulation_time, 10.0,
+              "Desired duration of the simulation in seconds.");
 
 namespace drake {
 namespace examples {
@@ -82,7 +87,7 @@ int do_main() {
   simulator.get_mutable_integrator()->set_maximum_step_size(0.002);
   simulator.set_target_realtime_rate(1.f);
   simulator.Initialize();
-  simulator.StepTo(10);
+  simulator.StepTo(FLAGS_simulation_time);
 
   return 0;
 }
@@ -93,6 +98,7 @@ int do_main() {
 }  // namespace examples
 }  // namespace drake
 
-int main() {
+int main(int argc, char* argv[]) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
   return drake::examples::scene_graph::bouncing_ball::do_main();
 }

--- a/examples/scene_graph/dev/BUILD.bazel
+++ b/examples/scene_graph/dev/BUILD.bazel
@@ -33,6 +33,13 @@ drake_cc_library(
 drake_cc_binary(
     name = "bouncing_ball_run_dynamics",
     srcs = ["bouncing_ball_run_dynamics.cc"],
+    add_test_rule = 1,
+    tags = [
+        "no_lsan",  # It doesn't pass yet.
+    ],
+    test_rule_args = [
+        "--simulation_time=0.1",
+    ],
     deps = [
         ":bouncing_ball_plant",
         "//geometry:scene_graph",
@@ -45,6 +52,7 @@ drake_cc_binary(
         "//systems/primitives:signal_logger",
         "//systems/sensors:image_to_lcm_image_array_t",
         "//systems/sensors/dev:rgbd_camera",
+        "@gflags",
     ],
 )
 
@@ -65,6 +73,10 @@ drake_cc_library(
 drake_cc_binary(
     name = "solar_system_run_dynamics",
     srcs = ["solar_system_run_dynamics.cc"],
+    add_test_rule = 1,
+    test_rule_args = [
+        "--simulation_time=0.1",
+    ],
     deps = [
         ":solar_system",
         "//geometry/dev:geometry_visualization",
@@ -73,6 +85,7 @@ drake_cc_binary(
         "//systems/framework:diagram",
         "//systems/primitives:constant_vector_source",
         "//systems/primitives:signal_logger",
+        "@gflags",
     ],
 )
 

--- a/examples/scene_graph/dev/bouncing_ball_plant.cc
+++ b/examples/scene_graph/dev/bouncing_ball_plant.cc
@@ -33,7 +33,10 @@ BouncingBallPlant<T>::BouncingBallPlant(SourceId source_id,
   DRAKE_DEMAND(scene_graph != nullptr);
   DRAKE_DEMAND(source_id_.is_valid());
 
-  geometry_query_port_ = this->DeclareAbstractInputPort().get_index();
+  const systems::Value<geometry::QueryObject<T>> query_object(
+      scene_graph->MakeQueryObject());
+  geometry_query_port_ = this->DeclareAbstractInputPort(
+      systems::kUseDefaultName, query_object).get_index();
   state_port_ =
       this->DeclareVectorOutputPort(BouncingBallVector<T>(),
                                     &BouncingBallPlant::CopyStateToOutput)

--- a/examples/scene_graph/dev/bouncing_ball_run_dynamics.cc
+++ b/examples/scene_graph/dev/bouncing_ball_run_dynamics.cc
@@ -1,6 +1,8 @@
 #include <memory>
 #include <utility>
 
+#include <gflags/gflags.h>
+
 #include "drake/examples/scene_graph/dev/bouncing_ball_plant.h"
 #include "drake/geometry/dev/geometry_visualization.h"
 #include "drake/geometry/dev/scene_graph.h"
@@ -14,6 +16,9 @@
 #include "drake/systems/lcm/lcm_publisher_system.h"
 #include "drake/systems/sensors/dev/rgbd_camera.h"
 #include "drake/systems/sensors/image_to_lcm_image_array_t.h"
+
+DEFINE_double(simulation_time, 10.0,
+              "Desired duration of the simulation in seconds.");
 
 namespace drake {
 namespace examples {
@@ -143,7 +148,7 @@ int do_main() {
   simulator.get_mutable_integrator()->set_maximum_step_size(0.002);
   simulator.set_target_realtime_rate(1.f);
   simulator.Initialize();
-  simulator.StepTo(10);
+  simulator.StepTo(FLAGS_simulation_time);
 
   return 0;
 }
@@ -154,6 +159,7 @@ int do_main() {
 }  // namespace examples
 }  // namespace drake
 
-int main() {
+int main(int argc, char* argv[]) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
   return drake::examples::scene_graph::bouncing_ball::do_main();
 }

--- a/examples/scene_graph/dev/solar_system_run_dynamics.cc
+++ b/examples/scene_graph/dev/solar_system_run_dynamics.cc
@@ -1,9 +1,14 @@
+#include <gflags/gflags.h>
+
 #include "drake/examples/scene_graph/dev/solar_system.h"
 #include "drake/geometry/dev/geometry_visualization.h"
 #include "drake/geometry/dev/scene_graph.h"
 #include "drake/lcm/drake_lcm.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram_builder.h"
+
+DEFINE_double(simulation_time, 13.0,
+              "Desired duration of the simulation in seconds.");
 
 namespace drake {
 namespace examples {
@@ -36,7 +41,7 @@ int do_main() {
   simulator.set_publish_every_time_step(false);
   simulator.set_target_realtime_rate(1);
   simulator.Initialize();
-  simulator.StepTo(13);
+  simulator.StepTo(FLAGS_simulation_time);
 
   return 0;
 }
@@ -46,4 +51,7 @@ int do_main() {
 }  // namespace examples
 }  // namespace drake
 
-int main() { return drake::examples::solar_system::do_main(); }
+int main(int argc, char* argv[]) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  return drake::examples::solar_system::do_main();
+}

--- a/examples/scene_graph/solar_system_run_dynamics.cc
+++ b/examples/scene_graph/solar_system_run_dynamics.cc
@@ -1,9 +1,14 @@
+#include <gflags/gflags.h>
+
 #include "drake/examples/scene_graph/solar_system.h"
 #include "drake/geometry/geometry_visualization.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/lcm/drake_lcm.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram_builder.h"
+
+DEFINE_double(simulation_time, 13.0,
+              "Desired duration of the simulation in seconds.");
 
 namespace drake {
 namespace examples {
@@ -35,7 +40,7 @@ int do_main() {
   simulator.set_publish_every_time_step(false);
   simulator.set_target_realtime_rate(1);
   simulator.Initialize();
-  simulator.StepTo(13);
+  simulator.StepTo(FLAGS_simulation_time);
 
   return 0;
 }
@@ -45,4 +50,7 @@ int do_main() {
 }  // namespace examples
 }  // namespace drake
 
-int main() { return drake::examples::solar_system::do_main(); }
+int main(int argc, char* argv[]) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  return drake::examples::solar_system::do_main();
+}

--- a/geometry/dev/query_object.h
+++ b/geometry/dev/query_object.h
@@ -261,6 +261,11 @@ class QueryObject {
 
   //@}
 
+  /** (Advanced.)  Ideally, only the SceneGraph should be able to create this
+   class.  However, that is not currently realistic, so we've made it public
+   for the time being. */
+  QueryObject() = default;
+
  private:
   // SceneGraph is the only class that can instantiate QueryObjects.
   friend class SceneGraph<T>;
@@ -268,11 +273,6 @@ class QueryObject {
   friend class QueryObjectTester;
 
   const GeometryState<T>& geometry_state() const;
-
-  // Only the SceneGraph<T> can instantiate this class - it gets
-  // instantiated into a *copyable* default instance (to facilitate allocation
-  // in contexts).
-  QueryObject() = default;
 
   void set(const GeometryContext<T>* context,
            const SceneGraph<T>* scene_graph) {

--- a/geometry/dev/scene_graph.cc
+++ b/geometry/dev/scene_graph.cc
@@ -305,8 +305,10 @@ void SceneGraph<T>::MakeSourcePorts(SourceId source_id) {
   DRAKE_ASSERT(input_source_ids_.count(source_id) == 0);
   // Create and store the input ports for this source id.
   SourcePorts& source_ports = input_source_ids_[source_id];
-  source_ports.pose_port = this->DeclareAbstractInputPort
-      (initial_state_->get_source_name(source_id) + "_pose").get_index();
+  source_ports.pose_port =
+      this->DeclareAbstractInputPort(
+          initial_state_->get_source_name(source_id) + "_pose",
+          Value<FramePoseVector<T>>()).get_index();
 }
 
 template <typename T>

--- a/geometry/frame_kinematics_vector.cc
+++ b/geometry/frame_kinematics_vector.cc
@@ -15,6 +15,10 @@ using std::make_pair;
 using std::move;
 
 template <typename KinematicsValue>
+FrameKinematicsVector<KinematicsValue>::FrameKinematicsVector()
+    : FrameKinematicsVector<KinematicsValue>({}, {}) {}
+
+template <typename KinematicsValue>
 FrameKinematicsVector<KinematicsValue>::FrameKinematicsVector(
     SourceId source_id, const std::vector<FrameId>& ids)
     : source_id_(source_id), values_(0) {

--- a/geometry/frame_kinematics_vector.h
+++ b/geometry/frame_kinematics_vector.h
@@ -171,6 +171,12 @@ class FrameKinematicsVector {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(FrameKinematicsVector)
 
+  // TODO(SeanCurtis-TRI) Find some API language that cautions users that this
+  // result is not terribly useful on its own, but instead it will usually be
+  // assigned into (using operator=) from another FrameKinematicsVector.
+  /** Initializes the vector using an invalid SourceId with no frames .*/
+  FrameKinematicsVector();
+
   /** Initializes the vector on the owned ids.
    @param source_id  The source id of the owning geometry source.
    @param ids        The set of *all* frames owned by this geometry source. All

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -214,8 +214,10 @@ void SceneGraph<T>::MakeSourcePorts(SourceId source_id) {
   DRAKE_ASSERT(input_source_ids_.count(source_id) == 0);
   // Create and store the input ports for this source id.
   SourcePorts& source_ports = input_source_ids_[source_id];
-  source_ports.pose_port = this->DeclareAbstractInputPort
-      (initial_state_->get_source_name(source_id) + "_pose").get_index();
+  source_ports.pose_port =
+      this->DeclareAbstractInputPort(
+          initial_state_->get_source_name(source_id) + "_pose",
+          Value<FramePoseVector<T>>()).get_index();
 }
 
 template <typename T>

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -434,6 +434,12 @@ class SceneGraph final : public systems::LeafSystem<T> {
                                 const GeometrySet& setB);
   //@}
 
+  // TODO(SeanCurtis-TRI) We should make the QueryObject constructor public,
+  // instead of forcing users to call a SceneGraph method to obtain one.
+  /** Constructs an empty QueryObject. This is intended for only only by
+   Systems to pass to DeclareAbstractInputPort as the model_value. */
+  QueryObject<T> MakeQueryObject() const;
+
  private:
   // Friend class to facilitate testing.
   friend class SceneGraphTester;
@@ -460,9 +466,6 @@ class SceneGraph final : public systems::LeafSystem<T> {
   // Allow the load dispatch to peek into SceneGraph.
   friend void DispatchLoadMessage(const SceneGraph<double>&,
                                   lcm::DrakeLcmInterface*);
-
-  // Constructs a QueryObject for OutputPort allocation.
-  QueryObject<T> MakeQueryObject() const;
 
   // Sets the context into the output port value so downstream consumers can
   // perform queries.

--- a/geometry/test/frame_kinematics_vector_test.cc
+++ b/geometry/test/frame_kinematics_vector_test.cc
@@ -20,6 +20,11 @@ namespace test {
                          I.matrix().block<3, 4>(0, 0));
 }
 
+GTEST_TEST(FrameKinematicsVector, DefaultConstructor) {
+  const FramePoseVector<double> dut;
+  EXPECT_FALSE(dut.source_id().is_valid());
+  EXPECT_EQ(dut.size(), 0);
+}
 
 GTEST_TEST(FrameKinematicsVector, Constructor) {
   SourceId source_id = SourceId::get_new_id();

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.cc
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.cc
@@ -1613,8 +1613,11 @@ MultibodyPlant<T>::get_contact_results_output_port() const {
 
 template <typename T>
 void MultibodyPlant<T>::DeclareSceneGraphPorts() {
+  const systems::Value<geometry::QueryObject<T>> query_object(
+      scene_graph_->MakeQueryObject());
   geometry_query_port_ =
-      this->DeclareAbstractInputPort("geometry_query").get_index();
+      this->DeclareAbstractInputPort("geometry_query", query_object)
+          .get_index();
   // This presupposes that the source id has been assigned and _all_ frames have
   // been registered.
   std::vector<FrameId> ids;

--- a/systems/rendering/pose_aggregator.cc
+++ b/systems/rendering/pose_aggregator.cc
@@ -185,7 +185,8 @@ PoseAggregator<T>::DeclareInput(const InputRecord& record) {
     case InputRecord::kSingleVelocity:
       return this->DeclareVectorInputPort(FrameVelocity<T>());
     case InputRecord::kBundle:
-      return this->DeclareAbstractInputPort();
+      return this->DeclareAbstractInputPort(
+          kUseDefaultName, Value<PoseBundle<T>>());
     case InputRecord::kUnknown:
       break;
   }

--- a/systems/rendering/pose_bundle.h
+++ b/systems/rendering/pose_bundle.h
@@ -42,7 +42,7 @@ class PoseBundle {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PoseBundle)
 
-  explicit PoseBundle(int num_poses);
+  explicit PoseBundle(int num_poses = 0);
   ~PoseBundle();
 
   int get_num_poses() const;

--- a/systems/rendering/pose_bundle_to_draw_message.cc
+++ b/systems/rendering/pose_bundle_to_draw_message.cc
@@ -8,7 +8,8 @@ namespace systems {
 namespace rendering {
 
 PoseBundleToDrawMessage::PoseBundleToDrawMessage() {
-  this->DeclareAbstractInputPort();
+  this->DeclareAbstractInputPort(
+      kUseDefaultName, Value<PoseBundle<double>>());
   this->DeclareAbstractOutputPort(
       &PoseBundleToDrawMessage::CalcViewerDrawMessage);
 }

--- a/systems/sensors/dev/rgbd_camera.cc
+++ b/systems/sensors/dev/rgbd_camera.cc
@@ -86,7 +86,8 @@ RgbdCamera::RgbdCamera(const std::string& name, FrameId parent_frame,
 void RgbdCamera::InitPorts(const std::string& name) {
   this->set_name(name);
 
-  query_object_input_port_ = &this->DeclareAbstractInputPort("geometry_query");
+  query_object_input_port_ = &this->DeclareAbstractInputPort(
+      "geometry_query", systems::Value<geometry::dev::QueryObject<double>>{});
 
   ImageRgba8U color_image(color_camera_info_.width(),
                           color_camera_info_.height());

--- a/systems/sensors/optitrack_sender.cc
+++ b/systems/sensors/optitrack_sender.cc
@@ -31,7 +31,9 @@ OptitrackLcmFrameSender::OptitrackLcmFrameSender(
     std::pair<std::string, int>>& frame_map)
     : num_rigid_bodies_(frame_map.size()),
       frame_map_(frame_map) {
-  pose_input_port_index_ = this->DeclareAbstractInputPort().get_index();
+  pose_input_port_index_ = this->DeclareAbstractInputPort(
+      kUseDefaultName,
+      Value<geometry::FramePoseVector<double>>()).get_index();
   this->DeclareAbstractOutputPort(
       optitrack::optitrack_frame_t(),
       &OptitrackLcmFrameSender::PopulatePoseMessage);


### PR DESCRIPTION
Almost all DeclareAbstractInputPort calls should provide a model value.  Only if the system overrides DoAllocateInputAbstract may it be omitted.

This corrects missing allocators for geometry-related inputs.

Relates #9669 and #9670.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9671)
<!-- Reviewable:end -->
