### PR TITLE
pydrake/maliput: Enforce clang-format idempotence

### DIFF
--- a/bindings/pydrake/doc/BUILD.bazel
+++ b/bindings/pydrake/doc/BUILD.bazel
@@ -35,4 +35,7 @@ drake_py_binary(
     deps = ["//doc:sphinx_base"],
 )
 
-add_lint_tests(python_lint_exclude = [":conf.py"])
+add_lint_tests(
+    enable_clang_format_lint = True,
+    python_lint_exclude = [":conf.py"],
+)

--- a/bindings/pydrake/maliput/BUILD.bazel
+++ b/bindings/pydrake/maliput/BUILD.bazel
@@ -97,4 +97,6 @@ drake_py_unittest(
     ],
 )
 
-add_lint_tests()
+add_lint_tests(
+    enable_clang_format_lint = True,
+)

--- a/bindings/pydrake/maliput/api_py.cc
+++ b/bindings/pydrake/maliput/api_py.cc
@@ -43,7 +43,8 @@ PYBIND11_MODULE(api, m) {
 
   py::class_<RoadPosition> road_position(m, "RoadPosition",
                                          doc.RoadPosition.doc);
-  road_position.def(py::init<>(), doc.RoadPosition.ctor.doc)
+  road_position  // BR
+      .def(py::init<>(), doc.RoadPosition.ctor.doc)
       .def(py::init<const Lane*, const LanePosition&>(), py::arg("lane"),
            py::arg("pos"),
            // Keep alive, reference: `self` keeps `Lane*` alive.

--- a/bindings/pydrake/maliput/api_py.cc
+++ b/bindings/pydrake/maliput/api_py.cc
@@ -33,18 +33,17 @@ PYBIND11_MODULE(api, m) {
       .def(py::init<double, double, double>(), py::arg("x"), py::arg("y"),
            py::arg("z"), doc.GeoPositionT.ctor.doc_4)
       .def("xyz", &GeoPosition::xyz, py_reference_internal,
-        doc.GeoPositionT.xyz.doc);
+           doc.GeoPositionT.xyz.doc);
 
   py::class_<LanePosition>(m, "LanePosition", doc.LanePositionT.doc)
       .def(py::init<double, double, double>(), py::arg("s"), py::arg("r"),
            py::arg("h"), doc.LanePositionT.ctor.doc_4)
       .def("srh", &LanePosition::srh, py_reference_internal,
-        doc.LanePositionT.srh.doc);
+           doc.LanePositionT.srh.doc);
 
   py::class_<RoadPosition> road_position(m, "RoadPosition",
                                          doc.RoadPosition.doc);
-  road_position
-      .def(py::init<>(), doc.RoadPosition.ctor.doc)
+  road_position.def(py::init<>(), doc.RoadPosition.ctor.doc)
       .def(py::init<const Lane*, const LanePosition&>(), py::arg("lane"),
            py::arg("pos"),
            // Keep alive, reference: `self` keeps `Lane*` alive.
@@ -55,20 +54,20 @@ PYBIND11_MODULE(api, m) {
 
   py::class_<Rotation>(m, "Rotation", doc.Rotation.doc)
       .def("quat", &Rotation::quat, py_reference_internal,
-        doc.Rotation.quat.doc)
+           doc.Rotation.quat.doc)
       .def("rpy", &Rotation::rpy, doc.Rotation.rpy.doc);
 
   py::class_<RoadGeometry>(m, "RoadGeometry", doc.RoadGeometry.doc)
       .def("num_junctions", &RoadGeometry::num_junctions,
-        doc.RoadGeometry.num_junctions.doc)
+           doc.RoadGeometry.num_junctions.doc)
       .def("junction", &RoadGeometry::junction, py_reference_internal,
-        doc.RoadGeometry.junction.doc);
+           doc.RoadGeometry.junction.doc);
 
   py::class_<Junction>(m, "Junction", doc.Junction.doc)
       .def("num_segments", &Junction::num_segments,
-        doc.Junction.num_segments.doc)
+           doc.Junction.num_segments.doc)
       .def("segment", &Junction::segment, py_reference_internal,
-        doc.Junction.segment.doc);
+           doc.Junction.segment.doc);
 
   py::class_<Segment>(m, "Segment", doc.Segment.doc)
       .def("num_lanes", &Segment::num_lanes, doc.Segment.num_lanes.doc)

--- a/bindings/pydrake/maliput/dragway_py.cc
+++ b/bindings/pydrake/maliput/dragway_py.cc
@@ -19,8 +19,8 @@ PYBIND11_MODULE(dragway, m) {
 
   m.doc() = "Bindings for the Dragway backend.";
 
-  py::class_<dragway::RoadGeometry, api::RoadGeometry>(m, "RoadGeometry",
-    doc.dragway.RoadGeometry.doc);
+  py::class_<dragway::RoadGeometry, api::RoadGeometry>(
+      m, "RoadGeometry", doc.dragway.RoadGeometry.doc);
 
   m.def("create_dragway",
         [](api::RoadGeometryId road_id, int num_lanes, double length,
@@ -29,7 +29,8 @@ PYBIND11_MODULE(dragway, m) {
           return make_unique<dragway::RoadGeometry>(
               road_id, num_lanes, length, lane_width, shoulder_width,
               maximum_height, linear_tolerance, angular_tolerance);
-        }, py::arg("road_id"), py::arg("num_lanes"), py::arg("length"),
+        },
+        py::arg("road_id"), py::arg("num_lanes"), py::arg("length"),
         py::arg("lane_width"), py::arg("shoulder_width"),
         py::arg("maximum_height"), py::arg("linear_tolerance"),
         py::arg("angular_tolerance"), doc.dragway.RoadGeometry.ctor.doc_3);

--- a/bindings/pydrake/third_party/BUILD.bazel
+++ b/bindings/pydrake/third_party/BUILD.bazel
@@ -1,3 +1,5 @@
+# -*- python -*-
+
 load("@drake//tools/install:install.bzl", "install")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load(
@@ -73,4 +75,6 @@ install(
     doc_dest = "share/doc",
 )
 
-add_lint_tests()
+add_lint_tests(
+    enable_clang_format_lint = True,
+)


### PR DESCRIPTION
(Also add the linter to doc and third_party, even though there is no C++ code in those folder yet.)

Relates #4843.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9934)
<!-- Reviewable:end -->
