### PR TITLE
[WIP] Remove easy-to-do Isometry from multibody/multibody-tree/test folder

### DIFF
--- a/multibody/multibody_tree/test/articulated_body_algorithm_test.cc
+++ b/multibody/multibody_tree/test/articulated_body_algorithm_test.cc
@@ -3,6 +3,7 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
+#include "drake/math/rigid_transform.h"
 #include "drake/multibody/multibody_tree/frame.h"
 #include "drake/multibody/multibody_tree/mobilizer_impl.h"
 #include "drake/multibody/multibody_tree/multibody_tree.h"
@@ -59,18 +60,17 @@ class FeatherstoneMobilizer final : public MobilizerImpl<T, 2, 2> {
 
   Isometry3<T> CalcAcrossMobilizerTransform(
       const MultibodyTreeContext<T>& context) const override {
-    Isometry3<T> X_FM = Isometry3<T>::Identity();
-
     const Vector3<T> axis_rotation_F = rotation_axis();
     const T rotation = get_rotation(context);
-    X_FM.linear() = Eigen::AngleAxis<T>(
-        rotation, axis_rotation_F).toRotationMatrix();
+    const math::RotationMatrix<T> R_FM(
+        Eigen::AngleAxis<T>(rotation, axis_rotation_F));
 
     const Vector3<T> axis_translation_F = translation_axis();
     const T translation = get_translation(context);
-    X_FM.translation() = translation * axis_translation_F;
+    const Vector3<T> p_FM = translation * axis_translation_F;
 
-    return X_FM;
+    const math::RigidTransform<T> X_FM(R_FM, p_FM);
+    return X_FM.GetAsIsometry3();
   }
 
   SpatialVelocity<T> CalcAcrossMobilizerSpatialVelocity(

--- a/multibody/multibody_tree/test/floating_body_plant.cc
+++ b/multibody/multibody_tree/test/floating_body_plant.cc
@@ -78,11 +78,11 @@ Vector3<T> AxiallySymmetricFreeBodyPlant<T>::get_translational_velocity(
 }
 
 template<typename T>
-Isometry3<T> AxiallySymmetricFreeBodyPlant<T>::CalcPoseInWorldFrame(
+math::RigidTransform<T> AxiallySymmetricFreeBodyPlant<T>::CalcPoseInWorldFrame(
     const systems::Context<T>& context) const {
   PositionKinematicsCache<T> pc(this->tree().get_topology());
   this->tree().CalcPositionKinematicsCache(context, &pc);
-  return pc.get_X_WB(body_->node_index());
+  return math::RigidTransform<T>(pc.get_X_WB(body_->node_index()));
 }
 
 template<typename T>

--- a/multibody/multibody_tree/test/floating_body_plant.h
+++ b/multibody/multibody_tree/test/floating_body_plant.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include "drake/math/rigid_transform.h"
 #include "drake/multibody/multibody_tree/multibody_plant/multibody_plant.h"
 #include "drake/multibody/multibody_tree/quaternion_floating_mobilizer.h"
 #include "drake/multibody/multibody_tree/rigid_body.h"
@@ -72,7 +73,7 @@ class AxiallySymmetricFreeBodyPlant final :
       const systems::Context<T>& context) const;
 
   /// Computes the pose `X_WB` of the body in the world frame.
-  Isometry3<T> CalcPoseInWorldFrame(
+  math::RigidTransform<T> CalcPoseInWorldFrame(
       const systems::Context<T>& context) const;
 
   /// Computes the spatial velocity `V_WB` of the body in the world frame.

--- a/multibody/multibody_tree/test/floating_body_test.cc
+++ b/multibody/multibody_tree/test/floating_body_test.cc
@@ -96,11 +96,11 @@ GTEST_TEST(QuaternionFloatingMobilizer, Simulation) {
       (1.5 * Vector3d::UnitX() +
        2.0 * Vector3d::UnitY() +
        3.0 * Vector3d::UnitZ()).normalized();
-  const Matrix3d R_WB_test = AngleAxisd(M_PI / 3.0, axis).toRotationMatrix();
-  mobilizer.SetFromRotationMatrix(&context, R_WB_test);
+  const math::RotationMatrixd R_WB_test(AngleAxisd(M_PI / 3.0, axis));
+  mobilizer.SetFromRotationMatrix(&context, R_WB_test.matrix());
   // Verify we get the right quaternion.
   const Quaterniond q_WB_test = mobilizer.get_quaternion(context);
-  const Quaterniond q_WB_test_expected(R_WB_test);
+  const Quaterniond q_WB_test_expected(R_WB_test.matrix());
   EXPECT_TRUE(CompareMatrices(
       q_WB_test.coeffs(), q_WB_test_expected.coeffs(),
       5 * kEpsilon, MatrixCompareType::relative));
@@ -186,8 +186,7 @@ GTEST_TEST(QuaternionFloatingMobilizer, Simulation) {
       benchmark_.CalculateExactTranslationalSolution(kEndTime);
 
   // Compare computed solution against benchmark:
-  EXPECT_TRUE(CompareMatrices(R_WB.matrix(), R_WB_exact.matrix(), kTolerance,
-                              MatrixCompareType::relative));
+  EXPECT_TRUE(R_WB.IsNearlyEqualTo(R_WB_exact, kTolerance));
   EXPECT_TRUE(CompareMatrices(p_WBcm, p_WBcm_exact, kTolerance,
                               MatrixCompareType::relative));
 

--- a/multibody/multibody_tree/test/free_rotating_body_plant.cc
+++ b/multibody/multibody_tree/test/free_rotating_body_plant.cc
@@ -10,8 +10,6 @@ namespace multibody {
 namespace multibody_tree {
 namespace test {
 
-using Eigen::Isometry3d;
-using Eigen::Translation3d;
 using Eigen::Vector3d;
 
 template<typename T>
@@ -137,10 +135,10 @@ void FreeRotatingBodyPlant<T>::set_angular_velocity(
 }
 
 template<typename T>
-Isometry3<T> FreeRotatingBodyPlant<T>::CalcPoseInWorldFrame(
+math::RigidTransform<T> FreeRotatingBodyPlant<T>::CalcPoseInWorldFrame(
     const systems::Context<T>& context) const {
   auto& pc = this->EvalPositionKinematics(context);
-  return pc.get_X_WB(body_->node_index());
+  return math::RigidTransform<T>(pc.get_X_WB(body_->node_index()));
 }
 
 template<typename T>

--- a/multibody/multibody_tree/test/free_rotating_body_plant.h
+++ b/multibody/multibody_tree/test/free_rotating_body_plant.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include "drake/math/rigid_transform.h"
 #include "drake/multibody/multibody_tree/multibody_tree.h"
 #include "drake/multibody/multibody_tree/multibody_tree_system.h"
 #include "drake/multibody/multibody_tree/rigid_body.h"
@@ -63,7 +64,7 @@ class FreeRotatingBodyPlant final : public MultibodyTreeSystem<T> {
       systems::Context<T>* context, const Vector3<T>& w_WB) const;
 
   /// Computes the pose `X_WB` of the body in the world frame.
-  Isometry3<T> CalcPoseInWorldFrame(
+  math::RigidTransform<T> CalcPoseInWorldFrame(
       const systems::Context<T>& context) const;
 
   /// Computes the spatial velocity `V_WB` of the body in the world frame.

--- a/multibody/multibody_tree/test/multibody_tree_creation_test.cc
+++ b/multibody/multibody_tree/test/multibody_tree_creation_test.cc
@@ -32,7 +32,6 @@ class JointTester {
 
 namespace {
 
-using Eigen::Isometry3d;
 using Eigen::Vector3d;
 using std::make_unique;
 using std::set;
@@ -268,7 +267,7 @@ class TreeTopologyTests : public ::testing::Test {
       const auto* joint = &model_->AddJoint<RevoluteJoint>(
           "FooJoint",
           inboard, {}, /* Model does not create frame F, and makes F = P.  */
-          outboard, Isometry3d::Identity(), /* Model does creates frame M. */
+          outboard, Eigen::Isometry3d::Identity(), /* Model creates frame M. */
           Vector3d::UnitZ());
       joints_.push_back(joint);
     } else {
@@ -631,7 +630,7 @@ GTEST_TEST(WeldedBodies, CreateListOfWeldedBodies) {
       [&model](const std::string& name,
                const Body<double>& parent, const Body<double>& child) {
         model.AddJoint<WeldJoint>(
-            name, parent, {}, child, {}, Isometry3d::Identity());
+            name, parent, {}, child, {}, Eigen::Isometry3d::Identity());
       };
 
   // Start building the test model.

--- a/multibody/multibody_tree/test/multibody_tree_test.cc
+++ b/multibody/multibody_tree/test/multibody_tree_test.cc
@@ -30,9 +30,7 @@ namespace {
 using benchmarks::kuka_iiwa_robot::MakeKukaIiwaModel;
 using benchmarks::kuka_iiwa_robot::MG::MGKukaIIwaRobot;
 using Eigen::AngleAxisd;
-using Eigen::Isometry3d;
 using Eigen::MatrixXd;
-using Eigen::Translation3d;
 using Eigen::Vector3d;
 using math::RigidTransform;
 using math::RollPitchYaw;
@@ -795,8 +793,8 @@ TEST_F(KukaIiwaModelTests, EvalPoseAndSpatialVelocity) {
       tree().EvalBodySpatialVelocityInWorld(*context_, *end_effector_link_);
 
   // Pose of the end effector in the world frame.
-  const Isometry3<double>& X_WE =
-      tree().EvalBodyPoseInWorld(*context_, *end_effector_link_);
+  const math::RigidTransform<double> X_WE(
+      tree().EvalBodyPoseInWorld(*context_, *end_effector_link_));
 
   // Independent benchmark solution.
   const SpatialKinematicsPVA<double> MG_kinematics =
@@ -804,12 +802,11 @@ TEST_F(KukaIiwaModelTests, EvalPoseAndSpatialVelocity) {
           q, v, VectorX<double>::Zero(7) /* vdot */);
   const SpatialVelocity<double>& V_WE_benchmark =
       MG_kinematics.spatial_velocity();
-  const Isometry3<double>& X_WE_benchmark = MG_kinematics.transform();
+  const math::RigidTransform<double> X_WE_benchmark(MG_kinematics.transform());
 
   // Compare against benchmark.
   EXPECT_TRUE(V_WE.IsApprox(V_WE_benchmark, kTolerance));
-  EXPECT_TRUE(CompareMatrices(X_WE.matrix(), X_WE_benchmark.matrix(),
-                              kTolerance, MatrixCompareType::relative));
+  EXPECT_TRUE(X_WE.IsNearlyEqualTo(X_WE_benchmark, kTolerance));
 }
 
 TEST_F(KukaIiwaModelTests, CalcFrameGeometricJacobianExpressedInWorld) {
@@ -846,13 +843,13 @@ TEST_F(KukaIiwaModelTests, CalcFrameGeometricJacobianExpressedInWorld) {
       tree().EvalBodySpatialVelocityInWorld(*context_, *end_effector_link_);
 
   // Pose of the end effector.
-  const Isometry3d& X_WE =
-      tree().EvalBodyPoseInWorld(*context_, *end_effector_link_);
+  const math::RigidTransformd X_WE(
+      tree().EvalBodyPoseInWorld(*context_, *end_effector_link_));
 
   // Position of a frame F measured and expressed in frame E.
   const Vector3d p_EoFo_E = Vector3d(0.2, -0.1, 0.5);
   // Express this same last vector in the world frame.
-  const Vector3d p_EoFo_W = X_WE.linear() * p_EoFo_E;
+  const Vector3d p_EoFo_W = X_WE.rotation() * p_EoFo_E;
 
   // The spatial velocity of a frame F moving with E can be obtained by
   // "shifting" the spatial velocity of frame E from Eo to Fo.
@@ -1048,14 +1045,18 @@ class WeldMobilizerTest : public ::testing::Test {
     body1_ = &model->AddBody<RigidBody>(M_B);
     body2_ = &model->AddBody<RigidBody>(M_B);
 
-    model->AddMobilizer<WeldMobilizer>(
-        model->world_body().body_frame(), body1_->body_frame(), X_WB1_);
+    model->AddMobilizer<WeldMobilizer>(model->world_body().body_frame(),
+                                       body1_->body_frame(),
+                                       X_WB1_.GetAsIsometry3());
 
     // Add a weld joint between bodies 1 and 2 by welding together inboard
     // frame F (on body 1) with outboard frame M (on body 2).
-    const auto& frame_F = model->AddFrame<FixedOffsetFrame>(*body1_, X_B1F_);
-    const auto& frame_M = model->AddFrame<FixedOffsetFrame>(*body2_, X_B2M_);
-    model->AddMobilizer<WeldMobilizer>(frame_F, frame_M, X_FM_);
+    const auto& frame_F =
+        model->AddFrame<FixedOffsetFrame>(*body1_, X_B1F_.GetAsIsometry3());
+    const auto& frame_M =
+        model->AddFrame<FixedOffsetFrame>(*body2_, X_B2M_.GetAsIsometry3());
+    model->AddMobilizer<WeldMobilizer>(frame_F, frame_M,
+                                       X_FM_.GetAsIsometry3());
 
     // We are done adding modeling elements. Transfer tree to system and get
     // a Context.
@@ -1064,11 +1065,9 @@ class WeldMobilizerTest : public ::testing::Test {
     context_ = system_->CreateDefaultContext();
 
     // Expected pose of body 2 in the world.
-    X_WB2_.translation() =
-        Vector3d(M_SQRT2 / 4, -M_SQRT2 / 4, 0.0) - Vector3d::UnitY() / M_SQRT2;
-    X_WB2_.linear() =
-        AngleAxisd(-3 * M_PI_4, Vector3d::UnitZ()).toRotationMatrix();
-    X_WB2_.makeAffine();
+    X_WB2_.set_translation(
+        Vector3d(M_SQRT2 / 4, -M_SQRT2 / 4, 0.0) - Vector3d::UnitY() / M_SQRT2);
+    X_WB2_.set_rotation(math::RotationMatrixd::MakeZRotation(-3 * M_PI_4));
   }
 
   const MultibodyTree<double>& tree() const { return system_->tree(); }
@@ -1079,12 +1078,13 @@ class WeldMobilizerTest : public ::testing::Test {
   const RigidBody<double>* body1_{nullptr};
   const RigidBody<double>* body2_{nullptr};
 
-  Isometry3d X_WB1_{
-      AngleAxisd(-M_PI_4, Vector3d::UnitZ()) * Translation3d(0.5, 0.0, 0.0)};
-  Isometry3d X_FM_{AngleAxisd(-M_PI_2, Vector3d::UnitZ())};
-  Isometry3d X_B1F_{Translation3d(0.5, 0.0, 0.0)};
-  Isometry3d X_B2M_{Translation3d(-0.5, 0.0, 0.0)};
-  Isometry3d X_WB2_;
+  const Eigen::Isometry3d X_WB1{AngleAxisd(-M_PI_4, Vector3d::UnitZ()) *
+                                Eigen::Translation3d(0.5, 0.0, 0.0)};
+  math::RigidTransformd X_WB1_{X_WB1};
+  math::RigidTransformd X_FM_{math::RotationMatrixd::MakeZRotation(-M_PI_2)};
+  math::RigidTransformd X_B1F_{Vector3d(0.5, 0.0, 0.0)};
+  math::RigidTransformd X_B2M_{Vector3d(-0.5, 0.0, 0.0)};
+  math::RigidTransformd X_WB2_;
 };
 
 TEST_F(WeldMobilizerTest, StateHasZeroSize) {
@@ -1097,14 +1097,14 @@ TEST_F(WeldMobilizerTest, PositionKinematics) {
   // Numerical tolerance used to verify numerical results.
   const double kTolerance = 10 * std::numeric_limits<double>::epsilon();
 
-  std::vector<Isometry3d> body_poses;
+  std::vector<Eigen::Isometry3d> body_poses;
   tree().CalcAllBodyPosesInWorld(*context_, &body_poses);
 
   EXPECT_TRUE(CompareMatrices(
-      body_poses[body1_->index()].matrix(), X_WB1_.matrix(),
+      body_poses[body1_->index()].matrix(), X_WB1_.GetAsMatrix4(),
       kTolerance, MatrixCompareType::relative));
   EXPECT_TRUE(CompareMatrices(
-      body_poses[body2_->index()].matrix(), X_WB2_.matrix(),
+      body_poses[body2_->index()].matrix(), X_WB2_.GetAsMatrix4(),
       kTolerance, MatrixCompareType::relative));
 }
 

--- a/multibody/multibody_tree/test/prismatic_mobilizer_test.cc
+++ b/multibody/multibody_tree/test/prismatic_mobilizer_test.cc
@@ -4,6 +4,7 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/math/rigid_transform.h"
 #include "drake/multibody/multibody_tree/multibody_tree.h"
 #include "drake/multibody/multibody_tree/multibody_tree_system.h"
 #include "drake/multibody/multibody_tree/rigid_body.h"
@@ -14,9 +15,7 @@ namespace multibody {
 namespace multibody_tree {
 namespace {
 
-using Eigen::Isometry3d;
 using Eigen::Matrix3d;
-using Eigen::Translation3d;
 using Eigen::Vector3d;
 using std::make_unique;
 using std::unique_ptr;
@@ -115,16 +114,16 @@ TEST_F(PrismaticMobilizerTest, ZeroState) {
 TEST_F(PrismaticMobilizerTest, CalcAcrossMobilizerTransform) {
   const double translation = 1.5;
   slider_->set_translation(context_.get(), translation);
-  const Isometry3d X_FM = slider_->CalcAcrossMobilizerTransform(*mbt_context_);
+  const math::RigidTransformd X_FM(
+      slider_->CalcAcrossMobilizerTransform(*mbt_context_));
 
-  const Isometry3d X_FM_expected(
-      Translation3d(axis_F_.normalized() * translation));
+  const math::RigidTransformd X_FM_expected(
+      Vector3d(axis_F_.normalized() * translation));
 
   // Though checked below, we make it explicit here that this mobilizer should
   // introduce no rotations at all.
-  EXPECT_EQ(X_FM.linear(), Matrix3d::Identity());
-  EXPECT_TRUE(CompareMatrices(X_FM.matrix(), X_FM_expected.matrix(),
-                              kTolerance, MatrixCompareType::relative));
+  EXPECT_EQ(X_FM.rotation().matrix(), Matrix3d::Identity());
+  EXPECT_TRUE(X_FM.IsNearlyEqualTo(X_FM_expected, kTolerance));
 }
 
 TEST_F(PrismaticMobilizerTest, CalcAcrossMobilizerSpatialVeloctiy) {

--- a/multibody/multibody_tree/test/tree_from_joints_test.cc
+++ b/multibody/multibody_tree/test/tree_from_joints_test.cc
@@ -23,9 +23,7 @@ namespace {
 const double kEpsilon = std::numeric_limits<double>::epsilon();
 
 using benchmarks::Acrobot;
-using Eigen::Isometry3d;
 using Eigen::Matrix2d;
-using Eigen::Translation3d;
 using Eigen::Vector2d;
 using Eigen::Vector3d;
 using std::make_unique;
@@ -138,14 +136,14 @@ class DoublePendulumModel {
     // L1's origin is located at the com of link 1.
     // X_L1So defines the pose of the shoulder outboard frame So in link 1's
     // frame.
-    const Isometry3d X_L1So{Translation3d(0.0, half_length1_, 0.0)};
+    const math::RigidTransformd X_L1So{Vector3d(0.0, half_length1_, 0.0)};
 
     shoulder_ = &model->template AddJoint<RevoluteJoint>(
         "ShoulderJoint",
         *world_body_,
         {},      /* Default to Identity; frame Si IS the world frame W. */
         *link1_,
-        X_L1So,  /* Pose of So in link 1's frame L1. */
+        X_L1So.GetAsIsometry3(),  /* Pose of So in link 1's frame L1. */
         Vector3d::UnitZ()  /* revolute axis */);
 
     // The elbow is the joint that connects links 1 and 2.
@@ -156,12 +154,12 @@ class DoublePendulumModel {
     // The elbow's outboard frame Eo is taken to be coincident with link 2's
     // frame L2 (i.e. L2o != L2cm).
     // X_L1Ei defines the pose of the elbow inboard frame Ei link 1's frame L1.
-    const Isometry3d X_L1Ei{Translation3d(0.0, -half_length1_, 0.0)};
+    const math::RigidTransformd X_L1Ei{Vector3d(0.0, -half_length1_, 0.0)};
 
     elbow_ = &model->template AddJoint<RevoluteJoint>(
         "ElbowJoint",
         *link1_,
-        X_L1Ei,  /* Pose of Ei in L1. */
+        X_L1Ei.GetAsIsometry3(),  /* Pose of Ei in L1. */
         *link2_,
         {},      /* Default to Identity; frame Eo IS frame L2. */
         Vector3d::UnitZ() /* revolute axis */);

--- a/multibody/multibody_tree/test/tree_from_mobilizers_test.cc
+++ b/multibody/multibody_tree/test/tree_from_mobilizers_test.cc
@@ -12,6 +12,7 @@
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/math/autodiff.h"
 #include "drake/math/autodiff_gradient.h"
+#include "drake/math/rigid_transform.h"
 #include "drake/multibody/benchmarks/acrobot/acrobot.h"
 #include "drake/multibody/multibody_tree/fixed_offset_frame.h"
 #include "drake/multibody/multibody_tree/joints/revolute_joint.h"
@@ -43,14 +44,16 @@ const double kEpsilon = std::numeric_limits<double>::epsilon();
 
 using benchmarks::Acrobot;
 using Eigen::AngleAxisd;
-using Eigen::Isometry3d;
 using Eigen::Matrix2d;
 using Eigen::Matrix3d;
 using Eigen::Matrix4d;
-using Eigen::Translation3d;
 using Eigen::Vector2d;
 using Eigen::Vector3d;
 using Eigen::VectorXd;
+using math::RigidTransform;
+using math::RigidTransformd;
+using math::RotationMatrix;
+using math::RotationMatrixd;
 using std::make_unique;
 using std::unique_ptr;
 using std::vector;
@@ -173,7 +176,7 @@ class PendulumTests : public ::testing::Test {
     // upper_link.
     shoulder_outboard_frame_ =
         &model_->AddFrame<FixedOffsetFrame>(
-            upper_link_->body_frame(), X_USo_);
+            upper_link_->body_frame(), X_USo_.GetAsIsometry3());
 
     // Adds the shoulder and elbow mobilizers of the pendulum.
     // Using:
@@ -203,7 +206,7 @@ class PendulumTests : public ::testing::Test {
     // MultibodyTree::AddJoint() method do that for us:
     elbow_joint_ = &model_->AddJoint<RevoluteJoint>(
         "ElbowJoint",
-        *upper_link_, X_UEi_, /* Pose of Ei in U. */
+        *upper_link_, X_UEi_.GetAsIsometry3(), /* Pose of Ei in U. */
         *lower_link_, {},     /* No pose provided, frame Eo IS frame L. */
         Vector3d::UnitZ()     /* revolute axis */);
     elbow_inboard_frame_ = &elbow_joint_->frame_on_parent();
@@ -226,13 +229,15 @@ class PendulumTests : public ::testing::Test {
   // Replace this by a method Body<T>::get_pose_in_world(const Context<T>&)
   // when we can place cache entries in the context.
   template <typename T>
-  static const Isometry3<T>& get_body_pose_in_world(
+  static const RigidTransform<T> get_body_pose_in_world(
       const MultibodyTree<T>& tree,
       const PositionKinematicsCache<T>& pc,
       const Body<T>& body) {
     const MultibodyTreeTopology& topology = tree.get_topology();
     // Cache entries are accessed by BodyNodeIndex for fast traversals.
-    return pc.get_X_WB(topology.get_body(body.index()).body_node);
+    const BodyNodeIndex body_node_index =
+        topology.get_body(body.index()).body_node;
+    return RigidTransform<T>(pc.get_X_WB(body_node_index));
   }
 
   // Helper method to extract spatial velocity from the velocity kinematics
@@ -270,7 +275,7 @@ class PendulumTests : public ::testing::Test {
   // this method initializes the poses of each link in the position kinematics
   // cache.
   void SetPendulumPoses(PositionKinematicsCache<double>* pc) {
-    pc->get_mutable_X_WB(BodyNodeIndex(1)) = X_WL_;
+    pc->get_mutable_X_WB(BodyNodeIndex(1)) = X_WL_.GetAsIsometry3();
   }
 
   // Add elements to this model_ and then transfer the whole thing to
@@ -306,13 +311,13 @@ class PendulumTests : public ::testing::Test {
   const double acceleration_of_gravity_ = 9.81;
   // Poses:
   // Desired pose of the lower link frame L in the world frame W.
-  const Isometry3d X_WL_{Translation3d(0.0, -half_link1_length_, 0.0)};
+  const RigidTransformd X_WL_{Vector3d(0.0, -half_link1_length_, 0.0)};
   // Pose of the shoulder outboard frame So in the upper link frame U.
-  const Isometry3d X_USo_{Translation3d(0.0, half_link1_length_, 0.0)};
+  const RigidTransformd X_USo_{Vector3d(0.0, half_link1_length_, 0.0)};
   // Pose of the elbow inboard frame Ei in the upper link frame U.
-  const Isometry3d X_UEi_{Translation3d(0.0, -half_link1_length_, 0.0)};
+  const RigidTransformd X_UEi_{Vector3d(0.0, -half_link1_length_, 0.0)};
   // Pose of the elbow outboard frame Eo in the lower link frame L.
-  const Isometry3d X_LEo_{Translation3d(0.0, half_link2_length_, 0.0)};
+  const RigidTransformd X_LEo_{Vector3d(0.0, half_link2_length_, 0.0)};
 };
 
 TEST_F(PendulumTests, CreateModelBasics) {
@@ -424,8 +429,9 @@ TEST_F(PendulumTests, Finalize) {
   // Asserts that no more multibody elements can be added after finalize.
   SpatialInertia<double> M_Bo_B;
   EXPECT_THROW(model_->AddBody<RigidBody>(M_Bo_B), std::logic_error);
-  EXPECT_THROW(model_->AddFrame<FixedOffsetFrame>(*lower_link_, X_LEo_),
-               std::logic_error);
+  EXPECT_THROW(
+      model_->AddFrame<FixedOffsetFrame>(*lower_link_, X_LEo_.GetAsIsometry3()),
+      std::logic_error);
   EXPECT_THROW(model_->AddMobilizer<RevoluteMobilizer>(
       *shoulder_inboard_frame_, *shoulder_outboard_frame_,
       Vector3d::UnitZ()), std::logic_error);
@@ -501,15 +507,15 @@ TEST_F(PendulumTests, CreateContext) {
   SetPendulumPoses(&pc);
 
   // Retrieve body poses from position kinematics cache.
-  const Isometry3d& X_WW =
+  const RigidTransformd X_WW =
       get_body_pose_in_world(system.tree(), pc, *world_body_);
-  const Isometry3d& X_WLu =
+  const RigidTransformd X_WLu =
       get_body_pose_in_world(system.tree(), pc, *upper_link_);
 
   // Asserts that the retrieved poses match with the ones specified by the unit
   // test method SetPendulumPoses().
-  EXPECT_TRUE(X_WW.matrix().isApprox(Matrix4d::Identity()));
-  EXPECT_TRUE(X_WLu.matrix().isApprox(X_WL_.matrix()));
+  EXPECT_TRUE(X_WW.GetAsMatrix4().isApprox(Matrix4d::Identity()));
+  EXPECT_TRUE(X_WLu.GetAsMatrix4().isApprox(X_WL_.GetAsMatrix4()));
 }
 
 // Unit test fixture to verify the correctness of MultibodyTree methods for
@@ -879,14 +885,16 @@ TEST_F(PendulumKinematicTests, CalcPositionKinematics) {
           elbow_mobilizer_->get_topology().body_node;
 
       // Expected poses of the outboard frames measured in the inboard frame.
-      Isometry3d X_SiSo(AngleAxisd(shoulder_angle, Vector3d::UnitZ()));
-      Isometry3d X_EiEo(AngleAxisd(elbow_angle, Vector3d::UnitZ()));
+      RotationMatrixd R_SiSo(AngleAxisd(shoulder_angle, Vector3d::UnitZ()));
+      RotationMatrixd R_EiEo(AngleAxisd(elbow_angle, Vector3d::UnitZ()));
+      const RigidTransformd X_SiSo(R_SiSo);
+      const RigidTransformd X_EiEo(R_EiEo);
 
       // Verify the values in the position kinematics cache.
       EXPECT_TRUE(pc.get_X_FM(shoulder_node).matrix().isApprox(
-          X_SiSo.matrix()));
+          X_SiSo.GetAsMatrix4()));
       EXPECT_TRUE(pc.get_X_FM(elbow_node).matrix().isApprox(
-          X_EiEo.matrix()));
+          X_EiEo.GetAsMatrix4()));
 
       // Verify that both, const and mutable versions point to the same address.
       EXPECT_EQ(&pc.get_X_FM(shoulder_node),
@@ -895,24 +903,28 @@ TEST_F(PendulumKinematicTests, CalcPositionKinematics) {
                 &pc.get_mutable_X_FM(elbow_node));
 
       // Retrieve body poses from position kinematics cache.
-      const Isometry3d& X_WW = get_body_pose_in_world(tree(), pc, *world_body_);
-      const Isometry3d& X_WU = get_body_pose_in_world(tree(), pc, *upper_link_);
-      const Isometry3d& X_WL = get_body_pose_in_world(tree(), pc, *lower_link_);
+      const RigidTransformd X_WW =
+          get_body_pose_in_world(tree(), pc, *world_body_);
+      const RigidTransformd X_WU =
+          get_body_pose_in_world(tree(), pc, *upper_link_);
+      const RigidTransformd X_WL =
+          get_body_pose_in_world(tree(), pc, *lower_link_);
 
-      const math::RigidTransformd X_WU_expected =
+      const RigidTransformd X_WU_expected =
           acrobot_benchmark_.CalcLink1PoseInWorldFrame(shoulder_angle);
 
-      const math::RigidTransformd X_WL_expected =
+      const RigidTransformd X_WL_expected =
           acrobot_benchmark_.CalcElbowOutboardFramePoseInWorldFrame(
               shoulder_angle, elbow_angle);
 
       // Asserts that the retrieved poses match with the ones specified by the
       // unit test method SetPendulumPoses().
-      EXPECT_TRUE(X_WW.matrix().isApprox(Matrix4d::Identity(), kTolerance));
       EXPECT_TRUE(
-          X_WU.matrix().isApprox(X_WU_expected.GetAsMatrix4(), kTolerance));
-      EXPECT_TRUE(
-          X_WL.matrix().isApprox(X_WL_expected.GetAsMatrix4(), kTolerance));
+          X_WW.GetAsMatrix4().isApprox(Matrix4d::Identity(), kTolerance));
+      EXPECT_TRUE(X_WU.GetAsMatrix4().isApprox(X_WU_expected.GetAsMatrix4(),
+                                               kTolerance));
+      EXPECT_TRUE(X_WL.GetAsMatrix4().isApprox(X_WL_expected.GetAsMatrix4(),
+                                               kTolerance));
     }
   }
 }
@@ -944,8 +956,9 @@ TEST_F(PendulumKinematicTests, CalcVelocityAndAccelerationKinematics) {
       // Obtain the lower link center of mass to later shift its computed
       // spatial velocity and acceleration to the center of mass frame for
       // comparison with the benchmark.
-      const Isometry3d& X_WL = get_body_pose_in_world(tree(), pc, *lower_link_);
-      const Matrix3d R_WL = X_WL.linear();
+      const RigidTransformd X_WL =
+          get_body_pose_in_world(tree(), pc, *lower_link_);
+      const RotationMatrixd R_WL = X_WL.rotation();
       const Vector3d p_LoLcm_L = lower_link_->default_com();
       const Vector3d p_LoLcm_W = R_WL * p_LoLcm_L;
 
@@ -1186,24 +1199,24 @@ TEST_F(PendulumKinematicTests, CalcVelocityKinematicsWithAutoDiffXd) {
           tree_autodiff.CalcPositionKinematicsCache(*context_autodiff, &pc);
 
           // Retrieve body poses from position kinematics cache.
-          const Isometry3<AutoDiffXd>& X_WU =
+          const RigidTransform<AutoDiffXd> X_WU =
               get_body_pose_in_world(tree_autodiff, pc, upper_link_autodiff);
-          const Isometry3<AutoDiffXd>& X_WL =
+          const RigidTransform<AutoDiffXd> X_WL =
               get_body_pose_in_world(tree_autodiff, pc, lower_link_autodiff);
 
-          const math::RigidTransformd X_WU_expected =
+          const RigidTransformd X_WU_expected =
               acrobot_benchmark_.CalcLink1PoseInWorldFrame(
                   shoulder_angle.value());
 
-          const math::RigidTransformd X_WL_expected =
+          const RigidTransformd X_WL_expected =
               acrobot_benchmark_.CalcElbowOutboardFramePoseInWorldFrame(
                   shoulder_angle.value(), elbow_angle.value());
 
           // Extract the transformations' values.
           Eigen::MatrixXd X_WU_value =
-              math::autoDiffToValueMatrix(X_WU.matrix());
+              math::autoDiffToValueMatrix(X_WU.GetAsMatrix4());
           Eigen::MatrixXd X_WL_value =
-              math::autoDiffToValueMatrix(X_WL.matrix());
+              math::autoDiffToValueMatrix(X_WL.GetAsMatrix4());
 
           // Obtain the lower link center of mass to later shift its computed
           // spatial velocity to the center of mass frame for comparison with
@@ -1221,10 +1234,10 @@ TEST_F(PendulumKinematicTests, CalcVelocityKinematicsWithAutoDiffXd) {
 
           // Extract the transformations' time derivatives.
           Eigen::MatrixXd X_WU_dot =
-              math::autoDiffToGradientMatrix(X_WU.matrix());
+              math::autoDiffToGradientMatrix(X_WU.GetAsMatrix4());
           X_WU_dot.resize(4, 4);
           Eigen::MatrixXd X_WL_dot =
-              math::autoDiffToGradientMatrix(X_WL.matrix());
+              math::autoDiffToGradientMatrix(X_WL.GetAsMatrix4());
           X_WL_dot.resize(4, 4);
 
           // Convert transformations' time derivatives to spatial velocities.
@@ -1329,10 +1342,10 @@ TEST_F(PendulumKinematicTests, PointsPositionsAndRelativeTransform) {
   EXPECT_TRUE(CompareMatrices(
       p_WPi_set, p_WPi_set_expected, kTolerance, MatrixCompareType::relative));
 
-  const Isometry3d X_UL = tree().CalcRelativeTransform(
-      *context_, upper_link_->body_frame(), lower_link_->body_frame());
+  const RigidTransformd X_UL(tree().CalcRelativeTransform(
+      *context_, upper_link_->body_frame(), lower_link_->body_frame()));
   const Vector3d p_UL = X_UL.translation();
-  const Matrix3d R_UL = X_UL.linear();
+  const RotationMatrixd R_UL = X_UL.rotation();
 
   const Vector3d p_UL_expected(0.0, -0.5, 0.0);
   const Matrix3d R_UL_expected(Eigen::AngleAxisd(M_PI_4, Vector3d::UnitZ()));
@@ -1340,7 +1353,7 @@ TEST_F(PendulumKinematicTests, PointsPositionsAndRelativeTransform) {
   EXPECT_TRUE(CompareMatrices(
       p_UL, p_UL_expected, kTolerance, MatrixCompareType::relative));
   EXPECT_TRUE(CompareMatrices(
-      R_UL, R_UL_expected, kTolerance, MatrixCompareType::relative));
+      R_UL.matrix(), R_UL_expected, kTolerance, MatrixCompareType::relative));
 }
 
 TEST_F(PendulumKinematicTests, PointsHaveTheWrongSize) {

--- a/multibody/multibody_tree/test/tree_from_mobilizers_test.cc
+++ b/multibody/multibody_tree/test/tree_from_mobilizers_test.cc
@@ -515,7 +515,7 @@ TEST_F(PendulumTests, CreateContext) {
   // Asserts that the retrieved poses match with the ones specified by the unit
   // test method SetPendulumPoses().
   EXPECT_TRUE(X_WW.GetAsMatrix4().isApprox(Matrix4d::Identity()));
-  EXPECT_TRUE(X_WLu.GetAsMatrix4().isApprox(X_WL_.GetAsMatrix4()));
+  EXPECT_TRUE(X_WLu.GetAsMatrix34().isApprox(X_WL_.GetAsMatrix34()));
 }
 
 // Unit test fixture to verify the correctness of MultibodyTree methods for
@@ -885,10 +885,8 @@ TEST_F(PendulumKinematicTests, CalcPositionKinematics) {
           elbow_mobilizer_->get_topology().body_node;
 
       // Expected poses of the outboard frames measured in the inboard frame.
-      RotationMatrixd R_SiSo(AngleAxisd(shoulder_angle, Vector3d::UnitZ()));
-      RotationMatrixd R_EiEo(AngleAxisd(elbow_angle, Vector3d::UnitZ()));
-      const RigidTransformd X_SiSo(R_SiSo);
-      const RigidTransformd X_EiEo(R_EiEo);
+      RigidTransformd X_SiSo(RotationMatrixd::MakeZRotation(shoulder_angle));
+      RigidTransformd X_EiEo(RotationMatrixd::MakeZRotation(elbow_angle));
 
       // Verify the values in the position kinematics cache.
       EXPECT_TRUE(pc.get_X_FM(shoulder_node).matrix().isApprox(
@@ -921,10 +919,8 @@ TEST_F(PendulumKinematicTests, CalcPositionKinematics) {
       // unit test method SetPendulumPoses().
       EXPECT_TRUE(
           X_WW.GetAsMatrix4().isApprox(Matrix4d::Identity(), kTolerance));
-      EXPECT_TRUE(X_WU.GetAsMatrix4().isApprox(X_WU_expected.GetAsMatrix4(),
-                                               kTolerance));
-      EXPECT_TRUE(X_WL.GetAsMatrix4().isApprox(X_WL_expected.GetAsMatrix4(),
-                                               kTolerance));
+      EXPECT_TRUE(X_WU.IsNearlyEqualTo(X_WU_expected, kTolerance));
+      EXPECT_TRUE(X_WL.IsNearlyEqualTo(X_WL_expected, kTolerance));
     }
   }
 }

--- a/multibody/multibody_tree/test/weld_mobilizer_test.cc
+++ b/multibody/multibody_tree/test/weld_mobilizer_test.cc
@@ -4,6 +4,7 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/math/rigid_transform.h"
 #include "drake/multibody/multibody_tree/multibody_tree.h"
 #include "drake/multibody/multibody_tree/multibody_tree_system.h"
 #include "drake/multibody/multibody_tree/rigid_body.h"
@@ -14,9 +15,6 @@ namespace multibody {
 namespace multibody_tree {
 namespace {
 
-using Eigen::Isometry3d;
-using Eigen::Matrix3d;
-using Eigen::Translation3d;
 using Eigen::Vector3d;
 using Eigen::VectorXd;
 using std::make_unique;
@@ -42,11 +40,12 @@ class WeldMobilizerTest : public ::testing::Test {
     // Add a body so we can add a mobilizer to it.
     auto& body = model->AddBody<RigidBody>(M_B);
 
-    X_WB_ = Translation3d(1.0, 2.0, 3.0);
+    X_WB_ = math::RigidTransformd(Vector3d(1.0, 2.0, 3.0));
 
     // Add a weld mobilizer between the world and the body:
     weld_body_to_world_ = &model->AddMobilizer<WeldMobilizer>(
-        model->world_body().body_frame(), body.body_frame(), X_WB_);
+        model->world_body().body_frame(), body.body_frame(),
+        X_WB_.GetAsIsometry3());
 
     // We are done adding modeling elements. Transfer tree to system and get
     // a Context.
@@ -68,7 +67,7 @@ class WeldMobilizerTest : public ::testing::Test {
 
   const WeldMobilizer<double>* weld_body_to_world_{nullptr};
   // Pose of body B in the world frame W.
-  Isometry3d X_WB_;
+  math::RigidTransformd X_WB_;
 };
 
 TEST_F(WeldMobilizerTest, ZeroSizedState) {
@@ -77,10 +76,9 @@ TEST_F(WeldMobilizerTest, ZeroSizedState) {
 }
 
 TEST_F(WeldMobilizerTest, CalcAcrossMobilizerTransform) {
-  const Isometry3d X_FM =
-      weld_body_to_world_->CalcAcrossMobilizerTransform(*mbt_context_);
-  EXPECT_TRUE(CompareMatrices(X_FM.matrix(), X_WB_.matrix(),
-                              kTolerance, MatrixCompareType::relative));
+  const math::RigidTransformd X_FM(
+      weld_body_to_world_->CalcAcrossMobilizerTransform(*mbt_context_));
+  EXPECT_TRUE(X_FM.IsNearlyEqualTo(X_WB_, kTolerance));
 }
 
 TEST_F(WeldMobilizerTest, CalcAcrossMobilizerSpatialVeloctiy) {


### PR DESCRIPTION
Removes all the easy-to-do Isometry from the folder multibody/multibody-tree/test
@sherm1   Let me know if think this is a sufficient "chunk" for review.
                   It hits 13 files, so perhaps it would be nice to merge before conflicts arise.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9920)
<!-- Reviewable:end -->
