### PR TITLE
attic: Move RBT DiffIK implementation to attic

### DIFF
--- a/attic/manipulation/planner/BUILD.bazel
+++ b/attic/manipulation/planner/BUILD.bazel
@@ -16,6 +16,7 @@ drake_cc_package_library(
     name = "planner",
     deps = [
         ":constraint_relaxing_ik",
+        ":rbt_differential_inverse_kinematics",
         ":robot_plan_interpolator",
     ],
 )
@@ -29,6 +30,17 @@ drake_cc_library(
         "//attic/multibody:rigid_body_tree",
         "//attic/multibody/parsers",
         "//common/trajectories:piecewise_polynomial",
+    ],
+)
+
+# N.B. This is unit tested in //manipulation/planner (non-attic).
+drake_cc_library(
+    name = "rbt_differential_inverse_kinematics",
+    srcs = ["rbt_differential_inverse_kinematics.cc"],
+    hdrs = ["rbt_differential_inverse_kinematics.h"],
+    deps = [
+        "//attic/multibody:rigid_body_tree",
+        "//manipulation/planner:differential_inverse_kinematics",
     ],
 )
 

--- a/attic/manipulation/planner/rbt_differential_inverse_kinematics.cc
+++ b/attic/manipulation/planner/rbt_differential_inverse_kinematics.cc
@@ -1,0 +1,38 @@
+#include "drake/manipulation/planner/rbt_differential_inverse_kinematics.h"
+
+namespace drake {
+namespace manipulation {
+namespace planner {
+namespace rbt {
+
+DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
+    const RigidBodyTree<double>& robot, const KinematicsCache<double>& cache,
+    const Isometry3<double>& X_WE_desired,
+    const RigidBodyFrame<double>& frame_E,
+    const DifferentialInverseKinematicsParameters& parameters) {
+  const Isometry3<double> X_WE =
+      robot.CalcFramePoseInWorldFrame(cache, frame_E);
+  const Vector6<double> V_WE_desired =
+      ComputePoseDiffInCommonFrame(X_WE, X_WE_desired) /
+      parameters.get_timestep();
+  // Call the below function.
+  return drake::manipulation::planner::rbt::DoDifferentialInverseKinematics(
+      robot, cache, V_WE_desired, frame_E, parameters);
+}
+
+DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
+    const RigidBodyTree<double>& robot, const KinematicsCache<double>& cache,
+    const Vector6<double>& V_WE_desired, const RigidBodyFrame<double>& frame_E,
+    const DifferentialInverseKinematicsParameters& parameters) {
+  Isometry3<double> X_WE = robot.CalcFramePoseInWorldFrame(cache, frame_E);
+  MatrixX<double> J_WE =
+      robot.CalcFrameSpatialVelocityJacobianInWorldFrame(cache, frame_E);
+  // Call the (non-attic) helper function.
+  return drake::manipulation::planner::detail::DoDifferentialInverseKinematics(
+      cache.getQ(), cache.getV(), X_WE, J_WE, V_WE_desired, parameters);
+}
+
+}  // namespace rbt
+}  // namespace planner
+}  // namespace manipulation
+}  // namespace drake

