### PR TITLE
Add ImageWriter - system that writes Image instances to disk.

### DIFF
--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -38,6 +38,7 @@ drake_cc_package_library(
         ":gyroscope",
         ":image",
         ":image_to_lcm_image_array_t",
+        ":image_writer",
         ":optitrack_sender",
         ":rgbd_camera",
         ":rgbd_renderer",
@@ -352,6 +353,21 @@ drake_cc_library(
     ],
 )
 
+drake_cc_library(
+    name = "image_writer",
+    srcs = ["image_writer.cc"],
+    hdrs = ["image_writer.h"],
+    deps = [
+        ":image",
+        ":vtk_util",
+        "//common:essential",
+        "//systems/framework",
+        "@spruce",
+        "@vtk//:vtkCommonDataModel",
+        "@vtk//:vtkIOImage",
+    ],
+)
+
 # === test/ ===
 
 drake_cc_googletest(
@@ -441,6 +457,18 @@ filegroup(
         "test/models/meshes/box2.obj",
         "test/models/nothing.sdf",
         "test/models/sphere.sdf",
+    ],
+)
+
+drake_cc_googletest(
+    name = "image_writer_test",
+    tags = vtk_test_tags,
+    deps = [
+        ":image_writer",
+        "//common:temp_directory",
+        "//common/test_utilities",
+        "@spruce",
+        "@vtk//:vtkIOImage",
     ],
 )
 

