### PR TITLE
solar_system: Disambiguate frames for planets

### DIFF
--- a/examples/scene_graph/solar_system.cc
+++ b/examples/scene_graph/solar_system.cc
@@ -167,50 +167,53 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
 
   // For the full description of the frame labels, see solar_system.h.
 
-  // Earth's frame E lies directly *below* the sun (to account for the
+  // Earth's orbital frame Oe lies directly *below* the sun (to account for the
   // orrery arm).
   const double kEarthBottom = orrery_bottom + 0.25;
-  Isometry3<double> X_SE{Translation3<double>{0, 0, kEarthBottom}};
-  FrameId planet_id =
-      scene_graph->RegisterFrame(source_id_, GeometryFrame("Earth", X_SE));
+  Isometry3<double> X_SOe{Translation3<double>{0, 0, kEarthBottom}};
+  FrameId planet_id = scene_graph->RegisterFrame(
+      source_id_, GeometryFrame("EarthOrbit", X_SOe));
   body_ids_.push_back(planet_id);
-  body_offset_.push_back(X_SE);
+  body_offset_.push_back(X_SOe);
   axes_.push_back(Vector3<double>::UnitZ());
 
-  // The geometry is displaced from the Earth _frame_ so that it orbits.
+  // The geometry is rigidly affixed to Earth's orbital frame so that it moves
+  // in a circular path.
   const double kEarthOrbitRadius = 3.0;
-  Isometry3<double> X_EGe{
+  Isometry3<double> X_OeE{
       Translation3<double>{kEarthOrbitRadius, 0, -kEarthBottom}};
   id = scene_graph->RegisterGeometry(
       source_id_, planet_id,
-      make_unique<GeometryInstance>(X_EGe, make_unique<Sphere>(0.25f),
-                                    "earth"));
+      make_unique<GeometryInstance>(X_OeE, make_unique<Sphere>(0.25f),
+                                    "Earth"));
   scene_graph->AssignRole(source_id_, id,
                           MakeDrakeVisualizerProperties(Vector4d(0, 0, 1, 1)));
   // Earth's orrery arm.
   MakeArm(source_id_, planet_id, kEarthOrbitRadius, -kEarthBottom, pipe_radius,
           post_material, scene_graph);
 
-  // Luna's frame L is at the center of Earth's geometry (Ge). So, X_EL = X_EGe.
-  const Isometry3<double>& X_EL = X_EGe;
-  FrameId luna_id = scene_graph->RegisterFrame(source_id_, planet_id,
-                                               GeometryFrame("Luna", X_EL));
+  // Luna's orbital frame Ol is at the center of Earth's geometry (E).
+  // So, X_OeOl = X_OeE.
+  const Isometry3<double>& X_OeOl = X_OeE;
+  FrameId luna_id = scene_graph->RegisterFrame(
+      source_id_, planet_id, GeometryFrame("LunaOrbit", X_OeOl));
   body_ids_.push_back(luna_id);
-  body_offset_.push_back(X_EL);
-  const Vector3<double> luna_axis_E{1, 1, 1};
-  axes_.push_back(luna_axis_E.normalized());
+  body_offset_.push_back(X_OeOl);
+  const Vector3<double> luna_axis_Oe{1, 1, 1};
+  axes_.push_back(luna_axis_Oe.normalized());
 
-  // The geometry is displaced from Luna's frame so that it orbits.
+  // The geometry is rigidly affixed to Luna's orbital frame so that it moves
+  // in a circular path.
   const double kLunaOrbitRadius = 0.35;
   // Pick a position at kLunaOrbitRadius distance from the Earth's origin on
   // the plane _perpendicular_ to the moon's normal (<1, 1, 1>).
-  // luna_position.dot(luna_axis_E) will be zero.
+  // luna_position.dot(luna_axis_Oe) will be zero.
   Vector3<double> luna_position =
       Vector3<double>(-1, 0.5, 0.5).normalized() * kLunaOrbitRadius;
