### PR TITLE
Adds Context<T>::to_string()

### DIFF
--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -88,6 +88,7 @@ void DefineFrameworkPySemantics(py::module m) {
     using T = decltype(dummy);
     DefineTemplateClassWithDefault<Context<T>>(
         m, "Context", GetPyParam<T>(), doc.Context.doc)
+        .def("__str__", &Context<T>::to_string, doc.Context.to_string.doc)
         .def("get_num_input_ports", &Context<T>::get_num_input_ports,
             doc.ContextBase.get_num_input_ports.doc)
         .def("FixInputPort",

--- a/bindings/pydrake/systems/framework_py_values.cc
+++ b/bindings/pydrake/systems/framework_py_values.cc
@@ -1,5 +1,7 @@
 #include "drake/bindings/pydrake/systems/framework_py_values.h"
 
+#include <sstream>
+
 #include "pybind11/eigen.h"
 #include "pybind11/eval.h"
 #include "pybind11/pybind11.h"
@@ -32,6 +34,12 @@ void DefineFrameworkPyValues(py::module m) {
     // Value types.
     DefineTemplateClassWithDefault<VectorBase<T>>(
         m, "VectorBase", GetPyParam<T>(), doc.VectorBase.doc)
+        .def("__str__",
+            [](const VectorBase<T>& vec) {
+              std::ostringstream oss;
+              oss << vec;
+              return oss.str();
+            })
         .def("CopyToVector", &VectorBase<T>::CopyToVector,
             doc.VectorBase.CopyToVector.doc)
         .def("SetAtIndex", &VectorBase<T>::SetAtIndex,

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -281,6 +281,10 @@ class TestGeneral(unittest.TestCase):
         input2 = BasicVector([0.003, 0.004, 0.005])
         context.FixInputPort(2, input2)  # Test the BasicVector overload.
 
+        # Test __str__ methods.
+        self.assertRegexpMatches(str(context), "integrator")
+        self.assertEqual(str(input2), "[0.003, 0.004, 0.005]")
+
         # Initialize integrator states.
         integrator_xc = (
             diagram.GetMutableSubsystemState(integrator, context)

--- a/examples/manipulation_station/BUILD.bazel
+++ b/examples/manipulation_station/BUILD.bazel
@@ -158,6 +158,15 @@ drake_py_binary(
     ],
 )
 
+drake_py_binary(
+    name = "print_station_context",
+    srcs = ["print_station_context.py"],
+    add_test_rule = 1,
+    deps = [
+        "//bindings/pydrake",
+    ],
+)
+
 install_data()
 
 add_lint_tests()

--- a/examples/manipulation_station/manipulation_station.cc
+++ b/examples/manipulation_station/manipulation_station.cc
@@ -134,6 +134,8 @@ ManipulationStation<T>::ManipulationStation(double time_step,
   plant_ = owned_plant_.get();
   scene_graph_ = owned_scene_graph_.get();
   plant_->RegisterAsSourceForSceneGraph(scene_graph_);
+  plant_->set_name("multibody_plant");
+  scene_graph_->set_name("scene_graph");
 
   // Add the table and 80/20 workcell frame.
   const double dx_table_center_to_robot_base = 0.3257;
@@ -207,8 +209,10 @@ ManipulationStation<T>::ManipulationStation(double time_step,
   owned_controller_plant_
       ->template AddForceElement<multibody::UniformGravityFieldElement>(
           -9.81 * Vector3d::UnitZ());
+  owned_controller_plant_->set_name("controller_plant");
 
   internal::get_camera_poses(&camera_poses_in_world_);
+  this->set_name("manipulation_station");
 }
 
 template <typename T>
@@ -364,6 +368,7 @@ void ManipulationStation<T>::Finalize() {
   {  // RGB-D Cameras
     auto render_scene_graph =
         builder.template AddSystem<geometry::dev::SceneGraph>(*scene_graph_);
+    render_scene_graph->set_name("dev_scene_graph_for_rendering");
 
     builder.Connect(plant_->get_geometry_poses_output_port(),
                     render_scene_graph->get_source_pose_port(

--- a/examples/manipulation_station/print_station_context.py
+++ b/examples/manipulation_station/print_station_context.py
@@ -1,0 +1,12 @@
+"""
+Provides some insight into the ManipulationStation model by printing out the
+contents of its (default) Context.
+"""
+
+from pydrake.examples.manipulation_station import ManipulationStation
+
+station = ManipulationStation()
+station.Finalize()
+
+context = station.CreateDefaultContext()
+print(context)

--- a/examples/manipulation_station/proof_of_life.cc
+++ b/examples/manipulation_station/proof_of_life.cc
@@ -109,7 +109,6 @@ int do_main(int argc, char* argv[]) {
                                            &station_context));
 
   simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
-  simulator.Initialize();
   simulator.StepTo(FLAGS_duration);
 
   // Check that the arm is (very roughly) in the commanded position.

--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 #include <utility>
 
 #include "drake/common/drake_optional.h"
@@ -602,6 +603,12 @@ class Context : public ContextBase {
   std::unique_ptr<State<T>> CloneState() const {
     return DoCloneState();
   }
+
+  /// Returns a partial textual description of the Context, intended to be
+  /// human-readable.  It is not guaranteed to be unambiguous nor complete.
+  std::string to_string() const {
+    return do_to_string();
+  }
   //@}
 
  protected:
@@ -676,6 +683,10 @@ class Context : public ContextBase {
   /// CloneState().
   virtual std::unique_ptr<State<T>> DoCloneState() const = 0;
 
+  /// Returns a partial textual description of the Context, intended to be
+  /// human-readable.  It is not guaranteed to be unambiguous nor complete.
+  virtual std::string do_to_string() const = 0;
+
   /// Invokes PropagateTimeChange() on all subcontexts of this Context. The
   /// default implementation does nothing, which is suitable for leaf contexts.
   /// Diagram contexts must override.
@@ -745,6 +756,12 @@ class Context : public ContextBase {
   copyable_unique_ptr<Parameters<T>> parameters_{
       std::make_unique<Parameters<T>>()};
 };
+
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const Context<T>& context) {
+  os << context.to_string();
+  return os;
+}
 
 }  // namespace systems
 }  // namespace drake

--- a/systems/framework/leaf_context.h
+++ b/systems/framework/leaf_context.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <set>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -105,6 +106,60 @@ class LeafContext : public Context<T> {
     DRAKE_ASSERT(state_ != nullptr);
     return *state_;
   }
+
+  /// Returns a partial textual description of the Context, intended to be
+  /// human-readable.  It is not guaranteed to be unambiguous nor complete.
+  std::string do_to_string() const final {
+    std::ostringstream os;
+
+    os << this->GetSystemPathname() << " Context\n";
+    os << std::string(this->GetSystemPathname().size() + 9, '-') << "\n";
+    os << "Time: " << this->get_time() << "\n";
+
+    if (this->get_continuous_state().size() ||
+        this->get_num_discrete_state_groups() ||
+        this->get_num_abstract_states()) {
+      os << "States:\n";
+      if (this->get_continuous_state().size()) {
+        os << "  " << this->get_continuous_state().size()
+           << " continuous states\n";
+        os << "    " << this->get_continuous_state_vector() << "\n";
+      }
+      if (this->get_num_discrete_state_groups()) {
+        os << "  " << this->get_num_discrete_state_groups()
+           << " discrete state groups with\n";
+        for (int i = 0; i < this->get_num_discrete_state_groups(); i++) {
+          os << "     " << this->get_discrete_state(i).size() << " states\n";
+          os << "       " << this->get_discrete_state(i) << "\n";
+        }
+      }
+      if (this->get_num_abstract_states()) {
+        os << "  " << this->get_num_abstract_states() << " abstract states\n";
+      }
+      os << "\n";
+    }
+
+    if (this->num_numeric_parameter_groups() ||
+        this->num_abstract_parameters()) {
+      os << "Parameters:\n";
+      if (this->num_numeric_parameter_groups()) {
+        os << "  " << this->num_numeric_parameter_groups()
+           << " numeric parameter groups";
+        os << " with\n";
+        for (int i = 0; i < this->num_numeric_parameter_groups(); i++) {
+          os << "     " << this->get_numeric_parameter(i).size()
+             << " parameters\n";
+          os << "       " << this->get_numeric_parameter(i) << "\n";
+        }
+      }
+      if (this->num_abstract_parameters()) {
+        os << "  " << this->num_abstract_parameters()
+           << " abstract parameters\n";
+      }
+    }
+    return os.str();
+  }
+
 
   // The state values (x) for this LeafContext; this is never null.
   std::unique_ptr<State<T>> state_;

--- a/systems/framework/test/diagram_context_test.cc
+++ b/systems/framework/test/diagram_context_test.cc
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include <Eigen/Dense>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/pointer_cast.h"
@@ -66,9 +67,7 @@ class DiagramContextTest : public ::testing::Test {
  protected:
   void SetUp() override {
     adder0_ = std::make_unique<Adder<double>>(2 /* inputs */, kSize);
-    adder0_->set_name("adder0");
     adder1_ = std::make_unique<Adder<double>>(2 /* inputs */, kSize);
-    adder1_->set_name("adder1");
 
     integrator0_.reset(new Integrator<double>(kSize));
     integrator1_.reset(new Integrator<double>(kSize));
@@ -79,6 +78,16 @@ class DiagramContextTest : public ::testing::Test {
         std::make_unique<SystemWithNumericParameters>();
     system_with_abstract_parameters_ =
         std::make_unique<SystemWithAbstractParameters>();
+
+    adder0_->set_name("adder0");
+    adder1_->set_name("adder1");
+    integrator0_->set_name("integrator0");
+    integrator1_->set_name("integrator1");
+    discrete_state_system_->set_name("discrete_state_system");
+    abstract_state_system_->set_name("abstract_state_system");
+    system_with_numeric_parameters_->set_name("system_with_numeric_parameters");
+    system_with_abstract_parameters_->set_name(
+        "system_with_abstract_parameters");
 
     // This chunk of code is partially mimicking Diagram::DoAllocateContext()
     // which is normally in charge of making DiagramContexts.
@@ -642,6 +651,21 @@ TEST_F(DiagramContextTest, SetAndGetInputPorts) {
   AttachInputPorts();
   EXPECT_EQ(128, ReadVectorInputPort(*context_, 0)->get_value()[0]);
   EXPECT_EQ(256, ReadVectorInputPort(*context_, 1)->get_value()[0]);
+}
+
+TEST_F(DiagramContextTest, ToString) {
+  const std::string str = context_->to_string();
+  EXPECT_THAT(str, ::testing::HasSubstr("integrator0"));
+  EXPECT_THAT(str, ::testing::HasSubstr("integrator1"));
+  EXPECT_THAT(str, ::testing::HasSubstr("discrete_state_system"));
+  EXPECT_THAT(str, ::testing::HasSubstr("abstract_state_system"));
+  EXPECT_THAT(str, ::testing::HasSubstr("system_with_numeric_parameters"));
+  EXPECT_THAT(str, ::testing::HasSubstr("system_with_abstract_parameters"));
+
+  // Adders named adder0 and adder1 are part of the diagram, but don't have
+  // any context that is useful to print, so are excluded.
+  EXPECT_THAT(str, ::testing::Not(::testing::HasSubstr("adder0")));
+  EXPECT_THAT(str, ::testing::Not(::testing::HasSubstr("adder1")));
 }
 
 // Test that start_next_change_event() returns a sequentially increasing

--- a/systems/framework/test/leaf_context_test.cc
+++ b/systems/framework/test/leaf_context_test.cc
@@ -6,6 +6,7 @@
 #include <utility>
 #include <vector>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/autodiff.h"
@@ -375,6 +376,17 @@ TEST_F(LeafContextTest, GetAbstractInput) {
 
   // Test that port 1 is nullptr.
   EXPECT_EQ(nullptr, ReadAbstractInputPort(context, 1));
+}
+
+TEST_F(LeafContextTest, ToString) {
+  const std::string str = context_.to_string();
+  using ::testing::HasSubstr;
+  EXPECT_THAT(str, HasSubstr("Time: 12"));
+  EXPECT_THAT(str, HasSubstr("5 continuous states"));
+  EXPECT_THAT(str, HasSubstr("2 discrete state groups"));
+  EXPECT_THAT(str, HasSubstr("1 abstract state"));
+  EXPECT_THAT(str, HasSubstr("2 numeric parameter groups"));
+  EXPECT_THAT(str, HasSubstr("1 abstract parameters"));
 }
 
 // Tests that items can be stored and retrieved in the cache.


### PR DESCRIPTION
GIves a very useful lens into where/what states and parameters have been allocated in complex systems (and their current values).

Example:
```
from pydrake.examples.manipulation_station import ManipulationStation

station = ManipulationStation()
station.Finalize()

context = station.CreateDefaultContext()
print(context)
```

Outputs
```
::manipulation_station Context (of a Diagram)
----------------------------------------------------------------
7 total continuous states
26 total discrete states in 3 groups
2 total abstract states
7 total numeric parameters in 1 groups

::manipulation_station::multibody_plant Context
------------------------------------------------------------------
Time: 0
States:
  1 discrete state groups with
     18 states
       [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]


::manipulation_station::scene_graph Context
------------------------------------------------------------------
Time: 0
States:
  1 abstract states


::manipulation_station::iiwa_controller Context (of a Diagram)
----------------------------------------------------------------
7 total continuous states
7 total numeric parameters in 1 groups

::manipulation_station::iiwa_controller::drake/systems/controllers/PidController@0000558d0d2068d8 Context
------------------------------------------------------------------
Time: 0
States:
  7 continuous states
    [0, 0, 0, 0, 0, 0, 0]


::manipulation_station::iiwa_controller::drake/systems/ConstantVectorSource@0000558d0d52db90 Context
------------------------------------------------------------------
Time: 0
Parameters:
  1 numeric parameter groups with
     7 parameters
       [0, 0, 0, 0, 0, 0, 0]

::manipulation_station::desired_state_from_position Context
------------------------------------------------------------------
Time: 0
States:
  1 discrete state groups with
     7 states
       [0, 0, 0, 0, 0, 0, 0]


::manipulation_station::wsg_controller Context
------------------------------------------------------------------
Time: 0
States:
  1 discrete state groups with
     1 states
       [0]


::manipulation_station::dev_scene_graph_for_rendering Context
------------------------------------------------------------------
Time: 0
States:
  1 abstract states
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10072)
<!-- Reviewable:end -->
