### PR TITLE
pydrake: Begin to enforce clang-format

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -419,18 +419,19 @@ drake_py_unittest(
     ],
 )
 
-add_lint_tests(
-    python_lint_extra_srcs = [
-        ":test/all_install_test.py",
-        ":test/common_install_test.py",
-    ],
-)
-
 drake_py_binary(
     name = "math_example",
     srcs = ["math_example.py"],
     isolate = 1,
     deps = [
         ":math_py",
+    ],
+)
+
+add_lint_tests(
+    enable_clang_format_lint = True,
+    python_lint_extra_srcs = [
+        ":test/all_install_test.py",
+        ":test/common_install_test.py",
     ],
 )

--- a/bindings/pydrake/autodiffutils_py.cc
+++ b/bindings/pydrake/autodiffutils_py.cc
@@ -8,8 +8,8 @@
 #include "drake/bindings/pydrake/util/wrap_pybind.h"
 
 using Eigen::AutoDiffScalar;
-using std::sin;
 using std::cos;
+using std::sin;
 
 namespace drake {
 namespace pydrake {
@@ -25,93 +25,87 @@ PYBIND11_MODULE(autodiffutils, m) {
 
   // TODO(m-chaturvedi) Add Pybind11 documentation.
   py::class_<AutoDiffXd> autodiff(m, "AutoDiffXd");
-  autodiff
-    .def(py::init<double>())
-    .def(py::init<const double&, const Eigen::VectorXd&>())
-    .def("value", [](const AutoDiffXd& self) {
-      return self.value();
-    })
-    .def("derivatives", [](const AutoDiffXd& self) {
-      return self.derivatives();
-    })
-    .def("__str__", [](const AutoDiffXd& self) {
-      return py::str("AD{{{}, nderiv={}}}").format(
-          self.value(), self.derivatives().size());
-    })
-    .def("__repr__", [](const AutoDiffXd& self) {
-      return py::str("<AutoDiffXd {} nderiv={}>").format(
-          self.value(), self.derivatives().size());
-    })
-    // Arithmetic
-    .def(-py::self)
-    .def(py::self + py::self)
-    .def(py::self + double())
-    .def(double() + py::self)
-    .def(py::self - py::self)
-    .def(py::self - double())
-    .def(double() - py::self)
-    .def(py::self * py::self)
-    .def(py::self * double())
-    .def(double() * py::self)
-    .def(py::self / py::self)
-    .def(py::self / double())
-    .def(double() / py::self)
-    // Logical comparison
-    .def(py::self == py::self)
-    .def(py::self == double())
-    .def(py::self != py::self)
-    .def(py::self != double())
-    .def(py::self < py::self)
-    .def(py::self < double())
-    .def(py::self <= py::self)
-    .def(py::self <= double())
-    .def(py::self > py::self)
-    .def(py::self > double())
-    .def(py::self >= py::self)
-    .def(py::self >= double())
-    // Additional math
-    .def("__pow__",
-         [](const AutoDiffXd& base, int exponent) {
-           return pow(base, exponent);
-         }, py::is_operator())
-    .def("__abs__", [](const AutoDiffXd& x) { return abs(x); });
+  autodiff.def(py::init<double>())
+      .def(py::init<const double&, const Eigen::VectorXd&>())
+      .def("value", [](const AutoDiffXd& self) { return self.value(); })
+      .def("derivatives",
+           [](const AutoDiffXd& self) { return self.derivatives(); })
+      .def("__str__",
+           [](const AutoDiffXd& self) {
+             return py::str("AD{{{}, nderiv={}}}")
+                 .format(self.value(), self.derivatives().size());
+           })
+      .def("__repr__",
+           [](const AutoDiffXd& self) {
+             return py::str("<AutoDiffXd {} nderiv={}>")
+                 .format(self.value(), self.derivatives().size());
+           })
+      // Arithmetic
+      .def(-py::self)
+      .def(py::self + py::self)
+      .def(py::self + double())
+      .def(double() + py::self)
+      .def(py::self - py::self)
+      .def(py::self - double())
+      .def(double() - py::self)
+      .def(py::self * py::self)
+      .def(py::self * double())
+      .def(double() * py::self)
+      .def(py::self / py::self)
+      .def(py::self / double())
+      .def(double() / py::self)
+      // Logical comparison
+      .def(py::self == py::self)
+      .def(py::self == double())
+      .def(py::self != py::self)
+      .def(py::self != double())
+      .def(py::self < py::self)
+      .def(py::self < double())
+      .def(py::self <= py::self)
+      .def(py::self <= double())
+      .def(py::self > py::self)
+      .def(py::self > double())
+      .def(py::self >= py::self)
+      .def(py::self >= double())
+      // Additional math
+      .def("__pow__",
+           [](const AutoDiffXd& base, int exponent) {
+             return pow(base, exponent);
+           },
+           py::is_operator())
+      .def("__abs__", [](const AutoDiffXd& x) { return abs(x); });
 
   py::implicitly_convertible<double, AutoDiffXd>();
   py::implicitly_convertible<int, AutoDiffXd>();
 
-    // Add overloads for `math` functions.
-    auto math = py::module::import("pydrake.math");
-    MirrorDef<py::module, decltype(autodiff)>(&math, &autodiff)
+  // Add overloads for `math` functions.
+  auto math = py::module::import("pydrake.math");
+  MirrorDef<py::module, decltype(autodiff)>(&math, &autodiff)
       .def("log", [](const AutoDiffXd& x) { return log(x); })
       .def("abs", [](const AutoDiffXd& x) { return abs(x); })
       .def("exp", [](const AutoDiffXd& x) { return exp(x); })
       .def("sqrt", [](const AutoDiffXd& x) { return sqrt(x); })
-      .def("pow", [](const AutoDiffXd& x, int y) {
-                      return pow(x, y);
-                    })
+      .def("pow", [](const AutoDiffXd& x, int y) { return pow(x, y); })
       .def("sin", [](const AutoDiffXd& x) { return sin(x); })
       .def("cos", [](const AutoDiffXd& x) { return cos(x); })
       .def("tan", [](const AutoDiffXd& x) { return tan(x); })
       .def("asin", [](const AutoDiffXd& x) { return asin(x); })
       .def("acos", [](const AutoDiffXd& x) { return acos(x); })
-      .def("atan2", [](const AutoDiffXd& y, const AutoDiffXd& x) {
-                      return atan2(y, x);
-                    })
+      .def("atan2",
+           [](const AutoDiffXd& y, const AutoDiffXd& x) { return atan2(y, x); })
       .def("sinh", [](const AutoDiffXd& x) { return sinh(x); })
       .def("cosh", [](const AutoDiffXd& x) { return cosh(x); })
       .def("tanh", [](const AutoDiffXd& x) { return tanh(x); })
-      .def("min", [](const AutoDiffXd& x, const AutoDiffXd& y) {
-                    return min(x, y);
-                  })
-      .def("max", [](const AutoDiffXd& x, const AutoDiffXd& y) {
-                    return max(x, y);
-                  })
+      .def("min",
+           [](const AutoDiffXd& x, const AutoDiffXd& y) { return min(x, y); })
+      .def("max",
+           [](const AutoDiffXd& x, const AutoDiffXd& y) { return max(x, y); })
       .def("ceil", [](const AutoDiffXd& x) { return ceil(x); })
       .def("floor", [](const AutoDiffXd& x) { return floor(x); });
-    // Mirror for numpy.
-    autodiff.attr("arcsin") = autodiff.attr("asin");
-    autodiff.attr("arccos") = autodiff.attr("acos");
-    autodiff.attr("arctan2") = autodiff.attr("atan2");
+  // Mirror for numpy.
+  autodiff.attr("arcsin") = autodiff.attr("asin");
+  autodiff.attr("arccos") = autodiff.attr("acos");
+  autodiff.attr("arctan2") = autodiff.attr("atan2");
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/autodiffutils_py.cc
+++ b/bindings/pydrake/autodiffutils_py.cc
@@ -25,7 +25,8 @@ PYBIND11_MODULE(autodiffutils, m) {
 
   // TODO(m-chaturvedi) Add Pybind11 documentation.
   py::class_<AutoDiffXd> autodiff(m, "AutoDiffXd");
-  autodiff.def(py::init<double>())
+  autodiff  // BR
+      .def(py::init<double>())
       .def(py::init<const double&, const Eigen::VectorXd&>())
       .def("value", [](const AutoDiffXd& self) { return self.value(); })
       .def("derivatives",

--- a/bindings/pydrake/automotive_py.cc
+++ b/bindings/pydrake/automotive_py.cc
@@ -38,16 +38,16 @@ PYBIND11_MODULE(automotive, m) {
       .value("kBehind", AheadOrBehind::kBehind, doc.AheadOrBehind.kBehind.doc);
 
   py::enum_<RoadPositionStrategy>(m, "RoadPositionStrategy",
-      doc.RoadPositionStrategy.doc)
+                                  doc.RoadPositionStrategy.doc)
       .value("kCache", RoadPositionStrategy::kCache,
-      doc.RoadPositionStrategy.kCache.doc)
+             doc.RoadPositionStrategy.kCache.doc)
       .value("kExhaustiveSearch", RoadPositionStrategy::kExhaustiveSearch,
-      doc.RoadPositionStrategy.kExhaustiveSearch.doc);
+             doc.RoadPositionStrategy.kExhaustiveSearch.doc);
 
   py::enum_<ScanStrategy>(m, "ScanStrategy", doc.ScanStrategy.doc)
       .value("kPath", ScanStrategy::kPath, doc.ScanStrategy.kPath.doc)
       .value("kBranches", ScanStrategy::kBranches,
-        doc.ScanStrategy.kBranches.doc);
+             doc.ScanStrategy.kBranches.doc);
 
   py::class_<ClosestPose<T>>(m, "ClosestPose", doc.ClosestPose.doc)
       .def(py::init<>(), doc.ClosestPose.ctor.doc)
@@ -59,12 +59,11 @@ PYBIND11_MODULE(automotive, m) {
       .def_readwrite("odometry", &ClosestPose<T>::odometry,
                      py_reference_internal, doc.ClosestPose.odometry.doc)
       .def_readwrite("distance", &ClosestPose<T>::distance,
-                doc.ClosestPose.distance.doc);
+                     doc.ClosestPose.distance.doc);
 
   py::class_<RoadOdometry<T>> road_odometry(m, "RoadOdometry",
-    doc.RoadOdometry.doc);
-  road_odometry
-      .def(py::init<>(), doc.RoadOdometry.ctor.doc)
+                                            doc.RoadOdometry.doc);
+  road_odometry.def(py::init<>(), doc.RoadOdometry.ctor.doc)
       .def(py::init<const maliput::api::RoadPosition&,
                     const systems::rendering::FrameVelocity<T>&>(),
            py::arg("road_position"), py::arg("frame_velocity"),
@@ -77,10 +76,8 @@ PYBIND11_MODULE(automotive, m) {
            py::arg("lane"), py::arg("lane_position"), py::arg("frame_velocity"),
            // Keep alive, reference: `self` keeps `Lane*` alive.
            py::keep_alive<1, 2>(), doc.RoadOdometry.ctor.doc_3)
-      .def_readwrite("pos", &RoadOdometry<T>::pos,
-           doc.RoadOdometry.pos.doc)
-      .def_readwrite("vel", &RoadOdometry<T>::vel,
-           doc.RoadOdometry.vel.doc);
+      .def_readwrite("pos", &RoadOdometry<T>::pos, doc.RoadOdometry.pos.doc)
+      .def_readwrite("vel", &RoadOdometry<T>::vel, doc.RoadOdometry.vel.doc);
   // TODO(m-chaturvedi) Add Pybind11 documentation.
   DefReadWriteKeepAlive(&road_odometry, "lane", &RoadOdometry<T>::lane);
 
@@ -88,26 +85,26 @@ PYBIND11_MODULE(automotive, m) {
       .def(py::init<const maliput::api::Lane*, bool>(), py::arg("lane"),
            py::arg("with_s"), doc.LaneDirection.ctor.doc_5)
       .def_readwrite("lane", &LaneDirection::lane, py_reference_internal,
-           doc.LaneDirection.lane.doc)
+                     doc.LaneDirection.lane.doc)
       .def_readwrite("with_s", &LaneDirection::with_s,
-           doc.LaneDirection.with_s.doc);
+                     doc.LaneDirection.with_s.doc);
   pysystems::AddValueInstantiation<LaneDirection>(m);
 
   // TODO(eric.cousineau) Bind this named vector automatically (see #8096).
   py::class_<DrivingCommand<T>, BasicVector<T>>(m, "DrivingCommand",
-      doc.DrivingCommand.doc)
+                                                doc.DrivingCommand.doc)
       .def(py::init<>(), doc.DrivingCommand.ctor.doc)
       .def("steering_angle", &DrivingCommand<T>::steering_angle,
-      doc.DrivingCommand.steering_angle.doc)
+           doc.DrivingCommand.steering_angle.doc)
       .def("acceleration", &DrivingCommand<T>::acceleration,
-      doc.DrivingCommand.acceleration.doc)
+           doc.DrivingCommand.acceleration.doc)
       .def("set_steering_angle", &DrivingCommand<T>::set_steering_angle,
-      doc.DrivingCommand.set_steering_angle.doc)
+           doc.DrivingCommand.set_steering_angle.doc)
       .def("set_acceleration", &DrivingCommand<T>::set_acceleration,
-      doc.DrivingCommand.set_acceleration.doc);
+           doc.DrivingCommand.set_acceleration.doc);
 
   py::class_<IdmController<T>, LeafSystem<T>>(m, "IdmController",
-      doc.IdmController.doc)
+                                              doc.IdmController.doc)
       .def(py::init<const maliput::api::RoadGeometry&, ScanStrategy,
                     RoadPositionStrategy, double>(),
            py::arg("road"), py::arg("path_or_branches"),
@@ -165,28 +162,28 @@ PYBIND11_MODULE(automotive, m) {
            doc.PurePursuitController.steering_command_output.doc);
 
   // TODO(eric.cousineau) Bind this named vector automatically (see #8096).
-  py::class_<SimpleCarState<T>, BasicVector<T>>(
-      m, "SimpleCarState", doc.SimpleCarState.doc)
+  py::class_<SimpleCarState<T>, BasicVector<T>>(m, "SimpleCarState",
+                                                doc.SimpleCarState.doc)
       .def(py::init<>(), doc.SimpleCarState.ctor.doc)
       .def("x", &SimpleCarState<T>::x, doc.SimpleCarState.x.doc)
       .def("y", &SimpleCarState<T>::y, doc.SimpleCarState.y.doc)
       .def("heading", &SimpleCarState<T>::heading,
-        doc.SimpleCarState.heading.doc)
+           doc.SimpleCarState.heading.doc)
       .def("velocity", &SimpleCarState<T>::velocity,
-        doc.SimpleCarState.velocity.doc)
+           doc.SimpleCarState.velocity.doc)
       .def("set_x", &SimpleCarState<T>::set_x, doc.SimpleCarState.set_x.doc)
       .def("set_y", &SimpleCarState<T>::set_y, doc.SimpleCarState.set_y.doc)
       .def("set_heading", &SimpleCarState<T>::set_heading,
-        doc.SimpleCarState.set_heading.doc)
+           doc.SimpleCarState.set_heading.doc)
       .def("set_velocity", &SimpleCarState<T>::set_velocity,
-        doc.SimpleCarState.set_velocity.doc);
+           doc.SimpleCarState.set_velocity.doc);
 
   py::class_<SimpleCar<T>, LeafSystem<T>>(m, "SimpleCar", doc.SimpleCar.doc)
       .def(py::init<>(), doc.SimpleCar.ctor.doc_4)
       .def("state_output", &SimpleCar<T>::state_output, py_reference_internal,
-        doc.SimpleCar.state_output.doc)
+           doc.SimpleCar.state_output.doc)
       .def("pose_output", &SimpleCar<T>::pose_output, py_reference_internal,
-        doc.SimpleCar.pose_output.doc)
+           doc.SimpleCar.pose_output.doc)
       .def("velocity_output", &SimpleCar<T>::velocity_output,
            py_reference_internal, doc.SimpleCar.velocity_output.doc);
 