-  Isometry3<double> X_LGl{Translation3<double>{luna_position}};
+  Isometry3<double> X_OlL{Translation3<double>{luna_position}};
   id = scene_graph->RegisterGeometry(
       source_id_, luna_id, make_unique<GeometryInstance>(
-                               X_LGl, make_unique<Sphere>(0.075f), "luna"));
+          X_OlL, make_unique<Sphere>(0.075f), "Luna"));
   scene_graph->AssignRole(
       source_id_, id,
       MakeDrakeVisualizerProperties(Vector4d(0.5, 0.5, 0.35, 1)));
@@ -218,55 +221,56 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
   // Convex satellite orbits Earth in the same revolution as Luna but with
   // different initial position. See SetDefaultState().
   FrameId convexsat_id = scene_graph->RegisterFrame(source_id_, planet_id,
-                                          GeometryFrame("Convexsat", X_EL));
+                                          GeometryFrame("Convexsat", X_OeOl));
   body_ids_.push_back(convexsat_id);
-  body_offset_.push_back(X_EL);
-  axes_.push_back(luna_axis_E.normalized());
+  body_offset_.push_back(X_OeOl);
+  axes_.push_back(luna_axis_Oe.normalized());
 
   std::string convexsat_absolute_path =
       FindResourceOrThrow("drake/examples/scene_graph/cuboctahedron.obj");
   id = scene_graph->RegisterGeometry(
       source_id_, convexsat_id,
       make_unique<GeometryInstance>(
-          X_LGl, make_unique<Convex>(convexsat_absolute_path, 0.075),
+          X_OlL, make_unique<Convex>(convexsat_absolute_path, 0.075),
           "convexsat"));
   scene_graph->AssignRole(source_id_, id,
                           MakeDrakeVisualizerProperties(Vector4d(1, 1, 0, 1)));
 
   // Box satellite orbits Earth in the same revolution as Luna but with
   // different initial position. See SetDefaultState().
-  FrameId boxsat_id = scene_graph->RegisterFrame(source_id_, planet_id,
-                                                 GeometryFrame("Boxsat", X_EL));
+  FrameId boxsat_id = scene_graph->RegisterFrame(
+      source_id_, planet_id, GeometryFrame("Boxsat", X_OeOl));
   body_ids_.push_back(boxsat_id);
-  body_offset_.push_back(X_EL);
-  axes_.push_back(luna_axis_E.normalized());
+  body_offset_.push_back(X_OeOl);
+  axes_.push_back(luna_axis_Oe.normalized());
 
   id = scene_graph->RegisterGeometry(
       source_id_, boxsat_id,
       make_unique<GeometryInstance>(
-          X_LGl, make_unique<Box>(0.15, 0.15, 0.15), "boxsat"));
+          X_OlL, make_unique<Box>(0.15, 0.15, 0.15), "boxsat"));
   scene_graph->AssignRole(source_id_, id,
                           MakeDrakeVisualizerProperties(Vector4d(1, 0, 1, 1)));
 
-  // Mars's frame M lies directly *below* the sun (to account for the orrery
-  // arm).
-  Isometry3<double> X_SM{Translation3<double>{0, 0, orrery_bottom}};
+  // Mars's orbital frame Om lies directly *below* the sun (to account for the
+  // orrery arm).
+  Isometry3<double> X_SOm{Translation3<double>{0, 0, orrery_bottom}};
   planet_id =
-      scene_graph->RegisterFrame(source_id_, GeometryFrame("Mars", X_SM));
+      scene_graph->RegisterFrame(source_id_, GeometryFrame("MarsOrbit", X_SOm));
   body_ids_.push_back(planet_id);
-  body_offset_.push_back(X_SM);
+  body_offset_.push_back(X_SOm);
   Vector3<double>  mars_axis_S {0, 0.1, 1};
   axes_.push_back(mars_axis_S.normalized());
 
-  // The geometry is displaced from the Mars _frame_ so that it orbits.
+  // The geometry is rigidly affixed to Mars's orbital frame so that it moves
+  // in a circular path.
   const double kMarsOrbitRadius = 5.0;
   const double kMarsSize = 0.24;
