### PR TITLE
Permit multiple discrete state groups and model vectors for each

### DIFF
--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -463,28 +463,39 @@ struct Impl {
         .def("_DeclareContinuousState",
             py::overload_cast<int>(&LeafSystemPublic::DeclareContinuousState),
             py::arg("num_state_variables"),
-            doc.LeafSystem.DeclareContinuousState.doc)
+            doc.LeafSystem.DeclareContinuousState.doc_1args_num_state_variables)
         .def("_DeclareContinuousState",
             py::overload_cast<int, int, int>(
                 &LeafSystemPublic::DeclareContinuousState),
             py::arg("num_q"), py::arg("num_v"), py::arg("num_z"),
-            doc.LeafSystem.DeclareContinuousState.doc_2)
+            doc.LeafSystem.DeclareContinuousState.doc_3args_num_q_num_v_num_z)
         .def("_DeclareContinuousState",
             py::overload_cast<const BasicVector<T>&>(
                 &LeafSystemPublic::DeclareContinuousState),
             py::arg("model_vector"),
-            doc.LeafSystem.DeclareContinuousState.doc_3)
+            doc.LeafSystem.DeclareContinuousState.doc_1args_model_vector)
         // TODO(eric.cousineau): Ideally the downstream class of
         // `BasicVector<T>` should expose `num_q`, `num_v`, and `num_z`?
         .def("_DeclareContinuousState",
             py::overload_cast<const BasicVector<T>&, int, int, int>(
                 &LeafSystemPublic::DeclareContinuousState),
             py::arg("model_vector"), py::arg("num_q"), py::arg("num_v"),
-            py::arg("num_z"), doc.LeafSystem.DeclareContinuousState.doc_4)
+            py::arg("num_z"),
+            doc.LeafSystem.DeclareContinuousState
+                .doc_4args_model_vector_num_q_num_v_num_z)
         // Discrete state.
