### PR TITLE
py manipulation: Disable test w/ windows

### DIFF
--- a/bindings/pydrake/manipulation/BUILD.bazel
+++ b/bindings/pydrake/manipulation/BUILD.bazel
@@ -77,6 +77,9 @@ drake_py_unittest(
     data = [
         "//multibody/benchmarks/acrobot:models",
     ],
+    # TODO(eric.cousineau): Remove if/when we can somehow test code paths
+    # without a window popping up.
+    tags = ["manual"],
     deps = [
         ":simple_ui_py",
         "//bindings/pydrake/multibody",

--- a/examples/manipulation_station/BUILD.bazel
+++ b/examples/manipulation_station/BUILD.bazel
@@ -147,7 +147,9 @@ drake_py_binary(
     name = "end_effector_teleop",
     srcs = ["end_effector_teleop.py"],
     add_test_rule = 1,
-    tags = vtk_test_tags(),
+    # TODO(eric.cousineau): Remove `manual` tag if/when we can somehow test
+    # code paths without a window popping up.
+    tags = vtk_test_tags() + ["manual"],
     test_rule_args = ["--target_realtime_rate=0.0 --duration=0.1"],
     deps = [
         "//bindings/pydrake",


### PR DESCRIPTION
@RussTedrake Sorry I hadn't faulted this in code review, but we shouldn't let tests open windows when testing.
For now, just putting a `manual` tag on it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9940)
<!-- Reviewable:end -->
