### PR TITLE
examples: Stop LCM thread before destroying its receivers

### DIFF
--- a/examples/acrobot/BUILD.bazel
+++ b/examples/acrobot/BUILD.bazel
@@ -200,12 +200,6 @@ drake_cc_binary(
         "spong_controller_w_lcm.cc",
     ],
     add_test_rule = 1,
-    # TODO (betsymcphail): TSan fails in LCM for this test. See issue #9697.
-    # TODO (liang.fok): ASan non-determistically failed in CI. See issue #9809.
-    tags = [
-        "no_asan",
-        "no_tsan",
-    ],
     test_rule_args = [
         "-time_limit_sec=1.0",
     ],

--- a/examples/acrobot/run_plant_w_lcm.cc
+++ b/examples/acrobot/run_plant_w_lcm.cc
@@ -98,6 +98,7 @@ int DoMain() {
   simulator.Initialize();
   simulator.StepTo(FLAGS_simulation_sec);
 
+  lcm.StopReceiveThread();
   return 0;
 }
 }  // namespace

--- a/examples/acrobot/spong_controller_w_lcm.cc
+++ b/examples/acrobot/spong_controller_w_lcm.cc
@@ -74,6 +74,7 @@ int DoMain() {
     command_pub->Publish(pub_context);
   }
 
+  lcm.StopReceiveThread();
   return 0;
 }
 

--- a/examples/acrobot/test/acrobot_lcm_msg_generator.cc
+++ b/examples/acrobot/test/acrobot_lcm_msg_generator.cc
@@ -58,6 +58,7 @@ int DoMain() {
     sleep_for(milliseconds(500));
   }
 
+  lcm.StopReceiveThread();
   return 0;
 }
 }  // namespace

--- a/examples/allegro_hand/joint_control/allegro_single_object_simulation.cc
+++ b/examples/allegro_hand/joint_control/allegro_single_object_simulation.cc
@@ -203,6 +203,8 @@ void DoMain() {
       VectorX<double>::Zero(plant.num_actuators()));
 
   simulator.StepTo(FLAGS_simulation_time);
+
+  lcm.StopReceiveThread();
 }
 
 }  // namespace

