### PR TITLE
Mathematical program result

### DIFF
--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -273,6 +273,16 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "mathematical_program_result",
+    hdrs = ["mathematical_program_result.h"],
+    srcs = ["mathematical_program_result.cc"],
+    deps = [
+        ":mathematical_program_api",
+        "//systems/framework:value",
+    ],
+)
+
+drake_cc_library(
     name = "branch_and_bound",
     srcs = ["branch_and_bound.cc"],
     hdrs = ["branch_and_bound.h"],
@@ -1361,6 +1371,15 @@ drake_cc_googletest(
         ":mathematical_program",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:symbolic_test_util",
+    ],
+)
+
+drake_cc_googletest(
+    name = "mathematical_program_result_test",
+    deps = [
+        ":mathematical_program_result",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -37,6 +37,7 @@ drake_cc_package_library(
         ":linear_system_solver",
         ":mathematical_program",
         ":mathematical_program_api",
+        ":mathematical_program_result",
         ":mixed_integer_optimization_util",
         ":mixed_integer_rotation_constraint",
         ":moby_lcp_solver",
@@ -274,8 +275,8 @@ drake_cc_library(
 
 drake_cc_library(
     name = "mathematical_program_result",
-    hdrs = ["mathematical_program_result.h"],
     srcs = ["mathematical_program_result.cc"],
+    hdrs = ["mathematical_program_result.h"],
     deps = [
         ":mathematical_program_api",
         "//systems/framework:value",

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -625,11 +625,13 @@ drake_cc_library(
     deps = select({
         "//tools:with_mosek": [
             ":mathematical_program_api",
+            ":mathematical_program_result",
             "//common:scoped_singleton",
             "@mosek",
         ],
         "//conditions:default": [
             ":mathematical_program_api",
+            ":mathematical_program_result",
         ],
     }),
 )

--- a/solvers/mathematical_program_result.cc
+++ b/solvers/mathematical_program_result.cc
@@ -22,5 +22,14 @@ const systems::AbstractValue& MathematicalProgramResult::solver_details()
   }
   return *solver_details_;
 }
+
+SolverResult MathematicalProgramResult::ConvertToSolverResult() const {
+  SolverResult solver_result(solver_id_);
+  if (x_val_.size() != 0) {
+    solver_result.set_decision_variable_values(x_val_);
+  }
+  solver_result.set_optimal_cost(optimal_cost_);
+  return solver_result;
+}
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/mathematical_program_result.cc
+++ b/solvers/mathematical_program_result.cc
@@ -7,15 +7,6 @@ MathematicalProgramResult::MathematicalProgramResult()
       x_val_{0},
       optimal_cost_{NAN},
       solver_id_{"unknown"},
-      solver_details_{nullptr} {}
-
-MathematicalProgramResult::MathematicalProgramResult(
-    SolutionResult result, const Eigen::VectorXd& x_val, double optimal_cost,
-    const SolverId& solver_id)
-    : result_{result},
-      x_val_{x_val},
-      optimal_cost_{optimal_cost},
-      solver_id_{solver_id},
       solver_details_{
           systems::AbstractValue::Make<NoSolverDetails>(NoSolverDetails())} {}
 

--- a/solvers/mathematical_program_result.cc
+++ b/solvers/mathematical_program_result.cc
@@ -13,9 +13,9 @@ MathematicalProgramResult::MathematicalProgramResult()
     : solution_result_{SolutionResult::kUnknownError},
       x_val_{0},
       optimal_cost_{NAN},
-      solver_id_{UnknownId()} {
-  this->SetSolverDetailsType<NoSolverDetails>();
-}
+      solver_id_{UnknownId()},
+      solver_details_type_{nullptr},
+      solver_details_{nullptr} {}
 
 const systems::AbstractValue& MathematicalProgramResult::get_solver_details()
     const {

--- a/solvers/mathematical_program_result.cc
+++ b/solvers/mathematical_program_result.cc
@@ -1,0 +1,35 @@
+#include "drake/solvers/mathematical_program_result.h"
+
+namespace drake {
+namespace solvers {
+MathematicalProgramResult::MathematicalProgramResult()
+    : result_{SolutionResult::kUnknownError},
+      x_val_{0},
+      optimal_cost_{NAN},
+      solver_id_{"unknown"},
+      solver_details_{nullptr} {}
+
+MathematicalProgramResult::MathematicalProgramResult(
+    SolutionResult result, const Eigen::VectorXd& x_val, double optimal_cost,
+    const SolverId& solver_id)
+    : result_{result},
+      x_val_{x_val},
+      optimal_cost_{optimal_cost},
+      solver_id_{solver_id},
+      solver_details_{
+          systems::AbstractValue::Make<NoSolverDetails>(NoSolverDetails())} {}
+
+void MathematicalProgramResult::SetSolverDetails(
+    std::unique_ptr<systems::AbstractValue> solver_details) {
+  solver_details_ = std::move(solver_details);
+}
+
+const systems::AbstractValue& MathematicalProgramResult::solver_details()
+    const {
+  if (!solver_details_) {
+    throw std::logic_error("The solver_details has not been set yet.");
+  }
+  return *solver_details_;
+}
+}  // namespace solvers
+}  // namespace drake

--- a/solvers/mathematical_program_result.cc
+++ b/solvers/mathematical_program_result.cc
@@ -1,5 +1,7 @@
 #include "drake/solvers/mathematical_program_result.h"
 
+#include <utility>
+
 namespace drake {
 namespace solvers {
 MathematicalProgramResult::MathematicalProgramResult()

--- a/solvers/mathematical_program_result.cc
+++ b/solvers/mathematical_program_result.cc
@@ -31,10 +31,6 @@ SolverResult MathematicalProgramResult::ConvertToSolverResult() const {
     solver_result.set_decision_variable_values(x_val_);
   }
   solver_result.set_optimal_cost(optimal_cost_);
-  // This function doesn't set optimal_cost_lower_bound. If
-  // SolverResult.optimal_cost_lower_bound needs to be set (like in
-  // GurobiSolver), then the user will have to set it after calling
-  // ConvertToSolverResult.
   return solver_result;
 }
 }  // namespace solvers

--- a/solvers/mathematical_program_result.h
+++ b/solvers/mathematical_program_result.h
@@ -11,9 +11,6 @@
 
 namespace drake {
 namespace solvers {
-/* The empty solver details. This is the default option for any solver. */
-struct NoSolverDetails {};
-
 /**
  * The result returned by solve(). It stores the SolutionResult (whether the
  * program is solved to optimality, detected infeasibility, etc), the optimal
@@ -25,7 +22,7 @@ class MathematicalProgramResult final {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(MathematicalProgramResult)
   /**
    * Constructs the result.
-   * @note The solver_details is set to NoSolverDetails.
+   * @note The solver_details is set to nullptr.
    */
   MathematicalProgramResult();
 
@@ -56,7 +53,7 @@ class MathematicalProgramResult final {
   void set_solver_id(const SolverId& solver_id) { solver_id_ = solver_id; }
 
   /** Gets the solver details. Throws an error if the solver_details has not
-   * been set*/
+   * been set.*/
   const systems::AbstractValue& get_solver_details() const;
 
   /** Forces the solver_details to be stored using the given type T.

--- a/solvers/mathematical_program_result.h
+++ b/solvers/mathematical_program_result.h
@@ -59,6 +59,12 @@ class MathematicalProgramResult {
    * not been set*/
   const systems::AbstractValue& solver_details() const;
 
+  /**
+   * Convert MathematicalProgramResult to SolverResult.
+   * TODO(hongkai.dai): remove this function, when we remove SolverResult class.
+   */
+  SolverResult ConvertToSolverResult() const;
+
  private:
   SolutionResult result_;
   Eigen::VectorXd x_val_;
@@ -66,5 +72,6 @@ class MathematicalProgramResult {
   SolverId solver_id_;
   std::unique_ptr<systems::AbstractValue> solver_details_;
 };
+
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/mathematical_program_result.h
+++ b/solvers/mathematical_program_result.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <typeinfo>
 #include <utility>
 
 // TODO(hongkai.dai): separate SolutionResult and SolverResult from
@@ -12,10 +13,10 @@
 namespace drake {
 namespace solvers {
 /**
- * The result returned by solve(). It stores the SolutionResult (whether the
- * program is solved to optimality, detected infeasibility, etc), the optimal
- * value for the decision variables, the optimal cost, and solver specific
- * details.
+ * The result returned by MathematicalProgram::Solve(). It stores the
+ * solvers::SolutionResult (whether the program is solved to optimality,
+ * detected infeasibility, etc), the optimal * value for the decision variables,
+ * the optimal cost, and solver specific details.
  */
 class MathematicalProgramResult final {
  public:
@@ -78,6 +79,10 @@ class MathematicalProgramResult final {
 
   /**
    * Convert MathematicalProgramResult to SolverResult.
+   * @note This function doesn't set optimal_cost_lower_bound. If
+   * SolverResult.optimal_cost_lower_bound needs to be set (like in
+   * GurobiSolver), then the user will have to set it after calling
+   * ConvertToSolverResult.
    */
   SolverResult ConvertToSolverResult() const;
 

--- a/solvers/mathematical_program_result.h
+++ b/solvers/mathematical_program_result.h
@@ -18,14 +18,35 @@ struct NoSolverDetails {};
  */
 class MathematicalProgramResult {
  public:
-  MathematicalProgramResult();
-
   /**
    * Constructs the result.
    * @note The solver_details is set to NoSolverDetails.
    */
-  MathematicalProgramResult(SolutionResult result, const Eigen::VectorXd& x_val,
-                            double optimal_cost, const SolverId& solver_id);
+  MathematicalProgramResult();
+
+  /** Getter for the mutable SolutionResult. */
+  SolutionResult& get_mutable_result() { return result_; }
+
+  /** Getter for the immutable SolutionResult. */
+  SolutionResult result() const { return result_; }
+
+  /** Getter for the mutable decision variable values. */
+  Eigen::VectorXd& get_mutable_x_val() { return x_val_; }
+
+  /** Getter for the immutable decision variable values. */
+  const Eigen::VectorXd& x_val() const { return x_val_; }
+
+  /** Getter for the mutable optimal cost. */
+  double& get_mutable_optimal_cost() { return optimal_cost_; }
+
+  /** Getter for the optimal cost. */
+  double optimal_cost() const { return optimal_cost_; }
+
+  /** Getter for the mutable solver id. */
+  SolverId& get_mutable_solver_id() { return solver_id_; }
+
+  /** Getter for the solver ID. */
+  const SolverId& solver_id() const { return solver_id_; }
 
   /**
    * Sets the solver details.
@@ -33,18 +54,6 @@ class MathematicalProgramResult {
    * own its recource after calling this function.
    */
   void SetSolverDetails(std::unique_ptr<systems::AbstractValue> solver_details);
-
-  /** Getter for the immutable SolutionResult. */
-  SolutionResult result() const { return result_; }
-
-  /** Getter for the immutable decision variable values. */
-  const Eigen::VectorXd& x_val() const { return x_val_; }
-
-  /** Getter for the optimal cost. */
-  double optimal_cost() const { return optimal_cost_; }
-
-  /** Getter for the solver ID. */
-  const SolverId& solver_id() const { return solver_id_; }
 
   /** Getter for the solver details. Throws an error if the solver_details has
    * not been set*/

--- a/solvers/mathematical_program_result.h
+++ b/solvers/mathematical_program_result.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <memory>
+
+#include "drake/solvers/mathematical_program_solver_interface.h"
+#include "drake/systems/framework/value.h"
+
+namespace drake {
+namespace solvers {
+/* The empty solver details. This is the default option for any solver. */
+struct NoSolverDetails {};
+
+/**
+ * The result returned by solve(). It stores the SolutionResult (whether the
+ * program is solved to optimality, detected infeasibility, etc), the optimal
+ * value for the decision variables, the optimal cost, and solver specific
+ * details.
+ */
+class MathematicalProgramResult {
+ public:
+  MathematicalProgramResult();
+
+  /**
+   * Constructs the result.
+   * @note The solver_details is set to NoSolverDetails.
+   */
+  MathematicalProgramResult(SolutionResult result, const Eigen::VectorXd& x_val,
+                            double optimal_cost, const SolverId& solver_id);
+
+  /**
+   * Sets the solver details.
+   * @param solver_details The details from the solver. solver_details will not
+   * own its recource after calling this function.
+   */
+  void SetSolverDetails(std::unique_ptr<systems::AbstractValue> solver_details);
+
+  /** Getter for the immutable SolutionResult. */
+  SolutionResult result() const { return result_; }
+
+  /** Getter for the immutable decision variable values. */
+  const Eigen::VectorXd& x_val() const { return x_val_; }
+
+  /** Getter for the optimal cost. */
+  double optimal_cost() const { return optimal_cost_; }
+
+  /** Getter for the solver ID. */
+  const SolverId& solver_id() const { return solver_id_; }
+
+  /** Getter for the solver details. Throws an error if the solver_details has
+   * not been set*/
+  const systems::AbstractValue& solver_details() const;
+
+ private:
+  SolutionResult result_;
+  Eigen::VectorXd x_val_;
+  double optimal_cost_;
+  SolverId solver_id_;
+  std::unique_ptr<systems::AbstractValue> solver_details_;
+};
+}  // namespace solvers
+}  // namespace drake

--- a/solvers/mosek_solver.cc
+++ b/solvers/mosek_solver.cc
@@ -756,7 +756,7 @@ MathematicalProgramResult MosekSolver::SolveConstProg(
   result.get_mutable_solver_id() = id();
   // TODO(hongkai.dai@tri.global) : Add MOSEK parameters.
   // Mosek parameter are added by enum, not by string.
-  MSKsolstae solution_status;
+  MSKsolstae solution_status{MSK_SOL_STA_UNKNOWN};
   if (rescode == MSK_RES_OK) {
     if (rescode == MSK_RES_OK) {
       rescode = MSK_getsolsta(task, solution_type, &solution_status);

--- a/solvers/mosek_solver.cc
+++ b/solvers/mosek_solver.cc
@@ -818,6 +818,11 @@ MathematicalProgramResult MosekSolver::SolveConstProg(
     rescode = MSK_getdouinf(task, MSK_DINF_OPTIMIZER_TIME,
                             &(solver_details.optimizer_time));
   }
+  // rescode is not used after this. If in the future, the user wants to call
+  // more MSK functions after this line, then he/she needs to check if rescode
+  // is OK. But do not modify result.solution_result_ if rescode is not OK after
+  // this line.
+  unused(rescode);
 
   MSK_deletetask(&task);
   return result;

--- a/solvers/mosek_solver.cc
+++ b/solvers/mosek_solver.cc
@@ -755,8 +755,8 @@ void MosekSolver::Solve(const MathematicalProgram& prog,
   result->get_mutable_solver_id() = id();
   // TODO(hongkai.dai@tri.global) : Add MOSEK parameters.
   // Mosek parameter are added by enum, not by string.
+  MSKsolstae solution_status;
   if (rescode == MSK_RES_OK) {
-    MSKsolstae solution_status;
     if (rescode == MSK_RES_OK) {
       rescode = MSK_getsolsta(task, solution_type, &solution_status);
     }
@@ -808,6 +808,16 @@ void MosekSolver::Solve(const MathematicalProgram& prog,
       }
     }
   }
+
+  MosekSolverDetails solver_details;
+  solver_details.rescode = rescode;
+  solver_details.solution_status = solution_status;
+  if (rescode == MSK_RES_OK) {
+    rescode = MSK_getdouinf(task, MSK_DINF_OPTIMIZER_TIME,
+                            &(solver_details.optimizer_time));
+  }
+  result->SetSolverDetails(
+      systems::AbstractValue::Make<MosekSolverDetails>(solver_details));
 
   if (rescode != MSK_RES_OK) {
     result->get_mutable_result() = SolutionResult::kUnknownError;

--- a/solvers/mosek_solver.h
+++ b/solvers/mosek_solver.h
@@ -6,6 +6,7 @@
 #include <Eigen/Core>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/solvers/mathematical_program_result.h"
 #include "drake/solvers/mathematical_program_solver_interface.h"
 
 namespace drake {
@@ -23,6 +24,8 @@ class MosekSolver : public MathematicalProgramSolverInterface {
    */
   bool available() const override;
 
+  void Solve(const MathematicalProgram& prog,
+             MathematicalProgramResult* result) const;
   SolutionResult Solve(MathematicalProgram& prog) const override;
 
   SolverId solver_id() const override;

--- a/solvers/mosek_solver.h
+++ b/solvers/mosek_solver.h
@@ -12,16 +12,17 @@
 namespace drake {
 namespace solvers {
 struct MosekSolverDetails {
-  // The mosek optimization time.
-  double optimizer_time;
+  // The mosek optimization time. Please refer to MSK_DINF_OPTIMIZER_TIME in
+  // https://docs.mosek.com/8.1/capi/constants.html?highlight=msk_dinf_optimizer_time
+  double optimizer_time{};
   // The response code returned from mosek solver. Check
   // https://docs.mosek.com/8.1/capi/response-codes.html for the meaning on the
   // response code.
-  int rescode;
+  int rescode{};
   // The solution status after solving the problem. Check
   // https://docs.mosek.com/8.1/capi/accessing-solution.html for the meaning on
   // the solution status.
-  int solution_status;
+  int solution_status{};
 };
 
 class MosekSolver : public MathematicalProgramSolverInterface {
@@ -36,11 +37,10 @@ class MosekSolver : public MathematicalProgramSolverInterface {
    */
   bool available() const override;
 
-  // Todo(hongkai.dai@tri.global): deprecate Solve with a non-const
-  // MathematicalProgram, and rename SolveConstProg as Solve.
-  MathematicalProgramResult SolveConstProg(
-      const MathematicalProgram& prog) const;
+  MathematicalProgramResult Solve(const MathematicalProgram& prog) const;
 
+  // Todo(hongkai.dai@tri.global): deprecate Solve with a non-const
+  // MathematicalProgram.
   SolutionResult Solve(MathematicalProgram& prog) const override;
 
   SolverId solver_id() const override;
@@ -83,6 +83,10 @@ class MosekSolver : public MathematicalProgramSolverInterface {
   static std::shared_ptr<License> AcquireLicense();
 
  private:
+  // TODO(hongkai.dai) remove this function when we remove Solve() with a
+  // non-cost MathematicalProgram.
+  MathematicalProgramResult SolveConstProg(
+      const MathematicalProgram& prog) const;
   // Note that this is mutable to allow latching the allocation of mosek_env_
   // during the first call of Solve() (which avoids grabbing a Mosek license
   // before we know that we actually want one).

--- a/solvers/mosek_solver.h
+++ b/solvers/mosek_solver.h
@@ -36,8 +36,11 @@ class MosekSolver : public MathematicalProgramSolverInterface {
    */
   bool available() const override;
 
-  void Solve(const MathematicalProgram& prog,
-             MathematicalProgramResult* result) const;
+  // Todo(hongkai.dai@tri.global): deprecate Solve with a non-const
+  // MathematicalProgram, and rename SolveConstProg as Solve.
+  MathematicalProgramResult SolveConstProg(
+      const MathematicalProgram& prog) const;
+
   SolutionResult Solve(MathematicalProgram& prog) const override;
 
   SolverId solver_id() const override;

--- a/solvers/mosek_solver.h
+++ b/solvers/mosek_solver.h
@@ -11,6 +11,18 @@
 
 namespace drake {
 namespace solvers {
+struct MosekSolverDetails {
+  // The mosek optimization time.
+  double optimizer_time;
+  // The response code returned from mosek solver. Check
+  // https://docs.mosek.com/8.1/capi/response-codes.html for the meaning on the
+  // response code.
+  int rescode;
+  // The solution status after solving the problem. Check
+  // https://docs.mosek.com/8.1/capi/accessing-solution.html for the meaning on
+  // the solution status.
+  int solution_status;
+};
 
 class MosekSolver : public MathematicalProgramSolverInterface {
  public:

--- a/solvers/no_mosek.cc
+++ b/solvers/no_mosek.cc
@@ -26,6 +26,12 @@ SolutionResult MosekSolver::Solve(MathematicalProgram&) const {
       "solver.");
 }
 
+MathematicalProgramResult MosekSolver::Solve(const MathematicalProgram&) const {
+  throw runtime_error(
+      "Mosek is not installed in your build. You'll need to use a different "
+      "solver.");
+}
+
 MathematicalProgramResult MosekSolver::SolveConstProg(
     const MathematicalProgram&) const {
   throw runtime_error(

--- a/solvers/no_mosek.cc
+++ b/solvers/no_mosek.cc
@@ -26,5 +26,12 @@ SolutionResult MosekSolver::Solve(MathematicalProgram&) const {
       "solver.");
 }
 
+MathematicalProgramResult MosekSolver::SolveConstProg(
+    const MathematicalProgram&) const {
+  throw runtime_error(
+      "Mosek is not installed in your build. You'll need to use a different "
+      "solver.");
+}
+
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/mathematical_program_result_test.cc
+++ b/solvers/test/mathematical_program_result_test.cc
@@ -20,12 +20,14 @@ GTEST_TEST(MathematicalProgramResultTest, DefaultConstructor) {
 GTEST_TEST(MathematicalProgramResultTest, Constructor) {
   MathematicalProgramResult result;
   result.get_mutable_result() = SolutionResult::kSolutionFound;
-  result.get_mutable_x_val() = Eigen::Vector2d::Zero();
-  result.get_mutable_optimal_cost() = 1;
+  const Eigen::Vector2d x_val(0, 0);
+  result.get_mutable_x_val() = x_val;
+  const double cost = 1;
+  result.get_mutable_optimal_cost() = cost;
   result.get_mutable_solver_id() = SolverId("foo");
   EXPECT_EQ(result.result(), SolutionResult::kSolutionFound);
-  EXPECT_TRUE(CompareMatrices(result.x_val(), Eigen::Vector2d::Zero()));
-  EXPECT_EQ(result.optimal_cost(), 1);
+  EXPECT_TRUE(CompareMatrices(result.x_val(), x_val));
+  EXPECT_EQ(result.optimal_cost(), cost);
   EXPECT_EQ(result.solver_id().name(), "foo");
   EXPECT_NO_THROW(result.solver_details().GetValueOrThrow<NoSolverDetails>());
 }
@@ -37,10 +39,11 @@ struct DummySolverDetails {
 
 GTEST_TEST(MathematicalProgramResultTest, SetSolverDetails) {
   MathematicalProgramResult result;
-  auto dummy_solver_result =
-      systems::AbstractValue::Make<DummySolverDetails>(1);
+  const int data = 1;
+  auto dummy_solver_result = systems::AbstractValue::Make<DummySolverDetails>(
+      DummySolverDetails(data));
   result.SetSolverDetails(std::move(dummy_solver_result));
-  EXPECT_EQ(result.solver_details().GetValue<DummySolverDetails>().data, 1);
+  EXPECT_EQ(result.solver_details().GetValue<DummySolverDetails>().data, data);
   EXPECT_FALSE(dummy_solver_result);
 }
 }  // namespace

--- a/solvers/test/mathematical_program_result_test.cc
+++ b/solvers/test/mathematical_program_result_test.cc
@@ -31,7 +31,7 @@ GTEST_TEST(MathematicalProgramResultTest, Constructor) {
 }
 
 struct DummySolverDetails {
-  DummySolverDetails(int m_data) : data(m_data) {}
+  explicit DummySolverDetails(int m_data) : data(m_data) {}
   int data;
 };
 

--- a/solvers/test/mathematical_program_result_test.cc
+++ b/solvers/test/mathematical_program_result_test.cc
@@ -1,0 +1,46 @@
+#include "drake/solvers/mathematical_program_result.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+namespace drake {
+namespace solvers {
+namespace {
+GTEST_TEST(MathematicalProgramResultTest, DefaultConstructor) {
+  MathematicalProgramResult result;
+  EXPECT_EQ(result.result(), SolutionResult::kUnknownError);
+  EXPECT_EQ(result.x_val().size(), 0);
+  EXPECT_TRUE(std::isnan(result.optimal_cost()));
+  EXPECT_EQ(result.solver_id().name(), "unknown");
+  DRAKE_EXPECT_THROWS_MESSAGE(result.solver_details(), std::logic_error,
+                              "The solver_details has not been set yet.");
+}
+
+GTEST_TEST(MathematicalProgramResultTest, Constructor) {
+  MathematicalProgramResult result(SolutionResult::kSolutionFound,
+                                   Eigen::Vector2d::Zero(), 1, SolverId("foo"));
+  EXPECT_EQ(result.result(), SolutionResult::kSolutionFound);
+  EXPECT_TRUE(CompareMatrices(result.x_val(), Eigen::Vector2d::Zero()));
+  EXPECT_EQ(result.optimal_cost(), 1);
+  EXPECT_EQ(result.solver_id().name(), "foo");
+  EXPECT_NO_THROW(result.solver_details().GetValueOrThrow<NoSolverDetails>());
+}
+
+struct DummySolverDetails {
+  DummySolverDetails(int m_data) : data(m_data) {}
+  int data;
+};
+
+GTEST_TEST(MathematicalProgramResultTest, SetSolverDetails) {
+  MathematicalProgramResult result;
+  auto dummy_solver_result =
+      systems::AbstractValue::Make<DummySolverDetails>(1);
+  result.SetSolverDetails(std::move(dummy_solver_result));
+  EXPECT_EQ(result.solver_details().GetValue<DummySolverDetails>().data, 1);
+  EXPECT_FALSE(dummy_solver_result);
+}
+}  // namespace
+}  // namespace solvers
+}  // namespace drake

--- a/solvers/test/mathematical_program_result_test.cc
+++ b/solvers/test/mathematical_program_result_test.cc
@@ -14,13 +14,15 @@ GTEST_TEST(MathematicalProgramResultTest, DefaultConstructor) {
   EXPECT_EQ(result.x_val().size(), 0);
   EXPECT_TRUE(std::isnan(result.optimal_cost()));
   EXPECT_EQ(result.solver_id().name(), "unknown");
-  DRAKE_EXPECT_THROWS_MESSAGE(result.solver_details(), std::logic_error,
-                              "The solver_details has not been set yet.");
+  EXPECT_NO_THROW(result.solver_details().GetValueOrThrow<NoSolverDetails>());
 }
 
 GTEST_TEST(MathematicalProgramResultTest, Constructor) {
-  MathematicalProgramResult result(SolutionResult::kSolutionFound,
-                                   Eigen::Vector2d::Zero(), 1, SolverId("foo"));
+  MathematicalProgramResult result;
+  result.get_mutable_result() = SolutionResult::kSolutionFound;
+  result.get_mutable_x_val() = Eigen::Vector2d::Zero();
+  result.get_mutable_optimal_cost() = 1;
+  result.get_mutable_solver_id() = SolverId("foo");
   EXPECT_EQ(result.result(), SolutionResult::kSolutionFound);
   EXPECT_TRUE(CompareMatrices(result.x_val(), Eigen::Vector2d::Zero()));
   EXPECT_EQ(result.optimal_cost(), 1);

--- a/solvers/test/mathematical_program_result_test.cc
+++ b/solvers/test/mathematical_program_result_test.cc
@@ -57,6 +57,23 @@ GTEST_TEST(MathematicalProgramResultTest, SetSolverDetails) {
   EXPECT_EQ(result.get_solver_details().GetValue<DummySolverDetails>().data,
             data);
 }
+
+GTEST_TEST(MathematicalProgramResultTest, ConvertToSolverResult) {
+  MathematicalProgramResult result;
+  result.set_solver_id(SolverId("foo"));
+  result.set_optimal_cost(2);
+  // The x_val is not set. So solver_result.decision_variable_values should be
+  // empty.
+  SolverResult solver_result = result.ConvertToSolverResult();
+  EXPECT_FALSE(solver_result.decision_variable_values());
+  // Now set x_val.
+  result.set_x_val(Eigen::Vector2d::Ones());
+  solver_result = result.ConvertToSolverResult();
+  EXPECT_EQ(result.get_solver_id(), solver_result.solver_id());
+  EXPECT_TRUE(CompareMatrices(
+      result.get_x_val(), solver_result.decision_variable_values().value()));
+  EXPECT_EQ(result.get_optimal_cost(), solver_result.optimal_cost());
+}
 }  // namespace
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/mathematical_program_result_test.cc
+++ b/solvers/test/mathematical_program_result_test.cc
@@ -10,41 +10,47 @@ namespace solvers {
 namespace {
 GTEST_TEST(MathematicalProgramResultTest, DefaultConstructor) {
   MathematicalProgramResult result;
-  EXPECT_EQ(result.result(), SolutionResult::kUnknownError);
-  EXPECT_EQ(result.x_val().size(), 0);
-  EXPECT_TRUE(std::isnan(result.optimal_cost()));
-  EXPECT_EQ(result.solver_id().name(), "unknown");
-  EXPECT_NO_THROW(result.solver_details().GetValueOrThrow<NoSolverDetails>());
+  EXPECT_EQ(result.get_solution_result(), SolutionResult::kUnknownError);
+  EXPECT_EQ(result.get_x_val().size(), 0);
+  EXPECT_TRUE(std::isnan(result.get_optimal_cost()));
+  EXPECT_NO_THROW(
+      result.get_solver_details().GetValueOrThrow<NoSolverDetails>());
 }
 
-GTEST_TEST(MathematicalProgramResultTest, Constructor) {
+GTEST_TEST(MathematicalProgramResultTest, Setters) {
   MathematicalProgramResult result;
-  result.get_mutable_result() = SolutionResult::kSolutionFound;
+  result.set_solution_result(SolutionResult::kSolutionFound);
   const Eigen::Vector2d x_val(0, 0);
-  result.get_mutable_x_val() = x_val;
+  result.set_x_val(x_val);
   const double cost = 1;
-  result.get_mutable_optimal_cost() = cost;
-  result.get_mutable_solver_id() = SolverId("foo");
-  EXPECT_EQ(result.result(), SolutionResult::kSolutionFound);
-  EXPECT_TRUE(CompareMatrices(result.x_val(), x_val));
-  EXPECT_EQ(result.optimal_cost(), cost);
-  EXPECT_EQ(result.solver_id().name(), "foo");
-  EXPECT_NO_THROW(result.solver_details().GetValueOrThrow<NoSolverDetails>());
+  result.set_optimal_cost(cost);
+  result.set_solver_id(SolverId("foo"));
+  EXPECT_EQ(result.get_solution_result(), SolutionResult::kSolutionFound);
+  EXPECT_TRUE(CompareMatrices(result.get_x_val(), x_val));
+  EXPECT_EQ(result.get_optimal_cost(), cost);
+  EXPECT_EQ(result.get_solver_id().name(), "foo");
+  EXPECT_NO_THROW(
+      result.get_solver_details().GetValueOrThrow<NoSolverDetails>());
 }
 
 struct DummySolverDetails {
-  explicit DummySolverDetails(int m_data) : data(m_data) {}
+  DummySolverDetails() : data(0) {}
   int data;
 };
 
 GTEST_TEST(MathematicalProgramResultTest, SetSolverDetails) {
   MathematicalProgramResult result;
   const int data = 1;
-  auto dummy_solver_result = systems::AbstractValue::Make<DummySolverDetails>(
-      DummySolverDetails(data));
-  result.SetSolverDetails(std::move(dummy_solver_result));
-  EXPECT_EQ(result.solver_details().GetValue<DummySolverDetails>().data, data);
-  EXPECT_FALSE(dummy_solver_result);
+  DummySolverDetails& dummy_solver_details =
+      result.SetSolverDetailsType<DummySolverDetails>();
+  dummy_solver_details.data = data;
+  EXPECT_EQ(result.get_solver_details().GetValue<DummySolverDetails>().data,
+            data);
+  // Now we test if we call SetSolverDetailsType again, it doesn't allocate new
+  // memory.
+  const systems::AbstractValue* details = &(result.get_solver_details());
+  dummy_solver_details = result.SetSolverDetailsType<DummySolverDetails>();
+  EXPECT_EQ(details, &(result.get_solver_details()));
 }
 }  // namespace
 }  // namespace solvers

--- a/solvers/test/mosek_solver_test.cc
+++ b/solvers/test/mosek_solver_test.cc
@@ -27,8 +27,7 @@ INSTANTIATE_TEST_CASE_P(
 TEST_F(UnboundedLinearProgramTest0, Test) {
   MosekSolver solver;
   if (solver.available()) {
-    MathematicalProgramResult result;
-    solver.Solve(*prog_, &result);
+    const MathematicalProgramResult result = solver.SolveConstProg(*prog_);
     // Mosek can only detect dual infeasibility, not primal unboundedness.
     EXPECT_EQ(result.result(), SolutionResult::kDualInfeasible);
     EXPECT_EQ(result.solver_details().GetValue<MosekSolverDetails>().rescode,

--- a/solvers/test/mosek_solver_test.cc
+++ b/solvers/test/mosek_solver_test.cc
@@ -27,11 +27,12 @@ INSTANTIATE_TEST_CASE_P(
 TEST_F(UnboundedLinearProgramTest0, Test) {
   MosekSolver solver;
   if (solver.available()) {
-    const MathematicalProgramResult result = solver.SolveConstProg(*prog_);
+    const MathematicalProgram& const_prog = *prog_;
+    const MathematicalProgramResult result = solver.Solve(const_prog);
     // Mosek can only detect dual infeasibility, not primal unboundedness.
-    EXPECT_EQ(result.result(), SolutionResult::kDualInfeasible);
-    EXPECT_EQ(result.solver_details().GetValue<MosekSolverDetails>().rescode,
-              0);
+    EXPECT_EQ(result.get_solution_result(), SolutionResult::kDualInfeasible);
+    EXPECT_EQ(
+        result.get_solver_details().GetValue<MosekSolverDetails>().rescode, 0);
   }
 }
 

--- a/solvers/test/mosek_solver_test.cc
+++ b/solvers/test/mosek_solver_test.cc
@@ -27,9 +27,12 @@ INSTANTIATE_TEST_CASE_P(
 TEST_F(UnboundedLinearProgramTest0, Test) {
   MosekSolver solver;
   if (solver.available()) {
-    const SolutionResult result = solver.Solve(*prog_);
+    MathematicalProgramResult result;
+    solver.Solve(*prog_, &result);
     // Mosek can only detect dual infeasibility, not primal unboundedness.
-    EXPECT_EQ(result, SolutionResult::kDualInfeasible);
+    EXPECT_EQ(result.result(), SolutionResult::kDualInfeasible);
+    EXPECT_EQ(result.solver_details().GetValue<MosekSolverDetails>().rescode,
+              0);
   }
 }
 


### PR DESCRIPTION
This is the first step to refactor MathematicalProgram. As mentioned in #9633 , we will create a `MathematicalProgramResult` class, that contains both the generic result (decision variable values, optimal cost, etc), and solver specific result. This PR creates this class, and also changed `MosekSolver` to use this result class.

@jwnimmer-tri I have some questions.
1. Do you think we should add this method
   ```C++
   void Solve(const MathematicalProgram& prog, MathematicalProgramResult* result) const
   ```
   to `MathematicalProgramSolverInterface` parent class? This method can default to thrown an error in the base class.
2. I plan to do this re-factoring solver by solver, so as to split the PR. Is that OK with you?
3. I will add some method to `MathematicalProgram`, to retrieve information from `MathematicalProgramResult`, for example
   ```C++
   Eigen::VectorXd MathematicalProgram::GetSolution(const VectorXDecisionVariable& x, const MathematicalProgramResult& result);
   ```
   does this sound good to you?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9786)
<!-- Reviewable:end -->