--- a/bindings/pydrake/automotive_py.cc
+++ b/bindings/pydrake/automotive_py.cc
@@ -63,7 +63,8 @@ PYBIND11_MODULE(automotive, m) {
 
   py::class_<RoadOdometry<T>> road_odometry(m, "RoadOdometry",
                                             doc.RoadOdometry.doc);
-  road_odometry.def(py::init<>(), doc.RoadOdometry.ctor.doc)
+  road_odometry  // BR
+      .def(py::init<>(), doc.RoadOdometry.ctor.doc)
       .def(py::init<const maliput::api::RoadPosition&,
                     const systems::rendering::FrameVelocity<T>&>(),
            py::arg("road_position"), py::arg("frame_velocity"),

--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -25,14 +25,14 @@ void BindIdentifier(py::module m, const std::string& name) {
 
   py::class_<Class> cls(m, name.c_str());
   py::handle cls_handle = cls;
-  cls
-      .def(py::init([cls_handle]() {
-        WarnDeprecated(
-          py::str(
-            "The constructor for {} in Python is deprecated. "
-            "Use `get_new_id()` if necessary.").format(cls_handle));
-        return Class{};
-      }), cls_doc.ctor.doc_3)
+  cls.def(py::init([cls_handle]() {
+            WarnDeprecated(
+                py::str("The constructor for {} in Python is deprecated. "
+                        "Use `get_new_id()` if necessary.")
+                    .format(cls_handle));
+            return Class{};
+          }),
+          cls_doc.ctor.doc_3)
       .def("get_value", &Class::get_value, cls_doc.get_value.doc)
       .def("is_valid", &Class::is_valid, cls_doc.is_valid.doc)
       .def(py::self == py::self)
@@ -61,49 +61,50 @@ PYBIND11_MODULE(geometry, m) {
            doc.SceneGraph.get_pose_bundle_output_port.doc)
       .def("get_query_output_port", &SceneGraph<T>::get_query_output_port,
            py_reference_internal, doc.SceneGraph.get_query_output_port.doc)
-      .def("RegisterSource",
-           py::overload_cast<const std::string&>(
-               &SceneGraph<T>::RegisterSource),
-           py::arg("name") = "", doc.SceneGraph.RegisterSource.doc);
+      .def(
+          "RegisterSource",
+          py::overload_cast<const std::string&>(&SceneGraph<T>::RegisterSource),
+          py::arg("name") = "", doc.SceneGraph.RegisterSource.doc);
 
   py::module::import("pydrake.systems.lcm");
   m.def("ConnectDrakeVisualizer",
         py::overload_cast<systems::DiagramBuilder<double>*,
-            const SceneGraph<double>&, lcm::DrakeLcmInterface*>(
-                &ConnectDrakeVisualizer),
+                          const SceneGraph<double>&, lcm::DrakeLcmInterface*>(
+            &ConnectDrakeVisualizer),
         py::arg("builder"), py::arg("scene_graph"), py::arg("lcm") = nullptr,
         // Keep alive, ownership: `return` keeps `builder` alive.
         py::keep_alive<0, 1>(),
         // TODO(eric.cousineau): Figure out why this is necessary (#9398).
         py_reference, doc.ConnectDrakeVisualizer.doc);
   m.def("ConnectDrakeVisualizer",
-        py::overload_cast<systems::DiagramBuilder<double>*,
-            const SceneGraph<double>&, const systems::OutputPort<double>&,
-                lcm::DrakeLcmInterface*>(&ConnectDrakeVisualizer),
-    py::arg("builder"), py::arg("scene_graph"), py::arg
-            ("pose_bundle_output_port"), py::arg("lcm") = nullptr,
-    // Keep alive, ownership: `return` keeps `builder` alive.
-    py::keep_alive<0, 1>(),
-    // TODO(eric.cousineau): Figure out why this is necessary (#9398).
-    py_reference, doc.ConnectDrakeVisualizer.doc);
-  m.def("DispatchLoadMessage", &DispatchLoadMessage,
-        py::arg("scene_graph"), py::arg("lcm"), doc.DispatchLoadMessage.doc);
+        py::overload_cast<
+            systems::DiagramBuilder<double>*, const SceneGraph<double>&,
+            const systems::OutputPort<double>&, lcm::DrakeLcmInterface*>(
+            &ConnectDrakeVisualizer),
+        py::arg("builder"), py::arg("scene_graph"),
+        py::arg("pose_bundle_output_port"), py::arg("lcm") = nullptr,
+        // Keep alive, ownership: `return` keeps `builder` alive.
+        py::keep_alive<0, 1>(),
+        // TODO(eric.cousineau): Figure out why this is necessary (#9398).
+        py_reference, doc.ConnectDrakeVisualizer.doc);
+  m.def("DispatchLoadMessage", &DispatchLoadMessage, py::arg("scene_graph"),
+        py::arg("lcm"), doc.DispatchLoadMessage.doc);
 
   // PenetrationAsPointPair
   py::class_<PenetrationAsPointPair<T>>(m, "PenetrationAsPointPair")
-    .def(py::init<>(), doc.PenetrationAsPointPair.ctor.doc_3)
-    .def_readwrite("id_A", &PenetrationAsPointPair<T>::id_A,
-      doc.PenetrationAsPointPair.id_A.doc)
-    .def_readwrite("id_B", &PenetrationAsPointPair<T>::id_B,
-      doc.PenetrationAsPointPair.id_B.doc)
-    .def_readwrite("p_WCa", &PenetrationAsPointPair<T>::p_WCa,
-      doc.PenetrationAsPointPair.p_WCa.doc)
-    .def_readwrite("p_WCb", &PenetrationAsPointPair<T>::p_WCb,
-      doc.PenetrationAsPointPair.p_WCb.doc)
-    .def_readwrite("nhat_BA_W", &PenetrationAsPointPair<T>::nhat_BA_W,
-      doc.PenetrationAsPointPair.nhat_BA_W.doc)
-    .def_readwrite("depth", &PenetrationAsPointPair<T>::depth,
-      doc.PenetrationAsPointPair.depth.doc);
+      .def(py::init<>(), doc.PenetrationAsPointPair.ctor.doc_3)
+      .def_readwrite("id_A", &PenetrationAsPointPair<T>::id_A,
+                     doc.PenetrationAsPointPair.id_A.doc)
+      .def_readwrite("id_B", &PenetrationAsPointPair<T>::id_B,
+                     doc.PenetrationAsPointPair.id_B.doc)
+      .def_readwrite("p_WCa", &PenetrationAsPointPair<T>::p_WCa,
+                     doc.PenetrationAsPointPair.p_WCa.doc)
+      .def_readwrite("p_WCb", &PenetrationAsPointPair<T>::p_WCb,
+                     doc.PenetrationAsPointPair.p_WCb.doc)
+      .def_readwrite("nhat_BA_W", &PenetrationAsPointPair<T>::nhat_BA_W,
+                     doc.PenetrationAsPointPair.nhat_BA_W.doc)
+      .def_readwrite("depth", &PenetrationAsPointPair<T>::depth,
+                     doc.PenetrationAsPointPair.depth.doc);
 }
 
 }  // namespace

