### PR TITLE
Ipopt solve const prog

### DIFF
--- a/solvers/ipopt_solver.cc
+++ b/solvers/ipopt_solver.cc
@@ -4,6 +4,7 @@
 #include <cstring>
 #include <limits>
 #include <memory>
+#include <unordered_map>
 #include <vector>
 
 #include <IpIpoptApplication.hpp>
@@ -152,6 +153,63 @@ struct ResultCache {
   std::vector<Number> grad;
 };
 
+IpoptSolverReturn ConvertToIpoptSolverReturn(Ipopt::SolverReturn status) {
+  switch (status) {
+    case Ipopt::SUCCESS: {
+      return IpoptSolverReturn::SUCCESS;
+    }
+    case Ipopt::MAXITER_EXCEEDED: {
+      return IpoptSolverReturn::MAXITER_EXCEEDED;
+    }
+    case Ipopt::CPUTIME_EXCEEDED: {
+      return IpoptSolverReturn::CPUTIME_EXCEEDED;
+    }
+    case Ipopt::STOP_AT_TINY_STEP: {
+      return IpoptSolverReturn::STOP_AT_TINY_STEP;
+    }
+    case Ipopt::STOP_AT_ACCEPTABLE_POINT: {
+      return IpoptSolverReturn::STOP_AT_ACCEPTABLE_POINT;
+    }
+    case Ipopt::LOCAL_INFEASIBILITY: {
+      return IpoptSolverReturn::LOCAL_INFEASIBILITY;
+    }
+    case Ipopt::USER_REQUESTED_STOP: {
+      return IpoptSolverReturn::USER_REQUESTED_STOP;
+    }
+    case Ipopt::FEASIBLE_POINT_FOUND: {
+      return IpoptSolverReturn::FEASIBLE_POINT_FOUND;
+    }
+    case Ipopt::DIVERGING_ITERATES: {
+      return IpoptSolverReturn::DIVERGING_ITERATES;
+    }
+    case Ipopt::RESTORATION_FAILURE: {
+      return IpoptSolverReturn::RESTORATION_FAILURE;
+    }
+    case Ipopt::ERROR_IN_STEP_COMPUTATION: {
+      return IpoptSolverReturn::ERROR_IN_STEP_COMPUTATION;
+    }
+    case Ipopt::INVALID_NUMBER_DETECTED: {
+      return IpoptSolverReturn::INVALID_NUMBER_DETECTED;
+    }
+    case Ipopt::TOO_FEW_DEGREES_OF_FREEDOM: {
+      return IpoptSolverReturn::TOO_FEW_DEGREES_OF_FREEDOM;
+    }
+    case Ipopt::INVALID_OPTION: {
+      return IpoptSolverReturn::INVALID_OPTION;
+    }
+    case Ipopt::OUT_OF_MEMORY: {
+      return IpoptSolverReturn::OUT_OF_MEMORY;
+    }
+    case Ipopt::INTERNAL_ERROR: {
+      return IpoptSolverReturn::INTERNAL_ERROR;
+    }
+    case Ipopt::UNASSIGNED: {
+      return IpoptSolverReturn::UNASSIGNED;
+    }
+    default: { throw std::runtime_error("Should not reach here."); }
+  }
+}
+
 // The C++ interface for IPOPT is described here:
 // http://www.coin-or.org/Ipopt/documentation/node23.html
 //
