### PR TITLE
mkdoc: Use arity to disambiguate overloads

### DIFF
--- a/bindings/pydrake/automotive_py.cc
+++ b/bindings/pydrake/automotive_py.cc
@@ -50,12 +50,12 @@ PYBIND11_MODULE(automotive, m) {
              doc.ScanStrategy.kBranches.doc);
 
   py::class_<ClosestPose<T>>(m, "ClosestPose", doc.ClosestPose.doc)
-      .def(py::init<>(), doc.ClosestPose.ctor.doc)
+      .def(py::init<>(), doc.ClosestPose.ctor.doc_0args)
       .def(py::init<const RoadOdometry<T>&, const T&>(), py::arg("odom"),
            py::arg("dist"),
            // Keep alive, transitive: `self` keeps `RoadOdometry` pointer
            // members alive.
-           py::keep_alive<1, 2>(), doc.ClosestPose.ctor.doc_2)
+           py::keep_alive<1, 2>(), doc.ClosestPose.ctor.doc_2args)
       .def_readwrite("odometry", &ClosestPose<T>::odometry,
                      py_reference_internal, doc.ClosestPose.odometry.doc)
       .def_readwrite("distance", &ClosestPose<T>::distance,
@@ -64,19 +64,19 @@ PYBIND11_MODULE(automotive, m) {
   py::class_<RoadOdometry<T>> road_odometry(m, "RoadOdometry",
                                             doc.RoadOdometry.doc);
   road_odometry  // BR
-      .def(py::init<>(), doc.RoadOdometry.ctor.doc)
+      .def(py::init<>(), doc.RoadOdometry.ctor.doc_0args)
       .def(py::init<const maliput::api::RoadPosition&,
                     const systems::rendering::FrameVelocity<T>&>(),
            py::arg("road_position"), py::arg("frame_velocity"),
            // Keep alive, transitive: `self` keeps `RoadPosition` pointer
            // members alive.
-           py::keep_alive<1, 2>(), doc.RoadOdometry.ctor.doc_2)
+           py::keep_alive<1, 2>(), doc.RoadOdometry.ctor.doc_2args)
       .def(py::init<const maliput::api::Lane*,
                     const maliput::api::LanePositionT<T>&,
                     const systems::rendering::FrameVelocity<T>&>(),
            py::arg("lane"), py::arg("lane_position"), py::arg("frame_velocity"),
            // Keep alive, reference: `self` keeps `Lane*` alive.
-           py::keep_alive<1, 2>(), doc.RoadOdometry.ctor.doc_3)
+           py::keep_alive<1, 2>(), doc.RoadOdometry.ctor.doc_3args)
       .def_readwrite("pos", &RoadOdometry<T>::pos, doc.RoadOdometry.pos.doc)
       .def_readwrite("vel", &RoadOdometry<T>::vel, doc.RoadOdometry.vel.doc);
   // TODO(m-chaturvedi) Add Pybind11 documentation.
