### PR TITLE
Split the command receiver part of the WSG LCM from the trajectory generator

### DIFF
--- a/manipulation/schunk_wsg/BUILD.bazel
+++ b/manipulation/schunk_wsg/BUILD.bazel
@@ -24,6 +24,7 @@ drake_cc_package_library(
         ":schunk_wsg_lcm",
         ":schunk_wsg_plain_controller",
         ":schunk_wsg_position_controller",
+        ":schunk_wsg_trajectory_generator",
         ":schunk_wsg_trajectory_generator_state_vector",
     ],
 )
@@ -36,6 +37,16 @@ drake_cc_library(
     ],
 )
 
+drake_cc_library(
+    name = "schunk_wsg_lcm",
+    srcs = ["schunk_wsg_lcm.cc"],
+    hdrs = ["schunk_wsg_lcm.h"],
+    deps = [
+        "//lcmtypes:schunk",
+        "//systems/framework:leaf_system",
+    ],
+)
+
 drake_cc_vector_gen_library(
     name = "schunk_wsg_trajectory_generator_state_vector",
     srcs = ["schunk_wsg_trajectory_generator_state_vector.named_vector"],
@@ -43,14 +54,13 @@ drake_cc_vector_gen_library(
 )
 
 drake_cc_library(
-    name = "schunk_wsg_lcm",
-    srcs = ["schunk_wsg_lcm.cc"],
-    hdrs = ["schunk_wsg_lcm.h"],
+    name = "schunk_wsg_trajectory_generator",
+    srcs = ["schunk_wsg_trajectory_generator.cc"],
+    hdrs = ["schunk_wsg_trajectory_generator.h"],
     deps = [
         ":schunk_wsg_trajectory_generator_state_vector",
         "//common/trajectories:piecewise_polynomial",
         "//common/trajectories:trajectory",
-        "//lcmtypes:schunk",
         "//systems/framework:leaf_system",
     ],
 )
@@ -88,6 +98,7 @@ drake_cc_library(
         ":schunk_wsg_constants",
         ":schunk_wsg_lcm",
         ":schunk_wsg_plain_controller",
+        ":schunk_wsg_trajectory_generator",
         "//common:essential",
         "//systems/framework:diagram",
         "//systems/framework:diagram_builder",
@@ -140,6 +151,17 @@ drake_cc_googletest(
     ],
     deps = [
         ":schunk_wsg_lcm",
+        "//systems/analysis:simulator",
+    ],
+)
+
+drake_cc_googletest(
+    name = "schunk_wsg_trajectory_generator_test",
+    data = [
+        "//manipulation/models/wsg_50_description:models",
+    ],
+    deps = [
+        ":schunk_wsg_trajectory_generator",
         "//systems/analysis:simulator",
     ],
 )

--- a/manipulation/schunk_wsg/schunk_wsg_controller.cc
+++ b/manipulation/schunk_wsg/schunk_wsg_controller.cc
@@ -3,6 +3,7 @@
 #include "drake/manipulation/schunk_wsg/schunk_wsg_constants.h"
 #include "drake/manipulation/schunk_wsg/schunk_wsg_lcm.h"
 #include "drake/manipulation/schunk_wsg/schunk_wsg_plain_controller.h"
+#include "drake/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/primitives/pass_through.h"
 
@@ -18,14 +19,20 @@ SchunkWsgController::SchunkWsgController(double kp, double ki, double kd) {
 
   state_input_port_ = builder.ExportInput(state_pass_through->get_input_port());
 
+  auto command_receiver = builder.AddSystem<SchunkWsgCommandReceiver>();
+  command_input_port_ =
+      builder.ExportInput(command_receiver->get_command_input_port());
+
   auto wsg_trajectory_generator =
       builder.AddSystem<SchunkWsgTrajectoryGenerator>(
           kSchunkWsgNumPositions + kSchunkWsgNumVelocities,
           kSchunkWsgPositionIndex);
   builder.Connect(state_pass_through->get_output_port(),
                   wsg_trajectory_generator->get_state_input_port());
-  command_input_port_ =
-      builder.ExportInput(wsg_trajectory_generator->get_command_input_port());
+  builder.Connect(command_receiver->get_commanded_position_output_port(),
+                  wsg_trajectory_generator->get_desired_position_input_port());
+  builder.Connect(command_receiver->get_force_limit_output_port(),
+                  wsg_trajectory_generator->get_force_limit_input_port());
 
   auto wsg_controller = builder.AddSystem<SchunkWsgPlainController>(
       ControlMode::kPosition, kp, ki, kd);

--- a/manipulation/schunk_wsg/schunk_wsg_lcm.cc
+++ b/manipulation/schunk_wsg/schunk_wsg_lcm.cc
@@ -6,7 +6,6 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/eigen_types.h"
-#include "drake/common/trajectories/piecewise_polynomial.h"
 #include "drake/lcmt_schunk_wsg_command.hpp"
 #include "drake/lcmt_schunk_wsg_status.hpp"
 
@@ -16,159 +15,58 @@ namespace schunk_wsg {
 
 using systems::BasicVector;
 using systems::Context;
-using systems::DiscreteValues;
 
-SchunkWsgTrajectoryGenerator::SchunkWsgTrajectoryGenerator(int input_size,
-                                                           int position_index)
-    : position_index_(position_index),
-      target_output_port_(this->DeclareVectorOutputPort(
-                                  BasicVector<double>(2),
-                                  &SchunkWsgTrajectoryGenerator::OutputTarget)
-                              .get_index()),
-      max_force_output_port_(this->DeclareVectorOutputPort(
-                                     BasicVector<double>(1),
-                                     &SchunkWsgTrajectoryGenerator::OutputForce)
-                                 .get_index()) {
-  this->DeclareAbstractInputPort(systems::kUseDefaultName,
+SchunkWsgCommandReceiver::SchunkWsgCommandReceiver(
+    double initial_position, double initial_force)
+    : initial_position_(initial_position),
+      initial_force_(initial_force),
+      commanded_position_output_port_(
+          this->DeclareVectorOutputPort(
+              "commanded_position", BasicVector<double>(1),
+              &SchunkWsgCommandReceiver::CalcCommandedPositionOutput)
+          .get_index()),
+      force_limit_output_port_(
+          this->DeclareVectorOutputPort(
+              "force_limit", BasicVector<double>(1),
+              &SchunkWsgCommandReceiver::CalcForceLimitOutput)
+          .get_index()) {
+  this->DeclareAbstractInputPort("wsg_command",
                                  systems::Value<lcmt_schunk_wsg_command>());
-  this->DeclareInputPort(systems::kVectorValued, input_size);
-  // The update period below matches the polling rate from
-  // drake-schunk-driver.
-  this->DeclarePeriodicDiscreteUpdate(0.05);
 }
 
-void SchunkWsgTrajectoryGenerator::OutputTarget(
+void SchunkWsgCommandReceiver::CalcCommandedPositionOutput(
     const Context<double>& context, BasicVector<double>* output) const {
-  const SchunkWsgTrajectoryGeneratorStateVector<double>* traj_state =
-      dynamic_cast<const SchunkWsgTrajectoryGeneratorStateVector<double>*>(
-          &context.get_discrete_state(0));
-
-  if (trajectory_) {
-    output->get_mutable_value() = trajectory_->value(
-        context.get_time() - traj_state->trajectory_start_time());
-  } else {
-    output->get_mutable_value() =
-        Eigen::Vector2d(traj_state->last_position(), 0);
-  }
-}
-
-void SchunkWsgTrajectoryGenerator::OutputForce(
-    const Context<double>& context, BasicVector<double>* output) const {
-  const SchunkWsgTrajectoryGeneratorStateVector<double>* traj_state =
-      dynamic_cast<const SchunkWsgTrajectoryGeneratorStateVector<double>*>(
-          &context.get_discrete_state(0));
-  output->get_mutable_value() = Vector1d(traj_state->max_force());
-}
-
-void SchunkWsgTrajectoryGenerator::DoCalcDiscreteVariableUpdates(
-    const Context<double>& context,
-    const std::vector<const systems::DiscreteUpdateEvent<double>*>&,
-    DiscreteValues<double>* discrete_state) const {
   const systems::AbstractValue* input = this->EvalAbstractInput(context, 0);
   DRAKE_ASSERT(input != nullptr);
   const auto& command = input->GetValue<lcmt_schunk_wsg_command>();
-  // The target_position_mm field represents the distance between the two
-  // fingers in millimeters. This class generates trajectories for the negative
-  // of the distance between the fingers in meters.
-  double target_position = -command.target_position_mm / 1e3;
-  if (std::isnan(target_position)) {
-    target_position = 0;
+
+  double target_position = initial_position_;
+  if (command.utime != 0) {
+    // The target_position_mm field represents the distance between the two
+    // fingers in millimeters. This class generates a desired position output
+    // for the distance for a single finger to the center.
+    target_position = 0.5 * command.target_position_mm / 1e3;
+    if (std::isnan(target_position)) {
+      target_position = 0;
+    }
   }
 
-  const systems::BasicVector<double>* state = this->EvalVectorInput(context, 1);
-  const double cur_position = 2 * state->GetAtIndex(position_index_);
-
-  const SchunkWsgTrajectoryGeneratorStateVector<double>* last_traj_state =
-      dynamic_cast<const SchunkWsgTrajectoryGeneratorStateVector<double>*>(
-          &context.get_discrete_state(0));
-  SchunkWsgTrajectoryGeneratorStateVector<double>* new_traj_state =
-      dynamic_cast<SchunkWsgTrajectoryGeneratorStateVector<double>*>(
-          &discrete_state->get_mutable_vector(0));
-  new_traj_state->set_last_position(cur_position);
-
-  double max_force = command.force;
-  if (std::isnan(max_force)) {
-    max_force = 0;
-  }
-  new_traj_state->set_max_force(max_force);
-
-  if (std::abs(last_traj_state->last_target_position() - target_position) >
-      kTargetEpsilon) {
-    UpdateTrajectory(cur_position, target_position);
-    new_traj_state->set_last_target_position(target_position);
-    new_traj_state->set_trajectory_start_time(context.get_time());
-  } else {
-    new_traj_state->set_last_target_position(
-        last_traj_state->last_target_position());
-    new_traj_state->set_trajectory_start_time(
-        last_traj_state->trajectory_start_time());
-  }
+  output->SetAtIndex(0, target_position);
 }
 
-std::unique_ptr<DiscreteValues<double>>
-SchunkWsgTrajectoryGenerator::AllocateDiscreteState() const {
-  return std::make_unique<DiscreteValues<double>>(
-      std::make_unique<SchunkWsgTrajectoryGeneratorStateVector<double>>());
-}
 
-void SchunkWsgTrajectoryGenerator::UpdateTrajectory(
-    double cur_position, double target_position) const {
-  // The acceleration and velocity limits correspond to the maximum
-  // values available for manual control through the gripper's web
-  // interface.
-  const double kMaxVelocity = 0.42;  // m/s
-  const double kMaxAccel = 5.;       // m/s^2
-  const double kTimeToMaxVelocity = kMaxVelocity / kMaxAccel;
-  // TODO(sam.creasey) this should probably consider current speed
-  // if the gripper is already moving.
-  const double kDistanceToMaxVelocity =
-      0.5 * kMaxAccel * kTimeToMaxVelocity * kTimeToMaxVelocity;
+void SchunkWsgCommandReceiver::CalcForceLimitOutput(
+    const Context<double>& context, BasicVector<double>* output) const {
+  const systems::AbstractValue* input = this->EvalAbstractInput(context, 0);
+  DRAKE_ASSERT(input != nullptr);
+  const auto& command = input->GetValue<lcmt_schunk_wsg_command>();
 
-  std::vector<Eigen::MatrixXd> knots;
-  std::vector<double> times;
-  knots.push_back(Eigen::Vector2d(cur_position, 0));
-  times.push_back(0);
-
-  const double direction = (cur_position < target_position) ? 1 : -1;
-  const double delta = std::abs(target_position - cur_position);
-
-  // The trajectory creation code below is, to say the best, a bit
-  // primitive.  I (sam.creasey) would not be surprised if it could
-  // be significantly improved.  It's also based only on the
-  // configurable constants for the WSG 50, not on analysis of the
-  // actual motion of the gripper.
-  if (delta < kDistanceToMaxVelocity * 2) {
-    // If we can't accelerate to our maximum (and decelerate again)
-    // within the target travel distance, calculate the peak velocity
-    // we will reach and create a trajectory which ramps to that
-    // velocity and back down.
-    const double mid_distance = delta / 2;
-    const double mid_velocity =
-        kMaxVelocity * (mid_distance / kDistanceToMaxVelocity);
-    const double mid_time = mid_velocity / kMaxAccel;
-    knots.push_back(Eigen::Vector2d(cur_position + mid_distance * direction,
-                                    mid_velocity * direction));
-    times.push_back(mid_time);
-    knots.push_back(Eigen::Vector2d(target_position, 0));
-    times.push_back(mid_time * 2);
-  } else {
-    knots.push_back(
-        Eigen::Vector2d(cur_position + (kDistanceToMaxVelocity * direction),
-                        kMaxVelocity * direction));
-    times.push_back(kTimeToMaxVelocity);
-
-    const double time_at_max =
-        (delta - 2 * kDistanceToMaxVelocity) / kMaxVelocity;
-    knots.push_back(
-        Eigen::Vector2d(target_position - (kDistanceToMaxVelocity * direction),
-                        kMaxVelocity * direction));
-    times.push_back(kTimeToMaxVelocity + time_at_max);
-
-    knots.push_back(Eigen::Vector2d(target_position, 0));
-    times.push_back(kTimeToMaxVelocity + time_at_max + kTimeToMaxVelocity);
+  double force_limit = initial_force_;
+  if (command.utime != 0) {
+    force_limit = command.force;
   }
-  trajectory_.reset(new trajectories::PiecewisePolynomial<double>(
-      trajectories::PiecewisePolynomial<double>::FirstOrderHold(times, knots)));
+
+  output->SetAtIndex(0, force_limit);
 }
 
 SchunkWsgStatusSender::SchunkWsgStatusSender(int input_state_size,

--- a/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.cc
+++ b/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.cc
@@ -1,0 +1,172 @@
+#include "drake/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.h"
+
+#include "drake/common/trajectories/piecewise_polynomial.h"
+#include "drake/manipulation/schunk_wsg/gen/schunk_wsg_trajectory_generator_state_vector.h"
+
+namespace drake {
+namespace manipulation {
+namespace schunk_wsg {
+
+using systems::BasicVector;
+using systems::Context;
+using systems::DiscreteValues;
+
+SchunkWsgTrajectoryGenerator::SchunkWsgTrajectoryGenerator(int input_size,
+                                                           int position_index)
+    : position_index_(position_index),
+      desired_position_input_port_(
+          this->DeclareVectorInputPort(
+              "desired_position", BasicVector<double>(1)).get_index()),
+      force_limit_input_port_(
+          this->DeclareVectorInputPort(
+              "force_limit", BasicVector<double>(1)).get_index()),
+      state_input_port_(
+          this->DeclareInputPort(
+              systems::kVectorValued, input_size).get_index()),
+      target_output_port_(
+          this->DeclareVectorOutputPort(
+              BasicVector<double>(2),
+              &SchunkWsgTrajectoryGenerator::OutputTarget).get_index()),
+      max_force_output_port_(
+          this->DeclareVectorOutputPort(
+              BasicVector<double>(1),
+              &SchunkWsgTrajectoryGenerator::OutputForce).get_index()) {
+  // The update period below matches the polling rate from
+  // drake-schunk-driver.
+  this->DeclarePeriodicDiscreteUpdate(0.05);
+}
+
+void SchunkWsgTrajectoryGenerator::OutputTarget(
+    const Context<double>& context, BasicVector<double>* output) const {
+  const SchunkWsgTrajectoryGeneratorStateVector<double>* traj_state =
+      dynamic_cast<const SchunkWsgTrajectoryGeneratorStateVector<double>*>(
+          &context.get_discrete_state(0));
+
+  if (trajectory_) {
+    output->get_mutable_value() = trajectory_->value(
+        context.get_time() - traj_state->trajectory_start_time());
+  } else {
+    output->get_mutable_value() =
+        Eigen::Vector2d(traj_state->last_position(), 0);
+  }
+}
+
+void SchunkWsgTrajectoryGenerator::OutputForce(
+    const Context<double>& context, BasicVector<double>* output) const {
+  const SchunkWsgTrajectoryGeneratorStateVector<double>* traj_state =
+      dynamic_cast<const SchunkWsgTrajectoryGeneratorStateVector<double>*>(
+          &context.get_discrete_state(0));
+  output->get_mutable_value() = Vector1d(traj_state->max_force());
+}
+
+void SchunkWsgTrajectoryGenerator::DoCalcDiscreteVariableUpdates(
+    const Context<double>& context,
+    const std::vector<const systems::DiscreteUpdateEvent<double>*>&,
+    DiscreteValues<double>* discrete_state) const {
+  const double desired_position =
+      this->EvalEigenVectorInput(context, desired_position_input_port_)[0];
+
+  // The desired position input is the distance from each finger to the center
+  // of the gripper in meters.  This class generates trajectories for the
+  // negative of the distance between the fingers in meters.
+
+  double target_position = -desired_position * 2;
+
+  const systems::BasicVector<double>* state =
+      this->EvalVectorInput(context, state_input_port_);
+  const double cur_position = 2 * state->GetAtIndex(position_index_);
+
+  const SchunkWsgTrajectoryGeneratorStateVector<double>* last_traj_state =
+      dynamic_cast<const SchunkWsgTrajectoryGeneratorStateVector<double>*>(
+          &context.get_discrete_state(0));
+  SchunkWsgTrajectoryGeneratorStateVector<double>* new_traj_state =
+      dynamic_cast<SchunkWsgTrajectoryGeneratorStateVector<double>*>(
+          &discrete_state->get_mutable_vector(0));
+  new_traj_state->set_last_position(cur_position);
+
+  const double max_force =
+      this->EvalEigenVectorInput(context, force_limit_input_port_)[0];
+  new_traj_state->set_max_force(max_force);
+
+  if (std::abs(last_traj_state->last_target_position() - target_position) >
+      kTargetEpsilon) {
+    UpdateTrajectory(cur_position, target_position);
+    new_traj_state->set_last_target_position(target_position);
+    new_traj_state->set_trajectory_start_time(context.get_time());
+  } else {
+    new_traj_state->set_last_target_position(
+        last_traj_state->last_target_position());
+    new_traj_state->set_trajectory_start_time(
+        last_traj_state->trajectory_start_time());
+  }
+}
+
+std::unique_ptr<DiscreteValues<double>>
+SchunkWsgTrajectoryGenerator::AllocateDiscreteState() const {
+  return std::make_unique<DiscreteValues<double>>(
+      std::make_unique<SchunkWsgTrajectoryGeneratorStateVector<double>>());
+}
+
+void SchunkWsgTrajectoryGenerator::UpdateTrajectory(
+    double cur_position, double target_position) const {
+  // The acceleration and velocity limits correspond to the maximum
+  // values available for manual control through the gripper's web
+  // interface.
+  const double kMaxVelocity = 0.42;  // m/s
+  const double kMaxAccel = 5.;       // m/s^2
+  const double kTimeToMaxVelocity = kMaxVelocity / kMaxAccel;
+  // TODO(sam.creasey) this should probably consider current speed
+  // if the gripper is already moving.
+  const double kDistanceToMaxVelocity =
+      0.5 * kMaxAccel * kTimeToMaxVelocity * kTimeToMaxVelocity;
+
+  std::vector<Eigen::MatrixXd> knots;
+  std::vector<double> times;
+  knots.push_back(Eigen::Vector2d(cur_position, 0));
+  times.push_back(0);
+
+  const double direction = (cur_position < target_position) ? 1 : -1;
+  const double delta = std::abs(target_position - cur_position);
+
+  // The trajectory creation code below is, to say the best, a bit
+  // primitive.  I (sam.creasey) would not be surprised if it could
+  // be significantly improved.  It's also based only on the
+  // configurable constants for the WSG 50, not on analysis of the
+  // actual motion of the gripper.
+  if (delta < kDistanceToMaxVelocity * 2) {
+    // If we can't accelerate to our maximum (and decelerate again)
+    // within the target travel distance, calculate the peak velocity
+    // we will reach and create a trajectory which ramps to that
+    // velocity and back down.
+    const double mid_distance = delta / 2;
+    const double mid_velocity =
+        kMaxVelocity * (mid_distance / kDistanceToMaxVelocity);
+    const double mid_time = mid_velocity / kMaxAccel;
+    knots.push_back(Eigen::Vector2d(cur_position + mid_distance * direction,
+                                    mid_velocity * direction));
+    times.push_back(mid_time);
+    knots.push_back(Eigen::Vector2d(target_position, 0));
+    times.push_back(mid_time * 2);
+  } else {
+    knots.push_back(
+        Eigen::Vector2d(cur_position + (kDistanceToMaxVelocity * direction),
+                        kMaxVelocity * direction));
+    times.push_back(kTimeToMaxVelocity);
+
+    const double time_at_max =
+        (delta - 2 * kDistanceToMaxVelocity) / kMaxVelocity;
+    knots.push_back(
+        Eigen::Vector2d(target_position - (kDistanceToMaxVelocity * direction),
+                        kMaxVelocity * direction));
+    times.push_back(kTimeToMaxVelocity + time_at_max);
+
+    knots.push_back(Eigen::Vector2d(target_position, 0));
+    times.push_back(kTimeToMaxVelocity + time_at_max + kTimeToMaxVelocity);
+  }
+  trajectory_.reset(new trajectories::PiecewisePolynomial<double>(
+      trajectories::PiecewisePolynomial<double>::FirstOrderHold(times, knots)));
+}
+
+}  // namespace schunk_wsg
+}  // namespace manipulation
+}  // namespace drake

--- a/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.h
+++ b/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "drake/common/trajectories/trajectory.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace manipulation {
+namespace schunk_wsg {
+
+
+// TODO(sam.creasey) Right now this class just outputs a position
+// which is not going to be sufficient to capture the entire control
+// state of the gripper (particularly the maximum force).
+
+/// This system defines input ports for the desired finger position
+/// represented as the desired distance from the center (zero) position in
+/// meters and the desired force limit in newtons, and emits target
+/// position/velocity for the actuated finger to reach the commanded target,
+/// expressed as the negative of the distance between the two fingers in
+/// meters.  The force portion of the command message is passed through this
+/// system, but does not affect the generated trajectory.  The
+/// desired_position and force_limit are scalars (BasicVector<double> of size
+/// 1).
+///
+/// @ingroup manipulation_systems
+class SchunkWsgTrajectoryGenerator : public systems::LeafSystem<double> {
+ public:
+  /// @param input_size The size of the state input port to create
+  /// (one reason this may vary is passing in the entire state of a
+  /// rigid body tree vs. having already demultiplexed the actuated
+  /// finger).
+  /// @param position_index The index in the state input vector
+  /// which contains the position of the actuated finger.
+  SchunkWsgTrajectoryGenerator(int input_size, int position_index);
+
+  const systems::InputPort<double>& get_desired_position_input_port() const {
+    return get_input_port(desired_position_input_port_);
+  }
+
+  const systems::InputPort<double>& get_force_limit_input_port() const {
+    return get_input_port(force_limit_input_port_);
+  }
+
+  const systems::InputPort<double>& get_state_input_port() const {
+    return get_input_port(state_input_port_);
+  }
+
+  const systems::OutputPort<double>& get_target_output_port() const {
+    return this->get_output_port(target_output_port_);
+  }
+
+  const systems::OutputPort<double>& get_max_force_output_port() const {
+    return this->get_output_port(max_force_output_port_);
+  }
+
+ private:
+  void OutputTarget(const systems::Context<double>& context,
+                    systems::BasicVector<double>* output) const;
+
+  void OutputForce(const systems::Context<double>& context,
+                   systems::BasicVector<double>* output) const;
+
+  /// Latches the input port into the discrete state.
+  void DoCalcDiscreteVariableUpdates(
+      const systems::Context<double>& context,
+      const std::vector<const systems::DiscreteUpdateEvent<double>*>& events,
+      systems::DiscreteValues<double>* discrete_state) const override;
+
+  std::unique_ptr<systems::DiscreteValues<double>> AllocateDiscreteState()
+      const override;
+
+  void UpdateTrajectory(double cur_position, double target_position) const;
+
+  /// The minimum change between the last received command and the
+  /// current command to trigger a trajectory update.  Based on
+  /// manually driving the actual gripper using the web interface, it
+  /// appears that it will at least attempt to respond to commands as
+  /// small as 0.1mm.
+  const double kTargetEpsilon = 0.0001;
+
+  const int position_index_{};
+  const systems::InputPortIndex desired_position_input_port_{};
+  const systems::InputPortIndex force_limit_input_port_{};
+  const systems::InputPortIndex state_input_port_{};
+  const systems::OutputPortIndex target_output_port_{};
+  const systems::OutputPortIndex max_force_output_port_{};
+
+  // TODO(sam.creasey) I'd prefer to store the trajectory as
+  // discrete state, but unfortunately that's not currently possible
+  // as DiscreteValues may only contain BasicVector.
+  mutable std::unique_ptr<trajectories::Trajectory<double>> trajectory_;
+};
+
+}  // namespace schunk_wsg
+}  // namespace manipulation
+}  // namespace drake

--- a/manipulation/schunk_wsg/test/schunk_wsg_controller_test.cc
+++ b/manipulation/schunk_wsg/test/schunk_wsg_controller_test.cc
@@ -44,6 +44,7 @@ GTEST_TEST(SchunkWsgControllerTest, SchunkWsgControllerTest) {
   // Start off with the gripper closed (zero) and a command to open to
   // 100mm.
   lcmt_schunk_wsg_command wsg_command{};
+  wsg_command.utime = 1;
   wsg_command.target_position_mm = 100;
   wsg_command.force = 40;
   std::pair<double, double> commanded_force =

--- a/manipulation/schunk_wsg/test/schunk_wsg_lcm_test.cc
+++ b/manipulation/schunk_wsg/test/schunk_wsg_lcm_test.cc
@@ -7,42 +7,45 @@
 #include "drake/lcmt_schunk_wsg_command.hpp"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/fixed_input_port_value.h"
-#include "drake/systems/framework/system_output.h"
 
 namespace drake {
 namespace manipulation {
 namespace schunk_wsg {
 namespace {
 
-GTEST_TEST(SchunkWsgLcmTest, SchunkWsgTrajectoryGeneratorTest) {
-  SchunkWsgTrajectoryGenerator dut(1, 0);
+using systems::BasicVector;
+
+GTEST_TEST(SchunkWsgLcmTest, SchunkWsgCommandReceiverTest) {
+  const double initial_position = 0.03;
+  const double initial_force = 27;
+
+  SchunkWsgCommandReceiver dut(initial_position, initial_force);
   std::unique_ptr<systems::Context<double>> context =
       dut.CreateDefaultContext();
-  std::unique_ptr<systems::SystemOutput<double>> output =
-      dut.AllocateOutput();
+
+  // Check that we get the initial position and force before receiving a
+  // command.
+  lcmt_schunk_wsg_command initial_command{};
+  context->FixInputPort(0,
+      systems::AbstractValue::Make<lcmt_schunk_wsg_command>(initial_command));
+  EXPECT_EQ(dut.get_commanded_position_output_port()
+            .Eval<BasicVector<double>>(*context).GetAtIndex(0),
+            initial_position);
+  EXPECT_EQ(dut.get_force_limit_output_port()
+            .Eval<BasicVector<double>>(*context).GetAtIndex(0),
+            initial_force);
 
   // Start off with the gripper closed (zero) and a command to open to
   // 100mm.
-  lcmt_schunk_wsg_command initial_command{};
+  initial_command.utime = 1;
   initial_command.target_position_mm = 100;
   initial_command.force = 40;
   context->FixInputPort(0,
       systems::AbstractValue::Make<lcmt_schunk_wsg_command>(initial_command));
-  context->FixInputPort(1, Eigen::VectorXd::Zero(1));
-
-  // Step a little bit. We should be commanding a point on the
-  // trajectory wider than zero, but not to the target yet.
-  const double expected_target = -0.1;  // 100mm
-  systems::Simulator<double> simulator(dut, std::move(context));
-  simulator.StepTo(0.1);
-  dut.CalcOutput(simulator.get_context(), output.get());
-  EXPECT_LT(output->get_vector_data(0)->GetAtIndex(0), 0);
-  EXPECT_GT(output->get_vector_data(0)->GetAtIndex(0), expected_target);
-
-  // Step quite a bit longer and see that we get there.
-  simulator.StepTo(2.0);
-  dut.CalcOutput(simulator.get_context(), output.get());
-  EXPECT_FLOAT_EQ(output->get_vector_data(0)->GetAtIndex(0), expected_target);
+  EXPECT_EQ(dut.get_commanded_position_output_port()
+            .Eval<BasicVector<double>>(*context).GetAtIndex(0), 0.05);
+  EXPECT_EQ(dut.get_force_limit_output_port()
+            .Eval<BasicVector<double>>(*context).GetAtIndex(0), 40);
 }
 
 }  // namespace

--- a/manipulation/schunk_wsg/test/schunk_wsg_trajectory_generator_test.cc
+++ b/manipulation/schunk_wsg/test/schunk_wsg_trajectory_generator_test.cc
@@ -1,0 +1,51 @@
+#include "drake/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+#include "drake/systems/analysis/simulator.h"
+#include "drake/systems/framework/fixed_input_port_value.h"
+#include "drake/systems/framework/system_output.h"
+
+namespace drake {
+namespace manipulation {
+namespace schunk_wsg {
+namespace {
+
+GTEST_TEST(SchunkWsgTrajectoryGeneratorTest, BasicTest) {
+  SchunkWsgTrajectoryGenerator dut(1, 0);
+  std::unique_ptr<systems::Context<double>> context =
+      dut.CreateDefaultContext();
+  std::unique_ptr<systems::SystemOutput<double>> output =
+      dut.AllocateOutput();
+
+  // Start off with the gripper closed (zero) and a command to open to
+  // 100mm.
+  context->FixInputPort(dut.get_desired_position_input_port().get_index(),
+                        Vector1d(0.05));
+  context->FixInputPort(dut.get_force_limit_input_port().get_index(),
+                        Vector1d(40));
+  context->FixInputPort(dut.get_state_input_port().get_index(),
+                        Eigen::VectorXd::Zero(1));
+
+  // Step a little bit. We should be commanding a point on the
+  // trajectory wider than zero, but not to the target yet.
+  const double expected_target = -0.1;  // 100mm
+  systems::Simulator<double> simulator(dut, std::move(context));
+  simulator.StepTo(0.1);
+  dut.CalcOutput(simulator.get_context(), output.get());
+  EXPECT_LT(output->get_vector_data(0)->GetAtIndex(0), 0);
+  EXPECT_GT(output->get_vector_data(0)->GetAtIndex(0), expected_target);
+
+  // Step quite a bit longer and see that we get there.
+  simulator.StepTo(2.0);
+  dut.CalcOutput(simulator.get_context(), output.get());
+  EXPECT_FLOAT_EQ(output->get_vector_data(0)->GetAtIndex(0), expected_target);
+}
+
+}  // namespace
+}  // namespace schunk_wsg
+}  // namespace manipulation
+}  // namespace drake


### PR DESCRIPTION
Related to #9731

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9760)
<!-- Reviewable:end -->
