### PR TITLE
install, cmake: Enable not stripping symbols for debug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,12 +267,32 @@ elseif(WITH_SNOPT)
   list(APPEND BAZEL_ENV "SNOPT_PATH=${SNOPT_PATH}")
 endif()
 
+# N.B. If you are testing the CMake API and making changes to `install.py.in`,
+# you can change this target to something more lightweight, such as
+# `//tools/install/dummy:install`.
 set(BAZEL_TARGETS //:install)
 
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}/install" CACHE STRING
     "Install path prefix, prepended onto install directories" FORCE
   )
+endif()
+
+set(BAZEL_TARGETS_ARGS "${CMAKE_INSTALL_PREFIX}")
+
+if(CMAKE_VERBOSE_MAKEFILE)
+  list(INSERT BAZEL_TARGETS_ARGS 0 "--verbose")
+endif()
+
+# If we are in debug mode, do not strip symbols.
+if(CMAKE_BUILD_TYPE STREQUAL Debug OR CMAKE_BUILD_TYPE STREQUAL RelWithDebugInfo)
+  # SNOPT has restrictions for redistribution given that we are statically
+  # linking it in.
+  if(WITH_SNOPT OR WITH_ROBOTLOCOMOTION_SNOPT)
+    message(WARNING "SNOPT is enabled, thus symbols will STILL be stripped, even in debug mode.")
+  else()
+    list(INSERT BAZEL_TARGETS_ARGS 0 "--no_strip")
+  endif()
 endif()
 
 include(ExternalProject)
@@ -283,7 +303,7 @@ ExternalProject_Add(drake_cxx_python
   BUILD_COMMAND ${BAZEL_ENV} "${Bazel_EXECUTABLE}" ${BAZEL_STARTUP_ARGS} build ${BAZEL_ARGS} ${BAZEL_TARGETS}
   BUILD_IN_SOURCE 1
   BUILD_ALWAYS 1
-  INSTALL_COMMAND ${BAZEL_ENV} "${Bazel_EXECUTABLE}" ${BAZEL_STARTUP_ARGS} run ${BAZEL_ARGS} ${BAZEL_TARGETS} -- "${CMAKE_INSTALL_PREFIX}"
+  INSTALL_COMMAND ${BAZEL_ENV} "${Bazel_EXECUTABLE}" ${BAZEL_STARTUP_ARGS} run ${BAZEL_ARGS} ${BAZEL_TARGETS} -- ${BAZEL_TARGETS_ARGS}
   USES_TERMINAL_BUILD 1
   USES_TERMINAL_INSTALL 1
 )

--- a/doc/python_bindings.rst
+++ b/doc/python_bindings.rst
@@ -177,6 +177,56 @@ explicitly refer to each symbol:
     simulator = pydrake.systems.analysis.Simulator(
         pydrake.multibody.rigid_body_plant.RigidBodyPlant(tree))
 
+Debugging with the Python Bindings
+----------------------------------
+
+You may encounter issues with the Python Bindings that may arise from the
+underlying C++ code, and it may not always be obvious what the root cause is.
+
+The first step to debugging is to consider running your code using the
+``trace`` module. It is best practice to always have a ``main()`` function, and
+have a ``if __name__ == "__main__"`` clause. If you do this, then it is easy to
+trace. As an example:
+
+.. code-block:: python
+
+    def main():
+        insert_awesome_code_here()
+
+    if __name__ == "__main__":
+        # main()  # This is what you would have, but the following is useful:
+
+        # These are temporary, for debugging, so meh for programming style.
+        import sys, trace
+
+        # If there are segfaults, it's a good idea to always use stderr as it
+        # always prints to the screen, so you should get as much output as
+        # possible.
+        sys.stdout = sys.stderr
+
+        # Now trace execution:
+        tracer = trace.Trace(trace=1, count=0, ignoredirs=["/usr", sys.prefix])
+        tracer.run('main()')
+
+.. note::
+
+    If you are developing in Drake and are using the ``drake_py_unittest``
+    macro, you can specify the argument ``--trace=user`` to get the same
+    behavior.
+
+This generally should help you trace where the code is dying. However, if you
+still need to dig in, you can build the bindings in debug mode, without symbol
+stripping, so you can debug with ``gdb`` or ``lldb``:
+
+.. code-block:: shell
+
+    cmake -DCMAKE_BUILD_TYPE=Debug ../drake
+
+.. warning::
+
+    If you have SNOPT enabled (either ``-DWITH_SNOPT=ON`` or
+    ``-DWITH_ROBOTLOCOMOTION_SNOPT=ON``), symbols will *still* be stripped.
+
 Differences with C++ API
 ========================
 

--- a/tools/install/BUILD.bazel
+++ b/tools/install/BUILD.bazel
@@ -37,4 +37,9 @@ drake_py_unittest(
     deps = [":install_test_helper"],
 )
 
+drake_py_unittest(
+    name = "install_meta_test",
+    data = ["//tools/install/dummy:install"],
+)
+
 add_lint_tests()