@@ -84,7 +84,7 @@ PYBIND11_MODULE(automotive, m) {
 
   py::class_<LaneDirection>(m, "LaneDirection", doc.LaneDirection.doc)
       .def(py::init<const maliput::api::Lane*, bool>(), py::arg("lane"),
-           py::arg("with_s"), doc.LaneDirection.ctor.doc_5)
+           py::arg("with_s"), doc.LaneDirection.ctor.doc_2args)
       .def_readwrite("lane", &LaneDirection::lane, py_reference_internal,
                      doc.LaneDirection.lane.doc)
       .def_readwrite("with_s", &LaneDirection::with_s,
@@ -94,7 +94,7 @@ PYBIND11_MODULE(automotive, m) {
   // TODO(eric.cousineau) Bind this named vector automatically (see #8096).
   py::class_<DrivingCommand<T>, BasicVector<T>>(m, "DrivingCommand",
                                                 doc.DrivingCommand.doc)
-      .def(py::init<>(), doc.DrivingCommand.ctor.doc)
+      .def(py::init<>(), doc.DrivingCommand.ctor.doc_0args)
       .def("steering_angle", &DrivingCommand<T>::steering_angle,
            doc.DrivingCommand.steering_angle.doc)
       .def("acceleration", &DrivingCommand<T>::acceleration,
@@ -110,7 +110,7 @@ PYBIND11_MODULE(automotive, m) {
                     RoadPositionStrategy, double>(),
            py::arg("road"), py::arg("path_or_branches"),
            py::arg("road_position_strategy"), py::arg("period_sec"),
-           doc.IdmController.ctor.doc_3)
+           doc.IdmController.ctor.doc_4args)
       .def("ego_pose_input", &IdmController<T>::ego_pose_input,
            py_reference_internal, doc.IdmController.ego_pose_input.doc)
       .def("ego_velocity_input", &IdmController<T>::ego_velocity_input,
@@ -165,7 +165,7 @@ PYBIND11_MODULE(automotive, m) {
   // TODO(eric.cousineau) Bind this named vector automatically (see #8096).
   py::class_<SimpleCarState<T>, BasicVector<T>>(m, "SimpleCarState",
                                                 doc.SimpleCarState.doc)
-      .def(py::init<>(), doc.SimpleCarState.ctor.doc)
+      .def(py::init<>(), doc.SimpleCarState.ctor.doc_0args)
       .def("x", &SimpleCarState<T>::x, doc.SimpleCarState.x.doc)
       .def("y", &SimpleCarState<T>::y, doc.SimpleCarState.y.doc)
       .def("heading", &SimpleCarState<T>::heading,

--- a/bindings/pydrake/examples/acrobot_py.cc
+++ b/bindings/pydrake/examples/acrobot_py.cc
@@ -46,13 +46,13 @@ PYBIND11_MODULE(acrobot, m) {
   // TODO(russt): Remove custom bindings once #8096 is resolved.
   py::class_<AcrobotInput<T>, BasicVector<T>>(m, "AcrobotInput",
                                               doc.AcrobotInput.doc)
-      .def(py::init<>(), doc.AcrobotInput.ctor.doc)
+      .def(py::init<>(), doc.AcrobotInput.ctor.doc_0args)
       .def("tau", &AcrobotInput<T>::tau, doc.AcrobotInput.tau.doc)
       .def("set_tau", &AcrobotInput<T>::set_tau, doc.AcrobotInput.set_tau.doc);
 
   py::class_<AcrobotParams<T>, BasicVector<T>>(m, "AcrobotParams",
                                                doc.AcrobotParams.doc)
-      .def(py::init<>(), doc.AcrobotParams.ctor.doc)
+      .def(py::init<>(), doc.AcrobotParams.ctor.doc_0args)
       .def("m1", &AcrobotParams<T>::m1, doc.AcrobotParams.m1.doc)
       .def("m2", &AcrobotParams<T>::m2, doc.AcrobotParams.m2.doc)
       .def("l1", &AcrobotParams<T>::l1, doc.AcrobotParams.l1.doc)
@@ -77,7 +77,7 @@ PYBIND11_MODULE(acrobot, m) {
 
   py::class_<AcrobotState<T>, BasicVector<T>>(m, "AcrobotState",
                                               doc.AcrobotState.doc)
-      .def(py::init<>(), doc.AcrobotState.ctor.doc)
+      .def(py::init<>(), doc.AcrobotState.ctor.doc_0args)
       .def("theta1", &AcrobotState<T>::theta1, doc.AcrobotState.theta1.doc)
       .def("theta1dot", &AcrobotState<T>::theta1dot,
            doc.AcrobotState.theta1dot.doc)

--- a/bindings/pydrake/examples/compass_gait_py.cc
+++ b/bindings/pydrake/examples/compass_gait_py.cc
@@ -33,7 +33,7 @@ PYBIND11_MODULE(compass_gait, m) {
   // TODO(russt): Remove custom bindings once #8096 is resolved.
   py::class_<CompassGaitParams<T>, BasicVector<T>>(m, "CompassGaitParams",
                                                    doc.CompassGaitParams.doc)
-      .def(py::init<>(), doc.CompassGaitParams.ctor.doc)
+      .def(py::init<>(), doc.CompassGaitParams.ctor.doc_0args)
       .def("mass_hip", &CompassGaitParams<T>::mass_hip,
            doc.CompassGaitParams.mass_hip.doc)
       .def("mass_leg", &CompassGaitParams<T>::mass_leg,
@@ -62,7 +62,7 @@ PYBIND11_MODULE(compass_gait, m) {
 
   py::class_<CompassGaitContinuousState<T>, BasicVector<T>>(
       m, "CompassGaitContinuousState", doc.CompassGaitContinuousState.doc)
-      .def(py::init<>(), doc.CompassGaitContinuousState.ctor.doc)
+      .def(py::init<>(), doc.CompassGaitContinuousState.ctor.doc_0args)
       .def("stance", &CompassGaitContinuousState<T>::stance,
            doc.CompassGaitContinuousState.stance.doc)
       .def("swing", &CompassGaitContinuousState<T>::swing,

--- a/bindings/pydrake/examples/manipulation_station_py.cc
+++ b/bindings/pydrake/examples/manipulation_station_py.cc
@@ -38,7 +38,7 @@ PYBIND11_MODULE(manipulation_station, m) {
   py::class_<ManipulationStation<T>, Diagram<T>>(m, "ManipulationStation")
       .def(py::init<double, IiwaCollisionModel>(), py::arg("time_step") = 0.002,
            py::arg("collision_model") = IiwaCollisionModel::kNoCollision,
-           doc.ManipulationStation.ctor.doc_3)
+           doc.ManipulationStation.ctor.doc_2args)
       .def("AddCupboard", &ManipulationStation<T>::AddCupboard,
            doc.ManipulationStation.AddCupboard.doc)
       .def("Finalize", &ManipulationStation<T>::Finalize,
@@ -82,7 +82,7 @@ PYBIND11_MODULE(manipulation_station, m) {
       m, "ManipulationStationHardwareInterface")
       .def(py::init<const std::vector<std::string>>(),
            py::arg("camera_ids") = std::vector<std::string>{},
-           doc.ManipulationStationHardwareInterface.ctor.doc_3)
+           doc.ManipulationStationHardwareInterface.ctor.doc_1args)
       .def("Connect", &ManipulationStationHardwareInterface::Connect,
            py::arg("wait_for_cameras") = true,
            doc.ManipulationStationHardwareInterface.Connect.doc)

--- a/bindings/pydrake/examples/pendulum_py.cc
+++ b/bindings/pydrake/examples/pendulum_py.cc
@@ -38,14 +38,14 @@ PYBIND11_MODULE(pendulum, m) {
   // TODO(russt): Remove custom bindings once #8096 is resolved.
   py::class_<PendulumInput<T>, BasicVector<T>>(m, "PendulumInput",
                                                doc.PendulumInput.doc)
-      .def(py::init<>(), doc.PendulumInput.ctor.doc)
+      .def(py::init<>(), doc.PendulumInput.ctor.doc_0args)
       .def("tau", &PendulumInput<T>::tau, doc.PendulumInput.tau.doc)
       .def("set_tau", &PendulumInput<T>::set_tau,
            doc.PendulumInput.set_tau.doc);
 
   py::class_<PendulumParams<T>, BasicVector<T>>(m, "PendulumParams",
                                                 doc.PendulumParams.doc)
-      .def(py::init<>(), doc.PendulumParams.ctor.doc)
+      .def(py::init<>(), doc.PendulumParams.ctor.doc_0args)
       .def("mass", &PendulumParams<T>::mass, doc.PendulumParams.mass.doc)
       .def("length", &PendulumParams<T>::length, doc.PendulumParams.length.doc)
       .def("damping", &PendulumParams<T>::damping,
@@ -63,7 +63,7 @@ PYBIND11_MODULE(pendulum, m) {
 
   py::class_<PendulumState<T>, BasicVector<T>>(m, "PendulumState",
                                                doc.PendulumState.doc)
-      .def(py::init<>(), doc.PendulumState.ctor.doc)
+      .def(py::init<>(), doc.PendulumState.ctor.doc_0args)
       .def("theta", &PendulumState<T>::theta, doc.PendulumState.theta.doc)
       .def("thetadot", &PendulumState<T>::thetadot,
            doc.PendulumState.thetadot.doc)

--- a/bindings/pydrake/examples/rimless_wheel_py.cc
+++ b/bindings/pydrake/examples/rimless_wheel_py.cc
@@ -33,7 +33,7 @@ PYBIND11_MODULE(rimless_wheel, m) {
   // TODO(russt): Remove custom bindings once #8096 is resolved.
   py::class_<RimlessWheelParams<T>, BasicVector<T>>(m, "RimlessWheelParams",
                                                     doc.RimlessWheelParams.doc)
-      .def(py::init<>(), doc.RimlessWheelParams.ctor.doc)
+      .def(py::init<>(), doc.RimlessWheelParams.ctor.doc_0args)
       .def("mass", &RimlessWheelParams<T>::mass,
            doc.RimlessWheelParams.mass.doc)
       .def("length", &RimlessWheelParams<T>::length,
@@ -57,7 +57,7 @@ PYBIND11_MODULE(rimless_wheel, m) {
 
   py::class_<RimlessWheelContinuousState<T>, BasicVector<T>>(
       m, "RimlessWheelContinuousState", doc.RimlessWheelContinuousState.doc)
-      .def(py::init<>(), doc.RimlessWheelContinuousState.ctor.doc)
+      .def(py::init<>(), doc.RimlessWheelContinuousState.ctor.doc_0args)
       .def("theta", &RimlessWheelContinuousState<T>::theta,
            doc.RimlessWheelContinuousState.theta.doc)
       .def("thetadot", &RimlessWheelContinuousState<T>::thetadot,

--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -34,7 +34,7 @@ void BindIdentifier(py::module m, const std::string& name) {
                      .format(cls_handle));
              return Class{};
            }),
-           cls_doc.ctor.doc_3)
+           cls_doc.ctor.doc_0args)
       .def("get_value", &Class::get_value, cls_doc.get_value.doc)
       .def("is_valid", &Class::is_valid, cls_doc.is_valid.doc)
       .def(py::self == py::self)
@@ -90,7 +90,7 @@ PYBIND11_MODULE(geometry, m) {
         // Keep alive, ownership: `return` keeps `builder` alive.
         py::keep_alive<0, 1>(),
         // TODO(eric.cousineau): Figure out why this is necessary (#9398).
-        py_reference, doc.ConnectDrakeVisualizer.doc);
+        py_reference, doc.ConnectDrakeVisualizer.doc_3args);
   m.def("ConnectDrakeVisualizer",
         py::overload_cast<
             systems::DiagramBuilder<double>*, const SceneGraph<double>&,
@@ -101,13 +101,13 @@ PYBIND11_MODULE(geometry, m) {
         // Keep alive, ownership: `return` keeps `builder` alive.
         py::keep_alive<0, 1>(),
         // TODO(eric.cousineau): Figure out why this is necessary (#9398).
-        py_reference, doc.ConnectDrakeVisualizer.doc);
+        py_reference, doc.ConnectDrakeVisualizer.doc_4args);
   m.def("DispatchLoadMessage", &DispatchLoadMessage, py::arg("scene_graph"),
         py::arg("lcm"), doc.DispatchLoadMessage.doc);
 
   // PenetrationAsPointPair
   py::class_<PenetrationAsPointPair<T>>(m, "PenetrationAsPointPair")
-      .def(py::init<>(), doc.PenetrationAsPointPair.ctor.doc_3)
+      .def(py::init<>(), doc.PenetrationAsPointPair.ctor.doc_0args)
       .def_readwrite("id_A", &PenetrationAsPointPair<T>::id_A,
                      doc.PenetrationAsPointPair.id_A.doc)
       .def_readwrite("id_B", &PenetrationAsPointPair<T>::id_B,

--- a/bindings/pydrake/lcm_py.cc
+++ b/bindings/pydrake/lcm_py.cc
@@ -45,7 +45,7 @@ PYBIND11_MODULE(lcm, m) {
   {
     using Class = DrakeLcm;
     py::class_<Class, DrakeLcmInterface>(m, "DrakeLcm", doc.DrakeLcm.doc)
-        .def(py::init<>(), doc.DrakeLcm.ctor.doc_3)
+        .def(py::init<>(), doc.DrakeLcm.ctor.doc_0args)
         .def("StartReceiveThread", &Class::StartReceiveThread,
              doc.DrakeLcm.StartReceiveThread.doc)
         .def("StopReceiveThread", &Class::StopReceiveThread,
@@ -57,7 +57,7 @@ PYBIND11_MODULE(lcm, m) {
     using Class = DrakeMockLcm;
     py::class_<Class, DrakeLcmInterface>(m, "DrakeMockLcm",
                                          doc.DrakeMockLcm.doc)
-        .def(py::init<>(), doc.DrakeMockLcm.ctor.doc_3)
+        .def(py::init<>(), doc.DrakeMockLcm.ctor.doc_0args)
         .def("Subscribe",
              [](Class* self, const std::string& channel,
                 PyHandlerFunction handler) {

--- a/bindings/pydrake/maliput/api_py.cc
+++ b/bindings/pydrake/maliput/api_py.cc
@@ -26,29 +26,29 @@ PYBIND11_MODULE(api, m) {
 
   // TODO(m-chaturvedi) Add doc when typedefs are parsed (#9599)
   py::class_<RoadGeometryId>(m, "RoadGeometryId")
-      .def(py::init<std::string>(), doc.RoadGeometry.ctor.doc_3)
+      .def(py::init<std::string>(), doc.RoadGeometry.ctor.doc_0args)
       .def("string", &RoadGeometryId::string, py_reference_internal);
 
   py::class_<GeoPosition>(m, "GeoPosition", doc.GeoPositionT.doc)
       .def(py::init<double, double, double>(), py::arg("x"), py::arg("y"),
-           py::arg("z"), doc.GeoPositionT.ctor.doc_4)
+           py::arg("z"), doc.GeoPositionT.ctor.doc_3args)
       .def("xyz", &GeoPosition::xyz, py_reference_internal,
            doc.GeoPositionT.xyz.doc);
 
   py::class_<LanePosition>(m, "LanePosition", doc.LanePositionT.doc)
       .def(py::init<double, double, double>(), py::arg("s"), py::arg("r"),
-           py::arg("h"), doc.LanePositionT.ctor.doc_4)
+           py::arg("h"), doc.LanePositionT.ctor.doc_3args)
       .def("srh", &LanePosition::srh, py_reference_internal,
            doc.LanePositionT.srh.doc);
 
   py::class_<RoadPosition> road_position(m, "RoadPosition",
                                          doc.RoadPosition.doc);
   road_position  // BR
-      .def(py::init<>(), doc.RoadPosition.ctor.doc)
+      .def(py::init<>(), doc.RoadPosition.ctor.doc_0args)
       .def(py::init<const Lane*, const LanePosition&>(), py::arg("lane"),
            py::arg("pos"),
            // Keep alive, reference: `self` keeps `Lane*` alive.
-           py::keep_alive<1, 2>(), doc.RoadPosition.ctor.doc_2)
+           py::keep_alive<1, 2>(), doc.RoadPosition.ctor.doc_2args)
       .def_readwrite("pos", &RoadPosition::pos, doc.RoadPosition.pos.doc);
   // TODO(m-chaturvedi) Add doc when typedefs are parsed (#9599)
   DefReadWriteKeepAlive(&road_position, "lane", &RoadPosition::lane);

--- a/bindings/pydrake/maliput/dragway_py.cc
+++ b/bindings/pydrake/maliput/dragway_py.cc
@@ -33,7 +33,7 @@ PYBIND11_MODULE(dragway, m) {
         py::arg("road_id"), py::arg("num_lanes"), py::arg("length"),
         py::arg("lane_width"), py::arg("shoulder_width"),
         py::arg("maximum_height"), py::arg("linear_tolerance"),
-        py::arg("angular_tolerance"), doc.dragway.RoadGeometry.ctor.doc_3);
+        py::arg("angular_tolerance"), doc.dragway.RoadGeometry.ctor.doc_8args);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/manipulation/planner_py.cc
+++ b/bindings/pydrake/manipulation/planner_py.cc
@@ -54,7 +54,7 @@ PYBIND11_MODULE(planner, m) {
               return Class{num_positions, num_velocities};
             }),
             py::arg("num_positions") = 0, py::arg("num_velocities") = 0,
-            class_doc.ctor.doc)
+            class_doc.ctor.doc_2args)
         .def("get_timestep", &Class::get_timestep, class_doc.get_timestep.doc)
         .def("set_timestep", &Class::set_timestep, class_doc.set_timestep.doc)
         .def("get_num_positions", &Class::get_num_positions,

--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -35,7 +35,7 @@ PYBIND11_MODULE(math, m) {
 
   py::class_<BarycentricMesh<T>>(m, "BarycentricMesh", doc.BarycentricMesh.doc)
       .def(py::init<BarycentricMesh<T>::MeshGrid>(),
-           doc.BarycentricMesh.ctor.doc_3)
+           doc.BarycentricMesh.ctor.doc_1args)
       .def("get_input_grid", &BarycentricMesh<T>::get_input_grid,
            doc.BarycentricMesh.get_input_grid.doc)
       .def("get_input_size", &BarycentricMesh<T>::get_input_size,
@@ -47,7 +47,7 @@ PYBIND11_MODULE(math, m) {
       .def("get_mesh_point",
            overload_cast_explicit<VectorX<T>, int>(
                &BarycentricMesh<T>::get_mesh_point),
-           doc.BarycentricMesh.get_mesh_point.doc)
+           doc.BarycentricMesh.get_mesh_point.doc_1args)
       .def("get_all_mesh_points", &BarycentricMesh<T>::get_all_mesh_points,
            doc.BarycentricMesh.get_all_mesh_points.doc)
       .def("EvalBarycentricWeights",
@@ -65,7 +65,7 @@ PYBIND11_MODULE(math, m) {
                                   const Eigen::Ref<const MatrixX<T>>&,
                                   const Eigen::Ref<const VectorX<T>>&>(
                &BarycentricMesh<T>::Eval),
-           doc.BarycentricMesh.Eval.doc)
+           doc.BarycentricMesh.Eval.doc_2args)
       .def("MeshValuesFrom", &BarycentricMesh<T>::MeshValuesFrom,
            doc.BarycentricMesh.MeshValuesFrom.doc);
 
@@ -167,7 +167,7 @@ PYBIND11_MODULE(math, m) {
       .def("ToQuaternion",
            overload_cast_explicit<Eigen::Quaternion<T>>(
                &RotationMatrix<T>::ToQuaternion),
-           doc.RotationMatrix.ToQuaternion.doc)
+           doc.RotationMatrix.ToQuaternion.doc_0args)
       .def_static("Identity", &RotationMatrix<T>::Identity,
                   doc.RotationMatrix.Identity.doc);
 

--- a/bindings/pydrake/multibody/benchmarks_py.cc
+++ b/bindings/pydrake/multibody/benchmarks_py.cc
@@ -25,7 +25,7 @@ void init_acrobot(py::module m) {
 
   py::class_<AcrobotParameters>(m, "AcrobotParameters",
                                 doc.AcrobotParameters.doc)
-      .def(py::init(), doc.AcrobotParameters.ctor.doc);
+      .def(py::init(), doc.AcrobotParameters.doc);
 
   m.def("MakeAcrobotPlant",
         py::overload_cast<const AcrobotParameters&, bool, SceneGraph<double>*>(

--- a/bindings/pydrake/multibody/multibody_tree_py.cc
+++ b/bindings/pydrake/multibody/multibody_tree_py.cc
@@ -181,7 +181,7 @@ void init_module(py::module m) {
                       const Vector3<T>&, double>(),
              py::arg("name"), py::arg("frame_on_parent"),
              py::arg("frame_on_child"), py::arg("axis"), py::arg("damping") = 0,
-             doc.RevoluteJoint.ctor.doc_4)
+             doc.RevoluteJoint.ctor.doc_5args)
         .def("get_angle", &Class::get_angle, py::arg("context"),
              doc.RevoluteJoint.get_angle.doc)
         .def("set_angle", &Class::set_angle, py::arg("context"),
@@ -196,7 +196,7 @@ void init_module(py::module m) {
                       const Isometry3<double>&>(),
              py::arg("name"), py::arg("parent_frame_P"),
              py::arg("child_frame_C"), py::arg("X_PC"),
-             doc.WeldJoint.ctor.doc_3);
+             doc.WeldJoint.ctor.doc_4args);
   }
 
   // Actuators.
@@ -222,7 +222,7 @@ void init_module(py::module m) {
     py::class_<Class, ForceElement<T>>(m, "UniformGravityFieldElement",
                                        doc.UniformGravityFieldElement.doc)
         .def(py::init<Vector3<double>>(), py::arg("g_W"),
-             doc.UniformGravityFieldElement.ctor.doc);
+             doc.UniformGravityFieldElement.ctor.doc_1args);
   }
 
   // MultibodyForces
@@ -231,7 +231,7 @@ void init_module(py::module m) {
     py::class_<Class> cls(m, "MultibodyForces", doc.MultibodyForces.doc);
     cls  // BR
         .def(py::init<MultibodyTree<double>&>(), py::arg("model"),
-             doc.MultibodyForces.ctor.doc);
+             doc.MultibodyForces.ctor.doc_1args);
   }
 
   // Tree.
@@ -268,7 +268,7 @@ void init_module(py::module m) {
              py_reference,
              // Keep alive, ownership: `return` keeps `Context` alive.
              py::keep_alive<0, 2>(), py::arg("context"),
-             doc.MultibodyTree.GetPositionsAndVelocities.doc)
+             doc.MultibodyTree.GetPositionsAndVelocities.doc_1args)
         .def("GetMutablePositionsAndVelocities",
              [](const MultibodyTree<T>* self,
                 Context<T>* context) -> Eigen::Ref<VectorX<T>> {
@@ -308,13 +308,13 @@ void init_module(py::module m) {
                  &Class::CalcInverseDynamics),
              py::arg("context"), py::arg("known_vdot"),
              py::arg("external_forces"),
-             doc.MultibodyTree.CalcInverseDynamics.doc)
+             doc.MultibodyTree.CalcInverseDynamics.doc_3args)
         .def("SetFreeBodyPoseOrThrow",
              overload_cast_explicit<void, const Body<T>&, const Isometry3<T>&,
                                     systems::Context<T>*>(
                  &Class::SetFreeBodyPoseOrThrow),
              py::arg("body"), py::arg("X_WB"), py::arg("context"),
-             doc.MultibodyTree.SetFreeBodyPoseOrThrow.doc)
+             doc.MultibodyTree.SetFreeBodyPoseOrThrow.doc_3args)
         .def("GetPositionsFromArray", &Class::GetPositionsFromArray,
              py::arg("model_instance"), py::arg("q_array"),
              doc.MultibodyTree.get_positions_from_array.doc)
@@ -327,7 +327,7 @@ void init_module(py::module m) {
                self->SetFreeBodySpatialVelocityOrThrow(body, V_WB, context);
              },
              py::arg("body"), py::arg("V_WB"), py::arg("context"),
-             doc.MultibodyTree.SetFreeBodySpatialVelocityOrThrow.doc)
+             doc.MultibodyTree.SetFreeBodySpatialVelocityOrThrow.doc_3args)
         .def("CalcAllBodySpatialVelocitiesInWorld",
              [](const Class* self, const Context<T>& context) {
                std::vector<SpatialVelocity<T>> V_WB;
@@ -386,7 +386,7 @@ void init_module(py::module m) {
             py_reference,
             // Keep alive, ownership: `return` keeps `Context` alive.
             py::keep_alive<0, 2>(), py::arg("context"),
-            doc.MultibodyTree.get_multibody_state_vector.doc);
+            doc.MultibodyTree.get_multibody_state_vector.doc_1args);
     cls.def("get_mutable_multibody_state_vector",
             [](const MultibodyTree<T>* self,
                Context<T>* context) -> Eigen::Ref<VectorX<T>> {
@@ -428,7 +428,7 @@ void init_math(py::module m) {
 
   py::class_<SpatialVelocity<T>, SpatialVector<SpatialVelocity, T>>(
       m, "SpatialVelocity")
-      .def(py::init(), doc.SpatialVelocity.ctor.doc)
+      .def(py::init(), doc.SpatialVelocity.ctor.doc_3)
       .def(py::init<const Eigen::Ref<const Vector3<T>>&,
                     const Eigen::Ref<const Vector3<T>>&>(),
            py::arg("w"), py::arg("v"), doc.SpatialVelocity.ctor.doc_4);
@@ -464,23 +464,24 @@ void init_multibody_plant(py::module m) {
              doc.MultibodyPlant.num_model_instances.doc)
         .def("num_positions",
              overload_cast_explicit<int>(&Class::num_positions),
-             doc.MultibodyPlant.num_positions.doc)
+             doc.MultibodyPlant.num_positions.doc_0args)
         .def("num_positions",
              overload_cast_explicit<int, ModelInstanceIndex>(
                  &Class::num_positions),
-             py::arg("model_instance"), doc.MultibodyPlant.num_positions.doc_2)
+             py::arg("model_instance"),
+             doc.MultibodyPlant.num_positions.doc_1args)
         .def("num_velocities",
              overload_cast_explicit<int>(&Class::num_velocities),
-             doc.MultibodyPlant.num_velocities.doc)
+             doc.MultibodyPlant.num_velocities.doc_0args)
         .def("num_velocities",
              overload_cast_explicit<int, ModelInstanceIndex>(
                  &Class::num_velocities),
-             doc.MultibodyPlant.num_velocities.doc_2)
+             doc.MultibodyPlant.num_velocities.doc_1args)
         .def("num_multibody_states", &Class::num_multibody_states,
              doc.MultibodyPlant.num_multibody_states.doc)
         .def("num_actuated_dofs",
              overload_cast_explicit<int>(&Class::num_actuated_dofs),
-             doc.MultibodyPlant.num_actuated_dofs.doc);
+             doc.MultibodyPlant.num_actuated_dofs.doc_0args);
     // Construction.
     cls  // BR
         .def("AddJoint",
@@ -504,40 +505,40 @@ void init_multibody_plant(py::module m) {
     cls  // BR
         .def("HasBodyNamed",
              overload_cast_explicit<bool, const string&>(&Class::HasBodyNamed),
-             py::arg("name"), doc.MultibodyPlant.HasBodyNamed.doc)
+             py::arg("name"), doc.MultibodyPlant.HasBodyNamed.doc_1args)
         .def("HasBodyNamed",
              overload_cast_explicit<bool, const string&, ModelInstanceIndex>(
                  &Class::HasBodyNamed),
              py::arg("name"), py::arg("model_instance"),
-             doc.MultibodyPlant.HasBodyNamed.doc_2)
+             doc.MultibodyPlant.HasBodyNamed.doc_2args)
         .def("HasJointNamed",
              overload_cast_explicit<bool, const string&>(&Class::HasJointNamed),
-             py::arg("name"), doc.MultibodyPlant.HasJointNamed.doc)
+             py::arg("name"), doc.MultibodyPlant.HasJointNamed.doc_1args)
         .def("HasJointNamed",
              overload_cast_explicit<bool, const string&, ModelInstanceIndex>(
                  &Class::HasJointNamed),
              py::arg("name"), py::arg("model_instance"),
-             doc.MultibodyPlant.HasJointNamed.doc_2)
+             doc.MultibodyPlant.HasJointNamed.doc_2args)
         .def("GetFrameByName",
              overload_cast_explicit<const Frame<T>&, const string&>(
                  &Class::GetFrameByName),
              py::arg("name"), py_reference_internal,
-             doc.MultibodyPlant.GetFrameByName.doc)
+             doc.MultibodyPlant.GetFrameByName.doc_1args)
         .def("GetFrameByName",
              overload_cast_explicit<const Frame<T>&, const string&,
                                     ModelInstanceIndex>(&Class::GetFrameByName),
              py::arg("name"), py::arg("model_instance"), py_reference_internal,
-             doc.MultibodyPlant.GetFrameByName.doc_2)
+             doc.MultibodyPlant.GetFrameByName.doc_2args)
         .def("GetBodyByName",
              overload_cast_explicit<const Body<T>&, const string&>(
                  &Class::GetBodyByName),
              py::arg("name"), py_reference_internal,
-             doc.MultibodyPlant.GetBodyByName.doc)
+             doc.MultibodyPlant.GetBodyByName.doc_1args)
         .def("GetBodyByName",
              overload_cast_explicit<const Body<T>&, const string&,
                                     ModelInstanceIndex>(&Class::GetBodyByName),
              py::arg("name"), py::arg("model_instance"), py_reference_internal,
-             doc.MultibodyPlant.GetBodyByName.doc_2)
+             doc.MultibodyPlant.GetBodyByName.doc_2args)
         .def("GetJointByName",
              [](const Class* self, const string& name) -> auto& {
                return self->GetJointByName(name);
@@ -555,7 +556,7 @@ void init_multibody_plant(py::module m) {
              overload_cast_explicit<const JointActuator<T>&, const string&>(
                  &Class::GetJointActuatorByName),
              py::arg("name"), py_reference_internal,
-             doc.MultibodyPlant.GetJointActuatorByName.doc)
+             doc.MultibodyPlant.GetJointActuatorByName.doc_1args)
         .def("GetModelInstanceByName",
              overload_cast_explicit<ModelInstanceIndex, const string&>(
                  &Class::GetModelInstanceByName),
@@ -585,12 +586,12 @@ void init_multibody_plant(py::module m) {
              overload_cast_explicit<const systems::InputPort<T>&>(
                  &Class::get_actuation_input_port),
              py_reference_internal,
-             doc.MultibodyPlant.get_actuation_input_port.doc)
+             doc.MultibodyPlant.get_actuation_input_port.doc_0args)
         .def("get_continuous_state_output_port",
              overload_cast_explicit<const systems::OutputPort<T>&>(
                  &Class::get_continuous_state_output_port),
              py_reference_internal,
-             doc.MultibodyPlant.get_continuous_state_output_port.doc)
+             doc.MultibodyPlant.get_continuous_state_output_port.doc_0args)
         .def("get_contact_results_output_port",
              overload_cast_explicit<const systems::OutputPort<T>&>(
                  &Class::get_contact_results_output_port),
@@ -643,7 +644,7 @@ void init_multibody_plant(py::module m) {
                return self->GetPositions(context);
              },
              py_reference, py::arg("context"),
-             doc.MultibodyPlant.GetPositions.doc)
+             doc.MultibodyPlant.GetPositions.doc_1args)
         .def("GetPositions",
              [](const MultibodyPlant<T>* self,
                 const systems::Context<T>& context,
@@ -651,12 +652,12 @@ void init_multibody_plant(py::module m) {
                return self->GetPositions(context, model_instance);
              },
              py_reference, py::arg("context"), py::arg("model_instance"),
-             doc.MultibodyPlant.GetPositions.doc_2)
+             doc.MultibodyPlant.GetPositions.doc_2args)
         .def("SetPositions",
              [](const MultibodyPlant<T>* self, systems::Context<T>* context,
                 const VectorX<T>& q) { self->SetPositions(context, q); },
              py_reference, py::arg("context"), py::arg("q"),
-             doc.MultibodyPlant.SetPositions.doc)
+             doc.MultibodyPlant.SetPositions.doc_2args)
         .def("SetPositions",
              [](const MultibodyPlant<T>* self, systems::Context<T>* context,
                 multibody::ModelInstanceIndex model_instance,
@@ -664,14 +665,14 @@ void init_multibody_plant(py::module m) {
                self->SetPositions(context, model_instance, q);
              },
              py_reference, py::arg("context"), py::arg("model_instance"),
-             py::arg("q"), doc.MultibodyPlant.SetPositions.doc_2)
+             py::arg("q"), doc.MultibodyPlant.SetPositions.doc_2args)
         .def("GetVelocities",
              [](const MultibodyPlant<T>* self,
                 const systems::Context<T>& context) -> VectorX<T> {
                return self->GetVelocities(context);
              },
              py_reference, py::arg("context"),
-             doc.MultibodyPlant.GetVelocities.doc)
+             doc.MultibodyPlant.GetVelocities.doc_1args)
         .def("GetVelocities",
              [](const MultibodyPlant<T>* self,
                 const systems::Context<T>& context,
@@ -679,26 +680,26 @@ void init_multibody_plant(py::module m) {
                return self->GetVelocities(context, model_instance);
              },
              py_reference, py::arg("context"), py::arg("model_instance"),
-             doc.MultibodyPlant.GetVelocities.doc_2)
+             doc.MultibodyPlant.GetVelocities.doc_2args)
         .def("SetVelocities",
              [](const MultibodyPlant<T>* self, systems::Context<T>* context,
                 const VectorX<T>& v) { self->SetVelocities(context, v); },
              py_reference, py::arg("context"), py::arg("v"),
-             doc.MultibodyPlant.SetVelocities.doc)
+             doc.MultibodyPlant.SetVelocities.doc_2args)
         .def("SetVelocities",
              [](const MultibodyPlant<T>* self, systems::Context<T>* context,
                 ModelInstanceIndex model_instance, const VectorX<T>& v) {
                self->SetVelocities(context, model_instance, v);
              },
              py_reference, py::arg("context"), py::arg("model_instance"),
-             py::arg("v"), doc.MultibodyPlant.SetVelocities.doc_2)
+             py::arg("v"), doc.MultibodyPlant.SetVelocities.doc_3args)
         .def("GetPositionsAndVelocities",
              [](const MultibodyPlant<T>* self,
                 const systems::Context<T>& context) -> VectorX<T> {
                return self->GetPositionsAndVelocities(context);
              },
              py_reference, py::arg("context"),
-             doc.MultibodyPlant.GetPositionsAndVelocities.doc)
+             doc.MultibodyPlant.GetPositionsAndVelocities.doc_1args)
         .def("GetPositionsAndVelocities",
              [](const MultibodyPlant<T>* self,
                 const systems::Context<T>& context,
@@ -706,14 +707,14 @@ void init_multibody_plant(py::module m) {
                return self->GetPositionsAndVelocities(context, model_instance);
              },
              py_reference, py::arg("context"), py::arg("model_instance"),
-             doc.MultibodyPlant.GetPositionsAndVelocities.doc_2)
+             doc.MultibodyPlant.GetPositionsAndVelocities.doc_2args)
         .def("SetPositionsAndVelocities",
              [](const MultibodyPlant<T>* self, systems::Context<T>* context,
                 const VectorX<T>& q_v) {
                self->SetPositionsAndVelocities(context, q_v);
              },
              py_reference, py::arg("context"), py::arg("q_v"),
-             doc.MultibodyPlant.SetPositionsAndVelocities.doc)
+             doc.MultibodyPlant.SetPositionsAndVelocities.doc_2args)
         .def("SetPositionsAndVelocities",
              [](const MultibodyPlant<T>* self, systems::Context<T>* context,
                 multibody::ModelInstanceIndex model_instance,
@@ -722,7 +723,7 @@ void init_multibody_plant(py::module m) {
              },
              py_reference, py::arg("context"), py::arg("model_instance"),
              py::arg("q_v"),
-             doc.MultibodyPlant.SetPositionsAndVelocities.doc_2);
+             doc.MultibodyPlant.SetPositionsAndVelocities.doc_3args);
 
     // Add deprecated methods.
 #pragma GCC diagnostic push
