### PR TITLE
python3: Support Python2 for lcm when being used by drake_visualizer

### DIFF
--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -178,6 +178,8 @@ def add_default_repositories(excludes = [], mirrors = DEFAULT_MIRRORS):
         pycps_repository(name = "pycps", mirrors = mirrors)
     if "python" not in excludes:
         python_repository(name = "python")
+    if "python2" not in excludes:
+        python_repository(name = "python2", compat_version = "2")
     if "python3" not in excludes:
         python3_repository(name = "python3")
     if "qdldl" not in excludes:

--- a/tools/workspace/drake_visualizer/repository.bzl
+++ b/tools/workspace/drake_visualizer/repository.bzl
@@ -95,7 +95,7 @@ licenses([
 py_library(
     name = "drake_visualizer_python_deps",
     deps = [
-        "@lcm//:lcm-python",
+        "@lcm//:lcm-python2",
         "@lcmtypes_bot2_core//:lcmtypes_bot2_core_py",
         # TODO(eric.cousineau): Expose VTK Python libraries here for Linux.
         "@lcmtypes_robotlocomotion//:lcmtypes_robotlocomotion_py",

--- a/tools/workspace/lcm/BUILD.bazel
+++ b/tools/workspace/lcm/BUILD.bazel
@@ -1,6 +1,7 @@
 # -*- python -*-
 
 load("//tools/lint:lint.bzl", "add_lint_tests")
+load("@drake//tools/skylark:drake_py.bzl", "drake_py_unittest")
 
 exports_files(
     [
@@ -8,6 +9,14 @@ exports_files(
         "test/lcm-gen_install_test.py",
     ],
     visibility = ["@lcm//:__pkg__"],
+)
+
+drake_py_unittest(
+    name = "lcm_py2_py3_test",
+    deps = [
+        "@lcm//:lcm-python",
+        "@lcm//:lcm-python2",
+    ],
 )
 
 add_lint_tests(python_lint_extra_srcs = ["test/lcm-gen_install_test.py"])

--- a/tools/workspace/lcm/package.BUILD.bazel
+++ b/tools/workspace/lcm/package.BUILD.bazel
@@ -16,6 +16,11 @@ load(
     "install_files",
 )
 load("@drake//tools/lint:python_lint.bzl", "python_lint")
+load(
+    "@drake//tools/workspace/python:py2_py3.bzl",
+    "py2_py3",
+    "py_select",
+)
 
 licenses([
     "notice",  # BSD-3-Clause
@@ -169,8 +174,20 @@ cc_binary(
     ],
 )
 
-cc_binary(
-    name = "_lcm.so",
+py2_py3(
+    rule = cc_binary,
+    name = "_lcm.@PYTHON_EXT_SUFFIX@",
+    deps = py_select(
+        py2 = [
+            ":lcm",
+            "@python2//:python",
+        ],
+        py3 = [
+            ":lcm",
+            # N.B. This will only run when @python refers to Python3.
+            "@python//:python",
+        ],
+    ),
     srcs = [
         "lcm-python/module.c",
         "lcm-python/pyeventlog.c",
@@ -184,10 +201,6 @@ cc_binary(
     linkshared = 1,
     linkstatic = 1,
     visibility = ["//visibility:private"],
-    deps = [
-        ":lcm",
-        "@python",
-    ],
 )
 
 # Downstream users of lcm-python expect to say "import lcm".  However, in the
@@ -219,10 +232,15 @@ generate_file(
     name = "__init__.py",
     content = """
 import ctypes
-import os.path
+from os.path import realpath
+from sysconfig import get_config_var
+
 import six
-ctypes.cdll.LoadLibrary(os.path.realpath(__path__[0] + '/_lcm.so'))
+
+_ext = get_config_var("EXT_SUFFIX") or get_config_var("SO")
+ctypes.cdll.LoadLibrary(realpath(__path__[0] + '/_lcm' + _ext))
 _filename = __path__[0] + \"/lcm-python/lcm/__init__.py\"
+
 if six.PY2:
     execfile(_filename)
 else:
@@ -233,17 +251,26 @@ else:
     visibility = ["//visibility:private"],
 )
 
-py_library(
-    name = "lcm-python-upstream",
+py2_py3(
+    rule = py_library,
+    name = py_select(
+        py2 = "lcm-python2-upstream",
+        py3 = "lcm-python3-upstream",
+    ),
+    data = ["_lcm.@PYTHON_EXT_SUFFIX@"],
     srcs = ["lcm-python/lcm/__init__.py"],  # Actual code from upstream.
-    data = [":_lcm.so"],
     visibility = ["//visibility:private"],
 )
 
-py_library(
-    name = "lcm-python",
+py2_py3(
+    rule = py_library,
+    alias = "lcm-python",
+    name = py_select(py2 = "lcm-python2", py3 = "lcm-python3"),
+    deps = py_select(
+        py2 = [":lcm-python2-upstream"],
+        py3 = [":lcm-python3-upstream"],
+    ),
     srcs = ["__init__.py"],  # Shim, from the genrule above.
-    deps = [":lcm-python-upstream"],
 )
 
 java_library(
@@ -298,13 +325,23 @@ install_files(
     strip_prefix = ["**/"],
 )
 
-install(
-    name = "install_python",
-    targets = [
-        ":_lcm.so",
-        ":lcm-python-upstream",
-    ],
+py2_py3(
+    rule = install,
+    alias = "install_python",
+    name = py_select(py2 = "install_python2", py3 = "install_python3"),
+    targets = py_select(
+        py2 = [
+            "_lcm.@PYTHON_EXT_SUFFIX@",
+            "lcm-python2-upstream",
+        ],
+        py3 = [
+            "_lcm.@PYTHON_EXT_SUFFIX@",
+            "lcm-python3-upstream",
+        ],
+    ),
     library_dest = "@PYTHON_SITE_PACKAGES@/lcm",
+    # Re-declare for `py2_py3` to intercept.
+    py_dest = "@PYTHON_SITE_PACKAGES@",
     py_strip_prefix = ["lcm-python"],
 )
 
@@ -340,7 +377,10 @@ install(
     deps = [
         ":install_cmake_config",
         ":install_extra_cmake",
+        # Using an alias enables us to install correctly for both Python2 and
+        # Python3.
         ":install_python",
+        ":install_python2",
     ],
 )
 

--- a/tools/workspace/lcm/test/lcm_py2_py3_test.py
+++ b/tools/workspace/lcm/test/lcm_py2_py3_test.py
@@ -1,0 +1,11 @@
+from subprocess import check_call
+import unittest
+
+# This will check the Bazel Python version (2 or 3).
+from lcm import LCM
+
+
+class TestLcmPython2and3(unittest.TestCase):
+    def test_python2(self):
+        # Explicitly check Python2.
+        check_call(["python2", "-c", "from lcm import LCM"])

--- a/tools/workspace/python/py2_py3.bzl
+++ b/tools/workspace/python/py2_py3.bzl
@@ -1,0 +1,107 @@
+load(
+    "@python//:version.bzl",
+    "PYTHON_EXT_SUFFIX",
+    "PYTHON_SITE_PACKAGES_RELPATH",
+    "PYTHON_VERSION",
+)
+load(
+    "@python2//:version.bzl",
+    PYTHON2_EXT_SUFFIX = "PYTHON_EXT_SUFFIX",
+    PYTHON2_SITE_PACKAGES_RELPATH = "PYTHON_SITE_PACKAGES_RELPATH",
+    PYTHON2_VERSION = "PYTHON_VERSION",
+)
+
+_BAZEL = struct(
+    version_field = "py" + PYTHON_VERSION.split(".")[0],
+    ext_suffix = PYTHON_EXT_SUFFIX,
+    major = PYTHON_VERSION.split(".")[0],
+    site_packages = PYTHON_SITE_PACKAGES_RELPATH,
+)
+_PY2 = struct(
+    version_field = "py2",
+    ext_suffix = PYTHON2_EXT_SUFFIX,
+    major = PYTHON2_VERSION.split(".")[0],
+    site_packages = PYTHON2_SITE_PACKAGES_RELPATH,
+)
+
+# Cannot use `type(x) == str`, etc., but can infer from literals?
+_list = type([])
+_str = type("")
+_struct = type(struct())
+
+def py_select(py2, py3):
+    return struct(py2 = py2, py3 = py3)
+
+def py2_py3(
+        rule,
+        alias = None,
+        **kwargs):
+    """
+    Provides Bazel Python and Python2 targets, without duplication or conflict.
+
+    If Bazel is using Python2, only a Python2 target will be defined.
+    If Bazel using Python3, both a Python2 and Python3 target will be defined.
+
+    @param rule
+        Starlark rule (e.g. `py_library`, `cc_binary`).
+    @param alias
+        If specified, will create an alias to the version of the target for
+        Bazel.
+    @param kwargs
+        Arguments for the rule.
+
+    Arguments are resolved in the following fashion:
+    * If an argument's value comes from `py_select`, it will be replaced
+      based on the Python version using the `py2` or `py3` values.
+    * Strings have the following tokens replaced:
+        @PYTHON_SITE_PACKAGES@
+        @PYTHON_EXT_SUFFIX@
+    """
+
+    # Define Python2 target.
+    if _PY2.major != "2":
+        fail("@python2 has the wrong major version: {}".format(_PY2))
+    kwargs_py2 = _format(kwargs, _PY2)
+    rule(**kwargs_py2)
+    alias_actual = kwargs_py2["name"]
+
+    if _BAZEL.major == "3":
+        # Define Python3 target.
+        kwargs_py3 = _format(kwargs, _BAZEL)
+        alias_actual = kwargs_py3["name"]
+        rule(**kwargs_py3)
+
+    # Define alias.
+    if alias:
+        native.alias(
+            name = alias,
+            actual = alias_actual,
+            visibility = kwargs_py2.get("visibility"),
+        )
+
+def _format(raw, build):
+    # Format a dict of arguments for `py2_py3`.
+    out = dict()
+    for key, value in raw.items():
+        if type(value) == _struct:
+            value = getattr(value, build.version_field)
+        out[key] = _format_value(value, build)
+    return out
+
+def _format_value(value, build):
+    # N.B. `str` and `list` do not work in this comparison.
+    if type(value) == _str:
+        return _format_str(value, build)
+    elif type(value) == _list:
+        return [_format_str(x, build) for x in value]
+    else:
+        return value
+
+def _format_str(value, build):
+    subs = (
+        ("@PYTHON_SITE_PACKAGES@", build.site_packages),
+        ("@PYTHON_EXT_SUFFIX@", build.ext_suffix),
+    )
+    for old, new in subs:
+        value = value.replace(old, new)
+    return value

--- a/tools/workspace/python/repository.bzl
+++ b/tools/workspace/python/repository.bzl
@@ -33,17 +33,32 @@ Arguments:
 load("@drake//tools/workspace:execute.bzl", "execute_or_fail", "which")
 load("@drake//tools/workspace:os.bzl", "determine_os")
 
+# bazel - Version for Bazel's version of Python.
+# compat - Version for maintaining compatibility (e.g. with Drake Visualizer).
 _VERSION_SUPPORT_MATRIX = {
-    "ubuntu:16.04": ["2.7"],
-    "ubuntu:18.04": ["2.7"],
-    "macos:10.13": ["2.7"],
-    "macos:10.14": ["2.7"],
+    "ubuntu:16.04": struct(
+        bazel = ["2.7", "3.5"],  # DO NOT MERGE: WIP on 3.5
+        compat = [],
+    ),
+    "ubuntu:18.04": struct(
+        bazel = ["3.5"],  # DO NOT MERGE: Example of what stuff looks like.
+        compat = ["2.7"],
+    ),
+    "macos:10.13": struct(
+        bazel = ["2.7"],
+        compat = [],
+    ),
+    "macos:10.14": struct(
+        bazel = ["2.7"],
+        compat = [],
+    ),
 }
 
 def _repository_python_info(repository_ctx):
     # Using `PYTHON_BIN_PATH` from the environment, determine:
     # - `python` - binary path
     # - `python_config` - configuration binary path
+    # - `ext_suffix` - extension suffix
     # - `site_packages_relpath` - relative to base of FHS
     # - `version` - '{major}.{minor}`
     # - `version_major` - major version
@@ -64,18 +79,24 @@ def _repository_python_info(repository_ctx):
     # interpreter during a repository rule, thus we can only catch mismatch
     # issues via `//tools/workspace/python:py/python_bin_test`.
     if os_result.is_macos:
-        version_supported_major, _ = versions_supported[0].split(".")
+        version_supported_major, _ = versions_supported.bazel[0].split(".")
 
         # N.B. On Mac, `which python{major}.{minor}` may refer to the system
         # Python, not Homebrew Python.
         python_default = "python{}".format(version_supported_major)
     else:
-        python_default = "python{}".format(versions_supported[0])
-    python_from_env = repository_ctx.os.environ.get(
-        "PYTHON_BIN_PATH",
-        python_default,
-    )
-    python = str(which(repository_ctx, python_from_env))
+        python_default = "python{}".format(versions_supported.bazel[0])
+
+    compat_version = repository_ctx.attr.compat_version
+    if compat_version:
+        python = str(which(repository_ctx, "python{}".format(compat_version)))
+    else:
+        python_from_env = repository_ctx.os.environ.get(
+            "PYTHON_BIN_PATH",
+            python_default,
+        )
+        python = str(which(repository_ctx, python_from_env))
+
     version = execute_or_fail(
         repository_ctx,
         [python, "-c", "from sys import version_info as v; print(\"{}.{}\"" +
@@ -90,19 +111,52 @@ def _repository_python_info(repository_ctx):
     python_config = "{}-config".format(python)
 
     # Warn if we do not the correct platform support.
-    if version not in versions_supported:
-        print((
-            "\n\nWARNING: Python {} is not a supported / tested version for " +
-            "use with Drake.\n  Supported versions on {}: {}\n\n"
-        ).format(version, os_key, versions_supported))
+    if not compat_version:
+        if version not in versions_supported.bazel:
+            print("""
+
+WARNING: Python {} is not a supported / tested version for use with Drake.
+  Supported versions on {}: {}
+
+""").format(version, os_key, versions_supported)
+    else:
+        versions_all = sorted(
+            versions_supported.bazel + versions_supported.compat,
+        )
+        if version not in versions_all:
+            print("""
+
+WARNING: Python {} is not a supported compatibility version.
+  Supported compatibility versions on {}: {}
+
+NOTE: Support of a compatibility version of Python does not imply that all of
+Drake buildable and tested against this version.
+
+""".format(version, os_key, versions_all))
 
     site_packages_relpath = "lib/python{}/site-packages".format(version)
+
+    # Get extension.
+    # `python-config` may not provide `--extension-suffix`, so we use raw
+    # Python. Strip the left '.' so that it's easier to see the boundary when
+    # using replacement tokens.
+    ext_suffix = execute_or_fail(
+        repository_ctx,
+        [
+            python,
+            "-c",
+            "from sysconfig import get_config_var; " +
+            "print(get_config_var('EXT_SUFFIX') or get_config_var('SO'))",
+        ],
+    ).stdout.strip().lstrip(".")
+
     return struct(
         python = python,
         python_config = python_config,
         site_packages_relpath = site_packages_relpath,
         version = version,
         version_major = version,
+        ext_suffix = ext_suffix,
         os = os_result,
     )
 
@@ -162,10 +216,12 @@ def _impl(repository_ctx):
 
 PYTHON_BIN_PATH = "{bin_path}"
 PYTHON_VERSION = "{version}"
+PYTHON_EXT_SUFFIX = "{ext_suffix}"
 PYTHON_SITE_PACKAGES_RELPATH = "{site_packages_relpath}"
 """.format(
         bin_path = py_info.python,
         version = py_info.version,
+        ext_suffix = py_info.ext_suffix,
         site_packages_relpath = py_info.site_packages_relpath,
     )
     repository_ctx.file(
@@ -232,6 +288,7 @@ py_library(
 
 python_repository = repository_rule(
     _impl,
+    attrs = {"compat_version": attr.string(default = "")},
     environ = [
         "PYTHON_BIN_PATH",
     ],


### PR DESCRIPTION
For #8352
Towards #9614 

Allows us to use Python2 builds of `director` when building other stuff with Python3.

Install for Python2+3, using [this setup script](https://github.com/EricCousineau-TRI/drake/blob/4bcebed09badf712c4179cda79ee921a6c1863ff/py3_setup.sh):
```
$ bazel run @lcm//:install -- ~+/build/install2
...
-- Installing: /home/eacousineau/proj/tri/repo/branches/drake/py3/drake/build/install2/lib/python2.7/site-packages/lcm/_lcm.so
-- Up-to-date: /home/eacousineau/proj/tri/repo/branches/drake/py3/drake/build/install2/lib/python2.7/site-packages/lcm/__init__.py
...
$ bazel-py3 run @lcm//:install -- ~+/build/install3
...
-- Installing: /home/eacousineau/proj/tri/repo/branches/drake/py3/drake/build/install3/lib/python3.5/site-packages/lcm/_lcm.cpython-35m-x86_64-linux-gnu.so
-- Up-to-date: /home/eacousineau/proj/tri/repo/branches/drake/py3/drake/build/install3/lib/python3.5/site-packages/lcm/__init__.py
-- Installing: /home/eacousineau/proj/tri/repo/branches/drake/py3/drake/build/install3/lib/python2.7/site-packages/lcm/_lcm.so
-- Up-to-date: /home/eacousineau/proj/tri/repo/branches/drake/py3/drake/build/install3/lib/python2.7/site-packages/lcm/__init__.py
...
```

Admittedly, the `py2_py3` macro may be a little too cute for now. If we think it's OK to just always compile LCM in Python2 + Python3, I could just manually expand those targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9699)
<!-- Reviewable:end -->
