### PR TITLE
Add meshcat visualizer via python bindings

### DIFF
--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -223,6 +223,17 @@ drake_py_unittest(
     ],
 )
 
+drake_py_library(
+    name = "meshcat_visualizer_py",
+    srcs = ["meshcat_visualizer.py"],
+    imports = PACKAGE_INFO.py_imports,
+    deps = [
+        ":module_py",
+        "//lcmtypes:lcmtypes_py",
+        "@meshcat_python//:meshcat",
+    ],
+)
+
 PY_LIBRARIES_WITH_INSTALL = [
     ":analysis_py",
     ":controllers_py",
@@ -236,6 +247,7 @@ PY_LIBRARIES_WITH_INSTALL = [
 
 PY_LIBRARIES = [
     ":drawing_py",
+    ":meshcat_visualizer_py",
     ":scalar_conversion_py",
     ":module_py",
 ]
@@ -345,6 +357,18 @@ drake_py_unittest(
         "//bindings/pydrake/examples:pendulum_py",
         "//bindings/pydrake/multibody:multibody_tree_py",
         "//bindings/pydrake/multibody:rigid_body_tree_py",
+    ],
+)
+
+drake_py_unittest(
+    name = "meshcat_visualizer_test",
+    deps = [
+        ":analysis_py",
+        ":framework_py",
+        ":meshcat_visualizer_py",
+        ":test_util_py",
+        "//bindings/pydrake:geometry_py",
+        "//bindings/pydrake/multibody",
     ],
 )
 

--- a/bindings/pydrake/systems/all.py
+++ b/bindings/pydrake/systems/all.py
@@ -2,6 +2,7 @@ from .analysis import *
 from .controllers import *
 from .framework import *
 from .lcm import *
+from .meshcat_visualizer import *
 from .primitives import *
 from .rendering import *
 from .scalar_conversion import *

--- a/bindings/pydrake/systems/meshcat_visualizer.py
+++ b/bindings/pydrake/systems/meshcat_visualizer.py
@@ -1,0 +1,154 @@
+"""
+Provides utilities for communicating with the browser-based visualization
+package, Meshcat:
+      https://github.com/rdeits/meshcat
+"""
+import math
+
+from pydrake.util.eigen_geometry import Quaternion
+from pydrake.geometry import DispatchLoadMessage, SceneGraph
+from pydrake.lcm import DrakeMockLcm
+from pydrake.math import RigidTransform, RotationMatrix
+from pydrake.systems.framework import LeafSystem, PortDataType
+
+from drake import lcmt_viewer_load_robot
+
+import meshcat
+import meshcat.transformations as tf
+
+
+def Rgb2Hex(rgb):
+    """ Turn a list of R,G,B elements (any indexable list of >= 3 elements
+    will work), where each element is specified on range [0., 1.], into the
+    equivalent 24-bit value 0xRRGGBB. """
+    val = 0
+    for i in range(3):
+        val += (256**(2 - i)) * int(255 * rgb[i])
+    return val
+
+
+class MeshcatVisualizer(LeafSystem):
+    """
+    MeshcatVisualizer is a System block that connects to the pose bundle output
+    port of a SceneGraph and visualizes the scene in Meshcat.
+
+    The most common workflow would be to run
+    `bazel run @meshcat_python//:meshcat-server`
+    in another terminal, open the url printed in that terminal in your
+    browser, then to run drake apps (potentially many times) that publish to
+    that default url.
+
+    Note that you *must* manually call the load() method after the
+    SceneGraph has been finalized.
+    """
+
+    def __init__(self,
+                 scene_graph,
+                 draw_period=0.033333,
+                 prefix="drake",
+                 zmq_url="tcp://127.0.0.1:6000"):
+        """
+        Args:
+            scene_graph: A SceneGraph object.
+            draw_period: The rate at which this class publishes to the
+                visualizer.
+            prefix: Appears as the root of the tree structure in the meshcat
+                data structure
+            zmq_url: Optionally set a non-default url to connect to the
+                visualizer.  The default value is the url obtained by
+                running `meshcat-server` in another terminal.  If
+                zmp_url=None, then then a new server will be automatically
+                started (as a child of this process).
+        """
+        LeafSystem.__init__(self)
+
+        self.set_name('meshcat_visualizer')
+        self._DeclarePeriodicPublish(draw_period, 0.0)
+
+        # Pose bundle (from SceneGraph) input port.
+        self._DeclareInputPort("lcm_visualization",
+                               PortDataType.kAbstractValued, 0)
+
+        # Set up meshcat.
+        self.prefix = prefix
+        print("Connecting to meshcat-server...")
+        self.vis = meshcat.Visualizer(zmq_url=zmq_url)
+        print("Connected.")
+        self.vis[self.prefix].delete()
+        self._scene_graph = scene_graph
+
+    def load(self):
+        """
+        Loads `meshcat` visualization elements.
+        @pre The `scene_graph` used to construct this object must be part of a
+        fully constructed diagram (e.g. via `DiagramBuilder.Build()`).
+        """
+        # TODO(russt): Declare an initialization event to publish this
+        # pending resolution of #9842.
+
+        # Intercept load message via mock LCM.
+        mock_lcm = DrakeMockLcm()
+        DispatchLoadMessage(self._scene_graph, mock_lcm)
+        load_robot_msg = lcmt_viewer_load_robot.decode(
+            mock_lcm.get_last_published_message("DRAKE_VIEWER_LOAD_ROBOT"))
+        # Translate elements to `meshcat`.
+        for i in range(load_robot_msg.num_links):
+            link = load_robot_msg.link[i]
+            [source_name, frame_name] = link.name.split("::")
+
+            for j in range(link.num_geom):
+                geom = link.geom[j]
+                element_local_tf = RigidTransform(
+                    RotationMatrix(Quaternion(geom.quaternion)),
+                    geom.position).GetAsMatrix4()
+
+                if geom.type == geom.BOX:
+                    assert geom.num_float_data == 3
+                    meshcat_geom = meshcat.geometry.Box(geom.float_data)
+                elif geom.type == geom.SPHERE:
+                    assert geom.num_float_data == 1
+                    meshcat_geom = meshcat.geometry.Sphere(geom.float_data[0])
+                elif geom.type == geom.CYLINDER:
+                    assert geom.num_float_data == 2
+                    meshcat_geom = meshcat.geometry.Cylinder(
+                        geom.float_data[1],
+                        geom.float_data[0])
+                    # In Drake, cylinders are along +z
+                    # In meshcat, cylinders are along +y
+                    # Rotate to fix this misalignment
+                    extra_rotation = tf.rotation_matrix(
+                        math.pi/2., [1, 0, 0])
+                    element_local_tf[0:3, 0:3] = \
+                        element_local_tf[0:3, 0:3].dot(
+                            extra_rotation[0:3, 0:3])
+                elif geom.type == geom.MESH:
+                    meshcat_geom = \
+                        meshcat.geometry.ObjMeshGeometry.from_file(
+                            geom.string_data[0:-3] + "obj")
+                else:
+                    print "UNSUPPORTED GEOMETRY TYPE ", \
+                        geom.type, " IGNORED"
+                    continue
+
+                self.vis[self.prefix][source_name][str(link.robot_num)][
+                    frame_name][str(j)]\
+                    .set_object(meshcat_geom,
+                                meshcat.geometry
+                                .MeshLambertMaterial(
+                                    color=Rgb2Hex(geom.color)))
+                self.vis[self.prefix][source_name][str(link.robot_num)][
+                    frame_name][str(j)].set_transform(element_local_tf)
+
+    def _DoPublish(self, context, event):
+        pose_bundle = self.EvalAbstractInput(context, 0).get_value()
+
+        for frame_i in range(pose_bundle.get_num_poses()):
+            # SceneGraph currently sets the name in PoseBundle as
+            #    "get_source_name::frame_name".
+            [source_name, frame_name] = pose_bundle.get_name(frame_i)\
+                .split("::")
+            model_id = pose_bundle.get_model_instance_id(frame_i)
+            # The MBP parsers only register the plant as a nameless source.
+            # TODO(russt): Use a more textual naming convention here?
+            self.vis[self.prefix][source_name][str(model_id)][frame_name]\
+                .set_transform(pose_bundle.get_pose(frame_i).matrix())

--- a/bindings/pydrake/systems/test/meshcat_visualizer_test.py
+++ b/bindings/pydrake/systems/test/meshcat_visualizer_test.py
@@ -1,0 +1,98 @@
+import numpy as np
+import unittest
+import subprocess
+
+from pydrake.common import FindResourceOrThrow
+from pydrake.geometry import (DispatchLoadMessage, SceneGraph)
+from pydrake.multibody.multibody_tree import UniformGravityFieldElement
+from pydrake.multibody.multibody_tree.multibody_plant import MultibodyPlant
+from pydrake.multibody.multibody_tree.parsing import AddModelFromSdfFile
+from pydrake.systems.analysis import Simulator
+from pydrake.systems.framework import DiagramBuilder
+from pydrake.systems.meshcat_visualizer import MeshcatVisualizer
+
+
+class TestMeshcat(unittest.TestCase):
+    # Cart-Pole with simple geometry.
+    def cartPoleTest(self):
+        file_name = FindResourceOrThrow(
+            "drake/examples/multibody/cart_pole/cart_pole.sdf")
+
+        builder = DiagramBuilder()
+        scene_graph = builder.AddSystem(SceneGraph())
+        cart_pole = builder.AddSystem(MultibodyPlant())
+        AddModelFromSdfFile(
+            file_name=file_name, plant=cart_pole, scene_graph=scene_graph)
+        cart_pole.AddForceElement(UniformGravityFieldElement([0, 0, -9.81]))
+        cart_pole.Finalize(scene_graph)
+        assert cart_pole.geometry_source_is_registered()
+
+        builder.Connect(
+            cart_pole.get_geometry_poses_output_port(),
+            scene_graph.get_source_pose_port(cart_pole.get_source_id()))
+
+        visualizer = builder.AddSystem(MeshcatVisualizer(scene_graph,
+                                                         zmq_url=None))
+        builder.Connect(scene_graph.get_pose_bundle_output_port(),
+                        visualizer.get_input_port(0))
+
+        diagram = builder.Build()
+        visualizer.load()
+
+        diagram_context = diagram.CreateDefaultContext()
+        cart_pole_context = diagram.GetMutableSubsystemContext(
+            cart_pole, diagram_context)
+
+        cart_pole_context.FixInputPort(
+            cart_pole.get_actuation_input_port().get_index(), [0])
+
+        cart_slider = cart_pole.GetJointByName("CartSlider")
+        pole_pin = cart_pole.GetJointByName("PolePin")
+        cart_slider.set_translation(context=cart_pole_context, translation=0.)
+        pole_pin.set_angle(context=cart_pole_context, angle=2.)
+
+        simulator = Simulator(diagram, diagram_context)
+        simulator.set_publish_every_time_step(False)
+        simulator.set_target_realtime_rate(args.target_realtime_rate)
+        simulator.Initialize()
+        simulator.StepTo(args.duration)
+
+    # Kuka IIWA with mesh geometry.
+    def kukaTest(args):
+        file_name = FindResourceOrThrow(
+            "drake/manipulation/models/iiwa_description/sdf/"
+            "iiwa14_no_collision.sdf")
+        builder = DiagramBuilder()
+        scene_graph = builder.AddSystem(SceneGraph())
+        kuka = builder.AddSystem(MultibodyPlant())
+        AddModelFromSdfFile(
+            file_name=file_name, plant=kuka, scene_graph=scene_graph)
+        kuka.AddForceElement(UniformGravityFieldElement([0, 0, -9.81]))
+        kuka.Finalize(scene_graph)
+        assert kuka.geometry_source_is_registered()
+
+        builder.Connect(
+            kuka.get_geometry_poses_output_port(),
+            scene_graph.get_source_pose_port(kuka.get_source_id()))
+
+        visualizer = builder.AddSystem(MeshcatVisualizer(scene_graph,
+                                                         zmq_url=None))
+        builder.Connect(scene_graph.get_pose_bundle_output_port(),
+                        visualizer.get_input_port(0))
+
+        diagram = builder.Build()
+        visualizer.load()
+
+        diagram_context = diagram.CreateDefaultContext()
+        kuka_context = diagram.GetMutableSubsystemContext(
+            kuka, diagram_context)
+
+        kuka_context.FixInputPort(
+            kuka.get_actuation_input_port().get_index(), np.zeros(
+                kuka.get_actuation_input_port().size()))
+
+        simulator = Simulator(diagram, diagram_context)
+        simulator.set_publish_every_time_step(False)
+        simulator.set_target_realtime_rate(args.target_realtime_rate)
+        simulator.Initialize()
+        simulator.StepTo(args.duration)


### PR DESCRIPTION
The functionality (and the unit test I've provided) requires 
```
sudo pip install meshcat
```
Can we add that to `install_prerequisites.sh` ?  (I don't see any pip entries in there now)
Or can/should we make the test run only conditionally.... if the prereq exists?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9833)
<!-- Reviewable:end -->
