### PR TITLE
pydrake util: Simplify `alias_cc_test`. Remove ASan

### DIFF
--- a/bindings/pydrake/util/BUILD.bazel
+++ b/bindings/pydrake/util/BUILD.bazel
@@ -5,7 +5,7 @@ load("@drake//tools/install:install.bzl", "install")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load(
     "@drake//tools/skylark:drake_cc.bzl",
-    "drake_cc_googletest",
+    "drake_cc_test",
 )
 load(
     "@drake//tools/skylark:pybind.bzl",
@@ -89,8 +89,12 @@ install(
     py_dest = PACKAGE_INFO.py_dest,
 )
 
-drake_cc_googletest(
+drake_cc_test(
     name = "alias_cc_test",
+    # Using `drake_shared_library` can cause timeouts in debug mode (#10025).
+    timeout = "moderate",
+    # Using `drake_shared_library` can cause ASan ODR failures (#10025).
+    tags = ["no_asan"],
     deps = cc_alias_names,
 )
 

--- a/bindings/pydrake/util/test/alias_cc_test.cc
+++ b/bindings/pydrake/util/test/alias_cc_test.cc
@@ -1,5 +1,3 @@
-#include <gtest/gtest.h>
-
 // Ensure we can include files from their old path.
 #include "drake/bindings/pydrake/util/cpp_param_pybind.h"
 #include "drake/bindings/pydrake/util/cpp_template_pybind.h"
@@ -12,12 +10,8 @@
 #include "drake/bindings/pydrake/util/wrap_function.h"
 #include "drake/bindings/pydrake/util/wrap_pybind.h"
 
-namespace drake {
-namespace pydrake {
-namespace {
+// Brief symbol check.
+using drake::pydrake::GetPyParam;
 
-GTEST_TEST(AliasCcTest, Dummy) {}
-
-}  // namespace
-}  // namespace pydrake
-}  // namespace drake
+// No-op; compilation test only.
+int main() { return 0; }


### PR DESCRIPTION
Works around #10025

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10026)
<!-- Reviewable:end -->
