### PR TITLE
[WIP] Event declaration sugar

### DIFF
--- a/examples/fibonacci/BUILD.bazel
+++ b/examples/fibonacci/BUILD.bazel
@@ -27,6 +27,7 @@ drake_cc_binary(
     deps = [
         ":fibonacci_difference_equation",
         "//systems/analysis:simulator",
+        "//systems/primitives:signal_logger",
         "@gflags",
     ],
 )
@@ -38,6 +39,7 @@ drake_cc_googletest(
     deps = [
         ":fibonacci_difference_equation",
         "//systems/analysis",
+        "//systems/primitives:signal_logger",
     ],
 )
 

--- a/examples/fibonacci/run_fibonacci.cc
+++ b/examples/fibonacci/run_fibonacci.cc
@@ -2,34 +2,42 @@
 
 #include "drake/examples/fibonacci/fibonacci_difference_equation.h"
 #include "drake/systems/analysis/simulator.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/primitives/signal_logger.h"
 
-namespace drake {
-namespace examples {
-namespace fibonacci {
-namespace {
+using drake::examples::fibonacci::FibonacciDifferenceEquation;
+using drake::systems::DiagramBuilder;
+using drake::systems::LogOutput;
+using drake::systems::SignalLogger;
+using drake::systems::Simulator;
 
 DEFINE_int32(steps, 10, "Length of Fibonacci sequence to generate.");
 
 // Use Drake's hybrid Simulator to produce the Fibonacci sequence up to
 // the step number supplied on the command line (default 10).
-int DoMain() {
-  FibonacciDifferenceEquation fibonacci;
-
-  systems::Simulator<double> simulator(fibonacci);
-
-  // Simulate forward until t=h*steps.
-  simulator.StepTo(FLAGS_steps * FibonacciDifferenceEquation::kPeriod);
-
-  return 0;
-}
-
-}  // namespace
-}  // namespace fibonacci
-}  // namespace examples
-}  // namespace drake
-
 int main(int argc, char* argv[]) {
+  // Handle the command line "steps" argument.
   gflags::SetUsageMessage("usage: run_fibonacci [--steps=n]");
   gflags::ParseCommandLineFlags(&argc, &argv, true);
-  return drake::examples::fibonacci::DoMain();
+
+  // Build a Diagram containing the Fibonacci system and a data logger that
+  // samples the Fibonacci output port exactly at the update times.
+  DiagramBuilder<double> builder;
+  auto fibonacci = builder.AddSystem<FibonacciDifferenceEquation>();
+  auto logger = LogOutput(fibonacci->GetOutputPort("Fn"), &builder);
+  logger->set_publish_period(FibonacciDifferenceEquation::kPeriod);
+  auto diagram = builder.Build();
+
+  // Create a Simulator and use it to advance time until t=steps*h.
+  Simulator<double> simulator(*diagram);
+  simulator.StepTo(FLAGS_steps * FibonacciDifferenceEquation::kPeriod);
+
+  // Print out the contents of the log.
+  for (int n = 0; n < logger->sample_times().size(); ++n) {
+    const double t = logger->sample_times()[n];
+    std::cout << n << ": " << logger->data()(0, n)
+        << " (t=" << t << ")\n";
+  }
+
+  return 0;
 }

