### PR TITLE
solvers: Remove spurious dreal dependency

### DIFF
--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -101,7 +101,6 @@ drake_cc_library(
     srcs = ["choose_best_solver.cc"],
     hdrs = ["choose_best_solver.h"],
     deps = [
-        ":dreal_solver",
         ":equality_constrained_qp_solver",
         ":gurobi_solver",
         ":ipopt_solver",

--- a/solvers/choose_best_solver.cc
+++ b/solvers/choose_best_solver.cc
@@ -1,6 +1,5 @@
 #include "drake/solvers/choose_best_solver.h"
 
-#include "drake/solvers/dreal_solver.h"
 #include "drake/solvers/equality_constrained_qp_solver.h"
 #include "drake/solvers/gurobi_solver.h"
 #include "drake/solvers/ipopt_solver.h"


### PR DESCRIPTION
The mathematical_program is not allowed to depend on dreal, at least not until we have a flag to opt-out of it.