### PR TITLE
pydrake/{examples,manipulation}: Enforce clang-format idempotence

### DIFF
--- a/bindings/pydrake/examples/BUILD.bazel
+++ b/bindings/pydrake/examples/BUILD.bazel
@@ -188,4 +188,6 @@ drake_py_unittest(
     ],
 )
 
-add_lint_tests()
+add_lint_tests(
+    enable_clang_format_lint = True,
+)

--- a/bindings/pydrake/examples/acrobot_py.cc
+++ b/bindings/pydrake/examples/acrobot_py.cc
@@ -32,26 +32,26 @@ PYBIND11_MODULE(acrobot, m) {
   using T = double;
 
   py::class_<AcrobotPlant<T>, LeafSystem<T>>(m, "AcrobotPlant",
-    doc.AcrobotPlant.doc)
+                                             doc.AcrobotPlant.doc)
       .def(py::init<>(), doc.AcrobotPlant.ctor.doc_3)
       .def("CalcPotentialEnergy", &AcrobotPlant<T>::CalcPotentialEnergy,
-        doc.AcrobotPlant.DoCalcPotentialEnergy.doc)
+           doc.AcrobotPlant.DoCalcPotentialEnergy.doc)
       .def("CalcKineticEnergy", &AcrobotPlant<T>::CalcKineticEnergy,
-        doc.AcrobotPlant.DoCalcKineticEnergy.doc)
+           doc.AcrobotPlant.DoCalcKineticEnergy.doc)
       .def("DynamicsBiasTerm", &AcrobotPlant<T>::DynamicsBiasTerm,
-        doc.AcrobotPlant.DynamicsBiasTerm.doc)
+           doc.AcrobotPlant.DynamicsBiasTerm.doc)
       .def("MassMatrix", &AcrobotPlant<T>::MassMatrix,
-        doc.AcrobotPlant.MassMatrix.doc);
+           doc.AcrobotPlant.MassMatrix.doc);
 
   // TODO(russt): Remove custom bindings once #8096 is resolved.
   py::class_<AcrobotInput<T>, BasicVector<T>>(m, "AcrobotInput",
-      doc.AcrobotInput.doc)
+                                              doc.AcrobotInput.doc)
       .def(py::init<>(), doc.AcrobotInput.ctor.doc)
       .def("tau", &AcrobotInput<T>::tau, doc.AcrobotInput.tau.doc)
       .def("set_tau", &AcrobotInput<T>::set_tau, doc.AcrobotInput.set_tau.doc);
 
   py::class_<AcrobotParams<T>, BasicVector<T>>(m, "AcrobotParams",
-      doc.AcrobotParams.doc)
+                                               doc.AcrobotParams.doc)
       .def(py::init<>(), doc.AcrobotParams.ctor.doc)
       .def("m1", &AcrobotParams<T>::m1, doc.AcrobotParams.m1.doc)
       .def("m2", &AcrobotParams<T>::m2, doc.AcrobotParams.m2.doc)