@@ -777,12 +778,12 @@ void init_parsing(py::module m) {
         py::overload_cast<const string&, const string&, MultibodyPlant<T>*,
                           SceneGraph<T>*>(&AddModelFromSdfFile),
         py::arg("file_name"), py::arg("model_name"), py::arg("plant"),
-        py::arg("scene_graph") = nullptr, doc.AddModelFromSdfFile.doc);
+        py::arg("scene_graph") = nullptr, doc.AddModelFromSdfFile.doc_4args);
   m.def("AddModelFromSdfFile",
         py::overload_cast<const string&, MultibodyPlant<T>*, SceneGraph<T>*>(
             &AddModelFromSdfFile),
         py::arg("file_name"), py::arg("plant"),
-        py::arg("scene_graph") = nullptr, doc.AddModelFromSdfFile.doc_2);
+        py::arg("scene_graph") = nullptr, doc.AddModelFromSdfFile.doc_3args);
 }
 
 void init_all(py::module m) {

--- a/bindings/pydrake/multibody/parsers_py.cc
+++ b/bindings/pydrake/multibody/parsers_py.cc
@@ -14,7 +14,7 @@ PYBIND11_MODULE(parsers, m) {
   m.doc() = "Tools for loading robots from various files";
 
   py::class_<PackageMap>(m, "PackageMap", doc.PackageMap.doc)
-      .def(py::init<>(), doc.PackageMap.ctor.doc)
+      .def(py::init<>(), doc.PackageMap.ctor.doc_0args)
       .def("Add", &PackageMap::Add, doc.PackageMap.Add.doc)
       .def("Contains", &PackageMap::Contains, doc.PackageMap.Contains.doc)
       .def("size", &PackageMap::size, doc.PackageMap.size.doc)

--- a/bindings/pydrake/multibody/rigid_body_plant_py.cc
+++ b/bindings/pydrake/multibody/rigid_body_plant_py.cc
@@ -72,7 +72,8 @@ PYBIND11_MODULE(rigid_body_plant, m) {
         .def(py::init<const Vector3<T>&, const Vector3<T>&, const Vector3<T>&,
                       const Vector3<T>&>(),
              py::arg("application_point"), py::arg("normal"), py::arg("force"),
-             py::arg("torque") = Vector3<T>::Zero(), doc.ContactForce.ctor.doc)
+             py::arg("torque") = Vector3<T>::Zero(),
+             doc.ContactForce.ctor.doc_4args)
         .def("get_reaction_force", &Class::get_reaction_force,
              doc.ContactForce.get_reaction_force.doc)
         .def("get_application_point", &Class::get_application_point,
@@ -90,7 +91,7 @@ PYBIND11_MODULE(rigid_body_plant, m) {
     using Class = ContactResults<T>;
     py::class_<Class> cls(m, "ContactResults", doc.ContactResults.doc);
     cls  // BR
-        .def(py::init<>(), doc.ContactResults.ctor.doc)
+        .def(py::init<>(), doc.ContactResults.ctor.doc_0args)
         .def("get_num_contacts", &Class::get_num_contacts,
              doc.ContactResults.get_num_contacts.doc)
         .def("get_contact_info", &Class::get_contact_info,
@@ -114,11 +115,11 @@ PYBIND11_MODULE(rigid_body_plant, m) {
     using Class = CompliantMaterial;
     py::class_<Class> cls(m, "CompliantMaterial", doc.CompliantMaterial.doc);
     cls  // BR
-        .def(py::init<>(), doc.CompliantMaterial.ctor.doc)
+        .def(py::init<>(), doc.CompliantMaterial.ctor.doc_0args)
         .def(py::init<double, double, double, double>(),
              py::arg("youngs_modulus"), py::arg("dissipation"),
              py::arg("static_friction"), py::arg("dynamic_friction"),
-             doc.CompliantMaterial.ctor.doc_4)
+             doc.CompliantMaterial.ctor.doc_4args)
         // youngs_modulus
         .def("set_youngs_modulus", &Class::set_youngs_modulus, py_reference,
              doc.CompliantMaterial.set_youngs_modulus.doc)
@@ -143,11 +144,11 @@ PYBIND11_MODULE(rigid_body_plant, m) {
         // friction
         .def("set_friction", py::overload_cast<double>(&Class::set_friction),
              py::arg("value"), py_reference,
-             doc.CompliantMaterial.set_friction.doc)
+             doc.CompliantMaterial.set_friction.doc_1args)
         .def("set_friction",
              py::overload_cast<double, double>(&Class::set_friction),
              py::arg("static_friction"), py::arg("dynamic_friction"),
-             py_reference, doc.CompliantMaterial.set_friction.doc_2)
+             py_reference, doc.CompliantMaterial.set_friction.doc_2args)
         .def("static_friction", &Class::static_friction,
              py::arg("default_value") = Class::kDefaultStaticFriction,
              doc.CompliantMaterial.static_friction.doc)
@@ -171,7 +172,7 @@ PYBIND11_MODULE(rigid_body_plant, m) {
                                      doc.RigidBodyPlant.doc)
         .def(py::init<unique_ptr<const RigidBodyTree<T>>, double>(),
              py::arg("tree"), py::arg("timestep") = 0.0,
-             doc.RigidBodyPlant.ctor.doc)
+             doc.RigidBodyPlant.ctor.doc_2args)
         .def("set_contact_model_parameters",
              &Class::set_contact_model_parameters,
              doc.RigidBodyPlant.set_contact_model_parameters.doc)
@@ -184,28 +185,28 @@ PYBIND11_MODULE(rigid_body_plant, m) {
              doc.RigidBodyPlant.get_num_bodies.doc)
         .def("get_num_positions",
              overload_cast_explicit<int>(&Class::get_num_positions),
-             doc.RigidBodyPlant.get_num_positions.doc)
+             doc.RigidBodyPlant.get_num_positions.doc_0args)
         .def("get_num_positions",
              overload_cast_explicit<int, int>(&Class::get_num_positions),
-             doc.RigidBodyPlant.get_num_positions.doc_2)
+             doc.RigidBodyPlant.get_num_positions.doc_1args)
         .def("get_num_velocities",
              overload_cast_explicit<int>(&Class::get_num_velocities),
-             doc.RigidBodyPlant.get_num_velocities.doc)
+             doc.RigidBodyPlant.get_num_velocities.doc_0args)
         .def("get_num_velocities",
              overload_cast_explicit<int, int>(&Class::get_num_velocities),
-             doc.RigidBodyPlant.get_num_velocities.doc_2)
+             doc.RigidBodyPlant.get_num_velocities.doc_1args)
         .def("get_num_states",
              overload_cast_explicit<int>(&Class::get_num_states),
-             doc.RigidBodyPlant.get_num_states.doc)
+             doc.RigidBodyPlant.get_num_states.doc_0args)
         .def("get_num_states",
              overload_cast_explicit<int, int>(&Class::get_num_states),
-             doc.RigidBodyPlant.get_num_states.doc_2)
+             doc.RigidBodyPlant.get_num_states.doc_1args)
         .def("get_num_actuators",
              overload_cast_explicit<int>(&Class::get_num_actuators),
-             doc.RigidBodyPlant.get_num_actuators.doc)
+             doc.RigidBodyPlant.get_num_actuators.doc_0args)
         .def("get_num_actuators",
              overload_cast_explicit<int, int>(&Class::get_num_actuators),
-             doc.RigidBodyPlant.get_num_actuators.doc_2)
+             doc.RigidBodyPlant.get_num_actuators.doc_1args)
         .def("get_num_model_instances", &Class::get_num_model_instances,
              doc.RigidBodyPlant.get_num_model_instances.doc)
         .def("get_input_size", &Class::get_input_size,
@@ -284,7 +285,7 @@ PYBIND11_MODULE(rigid_body_plant, m) {
              // Keep alive, reference: `this` keeps `tree` alive.
              py::keep_alive<1, 2>(),
              // Keep alive, reference: `this` keeps `lcm` alive.
-             py::keep_alive<1, 3>(), doc.DrakeVisualizer.ctor.doc)
+             py::keep_alive<1, 3>(), doc.DrakeVisualizer.ctor.doc_3args)
         .def("set_publish_period", &Class::set_publish_period,
              py::arg("period"), doc.DrakeVisualizer.set_publish_period.doc)
         .def("ReplayCachedSimulation", &Class::ReplayCachedSimulation,

--- a/bindings/pydrake/multibody/rigid_body_tree_py.cc
+++ b/bindings/pydrake/multibody/rigid_body_tree_py.cc
@@ -190,7 +190,7 @@ PYBIND11_MODULE(rigid_body_tree, m) {
            },
            py::arg("body_name"), py::arg("model_name") = "",
            py::arg("model_id") = -1, py::return_value_policy::reference,
-           doc.RigidBodyTree.FindBody.doc)
+           doc.RigidBodyTree.FindBody.doc_3args)
       .def("FindBodyIndex", &RigidBodyTree<double>::FindBodyIndex,
            py::arg("body_name"), py::arg("model_id") = -1,
            doc.RigidBodyTree.FindBodyIndex.doc)
