### PR TITLE
TEST-ONLY: Revert "workspace: Update externals to latest releases 

### DIFF
--- a/tools/workspace/pycps/repository.bzl
+++ b/tools/workspace/pycps/repository.bzl
@@ -8,8 +8,8 @@ def pycps_repository(
     github_archive(
         name = name,
         repository = "mwoehlke/pycps",
-        commit = "83326ffaf03528e83f673eccb8af9b129504bf42",
-        sha256 = "eede05c985d35f683445d8267be1ad7679b296b2d00290870c347e91822f51d1",  # noqa
+        commit = "d14257769e0110f542c7d3a0f6b0d2c80d59ff52",
+        sha256 = "3f36d5f2a7084749d4e602197c428816a5f28f39c13b6e01de78d8999bfc470e",  # noqa
         build_file = "@drake//tools/workspace/pycps:package.BUILD.bazel",
         mirrors = mirrors,
     )

--- a/tools/workspace/qdldl/package.BUILD.bazel
+++ b/tools/workspace/qdldl/package.BUILD.bazel
@@ -21,7 +21,6 @@ cmake_configure_file(
     src = "configure/qdldl_types.h.in",
     out = "include/qdldl_types.h",
     defines = [
-        "QDLDL_BOOL_TYPE=unsigned char",
         # Keep this sync'd with the 'DLONG' defined in //tools/workspace/osqp.
         "QDLDL_INT_TYPE=long long",
         # Keep this sync'd with the lack of 'DFLOAT' in //tools/workspace/osqp.

--- a/tools/workspace/qdldl/repository.bzl
+++ b/tools/workspace/qdldl/repository.bzl
@@ -10,10 +10,10 @@ def qdldl_repository(
         repository = "oxfordcontrol/qdldl",
         # When changing the commit of QDLDL used by Drake, ideally try to keep
         # it aligned with what Drake's commit of OSQP desires, e.g.,
-        # https://github.com/oxfordcontrol/osqp/tree/v0.4.1/lin_sys/direct/qdldl
-        # shows that v0.4.1 of OSQP prefers v0.1.3 of QDLDL.
-        commit = "v0.1.3",
-        sha256 = "a2c3a7d0c6a48b2fab7400fa8ca72a34fb1e3a19964b281c73564178f97afe54",  # noqa
+        # https://github.com/oxfordcontrol/osqp/tree/v0.4.0/lin_sys/direct/qdldl
+        # shows that v0.4.0 of OSQP prefers v0.1.2 of QDLDL.
+        commit = "v0.1.2",
+        sha256 = "e059b02516a5314e2a1d69c9ede910ef3a532699c76d5455a53dbff8a97f1fe5",  # noqa
         build_file = "@drake//tools/workspace/qdldl:package.BUILD.bazel",
         mirrors = mirrors,
     )

--- a/tools/workspace/spdlog/repository.bzl
+++ b/tools/workspace/spdlog/repository.bzl
@@ -8,8 +8,8 @@ def spdlog_repository(
     github_archive(
         name = name,
         repository = "gabime/spdlog",
-        commit = "v1.2.1",
-        sha256 = "867a4b7cedf9805e6f76d3ca41889679054f7e5a3b67722fe6d0eae41852a767",  # noqa
+        commit = "v1.1.0",
+        sha256 = "3dbcbfd8c07e25f5e0d662b194d3a7772ef214358c49ada23c044c4747ce8b19",  # noqa
         build_file = "@drake//tools/workspace/spdlog:package.BUILD.bazel",
         mirrors = mirrors,
     )

--- a/tools/workspace/tinydir/repository.bzl
+++ b/tools/workspace/tinydir/repository.bzl
@@ -8,8 +8,8 @@ def tinydir_repository(
     github_archive(
         name = name,
         repository = "cxong/tinydir",
-        commit = "1.2.4",
-        sha256 = "9c50eda69ba4854bb76ffa18961f49fd75f323b4cbebdf6b4b2d2db28f9f5ce2",  # noqa
+        commit = "677733daa2859c963da953872f8d591251c2ae5e",
+        sha256 = "ac87282bf2a127df61fabe2eb2e4cbe2adb2050ecf3c4b9885ffddd4bf887125",  # noqa
         build_file = "@drake//tools/workspace/tinydir:package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
One of the externals in #9966 is causing `no space left on device` errors on the nightly-ubsan-everything build.  This PR is to try to narrow down the root cause.

This partially reverts commit 696a94e5d899ced5abe8613d4dfe53c798287923.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10006)
<!-- Reviewable:end -->
