### PR TITLE
symbolic: Use shared_ptr to const objects

### DIFF
--- a/common/symbolic_expression.cc
+++ b/common/symbolic_expression.cc
@@ -43,16 +43,16 @@ bool operator<(ExpressionKind k1, ExpressionKind k2) {
 
 namespace {
 // This function is used in Expression(const double d) constructor. It turns out
-// a ternary expression "std::isnan(d) ? make_shared<ExpressionNaN>() :
-// make_shared<ExpressionConstant>()" does not work due to C++'s type-system.
-// It throws "Incompatible operand types when using ternary conditional
-// operator" error. Related S&O entry:
+// a ternary expression "std::isnan(d) ? make_shared<const ExpressionNaN>() :
+// make_shared<const ExpressionConstant>()" does not work due to C++'s
+// type-system. It throws "Incompatible operand types when using ternary
+// conditional operator" error. Related S&O entry:
 // http://stackoverflow.com/questions/29842095/incompatible-operand-types-when-using-ternary-conditional-operator.
-shared_ptr<ExpressionCell> make_cell(const double d) {
+shared_ptr<const ExpressionCell> make_cell(const double d) {
   if (std::isnan(d)) {
-    return make_shared<ExpressionNaN>();
+    return make_shared<const ExpressionNaN>();
   }
-  return make_shared<ExpressionConstant>(d);
+  return make_shared<const ExpressionConstant>(d);
 }
 
 // Negates an addition expression.
@@ -71,9 +71,9 @@ Expression NegateMultiplication(const Expression& e) {
 }  // namespace
 
 Expression::Expression(const Variable& var)
-    : ptr_{make_shared<ExpressionVar>(var)} {}
+    : ptr_{make_shared<const ExpressionVar>(var)} {}
 Expression::Expression(const double d) : ptr_{make_cell(d)} {}
-Expression::Expression(std::shared_ptr<ExpressionCell> ptr)
+Expression::Expression(std::shared_ptr<const ExpressionCell> ptr)
     : ptr_{std::move(ptr)} {}
 
 ExpressionKind Expression::get_kind() const {
@@ -109,7 +109,7 @@ Expression Expression::E() {
 
 Expression Expression::NaN() {
   static const never_destroyed<Expression> nan{
-      Expression{make_shared<ExpressionNaN>()}};
+      Expression{make_shared<const ExpressionNaN>()}};
   return nan.access();
 }
 
@@ -508,7 +508,7 @@ Expression& operator/=(Expression& lhs, const Expression& rhs) {
     lhs = Expression::One();
     return lhs;
   }
-  lhs.ptr_ = make_shared<ExpressionDiv>(lhs, rhs);
+  lhs.ptr_ = make_shared<const ExpressionDiv>(lhs, rhs);
   return lhs;
 }
 
@@ -544,7 +544,7 @@ Expression log(const Expression& e) {
     ExpressionLog::check_domain(v);
     return Expression{std::log(v)};
   }
-  return Expression{make_shared<ExpressionLog>(e)};
+  return Expression{make_shared<const ExpressionLog>(e)};
 }
 
 Expression abs(const Expression& e) {
@@ -552,7 +552,7 @@ Expression abs(const Expression& e) {
   if (is_constant(e)) {
     return Expression{std::fabs(get_constant_value(e))};
   }
-  return Expression{make_shared<ExpressionAbs>(e)};
+  return Expression{make_shared<const ExpressionAbs>(e)};
 }
 
 Expression exp(const Expression& e) {
@@ -560,7 +560,7 @@ Expression exp(const Expression& e) {
   if (is_constant(e)) {
     return Expression{std::exp(get_constant_value(e))};
   }
-  return Expression{make_shared<ExpressionExp>(e)};
+  return Expression{make_shared<const ExpressionExp>(e)};
 }
 
 Expression sqrt(const Expression& e) {
@@ -576,7 +576,7 @@ Expression sqrt(const Expression& e) {
       return abs(get_first_argument(e));
     }
   }
-  return Expression{make_shared<ExpressionSqrt>(e)};
+  return Expression{make_shared<const ExpressionSqrt>(e)};
 }
 
 Expression pow(const Expression& e1, const Expression& e2) {
@@ -604,9 +604,9 @@ Expression pow(const Expression& e1, const Expression& e2) {
     // pow(base, exponent) ^ e2 => pow(base, exponent * e2)
     const Expression& base{get_first_argument(e1)};
     const Expression& exponent{get_second_argument(e1)};
-    return Expression{make_shared<ExpressionPow>(base, exponent * e2)};
+    return Expression{make_shared<const ExpressionPow>(base, exponent * e2)};
   }
-  return Expression{make_shared<ExpressionPow>(e1, e2)};
+  return Expression{make_shared<const ExpressionPow>(e1, e2)};
 }
 
 Expression sin(const Expression& e) {
@@ -614,7 +614,7 @@ Expression sin(const Expression& e) {
   if (is_constant(e)) {
     return Expression{std::sin(get_constant_value(e))};
   }
-  return Expression{make_shared<ExpressionSin>(e)};
+  return Expression{make_shared<const ExpressionSin>(e)};
 }
 
 Expression cos(const Expression& e) {
@@ -623,7 +623,7 @@ Expression cos(const Expression& e) {
     return Expression{std::cos(get_constant_value(e))};
   }
 
-  return Expression{make_shared<ExpressionCos>(e)};
+  return Expression{make_shared<const ExpressionCos>(e)};
 }
 
 Expression tan(const Expression& e) {
@@ -631,7 +631,7 @@ Expression tan(const Expression& e) {
   if (is_constant(e)) {
     return Expression{std::tan(get_constant_value(e))};
   }
-  return Expression{make_shared<ExpressionTan>(e)};
+  return Expression{make_shared<const ExpressionTan>(e)};
 }
 
 Expression asin(const Expression& e) {
@@ -641,7 +641,7 @@ Expression asin(const Expression& e) {
     ExpressionAsin::check_domain(v);
     return Expression{std::asin(v)};
   }
-  return Expression{make_shared<ExpressionAsin>(e)};
+  return Expression{make_shared<const ExpressionAsin>(e)};
 }
 
 Expression acos(const Expression& e) {
@@ -651,7 +651,7 @@ Expression acos(const Expression& e) {
     ExpressionAcos::check_domain(v);
     return Expression{std::acos(v)};
   }
-  return Expression{make_shared<ExpressionAcos>(e)};
+  return Expression{make_shared<const ExpressionAcos>(e)};
 }
 
 Expression atan(const Expression& e) {
@@ -659,7 +659,7 @@ Expression atan(const Expression& e) {
   if (is_constant(e)) {
     return Expression{std::atan(get_constant_value(e))};
   }
-  return Expression{make_shared<ExpressionAtan>(e)};
+  return Expression{make_shared<const ExpressionAtan>(e)};
 }
 
 Expression atan2(const Expression& e1, const Expression& e2) {
@@ -668,7 +668,7 @@ Expression atan2(const Expression& e1, const Expression& e2) {
     return Expression{
         std::atan2(get_constant_value(e1), get_constant_value(e2))};
   }
-  return Expression{make_shared<ExpressionAtan2>(e1, e2)};
+  return Expression{make_shared<const ExpressionAtan2>(e1, e2)};
 }
 
 Expression sinh(const Expression& e) {
@@ -676,7 +676,7 @@ Expression sinh(const Expression& e) {
   if (is_constant(e)) {
     return Expression{std::sinh(get_constant_value(e))};
   }
-  return Expression{make_shared<ExpressionSinh>(e)};
+  return Expression{make_shared<const ExpressionSinh>(e)};
 }
 
 Expression cosh(const Expression& e) {
@@ -684,7 +684,7 @@ Expression cosh(const Expression& e) {
   if (is_constant(e)) {
     return Expression{std::cosh(get_constant_value(e))};
   }
-  return Expression{make_shared<ExpressionCosh>(e)};
+  return Expression{make_shared<const ExpressionCosh>(e)};
 }
 
 Expression tanh(const Expression& e) {
@@ -692,7 +692,7 @@ Expression tanh(const Expression& e) {
   if (is_constant(e)) {
     return Expression{std::tanh(get_constant_value(e))};
   }
-  return Expression{make_shared<ExpressionTanh>(e)};
+  return Expression{make_shared<const ExpressionTanh>(e)};
 }
 
 Expression min(const Expression& e1, const Expression& e2) {
@@ -704,7 +704,7 @@ Expression min(const Expression& e1, const Expression& e2) {
   if (is_constant(e1) && is_constant(e2)) {
     return Expression{std::min(get_constant_value(e1), get_constant_value(e2))};
   }
-  return Expression{make_shared<ExpressionMin>(e1, e2)};
+  return Expression{make_shared<const ExpressionMin>(e1, e2)};
 }
 
 Expression max(const Expression& e1, const Expression& e2) {
@@ -716,7 +716,7 @@ Expression max(const Expression& e1, const Expression& e2) {
   if (is_constant(e1) && is_constant(e2)) {
     return Expression{std::max(get_constant_value(e1), get_constant_value(e2))};
   }
-  return Expression{make_shared<ExpressionMax>(e1, e2)};
+  return Expression{make_shared<const ExpressionMax>(e1, e2)};
 }
 
 Expression ceil(const Expression& e) {
@@ -724,7 +724,7 @@ Expression ceil(const Expression& e) {
   if (is_constant(e)) {
     return Expression{std::ceil(get_constant_value(e))};
   }
-  return Expression{make_shared<ExpressionCeiling>(e)};
+  return Expression{make_shared<const ExpressionCeiling>(e)};
 }
 
 Expression floor(const Expression& e) {
@@ -732,7 +732,7 @@ Expression floor(const Expression& e) {
   if (is_constant(e)) {
     return Expression{std::floor(get_constant_value(e))};
   }
-  return Expression{make_shared<ExpressionFloor>(e)};
+  return Expression{make_shared<const ExpressionFloor>(e)};
 }
 
 Expression if_then_else(const Formula& f_cond, const Expression& e_then,
@@ -745,11 +745,12 @@ Expression if_then_else(const Formula& f_cond, const Expression& e_then,
   if (f_cond.EqualTo(Formula::False())) {
     return e_else;
   }
-  return Expression{make_shared<ExpressionIfThenElse>(f_cond, e_then, e_else)};
+  return Expression{
+      make_shared<const ExpressionIfThenElse>(f_cond, e_then, e_else)};
 }
 
 Expression uninterpreted_function(string name, vector<Expression> arguments) {
-  return Expression{make_shared<ExpressionUninterpretedFunction>(
+  return Expression{make_shared<const ExpressionUninterpretedFunction>(
       std::move(name), std::move(arguments))};
 }
 

--- a/common/symbolic_expression.h
+++ b/common/symbolic_expression.h
@@ -436,45 +436,52 @@ class Expression {
   // and not exposed to the user of drake/common/symbolic_expression.h
   // header. These functions are declared in
   // drake/common/symbolic_expression_cell.h header.
-  friend std::shared_ptr<ExpressionConstant> to_constant(const Expression& e);
-  friend std::shared_ptr<ExpressionVar> to_variable(const Expression& e);
-  friend std::shared_ptr<UnaryExpressionCell> to_unary(const Expression& e);
-  friend std::shared_ptr<BinaryExpressionCell> to_binary(const Expression& e);
-  friend std::shared_ptr<ExpressionAdd> to_addition(const Expression& e);
-  friend std::shared_ptr<ExpressionMul> to_multiplication(const Expression& e);
-  friend std::shared_ptr<ExpressionDiv> to_division(const Expression& e);
-  friend std::shared_ptr<ExpressionLog> to_log(const Expression& e);
-  friend std::shared_ptr<ExpressionAbs> to_abs(const Expression& e);
-  friend std::shared_ptr<ExpressionExp> to_exp(const Expression& e);
-  friend std::shared_ptr<ExpressionSqrt> to_sqrt(const Expression& e);
-  friend std::shared_ptr<ExpressionPow> to_pow(const Expression& e);
-  friend std::shared_ptr<ExpressionSin> to_sin(const Expression& e);
-  friend std::shared_ptr<ExpressionCos> to_cos(const Expression& e);
-  friend std::shared_ptr<ExpressionTan> to_tan(const Expression& e);
-  friend std::shared_ptr<ExpressionAsin> to_asin(const Expression& e);
-  friend std::shared_ptr<ExpressionAcos> to_acos(const Expression& e);
-  friend std::shared_ptr<ExpressionAtan> to_atan(const Expression& e);
-  friend std::shared_ptr<ExpressionAtan2> to_atan2(const Expression& e);
-  friend std::shared_ptr<ExpressionSinh> to_sinh(const Expression& e);
-  friend std::shared_ptr<ExpressionCosh> to_cosh(const Expression& e);
-  friend std::shared_ptr<ExpressionTanh> to_tanh(const Expression& e);
-  friend std::shared_ptr<ExpressionMin> to_min(const Expression& e);
-  friend std::shared_ptr<ExpressionMax> to_max(const Expression& e);
-  friend std::shared_ptr<ExpressionCeiling> to_ceil(const Expression& e);
-  friend std::shared_ptr<ExpressionFloor> to_floor(const Expression& e);
-  friend std::shared_ptr<ExpressionIfThenElse> to_if_then_else(
+  friend std::shared_ptr<const ExpressionConstant> to_constant(
       const Expression& e);
-  friend std::shared_ptr<ExpressionUninterpretedFunction>
+  friend std::shared_ptr<const ExpressionVar> to_variable(const Expression& e);
+  friend std::shared_ptr<const UnaryExpressionCell> to_unary(
+      const Expression& e);
+  friend std::shared_ptr<const BinaryExpressionCell> to_binary(
+      const Expression& e);
+  friend std::shared_ptr<const ExpressionAdd> to_addition(const Expression& e);
+  friend std::shared_ptr<const ExpressionMul> to_multiplication(
+      const Expression& e);
+  friend std::shared_ptr<const ExpressionDiv> to_division(const Expression& e);
+  friend std::shared_ptr<const ExpressionLog> to_log(const Expression& e);
+  friend std::shared_ptr<const ExpressionAbs> to_abs(const Expression& e);
+  friend std::shared_ptr<const ExpressionExp> to_exp(const Expression& e);
+  friend std::shared_ptr<const ExpressionSqrt> to_sqrt(const Expression& e);
+  friend std::shared_ptr<const ExpressionPow> to_pow(const Expression& e);
+  friend std::shared_ptr<const ExpressionSin> to_sin(const Expression& e);
+  friend std::shared_ptr<const ExpressionCos> to_cos(const Expression& e);
+  friend std::shared_ptr<const ExpressionTan> to_tan(const Expression& e);
+  friend std::shared_ptr<const ExpressionAsin> to_asin(const Expression& e);
+  friend std::shared_ptr<const ExpressionAcos> to_acos(const Expression& e);
+  friend std::shared_ptr<const ExpressionAtan> to_atan(const Expression& e);
+  friend std::shared_ptr<const ExpressionAtan2> to_atan2(const Expression& e);
+  friend std::shared_ptr<const ExpressionSinh> to_sinh(const Expression& e);
+  friend std::shared_ptr<const ExpressionCosh> to_cosh(const Expression& e);
+  friend std::shared_ptr<const ExpressionTanh> to_tanh(const Expression& e);
+  friend std::shared_ptr<const ExpressionMin> to_min(const Expression& e);
+  friend std::shared_ptr<const ExpressionMax> to_max(const Expression& e);
+  friend std::shared_ptr<const ExpressionCeiling> to_ceil(const Expression& e);
+  friend std::shared_ptr<const ExpressionFloor> to_floor(const Expression& e);
+  friend std::shared_ptr<const ExpressionIfThenElse> to_if_then_else(
+      const Expression& e);
+  friend std::shared_ptr<const ExpressionUninterpretedFunction>
   to_uninterpreted_function(const Expression& e);
 
   friend class ExpressionAddFactory;
   friend class ExpressionMulFactory;
 
  private:
-  explicit Expression(std::shared_ptr<ExpressionCell> ptr);
+  explicit Expression(std::shared_ptr<const ExpressionCell> ptr);
   void HashAppend(DelegatingHasher* hasher) const;
 
-  std::shared_ptr<ExpressionCell> ptr_;
+  // Note: We use "const" ExpressionCell type here because an ExpressionCell
+  // object can be shared by multiple expressions, an expression should _not_ be
+  // able to change the cell that it points to.
+  std::shared_ptr<const ExpressionCell> ptr_;
 };
 
 Expression operator+(Expression lhs, const Expression& rhs);

--- a/common/symbolic_expression_cell.cc
+++ b/common/symbolic_expression_cell.cc
@@ -626,7 +626,7 @@ void ExpressionAddFactory::Add(const shared_ptr<const ExpressionAdd>& ptr) {
 }
 
 ExpressionAddFactory& ExpressionAddFactory::operator=(
-    const std::shared_ptr<ExpressionAdd>& ptr) {
+    const std::shared_ptr<const ExpressionAdd>& ptr) {
   constant_ = ptr->get_constant();
   expr_to_coeff_map_ = ptr->get_expr_to_coeff_map();
   return *this;
@@ -649,7 +649,8 @@ Expression ExpressionAddFactory::GetExpression() const {
     const auto it(expr_to_coeff_map_.cbegin());
     return it->first * it->second;
   }
-  return Expression{make_shared<ExpressionAdd>(constant_, expr_to_coeff_map_)};
+  return Expression{
+      make_shared<const ExpressionAdd>(constant_, expr_to_coeff_map_)};
 }
 
 void ExpressionAddFactory::AddConstant(const double constant) {
@@ -907,7 +908,7 @@ void ExpressionMulFactory::Add(const shared_ptr<const ExpressionMul>& ptr) {
 }
 
 ExpressionMulFactory& ExpressionMulFactory::operator=(
-    const std::shared_ptr<ExpressionMul>& ptr) {
+    const std::shared_ptr<const ExpressionMul>& ptr) {
   constant_ = ptr->get_constant();
   base_to_exponent_map_ = ptr->get_base_to_exponent_map();
   return *this;
@@ -928,7 +929,7 @@ Expression ExpressionMulFactory::GetExpression() const {
     return pow(it->first, it->second);
   }
   return Expression{
-      make_shared<ExpressionMul>(constant_, base_to_exponent_map_)};
+      make_shared<const ExpressionMul>(constant_, base_to_exponent_map_)};
 }
 
 void ExpressionMulFactory::AddConstant(const double constant) {
@@ -2063,225 +2064,259 @@ bool is_uninterpreted_function(const ExpressionCell& c) {
   return c.get_kind() == ExpressionKind::UninterpretedFunction;
 }
 
-shared_ptr<ExpressionConstant> to_constant(
-    const shared_ptr<ExpressionCell>& expr_ptr) {
+shared_ptr<const ExpressionConstant> to_constant(
+    const shared_ptr<const ExpressionCell>& expr_ptr) {
   DRAKE_ASSERT(is_constant(*expr_ptr));
-  return static_pointer_cast<ExpressionConstant>(expr_ptr);
+  return static_pointer_cast<const ExpressionConstant>(expr_ptr);
 }
-shared_ptr<ExpressionConstant> to_constant(const Expression& e) {
+shared_ptr<const ExpressionConstant> to_constant(const Expression& e) {
   return to_constant(e.ptr_);
 }
 
-shared_ptr<ExpressionVar> to_variable(
-    const shared_ptr<ExpressionCell>& expr_ptr) {
+shared_ptr<const ExpressionVar> to_variable(
+    const shared_ptr<const ExpressionCell>& expr_ptr) {
   DRAKE_ASSERT(is_variable(*expr_ptr));
-  return static_pointer_cast<ExpressionVar>(expr_ptr);
+  return static_pointer_cast<const ExpressionVar>(expr_ptr);
 }
-shared_ptr<ExpressionVar> to_variable(const Expression& e) {
+shared_ptr<const ExpressionVar> to_variable(const Expression& e) {
   return to_variable(e.ptr_);
 }
 
-shared_ptr<UnaryExpressionCell> to_unary(
-    const shared_ptr<ExpressionCell>& expr_ptr) {
+shared_ptr<const UnaryExpressionCell> to_unary(
+    const shared_ptr<const ExpressionCell>& expr_ptr) {
   DRAKE_ASSERT(is_log(*expr_ptr) || is_abs(*expr_ptr) || is_exp(*expr_ptr) ||
                is_sqrt(*expr_ptr) || is_sin(*expr_ptr) || is_cos(*expr_ptr) ||
                is_tan(*expr_ptr) || is_asin(*expr_ptr) || is_acos(*expr_ptr) ||
                is_atan(*expr_ptr) || is_sinh(*expr_ptr) || is_cosh(*expr_ptr) ||
                is_tanh(*expr_ptr) || is_ceil(*expr_ptr) || is_floor(*expr_ptr));
-  return static_pointer_cast<UnaryExpressionCell>(expr_ptr);
+  return static_pointer_cast<const UnaryExpressionCell>(expr_ptr);
 }
-shared_ptr<UnaryExpressionCell> to_unary(const Expression& e) {
+shared_ptr<const UnaryExpressionCell> to_unary(const Expression& e) {
   return to_unary(e.ptr_);
 }
 
-shared_ptr<BinaryExpressionCell> to_binary(
-    const shared_ptr<ExpressionCell>& expr_ptr) {
+shared_ptr<const BinaryExpressionCell> to_binary(
+    const shared_ptr<const ExpressionCell>& expr_ptr) {
   DRAKE_ASSERT(is_division(*expr_ptr) || is_pow(*expr_ptr) ||
                is_atan2(*expr_ptr) || is_min(*expr_ptr) || is_max(*expr_ptr));
-  return static_pointer_cast<BinaryExpressionCell>(expr_ptr);
+  return static_pointer_cast<const BinaryExpressionCell>(expr_ptr);
 }
-shared_ptr<BinaryExpressionCell> to_binary(const Expression& e) {
+shared_ptr<const BinaryExpressionCell> to_binary(const Expression& e) {
   return to_binary(e.ptr_);
 }
 
-shared_ptr<ExpressionAdd> to_addition(
-    const shared_ptr<ExpressionCell>& expr_ptr) {
+shared_ptr<const ExpressionAdd> to_addition(
+    const shared_ptr<const ExpressionCell>& expr_ptr) {
   DRAKE_ASSERT(is_addition(*expr_ptr));
-  return static_pointer_cast<ExpressionAdd>(expr_ptr);
+  return static_pointer_cast<const ExpressionAdd>(expr_ptr);
 }
-shared_ptr<ExpressionAdd> to_addition(const Expression& e) {
+shared_ptr<const ExpressionAdd> to_addition(const Expression& e) {
   return to_addition(e.ptr_);
 }
 
-shared_ptr<ExpressionMul> to_multiplication(
-    const shared_ptr<ExpressionCell>& expr_ptr) {
+shared_ptr<const ExpressionMul> to_multiplication(
+    const shared_ptr<const ExpressionCell>& expr_ptr) {
   DRAKE_ASSERT(is_multiplication(*expr_ptr));
-  return static_pointer_cast<ExpressionMul>(expr_ptr);
+  return static_pointer_cast<const ExpressionMul>(expr_ptr);
 }
-shared_ptr<ExpressionMul> to_multiplication(const Expression& e) {
+shared_ptr<const ExpressionMul> to_multiplication(const Expression& e) {
   return to_multiplication(e.ptr_);
 }
 
-shared_ptr<ExpressionDiv> to_division(
-    const shared_ptr<ExpressionCell>& expr_ptr) {
+shared_ptr<const ExpressionDiv> to_division(
+    const shared_ptr<const ExpressionCell>& expr_ptr) {
   DRAKE_ASSERT(is_division(*expr_ptr));
-  return static_pointer_cast<ExpressionDiv>(expr_ptr);
+  return static_pointer_cast<const ExpressionDiv>(expr_ptr);
 }
-shared_ptr<ExpressionDiv> to_division(const Expression& e) {
+shared_ptr<const ExpressionDiv> to_division(const Expression& e) {
   return to_division(e.ptr_);
 }
 
-shared_ptr<ExpressionLog> to_log(const shared_ptr<ExpressionCell>& expr_ptr) {
+shared_ptr<const ExpressionLog> to_log(
+    const shared_ptr<const ExpressionCell>& expr_ptr) {
   DRAKE_ASSERT(is_log(*expr_ptr));
-  return static_pointer_cast<ExpressionLog>(expr_ptr);
+  return static_pointer_cast<const ExpressionLog>(expr_ptr);
 }
-shared_ptr<ExpressionLog> to_log(const Expression& e) { return to_log(e.ptr_); }
+shared_ptr<const ExpressionLog> to_log(const Expression& e) {
+  return to_log(e.ptr_);
+}
 
-shared_ptr<ExpressionAbs> to_abs(const shared_ptr<ExpressionCell>& expr_ptr) {
+shared_ptr<const ExpressionAbs> to_abs(
+    const shared_ptr<const ExpressionCell>& expr_ptr) {
   DRAKE_ASSERT(is_abs(*expr_ptr));
-  return static_pointer_cast<ExpressionAbs>(expr_ptr);
+  return static_pointer_cast<const ExpressionAbs>(expr_ptr);
 }
-shared_ptr<ExpressionAbs> to_abs(const Expression& e) { return to_abs(e.ptr_); }
+shared_ptr<const ExpressionAbs> to_abs(const Expression& e) {
+  return to_abs(e.ptr_);
+}
 
-shared_ptr<ExpressionExp> to_exp(const shared_ptr<ExpressionCell>& expr_ptr) {
+shared_ptr<const ExpressionExp> to_exp(
+    const shared_ptr<const ExpressionCell>& expr_ptr) {
   DRAKE_ASSERT(is_exp(*expr_ptr));
-  return static_pointer_cast<ExpressionExp>(expr_ptr);
+  return static_pointer_cast<const ExpressionExp>(expr_ptr);
 }
-shared_ptr<ExpressionExp> to_exp(const Expression& e) { return to_exp(e.ptr_); }
+shared_ptr<const ExpressionExp> to_exp(const Expression& e) {
+  return to_exp(e.ptr_);
+}
 
-shared_ptr<ExpressionSqrt> to_sqrt(const shared_ptr<ExpressionCell>& expr_ptr) {
+shared_ptr<const ExpressionSqrt> to_sqrt(
+    const shared_ptr<const ExpressionCell>& expr_ptr) {
   DRAKE_ASSERT(is_sqrt(*expr_ptr));
-  return static_pointer_cast<ExpressionSqrt>(expr_ptr);
+  return static_pointer_cast<const ExpressionSqrt>(expr_ptr);
 }
-shared_ptr<ExpressionSqrt> to_sqrt(const Expression& e) {
+shared_ptr<const ExpressionSqrt> to_sqrt(const Expression& e) {
   return to_sqrt(e.ptr_);
 }
-shared_ptr<ExpressionPow> to_pow(const shared_ptr<ExpressionCell>& expr_ptr) {
+shared_ptr<const ExpressionPow> to_pow(
+    const shared_ptr<const ExpressionCell>& expr_ptr) {
   DRAKE_ASSERT(is_pow(*expr_ptr));
-  return static_pointer_cast<ExpressionPow>(expr_ptr);
+  return static_pointer_cast<const ExpressionPow>(expr_ptr);
 }
-shared_ptr<ExpressionPow> to_pow(const Expression& e) { return to_pow(e.ptr_); }
+shared_ptr<const ExpressionPow> to_pow(const Expression& e) {
+  return to_pow(e.ptr_);
+}
 
-shared_ptr<ExpressionSin> to_sin(const shared_ptr<ExpressionCell>& expr_ptr) {
+shared_ptr<const ExpressionSin> to_sin(
+    const shared_ptr<const ExpressionCell>& expr_ptr) {
   DRAKE_ASSERT(is_sin(*expr_ptr));
-  return static_pointer_cast<ExpressionSin>(expr_ptr);
+  return static_pointer_cast<const ExpressionSin>(expr_ptr);
 }
-shared_ptr<ExpressionSin> to_sin(const Expression& e) { return to_sin(e.ptr_); }
+shared_ptr<const ExpressionSin> to_sin(const Expression& e) {
+  return to_sin(e.ptr_);
+}
 
-shared_ptr<ExpressionCos> to_cos(const shared_ptr<ExpressionCell>& expr_ptr) {
+shared_ptr<const ExpressionCos> to_cos(
+    const shared_ptr<const ExpressionCell>& expr_ptr) {
   DRAKE_ASSERT(is_cos(*expr_ptr));
-  return static_pointer_cast<ExpressionCos>(expr_ptr);
+  return static_pointer_cast<const ExpressionCos>(expr_ptr);
 }
-shared_ptr<ExpressionCos> to_cos(const Expression& e) { return to_cos(e.ptr_); }
+shared_ptr<const ExpressionCos> to_cos(const Expression& e) {
+  return to_cos(e.ptr_);
+}
 
-shared_ptr<ExpressionTan> to_tan(const shared_ptr<ExpressionCell>& expr_ptr) {
+shared_ptr<const ExpressionTan> to_tan(
+    const shared_ptr<const ExpressionCell>& expr_ptr) {
   DRAKE_ASSERT(is_tan(*expr_ptr));
-  return static_pointer_cast<ExpressionTan>(expr_ptr);
+  return static_pointer_cast<const ExpressionTan>(expr_ptr);
 }
-shared_ptr<ExpressionTan> to_tan(const Expression& e) { return to_tan(e.ptr_); }
+shared_ptr<const ExpressionTan> to_tan(const Expression& e) {
+  return to_tan(e.ptr_);
+}
 
-shared_ptr<ExpressionAsin> to_asin(const shared_ptr<ExpressionCell>& expr_ptr) {
+shared_ptr<const ExpressionAsin> to_asin(
+    const shared_ptr<const ExpressionCell>& expr_ptr) {
   DRAKE_ASSERT(is_asin(*expr_ptr));
-  return static_pointer_cast<ExpressionAsin>(expr_ptr);
+  return static_pointer_cast<const ExpressionAsin>(expr_ptr);
 }
-shared_ptr<ExpressionAsin> to_asin(const Expression& e) {
+shared_ptr<const ExpressionAsin> to_asin(const Expression& e) {
   return to_asin(e.ptr_);
 }
 
-shared_ptr<ExpressionAcos> to_acos(const shared_ptr<ExpressionCell>& expr_ptr) {
+shared_ptr<const ExpressionAcos> to_acos(
+    const shared_ptr<const ExpressionCell>& expr_ptr) {
   DRAKE_ASSERT(is_acos(*expr_ptr));
-  return static_pointer_cast<ExpressionAcos>(expr_ptr);
+  return static_pointer_cast<const ExpressionAcos>(expr_ptr);
 }
-shared_ptr<ExpressionAcos> to_acos(const Expression& e) {
+shared_ptr<const ExpressionAcos> to_acos(const Expression& e) {
   return to_acos(e.ptr_);
 }
 
-shared_ptr<ExpressionAtan> to_atan(const shared_ptr<ExpressionCell>& expr_ptr) {
+shared_ptr<const ExpressionAtan> to_atan(
+    const shared_ptr<const ExpressionCell>& expr_ptr) {
   DRAKE_ASSERT(is_atan(*expr_ptr));
-  return static_pointer_cast<ExpressionAtan>(expr_ptr);
+  return static_pointer_cast<const ExpressionAtan>(expr_ptr);
 }
-shared_ptr<ExpressionAtan> to_atan(const Expression& e) {
+shared_ptr<const ExpressionAtan> to_atan(const Expression& e) {
   return to_atan(e.ptr_);
 }
 
-shared_ptr<ExpressionAtan2> to_atan2(
-    const shared_ptr<ExpressionCell>& expr_ptr) {
+shared_ptr<const ExpressionAtan2> to_atan2(
+    const shared_ptr<const ExpressionCell>& expr_ptr) {
   DRAKE_ASSERT(is_atan2(*expr_ptr));
-  return static_pointer_cast<ExpressionAtan2>(expr_ptr);
+  return static_pointer_cast<const ExpressionAtan2>(expr_ptr);
 }
-shared_ptr<ExpressionAtan2> to_atan2(const Expression& e) {
+shared_ptr<const ExpressionAtan2> to_atan2(const Expression& e) {
   return to_atan2(e.ptr_);
 }
 
-shared_ptr<ExpressionSinh> to_sinh(const shared_ptr<ExpressionCell>& expr_ptr) {
+shared_ptr<const ExpressionSinh> to_sinh(
+    const shared_ptr<const ExpressionCell>& expr_ptr) {
   DRAKE_ASSERT(is_sinh(*expr_ptr));
-  return static_pointer_cast<ExpressionSinh>(expr_ptr);
+  return static_pointer_cast<const ExpressionSinh>(expr_ptr);
 }
-shared_ptr<ExpressionSinh> to_sinh(const Expression& e) {
+shared_ptr<const ExpressionSinh> to_sinh(const Expression& e) {
   return to_sinh(e.ptr_);
 }
 
-shared_ptr<ExpressionCosh> to_cosh(const shared_ptr<ExpressionCell>& expr_ptr) {
+shared_ptr<const ExpressionCosh> to_cosh(
+    const shared_ptr<const ExpressionCell>& expr_ptr) {
   DRAKE_ASSERT(is_cosh(*expr_ptr));
-  return static_pointer_cast<ExpressionCosh>(expr_ptr);
+  return static_pointer_cast<const ExpressionCosh>(expr_ptr);
 }
-shared_ptr<ExpressionCosh> to_cosh(const Expression& e) {
+shared_ptr<const ExpressionCosh> to_cosh(const Expression& e) {
   return to_cosh(e.ptr_);
 }
 
-shared_ptr<ExpressionTanh> to_tanh(const shared_ptr<ExpressionCell>& expr_ptr) {
+shared_ptr<const ExpressionTanh> to_tanh(
+    const shared_ptr<const ExpressionCell>& expr_ptr) {
   DRAKE_ASSERT(is_tanh(*expr_ptr));
-  return static_pointer_cast<ExpressionTanh>(expr_ptr);
+  return static_pointer_cast<const ExpressionTanh>(expr_ptr);
 }
-shared_ptr<ExpressionTanh> to_tanh(const Expression& e) {
+shared_ptr<const ExpressionTanh> to_tanh(const Expression& e) {
   return to_tanh(e.ptr_);
 }
 
-shared_ptr<ExpressionMin> to_min(const shared_ptr<ExpressionCell>& expr_ptr) {
+shared_ptr<const ExpressionMin> to_min(
+    const shared_ptr<const ExpressionCell>& expr_ptr) {
   DRAKE_ASSERT(is_min(*expr_ptr));
-  return static_pointer_cast<ExpressionMin>(expr_ptr);
+  return static_pointer_cast<const ExpressionMin>(expr_ptr);
 }
-shared_ptr<ExpressionMin> to_min(const Expression& e) { return to_min(e.ptr_); }
+shared_ptr<const ExpressionMin> to_min(const Expression& e) {
+  return to_min(e.ptr_);
+}
 
-shared_ptr<ExpressionMax> to_max(const shared_ptr<ExpressionCell>& expr_ptr) {
+shared_ptr<const ExpressionMax> to_max(
+    const shared_ptr<const ExpressionCell>& expr_ptr) {
   DRAKE_ASSERT(is_max(*expr_ptr));
-  return static_pointer_cast<ExpressionMax>(expr_ptr);
+  return static_pointer_cast<const ExpressionMax>(expr_ptr);
 }
-shared_ptr<ExpressionMax> to_max(const Expression& e) { return to_max(e.ptr_); }
+shared_ptr<const ExpressionMax> to_max(const Expression& e) {
+  return to_max(e.ptr_);
+}
 
-shared_ptr<ExpressionCeiling> to_ceil(
-    const shared_ptr<ExpressionCell>& expr_ptr) {
+shared_ptr<const ExpressionCeiling> to_ceil(
+    const shared_ptr<const ExpressionCell>& expr_ptr) {
   DRAKE_ASSERT(is_ceil(*expr_ptr));
-  return static_pointer_cast<ExpressionCeiling>(expr_ptr);
+  return static_pointer_cast<const ExpressionCeiling>(expr_ptr);
 }
-shared_ptr<ExpressionCeiling> to_ceil(const Expression& e) {
+shared_ptr<const ExpressionCeiling> to_ceil(const Expression& e) {
   return to_ceil(e.ptr_);
 }
 
-shared_ptr<ExpressionFloor> to_floor(
-    const shared_ptr<ExpressionCell>& expr_ptr) {
+shared_ptr<const ExpressionFloor> to_floor(
+    const shared_ptr<const ExpressionCell>& expr_ptr) {
   DRAKE_ASSERT(is_floor(*expr_ptr));
-  return static_pointer_cast<ExpressionFloor>(expr_ptr);
+  return static_pointer_cast<const ExpressionFloor>(expr_ptr);
 }
-shared_ptr<ExpressionFloor> to_floor(const Expression& e) {
+shared_ptr<const ExpressionFloor> to_floor(const Expression& e) {
   return to_floor(e.ptr_);
 }
 
-shared_ptr<ExpressionIfThenElse> to_if_then_else(
-    const shared_ptr<ExpressionCell>& expr_ptr) {
+shared_ptr<const ExpressionIfThenElse> to_if_then_else(
+    const shared_ptr<const ExpressionCell>& expr_ptr) {
   DRAKE_ASSERT(is_if_then_else(*expr_ptr));
-  return static_pointer_cast<ExpressionIfThenElse>(expr_ptr);
+  return static_pointer_cast<const ExpressionIfThenElse>(expr_ptr);
 }
-shared_ptr<ExpressionIfThenElse> to_if_then_else(const Expression& e) {
+shared_ptr<const ExpressionIfThenElse> to_if_then_else(const Expression& e) {
   return to_if_then_else(e.ptr_);
 }
 
-shared_ptr<ExpressionUninterpretedFunction> to_uninterpreted_function(
-    const shared_ptr<ExpressionCell>& expr_ptr) {
+shared_ptr<const ExpressionUninterpretedFunction> to_uninterpreted_function(
+    const shared_ptr<const ExpressionCell>& expr_ptr) {
   DRAKE_ASSERT(is_uninterpreted_function(*expr_ptr));
-  return static_pointer_cast<ExpressionUninterpretedFunction>(expr_ptr);
+  return static_pointer_cast<const ExpressionUninterpretedFunction>(expr_ptr);
 }
-shared_ptr<ExpressionUninterpretedFunction> to_uninterpreted_function(
+shared_ptr<const ExpressionUninterpretedFunction> to_uninterpreted_function(
     const Expression& e) {
   return to_uninterpreted_function(e.ptr_);
 }

--- a/common/symbolic_expression_cell.h
+++ b/common/symbolic_expression_cell.h
@@ -313,7 +313,8 @@ class ExpressionAddFactory {
   /** Adds ExpressionAdd pointed by @p ptr to this factory. */
   void Add(const std::shared_ptr<const ExpressionAdd>& ptr);
   /** Assigns a factory from a shared pointer to ExpressionAdd.  */
-  ExpressionAddFactory& operator=(const std::shared_ptr<ExpressionAdd>& ptr);
+  ExpressionAddFactory& operator=(
+      const std::shared_ptr<const ExpressionAdd>& ptr);
 
   /** Negates the expressions in factory.
    * If it represents c0 + c1 * t1 + ... + * cn * tn,
@@ -416,7 +417,8 @@ class ExpressionMulFactory {
   /** Adds ExpressionMul pointed by @p ptr to this factory. */
   void Add(const std::shared_ptr<const ExpressionMul>& ptr);
   /** Assigns a factory from a shared pointer to ExpressionMul.  */
-  ExpressionMulFactory& operator=(const std::shared_ptr<ExpressionMul>& ptr);
+  ExpressionMulFactory& operator=(
+      const std::shared_ptr<const ExpressionMul>& ptr);
   /** Negates the expressions in factory.
    * If it represents c0 * p1 * ... * pn,
    * this method flips it into -c0 * p1 * ... * pn.
@@ -870,296 +872,298 @@ bool is_if_then_else(const ExpressionCell& c);
 /** Checks if @p c is an uninterpreted-function expression. */
 bool is_uninterpreted_function(const ExpressionCell& c);
 
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionConstant>.
+/** Casts @p expr_ptr to @c shared_ptr<const ExpressionConstant>.
  *  @pre @p *expr_ptr is of @c ExpressionConstant.
  */
-std::shared_ptr<ExpressionConstant> to_constant(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-/** Casts @p e to @c shared_ptr<ExpressionConstant>.
+std::shared_ptr<const ExpressionConstant> to_constant(
+    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+/** Casts @p e to @c shared_ptr<const ExpressionConstant>.
  *  @pre @p *(e.ptr_) is of @c ExpressionConstant.
  */
-std::shared_ptr<ExpressionConstant> to_constant(const Expression& e);
+std::shared_ptr<const ExpressionConstant> to_constant(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionVar>.
+/** Casts @p expr_ptr to @c shared_ptr<const ExpressionVar>.
  *  @pre @p *expr_ptr is of @c ExpressionVar.
  */
-std::shared_ptr<ExpressionVar> to_variable(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-/** Casts @p e to @c shared_ptr<ExpressionVar>.
+std::shared_ptr<const ExpressionVar> to_variable(
+    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+/** Casts @p e to @c shared_ptr<const ExpressionVar>.
  *  @pre @p *(e.ptr_) is of @c ExpressionVar.
  */
-std::shared_ptr<ExpressionVar> to_variable(const Expression& e);
+std::shared_ptr<const ExpressionVar> to_variable(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<UnaryExpressionCell>.
+/** Casts @p expr_ptr to @c shared_ptr<const UnaryExpressionCell>.
  *  @pre @c *expr_ptr is of @c UnaryExpressionCell.
  */
-std::shared_ptr<UnaryExpressionCell> to_unary(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-/** Casts @p e to @c shared_ptr<UnaryExpressionCell>.
+std::shared_ptr<const UnaryExpressionCell> to_unary(
+    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+/** Casts @p e to @c shared_ptr<const UnaryExpressionCell>.
  *  @pre @c *(e.ptr_) is of @c UnaryExpressionCell.
  */
-std::shared_ptr<UnaryExpressionCell> to_unary(const Expression& e);
+std::shared_ptr<const UnaryExpressionCell> to_unary(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<BinaryExpressionCell>.
+/** Casts @p expr_ptr to @c shared_ptr<const BinaryExpressionCell>.
  *  @pre @c *expr_ptr is of @c BinaryExpressionCell.
  */
-std::shared_ptr<BinaryExpressionCell> to_binary(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-/** Casts @p e to @c shared_ptr<BinaryExpressionCell>.
+std::shared_ptr<const BinaryExpressionCell> to_binary(
+    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+/** Casts @p e to @c shared_ptr<const BinaryExpressionCell>.
  *  @pre @c *(e.ptr_) is of @c BinaryExpressionCell.
  */
-std::shared_ptr<BinaryExpressionCell> to_binary(const Expression& e);
+std::shared_ptr<const BinaryExpressionCell> to_binary(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionAdd>.
+/** Casts @p expr_ptr to @c shared_ptr<const ExpressionAdd>.
  *  @pre @c *expr_ptr is of @c ExpressionAdd.
  */
-std::shared_ptr<ExpressionAdd> to_addition(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-/** Casts @p e to @c shared_ptr<ExpressionAdd>.
+std::shared_ptr<const ExpressionAdd> to_addition(
+    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+/** Casts @p e to @c shared_ptr<const ExpressionAdd>.
  *  @pre @c *(e.ptr_) is of @c ExpressionAdd.
  */
-std::shared_ptr<ExpressionAdd> to_addition(const Expression& e);
+std::shared_ptr<const ExpressionAdd> to_addition(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionMul>.
+/** Casts @p expr_ptr to @c shared_ptr<const ExpressionMul>.
  *  @pre @c *expr_ptr is of @c ExpressionMul.
  */
-std::shared_ptr<ExpressionMul> to_multiplication(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-/** Casts @p e to @c shared_ptr<ExpressionMul>.
+std::shared_ptr<const ExpressionMul> to_multiplication(
+    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+/** Casts @p e to @c shared_ptr<const ExpressionMul>.
  *  @pre @c *(e.ptr_) is of @c ExpressionMul.
  */
-std::shared_ptr<ExpressionMul> to_multiplication(const Expression& e);
+std::shared_ptr<const ExpressionMul> to_multiplication(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionDiv>.
+/** Casts @p expr_ptr to @c shared_ptr<const ExpressionDiv>.
  *  @pre @c *expr_ptr is of @c ExpressionDiv.
  */
-std::shared_ptr<ExpressionDiv> to_division(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-/** Casts @p e to @c shared_ptr<ExpressionDiv>.
+std::shared_ptr<const ExpressionDiv> to_division(
+    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+/** Casts @p e to @c shared_ptr<const ExpressionDiv>.
  *  @pre @c *(e.ptr_) is of @c ExpressionDiv.
  */
-std::shared_ptr<ExpressionDiv> to_division(const Expression& e);
+std::shared_ptr<const ExpressionDiv> to_division(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionLog>.
+/** Casts @p expr_ptr to @c shared_ptr<const ExpressionLog>.
  *  @pre @c *expr_ptr is of @c ExpressionLog.
  */
-std::shared_ptr<ExpressionLog> to_log(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-/** Casts @p e to @c shared_ptr<ExpressionLog>.
+std::shared_ptr<const ExpressionLog> to_log(
+    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+/** Casts @p e to @c shared_ptr<const ExpressionLog>.
  *  @pre @c *(e.ptr_) is of @c ExpressionLog.
  */
-std::shared_ptr<ExpressionLog> to_log(const Expression& e);
+std::shared_ptr<const ExpressionLog> to_log(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionExp>.
+/** Casts @p expr_ptr to @c shared_ptr<const ExpressionExp>.
  *  @pre @c *expr_ptr is of @c ExpressionExp.
  */
-std::shared_ptr<ExpressionExp> to_exp(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-/** Casts @p e to @c shared_ptr<ExpressionExp>.
+std::shared_ptr<const ExpressionExp> to_exp(
+    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+/** Casts @p e to @c shared_ptr<const ExpressionExp>.
  *  @pre @c *(e.ptr_) is of @c ExpressionExp.
  */
-std::shared_ptr<ExpressionExp> to_exp(const Expression& e);
+std::shared_ptr<const ExpressionExp> to_exp(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionAbs>.
+/** Casts @p expr_ptr to @c shared_ptr<const ExpressionAbs>.
  *  @pre @c *expr_ptr is of @c ExpressionAbs.
  */
-std::shared_ptr<ExpressionAbs> to_abs(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-/** Casts @p e to @c shared_ptr<ExpressionAbs>.
+std::shared_ptr<const ExpressionAbs> to_abs(
+    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+/** Casts @p e to @c shared_ptr<const ExpressionAbs>.
  *  @pre @c *(e.ptr_) is of @c ExpressionAbs.
  */
-std::shared_ptr<ExpressionAbs> to_abs(const Expression& e);
+std::shared_ptr<const ExpressionAbs> to_abs(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionExp>.
+/** Casts @p expr_ptr to @c shared_ptr<const ExpressionExp>.
  *  @pre @c *expr_ptr is of @c ExpressionExp.
  */
-std::shared_ptr<ExpressionExp> to_exp(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-/** Casts @p e to @c shared_ptr<ExpressionExp>.
+std::shared_ptr<const ExpressionExp> to_exp(
+    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+/** Casts @p e to @c shared_ptr<const ExpressionExp>.
  *  @pre @c *(e.ptr_) is of @c ExpressionExp.
  */
-std::shared_ptr<ExpressionExp> to_exp(const Expression& e);
+std::shared_ptr<const ExpressionExp> to_exp(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionSqrt>.
+/** Casts @p expr_ptr to @c shared_ptr<const ExpressionSqrt>.
  *  @pre @c *expr_ptr is of @c ExpressionSqrt.
  */
-std::shared_ptr<ExpressionSqrt> to_sqrt(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-/** Casts @p e to @c shared_ptr<ExpressionSqrt>.
+std::shared_ptr<const ExpressionSqrt> to_sqrt(
+    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+/** Casts @p e to @c shared_ptr<const ExpressionSqrt>.
  *  @pre @c *(e.ptr_) is of @c ExpressionSqrt.
  */
-std::shared_ptr<ExpressionSqrt> to_sqrt(const Expression& e);
+std::shared_ptr<const ExpressionSqrt> to_sqrt(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionPow>.
+/** Casts @p expr_ptr to @c shared_ptr<const ExpressionPow>.
  *  @pre @c *expr_ptr is of @c ExpressionPow.
  */
-std::shared_ptr<ExpressionPow> to_pow(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-/** Casts @p e to @c shared_ptr<ExpressionPow>.
+std::shared_ptr<const ExpressionPow> to_pow(
+    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+/** Casts @p e to @c shared_ptr<const ExpressionPow>.
  *  @pre @c *(e.ptr_) is of @c ExpressionPow.
  */
-std::shared_ptr<ExpressionPow> to_pow(const Expression& e);
+std::shared_ptr<const ExpressionPow> to_pow(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionSin>.
+/** Casts @p expr_ptr to @c shared_ptr<const ExpressionSin>.
  *  @pre @c *expr_ptr is of @c ExpressionSin.
  */
-std::shared_ptr<ExpressionSin> to_sin(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-/** Casts @p e to @c shared_ptr<ExpressionSin>.
+std::shared_ptr<const ExpressionSin> to_sin(
+    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+/** Casts @p e to @c shared_ptr<const ExpressionSin>.
  *  @pre @c *(e.ptr_) is of @c ExpressionSin.
  */
-std::shared_ptr<ExpressionSin> to_sin(const Expression& e);
+std::shared_ptr<const ExpressionSin> to_sin(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionCos>.
+/** Casts @p expr_ptr to @c shared_ptr<const ExpressionCos>.
  *  @pre @c *expr_ptr is of @c ExpressionCos.
  */
-std::shared_ptr<ExpressionCos> to_cos(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-/** Casts @p e to @c shared_ptr<ExpressionCos>.
+std::shared_ptr<const ExpressionCos> to_cos(
+    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+/** Casts @p e to @c shared_ptr<const ExpressionCos>.
  *  @pre @c *(e.ptr_) is of @c ExpressionCos.
  */
-std::shared_ptr<ExpressionCos> to_cos(const Expression& e);
+std::shared_ptr<const ExpressionCos> to_cos(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionTan>.
+/** Casts @p expr_ptr to @c shared_ptr<const ExpressionTan>.
  *  @pre @c *expr_ptr is of @c ExpressionTan.
  */
-std::shared_ptr<ExpressionTan> to_tan(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-/** Casts @p e to @c shared_ptr<ExpressionTan>.
+std::shared_ptr<const ExpressionTan> to_tan(
+    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+/** Casts @p e to @c shared_ptr<const ExpressionTan>.
  *  @pre @c *(e.ptr_) is of @c ExpressionTan.
  */
-std::shared_ptr<ExpressionTan> to_tan(const Expression& e);
+std::shared_ptr<const ExpressionTan> to_tan(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionAsin>.
+/** Casts @p expr_ptr to @c shared_ptr<const ExpressionAsin>.
  *  @pre @c *expr_ptr is of @c ExpressionAsin.
  */
-std::shared_ptr<ExpressionAsin> to_asin(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-/** Casts @p e to @c shared_ptr<ExpressionAsin>.
+std::shared_ptr<const ExpressionAsin> to_asin(
+    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+/** Casts @p e to @c shared_ptr<const ExpressionAsin>.
  *  @pre @c *(e.ptr_) is of @c ExpressionAsin.
  */
-std::shared_ptr<ExpressionAsin> to_asin(const Expression& e);
+std::shared_ptr<const ExpressionAsin> to_asin(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionAcos>.
+/** Casts @p expr_ptr to @c shared_ptr<const ExpressionAcos>.
  *  @pre @c *expr_ptr is of @c ExpressionAcos.
  */
-std::shared_ptr<ExpressionAcos> to_acos(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-/** Casts @p e to @c shared_ptr<ExpressionAcos>.
+std::shared_ptr<const ExpressionAcos> to_acos(
+    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+/** Casts @p e to @c shared_ptr<const ExpressionAcos>.
  *  @pre @c *(e.ptr_) is of @c ExpressionAcos.
  */
-std::shared_ptr<ExpressionAcos> to_acos(const Expression& e);
+std::shared_ptr<const ExpressionAcos> to_acos(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionAtan>.
+/** Casts @p expr_ptr to @c shared_ptr<const ExpressionAtan>.
  *  @pre @c *expr_ptr is of @c ExpressionAtan.
  */
-std::shared_ptr<ExpressionAtan> to_atan(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-/** Casts @p e to @c shared_ptr<ExpressionAtan>.
+std::shared_ptr<const ExpressionAtan> to_atan(
+    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+/** Casts @p e to @c shared_ptr<const ExpressionAtan>.
  *  @pre @c *(e.ptr_) is of @c ExpressionAtan.
  */
-std::shared_ptr<ExpressionAtan> to_atan(const Expression& e);
+std::shared_ptr<const ExpressionAtan> to_atan(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionAtan2>.
+/** Casts @p expr_ptr to @c shared_ptr<const ExpressionAtan2>.
  *  @pre @c *expr_ptr is of @c ExpressionAtan2.
  */
-std::shared_ptr<ExpressionAtan2> to_atan2(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-/** Casts @p e to @c shared_ptr<ExpressionAtan2>.
+std::shared_ptr<const ExpressionAtan2> to_atan2(
+    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+/** Casts @p e to @c shared_ptr<const ExpressionAtan2>.
  *  @pre @c *(e.ptr_) is of @c ExpressionAtan2.
  */
-std::shared_ptr<ExpressionAtan2> to_atan2(const Expression& e);
+std::shared_ptr<const ExpressionAtan2> to_atan2(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionSinh>.
+/** Casts @p expr_ptr to @c shared_ptr<const ExpressionSinh>.
  *  @pre @c *expr_ptr is of @c ExpressionSinh.
  */
-std::shared_ptr<ExpressionSinh> to_sinh(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-/** Casts @p e to @c shared_ptr<ExpressionSinh>.
+std::shared_ptr<const ExpressionSinh> to_sinh(
+    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+/** Casts @p e to @c shared_ptr<const ExpressionSinh>.
  *  @pre @c *(e.ptr_) is of @c ExpressionSinh.
  */
-std::shared_ptr<ExpressionSinh> to_sinh(const Expression& e);
+std::shared_ptr<const ExpressionSinh> to_sinh(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionCosh>.
+/** Casts @p expr_ptr to @c shared_ptr<const ExpressionCosh>.
  *  @pre @c *expr_ptr is of @c ExpressionCosh.
  */
-std::shared_ptr<ExpressionCosh> to_cosh(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-/** Casts @p e to @c shared_ptr<ExpressionCosh>.
+std::shared_ptr<const ExpressionCosh> to_cosh(
+    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+/** Casts @p e to @c shared_ptr<const ExpressionCosh>.
  *  @pre @c *(e.ptr_) is of @c ExpressionCosh.
  */
-std::shared_ptr<ExpressionCosh> to_cosh(const Expression& e);
+std::shared_ptr<const ExpressionCosh> to_cosh(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionTanh>.
+/** Casts @p expr_ptr to @c shared_ptr<const ExpressionTanh>.
  *  @pre @c *expr_ptr is of @c ExpressionTanh.
  */
-std::shared_ptr<ExpressionTanh> to_tanh(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-/** Casts @p e to @c shared_ptr<ExpressionTanh>.
+std::shared_ptr<const ExpressionTanh> to_tanh(
+    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+/** Casts @p e to @c shared_ptr<const ExpressionTanh>.
  *  @pre @c *(e.ptr_) is of @c ExpressionTanh.
  */
-std::shared_ptr<ExpressionTanh> to_tanh(const Expression& e);
+std::shared_ptr<const ExpressionTanh> to_tanh(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionMin>.
+/** Casts @p expr_ptr to @c shared_ptr<const ExpressionMin>.
  *  @pre @c *expr_ptr is of @c ExpressionMin.
  */
-std::shared_ptr<ExpressionMin> to_min(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-/** Casts @p e to @c shared_ptr<ExpressionMin>.
+std::shared_ptr<const ExpressionMin> to_min(
+    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+/** Casts @p e to @c shared_ptr<const ExpressionMin>.
  *  @pre @c *(e.ptr_) is of @c ExpressionMin.
  */
-std::shared_ptr<ExpressionMin> to_min(const Expression& e);
+std::shared_ptr<const ExpressionMin> to_min(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionMax>.
+/** Casts @p expr_ptr to @c shared_ptr<const ExpressionMax>.
  *  @pre @c *expr_ptr is of @c ExpressionMax.
  */
-std::shared_ptr<ExpressionMax> to_max(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-/** Casts @p e to @c shared_ptr<ExpressionMax>.
+std::shared_ptr<const ExpressionMax> to_max(
+    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+/** Casts @p e to @c shared_ptr<const ExpressionMax>.
  *  @pre @c *(e.ptr_) is of @c ExpressionMax.
  */
-std::shared_ptr<ExpressionMax> to_max(const Expression& e);
+std::shared_ptr<const ExpressionMax> to_max(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionCeiling>.
+/** Casts @p expr_ptr to @c shared_ptr<const ExpressionCeiling>.
  *  @pre @c *expr_ptr is of @c ExpressionCeiling.
  */
-std::shared_ptr<ExpressionCeiling> to_ceil(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-/** Casts @p e to @c shared_ptr<ExpressionCeiling>.
+std::shared_ptr<const ExpressionCeiling> to_ceil(
+    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+/** Casts @p e to @c shared_ptr<const ExpressionCeiling>.
  *  @pre @c *(e.ptr_) is of @c ExpressionCeiling.
  */
-std::shared_ptr<ExpressionCeiling> to_ceil(const Expression& e);
+std::shared_ptr<const ExpressionCeiling> to_ceil(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionFloor>.
+/** Casts @p expr_ptr to @c shared_ptr<const ExpressionFloor>.
  *  @pre @c *expr_ptr is of @c ExpressionFloor.
  */
-std::shared_ptr<ExpressionFloor> to_floor(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-/** Casts @p e to @c shared_ptr<ExpressionFloor>.
+std::shared_ptr<const ExpressionFloor> to_floor(
+    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+/** Casts @p e to @c shared_ptr<const ExpressionFloor>.
  *  @pre @c *(e.ptr_) is of @c ExpressionFloor.
  */
-std::shared_ptr<ExpressionFloor> to_floor(const Expression& e);
+std::shared_ptr<const ExpressionFloor> to_floor(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionIfThenElse>.
+/** Casts @p expr_ptr to @c shared_ptr<const ExpressionIfThenElse>.
  *  @pre @c *expr_ptr is of @c ExpressionIfThenElse.
  */
-std::shared_ptr<ExpressionIfThenElse> to_if_then_else(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-/** Casts @p e to @c shared_ptr<ExpressionIfThenElse>.
+std::shared_ptr<const ExpressionIfThenElse> to_if_then_else(
+    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+/** Casts @p e to @c shared_ptr<const ExpressionIfThenElse>.
  *  @pre @c *(e.ptr_) is of @c ExpressionIfThenElse.
  */
-std::shared_ptr<ExpressionIfThenElse> to_if_then_else(const Expression& e);
+std::shared_ptr<const ExpressionIfThenElse> to_if_then_else(
+    const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionUninterpretedFunction>.
+/** Casts @p expr_ptr to @c shared_ptr<const ExpressionUninterpretedFunction>.
  *  @pre @c *expr_ptr is of @c ExpressionUninterpretedFunction.
  */
-std::shared_ptr<ExpressionUninterpretedFunction> to_uninterpreted_function(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-/** Casts @p e to @c shared_ptr<ExpressionUninterpretedFunction>.
+std::shared_ptr<const ExpressionUninterpretedFunction>
+to_uninterpreted_function(
+    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+/** Casts @p e to @c shared_ptr<const ExpressionUninterpretedFunction>.
  *  @pre @c *(e.ptr_) is of @c ExpressionUninterpretedFunction.
  */
-std::shared_ptr<ExpressionUninterpretedFunction> to_uninterpreted_function(
-    const Expression& e);
+std::shared_ptr<const ExpressionUninterpretedFunction>
+to_uninterpreted_function(const Expression& e);
 
 }  // namespace symbolic
 }  // namespace drake

--- a/common/symbolic_formula.cc
+++ b/common/symbolic_formula.cc
@@ -27,9 +27,11 @@ bool operator<(FormulaKind k1, FormulaKind k2) {
   return static_cast<int>(k1) < static_cast<int>(k2);
 }
 
-Formula::Formula(std::shared_ptr<FormulaCell> ptr) : ptr_{std::move(ptr)} {}
+Formula::Formula(std::shared_ptr<const FormulaCell> ptr)
+    : ptr_{std::move(ptr)} {}
 
-Formula::Formula(const Variable& var) : ptr_{make_shared<FormulaVar>(var)} {}
+Formula::Formula(const Variable& var)
+    : ptr_{make_shared<const FormulaVar>(var)} {}
 
 FormulaKind Formula::get_kind() const {
   DRAKE_ASSERT(ptr_ != nullptr);
@@ -99,16 +101,16 @@ string Formula::to_string() const {
 }
 
 Formula Formula::True() {
-  static Formula tt{make_shared<FormulaTrue>()};
+  static Formula tt{make_shared<const FormulaTrue>()};
   return tt;
 }
 Formula Formula::False() {
-  static Formula ff{make_shared<FormulaFalse>()};
+  static Formula ff{make_shared<const FormulaFalse>()};
   return ff;
 }
 
 Formula forall(const Variables& vars, const Formula& f) {
-  return Formula{make_shared<FormulaForall>(vars, f)};
+  return Formula{make_shared<const FormulaForall>(vars, f)};
 }
 
 Formula make_conjunction(const set<Formula>& formulas) {
@@ -142,7 +144,7 @@ Formula make_conjunction(const set<Formula>& formulas) {
     return *(operands.begin());
   }
   // TODO(soonho-tri): Returns False if both f and ¬f appear in operands.
-  return Formula{make_shared<FormulaAnd>(operands)};
+  return Formula{make_shared<const FormulaAnd>(operands)};
 }
 
 Formula operator&&(const Formula& f1, const Formula& f2) {
@@ -190,7 +192,7 @@ Formula make_disjunction(const set<Formula>& formulas) {
     return *(operands.begin());
   }
   // TODO(soonho-tri): Returns True if both f and ¬f appear in operands.
-  return Formula{make_shared<FormulaOr>(operands)};
+  return Formula{make_shared<const FormulaOr>(operands)};
 }
 
 Formula operator||(const Formula& f1, const Formula& f2) {
@@ -217,7 +219,7 @@ Formula operator!(const Formula& f) {
   if (is_negation(f)) {
     return get_operand(f);
   }
-  return Formula{make_shared<FormulaNot>(f)};
+  return Formula{make_shared<const FormulaNot>(f)};
 }
 
 Formula operator!(const Variable& v) { return !Formula(v); }
@@ -233,7 +235,7 @@ Formula operator==(const Expression& e1, const Expression& e2) {
   if (diff.get_kind() == ExpressionKind::Constant) {
     return diff.Evaluate() == 0.0 ? Formula::True() : Formula::False();
   }
-  return Formula{make_shared<FormulaEq>(e1, e2)};
+  return Formula{make_shared<const FormulaEq>(e1, e2)};
 }
 
 Formula operator!=(const Expression& e1, const Expression& e2) {
@@ -242,7 +244,7 @@ Formula operator!=(const Expression& e1, const Expression& e2) {
   if (diff.get_kind() == ExpressionKind::Constant) {
     return diff.Evaluate() != 0.0 ? Formula::True() : Formula::False();
   }
-  return Formula{make_shared<FormulaNeq>(e1, e2)};
+  return Formula{make_shared<const FormulaNeq>(e1, e2)};
 }
 
 Formula operator<(const Expression& e1, const Expression& e2) {
@@ -251,7 +253,7 @@ Formula operator<(const Expression& e1, const Expression& e2) {
   if (diff.get_kind() == ExpressionKind::Constant) {
     return diff.Evaluate() < 0 ? Formula::True() : Formula::False();
   }
-  return Formula{make_shared<FormulaLt>(e1, e2)};
+  return Formula{make_shared<const FormulaLt>(e1, e2)};
 }
 
 Formula operator<=(const Expression& e1, const Expression& e2) {
@@ -260,7 +262,7 @@ Formula operator<=(const Expression& e1, const Expression& e2) {
   if (diff.get_kind() == ExpressionKind::Constant) {
     return diff.Evaluate() <= 0 ? Formula::True() : Formula::False();
   }
-  return Formula{make_shared<FormulaLeq>(e1, e2)};
+  return Formula{make_shared<const FormulaLeq>(e1, e2)};
 }
 
 Formula operator>(const Expression& e1, const Expression& e2) {
@@ -269,7 +271,7 @@ Formula operator>(const Expression& e1, const Expression& e2) {
   if (diff.get_kind() == ExpressionKind::Constant) {
     return diff.Evaluate() > 0 ? Formula::True() : Formula::False();
   }
-  return Formula{make_shared<FormulaGt>(e1, e2)};
+  return Formula{make_shared<const FormulaGt>(e1, e2)};
 }
 
 Formula operator>=(const Expression& e1, const Expression& e2) {
@@ -278,11 +280,11 @@ Formula operator>=(const Expression& e1, const Expression& e2) {
   if (diff.get_kind() == ExpressionKind::Constant) {
     return diff.Evaluate() >= 0 ? Formula::True() : Formula::False();
   }
-  return Formula{make_shared<FormulaGeq>(e1, e2)};
+  return Formula{make_shared<const FormulaGeq>(e1, e2)};
 }
 
 Formula isnan(const Expression& e) {
-  return Formula{make_shared<FormulaIsnan>(e)};
+  return Formula{make_shared<const FormulaIsnan>(e)};
 }
 
 Formula isinf(const Expression& e) {
@@ -296,17 +298,17 @@ Formula isfinite(const Expression& e) {
 }
 
 Formula positive_semidefinite(const Eigen::Ref<const MatrixX<Expression>>& m) {
-  return Formula{make_shared<FormulaPositiveSemidefinite>(m)};
+  return Formula{make_shared<const FormulaPositiveSemidefinite>(m)};
 }
 
 Formula positive_semidefinite(const MatrixX<Expression>& m,
                               const Eigen::UpLoType mode) {
   switch (mode) {
     case Eigen::Lower:
-      return Formula{make_shared<FormulaPositiveSemidefinite>(
+      return Formula{make_shared<const FormulaPositiveSemidefinite>(
           m.triangularView<Eigen::Lower>())};
     case Eigen::Upper:
-      return Formula{make_shared<FormulaPositiveSemidefinite>(
+      return Formula{make_shared<const FormulaPositiveSemidefinite>(
           m.triangularView<Eigen::Upper>())};
     default:
       throw std::runtime_error(

--- a/common/symbolic_formula.h
+++ b/common/symbolic_formula.h
@@ -123,10 +123,9 @@ class Formula {
   /** Constructs from a `bool`.  This overload is also used by Eigen when
    * EIGEN_INITIALIZE_MATRICES_BY_ZERO is enabled.
    */
-  explicit Formula(bool value)
-      : Formula(value ? True() : False()) {}
+  explicit Formula(bool value) : Formula(value ? True() : False()) {}
 
-  explicit Formula(std::shared_ptr<FormulaCell> ptr);
+  explicit Formula(std::shared_ptr<const FormulaCell> ptr);
 
   /** Constructs a formula from @p var.
    * @pre @p var is of BOOLEAN type and not a dummy variable.
@@ -194,8 +193,7 @@ class Formula {
 
   /** Implements the @ref hash_append concept. */
   template <class HashAlgorithm>
-  friend void hash_append(
-      HashAlgorithm& hasher, const Formula& item) noexcept {
+  friend void hash_append(HashAlgorithm& hasher, const Formula& item) noexcept {
     DelegatingHasher delegating_hasher(
         [&hasher](const void* data, const size_t length) {
           return hasher(data, length);
@@ -226,30 +224,35 @@ class Formula {
   // Note that the following cast functions are only for low-level operations
   // and not exposed to the user of symbolic_formula.h. These functions are
   // declared in symbolic_formula_cell.h header.
-  friend std::shared_ptr<FormulaFalse> to_false(const Formula& f);
-  friend std::shared_ptr<FormulaTrue> to_true(const Formula& f);
-  friend std::shared_ptr<FormulaVar> to_variable(const Formula& f);
-  friend std::shared_ptr<RelationalFormulaCell> to_relational(const Formula& f);
-  friend std::shared_ptr<FormulaEq> to_equal_to(const Formula& f);
-  friend std::shared_ptr<FormulaNeq> to_not_equal_to(const Formula& f);
-  friend std::shared_ptr<FormulaGt> to_greater_than(const Formula& f);
-  friend std::shared_ptr<FormulaGeq> to_greater_than_or_equal_to(
+  friend std::shared_ptr<const FormulaFalse> to_false(const Formula& f);
+  friend std::shared_ptr<const FormulaTrue> to_true(const Formula& f);
+  friend std::shared_ptr<const FormulaVar> to_variable(const Formula& f);
+  friend std::shared_ptr<const RelationalFormulaCell> to_relational(
       const Formula& f);
-  friend std::shared_ptr<FormulaLt> to_less_than(const Formula& f);
-  friend std::shared_ptr<FormulaLeq> to_less_than_or_equal_to(const Formula& f);
-  friend std::shared_ptr<NaryFormulaCell> to_nary(const Formula& f);
-  friend std::shared_ptr<FormulaAnd> to_conjunction(const Formula& f);
-  friend std::shared_ptr<FormulaOr> to_disjunction(const Formula& f);
-  friend std::shared_ptr<FormulaNot> to_negation(const Formula& f);
-  friend std::shared_ptr<FormulaForall> to_forall(const Formula& f);
-  friend std::shared_ptr<FormulaIsnan> to_isnan(const Formula& f);
-  friend std::shared_ptr<FormulaPositiveSemidefinite> to_positive_semidefinite(
+  friend std::shared_ptr<const FormulaEq> to_equal_to(const Formula& f);
+  friend std::shared_ptr<const FormulaNeq> to_not_equal_to(const Formula& f);
+  friend std::shared_ptr<const FormulaGt> to_greater_than(const Formula& f);
+  friend std::shared_ptr<const FormulaGeq> to_greater_than_or_equal_to(
       const Formula& f);
+  friend std::shared_ptr<const FormulaLt> to_less_than(const Formula& f);
+  friend std::shared_ptr<const FormulaLeq> to_less_than_or_equal_to(
+      const Formula& f);
+  friend std::shared_ptr<const NaryFormulaCell> to_nary(const Formula& f);
+  friend std::shared_ptr<const FormulaAnd> to_conjunction(const Formula& f);
+  friend std::shared_ptr<const FormulaOr> to_disjunction(const Formula& f);
+  friend std::shared_ptr<const FormulaNot> to_negation(const Formula& f);
+  friend std::shared_ptr<const FormulaForall> to_forall(const Formula& f);
+  friend std::shared_ptr<const FormulaIsnan> to_isnan(const Formula& f);
+  friend std::shared_ptr<const FormulaPositiveSemidefinite>
+  to_positive_semidefinite(const Formula& f);
 
  private:
   void HashAppend(DelegatingHasher* hasher) const;
 
-  std::shared_ptr<FormulaCell> ptr_;
+  // Note: We use "const" FormulaCell type here because a FormulaCell object can
+  // be shared by multiple formulas, a formula should _not_ be able to change
+  // the cell that it points to.
+  std::shared_ptr<const FormulaCell> ptr_;
 };
 
 /** Returns a formula @p f, universally quantified by variables @p vars. */
@@ -1112,11 +1115,10 @@ inline bool ExtractBoolOrThrow(const Bool<symbolic::Expression>& b) {
 namespace std {
 /* Provides std::hash<drake::symbolic::Formula>. */
 template <>
-struct hash<drake::symbolic::Formula>
-    : public drake::DefaultHash {};
+struct hash<drake::symbolic::Formula> : public drake::DefaultHash {};
 #if defined(__GLIBCXX__)
 // https://gcc.gnu.org/onlinedocs/libstdc++/manual/unordered_associative.html
-template<>
+template <>
 struct __is_fast_hash<hash<drake::symbolic::Formula>> : std::false_type {};
 #endif
 

--- a/common/symbolic_formula_cell.cc
+++ b/common/symbolic_formula_cell.cc
@@ -27,15 +27,12 @@ using std::shared_ptr;
 using std::static_pointer_cast;
 using std::string;
 
-FormulaCell::FormulaCell(const FormulaKind k)
-    : kind_{k} {}
+FormulaCell::FormulaCell(const FormulaKind k) : kind_{k} {}
 
 RelationalFormulaCell::RelationalFormulaCell(const FormulaKind k,
                                              const Expression& lhs,
                                              const Expression& rhs)
-    : FormulaCell{k},
-      e_lhs_{lhs},
-      e_rhs_{rhs} {}
+    : FormulaCell{k}, e_lhs_{lhs}, e_rhs_{rhs} {}
 
 void RelationalFormulaCell::HashAppendDetail(DelegatingHasher* hasher) const {
   DRAKE_ASSERT(hasher);
@@ -72,8 +69,7 @@ bool RelationalFormulaCell::Less(const FormulaCell& f) const {
 
 NaryFormulaCell::NaryFormulaCell(const FormulaKind k,
                                  const set<Formula>& formulas)
-    : FormulaCell{k},
-      formulas_{formulas} {}
+    : FormulaCell{k}, formulas_{formulas} {}
 
 void NaryFormulaCell::HashAppendDetail(DelegatingHasher* hasher) const {
   DRAKE_ASSERT(hasher);
@@ -124,8 +120,7 @@ ostream& NaryFormulaCell::DisplayWithOp(ostream& os, const string& op) const {
   return os;
 }
 
-FormulaTrue::FormulaTrue()
-    : FormulaCell{FormulaKind::True} {}
+FormulaTrue::FormulaTrue() : FormulaCell{FormulaKind::True} {}
 
 void FormulaTrue::HashAppendDetail(DelegatingHasher*) const {}
 
@@ -152,8 +147,7 @@ Formula FormulaTrue::Substitute(const Substitution&) const {
 
 ostream& FormulaTrue::Display(ostream& os) const { return os << "True"; }
 
-FormulaFalse::FormulaFalse()
-    : FormulaCell{FormulaKind::False} {}
+FormulaFalse::FormulaFalse() : FormulaCell{FormulaKind::False} {}
 
 void FormulaFalse::HashAppendDetail(DelegatingHasher*) const {}
 
@@ -446,9 +440,7 @@ ostream& FormulaNot::Display(ostream& os) const {
 }
 
 FormulaForall::FormulaForall(const Variables& vars, const Formula& f)
-    : FormulaCell{FormulaKind::Forall},
-      vars_{vars},
-      f_{f} {}
+    : FormulaCell{FormulaKind::Forall}, vars_{vars}, f_{f} {}
 
 void FormulaForall::HashAppendDetail(DelegatingHasher* hasher) const {
   DRAKE_ASSERT(hasher);
@@ -544,8 +536,7 @@ ostream& FormulaIsnan::Display(ostream& os) const {
 
 FormulaPositiveSemidefinite::FormulaPositiveSemidefinite(
     const Eigen::Ref<const MatrixX<Expression>>& m)
-    : FormulaCell{FormulaKind::PositiveSemidefinite},
-      m_{m} {
+    : FormulaCell{FormulaKind::PositiveSemidefinite}, m_{m} {
   if (!math::IsSymmetric(m)) {
     ostringstream oss;
     oss << "The following matrix is not symmetric and cannot be used to "
@@ -575,8 +566,8 @@ struct VariablesCollector {
 };
 }  // namespace
 
-void FormulaPositiveSemidefinite::HashAppendDetail(DelegatingHasher* hasher)
-    const {
+void FormulaPositiveSemidefinite::HashAppendDetail(
+    DelegatingHasher* hasher) const {
   DRAKE_ASSERT(hasher);
   using drake::hash_append;
   // Computes a hash of a matrix only using its lower-triangular part.
@@ -600,7 +591,7 @@ bool FormulaPositiveSemidefinite::EqualTo(const FormulaCell& f) const {
   const FormulaPositiveSemidefinite& f_psd{
       static_cast<const FormulaPositiveSemidefinite&>(f)};
   return (m_.rows() == f_psd.m_.rows()) && (m_.cols() == f_psd.m_.cols()) &&
-      CheckStructuralEquality(m_, f_psd.m_);
+         CheckStructuralEquality(m_, f_psd.m_);
 }
 
 bool FormulaPositiveSemidefinite::Less(const FormulaCell& f) const {
@@ -714,154 +705,173 @@ bool is_positive_semidefinite(const FormulaCell& f) {
   return f.get_kind() == FormulaKind::PositiveSemidefinite;
 }
 
-shared_ptr<FormulaFalse> to_false(const shared_ptr<FormulaCell>& f_ptr) {
+shared_ptr<const FormulaFalse> to_false(
+    const shared_ptr<const FormulaCell>& f_ptr) {
   DRAKE_ASSERT(is_false(*f_ptr));
-  return static_pointer_cast<FormulaFalse>(f_ptr);
+  return static_pointer_cast<const FormulaFalse>(f_ptr);
 }
 
-shared_ptr<FormulaFalse> to_false(const Formula& f) { return to_false(f.ptr_); }
+shared_ptr<const FormulaFalse> to_false(const Formula& f) {
+  return to_false(f.ptr_);
+}
 
-shared_ptr<FormulaTrue> to_true(const shared_ptr<FormulaCell>& f_ptr) {
+shared_ptr<const FormulaTrue> to_true(
+    const shared_ptr<const FormulaCell>& f_ptr) {
   DRAKE_ASSERT(is_true(*f_ptr));
-  return static_pointer_cast<FormulaTrue>(f_ptr);
+  return static_pointer_cast<const FormulaTrue>(f_ptr);
 }
 
-shared_ptr<FormulaTrue> to_true(const Formula& f) { return to_true(f.ptr_); }
+shared_ptr<const FormulaTrue> to_true(const Formula& f) {
+  return to_true(f.ptr_);
+}
 
-shared_ptr<FormulaVar> to_variable(const shared_ptr<FormulaCell>& f_ptr) {
+shared_ptr<const FormulaVar> to_variable(
+    const shared_ptr<const FormulaCell>& f_ptr) {
   DRAKE_ASSERT(is_variable(*f_ptr));
-  return static_pointer_cast<FormulaVar>(f_ptr);
+  return static_pointer_cast<const FormulaVar>(f_ptr);
 }
 
-shared_ptr<FormulaVar> to_variable(const Formula& f) {
+shared_ptr<const FormulaVar> to_variable(const Formula& f) {
   return to_variable(f.ptr_);
 }
 
-shared_ptr<RelationalFormulaCell> to_relational(
-    const shared_ptr<FormulaCell>& f_ptr) {
+shared_ptr<const RelationalFormulaCell> to_relational(
+    const shared_ptr<const FormulaCell>& f_ptr) {
   DRAKE_ASSERT(is_relational(*f_ptr));
-  return static_pointer_cast<RelationalFormulaCell>(f_ptr);
+  return static_pointer_cast<const RelationalFormulaCell>(f_ptr);
 }
 
-shared_ptr<RelationalFormulaCell> to_relational(const Formula& f) {
+shared_ptr<const RelationalFormulaCell> to_relational(const Formula& f) {
   return to_relational(f.ptr_);
 }
 
-shared_ptr<FormulaEq> to_equal_to(const shared_ptr<FormulaCell>& f_ptr) {
+shared_ptr<const FormulaEq> to_equal_to(
+    const shared_ptr<const FormulaCell>& f_ptr) {
   DRAKE_ASSERT(is_equal_to(*f_ptr));
-  return static_pointer_cast<FormulaEq>(f_ptr);
+  return static_pointer_cast<const FormulaEq>(f_ptr);
 }
 
-shared_ptr<FormulaEq> to_equal_to(const Formula& f) {
+shared_ptr<const FormulaEq> to_equal_to(const Formula& f) {
   return to_equal_to(f.ptr_);
 }
 
-shared_ptr<FormulaNeq> to_not_equal_to(const shared_ptr<FormulaCell>& f_ptr) {
+shared_ptr<const FormulaNeq> to_not_equal_to(
+    const shared_ptr<const FormulaCell>& f_ptr) {
   DRAKE_ASSERT(is_not_equal_to(*f_ptr));
-  return static_pointer_cast<FormulaNeq>(f_ptr);
+  return static_pointer_cast<const FormulaNeq>(f_ptr);
 }
 
-shared_ptr<FormulaNeq> to_not_equal_to(const Formula& f) {
+shared_ptr<const FormulaNeq> to_not_equal_to(const Formula& f) {
   return to_not_equal_to(f.ptr_);
 }
 
-shared_ptr<FormulaGt> to_greater_than(const shared_ptr<FormulaCell>& f_ptr) {
+shared_ptr<const FormulaGt> to_greater_than(
+    const shared_ptr<const FormulaCell>& f_ptr) {
   DRAKE_ASSERT(is_greater_than(*f_ptr));
-  return static_pointer_cast<FormulaGt>(f_ptr);
+  return static_pointer_cast<const FormulaGt>(f_ptr);
 }
 
-shared_ptr<FormulaGt> to_greater_than(const Formula& f) {
+shared_ptr<const FormulaGt> to_greater_than(const Formula& f) {
   return to_greater_than(f.ptr_);
 }
 
-shared_ptr<FormulaGeq> to_greater_than_or_equal_to(
-    const shared_ptr<FormulaCell>& f_ptr) {
+shared_ptr<const FormulaGeq> to_greater_than_or_equal_to(
+    const shared_ptr<const FormulaCell>& f_ptr) {
   DRAKE_ASSERT(is_greater_than_or_equal_to(*f_ptr));
-  return static_pointer_cast<FormulaGeq>(f_ptr);
+  return static_pointer_cast<const FormulaGeq>(f_ptr);
 }
 
-shared_ptr<FormulaGeq> to_greater_than_or_equal_to(const Formula& f) {
+shared_ptr<const FormulaGeq> to_greater_than_or_equal_to(const Formula& f) {
   return to_greater_than_or_equal_to(f.ptr_);
 }
 
-shared_ptr<FormulaLt> to_less_than(const shared_ptr<FormulaCell>& f_ptr) {
+shared_ptr<const FormulaLt> to_less_than(
+    const shared_ptr<const FormulaCell>& f_ptr) {
   DRAKE_ASSERT(is_less_than(*f_ptr));
-  return static_pointer_cast<FormulaLt>(f_ptr);
+  return static_pointer_cast<const FormulaLt>(f_ptr);
 }
 
-shared_ptr<FormulaLt> to_less_than(const Formula& f) {
+shared_ptr<const FormulaLt> to_less_than(const Formula& f) {
   return to_less_than(f.ptr_);
 }
 
-shared_ptr<FormulaLeq> to_less_than_or_equal_to(
-    const shared_ptr<FormulaCell>& f_ptr) {
+shared_ptr<const FormulaLeq> to_less_than_or_equal_to(
+    const shared_ptr<const FormulaCell>& f_ptr) {
   DRAKE_ASSERT(is_less_than_or_equal_to(*f_ptr));
-  return static_pointer_cast<FormulaLeq>(f_ptr);
+  return static_pointer_cast<const FormulaLeq>(f_ptr);
 }
 
-shared_ptr<FormulaLeq> to_less_than_or_equal_to(const Formula& f) {
+shared_ptr<const FormulaLeq> to_less_than_or_equal_to(const Formula& f) {
   return to_less_than_or_equal_to(f.ptr_);
 }
 
-shared_ptr<NaryFormulaCell> to_nary(const shared_ptr<FormulaCell>& f_ptr) {
+shared_ptr<const NaryFormulaCell> to_nary(
+    const shared_ptr<const FormulaCell>& f_ptr) {
   DRAKE_ASSERT(is_nary(*f_ptr));
-  return static_pointer_cast<NaryFormulaCell>(f_ptr);
+  return static_pointer_cast<const NaryFormulaCell>(f_ptr);
 }
 
-shared_ptr<NaryFormulaCell> to_nary(const Formula& f) {
+shared_ptr<const NaryFormulaCell> to_nary(const Formula& f) {
   return to_nary(f.ptr_);
 }
 
-shared_ptr<FormulaAnd> to_conjunction(const shared_ptr<FormulaCell>& f_ptr) {
+shared_ptr<const FormulaAnd> to_conjunction(
+    const shared_ptr<const FormulaCell>& f_ptr) {
   DRAKE_ASSERT(is_conjunction(*f_ptr));
-  return static_pointer_cast<FormulaAnd>(f_ptr);
+  return static_pointer_cast<const FormulaAnd>(f_ptr);
 }
 
-shared_ptr<FormulaAnd> to_conjunction(const Formula& f) {
+shared_ptr<const FormulaAnd> to_conjunction(const Formula& f) {
   return to_conjunction(f.ptr_);
 }
 
-shared_ptr<FormulaOr> to_disjunction(const shared_ptr<FormulaCell>& f_ptr) {
+shared_ptr<const FormulaOr> to_disjunction(
+    const shared_ptr<const FormulaCell>& f_ptr) {
   DRAKE_ASSERT(is_disjunction(*f_ptr));
-  return static_pointer_cast<FormulaOr>(f_ptr);
+  return static_pointer_cast<const FormulaOr>(f_ptr);
 }
 
-shared_ptr<FormulaOr> to_disjunction(const Formula& f) {
+shared_ptr<const FormulaOr> to_disjunction(const Formula& f) {
   return to_disjunction(f.ptr_);
 }
 
-shared_ptr<FormulaNot> to_negation(const shared_ptr<FormulaCell>& f_ptr) {
+shared_ptr<const FormulaNot> to_negation(
+    const shared_ptr<const FormulaCell>& f_ptr) {
   DRAKE_ASSERT(is_negation(*f_ptr));
-  return static_pointer_cast<FormulaNot>(f_ptr);
+  return static_pointer_cast<const FormulaNot>(f_ptr);
 }
 
-shared_ptr<FormulaNot> to_negation(const Formula& f) {
+shared_ptr<const FormulaNot> to_negation(const Formula& f) {
   return to_negation(f.ptr_);
 }
 
-shared_ptr<FormulaForall> to_forall(const shared_ptr<FormulaCell>& f_ptr) {
+shared_ptr<const FormulaForall> to_forall(
+    const shared_ptr<const FormulaCell>& f_ptr) {
   DRAKE_ASSERT(is_forall(*f_ptr));
-  return static_pointer_cast<FormulaForall>(f_ptr);
+  return static_pointer_cast<const FormulaForall>(f_ptr);
 }
 
-shared_ptr<FormulaForall> to_forall(const Formula& f) {
+shared_ptr<const FormulaForall> to_forall(const Formula& f) {
   return to_forall(f.ptr_);
 }
 
-shared_ptr<FormulaIsnan> to_isnan(const shared_ptr<FormulaCell>& f_ptr) {
+shared_ptr<const FormulaIsnan> to_isnan(
+    const shared_ptr<const FormulaCell>& f_ptr) {
   DRAKE_ASSERT(is_isnan(*f_ptr));
-  return static_pointer_cast<FormulaIsnan>(f_ptr);
+  return static_pointer_cast<const FormulaIsnan>(f_ptr);
 }
 
-shared_ptr<FormulaIsnan> to_isnan(const Formula& f) { return to_isnan(f.ptr_); }
+shared_ptr<const FormulaIsnan> to_isnan(const Formula& f) {
+  return to_isnan(f.ptr_);
+}
 
-shared_ptr<FormulaPositiveSemidefinite> to_positive_semidefinite(
-    const shared_ptr<FormulaCell>& f_ptr) {
+shared_ptr<const FormulaPositiveSemidefinite> to_positive_semidefinite(
+    const shared_ptr<const FormulaCell>& f_ptr) {
   DRAKE_ASSERT(is_positive_semidefinite(*f_ptr));
-  return static_pointer_cast<FormulaPositiveSemidefinite>(f_ptr);
+  return static_pointer_cast<const FormulaPositiveSemidefinite>(f_ptr);
 }
 
-shared_ptr<FormulaPositiveSemidefinite> to_positive_semidefinite(
+shared_ptr<const FormulaPositiveSemidefinite> to_positive_semidefinite(
     const Formula& f) {
   return to_positive_semidefinite(f.ptr_);
 }

--- a/common/symbolic_formula_cell.h
+++ b/common/symbolic_formula_cell.h
@@ -461,188 +461,189 @@ bool is_isnan(const FormulaCell& f);
 /** Checks if @p f is a positive semidefinite formula. */
 bool is_positive_semidefinite(const FormulaCell& f);
 
-/** Casts @p f_ptr to @c shared_ptr<FormulaFalse>.
+/** Casts @p f_ptr to @c shared_ptr<const FormulaFalse>.
  * @pre @c is_false(*f_ptr) is true.
  */
-std::shared_ptr<FormulaFalse> to_false(
-    const std::shared_ptr<FormulaCell>& f_ptr);
-/** Casts @p f to @c shared_ptr<FormulaFalse>.
+std::shared_ptr<const FormulaFalse> to_false(
+    const std::shared_ptr<const FormulaCell>& f_ptr);
+/** Casts @p f to @c shared_ptr<const FormulaFalse>.
  * @pre @c is_false(f) is true.
  */
-std::shared_ptr<FormulaFalse> to_false(const Formula& f);
+std::shared_ptr<const FormulaFalse> to_false(const Formula& f);
 
-/** Casts @p f_ptr to @c shared_ptr<FormulaTrue>.
+/** Casts @p f_ptr to @c shared_ptr<const FormulaTrue>.
  * @pre @c is_true(*f_ptr) is true.
  */
-std::shared_ptr<FormulaTrue> to_true(const std::shared_ptr<FormulaCell>& f_ptr);
-/** Casts @p f to @c shared_ptr<FormulaTrue>.
+std::shared_ptr<const FormulaTrue> to_true(
+    const std::shared_ptr<const FormulaCell>& f_ptr);
+/** Casts @p f to @c shared_ptr<const FormulaTrue>.
  * @pre @c is_true(f) is true.
  */
-std::shared_ptr<FormulaTrue> to_true(const Formula& f);
+std::shared_ptr<const FormulaTrue> to_true(const Formula& f);
 
-/** Casts @p f_ptr to @c shared_ptr<FormulaVar>.
+/** Casts @p f_ptr to @c shared_ptr<const FormulaVar>.
  * @pre @c is_variable(*f_ptr) is true.
  */
-std::shared_ptr<FormulaVar> to_variable(
-    const std::shared_ptr<FormulaCell>& f_ptr);
-/** Casts @p f to @c shared_ptr<FormulaVar>.
+std::shared_ptr<const FormulaVar> to_variable(
+    const std::shared_ptr<const FormulaCell>& f_ptr);
+/** Casts @p f to @c shared_ptr<const FormulaVar>.
  * @pre @c is_variable(f) is true.
  */
-std::shared_ptr<FormulaVar> to_variable(const Formula& f);
+std::shared_ptr<const FormulaVar> to_variable(const Formula& f);
 
-/** Casts @p f_ptr to @c shared_ptr<RelationalFormulaCell>.
+/** Casts @p f_ptr to @c shared_ptr<const RelationalFormulaCell>.
  * @pre @c is_relational(*f_ptr) is true.
  */
-std::shared_ptr<RelationalFormulaCell> to_relational(
-    const std::shared_ptr<FormulaCell>& f_ptr);
+std::shared_ptr<const RelationalFormulaCell> to_relational(
+    const std::shared_ptr<const FormulaCell>& f_ptr);
 
-/** Casts @p f to @c shared_ptr<RelationalFormulaCell>.
+/** Casts @p f to @c shared_ptr<const RelationalFormulaCell>.
  * @pre @c is_relational(f) is true.
  */
-std::shared_ptr<RelationalFormulaCell> to_relational(const Formula& f);
+std::shared_ptr<const RelationalFormulaCell> to_relational(const Formula& f);
 
-/** Casts @p f_ptr to @c shared_ptr<FormulaEq>.
+/** Casts @p f_ptr to @c shared_ptr<const FormulaEq>.
  * @pre @c is_equal_to(*f_ptr) is true.
  */
-std::shared_ptr<FormulaEq> to_equal_to(
-    const std::shared_ptr<FormulaCell>& f_ptr);
+std::shared_ptr<const FormulaEq> to_equal_to(
+    const std::shared_ptr<const FormulaCell>& f_ptr);
 
-/** Casts @p f to @c shared_ptr<FormulaEq>.
+/** Casts @p f to @c shared_ptr<const FormulaEq>.
  * @pre @c is_equal_to(f) is true.
  */
-std::shared_ptr<FormulaEq> to_equal_to(const Formula& f);
+std::shared_ptr<const FormulaEq> to_equal_to(const Formula& f);
 
-/** Casts @p f_ptr to @c shared_ptr<FormulaNeq>.
+/** Casts @p f_ptr to @c shared_ptr<const FormulaNeq>.
  * @pre @c is_not_equal_to(*f_ptr) is true.
  */
-std::shared_ptr<FormulaNeq> to_not_equal_to(
-    const std::shared_ptr<FormulaCell>& f_ptr);
+std::shared_ptr<const FormulaNeq> to_not_equal_to(
+    const std::shared_ptr<const FormulaCell>& f_ptr);
 
-/** Casts @p f to @c shared_ptr<FormulaNeq>.
+/** Casts @p f to @c shared_ptr<const FormulaNeq>.
  * @pre @c is_not_equal_to(f) is true.
  */
-std::shared_ptr<FormulaNeq> to_not_equal_to(const Formula& f);
+std::shared_ptr<const FormulaNeq> to_not_equal_to(const Formula& f);
 
-/** Casts @p f_ptr to @c shared_ptr<FormulaGt>.
+/** Casts @p f_ptr to @c shared_ptr<const FormulaGt>.
  * @pre @c is_greater_than(*f_ptr) is true.
  */
-std::shared_ptr<FormulaGt> to_greater_than(
-    const std::shared_ptr<FormulaCell>& f_ptr);
+std::shared_ptr<const FormulaGt> to_greater_than(
+    const std::shared_ptr<const FormulaCell>& f_ptr);
 
-/** Casts @p f to @c shared_ptr<FormulaGt>.
+/** Casts @p f to @c shared_ptr<const FormulaGt>.
  * @pre @c is_greater_than(f) is true.
  */
-std::shared_ptr<FormulaGt> to_greater_than(const Formula& f);
+std::shared_ptr<const FormulaGt> to_greater_than(const Formula& f);
 
-/** Casts @p f_ptr to @c shared_ptr<FormulaGeq>.
+/** Casts @p f_ptr to @c shared_ptr<const FormulaGeq>.
  * @pre @c is_greater_than_or_equal_to(*f_ptr) is true.
  */
-std::shared_ptr<FormulaGeq> to_greater_than_or_equal_to(
-    const std::shared_ptr<FormulaCell>& f_ptr);
+std::shared_ptr<const FormulaGeq> to_greater_than_or_equal_to(
+    const std::shared_ptr<const FormulaCell>& f_ptr);
 
-/** Casts @p f to @c shared_ptr<FormulaGeq>.
+/** Casts @p f to @c shared_ptr<const FormulaGeq>.
  * @pre @c is_greater_than_or_equal_to(f) is true.
  */
-std::shared_ptr<FormulaGeq> to_greater_than_or_equal_to(const Formula& f);
+std::shared_ptr<const FormulaGeq> to_greater_than_or_equal_to(const Formula& f);
 
-/** Casts @p f_ptr to @c shared_ptr<FormulaLt>.
+/** Casts @p f_ptr to @c shared_ptr<const FormulaLt>.
  * @pre @c is_less_than(*f_ptr) is true.
  */
-std::shared_ptr<FormulaLt> to_less_than(
-    const std::shared_ptr<FormulaCell>& f_ptr);
+std::shared_ptr<const FormulaLt> to_less_than(
+    const std::shared_ptr<const FormulaCell>& f_ptr);
 
-/** Casts @p f to @c shared_ptr<FormulaLt>.
+/** Casts @p f to @c shared_ptr<const FormulaLt>.
  * @pre @c is_less_than(f) is true.
  */
-std::shared_ptr<FormulaLt> to_less_than(const Formula& f);
+std::shared_ptr<const FormulaLt> to_less_than(const Formula& f);
 
-/** Casts @p f_ptr to @c shared_ptr<FormulaLeq>.
+/** Casts @p f_ptr to @c shared_ptr<const FormulaLeq>.
  * @pre @c is_less_than_or_equal_to(*f_ptr) is true.
  */
-std::shared_ptr<FormulaLeq> to_less_than_or_equal_to(
-    const std::shared_ptr<FormulaCell>& f_ptr);
+std::shared_ptr<const FormulaLeq> to_less_than_or_equal_to(
+    const std::shared_ptr<const FormulaCell>& f_ptr);
 
-/** Casts @p f to @c shared_ptr<FormulaLeq>.
+/** Casts @p f to @c shared_ptr<const FormulaLeq>.
  * @pre @c is_less_than_or_equal_to(f) is true.
  */
-std::shared_ptr<FormulaLeq> to_less_than_or_equal_to(const Formula& f);
+std::shared_ptr<const FormulaLeq> to_less_than_or_equal_to(const Formula& f);
 
-/** Casts @p f_ptr to @c shared_ptr<FormulaAnd>.
+/** Casts @p f_ptr to @c shared_ptr<const FormulaAnd>.
  * @pre @c is_conjunction(*f_ptr) is true.
  */
-std::shared_ptr<FormulaAnd> to_conjunction(
-    const std::shared_ptr<FormulaCell>& f_ptr);
+std::shared_ptr<const FormulaAnd> to_conjunction(
+    const std::shared_ptr<const FormulaCell>& f_ptr);
 
-/** Casts @p f to @c shared_ptr<FormulaAnd>.
+/** Casts @p f to @c shared_ptr<const FormulaAnd>.
  * @pre @c is_conjunction(f) is true.
  */
-std::shared_ptr<FormulaAnd> to_conjunction(const Formula& f);
+std::shared_ptr<const FormulaAnd> to_conjunction(const Formula& f);
 
-/** Casts @p f_ptr to @c shared_ptr<FormulaOr>.
+/** Casts @p f_ptr to @c shared_ptr<const FormulaOr>.
  * @pre @c is_disjunction(*f_ptr) is true.
  */
-std::shared_ptr<FormulaOr> to_disjunction(
-    const std::shared_ptr<FormulaCell>& f_ptr);
+std::shared_ptr<const FormulaOr> to_disjunction(
+    const std::shared_ptr<const FormulaCell>& f_ptr);
 
-/** Casts @p f to @c shared_ptr<FormulaOr>.
+/** Casts @p f to @c shared_ptr<const FormulaOr>.
  * @pre @c is_disjunction(f) is true.
  */
-std::shared_ptr<FormulaOr> to_disjunction(const Formula& f);
+std::shared_ptr<const FormulaOr> to_disjunction(const Formula& f);
 
-/** Casts @p f_ptr to @c shared_ptr<NaryFormulaCell>.
+/** Casts @p f_ptr to @c shared_ptr<const NaryFormulaCell>.
  * @pre @c is_nary(*f_ptr) is true.
  */
-std::shared_ptr<NaryFormulaCell> to_nary(
-    const std::shared_ptr<FormulaCell>& f_ptr);
+std::shared_ptr<const NaryFormulaCell> to_nary(
+    const std::shared_ptr<const FormulaCell>& f_ptr);
 
-/** Casts @p f to @c shared_ptr<NaryFormulaCell>.
+/** Casts @p f to @c shared_ptr<const NaryFormulaCell>.
  * @pre @c is_nary(f) is true.
  */
-std::shared_ptr<NaryFormulaCell> to_nary(const Formula& f);
+std::shared_ptr<const NaryFormulaCell> to_nary(const Formula& f);
 
-/** Casts @p f_ptr to @c shared_ptr<FormulaNot>.
+/** Casts @p f_ptr to @c shared_ptr<const FormulaNot>.
  *  @pre @c is_negation(*f_ptr) is true.
  */
-std::shared_ptr<FormulaNot> to_negation(
-    const std::shared_ptr<FormulaCell>& f_ptr);
+std::shared_ptr<const FormulaNot> to_negation(
+    const std::shared_ptr<const FormulaCell>& f_ptr);
 
-/** Casts @p f to @c shared_ptr<FormulaNot>.
+/** Casts @p f to @c shared_ptr<const FormulaNot>.
  *  @pre @c is_negation(f) is true.
  */
-std::shared_ptr<FormulaNot> to_negation(const Formula& f);
+std::shared_ptr<const FormulaNot> to_negation(const Formula& f);
 
-/** Casts @p f_ptr to @c shared_ptr<FormulaForall>.
+/** Casts @p f_ptr to @c shared_ptr<const FormulaForall>.
  *  @pre @c is_forall(*f_ptr) is true.
  */
-std::shared_ptr<FormulaForall> to_forall(
-    const std::shared_ptr<FormulaCell>& f_ptr);
+std::shared_ptr<const FormulaForall> to_forall(
+    const std::shared_ptr<const FormulaCell>& f_ptr);
 
-/** Casts @p f to @c shared_ptr<FormulaForall>.
+/** Casts @p f to @c shared_ptr<const FormulaForall>.
  *  @pre @c is_forall(f) is true.
  */
-std::shared_ptr<FormulaForall> to_forall(const Formula& f);
+std::shared_ptr<const FormulaForall> to_forall(const Formula& f);
 
-/** Casts @p f_ptr to @c shared_ptr<FormulaIsnan>.
+/** Casts @p f_ptr to @c shared_ptr<const FormulaIsnan>.
  *  @pre @c is_isnan(*f_ptr) is true.
  */
-std::shared_ptr<FormulaIsnan> to_isnan(
-    const std::shared_ptr<FormulaCell>& f_ptr);
+std::shared_ptr<const FormulaIsnan> to_isnan(
+    const std::shared_ptr<const FormulaCell>& f_ptr);
 
-/** Casts @p f to @c shared_ptr<FormulaIsnan>.
+/** Casts @p f to @c shared_ptr<const FormulaIsnan>.
  *  @pre @c is_isnan(f) is true.
  */
-std::shared_ptr<FormulaIsnan> to_isnan(const Formula& f);
+std::shared_ptr<const FormulaIsnan> to_isnan(const Formula& f);
 
-/** Casts @p f_ptr to @c shared_ptr<FormulaPositiveSemidefinite>.
+/** Casts @p f_ptr to @c shared_ptr<const FormulaPositiveSemidefinite>.
  * @pre @c is_positive_semidefinite(*f_ptr) is true.
  */
-std::shared_ptr<FormulaPositiveSemidefinite> to_positive_semidefinite(
-    const std::shared_ptr<FormulaCell>& f_ptr);
+std::shared_ptr<const FormulaPositiveSemidefinite> to_positive_semidefinite(
+    const std::shared_ptr<const FormulaCell>& f_ptr);
 
-/** Casts @p f to @c shared_ptr<FormulaPositiveSemidefinite>.
+/** Casts @p f to @c shared_ptr<const FormulaPositiveSemidefinite>.
  *  @pre @c is_positive_semidefinite(f) is true.
  */
-std::shared_ptr<FormulaPositiveSemidefinite> to_positive_semidefinite(
+std::shared_ptr<const FormulaPositiveSemidefinite> to_positive_semidefinite(
     const Formula& f);
 
 }  // namespace symbolic

--- a/common/symbolic_variable.cc
+++ b/common/symbolic_variable.cc
@@ -30,7 +30,9 @@ Variable::Id Variable::get_next_id() {
 }
 
 Variable::Variable(string name, const Type type)
-    : id_{get_next_id()}, type_{type}, name_{make_shared<string>(move(name))} {
+    : id_{get_next_id()},
+      type_{type},
+      name_{make_shared<const string>(move(name))} {
   DRAKE_ASSERT(id_ > 0);
 }
 Variable::Id Variable::get_id() const { return id_; }

--- a/common/symbolic_variable.h
+++ b/common/symbolic_variable.h
@@ -92,11 +92,11 @@ class Variable {
   Id id_{};  // Unique identifier.
   Type type_{Type::CONTINUOUS};
 
-  // Variable class has shared_ptr<string> instead of string to be
+  // Variable class has shared_ptr<const string> instead of string to be
   // drake::test::IsMemcpyMovable.
   // Please check https://github.com/RobotLocomotion/drake/issues/5974
   // for more information.
-  std::shared_ptr<std::string> name_;  // Name of variable.
+  std::shared_ptr<const std::string> name_;  // Name of variable.
 };
 
 std::ostream& operator<<(std::ostream& os, Variable::Type type);

--- a/common/symbolic_variable.h
+++ b/common/symbolic_variable.h
@@ -75,8 +75,8 @@ class Variable {
 
   /** Implements the @ref hash_append concept. */
   template <class HashAlgorithm>
-  friend void hash_append(
-      HashAlgorithm& hasher, const Variable& item) noexcept {
+  friend void hash_append(HashAlgorithm& hasher,
+                          const Variable& item) noexcept {
     using drake::hash_append;
     hash_append(hasher, item.id_);
     // We do not send the type_ or name_ to the hasher, because the id_ is
@@ -301,8 +301,8 @@ Eigen::Matrix<Variable, rows, 1> MakeVectorIntegerVariable(
 namespace std {
 
 /* Provides std::hash<drake::symbolic::Variable>. */
-template <> struct hash<drake::symbolic::Variable>
-    : public drake::DefaultHash {};
+template <>
+struct hash<drake::symbolic::Variable> : public drake::DefaultHash {};
 
 /* Provides std::less<drake::symbolic::Variable>. */
 template <>
@@ -340,10 +340,9 @@ namespace symbolic {
 /// equal. That is, it returns true if and only if `m1(i, j)` is structurally
 /// equal to `m2(i, j)` for all `i`, `j`.
 template <typename DerivedA, typename DerivedB>
-typename std::enable_if<
-    is_eigen_scalar_same<DerivedA, Variable>::value &&
-        is_eigen_scalar_same<DerivedB, Variable>::value,
-    bool>::type
+typename std::enable_if<is_eigen_scalar_same<DerivedA, Variable>::value &&
+                            is_eigen_scalar_same<DerivedB, Variable>::value,
+                        bool>::type
 CheckStructuralEquality(const DerivedA& m1, const DerivedB& m2) {
   EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(DerivedA, DerivedB);
   DRAKE_DEMAND(m1.rows() == m2.rows() && m1.cols() == m2.cols());


### PR DESCRIPTION
This PR is to change the type of `ptr_` member in the `Expression`/`Formula` class. For example:
```c++
class Expression {
...
// Previously, std::shared_ptr<ExpressionCell> ptr_
std::shared_ptr<const ExpressionCell> ptr_;
...
}
```

Rationale for the change: `Expression` class (similarly `Formula` class) is a thin wrapper for an `ExpressionCell` object. Since a cell object can be shared by multiple expressions, an expression should *not* be able to change the cell that it points to.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9758)
<!-- Reviewable:end -->
