### PR TITLE
framework: Diagnose mismatched abstract values

### DIFF
--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -384,11 +384,8 @@ struct Impl {
                WarnDeprecated(
                    "`DeclareAbstractInputPort(self, name)` is deprecated. "
                    "Please use `(self, name, model_value)` instead.");
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
                Value<py::object> model_value;
                return self->DeclareAbstractInputPort(name, model_value);
-#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
              },
              py_reference_internal, py::arg("name"),
           doc.System.DeclareAbstractInputPort.doc_2)

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -407,8 +407,8 @@ class TestCustom(unittest.TestCase):
             self.assertEqual(value.get_value(), expected_output_value)
 
     def test_deprecated_abstract_input_port(self):
-        # A system that takes a Value[object] on its input, and parses it to a
-        # float on its output.
+        # A system that takes a Value[object] on its input, and parses the
+        # input value's first element to a float on its output.
         class ParseFloatSystem(LeafSystem_[float]):
             def __init__(self):
                 LeafSystem_[float].__init__(self)
@@ -416,12 +416,12 @@ class TestCustom(unittest.TestCase):
                 self._DeclareVectorOutputPort("out", BasicVector(1), self._Out)
 
             def _Out(self, context, y_data):
-                py_obj = self.EvalAbstractInput(context, 0).get_value()
+                py_obj = self.EvalAbstractInput(context, 0).get_value()[0]
                 y_data.SetAtIndex(0, float(py_obj))
 
         system = ParseFloatSystem()
         context = system.CreateDefaultContext()
         output = system.AllocateOutput()
-        context.FixInputPort(0, AbstractValue.Make("22.2"))
+        context.FixInputPort(0, AbstractValue.Make(["22.2"]))
         system.CalcOutput(context, output)
         self.assertEqual(output.get_vector_data(0).GetAtIndex(0), 22.2)

--- a/common/nice_type_name.h
+++ b/common/nice_type_name.h
@@ -52,7 +52,7 @@ class NiceTypeName {
   template <typename T>
   static const std::string& Get() {
     static const never_destroyed<std::string> canonical(
-        Canonicalize(Demangle(typeid(T).name())));
+        NiceTypeName::Get(typeid(T)));
     return canonical.access();
   }
 
@@ -64,7 +64,14 @@ class NiceTypeName {
   differ. */
   template <typename T>
   static std::string Get(const T& thing) {
-    return Canonicalize(Demangle(typeid(thing).name()));
+    return Get(typeid(thing));
+  }
+
+  /** Returns the nicely demangled and canonicalized type name of `info`. This
+  must be calculated on the fly so is expensive whenever called, though very
+  reasonable for use in error messages. */
+  static std::string Get(const std::type_info& info) {
+    return Canonicalize(Demangle(info.name()));
   }
 
   /** Using the algorithm appropriate to the current compiler, demangles a type

--- a/common/test/nice_type_name_test.cc
+++ b/common/test/nice_type_name_test.cc
@@ -147,6 +147,13 @@ GTEST_TEST(NiceTypeNameTest, Enum) {
             "drake::nice_type_name_test::ForTesting::MyEnumClass");
 }
 
+// Test the type_info form of NiceTypeName::Get().
+GTEST_TEST(NiceTypeNameTest, FromTypeInfo) {
+  EXPECT_EQ(NiceTypeName::Get(typeid(int)), "int");
+  EXPECT_EQ(NiceTypeName::Get(typeid(nice_type_name_test::Derived)),
+            "drake::nice_type_name_test::Derived");
+}
+
 // Test the expression-accepting form of NiceTypeName::Get().
 GTEST_TEST(NiceTypeNameTest, Expressions) {
   using nice_type_name_test::Derived;

--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -642,6 +642,7 @@ drake_cc_googletest(
         "//systems/primitives:demultiplexer",
         "//systems/primitives:gain",
         "//systems/primitives:integrator",
+        "//systems/primitives:pass_through",
     ],
 )
 

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -851,6 +851,9 @@ class LeafSystem : public System<T> {
   /// Declares an abstract-valued input port using the given @p model_value.
   /// This is the best way to declare LeafSystem abstract input ports.
   ///
+  /// Any port connected to this input, and any call to FixInputPort for this
+  /// input, must provide for values whose type matches this @p model_value.
+  ///
   /// @see System::DeclareInputPort() for more information.
   const InputPort<T>& DeclareAbstractInputPort(
       std::string name, const AbstractValue& model_value) {

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -906,6 +906,17 @@ GTEST_TEST(ModelLeafSystemTest, ModelInputGovernsFixedInput) {
       "for input port\\[0\\] but the actual type was "
       "drake::systems::Value<std::string>. "
       "\\(System ::dut\\)");
+
+  // The second port should only accept ints.
+  context->FixInputPort(2, Value<int>(11));
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      context->FixInputPort(2, Value<std::string>{}),
+      std::exception,
+      "System::FixInputPortTypeCheck\\(\\): expected value of type "
+      "int "
+      "for input port\\[2\\] but the actual type was "
+      "std::string. "
+      "\\(System ::dut\\)");
 }
 
 // Check that names can be assigned to the ports through all of the various

--- a/systems/framework/test/value_test.cc
+++ b/systems/framework/test/value_test.cc
@@ -169,10 +169,14 @@ GTEST_TEST(ValueTest, TypeInfo) {
   auto base_value =
       std::make_unique<Value<BasicVector<double>>>(MyVector2d::Make(1., 2.));
 
+  EXPECT_EQ(double_value->static_type_info(), typeid(double));
   EXPECT_EQ(double_value->type_info(), typeid(double));
+
+  EXPECT_EQ(string_value->static_type_info(), typeid(std::string));
   EXPECT_EQ(string_value->type_info(), typeid(std::string));
 
-  // Must return the typeid of the most-derived type.
+  // The static type is BasicVector, but the runtime type is MyVector2d.
+  EXPECT_EQ(base_value->static_type_info(), typeid(BasicVector<double>));
   EXPECT_EQ(base_value->type_info(), typeid(MyVector2d));
 }
 

--- a/systems/framework/value.h
+++ b/systems/framework/value.h
@@ -122,6 +122,11 @@ class AbstractValue {
   /// this returns the typeid of the most-derived type of the contained object.
   virtual const std::type_info& type_info() const = 0;
 
+  /// Returns typeid(T) for this Value<T> object. If T is polymorphic, this
+  /// does NOT reflect the typeid of the most-derived type of the contained
+  /// object; the result is always the base type T.
+  virtual const std::type_info& static_type_info() const = 0;
+
   /// Returns a human-readable name for the underlying type T. This may be
   /// slow but is useful for error messages. If T is polymorphic, this returns
   /// the typeid of the most-derived type of the contained object.
@@ -347,6 +352,10 @@ class Value : public AbstractValue {
 
   void SetFromOrThrow(const AbstractValue& other) override {
     value_ = Traits::to_storage(other.GetValueOrThrow<T>());
+  }
+
+  const std::type_info& static_type_info() const final {
+    return typeid(T);
   }
 
   const std::type_info& type_info() const override {


### PR DESCRIPTION
Relates #9669.  Inspired by #9591.  Carved out of #9620.  Speculatively discussed in #9792.

~If this idea seems worthwhile, then I should concurrently fix up `DiagramBuilder::Connect()`  to perform the same fail-fast checking.~  _Edit: Done._

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9875)
<!-- Reviewable:end -->
