### PR TITLE
Refines rpy2rotmat's deprecation comment

### DIFF
--- a/math/rotation_matrix.h
+++ b/math/rotation_matrix.h
@@ -930,8 +930,11 @@ RotationMatrix<T>::ThrowIfNotValid(const Matrix3<S>& R) {
 
 // TODO(mitiguy) Delete this deprecated code after February 5, 2019.
 template <typename Derived>
-DRAKE_DEPRECATED("Use  RotationMatrix(RollPitchYaw(rpy)) as per issue #8323. "
-                 "Code will be deleted after February 5, 2019.")
+DRAKE_DEPRECATED("Use  RotationMatrix(RollPitchYaw(rpy)).matrix() as per issue "
+                 "#8323. Code will be deleted after February 5, 2019. Consider "
+                 "updating call sites to use the RotationMatrix class rather "
+                 "than a Matrix3 because it ensures the underlying 3x3 matrix "
+                 "is a valid rotation matrix.")
 Matrix3<typename Derived::Scalar> rpy2rotmat(
     const Eigen::MatrixBase<Derived>& rpy) {
   EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Eigen::MatrixBase<Derived>, 3);


### PR DESCRIPTION
The method returns a Matrix3<T>, not a RotationMatrix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10138)
<!-- Reviewable:end -->