-  Isometry3<double> X_MGm{
+  Isometry3<double> X_OmM{
       Translation3<double>{kMarsOrbitRadius, 0, -orrery_bottom}};
   GeometryId mars_geometry_id = scene_graph->RegisterGeometry(
       source_id_, planet_id,
-      make_unique<GeometryInstance>(X_MGm, make_unique<Sphere>(kMarsSize),
-                                    "mars"));
+      make_unique<GeometryInstance>(X_OmM, make_unique<Sphere>(kMarsSize),
+                                    "Mars"));
   scene_graph->AssignRole(
       source_id_, mars_geometry_id,
       MakeDrakeVisualizerProperties(Vector4d(0.9, 0.1, 0, 1)));
@@ -274,11 +278,12 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
   std::string rings_absolute_path =
       FindResourceOrThrow("drake/examples/scene_graph/planet_rings.obj");
   Vector3<double> axis = Vector3<double>(1, 1, 1).normalized();
-  Isometry3<double> X_GmGr(AngleAxis<double>(M_PI / 3, axis));
+  Isometry3<double> X_MR(AngleAxis<double>(M_PI / 3, axis));
   id = scene_graph->RegisterGeometry(
       source_id_, mars_geometry_id,
       make_unique<GeometryInstance>(
-          X_GmGr, make_unique<Mesh>(rings_absolute_path, kMarsSize), "rings"));
+          X_MR, make_unique<Mesh>(rings_absolute_path, kMarsSize),
+          "MarsRings"));
   scene_graph->AssignRole(
       source_id_, id, MakeDrakeVisualizerProperties(Vector4d(0.45, 0.9, 0, 1)));
 
@@ -286,23 +291,23 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
   MakeArm(source_id_, planet_id, kMarsOrbitRadius, -orrery_bottom, pipe_radius,
           post_material, scene_graph);
 
-  // Phobos's frame P is at the center of Mars's geometry (Gm).
-  // So, X_MP = X_MGm. The normal of the plane is negated so it orbits in the
+  // Phobos's orbital frame Op is at the center of Mars (M).
+  // So, X_OmOp = X_OmM. The normal of the plane is negated so it orbits in the
   // opposite direction.
-  const Isometry3<double>& X_MP = X_MGm;
-  FrameId phobos_id = scene_graph->RegisterFrame(source_id_, planet_id,
-                                                 GeometryFrame("phobos", X_MP));
+  const Isometry3<double>& X_OmOp = X_OmM;
+  FrameId phobos_id = scene_graph->RegisterFrame(
+      source_id_, planet_id, GeometryFrame("PhobosOrbit", X_OmOp));
   body_ids_.push_back(phobos_id);
-  body_offset_.push_back(X_MP);
+  body_offset_.push_back(X_OmOp);
   mars_axis_S << 0, 0, -1;
   axes_.push_back(mars_axis_S.normalized());
 
   // The geometry is displaced from the Phobos's frame so that it orbits.
   const double kPhobosOrbitRadius = 0.34;
-  Isometry3<double> X_PGp{Translation3<double>{kPhobosOrbitRadius, 0, 0}};
+  Isometry3<double> X_OpP{Translation3<double>{kPhobosOrbitRadius, 0, 0}};
   id = scene_graph->RegisterGeometry(
       source_id_, phobos_id, make_unique<GeometryInstance>(
-                                 X_PGp, make_unique<Sphere>(0.06f), "phobos"));
+                                 X_OpP, make_unique<Sphere>(0.06f), "Phobos"));
   scene_graph->AssignRole(
       source_id_, id,
       MakeDrakeVisualizerProperties(Vector4d(0.65, 0.6, 0.8, 1)));

