### PR TITLE
tools: Don't force -Werror when compiling Drake as an external

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -44,6 +44,13 @@ drake_runfiles_binary(
 
 # === config_setting rules ===
 
+# When this is set, a Drake build will promote some warnings to errors.
+# See drake/tools/cc_toolchain/bazel.rc for details.
+config_setting(
+    name = "drake_werror",
+    values = {"define": "DRAKE_WERROR=ON"},
+)
+
 config_setting(
     name = "with_gurobi",
     values = {"define": "WITH_GUROBI=ON"},

--- a/tools/cc_toolchain/bazel.rc
+++ b/tools/cc_toolchain/bazel.rc
@@ -5,6 +5,18 @@ build --action_env=CCACHE_DISABLE=1
 build --cxxopt=-std=c++14
 build --host_cxxopt=-std=c++14
 
+# When compiling with Drake as the main WORKSPACE (i.e., if and only if this
+# rcfile is loaded), we enable -Werror by default for Drake's *own* targets,
+# but not for our externals.
+#
+# Developers may still disable errors locally by passing --copt=-w on the
+# command line, or promote *any* warnings even from externals to errors via
+# --copt=-Werror.
+#
+# When compiilng Drake as an external package, this rcfile is not loaded and we
+# won't promote warnings to errors by default.
+build --define=DRAKE_WERROR=ON
+
 ### Debug symbols on OS X. ###
 # See https://github.com/bazelbuild/bazel/issues/2537
 build:apple_debug --spawn_strategy=standalone

--- a/tools/lint/library_lint.bzl
+++ b/tools/lint/library_lint.bzl
@@ -93,9 +93,11 @@ def library_lint(
     ])
 
     # Find libraries that are deps of the package_library but shouldn't be.
-    extra_deps_expression = "deps({}, 1) except ({})".format(
+    extra_deps_expression = "deps({}, 1) except ({}) except {}".format(
         package_name,
         correct_deps_expression,
+        # This is fine (it's a dependency of our copt select() statement).
+        "//tools:drake_werror",
     )
 
     # Find libraries that should be deps of the package_library but aren't.

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -52,14 +52,20 @@ def _platform_copts(rule_copts, rule_gcc_copts, rule_clang_copts, cc_test = 0):
     When cc_test=1, the GCC_CC_TEST_FLAGS will be added.  It should only be set
     to 1 from cc_test rules or rules that are boil down to cc_test rules.
     """
-    extra_gcc_flags = []
-    if cc_test:
-        extra_gcc_flags = GCC_CC_TEST_FLAGS
     if COMPILER_ID.endswith("Clang"):
-        return CLANG_FLAGS + rule_copts + rule_clang_copts
-    if COMPILER_ID == "GNU":
-        return GCC_FLAGS + extra_gcc_flags + rule_copts + rule_gcc_copts
-    return rule_copts
+        result = CLANG_FLAGS + rule_copts + rule_clang_copts
+    elif COMPILER_ID == "GNU":
+        extra_gcc_flags = GCC_CC_TEST_FLAGS if cc_test else []
+        result = GCC_FLAGS + extra_gcc_flags + rule_copts + rule_gcc_copts
+    else:
+        result = rule_copts
+    return select({
+        "//tools:drake_werror": result,
+        "//conditions:default": [
+            x.replace("-Werror=", "-W")
+            for x in result
+        ],
+    })
 
 def _dsym_command(name):
     """Returns the command to produce .dSYM on macOS, or a no-op on Linux."""


### PR DESCRIPTION
We can't really know what compiler is being used, and so we might fail due to spurious warnings.  This is OK if Drake was the main workspace, because the user can opt-out, but with Drake as a Bazel external, there is no easy way for a user to set Drake-specific CXXFLAGS to opt-out.

This also more closely matches best practice to only force -Werror during development, but not for source releases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10150)
<!-- Reviewable:end -->