@@ -73,25 +73,25 @@ PYBIND11_MODULE(acrobot, m) {
       .def("set_b1", &AcrobotParams<T>::set_b1, doc.AcrobotParams.set_b1.doc)
       .def("set_b2", &AcrobotParams<T>::set_b2, doc.AcrobotParams.set_b2.doc)
       .def("set_gravity", &AcrobotParams<T>::set_gravity,
-        doc.AcrobotParams.set_gravity.doc);
+           doc.AcrobotParams.set_gravity.doc);
 
   py::class_<AcrobotState<T>, BasicVector<T>>(m, "AcrobotState",
-      doc.AcrobotState.doc)
+                                              doc.AcrobotState.doc)
       .def(py::init<>(), doc.AcrobotState.ctor.doc)
       .def("theta1", &AcrobotState<T>::theta1, doc.AcrobotState.theta1.doc)
       .def("theta1dot", &AcrobotState<T>::theta1dot,
-        doc.AcrobotState.theta1dot.doc)
+           doc.AcrobotState.theta1dot.doc)
       .def("theta2", &AcrobotState<T>::theta2, doc.AcrobotState.theta2.doc)
       .def("theta2dot", &AcrobotState<T>::theta2dot,
-        doc.AcrobotState.theta2dot.doc)
+           doc.AcrobotState.theta2dot.doc)
       .def("set_theta1", &AcrobotState<T>::set_theta1,
-        doc.AcrobotState.set_theta1.doc)
+           doc.AcrobotState.set_theta1.doc)
       .def("set_theta1dot", &AcrobotState<T>::set_theta1dot,
-        doc.AcrobotState.set_theta1dot.doc)
+           doc.AcrobotState.set_theta1dot.doc)
       .def("set_theta2", &AcrobotState<T>::set_theta2,
-        doc.AcrobotState.set_theta2.doc)
+           doc.AcrobotState.set_theta2.doc)
       .def("set_theta2dot", &AcrobotState<T>::set_theta2dot,
-        doc.AcrobotState.set_theta2dot.doc);
+           doc.AcrobotState.set_theta2dot.doc);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/examples/compass_gait_py.cc
+++ b/bindings/pydrake/examples/compass_gait_py.cc
@@ -27,57 +27,58 @@ PYBIND11_MODULE(compass_gait, m) {
   using T = double;
 
   py::class_<CompassGait<T>, LeafSystem<T>>(m, "CompassGait",
-    doc.CompassGait.doc).def(py::init<>(), doc.CompassGait.ctor.doc_3);
+                                            doc.CompassGait.doc)
+      .def(py::init<>(), doc.CompassGait.ctor.doc_3);
 
   // TODO(russt): Remove custom bindings once #8096 is resolved.
   py::class_<CompassGaitParams<T>, BasicVector<T>>(m, "CompassGaitParams",
-      doc.CompassGaitParams.doc)
+                                                   doc.CompassGaitParams.doc)
       .def(py::init<>(), doc.CompassGaitParams.ctor.doc)
       .def("mass_hip", &CompassGaitParams<T>::mass_hip,
-        doc.CompassGaitParams.mass_hip.doc)
+           doc.CompassGaitParams.mass_hip.doc)
       .def("mass_leg", &CompassGaitParams<T>::mass_leg,
-        doc.CompassGaitParams.mass_leg.doc)
+           doc.CompassGaitParams.mass_leg.doc)
       .def("length_leg", &CompassGaitParams<T>::length_leg,
-        doc.CompassGaitParams.length_leg.doc)
+           doc.CompassGaitParams.length_leg.doc)
       .def("center_of_mass_leg", &CompassGaitParams<T>::center_of_mass_leg,
-        doc.CompassGaitParams.center_of_mass_leg.doc)
+           doc.CompassGaitParams.center_of_mass_leg.doc)
       .def("gravity", &CompassGaitParams<T>::gravity,
-        doc.CompassGaitParams.gravity.doc)
+           doc.CompassGaitParams.gravity.doc)
       .def("slope", &CompassGaitParams<T>::slope,
-        doc.CompassGaitParams.slope.doc)
+           doc.CompassGaitParams.slope.doc)
       .def("set_mass_hip", &CompassGaitParams<T>::set_mass_hip,
-        doc.CompassGaitParams.set_mass_hip.doc)
+           doc.CompassGaitParams.set_mass_hip.doc)
       .def("set_mass_leg", &CompassGaitParams<T>::set_mass_leg,
-        doc.CompassGaitParams.set_mass_leg.doc)
+           doc.CompassGaitParams.set_mass_leg.doc)
       .def("set_length_leg", &CompassGaitParams<T>::set_length_leg,
-        doc.CompassGaitParams.set_length_leg.doc)
+           doc.CompassGaitParams.set_length_leg.doc)
       .def("set_center_of_mass_leg",
            &CompassGaitParams<T>::set_center_of_mass_leg,
-        doc.CompassGaitParams.set_center_of_mass_leg.doc)
+           doc.CompassGaitParams.set_center_of_mass_leg.doc)
       .def("set_gravity", &CompassGaitParams<T>::set_gravity,
-        doc.CompassGaitParams.set_gravity.doc)
+           doc.CompassGaitParams.set_gravity.doc)
       .def("set_slope", &CompassGaitParams<T>::set_slope,
-        doc.CompassGaitParams.set_slope.doc);
+           doc.CompassGaitParams.set_slope.doc);
 
   py::class_<CompassGaitContinuousState<T>, BasicVector<T>>(
       m, "CompassGaitContinuousState", doc.CompassGaitContinuousState.doc)
       .def(py::init<>(), doc.CompassGaitContinuousState.ctor.doc)
       .def("stance", &CompassGaitContinuousState<T>::stance,
-        doc.CompassGaitContinuousState.stance.doc)
+           doc.CompassGaitContinuousState.stance.doc)
       .def("swing", &CompassGaitContinuousState<T>::swing,
-        doc.CompassGaitContinuousState.swing.doc)
+           doc.CompassGaitContinuousState.swing.doc)
       .def("stancedot", &CompassGaitContinuousState<T>::stancedot,
-        doc.CompassGaitContinuousState.stancedot.doc)
+           doc.CompassGaitContinuousState.stancedot.doc)
       .def("swingdot", &CompassGaitContinuousState<T>::swingdot,
-        doc.CompassGaitContinuousState.swingdot.doc)
+           doc.CompassGaitContinuousState.swingdot.doc)
       .def("set_stance", &CompassGaitContinuousState<T>::set_stance,
-        doc.CompassGaitContinuousState.set_stance.doc)
+           doc.CompassGaitContinuousState.set_stance.doc)
       .def("set_swing", &CompassGaitContinuousState<T>::set_swing,
-        doc.CompassGaitContinuousState.set_swing.doc)
+           doc.CompassGaitContinuousState.set_swing.doc)
       .def("set_stancedot", &CompassGaitContinuousState<T>::set_stancedot,
-        doc.CompassGaitContinuousState.set_stancedot.doc)
+           doc.CompassGaitContinuousState.set_stancedot.doc)
       .def("set_swingdot", &CompassGaitContinuousState<T>::set_swingdot,
-        doc.CompassGaitContinuousState.set_swingdot.doc);
+           doc.CompassGaitContinuousState.set_swingdot.doc);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/examples/manipulation_station_py.cc
+++ b/bindings/pydrake/examples/manipulation_station_py.cc
@@ -63,7 +63,7 @@ PYBIND11_MODULE(manipulation_station, m) {
       .def("SetWsgVelocity", &ManipulationStation<T>::SetWsgVelocity,
            doc.ManipulationStation.SetWsgVelocity.doc)
       .def_static("get_camera_pose", &ManipulationStation<T>::get_camera_pose,
-           doc.ManipulationStation.get_camera_pose.doc);
+                  doc.ManipulationStation.get_camera_pose.doc);
 
   py::class_<ManipulationStationHardwareInterface, Diagram<double>>(
       m, "ManipulationStationHardwareInterface")

