### PR TITLE
[WIP] Baby step towards removing Isometry from joints via WeldJoint

### DIFF
--- a/multibody/benchmarks/kuka_iiwa_robot/drake_kuka_iiwa_robot.h
+++ b/multibody/benchmarks/kuka_iiwa_robot/drake_kuka_iiwa_robot.h
@@ -130,7 +130,7 @@ class DrakeKukaIIwaRobot {
 
     // Retrieve end-effector pose from position kinematics cache.
     tree().CalcPositionKinematicsCache(*context_, &pc);
-    const Isometry3<T>& X_NG = pc.get_X_WB(linkG_->node_index());
+    const math::RigidTransform<T> X_NG(pc.get_X_WB(linkG_->node_index()));
 
     // Retrieve end-effector spatial velocity from velocity kinematics cache.
     tree().CalcVelocityKinematicsCache(*context_, pc, &vc);
@@ -142,7 +142,7 @@ class DrakeKukaIIwaRobot {
     const SpatialAcceleration<T>& A_NG_N = A_WB[linkG_->node_index()];
 
     // Create a class to return the results.
-    return SpatialKinematicsPVA<T>(X_NG, V_NG_N, A_NG_N);
+    return SpatialKinematicsPVA<T>(X_NG.GetAsIsometry3(), V_NG_N, A_NG_N);
   }
 
   /// This method calculates joint reaction torques/forces for a 7-DOF KUKA iiwa

--- a/multibody/multibody_tree/joints/weld_joint.h
+++ b/multibody/multibody_tree/joints/weld_joint.h
@@ -6,6 +6,7 @@
 #include <utility>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/math/rigid_transform.h"
 #include "drake/multibody/multibody_tree/joints/joint.h"
 #include "drake/multibody/multibody_tree/multibody_forces.h"
 #include "drake/multibody/multibody_tree/weld_mobilizer.h"
@@ -34,20 +35,32 @@ class WeldJoint final : public Joint<T> {
   template<typename Scalar>
   using Context = systems::Context<Scalar>;
 
-  /// Constructor for a %WeldJoint between a `parent_frame_P` and a
-  /// `child_frame_C` so that their relative pose `X_PC` is fixed as if they
-  /// were "welded" together.
-  WeldJoint(const std::string& name,
-            const Frame<T>& parent_frame_P, const Frame<T>& child_frame_C,
+  /// Constructs a %WeldJoint between a parent frame `P` and a child frame `C`
+  /// with a constant pose `X_PC`, as if `P` and `C` were "welded" together.
+  /// @param[in] name Weld joint's name.
+  /// @param[in] P Weld joint's parent frame.
+  /// @param[in] C Weld joint's child frame.
+  /// @param[in] X_PC Pose relating parent frame P and child frame C.
+  WeldJoint(const std::string& name, const Frame<T>& P, const Frame<T>& C,
             const Isometry3<double>& X_PC) :
-      Joint<T>(name, parent_frame_P, child_frame_C,
-               VectorX<double>() /* no lower limits */,
-               VectorX<double>() /* no upper limits */), X_PC_(X_PC) {}
+      Joint<T>(name, P, C, VectorX<double>() /* no lower limits */,
+                           VectorX<double>() /* no upper limits */),
+                           X_PC_(X_PC) {}
 
-  /// Returns the pose X_PC of frame C in P.
-  const Isometry3<double>& X_PC() const {
-    return X_PC_;
-  }
+  /// Constructs a %WeldJoint between a parent frame `P` and a child frame `C`
+  /// with a constant pose `X_PC`, as if `P` and `C` were "welded" together.
+  /// @param[in] name Weld joint's name.
+  /// @param[in] P Weld joint's parent frame.
+  /// @param[in] C Weld joint's child frame.
+  /// @param[in] X_PC Pose relating parent frame P and child frame C.
+  WeldJoint(const std::string& name, const Frame<T>& P, const Frame<T>& C,
+            const math::RigidTransform<double>& X_PC) :
+      Joint<T>(name, P, C, VectorX<double>() /* no lower limits */,
+                           VectorX<double>() /* no upper limits */),
+                           X_PC_(X_PC.GetAsIsometry3()) {}
+
+  /// Returns the pose X_PC relating parent frame P and child frame C.
+  const Isometry3<double>& X_PC() const { return X_PC_; }
 
  protected:
   /// Joint<T> override called through public NVI, Joint::AddInForce().

--- a/multibody/multibody_tree/parsing/multibody_plant_sdf_parser.cc
+++ b/multibody/multibody_tree/parsing/multibody_plant_sdf_parser.cc
@@ -289,7 +289,7 @@ void AddJointFromSpecification(
           joint_spec.Name(),
           parent_body, X_PJ,
           child_body, X_CJ,
-          Isometry3d::Identity() /* X_JpJc */);
+          math::RigidTransform<double>::Identity() /* X_JpJc */);
       break;
     }
     case sdf::JointType::PRISMATIC: {


### PR DESCRIPTION
Two different items.
1.  Remove straggler Isometry3 from drake_kuka_iiwa_robot.h

2.  Make a single baby step towards removing Isometry in joints by
     implementing a new WeldJoint constructor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9877)
<!-- Reviewable:end -->
