### PR TITLE
framework: Work around gcc-7 bug

### DIFF
--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -2139,14 +2139,14 @@ class System : public SystemBase {
           const BasicVector<T>* const actual_vector =
               actual.MaybeGetValue<BasicVector<T>>();
           if (actual_vector == nullptr) {
-            ThrowInputPortHasWrongType(
+            SystemBase::ThrowInputPortHasWrongType(
                 "FixInputPortTypeCheck", pathname, port_index,
                 NiceTypeName::Get<Value<BasicVector<T>>>(),
                 NiceTypeName::Get(actual));
           }
           // Check that vector sizes match.
           if (actual_vector->size() != expected_size) {
-            ThrowInputPortHasWrongType(
+            SystemBase::ThrowInputPortHasWrongType(
                 "FixInputPortTypeCheck", pathname, port_index,
                 fmt::format("{} with size={}",
                             NiceTypeName::Get<BasicVector<T>>(),


### PR DESCRIPTION
Add classname when calling a static method, to avoid:
  "error: 'this' was not captured for this lambda function"
false positive error message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9807)
<!-- Reviewable:end -->
