### PR TITLE
Include missing SceneGraph ports when transmogrifying MultibodyPlant

### DIFF
--- a/multibody/multibody_tree/multibody_plant/multibody_plant.h
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.h
@@ -227,6 +227,9 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
     geometry_id_to_collision_index_ = other.geometry_id_to_collision_index_;
     visual_geometries_ = other.visual_geometries_;
     collision_geometries_ = other.collision_geometries_;
+    if (geometry_source_is_registered())
+      DeclareSceneGraphPorts();
+
     // MultibodyTree::CloneToScalar() already called MultibodyTree::Finalize()
     // on the new MultibodyTree on U. Therefore we only Finalize the plant's
     // internals (and not the MultibodyTree).

--- a/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
@@ -1355,6 +1355,10 @@ GTEST_TEST(MultibodyPlantTest, ScalarConversionConstructor) {
       plant_autodiff.GetBodyByName("link2")).size(), link2_num_visuals);
   EXPECT_EQ(plant_autodiff.GetVisualGeometriesForBody(
       plant_autodiff.GetBodyByName("link3")).size(), link3_num_visuals);
+
+  // Make sure the geometry ports were included in the autodiffed plant.
+  EXPECT_NO_THROW(plant_autodiff.get_geometry_query_input_port());
+  EXPECT_NO_THROW(plant_autodiff.get_geometry_poses_output_port());
 }
 
 // This test is used to verify the correctness of the methods to compute the


### PR DESCRIPTION
The scalar converting constructor (aka transmogrifier) in MBPlant was not reconstructing the SceneGraph ports for the new MBPlant.

Still needs:
- a unit test for an MBPlant/SceneGraph diagram transmogrification
- a framework addition that detects if the result of a transmogrification doesn't have the same topology as the original

@hongkai-dai please check that this fixes #9917.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9928)
<!-- Reviewable:end -->