--- a/attic/manipulation/planner/rbt_differential_inverse_kinematics.h
+++ b/attic/manipulation/planner/rbt_differential_inverse_kinematics.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "drake/manipulation/planner/differential_inverse_kinematics.h"
+#include "drake/multibody/rigid_body_tree.h"
+
+namespace drake {
+namespace manipulation {
+namespace planner {
+namespace rbt {
+
+/**
+ * A wrapper over
+ * DoDifferentialInverseKinematics(q_current, v_current, V, J, params)
+ * that tracks frame E's spatial velocity.
+ * q_current and v_current are taken from @p cache. V is computed by first
+ * transforming @p V_WE to V_WE_E, then taking the element-wise product between
+ * V_WE_E and the gains (specified in frame E) in @p parameters, and only
+ * selecting the non zero elements. J is computed similarly.
+ * @param robot Kinematic tree.
+ * @param cache Kinematic cache build from the current generalized position and
+ * velocity.
+ * @param V_WE_desired Desired world frame spatial velocity of @p frame_E.
+ * @param frame_E End effector frame.
+ * @param parameters Collection of various problem specific constraints and
+ * constants.
+ * @return If the solver successfully finds a solution, joint_velocities will
+ * be set to v, otherwise it will be nullopt.
+ */
+DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
+    const RigidBodyTree<double>& robot, const KinematicsCache<double>& cache,
+    const Vector6<double>& V_WE_desired, const RigidBodyFrame<double>& frame_E,
+    const DifferentialInverseKinematicsParameters& parameters);
+
+/**
+ * A wrapper over
+ * DoDifferentialInverseKinematics(robot, cache, V_WE_desired, frame_E, params)
+ * that tracks frame E's pose in the world frame.
+ * q_current and v_current are taken from @p cache. V_WE is computed by
+ * ComputePoseDiffInCommonFrame(X_WE, X_WE_desired) / dt, where X_WE is computed
+ * from @p cache, and dt is taken from @p parameters.
+ * @param robot Robot model.
+ * @param cache KinematiCache built from the current generalized position and
+ * velocity.
+ * @param X_WE_desired Desired pose of @p frame_E in the world frame.
+ * @param frame_E End effector frame.
+ * @param parameters Collection of various problem specific constraints and
+ * constants.
+ * @return If the solver successfully finds a solution, joint_velocities will
+ * be set to v, otherwise it will be nullopt.
+ */
+DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
+    const RigidBodyTree<double>& robot, const KinematicsCache<double>& cache,
+    const Isometry3<double>& X_WE_desired,
+    const RigidBodyFrame<double>& frame_E,
+    const DifferentialInverseKinematicsParameters& parameters);
+
+}  // namespace rbt
+}  // namespace planner
+}  // namespace manipulation
+}  // namespace drake

--- a/manipulation/planner/BUILD.bazel
+++ b/manipulation/planner/BUILD.bazel
@@ -24,8 +24,6 @@ drake_cc_library(
     srcs = ["differential_inverse_kinematics.cc"],
     hdrs = ["differential_inverse_kinematics.h"],
     deps = [
-        "//attic/multibody:rigid_body_tree",
-        "//attic/multibody/parsers",
         "//multibody/multibody_tree/multibody_plant",
         "//solvers:mathematical_program",
     ],
@@ -40,7 +38,8 @@ drake_cc_googletest(
     ],
     deps = [
         ":differential_inverse_kinematics",
-        "//attic/manipulation/util:world_sim_tree_builder",
+        "//attic/manipulation/planner:rbt_differential_inverse_kinematics",
+        "//attic/multibody/parsers",
         "//common/test_utilities:eigen_matrix_compare",
         "//examples/kuka_iiwa_arm:iiwa_common",
         "//multibody/multibody_tree/parsing",

--- a/manipulation/planner/differential_inverse_kinematics.cc
+++ b/manipulation/planner/differential_inverse_kinematics.cc
@@ -12,7 +12,7 @@ namespace drake {
 namespace manipulation {
 namespace planner {
 
-namespace {
+namespace detail {
 DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
     const Eigen::Ref<const VectorX<double>>& q_current,
     const Eigen::Ref<const VectorX<double>>& v_current,
@@ -44,7 +44,7 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
       q_current, v_current, V_WE_E_scaled.head(num_cart_constraints),
       J_WE_E_scaled.topRows(num_cart_constraints), parameters);
 }
-}  // namespace
+}  // namespace detail
 
 std::ostream& operator<<(std::ostream& os,
                          const DifferentialInverseKinematicsStatus value) {
@@ -237,31 +237,6 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
 }
 
 DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
-    const RigidBodyTree<double>& robot, const KinematicsCache<double>& cache,
-    const Isometry3<double>& X_WE_desired,
-    const RigidBodyFrame<double>& frame_E,
-    const DifferentialInverseKinematicsParameters& parameters) {
-  const Isometry3<double> X_WE =
-      robot.CalcFramePoseInWorldFrame(cache, frame_E);
-  const Vector6<double> V_WE_desired =
-      ComputePoseDiffInCommonFrame(X_WE, X_WE_desired) /
-      parameters.get_timestep();
-  return DoDifferentialInverseKinematics(robot, cache, V_WE_desired, frame_E,
-                                         parameters);
-}
-
-DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
-    const RigidBodyTree<double>& robot, const KinematicsCache<double>& cache,
-    const Vector6<double>& V_WE_desired, const RigidBodyFrame<double>& frame_E,
-    const DifferentialInverseKinematicsParameters& parameters) {
-  Isometry3<double> X_WE = robot.CalcFramePoseInWorldFrame(cache, frame_E);
-  MatrixX<double> J_WE =
-      robot.CalcFrameSpatialVelocityJacobianInWorldFrame(cache, frame_E);
-  return DoDifferentialInverseKinematics(cache.getQ(), cache.getV(), X_WE, J_WE,
-                                         V_WE_desired, parameters);
-}
-
-DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
     const multibody::multibody_plant::MultibodyPlant<double>& plant,
     const systems::Context<double>& context,
     const Vector6<double>& V_WE_desired,
@@ -276,9 +251,10 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
 
   const auto& mbt_context =
       dynamic_cast<const multibody::MultibodyTreeContext<double>&>(context);
-  return DoDifferentialInverseKinematics(mbt_context.get_positions(),
-                                         mbt_context.get_velocities(), X_WE,
-                                         J_WE, V_WE_desired, parameters);
+  return detail::DoDifferentialInverseKinematics(mbt_context.get_positions(),
+                                                 mbt_context.get_velocities(),
+                                                 X_WE, J_WE, V_WE_desired,
+                                                 parameters);
 }
 
 DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