--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -25,14 +25,15 @@ void BindIdentifier(py::module m, const std::string& name) {
 
   py::class_<Class> cls(m, name.c_str());
   py::handle cls_handle = cls;
-  cls.def(py::init([cls_handle]() {
-            WarnDeprecated(
-                py::str("The constructor for {} in Python is deprecated. "
-                        "Use `get_new_id()` if necessary.")
-                    .format(cls_handle));
-            return Class{};
-          }),
-          cls_doc.ctor.doc_3)
+  cls  // BR
+      .def(py::init([cls_handle]() {
+             WarnDeprecated(
+                 py::str("The constructor for {} in Python is deprecated. "
+                         "Use `get_new_id()` if necessary.")
+                     .format(cls_handle));
+             return Class{};
+           }),
+           cls_doc.ctor.doc_3)
       .def("get_value", &Class::get_value, cls_doc.get_value.doc)
       .def("is_valid", &Class::is_valid, cls_doc.is_valid.doc)
       .def(py::self == py::self)
@@ -61,10 +62,10 @@ PYBIND11_MODULE(geometry, m) {
            doc.SceneGraph.get_pose_bundle_output_port.doc)
       .def("get_query_output_port", &SceneGraph<T>::get_query_output_port,
            py_reference_internal, doc.SceneGraph.get_query_output_port.doc)
-      .def(
-          "RegisterSource",
-          py::overload_cast<const std::string&>(&SceneGraph<T>::RegisterSource),
-          py::arg("name") = "", doc.SceneGraph.RegisterSource.doc);
+      .def("RegisterSource",
+           py::overload_cast<const std::string&>(  // BR
+               &SceneGraph<T>::RegisterSource),
+           py::arg("name") = "", doc.SceneGraph.RegisterSource.doc);
 
   py::module::import("pydrake.systems.lcm");
   m.def("ConnectDrakeVisualizer",

--- a/bindings/pydrake/lcm_py.cc
+++ b/bindings/pydrake/lcm_py.cc
@@ -29,17 +29,17 @@ PYBIND11_MODULE(lcm, m) {
     py::class_<Class>(m, "DrakeLcmInterface", doc.DrakeLcmInterface.doc)
         // N.B. We do not bind `Subscribe` as multi-threading from C++ may
         // wreak havoc on the Python GIL with a callback.
-        .def("Publish", [](
-              Class* self, const std::string& channel,
-              py::bytes buffer, optional<double> time_sec) {
-            // TODO(eric.cousineau): See if there is a way to extra the raw
-            // bytes from `buffer` without copying.
-            std::string str = buffer;
-            self->Publish(channel, str.data(), str.size(), time_sec);
-          },
-          py::arg("channel"), py::arg("buffer"),
-          py::arg("time_sec") = py::none(),
-          doc.DrakeLcmInterface.Publish.doc);
+        .def("Publish",
+             [](Class* self, const std::string& channel, py::bytes buffer,
+                optional<double> time_sec) {
+               // TODO(eric.cousineau): See if there is a way to extra the raw
+               // bytes from `buffer` without copying.
+               std::string str = buffer;
+               self->Publish(channel, str.data(), str.size(), time_sec);
+             },
+             py::arg("channel"), py::arg("buffer"),
+             py::arg("time_sec") = py::none(),
+             doc.DrakeLcmInterface.Publish.doc);
   }
 
   {
@@ -47,41 +47,42 @@ PYBIND11_MODULE(lcm, m) {
     py::class_<Class, DrakeLcmInterface>(m, "DrakeLcm", doc.DrakeLcm.doc)
         .def(py::init<>(), doc.DrakeLcm.ctor.doc_3)
         .def("StartReceiveThread", &Class::StartReceiveThread,
-          doc.DrakeLcm.StartReceiveThread.doc)
+             doc.DrakeLcm.StartReceiveThread.doc)
         .def("StopReceiveThread", &Class::StopReceiveThread,
-          doc.DrakeLcm.StopReceiveThread.doc);
+             doc.DrakeLcm.StopReceiveThread.doc);
     // TODO(eric.cousineau): Add remaining methods.
   }
 
   {
     using Class = DrakeMockLcm;
-    py::class_<Class, DrakeLcmInterface>(
-        m, "DrakeMockLcm", doc.DrakeMockLcm.doc)
+    py::class_<Class, DrakeLcmInterface>(m, "DrakeMockLcm",
+                                         doc.DrakeMockLcm.doc)
         .def(py::init<>(), doc.DrakeMockLcm.ctor.doc_3)
-        .def("Subscribe", [](
-              Class* self, const std::string& channel,
-              PyHandlerFunction handler) {
-            self->Subscribe(
-                channel,
-                [handler](const void* data, int size) {
-                  handler(py::bytes(static_cast<const char*>(data), size));
-                });
-          }, py::arg("channel"), py::arg("handler"),
-            doc.DrakeMockLcm.Subscribe.doc)
-        .def("InduceSubscriberCallback", [](
-              Class* self, const std::string& channel, py::bytes buffer) {
-            std::string str = buffer;
-            self->InduceSubscriberCallback(channel, str.data(), str.size());
-          }, py::arg("channel"), py::arg("buffer"),
-            doc.DrakeMockLcm.InduceSubscriberCallback.doc)
-        .def("get_last_published_message", [](
-              const Class* self, const std::string& channel) {
-            const std::vector<uint8_t>& bytes =
-                self->get_last_published_message(channel);
-            return py::bytes(
-                reinterpret_cast<const char*>(bytes.data()), bytes.size());
-          }, py::arg("channel"),
-          doc.DrakeMockLcm.get_last_published_message.doc);
+        .def("Subscribe",
+             [](Class* self, const std::string& channel,
+                PyHandlerFunction handler) {
+               self->Subscribe(channel, [handler](const void* data, int size) {
+                 handler(py::bytes(static_cast<const char*>(data), size));
+               });
+             },
+             py::arg("channel"), py::arg("handler"),
+             doc.DrakeMockLcm.Subscribe.doc)
+        .def("InduceSubscriberCallback",
+             [](Class* self, const std::string& channel, py::bytes buffer) {
+               std::string str = buffer;
+               self->InduceSubscriberCallback(channel, str.data(), str.size());
+             },
+             py::arg("channel"), py::arg("buffer"),
+             doc.DrakeMockLcm.InduceSubscriberCallback.doc)
+        .def("get_last_published_message",
+             [](const Class* self, const std::string& channel) {
+               const std::vector<uint8_t>& bytes =
+                   self->get_last_published_message(channel);
+               return py::bytes(reinterpret_cast<const char*>(bytes.data()),
+                                bytes.size());
+             },
+             py::arg("channel"),
+             doc.DrakeMockLcm.get_last_published_message.doc);
     // TODO(eric.cousineau): Add remaining methods.
   }
 }

