### PR TITLE
geometry/dev: Corrects sanitizer error in use of rendering SceneGraph

### DIFF
--- a/examples/scene_graph/dev/BUILD.bazel
+++ b/examples/scene_graph/dev/BUILD.bazel
@@ -78,9 +78,6 @@ drake_cc_binary(
     name = "solar_system_run_dynamics",
     srcs = ["solar_system_run_dynamics.cc"],
     add_test_rule = 1,
-    tags = [
-        "no_asan",  # It doesn't pass yet.
-    ],
     test_rule_args = [
         "--simulation_time=0.1",
     ],

--- a/geometry/dev/test/geometry_properties_test.cc
+++ b/geometry/dev/test/geometry_properties_test.cc
@@ -162,6 +162,29 @@ GTEST_TEST(GeometryProperties, GetPropertyOrDefault) {
   read_value = properties.GetPropertyOrDefault("invalid_group", "invalid_prop",
                                                default_value);
   EXPECT_EQ(default_value, read_value);
+
+  // Case: Property exists of different type.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      properties.GetPropertyOrDefault(group_name, prop_name, "test"),
+      std::logic_error,
+      ".*a request to extract a value of type 'std::string' failed .* actual "
+      "type was 'int'.")
+
+  // Using r-values as defaults; this tests both compilability and correctness.
+  properties.AddGroup("strings");
+  properties.AddProperty("strings", "valid_string", "valid_string");
+  const std::string& valid_ref = properties.GetPropertyOrDefault(
+      "strings", "valid_string", "missing");
+  EXPECT_EQ("valid_string", valid_ref);
+
+  // If there is no mis-use of the stack, these should both work and the
+  // sequential invocation will *not* cause the names to collide.
+  const std::string& missing_ref1 = properties.GetPropertyOrDefault(
+      "strings", "missing1", "missing_ref1");
+  const std::string& missing_ref2 = properties.GetPropertyOrDefault(
+      "strings", "missing1", "missing_ref2");
+  EXPECT_EQ("missing_ref1", missing_ref1);
+  EXPECT_EQ("missing_ref2", missing_ref2);
 }
 
 // Tests the unsuccessful access to properties (successful access has been


### PR DESCRIPTION
GeometryProperties had bad semantics for `GetPropertyorDefault` when the default value was a temporary. Proper overload provided to handle temporary default values (documentation and testing likewise updated).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9679)
<!-- Reviewable:end -->
