### PR TITLE
ubuntu: Upgrade to Bazel 0.18

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,5 @@
 # Import legacy .bazelrc file.
 import %workspace%/tools/bazel.rc
+
+# Try to import user-specific configuration local to workspace.
+try-import %workspace%/user.bazelrc

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ xcode
 .settings
 
 external/
+/user.bazelrc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ endif()
 
 # The version passed to find_package(Bazel) should match the
 # minimum_bazel_version value in the call to versions.check() in WORKSPACE.
-set(MINIMUM_BAZEL_VERSION 0.16.1)
+set(MINIMUM_BAZEL_VERSION 0.18.0)
 find_package(Bazel ${MINIMUM_BAZEL_VERSION} MODULE REQUIRED)
 
 get_filename_component(C_COMPILER_REALPATH "${CMAKE_C_COMPILER}" REALPATH)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,4 +25,4 @@ load("@bazel_skylib//:lib.bzl", "versions")
 # This needs to be in WORKSPACE or a repository rule for native.bazel_version
 # to actually be defined. The minimum_bazel_version value should match the
 # version passed to the find_package(Bazel) call in the root CMakeLists.txt.
-versions.check(minimum_bazel_version = "0.16.1")
+versions.check(minimum_bazel_version = "0.18.0")

--- a/doc/developers.rst
+++ b/doc/developers.rst
@@ -80,10 +80,10 @@ supported for CMake builds using the "Unix Makefiles" generator.
 | Operating System                 | Build System    | C/C++ Compiler  | Java       | MATLAB (Optional) | Python |
 +==================================+=================+=================+============+===================+========+
 +----------------------------------+-----------------+-----------------+------------+-------------------+--------+
-| Ubuntu 16.04 LTS (Xenial Xerus)  | | Bazel 0.16.1  | | Clang 6.0     | OpenJDK 8  | R2017a            | 2.7.11 |
+| Ubuntu 16.04 LTS (Xenial Xerus)  | | Bazel 0.18.0  | | Clang 6.0     | OpenJDK 8  | R2017a            | 2.7.11 |
 |                                  | | CMake 3.5.1   | | GCC 5.4       |            |                   |        |
 +----------------------------------+-----------------+-----------------+------------+-------------------+--------+
-| Ubuntu 18.04 LTS (Bionic Beaver) | | Bazel 0.17.2  | | Clang 6.0     | OpenJDK 11 | R2018b            | 2.7.15 |
+| Ubuntu 18.04 LTS (Bionic Beaver) | | Bazel 0.18.0  | | Clang 6.0     | OpenJDK 11 | R2018b            | 2.7.15 |
 |                                  | | CMake 3.10.2  | | GCC 7.3       |            |                   |        |
 +----------------------------------+-----------------+-----------------+------------+                   |        |
 | macOS High Sierra (10.13)        | | Bazel 0.18.0  | Apple LLVM 10.0 | Oracle 11  |                   |        |

--- a/setup/ubuntu/16.04/source_distribution/install_prereqs.sh
+++ b/setup/ubuntu/16.04/source_distribution/install_prereqs.sh
@@ -71,6 +71,6 @@ dpkg_install_from_wget() {
 }
 
 dpkg_install_from_wget \
-  bazel 0.16.1 \
-  https://github.com/bazelbuild/bazel/releases/download/0.16.1/bazel_0.16.1-linux-x86_64.deb \
-  c29f9709910ee23879dffe59ad31f5babba7dcbb81244ff319a5ce81da3c9abe
+  bazel 0.18.0 \
+  https://github.com/bazelbuild/bazel/releases/download/0.18.0/bazel_0.18.0-linux-x86_64.deb \
+  fbdc6dd3bbac4512648314619a317de81df6bbea9826d9201c4e07ec48d3744f

--- a/setup/ubuntu/18.04/source_distribution/install_prereqs.sh
+++ b/setup/ubuntu/18.04/source_distribution/install_prereqs.sh
@@ -67,6 +67,6 @@ dpkg_install_from_wget() {
 }
 
 dpkg_install_from_wget \
-  bazel 0.17.2 \
-  https://github.com/bazelbuild/bazel/releases/download/0.17.2/bazel_0.17.2-linux-x86_64.deb \
-  74570692dadd05a5892990ab65f136262b572580b29789116aadfa75ea5a3e68
+  bazel 0.18.0 \
+  https://github.com/bazelbuild/bazel/releases/download/0.18.0/bazel_0.18.0-linux-x86_64.deb \
+  fbdc6dd3bbac4512648314619a317de81df6bbea9826d9201c4e07ec48d3744f


### PR DESCRIPTION
Resolves #9863 
Resolves #9868

~Will be trying out Bazel 0.19 as well, to see if we can jump to this version; failing that, would like to have this resolves soon.~
Deferring 0.19.0 to a later point for simplicity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9864)
<!-- Reviewable:end -->