--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -35,20 +35,21 @@ PYBIND11_MODULE(math, m) {
 
   py::class_<BarycentricMesh<T>>(m, "BarycentricMesh", doc.BarycentricMesh.doc)
       .def(py::init<BarycentricMesh<T>::MeshGrid>(),
-          doc.BarycentricMesh.ctor.doc_3)
+           doc.BarycentricMesh.ctor.doc_3)
       .def("get_input_grid", &BarycentricMesh<T>::get_input_grid,
-          doc.BarycentricMesh.get_input_grid.doc)
+           doc.BarycentricMesh.get_input_grid.doc)
       .def("get_input_size", &BarycentricMesh<T>::get_input_size,
-          doc.BarycentricMesh.get_input_size.doc)
+           doc.BarycentricMesh.get_input_size.doc)
       .def("get_num_mesh_points", &BarycentricMesh<T>::get_num_mesh_points,
-          doc.BarycentricMesh.get_num_mesh_points.doc)
+           doc.BarycentricMesh.get_num_mesh_points.doc)
       .def("get_num_interpolants", &BarycentricMesh<T>::get_num_interpolants,
-          doc.BarycentricMesh.get_num_interpolants.doc)
-      .def("get_mesh_point", overload_cast_explicit<VectorX<T>, int>(
-                                 &BarycentricMesh<T>::get_mesh_point),
-          doc.BarycentricMesh.get_mesh_point.doc)
+           doc.BarycentricMesh.get_num_interpolants.doc)
+      .def("get_mesh_point",
+           overload_cast_explicit<VectorX<T>, int>(
+               &BarycentricMesh<T>::get_mesh_point),
+           doc.BarycentricMesh.get_mesh_point.doc)
       .def("get_all_mesh_points", &BarycentricMesh<T>::get_all_mesh_points,
-          doc.BarycentricMesh.get_all_mesh_points.doc)
+           doc.BarycentricMesh.get_all_mesh_points.doc)
       .def("EvalBarycentricWeights",
            [](const BarycentricMesh<T>* self,
               const Eigen::Ref<const VectorX<T>>& input) {
@@ -57,13 +58,16 @@ PYBIND11_MODULE(math, m) {
              VectorX<T> weights(n);
              self->EvalBarycentricWeights(input, &indices, &weights);
              return std::make_pair(indices, weights);
-           }, doc.BarycentricMesh.EvalBarycentricWeights.doc)
-      .def("Eval", overload_cast_explicit<VectorX<T>,
-                                          const Eigen::Ref<const MatrixX<T>>&,
-                                          const Eigen::Ref<const VectorX<T>>&>(
-                       &BarycentricMesh<T>::Eval), doc.BarycentricMesh.Eval.doc)
+           },
+           doc.BarycentricMesh.EvalBarycentricWeights.doc)
+      .def("Eval",
+           overload_cast_explicit<VectorX<T>,
+                                  const Eigen::Ref<const MatrixX<T>>&,
+                                  const Eigen::Ref<const VectorX<T>>&>(
+               &BarycentricMesh<T>::Eval),
+           doc.BarycentricMesh.Eval.doc)
       .def("MeshValuesFrom", &BarycentricMesh<T>::MeshValuesFrom,
-          doc.BarycentricMesh.MeshValuesFrom.doc);
+           doc.BarycentricMesh.MeshValuesFrom.doc);
 
   py::class_<RigidTransform<T>>(m, "RigidTransform", doc.RigidTransform.doc)
       .def(py::init(), doc.RigidTransform.ctor.doc_3)
@@ -76,94 +80,96 @@ PYBIND11_MODULE(math, m) {
       .def(py::init<const Eigen::AngleAxis<T>&, const Vector3<T>&>(),
            py::arg("theta_lambda"), py::arg("p"), doc.RigidTransform.ctor.doc_7)
       .def(py::init<const RotationMatrix<T>&>(), py::arg("R"),
-          doc.RigidTransform.ctor.doc_8)
+           doc.RigidTransform.ctor.doc_8)
       .def(py::init<const Vector3<T>&>(), py::arg("p"),
-          doc.RigidTransform.ctor.doc_9)
+           doc.RigidTransform.ctor.doc_9)
       .def(py::init<const Isometry3<T>&>(), py::arg("pose"),
-          doc.RigidTransform.ctor.doc_10)
+           doc.RigidTransform.ctor.doc_10)
       .def("set", &RigidTransform<T>::set, py::arg("R"), py::arg("p"),
-          doc.RigidTransform.set.doc)
+           doc.RigidTransform.set.doc)
       .def("SetFromIsometry3", &RigidTransform<T>::SetFromIsometry3,
            py::arg("pose"), doc.RigidTransform.SetFromIsometry3.doc)
       .def_static("Identity", &RigidTransform<T>::Identity,
-          doc.RigidTransform.Identity.doc)
+                  doc.RigidTransform.Identity.doc)
       .def("rotation", &RigidTransform<T>::rotation, py_reference_internal,
-          doc.RigidTransform.rotation.doc)
+           doc.RigidTransform.rotation.doc)
       .def("set_rotation", &RigidTransform<T>::set_rotation, py::arg("R"),
-          doc.RigidTransform.set_rotation.doc)
+           doc.RigidTransform.set_rotation.doc)
       .def("translation", &RigidTransform<T>::translation,
            py_reference_internal, doc.RigidTransform.translation.doc)
       .def("set_translation", &RigidTransform<T>::set_translation, py::arg("p"),
            doc.RigidTransform.set_translation.doc)
       .def("GetAsMatrix4", &RigidTransform<T>::GetAsMatrix4,
-          doc.RigidTransform.GetAsMatrix4.doc)
+           doc.RigidTransform.GetAsMatrix4.doc)
       .def("GetAsMatrix34", &RigidTransform<T>::GetAsMatrix34,
-          doc.RigidTransform.GetAsMatrix34.doc)
+           doc.RigidTransform.GetAsMatrix34.doc)
       .def("GetAsIsometry3", &RigidTransform<T>::GetAsIsometry3,
-          doc.RigidTransform.GetAsIsometry3.doc)
+           doc.RigidTransform.GetAsIsometry3.doc)
       .def("SetIdentity", &RigidTransform<T>::SetIdentity,
-          doc.RigidTransform.SetIdentity.doc)
+           doc.RigidTransform.SetIdentity.doc)
       // .def("IsExactlyIdentity", ...)
       // .def("IsIdentityToEpsilon", ...)
       .def("inverse", &RigidTransform<T>::inverse,
-        doc.RigidTransform.inverse.doc)
+           doc.RigidTransform.inverse.doc)
       // TODO(eric.cousineau): Use `matmul` operator once we support Python3.
