### PR TITLE
py autodiff: Ensure fixed-size vectors are converted correctly

### DIFF
--- a/bindings/pydrake/multibody/rigid_body_tree_py.cc
+++ b/bindings/pydrake/multibody/rigid_body_tree_py.cc
@@ -429,6 +429,16 @@ PYBIND11_MODULE(rigid_body_tree, m) {
                    cache, points, from_body_or_frame_ind, to_body_or_frame_ind);
              },
              doc.RigidBodyTree.transformPoints.doc)
+        .def("relativeRollPitchYaw",
+             [](const RigidBodyTree<double>& tree,
+                const KinematicsCache<T>& cache, int from_body_or_frame_ind,
+                int to_body_or_frame_ind) {
+               return tree.relativeRollPitchYaw(cache, from_body_or_frame_ind,
+                                                to_body_or_frame_ind);
+             },
+             py::arg("cache"), py::arg("from_body_or_frame_ind"),
+             py::arg("to_body_or_frame_ind"),
+             doc.RigidBodyTree.relativeRollPitchYaw.doc)
         .def("transformPointsJacobian",
              [](const RigidBodyTree<double>& tree,
                 const KinematicsCache<T>& cache, const Matrix3X<double>& points,

--- a/bindings/pydrake/test/autodiffutils_test.py
+++ b/bindings/pydrake/test/autodiffutils_test.py
@@ -15,6 +15,7 @@ from pydrake.test.algebra_test_util import ScalarAlgebra, VectorizedAlgebra
 from pydrake.test.autodiffutils_test_util import (
     autodiff_scalar_pass_through,
     autodiff_vector_pass_through,
+    autodiff_vector3_pass_through,
 )
 
 # Use convenience abbreviation.
@@ -62,6 +63,11 @@ class TestAutoDiffXd(unittest.TestCase):
         self._check_scalar(
             autodiff_scalar_pass_through(1.),  # float
             AD(1., []))
+        # Test multi-element pass-through.
+        x = np.array([AD(1.), AD(2.), AD(3.)])
+        self._check_array(autodiff_vector_pass_through(x), x)
+        # Ensure fixed-size vectors are correctly converted (#9886).
+        self._check_array(autodiff_vector3_pass_through(x), x)
         # Ensure we can copy.
         self._check_scalar(copy.copy(a), a)
         self._check_scalar(copy.deepcopy(a), a)

--- a/bindings/pydrake/test/autodiffutils_test_util_py.cc
+++ b/bindings/pydrake/test/autodiffutils_test_util_py.cc
@@ -3,6 +3,8 @@
 
 #include "drake/bindings/pydrake/autodiff_types_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/math/roll_pitch_yaw.h"
+#include "drake/math/rotation_matrix.h"
 
 namespace drake {
 namespace pydrake {
@@ -17,6 +19,8 @@ PYBIND11_MODULE(autodiffutils_test_util, m) {
         [](const AutoDiffXd& value) { return value; });
   m.def("autodiff_vector_pass_through",
         [](const VectorX<AutoDiffXd>& value) { return value; });
+  m.def("autodiff_vector3_pass_through",
+        [](const Vector3<AutoDiffXd>& value) { return value; });
 }
 
 }  // namespace pydrake

--- a/tools/workspace/pybind11/repository.bzl
+++ b/tools/workspace/pybind11/repository.bzl
@@ -5,9 +5,9 @@ load("@drake//tools/workspace:github.bzl", "github_archive")
 
 _REPOSITORY = "RobotLocomotion/pybind11"
 
-_COMMIT = "cd239232aa51cbb12045d6283ccecac6df26f6b9"
+_COMMIT = "5501496d6984d81bef3a0dacd9a2e368d544bfce"
 
-_SHA256 = "bff3e651c80ac46b582edf92a846b514618d2ef5ebe3ccdec223cd4ae44b7e65"
+_SHA256 = "03f880238bdd4c29536448eb3999a75d38ff677ed1b3e38cdca0e8fd35753262"
 
 def pybind11_repository(
         name,


### PR DESCRIPTION
Resolves #9886

Requires:
- [x] https://github.com/RobotLocomotion/pybind11/pull/26

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10061)
<!-- Reviewable:end -->