--- a/tools/install/dummy/BUILD.bazel
+++ b/tools/install/dummy/BUILD.bazel
@@ -1,0 +1,61 @@
+load("//tools/lint:lint.bzl", "add_lint_tests")
+load("//tools/install:install.bzl", "install")
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_binary",
+    "drake_cc_library",
+    "drake_transitive_installed_hdrs_filegroup",
+)
+load(
+    "@drake//tools/skylark:drake_py.bzl",
+    "drake_py_unittest",
+)
+
+package(default_visibility = ["//tools/install:__subpackages__"])
+
+drake_cc_library(
+    name = "dummy",
+    testonly = 1,
+    srcs = ["dummy.cc"],
+    hdrs = ["dummy.h"],
+)
+
+drake_cc_binary(
+    name = "libdummy.so",
+    testonly = 1,
+    linkshared = 1,
+    linkstatic = 1,
+    deps = [":dummy"],
+)
+
+drake_transitive_installed_hdrs_filegroup(
+    name = "libdummy_headers",
+    testonly = 1,
+    deps = [":dummy"],
+)
+
+py_library(
+    name = "dummy_py",
+    testonly = 1,
+    srcs = ["dummy.py"],
+)
+
+# N.B. This should NOT be incorporated into `build_components.bzl`.
+install(
+    name = "install",
+    testonly = 1,
+    targets = [
+        ":dummy_py",
+        ":libdummy.so",
+    ],
+    # TODO(eric.cousineau): Ensure the install paths for these headers are not
+    # the same as what is used in the cc library.
+    hdrs = [":libdummy_headers"],
+    data = ["README.md"],
+    data_dest = "share",
+)
+
+add_lint_tests(
+    enable_install_lint = False,
+    enable_library_lint = False,
+)

--- a/tools/install/dummy/README.md
+++ b/tools/install/dummy/README.md
@@ -1,0 +1,1 @@
+Dummy artifacts to test installation code.

--- a/tools/install/dummy/dummy.cc
+++ b/tools/install/dummy/dummy.cc
@@ -1,0 +1,7 @@
+#include "drake/tools/install/dummy/dummy.h"
+
+namespace dummy {
+
+int dummy_func() { return 0; }
+
+}  // namespace dummy

--- a/tools/install/dummy/dummy.h
+++ b/tools/install/dummy/dummy.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace dummy {
+
+int dummy_func();
+
+}  // namespace dummy

--- a/tools/install/dummy/dummy.py
+++ b/tools/install/dummy/dummy.py
@@ -1,0 +1,2 @@
+def dummy_func():
+    return 0

--- a/tools/install/install.py.in
+++ b/tools/install/install.py.in
@@ -1,4 +1,11 @@
 #!/usr/bin/env python2
+"""
+Installation script generated from a Bazel `install` target.
+"""
+
+# N.B. Please ensure any significant behavior is tested by `install_meta_test`.
+# Example execution:
+#   $ bazel test //tools/install:py/install_meta_test --test_output=streamed --nocache_test_results  # noqa
 
 import argparse
 import collections

--- a/tools/install/install.py.in
+++ b/tools/install/install.py.in
@@ -7,6 +7,11 @@ Installation script generated from a Bazel `install` target.
 # Example execution:
 #   $ bazel test //tools/install:py/install_meta_test --test_output=streamed --nocache_test_results  # noqa
 
+# N.B. This is designed to emulate CMake's install mechanism. Do not add
+# unnecessary print statements.
+
+from __future__ import print_function
+
 import argparse
 import collections
 import filecmp
@@ -21,7 +26,9 @@ from subprocess import check_output, check_call
 # Stores subdirectories that have already been created.
 subdirs = set()
 # Stored from command-line.
+verbose = False
 prefix = None
+strip = True
 # Mapping used to (a) check for unique shared library names and (b) provide a
 # mapping from library name to paths for RPath fixes (where (a) is essential).
 # Structure: Map[ basename (Str) => full_path ]
@@ -193,13 +200,15 @@ def fix_rpaths_and_strip():
             # From the manual for BSD `strip`: for dynamic shared libraries,
             # the maximum level of stripping is usually -x (to remove all
             # non-global symbols).
-            check_call(['strip', '-x', dst_full])
+            if strip:
+                check_call(['strip', '-x', dst_full])
             macos_fix_rpaths(basename, dst_full)
         else:
             # Strip before running `patchelf`. Trying to strip after patching
             # the files is likely going to create the following error:
             # 'Not enough room for program headers, try linking with -N'
-            check_call(['strip', dst_full])
+            if strip:
+                check_call(['strip', dst_full])
             linux_fix_rpaths(dst_full)
 
 
@@ -362,7 +371,9 @@ java {} {} "$@"
 
 def main(args):
     global prefix
+    global verbose
     global list_only
+    global strip
 
     # Set up options.
     parser = argparse.ArgumentParser()
@@ -370,11 +381,20 @@ def main(args):
     parser.add_argument(
         '--list', action='store_true', default=False,
         help='print the list of installed files; do not install anything')
