### PR TITLE
Remove unused argument names

### DIFF
--- a/solvers/constraint.h
+++ b/solvers/constraint.h
@@ -590,9 +590,9 @@ class LinearEqualityConstraint : public LinearConstraint {
    * instead.
    */
   template <typename DerivedA, typename DerivedL, typename DerivedU>
-  void UpdateCoefficients(const Eigen::MatrixBase<DerivedA>& new_A,
-                          const Eigen::MatrixBase<DerivedL>& new_lb,
-                          const Eigen::MatrixBase<DerivedU>& new_ub) {
+  void UpdateCoefficients(const Eigen::MatrixBase<DerivedA>&,
+                          const Eigen::MatrixBase<DerivedL>&,
+                          const Eigen::MatrixBase<DerivedU>&) {
     static_assert(
         !std::is_same<DerivedA, DerivedA>::value,
         "This method should not be called form `LinearEqualityConstraint`");

--- a/solvers/create_constraint.h
+++ b/solvers/create_constraint.h
@@ -263,7 +263,7 @@ Binding<RotatedLorentzConeConstraint> ParseRotatedLorentzConeConstraint(
 template <typename Derived>
 typename std::enable_if<is_eigen_vector_of<Derived, symbolic::Formula>::value,
                         Binding<Constraint>>::type
-ParseConstraint(const Eigen::MatrixBase<Derived>& e) {
+ParseConstraint(const Eigen::MatrixBase<Derived>&) {
   // TODO(eric.cousineau): Implement this.
   throw std::runtime_error("Not implemented");
 }


### PR DESCRIPTION
clang-7 and higher can end up complaining about these with
-Wunused-parameter

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10116)
<!-- Reviewable:end -->
