### PR TITLE
Adds OutputPort::GetSourceOutputPort()

### DIFF
--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -240,6 +240,10 @@ void DefineFrameworkPySemantics(py::module m) {
         .def("size", &OutputPort<T>::size, doc.OutputPortBase.size.doc)
         .def("get_index", &OutputPort<T>::get_index,
              doc.OutputPortBase.get_index.doc)
+        .def("get_system", &OutputPort<T>::get_system,
+             doc.OutputPort.get_system.doc, py_reference_internal)
+        .def("GetSourceOutputPort", &OutputPort<T>::GetSourceOutputPort,
+             doc.OutputPort.GetSourceOutputPort.doc, py_reference_internal)
         .def("EvalAbstract", &OutputPort<T>::EvalAbstract,
              doc.OutputPort.EvalAbstract.doc, py_reference_internal)
         .def("Eval",

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -101,6 +101,13 @@ class TestGeneral(unittest.TestCase):
         # TODO(eric.cousineau): Consolidate the main API tests for `System`
         # to this test point.
 
+    def test_output_port_introspection(self):
+        system = Adder(1, 1)
+        output_port = system.GetOutputPort("sum")
+        self.assertEqual(output_port.get_index(), 0)
+        self.assertEqual(output_port.get_system(), system)
+        self.assertEqual(output_port.GetSourceOutputPort(), output_port)
+
     def test_context_api(self):
         system = Adder(3, 10)
         context = system.CreateDefaultContext()

--- a/systems/framework/diagram_output_port.h
+++ b/systems/framework/diagram_output_port.h
@@ -80,13 +80,6 @@ class DiagramOutputPort final : public OutputPort<T> {
 
   ~DiagramOutputPort() final = default;
 
-  /** Obtains a reference to the subsystem output port that was exported to
-  create this diagram port. Note that the source may itself be a diagram
-  output port. */
-  const OutputPort<T>& get_source_output_port() const {
-    return *source_output_port_;
-  }
-
  private:
   // Asks the source system output port to allocate an appropriate object.
   std::unique_ptr<AbstractValue> DoAllocate() const final {
@@ -113,6 +106,11 @@ class DiagramOutputPort final : public OutputPort<T> {
   internal::OutputPortPrerequisite DoGetPrerequisite() const final {
     return {source_subsystem_index_, source_output_port_->ticket()};
   };
+
+  // Find the lowest-level exported port.
+  const OutputPort<T>& DoGetSourceOutputPort() const final {
+    return source_output_port_->GetSourceOutputPort();
+  }
 
   // Digs out the right subcontext for delegation.
   const Context<T>& get_subcontext(const Context<T>& diagram_context) const {

--- a/systems/framework/leaf_output_port.h
+++ b/systems/framework/leaf_output_port.h
@@ -97,6 +97,9 @@ class LeafOutputPort final : public OutputPort<T> {
     return {nullopt, cache_entry().ticket()};
   };
 
+  // This port is the source.
+  const OutputPort<T>& DoGetSourceOutputPort() const final { return *this; }
+
   const CacheEntry* const cache_entry_;
 };
 

--- a/systems/framework/output_port.h
+++ b/systems/framework/output_port.h
@@ -135,9 +135,17 @@ class OutputPort : public OutputPortBase {
 
   /** Returns a reference to the System that owns this output port. Note that
   for a diagram output port this will be the diagram, not the leaf system whose
-  output port was forwarded. */
+  output port was exported. */
   const System<T>& get_system() const {
     return system_;
+  }
+
+  /** Returns a reference to the underlying output port that actually generates
+  the result seen on this output port. A LeafOutputPort will return itself while
+  a DiagramOutputPort will dig down recursively to find the LeafOutputPort that
+  has been exported (possibly through several levels of Diagram). */
+  const OutputPort<T>& GetSourceOutputPort() const {
+    return DoGetSourceOutputPort();
   }
 
  protected:
@@ -183,6 +191,11 @@ class OutputPort : public OutputPortBase {
   @param context A Context that has already been validated as compatible with
                  the System whose output port this is. */
   virtual const AbstractValue& DoEval(const Context<T>& context) const = 0;
+
+  /** A concrete %OutputPort must return the LeafOutputPort that is actually
+  generating the result for this %OutputPort. Diagrams should do this
+  recursively to find the port at the bottom. */
+  virtual const OutputPort<T>& DoGetSourceOutputPort() const = 0;
 
   /** This is useful for error messages and produces a human-readable
   identification of an offending output port. */


### PR DESCRIPTION
Adds a method to find the leaf output port providing the signal seen on a diagram output port, however many levels deep that may be. For discussion, see #9958.

For reviewers, what's here:
- adds the new method and implements it with overrides in Leaf/DiagramOutputPort
- adds Python binding for that method and missing get_system() method
- removed unused/untested/inaccesible/not-useful public method from DiagramOutputPort with similar name (not deprecating)
- unit tests in output_port_test.cc and general_test.py

Resolves #9958

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10009)
<!-- Reviewable:end -->
