### PR TITLE
Add RemoveGeometry API

### DIFF
--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -144,6 +144,10 @@ class GeometryState {
     return static_cast<int>(geometries_.size());
   }
 
+  /** Reports the number of frames registered to the given `source_id`. Returns
+   zero if the source is not valid.  */
+  int NumFramesForSource(SourceId source_id) const;
+
   /** Reports the total number of geometries directly registered to the given
    frame. This count does _not_ include geometries attached to frames that are
    descendants of this frame.
@@ -370,6 +374,19 @@ class GeometryState {
   GeometryId RegisterAnchoredGeometry(
       SourceId source_id,
       std::unique_ptr<GeometryInstance> geometry);
+
+  /** Removes the given geometry from the the indicated source's geometries. Any
+   geometry that was hung from the indicated geometry will _also_ be removed.
+   @param source_id     The identifier for the owner geometry source.
+   @param geometry_id   The identifier of the geometry to remove (can be dynamic
+                        or anchored).
+   @throws std::logic_error  1. If the `source_id` does _not_ map to a
+                             registered source, or
+                             2. the `geometry_id` does not map to a valid
+                             geometry, or
+                             3. the `geometry_id` maps to a geometry that does
+                             not belong to the indicated source. */
+  void RemoveGeometry(SourceId source_id, GeometryId geometry_id);
 
   /** Reports whether the canonicalized version of the given candidate geometry
    name is considered valid. This tests the requirements described in the
@@ -606,6 +623,29 @@ class GeometryState {
   // frame belongs to no registered source.
   SourceId get_source_id(FrameId frame_id) const;
 
+  // The origin from where an invocation of RemoveGeometryUnchecked was called.
+  // The origin changes the work that is required.
+  // TODO(SeanCurtis-TRI): Add `kFrame` when this can be invoked by removing
+  // a frame.
+  enum class RemoveGeometryOrigin {
+    kGeometry,   // Invoked by RemoveGeometry().
+    kRecurse     // Invoked by recursive call in RemoveGeometryUnchecked.
+  };
+
+  // Performs the work necessary to remove the identified geometry from
+  // the world. The amount of work depends on the context from which this
+  // method is invoked:
+  //
+  //  - RemoveGeometry(): A specific geometry (and its corresponding
+  //    hierarchy) is being removed. In addition to recursively removing all
+  //    child geometries, it must also remove this geometry id from its parent
+  //    frame and, if it exists, its parent geometry.
+  //   - RemoveGeometryUnchecked(): This is the recursive call; it's parent
+  //    is already slated for removal, so parent references can be left alone.
+  // @throws std::logic_error if `geometry_id` is not in `geometries_`.
+  void RemoveGeometryUnchecked(GeometryId geometry_id,
+                               RemoveGeometryOrigin caller);
+
   // Recursively updates the frame and geometry _pose_ information for the tree
   // rooted at the given frame, whose parent's pose in the world frame is given
   // as `X_WP`.
@@ -616,7 +656,7 @@ class GeometryState {
   // Reports true if the given id refers to a _dynamic_ geometry. Assumes the
   // precondition that id refers to a valid geometry in the state.
   bool is_dynamic(GeometryId id) const {
-    return geometries_.count(id) > 0;
+    return geometries_.at(id).is_dynamic();
   }
 
   // Convenience function for accessing geometry whether dynamic or anchored.
@@ -690,7 +730,8 @@ class GeometryState {
   // relative to its parent frame, P: X_PF.
   std::vector<Isometry3<T>> X_PF_;
 
-  // The pose of every _dynamic_ geometry relative to the _world_ frame.
+  // The pose of every _dynamic_ geometry relative to the _world_ frame. This is
+  // indexed by _ProximityIndex_ and _not_ GeometryIndex.
   // After a complete state update from input poses,
   //   X_WG_[i] == X_WFₙ · X_FₙFₙ₋₁ · ... · X_F₁F · G_i.X_FG()
   // Where F is the parent frame of geometry G_i, Fₖ₊₁ is the parent frame of

--- a/geometry/internal_frame.h
+++ b/geometry/internal_frame.h
@@ -140,6 +140,14 @@ class InternalFrame {
     child_geometries_.insert(geometry_id);
   }
 
+  /** Removes the given `geometry_id` from the set of geometries that this frame
+   considers to be children.
+   @pre the id _is_ a valid child of this frame.  */
+  void remove_child(GeometryId geometry_id) {
+    DRAKE_ASSERT(child_geometries_.count(geometry_id) > 0);
+    child_geometries_.erase(geometry_id);
+  }
+
   /** The identifier used for identifying the single world frame in all
    instances of SceneGraph. The world frame will eventually have an arbitrary
    number of child frames and geometries; but there will always only be one

--- a/geometry/internal_geometry.h
+++ b/geometry/internal_geometry.h
@@ -78,6 +78,10 @@ class InternalGeometry {
   /** Returns the index of this geometry in the full scene graph.  */
   GeometryIndex index() const { return index_; }
 
+  /** Sets the internal geometry's index -- facilitates removing geometries from
+   the scene graph.  */
+  void set_index(GeometryIndex index) { index_ = index; }
+
   /** Returns the source id that registered the geometry.  */
   SourceId source_id() const { return source_id_; }
 