@@ -506,7 +506,7 @@ PYBIND11_MODULE(rigid_body_tree, m) {
             &parsers::urdf::  // BR
             AddModelInstanceFromUrdfStringSearchingInRosPackages),
         doc.drake.parsers.urdf
-            .AddModelInstanceFromUrdfStringSearchingInRosPackages.doc);
+            .AddModelInstanceFromUrdfStringSearchingInRosPackages.doc_6args);
   m.def("AddModelInstancesFromSdfFile",
         [](const std::string& sdf_filename,
            const FloatingBaseType floating_base_type,
@@ -518,13 +518,13 @@ PYBIND11_MODULE(rigid_body_tree, m) {
         },
         py::arg("sdf_filename"), py::arg("floating_base_type"),
         py::arg("weld_to_frame"), py::arg("tree"), py::arg("do_compile") = true,
-        doc.drake.parsers.sdf.AddModelInstancesFromSdfFile.doc);
+        doc.drake.parsers.sdf.AddModelInstancesFromSdfFile.doc_5args);
   m.def("AddModelInstancesFromSdfString",
         py::overload_cast<const std::string&, const FloatingBaseType,
                           shared_ptr<RigidBodyFrame<double>>,
                           RigidBodyTree<double>*>(
             &sdf::AddModelInstancesFromSdfString),
-        doc.drake.parsers.sdf.AddModelInstancesFromSdfString.doc);
+        doc.drake.parsers.sdf.AddModelInstancesFromSdfString.doc_4args);
   m.def("AddModelInstancesFromSdfStringSearchingInRosPackages",
         py::overload_cast<
             const std::string&, const PackageMap&, const FloatingBaseType,
@@ -532,7 +532,7 @@ PYBIND11_MODULE(rigid_body_tree, m) {
             &sdf::  // BR
             AddModelInstancesFromSdfStringSearchingInRosPackages),
         doc.drake.parsers.sdf
-            .AddModelInstancesFromSdfStringSearchingInRosPackages.doc);
+            .AddModelInstancesFromSdfStringSearchingInRosPackages.doc_5args);
   m.def("AddFlatTerrainToWorld", &multibody::AddFlatTerrainToWorld,
         py::arg("tree"), py::arg("box_size") = 1000, py::arg("box_depth") = 10,
         doc.drake.multibody.AddFlatTerrainToWorld.doc);

--- a/bindings/pydrake/multibody/shapes_py.cc
+++ b/bindings/pydrake/multibody/shapes_py.cc
@@ -50,7 +50,7 @@ PYBIND11_MODULE(shapes, m) {
              self->getBoundingBoxPoints(pts);
              return pts;
            },
-           doc.Geometry.getBoundingBoxPoints.doc);
+           doc.Geometry.getBoundingBoxPoints.doc_1args);
 
   py::class_<Box, Geometry>(m, "Box", doc.Box.doc)
       .def(py::init<const Eigen::Vector3d&>(), py::arg("size"),
@@ -94,9 +94,10 @@ PYBIND11_MODULE(shapes, m) {
            doc.Element.getLocalTransform.doc);
   py::class_<VisualElement, Element>(m, "VisualElement")
       .def(py::init<const Geometry&, const Eigen::Isometry3d&,
-                    const Eigen::Vector4d&>(),
+                    const Eigen::Vector4d&, const std::string&>(),
            py::arg("geometry_in"), py::arg("T_element_to_local"),
-           py::arg("material_in"), doc.VisualElement.ctor.doc_2)
+           py::arg("material_in"), py::arg("name") = "",
+           doc.VisualElement.ctor.doc_4args)
       .def("setMaterial", &VisualElement::setMaterial,
            "Apply an RGBA material.", doc.VisualElement.setMaterial.doc)
       .def("getMaterial", &VisualElement::getMaterial, "Get an RGBA material.",

--- a/bindings/pydrake/perception_py.cc
+++ b/bindings/pydrake/perception_py.cc
@@ -70,9 +70,9 @@ void init_perception(py::module m) {
                     cls_doc.IsInvalidValue.doc)
         .def(py::init<int, pc_flags::Fields>(), py::arg("new_size") = 0,
              py::arg("fields") = pc_flags::Fields(pc_flags::kXYZs),
-             cls_doc.ctor.doc)
+             cls_doc.ctor.doc_3args)
         .def(py::init<const PointCloud&>(), py::arg("other"),
-             cls_doc.ctor.doc_2)
+             cls_doc.ctor.doc_copy)
         .def("fields", &Class::fields, cls_doc.fields.doc)
         .def("size", &Class::size, cls_doc.size.doc)
         .def("resize",
@@ -100,7 +100,7 @@ void init_perception(py::module m) {
     py::class_<Class, LeafSystem<double>>(m, "DepthImageToPointCloud",
                                           cls_doc.doc)
         .def(py::init<const CameraInfo&>(), py::arg("camera_info"),
-             cls_doc.ctor.doc_3)
+             cls_doc.ctor.doc_1args)
         .def("depth_image_input_port", &Class::depth_image_input_port,
              py_reference_internal, cls_doc.depth_image_input_port.doc)
         .def("point_cloud_output_port", &Class::point_cloud_output_port,

--- a/bindings/pydrake/pydrake_pybind.h
+++ b/bindings/pydrake/pydrake_pybind.h
@@ -143,10 +143,10 @@ An example of incorporating docstrings:
       constexpr auto& doc = pydrake_doc.drake.math;
       using T = double;
       py::class_<RigidTransform<T>>(m, "RigidTransform", doc.RigidTransform.doc)
-          .def(py::init(), doc.ExampleClass.ctor.doc_3)
+          .def(py::init(), doc.ExampleClass.ctor.doc_0args)
           ...
           .def(py::init<const RotationMatrix<T>&>(), py::arg("R"),
-               doc.RigidTransform.ctor.doc_5)
+               doc.RigidTransform.ctor.doc_1args)
           ...
           .def("set_rotation", &RigidTransform<T>::set_rotation, py::arg("R"),
                doc.RigidTransform.set_rotation.doc)
@@ -177,18 +177,13 @@ For more detail:
 
 - Each docstring is stored in `documentation_pybind.h` in the nested structure
 `pydrake_doc`.
-- The first docstring for a symbol will be accessible via
+- The docstring for a symbol without any overloads will be accessible via
 `pydrake_doc.drake.{namespace...}.{symbol}.doc`.
-- Any additional docstrings (e.g. overloads) will be accessible as `.doc_2`,
-`.doc_3`, etc; these indices are sorted lexically, by `(include_file, line)`.
+- The docstring for an overloaded symbol will be `.doc_something` instead of
+just `.doc`, where the `_something` suffix conveys some information about the
+overload.  Browse the documentation_pybind.h (described above) for details.
 - Constructors are accessible as `{symbol}.ctor.doc`, `{symbol}.ctor.doc_2`,
 etc.
-
-@note Macros are interpreted via `libclang` and could introduce more symbols.
-As an example, if a class uses `DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN` at the
-the top of its definition, and then defines a custom constructor below this,
-the custom constructor's documentation will be accessible as
-`{symbol}.ctor.doc_3`.
 
 @anchor PydrakeKeepAlive
 ## Keep Alive Behavior

--- a/bindings/pydrake/solvers/gurobi_py.cc
+++ b/bindings/pydrake/solvers/gurobi_py.cc
@@ -19,7 +19,7 @@ PYBIND11_MODULE(gurobi, m) {
 
   py::class_<GurobiSolver>(m, "GurobiSolver", solverinterface,
                            doc.GurobiSolver.doc)
-      .def(py::init<>(), doc.GurobiSolver.ctor.doc);
+      .def(py::init<>(), doc.GurobiSolver.ctor.doc_0args);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/solvers/ik_py.cc
+++ b/bindings/pydrake/solvers/ik_py.cc
@@ -28,7 +28,7 @@ PYBIND11_MODULE(ik, m) {
            static_cast<void (PostureConstraint::*)(  // NOLINT
                const Eigen::VectorXi&, const Eigen::VectorXd&,
                const Eigen::VectorXd&)>(&PostureConstraint::setJointLimits),
-           doc.PostureConstraint.setJointLimits.doc);
+           doc.PostureConstraint.setJointLimits.doc_3args);
 
   py::class_<WorldPositionConstraint, RigidBodyConstraint>(
       m, "_WorldPositionConstraint", doc.WorldPositionConstraint.doc)
@@ -143,10 +143,10 @@ PYBIND11_MODULE(ik, m) {
            static_cast<void (QuasiStaticConstraint::*)(  // NOLINT
                std::vector<int>, const Eigen::Matrix3Xd&)>(
                &QuasiStaticConstraint::addContact),
-           doc.QuasiStaticConstraint.addContact.doc);
+           doc.QuasiStaticConstraint.addContact.doc_2args);
 
   py::class_<IKoptions>(m, "IKoptions", doc.IKoptions.doc)
-      .def(py::init<RigidBodyTree<double>*>(), doc.IKoptions.ctor.doc)
+      .def(py::init<RigidBodyTree<double>*>(), doc.IKoptions.ctor.doc_1args)
       .def("setQ", &IKoptions::setQ, doc.IKoptions.setQ.doc)
       .def("getQ", &IKoptions::getQ, doc.IKoptions.getQ.doc)
       .def("setQa", &IKoptions::setQa, doc.IKoptions.setQa.doc)

