### PR TITLE
Adds RightOfWayPhaseBook and a simple version of it

### DIFF
--- a/automotive/maliput/api/BUILD.bazel
+++ b/automotive/maliput/api/BUILD.bazel
@@ -36,6 +36,7 @@ drake_cc_library(
         "road_geometry.h",
         "rules/regions.h",
         "rules/right_of_way_phase.h",
+        "rules/right_of_way_phase_book.h",
         "rules/right_of_way_phase_provider.h",
         "rules/right_of_way_phase_ring.h",
         "rules/right_of_way_rule.h",

--- a/automotive/maliput/api/rules/right_of_way_phase_book.h
+++ b/automotive/maliput/api/rules/right_of_way_phase_book.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "drake/automotive/maliput/api/rules/right_of_way_phase_ring.h"
+#include "drake/automotive/maliput/api/rules/right_of_way_rule.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/drake_optional.h"
+
+namespace drake {
+namespace maliput {
+namespace api {
+namespace rules {
+
+/// Abstract interface for providing the mapping from RightOfWayRule::Id to
+/// RightOfWayPhaseRing.
+class RightOfWayPhaseBook {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RightOfWayPhaseBook);
+
+  virtual ~RightOfWayPhaseBook() = default;
+
+  /// Gets the specified RightOfWayPhaseRing. Returns nullopt if @p ring_id is
+  /// unrecognized.
+  optional<RightOfWayPhaseRing> GetPhaseRing(
+      const RightOfWayPhaseRing::Id& ring_id) const {
+    return DoGetPhaseRing(ring_id);
+  }
+
+  /// Finds and returns the RightOfWayPhaseRing containing the specified
+  /// RightOfWayRule. Returns nullopt if @p rule_id is unrecognized.
+  optional<RightOfWayPhaseRing> FindPhaseRing(
+      const RightOfWayRule::Id& rule_id) const {
+    return DoFindPhaseRing(rule_id);
+  }
+
+ protected:
+  RightOfWayPhaseBook() = default;
+
+ private:
+  virtual optional<RightOfWayPhaseRing> DoGetPhaseRing(
+      const RightOfWayPhaseRing::Id& ring_id) const = 0;
+
+  virtual optional<RightOfWayPhaseRing> DoFindPhaseRing(
+      const RightOfWayRule::Id& rule_id) const  = 0;
+};
+
+}  // namespace rules
+}  // namespace api
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/simple_phase_book/BUILD.bazel
+++ b/automotive/maliput/simple_phase_book/BUILD.bazel
@@ -1,0 +1,43 @@
+# -*- python -*-
+
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_googletest",
+    "drake_cc_library",
+    "drake_cc_package_library",
+)
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+package(default_visibility = ["//visibility:public"])
+
+drake_cc_package_library(
+    name = "simple_phase_book",
+    deps = [
+        ":simple_right_of_way_phase_book",
+    ],
+)
+
+drake_cc_library(
+    name = "simple_right_of_way_phase_book",
+    srcs = [
+        "simple_right_of_way_phase_book.cc",
+    ],
+    hdrs = [
+        "simple_right_of_way_phase_book.h",
+    ],
+    deps = [
+        "//automotive/maliput/api",
+        "//common:essential",
+    ],
+)
+
+# === test/ ===
+
+drake_cc_googletest(
+    name = "simple_right_of_way_phase_book_test",
+    deps = [
+        ":simple_right_of_way_phase_book",
+    ],
+)
+
+add_lint_tests()

--- a/automotive/maliput/simple_phase_book/simple_right_of_way_phase_book.cc
+++ b/automotive/maliput/simple_phase_book/simple_right_of_way_phase_book.cc
@@ -1,0 +1,106 @@
+#include "drake/automotive/maliput/simple_phase_book/simple_right_of_way_phase_book.h"
+
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "drake/common/drake_throw.h"
+
+namespace drake {
+namespace maliput {
+namespace simple_phase_book {
+
+using api::rules::RightOfWayRule;
+using api::rules::RightOfWayPhase;
+using api::rules::RightOfWayPhaseRing;
+
+class SimpleRightOfWayPhaseBook::Impl {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Impl)
+
+  Impl() {}
+  ~Impl() {}
+
+  void AddPhaseRing(const RightOfWayPhaseRing& ring) {
+    auto result = ring_book_.emplace(ring.id(), ring);
+    if (!result.second) {
+      throw std::logic_error("Attempted to add multiple RightOfWayPhaseRing "
+                             "instances with ID " + ring.id().string());
+    }
+    const RightOfWayPhase& phase = ring.phases().begin()->second;
+    for (const auto& element : phase.rule_states()) {
+      auto r = rule_book_.emplace(element.first, ring.id());
+      if (!r.second) {
+        throw std::logic_error("RightOfWayRule with ID " +
+                               element.first.string() + " is part of more than "
+                               "one RightOfWayPhaseRing.");
+      }
+    }
+  }
+
+  void RemovePhaseRing(const RightOfWayPhaseRing::Id& ring_id) {
+    const optional<RightOfWayPhaseRing> ring = DoGetPhaseRing(ring_id);
+    if (ring == nullopt) {
+      throw std::logic_error("Attempted to remove unknown RightOfWayPhaseRing "
+                             "with ID " + ring_id.string());
+    }
+    DRAKE_THROW_UNLESS(ring_book_.erase(ring_id) == 1);
+    const RightOfWayPhase& phase = ring->phases().begin()->second;
+    for (const auto& element : phase.rule_states()) {
+      DRAKE_THROW_UNLESS(rule_book_.erase(element.first) == 1);
+    }
+  }
+
+  optional<RightOfWayPhaseRing> DoGetPhaseRing(
+      const RightOfWayPhaseRing::Id& ring_id) const {
+    auto it = ring_book_.find(ring_id);
+    if (it == ring_book_.end()) {
+      return nullopt;
+    }
+    return it->second;
+  }
+
+  optional<RightOfWayPhaseRing> DoFindPhaseRing(
+      const RightOfWayRule::Id& rule_id) const {
+    auto it = rule_book_.find(rule_id);
+    if (it == rule_book_.end()) {
+      return nullopt;
+    }
+    return ring_book_.at(it->second);
+  }
+
+ private:
+  std::unordered_map<RightOfWayPhaseRing::Id, const RightOfWayPhaseRing>
+      ring_book_;
+  std::unordered_map<RightOfWayRule::Id, const RightOfWayPhaseRing::Id>
+      rule_book_;
+};
+
+SimpleRightOfWayPhaseBook::SimpleRightOfWayPhaseBook()
+    : impl_(std::make_unique<Impl>()) {}
+
+SimpleRightOfWayPhaseBook::~SimpleRightOfWayPhaseBook() = default;
+
+void SimpleRightOfWayPhaseBook::AddPhaseRing(const RightOfWayPhaseRing& ring) {
+  impl_->AddPhaseRing(ring);
+}
+
+void SimpleRightOfWayPhaseBook::RemovePhaseRing(
+    const RightOfWayPhaseRing::Id& ring_id) {
+  impl_->RemovePhaseRing(ring_id);
+}
+
+optional<RightOfWayPhaseRing> SimpleRightOfWayPhaseBook::DoGetPhaseRing(
+    const RightOfWayPhaseRing::Id& ring_id) const {
+  return impl_->DoGetPhaseRing(ring_id);
+}
+
+optional<RightOfWayPhaseRing> SimpleRightOfWayPhaseBook::DoFindPhaseRing(
+    const RightOfWayRule::Id& rule_id) const {
+  return impl_->DoFindPhaseRing(rule_id);
+}
+
+}  // namespace simple_phase_book
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/simple_phase_book/simple_right_of_way_phase_book.h
+++ b/automotive/maliput/simple_phase_book/simple_right_of_way_phase_book.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <memory>
+
+#include "drake/automotive/maliput/api/rules/right_of_way_phase_book.h"
+#include "drake/automotive/maliput/api/rules/right_of_way_phase_ring.h"
+#include "drake/automotive/maliput/api/rules/right_of_way_rule.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/drake_optional.h"
+
+namespace drake {
+namespace maliput {
+namespace simple_phase_book {
+
+/// A simple concrete implementation of the api::rules::RightOfWayPhaseBook
+/// abstract interface. It allows users to obtain the ID of the
+/// RightOfWayPhaseRing that includes a particular RightOfWayRule.
+class SimpleRightOfWayPhaseBook : public api::rules::RightOfWayPhaseBook {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SimpleRightOfWayPhaseBook);
+
+  SimpleRightOfWayPhaseBook();
+
+  ~SimpleRightOfWayPhaseBook() override;
+
+  /// Adds @p ring to this SimpleRightOfWayPhaseBook.
+  ///
+  /// @throws std::exception if an api::rules::RightOfWayPhaseRing with the same
+  /// ID already exists, or if @p ring contains a rule that already exists in a
+  /// previously added api::rules::RightOfWayPhaseRing.
+  void AddPhaseRing(const api::rules::RightOfWayPhaseRing& ring);
+
+  /// Removes an api::rules::RightOfWayPhaseRing with an ID of @p ring_id from
+  /// this SimpleRightOfWayPhaseBook.
+  ///
+  /// @throws std::exception if the specified api::rules::RightOfWayPhaseRing
+  /// does not exist.
+  void RemovePhaseRing(const api::rules::RightOfWayPhaseRing::Id& ring_id);
+
+ private:
+  optional<api::rules::RightOfWayPhaseRing> DoGetPhaseRing(
+      const api::rules::RightOfWayPhaseRing::Id& ring_id) const override;
+
+  optional<api::rules::RightOfWayPhaseRing> DoFindPhaseRing(
+      const api::rules::RightOfWayRule::Id& rule_id) const override;
+
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace simple_phase_book
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/simple_phase_book/test/simple_right_of_way_phase_book_test.cc
+++ b/automotive/maliput/simple_phase_book/test/simple_right_of_way_phase_book_test.cc
@@ -1,0 +1,94 @@
+#include "drake/automotive/maliput/simple_phase_book/simple_right_of_way_phase_book.h"
+
+#include <stdexcept>
+
+#include <gtest/gtest.h>
+
+#include "drake/automotive/maliput/api/rules/right_of_way_phase.h"
+#include "drake/automotive/maliput/api/rules/right_of_way_phase_ring.h"
+#include "drake/automotive/maliput/api/rules/right_of_way_rule.h"
+#include "drake/common/drake_optional.h"
+
+namespace drake {
+namespace maliput {
+namespace simple_phase_book {
+namespace {
+
+using api::rules::RightOfWayRule;
+using api::rules::RightOfWayPhase;
+using api::rules::RightOfWayPhaseRing;
+
+struct SimpleRightOfWayPhaseBookTest : public ::testing::Test {
+  SimpleRightOfWayPhaseBookTest()
+      : rule_id_a("rule a"),
+        rule_id_b("rule b"),
+        phase(RightOfWayPhase::Id("phase"),
+              {{rule_id_a, RightOfWayRule::State::Id("a")},
+               {rule_id_b, RightOfWayRule::State::Id("b")}}),
+        ring_id("ring"),
+        ring(ring_id, {phase}) {}
+
+  const RightOfWayRule::Id rule_id_a;
+  const RightOfWayRule::Id rule_id_b;
+  const RightOfWayPhase phase;
+  const RightOfWayPhaseRing::Id ring_id;
+  const RightOfWayPhaseRing ring;
+};
+
+TEST_F(SimpleRightOfWayPhaseBookTest, BasicTest) {
+  SimpleRightOfWayPhaseBook dut;
+  EXPECT_NO_THROW(dut.AddPhaseRing(ring));
+  optional<RightOfWayPhaseRing> result = dut.GetPhaseRing(ring_id);
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result->id(), ring_id);
+  const RightOfWayPhaseRing::Id unknown_ring_id("unknown ring");
+  EXPECT_EQ(dut.GetPhaseRing(unknown_ring_id), nullopt);
+  for (const auto rule_id : {rule_id_a, rule_id_b}) {
+    result = dut.FindPhaseRing(rule_id);
+    EXPECT_TRUE(result.has_value());
+    EXPECT_EQ(result->id(), ring_id);
+  }
+  const RightOfWayRule::Id unknown_rule_id("unknown rule");
+  EXPECT_EQ(dut.FindPhaseRing(unknown_rule_id), nullopt);
+  EXPECT_THROW(dut.RemovePhaseRing(unknown_ring_id), std::logic_error);
+  EXPECT_NO_THROW(dut.RemovePhaseRing(ring_id));
+  EXPECT_EQ(dut.GetPhaseRing(ring_id), nullopt);
+  for (const auto rule_id : {rule_id_a, rule_id_b}) {
+    EXPECT_EQ(dut.FindPhaseRing(rule_id), nullopt);
+  }
+}
+
+// Verifies that an exception is thrown when the user attempts to add a
+// different RightOfWayPhaseRing that has the same ID as a previously
+// added RightOfWayPhaseRing.
+TEST_F(SimpleRightOfWayPhaseBookTest, RingWithSameId) {
+  SimpleRightOfWayPhaseBook dut;
+  dut.AddPhaseRing(ring);
+  const RightOfWayRule::Id rule_id_c("rule c");
+  const RightOfWayPhase different_phase(
+      RightOfWayPhase::Id("different phase with different rules"),
+      {{rule_id_c, RightOfWayRule::State::Id("c")}});
+  const RightOfWayPhaseRing ring_with_same_id(ring_id, {different_phase});
+  EXPECT_THROW(dut.AddPhaseRing(ring_with_same_id), std::logic_error);
+}
+
+// Verifies that an exception is thrown when the user attempts to add a
+// RightOfWayPhaseRing with a unique ID but contains a phase with a
+// RightOfWayRule::Id that overlaps the rules covered by a previously added
+// RightOfWayPhaseRing.
+TEST_F(SimpleRightOfWayPhaseBookTest, RingWithOverlappingRule) {
+  SimpleRightOfWayPhaseBook dut;
+  dut.AddPhaseRing(ring);
+  const RightOfWayPhase phase_with_overlapping_rule(
+      RightOfWayPhase::Id("different phase with overlapping rules"),
+      {{rule_id_a, RightOfWayRule::State::Id("a")}});
+  const RightOfWayPhaseRing ring_with_overlapping_rule(
+      RightOfWayPhaseRing::Id("unique phase ID"),
+      {phase_with_overlapping_rule});
+  EXPECT_THROW(dut.AddPhaseRing(ring_with_overlapping_rule), std::logic_error);
+}
+
+}  // namespace
+}  // namespace simple_phase_book
+}  // namespace maliput
+}  // namespace drake


### PR DESCRIPTION
This is needed for ado cars to obtain the RightOfWayPhaseRing that includes a particular RightOfWayRule.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9798)
<!-- Reviewable:end -->