--- a/examples/double_pendulum/BUILD.bazel
+++ b/examples/double_pendulum/BUILD.bazel
@@ -45,10 +45,12 @@ drake_cc_binary(
     srcs = [
         "double_pendulum_demo.cc",
     ],
+    add_test_rule = 1,
     data = [
         ":models",
         "//tools:drake_visualizer",
     ],
+    test_rule_args = ["--simulation_time=0.01"],
     deps = [
         ":sdf_helpers",
         "//attic/multibody/rigid_body_plant",

--- a/examples/double_pendulum/double_pendulum_demo.cc
+++ b/examples/double_pendulum/double_pendulum_demo.cc
@@ -37,9 +37,8 @@ int main(int argc, char* argv[]) {
                           "make sure drake-visualizer is running!");
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   logging::HandleSpdlogGflags();
-  // Instantiate LCM interface and start receiving.
+  // Instantiate LCM interface.
   auto lcm_interface = std::make_unique<lcm::DrakeLcm>();
-  lcm_interface->StartReceiveThread();
   // Load and parse double pendulum SDF from file into a tree.
   const std::string sdf_path = FindResourceOrThrow(kDoublePendulumSdfPath);
   auto tree = std::make_unique<RigidBodyTree<double>>();
@@ -62,7 +61,9 @@ int main(int argc, char* argv[]) {
   simulator->set_target_realtime_rate(FLAGS_realtime_rate);
   simulator->Initialize();
   // Run simulation.
+  lcm_interface->StartReceiveThread();
   simulator->StepTo(FLAGS_simulation_time);
+  lcm_interface->StopReceiveThread();
   return 0;
 }
 

--- a/examples/kuka_iiwa_arm/dev/box_rotation/iiwa_box_simulation.cc
+++ b/examples/kuka_iiwa_arm/dev/box_rotation/iiwa_box_simulation.cc
@@ -318,6 +318,7 @@ int DoMain() {
   simulator.set_publish_every_time_step(false);
   simulator.StepTo(FLAGS_simulation_sec);
 
+  lcm.StopReceiveThread();
   return 0;
 }
 

--- a/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/monolithic_pick_and_place_demo.cc
+++ b/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/monolithic_pick_and_place_demo.cc
@@ -113,6 +113,8 @@ int DoMain(void) {
     done = plant->is_done(
         sys->GetSubsystemContext(*plant, simulator.get_context()));
   }
+
+  lcm.StopReceiveThread();
   return 0;
 }
 

--- a/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/test/monolithic_pick_and_place_system_test.cc
+++ b/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/test/monolithic_pick_and_place_system_test.cc
@@ -170,6 +170,7 @@ class SingleMoveTests : public ::testing::TestWithParam<std::tuple<int, int>> {
       done = plant->is_done(
           sys->GetSubsystemContext(*plant, simulator.get_context()));
     }
+    lcm.reset();
 
     // Verify final state of the object.
     // Frames:

--- a/examples/kuka_iiwa_arm/dev/pick_and_place/lcm_pick_and_place_simulator.cc
+++ b/examples/kuka_iiwa_arm/dev/pick_and_place/lcm_pick_and_place_simulator.cc
@@ -151,6 +151,7 @@ int DoMain(void) {
   lcm.StartReceiveThread();
   simulator.StepTo(FLAGS_simulation_sec);
 
+  lcm.StopReceiveThread();
   return 0;
 }
 

--- a/examples/kuka_iiwa_arm/iiwa_wsg_simulation.cc
+++ b/examples/kuka_iiwa_arm/iiwa_wsg_simulation.cc
@@ -279,6 +279,7 @@ int DoMain() {
   simulator.set_publish_every_time_step(false);
   simulator.StepTo(FLAGS_simulation_sec);
 
+  lcm.StopReceiveThread();
   return 0;
 }
 

--- a/examples/kuka_iiwa_arm/kuka_simulation.cc
+++ b/examples/kuka_iiwa_arm/kuka_simulation.cc
@@ -202,6 +202,7 @@ int DoMain() {
   // Simulate for a very long time.
   simulator.StepTo(FLAGS_simulation_sec);
 
+  lcm.StopReceiveThread();
   return 0;
 }
 

--- a/examples/particles/uniformly_accelerated_particle.cc
+++ b/examples/particles/uniformly_accelerated_particle.cc
@@ -146,6 +146,7 @@ int main(int argc, char* argv[]) {
   simulator->Initialize();
   // Run simulation.
   simulator->StepTo(FLAGS_simulation_time);
+  interface->StopReceiveThread();
   return 0;
 }
 

--- a/examples/pr2/pr2_passive_simulation.cc
+++ b/examples/pr2/pr2_passive_simulation.cc
@@ -111,6 +111,7 @@ int DoMain() {
   simulator.Initialize();
   simulator.StepTo(FLAGS_simulation_sec);
 
+  lcm.StopReceiveThread();
   return 0;
 }
 

--- a/examples/schunk_wsg/schunk_wsg_simulation.cc
+++ b/examples/schunk_wsg/schunk_wsg_simulation.cc
@@ -93,6 +93,7 @@ int DoMain() {
   lcm.StartReceiveThread();
   simulator.Initialize();
   simulator.StepTo(FLAGS_simulation_sec);
+  lcm.StopReceiveThread();
   return 0;
 }
 

--- a/examples/valkyrie/valkyrie_simulation.cc
+++ b/examples/valkyrie/valkyrie_simulation.cc
@@ -51,6 +51,8 @@ int main() {
   lcm.StartReceiveThread();
 
   simulator.StepTo(std::numeric_limits<double>::infinity());
+
+  lcm.StopReceiveThread();
   return 0;
 }
 

--- a/lcm/drake_lcm.cc
+++ b/lcm/drake_lcm.cc
@@ -31,6 +31,13 @@ DrakeLcm::~DrakeLcm() { receive_thread_.reset(); }
 
 void DrakeLcm::StartReceiveThread() {
   DRAKE_DEMAND(receive_thread_ == nullptr);
+
+  // Ensure that LCM's self-test happens before our thread starts running.
+  // Without this, ThreadSanitizer builds may report false positives related to
+  // the self-test happening concurrently with the LCM publishing.
+  lcm_.getFileno();
+
+  // Now launch the thread.
   receive_thread_ = std::make_unique<LcmReceiveThread>(&lcm_);
 }
 


### PR DESCRIPTION
The DrakeLcm object launches a thread, that by default is not stopped until the DrakeLcm destructor.  Other classes might register "upon receipt of message" callbacks onto it, where DrakeLcm retains a pointer to user code that handles new messages.  Depending on the DrakeLcm declaration order with respect to other objects on the local stack, the message recipient might be destroyed prior to the DrakeLcm being destroyed, which means the thread might call back into garbage.

Here, we explicitly stop the thread prior to destroying any objects, so that we can be sure they are always safe to delete.

Closes #9697.  Closes #9809.  Closes #6634.

Relates to #7524, though some bugs beyond this patch still remain according to CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9810)
<!-- Reviewable:end -->
