### PR TITLE
perception: Remove spurious dependency

### DIFF
--- a/perception/BUILD.bazel
+++ b/perception/BUILD.bazel
@@ -47,7 +47,8 @@ drake_cc_library(
         ":point_cloud",
         "//common:essential",
         "//systems/framework",
-        "//systems/sensors",
+        "//systems/sensors:camera_info",
+        "//systems/sensors:image",
     ],
 )
 

--- a/perception/depth_image_to_point_cloud.h
+++ b/perception/depth_image_to_point_cloud.h
@@ -10,7 +10,6 @@
 #include "drake/systems/framework/leaf_system.h"
 #include "drake/systems/sensors/camera_info.h"
 #include "drake/systems/sensors/image.h"
-#include "drake/systems/sensors/rgbd_camera.h"
 
 namespace drake {
 namespace perception {


### PR DESCRIPTION
Relates #9783.  We overlooked this nit in #9972.  (Without this fix, the image-cloud projection code was still linking against RigidBodyTree.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10046)
<!-- Reviewable:end -->