--- a/bindings/pydrake/solvers/ipopt_py.cc
+++ b/bindings/pydrake/solvers/ipopt_py.cc
@@ -19,7 +19,7 @@ PYBIND11_MODULE(ipopt, m) {
 
   py::class_<IpoptSolver>(m, "IpoptSolver", solverinterface,
                           doc.IpoptSolver.doc)
-      .def(py::init<>(), doc.IpoptSolver.ctor.doc);
+      .def(py::init<>(), doc.IpoptSolver.ctor.doc_0args);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -191,7 +191,8 @@ PYBIND11_MODULE(mathematicalprogram, m) {
            static_cast<SolutionResult (MathematicalProgramSolverInterface::*)(
                MathematicalProgram&) const>(
                &MathematicalProgramSolverInterface::Solve),
-           py::arg("prog"), doc.MathematicalProgramSolverInterface.Solve.doc)
+           py::arg("prog"),
+           doc.MathematicalProgramSolverInterface.Solve.doc_1args)
       // TODO(m-chaturvedi) Add Pybind11 documentation.
       .def("solver_type",
            [](const MathematicalProgramSolverInterface& self) {
@@ -220,7 +221,7 @@ PYBIND11_MODULE(mathematicalprogram, m) {
 
   py::class_<MathematicalProgram> prog_cls(m, "MathematicalProgram",
                                            doc.MathematicalProgram.doc);
-  prog_cls.def(py::init<>(), doc.MathematicalProgram.ctor.doc)
+  prog_cls.def(py::init<>(), doc.MathematicalProgram.ctor.doc_0args)
       .def("NewContinuousVariables",
            // NOLINTNEXTLINE(whitespace/parens)
            static_cast<VectorXDecisionVariable (MathematicalProgram::*)(
@@ -254,7 +255,7 @@ PYBIND11_MODULE(mathematicalprogram, m) {
              return self->NewSymmetricContinuousVariables(rows, name);
            },
            py::arg("rows"), py::arg("name") = "Symmetric",
-           doc.MathematicalProgram.NewSymmetricContinuousVariables.doc)
+           doc.MathematicalProgram.NewSymmetricContinuousVariables.doc_2args)
       .def("NewFreePolynomial", &MathematicalProgram::NewFreePolynomial,
            py::arg("indeterminates"), py::arg("deg"),
            py::arg("coeff_name") = "a",
@@ -265,13 +266,13 @@ PYBIND11_MODULE(mathematicalprogram, m) {
                    MathematicalProgram::*)(
                    const Eigen::Ref<const VectorX<Monomial>>&)>(
                &MathematicalProgram::NewSosPolynomial),
-           doc.MathematicalProgram.NewSosPolynomial.doc)
+           doc.MathematicalProgram.NewSosPolynomial.doc_1args)
       .def("NewSosPolynomial",
            static_cast<
                std::pair<Polynomial, Binding<PositiveSemidefiniteConstraint>> (
                    MathematicalProgram::*)(const Variables&, int)>(
                &MathematicalProgram::NewSosPolynomial),
-           doc.MathematicalProgram.NewSosPolynomial.doc_2)
+           doc.MathematicalProgram.NewSosPolynomial.doc_2args)
       .def("NewIndeterminates",
            // NOLINTNEXTLINE(whitespace/parens)
            static_cast<VectorXIndeterminate (MathematicalProgram::*)(
@@ -371,7 +372,7 @@ PYBIND11_MODULE(mathematicalprogram, m) {
               const Eigen::Ref<const MatrixXDecisionVariable>& vars) {
              return self->AddPositiveSemidefiniteConstraint(vars);
            },
-           doc.MathematicalProgram.AddPositiveSemidefiniteConstraint.doc)
+           doc.MathematicalProgram.AddPositiveSemidefiniteConstraint.doc_1args)
       .def("AddLinearComplementarityConstraint",
            static_cast<Binding<LinearComplementarityConstraint> (
                MathematicalProgram::*)(
@@ -385,7 +386,7 @@ PYBIND11_MODULE(mathematicalprogram, m) {
               const Eigen::Ref<const MatrixX<Expression>>& e) {
              return self->AddPositiveSemidefiniteConstraint(e);
            },
-           doc.MathematicalProgram.AddPositiveSemidefiniteConstraint.doc)
+           doc.MathematicalProgram.AddPositiveSemidefiniteConstraint.doc_1args)
       .def("AddCost",
            [](MathematicalProgram* self, py::function func,
               const Eigen::Ref<const VectorXDecisionVariable>& vars,
@@ -518,33 +519,33 @@ PYBIND11_MODULE(mathematicalprogram, m) {
               const symbolic::Variable& decision_variable) {
              return prog.GetInitialGuess(decision_variable);
            },
-           doc.MathematicalProgram.GetInitialGuess.doc)
+           doc.MathematicalProgram.GetInitialGuess.doc_1args)
       .def("GetInitialGuess",
            [](MathematicalProgram& prog,
               const VectorXDecisionVariable& decision_variables) {
              return prog.GetInitialGuess(decision_variables);
            },
-           doc.MathematicalProgram.GetInitialGuess.doc)
+           doc.MathematicalProgram.GetInitialGuess.doc_0args)
       .def("GetInitialGuess",
            [](MathematicalProgram& prog,
               const MatrixXDecisionVariable& decision_variables) {
              return prog.GetInitialGuess(decision_variables);
            },
-           doc.MathematicalProgram.GetInitialGuess.doc)
+           doc.MathematicalProgram.GetInitialGuess.doc_0args)
       .def("SetInitialGuess",
            [](MathematicalProgram& prog,
               const symbolic::Variable& decision_variable,
               double variable_guess_value) {
              prog.SetInitialGuess(decision_variable, variable_guess_value);
            },
-           doc.MathematicalProgram.SetInitialGuess.doc)
+           doc.MathematicalProgram.SetInitialGuess.doc_2args)
       .def("SetInitialGuess",
            [](MathematicalProgram& prog,
               const MatrixXDecisionVariable& decision_variable_mat,
               const Eigen::MatrixXd& x0) {
              prog.SetInitialGuess(decision_variable_mat, x0);
            },
-           doc.MathematicalProgram.SetInitialGuess.doc)
+           doc.MathematicalProgram.SetInitialGuess.doc_0args)
       .def("SetInitialGuessForAllVariables",
            [](MathematicalProgram& prog, const Eigen::VectorXd& x0) {
              prog.SetInitialGuessForAllVariables(x0);
@@ -647,17 +648,17 @@ PYBIND11_MODULE(mathematicalprogram, m) {
 
   py::class_<BoundingBoxConstraint, LinearConstraint,
              std::shared_ptr<BoundingBoxConstraint>>(
-      m, "BoundingBoxConstraint", doc.BoundingBoxConstraint.ctor.doc);
+      m, "BoundingBoxConstraint", doc.BoundingBoxConstraint.doc);
 
   py::class_<PositiveSemidefiniteConstraint, Constraint,
              std::shared_ptr<PositiveSemidefiniteConstraint>>(
       m, "PositiveSemidefiniteConstraint",
-      doc.PositiveSemidefiniteConstraint.ctor.doc);
+      doc.PositiveSemidefiniteConstraint.doc);
 
   py::class_<LinearComplementarityConstraint, Constraint,
              std::shared_ptr<LinearComplementarityConstraint>>(
       m, "LinearComplementarityConstraint",
-      doc.LinearComplementarityConstraint.ctor.doc);
+      doc.LinearComplementarityConstraint.doc);
 
   RegisterBinding<Constraint>(&m, &prog_cls, "Constraint");
   RegisterBinding<LinearConstraint>(&m, &prog_cls, "LinearConstraint");
@@ -687,7 +688,7 @@ PYBIND11_MODULE(mathematicalprogram, m) {
            doc.LinearCost.UpdateCoefficients.doc);
 
   py::class_<QuadraticCost, Cost, std::shared_ptr<QuadraticCost>>(
-      m, "QuadraticCost", doc.QuadraticCost.ctor.doc)
+      m, "QuadraticCost", doc.QuadraticCost.doc)
       .def("Q", &QuadraticCost::Q, doc.QuadraticCost.Q.doc)
       .def("b", &QuadraticCost::b, doc.QuadraticCost.b.doc)
       .def("c", &QuadraticCost::c, doc.QuadraticCost.c.doc)

--- a/bindings/pydrake/solvers/mosek_py.cc
+++ b/bindings/pydrake/solvers/mosek_py.cc
@@ -19,7 +19,7 @@ PYBIND11_MODULE(mosek, m) {
 
   py::class_<MosekSolver>(m, "MosekSolver", solverinterface,
                           doc.MosekSolver.doc)
-      .def(py::init<>(), doc.MosekSolver.ctor.doc);
+      .def(py::init<>(), doc.MosekSolver.ctor.doc_0args);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/solvers/osqp_py.cc
+++ b/bindings/pydrake/solvers/osqp_py.cc
@@ -18,7 +18,7 @@ PYBIND11_MODULE(osqp, m) {
           .attr("MathematicalProgramSolverInterface");
 
   py::class_<OsqpSolver>(m, "OsqpSolver", solverinterface, doc.OsqpSolver.doc)
-      .def(py::init<>(), doc.OsqpSolver.ctor.doc);
+      .def(py::init<>(), doc.OsqpSolver.ctor.doc_0args);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/symbolic_py.cc
+++ b/bindings/pydrake/symbolic_py.cc
@@ -41,7 +41,7 @@ PYBIND11_MODULE(symbolic, m) {
 
   // TODO(m-chaturvedi) Add Pybind11 documentation for operator overloads, etc.
   py::class_<Variable> var_cls(m, "Variable", doc.Variable.doc);
-  var_cls.def(py::init<const string&>(), doc.Variable.ctor.doc)
+  var_cls.def(py::init<const string&>(), doc.Variable.ctor.doc_1args)
       .def("get_id", &Variable::get_id, doc.Variable.get_id.doc)
       .def("__str__", &Variable::to_string, doc.Variable.to_string.doc)
       .def("__repr__",
@@ -208,12 +208,12 @@ PYBIND11_MODULE(symbolic, m) {
       .def("Substitute",
            [](const Expression& self, const Variable& var,
               const Expression& e) { return self.Substitute(var, e); },
-           doc.Expression.Substitute.doc)
+           doc.Expression.Substitute.doc_2args)
       .def("Substitute",
            [](const Expression& self, const Substitution& s) {
              return self.Substitute(s);
            },
-           doc.Expression.Substitute.doc_2)
+           doc.Expression.Substitute.doc_1args)
       .def("EqualTo", &Expression::EqualTo, doc.Expression.EqualTo.doc)
       // Addition
       .def(py::self + py::self)
@@ -362,22 +362,22 @@ PYBIND11_MODULE(symbolic, m) {
            [](const Formula& self, const Variable& var, const Expression& e) {
              return self.Substitute(var, e);
            },
-           doc.Formula.Substitute.doc)
+           doc.Formula.Substitute.doc_2args)
       .def("Substitute",
            [](const Formula& self, const Variable& var1, const Variable& var2) {
              return self.Substitute(var1, var2);
            },
-           doc.Formula.Substitute.doc_2)
+           doc.Formula.Substitute.doc_2args)
       .def("Substitute",
            [](const Formula& self, const Variable& var, const double c) {
              return self.Substitute(var, c);
            },
-           doc.Formula.Substitute.doc_2)
+           doc.Formula.Substitute.doc_2args)
       .def("Substitute",
            [](const Formula& self, const Substitution& s) {
              return self.Substitute(s);
            },
-           doc.Formula.Substitute.doc_2)
+           doc.Formula.Substitute.doc_1args)
       .def("to_string", &Formula::to_string, doc.Formula.to_string.doc)
       .def("__str__", &Formula::to_string)
       .def("__repr__",
@@ -458,16 +458,18 @@ PYBIND11_MODULE(symbolic, m) {
       .def("__pow__",
            [](const Monomial& self, const int p) { return pow(self, p); });
 
-  m.def("MonomialBasis",
-        [](const Eigen::Ref<const VectorX<Variable>>& vars, const int degree) {
-          return MonomialBasis(Variables{vars}, degree);
-        },
-        doc.MonomialBasis.doc)
+  m  // BR
+      .def("MonomialBasis",
+           [](const Eigen::Ref<const VectorX<Variable>>& vars,
+              const int degree) {
+             return MonomialBasis(Variables{vars}, degree);
+           },
+           doc.MonomialBasis.doc_2args)
       .def("MonomialBasis",
            [](const Variables& vars, const int degree) {
              return MonomialBasis(vars, degree);
            },
-           doc.MonomialBasis.doc);
+           doc.MonomialBasis.doc_2args);
 
   // TODO(m-chaturvedi) Add Pybind11 documentation for operator overloads, etc.
   py::class_<Polynomial>(m, "Polynomial", doc.Polynomial.doc)

--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -60,7 +60,7 @@ PYBIND11_MODULE(analysis, m) {
              // Keep alive, reference: `self` keeps `System` alive.
              py::keep_alive<1, 2>(),
              // Keep alive, reference: `self` keeps `Context` alive.
-             py::keep_alive<1, 4>(), doc.RungeKutta2Integrator.ctor.doc_3);
+             py::keep_alive<1, 4>(), doc.RungeKutta2Integrator.ctor.doc_3args);
 
     DefineTemplateClassWithDefault<RungeKutta3Integrator<T>, IntegratorBase<T>>(
         m, "RungeKutta3Integrator", GetPyParam<T>(),
@@ -70,7 +70,7 @@ PYBIND11_MODULE(analysis, m) {
              // Keep alive, reference: `self` keeps `System` alive.
              py::keep_alive<1, 2>(),
              // Keep alive, reference: `self` keeps `Context` alive.
-             py::keep_alive<1, 3>(), doc.RungeKutta3Integrator.ctor.doc_3);
+             py::keep_alive<1, 3>(), doc.RungeKutta3Integrator.ctor.doc_2args);
 
     DefineTemplateClassWithDefault<Simulator<T>>(
         m, "Simulator", GetPyParam<T>(), doc.Simulator.doc)

--- a/bindings/pydrake/systems/controllers_py.cc
+++ b/bindings/pydrake/systems/controllers_py.cc
@@ -57,7 +57,7 @@ PYBIND11_MODULE(controllers, m) {
       m, "InverseDynamics", doc.InverseDynamics.doc);
   idyn.def(py::init<const RigidBodyTree<double>*,
                     InverseDynamics<double>::InverseDynamicsMode>(),
-           py::arg("tree"), py::arg("mode"), doc.InverseDynamics.ctor.doc);
+           py::arg("tree"), py::arg("mode"), doc.InverseDynamics.ctor.doc_3);
   idyn.def("is_pure_gravity_compensation",
            &InverseDynamics<double>::is_pure_gravity_compensation,
            doc.InverseDynamics.is_pure_gravity_compensation.doc);

--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -141,11 +141,12 @@ void DefineFrameworkPySemantics(py::module m) {
         .def("get_discrete_state",
              overload_cast_explicit<const DiscreteValues<T>&>(
                  &Context<T>::get_discrete_state),
-             py_reference_internal, doc.Context.get_discrete_state.doc)
+             py_reference_internal, doc.Context.get_discrete_state.doc_0args)
         .def("get_mutable_discrete_state",
              overload_cast_explicit<DiscreteValues<T>&>(
                  &Context<T>::get_mutable_discrete_state),
-             py_reference_internal, doc.Context.get_mutable_discrete_state.doc)
+             py_reference_internal,
+             doc.Context.get_mutable_discrete_state.doc_0args)
         .def("get_discrete_state_vector",
              &Context<T>::get_discrete_state_vector, py_reference_internal,
              doc.Context.get_discrete_state_vector.doc)
