### PR TITLE
Some small cleanups to the Event API

### DIFF
--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -939,7 +939,7 @@ bool Simulator<T>::IntegrateContinuousState(
       auto& event = witness_function_events_[fn];
       if (!event) {
         event = fn->get_event()->Clone();
-        event->set_trigger_type(Event<T>::TriggerType::kWitness);
+        event->set_trigger_type(TriggerType::kWitness);
         event->set_event_data(std::make_unique<WitnessTriggeredEventData<T>>());
       }
 

--- a/systems/analysis/test/simulator_test.cc
+++ b/systems/analysis/test/simulator_test.cc
@@ -962,8 +962,8 @@ class UnrestrictedUpdater : public LeafSystem<double> {
     const double inf = std::numeric_limits<double>::infinity();
     *time = (context.get_time() < t_upd_) ? t_upd_ : inf;
     UnrestrictedUpdateEvent<double> event(
-        Event<double>::TriggerType::kPeriodic);
-    event.add_to_composite(event_info);
+        TriggerType::kPeriodic);
+    event.AddToComposite(event_info);
   }
 
   void DoCalcUnrestrictedUpdate(
@@ -1479,18 +1479,18 @@ GTEST_TEST(SimulatorTest, PerStepAction) {
     }
 
     void AddPerStepPublishEvent() {
-      PublishEvent<double> event(Event<double>::TriggerType::kPerStep);
+      PublishEvent<double> event(TriggerType::kPerStep);
       this->DeclarePerStepEvent(event);
     }
 
     void AddPerStepDiscreteUpdateEvent() {
-      DiscreteUpdateEvent<double> event(Event<double>::TriggerType::kPerStep);
+      DiscreteUpdateEvent<double> event(TriggerType::kPerStep);
       this->DeclarePerStepEvent(event);
     }
 
     void AddPerStepUnrestrictedUpdateEvent() {
       UnrestrictedUpdateEvent<double> event(
-          Event<double>::TriggerType::kPerStep);
+          TriggerType::kPerStep);
       this->DeclarePerStepEvent(event);
     }
 
@@ -1599,20 +1599,20 @@ GTEST_TEST(SimulatorTest, Initialization) {
    public:
     InitializationTestSystem() {
       PublishEvent<double> pub_event(
-          Event<double>::TriggerType::kInitialization,
+          TriggerType::kInitialization,
           std::bind(&InitializationTestSystem::InitPublish, this,
                     std::placeholders::_1, std::placeholders::_2));
       DeclareInitializationEvent(pub_event);
 
       DeclareInitializationEvent(DiscreteUpdateEvent<double>(
-          Event<double>::TriggerType::kInitialization));
+          TriggerType::kInitialization));
       DeclareInitializationEvent(UnrestrictedUpdateEvent<double>(
-          Event<double>::TriggerType::kInitialization));
+          TriggerType::kInitialization));
 
       DeclarePeriodicDiscreteUpdate(0.1);
       DeclarePerStepEvent<UnrestrictedUpdateEvent<double>>(
           UnrestrictedUpdateEvent<double>(
-              Event<double>::TriggerType::kPerStep));
+              TriggerType::kPerStep));
     }
 
     bool get_pub_init() const { return pub_init_; }
@@ -1624,7 +1624,7 @@ GTEST_TEST(SimulatorTest, Initialization) {
                      const PublishEvent<double>& event) const {
       EXPECT_EQ(context.get_time(), 0);
       EXPECT_EQ(event.get_trigger_type(),
-                Event<double>::TriggerType::kInitialization);
+                TriggerType::kInitialization);
       pub_init_ = true;
     }
 
