### PR TITLE
[WIP] common: Throw, even on abort, for Python

### DIFF
--- a/common/drake_assert_and_throw.cc
+++ b/common/drake_assert_and_throw.cc
@@ -43,6 +43,11 @@ void PrintFailureDetailTo(std::ostream& out, const char* condition,
 // Declared in drake_assert.h.
 void Abort(const char* condition, const char* func, const char* file,
            int line) {
+  if (AssertionConfig::singleton().assertion_failures_are_exceptions) {
+    // Cross fingers.
+    Throw(condition, func, file, line);
+    return;
+  }
   std::cerr << "abort: ";
   PrintFailureDetailTo(std::cerr, condition, func, file, line);
   std::cerr << std::endl;


### PR DESCRIPTION
@edrumwri ran into this; would be nice to soften.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10097)
<!-- Reviewable:end -->
