### PR TITLE
pydrake: Simplify debugging instructions to use `gdbserver`

### DIFF
--- a/bindings/pydrake/pydrake_pybind.h
+++ b/bindings/pydrake/pydrake_pybind.h
@@ -242,43 +242,49 @@ an alias.
 @anchor PydrakeBazelDebug
 # Interactive Debugging with Bazel
 
-If you would like to interactively debug binding code (using IPython for
-general Python behavior, or GDB for C++ behavior), debug C++ behavior from a
-Python binary, while using Bazel, you may expose Bazel's development
-environment variables by adding these lines to your Python script:
+If you are debugging a unitest, first try running the test with `--trace=user`
+to see where the code is failing. This should cover most cases where you need
+to debug C++ bits. Example:
 
-    import subprocess
-    subprocess.Popen(
-        "export -p | sed 's# PWD=# OLD_PWD=#g' | tee /tmp/env.sh",
-        shell=True)
+    bazel run //bindings/pydrake/systems:py/lifetime_test -- --trace=user
 
-Run your target once from Bazel, and then source the generated `/tmp/env.sh` in
-your terminal to gain access to the environment variables (e.g. `$PYTHONPATH`).
+If you need to debug futher while using Bazel, it is suggested to use
+`gdbserver` for simplicity. Example:
 
-## Example with GDB
+```
+    # Terminal 1 - Host process.
+    cd drake
+    bazel run -c dbg \
+        --run_under='gdbserver localhost:9999' \
+        //bindings/pydrake/systems:py/lifetime_test -- \
+        --trace=user
 
-This is a brief recipe for debugging with GDB
-(note the usage of subshell `(...)` to keep the variables scoped):
+    # Terminal 2 - Client debugger.
+    cd drake
+    gdb -ex "dir ${PWD}/bazel-drake" \
+        -ex "target remote localhost:9999" \
+        -ex "set sysroot" \
+        -ex "set breakpoint pending on"
+    # In the GDB terminal:
+    (gdb) break drake::systems::Simulator<double>::Simulator
+    (gdb) continue
+```
 
-    (
-        target=//bindings/pydrake/systems:lifetime_test
-        target_bin=$(echo ${target} | sed -e 's#//##' -e 's#:#/#')
-        bazel run -c dbg ${target}
-        workspace=$(bazel info workspace)
-        name=$(basename ${workspace})
-        cd ${workspace}/bazel-${name}
-        source /tmp/env.sh
-        gdb --args python ${workspace}/bazel-bin/${target_bin}
-    )
+`set sysroot` is important for using `gdbserver`, `set breakpoint pending on`
+allows you set the breakpoints before loading `libdrake.so`, and `dir ...` adds
+source directories. It is also suggested that you
+[enable readline history](https://stackoverflow.com/a/3176802) in `~/.gdbinit`
+for ease of use.
 
-This allows you to use GDB from the terminal, while being able to inspect the
-sources in Bazel's symlink forests.
+If using CLion, you can still connect to the `gdbserver` instance.
 
-If using CLion, consider using `gdbserver`.
+There are analogs for `lldb` / `lldbserver` but for brevity, only GDB is
+covered.
 
 */
 
-// TODO(eric.cousineau): Add API naming conventions (#7819).
+// TODO(eric.cousineau): If it ever stops redirecting stdin, use
+// `bazel run --run_under='gdb --args python' --script_path=...`.
 
 // Note: Doxygen apparently doesn't process comments for namespace aliases. If
 // you put Doxygen comments here they will apply instead to py_reference. See


### PR DESCRIPTION
Expose `--trace=user` for unittests

Relates #10103 - will put a cross reference for using `trace` depending on how that comes out.

\cc @sherm1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10104)
<!-- Reviewable:end -->
