### PR TITLE
clang-format: DontAlignAfterOpenBracket only for pydrake

### DIFF
--- a/bindings/pydrake/.clang-format
+++ b/bindings/pydrake/.clang-format
@@ -1,5 +1,18 @@
 # -*- yaml -*-
 
+# This portion of the file contains settings that are local to the
+# //bindings/... code, rather than all of Drake.
+
+# When a function signature's parameters or a function call's arguments need to
+# wrap onto another line, indent by four spaces -- do not whitespace castle all
+# the way over to the open-paren.
+AlignAfterOpenBracket: DontAlign
+
+# -----------------------------------------------------------------------------
+# The contents of the root dotfile should be exactly copied below this point.
+# -----------------------------------------------------------------------------
+# -*- yaml -*-
+
 # This file determines clang-format's style settings; for details, refer to
 # http://clang.llvm.org/docs/ClangFormatStyleOptions.html
 

--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -26,6 +26,10 @@ package(default_visibility = [
     "//bindings:__subpackages__",
 ])
 
+exports_files([
+    ".clang-format",
+])
+
 # This determines how `PYTHONPATH` is configured, and how to install the
 # bindings.
 PACKAGE_INFO = get_pybind_package_info(base_package = "//bindings")
@@ -434,7 +438,17 @@ drake_py_binary(
     ],
 )
 
