### PR TITLE
memcheck also falls victim to nvidia driver issues

### DIFF
--- a/examples/scene_graph/dev/BUILD.bazel
+++ b/examples/scene_graph/dev/BUILD.bazel
@@ -35,7 +35,11 @@ drake_cc_binary(
     srcs = ["bouncing_ball_run_dynamics.cc"],
     add_test_rule = 1,
     tags = [
-        "no_lsan",  # It doesn't pass yet.
+        # These errors seem to arise from OpenGL drivers. The CI errors have
+        # yet to be reproduced locally (although memcheck may produce a
+        # different set of errors locally).
+        "no_lsan",
+        "no_memcheck",
     ],
     test_rule_args = [
         "--simulation_time=0.1",


### PR DESCRIPTION
Address the CI failure on memcheck for the bouncing ball

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9686)
<!-- Reviewable:end -->