@@ -150,6 +154,14 @@ class InternalGeometry {
    children.  */
   void add_child(GeometryId geometry_id) {
     child_geometry_ids_.insert(geometry_id);
+  }
+
+  /** Removes the given `geometry_id` from the set of geometries that this frame
+   considers to be children. If the id is not in the set of children, nothing
+   happens.  */
+  void remove_child(GeometryId geometry_id) {
+    DRAKE_ASSERT(child_geometry_ids_.count(geometry_id) > 0);
+    child_geometry_ids_.erase(geometry_id);
   }
 
   /** Returns true if the geometry is *not* attached to the world frame -- or,

--- a/geometry/proximity_engine.h
+++ b/geometry/proximity_engine.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "drake/common/autodiff.h"
+#include "drake/common/drake_optional.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/geometry_index.h"
 #include "drake/geometry/query_results/penetration_as_point_pair.h"
@@ -92,6 +93,25 @@ class ProximityEngine {
                                      const Isometry3<double>& X_WG,
                                      GeometryIndex index);
 
+  /** Informs the proximity engine that the geometry at `proximity_index` has
+   moved in the GeometryState storage (i.e., it's GeometryIndex has changed).
+   @param proximity_index   The index of the geometry.
+   @param is_dynamic        True if the geometry is dynamic (false if anchored).
+   @param geometry_index    The new _GeometryIndex_ for the geometry.  */
+  void UpdateGeometryIndex(ProximityIndex proximity_index, bool is_dynamic,
+                           GeometryIndex geometry_index);
+
+  /** Removes the given geometry indicated by `index` from the engine. Returns
+   the index of the geometry that was moved into this newly cleared index
+   position to maintain contiguous indices.
+   @param index       The proximity index of the geometry to be removed.
+   @param is_dynamic  True if the geometry is dynamic, false if anchored.
+   @returns The GeometryIndex of the geometry that was moved into this index
+            or nullopt if no geometry was moved.
+   @pre the index is valid value.
+  */
+  optional<GeometryIndex> RemoveGeometry(ProximityIndex index, bool is_dynamic);
+
   /** Reports the _total_ number of geometries in the engine -- dynamic and
    anchored (spanning all sources).  */
   int num_geometries() const;
@@ -103,11 +123,10 @@ class ProximityEngine {
   int num_anchored() const;
 
   /** The distance (signed/unsigned/penetration distance) is generally computed
-   * from an iterative process. The distance_tolerance determines when the
-   * iterative process will terminate.
-   * As a rule of rule of thumb, one can generally assume that the answer will
-   * be within 10 * tol to the true answer.
-   */
+   from an iterative process. The distance_tolerance determines when the
+   iterative process will terminate.
+   As a rule of rule of thumb, one can generally assume that the answer will
+   be within 10 * tol to the true answer.  */
   void set_distance_tolerance(double tol);
 
   double distance_tolerance() const;
@@ -253,6 +272,12 @@ class ProximityEngine {
 
   // Reveals what the next generated clique will be (without changing it).
   int peek_next_clique() const;
+
+  // Reports the pose (X_WG) of the geometry at the given index.
+  const Isometry3<double>& GetX_WG(ProximityIndex index, bool is_dynamic) const;
+
+  // Reports the GeometryIndex for the geometry at the given index.
+  GeometryIndex GetGeometryIndex(ProximityIndex index, bool is_dynamic) const;
 
   ////////////////////////////////////////////////////////////////////////////
 

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -190,6 +190,12 @@ GeometryId SceneGraph<T>::RegisterAnchoredGeometry(
 }
 
 template <typename T>
+void SceneGraph<T>::RemoveGeometry(SourceId source_id, GeometryId geometry_id) {
+  GS_THROW_IF_CONTEXT_ALLOCATED
+  initial_state_->RemoveGeometry(source_id, geometry_id);
+}
+
+template <typename T>
 const SceneGraphInspector<T>& SceneGraph<T>::model_inspector() const {
   GS_THROW_IF_CONTEXT_ALLOCATED
   return model_inspector_;

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -376,6 +376,18 @@ class SceneGraph final : public systems::LeafSystem<T> {
   GeometryId RegisterAnchoredGeometry(
       SourceId source_id, std::unique_ptr<GeometryInstance> geometry);
 
+  /** Removes the given geometry G (indicated by `geometry_id`) from the given
+   source's registered geometries. All registered geometries hanging from
+   this geometry will also be removed.
+   @param source_id   The identifier for the owner geometry source.
+   @param geometry_id The identifier of the geometry to remove.
+   @throws std::logic_error If:
+                            1. The `source_id` is not a registered source,
+                            2. the `geometry_id` doesn't belong to the source,
+                               or
+                            3. a context has been allocated. */
+  void RemoveGeometry(SourceId source_id, GeometryId geometry_id);
+
   //@}
 
   /** Reports the identifier for the world frame.  */


### PR DESCRIPTION
1. Geometry sources can remove a geometry via the SceneGraph -- it modifies the underlying model.
2. This is implemented by GeometryState and ProximityEngine.
3. Small modifications to InternalFrame and InternalGeometry support removing geometries.
4. Appropriate tests.

Relates to #9909 

cc: @siyuanfeng-tri (I suspect you don't want to go anywhere near feature reviewing this, but I wanted to at least let you see the progress in the `SceneGraph` API.)

```
Category            added  modified  removed  
----------------------------------------------
code                399    4         0        
comments            158    2         0        
blank               70     0         0        
----------------------------------------------
TOTAL               627    6         0 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10029)
<!-- Reviewable:end -->
