### PR TITLE
solvers: Rename snopt_solver_f2c to make room for others

### DIFF
--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -631,7 +631,7 @@ drake_cc_library(
     name = "snopt_solver",
     srcs = select({
         "//tools:with_snopt": [
-            "snopt_solver.cc",
+            "snopt_solver_f2c.cc",
             "snopt_solver_common.cc",
         ],
         "//conditions:default": [
@@ -644,7 +644,7 @@ drake_cc_library(
     # result of `const char*` to a function taking a `char*`, or passing a
     # function pointer that receives parameters to a function that takes a
     # (mismatched) function pointer with no arguments.  We could carefully
-    # craft our snopt_solver.cc to have appropriate casts depending on the
+    # craft our snopt_solver_f2c.cc to have appropriate casts depending on the
     # signatures of the version of SNOPT in use, but choose instead to just
     # suppress all such warnings until we find some case where they matter.
     # (The next best step would be to write a sensible C++ SNOPT API wrapper,
@@ -1393,7 +1393,7 @@ add_lint_tests(cpplint_extra_srcs = [
     "qp.cc",
     "scs_solver.cc",
     "scs_solver_common.cc",
-    "snopt_solver.cc",
+    "snopt_solver_f2c.cc",
     "snopt_solver.h",
     "snopt_solver_common.cc",
 ])

--- a/solvers/snopt_solver_f2c.cc
+++ b/solvers/snopt_solver_f2c.cc
@@ -1,4 +1,6 @@
+/* clang-format off to disable clang-format-includes */
 #include "drake/solvers/snopt_solver.h"
+/* clang-format on */
 
 #include <algorithm>
 #include <cstdio>


### PR DESCRIPTION
We expect to add variants of the snopt solver bindings concurrently in the Drake source tree.  They will need to have different names.

Relates #4893.  Relates #9177.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9804)
<!-- Reviewable:end -->
