### PR TITLE
Adds optional camera_pose input port to DepthImageToPointCloud

### DIFF
--- a/perception/BUILD.bazel
+++ b/perception/BUILD.bazel
@@ -46,6 +46,7 @@ drake_cc_library(
     deps = [
         ":point_cloud",
         "//common:essential",
+        "//math:geometric_transform",
         "//systems/framework",
         "//systems/sensors:camera_info",
         "//systems/sensors:image",

--- a/perception/depth_image_to_point_cloud.h
+++ b/perception/depth_image_to_point_cloud.h
@@ -17,8 +17,16 @@ namespace perception {
 /// Converts a depth image to a point cloud.
 /// Basically a system that wraps around ConvertDepthImageToPointCloud in
 /// RGBDCamera.
-/// The system has a single input port that takes a ImageDepth32F and a single
-/// output port that contains a PointCloud.
+/// The system has a single input port that takes a
+/// systems::sensors::ImageDepth32F and a single output port that contains a
+/// PointCloud.
+///
+/// @system{ DepthImageToPointCloud,
+///          @input_port{depth_image},
+///          @output_port{point_cloud}
+/// }
+///
+/// @ingroup perception_systems
 class DepthImageToPointCloud final : public systems::LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DepthImageToPointCloud)

--- a/perception/depth_image_to_point_cloud.h
+++ b/perception/depth_image_to_point_cloud.h
@@ -15,16 +15,21 @@ namespace drake {
 namespace perception {
 
 /// Converts a depth image to a point cloud.
-/// Basically a system that wraps around ConvertDepthImageToPointCloud in
-/// RGBDCamera.
-/// The system has a single input port that takes a
-/// systems::sensors::ImageDepth32F and a single output port that contains a
-/// PointCloud.
 ///
 /// @system{ DepthImageToPointCloud,
-///          @input_port{depth_image},
+///          @input_port{depth_image}
+///          @input_port{camera_pose (optional)},
 ///          @output_port{point_cloud}
 /// }
+///
+/// The system has an input port that takes a
+/// systems::sensors::ImageDepth32F and an additional optional input port
+/// that takes a math::RigidTransform for the camera_pose.  If this port is
+/// connected, then the point cloud is represented in the parent frame (e.g.
+/// if camera_pose is the pose of the camera in the world frame, then the
+/// point_cloud output will be a PointCloud in the world frame).  If
+/// the camera_pose input is not connected, the PointCloud will be represented
+/// in the camera frame.
 ///
 /// @ingroup perception_systems
 class DepthImageToPointCloud final : public systems::LeafSystem<double> {
@@ -39,7 +44,12 @@ class DepthImageToPointCloud final : public systems::LeafSystem<double> {
 
   /// Returns the abstract valued input port that contains an ImageDepth32F.
   const systems::InputPort<double>& depth_image_input_port() const {
-    return this->get_input_port(input_port_depth_image_index_);
+    return this->get_input_port(depth_image_input_port_);
+  }
+
+  /// Returns the abstract valued input port that contains an Isometry3d.
+  const systems::InputPort<double>& camera_pose_input_port() const {
+    return this->get_input_port(camera_pose_input_port_);
   }
 
   /// Returns the abstract valued output port that contains a PointCloud.
@@ -76,7 +86,8 @@ class DepthImageToPointCloud final : public systems::LeafSystem<double> {
   void ConvertDepthImageToPointCloud(const systems::Context<double>& context,
                                      PointCloud* output) const;
 
-  int input_port_depth_image_index_{-1};
+  systems::InputPortIndex depth_image_input_port_{};
+  systems::InputPortIndex camera_pose_input_port_{};
 
   const systems::sensors::CameraInfo& camera_info_;
 };

--- a/perception/point_cloud.h
+++ b/perception/point_cloud.h
@@ -37,7 +37,7 @@ namespace perception {
 /// This point cloud class provides the following fields:
 ///
 /// - xyz - Cartesian XYZ coordinates (float[3]).
-/// - descriptor - An descriptor that is run-time defined (float[X]).
+/// - descriptor - A descriptor that is run-time defined (float[X]).
 ///
 /// @note "contiguous" here means contiguous in memory. This was chosen to
 /// avoid ambiguity between PCL and Eigen, where in PCL "dense" implies that

--- a/systems/systems.h
+++ b/systems/systems.h
@@ -31,6 +31,7 @@
 ///   @defgroup automotive_systems Automotive Systems
 ///   @defgroup manipulation_systems Manipulation
 ///   @defgroup message_passing Message Passing
+///   @defgroup perception_systems Perception
 ///   @defgroup stochastic_systems Stochastic Systems
 ///   @defgroup visualization Visualization
 ///   @defgroup example_systems Examples
@@ -73,6 +74,12 @@
 /// @}
 // TODO(russt): Add pointers to / recommendations for connecting to ROS.
 // TODO(russt): Add ZMQ.
+
+/// @addtogroup perception_systems
+/// @{
+/// @brief Systems for dealing with perception data and/or wrapping basic
+/// perception algorithms.
+/// @}
 
 /// @addtogroup visualization
 /// @{


### PR DESCRIPTION
The handling of kTooClose, kTooFar, etc is pretty coupled with the implementation of this system.  I felt it was better to slightly generalize the system than to add additional transformers outside the system that had to rely on the internal representation assumptions.  

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10080)
<!-- Reviewable:end -->
