### PR TITLE
mbp: Propagate de-beetlejuicing

### DIFF
--- a/bindings/pydrake/examples/multibody/cart_pole_passive_simulation.py
+++ b/bindings/pydrake/examples/multibody/cart_pole_passive_simulation.py
@@ -33,10 +33,10 @@ def main():
     builder = DiagramBuilder()
     scene_graph = builder.AddSystem(SceneGraph())
     cart_pole = builder.AddSystem(MultibodyPlant(time_step=args.time_step))
-    AddModelFromSdfFile(
-        file_name=file_name, plant=cart_pole, scene_graph=scene_graph)
+    cart_pole.RegisterAsSourceForSceneGraph(scene_graph)
+    AddModelFromSdfFile(file_name=file_name, plant=cart_pole)
     cart_pole.AddForceElement(UniformGravityFieldElement([0, 0, -9.81]))
-    cart_pole.Finalize(scene_graph)
+    cart_pole.Finalize()
     assert cart_pole.geometry_source_is_registered()
 
     builder.Connect(

--- a/bindings/pydrake/manipulation/test/planner_test.py
+++ b/bindings/pydrake/manipulation/test/planner_test.py
@@ -65,8 +65,7 @@ class TestPlanner(unittest.TestCase):
         file_name = FindResourceOrThrow(
             "drake/multibody/benchmarks/acrobot/acrobot.sdf")
         plant = MultibodyPlant()
-        AddModelFromSdfFile(
-            file_name=file_name, plant=plant, scene_graph=None)
+        AddModelFromSdfFile(file_name=file_name, plant=plant)
         plant.Finalize()
 
         context = plant.CreateDefaultContext()

--- a/bindings/pydrake/manipulation/test/simple_ui_test.py
+++ b/bindings/pydrake/manipulation/test/simple_ui_test.py
@@ -19,7 +19,7 @@ class TestSimpleUI(unittest.TestCase):
         file_name = FindResourceOrThrow(
             "drake/multibody/benchmarks/acrobot/acrobot.sdf")
         plant = MultibodyPlant()
-        AddModelFromSdfFile(file_name=file_name, plant=plant, scene_graph=None)
+        AddModelFromSdfFile(file_name=file_name, plant=plant)
         plant.Finalize()
 
         slider = JointSliders(robot=plant, lower_limit=-5., upper_limit=5.,

--- a/bindings/pydrake/multibody/test/inverse_kinematics_test.py
+++ b/bindings/pydrake/multibody/test/inverse_kinematics_test.py
@@ -27,7 +27,7 @@ class TestInverseKinematics(unittest.TestCase):
             "drake/bindings/pydrake/multibody/test/two_bodies.sdf")
         self.plant = MultibodyPlant(time_step=0.01)
         model_instance = AddModelFromSdfFile(
-            file_name=file_name, plant=self.plant, scene_graph=None)
+            file_name=file_name, plant=self.plant)
         self.plant.Finalize()
         self.body1_frame = self.plant.GetBodyByName("body1").body_frame()
         self.body2_frame = self.plant.GetBodyByName("body2").body_frame()

--- a/bindings/pydrake/multibody/test/multibody_tree_test.py
+++ b/bindings/pydrake/multibody/test/multibody_tree_test.py
@@ -113,7 +113,7 @@ class TestMultibodyTree(unittest.TestCase):
             "drake/multibody/benchmarks/acrobot/acrobot.sdf")
         plant = MultibodyPlant(time_step=0.01)
         model_instance = AddModelFromSdfFile(
-            file_name=file_name, plant=plant, scene_graph=None)
+            file_name=file_name, plant=plant)
         self.assertIsInstance(model_instance, ModelInstanceIndex)
         plant.Finalize()
         benchmark = MakeAcrobotPlant(AcrobotParameters(), True)
@@ -213,13 +213,12 @@ class TestMultibodyTree(unittest.TestCase):
             "drake/multibody/benchmarks/acrobot/acrobot.sdf")
         plant = MultibodyPlant(time_step=0.01)
         model_instance = AddModelFromSdfFile(
-            file_name=file_name, plant=plant, scene_graph=None)
+            file_name=file_name, plant=plant)
         self.assertIsInstance(model_instance, ModelInstanceIndex)
 
         plant = MultibodyPlant(time_step=0.01)
         model_instance = AddModelFromSdfFile(
-            file_name=file_name, model_name="acrobot", plant=plant,
-            scene_graph=None)
+            file_name=file_name, model_name="acrobot", plant=plant)
 
     def test_multibody_tree_kinematics(self):
         file_name = FindResourceOrThrow(
@@ -327,11 +326,9 @@ class TestMultibodyTree(unittest.TestCase):
         plant = MultibodyPlant(timestep)
 
         iiwa_model = AddModelFromSdfFile(
-            file_name=iiwa_sdf_path, model_name='robot',
-            scene_graph=None, plant=plant)
+            file_name=iiwa_sdf_path, model_name='robot', plant=plant)
         gripper_model = AddModelFromSdfFile(
-            file_name=wsg50_sdf_path, model_name='gripper',
-            scene_graph=None, plant=plant)
+            file_name=wsg50_sdf_path, model_name='gripper', plant=plant)
 
         # Weld the base of arm and gripper to reduce the number of states.
         X_EeGripper = Isometry3.Identity()

