### PR TITLE
Resolve ODR issues with manipulation_station example

### DIFF
--- a/bindings/pydrake/examples/BUILD.bazel
+++ b/bindings/pydrake/examples/BUILD.bazel
@@ -63,7 +63,6 @@ drake_pybind_library(
     name = "manipulation_station_py",
     cc_deps = [
         "//bindings/pydrake:documentation_pybind",
-        "//examples/manipulation_station",
     ],
     cc_srcs = ["manipulation_station_py.cc"],
     package_info = PACKAGE_INFO,

--- a/tools/install/libdrake/build_components.bzl
+++ b/tools/install/libdrake/build_components.bzl
@@ -46,6 +46,7 @@ LIBDRAKE_COMPONENTS = [
     "//common/trajectories",
     "//common:drake_marker_shared_library",  # unpackaged
     "//common:text_logging_gflags_h",  # unpackaged
+    "//examples/manipulation_station:manipulation_station",  # unpackaged
     "//geometry",
     "//geometry/dev",
     "//geometry/dev/render",

--- a/tools/install/libdrake/build_components_refresh.py
+++ b/tools/install/libdrake/build_components_refresh.py
@@ -30,12 +30,18 @@ def _bazel_query(args):
 
 def _find_libdrake_components():
     # This forms the set of cc_library targets that will be installed.
+    # TODO(russt/eric-cousineau/jwnimmer): Remove any examples from
+    # libdrake.so, pending resolution of #9648.
     components_query = """
 kind("cc_library", visible("//tools/install/libdrake:libdrake.so", "//..."))
     except(attr("testonly", "1", "//..."))
     except("//:*")
     except("//bindings/pydrake/...")
-    except("//examples/...")
+    except(
+      "//examples/..." except(
+        "//examples/manipulation_station/..."
+      )
+    )
     except("//lcmtypes/...")
     except("//tools/install/libdrake:*")
     except(attr(tags, "exclude_from_libdrake", //...))


### PR DESCRIPTION
by including manipulation_station targets, and their dependencies, in libdrake.so.  
we consider this a temporary, and very imperfect, solution until in-tree examples can produce their own bindings w/o going through libdrake.so.  (see #9648)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9826)
<!-- Reviewable:end -->
