### PR TITLE
Remove deprecated transform.h file

### DIFF
--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -90,7 +90,6 @@ drake_cc_library(
         "rigid_transform.h",
         "roll_pitch_yaw.h",
         "rotation_matrix.h",
-        "transform.h",  # Deprecated.
     ],
     deps = [
         "//common:default_scalars",

--- a/math/transform.h
+++ b/math/transform.h
@@ -1,6 +1,0 @@
-// #pragma once intentionally left off to ensure warning issued for
-// every include of this deprecated header.
-// TODO(Mitiguy) Remove this file after 10/17/2018 (3 months).
-
-#warning Deprecated header transform.h; use rigid_transform.h instead.
-#include "drake/math/rigid_transform.h"


### PR DESCRIPTION
This cleans up a TODO associated with PR #9143.
That old PR renamed file Transform.h to RigidTransform.h.
This addresses issue #9774  Documentation requiring deprecation: transform.h

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9788)
<!-- Reviewable:end -->
