### PR TITLE
Add FrameIdRange to FrameKinematicsVector

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -67,6 +67,7 @@ drake_cc_library(
     ],
     deps = [
         ":geometry_ids",
+        ":utilities",
         "//common:autodiff",
         "//common:essential",
         "//common:symbolic",
@@ -172,6 +173,7 @@ drake_cc_library(
         ":internal_frame",
         ":internal_geometry",
         ":proximity_engine",
+        ":utilities",
     ],
 )
 

--- a/geometry/frame_kinematics_vector.h
+++ b/geometry/frame_kinematics_vector.h
@@ -7,6 +7,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/utilities.h"
 
 namespace drake {
 namespace geometry {
@@ -169,8 +170,15 @@ struct KinematicsValueInitializer<Isometry3<S>> {
   */
 template <class KinematicsValue>
 class FrameKinematicsVector {
+  // Forward declaration.
+  struct FlaggedValue;
+
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(FrameKinematicsVector)
+
+  /** An object that represents the range of FrameId values in this class. It
+   is used in range-based for loops to iterate through registered frames.  */
+  using FrameIdRange = internal::MapKeyRange<FrameId, FlaggedValue>;
 
   // TODO(SeanCurtis-TRI) Find some API language that cautions users that this
   // result is not terribly useful on its own, but instead it will usually be
@@ -215,6 +223,18 @@ class FrameKinematicsVector {
 
   /** Reports true if the given id is a member of this data. */
   bool has_id(FrameId id) const { return values_.count(id) > 0; }
+
+  /** Provides a range object for all of the frame ids in the vector.
+   This is intended to be used as:
+   @code
+   for (FrameId id : this_vector.frame_ids()) {
+    ...
+    // Obtain the KinematicsValue of an id by `this_vector.value(id)`
+    ...
+   }
+   @endcode
+   */
+  FrameIdRange frame_ids() const { return FrameIdRange(&values_); }
 
  private:
   // Utility function to help catch misuse.

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -17,6 +17,7 @@
 #include "drake/geometry/internal_frame.h"
 #include "drake/geometry/internal_geometry.h"
 #include "drake/geometry/proximity_engine.h"
+#include "drake/geometry/utilities.h"
 
 namespace drake {
 namespace geometry {
@@ -25,44 +26,6 @@ namespace geometry {
 namespace internal {
 
 class GeometryVisualizationImpl;
-
-// A const range iterator through the keys of an unordered map.
-template <typename K, typename V>
-class MapKeyRange {
- public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(MapKeyRange)
-
-  class ConstIterator {
-   public:
-    DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ConstIterator)
-
-    const K& operator*() const { return itr_->first; }
-    const ConstIterator& operator++() {
-      ++itr_;
-      return *this;
-    }
-    bool operator!=(const ConstIterator& other) { return itr_ != other.itr_; }
-
-   private:
-    explicit ConstIterator(
-        typename std::unordered_map<K, V>::const_iterator itr)
-        : itr_(itr) {}
-
-   private:
-    typename std::unordered_map<K, V>::const_iterator itr_;
-    friend class MapKeyRange;
-  };
-
-  explicit MapKeyRange(const std::unordered_map<K, V>* map)
-      : map_(map) {
-    DRAKE_DEMAND(map);
-  }
-  ConstIterator begin() const { return ConstIterator(map_->cbegin()); }
-  ConstIterator end() const { return ConstIterator(map_->cend()); }
-
- private:
-  const std::unordered_map<K, V>* map_;
-};
 
 }  // namespace internal
 #endif

--- a/geometry/test/frame_kinematics_vector_test.cc
+++ b/geometry/test/frame_kinematics_vector_test.cc
@@ -148,6 +148,20 @@ GTEST_TEST(FrameKinematicsVector, SymbolicInstantiation) {
   EXPECT_TRUE(z_.EqualTo(poses.value(ids[1]).translation()[2]));
 }
 
+GTEST_TEST(FrameKinematicsVector, FrameIdRange) {
+  SourceId source_id = SourceId::get_new_id();
+  int kPoseCount = 3;
+  std::vector<FrameId> ids;
+  for (int i = 0; i < kPoseCount; ++i) ids.push_back(FrameId::get_new_id());
+  FramePoseVector<double> poses(source_id, ids);
+
+  std::set<FrameId> actual_ids;
+  for (FrameId id : poses.frame_ids()) actual_ids.insert(id);
+
+  EXPECT_EQ(ids.size(), actual_ids.size());
+  for (FrameId id : ids) EXPECT_EQ(actual_ids.count(id), 1);
+}
+
 }  // namespace test
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/utilities.h
+++ b/geometry/utilities.h
@@ -1,9 +1,14 @@
 #pragma once
 
 #include <string>
+#include <unordered_map>
+
+#include "drake/common/drake_copyable.h"
 
 namespace drake {
 namespace geometry {
+
+// TODO(SeanCurtis-TRI): Get rid of the "detail" namespace.
 namespace detail {
 
 /** Canonicalizes the given geometry *candidate* name. A canonicalized name may
@@ -13,5 +18,47 @@ namespace detail {
 std::string CanonicalizeStringName(const std::string& name);
 
 }  // namespace detail
+
+namespace internal {
+
+/// A const range iterator through the keys of an unordered map.
+template <typename K, typename V>
+class MapKeyRange {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(MapKeyRange)
+
+  class ConstIterator {
+   public:
+    DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ConstIterator)
+
+    const K& operator*() const { return itr_->first; }
+    const ConstIterator& operator++() {
+      ++itr_;
+      return *this;
+    }
+    bool operator!=(const ConstIterator& other) { return itr_ != other.itr_; }
+
+   private:
+    explicit ConstIterator(
+        typename std::unordered_map<K, V>::const_iterator itr)
+        : itr_(itr) {}
+
+   private:
+    typename std::unordered_map<K, V>::const_iterator itr_;
+    friend class MapKeyRange;
+  };
+
+  explicit MapKeyRange(const std::unordered_map<K, V>* map) : map_(map) {
+    DRAKE_DEMAND(map);
+  }
+  ConstIterator begin() const { return ConstIterator(map_->cbegin()); }
+  ConstIterator end() const { return ConstIterator(map_->cend()); }
+
+ private:
+  const std::unordered_map<K, V>* map_;
+};
+
+}  // namespace internal
+
 }  // namespace geometry
 }  // namespace drake


### PR DESCRIPTION
So users of FrameKinematicsVector can iterate over all frame ids in the vector.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10038)
<!-- Reviewable:end -->
