### PR TITLE
meshcat: Minor tweaks from duplicate PR of #9982

### DIFF
--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -228,8 +228,13 @@ drake_py_library(
     srcs = ["meshcat_visualizer.py"],
     imports = PACKAGE_INFO.py_imports,
     deps = [
+        ":framework_py",
         ":module_py",
         ":rendering_py",
+        "//bindings/pydrake:geometry_py",
+        "//bindings/pydrake:lcm_py",
+        "//bindings/pydrake:math_py",
+        "//bindings/pydrake/util:eigen_geometry_py",
         "//lcmtypes:lcmtypes_py",
         "@meshcat_python//:meshcat",
         "@meshcat_python//:meshcat-server",

--- a/bindings/pydrake/systems/meshcat_visualizer.py
+++ b/bindings/pydrake/systems/meshcat_visualizer.py
@@ -6,6 +6,10 @@ package, Meshcat:
 import argparse
 import math
 
+import meshcat
+import meshcat.transformations as tf
+
+from drake import lcmt_viewer_load_robot
 from pydrake.util.eigen_geometry import Quaternion
 from pydrake.geometry import DispatchLoadMessage, SceneGraph
 from pydrake.lcm import DrakeMockLcm
@@ -14,11 +18,6 @@ from pydrake.systems.framework import (
     AbstractValue, LeafSystem, PublishEvent, TriggerType
 )
 from pydrake.systems.rendering import PoseBundle
-
-from drake import lcmt_viewer_load_robot
-
-import meshcat
-import meshcat.transformations as tf
 
 
 class MeshcatVisualizer(LeafSystem):

--- a/bindings/pydrake/systems/test/meshcat_visualizer_test.py
+++ b/bindings/pydrake/systems/test/meshcat_visualizer_test.py
@@ -1,8 +1,9 @@
-import numpy as np
 import unittest
 
+import numpy as np
+
 from pydrake.common import FindResourceOrThrow
-from pydrake.geometry import (DispatchLoadMessage, SceneGraph)
+from pydrake.geometry import SceneGraph
 from pydrake.multibody.multibody_tree import UniformGravityFieldElement
 from pydrake.multibody.multibody_tree.multibody_plant import MultibodyPlant
 from pydrake.multibody.multibody_tree.parsing import AddModelFromSdfFile
@@ -12,8 +13,8 @@ from pydrake.systems.meshcat_visualizer import MeshcatVisualizer
 
 
 class TestMeshcat(unittest.TestCase):
-    # Cart-Pole with simple geometry.
     def test_cart_pole(self):
+        """Cart-Pole with simple geometry."""
         file_name = FindResourceOrThrow(
             "drake/examples/multibody/cart_pole/cart_pole.sdf")
 
@@ -53,8 +54,8 @@ class TestMeshcat(unittest.TestCase):
         simulator.set_publish_every_time_step(False)
         simulator.StepTo(.1)
 
-    # Kuka IIWA with mesh geometry.
-    def test_kuka(args):
+    def test_kuka(self):
+        """Kuka IIWA with mesh geometry."""
         file_name = FindResourceOrThrow(
             "drake/manipulation/models/iiwa_description/sdf/"
             "iiwa14_no_collision.sdf")

--- a/examples/multibody/cart_pole/BUILD.bazel
+++ b/examples/multibody/cart_pole/BUILD.bazel
@@ -44,7 +44,7 @@ drake_cc_binary(
 
 drake_cc_googletest(
     name = "cart_pole_test",
-    data = ["cart_pole.sdf"],
+    data = [":models"],
     deps = [
         ":cart_pole_params",
         "//common:find_resource",


### PR DESCRIPTION
Simple follow-up from #9982 (basically changes picked from duplicate #10008)

This just cleans up the `deps`, a small typo in the Python test, and changes `cart_pole` to just use `:models`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10010)
<!-- Reviewable:end -->
