### PR TITLE
Adds StateInterpolatorWithDiscreteDerivative

### DIFF
--- a/systems/primitives/BUILD.bazel
+++ b/systems/primitives/BUILD.bazel
@@ -109,6 +109,8 @@ drake_cc_library(
     hdrs = ["discrete_derivative.h"],
     deps = [
         ":linear_system",
+        ":multiplexer",
+        ":pass_through",
         "//systems/framework",
     ],
 )


### PR DESCRIPTION
This is a very common use case for the DiscreteDerivative right now in the code.  My next PRs will have three uses of it.
Related to #9729.
Also switches the set method in DiscreteDerivative to put the context first, per our GSG exception.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10014)
<!-- Reviewable:end -->