@@ -1634,7 +1634,7 @@ GTEST_TEST(SimulatorTest, Initialization) {
         DiscreteValues<double>*) const final {
       EXPECT_EQ(events.size(), 1);
       if (events.front()->get_trigger_type() ==
-          Event<double>::TriggerType::kInitialization) {
+          TriggerType::kInitialization) {
         EXPECT_EQ(context.get_time(), 0);
         dis_update_init_ = true;
       } else {
@@ -1648,7 +1648,7 @@ GTEST_TEST(SimulatorTest, Initialization) {
         State<double>*) const final {
       EXPECT_EQ(events.size(), 1);
       if (events.front()->get_trigger_type() ==
-          Event<double>::TriggerType::kInitialization) {
+          TriggerType::kInitialization) {
         EXPECT_EQ(context.get_time(), 0);
         unres_update_init_ = true;
       } else {

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -630,7 +630,7 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
     data->set_xcf(DoGetTargetSystemContinuousState(subsystem, diagram_xcf));
 
     // Add the event to the collection.
-    event->add_to_composite(&subevents);
+    event->AddToComposite(&subevents);
   }
 
   /// Provides witness functions of subsystems that are active at the beginning

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -351,7 +351,7 @@ class LeafSystem : public System<T> {
     DRAKE_DEMAND(dynamic_cast<const WitnessTriggeredEventData<T>*>(
         event->get_event_data()));
     DRAKE_DEMAND(events);
-    event->add_to_composite(events);
+    event->AddToComposite(events);
   }
 
   /// Computes the next update time based on the configured periodic events, for
@@ -395,7 +395,7 @@ class LeafSystem : public System<T> {
     // Write out the events that fire at min_time.
     *time = min_time;
     for (const Event<T>* event : next_events) {
-      event->add_to_composite(events);
+      event->AddToComposite(events);
     }
   }
 
@@ -639,7 +639,7 @@ class LeafSystem : public System<T> {
   void DeclarePeriodicEvent(double period_sec, double offset_sec) {
     static_assert(std::is_base_of<Event<T>, EventType>::value,
                   "EventType must be a subclass of Event<T>.");
-    EventType event(Event<T>::TriggerType::kPeriodic);
+    EventType event(TriggerType::kPeriodic);
     PeriodicEventData periodic_data;
     periodic_data.set_period_sec(period_sec);
     periodic_data.set_offset_sec(offset_sec);
@@ -648,27 +648,32 @@ class LeafSystem : public System<T> {
   }
 
   /// Declares that this System has a simple, fixed-period event specified by
-  /// @p event. A deep copy of @p event will be made and maintained by `this`.
-  /// @p event's trigger type must be Event::TriggerType::kPeriodic or this
-  /// method aborts. The first tick will occur at t = @p offset_sec, and it
+  /// @p event. The first tick will occur at t = @p offset_sec, and it
   /// will recur at every @p period_sec thereafter. Note that the periodic
   /// events returned by system::CalcNextUpdateTime() will happen at a time
   /// strictly after the querying time. E.g. if there is a periodic event with
   /// offset = 0 and period = 5, when calling CalcNextUpdateTime() at t = 0,
   /// the returned event will happen at t = 5 not t = 0.
   ///
-  /// Note that @p event's attribute field is preserved.
+  /// A deep copy of @p event will be made and maintained by `this`. The
+  /// trigger type in the clone will be set to kPeriodic, unless it is already
+  /// set in the source @p event in which case it must be kPeriodic already.
+  /// The @p event's attribute field is preserved.
   ///
   /// @tparam EventType A class derived from Event (e.g., PublishEvent,
   /// DiscreteUpdateEvent, UnrestrictedUpdateEvent, etc.)
   template <typename EventType>
   void DeclarePeriodicEvent(double period_sec, double offset_sec,
-      const EventType& event) {
-    DRAKE_DEMAND(event.get_trigger_type() == Event<T>::TriggerType::kPeriodic);
+                            const EventType& event) {
+    DRAKE_DEMAND(event.get_trigger_type() == TriggerType::kUnknown ||
+                 event.get_trigger_type() == TriggerType::kPeriodic);
     PeriodicEventData periodic_data;
     periodic_data.set_period_sec(period_sec);
     periodic_data.set_offset_sec(offset_sec);
-    periodic_events_.push_back(std::make_pair(periodic_data, event.Clone()));
+    auto event_copy = event.Clone();
+    event_copy->set_trigger_type(TriggerType::kPeriodic);
+    periodic_events_.emplace_back(
+        std::make_pair(periodic_data, std::move(event_copy)));
   }
 
   /// Declares a periodic discrete update event with period = @p period_sec and
@@ -701,21 +706,22 @@ class LeafSystem : public System<T> {
 
   /// Declares a per-step event using @p event, which is deep copied (the
   /// copy is maintained by `this`). @p event's associated trigger type must be
-  /// set to Event::TriggerType::kPerStep. Aborts otherwise.
+  /// unknown or already set to Event::TriggerType::kPerStep. Aborts otherwise.
   template <typename EventType>
   void DeclarePerStepEvent(const EventType& event) {
-    DRAKE_DEMAND(event.get_trigger_type() == Event<T>::TriggerType::kPerStep);
-    event.add_to_composite(&per_step_events_);
+    DRAKE_DEMAND(event.get_trigger_type() == TriggerType::kUnknown ||
+        event.get_trigger_type() == TriggerType::kPerStep);
+    event.AddToComposite(TriggerType::kPerStep, &per_step_events_);
   }
 
   /// Declares an initialization event by deep copying @p event and storing it
-  /// internally. @p event's associated trigger type must be
-  /// Event::TriggerType::kInitialization. Aborts otherwise.
+  /// internally. @p event's associated trigger type must be unknown or already
+  /// set to Event::TriggerType::kInitialization. Aborts otherwise.
   template <typename EventType>
   void DeclareInitializationEvent(const EventType& event) {
-    DRAKE_DEMAND(event.get_trigger_type() ==
-                 Event<T>::TriggerType::kInitialization);
-    event.add_to_composite(&initialization_events_);
+    DRAKE_DEMAND(event.get_trigger_type() == TriggerType::kUnknown ||
+        event.get_trigger_type() == TriggerType::kInitialization);
+    event.AddToComposite(TriggerType::kInitialization, &initialization_events_);
   }
 
   /// Declares that this System should reserve continuous state with
@@ -1322,7 +1328,7 @@ class LeafSystem : public System<T> {
       return (system_ptr->*publish_callback)(context, publish_event);
     };
     PublishEvent<T> publish_event(fn);
-    publish_event.set_trigger_type(Event<T>::TriggerType::kWitness);
+    publish_event.set_trigger_type(TriggerType::kWitness);
     return std::make_unique<WitnessFunction<T>>(
         this, description, direction_type, calc, publish_event.Clone());
   }
@@ -1346,7 +1352,7 @@ class LeafSystem : public System<T> {
       return (system_ptr->*du_callback)(context, du_event, values);
     };
     DiscreteUpdateEvent<T> du_event(fn);
-    du_event.set_trigger_type(Event<T>::TriggerType::kWitness);
+    du_event.set_trigger_type(TriggerType::kWitness);
     return std::make_unique<WitnessFunction<T>>(
         this, description, direction_type, calc, du_event.Clone());
   }
@@ -1370,7 +1376,7 @@ class LeafSystem : public System<T> {
       return (system_ptr->*uu_callback)(context, uu_event, state);
     };
     UnrestrictedUpdateEvent<T> uu_event(fn);
-    uu_event.set_trigger_type(Event<T>::TriggerType::kWitness);
+    uu_event.set_trigger_type(TriggerType::kWitness);
     return std::make_unique<WitnessFunction<T>>(
         this, description, direction_type, calc, uu_event.Clone());
   }

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -2338,11 +2338,7 @@ class PerStepActionTestSystem : public LeafSystem<double> {
     DeclareAbstractState(AbstractValue::Make<std::string>(""));
   }
 
-  template <typename EventType>
-  void AddPerStepEvent() {
-    EventType event(Event<double>::TriggerType::kPerStep);
-    this->DeclarePerStepEvent(event);
-  }
+  using LeafSystem<double>::DeclarePerStepEvent;
 
   int get_publish_ctr() const { return publish_ctr_; }
 
@@ -2398,8 +2394,8 @@ GTEST_TEST(DiagramPerStepActionTest, TestEverything) {
     sys1 = builder.AddSystem<PerStepActionTestSystem>();
     sys1->set_name("sys1");
 
-    sys1->AddPerStepEvent<DiscreteUpdateEvent<double>>();
-    sys1->AddPerStepEvent<UnrestrictedUpdateEvent<double>>();
+    sys1->DeclarePerStepEvent(DiscreteUpdateEvent<double>());
+    sys1->DeclarePerStepEvent(UnrestrictedUpdateEvent<double>());
 
     sub_diagram = builder.Build();
     sub_diagram->set_name("sub_diagram");
@@ -2411,8 +2407,8 @@ GTEST_TEST(DiagramPerStepActionTest, TestEverything) {
   sys2->set_name("sys2");
 
   // sys2 has publish and unrestricted updates.
-  sys2->AddPerStepEvent<PublishEvent<double>>();
-  sys2->AddPerStepEvent<UnrestrictedUpdateEvent<double>>();
+  sys2->DeclarePerStepEvent(PublishEvent<double>());
+  sys2->DeclarePerStepEvent(UnrestrictedUpdateEvent<double>());
 
   auto diagram = builder.Build();
   auto context = diagram->CreateDefaultContext();
@@ -2471,7 +2467,7 @@ class MyEventTestSystem : public LeafSystem<double> {
       EXPECT_FALSE(this->GetUniquePeriodicDiscreteUpdateAttribute());
     } else {
       DeclarePerStepEvent<PublishEvent<double>>(
-          PublishEvent<double>(Event<double>::TriggerType::kPerStep));
+          PublishEvent<double>(TriggerType::kPerStep));
     }
     set_name(name);
   }
@@ -2486,10 +2482,10 @@ class MyEventTestSystem : public LeafSystem<double> {
       const std::vector<const PublishEvent<double>*>& events) const override {
     for (const PublishEvent<double>* event : events) {
       if (event->get_trigger_type() ==
-          Event<double>::TriggerType::kPeriodic) {
+          TriggerType::kPeriodic) {
         periodic_count_++;
       } else if (event->get_trigger_type() ==
-          Event<double>::TriggerType::kPerStep) {
+          TriggerType::kPerStep) {
         per_step_count_++;
       } else {
         DRAKE_ABORT();
@@ -2834,15 +2830,15 @@ GTEST_TEST(InitializationTest, InitializationTest) {
    public:
     InitializationTestSystem() {
       PublishEvent<double> pub_event(
-          Event<double>::TriggerType::kInitialization,
+          TriggerType::kInitialization,
           std::bind(&InitializationTestSystem::InitPublish, this,
                     std::placeholders::_1, std::placeholders::_2));
       DeclareInitializationEvent(pub_event);
 
       DeclareInitializationEvent(DiscreteUpdateEvent<double>(
-          Event<double>::TriggerType::kInitialization));
+          TriggerType::kInitialization));
       DeclareInitializationEvent(UnrestrictedUpdateEvent<double>(
-          Event<double>::TriggerType::kInitialization));
+          TriggerType::kInitialization));
     }
 
     bool get_pub_init() const { return pub_init_; }
@@ -2853,7 +2849,7 @@ GTEST_TEST(InitializationTest, InitializationTest) {
     void InitPublish(const Context<double>&,
                      const PublishEvent<double>& event) const {
       EXPECT_EQ(event.get_trigger_type(),
-                Event<double>::TriggerType::kInitialization);
+                TriggerType::kInitialization);
       pub_init_ = true;
     }
 
@@ -2863,7 +2859,7 @@ GTEST_TEST(InitializationTest, InitializationTest) {
         DiscreteValues<double>*) const final {
       EXPECT_EQ(events.size(), 1);
       EXPECT_EQ(events.front()->get_trigger_type(),
-                Event<double>::TriggerType::kInitialization);
+                TriggerType::kInitialization);
       dis_update_init_ = true;
     }
 
@@ -2873,7 +2869,7 @@ GTEST_TEST(InitializationTest, InitializationTest) {
         State<double>*) const final {
       EXPECT_EQ(events.size(), 1);
       EXPECT_EQ(events.front()->get_trigger_type(),
-                Event<double>::TriggerType::kInitialization);
+                TriggerType::kInitialization);
       unres_update_init_ = true;
     }
 

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -45,6 +45,7 @@ class TestSystem : public LeafSystem<T> {
   using LeafSystem<T>::DeclareAbstractInputPort;
   using LeafSystem<T>::DeclareVectorOutputPort;
   using LeafSystem<T>::DeclareAbstractOutputPort;
+  using LeafSystem<T>::DeclarePerStepEvent;
 
   void AddPeriodicUpdate() {
     const double period = 10.0;
@@ -76,12 +77,6 @@ class TestSystem : public LeafSystem<T> {
   }
 
   void AddPublish(double period) { this->DeclarePeriodicPublish(period); }
-
-  template <typename EventType>
-  void AddPerStepEvent() {
-    EventType event(Event<T>::TriggerType::kPerStep);
-    this->DeclarePerStepEvent(event);
-  }
 
   void DoCalcTimeDerivatives(const Context<T>& context,
                              ContinuousState<T>* derivatives) const override {}
@@ -355,8 +350,7 @@ TEST_F(LeafSystemTest, OffsetHasNotArrivedYet) {
   EXPECT_EQ(5.0, time);
   const auto& events = leaf_info_->get_discrete_update_events().get_events();
   EXPECT_EQ(events.size(), 1);
-  EXPECT_EQ(events.front()->get_trigger_type(),
-            Event<double>::TriggerType::kPeriodic);
+  EXPECT_EQ(events.front()->get_trigger_type(), TriggerType::kPeriodic);
 }
 
 // Tests that if the current time is smaller than the offset, the next
@@ -373,15 +367,13 @@ TEST_F(LeafSystemTest, EventsAtTheSameTime) {
   {
     const auto& events = leaf_info_->get_discrete_update_events().get_events();
     EXPECT_EQ(events.size(), 1);
-    EXPECT_EQ(events.front()->get_trigger_type(),
-              Event<double>::TriggerType::kPeriodic);
+    EXPECT_EQ(events.front()->get_trigger_type(), TriggerType::kPeriodic);
   }
   {
     const auto& events =
         leaf_info_->get_unrestricted_update_events().get_events();
     EXPECT_EQ(events.size(), 1);
-    EXPECT_EQ(events.front()->get_trigger_type(),
-              Event<double>::TriggerType::kPeriodic);
+    EXPECT_EQ(events.front()->get_trigger_type(), TriggerType::kPeriodic);
   }
 }
 
@@ -395,8 +387,7 @@ TEST_F(LeafSystemTest, ExactlyAtOffset) {
   EXPECT_EQ(15.0, time);
   const auto& events = leaf_info_->get_discrete_update_events().get_events();
   EXPECT_EQ(events.size(), 1);
-  EXPECT_EQ(events.front()->get_trigger_type(),
-            Event<double>::TriggerType::kPeriodic);
+  EXPECT_EQ(events.front()->get_trigger_type(), TriggerType::kPeriodic);
 }
 
 // Tests that if the current time is larger than the offset, the next
@@ -409,8 +400,7 @@ TEST_F(LeafSystemTest, OffsetIsInThePast) {
   EXPECT_EQ(25.0, time);
   const auto& events = leaf_info_->get_discrete_update_events().get_events();
   EXPECT_EQ(events.size(), 1);
-  EXPECT_EQ(events.front()->get_trigger_type(),
-            Event<double>::TriggerType::kPeriodic);
+  EXPECT_EQ(events.front()->get_trigger_type(), TriggerType::kPeriodic);
 }
 
 // Tests that if the current time is exactly an update time, the next update
@@ -423,8 +413,7 @@ TEST_F(LeafSystemTest, ExactlyOnUpdateTime) {
   EXPECT_EQ(35.0, time);
   const auto& events = leaf_info_->get_discrete_update_events().get_events();
   EXPECT_EQ(events.size(), 1);
-  EXPECT_EQ(events.front()->get_trigger_type(),
-            Event<double>::TriggerType::kPeriodic);
+  EXPECT_EQ(events.front()->get_trigger_type(), TriggerType::kPeriodic);
 }
 
 // Tests periodic events' scheduling when its offset is zero.
@@ -457,8 +446,7 @@ TEST_F(LeafSystemTest, UpdateAndPublish) {
   {
     const auto& events = leaf_info_->get_publish_events().get_events();
     EXPECT_EQ(events.size(), 1);
-    EXPECT_EQ(events.front()->get_trigger_type(),
-              Event<double>::TriggerType::kPeriodic);
+    EXPECT_EQ(events.front()->get_trigger_type(), TriggerType::kPeriodic);
   }
 
   // The update event fires at 15sec.
@@ -468,8 +456,7 @@ TEST_F(LeafSystemTest, UpdateAndPublish) {
   {
     const auto& events = leaf_info_->get_discrete_update_events().get_events();
     EXPECT_EQ(events.size(), 1);
-    EXPECT_EQ(events.front()->get_trigger_type(),
-              Event<double>::TriggerType::kPeriodic);
+    EXPECT_EQ(events.front()->get_trigger_type(), TriggerType::kPeriodic);
   }
 
   // Both events fire at 60sec.
@@ -479,14 +466,12 @@ TEST_F(LeafSystemTest, UpdateAndPublish) {
   {
     const auto& events = leaf_info_->get_discrete_update_events().get_events();
     EXPECT_EQ(events.size(), 1);
-    EXPECT_EQ(events.front()->get_trigger_type(),
-              Event<double>::TriggerType::kPeriodic);
+    EXPECT_EQ(events.front()->get_trigger_type(), TriggerType::kPeriodic);
   }
   {
     const auto& events = leaf_info_->get_publish_events().get_events();
     EXPECT_EQ(events.size(), 1);
-    EXPECT_EQ(events.front()->get_trigger_type(),
-              Event<double>::TriggerType::kPeriodic);
+    EXPECT_EQ(events.front()->get_trigger_type(), TriggerType::kPeriodic);
   }
 }
 
@@ -661,30 +646,27 @@ TEST_F(LeafSystemTest, DeclareTypedContinuousState) {
 TEST_F(LeafSystemTest, DeclarePerStepEvents) {
   std::unique_ptr<Context<double>> context = system_.CreateDefaultContext();
 
-  system_.AddPerStepEvent<PublishEvent<double>>();
-  system_.AddPerStepEvent<DiscreteUpdateEvent<double>>();
-  system_.AddPerStepEvent<UnrestrictedUpdateEvent<double>>();
+  system_.DeclarePerStepEvent(PublishEvent<double>());
+  system_.DeclarePerStepEvent(DiscreteUpdateEvent<double>());
+  system_.DeclarePerStepEvent(UnrestrictedUpdateEvent<double>());
 
   system_.GetPerStepEvents(*context, event_info_.get());
 
   {
     const auto& events = leaf_info_->get_publish_events().get_events();
     EXPECT_EQ(events.size(), 1);
-    EXPECT_EQ(events.front()->get_trigger_type(),
-              Event<double>::TriggerType::kPerStep);
+    EXPECT_EQ(events.front()->get_trigger_type(), TriggerType::kPerStep);
   }
   {
     const auto& events = leaf_info_->get_discrete_update_events().get_events();
     EXPECT_EQ(events.size(), 1);
-    EXPECT_EQ(events.front()->get_trigger_type(),
-              Event<double>::TriggerType::kPerStep);
+    EXPECT_EQ(events.front()->get_trigger_type(), TriggerType::kPerStep);
   }
   {
     const auto& events =
         leaf_info_->get_unrestricted_update_events().get_events();
     EXPECT_EQ(events.size(), 1);
-    EXPECT_EQ(events.front()->get_trigger_type(),
-              Event<double>::TriggerType::kPerStep);
+    EXPECT_EQ(events.front()->get_trigger_type(), TriggerType::kPerStep);
   }
 }
 
@@ -1349,10 +1331,8 @@ TEST_F(LeafSystemTest, CallbackAndInvalidUpdates) {
       s->CopyFrom(*c.CloneState());
     };
 
-    UnrestrictedUpdateEvent<double> event(Event<double>::TriggerType::kPeriodic,
-                                          callback);
-
-    event.add_to_composite(&leaf_events);
+    UnrestrictedUpdateEvent<double> event(TriggerType::kPeriodic, callback);
+    event.AddToComposite(&leaf_events);
   }
 
   // Verify no exception is thrown.
@@ -1371,10 +1351,8 @@ TEST_F(LeafSystemTest, CallbackAndInvalidUpdates) {
           std::make_unique<BasicVector<double>>(4), 4, 0, 0));
     };
 
-    UnrestrictedUpdateEvent<double> event(Event<double>::TriggerType::kPeriodic,
-                                          callback);
-
-    event.add_to_composite(&leaf_events);
+    UnrestrictedUpdateEvent<double> event(TriggerType::kPeriodic, callback);
+    event.AddToComposite(&leaf_events);
   }
 
   // Call the unrestricted update function, verifying that an exception
@@ -1401,10 +1379,8 @@ TEST_F(LeafSystemTest, CallbackAndInvalidUpdates) {
           std::make_unique<DiscreteValues<double>>(std::move(disc_data)));
     };
 
-    UnrestrictedUpdateEvent<double> event(Event<double>::TriggerType::kPeriodic,
-                                          callback);
-
-    event.add_to_composite(&leaf_events);
+    UnrestrictedUpdateEvent<double> event(TriggerType::kPeriodic, callback);
+    event.AddToComposite(&leaf_events);
   }
 
   // Call the unrestricted update function again, again verifying that an
