### PR TITLE
rotation_matrix: Optimize constructors by manually eliminating dead stores

### DIFF
--- a/math/rotation_matrix.h
+++ b/math/rotation_matrix.h
@@ -74,7 +74,7 @@ class RotationMatrix {
   // TODO(mitiguy) Although this method is fairly efficient, consider adding an
   // optional second argument if `quaternion` is known to be normalized apriori
   // or for some reason the calling site does not want `quaternion` normalized.
-  explicit RotationMatrix(const Eigen::Quaternion<T>& quaternion) {
+  explicit RotationMatrix(const Eigen::Quaternion<T>& quaternion) : R_AB_() {
     // Cost for various way to create a rotation matrix from a quaternion.
     // Eigen quaternion.toRotationMatrix() = 12 multiplies, 12 adds.
     // Drake  QuaternionToRotationMatrix() = 12 multiplies, 12 adds.
@@ -98,7 +98,7 @@ class RotationMatrix {
   // %RotationMatrix constructor (above) with that un-normalized quaternion.
   // TODO(mitiguy) Consider adding an optional second argument if `lambda` is
   // known to be normalized apriori or calling site does not want normalization.
-  explicit RotationMatrix(const Eigen::AngleAxis<T>& theta_lambda) {
+  explicit RotationMatrix(const Eigen::AngleAxis<T>& theta_lambda) : R_AB_() {
     const Vector3<T>& lambda = theta_lambda.axis();
     const T norm = lambda.norm();
     const T& theta = theta_lambda.angle();
@@ -136,7 +136,7 @@ class RotationMatrix {
   /// @li 3rd rotation R_AB: Frames D, C, B (collectively -- as if welded)
   /// rotate relative to frame A by a roll angle `y` about `Bz = Az`.
   /// Note: B and A are no longer aligned.
-  explicit RotationMatrix(const RollPitchYaw<T>& rpy) {
+  explicit RotationMatrix(const RollPitchYaw<T>& rpy) : R_AB_() {
     const T& r = rpy.roll_angle();
     const T& p = rpy.pitch_angle();
     const T& y = rpy.yaw_angle();
@@ -173,7 +173,7 @@ class RotationMatrix {
   /// columns of `R_AB` are `Bx`, `By`, `Bz`.
   static RotationMatrix<T> MakeFromOrthonormalColumns(
       const Vector3<T>& Bx, const Vector3<T>& By, const Vector3<T>& Bz) {
-    RotationMatrix<T> R;
+    RotationMatrix<T> R(DoNotInitializeMemberFields{});
     R.SetFromOrthonormalColumns(Bx, By, Bz);
     return R;
   }
@@ -192,7 +192,7 @@ class RotationMatrix {
   /// columns of `R_AB` are `Bx`, `By`, `Bz`.
   static RotationMatrix<T> MakeFromOrthonormalRows(
       const Vector3<T>& Ax, const Vector3<T>& Ay, const Vector3<T>& Az) {
-    RotationMatrix<T> R;
+    RotationMatrix<T> R(DoNotInitializeMemberFields{});
     R.SetFromOrthonormalRows(Ax, Ay, Az);
     return R;
   }
@@ -583,6 +583,10 @@ class RotationMatrix {
   // epsilon) used to check whether or not a rotation matrix is orthonormal.
   static constexpr double kInternalToleranceForOrthonormality_{
       128 * std::numeric_limits<double>::epsilon() };
+
+  // Constructs a RotationMatrix without initializing the underlying 3x3 matrix.
+  struct DoNotInitializeMemberFields{};
+  explicit RotationMatrix(DoNotInitializeMemberFields) : R_AB_() {}
 
   // Constructs a %RotationMatrix from a Matrix3.  No check is performed to test
   // whether or not the parameter R is a valid rotation matrix.

--- a/math/rotation_matrix.h
+++ b/math/rotation_matrix.h
@@ -61,7 +61,8 @@ class RotationMatrix {
   /// Constructs a %RotationMatrix from a Matrix3.
   /// @param[in] R an allegedly valid rotation matrix.
   /// @throws std::logic_error in debug builds if R fails IsValid(R).
-  explicit RotationMatrix(const Matrix3<T>& R) : R_AB_() { set(R); }
+  explicit RotationMatrix(const Matrix3<T>& R)
+      : RotationMatrix(DoNotInitializeMemberFields{}) { set(R); }
 
   /// Constructs a %RotationMatrix from an Eigen::Quaternion.
   /// @param[in] quaternion a non-zero, finite quaternion which may or may not
@@ -74,15 +75,15 @@ class RotationMatrix {
   // TODO(mitiguy) Although this method is fairly efficient, consider adding an
   // optional second argument if `quaternion` is known to be normalized apriori
   // or for some reason the calling site does not want `quaternion` normalized.
-  explicit RotationMatrix(const Eigen::Quaternion<T>& quaternion) : R_AB_() {
+  explicit RotationMatrix(const Eigen::Quaternion<T>& quaternion)
+      : RotationMatrix(DoNotInitializeMemberFields{}) {
     // Cost for various way to create a rotation matrix from a quaternion.
     // Eigen quaternion.toRotationMatrix() = 12 multiplies, 12 adds.
     // Drake  QuaternionToRotationMatrix() = 12 multiplies, 12 adds.
     // Extra cost for two_over_norm_squared =  4 multiplies,  3 adds, 1 divide.
     // Extra cost if normalized = 4 multiplies, 3 adds, 1 sqrt, 1 divide.
     const T two_over_norm_squared = T(2) / quaternion.squaredNorm();
-    R_AB_ = QuaternionToRotationMatrix(quaternion, two_over_norm_squared);
-    DRAKE_ASSERT_VOID(ThrowIfNotValid(R_AB_));
+    set(QuaternionToRotationMatrix(quaternion, two_over_norm_squared));
   }
 
   /// Constructs a %RotationMatrix from an Eigen::AngleAxis.
@@ -98,12 +99,12 @@ class RotationMatrix {
   // %RotationMatrix constructor (above) with that un-normalized quaternion.
   // TODO(mitiguy) Consider adding an optional second argument if `lambda` is
   // known to be normalized apriori or calling site does not want normalization.
-  explicit RotationMatrix(const Eigen::AngleAxis<T>& theta_lambda) : R_AB_() {
+  explicit RotationMatrix(const Eigen::AngleAxis<T>& theta_lambda)
+      : RotationMatrix(DoNotInitializeMemberFields{}) {
     const Vector3<T>& lambda = theta_lambda.axis();
     const T norm = lambda.norm();
     const T& theta = theta_lambda.angle();
-    R_AB_ = Eigen::AngleAxis<T>(theta, lambda / norm).toRotationMatrix();
-    DRAKE_ASSERT_VOID(ThrowIfNotValid(R_AB_));
+    set(Eigen::AngleAxis<T>(theta, lambda / norm).toRotationMatrix());
   }
 
   // TODO(@mitiguy) Add Sherm/Goldstein's way to visualize rotation sequences.
@@ -136,7 +137,8 @@ class RotationMatrix {
   /// @li 3rd rotation R_AB: Frames D, C, B (collectively -- as if welded)
   /// rotate relative to frame A by a roll angle `y` about `Bz = Az`.
   /// Note: B and A are no longer aligned.
-  explicit RotationMatrix(const RollPitchYaw<T>& rpy) : R_AB_() {
+  explicit RotationMatrix(const RollPitchYaw<T>& rpy)
+      : RotationMatrix(DoNotInitializeMemberFields{}) {
     const T& r = rpy.roll_angle();
     const T& p = rpy.pitch_angle();
     const T& y = rpy.yaw_angle();


### PR DESCRIPTION
Reverts #9874.  Relates #9812.

Compared to #9812, this placates GCC 7 `-Wmaybe-uninitialized` warnings by using the `set()` helper to establish `R_AB_`, instead of assigning to it directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9876)
<!-- Reviewable:end -->
