### PR TITLE
multibody/parsing: Add filename extension handling

### DIFF
--- a/bindings/pydrake/multibody/multibody_tree_py.cc
+++ b/bindings/pydrake/multibody/multibody_tree_py.cc
@@ -21,7 +21,8 @@
 #include "drake/multibody/multibody_tree/multibody_plant/contact_results.h"
 #include "drake/multibody/multibody_tree/multibody_plant/multibody_plant.h"
 #include "drake/multibody/multibody_tree/multibody_tree.h"
-#include "drake/multibody/multibody_tree/parsing/multibody_plant_sdf_parser.h"
+#include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/parsing/sdf_parser.h"
 
 namespace drake {
 namespace pydrake {
@@ -773,6 +774,19 @@ void init_parsing(py::module m) {
   constexpr auto& doc = pydrake_doc.drake.multibody.parsing;
 
   using multibody_plant::MultibodyPlant;
+
+  // Parser
+  {
+    using Class = Parser;
+    py::class_<Class>(m, "Parser", doc.Parser.doc)
+        .def(py::init<MultibodyPlant<double>*, SceneGraph<double>*>(),
+             py::arg("plant"), py::arg("scene_graph") = nullptr,
+             doc.Parser.ctor.doc_2args)
+        .def("AddAllModelsFromFile", &Class::AddAllModelsFromFile,
+             py::arg("file_name"), doc.Parser.AddAllModelsFromFile.doc)
+        .def("AddModelFromFile", &Class::AddModelFromFile, py::arg("file_name"),
+             py::arg("model_name") = "", doc.Parser.AddModelFromFile.doc);
+  }
 
   m.def("AddModelFromSdfFile",
         py::overload_cast<const string&, const string&, MultibodyPlant<T>*,

--- a/examples/multibody/acrobot/BUILD.bazel
+++ b/examples/multibody/acrobot/BUILD.bazel
@@ -45,7 +45,7 @@ drake_cc_binary(
         "//common:text_logging_gflags",
         "//geometry:geometry_visualization",
         "//multibody/benchmarks/acrobot:make_acrobot_plant",
-        "//multibody/multibody_tree/parsing:multibody_plant_sdf_parser",
+        "//multibody/parsing",
         "//systems/analysis:simulator",
         "//systems/controllers:linear_quadratic_regulator",
         "//systems/framework:diagram",

--- a/examples/multibody/acrobot/run_lqr.cc
+++ b/examples/multibody/acrobot/run_lqr.cc
@@ -10,8 +10,8 @@
 #include "drake/lcm/drake_lcm.h"
 #include "drake/multibody/benchmarks/acrobot/make_acrobot_plant.h"
 #include "drake/multibody/multibody_tree/joints/revolute_joint.h"
-#include "drake/multibody/multibody_tree/parsing/multibody_plant_sdf_parser.h"
 #include "drake/multibody/multibody_tree/uniform_gravity_field_element.h"
+#include "drake/multibody/parsing/parser.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/controllers/linear_quadratic_regulator.h"
 #include "drake/systems/framework/diagram_builder.h"
@@ -25,7 +25,7 @@ using lcm::DrakeLcm;
 using multibody::benchmarks::acrobot::AcrobotParameters;
 using multibody::benchmarks::acrobot::MakeAcrobotPlant;
 using multibody::multibody_plant::MultibodyPlant;
-using multibody::parsing::AddModelFromSdfFile;
+using multibody::parsing::Parser;
 using multibody::JointActuator;
 using multibody::RevoluteJoint;
 using multibody::UniformGravityFieldElement;
@@ -58,7 +58,8 @@ std::unique_ptr<systems::AffineSystem<double>> MakeBalancingLQRController(
   // created along with a SceneGraph for simulation would also have input ports
   // to interact with that SceneGraph).
   MultibodyPlant<double> acrobot;
-  AddModelFromSdfFile(full_name, &acrobot);
+  Parser parser(&acrobot);
+  parser.AddModelFromFile(full_name);
   // Add gravity to the model.
   acrobot.AddForceElement<UniformGravityFieldElement>(
       -9.81 * Vector3<double>::UnitZ());
@@ -108,7 +109,8 @@ int do_main() {
   MultibodyPlant<double>& acrobot =
       *builder.AddSystem<MultibodyPlant>(time_step);
 
-  AddModelFromSdfFile(full_name, &acrobot, &scene_graph);
+  Parser parser(&acrobot, &scene_graph);
+  parser.AddModelFromFile(full_name);
 
   // Add gravity to the model.
   acrobot.AddForceElement<UniformGravityFieldElement>(

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.h
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.h
@@ -82,28 +82,27 @@ namespace multibody_plant {
 ///
 /// @section sdf_loading Loading models from SDF files
 ///
-/// Drake has the capability of loading multibody models from SDF files.
-/// Consider the example below which loads an acrobot model from a file:
+/// Drake has the capability of loading multibody models from SDF and URDF
+/// files.  Consider the example below which loads an acrobot model:
 /// @code
 ///   MultibodyPlant<T> acrobot;
+///   SceneGraph<T> scene_graph;
+///   Parser parser(&acrobot, &scene_graph);
 ///   const std::string relative_name =
 ///     "drake/multibody/benchmarks/acrobot/acrobot.sdf";
 ///   const std::string full_name = FindResourceOrThrow(relative_name);
-///   AddModelFromSdfFile(full_name, &acrobot, &scene_graph);
+///   parser.AddModelFromFile(full_name);
 /// @endcode
 /// As in the example above, for models including visual geometry, collision
 /// geometry or both, the user must specify a SceneGraph for geometry handling.
 /// You can find a full example of the LQR controlled acrobot in
 /// examples/multibody/acrobot/run_lqr.cc.
 ///
-/// AddModelFromSdfFile() can be invoked multiple times on the same plant in
-/// order to load multiple model instances.
-/// Other parsing variants are available in
-/// multibody/multibody_tree/parsing/multibody_plant_sdf_parser.h such as
-/// AddModelsFromSdfFile() (please note the change to plural, i.e, "Models"
-/// instead of "Model") which allows creating model instances per each
-/// `<model>` tag found in the file. Please refer to each of these method's
-/// documentation for further details.
+/// AddModelFromFile() can be invoked multiple times on the same plant in order
+/// to load multiple model instances.  Other methods are available on Parser
+/// such as AddAllModelsFromFile() which allows creating model instances per
+/// each `<model>` tag found in the file. Please refer to each of these
+/// methods' documentation for further details.
 ///
 /// @section adding_elements Adding modeling elements
 ///

--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -26,6 +26,7 @@ drake_cc_package_library(
     name = "parsing",
     deps = [
         ":package_map",
+        ":parser",
         ":parser_common",
         ":parser_path_utils",
         ":scene_graph_parser_detail",
@@ -179,6 +180,20 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "parser",
+    srcs = [
+        "parser.cc",
+    ],
+    hdrs = [
+        "parser.h",
+    ],
+    deps = [
+        ":sdf_parser",
+        ":urdf_parser",
+    ],
+)
+
+drake_cc_library(
     name = "test_loaders",
     testonly = 1,
     srcs = [
@@ -233,6 +248,19 @@ drake_cc_googletest(
     ],
     deps = [
         ":test_loaders",
+        "//common/test_utilities",
+    ],
+)
+
+drake_cc_googletest(
+    name = "parser_test",
+    data = [
+        ":test_models",
+        "//multibody/benchmarks/acrobot:models",
+    ],
+    deps = [
+        ":parser",
+        "//common:find_resource",
         "//common/test_utilities",
     ],
 )

--- a/multibody/parsing/parser.cc
+++ b/multibody/parsing/parser.cc
@@ -1,0 +1,58 @@
+#include "drake/multibody/parsing/parser.h"
+
+#include <spruce.hh>
+
+#include "drake/multibody/parsing/sdf_parser.h"
+#include "drake/multibody/parsing/urdf_parser.h"
+
+namespace drake {
+namespace multibody {
+namespace parsing {
+
+Parser::Parser(
+    multibody_plant::MultibodyPlant<double>* plant,
+    geometry::SceneGraph<double>* scene_graph)
+    : plant_(plant), scene_graph_(scene_graph) {
+  DRAKE_THROW_UNLESS(plant != nullptr);
+}
+
+namespace {
+enum class FileType { kSdf, kUrdf };
+FileType DetermineFileType(const std::string& file_name) {
+  const std::string ext = spruce::path(file_name).extension();
+  if ((ext == ".urdf") || (ext == ".URDF")) {
+    return FileType::kUrdf;
+  }
+  if ((ext == ".sdf") || (ext == ".SDF")) {
+    return FileType::kSdf;
+  }
+  throw std::runtime_error(fmt::format(
+      "The file type '{}' is not supported for '{}'",
+      ext, file_name));
+}
+}  // namespace
+
+std::vector<ModelInstanceIndex> Parser::AddAllModelsFromFile(
+    const std::string& file_name) {
+  const FileType type = DetermineFileType(file_name);
+  if (type == FileType::kSdf) {
+    return AddModelsFromSdfFile(file_name, plant_, scene_graph_);
+  } else {
+    return {AddModelFromUrdfFile(file_name, {}, plant_, scene_graph_)};
+  }
+}
+
+ModelInstanceIndex Parser::AddModelFromFile(
+    const std::string& file_name,
+    const std::string& model_name) {
+  const FileType type = DetermineFileType(file_name);
+  if (type == FileType::kSdf) {
+    return AddModelFromSdfFile(file_name, model_name, plant_, scene_graph_);
+  } else {
+    return AddModelFromUrdfFile(file_name, model_name, plant_, scene_graph_);
+  }
+}
+
+}  // namespace parsing
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/parsing/parser.h
+++ b/multibody/parsing/parser.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "drake/geometry/scene_graph.h"
+#include "drake/multibody/multibody_tree/multibody_plant/multibody_plant.h"
+#include "drake/multibody/multibody_tree/multibody_tree_indexes.h"
+
+namespace drake {
+namespace multibody {
+namespace parsing {
+
+/// Parses SDF and URDF input files into a MultibodyPlant and (optionally) a
+/// SceneGraph.
+class Parser final {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Parser)
+
+  /// Creates a Parser that adds models to the given plant and (optionally)
+  /// scene_graph.
+  ///
+  /// @param plant A pointer to a mutable MultibodyPlant object to which parsed
+  ///   model(s) will be added; `plant->is_finalized()` must remain `false` for
+  ///   as long as the @p plant is in used by `this`.
+  /// @param scene_graph A pointer to a mutable SceneGraph object used for
+  ///   geometry registration (either to model visual or contact geometry).
+  ///   May be nullptr.
+  explicit Parser(
+    multibody_plant::MultibodyPlant<double>* plant,
+    geometry::SceneGraph<double>* scene_graph = nullptr);
+
+  /// Parses the SDF or URDF file named in @p file_name and adds all of its
+  /// model(s) to @p plant.
+  ///
+  /// SDF files may contain multiple `<model>` elements.  New model instances
+  /// will be added to @p plant for each `<model>` tag in the file.
+  ///
+  /// URDF files contain a single `<robot>` element.  Only a single model
+  /// instance will be added to @p plant.
+  ///
+  /// @param file_name The name of the SDF or URDF file to be parsed.  The file
+  ///   type will be inferred from the extension.
+  /// @returns The set of model instance indices for the newly added models.
+  /// @throws std::exception in case of errors.
+  std::vector<ModelInstanceIndex> AddAllModelsFromFile(
+      const std::string& file_name);
+
+  /// Parses the SDF or URDF file named in @p file_name and adds one model to
+  /// @p plant.  It is an error to call this using an SDF file with more than
+  /// one `<model>` element.
+  ///
+  /// @param file_name The name of the SDF or URDF file to be parsed.  The file
+  ///   type will be inferred from the extension.
+  /// @param model_name The name given to the newly created instance of this
+  ///   model.  If empty, the "name" attribute from the `<model>` or `<robot>`
+  ///   tag will be used.
+  /// @returns The instance index for the newly added model.
+  /// @throws std::exception in case of errors.
+  ModelInstanceIndex AddModelFromFile(
+      const std::string& file_name,
+      const std::string& model_name = {});
+
+ private:
+  multibody_plant::MultibodyPlant<double>* const plant_;
+  geometry::SceneGraph<double>* const scene_graph_;
+};
+
+}  // namespace parsing
+}  // namespace multibody
+}  // namespace drake
+

--- a/multibody/parsing/sdf_parser.h
+++ b/multibody/parsing/sdf_parser.h
@@ -6,7 +6,6 @@
 #include "drake/geometry/scene_graph.h"
 #include "drake/multibody/multibody_tree/multibody_plant/multibody_plant.h"
 #include "drake/multibody/multibody_tree/multibody_tree_indexes.h"
-#include "drake/multibody/parsing/sdf_parser_common.h"
 
 namespace drake {
 namespace multibody {

--- a/multibody/parsing/test/parser_test.cc
+++ b/multibody/parsing/test/parser_test.cc
@@ -1,0 +1,117 @@
+#include "drake/multibody/parsing/parser.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+using drake::multibody::multibody_plant::MultibodyPlant;
+
+namespace drake {
+namespace multibody {
+namespace parsing {
+namespace test {
+namespace {
+
+GTEST_TEST(FileParserTest, BasicTest) {
+  const std::string sdf_name = FindResourceOrThrow(
+      "drake/multibody/benchmarks/acrobot/acrobot.sdf");
+  const std::string urdf_name = FindResourceOrThrow(
+      "drake/multibody/benchmarks/acrobot/acrobot.urdf");
+
+  // Load from SDF using plural method.
+  // Add a second one with an overridden model_name.
+  {
+    MultibodyPlant<double> plant;
+    Parser dut(&plant);
+    EXPECT_EQ(dut.AddAllModelsFromFile(sdf_name).size(), 1);
+    dut.AddModelFromFile(sdf_name, "foo");
+  }
+
+  // Load from URDF using plural method.
+  // Add a second one with an overridden model_name.
+  {
+    MultibodyPlant<double> plant;
+    Parser dut(&plant);
+    EXPECT_EQ(dut.AddAllModelsFromFile(urdf_name).size(), 1);
+    dut.AddModelFromFile(urdf_name, "foo");
+  }
+
+  // Load an SDF then a URDF.
+  {
+    MultibodyPlant<double> plant;
+    Parser dut(&plant);
+    dut.AddModelFromFile(sdf_name, "foo");
+    dut.AddModelFromFile(urdf_name, "bar");
+  }
+}
+
+GTEST_TEST(FileParserTest, MultiModelTest) {
+  const std::string sdf_name = FindResourceOrThrow(
+      "drake/multibody/parsing/test/two_models.sdf");
+
+  // Check that the plural method loads two models.
+  {
+    MultibodyPlant<double> plant;
+    EXPECT_EQ(Parser(&plant).AddAllModelsFromFile(sdf_name).size(), 2);
+  }
+
+  // The singular method cannot load a two-model file.
+  const char* const expected_error =
+      "(.*must have a single <model> element.*)";
+
+  // Check the singular method without model_name.
+  {
+    MultibodyPlant<double> plant;
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        Parser(&plant).AddModelFromFile(sdf_name),
+        std::exception, expected_error);
+  }
+
+  // Check the singular method with empty model_name.
+  {
+    MultibodyPlant<double> plant;
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        Parser(&plant).AddModelFromFile(sdf_name, ""),
+        std::exception, expected_error);
+  }
+
+  // Check the singular method with non-empty model_name.
+  {
+    MultibodyPlant<double> plant;
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        Parser(&plant).AddModelFromFile(sdf_name, "foo"),
+        std::exception, expected_error);
+  }
+}
+
+GTEST_TEST(FileParserTest, ExtensionMatchTest) {
+  // An unknown extension is an error.
+  // (Check both singular and plural overloads.)
+  MultibodyPlant<double> plant;
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      Parser(&plant).AddModelFromFile("acrobot.foo"),
+      std::exception,
+      ".*file type '\\.foo' is not supported .*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      Parser(&plant).AddAllModelsFromFile("acrobot.foo"),
+      std::exception,
+      ".*file type '\\.foo' is not supported .*");
+
+  // Uppercase extensions are accepted (i.e., still call the underlying SDF or
+  // URDF parser, shown here by it generating a different exception message).
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      Parser(&plant).AddModelFromFile("acrobot.SDF"),
+      std::exception,
+      ".*does not exist.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      Parser(&plant).AddModelFromFile("acrobot.URDF"),
+      std::exception,
+      ".*does not exist.*");
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace parsing
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/parsing/test/sdf_parser_test.cc
+++ b/multibody/parsing/test/sdf_parser_test.cc
@@ -13,6 +13,7 @@
 #include "drake/math/rigid_transform.h"
 #include "drake/math/roll_pitch_yaw.h"
 #include "drake/multibody/multibody_tree/multibody_plant/multibody_plant.h"
+#include "drake/multibody/parsing/sdf_parser_common.h"
 #include "drake/systems/framework/context.h"
 
 namespace drake {

--- a/multibody/parsing/test/two_models.sdf
+++ b/multibody/parsing/test/two_models.sdf
@@ -1,0 +1,6 @@
+<sdf version='1.6'>
+  <model name='robot1'>
+  </model>
+  <model name='robot2'>
+  </model>
+</sdf>


### PR DESCRIPTION
The boilerplate repetition is growing rapidly for "if (endswith sdf) then `AddModelFromSdfFile` elif (endswith .urdf) then `AddModelFromUrdfFile`".  Let's nip it in the bud with `AddModelFromFile`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10058)
<!-- Reviewable:end -->
