### PR TITLE
libdrake: Install example classes used by pydrake

### DIFF
--- a/bindings/pydrake/examples/BUILD.bazel
+++ b/bindings/pydrake/examples/BUILD.bazel
@@ -35,7 +35,6 @@ drake_pybind_library(
     name = "acrobot_py",
     cc_deps = [
         "//bindings/pydrake:documentation_pybind",
-        "//examples/acrobot:acrobot_plant",
     ],
     cc_srcs = ["acrobot_py.cc"],
     package_info = PACKAGE_INFO,
@@ -49,7 +48,6 @@ drake_pybind_library(
     name = "compass_gait_py",
     cc_deps = [
         "//bindings/pydrake:documentation_pybind",
-        "//examples/compass_gait",
     ],
     cc_srcs = ["compass_gait_py.cc"],
     package_info = PACKAGE_INFO,
@@ -77,7 +75,6 @@ drake_pybind_library(
     name = "pendulum_py",
     cc_deps = [
         "//bindings/pydrake:documentation_pybind",
-        "//examples/pendulum:pendulum_plant",
     ],
     cc_srcs = ["pendulum_py.cc"],
     package_info = PACKAGE_INFO,
@@ -91,7 +88,6 @@ drake_pybind_library(
     name = "rimless_wheel_py",
     cc_deps = [
         "//bindings/pydrake:documentation_pybind",
-        "//examples/rimless_wheel",
     ],
     cc_srcs = ["rimless_wheel_py.cc"],
     package_info = PACKAGE_INFO,
@@ -105,7 +101,6 @@ drake_pybind_library(
     name = "van_der_pol_py",
     cc_deps = [
         "//bindings/pydrake:documentation_pybind",
-        "//examples/van_der_pol",
     ],
     cc_srcs = ["van_der_pol_py.cc"],
     package_info = PACKAGE_INFO,

--- a/examples/acrobot/BUILD.bazel
+++ b/examples/acrobot/BUILD.bazel
@@ -13,19 +13,24 @@ load(
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
+package(default_visibility = ["//visibility:private"])
+
 drake_cc_vector_gen_library(
     name = "acrobot_input",
     srcs = ["acrobot_input.named_vector"],
+    visibility = ["//visibility:public"],
 )
 
 drake_cc_vector_gen_library(
     name = "acrobot_params",
     srcs = ["acrobot_params.named_vector"],
+    visibility = ["//visibility:public"],
 )
 
 drake_cc_vector_gen_library(
     name = "acrobot_state",
     srcs = ["acrobot_state.named_vector"],
+    visibility = ["//visibility:public"],
 )
 
 drake_cc_library(

--- a/examples/compass_gait/BUILD.bazel
+++ b/examples/compass_gait/BUILD.bazel
@@ -13,7 +13,7 @@ load(
     "drake_cc_vector_gen_library",
 )
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//visibility:private"])
 
 drake_cc_vector_gen_library(
     name = "compass_gait_vector_types",
@@ -30,6 +30,7 @@ drake_cc_library(
     hdrs = [
         "compass_gait.h",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":compass_gait_vector_types",
         "//common:default_scalars",

--- a/examples/pendulum/BUILD.bazel
+++ b/examples/pendulum/BUILD.bazel
@@ -13,6 +13,8 @@ load(
     "drake_cc_vector_gen_library",
 )
 
+package(default_visibility = ["//visibility:private"])
+
 drake_cc_vector_gen_library(
     name = "pendulum_vector_types",
     srcs = [

--- a/examples/rimless_wheel/BUILD.bazel
+++ b/examples/rimless_wheel/BUILD.bazel
@@ -13,7 +13,7 @@ load(
     "drake_cc_vector_gen_library",
 )
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//visibility:private"])
 
 drake_cc_vector_gen_library(
     name = "rimless_wheel_vector_types",

--- a/examples/van_der_pol/BUILD.bazel
+++ b/examples/van_der_pol/BUILD.bazel
@@ -8,6 +8,8 @@ load(
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
+package(default_visibility = ["//visibility:private"])
+
 drake_cc_library(
     name = "van_der_pol",
     srcs = ["van_der_pol.cc"],

--- a/tools/install/libdrake/build_components.bzl
+++ b/tools/install/libdrake/build_components.bzl
@@ -42,8 +42,19 @@ LIBDRAKE_COMPONENTS = [
     "//common/trajectories",
     "//common:drake_marker_shared_library",  # unpackaged
     "//common:text_logging_gflags_h",  # unpackaged
+    "//examples/acrobot:acrobot_input",  # unpackaged
+    "//examples/acrobot:acrobot_params",  # unpackaged
+    "//examples/acrobot:acrobot_plant",  # unpackaged
+    "//examples/acrobot:acrobot_state",  # unpackaged
+    "//examples/compass_gait:compass_gait",  # unpackaged
+    "//examples/compass_gait:compass_gait_vector_types",  # unpackaged
     "//examples/manipulation_station:manipulation_station",  # unpackaged
     "//examples/manipulation_station:manipulation_station_hardware_interface",  # unpackaged  # noqa
+    "//examples/pendulum:pendulum_plant",  # unpackaged
+    "//examples/pendulum:pendulum_vector_types",  # unpackaged
+    "//examples/rimless_wheel:rimless_wheel",  # unpackaged
+    "//examples/rimless_wheel:rimless_wheel_vector_types",  # unpackaged
+    "//examples/van_der_pol:van_der_pol",  # unpackaged
     "//geometry",
     "//geometry/dev",
     "//geometry/dev/render",

--- a/tools/install/libdrake/build_components_refresh.py
+++ b/tools/install/libdrake/build_components_refresh.py
@@ -38,9 +38,14 @@ kind("cc_library", visible("//tools/install/libdrake:libdrake.so", "//..."))
     except("//:*")
     except("//bindings/pydrake/...")
     except(
-      "//examples/..." except(
+      "//examples/..." except(set(
+        "//examples/acrobot/..."
+        "//examples/compass_gait/..."
         "//examples/manipulation_station/..."
-      )
+        "//examples/pendulum/..."
+        "//examples/rimless_wheel/..."
+        "//examples/van_der_pol/..."
+      ))
     )
     except("//lcmtypes/...")
     except("//tools/install/libdrake:*")


### PR DESCRIPTION
This brings CMake C++ public access on par with pydrake and Bazel C++ public access, and resolves ODR violations in the pydrake bindings.

Closes #8911.