### PR TITLE
py systems: Bind `DeclareVectorInputPort` and `GetSubsystemContext`

### DIFF
--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -502,6 +502,13 @@ struct Impl {
              // Keep alive, ownership: `return` keeps `Context` alive.
              py::keep_alive<0, 3>(),
              doc.Diagram.GetMutableSubsystemState.doc_2args_subsystem_context)
+        .def("GetSubsystemContext",
+             overload_cast_explicit<const Context<T>&, const System<T>&,
+                                    const Context<T>&>(
+                 &Diagram<T>::GetSubsystemContext),
+             py_reference,
+             // Keep alive, ownership: `return` keeps `Context` alive.
+             py::keep_alive<0, 3>(), doc.Diagram.GetMutableSubsystemContext.doc)
         .def("GetMutableSubsystemContext",
              overload_cast_explicit<Context<T>&, const System<T>&, Context<T>*>(
                  &Diagram<T>::GetMutableSubsystemContext),

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -369,10 +369,12 @@ class TestCustom(unittest.TestCase):
         diagram = builder.Build()
         context = diagram.CreateDefaultContext()
         # Existence check.
-        self.assertTrue(
-            diagram.GetMutableSubsystemState(system, context) is not None)
-        self.assertTrue(
-            diagram.GetMutableSubsystemContext(system, context) is not None)
+        self.assertIsNot(
+            diagram.GetMutableSubsystemState(system, context), None)
+        subcontext = diagram.GetMutableSubsystemContext(system, context)
+        self.assertIsNot(subcontext, None)
+        self.assertIs(
+            diagram.GetSubsystemContext(system, context), subcontext)
 
     def test_continuous_state_api(self):
         # N.B. Since this has trivial operations, we can test all scalar types.


### PR DESCRIPTION
Resolves #10034
Resolves #10035

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10064)
<!-- Reviewable:end -->
