### PR TITLE
Bind PerStep and Periodic event methods to support callback-using API

### DIFF
--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -76,7 +76,9 @@ struct Impl {
     using Base::DeclareDiscreteState;
     using Base::DeclareInitializationEvent;
     using Base::DeclarePeriodicDiscreteUpdate;
+    using Base::DeclarePeriodicEvent;
     using Base::DeclarePeriodicPublish;
+    using Base::DeclarePerStepEvent;
     using Base::DeclareVectorOutputPort;
 
     // Because `LeafSystem<T>::DoPublish` is protected, and we had to override
@@ -422,6 +424,19 @@ struct Impl {
                self->DeclareInitializationEvent(event);
              },
              py::arg("event"), doc.LeafSystem.DeclareInitializationEvent.doc)
+        // Binding the *second* signature; first has no Event argument.
+        .def("_DeclarePeriodicEvent",
+             [](PyLeafSystem* self, double period_sec, double offset_sec,
+                const Event<T>& event) {
+               self->DeclarePeriodicEvent(period_sec, offset_sec, event);
+             },
+             py::arg("period_sec"), py::arg("offset_sec"), py::arg("event"),
+             doc.LeafSystem.DeclarePeriodicEvent.doc_2)
+        .def("_DeclarePerStepEvent",
+             [](PyLeafSystem* self, const Event<T>& event) {
+               self->DeclarePerStepEvent(event);
+             },
+             py::arg("event"), doc.LeafSystem.DeclarePerStepEvent.doc)
         .def("_DoPublish", &LeafSystemPublic::DoPublish,
              doc.LeafSystem.DoPublish.doc)
         // System attributes.

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -153,6 +153,8 @@ class TestCustom(unittest.TestCase):
                 self.called_continuous = False
                 self.called_discrete = False
                 self.called_initialize = False
+                self.called_per_step = False
+                self.called_periodic = False
                 # Ensure we have desired overloads.
                 self._DeclarePeriodicPublish(0.1)
                 self._DeclarePeriodicPublish(0.1, 0)
@@ -163,6 +165,16 @@ class TestCustom(unittest.TestCase):
                     event=PublishEvent(
                         trigger_type=TriggerType.kInitialization,
                         callback=self._on_initialize))
+                self._DeclarePerStepEvent(
+                    event=PublishEvent(
+                        trigger_type=TriggerType.kPerStep,
+                        callback=self._on_per_step))
+                self._DeclarePeriodicEvent(
+                    period_sec=0.1,
+                    offset_sec=0.0,
+                    event=PublishEvent(
+                        trigger_type=TriggerType.kPeriodic,
+                        callback=self._on_periodic))
                 self._DeclareContinuousState(2)
                 self._DeclareDiscreteState(1)
                 # Ensure that we have inputs / outputs to call direct
@@ -212,6 +224,17 @@ class TestCustom(unittest.TestCase):
                 test.assertFalse(self.called_initialize)
                 self.called_initialize = True
 
+            def _on_per_step(self, context, event):
+                test.assertIsInstance(context, Context)
+                test.assertIsInstance(event, PublishEvent)
+                self.called_per_step = True
+
+            def _on_periodic(self, context, event):
+                test.assertIsInstance(context, Context)
+                test.assertIsInstance(event, PublishEvent)
+                test.assertFalse(self.called_periodic)
+                self.called_periodic = True
+
         system = TrivialSystem()
         self.assertFalse(system.called_publish)
         self.assertFalse(system.called_feedthrough)
@@ -241,6 +264,13 @@ class TestCustom(unittest.TestCase):
         system.CalcTimeDerivatives(
             context, context_update.get_mutable_continuous_state())
         self.assertTrue(system.called_continuous)
+
+        # Test per-step and periodic call backs
+        system = TrivialSystem()
+        simulator = Simulator(system)
+        simulator.StepTo(0.1)
+        self.assertTrue(system.called_per_step)
+        self.assertTrue(system.called_periodic)
 
     def test_vector_system_overrides(self):
         dt = 0.5


### PR DESCRIPTION
Allow per-step and periodic events to be specified using callbacks in Python (like initialization events).

In practice, these can be used to avoid overriding DoPublish() and make for more-straightforward examples.

Resolves #9992.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10004)
<!-- Reviewable:end -->
