### PR TITLE
rigid_body: Fix leak in collision element removal logic

### DIFF
--- a/attic/multibody/rigid_body.cc
+++ b/attic/multibody/rigid_body.cc
@@ -110,6 +110,28 @@ void RigidBody<T>::AddCollisionElement(
   collision_elements_.push_back(element);
 }
 
+namespace {
+
+template <typename Container, typename UnaryPredicate>
+inline void RemoveOrFail(UnaryPredicate pred, Container* container) {
+  auto iter = std::find_if(container->begin(), container->end(), pred);
+  DRAKE_DEMAND(iter != container->end());
+  container->erase(iter);
+}
+
+}  // namespace
+
+template <typename T>
+void RigidBody<T>::RemoveCollisionElement(
+    const std::string& group_name,
+    const drake::multibody::collision::ElementId& id) {
+  RemoveOrFail([id](auto x) { return x == id; }, &collision_element_ids_);
+  RemoveOrFail(
+      [id](auto x) { return x == id; },
+      &collision_element_groups_[group_name]);
+  RemoveOrFail([id](auto x) { return x->getId() == id; }, &collision_elements_);
+}
+
 template <typename T>
 std::vector<drake::multibody::collision::ElementId>&
 RigidBody<T>::get_mutable_collision_element_ids() {

--- a/attic/multibody/rigid_body.h
+++ b/attic/multibody/rigid_body.h
@@ -243,6 +243,16 @@ class RigidBody {
                            drake::multibody::collision::Element* element);
 
   /**
+   * (Advanced) Remove collision element.
+   * @param[in] group_name Collision element's group name.
+   * @param[in] id Element id.
+   * @pre Element of `id` must have been added and belong to `group_name`.
+   */
+  void RemoveCollisionElement(
+      const std::string& group_name,
+      const drake::multibody::collision::ElementId& id);
+
+  /**
    * @returns A reference to an `std::vector` of collision elements that
    * represent the collision geometry of this rigid body.
    */

--- a/attic/multibody/rigid_body_tree.h
+++ b/attic/multibody/rigid_body_tree.h
@@ -1043,9 +1043,9 @@ class RigidBodyTree {
       for (const auto& group : body_ptr->get_group_to_collision_ids_map()) {
         const std::string& group_name = group.first;
         if (test(group_name)) {
-          auto& ids = body_ptr->get_mutable_collision_element_ids();
+          auto ids = body_ptr->get_collision_element_ids();
           for (const auto& id : group.second) {
-            ids.erase(std::find(ids.begin(), ids.end(), id));
+            body_ptr->RemoveCollisionElement(group_name, id);
             collision_model_->RemoveElement(id);
           }
           names_of_groups_to_delete.push_back(group_name);


### PR DESCRIPTION
Ran into an issue in Anzu where this memory leak was exercised, but *only* when switching from (a) frames (and a couple of small items) begin added programmatically to (b) having frames and items being added from a parsed SDF file.