-      .def("multiply", [](
-          const RigidTransform<T>* self, const RigidTransform<T>& other) {
-        return *self * other;
-      }, py::arg("other"), doc.RigidTransform.operator_mul.doc)
-      .def("multiply", [](
-          const RigidTransform<T>* self, const Vector3<T>& p_BoQ_B) {
-        return *self * p_BoQ_B;
-      }, py::arg("p_BoQ_B"), doc.RigidTransform.operator_mul.doc_2);
-      // .def("IsNearlyEqualTo", ...)
-      // .def("IsExactlyEqualTo", ...)
+      .def("multiply",
+           [](const RigidTransform<T>* self, const RigidTransform<T>& other) {
+             return *self * other;
+           },
+           py::arg("other"), doc.RigidTransform.operator_mul.doc)
+      .def("multiply",
+           [](const RigidTransform<T>* self, const Vector3<T>& p_BoQ_B) {
+             return *self * p_BoQ_B;
+           },
+           py::arg("p_BoQ_B"), doc.RigidTransform.operator_mul.doc_2);
+  // .def("IsNearlyEqualTo", ...)
+  // .def("IsExactlyEqualTo", ...)
 
   py::class_<RollPitchYaw<T>>(m, "RollPitchYaw")
       .def(py::init<const Vector3<T>>(), py::arg("rpy"),
-        doc.RollPitchYaw.ctor.doc_3)
-      .def(py::init<const T&, const T&, const T&>(),
-        py::arg("roll"), py::arg("pitch"), py::arg("yaw"),
-        doc.RollPitchYaw.ctor.doc_4)
+           doc.RollPitchYaw.ctor.doc_3)
+      .def(py::init<const T&, const T&, const T&>(), py::arg("roll"),
+           py::arg("pitch"), py::arg("yaw"), doc.RollPitchYaw.ctor.doc_4)
       .def(py::init<const RotationMatrix<T>&>(), py::arg("R"),
-        doc.RollPitchYaw.ctor.doc_5)
+           doc.RollPitchYaw.ctor.doc_5)
       .def(py::init<const Eigen::Quaternion<T>&>(), py::arg("quaternion"),
-        doc.RollPitchYaw.ctor.doc_6)
+           doc.RollPitchYaw.ctor.doc_6)
       .def("vector", &RollPitchYaw<T>::vector, doc.RollPitchYaw.vector.doc)
       .def("roll_angle", &RollPitchYaw<T>::roll_angle,
-        doc.RollPitchYaw.roll_angle.doc)
+           doc.RollPitchYaw.roll_angle.doc)
       .def("pitch_angle", &RollPitchYaw<T>::pitch_angle,
-        doc.RollPitchYaw.pitch_angle.doc)
+           doc.RollPitchYaw.pitch_angle.doc)
       .def("yaw_angle", &RollPitchYaw<T>::yaw_angle,
-        doc.RollPitchYaw.yaw_angle.doc)
+           doc.RollPitchYaw.yaw_angle.doc)
       .def("ToQuaternion", &RollPitchYaw<T>::ToQuaternion,
-        doc.RollPitchYaw.ToQuaternion.doc)
+           doc.RollPitchYaw.ToQuaternion.doc)
       .def("ToRotationMatrix", &RollPitchYaw<T>::ToRotationMatrix,
-        doc.RollPitchYaw.ToRotationMatrix.doc);
+           doc.RollPitchYaw.ToRotationMatrix.doc);
 
   py::class_<RotationMatrix<T>>(m, "RotationMatrix", doc.RotationMatrix.doc)
       .def(py::init(), doc.RotationMatrix.ctor.doc_3)
       .def(py::init<const Matrix3<T>&>(), py::arg("R"),
-        doc.RotationMatrix.ctor.doc_4)
+           doc.RotationMatrix.ctor.doc_4)
       .def(py::init<Eigen::Quaternion<T>>(), py::arg("quaternion"),
-        doc.RotationMatrix.ctor.doc_5)
+           doc.RotationMatrix.ctor.doc_5)
       .def(py::init<const RollPitchYaw<T>&>(), py::arg("rpy"),
-        doc.RotationMatrix.ctor.doc_7)
+           doc.RotationMatrix.ctor.doc_7)
       .def("matrix", &RotationMatrix<T>::matrix, doc.RotationMatrix.matrix.doc)
       // Do not define an operator until we have the Python3 `@` operator so
       // that operations are similar to those of arrays.
       .def("multiply",
            [](const RotationMatrix<T>& self, const RotationMatrix<T>& other) {
              return self * other;
-           }, doc.RotationMatrix.operator_mul.doc)
+           },
+           doc.RotationMatrix.operator_mul.doc)
       .def("inverse", &RotationMatrix<T>::inverse,
-        doc.RotationMatrix.inverse.doc)
+           doc.RotationMatrix.inverse.doc)
       .def("ToQuaternion",
            overload_cast_explicit<Eigen::Quaternion<T>>(
-              &RotationMatrix<T>::ToQuaternion),
-               doc.RotationMatrix.ToQuaternion.doc)
+               &RotationMatrix<T>::ToQuaternion),
+           doc.RotationMatrix.ToQuaternion.doc)
       .def_static("Identity", &RotationMatrix<T>::Identity,
-        doc.RotationMatrix.Identity.doc);
+                  doc.RotationMatrix.Identity.doc);
 
   // General math overloads.
   // N.B. Additional overloads will be added for autodiff, symbolic, etc, by
