### PR TITLE
Partial revert of #9756, avoiding duplicate library warning for `lcm.so`

### DIFF
--- a/bindings/pydrake/doc/pydrake.systems.lcm.rst
+++ b/bindings/pydrake/doc/pydrake.systems.lcm.rst
@@ -5,5 +5,6 @@ pydrake.systems.lcm
 
 .. automodule:: pydrake.systems.lcm
     :members:
+    :imported-members:
     :undoc-members:
     :show-inheritance:

--- a/bindings/pydrake/doc/refresh_doc_modules.py
+++ b/bindings/pydrake/doc/refresh_doc_modules.py
@@ -59,9 +59,7 @@ def has_cc_imported_symbols(name):
         sub = pieces[-1]
         test = ".".join(pieces[:-1] + ["_{}_py".format(sub)])
         if test in sys.modules:
-            raise RuntimeError(
-                ("The module `{}` should not exist; instead, only `{}` should "
-                 "exist").format(test, name))
+            return True
     return False
 
 

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -204,6 +204,7 @@ drake_pybind_library(
         "//bindings/pydrake:documentation_pybind",
         "//bindings/pydrake/systems:systems_pybind",
     ],
+    cc_so_name = "_lcm_py",
     cc_srcs = ["lcm_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
@@ -211,7 +212,7 @@ drake_pybind_library(
         ":module_py",
         "//bindings/pydrake:lcm_py",
     ],
-    py_srcs = ["_lcm_extra.py"],
+    py_srcs = ["lcm.py"],
 )
 
 drake_py_unittest(

--- a/bindings/pydrake/systems/lcm.py
+++ b/bindings/pydrake/systems/lcm.py
@@ -1,6 +1,6 @@
-# See `ExecuteExtraPythonCode` in `pydrake_pybind.h` for usage details and
-# rationale.
-from pydrake.systems.framework import AbstractValue
+from pydrake.systems._lcm_py import *
+
+from pydrake.systems.framework import AbstractValue, Value
 
 
 class PySerializer(SerializerInterface):

--- a/bindings/pydrake/systems/lcm_py.cc
+++ b/bindings/pydrake/systems/lcm_py.cc
@@ -60,7 +60,7 @@ class PySerializerInterface : public py::wrapper<SerializerInterface> {
 
 }  // namespace
 
-PYBIND11_MODULE(lcm, m) {
+PYBIND11_MODULE(_lcm_py, m) {
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
   using namespace drake::lcm;
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
@@ -113,8 +113,6 @@ PYBIND11_MODULE(lcm, m) {
         py::keep_alive<0, 2>(),
         // TODO(eric.cousineau): Figure out why this is necessary (#9398).
         py_reference, doc.ConnectLcmScope.doc);
-
-  ExecuteExtraPythonCode(m);
 }
 
 }  // namespace pydrake


### PR DESCRIPTION
Partial revert of #9756; this can be resolved once #9768 works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9770)
<!-- Reviewable:end -->
