### PR TITLE
trajectory_optimization: Work around compiler warning

### DIFF
--- a/systems/trajectory_optimization/multiple_shooting.h
+++ b/systems/trajectory_optimization/multiple_shooting.h
@@ -106,7 +106,8 @@ class MultipleShooting : public solvers::MathematicalProgram {
   /// index @p index.
   Eigen::VectorBlock<const solvers::VectorXDecisionVariable> input(
       int index) const {
-    DRAKE_DEMAND(index >= 0 && index < N_);
+    DRAKE_DEMAND(index >= 0);
+    DRAKE_DEMAND(index < N_);
     return u_vars_.segment(index * num_inputs_, num_inputs_);
   }
 


### PR DESCRIPTION
There is a -Wstrict-overflow gripe here if we use the conjunction. Listing each condition separately doesn't rise to the level of a warning.

Closes #9895.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10056)
<!-- Reviewable:end -->