@@ -176,8 +182,7 @@ PYBIND11_MODULE(math, m) {
   // always occur first, so it shouldn't be a problem.
   // See `math_overloads_test`, which tests this specifically.
   // TODO(m-chaturvedi) Add Pybind11 documentation.
-  m
-      .def("log", [](double x) { return log(x); })
+  m.def("log", [](double x) { return log(x); })
       .def("abs", [](double x) { return fabs(x); })
       .def("exp", [](double x) { return exp(x); })
       .def("sqrt", [](double x) { return sqrt(x); })

--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -182,7 +182,8 @@ PYBIND11_MODULE(math, m) {
   // always occur first, so it shouldn't be a problem.
   // See `math_overloads_test`, which tests this specifically.
   // TODO(m-chaturvedi) Add Pybind11 documentation.
-  m.def("log", [](double x) { return log(x); })
+  m  // BR
+      .def("log", [](double x) { return log(x); })
       .def("abs", [](double x) { return fabs(x); })
       .def("exp", [](double x) { return exp(x); })
       .def("sqrt", [](double x) { return sqrt(x); })

--- a/bindings/pydrake/perception_py.cc
+++ b/bindings/pydrake/perception_py.cc
@@ -34,8 +34,7 @@ void init_pc_flags(py::module m) {
     using Class = Fields;
     constexpr auto& cls_doc = doc.Fields;
     py::class_<Class>(m, "Fields", cls_doc.doc)
-        .def(py::init<BaseFieldT>(), py::arg("base_fields"),
-             cls_doc.ctor.doc_4)
+        .def(py::init<BaseFieldT>(), py::arg("base_fields"), cls_doc.ctor.doc_4)
         .def("base_fields", &Class::base_fields, cls_doc.base_fields.doc)
         .def("has_base_fields", &Class::has_base_fields,
              cls_doc.has_base_fields.doc)
@@ -65,15 +64,11 @@ void init_perception(py::module m) {
     cls.attr("D") = GetPyParam<Class::D>()[0];
     // N.B. Workaround linking error for `constexpr` bits.
     cls.attr("kDefaultValue") = Class::T{Class::kDefaultValue};
-    cls
-        .def_static(
-            "IsDefaultValue", &Class::IsDefaultValue, py::arg("value"),
-            cls_doc.IsDefaultValue.doc)
-        .def_static(
-            "IsInvalidValue", &Class::IsInvalidValue, py::arg("value"),
-            cls_doc.IsInvalidValue.doc)
-        .def(py::init<int, pc_flags::Fields>(),
-             py::arg("new_size") = 0,
+    cls.def_static("IsDefaultValue", &Class::IsDefaultValue, py::arg("value"),
+                   cls_doc.IsDefaultValue.doc)
+        .def_static("IsInvalidValue", &Class::IsInvalidValue, py::arg("value"),
+                    cls_doc.IsInvalidValue.doc)
+        .def(py::init<int, pc_flags::Fields>(), py::arg("new_size") = 0,
              py::arg("fields") = pc_flags::Fields(pc_flags::kXYZs),
              cls_doc.ctor.doc)
         .def(py::init<const PointCloud&>(), py::arg("other"),
@@ -81,9 +76,7 @@ void init_perception(py::module m) {
         .def("fields", &Class::fields, cls_doc.fields.doc)
         .def("size", &Class::size, cls_doc.size.doc)
         .def("resize",
-             [](PointCloud* self, int new_size) {
-               self->resize(new_size);
-             },
+             [](PointCloud* self, int new_size) { self->resize(new_size); },
              py::arg("new_size"), cls_doc.resize.doc)
         .def("has_xyzs", &Class::has_xyzs, cls_doc.has_xyzs.doc)
         .def("xyzs", &Class::xyzs, py_reference_internal, cls_doc.xyzs.doc)
@@ -104,8 +97,8 @@ void init_perception(py::module m) {
   {
     using Class = DepthImageToPointCloud;
     constexpr auto& cls_doc = doc.DepthImageToPointCloud;
-    py::class_<Class, LeafSystem<double>>(
-        m, "DepthImageToPointCloud", cls_doc.doc)
+    py::class_<Class, LeafSystem<double>>(m, "DepthImageToPointCloud",
+                                          cls_doc.doc)
         .def(py::init<const CameraInfo&>(), py::arg("camera_info"),
              cls_doc.ctor.doc_3)
         .def("depth_image_input_port", &Class::depth_image_input_port,

--- a/bindings/pydrake/pydrake_pybind.h
+++ b/bindings/pydrake/pydrake_pybind.h
@@ -214,7 +214,8 @@ from `DiagramBuilder` to `Diagram` when calling
 ## Function Overloads
 
 To bind function overloads, please try the following (in order):
-- `py::overload_cast<Args>(func)`: See [the pybind11 documentation](http://pybind11.readthedocs.io/en/stable/classes.html#overloaded-methods).
+- `py::overload_cast<Args>(func)`: See [the pybind11
+documentation](http://pybind11.readthedocs.io/en/stable/classes.html#overloaded-methods).
 This works about 80% of the time.
 - `pydrake::overload_cast_explicit<Return, Args...>(func)`: When
 `py::overload_cast` does not work (not always guaranteed to work).
@@ -296,8 +297,7 @@ const auto py_reference = py::return_value_policy::reference;
 /// Used when returning references to objects that are internally owned by
 /// `self`. Implies both `py_reference` and `py::keep_alive<0, 1>`, which
 /// implies "Keep alive, reference: `return` keeps` self` alive".
-const auto py_reference_internal =
-    py::return_value_policy::reference_internal;
+const auto py_reference_internal = py::return_value_policy::reference_internal;
 
 // Implementation for `overload_cast_explicit`. We must use this structure so
 // that we can constrain what is inferred. Otherwise, the ambiguity confuses
@@ -334,15 +334,15 @@ inline void ExecuteExtraPythonCode(py::module m) {
 // reimported in Python3. See pybind/pybind11#1559 for more details.
 // Use this ONLY when necessary (e.g. when using a utility method which imports
 // the module, within the module itself).
-#define PYDRAKE_PREVENT_PYTHON3_MODULE_REIMPORT(variable) \
-  { \
-    static py::handle variable##_original; \
-    if (variable##_original) { \
+#define PYDRAKE_PREVENT_PYTHON3_MODULE_REIMPORT(variable)                 \
+  {                                                                       \
+    static py::handle variable##_original;                                \
+    if (variable##_original) {                                            \
       variable = py::reinterpret_borrow<py::module>(variable##_original); \
-      return; \
-    } else { \
-      variable##_original = variable; \
-    } \
+      return;                                                             \
+    } else {                                                              \
+      variable##_original = variable;                                     \
+    }                                                                     \
   }
 #else  // PY_MAJOR_VERSION >= 3
 #define PYDRAKE_PREVENT_PYTHON3_MODULE_REIMPORT(variable)

--- a/bindings/pydrake/symbolic_py.cc
+++ b/bindings/pydrake/symbolic_py.cc
@@ -120,7 +120,7 @@ PYBIND11_MODULE(symbolic, m) {
   py::class_<Variables>(m, "Variables", doc.Variables.doc)
       .def(py::init<>(), doc.Variables.ctor.doc_3)
       .def(py::init<const Eigen::Ref<const VectorX<Variable>>&>(),
-        doc.Variables.ctor.doc_5)
+           doc.Variables.ctor.doc_5)
       .def("size", &Variables::size, doc.Variables.size.doc)
       .def("__len__", &Variables::size, doc.Variables.size.doc)
       .def("empty", &Variables::empty)
@@ -134,25 +134,27 @@ PYBIND11_MODULE(symbolic, m) {
            [](const Variables& self) { return std::hash<Variables>{}(self); })
       .def("insert",
            [](Variables& self, const Variable& var) { self.insert(var); },
-        doc.Variables.insert.doc)
+           doc.Variables.insert.doc)
       .def("insert",
            [](Variables& self, const Variables& vars) { self.insert(vars); },
-        doc.Variables.insert.doc_2)
+           doc.Variables.insert.doc_2)
       .def("erase",
            [](Variables& self, const Variable& var) { return self.erase(var); },
-        doc.Variables.erase.doc)
-      .def("erase", [](Variables& self,
-                       const Variables& vars) { return self.erase(vars); },
-        doc.Variables.erase.doc_2)
+           doc.Variables.erase.doc)
+      .def("erase",
+           [](Variables& self, const Variables& vars) {
+             return self.erase(vars);
+           },
+           doc.Variables.erase.doc_2)
       .def("include", &Variables::include, doc.Variables.include.doc)
       .def("__contains__", &Variables::include)
       .def("IsSubsetOf", &Variables::IsSubsetOf, doc.Variables.IsSubsetOf.doc)
       .def("IsSupersetOf", &Variables::IsSupersetOf,
-        doc.Variables.IsSupersetOf.doc)
+           doc.Variables.IsSupersetOf.doc)
       .def("IsStrictSubsetOf", &Variables::IsStrictSubsetOf,
-        doc.Variables.IsStrictSubsetOf.doc)
+           doc.Variables.IsStrictSubsetOf.doc)
       .def("IsStrictSupersetOf", &Variables::IsStrictSupersetOf,
-        doc.Variables.IsStrictSupersetOf.doc)
+           doc.Variables.IsStrictSupersetOf.doc)
       .def("EqualTo", [](const Variables& self,
                          const Variables& vars) { return self == vars; })
       .def("__iter__",
@@ -189,25 +191,29 @@ PYBIND11_MODULE(symbolic, m) {
       .def("to_string", &Expression::to_string, doc.Expression.to_string.doc)
       .def("Expand", &Expression::Expand, doc.Expression.Expand.doc)
       .def("Evaluate",
-        [](const Expression& self, const Environment::map& env) {
-          return self.Evaluate(Environment{env});
-        }, py::arg("env") = Environment::map{}, doc.Expression.Evaluate.doc)
+           [](const Expression& self, const Environment::map& env) {
+             return self.Evaluate(Environment{env});
+           },
+           py::arg("env") = Environment::map{}, doc.Expression.Evaluate.doc)
       .def("Evaluate",
            [](const Expression& self, const Environment::map& env) {
              return self.Evaluate(Environment{env});
-           }, doc.Expression.Evaluate.doc)
+           },
+           doc.Expression.Evaluate.doc)
       .def("EvaluatePartial",
            [](const Expression& self, const Environment::map& env) {
              return self.EvaluatePartial(Environment{env});
-           }, doc.Expression.EvaluatePartial.doc)
+           },
+           doc.Expression.EvaluatePartial.doc)
       .def("Substitute",
            [](const Expression& self, const Variable& var,
               const Expression& e) { return self.Substitute(var, e); },
-            doc.Expression.Substitute.doc)
+           doc.Expression.Substitute.doc)
       .def("Substitute",
            [](const Expression& self, const Substitution& s) {
              return self.Substitute(s);
-           }, doc.Expression.Substitute.doc_2)
+           },
+           doc.Expression.Substitute.doc_2)
       .def("EqualTo", &Expression::EqualTo, doc.Expression.EqualTo.doc)
       // Addition
       .def(py::self + py::self)
@@ -284,7 +290,7 @@ PYBIND11_MODULE(symbolic, m) {
       .def(py::self != Variable())
       .def(py::self != double())
       .def("Differentiate", &Expression::Differentiate,
-        doc.Expression.Differentiate.doc)
+           doc.Expression.Differentiate.doc)
       .def("Jacobian", &Expression::Jacobian, doc.Expression.Jacobian.doc)
       // TODO(eric.cousineau): Figure out how to consolidate with the below
       // methods.
@@ -334,35 +340,43 @@ PYBIND11_MODULE(symbolic, m) {
 
   m.def("if_then_else", &symbolic::if_then_else);
 
-  m.def("Jacobian", [](const Eigen::Ref<const VectorX<Expression>>& f,
-                       const Eigen::Ref<const VectorX<Variable>>& vars) {
-    return Jacobian(f, vars);
-  }, doc.Expression.Jacobian.doc);
+  m.def("Jacobian",
+        [](const Eigen::Ref<const VectorX<Expression>>& f,
+           const Eigen::Ref<const VectorX<Variable>>& vars) {
+          return Jacobian(f, vars);
+        },
+        doc.Expression.Jacobian.doc);
 
   py::class_<Formula> formula(m, "Formula", doc.Formula.doc);
   formula
       .def("GetFreeVariables", &Formula::GetFreeVariables,
-        doc.Formula.GetFreeVariables.doc)
+           doc.Formula.GetFreeVariables.doc)
       .def("EqualTo", &Formula::EqualTo, doc.Formula.EqualTo.doc)
       .def("Evaluate",
            [](const Formula& self, const Environment::map& env) {
              return self.Evaluate(Environment{env});
-           }, doc.Formula.Evaluate.doc)
+           },
+           doc.Formula.Evaluate.doc)
       .def("Substitute",
            [](const Formula& self, const Variable& var, const Expression& e) {
              return self.Substitute(var, e);
-           }, doc.Formula.Substitute.doc)
+           },
+           doc.Formula.Substitute.doc)
       .def("Substitute",
            [](const Formula& self, const Variable& var1, const Variable& var2) {
              return self.Substitute(var1, var2);
-           }, doc.Formula.Substitute.doc_2)
-      .def("Substitute", [](const Formula& self, const Variable& var,
-                            const double c) { return self.Substitute(var, c); },
-          doc.Formula.Substitute.doc_2)
+           },
+           doc.Formula.Substitute.doc_2)
+      .def("Substitute",
+           [](const Formula& self, const Variable& var, const double c) {
+             return self.Substitute(var, c);
+           },
+           doc.Formula.Substitute.doc_2)
       .def("Substitute",
            [](const Formula& self, const Substitution& s) {
              return self.Substitute(s);
-           }, doc.Formula.Substitute.doc_2)
+           },
+           doc.Formula.Substitute.doc_2)
       .def("to_string", &Formula::to_string, doc.Formula.to_string.doc)
       .def("__str__", &Formula::to_string)
       .def("__repr__",
@@ -411,7 +425,7 @@ PYBIND11_MODULE(symbolic, m) {
       .def(py::init<const map<Variable, int>&>(), doc.Monomial.ctor.doc_6)
       .def("degree", &Monomial::degree, doc.Monomial.degree.doc)
       .def("total_degree", &Monomial::total_degree,
-        doc.Monomial.total_degree.doc)
+           doc.Monomial.total_degree.doc)
       .def(py::self * py::self)
       .def(py::self *= py::self)
       .def(py::self == py::self)
@@ -428,27 +442,31 @@ PYBIND11_MODULE(symbolic, m) {
       .def("EqualTo", [](const Monomial& self,
                          const Monomial& monomial) { return self == monomial; })
       .def("GetVariables", &Monomial::GetVariables,
-        doc.Monomial.GetVariables.doc)
+           doc.Monomial.GetVariables.doc)
       .def("get_powers", &Monomial::get_powers, py_reference_internal,
-        doc.Monomial.get_powers.doc)
+           doc.Monomial.get_powers.doc)
       .def("ToExpression", &Monomial::ToExpression,
-        doc.Monomial.ToExpression.doc)
+           doc.Monomial.ToExpression.doc)
       .def("Evaluate",
            [](const Monomial& self, const Environment::map& env) {
              return self.Evaluate(Environment{env});
-           }, doc.Monomial.Evaluate.doc)
+           },
+           doc.Monomial.Evaluate.doc)
       .def("pow_in_place", &Monomial::pow_in_place, py_reference_internal,
-        doc.Monomial.pow_in_place.doc)
+           doc.Monomial.pow_in_place.doc)
       .def("__pow__",
            [](const Monomial& self, const int p) { return pow(self, p); });
 
   m.def("MonomialBasis",
         [](const Eigen::Ref<const VectorX<Variable>>& vars, const int degree) {
           return MonomialBasis(Variables{vars}, degree);
-        }, doc.MonomialBasis.doc)
-      .def("MonomialBasis", [](const Variables& vars, const int degree) {
-        return MonomialBasis(vars, degree);
-      }, doc.MonomialBasis.doc);
+        },
+        doc.MonomialBasis.doc)
+      .def("MonomialBasis",
+           [](const Variables& vars, const int degree) {
+             return MonomialBasis(vars, degree);
+           },
+           doc.MonomialBasis.doc);
 
   // TODO(m-chaturvedi) Add Pybind11 documentation for operator overloads, etc.
   py::class_<Polynomial>(m, "Polynomial", doc.Polynomial.doc)
