### PR TITLE
Fix-forward for image writer PR 9882

### DIFF
--- a/systems/sensors/test/image_writer_test.cc
+++ b/systems/sensors/test/image_writer_test.cc
@@ -454,11 +454,11 @@ TEST_F(ImageWriterTest, FileNameFormatting) {
 // directory path.
 TEST_F(ImageWriterTest, ValidateDirectory) {
   // Case: Non-existent directory.
-  EXPECT_TRUE(ImageWriterTester::DirectoryIsMissing(
-      "this/path/does/not_exist"));
+  EXPECT_TRUE(
+      ImageWriterTester::DirectoryIsMissing("this/path/does/not_exist"));
 
   // Case: No write permissions (assuming that this isn't run as root).
-EXPECT_TRUE(ImageWriterTester::DirectoryIsUnwritable("/root"));
+  EXPECT_TRUE(ImageWriterTester::DirectoryIsUnwritable("/usr"));
 
   // Case: the path is to a file.
   const std::string file_name = temp_name();


### PR DESCRIPTION
A unit test in #9882 depended on a directory name that exists on Linux but not Mac ("/root"). Switched to "/usr". This hopefully avoids reverting with PR #9954.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9957)
<!-- Reviewable:end -->