@@ -161,8 +219,10 @@ struct ResultCache {
 // the duration of the Solve() call.
 class IpoptSolver_NLP : public Ipopt::TNLP {
  public:
-  explicit IpoptSolver_NLP(MathematicalProgram* problem)
-      : problem_(problem), result_(SolutionResult::kUnknownError) {}
+  explicit IpoptSolver_NLP(const MathematicalProgram& problem,
+                           const Eigen::VectorXd& x_init,
+                           MathematicalProgramResult* result)
+      : problem_(&problem), x_init_{x_init}, result_(result) {}
 
   virtual ~IpoptSolver_NLP() {}
 
@@ -262,11 +322,10 @@ class IpoptSolver_NLP : public Ipopt::TNLP {
     unused(z_L, z_U, m, lambda);
 
     if (init_x) {
-      const Eigen::VectorXd& initial_guess = problem_->initial_guess();
-      DRAKE_ASSERT(initial_guess.size() == n);
+      DRAKE_ASSERT(x_init_.size() == n);
       for (Index i = 0; i < n; i++) {
-        if (!std::isnan(initial_guess[i])) {
-          x[i] = initial_guess[i];
+        if (!std::isnan(x_init_[i])) {
+          x[i] = x_init_[i];
         } else {
           x[i] = 0.0;
         }
@@ -384,26 +443,35 @@ class IpoptSolver_NLP : public Ipopt::TNLP {
                                  const Number* g, const Number* lambda,
                                  Number obj_value, const IpoptData* ip_data,
                                  IpoptCalculatedQuantities* ip_cq) {
-    unused(z_L, z_U, m, g, lambda, ip_data, ip_cq);
+    unused(ip_data, ip_cq);
 
-    SolverResult solver_result(IpoptSolver::id());
+    IpoptSolverDetails& solver_details =
+        result_->SetSolverDetailsType<IpoptSolverDetails>();
+    solver_details.status = ConvertToIpoptSolverReturn(status);
+    solver_details.z_L = Eigen::Map<const Eigen::VectorXd>(z_L, n);
+    solver_details.z_U = Eigen::Map<const Eigen::VectorXd>(z_U, n);
+    solver_details.g = Eigen::Map<const Eigen::VectorXd>(g, m);
+    solver_details.lambda = Eigen::Map<const Eigen::VectorXd>(lambda, m);
 
+    result_->set_solver_id(IpoptSolver::id());
+
+    result_->set_solution_result(SolutionResult::kUnknownError);
     switch (status) {
       case Ipopt::SUCCESS: {
-        result_ = SolutionResult::kSolutionFound;
+        result_->set_solution_result(SolutionResult::kSolutionFound);
         break;
       }
       case Ipopt::LOCAL_INFEASIBILITY: {
-        result_ = SolutionResult::kInfeasibleConstraints;
+        result_->set_solution_result(SolutionResult::kInfeasibleConstraints);
         break;
       }
       case Ipopt::DIVERGING_ITERATES: {
-        result_ = SolutionResult::kUnbounded;
-        obj_value = MathematicalProgram::kUnboundedCost;
+        result_->set_solution_result(SolutionResult::kUnbounded);
+        result_->set_optimal_cost(MathematicalProgram::kUnboundedCost);
         break;
       }
       case Ipopt::MAXITER_EXCEEDED: {
-        result_ = SolutionResult::kIterationLimit;
+        result_->set_solution_result(SolutionResult::kIterationLimit);
         drake::log()->warn(
             "IPOPT terminated after exceeding the maximum iteration limit.  "
             "Hint: Remember that IPOPT is an interior-point method "
@@ -411,7 +479,7 @@ class IpoptSolver_NLP : public Ipopt::TNLP {
         break;
       }
       default: {
-        result_ = SolutionResult::kUnknownError;
+        result_->set_solution_result(SolutionResult::kUnknownError);
         break;
       }
     }
@@ -420,12 +488,11 @@ class IpoptSolver_NLP : public Ipopt::TNLP {
     for (Index i = 0; i < n; i++) {
       solution(i) = x[i];
     }
-    solver_result.set_decision_variable_values(solution.cast<double>());
-    solver_result.set_optimal_cost(obj_value);
-    problem_->SetSolverResult(solver_result);
+    result_->set_x_val(solution.cast<double>());
+    if (result_->get_solution_result() != SolutionResult::kUnbounded) {
+      result_->set_optimal_cost(obj_value);
+    }
   }
-
-  SolutionResult result() const { return result_; }
 
  private:
   void EvaluateCosts(Index n, const Number* x) {
@@ -494,15 +561,12 @@ class IpoptSolver_NLP : public Ipopt::TNLP {
     }
   }
 
-  MathematicalProgram* const problem_;
+  const MathematicalProgram* const problem_;
   std::unique_ptr<ResultCache> cost_cache_;
   std::unique_ptr<ResultCache> constraint_cache_;
-  SolutionResult result_;
+  Eigen::VectorXd x_init_;
+  MathematicalProgramResult* const result_;
 };
-
-template <typename T>
-void SetIpoptApplicationOption(const std::string&, const T&,
-                               Ipopt::IpoptApplication*);
 
 template <typename T>
 typename std::enable_if<std::is_same<T, double>::value>::type
@@ -532,20 +596,24 @@ void SetIpoptOptionsHelper(
     const T& default_val, Ipopt::IpoptApplication* app) {
   auto it = ipopt_options.find(key);
   if (it == ipopt_options.end()) {
-    SetIpoptApplicationOption(key, default_val, app);
+    SetIpoptApplicationOption<T>(key, default_val, app);
   } else {
     SetIpoptApplicationOption(key, it->second, app);
   }
 }
 
-void SetIpoptOptions(const SolverOptions& solver_options, Ipopt::IpoptApplication* app) {
+void SetIpoptOptions(const SolverOptions& solver_options,
+                     Ipopt::IpoptApplication* app) {
   // The default tolerance.
   const double tol = 1.05e-10;  // Note: SNOPT is only 1e-6, but in #3712 we
   // diagnosed that the CompareMatrices tolerance needed to be the sqrt of the
   // constr_viol_tol
-  const auto& ipopt_options_double = solver_options.GetOptionsDouble(IpoptSolver::id());
-  const auto& ipopt_options_str = solver_options.GetOptionsStr(IpoptSolver::id());
-  const auto& ipopt_options_int = solver_options.GetOptionsInt(IpoptSolver::id());
+  const auto& ipopt_options_double =
+      solver_options.GetOptionsDouble(IpoptSolver::id());
+  const std::unordered_map<std::string, std::string>& ipopt_options_str =
+      solver_options.GetOptionsStr(IpoptSolver::id());
+  const auto& ipopt_options_int =
+      solver_options.GetOptionsInt(IpoptSolver::id());
   for (const auto& it : ipopt_options_double) {
     app->Options()->SetNumericValue(it.first, it.second);
   }
@@ -560,8 +628,10 @@ void SetIpoptOptions(const SolverOptions& solver_options, Ipopt::IpoptApplicatio
   SetIpoptOptionsHelper(ipopt_options_double, "tol", tol, app);
   SetIpoptOptionsHelper(ipopt_options_double, "constr_viol_tol", tol, app);
   SetIpoptOptionsHelper(ipopt_options_double, "acceptable_tol", tol, app);
-  SetIpoptOptionsHelper(ipopt_options_double, "acceptable_constr_viol_tol", tol, app);
-  SetIpoptOptionsHelper(ipopt_options_str, "hessian_approximation", "limited-memory", app);
+  SetIpoptOptionsHelper(ipopt_options_double, "acceptable_constr_viol_tol", tol,
+                        app);
+  SetIpoptOptionsHelper<std::string>(ipopt_options_str, "hessian_approximation",
+                                     std::string("limited-memory"), app);
   // Note: 0<= print_level <= 12, with higher numbers more verbose.  4 is very
   // useful for debugging.
   SetIpoptOptionsHelper(ipopt_options_int, "print_level", 2, app);
@@ -576,26 +646,40 @@ void IpoptSolver::Solve(const MathematicalProgram& prog,
                         const optional<SolverOptions>& solver_options,
                         MathematicalProgramResult* result) const {
   if (!AreProgramAttributesSatisfied(prog)) {
-    throw std::invalid_argument("Ipopt doesn't satisfy the capabilities required by the program");
+    throw std::invalid_argument(
+        "Ipopt doesn't satisfy the capabilities required by the program");
   }
+
+  // TODO(hongkai.dai): do not retrieve initial guess from prog.
+  const Eigen::VectorXd x_init =
+      initial_guess.has_value() ? initial_guess.value() : prog.initial_guess();
 
   Ipopt::SmartPtr<Ipopt::IpoptApplication> app = IpoptApplicationFactory();
   app->RethrowNonIpoptException(true);
 
-  SolverOptions merged_solver_options = solver_options.has_value() ? solver_options.value() : SolverOptions();
-  merged_solver_options.Merge(prog.solver_options);
+  SolverOptions merged_solver_options =
+      solver_options.has_value() ? solver_options.value() : SolverOptions();
+  merged_solver_options.Merge(prog.solver_options());
 
   SetIpoptOptions(merged_solver_options, &(*app));
 
   Ipopt::ApplicationReturnStatus status = app->Initialize();
   if (status != Ipopt::Solve_Succeeded) {
-    return SolutionResult::kInvalidInput;
+    result->set_solution_result(SolutionResult::kInvalidInput);
+    return;
   }
 
-  Ipopt::SmartPtr<IpoptSolver_NLP> nlp = new IpoptSolver_NLP(&prog);
+  Ipopt::SmartPtr<IpoptSolver_NLP> nlp =
+      new IpoptSolver_NLP(prog, x_init, result);
   status = app->OptimizeTNLP(nlp);
+}
 
-  return nlp->result();
+SolutionResult IpoptSolver::Solve(MathematicalProgram& prog) const {
+  MathematicalProgramResult result;
+  Solve(prog, {}, {}, &result);
+  const SolverResult solver_result = result.ConvertToSolverResult();
+  prog.SetSolverResult(solver_result);
+  return result.get_solution_result();
 }
 
 }  // namespace solvers

--- a/solvers/ipopt_solver.cc
+++ b/solvers/ipopt_solver.cc
@@ -573,7 +573,7 @@ void SetIpoptOptions(const MathematicalProgram& prog,
 
 }  // namespace
 
-std::string IpoptSolverDetails::ConvertStatusToString() const {
+const char* IpoptSolverDetails::ConvertStatusToString() const {
   switch (status) {
     case Ipopt::SolverReturn::SUCCESS: {
       return "Success";
@@ -627,7 +627,7 @@ std::string IpoptSolverDetails::ConvertStatusToString() const {
       return "Unassigned";
     }
   }
-  throw std::runtime_error("Should not reach here.");
+  return "Unknown enumerated SolverReturn value.";
 }
 
 bool IpoptSolver::is_available() { return true; }

--- a/solvers/ipopt_solver.cc
+++ b/solvers/ipopt_solver.cc
@@ -514,7 +514,7 @@ class IpoptSolver_NLP : public Ipopt::TNLP {
 template <typename T>
 bool HasOptionWithKey(const SolverOptions& solver_options,
                       const std::string& key) {
-  return solver_options.GetOptionsGeneric<T>(IpoptSolver::id()).count(key) > 0;
+  return solver_options.GetOptions<T>(IpoptSolver::id()).count(key) > 0;
 }
 
 /**

--- a/solvers/ipopt_solver.h
+++ b/solvers/ipopt_solver.h
@@ -10,33 +10,6 @@
 
 namespace drake {
 namespace solvers {
-/**
- * This enum class is copied from IpAlgTypes.hpp in the Ipopt source code. We provide this enum class here so that the user can understand the status in IpoptSolverDetails.
- */
-enum class IpoptSolverReturn {
-  SUCCESS,
-  MAXITER_EXCEEDED,
-  CPUTIME_EXCEEDED,
-  STOP_AT_TINY_STEP,
-  STOP_AT_ACCEPTABLE_POINT,
-  LOCAL_INFEASIBILITY,
-  USER_REQUESTED_STOP,
-  FEASIBLE_POINT_FOUND,
-  DIVERGING_ITERATES,
-  RESTORATION_FAILURE,
-  ERROR_IN_STEP_COMPUTATION,
-  INVALID_NUMBER_DETECTED,
-  TOO_FEW_DEGREES_OF_FREEDOM,
-  INVALID_OPTION,
-  OUT_OF_MEMORY,
-  INTERNAL_ERROR,
-  UNASSIGNED
-};
-
-
-std::string to_string(IpoptSolverReturn status);
-
-std::ostream& operator<<(std::ostream& os, IpoptSolverReturn solver_return);
 
 /**
  * The details of IPOPT solvers after calling Solve function. The users can get
@@ -45,18 +18,26 @@ std::ostream& operator<<(std::ostream& os, IpoptSolverReturn solver_return);
  */
 struct IpoptSolverDetails {
   /**
-   * The final status of the solver. Please refer to section 6 in Introduction
-to Ipopt: A tutorial for downloading, installing, and using Ipopt.
+   * The final status of the solver. Please refer to section 6 in
+   * Introduction to Ipopt: A tutorial for downloading, installing, and using
+   * Ipopt.
+   * You could also find the meaning of the status as Ipopt::SolverReturn
+   * defined in IpAlgTypes.hpp
    */
-  IpoptSolverReturn status;
-  // The final value for the lower bound multiplier.
+  int status{};
+  /// The final value for the lower bound multiplier.
   Eigen::VectorXd z_L;
-  // The final value for the upper bound multiplier.
+  /// The final value for the upper bound multiplier.
   Eigen::VectorXd z_U;
-  // The final value for the constraint function.
+  /// The final value for the constraint function.
   Eigen::VectorXd g;
-  // The final value for the constraint multiplier.
+  /// The final value for the constraint multiplier.
   Eigen::VectorXd lambda;
+
+  /** Convert status field to string. This function is useful if you want to
+   * interpret the meaning of status.
+   */
+  std::string ConvertStatusToString() const;
 };
 
 class IpoptSolver : public MathematicalProgramSolverInterface {

--- a/solvers/ipopt_solver.h
+++ b/solvers/ipopt_solver.h
@@ -37,7 +37,7 @@ struct IpoptSolverDetails {
   /** Convert status field to string. This function is useful if you want to
    * interpret the meaning of status.
    */
-  std::string ConvertStatusToString() const;
+  const char* ConvertStatusToString() const;
 };
 
 class IpoptSolver : public MathematicalProgramSolverInterface {

--- a/solvers/ipopt_solver.h
+++ b/solvers/ipopt_solver.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <ostream>
 #include <string>
+
+#include <Eigen/Core>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/solvers/mathematical_program_solver_interface.h"
@@ -30,7 +33,10 @@ enum class IpoptSolverReturn {
   UNASSIGNED
 };
 
+
 std::string to_string(IpoptSolverReturn status);
+
+std::ostream& operator<<(std::ostream& os, IpoptSolverReturn solver_return);
 
 /**
  * The details of IPOPT solvers after calling Solve function. The users can get
@@ -39,9 +45,18 @@ std::string to_string(IpoptSolverReturn status);
  */
 struct IpoptSolverDetails {
   /**
-   * The final status of the solver. Please refer to 
+   * The final status of the solver. Please refer to section 6 in Introduction
+to Ipopt: A tutorial for downloading, installing, and using Ipopt.
    */
   IpoptSolverReturn status;
+  // The final value for the lower bound multiplier.
+  Eigen::VectorXd z_L;
+  // The final value for the upper bound multiplier.
+  Eigen::VectorXd z_U;
+  // The final value for the constraint function.
+  Eigen::VectorXd g;
+  // The final value for the constraint multiplier.
+  Eigen::VectorXd lambda;
 };
 
 class IpoptSolver : public MathematicalProgramSolverInterface {

--- a/solvers/ipopt_solver.h
+++ b/solvers/ipopt_solver.h
@@ -7,6 +7,42 @@
 
 namespace drake {
 namespace solvers {
+/**
+ * This enum class is copied from IpAlgTypes.hpp in the Ipopt source code. We provide this enum class here so that the user can understand the status in IpoptSolverDetails.
+ */
+enum class IpoptSolverReturn {
+  SUCCESS,
+  MAXITER_EXCEEDED,
+  CPUTIME_EXCEEDED,
+  STOP_AT_TINY_STEP,
+  STOP_AT_ACCEPTABLE_POINT,
+  LOCAL_INFEASIBILITY,
+  USER_REQUESTED_STOP,
+  FEASIBLE_POINT_FOUND,
+  DIVERGING_ITERATES,
+  RESTORATION_FAILURE,
+  ERROR_IN_STEP_COMPUTATION,
+  INVALID_NUMBER_DETECTED,
+  TOO_FEW_DEGREES_OF_FREEDOM,
+  INVALID_OPTION,
+  OUT_OF_MEMORY,
+  INTERNAL_ERROR,
+  UNASSIGNED
+};
+
+std::string to_string(IpoptSolverReturn status);
+
+/**
+ * The details of IPOPT solvers after calling Solve function. The users can get
+ * the details by
+ * MathematicalProgramResult::get_solver_details().GetValue<IpoptSolverDetails>();
+ */
+struct IpoptSolverDetails {
+  /**
+   * The final status of the solver. Please refer to 
+   */
+  IpoptSolverReturn status;
+};
 
 class IpoptSolver : public MathematicalProgramSolverInterface {
  public:
@@ -23,11 +59,10 @@ class IpoptSolver : public MathematicalProgramSolverInterface {
 
   SolutionResult Solve(MathematicalProgram& prog) const override;
 
-  void Solve(const MathematicalProgram&, const optional<Eigen::VectorXd>&,
-             const optional<SolverOptions>&,
-             MathematicalProgramResult*) const override {
-    throw std::runtime_error("Not implemented yet.");
-  }
+  void Solve(const MathematicalProgram& prog,
+             const optional<Eigen::VectorXd>& initial_guess,
+             const optional<SolverOptions>& solver_options,
+             MathematicalProgramResult* result) const override;
 
   SolverId solver_id() const override;
 

--- a/solvers/ipopt_solver_common.cc
+++ b/solvers/ipopt_solver_common.cc
@@ -9,11 +9,11 @@ namespace drake {
 namespace solvers {
 
 std::string to_string(IpoptSolverReturn status) {
-  switch(status) {
+  switch (status) {
     case IpoptSolverReturn::SUCCESS: {
       return "Success";
     }
-    case IpoptSolverReturn::MAXITER_EXCEEDED : {
+    case IpoptSolverReturn::MAXITER_EXCEEDED: {
       return "Max iteration exceeded";
     }
     case IpoptSolverReturn::CPUTIME_EXCEEDED: {
@@ -61,9 +61,7 @@ std::string to_string(IpoptSolverReturn status) {
     case IpoptSolverReturn::UNASSIGNED: {
       return "Unassigned";
     }
-    default : {
-      throw std::runtime_error("Should not reach here.");
-    }
+    default: { throw std::runtime_error("Should not reach here."); }
   }
 }
 

--- a/solvers/ipopt_solver_common.cc
+++ b/solvers/ipopt_solver_common.cc
@@ -8,6 +8,21 @@
 namespace drake {
 namespace solvers {
 
+std::string to_string(IpoptSolverReturn status) {
+  switch(status) {
+    case IpoptSolverReturn::SUCCESS: {
+      return "Success";
+    }
+    case IpoptSolverReturn::MAXITER_EXCEEDED : {
+      return "Max iteration exceeded";
+    }
+    case IpoptSolverReturn::CPUTIME_EXCEEDED: {
+      return "CPU time exceeded";
+    }
+
+  }
+}
+
 SolverId IpoptSolver::solver_id() const {
   return id();
 }

--- a/solvers/ipopt_solver_common.cc
+++ b/solvers/ipopt_solver_common.cc
@@ -19,8 +19,57 @@ std::string to_string(IpoptSolverReturn status) {
     case IpoptSolverReturn::CPUTIME_EXCEEDED: {
       return "CPU time exceeded";
     }
-
+    case IpoptSolverReturn::STOP_AT_TINY_STEP: {
+      return "Stop at tiny step";
+    }
+    case IpoptSolverReturn::STOP_AT_ACCEPTABLE_POINT: {
+      return "Stop at acceptable point";
+    }
+    case IpoptSolverReturn::LOCAL_INFEASIBILITY: {
+      return "Local infeasibility";
+    }
+    case IpoptSolverReturn::USER_REQUESTED_STOP: {
+      return "User requested stop";
+    }
+    case IpoptSolverReturn::FEASIBLE_POINT_FOUND: {
+      return "Feasible point found";
+    }
+    case IpoptSolverReturn::DIVERGING_ITERATES: {
+      return "Divergent iterates";
+    }
+    case IpoptSolverReturn::RESTORATION_FAILURE: {
+      return "Restoration failure";
+    }
+    case IpoptSolverReturn::ERROR_IN_STEP_COMPUTATION: {
+      return "Error in step computation";
+    }
+    case IpoptSolverReturn::INVALID_NUMBER_DETECTED: {
+      return "Invalid number detected";
+    }
+    case IpoptSolverReturn::TOO_FEW_DEGREES_OF_FREEDOM: {
+      return "Too few degrees of freedom";
+    }
+    case IpoptSolverReturn::INVALID_OPTION: {
+      return "Invalid option";
+    }
+    case IpoptSolverReturn::OUT_OF_MEMORY: {
+      return "Out of memory";
+    }
+    case IpoptSolverReturn::INTERNAL_ERROR: {
+      return "Internal error";
+    }
+    case IpoptSolverReturn::UNASSIGNED: {
+      return "Unassigned";
+    }
+    default : {
+      throw std::runtime_error("Should not reach here.");
+    }
   }
+}
+
+std::ostream& operator<<(std::ostream& os, IpoptSolverReturn solver_return) {
+  os << to_string(solver_return);
+  return os;
 }
 
 SolverId IpoptSolver::solver_id() const {

--- a/solvers/ipopt_solver_common.cc
+++ b/solvers/ipopt_solver_common.cc
@@ -7,69 +7,6 @@
 
 namespace drake {
 namespace solvers {
-
-std::string to_string(IpoptSolverReturn status) {
-  switch (status) {
-    case IpoptSolverReturn::SUCCESS: {
-      return "Success";
-    }
-    case IpoptSolverReturn::MAXITER_EXCEEDED: {
-      return "Max iteration exceeded";
-    }
-    case IpoptSolverReturn::CPUTIME_EXCEEDED: {
-      return "CPU time exceeded";
-    }
-    case IpoptSolverReturn::STOP_AT_TINY_STEP: {
-      return "Stop at tiny step";
-    }
-    case IpoptSolverReturn::STOP_AT_ACCEPTABLE_POINT: {
-      return "Stop at acceptable point";
-    }
-    case IpoptSolverReturn::LOCAL_INFEASIBILITY: {
-      return "Local infeasibility";
-    }
-    case IpoptSolverReturn::USER_REQUESTED_STOP: {
-      return "User requested stop";
-    }
-    case IpoptSolverReturn::FEASIBLE_POINT_FOUND: {
-      return "Feasible point found";
-    }
-    case IpoptSolverReturn::DIVERGING_ITERATES: {
-      return "Divergent iterates";
-    }
-    case IpoptSolverReturn::RESTORATION_FAILURE: {
-      return "Restoration failure";
-    }
-    case IpoptSolverReturn::ERROR_IN_STEP_COMPUTATION: {
-      return "Error in step computation";
-    }
-    case IpoptSolverReturn::INVALID_NUMBER_DETECTED: {
-      return "Invalid number detected";
-    }
-    case IpoptSolverReturn::TOO_FEW_DEGREES_OF_FREEDOM: {
-      return "Too few degrees of freedom";
-    }
-    case IpoptSolverReturn::INVALID_OPTION: {
-      return "Invalid option";
-    }
-    case IpoptSolverReturn::OUT_OF_MEMORY: {
-      return "Out of memory";
-    }
-    case IpoptSolverReturn::INTERNAL_ERROR: {
-      return "Internal error";
-    }
-    case IpoptSolverReturn::UNASSIGNED: {
-      return "Unassigned";
-    }
-    default: { throw std::runtime_error("Should not reach here."); }
-  }
-}
-
-std::ostream& operator<<(std::ostream& os, IpoptSolverReturn solver_return) {
-  os << to_string(solver_return);
-  return os;
-}
-
 SolverId IpoptSolver::solver_id() const {
   return id();
 }

--- a/solvers/no_ipopt.cc
+++ b/solvers/no_ipopt.cc
@@ -15,5 +15,14 @@ SolutionResult IpoptSolver::Solve(MathematicalProgram&) const {
       "solver.");
 }
 
+void IpoptSolver::Solve(const MathematicalProgram&,
+                        const optional<Eigen::VectorXd>&,
+                        const optional<SolverOptions>&,
+                        MathematicalProgramResult*) const {
+  throw std::runtime_error(
+      "The IPOPT bindings were not compiled.  You'll need to use a different "
+      "solver.");
+}
+
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/no_ipopt.cc
+++ b/solvers/no_ipopt.cc
@@ -7,7 +7,7 @@
 namespace drake {
 namespace solvers {
 
-std::string IpoptSolverDetails::ConvertStatusToString() const {
+const char* IpoptSolverDetails::ConvertStatusToString() const {
   throw std::runtime_error(
       "The IPOPT bindings were not compiled.  You'll need to use a different "
       "solver.");

--- a/solvers/no_ipopt.cc
+++ b/solvers/no_ipopt.cc
@@ -7,6 +7,12 @@
 namespace drake {
 namespace solvers {
 
+std::string IpoptSolverDetails::ConvertStatusToString() const {
+  throw std::runtime_error(
+      "The IPOPT bindings were not compiled.  You'll need to use a different "
+      "solver.");
+}
+
 bool IpoptSolver::is_available() { return false; }
 
 SolutionResult IpoptSolver::Solve(MathematicalProgram&) const {

--- a/solvers/solver_options.cc
+++ b/solvers/solver_options.cc
@@ -168,5 +168,18 @@ void SolverOptions::CheckOptionKeysForSolver(
                                  solver_id.name());
 }
 
+const std::unordered_map<std::string, double>& SolverOptions::GetOptionsImpl(
+    const SolverId& solver_id, double*) const {
+  return GetOptionsDouble(solver_id);
+}
+const std::unordered_map<std::string, int>& SolverOptions::GetOptionsImpl(
+    const SolverId& solver_id, int*) const {
+  return GetOptionsInt(solver_id);
+}
+const std::unordered_map<std::string, std::string>&
+SolverOptions::GetOptionsImpl(const SolverId& solver_id, std::string*) const {
+  return GetOptionsStr(solver_id);
+}
+
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/solver_options.h
+++ b/solvers/solver_options.h
@@ -62,6 +62,28 @@ class SolverOptions {
   const std::unordered_map<std::string, std::string>& GetOptionsStr(
       const SolverId& solver_id) const;
 
+  template <typename T>
+  typename std::enable_if<std::is_same<T, double>::value,
+                          const std::unordered_map<std::string, double>&>::type
+  GetOptionsGeneric(const SolverId& solver_id) const {
+    return GetOptionsDouble(solver_id);
+  }
+
+  template <typename T>
+  typename std::enable_if<std::is_same<T, int>::value,
+                          const std::unordered_map<std::string, int>&>::type
+  GetOptionsGeneric(const SolverId& solver_id) const {
+    return GetOptionsInt(solver_id);
+  }
+
+  template <typename T>
+  typename std::enable_if<
+      std::is_same<T, std::string>::value,
+      const std::unordered_map<std::string, std::string>&>::type
+  GetOptionsGeneric(const SolverId& solver_id) const {
+    return GetOptionsStr(solver_id);
+  }
+
   /** Returns the IDs that have any option set. */
   std::unordered_set<SolverId> GetSolverIds() const;
 

--- a/solvers/solver_options.h
+++ b/solvers/solver_options.h
@@ -63,25 +63,9 @@ class SolverOptions {
       const SolverId& solver_id) const;
 
   template <typename T>
-  typename std::enable_if<std::is_same<T, double>::value,
-                          const std::unordered_map<std::string, double>&>::type
-  GetOptionsGeneric(const SolverId& solver_id) const {
-    return GetOptionsDouble(solver_id);
-  }
-
-  template <typename T>
-  typename std::enable_if<std::is_same<T, int>::value,
-                          const std::unordered_map<std::string, int>&>::type
-  GetOptionsGeneric(const SolverId& solver_id) const {
-    return GetOptionsInt(solver_id);
-  }
-
-  template <typename T>
-  typename std::enable_if<
-      std::is_same<T, std::string>::value,
-      const std::unordered_map<std::string, std::string>&>::type
-  GetOptionsGeneric(const SolverId& solver_id) const {
-    return GetOptionsStr(solver_id);
+  const std::unordered_map<std::string, T>& GetOptions(
+      const SolverId& solver_id) const {
+    return GetOptionsImpl(solver_id, static_cast<T*>(nullptr));
   }
 
   /** Returns the IDs that have any option set. */
@@ -123,6 +107,13 @@ class SolverOptions {
       const std::unordered_set<std::string>& allowable_str_keys) const;
 
  private:
+  const std::unordered_map<std::string, double>& GetOptionsImpl(
+      const SolverId& solver_id, double*) const;
+  const std::unordered_map<std::string, int>& GetOptionsImpl(
+      const SolverId& solver_id, int*) const;
+  const std::unordered_map<std::string, std::string>& GetOptionsImpl(
+      const SolverId& solver_id, std::string*) const;
+
   std::unordered_map<SolverId, std::unordered_map<std::string, double>>
       solver_options_double_{};
   std::unordered_map<SolverId, std::unordered_map<std::string, int>>

--- a/solvers/test/ipopt_solver_test.cc
+++ b/solvers/test/ipopt_solver_test.cc
@@ -26,11 +26,15 @@ TEST_F(InfeasibleLinearProgramTest0, TestIpopt) {
   prog_->SetInitialGuessForAllVariables(Eigen::Vector2d(1, 2));
   IpoptSolver solver;
   if (solver.available()) {
-    const auto solver_result = solver.Solve(*prog_);
-    EXPECT_EQ(solver_result, SolutionResult::kInfeasibleConstraints);
+    MathematicalProgramResult result;
+    solver.Solve(*prog_, {}, {}, &result);
+    EXPECT_EQ(result.get_solution_result(),
+              SolutionResult::kInfeasibleConstraints);
     const Eigen::Vector2d x_val =
-        prog_->GetSolution(prog_->decision_variables());
-    EXPECT_NEAR(prog_->GetOptimalCost(), -x_val(0) - x_val(1), 1E-7);
+        prog_->GetSolution(prog_->decision_variables(), result);
+    EXPECT_NEAR(result.get_optimal_cost(), -x_val(0) - x_val(1), 1E-7);
+    EXPECT_EQ(result.get_solver_details().GetValue<IpoptSolverDetails>().status,
+              IpoptSolverReturn::LOCAL_INFEASIBILITY);
   }
 }
 

--- a/solvers/test/ipopt_solver_test.cc
+++ b/solvers/test/ipopt_solver_test.cc
@@ -33,8 +33,10 @@ TEST_F(InfeasibleLinearProgramTest0, TestIpopt) {
     const Eigen::Vector2d x_val =
         prog_->GetSolution(prog_->decision_variables(), result);
     EXPECT_NEAR(result.get_optimal_cost(), -x_val(0) - x_val(1), 1E-7);
+    // local infeasibility is defined in Ipopt::SolverReturn in IpAlgTypes.hpp
+    const int kIpoptLocalInfeasibility = 5;
     EXPECT_EQ(result.get_solver_details().GetValue<IpoptSolverDetails>().status,
-              IpoptSolverReturn::LOCAL_INFEASIBILITY);
+              kIpoptLocalInfeasibility);
   }
 }
 


### PR DESCRIPTION
As mentioned in #9633 

@jwnimmer-tri I created an enum class `IpoptSolverReturn` in https://github.com/hongkai-dai/drake/blob/427c41605a064050df4abd56db8f31d8e1460a9a/solvers/ipopt_solver.h#L16-L34. This enum class is a replication of `Ipopt::SolverReturn` defined in ipopt source code. Ideally I wish I could avoid duplication, and use `Ipopt::SolverReturn` directly. But since `ipopt_solver.h` doesn't include ipopt.h, I cannot use it in `IpoptSolver.h`. Do you think there is a better solution? I tried to forward declare `IpoptSolverReturn` in `IpoptSolver.h`, and then `typedef Ipopt::SolverReturn IpoptSolverReturn` in `IpoptSolver.cc`, but since I use `IpoptSolverReturn` in https://github.com/hongkai-dai/drake/blob/427c41605a064050df4abd56db8f31d8e1460a9a/solvers/ipopt_solver.h#L51, the forward declaration fails and I need a complete type in `IpoptSolver.h`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10066)
<!-- Reviewable:end -->
