### PR TITLE
pydrake: Re-format using DontAlignAfterOpenBracket

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,6 +11,11 @@ Language: Cpp
 DerivePointerAlignment: false
 PointerAlignment: Left
 
+# When a function signature's parameters or a function call's arguments need to
+# wrap onto another line, indent by four spaces -- do not whitespace castle all
+# the way over to the open-paren.
+AlignAfterOpenBracket: DontAlign
+
 # Specify the #include statement order.  This implements the order mandated by
 # the Google C++ Style Guide: related header, C headers, C++ headers, library
 # headers, and finally the project headers.

--- a/bindings/pydrake/autodiffutils_py.cc
+++ b/bindings/pydrake/autodiffutils_py.cc
@@ -30,17 +30,17 @@ PYBIND11_MODULE(autodiffutils, m) {
       .def(py::init<const double&, const Eigen::VectorXd&>())
       .def("value", [](const AutoDiffXd& self) { return self.value(); })
       .def("derivatives",
-           [](const AutoDiffXd& self) { return self.derivatives(); })
+          [](const AutoDiffXd& self) { return self.derivatives(); })
       .def("__str__",
-           [](const AutoDiffXd& self) {
-             return py::str("AD{{{}, nderiv={}}}")
-                 .format(self.value(), self.derivatives().size());
-           })
+          [](const AutoDiffXd& self) {
+            return py::str("AD{{{}, nderiv={}}}")
+                .format(self.value(), self.derivatives().size());
+          })
       .def("__repr__",
-           [](const AutoDiffXd& self) {
-             return py::str("<AutoDiffXd {} nderiv={}>")
-                 .format(self.value(), self.derivatives().size());
-           })
+          [](const AutoDiffXd& self) {
+            return py::str("<AutoDiffXd {} nderiv={}>")
+                .format(self.value(), self.derivatives().size());
+          })
       // Arithmetic
       .def(-py::self)
       .def(py::self + py::self)
@@ -70,10 +70,10 @@ PYBIND11_MODULE(autodiffutils, m) {
       .def(py::self >= double())
       // Additional math
       .def("__pow__",
-           [](const AutoDiffXd& base, int exponent) {
-             return pow(base, exponent);
-           },
-           py::is_operator())
+          [](const AutoDiffXd& base, int exponent) {
+            return pow(base, exponent);
+          },
+          py::is_operator())
       .def("__abs__", [](const AutoDiffXd& x) { return abs(x); });
   DefCopyAndDeepCopy(&autodiff);
 
@@ -94,14 +94,14 @@ PYBIND11_MODULE(autodiffutils, m) {
       .def("asin", [](const AutoDiffXd& x) { return asin(x); })
       .def("acos", [](const AutoDiffXd& x) { return acos(x); })
       .def("atan2",
-           [](const AutoDiffXd& y, const AutoDiffXd& x) { return atan2(y, x); })
+          [](const AutoDiffXd& y, const AutoDiffXd& x) { return atan2(y, x); })
       .def("sinh", [](const AutoDiffXd& x) { return sinh(x); })
       .def("cosh", [](const AutoDiffXd& x) { return cosh(x); })
       .def("tanh", [](const AutoDiffXd& x) { return tanh(x); })
       .def("min",
-           [](const AutoDiffXd& x, const AutoDiffXd& y) { return min(x, y); })
+          [](const AutoDiffXd& x, const AutoDiffXd& y) { return min(x, y); })
       .def("max",
-           [](const AutoDiffXd& x, const AutoDiffXd& y) { return max(x, y); })
+          [](const AutoDiffXd& x, const AutoDiffXd& y) { return max(x, y); })
       .def("ceil", [](const AutoDiffXd& x) { return ceil(x); })
       .def("floor", [](const AutoDiffXd& x) { return floor(x); });
   // Mirror for numpy.

--- a/bindings/pydrake/automotive_py.cc
+++ b/bindings/pydrake/automotive_py.cc
@@ -37,46 +37,46 @@ PYBIND11_MODULE(automotive, m) {
       .value("kAhead", AheadOrBehind::kAhead, doc.AheadOrBehind.kAhead.doc)
       .value("kBehind", AheadOrBehind::kBehind, doc.AheadOrBehind.kBehind.doc);
 
-  py::enum_<RoadPositionStrategy>(m, "RoadPositionStrategy",
-                                  doc.RoadPositionStrategy.doc)
+  py::enum_<RoadPositionStrategy>(
+      m, "RoadPositionStrategy", doc.RoadPositionStrategy.doc)
       .value("kCache", RoadPositionStrategy::kCache,
-             doc.RoadPositionStrategy.kCache.doc)
+          doc.RoadPositionStrategy.kCache.doc)
       .value("kExhaustiveSearch", RoadPositionStrategy::kExhaustiveSearch,
-             doc.RoadPositionStrategy.kExhaustiveSearch.doc);
+          doc.RoadPositionStrategy.kExhaustiveSearch.doc);
 
   py::enum_<ScanStrategy>(m, "ScanStrategy", doc.ScanStrategy.doc)
       .value("kPath", ScanStrategy::kPath, doc.ScanStrategy.kPath.doc)
-      .value("kBranches", ScanStrategy::kBranches,
-             doc.ScanStrategy.kBranches.doc);
+      .value(
+          "kBranches", ScanStrategy::kBranches, doc.ScanStrategy.kBranches.doc);
 
   py::class_<ClosestPose<T>>(m, "ClosestPose", doc.ClosestPose.doc)
       .def(py::init<>(), doc.ClosestPose.ctor.doc_0args)
       .def(py::init<const RoadOdometry<T>&, const T&>(), py::arg("odom"),
-           py::arg("dist"),
-           // Keep alive, transitive: `self` keeps `RoadOdometry` pointer
-           // members alive.
-           py::keep_alive<1, 2>(), doc.ClosestPose.ctor.doc_2args)
+          py::arg("dist"),
+          // Keep alive, transitive: `self` keeps `RoadOdometry` pointer
+          // members alive.
+          py::keep_alive<1, 2>(), doc.ClosestPose.ctor.doc_2args)
       .def_readwrite("odometry", &ClosestPose<T>::odometry,
-                     py_reference_internal, doc.ClosestPose.odometry.doc)
-      .def_readwrite("distance", &ClosestPose<T>::distance,
-                     doc.ClosestPose.distance.doc);
+          py_reference_internal, doc.ClosestPose.odometry.doc)
+      .def_readwrite(
+          "distance", &ClosestPose<T>::distance, doc.ClosestPose.distance.doc);
 
-  py::class_<RoadOdometry<T>> road_odometry(m, "RoadOdometry",
-                                            doc.RoadOdometry.doc);
+  py::class_<RoadOdometry<T>> road_odometry(
+      m, "RoadOdometry", doc.RoadOdometry.doc);
   road_odometry  // BR
       .def(py::init<>(), doc.RoadOdometry.ctor.doc_0args)
       .def(py::init<const maliput::api::RoadPosition&,
-                    const systems::rendering::FrameVelocity<T>&>(),
-           py::arg("road_position"), py::arg("frame_velocity"),
-           // Keep alive, transitive: `self` keeps `RoadPosition` pointer
-           // members alive.
-           py::keep_alive<1, 2>(), doc.RoadOdometry.ctor.doc_2args)
+               const systems::rendering::FrameVelocity<T>&>(),
+          py::arg("road_position"), py::arg("frame_velocity"),
+          // Keep alive, transitive: `self` keeps `RoadPosition` pointer
+          // members alive.
+          py::keep_alive<1, 2>(), doc.RoadOdometry.ctor.doc_2args)
       .def(py::init<const maliput::api::Lane*,
-                    const maliput::api::LanePositionT<T>&,
-                    const systems::rendering::FrameVelocity<T>&>(),
-           py::arg("lane"), py::arg("lane_position"), py::arg("frame_velocity"),
-           // Keep alive, reference: `self` keeps `Lane*` alive.
-           py::keep_alive<1, 2>(), doc.RoadOdometry.ctor.doc_3args)
+               const maliput::api::LanePositionT<T>&,
+               const systems::rendering::FrameVelocity<T>&>(),
+          py::arg("lane"), py::arg("lane_position"), py::arg("frame_velocity"),
+          // Keep alive, reference: `self` keeps `Lane*` alive.
+          py::keep_alive<1, 2>(), doc.RoadOdometry.ctor.doc_3args)
       .def_readwrite("pos", &RoadOdometry<T>::pos, doc.RoadOdometry.pos.doc)
       .def_readwrite("vel", &RoadOdometry<T>::vel, doc.RoadOdometry.vel.doc);
   // TODO(m-chaturvedi) Add Pybind11 documentation.
@@ -84,49 +84,48 @@ PYBIND11_MODULE(automotive, m) {
 
   py::class_<LaneDirection>(m, "LaneDirection", doc.LaneDirection.doc)
       .def(py::init<const maliput::api::Lane*, bool>(), py::arg("lane"),
-           py::arg("with_s"), doc.LaneDirection.ctor.doc_2args)
+          py::arg("with_s"), doc.LaneDirection.ctor.doc_2args)
       .def_readwrite("lane", &LaneDirection::lane, py_reference_internal,
-                     doc.LaneDirection.lane.doc)
-      .def_readwrite("with_s", &LaneDirection::with_s,
-                     doc.LaneDirection.with_s.doc);
+          doc.LaneDirection.lane.doc)
+      .def_readwrite(
+          "with_s", &LaneDirection::with_s, doc.LaneDirection.with_s.doc);
   pysystems::AddValueInstantiation<LaneDirection>(m);
 
   // TODO(eric.cousineau) Bind this named vector automatically (see #8096).
-  py::class_<DrivingCommand<T>, BasicVector<T>>(m, "DrivingCommand",
-                                                doc.DrivingCommand.doc)
+  py::class_<DrivingCommand<T>, BasicVector<T>>(
+      m, "DrivingCommand", doc.DrivingCommand.doc)
       .def(py::init<>(), doc.DrivingCommand.ctor.doc_0args)
       .def("steering_angle", &DrivingCommand<T>::steering_angle,
-           doc.DrivingCommand.steering_angle.doc)
+          doc.DrivingCommand.steering_angle.doc)
       .def("acceleration", &DrivingCommand<T>::acceleration,
-           doc.DrivingCommand.acceleration.doc)
+          doc.DrivingCommand.acceleration.doc)
       .def("set_steering_angle", &DrivingCommand<T>::set_steering_angle,
-           doc.DrivingCommand.set_steering_angle.doc)
+          doc.DrivingCommand.set_steering_angle.doc)
       .def("set_acceleration", &DrivingCommand<T>::set_acceleration,
-           doc.DrivingCommand.set_acceleration.doc);
+          doc.DrivingCommand.set_acceleration.doc);
 
-  py::class_<IdmController<T>, LeafSystem<T>>(m, "IdmController",
-                                              doc.IdmController.doc)
+  py::class_<IdmController<T>, LeafSystem<T>>(
+      m, "IdmController", doc.IdmController.doc)
       .def(py::init<const maliput::api::RoadGeometry&, ScanStrategy,
-                    RoadPositionStrategy, double>(),
-           py::arg("road"), py::arg("path_or_branches"),
-           py::arg("road_position_strategy"), py::arg("period_sec"),
-           doc.IdmController.ctor.doc_4args)
+               RoadPositionStrategy, double>(),
+          py::arg("road"), py::arg("path_or_branches"),
+          py::arg("road_position_strategy"), py::arg("period_sec"),
+          doc.IdmController.ctor.doc_4args)
       .def("ego_pose_input", &IdmController<T>::ego_pose_input,
-           py_reference_internal, doc.IdmController.ego_pose_input.doc)
+          py_reference_internal, doc.IdmController.ego_pose_input.doc)
       .def("ego_velocity_input", &IdmController<T>::ego_velocity_input,
-           py_reference_internal, doc.IdmController.ego_velocity_input.doc)
+          py_reference_internal, doc.IdmController.ego_velocity_input.doc)
       .def("traffic_input", &IdmController<T>::traffic_input,
-           py_reference_internal, doc.IdmController.traffic_input.doc)
+          py_reference_internal, doc.IdmController.traffic_input.doc)
       .def("acceleration_output", &IdmController<T>::acceleration_output,
-           py_reference_internal, doc.IdmController.acceleration_output.doc);
+          py_reference_internal, doc.IdmController.acceleration_output.doc);
 
   py::class_<PoseSelector<T>>(m, "PoseSelector", doc.PoseSelector.doc)
-      .def_static(
-          "FindClosestPair",
+      .def_static("FindClosestPair",
           [](const maliput::api::Lane* lane,
-             const systems::rendering::PoseVector<T>& ego_pose,
-             const systems::rendering::PoseBundle<T>& traffic_poses,
-             const T& scan_distance, ScanStrategy path_or_branches) {
+              const systems::rendering::PoseVector<T>& ego_pose,
+              const systems::rendering::PoseBundle<T>& traffic_poses,
+              const T& scan_distance, ScanStrategy path_or_branches) {
             return PoseSelector<T>::FindClosestPair(
                 lane, ego_pose, traffic_poses, scan_distance, path_or_branches);
           },
@@ -134,59 +133,58 @@ PYBIND11_MODULE(automotive, m) {
           py::arg("scan_distance"), py::arg("path_or_branches"),
           doc.PoseSelector.FindClosestPair.doc)
       .def_static("FindSingleClosestPose",
-                  [](const maliput::api::Lane* lane,
-                     const systems::rendering::PoseVector<T>& ego_pose,
-                     const systems::rendering::PoseBundle<T>& traffic_poses,
-                     const T& scan_distance, const AheadOrBehind side,
-                     ScanStrategy path_or_branches) {
-                    return PoseSelector<T>::FindSingleClosestPose(
-                        lane, ego_pose, traffic_poses, scan_distance, side,
-                        path_or_branches);
-                  },
-                  py::arg("lane"), py::arg("ego_pose"),
-                  py::arg("traffic_poses"), py::arg("scan_distance"),
-                  py::arg("side"), py::arg("path_or_branches"),
-                  doc.PoseSelector.FindSingleClosestPose.doc)
+          [](const maliput::api::Lane* lane,
+              const systems::rendering::PoseVector<T>& ego_pose,
+              const systems::rendering::PoseBundle<T>& traffic_poses,
+              const T& scan_distance, const AheadOrBehind side,
+              ScanStrategy path_or_branches) {
+            return PoseSelector<T>::FindSingleClosestPose(lane, ego_pose,
+                traffic_poses, scan_distance, side, path_or_branches);
+          },
+          py::arg("lane"), py::arg("ego_pose"), py::arg("traffic_poses"),
+          py::arg("scan_distance"), py::arg("side"),
+          py::arg("path_or_branches"),
+          doc.PoseSelector.FindSingleClosestPose.doc)
       .def_static("GetSigmaVelocity", &PoseSelector<T>::GetSigmaVelocity,
-                  doc.PoseSelector.GetSigmaVelocity.doc);
+          doc.PoseSelector.GetSigmaVelocity.doc);
 
   py::class_<PurePursuitController<T>, LeafSystem<T>>(
       m, "PurePursuitController", doc.PurePursuitController.doc)
       .def(py::init<>(), doc.PurePursuitController.ctor.doc_4)
       .def("ego_pose_input", &PurePursuitController<T>::ego_pose_input,
-           py_reference_internal, doc.PurePursuitController.ego_pose_input.doc)
+          py_reference_internal, doc.PurePursuitController.ego_pose_input.doc)
       .def("lane_input", &PurePursuitController<T>::lane_input,
-           py_reference_internal, doc.PurePursuitController.lane_input.doc)
+          py_reference_internal, doc.PurePursuitController.lane_input.doc)
       .def("steering_command_output",
-           &PurePursuitController<T>::steering_command_output,
-           py_reference_internal,
-           doc.PurePursuitController.steering_command_output.doc);
+          &PurePursuitController<T>::steering_command_output,
+          py_reference_internal,
+          doc.PurePursuitController.steering_command_output.doc);
 
   // TODO(eric.cousineau) Bind this named vector automatically (see #8096).
-  py::class_<SimpleCarState<T>, BasicVector<T>>(m, "SimpleCarState",
-                                                doc.SimpleCarState.doc)
+  py::class_<SimpleCarState<T>, BasicVector<T>>(
+      m, "SimpleCarState", doc.SimpleCarState.doc)
       .def(py::init<>(), doc.SimpleCarState.ctor.doc_0args)
       .def("x", &SimpleCarState<T>::x, doc.SimpleCarState.x.doc)
       .def("y", &SimpleCarState<T>::y, doc.SimpleCarState.y.doc)
       .def("heading", &SimpleCarState<T>::heading,
-           doc.SimpleCarState.heading.doc)
+          doc.SimpleCarState.heading.doc)
       .def("velocity", &SimpleCarState<T>::velocity,
-           doc.SimpleCarState.velocity.doc)
+          doc.SimpleCarState.velocity.doc)
       .def("set_x", &SimpleCarState<T>::set_x, doc.SimpleCarState.set_x.doc)
       .def("set_y", &SimpleCarState<T>::set_y, doc.SimpleCarState.set_y.doc)
       .def("set_heading", &SimpleCarState<T>::set_heading,
-           doc.SimpleCarState.set_heading.doc)
+          doc.SimpleCarState.set_heading.doc)
       .def("set_velocity", &SimpleCarState<T>::set_velocity,
-           doc.SimpleCarState.set_velocity.doc);
+          doc.SimpleCarState.set_velocity.doc);
 
   py::class_<SimpleCar<T>, LeafSystem<T>>(m, "SimpleCar", doc.SimpleCar.doc)
       .def(py::init<>(), doc.SimpleCar.ctor.doc_4)
       .def("state_output", &SimpleCar<T>::state_output, py_reference_internal,
-           doc.SimpleCar.state_output.doc)
+          doc.SimpleCar.state_output.doc)
       .def("pose_output", &SimpleCar<T>::pose_output, py_reference_internal,
-           doc.SimpleCar.pose_output.doc)
+          doc.SimpleCar.pose_output.doc)
       .def("velocity_output", &SimpleCar<T>::velocity_output,
-           py_reference_internal, doc.SimpleCar.velocity_output.doc);
+          py_reference_internal, doc.SimpleCar.velocity_output.doc);
 
   // TODO(jadecastro) Bind more systems as appropriate.
 }

--- a/bindings/pydrake/examples/acrobot_py.cc
+++ b/bindings/pydrake/examples/acrobot_py.cc
@@ -31,27 +31,27 @@ PYBIND11_MODULE(acrobot, m) {
   // conversion. Issue #7660.
   using T = double;
 
-  py::class_<AcrobotPlant<T>, LeafSystem<T>>(m, "AcrobotPlant",
-                                             doc.AcrobotPlant.doc)
+  py::class_<AcrobotPlant<T>, LeafSystem<T>>(
+      m, "AcrobotPlant", doc.AcrobotPlant.doc)
       .def(py::init<>(), doc.AcrobotPlant.ctor.doc_3)
       .def("CalcPotentialEnergy", &AcrobotPlant<T>::CalcPotentialEnergy,
-           doc.AcrobotPlant.DoCalcPotentialEnergy.doc)
+          doc.AcrobotPlant.DoCalcPotentialEnergy.doc)
       .def("CalcKineticEnergy", &AcrobotPlant<T>::CalcKineticEnergy,
-           doc.AcrobotPlant.DoCalcKineticEnergy.doc)
+          doc.AcrobotPlant.DoCalcKineticEnergy.doc)
       .def("DynamicsBiasTerm", &AcrobotPlant<T>::DynamicsBiasTerm,
-           doc.AcrobotPlant.DynamicsBiasTerm.doc)
+          doc.AcrobotPlant.DynamicsBiasTerm.doc)
       .def("MassMatrix", &AcrobotPlant<T>::MassMatrix,
-           doc.AcrobotPlant.MassMatrix.doc);
+          doc.AcrobotPlant.MassMatrix.doc);
 
   // TODO(russt): Remove custom bindings once #8096 is resolved.
-  py::class_<AcrobotInput<T>, BasicVector<T>>(m, "AcrobotInput",
-                                              doc.AcrobotInput.doc)
+  py::class_<AcrobotInput<T>, BasicVector<T>>(
+      m, "AcrobotInput", doc.AcrobotInput.doc)
       .def(py::init<>(), doc.AcrobotInput.ctor.doc_0args)
       .def("tau", &AcrobotInput<T>::tau, doc.AcrobotInput.tau.doc)
       .def("set_tau", &AcrobotInput<T>::set_tau, doc.AcrobotInput.set_tau.doc);
 
-  py::class_<AcrobotParams<T>, BasicVector<T>>(m, "AcrobotParams",
-                                               doc.AcrobotParams.doc)
+  py::class_<AcrobotParams<T>, BasicVector<T>>(
+      m, "AcrobotParams", doc.AcrobotParams.doc)
       .def(py::init<>(), doc.AcrobotParams.ctor.doc_0args)
       .def("m1", &AcrobotParams<T>::m1, doc.AcrobotParams.m1.doc)
       .def("m2", &AcrobotParams<T>::m2, doc.AcrobotParams.m2.doc)
@@ -73,25 +73,25 @@ PYBIND11_MODULE(acrobot, m) {
       .def("set_b1", &AcrobotParams<T>::set_b1, doc.AcrobotParams.set_b1.doc)
       .def("set_b2", &AcrobotParams<T>::set_b2, doc.AcrobotParams.set_b2.doc)
       .def("set_gravity", &AcrobotParams<T>::set_gravity,
-           doc.AcrobotParams.set_gravity.doc);
+          doc.AcrobotParams.set_gravity.doc);
 
-  py::class_<AcrobotState<T>, BasicVector<T>>(m, "AcrobotState",
-                                              doc.AcrobotState.doc)
+  py::class_<AcrobotState<T>, BasicVector<T>>(
+      m, "AcrobotState", doc.AcrobotState.doc)
       .def(py::init<>(), doc.AcrobotState.ctor.doc_0args)
       .def("theta1", &AcrobotState<T>::theta1, doc.AcrobotState.theta1.doc)
       .def("theta1dot", &AcrobotState<T>::theta1dot,
-           doc.AcrobotState.theta1dot.doc)
+          doc.AcrobotState.theta1dot.doc)
       .def("theta2", &AcrobotState<T>::theta2, doc.AcrobotState.theta2.doc)
       .def("theta2dot", &AcrobotState<T>::theta2dot,
-           doc.AcrobotState.theta2dot.doc)
+          doc.AcrobotState.theta2dot.doc)
       .def("set_theta1", &AcrobotState<T>::set_theta1,
-           doc.AcrobotState.set_theta1.doc)
+          doc.AcrobotState.set_theta1.doc)
       .def("set_theta1dot", &AcrobotState<T>::set_theta1dot,
-           doc.AcrobotState.set_theta1dot.doc)
+          doc.AcrobotState.set_theta1dot.doc)
       .def("set_theta2", &AcrobotState<T>::set_theta2,
-           doc.AcrobotState.set_theta2.doc)
+          doc.AcrobotState.set_theta2.doc)
       .def("set_theta2dot", &AcrobotState<T>::set_theta2dot,
-           doc.AcrobotState.set_theta2dot.doc);
+          doc.AcrobotState.set_theta2dot.doc);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/examples/compass_gait_py.cc
+++ b/bindings/pydrake/examples/compass_gait_py.cc
@@ -26,59 +26,59 @@ PYBIND11_MODULE(compass_gait, m) {
   // conversion.
   using T = double;
 
-  py::class_<CompassGait<T>, LeafSystem<T>>(m, "CompassGait",
-                                            doc.CompassGait.doc)
+  py::class_<CompassGait<T>, LeafSystem<T>>(
+      m, "CompassGait", doc.CompassGait.doc)
       .def(py::init<>(), doc.CompassGait.ctor.doc_3);
 
   // TODO(russt): Remove custom bindings once #8096 is resolved.
-  py::class_<CompassGaitParams<T>, BasicVector<T>>(m, "CompassGaitParams",
-                                                   doc.CompassGaitParams.doc)
+  py::class_<CompassGaitParams<T>, BasicVector<T>>(
+      m, "CompassGaitParams", doc.CompassGaitParams.doc)
       .def(py::init<>(), doc.CompassGaitParams.ctor.doc_0args)
       .def("mass_hip", &CompassGaitParams<T>::mass_hip,
-           doc.CompassGaitParams.mass_hip.doc)
+          doc.CompassGaitParams.mass_hip.doc)
       .def("mass_leg", &CompassGaitParams<T>::mass_leg,
-           doc.CompassGaitParams.mass_leg.doc)
+          doc.CompassGaitParams.mass_leg.doc)
       .def("length_leg", &CompassGaitParams<T>::length_leg,
-           doc.CompassGaitParams.length_leg.doc)
+          doc.CompassGaitParams.length_leg.doc)
       .def("center_of_mass_leg", &CompassGaitParams<T>::center_of_mass_leg,
-           doc.CompassGaitParams.center_of_mass_leg.doc)
+          doc.CompassGaitParams.center_of_mass_leg.doc)
       .def("gravity", &CompassGaitParams<T>::gravity,
-           doc.CompassGaitParams.gravity.doc)
+          doc.CompassGaitParams.gravity.doc)
       .def("slope", &CompassGaitParams<T>::slope,
-           doc.CompassGaitParams.slope.doc)
+          doc.CompassGaitParams.slope.doc)
       .def("set_mass_hip", &CompassGaitParams<T>::set_mass_hip,
-           doc.CompassGaitParams.set_mass_hip.doc)
+          doc.CompassGaitParams.set_mass_hip.doc)
       .def("set_mass_leg", &CompassGaitParams<T>::set_mass_leg,
-           doc.CompassGaitParams.set_mass_leg.doc)
+          doc.CompassGaitParams.set_mass_leg.doc)
       .def("set_length_leg", &CompassGaitParams<T>::set_length_leg,
-           doc.CompassGaitParams.set_length_leg.doc)
+          doc.CompassGaitParams.set_length_leg.doc)
       .def("set_center_of_mass_leg",
-           &CompassGaitParams<T>::set_center_of_mass_leg,
-           doc.CompassGaitParams.set_center_of_mass_leg.doc)
+          &CompassGaitParams<T>::set_center_of_mass_leg,
+          doc.CompassGaitParams.set_center_of_mass_leg.doc)
       .def("set_gravity", &CompassGaitParams<T>::set_gravity,
-           doc.CompassGaitParams.set_gravity.doc)
+          doc.CompassGaitParams.set_gravity.doc)
       .def("set_slope", &CompassGaitParams<T>::set_slope,
-           doc.CompassGaitParams.set_slope.doc);
+          doc.CompassGaitParams.set_slope.doc);
 
   py::class_<CompassGaitContinuousState<T>, BasicVector<T>>(
       m, "CompassGaitContinuousState", doc.CompassGaitContinuousState.doc)
       .def(py::init<>(), doc.CompassGaitContinuousState.ctor.doc_0args)
       .def("stance", &CompassGaitContinuousState<T>::stance,
-           doc.CompassGaitContinuousState.stance.doc)
+          doc.CompassGaitContinuousState.stance.doc)
       .def("swing", &CompassGaitContinuousState<T>::swing,
-           doc.CompassGaitContinuousState.swing.doc)
+          doc.CompassGaitContinuousState.swing.doc)
       .def("stancedot", &CompassGaitContinuousState<T>::stancedot,
-           doc.CompassGaitContinuousState.stancedot.doc)
+          doc.CompassGaitContinuousState.stancedot.doc)
       .def("swingdot", &CompassGaitContinuousState<T>::swingdot,
-           doc.CompassGaitContinuousState.swingdot.doc)
+          doc.CompassGaitContinuousState.swingdot.doc)
       .def("set_stance", &CompassGaitContinuousState<T>::set_stance,
-           doc.CompassGaitContinuousState.set_stance.doc)
+          doc.CompassGaitContinuousState.set_stance.doc)
       .def("set_swing", &CompassGaitContinuousState<T>::set_swing,
-           doc.CompassGaitContinuousState.set_swing.doc)
+          doc.CompassGaitContinuousState.set_swing.doc)
       .def("set_stancedot", &CompassGaitContinuousState<T>::set_stancedot,
-           doc.CompassGaitContinuousState.set_stancedot.doc)
+          doc.CompassGaitContinuousState.set_stancedot.doc)
       .def("set_swingdot", &CompassGaitContinuousState<T>::set_swingdot,
-           doc.CompassGaitContinuousState.set_swingdot.doc);
+          doc.CompassGaitContinuousState.set_swingdot.doc);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/examples/manipulation_station_py.cc
+++ b/bindings/pydrake/examples/manipulation_station_py.cc
@@ -30,74 +30,74 @@ PYBIND11_MODULE(manipulation_station, m) {
 
   py::enum_<IiwaCollisionModel>(m, "IiwaCollisionModel")
       .value("kNoCollision", IiwaCollisionModel::kNoCollision,
-             doc.IiwaCollisionModel.kNoCollision.doc)
+          doc.IiwaCollisionModel.kNoCollision.doc)
       .value("kBoxCollision", IiwaCollisionModel::kBoxCollision,
-             doc.IiwaCollisionModel.kBoxCollision.doc)
+          doc.IiwaCollisionModel.kBoxCollision.doc)
       .export_values();
 
   py::class_<ManipulationStation<T>, Diagram<T>>(m, "ManipulationStation")
       .def(py::init<double, IiwaCollisionModel>(), py::arg("time_step") = 0.002,
-           py::arg("collision_model") = IiwaCollisionModel::kNoCollision,
-           doc.ManipulationStation.ctor.doc_2args)
+          py::arg("collision_model") = IiwaCollisionModel::kNoCollision,
+          doc.ManipulationStation.ctor.doc_2args)
       .def("AddCupboard", &ManipulationStation<T>::AddCupboard,
-           doc.ManipulationStation.AddCupboard.doc)
+          doc.ManipulationStation.AddCupboard.doc)
       .def("Finalize", &ManipulationStation<T>::Finalize,
-           doc.ManipulationStation.Finalize.doc)
+          doc.ManipulationStation.Finalize.doc)
       .def("get_multibody_plant", &ManipulationStation<T>::get_multibody_plant,
-           py_reference_internal,
-           doc.ManipulationStation.get_multibody_plant.doc)
+          py_reference_internal,
+          doc.ManipulationStation.get_multibody_plant.doc)
       .def("get_mutable_multibody_plant",
-           &ManipulationStation<T>::get_mutable_multibody_plant,
-           py_reference_internal,
-           doc.ManipulationStation.get_mutable_multibody_plant.doc)
+          &ManipulationStation<T>::get_mutable_multibody_plant,
+          py_reference_internal,
+          doc.ManipulationStation.get_mutable_multibody_plant.doc)
       .def("get_scene_graph", &ManipulationStation<T>::get_scene_graph,
-           py_reference_internal, doc.ManipulationStation.get_scene_graph.doc)
+          py_reference_internal, doc.ManipulationStation.get_scene_graph.doc)
       .def("get_mutable_scene_graph",
-           &ManipulationStation<T>::get_mutable_scene_graph,
-           py_reference_internal,
-           doc.ManipulationStation.get_mutable_scene_graph.doc)
+          &ManipulationStation<T>::get_mutable_scene_graph,
+          py_reference_internal,
+          doc.ManipulationStation.get_mutable_scene_graph.doc)
       .def("get_controller_plant",
-           &ManipulationStation<T>::get_controller_plant, py_reference_internal,
-           doc.ManipulationStation.get_controller_plant.doc)
+          &ManipulationStation<T>::get_controller_plant, py_reference_internal,
+          doc.ManipulationStation.get_controller_plant.doc)
       .def("GetIiwaPosition", &ManipulationStation<T>::GetIiwaPosition,
-           doc.ManipulationStation.GetIiwaPosition.doc)
+          doc.ManipulationStation.GetIiwaPosition.doc)
       .def("SetIiwaPosition", &ManipulationStation<T>::SetIiwaPosition,
-           doc.ManipulationStation.SetIiwaPosition.doc)
+          doc.ManipulationStation.SetIiwaPosition.doc)
       .def("GetIiwaVelocity", &ManipulationStation<T>::GetIiwaVelocity,
-           doc.ManipulationStation.GetIiwaVelocity.doc)
+          doc.ManipulationStation.GetIiwaVelocity.doc)
       .def("SetIiwaVelocity", &ManipulationStation<T>::SetIiwaVelocity,
-           doc.ManipulationStation.SetIiwaVelocity.doc)
+          doc.ManipulationStation.SetIiwaVelocity.doc)
       .def("GetWsgPosition", &ManipulationStation<T>::GetWsgPosition,
-           doc.ManipulationStation.GetWsgPosition.doc)
+          doc.ManipulationStation.GetWsgPosition.doc)
       .def("SetWsgPosition", &ManipulationStation<T>::SetWsgPosition,
-           doc.ManipulationStation.SetWsgPosition.doc)
+          doc.ManipulationStation.SetWsgPosition.doc)
       .def("GetWsgVelocity", &ManipulationStation<T>::GetWsgVelocity,
-           doc.ManipulationStation.GetWsgVelocity.doc)
+          doc.ManipulationStation.GetWsgVelocity.doc)
       .def("SetWsgVelocity", &ManipulationStation<T>::SetWsgVelocity,
-           doc.ManipulationStation.SetWsgVelocity.doc)
+          doc.ManipulationStation.SetWsgVelocity.doc)
       .def("get_camera_poses_in_world",
-           &ManipulationStation<T>::get_camera_poses_in_world,
-           py_reference_internal,
-           doc.ManipulationStation.get_camera_poses_in_world.doc)
+          &ManipulationStation<T>::get_camera_poses_in_world,
+          py_reference_internal,
+          doc.ManipulationStation.get_camera_poses_in_world.doc)
       .def("get_camera_names", &ManipulationStation<T>::get_camera_names,
-           doc.ManipulationStation.get_camera_names.doc);
+          doc.ManipulationStation.get_camera_names.doc);
 
   py::class_<ManipulationStationHardwareInterface, Diagram<double>>(
       m, "ManipulationStationHardwareInterface")
       .def(py::init<const std::vector<std::string>>(),
-           py::arg("camera_names") = std::vector<std::string>{},
-           doc.ManipulationStationHardwareInterface.ctor.doc_1args)
+          py::arg("camera_names") = std::vector<std::string>{},
+          doc.ManipulationStationHardwareInterface.ctor.doc_1args)
       .def("Connect", &ManipulationStationHardwareInterface::Connect,
-           py::arg("wait_for_cameras") = true,
-           doc.ManipulationStationHardwareInterface.Connect.doc)
+          py::arg("wait_for_cameras") = true,
+          doc.ManipulationStationHardwareInterface.Connect.doc)
       .def("get_controller_plant",
-           &ManipulationStationHardwareInterface::get_controller_plant,
-           py_reference_internal,
-           doc.ManipulationStationHardwareInterface.get_controller_plant.doc)
+          &ManipulationStationHardwareInterface::get_controller_plant,
+          py_reference_internal,
+          doc.ManipulationStationHardwareInterface.get_controller_plant.doc)
       .def("get_camera_names",
-           &ManipulationStationHardwareInterface::get_camera_names,
-           py_reference_internal,
-           doc.ManipulationStationHardwareInterface.get_camera_names.doc);
+          &ManipulationStationHardwareInterface::get_camera_names,
+          py_reference_internal,
+          doc.ManipulationStationHardwareInterface.get_camera_names.doc);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/examples/pendulum_py.cc
+++ b/bindings/pydrake/examples/pendulum_py.cc
@@ -31,46 +31,46 @@ PYBIND11_MODULE(pendulum, m) {
   // conversion.
   using T = double;
 
-  py::class_<PendulumPlant<T>, LeafSystem<T>>(m, "PendulumPlant",
-                                              doc.PendulumPlant.doc)
+  py::class_<PendulumPlant<T>, LeafSystem<T>>(
+      m, "PendulumPlant", doc.PendulumPlant.doc)
       .def(py::init<>(), doc.PendulumPlant.ctor.doc_3);
 
   // TODO(russt): Remove custom bindings once #8096 is resolved.
-  py::class_<PendulumInput<T>, BasicVector<T>>(m, "PendulumInput",
-                                               doc.PendulumInput.doc)
+  py::class_<PendulumInput<T>, BasicVector<T>>(
+      m, "PendulumInput", doc.PendulumInput.doc)
       .def(py::init<>(), doc.PendulumInput.ctor.doc_0args)
       .def("tau", &PendulumInput<T>::tau, doc.PendulumInput.tau.doc)
-      .def("set_tau", &PendulumInput<T>::set_tau,
-           doc.PendulumInput.set_tau.doc);
+      .def(
+          "set_tau", &PendulumInput<T>::set_tau, doc.PendulumInput.set_tau.doc);
 
-  py::class_<PendulumParams<T>, BasicVector<T>>(m, "PendulumParams",
-                                                doc.PendulumParams.doc)
+  py::class_<PendulumParams<T>, BasicVector<T>>(
+      m, "PendulumParams", doc.PendulumParams.doc)
       .def(py::init<>(), doc.PendulumParams.ctor.doc_0args)
       .def("mass", &PendulumParams<T>::mass, doc.PendulumParams.mass.doc)
       .def("length", &PendulumParams<T>::length, doc.PendulumParams.length.doc)
       .def("damping", &PendulumParams<T>::damping,
-           doc.PendulumParams.damping.doc)
+          doc.PendulumParams.damping.doc)
       .def("gravity", &PendulumParams<T>::gravity,
-           doc.PendulumParams.gravity.doc)
+          doc.PendulumParams.gravity.doc)
       .def("set_mass", &PendulumParams<T>::set_mass,
-           doc.PendulumParams.set_mass.doc)
+          doc.PendulumParams.set_mass.doc)
       .def("set_length", &PendulumParams<T>::set_length,
-           doc.PendulumParams.set_length.doc)
+          doc.PendulumParams.set_length.doc)
       .def("set_damping", &PendulumParams<T>::set_damping,
-           doc.PendulumParams.set_damping.doc)
+          doc.PendulumParams.set_damping.doc)
       .def("set_gravity", &PendulumParams<T>::set_gravity,
-           doc.PendulumParams.set_gravity.doc);
+          doc.PendulumParams.set_gravity.doc);
 
-  py::class_<PendulumState<T>, BasicVector<T>>(m, "PendulumState",
-                                               doc.PendulumState.doc)
+  py::class_<PendulumState<T>, BasicVector<T>>(
+      m, "PendulumState", doc.PendulumState.doc)
       .def(py::init<>(), doc.PendulumState.ctor.doc_0args)
       .def("theta", &PendulumState<T>::theta, doc.PendulumState.theta.doc)
       .def("thetadot", &PendulumState<T>::thetadot,
-           doc.PendulumState.thetadot.doc)
+          doc.PendulumState.thetadot.doc)
       .def("set_theta", &PendulumState<T>::set_theta,
-           doc.PendulumState.set_theta.doc)
+          doc.PendulumState.set_theta.doc)
       .def("set_thetadot", &PendulumState<T>::set_thetadot,
-           doc.PendulumState.set_thetadot.doc);
+          doc.PendulumState.set_thetadot.doc);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/examples/rimless_wheel_py.cc
+++ b/bindings/pydrake/examples/rimless_wheel_py.cc
@@ -26,46 +26,46 @@ PYBIND11_MODULE(rimless_wheel, m) {
   // conversion.
   using T = double;
 
-  py::class_<RimlessWheel<T>, LeafSystem<T>>(m, "RimlessWheel",
-                                             doc.RimlessWheel.doc)
+  py::class_<RimlessWheel<T>, LeafSystem<T>>(
+      m, "RimlessWheel", doc.RimlessWheel.doc)
       .def(py::init<>(), doc.RimlessWheel.ctor.doc_3);
 
   // TODO(russt): Remove custom bindings once #8096 is resolved.
-  py::class_<RimlessWheelParams<T>, BasicVector<T>>(m, "RimlessWheelParams",
-                                                    doc.RimlessWheelParams.doc)
+  py::class_<RimlessWheelParams<T>, BasicVector<T>>(
+      m, "RimlessWheelParams", doc.RimlessWheelParams.doc)
       .def(py::init<>(), doc.RimlessWheelParams.ctor.doc_0args)
-      .def("mass", &RimlessWheelParams<T>::mass,
-           doc.RimlessWheelParams.mass.doc)
+      .def(
+          "mass", &RimlessWheelParams<T>::mass, doc.RimlessWheelParams.mass.doc)
       .def("length", &RimlessWheelParams<T>::length,
-           doc.RimlessWheelParams.length.doc)
+          doc.RimlessWheelParams.length.doc)
       .def("gravity", &RimlessWheelParams<T>::gravity,
-           doc.RimlessWheelParams.gravity.doc)
+          doc.RimlessWheelParams.gravity.doc)
       .def("number_of_spokes", &RimlessWheelParams<T>::number_of_spokes,
-           doc.RimlessWheelParams.number_of_spokes.doc)
+          doc.RimlessWheelParams.number_of_spokes.doc)
       .def("slope", &RimlessWheelParams<T>::slope,
-           doc.RimlessWheelParams.slope.doc)
+          doc.RimlessWheelParams.slope.doc)
       .def("set_mass", &RimlessWheelParams<T>::set_mass,
-           doc.RimlessWheelParams.set_mass.doc)
+          doc.RimlessWheelParams.set_mass.doc)
       .def("set_length", &RimlessWheelParams<T>::set_length,
-           doc.RimlessWheelParams.set_length.doc)
+          doc.RimlessWheelParams.set_length.doc)
       .def("set_gravity", &RimlessWheelParams<T>::set_gravity,
-           doc.RimlessWheelParams.set_gravity.doc)
+          doc.RimlessWheelParams.set_gravity.doc)
       .def("set_number_of_spokes", &RimlessWheelParams<T>::set_number_of_spokes,
-           doc.RimlessWheelParams.set_number_of_spokes.doc)
+          doc.RimlessWheelParams.set_number_of_spokes.doc)
       .def("set_slope", &RimlessWheelParams<T>::set_slope,
-           doc.RimlessWheelParams.set_slope.doc);
+          doc.RimlessWheelParams.set_slope.doc);
 
   py::class_<RimlessWheelContinuousState<T>, BasicVector<T>>(
       m, "RimlessWheelContinuousState", doc.RimlessWheelContinuousState.doc)
       .def(py::init<>(), doc.RimlessWheelContinuousState.ctor.doc_0args)
       .def("theta", &RimlessWheelContinuousState<T>::theta,
-           doc.RimlessWheelContinuousState.theta.doc)
+          doc.RimlessWheelContinuousState.theta.doc)
       .def("thetadot", &RimlessWheelContinuousState<T>::thetadot,
-           doc.RimlessWheelContinuousState.thetadot.doc)
+          doc.RimlessWheelContinuousState.thetadot.doc)
       .def("set_theta", &RimlessWheelContinuousState<T>::set_theta,
-           doc.RimlessWheelContinuousState.set_theta.doc)
+          doc.RimlessWheelContinuousState.set_theta.doc)
       .def("set_thetadot", &RimlessWheelContinuousState<T>::set_thetadot,
-           doc.RimlessWheelContinuousState.set_thetadot.doc);
+          doc.RimlessWheelContinuousState.set_thetadot.doc);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/examples/van_der_pol_py.cc
+++ b/bindings/pydrake/examples/van_der_pol_py.cc
@@ -23,8 +23,8 @@ PYBIND11_MODULE(van_der_pol, m) {
   // conversion.
   using T = double;
 
-  py::class_<VanDerPolOscillator<T>, LeafSystem<T>>(m, "VanDerPolOscillator",
-                                                    doc.VanDerPolOscillator.doc)
+  py::class_<VanDerPolOscillator<T>, LeafSystem<T>>(
+      m, "VanDerPolOscillator", doc.VanDerPolOscillator.doc)
       .def(py::init<>(), doc.VanDerPolOscillator.ctor.doc_3);
 }
 

--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -28,13 +28,13 @@ void BindIdentifier(py::module m, const std::string& name) {
   py::handle cls_handle = cls;
   cls  // BR
       .def(py::init([cls_handle]() {
-             WarnDeprecated(
-                 py::str("The constructor for {} in Python is deprecated. "
-                         "Use `get_new_id()` if necessary.")
-                     .format(cls_handle));
-             return Class{};
-           }),
-           cls_doc.ctor.doc_0args)
+        WarnDeprecated(
+            py::str("The constructor for {} in Python is deprecated. "
+                    "Use `get_new_id()` if necessary.")
+                .format(cls_handle));
+        return Class{};
+      }),
+          cls_doc.ctor.doc_0args)
       .def("get_value", &Class::get_value, cls_doc.get_value.doc)
       .def("is_valid", &Class::is_valid, cls_doc.is_valid.doc)
       .def(py::self == py::self)
@@ -54,72 +54,71 @@ PYBIND11_MODULE(geometry, m) {
   BindIdentifier<GeometryId>(m, "GeometryId");
 
   py::module::import("pydrake.systems.framework");
-  py::class_<SceneGraphInspector<T>>(m, "SceneGraphInspector",
-                                     doc.SceneGraphInspector.doc)
+  py::class_<SceneGraphInspector<T>>(
+      m, "SceneGraphInspector", doc.SceneGraphInspector.doc)
       .def("GetFrameId", &SceneGraphInspector<T>::GetFrameId,
-           py::arg("geometry_id"), doc.SceneGraphInspector.GetFrameId.doc);
+          py::arg("geometry_id"), doc.SceneGraphInspector.GetFrameId.doc);
 
   py::class_<SceneGraph<T>, LeafSystem<T>>(m, "SceneGraph", doc.SceneGraph.doc)
       .def(py::init<>(), doc.SceneGraph.ctor.doc_4)
       .def("get_source_pose_port", &SceneGraph<T>::get_source_pose_port,
-           py_reference_internal, doc.SceneGraph.get_source_pose_port.doc)
+          py_reference_internal, doc.SceneGraph.get_source_pose_port.doc)
       .def("get_pose_bundle_output_port",
-           &SceneGraph<T>::get_pose_bundle_output_port, py_reference_internal,
-           doc.SceneGraph.get_pose_bundle_output_port.doc)
+          &SceneGraph<T>::get_pose_bundle_output_port, py_reference_internal,
+          doc.SceneGraph.get_pose_bundle_output_port.doc)
       .def("get_query_output_port", &SceneGraph<T>::get_query_output_port,
-           py_reference_internal, doc.SceneGraph.get_query_output_port.doc)
+          py_reference_internal, doc.SceneGraph.get_query_output_port.doc)
       .def("RegisterSource",
-           py::overload_cast<const std::string&>(  // BR
-               &SceneGraph<T>::RegisterSource),
-           py::arg("name") = "", doc.SceneGraph.RegisterSource.doc);
+          py::overload_cast<const std::string&>(  // BR
+              &SceneGraph<T>::RegisterSource),
+          py::arg("name") = "", doc.SceneGraph.RegisterSource.doc);
 
   py::class_<QueryObject<T>>(m, "QueryObject", doc.QueryObject.doc)
       .def("inspector", &QueryObject<T>::inspector, py_reference_internal,
-           doc.QueryObject.inspector.doc)
+          doc.QueryObject.inspector.doc)
       .def("ComputePointPairPenetration",
-           &QueryObject<T>::ComputePointPairPenetration,
-           doc.QueryObject.ComputePointPairPenetration.doc);
+          &QueryObject<T>::ComputePointPairPenetration,
+          doc.QueryObject.ComputePointPairPenetration.doc);
   pysystems::AddValueInstantiation<QueryObject<T>>(m);
 
   py::module::import("pydrake.systems.lcm");
   m.def("ConnectDrakeVisualizer",
-        py::overload_cast<systems::DiagramBuilder<double>*,
-                          const SceneGraph<double>&, lcm::DrakeLcmInterface*>(
-            &ConnectDrakeVisualizer),
-        py::arg("builder"), py::arg("scene_graph"), py::arg("lcm") = nullptr,
-        // Keep alive, ownership: `return` keeps `builder` alive.
-        py::keep_alive<0, 1>(),
-        // TODO(eric.cousineau): Figure out why this is necessary (#9398).
-        py_reference, doc.ConnectDrakeVisualizer.doc_3args);
+      py::overload_cast<systems::DiagramBuilder<double>*,
+          const SceneGraph<double>&, lcm::DrakeLcmInterface*>(
+          &ConnectDrakeVisualizer),
+      py::arg("builder"), py::arg("scene_graph"), py::arg("lcm") = nullptr,
+      // Keep alive, ownership: `return` keeps `builder` alive.
+      py::keep_alive<0, 1>(),
+      // TODO(eric.cousineau): Figure out why this is necessary (#9398).
+      py_reference, doc.ConnectDrakeVisualizer.doc_3args);
   m.def("ConnectDrakeVisualizer",
-        py::overload_cast<
-            systems::DiagramBuilder<double>*, const SceneGraph<double>&,
-            const systems::OutputPort<double>&, lcm::DrakeLcmInterface*>(
-            &ConnectDrakeVisualizer),
-        py::arg("builder"), py::arg("scene_graph"),
-        py::arg("pose_bundle_output_port"), py::arg("lcm") = nullptr,
-        // Keep alive, ownership: `return` keeps `builder` alive.
-        py::keep_alive<0, 1>(),
-        // TODO(eric.cousineau): Figure out why this is necessary (#9398).
-        py_reference, doc.ConnectDrakeVisualizer.doc_4args);
+      py::overload_cast<systems::DiagramBuilder<double>*,
+          const SceneGraph<double>&, const systems::OutputPort<double>&,
+          lcm::DrakeLcmInterface*>(&ConnectDrakeVisualizer),
+      py::arg("builder"), py::arg("scene_graph"),
+      py::arg("pose_bundle_output_port"), py::arg("lcm") = nullptr,
+      // Keep alive, ownership: `return` keeps `builder` alive.
+      py::keep_alive<0, 1>(),
+      // TODO(eric.cousineau): Figure out why this is necessary (#9398).
+      py_reference, doc.ConnectDrakeVisualizer.doc_4args);
   m.def("DispatchLoadMessage", &DispatchLoadMessage, py::arg("scene_graph"),
-        py::arg("lcm"), doc.DispatchLoadMessage.doc);
+      py::arg("lcm"), doc.DispatchLoadMessage.doc);
 
   // PenetrationAsPointPair
   py::class_<PenetrationAsPointPair<T>>(m, "PenetrationAsPointPair")
       .def(py::init<>(), doc.PenetrationAsPointPair.ctor.doc_0args)
       .def_readwrite("id_A", &PenetrationAsPointPair<T>::id_A,
-                     doc.PenetrationAsPointPair.id_A.doc)
+          doc.PenetrationAsPointPair.id_A.doc)
       .def_readwrite("id_B", &PenetrationAsPointPair<T>::id_B,
-                     doc.PenetrationAsPointPair.id_B.doc)
+          doc.PenetrationAsPointPair.id_B.doc)
       .def_readwrite("p_WCa", &PenetrationAsPointPair<T>::p_WCa,
-                     doc.PenetrationAsPointPair.p_WCa.doc)
+          doc.PenetrationAsPointPair.p_WCa.doc)
       .def_readwrite("p_WCb", &PenetrationAsPointPair<T>::p_WCb,
-                     doc.PenetrationAsPointPair.p_WCb.doc)
+          doc.PenetrationAsPointPair.p_WCb.doc)
       .def_readwrite("nhat_BA_W", &PenetrationAsPointPair<T>::nhat_BA_W,
-                     doc.PenetrationAsPointPair.nhat_BA_W.doc)
+          doc.PenetrationAsPointPair.nhat_BA_W.doc)
       .def_readwrite("depth", &PenetrationAsPointPair<T>::depth,
-                     doc.PenetrationAsPointPair.depth.doc);
+          doc.PenetrationAsPointPair.depth.doc);
 }
 
 }  // namespace

--- a/bindings/pydrake/lcm_py.cc
+++ b/bindings/pydrake/lcm_py.cc
@@ -30,16 +30,16 @@ PYBIND11_MODULE(lcm, m) {
         // N.B. We do not bind `Subscribe` as multi-threading from C++ may
         // wreak havoc on the Python GIL with a callback.
         .def("Publish",
-             [](Class* self, const std::string& channel, py::bytes buffer,
+            [](Class* self, const std::string& channel, py::bytes buffer,
                 optional<double> time_sec) {
-               // TODO(eric.cousineau): See if there is a way to extra the raw
-               // bytes from `buffer` without copying.
-               std::string str = buffer;
-               self->Publish(channel, str.data(), str.size(), time_sec);
-             },
-             py::arg("channel"), py::arg("buffer"),
-             py::arg("time_sec") = py::none(),
-             doc.DrakeLcmInterface.Publish.doc);
+              // TODO(eric.cousineau): See if there is a way to extra the raw
+              // bytes from `buffer` without copying.
+              std::string str = buffer;
+              self->Publish(channel, str.data(), str.size(), time_sec);
+            },
+            py::arg("channel"), py::arg("buffer"),
+            py::arg("time_sec") = py::none(),
+            doc.DrakeLcmInterface.Publish.doc);
   }
 
   {
@@ -47,43 +47,42 @@ PYBIND11_MODULE(lcm, m) {
     py::class_<Class, DrakeLcmInterface>(m, "DrakeLcm", doc.DrakeLcm.doc)
         .def(py::init<>(), doc.DrakeLcm.ctor.doc_0args)
         .def("StartReceiveThread", &Class::StartReceiveThread,
-             doc.DrakeLcm.StartReceiveThread.doc)
+            doc.DrakeLcm.StartReceiveThread.doc)
         .def("StopReceiveThread", &Class::StopReceiveThread,
-             doc.DrakeLcm.StopReceiveThread.doc);
+            doc.DrakeLcm.StopReceiveThread.doc);
     // TODO(eric.cousineau): Add remaining methods.
   }
 
   {
     using Class = DrakeMockLcm;
-    py::class_<Class, DrakeLcmInterface>(m, "DrakeMockLcm",
-                                         doc.DrakeMockLcm.doc)
+    py::class_<Class, DrakeLcmInterface>(
+        m, "DrakeMockLcm", doc.DrakeMockLcm.doc)
         .def(py::init<>(), doc.DrakeMockLcm.ctor.doc_0args)
         .def("Subscribe",
-             [](Class* self, const std::string& channel,
+            [](Class* self, const std::string& channel,
                 PyHandlerFunction handler) {
-               self->Subscribe(channel, [handler](const void* data, int size) {
-                 handler(py::bytes(static_cast<const char*>(data), size));
-               });
-             },
-             py::arg("channel"), py::arg("handler"),
-             doc.DrakeMockLcm.Subscribe.  // BR
-             doc)
+              self->Subscribe(channel, [handler](const void* data, int size) {
+                handler(py::bytes(static_cast<const char*>(data), size));
+              });
+            },
+            py::arg("channel"), py::arg("handler"),
+            doc.DrakeMockLcm.Subscribe.doc)
         .def("InduceSubscriberCallback",
-             [](Class* self, const std::string& channel, py::bytes buffer) {
-               std::string str = buffer;
-               self->InduceSubscriberCallback(channel, str.data(), str.size());
-             },
-             py::arg("channel"), py::arg("buffer"),
-             doc.DrakeMockLcm.InduceSubscriberCallback.doc)
+            [](Class* self, const std::string& channel, py::bytes buffer) {
+              std::string str = buffer;
+              self->InduceSubscriberCallback(channel, str.data(), str.size());
+            },
+            py::arg("channel"), py::arg("buffer"),
+            doc.DrakeMockLcm.InduceSubscriberCallback.doc)
         .def("get_last_published_message",
-             [](const Class* self, const std::string& channel) {
-               const std::vector<uint8_t>& bytes =
-                   self->get_last_published_message(channel);
-               return py::bytes(reinterpret_cast<const char*>(bytes.data()),
-                                bytes.size());
-             },
-             py::arg("channel"),
-             doc.DrakeMockLcm.get_last_published_message.doc);
+            [](const Class* self, const std::string& channel) {
+              const std::vector<uint8_t>& bytes =
+                  self->get_last_published_message(channel);
+              return py::bytes(
+                  reinterpret_cast<const char*>(bytes.data()), bytes.size());
+            },
+            py::arg("channel"),
+            doc.DrakeMockLcm.get_last_published_message.doc);
     // TODO(eric.cousineau): Add remaining methods.
   }
 }

--- a/bindings/pydrake/maliput/api_py.cc
+++ b/bindings/pydrake/maliput/api_py.cc
@@ -31,44 +31,44 @@ PYBIND11_MODULE(api, m) {
 
   py::class_<GeoPosition>(m, "GeoPosition", doc.GeoPositionT.doc)
       .def(py::init<double, double, double>(), py::arg("x"), py::arg("y"),
-           py::arg("z"), doc.GeoPositionT.ctor.doc_3args)
+          py::arg("z"), doc.GeoPositionT.ctor.doc_3args)
       .def("xyz", &GeoPosition::xyz, py_reference_internal,
-           doc.GeoPositionT.xyz.doc);
+          doc.GeoPositionT.xyz.doc);
 
   py::class_<LanePosition>(m, "LanePosition", doc.LanePositionT.doc)
       .def(py::init<double, double, double>(), py::arg("s"), py::arg("r"),
-           py::arg("h"), doc.LanePositionT.ctor.doc_3args)
+          py::arg("h"), doc.LanePositionT.ctor.doc_3args)
       .def("srh", &LanePosition::srh, py_reference_internal,
-           doc.LanePositionT.srh.doc);
+          doc.LanePositionT.srh.doc);
 
-  py::class_<RoadPosition> road_position(m, "RoadPosition",
-                                         doc.RoadPosition.doc);
+  py::class_<RoadPosition> road_position(
+      m, "RoadPosition", doc.RoadPosition.doc);
   road_position  // BR
       .def(py::init<>(), doc.RoadPosition.ctor.doc_0args)
       .def(py::init<const Lane*, const LanePosition&>(), py::arg("lane"),
-           py::arg("pos"),
-           // Keep alive, reference: `self` keeps `Lane*` alive.
-           py::keep_alive<1, 2>(), doc.RoadPosition.ctor.doc_2args)
+          py::arg("pos"),
+          // Keep alive, reference: `self` keeps `Lane*` alive.
+          py::keep_alive<1, 2>(), doc.RoadPosition.ctor.doc_2args)
       .def_readwrite("pos", &RoadPosition::pos, doc.RoadPosition.pos.doc);
   // TODO(m-chaturvedi) Add doc when typedefs are parsed (#9599)
   DefReadWriteKeepAlive(&road_position, "lane", &RoadPosition::lane);
 
   py::class_<Rotation>(m, "Rotation", doc.Rotation.doc)
-      .def("quat", &Rotation::quat, py_reference_internal,
-           doc.Rotation.quat.doc)
+      .def(
+          "quat", &Rotation::quat, py_reference_internal, doc.Rotation.quat.doc)
       .def("rpy", &Rotation::rpy, doc.Rotation.rpy.doc);
 
   py::class_<RoadGeometry>(m, "RoadGeometry", doc.RoadGeometry.doc)
       .def("num_junctions", &RoadGeometry::num_junctions,
-           doc.RoadGeometry.num_junctions.doc)
+          doc.RoadGeometry.num_junctions.doc)
       .def("junction", &RoadGeometry::junction, py_reference_internal,
-           doc.RoadGeometry.junction.doc);
+          doc.RoadGeometry.junction.doc);
 
   py::class_<Junction>(m, "Junction", doc.Junction.doc)
       .def("num_segments", &Junction::num_segments,
-           doc.Junction.num_segments.doc)
+          doc.Junction.num_segments.doc)
       .def("segment", &Junction::segment, py_reference_internal,
-           doc.Junction.segment.doc);
+          doc.Junction.segment.doc);
 
   py::class_<Segment>(m, "Segment", doc.Segment.doc)
       .def("num_lanes", &Segment::num_lanes, doc.Segment.num_lanes.doc)

--- a/bindings/pydrake/maliput/dragway_py.cc
+++ b/bindings/pydrake/maliput/dragway_py.cc
@@ -23,17 +23,17 @@ PYBIND11_MODULE(dragway, m) {
       m, "RoadGeometry", doc.dragway.RoadGeometry.doc);
 
   m.def("create_dragway",
-        [](api::RoadGeometryId road_id, int num_lanes, double length,
-           double lane_width, double shoulder_width, double maximum_height,
-           double linear_tolerance, double angular_tolerance) {
-          return make_unique<dragway::RoadGeometry>(
-              road_id, num_lanes, length, lane_width, shoulder_width,
-              maximum_height, linear_tolerance, angular_tolerance);
-        },
-        py::arg("road_id"), py::arg("num_lanes"), py::arg("length"),
-        py::arg("lane_width"), py::arg("shoulder_width"),
-        py::arg("maximum_height"), py::arg("linear_tolerance"),
-        py::arg("angular_tolerance"), doc.dragway.RoadGeometry.ctor.doc_8args);
+      [](api::RoadGeometryId road_id, int num_lanes, double length,
+          double lane_width, double shoulder_width, double maximum_height,
+          double linear_tolerance, double angular_tolerance) {
+        return make_unique<dragway::RoadGeometry>(road_id, num_lanes, length,
+            lane_width, shoulder_width, maximum_height, linear_tolerance,
+            angular_tolerance);
+      },
+      py::arg("road_id"), py::arg("num_lanes"), py::arg("length"),
+      py::arg("lane_width"), py::arg("shoulder_width"),
+      py::arg("maximum_height"), py::arg("linear_tolerance"),
+      py::arg("angular_tolerance"), doc.dragway.RoadGeometry.ctor.doc_8args);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/manipulation/planner_py.cc
+++ b/bindings/pydrake/manipulation/planner_py.cc
@@ -14,32 +14,32 @@ PYBIND11_MODULE(planner, m) {
   m.doc() = "Tools for manipulation planning.";
   constexpr auto& doc = pydrake_doc.drake.manipulation.planner;
 
-  py::enum_<DifferentialInverseKinematicsStatus>(
-      m, "DifferentialInverseKinematicsStatus",
+  py::enum_<DifferentialInverseKinematicsStatus>(m,
+      "DifferentialInverseKinematicsStatus",
       doc.DifferentialInverseKinematicsStatus.doc)
       .value("kSolutionFound",
-             DifferentialInverseKinematicsStatus::kSolutionFound,
-             doc.DifferentialInverseKinematicsStatus.kSolutionFound.doc)
+          DifferentialInverseKinematicsStatus::kSolutionFound,
+          doc.DifferentialInverseKinematicsStatus.kSolutionFound.doc)
       .value("kNoSolutionFound",
-             DifferentialInverseKinematicsStatus::kNoSolutionFound,
-             doc.DifferentialInverseKinematicsStatus.kNoSolutionFound.doc)
+          DifferentialInverseKinematicsStatus::kNoSolutionFound,
+          doc.DifferentialInverseKinematicsStatus.kNoSolutionFound.doc)
       .value("kStuck", DifferentialInverseKinematicsStatus::kStuck,
-             doc.DifferentialInverseKinematicsStatus.kStuck.doc);
+          doc.DifferentialInverseKinematicsStatus.kStuck.doc);
 
   {
     using Class = manipulation::planner::DifferentialInverseKinematicsResult;
     constexpr auto& class_doc = doc.DifferentialInverseKinematicsResult;
     py::class_<Class> cls(m, "DifferentialInverseKinematicsResult",
-                          doc.DifferentialInverseKinematicsResult.doc);
+        doc.DifferentialInverseKinematicsResult.doc);
 
     // TODO(m-chaturvedi) Add Pybind11 documentation.
     cls.def(py::init([](optional<VectorX<double>> joint_velocities,
-                        DifferentialInverseKinematicsStatus status) {
-              return Class{joint_velocities, status};
-            }),
-            py::arg("joint_velocities"), py::arg("status"))
+                         DifferentialInverseKinematicsStatus status) {
+         return Class{joint_velocities, status};
+       }),
+           py::arg("joint_velocities"), py::arg("status"))
         .def_readwrite("joint_velocities", &Class::joint_velocities,
-                       class_doc.joint_velocities.doc)
+            class_doc.joint_velocities.doc)
         .def_readwrite("status", &Class::status, class_doc.status.doc);
   }
   {
@@ -48,89 +48,89 @@ PYBIND11_MODULE(planner, m) {
     constexpr auto& class_doc = doc.DifferentialInverseKinematicsParameters;
 
     py::class_<Class> cls(m, "DifferentialInverseKinematicsParameters",
-                          doc.DifferentialInverseKinematicsParameters.doc);
+        doc.DifferentialInverseKinematicsParameters.doc);
 
     cls.def(py::init([](int num_positions, int num_velocities) {
-              return Class{num_positions, num_velocities};
-            }),
-            py::arg("num_positions") = 0, py::arg("num_velocities") = 0,
-            class_doc.ctor.doc_2args)
+         return Class{num_positions, num_velocities};
+       }),
+           py::arg("num_positions") = 0, py::arg("num_velocities") = 0,
+           class_doc.ctor.doc_2args)
         .def("get_timestep", &Class::get_timestep, class_doc.get_timestep.doc)
         .def("set_timestep", &Class::set_timestep, class_doc.set_timestep.doc)
         .def("get_num_positions", &Class::get_num_positions,
-             class_doc.get_num_positions.doc)
+            class_doc.get_num_positions.doc)
         .def("get_num_velocities", &Class::get_num_velocities,
-             class_doc.get_num_velocities.doc)
+            class_doc.get_num_velocities.doc)
         .def("get_nominal_joint_position", &Class::get_nominal_joint_position,
-             class_doc.get_nominal_joint_position.doc)
+            class_doc.get_nominal_joint_position.doc)
         .def("set_nominal_joint_position", &Class::set_nominal_joint_position,
-             class_doc.set_nominal_joint_position.doc)
+            class_doc.set_nominal_joint_position.doc)
         .def("get_end_effector_velocity_gain",
-             &Class::get_end_effector_velocity_gain,
-             class_doc.get_end_effector_velocity_gain.doc)
+            &Class::get_end_effector_velocity_gain,
+            class_doc.get_end_effector_velocity_gain.doc)
         .def("set_end_effector_velocity_gain",
-             &Class::set_end_effector_velocity_gain,
-             class_doc.set_end_effector_velocity_gain.doc)
+            &Class::set_end_effector_velocity_gain,
+            class_doc.set_end_effector_velocity_gain.doc)
         .def("get_unconstrained_degrees_of_freedom_velocity_limit",
-             &Class::get_unconstrained_degrees_of_freedom_velocity_limit,
-             class_doc.get_unconstrained_degrees_of_freedom_velocity_limit.doc)
+            &Class::get_unconstrained_degrees_of_freedom_velocity_limit,
+            class_doc.get_unconstrained_degrees_of_freedom_velocity_limit.doc)
         .def("set_unconstrained_degrees_of_freedom_velocity_limit",
-             &Class::set_unconstrained_degrees_of_freedom_velocity_limit,
-             class_doc.set_unconstrained_degrees_of_freedom_velocity_limit.doc)
+            &Class::set_unconstrained_degrees_of_freedom_velocity_limit,
+            class_doc.set_unconstrained_degrees_of_freedom_velocity_limit.doc)
         .def("get_joint_position_limits", &Class::get_joint_position_limits,
-             class_doc.get_joint_position_limits.doc)
+            class_doc.get_joint_position_limits.doc)
         .def("set_joint_position_limits", &Class::set_joint_position_limits,
-             class_doc.set_joint_position_limits.doc)
+            class_doc.set_joint_position_limits.doc)
         .def("get_joint_velocity_limits", &Class::get_joint_velocity_limits,
-             class_doc.get_joint_velocity_limits.doc)
+            class_doc.get_joint_velocity_limits.doc)
         .def("set_joint_velocity_limits", &Class::set_joint_velocity_limits,
-             class_doc.set_joint_velocity_limits.doc)
+            class_doc.set_joint_velocity_limits.doc)
         .def("get_joint_acceleration_limits",
-             &Class::get_joint_acceleration_limits,
-             class_doc.get_joint_acceleration_limits.doc)
+            &Class::get_joint_acceleration_limits,
+            class_doc.get_joint_acceleration_limits.doc)
         .def("set_joint_acceleration_limits",
-             &Class::set_joint_acceleration_limits,
-             class_doc.set_joint_acceleration_limits.doc);
+            &Class::set_joint_acceleration_limits,
+            class_doc.set_joint_acceleration_limits.doc);
   }
 
   m.def("DoDifferentialInverseKinematics",
-        [](const Eigen::VectorXd& q_current, const Eigen::VectorXd& v_current,
-           const Eigen::VectorXd& V, const Eigen::MatrixXd& J,
-           const manipulation::planner::DifferentialInverseKinematicsParameters&
-               parameters) {
-          return manipulation::planner::DoDifferentialInverseKinematics(
-              q_current, v_current, V, J, parameters);
-        },
-        py::arg("q_current"), py::arg("v_current"), py::arg("V"), py::arg("J"),
-        py::arg("parameters"), doc.DoDifferentialInverseKinematics.doc);
+      [](const Eigen::VectorXd& q_current, const Eigen::VectorXd& v_current,
+          const Eigen::VectorXd& V, const Eigen::MatrixXd& J,
+          const manipulation::planner::DifferentialInverseKinematicsParameters&
+              parameters) {
+        return manipulation::planner::DoDifferentialInverseKinematics(
+            q_current, v_current, V, J, parameters);
+      },
+      py::arg("q_current"), py::arg("v_current"), py::arg("V"), py::arg("J"),
+      py::arg("parameters"), doc.DoDifferentialInverseKinematics.doc);
 
   m.def("DoDifferentialInverseKinematics",
-        [](const multibody::multibody_plant::MultibodyPlant<double>& robot,
-           const systems::Context<double>& context,
-           const Vector6<double>& V_WE_desired,
-           const multibody::Frame<double>& frame_E,
-           const manipulation::planner::DifferentialInverseKinematicsParameters&
-               parameters) {
-          return manipulation::planner::DoDifferentialInverseKinematics(
-              robot, context, V_WE_desired, frame_E, parameters);
-        },
-        py::arg("robot"), py::arg("context"), py::arg("V_WE_desired"),
-        py::arg("frame_E"), py::arg("parameters"),
-        doc.DoDifferentialInverseKinematics.doc_4);
+      [](const multibody::multibody_plant::MultibodyPlant<double>& robot,
+          const systems::Context<double>& context,
+          const Vector6<double>& V_WE_desired,
+          const multibody::Frame<double>& frame_E,
+          const manipulation::planner::DifferentialInverseKinematicsParameters&
+              parameters) {
+        return manipulation::planner::DoDifferentialInverseKinematics(
+            robot, context, V_WE_desired, frame_E, parameters);
+      },
+      py::arg("robot"), py::arg("context"), py::arg("V_WE_desired"),
+      py::arg("frame_E"), py::arg("parameters"),
+      doc.DoDifferentialInverseKinematics.doc_4);
 
   m.def("DoDifferentialInverseKinematics",
-        [](const multibody::multibody_plant::MultibodyPlant<double>& robot,
-           const systems::Context<double>& context,
-           const Isometry3<double>& X_WE_desired,
-           const multibody::Frame<double>& frame_E,
-           const manipulation::planner::DifferentialInverseKinematicsParameters&
-               parameters) {
-          return manipulation::planner::DoDifferentialInverseKinematics(
-              robot, context, X_WE_desired, frame_E, parameters);
-        },
-        py::arg("robot"), py::arg("context"), py::arg("X_WE_desired"),
-        py::arg("frame_E"), py::arg("parameters"),
-        doc.DoDifferentialInverseKinematics.doc_5);
+      [](const multibody::multibody_plant::MultibodyPlant<double>& robot,
+          const systems::Context<double>& context,
+          const Isometry3<double>& X_WE_desired,
+          const multibody::Frame<double>& frame_E,
+          const manipulation::planner::DifferentialInverseKinematicsParameters&
+              parameters) {
+        return manipulation::planner::DoDifferentialInverseKinematics(
+            robot, context, X_WE_desired, frame_E, parameters);
+      },
+      py::arg("robot"), py::arg("context"), py::arg("X_WE_desired"),
+      py::arg("frame_E"), py::arg("parameters"),
+      doc.DoDifferentialInverseKinematics.doc_5);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -31,150 +31,148 @@ PYBIND11_MODULE(math, m) {
   using T = double;
 
   m.def("wrap_to", &wrap_to<T, T>, py::arg("value"), py::arg("low"),
-        py::arg("high"), doc.wrap_to.doc);
+      py::arg("high"), doc.wrap_to.doc);
 
   py::class_<BarycentricMesh<T>>(m, "BarycentricMesh", doc.BarycentricMesh.doc)
       .def(py::init<BarycentricMesh<T>::MeshGrid>(),
-           doc.BarycentricMesh.ctor.doc_1args)
+          doc.BarycentricMesh.ctor.doc_1args)
       .def("get_input_grid", &BarycentricMesh<T>::get_input_grid,
-           doc.BarycentricMesh.get_input_grid.doc)
+          doc.BarycentricMesh.get_input_grid.doc)
       .def("get_input_size", &BarycentricMesh<T>::get_input_size,
-           doc.BarycentricMesh.get_input_size.doc)
+          doc.BarycentricMesh.get_input_size.doc)
       .def("get_num_mesh_points", &BarycentricMesh<T>::get_num_mesh_points,
-           doc.BarycentricMesh.get_num_mesh_points.doc)
+          doc.BarycentricMesh.get_num_mesh_points.doc)
       .def("get_num_interpolants", &BarycentricMesh<T>::get_num_interpolants,
-           doc.BarycentricMesh.get_num_interpolants.doc)
+          doc.BarycentricMesh.get_num_interpolants.doc)
       .def("get_mesh_point",
-           overload_cast_explicit<VectorX<T>, int>(
-               &BarycentricMesh<T>::get_mesh_point),
-           doc.BarycentricMesh.get_mesh_point.doc_1args)
+          overload_cast_explicit<VectorX<T>, int>(
+              &BarycentricMesh<T>::get_mesh_point),
+          doc.BarycentricMesh.get_mesh_point.doc_1args)
       .def("get_all_mesh_points", &BarycentricMesh<T>::get_all_mesh_points,
-           doc.BarycentricMesh.get_all_mesh_points.doc)
+          doc.BarycentricMesh.get_all_mesh_points.doc)
       .def("EvalBarycentricWeights",
-           [](const BarycentricMesh<T>* self,
+          [](const BarycentricMesh<T>* self,
               const Eigen::Ref<const VectorX<T>>& input) {
-             const int n = self->get_num_interpolants();
-             Eigen::VectorXi indices(n);
-             VectorX<T> weights(n);
-             self->EvalBarycentricWeights(input, &indices, &weights);
-             return std::make_pair(indices, weights);
-           },
-           doc.BarycentricMesh.EvalBarycentricWeights.doc)
+            const int n = self->get_num_interpolants();
+            Eigen::VectorXi indices(n);
+            VectorX<T> weights(n);
+            self->EvalBarycentricWeights(input, &indices, &weights);
+            return std::make_pair(indices, weights);
+          },
+          doc.BarycentricMesh.EvalBarycentricWeights.doc)
       .def("Eval",
-           overload_cast_explicit<VectorX<T>,
-                                  const Eigen::Ref<const MatrixX<T>>&,
-                                  const Eigen::Ref<const VectorX<T>>&>(
-               &BarycentricMesh<T>::Eval),
-           doc.BarycentricMesh.Eval.doc_2args)
+          overload_cast_explicit<VectorX<T>,
+              const Eigen::Ref<const MatrixX<T>>&,
+              const Eigen::Ref<const VectorX<T>>&>(&BarycentricMesh<T>::Eval),
+          doc.BarycentricMesh.Eval.doc_2args)
       .def("MeshValuesFrom", &BarycentricMesh<T>::MeshValuesFrom,
-           doc.BarycentricMesh.MeshValuesFrom.doc);
+          doc.BarycentricMesh.MeshValuesFrom.doc);
 
   py::class_<RigidTransform<T>>(m, "RigidTransform", doc.RigidTransform.doc)
       .def(py::init(), doc.RigidTransform.ctor.doc_0args)
       .def(py::init<const RotationMatrix<T>&, const Vector3<T>&>(),
-           py::arg("R"), py::arg("p"), doc.RigidTransform.ctor.doc_2args_R_p)
+          py::arg("R"), py::arg("p"), doc.RigidTransform.ctor.doc_2args_R_p)
       .def(py::init<const RollPitchYaw<T>&, const Vector3<T>&>(),
-           py::arg("rpy"), py::arg("p"),
-           doc.RigidTransform.ctor.doc_2args_rpy_p)
+          py::arg("rpy"), py::arg("p"), doc.RigidTransform.ctor.doc_2args_rpy_p)
       .def(py::init<const Eigen::Quaternion<T>&, const Vector3<T>&>(),
-           py::arg("quaternion"), py::arg("p"),
-           doc.RigidTransform.ctor.doc_2args_quaternion_p)
+          py::arg("quaternion"), py::arg("p"),
+          doc.RigidTransform.ctor.doc_2args_quaternion_p)
       .def(py::init<const Eigen::AngleAxis<T>&, const Vector3<T>&>(),
-           py::arg("theta_lambda"), py::arg("p"),
-           doc.RigidTransform.ctor.doc_2args_theta_lambda_p)
+          py::arg("theta_lambda"), py::arg("p"),
+          doc.RigidTransform.ctor.doc_2args_theta_lambda_p)
       .def(py::init<const RotationMatrix<T>&>(), py::arg("R"),
-           doc.RigidTransform.ctor.doc_1args_R)
+          doc.RigidTransform.ctor.doc_1args_R)
       .def(py::init<const Vector3<T>&>(), py::arg("p"),
-           doc.RigidTransform.ctor.doc_1args_p)
+          doc.RigidTransform.ctor.doc_1args_p)
       .def(py::init<const Isometry3<T>&>(), py::arg("pose"),
-           doc.RigidTransform.ctor.doc_1args_pose)
+          doc.RigidTransform.ctor.doc_1args_pose)
       .def("set", &RigidTransform<T>::set, py::arg("R"), py::arg("p"),
-           doc.RigidTransform.set.doc)
+          doc.RigidTransform.set.doc)
       .def("SetFromIsometry3", &RigidTransform<T>::SetFromIsometry3,
-           py::arg("pose"), doc.RigidTransform.SetFromIsometry3.doc)
+          py::arg("pose"), doc.RigidTransform.SetFromIsometry3.doc)
       .def_static("Identity", &RigidTransform<T>::Identity,
-                  doc.RigidTransform.Identity.doc)
+          doc.RigidTransform.Identity.doc)
       .def("rotation", &RigidTransform<T>::rotation, py_reference_internal,
-           doc.RigidTransform.rotation.doc)
+          doc.RigidTransform.rotation.doc)
       .def("set_rotation", &RigidTransform<T>::set_rotation, py::arg("R"),
-           doc.RigidTransform.set_rotation.doc)
+          doc.RigidTransform.set_rotation.doc)
       .def("translation", &RigidTransform<T>::translation,
-           py_reference_internal, doc.RigidTransform.translation.doc)
+          py_reference_internal, doc.RigidTransform.translation.doc)
       .def("set_translation", &RigidTransform<T>::set_translation, py::arg("p"),
-           doc.RigidTransform.set_translation.doc)
+          doc.RigidTransform.set_translation.doc)
       .def("GetAsMatrix4", &RigidTransform<T>::GetAsMatrix4,
-           doc.RigidTransform.GetAsMatrix4.doc)
+          doc.RigidTransform.GetAsMatrix4.doc)
       .def("GetAsMatrix34", &RigidTransform<T>::GetAsMatrix34,
-           doc.RigidTransform.GetAsMatrix34.doc)
+          doc.RigidTransform.GetAsMatrix34.doc)
       .def("GetAsIsometry3", &RigidTransform<T>::GetAsIsometry3,
-           doc.RigidTransform.GetAsIsometry3.doc)
+          doc.RigidTransform.GetAsIsometry3.doc)
       .def("SetIdentity", &RigidTransform<T>::SetIdentity,
-           doc.RigidTransform.SetIdentity.doc)
+          doc.RigidTransform.SetIdentity.doc)
       // .def("IsExactlyIdentity", ...)
       // .def("IsIdentityToEpsilon", ...)
       .def("inverse", &RigidTransform<T>::inverse,
-           doc.RigidTransform.inverse.doc)
+          doc.RigidTransform.inverse.doc)
       // TODO(eric.cousineau): Use `matmul` operator once we support Python3.
       .def("multiply",
-           [](const RigidTransform<T>* self, const RigidTransform<T>& other) {
-             return *self * other;
-           },
-           py::arg("other"), doc.RigidTransform.operator_mul.doc_1args_other)
+          [](const RigidTransform<T>* self, const RigidTransform<T>& other) {
+            return *self * other;
+          },
+          py::arg("other"), doc.RigidTransform.operator_mul.doc_1args_other)
       .def("multiply",
-           [](const RigidTransform<T>* self, const Vector3<T>& p_BoQ_B) {
-             return *self * p_BoQ_B;
-           },
-           py::arg("p_BoQ_B"),
-           doc.RigidTransform.operator_mul.doc_1args_p_BoQ_B);
+          [](const RigidTransform<T>* self, const Vector3<T>& p_BoQ_B) {
+            return *self * p_BoQ_B;
+          },
+          py::arg("p_BoQ_B"),
+          doc.RigidTransform.operator_mul.doc_1args_p_BoQ_B);
   // .def("IsNearlyEqualTo", ...)
   // .def("IsExactlyEqualTo", ...)
 
   py::class_<RollPitchYaw<T>>(m, "RollPitchYaw")
       .def(py::init<const Vector3<T>>(), py::arg("rpy"),
-           doc.RollPitchYaw.ctor.doc_1args_rpy)
+          doc.RollPitchYaw.ctor.doc_1args_rpy)
       .def(py::init<const T&, const T&, const T&>(), py::arg("roll"),
-           py::arg("pitch"), py::arg("yaw"),
-           doc.RollPitchYaw.ctor.doc_3args_roll_pitch_yaw)
+          py::arg("pitch"), py::arg("yaw"),
+          doc.RollPitchYaw.ctor.doc_3args_roll_pitch_yaw)
       .def(py::init<const RotationMatrix<T>&>(), py::arg("R"),
-           doc.RollPitchYaw.ctor.doc_1args_R)
+          doc.RollPitchYaw.ctor.doc_1args_R)
       .def(py::init<const Eigen::Quaternion<T>&>(), py::arg("quaternion"),
-           doc.RollPitchYaw.ctor.doc_1args_quaternion)
+          doc.RollPitchYaw.ctor.doc_1args_quaternion)
       .def("vector", &RollPitchYaw<T>::vector, doc.RollPitchYaw.vector.doc)
       .def("roll_angle", &RollPitchYaw<T>::roll_angle,
-           doc.RollPitchYaw.roll_angle.doc)
+          doc.RollPitchYaw.roll_angle.doc)
       .def("pitch_angle", &RollPitchYaw<T>::pitch_angle,
-           doc.RollPitchYaw.pitch_angle.doc)
+          doc.RollPitchYaw.pitch_angle.doc)
       .def("yaw_angle", &RollPitchYaw<T>::yaw_angle,
-           doc.RollPitchYaw.yaw_angle.doc)
+          doc.RollPitchYaw.yaw_angle.doc)
       .def("ToQuaternion", &RollPitchYaw<T>::ToQuaternion,
-           doc.RollPitchYaw.ToQuaternion.doc)
+          doc.RollPitchYaw.ToQuaternion.doc)
       .def("ToRotationMatrix", &RollPitchYaw<T>::ToRotationMatrix,
-           doc.RollPitchYaw.ToRotationMatrix.doc);
+          doc.RollPitchYaw.ToRotationMatrix.doc);
 
   py::class_<RotationMatrix<T>>(m, "RotationMatrix", doc.RotationMatrix.doc)
       .def(py::init(), doc.RotationMatrix.ctor.doc_0args)
       .def(py::init<const Matrix3<T>&>(), py::arg("R"),
-           doc.RotationMatrix.ctor.doc_1args_R)
+          doc.RotationMatrix.ctor.doc_1args_R)
       .def(py::init<Eigen::Quaternion<T>>(), py::arg("quaternion"),
-           doc.RotationMatrix.ctor.doc_1args_quaternion)
+          doc.RotationMatrix.ctor.doc_1args_quaternion)
       .def(py::init<const RollPitchYaw<T>&>(), py::arg("rpy"),
-           doc.RotationMatrix.ctor.doc_1args_rpy)
+          doc.RotationMatrix.ctor.doc_1args_rpy)
       .def("matrix", &RotationMatrix<T>::matrix, doc.RotationMatrix.matrix.doc)
       // Do not define an operator until we have the Python3 `@` operator so
       // that operations are similar to those of arrays.
       .def("multiply",
-           [](const RotationMatrix<T>& self, const RotationMatrix<T>& other) {
-             return self * other;
-           },
-           doc.RotationMatrix.operator_mul.doc_1args_other)
+          [](const RotationMatrix<T>& self, const RotationMatrix<T>& other) {
+            return self * other;
+          },
+          doc.RotationMatrix.operator_mul.doc_1args_other)
       .def("inverse", &RotationMatrix<T>::inverse,
-           doc.RotationMatrix.inverse.doc)
+          doc.RotationMatrix.inverse.doc)
       .def("ToQuaternion",
-           overload_cast_explicit<Eigen::Quaternion<T>>(
-               &RotationMatrix<T>::ToQuaternion),
-           doc.RotationMatrix.ToQuaternion.doc_0args)
+          overload_cast_explicit<Eigen::Quaternion<T>>(
+              &RotationMatrix<T>::ToQuaternion),
+          doc.RotationMatrix.ToQuaternion.doc_0args)
       .def_static("Identity", &RotationMatrix<T>::Identity,
-                  doc.RotationMatrix.Identity.doc);
+          doc.RotationMatrix.Identity.doc);
 
   // General math overloads.
   // N.B. Additional overloads will be added for autodiff, symbolic, etc, by
@@ -200,7 +198,7 @@ PYBIND11_MODULE(math, m) {
       .def("acos", [](double x) { return acos(x); })
       .def("atan", [](double x) { return atan(x); })
       .def("atan2", [](double y, double x) { return atan2(y, x); },
-           py::arg("y"), py::arg("x"))
+          py::arg("y"), py::arg("x"))
       .def("sinh", [](double x) { return sinh(x); })
       .def("cosh", [](double x) { return cosh(x); })
       .def("tanh", [](double x) { return tanh(x); })

--- a/bindings/pydrake/multibody/benchmarks_py.cc
+++ b/bindings/pydrake/multibody/benchmarks_py.cc
@@ -23,21 +23,21 @@ void init_acrobot(py::module m) {
   // `MultibodyTree` is used by `MakeAcrobotPlant`.
   py::module::import("pydrake.multibody.multibody_tree");
 
-  py::class_<AcrobotParameters>(m, "AcrobotParameters",
-                                doc.AcrobotParameters.doc)
+  py::class_<AcrobotParameters>(
+      m, "AcrobotParameters", doc.AcrobotParameters.doc)
       .def(py::init(), doc.AcrobotParameters.doc);
 
   m.def("MakeAcrobotPlant",
-        py::overload_cast<const AcrobotParameters&, bool, SceneGraph<double>*>(
-            &MakeAcrobotPlant),
-        py::arg("default_parameters"), py::arg("finalize"),
-        py::arg("scene_graph") = nullptr, doc.MakeAcrobotPlant.doc);
+      py::overload_cast<const AcrobotParameters&, bool, SceneGraph<double>*>(
+          &MakeAcrobotPlant),
+      py::arg("default_parameters"), py::arg("finalize"),
+      py::arg("scene_graph") = nullptr, doc.MakeAcrobotPlant.doc);
 }
 
 void init_all(py::module m) {
   py::dict vars = m.attr("__dict__");
   py::exec("from pydrake.multibody.benchmarks.acrobot import *", py::globals(),
-           vars);
+      vars);
 }
 
 PYBIND11_MODULE(benchmarks, m) {

--- a/bindings/pydrake/multibody/collision_py.cc
+++ b/bindings/pydrake/multibody/collision_py.cc
@@ -20,11 +20,11 @@ PYBIND11_MODULE(collision, m) {
   py::module::import("pydrake.multibody.shapes");
   py::module::import("pydrake.multibody.rigid_body");
 
-  py::class_<Element, DrakeShapes::Element>(m, "CollisionElement",
-                                            doc.Element.doc)
+  py::class_<Element, DrakeShapes::Element>(
+      m, "CollisionElement", doc.Element.doc)
       .def(py::init<const DrakeShapes::Geometry&, const Eigen::Isometry3d&>(),
-           py::arg("geometry_in"), py::arg("T_element_to_local"),
-           doc.Element.ctor.doc_2args_geometry_T_element_to_local)
+          py::arg("geometry_in"), py::arg("T_element_to_local"),
+          doc.Element.ctor.doc_2args_geometry_T_element_to_local)
       .def("set_body", &Element::set_body, doc.Element.set_body.doc)
       .def("get_body", &Element::get_body, doc.Element.get_body.doc);
 }

--- a/bindings/pydrake/multibody/inverse_kinematics_py.cc
+++ b/bindings/pydrake/multibody/inverse_kinematics_py.cc
@@ -21,33 +21,33 @@ PYBIND11_MODULE(inverse_kinematics, m) {
   py::module::import("pydrake.solvers.mathematicalprogram");
   py::module::import("pydrake.math");
 
-  py::class_<InverseKinematics> ik_cls(m, "InverseKinematics",
-                                       doc.InverseKinematics.doc);
+  py::class_<InverseKinematics> ik_cls(
+      m, "InverseKinematics", doc.InverseKinematics.doc);
   ik_cls.def(py::init<const MultibodyPlant<double>&>(), py::arg("plant"))
       .def("AddPositionConstraint", &InverseKinematics::AddPositionConstraint,
-           py::arg("frameB"), py::arg("p_BQ"), py::arg("frameA"),
-           py::arg("p_AQ_lower"), py::arg("p_AQ_upper"),
-           doc.InverseKinematics.AddPositionConstraint.doc)
+          py::arg("frameB"), py::arg("p_BQ"), py::arg("frameA"),
+          py::arg("p_AQ_lower"), py::arg("p_AQ_upper"),
+          doc.InverseKinematics.AddPositionConstraint.doc)
       .def("AddOrientationConstraint",
-           &InverseKinematics::AddOrientationConstraint, py::arg("frameAbar"),
-           py::arg("R_AbarA"), py::arg("frameBbar"), py::arg("R_BbarB"),
-           py::arg("theta_bound"),
-           doc.InverseKinematics.AddOrientationConstraint.doc)
+          &InverseKinematics::AddOrientationConstraint, py::arg("frameAbar"),
+          py::arg("R_AbarA"), py::arg("frameBbar"), py::arg("R_BbarB"),
+          py::arg("theta_bound"),
+          doc.InverseKinematics.AddOrientationConstraint.doc)
       .def("AddGazeTargetConstraint",
-           &InverseKinematics::AddGazeTargetConstraint, py::arg("frameA"),
-           py::arg("p_AS"), py::arg("n_A"), py::arg("frameB"), py::arg("p_BT"),
-           py::arg("cone_half_angle"),
-           doc.InverseKinematics.AddGazeTargetConstraint.doc)
+          &InverseKinematics::AddGazeTargetConstraint, py::arg("frameA"),
+          py::arg("p_AS"), py::arg("n_A"), py::arg("frameB"), py::arg("p_BT"),
+          py::arg("cone_half_angle"),
+          doc.InverseKinematics.AddGazeTargetConstraint.doc)
       .def("AddAngleBetweenVectorsConstraint",
-           &InverseKinematics::AddAngleBetweenVectorsConstraint,
-           py::arg("frameA"), py::arg("na_A"), py::arg("frameB"),
-           py::arg("nb_B"), py::arg("angle_lower"), py::arg("angle_upper"),
-           doc.InverseKinematics.AddAngleBetweenVectorsConstraint.doc)
+          &InverseKinematics::AddAngleBetweenVectorsConstraint,
+          py::arg("frameA"), py::arg("na_A"), py::arg("frameB"),
+          py::arg("nb_B"), py::arg("angle_lower"), py::arg("angle_upper"),
+          doc.InverseKinematics.AddAngleBetweenVectorsConstraint.doc)
       .def("q", &InverseKinematics::q, doc.InverseKinematics.q.doc)
       .def("prog", &InverseKinematics::prog, py_reference_internal,
-           doc.InverseKinematics.prog.doc)
+          doc.InverseKinematics.prog.doc)
       .def("get_mutable_prog", &InverseKinematics::get_mutable_prog,
-           py_reference_internal, doc.InverseKinematics.get_mutable_prog.doc);
+          py_reference_internal, doc.InverseKinematics.get_mutable_prog.doc);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/multibody/joints_py.cc
+++ b/bindings/pydrake/multibody/joints_py.cc
@@ -19,22 +19,22 @@ PYBIND11_MODULE(joints, m) {
 
   py::class_<DrakeJoint>(m, "DrakeJoint", doc.DrakeJoint.doc)
       .def("get_num_positions", &DrakeJoint::get_num_positions,
-           doc.DrakeJoint.get_num_positions.doc)
+          doc.DrakeJoint.get_num_positions.doc)
       .def("get_name", &DrakeJoint::get_name, doc.DrakeJoint.get_name.doc);
 
-  py::class_<PrismaticJoint, DrakeJoint>(m, "PrismaticJoint",
-                                         doc.PrismaticJoint.doc)
+  py::class_<PrismaticJoint, DrakeJoint>(
+      m, "PrismaticJoint", doc.PrismaticJoint.doc)
       .def(py::init<const std::string&, const Eigen::Isometry3d&,
-                    const Eigen::Vector3d&>(),
-           py::arg("name"), py::arg("transform_to_parent_body"),
-           py::arg("translation_axis"), doc.PrismaticJoint.ctor.doc);
+               const Eigen::Vector3d&>(),
+          py::arg("name"), py::arg("transform_to_parent_body"),
+          py::arg("translation_axis"), doc.PrismaticJoint.ctor.doc);
 
-  py::class_<RevoluteJoint, DrakeJoint>(m, "RevoluteJoint",
-                                        doc.RevoluteJoint.doc)
+  py::class_<RevoluteJoint, DrakeJoint>(
+      m, "RevoluteJoint", doc.RevoluteJoint.doc)
       .def(py::init<const std::string&, const Eigen::Isometry3d&,
-                    const Eigen::Vector3d&>(),
-           py::arg("name"), py::arg("transform_to_parent_body"),
-           py::arg("rotation_axis"), doc.RevoluteJoint.ctor.doc);
+               const Eigen::Vector3d&>(),
+          py::arg("name"), py::arg("transform_to_parent_body"),
+          py::arg("rotation_axis"), doc.RevoluteJoint.ctor.doc);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/multibody/multibody_tree_py.cc
+++ b/bindings/pydrake/multibody/multibody_tree_py.cc
@@ -61,32 +61,24 @@ void init_module(py::module m) {
   // To simplify checking binding coverage, these are defined in the same order
   // as `multibody_tree_indexes.h`.
   // TODO(jamiesnape): Extract documentation automatically.
-  BindTypeSafeIndex<FrameIndex>(
-      m, "FrameIndex",
+  BindTypeSafeIndex<FrameIndex>(m, "FrameIndex",
       "Type used to identify frames by index in a multibody tree system.");
-  BindTypeSafeIndex<BodyIndex>(
-      m, "BodyIndex",
+  BindTypeSafeIndex<BodyIndex>(m, "BodyIndex",
       "Type used to identify bodies by index in a multibody tree system.");
-  BindTypeSafeIndex<MobilizerIndex>(
-      m, "MobilizerIndex",
+  BindTypeSafeIndex<MobilizerIndex>(m, "MobilizerIndex",
       "Type used to identify mobilizers by index in a multibody tree system.");
-  BindTypeSafeIndex<BodyNodeIndex>(
-      m, "BodyNodeIndex",
+  BindTypeSafeIndex<BodyNodeIndex>(m, "BodyNodeIndex",
       "Type used to identify tree nodes by index within a multibody tree "
       "system.");
-  BindTypeSafeIndex<ForceElementIndex>(
-      m, "ForceElementIndex",
+  BindTypeSafeIndex<ForceElementIndex>(m, "ForceElementIndex",
       "Type used to identify force elements by index within a multibody tree "
       "system.");
-  BindTypeSafeIndex<JointIndex>(
-      m, "JointIndex",
+  BindTypeSafeIndex<JointIndex>(m, "JointIndex",
       "Type used to identify joints by index within a multibody tree system.");
-  BindTypeSafeIndex<JointActuatorIndex>(
-      m, "JointActuatorIndex",
+  BindTypeSafeIndex<JointActuatorIndex>(m, "JointActuatorIndex",
       "Type used to identify actuators by index within a multibody tree "
       "system.");
-  BindTypeSafeIndex<ModelInstanceIndex>(
-      m, "ModelInstanceIndex",
+  BindTypeSafeIndex<ModelInstanceIndex>(m, "ModelInstanceIndex",
       "Type used to identify model instances by index within a multibody tree "
       "system.");
   m.def("world_index", &world_index, doc.world_index.doc);
@@ -115,7 +107,7 @@ void init_module(py::module m) {
     cls  // BR
         .def("name", &Class::name, doc.Body.name.doc)
         .def("body_frame", &Class::body_frame, py_reference_internal,
-             doc.Body.body_frame.doc);
+            doc.Body.body_frame.doc);
   }
 
   {
@@ -131,21 +123,21 @@ void init_module(py::module m) {
     cls  // BR
         .def("name", &Class::name, doc.Joint.name.doc)
         .def("parent_body", &Class::parent_body, py_reference_internal,
-             doc.Joint.parent_body.doc)
+            doc.Joint.parent_body.doc)
         .def("child_body", &Class::child_body, py_reference_internal,
-             doc.Joint.child_body.doc)
+            doc.Joint.child_body.doc)
         .def("frame_on_parent", &Class::frame_on_parent, py_reference_internal,
-             doc.Joint.frame_on_parent.doc)
+            doc.Joint.frame_on_parent.doc)
         .def("frame_on_child", &Class::frame_on_child, py_reference_internal,
-             doc.Joint.frame_on_child.doc)
+            doc.Joint.frame_on_child.doc)
         .def("position_start", &Class::position_start,
-             doc.Joint.position_start.doc)
+            doc.Joint.position_start.doc)
         .def("velocity_start", &Class::velocity_start,
-             doc.Joint.velocity_start.doc)
-        .def("num_positions", &Class::num_positions,
-             doc.Joint.num_positions.doc)
+            doc.Joint.velocity_start.doc)
+        .def(
+            "num_positions", &Class::num_positions, doc.Joint.num_positions.doc)
         .def("num_velocities", &Class::num_velocities,
-             doc.Joint.num_velocities.doc)
+            doc.Joint.num_velocities.doc)
         .def("lower_limits", &Class::lower_limits, doc.Joint.lower_limits.doc)
         .def("upper_limits", &Class::upper_limits, doc.Joint.upper_limits.doc);
 
@@ -160,18 +152,18 @@ void init_module(py::module m) {
 
   {
     using Class = PrismaticJoint<T>;
-    py::class_<Class, Joint<T>> cls(m, "PrismaticJoint",
-                                    doc.PrismaticJoint.doc);
+    py::class_<Class, Joint<T>> cls(
+        m, "PrismaticJoint", doc.PrismaticJoint.doc);
     cls  // BR
         .def("get_translation", &Class::get_translation, py::arg("context"),
-             doc.PrismaticJoint.get_translation.doc)
+            doc.PrismaticJoint.get_translation.doc)
         .def("set_translation", &Class::set_translation, py::arg("context"),
-             py::arg("translation"), doc.PrismaticJoint.set_translation.doc)
+            py::arg("translation"), doc.PrismaticJoint.set_translation.doc)
         .def("get_translation_rate", &Class::get_translation_rate,
-             py::arg("context"), doc.PrismaticJoint.get_translation_rate.doc)
+            py::arg("context"), doc.PrismaticJoint.get_translation_rate.doc)
         .def("set_translation_rate", &Class::set_translation_rate,
-             py::arg("context"), py::arg("translation_dot"),
-             doc.PrismaticJoint.set_translation_rate.doc);
+            py::arg("context"), py::arg("translation_dot"),
+            doc.PrismaticJoint.set_translation_rate.doc);
   }
 
   {
@@ -179,14 +171,14 @@ void init_module(py::module m) {
     py::class_<Class, Joint<T>> cls(m, "RevoluteJoint", doc.RevoluteJoint.doc);
     cls  // BR
         .def(py::init<const string&, const Frame<T>&, const Frame<T>&,
-                      const Vector3<T>&, double>(),
-             py::arg("name"), py::arg("frame_on_parent"),
-             py::arg("frame_on_child"), py::arg("axis"), py::arg("damping") = 0,
-             doc.RevoluteJoint.ctor.doc_5args)
+                 const Vector3<T>&, double>(),
+            py::arg("name"), py::arg("frame_on_parent"),
+            py::arg("frame_on_child"), py::arg("axis"), py::arg("damping") = 0,
+            doc.RevoluteJoint.ctor.doc_5args)
         .def("get_angle", &Class::get_angle, py::arg("context"),
-             doc.RevoluteJoint.get_angle.doc)
+            doc.RevoluteJoint.get_angle.doc)
         .def("set_angle", &Class::set_angle, py::arg("context"),
-             py::arg("angle"), doc.RevoluteJoint.set_angle.doc);
+            py::arg("angle"), doc.RevoluteJoint.set_angle.doc);
   }
 
   {
@@ -194,10 +186,10 @@ void init_module(py::module m) {
     py::class_<Class, Joint<T>> cls(m, "WeldJoint", doc.WeldJoint.doc);
     cls  // BR
         .def(py::init<const string&, const Frame<T>&, const Frame<T>&,
-                      const Isometry3<double>&>(),
-             py::arg("name"), py::arg("parent_frame_P"),
-             py::arg("child_frame_C"), py::arg("X_PC"),
-             doc.WeldJoint.ctor.doc_4args);
+                 const Isometry3<double>&>(),
+            py::arg("name"), py::arg("parent_frame_P"),
+            py::arg("child_frame_C"), py::arg("X_PC"),
+            doc.WeldJoint.ctor.doc_4args);
   }
 
   // Actuators.
@@ -208,7 +200,7 @@ void init_module(py::module m) {
     cls  // BR
         .def("name", &Class::name, doc.JointActuator.name.doc)
         .def("joint", &Class::joint, py_reference_internal,
-             doc.JointActuator.joint.doc);
+            doc.JointActuator.joint.doc);
   }
 
   // Force Elements.
@@ -220,10 +212,10 @@ void init_module(py::module m) {
 
   {
     using Class = UniformGravityFieldElement<T>;
-    py::class_<Class, ForceElement<T>>(m, "UniformGravityFieldElement",
-                                       doc.UniformGravityFieldElement.doc)
+    py::class_<Class, ForceElement<T>>(
+        m, "UniformGravityFieldElement", doc.UniformGravityFieldElement.doc)
         .def(py::init<Vector3<double>>(), py::arg("g_W"),
-             doc.UniformGravityFieldElement.ctor.doc_1args);
+            doc.UniformGravityFieldElement.ctor.doc_1args);
   }
 
   // MultibodyForces
@@ -232,7 +224,7 @@ void init_module(py::module m) {
     py::class_<Class> cls(m, "MultibodyForces", doc.MultibodyForces.doc);
     cls  // BR
         .def(py::init<MultibodyTree<double>&>(), py::arg("model"),
-             doc.MultibodyForces.ctor.doc_1args);
+            doc.MultibodyForces.ctor.doc_1args);
   }
 
   // Tree.
@@ -244,168 +236,166 @@ void init_module(py::module m) {
 
     cls  // BR
         .def("CalcRelativeTransform", &Class::CalcRelativeTransform,
-             py::arg("context"), py::arg("frame_A"), py::arg("frame_B"),
-             doc.MultibodyTree.CalcRelativeTransform.doc)
+            py::arg("context"), py::arg("frame_A"), py::arg("frame_B"),
+            doc.MultibodyTree.CalcRelativeTransform.doc)
         .def("num_frames", &Class::num_frames, doc.MultibodyTree.num_frames.doc)
         .def("get_body", &Class::get_body, py::arg("body_index"),
-             py_reference_internal, doc.MultibodyTree.get_body.doc)
+            py_reference_internal, doc.MultibodyTree.get_body.doc)
         .def("get_joint", &Class::get_joint, py::arg("joint_index"),
-             py_reference_internal, doc.MultibodyTree.get_joint.doc)
+            py_reference_internal, doc.MultibodyTree.get_joint.doc)
         .def("get_joint_actuator", &Class::get_joint_actuator,
-             py::arg("actuator_index"), py_reference_internal,
-             doc.MultibodyTree.get_joint_actuator.doc)
+            py::arg("actuator_index"), py_reference_internal,
+            doc.MultibodyTree.get_joint_actuator.doc)
         .def("get_frame", &Class::get_frame, py::arg("frame_index"),
-             py_reference_internal, doc.MultibodyTree.get_frame.doc)
+            py_reference_internal, doc.MultibodyTree.get_frame.doc)
         .def("GetModelInstanceName",
-             overload_cast_explicit<const string&, ModelInstanceIndex>(
-                 &Class::GetModelInstanceName),
-             py::arg("model_instance"), py_reference_internal,
-             doc.MultibodyTree.GetModelInstanceName.doc)
+            overload_cast_explicit<const string&, ModelInstanceIndex>(
+                &Class::GetModelInstanceName),
+            py::arg("model_instance"), py_reference_internal,
+            doc.MultibodyTree.GetModelInstanceName.doc)
         .def("GetPositionsAndVelocities",
-             [](const MultibodyTree<T>* self,
+            [](const MultibodyTree<T>* self,
                 const Context<T>& context) -> Eigen::Ref<const VectorX<T>> {
-               return self->GetPositionsAndVelocities(context);
-             },
-             py_reference,
-             // Keep alive, ownership: `return` keeps `Context` alive.
-             py::keep_alive<0, 2>(), py::arg("context"),
-             doc.MultibodyTree.GetPositionsAndVelocities.doc_1args)
+              return self->GetPositionsAndVelocities(context);
+            },
+            py_reference,
+            // Keep alive, ownership: `return` keeps `Context` alive.
+            py::keep_alive<0, 2>(), py::arg("context"),
+            doc.MultibodyTree.GetPositionsAndVelocities.doc_1args)
         .def("GetMutablePositionsAndVelocities",
-             [](const MultibodyTree<T>* self,
+            [](const MultibodyTree<T>* self,
                 Context<T>* context) -> Eigen::Ref<VectorX<T>> {
-               return self->GetMutablePositionsAndVelocities(context);
-             },
-             py_reference,
-             // Keep alive, ownership: `return` keeps `Context` alive.
-             py::keep_alive<0, 2>(), py::arg("context"),
-             doc.MultibodyTree.GetMutablePositionsAndVelocities.doc)
+              return self->GetMutablePositionsAndVelocities(context);
+            },
+            py_reference,
+            // Keep alive, ownership: `return` keeps `Context` alive.
+            py::keep_alive<0, 2>(), py::arg("context"),
+            doc.MultibodyTree.GetMutablePositionsAndVelocities.doc)
         .def("CalcPointsPositions",
-             [](const Class* self, const Context<T>& context,
+            [](const Class* self, const Context<T>& context,
                 const Frame<T>& frame_B,
                 const Eigen::Ref<const MatrixX<T>>& p_BQi,
                 const Frame<T>& frame_A) {
-               MatrixX<T> p_AQi(p_BQi.rows(), p_BQi.cols());
-               self->CalcPointsPositions(context, frame_B, p_BQi, frame_A,
-                                         &p_AQi);
-               return p_AQi;
-             },
-             py::arg("context"), py::arg("frame_B"), py::arg("p_BQi"),
-             py::arg("frame_A"), doc.MultibodyTree.CalcPointsPositions.doc)
+              MatrixX<T> p_AQi(p_BQi.rows(), p_BQi.cols());
+              self->CalcPointsPositions(
+                  context, frame_B, p_BQi, frame_A, &p_AQi);
+              return p_AQi;
+            },
+            py::arg("context"), py::arg("frame_B"), py::arg("p_BQi"),
+            py::arg("frame_A"), doc.MultibodyTree.CalcPointsPositions.doc)
         .def("CalcFrameGeometricJacobianExpressedInWorld",
-             [](const Class* self, const Context<T>& context,
+            [](const Class* self, const Context<T>& context,
                 const Frame<T>& frame_B, const Vector3<T>& p_BoFo_B) {
-               MatrixX<T> Jv_WF(6, self->num_velocities());
-               self->CalcFrameGeometricJacobianExpressedInWorld(
-                   context, frame_B, p_BoFo_B, &Jv_WF);
-               return Jv_WF;
-             },
-             py::arg("context"), py::arg("frame_B"),
-             py::arg("p_BoFo_B") = Vector3<T>::Zero().eval(),
-             doc.MultibodyTree.CalcFrameGeometricJacobianExpressedInWorld.doc)
+              MatrixX<T> Jv_WF(6, self->num_velocities());
+              self->CalcFrameGeometricJacobianExpressedInWorld(
+                  context, frame_B, p_BoFo_B, &Jv_WF);
+              return Jv_WF;
+            },
+            py::arg("context"), py::arg("frame_B"),
+            py::arg("p_BoFo_B") = Vector3<T>::Zero().eval(),
+            doc.MultibodyTree.CalcFrameGeometricJacobianExpressedInWorld.doc)
         .def("CalcInverseDynamics",
-             overload_cast_explicit<VectorX<T>, const Context<T>&,
-                                    const VectorX<T>&,
-                                    const MultibodyForces<T>&>(
-                 &Class::CalcInverseDynamics),
-             py::arg("context"), py::arg("known_vdot"),
-             py::arg("external_forces"),
-             doc.MultibodyTree.CalcInverseDynamics.doc_3args)
+            overload_cast_explicit<VectorX<T>, const Context<T>&,
+                const VectorX<T>&, const MultibodyForces<T>&>(
+                &Class::CalcInverseDynamics),
+            py::arg("context"), py::arg("known_vdot"),
+            py::arg("external_forces"),
+            doc.MultibodyTree.CalcInverseDynamics.doc_3args)
         .def("SetFreeBodyPoseOrThrow",
-             overload_cast_explicit<void, const Body<T>&, const Isometry3<T>&,
-                                    systems::Context<T>*>(
-                 &Class::SetFreeBodyPoseOrThrow),
-             py::arg("body"), py::arg("X_WB"), py::arg("context"),
-             doc.MultibodyTree.SetFreeBodyPoseOrThrow.doc_3args)
+            overload_cast_explicit<void, const Body<T>&, const Isometry3<T>&,
+                systems::Context<T>*>(&Class::SetFreeBodyPoseOrThrow),
+            py::arg("body"), py::arg("X_WB"), py::arg("context"),
+            doc.MultibodyTree.SetFreeBodyPoseOrThrow.doc_3args)
         .def("GetPositionsFromArray", &Class::GetPositionsFromArray,
-             py::arg("model_instance"), py::arg("q_array"),
-             doc.MultibodyTree.get_positions_from_array.doc)
+            py::arg("model_instance"), py::arg("q_array"),
+            doc.MultibodyTree.get_positions_from_array.doc)
         .def("GetVelocitiesFromArray", &Class::GetVelocitiesFromArray,
-             py::arg("model_instance"), py::arg("v_array"),
-             doc.MultibodyTree.get_velocities_from_array.doc)
+            py::arg("model_instance"), py::arg("v_array"),
+            doc.MultibodyTree.get_velocities_from_array.doc)
         .def("SetFreeBodySpatialVelocityOrThrow",
-             [](const Class* self, const Body<T>& body,
+            [](const Class* self, const Body<T>& body,
                 const SpatialVelocity<T>& V_WB, Context<T>* context) {
-               self->SetFreeBodySpatialVelocityOrThrow(body, V_WB, context);
-             },
-             py::arg("body"), py::arg("V_WB"), py::arg("context"),
-             doc.MultibodyTree.SetFreeBodySpatialVelocityOrThrow.doc_3args)
+              self->SetFreeBodySpatialVelocityOrThrow(body, V_WB, context);
+            },
+            py::arg("body"), py::arg("V_WB"), py::arg("context"),
+            doc.MultibodyTree.SetFreeBodySpatialVelocityOrThrow.doc_3args)
         .def("CalcAllBodySpatialVelocitiesInWorld",
-             [](const Class* self, const Context<T>& context) {
-               std::vector<SpatialVelocity<T>> V_WB;
-               self->CalcAllBodySpatialVelocitiesInWorld(context, &V_WB);
-               return V_WB;
-             },
-             py::arg("context"),
-             doc.MultibodyTree.CalcAllBodySpatialVelocitiesInWorld.doc)
+            [](const Class* self, const Context<T>& context) {
+              std::vector<SpatialVelocity<T>> V_WB;
+              self->CalcAllBodySpatialVelocitiesInWorld(context, &V_WB);
+              return V_WB;
+            },
+            py::arg("context"),
+            doc.MultibodyTree.CalcAllBodySpatialVelocitiesInWorld.doc)
         .def("EvalBodyPoseInWorld",
-             [](const Class* self, const Context<T>& context,
+            [](const Class* self, const Context<T>& context,
                 const Body<T>& body_B) {
-               return self->EvalBodyPoseInWorld(context, body_B);
-             },
-             py::arg("context"), py::arg("body"),
-             doc.MultibodyTree.EvalBodyPoseInWorld.doc)
+              return self->EvalBodyPoseInWorld(context, body_B);
+            },
+            py::arg("context"), py::arg("body"),
+            doc.MultibodyTree.EvalBodyPoseInWorld.doc)
         .def("EvalBodySpatialVelocityInWorld",
-             [](const Class* self, const Context<T>& context,
+            [](const Class* self, const Context<T>& context,
                 const Body<T>& body_B) {
-               return self->EvalBodySpatialVelocityInWorld(context, body_B);
-             },
-             py::arg("context"), py::arg("body"),
-             doc.MultibodyTree.EvalBodySpatialVelocityInWorld.doc)
+              return self->EvalBodySpatialVelocityInWorld(context, body_B);
+            },
+            py::arg("context"), py::arg("body"),
+            doc.MultibodyTree.EvalBodySpatialVelocityInWorld.doc)
         .def("CalcAllBodyPosesInWorld",
-             [](const Class* self, const Context<T>& context) {
-               std::vector<Isometry3<T>> X_WB;
-               self->CalcAllBodyPosesInWorld(context, &X_WB);
-               return X_WB;
-             },
-             py::arg("context"), doc.MultibodyTree.CalcAllBodyPosesInWorld.doc)
+            [](const Class* self, const Context<T>& context) {
+              std::vector<Isometry3<T>> X_WB;
+              self->CalcAllBodyPosesInWorld(context, &X_WB);
+              return X_WB;
+            },
+            py::arg("context"), doc.MultibodyTree.CalcAllBodyPosesInWorld.doc)
         .def("CalcMassMatrixViaInverseDynamics",
-             [](const Class* self, const Context<T>& context) {
-               MatrixX<T> H;
-               const int n = self->num_velocities();
-               H.resize(n, n);
-               self->CalcMassMatrixViaInverseDynamics(context, &H);
-               return H;
-             },
-             py::arg("context"))
+            [](const Class* self, const Context<T>& context) {
+              MatrixX<T> H;
+              const int n = self->num_velocities();
+              H.resize(n, n);
+              self->CalcMassMatrixViaInverseDynamics(context, &H);
+              return H;
+            },
+            py::arg("context"))
         .def("CalcBiasTerm",
-             [](const Class* self, const Context<T>& context) {
-               VectorX<T> Cv;
-               const int n = self->num_velocities();
-               Cv.resize(n);
-               self->CalcBiasTerm(context, &Cv);
-               return Cv;
-             },
-             py::arg("context"), doc.MultibodyTree.CalcBiasTerm.doc);
+            [](const Class* self, const Context<T>& context) {
+              VectorX<T> Cv;
+              const int n = self->num_velocities();
+              Cv.resize(n);
+              self->CalcBiasTerm(context, &Cv);
+              return Cv;
+            },
+            py::arg("context"), doc.MultibodyTree.CalcBiasTerm.doc);
     // Add deprecated methods.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     cls.def("get_multibody_state_vector",
-            [](const MultibodyTree<T>* self,
-               const Context<T>& context) -> Eigen::Ref<const VectorX<T>> {
-              return self->get_multibody_state_vector(context);
-            },
-            py_reference,
-            // Keep alive, ownership: `return` keeps `Context` alive.
-            py::keep_alive<0, 2>(), py::arg("context"),
-            doc.MultibodyTree.get_multibody_state_vector.doc_1args);
+        [](const MultibodyTree<T>* self,
+            const Context<T>& context) -> Eigen::Ref<const VectorX<T>> {
+          return self->get_multibody_state_vector(context);
+        },
+        py_reference,
+        // Keep alive, ownership: `return` keeps `Context` alive.
+        py::keep_alive<0, 2>(), py::arg("context"),
+        doc.MultibodyTree.get_multibody_state_vector.doc_1args);
     cls.def("get_mutable_multibody_state_vector",
-            [](const MultibodyTree<T>* self,
-               Context<T>* context) -> Eigen::Ref<VectorX<T>> {
-              return self->get_mutable_multibody_state_vector(context);
-            },
-            py_reference,
-            // Keep alive, ownership: `return` keeps `Context` alive.
-            py::keep_alive<0, 2>(), py::arg("context"),
-            doc.MultibodyTree.get_mutable_multibody_state_vector.doc);
+        [](const MultibodyTree<T>* self,
+            Context<T>* context) -> Eigen::Ref<VectorX<T>> {
+          return self->get_mutable_multibody_state_vector(context);
+        },
+        py_reference,
+        // Keep alive, ownership: `return` keeps `Context` alive.
+        py::keep_alive<0, 2>(), py::arg("context"),
+        doc.MultibodyTree.get_mutable_multibody_state_vector.doc);
 #pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
     cls.attr("message_get_mutable_multibody_state_vector") =
         "Please use GetMutablePositionsAndVelocities().";
     DeprecateAttribute(cls, "get_mutable_multibody_state_vector",
-                       cls.attr("message_get_mutable_multibody_state_vector"));
+        cls.attr("message_get_mutable_multibody_state_vector"));
     cls.attr("message_get_multibody_state_vector") =
         "Please use GetPositionsAndVelocities().";
     DeprecateAttribute(cls, "get_multibody_state_vector",
-                       cls.attr("message_get_multibody_state_vector"));
+        cls.attr("message_get_multibody_state_vector"));
   }
 }
 
@@ -416,23 +406,23 @@ void init_math(py::module m) {
 
   m.doc() = "MultibodyTree math functionality.";
 
-  py::class_<SpatialVector<SpatialVelocity, T>>(m, "SpatialVector",
-                                                doc.SpatialVector.doc)
+  py::class_<SpatialVector<SpatialVelocity, T>>(
+      m, "SpatialVector", doc.SpatialVector.doc)
       .def("rotational",
-           [](const SpatialVector<SpatialVelocity, T>* self)
-               -> const Vector3<T>& { return self->rotational(); },
-           py_reference_internal, doc.SpatialVector.rotational.doc)
+          [](const SpatialVector<SpatialVelocity, T>* self)
+              -> const Vector3<T>& { return self->rotational(); },
+          py_reference_internal, doc.SpatialVector.rotational.doc)
       .def("translational",
-           [](const SpatialVector<SpatialVelocity, T>* self)
-               -> const Vector3<T>& { return self->translational(); },
-           py_reference_internal, doc.SpatialVector.translational.doc);
+          [](const SpatialVector<SpatialVelocity, T>* self)
+              -> const Vector3<T>& { return self->translational(); },
+          py_reference_internal, doc.SpatialVector.translational.doc);
 
   py::class_<SpatialVelocity<T>, SpatialVector<SpatialVelocity, T>>(
       m, "SpatialVelocity")
       .def(py::init(), doc.SpatialVelocity.ctor.doc_3)
       .def(py::init<const Eigen::Ref<const Vector3<T>>&,
-                    const Eigen::Ref<const Vector3<T>>&>(),
-           py::arg("w"), py::arg("v"), doc.SpatialVelocity.ctor.doc_4);
+               const Eigen::Ref<const Vector3<T>>&>(),
+          py::arg("w"), py::arg("v"), doc.SpatialVelocity.ctor.doc_4);
 }
 
 void init_multibody_plant(py::module m) {
@@ -447,284 +437,284 @@ void init_multibody_plant(py::module m) {
 
   {
     using Class = MultibodyPlant<T>;
-    py::class_<Class, systems::LeafSystem<T>> cls(m, "MultibodyPlant",
-                                                  doc.MultibodyPlant.doc);
+    py::class_<Class, systems::LeafSystem<T>> cls(
+        m, "MultibodyPlant", doc.MultibodyPlant.doc);
     // N.B. These are defined as they appear in the class declaration.
     // TODO(eric.cousineau): Add model-instance based overloads beyond
     // forwarded methods.
     // Forwarded methods from `MultibodyTree`.
     cls  // BR
         .def(py::init<double>(), py::arg("time_step") = 0.)
-        .def("num_bodies", &Class::num_bodies,
-             doc.MultibodyPlant.num_bodies.doc)
-        .def("num_joints", &Class::num_joints,
-             doc.MultibodyPlant.num_joints.doc)
+        .def(
+            "num_bodies", &Class::num_bodies, doc.MultibodyPlant.num_bodies.doc)
+        .def(
+            "num_joints", &Class::num_joints, doc.MultibodyPlant.num_joints.doc)
         .def("num_actuators", &Class::num_actuators,
-             doc.MultibodyPlant.num_actuators.doc)
+            doc.MultibodyPlant.num_actuators.doc)
         .def("num_model_instances", &Class::num_model_instances,
-             doc.MultibodyPlant.num_model_instances.doc)
+            doc.MultibodyPlant.num_model_instances.doc)
         .def("num_positions",
-             overload_cast_explicit<int>(&Class::num_positions),
-             doc.MultibodyPlant.num_positions.doc_0args)
+            overload_cast_explicit<int>(&Class::num_positions),
+            doc.MultibodyPlant.num_positions.doc_0args)
         .def("num_positions",
-             overload_cast_explicit<int, ModelInstanceIndex>(
-                 &Class::num_positions),
-             py::arg("model_instance"),
-             doc.MultibodyPlant.num_positions.doc_1args)
+            overload_cast_explicit<int, ModelInstanceIndex>(
+                &Class::num_positions),
+            py::arg("model_instance"),
+            doc.MultibodyPlant.num_positions.doc_1args)
         .def("num_velocities",
-             overload_cast_explicit<int>(&Class::num_velocities),
-             doc.MultibodyPlant.num_velocities.doc_0args)
+            overload_cast_explicit<int>(&Class::num_velocities),
+            doc.MultibodyPlant.num_velocities.doc_0args)
         .def("num_velocities",
-             overload_cast_explicit<int, ModelInstanceIndex>(
-                 &Class::num_velocities),
-             doc.MultibodyPlant.num_velocities.doc_1args)
+            overload_cast_explicit<int, ModelInstanceIndex>(
+                &Class::num_velocities),
+            doc.MultibodyPlant.num_velocities.doc_1args)
         .def("num_multibody_states", &Class::num_multibody_states,
-             doc.MultibodyPlant.num_multibody_states.doc)
+            doc.MultibodyPlant.num_multibody_states.doc)
         .def("num_actuated_dofs",
-             overload_cast_explicit<int>(&Class::num_actuated_dofs),
-             doc.MultibodyPlant.num_actuated_dofs.doc_0args);
+            overload_cast_explicit<int>(&Class::num_actuated_dofs),
+            doc.MultibodyPlant.num_actuated_dofs.doc_0args);
     // Construction.
     cls  // BR
         .def("AddJoint",
-             [](Class * self, std::unique_ptr<Joint<T>> joint) -> auto& {
-               return self->AddJoint(std::move(joint));
-             },
-             py::arg("joint"), py_reference_internal,
-             doc.MultibodyPlant.AddJoint.doc)
+            [](Class * self, std::unique_ptr<Joint<T>> joint) -> auto& {
+              return self->AddJoint(std::move(joint));
+            },
+            py::arg("joint"), py_reference_internal,
+            doc.MultibodyPlant.AddJoint.doc)
         .def("WeldFrames", &Class::WeldFrames, py::arg("A"), py::arg("B"),
-             py::arg("X_AB") = Isometry3<double>::Identity(),
-             py_reference_internal, doc.MultibodyPlant.WeldFrames.doc)
+            py::arg("X_AB") = Isometry3<double>::Identity(),
+            py_reference_internal, doc.MultibodyPlant.WeldFrames.doc)
         .def("AddForceElement",
-             [](Class * self,
+            [](Class * self,
                 std::unique_ptr<ForceElement<T>> force_element) -> auto& {
-               return self->AddForceElement<ForceElement>(
-                   std::move(force_element));
-             },
-             py::arg("force_element"), py_reference_internal,
-             doc.MultibodyPlant.AddForceElement.doc);
+              return self->AddForceElement<ForceElement>(
+                  std::move(force_element));
+            },
+            py::arg("force_element"), py_reference_internal,
+            doc.MultibodyPlant.AddForceElement.doc);
     // Topology queries.
     cls  // BR
         .def("HasBodyNamed",
-             overload_cast_explicit<bool, const string&>(&Class::HasBodyNamed),
-             py::arg("name"), doc.MultibodyPlant.HasBodyNamed.doc_1args)
+            overload_cast_explicit<bool, const string&>(&Class::HasBodyNamed),
+            py::arg("name"), doc.MultibodyPlant.HasBodyNamed.doc_1args)
         .def("HasBodyNamed",
-             overload_cast_explicit<bool, const string&, ModelInstanceIndex>(
-                 &Class::HasBodyNamed),
-             py::arg("name"), py::arg("model_instance"),
-             doc.MultibodyPlant.HasBodyNamed.doc_2args)
+            overload_cast_explicit<bool, const string&, ModelInstanceIndex>(
+                &Class::HasBodyNamed),
+            py::arg("name"), py::arg("model_instance"),
+            doc.MultibodyPlant.HasBodyNamed.doc_2args)
         .def("HasJointNamed",
-             overload_cast_explicit<bool, const string&>(&Class::HasJointNamed),
-             py::arg("name"), doc.MultibodyPlant.HasJointNamed.doc_1args)
+            overload_cast_explicit<bool, const string&>(&Class::HasJointNamed),
+            py::arg("name"), doc.MultibodyPlant.HasJointNamed.doc_1args)
         .def("HasJointNamed",
-             overload_cast_explicit<bool, const string&, ModelInstanceIndex>(
-                 &Class::HasJointNamed),
-             py::arg("name"), py::arg("model_instance"),
-             doc.MultibodyPlant.HasJointNamed.doc_2args)
+            overload_cast_explicit<bool, const string&, ModelInstanceIndex>(
+                &Class::HasJointNamed),
+            py::arg("name"), py::arg("model_instance"),
+            doc.MultibodyPlant.HasJointNamed.doc_2args)
         .def("GetFrameByName",
-             overload_cast_explicit<const Frame<T>&, const string&>(
-                 &Class::GetFrameByName),
-             py::arg("name"), py_reference_internal,
-             doc.MultibodyPlant.GetFrameByName.doc_1args)
+            overload_cast_explicit<const Frame<T>&, const string&>(
+                &Class::GetFrameByName),
+            py::arg("name"), py_reference_internal,
+            doc.MultibodyPlant.GetFrameByName.doc_1args)
         .def("GetFrameByName",
-             overload_cast_explicit<const Frame<T>&, const string&,
-                                    ModelInstanceIndex>(&Class::GetFrameByName),
-             py::arg("name"), py::arg("model_instance"), py_reference_internal,
-             doc.MultibodyPlant.GetFrameByName.doc_2args)
+            overload_cast_explicit<const Frame<T>&, const string&,
+                ModelInstanceIndex>(&Class::GetFrameByName),
+            py::arg("name"), py::arg("model_instance"), py_reference_internal,
+            doc.MultibodyPlant.GetFrameByName.doc_2args)
         .def("GetBodyByName",
-             overload_cast_explicit<const Body<T>&, const string&>(
-                 &Class::GetBodyByName),
-             py::arg("name"), py_reference_internal,
-             doc.MultibodyPlant.GetBodyByName.doc_1args)
+            overload_cast_explicit<const Body<T>&, const string&>(
+                &Class::GetBodyByName),
+            py::arg("name"), py_reference_internal,
+            doc.MultibodyPlant.GetBodyByName.doc_1args)
         .def("GetBodyByName",
-             overload_cast_explicit<const Body<T>&, const string&,
-                                    ModelInstanceIndex>(&Class::GetBodyByName),
-             py::arg("name"), py::arg("model_instance"), py_reference_internal,
-             doc.MultibodyPlant.GetBodyByName.doc_2args)
+            overload_cast_explicit<const Body<T>&, const string&,
+                ModelInstanceIndex>(&Class::GetBodyByName),
+            py::arg("name"), py::arg("model_instance"), py_reference_internal,
+            doc.MultibodyPlant.GetBodyByName.doc_2args)
         .def("GetJointByName",
-             [](const Class* self, const string& name) -> auto& {
-               return self->GetJointByName(name);
-             },
-             py::arg("name"), py_reference_internal,
-             doc.MultibodyPlant.GetJointByName.doc)
+            [](const Class* self, const string& name) -> auto& {
+              return self->GetJointByName(name);
+            },
+            py::arg("name"), py_reference_internal,
+            doc.MultibodyPlant.GetJointByName.doc)
         .def("GetJointByName",
-             [](const Class* self, const string& name,
+            [](const Class* self, const string& name,
                 ModelInstanceIndex model_instance) -> auto& {
-               return self->GetJointByName(name, model_instance);
-             },
-             py::arg("name"), py::arg("model_instance"), py_reference_internal,
-             doc.MultibodyPlant.GetJointByName.doc_2)
+              return self->GetJointByName(name, model_instance);
+            },
+            py::arg("name"), py::arg("model_instance"), py_reference_internal,
+            doc.MultibodyPlant.GetJointByName.doc_2)
         .def("GetJointActuatorByName",
-             overload_cast_explicit<const JointActuator<T>&, const string&>(
-                 &Class::GetJointActuatorByName),
-             py::arg("name"), py_reference_internal,
-             doc.MultibodyPlant.GetJointActuatorByName.doc_1args)
+            overload_cast_explicit<const JointActuator<T>&, const string&>(
+                &Class::GetJointActuatorByName),
+            py::arg("name"), py_reference_internal,
+            doc.MultibodyPlant.GetJointActuatorByName.doc_1args)
         .def("GetModelInstanceByName",
-             overload_cast_explicit<ModelInstanceIndex, const string&>(
-                 &Class::GetModelInstanceByName),
-             py::arg("name"), py_reference_internal,
-             doc.MultibodyPlant.GetModelInstanceByName.doc);
+            overload_cast_explicit<ModelInstanceIndex, const string&>(
+                &Class::GetModelInstanceByName),
+            py::arg("name"), py_reference_internal,
+            doc.MultibodyPlant.GetModelInstanceByName.doc);
     // Geometry.
     cls  // BR
         .def("RegisterAsSourceForSceneGraph",
-             &Class::RegisterAsSourceForSceneGraph, py::arg("scene_graph"),
-             doc.MultibodyPlant.RegisterAsSourceForSceneGraph.doc)
+            &Class::RegisterAsSourceForSceneGraph, py::arg("scene_graph"),
+            doc.MultibodyPlant.RegisterAsSourceForSceneGraph.doc)
         .def("get_source_id", &Class::get_source_id,
-             doc.MultibodyPlant.get_source_id.doc)
+            doc.MultibodyPlant.get_source_id.doc)
         .def("get_geometry_query_input_port",
-             &Class::get_geometry_query_input_port, py_reference_internal,
-             doc.MultibodyPlant.get_geometry_query_input_port.doc)
+            &Class::get_geometry_query_input_port, py_reference_internal,
+            doc.MultibodyPlant.get_geometry_query_input_port.doc)
         .def("get_geometry_poses_output_port",
-             &Class::get_geometry_poses_output_port, py_reference_internal,
-             doc.MultibodyPlant.get_geometry_poses_output_port.doc)
+            &Class::get_geometry_poses_output_port, py_reference_internal,
+            doc.MultibodyPlant.get_geometry_poses_output_port.doc)
         .def("geometry_source_is_registered",
-             &Class::geometry_source_is_registered,
-             doc.MultibodyPlant.geometry_source_is_registered.doc)
+            &Class::geometry_source_is_registered,
+            doc.MultibodyPlant.geometry_source_is_registered.doc)
         .def("GetBodyFromFrameId", &Class::GetBodyFromFrameId,
-             py_reference_internal, doc.MultibodyPlant.GetBodyFromFrameId.doc);
+            py_reference_internal, doc.MultibodyPlant.GetBodyFromFrameId.doc);
     // Port accessors.
     cls  // BR
         .def("get_actuation_input_port",
-             overload_cast_explicit<const systems::InputPort<T>&>(
-                 &Class::get_actuation_input_port),
-             py_reference_internal,
-             doc.MultibodyPlant.get_actuation_input_port.doc_0args)
+            overload_cast_explicit<const systems::InputPort<T>&>(
+                &Class::get_actuation_input_port),
+            py_reference_internal,
+            doc.MultibodyPlant.get_actuation_input_port.doc_0args)
         .def("get_continuous_state_output_port",
-             overload_cast_explicit<const systems::OutputPort<T>&>(
-                 &Class::get_continuous_state_output_port),
-             py_reference_internal,
-             doc.MultibodyPlant.get_continuous_state_output_port.doc_0args)
+            overload_cast_explicit<const systems::OutputPort<T>&>(
+                &Class::get_continuous_state_output_port),
+            py_reference_internal,
+            doc.MultibodyPlant.get_continuous_state_output_port.doc_0args)
         .def("get_contact_results_output_port",
-             overload_cast_explicit<const systems::OutputPort<T>&>(
-                 &Class::get_contact_results_output_port),
-             py_reference_internal,
-             doc.MultibodyPlant.get_contact_results_output_port.doc);
+            overload_cast_explicit<const systems::OutputPort<T>&>(
+                &Class::get_contact_results_output_port),
+            py_reference_internal,
+            doc.MultibodyPlant.get_contact_results_output_port.doc);
     // Property accessors.
     cls  // BR
         .def("world_body", &Class::world_body, py_reference_internal,
-             doc.MultibodyPlant.world_body.doc)
+            doc.MultibodyPlant.world_body.doc)
         .def("world_frame", &Class::world_frame, py_reference_internal,
-             doc.MultibodyPlant.world_frame.doc)
+            doc.MultibodyPlant.world_frame.doc)
         .def("tree", &Class::tree, py_reference_internal,
-             pydrake_doc.drake.multibody.MultibodyTreeSystem.tree.doc)
+            pydrake_doc.drake.multibody.MultibodyTreeSystem.tree.doc)
         .def("is_finalized", &Class::is_finalized,
-             doc.MultibodyPlant.is_finalized.doc)
+            doc.MultibodyPlant.is_finalized.doc)
         .def("Finalize", py::overload_cast<SceneGraph<T>*>(&Class::Finalize),
-             py::arg("scene_graph") = nullptr, doc.MultibodyPlant.Finalize.doc);
+            py::arg("scene_graph") = nullptr, doc.MultibodyPlant.Finalize.doc);
     // Position and velocity accessors and mutators.
     cls  // BR
         .def("GetMutablePositionsAndVelocities",
-             [](const MultibodyPlant<T>* self,
+            [](const MultibodyPlant<T>* self,
                 systems::Context<T>* context) -> Eigen::Ref<VectorX<T>> {
-               return self->GetMutablePositionsAndVelocities(context);
-             },
-             py_reference,
-             // Keep alive, ownership: `return` keeps `Context` alive.
-             py::keep_alive<0, 2>(), py::arg("context"),
-             doc.MultibodyPlant.GetMutablePositionsAndVelocities.doc)
+              return self->GetMutablePositionsAndVelocities(context);
+            },
+            py_reference,
+            // Keep alive, ownership: `return` keeps `Context` alive.
+            py::keep_alive<0, 2>(), py::arg("context"),
+            doc.MultibodyPlant.GetMutablePositionsAndVelocities.doc)
         .def("GetMutablePositions",
-             [](const MultibodyPlant<T>* self,
+            [](const MultibodyPlant<T>* self,
                 systems::Context<T>* context) -> Eigen::Ref<VectorX<T>> {
-               return self->GetMutablePositions(context);
-             },
-             py_reference,
-             // Keep alive, ownership: `return` keeps `Context` alive.
-             py::keep_alive<0, 2>(), py::arg("context"),
-             doc.MultibodyPlant.GetMutablePositions.doc)
+              return self->GetMutablePositions(context);
+            },
+            py_reference,
+            // Keep alive, ownership: `return` keeps `Context` alive.
+            py::keep_alive<0, 2>(), py::arg("context"),
+            doc.MultibodyPlant.GetMutablePositions.doc)
         .def("GetMutableVelocities",
-             [](const MultibodyPlant<T>* self,
+            [](const MultibodyPlant<T>* self,
                 systems::Context<T>* context) -> Eigen::Ref<VectorX<T>> {
-               return self->GetMutableVelocities(context);
-             },
-             py_reference,
-             // Keep alive, ownership: `return` keeps `Context` alive.
-             py::keep_alive<0, 2>(), py::arg("context"),
-             doc.MultibodyPlant.GetMutableVelocities.doc)
+              return self->GetMutableVelocities(context);
+            },
+            py_reference,
+            // Keep alive, ownership: `return` keeps `Context` alive.
+            py::keep_alive<0, 2>(), py::arg("context"),
+            doc.MultibodyPlant.GetMutableVelocities.doc)
         .def("GetPositions",
-             [](const MultibodyPlant<T>* self,
+            [](const MultibodyPlant<T>* self,
                 const systems::Context<T>& context) -> VectorX<T> {
-               return self->GetPositions(context);
-             },
-             py_reference, py::arg("context"),
-             doc.MultibodyPlant.GetPositions.doc_1args)
+              return self->GetPositions(context);
+            },
+            py_reference, py::arg("context"),
+            doc.MultibodyPlant.GetPositions.doc_1args)
         .def("GetPositions",
-             [](const MultibodyPlant<T>* self,
+            [](const MultibodyPlant<T>* self,
                 const systems::Context<T>& context,
                 multibody::ModelInstanceIndex model_instance) -> VectorX<T> {
-               return self->GetPositions(context, model_instance);
-             },
-             py_reference, py::arg("context"), py::arg("model_instance"),
-             doc.MultibodyPlant.GetPositions.doc_2args)
+              return self->GetPositions(context, model_instance);
+            },
+            py_reference, py::arg("context"), py::arg("model_instance"),
+            doc.MultibodyPlant.GetPositions.doc_2args)
         .def("SetPositions",
-             [](const MultibodyPlant<T>* self, systems::Context<T>* context,
+            [](const MultibodyPlant<T>* self, systems::Context<T>* context,
                 const VectorX<T>& q) { self->SetPositions(context, q); },
-             py_reference, py::arg("context"), py::arg("q"),
-             doc.MultibodyPlant.SetPositions.doc_2args)
+            py_reference, py::arg("context"), py::arg("q"),
+            doc.MultibodyPlant.SetPositions.doc_2args)
         .def("SetPositions",
-             [](const MultibodyPlant<T>* self, systems::Context<T>* context,
+            [](const MultibodyPlant<T>* self, systems::Context<T>* context,
                 multibody::ModelInstanceIndex model_instance,
                 const VectorX<T>& q) {
-               self->SetPositions(context, model_instance, q);
-             },
-             py_reference, py::arg("context"), py::arg("model_instance"),
-             py::arg("q"), doc.MultibodyPlant.SetPositions.doc_2args)
+              self->SetPositions(context, model_instance, q);
+            },
+            py_reference, py::arg("context"), py::arg("model_instance"),
+            py::arg("q"), doc.MultibodyPlant.SetPositions.doc_2args)
         .def("GetVelocities",
-             [](const MultibodyPlant<T>* self,
+            [](const MultibodyPlant<T>* self,
                 const systems::Context<T>& context) -> VectorX<T> {
-               return self->GetVelocities(context);
-             },
-             py_reference, py::arg("context"),
-             doc.MultibodyPlant.GetVelocities.doc_1args)
+              return self->GetVelocities(context);
+            },
+            py_reference, py::arg("context"),
+            doc.MultibodyPlant.GetVelocities.doc_1args)
         .def("GetVelocities",
-             [](const MultibodyPlant<T>* self,
+            [](const MultibodyPlant<T>* self,
                 const systems::Context<T>& context,
                 multibody::ModelInstanceIndex model_instance) -> VectorX<T> {
-               return self->GetVelocities(context, model_instance);
-             },
-             py_reference, py::arg("context"), py::arg("model_instance"),
-             doc.MultibodyPlant.GetVelocities.doc_2args)
+              return self->GetVelocities(context, model_instance);
+            },
+            py_reference, py::arg("context"), py::arg("model_instance"),
+            doc.MultibodyPlant.GetVelocities.doc_2args)
         .def("SetVelocities",
-             [](const MultibodyPlant<T>* self, systems::Context<T>* context,
+            [](const MultibodyPlant<T>* self, systems::Context<T>* context,
                 const VectorX<T>& v) { self->SetVelocities(context, v); },
-             py_reference, py::arg("context"), py::arg("v"),
-             doc.MultibodyPlant.SetVelocities.doc_2args)
+            py_reference, py::arg("context"), py::arg("v"),
+            doc.MultibodyPlant.SetVelocities.doc_2args)
         .def("SetVelocities",
-             [](const MultibodyPlant<T>* self, systems::Context<T>* context,
+            [](const MultibodyPlant<T>* self, systems::Context<T>* context,
                 ModelInstanceIndex model_instance, const VectorX<T>& v) {
-               self->SetVelocities(context, model_instance, v);
-             },
-             py_reference, py::arg("context"), py::arg("model_instance"),
-             py::arg("v"), doc.MultibodyPlant.SetVelocities.doc_3args)
+              self->SetVelocities(context, model_instance, v);
+            },
+            py_reference, py::arg("context"), py::arg("model_instance"),
+            py::arg("v"), doc.MultibodyPlant.SetVelocities.doc_3args)
         .def("GetPositionsAndVelocities",
-             [](const MultibodyPlant<T>* self,
+            [](const MultibodyPlant<T>* self,
                 const systems::Context<T>& context) -> VectorX<T> {
-               return self->GetPositionsAndVelocities(context);
-             },
-             py_reference, py::arg("context"),
-             doc.MultibodyPlant.GetPositionsAndVelocities.doc_1args)
+              return self->GetPositionsAndVelocities(context);
+            },
+            py_reference, py::arg("context"),
+            doc.MultibodyPlant.GetPositionsAndVelocities.doc_1args)
         .def("GetPositionsAndVelocities",
-             [](const MultibodyPlant<T>* self,
+            [](const MultibodyPlant<T>* self,
                 const systems::Context<T>& context,
                 multibody::ModelInstanceIndex model_instance) -> VectorX<T> {
-               return self->GetPositionsAndVelocities(context, model_instance);
-             },
-             py_reference, py::arg("context"), py::arg("model_instance"),
-             doc.MultibodyPlant.GetPositionsAndVelocities.doc_2args)
+              return self->GetPositionsAndVelocities(context, model_instance);
+            },
+            py_reference, py::arg("context"), py::arg("model_instance"),
+            doc.MultibodyPlant.GetPositionsAndVelocities.doc_2args)
         .def("SetPositionsAndVelocities",
-             [](const MultibodyPlant<T>* self, systems::Context<T>* context,
+            [](const MultibodyPlant<T>* self, systems::Context<T>* context,
                 const VectorX<T>& q_v) {
-               self->SetPositionsAndVelocities(context, q_v);
-             },
-             py_reference, py::arg("context"), py::arg("q_v"),
-             doc.MultibodyPlant.SetPositionsAndVelocities.doc_2args)
+              self->SetPositionsAndVelocities(context, q_v);
+            },
+            py_reference, py::arg("context"), py::arg("q_v"),
+            doc.MultibodyPlant.SetPositionsAndVelocities.doc_2args)
         .def("SetPositionsAndVelocities",
-             [](const MultibodyPlant<T>* self, systems::Context<T>* context,
+            [](const MultibodyPlant<T>* self, systems::Context<T>* context,
                 multibody::ModelInstanceIndex model_instance,
                 const VectorX<T>& q_v) {
-               self->SetPositionsAndVelocities(context, model_instance, q_v);
-             },
-             py_reference, py::arg("context"), py::arg("model_instance"),
-             py::arg("q_v"),
-             doc.MultibodyPlant.SetPositionsAndVelocities.doc_3args);
+              self->SetPositionsAndVelocities(context, model_instance, q_v);
+            },
+            py_reference, py::arg("context"), py::arg("model_instance"),
+            py::arg("q_v"),
+            doc.MultibodyPlant.SetPositionsAndVelocities.doc_3args);
 
     // Add deprecated methods.
 #pragma GCC diagnostic push
@@ -740,11 +730,11 @@ void init_multibody_plant(py::module m) {
     using Class = PointPairContactInfo<T>;
     py::class_<Class>(m, "PointPairContactInfo")
         .def(py::init<BodyIndex, BodyIndex, const Vector3<T>, const Vector3<T>,
-                      const T&, const T&,
-                      const geometry::PenetrationAsPointPair<T>>(),
-             py::arg("bodyA_index"), py::arg("bodyB_index"), py::arg("f_Bc_W"),
-             py::arg("p_WC"), py::arg("separation_speed"),
-             py::arg("slip_speed"), py::arg("point_pair"))
+                 const T&, const T&,
+                 const geometry::PenetrationAsPointPair<T>>(),
+            py::arg("bodyA_index"), py::arg("bodyB_index"), py::arg("f_Bc_W"),
+            py::arg("p_WC"), py::arg("separation_speed"), py::arg("slip_speed"),
+            py::arg("point_pair"))
         .def("bodyA_index", &Class::bodyA_index)
         .def("bodyB_index", &Class::bodyB_index)
         .def("contact_force", &Class::contact_force)
@@ -760,7 +750,7 @@ void init_multibody_plant(py::module m) {
         .def(py::init<>())
         .def("num_contacts", &Class::num_contacts)
         .def("AddContactInfo", &Class::AddContactInfo,
-             py::arg("point_pair_info"))
+            py::arg("point_pair_info"))
         .def("contact_info", &Class::contact_info, py::arg("i"));
     pysystems::AddValueInstantiation<Class>(m);
   }
@@ -780,24 +770,24 @@ void init_parsing(py::module m) {
     using Class = Parser;
     py::class_<Class>(m, "Parser", doc.Parser.doc)
         .def(py::init<MultibodyPlant<double>*, SceneGraph<double>*>(),
-             py::arg("plant"), py::arg("scene_graph") = nullptr,
-             doc.Parser.ctor.doc_2args)
+            py::arg("plant"), py::arg("scene_graph") = nullptr,
+            doc.Parser.ctor.doc_2args)
         .def("AddAllModelsFromFile", &Class::AddAllModelsFromFile,
-             py::arg("file_name"), doc.Parser.AddAllModelsFromFile.doc)
+            py::arg("file_name"), doc.Parser.AddAllModelsFromFile.doc)
         .def("AddModelFromFile", &Class::AddModelFromFile, py::arg("file_name"),
-             py::arg("model_name") = "", doc.Parser.AddModelFromFile.doc);
+            py::arg("model_name") = "", doc.Parser.AddModelFromFile.doc);
   }
 
   m.def("AddModelFromSdfFile",
-        py::overload_cast<const string&, const string&, MultibodyPlant<T>*,
-                          SceneGraph<T>*>(&AddModelFromSdfFile),
-        py::arg("file_name"), py::arg("model_name"), py::arg("plant"),
-        py::arg("scene_graph") = nullptr, doc.AddModelFromSdfFile.doc_4args);
+      py::overload_cast<const string&, const string&, MultibodyPlant<T>*,
+          SceneGraph<T>*>(&AddModelFromSdfFile),
+      py::arg("file_name"), py::arg("model_name"), py::arg("plant"),
+      py::arg("scene_graph") = nullptr, doc.AddModelFromSdfFile.doc_4args);
   m.def("AddModelFromSdfFile",
-        py::overload_cast<const string&, MultibodyPlant<T>*, SceneGraph<T>*>(
-            &AddModelFromSdfFile),
-        py::arg("file_name"), py::arg("plant"),
-        py::arg("scene_graph") = nullptr, doc.AddModelFromSdfFile.doc_3args);
+      py::overload_cast<const string&, MultibodyPlant<T>*, SceneGraph<T>*>(
+          &AddModelFromSdfFile),
+      py::arg("file_name"), py::arg("plant"), py::arg("scene_graph") = nullptr,
+      doc.AddModelFromSdfFile.doc_3args);
 }
 
 void init_all(py::module m) {

--- a/bindings/pydrake/multibody/parsers_py.cc
+++ b/bindings/pydrake/multibody/parsers_py.cc
@@ -20,11 +20,11 @@ PYBIND11_MODULE(parsers, m) {
       .def("size", &PackageMap::size, doc.PackageMap.size.doc)
       .def("GetPath", &PackageMap::GetPath, doc.PackageMap.GetPath.doc)
       .def("PopulateFromFolder", &PackageMap::PopulateFromFolder,
-           doc.PackageMap.PopulateFromFolder.doc)
+          doc.PackageMap.PopulateFromFolder.doc)
       .def("PopulateFromEnvironment", &PackageMap::PopulateFromEnvironment,
-           doc.PackageMap.PopulateFromEnvironment.doc)
+          doc.PackageMap.PopulateFromEnvironment.doc)
       .def("PopulateUpstreamToDrake", &PackageMap::PopulateUpstreamToDrake,
-           doc.PackageMap.PopulateUpstreamToDrake.doc);
+          doc.PackageMap.PopulateUpstreamToDrake.doc);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/multibody/rigid_body_plant_py.cc
+++ b/bindings/pydrake/multibody/rigid_body_plant_py.cc
@@ -31,7 +31,7 @@ PYBIND11_MODULE(rigid_body_plant, m) {
   {
     using Class = CompliantContactModelParameters;
     py::class_<Class> cls(m, "CompliantContactModelParameters",
-                          doc.CompliantContactModelParameters.doc);
+        doc.CompliantContactModelParameters.doc);
     cls  // BR
         .def(
             // Implicit constructor does not have documentation.
@@ -42,11 +42,9 @@ PYBIND11_MODULE(rigid_body_plant, m) {
             py::arg("v_stiction_tolerance") = Class::kDefaultVStictionTolerance,
             py::arg("characteristic_radius") =
                 Class::kDefaultCharacteristicRadius)
-        .def_readwrite(
-            "v_stiction_tolerance", &Class::v_stiction_tolerance,
+        .def_readwrite("v_stiction_tolerance", &Class::v_stiction_tolerance,
             doc.CompliantContactModelParameters.v_stiction_tolerance.doc)
-        .def_readwrite(
-            "characteristic_radius", &Class::characteristic_radius,
+        .def_readwrite("characteristic_radius", &Class::characteristic_radius,
             doc.CompliantContactModelParameters.characteristic_radius.doc);
     cls.attr("kDefaultVStictionTolerance") = Class::kDefaultVStictionTolerance;
     cls.attr("kDefaultCharacteristicRadius") =
@@ -58,11 +56,11 @@ PYBIND11_MODULE(rigid_body_plant, m) {
     py::class_<Class> cls(m, "ContactInfo", doc.ContactInfo.doc);
     cls  // BR
         .def("get_element_id_1", &Class::get_element_id_1,
-             doc.ContactInfo.get_element_id_1.doc)
+            doc.ContactInfo.get_element_id_1.doc)
         .def("get_element_id_2", &Class::get_element_id_2,
-             doc.ContactInfo.get_element_id_2.doc)
+            doc.ContactInfo.get_element_id_2.doc)
         .def("get_resultant_force", &Class::get_resultant_force,
-             py_reference_internal, doc.ContactInfo.get_resultant_force.doc);
+            py_reference_internal, doc.ContactInfo.get_resultant_force.doc);
   }
 
   {
@@ -70,19 +68,19 @@ PYBIND11_MODULE(rigid_body_plant, m) {
     py::class_<Class> cls(m, "ContactForce", doc.ContactForce.doc);
     cls  // BR
         .def(py::init<const Vector3<T>&, const Vector3<T>&, const Vector3<T>&,
-                      const Vector3<T>&>(),
-             py::arg("application_point"), py::arg("normal"), py::arg("force"),
-             py::arg("torque") = Vector3<T>::Zero(),
-             doc.ContactForce.ctor.doc_4args)
+                 const Vector3<T>&>(),
+            py::arg("application_point"), py::arg("normal"), py::arg("force"),
+            py::arg("torque") = Vector3<T>::Zero(),
+            doc.ContactForce.ctor.doc_4args)
         .def("get_reaction_force", &Class::get_reaction_force,
-             doc.ContactForce.get_reaction_force.doc)
+            doc.ContactForce.get_reaction_force.doc)
         .def("get_application_point", &Class::get_application_point,
-             doc.ContactForce.get_application_point.doc)
+            doc.ContactForce.get_application_point.doc)
         .def("get_force", &Class::get_force, doc.ContactForce.get_force.doc)
         .def("get_normal_force", &Class::get_normal_force,
-             doc.ContactForce.get_normal_force.doc)
+            doc.ContactForce.get_normal_force.doc)
         .def("get_tangent_force", &Class::get_tangent_force,
-             doc.ContactForce.get_tangent_force.doc)
+            doc.ContactForce.get_tangent_force.doc)
         .def("get_torque", &Class::get_torque, doc.ContactForce.get_torque.doc)
         .def("get_normal", &Class::get_normal, doc.ContactForce.get_normal.doc);
   }
@@ -93,20 +91,20 @@ PYBIND11_MODULE(rigid_body_plant, m) {
     cls  // BR
         .def(py::init<>(), doc.ContactResults.ctor.doc_0args)
         .def("get_num_contacts", &Class::get_num_contacts,
-             doc.ContactResults.get_num_contacts.doc)
+            doc.ContactResults.get_num_contacts.doc)
         .def("get_contact_info", &Class::get_contact_info,
-             py_reference_internal, doc.ContactResults.get_contact_info.doc)
+            py_reference_internal, doc.ContactResults.get_contact_info.doc)
         .def("set_generalized_contact_force",
-             [](Class* self, const Eigen::VectorXd& f) {
-               self->set_generalized_contact_force(f);
-             },
-             doc.ContactResults.set_generalized_contact_force.doc)
+            [](Class* self, const Eigen::VectorXd& f) {
+              self->set_generalized_contact_force(f);
+            },
+            doc.ContactResults.set_generalized_contact_force.doc)
         .def("get_generalized_contact_force",
-             &Class::get_generalized_contact_force, py_reference_internal,
-             doc.ContactResults.get_generalized_contact_force.doc)
+            &Class::get_generalized_contact_force, py_reference_internal,
+            doc.ContactResults.get_generalized_contact_force.doc)
         .def("AddContact", &Class::AddContact, py_reference_internal,
-             py::arg("element_a"), py::arg("element_b"),
-             doc.ContactResults.AddContact.doc)
+            py::arg("element_a"), py::arg("element_b"),
+            doc.ContactResults.AddContact.doc)
         .def("Clear", &Class::Clear, doc.ContactResults.Clear.doc);
     pysystems::AddValueInstantiation<Class>(m);
   }
@@ -117,48 +115,48 @@ PYBIND11_MODULE(rigid_body_plant, m) {
     cls  // BR
         .def(py::init<>(), doc.CompliantMaterial.ctor.doc_0args)
         .def(py::init<double, double, double, double>(),
-             py::arg("youngs_modulus"), py::arg("dissipation"),
-             py::arg("static_friction"), py::arg("dynamic_friction"),
-             doc.CompliantMaterial.ctor.doc_4args)
+            py::arg("youngs_modulus"), py::arg("dissipation"),
+            py::arg("static_friction"), py::arg("dynamic_friction"),
+            doc.CompliantMaterial.ctor.doc_4args)
         // youngs_modulus
         .def("set_youngs_modulus", &Class::set_youngs_modulus, py_reference,
-             doc.CompliantMaterial.set_youngs_modulus.doc)
+            doc.CompliantMaterial.set_youngs_modulus.doc)
         .def("youngs_modulus", &Class::youngs_modulus,
-             py::arg("default_value") = Class::kDefaultYoungsModulus,
-             doc.CompliantMaterial.youngs_modulus.doc)
+            py::arg("default_value") = Class::kDefaultYoungsModulus,
+            doc.CompliantMaterial.youngs_modulus.doc)
         .def("youngs_modulus_is_default", &Class::youngs_modulus_is_default,
-             doc.CompliantMaterial.youngs_modulus_is_default.doc)
+            doc.CompliantMaterial.youngs_modulus_is_default.doc)
         .def("set_youngs_modulus_to_default",
-             &Class::set_youngs_modulus_to_default,
-             doc.CompliantMaterial.set_youngs_modulus_to_default.doc)
+            &Class::set_youngs_modulus_to_default,
+            doc.CompliantMaterial.set_youngs_modulus_to_default.doc)
         // dissipation
         .def("set_dissipation", &Class::set_dissipation, py_reference,
-             doc.CompliantMaterial.set_dissipation.doc)
+            doc.CompliantMaterial.set_dissipation.doc)
         .def("dissipation", &Class::dissipation,
-             py::arg("default_value") = Class::kDefaultDissipation,
-             doc.CompliantMaterial.dissipation.doc)
+            py::arg("default_value") = Class::kDefaultDissipation,
+            doc.CompliantMaterial.dissipation.doc)
         .def("dissipation_is_default", &Class::dissipation_is_default,
-             doc.CompliantMaterial.dissipation_is_default.doc)
+            doc.CompliantMaterial.dissipation_is_default.doc)
         .def("set_dissipation_to_default", &Class::set_dissipation_to_default,
-             doc.CompliantMaterial.set_dissipation_to_default.doc)
+            doc.CompliantMaterial.set_dissipation_to_default.doc)
         // friction
         .def("set_friction", py::overload_cast<double>(&Class::set_friction),
-             py::arg("value"), py_reference,
-             doc.CompliantMaterial.set_friction.doc_1args)
+            py::arg("value"), py_reference,
+            doc.CompliantMaterial.set_friction.doc_1args)
         .def("set_friction",
-             py::overload_cast<double, double>(&Class::set_friction),
-             py::arg("static_friction"), py::arg("dynamic_friction"),
-             py_reference, doc.CompliantMaterial.set_friction.doc_2args)
+            py::overload_cast<double, double>(&Class::set_friction),
+            py::arg("static_friction"), py::arg("dynamic_friction"),
+            py_reference, doc.CompliantMaterial.set_friction.doc_2args)
         .def("static_friction", &Class::static_friction,
-             py::arg("default_value") = Class::kDefaultStaticFriction,
-             doc.CompliantMaterial.static_friction.doc)
+            py::arg("default_value") = Class::kDefaultStaticFriction,
+            doc.CompliantMaterial.static_friction.doc)
         .def("dynamic_friction", &Class::dynamic_friction,
-             py::arg("default_value") = Class::kDefaultDynamicFriction,
-             doc.CompliantMaterial.dynamic_friction.doc)
+            py::arg("default_value") = Class::kDefaultDynamicFriction,
+            doc.CompliantMaterial.dynamic_friction.doc)
         .def("friction_is_default", &Class::friction_is_default,
-             doc.CompliantMaterial.friction_is_default.doc)
+            doc.CompliantMaterial.friction_is_default.doc)
         .def("set_friction_to_default", &Class::set_friction_to_default,
-             doc.CompliantMaterial.set_friction_to_default.doc);
+            doc.CompliantMaterial.set_friction_to_default.doc);
     cls.attr("kDefaultYoungsModulus") = Class::kDefaultYoungsModulus;
     cls.attr("kDefaultDissipation") = Class::kDefaultDissipation;
     cls.attr("kDefaultStaticFriction") = Class::kDefaultStaticFriction;
@@ -168,130 +166,127 @@ PYBIND11_MODULE(rigid_body_plant, m) {
   {
     using Class = RigidBodyPlant<T>;
     // Defined in order of declaration in `rigid_body_plant.h`.
-    py::class_<Class, LeafSystem<T>>(m, "RigidBodyPlant",
-                                     doc.RigidBodyPlant.doc)
+    py::class_<Class, LeafSystem<T>>(
+        m, "RigidBodyPlant", doc.RigidBodyPlant.doc)
         .def(py::init<unique_ptr<const RigidBodyTree<T>>, double>(),
-             py::arg("tree"), py::arg("timestep") = 0.0,
-             doc.RigidBodyPlant.ctor.doc_2args)
+            py::arg("tree"), py::arg("timestep") = 0.0,
+            doc.RigidBodyPlant.ctor.doc_2args)
         .def("set_contact_model_parameters",
-             &Class::set_contact_model_parameters,
-             doc.RigidBodyPlant.set_contact_model_parameters.doc)
+            &Class::set_contact_model_parameters,
+            doc.RigidBodyPlant.set_contact_model_parameters.doc)
         .def("set_default_compliant_material",
-             &Class::set_default_compliant_material,
-             doc.RigidBodyPlant.set_default_compliant_material.doc)
+            &Class::set_default_compliant_material,
+            doc.RigidBodyPlant.set_default_compliant_material.doc)
         .def("get_rigid_body_tree", &Class::get_rigid_body_tree,
-             py_reference_internal, doc.RigidBodyPlant.get_rigid_body_tree.doc)
+            py_reference_internal, doc.RigidBodyPlant.get_rigid_body_tree.doc)
         .def("get_num_bodies", &Class::get_num_bodies,
-             doc.RigidBodyPlant.get_num_bodies.doc)
+            doc.RigidBodyPlant.get_num_bodies.doc)
         .def("get_num_positions",
-             overload_cast_explicit<int>(&Class::get_num_positions),
-             doc.RigidBodyPlant.get_num_positions.doc_0args)
+            overload_cast_explicit<int>(&Class::get_num_positions),
+            doc.RigidBodyPlant.get_num_positions.doc_0args)
         .def("get_num_positions",
-             overload_cast_explicit<int, int>(&Class::get_num_positions),
-             doc.RigidBodyPlant.get_num_positions.doc_1args)
+            overload_cast_explicit<int, int>(&Class::get_num_positions),
+            doc.RigidBodyPlant.get_num_positions.doc_1args)
         .def("get_num_velocities",
-             overload_cast_explicit<int>(&Class::get_num_velocities),
-             doc.RigidBodyPlant.get_num_velocities.doc_0args)
+            overload_cast_explicit<int>(&Class::get_num_velocities),
+            doc.RigidBodyPlant.get_num_velocities.doc_0args)
         .def("get_num_velocities",
-             overload_cast_explicit<int, int>(&Class::get_num_velocities),
-             doc.RigidBodyPlant.get_num_velocities.doc_1args)
+            overload_cast_explicit<int, int>(&Class::get_num_velocities),
+            doc.RigidBodyPlant.get_num_velocities.doc_1args)
         .def("get_num_states",
-             overload_cast_explicit<int>(&Class::get_num_states),
-             doc.RigidBodyPlant.get_num_states.doc_0args)
+            overload_cast_explicit<int>(&Class::get_num_states),
+            doc.RigidBodyPlant.get_num_states.doc_0args)
         .def("get_num_states",
-             overload_cast_explicit<int, int>(&Class::get_num_states),
-             doc.RigidBodyPlant.get_num_states.doc_1args)
+            overload_cast_explicit<int, int>(&Class::get_num_states),
+            doc.RigidBodyPlant.get_num_states.doc_1args)
         .def("get_num_actuators",
-             overload_cast_explicit<int>(&Class::get_num_actuators),
-             doc.RigidBodyPlant.get_num_actuators.doc_0args)
+            overload_cast_explicit<int>(&Class::get_num_actuators),
+            doc.RigidBodyPlant.get_num_actuators.doc_0args)
         .def("get_num_actuators",
-             overload_cast_explicit<int, int>(&Class::get_num_actuators),
-             doc.RigidBodyPlant.get_num_actuators.doc_1args)
+            overload_cast_explicit<int, int>(&Class::get_num_actuators),
+            doc.RigidBodyPlant.get_num_actuators.doc_1args)
         .def("get_num_model_instances", &Class::get_num_model_instances,
-             doc.RigidBodyPlant.get_num_model_instances.doc)
+            doc.RigidBodyPlant.get_num_model_instances.doc)
         .def("get_input_size", &Class::get_input_size,
-             doc.RigidBodyPlant.get_input_size.doc)
+            doc.RigidBodyPlant.get_input_size.doc)
         .def("get_output_size", &Class::get_output_size,
-             doc.RigidBodyPlant.get_output_size.doc)
+            doc.RigidBodyPlant.get_output_size.doc)
         .def("set_position", &Class::set_position,
-             doc.RigidBodyPlant.set_position.doc)
+            doc.RigidBodyPlant.set_position.doc)
         .def("set_velocity", &Class::set_velocity,
-             doc.RigidBodyPlant.set_velocity.doc)
+            doc.RigidBodyPlant.set_velocity.doc)
         .def("set_state_vector",
-             overload_cast_explicit<void, Context<T>*,
-                                    const Eigen::Ref<const VectorX<T>>>(
-                 &Class::set_state_vector),
-             doc.RigidBodyPlant.set_state_vector.doc_2args_context_x)
+            overload_cast_explicit<void, Context<T>*,
+                const Eigen::Ref<const VectorX<T>>>(&Class::set_state_vector),
+            doc.RigidBodyPlant.set_state_vector.doc_2args_context_x)
         .def("set_state_vector",
-             overload_cast_explicit<void, State<T>*,
-                                    const Eigen::Ref<const VectorX<T>>>(
-                 &Class::set_state_vector),
-             doc.RigidBodyPlant.set_state_vector.doc_2args_state_x)
+            overload_cast_explicit<void, State<T>*,
+                const Eigen::Ref<const VectorX<T>>>(&Class::set_state_vector),
+            doc.RigidBodyPlant.set_state_vector.doc_2args_state_x)
         .def("SetDefaultState", &Class::SetDefaultState,
-             doc.RigidBodyPlant.SetDefaultState.doc)
+            doc.RigidBodyPlant.SetDefaultState.doc)
         .def("FindInstancePositionIndexFromWorldIndex",
-             &Class::FindInstancePositionIndexFromWorldIndex,
-             doc.RigidBodyPlant.FindInstancePositionIndexFromWorldIndex.doc)
+            &Class::FindInstancePositionIndexFromWorldIndex,
+            doc.RigidBodyPlant.FindInstancePositionIndexFromWorldIndex.doc)
         .def("actuator_command_input_port", &Class::actuator_command_input_port,
-             py_reference_internal,
-             doc.RigidBodyPlant.actuator_command_input_port.doc)
+            py_reference_internal,
+            doc.RigidBodyPlant.actuator_command_input_port.doc)
         .def("model_instance_has_actuators",
-             &Class::model_instance_has_actuators,
-             doc.RigidBodyPlant.model_instance_has_actuators.doc)
+            &Class::model_instance_has_actuators,
+            doc.RigidBodyPlant.model_instance_has_actuators.doc)
         .def("model_instance_actuator_command_input_port",
-             &Class::model_instance_actuator_command_input_port,
-             py_reference_internal,
-             doc.RigidBodyPlant.model_instance_actuator_command_input_port.doc)
+            &Class::model_instance_actuator_command_input_port,
+            py_reference_internal,
+            doc.RigidBodyPlant.model_instance_actuator_command_input_port.doc)
         .def("state_output_port", &Class::state_output_port,
-             py_reference_internal, doc.RigidBodyPlant.state_output_port.doc)
+            py_reference_internal, doc.RigidBodyPlant.state_output_port.doc)
         .def("state_derivative_output_port",
-             &Class::state_derivative_output_port, py_reference_internal,
-             doc.RigidBodyPlant.state_derivative_output_port.doc)
+            &Class::state_derivative_output_port, py_reference_internal,
+            doc.RigidBodyPlant.state_derivative_output_port.doc)
         .def("model_instance_state_output_port",
-             &Class::model_instance_state_output_port, py_reference_internal,
-             doc.RigidBodyPlant.model_instance_state_output_port.doc)
+            &Class::model_instance_state_output_port, py_reference_internal,
+            doc.RigidBodyPlant.model_instance_state_output_port.doc)
         .def("torque_output_port", &Class::torque_output_port,
-             py_reference_internal, doc.RigidBodyPlant.torque_output_port.doc)
+            py_reference_internal, doc.RigidBodyPlant.torque_output_port.doc)
         .def("model_instance_torque_output_port",
-             &Class::model_instance_torque_output_port, py_reference_internal,
-             doc.RigidBodyPlant.model_instance_torque_output_port.doc)
+            &Class::model_instance_torque_output_port, py_reference_internal,
+            doc.RigidBodyPlant.model_instance_torque_output_port.doc)
         .def("kinematics_results_output_port",
-             &Class::kinematics_results_output_port, py_reference_internal,
-             doc.RigidBodyPlant.kinematics_results_output_port.doc)
+            &Class::kinematics_results_output_port, py_reference_internal,
+            doc.RigidBodyPlant.kinematics_results_output_port.doc)
         .def("contact_results_output_port", &Class::contact_results_output_port,
-             py_reference_internal,
-             doc.RigidBodyPlant.contact_results_output_port.doc)
+            py_reference_internal,
+            doc.RigidBodyPlant.contact_results_output_port.doc)
         .def("GetStateVector",
-             [](const Class* self,
+            [](const Class* self,
                 const Context<T>& context) -> Eigen::Ref<const VectorX<T>> {
-               return self->GetStateVector(context);
-             },
-             py_reference,
-             // Keep alive, ownership: `return` keeps `Context` alive.
-             py::keep_alive<0, 2>(), doc.RigidBodyPlant.GetStateVector.doc)
+              return self->GetStateVector(context);
+            },
+            py_reference,
+            // Keep alive, ownership: `return` keeps `Context` alive.
+            py::keep_alive<0, 2>(), doc.RigidBodyPlant.GetStateVector.doc)
         .def("is_state_discrete", &Class::is_state_discrete,
-             doc.RigidBodyPlant.is_state_discrete.doc)
+            doc.RigidBodyPlant.is_state_discrete.doc)
         .def("get_time_step", &Class::get_time_step,
-             doc.RigidBodyPlant.get_time_step.doc);
+            doc.RigidBodyPlant.get_time_step.doc);
   }
 
   {
     using Class = DrakeVisualizer;
-    py::class_<Class, LeafSystem<T>>(m, "DrakeVisualizer",
-                                     doc.DrakeVisualizer.doc)
+    py::class_<Class, LeafSystem<T>>(
+        m, "DrakeVisualizer", doc.DrakeVisualizer.doc)
         .def(py::init<const RigidBodyTree<T>&, DrakeLcmInterface*, bool>(),
-             py::arg("tree"), py::arg("lcm"),
-             py::arg("enable_playback") = false,
-             // Keep alive, reference: `this` keeps `tree` alive.
-             py::keep_alive<1, 2>(),
-             // Keep alive, reference: `this` keeps `lcm` alive.
-             py::keep_alive<1, 3>(), doc.DrakeVisualizer.ctor.doc_3args)
+            py::arg("tree"), py::arg("lcm"), py::arg("enable_playback") = false,
+            // Keep alive, reference: `this` keeps `tree` alive.
+            py::keep_alive<1, 2>(),
+            // Keep alive, reference: `this` keeps `lcm` alive.
+            py::keep_alive<1, 3>(), doc.DrakeVisualizer.ctor.doc_3args)
         .def("set_publish_period", &Class::set_publish_period,
-             py::arg("period"), doc.DrakeVisualizer.set_publish_period.doc)
+            py::arg("period"), doc.DrakeVisualizer.set_publish_period.doc)
         .def("ReplayCachedSimulation", &Class::ReplayCachedSimulation,
-             doc.DrakeVisualizer.ReplayCachedSimulation.doc)
+            doc.DrakeVisualizer.ReplayCachedSimulation.doc)
         .def("PublishLoadRobot", &Class::PublishLoadRobot,
-             doc.DrakeVisualizer.PublishLoadRobot.doc);
+            doc.DrakeVisualizer.PublishLoadRobot.doc);
     // TODO(eric.cousineau): Bind `PlaybackTrajectory` when
     // `PiecewisePolynomial` has bindings.
   }

--- a/bindings/pydrake/multibody/rigid_body_py.cc
+++ b/bindings/pydrake/multibody/rigid_body_py.cc
@@ -21,37 +21,37 @@ PYBIND11_MODULE(rigid_body, m) {
   py::class_<RigidBody<double> >(m, "RigidBody", doc.RigidBody.doc)
       .def(py::init(), doc.RigidBody.ctor.doc)
       .def("get_body_index", &RigidBody<double>::get_body_index,
-           doc.RigidBody.get_body_index.doc)
+          doc.RigidBody.get_body_index.doc)
       .def("get_center_of_mass", &RigidBody<double>::get_center_of_mass,
-           doc.RigidBody.get_center_of_mass.doc)
+          doc.RigidBody.get_center_of_mass.doc)
       .def("get_name", &RigidBody<double>::get_name, doc.RigidBody.get_name.doc)
       .def("set_name", &RigidBody<double>::set_name, doc.RigidBody.set_name.doc)
       .def("get_position_start_index",
-           &RigidBody<double>::get_position_start_index,
-           doc.RigidBody.get_position_start_index.doc)
+          &RigidBody<double>::get_position_start_index,
+          doc.RigidBody.get_position_start_index.doc)
       .def("get_spatial_inertia", &RigidBody<double>::get_spatial_inertia,
-           doc.RigidBody.get_spatial_inertia.doc)
+          doc.RigidBody.get_spatial_inertia.doc)
       .def("set_spatial_inertia", &RigidBody<double>::set_spatial_inertia,
-           doc.RigidBody.set_spatial_inertia.doc)
+          doc.RigidBody.set_spatial_inertia.doc)
 
       .def("add_joint", &RigidBody<double>::add_joint<DrakeJoint>,
-           doc.RigidBody.add_joint.doc)
+          doc.RigidBody.add_joint.doc)
       .def("has_joint", &RigidBody<double>::has_joint,
-           doc.RigidBody.has_joint.doc)
+          doc.RigidBody.has_joint.doc)
       .def("getJoint", &RigidBody<double>::getJoint,
-           py::return_value_policy::reference_internal,
-           doc.RigidBody.getJoint.doc)
+          py::return_value_policy::reference_internal,
+          doc.RigidBody.getJoint.doc)
 
       .def("get_visual_elements", &RigidBody<double>::get_visual_elements,
-           doc.RigidBody.get_visual_elements.doc)
+          doc.RigidBody.get_visual_elements.doc)
       .def("AddVisualElement", &RigidBody<double>::AddVisualElement,
-           doc.RigidBody.AddVisualElement.doc)
+          doc.RigidBody.AddVisualElement.doc)
       .def("get_num_collision_elements",
-           &RigidBody<double>::get_num_collision_elements,
-           doc.RigidBody.get_num_collision_elements.doc)
+          &RigidBody<double>::get_num_collision_elements,
+          doc.RigidBody.get_num_collision_elements.doc)
       .def("get_collision_element_ids",
-           &RigidBody<double>::get_collision_element_ids,
-           doc.RigidBody.get_collision_element_ids.doc);
+          &RigidBody<double>::get_collision_element_ids,
+          doc.RigidBody.get_collision_element_ids.doc);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/multibody/rigid_body_tree_py.cc
+++ b/bindings/pydrake/multibody/rigid_body_tree_py.cc
@@ -41,211 +41,208 @@ PYBIND11_MODULE(rigid_body_tree, m) {
   py::module::import("pydrake.util.eigen_geometry");
 
   constexpr auto& joints_doc = doc.drake.multibody.joints;
-  py::enum_<FloatingBaseType>(m, "FloatingBaseType",
-                              doc.drake.multibody.joints.FloatingBaseType.doc)
+  py::enum_<FloatingBaseType>(
+      m, "FloatingBaseType", doc.drake.multibody.joints.FloatingBaseType.doc)
       .value("kFixed", FloatingBaseType::kFixed,
-             joints_doc.FloatingBaseType.kFixed.doc)
+          joints_doc.FloatingBaseType.kFixed.doc)
       .value("kRollPitchYaw", FloatingBaseType::kRollPitchYaw,
-             joints_doc.FloatingBaseType.kRollPitchYaw.doc)
+          joints_doc.FloatingBaseType.kRollPitchYaw.doc)
       .value("kQuaternion", FloatingBaseType::kQuaternion,
-             joints_doc.FloatingBaseType.kQuaternion.doc)
+          joints_doc.FloatingBaseType.kQuaternion.doc)
       .value("kExperimentalMultibodyPlantStyle",
-             FloatingBaseType::kExperimentalMultibodyPlantStyle,
-             joints_doc.FloatingBaseType.kExperimentalMultibodyPlantStyle.doc);
+          FloatingBaseType::kExperimentalMultibodyPlantStyle,
+          joints_doc.FloatingBaseType.kExperimentalMultibodyPlantStyle.doc);
 
   // TODO(eric.cousineau): Try to decouple these APIs so that `rigid_body_tree`
   // and `parsers` do not form a dependency cycle.
-  py::class_<RigidBodyTree<double>> tree_cls(m, "RigidBodyTree",
-                                             doc.RigidBodyTree.doc);
+  py::class_<RigidBodyTree<double>> tree_cls(
+      m, "RigidBodyTree", doc.RigidBodyTree.doc);
   tree_cls  // BR
       .def(py::init<>())
       .def(py::init([](const std::string& urdf_filename, const PackageMap& pmap,
-                       FloatingBaseType floating_base_type) {
-             auto instance = make_unique<RigidBodyTree<double>>();
-             drake::parsers::urdf::
-                 AddModelInstanceFromUrdfFileSearchingInRosPackages(
-                     urdf_filename, pmap, floating_base_type, nullptr,
-                     instance.get());
-             return instance;
-           }),
-           py::arg("urdf_filename"), py::arg("package_map"),
-           py::arg("floating_base_type") = FloatingBaseType::kRollPitchYaw,
-           doc.RigidBodyTree.ctor.doc)
+                        FloatingBaseType floating_base_type) {
+        auto instance = make_unique<RigidBodyTree<double>>();
+        drake::parsers::urdf::
+            AddModelInstanceFromUrdfFileSearchingInRosPackages(urdf_filename,
+                pmap, floating_base_type, nullptr, instance.get());
+        return instance;
+      }),
+          py::arg("urdf_filename"), py::arg("package_map"),
+          py::arg("floating_base_type") = FloatingBaseType::kRollPitchYaw,
+          doc.RigidBodyTree.ctor.doc)
       .def(py::init([](const std::string& urdf_filename,
-                       FloatingBaseType floating_base_type) {
-             auto instance = make_unique<RigidBodyTree<double>>();
-             drake::parsers::urdf::AddModelInstanceFromUrdfFileToWorld(
-                 urdf_filename, floating_base_type, instance.get());
-             return instance;
-           }),
-           py::arg("urdf_filename"),
-           py::arg("floating_base_type") = FloatingBaseType::kRollPitchYaw,
-           doc.RigidBodyTree.ctor.doc)
+                        FloatingBaseType floating_base_type) {
+        auto instance = make_unique<RigidBodyTree<double>>();
+        drake::parsers::urdf::AddModelInstanceFromUrdfFileToWorld(
+            urdf_filename, floating_base_type, instance.get());
+        return instance;
+      }),
+          py::arg("urdf_filename"),
+          py::arg("floating_base_type") = FloatingBaseType::kRollPitchYaw,
+          doc.RigidBodyTree.ctor.doc)
       .def(py::init([](const std::string& urdf_filename,
-                       const std::string& joint_type) {
-             // FIXED = 0, ROLLPITCHYAW = 1, QUATERNION = 2
-             FloatingBaseType floating_base_type;
-             std::cerr
-                 << "WARNING: passing joint_type as a string is "
-                 << "deprecated. Please pass a FloatingBaseType value such as "
-                 << "FloatingBaseType.kRollPitchYaw" << std::endl;
-             if (joint_type == "FIXED") {
-               floating_base_type = FloatingBaseType::kFixed;
-             } else if (joint_type == "ROLLPITCHYAW") {
-               floating_base_type = FloatingBaseType::kRollPitchYaw;
-             } else if (joint_type == "QUATERNION") {
-               floating_base_type = FloatingBaseType::kQuaternion;
-             } else {
-               throw(std::invalid_argument("Joint type not supported"));
-             }
-             auto instance = make_unique<RigidBodyTree<double>>();
-             drake::parsers::urdf::AddModelInstanceFromUrdfFileToWorld(
-                 urdf_filename, floating_base_type, instance.get());
-             return instance;
-           }),
-           py::arg("urdf_filename"), py::arg("joint_type") = "ROLLPITCHYAW",
-           doc.RigidBodyTree.ctor.doc)
+                        const std::string& joint_type) {
+        // FIXED = 0, ROLLPITCHYAW = 1, QUATERNION = 2
+        FloatingBaseType floating_base_type;
+        std::cerr << "WARNING: passing joint_type as a string is "
+                  << "deprecated. Please pass a FloatingBaseType value such as "
+                  << "FloatingBaseType.kRollPitchYaw" << std::endl;
+        if (joint_type == "FIXED") {
+          floating_base_type = FloatingBaseType::kFixed;
+        } else if (joint_type == "ROLLPITCHYAW") {
+          floating_base_type = FloatingBaseType::kRollPitchYaw;
+        } else if (joint_type == "QUATERNION") {
+          floating_base_type = FloatingBaseType::kQuaternion;
+        } else {
+          throw(std::invalid_argument("Joint type not supported"));
+        }
+        auto instance = make_unique<RigidBodyTree<double>>();
+        drake::parsers::urdf::AddModelInstanceFromUrdfFileToWorld(
+            urdf_filename, floating_base_type, instance.get());
+        return instance;
+      }),
+          py::arg("urdf_filename"), py::arg("joint_type") = "ROLLPITCHYAW",
+          doc.RigidBodyTree.ctor.doc)
       .def("compile", &RigidBodyTree<double>::compile,
-           doc.RigidBodyTree.compile.doc)
+          doc.RigidBodyTree.compile.doc)
       .def("initialized", &RigidBodyTree<double>::initialized,
-           doc.RigidBodyTree.initialized.doc)
+          doc.RigidBodyTree.initialized.doc)
       .def("get_bodies",
-           [](const RigidBodyTree<double>& tree) {
-             auto& body_unique_ptrs = tree.get_bodies();
-             py::list py_bodies;
-             // Get self-reference to so that we can leverage keep-alive
-             // behavior.
-             py::object self = py::cast(&tree);
-             for (auto& body_unique_ptr : body_unique_ptrs) {
-               py_bodies.append(py::cast(body_unique_ptr.get(),
-                                         py_reference_internal, self));
-             }
-             return py_bodies;
-           },
-           doc.RigidBodyTree.get_bodies.doc)
+          [](const RigidBodyTree<double>& tree) {
+            auto& body_unique_ptrs = tree.get_bodies();
+            py::list py_bodies;
+            // Get self-reference to so that we can leverage keep-alive
+            // behavior.
+            py::object self = py::cast(&tree);
+            for (auto& body_unique_ptr : body_unique_ptrs) {
+              py_bodies.append(
+                  py::cast(body_unique_ptr.get(), py_reference_internal, self));
+            }
+            return py_bodies;
+          },
+          doc.RigidBodyTree.get_bodies.doc)
       .def("get_frames", &RigidBodyTree<double>::get_frames,
-           doc.RigidBodyTree.get_frames.doc)
+          doc.RigidBodyTree.get_frames.doc)
       .def("drawKinematicTree", &RigidBodyTree<double>::drawKinematicTree,
-           doc.RigidBodyTree.drawKinematicTree.doc)
+          doc.RigidBodyTree.drawKinematicTree.doc)
       .def("getRandomConfiguration",
-           [](const RigidBodyTree<double>& tree) {
-             std::random_device device;
-             std::default_random_engine generator(device());
-             return tree.getRandomConfiguration(generator);
-           },
-           doc.RigidBodyTree.getRandomConfiguration.doc)
+          [](const RigidBodyTree<double>& tree) {
+            std::random_device device;
+            std::default_random_engine generator(device());
+            return tree.getRandomConfiguration(generator);
+          },
+          doc.RigidBodyTree.getRandomConfiguration.doc)
       .def("getZeroConfiguration", &RigidBodyTree<double>::getZeroConfiguration,
-           doc.RigidBodyTree.getZeroConfiguration.doc)
+          doc.RigidBodyTree.getZeroConfiguration.doc)
       .def("CalcBodyPoseInWorldFrame",
-           [](const RigidBodyTree<double>& tree,
+          [](const RigidBodyTree<double>& tree,
               const KinematicsCache<double>& cache,
               const RigidBody<double>& body) {
-             return tree.CalcBodyPoseInWorldFrame(cache, body).matrix();
-           },
-           doc.RigidBodyTree.CalcBodyPoseInWorldFrame.doc)
+            return tree.CalcBodyPoseInWorldFrame(cache, body).matrix();
+          },
+          doc.RigidBodyTree.CalcBodyPoseInWorldFrame.doc)
       .def("get_num_bodies", &RigidBodyTree<double>::get_num_bodies,
-           doc.RigidBodyTree.get_num_bodies.doc)
+          doc.RigidBodyTree.get_num_bodies.doc)
       .def("get_num_frames", &RigidBodyTree<double>::get_num_frames,
-           doc.RigidBodyTree.get_num_frames.doc)
+          doc.RigidBodyTree.get_num_frames.doc)
       .def("get_num_actuators", &RigidBodyTree<double>::get_num_actuators,
-           doc.RigidBodyTree.get_num_actuators.doc)
+          doc.RigidBodyTree.get_num_actuators.doc)
       .def("get_num_model_instances",
-           &RigidBodyTree<double>::get_num_model_instances,
-           doc.RigidBodyTree.get_num_model_instances.doc)
+          &RigidBodyTree<double>::get_num_model_instances,
+          doc.RigidBodyTree.get_num_model_instances.doc)
       .def("getBodyOrFrameName", &RigidBodyTree<double>::getBodyOrFrameName,
-           py::arg("body_or_frame_id"),
-           doc.RigidBodyTree.getBodyOrFrameName.doc)
+          py::arg("body_or_frame_id"), doc.RigidBodyTree.getBodyOrFrameName.doc)
       .def("number_of_positions", &RigidBodyTree<double>::get_num_positions,
-           doc.RigidBodyTree.number_of_positions.doc)
+          doc.RigidBodyTree.number_of_positions.doc)
       .def("get_num_positions", &RigidBodyTree<double>::get_num_positions,
-           doc.RigidBodyTree.get_num_positions.doc)
+          doc.RigidBodyTree.get_num_positions.doc)
       .def("number_of_velocities", &RigidBodyTree<double>::get_num_velocities,
-           doc.RigidBodyTree.number_of_velocities.doc)
+          doc.RigidBodyTree.number_of_velocities.doc)
       .def("get_num_velocities", &RigidBodyTree<double>::get_num_velocities,
-           doc.RigidBodyTree.get_num_velocities.doc)
+          doc.RigidBodyTree.get_num_velocities.doc)
       .def("get_body", &RigidBodyTree<double>::get_body,
-           py::return_value_policy::reference, doc.RigidBodyTree.get_body.doc)
+          py::return_value_policy::reference, doc.RigidBodyTree.get_body.doc)
       .def("get_position_name", &RigidBodyTree<double>::get_position_name,
-           doc.RigidBodyTree.get_position_name.doc)
+          doc.RigidBodyTree.get_position_name.doc)
       .def("add_rigid_body", &RigidBodyTree<double>::add_rigid_body,
-           doc.RigidBodyTree.add_rigid_body.doc)
+          doc.RigidBodyTree.add_rigid_body.doc)
       .def("addCollisionElement", &RigidBodyTree<double>::addCollisionElement,
-           doc.RigidBodyTree.addCollisionElement.doc)
+          doc.RigidBodyTree.addCollisionElement.doc)
       .def("AddCollisionFilterGroupMember",
-           &RigidBodyTree<double>::AddCollisionFilterGroupMember,
-           py::arg("group_name"), py::arg("body_name"), py::arg("model_id"),
-           doc.RigidBodyTree.AddCollisionFilterGroupMember.doc)
+          &RigidBodyTree<double>::AddCollisionFilterGroupMember,
+          py::arg("group_name"), py::arg("body_name"), py::arg("model_id"),
+          doc.RigidBodyTree.AddCollisionFilterGroupMember.doc)
       .def("DefineCollisionFilterGroup",
-           &RigidBodyTree<double>::DefineCollisionFilterGroup, py::arg("name"),
-           doc.RigidBodyTree.DefineCollisionFilterGroup.doc)
+          &RigidBodyTree<double>::DefineCollisionFilterGroup, py::arg("name"),
+          doc.RigidBodyTree.DefineCollisionFilterGroup.doc)
       .def("FindCollisionElement", &RigidBodyTree<double>::FindCollisionElement,
-           py::arg("id"), py::return_value_policy::reference,
-           doc.RigidBodyTree.FindCollisionElement.doc)
+          py::arg("id"), py::return_value_policy::reference,
+          doc.RigidBodyTree.FindCollisionElement.doc)
       .def("addFrame", &RigidBodyTree<double>::addFrame, py::arg("frame"),
-           doc.RigidBodyTree.addFrame.doc)
+          doc.RigidBodyTree.addFrame.doc)
       .def("FindBody",
-           [](const RigidBodyTree<double>& self, const std::string& body_name,
+          [](const RigidBodyTree<double>& self, const std::string& body_name,
               const std::string& model_name = "", int model_id = -1) {
-             return self.FindBody(body_name, model_name, model_id);
-           },
-           py::arg("body_name"), py::arg("model_name") = "",
-           py::arg("model_id") = -1, py::return_value_policy::reference,
-           doc.RigidBodyTree.FindBody.doc_3args)
+            return self.FindBody(body_name, model_name, model_id);
+          },
+          py::arg("body_name"), py::arg("model_name") = "",
+          py::arg("model_id") = -1, py::return_value_policy::reference,
+          doc.RigidBodyTree.FindBody.doc_3args)
       .def("FindBodyIndex", &RigidBodyTree<double>::FindBodyIndex,
-           py::arg("body_name"), py::arg("model_id") = -1,
-           doc.RigidBodyTree.FindBodyIndex.doc)
+          py::arg("body_name"), py::arg("model_id") = -1,
+          doc.RigidBodyTree.FindBodyIndex.doc)
       .def("FindChildBodyOfJoint",
-           [](const RigidBodyTree<double>& self, const std::string& joint_name,
+          [](const RigidBodyTree<double>& self, const std::string& joint_name,
               int model_id) {
-             return self.FindChildBodyOfJoint(joint_name, model_id);
-           },
-           py::arg("joint_name"), py::arg("model_id") = -1,
-           py::return_value_policy::reference,
-           doc.RigidBodyTree.FindChildBodyOfJoint.doc)
+            return self.FindChildBodyOfJoint(joint_name, model_id);
+          },
+          py::arg("joint_name"), py::arg("model_id") = -1,
+          py::return_value_policy::reference,
+          doc.RigidBodyTree.FindChildBodyOfJoint.doc)
       .def("FindIndexOfChildBodyOfJoint",
-           &RigidBodyTree<double>::FindIndexOfChildBodyOfJoint,
-           py::arg("joint_name"), py::arg("model_id") = -1,
-           doc.RigidBodyTree.FindIndexOfChildBodyOfJoint.doc)
+          &RigidBodyTree<double>::FindIndexOfChildBodyOfJoint,
+          py::arg("joint_name"), py::arg("model_id") = -1,
+          doc.RigidBodyTree.FindIndexOfChildBodyOfJoint.doc)
       .def("world",
-           static_cast<RigidBody<double>& (RigidBodyTree<double>::*)()>(
-               &RigidBodyTree<double>::world),
-           py::return_value_policy::reference, doc.RigidBodyTree.world.doc)
+          static_cast<RigidBody<double>& (RigidBodyTree<double>::*)()>(
+              &RigidBodyTree<double>::world),
+          py::return_value_policy::reference, doc.RigidBodyTree.world.doc)
       .def("findFrame", &RigidBodyTree<double>::findFrame,
-           py::arg("frame_name"), py::arg("model_id") = -1,
-           doc.RigidBodyTree.findFrame.doc)
+          py::arg("frame_name"), py::arg("model_id") = -1,
+          doc.RigidBodyTree.findFrame.doc)
       .def("getTerrainContactPoints",
-           [](const RigidBodyTree<double>& self, const RigidBody<double>& body,
+          [](const RigidBodyTree<double>& self, const RigidBody<double>& body,
               const std::string& group_name = "") {
-             auto pts = Eigen::Matrix3Xd(3, 0);
-             self.getTerrainContactPoints(body, &pts, group_name);
-             return pts;
-           },
-           py::arg("body"), py::arg("group_name") = "",
-           doc.RigidBodyTree.getTerrainContactPoints.doc)
+            auto pts = Eigen::Matrix3Xd(3, 0);
+            self.getTerrainContactPoints(body, &pts, group_name);
+            return pts;
+          },
+          py::arg("body"), py::arg("group_name") = "",
+          doc.RigidBodyTree.getTerrainContactPoints.doc)
       .def_readonly("B", &RigidBodyTree<double>::B, doc.RigidBodyTree.B.doc)
       .def_readonly("joint_limit_min", &RigidBodyTree<double>::joint_limit_min,
-                    doc.RigidBodyTree.joint_limit_min.doc)
+          doc.RigidBodyTree.joint_limit_min.doc)
       .def_readonly("joint_limit_max", &RigidBodyTree<double>::joint_limit_max,
-                    doc.RigidBodyTree.joint_limit_max.doc)
+          doc.RigidBodyTree.joint_limit_max.doc)
       // N.B. This will return *copies* of the actuators.
       // N.B. `def_readonly` implicitly adds `reference_internal` to the getter,
       // which is necessary since an actuator references a `RigidBody` that is
       // most likely owned by this tree.
       .def_readonly("actuators", &RigidBodyTree<double>::actuators,
-                    doc.RigidBodyTree.actuators.doc)
+          doc.RigidBodyTree.actuators.doc)
       .def("GetActuator", &RigidBodyTree<double>::GetActuator,
-           py_reference_internal, doc.RigidBodyTree.GetActuator.doc)
+          py_reference_internal, doc.RigidBodyTree.GetActuator.doc)
       .def("FindBaseBodies", &RigidBodyTree<double>::FindBaseBodies,
-           py::arg("model_instance_id") = -1,
-           doc.RigidBodyTree.FindBaseBodies.doc)
+          py::arg("model_instance_id") = -1,
+          doc.RigidBodyTree.FindBaseBodies.doc)
       .def("addDistanceConstraint",
-           &RigidBodyTree<double>::addDistanceConstraint,
-           py::arg("bodyA_index_in"), py::arg("r_AP_in"),
-           py::arg("bodyB_index_in"), py::arg("r_BQ_in"),
-           py::arg("distance_in"), doc.RigidBodyTree.addDistanceConstraint.doc)
+          &RigidBodyTree<double>::addDistanceConstraint,
+          py::arg("bodyA_index_in"), py::arg("r_AP_in"),
+          py::arg("bodyB_index_in"), py::arg("r_BQ_in"), py::arg("distance_in"),
+          doc.RigidBodyTree.addDistanceConstraint.doc)
       .def("getNumPositionConstraints",
-           &RigidBodyTree<double>::getNumPositionConstraints,
-           doc.RigidBodyTree.getNumPositionConstraints.doc)
+          &RigidBodyTree<double>::getNumPositionConstraints,
+          doc.RigidBodyTree.getNumPositionConstraints.doc)
       .def("Clone", &RigidBodyTree<double>::Clone, doc.RigidBodyTree.Clone.doc)
       .def("__copy__", &RigidBodyTree<double>::Clone);
 
@@ -265,207 +262,206 @@ PYBIND11_MODULE(rigid_body_tree, m) {
     // Type (a) methods:
     tree_cls
         .def("massMatrix", &RigidBodyTree<double>::massMatrix<T>,
-             doc.RigidBodyTree.massMatrix.doc)
+            doc.RigidBodyTree.massMatrix.doc)
         .def("centerOfMass", &RigidBodyTree<double>::centerOfMass<T>,
-             py::arg("cache"),
-             py::arg("model_instance_id_set") =
-                 RigidBodyTreeConstants::default_model_instance_id_set,
-             doc.RigidBodyTree.centerOfMass.doc)
+            py::arg("cache"),
+            py::arg("model_instance_id_set") =
+                RigidBodyTreeConstants::default_model_instance_id_set,
+            doc.RigidBodyTree.centerOfMass.doc)
         .def("transformVelocityToQDot",
-             [](const RigidBodyTree<double>& tree,
+            [](const RigidBodyTree<double>& tree,
                 const KinematicsCache<T>& cache, const VectorX<T>& v) {
-               return tree.transformVelocityToQDot(cache, v);
-             },
-             doc.RigidBodyTree.transformVelocityToQDot.doc)
+              return tree.transformVelocityToQDot(cache, v);
+            },
+            doc.RigidBodyTree.transformVelocityToQDot.doc)
         .def("transformQDotToVelocity",
-             [](const RigidBodyTree<double>& tree,
+            [](const RigidBodyTree<double>& tree,
                 const KinematicsCache<T>& cache, const VectorX<T>& qdot) {
-               return tree.transformQDotToVelocity(cache, qdot);
-             },
-             doc.RigidBodyTree.transformQDotToVelocity.doc)
+              return tree.transformQDotToVelocity(cache, qdot);
+            },
+            doc.RigidBodyTree.transformQDotToVelocity.doc)
         .def("GetVelocityToQDotMapping",
-             [](const RigidBodyTree<double>& tree,
+            [](const RigidBodyTree<double>& tree,
                 const KinematicsCache<T>& cache) {
-               return tree.GetVelocityToQDotMapping(cache);
-             },
-             doc.RigidBodyTree.GetVelocityToQDotMapping.doc)
+              return tree.GetVelocityToQDotMapping(cache);
+            },
+            doc.RigidBodyTree.GetVelocityToQDotMapping.doc)
         .def("GetQDotToVelocityMapping",
-             [](const RigidBodyTree<double>& tree,
+            [](const RigidBodyTree<double>& tree,
                 const KinematicsCache<T>& cache) {
-               return tree.GetQDotToVelocityMapping(cache);
-             },
-             doc.RigidBodyTree.GetQDotToVelocityMapping.doc)
+              return tree.GetQDotToVelocityMapping(cache);
+            },
+            doc.RigidBodyTree.GetQDotToVelocityMapping.doc)
         .def("dynamicsBiasTerm", &RigidBodyTree<double>::dynamicsBiasTerm<T>,
-             py::arg("cache"), py::arg("external_wrenches"),
-             py::arg("include_velocity_terms") = true,
-             doc.RigidBodyTree.dynamicsBiasTerm.doc)
+            py::arg("cache"), py::arg("external_wrenches"),
+            py::arg("include_velocity_terms") = true,
+            doc.RigidBodyTree.dynamicsBiasTerm.doc)
         .def("geometricJacobian",
-             [](const RigidBodyTree<double>& tree,
+            [](const RigidBodyTree<double>& tree,
                 const KinematicsCache<T>& cache, int base_body_or_frame_ind,
                 int end_effector_body_or_frame_ind,
                 int expressed_in_body_or_frame_ind, bool in_terms_of_qdot) {
-               std::vector<int> v_indices;
-               auto J = tree.geometricJacobian(cache, base_body_or_frame_ind,
-                                               end_effector_body_or_frame_ind,
-                                               expressed_in_body_or_frame_ind,
-                                               in_terms_of_qdot, &v_indices);
-               return py::make_tuple(J, v_indices);
-             },
-             py::arg("cache"), py::arg("base_body_or_frame_ind"),
-             py::arg("end_effector_body_or_frame_ind"),
-             py::arg("expressed_in_body_or_frame_ind"),
-             py::arg("in_terms_of_qdot") = false,
-             doc.RigidBodyTree.geometricJacobian.doc)
+              std::vector<int> v_indices;
+              auto J = tree.geometricJacobian(cache, base_body_or_frame_ind,
+                  end_effector_body_or_frame_ind,
+                  expressed_in_body_or_frame_ind, in_terms_of_qdot, &v_indices);
+              return py::make_tuple(J, v_indices);
+            },
+            py::arg("cache"), py::arg("base_body_or_frame_ind"),
+            py::arg("end_effector_body_or_frame_ind"),
+            py::arg("expressed_in_body_or_frame_ind"),
+            py::arg("in_terms_of_qdot") = false,
+            doc.RigidBodyTree.geometricJacobian.doc)
         .def("relativeTransform",
-             [](const RigidBodyTree<double>& tree,
+            [](const RigidBodyTree<double>& tree,
                 const KinematicsCache<T>& cache, int base_or_frame_ind,
                 int body_or_frame_ind) {
-               return tree
-                   .relativeTransform(cache, base_or_frame_ind,
-                                      body_or_frame_ind)
-                   .matrix();
-             },
-             py::arg("cache"), py::arg("base_or_frame_ind"),
-             py::arg("body_or_frame_ind"),
-             doc.RigidBodyTree.relativeTransform.doc)
+              return tree
+                  .relativeTransform(
+                      cache, base_or_frame_ind, body_or_frame_ind)
+                  .matrix();
+            },
+            py::arg("cache"), py::arg("base_or_frame_ind"),
+            py::arg("body_or_frame_ind"),
+            doc.RigidBodyTree.relativeTransform.doc)
         .def("centerOfMassJacobian",
-             &RigidBodyTree<double>::centerOfMassJacobian<T>, py::arg("cache"),
-             py::arg("model_instance_id_set") =
-                 RigidBodyTreeConstants::default_model_instance_id_set,
-             py::arg("in_terms_of_qdot") = false,
-             doc.RigidBodyTree.centerOfMassJacobian.doc)
+            &RigidBodyTree<double>::centerOfMassJacobian<T>, py::arg("cache"),
+            py::arg("model_instance_id_set") =
+                RigidBodyTreeConstants::default_model_instance_id_set,
+            py::arg("in_terms_of_qdot") = false,
+            doc.RigidBodyTree.centerOfMassJacobian.doc)
         .def("centroidalMomentumMatrix",
-             &RigidBodyTree<double>::centroidalMomentumMatrix<T>,
-             py::arg("cache"),
-             py::arg("model_instance_id_set") =
-                 RigidBodyTreeConstants::default_model_instance_id_set,
-             py::arg("in_terms_of_qdot") = false,
-             doc.RigidBodyTree.centroidalMomentumMatrix.doc)
+            &RigidBodyTree<double>::centroidalMomentumMatrix<T>,
+            py::arg("cache"),
+            py::arg("model_instance_id_set") =
+                RigidBodyTreeConstants::default_model_instance_id_set,
+            py::arg("in_terms_of_qdot") = false,
+            doc.RigidBodyTree.centroidalMomentumMatrix.doc)
         // forwardKinPositionGradient
         .def("geometricJacobianDotTimesV",
-             &RigidBodyTree<double>::geometricJacobianDotTimesV<T>,
-             py::arg("cache"), py::arg("base_body_or_frame_ind"),
-             py::arg("end_effector_body_or_frame_ind"),
-             py::arg("expressed_in_body_or_frame_ind"),
-             doc.RigidBodyTree.geometricJacobianDotTimesV.doc)
+            &RigidBodyTree<double>::geometricJacobianDotTimesV<T>,
+            py::arg("cache"), py::arg("base_body_or_frame_ind"),
+            py::arg("end_effector_body_or_frame_ind"),
+            py::arg("expressed_in_body_or_frame_ind"),
+            doc.RigidBodyTree.geometricJacobianDotTimesV.doc)
         .def("centerOfMassJacobianDotTimesV",
-             &RigidBodyTree<double>::centerOfMassJacobianDotTimesV<T>,
-             py::arg("cache"),
-             py::arg("model_instance_id_set") =
-                 RigidBodyTreeConstants::default_model_instance_id_set,
-             doc.RigidBodyTree.centerOfMassJacobianDotTimesV.doc)
+            &RigidBodyTree<double>::centerOfMassJacobianDotTimesV<T>,
+            py::arg("cache"),
+            py::arg("model_instance_id_set") =
+                RigidBodyTreeConstants::default_model_instance_id_set,
+            doc.RigidBodyTree.centerOfMassJacobianDotTimesV.doc)
         .def("centroidalMomentumMatrixDotTimesV",
-             &RigidBodyTree<double>::centroidalMomentumMatrixDotTimesV<T>,
-             py::arg("cache"),
-             py::arg("model_instance_id_set") =
-                 RigidBodyTreeConstants::default_model_instance_id_set,
-             doc.RigidBodyTree.centroidalMomentumMatrixDotTimesV.doc)
+            &RigidBodyTree<double>::centroidalMomentumMatrixDotTimesV<T>,
+            py::arg("cache"),
+            py::arg("model_instance_id_set") =
+                RigidBodyTreeConstants::default_model_instance_id_set,
+            doc.RigidBodyTree.centroidalMomentumMatrixDotTimesV.doc)
         .def("positionConstraints",
-             &RigidBodyTree<double>::positionConstraints<T>, py::arg("cache"),
-             doc.RigidBodyTree.positionConstraints.doc)
+            &RigidBodyTree<double>::positionConstraints<T>, py::arg("cache"),
+            doc.RigidBodyTree.positionConstraints.doc)
         .def("positionConstraintsJacobian",
-             &RigidBodyTree<double>::positionConstraintsJacobian<T>,
-             py::arg("cache"), py::arg("in_terms_of_qdot") = true,
-             doc.RigidBodyTree.positionConstraintsJacobian.doc)
+            &RigidBodyTree<double>::positionConstraintsJacobian<T>,
+            py::arg("cache"), py::arg("in_terms_of_qdot") = true,
+            doc.RigidBodyTree.positionConstraintsJacobian.doc)
         .def("positionConstraintsJacDotTimesV",
-             &RigidBodyTree<double>::positionConstraintsJacDotTimesV<T>,
-             py::arg("cache"),
-             doc.RigidBodyTree.positionConstraintsJacDotTimesV.doc)
+            &RigidBodyTree<double>::positionConstraintsJacDotTimesV<T>,
+            py::arg("cache"),
+            doc.RigidBodyTree.positionConstraintsJacDotTimesV.doc)
         // jointLimitConstriants
         .def("relativeTwist", &RigidBodyTree<double>::relativeTwist<T>,
-             py::arg("cache"), py::arg("base_or_frame_ind"),
-             py::arg("body_or_frame_ind"),
-             py::arg("expressed_in_body_or_frame_ind"),
-             doc.RigidBodyTree.relativeTwist.doc)
+            py::arg("cache"), py::arg("base_or_frame_ind"),
+            py::arg("body_or_frame_ind"),
+            py::arg("expressed_in_body_or_frame_ind"),
+            doc.RigidBodyTree.relativeTwist.doc)
         // worldMomentumMatrix
         // worldMomentumMatrixDotTimesV
         // transformSpatialAcceleration
         .def("frictionTorques",
-             [](const RigidBodyTree<double>* self, const VectorX<T>& v) {
-               return self->frictionTorques(v);
-             },
-             doc.RigidBodyTree.frictionTorques.doc)
+            [](const RigidBodyTree<double>* self, const VectorX<T>& v) {
+              return self->frictionTorques(v);
+            },
+            doc.RigidBodyTree.frictionTorques.doc)
         .def("inverseDynamics", &RigidBodyTree<double>::inverseDynamics<T>,
-             py::arg("cache"), py::arg("external_wrenches"), py::arg("vd"),
-             py::arg("include_velocity_terms") = true,
-             doc.RigidBodyTree.inverseDynamics.doc)
+            py::arg("cache"), py::arg("external_wrenches"), py::arg("vd"),
+            py::arg("include_velocity_terms") = true,
+            doc.RigidBodyTree.inverseDynamics.doc)
         // resolveCenterOfPressure
         .def("transformVelocityMappingToQDotMapping",
-             [](const RigidBodyTree<double>& tree,
+            [](const RigidBodyTree<double>& tree,
                 const KinematicsCache<T>& cache, const MatrixX<T>& Av) {
-               return tree.transformVelocityMappingToQDotMapping(cache, Av);
-             },
-             doc.RigidBodyTree.transformVelocityMappingToQDotMapping.doc)
+              return tree.transformVelocityMappingToQDotMapping(cache, Av);
+            },
+            doc.RigidBodyTree.transformVelocityMappingToQDotMapping.doc)
         .def("transformQDotMappingToVelocityMapping",
-             [](const RigidBodyTree<double>& tree,
+            [](const RigidBodyTree<double>& tree,
                 const KinematicsCache<T>& cache, const MatrixX<T>& Ap) {
-               return tree.transformQDotMappingToVelocityMapping(cache, Ap);
-             },
-             doc.RigidBodyTree.transformQDotMappingToVelocityMapping.doc)
+              return tree.transformQDotMappingToVelocityMapping(cache, Ap);
+            },
+            doc.RigidBodyTree.transformQDotMappingToVelocityMapping.doc)
         // relativeQuaternionJacobian
         // relativeRollPitchYawJacobian
         // relativeRollPitchYawJacobianDotTimesV
         // relativeQuaternionJacobianDotTimesV
         // CheckCacheValidity
         .def("doKinematics",
-             [](const RigidBodyTree<double>& tree, const VectorX<T>& q) {
-               return tree.doKinematics(q);
-             },
-             doc.RigidBodyTree.doKinematics.doc)
+            [](const RigidBodyTree<double>& tree, const VectorX<T>& q) {
+              return tree.doKinematics(q);
+            },
+            doc.RigidBodyTree.doKinematics.doc)
         .def("doKinematics",
-             [](const RigidBodyTree<double>& tree, const VectorX<T>& q,
+            [](const RigidBodyTree<double>& tree, const VectorX<T>& q,
                 const VectorX<T>& v) { return tree.doKinematics(q, v); },
-             doc.RigidBodyTree.doKinematics.doc_2);
+            doc.RigidBodyTree.doKinematics.doc_2);
     // CreateKinematicsCacheWithType
     // ComputeMaximumDepthCollisionPoints
     // Type (b) methods:
     tree_cls
         .def("transformPoints",
-             [](const RigidBodyTree<double>& tree,
+            [](const RigidBodyTree<double>& tree,
                 const KinematicsCache<T>& cache,
                 const Eigen::Matrix<double, 3, Eigen::Dynamic>& points,
                 int from_body_or_frame_ind, int to_body_or_frame_ind) {
-               return tree.transformPoints(
-                   cache, points, from_body_or_frame_ind, to_body_or_frame_ind);
-             },
-             doc.RigidBodyTree.transformPoints.doc)
+              return tree.transformPoints(
+                  cache, points, from_body_or_frame_ind, to_body_or_frame_ind);
+            },
+            doc.RigidBodyTree.transformPoints.doc)
         .def("relativeRollPitchYaw",
-             [](const RigidBodyTree<double>& tree,
+            [](const RigidBodyTree<double>& tree,
                 const KinematicsCache<T>& cache, int from_body_or_frame_ind,
                 int to_body_or_frame_ind) {
-               return tree.relativeRollPitchYaw(cache, from_body_or_frame_ind,
-                                                to_body_or_frame_ind);
-             },
-             py::arg("cache"), py::arg("from_body_or_frame_ind"),
-             py::arg("to_body_or_frame_ind"),
-             doc.RigidBodyTree.relativeRollPitchYaw.doc)
+              return tree.relativeRollPitchYaw(
+                  cache, from_body_or_frame_ind, to_body_or_frame_ind);
+            },
+            py::arg("cache"), py::arg("from_body_or_frame_ind"),
+            py::arg("to_body_or_frame_ind"),
+            doc.RigidBodyTree.relativeRollPitchYaw.doc)
         .def("transformPointsJacobian",
-             [](const RigidBodyTree<double>& tree,
+            [](const RigidBodyTree<double>& tree,
                 const KinematicsCache<T>& cache, const Matrix3X<double>& points,
                 int from_body_or_frame_ind, int to_body_or_frame_ind,
                 bool in_terms_of_qdot) {
-               return tree.transformPointsJacobian(
-                   cache, points, from_body_or_frame_ind, to_body_or_frame_ind,
-                   in_terms_of_qdot);
-             },
-             py::arg("cache"), py::arg("points"),
-             py::arg("from_body_or_frame_ind"), py::arg("to_body_or_frame_ind"),
-             py::arg("in_terms_of_qdot"),
-             doc.RigidBodyTree.transformPointsJacobian.doc)
+              return tree.transformPointsJacobian(cache, points,
+                  from_body_or_frame_ind, to_body_or_frame_ind,
+                  in_terms_of_qdot);
+            },
+            py::arg("cache"), py::arg("points"),
+            py::arg("from_body_or_frame_ind"), py::arg("to_body_or_frame_ind"),
+            py::arg("in_terms_of_qdot"),
+            doc.RigidBodyTree.transformPointsJacobian.doc)
         .def("transformPointsJacobianDotTimesV",
-             [](const RigidBodyTree<double>& tree,
+            [](const RigidBodyTree<double>& tree,
                 const KinematicsCache<T>& cache, const Matrix3X<double>& points,
                 int from_body_or_frame_ind, int to_body_or_frame_ind) {
-               return tree.transformPointsJacobianDotTimesV(
-                   cache, points, from_body_or_frame_ind, to_body_or_frame_ind);
-             },
-             py::arg("cache"), py::arg("points"),
-             py::arg("from_body_or_frame_ind"), py::arg("to_body_or_frame_ind"),
-             doc.RigidBodyTree.transformPointsJacobianDotTimesV.doc);
+              return tree.transformPointsJacobianDotTimesV(
+                  cache, points, from_body_or_frame_ind, to_body_or_frame_ind);
+            },
+            py::arg("cache"), py::arg("points"),
+            py::arg("from_body_or_frame_ind"), py::arg("to_body_or_frame_ind"),
+            doc.RigidBodyTree.transformPointsJacobianDotTimesV.doc);
   };
   // Bind for double and AutoDiff.
-  type_visit(add_rigid_body_tree_typed_methods,
-             type_pack<double, AutoDiffXd>{});
+  type_visit(
+      add_rigid_body_tree_typed_methods, type_pack<double, AutoDiffXd>{});
 
   // This class template does not have documentation.
   py::class_<KinematicsCache<double>>(m, "KinematicsCacheDouble");
@@ -474,27 +470,27 @@ PYBIND11_MODULE(rigid_body_tree, m) {
   py::class_<RigidBodyFrame<double>, shared_ptr<RigidBodyFrame<double>>>(
       m, "RigidBodyFrame", doc.RigidBodyFrame.doc)
       .def(py::init<const std::string&, RigidBody<double>*,
-                    const Eigen::VectorXd&, const Eigen::VectorXd&>(),
-           py::arg("name"), py::arg("body"),
-           py::arg("xyz") = Eigen::Vector3d::Zero(),
-           py::arg("rpy") = Eigen::Vector3d::Zero(),
-           doc.RigidBodyFrame.ctor.doc_4args_name_body_xyz_rpy)
+               const Eigen::VectorXd&, const Eigen::VectorXd&>(),
+          py::arg("name"), py::arg("body"),
+          py::arg("xyz") = Eigen::Vector3d::Zero(),
+          py::arg("rpy") = Eigen::Vector3d::Zero(),
+          doc.RigidBodyFrame.ctor.doc_4args_name_body_xyz_rpy)
       .def(py::init<const std::string&, RigidBody<double>*,
-                    const Eigen::Isometry3d&>(),
-           py::arg("name"), py::arg("body"), py::arg("transform_to_body"),
-           doc.RigidBodyFrame.ctor.  // BR
-           doc_4args_name_body_transform_to_body_model_instance_id)
+               const Eigen::Isometry3d&>(),
+          py::arg("name"), py::arg("body"), py::arg("transform_to_body"),
+          doc.RigidBodyFrame.ctor.  // BR
+          doc_4args_name_body_transform_to_body_model_instance_id)
       .def("get_name", &RigidBodyFrame<double>::get_name,
-           doc.RigidBodyFrame.get_name.doc)
+          doc.RigidBodyFrame.get_name.doc)
       .def("get_frame_index", &RigidBodyFrame<double>::get_frame_index,
-           doc.RigidBodyFrame.get_frame_index.doc)
+          doc.RigidBodyFrame.get_frame_index.doc)
       .def("get_rigid_body", &RigidBodyFrame<double>::get_rigid_body,
-           py_reference,
-           // Keep alive: `this` keeps `return` alive.
-           py::keep_alive<1, 0>(), doc.RigidBodyFrame.get_rigid_body.doc)
+          py_reference,
+          // Keep alive: `this` keeps `return` alive.
+          py::keep_alive<1, 0>(), doc.RigidBodyFrame.get_rigid_body.doc)
       .def("get_transform_to_body",
-           &RigidBodyFrame<double>::get_transform_to_body,
-           doc.RigidBodyFrame.get_transform_to_body.doc);
+          &RigidBodyFrame<double>::get_transform_to_body,
+          doc.RigidBodyFrame.get_transform_to_body.doc);
 
   // clang-format off
   const char* const doc_AddModelInstanceFromUrdfFile =
@@ -502,69 +498,66 @@ PYBIND11_MODULE(rigid_body_tree, m) {
       .doc_5args_urdf_filename_floating_base_type_weld_to_frame_do_compile_tree;
   // clang-format on
   m.def("AddModelInstanceFromUrdfFile",
-        [](const std::string& urdf_filename,
-           const FloatingBaseType floating_base_type,
-           shared_ptr<RigidBodyFrame<double>> weld_to_frame,
-           RigidBodyTree<double>* tree, bool do_compile) {
-          return parsers::urdf::AddModelInstanceFromUrdfFile(
-              urdf_filename, floating_base_type, weld_to_frame, do_compile,
-              tree);
-        },
-        py::arg("urdf_filename"), py::arg("floating_base_type"),
-        py::arg("weld_to_frame"), py::arg("tree"), py::arg("do_compile") = true,
-        doc_AddModelInstanceFromUrdfFile);
+      [](const std::string& urdf_filename,
+          const FloatingBaseType floating_base_type,
+          shared_ptr<RigidBodyFrame<double>> weld_to_frame,
+          RigidBodyTree<double>* tree, bool do_compile) {
+        return parsers::urdf::AddModelInstanceFromUrdfFile(
+            urdf_filename, floating_base_type, weld_to_frame, do_compile, tree);
+      },
+      py::arg("urdf_filename"), py::arg("floating_base_type"),
+      py::arg("weld_to_frame"), py::arg("tree"), py::arg("do_compile") = true,
+      doc_AddModelInstanceFromUrdfFile);
 
   m.def("AddModelInstanceFromUrdfStringSearchingInRosPackages",
-        py::overload_cast<const std::string&, const PackageMap&,
-                          const std::string&, const FloatingBaseType,
-                          shared_ptr<RigidBodyFrame<double>>,
-                          RigidBodyTree<double>*>(
-            &parsers::urdf::  // BR
-            AddModelInstanceFromUrdfStringSearchingInRosPackages),
-        doc.drake.parsers.urdf
-            .AddModelInstanceFromUrdfStringSearchingInRosPackages.doc_6args);
+      py::overload_cast<const std::string&, const PackageMap&,
+          const std::string&, const FloatingBaseType,
+          shared_ptr<RigidBodyFrame<double>>,
+          RigidBodyTree<double>*>(
+          &parsers::urdf::  // BR
+          AddModelInstanceFromUrdfStringSearchingInRosPackages),
+      doc.drake.parsers.urdf
+          .AddModelInstanceFromUrdfStringSearchingInRosPackages.doc_6args);
   m.def("AddModelInstancesFromSdfFile",
-        [](const std::string& sdf_filename,
-           const FloatingBaseType floating_base_type,
-           std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
-           RigidBodyTree<double>* tree, bool do_compile) {
-          return sdf::AddModelInstancesFromSdfFile(
-              sdf_filename, floating_base_type, weld_to_frame, do_compile,
-              tree);
-        },
-        py::arg("sdf_filename"), py::arg("floating_base_type"),
-        py::arg("weld_to_frame"), py::arg("tree"), py::arg("do_compile") = true,
-        doc.drake.parsers.sdf.AddModelInstancesFromSdfFile.doc_5args);
+      [](const std::string& sdf_filename,
+          const FloatingBaseType floating_base_type,
+          std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
+          RigidBodyTree<double>* tree, bool do_compile) {
+        return sdf::AddModelInstancesFromSdfFile(
+            sdf_filename, floating_base_type, weld_to_frame, do_compile, tree);
+      },
+      py::arg("sdf_filename"), py::arg("floating_base_type"),
+      py::arg("weld_to_frame"), py::arg("tree"), py::arg("do_compile") = true,
+      doc.drake.parsers.sdf.AddModelInstancesFromSdfFile.doc_5args);
   m.def("AddModelInstancesFromSdfString",
-        py::overload_cast<const std::string&, const FloatingBaseType,
-                          shared_ptr<RigidBodyFrame<double>>,
-                          RigidBodyTree<double>*>(
-            &sdf::AddModelInstancesFromSdfString),
-        doc.drake.parsers.sdf.AddModelInstancesFromSdfString.doc_4args);
+      py::overload_cast<const std::string&, const FloatingBaseType,
+          shared_ptr<RigidBodyFrame<double>>, RigidBodyTree<double>*>(
+          &sdf::AddModelInstancesFromSdfString),
+      doc.drake.parsers.sdf.AddModelInstancesFromSdfString.doc_4args);
   m.def("AddModelInstancesFromSdfStringSearchingInRosPackages",
-        py::overload_cast<
-            const std::string&, const PackageMap&, const FloatingBaseType,
-            shared_ptr<RigidBodyFrame<double>>, RigidBodyTree<double>*>(
-            &sdf::  // BR
-            AddModelInstancesFromSdfStringSearchingInRosPackages),
-        doc.drake.parsers.sdf
-            .AddModelInstancesFromSdfStringSearchingInRosPackages.doc_5args);
+      py::overload_cast<const std::string&, const PackageMap&,
+          const FloatingBaseType, shared_ptr<RigidBodyFrame<double>>,
+          RigidBodyTree<double>*>(
+          &sdf::  // BR
+          AddModelInstancesFromSdfStringSearchingInRosPackages),
+      doc.drake.parsers.sdf.AddModelInstancesFromSdfStringSearchingInRosPackages
+          .doc_5args);
   m.def("AddFlatTerrainToWorld", &multibody::AddFlatTerrainToWorld,
-        py::arg("tree"), py::arg("box_size") = 1000, py::arg("box_depth") = 10,
-        doc.drake.multibody.AddFlatTerrainToWorld.doc);
+      py::arg("tree"), py::arg("box_size") = 1000, py::arg("box_depth") = 10,
+      doc.drake.multibody.AddFlatTerrainToWorld.doc);
 
-  py::class_<RigidBodyActuator>(m, "RigidBodyActuator",
-                                doc.RigidBodyActuator.doc)
-      .def_readonly("name", &RigidBodyActuator::name_,
-                    doc.RigidBodyActuator.name_.doc)
-      .def_readonly("body", &RigidBodyActuator::body_,
-                    doc.RigidBodyActuator.body_.doc)
+  py::class_<RigidBodyActuator>(
+      m, "RigidBodyActuator", doc.RigidBodyActuator.doc)
+      .def_readonly(
+          "name", &RigidBodyActuator::name_, doc.RigidBodyActuator.name_.doc)
+      .def_readonly(
+          "body", &RigidBodyActuator::body_, doc.RigidBodyActuator.body_.doc)
       .def_readonly("reduction", &RigidBodyActuator::reduction_,
-                    doc.RigidBodyActuator.reduction_.doc)
+          doc.RigidBodyActuator.reduction_.doc)
       .def_readonly("effort_limit_min", &RigidBodyActuator::effort_limit_min_,
-                    doc.RigidBodyActuator.effort_limit_min_.doc)
+          doc.RigidBodyActuator.effort_limit_min_.doc)
       .def_readonly("effort_limit_max", &RigidBodyActuator::effort_limit_max_,
-                    doc.RigidBodyActuator.effort_limit_max_.doc);
+          doc.RigidBodyActuator.effort_limit_max_.doc);
 }  // NOLINT(readability/fn_size)
 
 }  // namespace pydrake

--- a/bindings/pydrake/multibody/shapes_py.cc
+++ b/bindings/pydrake/multibody/shapes_py.cc
@@ -31,76 +31,76 @@ PYBIND11_MODULE(shapes, m) {
       .def("getShape", &Geometry::getShape, doc.Geometry.getShape.doc)
       .def("hasFaces", &Geometry::hasFaces, doc.Geometry.hasFaces.doc)
       .def("getFaces",
-           [](const Geometry* self) {
-             TrianglesVector triangles;
-             self->getFaces(&triangles);
-             return triangles;
-           },
-           doc.Geometry.getFaces.doc)
+          [](const Geometry* self) {
+            TrianglesVector triangles;
+            self->getFaces(&triangles);
+            return triangles;
+          },
+          doc.Geometry.getFaces.doc)
       .def("getPoints",
-           [](const Geometry* self) {
-             Eigen::Matrix3Xd pts(3, 0);
-             self->getPoints(pts);
-             return pts;
-           },
-           doc.Geometry.getPoints.doc)
+          [](const Geometry* self) {
+            Eigen::Matrix3Xd pts(3, 0);
+            self->getPoints(pts);
+            return pts;
+          },
+          doc.Geometry.getPoints.doc)
       .def("getBoundingBoxPoints",
-           [](const Geometry* self) {
-             Eigen::Matrix3Xd pts(3, 0);
-             self->getBoundingBoxPoints(pts);
-             return pts;
-           },
-           doc.Geometry.getBoundingBoxPoints.doc_1args);
+          [](const Geometry* self) {
+            Eigen::Matrix3Xd pts(3, 0);
+            self->getBoundingBoxPoints(pts);
+            return pts;
+          },
+          doc.Geometry.getBoundingBoxPoints.doc_1args);
 
   py::class_<Box, Geometry>(m, "Box", doc.Box.doc)
-      .def(py::init<const Eigen::Vector3d&>(), py::arg("size"),
-           doc.Box.ctor.doc)
+      .def(
+          py::init<const Eigen::Vector3d&>(), py::arg("size"), doc.Box.ctor.doc)
       .def_readonly("size", &Box::size, doc.Box.size.doc);
   py::class_<Sphere, Geometry>(m, "Sphere", doc.Sphere.doc)
       .def(py::init<double>(), py::arg("radius"), doc.Sphere.ctor.doc)
       .def_readonly("radius", &Sphere::radius, doc.Sphere.radius.doc);
   py::class_<Cylinder, Geometry>(m, "Cylinder", doc.Cylinder.doc)
       .def(py::init<double, double>(), py::arg("radius"), py::arg("length"),
-           doc.Cylinder.ctor.doc)
+          doc.Cylinder.ctor.doc)
       .def_readonly("radius", &Cylinder::radius, doc.Cylinder.radius.doc)
       .def_readonly("length", &Cylinder::length, doc.Cylinder.length.doc);
   py::class_<Mesh, Geometry>(m, "Mesh", doc.Mesh.doc)
       .def(py::init<const std::string&, const std::string&>(), py::arg("uri"),
-           py::arg("resolved_filename"), doc.Mesh.ctor.doc)
+          py::arg("resolved_filename"), doc.Mesh.ctor.doc)
       .def_readonly("scale", &Mesh::scale_, doc.Mesh.scale_.doc)
       .def_readonly("uri", &Mesh::uri_, doc.Mesh.uri_.doc)
       .def_readonly("resolved_filename", &Mesh::resolved_filename_,
-                    doc.Mesh.resolved_filename_.doc);
+          doc.Mesh.resolved_filename_.doc);
   py::class_<MeshPoints, Geometry>(m, "MeshPoints", doc.MeshPoints.doc)
       .def(py::init<const Eigen::Matrix3Xd&>(), py::arg("points"),
-           doc.MeshPoints.ctor.doc);
+          doc.MeshPoints.ctor.doc);
   py::class_<Capsule, Geometry>(m, "Capsule", doc.Capsule.doc)
       .def(py::init<double, double>(), py::arg("radius"), py::arg("length"),
-           doc.Capsule.ctor.doc)
+          doc.Capsule.ctor.doc)
       .def_readonly("radius", &Capsule::radius, doc.Capsule.radius.doc)
       .def_readonly("length", &Capsule::length, doc.Capsule.length.doc);
 
   py::class_<Element>(m, "Element", doc.Element.doc)
       .def(py::init<const Geometry&, const Eigen::Isometry3d&>(),
-           py::arg("geometry_in"), py::arg("T_element_to_local"))
+          py::arg("geometry_in"), py::arg("T_element_to_local"))
       .def("hasGeometry", &Element::hasGeometry, doc.Element.hasGeometry.doc)
       .def("getGeometry", &Element::getGeometry, py_reference_internal,
-           doc.Element.getGeometry.doc)
+          doc.Element.getGeometry.doc)
       .def("getLocalTransform",
-           [](const Element* self) {
-             return self->getLocalTransform().matrix();
-           },
-           doc.Element.getLocalTransform.doc);
+          [](const Element* self) {
+            return self->getLocalTransform().matrix();
+          },
+          doc.Element.getLocalTransform.doc);
   py::class_<VisualElement, Element>(m, "VisualElement")
       .def(py::init<const Geometry&, const Eigen::Isometry3d&,
-                    const Eigen::Vector4d&, const std::string&>(),
-           py::arg("geometry_in"), py::arg("T_element_to_local"),
-           py::arg("material_in"), py::arg("name") = "",
-           doc.VisualElement.ctor.doc_4args)
+               const Eigen::Vector4d&, const std::string&>(),
+          py::arg("geometry_in"), py::arg("T_element_to_local"),
+          py::arg("material_in"), py::arg("name") = "",
+          doc.VisualElement.ctor.doc_4args)
       .def("setMaterial", &VisualElement::setMaterial,
-           "Apply an RGBA material.", doc.VisualElement.setMaterial.doc)
+          "Apply an RGBA material.", doc.VisualElement.setMaterial.doc)
       .def("getMaterial", &VisualElement::getMaterial, "Get an RGBA material.",
-           doc.VisualElement.getMaterial.doc);
+          doc.VisualElement.getMaterial.doc);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/perception_py.cc
+++ b/bindings/pydrake/perception_py.cc
@@ -35,10 +35,10 @@ void init_pc_flags(py::module m) {
     constexpr auto& cls_doc = doc.Fields;
     py::class_<Class>(m, "Fields", cls_doc.doc)
         .def(py::init<BaseFieldT>(), py::arg("base_fields"),
-             cls_doc.ctor.doc_1args_base_fields)
+            cls_doc.ctor.doc_1args_base_fields)
         .def("base_fields", &Class::base_fields, cls_doc.base_fields.doc)
         .def("has_base_fields", &Class::has_base_fields,
-             cls_doc.has_base_fields.doc)
+            cls_doc.has_base_fields.doc)
         // TODO(eric.cousineau): Bind bitwise operator overloads if they're
         // useful.
         .def(py::self == py::self)
@@ -66,31 +66,31 @@ void init_perception(py::module m) {
     // N.B. Workaround linking error for `constexpr` bits.
     cls.attr("kDefaultValue") = Class::T{Class::kDefaultValue};
     cls.def_static("IsDefaultValue", &Class::IsDefaultValue, py::arg("value"),
-                   cls_doc.IsDefaultValue.doc)
+           cls_doc.IsDefaultValue.doc)
         .def_static("IsInvalidValue", &Class::IsInvalidValue, py::arg("value"),
-                    cls_doc.IsInvalidValue.doc)
+            cls_doc.IsInvalidValue.doc)
         .def(py::init<int, pc_flags::Fields>(), py::arg("new_size") = 0,
-             py::arg("fields") = pc_flags::Fields(pc_flags::kXYZs),
-             cls_doc.ctor.doc_3args)
+            py::arg("fields") = pc_flags::Fields(pc_flags::kXYZs),
+            cls_doc.ctor.doc_3args)
         .def(py::init<const PointCloud&>(), py::arg("other"),
-             cls_doc.ctor.doc_copy)
+            cls_doc.ctor.doc_copy)
         .def("fields", &Class::fields, cls_doc.fields.doc)
         .def("size", &Class::size, cls_doc.size.doc)
         .def("resize",
-             [](PointCloud* self, int new_size) { self->resize(new_size); },
-             py::arg("new_size"), cls_doc.resize.doc)
+            [](PointCloud* self, int new_size) { self->resize(new_size); },
+            py::arg("new_size"), cls_doc.resize.doc)
         .def("has_xyzs", &Class::has_xyzs, cls_doc.has_xyzs.doc)
         .def("xyzs", &Class::xyzs, py_reference_internal, cls_doc.xyzs.doc)
         .def("mutable_xyzs", &Class::mutable_xyzs, py_reference_internal,
-             cls_doc.mutable_xyzs.doc)
+            cls_doc.mutable_xyzs.doc)
         .def("xyz", &Class::xyz, py::arg("i"), cls_doc.xyz.doc)
         .def("mutable_xyz", &Class::mutable_xyz, py::arg("i"),
-             py_reference_internal, cls_doc.mutable_xyz.doc)
+            py_reference_internal, cls_doc.mutable_xyz.doc)
         .def("SetFrom",
-             [](PointCloud* self, const PointCloud& other) {
-               self->SetFrom(other);
-             },
-             py::arg("other"), cls_doc.SetFrom.doc);
+            [](PointCloud* self, const PointCloud& other) {
+              self->SetFrom(other);
+            },
+            py::arg("other"), cls_doc.SetFrom.doc);
   }
 
   pysystems::AddValueInstantiation<PointCloud>(m);
@@ -98,14 +98,14 @@ void init_perception(py::module m) {
   {
     using Class = DepthImageToPointCloud;
     constexpr auto& cls_doc = doc.DepthImageToPointCloud;
-    py::class_<Class, LeafSystem<double>>(m, "DepthImageToPointCloud",
-                                          cls_doc.doc)
+    py::class_<Class, LeafSystem<double>>(
+        m, "DepthImageToPointCloud", cls_doc.doc)
         .def(py::init<const CameraInfo&>(), py::arg("camera_info"),
-             cls_doc.ctor.doc_1args)
+            cls_doc.ctor.doc_1args)
         .def("depth_image_input_port", &Class::depth_image_input_port,
-             py_reference_internal, cls_doc.depth_image_input_port.doc)
+            py_reference_internal, cls_doc.depth_image_input_port.doc)
         .def("point_cloud_output_port", &Class::point_cloud_output_port,
-             py_reference_internal, cls_doc.point_cloud_output_port.doc);
+            py_reference_internal, cls_doc.point_cloud_output_port.doc);
   }
 }
 

--- a/bindings/pydrake/pydrake_pybind.h
+++ b/bindings/pydrake/pydrake_pybind.h
@@ -327,7 +327,7 @@ void DefCopyAndDeepCopy(PyClass* ppy_class) {
   PyClass& py_class = *ppy_class;
   py_class.def("__copy__", [](const Class* self) { return Class{*self}; })
       .def("__deepcopy__",
-           [](const Class* self, py::dict /* memo */) { return Class{*self}; });
+          [](const Class* self, py::dict /* memo */) { return Class{*self}; });
 }
 
 /// Executes Python code to introduce additional symbols for a given module.

--- a/bindings/pydrake/solvers/gurobi_py.cc
+++ b/bindings/pydrake/solvers/gurobi_py.cc
@@ -17,8 +17,8 @@ PYBIND11_MODULE(gurobi, m) {
       py::module::import("pydrake.solvers.mathematicalprogram")
           .attr("MathematicalProgramSolverInterface");
 
-  py::class_<GurobiSolver>(m, "GurobiSolver", solverinterface,
-                           doc.GurobiSolver.doc)
+  py::class_<GurobiSolver>(
+      m, "GurobiSolver", solverinterface, doc.GurobiSolver.doc)
       .def(py::init<>(), doc.GurobiSolver.ctor.doc_0args);
 }
 

--- a/bindings/pydrake/solvers/ik_py.cc
+++ b/bindings/pydrake/solvers/ik_py.cc
@@ -15,135 +15,133 @@ PYBIND11_MODULE(ik, m) {
   m.doc() = "RigidBodyTree inverse kinematics";
   constexpr auto& doc = pydrake_doc;
 
-  py::class_<RigidBodyConstraint>(m, "RigidBodyConstraint",
-                                  doc.RigidBodyConstraint.doc);
+  py::class_<RigidBodyConstraint>(
+      m, "RigidBodyConstraint", doc.RigidBodyConstraint.doc);
 
-  py::class_<PostureConstraint, RigidBodyConstraint>(m, "PostureConstraint",
-                                                     doc.PostureConstraint.doc)
+  py::class_<PostureConstraint, RigidBodyConstraint>(
+      m, "PostureConstraint", doc.PostureConstraint.doc)
       .def(py::init<RigidBodyTree<double>*, const Eigen::Vector2d&>(),
-           py::arg("model"),
-           py::arg("tspan") = DrakeRigidBodyConstraint::default_tspan,
-           doc.PostureConstraint.ctor.doc)
+          py::arg("model"),
+          py::arg("tspan") = DrakeRigidBodyConstraint::default_tspan,
+          doc.PostureConstraint.ctor.doc)
       .def("setJointLimits",
-           static_cast<void (PostureConstraint::*)(  // NOLINT
-               const Eigen::VectorXi&, const Eigen::VectorXd&,
-               const Eigen::VectorXd&)>(&PostureConstraint::setJointLimits),
-           doc.PostureConstraint.setJointLimits.doc_3args);
+          static_cast<void (PostureConstraint::*)(  // NOLINT
+              const Eigen::VectorXi&, const Eigen::VectorXd&,
+              const Eigen::VectorXd&)>(&PostureConstraint::setJointLimits),
+          doc.PostureConstraint.setJointLimits.doc_3args);
 
   py::class_<WorldPositionConstraint, RigidBodyConstraint>(
       m, "_WorldPositionConstraint", doc.WorldPositionConstraint.doc)
       .def(py::init<RigidBodyTree<double>*, int, const Eigen::Matrix3Xd&,
-                    Eigen::MatrixXd, Eigen::MatrixXd, const Eigen::Vector2d&>(),
-           py::arg("model"), py::arg("body"), py::arg("pts"), py::arg("lb"),
-           py::arg("ub"),
-           py::arg("tspan") = DrakeRigidBodyConstraint::default_tspan,
-           doc.WorldPositionConstraint.ctor.doc);
+               Eigen::MatrixXd, Eigen::MatrixXd, const Eigen::Vector2d&>(),
+          py::arg("model"), py::arg("body"), py::arg("pts"), py::arg("lb"),
+          py::arg("ub"),
+          py::arg("tspan") = DrakeRigidBodyConstraint::default_tspan,
+          doc.WorldPositionConstraint.ctor.doc);
 
   py::class_<RelativePositionConstraint, RigidBodyConstraint>(
       m, "RelativePositionConstraint", doc.RelativePositionConstraint.doc)
       .def(py::init<RigidBodyTree<double>*, const Eigen::Matrix3Xd&,
-                    const Eigen::MatrixXd&, const Eigen::MatrixXd&, int, int,
-                    const Eigen::Matrix<double, 7, 1>&,
-                    const Eigen::Vector2d&>(),
-           py::arg("model"), py::arg("pts"), py::arg("lb"), py::arg("ub"),
-           py::arg("bodyA_idx"), py::arg("bodyB_idx"), py::arg("bTbp"),
-           py::arg("tspan") = DrakeRigidBodyConstraint::default_tspan,
-           doc.RelativePositionConstraint.ctor.doc);
+               const Eigen::MatrixXd&, const Eigen::MatrixXd&, int, int,
+               const Eigen::Matrix<double, 7, 1>&, const Eigen::Vector2d&>(),
+          py::arg("model"), py::arg("pts"), py::arg("lb"), py::arg("ub"),
+          py::arg("bodyA_idx"), py::arg("bodyB_idx"), py::arg("bTbp"),
+          py::arg("tspan") = DrakeRigidBodyConstraint::default_tspan,
+          doc.RelativePositionConstraint.ctor.doc);
 
   py::class_<RelativeQuatConstraint, RigidBodyConstraint>(
       m, "RelativeQuatConstraint", doc.RelativeQuatConstraint.doc)
       .def(py::init<RigidBodyTree<double>*, int, int, const Eigen::Vector4d&,
-                    double, const Eigen::Vector2d&>(),
-           py::arg("model"), py::arg("bodyA_idx"), py::arg("bodyB_idx"),
-           py::arg("quat_des"), py::arg("tol"),
-           py::arg("tspan") = DrakeRigidBodyConstraint::default_tspan,
-           doc.RelativeQuatConstraint.ctor.doc);
+               double, const Eigen::Vector2d&>(),
+          py::arg("model"), py::arg("bodyA_idx"), py::arg("bodyB_idx"),
+          py::arg("quat_des"), py::arg("tol"),
+          py::arg("tspan") = DrakeRigidBodyConstraint::default_tspan,
+          doc.RelativeQuatConstraint.ctor.doc);
 
-  py::class_<WorldPositionInFrameConstraint, RigidBodyConstraint>(
-      m, "_WorldPositionInFrameConstraint",
-      doc.WorldPositionInFrameConstraint.doc)
+  py::class_<WorldPositionInFrameConstraint, RigidBodyConstraint>(m,
+      "_WorldPositionInFrameConstraint", doc.WorldPositionInFrameConstraint.doc)
       .def(py::init<RigidBodyTree<double>*, int, const Eigen::Matrix3Xd&,
-                    const Eigen::Matrix4d&, const Eigen::MatrixXd&,
-                    const Eigen::MatrixXd&, const Eigen::Vector2d&>(),
-           py::arg("model"), py::arg("body"), py::arg("pts"),
-           py::arg("T_world_to_frame"), py::arg("lb"), py::arg("ub"),
-           py::arg("tspan") = DrakeRigidBodyConstraint::default_tspan,
-           doc.WorldPositionInFrameConstraint.ctor.doc);
+               const Eigen::Matrix4d&, const Eigen::MatrixXd&,
+               const Eigen::MatrixXd&, const Eigen::Vector2d&>(),
+          py::arg("model"), py::arg("body"), py::arg("pts"),
+          py::arg("T_world_to_frame"), py::arg("lb"), py::arg("ub"),
+          py::arg("tspan") = DrakeRigidBodyConstraint::default_tspan,
+          doc.WorldPositionInFrameConstraint.ctor.doc);
 
   py::class_<WorldGazeDirConstraint, RigidBodyConstraint>(
       m, "WorldGazeDirConstraint", doc.WorldGazeDirConstraint.doc)
       .def(py::init<RigidBodyTree<double>*, int, const Eigen::Vector3d&,
-                    const Eigen::Vector3d&, double, const Eigen::Vector2d&>(),
-           py::arg("model"), py::arg("body"), py::arg("axis"), py::arg("dir"),
-           py::arg("conethreshold"),
-           py::arg("tspan") = DrakeRigidBodyConstraint::default_tspan,
-           doc.WorldGazeDirConstraint.ctor.doc);
+               const Eigen::Vector3d&, double, const Eigen::Vector2d&>(),
+          py::arg("model"), py::arg("body"), py::arg("axis"), py::arg("dir"),
+          py::arg("conethreshold"),
+          py::arg("tspan") = DrakeRigidBodyConstraint::default_tspan,
+          doc.WorldGazeDirConstraint.ctor.doc);
 
   py::class_<WorldGazeTargetConstraint, RigidBodyConstraint>(
       m, "WorldGazeTargetConstraint", doc.WorldGazeTargetConstraint.doc)
       .def(py::init<RigidBodyTree<double>*, int, const Eigen::Vector3d&,
-                    const Eigen::Vector3d&, const Eigen::Vector3d&, double,
-                    const Eigen::Vector2d&>(),
-           py::arg("model"), py::arg("body"), py::arg("axis"),
-           py::arg("target"), py::arg("gaze_origin"), py::arg("conethreshold"),
-           py::arg("tspan") = DrakeRigidBodyConstraint::default_tspan,
-           doc.WorldGazeTargetConstraint.ctor.doc);
+               const Eigen::Vector3d&, const Eigen::Vector3d&, double,
+               const Eigen::Vector2d&>(),
+          py::arg("model"), py::arg("body"), py::arg("axis"), py::arg("target"),
+          py::arg("gaze_origin"), py::arg("conethreshold"),
+          py::arg("tspan") = DrakeRigidBodyConstraint::default_tspan,
+          doc.WorldGazeTargetConstraint.ctor.doc);
 
   py::class_<RelativeGazeDirConstraint, RigidBodyConstraint>(
       m, "RelativeGazeDirConstraint", doc.RelativeGazeDirConstraint.doc)
       .def(py::init<RigidBodyTree<double>*, int, int, const Eigen::Vector3d&,
-                    const Eigen::Vector3d&, double, const Eigen::Vector2d&>(),
-           py::arg("model"), py::arg("bodyA_idx"), py::arg("bodyB_idx"),
-           py::arg("axis"), py::arg("dir"), py::arg("conethreshold"),
-           py::arg("tspan") = DrakeRigidBodyConstraint::default_tspan,
-           doc.RelativeGazeDirConstraint.ctor.doc);
+               const Eigen::Vector3d&, double, const Eigen::Vector2d&>(),
+          py::arg("model"), py::arg("bodyA_idx"), py::arg("bodyB_idx"),
+          py::arg("axis"), py::arg("dir"), py::arg("conethreshold"),
+          py::arg("tspan") = DrakeRigidBodyConstraint::default_tspan,
+          doc.RelativeGazeDirConstraint.ctor.doc);
 
   py::class_<MinDistanceConstraint, RigidBodyConstraint>(
       m, "MinDistanceConstraint", doc.MinDistanceConstraint.doc)
       .def(py::init<RigidBodyTree<double>*, double, const std::vector<int>&,
-                    const std::set<std::string>&, const Eigen::Vector2d&>(),
-           py::arg("model"), py::arg("min_distance"),
-           py::arg("active_bodies_idx"), py::arg("active_group_names"),
-           py::arg("tspan") = DrakeRigidBodyConstraint::default_tspan,
-           doc.MinDistanceConstraint.ctor.doc);
+               const std::set<std::string>&, const Eigen::Vector2d&>(),
+          py::arg("model"), py::arg("min_distance"),
+          py::arg("active_bodies_idx"), py::arg("active_group_names"),
+          py::arg("tspan") = DrakeRigidBodyConstraint::default_tspan,
+          doc.MinDistanceConstraint.ctor.doc);
 
   py::class_<WorldEulerConstraint, RigidBodyConstraint>(
       m, "WorldEulerConstraint", doc.WorldEulerConstraint.doc)
       .def(py::init<RigidBodyTree<double>*, int, const Eigen::Vector3d&,
-                    const Eigen::Vector3d&, const Eigen::Vector2d>(),
-           py::arg("model"), py::arg("body"), py::arg("lb"), py::arg("ub"),
-           py::arg("tspan") = DrakeRigidBodyConstraint::default_tspan,
-           doc.WorldEulerConstraint.ctor.doc);
+               const Eigen::Vector3d&, const Eigen::Vector2d>(),
+          py::arg("model"), py::arg("body"), py::arg("lb"), py::arg("ub"),
+          py::arg("tspan") = DrakeRigidBodyConstraint::default_tspan,
+          doc.WorldEulerConstraint.ctor.doc);
 
   py::class_<WorldQuatConstraint, RigidBodyConstraint>(
       m, "WorldQuatConstraint", doc.WorldQuatConstraint.doc)
       .def(py::init<RigidBodyTree<double>*, int, const Eigen::Vector4d&, double,
-                    const Eigen::Vector2d>(),
-           py::arg("model"), py::arg("body"), py::arg("quat_des"),
-           py::arg("tol"),
-           py::arg("tspan") = DrakeRigidBodyConstraint::default_tspan,
-           doc.WorldQuatConstraint.ctor.doc);
+               const Eigen::Vector2d>(),
+          py::arg("model"), py::arg("body"), py::arg("quat_des"),
+          py::arg("tol"),
+          py::arg("tspan") = DrakeRigidBodyConstraint::default_tspan,
+          doc.WorldQuatConstraint.ctor.doc);
 
   py::class_<QuasiStaticConstraint, RigidBodyConstraint>(
       m, "QuasiStaticConstraint", doc.QuasiStaticConstraint.doc)
       .def(py::init<RigidBodyTree<double>*, const Eigen::Vector2d&>(),
-           py::arg("model"),
-           py::arg("tspan") = DrakeRigidBodyConstraint::default_tspan,
-           doc.QuasiStaticConstraint.ctor.doc)
+          py::arg("model"),
+          py::arg("tspan") = DrakeRigidBodyConstraint::default_tspan,
+          doc.QuasiStaticConstraint.ctor.doc)
       .def(py::init<RigidBodyTree<double>*, const Eigen::Vector2d&,
-                    const std::set<int>&>(),
-           doc.QuasiStaticConstraint.ctor.doc)
+               const std::set<int>&>(),
+          doc.QuasiStaticConstraint.ctor.doc)
       .def("setActive", &QuasiStaticConstraint::setActive,
-           doc.QuasiStaticConstraint.setActive.doc)
+          doc.QuasiStaticConstraint.setActive.doc)
       .def("bounds", &QuasiStaticConstraint::bounds,
-           doc.QuasiStaticConstraint.bounds.doc)
+          doc.QuasiStaticConstraint.bounds.doc)
       .def("setShrinkFactor", &QuasiStaticConstraint::setShrinkFactor,
-           doc.QuasiStaticConstraint.setShrinkFactor.doc)
+          doc.QuasiStaticConstraint.setShrinkFactor.doc)
       .def("addContact",
-           static_cast<void (QuasiStaticConstraint::*)(  // NOLINT
-               std::vector<int>, const Eigen::Matrix3Xd&)>(
-               &QuasiStaticConstraint::addContact),
-           doc.QuasiStaticConstraint.addContact.doc_2args);
+          static_cast<void (QuasiStaticConstraint::*)(  // NOLINT
+              std::vector<int>, const Eigen::Matrix3Xd&)>(
+              &QuasiStaticConstraint::addContact),
+          doc.QuasiStaticConstraint.addContact.doc_2args);
 
   py::class_<IKoptions>(m, "IKoptions", doc.IKoptions.doc)
       .def(py::init<RigidBodyTree<double>*>(), doc.IKoptions.ctor.doc_1args)
@@ -156,37 +154,37 @@ PYBIND11_MODULE(ik, m) {
       .def("setDebug", &IKoptions::setDebug, doc.IKoptions.setDebug.doc)
       .def("getDebug", &IKoptions::getDebug, doc.IKoptions.getDebug.doc)
       .def("setSequentialSeedFlag", &IKoptions::setSequentialSeedFlag,
-           doc.IKoptions.setSequentialSeedFlag.doc)
+          doc.IKoptions.setSequentialSeedFlag.doc)
       .def("getSequentialSeedFlag", &IKoptions::getSequentialSeedFlag,
-           doc.IKoptions.getSequentialSeedFlag.doc)
+          doc.IKoptions.getSequentialSeedFlag.doc)
       .def("setMajorOptimalityTolerance",
-           &IKoptions::setMajorOptimalityTolerance,
-           doc.IKoptions.setMajorOptimalityTolerance.doc)
+          &IKoptions::setMajorOptimalityTolerance,
+          doc.IKoptions.setMajorOptimalityTolerance.doc)
       .def("getMajorOptimalityTolerance",
-           &IKoptions::getMajorOptimalityTolerance,
-           doc.IKoptions.getMajorOptimalityTolerance.doc)
+          &IKoptions::getMajorOptimalityTolerance,
+          doc.IKoptions.getMajorOptimalityTolerance.doc)
       .def("setMajorFeasibilityTolerance",
-           &IKoptions::setMajorFeasibilityTolerance,
-           doc.IKoptions.setMajorFeasibilityTolerance.doc)
+          &IKoptions::setMajorFeasibilityTolerance,
+          doc.IKoptions.setMajorFeasibilityTolerance.doc)
       .def("getMajorFeasibilityTolerance",
-           &IKoptions::getMajorFeasibilityTolerance,
-           doc.IKoptions.getMajorFeasibilityTolerance.doc)
+          &IKoptions::getMajorFeasibilityTolerance,
+          doc.IKoptions.getMajorFeasibilityTolerance.doc)
       .def("setSuperbasicsLimit", &IKoptions::setSuperbasicsLimit,
-           doc.IKoptions.setSuperbasicsLimit.doc)
+          doc.IKoptions.setSuperbasicsLimit.doc)
       .def("getSuperbasicsLimit", &IKoptions::getSuperbasicsLimit,
-           doc.IKoptions.getSuperbasicsLimit.doc)
+          doc.IKoptions.getSuperbasicsLimit.doc)
       .def("setMajorIterationsLimit", &IKoptions::setMajorIterationsLimit,
-           doc.IKoptions.setMajorIterationsLimit.doc)
+          doc.IKoptions.setMajorIterationsLimit.doc)
       .def("getMajorIterationsLimit", &IKoptions::getMajorIterationsLimit,
-           doc.IKoptions.getMajorIterationsLimit.doc)
+          doc.IKoptions.getMajorIterationsLimit.doc)
       .def("setIterationsLimit", &IKoptions::setIterationsLimit,
-           doc.IKoptions.setIterationsLimit.doc)
+          doc.IKoptions.setIterationsLimit.doc)
       .def("getIterationsLimit", &IKoptions::getIterationsLimit,
-           doc.IKoptions.getIterationsLimit.doc)
+          doc.IKoptions.getIterationsLimit.doc)
       .def("setFixInitialState", &IKoptions::setFixInitialState,
-           doc.IKoptions.setFixInitialState.doc)
+          doc.IKoptions.setFixInitialState.doc)
       .def("getFixInitialState", &IKoptions::getFixInitialState,
-           doc.IKoptions.getFixInitialState.doc)
+          doc.IKoptions.getFixInitialState.doc)
       .def("setq0", &IKoptions::setq0, doc.IKoptions.setq0.doc)
       .def("getq0", &IKoptions::getq0, doc.IKoptions.getq0.doc)
       .def("setqd0", &IKoptions::setqd0, doc.IKoptions.setqd0.doc)
@@ -194,23 +192,22 @@ PYBIND11_MODULE(ik, m) {
       .def("setqdf", &IKoptions::setqdf, doc.IKoptions.setqdf.doc)
       .def("getqdf", &IKoptions::getqdf, doc.IKoptions.getqdf.doc)
       .def("setAdditionaltSamples", &IKoptions::setAdditionaltSamples,
-           doc.IKoptions.setAdditionaltSamples.doc)
+          doc.IKoptions.setAdditionaltSamples.doc)
       .def("getAdditionaltSamples", &IKoptions::getAdditionaltSamples,
-           doc.IKoptions.getAdditionaltSamples.doc);
+          doc.IKoptions.getAdditionaltSamples.doc);
 
   m.def("InverseKin",
-        static_cast<IKResults (*)(  // NOLINT
-            RigidBodyTree<double>*, const Eigen::VectorXd&,
-            const Eigen::VectorXd&, const std::vector<RigidBodyConstraint*>&,
-            const IKoptions&)>(&inverseKinSimple),
-        doc.inverseKin.doc);
+      static_cast<IKResults (*)(  // NOLINT
+          RigidBodyTree<double>*, const Eigen::VectorXd&,
+          const Eigen::VectorXd&, const std::vector<RigidBodyConstraint*>&,
+          const IKoptions&)>(&inverseKinSimple),
+      doc.inverseKin.doc);
 
-  m.def(
-      "InverseKinPointwise",
+  m.def("InverseKinPointwise",
       static_cast<IKResults (*)(RigidBodyTree<double>*, const Eigen::VectorXd&,
-                                const Eigen::MatrixXd&, const Eigen::MatrixXd&,
-                                const std::vector<RigidBodyConstraint*>&,
-                                const IKoptions&)>(&inverseKinPointwiseSimple),
+          const Eigen::MatrixXd&, const Eigen::MatrixXd&,
+          const std::vector<RigidBodyConstraint*>&, const IKoptions&)>(
+          &inverseKinPointwiseSimple),
       doc.inverseKinPointwise.doc);
 
   m.def("InverseKinTraj", &inverseKinTrajSimple, doc.inverseKinTraj.doc);
@@ -219,8 +216,8 @@ PYBIND11_MODULE(ik, m) {
       .def_readonly("q_sol", &IKResults::q_sol, doc.IKResults.q_sol.doc)
       .def_readonly("info", &IKResults::info, doc.IKResults.info.doc)
       .def_readonly("infeasible_constraints",
-                    &IKResults::infeasible_constraints,
-                    doc.IKResults.infeasible_constraints.doc);
+          &IKResults::infeasible_constraints,
+          doc.IKResults.infeasible_constraints.doc);
 
   ExecuteExtraPythonCode(m);
 }

--- a/bindings/pydrake/solvers/ipopt_py.cc
+++ b/bindings/pydrake/solvers/ipopt_py.cc
@@ -17,8 +17,8 @@ PYBIND11_MODULE(ipopt, m) {
       py::module::import("pydrake.solvers.mathematicalprogram")
           .attr("MathematicalProgramSolverInterface");
 
-  py::class_<IpoptSolver>(m, "IpoptSolver", solverinterface,
-                          doc.IpoptSolver.doc)
+  py::class_<IpoptSolver>(
+      m, "IpoptSolver", solverinterface, doc.IpoptSolver.doc)
       .def(py::init<>(), doc.IpoptSolver.ctor.doc_0args);
 }
 

--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -58,8 +58,7 @@ namespace {
 /// Helper to adapt SolverType to SolverId.
 template <typename Value>
 void SetSolverOptionBySolverType(MathematicalProgram* self,
-                                 SolverType solver_type, const std::string& key,
-                                 const Value& value) {
+    SolverType solver_type, const std::string& key, const Value& value) {
   self->SetSolverOption(SolverTypeConverter::TypeToId(solver_type), key, value);
 }
 
@@ -73,8 +72,7 @@ void SetSolverOptionBySolverType(MathematicalProgram* self,
  */
 template <typename C>
 auto RegisterBinding(py::handle* pscope,
-                     py::class_<MathematicalProgram>* pprog_cls,
-                     const string& name) {
+    py::class_<MathematicalProgram>* pprog_cls, const string& name) {
   auto& scope = *pscope;
   auto& prog_cls = *pprog_cls;
   typedef Binding<C> B;
@@ -85,13 +83,11 @@ auto RegisterBinding(py::handle* pscope,
                          .def("constraint", &B::evaluator)
                          .def("variables", &B::variables);
   // Deprecate `constraint`.
-  DeprecateAttribute(
-      binding_cls, "constraint",
+  DeprecateAttribute(binding_cls, "constraint",
       "`constraint` is deprecated; please use `evaluator` instead.");
   // Register overloads for MathematicalProgram class
   // TODO(m-chaturvedi) Add Pybind11 documentation.
-  prog_cls.def(
-      "EvalBindingAtSolution",
+  prog_cls.def("EvalBindingAtSolution",
       static_cast<Eigen::VectorXd (MathematicalProgram::*)(const B&) const>(
           &MathematicalProgram::EvalBindingAtSolution));
   return binding_cls;
@@ -102,25 +98,25 @@ class PyFunctionCost : public Cost {
   using DoubleFunc = std::function<double(const Eigen::VectorXd&)>;
   using AutoDiffFunc = std::function<AutoDiffXd(const VectorX<AutoDiffXd>&)>;
 
-  PyFunctionCost(int num_vars, const py::function& func,
-                 const std::string& description)
+  PyFunctionCost(
+      int num_vars, const py::function& func, const std::string& description)
       : Cost(num_vars, description),
         double_func_(py::cast<DoubleFunc>(func)),
         autodiff_func_(py::cast<AutoDiffFunc>(func)) {}
 
  protected:
   void DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
-              Eigen::VectorXd* y) const override {
+      Eigen::VectorXd* y) const override {
     (*y)[0] = double_func_(x);
   }
 
   void DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
-              AutoDiffVecXd* y) const override {
+      AutoDiffVecXd* y) const override {
     (*y)[0] = autodiff_func_(x);
   }
 
   void DoEval(const Eigen::Ref<const VectorX<symbolic::Variable>>&,
-              VectorX<symbolic::Expression>*) const override {
+      VectorX<symbolic::Expression>*) const override {
     throw std::logic_error(
         "PyFunctionCost does not support symbolic evaluation.");
   }
@@ -137,25 +133,25 @@ class PyFunctionConstraint : public Constraint {
       std::function<VectorX<AutoDiffXd>(const VectorX<AutoDiffXd>&)>;
 
   PyFunctionConstraint(int num_vars, const py::function& func,
-                       const Eigen::VectorXd& lb, const Eigen::VectorXd& ub,
-                       const std::string& description)
+      const Eigen::VectorXd& lb, const Eigen::VectorXd& ub,
+      const std::string& description)
       : Constraint(lb.size(), num_vars, lb, ub, description),
         double_func_(py::cast<DoubleFunc>(func)),
         autodiff_func_(py::cast<AutoDiffFunc>(func)) {}
 
  protected:
   void DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
-              Eigen::VectorXd* y) const override {
+      Eigen::VectorXd* y) const override {
     *y = double_func_(x);
   }
 
   void DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
-              AutoDiffVecXd* y) const override {
+      AutoDiffVecXd* y) const override {
     *y = autodiff_func_(x);
   }
 
   void DoEval(const Eigen::Ref<const VectorX<symbolic::Variable>>&,
-              VectorX<symbolic::Expression>*) const override {
+      VectorX<symbolic::Expression>*) const override {
     throw std::logic_error(
         "PyFunctionConstraint does not support symbolic evaluation.");
   }
@@ -179,25 +175,25 @@ PYBIND11_MODULE(mathematicalprogram, m) {
       py::module::import("pydrake.symbolic").attr("Expression");
   py::object formula = py::module::import("pydrake.symbolic").attr("Formula");
 
-  py::class_<MathematicalProgramSolverInterface>(
-      m, "MathematicalProgramSolverInterface",
+  py::class_<MathematicalProgramSolverInterface>(m,
+      "MathematicalProgramSolverInterface",
       doc.MathematicalProgramSolverInterface.doc)
       .def("available", &MathematicalProgramSolverInterface::available,
-           doc.MathematicalProgramSolverInterface.available.doc)
+          doc.MathematicalProgramSolverInterface.available.doc)
       .def("solver_id", &MathematicalProgramSolverInterface::solver_id,
-           doc.MathematicalProgramSolverInterface.solver_id.doc)
+          doc.MathematicalProgramSolverInterface.solver_id.doc)
       .def("Solve",
-           // NOLINTNEXTLINE(whitespace/parens)
-           static_cast<SolutionResult (MathematicalProgramSolverInterface::*)(
-               MathematicalProgram&) const>(
-               &MathematicalProgramSolverInterface::Solve),
-           py::arg("prog"),
-           doc.MathematicalProgramSolverInterface.Solve.doc_1args)
+          // NOLINTNEXTLINE(whitespace/parens)
+          static_cast<SolutionResult (MathematicalProgramSolverInterface::*)(
+              MathematicalProgram&) const>(
+              &MathematicalProgramSolverInterface::Solve),
+          py::arg("prog"),
+          doc.MathematicalProgramSolverInterface.Solve.doc_1args)
       // TODO(m-chaturvedi) Add Pybind11 documentation.
       .def("solver_type",
-           [](const MathematicalProgramSolverInterface& self) {
-             return SolverTypeConverter::IdToType(self.solver_id());
-           })
+          [](const MathematicalProgramSolverInterface& self) {
+            return SolverTypeConverter::IdToType(self.solver_id());
+          })
       .def("SolverName", [](const MathematicalProgramSolverInterface& self) {
         return self.solver_id().name();
       });
@@ -208,466 +204,455 @@ PYBIND11_MODULE(mathematicalprogram, m) {
   py::enum_<SolverType>(m, "SolverType", doc.SolverType.doc)
       .value("kDReal", SolverType::kDReal, doc.SolverType.kDReal.doc)
       .value("kEqualityConstrainedQP", SolverType::kEqualityConstrainedQP,
-             doc.SolverType.kEqualityConstrainedQP.doc)
+          doc.SolverType.kEqualityConstrainedQP.doc)
       .value("kGurobi", SolverType::kGurobi, doc.SolverType.kGurobi.doc)
       .value("kIpopt", SolverType::kIpopt, doc.SolverType.kIpopt.doc)
       .value("kLinearSystem", SolverType::kLinearSystem,
-             doc.SolverType.kLinearSystem.doc)
+          doc.SolverType.kLinearSystem.doc)
       .value("kMobyLCP", SolverType::kMobyLCP, doc.SolverType.kMobyLCP.doc)
       .value("kMosek", SolverType::kMosek, doc.SolverType.kMosek.doc)
       .value("kNlopt", SolverType::kNlopt, doc.SolverType.kNlopt.doc)
       .value("kOsqp", SolverType::kOsqp, doc.SolverType.kOsqp.doc)
       .value("kSnopt", SolverType::kSnopt, doc.SolverType.kSnopt.doc);
 
-  py::class_<MathematicalProgram> prog_cls(m, "MathematicalProgram",
-                                           doc.MathematicalProgram.doc);
+  py::class_<MathematicalProgram> prog_cls(
+      m, "MathematicalProgram", doc.MathematicalProgram.doc);
   prog_cls.def(py::init<>(), doc.MathematicalProgram.ctor.doc_0args)
       .def("NewContinuousVariables",
-           // NOLINTNEXTLINE(whitespace/parens)
-           static_cast<VectorXDecisionVariable (MathematicalProgram::*)(
-               int, const std::string&)>(
-               &MathematicalProgram::NewContinuousVariables),
-           py::arg("rows"), py::arg("name") = "x",
-           doc.MathematicalProgram.NewContinuousVariables.doc)
+          // NOLINTNEXTLINE(whitespace/parens)
+          static_cast<VectorXDecisionVariable (MathematicalProgram::*)(
+              int, const std::string&)>(
+              &MathematicalProgram::NewContinuousVariables),
+          py::arg("rows"), py::arg("name") = "x",
+          doc.MathematicalProgram.NewContinuousVariables.doc)
       .def("NewContinuousVariables",
-           // NOLINTNEXTLINE(whitespace/parens)
-           static_cast<MatrixXDecisionVariable (MathematicalProgram::*)(
-               int, int, const std::string&)>(
-               &MathematicalProgram::NewContinuousVariables),
-           py::arg("rows"), py::arg("cols"), py::arg("name") = "x",
-           doc.MathematicalProgram.NewContinuousVariables.doc_2)
+          // NOLINTNEXTLINE(whitespace/parens)
+          static_cast<MatrixXDecisionVariable (MathematicalProgram::*)(
+              int, int, const std::string&)>(
+              &MathematicalProgram::NewContinuousVariables),
+          py::arg("rows"), py::arg("cols"), py::arg("name") = "x",
+          doc.MathematicalProgram.NewContinuousVariables.doc_2)
       .def("NewBinaryVariables",
-           // NOLINTNEXTLINE(whitespace/parens)
-           static_cast<VectorXDecisionVariable (MathematicalProgram::*)(
-               int, const std::string&)>(
-               &MathematicalProgram::NewBinaryVariables),
-           py::arg("rows"), py::arg("name") = "b",
-           doc.MathematicalProgram.NewBinaryVariables.doc)
+          // NOLINTNEXTLINE(whitespace/parens)
+          static_cast<VectorXDecisionVariable (MathematicalProgram::*)(int,
+              const std::string&)>(&MathematicalProgram::NewBinaryVariables),
+          py::arg("rows"), py::arg("name") = "b",
+          doc.MathematicalProgram.NewBinaryVariables.doc)
       .def("NewBinaryVariables",
-           py::overload_cast<int, int, const string&>(
-               &MathematicalProgram::NewBinaryVariables<Dynamic, Dynamic>),
-           py::arg("rows"), py::arg("cols"), py::arg("name") = "b",
-           doc.MathematicalProgram.NewBinaryVariables.doc_2)
+          py::overload_cast<int, int, const string&>(
+              &MathematicalProgram::NewBinaryVariables<Dynamic, Dynamic>),
+          py::arg("rows"), py::arg("cols"), py::arg("name") = "b",
+          doc.MathematicalProgram.NewBinaryVariables.doc_2)
       .def("NewSymmetricContinuousVariables",
-           // `py::overload_cast` and `overload_cast_explict` struggle with
-           // overloads that compete with templated methods.
-           [](MathematicalProgram* self, int rows, const string& name) {
-             return self->NewSymmetricContinuousVariables(rows, name);
-           },
-           py::arg("rows"), py::arg("name") = "Symmetric",
-           doc.MathematicalProgram.NewSymmetricContinuousVariables.doc_2args)
+          // `py::overload_cast` and `overload_cast_explict` struggle with
+          // overloads that compete with templated methods.
+          [](MathematicalProgram* self, int rows, const string& name) {
+            return self->NewSymmetricContinuousVariables(rows, name);
+          },
+          py::arg("rows"), py::arg("name") = "Symmetric",
+          doc.MathematicalProgram.NewSymmetricContinuousVariables.doc_2args)
       .def("NewFreePolynomial", &MathematicalProgram::NewFreePolynomial,
-           py::arg("indeterminates"), py::arg("deg"),
-           py::arg("coeff_name") = "a",
-           doc.MathematicalProgram.NewFreePolynomial.doc)
+          py::arg("indeterminates"), py::arg("deg"),
+          py::arg("coeff_name") = "a",
+          doc.MathematicalProgram.NewFreePolynomial.doc)
       .def("NewSosPolynomial",
-           static_cast<
-               std::pair<Polynomial, Binding<PositiveSemidefiniteConstraint>> (
-                   MathematicalProgram::*)(
-                   const Eigen::Ref<const VectorX<Monomial>>&)>(
-               &MathematicalProgram::NewSosPolynomial),
-           doc.MathematicalProgram.NewSosPolynomial.doc_1args)
+          static_cast<std::pair<Polynomial,
+              Binding<PositiveSemidefiniteConstraint>> (MathematicalProgram::*)(
+              const Eigen::Ref<const VectorX<Monomial>>&)>(
+              &MathematicalProgram::NewSosPolynomial),
+          doc.MathematicalProgram.NewSosPolynomial.doc_1args)
       .def("NewSosPolynomial",
-           static_cast<
-               std::pair<Polynomial, Binding<PositiveSemidefiniteConstraint>> (
-                   MathematicalProgram::*)(const Variables&, int)>(
-               &MathematicalProgram::NewSosPolynomial),
-           doc.MathematicalProgram.NewSosPolynomial.doc_2args)
+          static_cast<
+              std::pair<Polynomial, Binding<PositiveSemidefiniteConstraint>> (
+                  MathematicalProgram::*)(const Variables&, int)>(
+              &MathematicalProgram::NewSosPolynomial),
+          doc.MathematicalProgram.NewSosPolynomial.doc_2args)
       .def("NewIndeterminates",
-           // NOLINTNEXTLINE(whitespace/parens)
-           static_cast<VectorXIndeterminate (MathematicalProgram::*)(
-               int, const std::string&)>(
-               &MathematicalProgram::NewIndeterminates),
-           py::arg("rows"), py::arg("name") = "x",
-           doc.MathematicalProgram.NewIndeterminates.doc)
+          // NOLINTNEXTLINE(whitespace/parens)
+          static_cast<VectorXIndeterminate (MathematicalProgram::*)(int,
+              const std::string&)>(&MathematicalProgram::NewIndeterminates),
+          py::arg("rows"), py::arg("name") = "x",
+          doc.MathematicalProgram.NewIndeterminates.doc)
       .def("NewIndeterminates",
-           // NOLINTNEXTLINE(whitespace/parens)
-           static_cast<MatrixXIndeterminate (MathematicalProgram::*)(
-               int, int, const std::string&)>(
-               &MathematicalProgram::NewIndeterminates),
-           py::arg("rows"), py::arg("cols"), py::arg("name") = "X",
-           doc.MathematicalProgram.NewIndeterminates.doc_2)
+          // NOLINTNEXTLINE(whitespace/parens)
+          static_cast<MatrixXIndeterminate (MathematicalProgram::*)(int, int,
+              const std::string&)>(&MathematicalProgram::NewIndeterminates),
+          py::arg("rows"), py::arg("cols"), py::arg("name") = "X",
+          doc.MathematicalProgram.NewIndeterminates.doc_2)
       .def("AddBoundingBoxConstraint",
-           static_cast<Binding<BoundingBoxConstraint> (MathematicalProgram::*)(
-               const Eigen::Ref<const Eigen::VectorXd>&,
-               const Eigen::Ref<const Eigen::VectorXd>&,
-               const Eigen::Ref<const VectorXDecisionVariable>&)>(
-               &MathematicalProgram::AddBoundingBoxConstraint),
-           doc.MathematicalProgram.AddBoundingBoxConstraint.doc)
+          static_cast<Binding<BoundingBoxConstraint> (MathematicalProgram::*)(
+              const Eigen::Ref<const Eigen::VectorXd>&,
+              const Eigen::Ref<const Eigen::VectorXd>&,
+              const Eigen::Ref<const VectorXDecisionVariable>&)>(
+              &MathematicalProgram::AddBoundingBoxConstraint),
+          doc.MathematicalProgram.AddBoundingBoxConstraint.doc)
       .def("AddBoundingBoxConstraint",
-           static_cast<Binding<BoundingBoxConstraint> (MathematicalProgram::*)(
-               double, double, const symbolic::Variable&)>(
-               &MathematicalProgram::AddBoundingBoxConstraint),
-           doc.MathematicalProgram.AddBoundingBoxConstraint.doc_3)
+          static_cast<Binding<BoundingBoxConstraint> (MathematicalProgram::*)(
+              double, double, const symbolic::Variable&)>(
+              &MathematicalProgram::AddBoundingBoxConstraint),
+          doc.MathematicalProgram.AddBoundingBoxConstraint.doc_3)
       .def("AddBoundingBoxConstraint",
-           [](MathematicalProgram* self, double lb, double ub,
+          [](MathematicalProgram* self, double lb, double ub,
               const Eigen::Ref<const MatrixX<symbolic::Variable>>& vars) {
-             return self->AddBoundingBoxConstraint(lb, ub, vars);
-           },
-           doc.MathematicalProgram.AddBoundingBoxConstraint.doc_4)
+            return self->AddBoundingBoxConstraint(lb, ub, vars);
+          },
+          doc.MathematicalProgram.AddBoundingBoxConstraint.doc_4)
       .def("AddConstraint",
-           [](MathematicalProgram* self, py::function func,
+          [](MathematicalProgram* self, py::function func,
               const Eigen::VectorXd& lb, const Eigen::VectorXd& ub,
               const Eigen::Ref<const VectorXDecisionVariable>& vars,
               std::string& description) {
-             return self->AddConstraint(
-                 std::make_shared<PyFunctionConstraint>(vars.size(), func, lb,
-                                                        ub, description),
-                 vars);
-           },
-           py::arg("func"), py::arg("vars"), py::arg("lb"), py::arg("ub"),
-           py::arg("description") = "",
-           doc.MathematicalProgram.AddConstraint.doc_3)
+            return self->AddConstraint(
+                std::make_shared<PyFunctionConstraint>(
+                    vars.size(), func, lb, ub, description),
+                vars);
+          },
+          py::arg("func"), py::arg("vars"), py::arg("lb"), py::arg("ub"),
+          py::arg("description") = "",
+          doc.MathematicalProgram.AddConstraint.doc_3)
       .def("AddConstraint",
-           static_cast<Binding<Constraint> (MathematicalProgram::*)(
-               const Expression&, double, double)>(
-               &MathematicalProgram::AddConstraint),
-           doc.MathematicalProgram.AddConstraint.doc_2)
+          static_cast<Binding<Constraint> (MathematicalProgram::*)(
+              const Expression&, double, double)>(
+              &MathematicalProgram::AddConstraint),
+          doc.MathematicalProgram.AddConstraint.doc_2)
       .def("AddConstraint",
-           static_cast<Binding<Constraint> (MathematicalProgram::*)(
-               const Formula&)>(&MathematicalProgram::AddConstraint),
-           doc.MathematicalProgram.AddConstraint.doc_5)
+          static_cast<Binding<Constraint> (MathematicalProgram::*)(
+              const Formula&)>(&MathematicalProgram::AddConstraint),
+          doc.MathematicalProgram.AddConstraint.doc_5)
       .def("AddLinearConstraint",
-           static_cast<Binding<LinearConstraint> (MathematicalProgram::*)(
-               const Eigen::Ref<const Eigen::MatrixXd>&,
-               const Eigen::Ref<const Eigen::VectorXd>&,
-               const Eigen::Ref<const Eigen::VectorXd>&,
-               const Eigen::Ref<const VectorXDecisionVariable>&)>(
-               &MathematicalProgram::AddLinearConstraint),
-           doc.MathematicalProgram.AddLinearConstraint.doc)
+          static_cast<Binding<LinearConstraint> (MathematicalProgram::*)(
+              const Eigen::Ref<const Eigen::MatrixXd>&,
+              const Eigen::Ref<const Eigen::VectorXd>&,
+              const Eigen::Ref<const Eigen::VectorXd>&,
+              const Eigen::Ref<const VectorXDecisionVariable>&)>(
+              &MathematicalProgram::AddLinearConstraint),
+          doc.MathematicalProgram.AddLinearConstraint.doc)
       .def("AddLinearConstraint",
-           static_cast<Binding<LinearConstraint> (MathematicalProgram::*)(
-               const Expression&, double, double)>(
-               &MathematicalProgram::AddLinearConstraint),
-           doc.MathematicalProgram.AddLinearConstraint.doc_5)
+          static_cast<Binding<LinearConstraint> (MathematicalProgram::*)(
+              const Expression&, double, double)>(
+              &MathematicalProgram::AddLinearConstraint),
+          doc.MathematicalProgram.AddLinearConstraint.doc_5)
       .def("AddLinearConstraint",
-           static_cast<Binding<LinearConstraint> (MathematicalProgram::*)(
-               const Formula&)>(&MathematicalProgram::AddLinearConstraint),
-           doc.MathematicalProgram.AddLinearConstraint.doc_7)
+          static_cast<Binding<LinearConstraint> (MathematicalProgram::*)(
+              const Formula&)>(&MathematicalProgram::AddLinearConstraint),
+          doc.MathematicalProgram.AddLinearConstraint.doc_7)
       .def("AddLinearEqualityConstraint",
-           static_cast<Binding<LinearEqualityConstraint> (
-               MathematicalProgram::*)(
-               const Eigen::Ref<const Eigen::MatrixXd>&,
-               const Eigen::Ref<const Eigen::VectorXd>&,
-               const Eigen::Ref<const VectorXDecisionVariable>&)>(
-               &MathematicalProgram::AddLinearEqualityConstraint),
-           doc.MathematicalProgram.AddLinearEqualityConstraint.doc_7)
+          static_cast<Binding<LinearEqualityConstraint> (
+              MathematicalProgram::*)(const Eigen::Ref<const Eigen::MatrixXd>&,
+              const Eigen::Ref<const Eigen::VectorXd>&,
+              const Eigen::Ref<const VectorXDecisionVariable>&)>(
+              &MathematicalProgram::AddLinearEqualityConstraint),
+          doc.MathematicalProgram.AddLinearEqualityConstraint.doc_7)
       .def("AddLinearEqualityConstraint",
-           static_cast<Binding<LinearEqualityConstraint> (
-               MathematicalProgram::*)(const Expression&, double)>(
-               &MathematicalProgram::AddLinearEqualityConstraint),
-           doc.MathematicalProgram.AddLinearEqualityConstraint.doc)
+          static_cast<Binding<LinearEqualityConstraint> (
+              MathematicalProgram::*)(const Expression&, double)>(
+              &MathematicalProgram::AddLinearEqualityConstraint),
+          doc.MathematicalProgram.AddLinearEqualityConstraint.doc)
       .def("AddLinearEqualityConstraint",
-           static_cast<Binding<LinearEqualityConstraint> (
-               MathematicalProgram::*)(const Formula&)>(
-               &MathematicalProgram::AddLinearEqualityConstraint),
-           doc.MathematicalProgram.AddLinearEqualityConstraint.doc_2)
+          static_cast<Binding<LinearEqualityConstraint> (
+              MathematicalProgram::*)(const Formula&)>(
+              &MathematicalProgram::AddLinearEqualityConstraint),
+          doc.MathematicalProgram.AddLinearEqualityConstraint.doc_2)
       .def("AddLorentzConeConstraint",
-           static_cast<Binding<LorentzConeConstraint> (MathematicalProgram::*)(
-               const Eigen::Ref<const VectorX<drake::symbolic::Expression>>&)>(
-               &MathematicalProgram::AddLorentzConeConstraint),
-           doc.MathematicalProgram.AddLorentzConeConstraint.doc)
+          static_cast<Binding<LorentzConeConstraint> (MathematicalProgram::*)(
+              const Eigen::Ref<const VectorX<drake::symbolic::Expression>>&)>(
+              &MathematicalProgram::AddLorentzConeConstraint),
+          doc.MathematicalProgram.AddLorentzConeConstraint.doc)
       .def("AddPositiveSemidefiniteConstraint",
-           [](MathematicalProgram* self,
+          [](MathematicalProgram* self,
               const Eigen::Ref<const MatrixXDecisionVariable>& vars) {
-             return self->AddPositiveSemidefiniteConstraint(vars);
-           },
-           doc.MathematicalProgram.AddPositiveSemidefiniteConstraint.doc_1args)
+            return self->AddPositiveSemidefiniteConstraint(vars);
+          },
+          doc.MathematicalProgram.AddPositiveSemidefiniteConstraint.doc_1args)
       .def("AddLinearComplementarityConstraint",
-           static_cast<Binding<LinearComplementarityConstraint> (
-               MathematicalProgram::*)(
-               const Eigen::Ref<const Eigen::MatrixXd>&,
-               const Eigen::Ref<const Eigen::VectorXd>&,
-               const Eigen::Ref<const VectorXDecisionVariable>&)>(
-               &MathematicalProgram::AddLinearComplementarityConstraint),
-           doc.MathematicalProgram.AddLinearComplementarityConstraint.doc)
+          static_cast<Binding<LinearComplementarityConstraint> (
+              MathematicalProgram::*)(const Eigen::Ref<const Eigen::MatrixXd>&,
+              const Eigen::Ref<const Eigen::VectorXd>&,
+              const Eigen::Ref<const VectorXDecisionVariable>&)>(
+              &MathematicalProgram::AddLinearComplementarityConstraint),
+          doc.MathematicalProgram.AddLinearComplementarityConstraint.doc)
       .def("AddPositiveSemidefiniteConstraint",
-           [](MathematicalProgram* self,
+          [](MathematicalProgram* self,
               const Eigen::Ref<const MatrixX<Expression>>& e) {
-             return self->AddPositiveSemidefiniteConstraint(e);
-           },
-           doc.MathematicalProgram.AddPositiveSemidefiniteConstraint.doc_1args)
+            return self->AddPositiveSemidefiniteConstraint(e);
+          },
+          doc.MathematicalProgram.AddPositiveSemidefiniteConstraint.doc_1args)
       .def("AddCost",
-           [](MathematicalProgram* self, py::function func,
+          [](MathematicalProgram* self, py::function func,
               const Eigen::Ref<const VectorXDecisionVariable>& vars,
               std::string& description) {
-             return self->AddCost(std::make_shared<PyFunctionCost>(
-                                      vars.size(), func, description),
-                                  vars);
-           },
-           py::arg("func"), py::arg("vars"), py::arg("description") = "",
-           doc.MathematicalProgram.AddCost.doc)
+            return self->AddCost(std::make_shared<PyFunctionCost>(
+                                     vars.size(), func, description),
+                vars);
+          },
+          py::arg("func"), py::arg("vars"), py::arg("description") = "",
+          doc.MathematicalProgram.AddCost.doc)
       .def("AddCost",
-           static_cast<Binding<Cost> (MathematicalProgram::*)(
-               const Expression&)>(&MathematicalProgram::AddCost),
-           doc.MathematicalProgram.AddCost.doc)
+          static_cast<Binding<Cost> (MathematicalProgram::*)(
+              const Expression&)>(&MathematicalProgram::AddCost),
+          doc.MathematicalProgram.AddCost.doc)
       .def("AddLinearCost",
-           static_cast<Binding<LinearCost> (MathematicalProgram::*)(
-               const Expression&)>(&MathematicalProgram::AddLinearCost),
-           doc.MathematicalProgram.AddLinearCost.doc)
+          static_cast<Binding<LinearCost> (MathematicalProgram::*)(
+              const Expression&)>(&MathematicalProgram::AddLinearCost),
+          doc.MathematicalProgram.AddLinearCost.doc)
       .def("AddQuadraticCost",
-           static_cast<Binding<QuadraticCost> (MathematicalProgram::*)(
-               const Eigen::Ref<const Eigen::MatrixXd>&,
-               const Eigen::Ref<const Eigen::VectorXd>&,
-               const Eigen::Ref<const VectorXDecisionVariable>&)>(
-               &MathematicalProgram::AddQuadraticCost),
-           doc.MathematicalProgram.AddQuadraticCost.doc)
+          static_cast<Binding<QuadraticCost> (MathematicalProgram::*)(
+              const Eigen::Ref<const Eigen::MatrixXd>&,
+              const Eigen::Ref<const Eigen::VectorXd>&,
+              const Eigen::Ref<const VectorXDecisionVariable>&)>(
+              &MathematicalProgram::AddQuadraticCost),
+          doc.MathematicalProgram.AddQuadraticCost.doc)
       .def("AddQuadraticCost",
-           static_cast<Binding<QuadraticCost> (MathematicalProgram::*)(
-               const Expression&)>(&MathematicalProgram::AddQuadraticCost),
-           doc.MathematicalProgram.AddQuadraticCost.doc)
+          static_cast<Binding<QuadraticCost> (MathematicalProgram::*)(
+              const Expression&)>(&MathematicalProgram::AddQuadraticCost),
+          doc.MathematicalProgram.AddQuadraticCost.doc)
       .def("AddQuadraticErrorCost",
-           overload_cast_explicit<
-               Binding<QuadraticCost>, const Eigen::Ref<const Eigen::MatrixXd>&,
-               const Eigen::Ref<const Eigen::VectorXd>&,
-               const Eigen::Ref<const VectorXDecisionVariable>&>(
-               &MathematicalProgram::AddQuadraticErrorCost),
-           py::arg("Q"), py::arg("x_desired"), py::arg("vars"),
-           doc.MathematicalProgram.AddQuadraticErrorCost.doc)
+          overload_cast_explicit<Binding<QuadraticCost>,
+              const Eigen::Ref<const Eigen::MatrixXd>&,
+              const Eigen::Ref<const Eigen::VectorXd>&,
+              const Eigen::Ref<const VectorXDecisionVariable>&>(
+              &MathematicalProgram::AddQuadraticErrorCost),
+          py::arg("Q"), py::arg("x_desired"), py::arg("vars"),
+          doc.MathematicalProgram.AddQuadraticErrorCost.doc)
       .def("AddL2NormCost",
-           overload_cast_explicit<
-               Binding<QuadraticCost>, const Eigen::Ref<const Eigen::MatrixXd>&,
-               const Eigen::Ref<const Eigen::VectorXd>&,
-               const Eigen::Ref<const VectorXDecisionVariable>&>(
-               &MathematicalProgram::AddL2NormCost),
-           py::arg("A"), py::arg("b"), py::arg("vars"),
-           doc.MathematicalProgram.AddL2NormCost.doc)
+          overload_cast_explicit<Binding<QuadraticCost>,
+              const Eigen::Ref<const Eigen::MatrixXd>&,
+              const Eigen::Ref<const Eigen::VectorXd>&,
+              const Eigen::Ref<const VectorXDecisionVariable>&>(
+              &MathematicalProgram::AddL2NormCost),
+          py::arg("A"), py::arg("b"), py::arg("vars"),
+          doc.MathematicalProgram.AddL2NormCost.doc)
       .def("AddSosConstraint",
-           static_cast<std::pair<Binding<PositiveSemidefiniteConstraint>,
-                                 Binding<LinearEqualityConstraint>> (
-               MathematicalProgram::*)(
-               const Polynomial&, const Eigen::Ref<const VectorX<Monomial>>&)>(
-               &MathematicalProgram::AddSosConstraint),
-           doc.MathematicalProgram.AddSosConstraint.doc_2args_p_monomial_basis)
+          static_cast<std::pair<Binding<PositiveSemidefiniteConstraint>,
+              Binding<LinearEqualityConstraint>> (MathematicalProgram::*)(
+              const Polynomial&, const Eigen::Ref<const VectorX<Monomial>>&)>(
+              &MathematicalProgram::AddSosConstraint),
+          doc.MathematicalProgram.AddSosConstraint.doc_2args_p_monomial_basis)
       .def("AddSosConstraint",
-           static_cast<std::pair<Binding<PositiveSemidefiniteConstraint>,
-                                 Binding<LinearEqualityConstraint>> (
-               MathematicalProgram::*)(const Polynomial&)>(
-               &MathematicalProgram::AddSosConstraint),
-           doc.MathematicalProgram.AddSosConstraint.doc_1args_p)
+          static_cast<std::pair<Binding<PositiveSemidefiniteConstraint>,
+              Binding<LinearEqualityConstraint>> (MathematicalProgram::*)(
+              const Polynomial&)>(&MathematicalProgram::AddSosConstraint),
+          doc.MathematicalProgram.AddSosConstraint.doc_1args_p)
       .def("AddSosConstraint",
-           static_cast<std::pair<Binding<PositiveSemidefiniteConstraint>,
-                                 Binding<LinearEqualityConstraint>> (
-               MathematicalProgram::*)(
-               const Expression&, const Eigen::Ref<const VectorX<Monomial>>&)>(
-               &MathematicalProgram::AddSosConstraint),
-           doc.MathematicalProgram.AddSosConstraint.doc_2args_e_monomial_basis)
+          static_cast<std::pair<Binding<PositiveSemidefiniteConstraint>,
+              Binding<LinearEqualityConstraint>> (MathematicalProgram::*)(
+              const Expression&, const Eigen::Ref<const VectorX<Monomial>>&)>(
+              &MathematicalProgram::AddSosConstraint),
+          doc.MathematicalProgram.AddSosConstraint.doc_2args_e_monomial_basis)
       .def("AddSosConstraint",
-           static_cast<std::pair<Binding<PositiveSemidefiniteConstraint>,
-                                 Binding<LinearEqualityConstraint>> (
-               MathematicalProgram::*)(const Expression&)>(
-               &MathematicalProgram::AddSosConstraint),
-           doc.MathematicalProgram.AddSosConstraint.doc_1args_e)
+          static_cast<std::pair<Binding<PositiveSemidefiniteConstraint>,
+              Binding<LinearEqualityConstraint>> (MathematicalProgram::*)(
+              const Expression&)>(&MathematicalProgram::AddSosConstraint),
+          doc.MathematicalProgram.AddSosConstraint.doc_1args_e)
       .def("AddVisualizationCallback",
-           static_cast<Binding<VisualizationCallback> (MathematicalProgram::*)(
-               const VisualizationCallback::CallbackFunction&,
-               const Eigen::Ref<const VectorXDecisionVariable>&)>(
-               &MathematicalProgram::AddVisualizationCallback),
-           doc.MathematicalProgram.AddVisualizationCallback.doc)
+          static_cast<Binding<VisualizationCallback> (MathematicalProgram::*)(
+              const VisualizationCallback::CallbackFunction&,
+              const Eigen::Ref<const VectorXDecisionVariable>&)>(
+              &MathematicalProgram::AddVisualizationCallback),
+          doc.MathematicalProgram.AddVisualizationCallback.doc)
       .def("Solve", &MathematicalProgram::Solve,
-           doc.MathematicalProgram.Solve.doc)
+          doc.MathematicalProgram.Solve.doc)
       .def("GetSolverId", &MathematicalProgram::GetSolverId,
-           doc.MathematicalProgram.GetSolverId.doc)
+          doc.MathematicalProgram.GetSolverId.doc)
       .def("linear_constraints", &MathematicalProgram::linear_constraints,
-           doc.MathematicalProgram.linear_constraints.doc)
+          doc.MathematicalProgram.linear_constraints.doc)
       .def("linear_equality_constraints",
-           &MathematicalProgram::linear_equality_constraints,
-           doc.MathematicalProgram.linear_equality_constraints.doc)
+          &MathematicalProgram::linear_equality_constraints,
+          doc.MathematicalProgram.linear_equality_constraints.doc)
       .def("bounding_box_constraints",
-           &MathematicalProgram::bounding_box_constraints,
-           doc.MathematicalProgram.bounding_box_constraints.doc)
+          &MathematicalProgram::bounding_box_constraints,
+          doc.MathematicalProgram.bounding_box_constraints.doc)
       .def("linear_costs", &MathematicalProgram::linear_costs,
-           doc.MathematicalProgram.linear_costs.doc)
+          doc.MathematicalProgram.linear_costs.doc)
       .def("quadratic_costs", &MathematicalProgram::quadratic_costs,
-           doc.MathematicalProgram.quadratic_costs.doc)
+          doc.MathematicalProgram.quadratic_costs.doc)
       .def("FindDecisionVariableIndex",
-           &MathematicalProgram::FindDecisionVariableIndex,
-           doc.MathematicalProgram.FindDecisionVariableIndex.doc)
+          &MathematicalProgram::FindDecisionVariableIndex,
+          doc.MathematicalProgram.FindDecisionVariableIndex.doc)
       .def("num_vars", &MathematicalProgram::num_vars,
-           doc.MathematicalProgram.num_vars.doc)
+          doc.MathematicalProgram.num_vars.doc)
       .def("decision_variables", &MathematicalProgram::decision_variables,
-           doc.MathematicalProgram.decision_variables.doc)
+          doc.MathematicalProgram.decision_variables.doc)
       .def("GetSolution",
-           [](const MathematicalProgram& prog, const Variable& var) {
-             return prog.GetSolution(var);
-           },
-           doc.MathematicalProgram.GetSolution.doc)
+          [](const MathematicalProgram& prog, const Variable& var) {
+            return prog.GetSolution(var);
+          },
+          doc.MathematicalProgram.GetSolution.doc)
       .def("GetSolution",
-           [](const MathematicalProgram& prog,
+          [](const MathematicalProgram& prog,
               const VectorXDecisionVariable& var) {
-             return prog.GetSolution(var);
-           },
-           doc.MathematicalProgram.GetSolution.doc)
+            return prog.GetSolution(var);
+          },
+          doc.MathematicalProgram.GetSolution.doc)
       .def("GetSolution",
-           [](const MathematicalProgram& prog,
+          [](const MathematicalProgram& prog,
               const MatrixXDecisionVariable& var) {
-             return prog.GetSolution(var);
-           },
-           doc.MathematicalProgram.GetSolution.doc)
+            return prog.GetSolution(var);
+          },
+          doc.MathematicalProgram.GetSolution.doc)
       .def("SubstituteSolution",
-           [](const MathematicalProgram& prog, const symbolic::Expression& e) {
-             return prog.SubstituteSolution(e);
-           },
-           doc.MathematicalProgram.SubstituteSolution.doc_1args_e)
+          [](const MathematicalProgram& prog, const symbolic::Expression& e) {
+            return prog.SubstituteSolution(e);
+          },
+          doc.MathematicalProgram.SubstituteSolution.doc_1args_e)
       .def("SubstituteSolution",
-           [](const MathematicalProgram& prog, const symbolic::Polynomial& p) {
-             return prog.SubstituteSolution(p);
-           },
-           doc.MathematicalProgram.SubstituteSolution.doc_1args_p)
+          [](const MathematicalProgram& prog, const symbolic::Polynomial& p) {
+            return prog.SubstituteSolution(p);
+          },
+          doc.MathematicalProgram.SubstituteSolution.doc_1args_p)
       .def("GetInitialGuess",
-           [](MathematicalProgram& prog,
+          [](MathematicalProgram& prog,
               const symbolic::Variable& decision_variable) {
-             return prog.GetInitialGuess(decision_variable);
-           },
-           doc.MathematicalProgram.GetInitialGuess.doc_1args)
+            return prog.GetInitialGuess(decision_variable);
+          },
+          doc.MathematicalProgram.GetInitialGuess.doc_1args)
       .def("GetInitialGuess",
-           [](MathematicalProgram& prog,
+          [](MathematicalProgram& prog,
               const VectorXDecisionVariable& decision_variables) {
-             return prog.GetInitialGuess(decision_variables);
-           },
-           doc.MathematicalProgram.GetInitialGuess.doc_0args)
+            return prog.GetInitialGuess(decision_variables);
+          },
+          doc.MathematicalProgram.GetInitialGuess.doc_0args)
       .def("GetInitialGuess",
-           [](MathematicalProgram& prog,
+          [](MathematicalProgram& prog,
               const MatrixXDecisionVariable& decision_variables) {
-             return prog.GetInitialGuess(decision_variables);
-           },
-           doc.MathematicalProgram.GetInitialGuess.doc_0args)
+            return prog.GetInitialGuess(decision_variables);
+          },
+          doc.MathematicalProgram.GetInitialGuess.doc_0args)
       .def("SetInitialGuess",
-           [](MathematicalProgram& prog,
+          [](MathematicalProgram& prog,
               const symbolic::Variable& decision_variable,
               double variable_guess_value) {
-             prog.SetInitialGuess(decision_variable, variable_guess_value);
-           },
-           doc.MathematicalProgram.SetInitialGuess.doc_2args)
+            prog.SetInitialGuess(decision_variable, variable_guess_value);
+          },
+          doc.MathematicalProgram.SetInitialGuess.doc_2args)
       .def("SetInitialGuess",
-           [](MathematicalProgram& prog,
+          [](MathematicalProgram& prog,
               const MatrixXDecisionVariable& decision_variable_mat,
               const Eigen::MatrixXd& x0) {
-             prog.SetInitialGuess(decision_variable_mat, x0);
-           },
-           doc.MathematicalProgram.SetInitialGuess.doc_0args)
+            prog.SetInitialGuess(decision_variable_mat, x0);
+          },
+          doc.MathematicalProgram.SetInitialGuess.doc_0args)
       .def("SetInitialGuessForAllVariables",
-           [](MathematicalProgram& prog, const Eigen::VectorXd& x0) {
-             prog.SetInitialGuessForAllVariables(x0);
-           },
-           doc.MathematicalProgram.SetInitialGuessForAllVariables.doc)
+          [](MathematicalProgram& prog, const Eigen::VectorXd& x0) {
+            prog.SetInitialGuessForAllVariables(x0);
+          },
+          doc.MathematicalProgram.SetInitialGuessForAllVariables.doc)
       .def("SetSolverOption", &SetSolverOptionBySolverType<double>,
-           doc.MathematicalProgram.SetSolverOption.doc)
+          doc.MathematicalProgram.SetSolverOption.doc)
       .def("SetSolverOption", &SetSolverOptionBySolverType<int>,
-           doc.MathematicalProgram.SetSolverOption.doc_2)
+          doc.MathematicalProgram.SetSolverOption.doc_2)
       .def("SetSolverOption", &SetSolverOptionBySolverType<string>,
-           doc.MathematicalProgram.SetSolverOption.doc_3)
+          doc.MathematicalProgram.SetSolverOption.doc_3)
       // TODO(m-chaturvedi) Add Pybind11 documentation.
       .def("GetSolverOptions",
-           [](MathematicalProgram& prog, SolverType solver_type) {
-             py::dict out;
-             py::object update = out.attr("update");
-             const SolverId id = SolverTypeConverter::TypeToId(solver_type);
-             update(prog.GetSolverOptionsDouble(id));
-             update(prog.GetSolverOptionsInt(id));
-             update(prog.GetSolverOptionsStr(id));
-             return out;
-           });
+          [](MathematicalProgram& prog, SolverType solver_type) {
+            py::dict out;
+            py::object update = out.attr("update");
+            const SolverId id = SolverTypeConverter::TypeToId(solver_type);
+            update(prog.GetSolverOptionsDouble(id));
+            update(prog.GetSolverOptionsInt(id));
+            update(prog.GetSolverOptionsStr(id));
+            return out;
+          });
 
   py::enum_<SolutionResult>(m, "SolutionResult", doc.SolutionResult.doc)
       .value("kSolutionFound", SolutionResult::kSolutionFound,
-             doc.SolutionResult.kSolutionFound.doc)
+          doc.SolutionResult.kSolutionFound.doc)
       .value("kInvalidInput", SolutionResult::kInvalidInput,
-             doc.SolutionResult.kInvalidInput.doc)
+          doc.SolutionResult.kInvalidInput.doc)
       .value("kInfeasibleConstraints", SolutionResult::kInfeasibleConstraints,
-             doc.SolutionResult.kInfeasibleConstraints.doc)
+          doc.SolutionResult.kInfeasibleConstraints.doc)
       .value("kUnbounded", SolutionResult::kUnbounded,
-             doc.SolutionResult.kUnbounded.doc)
+          doc.SolutionResult.kUnbounded.doc)
       .value("kUnknownError", SolutionResult::kUnknownError,
-             doc.SolutionResult.kUnknownError.doc)
+          doc.SolutionResult.kUnknownError.doc)
       .value("kInfeasible_Or_Unbounded",
-             SolutionResult::kInfeasible_Or_Unbounded,
-             doc.SolutionResult.kInfeasible_Or_Unbounded.doc)
+          SolutionResult::kInfeasible_Or_Unbounded,
+          doc.SolutionResult.kInfeasible_Or_Unbounded.doc)
       .value("kIterationLimit", SolutionResult::kIterationLimit,
-             doc.SolutionResult.kIterationLimit.doc)
+          doc.SolutionResult.kIterationLimit.doc)
       .value("kDualInfeasible", SolutionResult::kDualInfeasible,
-             doc.SolutionResult.kDualInfeasible.doc);
+          doc.SolutionResult.kDualInfeasible.doc);
 
   // TODO(eric.cousineau): Expose Eval() in a Python-friendly fashion.
   py::class_<EvaluatorBase, std::shared_ptr<EvaluatorBase>>(m, "EvaluatorBase")
       .def("num_outputs", &EvaluatorBase::num_outputs,
-           doc.EvaluatorBase.num_outputs.doc)
-      .def("num_vars", &EvaluatorBase::num_vars,
-           doc.EvaluatorBase.num_vars.doc);
+          doc.EvaluatorBase.num_outputs.doc)
+      .def(
+          "num_vars", &EvaluatorBase::num_vars, doc.EvaluatorBase.num_vars.doc);
 
   py::class_<Constraint, EvaluatorBase, std::shared_ptr<Constraint>>(
       m, "Constraint", doc.Constraint.doc)
       .def("num_constraints", &Constraint::num_constraints,
-           doc.Constraint.num_constraints.doc)
+          doc.Constraint.num_constraints.doc)
       .def("lower_bound", &Constraint::lower_bound,
-           doc.Constraint.lower_bound.doc)
+          doc.Constraint.lower_bound.doc)
       .def("upper_bound", &Constraint::upper_bound,
-           doc.Constraint.upper_bound.doc);
+          doc.Constraint.upper_bound.doc);
 
   py::class_<LinearConstraint, Constraint, std::shared_ptr<LinearConstraint>>(
       m, "LinearConstraint", doc.LinearConstraint.doc)
       .def("A", &LinearConstraint::A, doc.LinearConstraint.A.doc)
       .def("UpdateCoefficients",
-           [](LinearConstraint& self, const Eigen::MatrixXd& new_A,
+          [](LinearConstraint& self, const Eigen::MatrixXd& new_A,
               const Eigen::VectorXd& new_lb, const Eigen::VectorXd& new_ub) {
-             self.UpdateCoefficients(new_A, new_lb, new_ub);
-           },
-           py::arg("new_A"), py::arg("new_lb"), py::arg("new_ub"),
-           doc.LinearConstraint.UpdateCoefficients.doc)
+            self.UpdateCoefficients(new_A, new_lb, new_ub);
+          },
+          py::arg("new_A"), py::arg("new_lb"), py::arg("new_ub"),
+          doc.LinearConstraint.UpdateCoefficients.doc)
       .def("UpdateLowerBound",
-           [](LinearConstraint& self, const Eigen::VectorXd& new_lb) {
-             self.UpdateLowerBound(new_lb);
-           },
-           py::arg("new_lb"), doc.Constraint.UpdateLowerBound.doc)
+          [](LinearConstraint& self, const Eigen::VectorXd& new_lb) {
+            self.UpdateLowerBound(new_lb);
+          },
+          py::arg("new_lb"), doc.Constraint.UpdateLowerBound.doc)
       .def("UpdateUpperBound",
-           [](LinearConstraint& self, const Eigen::VectorXd& new_ub) {
-             self.UpdateUpperBound(new_ub);
-           },
-           py::arg("new_ub"), doc.Constraint.UpdateUpperBound.doc)
+          [](LinearConstraint& self, const Eigen::VectorXd& new_ub) {
+            self.UpdateUpperBound(new_ub);
+          },
+          py::arg("new_ub"), doc.Constraint.UpdateUpperBound.doc)
       .def("set_bounds",
-           [](LinearConstraint& self, const Eigen::VectorXd& new_lb,
+          [](LinearConstraint& self, const Eigen::VectorXd& new_lb,
               const Eigen::VectorXd& new_ub) {
-             self.set_bounds(new_lb, new_ub);
-           },
-           py::arg("new_lb"), py::arg("new_ub"), doc.Constraint.set_bounds.doc);
+            self.set_bounds(new_lb, new_ub);
+          },
+          py::arg("new_lb"), py::arg("new_ub"), doc.Constraint.set_bounds.doc);
 
   py::class_<LorentzConeConstraint, Constraint,
-             std::shared_ptr<LorentzConeConstraint>>(
+      std::shared_ptr<LorentzConeConstraint>>(
       m, "LorentzConeConstraint", doc.LorentzConeConstraint.doc)
       .def("A", &LorentzConeConstraint::A, doc.LorentzConeConstraint.A.doc);
   py::class_<LinearEqualityConstraint, LinearConstraint,
-             std::shared_ptr<LinearEqualityConstraint>>(
+      std::shared_ptr<LinearEqualityConstraint>>(
       m, "LinearEqualityConstraint", doc.LinearEqualityConstraint.doc)
       .def("UpdateCoefficients",
-           [](LinearEqualityConstraint& self,  // BR
+          [](LinearEqualityConstraint& self,  // BR
               const Eigen::MatrixXd& Aeq, const Eigen::VectorXd& beq) {
-             self.UpdateCoefficients(Aeq, beq);
-           },
-           py::arg("Aeq"), py::arg("beq"),
-           doc.LinearEqualityConstraint.UpdateCoefficients.doc);
+            self.UpdateCoefficients(Aeq, beq);
+          },
+          py::arg("Aeq"), py::arg("beq"),
+          doc.LinearEqualityConstraint.UpdateCoefficients.doc);
 
   py::class_<BoundingBoxConstraint, LinearConstraint,
-             std::shared_ptr<BoundingBoxConstraint>>(
+      std::shared_ptr<BoundingBoxConstraint>>(
       m, "BoundingBoxConstraint", doc.BoundingBoxConstraint.doc);
 
   py::class_<PositiveSemidefiniteConstraint, Constraint,
-             std::shared_ptr<PositiveSemidefiniteConstraint>>(
-      m, "PositiveSemidefiniteConstraint",
-      doc.PositiveSemidefiniteConstraint.doc);
+      std::shared_ptr<PositiveSemidefiniteConstraint>>(m,
+      "PositiveSemidefiniteConstraint", doc.PositiveSemidefiniteConstraint.doc);
 
   py::class_<LinearComplementarityConstraint, Constraint,
-             std::shared_ptr<LinearComplementarityConstraint>>(
-      m, "LinearComplementarityConstraint",
+      std::shared_ptr<LinearComplementarityConstraint>>(m,
+      "LinearComplementarityConstraint",
       doc.LinearComplementarityConstraint.doc);
 
   RegisterBinding<Constraint>(&m, &prog_cls, "Constraint");
   RegisterBinding<LinearConstraint>(&m, &prog_cls, "LinearConstraint");
-  RegisterBinding<LorentzConeConstraint>(&m, &prog_cls,
-                                         "LorentzConeConstraint");
-  RegisterBinding<LinearEqualityConstraint>(&m, &prog_cls,
-                                            "LinearEqualityConstraint");
-  RegisterBinding<BoundingBoxConstraint>(&m, &prog_cls,
-                                         "BoundingBoxConstraint");
+  RegisterBinding<LorentzConeConstraint>(
+      &m, &prog_cls, "LorentzConeConstraint");
+  RegisterBinding<LinearEqualityConstraint>(
+      &m, &prog_cls, "LinearEqualityConstraint");
+  RegisterBinding<BoundingBoxConstraint>(
+      &m, &prog_cls, "BoundingBoxConstraint");
   RegisterBinding<PositiveSemidefiniteConstraint>(
       &m, &prog_cls, "PositiveSemidefiniteConstraint");
   RegisterBinding<LinearComplementarityConstraint>(
@@ -676,16 +661,16 @@ PYBIND11_MODULE(mathematicalprogram, m) {
   // Mirror procedure for costs
   py::class_<Cost, std::shared_ptr<Cost>> cost(m, "Cost", doc.Cost.doc);
 
-  py::class_<LinearCost, Cost, std::shared_ptr<LinearCost>>(m, "LinearCost",
-                                                            doc.LinearCost.doc)
+  py::class_<LinearCost, Cost, std::shared_ptr<LinearCost>>(
+      m, "LinearCost", doc.LinearCost.doc)
       .def("a", &LinearCost::a, doc.LinearCost.a.doc)
       .def("b", &LinearCost::b, doc.LinearCost.b.doc)
       .def("UpdateCoefficients",
-           [](LinearCost& self, const Eigen::VectorXd& new_a, double new_b) {
-             self.UpdateCoefficients(new_a, new_b);
-           },
-           py::arg("new_a"), py::arg("new_b") = 0,
-           doc.LinearCost.UpdateCoefficients.doc);
+          [](LinearCost& self, const Eigen::VectorXd& new_a, double new_b) {
+            self.UpdateCoefficients(new_a, new_b);
+          },
+          py::arg("new_a"), py::arg("new_b") = 0,
+          doc.LinearCost.UpdateCoefficients.doc);
 
   py::class_<QuadraticCost, Cost, std::shared_ptr<QuadraticCost>>(
       m, "QuadraticCost", doc.QuadraticCost.doc)
@@ -693,22 +678,22 @@ PYBIND11_MODULE(mathematicalprogram, m) {
       .def("b", &QuadraticCost::b, doc.QuadraticCost.b.doc)
       .def("c", &QuadraticCost::c, doc.QuadraticCost.c.doc)
       .def("UpdateCoefficients",
-           [](QuadraticCost& self, const Eigen::MatrixXd& new_Q,
+          [](QuadraticCost& self, const Eigen::MatrixXd& new_Q,
               const Eigen::VectorXd& new_b,
               double new_c) { self.UpdateCoefficients(new_Q, new_b, new_c); },
-           py::arg("new_Q"), py::arg("new_b"), py::arg("new_c") = 0,
-           doc.QuadraticCost.UpdateCoefficients.doc);
+          py::arg("new_Q"), py::arg("new_b"), py::arg("new_c") = 0,
+          doc.QuadraticCost.UpdateCoefficients.doc);
 
   RegisterBinding<Cost>(&m, &prog_cls, "Cost");
   RegisterBinding<LinearCost>(&m, &prog_cls, "LinearCost");
   RegisterBinding<QuadraticCost>(&m, &prog_cls, "QuadraticCost");
 
   py::class_<VisualizationCallback, EvaluatorBase,
-             std::shared_ptr<VisualizationCallback>>(
+      std::shared_ptr<VisualizationCallback>>(
       m, "VisualizationCallback", doc.VisualizationCallback.doc);
 
-  RegisterBinding<VisualizationCallback>(&m, &prog_cls,
-                                         "VisualizationCallback");
+  RegisterBinding<VisualizationCallback>(
+      &m, &prog_cls, "VisualizationCallback");
 }  // NOLINT(readability/fn_size)
 
 }  // namespace pydrake

--- a/bindings/pydrake/solvers/mosek_py.cc
+++ b/bindings/pydrake/solvers/mosek_py.cc
@@ -17,8 +17,8 @@ PYBIND11_MODULE(mosek, m) {
       py::module::import("pydrake.solvers.mathematicalprogram")
           .attr("MathematicalProgramSolverInterface");
 
-  py::class_<MosekSolver>(m, "MosekSolver", solverinterface,
-                          doc.MosekSolver.doc)
+  py::class_<MosekSolver>(
+      m, "MosekSolver", solverinterface, doc.MosekSolver.doc)
       .def(py::init<>(), doc.MosekSolver.ctor.doc_0args);
 }
 

--- a/bindings/pydrake/symbolic_py.cc
+++ b/bindings/pydrake/symbolic_py.cc
@@ -45,11 +45,11 @@ PYBIND11_MODULE(symbolic, m) {
       .def("get_id", &Variable::get_id, doc.Variable.get_id.doc)
       .def("__str__", &Variable::to_string, doc.Variable.to_string.doc)
       .def("__repr__",
-           [](const Variable& self) {
-             return fmt::format("Variable('{}')", self.to_string());
-           })
+          [](const Variable& self) {
+            return fmt::format("Variable('{}')", self.to_string());
+          })
       .def("__hash__",
-           [](const Variable& self) { return std::hash<Variable>{}(self); })
+          [](const Variable& self) { return std::hash<Variable>{}(self); })
       // Addition.
       .def(py::self + py::self)
       .def(py::self + double())
@@ -68,18 +68,18 @@ PYBIND11_MODULE(symbolic, m) {
       .def(double() / py::self)
       // Pow.
       .def("__pow__",
-           [](const Variable& self, double other) { return pow(self, other); },
-           py::is_operator())
+          [](const Variable& self, double other) { return pow(self, other); },
+          py::is_operator())
       .def("__pow__",
-           [](const Variable& self, const Variable& other) {
-             return pow(self, other);
-           },
-           py::is_operator())
+          [](const Variable& self, const Variable& other) {
+            return pow(self, other);
+          },
+          py::is_operator())
       .def("__pow__",
-           [](const Variable& self, const Expression& other) {
-             return pow(self, other);
-           },
-           py::is_operator())
+          [](const Variable& self, const Expression& other) {
+            return pow(self, other);
+          },
+          py::is_operator())
       // We add `EqualTo` instead of `equal_to` to maintain consistency among
       // symbolic classes (Variable, Expression, Formula, Polynomial) on Python
       // side. This enables us to achieve polymorphism via ducktyping in Python.
@@ -120,49 +120,49 @@ PYBIND11_MODULE(symbolic, m) {
   py::class_<Variables>(m, "Variables", doc.Variables.doc)
       .def(py::init<>(), doc.Variables.ctor.doc_0args)
       .def(py::init<const Eigen::Ref<const VectorX<Variable>>&>(),
-           doc.Variables.ctor.doc_1args_vec)
+          doc.Variables.ctor.doc_1args_vec)
       .def("size", &Variables::size, doc.Variables.size.doc)
       .def("__len__", &Variables::size, doc.Variables.size.doc)
       .def("empty", &Variables::empty)
       .def("__str__", &Variables::to_string)
       .def("__repr__",
-           [](const Variables& self) {
-             return fmt::format("<Variables \"{}\">", self);
-           })
+          [](const Variables& self) {
+            return fmt::format("<Variables \"{}\">", self);
+          })
       .def("to_string", &Variables::to_string, doc.Variables.to_string.doc)
       .def("__hash__",
-           [](const Variables& self) { return std::hash<Variables>{}(self); })
+          [](const Variables& self) { return std::hash<Variables>{}(self); })
       .def("insert",
-           [](Variables& self, const Variable& var) { self.insert(var); },
-           doc.Variables.insert.doc_1args_var)
+          [](Variables& self, const Variable& var) { self.insert(var); },
+          doc.Variables.insert.doc_1args_var)
       .def("insert",
-           [](Variables& self, const Variables& vars) { self.insert(vars); },
-           doc.Variables.insert.doc_0args)
+          [](Variables& self, const Variables& vars) { self.insert(vars); },
+          doc.Variables.insert.doc_0args)
       .def("erase",
-           [](Variables& self, const Variable& key) { return self.erase(key); },
-           doc.Variables.erase.doc_1args_key)
+          [](Variables& self, const Variable& key) { return self.erase(key); },
+          doc.Variables.erase.doc_1args_key)
       .def("erase",
-           [](Variables& self, const Variables& vars) {
-             return self.erase(vars);
-           },
-           doc.Variables.erase.doc_1args_vars)
+          [](Variables& self, const Variables& vars) {
+            return self.erase(vars);
+          },
+          doc.Variables.erase.doc_1args_vars)
       .def("include", &Variables::include, doc.Variables.include.doc)
       .def("__contains__", &Variables::include)
       .def("IsSubsetOf", &Variables::IsSubsetOf, doc.Variables.IsSubsetOf.doc)
       .def("IsSupersetOf", &Variables::IsSupersetOf,
-           doc.Variables.IsSupersetOf.doc)
+          doc.Variables.IsSupersetOf.doc)
       .def("IsStrictSubsetOf", &Variables::IsStrictSubsetOf,
-           doc.Variables.IsStrictSubsetOf.doc)
+          doc.Variables.IsStrictSubsetOf.doc)
       .def("IsStrictSupersetOf", &Variables::IsStrictSupersetOf,
-           doc.Variables.IsStrictSupersetOf.doc)
+          doc.Variables.IsStrictSupersetOf.doc)
       .def("EqualTo", [](const Variables& self,
-                         const Variables& vars) { return self == vars; })
+                          const Variables& vars) { return self == vars; })
       .def("__iter__",
-           [](const Variables& vars) {
-             return py::make_iterator(vars.begin(), vars.end());
-           },
-           // Keep alive, reference: `return` keeps `self` alive
-           py::keep_alive<0, 1>())
+          [](const Variables& vars) {
+            return py::make_iterator(vars.begin(), vars.end());
+          },
+          // Keep alive, reference: `return` keeps `self` alive
+          py::keep_alive<0, 1>())
       .def(py::self == py::self)
       .def(py::self < py::self)
       .def(py::self + py::self)
@@ -183,37 +183,38 @@ PYBIND11_MODULE(symbolic, m) {
       .def(py::init<const Variable&>(), doc.Expression.ctor.doc_1args_var)
       .def("__str__", &Expression::to_string)
       .def("__repr__",
-           [](const Expression& self) {
-             return fmt::format("<Expression \"{}\">", self.to_string());
-           })
-      .def("__copy__",
-           [](const Expression& self) -> Expression { return self; })
+          [](const Expression& self) {
+            return fmt::format("<Expression \"{}\">", self.to_string());
+          })
+      .def(
+          "__copy__", [](const Expression& self) -> Expression { return self; })
       .def("to_string", &Expression::to_string, doc.Expression.to_string.doc)
       .def("Expand", &Expression::Expand, doc.Expression.Expand.doc)
       .def("Evaluate",
-           [](const Expression& self, const Environment::map& env) {
-             return self.Evaluate(Environment{env});
-           },
-           py::arg("env") = Environment::map{}, doc.Expression.Evaluate.doc)
+          [](const Expression& self, const Environment::map& env) {
+            return self.Evaluate(Environment{env});
+          },
+          py::arg("env") = Environment::map{}, doc.Expression.Evaluate.doc)
       .def("Evaluate",
-           [](const Expression& self, const Environment::map& env) {
-             return self.Evaluate(Environment{env});
-           },
-           doc.Expression.Evaluate.doc)
+          [](const Expression& self, const Environment::map& env) {
+            return self.Evaluate(Environment{env});
+          },
+          doc.Expression.Evaluate.doc)
       .def("EvaluatePartial",
-           [](const Expression& self, const Environment::map& env) {
-             return self.EvaluatePartial(Environment{env});
-           },
-           doc.Expression.EvaluatePartial.doc)
+          [](const Expression& self, const Environment::map& env) {
+            return self.EvaluatePartial(Environment{env});
+          },
+          doc.Expression.EvaluatePartial.doc)
       .def("Substitute",
-           [](const Expression& self, const Variable& var,
-              const Expression& e) { return self.Substitute(var, e); },
-           doc.Expression.Substitute.doc_2args)
+          [](const Expression& self, const Variable& var, const Expression& e) {
+            return self.Substitute(var, e);
+          },
+          doc.Expression.Substitute.doc_2args)
       .def("Substitute",
-           [](const Expression& self, const Substitution& s) {
-             return self.Substitute(s);
-           },
-           doc.Expression.Substitute.doc_1args)
+          [](const Expression& self, const Substitution& s) {
+            return self.Substitute(s);
+          },
+          doc.Expression.Substitute.doc_1args)
       .def("EqualTo", &Expression::EqualTo, doc.Expression.EqualTo.doc)
       // Addition
       .def(py::self + py::self)
@@ -253,11 +254,11 @@ PYBIND11_MODULE(symbolic, m) {
       .def(py::self /= double())
       // Pow.
       .def("__pow__", [](const Expression& self,
-                         const double other) { return pow(self, other); })
+                          const double other) { return pow(self, other); })
       .def("__pow__", [](const Expression& self,
-                         const Variable& other) { return pow(self, other); })
+                          const Variable& other) { return pow(self, other); })
       .def("__pow__", [](const Expression& self,
-                         const Expression& other) { return pow(self, other); })
+                          const Expression& other) { return pow(self, other); })
       // Unary Plus.
       .def(+py::self)
       // Unary Minus.
@@ -290,7 +291,7 @@ PYBIND11_MODULE(symbolic, m) {
       .def(py::self != Variable())
       .def(py::self != double())
       .def("Differentiate", &Expression::Differentiate,
-           doc.Expression.Differentiate.doc)
+          doc.Expression.Differentiate.doc)
       .def("Jacobian", &Expression::Jacobian, doc.Expression.Jacobian.doc)
       // TODO(eric.cousineau): Figure out how to consolidate with the below
       // methods.
@@ -342,54 +343,54 @@ PYBIND11_MODULE(symbolic, m) {
   m.def("if_then_else", &symbolic::if_then_else);
 
   m.def("Jacobian",
-        [](const Eigen::Ref<const VectorX<Expression>>& f,
-           const Eigen::Ref<const VectorX<Variable>>& vars) {
-          return Jacobian(f, vars);
-        },
-        doc.Expression.Jacobian.doc);
+      [](const Eigen::Ref<const VectorX<Expression>>& f,
+          const Eigen::Ref<const VectorX<Variable>>& vars) {
+        return Jacobian(f, vars);
+      },
+      doc.Expression.Jacobian.doc);
 
   py::class_<Formula> formula_cls(m, "Formula", doc.Formula.doc);
   formula_cls
       .def("GetFreeVariables", &Formula::GetFreeVariables,
-           doc.Formula.GetFreeVariables.doc)
+          doc.Formula.GetFreeVariables.doc)
       .def("EqualTo", &Formula::EqualTo, doc.Formula.EqualTo.doc)
       .def("Evaluate",
-           [](const Formula& self, const Environment::map& env) {
-             return self.Evaluate(Environment{env});
-           },
-           doc.Formula.Evaluate.doc)
+          [](const Formula& self, const Environment::map& env) {
+            return self.Evaluate(Environment{env});
+          },
+          doc.Formula.Evaluate.doc)
       .def("Substitute",
-           [](const Formula& self, const Variable& var, const Expression& e) {
-             return self.Substitute(var, e);
-           },
-           doc.Formula.Substitute.doc_2args)
+          [](const Formula& self, const Variable& var, const Expression& e) {
+            return self.Substitute(var, e);
+          },
+          doc.Formula.Substitute.doc_2args)
       .def("Substitute",
-           [](const Formula& self, const Variable& var1, const Variable& var2) {
-             return self.Substitute(var1, var2);
-           },
-           doc.Formula.Substitute.doc_2args)
+          [](const Formula& self, const Variable& var1, const Variable& var2) {
+            return self.Substitute(var1, var2);
+          },
+          doc.Formula.Substitute.doc_2args)
       .def("Substitute",
-           [](const Formula& self, const Variable& var, const double c) {
-             return self.Substitute(var, c);
-           },
-           doc.Formula.Substitute.doc_2args)
+          [](const Formula& self, const Variable& var, const double c) {
+            return self.Substitute(var, c);
+          },
+          doc.Formula.Substitute.doc_2args)
       .def("Substitute",
-           [](const Formula& self, const Substitution& s) {
-             return self.Substitute(s);
-           },
-           doc.Formula.Substitute.doc_1args)
+          [](const Formula& self, const Substitution& s) {
+            return self.Substitute(s);
+          },
+          doc.Formula.Substitute.doc_1args)
       .def("to_string", &Formula::to_string, doc.Formula.to_string.doc)
       .def("__str__", &Formula::to_string)
       .def("__repr__",
-           [](const Formula& self) {
-             return fmt::format("<Formula \"{}\">", self.to_string());
-           })
+          [](const Formula& self) {
+            return fmt::format("<Formula \"{}\">", self.to_string());
+          })
       .def("__eq__", [](const Formula& self,
-                        const Formula& other) { return self.EqualTo(other); })
+                         const Formula& other) { return self.EqualTo(other); })
       .def("__ne__", [](const Formula& self,
-                        const Formula& other) { return !self.EqualTo(other); })
+                         const Formula& other) { return !self.EqualTo(other); })
       .def("__hash__",
-           [](const Formula& self) { return std::hash<Formula>{}(self); })
+          [](const Formula& self) { return std::hash<Formula>{}(self); })
       .def_static("True", &Formula::True, doc.FormulaTrue.doc)
       .def_static("False", &Formula::False, doc.FormulaFalse.doc)
       // `True` and `False` are reserved as of Python3
@@ -414,64 +415,65 @@ PYBIND11_MODULE(symbolic, m) {
       // Hide AND and OR to permit us to make it accept 1 or more arguments in
       // Python (and not have to handle type safety within C++).
       .def("__logical_and",
-           [](const Formula& a, const Formula& b) { return a && b; })
+          [](const Formula& a, const Formula& b) { return a && b; })
       .def("__logical_or",
-           [](const Formula& a, const Formula& b) { return a || b; })
+          [](const Formula& a, const Formula& b) { return a || b; })
       .def("logical_not", [](const Formula& a) { return !a; });
 
   // TODO(m-chaturvedi) Add Pybind11 documentation for operator overloads, etc.
   py::class_<Monomial>(m, "Monomial")
       .def(py::init<const Variable&>(), doc.Monomial.ctor.doc_1args_var)
       .def(py::init<const Variable&, int>(),
-           doc.Monomial.ctor.doc_2args_var_exponent)
+          doc.Monomial.ctor.doc_2args_var_exponent)
       .def(py::init<const map<Variable, int>&>(),
-           doc.Monomial.ctor.doc_1args_powers)
+          doc.Monomial.ctor.doc_1args_powers)
       .def("degree", &Monomial::degree, doc.Monomial.degree.doc)
       .def("total_degree", &Monomial::total_degree,
-           doc.Monomial.total_degree.doc)
+          doc.Monomial.total_degree.doc)
       .def(py::self * py::self)
       .def(py::self *= py::self)
       .def(py::self == py::self)
       .def(py::self != py::self)
       .def("__hash__",
-           [](const Monomial& self) { return std::hash<Monomial>{}(self); })
+          [](const Monomial& self) { return std::hash<Monomial>{}(self); })
       .def(py::self != py::self)
       .def("__str__",
-           [](const Monomial& self) { return fmt::format("{}", self); })
+          [](const Monomial& self) { return fmt::format("{}", self); })
       .def("__repr__",
-           [](const Monomial& self) {
-             return fmt::format("<Monomial \"{}\">", self);
-           })
-      .def("EqualTo", [](const Monomial& self,
+          [](const Monomial& self) {
+            return fmt::format("<Monomial \"{}\">", self);
+          })
+      .def(
+          "EqualTo", [](const Monomial& self,
                          const Monomial& monomial) { return self == monomial; })
       .def("GetVariables", &Monomial::GetVariables,
-           doc.Monomial.GetVariables.doc)
+          doc.Monomial.GetVariables.doc)
       .def("get_powers", &Monomial::get_powers, py_reference_internal,
-           doc.Monomial.get_powers.doc)
+          doc.Monomial.get_powers.doc)
       .def("ToExpression", &Monomial::ToExpression,
-           doc.Monomial.ToExpression.doc)
+          doc.Monomial.ToExpression.doc)
       .def("Evaluate",
-           [](const Monomial& self, const Environment::map& env) {
-             return self.Evaluate(Environment{env});
-           },
-           doc.Monomial.Evaluate.doc)
+          [](const Monomial& self, const Environment::map& env) {
+            return self.Evaluate(Environment{env});
+          },
+          doc.Monomial.Evaluate.doc)
       .def("pow_in_place", &Monomial::pow_in_place, py_reference_internal,
-           doc.Monomial.pow_in_place.doc)
+          doc.Monomial.pow_in_place.doc)
       .def("__pow__",
-           [](const Monomial& self, const int p) { return pow(self, p); });
+          [](const Monomial& self, const int p) { return pow(self, p); });
 
   m  // BR
       .def("MonomialBasis",
-           [](const Eigen::Ref<const VectorX<Variable>>& vars,
+          [](const Eigen::Ref<const VectorX<Variable>>& vars,
               const int degree) {
-             return MonomialBasis(Variables{vars}, degree);
-           },
-           doc.MonomialBasis.doc_2args)
+            return MonomialBasis(Variables{vars}, degree);
+          },
+          doc.MonomialBasis.doc_2args)
       .def("MonomialBasis",
-           [](const Variables& vars, const int degree) {
-             return MonomialBasis(vars, degree);
-           },
-           doc.MonomialBasis.doc_2args);
+          [](const Variables& vars, const int degree) {
+            return MonomialBasis(vars, degree);
+          },
+          doc.MonomialBasis.doc_2args);
 
   // TODO(m-chaturvedi) Add Pybind11 documentation for operator overloads, etc.
   py::class_<Polynomial>(m, "Polynomial", doc.Polynomial.doc)
@@ -480,26 +482,26 @@ PYBIND11_MODULE(symbolic, m) {
       .def(py::init<const Monomial&>(), doc.Polynomial.ctor.doc_1args_m)
       .def(py::init<const Expression&>(), doc.Polynomial.ctor.doc_1args_e)
       .def(py::init<const Expression&, const Variables&>(),
-           doc.Polynomial.ctor.doc_2args_e_indeterminates)
+          doc.Polynomial.ctor.doc_2args_e_indeterminates)
       .def(py::init([](const Expression& e,
-                       const Eigen::Ref<const VectorX<Variable>>& vars) {
-             return Polynomial{e, Variables{vars}};
-           }),
-           doc.Polynomial.ctor.doc_2args_e_indeterminates)
+                        const Eigen::Ref<const VectorX<Variable>>& vars) {
+        return Polynomial{e, Variables{vars}};
+      }),
+          doc.Polynomial.ctor.doc_2args_e_indeterminates)
       .def("indeterminates", &Polynomial::indeterminates,
-           doc.Polynomial.indeterminates.doc, doc.Polynomial.indeterminates.doc)
+          doc.Polynomial.indeterminates.doc, doc.Polynomial.indeterminates.doc)
       .def("decision_variables", &Polynomial::decision_variables,
-           doc.Polynomial.decision_variables.doc)
+          doc.Polynomial.decision_variables.doc)
       .def("Degree", &Polynomial::Degree, doc.Polynomial.Degree.doc)
       .def("TotalDegree", &Polynomial::TotalDegree,
-           doc.Polynomial.TotalDegree.doc)
+          doc.Polynomial.TotalDegree.doc)
       .def("monomial_to_coefficient_map",
-           &Polynomial::monomial_to_coefficient_map,
-           doc.Polynomial.monomial_to_coefficient_map.doc)
+          &Polynomial::monomial_to_coefficient_map,
+          doc.Polynomial.monomial_to_coefficient_map.doc)
       .def("ToExpression", &Polynomial::ToExpression,
-           doc.Polynomial.ToExpression.doc)
+          doc.Polynomial.ToExpression.doc)
       .def("Differentiate", &Polynomial::Differentiate,
-           doc.Polynomial.Differentiate.doc)
+          doc.Polynomial.Differentiate.doc)
       .def("AddProduct", &Polynomial::AddProduct, doc.Polynomial.AddProduct.doc)
       .def(py::self + py::self)
       .def(py::self + Monomial())
@@ -521,26 +523,26 @@ PYBIND11_MODULE(symbolic, m) {
       .def(py::self == py::self)
       .def(py::self != py::self)
       .def("__hash__",
-           [](const Polynomial& self) { return std::hash<Polynomial>{}(self); })
+          [](const Polynomial& self) { return std::hash<Polynomial>{}(self); })
       .def("__str__",
-           [](const Polynomial& self) { return fmt::format("{}", self); })
+          [](const Polynomial& self) { return fmt::format("{}", self); })
       .def("__repr__",
-           [](const Polynomial& self) {
-             return fmt::format("<Polynomial \"{}\">", self);
-           })
+          [](const Polynomial& self) {
+            return fmt::format("<Polynomial \"{}\">", self);
+          })
       .def("__pow__",
-           [](const Polynomial& self, const int n) { return pow(self, n); })
+          [](const Polynomial& self, const int n) { return pow(self, n); })
       .def("Evaluate",
-           [](const Polynomial& self, const Environment::map& env) {
-             return self.Evaluate(Environment{env});
-           },
-           doc.Polynomial.Evaluate.doc)
+          [](const Polynomial& self, const Environment::map& env) {
+            return self.Evaluate(Environment{env});
+          },
+          doc.Polynomial.Evaluate.doc)
       .def("Jacobian",
-           [](const Polynomial& p,
+          [](const Polynomial& p,
               const Eigen::Ref<const VectorX<Variable>>& vars) {
-             return p.Jacobian(vars);
-           },
-           doc.Polynomial.Jacobian.doc);
+            return p.Jacobian(vars);
+          },
+          doc.Polynomial.Jacobian.doc);
 
   // We have this line because pybind11 does not permit transitive
   // conversions. See
@@ -548,9 +550,9 @@ PYBIND11_MODULE(symbolic, m) {
   py::implicitly_convertible<int, drake::symbolic::Expression>();
   py::implicitly_convertible<double, drake::symbolic::Expression>();
   py::implicitly_convertible<drake::symbolic::Variable,
-                             drake::symbolic::Expression>();
+      drake::symbolic::Expression>();
   py::implicitly_convertible<drake::symbolic::Monomial,
-                             drake::symbolic::Polynomial>();
+      drake::symbolic::Polynomial>();
 
   ExecuteExtraPythonCode(m);
 }

--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -27,83 +27,83 @@ PYBIND11_MODULE(analysis, m) {
     DefineTemplateClassWithDefault<IntegratorBase<T>>(
         m, "IntegratorBase", GetPyParam<T>(), doc.IntegratorBase.doc)
         .def("set_fixed_step_mode", &IntegratorBase<T>::set_fixed_step_mode,
-             doc.IntegratorBase.set_fixed_step_mode.doc)
+            doc.IntegratorBase.set_fixed_step_mode.doc)
         .def("get_fixed_step_mode", &IntegratorBase<T>::get_fixed_step_mode,
-             doc.IntegratorBase.get_fixed_step_mode.doc)
+            doc.IntegratorBase.get_fixed_step_mode.doc)
         .def("set_target_accuracy", &IntegratorBase<T>::set_target_accuracy,
-             doc.IntegratorBase.set_target_accuracy.doc)
+            doc.IntegratorBase.set_target_accuracy.doc)
         .def("get_target_accuracy", &IntegratorBase<T>::get_target_accuracy,
-             doc.IntegratorBase.get_target_accuracy.doc)
+            doc.IntegratorBase.get_target_accuracy.doc)
         .def("set_maximum_step_size", &IntegratorBase<T>::set_maximum_step_size,
-             doc.IntegratorBase.set_maximum_step_size.doc)
+            doc.IntegratorBase.set_maximum_step_size.doc)
         .def("get_maximum_step_size", &IntegratorBase<T>::get_maximum_step_size,
-             doc.IntegratorBase.get_maximum_step_size.doc)
+            doc.IntegratorBase.get_maximum_step_size.doc)
         .def("set_requested_minimum_step_size",
-             &IntegratorBase<T>::set_requested_minimum_step_size,
-             doc.IntegratorBase.set_requested_minimum_step_size.doc)
+            &IntegratorBase<T>::set_requested_minimum_step_size,
+            doc.IntegratorBase.set_requested_minimum_step_size.doc)
         .def("get_requested_minimum_step_size",
-             &IntegratorBase<T>::get_requested_minimum_step_size,
-             doc.IntegratorBase.get_requested_minimum_step_size.doc)
+            &IntegratorBase<T>::get_requested_minimum_step_size,
+            doc.IntegratorBase.get_requested_minimum_step_size.doc)
         .def("set_throw_on_minimum_step_size_violation",
-             &IntegratorBase<T>::set_throw_on_minimum_step_size_violation,
-             doc.IntegratorBase.set_throw_on_minimum_step_size_violation.doc)
+            &IntegratorBase<T>::set_throw_on_minimum_step_size_violation,
+            doc.IntegratorBase.set_throw_on_minimum_step_size_violation.doc)
         .def("get_throw_on_minimum_step_size_violation",
-             &IntegratorBase<T>::get_throw_on_minimum_step_size_violation,
-             doc.IntegratorBase.get_throw_on_minimum_step_size_violation.doc);
+            &IntegratorBase<T>::get_throw_on_minimum_step_size_violation,
+            doc.IntegratorBase.get_throw_on_minimum_step_size_violation.doc);
 
     DefineTemplateClassWithDefault<RungeKutta2Integrator<T>, IntegratorBase<T>>(
         m, "RungeKutta2Integrator", GetPyParam<T>(),
         doc.RungeKutta2Integrator.doc)
         .def(py::init<const System<T>&, const T&, Context<T>*>(),
-             py::arg("system"), py::arg("max_step_size"),
-             py::arg("context") = nullptr,
-             // Keep alive, reference: `self` keeps `System` alive.
-             py::keep_alive<1, 2>(),
-             // Keep alive, reference: `self` keeps `Context` alive.
-             py::keep_alive<1, 4>(), doc.RungeKutta2Integrator.ctor.doc_3args);
+            py::arg("system"), py::arg("max_step_size"),
+            py::arg("context") = nullptr,
+            // Keep alive, reference: `self` keeps `System` alive.
+            py::keep_alive<1, 2>(),
+            // Keep alive, reference: `self` keeps `Context` alive.
+            py::keep_alive<1, 4>(), doc.RungeKutta2Integrator.ctor.doc_3args);
 
     DefineTemplateClassWithDefault<RungeKutta3Integrator<T>, IntegratorBase<T>>(
         m, "RungeKutta3Integrator", GetPyParam<T>(),
         doc.RungeKutta3Integrator.doc)
         .def(py::init<const System<T>&, Context<T>*>(), py::arg("system"),
-             py::arg("context") = nullptr,
-             // Keep alive, reference: `self` keeps `System` alive.
-             py::keep_alive<1, 2>(),
-             // Keep alive, reference: `self` keeps `Context` alive.
-             py::keep_alive<1, 3>(), doc.RungeKutta3Integrator.ctor.doc_2args);
+            py::arg("context") = nullptr,
+            // Keep alive, reference: `self` keeps `System` alive.
+            py::keep_alive<1, 2>(),
+            // Keep alive, reference: `self` keeps `Context` alive.
+            py::keep_alive<1, 3>(), doc.RungeKutta3Integrator.ctor.doc_2args);
 
     DefineTemplateClassWithDefault<Simulator<T>>(
         m, "Simulator", GetPyParam<T>(), doc.Simulator.doc)
         .def(py::init<const System<T>&, unique_ptr<Context<T>>>(),
-             py::arg("system"), py::arg("context") = nullptr,
-             // Keep alive, reference: `self` keeps `System` alive.
-             py::keep_alive<1, 2>(),
-             // Keep alive, ownership: `Context` keeps `self` alive.
-             py::keep_alive<3, 1>(), doc.Simulator.ctor.doc_3)
+            py::arg("system"), py::arg("context") = nullptr,
+            // Keep alive, reference: `self` keeps `System` alive.
+            py::keep_alive<1, 2>(),
+            // Keep alive, ownership: `Context` keeps `self` alive.
+            py::keep_alive<3, 1>(), doc.Simulator.ctor.doc_3)
         .def("Initialize", &Simulator<T>::Initialize,
-             doc.Simulator.Initialize.doc)
+            doc.Simulator.Initialize.doc)
         .def("StepTo", &Simulator<T>::StepTo, doc.Simulator.StepTo.doc)
         .def("get_context", &Simulator<T>::get_context, py_reference_internal,
-             doc.Simulator.get_context.doc)
+            doc.Simulator.get_context.doc)
         .def("get_integrator", &Simulator<T>::get_integrator,
-             py_reference_internal, doc.Simulator.get_integrator.doc)
+            py_reference_internal, doc.Simulator.get_integrator.doc)
         .def("get_mutable_integrator", &Simulator<T>::get_mutable_integrator,
-             py_reference_internal, doc.Simulator.get_mutable_integrator.doc)
+            py_reference_internal, doc.Simulator.get_mutable_integrator.doc)
         .def("get_mutable_context", &Simulator<T>::get_mutable_context,
-             py_reference_internal, doc.Simulator.get_mutable_context.doc)
+            py_reference_internal, doc.Simulator.get_mutable_context.doc)
         .def("reset_integrator",
-             [](Simulator<T>* self,
+            [](Simulator<T>* self,
                 std::unique_ptr<IntegratorBase<T>> integrator) {
-               return self->reset_integrator(std::move(integrator));
-             },
-             // Keep alive, ownership: 'Integrator' keeps 'self' alive.
-             py::keep_alive<2, 1>(), doc.Simulator.reset_integrator.doc)
+              return self->reset_integrator(std::move(integrator));
+            },
+            // Keep alive, ownership: 'Integrator' keeps 'self' alive.
+            py::keep_alive<2, 1>(), doc.Simulator.reset_integrator.doc)
         .def("set_publish_every_time_step",
-             &Simulator<T>::set_publish_every_time_step,
-             doc.Simulator.set_publish_every_time_step.doc)
+            &Simulator<T>::set_publish_every_time_step,
+            doc.Simulator.set_publish_every_time_step.doc)
         .def("set_target_realtime_rate",
-             &Simulator<T>::set_target_realtime_rate,
-             doc.Simulator.set_target_realtime_rate.doc);
+            &Simulator<T>::set_target_realtime_rate,
+            doc.Simulator.set_target_realtime_rate.doc);
   };
   type_visit(bind_scalar_types, pysystems::NonSymbolicScalarPack{});
 }

--- a/bindings/pydrake/systems/controllers_py.cc
+++ b/bindings/pydrake/systems/controllers_py.cc
@@ -32,28 +32,27 @@ PYBIND11_MODULE(controllers, m) {
   py::module::import("pydrake.systems.framework");
   py::module::import("pydrake.systems.primitives");
 
-  py::class_<DynamicProgrammingOptions::PeriodicBoundaryCondition>(
-      m, "PeriodicBoundaryCondition",
+  py::class_<DynamicProgrammingOptions::PeriodicBoundaryCondition>(m,
+      "PeriodicBoundaryCondition",
       doc.DynamicProgrammingOptions.PeriodicBoundaryCondition.doc)
       .def(py::init<int, double, double>(),
-           doc.DynamicProgrammingOptions.PeriodicBoundaryCondition.ctor.doc);
+          doc.DynamicProgrammingOptions.PeriodicBoundaryCondition.ctor.doc);
 
-  py::class_<DynamicProgrammingOptions>(m, "DynamicProgrammingOptions",
-                                        doc.DynamicProgrammingOptions.doc)
+  py::class_<DynamicProgrammingOptions>(
+      m, "DynamicProgrammingOptions", doc.DynamicProgrammingOptions.doc)
       .def(py::init<>())
       .def_readwrite("discount_factor",
-                     &DynamicProgrammingOptions::discount_factor,
-                     doc.DynamicProgrammingOptions.discount_factor.doc)
-      .def_readwrite(
-          "periodic_boundary_conditions",
+          &DynamicProgrammingOptions::discount_factor,
+          doc.DynamicProgrammingOptions.discount_factor.doc)
+      .def_readwrite("periodic_boundary_conditions",
           &DynamicProgrammingOptions::periodic_boundary_conditions,
           doc.DynamicProgrammingOptions.periodic_boundary_conditions.doc)
       .def_readwrite("convergence_tol",
-                     &DynamicProgrammingOptions::convergence_tol,
-                     doc.DynamicProgrammingOptions.convergence_tol.doc)
+          &DynamicProgrammingOptions::convergence_tol,
+          doc.DynamicProgrammingOptions.convergence_tol.doc)
       .def_readwrite("visualization_callback",
-                     &DynamicProgrammingOptions::visualization_callback,
-                     doc.DynamicProgrammingOptions.visualization_callback.doc);
+          &DynamicProgrammingOptions::visualization_callback,
+          doc.DynamicProgrammingOptions.visualization_callback.doc);
 
   // The RBT flavor of inverse dynamics.
 
@@ -61,19 +60,18 @@ PYBIND11_MODULE(controllers, m) {
       m, "RbtInverseDynamics", doc.rbt.InverseDynamics.doc);
   rbt_idyn  // BR
       .def(py::init<const RigidBodyTree<double>*,
-                    rbt::InverseDynamics<double>::InverseDynamicsMode>(),
-           py::arg("tree"), py::arg("mode"),
-           doc.rbt.InverseDynamics.ctor.doc_2args_tree_mode)
+               rbt::InverseDynamics<double>::InverseDynamicsMode>(),
+          py::arg("tree"), py::arg("mode"),
+          doc.rbt.InverseDynamics.ctor.doc_2args_tree_mode)
       .def("is_pure_gravity_compensation",
-           &rbt::InverseDynamics<double>::is_pure_gravity_compensation,
-           doc.rbt.InverseDynamics.is_pure_gravity_compensation.doc);
+          &rbt::InverseDynamics<double>::is_pure_gravity_compensation,
+          doc.rbt.InverseDynamics.is_pure_gravity_compensation.doc);
 
   py::enum_<rbt::InverseDynamics<double>::InverseDynamicsMode>(  // BR
       rbt_idyn, "InverseDynamicsMode")
       .value("kInverseDynamics", rbt::InverseDynamics<double>::kInverseDynamics,
-             doc.rbt.InverseDynamics.InverseDynamicsMode.doc)
-      .value(
-          "kGravityCompensation",
+          doc.rbt.InverseDynamics.InverseDynamicsMode.doc)
+      .value("kGravityCompensation",
           rbt::InverseDynamics<double>::kGravityCompensation,
           doc.rbt.InverseDynamics.InverseDynamicsMode.kGravityCompensation.doc)
       .export_values();
@@ -81,17 +79,17 @@ PYBIND11_MODULE(controllers, m) {
   py::class_<rbt::InverseDynamicsController<double>, Diagram<double>>(
       m, "RbtInverseDynamicsController", doc.rbt.InverseDynamicsController.doc)
       .def(py::init<std::unique_ptr<RigidBodyTree<double>>,
-                    const VectorX<double>&, const VectorX<double>&,
-                    const VectorX<double>&, bool>(),
-           py::arg("robot"), py::arg("kp"), py::arg("ki"), py::arg("kd"),
-           py::arg("has_reference_acceleration"),
-           // Keep alive, ownership: RigidBodyTree keeps this alive.
-           // See "Keep Alive Behavior" in pydrake_pybind.h for details.
-           py::keep_alive<2 /* Nurse */, 1 /* Patient */>(),
-           doc.rbt.InverseDynamicsController.ctor.doc_5args)
+               const VectorX<double>&, const VectorX<double>&,
+               const VectorX<double>&, bool>(),
+          py::arg("robot"), py::arg("kp"), py::arg("ki"), py::arg("kd"),
+          py::arg("has_reference_acceleration"),
+          // Keep alive, ownership: RigidBodyTree keeps this alive.
+          // See "Keep Alive Behavior" in pydrake_pybind.h for details.
+          py::keep_alive<2 /* Nurse */, 1 /* Patient */>(),
+          doc.rbt.InverseDynamicsController.ctor.doc_5args)
       .def("set_integral_value",
-           &rbt::InverseDynamicsController<double>::set_integral_value,
-           doc.rbt.InverseDynamicsController.set_integral_value.doc);
+          &rbt::InverseDynamicsController<double>::set_integral_value,
+          doc.rbt.InverseDynamicsController.set_integral_value.doc);
 
   // The MBP flavor of inverse dynamics.
 
@@ -99,95 +97,93 @@ PYBIND11_MODULE(controllers, m) {
       m, "InverseDynamics", doc.InverseDynamics.doc);
   idyn  // BR
       .def(py::init<const multibody::multibody_plant::MultibodyPlant<double>*,
-                    InverseDynamics<double>::InverseDynamicsMode>(),
-           py::arg("plant"), py::arg("mode"),
-           doc.InverseDynamics.ctor.doc_2args_plant_mode)
+               InverseDynamics<double>::InverseDynamicsMode>(),
+          py::arg("plant"), py::arg("mode"),
+          doc.InverseDynamics.ctor.doc_2args_plant_mode)
       .def("is_pure_gravity_compensation",
-           &InverseDynamics<double>::is_pure_gravity_compensation,
-           doc.InverseDynamics.is_pure_gravity_compensation.doc);
+          &InverseDynamics<double>::is_pure_gravity_compensation,
+          doc.InverseDynamics.is_pure_gravity_compensation.doc);
 
   py::enum_<InverseDynamics<double>::InverseDynamicsMode>(  // BR
       idyn, "InverseDynamicsMode")
       .value("kInverseDynamics", InverseDynamics<double>::kInverseDynamics,
-             doc.InverseDynamics.InverseDynamicsMode.doc)
+          doc.InverseDynamics.InverseDynamicsMode.doc)
       .value("kGravityCompensation",
-             InverseDynamics<double>::kGravityCompensation,
-             doc.InverseDynamics.InverseDynamicsMode.kGravityCompensation.doc)
+          InverseDynamics<double>::kGravityCompensation,
+          doc.InverseDynamics.InverseDynamicsMode.kGravityCompensation.doc)
       .export_values();
 
   py::class_<InverseDynamicsController<double>, Diagram<double>>(
       m, "InverseDynamicsController", doc.InverseDynamicsController.doc)
       .def(py::init<std::unique_ptr<RigidBodyTree<double>>,
-                    const VectorX<double>&, const VectorX<double>&,
-                    const VectorX<double>&, bool>(),
-           py::arg("robot"), py::arg("kp"), py::arg("ki"), py::arg("kd"),
-           py::arg("has_reference_acceleration"),
-           // Keep alive, ownership: RigidBodyTree keeps this alive.
-           // See "Keep Alive Behavior" in pydrake_pybind.h for details.
-           py::keep_alive<2 /* Nurse */, 1 /* Patient */>())
+               const VectorX<double>&, const VectorX<double>&,
+               const VectorX<double>&, bool>(),
+          py::arg("robot"), py::arg("kp"), py::arg("ki"), py::arg("kd"),
+          py::arg("has_reference_acceleration"),
+          // Keep alive, ownership: RigidBodyTree keeps this alive.
+          // See "Keep Alive Behavior" in pydrake_pybind.h for details.
+          py::keep_alive<2 /* Nurse */, 1 /* Patient */>())
       .def(py::init<const MultibodyPlant<double>&, const VectorX<double>&,
-                    const VectorX<double>&, const VectorX<double>&, bool>(),
-           py::arg("robot"), py::arg("kp"), py::arg("ki"), py::arg("kd"),
-           py::arg("has_reference_acceleration"),
-           // Keep alive, reference: `self` keeps `MultibodyPlant` alive.
-           py::keep_alive<1, 2>(),
-           doc.InverseDynamicsController.ctor.  // BR
-           doc_5args_plant_kp_ki_kd_has_reference_acceleration)
+               const VectorX<double>&, const VectorX<double>&, bool>(),
+          py::arg("robot"), py::arg("kp"), py::arg("ki"), py::arg("kd"),
+          py::arg("has_reference_acceleration"),
+          // Keep alive, reference: `self` keeps `MultibodyPlant` alive.
+          py::keep_alive<1, 2>(),
+          doc.InverseDynamicsController.ctor.  // BR
+          doc_5args_plant_kp_ki_kd_has_reference_acceleration)
       .def("set_integral_value",
-           &InverseDynamicsController<double>::set_integral_value,
-           doc.InverseDynamicsController.set_integral_value.doc);
+          &InverseDynamicsController<double>::set_integral_value,
+          doc.InverseDynamicsController.set_integral_value.doc);
 
   m.def("FittedValueIteration", WrapCallbacks(&FittedValueIteration),
-        doc.FittedValueIteration.doc);
+      doc.FittedValueIteration.doc);
 
   m.def("LinearProgrammingApproximateDynamicProgramming",
-        WrapCallbacks(&LinearProgrammingApproximateDynamicProgramming),
-        doc.LinearProgrammingApproximateDynamicProgramming.doc);
+      WrapCallbacks(&LinearProgrammingApproximateDynamicProgramming),
+      doc.LinearProgrammingApproximateDynamicProgramming.doc);
 
   m.def("LinearQuadraticRegulator",
-        [](const Eigen::Ref<const Eigen::MatrixXd>& A,
-           const Eigen::Ref<const Eigen::MatrixXd>& B,
-           const Eigen::Ref<const Eigen::MatrixXd>& Q,
-           const Eigen::Ref<const Eigen::MatrixXd>& R,
-           const Eigen::Ref<const Eigen::MatrixXd>& N) {
-          auto result = LinearQuadraticRegulator(A, B, Q, R, N);
-          return std::make_pair(result.K, result.S);
-        },
-        py::arg("A"), py::arg("B"), py::arg("Q"), py::arg("R"),
-        py::arg("N") = Eigen::Matrix<double, 0, 0>::Zero(),
-        doc.LinearQuadraticRegulator.doc_5args_A_B_Q_R_N);
+      [](const Eigen::Ref<const Eigen::MatrixXd>& A,
+          const Eigen::Ref<const Eigen::MatrixXd>& B,
+          const Eigen::Ref<const Eigen::MatrixXd>& Q,
+          const Eigen::Ref<const Eigen::MatrixXd>& R,
+          const Eigen::Ref<const Eigen::MatrixXd>& N) {
+        auto result = LinearQuadraticRegulator(A, B, Q, R, N);
+        return std::make_pair(result.K, result.S);
+      },
+      py::arg("A"), py::arg("B"), py::arg("Q"), py::arg("R"),
+      py::arg("N") = Eigen::Matrix<double, 0, 0>::Zero(),
+      doc.LinearQuadraticRegulator.doc_5args_A_B_Q_R_N);
 
   m.def("DiscreteTimeLinearQuadraticRegulator",
-        [](const Eigen::Ref<const Eigen::MatrixXd>& A,
-           const Eigen::Ref<const Eigen::MatrixXd>& B,
-           const Eigen::Ref<const Eigen::MatrixXd>& Q,
-           const Eigen::Ref<const Eigen::MatrixXd>& R) {
-          auto result = DiscreteTimeLinearQuadraticRegulator(A, B, Q, R);
-          return std::make_pair(result.K, result.S);
-        },
-        py::arg("A"), py::arg("B"), py::arg("Q"), py::arg("R"),
-        doc.DiscreteTimeLinearQuadraticRegulator.doc);
+      [](const Eigen::Ref<const Eigen::MatrixXd>& A,
+          const Eigen::Ref<const Eigen::MatrixXd>& B,
+          const Eigen::Ref<const Eigen::MatrixXd>& Q,
+          const Eigen::Ref<const Eigen::MatrixXd>& R) {
+        auto result = DiscreteTimeLinearQuadraticRegulator(A, B, Q, R);
+        return std::make_pair(result.K, result.S);
+      },
+      py::arg("A"), py::arg("B"), py::arg("Q"), py::arg("R"),
+      doc.DiscreteTimeLinearQuadraticRegulator.doc);
 
   m.def("LinearQuadraticRegulator",
-        py::overload_cast<const systems::LinearSystem<double>&,
-                          const Eigen::Ref<const Eigen::MatrixXd>&,
-                          const Eigen::Ref<const Eigen::MatrixXd>&,
-                          const Eigen::Ref<const Eigen::MatrixXd>&>(
-            &LinearQuadraticRegulator),
-        py::arg("system"), py::arg("Q"), py::arg("R"),
-        py::arg("N") = Eigen::Matrix<double, 0, 0>::Zero(),
-        doc.LinearQuadraticRegulator.doc_4args_system_Q_R_N);
+      py::overload_cast<const systems::LinearSystem<double>&,
+          const Eigen::Ref<const Eigen::MatrixXd>&,
+          const Eigen::Ref<const Eigen::MatrixXd>&,
+          const Eigen::Ref<const Eigen::MatrixXd>&>(&LinearQuadraticRegulator),
+      py::arg("system"), py::arg("Q"), py::arg("R"),
+      py::arg("N") = Eigen::Matrix<double, 0, 0>::Zero(),
+      doc.LinearQuadraticRegulator.doc_4args_system_Q_R_N);
 
   m.def("LinearQuadraticRegulator",
-        py::overload_cast<const systems::System<double>&,
-                          const systems::Context<double>&,
-                          const Eigen::Ref<const Eigen::MatrixXd>&,
-                          const Eigen::Ref<const Eigen::MatrixXd>&,
-                          const Eigen::Ref<const Eigen::MatrixXd>&>(
-            &LinearQuadraticRegulator),
-        py::arg("system"), py::arg("context"), py::arg("Q"), py::arg("R"),
-        py::arg("N") = Eigen::Matrix<double, 0, 0>::Zero(),
-        doc.LinearQuadraticRegulator.doc_5args_system_context_Q_R_N);
+      py::overload_cast<const systems::System<double>&,
+          const systems::Context<double>&,
+          const Eigen::Ref<const Eigen::MatrixXd>&,
+          const Eigen::Ref<const Eigen::MatrixXd>&,
+          const Eigen::Ref<const Eigen::MatrixXd>&>(&LinearQuadraticRegulator),
+      py::arg("system"), py::arg("context"), py::arg("Q"), py::arg("R"),
+      py::arg("N") = Eigen::Matrix<double, 0, 0>::Zero(),
+      doc.LinearQuadraticRegulator.doc_5args_system_context_Q_R_N);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -48,26 +48,26 @@ void DefineFrameworkPySemantics(py::module m) {
   BindTypeSafeIndex<NumericParameterIndex>(m, "NumericParameterIndex");
   BindTypeSafeIndex<AbstractParameterIndex>(m, "AbstractParameterIndex");
 
-  py::class_<FixedInputPortValue>(m, "FixedInputPortValue",
-                                  doc.FixedInputPortValue.doc);
+  py::class_<FixedInputPortValue>(
+      m, "FixedInputPortValue", doc.FixedInputPortValue.doc);
 
   using AbstractValuePtrList = vector<unique_ptr<AbstractValue>>;
   // N.B. `AbstractValues` provides the ability to reference non-owned values,
   // without copying them. For consistency with other model-value Python
   // bindings, only the ownership variant is exposed.
-  py::class_<AbstractValues> abstract_values(m, "AbstractValues",
-                                             doc.AbstractValues.doc);
+  py::class_<AbstractValues> abstract_values(
+      m, "AbstractValues", doc.AbstractValues.doc);
   DefClone(&abstract_values);
   abstract_values  // BR
       .def(py::init<>(), doc.AbstractValues.ctor.doc_3)
       .def(py::init<AbstractValuePtrList>(), doc.AbstractValues.ctor.doc_4)
       .def("size", &AbstractValues::size, doc.AbstractValues.size.doc)
       .def("get_value", &AbstractValues::get_value, py_reference_internal,
-           doc.AbstractValues.get_value.doc)
+          doc.AbstractValues.get_value.doc)
       .def("get_mutable_value", &AbstractValues::get_mutable_value,
-           py_reference_internal, doc.AbstractValues.get_mutable_value.doc)
+          py_reference_internal, doc.AbstractValues.get_mutable_value.doc)
       .def("CopyFrom", &AbstractValues::CopyFrom,
-           doc.AbstractValues.CopyFrom.doc);
+          doc.AbstractValues.CopyFrom.doc);
 
   {
     using Class = TriggerType;
@@ -75,7 +75,7 @@ void DefineFrameworkPySemantics(py::module m) {
     py::enum_<TriggerType>(m, "TriggerType", cls_doc.doc)
         .value("kUnknown", Class::kUnknown, cls_doc.kUnknown.doc)
         .value("kInitialization", Class::kInitialization,
-               cls_doc.kInitialization.doc)
+            cls_doc.kInitialization.doc)
         .value("kForced", Class::kForced, cls_doc.kForced.doc)
         .value("kTimed", Class::kTimed, cls_doc.kTimed.doc)
         .value("kPeriodic", Class::kPeriodic, cls_doc.kPeriodic.doc)
@@ -86,126 +86,127 @@ void DefineFrameworkPySemantics(py::module m) {
   // N.B. Capturing `&doc` should not be required; workaround per #9600.
   auto bind_common_scalar_types = [m, &doc](auto dummy) {
     using T = decltype(dummy);
-    DefineTemplateClassWithDefault<Context<T>>(m, "Context", GetPyParam<T>(),
-                                               doc.Context.doc)
+    DefineTemplateClassWithDefault<Context<T>>(
+        m, "Context", GetPyParam<T>(), doc.Context.doc)
         .def("get_num_input_ports", &Context<T>::get_num_input_ports,
-             doc.ContextBase.get_num_input_ports.doc)
+            doc.ContextBase.get_num_input_ports.doc)
         .def("FixInputPort",
-             py::overload_cast<int, const BasicVector<T>&>(
-                 &Context<T>::FixInputPort),
-             py::arg("index"), py::arg("vec"), py_reference_internal,
-             doc.Context.FixInputPort.doc)
+            py::overload_cast<int, const BasicVector<T>&>(
+                &Context<T>::FixInputPort),
+            py::arg("index"), py::arg("vec"), py_reference_internal,
+            doc.Context.FixInputPort.doc)
         .def("FixInputPort",
-             py::overload_cast<int, unique_ptr<AbstractValue>>(
-                 &Context<T>::FixInputPort),
-             py::arg("index"), py::arg("value"), py_reference_internal,
-             // Keep alive, ownership: `AbstractValue` keeps `self` alive.
-             py::keep_alive<3, 1>(), doc.Context.FixInputPort.doc_2)
+            py::overload_cast<int, unique_ptr<AbstractValue>>(
+                &Context<T>::FixInputPort),
+            py::arg("index"), py::arg("value"), py_reference_internal,
+            // Keep alive, ownership: `AbstractValue` keeps `self` alive.
+            py::keep_alive<3, 1>(), doc.Context.FixInputPort.doc_2)
         .def("FixInputPort",
-             py::overload_cast<int, const Eigen::Ref<const VectorX<T>>&>(
-                 &Context<T>::FixInputPort),
-             py::arg("index"), py::arg("data"), py_reference_internal,
-             doc.Context.FixInputPort.doc_3)
+            py::overload_cast<int, const Eigen::Ref<const VectorX<T>>&>(
+                &Context<T>::FixInputPort),
+            py::arg("index"), py::arg("data"), py_reference_internal,
+            doc.Context.FixInputPort.doc_3)
         .def("get_time", &Context<T>::get_time, doc.Context.get_time.doc)
         .def("set_time", &Context<T>::set_time, doc.Context.set_time.doc)
         .def("set_accuracy", &Context<T>::set_accuracy,
-             doc.Context.set_accuracy.doc)
+            doc.Context.set_accuracy.doc)
         .def("get_accuracy", &Context<T>::get_accuracy,
-             doc.Context.get_accuracy.doc)
+            doc.Context.get_accuracy.doc)
         .def("Clone", &Context<T>::Clone, doc.Context.Clone.doc)
         .def("__copy__", &Context<T>::Clone)
         .def("__deepcopy__", [](const Context<T>* self,
-                                py::dict /* memo */) { return self->Clone(); })
+                                 py::dict /* memo */) { return self->Clone(); })
         .def("get_state", &Context<T>::get_state, py_reference_internal,
-             doc.Context.get_state.doc)
+            doc.Context.get_state.doc)
         .def("get_mutable_state", &Context<T>::get_mutable_state,
-             py_reference_internal, doc.Context.get_mutable_state.doc)
+            py_reference_internal, doc.Context.get_mutable_state.doc)
         // Sugar methods
         // - Continuous.
         .def("get_continuous_state", &Context<T>::get_continuous_state,
-             py_reference_internal, doc.Context.get_continuous_state.doc)
+            py_reference_internal, doc.Context.get_continuous_state.doc)
         .def("get_mutable_continuous_state",
-             &Context<T>::get_mutable_continuous_state, py_reference_internal,
-             doc.Context.get_mutable_continuous_state.doc)
+            &Context<T>::get_mutable_continuous_state, py_reference_internal,
+            doc.Context.get_mutable_continuous_state.doc)
         .def("get_continuous_state_vector",
-             &Context<T>::get_continuous_state_vector, py_reference_internal,
-             doc.Context.get_continuous_state_vector.doc)
+            &Context<T>::get_continuous_state_vector, py_reference_internal,
+            doc.Context.get_continuous_state_vector.doc)
         .def("get_mutable_continuous_state_vector",
-             &Context<T>::get_mutable_continuous_state_vector,
-             py_reference_internal,
-             doc.Context.get_mutable_continuous_state_vector.doc)
+            &Context<T>::get_mutable_continuous_state_vector,
+            py_reference_internal,
+            doc.Context.get_mutable_continuous_state_vector.doc)
         // - Discrete.
         .def("get_num_discrete_state_groups",
-             &Context<T>::get_num_discrete_state_groups,
-             doc.Context.get_num_discrete_state_groups.doc)
+            &Context<T>::get_num_discrete_state_groups,
+            doc.Context.get_num_discrete_state_groups.doc)
         .def("get_discrete_state",
-             overload_cast_explicit<const DiscreteValues<T>&>(
-                 &Context<T>::get_discrete_state),
-             py_reference_internal, doc.Context.get_discrete_state.doc_0args)
+            overload_cast_explicit<const DiscreteValues<T>&>(
+                &Context<T>::get_discrete_state),
+            py_reference_internal, doc.Context.get_discrete_state.doc_0args)
         .def("get_mutable_discrete_state",
-             overload_cast_explicit<DiscreteValues<T>&>(
-                 &Context<T>::get_mutable_discrete_state),
-             py_reference_internal,
-             doc.Context.get_mutable_discrete_state.doc_0args)
+            overload_cast_explicit<DiscreteValues<T>&>(
+                &Context<T>::get_mutable_discrete_state),
+            py_reference_internal,
+            doc.Context.get_mutable_discrete_state.doc_0args)
         .def("get_discrete_state_vector",
-             &Context<T>::get_discrete_state_vector, py_reference_internal,
-             doc.Context.get_discrete_state_vector.doc)
+            &Context<T>::get_discrete_state_vector, py_reference_internal,
+            doc.Context.get_discrete_state_vector.doc)
         .def("get_mutable_discrete_state_vector",
-             &Context<T>::get_mutable_discrete_state_vector,
-             py_reference_internal,
-             doc.Context.get_mutable_discrete_state_vector.doc)
+            &Context<T>::get_mutable_discrete_state_vector,
+            py_reference_internal,
+            doc.Context.get_mutable_discrete_state_vector.doc)
         .def("get_discrete_state",
-             overload_cast_explicit<const BasicVector<T>&, int>(
-                 &Context<T>::get_discrete_state),
-             py_reference_internal, doc.Context.get_discrete_state.doc_1args)
+            overload_cast_explicit<const BasicVector<T>&, int>(
+                &Context<T>::get_discrete_state),
+            py_reference_internal, doc.Context.get_discrete_state.doc_1args)
         .def("get_mutable_discrete_state",
-             overload_cast_explicit<BasicVector<T>&, int>(
-                 &Context<T>::get_mutable_discrete_state),
-             py_reference_internal,
-             doc.Context.get_mutable_discrete_state.doc_1args)
+            overload_cast_explicit<BasicVector<T>&, int>(
+                &Context<T>::get_mutable_discrete_state),
+            py_reference_internal,
+            doc.Context.get_mutable_discrete_state.doc_1args)
         // - Abstract.
         .def("get_num_abstract_states", &Context<T>::get_num_abstract_states,
-             doc.Context.get_num_abstract_states.doc)
+            doc.Context.get_num_abstract_states.doc)
         .def("get_abstract_state",
-             static_cast<const AbstractValues& (Context<T>::*)() const>(
-                 &Context<T>::get_abstract_state),
-             py_reference_internal, doc.Context.get_abstract_state.doc)
+            static_cast<const AbstractValues& (Context<T>::*)() const>(
+                &Context<T>::get_abstract_state),
+            py_reference_internal, doc.Context.get_abstract_state.doc)
         .def("get_abstract_state",
-             [](const Context<T>* self, int index) -> auto& {
-               return self->get_abstract_state().get_value(index);
-             },
-             py_reference_internal, doc.Context.get_abstract_state.doc)
+            [](const Context<T>* self, int index) -> auto& {
+              return self->get_abstract_state().get_value(index);
+            },
+            py_reference_internal, doc.Context.get_abstract_state.doc)
         .def("get_mutable_abstract_state",
-             [](Context<T>* self) -> AbstractValues& {
-               return self->get_mutable_abstract_state();
-             },
-             py_reference_internal, doc.Context.get_mutable_abstract_state.doc)
+            [](Context<T>* self) -> AbstractValues& {
+              return self->get_mutable_abstract_state();
+            },
+            py_reference_internal, doc.Context.get_mutable_abstract_state.doc)
         .def("get_mutable_abstract_state",
-             [](Context<T>* self, int index) -> AbstractValue& {
-               return self->get_mutable_abstract_state().get_mutable_value(
-                   index);
-             },
-             py_reference_internal,
-             doc.Context.get_mutable_abstract_state.doc_2);
+            [](Context<T>* self, int index) -> AbstractValue& {
+              return self->get_mutable_abstract_state().get_mutable_value(
+                  index);
+            },
+            py_reference_internal,
+            doc.Context.get_mutable_abstract_state.doc_2);
 
     DefineTemplateClassWithDefault<LeafContext<T>, Context<T>>(
         m, "LeafContext", GetPyParam<T>(), doc.LeafContext.doc);
 
     // Event mechanisms.
-    DefineTemplateClassWithDefault<Event<T>>(m, "Event", GetPyParam<T>(),
-                                             doc.Event.doc)
+    DefineTemplateClassWithDefault<Event<T>>(
+        m, "Event", GetPyParam<T>(), doc.Event.doc)
         .def("get_trigger_type", &Event<T>::get_trigger_type,
-             doc.Event.get_trigger_type.doc);
+            doc.Event.get_trigger_type.doc);
     DefineTemplateClassWithDefault<PublishEvent<T>, Event<T>>(
         m, "PublishEvent", GetPyParam<T>(), doc.PublishEvent.doc)
-        .def(py::init(WrapCallbacks(
-                 [](const TriggerType& trigger_type,
+        .def(
+            py::init(WrapCallbacks(
+                [](const TriggerType& trigger_type,
                     const typename PublishEvent<T>::PublishCallback& callback) {
-                   return std::make_unique<PublishEvent<T>>(trigger_type,
-                                                            callback);
-                 })),
-             py::arg("trigger_type"), py::arg("callback"),
-             doc.PublishEvent.ctor.doc_2args_trigger_type_callback);
+                  return std::make_unique<PublishEvent<T>>(
+                      trigger_type, callback);
+                })),
+            py::arg("trigger_type"), py::arg("callback"),
+            doc.PublishEvent.ctor.doc_2args_trigger_type_callback);
     DefineTemplateClassWithDefault<DiscreteUpdateEvent<T>, Event<T>>(
         m, "DiscreteUpdateEvent", GetPyParam<T>(), doc.DiscreteUpdateEvent.doc);
 
@@ -214,63 +215,63 @@ void DefineFrameworkPySemantics(py::module m) {
         m, "DiagramBuilder", GetPyParam<T>(), doc.DiagramBuilder.doc)
         .def(py::init<>(), doc.DiagramBuilder.ctor.doc_0args)
         .def("AddSystem",
-             [](DiagramBuilder<T>* self, unique_ptr<System<T>> arg1) {
-               return self->AddSystem(std::move(arg1));
-             },
-             // Keep alive, ownership: `System` keeps `self` alive.
-             py::keep_alive<2, 1>(), doc.DiagramBuilder.AddSystem.doc)
+            [](DiagramBuilder<T>* self, unique_ptr<System<T>> arg1) {
+              return self->AddSystem(std::move(arg1));
+            },
+            // Keep alive, ownership: `System` keeps `self` alive.
+            py::keep_alive<2, 1>(), doc.DiagramBuilder.AddSystem.doc)
         .def("Connect",
-             py::overload_cast<const OutputPort<T>&, const InputPort<T>&>(
-                 &DiagramBuilder<T>::Connect),
-             doc.DiagramBuilder.Connect.doc)
+            py::overload_cast<const OutputPort<T>&, const InputPort<T>&>(
+                &DiagramBuilder<T>::Connect),
+            doc.DiagramBuilder.Connect.doc)
         .def("ExportInput", &DiagramBuilder<T>::ExportInput, py::arg("input"),
-             py::arg("name") = kUseDefaultName, py_reference_internal,
-             doc.DiagramBuilder.ExportInput.doc)
+            py::arg("name") = kUseDefaultName, py_reference_internal,
+            doc.DiagramBuilder.ExportInput.doc)
         .def("ExportOutput", &DiagramBuilder<T>::ExportOutput,
-             py::arg("output"), py::arg("name") = kUseDefaultName,
-             py_reference_internal, doc.DiagramBuilder.ExportOutput.doc)
+            py::arg("output"), py::arg("name") = kUseDefaultName,
+            py_reference_internal, doc.DiagramBuilder.ExportOutput.doc)
         .def("Build", &DiagramBuilder<T>::Build,
-             // Keep alive, transitive: `return` keeps `self` alive.
-             py::keep_alive<1, 0>(), doc.DiagramBuilder.Build.doc)
+            // Keep alive, transitive: `return` keeps `self` alive.
+            py::keep_alive<1, 0>(), doc.DiagramBuilder.Build.doc)
         .def("BuildInto", &DiagramBuilder<T>::BuildInto,
-             // Keep alive, transitive: `Diagram` keeps `self` alive.
-             py::keep_alive<2, 1>(), doc.DiagramBuilder.BuildInto.doc);
+            // Keep alive, transitive: `Diagram` keeps `self` alive.
+            py::keep_alive<2, 1>(), doc.DiagramBuilder.BuildInto.doc);
 
     DefineTemplateClassWithDefault<OutputPort<T>>(
         m, "OutputPort", GetPyParam<T>(), doc.OutputPort.doc)
         .def("size", &OutputPort<T>::size, doc.OutputPortBase.size.doc)
         .def("get_index", &OutputPort<T>::get_index,
-             doc.OutputPortBase.get_index.doc)
+            doc.OutputPortBase.get_index.doc)
         .def("EvalAbstract", &OutputPort<T>::EvalAbstract,
-             doc.OutputPort.EvalAbstract.doc, py_reference_internal)
+            doc.OutputPort.EvalAbstract.doc, py_reference_internal)
         .def("Eval",
-             [](const OutputPort<T>* self, const Context<T>& context) {
-               // Use type-erased signature to get value.
-               // TODO(eric.cousineau): Figure out why `py_reference` is
-               // necessary below (#9398).
-               py::object value_ref =
-                   py::cast(&self->EvalAbstract(context), py_reference);
-               return value_ref.attr("get_value")();
-             },
-             doc.OutputPort.Eval.doc);
+            [](const OutputPort<T>* self, const Context<T>& context) {
+              // Use type-erased signature to get value.
+              // TODO(eric.cousineau): Figure out why `py_reference` is
+              // necessary below (#9398).
+              py::object value_ref =
+                  py::cast(&self->EvalAbstract(context), py_reference);
+              return value_ref.attr("get_value")();
+            },
+            doc.OutputPort.Eval.doc);
 
     auto system_output = DefineTemplateClassWithDefault<SystemOutput<T>>(
         m, "SystemOutput", GetPyParam<T>(), doc.SystemOutput.doc);
     system_output
         .def("get_num_ports", &SystemOutput<T>::get_num_ports,
-             doc.SystemOutput.get_num_ports.doc)
+            doc.SystemOutput.get_num_ports.doc)
         .def("get_data", &SystemOutput<T>::get_data, py_reference_internal,
-             doc.SystemOutput.get_data.doc)
+            doc.SystemOutput.get_data.doc)
         .def("get_vector_data", &SystemOutput<T>::get_vector_data,
-             py_reference_internal, doc.SystemOutput.get_vector_data.doc);
+            py_reference_internal, doc.SystemOutput.get_vector_data.doc);
 
     DefineTemplateClassWithDefault<InputPort<T>>(
         m, "InputPort", GetPyParam<T>(), doc.InputPort.doc)
         .def("size", &InputPort<T>::size, doc.InputPortBase.size.doc)
         .def("get_data_type", &InputPort<T>::get_data_type,
-             doc.InputPortBase.get_data_type.doc)
+            doc.InputPortBase.get_data_type.doc)
         .def("get_index", &InputPort<T>::get_index,
-             doc.InputPortBase.get_index.doc);
+            doc.InputPortBase.get_index.doc);
 
     // Parameters.
     auto parameters = DefineTemplateClassWithDefault<Parameters<T>>(
@@ -282,108 +283,108 @@ void DefineFrameworkPySemantics(py::module m) {
         // TODO(eric.cousineau): Ensure that we can respect keep alive behavior
         // with lists of pointers.
         .def(py::init<BasicVectorPtrList, AbstractValuePtrList>(),
-             py::arg("numeric"), py::arg("abstract"),
-             doc.Parameters.ctor.doc_2args_numeric_abstract)
+            py::arg("numeric"), py::arg("abstract"),
+            doc.Parameters.ctor.doc_2args_numeric_abstract)
         .def(py::init<BasicVectorPtrList>(), py::arg("numeric"),
-             doc.Parameters.ctor.doc_1args_numeric)
+            doc.Parameters.ctor.doc_1args_numeric)
         .def(py::init<AbstractValuePtrList>(), py::arg("abstract"),
-             doc.Parameters.ctor.doc_1args_abstract)
+            doc.Parameters.ctor.doc_1args_abstract)
         .def(py::init<unique_ptr<BasicVector<T>>>(), py::arg("vec"),
-             // Keep alive, ownership: `vec` keeps `self` alive.
-             py::keep_alive<2, 1>(), doc.Parameters.ctor.doc_1args_vec)
+            // Keep alive, ownership: `vec` keeps `self` alive.
+            py::keep_alive<2, 1>(), doc.Parameters.ctor.doc_1args_vec)
         .def(py::init<unique_ptr<AbstractValue>>(), py::arg("value"),
-             // Keep alive, ownership: `value` keeps `self` alive.
-             py::keep_alive<2, 1>(), doc.Parameters.ctor.doc_1args_value)
+            // Keep alive, ownership: `value` keeps `self` alive.
+            py::keep_alive<2, 1>(), doc.Parameters.ctor.doc_1args_value)
         .def("num_numeric_parameter_groups",
-             &Parameters<T>::num_numeric_parameter_groups,
-             doc.Parameters.num_numeric_parameter_groups.doc)
+            &Parameters<T>::num_numeric_parameter_groups,
+            doc.Parameters.num_numeric_parameter_groups.doc)
         .def("num_abstract_parameters", &Parameters<T>::num_abstract_parameters,
-             doc.Parameters.num_abstract_parameters.doc)
+            doc.Parameters.num_abstract_parameters.doc)
         .def("get_numeric_parameter", &Parameters<T>::get_numeric_parameter,
-             py_reference_internal, py::arg("index"),
-             doc.Parameters.get_numeric_parameter.doc)
+            py_reference_internal, py::arg("index"),
+            doc.Parameters.get_numeric_parameter.doc)
         .def("get_mutable_numeric_parameter",
-             &Parameters<T>::get_mutable_numeric_parameter,
-             py_reference_internal, py::arg("index"),
-             doc.Parameters.get_mutable_numeric_parameter.doc)
+            &Parameters<T>::get_mutable_numeric_parameter,
+            py_reference_internal, py::arg("index"),
+            doc.Parameters.get_mutable_numeric_parameter.doc)
         .def("get_numeric_parameters", &Parameters<T>::get_numeric_parameters,
-             py_reference_internal, doc.Parameters.get_numeric_parameters.doc)
+            py_reference_internal, doc.Parameters.get_numeric_parameters.doc)
         // TODO(eric.cousineau): Should this C++ code constrain the number of
         // parameters???
         .def("set_numeric_parameters", &Parameters<T>::set_numeric_parameters,
-             // WARNING: This will DELETE the existing parameters. See C++
-             // `AddValueInstantiation` for more information.
-             // Keep alive, ownership: `value` keeps `self` alive.
-             py::keep_alive<2, 1>(), py::arg("numeric_params"),
-             doc.Parameters.set_numeric_parameters.doc)
+            // WARNING: This will DELETE the existing parameters. See C++
+            // `AddValueInstantiation` for more information.
+            // Keep alive, ownership: `value` keeps `self` alive.
+            py::keep_alive<2, 1>(), py::arg("numeric_params"),
+            doc.Parameters.set_numeric_parameters.doc)
         .def("get_abstract_parameter",
-             [](const Parameters<T>* self, int index) -> auto& {
-               return self->get_abstract_parameter(index);
-             },
-             py_reference_internal, py::arg("index"),
-             doc.Parameters.get_abstract_parameter.doc_1args)
+            [](const Parameters<T>* self, int index) -> auto& {
+              return self->get_abstract_parameter(index);
+            },
+            py_reference_internal, py::arg("index"),
+            doc.Parameters.get_abstract_parameter.doc_1args)
         .def("get_mutable_abstract_parameter",
-             [](Parameters<T>* self, int index) -> AbstractValue& {
-               return self->get_mutable_abstract_parameter(index);
-             },
-             py_reference_internal, py::arg("index"),
-             doc.Parameters.get_mutable_abstract_parameter.doc_1args)
+            [](Parameters<T>* self, int index) -> AbstractValue& {
+              return self->get_mutable_abstract_parameter(index);
+            },
+            py_reference_internal, py::arg("index"),
+            doc.Parameters.get_mutable_abstract_parameter.doc_1args)
         .def("get_abstract_parameters", &Parameters<T>::get_abstract_parameters,
-             py_reference_internal, doc.Parameters.get_abstract_parameters.doc)
+            py_reference_internal, doc.Parameters.get_abstract_parameters.doc)
         .def("set_abstract_parameters", &Parameters<T>::set_abstract_parameters,
-             // WARNING: This will DELETE the existing parameters. See C++
-             // `AddValueInstantiation` for more information.
-             // Keep alive, ownership: `value` keeps `self` alive.
-             py::keep_alive<2, 1>(), py::arg("abstract_params"),
-             doc.Parameters.set_abstract_parameters.doc)
+            // WARNING: This will DELETE the existing parameters. See C++
+            // `AddValueInstantiation` for more information.
+            // Keep alive, ownership: `value` keeps `self` alive.
+            py::keep_alive<2, 1>(), py::arg("abstract_params"),
+            doc.Parameters.set_abstract_parameters.doc)
         .def("SetFrom", &Parameters<T>::SetFrom, doc.Parameters.SetFrom.doc);
 
     // State.
-    DefineTemplateClassWithDefault<State<T>>(m, "State", GetPyParam<T>(),
-                                             doc.State.doc)
+    DefineTemplateClassWithDefault<State<T>>(
+        m, "State", GetPyParam<T>(), doc.State.doc)
         .def(py::init<>(), doc.State.ctor.doc_0args)
         .def("get_continuous_state", &State<T>::get_continuous_state,
-             py_reference_internal, doc.State.get_continuous_state.doc)
+            py_reference_internal, doc.State.get_continuous_state.doc)
         .def("get_mutable_continuous_state",
-             &State<T>::get_mutable_continuous_state, py_reference_internal,
-             doc.State.get_mutable_continuous_state.doc)
+            &State<T>::get_mutable_continuous_state, py_reference_internal,
+            doc.State.get_mutable_continuous_state.doc)
         .def("get_discrete_state",
-             overload_cast_explicit<const DiscreteValues<T>&>(
-                 &State<T>::get_discrete_state),
-             py_reference_internal, doc.State.get_discrete_state.doc_0args)
+            overload_cast_explicit<const DiscreteValues<T>&>(
+                &State<T>::get_discrete_state),
+            py_reference_internal, doc.State.get_discrete_state.doc_0args)
         .def("get_mutable_discrete_state",
-             overload_cast_explicit<DiscreteValues<T>&>(
-                 &State<T>::get_mutable_discrete_state),
-             py_reference_internal,
-             doc.State.get_mutable_discrete_state.doc_0args);
+            overload_cast_explicit<DiscreteValues<T>&>(
+                &State<T>::get_mutable_discrete_state),
+            py_reference_internal,
+            doc.State.get_mutable_discrete_state.doc_0args);
 
     // - Constituents.
     DefineTemplateClassWithDefault<ContinuousState<T>>(
         m, "ContinuousState", GetPyParam<T>(), doc.ContinuousState.doc)
         .def(py::init<>(), doc.ContinuousState.ctor.doc_0args)
         .def("get_vector", &ContinuousState<T>::get_vector,
-             py_reference_internal, doc.ContinuousState.get_vector.doc)
+            py_reference_internal, doc.ContinuousState.get_vector.doc)
         .def("get_mutable_vector", &ContinuousState<T>::get_mutable_vector,
-             py_reference_internal, doc.ContinuousState.get_mutable_vector.doc);
+            py_reference_internal, doc.ContinuousState.get_mutable_vector.doc);
 
     auto discrete_values = DefineTemplateClassWithDefault<DiscreteValues<T>>(
         m, "DiscreteValues", GetPyParam<T>(), doc.DiscreteValues.doc);
     DefClone(&discrete_values);
     discrete_values
         .def("num_groups", &DiscreteValues<T>::num_groups,
-             doc.DiscreteValues.num_groups.doc)
+            doc.DiscreteValues.num_groups.doc)
         .def("get_data", &DiscreteValues<T>::get_data, py_reference_internal,
-             doc.DiscreteValues.get_data.doc)
+            doc.DiscreteValues.get_data.doc)
         .def("get_vector",
-             overload_cast_explicit<const BasicVector<T>&, int>(
-                 &DiscreteValues<T>::get_vector),
-             py_reference_internal, py::arg("index") = 0,
-             doc.DiscreteValues.get_vector.doc_1args)
+            overload_cast_explicit<const BasicVector<T>&, int>(
+                &DiscreteValues<T>::get_vector),
+            py_reference_internal, py::arg("index") = 0,
+            doc.DiscreteValues.get_vector.doc_1args)
         .def("get_mutable_vector",
-             overload_cast_explicit<BasicVector<T>&, int>(
-                 &DiscreteValues<T>::get_mutable_vector),
-             py_reference_internal, py::arg("index") = 0,
-             doc.DiscreteValues.get_mutable_vector.doc_1args);
+            overload_cast_explicit<BasicVector<T>&, int>(
+                &DiscreteValues<T>::get_mutable_vector),
+            py_reference_internal, py::arg("index") = 0,
+            doc.DiscreteValues.get_mutable_vector.doc_1args);
   };
   type_visit(bind_common_scalar_types, pysystems::CommonScalarPack{});
 }

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -103,8 +103,7 @@ struct Impl {
     using Base::Base;
 
     // Trampoline virtual methods.
-    void DoPublish(
-        const Context<T>& context,
+    void DoPublish(const Context<T>& context,
         const vector<const PublishEvent<T>*>& events) const override {
       // Yuck! We have to dig in and use internals :(
       // We must ensure that pybind only sees pointers, since this method may
@@ -112,37 +111,35 @@ struct Impl {
       // @see https://github.com/pybind/pybind11/issues/1241
       // TODO(eric.cousineau): Figure out how to supply different behavior,
       // possibly using function wrapping.
-      PYBIND11_OVERLOAD_INT(void, LeafSystem<T>, "_DoPublish", &context,
-                            events);
+      PYBIND11_OVERLOAD_INT(
+          void, LeafSystem<T>, "_DoPublish", &context, events);
       // If the macro did not return, use default functionality.
       Base::DoPublish(context, events);
     }
 
-    optional<bool> DoHasDirectFeedthrough(int input_port,
-                                          int output_port) const override {
+    optional<bool> DoHasDirectFeedthrough(
+        int input_port, int output_port) const override {
       PYBIND11_OVERLOAD_INT(optional<bool>, LeafSystem<T>,
-                            "_DoHasDirectFeedthrough", input_port, output_port);
+          "_DoHasDirectFeedthrough", input_port, output_port);
       // If the macro did not return, use default functionality.
       return Base::DoHasDirectFeedthrough(input_port, output_port);
     }
 
     void DoCalcTimeDerivatives(const Context<T>& context,
-                               ContinuousState<T>* derivatives) const override {
+        ContinuousState<T>* derivatives) const override {
       // See `DoPublish` for explanation.
-      PYBIND11_OVERLOAD_INT(void, LeafSystem<T>, "_DoCalcTimeDerivatives",
-                            &context, derivatives);
+      PYBIND11_OVERLOAD_INT(
+          void, LeafSystem<T>, "_DoCalcTimeDerivatives", &context, derivatives);
       // If the macro did not return, use default functionality.
       Base::DoCalcTimeDerivatives(context, derivatives);
     }
 
-    void DoCalcDiscreteVariableUpdates(
-        const Context<T>& context,
+    void DoCalcDiscreteVariableUpdates(const Context<T>& context,
         const std::vector<const DiscreteUpdateEvent<T>*>& events,
         DiscreteValues<T>* discrete_state) const override {
       // See `DoPublish` for explanation.
       PYBIND11_OVERLOAD_INT(void, LeafSystem<T>,
-                            "_DoCalcDiscreteVariableUpdates", &context, events,
-                            discrete_state);
+          "_DoCalcDiscreteVariableUpdates", &context, events, discrete_state);
       // If the macro did not return, use default functionality.
       Base::DoCalcDiscreteVariableUpdates(context, events, discrete_state);
     }
@@ -171,28 +168,26 @@ struct Impl {
     using Base::Base;
 
     // Trampoline virtual methods.
-    void DoPublish(
-        const Context<T>& context,
+    void DoPublish(const Context<T>& context,
         const vector<const PublishEvent<T>*>& events) const override {
       // Copied from above, since we cannot use `PyLeafSystemBase` due to final
       // overrides of some methods.
       // TODO(eric.cousineau): Make this more granular?
-      PYBIND11_OVERLOAD_INT(void, VectorSystem<T>, "_DoPublish", &context,
-                            events);
+      PYBIND11_OVERLOAD_INT(
+          void, VectorSystem<T>, "_DoPublish", &context, events);
       // If the macro did not return, use default functionality.
       Base::DoPublish(context, events);
     }
 
-    optional<bool> DoHasDirectFeedthrough(int input_port,
-                                          int output_port) const override {
+    optional<bool> DoHasDirectFeedthrough(
+        int input_port, int output_port) const override {
       PYBIND11_OVERLOAD_INT(optional<bool>, VectorSystem<T>,
-                            "_DoHasDirectFeedthrough", input_port, output_port);
+          "_DoHasDirectFeedthrough", input_port, output_port);
       // If the macro did not return, use default functionality.
       return Base::DoHasDirectFeedthrough(input_port, output_port);
     }
 
-    void DoCalcVectorOutput(
-        const Context<T>& context,
+    void DoCalcVectorOutput(const Context<T>& context,
         const Eigen::VectorBlock<const VectorX<T>>& input,
         const Eigen::VectorBlock<const VectorX<T>>& state,
         Eigen::VectorBlock<VectorX<T>>* output) const override {
@@ -201,8 +196,7 @@ struct Impl {
       // https://github.com/pybind/pybind11/pull/1152#issuecomment-340091423
       // TODO(eric.cousineau): This will be resolved once dtype=custom is
       // resolved.
-      PYBIND11_OVERLOAD_INT(
-          void, VectorSystem<T>, "_DoCalcVectorOutput",
+      PYBIND11_OVERLOAD_INT(void, VectorSystem<T>, "_DoCalcVectorOutput",
           // N.B. Passing `Eigen::Map<>` derived classes by reference rather
           // than pointer to ensure conceptual clarity. pybind11 `type_caster`
           // struggles with types of `Map<Derived>*`, but not `Map<Derived>&`.
@@ -211,33 +205,31 @@ struct Impl {
       Base::DoCalcVectorOutput(context, input, state, output);
     }
 
-    void DoCalcVectorTimeDerivatives(
-        const Context<T>& context,
+    void DoCalcVectorTimeDerivatives(const Context<T>& context,
         const Eigen::VectorBlock<const VectorX<T>>& input,
         const Eigen::VectorBlock<const VectorX<T>>& state,
         Eigen::VectorBlock<VectorX<T>>* derivatives) const override {
       // WARNING: Mutating `derivatives` will not work when T is AutoDiffXd,
       // Expression, etc. See above.
       PYBIND11_OVERLOAD_INT(void, VectorSystem<T>,
-                            "_DoCalcVectorTimeDerivatives", &context, input,
-                            state, ToEigenRef(derivatives));
+          "_DoCalcVectorTimeDerivatives", &context, input, state,
+          ToEigenRef(derivatives));
       // If the macro did not return, use default functionality.
       Base::DoCalcVectorOutput(context, input, state, derivatives);
     }
 
-    void DoCalcVectorDiscreteVariableUpdates(
-        const Context<T>& context,
+    void DoCalcVectorDiscreteVariableUpdates(const Context<T>& context,
         const Eigen::VectorBlock<const VectorX<T>>& input,
         const Eigen::VectorBlock<const VectorX<T>>& state,
         Eigen::VectorBlock<VectorX<T>>* next_state) const override {
       // WARNING: Mutating `next_state` will not work when T is AutoDiffXd,
       // Expression, etc. See above.
       PYBIND11_OVERLOAD_INT(void, VectorSystem<T>,
-                            "_DoCalcVectorDiscreteVariableUpdates", &context,
-                            input, state, ToEigenRef(next_state));
+          "_DoCalcVectorDiscreteVariableUpdates", &context, input, state,
+          ToEigenRef(next_state));
       // If the macro did not return, use default functionality.
-      Base::DoCalcVectorDiscreteVariableUpdates(context, input, state,
-                                                next_state);
+      Base::DoCalcVectorDiscreteVariableUpdates(
+          context, input, state, next_state);
     }
   };
 
@@ -256,96 +248,95 @@ struct Impl {
         .def("set_name", &System<T>::set_name, doc.SystemBase.set_name.doc)
         // Topology.
         .def("get_num_input_ports", &System<T>::get_num_input_ports,
-             doc.SystemBase.get_num_input_ports.doc)
+            doc.SystemBase.get_num_input_ports.doc)
         .def("get_input_port", &System<T>::get_input_port,
-             py_reference_internal, py::arg("port_index"),
-             doc.System.get_input_port.doc)
+            py_reference_internal, py::arg("port_index"),
+            doc.System.get_input_port.doc)
         .def("GetInputPort", &System<T>::GetInputPort, py_reference_internal,
-             py::arg("port_name"), doc.System.GetInputPort.doc)
+            py::arg("port_name"), doc.System.GetInputPort.doc)
         .def("get_num_output_ports", &System<T>::get_num_output_ports,
-             doc.SystemBase.get_num_output_ports.doc)
+            doc.SystemBase.get_num_output_ports.doc)
         .def("get_output_port", &System<T>::get_output_port,
-             py_reference_internal, py::arg("port_index"),
-             doc.System.get_output_port.doc)
+            py_reference_internal, py::arg("port_index"),
+            doc.System.get_output_port.doc)
         .def("GetOutputPort", &System<T>::GetOutputPort, py_reference_internal,
-             py::arg("port_name"), doc.System.GetOutputPort.doc)
+            py::arg("port_name"), doc.System.GetOutputPort.doc)
         .def("_DeclareInputPort",
-             overload_cast_explicit<const InputPort<T>&, std::string,
-                                    PortDataType, int,
-                                    optional<RandomDistribution>>(
-                 &PySystem::DeclareInputPort),
-             py_reference_internal, py::arg("name"), py::arg("type"),
-             py::arg("size"), py::arg("random_type") = nullopt,
-             doc.System.DeclareInputPort.doc_4args)
+            overload_cast_explicit<const InputPort<T>&, std::string,
+                PortDataType, int, optional<RandomDistribution>>(
+                &PySystem::DeclareInputPort),
+            py_reference_internal, py::arg("name"), py::arg("type"),
+            py::arg("size"), py::arg("random_type") = nullopt,
+            doc.System.DeclareInputPort.doc_4args)
         .def("_DeclareInputPort",
-             overload_cast_explicit<  // BR
-                 const InputPort<T>&, PortDataType, int,
-                 optional<RandomDistribution>>(&PySystem::DeclareInputPort),
-             py_reference_internal, py::arg("type"), py::arg("size"),
-             py::arg("random_type") = nullopt)
+            overload_cast_explicit<  // BR
+                const InputPort<T>&, PortDataType, int,
+                optional<RandomDistribution>>(&PySystem::DeclareInputPort),
+            py_reference_internal, py::arg("type"), py::arg("size"),
+            py::arg("random_type") = nullopt)
         // - Feedthrough.
         .def("HasAnyDirectFeedthrough", &System<T>::HasAnyDirectFeedthrough,
-             doc.System.HasAnyDirectFeedthrough.doc)
+            doc.System.HasAnyDirectFeedthrough.doc)
         .def("HasDirectFeedthrough",
-             overload_cast_explicit<bool, int>(  // BR
-                 &System<T>::HasDirectFeedthrough),
-             py::arg("output_port"), doc.System.HasDirectFeedthrough.doc_1args)
+            overload_cast_explicit<bool, int>(  // BR
+                &System<T>::HasDirectFeedthrough),
+            py::arg("output_port"), doc.System.HasDirectFeedthrough.doc_1args)
         .def("HasDirectFeedthrough",
-             overload_cast_explicit<bool, int, int>(
-                 &System<T>::HasDirectFeedthrough),
-             py::arg("input_port"), py::arg("output_port"),
-             doc.System.HasDirectFeedthrough.doc_2args)
+            overload_cast_explicit<bool, int, int>(
+                &System<T>::HasDirectFeedthrough),
+            py::arg("input_port"), py::arg("output_port"),
+            doc.System.HasDirectFeedthrough.doc_2args)
         // Context.
         .def("CreateDefaultContext", &System<T>::CreateDefaultContext,
-             doc.System.CreateDefaultContext.doc)
+            doc.System.CreateDefaultContext.doc)
         .def("AllocateOutput",
-             overload_cast_explicit<unique_ptr<SystemOutput<T>>>(
-                 &System<T>::AllocateOutput),
-             doc.System.AllocateOutput.doc)
+            overload_cast_explicit<unique_ptr<SystemOutput<T>>>(
+                &System<T>::AllocateOutput),
+            doc.System.AllocateOutput.doc)
         .def("EvalVectorInput",
-             [](const System<T>* self, const Context<T>& arg1, int arg2) {
-               return self->EvalVectorInput(arg1, arg2);
-             },
-             py_reference,
-             // Keep alive, ownership: `return` keeps `Context` alive.
-             py::keep_alive<0, 2>(), doc.System.EvalVectorInput.doc)
+            [](const System<T>* self, const Context<T>& arg1, int arg2) {
+              return self->EvalVectorInput(arg1, arg2);
+            },
+            py_reference,
+            // Keep alive, ownership: `return` keeps `Context` alive.
+            py::keep_alive<0, 2>(), doc.System.EvalVectorInput.doc)
         .def("EvalAbstractInput",
-             [](const System<T>* self, const Context<T>& arg1, int arg2) {
-               return self->EvalAbstractInput(arg1, arg2);
-             },
-             py_reference,
-             // Keep alive, ownership: `return` keeps `Context` alive.
-             py::keep_alive<0, 2>(), doc.SystemBase.EvalAbstractInput.doc)
+            [](const System<T>* self, const Context<T>& arg1, int arg2) {
+              return self->EvalAbstractInput(arg1, arg2);
+            },
+            py_reference,
+            // Keep alive, ownership: `return` keeps `Context` alive.
+            py::keep_alive<0, 2>(), doc.SystemBase.EvalAbstractInput.doc)
         // Computation.
         .def("CalcOutput", &System<T>::CalcOutput, doc.System.CalcOutput.doc)
         .def("CalcTimeDerivatives", &System<T>::CalcTimeDerivatives,
-             doc.System.CalcTimeDerivatives.doc)
+            doc.System.CalcTimeDerivatives.doc)
         // Sugar.
         .def("GetGraphvizString",
-             [str_py](const System<T>* self, int max_depth) {
-               // @note This is a workaround; for some reason,
-               // casting this using `py::str` does not work, but directly
-               // calling the Python function (`str_py`) does.
-               return str_py(self->GetGraphvizString(max_depth));
-             },
-             doc.System.GetGraphvizString.doc,
-             py::arg("max_depth") = std::numeric_limits<int>::max())
+            [str_py](const System<T>* self, int max_depth) {
+              // @note This is a workaround; for some reason,
+              // casting this using `py::str` does not work, but directly
+              // calling the Python function (`str_py`) does.
+              return str_py(self->GetGraphvizString(max_depth));
+            },
+            doc.System.GetGraphvizString.doc,
+            py::arg("max_depth") = std::numeric_limits<int>::max())
         // Events.
         .def("Publish",
-             overload_cast_explicit<void, const Context<T>&>(
-                 &System<T>::Publish),
-             doc.System.Publish.doc_1args)
+            overload_cast_explicit<void, const Context<T>&>(
+                &System<T>::Publish),
+            doc.System.Publish.doc_1args)
         // Scalar types.
         .def("ToAutoDiffXd",
-             [](const System<T>& self) { return self.ToAutoDiffXd(); },
-             doc.System.ToAutoDiffXd.doc)
+            [](const System<T>& self) { return self.ToAutoDiffXd(); },
+            doc.System.ToAutoDiffXd.doc)
         .def("ToAutoDiffXdMaybe", &System<T>::ToAutoDiffXdMaybe,
-             doc.System.ToAutoDiffXdMaybe.doc)
+            doc.System.ToAutoDiffXdMaybe.doc)
         .def("ToSymbolic",
-             [](const System<T>& self) { return self.ToSymbolic(); },
-             doc.System.ToSymbolic.doc)
+            [](const System<T>& self) { return self.ToSymbolic(); },
+            doc.System.ToSymbolic.doc)
         .def("ToSymbolicMaybe", &System<T>::ToSymbolicMaybe,
-             doc.System.ToSymbolicMaybe.doc);
+            doc.System.ToSymbolicMaybe.doc);
 
     using AllocCallback = typename LeafOutputPort<T>::AllocCallback;
     using CalcCallback = typename LeafOutputPort<T>::CalcCallback;
@@ -361,164 +352,161 @@ struct Impl {
         // being used, and pass that as the converter. However, that requires an
         // old-style `py::init`, which is deprecated in Python...
         .def(py::init<SystemScalarConverter>(), py::arg("converter"),
-             doc.LeafSystem.ctor.doc_1args)
+            doc.LeafSystem.ctor.doc_1args)
         .def("_DeclareAbstractInputPort",
-             [](PyLeafSystem* self, const std::string& name,
+            [](PyLeafSystem* self, const std::string& name,
                 const AbstractValue& model_value) -> const InputPort<T>& {
-               return self->DeclareAbstractInputPort(name, model_value);
-             },
-             py_reference_internal, py::arg("name"), py::arg("model_value"),
-             doc.LeafSystem.DeclareAbstractInputPort.doc_2args)
+              return self->DeclareAbstractInputPort(name, model_value);
+            },
+            py_reference_internal, py::arg("name"), py::arg("model_value"),
+            doc.LeafSystem.DeclareAbstractInputPort.doc_2args)
         .def("_DeclareAbstractInputPort",
-             [](PyLeafSystem* self,
+            [](PyLeafSystem* self,
                 const std::string& name) -> const InputPort<T>& {
-               WarnDeprecated(
-                   "`DeclareAbstractInputPort(self, name)` is deprecated. "
-                   "Please use `(self, name, model_value)` instead.");
-               Value<py::object> model_value;
-               return self->DeclareAbstractInputPort(name, model_value);
-             },
-             py_reference_internal, py::arg("name"),
-             doc.System.DeclareAbstractInputPort.doc_1args)
+              WarnDeprecated(
+                  "`DeclareAbstractInputPort(self, name)` is deprecated. "
+                  "Please use `(self, name, model_value)` instead.");
+              Value<py::object> model_value;
+              return self->DeclareAbstractInputPort(name, model_value);
+            },
+            py_reference_internal, py::arg("name"),
+            doc.System.DeclareAbstractInputPort.doc_1args)
         .def("_DeclareAbstractOutputPort",
-             WrapCallbacks([](PyLeafSystem * self, const std::string& name,
+            WrapCallbacks([](PyLeafSystem * self, const std::string& name,
                               AllocCallback arg1, CalcCallback arg2) -> auto& {
-               return self->DeclareAbstractOutputPort(name, arg1, arg2);
-             }),
-             py_reference_internal, py::arg("name"), py::arg("alloc"),
-             py::arg("calc"))
+              return self->DeclareAbstractOutputPort(name, arg1, arg2);
+            }),
+            py_reference_internal, py::arg("name"), py::arg("alloc"),
+            py::arg("calc"))
         .def("_DeclareAbstractOutputPort",
-             WrapCallbacks([](PyLeafSystem * self, AllocCallback arg1,
+            WrapCallbacks([](PyLeafSystem * self, AllocCallback arg1,
                               CalcCallback arg2) -> auto& {
-               return self->DeclareAbstractOutputPort(arg1, arg2);
-             }),
-             py_reference_internal, py::arg("alloc"), py::arg("calc"),
-             doc.LeafSystem.DeclareAbstractOutputPort.doc)
+              return self->DeclareAbstractOutputPort(arg1, arg2);
+            }),
+            py_reference_internal, py::arg("alloc"), py::arg("calc"),
+            doc.LeafSystem.DeclareAbstractOutputPort.doc)
         .def("_DeclareVectorInputPort",
-             [](PyLeafSystem * self, std::string name,
+            [](PyLeafSystem * self, std::string name,
                 const BasicVector<T>& model_vector,
                 optional<RandomDistribution> random_type) -> auto& {
-               return self->DeclareVectorInputPort(name, model_vector,
-                                                   random_type);
-             },
-             py_reference_internal, py::arg("name"), py::arg("model_vector"),
-             py::arg("random_type") = nullopt,
-             doc.LeafSystem.DeclareVectorInputPort.doc_3args)
+              return self->DeclareVectorInputPort(
+                  name, model_vector, random_type);
+            },
+            py_reference_internal, py::arg("name"), py::arg("model_vector"),
+            py::arg("random_type") = nullopt,
+            doc.LeafSystem.DeclareVectorInputPort.doc_3args)
         .def("_DeclareVectorOutputPort",
-             WrapCallbacks([](PyLeafSystem * self, const std::string& name,
+            WrapCallbacks([](PyLeafSystem * self, const std::string& name,
                               const BasicVector<T>& arg1,
                               CalcVectorCallback arg2) -> auto& {
-               return self->DeclareVectorOutputPort(name, arg1, arg2);
-             }),
-             py_reference_internal, py::arg("name"), py::arg("model_value"),
-             py::arg("calc"))
+              return self->DeclareVectorOutputPort(name, arg1, arg2);
+            }),
+            py_reference_internal, py::arg("name"), py::arg("model_value"),
+            py::arg("calc"))
         .def("_DeclareVectorOutputPort",
-             WrapCallbacks([](PyLeafSystem * self, const BasicVector<T>& arg1,
+            WrapCallbacks([](PyLeafSystem * self, const BasicVector<T>& arg1,
                               CalcVectorCallback arg2) -> auto& {
-               return self->DeclareVectorOutputPort(arg1, arg2);
-             }),
-             py_reference_internal, doc.LeafSystem.DeclareVectorOutputPort.doc)
+              return self->DeclareVectorOutputPort(arg1, arg2);
+            }),
+            py_reference_internal, doc.LeafSystem.DeclareVectorOutputPort.doc)
         .def("_DeclarePeriodicPublish", &PyLeafSystem::DeclarePeriodicPublish,
-             py::arg("period_sec"), py::arg("offset_sec") = 0.,
-             doc.LeafSystem.DeclarePeriodicPublish.doc)
+            py::arg("period_sec"), py::arg("offset_sec") = 0.,
+            doc.LeafSystem.DeclarePeriodicPublish.doc)
         .def("_DeclareInitializationEvent",
-             [](PyLeafSystem* self, const Event<T>& event) {
-               self->DeclareInitializationEvent(event);
-             },
-             py::arg("event"), doc.LeafSystem.DeclareInitializationEvent.doc)
+            [](PyLeafSystem* self, const Event<T>& event) {
+              self->DeclareInitializationEvent(event);
+            },
+            py::arg("event"), doc.LeafSystem.DeclareInitializationEvent.doc)
         // Binding the *second* signature; first has no Event argument.
         .def("_DeclarePeriodicEvent",
-             [](PyLeafSystem* self, double period_sec, double offset_sec,
+            [](PyLeafSystem* self, double period_sec, double offset_sec,
                 const Event<T>& event) {
-               self->DeclarePeriodicEvent(period_sec, offset_sec, event);
-             },
-             py::arg("period_sec"), py::arg("offset_sec"), py::arg("event"),
-             doc.LeafSystem.DeclarePeriodicEvent.doc_2)
+              self->DeclarePeriodicEvent(period_sec, offset_sec, event);
+            },
+            py::arg("period_sec"), py::arg("offset_sec"), py::arg("event"),
+            doc.LeafSystem.DeclarePeriodicEvent.doc_2)
         .def("_DeclarePerStepEvent",
-             [](PyLeafSystem* self, const Event<T>& event) {
-               self->DeclarePerStepEvent(event);
-             },
-             py::arg("event"), doc.LeafSystem.DeclarePerStepEvent.doc)
+            [](PyLeafSystem* self, const Event<T>& event) {
+              self->DeclarePerStepEvent(event);
+            },
+            py::arg("event"), doc.LeafSystem.DeclarePerStepEvent.doc)
         .def("_DoPublish", &LeafSystemPublic::DoPublish,
-             doc.LeafSystem.DoPublish.doc)
+            doc.LeafSystem.DoPublish.doc)
         // System attributes.
         .def("_DoHasDirectFeedthrough",
-             &LeafSystemPublic::DoHasDirectFeedthrough,
-             doc.LeafSystem.DoHasDirectFeedthrough.doc)
+            &LeafSystemPublic::DoHasDirectFeedthrough,
+            doc.LeafSystem.DoHasDirectFeedthrough.doc)
         // Continuous state.
         .def("_DeclareContinuousState",
-             py::overload_cast<int>(&LeafSystemPublic::DeclareContinuousState),
-             py::arg("num_state_variables"),
-             doc.LeafSystem.DeclareContinuousState.doc)
+            py::overload_cast<int>(&LeafSystemPublic::DeclareContinuousState),
+            py::arg("num_state_variables"),
+            doc.LeafSystem.DeclareContinuousState.doc)
         .def("_DeclareContinuousState",
-             py::overload_cast<int, int, int>(
-                 &LeafSystemPublic::DeclareContinuousState),
-             py::arg("num_q"), py::arg("num_v"), py::arg("num_z"),
-             doc.LeafSystem.DeclareContinuousState.doc_2)
+            py::overload_cast<int, int, int>(
+                &LeafSystemPublic::DeclareContinuousState),
+            py::arg("num_q"), py::arg("num_v"), py::arg("num_z"),
+            doc.LeafSystem.DeclareContinuousState.doc_2)
         .def("_DeclareContinuousState",
-             py::overload_cast<const BasicVector<T>&>(
-                 &LeafSystemPublic::DeclareContinuousState),
-             py::arg("model_vector"),
-             doc.LeafSystem.DeclareContinuousState.doc_3)
+            py::overload_cast<const BasicVector<T>&>(
+                &LeafSystemPublic::DeclareContinuousState),
+            py::arg("model_vector"),
+            doc.LeafSystem.DeclareContinuousState.doc_3)
         // TODO(eric.cousineau): Ideally the downstream class of
         // `BasicVector<T>` should expose `num_q`, `num_v`, and `num_z`?
         .def("_DeclareContinuousState",
-             py::overload_cast<const BasicVector<T>&, int, int, int>(
-                 &LeafSystemPublic::DeclareContinuousState),
-             py::arg("model_vector"), py::arg("num_q"), py::arg("num_v"),
-             py::arg("num_z"), doc.LeafSystem.DeclareContinuousState.doc_4)
+            py::overload_cast<const BasicVector<T>&, int, int, int>(
+                &LeafSystemPublic::DeclareContinuousState),
+            py::arg("model_vector"), py::arg("num_q"), py::arg("num_v"),
+            py::arg("num_z"), doc.LeafSystem.DeclareContinuousState.doc_4)
         // Discrete state.
         // TODO(eric.cousineau): Should there be a `BasicVector<>` overload?
         .def("_DeclareDiscreteState", &LeafSystemPublic::DeclareDiscreteState,
-             doc.LeafSystem.DeclareDiscreteState.doc)
+            doc.LeafSystem.DeclareDiscreteState.doc)
         .def("_DeclarePeriodicDiscreteUpdate",
-             &LeafSystemPublic::DeclarePeriodicDiscreteUpdate,
-             py::arg("period_sec"), py::arg("offset_sec") = 0.,
-             doc.LeafSystem.DeclarePeriodicDiscreteUpdate.doc)
+            &LeafSystemPublic::DeclarePeriodicDiscreteUpdate,
+            py::arg("period_sec"), py::arg("offset_sec") = 0.,
+            doc.LeafSystem.DeclarePeriodicDiscreteUpdate.doc)
         .def("_DoCalcTimeDerivatives", &LeafSystemPublic::DoCalcTimeDerivatives)
         .def("_DoCalcDiscreteVariableUpdates",
-             &LeafSystemPublic::DoCalcDiscreteVariableUpdates,
-             doc.LeafSystem.DoCalcDiscreteVariableUpdates.doc)
+            &LeafSystemPublic::DoCalcDiscreteVariableUpdates,
+            doc.LeafSystem.DoCalcDiscreteVariableUpdates.doc)
         // Abstract state.
         .def("_DeclareAbstractState", &LeafSystemPublic::DeclareAbstractState,
-             // Keep alive, ownership: `AbstractValue` keeps `self` alive.
-             py::keep_alive<2, 1>(), doc.LeafSystem.DeclareAbstractState.doc);
+            // Keep alive, ownership: `AbstractValue` keeps `self` alive.
+            py::keep_alive<2, 1>(), doc.LeafSystem.DeclareAbstractState.doc);
 
     DefineTemplateClassWithDefault<Diagram<T>, System<T>>(
         m, "Diagram", GetPyParam<T>(), doc.Diagram.doc)
         .def("GetMutableSubsystemState",
-             overload_cast_explicit<State<T>&, const System<T>&, Context<T>*>(
-                 &Diagram<T>::GetMutableSubsystemState),
-             py_reference,
-             // Keep alive, ownership: `return` keeps `Context` alive.
-             py::keep_alive<0, 3>(),
-             doc.Diagram.GetMutableSubsystemState.doc_2args_subsystem_context)
+            overload_cast_explicit<State<T>&, const System<T>&, Context<T>*>(
+                &Diagram<T>::GetMutableSubsystemState),
+            py_reference,
+            // Keep alive, ownership: `return` keeps `Context` alive.
+            py::keep_alive<0, 3>(),
+            doc.Diagram.GetMutableSubsystemState.doc_2args_subsystem_context)
         .def("GetSubsystemContext",
-             overload_cast_explicit<const Context<T>&, const System<T>&,
-                                    const Context<T>&>(
-                 &Diagram<T>::GetSubsystemContext),
-             py_reference,
-             // Keep alive, ownership: `return` keeps `Context` alive.
-             py::keep_alive<0, 3>(), doc.Diagram.GetMutableSubsystemContext.doc)
+            overload_cast_explicit<const Context<T>&, const System<T>&,
+                const Context<T>&>(&Diagram<T>::GetSubsystemContext),
+            py_reference,
+            // Keep alive, ownership: `return` keeps `Context` alive.
+            py::keep_alive<0, 3>(), doc.Diagram.GetMutableSubsystemContext.doc)
         .def("GetMutableSubsystemContext",
-             overload_cast_explicit<Context<T>&, const System<T>&, Context<T>*>(
-                 &Diagram<T>::GetMutableSubsystemContext),
-             py_reference,
-             // Keep alive, ownership: `return` keeps `Context` alive.
-             py::keep_alive<0, 3>(),
-             doc.Diagram.GetMutableSubsystemContext.doc);
+            overload_cast_explicit<Context<T>&, const System<T>&, Context<T>*>(
+                &Diagram<T>::GetMutableSubsystemContext),
+            py_reference,
+            // Keep alive, ownership: `return` keeps `Context` alive.
+            py::keep_alive<0, 3>(), doc.Diagram.GetMutableSubsystemContext.doc);
 
     // N.B. This will effectively allow derived classes of `VectorSystem` to
     // override `LeafSystem` methods, disrespecting `final`-ity.
     // This could be changed (see https://stackoverflow.com/a/2425785), but meh,
     // we're already abusing Python and C++ enough.
     DefineTemplateClassWithDefault<VectorSystem<T>, PyVectorSystem,
-                                   LeafSystem<T>>(
-        m, "VectorSystem", GetPyParam<T>(), doc.VectorSystem.doc)
+        LeafSystem<T>>(m, "VectorSystem", GetPyParam<T>(), doc.VectorSystem.doc)
         .def(py::init([](int inputs, int outputs) {
-               return new PyVectorSystem(inputs, outputs);
-             }),
-             doc.VectorSystem.ctor.doc_2args);
+          return new PyVectorSystem(inputs, outputs);
+        }),
+            doc.VectorSystem.ctor.doc_2args);
     // TODO(eric.cousineau): Bind virtual methods once we provide a function
     // wrapper to convert `Map<Derived>*` arguments.
     // N.B. This could be mitigated by using `EigenPtr` in public interfaces in
@@ -539,20 +527,18 @@ void DefineFrameworkPySystems(py::module m) {
   converter  // BR
       .def(py::init())
       .def("__copy__",
-           [](const SystemScalarConverter& in) -> SystemScalarConverter {
-             return in;
-           });
+          [](const SystemScalarConverter& in) -> SystemScalarConverter {
+            return in;
+          });
   // Bind templated instantiations.
   auto converter_methods = [converter](auto pack) {
     using Pack = decltype(pack);
     using T = typename Pack::template type_at<0>;
     using U = typename Pack::template type_at<1>;
     AddTemplateMethod(converter, "Add",
-                      WrapCallbacks(&SystemScalarConverter::Add<T, U>),
-                      GetPyParam<T, U>());
+        WrapCallbacks(&SystemScalarConverter::Add<T, U>), GetPyParam<T, U>());
     AddTemplateMethod(converter, "IsConvertible",
-                      &SystemScalarConverter::IsConvertible<T, U>,
-                      GetPyParam<T, U>());
+        &SystemScalarConverter::IsConvertible<T, U>, GetPyParam<T, U>());
   };
   // N.B. When changing the pairs of supported types below, ensure that these
   // reflect the stanzas for the advanced constructor of

--- a/bindings/pydrake/systems/framework_py_values.cc
+++ b/bindings/pydrake/systems/framework_py_values.cc
@@ -33,11 +33,11 @@ void DefineFrameworkPyValues(py::module m) {
     DefineTemplateClassWithDefault<VectorBase<T>>(
         m, "VectorBase", GetPyParam<T>(), doc.VectorBase.doc)
         .def("CopyToVector", &VectorBase<T>::CopyToVector,
-             doc.VectorBase.CopyToVector.doc)
+            doc.VectorBase.CopyToVector.doc)
         .def("SetAtIndex", &VectorBase<T>::SetAtIndex,
-             doc.VectorBase.SetAtIndex.doc)
+            doc.VectorBase.SetAtIndex.doc)
         .def("SetFromVector", &VectorBase<T>::SetFromVector,
-             doc.VectorBase.SetFromVector.doc)
+            doc.VectorBase.SetFromVector.doc)
         .def("size", &VectorBase<T>::size, doc.VectorBase.size.doc);
 
     // TODO(eric.cousineau): Make a helper function for the Eigen::Ref<>
@@ -51,30 +51,30 @@ void DefineFrameworkPyValues(py::module m) {
         // implicitly convert scalar-size `np.array` objects to `int` (since
         // this is normally permitted).
         .def(py::init<VectorX<T>>(), py::arg("data"),
-             doc.BasicVector.ctor.doc_1args_vec)
+            doc.BasicVector.ctor.doc_1args_vec)
         .def(py::init<int>(), py::arg("size"),
-             doc.BasicVector.ctor.doc_1args_size)
+            doc.BasicVector.ctor.doc_1args_size)
         .def("get_value",
-             [](const BasicVector<T>* self) -> Eigen::Ref<const VectorX<T>> {
-               return self->get_value();
-             },
-             py_reference_internal, doc.BasicVector.get_value.doc)
+            [](const BasicVector<T>* self) -> Eigen::Ref<const VectorX<T>> {
+              return self->get_value();
+            },
+            py_reference_internal, doc.BasicVector.get_value.doc)
         // TODO(eric.cousineau): Remove this once `get_value` is changed, or
         // reference semantics are changed for custom dtypes.
         .def("_get_value_copy",
-             [](const BasicVector<T>* self) -> VectorX<T> {
-               return self->get_value();
-             })
+            [](const BasicVector<T>* self) -> VectorX<T> {
+              return self->get_value();
+            })
         .def("get_mutable_value",
-             [](BasicVector<T>* self) -> Eigen::Ref<VectorX<T>> {
-               return self->get_mutable_value();
-             },
-             py_reference_internal, doc.BasicVector.get_mutable_value.doc)
+            [](BasicVector<T>* self) -> Eigen::Ref<VectorX<T>> {
+              return self->get_mutable_value();
+            },
+            py_reference_internal, doc.BasicVector.get_mutable_value.doc)
         .def("GetAtIndex",
-             [](BasicVector<T>* self, int index) -> T& {
-               return self->GetAtIndex(index);
-             },
-             py_reference_internal, doc.BasicVector.GetAtIndex.doc);
+            [](BasicVector<T>* self, int index) -> T& {
+              return self->GetAtIndex(index);
+            },
+            py_reference_internal, doc.BasicVector.GetAtIndex.doc);
 
     DefineTemplateClassWithDefault<Supervector<T>, VectorBase<T>>(
         m, "Supervector", GetPyParam<T>(), doc.Supervector.doc);
@@ -103,13 +103,13 @@ void DefineFrameworkPyValues(py::module m) {
       // Only bind the exception variant, `SetFromOrThrow`, for use in Python.
       // Otherwise, a user could encounter undefind behavior via `SetFrom`.
       .def("SetFrom", &AbstractValue::SetFromOrThrow,
-           doc.AbstractValue.SetFrom.doc)
+          doc.AbstractValue.SetFrom.doc)
       .def("get_value", abstract_stub("get_value"),
-           doc.AbstractValue.GetValue.doc)
+          doc.AbstractValue.GetValue.doc)
       .def("get_mutable_value", abstract_stub("get_mutable_value"),
-           doc.AbstractValue.GetMutableValue.doc)
+          doc.AbstractValue.GetMutableValue.doc)
       .def("set_value", abstract_stub("set_value"),
-           doc.AbstractValue.SetValue.doc);
+          doc.AbstractValue.SetValue.doc);
 
   // Add `Value<std::string>` instantiation (visible in Python as `Value[str]`).
   AddValueInstantiation<string>(m);
@@ -143,8 +143,7 @@ void DefineFrameworkPyValues(py::module m) {
   py::object py_object_type = py::eval("object");
   // `Value` was defined by the first call to `AddValueInstantiation`.
   py::object py_value_template = m.attr("Value");
-  abstract_value.def_static(
-      "Make",
+  abstract_value.def_static("Make",
       [py_type_func, py_value_template, py_object_type](py::object value) {
         // Try to infer type from the object. If that does not work, just return
         // `Value[object]`.

--- a/bindings/pydrake/systems/lcm_py.cc
+++ b/bindings/pydrake/systems/lcm_py.cc
@@ -30,24 +30,24 @@ class PySerializerInterface : public py::wrapper<SerializerInterface> {
 
   std::unique_ptr<AbstractValue> CreateDefaultValue() const override {
     PYBIND11_OVERLOAD_PURE(std::unique_ptr<AbstractValue>, SerializerInterface,
-                           CreateDefaultValue);
+        CreateDefaultValue);
   }
 
   void Deserialize(const void* message_bytes, int message_length,
-                   AbstractValue* abstract_value) const override {
-    py::bytes buffer(reinterpret_cast<const char*>(message_bytes),
-                     message_length);
-    PYBIND11_OVERLOAD_PURE(void, SerializerInterface, Deserialize, buffer,
-                           abstract_value);
+      AbstractValue* abstract_value) const override {
+    py::bytes buffer(
+        reinterpret_cast<const char*>(message_bytes), message_length);
+    PYBIND11_OVERLOAD_PURE(
+        void, SerializerInterface, Deserialize, buffer, abstract_value);
   }
 
   void Serialize(const AbstractValue& abstract_value,
-                 std::vector<uint8_t>* message_bytes) const override {
+      std::vector<uint8_t>* message_bytes) const override {
     auto wrapped = [&]() -> py::bytes {
       // N.B. We must pass `abstract_value` as a pointer to prevent `pybind11`
       // from copying it.
-      PYBIND11_OVERLOAD_PURE(py::bytes, SerializerInterface, Serialize,
-                             &abstract_value);
+      PYBIND11_OVERLOAD_PURE(
+          py::bytes, SerializerInterface, Serialize, &abstract_value);
     };
     std::string str = wrapped();
     message_bytes->resize(str.size());
@@ -74,7 +74,7 @@ PYBIND11_MODULE(lcm, m) {
     py::class_<Class, PySerializerInterface>(m, "SerializerInterface")
         .def(py::init(
                  []() { return std::make_unique<PySerializerInterface>(); }),
-             doc.SerializerInterface.ctor.doc_0args);
+            doc.SerializerInterface.ctor.doc_0args);
     // TODO(eric.cousineau): Consider providing bindings of C++ types if we want
     // to be able to connect to ports which use C++ LCM types.
   }
@@ -83,29 +83,29 @@ PYBIND11_MODULE(lcm, m) {
     using Class = LcmPublisherSystem;
     py::class_<Class, LeafSystem<double>>(m, "LcmPublisherSystem")
         .def(py::init<const std::string&, std::unique_ptr<SerializerInterface>,
-                      DrakeLcmInterface*>(),
-             py::arg("channel"), py::arg("serializer"), py::arg("lcm"),
-             // Keep alive: `self` keeps `DrakeLcmInterface` alive.
-             py::keep_alive<1, 3>(), doc.LcmPublisherSystem.ctor.doc_4)
+                 DrakeLcmInterface*>(),
+            py::arg("channel"), py::arg("serializer"), py::arg("lcm"),
+            // Keep alive: `self` keeps `DrakeLcmInterface` alive.
+            py::keep_alive<1, 3>(), doc.LcmPublisherSystem.ctor.doc_4)
         .def("set_publish_period", &Class::set_publish_period,
-             py::arg("period"), doc.LcmPublisherSystem.set_publish_period.doc);
+            py::arg("period"), doc.LcmPublisherSystem.set_publish_period.doc);
   }
 
   {
     using Class = LcmSubscriberSystem;
     py::class_<Class, LeafSystem<double>>(m, "LcmSubscriberSystem")
         .def(py::init<const std::string&, std::unique_ptr<SerializerInterface>,
-                      DrakeLcmInterface*>(),
-             py::arg("channel"), py::arg("serializer"), py::arg("lcm"),
-             // Keep alive: `self` keeps `DrakeLcmInterface` alive.
-             py::keep_alive<1, 3>(),
-             doc.LcmSubscriberSystem.ctor.doc_3args_channel_serializer_lcm);
+                 DrakeLcmInterface*>(),
+            py::arg("channel"), py::arg("serializer"), py::arg("lcm"),
+            // Keep alive: `self` keeps `DrakeLcmInterface` alive.
+            py::keep_alive<1, 3>(),
+            doc.LcmSubscriberSystem.ctor.doc_3args_channel_serializer_lcm);
   }
 
   m.def("ConnectLcmScope", &ConnectLcmScope, py::arg("src"), py::arg("channel"),
-        py::arg("builder"), py::arg("lcm") = nullptr, py::keep_alive<0, 2>(),
-        // TODO(eric.cousineau): Figure out why this is necessary (#9398).
-        py_reference, doc.ConnectLcmScope.doc);
+      py::arg("builder"), py::arg("lcm") = nullptr, py::keep_alive<0, 2>(),
+      // TODO(eric.cousineau): Figure out why this is necessary (#9398).
+      py_reference, doc.ConnectLcmScope.doc);
 
   ExecuteExtraPythonCode(m);
 }

--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -26,6 +26,9 @@
 #include "drake/systems/primitives/wrap_to_system.h"
 #include "drake/systems/primitives/zero_order_hold.h"
 
+using Eigen::MatrixXd;
+using Eigen::VectorXd;
+
 namespace drake {
 namespace pydrake {
 
@@ -44,87 +47,78 @@ PYBIND11_MODULE(primitives, m) {
     DefineTemplateClassWithDefault<Adder<T>, LeafSystem<T>>(
         m, "Adder", GetPyParam<T>(), doc.Adder.doc)
         .def(py::init<int, int>(), py::arg("num_inputs"), py::arg("size"),
-             doc.Adder.ctor.doc_2args);
+            doc.Adder.ctor.doc_2args);
 
     DefineTemplateClassWithDefault<AffineSystem<T>, LeafSystem<T>>(
         m, "AffineSystem", GetPyParam<T>(), doc.AffineSystem.doc)
-        .def(py::init<const Eigen::Ref<const Eigen::MatrixXd>&,
-                      const Eigen::Ref<const Eigen::MatrixXd>&,
-                      const Eigen::Ref<const Eigen::VectorXd>&,
-                      const Eigen::Ref<const Eigen::MatrixXd>&,
-                      const Eigen::Ref<const Eigen::MatrixXd>&,
-                      const Eigen::Ref<const Eigen::VectorXd>&, double>(),
-             py::arg("A"), py::arg("B"), py::arg("f0"), py::arg("C"),
-             py::arg("D"), py::arg("y0"), py::arg("time_period") = 0.0,
-             doc.AffineSystem.ctor.doc_7args)
+        .def(py::init<const Eigen::Ref<const MatrixXd>&,
+                 const Eigen::Ref<const MatrixXd>&,
+                 const Eigen::Ref<const VectorXd>&,
+                 const Eigen::Ref<const MatrixXd>&,
+                 const Eigen::Ref<const MatrixXd>&,
+                 const Eigen::Ref<const VectorXd>&, double>(),
+            py::arg("A"), py::arg("B"), py::arg("f0"), py::arg("C"),
+            py::arg("D"), py::arg("y0"), py::arg("time_period") = 0.0,
+            doc.AffineSystem.ctor.doc_7args)
         // TODO(eric.cousineau): Fix these to return references instead of
         // copies.
-        .def("A",
-             overload_cast_explicit<const Eigen::MatrixXd&>(  // BR
-                 &AffineSystem<T>::A),
-             doc.AffineSystem.A.doc_0args)
-        .def("B",
-             overload_cast_explicit<const Eigen::MatrixXd&>(  // BR
-                 &AffineSystem<T>::B),
-             doc.AffineSystem.B.doc_0args)
+        .def("A", overload_cast_explicit<const MatrixXd&>(&AffineSystem<T>::A),
+            doc.AffineSystem.A.doc_0args)
+        .def("B", overload_cast_explicit<const MatrixXd&>(&AffineSystem<T>::B),
+            doc.AffineSystem.B.doc_0args)
         .def("f0",
-             overload_cast_explicit<const Eigen::VectorXd&>(  // BR
-                 &AffineSystem<T>::f0),
-             doc.AffineSystem.f0.doc_0args)
-        .def("C",
-             overload_cast_explicit<const Eigen::MatrixXd&>(  // BR
-                 &AffineSystem<T>::C),
-             doc.AffineSystem.C.doc_0args)
-        .def("D",
-             overload_cast_explicit<const Eigen::MatrixXd&>(  // BR
-                 &AffineSystem<T>::D),
-             doc.AffineSystem.D.doc_0args)
+            overload_cast_explicit<const VectorXd&>(&AffineSystem<T>::f0),
+            doc.AffineSystem.f0.doc_0args)
+        .def("C", overload_cast_explicit<const MatrixXd&>(&AffineSystem<T>::C),
+            doc.AffineSystem.C.doc_0args)
+        .def("D", overload_cast_explicit<const MatrixXd&>(&AffineSystem<T>::D),
+            doc.AffineSystem.D.doc_0args)
         .def("y0",
-             overload_cast_explicit<const Eigen::VectorXd&>(  // BR
-                 &AffineSystem<T>::y0),
-             doc.AffineSystem.y0.doc_0args)
+            overload_cast_explicit<const VectorXd&>(&AffineSystem<T>::y0),
+            doc.AffineSystem.y0.doc_0args)
         .def("time_period", &AffineSystem<T>::time_period,
-             doc.TimeVaryingAffineSystem.time_period.doc);
+            doc.TimeVaryingAffineSystem.time_period.doc);
 
     DefineTemplateClassWithDefault<ConstantValueSource<T>, LeafSystem<T>>(
         m, "ConstantValueSource", GetPyParam<T>(), doc.ConstantValueSource.doc)
         .def(py::init<const AbstractValue&>(), py::arg("value"),
-             doc.ConstantValueSource.ctor.doc_3);
+            doc.ConstantValueSource.ctor.doc_3);
 
     DefineTemplateClassWithDefault<ConstantVectorSource<T>, LeafSystem<T>>(
         m, "ConstantVectorSource", GetPyParam<T>(), doc.ConstantValueSource.doc)
         .def(py::init<VectorX<T>>(), py::arg("source_value"),
-             doc.ConstantValueSource.ctor.doc_3);
+            doc.ConstantValueSource.ctor.doc_3);
 
     DefineTemplateClassWithDefault<Demultiplexer<T>, LeafSystem<T>>(
         m, "Demultiplexer", GetPyParam<T>(), doc.Demultiplexer.doc)
         .def(py::init<int, int>(), py::arg("size"),
-             py::arg("output_ports_sizes") = 1,
-             doc.Demultiplexer.ctor.doc_2args);
+            py::arg("output_ports_sizes") = 1,
+            doc.Demultiplexer.ctor.doc_2args);
 
-    DefineTemplateClassWithDefault<FirstOrderLowPassFilter<T>, LeafSystem<T>>(
+    DefineTemplateClassWithDefault<                  // BR
+        FirstOrderLowPassFilter<T>, LeafSystem<T>>(  //
         m, "FirstOrderLowPassFilter", GetPyParam<T>(),
         doc.FirstOrderLowPassFilter.doc)
         .def(py::init<double, int>(), py::arg("time_constant"),
-             py::arg("size") = 1, doc.FirstOrderLowPassFilter.ctor.doc_2args)
+            py::arg("size") = 1, doc.FirstOrderLowPassFilter.ctor.doc_2args)
         .def(py::init<const VectorX<double>&>(), py::arg("time_constants"),
-             doc.FirstOrderLowPassFilter.ctor.doc_1args)
+            doc.FirstOrderLowPassFilter.ctor.doc_1args)
         .def("get_time_constant",
-             &FirstOrderLowPassFilter<T>::get_time_constant,
-             doc.FirstOrderLowPassFilter.get_time_constant.doc)
+            &FirstOrderLowPassFilter<T>::get_time_constant,
+            doc.FirstOrderLowPassFilter.get_time_constant.doc)
         .def("get_time_constants_vector",
-             &FirstOrderLowPassFilter<T>::get_time_constants_vector,
-             doc.FirstOrderLowPassFilter.get_time_constants_vector.doc)
+            &FirstOrderLowPassFilter<T>::get_time_constants_vector,
+            doc.FirstOrderLowPassFilter.get_time_constants_vector.doc)
         .def("set_initial_output_value",
-             &FirstOrderLowPassFilter<T>::set_initial_output_value,
-             doc.FirstOrderLowPassFilter.set_initial_output_value.doc);
+            &FirstOrderLowPassFilter<T>::set_initial_output_value,
+            doc.FirstOrderLowPassFilter.set_initial_output_value.doc);
 
     DefineTemplateClassWithDefault<Gain<T>, LeafSystem<T>>(
         m, "Gain", GetPyParam<T>(), doc.Gain.doc)
         .def(py::init<double, int>(), py::arg("k"), py::arg("size"),
-             doc.Gain.ctor.doc)
-        .def(py::init<const Eigen::Ref<const Eigen::VectorXd>&>(), py::arg("k"),
-             doc.Gain.ctor.doc_3);
+            doc.Gain.ctor.doc)
+        .def(py::init<const Eigen::Ref<const VectorXd>&>(), py::arg("k"),
+            doc.Gain.ctor.doc_3);
 
     DefineTemplateClassWithDefault<Integrator<T>, LeafSystem<T>>(
         m, "Integrator", GetPyParam<T>(), doc.Integrator.doc)
@@ -132,26 +126,26 @@ PYBIND11_MODULE(primitives, m) {
 
     DefineTemplateClassWithDefault<LinearSystem<T>, AffineSystem<T>>(
         m, "LinearSystem", GetPyParam<T>(), doc.LinearSystem.doc)
-        .def(py::init<const Eigen::Ref<const Eigen::MatrixXd>&,
-                      const Eigen::Ref<const Eigen::MatrixXd>&,
-                      const Eigen::Ref<const Eigen::MatrixXd>&,
-                      const Eigen::Ref<const Eigen::MatrixXd>&, double>(),
-             py::arg("A"), py::arg("B"), py::arg("C"), py::arg("D"),
-             py::arg("time_period") = 0.0, doc.LinearSystem.ctor.doc_5args);
+        .def(py::init<const Eigen::Ref<const MatrixXd>&,
+                 const Eigen::Ref<const MatrixXd>&,
+                 const Eigen::Ref<const MatrixXd>&,
+                 const Eigen::Ref<const MatrixXd>&, double>(),
+            py::arg("A"), py::arg("B"), py::arg("C"), py::arg("D"),
+            py::arg("time_period") = 0.0, doc.LinearSystem.ctor.doc_5args);
 
     DefineTemplateClassWithDefault<MatrixGain<T>, LinearSystem<T>>(
         m, "MatrixGain", GetPyParam<T>(), doc.MatrixGain.doc)
-        .def(py::init<const Eigen::Ref<const Eigen::MatrixXd>&>(), py::arg("D"),
-             doc.MatrixGain.ctor.doc_1args_D);
+        .def(py::init<const Eigen::Ref<const MatrixXd>&>(), py::arg("D"),
+            doc.MatrixGain.ctor.doc_1args_D);
 
     DefineTemplateClassWithDefault<Multiplexer<T>, LeafSystem<T>>(
         m, "Multiplexer", GetPyParam<T>(), doc.Multiplexer.doc)
         .def(py::init<int>(), py::arg("num_scalar_inputs"),
-             doc.Multiplexer.ctor.doc_1args_num_scalar_inputs)
+            doc.Multiplexer.ctor.doc_1args_num_scalar_inputs)
         .def(py::init<std::vector<int>>(), py::arg("input_sizes"),
-             doc.Multiplexer.ctor.doc_1args_input_sizes)
+            doc.Multiplexer.ctor.doc_1args_input_sizes)
         .def(py::init<const BasicVector<T>&>(), py::arg("model_vector"),
-             doc.Multiplexer.ctor.doc_0args);
+            doc.Multiplexer.ctor.doc_0args);
 
     DefineTemplateClassWithDefault<PassThrough<T>, LeafSystem<T>>(
         m, "PassThrough", GetPyParam<T>(), doc.PassThrough.doc)
@@ -161,16 +155,16 @@ PYBIND11_MODULE(primitives, m) {
     DefineTemplateClassWithDefault<Saturation<T>, LeafSystem<T>>(
         m, "Saturation", GetPyParam<T>(), doc.Saturation.doc)
         .def(py::init<const VectorX<T>&, const VectorX<T>&>(),
-             py::arg("min_value"), py::arg("max_value"),
-             doc.Saturation.ctor.doc_2args);
+            py::arg("min_value"), py::arg("max_value"),
+            doc.Saturation.ctor.doc_2args);
 
     DefineTemplateClassWithDefault<SignalLogger<T>, LeafSystem<T>>(
         m, "SignalLogger", GetPyParam<T>(), doc.SignalLogger.doc)
         .def(py::init<int, int>(), py::arg("input_size"),
-             py::arg("batch_allocation_size") = 1000,
-             doc.SignalLogger.ctor.doc_2args)
+            py::arg("batch_allocation_size") = 1000,
+            doc.SignalLogger.ctor.doc_2args)
         .def("sample_times", &SignalLogger<T>::sample_times,
-             doc.SignalLogger.sample_times.doc)
+            doc.SignalLogger.sample_times.doc)
         .def("data", &SignalLogger<T>::data, doc.SignalLogger.data.doc)
         .def("reset", &SignalLogger<T>::reset, doc.SignalLogger.reset.doc);
 
@@ -178,83 +172,83 @@ PYBIND11_MODULE(primitives, m) {
         m, "WrapToSystem", GetPyParam<T>(), doc.WrapToSystem.doc)
         .def(py::init<int>(), doc.WrapToSystem.ctor.doc_1args)
         .def("set_interval", &WrapToSystem<T>::set_interval,
-             doc.WrapToSystem.set_interval.doc);
+            doc.WrapToSystem.set_interval.doc);
 
     DefineTemplateClassWithDefault<ZeroOrderHold<T>, LeafSystem<T>>(
         m, "ZeroOrderHold", GetPyParam<T>(), doc.ZeroOrderHold.doc)
         .def(py::init<double, int>(), py::arg("period_sec"),
-             py::arg("vector_size"), doc.ZeroOrderHold.ctor.doc_4)
+            py::arg("vector_size"), doc.ZeroOrderHold.ctor.doc_4)
         .def(py::init<double, const AbstractValue&>(), py::arg("period_sec"),
-             py::arg("abstract_model_value"), doc.ZeroOrderHold.ctor.doc_5);
+            py::arg("abstract_model_value"), doc.ZeroOrderHold.ctor.doc_5);
   };
   type_visit(bind_common_scalar_types, pysystems::CommonScalarPack{});
 
   py::class_<BarycentricMeshSystem<double>, LeafSystem<double>>(
       m, "BarycentricMeshSystem", doc.BarycentricMeshSystem.doc)
       .def(py::init<math::BarycentricMesh<double>,
-                    const Eigen::Ref<const MatrixX<double>>&>(),
-           doc.BarycentricMeshSystem.ctor.doc_2args)
+               const Eigen::Ref<const MatrixX<double>>&>(),
+          doc.BarycentricMeshSystem.ctor.doc_2args)
       .def("get_mesh", &BarycentricMeshSystem<double>::get_mesh,
-           doc.BarycentricMeshSystem.get_mesh.doc)
+          doc.BarycentricMeshSystem.get_mesh.doc)
       .def("get_output_values",
-           &BarycentricMeshSystem<double>::get_output_values,
-           doc.BarycentricMeshSystem.get_output_values.doc);
+          &BarycentricMeshSystem<double>::get_output_values,
+          doc.BarycentricMeshSystem.get_output_values.doc);
 
   // Docs for typedef not being parsed.
   py::class_<UniformRandomSource, LeafSystem<double>>(m, "UniformRandomSource")
       .def(py::init<int, double>(), py::arg("num_outputs"),
-           py::arg("sampling_interval_sec"));
+          py::arg("sampling_interval_sec"));
 
   // Docs for typedef not being parsed.
-  py::class_<GaussianRandomSource, LeafSystem<double>>(m,
-                                                       "GaussianRandomSource")
+  py::class_<GaussianRandomSource, LeafSystem<double>>(
+      m, "GaussianRandomSource")
       .def(py::init<int, double>(), py::arg("num_outputs"),
-           py::arg("sampling_interval_sec"));
+          py::arg("sampling_interval_sec"));
 
   // Docs for typedef not being parsed.
   py::class_<ExponentialRandomSource, LeafSystem<double>>(
       m, "ExponentialRandomSource")
       .def(py::init<int, double>(), py::arg("num_outputs"),
-           py::arg("sampling_interval_sec"));
+          py::arg("sampling_interval_sec"));
 
   py::class_<TrajectorySource<double>, LeafSystem<double>>(
       m, "TrajectorySource", doc.TrajectorySource.doc)
       .def(py::init<const trajectories::Trajectory<double>&, int, bool>(),
-           py::arg("trajectory"), py::arg("output_derivative_order") = 0,
-           py::arg("zero_derivatives_beyond_limits") = true,
-           doc.TrajectorySource.ctor.doc_3args);
+          py::arg("trajectory"), py::arg("output_derivative_order") = 0,
+          py::arg("zero_derivatives_beyond_limits") = true,
+          doc.TrajectorySource.ctor.doc_3args);
 
   m.def("AddRandomInputs", &AddRandomInputs, py::arg("sampling_interval_sec"),
-        py::arg("builder"), doc.AddRandomInputs.doc);
+      py::arg("builder"), doc.AddRandomInputs.doc);
 
   m.def("Linearize", &Linearize, py::arg("system"), py::arg("context"),
-        py::arg("input_port_index") = systems::kUseFirstInputIfItExists,
-        py::arg("output_port_index") = systems::kUseFirstOutputIfItExists,
-        py::arg("equilibrium_check_tolerance") = 1e-6, doc.Linearize.doc);
+      py::arg("input_port_index") = systems::kUseFirstInputIfItExists,
+      py::arg("output_port_index") = systems::kUseFirstOutputIfItExists,
+      py::arg("equilibrium_check_tolerance") = 1e-6, doc.Linearize.doc);
 
   m.def("FirstOrderTaylorApproximation", &FirstOrderTaylorApproximation,
-        py::arg("system"), py::arg("context"),
-        py::arg("input_port_index") = systems::kUseFirstInputIfItExists,
-        py::arg("output_port_index") = systems::kUseFirstOutputIfItExists,
-        doc.FirstOrderTaylorApproximation.doc);
+      py::arg("system"), py::arg("context"),
+      py::arg("input_port_index") = systems::kUseFirstInputIfItExists,
+      py::arg("output_port_index") = systems::kUseFirstOutputIfItExists,
+      doc.FirstOrderTaylorApproximation.doc);
 
   m.def("ControllabilityMatrix", &ControllabilityMatrix,
-        doc.ControllabilityMatrix.doc);
+      doc.ControllabilityMatrix.doc);
 
   m.def("IsControllable", &IsControllable, py::arg("sys"),
-        py::arg("threshold") = nullopt, doc.IsControllable.doc);
+      py::arg("threshold") = nullopt, doc.IsControllable.doc);
 
-  m.def("ObservabilityMatrix", &ObservabilityMatrix,
-        doc.ObservabilityMatrix.doc);
+  m.def(
+      "ObservabilityMatrix", &ObservabilityMatrix, doc.ObservabilityMatrix.doc);
 
   m.def("IsObservable", &IsObservable, py::arg("sys"),
-        py::arg("threshold") = nullopt, doc.IsObservable.doc);
+      py::arg("threshold") = nullopt, doc.IsObservable.doc);
 
   m.def("LogOutput", &LogOutput<double>, py::arg("src"), py::arg("builder"),
-        // Keep alive, ownership: `return` keeps `builder` alive.
-        py::keep_alive<0, 2>(),
-        // TODO(eric.cousineau): Figure out why this is necessary (#9398).
-        py_reference, doc.LogOutput.doc);
+      // Keep alive, ownership: `return` keeps `builder` alive.
+      py::keep_alive<0, 2>(),
+      // TODO(eric.cousineau): Figure out why this is necessary (#9398).
+      py_reference, doc.LogOutput.doc);
 
   // TODO(eric.cousineau): Add more systems as needed.
 }

--- a/bindings/pydrake/systems/rendering_py.cc
+++ b/bindings/pydrake/systems/rendering_py.cc
@@ -28,24 +28,24 @@ PYBIND11_MODULE(rendering, m) {
 
   using T = double;
 
-  py::class_<PoseVector<T>, BasicVector<T>> pose_vector(m, "PoseVector",
-                                                        doc.PoseVector.doc);
+  py::class_<PoseVector<T>, BasicVector<T>> pose_vector(
+      m, "PoseVector", doc.PoseVector.doc);
   pose_vector  // BR
       .def(py::init(), doc.PoseVector.ctor.doc_0args)
       .def(py::init<const Eigen::Quaternion<T>&,
-                    const Eigen::Translation<T, 3>&>(),
-           py::arg("rotation"), py::arg("translation"),
-           doc.PoseVector.ctor.doc_2args)
+               const Eigen::Translation<T, 3>&>(),
+          py::arg("rotation"), py::arg("translation"),
+          doc.PoseVector.ctor.doc_2args)
       .def("get_isometry", &PoseVector<T>::get_isometry,
-           doc.PoseVector.get_isometry.doc)
+          doc.PoseVector.get_isometry.doc)
       .def("get_translation", &PoseVector<T>::get_translation,
-           doc.PoseVector.get_translation.doc)
+          doc.PoseVector.get_translation.doc)
       .def("set_translation", &PoseVector<T>::set_translation,
-           doc.PoseVector.set_translation.doc)
+          doc.PoseVector.set_translation.doc)
       .def("get_rotation", &PoseVector<T>::get_rotation,
-           doc.PoseVector.get_rotation.doc)
+          doc.PoseVector.get_rotation.doc)
       .def("set_rotation", &PoseVector<T>::set_rotation,
-           doc.PoseVector.set_rotation.doc);
+          doc.PoseVector.set_rotation.doc);
 
   pose_vector.attr("kSize") = int{PoseVector<T>::kSize};
 
@@ -54,73 +54,71 @@ PYBIND11_MODULE(rendering, m) {
   frame_velocity  // BR
       .def(py::init(), doc.FrameVelocity.ctor.doc_0args)
       .def(py::init<const multibody::SpatialVelocity<T>&>(),
-           py::arg("velocity"), doc.FrameVelocity.ctor.doc_1args)
+          py::arg("velocity"), doc.FrameVelocity.ctor.doc_1args)
       .def("get_velocity", &FrameVelocity<T>::get_velocity,
-           doc.FrameVelocity.get_velocity.doc)
+          doc.FrameVelocity.get_velocity.doc)
       .def("set_velocity", &FrameVelocity<T>::set_velocity, py::arg("velocity"),
-           doc.FrameVelocity.set_velocity.doc);
+          doc.FrameVelocity.set_velocity.doc);
 
   frame_velocity.attr("kSize") = int{FrameVelocity<T>::kSize};
 
   py::class_<PoseBundle<T>>(m, "PoseBundle", doc.PoseBundle.doc)
       .def(py::init<int>(), py::arg("num_poses"), doc.PoseBundle.ctor.doc_1args)
       .def("get_num_poses", &PoseBundle<T>::get_num_poses,
-           doc.PoseBundle.get_num_poses.doc)
+          doc.PoseBundle.get_num_poses.doc)
       .def("get_pose", &PoseBundle<T>::get_pose, doc.PoseBundle.get_pose.doc)
       .def("set_pose", &PoseBundle<T>::set_pose, doc.PoseBundle.set_pose.doc)
       .def("get_velocity", &PoseBundle<T>::get_velocity,
-           doc.PoseBundle.get_velocity.doc)
+          doc.PoseBundle.get_velocity.doc)
       .def("set_velocity", &PoseBundle<T>::set_velocity,
-           doc.PoseBundle.set_velocity.doc)
+          doc.PoseBundle.set_velocity.doc)
       .def("get_name", &PoseBundle<T>::get_name, doc.PoseBundle.get_name.doc)
       .def("set_name", &PoseBundle<T>::set_name, doc.PoseBundle.set_name.doc)
       .def("get_model_instance_id", &PoseBundle<T>::get_model_instance_id,
-           doc.PoseBundle.get_model_instance_id.doc)
+          doc.PoseBundle.get_model_instance_id.doc)
       .def("set_model_instance_id", &PoseBundle<T>::set_model_instance_id,
-           doc.PoseBundle.set_model_instance_id.doc);
+          doc.PoseBundle.set_model_instance_id.doc);
   pysystems::AddValueInstantiation<PoseBundle<T>>(m);
 
-  py::class_<PoseVelocityInputPorts<T>>(m, "PoseVelocityInputPorts",
-                                        doc.PoseVelocityInputPorts.doc)
+  py::class_<PoseVelocityInputPorts<T>>(
+      m, "PoseVelocityInputPorts", doc.PoseVelocityInputPorts.doc)
       // N.B. We use lambdas below since we cannot use `def_readonly` with
       // reference members.
-      .def_property_readonly(
-          "pose_input_port",
+      .def_property_readonly("pose_input_port",
           [](PoseVelocityInputPorts<T>* self) -> const InputPort<T>& {
             return self->pose_input_port;
           },
           doc.PoseVelocityInputPorts.pose_input_port.doc)
-      .def_property_readonly(
-          "velocity_input_port",
+      .def_property_readonly("velocity_input_port",
           [](PoseVelocityInputPorts<T>* self) -> const InputPort<T>& {
             return self->velocity_input_port;
           },
           doc.PoseVelocityInputPorts.velocity_input_port.doc);
 
-  py::class_<PoseAggregator<T>, LeafSystem<T>>(m, "PoseAggregator",
-                                               doc.PoseAggregator.doc)
+  py::class_<PoseAggregator<T>, LeafSystem<T>>(
+      m, "PoseAggregator", doc.PoseAggregator.doc)
       .def(py::init<>(), doc.PoseAggregator.ctor.doc_3)
       .def("AddSingleInput", &PoseAggregator<T>::AddSingleInput,
-           py_reference_internal, doc.PoseAggregator.AddSingleInput.doc)
+          py_reference_internal, doc.PoseAggregator.AddSingleInput.doc)
       .def("AddSinglePoseAndVelocityInput",
-           &PoseAggregator<T>::AddSinglePoseAndVelocityInput,
-           doc.PoseAggregator.AddSinglePoseAndVelocityInput.doc)
+          &PoseAggregator<T>::AddSinglePoseAndVelocityInput,
+          doc.PoseAggregator.AddSinglePoseAndVelocityInput.doc)
       .def("AddBundleInput", &PoseAggregator<T>::AddBundleInput,
-           py_reference_internal, doc.PoseAggregator.AddBundleInput.doc);
+          py_reference_internal, doc.PoseAggregator.AddBundleInput.doc);
 
-  py::class_<MultibodyPositionToGeometryPose<T>, LeafSystem<T>>(
-      m, "MultibodyPositionToGeometryPose",
+  py::class_<MultibodyPositionToGeometryPose<T>, LeafSystem<T>>(m,
+      "MultibodyPositionToGeometryPose",
       doc.MultibodyPositionToGeometryPose.doc)
       .def(py::init<const multibody::multibody_plant::MultibodyPlant<T>&>(),
-           doc.MultibodyPositionToGeometryPose.ctor.doc_1args)
+          doc.MultibodyPositionToGeometryPose.ctor.doc_1args)
       .def("get_input_port",
-           &MultibodyPositionToGeometryPose<T>::get_input_port,
-           py_reference_internal,
-           doc.MultibodyPositionToGeometryPose.get_input_port.doc)
+          &MultibodyPositionToGeometryPose<T>::get_input_port,
+          py_reference_internal,
+          doc.MultibodyPositionToGeometryPose.get_input_port.doc)
       .def("get_output_port",
-           &MultibodyPositionToGeometryPose<T>::get_output_port,
-           py_reference_internal,
-           doc.MultibodyPositionToGeometryPose.get_output_port.doc);
+          &MultibodyPositionToGeometryPose<T>::get_output_port,
+          py_reference_internal,
+          doc.MultibodyPositionToGeometryPose.get_output_port.doc);
 
   // TODO(eric.cousineau): Add more systems as needed.
 }

--- a/bindings/pydrake/systems/sensors_py.cc
+++ b/bindings/pydrake/systems/sensors_py.cc
@@ -93,8 +93,8 @@ PYBIND11_MODULE(sensors, m) {
       // Shape for use with NumPy, OpenCV, etc. Using same shape as what is
       // present in `show_images.py`.
       auto get_shape = [](const ImageT* self) {
-        return py::make_tuple(self->height(), self->width(),
-                              int{ImageTraitsT::kNumChannels});
+        return py::make_tuple(
+            self->height(), self->width(), int{ImageTraitsT::kNumChannels});
       };
       auto get_data = [=](const ImageT* self) {
         return ToArray(self->at(0, 0), self->size(), get_shape(self));
@@ -119,19 +119,19 @@ PYBIND11_MODULE(sensors, m) {
           .def("size", &ImageT::size, doc.Image.size.doc)
           .def("resize", &ImageT::resize, doc.Image.resize.doc)
           .def("at",
-               [=](ImageT* self, int x, int y) {
-                 check_coord(self, x, y);
-                 Map<VectorX<T>> pixel(self->at(x, y),
-                                       int{ImageTraitsT::kNumChannels});
-                 return pixel;
-               },
-               py::arg("x"), py::arg("y"), py_reference_internal,
-               doc.Image.at.doc)
+              [=](ImageT* self, int x, int y) {
+                check_coord(self, x, y);
+                Map<VectorX<T>> pixel(
+                    self->at(x, y), int{ImageTraitsT::kNumChannels});
+                return pixel;
+              },
+              py::arg("x"), py::arg("y"), py_reference_internal,
+              doc.Image.at.doc)
           // Non-C++ properties. Make them Pythonic.
           .def_property_readonly("shape", get_shape)
           .def_property_readonly("data", get_data, py_reference_internal)
-          .def_property_readonly("mutable_data", get_mutable_data,
-                                 py_reference_internal);
+          .def_property_readonly(
+              "mutable_data", get_mutable_data, py_reference_internal);
       // Constants.
       image.attr("Traits") = traits;
       // - Do not duplicate aliases (e.g. `kNumChannels`) for now.
@@ -160,11 +160,11 @@ PYBIND11_MODULE(sensors, m) {
   // Systems.
   py::class_<CameraInfo>(m, "CameraInfo", doc.CameraInfo.doc)
       .def(py::init<int, int, double>(), py::arg("width"), py::arg("height"),
-           py::arg("fov_y"), doc.CameraInfo.ctor.doc_3args)
+          py::arg("fov_y"), doc.CameraInfo.ctor.doc_3args)
       .def(py::init<int, int, double, double, double, double>(),
-           py::arg("width"), py::arg("height"), py::arg("focal_x"),
-           py::arg("focal_y"), py::arg("center_x"), py::arg("center_y"),
-           doc.CameraInfo.ctor.doc_6args)
+          py::arg("width"), py::arg("height"), py::arg("focal_x"),
+          py::arg("focal_y"), py::arg("center_x"), py::arg("center_y"),
+          doc.CameraInfo.ctor.doc_6args)
       .def("width", &CameraInfo::width, doc.CameraInfo.width.doc)
       .def("height", &CameraInfo::height, doc.CameraInfo.height.doc)
       .def("focal_x", &CameraInfo::focal_x, doc.CameraInfo.focal_x.doc)
@@ -172,50 +172,50 @@ PYBIND11_MODULE(sensors, m) {
       .def("center_x", &CameraInfo::center_x, doc.CameraInfo.center_x.doc)
       .def("center_y", &CameraInfo::center_y, doc.CameraInfo.center_y.doc)
       .def("intrinsic_matrix", &CameraInfo::intrinsic_matrix,
-           doc.CameraInfo.intrinsic_matrix.doc);
+          doc.CameraInfo.intrinsic_matrix.doc);
 
   auto def_camera_ports = [](auto* ppy_class) {
     auto& py_class = *ppy_class;
     using PyClass = std::decay_t<decltype(py_class)>;
     using Class = typename PyClass::type;
     py_class
-        .def("state_input_port", &Class::state_input_port,
-             py_reference_internal)
+        .def(
+            "state_input_port", &Class::state_input_port, py_reference_internal)
         .def("color_image_output_port", &Class::color_image_output_port,
-             py_reference_internal)
+            py_reference_internal)
         .def("depth_image_output_port", &Class::depth_image_output_port,
-             py_reference_internal)
+            py_reference_internal)
         .def("label_image_output_port", &Class::label_image_output_port,
-             py_reference_internal)
+            py_reference_internal)
         .def("camera_base_pose_output_port",
-             &Class::camera_base_pose_output_port, py_reference_internal);
+            &Class::camera_base_pose_output_port, py_reference_internal);
   };
 
   // TODO(eric.cousineau): Use something like `RenderingConfig`, per (#8123).
   py::class_<RgbdCamera, LeafSystem<T>> rgbd_camera(m, "RgbdCamera");
   rgbd_camera
       .def(py::init<string, const RigidBodyTree<T>&, const RigidBodyFrame<T>&,
-                    double, double, double, bool, int, int>(),
-           py::arg("name"), py::arg("tree"), py::arg("frame"),
-           py::arg("z_near") = 0.5, py::arg("z_far") = 5.0,
-           py::arg("fov_y") = M_PI_4,
-           py::arg("show_window") = bool{RenderingConfig::kDefaultShowWindow},
-           py::arg("width") = int{RenderingConfig::kDefaultWidth},
-           py::arg("height") = int{RenderingConfig::kDefaultHeight},
-           // Keep alive, reference: `this` keeps  `RigidBodyTree` alive.
-           py::keep_alive<1, 3>(), doc.RgbdCamera.ctor.doc_10args)
+               double, double, double, bool, int, int>(),
+          py::arg("name"), py::arg("tree"), py::arg("frame"),
+          py::arg("z_near") = 0.5, py::arg("z_far") = 5.0,
+          py::arg("fov_y") = M_PI_4,
+          py::arg("show_window") = bool{RenderingConfig::kDefaultShowWindow},
+          py::arg("width") = int{RenderingConfig::kDefaultWidth},
+          py::arg("height") = int{RenderingConfig::kDefaultHeight},
+          // Keep alive, reference: `this` keeps  `RigidBodyTree` alive.
+          py::keep_alive<1, 3>(), doc.RgbdCamera.ctor.doc_10args)
       .def("color_camera_info", &RgbdCamera::color_camera_info,
-           py_reference_internal, doc.RgbdCamera.color_camera_info.doc)
+          py_reference_internal, doc.RgbdCamera.color_camera_info.doc)
       .def("depth_camera_info", &RgbdCamera::depth_camera_info,
-           py_reference_internal, doc.RgbdCamera.depth_camera_info.doc)
+          py_reference_internal, doc.RgbdCamera.depth_camera_info.doc)
       .def("color_camera_optical_pose", &RgbdCamera::color_camera_optical_pose,
-           doc.RgbdCamera.color_camera_optical_pose.doc)
+          doc.RgbdCamera.color_camera_optical_pose.doc)
       .def("depth_camera_optical_pose", &RgbdCamera::depth_camera_optical_pose,
-           doc.RgbdCamera.depth_camera_optical_pose.doc)
+          doc.RgbdCamera.depth_camera_optical_pose.doc)
       .def("frame", &RgbdCamera::frame, py_reference_internal,
-           doc.RgbdCamera.frame.doc)
+          doc.RgbdCamera.frame.doc)
       .def("frame", &RgbdCamera::frame, py_reference_internal,
-           doc.RgbdCamera.frame.doc)
+          doc.RgbdCamera.frame.doc)
       .def("tree", &RgbdCamera::tree, py_reference, doc.RgbdCamera.tree.doc);
   def_camera_ports(&rgbd_camera);
 
@@ -223,18 +223,18 @@ PYBIND11_MODULE(sensors, m) {
       m, "RgbdCameraDiscrete", doc.RgbdCameraDiscrete.doc);
   rgbd_camera_discrete
       .def(py::init<unique_ptr<RgbdCamera>, double, bool>(), py::arg("camera"),
-           py::arg("period") = double{RgbdCameraDiscrete::kDefaultPeriod},
-           py::arg("render_label_image") = true,
-           // Keep alive, ownership: `RgbdCamera` keeps `this` alive.
-           py::keep_alive<2, 1>(), doc.RgbdCameraDiscrete.ctor.doc_3args)
+          py::arg("period") = double{RgbdCameraDiscrete::kDefaultPeriod},
+          py::arg("render_label_image") = true,
+          // Keep alive, ownership: `RgbdCamera` keeps `this` alive.
+          py::keep_alive<2, 1>(), doc.RgbdCameraDiscrete.ctor.doc_3args)
       // N.B. Since `camera` is already connected, we do not need additional
       // `keep_alive`s.
       .def("camera", &RgbdCameraDiscrete::camera,
-           doc.RgbdCameraDiscrete.camera.doc)
+          doc.RgbdCameraDiscrete.camera.doc)
       .def("mutable_camera", &RgbdCameraDiscrete::mutable_camera,
-           doc.RgbdCameraDiscrete.mutable_camera.doc)
+          doc.RgbdCameraDiscrete.mutable_camera.doc)
       .def("period", &RgbdCameraDiscrete::period,
-           doc.RgbdCameraDiscrete.period.doc);
+          doc.RgbdCameraDiscrete.period.doc);
   def_camera_ports(&rgbd_camera_discrete);
   rgbd_camera_discrete.attr("kDefaultPeriod") =
       double{RgbdCameraDiscrete::kDefaultPeriod};

--- a/bindings/pydrake/systems/systems_pybind.h
+++ b/bindings/pydrake/systems/systems_pybind.h
@@ -25,9 +25,8 @@ void DefClone(PyClass* ppy_class) {
   py_class  // BR
       .def("Clone", &Class::Clone)
       .def("__copy__", &Class::Clone)
-      .def("__deepcopy__", [](const Class* self, py::dict /* memo */) {
-        return self->Clone();
-      });
+      .def("__deepcopy__",
+          [](const Class* self, py::dict /* memo */) { return self->Clone(); });
 }
 
 /// Defines an instantiation of `pydrake.systems.framework.Value[...]`. This is
@@ -71,7 +70,7 @@ py::object AddValueInstantiation(py::module scope) {
   py_class  // BR
       .def("get_value", &Class::get_value, py_reference_internal)
       .def("get_mutable_value", &Class::get_mutable_value,
-           py_reference_internal);
+          py_reference_internal);
   std::string set_value_docstring = "Replaces stored value with a new one.";
   if (!std::is_copy_constructible<T>::value) {
     set_value_docstring += R"""(

--- a/bindings/pydrake/systems/test/test_util_py.cc
+++ b/bindings/pydrake/systems/test/test_util_py.cc
@@ -106,7 +106,7 @@ PYBIND11_MODULE(test_util, m) {
       .def(py::init<const Eigen::Vector2d&>(), py::arg("data"));
 
   m.def("make_unknown_abstract_value",
-        []() { return AbstractValue::Make(UnknownType{}); });
+      []() { return AbstractValue::Make(UnknownType{}); });
 
   // Call overrides to ensure a custom Python class can override these methods.
 
@@ -160,32 +160,32 @@ PYBIND11_MODULE(test_util, m) {
     return results;
   });
 
-  m.def("call_vector_system_overrides", [clone_vector](
-                                            const VectorSystem<T>& system,
-                                            Context<T>* context,
-                                            bool is_discrete, double dt) {
-    // While this is not convention, update state first to ensure that our
-    // output incorporates it correctly, for testing purposes.
-    // TODO(eric.cousineau): Add (Continuous|Discrete)State::Clone().
-    if (is_discrete) {
-      auto& state = context->get_mutable_discrete_state();
-      DiscreteValues<T> state_copy(clone_vector(state.get_vector()));
-      system.CalcDiscreteVariableUpdates(*context, &state_copy);
-      state.SetFrom(state_copy);
-    } else {
-      auto& state = context->get_mutable_continuous_state();
-      ContinuousState<T> state_dot(clone_vector(state.get_vector()),
-                                   state.get_generalized_position().size(),
-                                   state.get_generalized_velocity().size(),
-                                   state.get_misc_continuous_state().size());
-      system.CalcTimeDerivatives(*context, &state_dot);
-      state.SetFromVector(state.CopyToVector() + dt * state_dot.CopyToVector());
-    }
-    // Calculate output.
-    auto output = system.AllocateOutput();
-    system.CalcOutput(*context, output.get());
-    return output;
-  });
+  m.def("call_vector_system_overrides",
+      [clone_vector](const VectorSystem<T>& system, Context<T>* context,
+          bool is_discrete, double dt) {
+        // While this is not convention, update state first to ensure that our
+        // output incorporates it correctly, for testing purposes.
+        // TODO(eric.cousineau): Add (Continuous|Discrete)State::Clone().
+        if (is_discrete) {
+          auto& state = context->get_mutable_discrete_state();
+          DiscreteValues<T> state_copy(clone_vector(state.get_vector()));
+          system.CalcDiscreteVariableUpdates(*context, &state_copy);
+          state.SetFrom(state_copy);
+        } else {
+          auto& state = context->get_mutable_continuous_state();
+          ContinuousState<T> state_dot(clone_vector(state.get_vector()),
+              state.get_generalized_position().size(),
+              state.get_generalized_velocity().size(),
+              state.get_misc_continuous_state().size());
+          system.CalcTimeDerivatives(*context, &state_dot);
+          state.SetFromVector(
+              state.CopyToVector() + dt * state_dot.CopyToVector());
+        }
+        // Calculate output.
+        auto output = system.AllocateOutput();
+        system.CalcOutput(*context, output.get());
+        return output;
+      });
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/systems/trajectory_optimization_py.cc
+++ b/bindings/pydrake/systems/trajectory_optimization_py.cc
@@ -28,138 +28,138 @@ PYBIND11_MODULE(trajectory_optimization, m) {
       m, "MultipleShooting", doc.MultipleShooting.doc)
       .def("time", &MultipleShooting::time, doc.MultipleShooting.time.doc)
       .def("timestep", &MultipleShooting::timestep,
-           doc.MultipleShooting.timestep.doc)
+          doc.MultipleShooting.timestep.doc)
       .def("fixed_timestep", &MultipleShooting::fixed_timestep,
-           doc.MultipleShooting.fixed_timestep.doc)
+          doc.MultipleShooting.fixed_timestep.doc)
       // TODO(eric.cousineau): The original bindings returned references
       // instead of copies using VectorXBlock. Restore this once dtype=custom
       // is resolved.
       .def("state",
-           [](const MultipleShooting& self) -> VectorXDecisionVariable {
-             return self.state();
-           },
-           doc.MultipleShooting.state.doc_0args)
+          [](const MultipleShooting& self) -> VectorXDecisionVariable {
+            return self.state();
+          },
+          doc.MultipleShooting.state.doc_0args)
       .def("state",
-           [](const MultipleShooting& self, int index)
-               -> VectorXDecisionVariable { return self.state(index); },
-           doc.MultipleShooting.state.doc_1args)
+          [](const MultipleShooting& self, int index)
+              -> VectorXDecisionVariable { return self.state(index); },
+          doc.MultipleShooting.state.doc_1args)
       .def("initial_state",
-           [](const MultipleShooting& self) -> VectorXDecisionVariable {
-             return self.initial_state();
-           },
-           doc.MultipleShooting.initial_state.doc)
+          [](const MultipleShooting& self) -> VectorXDecisionVariable {
+            return self.initial_state();
+          },
+          doc.MultipleShooting.initial_state.doc)
       .def("final_state",
-           [](const MultipleShooting& self) -> VectorXDecisionVariable {
-             return self.final_state();
-           },
-           doc.MultipleShooting.final_state.doc)
+          [](const MultipleShooting& self) -> VectorXDecisionVariable {
+            return self.final_state();
+          },
+          doc.MultipleShooting.final_state.doc)
       .def("input",
-           [](const MultipleShooting& self) -> VectorXDecisionVariable {
-             return self.input();
-           },
-           doc.MultipleShooting.input.doc_0args)
+          [](const MultipleShooting& self) -> VectorXDecisionVariable {
+            return self.input();
+          },
+          doc.MultipleShooting.input.doc_0args)
       .def("input",
-           [](const MultipleShooting& self, int index)
-               -> VectorXDecisionVariable { return self.input(index); },
-           doc.MultipleShooting.input.doc_1args)
+          [](const MultipleShooting& self, int index)
+              -> VectorXDecisionVariable { return self.input(index); },
+          doc.MultipleShooting.input.doc_1args)
       .def("AddRunningCost",
-           [](MultipleShooting& prog, const symbolic::Expression& g) {
-             prog.AddRunningCost(g);
-           },
-           doc.MultipleShooting.AddRunningCost.doc_1args)
+          [](MultipleShooting& prog, const symbolic::Expression& g) {
+            prog.AddRunningCost(g);
+          },
+          doc.MultipleShooting.AddRunningCost.doc_1args)
       .def("AddRunningCost",
-           [](MultipleShooting& prog,
+          [](MultipleShooting& prog,
               const Eigen::Ref<const MatrixX<symbolic::Expression>>& g) {
-             prog.AddRunningCost(g);
-           },
-           doc.MultipleShooting.AddRunningCost.doc_0args)
+            prog.AddRunningCost(g);
+          },
+          doc.MultipleShooting.AddRunningCost.doc_0args)
       .def("AddConstraintToAllKnotPoints",
-           &MultipleShooting::AddConstraintToAllKnotPoints,
-           doc.MultipleShooting.AddConstraintToAllKnotPoints.doc)
+          &MultipleShooting::AddConstraintToAllKnotPoints,
+          doc.MultipleShooting.AddConstraintToAllKnotPoints.doc)
       .def("AddTimeIntervalBounds", &MultipleShooting::AddTimeIntervalBounds,
-           doc.MultipleShooting.AddTimeIntervalBounds.doc)
+          doc.MultipleShooting.AddTimeIntervalBounds.doc)
       .def("AddEqualTimeIntervalsConstraints",
-           &MultipleShooting::AddEqualTimeIntervalsConstraints,
-           doc.MultipleShooting.AddEqualTimeIntervalsConstraints.doc)
+          &MultipleShooting::AddEqualTimeIntervalsConstraints,
+          doc.MultipleShooting.AddEqualTimeIntervalsConstraints.doc)
       .def("AddDurationBounds", &MultipleShooting::AddDurationBounds,
-           doc.MultipleShooting.AddDurationBounds.doc)
+          doc.MultipleShooting.AddDurationBounds.doc)
       .def("AddFinalCost",
-           py::overload_cast<const symbolic::Expression&>(
-               &MultipleShooting::AddFinalCost),
-           doc.MultipleShooting.AddFinalCost.doc)
+          py::overload_cast<const symbolic::Expression&>(
+              &MultipleShooting::AddFinalCost),
+          doc.MultipleShooting.AddFinalCost.doc)
       .def("AddFinalCost",
-           py::overload_cast<
-               const Eigen::Ref<const MatrixX<symbolic::Expression>>&>(
-               &MultipleShooting::AddFinalCost),
-           doc.MultipleShooting.AddFinalCost.doc_2)
+          py::overload_cast<
+              const Eigen::Ref<const MatrixX<symbolic::Expression>>&>(
+              &MultipleShooting::AddFinalCost),
+          doc.MultipleShooting.AddFinalCost.doc_2)
       .def("AddInputTrajectoryCallback",
-           &MultipleShooting::AddInputTrajectoryCallback,
-           doc.MultipleShooting.AddInputTrajectoryCallback.doc)
+          &MultipleShooting::AddInputTrajectoryCallback,
+          doc.MultipleShooting.AddInputTrajectoryCallback.doc)
       .def("AddStateTrajectoryCallback",
-           &MultipleShooting::AddStateTrajectoryCallback,
-           doc.MultipleShooting.AddStateTrajectoryCallback.doc)
+          &MultipleShooting::AddStateTrajectoryCallback,
+          doc.MultipleShooting.AddStateTrajectoryCallback.doc)
       .def("SetInitialTrajectory", &MultipleShooting::SetInitialTrajectory,
-           doc.MultipleShooting.SetInitialTrajectory.doc)
+          doc.MultipleShooting.SetInitialTrajectory.doc)
       .def("GetSampleTimes",
-           overload_cast_explicit<Eigen::VectorXd>(
-               &MultipleShooting::GetSampleTimes),
-           doc.MultipleShooting.GetSampleTimes.doc_0args)
+          overload_cast_explicit<Eigen::VectorXd>(
+              &MultipleShooting::GetSampleTimes),
+          doc.MultipleShooting.GetSampleTimes.doc_0args)
       .def("GetInputSamples", &MultipleShooting::GetInputSamples,
-           doc.MultipleShooting.GetInputSamples.doc)
+          doc.MultipleShooting.GetInputSamples.doc)
       .def("GetStateSamples", &MultipleShooting::GetStateSamples,
-           doc.MultipleShooting.GetStateSamples.doc)
+          doc.MultipleShooting.GetStateSamples.doc)
       .def("ReconstructInputTrajectory",
-           &MultipleShooting::ReconstructInputTrajectory,
-           doc.MultipleShooting.ReconstructInputTrajectory.doc)
+          &MultipleShooting::ReconstructInputTrajectory,
+          doc.MultipleShooting.ReconstructInputTrajectory.doc)
       .def("ReconstructStateTrajectory",
-           &MultipleShooting::ReconstructStateTrajectory,
-           doc.MultipleShooting.ReconstructStateTrajectory.doc);
+          &MultipleShooting::ReconstructStateTrajectory,
+          doc.MultipleShooting.ReconstructStateTrajectory.doc);
 
-  py::class_<DirectCollocation, MultipleShooting>(m, "DirectCollocation",
-                                                  doc.DirectCollocation.doc)
+  py::class_<DirectCollocation, MultipleShooting>(
+      m, "DirectCollocation", doc.DirectCollocation.doc)
       .def(py::init<const systems::System<double>*,
-                    const systems::Context<double>&, int, double, double>(),
-           py::arg("system"), py::arg("context"), py::arg("num_time_samples"),
-           py::arg("minimum_timestep"), py::arg("maximum_timestep"),
-           doc.DirectCollocation.ctor.doc_5args)
+               const systems::Context<double>&, int, double, double>(),
+          py::arg("system"), py::arg("context"), py::arg("num_time_samples"),
+          py::arg("minimum_timestep"), py::arg("maximum_timestep"),
+          doc.DirectCollocation.ctor.doc_5args)
       .def("ReconstructInputTrajectory",
-           &DirectCollocation::ReconstructInputTrajectory,
-           doc.DirectCollocation.ReconstructInputTrajectory.doc)
+          &DirectCollocation::ReconstructInputTrajectory,
+          doc.DirectCollocation.ReconstructInputTrajectory.doc)
       .def("ReconstructStateTrajectory",
-           &DirectCollocation::ReconstructStateTrajectory,
-           doc.DirectCollocation.ReconstructStateTrajectory.doc);
+          &DirectCollocation::ReconstructStateTrajectory,
+          doc.DirectCollocation.ReconstructStateTrajectory.doc);
 
   py::class_<DirectCollocationConstraint, solvers::Constraint,
-             std::shared_ptr<DirectCollocationConstraint>>(
+      std::shared_ptr<DirectCollocationConstraint>>(
       m, "DirectCollocationConstraint", doc.DirectCollocationConstraint.doc)
       .def(py::init<const systems::System<double>&,
-                    const systems::Context<double>&>(),
-           doc.DirectCollocationConstraint.ctor.doc_2args);
+               const systems::Context<double>&>(),
+          doc.DirectCollocationConstraint.ctor.doc_2args);
 
   m.def("AddDirectCollocationConstraint", &AddDirectCollocationConstraint,
-        py::arg("constraint"), py::arg("timestep"), py::arg("state"),
-        py::arg("next_state"), py::arg("input"), py::arg("next_input"),
-        py::arg("prog"), doc.AddDirectCollocationConstraint.doc);
+      py::arg("constraint"), py::arg("timestep"), py::arg("state"),
+      py::arg("next_state"), py::arg("input"), py::arg("next_input"),
+      py::arg("prog"), doc.AddDirectCollocationConstraint.doc);
 
-  py::class_<DirectTranscription, MultipleShooting>(m, "DirectTranscription",
-                                                    doc.DirectTranscription.doc)
+  py::class_<DirectTranscription, MultipleShooting>(
+      m, "DirectTranscription", doc.DirectTranscription.doc)
       .def(py::init<const systems::System<double>*,
-                    const systems::Context<double>&, int>(),
-           py::arg("system"), py::arg("context"), py::arg("num_time_samples"),
-           doc.DirectTranscription.ctor.doc_3)
+               const systems::Context<double>&, int>(),
+          py::arg("system"), py::arg("context"), py::arg("num_time_samples"),
+          doc.DirectTranscription.ctor.doc_3)
       .def(py::init<const systems::LinearSystem<double>*,
-                    const systems::Context<double>&, int>(),
-           py::arg("system"), py::arg("context"), py::arg("num_time_samples"),
-           doc.DirectTranscription.ctor.doc_4)
+               const systems::Context<double>&, int>(),
+          py::arg("system"), py::arg("context"), py::arg("num_time_samples"),
+          doc.DirectTranscription.ctor.doc_4)
       // TODO(russt): Add this once TimeVaryingLinearSystem is bound.
       //      .def(py::init<const TimeVaryingLinearSystem<double>*,
       //                    const Context<double>&, int>())
       .def("ReconstructInputTrajectory",
-           &DirectTranscription::ReconstructInputTrajectory,
-           doc.DirectTranscription.ReconstructInputTrajectory.doc)
+          &DirectTranscription::ReconstructInputTrajectory,
+          doc.DirectTranscription.ReconstructInputTrajectory.doc)
       .def("ReconstructStateTrajectory",
-           &DirectTranscription::ReconstructStateTrajectory,
-           doc.DirectTranscription.ReconstructStateTrajectory.doc);
+          &DirectTranscription::ReconstructStateTrajectory,
+          doc.DirectTranscription.ReconstructStateTrajectory.doc);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/test/autodiffutils_test_util_py.cc
+++ b/bindings/pydrake/test/autodiffutils_test_util_py.cc
@@ -16,11 +16,11 @@ PYBIND11_MODULE(autodiffutils_test_util, m) {
 
   // For testing implicit argument conversion.
   m.def("autodiff_scalar_pass_through",
-        [](const AutoDiffXd& value) { return value; });
+      [](const AutoDiffXd& value) { return value; });
   m.def("autodiff_vector_pass_through",
-        [](const VectorX<AutoDiffXd>& value) { return value; });
+      [](const VectorX<AutoDiffXd>& value) { return value; });
   m.def("autodiff_vector3_pass_through",
-        [](const Vector3<AutoDiffXd>& value) { return value; });
+      [](const Vector3<AutoDiffXd>& value) { return value; });
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/test/odr_test_module_py.cc
+++ b/bindings/pydrake/test/odr_test_module_py.cc
@@ -13,7 +13,7 @@ PYBIND11_MODULE(odr_test_module, m) {
   m.doc() = "Test ODR using Variable.";
 
   m.def("new_variable",
-        [](const std::string& name) { return new Variable(name); });
+      [](const std::string& name) { return new Variable(name); });
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -19,87 +19,86 @@ PYBIND11_MODULE(trajectories, m) {
 
   py::class_<Trajectory<T>>(m, "Trajectory", doc.Trajectory.doc);
 
-  py::class_<PiecewiseTrajectory<T>, Trajectory<T>>(m, "PiecewiseTrajectory",
-                                                    doc.PiecewiseTrajectory.doc)
+  py::class_<PiecewiseTrajectory<T>, Trajectory<T>>(
+      m, "PiecewiseTrajectory", doc.PiecewiseTrajectory.doc)
       .def("get_number_of_segments",
-           &PiecewiseTrajectory<T>::get_number_of_segments,
-           doc.PiecewiseTrajectory.get_number_of_segments.doc)
+          &PiecewiseTrajectory<T>::get_number_of_segments,
+          doc.PiecewiseTrajectory.get_number_of_segments.doc)
       .def("start_time",
-           overload_cast_explicit<double, int>(
-               &PiecewiseTrajectory<T>::start_time),
-           doc.PiecewiseTrajectory.start_time.doc_1args)
+          overload_cast_explicit<double, int>(
+              &PiecewiseTrajectory<T>::start_time),
+          doc.PiecewiseTrajectory.start_time.doc_1args)
       .def("end_time",
-           overload_cast_explicit<double, int>(
-               &PiecewiseTrajectory<T>::end_time),
-           doc.PiecewiseTrajectory.end_time.doc_1args)
+          overload_cast_explicit<double, int>(
+              &PiecewiseTrajectory<T>::end_time),
+          doc.PiecewiseTrajectory.end_time.doc_1args)
       .def("duration", &PiecewiseTrajectory<T>::duration,
-           doc.PiecewiseTrajectory.duration.doc)
+          doc.PiecewiseTrajectory.duration.doc)
       .def("start_time",
-           overload_cast_explicit<double>(&PiecewiseTrajectory<T>::start_time),
-           doc.PiecewiseTrajectory.start_time.doc_0args)
+          overload_cast_explicit<double>(&PiecewiseTrajectory<T>::start_time),
+          doc.PiecewiseTrajectory.start_time.doc_0args)
       .def("end_time",
-           overload_cast_explicit<double>(&PiecewiseTrajectory<T>::end_time),
-           doc.PiecewiseTrajectory.end_time.doc_0args)
+          overload_cast_explicit<double>(&PiecewiseTrajectory<T>::end_time),
+          doc.PiecewiseTrajectory.end_time.doc_0args)
       .def("get_segment_index", &PiecewiseTrajectory<T>::get_segment_index,
-           doc.PiecewiseTrajectory.get_segment_index.doc)
+          doc.PiecewiseTrajectory.get_segment_index.doc)
       .def("get_segment_times", &PiecewiseTrajectory<T>::get_segment_times,
-           doc.PiecewiseTrajectory.get_segment_times.doc);
+          doc.PiecewiseTrajectory.get_segment_times.doc);
 
   py::class_<PiecewisePolynomial<T>, PiecewiseTrajectory<T>>(
       m, "PiecewisePolynomial", doc.PiecewisePolynomial.doc)
       .def(py::init<>(), doc.PiecewisePolynomial.ctor.doc_3)
       .def(py::init<const Eigen::Ref<const MatrixX<T>>&>(),
-           doc.PiecewisePolynomial.ctor.doc_4)
+          doc.PiecewisePolynomial.ctor.doc_4)
       .def_static("ZeroOrderHold",
-                  py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
-                                    const Eigen::Ref<const MatrixX<T>>&>(
-                      &PiecewisePolynomial<T>::ZeroOrderHold),
-                  doc.PiecewisePolynomial.ZeroOrderHold.doc)
+          py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
+              const Eigen::Ref<const MatrixX<T>>&>(
+              &PiecewisePolynomial<T>::ZeroOrderHold),
+          doc.PiecewisePolynomial.ZeroOrderHold.doc)
       .def_static("FirstOrderHold",
-                  py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
-                                    const Eigen::Ref<const MatrixX<T>>&>(
-                      &PiecewisePolynomial<T>::FirstOrderHold),
-                  doc.PiecewisePolynomial.FirstOrderHold.doc)
+          py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
+              const Eigen::Ref<const MatrixX<T>>&>(
+              &PiecewisePolynomial<T>::FirstOrderHold),
+          doc.PiecewisePolynomial.FirstOrderHold.doc)
       .def_static("Pchip",
-                  py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
-                                    const Eigen::Ref<const MatrixX<T>>&, bool>(
-                      &PiecewisePolynomial<T>::Pchip),
-                  doc.PiecewisePolynomial.Pchip.doc)
+          py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
+              const Eigen::Ref<const MatrixX<T>>&, bool>(
+              &PiecewisePolynomial<T>::Pchip),
+          doc.PiecewisePolynomial.Pchip.doc)
       .def_static("Cubic",
-                  py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
-                                    const Eigen::Ref<const MatrixX<T>>&,
-                                    const Eigen::Ref<const VectorX<T>>&,
-                                    const Eigen::Ref<const VectorX<T>>&>(
-                      &PiecewisePolynomial<T>::Cubic),
-                  py::arg("breaks"), py::arg("knots"),
-                  py::arg("knot_dot_start"), py::arg("knot_dot_end"),
-                  doc.PiecewisePolynomial.Cubic.doc)
+          py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
+              const Eigen::Ref<const MatrixX<T>>&,
+              const Eigen::Ref<const VectorX<T>>&,
+              const Eigen::Ref<const VectorX<T>>&>(
+              &PiecewisePolynomial<T>::Cubic),
+          py::arg("breaks"), py::arg("knots"), py::arg("knot_dot_start"),
+          py::arg("knot_dot_end"), doc.PiecewisePolynomial.Cubic.doc)
       .def_static("Cubic",
-                  py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
-                                    const Eigen::Ref<const MatrixX<T>>&,
-                                    const Eigen::Ref<const MatrixX<T>>&>(
-                      &PiecewisePolynomial<T>::Cubic),
-                  py::arg("breaks"), py::arg("knots"), py::arg("knots_dot"),
-                  doc.PiecewisePolynomial.Cubic.doc_2)
+          py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
+              const Eigen::Ref<const MatrixX<T>>&,
+              const Eigen::Ref<const MatrixX<T>>&>(
+              &PiecewisePolynomial<T>::Cubic),
+          py::arg("breaks"), py::arg("knots"), py::arg("knots_dot"),
+          doc.PiecewisePolynomial.Cubic.doc_2)
       .def_static("Cubic",
-                  py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
-                                    const Eigen::Ref<const MatrixX<T>>&, bool>(
-                      &PiecewisePolynomial<T>::Cubic),
-                  py::arg("breaks"), py::arg("knots"), py::arg("periodic_end"),
-                  doc.PiecewisePolynomial.Cubic.doc_3)
+          py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
+              const Eigen::Ref<const MatrixX<T>>&, bool>(
+              &PiecewisePolynomial<T>::Cubic),
+          py::arg("breaks"), py::arg("knots"), py::arg("periodic_end"),
+          doc.PiecewisePolynomial.Cubic.doc_3)
       .def("value", &PiecewisePolynomial<T>::value,
-           doc.PiecewisePolynomial.value.doc)
+          doc.PiecewisePolynomial.value.doc)
       .def("derivative", &PiecewisePolynomial<T>::derivative,
-           doc.PiecewisePolynomial.derivative.doc)
+          doc.PiecewisePolynomial.derivative.doc)
       .def("rows", &PiecewisePolynomial<T>::rows,
-           doc.PiecewisePolynomial.rows.doc)
+          doc.PiecewisePolynomial.rows.doc)
       .def("cols", &PiecewisePolynomial<T>::cols,
-           doc.PiecewisePolynomial.cols.doc)
+          doc.PiecewisePolynomial.cols.doc)
       .def("slice", &PiecewisePolynomial<T>::slice,
-           py::arg("start_segment_index"), py::arg("num_segments"),
-           doc.PiecewisePolynomial.slice.doc)
+          py::arg("start_segment_index"), py::arg("num_segments"),
+          doc.PiecewisePolynomial.slice.doc)
       .def("shiftRight", &PiecewisePolynomial<T>::shiftRight, py::arg("offset"),
-           doc.PiecewisePolynomial.shiftRight.doc);
+          doc.PiecewisePolynomial.shiftRight.doc);
 }
 
 }  // namespace pydrake

--- a/tools/vector_gen/test/goal/sample_translator.cc
+++ b/tools/vector_gen/test/goal/sample_translator.cc
@@ -16,8 +16,8 @@ SampleTranslator::AllocateOutputVector() const {
   return std::make_unique<Sample<double>>();
 }
 
-void SampleTranslator::Serialize(
-    double time, const drake::systems::VectorBase<double>& vector_base,
+void SampleTranslator::Serialize(double time,
+    const drake::systems::VectorBase<double>& vector_base,
     std::vector<uint8_t>* lcm_message_bytes) const {
   const auto* const vector = dynamic_cast<const Sample<double>*>(&vector_base);
   DRAKE_DEMAND(vector != nullptr);
@@ -32,8 +32,8 @@ void SampleTranslator::Serialize(
   message.encode(lcm_message_bytes->data(), 0, lcm_message_length);
 }
 
-void SampleTranslator::Deserialize(
-    const void* lcm_message_bytes, int lcm_message_length,
+void SampleTranslator::Deserialize(const void* lcm_message_bytes,
+    int lcm_message_length,
     drake::systems::VectorBase<double>* vector_base) const {
   DRAKE_DEMAND(vector_base != nullptr);
   auto* const my_vector = dynamic_cast<Sample<double>*>(vector_base);

--- a/tools/vector_gen/test/goal/sample_translator.h
+++ b/tools/vector_gen/test/goal/sample_translator.h
@@ -26,10 +26,10 @@ class SampleTranslator final
   std::unique_ptr<drake::systems::BasicVector<double>> AllocateOutputVector()
       const final;
   void Deserialize(const void* lcm_message_bytes, int lcm_message_length,
-                   drake::systems::VectorBase<double>* vector_base) const final;
+      drake::systems::VectorBase<double>* vector_base) const final;
   void Serialize(double time,
-                 const drake::systems::VectorBase<double>& vector_base,
-                 std::vector<uint8_t>* lcm_message_bytes) const final;
+      const drake::systems::VectorBase<double>& vector_base,
+      std::vector<uint8_t>* lcm_message_bytes) const final;
 };
 
 }  // namespace test


### PR DESCRIPTION
This style is more horizontally compact, which tends to make the bindings slightly easier to read.  Also, as we start to format non-wrapper code such as `//bindings/pydrake/common` this indentation style will better match the prevailing Drake habits.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10074)
<!-- Reviewable:end -->
