### PR TITLE
[WIP] Imported MultibodyGraphMaker from Simbody

### DIFF
--- a/common/type_safe_index.h
+++ b/common/type_safe_index.h
@@ -173,8 +173,13 @@ class TypeSafeIndex {
   /// @name     Utility methods
   ///@{
 
-  /// Implicit conversion-to-int operator.
+  /// Implicit conversion-to-int operator. Must be valid.
   operator int() const {
+    return to_int();
+  }
+
+  /// Explicit conversion-to-int operator. Must be valid.
+  int to_int() const {
     DRAKE_ASSERT_VOID(AssertValid(index_, "Converting to an int."));
     return index_;
   }

--- a/multibody/graph_modeler/BUILD.bazel
+++ b/multibody/graph_modeler/BUILD.bazel
@@ -1,0 +1,41 @@
+# -*- python -*-
+# This file contains rules for Bazel; see drake/doc/bazel.rst.
+
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_googletest",
+    "drake_cc_library",
+    "drake_cc_package_library",
+)
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+drake_cc_library(
+    name = "multibody_graph_modeler",
+    srcs = [
+        "multibody_graph_modeler.cc",
+        "multibody_tree_model.cc",
+    ],
+    hdrs = [
+        "multibody_graph_modeler.h",
+        "multibody_tree_model.h",
+    ],
+    deps = [
+        "//common:essential",
+        "//common:type_safe_index",
+        "//multibody/tree:multibody_tree_indexes",
+    ],
+)
+
+drake_cc_googletest(
+    name = "multibody_graph_modeler_test",
+    deps = [
+        ":multibody_graph_modeler",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+add_lint_tests()

--- a/multibody/graph_modeler/multibody_graph_modeler.cc
+++ b/multibody/graph_modeler/multibody_graph_modeler.cc
@@ -1,0 +1,502 @@
+/* Adapted for Drake from Simbody's MultibodyGraphModeler class.
+Portions copyright (c) 2013-14 Stanford University and the Authors.
+Authors: Michael Sherman
+Contributors: Kevin He
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may
+not use this file except in compliance with the License. You may obtain a
+copy of the License at http://www.apache.org/licenses/LICENSE-2.0. */
+
+#include "drake/multibody/graph_modeler/multibody_graph_modeler.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <exception>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+#include <fmt/format.h>
+
+#include "drake/common/drake_assert.h"
+#include "drake/multibody/graph_modeler/multibody_tree_model.h"
+
+using std::cout;
+using std::endl;
+
+namespace drake {
+namespace multibody {
+
+namespace {
+template <typename FlagsType>
+void add_if_flag(FlagsType or_flags, FlagsType test_flag, const char* flag_name,
+                 std::string* out) {
+  if (or_flags & test_flag) {
+    if (!out->empty()) *out += "|";
+    *out += flag_name;
+  }
+}
+}  // namespace
+
+std::string to_string(BodyFlags flags) {
+  std::string out;
+  if (flags == 0) {
+    out = "default";
+  } else {
+    add_if_flag(flags, kStaticBody, "static", &out);
+    add_if_flag(flags, kMustBeBaseBody, "must_be_base_body", &out);
+    add_if_flag(flags, kMustNotBeTerminalBody, "must_be_nonterminal", &out);
+  }
+  return out;
+}
+
+std::string to_string(JointFlags flags) {
+  std::string out;
+  if (flags == 0) {
+    out = "default";
+  } else {
+    add_if_flag(flags, kMustBeConstraint, "must_be_constraint", &out);
+  }
+  return out;
+}
+
+std::string to_string(JointTypeFlags flags) {
+  std::string out;
+  if (flags == 0) {
+    out = "default";
+  } else {
+    add_if_flag(flags, kOkToUseAsJointConstraint, "ok_to_use_as_loop_joint",
+                &out);
+  }
+  return out;
+}
+
+//------------------------------------------------------------------------------
+//                              CONSTRUCTOR
+//------------------------------------------------------------------------------
+MultibodyGraphModeler::MultibodyGraphModeler(bool use_drake_defaults)
+    : weld_type_name_("weld"), free_type_name_("free") {
+  Clear(use_drake_defaults);
+}
+
+//------------------------------------------------------------------------------
+//                                 CLEAR
+//------------------------------------------------------------------------------
+void MultibodyGraphModeler::Clear(bool use_drake_defaults) {
+  ClearContainers();
+  RegisterJointType(weld_type_name_, 0, 0);
+  RegisterJointType(free_type_name_, 7, 6);
+
+  if (use_drake_defaults) {
+    AddBody("world", ModelInstanceIndex(0), kStaticBody);
+    // These are the names used in .sdf files.
+    RegisterJointType("revolute", 1, 1);
+    RegisterJointType("prismatic", 1, 1);
+    // TODO(sherm1) Should allow for a loop ball joint as soon as one is
+    // available (change flag to kOkToUseAsJointConstraint).
+    RegisterJointType("ball", 4, 3, kDefaultJointTypeFlags);
+    RegisterJointType("fixed", 0, 0);  // .sdf for "weld".
+
+    // "weld" and "free" are always present.
+  }
+}
+
+//------------------------------------------------------------------------------
+//                            WORLD BODY NAME
+//------------------------------------------------------------------------------
+const std::string& MultibodyGraphModeler::world_body_name() const {
+  if (bodies_.empty())
+    throw std::logic_error(
+        "get_world_body_name(): you can't call this until you have called "
+        "AddBody() at least once -- the first body is World.");
+  return bodies_[0].name();
+}
+
+//------------------------------------------------------------------------------
+//                          REGISTER JOINT TYPE
+//------------------------------------------------------------------------------
+auto MultibodyGraphModeler::RegisterJointType(const std::string& name,
+                                              int num_q, int num_v,
+                                              JointTypeFlags flags,
+                                              void* user_ref)
+    -> JointTypeIndex {
+  if (!(0 <= num_q && num_q <= 7 && 0 <= num_v && num_v <= 6 && num_v <= num_q))
+    throw std::runtime_error(
+        fmt::format("RegisterJointType(): Illegal joint state specification "
+                    "nq={}, nv={} for joint type '{}'",
+                    num_q, num_v, name));
+
+  // Reject duplicate type name.
+  std::map<std::string, JointTypeIndex>::const_iterator p =
+      joint_type_name_to_num_.find(name);
+  if (p != joint_type_name_to_num_.end())
+    throw std::runtime_error(
+        fmt::format("RegisterJointType(): Duplicate joint type '{}'.", name));
+
+  const JointTypeIndex joint_type_num(num_joint_types());  // next available
+  joint_type_name_to_num_[name] = joint_type_num;  // provide fast name lookup
+
+  // Can't use emplace_back because constructor is private.
+  joint_types_.push_back(JointType(name, num_q, num_v, flags, user_ref));
+
+  return joint_type_num;
+}
+
+//------------------------------------------------------------------------------
+//                                 ADD BODY
+//------------------------------------------------------------------------------
+void MultibodyGraphModeler::AddBody(std::string body_name,
+                                    ModelInstanceIndex model_instance,
+                                    BodyFlags flags, void* user_ref) {
+  DRAKE_DEMAND(!body_name.empty() && model_instance.is_valid());
+  const BodyIndex body_num(num_bodies());  // next available
+
+  // If this is the first body it is going to be World, which has its own
+  // model instance. If the supplied model instance is "default", we'll
+  // substitute the world instance. Otherwise we'll complain.
+  if (body_num == world_body_num()) {
+    if (model_instance == default_model_instance())
+      model_instance = world_model_instance();
+    if (model_instance != world_model_instance()) {
+      throw std::runtime_error(fmt::format(
+          "AddBody({},{}): World body must be in the World model instance.",
+          body_name, model_instance));
+    }
+
+    // Make flags suitable for World also.
+    flags = kStaticBody;
+  }
+
+  // Creates an empty map if we haven't seen this name before.
+  InstanceBodyIndexMap& all_body_nums = body_name_to_num_[body_name];
+  auto p = all_body_nums.find(model_instance);
+
+  // Reject duplicate body name.
+  if (p != all_body_nums.end()) {
+    throw std::logic_error(fmt::format(
+        "AddBody({},{}): Name already present in this model instance.",
+        body_name, model_instance));
+  }
+
+  all_body_nums[model_instance] = body_num;
+  // Can't use emplace_back here since constructor is private.
+  bodies_.push_back(Body(body_name, model_instance, flags, user_ref));
+}
+
+//------------------------------------------------------------------------------
+//                             CHANGE BODY FLAGS
+//------------------------------------------------------------------------------
+void MultibodyGraphModeler::ChangeBodyFlags(BodyIndex body_num,
+                                            BodyFlags flags) {
+  Body& body = get_mutable_body(body_num);
+  body.set_flags(flags);
+}
+
+//------------------------------------------------------------------------------
+//                                 DELETE BODY
+//------------------------------------------------------------------------------
+bool MultibodyGraphModeler::DeleteBody(BodyIndex body_num) {
+  const ModelInstanceIndex model_instance = get_body(body_num).model_instance();
+  DRAKE_DEMAND(model_instance.is_valid());
+
+  // Remove joints for which this is the parent body.
+  const std::vector<JointIndex>& joints_as_parent =
+      get_mutable_body(body_num).joints_as_parent();
+  while (joints_as_parent.size() > 0) DeleteJoint(joints_as_parent[0]);
+
+  // Remove joints for which this is the child body.
+  const std::vector<JointIndex>& joints_as_child =
+      get_mutable_body(body_num).joints_as_child();
+  while (joints_as_child.size() > 0) DeleteJoint(joints_as_child[0]);
+
+  // Remove the body itself. This implicitly renumbers the bodies after this
+  // one, because we expect the BodyIndex to be an index into bodies_.
+  bodies_.erase(bodies_.begin() + body_num);
+
+  // Update body indexes in the remaining joints due to the deletion
+  // of this body.
+  for (JointIndex i(0); i < num_joints(); ++i) {
+    if (joints_[i].parent_body_num() > body_num)
+      get_mutable_joint(i).set_parent_body_num(
+          BodyIndex(get_joint(i).parent_body_num() - 1));
+    if (joints_[i].child_body_num() > body_num)
+      get_mutable_joint(i).set_child_body_num(
+          BodyIndex(get_joint(i).child_body_num() - 1));
+  }
+
+  // Rebuild the body name-to-body number map to reflect the new numbering.
+  body_name_to_num_.clear();
+  for (BodyIndex i(0); i < num_bodies(); ++i) {
+    const Body& body = get_body(i);
+    body_name_to_num_[body.name()][body.model_instance()] = i;
+  }
+
+  return true;
+}
+
+//------------------------------------------------------------------------------
+//                                ADD JOINT
+//------------------------------------------------------------------------------
+void MultibodyGraphModeler::AddJoint(const std::string& joint_name,
+                                     ModelInstanceIndex model_instance,
+                                     const std::string& type,
+                                     BodyIndex parent_body_num,
+                                     BodyIndex child_body_num, JointFlags flags,
+                                     void* user_ref) {
+  // Reject duplicate joint name, unrecognized type or body names.
+  DRAKE_DEMAND(!joint_name.empty() && model_instance.is_valid());
+  DRAKE_DEMAND(parent_body_num.is_valid() && child_body_num.is_valid());
+
+  InstanceJointIndexMap& all_joint_nums = joint_name_to_num_[joint_name];
+  auto p = all_joint_nums.find(model_instance);
+
+  // Reject duplicate joint name.
+  if (p != all_joint_nums.end()) {
+    throw std::logic_error(fmt::format(
+        "AddJoint({},{}): Name already present in this model instance.",
+        joint_name, model_instance));
+  }
+
+  const JointTypeIndex type_num = FindJointTypeNum(type);
+  if (!type_num.is_valid()) {
+    throw std::logic_error("AddJoint(): Joint " + joint_name +
+                           " had unrecognized joint type '" + type + "'");
+  }
+
+  if (!has_body(parent_body_num)) {
+    throw std::logic_error(
+        fmt::format("AddJoint({},{}): Invalid parent body {}."));
+  }
+
+  if (!has_body(child_body_num)) {
+    throw std::logic_error(
+        fmt::format("AddJoint({},{}): Invalid child body {}."));
+  }
+
+  const JointIndex joint_num(num_joints());  // next available
+  all_joint_nums[model_instance] = joint_num;
+
+  // Can't use emplace_back because the constructor is private.
+  joints_.push_back(Joint(joint_name, model_instance, type_num, parent_body_num,
+                          child_body_num, flags, user_ref));
+
+  get_mutable_body(parent_body_num).add_joint_as_parent(joint_num);
+  get_mutable_body(child_body_num).add_joint_as_child(joint_num);
+}
+
+//------------------------------------------------------------------------------
+//                                DELETE JOINT
+//------------------------------------------------------------------------------
+bool MultibodyGraphModeler::DeleteJoint(JointIndex joint_num) {
+  if (!has_joint(joint_num)) return false;
+
+  const ModelInstanceIndex model_instance =
+      get_joint(joint_num).model_instance();
+  DRAKE_DEMAND(model_instance.is_valid());
+
+  std::vector<JointIndex>& joints_as_parent =
+      get_mutable_body(joints_[joint_num].parent_body_num())
+          .mutable_joints_as_parent();
+  std::vector<JointIndex>::iterator it =
+      std::find(joints_as_parent.begin(), joints_as_parent.end(), joint_num);
+
+  // Data structures are corrupted if this joint is not found in
+  // joints_as_parent of parent body.
+  DRAKE_DEMAND(it != joints_as_parent.end());
+  joints_as_parent.erase(it);
+
+  std::vector<JointIndex>& joints_as_child =
+      get_mutable_body(joints_[joint_num].child_body_num())
+          .mutable_joints_as_child();
+  it = std::find(joints_as_child.begin(), joints_as_child.end(), joint_num);
+
+  // Data structures are corrupted if this joint is not found in
+  // joints_as_child of child body.
+  DRAKE_DEMAND(it != joints_as_child.end());
+  joints_as_child.erase(it);
+
+  // Remove the joint itself. This implicitly renumbers the joints after this
+  // one, because we expect the JointIndex to be an index into joints_.
+  joints_.erase(joints_.begin() + joint_num);
+
+  // Update indices due to the deletion of this joint
+  for (BodyIndex i(0); i < num_bodies(); ++i) {
+    auto& children = get_mutable_body(i).mutable_joints_as_parent();
+    for (auto& child : children) {
+      if (child > joint_num) --child;
+    }
+
+    auto& parents = get_mutable_body(i).mutable_joints_as_child();
+    for (auto& parent : parents) {
+      if (parent > joint_num) --parent;
+    }
+  }
+
+  // Rebuild the joint name-to-joint number map to reflect the new numbering.
+  joint_name_to_num_.clear();
+  for (JointIndex i(0); i < num_joints(); ++i) {
+    const Joint& joint = get_joint(i);
+    joint_name_to_num_[joint.name()][joint.model_instance()] = i;
+  }
+
+  return true;
+}
+
+//------------------------------------------------------------------------------
+//                               DUMP INPUT
+//------------------------------------------------------------------------------
+void MultibodyGraphModeler::DumpInput(std::ostream& o) const {
+  o << "\nMULTIBODY GRAPH MODELER INPUT\n";
+  o << "-----------------------------\n";
+  o << "\n" << num_bodies() << " BODIES:\n";
+  for (BodyIndex i(0); i < num_bodies(); ++i) {
+    const Body& body = get_body(i);
+    const std::string out =
+        fmt::format("{}: {} flags={}", i, body.name(), to_string(body.flags()));
+    o << out;
+    o << "\n    joints_as_parent=[";
+    for (JointIndex j(0); j < body.num_children(); ++j)
+      o << " " << body.joints_as_parent()[j];
+    o << "]\t  joints_as_child=[";
+    for (JointIndex j(0); j < body.num_parents(); ++j)
+      o << " " << body.joints_as_child()[j];
+    o << "]\n";
+  }
+
+  o << "\n" << num_joints() << " JOINTS:\n";
+  for (JointIndex i(0); i < num_joints(); ++i) {
+    const Joint& joint = get_joint(i);
+    const std::string out =
+        fmt::format("{}: {} {}->{} {} flags={}\n", i, joint.name(),
+                    get_body(joint.parent_body_num()).name(),
+                    get_body(joint.child_body_num()).name(),
+                    get_joint_type(joint.joint_type_num()).name(),
+                    to_string(joint.flags()));
+    o << out;
+  }
+
+  o << "\n---------- END OF MULTIBODY GRAPH MODELER INPUT.\n\n";
+}
+
+//------------------------------------------------------------------------------
+//                        GET BODY NUM FROM NAME
+//------------------------------------------------------------------------------
+auto MultibodyGraphModeler::GetAllBodyIndexFromName(
+    const std::string& body_name) const -> const InstanceBodyIndexMap* {
+  const auto body_nums = body_name_to_num_.find(body_name);
+  if (body_nums == body_name_to_num_.end()) return nullptr;
+  const auto& instance_map = body_nums->second;
+  DRAKE_DEMAND(!instance_map.empty());
+  return &instance_map;
+}
+
+auto MultibodyGraphModeler::GetBodyIndexFromNameAndInstance(
+    const std::string& body_name, ModelInstanceIndex model_instance,
+    const char* func) const -> BodyIndex {
+  DRAKE_DEMAND(model_instance.is_valid());
+
+  if (auto instance_map = GetAllBodyIndexFromName(body_name)) {
+    const auto entry = instance_map->find(model_instance);
+    if (entry != instance_map->end()) {
+      DRAKE_DEMAND(entry->second.is_valid());
+      return entry->second;
+    }
+  }
+
+  throw std::logic_error(
+      fmt::format("{}: body '{}' not found in model_instance {}.", func,
+                  body_name, model_instance));
+}
+
+auto MultibodyGraphModeler::GetUniqueBodyIndexFromName(
+    const std::string& body_name, const char* func) const -> BodyIndex {
+  auto instance_map = GetAllBodyIndexFromName(body_name);
+
+  if (instance_map == nullptr) {
+    throw std::logic_error(fmt::format(
+        "{}: body '{}' not found in any model_instance.", func, body_name));
+  }
+
+  if (instance_map->size() == 1) {
+    const BodyIndex body_num = instance_map->cbegin()->second;
+    DRAKE_DEMAND(body_num.is_valid());
+    return body_num;
+  }
+
+  throw std::logic_error(
+      fmt::format("{}: body name '{}' not unique. It appears in {} "
+                  "model instances. Provide a model instance to "
+                  "disambiguate.",
+                  func, body_name, instance_map->size()));
+}
+
+//------------------------------------------------------------------------------
+//                        GET JOINT INDEX FROM NAME
+//------------------------------------------------------------------------------
+auto MultibodyGraphModeler::GetAllJointIndexFromName(
+    const std::string& joint_name) const -> const InstanceJointIndexMap* {
+  const auto joint_nums = joint_name_to_num_.find(joint_name);
+  if (joint_nums == joint_name_to_num_.end()) return nullptr;
+  const auto& instance_map = joint_nums->second;
+  DRAKE_DEMAND(!instance_map.empty());
+  return &instance_map;
+}
+
+auto MultibodyGraphModeler::GetJointIndexFromNameAndInstance(
+    const std::string& joint_name, ModelInstanceIndex model_instance,
+    const char* func) const -> JointIndex {
+  DRAKE_DEMAND(model_instance.is_valid());
+
+  if (auto instance_map = GetAllJointIndexFromName(joint_name)) {
+    const auto entry = instance_map->find(model_instance);
+    if (entry != instance_map->end()) {
+      DRAKE_DEMAND(entry->second.is_valid());
+      return entry->second;
+    }
+  }
+
+  throw std::logic_error(
+      fmt::format("{}: joint '{}' not found in model_instance {}.", func,
+                  joint_name, model_instance));
+}
+
+auto MultibodyGraphModeler::GetUniqueJointIndexFromName(
+    const std::string& joint_name, const char* func) const -> JointIndex {
+  auto instance_map = GetAllJointIndexFromName(joint_name);
+
+  if (instance_map && instance_map->size() == 1) {
+    const JointIndex joint_num = instance_map->cbegin()->second;
+    DRAKE_DEMAND(joint_num.is_valid());
+    return joint_num;
+  }
+
+  throw std::logic_error(
+      fmt::format("{}: joint name '{}' not unique. It appears in {} "
+                  "model instances. Provide a model instance to "
+                  "disambiguate.",
+                  func, joint_name, instance_map->size()));
+}
+
+//------------------------------------------------------------------------------
+//                         BODIES ARE CONNECTED
+//------------------------------------------------------------------------------
+// Return true if there is a joint between two bodies given by body number,
+// regardless of parent/child ordering.
+bool MultibodyGraphModeler::BodiesAreConnected(BodyIndex body1_num,
+                                               BodyIndex body2_num) const {
+  const Body& body1 = get_body(body1_num);
+  for (JointIndex joint_num : body1.joints_as_parent()) {
+    if (get_joint(joint_num).child_body_num() == body2_num) return true;
+  }
+  for (JointIndex joint_num : body1.joints_as_child()) {
+    if (get_joint(joint_num).parent_body_num() == body2_num) return true;
+  }
+  return false;
+}
+
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/graph_modeler/multibody_graph_modeler.h
+++ b/multibody/graph_modeler/multibody_graph_modeler.h
@@ -1,0 +1,688 @@
+#pragma once
+
+/* Adapted for Drake from Simbody's MultibodyGraphMaker class.
+Portions copyright (c) 2013-14 Stanford University and the Authors.
+Authors: Michael Sherman
+Contributors: Kevin He
+
+Modifications copyright (c) 2019-20 Toyota Research Institute, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may
+not use this file except in compliance with the License. You may obtain a
+copy of the License at http://www.apache.org/licenses/LICENSE-2.0. */
+
+/** @file
+Declares the MultibodyGraphModeler class for use in representing a multibody
+system as input by a user in terms of bodies and joints. */
+
+#include <iosfwd>
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <fmt/format.h>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/multibody/tree/multibody_tree_indexes.h"
+
+namespace drake {
+namespace multibody {
+
+// TODO(sherm1) Make these multibody index types.
+using JointTypeIndex = TypeSafeIndex<class JointTypeNumTag>;
+
+// TODO(sherm1) Move these flags to MultibodyTreeModel and don't expose
+// them here?
+
+/** Boolean properties of a body that can affect the resulting tree model.
+These may be or-ed together and the result type is still BodyFlags. */
+enum BodyFlags : unsigned {
+  kDefaultBodyFlags = 0b0000,
+  kStaticBody = 0b0001,
+  kMustBeBaseBody = 0b0010,
+  kMustNotBeTerminalBody = 0b0100,
+};
+
+inline BodyFlags operator|(BodyFlags left, BodyFlags right) {
+  return static_cast<BodyFlags>(static_cast<unsigned>(left) |
+                                static_cast<unsigned>(right));
+}
+
+inline BodyFlags operator&(BodyFlags left, BodyFlags right) {
+  return static_cast<BodyFlags>(static_cast<unsigned>(left) &
+                                static_cast<unsigned>(right));
+}
+
+/** Boolean properties of a joint that can affect the resulting tree model. */
+enum JointFlags : unsigned {
+  kDefaultJointFlags = 0b0000,
+  kMustBeConstraint = 0b0001,
+};
+
+/** Boolean properties of a joint _type_ that can affect the resulting
+tree model. */
+enum JointTypeFlags : unsigned {
+  kDefaultJointTypeFlags = 0b0000,
+  kOkToUseAsJointConstraint = 0b0001,
+};
+
+std::string to_string(BodyFlags);
+std::string to_string(JointFlags);
+std::string to_string(JointTypeFlags);
+
+//==============================================================================
+//                          MULTIBODY GRAPH MODELER
+//==============================================================================
+/** Defines a multibody graph consisting of bodies interconnected by joints,
+with semantics identical to `.sdf` or `.urdf` files. This is not the
+computational model used by Drake; see MultibodyTreeModel for information about
+generating a computational model from a MultibodyGraph.
+
+The first body added (body 0) is assumed to be World and its name is used for
+recognizing World connections later in joints. If you accept the Drake defaults,
+that body will be named "world". The default names for Weld (0 dof) and Free
+(6 dof) joints are, not surprisingly, "weld" and "free" but you can change them.
+*/
+class MultibodyGraphModeler {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MultibodyGraphModeler)
+
+  // Local classes.
+  class Body;
+  class Joint;
+  class JointType;
+
+  /** Construct an empty %MultibodyGraphModeler object and set the default
+  names for Weld and Free joints to "weld" and "free". Also sets up Drake's
+  World body (named "world") and supported joint types, unless
+  `use_drake_defaults` is set `false`. In that case the first added body (body
+  number 0) is the World body and its name is used to represent World. */
+  explicit MultibodyGraphModeler(bool use_drake_defaults = true);
+
+  /** Restores this %MultibodyGraphModeler object to its just-constructed
+  condition. See the constructor documentation for the meaning of the
+  parameter. */
+  void Clear(bool use_drake_defaults = true);
+
+  /** @name         Define the input graph (bodies and joints)
+  Methods in this section are used to inform %MultibodyGraphModeler about the
+  bodies and joints as given, typically in an .sdf or .urdf file. You
+  can also inspect the set of bodies and joints, and remove bodies and joints
+  from an existing specification. */
+  //@{
+
+  /** Add a new body to the set of input bodies.
+  @param[in]      body_name
+      A unique string identifying this body. There are no other restrictions
+      on the contents of `name`. If this %MultibodyGraphModeler was constructed
+      without Drake defaults, the first body you add is considered to be
+      World, and its name is remembered and recognized when used in joints.
+  @param[in]      model_instance
+      The model instance to which this body belongs. If none is specified then
+      the body belongs to the default model instance. This is simply a tag that
+      is carried with the body and bodies generated from it; it has no effect
+      on the structure of the generated tree model. However, it does permit
+      queries that return only elements of a particular model instance.
+  @param[in]      flags
+      Optional flags affecting the generated tree model. Flags can be used to
+      designate a body as static, to require that it not be used as a terminal
+      mobilized body in the graph (because it is effectively massless), or to
+      require that the resulting mobilized body is a base body (that is,
+      connected directly to World).
+  @param[in]      user_ref
+      A generic user reference pointer that is kept with the associated
+      body and can be used by the caller to map back to their own data
+      structure containing additional body information.
+  @see DeleteBody() */
+  void AddBody(std::string name, ModelInstanceIndex model_instance,
+               BodyFlags flags = kDefaultBodyFlags, void* user_ref = nullptr);
+
+  /** Convenience overload that puts the body into the default model
+  instance. */
+  void AddBody(const std::string& name, BodyFlags flags = kDefaultBodyFlags,
+               void* user_ref = nullptr) {
+    AddBody(name, default_model_instance(), flags, user_ref);
+  }
+
+  /** Delete a body from the set of input bodies. All the joints that
+  reference this body will be deleted too. Body numbers and joint numbers will
+  have changed after this call.
+  @param[in]      body_num
+      The body index of the body to delete. Note that other bodies may get
+      renumbered after a deletion.
+  @returns `true` if the body is successfully deleted, `false` if it
+      didn't exist. */
+  bool DeleteBody(BodyIndex body_num);
+
+  /** Delete a body given by just its name, which must be unique among all
+  model instances. */
+  bool DeleteBody(const std::string& body_name) {
+    return DeleteBody(FindBodyIndex(body_name));
+  }
+
+  /** Add a new joint to the set of input joints.
+  @param[in]      name
+      A string uniquely identifying this joint within its model instance. There
+      are no other restrictions on the contents of `name`.
+  @param[in]      model_instance
+      The model instance to which this joint belongs. If none is specified then
+      the joint belongs to the default model instance. This is simply a tag that
+      is carried with the joint and mobilizers generated from it; it has no
+      effect on the structure of the generated tree model. However, it does
+      permit queries that return only elements of a particular model instance.
+  @param[in]      type
+      A string designating the type of this joint, such as "revolute" or
+      "ball". This must be chosen from the set of joint types previously
+      registered.
+  @param[in]      parent_body_num
+      This must be the index of a body that was already specified in an earlier
+      AddBody() call, including the World body which is always body 0. If
+      possible, this will be used as the inboard mobilized body for the
+      corresponding mobilizer in the tree model.
+  @param[in]      child_body_num
+      This must be the index of a body that was already specified in an earlier
+      AddBody() call, including the World body which is always body 0. It must
+      be distinct from `parent_body_num`. If possible, this will be used as the
+      outboard mobilized body for the corresponding mobilizer.
+  @param[in]      flags
+      If you feel strongly that this joint should be implemented using
+      a constraint rather than a mobilizer (not common), provide the flag
+      kMustBeConstraint. In that case the joint will not appear in the list of
+      joints that are candidates to be modeled as mobilizers in a multibody
+      tree. See MultibodyTreeModel for details.
+  @param[in]      user_ref
+      This is a generic user reference pointer that is kept with the joint
+      and can be used by the caller to map back to their own data
+      structure containing additional joint information.
+  @see DeleteJoint() */
+  void AddJoint(const std::string& name, ModelInstanceIndex model_instance,
+                const std::string& type, BodyIndex parent_body_num,
+                BodyIndex child_body_num, JointFlags flags = kDefaultJointFlags,
+                void* user_ref = nullptr);
+
+  /** Convenience overload that puts the joint into the default model
+  instance. */
+  void AddJoint(const std::string& name, const std::string& type,
+                BodyIndex parent_body_num, BodyIndex child_body_num,
+                JointFlags flags = kDefaultJointFlags,
+                void* user_ref = nullptr) {
+    AddJoint(name, default_model_instance(), type, parent_body_num,
+             child_body_num, flags, user_ref);
+  }
+
+  /** Convenience overload that accepts names for the parent and child bodies.
+  This can only be used if those names are unique across all model instances. */
+  void AddJoint(const std::string& name, const std::string& type,
+                const std::string& parent_body_name,
+                const std::string& child_body_name,
+                JointFlags flags = kDefaultJointFlags,
+                void* user_ref = nullptr) {
+    AddJoint(name, default_model_instance(), type,
+             FindBodyIndex(parent_body_name), FindBodyIndex(child_body_name),
+             flags, user_ref);
+  }
+
+  /** Delete an existing joint from the set of input joints. The bodies
+  referenced by the joint are expected to exist and their references to this
+  joint will be removed as well. Joint numbers will have changed after this
+  call.
+  @param[in]      joint_num
+      The index of the joint to delete. Note that other joints may get
+      renumbered after a deletion.
+  @returns `true` if the joint is successfully deleted, `false` if it
+      didn't exist. */
+  bool DeleteJoint(JointIndex joint_num);
+
+  /** Delete a body given by just its name, which must be unique among all
+  model instances. */
+  bool DeleteJoint(const std::string& joint_name) {
+    return DeleteJoint(FindJointIndex(joint_name));
+  }
+
+  /** (Advanced) Change the flags for an existing body. May cause a different
+  graph to be generated on the next call to MakeTreeModel(). This method
+  exists primarily for testing purposes; normally the flags provided when the
+  body is added remain unchanged. */
+  void ChangeBodyFlags(BodyIndex body_num, BodyFlags flags);
+
+  /** (Advanced) Convenience overload for changing flags for a body given by
+  just its name, which must be unique among all model instances. */
+  void ChangeBodyFlags(const std::string& body_name, BodyFlags flags) {
+    ChangeBodyFlags(FindBodyIndex(body_name), flags);
+  }
+
+  /** Returns the name we recognize as the World (or Ground) body. This is
+  the name that was provided in the first AddBody() call. */
+  const std::string& world_body_name() const;
+
+  /** Returns the body number for the World body (always zero). */
+  BodyIndex world_body_num() const { return BodyIndex(0); }
+
+  /** For debugging, write a human-readable representation of the input graph
+  to the given output stream. */
+  void DumpInput(std::ostream& output_stream) const;
+  //@}
+
+  /** @name             Inspect the bodies and joints
+  Methods in this section allow introspection of the input objects. */
+  //@{
+
+  /** Returns the number of bodies, including all input bodies, and a World
+  body. */
+  int num_bodies() const { return static_cast<int>(bodies_.size()); }
+
+  /** Gets a Body object by its assigned number. These are assigned first to
+  World (body 0) and then input bodies. */
+  const Body& get_body(BodyIndex body_num) const {
+    DRAKE_ASSERT(has_body(body_num));
+    return bodies_[body_num];
+  }
+
+  /** Returns true if the given BodyIndex corresponds to a Body.
+  @pre `body_num` must not be invalid (that is, it can't be uninitialized). */
+  bool has_body(BodyIndex body_num) const {
+    DRAKE_DEMAND(body_num.is_valid());
+    return body_num < num_bodies();
+  }
+
+  /** Returns true iff there is a body by this name in any model instance. Note
+  that there may be more than one. */
+  bool HasBody(const std::string& body_name) const {
+    auto instance_map = GetAllBodyIndexFromName(body_name);
+    return instance_map != nullptr;  // At least one body found.
+  }
+
+  /** Returns true iff this body name appears in exactly one model instance. */
+  bool IsUniqueBodyName(const std::string& body_name) const {
+    auto instance_map = GetAllBodyIndexFromName(body_name);
+    return instance_map && instance_map->size() == 1;
+  }
+
+  /** Returns the body number assigned to the input body with the given name
+  in the given model instance. Throws std::logic_error if the name is not found
+  in that model instance. */
+  BodyIndex FindBodyIndex(const std::string& name,
+                          ModelInstanceIndex model_instance) const {
+    DRAKE_DEMAND(!name.empty() && model_instance.is_valid());
+    return GetBodyIndexFromNameAndInstance(name, model_instance, __func__);
+  }
+
+  /** Returns the body number assigned to the input body identified by name
+  only (no model instance). The name must be globally unique. Throws
+  std::logic_error if the name is not recognized or not unique. */
+  BodyIndex FindBodyIndex(const std::string& name) const {
+    return GetUniqueBodyIndexFromName(name, __func__);
+  }
+
+  /** Returns the number of input joints. */
+  int num_joints() const { return static_cast<int>(joints_.size()); }
+
+  /** Gets a Joint object by its assigned number. */
+  const Joint& get_joint(JointIndex joint_num) const {
+    DRAKE_ASSERT(has_joint(joint_num));
+    return joints_[joint_num];
+  }
+
+  /** Returns true if the given JointIndex corresponds to a Joint.
+  @pre `joint_num` must not be invalid (that is, it can't be uninitialized). */
+  bool has_joint(JointIndex joint_num) const {
+    DRAKE_DEMAND(joint_num.is_valid());
+    return joint_num < num_joints();
+  }
+
+  /** Returns true iff there is a joint by this name in any model instance. Note
+  that there may be more than one. */
+  bool HasJoint(const std::string& joint_name) const {
+    auto instance_map = GetAllJointIndexFromName(joint_name);
+    return instance_map != nullptr;  // At least one joint found.
+  }
+
+  /** Returns true iff this joint name appears in exactly one model instance. */
+  bool IsUniqueJointName(const std::string& joint_name) const {
+    auto instance_map = GetAllJointIndexFromName(joint_name);
+    return instance_map && instance_map->size() == 1;
+  }
+
+  /** Returns the joint number assigned to the input joint with the given name
+  in the given model instance. Throws std::logic_error if the name is not found
+  in that model instance. */
+  JointIndex FindJointIndex(const std::string& name,
+                            ModelInstanceIndex model_instance) const {
+    return GetJointIndexFromNameAndInstance(name, model_instance, __func__);
+  }
+
+  /** Returns the joint number assigned to the input joint identified by name
+  only (no model instance). The name must be globally unique. Throws
+  std::logic_error if the name is not recognized or not unique.  */
+  JointIndex FindJointIndex(const std::string& name) const {
+    return GetUniqueJointIndexFromName(name, __func__);
+  }
+
+  /** Returns true if there is any joint _directly_ connecting these two
+  bodies. */
+  bool BodiesAreConnected(BodyIndex body1_num, BodyIndex body2_num) const;
+  //@}
+
+  /** @name         Specify and inspect available joint types
+  Use the methods in this section to inform %MultibodyGraphModeler about the
+  available joint types in your multibody code. You can also inspect what has
+  been defined already. Some joint types are predefined if you accept the
+  Drake defaults at construction. */
+  //@{
+  /** Specify relevant properties of a joint type as implemented in your
+  multibody code. The joint type name must be unique. Weld and Free types are
+  predefined and their names are reserved (though you can change the names to be
+  used).
+  @param[in]      name
+      A unique string identifying a joint type, such as "pin" or "prismatic".
+      There is no model instance associated with a joint type.
+  @param[in]      num_q
+      The number of generalized coordinates (positions) to be included in the
+      model for this joint type. Must be greater than or equal to `num_v`.
+  @param[in]      num_v
+      The number of generalized velocities (degrees of freedom) to be included
+      in the model for this joint type. Must be less than or equal to `num_q`.
+  @param[in]      flags
+      You can set this to `kOkToUseAsJointConstraint` which
+      means that, in addition to a mobilizer of this type, your multibody code
+      has available a constraint-based joint that is just as good. If so
+      MultibodyTreeModel will attempt to use that constraint rather than
+      cutting a body to break a loop. Typically used only for ball (spherical)
+      joints.
+  @param[in]      user_ref
+      This is a generic user reference pointer that is kept with the joint type
+      and can be used by the caller to map back to their own data
+      structure containing more joint type information.
+  @retval JointTypeNum Small integer joint type number used for referencing. */
+  JointTypeIndex RegisterJointType(
+      const std::string& name, int num_q, int num_v,
+      JointTypeFlags flags = kDefaultJointTypeFlags, void* user_ref = nullptr);
+
+  /** Change the name to be used to identify the weld joint type (0 dof) and
+  weld loop constraint type (6 constraints). */
+  void SetWeldJointTypeName(const std::string& name) { weld_type_name_ = name; }
+
+  /** Changes the name to be used to identify the free (6 dof) joint type and
+  free (0 constraints) loop constraint type. */
+  void SetFreeJointTypeName(const std::string& name) { free_type_name_ = name; }
+
+  /** Returns the number of registered joint types. */
+  int num_joint_types() const { return static_cast<int>(joint_types_.size()); }
+
+  /** Get a JointType object by its assigned number. */
+  const JointType& get_joint_type(JointTypeIndex joint_type_num) const {
+    DRAKE_ASSERT(joint_type_num.is_valid() &&
+                 joint_type_num < num_joint_types());
+    return joint_types_[joint_type_num];
+  }
+
+  /** Finds the assigned number for a joint type from the type name. */
+  JointTypeIndex FindJointTypeNum(const std::string& joint_type_name) const {
+    std::map<std::string, JointTypeIndex>::const_iterator p =
+        joint_type_name_to_num_.find(joint_type_name);
+    return p == joint_type_name_to_num_.end() ? JointTypeIndex() : p->second;
+  }
+
+  /** Return the name currently being used to identify the weld joint type
+  and weld loop constraint type. */
+  const std::string& get_weld_joint_type_name() const {
+    return weld_type_name_;
+  }
+
+  /** Returns the name currently being used to identify the free joint type
+  and free loop constraint type. */
+  const std::string& get_free_joint_type_name() const {
+    return free_type_name_;
+  }
+  //@}
+
+ private:
+  // Get writable access to bodies and joints.
+  Body& get_mutable_body(BodyIndex body_num) {
+    DRAKE_DEMAND(has_body(body_num));
+    return bodies_[body_num];
+  }
+
+  Joint& get_mutable_joint(JointIndex joint_num) {
+    DRAKE_DEMAND(has_joint(joint_num));
+    return joints_[joint_num];
+  }
+
+  // These maps are used to collect together all the bodies or joints with
+  // the same name, but in different model instances.
+  using InstanceBodyIndexMap = std::map<ModelInstanceIndex, BodyIndex>;
+  using InstanceJointIndexMap = std::map<ModelInstanceIndex, JointIndex>;
+
+  // Returns the model_instance->body_num map for all bodies with this name,
+  // if any, otherwise nullptr.
+  const InstanceBodyIndexMap* GetAllBodyIndexFromName(
+      const std::string& body_name) const;
+
+  // Returns the body_num for the a body name in a model instance.
+  BodyIndex GetBodyIndexFromNameAndInstance(const std::string& body_name,
+                                            ModelInstanceIndex model_instance,
+                                            const char* func) const;
+
+  // Returns the body_num for this body name, which must appear in only one
+  // model instance.
+  BodyIndex GetUniqueBodyIndexFromName(const std::string& name,
+                                       const char* func) const;
+
+  // Returns the model_instance->joint_num map for all joints with this name,
+  // if any, otherwise nullptr.
+  const InstanceJointIndexMap* GetAllJointIndexFromName(
+      const std::string& joint_name) const;
+
+  // Returns the JointIndex for the a joint name in a model instance.
+  JointIndex GetJointIndexFromNameAndInstance(const std::string& joint_name,
+                                              ModelInstanceIndex model_instance,
+                                              const char* func) const;
+
+  // Returns the JointIndex for this joint name, which must appear in only one
+  // model instance.
+  JointIndex GetUniqueJointIndexFromName(const std::string& joint_name,
+                                         const char* func) const;
+
+  // Clear everything except for default names.
+  void ClearContainers() {
+    joint_types_.clear();
+    joint_type_name_to_num_.clear();
+    bodies_.clear();
+    body_name_to_num_.clear();
+    joints_.clear();
+    joint_name_to_num_.clear();
+  }
+
+  std::string weld_type_name_, free_type_name_;
+  std::vector<JointType> joint_types_;
+  std::map<std::string, JointTypeIndex> joint_type_name_to_num_;
+
+  std::vector<Body> bodies_;  // world + input bodies
+  std::map<std::string, InstanceBodyIndexMap> body_name_to_num_;
+
+  std::vector<Joint> joints_;  // input joints
+  std::map<std::string, InstanceJointIndexMap> joint_name_to_num_;
+};
+
+//------------------------------------------------------------------------------
+//                      MULTIBODY GRAPH MODELER :: BODY
+//------------------------------------------------------------------------------
+/** Local class that collects information about bodies in the input. */
+class MultibodyGraphModeler::Body {
+ public:
+  /** Returns the number of joints that specify this body as their parent
+  body. This refers to the input parent/child designation _not_ necessarily
+  the inboard/outboard relationship in the generated tree. */
+  int num_children() const {
+    return static_cast<int>(joints_as_parent_.size());
+  }
+
+  /** Returns the number of joints that specify this body as their child
+  body. This refers to the input parent/child designation _not_ necessarily
+  the inboard/outboard relationship in the generated tree. */
+  int num_parents() const { return static_cast<int>(joints_as_child_.size()); }
+
+  /** Returns the total number of joints that specify this body as either
+  parent or child (this is num_children() + num_parents()). */
+  int num_joints() const { return num_children() + num_parents(); }
+
+  const std::string& name() const { return name_; }
+  ModelInstanceIndex model_instance() const { return model_instance_; }
+  BodyFlags flags() const { return flags_; }
+  bool must_be_nonterminal() const { return flags_ & kMustNotBeTerminalBody; }
+  bool is_static() const { return flags_ & kStaticBody; }
+  bool must_be_base_body() const { return flags_ & kMustBeBaseBody; }
+  void* user_ref() const { return user_ref_; }
+
+  /** Returns the list of joints (by joint number) for which this body is
+  the child body. */
+  const std::vector<JointIndex>& joints_as_child() const {
+    return joints_as_child_;
+  }
+
+  /** Returns the list of joints (by joint number) for which this body is
+  the parent body. */
+  const std::vector<JointIndex>& joints_as_parent() const {
+    return joints_as_parent_;
+  }
+
+  /** Changes the flags for this body. */
+  void set_flags(BodyFlags flags) { flags_ = flags; }
+
+ private:
+  // Restrict construction and modification to only MultibodyGraphModeler.
+  friend class MultibodyGraphModeler;
+
+  Body(const std::string& name, ModelInstanceIndex model_instance,
+       BodyFlags flags, void* user_ref)
+      : name_(name),
+        model_instance_(model_instance),
+        flags_(flags),
+        user_ref_(user_ref) {
+    DRAKE_DEMAND(!name.empty() && model_instance.is_valid());
+  }
+
+  // Notes that this body serves as the parent body for the given joint.
+  void add_joint_as_parent(JointIndex joint_num) {
+    joints_as_parent_.push_back(joint_num);
+  }
+
+  // Notes that this body serves as the child body for the given joint.
+  void add_joint_as_child(JointIndex joint_num) {
+    joints_as_child_.push_back(joint_num);
+  }
+
+  // Returns mutable access to the list of joints for which this body is
+  // the child body.
+  std::vector<JointIndex>& mutable_joints_as_child() {
+    return joints_as_child_;
+  }
+
+  // Returns mutable access to the list of joints for which this body is
+  // the parent body.
+  std::vector<JointIndex>& mutable_joints_as_parent() {
+    return joints_as_parent_;
+  }
+
+  // Inputs
+  std::string name_;
+  ModelInstanceIndex model_instance_;
+  BodyFlags flags_{kDefaultBodyFlags};
+  void* user_ref_;
+
+  // How this body appears in joints (input and added).
+  std::vector<JointIndex> joints_as_child_;   // where this body is the child
+  std::vector<JointIndex> joints_as_parent_;  // where this body is the parent
+};
+
+//------------------------------------------------------------------------------
+//                      MULTIBODY GRAPH MODELER :: JOINT
+//------------------------------------------------------------------------------
+/** Local class that collects information about input joints. */
+class MultibodyGraphModeler::Joint {
+ public:
+  const std::string& name() const { return name_; }
+  ModelInstanceIndex model_instance() const { return model_instance_; }
+  JointFlags flags() const { return flags_; }
+  bool must_be_constraint() const { return flags_ & kMustBeConstraint; }
+  void* user_ref() const { return user_ref_; }
+
+  BodyIndex parent_body_num() const { return parent_body_num_; }
+  BodyIndex child_body_num() const { return child_body_num_; }
+  JointTypeIndex joint_type_num() const { return joint_type_num_; }
+
+ private:
+  // Restrict construction and modification to only MultibodyGraphModeler.
+  friend class MultibodyGraphModeler;
+
+  Joint(const std::string& name, ModelInstanceIndex model_instance,
+        JointTypeIndex joint_type_num, BodyIndex parent_body_num,
+        BodyIndex child_body_num, JointFlags flags, void* user_ref)
+      : name_(name),
+        model_instance_(model_instance),
+        joint_type_num_(joint_type_num),
+        flags_(flags),
+        user_ref_(user_ref),
+        parent_body_num_(parent_body_num),
+        child_body_num_(child_body_num) {
+    DRAKE_DEMAND(!name.empty() && model_instance.is_valid());
+  }
+
+  void set_parent_body_num(BodyIndex parent_body_num) {
+    parent_body_num_ = parent_body_num;
+  }
+  void set_child_body_num(BodyIndex child_body_num) {
+    child_body_num_ = child_body_num;
+  }
+
+  // Inputs
+  std::string name_;
+  ModelInstanceIndex model_instance_;
+  JointTypeIndex joint_type_num_;
+  JointFlags flags_;
+  void* user_ref_{nullptr};
+
+  BodyIndex parent_body_num_;
+  BodyIndex child_body_num_;
+};
+
+//------------------------------------------------------------------------------
+//                   MULTIBODY GRAPH MODELER :: JOINT TYPE
+//------------------------------------------------------------------------------
+/** Local class that defines the properties of a known joint type. */
+class MultibodyGraphModeler::JointType {
+ public:
+  const std::string& name() const { return name_; }
+  int num_q() const { return num_q_; }
+  int num_v() const { return num_v_; }
+  bool have_good_joint_constraint_available() const {
+    return flags_ & kOkToUseAsJointConstraint;
+  }
+  void* user_ref() const { return user_ref_; }
+
+ private:
+  // Restrict construction to only MultibodyGraphModeler.
+  friend class MultibodyGraphModeler;
+
+  JointType(const std::string& name, int num_q, int num_v, JointTypeFlags flags,
+            void* user_ref)
+      : name_(name),
+        num_q_(num_q),
+        num_v_(num_v),
+        flags_(flags),
+        user_ref_(user_ref) {
+    DRAKE_DEMAND(!name.empty());
+  }
+
+  std::string name_;
+  int num_q_{-1};
+  int num_v_{-1};
+  JointTypeFlags flags_{kDefaultJointTypeFlags};
+  void* user_ref_{nullptr};
+};
+
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/graph_modeler/multibody_tree_model.cc
+++ b/multibody/graph_modeler/multibody_tree_model.cc
@@ -1,0 +1,799 @@
+/* Adapted for Drake from Simbody's MultibodyGraphModeler class.
+Portions copyright (c) 2013-14 Stanford University and the Authors.
+Authors: Michael Sherman
+Contributors: Kevin He
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may
+not use this file except in compliance with the License. You may obtain a
+copy of the License at http://www.apache.org/licenses/LICENSE-2.0. */
+
+#include "drake/multibody/graph_modeler/multibody_tree_model.h"
+
+#include <algorithm>
+#include <exception>
+#include <iostream>
+#include <limits>
+#include <set>
+#include <stdexcept>
+#include <string>
+
+#include <fmt/format.h>
+
+#include "drake/common/drake_assert.h"
+
+using std::cout;
+using std::endl;
+
+namespace drake {
+namespace multibody {
+
+//------------------------------------------------------------------------------
+//                              MAKE TREE MODEL
+//------------------------------------------------------------------------------
+void MultibodyTreeModel::MakeTreeModel(const MultibodyGraphModeler& graph) {
+  // Body and Joint inputs have been supplied. Body 0 is World.
+
+  // First construct the table of joint types in the generated tree.
+  for (JointTypeIndex joint_type_num(0);
+       joint_type_num < graph.num_joint_types(); ++joint_type_num) {
+    const JointType& joint_type = graph.get_joint_type(joint_type_num);
+    const JointTypeIndex graph_joint_type_num =
+        AddJointType(joint_type.name(), joint_type.user_ref());
+    DRAKE_DEMAND(graph_joint_type_num == joint_type_num);
+  }
+
+  // Next, add a subset of the body and joint information to the tree.
+  for (BodyIndex body_num(0); body_num < graph.num_bodies(); ++body_num) {
+    const Body& body = graph.get_body(body_num);
+    const BodyIndex graph_body_num = AddBodyInfo(body.name(), body.user_ref());
+    DRAKE_DEMAND(graph_body_num == body_num);
+  }
+
+  for (JointIndex joint_num(0); joint_num < graph.num_joints(); ++joint_num) {
+    const Joint& joint = graph.get_joint(joint_num);
+    const JointIndex graph_joint_num =
+        AddJointInfo(joint.name(), joint.joint_type_num(), joint.user_ref());
+    DRAKE_DEMAND(graph_joint_num == joint_num);
+  }
+
+  // Next, create a MobilizedBody in tree corresponding to each Body.
+  // By construction, mobilized body numbers are the same as their corresponding
+  // input body numbers.
+  for (BodyIndex body_num(0); body_num < graph.num_bodies(); ++body_num) {
+    const MobilizedBodyNum mobod_num = AddMobodFromBody(body_num);
+    DRAKE_DEMAND(mobod_num.to_int() == body_num.to_int());
+  }
+
+  // 1. Add a free mobilizer to World for any mobilized body whose input body
+  // said it must be a base body and didn't already have a connection to World.
+  //
+  // While we're at it, look for dangling massless bodies -- they are only
+  // allowed if they were originally connected to at least two other bodies
+  // by given tree-eligible joints, or if they are connected by a weld
+  // joint and thus have no mobility.
+  // TODO(sherm1): "must be constraint" joints shouldn't count towards the
+  // required two for massless bodies, but we're not checking.
+  for (BodyIndex body_num(1); body_num < graph.num_bodies();
+       ++body_num) {  // skip World
+    const Body& body = graph.get_body(body_num);
+    if (body.must_be_nonterminal()) {
+      if (body.num_joints() == 0) {
+        throw std::runtime_error(
+            "MakeTreeModel(): body " + body.name() +
+            " must be nonterminal but it is free (no joint). Must be"
+            " internal or welded to a terminal-ok body.");
+      }
+      if (body.num_joints() == 1) {
+        const JointIndex joint_num = body.joints_as_child().empty()
+                                         ? body.joints_as_parent()[0]
+                                         : body.joints_as_child()[0];
+        const Joint& joint = graph.get_joint(joint_num);
+        const JointType& joint_type =
+            graph.get_joint_type(joint.joint_type_num());
+        if (joint_type.num_v() > 0) {
+          throw std::runtime_error(
+              "MakeTreeModel(): body " + body.name() +
+              " must be nonterminal but is not internal and not welded to"
+              " a terminal-ok body.");
+        }
+      }
+    }
+
+    // Attach the body of must-be-base-body bodies to World.
+    if (body.must_be_base_body() &&
+        !graph.BodiesAreConnected(body_num, graph.world_body_num())) {
+      const MultibodyTreeModel::MobilizedBodyNum mobod_num{
+          body_num.to_int()};  // By construction.
+      ConnectBodyToWorld(mobod_num, false /* not static */);
+    }
+  }
+
+  // 2. Repeat until all bodies are in the tree:
+  //   - try to build the tree from World outwards
+  //   - if incomplete, add one missing connection to World
+  // This terminates because we add at  least one body to the tree each time.
+  int start_level = 1;  // Start by looking for base bodies.
+  while (true) {
+    GrowTree(graph, start_level);
+    const BodyIndex new_base_body = ChooseNewBaseBody(graph);
+    if (!new_base_body.is_valid()) break;  // all body are in the tree
+    // Add mobilizer to World for this mobilized body's body.
+    ConnectBodyToWorld(body_to_mobod_num(new_base_body),
+                       false /* not static */);
+    start_level = 2;  // Start from new base body.
+  }
+
+  // 3. Split the loops
+  // This requires adding new "slave" bodies to replace the child bodies in
+  // the loop-forming joints. Then each slave is welded back to its master
+  // body (the original child).
+  BreakLoops(graph);
+}
+
+//------------------------------------------------------------------------------
+//                          CHOOSE NEW BASE BODY
+//------------------------------------------------------------------------------
+// We've tried to build the tree but might not have succeeded in using
+// all the bodies. That means we'll have to connect one of them to World.
+// Select the best unattached body to model with a base body, or returns
+// an invalid BodyIndex if all bodies
+// are already modeled in the spanning tree. We hope to find a body that is
+// serving as a parent but has never been listed as a child; that is crying out
+// to be connected directly to World. We'll take the first one of those we
+// find to roughly preserve the order of connected graphs in the input.
+//
+// If there is no parent-only body, we're going to have to pick a child body
+// as a base body, meaning that any joint for which it was the child will have
+// to use a reversed mobilizer (because a base body is always a parent). Of
+// those we pick the one with the most children.
+//
+// Note that any must-be-base-body bodies get attached to World before anything
+// else; that is done at the start of MakeTreeModel() rather than here.
+auto MultibodyTreeModel::ChooseNewBaseBody(
+    const MultibodyGraphModeler& graph) const -> BodyIndex {
+  BodyIndex best_body;
+  int num_children = -1;
+  // Skip the World body.
+  // TODO(sherm1) This runs through all the bodies each time; if that
+  // becomes expensive, start after the last-found base body.
+  for (BodyIndex body_num(1); body_num < graph.num_bodies(); ++body_num) {
+    const Body& body = graph.get_body(body_num);
+    const MobilizedBody& mobod = this->mobod(body_to_mobod_num(body_num));
+    if (mobod.is_in_tree()) continue;  // Unavailable.
+
+    // If this is a parent-only body, choose it.
+    if (body.num_parents() == 0) return body_num;
+
+    // This is a childish body, keep the one with the most children.
+    if (body.num_children() > num_children) {
+      best_body = body_num;
+      num_children = body.num_children();
+    }
+  }
+  return best_body;
+}
+
+//------------------------------------------------------------------------------
+//                   FIND HEAVIEST UNASSIGNED FORWARD JOINT
+//------------------------------------------------------------------------------
+// Starting with a given body whose body is in the tree already, look at its
+// unassigned children (meaning bodies connected by joints that aren't
+// mobilizers yet) and return a joint connecting it to a child that can serve
+// as a terminal body (has mass). (The idea is that this would be a good
+// direction to extend the chain.) Returns an invalid joint number if this body
+// has no children.
+auto MultibodyTreeModel::FindHeaviestUnassignedForwardJoint(
+    BodyIndex parent_body_num, const MultibodyGraphModeler& graph) const
+    -> JointIndex {
+  const Body& parent_body = graph.get_body(parent_body_num);
+  const MultibodyTreeModel::MobilizedBody& inboard_body =
+      body_to_mobod(parent_body_num);
+  DRAKE_DEMAND(inboard_body.is_in_tree());
+
+  JointIndex joint_num;
+  // Search joints for which this is the parent body.
+  for (JointIndex joint_forward : parent_body.joints_as_parent()) {
+    const Joint& joint = graph.get_joint(joint_forward);
+    if (joint.must_be_constraint()) continue;  // Can't be a tree joint.
+
+    if (joint_info(joint_forward).has_mobilizer())
+      continue;  // already in the tree
+
+    const Body& child_body = graph.get_body(joint.child_body_num());
+    const MobilizedBody& child_mobod = body_to_mobod(joint.child_body_num());
+
+    if (child_mobod.is_in_tree()) continue;  // This is a loop joint.
+
+    if (!child_body.must_be_nonterminal()) {
+      joint_num = joint_forward;
+      break;
+    }
+  }
+  return joint_num;
+}
+
+//------------------------------------------------------------------------------
+//                   FIND HEAVIEST UNASSIGNED REVERSE JOINT
+//------------------------------------------------------------------------------
+// Same as previous method, but now we are looking for unassigned joints where
+// the given body serves as the child so we would have to reverse the joint to
+// add it to the tree. (This is less desirable so is a fallback.)
+auto MultibodyTreeModel::FindHeaviestUnassignedReverseJoint(
+    BodyIndex child_body_num, const MultibodyGraphModeler& graph) const
+    -> JointIndex {
+  const Body& child_body = graph.get_body(child_body_num);
+  const MultibodyTreeModel::MobilizedBody& outboard_body =
+      body_to_mobod(child_body_num);
+  DRAKE_DEMAND(outboard_body.is_in_tree());
+
+  JointIndex joint_num;
+  // Search joints for which this is the child body.
+  for (JointIndex joint_reverse : child_body.joints_as_child()) {
+    const Joint& joint = graph.get_joint(joint_reverse);
+    if (joint.must_be_constraint()) continue;  // Can't be a tree joint.
+
+    if (joint_info(joint_reverse).has_mobilizer())
+      continue;  // already in the tree
+
+    const Body& parent_body = graph.get_body(joint.parent_body_num());
+    const MobilizedBody& parent_mobod =
+        body_to_mobod(joint.parent_body_num());
+
+    if (parent_mobod.is_in_tree()) continue;  // This is a loop joint.
+
+    if (!parent_body.must_be_nonterminal()) {
+      joint_num = joint_reverse;
+      break;
+    }
+  }
+  return joint_num;
+}
+
+//------------------------------------------------------------------------------
+//                                 GROW TREE
+//------------------------------------------------------------------------------
+// Process unused joints for which one body's body is in the tree (at level h)
+// and the other is not. Add the other body's body as the outboard body at
+// level h+1, marking the mobilizer as forward (other body is child) or reverse
+// (other body is parent). Repeat
+// until no changes are made. Does not assign loop joints or any bodies that
+// don't have a path to World. Extend the multibody tree starting with the
+// lowest-level eligible joints and moving outwards. We're doing this
+// breadth-first so that we get roughly even-length chains and we'll stop at
+// the first level at which we fail to find any joint. If we fail to consume
+// all the bodies, the caller will have to add a level 1 mobilizer to attach a
+// previously-disconnected base body to World and then call this again.
+//
+// We violate the breadth-first heuristic to avoid ending a branch with a
+// massless body, unless it is welded to its parent. If we add a mobile massless
+// body, we'll keep going out along its branch until we hit a massful body. It
+// is a disaster if we fail to find a massful body because a tree that
+// terminates in a mobile massless body will generate a singular mass matrix.
+// We'll throw an exception in that case, but note that this may just be a
+// failure of the heuristic; there may be some tree that could have avoided the
+// terminal massless body but we failed to discover it.
+//
+// TODO(sherm1): keep a list of unprocessed joints so we don't have to go
+// through all of them again at each level.
+void MultibodyTreeModel::GrowTree(const MultibodyGraphModeler& graph,
+                                  int start_level) {
+  // Record the joints for which we added mobilizers during this subtree
+  // sweep. That way if we jumped levels ahead due to massless bodies we
+  // can take credit and keep going rather than quit.
+  std::set<JointIndex> joints_added;
+  for (int level = start_level;; ++level) {  // level of outboard body
+    bool any_mobilizer_added = false;
+    for (JointIndex joint_num(0); joint_num < num_joints(); ++joint_num) {
+      // See if this joint is at the right level (meaning its inboard
+      // body is at level-1) and is available to become a mobilizer.
+      const Joint& joint = graph.get_joint(joint_num);
+      const JointInfo& joint_info =
+          this->joint_info(joint_num);
+      if (joint_info.has_mobilizer()) {
+        // Already done -- one of ours?
+        if (joints_added.count(joint_num)) {
+          // We added it during this GrowTree() call -- is it at
+          // the current level?
+          const Mobilizer& mobilizer =
+              get_mobilizer(joint_info.mobilizer_num());
+          if (mobilizer.level() == level)
+            any_mobilizer_added = true;  // Added one at level.
+        }
+        continue;
+      }
+
+      if (joint.must_be_constraint()) continue;  // can't be a tree joint
+
+      const Body& parent_body = graph.get_body(joint.parent_body_num());
+      const Body& child_body = graph.get_body(joint.child_body_num());
+
+      const MobilizedBodyNum parent_mobod_num =
+          body_to_mobod_num(joint.parent_body_num());
+      const MobilizedBodyNum child_mobod_num =
+          body_to_mobod_num(joint.child_body_num());
+
+      const MobilizedBody& parent_mobod =
+          mobod(parent_mobod_num);
+      const MobilizedBody& child_mobod =
+          mobod(child_mobod_num);
+
+      // Exactly one of parent or child body must already be in the tree.
+      if (!(parent_mobod.is_in_tree() ^ child_mobod.is_in_tree())) continue;
+
+      // Stop growing this branch after the current level so we can balance
+      // branch lengths. However, if our outboard body is massless we don't
+      // want to risk it ending up as terminal so keep going in that case.
+      BodyIndex inboard_body_num, outboard_body_num;
+      MobilizedBodyNum inboard_mobod_num,
+          outboard_mobod_num;
+      if (parent_mobod.is_in_tree()) {
+        if (!child_body.must_be_nonterminal() &&
+            parent_mobod.level() != level - 1)
+          continue;  // not time yet
+        inboard_body_num = joint.parent_body_num();
+        outboard_body_num = joint.child_body_num();
+        inboard_mobod_num = parent_mobod_num;
+        outboard_mobod_num = child_mobod_num;
+      } else {  // child is in tree
+        if (!parent_body.must_be_nonterminal() &&
+            child_mobod.level() != level - 1)
+          continue;  // not time yet
+        inboard_body_num = joint.child_body_num();
+        outboard_body_num = joint.parent_body_num();
+        inboard_mobod_num = child_mobod_num;
+        outboard_mobod_num = parent_mobod_num;
+      }
+
+      MobilizerNum mobilizer_num =
+          AddMobilizerFromJoint(joint_num, inboard_mobod_num,
+                                outboard_mobod_num, child_mobod.is_in_tree());
+
+      joints_added.insert(joint_num);
+      any_mobilizer_added = true;
+
+      // We just made joint joint_num a mobilizer. If its outboard body
+      // is massless and the mobilizer was not a weld, we need to keep
+      // extending this branch of the tree until we can end it with a
+      // massful body.
+      const Body& outboard_body = graph.get_body(outboard_body_num);
+      const JointType& joint_type =
+          graph.get_joint_type(joint.joint_type_num());
+      if (joint_type.num_v() == 0 || !outboard_body.must_be_nonterminal())
+        continue;
+
+      // Pick a further-outboard body with mass and extend branch to it.
+      // Prefer forward-direction joints if possible.
+      // If only massless outboard bodies are available, add one and
+      // keep going.
+      while (true) {
+        // The outboard mobilized body of the mobilizer we just added will be
+        // the next one we connect. Ideally it will serve as inboard, but we
+        // may have to reverse.
+        const BodyIndex body_num = mobod_to_body_num(
+            get_mobilizer(mobilizer_num).outboard_mobod_num());
+
+        const JointIndex joint_forward_num =
+            FindHeaviestUnassignedForwardJoint(body_num, graph);
+        if (joint_forward_num.is_valid()) {
+          const Joint& joint_forward = graph.get_joint(joint_forward_num);
+          const BodyIndex fwd_outboard_body_num =
+              joint_forward.child_body_num();
+          if (!graph.get_body(fwd_outboard_body_num).must_be_nonterminal()) {
+            mobilizer_num = AddMobilizerFromJoint(
+                joint_forward_num, body_to_mobod_num(body_num),
+                body_to_mobod_num(fwd_outboard_body_num),
+                false /* not reversed */);
+            joints_added.insert(joint_forward_num);
+            break;
+          }
+        }
+
+        const JointIndex joint_reverse_num =
+            FindHeaviestUnassignedReverseJoint(body_num, graph);
+        if (joint_reverse_num.is_valid()) {
+          const Joint& joint_reverse = graph.get_joint(joint_reverse_num);
+          const BodyIndex rev_outboard_body_num =
+              joint_reverse.parent_body_num();
+          if (!graph.get_body(rev_outboard_body_num).must_be_nonterminal()) {
+            mobilizer_num = AddMobilizerFromJoint(
+                joint_reverse_num, body_to_mobod_num(body_num),
+                body_to_mobod_num(rev_outboard_body_num), true /* reversed */);
+            joints_added.insert(joint_reverse_num);
+            break;
+          }
+        }
+
+        // Couldn't find a massful body to add. Add another massless
+        // body (if there is one) and keep trying.
+        if (joint_forward_num.is_valid()) {
+          mobilizer_num = AddMobilizerFromJoint(
+              joint_forward_num, body_to_mobod_num(body_num),
+              body_to_mobod_num(joint.child_body_num()),
+              false /* not reversed */);
+          joints_added.insert(joint_forward_num);
+          continue;
+        }
+        if (joint_reverse_num.is_valid()) {
+          mobilizer_num = AddMobilizerFromJoint(
+              joint_reverse_num, body_to_mobod_num(body_num),
+              body_to_mobod_num(joint.parent_body_num()), true /* reversed */);
+          joints_added.insert(joint_reverse_num);
+          continue;
+        }
+
+        // Uh oh. Nothing outboard of the massless body we just added.
+        // We're ending this chain with a massless body; not good.
+        throw std::runtime_error(
+            "GrowTree(): algorithm produced an"
+            " invalid tree containing a terminal massless body (" +
+            graph.get_body(body_num).name() +
+            "). This may be due to an invalid"
+            " model or failure of heuristics. In the latter case you"
+            " may be able to get a valid tree by forcing a different"
+            " loop break or changing parent->child ordering.");
+      }
+    }
+    if (!any_mobilizer_added) break;
+  }
+}
+
+//------------------------------------------------------------------------------
+//                                 BREAK LOOPS
+//------------------------------------------------------------------------------
+// Find any remaining unused joints, which will have both parent and
+// child bodies already in the tree. This includes joints that the user
+// told us must be loop joints, and ones picked by the algorithm.
+// For each of those, implement the joint with a loop constraint if one
+// is provided, otherwise implement it with a mobilizer and split off a
+// slave body from the "split body" (normally the child), use that slave as the
+// outboard body for the mobilizer, and add a weld constraint to reconnect the
+// slave to its master (the original split body). If the child is World, we
+// must reverse the mobilizer since World must always be the inboard body. In
+// that case the split body is the parent.
+void MultibodyTreeModel::BreakLoops(const MultibodyGraphModeler& graph) {
+  for (JointIndex joint_num(0); joint_num < num_joints(); ++joint_num) {
+    const Joint& joint = graph.get_joint(joint_num);
+    if (joint_info(joint_num).has_mobilizer()) continue;  // already done
+
+    const BodyIndex parent_body_num = joint.parent_body_num();
+    const BodyIndex child_body_num = joint.child_body_num();
+    const MultibodyTreeModel::MobilizedBodyNum parent_mobod_num =
+        body_to_mobod_num(parent_body_num);
+    const MultibodyTreeModel::MobilizedBodyNum child_mobod_num =
+        body_to_mobod_num(child_body_num);
+    DRAKE_DEMAND(mobod(parent_mobod_num).is_in_tree() &&
+                 mobod(child_mobod_num).is_in_tree());
+
+    // Use a loop joint if there's a good one available.
+    const JointType& joint_type = graph.get_joint_type(joint.joint_type_num());
+    if (joint_type.have_good_joint_constraint_available()) {
+      AddConstraintFromJoint(joint_num, parent_mobod_num, child_mobod_num);
+      continue;
+    }
+
+    // No usable loop constraint for this type of joint. Add a new slave
+    // body so we can use a mobilizer. (MobilizedBody references are invalidated
+    // here since we're adding a new body -- don't reuse them.)
+
+    // First assume we will be able to split the child, which is the usual case.
+    BodyIndex split_body_num = child_body_num;
+    BodyIndex inboard_body_num = parent_body_num;
+    bool is_reversed = false;
+    // If the child is World, choose the parent instead, reverse the mobilizer.
+    if (child_body_num == graph.world_body_num()) {
+      DRAKE_DEMAND(parent_body_num != graph.world_body_num());
+      split_body_num = parent_body_num;
+      inboard_body_num = child_body_num;  // That is, World.
+      is_reversed = true;
+    }
+    const MultibodyTreeModel::MobilizedBodyNum split_mobod_num =
+        body_to_mobod_num(split_body_num);
+    const MultibodyTreeModel::MobilizedBodyNum inboard_mobod_num =
+        body_to_mobod_num(inboard_body_num);
+    const MultibodyTreeModel::MobilizedBodyNum slave_mobod_num =
+        SplitBody(split_mobod_num);
+
+    // Mobilize the slave body.
+    AddMobilizerFromJoint(joint_num, inboard_mobod_num, slave_mobod_num,
+                          is_reversed);
+
+    // Add the weld loop constraint.
+    std::string constraint_name = "#" + mobod(split_mobod_num).name() + "|" +
+                                  mobod(slave_mobod_num).name();
+    AddSlaveWeldConstraint(std::move(constraint_name), joint_num,
+                           split_mobod_num, slave_mobod_num);
+  }
+}
+
+//------------------------------------------------------------------------------
+//                         ADD TO MULTIBODY TREE
+//------------------------------------------------------------------------------
+
+auto MultibodyTreeModel::AddJointType(std::string joint_type_name,
+                                      void* joint_type_user_ref)
+    -> JointTypeIndex {
+  const JointTypeIndex joint_type_num(num_joint_types());
+  joint_type_info_.push_back(
+      JointTypeInfo(std::move(joint_type_name), joint_type_user_ref));
+  return joint_type_num;
+}
+
+auto MultibodyTreeModel::AddBodyInfo(std::string body_name, void* body_user_ref)
+    -> BodyIndex {
+  const BodyIndex body_num(num_bodies());
+  body_info_.push_back(BodyInfo(std::move(body_name), body_user_ref));
+  return body_num;
+}
+
+auto MultibodyTreeModel::AddJointInfo(std::string joint_name,
+                                      JointTypeIndex joint_type_num,
+                                      void* joint_user_ref) -> JointIndex {
+  const JointIndex joint_num(num_joints());
+  joint_info_.push_back(
+      JointInfo(std::move(joint_name), joint_type_num, joint_user_ref));
+  return joint_num;
+}
+
+auto MultibodyTreeModel::AddMobodFromBody(BodyIndex body_num)
+    -> MobilizedBodyNum {
+  const MobilizedBodyNum mobod_num(num_mobods());
+  mobods_.push_back(MobilizedBody(body_num, this));
+  BodyInfo& body_info = body_info_[body_num];
+  body_info.set_master_mobod_num(mobod_num);
+  body_name_to_mobod_num_[body_info.body_name()] = mobod_num;
+
+  // World goes in the tree right away.
+  if (mobod_num == world_mobod_num()) mobods_.back().set_level(0);
+
+  return mobod_num;
+}
+
+//------------------------------------------------------------------------------
+//                       ADD MOBILIZER FROM JOINT
+//------------------------------------------------------------------------------
+auto MultibodyTreeModel::AddMobilizerFromJoint(
+    JointIndex joint_num, MobilizedBodyNum inboard_mobod_num,
+    MobilizedBodyNum outboard_mobod_num, bool is_reversed) -> MobilizerNum {
+  MobilizedBody& inboard = get_mutable_body(inboard_mobod_num);
+  MobilizedBody& outboard = get_mutable_body(outboard_mobod_num);
+  DRAKE_DEMAND(inboard.is_in_tree());
+  const int level = inboard.level() + 1;
+  const MobilizerNum mobilizer_num =
+      MobilizerNum(num_mobilizers());  // next available
+  mobilizers_.push_back(Mobilizer(joint_num, level, inboard_mobod_num,
+                                  outboard_mobod_num, is_reversed, this));
+  joint_info_[joint_num].set_mobilizer_num(mobilizer_num);
+
+  outboard.set_level(level);
+  outboard.set_mobilizer_num(mobilizer_num);
+  inboard.add_outboard_mobilizer_num(mobilizer_num);
+  return mobilizer_num;
+}
+
+//------------------------------------------------------------------------------
+//                          CONNECT BODY TO WORLD
+//------------------------------------------------------------------------------
+// Connect the given body to World by a free mobilizer with inboard body
+// World and outboard body the given body. This makes the body a base body
+// (level 1 body) for some subtree of the multibody graph.
+auto MultibodyTreeModel::ConnectBodyToWorld(MobilizedBodyNum mobod_num,
+                                            bool is_static) -> MobilizerNum {
+  MobilizedBody& mobod = get_mutable_body(mobod_num);
+  DRAKE_ASSERT(!mobod.is_in_tree());
+  MobilizedBody& world = get_mutable_body(world_mobod_num());
+
+  const std::string mobilizer_name =
+      "#" + world_body_name() + "_" + mobod.name();
+
+  const MobilizerNum mobilizer_num(num_mobilizers());
+  mobilizers_.push_back(
+      Mobilizer(std::move(mobilizer_name),
+                is_static ? weld_joint_type_num() : free_joint_type_num(),
+                1 /* level */, world_mobod_num(), mobod_num, this));
+
+  mobod.set_level(1);
+  mobod.set_mobilizer_num(mobilizer_num);
+  world.add_outboard_mobilizer_num(mobilizer_num);
+  return mobilizer_num;
+}
+
+//------------------------------------------------------------------------------
+//                       ADD CONSTRAINT FROM JOINT
+//------------------------------------------------------------------------------
+auto MultibodyTreeModel::AddConstraintFromJoint(
+    JointIndex joint_num, MobilizedBodyNum parent_mobod_num,
+    MobilizedBodyNum child_mobod_num) -> ConstraintNum {
+  MobilizedBody& parent = get_mutable_body(parent_mobod_num);
+  MobilizedBody& child = get_mutable_body(child_mobod_num);
+  DRAKE_DEMAND(parent.is_in_tree() && child.is_in_tree());
+  const ConstraintNum constraint_num = ConstraintNum(num_constraints());
+  constraints_.push_back(
+      Constraint(joint_num, parent_mobod_num, child_mobod_num, this));
+  joint_info_[joint_num].set_constraint_num(constraint_num);
+  parent.add_joint_constraint_num(constraint_num);
+  child.add_joint_constraint_num(constraint_num);
+  return constraint_num;
+}
+
+auto MultibodyTreeModel::AddSlaveWeldConstraint(
+    std::string constraint_name, JointIndex joint_num,
+    MobilizedBodyNum master_mobod_num, MobilizedBodyNum slave_mobod_num)
+    -> ConstraintNum {
+  MobilizedBody& master = get_mutable_body(master_mobod_num);
+  MobilizedBody& slave = get_mutable_body(slave_mobod_num);
+  DRAKE_DEMAND(master.is_in_tree() && slave.is_in_tree());
+  const ConstraintNum constraint_num = ConstraintNum(num_constraints());
+  constraints_.push_back(Constraint(constraint_name, weld_joint_type_num(),
+                                    joint_num, master_mobod_num,
+                                    slave_mobod_num, this));
+  master.add_joint_constraint_num(constraint_num);
+  slave.add_joint_constraint_num(constraint_num);
+  return constraint_num;
+}
+
+//------------------------------------------------------------------------------
+//                                SPLIT BODY
+//------------------------------------------------------------------------------
+// Create a new slave body for the given master, and add it to the list of
+// bodies. Does not create the related loop constraint. The body
+// number assigned to the slave is returned.
+auto MultibodyTreeModel::SplitBody(MobilizedBodyNum master_mobod_num)
+    -> MobilizedBodyNum {
+  // First slave is number 1, slave 0 is the master.
+  const MobilizedBody& master = mobod(master_mobod_num);
+  std::string slave_name =
+      "#" + master.name() + "_slave_" + std::to_string(master.num_slaves() + 1);
+  const MobilizedBodyNum slave_mobod_num(num_mobods());  // next available
+  mobods_.push_back(
+      MobilizedBody(std::move(slave_name), master_mobod_num, this));
+  // There is no corresponding BodyInfo.
+
+  // Careful -- master reference above is invalid now since we pushed a
+  // new MobilizedBody.
+  get_mutable_body(master_mobod_num).add_slave_mobod_num(slave_mobod_num);
+  // No name lookup for slave bodies.
+  return slave_mobod_num;
+}
+
+//------------------------------------------------------------------------------
+//                               DUMP GRAPH
+//------------------------------------------------------------------------------
+void MultibodyTreeModel::DumpTreeModel(std::ostream& out) const {
+  // constexpr int kBufSize = 1024;
+  out << "\nMULTIBODY TREE MODEL\n";
+  out << "--------------------\n";
+  out << "\n" << num_mobods() << " MOBILIZED BODIES:\n";
+  out << "body@lev: mob name\n";
+  for (MobilizedBodyNum mobod_num(0); mobod_num < num_mobods(); ++mobod_num) {
+    const MobilizedBody& mobod = this->mobod(mobod_num);
+    const std::string inb_mob = mobod.is_world_body()
+                                    ? std::string("--")
+                                    : fmt::format("{}", mobod.mobilizer_num());
+    out << fmt::format("{}{:<3}@{:3}: {:3} {}",
+                       mobod.is_master() ? "M" : (mobod.is_slave() ? "S" : " "),
+                       mobod_num, mobod.level(), inb_mob, mobod.name());
+    if (mobod.is_slave())
+      out << fmt::format(" master={}", mobod.master_mobod_num());
+    if (mobod.num_outboard_mobilizers()) {
+      out << "  outboard mob=[";
+      for (int j = 0; j < mobod.num_outboard_mobilizers(); ++j)
+        out << " " << mobod.outboard_mobilizers()[j];
+      out << "]";
+    }
+    if (mobod.num_slaves()) {
+      out << "  slaves=[";
+      for (int j = 0; j < mobod.num_slaves(); ++j)
+        out << " " << mobod.slaves()[j];
+      out << "]";
+    }
+    out << "\n";
+  }
+
+  out << "\n" << num_mobilizers() << " MOBILIZERS:\n";
+  for (MobilizerNum i(0); i < num_mobilizers(); ++i) {
+    const Mobilizer& mo = get_mobilizer(i);
+    const MobilizedBody& inb = mobod(mo.inboard_mobod_num());
+    const MobilizedBody& outb = mobod(mo.outboard_mobod_num());
+    const std::string joint_num = mo.joint_num().is_valid()
+                                      ? fmt::format("{}", mo.joint_num())
+                                      : std::string("--");
+    out << fmt::format("{:2} {:2}: {:20} {:20}->{:<20} {:10} {:2} {:3}\n", i,
+                       mo.level(), mo.name(), inb.name(), outb.name(),
+                       mo.get_joint_type_name(), joint_num,
+                       (mo.is_reversed_from_joint() ? "REV" : ""));
+  }
+
+  out << "\n" << num_constraints() << " LOOP CONSTRAINTS:\n";
+  for (ConstraintNum i(0); i < num_constraints(); ++i) {
+    const Constraint& lc = get_constraint(i);
+    const MobilizedBody& parent = mobod(lc.parent_mobod_num());
+    const MobilizedBody& child = mobod(lc.child_mobod_num());
+    out << fmt::format("{}: {}({}) parent={} child={} joint_num={}\n", i,
+                       lc.name(), lc.constraint_type_name(), parent.name(),
+                       child.name(), lc.joint_num());
+  }
+
+  std::vector<MobilizedBodyNum> base_bodies = FindBaseBodies();
+  out << "\n" << base_bodies.size() << " BASE BODIES:\n";
+  for (MobilizedBodyNum mobod_num : base_bodies)
+    out << " " << mobod(mobod_num).name();
+  out << "\n---------- END OF MULTIBODY TREE MODEL.\n\n";
+}
+
+//------------------------------------------------------------------------------
+//                            FIND BASE BODIES
+//------------------------------------------------------------------------------
+auto MultibodyTreeModel::FindBaseBodies() const
+    -> std::vector<MobilizedBodyNum> {
+  std::vector<MobilizedBodyNum> base_bodies;
+  for (const auto& mobilizer : mobilizers_) {
+    if (mobilizer.level() != 1) continue;
+    base_bodies.push_back(mobilizer.outboard_mobod_num());
+  }
+  return base_bodies;
+}
+
+auto MultibodyTreeModel::FindBaseBody(MobilizedBodyNum mobod_num) const
+    -> MobilizedBodyNum {
+  std::vector<MobilizedBodyNum> path_bodies = FindPathToWorld(mobod_num);
+  return path_bodies.empty() ? MobilizedBodyNum() : path_bodies.back();
+}
+
+//------------------------------------------------------------------------------
+//                            FIND PATH TO WORLD
+//------------------------------------------------------------------------------
+auto MultibodyTreeModel::FindPathToWorld(MobilizedBodyNum mobod_num) const
+    -> std::vector<MobilizedBodyNum> {
+  DRAKE_DEMAND(mobod_num.is_valid());
+  std::vector<MobilizedBodyNum> path_bodies;
+  // Note that nothing gets pushed if mobod_num is World.
+  while (mobod(mobod_num).level() > 0) {
+    path_bodies.push_back(mobod_num);
+    const Mobilizer& mobilizer =
+        get_mobilizer(mobod(mobod_num).mobilizer_num());
+    mobod_num = mobilizer.inboard_mobod_num();
+  }
+  return path_bodies;
+}
+
+//------------------------------------------------------------------------------
+//                      BODIES ARE CONNECTED BY MOBILIZER
+//------------------------------------------------------------------------------
+// Return true if there is a mobilizer between two bodies given by body number,
+// regardless of inboard/outboard ordering.
+bool MultibodyTreeModel::MobodsAreConnectedByMobilizer(
+    MobilizedBodyNum mobod1_num, MobilizedBodyNum mobod2_num) const {
+  const MobilizedBody& mobod1 = mobod(mobod1_num);
+  if (get_mobilizer(mobod1.mobilizer_num()).inboard_mobod_num() == mobod2_num)
+    return true;  // Body2 is mobod1's parent.
+
+  const MobilizedBody& mobod2 = mobod(mobod2_num);
+  if (get_mobilizer(mobod2.mobilizer_num()).inboard_mobod_num() == mobod1_num)
+    return true;  // Body1 is mobod2's parent.
+
+  return false;  // Otherwise they aren't connected.
+}
+
+//------------------------------------------------------------------------------
+//                BODIES ARE CONNECTED BY JOINT CONSTRAINT
+//------------------------------------------------------------------------------
+// Return true if there is a joint constraint between two bodies given by
+// body number, regardless of parent/child ordering.
+bool MultibodyTreeModel::MobodsAreConnectedByJointConstraint(
+    MobilizedBodyNum mobod1_num, MobilizedBodyNum mobod2_num) const {
+  const MobilizedBody& mobod1 = mobod(mobod1_num);
+  for (ConstraintNum constraint_num : mobod1.joint_constraints()) {
+    const Constraint& constraint = this->get_constraint(constraint_num);
+    const MobilizedBodyNum parent = constraint.parent_mobod_num();
+    const MobilizedBodyNum child = constraint.child_mobod_num();
+    DRAKE_DEMAND(parent == mobod1_num || child == mobod1_num);
+    if (parent == mobod2_num || child == mobod2_num) {
+      return true;
+    }
+  }
+
+  return false;  // They aren't connected.
+}
+
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/graph_modeler/multibody_tree_model.h
+++ b/multibody/graph_modeler/multibody_tree_model.h
@@ -1,0 +1,961 @@
+#pragma once
+
+/* Adapted for Drake from Simbody's MultibodyGraphModeler class.
+Portions copyright (c) 2013-14 Stanford University and the Authors.
+Authors: Michael Sherman
+Contributors: Kevin He
+
+Modifications copyright (c) 2019-20 Toyota Research Institute, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may
+not use this file except in compliance with the License. You may obtain a
+copy of the License at http://www.apache.org/licenses/LICENSE-2.0. */
+
+/** @file
+Declares the MultibodyTreeModel class that contains a computational
+spanning tree-plus-constraints model representing a MultibodyGraph. */
+
+#include <iosfwd>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/type_safe_index.h"
+#include "drake/multibody/graph_modeler/multibody_graph_modeler.h"
+#include "drake/multibody/tree/multibody_tree_indexes.h"
+
+namespace drake {
+namespace multibody {
+
+//==============================================================================
+//                           MULTIBODY TREE MODEL
+//==============================================================================
+/** Contains a computational spanning tree-plus-constraints model representing
+the bodies and joints of a MultibodyGraph. A %MultibodyTreeModel uses
+"mobilized bodies" (mobods) to model bodies, and "mobilizers" or "constraints"
+to model joints.
+
+In addition to the tree model, a %MultibodyTreeModel contains an abbreviated
+summary of the bodies and joints forming the input graph that was used to
+construct this model. The model consists of
+ - one or more _mobilized bodies_ (mobods) for each input _body_,
+ - one _mobilizer_ for each of the mobilized bodies, forming a tree, and
+ - one _constraint_ for each kinematic loop in the input graph
+   connectivity.
+
+Bodies are cut as necessary to break loops, producing a master mobilized body
+and one or more slave mobilized bodies, and "weld" constraints fixing each slave
+to its master.
+
+Each mobilized body has an "inboard" mobilizer, which connects it to World or a
+mobilized body that is
+closer to World in the multibody tree. In most cases, each input joint
+is represented in the tree by a mobilizer, ideally with the joint's parent body
+being the mobilizer's inboard mobod, and the joint's child body being the
+mobilizer's outboard mobod. Depending on parent/child ordering in the input,
+that is not always possible, so the joint's mobilizer will be marked as
+"reversed" meaning inboard=child and outboard=parent instead. There will be more
+mobilizers than joints in general, since free bodies in the input will have a
+"free" (6 dof) mobilizer, and static bodies in the input will have a "weld" (0
+dof) mobilizer ("immobilizer" might be a better word :).
+
+When possible we use a mobilizer to model a joint by the degrees of freedom it
+_permits_. However, we can instead use a joint constraint to model a joint by
+the restrictions it _imposes_. Most commonly we use only weld constraints that
+we have added to attach master and slave mobods, although some efficiency gains
+are possible by using other joint constraints when available.
+
+<h3>A basic example</h3>
+Here is a usage example, assuming the MultibodyGraph input is: <pre>
+       link1 <-- link2 <-- link3 --> link4 --> link5
+</pre> where the arrows represent revolute joints and point from the "parent"
+body to the "child" body. Note that no explicit connection to World (body 0) has
+been given, so we will add one in the generated tree model.
+@code
+  MultibodyGraphModeler graph;
+  // "world" is body 0
+  graph.AddBody("link1");  // name (optional flags)
+  graph.AddBody("link2");
+  graph.AddBody("link3");
+  graph.AddBody("link4");
+  graph.AddBody("link5");
+  graph.AddJoint("joint0", "revolute", "link2", "link1");  // parent, child
+  graph.AddJoint("joint1", "revolute", "link3", "link2");
+  graph.AddJoint("joint2", "revolute", "link3", "link4");
+  graph.AddJoint("joint3", "revolute", "link4", "link5");
+  MultibodyTreeModel model(graph);
+
+  for (int i=0; i < model.num_mobilizers(); ++i) {
+    auto& mobilizer = model.get_mobilizer(i);
+    auto& inb = model.mobilized_body(mobilizer.inboard_mobod_num());
+    auto& outb = model.mobilized_body(mobilizer.outboard_mobod_num());
+    std::cout << i << ": " << inb.name() << " --> " << outb.name()
+              << " (" << mobilizer.get_joint_type_name() << ")\n";
+  }
+@endcode
+
+The above outputs <pre>
+  0: world --> link3 (free)
+  1: link3 --> link2 (revolute)
+  2: link3 --> link4 (revolute)
+  3: link2 --> link1 (revolute)
+  4: link4 --> link5 (revolute)
+</pre>
+showing that the algorithm picked link3 as the base mobilized body and was thus
+able to preserve parent->child ordering for every joint. In actual use, the
+contents of the mobilizer for-loop above would _build_ the multibody system
+rather than _print_ it.
+
+<h3>Explanation</h3>
+Each body has a unique name; each joint connects two distinct bodies with one
+designated as the "parent" body and the other the "child" body. The generated
+model (of type MultibodyTreeModel) will include a spanning tree with World as
+the root, with a mobilized body corresponding to every body, and containing a
+mobilizer for every mobilized body. You can also think of this graph as a
+forest of trees each with a "base mobilized body" as its root, where a base
+mobilized body is a mobilized body directly connected to World (often by a
+"free" or "floating" joint).
+
+There is a mobilizer in the generated tree model corresponding to each of
+the joints from the input, with an "inboard" (topologically closer to World)
+and "outboard" (further from World) mobilized body, chosen from the parent and
+child bodies of the joint but possibly reordered in which case the mobilizer is
+marked as "reversed". Additional "free" mobilizers are added as needed between
+bodies and World so that there is a path from every mobilized body in the
+inboard direction all the way to World. Additional mobilized bodies and
+constraints are added if topological loops are found in the input.
+
+Heuristics here attempt to balance a number of competing goals:
+  - choose "sensible" base mobilized bodies for trees that don't have a
+    connection to World provided in the input,
+  - make the mobilizer inboard/output ordering follow the parent/child ordering
+    in the input,
+  - cut loops such that branch lengths are balanced (minimizes the maximum
+    length of any branch for better numerics),
+  - make sure no massless mobilized body ends up as a terminal node of a tree
+    (that would make the mass matrix singular),
+  - follow any stated user preferences about the generated graph.
+
+See below for more details.
+
+<h3>Results</h3>
+The output is
+  -# A sequence of mobilizers (tree joints) in ascending order from World to a
+set of terminal bodies, for each subtree. Every input body will be mobilized by
+one of these, and there may also be some additional mobilized "slave" mobilized
+bodies due to loop-breaking.
+  -# A set of "loop constraints", representing either welds to attach slave
+mobilized bodies to their masters, or loop joint constraints that correspond to
+particular input joints.
+  -# A correspondence between input bodies and mobilized bodies, with some
+mobilized bodies designated as slaves to particular master mobilized bodies.
+That is, more than one mobilized body may correspond to the same input body.
+  -# A correspondence between mobilizers and input joints, with some extra
+mobilizers having been added to connect base mobilized bodies to World.
+  -# Statistics, diagnostics, and introspection of the resulting trees.
+
+Then to build a multibody system
+  -# Run through the generated mobilizers in order, adding one mobilized body to
+the tree each time, using "reversed" mobilizers if appropriate (that just
+affects the interpretation of the generalized coordinates). Mass properties and
+joint placement information are obtained from the original bodies and joints;
+they are not stored here.
+  -# Run through the list of constraints adding master-slave welds or loop
+joint constraints as indicated.
+
+<h3>Inputs</h3>
+  - bodies: name, mass, must_be_base_mobilized_body flag
+  - joints: name, type, parent body, child body, must_be_loop_joint flag
+  - joint type: name, # dofs, have_good_joint_constraint_available flag
+  - names for the World body and important joint types weld and free (Drake
+    defaults are available).
+
+<h3>Loop joints</h3>
+Normally every joint produces a corresponding mobilizer. A joint that would form
+a kinematic loop is marked as such, and then its child body is split to form a
+new "slave" mobilized body that can be mobilized by the joint. We expect that in
+the constructed multibody model, a master mobilized body and its slaves will be
+reconnected via weld constraints. This provides for uniform treatment of all
+joints, such as providing revolute joint coordinates that can wrap. However, for
+some joint types that doesn't matter because the multibody system has equally
+good "loop joint" constraints. For example, Simbody's Ball mobilizer uses
+quaternions for orientation and hence has no wrapping; it can be replaced with
+a Ball constraint which removes the 3-dof mobilizer and 6 weld constraint
+equations, leaving just 3 translational constraints and indistinguishable
+behavior. Similarly a loop-closing Weld joint can just be replaced by a Weld
+constraint, and a loop-closing Free joint can simply be ignored.
+
+The algorithm normally decides which joints are the loop-breakers, however you
+can specify in the input that certain joints must be loop joints.
+
+<h3>Massless bodies</h3>
+Massless bodies can be very useful in defining compound joints, by composing
+revolute and prismatic joints, for example. This is fine in an internal
+coordinate code as long as no massless (or inertialess) mobilized body is a
+terminal (most outboard) mobilized body in the spanning tree. (Terminal massless
+mobilized bodies are OK if their inboard mobilizer has no dofs, i.e. is a Weld.)
+Bodies can have a mass provided; if a movable body has zero mass the algorithm
+will try to avoid ending any branch of the spanning tree with that body's
+mobilized body. If it fails, the resulting spanning tree is no good and an
+exception will be thrown. The attempt to find an acceptable tree is heuristic
+and can fail in difficult cases even if there might be a solution. Explicit user
+guidance may be required in that case (for example, specifying
+`must_be_base_mobilized_body` for some body.)
+
+<h3>Base mobilized bodies</h3>
+A mobilized body in the spanning tree that is directly connected to World is
+called a "base" mobilized body. If its mobilizer is a Free joint then it can be
+given an arbitrary pose with respect to World and everything outboard of it
+moves together. This is a nice property and you can influence this choice by
+providing an explicit joint to World or designating some bodies as required to
+be modeled as base mobilized bodies. Note that although you will then have a set
+of generalized coordinates permitting you to place these mobilized bodies
+arbitrarily, there is no guarantee that such placement will satisfy constraints.
+If you don't designate base mobilized bodies, the algorithm will pick
+them heuristically, which often leads to a good choice. The heuristic is to
+attempt to find a body that does not ever appear as a child in the input.
+Failing that, pick the body that has the most children. In case of tie, pick
+the first body among the tied ones.
+
+<h3>World body</h3>
+The first body defined in the input will be interpreted as the World body.
+Its name will be used to recognize joints that connect other bodies to World.
+Typical names are "world" or "ground". If you accept the Drake defaults, the
+World body will be predefined as body zero and will be named "world". The
+World body in the input graph is identical to the World mobilized body in the
+generated spanning tree.
+
+<h3>Levels</h3>
+Each mobilized body in the spanning tree will be assigned a level, an integer
+that measures how many edges must be traversed to get from that mobilized body
+to World. World is at level 0, mobilized bodies that have a direct connection to
+World (base mobilized bodies) are at level 1, mobilized bodies whose mobilizer
+connects them to base mobilized bodies are at level 2, and so on. Multibody
+systems need to be constructed in order of increasing level, so that the inboard
+mobilized body is already in the tree when the outboard mobilized body is added.
+We consider the level of a mobilizer to be the same as the level of its outboard
+mobilized body. Loop joints are not mobilizers and do not have a level. */
+class MultibodyTreeModel {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MultibodyTreeModel)
+
+  using MobilizedBodyNum = TypeSafeIndex<class MobilizedBodyNumTag>;
+  using MobilizerNum = TypeSafeIndex<class MobilizerNumTag>;
+  using ConstraintNum = TypeSafeIndex<class ConstraintNumTag>;
+
+  using Body = MultibodyGraphModeler::Body;
+  using Joint = MultibodyGraphModeler::Joint;
+  using JointType = MultibodyGraphModeler::JointType;
+
+  // Local classes.
+  class MobilizedBody;
+  class Mobilizer;
+  class Constraint;
+  class BodyInfo;
+  class JointInfo;
+  class JointTypeInfo;
+
+  explicit MultibodyTreeModel(const MultibodyGraphModeler& graph) {
+    MakeTreeModel(graph);
+  }
+
+  /** @name               Work with the generated tree model
+  Methods in this section manipulate the generated multibody tree model
+  consisting of mobilized bodies (from input bodies and additional slaves),
+  mobilizers (from input joints plus additional connections to World), and loop
+  joint constraints. */
+  //@{
+
+  /** Output a text representation of the multibody tree model for debugging. */
+  void DumpTreeModel(std::ostream& out) const;
+
+  /** Returns the number of mobilizers (tree joints) in the spanning forest.
+  This is also the number of mobilized bodies, including slave mobilized
+  bodies. */
+  int num_mobilizers() const { return static_cast<int>(mobilizers_.size()); }
+
+  /** Gets a Mobilizer object by its mobilizer number, ordered outwards by
+  topological distance from World. */
+  const Mobilizer& get_mobilizer(MobilizerNum mobilizer_num) const {
+    return mobilizers_[mobilizer_num];
+  }
+
+  /** Returns the number of joint constraints that were used to close
+  loops in the graph topology. These include loops that were broken
+  by cutting a body to make master and slave mobilized bodies, and those
+  where the joint itself was implemented using a constraint rather than a
+  mobilizer plus a slave mobilized body. The latter occurs only if we're told
+  there is a perfectly good loop joint constraint available; typically that
+  applies for ball (spherical) joints and not much else. */
+  int num_constraints() const { return static_cast<int>(constraints_.size()); }
+
+  /** Gets a loop constraint by its assigned number. These are assigned in
+  an arbitrary order. */
+  const Constraint& get_constraint(ConstraintNum loop_constraint_num) const {
+    return constraints_[loop_constraint_num];
+  }
+
+  /** Returns the number of mobilized bodies, including a World body, mobilized
+  bodies directly representing an input body, and any slave mobilized bodies. */
+  int num_mobods() const { return static_cast<int>(mobods_.size()); }
+
+  /** Gets a MobilizedBody object by its assigned number. These are assigned
+  first to World (body 0), then bodies representing input bodies, then we add
+  slave bodies created by body splitting after that. */
+  const MobilizedBody& mobod(MobilizedBodyNum mobod_num) const {
+    return mobods_[mobod_num];
+  }
+
+  /** Returns the mobilized body number assigned to the input body with the
+  given name. Returns an invalid MobilizedBodyNum if the body name is not
+  recognized. You can't look up by name slave mobilized bodies that were added
+  by the model-making algorithm. */
+  MobilizedBodyNum FindBodyMobodNum(const std::string& body_name) const {
+    std::map<std::string, MobilizedBodyNum>::const_iterator p =
+        body_name_to_mobod_num_.find(body_name);
+    return p == body_name_to_mobod_num_.end() ? MobilizedBodyNum() : p->second;
+  }
+
+  /** Returns the set of base bodies (bodies connected directly to World) in
+  the generated multibody model. These are ordered by increasing mobilizer
+  number of their base mobilizers. */
+  std::vector<MobilizedBodyNum> FindBaseBodies() const;
+
+  /** Returns the base mobilized body of the subtree containing the given
+  `mobod_num`. If `mobod_num` is a base mobilized body it is returned. If
+  `mobod_num` is World we return an invalid MobilizedBodyNum. */
+  MobilizedBodyNum FindBaseBody(MobilizedBodyNum mobod_num) const;
+
+  /** Returns a list of mobilized bodies, starting with `mobod_num` and ending
+  with the base mobilized body that connects that mobilized body to World
+  through inboard mobilizers. Will have just one element if `mobod_num` is a
+  base mobilized body, and be empty if `mobod_num` is the World body. */
+  std::vector<MobilizedBodyNum> FindPathToWorld(
+      MobilizedBodyNum mobod_num) const;
+
+  /** Returns the MobilizedBodyNum of the master mobilized body being used to
+  model the given body. */
+  inline MobilizedBodyNum body_to_mobod_num(BodyIndex body_num) const;
+
+  /** Returns the BodyIndex associated with this mobilized body, if any. */
+  inline BodyIndex mobod_to_body_num(MobilizedBodyNum mobod_num) const;
+
+  /** Returns the master MobilizedBody being used to model the given body. */
+  const MobilizedBody& body_to_mobod(BodyIndex body_num) const {
+    return mobod(body_to_mobod_num(body_num));
+  }
+  //@}
+
+  int num_bodies() const { return static_cast<int>(body_info_.size()); }
+
+  const BodyInfo& body_info(BodyIndex body_num) const {
+    return body_info_[body_num];
+  }
+
+  int num_joints() const { return static_cast<int>(joint_info_.size()); }
+
+  const JointInfo& joint_info(JointIndex joint_num) const {
+    return joint_info_[joint_num];
+  }
+
+  int num_joint_types() const {
+    return static_cast<int>(joint_type_info_.size());
+  }
+  const JointTypeInfo& joint_type_info(JointTypeIndex joint_type_num) const {
+    return joint_type_info_[joint_type_num];
+  }
+
+  inline const std::string& world_body_name() const;
+  MobilizedBodyNum world_mobod_num() const { return MobilizedBodyNum(0); }
+
+  // TODO(sherm1) Make these less brittle.
+  JointTypeIndex weld_joint_type_num() const { return JointTypeIndex(0); }
+  JointTypeIndex free_joint_type_num() const { return JointTypeIndex(1); }
+
+ private:
+  // Restores this %MultibodyTreeModel object to its just-constructed
+  // condition.
+  void Clear();
+
+  void MakeTreeModel(const MultibodyGraphModeler& graph);
+  BodyIndex ChooseNewBaseBody(const MultibodyGraphModeler& graph) const;
+  JointIndex FindHeaviestUnassignedForwardJoint(
+      BodyIndex parent_body_num, const MultibodyGraphModeler& graph) const;
+  JointIndex FindHeaviestUnassignedReverseJoint(
+      BodyIndex parent_body_num, const MultibodyGraphModeler& graph) const;
+  void GrowTree(const MultibodyGraphModeler& graph, int start_level);
+  void BreakLoops(const MultibodyGraphModeler& graph);
+
+  JointTypeIndex AddJointType(std::string joint_type_name,
+                              void* joint_type_user_ref);
+
+  BodyIndex AddBodyInfo(std::string body_name, void* body_user_ref);
+
+  JointIndex AddJointInfo(std::string joint_name, JointTypeIndex joint_type_num,
+                          void* joint_user_ref);
+
+  MobilizedBodyNum AddMobodFromBody(BodyIndex body_num);
+
+  MobilizerNum AddMobilizerFromJoint(JointIndex joint_num,
+                                     MobilizedBodyNum inboard_mobod_num,
+                                     MobilizedBodyNum outboard_mobod_num,
+                                     bool is_reversed);
+
+  ConstraintNum AddConstraintFromJoint(JointIndex joint_num,
+                                       MobilizedBodyNum parent_mobod_num,
+                                       MobilizedBodyNum child_mobod_num);
+
+  ConstraintNum AddSlaveWeldConstraint(std::string constraint_name,
+                                       JointIndex joint_num,
+                                       MobilizedBodyNum master_mobod_num,
+                                       MobilizedBodyNum slave_mobod_num);
+
+  // Adds a free or weld mobilizer.
+  MobilizerNum ConnectBodyToWorld(MobilizedBodyNum mobod_num, bool is_static);
+
+  // Get writable access to bodies.
+  MobilizedBody& get_mutable_body(MobilizedBodyNum mobod_num) {
+    return mobods_[mobod_num];
+  }
+
+  MobilizedBodyNum SplitBody(MobilizedBodyNum master_mobod_num);
+  bool MobodsAreConnected(MobilizedBodyNum mobod1_num,
+                          MobilizedBodyNum mobod2_num) const {
+    return MobodsAreConnectedByMobilizer(mobod1_num, mobod2_num) ||
+           MobodsAreConnectedByJointConstraint(mobod1_num, mobod2_num);
+  }
+  bool MobodsAreConnectedByMobilizer(MobilizedBodyNum mobod1_num,
+                                     MobilizedBodyNum mobod2_num) const;
+  bool MobodsAreConnectedByJointConstraint(MobilizedBodyNum mobod1_num,
+                                           MobilizedBodyNum mobod2_num) const;
+
+  // Calculated by MultibodyGraphModeler::MakeTreeModel().
+  // Index by MobilizedBodyNum, MobilizerNum, ConstraintNum, resp.
+  std::vector<MobilizedBody> mobods_;    // world + input bodies + slaves
+  std::vector<Mobilizer> mobilizers_;    // mobilized bodies
+  std::vector<Constraint> constraints_;  // master/slave welds, loop joints
+
+  // Information about bodies, modified as model is built. Order and numbering
+  // here are identical to bodies in MultibodyGraphModeler at the time this
+  // model was generated.
+  std::map<std::string, MobilizedBodyNum> body_name_to_mobod_num_;
+  std::vector<BodyInfo> body_info_;  // Index by BodyIndex.
+
+  // Information about joints, modified as model is built. Order and numbering
+  // here are identical to joints in MultibodyGraphModeler at the time this
+  // model was generated. Index by JointIndex.
+  std::vector<JointInfo> joint_info_;
+
+  // Information about joint types. Order and numbering here is identical to
+  // joint types in MultibodyGraphModeler at the time this model was generated.
+  // Index by JointTypeIndex.
+  std::vector<JointTypeInfo> joint_type_info_;
+};
+
+//------------------------------------------------------------------------------
+//                    MULTIBODY TREE MODEL :: BODY INFO
+//------------------------------------------------------------------------------
+/** Local class that collects information about how we modeled a given
+input body. */
+class MultibodyTreeModel::BodyInfo {
+ public:
+  // Move only.
+  BodyInfo(const BodyInfo&) = delete;
+  BodyInfo& operator=(const BodyInfo&) = delete;
+  BodyInfo(BodyInfo&&) = default;
+  BodyInfo& operator=(BodyInfo&&) = default;
+
+  const std::string& body_name() const { return body_name_; }
+  void* user_ref() const { return user_ref_; }
+  MobilizedBodyNum master_mobod_num() const { return master_mobod_num_; }
+
+ private:
+  friend class MultibodyTreeModel;
+
+  BodyInfo(std::string body_name, void* user_ref)
+      : body_name_(std::move(body_name)), user_ref_(user_ref) {}
+
+  void set_master_mobod_num(MobilizedBodyNum master_mobod_num) {
+    DRAKE_DEMAND(!master_mobod_num_.is_valid() && master_mobod_num.is_valid());
+    master_mobod_num_ = master_mobod_num;
+  }
+
+  // Copied from the input body.
+  std::string body_name_;
+  void* user_ref_{nullptr};
+
+  // Determined during model generation.
+  MobilizedBodyNum master_mobod_num_;
+};
+
+//------------------------------------------------------------------------------
+//                   MULTIBODY TREE MODEL :: JOINT INFO
+//------------------------------------------------------------------------------
+/** Local class that collects information about how we modeled a given
+input joint. */
+class MultibodyTreeModel::JointInfo {
+ public:
+  // Move only.
+  JointInfo(const JointInfo&) = delete;
+  JointInfo& operator=(const JointInfo&) = delete;
+  JointInfo(JointInfo&&) = default;
+  JointInfo& operator=(JointInfo&&) = default;
+
+  const std::string& joint_name() const { return joint_name_; }
+  void* user_ref() const { return user_ref_; }
+  JointTypeIndex joint_type_num() const { return joint_type_num_; }
+
+  bool has_mobilizer() const { return mobilizer_num_.is_valid(); }
+
+  /** Returns the mobilizer that represents this joint, if any. Otherwise the
+  returned value is not valid. */
+  MobilizerNum mobilizer_num() const { return mobilizer_num_; }
+
+  /** Returns the constraint that represents this joint, if any. Otherwise the
+  returned value is not valid. */
+  ConstraintNum constraint_num() const { return constraint_num_; }
+
+ private:
+  friend class MultibodyTreeModel;
+  JointInfo(std::string joint_name, JointTypeIndex joint_type_num,
+            void* user_ref)
+      : joint_name_(std::move(joint_name)),
+        joint_type_num_(joint_type_num),
+        user_ref_(user_ref) {}
+
+  void set_mobilizer_num(MobilizerNum num) { mobilizer_num_ = num; }
+
+  void set_constraint_num(ConstraintNum num) { constraint_num_ = num; }
+
+  // Copied from the input joint.
+  std::string joint_name_;
+  JointTypeIndex joint_type_num_;
+  void* user_ref_{nullptr};
+
+  // Determined during model generation (only one of these will be valid).
+  MobilizerNum mobilizer_num_;    // If modeled with a mobilizer.
+  ConstraintNum constraint_num_;  // If modeled with a constraint.
+};
+
+//------------------------------------------------------------------------------
+//                   MULTIBODY TREE MODEL :: JOINT TYPE INFO
+//------------------------------------------------------------------------------
+/** Local class that holds joint type information we can reference from
+mobilizers and joint constraints. */
+class MultibodyTreeModel::JointTypeInfo {
+ public:
+  // Move only.
+  JointTypeInfo(const JointTypeInfo&) = delete;
+  JointTypeInfo& operator=(const JointTypeInfo&) = delete;
+  JointTypeInfo(JointTypeInfo&&) = default;
+  JointTypeInfo& operator=(JointTypeInfo&&) = default;
+
+  /** Returns the name of the original joint type. */
+  const std::string& joint_type_name() const { return joint_type_name_; }
+
+  /** Returns the mobilizer type name that should be used when a joint of this
+  type is modeled with a mobilizer. */
+  // TODO(sherm1) Provide for a different name.
+  const std::string& mobilizer_type_name() const { return joint_type_name_; }
+
+  /** Returns the constraint type name that should be used when a joint of this
+  type is modeled with a constraint. */
+  // TODO(sherm1) Provide for a different name.
+  const std::string& constraint_type_name() const { return joint_type_name_; }
+
+  /** Return the user reference pointer for this joint type if one was provided
+  in MultibodyGraphModeler. */
+  void* user_ref() const { return user_ref_; }
+
+ private:
+  friend class MultibodyTreeModel;
+
+  JointTypeInfo(const std::string& name, void* user_ref)
+      : joint_type_name_(name), user_ref_(user_ref) {}
+
+  std::string joint_type_name_;
+  void* user_ref_{nullptr};  // Copied from the input joint type.
+};
+
+//------------------------------------------------------------------------------
+//                         MULTIBODY TREE MODEL :: BODY
+//------------------------------------------------------------------------------
+/** Local class that accumulates modeling information and represents bodies as
+the multibody tree is generated. */
+class MultibodyTreeModel::MobilizedBody {
+ public:
+  // Move only.
+  MobilizedBody(const MobilizedBody&) = delete;
+  MobilizedBody& operator=(const MobilizedBody&) = delete;
+  MobilizedBody(MobilizedBody&&) = default;
+  MobilizedBody& operator=(MobilizedBody&&) = default;
+
+  /** Returns the number of fragments into which we had to break the
+  corresponding body. Normally this is just one, meaning we didn't break the
+  body, but master mobilized bodies that have slaves will return the number of
+  slaves plus one. */
+  int num_fragments() const { return 1 + num_slaves(); }
+
+  /** Returns the number of slave bodies associated with this master body.
+  Normally zero, but a master body with (for example) three slave bodies would
+  return three. */
+  int num_slaves() const { return static_cast<int>(slaves_.size()); }
+
+  /** Returns `true` if this mobilized body is a slave mobilized body generated
+  by breaking an input body into multiple mobilized bodies. If so you can find
+  its master using master_mobod_num(). */
+  bool is_slave() const { return master_mobod_num_.is_valid(); }
+
+  /** Returns `true` if this is a mobilized body that represents a body that had
+  to be broken into multiple mobilized bodies. If so you can find the generated
+  slave mobilized bodies using slaves(). */
+  bool is_master() const { return num_slaves() > 0; }
+
+  /** Returns `true` if this is the body that represents the World. */
+  bool is_world_body() const { return level_ == 0; }
+
+  const std::string& name() const { return name_; }
+
+  /** Returns `true` if this mobilized body has already been assigned a place in
+  the multibody tree. This will be true for all mobilized bodies once model
+  building is complete. */
+  bool is_in_tree() const { return level_ >= 0; }
+
+  /** Returns the level of this mobilized body in the multibody tree. If this is
+  World it is level 0, if it's a base mobilized body it's level 1, if it's
+  connected to a base mobilized body it's level 2, etc. The level of a mobilized
+  body is the same as the level of its inboard mobilizer as obtained with
+  mobilizer_num(). */
+  int level() const { return level_; }
+
+  /** Returns the unique mobilizer (by number) for which this mobilized body is
+  the outboard body, or an invalid MobilizerNum if the multibody tree has not
+  yet been generated. */
+  MobilizerNum mobilizer_num() const { return mobilizer_num_; }
+
+  /** Returns the number of mobilizers for which this mobilized body is the
+  inboard mobilized body. */
+  int num_outboard_mobilizers() const {
+    return static_cast<int>(outboard_mobilizers().size());
+  }
+
+  /** Returns a reference to a vector of MobilizerNum values containing all
+  the mobilizers for which this mobilized body is the inboard body. */
+  const std::vector<MobilizerNum>& outboard_mobilizers() const {
+    return outboard_mobilizers_;
+  }
+
+  int num_joint_constraints() const {
+    return static_cast<int>(joint_constraints().size());
+  }
+
+  const std::vector<ConstraintNum>& joint_constraints() const {
+    return joint_constraints_;
+  }
+
+  /** Returns the list of slave bodies (by mobilized body number), if this is a
+  master body. */
+  const std::vector<MobilizedBodyNum>& slaves() const { return slaves_; }
+
+  /** Returns the master mobilized body number if this is a slave mobilized
+  body, otherwise returns an invalid MobilizedBodyNum. */
+  MobilizedBodyNum master_mobod_num() const { return master_mobod_num_; }
+
+  /** Returns the body number of the body modeled by this mobilized body. Master
+  and slave mobilized bodies both return the same body number. */
+  BodyIndex body_num() const { return body_num_; }
+
+ private:
+  // Restrict construction and modification to only MultibodyTreeModel.
+  friend class MultibodyTreeModel;
+
+  // Create a mobilized body that directly models a body.
+  MobilizedBody(BodyIndex body_num, MultibodyTreeModel* model)
+      : name_(model->body_info(body_num).body_name()),
+        body_num_(body_num),
+        model_(model) {}
+
+  // Create a slave mobilized body for the given master.
+  MobilizedBody(std::string name, MobilizedBodyNum master_mobod_num,
+                MultibodyTreeModel* model)
+      : name_(std::move(name)),
+        body_num_(model->mobod(master_mobod_num).body_num()),
+        master_mobod_num_(master_mobod_num),
+        model_(model) {}
+
+  void set_level(int level) { level_ = level; }
+  void set_mobilizer_num(MobilizerNum mobilizer_num) {
+    mobilizer_num_ = mobilizer_num;
+  }
+
+  // When this mobilized body serves as the inboard body for a mobilizer, note
+  // that.
+  void add_outboard_mobilizer_num(MobilizerNum outboard_mobilizer_num) {
+    outboard_mobilizers_.push_back(outboard_mobilizer_num);
+  }
+
+  // When this mobilized body participates in a joint constraint, note that.
+  void add_joint_constraint_num(ConstraintNum joint_constraint_num) {
+    joint_constraints_.push_back(joint_constraint_num);
+  }
+
+  // Records the master body number for this slave mobilized body.
+  void set_master_mobod_num(MobilizedBodyNum master_mobod_num) {
+    master_mobod_num_ = master_mobod_num;
+  }
+
+  // Records a slave mobilized body number for this master body.
+  void add_slave_mobod_num(MobilizedBodyNum slave_mobod_num) {
+    slaves_.push_back(slave_mobod_num);
+  }
+
+  std::string name_;    // Body name if this was an input body.
+  BodyIndex body_num_;  // Original body number if any.
+
+  // Disposition of this mobilized body in the spanning tree.
+
+  int level_{-1};               // Distance from World in the tree.
+  MobilizerNum mobilizer_num_;  // The unique inboard mobilizer.
+  std::vector<MobilizerNum> outboard_mobilizers_;
+
+  // Joint constraints in which this mobilized body participates.
+  std::vector<ConstraintNum> joint_constraints_;
+
+  MobilizedBodyNum master_mobod_num_;     // valid if this is a slave.
+  std::vector<MobilizedBodyNum> slaves_;  // Slave bodies, if this is a master.
+
+  MultibodyTreeModel* const model_{nullptr};  // just a reference to container
+};
+
+//------------------------------------------------------------------------------
+//                   MULTIBODY TREE MODEL :: MOBILIZER
+//------------------------------------------------------------------------------
+/** Local class that represents one of the mobilizers (tree joints) in the
+generated spanning tree. */
+class MultibodyTreeModel::Mobilizer {
+ public:
+  // Move only.
+  Mobilizer(const Mobilizer&) = delete;
+  Mobilizer& operator=(const Mobilizer&) = delete;
+  Mobilizer(Mobilizer&&) = default;
+  Mobilizer& operator=(Mobilizer&&) = default;
+
+  /** Returns the mobilizer's name. This will be the input joint's name if this
+  mobilizer models one of the input joints. Otherwise, it will have a name
+  constructed from the inboard and output mobilized body names. */
+  const std::string& name() const { return name_; }
+
+  /** Returns the joint associated with this mobilizer. There will always be
+  one, but it may have been an added joint rather than an input joint. */
+  JointIndex joint_num() const { return joint_num_; }
+
+  /** Returns the inboard mobilized body number of this mobilizer. This is the
+  parent mobilized body of the associated joint unless the mobilizer is
+  reversed. */
+  MobilizedBodyNum inboard_mobod_num() const { return inboard_mobod_num_; }
+
+  /** Returns the outboard mobilized body number of this mobilizer. This is the
+  child
+  mobilized body of the associated joint unless the mobilizer is reversed. */
+  MobilizedBodyNum outboard_mobod_num() const { return outboard_mobod_num_; }
+
+  /** Return true if this mobilizer represents one of the input joints but
+  the sense of inboard->outboard is reversed from the parent->child sense
+  defined in the input joint. In that case you should use a reverse mobilizer
+  when you build the system. */
+  bool is_reversed_from_joint() const { return is_reversed_; }
+
+  /** Return the level of the outboard body. World is level 0, a base mobilized
+  body is level 1, etc. */
+  int level() const { return level_; }
+
+  /** Return true if this mobilizer does not represent one of the input
+  joints, but is instead a mobilizer we added connecting a base mobilized body
+  to World. If this returns true, the inboard mobilized body is always World.
+  When you create this mobilizer, the joint frames should be identity, that is,
+  the joint should connect the World frame to the outboard body frame. */
+  bool is_added_base_mobilizer() const { return !joint_num_.is_valid(); }
+
+  /** Get the mobilizer type name. These are mapped from joint type names. */
+  const std::string& get_joint_type_name() const {
+    return model_->joint_type_info(mobilizer_type_num_).mobilizer_type_name();
+  }
+
+  /** Return true if the outboard mobilized body of this mobilizer is a slave we
+  created in order to cut a loop, rather than one of the input bodies. */
+  bool is_slave_mobilizer() const {
+    return model_->mobod(outboard_mobod_num_).is_slave();
+  }
+
+  /** Return the number of fragments into which we chopped the outboard
+  mobilized body of this mobilizer. There is one fragment for the master
+  mobilized body plus however many slaves of that mobilized body were created.
+  Thus you should divide the body's mass properties by this number to obtain the
+  mass and inertia to be assigned to each of the mobilized body fragments. */
+  int num_fragments() const {
+    return model_->mobod(outboard_master_mobod_num()).num_fragments();
+  }
+
+  /** Returns the mobilized body number of the master body for this mobilizer's
+  outboard mobilized body, which might be a slave. If the outboard body is not a
+  slave mobilized body, then this returns the same value as
+  outboard_mobod_num(). */
+  MobilizedBodyNum outboard_master_mobod_num() const {
+    const MobilizedBody& outboard_mobod = model_->mobod(outboard_mobod_num_);
+    return outboard_mobod.is_slave() ? outboard_mobod.master_mobod_num()
+                                     : outboard_mobod_num_;
+  }
+
+ private:
+  // Restrict construction to only MultibodyTreeModel.
+  friend class MultibodyTreeModel;
+
+  // Construct a mobilizer that directly represents an input joint.
+  Mobilizer(JointIndex joint_num, int level, MobilizedBodyNum inboard_mobod_num,
+            MobilizedBodyNum outboard_mobod_num, bool is_reversed,
+            MultibodyTreeModel* model)
+      : joint_num_(joint_num),
+        is_reversed_(is_reversed),
+        level_(level),
+        inboard_mobod_num_(inboard_mobod_num),
+        outboard_mobod_num_(outboard_mobod_num),
+        model_(model) {
+    DRAKE_DEMAND(joint_num_.is_valid());
+    DRAKE_DEMAND(level_ >= 0);
+    DRAKE_DEMAND(inboard_mobod_num_.is_valid());
+    DRAKE_DEMAND(outboard_mobod_num_.is_valid());
+    DRAKE_DEMAND(model_ != nullptr);
+
+    name_ = model->joint_info(joint_num).joint_name();
+    mobilizer_type_num_ = model->joint_info(joint_num).joint_type_num();
+  }
+
+  // Construct a mobilizer for which there is no input joint counterpart.
+  Mobilizer(std::string name, JointTypeIndex joint_type_num, int level,
+            MobilizedBodyNum inboard_mobod_num,
+            MobilizedBodyNum outboard_mobod_num, MultibodyTreeModel* model)
+      : name_(std::move(name)),
+        mobilizer_type_num_(joint_type_num),
+        level_(level),
+        inboard_mobod_num_(inboard_mobod_num),
+        outboard_mobod_num_(outboard_mobod_num),
+        model_(model) {
+    DRAKE_DEMAND(mobilizer_type_num_.is_valid());
+    DRAKE_DEMAND(level_ >= 0);
+    DRAKE_DEMAND(inboard_mobod_num_.is_valid());
+    DRAKE_DEMAND(outboard_mobod_num_.is_valid());
+    DRAKE_DEMAND(model_ != nullptr);
+  }
+
+  std::string name_;  // Will be input joint name if possible.
+  JointTypeIndex mobilizer_type_num_;
+
+  // If this mobilizer directly models an input joint, note the joint number
+  // and whether the mobilizer is reversed s.t. inboard=child, outboard=parent.
+  JointIndex joint_num_;
+  bool is_reversed_{false};
+
+  int level_{-1};  // Level of outboard body; distance from World.
+  MobilizedBodyNum inboard_mobod_num_;   // Might be World.
+  MobilizedBodyNum outboard_mobod_num_;  // Might be a slave mobilized body;
+                                         // can't be World.
+
+  MultibodyTreeModel* const model_{nullptr};  // Just a reference to container.
+};
+
+//------------------------------------------------------------------------------
+//                    MULTIBODY TREE MODEL :: CONSTRAINT
+//------------------------------------------------------------------------------
+/** Local class that represents one of the constraints that were added to close
+topological loops that were cut to form the spanning tree. */
+class MultibodyTreeModel::Constraint {
+ public:
+  const std::string& name() const { return name_; }
+
+  /** Get the loop constraint type name of the constraint that should be
+  used here. This will be either the type name of the associated joint, or the
+  type name of a weld joint if this is a master/slave weld. */
+  const std::string& constraint_type_name() const {
+    return model_->joint_type_info(constraint_type_num_).constraint_type_name();
+  }
+
+  /** Returns the parent mobilized body number from the modeled input joint, or
+  the master mobilized body number if this is a master/slave weld. */
+  MobilizedBodyNum parent_mobod_num() const { return parent_mobod_num_; }
+
+  /** Returns the child mobilized body number from the modeled input joint, or
+  the slave mobilized body number if this is a master/slave weld. */
+  MobilizedBodyNum child_mobod_num() const { return child_mobod_num_; }
+
+  /** Returns the joint number if this loop constraint models one of the input
+  joints, otherwise returns an invalid JointIndex. */
+  JointIndex joint_num() const { return joint_num_; }
+
+ private:
+  // Restrict construction to only MultibodyTreeModel.
+  friend class MultibodyTreeModel;
+
+  // Construct a constraint that directly represents an input joint.
+  Constraint(JointIndex joint_num, MobilizedBodyNum parent_mobod_num,
+             MobilizedBodyNum child_mobod_num, MultibodyTreeModel* model)
+      : joint_num_(joint_num),
+        parent_mobod_num_(parent_mobod_num),
+        child_mobod_num_(child_mobod_num),
+        model_(model) {
+    DRAKE_DEMAND(joint_num.is_valid());
+    DRAKE_DEMAND(parent_mobod_num.is_valid() && child_mobod_num.is_valid());
+    DRAKE_DEMAND(model != nullptr);
+
+    name_ = model->joint_info(joint_num).joint_name();
+    constraint_type_num_ = model->joint_info(joint_num).joint_type_num();
+  }
+
+  // Construct a constraint that does not directly represent an input joint,
+  // but may be associated with one.
+  Constraint(std::string name, JointTypeIndex joint_type_num,
+             JointIndex joint_num, MobilizedBodyNum parent_mobod_num,
+             MobilizedBodyNum child_mobod_num, MultibodyTreeModel* model)
+      : name_(std::move(name)),
+        constraint_type_num_(joint_type_num),
+        joint_num_(joint_num),
+        parent_mobod_num_(parent_mobod_num),
+        child_mobod_num_(child_mobod_num),
+        model_(model) {
+    DRAKE_DEMAND(joint_type_num.is_valid());
+    DRAKE_DEMAND(parent_mobod_num.is_valid() && child_mobod_num.is_valid());
+    DRAKE_DEMAND(model_ != nullptr);
+  }
+
+  std::string name_;  // Will be input joint name if possible.
+  JointTypeIndex constraint_type_num_;
+
+  JointIndex joint_num_;  // Set if one of the input joints.
+
+  MobilizedBodyNum parent_mobod_num_;  // parent from the joint, or master mobod
+  MobilizedBodyNum child_mobod_num_;   // child from the joint, or slave mobod
+
+  MultibodyTreeModel* model_{nullptr};  // Just a reference to container.
+};
+
+inline auto MultibodyTreeModel::body_to_mobod_num(BodyIndex body_num) const
+    -> MobilizedBodyNum {
+  const BodyInfo& body_info = this->body_info(body_num);
+  return body_info.master_mobod_num();
+}
+
+inline auto MultibodyTreeModel::mobod_to_body_num(
+    MobilizedBodyNum mobod_num) const -> BodyIndex {
+  const MobilizedBody& mobod = this->mobod(mobod_num);
+  return mobod.body_num();
+}
+
+inline const std::string& MultibodyTreeModel::world_body_name() const {
+  DRAKE_DEMAND(!mobods_.empty());  // World should always be here.
+  return mobod(MobilizedBodyNum(0)).name();
+}
+
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/graph_modeler/test/multibody_graph_modeler_test.cc
+++ b/multibody/graph_modeler/test/multibody_graph_modeler_test.cc
@@ -1,0 +1,641 @@
+/* Adapted for Drake from Simbody's MultibodyGraphModeler class.
+Portions copyright (c) 2017 Stanford University and the Authors.
+Authors: Chris Dembia
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may
+not use this file except in compliance with the License. You may obtain a
+copy of the License at http://www.apache.org/licenses/LICENSE-2.0. */
+
+#include "drake/multibody/graph_modeler/multibody_graph_modeler.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/multibody/graph_modeler/multibody_tree_model.h"
+
+namespace drake {
+namespace multibody {
+namespace {
+
+using MobodNum = MultibodyTreeModel::MobilizedBodyNum;
+using MobilizerNum = MultibodyTreeModel::MobilizerNum;
+using ConstraintNum = MultibodyTreeModel::ConstraintNum;
+
+// Test a straightforward serial chain of massful bodies connected by
+// pin joints: world->link1->link2->link3->link4->link5
+// Should produce the obvious multibody tree.
+GTEST_TEST(MultibodyGraphModeler, SerialChain) {
+  MultibodyGraphModeler maker(false);  // Don't use Drake defaults.
+  maker.AddBody("world");
+  maker.RegisterJointType("pin", 1, 1);
+
+  maker.AddBody("link1");  // Default is massful links.
+  maker.AddBody("link2");
+  maker.AddBody("link3");
+  maker.AddBody("link4");
+  maker.AddBody("link5");
+
+  maker.AddJoint("pin1", "pin", "world", "link1");
+  maker.AddJoint("pin2", "pin", "link1", "link2");
+  maker.AddJoint("pin3", "pin", "link2", "link3");
+  maker.AddJoint("pin4", "pin", "link3", "link4");
+  maker.AddJoint("pin5", "pin", "link4", "link5");
+
+  MultibodyTreeModel tree(maker);
+
+  // First, some basic tests.
+  EXPECT_EQ(maker.num_joint_types(), 3);  // include weld and free.
+  EXPECT_EQ(maker.FindJointTypeNum("weld"), 0);
+  EXPECT_EQ(maker.FindJointTypeNum("free"), 1);
+  EXPECT_EQ(maker.FindJointTypeNum("pin"), 2);  // 3rd joint.
+  EXPECT_EQ(maker.world_body_name(), "world");
+  EXPECT_EQ(maker.num_bodies(), 6);
+  EXPECT_EQ(maker.FindBodyIndex("link3"), 3);  // world is 0th body and mobod.
+  EXPECT_EQ(maker.num_joints(), 5);
+  EXPECT_EQ(maker.FindJointIndex("pin4"), 3);
+
+  EXPECT_EQ(tree.num_constraints(), 0);
+
+  EXPECT_EQ(tree.num_mobilizers(), 5);
+  for (MobilizerNum i(0); i < tree.num_mobilizers(); ++i) {
+    const auto& mobilizer = tree.get_mobilizer(i);
+    EXPECT_FALSE(mobilizer.is_added_base_mobilizer());
+    EXPECT_FALSE(mobilizer.is_slave_mobilizer());
+    EXPECT_FALSE(mobilizer.is_reversed_from_joint());
+    EXPECT_EQ(mobilizer.get_joint_type_name(), "pin");
+    EXPECT_EQ(mobilizer.inboard_mobod_num(), i.to_int());
+    EXPECT_EQ(mobilizer.outboard_mobod_num(), i + 1);
+    EXPECT_EQ(mobilizer.num_fragments(), 1);
+
+    EXPECT_EQ(mobilizer.level(), i + 1);
+  }
+}
+
+// This test ensures that the graph maker produces the same topology for a
+// 5-body chain of pin joints (world-link1-link2-link3-link4-link5) whether or
+// not link2 is massless.
+GTEST_TEST(MultibodyGraphModeler, IntermediateMasslessBody) {
+  MultibodyGraphModeler maker;
+
+  maker.AddBody("link1");
+  maker.AddBody("link2", kMustNotBeTerminalBody);
+  maker.AddBody("link3");
+  maker.AddBody("link4");
+  maker.AddBody("link5");
+
+  maker.AddJoint("pin1", "revolute", "world", "link1");
+  maker.AddJoint("pin2", "revolute", "link1", "link2");
+  maker.AddJoint("pin3", "revolute", "link2", "link3");
+  maker.AddJoint("pin4", "revolute", "link3", "link4");
+  maker.AddJoint("pin5", "revolute", "link4", "link5");
+
+  maker.DumpInput(std::cout);
+  MultibodyTreeModel tree(maker);
+  tree.DumpTreeModel(std::cout);
+
+  EXPECT_EQ(tree.num_mobilizers(), 5);
+  for (MobilizerNum i(0); i < tree.num_mobilizers(); ++i) {
+    const auto& mobilizer = tree.get_mobilizer(i);
+    EXPECT_FALSE(mobilizer.is_added_base_mobilizer());
+    EXPECT_FALSE(mobilizer.is_slave_mobilizer());
+    EXPECT_FALSE(mobilizer.is_reversed_from_joint());
+    EXPECT_EQ(mobilizer.get_joint_type_name(), "revolute");
+    EXPECT_EQ(mobilizer.num_fragments(), 1);
+
+    // Here's the test that the resulting tree is as expected:
+    EXPECT_EQ(mobilizer.level(), i + 1);
+  }
+}
+
+// Terminal massless mobilized bodies are not allowed (unless welded to a
+// massful mobilized body).
+GTEST_TEST(MultibodyGraphModeler, TerminalMasslessBody) {
+  MultibodyGraphModeler maker;
+
+  maker.AddBody("link1", kMustNotBeTerminalBody);
+  maker.AddJoint("pin1", "revolute", "world", "link1");
+  EXPECT_THROW(MultibodyTreeModel{maker}, std::runtime_error);
+
+  // If the terminal massless mobod is welded, then there's no issue.
+  maker.DeleteJoint("pin1");
+  maker.AddJoint("pin1", "weld", "world", "link1");
+  EXPECT_NO_THROW(MultibodyTreeModel{maker});
+}
+
+// This is a basic test for how MultibodyGraphModeler handles a system with a
+// loop (four-bar linkage). We have the input four-bar linkage:
+//    world-->link1-->link2-->link3-->world
+// We get
+//                                              REV
+//    world-->link1-->link2-->#link3_slave  world-->link3
+// and a weld constraint link3##link3_slave. Note that the link3-->world joint
+// had to be reversed. See the next test for what should happen if link3 is
+// massless.
+GTEST_TEST(MultibodyGraphModeler, HasLoop) {
+  MultibodyGraphModeler maker(false);  // Don't use Drake defaults.
+  maker.RegisterJointType("pin", 1, 1);
+  maker.AddBody("world");
+  for (int i = 1; i <= 3; ++i) maker.AddBody("link" + std::to_string(i));
+
+  maker.AddJoint("pin1", "pin", "world", "link1");
+  maker.AddJoint("pin2", "pin", "link1", "link2");
+  maker.AddJoint("pin3", "pin", "link2", "link3");
+  maker.AddJoint("pin4", "pin", "link3", "world");
+
+  maker.DumpInput(std::cout);
+  MultibodyTreeModel tree(maker);
+  tree.DumpTreeModel(std::cout);
+
+  EXPECT_EQ(maker.num_bodies(), 4);
+  EXPECT_EQ(maker.num_joints(), 4);
+  EXPECT_EQ(maker.num_joint_types(), 3);  // include weld and free.
+  EXPECT_EQ(maker.FindJointTypeNum("weld"), 0);
+  EXPECT_EQ(maker.FindJointTypeNum("free"), 1);
+  EXPECT_EQ(maker.FindJointTypeNum("pin"), 2);  // 3rd joint type.
+  EXPECT_EQ(maker.world_body_name(), "world");
+
+  // Should have one more mobod than link because we had to split link3.
+  // Should have one loop constraint; the loop is broken by splitting a body and
+  // adding a weld constraint.
+  EXPECT_EQ(tree.num_mobods(), 5);
+  EXPECT_EQ(tree.mobod(MobodNum(4)).name(), "#link3_slave_1");
+
+  EXPECT_EQ(tree.num_mobilizers(), 4);
+  EXPECT_EQ(tree.num_constraints(), 1);
+  // Body numbers are the same as their corresponding link numbers.
+  EXPECT_EQ(tree.FindBaseBodies(),
+            std::vector<MobodNum>({MobodNum(1), MobodNum(3)}));
+
+  // Resulting mobilizers (breadth-first):
+  // 0: pin1 world->link1
+  // 1: pin4 world->link3 (reversed)
+  // 2: pin2 link1->link2
+  // 3: pin3 link2->#link3_slave_1
+
+  EXPECT_EQ(tree.get_mobilizer(MobilizerNum(0)).level(), 1);
+  EXPECT_EQ(tree.get_mobilizer(MobilizerNum(1)).level(), 1);
+  EXPECT_EQ(tree.get_mobilizer(MobilizerNum(2)).level(), 2);
+  EXPECT_EQ(tree.get_mobilizer(MobilizerNum(3)).level(), 3);
+  for (MobilizerNum i(0); i < tree.num_mobilizers(); ++i) {
+    const auto& mobilizer = tree.get_mobilizer(i);
+    EXPECT_FALSE(mobilizer.is_added_base_mobilizer());
+    // The 4th mobilizer is a slave mobilizer (child mobod is a slave).
+    EXPECT_EQ(mobilizer.is_slave_mobilizer(), (i == 3));
+    EXPECT_EQ(mobilizer.is_reversed_from_joint(), (i == 1));
+    EXPECT_EQ(mobilizer.get_joint_type_name(), "pin");
+    // Body 3 is split, and it's the outboard mobod for mobilizers 1 and 3.
+    EXPECT_EQ(mobilizer.num_fragments(), (i == 1 || i == 3 ? 2 : 1));
+  }
+
+  // Check the loop weld constraint.
+  const auto& constraint = tree.get_constraint(ConstraintNum(0));
+  EXPECT_EQ(constraint.constraint_type_name(), "weld");
+  EXPECT_EQ(constraint.parent_mobod_num(), 3);  // link3
+  EXPECT_EQ(constraint.child_mobod_num(), 4);   // #link3_slave
+  EXPECT_EQ(constraint.joint_num(), 2);  // Needed for the link2->link3 joint.
+}
+
+// This is the same 4-bar linkage as in the previous test, but with massless
+// bodies that affect how we must construct the spanning tree. First, link3 is
+// massless and thus ineligible to serve as a terminal mobod as it did above.
+// Then we expect    world-->link1-->link2-->link3-->world
+// to become
+//                                REV
+//    world-->link1-->link2  world-->link3-->#link2_slave
+// and a weld constraint link2##link2_slave.
+//
+// Then we'll try link2 as the massless body, and expect
+//                                        REV
+//    world-->link1-->link2-->link3  world-->#link3_slave
+// and a weld constraint link3##link3_slave. That structure avoids making
+// massless link2 a terminal mobod.
+GTEST_TEST(MultibodyGraphModeler, HasLoopWithMasslessBody) {
+  MultibodyGraphModeler maker(false);  // Don't use Drake defaults.
+  maker.RegisterJointType("pin", 1, 1);
+  maker.AddBody("world");
+  maker.AddBody("link1");
+  maker.AddBody("link2");
+  maker.AddBody("link3", kMustNotBeTerminalBody);
+
+  maker.AddJoint("pin1", "pin", "world", "link1");
+  maker.AddJoint("pin2", "pin", "link1", "link2");
+  maker.AddJoint("pin3", "pin", "link2", "link3");
+  maker.AddJoint("pin4", "pin", "link3", "world");
+
+  maker.DumpInput(std::cout);
+  MultibodyTreeModel tree(maker);
+  tree.DumpTreeModel(std::cout);
+
+  EXPECT_EQ(maker.num_bodies(), 4);
+  EXPECT_EQ(maker.num_joints(), 4);
+
+  // Should have an extra mobod and one loop constraint; the loop is broken by
+  // splitting a body and adding a weld constraint.
+  EXPECT_EQ(tree.num_mobods(), 5);  // link2 is split into two bodies.
+  EXPECT_EQ(tree.mobod(MobodNum(4)).name(), "#link2_slave_1");
+
+  EXPECT_EQ(tree.num_constraints(), 1);
+  EXPECT_EQ(tree.num_mobilizers(), 4);
+  EXPECT_EQ(tree.FindBaseBodies(),
+            std::vector<MobodNum>({MobodNum(1), MobodNum(3)}));
+
+  // Resulting mobilizers (breadth-first):
+  // 0: pin1 world->link1
+  // 1: pin4 world->link3 (reversed)
+  // 2: pin3 link3->link2 (reversed)
+  // 3: pin2 link1->#link2_slave_1
+
+  EXPECT_EQ(tree.get_mobilizer(MobilizerNum(0)).level(), 1);
+  EXPECT_EQ(tree.get_mobilizer(MobilizerNum(1)).level(), 1);
+  EXPECT_EQ(tree.get_mobilizer(MobilizerNum(2)).level(), 2);
+  EXPECT_EQ(tree.get_mobilizer(MobilizerNum(3)).level(), 2);
+  for (MobilizerNum i(0); i < tree.num_mobilizers(); ++i) {
+    const auto& mobilizer = tree.get_mobilizer(i);
+    EXPECT_FALSE(mobilizer.is_added_base_mobilizer());
+    // The 4th mobilizer is a slave mobilizer (child mobod is a slave).
+    EXPECT_EQ(mobilizer.is_slave_mobilizer(), (i == 3));
+    EXPECT_EQ(mobilizer.is_reversed_from_joint(), (i == 1 || i == 2));
+    EXPECT_EQ(mobilizer.get_joint_type_name(), "pin");
+    // Body 2 is split, and it's the outboard mobod for mobilizers 2 and 3.
+    EXPECT_EQ(mobilizer.num_fragments(), (i == 2 || i == 3 ? 2 : 1));
+  }
+
+  // Check the loop weld constraint.
+  const auto& constraint = tree.get_constraint(ConstraintNum(0));
+  EXPECT_EQ(constraint.constraint_type_name(), "weld");
+  EXPECT_EQ(constraint.parent_mobod_num(), 2);  // link2
+  EXPECT_EQ(constraint.child_mobod_num(), 4);   // #link2_slave
+  EXPECT_EQ(constraint.joint_num(), 1);  // Needed for the link1->link2 joint.
+
+  // Now make link3 massful and link2 massless.
+  maker.ChangeBodyFlags("link3", kDefaultBodyFlags);
+  maker.ChangeBodyFlags("link2", kMustNotBeTerminalBody);
+
+  maker.DumpInput(std::cout);
+  MultibodyTreeModel tree2(maker);
+  tree2.DumpTreeModel(std::cout);
+
+  // Resulting mobilizers:
+  // 0: pin1 world->link1
+  // 1: pin2 link1->link2
+  // 2: pin3 link2->link3
+  // 3: pin4 world->#link3_slave_1 (reversed)
+  EXPECT_EQ(tree2.get_mobilizer(MobilizerNum(0)).level(), 1);
+  EXPECT_EQ(tree2.get_mobilizer(MobilizerNum(1)).level(), 2);
+  EXPECT_EQ(tree2.get_mobilizer(MobilizerNum(2)).level(), 3);
+  EXPECT_EQ(tree2.get_mobilizer(MobilizerNum(3)).level(), 1);
+
+  for (MultibodyTreeModel::MobilizerNum i(0); i < tree2.num_mobilizers(); ++i) {
+    const auto& mobilizer = tree2.get_mobilizer(i);
+    EXPECT_FALSE(mobilizer.is_added_base_mobilizer());
+    // The 4th mobilizer is a slave mobilizer (child mobod is a slave).
+    EXPECT_EQ(mobilizer.is_slave_mobilizer(), (i == 3));
+    EXPECT_EQ(mobilizer.is_reversed_from_joint(), (i == 3));
+    EXPECT_EQ(mobilizer.get_joint_type_name(), "pin");
+    // Body 3 is split, and it's the outboard mobod for mobilizers 2 and 3.
+    EXPECT_EQ(mobilizer.num_fragments(), (i == 2 || i == 3 ? 2 : 1));
+  }
+
+  // Check the loop weld constraint.
+  const auto& constraint2 = tree2.get_constraint(ConstraintNum(0));
+  EXPECT_EQ(constraint2.constraint_type_name(), "weld");
+  EXPECT_EQ(constraint2.parent_mobod_num(), 3);  // link3
+  EXPECT_EQ(constraint2.child_mobod_num(), 4);   // #link3_slave
+  EXPECT_EQ(constraint2.joint_num(), maker.FindJointIndex("pin4"));
+}
+
+// The base mobod choice heuristic is:
+//   - pick the first body that has no parent
+//   - if all bodies have a parent, then pick one with the most children
+GTEST_TEST(MultibodyGraphModeler, ChooseBaseBody) {
+  MultibodyGraphModeler maker(false);  // Don't use Drake defaults.
+  maker.RegisterJointType("pin", 1, 1);
+  maker.AddBody("ground");  // Instead of "world".
+
+  // First system (arrows point from parent to child):
+  //                                      -->link5
+  //       link1     link2<--link3-->link4-->link6
+  //                         ^^^^         -->link7
+  // link1 and link3 are parent-only. We expect these to be processed
+  // in body order, so link1 gets the first free joint. Then, link3 should be
+  // chosen. Note that link4 has the most children but shouldn't be
+  // picked as a base mobod since it is also a child.
+
+  // Define bodies such that bodyi has body number i.
+  for (int i = 1; i <= 7; ++i) {
+    maker.AddBody("link" + std::to_string(i));
+  }
+  maker.AddJoint("joint0", "pin", "link3", "link2");
+  maker.AddJoint("joint1", "pin", "link3", "link4");
+  maker.AddJoint("joint2", "pin", "link4", "link5");
+  maker.AddJoint("joint3", "weld", "link4", "link6");
+  maker.AddJoint("joint4", "pin", "link4", "link7");
+
+  maker.DumpInput(std::cout);
+  MultibodyTreeModel tree(maker);
+  tree.DumpTreeModel(std::cout);
+
+  const MobilizerNum zero(0), one(1);
+  EXPECT_EQ(tree.get_mobilizer(zero).get_joint_type_name(), "free");
+  EXPECT_EQ(tree.get_mobilizer(zero).inboard_mobod_num(),
+            tree.FindBodyMobodNum("ground"));  // Should be 0.
+  EXPECT_EQ(tree.get_mobilizer(zero).outboard_mobod_num(), 1);
+
+  EXPECT_EQ(tree.get_mobilizer(one).get_joint_type_name(), "free");
+  EXPECT_EQ(tree.get_mobilizer(one).inboard_mobod_num(), 0);
+  EXPECT_EQ(tree.get_mobilizer(one).outboard_mobod_num(), 3);
+
+  // Now add a joint from link7 to link3:
+  //                                       -->link5
+  //        link1     link2<--link3-->link4-->link6
+  //                            ^     ^^^^ -->link7
+  //                            |               |
+  //                            +---------------+
+  // Now link1 is the only parent-only body so should be chosen as a base mobod
+  // first. But then another base mobod must be chosen and it has to be link4
+  // since there is no remaining parent-only body, and link4 has the most
+  // children. So the result should be:
+  //                                           REV
+  //   ground --> link1       ground --> link4 --> link3 --> link2
+  //                                    🡧  🡣  🡦
+  //                                link5 link6 link7 --> #link3_slave
+  //
+  // where "REV" indicates that the mobilizer had to be reversed from the
+  // input joint. There should be a loop weld constraint between link3 and
+  // its slave.
+
+  maker.AddJoint("joint5", "pin", "link7", "link3");
+  maker.DumpInput(std::cout);
+  MultibodyTreeModel tree2(maker);
+  tree2.DumpTreeModel(std::cout);
+
+  EXPECT_EQ(tree2.num_mobilizers(), 8);
+  EXPECT_EQ(tree2.num_mobods(), 9);  // Added one slave.
+  EXPECT_EQ(tree2.num_constraints(), 1);
+
+  EXPECT_EQ(tree2.get_mobilizer(zero).get_joint_type_name(), "free");
+  EXPECT_EQ(tree2.get_mobilizer(zero).inboard_mobod_num(), 0);
+  EXPECT_EQ(tree2.get_mobilizer(zero).outboard_mobod_num(), 1);
+
+  EXPECT_EQ(tree2.get_mobilizer(one).get_joint_type_name(), "free");
+  EXPECT_EQ(tree2.get_mobilizer(one).inboard_mobod_num(), 0);
+  EXPECT_EQ(tree2.get_mobilizer(one).outboard_mobod_num(), 4);
+}
+
+// Test that a multiloop system can be resolved by chopping up one input body
+// into more than one slave.
+GTEST_TEST(MultibodyGraphModeler, MultipleSlaves) {
+  MultibodyGraphModeler maker;  // Use Drake defaults.
+
+  // A three-loop system with link3 involved in every loop.
+  //       +-0-> link2
+  //       |      3🡣
+  // link1 +-1-> link3 <--6---+       (Joint numbers shown -- 3, 4, and 6
+  //       |      4🡡          |        will need loop-breaking.)
+  //       +-2-> link4 -5-> link5
+  //
+  // link1 should get chosen as the base mobod, and link3 should get chopped
+  // into four pieces (mobilizer numbers shown):
+  //
+  //                  +-1-> link2 -4-> link3_slave1          Weld constraints
+  //                  |                                          ## slave1 0
+  // world -0-> link1 +-2-> link3                          link3 ## slave2 1
+  //                  |                                          ## slave3 2
+  //                  +-3-> link4 -5-> link3_slave2
+  //                              -6-> link5 -7-> link3_slave3
+  //
+  // There should be a loop weld constraint connecting link3 to each of its
+  // slaves.
+
+  for (int i = 1; i <= 5; ++i) {
+    maker.AddBody("link" + std::to_string(i));
+  }
+  maker.AddJoint("joint0", "revolute", "link1", "link2");
+  maker.AddJoint("joint1", "revolute", "link1", "link3");
+  maker.AddJoint("joint2", "revolute", "link1", "link4");
+  maker.AddJoint("joint3", "revolute", "link2", "link3");
+  maker.AddJoint("joint4", "revolute", "link4", "link3");
+  maker.AddJoint("joint5", "revolute", "link4", "link5");
+  maker.AddJoint("joint6", "revolute", "link5", "link3");
+
+  // Before generating the tree we have just what we input.
+  EXPECT_EQ(maker.num_bodies(), 6);  // World plus the above five.
+  EXPECT_EQ(maker.num_joints(), 7);  // No free joint to World.
+
+  maker.DumpInput(std::cout);
+  MultibodyTreeModel tree(maker);
+  tree.DumpTreeModel(std::cout);
+
+  const BodyIndex link3_num = maker.FindBodyIndex("link3");
+  const MultibodyGraphModeler::Body& link3 = maker.get_body(link3_num);
+  EXPECT_EQ(link3.num_children(), 0);  // As input.
+  EXPECT_EQ(link3.num_parents(), 4);
+
+  const MultibodyTreeModel::MobilizedBody& mobod3 =
+      tree.body_to_mobod(link3_num);
+
+  EXPECT_TRUE(mobod3.is_master());
+  EXPECT_FALSE(mobod3.is_slave());
+  EXPECT_EQ(mobod3.num_fragments(), 4);
+  EXPECT_EQ(mobod3.num_slaves(), 3);
+
+  EXPECT_EQ(tree.num_mobods(), 9);  // Added three slave bodies.
+  EXPECT_EQ(tree.mobod(MobodNum(6)).name(), "#link3_slave_1");
+  EXPECT_EQ(tree.mobod(MobodNum(7)).name(), "#link3_slave_2");
+  EXPECT_EQ(tree.mobod(MobodNum(8)).name(), "#link3_slave_3");
+
+  EXPECT_EQ(tree.num_mobilizers(), 8);
+  EXPECT_EQ(tree.get_mobilizer(MobilizerNum(7)).name(), "joint6");
+  EXPECT_EQ(tree.num_constraints(), 3);
+
+  for (ConstraintNum i(0); i < tree.num_constraints(); ++i) {
+    const int expected_joint_num[] = {3, 4, 6};
+    const auto& loop_constraint = tree.get_constraint(i);
+    EXPECT_EQ(loop_constraint.constraint_type_name(),
+              maker.get_weld_joint_type_name());
+    EXPECT_EQ(loop_constraint.joint_num(), expected_joint_num[i]);
+    EXPECT_EQ(loop_constraint.parent_mobod_num(),
+              tree.FindBodyMobodNum("link3"));
+    EXPECT_EQ(loop_constraint.child_mobod_num(), 6 + i);  // One of the slaves.
+  }
+
+  EXPECT_EQ(tree.get_mobilizer(MobilizerNum(0)).get_joint_type_name(), "free");
+  EXPECT_EQ(tree.get_mobilizer(MobilizerNum(0)).inboard_mobod_num(),
+            tree.FindBodyMobodNum("world"));
+  EXPECT_EQ(tree.get_mobilizer(MobilizerNum(0)).outboard_mobod_num(),
+            tree.FindBodyMobodNum("link1"));
+}
+
+// When there are multiple disjoint subtrees, they should each get a base
+// mobod attached to World by a free joint. Base mobilized bodies are important
+// since they can be moved freely -- check that we can report the structure
+// properly.
+//
+//     link1->link2->link3    link4->link5          link7->link8   link9
+//                                 ->link6->world
+// Here link1, link6, link7, and link9 should be the chosen base mobods (link6
+// because it is already attached to world).
+GTEST_TEST(MultibodyGraphModeler, MultipleSubtrees) {
+  MultibodyGraphModeler maker;
+  for (int i = 1; i <= 9; ++i) {
+    maker.AddBody("link" + std::to_string(i));
+  }
+  maker.AddJoint("joint0", "prismatic", "link1", "link2");
+  maker.AddJoint("joint1", "fixed", "link2", "link3");
+  maker.AddJoint("joint2", "revolute", "link4", "link5");
+  maker.AddJoint("joint3", "prismatic", "link4", "link6");
+  maker.AddJoint("joint4", "ball", "link6", "world");
+  maker.AddJoint("joint5", "prismatic", "link7", "link8");
+
+  maker.DumpInput(std::cout);
+  MultibodyTreeModel tree(maker);
+  tree.DumpTreeModel(std::cout);
+
+  // link6 comes first since it was already attached to World.
+  EXPECT_EQ(tree.FindBaseBodies(),
+            std::vector<MobodNum>(
+                {MobodNum(6), MobodNum(1), MobodNum(7), MobodNum(9)}));
+
+  // World has no base mobilized body.
+  EXPECT_FALSE(tree.FindBaseBody(MobodNum(0)).is_valid());
+
+  EXPECT_EQ(tree.FindBaseBody(MobodNum(3)), 1);  // See above.
+  EXPECT_EQ(tree.FindBaseBody(MobodNum(4)), 6);
+  EXPECT_EQ(tree.FindBaseBody(MobodNum(5)), 6);
+  EXPECT_EQ(tree.FindBaseBody(MobodNum(7)), 7);  // Already a base mobod.
+  EXPECT_EQ(tree.FindBaseBody(MobodNum(8)), 7);
+  EXPECT_EQ(tree.FindBaseBody(MobodNum(9)), 9);
+
+  EXPECT_EQ(tree.FindPathToWorld(MobodNum(3)),
+            std::vector<MobodNum>({MobodNum(3), MobodNum(2), MobodNum(1)}));
+  EXPECT_EQ(tree.FindPathToWorld(MobodNum(5)),
+            std::vector<MobodNum>({MobodNum(5), MobodNum(4), MobodNum(6)}));
+  EXPECT_EQ(tree.FindPathToWorld(MobodNum(9)),
+            std::vector<MobodNum>({MobodNum(9)}));
+  EXPECT_EQ(tree.FindPathToWorld(MobodNum(0)), std::vector<MobodNum>());
+}
+
+// Test that DeleteBody() and DeleteJoint() properly untangle affected
+// connections.
+//
+// Starting with link1->link2->link3,
+//   - delete link1 should give link2->link3 (new base mobod, joint deleted)
+//   - or, delete link2 should give link1 link3  (two independent bodies)
+// Body and joint numbers should change also.
+//
+// Also tests Clear() and ClearGraph().
+GTEST_TEST(MultibodyGraphModeler, DeleteBodiesAndClear) {
+  MultibodyGraphModeler maker;
+  for (int i = 1; i <= 3; ++i) maker.AddBody("link" + std::to_string(i));
+  maker.AddJoint("joint0", "prismatic", "link1", "link2");
+  maker.AddJoint("joint1", "revolute", "link2", "link3");
+
+  EXPECT_EQ(maker.num_bodies(), 4);
+  EXPECT_EQ(maker.num_joints(), 2);
+  EXPECT_EQ(maker.FindBodyIndex("world"), 0);
+  EXPECT_EQ(maker.FindBodyIndex("link1"), 1);
+  EXPECT_EQ(maker.FindBodyIndex("link2"), 2);
+  EXPECT_EQ(maker.FindBodyIndex("link3"), 3);
+  EXPECT_EQ(maker.FindJointIndex("joint0"), 0);
+  EXPECT_EQ(maker.FindJointIndex("joint1"), 1);
+
+  MultibodyTreeModel tree(maker);
+  EXPECT_EQ(tree.FindBaseBodies(),
+            std::vector<MobodNum>({MobodNum(1)}));  // link1
+
+  EXPECT_EQ(tree.num_mobilizers(), 3);
+
+  maker.DeleteBody("link1");
+  EXPECT_EQ(maker.num_bodies(), 3);
+  EXPECT_EQ(maker.num_joints(), 1);
+  // Deleting link1 should have taken out joint0 also.
+  EXPECT_FALSE(maker.HasBody("link1"));
+  EXPECT_FALSE(maker.HasBody("joint0"));
+
+  EXPECT_EQ(maker.FindBodyIndex("world"), 0);
+  EXPECT_EQ(maker.FindBodyIndex("link2"), 1);
+  EXPECT_EQ(maker.FindBodyIndex("link3"), 2);
+  EXPECT_EQ(maker.FindJointIndex("joint1"), 0);
+
+  MultibodyTreeModel tree2(maker);
+  EXPECT_EQ(tree2.FindBaseBodies(),
+            std::vector<MobodNum>({MobodNum(1)}));  // link2
+
+  maker.Clear();
+  EXPECT_EQ(maker.num_bodies(), 1);  // Just World.
+  EXPECT_EQ(maker.num_joints(), 0);
+
+  // Recreate the link1->link2->link3 graph.
+  for (int i = 1; i <= 3; ++i) maker.AddBody("link" + std::to_string(i));
+  maker.AddJoint("joint0", "prismatic", "link1", "link2");
+  maker.AddJoint("joint1", "revolute", "link2", "link3");
+
+  maker.DeleteBody("link2");  // Should remove 2 joints also.
+  EXPECT_EQ(maker.num_bodies(), 3);
+  EXPECT_EQ(maker.num_joints(), 0);
+  EXPECT_FALSE(maker.HasBody("link2"));
+  EXPECT_FALSE(maker.HasJoint("joint0"));
+  EXPECT_FALSE(maker.HasJoint("joint1"));
+
+  EXPECT_EQ(maker.FindBodyIndex("world"), 0);
+  EXPECT_EQ(maker.FindBodyIndex("link1"), 1);
+  EXPECT_EQ(maker.FindBodyIndex("link3"), 2);
+
+  MultibodyTreeModel tree3(maker);
+  EXPECT_EQ(tree3.FindBaseBodies(),
+            std::vector<MobodNum>({MobodNum(1), MobodNum(2)}));  // link1
+}
+
+// Use MBTreeModel twice: first, find the body that would be the base mobod;
+// then, weld that body to world.
+//            link1<--link2<--link3-->link4-->link5
+// Here link3 should become the base mobod.
+GTEST_TEST(MultibodyGraphModeler, ReplaceJoint) {
+  MultibodyGraphModeler maker;
+  for (int i = 1; i <= 5; ++i) maker.AddBody("link" + std::to_string(i));
+  maker.AddJoint("joint0", "revolute", "link2", "link1");
+  maker.AddJoint("joint1", "revolute", "link3", "link2");
+  maker.AddJoint("joint2", "revolute", "link3", "link4");
+  maker.AddJoint("joint3", "revolute", "link4", "link5");
+  MultibodyTreeModel tree(maker);
+
+  // From the example in the original PR.
+  for (MobilizerNum i(0); i < tree.num_mobilizers(); ++i) {
+    auto& mobilizer = tree.get_mobilizer(i);
+    auto& inb = tree.mobod(mobilizer.inboard_mobod_num());
+    auto& outb = tree.mobod(mobilizer.outboard_mobod_num());
+    std::cout << i << ": " << inb.name() << " --> " << outb.name() << "\n";
+  }
+
+  EXPECT_EQ(tree.FindBaseBody(MobodNum(1)), 3);  // link1's base mobod is link3.
+  EXPECT_EQ(tree.FindBaseBodies(), std::vector<MobodNum>({MobodNum(3)}));
+
+  // Now replace link3's free joint with a weld.
+  maker.AddJoint("joint5", "weld", "world",
+                 maker.get_body(BodyIndex(3)).name());
+  MultibodyTreeModel tree2(maker);
+  tree2.DumpTreeModel(std::cout);
+
+  // Expected mobilizers:
+  // 0 world->link3 (weld)
+  // 1 link3->link2 (revolute)
+  // 2 link3->link4     "
+  // 3 link2->link1     "
+  // 4 link4->link5     "
+  EXPECT_EQ(tree2.num_mobilizers(), 5);
+  std::vector<int> expect_inboard({0, 3, 3, 2, 4});
+  std::vector<int> expect_outboard({3, 2, 4, 1, 5});
+  for (MobilizerNum i(0); i < tree2.num_mobilizers(); ++i) {
+    const MultibodyTreeModel::Mobilizer& mobilizer = tree2.get_mobilizer(i);
+    EXPECT_EQ(mobilizer.inboard_mobod_num(), expect_inboard[i]);
+    EXPECT_EQ(mobilizer.outboard_mobod_num(), expect_outboard[i]);
+    EXPECT_EQ(mobilizer.get_joint_type_name(), (i == 0 ? "weld" : "revolute"));
+    EXPECT_FALSE(mobilizer.is_added_base_mobilizer());
+    EXPECT_FALSE(mobilizer.is_reversed_from_joint());
+    EXPECT_FALSE(mobilizer.is_slave_mobilizer());
+  }
+}
+
+}  // namespace
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
We need to be able to analyze links & joints input to determine how it would be modeled as a spanning tree plus constraints, without actually building a multibody tree. Simbody has a utility for that which is used by Gazebo to analyze sdf files. This PR imports the Simbody utility with style and minor substantive changes for use in Drake.

Relates to #9747 -- this is needed to discover where the disconnected base body would be.

This is a big PR since it moved over a substantial block of existing code.
```
Category            added  modified  removed  
----------------------------------------------
code                1958   0         0        
comments            1116   1         0        
blank               514    0         0        
----------------------------------------------
TOTAL               3588   1         0        
```
About half the code is unit tests (and it likely needs more).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10068)
<!-- Reviewable:end -->