@@ -156,12 +157,12 @@ void DefineFrameworkPySemantics(py::module m) {
         .def("get_discrete_state",
              overload_cast_explicit<const BasicVector<T>&, int>(
                  &Context<T>::get_discrete_state),
-             py_reference_internal, doc.Context.get_discrete_state.doc_2)
+             py_reference_internal, doc.Context.get_discrete_state.doc_1args)
         .def("get_mutable_discrete_state",
              overload_cast_explicit<BasicVector<T>&, int>(
                  &Context<T>::get_mutable_discrete_state),
              py_reference_internal,
-             doc.Context.get_mutable_discrete_state.doc_2)
+             doc.Context.get_mutable_discrete_state.doc_1args)
         // - Abstract.
         .def("get_num_abstract_states", &Context<T>::get_num_abstract_states,
              doc.Context.get_num_abstract_states.doc)
@@ -211,7 +212,7 @@ void DefineFrameworkPySemantics(py::module m) {
     // Glue mechanisms.
     DefineTemplateClassWithDefault<DiagramBuilder<T>>(
         m, "DiagramBuilder", GetPyParam<T>(), doc.DiagramBuilder.doc)
-        .def(py::init<>(), doc.DiagramBuilder.ctor.doc_3)
+        .def(py::init<>(), doc.DiagramBuilder.ctor.doc_0args)
         .def("AddSystem",
              [](DiagramBuilder<T>* self, unique_ptr<System<T>> arg1) {
                return self->AddSystem(std::move(arg1));
@@ -332,13 +333,13 @@ void DefineFrameworkPySemantics(py::module m) {
                return self->get_abstract_parameter(index);
              },
              py_reference_internal, py::arg("index"),
-             doc.Parameters.get_abstract_parameter.doc)
+             doc.Parameters.get_abstract_parameter.doc_1args)
         .def("get_mutable_abstract_parameter",
              [](Parameters<T>* self, int index) -> AbstractValue& {
                return self->get_mutable_abstract_parameter(index);
              },
              py_reference_internal, py::arg("index"),
-             doc.Parameters.get_mutable_abstract_parameter.doc)
+             doc.Parameters.get_mutable_abstract_parameter.doc_1args)
         .def("get_abstract_parameters", &Parameters<T>::get_abstract_parameters,
              py_reference_internal, doc.Parameters.get_abstract_parameters.doc)
         .def("set_abstract_parameters", &Parameters<T>::set_abstract_parameters,
@@ -352,7 +353,7 @@ void DefineFrameworkPySemantics(py::module m) {
     // State.
     DefineTemplateClassWithDefault<State<T>>(m, "State", GetPyParam<T>(),
                                              doc.State.doc)
-        .def(py::init<>(), doc.State.ctor.doc_3)
+        .def(py::init<>(), doc.State.ctor.doc_0args)
         .def("get_continuous_state", &State<T>::get_continuous_state,
              py_reference_internal, doc.State.get_continuous_state.doc)
         .def("get_mutable_continuous_state",
@@ -361,11 +362,12 @@ void DefineFrameworkPySemantics(py::module m) {
         .def("get_discrete_state",
              overload_cast_explicit<const DiscreteValues<T>&>(
                  &State<T>::get_discrete_state),
-             py_reference_internal, doc.State.get_discrete_state.doc)
+             py_reference_internal, doc.State.get_discrete_state.doc_0args)
         .def("get_mutable_discrete_state",
              overload_cast_explicit<DiscreteValues<T>&>(
                  &State<T>::get_mutable_discrete_state),
-             py_reference_internal, doc.State.get_mutable_discrete_state.doc);
+             py_reference_internal,
+             doc.State.get_mutable_discrete_state.doc_0args);
 
     // - Constituents.
     DefineTemplateClassWithDefault<ContinuousState<T>>(
@@ -388,12 +390,12 @@ void DefineFrameworkPySemantics(py::module m) {
              overload_cast_explicit<const BasicVector<T>&, int>(
                  &DiscreteValues<T>::get_vector),
              py_reference_internal, py::arg("index") = 0,
-             doc.DiscreteValues.get_vector.doc)
+             doc.DiscreteValues.get_vector.doc_1args)
         .def("get_mutable_vector",
              overload_cast_explicit<BasicVector<T>&, int>(
                  &DiscreteValues<T>::get_mutable_vector),
              py_reference_internal, py::arg("index") = 0,
-             doc.DiscreteValues.get_mutable_vector.doc);
+             doc.DiscreteValues.get_mutable_vector.doc_1args);
   };
   type_visit(bind_common_scalar_types, pysystems::CommonScalarPack{});
 }

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -275,7 +275,7 @@ struct Impl {
                  &PySystem::DeclareInputPort),
              py_reference_internal, py::arg("name"), py::arg("type"),
              py::arg("size"), py::arg("random_type") = nullopt,
-             doc.System.DeclareInputPort.doc)
+             doc.System.DeclareInputPort.doc_4args)
         .def("_DeclareInputPort",
              overload_cast_explicit<  // BR
                  const InputPort<T>&, PortDataType, int,
@@ -288,19 +288,19 @@ struct Impl {
         .def("HasDirectFeedthrough",
              overload_cast_explicit<bool, int>(  // BR
                  &System<T>::HasDirectFeedthrough),
-             py::arg("output_port"), doc.System.HasDirectFeedthrough.doc)
+             py::arg("output_port"), doc.System.HasDirectFeedthrough.doc_1args)
         .def("HasDirectFeedthrough",
              overload_cast_explicit<bool, int, int>(
                  &System<T>::HasDirectFeedthrough),
              py::arg("input_port"), py::arg("output_port"),
-             doc.System.HasDirectFeedthrough.doc_2)
+             doc.System.HasDirectFeedthrough.doc_2args)
         // Context.
         .def("CreateDefaultContext", &System<T>::CreateDefaultContext,
              doc.System.CreateDefaultContext.doc)
         .def("AllocateOutput",
              overload_cast_explicit<unique_ptr<SystemOutput<T>>>(
                  &System<T>::AllocateOutput),
-             doc.System.AllocateOutput.doc)
+             doc.System.AllocateOutput.doc_0args)
         // TODO(sherm1) Deprecate this next signature (context unused).
         .def("AllocateOutput",
              [](const System<T>* self, const Context<T>&) {
@@ -309,7 +309,7 @@ struct Impl {
                    "Please use `System.AllocateOutput(self)` instead.");
                return self->AllocateOutput();
              },
-             py::arg("context"), doc.System.AllocateOutput.doc)
+             py::arg("context"), doc.System.AllocateOutput.doc_1args)
         .def("EvalVectorInput",
              [](const System<T>* self, const Context<T>& arg1, int arg2) {
                return self->EvalVectorInput(arg1, arg2);
@@ -342,7 +342,7 @@ struct Impl {
         .def("Publish",
              overload_cast_explicit<void, const Context<T>&>(
                  &System<T>::Publish),
-             doc.System.Publish.doc)
+             doc.System.Publish.doc_1args)
         // Scalar types.
         .def("ToAutoDiffXd",
              [](const System<T>& self) { return self.ToAutoDiffXd(); },
@@ -361,7 +361,7 @@ struct Impl {
 
     DefineTemplateClassWithDefault<LeafSystem<T>, PyLeafSystem, System<T>>(
         m, "LeafSystem", GetPyParam<T>(), doc.LeafSystem.doc)
-        .def(py::init<>(), doc.LeafSystem.ctor.doc_3)
+        .def(py::init<>(), doc.LeafSystem.ctor.doc_0args)
         // TODO(eric.cousineau): It'd be nice if we did not need the user to
         // propagate scalar conversion information. Ideally, if we could
         // intercept `self` at this point, when constructing `PyLeafSystem` for
@@ -369,14 +369,14 @@ struct Impl {
         // being used, and pass that as the converter. However, that requires an
         // old-style `py::init`, which is deprecated in Python...
         .def(py::init<SystemScalarConverter>(), py::arg("converter"),
-             doc.LeafSystem.ctor.doc_4)
+             doc.LeafSystem.ctor.doc_1args)
         .def("_DeclareAbstractInputPort",
              [](PyLeafSystem* self, const std::string& name,
                 const AbstractValue& model_value) -> const InputPort<T>& {
                return self->DeclareAbstractInputPort(name, model_value);
              },
              py_reference_internal, py::arg("name"), py::arg("model_value"),
-             doc.LeafSystem.DeclareAbstractInputPort.doc)
+             doc.LeafSystem.DeclareAbstractInputPort.doc_2args)
         .def("_DeclareAbstractInputPort",
              [](PyLeafSystem* self,
                 const std::string& name) -> const InputPort<T>& {
@@ -387,7 +387,7 @@ struct Impl {
                return self->DeclareAbstractInputPort(name, model_value);
              },
              py_reference_internal, py::arg("name"),
-             doc.System.DeclareAbstractInputPort.doc_2)
+             doc.System.DeclareAbstractInputPort.doc_1args)
         .def("_DeclareAbstractOutputPort",
              WrapCallbacks([](PyLeafSystem * self, const std::string& name,
                               AllocCallback arg1, CalcCallback arg2) -> auto& {
@@ -508,7 +508,7 @@ struct Impl {
         .def(py::init([](int inputs, int outputs) {
                return new PyVectorSystem(inputs, outputs);
              }),
-             doc.VectorSystem.ctor.doc);
+             doc.VectorSystem.ctor.doc_2args);
     // TODO(eric.cousineau): Bind virtual methods once we provide a function
     // wrapper to convert `Map<Derived>*` arguments.
     // N.B. This could be mitigated by using `EigenPtr` in public interfaces in

--- a/bindings/pydrake/systems/lcm_py.cc
+++ b/bindings/pydrake/systems/lcm_py.cc
@@ -74,7 +74,7 @@ PYBIND11_MODULE(lcm, m) {
     py::class_<Class, PySerializerInterface>(m, "SerializerInterface")
         .def(py::init(
                  []() { return std::make_unique<PySerializerInterface>(); }),
-             doc.SerializerInterface.ctor.doc);
+             doc.SerializerInterface.ctor.doc_0args);
     // TODO(eric.cousineau): Consider providing bindings of C++ types if we want
     // to be able to connect to ports which use C++ LCM types.
   }
@@ -86,7 +86,7 @@ PYBIND11_MODULE(lcm, m) {
                       DrakeLcmInterface*>(),
              py::arg("channel"), py::arg("serializer"), py::arg("lcm"),
              // Keep alive: `self` keeps `DrakeLcmInterface` alive.
-             py::keep_alive<1, 3>(), doc.LcmPublisherSystem.ctor.doc)
+             py::keep_alive<1, 3>(), doc.LcmPublisherSystem.ctor.doc_4)
         .def("set_publish_period", &Class::set_publish_period,
              py::arg("period"), doc.LcmPublisherSystem.set_publish_period.doc);
   }
@@ -98,7 +98,7 @@ PYBIND11_MODULE(lcm, m) {
                       DrakeLcmInterface*>(),
              py::arg("channel"), py::arg("serializer"), py::arg("lcm"),
              // Keep alive: `self` keeps `DrakeLcmInterface` alive.
-             py::keep_alive<1, 3>(), doc.LcmSubscriberSystem.ctor.doc);
+             py::keep_alive<1, 3>(), doc.LcmSubscriberSystem.ctor.doc_3);
   }
 
   m.def("ConnectLcmScope", &ConnectLcmScope, py::arg("src"), py::arg("channel"),

--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -44,7 +44,7 @@ PYBIND11_MODULE(primitives, m) {
     DefineTemplateClassWithDefault<Adder<T>, LeafSystem<T>>(
         m, "Adder", GetPyParam<T>(), doc.Adder.doc)
         .def(py::init<int, int>(), py::arg("num_inputs"), py::arg("size"),
-             doc.Adder.ctor.doc);
+             doc.Adder.ctor.doc_2args);
 
     DefineTemplateClassWithDefault<AffineSystem<T>, LeafSystem<T>>(
         m, "AffineSystem", GetPyParam<T>(), doc.AffineSystem.doc)
@@ -56,33 +56,33 @@ PYBIND11_MODULE(primitives, m) {
                       const Eigen::Ref<const Eigen::VectorXd>&, double>(),
              py::arg("A"), py::arg("B"), py::arg("f0"), py::arg("C"),
              py::arg("D"), py::arg("y0"), py::arg("time_period") = 0.0,
-             doc.AffineSystem.ctor.doc_3)
+             doc.AffineSystem.ctor.doc_7args)
         // TODO(eric.cousineau): Fix these to return references instead of
         // copies.
         .def("A",
              overload_cast_explicit<const Eigen::MatrixXd&>(  // BR
                  &AffineSystem<T>::A),
-             doc.AffineSystem.A.doc)
+             doc.AffineSystem.A.doc_0args)
         .def("B",
              overload_cast_explicit<const Eigen::MatrixXd&>(  // BR
                  &AffineSystem<T>::B),
-             doc.AffineSystem.B.doc)
+             doc.AffineSystem.B.doc_0args)
         .def("f0",
              overload_cast_explicit<const Eigen::VectorXd&>(  // BR
                  &AffineSystem<T>::f0),
-             doc.AffineSystem.f0.doc)
+             doc.AffineSystem.f0.doc_0args)
         .def("C",
              overload_cast_explicit<const Eigen::MatrixXd&>(  // BR
                  &AffineSystem<T>::C),
-             doc.AffineSystem.C.doc)
+             doc.AffineSystem.C.doc_0args)
         .def("D",
              overload_cast_explicit<const Eigen::MatrixXd&>(  // BR
                  &AffineSystem<T>::D),
-             doc.AffineSystem.D.doc)
+             doc.AffineSystem.D.doc_0args)
         .def("y0",
              overload_cast_explicit<const Eigen::VectorXd&>(  // BR
                  &AffineSystem<T>::y0),
-             doc.AffineSystem.y0.doc)
+             doc.AffineSystem.y0.doc_0args)
         .def("time_period", &AffineSystem<T>::time_period,
              doc.TimeVaryingAffineSystem.time_period.doc);
 
@@ -99,15 +99,16 @@ PYBIND11_MODULE(primitives, m) {
     DefineTemplateClassWithDefault<Demultiplexer<T>, LeafSystem<T>>(
         m, "Demultiplexer", GetPyParam<T>(), doc.Demultiplexer.doc)
         .def(py::init<int, int>(), py::arg("size"),
-             py::arg("output_ports_sizes") = 1, doc.Demultiplexer.ctor.doc_3);
+             py::arg("output_ports_sizes") = 1,
+             doc.Demultiplexer.ctor.doc_2args);
 
     DefineTemplateClassWithDefault<FirstOrderLowPassFilter<T>, LeafSystem<T>>(
         m, "FirstOrderLowPassFilter", GetPyParam<T>(),
         doc.FirstOrderLowPassFilter.doc)
         .def(py::init<double, int>(), py::arg("time_constant"),
-             py::arg("size") = 1, doc.FirstOrderLowPassFilter.ctor.doc_3)
+             py::arg("size") = 1, doc.FirstOrderLowPassFilter.ctor.doc_2args)
         .def(py::init<const VectorX<double>&>(), py::arg("time_constants"),
-             doc.FirstOrderLowPassFilter.ctor.doc_4)
+             doc.FirstOrderLowPassFilter.ctor.doc_1args)
         .def("get_time_constant",
              &FirstOrderLowPassFilter<T>::get_time_constant,
              doc.FirstOrderLowPassFilter.get_time_constant.doc)