@@ -457,25 +475,26 @@ PYBIND11_MODULE(symbolic, m) {
       .def(py::init<const Monomial&>(), doc.Polynomial.ctor.doc_6)
       .def(py::init<const Expression&>(), doc.Polynomial.ctor.doc_7)
       .def(py::init<const Expression&, const Variables&>(),
-        doc.Polynomial.ctor.doc_7)
+           doc.Polynomial.ctor.doc_7)
       .def(py::init([](const Expression& e,
                        const Eigen::Ref<const VectorX<Variable>>& vars) {
-        return Polynomial{e, Variables{vars}};
-      }), doc.Polynomial.ctor.doc_8)
+             return Polynomial{e, Variables{vars}};
+           }),
+           doc.Polynomial.ctor.doc_8)
       .def("indeterminates", &Polynomial::indeterminates,
-        doc.Polynomial.indeterminates.doc, doc.Polynomial.indeterminates.doc)
+           doc.Polynomial.indeterminates.doc, doc.Polynomial.indeterminates.doc)
       .def("decision_variables", &Polynomial::decision_variables,
-        doc.Polynomial.decision_variables.doc)
+           doc.Polynomial.decision_variables.doc)
       .def("Degree", &Polynomial::Degree, doc.Polynomial.Degree.doc)
       .def("TotalDegree", &Polynomial::TotalDegree,
-        doc.Polynomial.TotalDegree.doc)
+           doc.Polynomial.TotalDegree.doc)
       .def("monomial_to_coefficient_map",
            &Polynomial::monomial_to_coefficient_map,
-          doc.Polynomial.monomial_to_coefficient_map.doc)
+           doc.Polynomial.monomial_to_coefficient_map.doc)
       .def("ToExpression", &Polynomial::ToExpression,
-        doc.Polynomial.ToExpression.doc)
+           doc.Polynomial.ToExpression.doc)
       .def("Differentiate", &Polynomial::Differentiate,
-        doc.Polynomial.Differentiate.doc)
+           doc.Polynomial.Differentiate.doc)
       .def("AddProduct", &Polynomial::AddProduct, doc.Polynomial.AddProduct.doc)
       .def(py::self + py::self)
       .def(py::self + Monomial())
@@ -509,11 +528,14 @@ PYBIND11_MODULE(symbolic, m) {
       .def("Evaluate",
            [](const Polynomial& self, const Environment::map& env) {
              return self.Evaluate(Environment{env});
-           }, doc.Polynomial.Evaluate.doc)
-      .def("Jacobian", [](const Polynomial& p,
-                          const Eigen::Ref<const VectorX<Variable>>& vars) {
-        return p.Jacobian(vars);
-      }, doc.Polynomial.Jacobian.doc);
+           },
+           doc.Polynomial.Evaluate.doc)
+      .def("Jacobian",
+           [](const Polynomial& p,
+              const Eigen::Ref<const VectorX<Variable>>& vars) {
+             return p.Jacobian(vars);
+           },
+           doc.Polynomial.Jacobian.doc);
 
   // We have this line because pybind11 does not permit transitive
   // conversions. See