--- a/bindings/pydrake/systems/drawing_graphviz_example.py
+++ b/bindings/pydrake/systems/drawing_graphviz_example.py
@@ -24,10 +24,10 @@ file_name = FindResourceOrThrow(
 builder = DiagramBuilder()
 scene_graph = builder.AddSystem(SceneGraph())
 cart_pole = builder.AddSystem(MultibodyPlant())
-AddModelFromSdfFile(
-    file_name=file_name, plant=cart_pole, scene_graph=scene_graph)
+cart_pole.RegisterAsSourceForSceneGraph(scene_graph)
+AddModelFromSdfFile(file_name=file_name, plant=cart_pole)
 cart_pole.AddForceElement(UniformGravityFieldElement([0, 0, -9.81]))
-cart_pole.Finalize(scene_graph)
+cart_pole.Finalize()
 assert cart_pole.geometry_source_is_registered()
 
 builder.Connect(

--- a/examples/allegro_hand/joint_control/allegro_single_object_simulation.cc
+++ b/examples/allegro_hand/joint_control/allegro_single_object_simulation.cc
@@ -64,6 +64,7 @@ void DoMain() {
 
   MultibodyPlant<double>& plant =
       *builder.AddSystem<MultibodyPlant>(FLAGS_max_time_step);
+  plant.RegisterAsSourceForSceneGraph(&scene_graph);
   std::string hand_model_path;
   if (FLAGS_use_right_hand)
     hand_model_path = FindResourceOrThrow(
@@ -76,10 +77,8 @@ void DoMain() {
 
   const std::string object_model_path = FindResourceOrThrow(
       "drake/examples/allegro_hand/joint_control/simple_mug.sdf");
-  multibody::parsing::AddModelFromSdfFile(hand_model_path, &plant,
-                                          &scene_graph);
-  multibody::parsing::AddModelFromSdfFile(object_model_path, &plant,
-                                          &scene_graph);
+  multibody::parsing::AddModelFromSdfFile(hand_model_path, &plant);
+  multibody::parsing::AddModelFromSdfFile(object_model_path, &plant);
 
   // Weld the hand to the world frame
   const auto& joint_hand_root = plant.GetBodyByName("hand_root");
@@ -93,7 +92,7 @@ void DoMain() {
         -9.81 * Eigen::Vector3d::UnitZ());
 
   // Finished building the plant
-  plant.Finalize(&scene_graph);
+  plant.Finalize();
 
   // Visualization
   geometry::ConnectDrakeVisualizer(&builder, scene_graph);

--- a/examples/allegro_hand/run_allegro_constant_load_demo.cc
+++ b/examples/allegro_hand/run_allegro_constant_load_demo.cc
@@ -60,6 +60,7 @@ void DoMain() {
 
   MultibodyPlant<double>& plant = *builder.AddSystem<MultibodyPlant>
                                   (FLAGS_max_time_step);
+  plant.RegisterAsSourceForSceneGraph(&scene_graph);
   std::string full_name;
   if (FLAGS_use_right_hand)
     full_name = FindResourceOrThrow("drake/manipulation/models/"
@@ -68,8 +69,7 @@ void DoMain() {
     full_name = FindResourceOrThrow("drake/manipulation/models/"
       "allegro_hand_description/sdf/allegro_hand_description_left.sdf");
 
-  multibody::parsing::AddModelFromSdfFile(
-                          full_name, &plant, &scene_graph);
+  multibody::parsing::AddModelFromSdfFile(full_name, &plant);
 
   // Weld the hand to the world frame
   const auto& joint_hand_root = plant.GetBodyByName("hand_root");
@@ -82,7 +82,7 @@ void DoMain() {
         -9.81 * Eigen::Vector3d::UnitZ());
 
   // Now the model is complete.
-  plant.Finalize(&scene_graph);
+  plant.Finalize();
 
   DRAKE_DEMAND(plant.num_actuators() == 16);
   DRAKE_DEMAND(plant.num_actuated_dofs() == 16);

--- a/examples/kuka_iiwa_arm/controlled_kuka/controlled_kuka_multibody_demo.cc
+++ b/examples/kuka_iiwa_arm/controlled_kuka/controlled_kuka_multibody_demo.cc
@@ -63,7 +63,7 @@ int DoMain() {
       -9.81 * Vector3<double>::UnitZ());
 
   // Now the model is complete.
-  kuka_plant.Finalize(&scene_graph);
+  kuka_plant.Finalize();
   DRAKE_THROW_UNLESS(kuka_plant.num_positions() == 7);
   // Sanity check on the availability of the optional source id before using it.
   DRAKE_DEMAND(!!kuka_plant.get_source_id());

--- a/examples/manipulation_station/manipulation_station.cc
+++ b/examples/manipulation_station/manipulation_station.cc
@@ -114,6 +114,7 @@ ManipulationStation<T>::ManipulationStation(double time_step)
   // the raw pointers, which should stay valid for the lifetime of the Diagram.
   plant_ = owned_plant_.get();
   scene_graph_ = owned_scene_graph_.get();
+  plant_->RegisterAsSourceForSceneGraph(scene_graph_);
 
   // Add the table and 80/20 workcell frame.
   const double dx_table_center_to_robot_base = 0.3257;
@@ -121,7 +122,7 @@ ManipulationStation<T>::ManipulationStation(double time_step)
   const std::string table_sdf_path = FindResourceOrThrow(
       "drake/examples/manipulation_station/models/amazon_table_simplified.sdf");
   const auto table =
-      AddModelFromSdfFile(table_sdf_path, "table", plant_, scene_graph_);
+      AddModelFromSdfFile(table_sdf_path, "table", plant_);
   plant_->WeldFrames(
       plant_->world_frame(), plant_->GetFrameByName("amazon_table", table),
       RigidTransform<double>(
@@ -133,7 +134,7 @@ ManipulationStation<T>::ManipulationStation(double time_step)
       "drake/manipulation/models/iiwa_description/"
       "sdf/iiwa14_no_collision.sdf");
   iiwa_model_ =
-      AddModelFromSdfFile(iiwa_sdf_path, "iiwa", plant_, scene_graph_);
+      AddModelFromSdfFile(iiwa_sdf_path, "iiwa", plant_);
   plant_->WeldFrames(plant_->world_frame(),
                      plant_->GetFrameByName("iiwa_link_0", iiwa_model_));
 
@@ -142,7 +143,7 @@ ManipulationStation<T>::ManipulationStation(double time_step)
       "drake/manipulation/models/"
       "wsg_50_description/sdf/schunk_wsg_50.sdf");
   wsg_model_ =
-      AddModelFromSdfFile(wsg_sdf_path, "gripper", plant_, scene_graph_);
+      AddModelFromSdfFile(wsg_sdf_path, "gripper", plant_);
   const Isometry3d wsg_pose =
       RigidTransform<double>(
           RollPitchYaw<double>(M_PI_2, 0, M_PI_2).ToRotationMatrix(),
@@ -191,7 +192,7 @@ void ManipulationStation<T>::AddCupboard() {
   const std::string sdf_path = FindResourceOrThrow(
       "drake/examples/manipulation_station/models/cupboard.sdf");
   const auto cupboard =
-      AddModelFromSdfFile(sdf_path, "cupboard", plant_, scene_graph_);
+      AddModelFromSdfFile(sdf_path, "cupboard", plant_);
   plant_->WeldFrames(
       plant_->world_frame(), plant_->GetFrameByName("cupboard_body", cupboard),
       RigidTransform<double>(
@@ -208,7 +209,7 @@ void ManipulationStation<T>::Finalize() {
   //   - cannot finalize plant until all of my objects are added, and
   //   - cannot wire up my diagram until we have finalized the plant.
 
-  plant_->Finalize(scene_graph_);
+  plant_->Finalize();
 
   systems::DiagramBuilder<T> builder;
 

--- a/examples/multibody/acrobot/run_lqr.cc
+++ b/examples/multibody/acrobot/run_lqr.cc
@@ -115,7 +115,7 @@ int do_main() {
       -9.81 * Vector3<double>::UnitZ());
 
   // We are done defining the model.
-  acrobot.Finalize(&scene_graph);
+  acrobot.Finalize();
 
   DRAKE_DEMAND(acrobot.num_actuators() == 1);
   DRAKE_DEMAND(acrobot.num_actuated_dofs() == 1);

--- a/examples/multibody/bouncing_ball/make_bouncing_ball_plant.cc
+++ b/examples/multibody/bouncing_ball/make_bouncing_ball_plant.cc
@@ -39,34 +39,33 @@ MakeBouncingBallPlant(double radius, double mass,
     // A half-space for the ground geometry.
     plant->RegisterCollisionGeometry(
         plant->world_body(), HalfSpace::MakePose(normal_W, point_W),
-        HalfSpace(), "collision", surface_friction, scene_graph);
+        HalfSpace(), "collision", surface_friction);
 
     // Add visual for the ground.
     plant->RegisterVisualGeometry(
         plant->world_body(), HalfSpace::MakePose(normal_W, point_W),
-        HalfSpace(), "visual", scene_graph);
+        HalfSpace(), "visual");
 
     // Add sphere geometry for the ball.
     plant->RegisterCollisionGeometry(
         ball,
         /* Pose X_BG of the geometry frame G in the ball frame B. */
         Isometry3<double>::Identity(), Sphere(radius), "collision",
-            surface_friction, scene_graph);
+            surface_friction);
 
     // Add visual for the ball.
     const VisualMaterial orange(Vector4<double>(1.0, 0.55, 0.0, 1.0));
     plant->RegisterVisualGeometry(
         ball,
         /* Pose X_BG of the geometry frame G in the ball frame B. */
-        Isometry3<double>::Identity(), Sphere(radius), "visual", orange,
-        scene_graph);
+        Isometry3<double>::Identity(), Sphere(radius), "visual", orange);
   }
 
   // Gravity acting in the -z direction.
   plant->AddForceElement<UniformGravityFieldElement>(gravity_W);
 
   // We are done creating the plant.
-  plant->Finalize(scene_graph);
+  plant->Finalize();
 
   return plant;
 }

--- a/examples/multibody/cart_pole/cart_pole_passive_simulation.cc
+++ b/examples/multibody/cart_pole/cart_pole_passive_simulation.cc
@@ -62,7 +62,7 @@ int do_main() {
       -9.81 * Vector3<double>::UnitZ());
 
   // Now the model is complete.
-  cart_pole.Finalize(&scene_graph);
+  cart_pole.Finalize();
 
   // Sanity check on the availability of the optional source id before using it.
   DRAKE_DEMAND(cart_pole.geometry_source_is_registered());

--- a/examples/multibody/cylinder_with_multicontact/make_cylinder_plant.cc
+++ b/examples/multibody/cylinder_with_multicontact/make_cylinder_plant.cc
@@ -21,8 +21,7 @@ using drake::multibody::UnitInertia;
 using Eigen::Isometry3d;
 
 void AddCylinderWithMultiContact(
-    MultibodyPlant<double>* plant, SceneGraph<double>* scene_graph,
-    const RigidBody<double>& body,
+    MultibodyPlant<double>* plant, const RigidBody<double>& body,
     double radius, double length, const CoulombFriction<double>& friction,
     double contact_spheres_radius, int num_contacts) {
   const VisualMaterial orange(Vector4<double>(1.0, 0.55, 0.0, 1.0));
@@ -32,8 +31,7 @@ void AddCylinderWithMultiContact(
   plant->RegisterVisualGeometry(
       body,
       /* Pose X_BG of the geometry frame G in the cylinder body frame B. */
-      Isometry3d::Identity(), Cylinder(radius, length), "visual", orange,
-      scene_graph);
+      Isometry3d::Identity(), Cylinder(radius, length), "visual", orange);
 
   // Add a bunch of little spheres to simulate "multi-contact".
   for (int i = 0; i < num_contacts; ++i) {
@@ -48,12 +46,11 @@ void AddCylinderWithMultiContact(
         body,
         X_BG,
         Sphere(contact_spheres_radius), "collision_top_" + std::to_string(i),
-        friction, scene_graph);
+        friction);
     plant->RegisterVisualGeometry(
         body,
         X_BG,
-        Sphere(contact_spheres_radius), "visual_top_" + std::to_string(i), red,
-        scene_graph);
+        Sphere(contact_spheres_radius), "visual_top_" + std::to_string(i), red);
 
     // Bottom spheres:
     X_BG.translation() << x, y, -length / 2;
@@ -61,12 +58,12 @@ void AddCylinderWithMultiContact(
         body,
         X_BG,
         Sphere(contact_spheres_radius), "collision_bottom_" + std::to_string(i),
-        friction, scene_graph);
+        friction);
     plant->RegisterVisualGeometry(
         body,
         X_BG,
         Sphere(contact_spheres_radius), "visual_bottom_" + std::to_string(i),
-        red, scene_graph);
+        red);
   }
 }
 
@@ -95,7 +92,7 @@ MakeCylinderPlant(double radius, double length, double mass,
 
   // Add geometry to the cylinder for both contact and visualization.
   AddCylinderWithMultiContact(
-      plant.get(), scene_graph,
+      plant.get(),
       cylinder, radius, length, surface_friction,
       contact_radius, num_contact_spheres);
 
@@ -107,17 +104,17 @@ MakeCylinderPlant(double radius, double length, double mass,
   plant->RegisterCollisionGeometry(
       plant->world_body(),
       HalfSpace::MakePose(normal_W, point_W), HalfSpace(), "collision",
-      surface_friction, scene_graph);
+      surface_friction);
 
   // Add visual for the ground.
   plant->RegisterVisualGeometry(
       plant->world_body(), HalfSpace::MakePose(normal_W, point_W),
-      HalfSpace(), "visual", scene_graph);
+      HalfSpace(), "visual");
 
   plant->AddForceElement<UniformGravityFieldElement>(gravity_W);
 
   // We are done creating the plant.
-  plant->Finalize(scene_graph);
+  plant->Finalize();
 
   return plant;
 }

--- a/multibody/benchmarks/acrobot/make_acrobot_plant.cc
+++ b/multibody/benchmarks/acrobot/make_acrobot_plant.cc
@@ -61,21 +61,19 @@ MakeAcrobotPlant(const AcrobotParameters& params, bool finalize,
     // Pose of the geometry for link 1 in the link's frame.
     const RigidTransformd X_L1G1(-params.l1() / 2.0 * Vector3d::UnitZ());
     plant->RegisterVisualGeometry(link1, X_L1G1.GetAsIsometry3(),
-                                  Cylinder(params.r1(), params.l1()), "visual",
-                                  scene_graph);
+                                  Cylinder(params.r1(), params.l1()), "visual");
 
     // Pose of the geometry for link 2 in the link's frame.
     const RigidTransformd X_L2G2(-params.l2() / 2.0 * Vector3d::UnitZ());
     plant->RegisterVisualGeometry(link2, X_L2G2.GetAsIsometry3(),
-                                  Cylinder(params.r2(), params.l2()), "visual",
-                                  scene_graph);
+                                  Cylinder(params.r2(), params.l2()), "visual");
 
     // Register some (anchored) geometry to the world.
     const RigidTransformd X_WG;  // Default is identity transform.
     plant->RegisterVisualGeometry(
         plant->world_body(), X_WG.GetAsIsometry3(),
         Sphere(params.l1() / 8.0), /* Arbitrary radius to decorate the model. */
-        "visual", scene_graph);
+        "visual");
   }
 
   plant->AddJoint<RevoluteJoint>(
@@ -105,7 +103,7 @@ MakeAcrobotPlant(const AcrobotParameters& params, bool finalize,
       -params.g() * Vector3d::UnitZ());
 
   // We are done creating the plant.
-  if (finalize) plant->Finalize(scene_graph);
+  if (finalize) plant->Finalize();
 
   return plant;
 }

