### PR TITLE
ubuntu: Ensure `locales` is installed for `mkdoc`

### DIFF
--- a/setup/ubuntu/16.04/source_distribution/install_prereqs.sh
+++ b/setup/ubuntu/16.04/source_distribution/install_prereqs.sh
@@ -31,6 +31,8 @@ apt-get remove lldb-4.0 python-lldb-4.0
 
 apt-get install --no-install-recommends $(cat "${BASH_SOURCE%/*}/packages.txt" | tr '\n' ' ')
 
+locale-gen en_US.UTF-8
+
 dpkg_install_from_wget() {
   package="$1"
   version="$2"

--- a/setup/ubuntu/16.04/source_distribution/packages.txt
+++ b/setup/ubuntu/16.04/source_distribution/packages.txt
@@ -39,6 +39,7 @@ libxml2-dev
 libxt-dev
 libyaml-cpp-dev
 lldb-6.0
+locales
 patchelf
 patchutils
 pkg-config

--- a/setup/ubuntu/18.04/source_distribution/install_prereqs.sh
+++ b/setup/ubuntu/18.04/source_distribution/install_prereqs.sh
@@ -27,6 +27,8 @@ echo 'deb [arch=amd64] https://drake-apt.csail.mit.edu/bionic bionic main' > /et
 apt-get update
 apt-get install --no-install-recommends $(cat "${BASH_SOURCE%/*}/packages.txt" | tr '\n' ' ')
 
+locale-gen en_US.UTF-8
+
 dpkg_install_from_wget() {
   package="$1"
   version="$2"

--- a/setup/ubuntu/18.04/source_distribution/packages.txt
+++ b/setup/ubuntu/18.04/source_distribution/packages.txt
@@ -39,6 +39,7 @@ libxml2-dev
 libxt-dev
 libyaml-cpp-dev
 lldb
+locales
 patchelf
 patchutils
 pkg-config

--- a/third_party/com_github_pybind_pybind11/mkdoc.py
+++ b/third_party/com_github_pybind_pybind11/mkdoc.py
@@ -11,8 +11,8 @@ from collections import OrderedDict, defaultdict
 from fnmatch import fnmatch
 import os
 import platform
-import sys
 import re
+import sys
 from tempfile import NamedTemporaryFile
 import textwrap
 
@@ -779,7 +779,7 @@ def main():
     if output_filename is None or len(filenames) == 0:
         eprint('Syntax: %s -output=<file> [.. a list of header files ..]'
                % sys.argv[0])
-        exit(-1)
+        sys.exit(1)
 
     f = open(output_filename, 'w')
     # N.B. We substitute the `GENERATED FILE...` bits in this fashion because
@@ -850,7 +850,17 @@ def main():
     # Write header file.
     if not quiet:
         eprint("Writing header file...")
-    print_symbols(f, root_name, symbol_tree.root)
+    try:
+        print_symbols(f, root_name, symbol_tree.root)
+    except UnicodeEncodeError as e:
+        # User-friendly error for #9903.
+        print("""
+Encountered unicode error: {}
+If you are on Ubuntu, please ensure you have en_US.UTF-8 locales generated:
+    sudo apt-get install --no-install-recommends  locales
+    sudo locale-gen en_US.UTF-8
+""".format(e), file=sys.stderr)
+        sys.exit(1)
 
     f.write('''
 #if defined(__GNUG__)


### PR DESCRIPTION
Resolves #9903.

For testing, inject `raise UnicodeEncodeError('asdf', u'asdf', 3, 4, 'asdf')` in the `try` / `except` block.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9918)
<!-- Reviewable:end -->
