### PR TITLE
libdrake: Document indirectly-installed components

### DIFF
--- a/attic/multibody/BUILD.bazel
+++ b/attic/multibody/BUILD.bazel
@@ -8,6 +8,10 @@ load(
     drake_cc_test = "attic_drake_cc_test",
 )
 load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_package_library",
+)
+load(
     "@drake//tools/skylark:drake_proto.bzl",
     "drake_cc_proto_library",
 )
@@ -15,6 +19,33 @@ load("//tools/skylark:test_tags.bzl", "gurobi_test_tags")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 package(default_visibility = ["//visibility:public"])
+
+drake_cc_package_library(
+    name = "multibody",
+    deps = [
+        ":approximate_ik",
+        ":global_inverse_kinematics",
+        ":inverse_kinematics",
+        ":kinematics_cache",
+        ":kinematics_cache_helper",
+        ":resolve_center_of_pressure",
+        ":rigid_body",
+        ":rigid_body_actuator",
+        ":rigid_body_constraint",
+        ":rigid_body_distance_constraint",
+        ":rigid_body_frame",
+        ":rigid_body_loop",
+        ":rigid_body_tree",
+        ":rigid_body_tree_alias_groups",
+        ":rigid_body_tree_alias_groups_proto",
+        ":rigid_body_tree_cc",
+        ":rigid_body_tree_cc_0",
+        ":rigid_body_tree_cc_1",
+        ":rigid_body_tree_construction",
+        ":rigid_body_tree_contact",
+        ":rigid_body_tree_datatypes",
+    ],
+)
 
 drake_cc_library(
     name = "global_inverse_kinematics",

--- a/tools/install/libdrake/build_components.bzl
+++ b/tools/install/libdrake/build_components.bzl
@@ -78,4 +78,5 @@ LIBDRAKE_COMPONENTS = [
     "//systems/sensors/dev",
     "//systems/trajectory_optimization",
     "//util",
+    # //examples/atlas:atlas_util (indirectly)
 ]

--- a/tools/install/libdrake/build_components.bzl
+++ b/tools/install/libdrake/build_components.bzl
@@ -4,6 +4,7 @@
 #
 # Do not update this list by hand; instead, run build_components_refresh.py.
 LIBDRAKE_COMPONENTS = [
+    "//attic/multibody",
     "//attic/multibody/collision",
     "//attic/multibody/joints",
     "//attic/multibody/parsers",
@@ -17,21 +18,6 @@ LIBDRAKE_COMPONENTS = [
     "//attic/multibody/rigid_body_plant:rigid_body_plant",  # unpackaged
     "//attic/multibody/rigid_body_plant:rigid_body_plant_bridge",  # unpackaged
     "//attic/multibody/shapes",
-    "//attic/multibody:approximate_ik",  # unpackaged
-    "//attic/multibody:global_inverse_kinematics",  # unpackaged
-    "//attic/multibody:inverse_kinematics",  # unpackaged
-    "//attic/multibody:kinematics_cache",  # unpackaged
-    "//attic/multibody:kinematics_cache_helper",  # unpackaged
-    "//attic/multibody:resolve_center_of_pressure",  # unpackaged
-    "//attic/multibody:rigid_body",  # unpackaged
-    "//attic/multibody:rigid_body_actuator",  # unpackaged
-    "//attic/multibody:rigid_body_constraint",  # unpackaged
-    "//attic/multibody:rigid_body_distance_constraint",  # unpackaged
-    "//attic/multibody:rigid_body_frame",  # unpackaged
-    "//attic/multibody:rigid_body_loop",  # unpackaged
-    "//attic/multibody:rigid_body_tree",  # unpackaged
-    "//attic/multibody:rigid_body_tree_alias_groups",  # unpackaged
-    "//attic/multibody:rigid_body_tree_construction",  # unpackaged
     "//automotive",
     "//automotive/maliput/api",
     "//automotive/maliput/dragway",


### PR DESCRIPTION
Some targets are nominally excluded from the install (because they are private visibility, or part of examples, or etc.) but are dependencies of installed public code.  We should express them as comments in the installed components list, so that authors and reviewers can be sure that they understand what's being installed.

The first commit adds a new drake_cc_package_library that's been on my back burner to do for a while.  I'm adding it now because the new report has false positives without it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9839)
<!-- Reviewable:end -->