--- a/multibody/benchmarks/inclined_plane/make_inclined_plane_plant.cc
+++ b/multibody/benchmarks/inclined_plane/make_inclined_plane_plant.cc
@@ -49,12 +49,12 @@ std::unique_ptr<MultibodyPlant<double>> MakeInclinedPlanePlant(
   // A half-space for the inclined plane geometry.
   plant->RegisterCollisionGeometry(
       plant->world_body(), HalfSpace::MakePose(normal_W, point_W), HalfSpace(),
-      "collision", surface_friction, scene_graph);
+      "collision", surface_friction);
 
   // Visual for the ground.
   plant->RegisterVisualGeometry(plant->world_body(),
                                 HalfSpace::MakePose(normal_W, point_W),
-                                HalfSpace(), "visual", scene_graph);
+                                HalfSpace(), "visual");
 
   // Add sphere geometry for the ball.
   // Pose X_BG of geometry frame G in the ball frame B is an identity transform.
@@ -62,13 +62,13 @@ std::unique_ptr<MultibodyPlant<double>> MakeInclinedPlanePlant(
   plant->RegisterCollisionGeometry(
       ball,
       X_BG.GetAsIsometry3(), Sphere(radius), "collision",
-      surface_friction, scene_graph);
+      surface_friction);
 
   // Visual for the ball.
   const VisualMaterial orange(Vector4<double>(1.0, 0.55, 0.0, 1.0));
   plant->RegisterVisualGeometry(
       ball,
-      X_BG.GetAsIsometry3(), Sphere(radius), "visual1", orange, scene_graph);
+      X_BG.GetAsIsometry3(), Sphere(radius), "visual1", orange);
 
   // Add little spherical spokes to highlight the sphere's rotation.
   const VisualMaterial red(Vector4<double>(1.0, 0.0, 0.0, 1.0));
