### PR TITLE
Connecting geometry roles *strictly* internally.

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -239,6 +239,7 @@ drake_cc_library(
     deps = [
         ":geometry_ids",
         ":geometry_index",
+        ":geometry_roles",
         ":internal_frame",
         ":materials",
         ":shape_specification",

--- a/geometry/geometry_visualization.h
+++ b/geometry/geometry_visualization.h
@@ -45,6 +45,23 @@ class GeometryVisualizationImpl {
    system, and
  - sets the publishing rate to 1/60 of a second (simulated time).
 
+ @anchor geometry_visualization_role_dependency
+ The visualization mechanism depends on the illustration role (see
+ @ref geometry_roles for details). Specifically, only geometries with
+ the illustration role assigned will be included. The visualization function
+ looks for the following properties in the IllustrationProperties instance.
+ | Group name | Required | Property Name |  Property Type  | Property Description |
+ | :--------: | :------: | :-----------: | :-------------: | :------------------- |
+ |    phong   | no       | diffuse       | Eigen::Vector4d | The rgba value of the object surface |
+ See MakeDrakeVisualizerProperties() to facilitate making a compliant set of
+ illustration properties.
+
+ You can then connect source output ports for visualization like this:
+ @code
+   builder->Connect(pose_output_port,
+                    scene_graph.get_source_pose_port(source_id));
+ @endcode
+
  @note The initialization event occurs when Simulator::Initialize() is called
  (explicitly or implicitly at the start of a simulation). If you aren't going
  to be using a Simulator, use DispatchLoadMessage() to send the message
@@ -88,6 +105,11 @@ systems::lcm::LcmPublisherSystem* ConnectDrakeVisualizer(
     const SceneGraph<double>& scene_graph,
     const systems::OutputPort<double>& pose_bundle_output_port,
     lcm::DrakeLcmInterface* lcm = nullptr);
+
+/** Constructs an IllustrationProperties instance compatible with the
+ ConnectDrakeVisualizer incorporating the given diffuse color.  */
+IllustrationProperties MakeDrakeVisualizerProperties(
+    const Vector4<double>& diffuse);
 
 /** (Advanced) Explicitly dispatches an LCM load message based on the registered
  geometry. Normally this is done automatically at Simulator initialization. But

--- a/geometry/internal_geometry.cc
+++ b/geometry/internal_geometry.cc
@@ -1,5 +1,7 @@
 #include "drake/geometry/internal_geometry.h"
 
+#include "drake/common/drake_assert.h"
+
 namespace drake {
 namespace geometry {
 namespace internal {
@@ -17,8 +19,24 @@ InternalGeometry::InternalGeometry(
       X_PG_(X_FG),
       X_FG_(X_FG),
       parent_geometry_id_(nullopt),
-      visual_material_(material) {}
+      visual_material_(material) {
+  // Short-term expedient; all internal geometries have illustration properties.
+  IllustrationProperties properties;
+  properties.AddProperty("phong", "diffuse", material.diffuse());
+  SetRole(properties);
+}
 
+bool InternalGeometry::has_role(Role role) const {
+  switch (role) {
+    case Role::kProximity:
+      return has_proximity_role();
+    case Role::kIllustration:
+      return has_illustration_role();
+    case Role::kUnassigned:
+      return !(has_proximity_role() || has_illustration_role());
+  }
+  DRAKE_ABORT_MSG("Unreachable code; switch on enum had unexpected value");
+}
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/internal_geometry.h
+++ b/geometry/internal_geometry.h
@@ -10,6 +10,7 @@
 #include "drake/common/drake_optional.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/geometry_index.h"
+#include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/internal_frame.h"
 #include "drake/geometry/shape_specification.h"
 #include "drake/geometry/visual_material.h"
@@ -174,11 +175,57 @@ class InternalGeometry {
 
   //@}
 
-  /** Returns this geometry's valid index in the proximity engine iff this
-   geometry has a proximity role. If not, the returned index will be invalid.
-   */
+  /** @name   Role management  */
+  //@{
+
+  /** Assigns a proximity role to this geometry. Fails if it has already been
+   assigned.  */
+  void SetRole(ProximityProperties properties) {
+    if (proximity_props_) {
+      throw std::logic_error("Geometry already has proximity role assigned");
+    }
+    proximity_props_ = std::move(properties);
+  }
+
+  /** Assigns a illustration role to this geometry. Fails if it has already been
+   assigned.  */
+  void SetRole(IllustrationProperties properties) {
+    if (illustration_props_) {
+      throw std::logic_error("Geometry already has illustration role assigned");
+    }
+    illustration_props_ = std::move(properties);
+  }
+
+  /** Reports if the geometry has the indicated `role`.  */
+  bool has_role(Role role) const;
+
+  /** Reports if the geometry has a proximity role.  */
+  bool has_proximity_role() const { return proximity_props_ != nullopt; }
+
+  /** Reports if the geometry has a illustration role.  */
+  bool has_illustration_role() const { return illustration_props_ != nullopt; }
+
+  /** Returns a pointer to the geometry's proximity properties (if they are
+   defined. Nullptr otherwise.  */
+  const ProximityProperties* proximity_properties() const {
+    if (proximity_props_) return &*proximity_props_;
+    return nullptr;
+  }
+
+  /** Returns a pointer to the geometry's illustration properties (if they are
+   defined. Nullptr otherwise.  */
+  const IllustrationProperties* illustration_properties() const {
+    if (illustration_props_) return &*illustration_props_;
+    return nullptr;
+  }
+
+  /** If this geometry has a proximity role, this that geometry's index in the
+   proximity engine. It will be undefined it it does not have the proximity
+   role.  */
   ProximityIndex proximity_index() const { return proximity_index_; }
   void set_proximity_index(ProximityIndex index) { proximity_index_ = index; }
+
+  //@}
 
  private:
   // The specification for this instance's shape.
@@ -214,6 +261,13 @@ class InternalGeometry {
 
   // The identifiers for the geometry hung on this frame.
   std::unordered_set<GeometryId> child_geometry_ids_;
+
+  // TODO(SeanCurtis-TRI): Consider introducing a mechanism where these are
+  // defined at the frame level, and all child geometries inherit.
+
+  // The optional property sets tied to the roles that the geometry plays.
+  optional<ProximityProperties> proximity_props_{nullopt};
+  optional<IllustrationProperties> illustration_props_{nullopt};
 
   // The index of the geometry in the engine. Note: is currently unused but will
   // gain importance when the API for *removing* geometry is added. It is the

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -628,10 +628,11 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
   //  1. I could make this move semantics (or swap semantics).
   //  2. I could simply have a method that returns a mutable reference to such
   //    a vector and the caller sets values there directly.
-  void UpdateWorldPoses(const std::vector<Isometry3<T>>& X_WG) {
-    DRAKE_DEMAND(X_WG.size() == dynamic_objects_.size());
-    for (size_t i = 0; i < X_WG.size(); ++i) {
-      dynamic_objects_[i]->setTransform(convert(X_WG[i]));
+  void UpdateWorldPoses(const std::vector<Isometry3<T>>& X_WG,
+                        const std::vector<GeometryIndex>& indices) {
+    DRAKE_DEMAND(indices.size() == dynamic_objects_.size());
+    for (size_t i = 0; i < indices.size(); ++i) {
+      dynamic_objects_[i]->setTransform(convert(X_WG[indices[i]]));
     }
     dynamic_tree_.update();
   }
@@ -1209,8 +1210,9 @@ std::unique_ptr<ProximityEngine<AutoDiffXd>> ProximityEngine<T>::ToAutoDiffXd()
 
 template <typename T>
 void ProximityEngine<T>::UpdateWorldPoses(
-    const std::vector<Isometry3<T>>& X_WG) {
-  impl_->UpdateWorldPoses(X_WG);
+    const std::vector<Isometry3<T>>& X_WG,
+    const std::vector<GeometryIndex>& indices) {
+  impl_->UpdateWorldPoses(X_WG, indices);
 }
 
 template <typename T>

--- a/geometry/proximity_engine.h
+++ b/geometry/proximity_engine.h
@@ -135,17 +135,20 @@ class ProximityEngine {
 
   /** Updates the poses for all of the dynamic geometries in the engine. It
    is an invariant that _every_ registered dynamic geometry, across _all_
-   geometry sources, has a _unique_ index that lies in the range
-   [0, num_dynamic() - 1]. Therefore, `X_WG` should have size equal to
-   num_dynamics() and any other length will cause program failure. The iᵗʰ entry
-   contains the pose for the geometry whose GeometryIndex value is `i`.
-   @param X_WG     The poses of each geometry `G` measured and expressed in the
-                   world frame `W`.  */
+   geometry sources, with a proximity role has a _unique_ index that lies in the
+   range [0, num_dynamic() - 1]. `indices.size()` should be equal to
+   num_dynamic() and any other length will cause program failure.
+   @param X_WG      The poses of each geometry `G` measured and expressed in the
+                    world frame `W` (including geometries which may *not* be
+                    registered with the proximity engine).
+   @param indices   Indices into `X_WG` mapping engine index to geometry index.
+  */
   // TODO(SeanCurtis-TRI): I could do things here differently a number of ways:
   //  1. I could make this move semantics (or swap semantics).
   //  2. I could simply have a method that returns a mutable reference to such
   //    a vector and the caller sets values there directly.
-  void UpdateWorldPoses(const std::vector<Isometry3<T>>& X_WG);
+  void UpdateWorldPoses(const std::vector<Isometry3<T>>& X_WG,
+                        const std::vector<GeometryIndex>& indices);
 
   // ----------------------------------------------------------------------
   /**@name              Signed Distance Queries

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -2,6 +2,7 @@
 
 #include <string>
 
+#include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/geometry_state.h"
 
 namespace drake {
@@ -96,8 +97,9 @@ class SceneGraphInspector {
   }
 
   /** Reports the id of the geometry with the given name, attached to the
-   indicated frame.
+   indicated frame with the given role.
    @param frame_id  The frame whose geometry is being queried.
+   @param role      The assigned role of the desired geometry.
    @param name      The name of the geometry to query for. The name will be
                     canonicalized prior to lookup (see
                     @ref canonicalized_geometry_names "GeometryInstance" for
@@ -105,11 +107,10 @@ class SceneGraphInspector {
    @return The id of the queried geometry.
    @throws std::logic_error if no such geometry exists, multiple geometries have
                             that name, or if the frame doesn't exist.  */
-  // TODO(SeanCurtis-TRI): Extend to include role.
-  GeometryId GetGeometryIdByName(FrameId frame_id,
+  GeometryId GetGeometryIdByName(FrameId frame_id, Role role,
                                  const std::string& name) const {
     DRAKE_DEMAND(state_ != nullptr);
-    return state_->GetGeometryFromName(frame_id, name);
+    return state_->GetGeometryFromName(frame_id, role, name);
   }
 
   //@}

--- a/geometry/test/geometry_visualization_test.cc
+++ b/geometry/test/geometry_visualization_test.cc
@@ -43,11 +43,13 @@ GTEST_TEST(GeometryVisualization, SimpleScene) {
   const float g = 0.5f;
   const float b = 0.25f;
   const float a = 0.125f;
+  Vector4<double> color{r, g, b, a};
+  VisualMaterial material(color);
   scene_graph.RegisterGeometry(
       source_id, frame_id,
       make_unique<GeometryInstance>(Isometry3d::Identity(),
                                     make_unique<Sphere>(radius), "sphere",
-                                    VisualMaterial(Vector4d{r, g, b, a})));
+                                    material));
 
   unique_ptr<Context<double>> context = scene_graph.AllocateContext();
   const GeometryContext<double>& geo_context =

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -145,7 +145,9 @@ GTEST_TEST(ProximityEngineTests, RemoveGeometry) {
 
     if (is_dynamic) {
       // Poses for dynamic geometries need to be explicitly updated.
-      engine.UpdateWorldPoses(poses);
+      std::vector<GeometryIndex> indices(poses.size());
+      std::iota(indices.begin(), indices.end(), GeometryIndex(0));
+      engine.UpdateWorldPoses(poses, indices);
     }
 
     // Case: Remove middle object, confirm that final gets moved.
@@ -318,7 +320,6 @@ GTEST_TEST(ProximityEngineTests, SignedDistanceClosestPointsMultipleAnchored) {
       geometry_map);
   EXPECT_EQ(results.size(), 0);
 }
-
 // Penetration tests -- testing data flow; not testing the value of the query.
 
 // A scene with no geometry reports no penetrations.
@@ -416,7 +417,9 @@ class SimplePenetrationTest : public ::testing::Test {
                                          Isometry3<double>::Identity());
     const double x_pos = is_colliding ? colliding_x_ : free_x_;
     poses[index] = Isometry3<double>(Translation3d{x_pos, 0, 0});
-    engine->UpdateWorldPoses(poses);
+    std::vector<GeometryIndex> indices(poses.size());
+    std::iota(indices.begin(), indices.end(), GeometryIndex(0));
+    engine->UpdateWorldPoses(poses, indices);
   }
 
   // Compute penetration and confirm that a single penetration with the expected
@@ -599,7 +602,9 @@ TEST_F(SimplePenetrationTest, PenetrationDynamicAndDynamicSingleSource) {
   geometry_map_.push_back(origin_id);
   EXPECT_EQ(origin_index, 0);
   std::vector<Isometry3<double>> poses{Isometry3<double>::Identity()};
-  engine_.UpdateWorldPoses(poses);
+  std::vector<GeometryIndex> indices(poses.size());
+  std::iota(indices.begin(), indices.end(), GeometryIndex(0));
+  engine_.UpdateWorldPoses(poses, indices);
 
   ProximityIndex collide_index =
       engine_.AddDynamicGeometry(sphere_, GeometryIndex(1));
@@ -676,7 +681,9 @@ TEST_F(SimplePenetrationTest, ExcludeCollisionsWithin) {
   geometry_map_.push_back(origin_id);
 
   std::vector<Isometry3<double>> poses{Isometry3<double>::Identity()};
-  engine_.UpdateWorldPoses(poses);
+  std::vector<GeometryIndex> indices(poses.size());
+  std::iota(indices.begin(), indices.end(), GeometryIndex(0));
+  engine_.UpdateWorldPoses(poses, indices);
 
   GeometryIndex collide_index(1);
   engine_.AddDynamicGeometry(sphere_, collide_index);
@@ -772,7 +779,9 @@ TEST_F(SimplePenetrationTest, ExcludeCollisionsBetween) {
   geometry_map_.push_back(origin_id);
 
   std::vector<Isometry3<double>> poses{Isometry3<double>::Identity()};
-  engine_.UpdateWorldPoses(poses);
+  std::vector<GeometryIndex> indices(poses.size());
+  std::iota(indices.begin(), indices.end(), GeometryIndex(0));
+  engine_.UpdateWorldPoses(poses, indices);
 
   GeometryIndex collide_index(1);
   engine_.AddDynamicGeometry(sphere_, collide_index);
@@ -901,9 +910,11 @@ GTEST_TEST(ProximityEngineCollisionTest, SpherePunchThroughBox) {
       {"sphere's center has crossed the box's origin - flipped normal",
        {-eps, 0, 0}, 1, {1, 0, 0}, radius + half_w - eps}};
   // clang-format on
+  std::vector<GeometryIndex> indices(poses.size());
+  std::iota(indices.begin(), indices.end(), GeometryIndex(0));
   for (const auto& test : test_data) {
     poses[1].translation() = test.sphere_pose;
-    engine.UpdateWorldPoses(poses);
+    engine.UpdateWorldPoses(poses, indices);
     std::vector<PenetrationAsPointPair<double>> results =
         engine.ComputePointPairPenetration(geometry_map);
 
@@ -1067,7 +1078,9 @@ class BoxPenetrationTest : public ::testing::Test {
 
     // Update the poses of the geometry.
     std::vector<Isometry3d> poses{shape_pose(shape_type), X_WB};
-    engine_.UpdateWorldPoses(poses);
+    std::vector<GeometryIndex> indices(poses.size());
+    std::iota(indices.begin(), indices.end(), GeometryIndex(0));
+    engine_.UpdateWorldPoses(poses, indices);
     std::vector<PenetrationAsPointPair<double>> results =
         engine_.ComputePointPairPenetration(geometry_map_);
 


### PR DESCRIPTION
The key to this is that geometry internals make use of the roles, but the public API and historical semantics are preserved -- specifically, *every* geometry has both a proximity and illustration role by default. This specific aspect will be addressed in the next PR.

- Geometry visualization relies on the illustration role
- The interface with the proximity engine now allows for the fact that not all geometries have a proximity role.
- Internal geometry has role functionality and can report what roles it has.
- Name validation is done on a role-basis.
- Geometry query counts include roles.

```
Category            added  modified  removed  
----------------------------------------------
code                296    79        27       
comments            158    32        8        
blank               59     0         1        
----------------------------------------------
TOTAL               513    111       36  
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10044)
<!-- Reviewable:end -->
