### PR TITLE
discrete_derivative: Make implementation explanation more general

### DIFF
--- a/systems/primitives/discrete_derivative.h
+++ b/systems/primitives/discrete_derivative.h
@@ -21,14 +21,10 @@ namespace systems {
 ///   x₀[0] and x₁[0] are initialized in the Context (default is zeros).
 /// </pre>
 ///
-/// Note: The reason for this specific implementation is a little subtle.
-/// Since drake systems do not control the evaluation time of their output
-/// ports, a downstream system may ask for the output at any continuous time.
-/// The estimate y(t) = (u(t) - u[n])/(t-n*h), which is a more
-/// continuous-time derivative, would require fewer state variables, and
-/// introduce less delay.  But the inconsistent time interval (which could be
-/// arbitrarily close to zero) makes it numerically unreliable.  Prefer the
-/// discrete-time derivative implemented here.
+/// @note For dynamical systems, a derivative should not be computed in
+/// continuous-time, i.e. `y(t) = (u(t) - u[n])/(t-n*h)`. This is numerically
+/// unstable since the time interval `t-n*h` could be arbitrarily close to
+/// zero. Prefer the discrete-time implementation for robustness.
 ///
 /// @system{ DiscreteDerivative, @input_port{u}, @output_port{dudt} }
 ///


### PR DESCRIPTION
Follow-up to #10052.

My complaint with the existing note is that (a) it may imply that this is Drake-specific and (b) indicates that doing `y(t) = (u(t) - u[n])/(t-n*h)` may be better in other frameworks situations.

My guestimate for (a) is that this applies beyond just Drake, and for (b) is that people should generally never do this (unless they're hacking in something like `ode45` and don't have access to good periodic discrete updates in a hybrid system).

I'd like to make the wording a little more harsh to counter (b), and remove Drake to counter (a).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10102)
<!-- Reviewable:end -->