@@ -76,29 +76,29 @@ std::unique_ptr<MultibodyPlant<double>> MakeInclinedPlanePlant(
       ball,
       // Pose of 1st spoke frame in the ball frame B.
       math::RigidTransformd(Vector3<double>(0, 0, radius)).GetAsIsometry3(),
-      Sphere(radius / 5), "visual2", red, scene_graph);
+      Sphere(radius / 5), "visual2", red);
   plant->RegisterVisualGeometry(
       ball,
       // Pose of 2nd spoke frame in the ball frame B.
       math::RigidTransformd(Vector3<double>(0, 0, -radius)).GetAsIsometry3(),
-      Sphere(radius / 5), "visual3", red, scene_graph);
+      Sphere(radius / 5), "visual3", red);
   plant->RegisterVisualGeometry(
       ball,
       // Pose of 3rd spoke frame in the ball frame B.
       math::RigidTransformd(Vector3<double>(radius, 0, 0)).GetAsIsometry3(),
-      Sphere(radius / 5), "visual4", red, scene_graph);
+      Sphere(radius / 5), "visual4", red);
   plant->RegisterVisualGeometry(
       ball,
       // Pose of 4th spoke frame in the ball frame B.
       math::RigidTransformd(Vector3<double>(-radius, 0, 0)).GetAsIsometry3(),
-      Sphere(radius / 5), "visual5", red, scene_graph);
+      Sphere(radius / 5), "visual5", red);
 
   // Gravity acting in the -z direction.
   plant->AddForceElement<UniformGravityFieldElement>(
       -gravity * Vector3<double>::UnitZ());
 
   // We are done creating the plant.
