### PR TITLE
Remove xcode-select --install from install_prereqs

### DIFF
--- a/setup/mac/binary_distribution/install_prereqs.sh
+++ b/setup/mac/binary_distribution/install_prereqs.sh
@@ -17,8 +17,4 @@ fi
 /usr/local/bin/brew update
 /usr/local/bin/brew bundle --file="${BASH_SOURCE%/*}/Brewfile"
 
-if [[ ! -f /usr/include/expat.h || ! -f /usr/include/zlib.h ]]; then
-  /usr/bin/xcode-select --install
-fi
-
 /usr/local/bin/pip2 install --upgrade --requirement "${BASH_SOURCE%/*}/requirements.txt"


### PR DESCRIPTION
Homebrew installs the command line tools if necessary in its setup script (called from `install_prereqs`) and current logic does not work for Mojave anyway.