### PR TITLE
Add basis of geometry roles

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -19,6 +19,8 @@ drake_cc_package_library(
         ":geometry_ids",
         ":geometry_index",
         ":geometry_instance",
+        ":geometry_properties",
+        ":geometry_roles",
         ":geometry_set",
         ":geometry_state",
         ":geometry_visualization",
@@ -120,12 +122,6 @@ drake_cc_library(
 )
 
 drake_cc_library(
-    name = "geometry_set",
-    hdrs = ["geometry_set.h"],
-    deps = [":geometry_ids"],
-)
-
-drake_cc_library(
     # NOTE: The material library and file name don't appear to match. This
     # library will eventually contain multiple types of materials (e.g.,
     # contact, rendering, depth, etc.)
@@ -133,6 +129,33 @@ drake_cc_library(
     srcs = ["visual_material.cc"],
     hdrs = ["visual_material.h"],
     deps = ["//common"],
+)
+
+drake_cc_library(
+    name = "geometry_properties",
+    srcs = ["geometry_properties.cc"],
+    hdrs = ["geometry_properties.h"],
+    deps = [
+        "//common:essential",
+        "//systems/framework:value",
+        "@fmt",
+    ],
+)
+
+drake_cc_library(
+    name = "geometry_roles",
+    srcs = ["geometry_roles.cc"],
+    hdrs = ["geometry_roles.h"],
+    deps = [
+        ":geometry_properties",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "geometry_set",
+    hdrs = ["geometry_set.h"],
+    deps = [":geometry_ids"],
 )
 
 drake_cc_library(
@@ -280,6 +303,14 @@ drake_cc_googletest(
     name = "geometry_instance_test",
     deps = [
         ":geometry_instance",
+        "//common/test_utilities",
+    ],
+)
+
+drake_cc_googletest(
+    name = "geometry_properties_test",
+    deps = [
+        ":geometry_properties",
         "//common/test_utilities",
     ],
 )

--- a/geometry/geometry_properties.cc
+++ b/geometry/geometry_properties.cc
@@ -1,0 +1,56 @@
+#include "drake/geometry/geometry_properties.h"
+
+namespace drake {
+namespace geometry {
+
+const GeometryProperties::Group& GeometryProperties::GetPropertiesInGroup(
+    const std::string& group_name) const {
+  const auto iter = values_.find(group_name);
+  if (iter != values_.end()) {
+    return iter->second;
+  }
+  throw std::logic_error(
+      fmt::format("GetPropertiesInGroup(): Can't retrieve properties for a "
+                  "group that doesn't exist: '{}'",
+                  group_name));
+}
+
+std::set<std::string> GeometryProperties::GetGroupNames() const {
+  std::set<std::string> group_names;
+  for (const auto& pair : values_) {
+    group_names.insert(pair.first);
+  }
+  return group_names;
+}
+
+bool GeometryProperties::HasProperty(const std::string& group_name,
+                                     const std::string& name) const {
+  const auto iter = values_.find(group_name);
+  if (iter != values_.end()) {
+    const Group& group = iter->second;
+    return group.count(name) > 0;
+  }
+  return false;
+}
+
+std::ostream& operator<<(std::ostream& out, const GeometryProperties& props) {
+  int i = 0;
+  for (const auto& group_pair : props.values_) {
+    const std::string& group_name = group_pair.first;
+    const GeometryProperties::Group& group_properties =
+        group_pair.second;
+    out << "[" << group_name << "]";
+    for (const auto& property_pair : group_properties) {
+      const std::string& property_name = property_pair.first;
+      out << "\n  " << property_name << ": "
+          << property_pair.second->GetNiceTypeName();
+      // TODO(SeanCurtis-TRI): How do I print the value in an AbstractValue?
+    }
+    if (i < props.num_groups() - 1) out << "\n";
+    ++i;
+  }
+  return out;
+}
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/geometry_properties.h
+++ b/geometry/geometry_properties.h
@@ -1,0 +1,425 @@
+#pragma once
+
+#include <memory>
+#include <set>
+#include <string>
+#include <unordered_map>
+
+#include "fmt/ostream.h"
+
+#include "drake/common/copyable_unique_ptr.h"
+#include "drake/common/never_destroyed.h"
+#include "drake/systems/framework/value.h"
+
+namespace drake {
+namespace geometry {
+
+/** The base class for defining a set of geometry properties.
+
+ Each property consists of a `(group, property)` name-pair and a typed value.
+ The name pair allows for reuse of common property names (e.g., "diffuse") to be
+ differentiated in interpretation by associating them with different groups. The
+ only restriction on the value type is that it must be either cloneable or
+ copy-constructible.
+
+ A set of geometry property values are defined when geometry is registered
+ with SceneGraph by an instantiator and accessed by some downstream consumer
+ entity. Each consumer specifies what properties it expects to find and what
+ default values (if any) it provides. For example, the consumer could document
+ that a particular property is always required and its absence would throw an
+ exception. Alternatively, it could indicate that a property is optional
+ and a default value will be used in its absence. It is the responsibility of
+ the instantiator to make sure that the geometry property values are _correctly_
+ defined according to the expected consumer's specification. Correctness
+ includes such issues as key-value pairs placed into a _correctly_-spelled
+ group, property keys being likewise correctly spelled, and values of the
+ expected type. Correct spelling includes correct case. The instantiator uses
+ the AddProperty() method to add new properties to the set.
+ <!-- TODO(SeanCurtis-TRI): As need becomes apparent, add interface to replace
+ values in previously defined values -- while preserving the original type.
+ -->
+
+ To read the property (`some_group`, `some_property`) from a property set:
+
+   1. Optionally test to see if the property exists by confirming the group
+      `some_group` is in the set via HasGroup() and that the property
+      `some_property` is in `some_group` via HasProperty(). Attempting to access
+      a property with a non-existant (group, property) pair may lead to an
+      exception (see API documentation below).
+   2. Acquire a property value via the GetProperty() or GetPropertyOrDefault()
+      methods.
+      NOTE: Reading a property requires a compile-time declaration of the _type_
+      of value being read. If the stored value is of a different type, an
+      exception will be thrown.
+
+ <h2>Common workflows</h2>
+
+ The following examples outline a number of ways to create and consume geometry
+ properties. By design, %GeometryProperties cannot be constructed,
+ copied, or moved directly. Only derived classes can do so. This facilitates
+ _strongly typed_ sets of properties associated with particular geometry roles.
+ So, for these examples we'll exercise the derived class associated with
+ proximity queries: ProximityProperties.
+
+ The string-based structure of %GeometryProperties provides a great deal of
+ flexibility at the cost of spelling sensitivity. It would be easy to introduce
+ typos that would then "hide" property values in some group a consumer
+ wouldn't look. In these examples, we avoid using string literals as group or
+ property names (at least in the cases where the same name is used multiple
+ times) to help avoid the possibility of typo-induced errors. That is not
+ required and certainly not the only way to avoid such bugs.
+
+ <h3>Creating properties</h3>
+
+ <h4>Creating properties in a new group</h4>
+
+ This is a simple example in which a single group is added with properties
+ of various types.
+
+ ```
+ const std::string group_name("my_group");
+ ProximityProperties properties;
+ // This first invocation implicitly creates the group "my_group".
+ properties.AddProperty(group_name, "count", 7);     // int type
+ properties.AddProperty(group_name, "length", 7.);   // double type
+ properties.AddProperty(group_name, "name", "7");    // std::string type
+ ```
+
+ <h4>Creating properties in the default group</h4>
+
+ Similar to the previous examples, the properties are added to the default
+ group. Just be aware that if multiple sites in your code add properties to
+ the default group, the possibility that names get repeated increases. Property
+ names _must_ be unique within a single group, including the default group.
+
+ ```
+ ProximityProperties properties;
+ properties.AddProperty(ProximityProperties::default_group_name(), "count", 7);
+ properties.AddProperty(ProximityProperties::default_group_name(), "length", 7.);
+ properties.AddProperty(ProximityProperties::default_group_name(), "name", "7");
+ ```
+
+ <h4>Aggregate properties in a struct</h4>
+
+ In some cases, there is a set of values that will _always_ be accessed
+ together (specified with coordinated semantics). In these cases, it makes sense
+ to aggregate them into a struct and store that as a single value. This reduces
+ the number of lookups required.
+
+ It's worth noting, that if the data value is a struct, calls to
+ GetPropertyOrDefault() still operate as an "all-or-nothing" basis.
+ If the property _struct_ exists, it will be returned, if it's missing the
+ default struct will be returned. There is no concept of a "partial" struct
+ in which some undefined values in the struct will be replaced with their
+ corresponding values in the default struct.
+
+ ```
+ struct MyData {
+    int i{};
+    double d{};
+    std::string s;
+ };
+
+ ProximityProperties properties;
+ const std::string group_name("my_group");
+ MyData data{7, 7., "7"};
+ properties.AddProperty(group_name, "data1", data);
+ // These alternate forms are also acceptable (but not in succession, as the
+ // property name has already been used by the first invocation).
+ properties.AddProperty(group_name, "data2", MyData{6, 6., "6"});
+ properties.AddProperty<MyData>(group_name, "data2", {6, 6., "6"});
+ ```
+
+ <h3>Reading properties</h3>
+
+ This section describes how to read properties under several different
+ scenarios: (a) when specific properties are required, (b) when the consumer
+ provides a default value for missing properties, and (c) when the consumer
+ needs to inspect what properties are available.
+
+ <h4>Look up specific, _required_ properties</h4>
+
+ In this case, the consumer of the properties is looking for one or more
+ specific properties. It will ignore any other properties. More particularly, if
+ those properties are missing, it is considered a runtime error and an exception
+ is thrown.
+
+ The error can be handled in one of two ways: simply let the generic exception
+ generated by %GeometryProperties propagate upward, or detect the missing
+ property and throw an exception with a custom message. The example below shows
+ both approaches.
+
+ ```
+ const ProximityProperties& properties = FunctionThatReturnsProperties();
+ // Looking for a Vector3d of rgb colors named "rgb" - send generic error that
+ // the property set is missing the required property.
+ const Eigen::Vector3d rgb =
+     properties.GetProperty<Eigen::Vector3d>("MyGroup", "rgb");
+
+ // Explicitly detect missing property and throw exception with custom message.
+ if (!properties.HasProperty("MyGroup", "rgb")) {
+   throw std::logic_error(
+       "ThisClass: Missing the necessary 'rgb' property; the object cannot be "
+       "rendered");
+ }
+ // Otherwise acquire value, confident that no exception will be thrown.
+ const Eigen::Vector3d rgb =
+     properties.GetProperty<Eigen::Vector3d>("MyGroup", "rgb");
+ ```
+
+ @note calls to `GetProperty()` always require the return type template value
+ (e.g., `Eigen::Vector3d`) to be specified in the call.
+
+ <h4>Look up specific properties with default property values</h4>
+
+ As with the previous case, the consumer is looking for one or more specific
+ properties. However, in this case, the consumer provides a default value to
+ use in case the target property is not defined. In this invocation, the
+ template parameter need not be explicitly declared -- the inferred return type
+ will be the same as the default value.
+
+ ```
+ const ProximityProperties& properties = FunctionThatReturnsProperties();
+ // Looking for a Vector3d of rgb colors named "rgb".
+ const Eigen::Vector3d default_color{0.9, 0.9, 0.9};
+ const Eigen::Vector3d rgb =
+     properties.GetPropertyOrDefault("MyGroup", "rgb", default_color);
+ ```
+
+ Alternatively, the default value can be provided in one of the following forms:
+
+ ```
+ properties.GetPropertyOrDefault("MyGroup", "rgb",
+     Eigen::Vector3d{0.9, 0.9, 0.9});
+ properties.GetPropertyOrDefault<Eigen::Vector3d>("MyGroup", "rgb",
+     {0.9, 0.9, 0.9});
+ ```
+
+ <h4>Iterating through provided properties</h4>
+
+ Another alternative is to iterate through the properties that _have_ been
+ provided. This might be done for several reasons, e.g.:
+
+   - the consumer wants to validate the set of properties, giving the user
+     feedback if an unsupported property has been provided, and/or
+   - the consumer has a default value for every property and allows the
+     registering code to define only those properties that deviate from the
+     specified default.
+
+ Working with properties in this manner requires knowledge of how to work with
+ systems::AbstractValue.
+
+ ```
+ const ProximityProperties& properties = FunctionThatReturnsProperties();
+ for (const auto& pair : properties.GetGroupProperties("MyGroup") {
+   const std::string& name = pair.first;
+   if (name == "rgb") {
+     // Throws an exception if the named parameter is of the wrong type.
+     const Eigen::Vector3d& rgb =
+         pair.second->GetValueOrThrow<Eigen::Vector3d>();
+   }
+ }
+ ```
+ */
+class GeometryProperties {
+ public:
+  virtual ~GeometryProperties() = default;
+
+  /** The properties for a single group as a property name-value map.  */
+  using Group =
+      std::unordered_map<std::string,
+                         copyable_unique_ptr<systems::AbstractValue>>;
+
+  /** Reports if the given named group is part of this property set.  */
+  bool HasGroup(const std::string& group_name) const {
+    return values_.count(group_name) > 0;
+  }
+
+  /** Reports the number of property groups in this set.  */
+  int num_groups() const { return static_cast<int>(values_.size()); }
+
+  /** Retrieves the indicated property group. The returned group is valid for
+   as long as this instance.
+   @throws std::logic_error if there is no group with the given name.  */
+  const Group& GetPropertiesInGroup(const std::string& group_name) const;
+
+  /** Returns all of the defined group names.  */
+  std::set<std::string> GetGroupNames() const;
+
+  /** Adds a property with the given `name` and `value` to the the named
+   property group. Adds the group if it doesn't already exist.
+
+   @param group_name   The group name.
+   @param name         The name of the property -- must be unique in the group.
+   @param value        The value to assign to the property.
+   @throws std::logic_error if `name` already exists in the group `group_name`.
+   @tparam ValueType   The type of data to store with the attribute -- must be
+                       copy constructible or cloneable (see systems::Value).  */
+  template <typename ValueType>
+  void AddProperty(const std::string& group_name, const std::string& name,
+                   const ValueType& value) {
+    auto iter = values_.find(group_name);
+    if (iter == values_.end()) {
+      auto result = values_.insert({group_name, Group{}});
+      DRAKE_DEMAND(result.second);
+      iter = result.first;
+    }
+
+    Group& group = iter->second;
+    auto value_iter = group.find(name);
+    if (value_iter == group.end()) {
+      group[name] = std::make_unique<systems::Value<ValueType>>(value);
+      return;
+    }
+    throw std::logic_error(fmt::format(
+        "AddProperty(): Trying to add property '{}' to group '{}'; "
+        "a property with that name already exists",
+        name, group_name));
+  }
+
+  /** Reports if the property exists in the group.
+
+   @param group_name  The name of the group to which the tested property should
+                      belong.
+   @param name        The name of the property under question.
+   @returns true iff the group exists and a property with the given `name`
+                 exists in that group.  */
+  bool HasProperty(const std::string& group_name,
+                   const std::string& name) const;
+
+  /** Retrieves the typed value from this set of properties.
+
+   @param group_name  The name of the group to which the property belongs.
+   @param name        The name of the desired property.
+   @throws std::logic_error
+                            1. if the group name is invalid,
+                            2. if the property name is invalid, or
+                            3. if the property type is not that specified.
+   @tparam ValueType  The expected type of the desired property.  */
+  template <typename ValueType>
+  const ValueType& GetProperty(const std::string& group_name,
+                               const std::string& name) const {
+    const auto iter = values_.find(group_name);
+    if (iter == values_.end()) {
+      throw std::logic_error(
+          fmt::format("GetProperty(): Trying to read property '{}' from group "
+                      "'{}'. But the group does not exist.",
+                      name, group_name));
+    }
+
+    const Group& group = iter->second;
+    const auto value_iter = group.find(name);
+    if (value_iter == group.end()) {
+      throw std::logic_error(
+          fmt::format("GetProperty(): There is no property '{}' in group '{}'.",
+                      name, group_name));
+    }
+
+    const ValueType* value = value_iter->second->MaybeGetValue<ValueType>();
+    if (value == nullptr) {
+      throw std::logic_error(fmt::format(
+          "GetProperty(): The property '{}' in group '{}' exists, "
+          "but is of a different type. Requested '{}', but found '{}'",
+          name, group_name, NiceTypeName::Get<ValueType>(),
+          value_iter->second->GetNiceTypeName()));
+    }
+
+    return *value;
+  }
+
+  /** Retrieves the typed value from the set of properties (if it exists),
+   otherwise returns the given default value. The given `default_value` is
+   returned only if the group or property are missing. If the property exists
+   and is of a _different_ type, an exception will be thrown. If it is of the
+   expected type, the stored value will be returned.
+
+   Generally, it is unnecessary to explicitly declare the `ValueType` of the
+   property value; it will be inferred from the provided default value.
+   Sometimes it is convenient to provide the default value in a form that can
+   be implicitly converted to the final type. In that case, it is necessary
+   to explicitly declare the desired `ValueType` so the compiler does not
+   infer the wrong type, e.g.:
+
+   ```
+   // Note the _integer_ value as default value.
+   const double my_value = properties.GetPropertyOrDefault<double>("g", "p", 2);
+   ```
+
+   @param group_name     The name of the group to which the property belongs.
+   @param name           The name of the desired property.
+   @param default_value  The alternate value to return if the property cannot
+                         be acquired.
+   @throws std::logic_error if a property of the given name exists but is not
+                            of `ValueType`.  */
+  template <typename ValueType>
+  ValueType GetPropertyOrDefault(const std::string& group_name,
+                                 const std::string& name,
+                                 ValueType default_value) const {
+    const auto iter = values_.find(group_name);
+    if (iter != values_.end()) {
+      const Group& group = iter->second;
+      const auto value_iter = group.find(name);
+      if (value_iter != group.end()) {
+        const ValueType* value = value_iter->second->MaybeGetValue<ValueType>();
+        if (value == nullptr) {
+          throw std::logic_error(fmt::format(
+              "GetPropertyOrDefault(): The property '{}' in group '{}' exists, "
+              "but is of a different type. Requested '{}', but found '{}'",
+              name, group_name, NiceTypeName::Get<ValueType>(),
+              value_iter->second->GetNiceTypeName()));
+        }
+        // This incurs the cost of copying a stored value.
+        return *value;
+      }
+    }
+    return default_value;
+  }
+
+  /** Returns the default group name. There is no guarantee as to _what_ string
+   corresponds to the default group. Therefore it should always be accessed via
+   this method.  */
+  static const std::string& default_group_name() {
+    static const never_destroyed<std::string> kDefaultGroup("__default__");
+    return kDefaultGroup.access();
+  }
+
+#ifndef DRAKE_DOXYGEN_CXX
+  // Note: these overloads of the property access methods exist to enable
+  // calls like `properties.AddProperty("group", "property", "string literal");
+  // Template matching would deduce that the `ValueType` in this case is a const
+  // char* (which is not copyable). By explicitly declaring this API, we can
+  // implicitly convert the string literals to copyable std::strings. We assume
+  // that the user is never actually trying to store const char*. We omit
+  // these from the doxygen because they provide no value there.
+  void AddProperty(const std::string& group_name, const std::string& name,
+                   const char* value) {
+    AddProperty<std::string>(group_name, name, value);
+  }
+
+  std::string GetPropertyOrDefault(const std::string& group_name,
+                                   const std::string& name,
+                                   const char* default_value) const {
+    return GetPropertyOrDefault(group_name, name, std::string(default_value));
+  }
+#endif
+
+ protected:
+  /** Constructs a property set with the default group. Only invoked by final
+   subclasses.  */
+  GeometryProperties() {
+    values_.emplace(default_group_name(), Group{});
+  }
+
+  // Final subclasses are allowed to make copy/move/assign public.
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(GeometryProperties)
+
+ private:
+  // The collection of property groups.
+  std::unordered_map<std::string, Group> values_;
+
+  friend std::ostream& operator<<(std::ostream& out,
+                                  const GeometryProperties& props);
+};
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/geometry_roles.cc
+++ b/geometry/geometry_roles.cc
@@ -1,0 +1,26 @@
+#include "drake/geometry/geometry_roles.h"
+
+#include <string>
+
+namespace drake {
+namespace geometry {
+
+std::string to_string(const Role& role) {
+  switch (role) {
+    case Role::kProximity:
+      return "proximity";
+    case Role::kIllustration:
+      return "illustration";
+    case Role::kUnassigned:
+      return "unassigned";
+  }
+  return "unknown";
+}
+
+std::ostream& operator<<(std::ostream& out, const Role& role) {
+  out << to_string(role);
+  return out;
+}
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/geometry_roles.h
+++ b/geometry/geometry_roles.h
@@ -1,0 +1,182 @@
+#pragma once
+
+#include <iostream>
+#include <string>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/geometry/geometry_properties.h"
+
+namespace drake {
+namespace geometry {
+
+/** @defgroup geometry_roles Geometry Roles
+ @ingroup scene_graph_module
+
+ Geometry roles help define how a real-world object is modeled in Drake.
+
+ We model the physical presence of real-world objects with geometric
+ representations. For a single object, we can assign many different properties
+ to the corresponding geometry depending on how the geometry is used (or what
+ aspect of the real-world object it represents). There are many operations that
+ can be applied to geometric representations. Each operation may only depend on
+ some of the possible properties. Furthermore, it may be advantageous to
+ represent a single real-world object with different geometries for different
+ operations.
+
+ __An example__
+
+ A physical robot arm (such as the KUKA Iiwa) has a great deal of detail:
+ flanges, vents, bolts, inset holes, stylistic creases, shiny paint, dull paint,
+ lettering, etc. Furthermore, the materials the arm is made of have meaningful
+ properties (e.g., Young's modulus, Poisson ratio, etc.) All of these
+ taken together are part of the physical whole.
+
+ The physical arm is partially represented in Drake with geometric
+ approximations and a set of properties which map the physical detail to the
+ Drake's underlying mathematical models (other aspects of the arm, e.g., mass
+ properties, are associated with the arm components as "bodies"). There are many
+ things we may want to use this geometric representation of the arm for:
+
+ - Display the progress of an interactive simulation of the arm in a GUI-based
+   visualization tool.
+ - Compute contact forces between the virtual arm and its virtual environment.
+ - Find clearances between objects.
+ - Simulate what a camera or other sensor reports when exposed to the simulated
+   environment.
+ - Calculate aerodynamic or fluid forces acting on objects.
+ - And more in the future.
+
+ These are all meaningful operations on the virtual arm, but each operation
+ requires a subset of the objects' properties. For example, the Young's
+ modulus of the arm's end effector is not relevant to the external display
+ of the state of the arm.
+
+ Beyond the relevancy of a property for any given operation, two different
+ operations may be best served by having different geometric representations of
+ the same physical object. For example, in modeling a bowling ball, the finger
+ holes may not be necessary for determining contact forces and by simply
+ representing the ball as a sphere the operation becomes much more efficient.
+ On the other hand, a perception system for a robot that is attempting to
+ pick up the ball and place fingers in the holes, would require a representation
+ with the actual holes.
+
+ __Geometry roles and geometry operations__
+
+ _Geometry roles_ are the Drake mechanism that allows us to represent a single
+ real-world object with different geometries best suited to the type of
+ operation. (Rather than a single, monolithic representation which may be
+ ill-suited for all operations.)
+
+ Drake partitions its geometry operations into classes (in the non-C++ sense of
+ the word) and defines a unique role for each class of operations.
+
+   - __Proximity role__: these are the operations that are related to
+     evaluations of the signed distance between two geometries. When the
+     objects are separated, the distance is positive, when penetrating, the
+     distance is negative. The distance value can be characterized by e.g.,
+     nearest points in the separated case and by points of deepest penetration
+     in the penetrating case (although this is not an exhaustive list). Due to
+     the cost of these types of algorithms, these geometric representations tend
+     to be simple approximations of real-world objects: single primitive shapes,
+     unions of multiple primitive shapes, simple convex meshes, lower resolution
+     versions of otherwise complex meshes. Typically, these types of queries are
+     used in motion planning and the generation of contact forces. The
+     properties associated with this role are typically things like Young's
+     modulus, Poisson ratio, coefficients of friction, etc. Generally, these
+     properties don't affect the _geometric_ operation, but are used in
+     conjunction with the geometry query results to produce forces and the like.
+     Since these properties are defined on a per-geometry basis, SceneGraph
+     stores these quantities with the geometries as a courtesy and these values
+     can be requested from SceneGraph to, e.g., calculate forces. This role is
+     unique in this regard -- the geometry parameters for the other roles
+     affect the result of the geometric operation.
+   - __Illustration role__: these are the operations that connect drake to some
+     external visualizers. The intent is that geometries with this role don't
+     contribute to system calculations, they provide the basis for visualizing,
+     or _illustrating_, the state of the system. It can include geometries that
+     illustrate abstract concepts or geometries which are literal
+     representations of real-world object surfaces. The properties associated
+     with this role are those necessary to draw the illustration.
+
+ Role assignment is achieved by assigning as set of role-related _properties_
+ to a geometry (see SceneGraph::AssignRole()). The set _can_ be empty. Each
+ role has a specific property set associated with it:
+   - __Proximity role__: ProximityProperties
+   - __Illustration role__: IllustrationProperties
+
+ Even for a single role, different consumers of a geometry may use different
+ properties. For example, a contact model is a likely consumer of geometries
+ with the proximity role. However, how contact is implemented may vary from
+ model to model. Those implementations can require model-specific parameters.
+ The ProximityProperties need to include properties compatible with all
+ the consumers active in the system.
+
+ In such a case, each consumer should document the properties it requires and
+ how they are organized (see GeometryProperties). The properties can be
+ segregated by collecting their model-specific parameters into a named property
+ group as specified by each consumer.
+
+ To make a geometry _universally_ compatible with _anything_ in Drake, it would
+ provide properties for all known consumers of geometry properties (e.g.,
+ contact models, visualizers, etc.) In practice, it is sufficient to satisfy
+ those consumers used in a particular system.
+
+ Finally, a geometry is not limited to having a single role. A geometry must
+ always have at least one role to have any impact. But it can have multiple
+ roles.
+
+ Generally, any code that is dependent on geometry roles, should document the
+ type of role that it depends on, and the properties (if any) associated with
+ that role that it requires/prefers.
+
+ Roles are assigned during geometry registration (see
+ SceneGraph::AssignRole()). */
+
+/** The set of properties for geometry used in a _proximity_ role.
+
+ Examples of functionality that depends on the proximity role:
+   - n/a
+ */
+class ProximityProperties final : public GeometryProperties {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ProximityProperties);
+  // TODO(SeanCurtis-TRI): Should this have the physical properties built in?
+
+  // TODO(SeanCurtis-TRI): Consider adding ProximityIndex to this.
+  ProximityProperties() = default;
+};
+
+/** The set of properties for geometry used in an "illustration" role.
+
+ Examples of functionality that depends on the illustration role:
+   - @ref geometry_visualization_role_dependency "drake::geometry::ConnectDrakeVisualizer()"
+ */
+class IllustrationProperties final : public GeometryProperties {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(IllustrationProperties);
+
+  IllustrationProperties() = default;
+};
+
+/** General enumeration for indicating geometry role.  */
+enum class Role {
+  // Bitmask-able values so they can be OR'd together.
+  kUnassigned = 0x0,
+  kProximity = 0x1,
+  kIllustration = 0x2,
+};
+
+/** @name  Geometry role to string conversions
+
+ These are simply convenience functions for converting the Role enumeration into
+ a human-readable string. */
+//@{
+
+std::string to_string(const Role& role);
+
+std::ostream& operator<<(std::ostream& out, const Role& role);
+
+//@}
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/test/geometry_properties_test.cc
+++ b/geometry/test/geometry_properties_test.cc
@@ -1,0 +1,292 @@
+#include "drake/geometry/geometry_properties.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+namespace drake {
+namespace geometry {
+namespace {
+
+// A constructible sub-class of GeometryProperties.
+class TestProperties : public GeometryProperties {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(TestProperties);
+
+  TestProperties() = default;
+};
+
+GTEST_TEST(GeometryProperties, ManagingGroups) {
+  TestProperties properties;
+  const std::string& group_name{"some_group"};
+  // Only contains the default group.
+  ASSERT_EQ(1, properties.num_groups());
+  ASSERT_FALSE(properties.HasGroup(group_name));
+  ASSERT_TRUE(properties.HasGroup(TestProperties::default_group_name()));
+
+  // Add the group for the first time by adding a property.
+  properties.AddProperty(group_name, "junk_value", 1);
+  ASSERT_TRUE(properties.HasGroup(group_name));
+  ASSERT_EQ(2, properties.num_groups());
+
+  // Retrieve the group.
+  using PropertyGroup = GeometryProperties::Group;
+  const PropertyGroup& group = properties.GetPropertiesInGroup(group_name);
+  EXPECT_EQ(1u, group.size());
+
+  DRAKE_EXPECT_THROWS_MESSAGE(properties.GetPropertiesInGroup("invalid_name"),
+                              std::logic_error,
+                              ".*Can't retrieve properties for a group that "
+                              "doesn't exist: '.*'");
+}
+
+// Tests adding properties (successfully and otherwise). Uses a call to
+// GetProperty() to confirm successful add.
+GTEST_TEST(GeometryProperties, AddProperty) {
+  TestProperties properties;
+  const std::string& group_name{"some_group"};
+
+  // Confirm property doesn't exist.
+  const std::string prop_name("some_property");
+  ASSERT_FALSE(properties.HasProperty(group_name, prop_name));
+
+  // Add the property.
+  const int int_value{7};
+  EXPECT_NO_THROW(properties.AddProperty(group_name, prop_name, int_value));
+
+  // Confirm existence.
+  ASSERT_TRUE(properties.HasProperty(group_name, prop_name));
+  int read_value = properties.GetProperty<int>(group_name, prop_name);
+  ASSERT_EQ(int_value, read_value);
+
+  // Redundant add.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      properties.AddProperty(group_name, prop_name, int_value),
+      std::logic_error,
+      ".*Trying to add property .+ to group .+; .* name already exists");
+  ASSERT_TRUE(properties.HasProperty(group_name, prop_name));
+}
+
+// Struct for the AddPropertyStruct test.
+struct TestData {
+  int i {};
+  double d{};
+  std::string s;
+};
+
+// Tests the case where the property value is a struct.
+GTEST_TEST(GeometryProperties, AddPropertyStruct) {
+  TestProperties properties;
+
+  const std::string prop_name("test data");
+  TestData data{1, 2., "3"};
+  EXPECT_NO_THROW(properties.AddProperty(TestProperties::default_group_name(),
+                                         prop_name, data));
+
+  const TestData& read = properties.GetProperty<TestData>(
+      TestProperties::default_group_name(), prop_name);
+  EXPECT_EQ(data.i, read.i);
+  EXPECT_EQ(data.d, read.d);
+  EXPECT_EQ(data.s, read.s);
+}
+
+// Tests property access with default.
+GTEST_TEST(GeometryProperties, GetPropertyOrDefault) {
+  // Create one group with a single property.
+  TestProperties properties;
+  const std::string group_name{"some_group"};
+  const double double_value{7};
+  const double default_value = double_value - 1;
+  const std::string prop_name("some_property");
+  EXPECT_NO_THROW(properties.AddProperty(group_name, prop_name, double_value));
+
+  // Case: default value that can be *implicitly* converted to the desired
+  // type requires explicit template declaration.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      properties.GetPropertyOrDefault(group_name, prop_name, 3),
+      std::logic_error,
+      ".*The property '.*' in group '.*' exists, but is of a different type. "
+      "Requested 'int', but found 'double'");
+  EXPECT_NO_THROW(properties.GetPropertyOrDefault<double>(group_name,
+                                                          prop_name, 3));
+
+  // Case: read an existing property.
+  int read_value = properties.GetPropertyOrDefault(group_name, prop_name,
+                                                   default_value);
+  EXPECT_EQ(double_value, read_value);
+
+  // Case: read from valid group, but invalid property.
+  read_value = properties.GetPropertyOrDefault(group_name, "invalid_prop",
+                                               default_value);
+  EXPECT_EQ(default_value, read_value);
+
+  // Case: read from invalid group.
+  read_value = properties.GetPropertyOrDefault("invalid_group", "invalid_prop",
+                                               default_value);
+  EXPECT_EQ(default_value, read_value);
+
+  // Case: Property exists of different type.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      properties.GetPropertyOrDefault(group_name, prop_name, "test"),
+      std::logic_error,
+      ".*The property '" + prop_name + "' in group '" + group_name + "' "
+      "exists, but is of a different type. Requested 'std::string', but found "
+      "'double'");
+
+  // Using r-values as defaults; this tests both compilability and correctness.
+  properties.AddProperty("strings", "valid_string", "valid_string");
+  std::string valid_value = properties.GetPropertyOrDefault(
+      "strings", "valid_string", "missing");
+  EXPECT_EQ("valid_string", valid_value);
+  std::string default_value_return = properties.GetPropertyOrDefault(
+      "strings", "invalid_string", "rvalue_string");
+  EXPECT_EQ("rvalue_string", default_value_return);
+}
+
+// Tests the unsuccessful access to properties (successful access has been
+// implicitly tested in the functions that added/set properties).
+GTEST_TEST(GeometryProperties, GetPropertyFailure) {
+  TestProperties properties;
+  const std::string& group_name{"some_group"};
+  const std::string prop_name("some_property");
+
+  // Getter errors
+  // Case: Asking for property from non-existant group.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      properties.GetProperty<int>(group_name, prop_name), std::logic_error,
+      ".*Trying to read property .* from group .*. But the group does not "
+      "exist.");
+
+  // Case: Group exists, property does not.
+  properties.AddProperty(group_name, prop_name + "_alt", 1);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      properties.GetProperty<int>(group_name, prop_name), std::logic_error,
+      ".*There is no property .* in group .*.");
+
+  // Case: Group and property exists, but property is of different type.
+  EXPECT_NO_THROW(properties.AddProperty(group_name, prop_name, 7.0));
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      properties.GetProperty<int>(group_name, prop_name), std::logic_error,
+      ".*The property '" + prop_name + "' in group '" + group_name + "' exists"
+      ", but is of a different type. Requested 'int', but found 'double'");
+}
+
+// Tests iteration through a group's properties.
+GTEST_TEST(GeometryProperties, PropertyIteration) {
+  TestProperties properties;
+  const std::string& default_group = TestProperties::default_group_name();
+  std::unordered_map<std::string, int> reference{{"prop1", 10}, {"prop2", 20}};
+  for (const auto& pair : reference) {
+    properties.AddProperty(default_group, pair.first, pair.second);
+  }
+
+  // Get exception for non-existant group.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      properties.GetPropertiesInGroup("bad group"), std::logic_error,
+      ".*Can't retrieve properties for a group that doesn't exist.*");
+
+  // Confirm that all properties have the right value and get visited.
+  std::set<std::string> visited_properties;
+  for (const auto& pair : properties.GetPropertiesInGroup(default_group)) {
+    const std::string& name = pair.first;
+    EXPECT_GT(reference.count(name), 0);
+    EXPECT_EQ(reference[name],
+              properties.GetProperty<int>(default_group, name));
+    visited_properties.insert(name);
+  }
+  EXPECT_EQ(reference.size(), visited_properties.size());
+}
+
+// Confirms that derived classes *can* be copied/moved.
+GTEST_TEST(GeometryProperties, CopyMoveSemantics) {
+  // Populate a property set with an arbitrary set of properties. In this case,
+  // they are all int-valued to facilitate comparison between property sets.
+  auto make_properties = []() {
+    TestProperties props;
+    const std::string& default_group = TestProperties::default_group_name();
+    props.AddProperty(default_group, "prop1", 1);
+    props.AddProperty(default_group, "prop2", 2);
+
+    const std::string group1("group1");
+    // NOTE: Duplicate property name differentiated by different group.
+    props.AddProperty(group1, "prop1", 3);
+    props.AddProperty(group1, "prop3", 4);
+    props.AddProperty(group1, "prop4", 5);
+
+    const std::string group2("group2");
+    props.AddProperty(group2, "prop5", 6);
+    return props;
+  };
+
+  // Only works for int-valued properties.
+  auto properties_equal = [](
+      const TestProperties& reference,
+      const TestProperties& test) -> ::testing::AssertionResult {
+    if (reference.num_groups() != test.num_groups()) {
+      return ::testing::AssertionFailure()
+          << "Different number of groups. Expected "
+          << reference.num_groups() << " found " << test.num_groups();
+    }
+
+    for (const auto& group_name : reference.GetGroupNames()) {
+      if (test.HasGroup(group_name)) {
+        for (const auto& pair : reference.GetPropertiesInGroup(group_name)) {
+          const std::string& name = pair.first;
+          int expected_value = pair.second->GetValueOrThrow<int>();
+          if (test.HasProperty(group_name, name)) {
+            int test_value = test.GetProperty<int>(group_name, name);
+            if (expected_value != test_value) {
+              return ::testing::AssertionFailure()
+                  << "Expected value for '" << group_name << "':'" << name
+                  << "' to be " << expected_value << ". Found " << test_value;
+            }
+          } else {
+            return ::testing::AssertionFailure()
+                << "Expected group '" << group_name << "' to have property '"
+                << name <<"'. It does not exist.";
+          }
+        }
+      } else {
+        return ::testing::AssertionFailure()
+            << "Expected group '" << group_name
+            << "' is missing from test properties";
+      }
+    }
+    return ::testing::AssertionSuccess();
+  };
+
+  TestProperties source = make_properties();
+  TestProperties reference = make_properties();
+
+  // Copy construction.
+  TestProperties copy_construct(source);
+  EXPECT_TRUE(properties_equal(reference, copy_construct));
+
+  // Copy assignment.
+  TestProperties copy_assign;
+  EXPECT_FALSE(properties_equal(reference, copy_assign));
+  copy_assign = source;
+  EXPECT_TRUE(properties_equal(reference, copy_assign));
+
+  // Strictly speaking, confirming that the move *source* has changed isn't
+  // necessary. The move semantics aren't documented. However, given that this
+  // is using default move semantics on unordered_map, we can assume that the
+  // source is modified by the move. So, we'll go ahead and test that.
+
+  // Move construction.
+  TestProperties move_construct(std::move(source));
+  EXPECT_FALSE(properties_equal(reference, source));
+  EXPECT_TRUE(properties_equal(reference, move_construct));
+
+  // Move assignment.
+  TestProperties move_assign;
+  EXPECT_FALSE(properties_equal(reference, move_assign));
+  move_assign = std::move(move_construct);
+  EXPECT_FALSE(properties_equal(reference, move_construct));
+  EXPECT_TRUE(properties_equal(reference, move_assign));
+}
+
+}  // namespace
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
Roles are defined by role-related properties. This includes the underlying class that supports geometry properties (and tests) and the declaration of specific roles (currently only proximity and illustration).

The roles are not incorporated anywhere and do not affect functionality or API. It is merely the basis for defining roles which will *eventually* enter the API.

The two most important parts of this PR are:

1. The implementation of `GeometryProperties` and its tests.
2. The *documentation* for geometry roles.

```
Category            added  modified  removed  
----------------------------------------------
code                519    0         0        
comments            391    0         0        
blank               169    0         0        
----------------------------------------------
TOTAL               1079   0         0
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9813)
<!-- Reviewable:end -->