-  plant->Finalize(scene_graph);
+  plant->Finalize();
 
   return plant;
 }

--- a/multibody/benchmarks/pendulum/make_pendulum_plant.cc
+++ b/multibody/benchmarks/pendulum/make_pendulum_plant.cc
@@ -52,12 +52,12 @@ MakePendulumPlant(const PendulumParameters& params,
     const math::RigidTransformd X_BGs(-params.l() * Vector3d::UnitZ());
     plant->RegisterVisualGeometry(point_mass, X_BGs.GetAsIsometry3(),
                                   Sphere(params.point_mass_radius()),
-                                  params.body_name(), scene_graph);
+                                  params.body_name());
 
     // Pose of the cylinder used to visualize the massless rod in frame B.
     const math::RigidTransformd X_BGc(-params.l() / 2.0 * Vector3d::UnitZ());
     plant->RegisterVisualGeometry(point_mass, X_BGc.GetAsIsometry3(),
-        Cylinder(params.massless_rod_radius(), params.l()), "arm", scene_graph);
+        Cylinder(params.massless_rod_radius(), params.l()), "arm");
   }
 
   const RevoluteJoint<double>& pin = plant->AddJoint<RevoluteJoint>(
@@ -76,7 +76,7 @@ MakePendulumPlant(const PendulumParameters& params,
   plant->AddForceElement<UniformGravityFieldElement>(
       -params.g() * Vector3d::UnitZ());
 
-  plant->Finalize(scene_graph);
+  plant->Finalize();
 
   return plant;
 }

--- a/multibody/multibody_tree/multibody_plant/test/box_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/box_test.cc
@@ -74,7 +74,7 @@ GTEST_TEST(Box, UnderStiction) {
   plant.AddForceElement<UniformGravityFieldElement>(
       -g * Vector3<double>::UnitZ());
 
-  plant.Finalize(&scene_graph);  // Done creating the model.
+  plant.Finalize();  // Done creating the model.
 
   const MultibodyTree<double>& tree = plant.tree();
   // Set contact parameters.

--- a/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
@@ -270,7 +270,8 @@ class AcrobotPlantTests : public ::testing::Test {
     const std::string full_name = FindResourceOrThrow(
         "drake/multibody/benchmarks/acrobot/acrobot.sdf");
     plant_ = builder.AddSystem<MultibodyPlant>();
-    AddModelFromSdfFile(full_name, plant_, scene_graph_);
+    plant_->RegisterAsSourceForSceneGraph(scene_graph_);
+    AddModelFromSdfFile(full_name, plant_);
     // Add gravity to the model.
     plant_->AddForceElement<UniformGravityFieldElement>(
         -9.81 * Vector3<double>::UnitZ());
@@ -294,7 +295,7 @@ class AcrobotPlantTests : public ::testing::Test {
         "you must call Finalize\\(\\) first.");
 
     // Finalize() the plant.
-    plant_->Finalize(scene_graph_);
+    plant_->Finalize();
 
     // And build the Diagram:
     diagram_ = builder.Build();
@@ -709,8 +710,7 @@ class SphereChainScenario {
         plant_->world_body(),
         // A half-space passing through the origin in the x-z plane.
         geometry::HalfSpace::MakePose(Vector3d::UnitY(), Vector3d::Zero()),
-        geometry::HalfSpace(), "ground", CoulombFriction<double>(),
-        scene_graph_);
+        geometry::HalfSpace(), "ground", CoulombFriction<double>());
 
     auto make_sphere = [this](int i) {
       const double radius = 0.5;
@@ -718,12 +718,11 @@ class SphereChainScenario {
           "Sphere" + to_string(i), SpatialInertia<double>());
       GeometryId sphere_id = plant_->RegisterCollisionGeometry(
           sphere, Isometry3d::Identity(), geometry::Sphere(radius), "collision",
-          CoulombFriction<double>(), scene_graph_);
+          CoulombFriction<double>());
       // We add visual geometry to implicitly test that they are *not* included
       // in the collision results. We don't even save the ids for them.
       plant_->RegisterVisualGeometry(sphere, Isometry3d::Identity(),
-                                     geometry::Sphere(radius), "visual",
-                                     scene_graph_);
+                                     geometry::Sphere(radius), "visual");
       return std::make_tuple(&sphere, sphere_id);
     };
 
