### PR TITLE
Adds contact results and continuous state output ports to manipulation station

### DIFF
--- a/examples/manipulation_station/BUILD.bazel
+++ b/examples/manipulation_station/BUILD.bazel
@@ -100,6 +100,7 @@ drake_cc_binary(
     deps = [
         ":manipulation_station",
         "//geometry:geometry_visualization",
+        "//multibody/multibody_tree/multibody_plant:contact_results_to_lcm",
         "//systems/analysis:simulator",
         "@gflags",
     ],

--- a/examples/manipulation_station/manipulation_station.cc
+++ b/examples/manipulation_station/manipulation_station.cc
@@ -365,6 +365,11 @@ void ManipulationStation<T>::Finalize() {
   builder.ExportOutput(scene_graph_->get_pose_bundle_output_port(),
                        "pose_bundle");
 
+  builder.ExportOutput(plant_->get_contact_results_output_port(),
+      "contact_results");
+  builder.ExportOutput(plant_->get_continuous_state_output_port(),
+      "plant_continuous_state");
+
   builder.BuildInto(this);
 }
 

--- a/examples/manipulation_station/manipulation_station.h
+++ b/examples/manipulation_station/manipulation_station.h
@@ -47,7 +47,10 @@ namespace manipulation_station {
 ///   @output_port{camera2_rgb_image}
 ///   @output_port{camera2_depth_image}
 ///   @output_port{<b style="color:orange">camera2_label_image</b>}
-///   @output_port{<b style="color:orange">pose_bundle</b>} }
+///   @output_port{<b style="color:orange">pose_bundle</b>}
+///   @output_port{<b style="color:orange">contact_results</b>}
+///   @output_port{<b style="color:orange">plant_continuous_state</b>}
+/// }
 ///
 /// Note that outputs in <b style="color:orange">orange</b> are
 /// available in the simulation, but not on the real robot.  The distinction

--- a/examples/manipulation_station/proof_of_life.cc
+++ b/examples/manipulation_station/proof_of_life.cc
@@ -5,6 +5,7 @@
 #include "drake/common/is_approx_equal_abstol.h"
 #include "drake/examples/manipulation_station/manipulation_station.h"
 #include "drake/geometry/geometry_visualization.h"
+#include "drake/multibody/multibody_tree/multibody_plant/contact_results_to_lcm.h"
 #include "drake/multibody/multibody_tree/parsing/multibody_plant_sdf_parser.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram.h"
@@ -44,6 +45,9 @@ int do_main(int argc, char* argv[]) {
 
   geometry::ConnectDrakeVisualizer(&builder, station->get_mutable_scene_graph(),
                                    station->GetOutputPort("pose_bundle"));
+  multibody::multibody_plant::ConnectContactResultsToDrakeVisualizer(
+      &builder, station->get_mutable_multibody_plant(),
+      station->GetOutputPort("contact_results"));
 
   auto diagram = builder.Build();
 

--- a/examples/manipulation_station/test/manipulation_station_test.cc
+++ b/examples/manipulation_station/test/manipulation_station_test.cc
@@ -100,6 +100,10 @@ GTEST_TEST(ManipulationStationTest, CheckPlantBasics) {
                   .Eval<BasicVector<double>>(*context)
                   .get_value()
                   .isZero());
+
+  // Check that the additional output ports exist and are spelled correctly.
+  EXPECT_NO_THROW(station.GetOutputPort("contact_results"));
+  EXPECT_NO_THROW(station.GetOutputPort("plant_continuous_state"));
 }
 
 GTEST_TEST(ManipulationStationTest, CheckStateFromPosition) {

--- a/multibody/multibody_tree/multibody_plant/contact_results_to_lcm.cc
+++ b/multibody/multibody_tree/multibody_plant/contact_results_to_lcm.cc
@@ -88,6 +88,16 @@ systems::lcm::LcmPublisherSystem* ConnectContactResultsToDrakeVisualizer(
     systems::DiagramBuilder<double>* builder,
     const MultibodyPlant<double>& multibody_plant,
     lcm::DrakeLcmInterface* lcm) {
+  return ConnectContactResultsToDrakeVisualizer(
+      builder, multibody_plant,
+      multibody_plant.get_contact_results_output_port(), lcm);
+}
+
+systems::lcm::LcmPublisherSystem* ConnectContactResultsToDrakeVisualizer(
+    systems::DiagramBuilder<double>* builder,
+    const MultibodyPlant<double>& multibody_plant,
+    const systems::OutputPort<double>& contact_results_port,
+    lcm::DrakeLcmInterface* lcm) {
   DRAKE_DEMAND(builder != nullptr);
 
   auto contact_to_lcm =
@@ -100,8 +110,7 @@ systems::lcm::LcmPublisherSystem* ConnectContactResultsToDrakeVisualizer(
           "CONTACT_RESULTS", lcm));
   contact_results_publisher->set_name("contact_results_publisher");
 
-  builder->Connect(multibody_plant.get_contact_results_output_port(),
-                   contact_to_lcm->get_input_port(0));
+  builder->Connect(contact_results_port, contact_to_lcm->get_input_port(0));
   builder->Connect(contact_to_lcm->get_output_port(0),
                    contact_results_publisher->get_input_port());
   contact_results_publisher->set_publish_period(1 / 60.0);

--- a/multibody/multibody_tree/multibody_plant/contact_results_to_lcm.h
+++ b/multibody/multibody_tree/multibody_plant/contact_results_to_lcm.h
@@ -39,7 +39,9 @@ class ContactResultsToLcmSystem final : public systems::LeafSystem<T> {
   /** Constructs a ContactResultsToLcmSystem.
    @param plant The MultibodyPlant that the ContactResults are generated from.
    @pre The `plant` must be finalized already. The input port of this system
-        must be connected to the corresponding output port of `plant`.  */
+        must be connected to the corresponding output port of `plant`
+        (either directly or from an exported port in a Diagram).
+  */
   explicit ContactResultsToLcmSystem(const MultibodyPlant<T>& plant);
 
   /** Scalar-converting copy constructor.  */
@@ -99,6 +101,25 @@ class ContactResultsToLcmSystem final : public systems::LeafSystem<T> {
 systems::lcm::LcmPublisherSystem* ConnectContactResultsToDrakeVisualizer(
     systems::DiagramBuilder<double>* builder,
     const MultibodyPlant<double>& multibody_plant,
+    lcm::DrakeLcmInterface* lcm = nullptr);
+
+/** Implements ConnectContactResultsToDrakeVisualizer, but using @p
+ contact_results_port to explicitly specify the output port used to get
+ contact results for @p multibody_plant.  This is required, for instance,
+ when the MultibodyPlant is inside a Diagram, and the Diagram exports the
+ pose bundle port.
+
+ @pre contact_results_port must be connected to the contact_results_port of
+ @p multibody_plant.
+
+ @see ConnectContactResultsToDrakeVisualizer().
+
+ @ingroup visualization
+ */
+systems::lcm::LcmPublisherSystem* ConnectContactResultsToDrakeVisualizer(
+    systems::DiagramBuilder<double>* builder,
+    const MultibodyPlant<double>& multibody_plant,
+    const systems::OutputPort<double>& contact_results_port,
     lcm::DrakeLcmInterface* lcm = nullptr);
 
 }  // namespace multibody_plant

--- a/multibody/multibody_tree/multibody_plant/test/contact_results_to_lcm_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/contact_results_to_lcm_test.cc
@@ -136,6 +136,32 @@ GTEST_TEST(ConnectContactResultsToDrakeVisualizer, BasicTest) {
   EXPECT_EQ(periodic_events.begin()->first.period_sec(), 1/60.0);
 }
 
+GTEST_TEST(ConnectContactResultsToDrakeVisualizer, NestedDiagramTest) {
+  systems::DiagramBuilder<double> interior_builder;
+
+  // Make a trivial plant with at least one body and a discrete time step.
+  auto plant = interior_builder.AddSystem<MultibodyPlant>(0.001);
+  plant->AddRigidBody("link", SpatialInertia<double>());
+  plant->Finalize();
+
+  interior_builder.ExportOutput(plant->get_contact_results_output_port(),
+      "contact_results");
+
+  systems::DiagramBuilder<double> builder;
+  auto interior_diagram = builder.AddSystem(interior_builder.Build());
+
+  auto publisher = ConnectContactResultsToDrakeVisualizer(&builder, *plant,
+      interior_diagram->GetOutputPort("contact_results"));
+
+  // Confirm that we get a non-null result.
+  EXPECT_NE(publisher, nullptr);
+
+  // Check that the publishing event was set as documented.
+  auto periodic_events = publisher->GetPeriodicEvents();
+  EXPECT_EQ(periodic_events.size(), 1);
+  EXPECT_EQ(periodic_events.begin()->first.period_sec(), 1/60.0);
+}
+
 }  // namespace
 }  // namespace multibody_plant
 }  // namespace multibody


### PR DESCRIPTION
Also generalizes the ConnectContactResultsToDrakeVisualizer method to support MBPs inside diagrams.

cc @pangtao22

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9911)
<!-- Reviewable:end -->
