### PR TITLE
Extend public API to provide ability to assign roles.

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -115,6 +115,7 @@ drake_cc_library(
     hdrs = ["geometry_instance.h"],
     deps = [
         ":geometry_ids",
+        ":geometry_roles",
         ":materials",
         ":shape_specification",
         ":utilities",

--- a/geometry/geometry_instance.h
+++ b/geometry/geometry_instance.h
@@ -6,8 +6,10 @@
 
 #include "drake/common/copyable_unique_ptr.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_optional.h"
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/shape_specification.h"
 #include "drake/geometry/visual_material.h"
 
@@ -104,7 +106,7 @@ class GeometryInstance {
    instantiation of %GeometryInstance will contain a unique id value. The id
    value is preserved across copies. After successfully registering this
    %GeometryInstance, this id will serve as the identifier for the registered
-   representation as well. */
+   representation as well.  */
   GeometryId id() const { return id_; }
 
   const Isometry3<double>& pose() const { return X_PG_; }
@@ -115,13 +117,51 @@ class GeometryInstance {
     return *shape_;
   }
 
-  /** Releases the shape from the instance. */
+  /** Releases the shape from the instance.  */
   std::unique_ptr<Shape> release_shape() { return std::move(shape_); }
 
   const VisualMaterial& visual_material() const { return visual_material_; }
 
-  /** Returns the *canonicalized* name for the instance. */
+  /** Returns the *canonicalized* name for the instance.  */
   const std::string& name() const { return name_; }
+
+  /** Sets the proximity properties for the given instance.  */
+  void set_proximity_properties(ProximityProperties properties) {
+    proximity_properties_ = std::move(properties);
+  }
+
+  /** Sets the illustration properties for the given instance.  */
+  void set_illustration_properties(IllustrationProperties properties) {
+    illustration_props_ = std::move(properties);
+  }
+
+  /** Returns a pointer to the geometry's mutable proximity properties (if they
+   are defined). Nullptr otherwise.  */
+  ProximityProperties* mutable_proximity_properties() {
+    if (proximity_properties_) return &*proximity_properties_;
+    return nullptr;
+  }
+
+  /** Returns a pointer to the geometry's const proximity properties (if they
+   are defined). Nullptr otherwise.  */
+  const ProximityProperties* proximity_properties() const {
+    if (proximity_properties_) return &*proximity_properties_;
+    return nullptr;
+  }
+
+  /** Returns a pointer to the geometry's mutable illustration properties (if
+   they are defined). Nullptr otherwise.  */
+  IllustrationProperties* mutable_illustration_properties() {
+    if (illustration_props_) return &*illustration_props_;
+    return nullptr;
+  }
+
+  /** Returns a pointer to the geometry's const illustration properties (if
+   they are defined). Nullptr otherwise.  */
+  const IllustrationProperties* illustration_properties() const {
+    if (illustration_props_) return &*illustration_props_;
+    return nullptr;
+  }
 
  private:
   // The *globally* unique identifier for this instance. It is functionally
@@ -140,6 +180,10 @@ class GeometryInstance {
 
   // The "rendering" material -- e.g., OpenGl contexts and the like.
   VisualMaterial visual_material_;
+  // Optional properties.
+  optional<ProximityProperties> proximity_properties_{nullopt};
+  optional<IllustrationProperties> illustration_props_{nullopt};
 };
+
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/geometry_roles.h
+++ b/geometry/geometry_roles.h
@@ -98,8 +98,10 @@ namespace geometry {
      representations of real-world object surfaces. The properties associated
      with this role are those necessary to draw the illustration.
 
- Role assignment is achieved by assigning as set of role-related _properties_
- to a geometry (see SceneGraph::AssignRole()). The set _can_ be empty. Each
+ Role assignment is achieved by assigning a set of role-related _properties_
+ to a geometry. The properties can either be assigned to the GeometryInstance
+ prior to registration, or after registration via the registered geometry's
+ identifier (see SceneGraph::AssignRole()). The set _can_ be empty. Each
  role has a specific property set associated with it:
    - __Proximity role__: ProximityProperties
    - __Illustration role__: IllustrationProperties
@@ -127,10 +129,7 @@ namespace geometry {
 
  Generally, any code that is dependent on geometry roles, should document the
  type of role that it depends on, and the properties (if any) associated with
- that role that it requires/prefers.
-
- Roles are assigned during geometry registration (see
- SceneGraph::AssignRole()). */
+ that role that it requires/prefers.  */
 
 /** The set of properties for geometry used in a _proximity_ role.
 
@@ -169,7 +168,7 @@ enum class Role {
 /** @name  Geometry role to string conversions
 
  These are simply convenience functions for converting the Role enumeration into
- a human-readable string. */
+ a human-readable string.  */
 //@{
 
 std::string to_string(const Role& role);

--- a/geometry/internal_geometry.cc
+++ b/geometry/internal_geometry.cc
@@ -19,12 +19,7 @@ InternalGeometry::InternalGeometry(
       X_PG_(X_FG),
       X_FG_(X_FG),
       parent_geometry_id_(nullopt),
-      visual_material_(material) {
-  // Short-term expedient; all internal geometries have illustration properties.
-  IllustrationProperties properties;
-  properties.AddProperty("phong", "diffuse", material.diffuse());
-  SetRole(properties);
-}
+      visual_material_(material) {}
 
 bool InternalGeometry::has_role(Role role) const {
   switch (role) {

--- a/geometry/internal_geometry.h
+++ b/geometry/internal_geometry.h
@@ -35,8 +35,8 @@ class InternalGeometry {
    be nullptr, and the pose will be uninitialized.  */
   InternalGeometry() {}
 
-  /** Constructs the internal geometry as an *immediate* child of the frame.
-   Therefore, it is assumed that X_FG = X_PG.
+  /** Constructs the internal geometry without any assigned roles defined as an
+   *immediate* child of the frame. Therefore, it is assumed that X_FG = X_PG.
    @param source_id     The id for the source that registered this geometry.
    @param shape         The shape specification for this instance.
    @param frame_id      The id of the frame this belongs to.

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -173,6 +173,15 @@ GeometryId SceneGraph<T>::RegisterGeometry(
 }
 
 template <typename T>
+GeometryId SceneGraph<T>::RegisterGeometryWithoutRole(
+    SourceId source_id, FrameId frame_id,
+    std::unique_ptr<GeometryInstance> geometry) {
+  GS_THROW_IF_CONTEXT_ALLOCATED
+  return initial_state_->RegisterGeometryWithoutRole(
+      source_id, frame_id, std::move(geometry));
+}
+
+template <typename T>
 GeometryId SceneGraph<T>::RegisterGeometry(
     Context<T>* context, SourceId source_id, FrameId frame_id,
     std::unique_ptr<GeometryInstance> geometry) {
@@ -182,12 +191,31 @@ GeometryId SceneGraph<T>::RegisterGeometry(
 }
 
 template <typename T>
+GeometryId SceneGraph<T>::RegisterGeometryWithoutRole(
+    Context<T>* context, SourceId source_id, FrameId frame_id,
+    std::unique_ptr<GeometryInstance> geometry) {
+  auto* g_context = static_cast<GeometryContext<T>*>(context);
+  auto& g_state = g_context->get_mutable_geometry_state();
+  return g_state.RegisterGeometryWithoutRole(source_id, frame_id,
+                                             std::move(geometry));
+}
+
+template <typename T>
 GeometryId SceneGraph<T>::RegisterGeometry(
     SourceId source_id, GeometryId geometry_id,
     std::unique_ptr<GeometryInstance> geometry) {
   GS_THROW_IF_CONTEXT_ALLOCATED
   return initial_state_->RegisterGeometryWithParent(source_id, geometry_id,
                                                     std::move(geometry));
+}
+
+template <typename T>
+GeometryId SceneGraph<T>::RegisterGeometryWithoutRole(
+    SourceId source_id, GeometryId geometry_id,
+    std::unique_ptr<GeometryInstance> geometry) {
+  GS_THROW_IF_CONTEXT_ALLOCATED
+  return initial_state_->RegisterGeometryWithParentWithoutRole(
+      source_id, geometry_id, std::move(geometry));
 }
 
 template <typename T>
@@ -201,11 +229,29 @@ GeometryId SceneGraph<T>::RegisterGeometry(
 }
 
 template <typename T>
+GeometryId SceneGraph<T>::RegisterGeometryWithoutRole(
+    Context<T>* context, SourceId source_id, GeometryId geometry_id,
+    std::unique_ptr<GeometryInstance> geometry) {
+  auto* g_context = static_cast<GeometryContext<T>*>(context);
+  auto& g_state = g_context->get_mutable_geometry_state();
+  return g_state.RegisterGeometryWithParentWithoutRole(
+      source_id, geometry_id, std::move(geometry));
+}
+
+template <typename T>
 GeometryId SceneGraph<T>::RegisterAnchoredGeometry(
     SourceId source_id, std::unique_ptr<GeometryInstance> geometry) {
   GS_THROW_IF_CONTEXT_ALLOCATED
   return initial_state_->RegisterAnchoredGeometry(source_id,
                                                   std::move(geometry));
+}
+
+template <typename T>
+GeometryId SceneGraph<T>::RegisterAnchoredGeometryWithoutRole(
+    SourceId source_id, std::unique_ptr<GeometryInstance> geometry) {
+  GS_THROW_IF_CONTEXT_ALLOCATED
+  return initial_state_->RegisterAnchoredGeometryWithoutRole(
+      source_id, std::move(geometry));
 }
 
 template <typename T>
@@ -220,6 +266,22 @@ void SceneGraph<T>::RemoveGeometry(Context<T>* context, SourceId source_id,
   auto* g_context = static_cast<GeometryContext<T>*>(context);
   auto& g_state = g_context->get_mutable_geometry_state();
   g_state.RemoveGeometry(source_id, geometry_id);
+}
+
+template <typename T>
+void SceneGraph<T>::AssignRole(SourceId source_id,
+                               GeometryId geometry_id,
+                               ProximityProperties properties) {
+  GS_THROW_IF_CONTEXT_ALLOCATED
+  initial_state_->AssignRole(source_id, geometry_id, std::move(properties));
+}
+
+template <typename T>
+void SceneGraph<T>::AssignRole(SourceId source_id,
+                               GeometryId geometry_id,
+                               IllustrationProperties properties) {
+  GS_THROW_IF_CONTEXT_ALLOCATED
+  initial_state_->AssignRole(source_id, geometry_id, std::move(properties));
 }
 
 template <typename T>

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -52,7 +52,7 @@ class SceneGraphInspector {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SceneGraphInspector)
 
   //----------------------------------------------------------------------------
-  /** @name                State queries */
+  /** @name                State queries  */
   //@{
 
   // NOTE: An inspector should never be released into the wild without having
@@ -90,7 +90,7 @@ class SceneGraphInspector {
 
   /** Reports the name of the geometry indicated by the given id.
    @throws std::logic_error if `geometry_id` doesn't refer to a valid geometry.
-   */
+  */
   const std::string& GetName(GeometryId geometry_id) const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->get_name(geometry_id);
@@ -125,6 +125,57 @@ class SceneGraphInspector {
   int NumGeometriesForFrame(FrameId frame_id) const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->GetNumFrameGeometries(frame_id);
+  }
+
+  /** Returns a pointer to the const proximity properties of the geometry
+   identified by `geometry_id`.
+   @param geometry_id   The identifier for the queried geometry.
+   @return A pointer to the properties (or nullptr if there are no such
+           properties).  */
+  const ProximityProperties* GetProximityProperties(
+      GeometryId geometry_id) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->get_proximity_properties(geometry_id);
+  }
+
+  /** Returns a pointer to the const illustration properties of the geometry
+   identified by `geometry_id`.
+   @param geometry_id   The identifier for the queried geometry.
+   @return A pointer to the properties (or nullptr if there are no such
+           properties.  */
+  const IllustrationProperties* GetIllustrationProperties(
+      GeometryId geometry_id) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->get_illustration_properties(geometry_id);
+  }
+
+  /** Reports the *total* number of geometries in the scene graph.  */
+  int num_geometries() const {
+    DRAKE_DEMAND(state_ != nullptr);
+    state_->get_num_geometries();
+  }
+
+  /** Reports the *total* number of geometries in the scene graph with the
+   indicated role.  */
+  int NumGeometriesWithRole(Role role) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    state_->GetNumGeometriesWithRole(role);
+  }
+
+  /** Reports the total number of geometries directly registered to the given
+   frame. This count does _not_ include geometries attached to frames that are
+   descendants of this frame.
+   @throws std::runtime_error if the `frame_id` is invalid.  */
+  int NumFrameGeometries(FrameId frame_id) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    state_->GetNumFrameGeometries(frame_id);
+  }
+
+  /** Reports the number of geometries assigned to the given frame with the
+   given role.  */
+  int NumFrameGeometriesWithRole(FrameId frame_id, Role role) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    state_->GetNumFrameGeometriesWithRole(frame_id, role);
   }
 
   //@}

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -175,7 +175,7 @@ class GeometryStateTest : public ::testing::Test {
   //  Although the sibling geometries affixed to each frame overlap, the pairs
   //  (g0, g1), (g2, g3), and (g4, g5) are implicitly filtered because they are
   //  sibling geometries affixed to the same frame.
-  SourceId SetUpSingleSourceTree() {
+  SourceId SetUpSingleSourceTree(bool assign_proximity_role = false) {
     using std::to_string;
 
     source_id_ = NewSource();
@@ -218,9 +218,13 @@ class GeometryStateTest : public ::testing::Test {
         const std::string& name =
             to_string(frame_id) + "_g" + std::to_string(i);
         geometry_names_[g_count] = name;
-        geometries_[g_count] = geometry_state_.RegisterGeometry(
+        geometries_[g_count] = geometry_state_.RegisterGeometryWithoutRole(
             source_id_, frame_id,
             make_unique<GeometryInstance>(pose, make_unique<Sphere>(1), name));
+        if (assign_proximity_role) {
+          geometry_state_.AssignRole(source_id_, geometries_[g_count],
+                                     ProximityProperties());
+        }
         X_FG_.push_back(pose);
         ++g_count;
       }
@@ -232,10 +236,13 @@ class GeometryStateTest : public ::testing::Test {
     // This simultaneously tests the named registration function and
     // _implicitly_ tests registration of geometry against the world frame id
     // (as that is how `RegisterAnchoredGeometry()` works.
-    anchored_geometry_ = geometry_state_.RegisterAnchoredGeometry(
-        source_id_,
-        make_unique<GeometryInstance>(
-            X_WA_, make_unique<Box>(100, 100, 2), anchored_name_));
+    anchored_geometry_ = geometry_state_.RegisterAnchoredGeometryWithoutRole(
+        source_id_, make_unique<GeometryInstance>(
+                        X_WA_, make_unique<Box>(100, 100, 2), anchored_name_));
+    if (assign_proximity_role) {
+      geometry_state_.AssignRole(
+          source_id_, anchored_geometry_, ProximityProperties());
+    }
     return source_id_;
   }
 
@@ -554,7 +561,7 @@ TEST_F(GeometryStateTest, ValidateSingleSourceTree) {
       EXPECT_FALSE(geometry.parent_id());
       EXPECT_EQ(geometry.name(), geometry_names_[i]);
       EXPECT_EQ(geometry.index(), i);
-      EXPECT_TRUE(geometry.proximity_index().is_valid());
+      EXPECT_FALSE(geometry.proximity_index().is_valid());
       EXPECT_EQ(geometry.child_geometry_ids().size(), 0);
 
       // Note: There are no geometries parented to other geometries. The results
@@ -579,14 +586,13 @@ TEST_F(GeometryStateTest, ValidateSingleSourceTree) {
 
 // Tests the GetNum*Geometry*Methods.
 TEST_F(GeometryStateTest, GetNumGeometryTests) {
-  SetUpSingleSourceTree();
+  SetUpSingleSourceTree(true /* add proximity roles */);
 
   EXPECT_EQ(single_tree_total_geometry_count(),
             geometry_state_.get_num_geometries());
   EXPECT_EQ(single_tree_total_geometry_count(),
             geometry_state_.GetNumGeometriesWithRole(Role::kProximity));
-  EXPECT_EQ(single_tree_total_geometry_count(),
-            geometry_state_.GetNumGeometriesWithRole(Role::kIllustration));
+  EXPECT_EQ(0, geometry_state_.GetNumGeometriesWithRole(Role::kIllustration));
 
   for (int i = 0; i < kFrameCount; ++i) {
     EXPECT_EQ(kGeometryCount,
@@ -594,7 +600,7 @@ TEST_F(GeometryStateTest, GetNumGeometryTests) {
     EXPECT_EQ(kGeometryCount,
               geometry_state_.GetNumFrameGeometriesWithRole(frames_[i],
                                                             Role::kProximity));
-    EXPECT_EQ(kGeometryCount,
+    EXPECT_EQ(0,
               geometry_state_.GetNumFrameGeometriesWithRole(
                   frames_[i], Role::kIllustration));
   }
@@ -939,7 +945,7 @@ TEST_F(GeometryStateTest, RegisterAnchoredNullGeometry) {
 //  ProximityIndex(0) will refer to the last _dynamic_ geometry (the
 //    dynamic geometry that previously had the highest ProximityIndex value.)
 TEST_F(GeometryStateTest, RemoveGeometry) {
-  SourceId s_id = SetUpSingleSourceTree();
+  SourceId s_id = SetUpSingleSourceTree(true);
   // Pose all of the frames to the specified poses in their parent frame.
   FramePoseVector<double> poses(source_id_, frames_);
   poses.clear();
@@ -994,7 +1000,7 @@ TEST_F(GeometryStateTest, RemoveGeometry) {
 // Tests the RemoveGeometry functionality in which the geometry removed has
 // geometry children.
 TEST_F(GeometryStateTest, RemoveGeometryTree) {
-  SourceId s_id = SetUpSingleSourceTree();
+  SourceId s_id = SetUpSingleSourceTree(true);
   // Pose all of the frames to the specified poses in their parent frame.
   FramePoseVector<double> poses(source_id_, frames_);
   poses.clear();
@@ -1012,10 +1018,12 @@ TEST_F(GeometryStateTest, RemoveGeometryTree) {
   // Confirm that the first geometry belongs to the first frame.
   ASSERT_EQ(geometry_state_.GetFrameId(root_id), f_id);
   // Hang geometry from the first geometry.
-  GeometryId g_id = geometry_state_.RegisterGeometryWithParent(
+  GeometryId g_id = geometry_state_.RegisterGeometryWithParentWithoutRole(
       s_id, root_id,
       make_unique<GeometryInstance>(Isometry3<double>::Identity(),
                                     unique_ptr<Shape>(new Sphere(1)), "leaf"));
+  geometry_state_.AssignRole(s_id, g_id, ProximityProperties());
+
   EXPECT_EQ(geometry_state_.get_num_geometries(),
             single_tree_total_geometry_count() + 1);
   EXPECT_EQ(geometry_state_.GetNumDynamicGeometries(),
@@ -1063,7 +1071,7 @@ TEST_F(GeometryStateTest, RemoveGeometryTree) {
 // Tests the RemoveGeometry functionality in which the geometry is a child of
 // another geometry (and has no child geometries itself).
 TEST_F(GeometryStateTest, RemoveChildLeaf) {
-  SourceId s_id = SetUpSingleSourceTree();
+  SourceId s_id = SetUpSingleSourceTree(true);
   // The geometry parent and frame to which it belongs.
   GeometryId parent_id = geometries_[0];
   FrameId frame_id = frames_[0];
@@ -1133,14 +1141,16 @@ TEST_F(GeometryStateTest, RemoveGeometryInvalid) {
 
 // Tests removal of anchored geometry.
 TEST_F(GeometryStateTest, RemoveAnchoredGeometry) {
-  SourceId s_id = SetUpSingleSourceTree();
+  SourceId s_id = SetUpSingleSourceTree(true);
 
   const Vector3<double> normal{0, 1, 0};
   const Vector3<double> point{1, 1, 1};
-  const auto anchored_id_1 = geometry_state_.RegisterAnchoredGeometry(
-      s_id,
-      make_unique<GeometryInstance>(HalfSpace::MakePose(normal, point),
-                                    make_unique<HalfSpace>(), "anchored1"));
+  const auto anchored_id_1 =
+      geometry_state_.RegisterAnchoredGeometryWithoutRole(
+          s_id,
+          make_unique<GeometryInstance>(HalfSpace::MakePose(normal, point),
+                                        make_unique<HalfSpace>(), "anchored1"));
+  geometry_state_.AssignRole(s_id, anchored_id_1, ProximityProperties());
   // Confirm conditions of having added the anchored geometry.
   EXPECT_EQ(gs_tester_.get_geometry_index_id_map().size(),
             single_tree_total_geometry_count() + 1);
@@ -1413,7 +1423,7 @@ TEST_F(GeometryStateTest, QueryFrameProperties) {
 
 // Test disallowing collisions among members of a group (self collisions).
 TEST_F(GeometryStateTest, ExcludeCollisionsWithin) {
-  SetUpSingleSourceTree();
+  SetUpSingleSourceTree(true /* assign proximity roles */);
 
   // Pose all of the frames to the specified poses in their parent frame.
   FramePoseVector<double> poses(source_id_, frames_);
@@ -1486,7 +1496,7 @@ TEST_F(GeometryStateTest, ExcludeCollisionsWithin) {
 
 // Test disallowing collision between members fo two groups.
 TEST_F(GeometryStateTest, ExcludeCollisionsBetween) {
-  SetUpSingleSourceTree();
+  SetUpSingleSourceTree(true  /* add proximity roles */);
 
   // Pose all of the frames to the specified poses in their parent frame.
   FramePoseVector<double> poses(source_id_, frames_);
@@ -1521,6 +1531,75 @@ TEST_F(GeometryStateTest, ExcludeCollisionsBetween) {
   expected_collisions -= 2;
   pairs = geometry_state_.ComputePointPairPenetration();
   ASSERT_EQ(static_cast<int>(pairs.size()), expected_collisions);
+}
+
+// Test collision filtering configuration when the input GeometrySet includes
+// geometries that *do not* have a proximity role.
+TEST_F(GeometryStateTest, NonProximityRoleInCollisionFilter) {
+  SetUpSingleSourceTree(true  /* add proximity roles */);
+
+  // Pose all of the frames to the specified poses in their parent frame.
+  FramePoseVector<double> poses(source_id_, frames_);
+  poses.clear();
+  for (int f = 0; f < static_cast<int>(frames_.size()); ++f) {
+    poses.set_value(frames_[f], X_PF_[f]);
+  }
+  gs_tester_.SetFramePoses(poses);
+  gs_tester_.FinalizePoseUpdate();
+
+  // This is *non* const; we'll decrement it as we filter more and more
+  // collisions.
+  int expected_collisions = default_collision_pair_count();
+
+  // Baseline collision - the unfiltered collisions.
+  auto pairs = geometry_state_.ComputePointPairPenetration();
+  EXPECT_EQ(static_cast<int>(pairs.size()), expected_collisions);
+
+  // Add a new collision element to the third frame. Position it so that the
+  // sphere penetrates with both the previous geometries on the frame and
+  // the anchored geometry. Initially, assign no proximity role to the new
+  // geometry.
+  //   - No proximity role implies no additional contacts are reported.
+  //   - However, when a role is assigned to the new geometry, it will *only*
+  //     report one new collision (with the anchored geometry). Collisions
+  //     between the new geometry and the previous geometries should be
+  //     automatically filtered because they are rigidly affixed to the same
+  //     frame.
+  Isometry3<double> pose = Isometry3<double>::Identity();
+  // Documentation on the single source tree indicates that the previous spheres
+  // are at (5, 0, 0) and (6, 0, 0), respectively. Split the distance to put the
+  // new geometry in a penetrating configuration.
+  pose.translation() << 5.5, 0, 0;
+  const std::string name("added_sphere");
+  GeometryId added_id = geometry_state_.RegisterGeometryWithoutRole(
+      source_id_, frames_[2],
+      make_unique<GeometryInstance>(pose, make_unique<Sphere>(1), name));
+  gs_tester_.FinalizePoseUpdate();
+
+  // No change in number of collisions.
+  pairs = geometry_state_.ComputePointPairPenetration();
+  EXPECT_EQ(static_cast<int>(pairs.size()), expected_collisions);
+
+  // Attempting to filter collisions between a geometry with no proximity role
+  // and other geometry should have no effect on the number of collisions.
+  geometry_state_.ExcludeCollisionsBetween(GeometrySet{added_id},
+                                           GeometrySet{anchored_geometry_});
+  pairs = geometry_state_.ComputePointPairPenetration();
+  EXPECT_EQ(static_cast<int>(pairs.size()), expected_collisions);
+
+  // If we assign a role, the collisions go up by one. The previous attempt
+  // to filter collisions was a no op because added_id didn't have a proximity
+  // role. So, collisions between added_id and anchored_geometry_ have not been
+  // filtered.
+  geometry_state_.AssignRole(source_id_, added_id, ProximityProperties());
+  pairs = geometry_state_.ComputePointPairPenetration();
+  EXPECT_EQ(static_cast<int>(pairs.size()), expected_collisions + 1);
+
+  // Now if we filter it, it should get removed.
+  geometry_state_.ExcludeCollisionsBetween(GeometrySet{added_id},
+                                           GeometrySet{anchored_geometry_});
+  pairs = geometry_state_.ComputePointPairPenetration();
+  EXPECT_EQ(static_cast<int>(pairs.size()), expected_collisions);
 }
 
 // Tests the documented error conditions of ExcludeCollisionsWithin.
@@ -1578,7 +1657,34 @@ TEST_F(GeometryStateTest, CrossCollisionFilterExceptions) {
 
 // Test that the appropriate error messages are dispatched.
 TEST_F(GeometryStateTest, CollisionFilteredExceptions) {
+  // Initialize tree *without* any proximity roles assigned.
   SetUpSingleSourceTree();
+
+  // Assign proximity to a *single* geometry (which won't cause any automatic
+  // filtering.
+  geometry_state_.AssignRole(source_id_, geometries_[0], ProximityProperties());
+
+  // Case: First argument does not have a proximity role.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      geometry_state_.CollisionFiltered(geometries_[1], geometries_[0]),
+      std::logic_error,
+      ".* " + to_string(geometries_[1]) + " does not have a proximity role");
+
+  // Case: Second argument does not have a proximity role.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      geometry_state_.CollisionFiltered(geometries_[0], geometries_[1]),
+      std::logic_error,
+      ".* " + to_string(geometries_[1]) + " does not have a proximity role");
+
+  // Case: Neither argument has a proximity role.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      geometry_state_.CollisionFiltered(geometries_[1], geometries_[2]),
+      std::logic_error,
+      ".* neither id has a proximity role");
+
+  // Assign proximity to the *other* geometry on frame 1 -- triggering collision
+  // filtering between them.
+  geometry_state_.AssignRole(source_id_, geometries_[1], ProximityProperties());
 
   // Base case: Two geometries on same frame *are* filtered.
   EXPECT_TRUE(
@@ -1586,21 +1692,21 @@ TEST_F(GeometryStateTest, CollisionFilteredExceptions) {
 
   GeometryId bad_id = GeometryId::get_new_id();
 
-  // Case: First geometry is bad.
+  // Case: First argument is bad.
   DRAKE_EXPECT_THROWS_MESSAGE(
       geometry_state_.CollisionFiltered(bad_id, geometries_[0]),
       std::logic_error,
       "Can't report collision filter status between geometries .* " +
           to_string(bad_id) + " is not a valid geometry");
 
-  // Case: Second geometry is bad.
+  // Case: Second argument is bad.
   DRAKE_EXPECT_THROWS_MESSAGE(
       geometry_state_.CollisionFiltered(geometries_[0], bad_id),
       std::logic_error,
       "Can't report collision filter status between geometries .* " +
           to_string(bad_id) + " is not a valid geometry");
 
-  // Case: Both geometries are bad.
+  // Case: Both arguments are bad.
   DRAKE_EXPECT_THROWS_MESSAGE(geometry_state_.CollisionFiltered(bad_id, bad_id),
                               std::logic_error,
                               "Can't report collision filter status between "
@@ -1609,7 +1715,7 @@ TEST_F(GeometryStateTest, CollisionFilteredExceptions) {
 
 // Tests the ability to query for a geometry from the name of a geometry.
 TEST_F(GeometryStateTest, GetGeometryIdFromName) {
-  SetUpSingleSourceTree();
+  SetUpSingleSourceTree(true /* intialize with proximity role */);
   // Frame i has geometries f * kFrameCount + g, where g ∈ [0, kGeometryCount).
   for (int f = 0; f < kFrameCount; ++f) {
     for (int g = 0; g < kGeometryCount; ++g) {
@@ -1739,6 +1845,196 @@ TEST_F(GeometryStateTest, GeometryNameValidation) {
   }
 }
 
+// Simply tests that when a role is assigned to a geometry, that it successfully
+// reports that it has that role.
+TEST_F(GeometryStateTest, AssignRolesToGeometry) {
+  SetUpSingleSourceTree();
+
+  // We need at least 8 geometries to run through all role permutations. Add
+  // geometries until we're there.
+  const Isometry3<double> pose = Isometry3<double>::Identity();
+  for (int i = 0; i < 8 - single_tree_dynamic_geometry_count(); ++i) {
+    const std::string name = "new_geom" + std::to_string(i);
+    geometries_.push_back(geometry_state_.RegisterGeometryWithoutRole(
+        source_id_, frames_[0],
+        make_unique<GeometryInstance>(pose, make_unique<Sphere>(1), name)));
+  }
+
+  auto set_roles = [this](GeometryId id, bool set_proximity,
+                          bool set_illustration) {
+    if (set_proximity) {
+      geometry_state_.AssignRole(source_id_, id, ProximityProperties());
+    }
+    if (set_illustration) {
+      geometry_state_.AssignRole(source_id_, id, IllustrationProperties());
+    }
+  };
+
+  auto has_expected_roles = [this](
+      GeometryId id, bool has_proximity,
+      bool has_illustration) -> ::testing::AssertionResult {
+    const internal::InternalGeometry* geometry =
+        gs_tester_.GetGeometry(id);
+    bool passes = true;
+    ::testing::AssertionResult failure = ::testing::AssertionFailure();
+    if (has_proximity != (geometry->proximity_properties() != nullptr)) {
+      failure << "Proximity role: "
+              << (has_proximity ? " expected, but not found"
+                                : " not expected, but found. ");
+      passes = false;
+    }
+    if (has_illustration != (geometry->illustration_properties() != nullptr)) {
+      failure << "Illustration role: "
+              << (has_illustration ? " expected, but not found"
+                                   : " not expected, but found. ");
+      passes = false;
+    }
+    if (passes)
+      return ::testing::AssertionSuccess();
+    else
+      return failure;
+  };
+
+  // Given two role types, assign all four types of assignments.
+  for (int i = 0; i < 4; ++i) {
+    const bool proximity = i & 0x1;
+    const bool illustration = i & 0x2;
+    const GeometryId id = geometries_[i];
+    EXPECT_TRUE(has_expected_roles(id, false, false))
+              << "Geometry " << id << " at index (" << i
+              << ") didn't start without roles";
+    set_roles(id, proximity, illustration);
+    EXPECT_TRUE(has_expected_roles(id, proximity, illustration))
+              << "Incorrect roles for geometry " << id << " at index (" << i
+              << ").";
+  }
+
+  // Confirm it works on anchored geometry. Pick, arbitrarily, assigning
+  // proximity and illustration roles.
+  EXPECT_TRUE(has_expected_roles(anchored_geometry_, false, false));
+  set_roles(anchored_geometry_, true, true);
+  EXPECT_TRUE(has_expected_roles(anchored_geometry_, true, true));
+}
+
+// Tests that properties assigned to a geometry instance lead to the resulting
+// geometry having the appropriate roles assigned.
+TEST_F(GeometryStateTest, InstanceRoleAssignment) {
+  SourceId s_id = NewSource();
+  FrameId f_id = geometry_state_.RegisterFrame(
+      s_id, GeometryFrame("frame", Isometry3<double>::Identity()));
+
+  auto make_instance = [this](const std::string& name) {
+    return make_unique<GeometryInstance>(
+        instance_pose_, make_unique<Sphere>(1.0), name);
+  };
+
+  // Case: no properties assigned leaves geometry with no roles.
+  {
+    GeometryId g_id = geometry_state_.RegisterGeometryWithoutRole(
+        s_id, f_id, make_instance("instance1"));
+    const internal::InternalGeometry* geometry = gs_tester_.GetGeometry(g_id);
+    EXPECT_FALSE(geometry->has_proximity_role());
+    EXPECT_FALSE(geometry->has_illustration_role());
+  }
+
+  // Case: Only proximity properties provided.
+  {
+    auto instance = make_instance("instance2");
+    instance->set_proximity_properties(ProximityProperties());
+    GeometryId g_id =
+        geometry_state_.RegisterGeometryWithoutRole(s_id, f_id, move(instance));
+
+    const internal::InternalGeometry* geometry = gs_tester_.GetGeometry(g_id);
+    EXPECT_TRUE(geometry->has_proximity_role());
+    EXPECT_FALSE(geometry->has_illustration_role());
+  }
+
+  // Case: Only illustration properties provided.
+  {
+    auto instance = make_instance("instance3");
+    instance->set_illustration_properties(IllustrationProperties());
+    GeometryId g_id =
+        geometry_state_.RegisterGeometryWithoutRole(s_id, f_id, move(instance));
+
+    const internal::InternalGeometry* geometry = gs_tester_.GetGeometry(g_id);
+    EXPECT_FALSE(geometry->has_proximity_role());
+    EXPECT_TRUE(geometry->has_illustration_role());
+  }
+
+  // Case: All properties provided.
+  {
+    auto instance = make_instance("instance4");
+    instance->set_proximity_properties(ProximityProperties());
+    instance->set_illustration_properties(IllustrationProperties());
+    GeometryId g_id =
+        geometry_state_.RegisterGeometryWithoutRole(s_id, f_id, move(instance));
+
+    const internal::InternalGeometry* geometry = gs_tester_.GetGeometry(g_id);
+    EXPECT_TRUE(geometry->has_proximity_role());
+    EXPECT_TRUE(geometry->has_illustration_role());
+  }
+}
+
+// Tests that the property values created get correctly propagated to the
+// target geometry.
+TEST_F(GeometryStateTest, RolePropertyValueAssignment) {
+  SetUpSingleSourceTree();
+  // Tests for proximity properties and assumes the same holds true for the
+  // other role property types.
+
+  ProximityProperties source;
+  const std::string& default_group = source.default_group_name();
+  source.AddProperty(default_group, "prop1", 7);
+  source.AddProperty(default_group, "prop2", 10);
+  const std::string group1("group1");
+  source.AddProperty(group1, "propA", 7.5);
+  source.AddProperty(group1, "propB", "test");
+
+  geometry_state_.AssignRole(source_id_, geometries_[0], source);
+  const ProximityProperties* read =
+      gs_tester_.GetGeometry(geometries_[0])->proximity_properties();
+  ASSERT_NE(read, nullptr);
+
+  // Test groups.
+  ASSERT_EQ(source.num_groups(), read->num_groups());
+  ASSERT_TRUE(read->HasGroup(group1));
+  ASSERT_TRUE(read->HasGroup(default_group));
+
+  // Utility for counting properties in a group.
+  auto num_group_properties = [](const ProximityProperties& properties,
+                                 const std::string& group_name) {
+    const auto& group = properties.GetPropertiesInGroup(group_name);
+    return static_cast<int>(group.size());
+  };
+
+  // Utility for counting properties in a full set of properties.
+  auto num_total_properties =
+      [num_group_properties](const ProximityProperties& properties) {
+        int count = 0;
+        for (const auto& group_name : properties.GetGroupNames()) {
+          count += num_group_properties(properties, group_name);
+        }
+        return count;
+      };
+
+  // Test properties.
+  EXPECT_EQ(num_total_properties(source), num_total_properties(*read));
+
+  EXPECT_EQ(num_group_properties(source, default_group),
+            num_group_properties(*read, default_group));
+  EXPECT_EQ(source.GetProperty<int>(default_group, "prop1"),
+            read->GetProperty<int>(default_group, "prop1"));
+  EXPECT_EQ(source.GetProperty<int>(default_group, "prop2"),
+            read->GetProperty<int>(default_group, "prop2"));
+
+  EXPECT_EQ(num_group_properties(source, group1),
+            num_group_properties(*read, group1));
+  EXPECT_EQ(source.GetProperty<double>(group1, "propA"),
+            read->GetProperty<double>(group1, "propA"));
+  EXPECT_EQ(source.GetProperty<std::string>(group1, "propB"),
+            read->GetProperty<std::string>(group1, "propB"));
+}
+
 // Tests the conditions in which `AssignRole()` throws an exception.
 TEST_F(GeometryStateTest, RoleAssignExceptions) {
   SetUpSingleSourceTree();
@@ -1772,20 +2068,91 @@ TEST_F(GeometryStateTest, RoleAssignExceptions) {
 
   // Redefinition of role - test each role individually to make sure it has
   // the right error message.
+  EXPECT_NO_THROW(geometry_state_.AssignRole(source_id_, geometries_[0],
+                                             ProximityProperties()));
   DRAKE_EXPECT_THROWS_MESSAGE(
       geometry_state_.AssignRole(source_id_, geometries_[0],
                                  ProximityProperties()),
       std::logic_error,
       "Geometry already has proximity role assigned");
+
+  EXPECT_NO_THROW(geometry_state_.AssignRole(source_id_, geometries_[0],
+                                             IllustrationProperties()));
   DRAKE_EXPECT_THROWS_MESSAGE(
       geometry_state_.AssignRole(source_id_, geometries_[0],
                                  IllustrationProperties()),
       std::logic_error,
       "Geometry already has illustration role assigned");
+}
 
-  // TODO(SeanCurtis-TRI): When role assignment is delayed, add a geometry with
-  // the name of an *exisiting* geometry and show it breaks when the duplicate
-  // role is assigned.
+// Tests the functionality that counts the number of children geometry a frame
+// has for each role.
+TEST_F(GeometryStateTest, ChildGeometryRoleCount) {
+  // Defaults to *no* roles being set.
+  SetUpSingleSourceTree();
+
+  auto expected_roles = [this](
+      FrameId f_id, int num_proximity,
+      int num_illustration) -> ::testing::AssertionResult {
+    bool success = true;
+    ::testing::AssertionResult failure = ::testing::AssertionFailure();
+    std::vector<std::pair<Role, int>> roles{
+        {Role::kProximity, num_proximity},
+        {Role::kIllustration, num_illustration}};
+    for (const auto& pair : roles) {
+      const Role role = pair.first;
+      const int expected_count = pair.second;
+      const int actual_count =
+          geometry_state_.NumGeometriesWithRole(f_id, role);
+      if (actual_count != expected_count) {
+        success = false;
+        failure << "\nExpected " << expected_count << " geometries with the "
+                << role << " role. Found " << actual_count;
+      }
+    }
+    if (success)
+      return ::testing::AssertionSuccess();
+    else
+      return failure;
+  };
+
+  // Assert initial conditions.
+  int proximity_count = 0;
+  int illustration_count = 0;
+  FrameId f_id = frames_[0];
+  ASSERT_TRUE(expected_roles(f_id, proximity_count, illustration_count));
+
+  // Confirm the two geometries I'm going to play with belong to the same frame.
+  GeometryId g_id1 = geometries_[0];
+  GeometryId g_id2 = geometries_[1];
+  ASSERT_EQ(f_id, geometry_state_.GetFrameId(g_id1));
+  ASSERT_EQ(f_id, geometry_state_.GetFrameId(g_id2));
+
+  // Now start assigning roles and confirm results. Do *not* re-order these
+  // tests; the expected results accumulate.
+  geometry_state_.AssignRole(source_id_, g_id1, ProximityProperties());
+  ++proximity_count;
+  ASSERT_TRUE(expected_roles(f_id, proximity_count, illustration_count));
+
+  geometry_state_.AssignRole(source_id_, g_id2, IllustrationProperties());
+  ++illustration_count;
+  ASSERT_TRUE(expected_roles(f_id, proximity_count, illustration_count));
+
+  geometry_state_.AssignRole(source_id_, g_id1, IllustrationProperties());
+  ++illustration_count;
+  ASSERT_TRUE(expected_roles(f_id, proximity_count, illustration_count));
+  geometry_state_.AssignRole(source_id_, g_id2, ProximityProperties());
+  ++proximity_count;
+  ASSERT_TRUE(expected_roles(f_id, proximity_count, illustration_count));
+  // Now test against anchored geometry by passing in the world frame.
+  FrameId world_id = InternalFrame::world_frame_id();
+  ASSERT_TRUE(expected_roles(world_id, 0, 0));
+  geometry_state_.AssignRole(source_id_, anchored_geometry_,
+                             ProximityProperties());
+  ASSERT_TRUE(expected_roles(world_id, 1, 0));
+  geometry_state_.AssignRole(source_id_, anchored_geometry_,
+                             IllustrationProperties());
+  ASSERT_TRUE(expected_roles(world_id, 1, 1));
 }
 
 }  // namespace

--- a/geometry/test/geometry_visualization_test.cc
+++ b/geometry/test/geometry_visualization_test.cc
@@ -43,13 +43,23 @@ GTEST_TEST(GeometryVisualization, SimpleScene) {
   const float g = 0.5f;
   const float b = 0.25f;
   const float a = 0.125f;
-  Vector4<double> color{r, g, b, a};
-  VisualMaterial material(color);
-  scene_graph.RegisterGeometry(
+  GeometryId sphere_id = scene_graph.RegisterGeometryWithoutRole(
       source_id, frame_id,
       make_unique<GeometryInstance>(Isometry3d::Identity(),
-                                    make_unique<Sphere>(radius), "sphere",
-                                    material));
+                                    make_unique<Sphere>(radius), "sphere"));
+  Vector4<double> color{r, g, b, a};
+  scene_graph.AssignRole(source_id, sphere_id,
+                         MakeDrakeVisualizerProperties(color));
+
+  // Add a second frame and geometry that only has proximity properties. It
+  // should not impact the result.
+  FrameId collision_frame_id = scene_graph.RegisterFrame(
+      source_id, GeometryFrame("collision frame", Isometry3d::Identity()));
+  GeometryId collision_id = scene_graph.RegisterGeometryWithoutRole(
+      source_id, collision_frame_id,
+      make_unique<GeometryInstance>(Isometry3d::Identity(),
+      make_unique<Sphere>(radius), "sphere_collision"));
+  scene_graph.AssignRole(source_id, collision_id, ProximityProperties());
 
   unique_ptr<Context<double>> context = scene_graph.AllocateContext();
   const GeometryContext<double>& geo_context =


### PR DESCRIPTION
This introduces a parallel API for registering geometry: Register*WithoutRole(). Previous commits had introduced roles internally and all geometries were registered with both proximity and illustration roles by default. This alternate API registers the geometry with the same effect, but without any default roles
assigned.

The parallel API will be used to migrate all the call sites over to the new paradigm (of having to assign roles at the registration site). Once those have been moved, the old API will be replaced with the new (and names will be swapped).

The majority of the new code is in the geometry state unit tests. In addition to testing the new AssignRole() methods, Role-dependent count methods, and role assignment from geometry instances, it also includes new unit tests on old code that is now impacted by roles (e.g., collision filtering).

relates #9540.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10134)
<!-- Reviewable:end -->
