### PR TITLE
pydrake: Commmit selected clang-format results

### DIFF
--- a/bindings/BUILD.bazel
+++ b/bindings/BUILD.bazel
@@ -26,4 +26,7 @@ drake_pybind_library(
     package_info = get_bazel_workaround_4594_libdrake_package_info(),
 )
 
-add_lint_tests()
+add_lint_tests(
+    cpplint_data = ["//bindings/pydrake:.clang-format"],
+    enable_clang_format_lint = True,
+)

--- a/bindings/bazel_workaround_4594_libdrake_py.cc
+++ b/bindings/bazel_workaround_4594_libdrake_py.cc
@@ -4,8 +4,9 @@ namespace drake {
 namespace pydrake {
 
 PYBIND11_MODULE(bazel_workaround_4594_libdrake, m) {
-  m.doc() = "Consolidated workaround for bazelbuild/bazel#4594 to load "
-            "libdrake.so, to be used by `pydrake/__init__.py`.";
+  m.doc() =
+      "Consolidated workaround for bazelbuild/bazel#4594 to load "
+      "libdrake.so, to be used by `pydrake/__init__.py`.";
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/.clang-format
+++ b/bindings/pydrake/.clang-format
@@ -8,6 +8,12 @@
 # the way over to the open-paren.
 AlignAfterOpenBracket: DontAlign
 
+# Try to fit onto a single line:
+# - functions with an empty body, or
+# - member functions defined inside a class;
+# everything else (e.g., free functions) are forced onto multiple lines.
+AllowShortFunctionsOnASingleLine: Inline
+
 # -----------------------------------------------------------------------------
 # The contents of the root dotfile should be exactly copied below this point.
 # -----------------------------------------------------------------------------

--- a/bindings/pydrake/common/BUILD.bazel
+++ b/bindings/pydrake/common/BUILD.bazel
@@ -433,4 +433,8 @@ drake_py_unittest(
     ],
 )
 
-add_lint_tests()
+add_lint_tests(
+    cpplint_data = ["//bindings/pydrake:.clang-format"],
+    # TODO(jwnimmer-tri) We should enable this eventually.
+    enable_clang_format_lint = False,
+)

--- a/bindings/pydrake/common/cpp_param_pybind.cc
+++ b/bindings/pydrake/common/cpp_param_pybind.cc
@@ -75,8 +75,7 @@ py::object GetPyParamScalarImpl(const std::type_info& tinfo) {
       // once simpler dependencies are used (or something else is used to
       // justify linking in `libdrake.so`).
       const std::string name = tinfo.name();
-      throw std::runtime_error(
-          "C++ type is not registered in pybind: " + name);
+      throw std::runtime_error("C++ type is not registered in pybind: " + name);
     }
     py::handle h(reinterpret_cast<PyObject*>(info->type));
     return py::reinterpret_borrow<py::object>(h);

--- a/bindings/pydrake/common/cpp_param_pybind.h
+++ b/bindings/pydrake/common/cpp_param_pybind.h
@@ -43,7 +43,7 @@ inline py::object GetPyParamScalarImpl(
 /// @returns Python tuple of canonical parameters.
 /// @throws std::runtime_error on the first type it encounters that is neither
 /// aliased nor registered in `pybind11`.
-template <typename ... Ts>
+template <typename... Ts>
 inline py::tuple GetPyParam(type_pack<Ts...> = {}) {
   return py::make_tuple(internal::GetPyParamScalarImpl(type_pack<Ts>{})...);
 }

--- a/bindings/pydrake/common/cpp_template_pybind.h
+++ b/bindings/pydrake/common/cpp_template_pybind.h
@@ -39,18 +39,15 @@ inline void AddInstantiation(
 // Gets name for a given instantiation.
 inline std::string GetInstantiationName(
     py::handle py_template, py::tuple param) {
-  return py::cast<std::string>(
-    py_template.attr("_instantiation_name")(param));
+  return py::cast<std::string>(py_template.attr("_instantiation_name")(param));
 }
 
 }  // namespace internal
 
-
 /// Provides a temporary, unique name for a class instantiation that
 /// will be passed to `AddTemplateClass`.
 template <typename T>
-std::string TemporaryClassName(
-    const std::string& name = "TemporaryName") {
+std::string TemporaryClassName(const std::string& name = "TemporaryName") {
   return "_" + name + "_" + typeid(T).name();
 }
 
@@ -100,8 +97,7 @@ py::class_<Class, Options...> DefineTemplateClassWithDefault(
 /// @param param Parameters for the instantiation.
 template <typename Func>
 py::object AddTemplateFunction(
-    py::handle scope, const std::string& name, Func&& func,
-    py::tuple param) {
+    py::handle scope, const std::string& name, Func&& func, py::tuple param) {
   // TODO(eric.cousineau): Use `py::sibling` if overloads are needed.
   py::object py_template =
       internal::GetOrInitTemplate(scope, name, "TemplateFunction");
@@ -121,9 +117,8 @@ template <typename Method>
 py::object AddTemplateMethod(
     py::handle scope, const std::string& name, Method&& method,
     py::tuple param) {
-  py::object py_template =
-      internal::GetOrInitTemplate(
-          scope, name, "TemplateMethod", py::make_tuple(scope));
+  py::object py_template = internal::GetOrInitTemplate(
+      scope, name, "TemplateMethod", py::make_tuple(scope));
   py::object py_func = py::cpp_function(
       std::forward<Method>(method),
       py::name(internal::GetInstantiationName(py_template, param).c_str()),

--- a/bindings/pydrake/common/deprecation_pybind.h
+++ b/bindings/pydrake/common/deprecation_pybind.h
@@ -13,8 +13,7 @@ namespace pydrake {
 /// Deprecates an attribute `name` of a class `cls`.
 /// This *only* works with class attributes (unbound members or methods) as it
 /// is implemented with a Python property descriptor.
-inline void DeprecateAttribute(
-    py::object cls, py::str name, py::str message) {
+inline void DeprecateAttribute(py::object cls, py::str name, py::str message) {
   py::object deprecated =
       py::module::import("pydrake.common.deprecation").attr("deprecated");
   py::object original = cls.attr(name);

--- a/bindings/pydrake/common/drake_optional_pybind.h
+++ b/bindings/pydrake/common/drake_optional_pybind.h
@@ -15,12 +15,12 @@ namespace detail {
 // @see pybind11/stl.h, `optional_caster`.
 
 template <typename T>
-struct type_caster<stx::optional<T>> :
-    public optional_caster<stx::optional<T>> {};
+struct type_caster<stx::optional<T>>
+    : public optional_caster<stx::optional<T>> {};
 
-template<>
-struct type_caster<stx::nullopt_t> :
-    public void_caster<stx::nullopt_t> {};
+template <>
+struct type_caster<stx::nullopt_t>
+    : public void_caster<stx::nullopt_t> {};
 
 }  // namespace detail
 }  // namespace pybind11

--- a/bindings/pydrake/common/drake_variant_pybind.h
+++ b/bindings/pydrake/common/drake_variant_pybind.h
@@ -11,8 +11,8 @@ namespace detail {
 // @see pybind11/stl.h, `variant_caster`.
 
 template <typename... Types>
-struct type_caster<stx::variant<Types...>> :
-    public variant_caster<stx::variant<Types...>> {};
+struct type_caster<stx::variant<Types...>>
+    : public variant_caster<stx::variant<Types...>> {};
 
 }  // namespace detail
 }  // namespace pybind11

--- a/bindings/pydrake/common/eigen_geometry_py.cc
+++ b/bindings/pydrake/common/eigen_geometry_py.cc
@@ -34,8 +34,7 @@ template <typename T>
 void CheckRotMat(const Matrix3<T>& R) {
   // See `ExpectRotMat`.
   const T identity_error =
-      (R * R.transpose() - Matrix3<T>::Identity())
-      .array().abs().maxCoeff();
+      (R * R.transpose() - Matrix3<T>::Identity()).array().abs().maxCoeff();
   if (identity_error >= kCheckTolerance) {
     throw std::logic_error("Rotation matrix is not orthonormal");
   }
@@ -89,81 +88,80 @@ PYBIND11_MODULE(eigen_geometry, m) {
     using Class = Isometry3<T>;
     py::class_<Class> py_class(m, "Isometry3");
     py_class
-      .def(py::init([]() {
-        return Class::Identity();
-      }))
-      .def_static("Identity", []() {
-        return Class::Identity();
-      })
-      .def(py::init([](const Matrix4<T>& matrix) {
-        Class out(matrix);
-        CheckIsometry(out);
-        return out;
-      }), py::arg("matrix"))
-      .def(py::init([](
-          const Matrix3<T>& rotation,
-          const Vector3<T>& translation) {
-        CheckRotMat(rotation);
-        Class out = Class::Identity();
-        out.linear() = rotation;
-        out.translation() = translation;
-        return out;
-      }), py::arg("rotation"), py::arg("translation"))
-      .def(py::init([](
-          const Eigen::Quaternion<T>& q,
-          const Vector3<T>& translation) {
-        CheckQuaternion(q);
-        Class out = Class::Identity();
-        out.linear() = q.toRotationMatrix();
-        out.translation() = translation;
-        return out;
-      }), py::arg("quaternion"), py::arg("translation"))
-      .def(py::init([](const Class& other) {
-        CheckIsometry(other);
-        return other;
-      }), py::arg("other"))
-      .def("matrix", [](const Class* self) -> Matrix4<T> {
-        return self->matrix();
-      })
-      .def("set_matrix", [](Class* self, const Matrix4<T>& matrix) {
-        Class update(matrix);
-        CheckIsometry(update);
-        *self = update;
-      })
-      .def("translation", [](const Class* self) -> Vector3<T> {
-        return self->translation();
-      })
-      .def("set_translation", [](Class* self, const Vector3<T>& translation) {
-        self->translation() = translation;
-      })
-      .def("rotation", [](const Class* self) -> Matrix3<T> {
-        return self->linear();
-      })
-      .def("set_rotation", [](Class* self, const Matrix3<T>& rotation) {
-        CheckRotMat(rotation);
-        self->linear() = rotation;
-      })
-      .def("quaternion", [](const Class* self) {
-        return Eigen::Quaternion<T>(self->linear());
-      })
-      .def("set_quaternion", [](Class* self, const Eigen::Quaternion<T>& q) {
-        CheckQuaternion(q);
-        self->linear() = q.toRotationMatrix();
-      })
-      .def("__str__", [](py::object self) {
-        return py::str(self.attr("matrix")());
-      })
-      // Do not define operator `__mul__` until we have the Python3 `@`
-      // operator so that operations are similar to those of arrays.
-      .def("multiply", [](const Class& self, const Class& other) {
-        return self * other;
-      }, py::arg("other"))
-      .def("multiply", [](const Class& self, const Vector3<T>& position) {
-        return self * position;
-      }, py::arg("position"))
-      .def("inverse", [](const Class* self) {
-        return self->inverse();
-      });
+        .def(py::init([]() { return Class::Identity(); }))
+        .def_static("Identity", []() { return Class::Identity(); })
+        .def(py::init([](const Matrix4<T>& matrix) {
+          Class out(matrix);
+          CheckIsometry(out);
+          return out;
+        }),
+            py::arg("matrix"))
+        .def(py::init(
+                 [](const Matrix3<T>& rotation, const Vector3<T>& translation) {
+                   CheckRotMat(rotation);
+                   Class out = Class::Identity();
+                   out.linear() = rotation;
+                   out.translation() = translation;
+                   return out;
+                 }),
+            py::arg("rotation"), py::arg("translation"))
+        .def(py::init([](const Eigen::Quaternion<T>& q,
+                          const Vector3<T>& translation) {
+          CheckQuaternion(q);
+          Class out = Class::Identity();
+          out.linear() = q.toRotationMatrix();
+          out.translation() = translation;
+          return out;
+        }),
+            py::arg("quaternion"), py::arg("translation"))
+        .def(py::init([](const Class& other) {
+          CheckIsometry(other);
+          return other;
+        }),
+            py::arg("other"))
+        .def("matrix",
+            [](const Class* self) -> Matrix4<T> { return self->matrix(); })
+        .def("set_matrix",
+            [](Class* self, const Matrix4<T>& matrix) {
+              Class update(matrix);
+              CheckIsometry(update);
+              *self = update;
+            })
+        .def("translation",
+            [](const Class* self) -> Vector3<T> { return self->translation(); })
+        .def("set_translation",
+            [](Class* self, const Vector3<T>& translation) {
+              self->translation() = translation;
+            })
+        .def("rotation",
+            [](const Class* self) -> Matrix3<T> { return self->linear(); })
+        .def("set_rotation",
+            [](Class* self, const Matrix3<T>& rotation) {
+              CheckRotMat(rotation);
+              self->linear() = rotation;
+            })
+        .def("quaternion",
+            [](const Class* self) {
+              return Eigen::Quaternion<T>(self->linear());
+            })
+        .def("set_quaternion",
+            [](Class* self, const Eigen::Quaternion<T>& q) {
+              CheckQuaternion(q);
+              self->linear() = q.toRotationMatrix();
+            })
+        .def("__str__",
+            [](py::object self) { return py::str(self.attr("matrix")()); })
+        // Do not define operator `__mul__` until we have the Python3 `@`
+        // operator so that operations are similar to those of arrays.
+        .def("multiply",
+            [](const Class& self, const Class& other) { return self * other; },
+            py::arg("other"))
+        .def("multiply",
+            [](const Class& self, const Vector3<T>& position) {
+              return self * position;
+            },
+            py::arg("position"))
+        .def("inverse", [](const Class* self) { return self->inverse(); });
     py::implicitly_convertible<Matrix4<T>, Class>();
   }
 
@@ -178,156 +176,161 @@ PYBIND11_MODULE(eigen_geometry, m) {
         "Provides a unit quaternion binding of Eigen::Quaternion<>.";
     py::object py_class_obj = py_class;
     py_class
-      .def(py::init([]() {
-        return Class::Identity();
-      }))
-      .def_static("Identity", []() {
-        return Class::Identity();
-      })
-      .def(py::init([](const Vector4<T>& wxyz) {
-        Class out(wxyz(0), wxyz(1), wxyz(2), wxyz(3));
-        CheckQuaternion(out);
-        return out;
-      }), py::arg("wxyz"))
-      .def(py::init([](T w, T x, T y, T z) {
-        Class out(w, x, y, z);
-        CheckQuaternion(out);
-        return out;
-      }), py::arg("w"), py::arg("x"), py::arg("y"), py::arg("z"))
-      .def(py::init([](const Matrix3<T>& rotation) {
-        Class out(rotation);
-        CheckQuaternion(out);
-        return out;
-      }), py::arg("rotation"))
-      .def(py::init([](const Class& other) {
-        CheckQuaternion(other);
-        return other;
-      }), py::arg("other"))
-      .def("w", [](const Class* self) { return self->w(); })
-      .def("x", [](const Class* self) { return self->x(); })
-      .def("y", [](const Class* self) { return self->y(); })
-      .def("z", [](const Class* self) { return self->z(); })
-      .def("xyz", [](const Class* self) { return self->vec(); })
-      .def("wxyz", [](Class* self) {
-        Vector4<T> wxyz;
-        wxyz << self->w(), self->vec();
-        return wxyz;
-      })
-      .def("set_wxyz", [](Class* self, const Vector4<T>& wxyz) {
-        Class update;
-        update.w() = wxyz(0);
-        update.vec() = wxyz.tail(3);
-        CheckQuaternion(update);
-        *self = update;
-      }, py::arg("wxyz"))
-      .def("set_wxyz", [](Class* self, T w, T x, T y, T z) {
-        Class update(w, x, y, z);
-        CheckQuaternion(update);
-        *self = update;
-      }, py::arg("w"), py::arg("x"), py::arg("y"), py::arg("z"))
-      .def("rotation", [](const Class* self) {
-        return self->toRotationMatrix();
-      })
-      .def("set_rotation", [](Class* self, const Matrix3<T>& rotation) {
-        Class update(rotation);
-        CheckQuaternion(update);
-        *self = update;
-      })
-      .def("__str__", [py_class_obj](const Class* self) {
-        return py::str("{}(w={}, x={}, y={}, z={})").format(
-            py_class_obj.attr("__name__"),
-            self->w(), self->x(), self->y(), self->z());
-      })
-      // Do not define operator `__mul__` until we have the Python3 `@`
-      // operator so that operations are similar to those of arrays.
-      .def("multiply", [](const Class& self, const Class& other) {
-        return self * other;
-      })
-      .def("multiply", [](const Class& self, const Vector3<T>& position) {
-        return self * position;
-      }, py::arg("position"))
-      .def("inverse", [](const Class* self) {
-        return self->inverse();
-      })
-      .def("conjugate", [](const Class* self) {
-        return self->conjugate();
-      });
+        .def(py::init([]() { return Class::Identity(); }))
+        .def_static("Identity", []() { return Class::Identity(); })
+        .def(py::init([](const Vector4<T>& wxyz) {
+          Class out(wxyz(0), wxyz(1), wxyz(2), wxyz(3));
+          CheckQuaternion(out);
+          return out;
+        }),
+            py::arg("wxyz"))
+        .def(py::init([](T w, T x, T y, T z) {
+          Class out(w, x, y, z);
+          CheckQuaternion(out);
+          return out;
+        }),
+            py::arg("w"), py::arg("x"), py::arg("y"), py::arg("z"))
+        .def(py::init([](const Matrix3<T>& rotation) {
+          Class out(rotation);
+          CheckQuaternion(out);
+          return out;
+        }),
+            py::arg("rotation"))
+        .def(py::init([](const Class& other) {
+          CheckQuaternion(other);
+          return other;
+        }),
+            py::arg("other"))
+        .def("w", [](const Class* self) { return self->w(); })
+        .def("x", [](const Class* self) { return self->x(); })
+        .def("y", [](const Class* self) { return self->y(); })
+        .def("z", [](const Class* self) { return self->z(); })
+        .def("xyz", [](const Class* self) { return self->vec(); })
+        .def("wxyz",
+            [](Class* self) {
+              Vector4<T> wxyz;
+              wxyz << self->w(), self->vec();
+              return wxyz;
+            })
+        .def("set_wxyz",
+            [](Class* self, const Vector4<T>& wxyz) {
+              Class update;
+              update.w() = wxyz(0);
+              update.vec() = wxyz.tail(3);
+              CheckQuaternion(update);
+              *self = update;
+            },
+            py::arg("wxyz"))
+        .def("set_wxyz",
+            [](Class* self, T w, T x, T y, T z) {
+              Class update(w, x, y, z);
+              CheckQuaternion(update);
+              *self = update;
+            },
+            py::arg("w"), py::arg("x"), py::arg("y"), py::arg("z"))
+        .def("rotation",
+            [](const Class* self) { return self->toRotationMatrix(); })
+        .def("set_rotation",
+            [](Class* self, const Matrix3<T>& rotation) {
+              Class update(rotation);
+              CheckQuaternion(update);
+              *self = update;
+            })
+        .def("__str__",
+            [py_class_obj](const Class* self) {
+              return py::str("{}(w={}, x={}, y={}, z={})")
+                  .format(py_class_obj.attr("__name__"), self->w(), self->x(),
+                      self->y(), self->z());
+            })
+        // Do not define operator `__mul__` until we have the Python3 `@`
+        // operator so that operations are similar to those of arrays.
+        .def("multiply",
+            [](const Class& self, const Class& other) { return self * other; })
+        .def("multiply",
+            [](const Class& self, const Vector3<T>& position) {
+              return self * position;
+            },
+            py::arg("position"))
+        .def("inverse", [](const Class* self) { return self->inverse(); })
+        .def("conjugate", [](const Class* self) { return self->conjugate(); });
   }
 
   // Angle-axis.
   {
     using Class = Eigen::AngleAxis<T>;
     py::class_<Class> py_class(m, "AngleAxis");
-    py_class.attr("__doc__") =
-        "Bindings for Eigen::AngleAxis<>.";
+    py_class.attr("__doc__") = "Bindings for Eigen::AngleAxis<>.";
     py::object py_class_obj = py_class;
     py_class
-      .def(py::init([]() {
-        return Class::Identity();
-      }))
-      .def_static("Identity", []() {
-        return Class::Identity();
-      })
-      .def(py::init([](const T& angle, const Vector3<T>& axis) {
-        Class out(angle, axis);
-        CheckAngleAxis(out);
-        return out;
-      }), py::arg("angle"), py::arg("axis"))
-      .def(py::init([](const Eigen::Quaternion<T>& q) {
-        Class out(q);
-        CheckAngleAxis(out);
-        return out;
-      }), py::arg("quaternion"))
-      .def(py::init([](const Matrix3<T>& rotation) {
-        Class out(rotation);
-        CheckAngleAxis(out);
-        return out;
-      }), py::arg("rotation"))
-      .def(py::init([](const Class& other) {
-        CheckAngleAxis(other);
-        return other;
-      }), py::arg("other"))
-      .def("angle", [](const Class* self) { return self->angle(); })
-      .def("axis", [](const Class* self) { return self->axis(); })
-      .def("set_angle", [](Class* self, const T& angle) {
-        // N.B. Since `axis` should already be valid, do not need to check.
-        self->angle() = angle;
-      }, py::arg("angle"))
-      .def("set_axis", [](Class* self, const Vector3<T>& axis) {
-        Class update(self->angle(), axis);
-        CheckAngleAxis(update);
-        *self = update;
-      }, py::arg("axis"))
-      .def("rotation", [](const Class* self) {
-        return self->toRotationMatrix();
-      })
-      .def("set_rotation", [](Class* self, const Matrix3<T>& rotation) {
-        Class update(rotation);
-        CheckAngleAxis(update);
-        *self = update;
-      })
-      .def("quaternion", [](const Class* self) {
-        return Eigen::Quaternion<T>(*self);
-      })
-      .def("set_quaternion", [](Class* self, const Eigen::Quaternion<T>& q) {
-        CheckQuaternion(q);
-        Class update(q);
-        CheckAngleAxis(update);
-        *self = update;
-      })
-      .def("__str__", [py_class_obj](const Class* self) {
-        return py::str("{}(angle={}, axis={})").format(
-            py_class_obj.attr("__name__"),
-            self->angle(), self->axis());
-      })
-      // Do not define operator `__mul__` until we have the Python3 `@`
-      // operator so that operations are similar to those of arrays.
-      .def("multiply", [](const Class& self, const Class& other) {
-        return self * other;
-      })
-      .def("inverse", [](const Class* self) {
-        return self->inverse();
-      });
+        .def(py::init([]() { return Class::Identity(); }))
+        .def_static("Identity", []() { return Class::Identity(); })
+        .def(py::init([](const T& angle, const Vector3<T>& axis) {
+          Class out(angle, axis);
+          CheckAngleAxis(out);
+          return out;
+        }),
+            py::arg("angle"), py::arg("axis"))
+        .def(py::init([](const Eigen::Quaternion<T>& q) {
+          Class out(q);
+          CheckAngleAxis(out);
+          return out;
+        }),
+            py::arg("quaternion"))
+        .def(py::init([](const Matrix3<T>& rotation) {
+          Class out(rotation);
+          CheckAngleAxis(out);
+          return out;
+        }),
+            py::arg("rotation"))
+        .def(py::init([](const Class& other) {
+          CheckAngleAxis(other);
+          return other;
+        }),
+            py::arg("other"))
+        .def("angle", [](const Class* self) { return self->angle(); })
+        .def("axis", [](const Class* self) { return self->axis(); })
+        .def("set_angle",
+            [](Class* self, const T& angle) {
+              // N.B. Since `axis` should already be valid, do not need to
+              // check.
+              self->angle() = angle;
+            },
+            py::arg("angle"))
+        .def("set_axis",
+            [](Class* self, const Vector3<T>& axis) {
+              Class update(self->angle(), axis);
+              CheckAngleAxis(update);
+              *self = update;
+            },
+            py::arg("axis"))
+        .def("rotation",
+            [](const Class* self) { return self->toRotationMatrix(); })
+        .def("set_rotation",
+            [](Class* self, const Matrix3<T>& rotation) {
+              Class update(rotation);
+              CheckAngleAxis(update);
+              *self = update;
+            })
+        .def("quaternion",
+            [](const Class* self) { return Eigen::Quaternion<T>(*self); })
+        .def("set_quaternion",
+            [](Class* self, const Eigen::Quaternion<T>& q) {
+              CheckQuaternion(q);
+              Class update(q);
+              CheckAngleAxis(update);
+              *self = update;
+            })
+        .def("__str__",
+            [py_class_obj](const Class* self) {
+              return py::str("{}(angle={}, axis={})")
+                  .format(py_class_obj.attr("__name__"), self->angle(),
+                      self->axis());
+            })
+        // Do not define operator `__mul__` until we have the Python3 `@`
+        // operator so that operations are similar to those of arrays.
+        .def("multiply",
+            [](const Class& self, const Class& other) { return self * other; })
+        .def("inverse", [](const Class* self) { return self->inverse(); });
   }
 }
 

--- a/bindings/pydrake/common/eigen_geometry_pybind.h
+++ b/bindings/pydrake/common/eigen_geometry_pybind.h
@@ -51,14 +51,14 @@ struct type_caster_wrapped {
     DRAKE_DEMAND(loaded_);
     return value_;
   }
-  template <typename T> using cast_op_type =
-      py::detail::movable_cast_op_type<T>;
+  template <typename T>
+  using cast_op_type = py::detail::movable_cast_op_type<T>;
   static constexpr auto name = WrappedTypeCaster::props::descriptor;
 
   // C++ to Python.
   template <typename TType>
-  static py::handle cast(TType&& src, py::return_value_policy policy,
-      py::handle parent) {
+  static py::handle cast(
+      TType&& src, py::return_value_policy policy, py::handle parent) {
     if (policy == py::return_value_policy::reference ||
         policy == py::return_value_policy::reference_internal) {
       // N.B. We must declare a local `static constexpr` here to prevent
@@ -68,8 +68,7 @@ struct type_caster_wrapped {
       // example.
       static constexpr auto original_name = Wrapper::original_name;
       throw py::cast_error(
-          std::string("Can only pass ") + original_name.text +
-          " by value.");
+          std::string("Can only pass ") + original_name.text + " by value.");
     }
     return WrappedTypeCaster::cast(
         Wrapper::wrap(std::forward<TType>(src)), policy, parent);
@@ -92,9 +91,7 @@ struct wrapper_eigen_translation {
   static Type unwrap(const WrappedType& arg_wrapped) {
     return Type(arg_wrapped);
   }
-  static WrappedType wrap(const Type& arg) {
-    return arg.vector();
-  }
+  static WrappedType wrap(const Type& arg) { return arg.vector(); }
 };
 
 // N.B. Since `Isometry3<>` and `Eigen::Quaternion<>` have more
@@ -110,7 +107,7 @@ namespace detail {
 template <typename T, int Dim>
 struct type_caster<Eigen::Translation<T, Dim>>
     : public drake::pydrake::detail::type_caster_wrapped<
-        drake::pydrake::detail::wrapper_eigen_translation<T, Dim>> {};
+          drake::pydrake::detail::wrapper_eigen_translation<T, Dim>> {};
 
 }  // namespace detail
 }  // namespace pybind11

--- a/bindings/pydrake/common/eigen_pybind.h
+++ b/bindings/pydrake/common/eigen_pybind.h
@@ -23,8 +23,8 @@ py::object ToArray(T* ptr, int size, py::tuple shape) {
   // Create flat array to be reshaped in numpy.
   using Vector = VectorX<T>;
   Eigen::Map<Vector> data(ptr, size);
-  return py::cast(
-      Eigen::Ref<Vector>(data), py_reference).attr("reshape")(shape);
+  return py::cast(Eigen::Ref<Vector>(data), py_reference)
+      .attr("reshape")(shape);
 }
 
 /// Converts a raw array to a numpy array (`const` variant).
@@ -33,8 +33,8 @@ py::object ToArray(const T* ptr, int size, py::tuple shape) {
   // Create flat array to be reshaped in numpy.
   using Vector = const VectorX<T>;
   Eigen::Map<Vector> data(ptr, size);
-  return py::cast(
-      Eigen::Ref<Vector>(data), py_reference).attr("reshape")(shape);
+  return py::cast(Eigen::Ref<Vector>(data), py_reference)
+      .attr("reshape")(shape);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/common/module_py.cc
+++ b/bindings/pydrake/common/module_py.cc
@@ -30,64 +30,63 @@ PYBIND11_MODULE(_module_py, m) {
   constexpr auto& doc = pydrake_doc.drake;
   m.attr("_HAVE_SPDLOG") = logging::kHaveSpdlog;
 
-  py::enum_<drake::RandomDistribution>(m, "RandomDistribution",
-    doc.RandomDistribution.doc)
-    .value("kUniform", drake::RandomDistribution::kUniform,
-    doc.RandomDistribution.kUniform.doc)
-    .value("kGaussian", drake::RandomDistribution::kGaussian,
-    doc.RandomDistribution.kGaussian.doc)
-    .value("kExponential", drake::RandomDistribution::kExponential,
-    doc.RandomDistribution.kExponential.doc);
+  py::enum_<drake::RandomDistribution>(
+      m, "RandomDistribution", doc.RandomDistribution.doc)
+      .value("kUniform", drake::RandomDistribution::kUniform,
+          doc.RandomDistribution.kUniform.doc)
+      .value("kGaussian", drake::RandomDistribution::kGaussian,
+          doc.RandomDistribution.kGaussian.doc)
+      .value("kExponential", drake::RandomDistribution::kExponential,
+          doc.RandomDistribution.kExponential.doc);
 
-// Turn DRAKE_ASSERT and DRAKE_DEMAND exceptions into native SystemExit.
+  // Turn DRAKE_ASSERT and DRAKE_DEMAND exceptions into native SystemExit.
   // Admittedly, it's unusual for a python library like pydrake to raise
   // SystemExit, but for now its better than C++ ::abort() taking down the
   // whole interpreter with a worse diagnostic message.
   py::register_exception_translator([](std::exception_ptr p) {
-      try {
-        if (p) { std::rethrow_exception(p); }
-      } catch (const drake::detail::assertion_error& e) {
-        PyErr_SetString(PyExc_SystemExit, e.what());
+    try {
+      if (p) {
+        std::rethrow_exception(p);
       }
-    });
+    } catch (const drake::detail::assertion_error& e) {
+      PyErr_SetString(PyExc_SystemExit, e.what());
+    }
+  });
   // Convenient wrapper to add a resource search path.
   m.def("AddResourceSearchPath", &AddResourceSearchPath,
-        "Adds a path in which to search for resource files. "
-        "The path refers to the relative path within the Drake repository, ",
-        py::arg("search_path"),
-        doc.AddResourceSearchPath.doc);
+      "Adds a path in which to search for resource files. "
+      "The path refers to the relative path within the Drake repository, ",
+      py::arg("search_path"), doc.AddResourceSearchPath.doc);
   // Convenient wrapper to get the list of resource search paths.
   m.def("GetResourceSearchPaths", &GetResourceSearchPaths,
-        "Gets a copy of the list of paths set programmatically in which "
-        "resource files are searched.",
-        doc.GetResourceSearchPaths.doc);
+      "Gets a copy of the list of paths set programmatically in which "
+      "resource files are searched.",
+      doc.GetResourceSearchPaths.doc);
   // Convenient wrapper for querying FindResource(resource_path).
   m.def("FindResourceOrThrow", &FindResourceOrThrow,
-        "Attempts to locate a Drake resource named by the given path string. "
-        "The path refers to the relative path within the Drake repository, "
-        "e.g., drake/examples/pendulum/Pendulum.urdf. Raises an exception "
-        "if the resource was not found.",
-        py::arg("resource_path"),
-        doc.FindResourceOrThrow.doc);
+      "Attempts to locate a Drake resource named by the given path string. "
+      "The path refers to the relative path within the Drake repository, "
+      "e.g., drake/examples/pendulum/Pendulum.urdf. Raises an exception "
+      "if the resource was not found.",
+      py::arg("resource_path"), doc.FindResourceOrThrow.doc);
   m.def("temp_directory", &temp_directory,
-        "Returns a directory location suitable for temporary files that is "
-        "the value of the environment variable TEST_TMPDIR if defined or "
-        "otherwise ${TMPDIR:-/tmp}/robotlocomotion_drake_XXXXXX where each X "
-        "is replaced by a character from the portable filename character set. "
-        "Any trailing / will be stripped from the output.",
-        doc.temp_directory.doc);
-  // Returns the fully-qualified path to the root of the `drake` source tree.
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  m.def("GetDrakePath", &GetDrakePath,
-        "Get Drake path", doc.GetDrakePath.doc);
-  #pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
+      "Returns a directory location suitable for temporary files that is "
+      "the value of the environment variable TEST_TMPDIR if defined or "
+      "otherwise ${TMPDIR:-/tmp}/robotlocomotion_drake_XXXXXX where each X "
+      "is replaced by a character from the portable filename character set. "
+      "Any trailing / will be stripped from the output.",
+      doc.temp_directory.doc);
+// Returns the fully-qualified path to the root of the `drake` source tree.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  m.def("GetDrakePath", &GetDrakePath, "Get Drake path", doc.GetDrakePath.doc);
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
   // These are meant to be called internally by pydrake; not by users.
   m.def("set_assertion_failure_to_throw_exception",
-        &drake_set_assertion_failure_to_throw_exception,
-        "Set Drake's assertion failure mechanism to be exceptions");
+      &drake_set_assertion_failure_to_throw_exception,
+      "Set Drake's assertion failure mechanism to be exceptions");
   m.def("trigger_an_assertion_failure", &trigger_an_assertion_failure,
-        "Trigger a Drake C++ assertion failure");
+      "Trigger a Drake C++ assertion failure");
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/common/test/cpp_param_pybind_test.cc
+++ b/bindings/pydrake/common/test/cpp_param_pybind_test.cc
@@ -22,7 +22,7 @@ bool PyEquals(py::object lhs, py::object rhs) {
 }
 
 // Ensures that the type `T` maps to the expression in `py_expr_expected`.
-template <typename ... Ts>
+template <typename... Ts>
 bool CheckPyParam(const string& py_expr_expected, type_pack<Ts...> param = {}) {
   py::object actual = GetPyParam(param);
   py::object expected = py::eval(py_expr_expected.c_str());

--- a/bindings/pydrake/common/test/cpp_template_pybind_test.cc
+++ b/bindings/pydrake/common/test/cpp_template_pybind_test.cc
@@ -22,22 +22,21 @@ namespace drake {
 namespace pydrake {
 namespace {
 
-template <typename ... Ts>
+template <typename... Ts>
 struct SimpleTemplate {
   vector<string> GetNames() {
     return {NiceTypeName::Get<Ts>()...};
   }
 };
 
-template <typename ... Ts>
+template <typename... Ts>
 py::object BindSimpleTemplate(py::module m) {
   using Class = SimpleTemplate<Ts...>;
   py::class_<Class> py_class(m, TemporaryClassName<Class>().c_str());
   py_class
       .def(py::init<>())
       .def("GetNames", &Class::GetNames);
-  AddTemplateClass(
-      m, "SimpleTemplate", py_class, GetPyParam<Ts...>());
+  AddTemplateClass(m, "SimpleTemplate", py_class, GetPyParam<Ts...>());
   return py_class;
 }
 
@@ -78,7 +77,7 @@ GTEST_TEST(CppTemplateTest, TemplateClass) {
       R"([^\0]*incompatible function arguments[^\0]*\(arg0: __main__\.SimpleTemplate\[int\]\)[^\0]*)");  // NOLINT
 }
 
-template <typename ... Ts>
+template <typename... Ts>
 vector<string> SimpleFunction() {
   return {NiceTypeName::Get<Ts>()...};
 }
@@ -100,7 +99,7 @@ GTEST_TEST(CppTemplateTest, TemplateFunction) {
 }
 
 struct SimpleType {
-  template <typename ... Ts>
+  template <typename... Ts>
   vector<string> SimpleMethod() {
     return {NiceTypeName::Get<Ts>()...};
   }

--- a/bindings/pydrake/common/test/eigen_geometry_test_util_py.cc
+++ b/bindings/pydrake/common/test/eigen_geometry_test_util_py.cc
@@ -23,9 +23,7 @@ PYBIND11_MODULE(eigen_geometry_test_util, m) {
 
   using T = double;
 
-  m.def("create_isometry", []() {
-    return Isometry3<T>::Identity();
-  });
+  m.def("create_isometry", []() { return Isometry3<T>::Identity(); });
   m.def("check_isometry", [](const Isometry3d& X) {
     const T error =
         (X.matrix() - Isometry3<T>::Identity().matrix())
@@ -33,17 +31,14 @@ PYBIND11_MODULE(eigen_geometry_test_util, m) {
     DRAKE_THROW_UNLESS(error < kTolerance);
   });
 
-  m.def("create_translation", []() {
-    return Translation3<T>(Vector3<T>::Zero());
-  });
+  m.def("create_translation",
+      []() { return Translation3<T>(Vector3<T>::Zero()); });
   m.def("check_translation", [](const Translation3<T>& p) {
     const T error = p.vector().array().abs().maxCoeff();
     DRAKE_THROW_UNLESS(error < kTolerance);
   });
 
-  m.def("create_quaternion", []() {
-    return Quaternion<T>::Identity();
-  });
+  m.def("create_quaternion", []() { return Quaternion<T>::Identity(); });
   m.def("check_quaternion", [](const Quaternion<T>& q) {
     const T error =
         (q.coeffs() - Quaternion<T>::Identity().coeffs())

--- a/bindings/pydrake/common/test/type_pack_test.cc
+++ b/bindings/pydrake/common/test/type_pack_test.cc
@@ -39,24 +39,22 @@ GTEST_TEST(TypeUtilTest, TypeTags) {
   // Ensure that we can default-construct tags for types that are not
   // default-constructible.
   auto tag_check = type_tag<void>{};
-  EXPECT_TRUE((std::is_same<
-      decltype(tag_check), type_tag<void>>::value));
+  EXPECT_TRUE((std::is_same<decltype(tag_check), type_tag<void>>::value));
   auto pack_check_empty = type_pack<>{};
-  EXPECT_TRUE((std::is_same<
-      decltype(pack_check_empty), type_pack<>>::value));
+  EXPECT_TRUE((std::is_same<decltype(pack_check_empty), type_pack<>>::value));
   auto pack_check = type_pack<void, void>{};
-  EXPECT_TRUE((std::is_same<
-      decltype(pack_check), type_pack<void, void>>::value));
+  EXPECT_TRUE(
+      (std::is_same<decltype(pack_check), type_pack<void, void>>::value));
 }
 
 GTEST_TEST(TypeUtilTest, Bind) {
   using T_0 = Pack::bind<SimpleTemplate>;
-  EXPECT_TRUE((std::is_same<
-      T_0, SimpleTemplate<int, double, char, void>>::value));
+  EXPECT_TRUE(
+      (std::is_same<T_0, SimpleTemplate<int, double, char, void>>::value));
   Pack pack;
   using T_1 = decltype(type_bind<SimpleTemplate>(pack));
-  EXPECT_TRUE((std::is_same<
-      T_1, SimpleTemplate<int, double, char, void>>::value));
+  EXPECT_TRUE(
+      (std::is_same<T_1, SimpleTemplate<int, double, char, void>>::value));
 }
 
 GTEST_TEST(TypeUtilTest, Extract) {
@@ -66,8 +64,8 @@ GTEST_TEST(TypeUtilTest, Extract) {
 }
 
 GTEST_TEST(TypeUtilTest, Visit) {
-  using PackTags = type_pack<
-      type_tag<int>, type_tag<double>, type_tag<char>, type_tag<void>>;
+  using PackTags = type_pack<type_tag<int>, type_tag<double>, type_tag<char>,
+      type_tag<void>>;
   vector<string> names;
   const vector<string> names_expected = {"int", "double", "char", "void"};
 

--- a/bindings/pydrake/common/test/type_safe_index_pybind_test.cc
+++ b/bindings/pydrake/common/test/type_safe_index_pybind_test.cc
@@ -39,9 +39,7 @@ GTEST_TEST(TypeSafeIndexTest, CheckCasting) {
   CheckValue("pass_thru_int(Index(10))", 10);
   // TypeSafeIndex<> is not implicitly constructible from an int.
   py::object py_int = py::eval("10");
-  ASSERT_THROW(
-      py_int.cast<Index>(),
-      std::runtime_error);
+  ASSERT_THROW(py_int.cast<Index>(), std::runtime_error);
 
   m.def("pass_thru_index", [](Index x) {
     EXPECT_EQ(x, 10);
@@ -53,9 +51,7 @@ GTEST_TEST(TypeSafeIndexTest, CheckCasting) {
   // TypeSafeIndex<> is not implicitly constructible from an int.
   // TODO(eric.cousineau): Consider relaxing this to *only* accept `int`s, and
   // puke if another `TypeSafeIndex<U>` is encountered.
-  ASSERT_THROW(
-      py::eval("pass_thru_index(10)"),
-      std::runtime_error);
+  ASSERT_THROW(py::eval("pass_thru_index(10)"), std::runtime_error);
   CheckValue("pass_thru_index(Index(10))", 10);
   CheckValue("pass_thru_index(Index(10))", Index{10});
 
@@ -63,13 +59,9 @@ GTEST_TEST(TypeSafeIndexTest, CheckCasting) {
   using OtherIndex = TypeSafeIndex<OtherTag>;
   BindTypeSafeIndex<OtherIndex>(m, "OtherIndex");
 
-  ASSERT_THROW(
-      py::eval("pass_thru_index(OtherIndex(10))"),
-      std::runtime_error);
+  ASSERT_THROW(py::eval("pass_thru_index(OtherIndex(10))"), std::runtime_error);
   py::object py_index = py::eval("Index(10)");
-  ASSERT_THROW(
-      py_index.cast<OtherIndex>(),
-      std::runtime_error);
+  ASSERT_THROW(py_index.cast<OtherIndex>(), std::runtime_error);
 
   CheckValue("Index(10) == Index(10)", true);
   CheckValue("Index(10) == 10", true);

--- a/bindings/pydrake/common/type_pack.h
+++ b/bindings/pydrake/common/type_pack.h
@@ -12,19 +12,19 @@
 
 namespace drake {
 
-template <typename ... Ts>
+template <typename... Ts>
 struct type_pack;
 
 namespace detail {
 
 // Provides type at given index.
-template <size_t N, size_t K, typename T, typename ... Ts>
+template <size_t N, size_t K, typename T, typename... Ts>
 struct type_at_impl {
   using type = typename type_at_impl<N, K + 1, Ts...>::type;
 };
 
 // Base case.
-template <size_t N, typename T, typename ... Ts>
+template <size_t N, typename T, typename... Ts>
 struct type_at_impl<N, N, T, Ts...> {
   using type = T;
 };
@@ -52,7 +52,7 @@ struct type_pack_extract_impl {
   static_assert(!std::is_same<T, T>::value, "Wrong template");
 };
 
-template <template <typename ... Ts> class Tpl, typename ... Ts>
+template <template <typename... Ts> class Tpl, typename... Ts>
 struct type_pack_extract_impl<Tpl<Ts...>> {
   using type = type_pack<Ts...>;
 };
@@ -69,9 +69,8 @@ struct assert_default_constructible {
 
 }  // namespace detail
 
-
 /// Extracts the Ith type from a sequence of types.
-template <size_t I, typename ... Ts>
+template <size_t I, typename... Ts>
 struct type_at {
   static_assert(I >= 0 && I < sizeof...(Ts), "Invalid type index");
   using type = typename detail::type_at_impl<I, 0, Ts...>::type;
@@ -97,7 +96,7 @@ struct template_single_tag {
 };
 
 /// Provides a tag to pass a parameter packs for ease of inference.
-template <typename ... Ts>
+template <typename... Ts>
 struct type_pack {
   /// Number of template parameters.
   static constexpr int size = sizeof...(Ts);
@@ -113,7 +112,7 @@ struct type_pack {
 
 /// Returns an expression (only to be used in `decltype`) for inferring
 /// and binding a parameter pack to a template.
-template <template <typename...> class Tpl, typename ... Ts>
+template <template <typename...> class Tpl, typename... Ts>
 Tpl<Ts...> type_bind(type_pack<Ts...>);
 
 /// Extracts the inner template arguments (typename only) for a typename which

--- a/bindings/pydrake/common/type_safe_index_pybind.h
+++ b/bindings/pydrake/common/type_safe_index_pybind.h
@@ -13,22 +13,20 @@ namespace pydrake {
 
 /// Binds a TypeSafeIndex instantiation.
 template <typename Type>
-auto BindTypeSafeIndex(py::module m, const std::string& name,
-                       const std::string& class_doc = "") {
+auto BindTypeSafeIndex(
+    py::module m, const std::string& name, const std::string& class_doc = "") {
   py::class_<Type> cls(m, name.c_str(), class_doc.c_str());
   cls
-    .def(py::init<int>(),
-         pydrake_doc.drake.TypeSafeIndex.ctor.doc_2)
-    .def("__int__", &Type::operator int)
-    .def("__eq__", [](const Type* self, const Type* other) {
-      return *self == *other;
-    }, py::is_operator())
-    .def("__eq__", [](const Type* self, int other) {
-      return *self == other;
-    }, py::is_operator())
-    // TODO(eric.cousineau): Add more operators.
-    .def("is_valid", &Type::is_valid,
-         pydrake_doc.drake.TypeSafeIndex.is_valid.doc);
+      .def(py::init<int>(), pydrake_doc.drake.TypeSafeIndex.ctor.doc_2)
+      .def("__int__", &Type::operator int)
+      .def("__eq__",
+          [](const Type* self, const Type* other) { return *self == *other; },
+          py::is_operator())
+      .def("__eq__", [](const Type* self, int other) { return *self == other; },
+          py::is_operator())
+      // TODO(eric.cousineau): Add more operators.
+      .def("is_valid", &Type::is_valid,
+          pydrake_doc.drake.TypeSafeIndex.is_valid.doc);
   return cls;
 }
 

--- a/bindings/pydrake/util/BUILD.bazel
+++ b/bindings/pydrake/util/BUILD.bazel
@@ -102,4 +102,7 @@ drake_py_test(
     deps = [":util"],
 )
 
-add_lint_tests()
+add_lint_tests(
+    cpplint_data = ["//bindings/pydrake:.clang-format"],
+    enable_clang_format_lint = True,
+)

--- a/bindings/pydrake/util/test/alias_cc_test.cc
+++ b/bindings/pydrake/util/test/alias_cc_test.cc
@@ -14,4 +14,6 @@
 using drake::pydrake::GetPyParam;
 
 // No-op; compilation test only.
-int main() { return 0; }
+int main() {
+  return 0;
+}


### PR DESCRIPTION
Relates #4843.

All of the C++ changes were suggested by clang-format, though some other suggested changes within these same files have been declined.

In a future commit, we will finish up the re-formatting work and enable the clang-format idempotency linter.

For the `AllowShortFunctionsOnASingleLine` config, other than a few outliers, this matches the current prevailing style within pydrake.  At least, it is better than folding *all* functions onto a single line, which is the current global setting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10121)
<!-- Reviewable:end -->
