### PR TITLE
pydrake doc: Add docs on how to generate docs

### DIFF
--- a/bindings/pydrake/pydrake_pybind.h
+++ b/bindings/pydrake/pydrake_pybind.h
@@ -127,6 +127,7 @@ modules should not re-define this alias at global scope.
 may use `using namespace drake::systems::sensors` within functions or
 anonymous namespaces. Avoid `using namespace` directives otherwise.
 
+@anchor PydrakeDoc
 ## Documentation
 
 Drake uses a modified version of `mkdoc.py` from `pybind11`, where `libclang`
@@ -151,6 +152,14 @@ An example of incorporating docstrings:
                doc.RigidTransform.set_rotation.doc)
       ...
     }
+
+To view the documentation rendered in Sphinx:
+
+    bazel run //bindings/pydrake/doc:serve_sphinx [-- --browser=false]
+
+@note Drake's online Python documentation is generated on Ubuntu Bionic, and it
+is suggested to preview documentation using this platform. Other platforms may
+have slightly different generated documentation.
 
 To see what indices are present, generate and open the docstring header:
 
@@ -181,6 +190,7 @@ the top of its definition, and then defines a custom constructor below this,
 the custom constructor's documentation will be accessible as
 `{symbol}.ctor.doc_3`.
 
+@anchor PydrakeKeepAlive
 ## Keep Alive Behavior
 
 `py::keep_alive` is used heavily throughout this code. For more
@@ -200,6 +210,7 @@ objects from one container to another (e.g. transferring all `System`s
 from `DiagramBuilder` to `Diagram` when calling
 `DiagramBuilder.Build()`).
 
+@anchor PydrakeOverloads
 ## Function Overloads
 
 To bind function overloads, please try the following (in order):
@@ -232,6 +243,7 @@ Some aliases are provided; prefer these to the full spellings.
 this may create ambiguous aliases (especially for GCC). Instead, consider
 an alias.
 
+@anchor PydrakeBazelDebug
 # Interactive Debugging with Bazel
 
 If you would like to interactively debug binding code (using IPython for

--- a/doc/documentation_instructions.rst
+++ b/doc/documentation_instructions.rst
@@ -8,34 +8,36 @@ Documentation Generation Instructions
 :ref:`build Drake from source <build_from_source>`. This is necessary because
 otherwise the various build targets mentioned below will not exist.
 
-This section contains instructions on how to generate Drake's documentation.
-This includes both API documentation
-(`C++ <https://drake.mit.edu/doxygen_cxx/index.html>`_),
-which uses `Doxygen <http://www.stack.nl/~dimitri/doxygen/>`_, and
-`Drake's website <https://drake.mit.edu>`_, which
-uses `Sphinx <http://www.sphinx-doc.org/en/stable/index.html>`_.
+This section contains instructions on how to generate Drake's documentation,
+which uses a combination of
+`Sphinx <http://www.sphinx-doc.org/en/stable/index.html>`_ and
+`Doxygen <https://www.stack.nl/~dimitri/doxygen/>`_.
+This includes API documentation
+(`C++ <https://drake.mit.edu/doxygen_cxx/index.html>`_ and
+`Python <https://drake.mit.edu/pydrake/index.html>`_) and
+`Drake's website <https://drake.mit.edu>`_.
 
 .. _documentation-generation-instructions-bazel:
 
 When using Bazel
 ================
 
-To generate the website (Sphinx) documentation::
+To generate the website and serve it locally with
+`webbrowser <https://docs.python.org/2/library/webbrowser.html>`_::
 
-    $ bazel run //doc:serve_sphinx
+    $ bazel run //doc:serve_sphinx [-- --browser=false]
 
-This will rebuild the website content and serve it to your web browser for
-preview using https://docs.python.org/2/library/webbrowser.html.
+The contents of the website are also available via
+``bazel build //doc:sphinx.zip``.
 
-To merely compile the website into ``bazel-genfiles/doc/sphinx.zip``
-without launching a preview::
-
-    $ bazel build //doc:sphinx.zip
-
-To generate the Doxygen documentation::
+To generate the C++ API documentation::
 
     $ cd drake
     $ doc/doxygen.py [--quick]
 
-To view the generated documentation, open using a web browser to
-``drake/build/drake/doc/doxygen_cxx/html/index.html``
+To generate the Python API documentation::
+
+    $ bazel run //bindings/pydrake/doc:serve_sphinx [-- --browser=false]
+
+The contents of the Python API documentation are also available via
+``bazel build //bindings/pydrake/doc:sphinx.zip``).

--- a/doc/python_bindings.rst
+++ b/doc/python_bindings.rst
@@ -266,7 +266,6 @@ Additionally, you may convert an instance (if the conversion is available) using
 For Developers
 --------------
 
-If you are developing Python bindings, please see the Doxygen page for
-`Python Bindings <https://drake.mit.edu/doxygen_cxx/python_bindings.html>`_.
-This provides information on programming conventions as well as tips for
-debugging.
+If you are developing Python bindings, please see the Doxygen page
+`Python Bindings <https://drake.mit.edu/doxygen_cxx/group__python__bindings.html>`_ which provides information on programming conventions, documentation, tips
+for debugging, and other advice.


### PR DESCRIPTION
Resolves #9657.

Some slight compacting of our doc generation instructions as well.

\cc @SeanCurtis-TRI @mitiguy

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9733)
<!-- Reviewable:end -->