+drake_py_unittest(
+    name = "dot_clang_format_test",
+    data = [
+        "//:.clang-format",
+        "//bindings/pydrake:.clang-format",
+    ],
+    tags = ["lint"],
+)
+
 add_lint_tests(
+    cpplint_data = ["//bindings/pydrake:.clang-format"],
     enable_clang_format_lint = True,
     python_lint_extra_srcs = [
         ":test/all_install_test.py",

--- a/bindings/pydrake/doc/BUILD.bazel
+++ b/bindings/pydrake/doc/BUILD.bazel
@@ -36,6 +36,7 @@ drake_py_binary(
 )
 
 add_lint_tests(
+    cpplint_data = ["//bindings/pydrake:.clang-format"],
     enable_clang_format_lint = True,
     python_lint_exclude = [":conf.py"],
 )

--- a/bindings/pydrake/examples/BUILD.bazel
+++ b/bindings/pydrake/examples/BUILD.bazel
@@ -184,5 +184,6 @@ drake_py_unittest(
 )
 
 add_lint_tests(
+    cpplint_data = ["//bindings/pydrake:.clang-format"],
     enable_clang_format_lint = True,
 )

--- a/bindings/pydrake/examples/multibody/BUILD.bazel
+++ b/bindings/pydrake/examples/multibody/BUILD.bazel
@@ -68,5 +68,6 @@ install(
 )
 
 add_lint_tests(
+    cpplint_data = ["//bindings/pydrake:.clang-format"],
     enable_clang_format_lint = True,
 )

--- a/bindings/pydrake/maliput/BUILD.bazel
+++ b/bindings/pydrake/maliput/BUILD.bazel
@@ -98,5 +98,6 @@ drake_py_unittest(
 )
 
 add_lint_tests(
+    cpplint_data = ["//bindings/pydrake:.clang-format"],
     enable_clang_format_lint = True,
 )

--- a/bindings/pydrake/manipulation/BUILD.bazel
+++ b/bindings/pydrake/manipulation/BUILD.bazel
@@ -105,5 +105,6 @@ install(
 )
 
 add_lint_tests(
+    cpplint_data = ["//bindings/pydrake:.clang-format"],
     enable_clang_format_lint = True,
 )

--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -283,5 +283,6 @@ drake_py_unittest(
 )
 
 add_lint_tests(
+    cpplint_data = ["//bindings/pydrake:.clang-format"],
     enable_clang_format_lint = True,
 )

--- a/bindings/pydrake/solvers/BUILD.bazel
+++ b/bindings/pydrake/solvers/BUILD.bazel
@@ -186,5 +186,6 @@ drake_py_unittest(
 )
 
 add_lint_tests(
+    cpplint_data = ["//bindings/pydrake:.clang-format"],
     enable_clang_format_lint = True,
 )

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -444,5 +444,6 @@ drake_py_binary(
 )
 
 add_lint_tests(
+    cpplint_data = ["//bindings/pydrake:.clang-format"],
     enable_clang_format_lint = True,
 )

--- a/bindings/pydrake/test/dot_clang_format_test.py
+++ b/bindings/pydrake/test/dot_clang_format_test.py
@@ -1,0 +1,24 @@
+import unittest
+
+
+class TestDotfile(unittest.TestCase):
+    def setUp(self):
+        self.maxDiff = None
+
+    def test_dotfile_consistency(self):
+        # Drake's bindings/pydrake/.clang-format file should be a prologue atop
+        # the root .clang-format file.
+        with open(".clang-format") as f:
+            root_contents = f.readlines()
+        with open("bindings/pydrake/.clang-format") as f:
+            bindings_contents = f.readlines()
+
+        # The bindings file should be longer.
+        self.assertGreater(len(bindings_contents), len(root_contents))
+        offset = len(bindings_contents) - len(root_contents)
+        assert offset > 0
+
+        # Every line in root should appear in bindings.
+        self.assertMultiLineEqual(
+            "".join(root_contents),
+            "".join(bindings_contents[offset:]))

--- a/bindings/pydrake/third_party/BUILD.bazel
+++ b/bindings/pydrake/third_party/BUILD.bazel
@@ -76,5 +76,6 @@ install(
 )
 
 add_lint_tests(
+    cpplint_data = ["//bindings/pydrake:.clang-format"],
     enable_clang_format_lint = True,
 )

--- a/tools/vector_gen/test/goal/sample_translator.cc
+++ b/tools/vector_gen/test/goal/sample_translator.cc
@@ -16,8 +16,8 @@ SampleTranslator::AllocateOutputVector() const {
   return std::make_unique<Sample<double>>();
 }
 
-void SampleTranslator::Serialize(double time,
-    const drake::systems::VectorBase<double>& vector_base,
+void SampleTranslator::Serialize(
+    double time, const drake::systems::VectorBase<double>& vector_base,
     std::vector<uint8_t>* lcm_message_bytes) const {
   const auto* const vector = dynamic_cast<const Sample<double>*>(&vector_base);
   DRAKE_DEMAND(vector != nullptr);
@@ -32,8 +32,8 @@ void SampleTranslator::Serialize(double time,
   message.encode(lcm_message_bytes->data(), 0, lcm_message_length);
 }
 
-void SampleTranslator::Deserialize(const void* lcm_message_bytes,
-    int lcm_message_length,
+void SampleTranslator::Deserialize(
+    const void* lcm_message_bytes, int lcm_message_length,
     drake::systems::VectorBase<double>* vector_base) const {
   DRAKE_DEMAND(vector_base != nullptr);
   auto* const my_vector = dynamic_cast<Sample<double>*>(vector_base);

--- a/tools/vector_gen/test/goal/sample_translator.h
+++ b/tools/vector_gen/test/goal/sample_translator.h
@@ -26,10 +26,10 @@ class SampleTranslator final
   std::unique_ptr<drake::systems::BasicVector<double>> AllocateOutputVector()
       const final;
   void Deserialize(const void* lcm_message_bytes, int lcm_message_length,
-      drake::systems::VectorBase<double>* vector_base) const final;
+                   drake::systems::VectorBase<double>* vector_base) const final;
   void Serialize(double time,
-      const drake::systems::VectorBase<double>& vector_base,
-      std::vector<uint8_t>* lcm_message_bytes) const final;
+                 const drake::systems::VectorBase<double>& vector_base,
+                 std::vector<uint8_t>* lcm_message_bytes) const final;
 };
 
 }  // namespace test


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10118)
<!-- Reviewable:end -->
