### PR TITLE
framework: Work around gcc-6 bug

### DIFF
--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -2112,7 +2112,7 @@ class System : public SystemBase {
         return [&expected_type, port_index, pathname](
             const AbstractValue& actual) {
           if (actual.static_type_info() != expected_type) {
-            ThrowInputPortHasWrongType(
+            SystemBase::ThrowInputPortHasWrongType(
                 "FixInputPortTypeCheck", pathname, port_index,
                 NiceTypeName::Get(expected_type),
                 NiceTypeName::Get(actual.type_info()));


### PR DESCRIPTION
Add classname when calling a static method, to avoid:
```
  "error: 'this' was not captured for this lambda function"
```
false positive error message.

This is identical to ba4493ae2c8df7fbd691518387f32bf5b38d5d17's two other fixes required by gcc-7; I guess gcc-6 was slightly different enough to also trigger on the third identical case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10124)
<!-- Reviewable:end -->
