### PR TITLE
pydrake: Remove forwarding modules (for doc), simplify module naming

### DIFF
--- a/bindings/BUILD.bazel
+++ b/bindings/BUILD.bazel
@@ -20,7 +20,6 @@ package(default_visibility = [
 drake_pybind_library(
     name = "bazel_workaround_4594_libdrake_py",
     add_install = False,
-    cc_so_name = "bazel_workaround_4594_libdrake",
     cc_srcs = ["bazel_workaround_4594_libdrake_py.cc"],
     # Since `package_info` must be a `struct`, we must define this in a `*.bzl`
     # file.

--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -104,7 +104,6 @@ drake_pybind_library(
         "//bindings/pydrake/util:deprecation_py",
     ],
     py_srcs = [
-        "autodiffutils.py",
         "forwarddiff.py",
     ],
 )
@@ -116,7 +115,6 @@ drake_pybind_library(
         "//bindings/pydrake/systems:systems_pybind",
         "//bindings/pydrake/util:wrap_pybind",
     ],
-    cc_so_name = "automotive",
     cc_srcs = ["automotive_py.cc"],
     package_info = PACKAGE_INFO,
 )
@@ -140,7 +138,6 @@ drake_pybind_library(
         "//bindings/pydrake/util:deprecation_pybind",
         "//lcmtypes:viewer",
     ],
-    cc_so_name = "geometry",
     cc_srcs = ["geometry_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
@@ -156,7 +153,6 @@ drake_pybind_library(
         "//bindings/pydrake:documentation_pybind",
         "//bindings/pydrake/util:drake_optional_pybind",
     ],
-    cc_so_name = "lcm",
     cc_srcs = ["lcm_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
@@ -167,7 +163,6 @@ drake_pybind_library(
 drake_pybind_library(
     name = "math_py",
     cc_deps = ["//bindings/pydrake:documentation_pybind"],
-    cc_so_name = "math",
     cc_srcs = ["math_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
@@ -197,13 +192,12 @@ drake_pybind_library(
         "//bindings/pydrake/util:compatibility_py",
         "//bindings/pydrake/util:deprecation_py",
     ],
-    py_srcs = ["symbolic.py"],
+    py_srcs = ["_symbolic_extra.py"],
 )
 
 drake_pybind_library(
     name = "trajectories_py",
     cc_deps = ["//bindings/pydrake:documentation_pybind"],
-    cc_so_name = "trajectories",
     cc_srcs = ["trajectories_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
@@ -277,7 +271,11 @@ drake_py_unittest(
 drake_py_library(
     name = "algebra_test_util_py",
     testonly = 1,
-    srcs = ["test/algebra_test_util.py"],
+    srcs = [
+        "test/__init__.py",
+        "test/algebra_test_util.py",
+    ],
+    visibility = ["//visibility:private"],
 )
 
 # Test ODR (One Definition Rule).
@@ -292,6 +290,8 @@ drake_pybind_library(
     cc_so_name = "test/autodiffutils_test_util",
     cc_srcs = ["test/autodiffutils_test_util_py.cc"],
     package_info = PACKAGE_INFO,
+    py_srcs = ["test/__init__.py"],
+    visibility = ["//visibility:private"],
 )
 
 drake_py_unittest(
@@ -315,6 +315,8 @@ drake_pybind_library(
     cc_so_name = "test/odr_test_module",
     cc_srcs = ["test/odr_test_module_py.cc"],
     package_info = PACKAGE_INFO,
+    py_srcs = ["test/__init__.py"],
+    visibility = ["//visibility:private"],
 )
 
 drake_py_unittest(

--- a/bindings/pydrake/_symbolic_extra.py
+++ b/bindings/pydrake/_symbolic_extra.py
@@ -1,11 +1,6 @@
-from __future__ import absolute_import, division, print_function
-
+# See `ExecuteExtraPythonCode` in `pydrake_pybind.h` for usage details and
+# rationale.
 import functools
-
-from ._symbolic_py import *
-
-# Explicitly import private symbols
-from ._symbolic_py import __logical_and, __logical_or
 
 
 def logical_and(*formulas):

--- a/bindings/pydrake/autodiffutils.py
+++ b/bindings/pydrake/autodiffutils.py
@@ -1,3 +1,0 @@
-from __future__ import absolute_import, division, print_function
-
-from ._autodiffutils_py import *

--- a/bindings/pydrake/autodiffutils_py.cc
+++ b/bindings/pydrake/autodiffutils_py.cc
@@ -14,7 +14,7 @@ using std::cos;
 namespace drake {
 namespace pydrake {
 
-PYBIND11_MODULE(_autodiffutils_py, m) {
+PYBIND11_MODULE(autodiffutils, m) {
   m.doc() = "Bindings for Eigen AutoDiff Scalars";
 
   // Install NumPy warning filtres.

--- a/bindings/pydrake/doc/pydrake.autodiffutils.rst
+++ b/bindings/pydrake/doc/pydrake.autodiffutils.rst
@@ -5,6 +5,5 @@ pydrake.autodiffutils
 
 .. automodule:: pydrake.autodiffutils
     :members:
-    :imported-members:
     :undoc-members:
     :show-inheritance:

--- a/bindings/pydrake/doc/pydrake.examples.multibody.cart_pole_passive_simulation.rst
+++ b/bindings/pydrake/doc/pydrake.examples.multibody.cart_pole_passive_simulation.rst
@@ -6,3 +6,4 @@ pydrake.examples.multibody.cart\_pole\_passive\_simulation
 .. automodule:: pydrake.examples.multibody.cart_pole_passive_simulation
     :members:
     :undoc-members:
+    :show-inheritance:

--- a/bindings/pydrake/doc/pydrake.examples.multibody.rst
+++ b/bindings/pydrake/doc/pydrake.examples.multibody.rst
@@ -12,3 +12,4 @@ pydrake.examples.multibody
 .. automodule:: pydrake.examples.multibody
     :members:
     :undoc-members:
+    :show-inheritance:

--- a/bindings/pydrake/doc/pydrake.examples.rst
+++ b/bindings/pydrake/doc/pydrake.examples.rst
@@ -8,6 +8,7 @@ pydrake.examples
 
     pydrake.examples.acrobot
     pydrake.examples.compass_gait
+    pydrake.examples.multibody
     pydrake.examples.pendulum
     pydrake.examples.rimless_wheel
     pydrake.examples.van_der_pol

--- a/bindings/pydrake/doc/pydrake.manipulation.rst
+++ b/bindings/pydrake/doc/pydrake.manipulation.rst
@@ -8,6 +8,7 @@ pydrake.manipulation
 
     pydrake.manipulation.all
     pydrake.manipulation.planner
+    pydrake.manipulation.simple_ui
 
 
 .. automodule:: pydrake.manipulation

--- a/bindings/pydrake/doc/pydrake.manipulation.simple_ui.rst
+++ b/bindings/pydrake/doc/pydrake.manipulation.simple_ui.rst
@@ -1,0 +1,9 @@
+.. GENERATED FILE DO NOT EDIT
+
+pydrake.manipulation.simple\_ui
+===============================
+
+.. automodule:: pydrake.manipulation.simple_ui
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/bindings/pydrake/doc/pydrake.solvers.ik.rst
+++ b/bindings/pydrake/doc/pydrake.solvers.ik.rst
@@ -5,6 +5,5 @@ pydrake.solvers.ik
 
 .. automodule:: pydrake.solvers.ik
     :members:
-    :imported-members:
     :undoc-members:
     :show-inheritance:

--- a/bindings/pydrake/doc/pydrake.solvers.mathematicalprogram.rst
+++ b/bindings/pydrake/doc/pydrake.solvers.mathematicalprogram.rst
@@ -5,6 +5,5 @@ pydrake.solvers.mathematicalprogram
 
 .. automodule:: pydrake.solvers.mathematicalprogram
     :members:
-    :imported-members:
     :undoc-members:
     :show-inheritance:

--- a/bindings/pydrake/doc/pydrake.symbolic.rst
+++ b/bindings/pydrake/doc/pydrake.symbolic.rst
@@ -5,6 +5,5 @@ pydrake.symbolic
 
 .. automodule:: pydrake.symbolic
     :members:
-    :imported-members:
     :undoc-members:
     :show-inheritance:

--- a/bindings/pydrake/doc/pydrake.systems.lcm.rst
+++ b/bindings/pydrake/doc/pydrake.systems.lcm.rst
@@ -5,6 +5,5 @@ pydrake.systems.lcm
 
 .. automodule:: pydrake.systems.lcm
     :members:
-    :imported-members:
     :undoc-members:
     :show-inheritance:

--- a/bindings/pydrake/doc/refresh_doc_modules.py
+++ b/bindings/pydrake/doc/refresh_doc_modules.py
@@ -15,6 +15,7 @@ from pydrake.examples import (
     rimless_wheel,
     van_der_pol,
 )
+from pydrake.examples.multibody import cart_pole_passive_simulation
 # TODO(eric.cousineau): Indicate these as deprecated.
 from pydrake.util import (
     cpp_const,
@@ -58,7 +59,9 @@ def has_cc_imported_symbols(name):
         sub = pieces[-1]
         test = ".".join(pieces[:-1] + ["_{}_py".format(sub)])
         if test in sys.modules:
-            return True
+            raise RuntimeError(
+                ("The module `{}` should not exist; instead, only `{}` should "
+                 "exist").format(test, name))
     return False
 
 

--- a/bindings/pydrake/examples/BUILD.bazel
+++ b/bindings/pydrake/examples/BUILD.bazel
@@ -37,7 +37,6 @@ drake_pybind_library(
         "//bindings/pydrake:documentation_pybind",
         "//examples/acrobot:acrobot_plant",
     ],
-    cc_so_name = "acrobot",
     cc_srcs = ["acrobot_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
@@ -52,7 +51,6 @@ drake_pybind_library(
         "//bindings/pydrake:documentation_pybind",
         "//examples/compass_gait",
     ],
-    cc_so_name = "compass_gait",
     cc_srcs = ["compass_gait_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
@@ -67,7 +65,6 @@ drake_pybind_library(
         "//bindings/pydrake:documentation_pybind",
         "//examples/manipulation_station:station_simulation",
     ],
-    cc_so_name = "manipulation_station",
     cc_srcs = ["manipulation_station_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
@@ -83,7 +80,6 @@ drake_pybind_library(
         "//bindings/pydrake:documentation_pybind",
         "//examples/pendulum:pendulum_plant",
     ],
-    cc_so_name = "pendulum",
     cc_srcs = ["pendulum_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
@@ -98,7 +94,6 @@ drake_pybind_library(
         "//bindings/pydrake:documentation_pybind",
         "//examples/rimless_wheel",
     ],
-    cc_so_name = "rimless_wheel",
     cc_srcs = ["rimless_wheel_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
@@ -113,7 +108,6 @@ drake_pybind_library(
         "//bindings/pydrake:documentation_pybind",
         "//examples/van_der_pol",
     ],
-    cc_so_name = "van_der_pol",
     cc_srcs = ["van_der_pol_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [

--- a/bindings/pydrake/maliput/BUILD.bazel
+++ b/bindings/pydrake/maliput/BUILD.bazel
@@ -42,7 +42,6 @@ drake_pybind_library(
         "//bindings/pydrake:documentation_pybind",
         "//bindings/pydrake/util:wrap_pybind",
     ],
-    cc_so_name = "api",
     cc_srcs = ["api_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
@@ -53,7 +52,6 @@ drake_pybind_library(
 drake_pybind_library(
     name = "dragway_py",
     cc_deps = ["//bindings/pydrake:documentation_pybind"],
-    cc_so_name = "dragway",
     cc_srcs = ["dragway_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [

--- a/bindings/pydrake/manipulation/BUILD.bazel
+++ b/bindings/pydrake/manipulation/BUILD.bazel
@@ -38,7 +38,6 @@ drake_pybind_library(
         "//bindings/pydrake/util:drake_optional_pybind",
         "//bindings/pydrake/util:eigen_pybind",
     ],
-    cc_so_name = "planner",
     cc_srcs = ["planner_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [

--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -34,7 +34,6 @@ drake_py_library(
 drake_pybind_library(
     name = "benchmarks_py",
     cc_deps = ["//bindings/pydrake:documentation_pybind"],
-    cc_so_name = "benchmarks",
     cc_srcs = ["benchmarks_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
@@ -53,7 +52,6 @@ drake_pybind_library(
         "//bindings/pydrake/util:eigen_geometry_pybind",
         "//bindings/pydrake/util:type_safe_index_pybind",
     ],
-    cc_so_name = "multibody_tree",
     cc_srcs = ["multibody_tree_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
@@ -67,7 +65,6 @@ drake_pybind_library(
 drake_pybind_library(
     name = "parsers_py",
     cc_deps = ["//bindings/pydrake:documentation_pybind"],
-    cc_so_name = "parsers",
     cc_srcs = ["parsers_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
@@ -82,7 +79,6 @@ drake_pybind_library(
         "//bindings/pydrake/systems:systems_pybind",
         "//lcmtypes:viewer",
     ],
-    cc_so_name = "rigid_body_plant",
     cc_srcs = ["rigid_body_plant_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
@@ -100,7 +96,6 @@ drake_pybind_library(
         "//bindings/pydrake:documentation_pybind",
         "//bindings/pydrake/util:type_pack",
     ],
-    cc_so_name = "rigid_body_tree",
     cc_srcs = ["rigid_body_tree_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
@@ -118,7 +113,6 @@ drake_pybind_library(
 drake_pybind_library(
     name = "collision_py",
     cc_deps = ["//bindings/pydrake:documentation_pybind"],
-    cc_so_name = "collision",
     cc_srcs = ["collision_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
@@ -134,7 +128,6 @@ drake_pybind_library(
         "//bindings/pydrake:documentation_pybind",
         "//bindings/pydrake/util:eigen_geometry_pybind",
     ],
-    cc_so_name = "joints",
     cc_srcs = ["joints_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
@@ -146,7 +139,6 @@ drake_pybind_library(
 drake_pybind_library(
     name = "rigid_body_py",
     cc_deps = ["//bindings/pydrake:documentation_pybind"],
-    cc_so_name = "rigid_body",
     cc_srcs = ["rigid_body_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
@@ -158,7 +150,6 @@ drake_pybind_library(
 drake_pybind_library(
     name = "shapes_py",
     cc_deps = ["//bindings/pydrake:documentation_pybind"],
-    cc_so_name = "shapes",
     cc_srcs = ["shapes_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
@@ -173,7 +164,6 @@ drake_pybind_library(
         "//bindings/pydrake:documentation_pybind",
         "//bindings/pydrake:symbolic_types_pybind",
     ],
-    cc_so_name = "inverse_kinematics",
     cc_srcs = ["inverse_kinematics_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [

--- a/bindings/pydrake/pydrake_pybind.h
+++ b/bindings/pydrake/pydrake_pybind.h
@@ -322,6 +322,13 @@ struct overload_cast_impl {
 template <typename Return, typename... Args>
 constexpr auto overload_cast_explicit = overload_cast_impl<Return, Args...>{};
 
+/// Executes Python code to introduce additional symbols for a given module.
+/// For a module with local name `{name}`, the code executed will be
+/// `_{name}_extra.py`. See #9599 for relevant background.
+inline void ExecuteExtraPythonCode(py::module m) {
+  py::module::import("pydrake").attr("_execute_extra_python_code")(m);
+}
+
 #if PY_MAJOR_VERSION >= 3
 // The following works around pybind11 modules getting reconstructed /
 // reimported in Python3. See pybind/pybind11#1559 for more details.

--- a/bindings/pydrake/solvers/BUILD.bazel
+++ b/bindings/pydrake/solvers/BUILD.bazel
@@ -42,7 +42,7 @@ drake_pybind_library(
     py_deps = [
         "//bindings/pydrake/multibody:rigid_body_tree_py",
     ],
-    py_srcs = ["ik.py"],
+    py_srcs = ["_ik_extra.py"],
 )
 
 # TODO(eric.cousineau): Rename `mathematicalprogram` to
@@ -62,13 +62,11 @@ drake_pybind_library(
         "//bindings/pydrake:autodiffutils_py",
         "//bindings/pydrake:symbolic_py",
     ],
-    py_srcs = ["mathematicalprogram.py"],
 )
 
 drake_pybind_library(
     name = "gurobi_py",
     cc_deps = ["//bindings/pydrake:documentation_pybind"],
-    cc_so_name = "gurobi",
     cc_srcs = ["gurobi_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [":mathematicalprogram_py"],
@@ -77,7 +75,6 @@ drake_pybind_library(
 drake_pybind_library(
     name = "ipopt_py",
     cc_deps = ["//bindings/pydrake:documentation_pybind"],
-    cc_so_name = "ipopt",
     cc_srcs = ["ipopt_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [":mathematicalprogram_py"],
@@ -86,7 +83,6 @@ drake_pybind_library(
 drake_pybind_library(
     name = "mosek_py",
     cc_deps = ["//bindings/pydrake:documentation_pybind"],
-    cc_so_name = "mosek",
     cc_srcs = ["mosek_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [":mathematicalprogram_py"],
@@ -95,7 +91,6 @@ drake_pybind_library(
 drake_pybind_library(
     name = "osqp_py",
     cc_deps = ["//bindings/pydrake:documentation_pybind"],
-    cc_so_name = "osqp",
     cc_srcs = ["osqp_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [":mathematicalprogram_py"],

--- a/bindings/pydrake/solvers/_ik_extra.py
+++ b/bindings/pydrake/solvers/_ik_extra.py
@@ -1,26 +1,8 @@
+# See `ExecuteExtraPythonCode` in `pydrake_pybind.h` for usage details and
+# rationale.
 from __future__ import absolute_import, division, print_function
 
 import numpy as np
-
-from ._ik_py import (IKResults,
-                     IKoptions,
-                     InverseKin,
-                     InverseKinTraj,
-                     InverseKinPointwise,
-                     PostureConstraint,
-                     RelativePositionConstraint,
-                     RelativeQuatConstraint,
-                     WorldEulerConstraint,
-                     WorldQuatConstraint,
-                     WorldGazeDirConstraint,
-                     WorldGazeTargetConstraint,
-                     RelativeGazeDirConstraint,
-                     MinDistanceConstraint,
-                     QuasiStaticConstraint)
-
-from ._ik_py import WorldPositionConstraint as _WorldPositionConstraint
-from ._ik_py import WorldPositionInFrameConstraint as \
-    _WorldPositionInFrameConstraint
 
 
 class WorldPositionConstraint(_WorldPositionConstraint):

--- a/bindings/pydrake/solvers/ik_py.cc
+++ b/bindings/pydrake/solvers/ik_py.cc
@@ -11,7 +11,7 @@
 namespace drake {
 namespace pydrake {
 
-PYBIND11_MODULE(_ik_py, m) {
+PYBIND11_MODULE(ik, m) {
   m.doc() = "RigidBodyTree inverse kinematics";
   constexpr auto& doc = pydrake_doc;
 
@@ -34,7 +34,7 @@ PYBIND11_MODULE(_ik_py, m) {
         doc.PostureConstraint.setJointLimits.doc);
 
   py::class_<WorldPositionConstraint, RigidBodyConstraint>(
-    m, "WorldPositionConstraint", doc.WorldPositionConstraint.doc)
+    m, "_WorldPositionConstraint", doc.WorldPositionConstraint.doc)
     .def(py::init<RigidBodyTree<double>*,
                   int,
                   const Eigen::Matrix3Xd&,
@@ -86,7 +86,8 @@ PYBIND11_MODULE(_ik_py, m) {
          doc.RelativeQuatConstraint.ctor.doc);
 
   py::class_<WorldPositionInFrameConstraint, RigidBodyConstraint>(
-    m, "WorldPositionInFrameConstraint", doc.WorldPositionInFrameConstraint.doc)
+    m, "_WorldPositionInFrameConstraint",
+    doc.WorldPositionInFrameConstraint.doc)
     .def(py::init<RigidBodyTree<double>*,
                   int,
                   const Eigen::Matrix3Xd&,
@@ -297,6 +298,8 @@ PYBIND11_MODULE(_ik_py, m) {
     .def_readonly("info", &IKResults::info, doc.IKResults.info.doc)
     .def_readonly("infeasible_constraints", &IKResults::infeasible_constraints,
       doc.IKResults.infeasible_constraints.doc);
+
+  ExecuteExtraPythonCode(m);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/solvers/mathematicalprogram.py
+++ b/bindings/pydrake/solvers/mathematicalprogram.py
@@ -1,3 +1,0 @@
-from __future__ import absolute_import
-
-from ._mathematicalprogram_py import *

--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -167,7 +167,7 @@ class PyFunctionConstraint : public Constraint {
 
 }  // namespace
 
-PYBIND11_MODULE(_mathematicalprogram_py, m) {
+PYBIND11_MODULE(mathematicalprogram, m) {
   m.doc() = "Drake MathematicalProgram Bindings";
   constexpr auto& doc = pydrake_doc.drake.solvers;
 

--- a/bindings/pydrake/symbolic_py.cc
+++ b/bindings/pydrake/symbolic_py.cc
@@ -20,7 +20,7 @@ using std::map;
 using std::string;
 
 // TODO(eric.cousineau): Use py::self for operator overloads?
-PYBIND11_MODULE(_symbolic_py, m) {
+PYBIND11_MODULE(symbolic, m) {
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
   using namespace drake::symbolic;
   constexpr auto& doc = pydrake_doc.drake.symbolic;
@@ -524,6 +524,8 @@ PYBIND11_MODULE(_symbolic_py, m) {
                              drake::symbolic::Expression>();
   py::implicitly_convertible<drake::symbolic::Monomial,
                              drake::symbolic::Polynomial>();
+
+  ExecuteExtraPythonCode(m);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -64,7 +64,6 @@ drake_pybind_library(
         "//bindings/pydrake/util:type_safe_index_pybind",
         "//bindings/pydrake/util:wrap_pybind",
     ],
-    cc_so_name = "framework",
     cc_srcs = [
         "framework_py.cc",
         "framework_py_semantics.cc",
@@ -98,7 +97,6 @@ drake_pybind_library(
         "//bindings/pydrake:documentation_pybind",
         "//bindings/pydrake/util:drake_optional_pybind",
     ],
-    cc_so_name = "primitives",
     cc_srcs = ["primitives_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
@@ -113,7 +111,6 @@ drake_pybind_library(
         ":systems_pybind",
         "//bindings/pydrake:documentation_pybind",
     ],
-    cc_so_name = "analysis",
     cc_srcs = ["analysis_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
@@ -129,7 +126,6 @@ drake_pybind_library(
         "//bindings/pydrake:symbolic_types_pybind",
         "//bindings/pydrake/util:wrap_pybind",
     ],
-    cc_so_name = "controllers",
     cc_srcs = ["controllers_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
@@ -148,7 +144,6 @@ drake_pybind_library(
         "//bindings/pydrake:documentation_pybind",
         "//bindings/pydrake/util:eigen_geometry_pybind",
     ],
-    cc_so_name = "rendering",
     cc_srcs = ["rendering_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
@@ -167,7 +162,6 @@ drake_pybind_library(
         "//bindings/pydrake/util:eigen_geometry_pybind",
         "//bindings/pydrake/util:eigen_pybind",
     ],
-    cc_so_name = "sensors",
     cc_srcs = ["sensors_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
@@ -185,7 +179,6 @@ drake_pybind_library(
         "//bindings/pydrake:documentation_pybind",
         "//bindings/pydrake:symbolic_types_pybind",
     ],
-    cc_so_name = "trajectory_optimization",
     cc_srcs = ["trajectory_optimization_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
@@ -211,7 +204,6 @@ drake_pybind_library(
         "//bindings/pydrake:documentation_pybind",
         "//bindings/pydrake/systems:systems_pybind",
     ],
-    cc_so_name = "_lcm_py",
     cc_srcs = ["lcm_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
@@ -219,7 +211,7 @@ drake_pybind_library(
         ":module_py",
         "//bindings/pydrake:lcm_py",
     ],
-    py_srcs = ["lcm.py"],
+    py_srcs = ["_lcm_extra.py"],
 )
 
 drake_py_unittest(
@@ -311,6 +303,7 @@ drake_pybind_library(
         ":primitives_py",
         "//bindings/pydrake/util:cpp_template_py",
     ],
+    visibility = ["//visibility:private"],
 )
 
 drake_py_unittest(

--- a/bindings/pydrake/systems/_lcm_extra.py
+++ b/bindings/pydrake/systems/_lcm_extra.py
@@ -1,6 +1,6 @@
-from pydrake.systems._lcm_py import *
-
-from pydrake.systems.framework import AbstractValue, Value
+# See `ExecuteExtraPythonCode` in `pydrake_pybind.h` for usage details and
+# rationale.
+from pydrake.systems.framework import AbstractValue
 
 
 class PySerializer(SerializerInterface):

--- a/bindings/pydrake/systems/all.py
+++ b/bindings/pydrake/systems/all.py
@@ -4,6 +4,7 @@ from .framework import *
 from .lcm import *
 from .primitives import *
 from .rendering import *
+from .scalar_conversion import *
 from .sensors import *
 from .trajectory_optimization import *
 

--- a/bindings/pydrake/systems/lcm_py.cc
+++ b/bindings/pydrake/systems/lcm_py.cc
@@ -60,7 +60,7 @@ class PySerializerInterface : public py::wrapper<SerializerInterface> {
 
 }  // namespace
 
-PYBIND11_MODULE(_lcm_py, m) {
+PYBIND11_MODULE(lcm, m) {
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
   using namespace drake::lcm;
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
@@ -113,6 +113,8 @@ PYBIND11_MODULE(_lcm_py, m) {
         py::keep_alive<0, 2>(),
         // TODO(eric.cousineau): Figure out why this is necessary (#9398).
         py_reference, doc.ConnectLcmScope.doc);
+
+  ExecuteExtraPythonCode(m);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/systems/trajectory_optimization_py.cc
+++ b/bindings/pydrake/systems/trajectory_optimization_py.cc
@@ -22,7 +22,7 @@ PYBIND11_MODULE(trajectory_optimization, m) {
   py::module::import("pydrake.symbolic");
   py::module::import("pydrake.systems.framework");
   py::module::import("pydrake.systems.primitives");
-  py::module::import("pydrake.solvers._mathematicalprogram_py");
+  py::module::import("pydrake.solvers.mathematicalprogram");
 
   py::class_<MultipleShooting, solvers::MathematicalProgram>(m,
                                                              "MultipleShooting",

--- a/bindings/pydrake/test/__init__.py
+++ b/bindings/pydrake/test/__init__.py
@@ -1,0 +1,1 @@
+# Empty Python module `__init__`, required to make this a module.

--- a/bindings/pydrake/test/all_test.py
+++ b/bindings/pydrake/test/all_test.py
@@ -126,6 +126,8 @@ class TestAll(unittest.TestCase):
             "Adder",
             # - rendering
             "PoseVector",
+            # - scalar_conversion
+            "TemplateSystem",
             # - sensors
             "Image",
             # util

--- a/bindings/pydrake/util/BUILD.bazel
+++ b/bindings/pydrake/util/BUILD.bazel
@@ -93,7 +93,6 @@ drake_cc_library(
 drake_pybind_library(
     name = "eigen_geometry_py",
     cc_deps = [":eigen_geometry_pybind"],
-    cc_so_name = "eigen_geometry",
     cc_srcs = ["eigen_geometry_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [":module_py"],
@@ -251,6 +250,7 @@ drake_pybind_library(
     cc_so_name = "test/deprecation_example/cc_module",
     cc_srcs = ["test/deprecation_example/cc_module_py.cc"],
     package_info = PACKAGE_INFO,
+    visibility = ["//visibility:private"],
 )
 
 drake_py_library(
@@ -258,6 +258,7 @@ drake_py_library(
     testonly = 1,
     srcs = glob(["test/deprecation_example/*.py"]),
     imports = ["test"],
+    visibility = ["//visibility:private"],
     deps = [
         ":deprecation_example_cc_module_py",
         ":deprecation_py",
@@ -316,6 +317,7 @@ drake_pybind_library(
     cc_so_name = "test/eigen_geometry_test_util",
     cc_srcs = ["test/eigen_geometry_test_util_py.cc"],
     package_info = PACKAGE_INFO,
+    visibility = ["//visibility:private"],
 )
 
 drake_py_unittest(
@@ -360,9 +362,9 @@ drake_pybind_library(
     testonly = 1,
     add_install = False,
     cc_deps = [":wrap_pybind"],
-    cc_so_name = "wrap_test_util",
     cc_srcs = ["test/wrap_test_util_py.cc"],
     package_info = PACKAGE_INFO,
+    visibility = ["//visibility:private"],
 )
 
 drake_py_unittest(

--- a/tools/skylark/pybind.bzl
+++ b/tools/skylark/pybind.bzl
@@ -119,9 +119,8 @@ def drake_pybind_library(
         By default, this includes `pydrake_pybind` and
         `//:drake_shared_library`.
     @param cc_so_name (optional)
-        Shared object name. By default, this is `_${name}`, so that the C++
-        code can be then imported in a more controlled fashion in Python.
-        If overridden, this could be the public interface exposed to the user.
+        Shared object name. By default, this is `${name}` (without the `_py`
+        suffix if it's present).
     @param package_info
         This should be the result of `get_pybind_package_info` called from the
         current package. This dictates how `PYTHONPATH` is configured, and
@@ -132,7 +131,10 @@ def drake_pybind_library(
     if package_info == None:
         fail("`package_info` must be supplied.")
     if not cc_so_name:
-        cc_so_name = "_" + name
+        if name.endswith("_py"):
+            cc_so_name = name[:-3]
+        else:
+            cc_so_name = name
     install_name = name + "_install"
     targets = pybind_py_library(
         name = name,


### PR DESCRIPTION
Resolves item 5 in #9599.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9756)
<!-- Reviewable:end -->