--- a/bindings/pydrake/examples/multibody/BUILD.bazel
+++ b/bindings/pydrake/examples/multibody/BUILD.bazel
@@ -67,4 +67,6 @@ install(
     py_dest = PACKAGE_INFO.py_dest,
 )
 
-add_lint_tests()
+add_lint_tests(
+    enable_clang_format_lint = True,
+)

--- a/bindings/pydrake/examples/pendulum_py.cc
+++ b/bindings/pydrake/examples/pendulum_py.cc
@@ -32,43 +32,45 @@ PYBIND11_MODULE(pendulum, m) {
   using T = double;
 
   py::class_<PendulumPlant<T>, LeafSystem<T>>(m, "PendulumPlant",
-    doc.PendulumPlant.doc)
-    .def(py::init<>(), doc.PendulumPlant.ctor.doc_3);
+                                              doc.PendulumPlant.doc)
+      .def(py::init<>(), doc.PendulumPlant.ctor.doc_3);
 
   // TODO(russt): Remove custom bindings once #8096 is resolved.
   py::class_<PendulumInput<T>, BasicVector<T>>(m, "PendulumInput",
-    doc.PendulumInput.doc)
+                                               doc.PendulumInput.doc)
       .def(py::init<>(), doc.PendulumInput.ctor.doc)
       .def("tau", &PendulumInput<T>::tau, doc.PendulumInput.tau.doc)
       .def("set_tau", &PendulumInput<T>::set_tau,
-        doc.PendulumInput.set_tau.doc);
+           doc.PendulumInput.set_tau.doc);
 
   py::class_<PendulumParams<T>, BasicVector<T>>(m, "PendulumParams",
-    doc.PendulumParams.doc)
-    .def(py::init<>(), doc.PendulumParams.ctor.doc)
-    .def("mass", &PendulumParams<T>::mass, doc.PendulumParams.mass.doc)
-    .def("length", &PendulumParams<T>::length, doc.PendulumParams.length.doc)
-    .def("damping", &PendulumParams<T>::damping, doc.PendulumParams.damping.doc)
-    .def("gravity", &PendulumParams<T>::gravity, doc.PendulumParams.gravity.doc)
-    .def("set_mass", &PendulumParams<T>::set_mass,
-      doc.PendulumParams.set_mass.doc)
-    .def("set_length", &PendulumParams<T>::set_length,
-      doc.PendulumParams.set_length.doc)
-    .def("set_damping", &PendulumParams<T>::set_damping,
-      doc.PendulumParams.set_damping.doc)
-    .def("set_gravity", &PendulumParams<T>::set_gravity,
-      doc.PendulumParams.set_gravity.doc);
+                                                doc.PendulumParams.doc)
+      .def(py::init<>(), doc.PendulumParams.ctor.doc)
+      .def("mass", &PendulumParams<T>::mass, doc.PendulumParams.mass.doc)
+      .def("length", &PendulumParams<T>::length, doc.PendulumParams.length.doc)
+      .def("damping", &PendulumParams<T>::damping,
+           doc.PendulumParams.damping.doc)
+      .def("gravity", &PendulumParams<T>::gravity,
+           doc.PendulumParams.gravity.doc)
+      .def("set_mass", &PendulumParams<T>::set_mass,
+           doc.PendulumParams.set_mass.doc)
+      .def("set_length", &PendulumParams<T>::set_length,
+           doc.PendulumParams.set_length.doc)
+      .def("set_damping", &PendulumParams<T>::set_damping,
+           doc.PendulumParams.set_damping.doc)
+      .def("set_gravity", &PendulumParams<T>::set_gravity,
+           doc.PendulumParams.set_gravity.doc);
 
   py::class_<PendulumState<T>, BasicVector<T>>(m, "PendulumState",
-      doc.PendulumState.doc)
+                                               doc.PendulumState.doc)
       .def(py::init<>(), doc.PendulumState.ctor.doc)
       .def("theta", &PendulumState<T>::theta, doc.PendulumState.theta.doc)
       .def("thetadot", &PendulumState<T>::thetadot,
-        doc.PendulumState.thetadot.doc)
+           doc.PendulumState.thetadot.doc)
       .def("set_theta", &PendulumState<T>::set_theta,
-        doc.PendulumState.set_theta.doc)
+           doc.PendulumState.set_theta.doc)
       .def("set_thetadot", &PendulumState<T>::set_thetadot,
-        doc.PendulumState.set_thetadot.doc);
+           doc.PendulumState.set_thetadot.doc);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/examples/rimless_wheel_py.cc
+++ b/bindings/pydrake/examples/rimless_wheel_py.cc
@@ -27,45 +27,45 @@ PYBIND11_MODULE(rimless_wheel, m) {
   using T = double;
 
   py::class_<RimlessWheel<T>, LeafSystem<T>>(m, "RimlessWheel",
-      doc.RimlessWheel.doc)
+                                             doc.RimlessWheel.doc)
       .def(py::init<>(), doc.RimlessWheel.ctor.doc_3);
 
   // TODO(russt): Remove custom bindings once #8096 is resolved.
   py::class_<RimlessWheelParams<T>, BasicVector<T>>(m, "RimlessWheelParams",
-    doc.RimlessWheelParams.doc)
+                                                    doc.RimlessWheelParams.doc)
       .def(py::init<>(), doc.RimlessWheelParams.ctor.doc)
       .def("mass", &RimlessWheelParams<T>::mass,
-        doc.RimlessWheelParams.mass.doc)
+           doc.RimlessWheelParams.mass.doc)
       .def("length", &RimlessWheelParams<T>::length,
-        doc.RimlessWheelParams.length.doc)
+           doc.RimlessWheelParams.length.doc)
       .def("gravity", &RimlessWheelParams<T>::gravity,
-        doc.RimlessWheelParams.gravity.doc)
+           doc.RimlessWheelParams.gravity.doc)
       .def("number_of_spokes", &RimlessWheelParams<T>::number_of_spokes,
-        doc.RimlessWheelParams.number_of_spokes.doc)
+           doc.RimlessWheelParams.number_of_spokes.doc)
       .def("slope", &RimlessWheelParams<T>::slope,
-          doc.RimlessWheelParams.slope.doc)
+           doc.RimlessWheelParams.slope.doc)
       .def("set_mass", &RimlessWheelParams<T>::set_mass,
-        doc.RimlessWheelParams.set_mass.doc)
+           doc.RimlessWheelParams.set_mass.doc)
       .def("set_length", &RimlessWheelParams<T>::set_length,
-        doc.RimlessWheelParams.set_length.doc)
+           doc.RimlessWheelParams.set_length.doc)
       .def("set_gravity", &RimlessWheelParams<T>::set_gravity,
-        doc.RimlessWheelParams.set_gravity.doc)
+           doc.RimlessWheelParams.set_gravity.doc)
       .def("set_number_of_spokes", &RimlessWheelParams<T>::set_number_of_spokes,
-        doc.RimlessWheelParams.set_number_of_spokes.doc)
+           doc.RimlessWheelParams.set_number_of_spokes.doc)
       .def("set_slope", &RimlessWheelParams<T>::set_slope,
-        doc.RimlessWheelParams.set_slope.doc);
+           doc.RimlessWheelParams.set_slope.doc);
 
   py::class_<RimlessWheelContinuousState<T>, BasicVector<T>>(
       m, "RimlessWheelContinuousState", doc.RimlessWheelContinuousState.doc)
       .def(py::init<>(), doc.RimlessWheelContinuousState.ctor.doc)
       .def("theta", &RimlessWheelContinuousState<T>::theta,
-        doc.RimlessWheelContinuousState.theta.doc)
+           doc.RimlessWheelContinuousState.theta.doc)
       .def("thetadot", &RimlessWheelContinuousState<T>::thetadot,
-        doc.RimlessWheelContinuousState.thetadot.doc)
+           doc.RimlessWheelContinuousState.thetadot.doc)
       .def("set_theta", &RimlessWheelContinuousState<T>::set_theta,
-        doc.RimlessWheelContinuousState.set_theta.doc)
+           doc.RimlessWheelContinuousState.set_theta.doc)
       .def("set_thetadot", &RimlessWheelContinuousState<T>::set_thetadot,
-        doc.RimlessWheelContinuousState.set_thetadot.doc);
+           doc.RimlessWheelContinuousState.set_thetadot.doc);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/examples/van_der_pol_py.cc
+++ b/bindings/pydrake/examples/van_der_pol_py.cc
@@ -24,7 +24,7 @@ PYBIND11_MODULE(van_der_pol, m) {
   using T = double;
 
   py::class_<VanDerPolOscillator<T>, LeafSystem<T>>(m, "VanDerPolOscillator",
-    doc.VanDerPolOscillator.doc)
+                                                    doc.VanDerPolOscillator.doc)
       .def(py::init<>(), doc.VanDerPolOscillator.ctor.doc_3);
 }
 

