### PR TITLE
rbt: Deprecate direct public mutable access to collision containers

### DIFF
--- a/attic/multibody/rigid_body.h
+++ b/attic/multibody/rigid_body.h
@@ -243,6 +243,14 @@ class RigidBody {
                            drake::multibody::collision::Element* element);
 
   /**
+   * (Advanced) Removes collision element group; does NOT unregister element
+   * from collision model.
+   * Do NOT call this directly; instead, use
+   * `RigidBodyTree::removeCollisionGroupsIf`.
+   */
+  void RemoveGroup(const std::string& group_name);
+
+  /**
    * @returns A reference to an `std::vector` of collision elements that
    * represent the collision geometry of this rigid body.
    */
@@ -440,6 +448,11 @@ class RigidBody {
   }
 
  private:
+  // (Advanced) Remove collision element.
+  void RemoveCollisionElement(
+      const std::string& group_name,
+      drake::multibody::collision::ElementId id);
+
   // TODO(tkoolen): It's very ugly, but parent, dofnum, and pitch also exist
   // currently (independently) at the RigidBodyTree level to represent the
   // featherstone structure. This version is for the kinematics.

--- a/attic/multibody/rigid_body.h
+++ b/attic/multibody/rigid_body.h
@@ -261,6 +261,7 @@ class RigidBody {
    * Returns a reference to an `std::vector` of collision elements that
    * represent the collision geometry of this rigid body.
    */
+  DRAKE_DEPRECATED("Mutable access to collision inormation is deprecated.");
   std::vector<drake::multibody::collision::ElementId>&
   get_mutable_collision_element_ids();
 
@@ -278,6 +279,7 @@ class RigidBody {
    * element IDs. These are the collision element groups created through calls
    * to RigidBody::AddCollisionElementToGroup().
    */
+  DRAKE_DEPRECATED("Mutable access to collision inormation is deprecated.");
   std::map<std::string, std::vector<drake::multibody::collision::ElementId>>&
   get_mutable_group_to_collision_ids_map();
 
@@ -429,13 +431,14 @@ class RigidBody {
 
   typedef std::vector<drake::multibody::collision::Element*>
       CollisionElementsVector;
-  typedef typename CollisionElementsVector::iterator CollisionElementsIterator;
+  typedef typename CollisionElementsVector::const_iterator
+      CollisionElementsIterator;
 
-  CollisionElementsIterator collision_elements_begin() {
+  CollisionElementsIterator collision_elements_begin() const {
     return collision_elements_.begin();
   }
 
-  CollisionElementsIterator collision_elements_end() {
+  CollisionElementsIterator collision_elements_end() const {
     return collision_elements_.end();
   }
 

--- a/attic/multibody/rigid_body_tree.h
+++ b/attic/multibody/rigid_body_tree.h
@@ -1043,16 +1043,14 @@ class RigidBodyTree {
       for (const auto& group : body_ptr->get_group_to_collision_ids_map()) {
         const std::string& group_name = group.first;
         if (test(group_name)) {
-          auto& ids = body_ptr->get_mutable_collision_element_ids();
-          for (const auto& id : group.second) {
-            ids.erase(std::find(ids.begin(), ids.end(), id));
+          for (auto id : group.second) {
             collision_model_->RemoveElement(id);
           }
           names_of_groups_to_delete.push_back(group_name);
         }
       }
       for (const auto& group_name : names_of_groups_to_delete) {
-        body_ptr->get_mutable_group_to_collision_ids_map().erase(group_name);
+        body_ptr->RemoveGroup(group_name);
       }
     }
   }


### PR DESCRIPTION
Follow-up to #9921.
I want to keep this separate so that we can easily revert this if it hurts downstream users.

Requires:
- [ ] #9921