### PR TITLE
common: Add variant<> support

### DIFF
--- a/bindings/pydrake/common/BUILD.bazel
+++ b/bindings/pydrake/common/BUILD.bazel
@@ -190,6 +190,13 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "drake_variant_pybind",
+    hdrs = ["drake_variant_pybind.h"],
+    declare_installed_headers = 0,
+    visibility = ["//visibility:public"],
+)
+
+drake_cc_library(
     name = "type_safe_index_pybind",
     hdrs = ["type_safe_index_pybind.h"],
     declare_installed_headers = 0,
@@ -352,6 +359,13 @@ drake_pybind_cc_googletest(
         "//common/test_utilities:expect_throws_message",
     ],
     py_deps = [":cpp_template_py"],
+)
+
+drake_pybind_cc_googletest(
+    name = "drake_variant_pybind_test",
+    cc_deps = [
+        ":drake_variant_pybind",
+    ],
 )
 
 drake_pybind_library(

--- a/bindings/pydrake/common/drake_variant_pybind.h
+++ b/bindings/pydrake/common/drake_variant_pybind.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "pybind11/stl.h"
+
+#include "drake/common/drake_variant.h"
+
+namespace pybind11 {
+namespace detail {
+
+// Ensure that we expose a type_caster for `stx::variant`.
+// @see pybind11/stl.h, `variant_caster`.
+
+template <typename... Types>
+struct type_caster<stx::variant<Types...>> :
+    public variant_caster<stx::variant<Types...>> {};
+
+}  // namespace detail
+}  // namespace pybind11

--- a/bindings/pydrake/common/test/drake_variant_pybind_test.cc
+++ b/bindings/pydrake/common/test/drake_variant_pybind_test.cc
@@ -1,0 +1,58 @@
+#include "drake/bindings/pydrake/common/drake_variant_pybind.h"
+
+#include <string>
+#include <vector>
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+#include "pybind11/embed.h"
+#include "pybind11/eval.h"
+#include "pybind11/pybind11.h"
+
+#include "drake/bindings/pydrake/pydrake_pybind.h"
+
+using std::string;
+
+namespace drake {
+namespace pydrake {
+namespace {
+
+string VariantToString(const variant<int, double, string>& value) {
+  const bool is_int = holds_alternative<int>(value);
+  const bool is_double = holds_alternative<double>(value);
+  const bool is_string = holds_alternative<string>(value);
+  return
+      is_int ? fmt::format("int({})", get<int>(value)) :
+      is_double ? fmt::format("double({})", get<double>(value)) :
+      is_string ? fmt::format("string({})", get<string>(value)) :
+      "FAILED";
+}
+
+void ExpectString(const string& expr, const string& expected) {
+  EXPECT_EQ(py::eval(expr).cast<string>(), expected) << expr;
+}
+
+GTEST_TEST(VariantTest, CheckCasting) {
+  py::module m("__main__");
+
+  m.def("VariantToString", &VariantToString, py::arg("value"));
+  ExpectString("VariantToString(1)", "int(1)");
+  ExpectString("VariantToString(0.5)", "double(0.5)");
+  ExpectString("VariantToString('foo')", "string(foo)");
+}
+
+int main(int argc, char** argv) {
+  // Reconstructing `scoped_interpreter` multiple times (e.g. via `SetUp()`)
+  // while *also* importing `numpy` wreaks havoc.
+  py::scoped_interpreter guard;
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+
+}  // namespace
+}  // namespace pydrake
+}  // namespace drake
+
+int main(int argc, char** argv) {
+  return drake::pydrake::main(argc, argv);
+}

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -68,6 +68,7 @@ drake_cc_library(
         "drake_deprecated.h",
         "drake_optional.h",
         "drake_throw.h",
+        "drake_variant.h",
         "eigen_stl_types.h",
         "eigen_types.h",
         "never_destroyed.h",
@@ -699,6 +700,13 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "drake_throw_test",
+    deps = [
+        ":essential",
+    ],
+)
+
+drake_cc_googletest(
+    name = "drake_variant_test",
     deps = [
         ":essential",
     ],

--- a/common/drake_optional.h
+++ b/common/drake_optional.h
@@ -1,5 +1,12 @@
 #pragma once
 
+// Due to https://github.com/tcbrindle/cpp17_headers/issues/4, we must always
+// include variant before optional.  Rather than leaving that up to our users,
+// we force the issue here.  Note that this does NOT place stx::variant into
+// the drake namespace, so users still need to include drake_variant.h in order
+// to use variants.
+#include <stx/variant.hpp>
+
 // As of our currently supported platforms (Ubuntu 16.04 Xenial and macOS 10.13
 // High Sierra), the std::experimental::optional implementations for libstdc++
 // and libc++ lack some C++17 features, such as std::optional::has_value() or

--- a/common/drake_variant.h
+++ b/common/drake_variant.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <stx/variant.hpp>
+
+/// @file
+/// Provides drake::variant as an alias for the appropriate implementation of
+/// std::variant or or stx::variant for the C++ toolchain being used.
+
+namespace drake {
+
+template <typename... Types>
+using variant = stx::variant<Types...>;
+
+using stx::get;
+using stx::holds_alternative;
+
+// N.B. We don't alias stx::get_if, because it's signature (reference argument)
+// differs from what was standardized (pointer argument).
+
+}  // namespace drake

--- a/common/test/drake_variant_test.cc
+++ b/common/test/drake_variant_test.cc
@@ -1,0 +1,57 @@
+#include "drake/common/drake_variant.h"
+
+#include <stdexcept>
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace {
+
+struct Squared {
+  double operator()(double arg) { return arg * arg; }
+};
+
+GTEST_TEST(VariantTest, BasicTest) {
+  // Default.
+  variant<int, double> dut;
+  EXPECT_EQ(dut.index(), 0);
+  EXPECT_EQ(get<int>(dut), 0);
+  EXPECT_EQ(get<0>(dut), 0);
+
+  // Assign int.
+  dut = 11;
+  EXPECT_EQ(dut.index(), 0);
+  EXPECT_EQ(get<int>(dut), 11);
+  EXPECT_EQ(get<0>(dut), 11);
+
+  // Assign double.
+  dut = 1.23;
+  EXPECT_EQ(dut.index(), 1);
+  EXPECT_EQ(get<1>(dut), 1.23);
+  EXPECT_EQ(get<double>(dut), 1.23);
+
+  // Comparison.
+  dut = 22;
+  variant<int, double> other = 1.1;
+  EXPECT_LT(dut, other);
+  EXPECT_NE(dut, other);
+  EXPECT_EQ(dut, dut);
+
+  // Visiting.
+  dut = 2;
+  EXPECT_EQ(visit(Squared{}, dut), 4.0);
+  dut = 0.5;
+  EXPECT_EQ(visit(Squared{}, dut), 0.25);
+
+  // Checking the alternatives.
+  dut = 22;
+  EXPECT_TRUE(holds_alternative<int>(dut));
+  EXPECT_FALSE(holds_alternative<double>(dut));
+
+  // Bad access.
+  dut = 0;
+  EXPECT_THROW(get<double>(dut), std::logic_error);
+}
+
+}  // namespace
+}  // namespace drake

--- a/tools/workspace/stx/package.BUILD.bazel
+++ b/tools/workspace/stx/package.BUILD.bazel
@@ -13,7 +13,10 @@ package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "stx",
-    hdrs = ["include/stx/optional.hpp"],
+    hdrs = [
+        "include/stx/optional.hpp",
+        "include/stx/variant.hpp",
+    ],
     includes = ["include"],
 )
 


### PR DESCRIPTION
We want this for Anzu, but it's easier to PR to Drake right away.

A sample Drake use of this is shown in #10089.  There are also several other TODOs in Drake for "we should use variant here".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10088)
<!-- Reviewable:end -->
