### PR TITLE
scene_graph/dev: Use `vtk_test_tags`

### DIFF
--- a/examples/scene_graph/dev/BUILD.bazel
+++ b/examples/scene_graph/dev/BUILD.bazel
@@ -11,6 +11,7 @@ load(
     "drake_cc_vector_gen_library",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
+load("//tools/skylark:test_tags.bzl", "vtk_test_tags")
 
 drake_cc_vector_gen_library(
     name = "bouncing_ball_vector",
@@ -34,13 +35,7 @@ drake_cc_binary(
     name = "bouncing_ball_run_dynamics",
     srcs = ["bouncing_ball_run_dynamics.cc"],
     add_test_rule = 1,
-    tags = [
-        # These errors seem to arise from OpenGL drivers. The CI errors have
-        # yet to be reproduced locally (although memcheck may produce a
-        # different set of errors locally).
-        "no_lsan",
-        "no_memcheck",
-    ],
+    tags = vtk_test_tags(),
     test_rule_args = [
         "--simulation_time=0.1",
     ],

--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -12,18 +12,9 @@ load(
     "drake_cc_vector_gen_library",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
+load("//tools/skylark:test_tags.bzl", "vtk_test_tags")
 
 package(default_visibility = ["//visibility:public"])
-
-vtk_test_tags = [
-    # Disable under LeakSanitizer and Valgrind Memcheck due to
-    # driver-related leaks. For more information, see #7520.
-    "no_lsan",
-    "no_memcheck",
-    # Mitigates driver-related issues when running under `bazel test`. For
-    # more information, see #7004.
-    "no-sandbox",
-]
 
 drake_cc_package_library(
     name = "sensors",
@@ -449,7 +440,7 @@ drake_cc_googletest(
     data = [
         ":test_models",
     ],
-    tags = vtk_test_tags,
+    tags = vtk_test_tags(),
     deps = [
         ":rgbd_camera",
         "//attic/multibody/parsers",
@@ -471,7 +462,7 @@ drake_cc_googletest(
     data = [
         ":test_models",
     ],
-    tags = vtk_test_tags,
+    tags = vtk_test_tags(),
     deps = [
         ":rgbd_renderer",
         ":rgbd_renderer_test_util",
@@ -486,7 +477,7 @@ drake_cc_googletest(
     data = [
         ":test_models",
     ],
-    tags = vtk_test_tags,
+    tags = vtk_test_tags(),
     deps = [
         ":rgbd_renderer",
         ":rgbd_renderer_test_util",
@@ -507,7 +498,7 @@ sh_test(
     data = [
         ":test_models",
     ],
-    tags = vtk_test_tags,
+    tags = vtk_test_tags(),
 )
 
 drake_cc_googletest(

--- a/tools/skylark/test_tags.bzl
+++ b/tools/skylark/test_tags.bzl
@@ -1,10 +1,10 @@
 # -*- mode: python -*-
 
 # These macros are intended to be used when declaring tests that either may-use
-# or must-use either Gurobi or MOSEK commercial solvers. These labels both
-# account for any license-related needs and provide a marker so that
-# //tools/bazel.rc can selectively enable tests based on the developer's chosen
-# configuration.
+# or must-use dependencies that have constraints (commerical licenses, or
+# peculiar behavior). For commercial dependnecies, these labels both account
+# for any license-related needs and provide a marker so that //tools/bazel.rc
+# can selectively enable tests based on the developer's chosen configuration.
 
 def gurobi_test_tags(gurobi_required = True):
     """Returns the test tags necessary for properly running Gurobi tests.
@@ -43,3 +43,17 @@ def mosek_test_tags(mosek_required = True):
         return nominal_tags + ["mosek"]
     else:
         return nominal_tags
+
+def vtk_test_tags():
+    """Returns test tags necessary for properly running VTK rendering tests
+    locally.
+    """
+    return [
+        # Disable under LeakSanitizer and Valgrind Memcheck due to
+        # driver-related leaks. For more information, see #7520.
+        "no_lsan",
+        "no_memcheck",
+        # Mitigates driver-related issues when running under `bazel test`. For
+        # more information, see #7004.
+        "no-sandbox",
+    ]


### PR DESCRIPTION
Resolves #9825

~I'd say we de-duplicate these tags on the rule of 3.~
Forgot we had `test_tags.bzl`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9836)
<!-- Reviewable:end -->
