### PR TITLE
libdrake: Remove ODR violation for linking in `@osqp`

### DIFF
--- a/bindings/pydrake/util/BUILD.bazel
+++ b/bindings/pydrake/util/BUILD.bazel
@@ -91,10 +91,8 @@ install(
 
 drake_cc_test(
     name = "alias_cc_test",
-    # Using `drake_shared_library` can cause timeouts in debug mode (#10025).
+    # Using `drake_shared_library` can cause timeouts in debug mode.
     timeout = "moderate",
-    # Using `drake_shared_library` can cause ASan ODR failures (#10025).
-    tags = ["no_asan"],
     deps = cc_alias_names,
 )
 

--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -10,6 +10,7 @@ load(
 )
 load(
     "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_test",
     "drake_transitive_installed_hdrs_filegroup",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
@@ -165,7 +166,8 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":libdrake_headers_only_attic_cc_library",
-        # The list of depended-on *.so files.
+        # The list of depended-on *.so files. These should ONLY be shared
+        # libraries; do not add static dependencies here.
         ":gurobi_deps",
         ":mosek_deps",
         ":vtk_deps",
@@ -175,7 +177,6 @@ cc_library(
         "@ignition_rndf",
         "@lcm",
         "@libprotobuf",
-        "@osqp",
         "@scs//:scsdir",
         "@tinyxml2",
     ] + [
@@ -199,6 +200,13 @@ cc_library(
     hdrs = [":libdrake_headers_only_attic"],
     include_prefix = "drake",
     strip_include_prefix = "/attic",
+)
+
+drake_cc_test(
+    name = "drake_shared_library_test",
+    # Using `drake_shared_library` can cause timeouts in debug mode.
+    timeout = "moderate",
+    deps = [":drake_shared_library"],
 )
 
 add_lint_tests(

--- a/tools/install/libdrake/test/drake_shared_library_test.cc
+++ b/tools/install/libdrake/test/drake_shared_library_test.cc
@@ -1,0 +1,11 @@
+// This test is meant to consume `drake_shared_libary` only to test for things
+// such as ODR violations using ASan.
+
+// Trivial include.
+#include "drake/common/find_resource.h"
+
+// Trivial symbol test.
+using drake::FindResourceOrThrow;
+
+// No-op.
+int main() { return 0; }


### PR DESCRIPTION
Resolves #10025

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10027)
<!-- Reviewable:end -->
