### PR TITLE
py systems: Bind and test explicit initialization events

### DIFF
--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -73,6 +73,7 @@ struct Impl {
     using Base::DeclareAbstractOutputPort;
     using Base::DeclareVectorOutputPort;
     using Base::DeclarePeriodicPublish;
+    using Base::DeclareInitializationEvent;
     using Base::DeclareContinuousState;
     using Base::DeclareDiscreteState;
     using Base::DeclarePeriodicDiscreteUpdate;
@@ -422,6 +423,11 @@ struct Impl {
       .def("_DeclarePeriodicPublish", &PyLeafSystem::DeclarePeriodicPublish,
            py::arg("period_sec"), py::arg("offset_sec") = 0.,
            doc.LeafSystem.DeclarePeriodicPublish.doc)
+      .def("_DeclareInitializationEvent",
+           [](PyLeafSystem* self, const Event<T>& event) {
+             self->DeclareInitializationEvent(event);
+           },
+           py::arg("event"), doc.LeafSystem.DeclareInitializationEvent.doc)
       .def("_DoPublish", &LeafSystemPublic::DoPublish,
            doc.LeafSystem.DoPublish.doc)
       // System attributes.

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -14,10 +14,13 @@ from pydrake.systems.analysis import (
 from pydrake.systems.framework import (
     AbstractValue,
     BasicVector, BasicVector_,
+    Context,
     DiagramBuilder,
     kUseDefaultName,
     LeafSystem, LeafSystem_,
     PortDataType,
+    PublishEvent,
+    TriggerType,
     VectorSystem,
     )
 from pydrake.systems.primitives import (
@@ -144,12 +147,17 @@ class TestCustom(unittest.TestCase):
                 self.called_feedthrough = False
                 self.called_continuous = False
                 self.called_discrete = False
+                self.called_initialize = False
                 # Ensure we have desired overloads.
                 self._DeclarePeriodicPublish(0.1)
                 self._DeclarePeriodicPublish(0.1, 0)
                 self._DeclarePeriodicPublish(period_sec=0.1, offset_sec=0.)
                 self._DeclarePeriodicDiscreteUpdate(
                     period_sec=0.1, offset_sec=0.)
+                self._DeclareInitializationEvent(
+                    event=PublishEvent(
+                        trigger_type=TriggerType.kInitialization,
+                        callback=self._on_initialize))
                 self._DeclareContinuousState(2)
                 self._DeclareDiscreteState(1)
                 # Ensure that we have inputs / outputs to call direct
@@ -160,6 +168,12 @@ class TestCustom(unittest.TestCase):
             def _DoPublish(self, context, events):
                 # Call base method to ensure we do not get recursion.
                 LeafSystem._DoPublish(self, context, events)
+                # N.B. We do not test for a singular call to `DoPublish`
+                # (checking `assertFalse(self.called_publish)` first) because
+                # the above `_DeclareInitializationEvent` will call both its
+                # callback and this event when invoked via
+                # `Simulator::Initialize` from `call_leaf_system_overrides`,
+                # even when we explicitly say not to publish at initialize.
                 self.called_publish = True
 
             def _DoHasDirectFeedthrough(self, input_port, output_port):
@@ -187,17 +201,25 @@ class TestCustom(unittest.TestCase):
                     self, context, events, discrete_state)
                 self.called_discrete = True
 
+            def _on_initialize(self, context, event):
+                test.assertIsInstance(context, Context)
+                test.assertIsInstance(event, PublishEvent)
+                test.assertFalse(self.called_initialize)
+                self.called_initialize = True
+
         system = TrivialSystem()
         self.assertFalse(system.called_publish)
         self.assertFalse(system.called_feedthrough)
         self.assertFalse(system.called_continuous)
         self.assertFalse(system.called_discrete)
+        self.assertFalse(system.called_initialize)
         results = call_leaf_system_overrides(system)
         self.assertTrue(system.called_publish)
         self.assertTrue(system.called_feedthrough)
         self.assertFalse(results["has_direct_feedthrough"])
         self.assertTrue(system.called_continuous)
         self.assertTrue(system.called_discrete)
+        self.assertTrue(system.called_initialize)
         self.assertEqual(results["discrete_next_t"], 0.1)
 
         self.assertFalse(system.HasAnyDirectFeedthrough())

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -30,19 +30,21 @@ from pydrake.systems.framework import (
     DiagramBuilder, DiagramBuilder_,
     DiscreteUpdateEvent_,
     DiscreteValues_,
-    Event_,
+    Event, Event_,
     InputPort_,
     kUseDefaultName,
     LeafContext_,
     LeafSystem_,
     OutputPort_,
     Parameters_,
-    PublishEvent_,
+    PublishEvent, PublishEvent_,
     State_,
     Subvector_,
     Supervector_,
     System_,
-    SystemOutput_,    VectorBase, VectorBase_,
+    SystemOutput_,
+    VectorBase, VectorBase_,
+    TriggerType,
     VectorSystem_,
     )
 from pydrake.systems import primitives
@@ -111,6 +113,27 @@ class TestGeneral(unittest.TestCase):
         self.assertIsInstance(
             context.get_mutable_continuous_state_vector(), VectorBase)
         # TODO(eric.cousineau): Consolidate main API tests for `Context` here.
+
+    def test_event_api(self):
+        # TriggerType - existence check.
+        TriggerType.kUnknown
+        TriggerType.kInitialization
+        TriggerType.kForced
+        TriggerType.kTimed
+        TriggerType.kPeriodic
+        TriggerType.kPerStep
+        TriggerType.kWitness
+
+        # PublishEvent.
+        # TODO(eric.cousineau): Test other event types when it is useful to
+        # expose them.
+
+        def callback(context, event): pass
+
+        event = PublishEvent(
+            trigger_type=TriggerType.kInitialization, callback=callback)
+        self.assertIsInstance(event, Event)
+        self.assertEqual(event.get_trigger_type(), TriggerType.kInitialization)
 
     def test_instantiations(self):
         # Quick check of instantions for given types.

--- a/bindings/pydrake/systems/test/test_util_py.cc
+++ b/bindings/pydrake/systems/test/test_util_py.cc
@@ -4,6 +4,7 @@
 
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/systems/systems_pybind.h"
+#include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/leaf_system.h"
 #include "drake/systems/framework/vector_system.h"
@@ -14,6 +15,7 @@ namespace drake {
 
 using systems::BasicVector;
 using systems::LeafSystem;
+using systems::Simulator;
 
 namespace pydrake {
 namespace {
@@ -123,6 +125,14 @@ PYBIND11_MODULE(test_util, m) {
       const LeafSystem<T>& system) {
     py::dict results;
     auto context = system.AllocateContext();
+    {
+      // Leverage simulator to call initialization events.
+      Simulator<T> simulator(system);
+      // Do not publish at initialization because we want to track publishes
+      // from only events of trigger type `kInitialization`.
+      simulator.set_publish_at_initialization(false);
+      simulator.Initialize();
+    }
     {
       // Call `Publish` to test `DoPublish`.
       auto events =

--- a/systems/framework/event.h
+++ b/systems/framework/event.h
@@ -153,6 +153,65 @@ class WitnessTriggeredEventData : public EventData {
 };
 
 /**
+ * Predefined types of triggers for events. Used at run time to determine why
+ * the associated event has occurred.
+ */
+enum class TriggerType {
+  kUnknown,
+
+  /**
+   * This trigger indicates that an associated event is triggered at system
+   * initialization.
+   */
+  kInitialization,
+
+  /**
+   * This trigger indicates that an associated event is triggered by directly
+   * calling the corresponding public system API for event handling (e.g.
+   * Publish(context)).
+   */
+  kForced,
+
+  /**
+   * This trigger indicates that an associated event is triggered by the
+   * system proceeding to a single, arbitrary time. Timed events are commonly
+   * created in System::CalcNextUpdateTime().
+   */
+  kTimed,
+
+  /**
+   * This type indicates that an associated event is triggered by the system
+   * proceeding to a time t ∈ {tᵢ = t₀ + p * i} for some period p, time
+   * offset t₀, and i is a non-negative integer. @see PeriodicEventData.
+   * Periodic events are commonly created in System::CalcNextUpdateTime().
+   */
+  kPeriodic,
+
+  /**
+   * This trigger indicates that an associated event is triggered whenever a
+   * `solver` takes a `step`. A `solver` is an abstract construct that
+   * controls the time and state evolution of a System. For example, a
+   * simulator is a `solver`. Its `step` advances time a finite duration by
+   * integrating a system, modifying its state accordingly. Per-step events
+   * are most commonly created in System::GetPerStepEvents(). A very common
+   * use of such per-step events is to update a discrete or abstract state
+   * variable that changes whenever the continuous state advances; examples
+   * are computing the "min" or "max" of some state variable, recording a
+   * signal in a delay buffer, or publishing. Per-step events are also useful
+   * to implement feedback controllers interfaced with physical devices; the
+   * controller can be implemented in the event handler, and the "step" would
+   * correspond to receiving sensory data from the hardware.
+   */
+  kPerStep,
+
+  /**
+   * This trigger indicates that an associated event is triggered by the zero
+   * crossing of a witness function.
+   */
+  kWitness,
+};
+
+/**
  * Abstract base class that represents an event. The base event contains two
  * main pieces of information: an enum trigger type and an optional attribute
  * of AbstractValue that can be used to explain why the event is triggered.
@@ -175,67 +234,11 @@ class Event {
   Event(Event&&) = delete;
   void operator=(Event&&) = delete;
 
+  // TODO(eric.cousineau): Deprecate and remove this alias.
+  using TriggerType = systems::TriggerType;
+
   /// Returns `true` if this is a DiscreteUpdateEvent.
   virtual bool is_discrete_update() const = 0;
-
-  /**
-   * Predefined types of triggers. Used at run time to determine why the
-   * associated event has occurred.
-   */
-  enum class TriggerType {
-    kUnknown,
-
-    /**
-     * This trigger indicates that an associated event is triggered at system
-     * initialization.
-     */
-    kInitialization,
-
-    /**
-     * This trigger indicates that an associated event is triggered by directly
-     * calling the corresponding public system API for event handling (e.g.
-     * Publish(context)).
-     */
-    kForced,
-
-    /**
-     * This trigger indicates that an associated event is triggered by the
-     * system proceeding to a single, arbitrary time. Timed events are commonly
-     * created in System::CalcNextUpdateTime().
-     */
-    kTimed,
-
-    /**
-     * This type indicates that an associated event is triggered by the system
-     * proceeding to a time t ∈ {tᵢ = t₀ + p * i} for some period p, time
-     * offset t₀, and i is a non-negative integer. @see PeriodicEventData.
-     * Periodic events are commonly created in System::CalcNextUpdateTime().
-     */
-    kPeriodic,
-
-    /**
-     * This trigger indicates that an associated event is triggered whenever a
-     * `solver` takes a `step`. A `solver` is an abstract construct that
-     * controls the time and state evolution of a System. For example, a
-     * simulator is a `solver`. Its `step` advances time a finite duration by
-     * integrating a system, modifying its state accordingly. Per-step events
-     * are most commonly created in System::GetPerStepEvents(). A very common
-     * use of such per-step events is to update a discrete or abstract state
-     * variable that changes whenever the continuous state advances; examples
-     * are computing the "min" or "max" of some state variable, recording a
-     * signal in a delay buffer, or publishing. Per-step events are also useful
-     * to implement feedback controllers interfaced with physical devices; the
-     * controller can be implemented in the event handler, and the "step" would
-     * correspond to receiving sensory data from the hardware.
-     */
-    kPerStep,
-
-    /**
-     * This trigger indicates that an associated event is triggered by the zero
-     * crossing of a witness function.
-     */
-    kWitness,
-  };
 
   /**
    * An object passed


### PR DESCRIPTION
Resolves #9842
Resolves #9846 

Also strips out unnecessary templating in relevant methods.

\cc @RussTedrake 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9847)
<!-- Reviewable:end -->
