### PR TITLE
make parameter accessors in Context consistent with state accessors

### DIFF
--- a/automotive/test/mobil_planner_test.cc
+++ b/automotive/test/mobil_planner_test.cc
@@ -187,7 +187,7 @@ TEST_P(MobilPlannerTest, MutableParameterAccessors) {
   InitializeDragway(2 /* num_lanes */);
   InitializeMobilPlanner(true /* initial_with_s */);
 
-  ASSERT_EQ(2, context_->num_numeric_parameters());
+  ASSERT_EQ(2, context_->num_numeric_parameter_groups());
   const auto mobil = dynamic_cast<const MobilPlanner<double>*>(dut_.get());
 
   auto& mobil_params = mobil->get_mutable_mobil_params(context_.get());

--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -308,8 +308,9 @@ void DefineFrameworkPySemantics(py::module m) {
         .def(py::init<unique_ptr<AbstractValue>>(), py::arg("value"),
              // Keep alive, ownership: `value` keeps `self` alive.
              py::keep_alive<2, 1>(), doc.Parameters.ctor.doc_1args_value)
-        .def("num_numeric_parameters", &Parameters<T>::num_numeric_parameters,
-             doc.Parameters.num_numeric_parameters.doc)
+        .def("num_numeric_parameter_groups",
+             &Parameters<T>::num_numeric_parameter_groups,
+             doc.Parameters.num_numeric_parameter_groups.doc)
         .def("num_abstract_parameters", &Parameters<T>::num_abstract_parameters,
              doc.Parameters.num_abstract_parameters.doc)
         .def("get_numeric_parameter", &Parameters<T>::get_numeric_parameter,

--- a/bindings/pydrake/systems/test/value_test.py
+++ b/bindings/pydrake/systems/test/value_test.py
@@ -167,7 +167,7 @@ class TestValue(unittest.TestCase):
 
         params = Parameters(
             numeric=[model_numeric.Clone()], abstract=[model_abstract.Clone()])
-        self.assertEqual(params.num_numeric_parameters(), 1)
+        self.assertEqual(params.num_numeric_parameter_groups(), 1)
         self.assertEqual(params.num_abstract_parameters(), 1)
         # Numeric.
         compare(params.get_numeric_parameter(index=0), model_numeric)

--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -177,8 +177,15 @@ class Context : public ContextBase {
   const Parameters<T>& get_parameters() const { return *parameters_; }
 
   /// Returns the number of vector-valued parameters.
+  int num_numeric_parameter_groups() const {
+    return parameters_->num_numeric_parameter_groups();
+  }
+
+  DRAKE_DEPRECATED(
+      "Use num_numeric_parameter_groups().  This method will be removed after "
+      "2/15/19.")
   int num_numeric_parameters() const {
-    return parameters_->num_numeric_parameters();
+    return num_numeric_parameter_groups();
   }
 
   /// Returns a const reference to the vector-valued parameter at @p index.

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -121,7 +121,7 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
     for (SubsystemIndex i(0); i < num_subsystems(); ++i) {
       auto& subcontext = diagram_context->GetSubsystemContext(i);
 
-      if (!subcontext.num_numeric_parameters() &&
+      if (!subcontext.num_numeric_parameter_groups() &&
           !subcontext.num_abstract_parameters()) {
         // Then there is no work to do for this subcontext.
         continue;
@@ -135,11 +135,11 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
       // expensive.
 
       std::vector<BasicVector<T>*> numeric_params;
-      for (int j = 0; j < subcontext.num_numeric_parameters(); ++j) {
+      for (int j = 0; j < subcontext.num_numeric_parameter_groups(); ++j) {
         numeric_params.push_back(&params->get_mutable_numeric_parameter(
             numeric_parameter_offset + j));
       }
-      numeric_parameter_offset += subcontext.num_numeric_parameters();
+      numeric_parameter_offset += subcontext.num_numeric_parameter_groups();
 
       std::vector<AbstractValue*> abstract_params;
       for (int j = 0; j < subcontext.num_abstract_parameters(); ++j) {
@@ -186,7 +186,7 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
     for (SubsystemIndex i(0); i < num_subsystems(); ++i) {
       auto& subcontext = diagram_context->GetSubsystemContext(i);
 
-      if (!subcontext.num_numeric_parameters() &&
+      if (!subcontext.num_numeric_parameter_groups() &&
           !subcontext.num_abstract_parameters()) {
         // Then there is no work to do for this subcontext.
         continue;
@@ -201,11 +201,11 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
 
       std::vector<BasicVector<T>*> numeric_params;
       std::vector<AbstractValue*> abstract_params;
-      for (int j = 0; j < subcontext.num_numeric_parameters(); ++j) {
+      for (int j = 0; j < subcontext.num_numeric_parameter_groups(); ++j) {
         numeric_params.push_back(&params->get_mutable_numeric_parameter(
             numeric_parameter_offset + j));
       }
-      numeric_parameter_offset += subcontext.num_numeric_parameters();
+      numeric_parameter_offset += subcontext.num_numeric_parameter_groups();
       for (int j = 0; j < subcontext.num_abstract_parameters(); ++j) {
         abstract_params.push_back(&params->get_mutable_abstract_parameter(
             abstract_parameter_offset + j));

--- a/systems/framework/diagram_context.h
+++ b/systems/framework/diagram_context.h
@@ -316,7 +316,7 @@ class DiagramContext final : public Context<T> {
       // Using `access` here to avoid sending invalidations.
       Parameters<T>& subparams =
           Context<T>::access_mutable_parameters(&*subcontext);
-      for (int i = 0; i < subparams.num_numeric_parameters(); ++i) {
+      for (int i = 0; i < subparams.num_numeric_parameter_groups(); ++i) {
         numeric_params.push_back(&subparams.get_mutable_numeric_parameter(i));
       }
       for (int i = 0; i < subparams.num_abstract_parameters(); ++i) {

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -157,7 +157,8 @@ class LeafSystem : public System<T> {
     }
 
     // The numeric parameters must all be valid BasicVectors.
-    const int num_numeric_parameters = context->num_numeric_parameters();
+    const int num_numeric_parameters =
+        context->num_numeric_parameter_groups();
     for (int i = 0; i < num_numeric_parameters; ++i) {
       const BasicVector<T>& group = context->get_numeric_parameter(i);
       detail::CheckBasicVectorInvariants(&group);
@@ -206,7 +207,7 @@ class LeafSystem : public System<T> {
   void SetDefaultParameters(const Context<T>& context,
                             Parameters<T>* parameters) const override {
     unused(context);
-    for (int i = 0; i < parameters->num_numeric_parameters(); i++) {
+    for (int i = 0; i < parameters->num_numeric_parameter_groups(); i++) {
       BasicVector<T>& p = parameters->get_mutable_numeric_parameter(i);
       auto model_vector = model_numeric_parameters_.CloneVectorModel<T>(i);
       if (model_vector != nullptr) {

--- a/systems/framework/parameters.h
+++ b/systems/framework/parameters.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/systems/framework/abstract_values.h"
 #include "drake/systems/framework/discrete_values.h"
 
@@ -63,11 +64,17 @@ class Parameters {
 
   virtual ~Parameters() {}
 
-  int num_numeric_parameters() const {
+  int num_numeric_parameter_groups() const {
     return numeric_parameters_->num_groups();
   }
 
-  int num_abstract_parameters() const {
+  DRAKE_DEPRECATED("Use num_numeric_parameter_groups().  This method will be"
+                   " removed after 2/15/19.")
+  int num_numeric_parameters() const {
+    return num_numeric_parameter_groups();
+  }
+
+    int num_abstract_parameters() const {
     return abstract_parameters_->size();
   }
 

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -201,9 +201,9 @@ class System : public SystemBase {
 
     // Set the default parameters, checking that the number of parameters does
     // not change.
-    const int num_params = context->num_numeric_parameters();
+    const int num_params = context->num_numeric_parameter_groups();
     SetDefaultParameters(*context, &context->get_mutable_parameters());
-    DRAKE_DEMAND(num_params == context->num_numeric_parameters());
+    DRAKE_DEMAND(num_params == context->num_numeric_parameter_groups());
   }
 
   /// Assigns random values to all elements of the state.
@@ -258,10 +258,10 @@ class System : public SystemBase {
 
     // Set the default parameters, checking that the number of parameters does
     // not change.
-    const int num_params = context->num_numeric_parameters();
+    const int num_params = context->num_numeric_parameter_groups();
     SetRandomParameters(*context, &context->get_mutable_parameters(),
                         generator);
-    DRAKE_DEMAND(num_params == context->num_numeric_parameters());
+    DRAKE_DEMAND(num_params == context->num_numeric_parameter_groups());
   }
 
   /// For each input port, allocates a fixed input of the concrete type

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -735,8 +735,14 @@ class SystemBase : public internal::SystemMessageInterface {
 
   /** Returns the number of declared numeric parameters (each of these is
   a vector-valued parameter). */
-  int num_numeric_parameters() const {
+  int num_numeric_parameter_groups() const {
     return static_cast<int>(numeric_parameter_tickets_.size());
+  }
+
+  DRAKE_DEPRECATED("Use num_numeric_parameter_groups().  This method will be"
+                   " removed after 2/15/19.")
+  int num_numeric_parameters() const {
+    return num_numeric_parameter_groups();
   }
 
   /** Returns the number of declared abstract parameters. */
@@ -848,7 +854,7 @@ class SystemBase : public internal::SystemMessageInterface {
   @pre The supplied index must be the next available one; that is, indexes
        must be assigned sequentially. */
   void AddNumericParameter(NumericParameterIndex index) {
-    DRAKE_DEMAND(index == num_numeric_parameters());
+    DRAKE_DEMAND(index == num_numeric_parameter_groups());
     const DependencyTicket ticket(assign_next_dependency_ticket());
     numeric_parameter_tickets_.push_back(
         {ticket, "numeric parameter " + std::to_string(index)});
@@ -1036,7 +1042,7 @@ class SystemBase : public internal::SystemMessageInterface {
 
   const TrackerInfo& numeric_parameter_tracker_info(
       NumericParameterIndex index) const {
-    DRAKE_DEMAND(0 <= index && index < num_numeric_parameters());
+    DRAKE_DEMAND(0 <= index && index < num_numeric_parameter_groups());
     return numeric_parameter_tickets_[index];
   }
 

--- a/systems/framework/system_symbolic_inspector.cc
+++ b/systems/framework/system_symbolic_inspector.cc
@@ -18,7 +18,7 @@ SystemSymbolicInspector::SystemSymbolicInspector(
       input_variables_(system.get_num_input_ports()),
       continuous_state_variables_(context_->get_continuous_state().size()),
       discrete_state_variables_(context_->get_num_discrete_state_groups()),
-      numeric_parameters_(context_->num_numeric_parameters()),
+      numeric_parameters_(context_->num_numeric_parameter_groups()),
       output_(system.AllocateOutput()),
       derivatives_(system.AllocateTimeDerivatives()),
       discrete_updates_(system.AllocateDiscreteVariables()),
@@ -120,7 +120,7 @@ void SystemSymbolicInspector::InitializeDiscreteState() {
 void SystemSymbolicInspector::InitializeParameters() {
   // For each numeric parameter vector i, set each element j to a symbolic
   // expression whose value is the variable "pi_j".
-  for (int i = 0; i < context_->num_numeric_parameters(); ++i) {
+  for (int i = 0; i < context_->num_numeric_parameter_groups(); ++i) {
     auto& pi = context_->get_mutable_numeric_parameter(i);
     numeric_parameters_[i].resize(pi.size());
     for (int j = 0; j < pi.size(); ++j) {

--- a/systems/framework/test/diagram_context_test.cc
+++ b/systems/framework/test/diagram_context_test.cc
@@ -117,7 +117,7 @@ class DiagramContextTest : public ::testing::Test {
     EXPECT_EQ(context_->get_continuous_state().size(), 2);
     EXPECT_EQ(context_->get_num_discrete_state_groups(), 1);
     EXPECT_EQ(context_->get_num_abstract_states(), 1);
-    EXPECT_EQ(context_->num_numeric_parameters(), 1);
+    EXPECT_EQ(context_->num_numeric_parameter_groups(), 1);
     EXPECT_EQ(context_->num_abstract_parameters(), 1);
     EXPECT_EQ(context_->num_subcontexts(), kNumSystems);
   }
@@ -278,7 +278,7 @@ void VerifyClonedState(const State<double>& clone) {
 // Verifies that the @p params are a clone of the params constructed in
 // DiagramContextTest::SetUp.
 void VerifyClonedParameters(const Parameters<double>& params) {
-  ASSERT_EQ(1, params.num_numeric_parameters());
+  ASSERT_EQ(1, params.num_numeric_parameter_groups());
   EXPECT_EQ(76.0, params.get_numeric_parameter(0).GetAtIndex(0));
   EXPECT_EQ(77.0, params.get_numeric_parameter(0).GetAtIndex(1));
   ASSERT_EQ(1, params.num_abstract_parameters());

--- a/systems/framework/test/leaf_context_test.cc
+++ b/systems/framework/test/leaf_context_test.cc
@@ -524,7 +524,7 @@ TEST_F(LeafContextTest, Clone) {
   // Verify that the parameters were copied.
   LeafContext<double>* leaf_clone =
       dynamic_cast<LeafContext<double>*>(clone.get());
-  EXPECT_EQ(2, leaf_clone->num_numeric_parameters());
+  EXPECT_EQ(2, leaf_clone->num_numeric_parameter_groups());
   const BasicVector<double>& param0 = leaf_clone->get_numeric_parameter(0);
   EXPECT_EQ(1.0, param0[0]);
   EXPECT_EQ(2.0, param0[1]);

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -535,10 +535,11 @@ TEST_F(LeafSystemTest, NumericParameters) {
   mutable_vec.SetAtIndex(1, 42.0);
   EXPECT_EQ(42.0, vec[1]);
 
-  EXPECT_EQ(system_.num_numeric_parameters(), 1);
+  EXPECT_EQ(system_.num_numeric_parameter_groups(), 1);
   const DependencyTracker& pn_tracker =
       context->get_tracker(system_.pn_ticket());
-  for (NumericParameterIndex i(0); i < system_.num_numeric_parameters(); ++i) {
+  for (NumericParameterIndex i(0);
+       i < system_.num_numeric_parameter_groups(); ++i) {
     const DependencyTracker& tracker =
         context->get_tracker(system_.numeric_parameter_ticket(i));
     EXPECT_TRUE(pn_tracker.HasPrerequisite(tracker));
@@ -1048,7 +1049,7 @@ GTEST_TEST(ModelLeafSystemTest, ModelPortsCalcOutput) {
 GTEST_TEST(ModelLeafSystemTest, ModelNumericParams) {
   DeclaredModelPortsSystem dut;
   auto context = dut.CreateDefaultContext();
-  ASSERT_EQ(context->num_numeric_parameters(), 1);
+  ASSERT_EQ(context->num_numeric_parameter_groups(), 1);
   const BasicVector<double>& param = context->get_numeric_parameter(0);
   // Check that type was preserved.
   ASSERT_TRUE(is_dynamic_castable<const MyVector2d>(&param));

--- a/systems/framework/test/parameters_test.cc
+++ b/systems/framework/test/parameters_test.cc
@@ -41,7 +41,7 @@ class ParametersTest : public ::testing::Test {
 };
 
 TEST_F(ParametersTest, Numeric) {
-  ASSERT_EQ(2, params_->num_numeric_parameters());
+  ASSERT_EQ(2, params_->num_numeric_parameter_groups());
   ASSERT_EQ(2, params_->get_numeric_parameters().num_groups());
   EXPECT_EQ(3.0, params_->get_numeric_parameter(0).GetAtIndex(0));
   EXPECT_EQ(6.0, params_->get_numeric_parameter(0).GetAtIndex(1));

--- a/systems/trajectory_optimization/direct_transcription.cc
+++ b/systems/trajectory_optimization/direct_transcription.cc
@@ -229,7 +229,7 @@ bool DirectTranscription::AddSymbolicDynamicConstraints(
   }
 
   symbolic::Substitution sub;
-  for (int i = 0; i < context.num_numeric_parameters(); i++) {
+  for (int i = 0; i < context.num_numeric_parameter_groups(); i++) {
     const auto& params = context.get_numeric_parameter(i).get_value();
     for (int j = 0; j < params.size(); j++) {
       sub.emplace(inspector->numeric_parameters(i)[j], params[j]);


### PR DESCRIPTION
num_numeric_parameters() => get_num_numeric_parameter_groups()
num_abstract_parameters() => get_num_abstract_parameters()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10063)
<!-- Reviewable:end -->