@@ -749,7 +748,7 @@ class SphereChainScenario {
                                               SpatialInertia<double>());
 
     // We are done defining the model.
-    plant_->Finalize(scene_graph_);
+    plant_->Finalize();
 
     builder.Connect(
         plant_->get_geometry_poses_output_port(),
@@ -978,7 +977,7 @@ GTEST_TEST(MultibodyPlantTest, CollisionGeometryRegistration) {
       plant.world_body(),
       // A half-space passing through the origin in the x-z plane.
       geometry::HalfSpace::MakePose(Vector3d::UnitY(), Vector3d::Zero()),
-      geometry::HalfSpace(), "ground", ground_friction, &scene_graph);
+      geometry::HalfSpace(), "ground", ground_friction);
 
   // Add two spherical bodies.
   const RigidBody<double>& sphere1 =
@@ -986,16 +985,16 @@ GTEST_TEST(MultibodyPlantTest, CollisionGeometryRegistration) {
   CoulombFriction<double> sphere1_friction(0.8, 0.5);
   GeometryId sphere1_id = plant.RegisterCollisionGeometry(
       sphere1, Isometry3d::Identity(), geometry::Sphere(radius),
-      "collision", sphere1_friction, &scene_graph);
+      "collision", sphere1_friction);
   const RigidBody<double>& sphere2 =
       plant.AddRigidBody("Sphere2", SpatialInertia<double>());
   CoulombFriction<double> sphere2_friction(0.7, 0.6);
   GeometryId sphere2_id = plant.RegisterCollisionGeometry(
       sphere2, Isometry3d::Identity(), geometry::Sphere(radius),
-      "collision", sphere2_friction, &scene_graph);
+      "collision", sphere2_friction);
 
   // We are done defining the model.