@@ -121,13 +122,13 @@ PYBIND11_MODULE(primitives, m) {
     DefineTemplateClassWithDefault<Gain<T>, LeafSystem<T>>(
         m, "Gain", GetPyParam<T>(), doc.Gain.doc)
         .def(py::init<double, int>(), py::arg("k"), py::arg("size"),
-             doc.Gain.ctor.doc_3)
+             doc.Gain.ctor.doc)
         .def(py::init<const Eigen::Ref<const Eigen::VectorXd>&>(), py::arg("k"),
-             doc.Gain.ctor.doc_4);
+             doc.Gain.ctor.doc_3);
 
     DefineTemplateClassWithDefault<Integrator<T>, LeafSystem<T>>(
         m, "Integrator", GetPyParam<T>(), doc.Integrator.doc)
-        .def(py::init<int>(), doc.Integrator.ctor.doc_3);
+        .def(py::init<int>(), doc.Integrator.ctor.doc_0args);
 
     DefineTemplateClassWithDefault<LinearSystem<T>, AffineSystem<T>>(
         m, "LinearSystem", GetPyParam<T>(), doc.LinearSystem.doc)
@@ -136,7 +137,7 @@ PYBIND11_MODULE(primitives, m) {
                       const Eigen::Ref<const Eigen::MatrixXd>&,
                       const Eigen::Ref<const Eigen::MatrixXd>&, double>(),
              py::arg("A"), py::arg("B"), py::arg("C"), py::arg("D"),
-             py::arg("time_period") = 0.0, doc.LinearSystem.ctor.doc_3);
+             py::arg("time_period") = 0.0, doc.LinearSystem.ctor.doc_5args);
 
     DefineTemplateClassWithDefault<MatrixGain<T>, LinearSystem<T>>(
         m, "MatrixGain", GetPyParam<T>(), doc.MatrixGain.doc)
@@ -154,20 +155,20 @@ PYBIND11_MODULE(primitives, m) {
 
     DefineTemplateClassWithDefault<PassThrough<T>, LeafSystem<T>>(
         m, "PassThrough", GetPyParam<T>(), doc.PassThrough.doc)
-        .def(py::init<int>(), doc.PassThrough.ctor.doc_3)
-        .def(py::init<const AbstractValue&>(), doc.PassThrough.ctor.doc_4);
+        .def(py::init<int>(), doc.PassThrough.ctor.doc_4)
+        .def(py::init<const AbstractValue&>(), doc.PassThrough.ctor.doc_5);
 
     DefineTemplateClassWithDefault<Saturation<T>, LeafSystem<T>>(
         m, "Saturation", GetPyParam<T>(), doc.Saturation.doc)
         .def(py::init<const VectorX<T>&, const VectorX<T>&>(),
              py::arg("min_value"), py::arg("max_value"),
-             doc.Saturation.ctor.doc_3);
+             doc.Saturation.ctor.doc_2args);
 
     DefineTemplateClassWithDefault<SignalLogger<T>, LeafSystem<T>>(
         m, "SignalLogger", GetPyParam<T>(), doc.SignalLogger.doc)
         .def(py::init<int, int>(), py::arg("input_size"),
              py::arg("batch_allocation_size") = 1000,
-             doc.SignalLogger.ctor.doc_3)
+             doc.SignalLogger.ctor.doc_2args)
         .def("sample_times", &SignalLogger<T>::sample_times,
              doc.SignalLogger.sample_times.doc)
         .def("data", &SignalLogger<T>::data, doc.SignalLogger.data.doc)
@@ -175,16 +176,16 @@ PYBIND11_MODULE(primitives, m) {
 
     DefineTemplateClassWithDefault<WrapToSystem<T>, LeafSystem<T>>(
         m, "WrapToSystem", GetPyParam<T>(), doc.WrapToSystem.doc)
-        .def(py::init<int>(), doc.WrapToSystem.ctor.doc_3)
+        .def(py::init<int>(), doc.WrapToSystem.ctor.doc_1args)
         .def("set_interval", &WrapToSystem<T>::set_interval,
              doc.WrapToSystem.set_interval.doc);
 
     DefineTemplateClassWithDefault<ZeroOrderHold<T>, LeafSystem<T>>(
         m, "ZeroOrderHold", GetPyParam<T>(), doc.ZeroOrderHold.doc)
         .def(py::init<double, int>(), py::arg("period_sec"),
-             py::arg("vector_size"), doc.ZeroOrderHold.ctor.doc_3)
+             py::arg("vector_size"), doc.ZeroOrderHold.ctor.doc_4)
         .def(py::init<double, const AbstractValue&>(), py::arg("period_sec"),
-             py::arg("abstract_model_value"), doc.ZeroOrderHold.ctor.doc_4);
+             py::arg("abstract_model_value"), doc.ZeroOrderHold.ctor.doc_5);
   };
   type_visit(bind_common_scalar_types, pysystems::CommonScalarPack{});
 
@@ -192,7 +193,7 @@ PYBIND11_MODULE(primitives, m) {
       m, "BarycentricMeshSystem", doc.BarycentricMeshSystem.doc)
       .def(py::init<math::BarycentricMesh<double>,
                     const Eigen::Ref<const MatrixX<double>>&>(),
-           doc.BarycentricMeshSystem.ctor.doc_3)
+           doc.BarycentricMeshSystem.ctor.doc_2args)
       .def("get_mesh", &BarycentricMeshSystem<double>::get_mesh,
            doc.BarycentricMeshSystem.get_mesh.doc)
       .def("get_output_values",
@@ -221,7 +222,7 @@ PYBIND11_MODULE(primitives, m) {
       .def(py::init<const trajectories::Trajectory<double>&, int, bool>(),
            py::arg("trajectory"), py::arg("output_derivative_order") = 0,
            py::arg("zero_derivatives_beyond_limits") = true,
-           doc.TrajectorySource.ctor.doc_3);
+           doc.TrajectorySource.ctor.doc_3args);
 
   m.def("AddRandomInputs", &AddRandomInputs, py::arg("sampling_interval_sec"),
         py::arg("builder"), doc.AddRandomInputs.doc);

--- a/bindings/pydrake/systems/rendering_py.cc
+++ b/bindings/pydrake/systems/rendering_py.cc
@@ -31,11 +31,11 @@ PYBIND11_MODULE(rendering, m) {
   py::class_<PoseVector<T>, BasicVector<T>> pose_vector(m, "PoseVector",
                                                         doc.PoseVector.doc);
   pose_vector  // BR
-      .def(py::init(), doc.PoseVector.ctor.doc)
+      .def(py::init(), doc.PoseVector.ctor.doc_0args)
       .def(py::init<const Eigen::Quaternion<T>&,
                     const Eigen::Translation<T, 3>&>(),
            py::arg("rotation"), py::arg("translation"),
-           doc.PoseVector.ctor.doc_2)
+           doc.PoseVector.ctor.doc_2args)
       .def("get_isometry", &PoseVector<T>::get_isometry,
            doc.PoseVector.get_isometry.doc)
       .def("get_translation", &PoseVector<T>::get_translation,
@@ -52,9 +52,9 @@ PYBIND11_MODULE(rendering, m) {
   py::class_<FrameVelocity<T>, BasicVector<T>> frame_velocity(
       m, "FrameVelocity", doc.FrameVelocity.doc);
   frame_velocity  // BR
-      .def(py::init(), doc.FrameVelocity.ctor.doc)
+      .def(py::init(), doc.FrameVelocity.ctor.doc_0args)
       .def(py::init<const multibody::SpatialVelocity<T>&>(),
-           py::arg("velocity"), doc.FrameVelocity.ctor.doc_2)
+           py::arg("velocity"), doc.FrameVelocity.ctor.doc_1args)
       .def("get_velocity", &FrameVelocity<T>::get_velocity,
            doc.FrameVelocity.get_velocity.doc)
       .def("set_velocity", &FrameVelocity<T>::set_velocity, py::arg("velocity"),
@@ -63,7 +63,7 @@ PYBIND11_MODULE(rendering, m) {
   frame_velocity.attr("kSize") = int{FrameVelocity<T>::kSize};
 
   py::class_<PoseBundle<T>>(m, "PoseBundle", doc.PoseBundle.doc)
-      .def(py::init<int>(), py::arg("num_poses"), doc.PoseBundle.ctor.doc_3)
+      .def(py::init<int>(), py::arg("num_poses"), doc.PoseBundle.ctor.doc_1args)
       .def("get_num_poses", &PoseBundle<T>::get_num_poses,
            doc.PoseBundle.get_num_poses.doc)
       .def("get_pose", &PoseBundle<T>::get_pose, doc.PoseBundle.get_pose.doc)
@@ -112,7 +112,7 @@ PYBIND11_MODULE(rendering, m) {
       m, "MultibodyPositionToGeometryPose",
       doc.MultibodyPositionToGeometryPose.doc)
       .def(py::init<const multibody::multibody_plant::MultibodyPlant<T>&>(),
-           doc.MultibodyPositionToGeometryPose.ctor.doc_3)
+           doc.MultibodyPositionToGeometryPose.ctor.doc_1args)
       .def("get_input_port",
            &MultibodyPositionToGeometryPose<T>::get_input_port,
            py_reference_internal,

--- a/bindings/pydrake/systems/sensors_py.cc
+++ b/bindings/pydrake/systems/sensors_py.cc
@@ -112,8 +112,8 @@ PYBIND11_MODULE(sensors, m) {
 
       py::class_<ImageT> image(m, TemporaryClassName<ImageT>().c_str());
       image  // BR
-          .def(py::init<int, int>(), doc.Image.ctor.doc_3)
-          .def(py::init<int, int, T>(), doc.Image.ctor.doc_4)
+          .def(py::init<int, int>(), doc.Image.ctor.doc_2args)
+          .def(py::init<int, int, T>(), doc.Image.ctor.doc_3args)
           .def("width", &ImageT::width, doc.Image.width.doc)
           .def("height", &ImageT::height, doc.Image.height.doc)
           .def("size", &ImageT::size, doc.Image.size.doc)
@@ -160,11 +160,11 @@ PYBIND11_MODULE(sensors, m) {
   // Systems.
   py::class_<CameraInfo>(m, "CameraInfo", doc.CameraInfo.doc)
       .def(py::init<int, int, double>(), py::arg("width"), py::arg("height"),
-           py::arg("fov_y"), doc.CameraInfo.ctor.doc_4)
+           py::arg("fov_y"), doc.CameraInfo.ctor.doc_3args)
       .def(py::init<int, int, double, double, double, double>(),
            py::arg("width"), py::arg("height"), py::arg("focal_x"),
            py::arg("focal_y"), py::arg("center_x"), py::arg("center_y"),
-           doc.CameraInfo.ctor.doc_3)
+           doc.CameraInfo.ctor.doc_6args)
       .def("width", &CameraInfo::width, doc.CameraInfo.width.doc)
       .def("height", &CameraInfo::height, doc.CameraInfo.height.doc)
       .def("focal_x", &CameraInfo::focal_x, doc.CameraInfo.focal_x.doc)
@@ -203,7 +203,7 @@ PYBIND11_MODULE(sensors, m) {
            py::arg("width") = int{RenderingConfig::kDefaultWidth},
            py::arg("height") = int{RenderingConfig::kDefaultHeight},
            // Keep alive, reference: `this` keeps  `RigidBodyTree` alive.
-           py::keep_alive<1, 3>(), doc.RgbdCamera.ctor.doc_3)
+           py::keep_alive<1, 3>(), doc.RgbdCamera.ctor.doc_10args)
       .def("color_camera_info", &RgbdCamera::color_camera_info,
            py_reference_internal, doc.RgbdCamera.color_camera_info.doc)
       .def("depth_camera_info", &RgbdCamera::depth_camera_info,
@@ -226,7 +226,7 @@ PYBIND11_MODULE(sensors, m) {
            py::arg("period") = double{RgbdCameraDiscrete::kDefaultPeriod},
            py::arg("render_label_image") = true,
            // Keep alive, ownership: `RgbdCamera` keeps `this` alive.
-           py::keep_alive<2, 1>(), doc.RgbdCameraDiscrete.ctor.doc_3)
+           py::keep_alive<2, 1>(), doc.RgbdCameraDiscrete.ctor.doc_3args)
       // N.B. Since `camera` is already connected, we do not need additional
       // `keep_alive`s.
       .def("camera", &RgbdCameraDiscrete::camera,

--- a/bindings/pydrake/systems/trajectory_optimization_py.cc
+++ b/bindings/pydrake/systems/trajectory_optimization_py.cc
@@ -38,11 +38,11 @@ PYBIND11_MODULE(trajectory_optimization, m) {
            [](const MultipleShooting& self) -> VectorXDecisionVariable {
              return self.state();
            },
-           doc.MultipleShooting.state.doc)
+           doc.MultipleShooting.state.doc_0args)
       .def("state",
            [](const MultipleShooting& self, int index)
                -> VectorXDecisionVariable { return self.state(index); },
-           doc.MultipleShooting.state.doc_2)
+           doc.MultipleShooting.state.doc_1args)
       .def("initial_state",
            [](const MultipleShooting& self) -> VectorXDecisionVariable {
              return self.initial_state();
@@ -57,22 +57,22 @@ PYBIND11_MODULE(trajectory_optimization, m) {
            [](const MultipleShooting& self) -> VectorXDecisionVariable {
              return self.input();
            },
-           doc.MultipleShooting.input.doc)
+           doc.MultipleShooting.input.doc_0args)
       .def("input",
            [](const MultipleShooting& self, int index)
                -> VectorXDecisionVariable { return self.input(index); },
-           doc.MultipleShooting.input.doc_2)
+           doc.MultipleShooting.input.doc_1args)
       .def("AddRunningCost",
            [](MultipleShooting& prog, const symbolic::Expression& g) {
              prog.AddRunningCost(g);
            },
-           doc.MultipleShooting.AddRunningCost.doc)
+           doc.MultipleShooting.AddRunningCost.doc_1args)
       .def("AddRunningCost",
            [](MultipleShooting& prog,
               const Eigen::Ref<const MatrixX<symbolic::Expression>>& g) {
              prog.AddRunningCost(g);
            },
-           doc.MultipleShooting.AddRunningCost.doc_2)
+           doc.MultipleShooting.AddRunningCost.doc_0args)
       .def("AddConstraintToAllKnotPoints",
            &MultipleShooting::AddConstraintToAllKnotPoints,
            doc.MultipleShooting.AddConstraintToAllKnotPoints.doc)
