### PR TITLE
Resolves potential linking error in python bindings

### DIFF
--- a/geometry/internal_frame.cc
+++ b/geometry/internal_frame.cc
@@ -1,10 +1,10 @@
 #include "drake/geometry/internal_frame.h"
 
+#include "drake/common/never_destroyed.h"
+
 namespace drake {
 namespace geometry {
 namespace internal {
-
-const FrameId InternalFrame::kWorldFrame{FrameId::get_new_id()};
 
 InternalFrame::InternalFrame() {}
 
@@ -28,6 +28,11 @@ bool InternalFrame::operator==(const InternalFrame& other) const {
 
 bool InternalFrame::operator!=(const InternalFrame& other) const {
   return !(*this == other);
+}
+
+FrameId InternalFrame::world_frame_id() {
+  static const never_destroyed<FrameId> kWorldFrame{FrameId::get_new_id()};
+  return kWorldFrame.access();
 }
 
 }  // namespace internal

--- a/geometry/internal_frame.h
+++ b/geometry/internal_frame.h
@@ -144,7 +144,7 @@ class InternalFrame {
    instances of SceneGraph. The world frame will eventually have an arbitrary
    number of child frames and geometries; but there will always only be one
    world frame.  */
-  static FrameId world_frame_id() { return kWorldFrame; }
+  static FrameId world_frame_id();
 
   /** Reports the reserved frame group for the world frame.  */
   static int world_frame_group() {
@@ -198,9 +198,6 @@ class InternalFrame {
   // that were hung on geometries that were already rigidly affixed.
   // It does *not* include geometries hung on child frames.
   std::unordered_set<GeometryId> child_geometries_;
-
-  // The frame identifier of the world frame.
-  static const FrameId kWorldFrame;
 };
 
 }  // namespace internal


### PR DESCRIPTION
Move the static world frame id into function static -- this eliminates ODR problems based on how python bindings are articulated and combined.

(Came up in PR 9796).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9820)
<!-- Reviewable:end -->