--- a/examples/fibonacci/test/fibonacci_difference_equation_test.cc
+++ b/examples/fibonacci/test/fibonacci_difference_equation_test.cc
@@ -12,7 +12,6 @@ namespace {
 // Verify that we get the right sequence for one sequence length.
 GTEST_TEST(Fibonacci, CheckSequence) {
   FibonacciDifferenceEquation fibonacci;
-
   systems::Simulator<double> simulator(fibonacci);
 
   // Simulate forward to fibonacci(6): 0 1 1 2 3 5 8

--- a/examples/fibonacci/test/fibonacci_difference_equation_test.cc
+++ b/examples/fibonacci/test/fibonacci_difference_equation_test.cc
@@ -3,6 +3,8 @@
 #include <gtest/gtest.h>
 
 #include "drake/systems/analysis/simulator.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/primitives/signal_logger.h"
 
 namespace drake {
 namespace examples {
@@ -11,22 +13,25 @@ namespace {
 
 // Verify that we get the right sequence for one sequence length.
 GTEST_TEST(Fibonacci, CheckSequence) {
-  FibonacciDifferenceEquation fibonacci;
-  systems::Simulator<double> simulator(fibonacci);
+  systems::DiagramBuilder<double> builder;
+  auto fibonacci = builder.AddSystem<FibonacciDifferenceEquation>();
+  auto logger =
+      builder.AddSystem<systems::SignalLogger<double>>(1);  // Size of input.
+  logger->set_publish_period(FibonacciDifferenceEquation::kPeriod);
+  builder.Connect(fibonacci->GetOutputPort("Fn"), logger->GetInputPort("data"));
+  auto diagram = builder.Build();
+
+  systems::Simulator<double> simulator(*diagram);
+  simulator.set_publish_every_time_step(false);
+  simulator.set_publish_at_initialization(false);
 
   // Simulate forward to fibonacci(6): 0 1 1 2 3 5 8
-  testing::internal::CaptureStdout();
   simulator.StepTo(6 * FibonacciDifferenceEquation::kPeriod);
-  std::string output = testing::internal::GetCapturedStdout();
 
-  EXPECT_EQ(output,
-            "0: 0\n"
-            "1: 1\n"
-            "2: 1\n"
-            "3: 2\n"
-            "4: 3\n"
-            "5: 5\n"
-            "6: 8\n");
+  Eigen::VectorXd expected(7);
+  expected << 0, 1, 1, 2, 3, 5, 8;
+
+  EXPECT_EQ(logger->data().transpose(), expected);
 }
 
 }  // namespace

--- a/systems/analysis/test/simulator_test.cc
+++ b/systems/analysis/test/simulator_test.cc
@@ -968,52 +968,64 @@ class ExampleDiscreteSystem : public LeafSystem<double> {
   ExampleDiscreteSystem() {
     DeclareDiscreteState(1);  // Just one state variable, x[0], default=0.
 
-    // Output yₙ using a Drake "publish" event (occurs at the end of step n,
-    // where step 0 is "initialize" and StepTo(kPeriod) yields step 1).
-    DeclarePeriodicPublish(kPeriod, kOffset,
-                           &ExampleDiscreteSystem::PrintResult);
-
     // Update to xₙ₊₁, using a Drake "discrete update" event (occurs
     // at the beginning of step n+1).
     DeclarePeriodicDiscreteUpdate(kPeriod, kOffset,
                                   &ExampleDiscreteSystem::Update);
+
+    // Present yₙ (=Sₙ) at the output port.
+    DeclareVectorOutputPort("Sn", systems::BasicVector<double>(1),
+                            &ExampleDiscreteSystem::Output);
   }
 
-  static constexpr double kPeriod = 1/50.;  // Update at 50Hz (h=1/50).
-  static constexpr double kOffset = 0.;  // Trigger events at n=0.
+  static constexpr double kPeriod = 1 / 50.;  // Update at 50Hz (h=1/50).
+  static constexpr double kOffset = 0.;       // Trigger events at n=0.
 
  private:
   systems::EventStatus Update(const systems::Context<double>& context,
                               systems::DiscreteValues<double>* xd) const {
-    const double x_n = GetX(context);
+    const double x_n = context.get_discrete_state()[0];
     (*xd)[0] = x_n + 1.;
     return systems::EventStatus::Succeeded();
   }
 
-  // Prints the result of output function yₙ = g(n, xₙ) to cout.
-  systems::EventStatus PrintResult(const systems::Context<double>& context) const {
-    const double t = context.get_time();
-    const int n = static_cast<int>(std::round(t / kPeriod));
-    const double S_n = 10 * GetX(context);  // 10 xₙ[0]
-    std::cout << n << ": " << S_n << " (" << t << ")\n";
-    return systems::EventStatus::Succeeded();
-  }
-
-  double GetX(const Context<double>& context) const {
-    return context.get_discrete_state()[0];
+  void Output(const systems::Context<double>& context,
+              systems::BasicVector<double>* result) const {
+    const double x_n = context.get_discrete_state()[0];
+    const double S_n = 10 * x_n;
+    (*result)[0] = S_n;
   }
 };
 
+// Tests the code fragment shown in the systems/discrete_systems.h module. Make
+// this as copypasta-identical as possible to the code there, and make matching
+// changes there if you change anything here.
 GTEST_TEST(SimulatorTest, ExampleDiscreteSystem) {
-  ExampleDiscreteSystem system;
+  // Build a Diagram containing the Example system and a data logger that
+  // samples the Sn output port exactly at the update times.
+  DiagramBuilder<double> builder;
+  auto example = builder.AddSystem<ExampleDiscreteSystem>();
+  auto logger = LogOutput(example->GetOutputPort("Sn"), &builder);
+  logger->set_publish_period(ExampleDiscreteSystem::kPeriod);
+  auto diagram = builder.Build();
 
-  Simulator<double> simulator(system);
-
-  // Simulate forward.
-  testing::internal::CaptureStdout();
+  // Create a Simulator and use it to advance time until t=3*h.
+  Simulator<double> simulator(*diagram);
+  simulator.set_publish_every_time_step(false);
+  simulator.set_publish_at_initialization(false);
   simulator.StepTo(3 * ExampleDiscreteSystem::kPeriod);
-  std::string output = testing::internal::GetCapturedStdout();
 
+  testing::internal::CaptureStdout();  // Not in example.
+
+  // Print out the contents of the log.
+  for (int n = 0; n < logger->sample_times().size(); ++n) {
+    const double t = logger->sample_times()[n];
+    std::cout << n << ": " << logger->data()(0, n)
+              << " (" << t << ")\n";
+  }
+
+  // Not in example (although the expected output is there).
+  std::string output = testing::internal::GetCapturedStdout();
   EXPECT_EQ(output, "0: 0 (0)\n"
                     "1: 10 (0.02)\n"
                     "2: 20 (0.04)\n"
@@ -1077,8 +1089,11 @@ GTEST_TEST(SimulatorTest, SinusoidalHybridSystem) {
   const double t_final = 10.0;
   const double initial_value = std::sin(-f * h);  // = sin(f*-1*h)
   Simulator<double> simulator(*diagram);
-  simulator.set_publish_at_initialization(false);  // Remove these when #10132
-  simulator.set_publish_every_time_step(false);    // lands.
+
+  // TODO(sherm1) Remove these when #10269 lands (fix to SignalLogger).
+  simulator.set_publish_at_initialization(false);
+  simulator.set_publish_every_time_step(false);
+
   simulator.get_mutable_context().get_mutable_discrete_state()[0] =
       initial_value;
   simulator.StepTo(t_final);

--- a/systems/discrete_systems.h
+++ b/systems/discrete_systems.h
@@ -50,41 +50,32 @@ class ExampleDiscreteSystem : public LeafSystem<double> {
     DeclareDiscreteState(1);  // Just one state variable, x[0], default=0.
 
     // Output yₙ using a Drake "publish" event (occurs at the end of step n).
-    DeclarePeriodicEvent(kPeriod, kOffset,
-                         systems::PublishEvent<double>(
-                             [this](const systems::Context<double>& context,
-                                    const systems::PublishEvent<double>&) {
-                               PrintResult(context);
-                             }));
+    DeclarePeriodicPublish(kPeriod, kOffset, &SimpleDiscreteSystem::PrintResult);
 
-    // Update to xₙ₊₁, using a Drake "discrete update" event (occurs at the
-    // beginning of step n+1).
-    DeclarePeriodicEvent(kPeriod, kOffset,
-                         systems::DiscreteUpdateEvent<double>(
-                             [this](const systems::Context<double>& context,
-                                    const systems::DiscreteUpdateEvent<double>&,
-                                    systems::DiscreteValues<double>* xd) {
-                               Update(context, xd);
-                             }));
+    // Update to xₙ₊₁, using a Drake "discrete update" event (occurs
+    // at the beginning of step n+1).
+    DeclarePeriodicDiscreteUpdate(kPeriod, kOffset,
+                                  &SimpleDiscreteSystem::Update);
   }
 
   static constexpr double kPeriod = 1/50.;  // Update at 50Hz (h=1/50).
   static constexpr double kOffset = 0.;  // Trigger events at n=0.
 
  private:
-  // Update function xₙ₊₁ = f(n, xₙ).
-  void Update(const systems::Context<double>& context,
-              systems::DiscreteValues<double>* xd) const {
+  systems::EventStatus Update(const systems::Context<double>& context,
+                              systems::DiscreteValues<double>* xd) const {
     const double x_n = GetX(context);
     (*xd)[0] = x_n + 1.;
+    return systems::EventStatus::Succeeded();
   }
 
   // Prints the result of output function yₙ = g(n, xₙ) to cout.
-  void PrintResult(const systems::Context<double>& context) const {
+  systems::EventStatus PrintResult(const systems::Context<double>& context) const {
     const double t = context.get_time();
     const int n = static_cast<int>(std::round(t / kPeriod));
     const double S_n = 10 * GetX(context);  // 10 xₙ[0]
     std::cout << n << ": " << S_n << " (" << t << ")\n";
+    return systems::EventStatus::Succeeded();
   }
 
   double GetX(const Context<double>& context) const {

--- a/systems/framework/event.h
+++ b/systems/framework/event.h
@@ -2,6 +2,7 @@
 
 #include <limits>
 #include <memory>
+#include <string>
 #include <utility>
 
 #include "drake/common/drake_copyable.h"
@@ -323,7 +324,7 @@ class Event {
 
   // Note: Users should not be calling this.
   #if !defined(DRAKE_DOXYGEN_CXX)
-  /// Constructs an Event with the specified @p trigger.
+  // Constructs an Event with the specified @p trigger.
   explicit Event(const TriggerType& trigger) : trigger_type_(trigger) {}
   #endif
 
@@ -346,8 +347,10 @@ class Event {
   std::unique_ptr<EventData> event_data_{nullptr};
 };
 
-/// Structure for comparing two PeriodicEventData objects for use in a map
-/// container, using an arbitrary comparison method.
+/**
+ * Structure for comparing two PeriodicEventData objects for use in a map
+ * container, using an arbitrary comparison method.
+ */
 struct PeriodicEventDataComparator {
   bool operator()(const PeriodicEventData& a,
     const PeriodicEventData& b) const {
@@ -355,6 +358,74 @@ struct PeriodicEventDataComparator {
         return a.offset_sec() < b.offset_sec();
       return a.period_sec() < b.period_sec();
   }
+};
+
+/**
+ * Holds the return status from execution of an event handler function, or
+ * the effective result from calling a series of such functions due to
+ * the occurrence of simultaneous events. In the latter case the return
+ * should be the returned status of highest severity. In case of multiple
+ * returns at the same severity, the first one wins.
+ */
+class EventStatus {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(EventStatus)
+
+  /// The numerical values are ordered, with
+  /// no-op < success < terminate < fatal.
+  enum Severity {
+    /// Nothing happened; no state update needed.
+    kDidNothing = 0,
+    /// Handler executed successfully.
+    kSucceeded = 1,
+    /// Handler succeeded but detected a termination condition (has message).
+    kReachedTermination = 2,
+    /// Handler was unable to perform its job (has message).
+    kFailed = 3
+  };
+
+  /// Sets this status to "did nothing", with no message.
+  static EventStatus DidNothing() { return EventStatus(kDidNothing); }
+
+  /// Sets this status to "succeeded" with no message.
+  static EventStatus Succeeded() { return EventStatus(kSucceeded); }
+
+  /// Sets this status to "reached termination" with a message explaining why.
+  static EventStatus ReachedTermination(const SystemBase* system,
+                                        std::string message) {
+    return EventStatus(kReachedTermination, system, message);
+  }
+
+  /// Sets this status to "failed" with a message explaining why.
+  static EventStatus Failed(const SystemBase* system, std::string message) {
+    return EventStatus(kFailed, system, message);
+  }
+
+  /// If the `candidate` is a more-severe status than `this` one,
+  /// replaces the contents of `this` with the more-severe status.
+  EventStatus& KeepMoreSevere(EventStatus candidate) {
+    if (candidate.severity() > severity()) *this = candidate;
+    return *this;
+  }
+
+  bool did_nothing() const { return severity_ == kDidNothing; }
+  bool reached_termination() const { return severity_ == kReachedTermination; }
+  bool failed() const { return severity_ == kFailed; }
+  Severity severity() const { return severity_; }
+  const SystemBase& system() const {
+    DRAKE_DEMAND(system_);
+    return *system_;
+  }
+  const std::string& message() const { return message_; }
+
+ private:
+  explicit EventStatus(Severity severity) : severity_(severity) {}
+  EventStatus(Severity severity, const SystemBase* system, std::string message)
+      : severity_(severity), system_(system), message_(std::move(message)) {}
+
+  Severity severity_{kDidNothing};
+  const SystemBase* system_{nullptr};
+  std::string message_;
 };
 
 /**

--- a/systems/lcm/lcm_driven_loop.h
+++ b/systems/lcm/lcm_driven_loop.h
@@ -65,7 +65,7 @@ class UtimeMessageToSeconds : public LcmMessageToTimeInterface {
  * the concrete type of the message, and is able to supply a time converter.
  *
  * This class uses the Simulator class internally for event handling
- * (kPublishAction, kDiscreteUpdateAction, kUnrestrictedUpdateAction) and
+ * (publish, discrete update, and unrestricted update) and
  * continuous state integration (e.g. the I term in a PID). The main message
  * handling loop conceptually is:
  * <pre>
@@ -96,7 +96,7 @@ class UtimeMessageToSeconds : public LcmMessageToTimeInterface {
  * This implementation relies on several assumptions:
  *
  * 1. The loop is blocked only on one Lcm message.
- * 2. It's pointless to for the handler system to perform any computation
+ * 2. It's pointless for the handler system to perform any computation
  *    without a new Lcm message, thus the handler loop is blocking.
  * 3. The computation for the given system should be faster than the incoming
  *    message rate.


### PR DESCRIPTION
(Do not review yet)

We prefer that events always be declared with associated handler callbacks, rather than overloading the dispatcher virtuals like DoPublish() and DoDiscreteUpdate(). Pursuing that in #9766 it is clear that some sugar is needed to make that approach palatable, similar to the sugar available for output port callbacks. This PR adds that sugar and reworks the examples to make them beautiful.

This is also a step in the direction of being able to report status from event handlers -- the new sugar methods return status although that status does not yet percolate through the rest of the system.

(Currently this PR includes much code from #9766 but that will be removed when it lands.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10132)
<!-- Reviewable:end -->
