### PR TITLE
Increase timeout of 'proof_of_life_test' to moderate

### DIFF
--- a/examples/manipulation_station/BUILD.bazel
+++ b/examples/manipulation_station/BUILD.bazel
@@ -41,6 +41,7 @@ drake_cc_binary(
     ],
     add_test_rule = 1,
     test_rule_args = ["--target_realtime_rate=0.0"],
+    test_rule_timeout = "moderate",
     deps = [
         ":station_simulation",
         "//geometry:geometry_visualization",


### PR DESCRIPTION
GCC everything ASan builds are timing out on CI

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9682)
<!-- Reviewable:end -->