@@ -1427,10 +1403,8 @@ TEST_F(LeafSystemTest, CallbackAndInvalidUpdates) {
       s->set_abstract_state(std::make_unique<AbstractValues>());
     };
 
-    UnrestrictedUpdateEvent<double> event(Event<double>::TriggerType::kPeriodic,
-                                          callback);
-
-    event.add_to_composite(&leaf_events);
+    UnrestrictedUpdateEvent<double> event(TriggerType::kPeriodic, callback);
+    event.AddToComposite(&leaf_events);
   }
 
   // Call the unrestricted update function again, again verifying that an
@@ -1794,7 +1768,7 @@ class TestTriggerSystem : public LeafSystem<double> {
       const Context<double>& context,
       const std::vector<const PublishEvent<double>*>& events) const override {
     for (const PublishEvent<double>* event : events) {
-      if (event->get_trigger_type() == Event<double>::TriggerType::kForced)
+      if (event->get_trigger_type() == TriggerType::kForced)
         continue;
 
       // Call custom callback handler.
@@ -1809,19 +1783,17 @@ class TestTriggerSystem : public LeafSystem<double> {
       CompositeEventCollection<double>* events) const override {
     {
       PublishEvent<double> event(
-          Event<double>::TriggerType::kPerStep,
           std::bind(&TestTriggerSystem::StringCallback, this,
               std::placeholders::_1, std::placeholders::_2,
               std::make_shared<const std::string>("hello")));
-      event.add_to_composite(events);
+      event.AddToComposite(TriggerType::kPerStep, events);
     }
 
     {
       PublishEvent<double> event(
-          Event<double>::TriggerType::kPerStep,
           std::bind(&TestTriggerSystem::IntCallback, this,
               std::placeholders::_1, std::placeholders::_2, 42));
-      event.add_to_composite(events);
+      event.AddToComposite(TriggerType::kPerStep, events);
     }
   }
 
@@ -2205,15 +2177,12 @@ GTEST_TEST(InitializationTest, InitializationTest) {
    public:
     InitializationTestSystem() {
       PublishEvent<double> pub_event(
-          Event<double>::TriggerType::kInitialization,
           std::bind(&InitializationTestSystem::InitPublish, this,
                     std::placeholders::_1, std::placeholders::_2));
       DeclareInitializationEvent(pub_event);
 
-      DeclareInitializationEvent(DiscreteUpdateEvent<double>(
-          Event<double>::TriggerType::kInitialization));
-      DeclareInitializationEvent(UnrestrictedUpdateEvent<double>(
-          Event<double>::TriggerType::kInitialization));
+      DeclareInitializationEvent(DiscreteUpdateEvent<double>());
+      DeclareInitializationEvent(UnrestrictedUpdateEvent<double>());
     }
 
     bool get_pub_init() const { return pub_init_; }
@@ -2223,8 +2192,7 @@ GTEST_TEST(InitializationTest, InitializationTest) {
    private:
     void InitPublish(const Context<double>&,
                      const PublishEvent<double>& event) const {
-      EXPECT_EQ(event.get_trigger_type(),
-                Event<double>::TriggerType::kInitialization);
+      EXPECT_EQ(event.get_trigger_type(), TriggerType::kInitialization);
       pub_init_ = true;
     }
 
@@ -2234,7 +2202,7 @@ GTEST_TEST(InitializationTest, InitializationTest) {
         DiscreteValues<double>*) const final {
       EXPECT_EQ(events.size(), 1);
       EXPECT_EQ(events.front()->get_trigger_type(),
-                Event<double>::TriggerType::kInitialization);
+                TriggerType::kInitialization);
       dis_update_init_ = true;
     }
 
@@ -2244,7 +2212,7 @@ GTEST_TEST(InitializationTest, InitializationTest) {
         State<double>*) const final {
       EXPECT_EQ(events.size(), 1);
       EXPECT_EQ(events.front()->get_trigger_type(),
-                Event<double>::TriggerType::kInitialization);
+                TriggerType::kInitialization);
       unres_update_init_ = true;
     }
 

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -179,11 +179,11 @@ class TestSystem : public System<double> {
     *time = context.get_time() + 1;
 
     if (context.get_time() < 10.0) {
-      PublishEvent<double> event(Event<double>::TriggerType::kPeriodic);
-      event.add_to_composite(event_info);
+      PublishEvent<double> event(TriggerType::kPeriodic);
+      event.AddToComposite(event_info);
     } else {
-      DiscreteUpdateEvent<double> event(Event<double>::TriggerType::kPeriodic);
-      event.add_to_composite(event_info);
+      DiscreteUpdateEvent<double> event(TriggerType::kPeriodic);
+      event.AddToComposite(event_info);
     }
   }
 
@@ -298,7 +298,7 @@ TEST_F(SystemTest, DiscretePublish) {
           event_info.get())->get_publish_events().get_events();
   EXPECT_EQ(events.size(), 1);
   EXPECT_EQ(events.front()->get_trigger_type(),
-            Event<double>::TriggerType::kPeriodic);
+            TriggerType::kPeriodic);
 
   system_.Publish(context_, event_info->get_publish_events());
   EXPECT_EQ(1, system_.get_publish_count());

--- a/systems/lcm/lcm_log_playback_system.cc
+++ b/systems/lcm/lcm_log_playback_system.cc
@@ -45,7 +45,7 @@ void LcmLogPlaybackSystem::DoCalcNextUpdateTime(
   *time = next_message_time;
   events->get_mutable_publish_events().add_event(
       std::make_unique<systems::PublishEvent<double>>(
-          Event<double>::TriggerType::kTimed, callback));
+          TriggerType::kTimed, callback));
 }
 
 }  // namespace lcm

