### PR TITLE
mbp + rbt: Permit welding joint to world; rbt sdf: Support proper sdformat `<frame/>` elements

### DIFF
--- a/attic/multibody/joints/floating_base_types.h
+++ b/attic/multibody/joints/floating_base_types.h
@@ -4,7 +4,26 @@ namespace drake {
 namespace multibody {
 namespace joints {
 
-enum FloatingBaseType { kFixed = 0, kRollPitchYaw = 1, kQuaternion = 2 };
+/// Indicates how unattached links are to be mobilized in the world (fixed or
+/// floating) after parsing.
+enum FloatingBaseType {
+    /// A fixed body will be added to all unattached links. An error will be
+    // triggered if no unattached links are found.
+    kFixed = 0,
+    /// A floating roll-pitch-yaw joint will be added to all unattached links.
+    /// An error will be triggered if no unattached links are found.
+    kRollPitchYaw = 1,
+    /// A floating quaternion joint will be added to all unattached links. An
+    /// error will be triggered if no unattached links are found.
+    kQuaternion = 2,
+    /// (Experimental) Intended for compatibility with MultibodyPlant SDF
+    /// parsing: A floating quaternion joint will be added to all unattached
+    /// links; however, it does not trigger an error if no unattachced links
+    /// are found.
+    /// @warning This is an experimental feature whose functionality and name
+    /// may change before it becomes stable. Please proceed with caution.
+    kExperimentalMultibodyPlantStyle = 3,
+};
 
 }  // namespace joints
 }  // namespace multibody

--- a/attic/multibody/parsers/BUILD.bazel
+++ b/attic/multibody/parsers/BUILD.bazel
@@ -89,6 +89,18 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "rbt_sdf_parser_test",
+    data = [
+        ":test_models",
+    ],
+    deps = [
+        ":parsers",
+        "//common:find_resource",
+        "//common/test_utilities",
+    ],
+)
+
+drake_cc_googletest(
     name = "xml_util_test",
     deps = [
         ":parsers",

--- a/attic/multibody/parsers/parser_common.cc
+++ b/attic/multibody/parsers/parser_common.cc
@@ -20,6 +20,7 @@ namespace drake {
 namespace parsers {
 
 using drake::multibody::joints::FloatingBaseType;
+using drake::multibody::joints::kExperimentalMultibodyPlantStyle;
 using drake::multibody::joints::kFixed;
 using drake::multibody::joints::kRollPitchYaw;
 using drake::multibody::joints::kQuaternion;
@@ -96,7 +97,8 @@ int AddFloatingJoint(
           tree->get_bodies()[i]->setJoint(move(joint));
           num_floating_joints_added++;
         } break;
-        case kQuaternion: {
+        case kQuaternion:
+        case kExperimentalMultibodyPlantStyle: {
           unique_ptr<DrakeJoint> joint(new QuaternionFloatingJoint(
               floating_joint_name, transform_to_world * transform_to_model));
           tree->get_bodies()[i]->setJoint(move(joint));
@@ -108,7 +110,8 @@ int AddFloatingJoint(
     }
   }
 
-  if (num_floating_joints_added == 0) {
+  if (floating_base_type != kExperimentalMultibodyPlantStyle &&
+      num_floating_joints_added == 0) {
     // TODO(liang.fok) Handle this by disconnecting one of the internal nodes,
     // replacing the disconnected joint with a loop joint, and then connecting
     // the newly freed body (i.e., the body without a joint) to the world.

--- a/attic/multibody/parsers/test/rbt_sdf_parser_test.cc
+++ b/attic/multibody/parsers/test/rbt_sdf_parser_test.cc
@@ -1,0 +1,82 @@
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/math/roll_pitch_yaw.h"
+#include "drake/multibody/joints/floating_base_types.h"
+#include "drake/multibody/parsers/sdf_parser.h"
+#include "drake/multibody/rigid_body_tree.h"
+
+namespace drake {
+
+using Eigen::Isometry3d;
+using Eigen::Vector3d;
+using multibody::joints::FloatingBaseType;
+using parsers::sdf::AddModelInstancesFromSdfFileToWorld;
+
+namespace parsers {
+namespace {
+
+// TODO(eric.cousineau): Figure out a core location for a sugar method like
+// this.
+Isometry3d XyzRpy(const Vector3d& xyz, const Vector3d& rpy) {
+  return math::RigidTransform<double>(
+      math::RollPitchYaw<double>(rpy).ToRotationMatrix(), xyz).GetAsIsometry3();
+}
+
+GTEST_TEST(SdfParserTest, ParseFrames) {
+  // Minimal test of backporting *proper* frame parsing from MultibodyPlant to
+  // RigidBodyTree.
+  RigidBodyTree<double> tree;
+  const auto id_table = AddModelInstancesFromSdfFileToWorld(
+      FindResourceOrThrow(
+          "drake/attic/multibody/parsers/test/rbt_sdf_parser_test_model.sdf"),
+      FloatingBaseType::kExperimentalMultibodyPlantStyle, &tree);
+  ASSERT_EQ(id_table.size(), 2);
+  const int world_instance = tree.world().get_model_instance_id();
+  ASSERT_EQ(id_table.at("dummy_model"), world_instance);
+  const int test_instance = id_table.at("sdf_parser_test_model");
+
+  // Check model scope frames.
+  // Backport from MultibodyPlant test:
+  //   multibody/multibody_tree/parsing/test/multibody_plant_sdf_parser_test.cc
+  //   at line 158, git sha 5687173
+  auto cache = tree.doKinematics(tree.getZeroConfiguration());
+  const double eps = std::numeric_limits<double>::epsilon();
+  auto check_frame = [&tree, test_instance, &cache, eps](
+      std::shared_ptr<RigidBodyFrame<double>> parent_frame, std::string name,
+      const Isometry3d& X_PF_expected) {
+    std::shared_ptr<RigidBodyFrame<double>> frame = tree.findFrame(
+        name, test_instance);
+    const Isometry3d X_PF = tree.relativeTransform(
+        cache, parent_frame->get_frame_index(), frame->get_frame_index());
+    EXPECT_TRUE(CompareMatrices(X_PF_expected.matrix(), X_PF.matrix(), eps))
+        << name;
+  };
+
+  const Isometry3d X_L1F1 = XyzRpy(
+      Vector3d(0.1, 0.2, 0.3), Vector3d(0.4, 0.5, 0.6));
+  check_frame(
+      tree.findFrame("link1", test_instance),
+      "model_scope_link1_frame", X_L1F1);
+  const Isometry3d X_F1F2 = XyzRpy(Vector3d(0.1, 0.0, 0.0), Vector3d::Zero());
+  check_frame(
+      tree.findFrame("model_scope_link1_frame", test_instance),
+      "model_scope_link1_frame_child", X_F1F2);
+  // TODO(eric.cousineau): Consider using model frame.
+  const Isometry3d X_MF3 = XyzRpy(Vector3d(0.7, 0.8, 0.9), Vector3d::Zero());
+  auto world_frame = tree.findFrame("world", world_instance);
+  check_frame(world_frame, "model_scope_model_frame_implicit", X_MF3);
+  const Isometry3d X_WF4 = XyzRpy(Vector3d(1.1, 1.2, 1.3), Vector3d::Zero());
+  check_frame(world_frame, "model_scope_world_frame", X_WF4);
+
+  // Old-style frame:
+  const Isometry3d X_L1O1 = XyzRpy(Vector3d(1, 2, 3), Vector3d(4, 5, 6));
+  check_frame(
+      tree.findFrame("link1", test_instance), "old_style_frame", X_L1O1);
+}
+
+}  // namespace
+}  // namespace parsers
+}  // namespace drake

--- a/attic/multibody/parsers/test/rbt_sdf_parser_test_model.sdf
+++ b/attic/multibody/parsers/test/rbt_sdf_parser_test_model.sdf
@@ -1,0 +1,57 @@
+<sdf version='1.6'>
+  <!-- Add a model to ensure `sdf_parser_test_model` does not share the same
+       model instance ID as the world body. -->
+  <model name='dummy_model'>
+    <link name='dummy_link'/>
+  </model>
+
+  <model name='sdf_parser_test_model'>
+    <!-- TODO(eric.cousineau): Make this happen. -->
+    <!-- <pose>10 20 30 0 0 0</pose> -->
+
+    <!-- This is a subset of elements from:
+         //multibody/multibody_tree/parsing/test:links_with_visuals_and_collisions.sdf
+         This is meant to test a subset of porting backwards compatible
+         functionality. -->
+
+    <link name='link1'>
+      <!-- We will denote this link frame as `L1`. -->
+    </link>
+
+    <joint name='weld_link1' type='fixed'>
+      <parent>world</parent>
+      <child>link1</child>
+    </joint>
+
+    <!-- Test new-style frames -->
+    <!-- We will define this frame as `F1`. -->
+    <frame name='model_scope_link1_frame'>
+      <!-- This pose represents `X_L1F1`. -->
+      <pose frame='link1'>0.1 0.2 0.3 0.4 0.5 0.6</pose>
+    </frame>
+    <!-- We will define this frame as `F2`. -->
+    <frame name='model_scope_link1_frame_child'>
+      <!-- This pose represents `X_F1F2`. -->
+      <pose frame='model_scope_link1_frame'>0.1 0 0 0 0 0</pose>
+    </frame>
+    <!-- We will define this frame as `F3`. -->
+    <frame name='model_scope_model_frame_implicit'>
+      <!-- This pose represents `X_MF3`. -->
+      <pose>0.7 0.8 0.9 0 0 0</pose>
+    </frame>
+    <!-- We will define this frame as `F4`. -->
+    <frame name='model_scope_world_frame'>
+      <!-- This pose represents `X_WF4`. -->
+      <pose frame='world'>1.1 1.2 1.3 0 0 0</pose>
+    </frame>
+
+    <!-- Test old (Drake-specific) frames, NOT supported by sdformat
+         (i.e., MultibodyPlant) -->
+    <!-- We will define this frame as `O1`. -->
+    <frame name='old_style_frame'>
+      <link>link1</link>
+      <pose>1 2 3 4 5 6</pose>
+    </frame>
+
+  </model>
+</sdf>

--- a/attic/multibody/rigid_body_frame.cc
+++ b/attic/multibody/rigid_body_frame.cc
@@ -8,8 +8,10 @@
 
 template <typename T>
 RigidBodyFrame<T>::RigidBodyFrame(const std::string& name, RigidBody<T>* body,
-                 const Eigen::Isometry3d& transform_to_body)
-      : name_(name), body_(body), transform_to_body_(transform_to_body) {}
+                 const Eigen::Isometry3d& transform_to_body,
+                 int model_instance_id)
+      : name_(name), body_(body), transform_to_body_(transform_to_body),
+        model_instance_id_(model_instance_id) {}
 
 template <typename T>
 RigidBodyFrame<T>::RigidBodyFrame(const std::string& name, RigidBody<T>* body,
@@ -23,7 +25,11 @@ RigidBodyFrame<T>::RigidBodyFrame(const std::string& name, RigidBody<T>* body,
 
 template <typename T>
 int RigidBodyFrame<T>::get_model_instance_id() const {
-  return body_->get_model_instance_id();
+  if (model_instance_id_ == -1) {
+    return body_->get_model_instance_id();
+  } else {
+    return model_instance_id_;
+  }
 }
 
 template <typename T>

--- a/attic/multibody/rigid_body_frame.h
+++ b/attic/multibody/rigid_body_frame.h
@@ -40,7 +40,8 @@ class RigidBodyFrame final {
   // TODO(amcastro-tri): Remove this constructor. The appropriate signature
   // is described in #4407.
   RigidBodyFrame(const std::string& name, RigidBody<T>* body,
-                 const Eigen::Isometry3d& transform_to_body);
+                 const Eigen::Isometry3d& transform_to_body,
+                 int model_instance_id = -1);
 
   /**
    * A constructor where the transform-to-body is specified using
@@ -177,4 +178,5 @@ class RigidBodyFrame final {
   RigidBody<T>* body_{nullptr};
   Eigen::Isometry3d transform_to_body_;
   int frame_index_ = 0;  // this will be negative, but will also be gone soon!
+  int model_instance_id_ = -1;
 };

--- a/attic/multibody/test/rigid_body_tree/rigid_body_collision_clique_test.cc
+++ b/attic/multibody/test/rigid_body_tree/rigid_body_collision_clique_test.cc
@@ -23,6 +23,7 @@ using std::move;
 using std::unique_ptr;
 using drake::multibody::joints::FloatingBaseType;
 using drake::multibody::joints::kFixed;
+using drake::multibody::joints::kExperimentalMultibodyPlantStyle;
 using drake::multibody::joints::kRollPitchYaw;
 using drake::multibody::joints::kQuaternion;
 
@@ -105,7 +106,8 @@ void JoinBodies(const FloatingBaseType floating_base_type,
       joint.reset(
           new RollPitchYawFloatingJoint(joint_name, transform_to_world));
     } break;
-    case kQuaternion: {
+    case kQuaternion:
+    case kExperimentalMultibodyPlantStyle: {
       joint.reset(new QuaternionFloatingJoint(joint_name, transform_to_world));
     } break;
     default:

--- a/attic/multibody/test/rigid_body_tree_alias_groups_test.cc
+++ b/attic/multibody/test/rigid_body_tree_alias_groups_test.cc
@@ -52,6 +52,7 @@ void TestFullConfig(multibody::joints::FloatingBaseType type) {
   const std::vector<int>& v_indices = alias.get_velocity_group("j_group2");
   switch (type) {
     case drake::multibody::joints::kQuaternion:
+    case drake::multibody::joints::kExperimentalMultibodyPlantStyle:
       EXPECT_EQ(q_indices.size(), 8u);
       EXPECT_EQ(v_indices.size(), 7u);
       EXPECT_EQ(robot->get_position_name(q_indices[0]), "base_x");

--- a/bindings/pydrake/multibody/rigid_body_tree_py.cc
+++ b/bindings/pydrake/multibody/rigid_body_tree_py.cc
@@ -41,14 +41,18 @@ PYBIND11_MODULE(rigid_body_tree, m) {
   py::module::import("pydrake.multibody.shapes");
   py::module::import("pydrake.util.eigen_geometry");
 
+  constexpr auto& joints_doc = doc.drake.multibody.joints;
   py::enum_<FloatingBaseType>(m, "FloatingBaseType",
                               doc.drake.multibody.joints.FloatingBaseType.doc)
     .value("kFixed", FloatingBaseType::kFixed,
-           doc.drake.multibody.joints.FloatingBaseType.kFixed.doc)
+           joints_doc.FloatingBaseType.kFixed.doc)
     .value("kRollPitchYaw", FloatingBaseType::kRollPitchYaw,
-           doc.drake.multibody.joints.FloatingBaseType.kRollPitchYaw.doc)
+           joints_doc.FloatingBaseType.kRollPitchYaw.doc)
     .value("kQuaternion", FloatingBaseType::kQuaternion,
-           doc.drake.multibody.joints.FloatingBaseType.kQuaternion.doc);
+           joints_doc.FloatingBaseType.kQuaternion.doc)
+    .value("kExperimentalMultibodyPlantStyle",
+           FloatingBaseType::kExperimentalMultibodyPlantStyle,
+           joints_doc.FloatingBaseType.kExperimentalMultibodyPlantStyle.doc);
 
   // TODO(eric.cousineau): Try to decouple these APIs so that `rigid_body_tree`
   // and `parsers` do not form a dependency cycle.

--- a/bindings/pydrake/multibody/test/parsers_test.py
+++ b/bindings/pydrake/multibody/test/parsers_test.py
@@ -19,6 +19,21 @@ from pydrake.multibody.rigid_body_tree import (
 
 
 class TestParsers(unittest.TestCase):
+    def test_enum_api(self):
+        # Existence check.
+        enums = [
+            FloatingBaseType.kFixed,
+            FloatingBaseType.kRollPitchYaw,
+            FloatingBaseType.kQuaternion,
+            # WARNING: This is experimental.
+            FloatingBaseType.kExperimentalMultibodyPlantStyle,
+        ]
+        for enum in enums:
+            # Expect a novel value.
+            self.assertEqual(enums.count(enum), 1)
+            # Expect documentation.
+            self.assertGreater(len(enum.__doc__), 0)
+
     def test_urdf(self):
         """Test that an instance of a URDF model can be loaded into a
         RigidBodyTree by passing a complete set of arguments to Drake's URDF

--- a/examples/valkyrie/test/robot_state_encoder_decoder_test.cc
+++ b/examples/valkyrie/test/robot_state_encoder_decoder_test.cc
@@ -241,6 +241,7 @@ void TestEncodeThenDecode(FloatingBaseType floating_base_type) {
       v_non_floating_joint_start_index = 6;
       break;
     case FloatingBaseType::kQuaternion:
+    case FloatingBaseType::kExperimentalMultibodyPlantStyle:
       q_non_floating_joint_start_index = 7;
       v_non_floating_joint_start_index = 6;
       break;

--- a/multibody/multibody_tree/parsing/multibody_plant_sdf_parser.cc
+++ b/multibody/multibody_tree/parsing/multibody_plant_sdf_parser.cc
@@ -422,6 +422,17 @@ void AddLinksFromSpecification(
   }
 }
 
+template <typename T>
+const Frame<T>& GetFrameOrWorldByName(
+    const MultibodyPlant<T>& plant, const std::string& name,
+    ModelInstanceIndex model_instance) {
+  if (name == "world") {
+    return plant.world_frame();
+  } else {
+    return plant.GetFrameByName(name, model_instance);
+  }
+}
+
 void AddFramesFromSpecification(
     ModelInstanceIndex model_instance,
     sdf::ElementPtr parent_element,
@@ -443,7 +454,8 @@ void AddFramesFromSpecification(
       if (!pose_frame_name.empty()) {
         // TODO(eric.cousineau): Prevent instance name from leaking in? Throw
         // an error if a user ever specifies it?
-        pose_frame = &plant->GetFrameByName(pose_frame_name, model_instance);
+        pose_frame = &GetFrameOrWorldByName(
+            *plant, pose_frame_name, model_instance);
       }
       const Isometry3d X_PF =
           ToIsometry3(pose_element->Get<ignition::math::Pose3d>());

--- a/multibody/multibody_tree/parsing/test/links_with_visuals_and_collisions.sdf
+++ b/multibody/multibody_tree/parsing/test/links_with_visuals_and_collisions.sdf
@@ -114,6 +114,12 @@
       </collision>
     </link>
 
+    <!-- Ensure we can weld to the world. -->
+    <joint name='weld_link1' type='fixed'>
+      <parent>world</parent>
+      <child>link1</child>
+    </joint>
+
     <!-- Test frames -->
     <!-- We will define this frame as `F1`. -->
     <frame name='model_scope_link1_frame'>
@@ -131,6 +137,11 @@
     <frame name='model_scope_model_frame_implicit'>
       <!-- This pose represents `X_MF3`. -->
       <pose>0.7 0.8 0.9 0 0 0</pose>
+    </frame>
+    <!-- We will define this frame as `F4`. -->
+    <frame name='model_scope_world_frame'>
+      <!-- This pose represents `X_WF4`. -->
+      <pose frame='world'>1.1 1.2 1.3 0 0 0</pose>
     </frame>
 
     <!-- IMPORTANT NOTE: The model frame is NOT affixed to any particular


### PR DESCRIPTION
Backport of a bit of functionality from #9352, relevant to Anzu development

Still unsure of what to do about model instance shenanigans for base-frame cases.
Perhaps the better way to proceed forward is to prevent that from being parsed at all?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9677)
<!-- Reviewable:end -->