--- a/bindings/pydrake/manipulation/BUILD.bazel
+++ b/bindings/pydrake/manipulation/BUILD.bazel
@@ -103,4 +103,6 @@ install(
     deps = get_drake_py_installs(PY_LIBRARIES_WITH_INSTALL),
 )
 
-add_lint_tests()
+add_lint_tests(
+    enable_clang_format_lint = True,
+)

--- a/bindings/pydrake/manipulation/planner_py.cc
+++ b/bindings/pydrake/manipulation/planner_py.cc
@@ -30,18 +30,17 @@ PYBIND11_MODULE(planner, m) {
     using Class = manipulation::planner::DifferentialInverseKinematicsResult;
     constexpr auto& class_doc = doc.DifferentialInverseKinematicsResult;
     py::class_<Class> cls(m, "DifferentialInverseKinematicsResult",
-        doc.DifferentialInverseKinematicsResult.doc);
+                          doc.DifferentialInverseKinematicsResult.doc);
 
     // TODO(m-chaturvedi) Add Pybind11 documentation.
-    cls
-        .def(py::init([](optional<VectorX<double>> joint_velocities,
-                          DifferentialInverseKinematicsStatus status) {
-           return Class{joint_velocities, status};
-         }), py::arg("joint_velocities"), py::arg("status"))
+    cls.def(py::init([](optional<VectorX<double>> joint_velocities,
+                        DifferentialInverseKinematicsStatus status) {
+              return Class{joint_velocities, status};
+            }),
+            py::arg("joint_velocities"), py::arg("status"))
         .def_readwrite("joint_velocities", &Class::joint_velocities,
-            class_doc.joint_velocities.doc)
-        .def_readwrite("status", &Class::status,
-            class_doc.status.doc);
+                       class_doc.joint_velocities.doc)
+        .def_readwrite("status", &Class::status, class_doc.status.doc);
   }
   {
     using Class =
@@ -49,7 +48,7 @@ PYBIND11_MODULE(planner, m) {
     constexpr auto& class_doc = doc.DifferentialInverseKinematicsParameters;
 
     py::class_<Class> cls(m, "DifferentialInverseKinematicsParameters",
-        doc.DifferentialInverseKinematicsParameters.doc);
+                          doc.DifferentialInverseKinematicsParameters.doc);
 
     cls.def(py::init([](int num_positions, int num_velocities) {
               return Class{num_positions, num_velocities};
@@ -59,13 +58,13 @@ PYBIND11_MODULE(planner, m) {
         .def("get_timestep", &Class::get_timestep, class_doc.get_timestep.doc)
         .def("set_timestep", &Class::set_timestep, class_doc.set_timestep.doc)
         .def("get_num_positions", &Class::get_num_positions,
-            class_doc.get_num_positions.doc)
+             class_doc.get_num_positions.doc)
         .def("get_num_velocities", &Class::get_num_velocities,
-            class_doc.get_num_velocities.doc)
+             class_doc.get_num_velocities.doc)
         .def("get_nominal_joint_position", &Class::get_nominal_joint_position,
-            class_doc.get_nominal_joint_position.doc)
+             class_doc.get_nominal_joint_position.doc)
         .def("set_nominal_joint_position", &Class::set_nominal_joint_position,
-            class_doc.set_nominal_joint_position.doc)
+             class_doc.set_nominal_joint_position.doc)
         .def("get_end_effector_velocity_gain",
              &Class::get_end_effector_velocity_gain,
              class_doc.get_end_effector_velocity_gain.doc)
@@ -79,13 +78,13 @@ PYBIND11_MODULE(planner, m) {
              &Class::set_unconstrained_degrees_of_freedom_velocity_limit,
              class_doc.set_unconstrained_degrees_of_freedom_velocity_limit.doc)
         .def("get_joint_position_limits", &Class::get_joint_position_limits,
-           class_doc.get_joint_position_limits.doc)
+             class_doc.get_joint_position_limits.doc)
         .def("set_joint_position_limits", &Class::set_joint_position_limits,
-           class_doc.set_joint_position_limits.doc)
+             class_doc.set_joint_position_limits.doc)
         .def("get_joint_velocity_limits", &Class::get_joint_velocity_limits,
              class_doc.get_joint_velocity_limits.doc)
         .def("set_joint_velocity_limits", &Class::set_joint_velocity_limits,
-            class_doc.set_joint_velocity_limits.doc)
+             class_doc.set_joint_velocity_limits.doc)
         .def("get_joint_acceleration_limits",
              &Class::get_joint_acceleration_limits,
              class_doc.get_joint_acceleration_limits.doc)
@@ -102,9 +101,8 @@ PYBIND11_MODULE(planner, m) {
           return manipulation::planner::DoDifferentialInverseKinematics(
               q_current, v_current, V, J, parameters);
         },
-        py::arg("q_current"), py::arg("v_current"),
-        py::arg("V"), py::arg("J"), py::arg("parameters"),
-        doc.DoDifferentialInverseKinematics.doc);
+        py::arg("q_current"), py::arg("v_current"), py::arg("V"), py::arg("J"),
+        py::arg("parameters"), doc.DoDifferentialInverseKinematics.doc);
 
   m.def("DoDifferentialInverseKinematics",
         [](const multibody::multibody_plant::MultibodyPlant<double>& robot,


### PR DESCRIPTION
Relates #4843.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9932)
<!-- Reviewable:end -->