--- a/systems/lcm/lcm_publisher_system.cc
+++ b/systems/lcm/lcm_publisher_system.cc
@@ -90,7 +90,7 @@ void LcmPublisherSystem::AddInitializationMessage(
   initialization_publisher_ = std::move(initialization_publisher);
 
   DeclareInitializationEvent(systems::PublishEvent<double>(
-      systems::Event<double>::TriggerType::kInitialization,
+      systems::TriggerType::kInitialization,
       [this](const systems::Context<double>& context,
              const systems::PublishEvent<double>&) {
         this->initialization_publisher_(context, this->lcm_);
@@ -117,7 +117,7 @@ void LcmPublisherSystem::DoPublish(
   const auto& event = events.front();
 
   if (event->get_trigger_type() ==
-      systems::Event<double>::TriggerType::kInitialization) {
+      systems::TriggerType::kInitialization) {
     // We shouldn't get another event along with our own initialization event.
     DRAKE_DEMAND(events.size() == 1);
     SPDLOG_TRACE(drake::log(), "Invoking initialization publisher");

--- a/systems/lcm/lcm_subscriber_system.cc
+++ b/systems/lcm/lcm_subscriber_system.cc
@@ -168,13 +168,13 @@ void LcmSubscriberSystem::DoCalcNextUpdateTime(
         events->get_mutable_unrestricted_update_events();
     uu_events.add_event(
         std::make_unique<systems::UnrestrictedUpdateEvent<double>>(
-            Event<double>::TriggerType::kTimed));
+            TriggerType::kTimed));
   } else {
     EventCollection<DiscreteUpdateEvent<double>>& du_events =
         events->get_mutable_discrete_update_events();
     du_events.add_event(
         std::make_unique<systems::DiscreteUpdateEvent<double>>(
-            Event<double>::TriggerType::kTimed));
+            TriggerType::kTimed));
   }
 }
 

--- a/systems/primitives/test/linear_system_test.cc
+++ b/systems/primitives/test/linear_system_test.cc
@@ -313,8 +313,7 @@ class TestNonPeriodicSystem : public LeafSystem<double> {
  public:
   TestNonPeriodicSystem() {
     this->DeclareDiscreteState(1);
-    PublishEvent<double> event(Event<double>::TriggerType::kPerStep);
-    this->DeclarePerStepEvent(event);
+    this->DeclarePerStepEvent(PublishEvent<double>());
   }
 
   void DoCalcDiscreteVariableUpdates(

--- a/systems/primitives/test/zero_order_hold_test.cc
+++ b/systems/primitives/test/zero_order_hold_test.cc
@@ -40,7 +40,7 @@ void CheckForSinglePeriodicEvent(const EventListType& events) {
   // met.
   if (events.size() == 1) {
     EXPECT_EQ(events.front()->get_trigger_type(),
-        Event<double>::TriggerType::kPeriodic);
+        TriggerType::kPeriodic);
   }
 }
 

--- a/systems/sensors/image_writer.cc
+++ b/systems/sensors/image_writer.cc
@@ -147,7 +147,7 @@ const InputPort<double>& ImageWriter::DeclareImageInputPort(
       DeclareAbstractInputPort(port_name, systems::Value<Image<kPixelType>>());
 
   PublishEvent<double> event(
-      Event<double>::TriggerType::kPeriodic,
+      TriggerType::kPeriodic,
       [this, port_index = port.get_index()](const Context<double>& context,
                                             const PublishEvent<double>&) {
         WriteImage<kPixelType>(context, port_index);

--- a/systems/sensors/test/image_writer_test.cc
+++ b/systems/sensors/test/image_writer_test.cc
@@ -611,7 +611,7 @@ TEST_F(ImageWriterTest, SingleConfiguredPort) {
               .get_events();
       ASSERT_EQ(1u, publish_events.size());
       const auto& event = publish_events.front();
-      EXPECT_EQ(Event<double>::TriggerType::kPeriodic,
+      EXPECT_EQ(TriggerType::kPeriodic,
                 event->get_trigger_type());
 
       // With no connection on the input port, publishing this event will result


### PR DESCRIPTION
This is a preliminary step towards switching our best-practices API use to Events with callbacks instead of overloading the event dispatachers like DoPublish(), per discussion in PR #9292. The main purpose of the change in this PR is to permit DeclarePeriodicEvent(), DeclarePerStepEvent(), and DeclareInitializationEvent() to accept an Event object that doesn't already have its trigger type set. That means
```c++
DeclarePeriodicEvent(1., 0., PublishEvent<T>(callback));
```
rather than today's redundant
```c++
DeclarePeriodicEvent(1., 0., PublishEvent<T>(TriggerType::kPeriodic, callback));
```

TriggerType specifications throughout drake/system have been fixed to remove the obsolete alias in preparation for deprecating that alias per the TODO in event.h.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10033)
<!-- Reviewable:end -->
