### PR TITLE
Add Context-modifying API

### DIFF
--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -571,6 +571,29 @@ void GeometryState<T>::ExcludeCollisionsBetween(const GeometrySet& setA,
 }
 
 template <typename T>
+bool GeometryState<T>::CollisionFiltered(GeometryId id1, GeometryId id2) const {
+  const internal::InternalGeometry* geometry1 = GetGeometry(id1);
+  const internal::InternalGeometry* geometry2 = GetGeometry(id2);
+  if (geometry1 != nullptr && geometry2 != nullptr) {
+    return geometry_engine_->CollisionFiltered(
+        geometry1->index(), geometry1->is_dynamic(),
+        geometry2->index(), geometry2->is_dynamic());
+  }
+  std::string base_message =
+      "Can't report collision filter status between geometries " +
+      to_string(id1) + " and " + to_string(id2) + "; ";
+  if (geometry1 != nullptr) {
+    throw std::logic_error(base_message + to_string(id2) +
+                           " is not a valid geometry");
+  } else if (geometry2 != nullptr) {
+    throw std::logic_error(base_message + to_string(id1) +
+        " is not a valid geometry");
+  } else {
+    throw std::logic_error(base_message + "neither id is a valid geometry");
+  }
+}
+
+template <typename T>
 std::unique_ptr<GeometryState<AutoDiffXd>> GeometryState<T>::ToAutoDiffXd()
     const {
   return std::unique_ptr<GeometryState<AutoDiffXd>>(

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -456,6 +456,13 @@ class GeometryState {
   void ExcludeCollisionsBetween(const GeometrySet& setA,
                                 const GeometrySet& setB);
 
+  /** Reports true if the collision pair (id1, id2) has been filtered out.
+   @throws std::logic_error if either id does not reference a registered
+                            geometry.  */
+  bool CollisionFiltered(GeometryId id1, GeometryId id2) const;
+
+  //@}
+
   //---------------------------------------------------------------------------
   /** @name                Signed Distance Queries
 

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -944,6 +944,16 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     }
   }
 
+  bool CollisionFiltered(GeometryIndex index1, bool is_dynamic_1,
+                         GeometryIndex index2, bool is_dynamic_2) const {
+    // Collisions between anchored geometries are implicitly filtered.
+    if (!is_dynamic_1 && !is_dynamic_2) return true;
+    EncodedData encoding1(index1, is_dynamic_1);
+    EncodedData encoding2(index2, is_dynamic_2);
+    return !collision_filter_.CanCollideWith(encoding1.encoded_data(),
+                                             encoding2.encoded_data());
+  }
+
   int get_next_clique() { return collision_filter_.next_clique_id(); }
 
   void set_clique(GeometryIndex index, int clique) {
@@ -1241,6 +1251,13 @@ void ProximityEngine<T>::ExcludeCollisionsBetween(
     const std::unordered_set<GeometryIndex>& dynamic2,
     const std::unordered_set<GeometryIndex>& anchored2) {
   impl_->ExcludeCollisionsBetween(dynamic1, anchored1, dynamic2, anchored2);
+}
+
+template <typename T>
+bool ProximityEngine<T>::CollisionFiltered(
+    GeometryIndex index1, bool is_dynamic_1,
+    GeometryIndex index2, bool is_dynamic_2) const {
+  return impl_->CollisionFiltered(index1, is_dynamic_1, index2, is_dynamic_2);
 }
 
 // Client-attorney interface for GeometryState to manipulate collision filters.

--- a/geometry/proximity_engine.h
+++ b/geometry/proximity_engine.h
@@ -246,6 +246,10 @@ class ProximityEngine {
       const std::unordered_set<GeometryIndex>& dynamic2,
       const std::unordered_set<GeometryIndex>& anchored2);
 
+  /** Reports true if the geometry pair (index1, index2) has been filtered from
+   collision.  */
+  bool CollisionFiltered(GeometryIndex index1, bool is_dynamic_1,
+                         GeometryIndex index2, bool is_dynamic_2) const;
   //@}
 
  private:

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -174,11 +174,30 @@ GeometryId SceneGraph<T>::RegisterGeometry(
 
 template <typename T>
 GeometryId SceneGraph<T>::RegisterGeometry(
+    Context<T>* context, SourceId source_id, FrameId frame_id,
+    std::unique_ptr<GeometryInstance> geometry) {
+  auto* g_context = static_cast<GeometryContext<T>*>(context);
+  auto& g_state = g_context->get_mutable_geometry_state();
+  return g_state.RegisterGeometry(source_id, frame_id, std::move(geometry));
+}
+
+template <typename T>
+GeometryId SceneGraph<T>::RegisterGeometry(
     SourceId source_id, GeometryId geometry_id,
     std::unique_ptr<GeometryInstance> geometry) {
   GS_THROW_IF_CONTEXT_ALLOCATED
   return initial_state_->RegisterGeometryWithParent(source_id, geometry_id,
                                                     std::move(geometry));
+}
+
+template <typename T>
+GeometryId SceneGraph<T>::RegisterGeometry(
+    Context<T>* context, SourceId source_id, GeometryId geometry_id,
+    std::unique_ptr<GeometryInstance> geometry) {
+  auto* g_context = static_cast<GeometryContext<T>*>(context);
+  auto& g_state = g_context->get_mutable_geometry_state();
+  return g_state.RegisterGeometryWithParent(source_id, geometry_id,
+                                            std::move(geometry));
 }
 
 template <typename T>
@@ -196,6 +215,14 @@ void SceneGraph<T>::RemoveGeometry(SourceId source_id, GeometryId geometry_id) {
 }
 
 template <typename T>
+void SceneGraph<T>::RemoveGeometry(Context<T>* context, SourceId source_id,
+                                   GeometryId geometry_id) {
+  auto* g_context = static_cast<GeometryContext<T>*>(context);
+  auto& g_state = g_context->get_mutable_geometry_state();
+  g_state.RemoveGeometry(source_id, geometry_id);
+}
+
+template <typename T>
 const SceneGraphInspector<T>& SceneGraph<T>::model_inspector() const {
   GS_THROW_IF_CONTEXT_ALLOCATED
   return model_inspector_;
@@ -208,10 +235,27 @@ void SceneGraph<T>::ExcludeCollisionsWithin(const GeometrySet& geometry_set) {
 }
 
 template <typename T>
+void SceneGraph<T>::ExcludeCollisionsWithin(Context<T>* context,
+                                            const GeometrySet& geometry_set) {
+  auto* g_context = static_cast<GeometryContext<T>*>(context);
+  auto& g_state = g_context->get_mutable_geometry_state();
+  g_state.ExcludeCollisionsWithin(geometry_set);
+}
+
+template <typename T>
 void SceneGraph<T>::ExcludeCollisionsBetween(const GeometrySet& setA,
                                              const GeometrySet& setB) {
   GS_THROW_IF_CONTEXT_ALLOCATED
   initial_state_->ExcludeCollisionsBetween(setA, setB);
+}
+
+template <typename T>
+void SceneGraph<T>::ExcludeCollisionsBetween(Context<T>* context,
+                                             const GeometrySet& setA,
+                                             const GeometrySet& setB) {
+  auto* g_context = static_cast<GeometryContext<T>*>(context);
+  auto& g_state = g_context->get_mutable_geometry_state();
+  g_state.ExcludeCollisionsBetween(setA, setB);
 }
 
 template <typename T>

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -181,6 +181,23 @@ class QueryObject;
 
  Failure to meet these requirements will lead to a run-time error.
 
+ @section geom_model_vs_context Model versus Context
+
+ Many (and eventually all) methods that configure the population of SceneGraph
+ have two variants that differ by whether they accept a mutable Context or not.
+ When no Context is provided, _this_ %SceneGraph instance's underlying model is
+ modified. When the %SceneGraph instance allocates a context, its model is
+ copied into that context.
+
+ The second variant causes %SceneGraph to modify the data stored in the provided
+ Context to be modified _instead of the internal model_.
+
+ @note In this initial version, the only methods with the Context-modifying
+ variant are those methods that _do not_ change the the semantics of the input
+ or output ports. Modifications that make such changes must be coordinated
+ across systems.
+ <!-- TODO(SeanCurtis-TRI): Add context-modifying variants of all methods. -->
+
  @cond
  // TODO(SeanCurtis-TRI): Future work which will require add'l documentation:
  //   - velocity kinematics.
@@ -270,31 +287,38 @@ class SceneGraph final : public systems::LeafSystem<T> {
    This includes registering a new geometry source, adding or
    removing frames, and adding or removing geometries.
 
-   Currently, the topology can only be manipulated during initialization.
-   Eventually, the API will expand to include modifications of the topology
-   during discrete updates.
+   The work flow for adding geometry to the SceneGraph is as follows:
 
-   The initialization phase begins with the instantiation of a %SceneGraph
-   and ends when a context is allocated by the %SceneGraph instance. This is
-   the only phase when geometry sources can be registered with %SceneGraph.
-   Once a source is registered, it can register frames and geometries. Any
-   frames and geometries registered during this phase become part of the
-   _default_ context state for %SceneGraph and calls to
-   CreateDefaultContext() will produce identical contexts.
+   - A geometry source registers itself with %SceneGraph (via RegisterSource()).
+   - The geometry source can then immediately register "anchored" geometry --
+     geometry that is affixed to the world frame. These geometries will never
+     move.
+   - For geometries that need to move based on the source's state, the
+     geometry source must first register a GeometryFrame. In fact, geometries
+     never move directly; it is the frames to which they are affixed that move.
+     A geometry source can register a frame via the RegisterFrame() methods.
+   - Once a frame has been registered, the geometry source can register
+     geometries that are rigidly affixed to that frame (or, figuratively
+     speaking, "hung" on that frame). The geometry is immovably posed in that
+     frame and assigned various properties. The geometry is registered via calls
+     to the RegisterGeometry() methods.
 
-   Every geometry must ultimately be associated with a parent frame.
-   The position of every geometry in the world depends on a hierarchy of frames
-   between it and the world. The pose of a geometry is described relative
-   to its parent (a frame or another geometry). That parent may, in turn, also
-   have a parent. So, the position of a particular geometry in the world frame
-   depends on all of its ancestors which lie between it and the world frame. The
-   act of assigning a frame or geometry as a child to another frame or geometry
-   (as appropriate) and defining its pose, is referred to colloquially has
-   "hanging" it on the parent.
+   %SceneGraph has a concept of "ownership" that is separate from the C++
+   notion of ownership. In this case, %SceneGraph protects geometry and frames
+   registered by one source from being modified by another source. All methods
+   that change the world are associated with the SourceId of the geometry source
+   requesting the change. One source cannot "hang" geometry onto a frame (or
+   geometry) that belongs to another source. However, all sources have read
+   access to all geometries in the world. For example, queries will return
+   GeometryId values that span all sources and the properties of the associated
+   geometries can be queried by arbitrary sources.
 
-   Geometry sources can only hang frames or geometries onto other frames and/or
-   geometries that it "owns".
-   */
+   That said, if one source _chooses_ to share its SourceId externally, then
+   arbitrary code can use that SourceId to modify the geometry resources that
+   are associated with that SourceId.
+
+   @note There are no Context-modifying variants for source or frame
+   registration yet, as these methods modify the port semantics.  */
   //@{
 
   /** Registers a new frame F on for this source. This hangs frame F on the
@@ -342,6 +366,13 @@ class SceneGraph final : public systems::LeafSystem<T> {
   GeometryId RegisterGeometry(SourceId source_id, FrameId frame_id,
                               std::unique_ptr<GeometryInstance> geometry);
 
+  /** systems::Context-modifying variant of RegisterGeometry(). Rather than
+   modifying %SceneGraph's model, it modifies the copy of the model stored in
+   the provided context.  */
+  GeometryId RegisterGeometry(systems::Context<T>* context, SourceId source_id,
+                              FrameId frame_id,
+                              std::unique_ptr<GeometryInstance> geometry);
+
   /** Registers a new geometry G for this source. This hangs geometry G on a
    previously registered geometry P (indicated by `geometry_id`). The pose of
    the geometry is defined in a fixed pose relative to geometry P (i.e.,
@@ -360,6 +391,13 @@ class SceneGraph final : public systems::LeafSystem<T> {
                             5. the geometry's name doesn't satisfy the
                             requirements outlined in GeometryInstance.  */
   GeometryId RegisterGeometry(SourceId source_id, GeometryId geometry_id,
+                              std::unique_ptr<GeometryInstance> geometry);
+
+  /** systems::Context-modifying variant of RegisterGeometry(). Rather than
+   modifying %SceneGraph's model, it modifies the copy of the model stored in
+   the provided context.  */
+  GeometryId RegisterGeometry(systems::Context<T>* context, SourceId source_id,
+                              GeometryId geometry_id,
                               std::unique_ptr<GeometryInstance> geometry);
 
   /** Registers a new _anchored_ geometry G for this source. This hangs geometry
@@ -387,6 +425,12 @@ class SceneGraph final : public systems::LeafSystem<T> {
                                or
                             3. a context has been allocated. */
   void RemoveGeometry(SourceId source_id, GeometryId geometry_id);
+
+  /** systems::Context-modifying variant of RemoveGeometry(). Rather than
+   modifying %SceneGraph's model, it modifies the copy of the model stored in
+   the provided context.  */
+  void RemoveGeometry(systems::Context<T>* context, SourceId source_id,
+                      GeometryId geometry_id);
 
   //@}
 
@@ -436,6 +480,12 @@ class SceneGraph final : public systems::LeafSystem<T> {
                             scene graph.  */
   void ExcludeCollisionsWithin(const GeometrySet& set);
 
+  /** systems::Context-modifying variant of ExcludeCollisionsWithin(). Rather
+   than modifying %SceneGraph's model, it modifies the copy of the model stored
+   in the provided context.  */
+  void ExcludeCollisionsWithin(systems::Context<T>* context,
+                               const GeometrySet& set);
+
   /** Excludes geometry pairs from collision evaluation by updating the
    candidate pair set `C = C - P`, where `P = {(a, b)}, ∀ a ∈ A, b ∈ B` and
    `A = {a₀, a₁, ..., aₘ}` and `B = {b₀, b₁, ..., bₙ}` are the input sets of
@@ -445,6 +495,13 @@ class SceneGraph final : public systems::LeafSystem<T> {
    @throws std::logic_error if the groups include ids that don't exist in the
                             scene graph.   */
   void ExcludeCollisionsBetween(const GeometrySet& setA,
+                                const GeometrySet& setB);
+
+  /** systems::Context-modifying variant of ExcludeCollisionsBetween(). Rather
+   than modifying %SceneGraph's model, it modifies the copy of the model stored
+   in the provided context.  */
+  void ExcludeCollisionsBetween(systems::Context<T>* context,
+                                const GeometrySet& setA,
                                 const GeometrySet& setB);
   //@}
 

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -112,7 +112,28 @@ class SceneGraphInspector {
     return state_->GetGeometryFromName(frame_id, name);
   }
 
+  /** Reports the number of frames registered to the given source id. Returns
+   zero for unregistered source ids.  */
+  int NumFramesForSource(SourceId source_id) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->NumFramesForSource(source_id);
+  }
+
+  /** Reports the number of geometries affixed to the given frame id.
+   @throws std::runtime_error if `frame_id` is invalid.  */
+  int NumGeometriesForFrame(FrameId frame_id) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->GetNumFrameGeometries(frame_id);
+  }
+
   //@}
+
+  /** Reports true if collision between the two indicated geometries has been
+   filtered out.  */
+  bool CollisionFiltered(GeometryId id1, GeometryId id2) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->CollisionFiltered(id1, id2);
+  }
 
  private:
   // Only SceneGraph and QueryObject instances can construct

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -643,9 +643,17 @@ TEST_F(SimplePenetrationTest, ExcludeCollisionsWithinCliqueGeneration) {
 
   int expected_clique = PET::peek_next_clique(engine_);
 
+  // Named aliases for otherwise inscrutable true/false magic values. The
+  // parameter in the invoked method is called `is_dynamic`. So, we set the
+  // the constant `is_dynamic` to true and its opposite, `is_anchored` to false.
+  const bool is_anchored = false;
+  const bool is_dynamic = true;
+
   // No dynamic geometry --> no cliques generated.
   engine_.ExcludeCollisionsWithin({}, {anchored1, anchored2});
   ASSERT_EQ(PET::peek_next_clique(engine_), expected_clique);
+  EXPECT_TRUE(engine_.CollisionFiltered(anchored1, is_anchored,
+                                        anchored2, is_anchored));
 
   // Single dynamic and no anchored geometry --> no cliques generated.
   engine_.ExcludeCollisionsWithin({dynamic1}, {});
@@ -654,12 +662,18 @@ TEST_F(SimplePenetrationTest, ExcludeCollisionsWithinCliqueGeneration) {
   // Multiple dynamic and no anchored geometry --> cliques generated.
   engine_.ExcludeCollisionsWithin({dynamic1, dynamic2}, {});
   ASSERT_EQ(PET::peek_next_clique(engine_), ++expected_clique);
+  EXPECT_TRUE(engine_.CollisionFiltered(dynamic1, is_dynamic,
+                                        dynamic2, is_dynamic));
 
   // Single dynamic and (one or more) anchored geometry --> cliques generated.
   engine_.ExcludeCollisionsWithin({dynamic1}, {anchored1});
   ASSERT_EQ(PET::peek_next_clique(engine_), ++expected_clique);
+  EXPECT_TRUE(engine_.CollisionFiltered(anchored1, is_anchored,
+                                        dynamic1, is_dynamic));
   engine_.ExcludeCollisionsWithin({dynamic1}, {anchored1, anchored2});
   ASSERT_EQ(PET::peek_next_clique(engine_), ++expected_clique);
+  EXPECT_TRUE(engine_.CollisionFiltered(anchored2, is_anchored,
+                                        dynamic1, is_dynamic));
 
   // Multiple dynamic and (one or more) anchored geometry --> cliques generated.
   engine_.ExcludeCollisionsWithin({dynamic1, dynamic2}, {anchored1});
@@ -684,7 +698,11 @@ TEST_F(SimplePenetrationTest, ExcludeCollisionsWithin) {
   geometry_map_.push_back(collide_id);
   EXPECT_EQ(engine_.num_geometries(), 2);
 
+  EXPECT_FALSE(engine_.CollisionFiltered(origin_index, true,
+                                         collide_index, true));
   engine_.ExcludeCollisionsWithin({origin_index, collide_index}, {});
+  EXPECT_TRUE(engine_.CollisionFiltered(origin_index, true,
+                                        collide_index, true));
 
   // Non-colliding case
   MoveDynamicSphere(collide_index, false /* not colliding */);
@@ -780,7 +798,11 @@ TEST_F(SimplePenetrationTest, ExcludeCollisionsBetween) {
   geometry_map_.push_back(collide_id);
   EXPECT_EQ(engine_.num_geometries(), 2);
 
+  EXPECT_FALSE(engine_.CollisionFiltered(origin_index, true,
+                                         collide_index, true));
   engine_.ExcludeCollisionsBetween({origin_index}, {}, {collide_index}, {});
+  EXPECT_TRUE(engine_.CollisionFiltered(origin_index, true,
+                                        collide_index, true));
 
   // Non-colliding case
   MoveDynamicSphere(collide_index, false /* not colliding */);

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -93,6 +93,13 @@ class SceneGraphTester {
 
 namespace {
 
+// Convenience function for making a geometry instance.
+std::unique_ptr<GeometryInstance> make_sphere_instance(
+    double radius = 1.0) {
+  return make_unique<GeometryInstance>(Isometry3<double>::Identity(),
+                                       make_unique<Sphere>(radius), "sphere");
+}
+
 // Testing harness to facilitate working with/testing the SceneGraph. Before
 // performing *any* queries in tests, `AllocateContext` must be explicitly
 // invoked in the test.
@@ -120,12 +127,6 @@ class SceneGraphTest : public ::testing::Test {
     if (!geom_context_)
       throw std::runtime_error("Must call AllocateContext() first.");
     return query_object_;
-  }
-
-  static std::unique_ptr<GeometryInstance> make_sphere_instance(
-      double radius = 1.0) {
-    return make_unique<GeometryInstance>(Isometry3<double>::Identity(),
-                                         make_unique<Sphere>(radius), "sphere");
   }
 
   SceneGraph<double> scene_graph_;
@@ -637,6 +638,105 @@ GTEST_TEST(SceneGraphVisualizationTest, NoWorldInPoseVector) {
     EXPECT_NO_THROW(SceneGraphTester::CalcPoseBundle(scene_graph, *context,
                                                      &poses));
   }
+}
+
+// Tests that exercise the Context-modifying API
+
+// Test that geometries can be successfully added to an allocated context.
+GTEST_TEST(SceneGraphContextModifier, RegisterGeometry) {
+  // Initializes the scene graph and context.
+  SceneGraph<double> scene_graph;
+  SourceId source_id = scene_graph.RegisterSource("source");
+  FrameId frame_id = scene_graph.RegisterFrame(
+      source_id, GeometryFrame("frame", Isometry3d::Identity()));
+  auto context = scene_graph.AllocateContext();
+
+  // Confirms the state. NOTE: All subsequent actions modify `context` in place.
+  // This allows us to use this same query_object and inspector throughout the
+  // test without requiring any updates or changes to them..
+  QueryObject<double> query_object;
+  SceneGraphTester::GetQueryObjectPortValue(scene_graph, *context,
+                                            &query_object);
+  const auto& inspector = query_object.inspector();
+  EXPECT_EQ(1, inspector.NumFramesForSource(source_id));
+  EXPECT_EQ(0, inspector.NumGeometriesForFrame(frame_id));
+
+  // Test registration of geometry onto _frame_.
+  GeometryId sphere_id_1 = scene_graph.RegisterGeometry(
+      context.get(), source_id, frame_id, make_sphere_instance());
+  EXPECT_EQ(1, inspector.NumGeometriesForFrame(frame_id));
+  EXPECT_EQ(frame_id, inspector.GetFrameId(sphere_id_1));
+
+  // Test registration of geometry onto _geometry_.
+  GeometryId sphere_id_2 = scene_graph.RegisterGeometry(
+      context.get(), source_id, sphere_id_1, make_sphere_instance());
+  EXPECT_EQ(2, inspector.NumGeometriesForFrame(frame_id));
+  EXPECT_EQ(frame_id, inspector.GetFrameId(sphere_id_2));
+
+  // Remove the geometry.
+  EXPECT_NO_THROW(scene_graph.RemoveGeometry(context.get(), source_id,
+                                             sphere_id_2));
+  EXPECT_EQ(1, inspector.NumGeometriesForFrame(frame_id));
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      inspector.GetFrameId(sphere_id_2),
+      std::logic_error,
+      "Referenced geometry \\d+ has not been registered.");
+}
+
+GTEST_TEST(SceneGraphContextModifier, CollisionFilters) {
+  // Initializes the scene graph and context.
+  SceneGraph<double> scene_graph;
+  // Simple scene with three frames, each with a sphere which, by default
+  // collide.
+  SourceId source_id = scene_graph.RegisterSource("source");
+  FrameId f_id1 = scene_graph.RegisterFrame(
+      source_id, GeometryFrame("frame_1", Isometry3d::Identity()));
+  FrameId f_id2 = scene_graph.RegisterFrame(
+      source_id, GeometryFrame("frame_2", Isometry3d::Identity()));
+  FrameId f_id3 = scene_graph.RegisterFrame(
+      source_id, GeometryFrame("frame_3", Isometry3d::Identity()));
+  GeometryId g_id1 =
+      scene_graph.RegisterGeometry(source_id, f_id1, make_sphere_instance());
+  GeometryId g_id2 =
+      scene_graph.RegisterGeometry(source_id, f_id2, make_sphere_instance());
+  GeometryId g_id3 =
+      scene_graph.RegisterGeometry(source_id, f_id3, make_sphere_instance());
+
+  // Confirm that the model reports no filtered pairs.
+  EXPECT_FALSE(scene_graph.model_inspector().CollisionFiltered(g_id1, g_id2));
+  EXPECT_FALSE(scene_graph.model_inspector().CollisionFiltered(g_id1, g_id3));
+  EXPECT_FALSE(scene_graph.model_inspector().CollisionFiltered(g_id2, g_id3));
+
+  auto context = scene_graph.AllocateContext();
+
+  // Confirms the state. NOTE: Because we're not copying the query object or
+  // changing context, this query object and inspector are valid for querying
+  // the modified context.
+  QueryObject<double> query_object;
+  SceneGraphTester::GetQueryObjectPortValue(scene_graph, *context,
+                                            &query_object);
+  const auto& inspector = query_object.inspector();
+
+  // Confirm unfiltered state.
+  EXPECT_FALSE(inspector.CollisionFiltered(g_id1, g_id2));
+  EXPECT_FALSE(inspector.CollisionFiltered(g_id1, g_id3));
+  EXPECT_FALSE(inspector.CollisionFiltered(g_id2, g_id3));
+
+  scene_graph.ExcludeCollisionsWithin(context.get(),
+                                      GeometrySet({g_id1, g_id2}));
+  EXPECT_TRUE(inspector.CollisionFiltered(g_id1, g_id2));
+  EXPECT_FALSE(inspector.CollisionFiltered(g_id1, g_id3));
+  EXPECT_FALSE(inspector.CollisionFiltered(g_id2, g_id3));
+
+  scene_graph.ExcludeCollisionsBetween(context.get(),
+                                       GeometrySet({g_id1, g_id2}),
+                                       GeometrySet({g_id3}));
+  EXPECT_TRUE(inspector.CollisionFiltered(g_id1, g_id2));
+  EXPECT_TRUE(inspector.CollisionFiltered(g_id1, g_id3));
+  EXPECT_TRUE(inspector.CollisionFiltered(g_id2, g_id3));
+
+  // TODO(SeanCurtis-TRI): When post-allocation model modification is allowed,
+  // confirm that the model didn't change.
 }
 
 }  // namespace


### PR DESCRIPTION
Extend SceneGraph API to support operations that modify the geometry state stored in a context instead of in the SceneGraph instance's model. These changes are currently limited to geometry and geometry-related functions. (Changes to frames and sources are deferred because they will affect the SceneGraph's ports and we want to make sure we have some coordination mechanism appropriately planned).

Extended SceneGraph documentation to call out the two API variants.

APIs include:
  1. RegisterGeometry (onto frame and onto other geometry)
  2. RemoveGeometry
  3. Add collision filters (ExcludeCollisionsWithin and ExcludeCollisionsBetween)
  4. SceneGraphInspector extended to provide more introspection functionality. Supporting functionality also pushed into GeometryState and ProximityEngine.

```
Category            added  modified  removed  
----------------------------------------------
code                224    0         5        
comments            79     22        0        
blank               45     0         0        
----------------------------------------------
TOTAL               348    22        5 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10096)
<!-- Reviewable:end -->
