### PR TITLE
skylark: Prefer `@drake//tools/skylark` over `//tools/skylark`

### DIFF
--- a/attic/multibody/BUILD.bazel
+++ b/attic/multibody/BUILD.bazel
@@ -11,7 +11,7 @@ load(
     "@drake//tools/skylark:drake_proto.bzl",
     "drake_cc_proto_library",
 )
-load("//tools/skylark:test_tags.bzl", "gurobi_test_tags")
+load("@drake//tools/skylark:test_tags.bzl", "gurobi_test_tags")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 package(default_visibility = ["//visibility:public"])

--- a/attic/multibody/dev/BUILD.bazel
+++ b/attic/multibody/dev/BUILD.bazel
@@ -5,7 +5,7 @@ load(
     drake_cc_googletest = "attic_drake_cc_googletest",
     drake_cc_library = "attic_drake_cc_library",
 )
-load("//tools/skylark:test_tags.bzl", "gurobi_test_tags")
+load("@drake//tools/skylark:test_tags.bzl", "gurobi_test_tags")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 drake_cc_library(

--- a/bindings/BUILD.bazel
+++ b/bindings/BUILD.bazel
@@ -2,7 +2,7 @@
 
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load(
-    "//tools/skylark:pybind.bzl",
+    "@drake//tools/skylark:pybind.bzl",
     "drake_pybind_library",
 )
 load(

--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -8,14 +8,14 @@ load(
     "drake_cc_library",
 )
 load(
-    "//tools/skylark:drake_py.bzl",
+    "@drake//tools/skylark:drake_py.bzl",
     "drake_py_binary",
     "drake_py_library",
     "drake_py_test",
     "drake_py_unittest",
 )
 load(
-    "//tools/skylark:pybind.bzl",
+    "@drake//tools/skylark:pybind.bzl",
     "drake_pybind_library",
     "generate_pybind_documentation_header",
     "get_drake_py_installs",

--- a/bindings/pydrake/common/BUILD.bazel
+++ b/bindings/pydrake/common/BUILD.bazel
@@ -3,13 +3,13 @@
 load("@drake//tools/install:install.bzl", "install")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load(
-    "//tools/skylark:pybind.bzl",
+    "@drake//tools/skylark:pybind.bzl",
     "drake_pybind_library",
     "get_drake_py_installs",
     "get_pybind_package_info",
 )
 load(
-    "//tools/skylark:drake_py.bzl",
+    "@drake//tools/skylark:drake_py.bzl",
     "drake_py_library",
     "drake_py_unittest",
 )

--- a/bindings/pydrake/doc/BUILD.bazel
+++ b/bindings/pydrake/doc/BUILD.bazel
@@ -4,7 +4,10 @@ package(default_visibility = ["//visibility:private"])
 
 load("@drake//tools/skylark:drake_py.bzl", "drake_py_binary")
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("//tools/skylark:drake_runfiles_binary.bzl", "drake_runfiles_binary")
+load(
+    "@drake//tools/skylark:drake_runfiles_binary.bzl",
+    "drake_runfiles_binary",
+)
 
 py_library(
     name = "sphinx_pydrake",

--- a/bindings/pydrake/examples/BUILD.bazel
+++ b/bindings/pydrake/examples/BUILD.bazel
@@ -3,13 +3,13 @@
 load("@drake//tools/install:install.bzl", "install")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load(
-    "//tools/skylark:pybind.bzl",
+    "@drake//tools/skylark:pybind.bzl",
     "drake_pybind_library",
     "get_drake_py_installs",
     "get_pybind_package_info",
 )
 load(
-    "//tools/skylark:drake_py.bzl",
+    "@drake//tools/skylark:drake_py.bzl",
     "drake_py_library",
     "drake_py_unittest",
 )

--- a/bindings/pydrake/examples/multibody/BUILD.bazel
+++ b/bindings/pydrake/examples/multibody/BUILD.bazel
@@ -3,12 +3,12 @@
 load("@drake//tools/install:install.bzl", "install")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load(
-    "//tools/skylark:pybind.bzl",
+    "@drake//tools/skylark:pybind.bzl",
     "get_drake_py_installs",
     "get_pybind_package_info",
 )
 load(
-    "//tools/skylark:drake_py.bzl",
+    "@drake//tools/skylark:drake_py.bzl",
     "drake_py_binary",
     "drake_py_library",
 )

--- a/bindings/pydrake/maliput/BUILD.bazel
+++ b/bindings/pydrake/maliput/BUILD.bazel
@@ -3,13 +3,13 @@
 load("@drake//tools/install:install.bzl", "install")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load(
-    "//tools/skylark:pybind.bzl",
+    "@drake//tools/skylark:pybind.bzl",
     "drake_pybind_library",
     "get_drake_py_installs",
     "get_pybind_package_info",
 )
 load(
-    "//tools/skylark:drake_py.bzl",
+    "@drake//tools/skylark:drake_py.bzl",
     "drake_py_binary",
     "drake_py_library",
     "drake_py_unittest",

--- a/bindings/pydrake/manipulation/BUILD.bazel
+++ b/bindings/pydrake/manipulation/BUILD.bazel
@@ -3,13 +3,13 @@
 load("@drake//tools/install:install.bzl", "install")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load(
-    "//tools/skylark:pybind.bzl",
+    "@drake//tools/skylark:pybind.bzl",
     "drake_pybind_library",
     "get_drake_py_installs",
     "get_pybind_package_info",
 )
 load(
-    "//tools/skylark:drake_py.bzl",
+    "@drake//tools/skylark:drake_py.bzl",
     "drake_py_library",
     "drake_py_unittest",
 )

--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -3,13 +3,13 @@
 load("@drake//tools/install:install.bzl", "install")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load(
-    "//tools/skylark:pybind.bzl",
+    "@drake//tools/skylark:pybind.bzl",
     "drake_pybind_library",
     "get_drake_py_installs",
     "get_pybind_package_info",
 )
 load(
-    "//tools/skylark:drake_py.bzl",
+    "@drake//tools/skylark:drake_py.bzl",
     "drake_py_library",
     "drake_py_unittest",
 )

--- a/bindings/pydrake/solvers/BUILD.bazel
+++ b/bindings/pydrake/solvers/BUILD.bazel
@@ -2,15 +2,19 @@
 
 load("@drake//tools/install:install.bzl", "install")
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("//tools/skylark:test_tags.bzl", "gurobi_test_tags", "mosek_test_tags")
 load(
-    "//tools/skylark:pybind.bzl",
+    "@drake//tools/skylark:test_tags.bzl",
+    "gurobi_test_tags",
+    "mosek_test_tags",
+)
+load(
+    "@drake//tools/skylark:pybind.bzl",
     "drake_pybind_library",
     "get_drake_py_installs",
     "get_pybind_package_info",
 )
 load(
-    "//tools/skylark:drake_py.bzl",
+    "@drake//tools/skylark:drake_py.bzl",
     "drake_py_library",
     "drake_py_test",
     "drake_py_unittest",

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -3,7 +3,7 @@
 load("@drake//tools/install:install.bzl", "install")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load(
-    "//tools/skylark:pybind.bzl",
+    "@drake//tools/skylark:pybind.bzl",
     "drake_pybind_library",
     "get_drake_py_installs",
     "get_pybind_package_info",
@@ -13,7 +13,7 @@ load(
     "drake_cc_library",
 )
 load(
-    "//tools/skylark:drake_py.bzl",
+    "@drake//tools/skylark:drake_py.bzl",
     "drake_py_binary",
     "drake_py_library",
     "drake_py_unittest",

--- a/bindings/pydrake/third_party/BUILD.bazel
+++ b/bindings/pydrake/third_party/BUILD.bazel
@@ -1,11 +1,11 @@
 load("@drake//tools/install:install.bzl", "install")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load(
-    "//tools/skylark:drake_py.bzl",
+    "@drake//tools/skylark:drake_py.bzl",
     "drake_py_library",
 )
 load(
-    "//tools/skylark:pybind.bzl",
+    "@drake//tools/skylark:pybind.bzl",
     "get_pybind_package_info",
 )
 load(":forward_files.bzl", "forward_files")

--- a/bindings/pydrake/util/BUILD.bazel
+++ b/bindings/pydrake/util/BUILD.bazel
@@ -8,14 +8,14 @@ load(
     "drake_cc_library",
 )
 load(
-    "//tools/skylark:pybind.bzl",
+    "@drake//tools/skylark:pybind.bzl",
     "drake_pybind_cc_googletest",
     "drake_pybind_library",
     "get_drake_py_installs",
     "get_pybind_package_info",
 )
 load(
-    "//tools/skylark:drake_py.bzl",
+    "@drake//tools/skylark:drake_py.bzl",
     "drake_py_library",
     "drake_py_test",
     "drake_py_unittest",

--- a/common/proto/BUILD.bazel
+++ b/common/proto/BUILD.bazel
@@ -7,7 +7,7 @@ load(
     "drake_cc_package_library",
 )
 load(
-    "//tools/skylark:drake_py.bzl",
+    "@drake//tools/skylark:drake_py.bzl",
     "drake_py_binary",
     "drake_py_library",
     "drake_py_unittest",

--- a/examples/cubic_polynomial/BUILD.bazel
+++ b/examples/cubic_polynomial/BUILD.bazel
@@ -2,7 +2,7 @@
 
 load("@drake//tools/skylark:drake_cc.bzl", "drake_cc_binary")
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("//tools/skylark:test_tags.bzl", "mosek_test_tags")
+load("@drake//tools/skylark:test_tags.bzl", "mosek_test_tags")
 
 drake_cc_binary(
     name = "region_of_attraction",

--- a/examples/humanoid_controller/BUILD.bazel
+++ b/examples/humanoid_controller/BUILD.bazel
@@ -6,7 +6,7 @@ load(
     "drake_cc_googletest",
     "drake_cc_library",
 )
-load("//tools/skylark:test_tags.bzl", "gurobi_test_tags")
+load("@drake//tools/skylark:test_tags.bzl", "gurobi_test_tags")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 package(default_visibility = ["//visibility:public"])

--- a/examples/kuka_iiwa_arm/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/BUILD.bazel
@@ -7,13 +7,13 @@ load(
     "drake_cc_library",
 )
 load(
-    "//tools/skylark:drake_py.bzl",
+    "@drake//tools/skylark:drake_py.bzl",
     "drake_py_unittest",
 )
 load("//tools/install:install_data.bzl", "install", "install_data")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load(
-    "//tools/skylark:drake_py.bzl",
+    "@drake//tools/skylark:drake_py.bzl",
     "drake_py_test",
 )
 

--- a/examples/manipulation_station/BUILD.bazel
+++ b/examples/manipulation_station/BUILD.bazel
@@ -64,7 +64,7 @@ drake_cc_googletest(
 # Python examples
 
 load(
-    "//tools/skylark:drake_py.bzl",
+    "@drake//tools/skylark:drake_py.bzl",
     "drake_py_binary",
     "drake_py_library",
 )

--- a/examples/qp_inverse_dynamics/BUILD.bazel
+++ b/examples/qp_inverse_dynamics/BUILD.bazel
@@ -5,7 +5,7 @@ load(
     "drake_cc_googletest",
     "drake_cc_library",
 )
-load("//tools/skylark:test_tags.bzl", "gurobi_test_tags")
+load("@drake//tools/skylark:test_tags.bzl", "gurobi_test_tags")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 package(

--- a/lcm/BUILD.bazel
+++ b/lcm/BUILD.bazel
@@ -6,7 +6,7 @@ load(
     "drake_cc_library",
     "drake_cc_package_library",
 )
-load("//tools/skylark:drake_py.bzl", "drake_py_test")
+load("@drake//tools/skylark:drake_py.bzl", "drake_py_test")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 package(default_visibility = ["//visibility:public"])

--- a/lcmtypes/BUILD.bazel
+++ b/lcmtypes/BUILD.bazel
@@ -17,7 +17,7 @@ load(
     "drake_py_test",
 )
 load(
-    "//tools/skylark:drake_lcm.bzl",
+    "@drake//tools/skylark:drake_lcm.bzl",
     "drake_lcm_cc_library",
     "drake_lcm_java_library",
     "drake_lcm_py_library",

--- a/manipulation/dev/BUILD.bazel
+++ b/manipulation/dev/BUILD.bazel
@@ -8,7 +8,7 @@ load(
     "drake_cc_library",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("//tools/skylark:test_tags.bzl", "gurobi_test_tags")
+load("@drake//tools/skylark:test_tags.bzl", "gurobi_test_tags")
 
 filegroup(
     name = "test_models",

--- a/multibody/inverse_kinematics/BUILD.bazel
+++ b/multibody/inverse_kinematics/BUILD.bazel
@@ -12,7 +12,7 @@ load(
     "@drake//tools/skylark:drake_proto.bzl",
     "drake_cc_proto_library",
 )
-load("//tools/skylark:test_tags.bzl", "gurobi_test_tags")
+load("@drake//tools/skylark:test_tags.bzl", "gurobi_test_tags")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 package(default_visibility = ["//visibility:public"])

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -8,7 +8,11 @@ load(
     "drake_cc_package_library",
     "drake_cc_test",
 )
-load("//tools/skylark:test_tags.bzl", "gurobi_test_tags", "mosek_test_tags")
+load(
+    "@drake//tools/skylark:test_tags.bzl",
+    "gurobi_test_tags",
+    "mosek_test_tags",
+)
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 package(default_visibility = ["//visibility:public"])

--- a/systems/controllers/plan_eval/BUILD.bazel
+++ b/systems/controllers/plan_eval/BUILD.bazel
@@ -7,7 +7,7 @@ load(
     "drake_cc_library",
     "drake_cc_package_library",
 )
-load("//tools/skylark:test_tags.bzl", "gurobi_test_tags")
+load("@drake//tools/skylark:test_tags.bzl", "gurobi_test_tags")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 package(default_visibility = ["//visibility:public"])

--- a/systems/controllers/qp_inverse_dynamics/BUILD.bazel
+++ b/systems/controllers/qp_inverse_dynamics/BUILD.bazel
@@ -11,7 +11,7 @@ load(
     "@drake//tools/skylark:drake_proto.bzl",
     "drake_cc_proto_library",
 )
-load("//tools/skylark:test_tags.bzl", "gurobi_test_tags")
+load("@drake//tools/skylark:test_tags.bzl", "gurobi_test_tags")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/systems/estimators/dev/BUILD.bazel
+++ b/systems/estimators/dev/BUILD.bazel
@@ -5,7 +5,7 @@ load(
     "drake_cc_test",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("//tools/skylark:test_tags.bzl", "mosek_test_tags")
+load("@drake//tools/skylark:test_tags.bzl", "mosek_test_tags")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,7 +1,10 @@
 # -*- python -*-
 
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("//tools/skylark:drake_runfiles_binary.bzl", "drake_runfiles_binary")
+load(
+    "@drake//tools/skylark:drake_runfiles_binary.bzl",
+    "drake_runfiles_binary",
+)
 
 package(default_visibility = ["//visibility:public"])
 

--- a/tools/install/BUILD.bazel
+++ b/tools/install/BUILD.bazel
@@ -4,7 +4,7 @@ package(default_visibility = ["//visibility:public"])
 
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load(
-    "//tools/skylark:drake_py.bzl",
+    "@drake//tools/skylark:drake_py.bzl",
     "drake_py_test",
     "drake_py_unittest",
 )

--- a/tools/lint/bazel_lint.bzl
+++ b/tools/lint/bazel_lint.bzl
@@ -1,7 +1,7 @@
 # -*- mode: python -*-
 # vi: set ft=python :
 
-load("//tools/skylark:drake_py.bzl", "py_test_isolated")
+load("@drake//tools/skylark:drake_py.bzl", "py_test_isolated")
 
 #------------------------------------------------------------------------------
 # Internal helper; set up test given name and list of files. Will do nothing

--- a/tools/lint/cpplint.bzl
+++ b/tools/lint/cpplint.bzl
@@ -1,6 +1,6 @@
 # -*- python -*-
 
-load("//tools/skylark:drake_py.bzl", "py_test_isolated")
+load("@drake//tools/skylark:drake_py.bzl", "py_test_isolated")
 
 # From https://bazel.build/versions/master/docs/be/c-cpp.html#cc_library.srcs
 _SOURCE_EXTENSIONS = [source_ext for source_ext in """

--- a/tools/lint/install_lint.bzl
+++ b/tools/lint/install_lint.bzl
@@ -1,6 +1,6 @@
 # -*- python -*-
 
-load("//tools/skylark:drake_py.bzl", "py_test_isolated")
+load("@drake//tools/skylark:drake_py.bzl", "py_test_isolated")
 
 def install_lint(
         existing_rules = None):

--- a/tools/lint/library_lint.bzl
+++ b/tools/lint/library_lint.bzl
@@ -1,6 +1,6 @@
 # -*- python -*-
 
-load("//tools/skylark:drake_py.bzl", "py_test_isolated")
+load("@drake//tools/skylark:drake_py.bzl", "py_test_isolated")
 
 # Keep this constant in sync with library_lint_reporter.py.
 _TAG_EXCLUDE_FROM_PACKAGE = "exclude_from_package"

--- a/tools/lint/python_lint.bzl
+++ b/tools/lint/python_lint.bzl
@@ -1,7 +1,7 @@
 # -*- mode: python -*-
 # vi: set ft=python :
 
-load("//tools/skylark:drake_py.bzl", "py_test_isolated")
+load("@drake//tools/skylark:drake_py.bzl", "py_test_isolated")
 
 # Internal helper.
 def _python_lint(name_prefix, files, ignore):

--- a/tools/skylark/drake_proto.bzl
+++ b/tools/skylark/drake_proto.bzl
@@ -33,7 +33,7 @@ def drake_cc_proto_library(
 
     # Apply ubsan fixups.
     pb_ubsan_fixups = [x[:-len(".proto")] + "_ubsan_fixup.pb.cc" for x in srcs]
-    tool = "//tools/skylark:drake_proto_ubsan_fix"
+    tool = "@drake//tools/skylark:drake_proto_ubsan_fix"
     native.genrule(
         name = name + "_ubsan_fixup",
         srcs = pb_srcs,

--- a/tools/skylark/pybind.bzl
+++ b/tools/skylark/pybind.bzl
@@ -8,7 +8,7 @@ load(
     "drake_cc_googletest",
 )
 load(
-    "//tools/skylark:drake_py.bzl",
+    "@drake//tools/skylark:drake_py.bzl",
     "drake_py_library",
     "drake_py_test",
 )
@@ -276,7 +276,7 @@ def drake_pybind_cc_googletest(
 
     # Use this Python test as the glue for Bazel to expose the appropriate
     # environment for the C++ binary.
-    py_main = "//tools/skylark:py_env_runner.py"
+    py_main = "@drake//tools/skylark:py_env_runner.py"
     drake_py_test(
         name = name,
         srcs = [py_main],

--- a/tools/workspace/pybind11/BUILD.bazel
+++ b/tools/workspace/pybind11/BUILD.bazel
@@ -1,8 +1,14 @@
 # -*- python -*-
 
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("//tools/skylark:drake_runfiles_binary.bzl", "drake_runfiles_binary")
-load("//tools/skylark:pybind.bzl", "generate_pybind_documentation_header")
+load(
+    "@drake//tools/skylark:drake_runfiles_binary.bzl",
+    "drake_runfiles_binary",
+)
+load(
+    "@drake//tools/skylark:pybind.bzl",
+    "generate_pybind_documentation_header",
+)
 load("@drake//tools/skylark:drake_py.bzl", "drake_py_unittest")
 load(
     "@drake//tools/skylark:drake_cc.bzl",

--- a/tools/workspace/python/BUILD.bazel
+++ b/tools/workspace/python/BUILD.bazel
@@ -4,7 +4,7 @@
 # neighboring *.bzl file can be loaded elsewhere.
 
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("//tools/skylark:drake_py.bzl", "drake_py_unittest")
+load("@drake//tools/skylark:drake_py.bzl", "drake_py_unittest")
 
 drake_py_unittest(
     name = "python_bin_test",


### PR DESCRIPTION
For more information, see:
- https://github.com/bazelbuild/bazel/issues/3115
- https://github.com/RobotLocomotion/drake/issues/8700

Resolves #8732

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9845)
<!-- Reviewable:end -->