--- a/examples/scene_graph/solar_system.h
+++ b/examples/scene_graph/solar_system.h
@@ -46,48 +46,43 @@ namespace solar_system {
  Illustration of the orrery:
 
  Legend:
-     Body Symbol | Meaning
-    :-----------:|:--------------------
-        E - ◯    | Earth
-        L - ◑    | Luna (Earth's moon)
-        M - ◍    | Mars
-        P - ●    | Phobos (Mars's moon)
-
         Frames   | Meaning
     :-----------:|:--------------------
         S        | The sun's frame
-        E        | Earth's orbital frame
-        M        | Mars's orbital frame
-        L        | Luna's orbital frame
-        P        | Phobos's orbital frame
-        Gᵢ       | Frame of geometry; `i ∈ {e, m, l, p, r}` for Earth, Mars, Luna, Phobos, and rings of Mars, respectively.
+        E - ◯    | Earth's frame
+        M - ◍    | Mars's frame
+        L - ◑    | Luna's (Earth's moon) frame
+        P - ●    | Phobos's (Mars's moon) frame
+        Oᵢ       | Body's orbit in a circular path. `i ∈ {e, m, l, p}` for Earth, Mars, Luna, and Phobos, respectively.
 
      Pose Symbol | Meaning
     :-----------:|:--------------------
-       `X_SE`    | Earth's frame E relative to S
-       `X_EGₑ`   | Earth's geometry Gₑ relative to E (placed at the end of the arm)
-       `X_EL`    | Luna's frame L relative to E (X_EL = X_EGₑ)
-       `X_LGₗ`   | Luna's geometry Gₗ relative to L (placed out in orbit)
-       `X_SM`    | Mars's frame M relative to S
-       `X_MGₘ`   | Mars's geometry Gₘ relative to M (placed at the end of the arm)
-       `X_MP`    | Phobos's frame P relative to M (X_MP = X_MGₘ)
-       `X_PGₚ`   | Phobos's geometry Gₚ relative to P (placed out in orbit)
-       `X_GₘGᵣ`  | Mars's rings Gr relative to Mars's geometry Gm (not shown in diagram).
+       `X_SOₑ`   | Earth's orbit Oₑ relative to S
+       `X_OₑE`   | Earth's frame E relative to its orbit Oₑ
+       `X_OₑOₗ`  | Luna's orbit Oₗ relative to Earth's Oₑ
+       `X_OₗL`   | Luna's geometry L relative to its orbit Oₗ
+       `X_SOₘ`   | Mars's orbit Oₘ relative to S
+       `X_OₘM`   | Mars's frame M relative to its orbit Oₘ
+       `X_OₘOₚ`  | Phobos's orbit Oₚ relative to Mars's orbit Oₘ
+       `X_OₚP`   | Phobos's frame P relative to its orbit Oₚ
+       `X_MR`    | Mars's rings R relative to Mars's frame M (not shown in diagram).
 
-<br>
 ```
-   X_EGₑ  X_LGₗ                          X_MGₘ  X_PGₚ
-      ↓   ↓                                ↓   ↓
-      E   L         ▁▁▁                    M   p
-      ◯   ◑        ╱   ╲                   ◍   ●
-X_EL →├───┘       │  S  │           X_MP → ├───┘
-      │            ╲▁▁▁╱                   │
-      │              │                     │
-      └──────────────┤ ← X_SE              │
-                     └─────────────────────┘
-                     ↑
-                    X_SM
+    X_OₑE  X_OₗL                          X_OₘM  X_OₚP
+       ↓   ↓                                ↓   ↓
+       E   L         ▁▁▁                    M   P
+       ◯   ◑        ╱   ╲                   ◍   ●
+X_OₑOₗ→├───┘       │  S  │         X_OₘOₚ → ├───┘
+       │            ╲▁▁▁╱                   │
+       │              │                     │
+       └──────────────┤ ← X_SOₑ             │
+                      └─────────────────────┘
+                      ↑
+                     X_SOₘ
 ```
+
+ The frame of orbit's origin lies at the circle's center and it's z-axis is
+ perpendicular to the plane of the circle.
 
  @tparam T The vector element type, which must be a valid Eigen scalar.
 


### PR DESCRIPTION
Prefer to specialize frame names on orbits, not geometries

In reviewing #9663, it was a bit difficult for me to grasp what frame kinematics the diagram represented. This was due to the overloaded use of plant's orbital frames and their bodies, and (due to this) the fact that orbits were not specialized (they used the planet's initial) while the geometries were (whereas I'd expect geometries that coincide with the body to share that name).

This is an initial suggestion; I can update the code afterwards if/when we agree on something (and after #9663 lands).

Legend doxygen preview @ ca31b3e7a:
> ![image](https://user-images.githubusercontent.com/26719449/50788924-b56a3700-1288-11e9-868b-e1a2acd0c5a6.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9675)
<!-- Reviewable:end -->
