### PR TITLE
solvers: Resolve link error when SCS is disabled

### DIFF
--- a/solvers/no_scs.cc
+++ b/solvers/no_scs.cc
@@ -11,6 +11,15 @@ namespace solvers {
 
 bool ScsSolver::is_available() { return false; }
 
+void ScsSolver::Solve(const MathematicalProgram&,
+                      const optional<Eigen::VectorXd>&,
+                      const optional<SolverOptions>&,
+                      MathematicalProgramResult*) const {
+  throw std::runtime_error(
+      "The SCS bindings were not compiled.  You'll need to use a different "
+      "solver.");
+}
+
 SolutionResult ScsSolver::Solve(MathematicalProgram&) const {
   throw std::runtime_error(
       "The SCS bindings were not compiled.  You'll need to use a different "


### PR DESCRIPTION
This amends 1c3cd9449b705b1072527f25d42b5508beb56937 to provide the const-Solve method even when SCS is disabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10131)
<!-- Reviewable:end -->
