### PR TITLE
pydrake util: Ensure cc_library aliases have same visibility

### DIFF
--- a/bindings/pydrake/util/build_macros.bzl
+++ b/bindings/pydrake/util/build_macros.bzl
@@ -34,6 +34,7 @@ def util_cc_alias(name):
         declare_installed_headers = 0,
         tags = ["nolint"],
         deps = ["//bindings/pydrake/common:" + name],
+        visibility = ["//visibility:public"],
     )
 
 def util_py_alias(name):


### PR DESCRIPTION
Hotfix for #9416 that @jwnimmer-tri caught.

Shambhala CI will most likely break here without this fix:
https://github.com/RobotLocomotion/drake-shambhala/blob/62a69373adb9994e4621a1159be29489bce8db5e/drake_bazel_external/apps/simple_adder_py.cc#L41
(I plan to leave it in `shambhala` as `util` until we deprecate the header.)

\cc @jamiesnape

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10020)
<!-- Reviewable:end -->
