### PR TITLE
pydrake/common: Rephrase geometry errors for less silliness

### DIFF
--- a/bindings/pydrake/common/eigen_geometry_py.cc
+++ b/bindings/pydrake/common/eigen_geometry_py.cc
@@ -1,4 +1,5 @@
 #include <cmath>
+#include <stdexcept>
 
 #include "pybind11/pybind11.h"
 
@@ -33,15 +34,15 @@ template <typename T>
 void CheckRotMat(const Matrix3<T>& R) {
   // See `ExpectRotMat`.
   const T identity_error =
-      (R * R.transpose() - Eigen::Matrix<T, 3, 3>::Identity())
+      (R * R.transpose() - Matrix3<T>::Identity())
       .array().abs().maxCoeff();
-  DRAKE_THROW_UNLESS(
-      identity_error < kCheckTolerance &&
-      "Rotation matrix is not orthonormal");
+  if (identity_error >= kCheckTolerance) {
+    throw std::logic_error("Rotation matrix is not orthonormal");
+  }
   const T det_error = fabs(R.determinant() - 1);
-  DRAKE_THROW_UNLESS(
-    det_error < kCheckTolerance &&
-    "Rotation matrix violates right-hand rule");
+  if (det_error >= kCheckTolerance) {
+    throw std::logic_error("Rotation matrix violates right-hand rule");
+  }
 }
 
 template <typename T>
@@ -51,25 +52,25 @@ void CheckIsometry(const Isometry3<T>& X) {
   bottom_expected << 0, 0, 0, 1;
   const T bottom_error =
       (X.matrix().bottomRows(1) - bottom_expected).array().abs().maxCoeff();
-  DRAKE_THROW_UNLESS(
-      bottom_error < kCheckTolerance &&
-      "Homogeneous matrix is improperly scaled.");
+  if (bottom_error >= kCheckTolerance) {
+    throw std::logic_error("Homogeneous matrix is improperly scaled.");
+  }
 }
 
 template <typename T>
 void CheckQuaternion(const Eigen::Quaternion<T>& q) {
   const T norm_error = fabs(q.coeffs().norm() - 1);
-  DRAKE_THROW_UNLESS(
-      norm_error < kCheckTolerance &&
-      "Quaternion is not normalized");
+  if (norm_error >= kCheckTolerance) {
+    throw std::logic_error("Quaternion is not normalized");
+  }
 }
 
 template <typename T>
 void CheckAngleAxis(const Eigen::AngleAxis<T>& value) {
   const T norm_error = fabs(value.axis().norm() - 1);
-  DRAKE_THROW_UNLESS(
-      norm_error < kCheckTolerance &&
-      "Axis is not normalized");
+  if (norm_error >= kCheckTolerance) {
+    throw std::logic_error("Axis is not normalized");
+  }
 }
 
 }  // namespace

--- a/bindings/pydrake/common/test/eigen_geometry_test.py
+++ b/bindings/pydrake/common/test/eigen_geometry_test.py
@@ -57,13 +57,13 @@ class TestEigenGeometry(unittest.TestCase):
         q = mut.Quaternion.Identity()
         # - wxyz
         q_wxyz_bad = [1., 2, 3, 4]
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(RuntimeError):
             q.set_wxyz(q_wxyz_bad)
         self.assertTrue(np.allclose(q.wxyz(), [1, 0, 0, 0]))
         # - Rotation.
         R_bad = np.copy(R)
         R_bad[0, 0] = 10
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(RuntimeError):
             q_other.set_rotation(R_bad)
         self.assertTrue(np.allclose(q_other.rotation(), R_I))
 
@@ -115,12 +115,12 @@ class TestEigenGeometry(unittest.TestCase):
         transform = mut.Isometry3(rotation=R, translation=p)
         R_bad = np.copy(R)
         R_bad[0, 0] = 10.
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(RuntimeError):
             transform.set_rotation(R_bad)
         self.assertTrue(np.allclose(R, transform.rotation()))
         X_bad = np.copy(X)
         X_bad[:3, :3] = R_bad
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(RuntimeError):
             transform.set_matrix(X_bad)
         self.assertTrue(np.allclose(X, transform.matrix()))
         # Test `type_caster`s.
@@ -172,7 +172,7 @@ class TestEigenGeometry(unittest.TestCase):
         value = mut.AngleAxis(value_identity)
         value.set_angle(np.pi / 4)
         v = normalize(np.array([0.1, 0.2, 0.3]))
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(RuntimeError):
             value.set_axis([0.1, 0.2, 0.3])
         value.set_axis(v)
         self.assertEqual(value.angle(), np.pi / 4)


### PR DESCRIPTION
We should not be using DRAKE_THROW_UNLESS to provide curated messages to
the user, even moreso inside our pydrake scaffolding.  Using logic_error
here matches what is thrown by drake::math::RotationMatrix.

(It also turns out that DRAKE_THROW_UNLESS(condition && "message")
formats really stupidly under clang-format, which is another reason to
disprefer it.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10111)
<!-- Reviewable:end -->
