### PR TITLE
New RigidTransform constructor with RollPitchYaw and position vector

### DIFF
--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -69,12 +69,14 @@ PYBIND11_MODULE(math, m) {
       .def(py::init(), doc.RigidTransform.ctor.doc_3)
       .def(py::init<const RotationMatrix<T>&, const Vector3<T>&>(),
            py::arg("R"), py::arg("p"), doc.RigidTransform.ctor.doc_4)
+      .def(py::init<const RollPitchYaw<T>&, const Vector3<T>&>(),
+           py::arg("rpy"), py::arg("p"), doc.RigidTransform.ctor.doc_5)
       .def(py::init<const RotationMatrix<T>&>(), py::arg("R"),
-          doc.RigidTransform.ctor.doc_5)
-      .def(py::init<const Vector3<T>&>(), py::arg("p"),
           doc.RigidTransform.ctor.doc_6)
-      .def(py::init<const Isometry3<T>&>(), py::arg("pose"),
+      .def(py::init<const Vector3<T>&>(), py::arg("p"),
           doc.RigidTransform.ctor.doc_7)
+      .def(py::init<const Isometry3<T>&>(), py::arg("pose"),
+          doc.RigidTransform.ctor.doc_8)
       .def("set", &RigidTransform<T>::set, py::arg("R"), py::arg("p"),
           doc.RigidTransform.set.doc)
       .def("SetFromIsometry3", &RigidTransform<T>::SetFromIsometry3,

--- a/bindings/pydrake/test/math_test.py
+++ b/bindings/pydrake/test/math_test.py
@@ -100,7 +100,9 @@ class TestMath(unittest.TestCase):
         check_equality(mut.RigidTransform(), X_I)
         R_I = mut.RotationMatrix()
         p_I = np.zeros(3)
+        rpy_I = mut.RollPitchYaw(0, 0, 0)
         check_equality(mut.RigidTransform(R=R_I, p=p_I), X_I)
+        check_equality(mut.RigidTransform(rpy=rpy_I, p=p_I), X_I)
         check_equality(mut.RigidTransform(R=R_I), X_I)
         check_equality(mut.RigidTransform(p=p_I), X_I)
         # - Accessors, mutators, and general methods.

--- a/math/rigid_transform.h
+++ b/math/rigid_transform.h
@@ -64,6 +64,18 @@ class RigidTransform {
   /// expressed in frame A.  In monogram notation p is denoted `p_AoBo_A`.
   RigidTransform(const RotationMatrix<T>& R, const Vector3<T>& p) { set(R, p); }
 
+#if 0
+  /// Constructs a %RigidTransform from a RollPitchYaw and a position vector.
+  /// @param[in] rpy a %RollPitchYaw which is a Space-fixed (extrinsic) X-Y-Z
+  /// rotation with "roll-pitch-yaw" angles `[r, p, y]` or equivalently a Body-
+  /// fixed (intrinsic) Z-Y-X rotation with "yaw-pitch-roll" angles `[y, p, r]`.
+  /// @see math::RotationMatrix::RotationMatrix(const RollPitchYaw<T>&)
+  /// @param[in] p position vector from frame A's origin to frame B's origin,
+  /// expressed in frame A.  In monogram notation p is denoted `p_AoBo_A`.
+  RigidTransform(const RollPitchYaw<T>& rpy, const Vector3<T>& p) :
+      RigidTransform(RotationMatrix<T>(rpy), p) {}
+#endif
+
   /// Constructs a %RigidTransform with a given RotationMatrix and a zero
   /// position vector.
   /// @param[in] R rotation matrix relating frames A and B (e.g., `R_AB`).

--- a/math/rigid_transform.h
+++ b/math/rigid_transform.h
@@ -64,7 +64,6 @@ class RigidTransform {
   /// expressed in frame A.  In monogram notation p is denoted `p_AoBo_A`.
   RigidTransform(const RotationMatrix<T>& R, const Vector3<T>& p) { set(R, p); }
 
-#if 0
   /// Constructs a %RigidTransform from a RollPitchYaw and a position vector.
   /// @param[in] rpy a %RollPitchYaw which is a Space-fixed (extrinsic) X-Y-Z
   /// rotation with "roll-pitch-yaw" angles `[r, p, y]` or equivalently a Body-
@@ -74,7 +73,6 @@ class RigidTransform {
   /// expressed in frame A.  In monogram notation p is denoted `p_AoBo_A`.
   RigidTransform(const RollPitchYaw<T>& rpy, const Vector3<T>& p) :
       RigidTransform(RotationMatrix<T>(rpy), p) {}
-#endif
 
   /// Constructs a %RigidTransform with a given RotationMatrix and a zero
   /// position vector.

--- a/math/test/rigid_transform_test.cc
+++ b/math/test/rigid_transform_test.cc
@@ -138,7 +138,6 @@ GTEST_TEST(RigidTransform, RigidTransformConstructorFromPositionVector) {
   EXPECT_TRUE(X.translation() == p);
 }
 
-#if 0
 // Tests constructing a RigidTransform from RollPitchYaw and a position vector.
 GTEST_TEST(RigidTransform, RigidTransformContructorRollPitchYawPositionVector) {
   const RollPitchYaw<double> rpy(1, 2, 3);
@@ -147,7 +146,6 @@ GTEST_TEST(RigidTransform, RigidTransformContructorRollPitchYawPositionVector) {
   EXPECT_TRUE(X.rotation().IsExactlyEqualTo(rpy.ToRotationMatrix()));
   EXPECT_TRUE(X.translation() == position);
 }
-#endif
 
 // Tests getting a 4x4 and 3x4 matrix from a RigidTransform.
 GTEST_TEST(RigidTransform, GetAsMatrices) {

--- a/math/test/rigid_transform_test.cc
+++ b/math/test/rigid_transform_test.cc
@@ -138,6 +138,17 @@ GTEST_TEST(RigidTransform, RigidTransformConstructorFromPositionVector) {
   EXPECT_TRUE(X.translation() == p);
 }
 
+#if 0
+// Tests constructing a RigidTransform from RollPitchYaw and a position vector.
+GTEST_TEST(RigidTransform, RigidTransformContructorRollPitchYawPositionVector) {
+  const RollPitchYaw<double> rpy(1, 2, 3);
+  const Vector3<double> position(4, 5, 6);
+  const RigidTransform<double> X(rpy, position);
+  EXPECT_TRUE(X.rotation().IsExactlyEqualTo(rpy.ToRotationMatrix()));
+  EXPECT_TRUE(X.translation() == position);
+}
+#endif
+
 // Tests getting a 4x4 and 3x4 matrix from a RigidTransform.
 GTEST_TEST(RigidTransform, GetAsMatrices) {
   const RotationMatrix<double> R = GetRotationMatrixB();


### PR DESCRIPTION
Sugar method to facilitate use of RigidTransform class (with unit tests).

EDIT (eric): Resolves #9680

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9684)
<!-- Reviewable:end -->