-        // TODO(eric.cousineau): Should there be a `BasicVector<>` overload?
-        .def("_DeclareDiscreteState", &LeafSystemPublic::DeclareDiscreteState,
-            doc.LeafSystem.DeclareDiscreteState.doc)
+        .def("_DeclareDiscreteState",
+            py::overload_cast<const BasicVector<T>&>(
+                &LeafSystemPublic::DeclareDiscreteState),
+            py::arg("model_vector"), doc.LeafSystem.DeclareDiscreteState.doc)
+        .def("_DeclareDiscreteState",
+            py::overload_cast<const Eigen::Ref<const VectorX<T>>&>(
+                &LeafSystemPublic::DeclareDiscreteState),
+            py::arg("model_vector"), doc.LeafSystem.DeclareDiscreteState.doc_2)
+        .def("_DeclareDiscreteState",
+            py::overload_cast<int>(&LeafSystemPublic::DeclareDiscreteState),
+            py::arg("num_state_variables"),
+            doc.LeafSystem.DeclareDiscreteState.doc_3)
         .def("_DeclarePeriodicDiscreteUpdate",
             &LeafSystemPublic::DeclarePeriodicDiscreteUpdate,
             py::arg("period_sec"), py::arg("offset_sec") = 0.,

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -434,6 +434,29 @@ class TestCustom(unittest.TestCase):
                 self.assertEqual(
                     context.get_continuous_state_vector().size(), 6)
 
+    def test_discrete_state_api(self):
+        # N.B. Since this has trivial operations, we can test all scalar types.
+        for T in [float, AutoDiffXd, Expression]:
+
+            class TrivialSystem(LeafSystem_[T]):
+                def __init__(self, index):
+                    LeafSystem_[T].__init__(self)
+                    num_states = 3
+                    if index == 0:
+                        self._DeclareDiscreteState(
+                            num_state_variables=num_states)
+                    elif index == 1:
+                        self._DeclareDiscreteState([1, 2, 3])
+                    elif index == 2:
+                        self._DeclareDiscreteState(
+                            BasicVector_[T](num_states))
+
+            for index in range(3):
+                system = TrivialSystem(index)
+                context = system.CreateDefaultContext()
+                self.assertEqual(
+                    context.get_discrete_state(0).size(), 3)
+
     def test_abstract_io_port(self):
         test = self
         # N.B. Since this has trivial operations, we can test all scalar types.

--- a/systems/framework/discrete_values.h
+++ b/systems/framework/discrete_values.h
@@ -64,10 +64,21 @@ class DiscreteValues {
   /// Constructs a one-group %DiscreteValues object that owns a single @p datum
   /// vector which may not be null.
   explicit DiscreteValues(std::unique_ptr<BasicVector<T>> datum) {
-    if (datum == nullptr)
-      throw std::logic_error("DiscreteValues: null groups not allowed");
+    AppendGroup(std::move(datum));
+  }
+
+  /// Adds an additional group that owns the given @p datum, which must be
+  /// non-null. Returns the assigned group number, counting up from 0 for the
+  /// first group.
+  int AppendGroup(std::unique_ptr<BasicVector<T>> datum) {
+    if (datum == nullptr) {
+      throw std::logic_error(
+          "DiscreteValues::AppendGroup(): null groups not allowed");
+    }
+    const int group_num = static_cast<int>(data_.size());
     data_.push_back(datum.get());
     owned_data_.push_back(std::move(datum));
+    return group_num;
   }
 
   virtual ~DiscreteValues() {}

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -190,11 +190,23 @@ class LeafSystem : public System<T> {
     } else {
       xc.SetFromVector(VectorX<T>::Zero(xc.size()));
     }
+
     DiscreteValues<T>& xd = state->get_mutable_discrete_state();
-    for (int i = 0; i < xd.num_groups(); i++) {
-      BasicVector<T>& s = xd.get_mutable_vector(i);
-      s.SetFromVector(VectorX<T>::Zero(s.size()));
+
+    // Check that _if_ we have models, there is one for each group.
+    DRAKE_DEMAND(model_discrete_state_.num_groups() == 0 ||
+        model_discrete_state_.num_groups() == xd.num_groups());
+
+    if (model_discrete_state_.num_groups() > 0) {
+      xd.CopyFrom(model_discrete_state_);
+    } else {
+      // With no model vector, we just zero all the discrete variables.
+      for (int i = 0; i < xd.num_groups(); i++) {
+        BasicVector<T>& s = xd.get_mutable_vector(i);
+        s.SetFromVector(VectorX<T>::Zero(s.size()));
+      }
     }
+
     AbstractValues& xa = state->get_mutable_abstract_state();
     xa.CopyFrom(AbstractValues(model_abstract_states_.CloneAllModels()));
   }
@@ -471,8 +483,8 @@ class LeafSystem : public System<T> {
   /// Returns a ContinuousState used to implement both CreateDefaultContext and
   /// AllocateTimeDerivatives. Allocates the state configured with
   /// DeclareContinuousState, or none by default. Systems with continuous state
-  /// variables may override, but must ensure the ContinuousState vector is
-  /// a subclass of BasicVector.
+  /// variables may override (not recommended), but must ensure the
+  /// ContinuousState vector is a subclass of BasicVector.
   virtual std::unique_ptr<ContinuousState<T>> AllocateContinuousState() const {
     if (model_continuous_state_vector_ != nullptr) {
       return std::make_unique<ContinuousState<T>>(
@@ -483,19 +495,17 @@ class LeafSystem : public System<T> {
   }
 
   /// Reserves the discrete state as required by CreateDefaultContext. By
-  /// default, reserves no state. Systems with discrete state should override.
+  /// default, clones the model values as provided in DeclareDiscreteState()
+  /// calls. Alternatively, systems with discrete state can override this
+  /// method (not recommended).
   virtual std::unique_ptr<DiscreteValues<T>> AllocateDiscreteState() const {
-    if (model_discrete_state_vector_ != nullptr) {
-      return std::make_unique<DiscreteValues<T>>(
-          model_discrete_state_vector_->Clone());
-    }
-    return std::make_unique<DiscreteValues<T>>();
+    return model_discrete_state_.Clone();
   }
 
   /// Reserves the abstract state as required by CreateDefaultContext. By
   /// default, it clones the abstract states declared through
-  /// DeclareAbstractState() calls. Derived systems should override for
-  /// different behaviors.
+  /// DeclareAbstractState() calls. Derived systems may override for
+  /// different behaviors (not recommended).
   virtual std::unique_ptr<AbstractValues> AllocateAbstractState() const {
     return std::make_unique<AbstractValues>(
         std::move(model_abstract_states_.CloneAllModels()));
@@ -725,9 +735,23 @@ class LeafSystem : public System<T> {
     event.AddToComposite(TriggerType::kInitialization, &initialization_events_);
   }
 
+  /// @name          Declare continuous state variables
+  /// Continuous state consists of up to three kinds of variables: generalized
+  /// coordinates q, generalized velocities v, and miscellaneous continuous
+  /// variables z. Methods in this section provide different ways to declare
+  /// these, and offer the ability to provide a `model_vector` to specify the
+  /// initial values for these variables. Model values are useful when you want
+  /// the values of these variables in a default Context to be something other
+  /// than zero.
+  ///
+  /// If multiple calls are made to DeclareContinuousState() methods, only the
+  /// last call has any effect. Also, these methods have no effect if
+  /// AllocateContinuousState() is overridden (not recommended).
+  //@{
+
   /// Declares that this System should reserve continuous state with
   /// @p num_state_variables state variables, which have no second-order
-  /// structure. Has no effect if AllocateContinuousState is overridden.
+  /// structure.
   void DeclareContinuousState(int num_state_variables) {
     const int num_q = 0, num_v = 0;
     DeclareContinuousState(num_q, num_v, num_state_variables);
@@ -735,8 +759,7 @@ class LeafSystem : public System<T> {
 
   /// Declares that this System should reserve continuous state with @p num_q
   /// generalized positions, @p num_v generalized velocities, and @p num_z
-  /// miscellaneous state variables.  Has no effect if AllocateContinuousState
-  /// is overridden.
+  /// miscellaneous state variables.
   void DeclareContinuousState(int num_q, int num_v, int num_z) {
     const int n = num_q + num_v + num_z;
     DeclareContinuousState(BasicVector<T>(VectorX<T>::Zero(n)), num_q, num_v,
@@ -745,8 +768,7 @@ class LeafSystem : public System<T> {
 
   /// Declares that this System should reserve continuous state with
   /// @p model_vector.size() miscellaneous state variables, stored in a
-  /// vector Cloned from @p model_vector.  Has no effect if
-  /// AllocateContinuousState is overridden.
+  /// vector cloned from @p model_vector.
   void DeclareContinuousState(const BasicVector<T>& model_vector) {
     const int num_q = 0, num_v = 0;
     const int num_z = model_vector.size();
@@ -755,12 +777,11 @@ class LeafSystem : public System<T> {
 
   /// Declares that this System should reserve continuous state with @p num_q
   /// generalized positions, @p num_v generalized velocities, and @p num_z
-  /// miscellaneous state variables, stored in a vector Cloned from
-  /// @p model_vector. Aborts if @p model_vector has the wrong size. Has no
-  /// effect if AllocateContinuousState is overridden. If the @p model_vector
-  /// declares any VectorBase::CalcInequalityConstraint() constraints, they
-  /// will be re-declared as inequality constraints on this system (see
-  /// DeclareInequalityConstraint()).
+  /// miscellaneous state variables, stored in a vector cloned from
+  /// @p model_vector. Aborts if @p model_vector has the wrong size. If the
+  /// @p model_vector declares any VectorBase::CalcInequalityConstraint()
+  /// constraints, they will be re-declared as inequality constraints on this
+  /// system (see DeclareInequalityConstraint()).
   void DeclareContinuousState(const BasicVector<T>& model_vector, int num_q,
                               int num_v, int num_z) {
     DRAKE_DEMAND(model_vector.size() == num_q + num_v + num_z);
@@ -775,40 +796,75 @@ class LeafSystem : public System<T> {
           return state.get_vector();
         });
   }
+  //@}
 
-  /// Declares that this System should reserve continuous state with @p num_q
-  /// generalized positions, @p num_v generalized velocities, and @p num_z
-  /// miscellaneous state variables, stored in the a vector Cloned from
-  /// @p model_vector. Aborts if @p model_vector is nullptr or has the wrong
-  /// size. Has no effect if AllocateContinuousState is overridden.
-  DRAKE_DEPRECATED("Use the const-reference model_vector overload instead")
-  void DeclareContinuousState(std::unique_ptr<BasicVector<T>> model_vector,
-                              int num_q, int num_v, int num_z) {
-    DRAKE_DEMAND(model_vector != nullptr);
-    DeclareContinuousState(*model_vector, num_q, num_v, num_z);
-  }
+  /// @name            Declare discrete state variables
+  /// Discrete state consists of any number of discrete state "groups", each
+  /// of which is a vector of discrete state variables. Methods in this section
+  /// provide different ways to declare these, and offer the ability to provide
+  /// a `model_vector` to specify the initial values for each group of
+  /// variables. Model values are useful when you want the values of
+  /// these variables in a default Context to be something other than zero.
+  ///
+  /// Each call to a DeclareDiscreteState() method produces another
+  /// discrete state group, and the group index is returned. These methods have
+  /// no effect if AllocateDiscreteState() is overridden (not recommended).
+  //@{
 
-  /// Declares that this System should reserve discrete state with
-  /// @p num_state_variables state variables. Has no effect if
-  /// AllocateDiscreteState is overridden.
-  // TODO(sherm1) Repeated calls to this should allocate additional discrete
-  // state groups. Currently there is only one.
-  void DeclareDiscreteState(int num_state_variables) {
-    const DiscreteStateIndex index(0);  // Only one implemented currently.
-    model_discrete_state_vector_ =
-        std::make_unique<BasicVector<T>>(num_state_variables);
+  /// Declares a discrete state group with @p model_vector.size() state
+  /// variables, stored in a vector cloned from @p model_vector (preserving the
+  /// concrete type and value).
+  DiscreteStateIndex DeclareDiscreteState(const BasicVector<T>& model_vector) {
+    const DiscreteStateIndex index(model_discrete_state_.num_groups());
+    model_discrete_state_.AppendGroup(model_vector.Clone());
     this->AddDiscreteStateGroup(index);
+    MaybeDeclareVectorBaseInequalityConstraint(
+        "discrete state", model_vector,
+        [index](const Context<T>& context) -> const VectorBase<T>& {
+          const BasicVector<T>& state = context.get_discrete_state(index);
+          return state;
+        });
+    return index;
   }
+
+  /// Declares a discrete state group with @p model_vector.size() state
+  /// variables, stored in a BasicVector initialized with the contents of
+  /// @p model_vector.
+  DiscreteStateIndex DeclareDiscreteState(
+      const Eigen::Ref<const VectorX<T>>& model_vector) {
+    return DeclareDiscreteState(BasicVector<T>(model_vector));
+  }
+
+  /// Declares a discrete state group with @p num_state_variables state
+  /// variables, stored in a BasicVector initialized to be all-zero. If you want
+  /// non-zero initial values, use an alternate DeclareDiscreteState() signature
+  /// that accepts a `model_vector` parameter.
+  /// @pre `num_state_variables` must be non-negative.
+  DiscreteStateIndex DeclareDiscreteState(int num_state_variables) {
+    DRAKE_DEMAND(num_state_variables >= 0);
+    return DeclareDiscreteState(VectorX<T>::Zero(num_state_variables));
+  }
+  //@}
+
+  /// @name            Declare abstract state variables
+  /// Abstract state consists of any number of arbitrarily-typed variables, each
+  /// represented by an AbstractValue. Each call to the DeclareAbstractState()
+  /// method produces another abstract state variable, and the abstract state
+  /// variable index is returned. This method has no effect if
+  /// AllocateAbstractState() is overridden (not recommended).
+  //@{
 
   /// Declares an abstract state.
   /// @param abstract_state The abstract state, its ownership is transferred.
   /// @return index of the declared abstract state.
-  int DeclareAbstractState(std::unique_ptr<AbstractValue> abstract_state) {
+  AbstractStateIndex DeclareAbstractState(
+      std::unique_ptr<AbstractValue> abstract_state) {
     const AbstractStateIndex index(model_abstract_states_.size());
     model_abstract_states_.AddModel(index, std::move(abstract_state));
     this->AddAbstractState(index);
     return index;
   }
+  //@}
 
   // =========================================================================
   /// @name                    Declare input ports
@@ -1889,7 +1945,7 @@ class LeafSystem : public System<T> {
   int num_misc_continuous_states_{0};
 
   // A model discrete state to be used during Context allocation.
-  std::unique_ptr<BasicVector<T>> model_discrete_state_vector_;
+  DiscreteValues<T> model_discrete_state_;
 
   // A model abstract state to be used during Context allocation.
   detail::ModelValues model_abstract_states_;

--- a/systems/framework/test/discrete_values_test.cc
+++ b/systems/framework/test/discrete_values_test.cc
@@ -55,6 +55,24 @@ TEST_F(DiscreteValuesTest, UnownedState) {
   EXPECT_EQ(xd.get_vector(1).get_value(), v01_);
 }
 
+TEST_F(DiscreteValuesTest, AppendGroup) {
+  DiscreteValues<double> xd(std::move(data_));
+  ASSERT_EQ(xd.num_groups(), 2);
+  EXPECT_EQ(xd.get_vector(0).get_value(), v00_);
+  EXPECT_EQ(xd.get_vector(1).get_value(), v01_);
+  const int group_num = xd.AppendGroup(std::make_unique<MyVector3d>(v11_));
+  EXPECT_EQ(group_num, 2);
+  ASSERT_EQ(xd.num_groups(), 3);
+
+  // Check that we didn't break previous values.
+  EXPECT_EQ(xd.get_vector(0).get_value(), v00_);
+  EXPECT_EQ(xd.get_vector(1).get_value(), v01_);
+
+  // Check that new value and type are preserved.
+  EXPECT_EQ(xd.get_vector(2).get_value(), v11_);
+  EXPECT_TRUE(is_dynamic_castable<MyVector3d>(&xd.get_vector(2)));
+}
+
 TEST_F(DiscreteValuesTest, NoNullsAllowed) {
   // Unowned.
   EXPECT_THROW(DiscreteValues<double>(

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -3,6 +3,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <typeinfo>
 
 #include <Eigen/Dense>
 #include <gmock/gmock.h>
@@ -1058,6 +1059,65 @@ GTEST_TEST(ModelLeafSystemTest, ModelNumericParams) {
   EXPECT_EQ(2.2, param.GetAtIndex(1));
 }
 
+// Tests that various DeclareDiscreteState() signatures work correctly and
+// that the model values get used in SetDefaultContext().
+GTEST_TEST(ModelLeafSystemTest, ModelDiscreteState) {
+  class DeclaredModelDiscreteStateSystem : public LeafSystem<double> {
+   public:
+    // This should produce three discrete variable groups.
+    DeclaredModelDiscreteStateSystem() {
+      // Takes a BasicVector.
+      indexes_.push_back(
+          DeclareDiscreteState(MyVector2d(Eigen::Vector2d(1., 2.))));
+      // Takes an Eigen vector.
+      indexes_.push_back(DeclareDiscreteState(Eigen::Vector3d(3., 4., 5.)));
+      // Four state variables, initialized to zero.
+      indexes_.push_back(DeclareDiscreteState(4));
+    }
+    std::vector<DiscreteStateIndex> indexes_;
+  };
+
+  DeclaredModelDiscreteStateSystem dut;
+  EXPECT_EQ(dut.num_discrete_state_groups(), 3);
+  for (int i=0; i < static_cast<int>(dut.indexes_.size()); ++i)
+    EXPECT_TRUE(dut.indexes_[i] == i);
+
+  auto context = dut.CreateDefaultContext();
+  DiscreteValues<double>& xd = context->get_mutable_discrete_state();
+  EXPECT_EQ(xd.num_groups(), 3);
+
+  // Concrete type and value should have been preserved.
+  BasicVector<double>& xd0 = xd.get_mutable_vector(0);
+  EXPECT_TRUE(is_dynamic_castable<const MyVector2d>(&xd0));
+  EXPECT_EQ(xd0.get_value(), Eigen::Vector2d(1., 2.));
+
+  // Eigen vector should have been stored in a BasicVector-type object.
+  BasicVector<double>& xd1 = xd.get_mutable_vector(1);
+  EXPECT_EQ(typeid(xd1), typeid(BasicVector<double>));
+  EXPECT_EQ(xd1.get_value(), Eigen::Vector3d(3., 4., 5.));
+
+  // Discrete state with no model should act as though it were given an
+  // all-zero Eigen vector model.
+  BasicVector<double>& xd2 = xd.get_mutable_vector(2);
+  EXPECT_EQ(typeid(xd2), typeid(BasicVector<double>));
+  EXPECT_EQ(xd2.get_value(), Eigen::Vector4d(0., 0., 0., 0.));
+
+  // Now make changes, then see if SetDefaultContext() puts them back.
+  xd0.SetFromVector(Eigen::Vector2d(9., 10.));
+  xd1.SetFromVector(Eigen::Vector3d(11., 12., 13.));
+  xd2.SetFromVector(Eigen::Vector4d(1., 2., 3., 4.));
+
+  // Of course that had to work, but let's just prove it ...
+  EXPECT_EQ(xd0.get_value(), Eigen::Vector2d(9., 10.));
+  EXPECT_EQ(xd1.get_value(), Eigen::Vector3d(11., 12., 13.));
+  EXPECT_EQ(xd2.get_value(), Eigen::Vector4d(1., 2., 3., 4.));
+
+  dut.SetDefaultContext(&*context);
+  EXPECT_EQ(xd0.get_value(), Eigen::Vector2d(1., 2.));
+  EXPECT_EQ(xd1.get_value(), Eigen::Vector3d(3., 4., 5.));
+  EXPECT_EQ(xd2.get_value(), Eigen::Vector4d(0., 0., 0., 0.));
+}
+
 // Tests that DeclareAbstractState works expectedly.
 GTEST_TEST(ModelLeafSystemTest, ModelAbstractState) {
   class DeclaredModelAbstractStateSystem : public LeafSystem<double> {
@@ -1915,6 +1975,7 @@ class ConstraintTestSystem : public LeafSystem<double> {
 
   // Expose some protected methods for testing.
   using LeafSystem<double>::DeclareContinuousState;
+  using LeafSystem<double>::DeclareDiscreteState;
   using LeafSystem<double>::DeclareEqualityConstraint;
   using LeafSystem<double>::DeclareInequalityConstraint;
   using LeafSystem<double>::DeclareNumericParameter;
@@ -2069,6 +2130,16 @@ GTEST_TEST(SystemConstraintTest, ModelVectorTest) {
   EXPECT_FALSE(constraint3.is_equality_constraint());
   EXPECT_THAT(constraint3.description(), ::testing::ContainsRegex(
       "^output 0 of type .*ConstraintBasicVector<double,44>$"));
+
+  // Declaring constrained model discrete state should add constraints.
+  // We want `vec[0] >= 55` on the state vector.
+  using DiscreteStateVector = ConstraintBasicVector<double, 55>;
+  dut.DeclareDiscreteState(DiscreteStateVector{});
+  EXPECT_EQ(dut.get_num_constraints(), 5);
+  const SystemConstraint<double>& constraint4 = dut.get_constraint(Index{4});
+  EXPECT_FALSE(constraint4.is_equality_constraint());
+  EXPECT_THAT(constraint4.description(), ::testing::ContainsRegex(
+      "^discrete state of type .*ConstraintBasicVector<double,55>$"));
 
   // We'll work through the Calc results all at the end, so that we don't
   // change the shape of the System and Context while we're Calc'ing.


### PR DESCRIPTION
Modifies `LeafSystem::DeclareDiscreteState()` to create a new discrete state group each time it is called, and permits model values to be provided for them. The DiscreteStateIndex of the group is returned.

Changes here should be backwards compatible unless someone was depending on multiple DeclareDiscreteState() calls to be ignored except for the last one (now you'll get multiple groups instead).

Reviewer notes:
- Required adding a method to DiscreteValues to allow groups to be added incrementally.
- DeclareDiscreteState() behaves much more like DeclareAbstractState() now.
- I made DeclareAbstractState() return the AbstractStateIndex which it should have been doing before.

Fixes #9705 
Fixes #7058
Relates #9766 because we want model values there to make the examples look nice.
Priority is high because #9766 is waiting for this to land.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10136)
<!-- Reviewable:end -->
