### PR TITLE
mbp: Add "world" frame for ease of use in parsing

### DIFF
--- a/multibody/multibody_tree/multibody_tree.cc
+++ b/multibody/multibody_tree/multibody_tree.cc
@@ -10,6 +10,7 @@
 #include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/multibody_tree/body_node_welded.h"
+#include "drake/multibody/multibody_tree/fixed_offset_frame.h"
 #include "drake/multibody/multibody_tree/quaternion_floating_mobilizer.h"
 #include "drake/multibody/multibody_tree/rigid_body.h"
 #include "drake/multibody/multibody_tree/spatial_inertia.h"
@@ -70,6 +71,11 @@ MultibodyTree<T>::MultibodyTree() {
   ModelInstanceIndex default_instance =
       AddModelInstance("DefaultModelInstance");
   DRAKE_DEMAND(default_instance == default_model_instance());
+
+  // Add "world" frame for ease-of-use.
+  AddFrame(std::make_unique<FixedOffsetFrame<T>>(
+      "world", world_frame(), Eigen::Isometry3d::Identity(),
+      world_model_instance()));
 }
 
 template <typename T>

--- a/multibody/multibody_tree/multibody_tree.h
+++ b/multibody/multibody_tree/multibody_tree.h
@@ -309,6 +309,10 @@ class MultibodyTree {
     if (frame == nullptr) {
       throw std::logic_error("Input frame is a nullptr.");
     }
+    if (frame->name() == "world" && HasFrameNamed("world")) {
+      throw std::logic_error(
+          "'world' cannot be added as frame in any model instance");
+    }
     FrameIndex frame_index = topology_.add_frame(frame->body().index());
     // This test MUST be performed BEFORE frames_.push_back() and
     // owned_frames_.push_back() below. Do not move it around!

--- a/multibody/multibody_tree/test/multibody_tree_test.cc
+++ b/multibody/multibody_tree/test/multibody_tree_test.cc
@@ -14,6 +14,7 @@
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/benchmarks/kuka_iiwa_robot/MG/MG_kuka_iiwa_robot.h"
 #include "drake/multibody/benchmarks/kuka_iiwa_robot/make_kuka_iiwa_model.h"
+#include "drake/multibody/multibody_tree/fixed_offset_frame.h"
 #include "drake/multibody/multibody_tree/frame.h"
 #include "drake/multibody/multibody_tree/joints/revolute_joint.h"
 #include "drake/multibody/multibody_tree/multibody_tree_system.h"
@@ -231,6 +232,12 @@ GTEST_TEST(MultibodyTree, VerifyModelBasics) {
       /* Verify this method is throwing for the right reasons. */
       ".* already contains a joint actuator named 'iiwa_actuator_4'. "
           "Joint actuator names must be unique within a given model.");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      model->AddFrame(std::make_unique<FixedOffsetFrame<double>>(
+          "world", model->world_frame(), Eigen::Isometry3d::Identity())),
+      std::logic_error,
+      "'world' cannot be added as frame in any model instance");
 
   // Now we tested we cannot add body or joints with an existing name, finalize
   // the model.


### PR DESCRIPTION
Prevent users from adding in `world` frame.

Not yet sure how I feel about these constraints (as they don't simplify parsing, since the model instance is still necessary), but it's an initial pass.

\cc @siyuanfeng-tri

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10055)
<!-- Reviewable:end -->
