### PR TITLE
common: Fix drake_variant for C++17

### DIFF
--- a/common/drake_optional.h
+++ b/common/drake_optional.h
@@ -5,7 +5,16 @@
 // we force the issue here.  Note that this does NOT place stx::variant into
 // the drake namespace, so users still need to include drake_variant.h in order
 // to use variants.
+//
+// Furthermore, the stx header is broken in various ways, so we have to do some
+// work-arounds before and after including it.
+#if defined(__has_include)
+#if __has_include(<variant>)
+#include <variant>
+#endif
+#endif
 #include <stx/variant.hpp>
+#define STX_HAVE_IN_PLACE_T 1
 
 // As of our currently supported platforms (Ubuntu 16.04 Xenial and macOS 10.13
 // High Sierra), the std::experimental::optional implementations for libstdc++

--- a/common/drake_variant.h
+++ b/common/drake_variant.h
@@ -1,6 +1,8 @@
 #pragma once
 
-#include <stx/variant.hpp>
+// For now, #include <stx/variant.hpp> via drake_optional.h; there is a lot of
+// ceremony to include it correctly, which we only want to repeat once.
+#include "drake/common/drake_optional.h"
 
 /// @file
 /// Provides drake::variant as an alias for the appropriate implementation of
@@ -11,7 +13,13 @@ namespace drake {
 template <typename... Types>
 using variant = stx::variant<Types...>;
 
+#ifdef STX_HAVE_STD_VARIANT
+// The stx::get alias is missing, so we have to do this instead.
+using std::get;
+#else
 using stx::get;
+#endif
+
 using stx::holds_alternative;
 
 // N.B. We don't alias stx::get_if, because it's signature (reference argument)


### PR DESCRIPTION
(Obviously, working around this many upstream bugs is unsustainable.  I'll work on getting a _good_ replacement sooner rather than later.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10152)
<!-- Reviewable:end -->