--- a/systems/sensors/image_writer.cc
+++ b/systems/sensors/image_writer.cc
@@ -1,0 +1,193 @@
+#include "drake/systems/sensors/image_writer.h"
+
+#include <unistd.h>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <spruce.hh>
+#include <vtkImageData.h>
+#include <vtkNew.h>
+#include <vtkPNGWriter.h>
+#include <vtkSmartPointer.h>
+#include <vtkTIFFWriter.h>
+#include "fmt/ostream.h"
+
+#include "drake/common/text_logging.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+
+using std::move;
+
+template <PixelType kPixelType>
+void SaveToFileHelper(const std::string& file_path,
+                      const Image<kPixelType>& image) {
+  const int width = image.width();
+  const int height = image.height();
+  const int num_channels = Image<kPixelType>::kNumChannels;
+
+  vtkSmartPointer<vtkImageWriter> writer;
+  vtkNew<vtkImageData> vtk_image;
+  vtk_image->SetDimensions(width, height, 1);
+
+  switch (kPixelType) {
+    case PixelType::kRgba8U:
+      vtk_image->AllocateScalars(VTK_UNSIGNED_CHAR, num_channels);
+      writer = vtkSmartPointer<vtkPNGWriter>::New();
+      break;
+    case PixelType::kDepth32F:
+      vtk_image->AllocateScalars(VTK_FLOAT, num_channels);
+      writer = vtkSmartPointer<vtkTIFFWriter>::New();
+      break;
+    case PixelType::kLabel16I:
+      vtk_image->AllocateScalars(VTK_UNSIGNED_SHORT, num_channels);
+      writer = vtkSmartPointer<vtkPNGWriter>::New();
+      break;
+    default:
+      throw std::logic_error(
+          "Unsupported image type; cannot be written to file");
+  }
+
+  auto image_ptr = reinterpret_cast<typename Image<kPixelType>::T*>(
+      vtk_image->GetScalarPointer());
+  const int num_scalar_components = vtk_image->GetNumberOfScalarComponents();
+  DRAKE_DEMAND(num_scalar_components == num_channels);
+
+  for (int v = height - 1; v >= 0; --v) {
+    for (int u = 0; u < width; ++u) {
+      for (int c = 0; c < num_channels; ++c) {
+        image_ptr[c] =
+            static_cast<typename Image<kPixelType>::T>(image.at(u, v)[c]);
+      }
+      image_ptr += num_scalar_components;
+    }
+  }
+
+  writer->SetFileName(file_path.c_str());
+  writer->SetInputData(vtk_image.GetPointer());
+  writer->Write();
+}
+
+void SaveToPng(const std::string& file_path, const ImageRgba8U& image) {
+  SaveToFileHelper(file_path, image);
+}
+
+void SaveToTiff(const std::string& file_path, const ImageDepth32F& image) {
+  SaveToFileHelper(file_path, image);
+}
+
+void SaveToPng(const std::string& file_path, const ImageLabel16I& image) {
+  SaveToFileHelper(file_path, image);
+}
+
+ImageWriter::ImageWriter(std::string folder_path, std::string image_name,
+                         double start_time, int padding)
+    : folder_path_(move(folder_path)),
+      image_name_base_(move(image_name)),
+      start_time_(start_time),
+      padding_(padding),
+      can_write_(IsDirectoryValid(folder_path_)) {
+  color_image_port_index_ =
+      DeclareAbstractInputPort("color_image",
+                               systems::Value<ImageRgba8U>()).get_index();
+  depth_image_port_index_ =
+      DeclareAbstractInputPort("depth_image",
+                               systems::Value<ImageDepth32F>()).get_index();
+  label_image_port_index_ =
+      DeclareAbstractInputPort("label_image",
+                               systems::Value<ImageLabel16I>()).get_index();
+}
+
+void ImageWriter::set_publish_period(double period) {
+  if (period < 0) {
+    throw std::logic_error("ImageWriter requires a positive period value");
+  }
+
+  if (can_write_) {
+    LeafSystem<double>::DeclarePeriodicPublish(period);
+  } else {
+    drake::log()->warn(
+        "ImageWriter: the provided folder cannot be written to: " +
+        folder_path_ + "; No files will be written.");
+  }
+}
+
+const InputPort<double>& ImageWriter::color_image_input_port() const {
+  return this->get_input_port(color_image_port_index_);
+}
+
+const InputPort<double>& ImageWriter::depth_image_input_port() const {
+  return this->get_input_port(depth_image_port_index_);
+}
+
+const InputPort<double>& ImageWriter::label_image_input_port() const {
+  return this->get_input_port(label_image_port_index_);
+}
+
+void ImageWriter::DoPublish(
+    const Context<double>& context,
+    const std::vector<const PublishEvent<double>*>&) const {
+  // Includes can_write_ to guard against forced invocations of Publish (in
+  // addition to the events this system may create).
+  if (can_write_ && context.get_time() >= start_time_) {
+    const ImageRgba8U* color_image =
+        this->EvalInputValue<ImageRgba8U>(context, color_image_port_index_);
+    const ImageDepth32F* depth_image =
+        this->EvalInputValue<ImageDepth32F>(context, depth_image_port_index_);
+    const ImageLabel16I* label_image =
+        this->EvalInputValue<ImageLabel16I>(context, label_image_port_index_);
+    if (color_image || depth_image || label_image) ++previous_frame_index_;
+
+    if (color_image) {
+      SaveToPng(make_file_name("color", previous_frame_index_, "png"),
+                *color_image);
+    }
+    if (depth_image) {
+      SaveToTiff(make_file_name("depth", previous_frame_index_, "tiff"),
+                 *depth_image);
+    }
+    if (label_image) {
+      SaveToPng(make_file_name("label", previous_frame_index_, "png"),
+                *label_image);
+    }
+  }
+}
+
+bool ImageWriter::IsDirectoryValid(const std::string& file_path) {
+  spruce::path dirpath(file_path);
+  if (dirpath.exists()) {
+    if (dirpath.isDir()) {
+      if (access(dirpath.getStr().c_str(), W_OK) == 0) {
+        return true;
+      } else {
+        drake::log()->warn(
+            "ImageWriter: no write permissions for the given folder: " +
+            file_path);
+      }
+    } else {
+      drake::log()->warn(
+          "ImageWriter: the provided folder isn't a directory: " + file_path);
+    }
+  } else {
+    drake::log()->warn("ImageWriter: the provided folder doesn't exist: " +
+                       file_path);
+  }
+  return false;
+}
+
+std::string ImageWriter::make_file_name(const std::string& type_name,
+                                        int frame_number,
+                                        const std::string& ext) const {
+  spruce::path dirpath(folder_path_);
+  std::string file_name = fmt::format("{0}_{1}_{2:0{3}d}.{4}", image_name_base_,
+                                      type_name, frame_number, padding_, ext);
+  dirpath.append(file_name);
+  return dirpath.getStr();
+}
+
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/systems/sensors/image_writer.h
+++ b/systems/sensors/image_writer.h
@@ -1,0 +1,172 @@
+#pragma once
+
+/** @file Provides utilities for writing images to disk.
+
+ This file provides two sets of utilities: stand alone methods that can be
+ invoked in any context and a System that can be connected into a diagram to
+ automatically capture images during simulation at a fixed frequency.  */
+
+#include <string>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/systems/framework/leaf_system.h"
+#include "drake/systems/sensors/image.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+
+/** @name     Utility functions for writing common image types to disk.
+
+ Given a fully-specified path to the file to write and corresponding image data,
+ these functions will _attempt_ to write the image data to the file. The
+ functions assume that the path is valid and writable.  */
+//@{
+
+/** Writes the color (8-bit, RGBA) image data to disk.  */
+void SaveToPng(const std::string& file_path, const ImageRgba8U& image);
+
+/** Writes the depth (32-bit) image data to disk. Png files do not support
+ channels larger than 16-bits and its support for floating point values is
+ also limited at best. So, depth images can only be written as tiffs.  */
+void SaveToTiff(const std::string& file_path, const ImageDepth32F& image);
+
+/** Writes the label (16-bit) image data to disk.  */
+void SaveToPng(const std::string& file_path, const ImageLabel16I& image);
+
+//@}
+
+/** A system for periodically writing images to the file system. This is a
+ convenience mechanism for capturing images from (typically) an RgbdCamera.
+ However, any system that outputs a compatible image type can act as an input
+ for this system.
+
+ @system{ImageWriter,
+    @input_port{color_image} @input_port{depth_image} @input_port{label_image},
+ }
+
+ The writer saves images based on a periodic publish event. For a given period
+ `P`, images will be written at times `t = [0, P, 2P, ...]`. Optionally, the
+ writer can be configured to create images starting at some time greater than
+ zero. Given a positive "start time" value `tₛ`, the first frame will be written
+ at `t = minᵢ i⋅P`, such that `i ∈ ℕ, t ≥ tₛ` -- not necessarily exactly _at_
+ `tₛ`.
+
+ The output image names are a combination of a provided base name, the image
+ type, and an optionally zero-padded frame enumeration. The enumeration starts
+ at 0. For example, given a base name of "my_image", padding of 3, the
+ %ImageWriter could produce image files with the following names:
+
+   - `my_image_color_002.png`: the _third_ color image written.
+   - `my_image_depth_020.tiff`: the _21ˢᵗ_ depth image written.
+   - `my_image_label_1000.png`: the 1001ˢᵗ label image written.
+
+ Each image type corresponds to a unique input port. If the input port is not
+ connected, that image type will not be written. All image types are written
+ to the same directory. All image types are written at the same frequency and
+ images of different types with the same enumeration value reflect the same
+ time represented in the Context. If different image types need to be written at
+ different periods or to different directories, simply instantiate multiple
+ %ImageWriter instances and configure them accordingly.
+
+ @note Color and label images are saved as png files -- a lossless compressed
+ image format. However, depth images are stored as tiff files; png does not
+ support 32-bit floating-point-valued channels.
+
+ @note Every invocation of `Publish()` that writes images will increment the
+ frame counter. If `Publish()` is only called based on this system's periodic
+ events (see set_publish_period()`), then the image sequence will directly map
+ to uniform intervals of time. Calls to `Publish()` outside of the periodic
+ events will render enumerated frames into the sequence without this same
+ relationship in time.  */
+class ImageWriter : public LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ImageWriter)
+
+  /** Constructs the image-to-file system. The system writes *files* but does
+   not create directories. If the given `folder_path` specifies a directory
+   that does not exist (or can't be written to), the system will be disabled.
+   A warning will be emitted but, otherwise, it will not interfere with the
+   evaluation of the diagram in which this image writer is placed.
+
+   @param folder_path The path to the directory into which the images will be
+                      written. The empty string is interpreted as "/".
+   @param image_name  The base name of the files to write. Images will be
+                      written as `[image_name]_[type]_%0Xd.ext` where X is
+                      `padding`. Defaults to "image".
+   @param start_time  The earliest simulation time at which an image may be
+                      written. See class documentation on the time at which
+                      the first frame will be written relative to `start_time`.
+                      Defaults to zero.
+   @param padding     The minimum number of digits in the output file name for
+                      image sequence enumeration (with the total count padded by
+                      zeros). For example:
+                        padding = 1 --> image1.png, image2.png, ...
+                        padding = 2 --> image01.png, image02.png, ...
+                        padding = 3 --> image001.png, image002.png, ...
+                        etc.
+                      Default value is 4.  */
+  ImageWriter(std::string folder_path, std::string image_name = "image",
+            double start_time = 0, int padding = 4);
+
+  /** The period at which images are written. See the class documentation for
+   details regarding the time stamps at which images will be written. `period`
+   must be positive.
+   @throws std::logic_error if period is not positive.  */
+  void set_publish_period(double period);
+
+  /** @name     Image-typed input ports      */
+  //@{
+
+  const InputPort<double>& color_image_input_port() const;
+
+  const InputPort<double>& depth_image_input_port() const;
+
+  const InputPort<double>& label_image_input_port() const;
+
+  //@}
+
+ private:
+#ifndef DRAKE_DOXYGEN_CXX
+  // Friend for facilitating unit testing.
+  friend class ImageWriterTester;
+#endif
+
+  // Returns true if the directory path provided is valid: it exists, it's a
+  // directory, and it's writable.
+  static bool IsDirectoryValid(const std::string& file_path);
+
+  // Creates a file name from the writer's base name, image directory, and the
+  // given type name and frame number.
+  std::string make_file_name(const std::string& type_name,
+                             int frame_number, const std::string& ext) const;
+
+  // Do the image writing.
+  void DoPublish(
+      const systems::Context<double>& context,
+      const std::vector<const PublishEvent<double>*>&) const override;
+
+  // Output parameters.
+  const std::string folder_path_;
+  const std::string image_name_base_;
+  const double start_time_{0.0};
+  const int padding_{4};
+
+  const bool can_write_{false};
+
+  int color_image_port_index_{-1};
+  int depth_image_port_index_{-1};
+  int label_image_port_index_{-1};
+
+  // The index of the _last_ frame created. For simplicity's sake, this is
+  // simply a mutable member because it is *only* touched in the `Publish()`
+  // method -- that means it won't be affected by a Simulator's test steps
+  // or an integrator's intermediate steps. The alternative of putting it in
+  // discrete state feels overly heavyweight for such a simple use.
+  mutable int previous_frame_index_{-1};
+};
+
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/systems/sensors/test/image_writer_test.cc
+++ b/systems/sensors/test/image_writer_test.cc
@@ -1,0 +1,419 @@
+#include "drake/systems/sensors/image_writer.h"
+
+#include <unistd.h>
+
+#include <fstream>
+#include <set>
+#include <string>
+
+#include <gtest/gtest.h>
+#include <spruce.hh>
+#include <vtkImageData.h>
+#include <vtkImageExport.h>
+#include <vtkNew.h>
+#include <vtkPNGReader.h>
+#include <vtkSmartPointer.h>
+#include <vtkTIFFReader.h>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/temp_directory.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/systems/framework/event_collection.h"
+
+// NOTE: This is a limited test of ImageWriter functionality.
+namespace drake {
+namespace systems {
+namespace sensors {
+
+// Friend class to get access to ImageWriter private functions for testing.
+class ImageWriterTester {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ImageWriterTester)
+
+  explicit ImageWriterTester(const ImageWriter& writer) : writer_(writer) {}
+
+  bool can_write() const { return writer_.can_write_; }
+
+  std::string make_file_name(const std::string& type_name, int i,
+                             const std::string& ext) const {
+    return writer_.make_file_name(type_name, i, ext);
+  }
+
+  int previous_frame_index() const {
+    return writer_.previous_frame_index_;
+  }
+
+  double start_time() const {
+    return writer_.start_time_;
+  }
+
+ private:
+  const ImageWriter& writer_;
+};
+
+namespace {
+
+// Class for testing actual I/O work. This helps manage generated files by
+// facilitating temporary file names and registering additional names so that
+// they can be cleaned up at the conclusion of the tests.
+class ImageWriterTest : public ::testing::Test {
+ public:
+  static void SetUpTestCase() {
+    ASSERT_TRUE(ImageWriterTester(ImageWriter(temp_dir())).can_write());
+  }
+
+  static void TearDownTestCase() {
+    for (const auto& file_name : files_) {
+      spruce::path file_path(file_name);
+      if (file_path.exists()) {
+        // We'll consider a failure to delete a temporary file as a test
+        // failure.
+        unlink(file_path.getStr().c_str());
+        EXPECT_FALSE(file_path.exists())
+                  << "Failed to delete temporary test file: " << file_name;
+      }
+    }
+  }
+
+  // This assumes that the temp_directory() API will *always* return the same
+  // name.
+  static std::string temp_dir() { return temp_directory(); }
+
+  // Returns a unique temporary image name - every requested name will be
+  // examined at tear down for deletion. When it comes to writing images, all
+  // names should come from here.
+  static std::string temp_name() {
+    spruce::path temp_path;
+    do {
+      temp_path.setStr(temp_dir());
+      temp_path.append("image_writer_test_" + std::to_string(++img_count_) +
+          ".png");
+    } while (temp_path.exists());
+    files_.insert(temp_path.getStr());
+    return temp_path.getStr();
+  }
+
+  // Arbitrary files that are generated can be added to the set of files that
+  // require clean up. This should be invoked for _every_ file generated in this
+  // test suite.
+  static void add_file_for_cleanup(const std::string& file_name) {
+    files_.insert(file_name);
+  }
+
+  template <PixelType kPixelType>
+  ::testing::AssertionResult ReadImage(const std::string& image_name,
+                                       Image<kPixelType>* image) {
+    spruce::path image_path(image_name);
+    if (image_path.exists()) {
+      vtkSmartPointer<vtkImageReader2> reader;
+      switch (kPixelType) {
+        case PixelType::kRgba8U:
+        case PixelType::kLabel16I:
+          reader = vtkSmartPointer<vtkPNGReader>::New();
+          break;
+        case PixelType::kDepth32F:
+          reader = vtkSmartPointer<vtkTIFFReader>::New();
+          break;
+        default:
+          return ::testing::AssertionFailure()
+              << "Trying to read an unknown image type";
+      }
+      reader->SetFileName(image_name.c_str());
+      vtkNew<vtkImageExport> png_exporter;
+      png_exporter->SetInputConnection(reader->GetOutputPort());
+      png_exporter->Update();
+      vtkImageData *image_data = png_exporter->GetInput();
+      // Assumes 1-dimensional data -- the 4x1 image.
+      if (image_data->GetDataDimension() == 1) {
+        int read_width;
+        image_data->GetDimensions(&read_width);
+        if (read_width == image->width()) {
+          png_exporter->Export(image->at(0, 0));
+          return ::testing::AssertionSuccess();
+        }
+      }
+      int dims[3];
+      png_exporter->GetDataDimensions(&dims[0]);
+      return ::testing::AssertionFailure()
+          << "Expected a " << image->width() << "x" << image->height()
+          << "image. Read an image of size: " << dims[0] << "x" << dims[1]
+          << "x" << dims[2];
+    } else {
+      return ::testing::AssertionFailure()
+          << "The image to be read does not exist: " << image_name;
+    }
+  }
+
+  // Generates a simple, known color image.
+  static ImageRgba8U test_color_image() {
+    // Creates a simple 4x1 image consisting of: [red][green][blue][white].
+    ImageRgba8U color_image(4, 1);
+    auto set_color = [&color_image](int x, int y, uint8_t r, uint8_t g,
+                                    uint8_t b) {
+      color_image.at(x, y)[0] = r;
+      color_image.at(x, y)[1] = g;
+      color_image.at(x, y)[2] = b;
+      color_image.at(x, y)[3] = 255;
+    };
+    set_color(0, 0, 255, 0, 0);
+    set_color(1, 0, 0, 255, 0);
+    set_color(2, 0, 0, 0, 255);
+    set_color(3, 0, 255, 255, 255);
+    return color_image;
+  }
+
+ private:
+  // NOTE: These are static so that they are shared across the entire test
+  // suite. This allows all tests to have non-conflicting names *and* get
+  // cleaned up when the test suite shuts down.
+
+  // This presumes the tests in a single test case do *not* run in parallel.
+  static int img_count_;
+
+  // Files that may need to be cleaned up. It _must_ include every file that has
+  // been created by these tests but *may* include purely speculative file
+  // names.
+  static std::set<std::string> files_;
+};
+
+int  ImageWriterTest::img_count_{-1};
+std::set<std::string> ImageWriterTest::files_;
+
+// Tests the logic for formatting images.
+TEST_F(ImageWriterTest, FileNameFormatting) {
+  auto test_file_name = [](const ImageWriter& writer,
+                           const std::string expected, int frame = 0) {
+    const std::string path =
+        ImageWriterTester(writer).make_file_name("type", frame, "png");
+    EXPECT_EQ(path, expected);
+  };
+
+  // Test various folder paths.
+  test_file_name(ImageWriter("", "base"), "/base_type_0000.png");
+  test_file_name(ImageWriter("/", "base"), "/base_type_0000.png");
+  test_file_name(ImageWriter("test", "base"), "test/base_type_0000.png");
+  test_file_name(ImageWriter("test/", "base"), "test/base_type_0000.png");
+  test_file_name(ImageWriter("/test", "base"), "/test/base_type_0000.png");
+
+  // Test various padding values.
+  const double start_time = 0;
+  test_file_name(ImageWriter("", "base", start_time, 0), "/base_type_0.png");
+  test_file_name(ImageWriter("", "base", start_time, 1), "/base_type_0.png");
+  test_file_name(ImageWriter("", "base", start_time, 2), "/base_type_00.png");
+  test_file_name(ImageWriter("", "base", start_time, 5),
+                 "/base_type_00000.png");
+
+  // Confirm it uses the provided frame (and not a hard-coded zero).
+  test_file_name(ImageWriter("", "base"), "/base_type_0001.png", 1);
+  test_file_name(ImageWriter("", "base"), "/base_type_0100.png", 100);
+  test_file_name(ImageWriter("", "base"), "/base_type_12345.png", 12345);
+}
+
+// Test initialization of various non-name related fields.
+TEST_F(ImageWriterTest, ConstructorNonNamed) {
+  {
+    ImageWriterTester png_tester{ImageWriter(temp_dir())};
+    EXPECT_EQ(png_tester.previous_frame_index(), -1);
+    EXPECT_EQ(png_tester.start_time(), 0.0);  // default value.
+  }
+
+  {
+    const double start_time = 1.75;
+    ImageWriterTester png_tester(ImageWriter(temp_dir(), "name", start_time));
+    EXPECT_EQ(png_tester.previous_frame_index(), -1);
+    EXPECT_EQ(png_tester.start_time(), start_time);
+  }
+}
+
+// Tests the writeability of a image writer based on the validity of the
+// directory path.
+TEST_F(ImageWriterTest, CanWrite) {
+  // Case: Non-existent directory.
+  {
+    ImageWriter writer("this/path/does/not_exist");
+    EXPECT_FALSE(ImageWriterTester(writer).can_write());
+  }
+
+  // Case: No write permissions (assuming that this isn't run as root).
+  {
+    ImageWriter writer("/root");
+    EXPECT_FALSE(ImageWriterTester(writer).can_write());
+  }
+
+  // Case: the path is to a file.
+  {
+    const std::string file_name = temp_name();
+    std::ofstream stream(file_name, std::ios::out);
+    ASSERT_FALSE(stream.fail());
+    ImageWriter writer(file_name);
+    EXPECT_FALSE(ImageWriterTester(writer).can_write());
+  }
+}
+
+// Confirms publishing semantics.
+TEST_F(ImageWriterTest, ConfigurePublishPeriod) {
+  // Case: valid working directory.
+  {
+    ImageWriter writer(temp_dir());
+
+    // Freshly constructed, the writer has no timed events.
+    auto events = writer.AllocateCompositeEventCollection();
+    auto context = writer.AllocateContext();
+    writer.CalcNextUpdateTime(*context, events.get());
+    EXPECT_FALSE(events->HasEvents());
+
+    // Invalid period value throws an exception and, god forbid someone catches
+    // the exception, it has no timed events.
+    DRAKE_EXPECT_THROWS_MESSAGE(writer.set_publish_period(-1), std::logic_error,
+                                "ImageWriter requires a positive period value");
+    events->Clear();    // Should already be clear; but we're just being safe.
+    writer.CalcNextUpdateTime(*context, events.get());
+    EXPECT_FALSE(events->HasEvents());
+
+    // With a valid period value, it should report a timed event.
+    EXPECT_NO_THROW(writer.set_publish_period(1));
+    events->Clear();    // Should already be clear; but we're just being safe.
+    writer.CalcNextUpdateTime(*context, events.get());
+    EXPECT_TRUE(events->HasEvents());
+  }
+
+  // Case: invalid working directory.
+  {
+    ImageWriter writer("/this/is/garbage");
+
+    // Freshly constructed, the writer has no timed events.
+    auto events = writer.AllocateCompositeEventCollection();
+    auto context = writer.AllocateContext();
+
+    // A valid period should not throw an exception, but no timed events should
+    // be created.
+    EXPECT_NO_THROW(writer.set_publish_period(1));
+    writer.CalcNextUpdateTime(*context, events.get());
+    EXPECT_FALSE(events->HasEvents());
+  }
+}
+
+// Evaluate the stand-alone test for color images.
+TEST_F(ImageWriterTest, SaveToPng_Color) {
+  const std::string color_image_name = temp_name();
+  ImageRgba8U color_image = test_color_image();
+  SaveToPng(color_image_name, color_image);
+
+  ImageRgba8U read_image(color_image.width(), color_image.height());
+  ASSERT_TRUE(ReadImage(color_image_name, &read_image));
+  for (int u = 0; u < 4; ++u) {
+    for (int c = 0; c < 4; ++c) {
+      EXPECT_EQ(read_image.at(u, 0)[c], color_image.at(u, 0)[c]);
+    }
+  }
+}
+
+// Evaluate the stand-alone test for depth images.
+TEST_F(ImageWriterTest, SaveToTiff_Depth) {
+  // Creates a simple 4x1 image consisting of: 0, 0.25, 0.5, 0.75
+  ImageDepth32F depth_image(4, 1);
+  *depth_image.at(0, 0) = 0.0f;
+  *depth_image.at(1, 0) = 0.25f;
+  *depth_image.at(2, 0) = 0.5f;
+  *depth_image.at(3, 0) = 1.0f;
+
+  const std::string depth_image_name = temp_name();
+  SaveToTiff(depth_image_name, depth_image);
+
+  ImageDepth32F read_image(depth_image.width(), depth_image.height());
+  ASSERT_TRUE(ReadImage(depth_image_name, &read_image));
+  for (int u = 0; u < 4; ++u) {
+    EXPECT_EQ(read_image.at(u, 0)[0], depth_image.at(u, 0)[0]);
+  }
+}
+
+// Evaluate the stand-alone test for label images.
+TEST_F(ImageWriterTest, SaveToPng_Label) {
+  // Creates a simple 4x1 image consisting of: 0, 1, 2, 3.
+  ImageLabel16I label_image(4, 1);
+  *label_image.at(0, 0) = 0;
+  *label_image.at(1, 0) = 1;
+  *label_image.at(2, 0) = 2;
+  *label_image.at(3, 0) = 3;
+
+  const std::string label_image_name = temp_name();
+  SaveToPng(label_image_name, label_image);
+
+  ImageLabel16I read_image(label_image.width(), label_image.height());
+  ASSERT_TRUE(ReadImage(label_image_name, &read_image));
+  for (int u = 0; u < 4; ++u) {
+    EXPECT_EQ(read_image.at(u, 0)[0], label_image.at(u, 0)[0]);
+  }
+}
+
+// Confirms that writing increments the counter.
+TEST_F(ImageWriterTest, WriteIncrementsCounter) {
+  ImageWriter writer(temp_dir(), "increment_test");
+  auto context = writer.AllocateContext();
+  context->FixInputPort(
+      writer.color_image_input_port().get_index(),
+      AbstractValue::Make<ImageRgba8U>(test_color_image()));
+  ImageWriterTester tester(writer);
+
+  int expected_previous = -1;
+  for (int i = 0; i < 2; ++i) {
+    // Confirms initial conditions.
+    ASSERT_EQ(tester.previous_frame_index(), expected_previous);
+    const std::string first_file =
+        fmt::format("increment_test_color_{0:04}.png", ++expected_previous);
+    spruce::path file_path(temp_dir());
+    file_path.append(first_file);
+    ASSERT_FALSE(file_path.exists());
+
+    // Publish.
+    writer.Publish(*context);
+    add_file_for_cleanup(file_path.getStr());
+
+    // Confirm expected state.
+    ASSERT_EQ(tester.previous_frame_index(), expected_previous);
+    ASSERT_TRUE(file_path.exists());
+  }
+}
+
+// Confirms that calling publish with contexts before start time do not write
+// images (as detected by incrementing the counter).
+TEST_F(ImageWriterTest, NoWritingBeforeStartTime) {
+  const double start_time = 10;
+  ImageWriter writer(temp_dir(), "start_time_test", start_time);
+  auto context = writer.AllocateContext();
+  context->FixInputPort(
+      writer.color_image_input_port().get_index(),
+      AbstractValue::Make<ImageRgba8U>(test_color_image()));
+  ImageWriterTester tester(writer);
+
+  // Confirms initial conditions.
+  ASSERT_EQ(tester.previous_frame_index(), -1);
+  const std::string first_file = "start_time_test_color_0000.png";
+  spruce::path file_path(temp_dir());
+  file_path.append(first_file);
+  ASSERT_FALSE(file_path.exists());
+
+  const int kCount = 10;
+  for (int i = 0; i < kCount; ++i) {
+    // Guarantee that t < start_time. start_time / (kCount + 1)
+    const double t = start_time / kCount * i;
+    context->set_accuracy(t);
+    writer.Publish(*context);
+    // If images are *actually* being written, we want to stop this test
+    // *immediately*.
+    ASSERT_EQ(tester.previous_frame_index(), -1);
+    ASSERT_FALSE(file_path.exists());
+  }
+
+  context->set_time(start_time);
+  writer.Publish(*context);
+  add_file_for_cleanup(file_path.getStr());
+
+  ASSERT_EQ(tester.previous_frame_index(), 0);
+  ASSERT_TRUE(file_path.exists());
+}
+
+}  // namespace
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -37,6 +37,7 @@ load("@drake//tools/workspace/lcmtypes_robotlocomotion:repository.bzl", "lcmtype
 load("@drake//tools/workspace/liblz4:repository.bzl", "liblz4_repository")
 load("@drake//tools/workspace/libpng:repository.bzl", "libpng_repository")
 load("@drake//tools/workspace/libprotobuf:repository.bzl", "libprotobuf_repository")  # noqa
+load("@drake//tools/workspace/libtiff:repository.bzl", "libtiff_repository")
 load("@drake//tools/workspace/mosek:repository.bzl", "mosek_repository")
 load("@drake//tools/workspace/net_sf_jchart2d:repository.bzl", "net_sf_jchart2d_repository")  # noqa
 load("@drake//tools/workspace/nlopt:repository.bzl", "nlopt_repository")
@@ -152,6 +153,8 @@ def add_default_repositories(excludes = [], mirrors = DEFAULT_MIRRORS):
         libpng_repository(name = "libpng")
     if "libprotobuf" not in excludes:
         libprotobuf_repository(name = "libprotobuf")
+    if "libtiff" not in excludes:
+        libtiff_repository(name = "libtiff")
     if "mosek" not in excludes:
         mosek_repository(name = "mosek")
     if "net_sf_jchart2d" not in excludes:

--- a/tools/workspace/libtiff/BUILD.bazel
+++ b/tools/workspace/libtiff/BUILD.bazel
@@ -1,0 +1,8 @@
+# -*- python -*-
+
+# This file exists to make our directory into a Bazel package, so that our
+# neighboring *.bzl file can be loaded elsewhere.
+
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+add_lint_tests()

--- a/tools/workspace/libtiff/repository.bzl
+++ b/tools/workspace/libtiff/repository.bzl
@@ -1,0 +1,20 @@
+# -*- mode: python -*-
+
+load(
+    "@drake//tools/workspace:pkg_config.bzl",
+    "pkg_config_repository",
+)
+
+def libtiff_repository(
+        name,
+        licenses = ["notice"],  # Libtiff
+        modname = "libtiff-4",
+        pkg_config_paths = ["/usr/local/opt/libtiff/lib/pkgconfig"],
+        **kwargs):
+    pkg_config_repository(
+        name = name,
+        licenses = licenses,
+        modname = modname,
+        pkg_config_paths = pkg_config_paths,
+        **kwargs
+    )

--- a/tools/workspace/vtk/repository.bzl
+++ b/tools/workspace/vtk/repository.bzl
@@ -504,6 +504,8 @@ licenses([
             "vtkJPEGReader.h",
             "vtkPNGReader.h",
             "vtkPNGWriter.h",
+            "vtkTIFFReader.h",
+            "vtkTIFFWriter.h",
         ],
         deps = [
             ":vtkCommonCore",
@@ -512,6 +514,7 @@ licenses([
             ":vtkmetaio",
             "@libpng",
             "@zlib",
+            "@libtiff",
         ],
     )
 


### PR DESCRIPTION
Simple publishing system whose whole point is to save `Image` instances to the disk (format depends on image type) from an RgbdCamera.

- This includes expanding VTK to include `vtkTiff{Reader|Writer}` and adds a repository for `libtiff`.
- The system itself: `ImageWriter` and some stand-alone utility methods (that the system makes use of).
- Unit tests.

```
Category            added  modified  removed  
----------------------------------------------
code                511    0         0        
comments            147    0         0        
blank               114    0         0        
----------------------------------------------
TOTAL               772    0         0   
```

Sorry for the size.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9772)
<!-- Reviewable:end -->