--- a/bindings/pydrake/test/autodiffutils_test_util_py.cc
+++ b/bindings/pydrake/test/autodiffutils_test_util_py.cc
@@ -13,12 +13,10 @@ PYBIND11_MODULE(autodiffutils_test_util, m) {
   py::module::import("pydrake.autodiffutils");
 
   // For testing implicit argument conversion.
-  m.def("autodiff_scalar_pass_through", [](const AutoDiffXd& value) {
-    return value;
-  });
-  m.def("autodiff_vector_pass_through", [](const VectorX<AutoDiffXd>& value) {
-    return value;
-  });
+  m.def("autodiff_scalar_pass_through",
+        [](const AutoDiffXd& value) { return value; });
+  m.def("autodiff_vector_pass_through",
+        [](const VectorX<AutoDiffXd>& value) { return value; });
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/test/odr_test_module_py.cc
+++ b/bindings/pydrake/test/odr_test_module_py.cc
@@ -12,9 +12,8 @@ namespace pydrake {
 PYBIND11_MODULE(odr_test_module, m) {
   m.doc() = "Test ODR using Variable.";
 
-  m.def("new_variable", [](const std::string& name) {
-    return new Variable(name);
-  });
+  m.def("new_variable",
+        [](const std::string& name) { return new Variable(name); });
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -20,49 +20,51 @@ PYBIND11_MODULE(trajectories, m) {
   py::class_<Trajectory<T>>(m, "Trajectory", doc.Trajectory.doc);
 
   py::class_<PiecewiseTrajectory<T>, Trajectory<T>>(m, "PiecewiseTrajectory",
-      doc.PiecewiseTrajectory.doc)
+                                                    doc.PiecewiseTrajectory.doc)
       .def("get_number_of_segments",
            &PiecewiseTrajectory<T>::get_number_of_segments,
-          doc.PiecewiseTrajectory.get_number_of_segments.doc)
-      .def("start_time", overload_cast_explicit<double, int>(
-                             &PiecewiseTrajectory<T>::start_time),
-          doc.PiecewiseTrajectory.start_time.doc)
-      .def("end_time", overload_cast_explicit<double, int>(
-                           &PiecewiseTrajectory<T>::end_time),
-          doc.PiecewiseTrajectory.end_time.doc)
+           doc.PiecewiseTrajectory.get_number_of_segments.doc)
+      .def("start_time",
+           overload_cast_explicit<double, int>(
+               &PiecewiseTrajectory<T>::start_time),
+           doc.PiecewiseTrajectory.start_time.doc)
+      .def("end_time",
+           overload_cast_explicit<double, int>(
+               &PiecewiseTrajectory<T>::end_time),
+           doc.PiecewiseTrajectory.end_time.doc)
       .def("duration", &PiecewiseTrajectory<T>::duration,
-          doc.PiecewiseTrajectory.duration.doc)
+           doc.PiecewiseTrajectory.duration.doc)
       .def("start_time",
            overload_cast_explicit<double>(&PiecewiseTrajectory<T>::start_time),
-               doc.PiecewiseTrajectory.start_time.doc)
+           doc.PiecewiseTrajectory.start_time.doc)
       .def("end_time",
            overload_cast_explicit<double>(&PiecewiseTrajectory<T>::end_time),
-               doc.PiecewiseTrajectory.end_time.doc)
+           doc.PiecewiseTrajectory.end_time.doc)
       .def("get_segment_index", &PiecewiseTrajectory<T>::get_segment_index,
-          doc.PiecewiseTrajectory.get_segment_index.doc)
+           doc.PiecewiseTrajectory.get_segment_index.doc)
       .def("get_segment_times", &PiecewiseTrajectory<T>::get_segment_times,
-          doc.PiecewiseTrajectory.get_segment_times.doc);
+           doc.PiecewiseTrajectory.get_segment_times.doc);
 
   py::class_<PiecewisePolynomial<T>, PiecewiseTrajectory<T>>(
       m, "PiecewisePolynomial", doc.PiecewisePolynomial.doc)
       .def(py::init<>(), doc.PiecewisePolynomial.ctor.doc_3)
       .def(py::init<const Eigen::Ref<const MatrixX<T>>&>(),
-          doc.PiecewisePolynomial.ctor.doc_4)
+           doc.PiecewisePolynomial.ctor.doc_4)
       .def_static("ZeroOrderHold",
                   py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
                                     const Eigen::Ref<const MatrixX<T>>&>(
                       &PiecewisePolynomial<T>::ZeroOrderHold),
-          doc.PiecewisePolynomial.ZeroOrderHold.doc)
+                  doc.PiecewisePolynomial.ZeroOrderHold.doc)
       .def_static("FirstOrderHold",
                   py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
                                     const Eigen::Ref<const MatrixX<T>>&>(
                       &PiecewisePolynomial<T>::FirstOrderHold),
-        doc.PiecewisePolynomial.FirstOrderHold.doc)
+                  doc.PiecewisePolynomial.FirstOrderHold.doc)
       .def_static("Pchip",
                   py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
                                     const Eigen::Ref<const MatrixX<T>>&, bool>(
                       &PiecewisePolynomial<T>::Pchip),
-        doc.PiecewisePolynomial.Pchip.doc)
+                  doc.PiecewisePolynomial.Pchip.doc)
       .def_static("Cubic",
                   py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
                                     const Eigen::Ref<const MatrixX<T>>&,
@@ -71,34 +73,33 @@ PYBIND11_MODULE(trajectories, m) {
                       &PiecewisePolynomial<T>::Cubic),
                   py::arg("breaks"), py::arg("knots"),
                   py::arg("knot_dot_start"), py::arg("knot_dot_end"),
-                      doc.PiecewisePolynomial.Cubic.doc)
+                  doc.PiecewisePolynomial.Cubic.doc)
       .def_static("Cubic",
                   py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
                                     const Eigen::Ref<const MatrixX<T>>&,
                                     const Eigen::Ref<const MatrixX<T>>&>(
                       &PiecewisePolynomial<T>::Cubic),
                   py::arg("breaks"), py::arg("knots"), py::arg("knots_dot"),
-          doc.PiecewisePolynomial.Cubic.doc_2)
+                  doc.PiecewisePolynomial.Cubic.doc_2)
       .def_static("Cubic",
                   py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
-                                    const Eigen::Ref<const MatrixX<T>>&,
-                                    bool>(
+                                    const Eigen::Ref<const MatrixX<T>>&, bool>(
                       &PiecewisePolynomial<T>::Cubic),
                   py::arg("breaks"), py::arg("knots"), py::arg("periodic_end"),
-          doc.PiecewisePolynomial.Cubic.doc_3)
+                  doc.PiecewisePolynomial.Cubic.doc_3)
       .def("value", &PiecewisePolynomial<T>::value,
-          doc.PiecewisePolynomial.value.doc)
+           doc.PiecewisePolynomial.value.doc)
       .def("derivative", &PiecewisePolynomial<T>::derivative,
-          doc.PiecewisePolynomial.derivative.doc)
+           doc.PiecewisePolynomial.derivative.doc)
       .def("rows", &PiecewisePolynomial<T>::rows,
-          doc.PiecewisePolynomial.rows.doc)
+           doc.PiecewisePolynomial.rows.doc)
       .def("cols", &PiecewisePolynomial<T>::cols,
-          doc.PiecewisePolynomial.cols.doc)
+           doc.PiecewisePolynomial.cols.doc)
       .def("slice", &PiecewisePolynomial<T>::slice,
            py::arg("start_segment_index"), py::arg("num_segments"),
-          doc.PiecewisePolynomial.slice.doc)
-      .def("shiftRight", &PiecewisePolynomial<T>::shiftRight,
-           py::arg("offset"), doc.PiecewisePolynomial.shiftRight.doc);
+           doc.PiecewisePolynomial.slice.doc)
+      .def("shiftRight", &PiecewisePolynomial<T>::shiftRight, py::arg("offset"),
+           doc.PiecewisePolynomial.shiftRight.doc);
 }
 
 }  // namespace pydrake

--- a/tools/lint/BUILD.bazel
+++ b/tools/lint/BUILD.bazel
@@ -45,6 +45,14 @@ drake_py_library(
 )
 
 drake_py_binary(
+    name = "clang_format_lint",
+    srcs = ["clang_format_lint.py"],
+    deps = [
+        ":clang_format",
+    ],
+)
+
+drake_py_binary(
     name = "drakelint",
     srcs = ["drakelint.py"],
     # The clang-format-includes binary is not used by drakelint, because

--- a/tools/lint/clang_format_lint.py
+++ b/tools/lint/clang_format_lint.py
@@ -1,0 +1,60 @@
+from __future__ import print_function
+
+import os
+import subprocess
+import sys
+
+import drake.tools.lint.clang_format as clang_format_lib
+
+
+def _is_cxx(filename):
+    """Returns True only if filename is reasonable to clang-format."""
+    root, ext = os.path.splitext(filename)
+    _, penultimate_ext = os.path.splitext(root)
+
+    # Don't clang-format CUDA files.
+    if penultimate_ext == "cu":
+        return False
+
+    # Per https://bazel.build/versions/master/docs/be/c-cpp.html#cc_library
+    return ext in [".c", ".cc", ".cpp", ".cxx", ".c++", ".C",
+                   ".h", ".hh", ".hpp", ".hxx", ".inc"]
+
+
+def _check_clang_format_idempotence(filename):
+    clang_format = clang_format_lib.get_clang_format_path()
+    formatter = subprocess.Popen(
+        [clang_format, "-style=file", filename],
+        stdout=subprocess.PIPE)
+    differ = subprocess.Popen(
+        ["/usr/bin/diff", "-u", "-", filename],
+        stdin=formatter.stdout, stdout=subprocess.PIPE)
+    changes = differ.communicate()[0]
+    if not changes:
+        return 0
+    print("ERROR: {} needs clang-format".format(filename))
+    print("note: fix via {} -style=file -i {}".format(clang_format, filename))
+    return 1
+
+
+def main():
+    """Checks that clang-format is idempotent on each path specified as a
+    command-line argument.  Exit 1 if any of the paths are invalid or
+    clang-format suggests any edits.  Otherwise exit 0.
+    """
+    total_errors = 0
+    for filename in sys.argv[1:]:
+        if not _is_cxx(filename):
+            print("clang_format_lint.py: Skipping " + filename)
+            continue
+        print("clang_format_lint.py: Linting " + filename)
+        total_errors += _check_clang_format_idempotence(filename)
+
+    if total_errors == 0:
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/lint/lint.bzl
+++ b/tools/lint/lint.bzl
@@ -15,6 +15,7 @@ def add_lint_tests(
         bazel_lint_ignore = None,
         bazel_lint_extra_srcs = None,
         bazel_lint_exclude = None,
+        enable_clang_format_lint = False,
         enable_install_lint = True,
         enable_library_lint = True):
     """For every rule in the BUILD file so far, and for all Bazel files in this
@@ -33,6 +34,7 @@ def add_lint_tests(
         existing_rules = existing_rules,
         data = cpplint_data,
         extra_srcs = cpplint_extra_srcs,
+        enable_clang_format_lint = enable_clang_format_lint,
     )
     python_lint(
         existing_rules = existing_rules,


### PR DESCRIPTION
My premise is that, while code layout and whitespace _is_ important for `//pydrake/bindings` code readability, nitpicking it during code review is an inefficient way to enforce it.  At least for pydrake, I think its okay to accept whatever layout choices that clang-format suggests.  Here, I've reformatted the root package as an example, and added opt-in linter enforcement of clang-format idempotence.

If this PR is accepted, the plan is that we should opt-in to clang-format for all of the `//pydrake/bindings`.

Relates #4843.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9860)
<!-- Reviewable:end -->
