### PR TITLE
Clean up wsg lcm messages

### DIFF
--- a/examples/kuka_iiwa_arm/iiwa_wsg_simulation.cc
+++ b/examples/kuka_iiwa_arm/iiwa_wsg_simulation.cc
@@ -49,6 +49,8 @@ namespace examples {
 namespace kuka_iiwa_arm {
 namespace {
 
+using manipulation::schunk_wsg::MakeMultibodyForceToWsgForceSystem;
+using manipulation::schunk_wsg::MakeMultibodyStateToWsgStateSystem;
 using manipulation::schunk_wsg::SchunkWsgStatusSender;
 using manipulation::schunk_wsg::SchunkWsgController;
 using manipulation::util::WorldSimTreeBuilder;
@@ -220,11 +222,11 @@ int DoMain() {
   wsg_status_pub->set_publish_period(
       manipulation::schunk_wsg::kSchunkWsgLcmStatusPeriod);
 
-  auto wsg_status_sender = builder.AddSystem<SchunkWsgStatusSender>(
-      model->get_output_port_wsg_state().size(),
-      model->get_output_port_wsg_measured_torque().size(),
-      manipulation::schunk_wsg::kSchunkWsgPositionIndex,
-      manipulation::schunk_wsg::kSchunkWsgVelocityIndex);
+  auto wsg_status_sender = builder.AddSystem<SchunkWsgStatusSender>();
+  auto mbp_state_to_wsg_state = builder.AddSystem
+      (MakeMultibodyStateToWsgStateSystem<double>());
+  auto mbp_force_to_wsg_force = builder.AddSystem
+      (MakeMultibodyForceToWsgForceSystem<double>());
   wsg_status_sender->set_name("wsg_status_sender");
 
   builder.Connect(wsg_command_sub->get_output_port(),
@@ -232,9 +234,13 @@ int DoMain() {
   builder.Connect(wsg_controller->get_output_port(0),
                   model->get_input_port_wsg_command());
   builder.Connect(model->get_output_port_wsg_state(),
-                  wsg_status_sender->get_input_port_wsg_state());
+                  mbp_state_to_wsg_state->get_input_port());
+  builder.Connect(mbp_state_to_wsg_state->get_output_port(),
+                  wsg_status_sender->get_state_input_port());
   builder.Connect(model->get_output_port_wsg_measured_torque(),
-                  wsg_status_sender->get_input_port_measured_torque());
+                  mbp_force_to_wsg_force->get_input_port());
+  builder.Connect(mbp_force_to_wsg_force->get_output_port(),
+                  wsg_status_sender->get_force_input_port());
   builder.Connect(model->get_output_port_wsg_state(),
                   wsg_controller->get_state_input_port());
   builder.Connect(*wsg_status_sender, *wsg_status_pub);

--- a/examples/schunk_wsg/schunk_wsg_simulation.cc
+++ b/examples/schunk_wsg/schunk_wsg_simulation.cc
@@ -69,11 +69,9 @@ int DoMain() {
   status_pub->set_publish_period(
       manipulation::schunk_wsg::kSchunkWsgLcmStatusPeriod);
 
-  auto status_sender = builder.AddSystem<SchunkWsgStatusSender>(
-      tree.get_num_positions() + tree.get_num_velocities(),
-      tree.get_num_actuators(),
-      manipulation::schunk_wsg::kSchunkWsgPositionIndex,
-      manipulation::schunk_wsg::kSchunkWsgVelocityIndex);
+  auto status_sender = builder.AddSystem<SchunkWsgStatusSender>();
+  auto mbp_state_to_wsg_state = builder.AddSystem(
+      manipulation::schunk_wsg::MakeMultibodyStateToWsgStateSystem<double>());
   status_sender->set_name("status_sender");
 
   builder.Connect(command_sub->get_output_port(),
@@ -82,7 +80,9 @@ int DoMain() {
                   plant->actuator_command_input_port());
   builder.Connect(plant->state_output_port(), visualizer->get_input_port(0));
   builder.Connect(plant->state_output_port(),
-                  status_sender->get_input_port(0));
+                  mbp_state_to_wsg_state->get_input_port());
+  builder.Connect(mbp_state_to_wsg_state->get_output_port(),
+                  status_sender->get_state_input_port());
   builder.Connect(plant->state_output_port(),
                   wsg_controller->get_state_input_port());
   builder.Connect(*status_sender, *status_pub);

--- a/manipulation/schunk_wsg/BUILD.bazel
+++ b/manipulation/schunk_wsg/BUILD.bazel
@@ -34,6 +34,7 @@ drake_cc_library(
     hdrs = ["schunk_wsg_constants.h"],
     deps = [
         "//common:essential",
+        "//systems/primitives:matrix_gain",
     ],
 )
 
@@ -44,6 +45,7 @@ drake_cc_library(
     deps = [
         "//lcmtypes:schunk",
         "//systems/framework:leaf_system",
+        "//systems/primitives:matrix_gain",
     ],
 )
 

--- a/manipulation/schunk_wsg/schunk_wsg_constants.h
+++ b/manipulation/schunk_wsg/schunk_wsg_constants.h
@@ -7,7 +7,10 @@
 
 #pragma once
 
+#include <memory>
+
 #include "drake/common/eigen_types.h"
+#include "drake/systems/primitives/matrix_gain.h"
 
 namespace drake {
 namespace manipulation {
@@ -17,6 +20,11 @@ constexpr int kSchunkWsgNumActuators = 2;
 constexpr int kSchunkWsgNumPositions = 2;
 constexpr int kSchunkWsgNumVelocities = 2;
 
+// TODO(russt): These constants are predicated on the idea that we can map
+// one finger's state => gripper state.  We should prefer using
+// MakeMultibodyStateToWsgState and MakeMultibodyForceToWsgForce instead.
+// But I cannot deprecate them yet without performing surgery on the old
+// controller.
 constexpr int kSchunkWsgPositionIndex = 0;
 constexpr int kSchunkWsgVelocityIndex =
     kSchunkWsgNumPositions + kSchunkWsgPositionIndex;
@@ -36,6 +44,29 @@ VectorX<T> GetSchunkWsgOpenPosition() {
        0.0550667).finished();
   // clang-format on
 }
+
+/// Extract the distance between the fingers (and its time derivative) out
+/// of the plant model which pretends the two fingers are independent.
+template <typename T>
+std::unique_ptr<systems::MatrixGain<T>>
+MakeMultibodyStateToWsgStateSystem() {
+  Eigen::Matrix<double, 2, 4> D;
+  // clang-format off
+  D << 1, -1, 0,  0,
+      0,  0, 1, -1;
+  // clang-format on
+  return std::make_unique<systems::MatrixGain<T>>(D);
+}
+
+/// Extract the gripper measured force from the generalized forces on the two
+/// fingers.
+template <typename T>
+std::unique_ptr<systems::MatrixGain<T>>
+MakeMultibodyForceToWsgForceSystem() {
+  // gripper force = -finger0 + finger1.
+  return std::make_unique<systems::MatrixGain<T>>(Eigen::RowVector2d(-1, 1));
+}
+
 
 }  // namespace schunk_wsg
 }  // namespace manipulation

--- a/manipulation/schunk_wsg/schunk_wsg_controller.cc
+++ b/manipulation/schunk_wsg/schunk_wsg_controller.cc
@@ -29,7 +29,7 @@ SchunkWsgController::SchunkWsgController(double kp, double ki, double kd) {
           kSchunkWsgPositionIndex);
   builder.Connect(state_pass_through->get_output_port(),
                   wsg_trajectory_generator->get_state_input_port());
-  builder.Connect(command_receiver->get_commanded_position_output_port(),
+  builder.Connect(command_receiver->get_position_output_port(),
                   wsg_trajectory_generator->get_desired_position_input_port());
   builder.Connect(command_receiver->get_force_limit_output_port(),
                   wsg_trajectory_generator->get_force_limit_input_port());

--- a/manipulation/schunk_wsg/schunk_wsg_lcm.h
+++ b/manipulation/schunk_wsg/schunk_wsg_lcm.h
@@ -3,6 +3,7 @@
 /// @file This file contains classes dealing with sending/receiving
 /// LCM messages related to the Schunk WSG gripper.
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/lcmt_schunk_wsg_status.hpp"
 #include "drake/systems/framework/leaf_system.h"
 
@@ -12,13 +13,13 @@ namespace schunk_wsg {
 
 /// Handles lcmt_schunk_wsg_command messages from a LcmSubscriberSystem.  Has
 /// two output ports: one for the commanded finger position represented as the
-/// desired distance from the center (zero) position in meters, and one for
-/// the commanded force limit.  The commanded position and force limit are
-/// scalars (BasicVector<double> of size 1).
+/// desired distance between the fingers in meters, and one for the commanded
+/// force limit.  The commanded position and force limit are scalars
+/// (BasicVector<double> of size 1).
 ///
 /// @system{ SchunkWsgCommandReceiver,
 ///   @input_port{lcmt_schunk_wsg_command},
-///   @output_port{commanded_position}
+///   @output_port{position}
 ///   @output_port{force_limit} }
 class SchunkWsgCommandReceiver : public systems::LeafSystem<double> {
  public:
@@ -36,29 +37,25 @@ class SchunkWsgCommandReceiver : public systems::LeafSystem<double> {
     return this->get_input_port(0);
   }
 
-  const systems::OutputPort<double>& get_commanded_position_output_port()
-      const {
-    return this->get_output_port(commanded_position_output_port_);
+  const systems::OutputPort<double>& get_position_output_port() const {
+    return this->get_output_port(position_output_port_);
   }
 
-  const systems::OutputPort<double>& get_force_limit_output_port()
-      const {
+  const systems::OutputPort<double>& get_force_limit_output_port() const {
     return this->get_output_port(force_limit_output_port_);
   }
 
  private:
-  void CalcCommandedPositionOutput(
-      const systems::Context<double>& context,
-      systems::BasicVector<double>* output) const;
+  void CalcPositionOutput(const systems::Context<double>& context,
+                          systems::BasicVector<double>* output) const;
 
-  void CalcForceLimitOutput(
-      const systems::Context<double>& context,
-      systems::BasicVector<double>* output) const;
+  void CalcForceLimitOutput(const systems::Context<double>& context,
+                            systems::BasicVector<double>* output) const;
 
  private:
   const double initial_position_{};
   const double initial_force_{};
-  const systems::OutputPortIndex commanded_position_output_port_{};
+  const systems::OutputPortIndex position_output_port_{};
   const systems::OutputPortIndex force_limit_output_port_{};
 };
 
@@ -73,28 +70,24 @@ class SchunkWsgCommandReceiver : public systems::LeafSystem<double> {
 /// }
 ///
 /// The state input is a BasicVector<double> of size 2 -- with one position
-/// and one velocity -- representing the *positive* position of the fingers
-/// from the middle/zero position.
+/// and one velocity -- representing the distance between the fingers (positive
+/// implies non-penetration).
 ///
 /// @ingroup manipulation_systems
 class SchunkWsgStatusSender : public systems::LeafSystem<double> {
  public:
-
-  DRAKE_DEPRECATED("Don't use this constructor.  Use the default constructor "
-                   "and just wire in the two-dimensional state input.  Note "
-                   "that the *sign* of the expected input has also changed --"
-                   " positive position means open.")
   SchunkWsgStatusSender(int input_state_size, int input_torque_size,
                         int position_index, int velocity_index);
 
-  DRAKE_DEPRECATED("Use get_state_input_port() instead which takes a "
-                   "two-dimensional BasicVector<double>.")
+  DRAKE_DEPRECATED(
+      "Use get_state_input_port() instead which takes a "
+      "two-dimensional BasicVector<double>.")
   const systems::InputPort<double>& get_input_port_wsg_state() const {
-    DRAKE_DEMAND(input_port_wsg_state_ != -1);
+    DRAKE_DEMAND(input_port_wsg_state_.is_valid());
     return this->get_input_port(input_port_wsg_state_);
   }
 
-  DRAKE_DEPRECTED("Use get_force_input_port() instead.")
+  DRAKE_DEPRECATED("Use get_force_input_port() instead.")
   const systems::InputPort<double>& get_input_port_measured_torque() {
     return this->get_input_port(force_input_port_);
   }
@@ -102,12 +95,11 @@ class SchunkWsgStatusSender : public systems::LeafSystem<double> {
   SchunkWsgStatusSender();
 
   const systems::InputPort<double>& get_state_input_port() const {
-    DRAKE_DEMAND(state_input_port_ != -1);
+    DRAKE_DEMAND(state_input_port_.is_valid());
     return this->get_input_port(state_input_port_);
   }
 
-  const systems::InputPort<double>& get_force_input_port()
-      const {
+  const systems::InputPort<double>& get_force_input_port() const {
     return this->get_input_port(force_input_port_);
   }
 
@@ -115,11 +107,13 @@ class SchunkWsgStatusSender : public systems::LeafSystem<double> {
   void OutputStatus(const systems::Context<double>& context,
                     lcmt_schunk_wsg_status* output) const;
 
-  systems::InputPortIndex state_input_port_{-1};
+  systems::InputPortIndex state_input_port_{};
   systems::InputPortIndex force_input_port_{};
 
   // TODO(russt): Remove this port after the deprecation timeline.
-  systems::InputPortIndex input_port_wsg_state_{-1};
+  const int position_index_{};
+  const int velocity_index_{};
+  systems::InputPortIndex input_port_wsg_state_{};
 };
 
 }  // namespace schunk_wsg

--- a/manipulation/schunk_wsg/schunk_wsg_position_controller.cc
+++ b/manipulation/schunk_wsg/schunk_wsg_position_controller.cc
@@ -93,10 +93,10 @@ Vector2d SchunkWsgPositionController::CalcGeneralizedForce(
   const double f0_plus_f1 = -kp_constraint_ * (state[0] + state[1]) -
                             kd_constraint_ * (state[2] + state[3]);
 
-  // -f₀+f₁ = sat(kp_command*(2*q_d + q₀ - q₁) + kd_command*(2*v_d + v₀ - v₁)).
+  // -f₀+f₁ = sat(kp_command*(q_d + q₀ - q₁) + kd_command*(v_d + v₀ - v₁)).
   const double neg_f0_plus_f1 = math::saturate(
-      kp_command_ * (2 * desired_position + state[0] - state[1]) +
-          kd_command_ * (2 * desired_velocity + state[2] - state[3]),
+      kp_command_ * (desired_position + state[0] - state[1]) +
+          kd_command_ * (desired_velocity + state[2] - state[3]),
       -force_limit, force_limit);
 
   // f₀ = (f₀+f₁)/2 - (-f₀+f₁)/2,

--- a/manipulation/schunk_wsg/schunk_wsg_position_controller.h
+++ b/manipulation/schunk_wsg/schunk_wsg_position_controller.h
@@ -22,12 +22,13 @@ namespace schunk_wsg {
 /// gripper is open, q₀ < 0 and q₁ > 0.
 ///
 /// The physical gripper mechanically imposes that -q₀ = q₁, and implements a
-/// controller to track -q₀ = q₁ = q_d (the desired position).  We model that
-/// here with two PD controllers -- one that implements the physical constraint
+/// controller to track -q₀ = q₁ = q_d/2 (q_d is the desired position, which
+/// is the signed distance between the two fingers).  We model that here with
+/// two PD controllers -- one that implements the physical constraint
 /// (keeping the fingers centered):
 ///   f₀+f₁ = -kp_constraint*(q₀+q₁) - kd_constraint*(v₀+v₁),
 /// and another to implement the controller (opening/closing the fingers):
-///   -f₀+f₁ = sat(kp_command*(2*q_d + q₀ - q₁) + kd_command*(2*v_d + v₀ - v₁)),
+///   -f₀+f₁ = sat(kp_command*(q_d + q₀ - q₁) + kd_command*(v_d + v₀ - v₁)),
 /// where sat() saturates the command to be in the range [-force_limit,
 /// force_limit], and v_d is estimated from q_d via a discrete-time derivative:
 ///   v_d[n] = (q_d[n] - q_d[n-1])/h,

--- a/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.cc
+++ b/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.cc
@@ -66,11 +66,11 @@ void SchunkWsgTrajectoryGenerator::DoCalcDiscreteVariableUpdates(
   const double desired_position =
       this->EvalEigenVectorInput(context, desired_position_input_port_)[0];
 
-  // The desired position input is the distance from each finger to the center
-  // of the gripper in meters.  This class generates trajectories for the
-  // negative of the distance between the fingers in meters.
+  // The desired position input is the distance between the fingers in meters.
+  // This class generates trajectories for the negative of the distance
+  // between the fingers in meters.
 
-  double target_position = -desired_position * 2;
+  double target_position = -desired_position;
 
   const systems::BasicVector<double>* state =
       this->EvalVectorInput(context, state_input_port_);

--- a/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.h
+++ b/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.h
@@ -16,7 +16,7 @@ namespace schunk_wsg {
 // state of the gripper (particularly the maximum force).
 
 /// This system defines input ports for the desired finger position
-/// represented as the desired distance from the center (zero) position in
+/// represented as the desired distance between the fingers in
 /// meters and the desired force limit in newtons, and emits target
 /// position/velocity for the actuated finger to reach the commanded target,
 /// expressed as the negative of the distance between the two fingers in

--- a/manipulation/schunk_wsg/test/schunk_wsg_lcm_test.cc
+++ b/manipulation/schunk_wsg/test/schunk_wsg_lcm_test.cc
@@ -31,7 +31,7 @@ GTEST_TEST(SchunkWsgLcmTest, SchunkWsgCommandReceiverTest) {
   context->FixInputPort(
       0,
       systems::AbstractValue::Make<lcmt_schunk_wsg_command>(initial_command));
-  EXPECT_EQ(dut.get_commanded_position_output_port()
+  EXPECT_EQ(dut.get_position_output_port()
                 .Eval<BasicVector<double>>(*context)
                 .GetAtIndex(0),
             initial_position);
@@ -48,10 +48,10 @@ GTEST_TEST(SchunkWsgLcmTest, SchunkWsgCommandReceiverTest) {
   context->FixInputPort(
       0,
       systems::AbstractValue::Make<lcmt_schunk_wsg_command>(initial_command));
-  EXPECT_EQ(dut.get_commanded_position_output_port()
+  EXPECT_EQ(dut.get_position_output_port()
                 .Eval<BasicVector<double>>(*context)
                 .GetAtIndex(0),
-            0.05);
+            0.1);
   EXPECT_EQ(dut.get_force_limit_output_port()
                 .Eval<BasicVector<double>>(*context)
                 .GetAtIndex(0),
@@ -74,8 +74,8 @@ GTEST_TEST(SchunkWsgLcmTest, SchunkWsgStatusSenderTest) {
         dut.get_output_port(0).Eval<lcmt_schunk_wsg_status>(*context);
 
     EXPECT_EQ(status.actual_force, 0.0);
-    EXPECT_EQ(status.actual_position_mm, 2.0);
-    EXPECT_EQ(status.actual_speed_mm_per_s, 80.0);
+    EXPECT_EQ(status.actual_position_mm, 1.0);
+    EXPECT_EQ(status.actual_speed_mm_per_s, 40.0);
   }
 
   // Check that we can also set the force.

--- a/manipulation/schunk_wsg/test/schunk_wsg_lcm_test.cc
+++ b/manipulation/schunk_wsg/test/schunk_wsg_lcm_test.cc
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/lcmt_schunk_wsg_command.hpp"
+#include "drake/lcmt_schunk_wsg_status.hpp"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/fixed_input_port_value.h"
 
@@ -13,6 +14,7 @@ namespace manipulation {
 namespace schunk_wsg {
 namespace {
 
+using Eigen::Vector2d;
 using systems::BasicVector;
 
 GTEST_TEST(SchunkWsgLcmTest, SchunkWsgCommandReceiverTest) {
@@ -26,13 +28,16 @@ GTEST_TEST(SchunkWsgLcmTest, SchunkWsgCommandReceiverTest) {
   // Check that we get the initial position and force before receiving a
   // command.
   lcmt_schunk_wsg_command initial_command{};
-  context->FixInputPort(0,
+  context->FixInputPort(
+      0,
       systems::AbstractValue::Make<lcmt_schunk_wsg_command>(initial_command));
   EXPECT_EQ(dut.get_commanded_position_output_port()
-            .Eval<BasicVector<double>>(*context).GetAtIndex(0),
+                .Eval<BasicVector<double>>(*context)
+                .GetAtIndex(0),
             initial_position);
   EXPECT_EQ(dut.get_force_limit_output_port()
-            .Eval<BasicVector<double>>(*context).GetAtIndex(0),
+                .Eval<BasicVector<double>>(*context)
+                .GetAtIndex(0),
             initial_force);
 
   // Start off with the gripper closed (zero) and a command to open to
@@ -40,12 +45,48 @@ GTEST_TEST(SchunkWsgLcmTest, SchunkWsgCommandReceiverTest) {
   initial_command.utime = 1;
   initial_command.target_position_mm = 100;
   initial_command.force = 40;
-  context->FixInputPort(0,
+  context->FixInputPort(
+      0,
       systems::AbstractValue::Make<lcmt_schunk_wsg_command>(initial_command));
   EXPECT_EQ(dut.get_commanded_position_output_port()
-            .Eval<BasicVector<double>>(*context).GetAtIndex(0), 0.05);
+                .Eval<BasicVector<double>>(*context)
+                .GetAtIndex(0),
+            0.05);
   EXPECT_EQ(dut.get_force_limit_output_port()
-            .Eval<BasicVector<double>>(*context).GetAtIndex(0), 40);
+                .Eval<BasicVector<double>>(*context)
+                .GetAtIndex(0),
+            40);
+}
+
+GTEST_TEST(SchunkWsgLcmTest, SchunkWsgStatusSenderTest) {
+  SchunkWsgStatusSender dut;
+  std::unique_ptr<systems::Context<double>> context =
+      dut.CreateDefaultContext();
+
+  const double position = 0.001;
+  const double velocity = 0.04;
+  context->FixInputPort(dut.get_state_input_port().get_index(),
+                        Vector2d(position, velocity));
+
+  // Check that the force input port is indeed optional.
+  {
+    const lcmt_schunk_wsg_status& status =
+        dut.get_output_port(0).Eval<lcmt_schunk_wsg_status>(*context);
+
+    EXPECT_EQ(status.actual_force, 0.0);
+    EXPECT_EQ(status.actual_position_mm, 2.0);
+    EXPECT_EQ(status.actual_speed_mm_per_s, 80.0);
+  }
+
+  // Check that we can also set the force.
+  const double force = 32.0;
+  context->FixInputPort(dut.get_force_input_port().get_index(),
+                        Vector1d(force));
+
+  EXPECT_EQ(dut.get_output_port(0)
+                .Eval<lcmt_schunk_wsg_status>(*context)
+                .actual_force,
+            force);
 }
 
 }  // namespace

--- a/manipulation/schunk_wsg/test/schunk_wsg_position_controller_test.cc
+++ b/manipulation/schunk_wsg/test/schunk_wsg_position_controller_test.cc
@@ -69,8 +69,8 @@ GTEST_TEST(SchunkWsgControllerTest, SchunkWsgControllerTest) {
       diagram->GetMutableSubsystemContext(*controller, &context);
 
   // Start off with the gripper closed (zero) and a command to open to
-  // 50mm.
-  double desired_position = 0.05;
+  // 100mm.
+  double desired_position = 0.1;
   double force_limit = 40;
   FixInputsAndHistory(*controller, desired_position, force_limit,
                       &controller_context);
@@ -91,7 +91,7 @@ GTEST_TEST(SchunkWsgControllerTest, SchunkWsgControllerTest) {
 
   // Check that we achieved the desired position.
   EXPECT_TRUE(CompareMatrices(
-      wsg_state, Vector4d(-desired_position, desired_position, 0.0, 0.0),
+      wsg_state, Vector4d(-desired_position/2, desired_position/2, 0.0, 0.0),
       kTolerance));
   // The steady-state force should be near zero.
   EXPECT_NEAR(controller->get_grip_force_output_port()
@@ -100,13 +100,13 @@ GTEST_TEST(SchunkWsgControllerTest, SchunkWsgControllerTest) {
               0.0, kTolerance);
 
   // Move in toward the middle of the range with lower force from the outside.
-  desired_position = 0.025;
+  desired_position = 0.05;
   force_limit = 20;
   FixInputsAndHistory(*controller, desired_position, force_limit,
                       &controller_context);
   simulator.StepTo(2.0);
   EXPECT_TRUE(CompareMatrices(
-      wsg_state, Vector4d(-desired_position, desired_position, 0.0, 0.0),
+      wsg_state, Vector4d(-desired_position/2, desired_position/2, 0.0, 0.0),
       kTolerance));
   // The steady-state force should be near zero.
   EXPECT_NEAR(controller->get_grip_force_output_port()
@@ -115,7 +115,7 @@ GTEST_TEST(SchunkWsgControllerTest, SchunkWsgControllerTest) {
               0.0, kTolerance);
 
   // Move to more than closed, and see that the force is at the limit.
-  desired_position = -0.5;
+  desired_position = -1.0;
   force_limit = 20;
   FixInputsAndHistory(*controller, desired_position, force_limit,
                       &controller_context);
@@ -126,7 +126,7 @@ GTEST_TEST(SchunkWsgControllerTest, SchunkWsgControllerTest) {
               force_limit, kTolerance);
 
   // Set the position to the target and observe zero force.
-  wsg_state = Vector4d(-desired_position, desired_position, 0.0, 0.0);
+  wsg_state = Vector4d(-desired_position/2, desired_position/2, 0.0, 0.0);
 
   EXPECT_EQ(controller->get_grip_force_output_port()
                 .Eval<BasicVector<double>>(controller_context)

--- a/manipulation/schunk_wsg/test/schunk_wsg_trajectory_generator_test.cc
+++ b/manipulation/schunk_wsg/test/schunk_wsg_trajectory_generator_test.cc
@@ -32,7 +32,7 @@ GTEST_TEST(SchunkWsgTrajectoryGeneratorTest, BasicTest) {
 
   // Step a little bit. We should be commanding a point on the
   // trajectory wider than zero, but not to the target yet.
-  const double expected_target = -0.1;  // 100mm
+  const double expected_target = -0.05;  // 50mm
   systems::Simulator<double> simulator(dut, std::move(context));
   simulator.StepTo(0.1);
   dut.CalcOutput(simulator.get_context(), output.get());


### PR DESCRIPTION
updates and disentangles the status sender from the simulation implementation details

gets rid of the factor of two from the WSG signals
Previously, the messages used "distance between fingers" and the drake signals used "distance to the left finger from center" -- sometimes the negative of that distance, sometimes not.

deprecates old interfaces that were part of the public API instead of deleting them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9818)
<!-- Reviewable:end -->
