### PR TITLE
libdrake: Install code from dev folders

### DIFF
--- a/tools/install/libdrake/build_components.bzl
+++ b/tools/install/libdrake/build_components.bzl
@@ -38,6 +38,7 @@ LIBDRAKE_COMPONENTS = [
     "//automotive/maliput/geometry_base",
     "//automotive/maliput/multilane",
     "//automotive/maliput/rndf",
+    "//automotive/maliput/simple_phase_provider",
     "//automotive/maliput/simplerulebook",
     "//automotive/maliput/utility",
     "//common",
@@ -46,8 +47,12 @@ LIBDRAKE_COMPONENTS = [
     "//common:drake_marker_shared_library",  # unpackaged
     "//common:text_logging_gflags_h",  # unpackaged
     "//geometry",
+    "//geometry/dev",
+    "//geometry/dev/render",
+    "//geometry/dev/render/shaders",
     "//geometry/query_results",
     "//lcm",
+    "//manipulation/dev:remote_tree_viewer_wrapper",  # unpackaged
     "//manipulation/perception",
     "//manipulation/planner",
     "//manipulation/scene_generation:random_clutter_generator",  # unpackaged
@@ -84,6 +89,7 @@ LIBDRAKE_COMPONENTS = [
     "//systems/rendering",
     "//systems/robotInterfaces",
     "//systems/sensors",
+    "//systems/sensors/dev",
     "//systems/trajectory_optimization",
     "//util",
 ]

--- a/tools/install/libdrake/build_components_refresh.py
+++ b/tools/install/libdrake/build_components_refresh.py
@@ -10,15 +10,6 @@ import subprocess
 import sys
 
 
-def _is_dev(label):
-    return "/dev:" in label or "/dev/" in label
-
-
-def _remove_dev(components):
-    # Filter out components that are in a dev (unsupported) package.
-    return [x for x in components if not _is_dev(x)]
-
-
 def _label_sort_key(label):
     # How to compare labels (lexicographically by subpackage names).
     return label.split("/")
@@ -64,7 +55,6 @@ kind("cc_library", visible("//tools/install/libdrake:libdrake.so", "//..."))
             "except deps({}, 1)".format(x)
             for x in package_libs
         ])])
-    misc_libs = _remove_dev(misc_libs)
     # Sort the result for consistency.
     return sorted(package_libs + misc_libs, key=_label_sort_key)
 

--- a/tools/lint/install_lint.bzl
+++ b/tools/lint/install_lint.bzl
@@ -11,10 +11,6 @@ def install_lint(
         existing_rules = native.existing_rules().values()
     package_name = "//" + native.package_name()  # e.g., "//systems/framework"
 
-    # This linter does not apply to 'dev' code (it is never installed).
-    if "/dev/" in package_name or package_name.endswith("/dev"):
-        return
-
     # For each rule tagged as "install", find a dependency chain from
     # //:install that reaches it. When there is no such chain, it is likely
     # that the developer forgot to list their package in the install.


### PR DESCRIPTION
Any dev packages that have public visibility were already available for downstream use, when compiling using Bazel.  If we want to prevent external use of certain Drake code, then we should do that using the Bazel visibility attribute, not a folder name heuristic.

The same reasoning will probably apply to the examples folders (though perhaps in a slightly modified form), but for expediency this PR only deals with the `dev` change, not touching `examples` yet.

Relates #9826.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9830)
<!-- Reviewable:end -->
