### PR TITLE
Adds PhaseBasedRightOfWayStateProvider

### DIFF
--- a/automotive/BUILD.bazel
+++ b/automotive/BUILD.bazel
@@ -44,6 +44,7 @@ drake_cc_package_library(
         ":maliput_railcar",
         ":mobil_planner",
         ":multilane_onramp_merge",
+        ":phase_based_right_of_way_state_provider",
         ":pose_selector",
         ":pure_pursuit",
         ":pure_pursuit_controller",
@@ -397,6 +398,20 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "phase_based_right_of_way_state_provider",
+    srcs = [
+        "phase_based_right_of_way_state_provider.cc",
+    ],
+    hdrs = [
+        "phase_based_right_of_way_state_provider.h",
+    ],
+    deps = [
+        "//automotive/maliput/api",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
     name = "trivial_right_of_way_state_provider",
     srcs = [
         "trivial_right_of_way_state_provider.cc",
@@ -720,6 +735,15 @@ drake_cc_googletest(
         "//common/proto:call_matlab",
         "//common/test_utilities:eigen_matrix_compare",
         "//systems/trajectory_optimization:direct_collocation",
+    ],
+)
+
+drake_cc_googletest(
+    name = "phase_based_right_of_way_state_provider_test",
+    deps = [
+        ":phase_based_right_of_way_state_provider",
+        "//automotive/maliput/simple_phase_book",
+        "//automotive/maliput/simple_phase_provider",
     ],
 )
 

--- a/automotive/maliput/simple_phase_provider/simple_right_of_way_phase_provider.cc
+++ b/automotive/maliput/simple_phase_provider/simple_right_of_way_phase_provider.cc
@@ -34,6 +34,7 @@ SimpleRightOfWayPhaseProvider::DoGetPhase(
   if (it == phases_.end()) {
     return nullopt;
   }
+  // TODO(liang.fok) Add support for "next phase" and "duration until", #9993.
   return Result{it->second, nullopt};
 }
 

--- a/automotive/phase_based_right_of_way_state_provider.cc
+++ b/automotive/phase_based_right_of_way_state_provider.cc
@@ -1,0 +1,52 @@
+#include "drake/automotive/phase_based_right_of_way_state_provider.h"
+
+#include "drake/automotive/maliput/api/rules/right_of_way_phase.h"
+#include "drake/automotive/maliput/api/rules/right_of_way_phase_ring.h"
+#include "drake/common/drake_assert.h"
+
+namespace drake {
+namespace automotive {
+
+using maliput::api::rules::RightOfWayPhase;
+using maliput::api::rules::RightOfWayPhaseBook;
+using maliput::api::rules::RightOfWayPhaseProvider;
+using maliput::api::rules::RightOfWayPhaseRing;
+using maliput::api::rules::RightOfWayRule;
+using maliput::api::rules::RightOfWayStateProvider;
+
+PhaseBasedRightOfWayStateProvider::PhaseBasedRightOfWayStateProvider(
+    const RightOfWayPhaseBook* phase_book,
+    const RightOfWayPhaseProvider* phase_provider)
+    : phase_book_(phase_book),
+      phase_provider_(phase_provider) {
+  DRAKE_DEMAND(phase_book_ != nullptr && phase_provider != nullptr);
+}
+
+optional<RightOfWayStateProvider::Result>
+PhaseBasedRightOfWayStateProvider::DoGetState(const RightOfWayRule::Id& rule_id)
+    const {
+  optional<RightOfWayPhaseRing> ring = phase_book_->FindPhaseRing(rule_id);
+  if (ring.has_value()) {
+    const optional<RightOfWayPhaseProvider::Result> phase_result
+        = phase_provider_->GetPhase(ring->id());
+    if (phase_result.has_value()) {
+      const RightOfWayPhase::Id phase_id = phase_result->id;
+      const RightOfWayPhase& phase = ring->phases().at(phase_id);
+      const RightOfWayRule::State::Id state_id =
+          phase.rule_states().at(rule_id);
+      optional<Result::Next> next = nullopt;
+      if (phase_result->next.has_value()) {
+        const RightOfWayPhase::Id next_phase_id = phase_result->next->id;
+        const RightOfWayPhase& next_phase = ring->phases().at(next_phase_id);
+        const RightOfWayRule::State::Id next_state_id =
+          next_phase.rule_states().at(rule_id);
+        next = Result::Next{next_state_id, phase_result->next->duration_until};
+      }
+      return Result{state_id, next};
+    }
+  }
+  return nullopt;
+}
+
+}  // namespace automotive
+}  // namespace drake

--- a/automotive/phase_based_right_of_way_state_provider.h
+++ b/automotive/phase_based_right_of_way_state_provider.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "drake/automotive/maliput/api/rules/right_of_way_phase_book.h"
+#include "drake/automotive/maliput/api/rules/right_of_way_phase_provider.h"
+#include "drake/automotive/maliput/api/rules/right_of_way_rule.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/drake_optional.h"
+
+namespace drake {
+namespace automotive {
+
+/// Provides the state of maliput::api::rules::RightOfWayRule instances based on
+/// the current maliput::api::rules::RightOfWayPhase. The states of the rules
+/// that govern an intersection are organized into phases. Each phase typically
+/// assigns different states to each rule to ensure intersection safety and
+/// fairness. For example, given an intersection between streets A and B
+/// governed by Rule_A and Rule_B, respectively, two phases are necessary:
+///
+/// Phase  | Rule_A State | Rule_B State
+/// ------ | ------------ | ------------
+///   1    | GO           | STOP
+///   2    | STOP         | GO
+///
+/// The rules above will ensure vehicles traveling on Street A do not collide
+/// with vehicles traveling on Street B and vice versa.
+class PhaseBasedRightOfWayStateProvider final
+    : public maliput::api::rules::RightOfWayStateProvider {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PhaseBasedRightOfWayStateProvider)
+
+  /// Constructs a PhaseBasedRightOfWayStateProvider.
+  ///
+  /// All pointer parameters are aliased; they must not be nullptr and their
+  /// lifespans must exceed that of this instance.
+  PhaseBasedRightOfWayStateProvider(
+      const maliput::api::rules::RightOfWayPhaseBook* phase_book,
+      const maliput::api::rules::RightOfWayPhaseProvider* phase_provider);
+
+  ~PhaseBasedRightOfWayStateProvider() final = default;
+
+  const maliput::api::rules::RightOfWayPhaseBook& phase_book() const {
+    return *phase_book_;
+  }
+
+  const maliput::api::rules::RightOfWayPhaseProvider& phase_provider()
+      const {
+    return *phase_provider_;
+  }
+
+ private:
+  optional<maliput::api::rules::RightOfWayStateProvider::Result>
+      DoGetState(const maliput::api::rules::RightOfWayRule::Id& id) const final;
+
+  const maliput::api::rules::RightOfWayPhaseBook* phase_book_;
+  const maliput::api::rules::RightOfWayPhaseProvider* phase_provider_;
+};
+
+}  // namespace automotive
+}  // namespace drake

--- a/automotive/test/phase_based_right_of_way_state_provider_test.cc
+++ b/automotive/test/phase_based_right_of_way_state_provider_test.cc
@@ -1,0 +1,90 @@
+#include "drake/automotive/phase_based_right_of_way_state_provider.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/automotive/maliput/simple_phase_book/simple_right_of_way_phase_book.h"
+#include "drake/automotive/maliput/simple_phase_provider/simple_right_of_way_phase_provider.h"
+
+namespace drake {
+namespace automotive {
+namespace {
+
+using maliput::api::rules::RightOfWayPhase;
+using maliput::api::rules::RightOfWayPhaseRing;
+using maliput::api::rules::RightOfWayRule;
+using maliput::api::rules::RightOfWayStateProvider;
+using maliput::simple_phase_book::SimpleRightOfWayPhaseBook;
+using maliput::simple_phase_provider::SimpleRightOfWayPhaseProvider;
+
+GTEST_TEST(PhaseBasedRightOfWayStateProviderTest, BasicTest) {
+  const RightOfWayRule::Id rule_id_a("rule a");
+  const RightOfWayRule::Id rule_id_b("rule b");
+
+  const RightOfWayRule::State::Id state_id_go("GO");
+  const RightOfWayRule::State::Id state_id_stop("STOP");
+
+  const RightOfWayPhase::Id phase_id_1("phase1");
+  const RightOfWayPhase phase1(phase_id_1,
+      {{rule_id_a, state_id_go},
+       {rule_id_b, state_id_stop}});
+  const RightOfWayPhase::Id phase_id_2("phase2");
+  const RightOfWayPhase phase2(phase_id_2,
+      {{rule_id_a, state_id_stop},
+       {rule_id_b, state_id_go}});
+
+  const RightOfWayPhaseRing::Id ring_id("ring");
+  const RightOfWayPhaseRing ring(ring_id, {phase1, phase2});
+
+  SimpleRightOfWayPhaseBook phase_book;
+  phase_book.AddPhaseRing(ring);
+
+  SimpleRightOfWayPhaseProvider phase_provider;
+  phase_provider.AddPhaseRing(ring_id, phase_id_1);
+
+  PhaseBasedRightOfWayStateProvider dut(&phase_book, &phase_provider);
+
+  EXPECT_EQ(&dut.phase_book(), &phase_book);
+  EXPECT_EQ(&dut.phase_provider(), &phase_provider);
+
+  struct ExpectedState {
+    const RightOfWayRule::Id rule;
+    const RightOfWayStateProvider::Result result;
+  };
+
+  auto compare_expected = [&](const std::vector<ExpectedState>& test_cases) {
+    for (const auto& test : test_cases) {
+      optional<RightOfWayStateProvider::Result> result =
+          dut.GetState(test.rule);
+      EXPECT_TRUE(result.has_value());
+      EXPECT_EQ(result->current_id, test.result.current_id);
+      if (test.result.next) {
+        EXPECT_EQ(result->next->id, test.result.next->id);
+        if (test.result.next->duration_until) {
+          EXPECT_EQ(*result->next->duration_until,
+                    *test.result.next->duration_until);
+        } else {
+          EXPECT_EQ(result->next->duration_until, nullopt);
+        }
+      } else {
+        EXPECT_EQ(result->next, nullopt);
+      }
+    }
+  };
+
+  // TODO(liang.fok) Add tests for "next state" in returned results once #9993
+  // is resolved.
+  const std::vector<ExpectedState> phase_1_test_cases{
+      {rule_id_a, {state_id_go, nullopt}},
+      {rule_id_b, {state_id_stop, nullopt}}};
+  compare_expected(phase_1_test_cases);
+  phase_provider.SetPhase(ring_id, phase_id_2);
+  const std::vector<ExpectedState> phase_2_test_cases{
+      {rule_id_a, {state_id_stop}},
+      {rule_id_b, {state_id_go}}};
+  compare_expected(phase_2_test_cases);
+  EXPECT_FALSE(dut.GetState(RightOfWayRule::Id("unknown rule")).has_value());
+}
+
+}  // namespace
+}  // namespace automotive
+}  // namespace drake


### PR DESCRIPTION
This enables ado cars to determine RightOfWayRule states based on RightOfWayPhase states.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9913)
<!-- Reviewable:end -->
