### PR TITLE
py rbt: Expose `get_bodies()` and `get_frames()`

### DIFF
--- a/bindings/pydrake/multibody/rigid_body_tree_py.cc
+++ b/bindings/pydrake/multibody/rigid_body_tree_py.cc
@@ -119,6 +119,22 @@ PYBIND11_MODULE(rigid_body_tree, m) {
          doc.RigidBodyTree.compile.doc)
     .def("initialized", &RigidBodyTree<double>::initialized,
          doc.RigidBodyTree.initialized.doc)
+    .def("get_bodies",
+         [](const RigidBodyTree<double>& tree) {
+           auto& body_unique_ptrs = tree.get_bodies();
+           py::list py_bodies;
+           // Get self-reference to so that we can leverage keep-alive
+           // behavior.
+           py::object self = py::cast(&tree);
+           for (auto& body_unique_ptr : body_unique_ptrs) {
+            py_bodies.append(py::cast(
+                body_unique_ptr.get(), py_reference_internal, self));
+           }
+           return py_bodies;
+         },
+         doc.RigidBodyTree.get_bodies.doc)
+    .def("get_frames", &RigidBodyTree<double>::get_frames,
+         doc.RigidBodyTree.get_frames.doc)
     .def("drawKinematicTree", &RigidBodyTree<double>::drawKinematicTree,
          doc.RigidBodyTree.drawKinematicTree.doc)
     .def("getRandomConfiguration", [](const RigidBodyTree<double>& tree) {

--- a/bindings/pydrake/multibody/test/rigid_body_tree_test.py
+++ b/bindings/pydrake/multibody/test/rigid_body_tree_test.py
@@ -211,6 +211,18 @@ class TestRigidBodyTree(unittest.TestCase):
                                    expressed_in_body_or_frame_ind=0)
         self.assertEqual(twist.shape[0], 6)
 
+    def test_accessor_api(self):
+        tree = RigidBodyTree(FindResourceOrThrow(
+            "drake/examples/simple_four_bar/FourBar.urdf"))
+        bodies = tree.get_bodies()
+        self.assertGreater(len(bodies), 0)
+        for body in bodies:
+            self.assertIsInstance(body, RigidBody)
+        frames = tree.get_frames()
+        self.assertGreater(len(frames), 0)
+        for frame in frames:
+            self.assertIsInstance(frame, RigidBodyFrame)
+
     def test_constraint_api(self):
         tree = RigidBodyTree(FindResourceOrThrow(
             "drake/examples/simple_four_bar/FourBar.urdf"))


### PR DESCRIPTION
Enables simple model benchmarking in Python.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9869)
<!-- Reviewable:end -->
