### PR TITLE
Revert a portion of "Add required abstract geomery input model values"

### DIFF
--- a/multibody/multibody_tree/multibody_plant/multibody_plant.cc
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.cc
@@ -1613,11 +1613,8 @@ MultibodyPlant<T>::get_contact_results_output_port() const {
 
 template <typename T>
 void MultibodyPlant<T>::DeclareSceneGraphPorts() {
-  const systems::Value<geometry::QueryObject<T>> query_object(
-      scene_graph_->MakeQueryObject());
   geometry_query_port_ =
-      this->DeclareAbstractInputPort("geometry_query", query_object)
-          .get_index();
+      this->DeclareAbstractInputPort("geometry_query").get_index();
   // This presupposes that the source id has been assigned and _all_ frames have
   // been registered.
   std::vector<FrameId> ids;


### PR DESCRIPTION
This reverts a portion of e4f26a5157f2a19bddfef9392dd13a85290d913b.

During scalar conversion post-finalization, we no longer have a scene graph pointer that we can ask to make QueryObject values for us.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9687)
<!-- Reviewable:end -->