+    parser.add_argument(
+        '--no_strip', dest='strip', action='store_false', default=True,
+        help='do not strip symbols (for debugging)')
+    parser.add_argument(
+        '-v', '--verbose', action='store_true',
+        help='print additional information')
     args = parser.parse_args(args)
 
     # Get install prefix.
     prefix = args.prefix
+    verbose = args.verbose
     list_only = args.list
+    # Check if we want to avoid stripping symbols.
+    strip = args.strip
 
     # Transform install prefix if DESTDIR is set.
     # https://www.gnu.org/prep/standards/html_node/DESTDIR.html
@@ -386,13 +406,15 @@ def main(args):
     # working directory of the user's shell, enforce that the install
     # location is an absolute path so that the user is not surprised.
     if not os.path.isabs(prefix):
-        sys.stderr.write(
-            "Install prefix must be an absolute path (got {})\n"
-            .format(prefix))
-        sys.exit(1)
+        parser.error(
+            "Install prefix must be an absolute path (got '{}')\n".format(
+                prefix))
 
     # Match the output of the CMake install step.
     print("Install the project...")
+
+    if verbose and not strip:
+        print("-- Symbols will NOT be stripped")
 
     # Execute the install actions.
     <<actions>>

--- a/tools/install/libdrake/build_components_refresh.py
+++ b/tools/install/libdrake/build_components_refresh.py
@@ -48,7 +48,7 @@ kind("cc_library", visible("//tools/install/libdrake:libdrake.so", "//..."))
       ))
     )
     except("//lcmtypes/...")
-    except("//tools/install/libdrake:*")
+    except("//tools/install/...")
     except(attr(tags, "exclude_from_libdrake", //...))
 """
     # First, find the drake_cc_package_library targets within that query.

--- a/tools/install/test/install_meta_test.py
+++ b/tools/install/test/install_meta_test.py
@@ -48,3 +48,20 @@ class TestInstallMeta(unittest.TestCase):
         }
         actual_manifest = self.listdir_recursive(install_dir)
         self.assertSetEqual(actual_manifest, expected_manifest)
+
+    def test_strip_args(self):
+        """Test behavior of `--no_strip`."""
+        install_dir = self.get_install_dir("test_strip_args")
+        strip_substr = "-- Symbols will NOT be stripped"
+        # - Without.
+        text_without = check_output(
+            [self.BINARY, "-v", install_dir], stderr=STDOUT)
+        # N.B. `assertIn` error messages are not great for multiline, so just
+        # print and use nominal asserts.
+        print(text_without)
+        self.assertTrue(strip_substr not in text_without)
+        # - With.
+        text_with = check_output(
+            [self.BINARY, install_dir, "-v", "--no_strip"], stderr=STDOUT)
+        print(text_with)
+        self.assertTrue(strip_substr in text_with)

--- a/tools/install/test/install_meta_test.py
+++ b/tools/install/test/install_meta_test.py
@@ -1,0 +1,50 @@
+"""Tests the behavior of targets generated from `install.py.in`."""
+
+import os
+from os.path import isdir, join, relpath
+import unittest
+from subprocess import STDOUT, check_call, check_output
+import sys
+
+# TODO(eric.cousineau): Expand on these tests, especially for nuanced things
+# like Python C extensions.
+
+
+class TestInstallMeta(unittest.TestCase):
+    BINARY = "tools/install/dummy/install"
+
+    def get_install_dir(self, case):
+        # Do not use `install_test_helper`, as its behavior is more constrained
+        # than what is useful for these tests.
+        assert "TEST_TMPDIR" in os.environ, (
+            "Must only be run within `bazel test`.")
+        install_dir = join(os.environ["TEST_TMPDIR"], "installation", case)
+        # Ensure this is only called once per case.
+        self.assertFalse(isdir(install_dir), case)
+        return install_dir
+
+    def get_python_site_packages_dir(self):
+        major, minor = sys.version_info.major, sys.version_info.minor
+        return join("lib", "python{}.{}".format(major, minor), "site-packages")
+
+    def listdir_recursive(self, d):
+        out = set()
+        for (dirpath, _, filenames) in os.walk(d):
+            dirrel = relpath(dirpath, d)
+            for filename in filenames:
+                out.add(join(dirrel, filename))
+        return out
+
+    def test_nominal(self):
+        """Test nominal behavior of install."""
+        install_dir = self.get_install_dir("test_nominal")
+        check_call([self.BINARY, install_dir])
+        py_dir = self.get_python_site_packages_dir()
+        expected_manifest = {
+            "share/README.md",
+            "include/dummy.h",
+            "lib/libdummy.so",
+            join(py_dir, "dummy.py"),
+        }
+        actual_manifest = self.listdir_recursive(install_dir)
+        self.assertSetEqual(actual_manifest, expected_manifest)


### PR DESCRIPTION
pydrake: Add debugging info for cmake build

Resolves #10019

Given @edrumwri's prior comments, I think this is a good idea; I've sprinkled warnings all throughout to avoid any potential mishaps for redistribution, as I think it's more useful to keep things simple to enable user debugging workflows as Evan has pointed out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10103)
<!-- Reviewable:end -->
