### PR TITLE
Make iiwa7 look respectable in meshcat

### DIFF
--- a/bindings/pydrake/systems/meshcat_visualizer.py
+++ b/bindings/pydrake/systems/meshcat_visualizer.py
@@ -98,6 +98,11 @@ class MeshcatVisualizer(LeafSystem):
 
             for j in range(link.num_geom):
                 geom = link.geom[j]
+                # MultibodyPlant currenly sets alpha=0 to make collision
+                # geometry "invisible".  Ignore those geometries here.
+                if geom.color[3] == 0:
+                    continue
+
                 element_local_tf = RigidTransform(
                     RotationMatrix(Quaternion(geom.quaternion)),
                     geom.position).GetAsMatrix4()

--- a/manipulation/models/iiwa_description/iiwa7/iiwa7_no_collision.sdf
+++ b/manipulation/models/iiwa_description/iiwa7/iiwa7_no_collision.sdf
@@ -105,7 +105,7 @@
           </mesh>
         </geometry>
         <material>
-          <diffuse>0.4 0.4 0.4 1.0</diffuse>
+          <diffuse>1.0 0.423529411765 0.0392156862745 1.0</diffuse>
         </material>
       </visual>
       <gravity>1</gravity>
@@ -205,7 +205,7 @@
           </mesh>
         </geometry>
         <material>
-          <diffuse>0.4 0.4 0.4 1.0</diffuse>
+          <diffuse>1.0 0.423529411765 0.0392156862745 1.0</diffuse>
         </material>
       </visual>
       <gravity>1</gravity>
@@ -305,7 +305,7 @@
           </mesh>
         </geometry>
         <material>
-          <diffuse>0.4 0.4 0.4 1.0</diffuse>
+          <diffuse>1.0 0.423529411765 0.0392156862745 1.0</diffuse>
         </material>
       </visual>
       <gravity>1</gravity>

--- a/manipulation/models/iiwa_description/iiwa7/iiwa7_with_box_collision.sdf
+++ b/manipulation/models/iiwa_description/iiwa7/iiwa7_with_box_collision.sdf
@@ -121,7 +121,7 @@
           </mesh>
         </geometry>
         <material>
-          <diffuse>0.4 0.4 0.4 1.0</diffuse>
+          <diffuse>1.0 0.423529411765 0.0392156862745 1.0</diffuse>
         </material>
       </visual>
        <collision name='iiwa_link_2_collision'>
@@ -237,7 +237,7 @@
           </mesh>
         </geometry>
         <material>
-          <diffuse>0.4 0.4 0.4 1.0</diffuse>
+          <diffuse>1.0 0.423529411765 0.0392156862745 1.0</diffuse>
         </material>
       </visual>
       <collision name='iiwa_link_4_collision'>
@@ -353,7 +353,7 @@
           </mesh>
         </geometry>
         <material>
-          <diffuse>0.4 0.4 0.4 1.0</diffuse>
+          <diffuse>1.0 0.423529411765 0.0392156862745 1.0</diffuse>
         </material>
       </visual>
       <collision name='iiwa_link_6_collision'>


### PR DESCRIPTION
Adds the orange color to the correct links.
Stop showing solid black collision geometries by filtering by alpha in the same way the drake_visualizer does.