### PR TITLE
Move BasicVector's operator<< to VectorBase

### DIFF
--- a/systems/framework/basic_vector.h
+++ b/systems/framework/basic_vector.h
@@ -188,22 +188,5 @@ class BasicVector : public VectorBase<T> {
   // BasicVector(VectorX<T>) constructor is all that is needed.
 };
 
-// Allows a BasicVector<T> to be streamed into a string. This is useful for
-// debugging purposes.
-template <typename T>
-std::ostream& operator<<(std::ostream& os, const BasicVector<T>& vec) {
-  os << "[";
-
-  Eigen::VectorBlock<const VectorX<T>> v = vec.get_value();
-  for (int i = 0; i < v.size(); ++i) {
-    if (i > 0)
-       os << ", ";
-    os << v[i];
-  }
-
-  os << "]";
-  return os;
-}
-
 }  // namespace systems
 }  // namespace drake

--- a/systems/framework/test/continuous_state_test.cc
+++ b/systems/framework/test/continuous_state_test.cc
@@ -154,6 +154,13 @@ TEST_F(ContinuousStateTest, Clone) {
   EXPECT_EQ((*vector)[2], 1.75);
 }
 
+// Tests ability to stream a ContinuousState vector into a string.
+TEST_F(ContinuousStateTest, StringStream) {
+  std::stringstream s;
+  s << "hello " << continuous_state_->get_vector() << " world";
+  EXPECT_EQ(s.str(), "hello [1, 2, 3, 4] world");
+}
+
 // Tests for DiagramContinousState.
 
 class DiagramContinuousStateTest : public ::testing::Test {

--- a/systems/framework/vector_base.h
+++ b/systems/framework/vector_base.h
@@ -206,5 +206,21 @@ class VectorBase {
   }
 };
 
+// Allows a VectorBase<T> to be streamed into a string. This is useful for
+// debugging purposes.
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const VectorBase<T>& vec) {
+  os << "[";
+
+  for (int i = 0; i < vec.size(); ++i) {
+    if (i > 0)
+      os << ", ";
+    os << vec.GetAtIndex(i);
+  }
+
+  os << "]";
+  return os;
+}
+
 }  // namespace systems
 }  // namespace drake


### PR DESCRIPTION
So it can be used for continuous states, too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10065)
<!-- Reviewable:end -->