-  plant.Finalize(&scene_graph);
+  plant.Finalize();
 
   EXPECT_EQ(plant.num_visual_geometries(), 0);
   EXPECT_EQ(plant.num_collision_geometries(), 3);
@@ -1062,7 +1061,7 @@ GTEST_TEST(MultibodyPlantTest, VisualGeometryRegistration) {
       plant.world_body(),
       // A half-space passing through the origin in the x-z plane.
       geometry::HalfSpace::MakePose(Vector3d::UnitY(), Vector3d::Zero()),
-      geometry::HalfSpace(), "ground", &scene_graph);
+      geometry::HalfSpace(), "ground");
 
   // Add two spherical bodies.
   const RigidBody<double>& sphere1 =
@@ -1070,16 +1069,16 @@ GTEST_TEST(MultibodyPlantTest, VisualGeometryRegistration) {
   Vector4<double> sphere1_diffuse{0.9, 0.1, 0.1, 0.5};
   GeometryId sphere1_id = plant.RegisterVisualGeometry(
       sphere1, Isometry3d::Identity(), geometry::Sphere(radius),
-      "visual", VisualMaterial(sphere1_diffuse), &scene_graph);
+      "visual", VisualMaterial(sphere1_diffuse));
   const RigidBody<double>& sphere2 =
       plant.AddRigidBody("Sphere2", SpatialInertia<double>());
   Vector4<double> sphere2_diffuse{0.1, 0.9, 0.1, 0.5};
   GeometryId sphere2_id = plant.RegisterVisualGeometry(
       sphere2, Isometry3d::Identity(), geometry::Sphere(radius),
-      "visual", VisualMaterial(sphere2_diffuse), &scene_graph);
+      "visual", VisualMaterial(sphere2_diffuse));
 
   // We are done defining the model.
-  plant.Finalize(&scene_graph);
+  plant.Finalize();
 
   EXPECT_EQ(plant.num_visual_geometries(), 3);
   EXPECT_EQ(plant.num_collision_geometries(), 0);
@@ -1312,7 +1311,7 @@ GTEST_TEST(MultibodyPlantTest, ScalarConversionConstructor) {
       (MultibodyPlant<AutoDiffXd>(plant)), std::logic_error,
       ".*MultibodyTree with an invalid topology.*");
 
-  plant.Finalize(&scene_graph);
+  plant.Finalize();
 
   EXPECT_EQ(plant.num_bodies(), 4);  // It includes the world body.
   EXPECT_TRUE(plant.geometry_source_is_registered());
@@ -1385,17 +1384,17 @@ class MultibodyPlantContactJacobianTests : public ::testing::Test {
     large_box_id_ = plant_.RegisterCollisionGeometry(
         large_box, Isometry3d::Identity(),
         geometry::Box(large_box_size_, large_box_size_, large_box_size_),
-        "collision", CoulombFriction<double>(), &scene_graph_);
+        "collision", CoulombFriction<double>());
 
     const RigidBody<double>& small_box =
         plant_.AddRigidBody("SmallBox", SpatialInertia<double>());
     small_box_id_ = plant_.RegisterCollisionGeometry(
         small_box, Isometry3d::Identity(),
         geometry::Box(small_box_size_, small_box_size_, small_box_size_),
-        "collision", CoulombFriction<double>(), &scene_graph_);
+        "collision", CoulombFriction<double>());
 
     // We are done defining the model.
-    plant_.Finalize(&scene_graph_);
+    plant_.Finalize();
 
     // Some sanity checks before proceeding.
     ASSERT_EQ(plant_.num_collision_geometries(), 2);

