### PR TITLE
Stop commanding double the intended grip force.

### DIFF
--- a/lcmtypes/lcmt_schunk_wsg_status.lcm
+++ b/lcmtypes/lcmt_schunk_wsg_status.lcm
@@ -5,6 +5,11 @@ struct lcmt_schunk_wsg_status
   int64_t utime;  //< The timestamp in microseconds.
 
   double actual_position_mm;
+
+  // The combined force being applied by both gripper fingers in newtons.
+  // While some implementations may report a negative value for this field
+  // under some circumstances, it should always be interpreted as an unsigned
+  // quantity (absolute value).
   double actual_force;
   double actual_speed_mm_per_s;
 }

--- a/manipulation/schunk_wsg/schunk_wsg_plain_controller.cc
+++ b/manipulation/schunk_wsg/schunk_wsg_plain_controller.cc
@@ -98,9 +98,9 @@ SchunkWsgPlainController::SchunkWsgPlainController(ControlMode control_mode,
   const auto max_force_passthrough =
       builder.AddSystem<systems::PassThrough<double>>(1);
   const auto positive_gain = builder.AddSystem<systems::MatrixGain<double>>(
-      MatrixX<double>::Ones(ng, 1));
+      0.5 * MatrixX<double>::Ones(ng, 1));
   const auto negative_gain = builder.AddSystem<systems::MatrixGain<double>>(
-      -MatrixX<double>::Ones(ng, 1));
+      -0.5 * MatrixX<double>::Ones(ng, 1));
   const auto saturation = builder.AddSystem<systems::Saturation<double>>(ng);
 
   // Add blocks to generate the desired control state.

--- a/manipulation/schunk_wsg/schunk_wsg_plain_controller.h
+++ b/manipulation/schunk_wsg/schunk_wsg_plain_controller.h
@@ -42,7 +42,7 @@ enum class ControlMode { kPosition = 0, kForce = 1 };
  *                           │   ┌──────────┐   ┌───────────┐   │   │
  *                 ┌─────────│──▶│          │   │Grip Force │   │   │
  *                 │   ┌──┐  └──▶│Saturation├──▶│To Joint   ├──▶│   │
- * max force ──────┴──▶│-1├─────▶│          │   │Force      │   └───┘
+ * max force / 2 ──┴──▶│-1├─────▶│          │   │Force      │   └───┘
  *                     └──┘      └──────────┘   └───────────┘
  *```
  * The blocks with double outlines (══) differ between the two control modes:

--- a/manipulation/schunk_wsg/schunk_wsg_position_controller.cc
+++ b/manipulation/schunk_wsg/schunk_wsg_position_controller.cc
@@ -116,7 +116,7 @@ void SchunkWsgPositionController::CalcGripForceOutput(
     const drake::systems::Context<double>& context,
     drake::systems::BasicVector<double>* output_vector) const {
   Vector2d force = CalcGeneralizedForce(context);
-  output_vector->SetAtIndex(0, force[0] - force[1]);
+  output_vector->SetAtIndex(0, std::abs(force[0] - force[1]));
 }
 
 }  // namespace schunk_wsg

--- a/manipulation/schunk_wsg/schunk_wsg_position_controller.h
+++ b/manipulation/schunk_wsg/schunk_wsg_position_controller.h
@@ -47,8 +47,8 @@ namespace schunk_wsg {
 /// velocities of the two fingers).  The output generalized_force is a
 /// BasicVector<double> of size 2 (generalized force inputs to the two
 /// fingers).  The output grip_force is a scalar surrogate for the force
-/// measurement from the driver, f = f₀-f₁, chosen so that positive grip force
-/// corresponds with closing the gripper.
+/// measurement from the driver, f = abs(f₀-f₁) which, like the gripper
+/// itself, only reports a positive force.
 ///
 class SchunkWsgPositionController : public systems::LeafSystem<double> {
  public:

--- a/manipulation/schunk_wsg/test/schunk_wsg_controller_test.cc
+++ b/manipulation/schunk_wsg/test/schunk_wsg_controller_test.cc
@@ -49,15 +49,15 @@ GTEST_TEST(SchunkWsgControllerTest, SchunkWsgControllerTest) {
   wsg_command.force = 40;
   std::pair<double, double> commanded_force =
       RunWsgControllerTestStep(wsg_command, 0);
-  EXPECT_FLOAT_EQ(commanded_force.first, -wsg_command.force);
-  EXPECT_FLOAT_EQ(commanded_force.second, wsg_command.force);
+  EXPECT_FLOAT_EQ(commanded_force.first, -wsg_command.force * 0.5);
+  EXPECT_FLOAT_EQ(commanded_force.second, wsg_command.force * 0.5);
 
   // Move in toward the middle of the range with lower force from the outside.
   wsg_command.target_position_mm = 50;
   wsg_command.force = 20;
   commanded_force = RunWsgControllerTestStep(wsg_command, 100);
-  EXPECT_FLOAT_EQ(commanded_force.first, wsg_command.force);
-  EXPECT_FLOAT_EQ(commanded_force.second, -wsg_command.force);
+  EXPECT_FLOAT_EQ(commanded_force.first, wsg_command.force * 0.5);
+  EXPECT_FLOAT_EQ(commanded_force.second, -wsg_command.force * 0.5);
 
   // Set the position to something near the target and observe zero force.
   commanded_force = RunWsgControllerTestStep(


### PR DESCRIPTION
There appears to have been an issue for some time where
SchunkWsgController was commanding double the desired grip force,
which wasn't noticed because SchunkWsgStatusSender had been reporting
half of the total force.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9950)
<!-- Reviewable:end -->
