### PR TITLE
framework: Diagnose bad FixInputPort values

### DIFF
--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -711,6 +711,7 @@ drake_cc_googletest(
         ":leaf_context",
         "//common:essential",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
         "//common/test_utilities:is_dynamic_castable",
         "//systems/framework/test_utilities",
     ],

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -2115,6 +2115,52 @@ class System : public SystemBase {
     CheckValidContextT(*context);
   }
 
+  std::function<void(const AbstractValue&)> MakeFixInputPortTypeChecker(
+      InputPortIndex port_index) const final {
+    const InputPort<T>& port = this->get_input_port(port_index);
+    const std::string pathname = this->GetSystemPathname();
+
+    // Note that our lambdas below will capture all necessary items by-value,
+    // so that they do not rely on this System still being alive.  (We do not
+    // allow a Context and System to have pointers to each other.)
+    switch (port.get_data_type()) {
+      case kAbstractValued: {
+        // TODO(jwnimmer-tri) We should type-check abstract values, eventually.
+        return {};
+      }
+      case kVectorValued: {
+        // For vector inputs, check that the size is the same.
+        // TODO(jwnimmer-tri) We should type-check the vector, eventually.
+        const std::unique_ptr<BasicVector<T>> model_vector =
+            this->AllocateInputVector(port);
+        const int expected_size = model_vector->size();
+        return [expected_size, port_index, pathname](
+            const AbstractValue& actual) {
+          const BasicVector<T>* const actual_vector =
+              actual.MaybeGetValue<BasicVector<T>>();
+          if (actual_vector == nullptr) {
+            ThrowInputPortHasWrongType(
+                "FixInputPortTypeCheck", pathname, port_index,
+                NiceTypeName::Get<Value<BasicVector<T>>>(),
+                NiceTypeName::Get(actual));
+          }
+          // Check that vector sizes match.
+          if (actual_vector->size() != expected_size) {
+            ThrowInputPortHasWrongType(
+                "FixInputPortTypeCheck", pathname, port_index,
+                fmt::format("{} with size={}",
+                            NiceTypeName::Get<BasicVector<T>>(),
+                            expected_size),
+                fmt::format("{} with size={}",
+                            NiceTypeName::Get(*actual_vector),
+                            actual_vector->size()));
+          }
+        };
+      }
+    }
+    DRAKE_ABORT();
+  }
+
   // Shared code for updating a vector input port and returning a pointer to its
   // value as a BasicVector<T>, or nullptr if the port is not connected. Throws
   // a logic_error if the port_index is out of range or if the input port is not

--- a/systems/framework/system_base.cc
+++ b/systems/framework/system_base.cc
@@ -151,7 +151,8 @@ void SystemBase::CreateSourceTrackers(ContextBase* context_ptr) const {
   // ports" tracker u to them. Doesn't use TrackerInfo so can't use the lambda.
   for (const auto& iport : input_ports_) {
     detail::SystemBaseContextBaseAttorney::AddInputPort(
-        &context, iport->get_index(), iport->ticket());
+        &context, iport->get_index(), iport->ticket(),
+        MakeFixInputPortTypeChecker(iport->get_index()));
   }
 }
 
@@ -220,10 +221,17 @@ void SystemBase::ThrowNotAVectorInputPort(const char* func,
 void SystemBase::ThrowInputPortHasWrongType(
     const char* func, InputPortIndex port, const std::string& expected_type,
     const std::string& actual_type) const {
+  ThrowInputPortHasWrongType(
+      func, GetSystemPathname(), port, expected_type, actual_type);
+}
+
+void SystemBase::ThrowInputPortHasWrongType(
+    const char* func, const std::string& system_pathname, InputPortIndex port,
+    const std::string& expected_type, const std::string& actual_type) {
   throw std::logic_error(fmt::format(
       "{}: expected value of type {} for input port[{}] "
           "but the actual type was {}. (System {})",
-      FmtFunc(func), expected_type, port, actual_type, GetSystemPathname()));
+      FmtFunc(func), expected_type, port, actual_type, system_pathname));
 }
 
 void SystemBase::ThrowCantEvaluateInputPort(const char* func,

--- a/systems/framework/test/cache_entry_test.cc
+++ b/systems/framework/test/cache_entry_test.cc
@@ -161,6 +161,11 @@ class MySystemBase final : public SystemBase {
 
   void DoCheckValidContext(const ContextBase&) const final {}
 
+  std::function<void(const AbstractValue&)> MakeFixInputPortTypeChecker(
+      InputPortIndex /* unused */) const final {
+    return {};
+  }
+
   const CacheEntry& entry0_;
   const CacheEntry& entry1_;
   const CacheEntry& entry2_;

--- a/systems/framework/test/diagram_context_test.cc
+++ b/systems/framework/test/diagram_context_test.cc
@@ -95,8 +95,8 @@ class DiagramContextTest : public ::testing::Test {
     AddSystem(*system_with_abstract_parameters_, SubsystemIndex(7));
 
     // Fake up some input ports for this diagram.
-    context_->AddInputPort(InputPortIndex(0), DependencyTicket(100));
-    context_->AddInputPort(InputPortIndex(1), DependencyTicket(101));
+    context_->AddInputPort(InputPortIndex(0), DependencyTicket(100), {});
+    context_->AddInputPort(InputPortIndex(1), DependencyTicket(101), {});
 
     context_->MakeState();
     context_->MakeParameters();

--- a/systems/framework/test/fixed_input_port_value_test.cc
+++ b/systems/framework/test/fixed_input_port_value_test.cc
@@ -22,8 +22,8 @@ namespace {
 class MyContextBase : public ContextBase {
  public:
   MyContextBase() {
-    AddInputPort(InputPortIndex(0), DependencyTicket(100));
-    AddInputPort(InputPortIndex(1), DependencyTicket(101));
+    AddInputPort(InputPortIndex(0), DependencyTicket(100), {});
+    AddInputPort(InputPortIndex(1), DependencyTicket(101), {});
   }
   MyContextBase(const MyContextBase&) = default;
 

--- a/systems/framework/test/system_base_test.cc
+++ b/systems/framework/test/system_base_test.cc
@@ -54,6 +54,11 @@ class MySystemBase final : public SystemBase {
       return;
     throw std::logic_error("This Context is totally unacceptable!");
   }
+
+  std::function<void(const AbstractValue&)> MakeFixInputPortTypeChecker(
+      InputPortIndex) const override {
+    return {};
+  }
 };
 
 // Verify that system name methods work properly. Can't fully test the


### PR DESCRIPTION
For now, this only detects fixing a vector input port with the wrong size.  Future revisions could perform type-checking.

Closes #9591.   Relates #9669.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9676)
<!-- Reviewable:end -->