--- a/multibody/multibody_tree/parsing/multibody_plant_sdf_parser.cc
+++ b/multibody/multibody_tree/parsing/multibody_plant_sdf_parser.cc
@@ -384,7 +384,7 @@ void AddLinksFromSpecification(
     const RigidBody<double>& body =
         plant->AddRigidBody(link.Name(), model_instance, M_BBo_B);
 
-    if (scene_graph != nullptr) {
+    if (plant->geometry_source_is_registered()) {
       for (uint64_t visual_index = 0; visual_index < link.VisualCount();
            ++visual_index) {
         const sdf::Visual sdf_visual = detail::ResolveVisualUri(

--- a/multibody/multibody_tree/parsing/multibody_plant_urdf_parser.cc
+++ b/multibody/multibody_tree/parsing/multibody_plant_urdf_parser.cc
@@ -121,7 +121,7 @@ void ParseBody(const PackageMap& package_map,
   const RigidBody<double>& body =
       plant->AddRigidBody(body_name, model_instance, M_BBo_B);
 
-  if (scene_graph != nullptr) {
+  if (plant->geometry_source_is_registered()) {
     for (XMLElement* visual_node = node->FirstChildElement("visual");
          visual_node;
          visual_node = visual_node->NextSiblingElement("visual")) {

--- a/multibody/multibody_tree/parsing/test/multibody_plant_sdf_parser_test.cc
+++ b/multibody/multibody_tree/parsing/test/multibody_plant_sdf_parser_test.cc
@@ -252,6 +252,31 @@ GTEST_TEST(SdfParser, IncludeTags) {
   EXPECT_TRUE(plant.HasJointNamed("weld_robots", weld_model));
 }
 
+GTEST_TEST(SdfParser, TestOptionalSceneGraph) {
+  const std::string full_name = FindResourceOrThrow(
+      "drake/multibody/multibody_tree/parsing/test/"
+      "links_with_visuals_and_collisions.sdf");
+  int num_visuals_explicit{};
+  {
+    // Test explicitly specifying `scene_graph`.
+    MultibodyPlant<double> plant;
+    SceneGraph<double> scene_graph;
+    AddModelsFromSdfFile(full_name, &plant, &scene_graph);
+    plant.Finalize();
+    num_visuals_explicit = plant.num_visual_geometries();
+  }
+  EXPECT_NE(num_visuals_explicit, 0);
+  {
+    // Test implicitly specifying.
+    MultibodyPlant<double> plant;
+    SceneGraph<double> scene_graph;
+    plant.RegisterAsSourceForSceneGraph(&scene_graph);
+    AddModelsFromSdfFile(full_name, &plant);
+    plant.Finalize();
+    EXPECT_EQ(plant.num_visual_geometries(), num_visuals_explicit);
+  }
+}
+
 }  // namespace
 }  // namespace test
 }  // namespace parsing

--- a/multibody/multibody_tree/parsing/test/multibody_plant_urdf_parser_test.cc
+++ b/multibody/multibody_tree/parsing/test/multibody_plant_urdf_parser_test.cc
@@ -26,7 +26,7 @@ GTEST_TEST(MultibodyPlantUrdfParserTest, DoublePendulum) {
   std::string full_name = FindResourceOrThrow(
       "drake/multibody/benchmarks/acrobot/double_pendulum.urdf");
   AddModelFromUrdfFile(full_name, &plant, &scene_graph);
-  plant.Finalize(&scene_graph);
+  plant.Finalize();
 
   const MultibodyTree<double>& tree = plant.tree();
   EXPECT_EQ(tree.num_bodies(), 4);
@@ -64,7 +64,7 @@ GTEST_TEST(MultibodyPlantUrdfParserTest, TestAtlasMinimalContact) {
       "drake/examples/atlas/urdf/atlas_minimal_contact.urdf");
 
   AddModelFromUrdfFile(full_name, &plant, &scene_graph);
-  plant.Finalize(&scene_graph);
+  plant.Finalize();
 
   EXPECT_EQ(plant.num_positions(), 37);
   EXPECT_EQ(plant.num_velocities(), 36);
@@ -83,6 +83,30 @@ GTEST_TEST(MultibodyPlantUrdfParserTest, TestAddWithQuaternionFloatingDof) {
 
   EXPECT_EQ(plant.num_positions(), 7);
   EXPECT_EQ(plant.num_velocities(), 6);
+}
+
+GTEST_TEST(MultibodyPlantUrdfParserTest, TestOptionalSceneGraph) {
+  const std::string full_name = FindResourceOrThrow(
+      "drake/examples/atlas/urdf/atlas_minimal_contact.urdf");
+  int num_visuals_explicit{};
+  {
+    // Test explicitly specifying `scene_graph`.
+    MultibodyPlant<double> plant;
+    SceneGraph<double> scene_graph;
+    AddModelFromUrdfFile(full_name, &plant, &scene_graph);
+    plant.Finalize();
+    num_visuals_explicit = plant.num_visual_geometries();
+  }
+  EXPECT_NE(num_visuals_explicit, 0);
+  {
+    // Test implicitly specifying.
+    MultibodyPlant<double> plant;
+    SceneGraph<double> scene_graph;
+    plant.RegisterAsSourceForSceneGraph(&scene_graph);
+    AddModelFromUrdfFile(full_name, &plant);
+    plant.Finalize();
+    EXPECT_EQ(plant.num_visual_geometries(), num_visuals_explicit);
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
- [x] Requires #9834.

- Ensures URDF + SDF parsing do not require redundant scene graph
- Simplifies usages in downstream applications

\cc @SeanCurtis-TRI @sammy-tri 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9835)
<!-- Reviewable:end -->