@@ -103,7 +103,7 @@ PYBIND11_MODULE(trajectory_optimization, m) {
       .def("GetSampleTimes",
            overload_cast_explicit<Eigen::VectorXd>(
                &MultipleShooting::GetSampleTimes),
-           doc.MultipleShooting.GetSampleTimes.doc)
+           doc.MultipleShooting.GetSampleTimes.doc_0args)
       .def("GetInputSamples", &MultipleShooting::GetInputSamples,
            doc.MultipleShooting.GetInputSamples.doc)
       .def("GetStateSamples", &MultipleShooting::GetStateSamples,
@@ -121,7 +121,7 @@ PYBIND11_MODULE(trajectory_optimization, m) {
                     const systems::Context<double>&, int, double, double>(),
            py::arg("system"), py::arg("context"), py::arg("num_time_samples"),
            py::arg("minimum_timestep"), py::arg("maximum_timestep"),
-           doc.DirectCollocation.ctor.doc)
+           doc.DirectCollocation.ctor.doc_5args)
       .def("ReconstructInputTrajectory",
            &DirectCollocation::ReconstructInputTrajectory,
            doc.DirectCollocation.ReconstructInputTrajectory.doc)
@@ -134,7 +134,7 @@ PYBIND11_MODULE(trajectory_optimization, m) {
       m, "DirectCollocationConstraint", doc.DirectCollocationConstraint.doc)
       .def(py::init<const systems::System<double>&,
                     const systems::Context<double>&>(),
-           doc.DirectCollocationConstraint.ctor.doc_3);
+           doc.DirectCollocationConstraint.ctor.doc_2args);
 
   m.def("AddDirectCollocationConstraint", &AddDirectCollocationConstraint,
         py::arg("constraint"), py::arg("timestep"), py::arg("state"),

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -27,19 +27,19 @@ PYBIND11_MODULE(trajectories, m) {
       .def("start_time",
            overload_cast_explicit<double, int>(
                &PiecewiseTrajectory<T>::start_time),
-           doc.PiecewiseTrajectory.start_time.doc)
+           doc.PiecewiseTrajectory.start_time.doc_1args)
       .def("end_time",
            overload_cast_explicit<double, int>(
                &PiecewiseTrajectory<T>::end_time),
-           doc.PiecewiseTrajectory.end_time.doc)
+           doc.PiecewiseTrajectory.end_time.doc_1args)
       .def("duration", &PiecewiseTrajectory<T>::duration,
            doc.PiecewiseTrajectory.duration.doc)
       .def("start_time",
            overload_cast_explicit<double>(&PiecewiseTrajectory<T>::start_time),
-           doc.PiecewiseTrajectory.start_time.doc)
+           doc.PiecewiseTrajectory.start_time.doc_0args)
       .def("end_time",
            overload_cast_explicit<double>(&PiecewiseTrajectory<T>::end_time),
-           doc.PiecewiseTrajectory.end_time.doc)
+           doc.PiecewiseTrajectory.end_time.doc_0args)
       .def("get_segment_index", &PiecewiseTrajectory<T>::get_segment_index,
            doc.PiecewiseTrajectory.get_segment_index.doc)
       .def("get_segment_times", &PiecewiseTrajectory<T>::get_segment_times,

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.h
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.h
@@ -315,9 +315,6 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   ///       i.e., O(1) time complexity, and runs very quickly.
   /// @throws std::exception if the `context` does not
   /// correspond to the context for a multibody model.
-  // *** WARNING *** Auto-generated Python documentation assumes a fixed
-  // ordering of the overloaded methods. Change this ordering only if you change
-  // the associated Python documentation.
   Eigen::VectorBlock<const VectorX<T>> GetPositionsAndVelocities(
       const systems::Context<T>& context) const {
     return tree().GetPositionsAndVelocities(context);
@@ -330,9 +327,6 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   /// for a multibody model or `model_instance` is invalid.
   /// @note returns a dense vector of dimension `q.size() + v.size()` associated
   ///          with `model_instance` in O(`q.size()`) time.
-  // *** WARNING *** Auto-generated Python documentation assumes a fixed
-  // ordering of the overloaded methods. Change this ordering only if you change
-  // the associated Python documentation.
   VectorX<T> GetPositionsAndVelocities(
       const systems::Context<T>& context,
       ModelInstanceIndex model_instance) const {
@@ -357,9 +351,6 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   /// @throws std::exception if the `context` is nullptr, if the context does
   /// not correspond to the context for a multibody model, or if the length of
   /// `q_v` is not equal to `num_positions() + num_velocities()`.
-  // *** WARNING *** Auto-generated Python documentation assumes a fixed
-  // ordering of the overloaded methods. Change this ordering only if you change
-  // the associated Python documentation.
   void SetPositionsAndVelocities(
       systems::Context<T>* context, const VectorX<T>& q_v) const {
     tree().GetMutablePositionsAndVelocities(context) = q_v;
@@ -371,9 +362,6 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   /// not correspond to the context for a multibody model, if the model instance
   /// index is invalid, or if the length of `q_v` is not equal to
   /// `num_positions(model_instance) + num_velocities(model_instance)`.
-  // *** WARNING *** Auto-generated Python documentation assumes a fixed
-  // ordering of the overloaded methods. Change this ordering only if you change
-  // the associated Python documentation.
   void SetPositionsAndVelocities(
       systems::Context<T>* context, ModelInstanceIndex model_instance,
       const VectorX<T>& q_v) const {
@@ -386,9 +374,6 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   ///       i.e., O(1) time complexity, and runs very quickly.
   /// @throws std::exception if the `context` does not
   /// correspond to the context for a multibody model.
-  // *** WARNING *** Auto-generated Python documentation assumes a fixed
-  // ordering of the overloaded methods. Change this ordering only if you change
-  // the associated Python documentation.
   Eigen::VectorBlock<const VectorX<T>> GetPositions(
       const systems::Context<T>& context) const {
     // Note: the nestedExpression() is necessary to treat the VectorBlock<T>
@@ -404,9 +389,6 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   /// correspond to the context for a multibody model.
   /// @note returns a dense vector of dimension `q.size()` associated with
   ///          `model_instance` in O(`q.size()`) time.
-  // *** WARNING *** Auto-generated Python documentation assumes a fixed
-  // ordering of the overloaded methods. Change this ordering only if you change
-  // the associated Python documentation.
   VectorX<T> GetPositions(
       const systems::Context<T>& context,
       ModelInstanceIndex model_instance) const {
@@ -436,9 +418,6 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   /// @throws std::exception if the `context` is nullptr, if the context does
   /// not correspond to the context for a multibody model, or if the length of
   /// `q` is not equal to `num_positions()`.
-  // *** WARNING *** Auto-generated Python documentation assumes a fixed
-  // ordering of the overloaded methods. Change this ordering only if you change
-  // the associated Python documentation.
   void SetPositions(systems::Context<T>* context, const VectorX<T>& q) const {
     GetMutablePositions(context) = q;
   }
@@ -448,9 +427,6 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   /// not correspond to the context for a multibody model, if the model instance
   /// index is invalid, or if the length of `q_instance` is not equal to
   /// `num_positions(model_instance)`.
-  // *** WARNING *** Auto-generated Python documentation assumes a fixed
-  // ordering of the overloaded methods. Change this ordering only if you change
-  // the associated Python documentation.
   void SetPositions(
       systems::Context<T>* context,
       ModelInstanceIndex model_instance, const VectorX<T>& q_instance) const {
@@ -461,9 +437,6 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   /// Returns a const vector reference containing the generalized velocities.
   /// @note This method returns a reference to existing data, exhibits constant
   ///       i.e., O(1) time complexity, and runs very quickly.
-  // *** WARNING *** Auto-generated Python documentation assumes a fixed
-  // ordering of the overloaded methods. Change this ordering only if you change
-  // the associated Python documentation.
   Eigen::VectorBlock<const VectorX<T>> GetVelocities(
       const systems::Context<T>& context) const {
     // Note: the nestedExpression() is necessary to treat the VectorBlock<T>
@@ -479,9 +452,6 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   /// correspond to the context for a multibody model.
   /// @note returns a dense vector of dimension `v.size()` associated with
   ///          `model_instance` in O(`v.size()`) time.
-  // *** WARNING *** Auto-generated Python documentation assumes a fixed
-  // ordering of the overloaded methods. Change this ordering only if you change
-  // the associated Python documentation.
   VectorX<T> GetVelocities(
       const systems::Context<T>& context,
       ModelInstanceIndex model_instance) const {
@@ -511,9 +481,6 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   /// @throws std::exception if the `context` is nullptr, if the context does
   /// not correspond to the context for a multibody model, or if the length of
   /// `v` is not equal to `num_velocities()`.
-  // *** WARNING *** Auto-generated Python documentation assumes a fixed
-  // ordering of the overloaded methods. Change this ordering only if you change
-  // the associated Python documentation.
   void SetVelocities(systems::Context<T>* context, const VectorX<T>& v) const {
     GetMutableVelocities(context) = v;
   }
@@ -524,9 +491,6 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   /// not correspond to the context for a multibody model, if the model instance
   /// index is invalid, or if the length of `v_instance` is not equal to
   /// `num_velocities(model_instance)`.
-  // *** WARNING *** Auto-generated Python documentation assumes a fixed
-  // ordering of the overloaded methods. Change this ordering only if you change
-  // the associated Python documentation.
   void SetVelocities(
       systems::Context<T>* context,
       ModelInstanceIndex model_instance, const VectorX<T>& v_instance) const {

--- a/third_party/com_github_pybind_pybind11/mkdoc.py
+++ b/third_party/com_github_pybind_pybind11/mkdoc.py
@@ -658,6 +658,44 @@ def extract(include_file_map, cursor, symbol_tree):
             node.doc_symbols.append(symbol)
 
 
+def choose_doc_var_names(symbols):
+    """
+    Given a list of Symbol objects for a single doc struct, choose unambiguous,
+    meaningful, terse names for them.
+    """
+    result = []
+
+    def specialize_well_known_doc_var_names():
+        # Force well-known methods to have well-known names.
+        nonlocal symbols, result
+        for i, sym in enumerate(symbols):
+            if sym.cursor.is_copy_constructor():
+                result[i] = "doc_copy"
+            elif sym.cursor.is_move_constructor():
+                result[i] = "doc_move"
+
+    # No salt will be needed if there is only one name -- but we should still
+    # apply the well-known name heuristics.
+    result = ["doc" for _ in symbols]
+    specialize_well_known_doc_var_names()
+    if len(symbols) <= 1:
+        return result
+
+    # The argument count might be sufficient to disambiguate.
+    # TODO(jwnimmer-tri) Methods with enable_if sometimes report as 0args.
+    args = [list(x.cursor.get_arguments()) for x in symbols]
+    result = ["doc_{}args".format(len(x)) for x in args]
+    specialize_well_known_doc_var_names()
+    if len(result) == len(set(result)):
+        return result
+
+    # As a last resort, fall back to doc, doc_1, doc_2, etc.
+    result = ["doc"] + ["doc_{}".format(i + 1) for i in range(1, len(symbols))]
+    specialize_well_known_doc_var_names()
+    assert len(result) == len(set(result))
+    return result
+
+
 def print_symbols(f, name, node, level=0):
     """
     Prints C++ code for releveant documentation.
@@ -689,11 +727,9 @@ def print_symbols(f, name, node, level=0):
     iprint('{}struct /* {} */ {{'.format(modifier, name_var))
     # Print documentation items.
     symbol_iter = sorted(node.doc_symbols, key=Symbol.sorting_key)
-    for i, symbol in enumerate(symbol_iter):
+    doc_vars = choose_doc_var_names(symbol_iter)
+    for symbol, doc_var in zip(symbol_iter, doc_vars):
         assert name_chain == symbol.name_chain
-        doc_var = "doc"
-        if i > 0:
-            doc_var += "_{}".format(i + 1)
         delim = "\n"
         if "\n" not in symbol.comment and len(symbol.comment) < 40:
             delim = " "

--- a/tools/workspace/pybind11/test/sample_header_documentation.expected.h
+++ b/tools/workspace/pybind11/test/sample_header_documentation.expected.h
@@ -115,13 +115,13 @@ See also:
         // Symbol: drake::mkdoc_test::Class::Class
         struct /* ctor */ {
           // Source: drake/tools/workspace/pybind11/test/sample_header.h:125
-          const char* doc = R"""()""";
+          const char* doc_copy = R"""()""";
           // Source: drake/tools/workspace/pybind11/test/sample_header.h:125
-          const char* doc_2 = R"""()""";
+          const char* doc_move = R"""()""";
           // Source: drake/tools/workspace/pybind11/test/sample_header.h:146
-          const char* doc_3 = R"""(Custom constructor 1.)""";
+          const char* doc_0args = R"""(Custom constructor 1.)""";
           // Source: drake/tools/workspace/pybind11/test/sample_header.h:159
-          const char* doc_4 =
+          const char* doc_1args =
 R"""(Custom constructor 2. *Italics*. Ut tristique et egestas quis ipsum
 suspendisse ultrices gravida. ``Typewriter``. Suscipit tellus mauris a
 diam. Maecenas accumsan lacus vel facilisis volutpat est.
@@ -138,7 +138,7 @@ Ut consequat semper viverra nam libero.
     Class class();
     class.PublicMethod();)""";
           // Source: drake/tools/workspace/pybind11/test/sample_header.h:172
-          const char* doc_5 =
+          const char* doc_2args =
 R"""(Custom constructor 3. *Italics*. Integer quis auctor elit sed
 vulputate mi sit.
 

--- a/tools/workspace/pybind11/test/sample_header_documentation_cc_test.cc
+++ b/tools/workspace/pybind11/test/sample_header_documentation_cc_test.cc
@@ -7,7 +7,7 @@ namespace {
 // Mostly, this just checks for compilation failures.
 GTEST_TEST(TestHeaderDocumentation, ExistenceTest) {
   EXPECT_EQ(
-      sample_header_doc.drake.mkdoc_test.Class.ctor.doc_3,
+      sample_header_doc.drake.mkdoc_test.Class.ctor.doc_0args,
       "Custom constructor 1.");
 }
 


### PR DESCRIPTION
Relates #10031 and #10017.

This is a partial solution, covering about 75% of the cases.  Future work will iterate on the methods where arity isn't enough to disambiguate.

There is a known issue with enable_if arity, as noted in the TODO.  This shows up in a few of the MathematicalProgram overloads, for example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10032)
<!-- Reviewable:end -->
