### PR TITLE
Disable tsan for 'spong_controller_w_lcm_test'

### DIFF
--- a/examples/acrobot/BUILD.bazel
+++ b/examples/acrobot/BUILD.bazel
@@ -200,6 +200,10 @@ drake_cc_binary(
         "spong_controller_w_lcm.cc",
     ],
     add_test_rule = 1,
+    # TODO (betsymcphail): TSan fails in LCM for this test. See issue #9697.
+    tags = [
+        "no_tsan",
+    ],
     test_rule_args = [
         "-time_limit_sec=1.0",
     ],


### PR DESCRIPTION
The test is failing in LCM, see
https://drake-cdash.csail.mit.edu/testDetails.php?test=22032326&build=1066390

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9695)
<!-- Reviewable:end -->
