### PR TITLE
doc: Update FirstOrderTaylorApproximation math to use LaTeX subscripts

### DIFF
--- a/systems/primitives/linear_system.h
+++ b/systems/primitives/linear_system.h
@@ -206,20 +206,20 @@ std::unique_ptr<LinearSystem<double>> Linearize(
 /// A first-order Taylor series approximation to a @p system in the neighborhood
 /// of an arbitrary point.  When Taylor-expanding a system at a non-equilibrium
 /// point, it may be represented either of the form:
-///   @f[ \dot{x} - \dot{x0} = A (x - x0) + B (u - u0), @f]
+///   @f[ \dot{x} - \dot{x_0} = A (x - x_0) + B (u - u_0), @f]
 /// for continuous time, or
-///   @f[ x[n+1] - x0[n+1] = A (x[n] - x0[n]) + B (u[n] - u0[n]), @f]
-/// for discrete time.  As above, we denote x0, u0 to be the nominal state and
-/// input at the provided @p context.  The system description is affine when the
-/// terms @f$ \dot{x0} - A x0 - B u0 @f$ and @f$ x0[n+1] - A x0[n] - B u0[n] @f$
-/// are nonzero.
+///   @f[ x[n+1] - x_0[n+1] = A (x[n] - x_0[n]) + B (u[n] - u_0[n]), @f]
+/// for discrete time.  As above, we denote @f$ x_0, u_0 @f$ to be the nominal
+/// state and input at the provided @p context.  The system description is
+/// affine when the terms @f$ \dot{x_0} - A x_0 - B u_0 @f$ and @f$ x_0[n+1] -
+/// A x_0[n] - B u_0[n] @f$ are nonzero.
 ///
 /// More precisely, let x be a state and u be an input.  This function returns
 /// an AffineSystem of the form:
-///   @f[ \dot{x} = A x + B u + f0, @f] (CT)
-///   @f[ x[n+1] = A x[n] + B u[n] + f0, @f] (DT)
-/// where @f$ f0 = \dot{x0} - A x0 - B u0 @f$ (CT) and
-/// @f$ f0 = x0[n+1] - A x[n] - B u[n] @f$ (DT).
+///   @f[ \dot{x} = A x + B u + f_0, @f] (CT)
+///   @f[ x[n+1] = A x[n] + B u[n] + f_0, @f] (DT)
+/// where @f$ f_0 = \dot{x_0} - A x_0 - B u_0 @f$ (CT) and
+/// @f$ f_0 = x_0[n+1] - A x[n] - B u[n] @f$ (DT).
 ///
 /// This method currently supports approximating around at most a single vector
 /// input port and at most a single vector output port.  For systems with
@@ -239,7 +239,8 @@ std::unique_ptr<LinearSystem<double>> Linearize(
 /// continuous or (only) discrete time with a single periodic update.
 ///
 /// Note that x, u and y are in the same coordinate system as the original
-/// @p system, since the terms involving x0, u0 reside in f0.
+/// @p system, since the terms involving @f$ x_0, u_0 @f$ reside in
+/// @f$ f_0 @f$.
 ///
 /// @ingroup primitive_systems
 ///


### PR DESCRIPTION
Noticed this when reviewing #9703. Before:
> ![image](https://user-images.githubusercontent.com/26719449/47224737-369ce680-d38a-11e8-9f3f-363b17d0afeb.png)
After:
> ![image](https://user-images.githubusercontent.com/26719449/47224719-27b63400-d38a-11e8-87c2-5eea151dbc79.png)

The "Before" bit showed up the same in Sphinx. I'm fairly confident it'll show up properly after #9703 lands.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9734)
<!-- Reviewable:end -->
