### PR TITLE
gitignore some Clion cruft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ xcode
 .cproject
 .project
 .settings
+.clwb/
 
 external/
 /user.bazelrc


### PR DESCRIPTION
Sometimes CLion drops a directory `.clwb`; let's pretend we don't see it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10110)
<!-- Reviewable:end -->