@@ -311,9 +287,10 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
 
   const auto& mbt_context =
       dynamic_cast<const multibody::MultibodyTreeContext<double>&>(context);
-  return DoDifferentialInverseKinematics(mbt_context.get_positions(),
-                                         mbt_context.get_velocities(), X_WE,
-                                         J_WE, V_WE_desired, parameters);
+  return detail::DoDifferentialInverseKinematics(mbt_context.get_positions(),
+                                                 mbt_context.get_velocities(),
+                                                 X_WE, J_WE, V_WE_desired,
+                                                 parameters);
 }
 
 DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(

--- a/manipulation/planner/differential_inverse_kinematics.h
+++ b/manipulation/planner/differential_inverse_kinematics.h
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <limits>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -13,8 +14,18 @@
 #include "drake/common/drake_optional.h"
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/multibody_tree/multibody_plant/multibody_plant.h"
-#include "drake/multibody/rigid_body_tree.h"
 #include "drake/solvers/mathematical_program.h"
+
+#ifndef DRAKE_DOXYGEN_CXX
+// Forward declarations because we only need the type name for deprecation
+// purposes; we never call any methods on an RBT.
+template <class T>
+class RigidBodyTree;
+template <class T>
+class RigidBodyFrame;
+template <class T>
+class KinematicsCache;
+#endif
 
 namespace drake {
 namespace manipulation {
@@ -282,51 +293,34 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
     const Eigen::Ref<const MatrixX<double>>& J,
     const DifferentialInverseKinematicsParameters& parameters);
 
-/**
- * A wrapper over
- * DoDifferentialInverseKinematics(q_current, v_current, V, J, params)
- * that tracks frame E's spatial velocity.
- * q_current and v_current are taken from @p cache. V is computed by first
- * transforming @p V_WE to V_WE_E, then taking the element-wise product between
- * V_WE_E and the gains (specified in frame E) in @p parameters, and only
- * selecting the non zero elements. J is computed similarly.
- * @param robot Kinematic tree.
- * @param cache Kinematic cache build from the current generalized position and
- * velocity.
- * @param V_WE_desired Desired world frame spatial velocity of @p frame_E.
- * @param frame_E End effector frame.
- * @param parameters Collection of various problem specific constraints and
- * constants.
- * @return If the solver successfully finds a solution, joint_velocities will
- * be set to v, otherwise it will be nullopt.
- */
-DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
-    const RigidBodyTree<double>& robot, const KinematicsCache<double>& cache,
-    const Vector6<double>& V_WE_desired, const RigidBodyFrame<double>& frame_E,
-    const DifferentialInverseKinematicsParameters& parameters);
-
-/**
- * A wrapper over
- * DoDifferentialInverseKinematics(robot, cache, V_WE_desired, frame_E, params)
- * that tracks frame E's pose in the world frame.
- * q_current and v_current are taken from @p cache. V_WE is computed by
- * ComputePoseDiffInCommonFrame(X_WE, X_WE_desired) / dt, where X_WE is computed
- * from @p cache, and dt is taken from @p parameters.
- * @param robot Robot model.
- * @param cache KinematiCache built from the current generalized position and
- * velocity.
- * @param X_WE_desired Desired pose of @p frame_E in the world frame.
- * @param frame_E End effector frame.
- * @param parameters Collection of various problem specific constraints and
- * constants.
- * @return If the solver successfully finds a solution, joint_velocities will
- * be set to v, otherwise it will be nullopt.
- */
-DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
-    const RigidBodyTree<double>& robot, const KinematicsCache<double>& cache,
-    const Isometry3<double>& X_WE_desired,
-    const RigidBodyFrame<double>& frame_E,
-    const DifferentialInverseKinematicsParameters& parameters);
+#ifndef DRAKE_DOXYGEN_CXX
+// TODO(jwnimmer-tri) Remove these stubs on or about 2019-03-01.
+// Remember to remove the forward declaration above at the same time.
+DRAKE_DEPRECATED(
+    "DiffIK for RigidBodyTree no longer uses this file; for new "
+    "instructions, see https://github.com/RobotLocomotion/drake/pull/####")
+inline DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
+    const RigidBodyTree<double>&, const KinematicsCache<double>&,
+    const Vector6<double>&, const RigidBodyFrame<double>&,
+    const DifferentialInverseKinematicsParameters&) {
+  throw std::runtime_error(
+      "DiffIK for RigidBodyTree no longer uses this file; for new "
+      "instructions, see https://github.com/RobotLocomotion/drake/pull/####");
+}
+// TODO(jwnimmer-tri) Remove these stubs on or about 2019-03-01.
+// Remember to remove the forward declaration above at the same time.
+DRAKE_DEPRECATED(
+    "DiffIK for RigidBodyTree no longer uses this file; for new "
+    "instructions, see https://github.com/RobotLocomotion/drake/pull/####")
+inline DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
+    const RigidBodyTree<double>&, const KinematicsCache<double>&,
+    const Isometry3<double>&, const RigidBodyFrame<double>&,
+    const DifferentialInverseKinematicsParameters&) {
+  throw std::runtime_error(
+      "DiffIK for RigidBodyTree no longer uses this file; for new "
+      "instructions, see https://github.com/RobotLocomotion/drake/pull/####");
+}
+#endif
 
 /**
  * A wrapper over
@@ -398,6 +392,18 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
     const Isometry3<double>& X_WE_desired,
     const multibody::Frame<double>& frame_E,
     const DifferentialInverseKinematicsParameters& parameters);
+
+#ifndef DRAKE_DOXYGEN_CXX
+namespace detail {
+DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
+    const Eigen::Ref<const VectorX<double>>&,
+    const Eigen::Ref<const VectorX<double>>&,
+    const Isometry3<double>&,
+    const Eigen::Ref<const MatrixX<double>>&,
+    const Vector6<double>&,
+    const DifferentialInverseKinematicsParameters&);
+}  // namespace detail
+#endif
 
 }  // namespace planner
 }  // namespace manipulation

--- a/manipulation/planner/test/differential_inverse_kinematics_test.cc
+++ b/manipulation/planner/test/differential_inverse_kinematics_test.cc
@@ -12,6 +12,7 @@
 #include "drake/common/find_resource.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/examples/kuka_iiwa_arm/iiwa_common.h"
+#include "drake/manipulation/planner/rbt_differential_inverse_kinematics.h"
 #include "drake/multibody/multibody_tree/parsing/multibody_plant_sdf_parser.h"
 #include "drake/multibody/parsers/urdf_parser.h"
 #include "drake/multibody/rigid_body.h"
@@ -150,8 +151,9 @@ TEST_F(DifferentialInverseKinematicsTest, PositiveTest) {
   auto V_WE = (Vector6<double>() << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0).finished();
 
   // Test without additional linear constraints.
-  DifferentialInverseKinematicsResult result = DoDifferentialInverseKinematics(
-      *tree_, *cache_, V_WE, *frame_E_, *params_);
+  DifferentialInverseKinematicsResult result =
+      rbt::DoDifferentialInverseKinematics(
+          *tree_, *cache_, V_WE, *frame_E_, *params_);
   DifferentialInverseKinematicsStatus function_status{result.status};
   drake::log()->info("function_status = {}", function_status);
 
@@ -162,8 +164,8 @@ TEST_F(DifferentialInverseKinematicsTest, PositiveTest) {
   const auto b = VectorX<double>::Zero(A.rows());
   params_->AddLinearVelocityConstraint(
       std::make_shared<LinearConstraint>(A, b, b));
-  result = DoDifferentialInverseKinematics(*tree_, *cache_, V_WE, *frame_E_,
-                                           *params_);
+  result = rbt::DoDifferentialInverseKinematics(
+      *tree_, *cache_, V_WE, *frame_E_, *params_);
   drake::log()->info("function_status = {}", function_status);
 
   CheckPositiveResult(V_WE, result);
@@ -181,8 +183,8 @@ TEST_F(DifferentialInverseKinematicsTest, OverConstrainedTest) {
   params_->AddLinearVelocityConstraint(
       std::make_shared<LinearConstraint>(A, b, b));
   DifferentialInverseKinematicsResult function_result =
-      DoDifferentialInverseKinematics(*tree_, *cache_, V_WE, *frame_E_,
-                                      *params_);
+      rbt::DoDifferentialInverseKinematics(
+          *tree_, *cache_, V_WE, *frame_E_, *params_);
   DifferentialInverseKinematicsStatus function_status{function_result.status};
   drake::log()->info("function_status = {}", function_status);
 
@@ -193,8 +195,8 @@ TEST_F(DifferentialInverseKinematicsTest, MultiBodyTreeTest) {
   const double eps = std::numeric_limits<double>::epsilon();
   auto V_WE = (Vector6<double>() << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0).finished();
   DifferentialInverseKinematicsResult rbt_result =
-      DoDifferentialInverseKinematics(*tree_, *cache_, V_WE, *frame_E_,
-                                      *params_);
+      rbt::DoDifferentialInverseKinematics(
+          *tree_, *cache_, V_WE, *frame_E_, *params_);
   DifferentialInverseKinematicsResult mbp_result =
       DoDifferentialInverseKinematics(*mbp_, *context_, V_WE, *frame_E_mbt_,
                                       *params_);
@@ -215,8 +217,8 @@ TEST_F(DifferentialInverseKinematicsTest, MultiBodyTreeTest) {
   Isometry3<double> X_WE_desired =
       Translation3<double>(Vector3<double>(0.1, 0.2, 0.3)) *
       AngleAxis<double>(3.44, Vector3<double>(0.3, -0.2, 0.1).normalized());
-  rbt_result = DoDifferentialInverseKinematics(*tree_, *cache_, X_WE_desired,
-                                               *frame_E_, *params_);
+  rbt_result = rbt::DoDifferentialInverseKinematics(
+      *tree_, *cache_, X_WE_desired, *frame_E_, *params_);
   mbp_result = DoDifferentialInverseKinematics(*mbp_, *context_, X_WE_desired,
                                                *frame_E_mbt_, *params_);
   // TODO(siyuanfeng-tri) Ideally a smaller tolerance would pass, but there
@@ -252,8 +254,8 @@ TEST_F(DifferentialInverseKinematicsTest, GainTest) {
     params_->set_end_effector_velocity_gain(gain_E);
 
     DifferentialInverseKinematicsResult function_result =
-        DoDifferentialInverseKinematics(*tree_, *cache_, V_WE_desired,
-                                        *frame_E_, *params_);
+        rbt::DoDifferentialInverseKinematics(
+            *tree_, *cache_, V_WE_desired, *frame_E_, *params_);
     ASSERT_TRUE(function_result.joint_velocities != nullopt);
 
     // Transform the resulting end effector frame's velocity into body frame.
@@ -299,8 +301,8 @@ TEST_F(DifferentialInverseKinematicsTest, SimpleTracker) {
   const double dt = params_->get_timestep();
   for (int iteration = 0; iteration < 900; iteration++) {
     DifferentialInverseKinematicsResult function_result =
-        DoDifferentialInverseKinematics(*tree_, *cache_, X_WE_desired,
-                                        *frame_E_, *params_);
+        rbt::DoDifferentialInverseKinematics(
+            *tree_, *cache_, X_WE_desired, *frame_E_, *params_);
 
     EXPECT_EQ(function_result.status,
               DifferentialInverseKinematicsStatus::kSolutionFound);


### PR DESCRIPTION
This removes the runtime dependency from //manipulation/planner into //attic.  The unit test is still based on RigidBodyTree.

Relates #9783.

I originally attempted to move this in #9965 but accidentally moved the MBP code into the attic as well, so reverted it in #9989.  This time, the MBP code is left alone.