### PR TITLE
Change how real LCM message (for iiwa and wsg) interact with simulator.

### DIFF
--- a/examples/kuka_iiwa_arm/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/BUILD.bazel
@@ -54,6 +54,7 @@ drake_cc_library(
         "//common/trajectories:piecewise_polynomial",
         "//lcmtypes:iiwa",
         "//systems/framework:leaf_system",
+        "//systems/lcm:translator",
     ],
 )
 

--- a/examples/kuka_iiwa_arm/dev/pick_and_place/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/dev/pick_and_place/BUILD.bazel
@@ -159,6 +159,7 @@ drake_cc_binary(
         "//lcmtypes:iiwa",
         "//lcmtypes:viewer",
         "//manipulation/schunk_wsg:schunk_wsg_controller",
+        "//manipulation/schunk_wsg:schunk_wsg_lcm",
         "//systems/analysis:simulator",
         "@gflags",
         "@lcmtypes_bot2_core",

--- a/examples/kuka_iiwa_arm/dev/pick_and_place/lcm_pick_and_place_simulator.cc
+++ b/examples/kuka_iiwa_arm/dev/pick_and_place/lcm_pick_and_place_simulator.cc
@@ -16,6 +16,7 @@
 #include "drake/lcmt_iiwa_status.hpp"
 #include "drake/lcmt_schunk_wsg_command.hpp"
 #include "drake/lcmt_schunk_wsg_status.hpp"
+#include "drake/manipulation/schunk_wsg/schunk_wsg_lcm.h"
 #include "drake/multibody/rigid_body_plant/contact_results_to_lcm.h"
 #include "drake/multibody/rigid_body_plant/drake_visualizer.h"
 #include "drake/systems/analysis/runge_kutta2_integrator.h"
@@ -94,13 +95,15 @@ int DoMain(void) {
 
   // Add LCM subscribers/publishers for the iiwa arms.
   const int num_iiwa{plant->num_iiwa()};
+  kuka_iiwa_arm::IiwaCommandTranslator iiwa_cmd_to_vec;
   for (int i = 0; i < num_iiwa; ++i) {
     // All LCM traffic for this arm will occur on channels that end with the
     // suffix specified below.
     const std::string suffix = (num_iiwa > 1) ? "_" + std::to_string(i) : "";
-    auto iiwa_command_sub = builder.AddSystem(
-        systems::lcm::LcmSubscriberSystem::Make<lcmt_iiwa_command>(
-            "IIWA_COMMAND" + suffix, &lcm));
+    auto iiwa_command_sub =
+        builder.AddSystem(std::make_unique<systems::lcm::LcmSubscriberSystem>(
+            "IIWA_COMMAND" + suffix, iiwa_cmd_to_vec, &lcm));
+
     iiwa_command_sub->set_name("iiwa_command_subscriber" + suffix);
     builder.Connect(iiwa_command_sub->get_output_port(),
                     plant->get_input_port_iiwa_command(i));
@@ -115,6 +118,7 @@ int DoMain(void) {
   }
 
   // Add LCM subscribers/publishers for the Schunk grippers.
+  manipulation::schunk_wsg::SchunkWsgCommandTranslator wsg_cmd_to_vec;
   const int num_wsg{plant->num_wsg()};
   for (int i = 0; i < num_wsg; ++i) {
     // All LCM traffic for this gripper will occur on channels that end with the
@@ -127,9 +131,9 @@ int DoMain(void) {
                     wsg_status_pub->get_input_port());
     wsg_status_pub->set_publish_period(kIiwaLcmStatusPeriod);
 
-    auto wsg_command_sub = builder.AddSystem(
-        systems::lcm::LcmSubscriberSystem::Make<lcmt_schunk_wsg_command>(
-            "SCHUNK_WSG_COMMAND" + suffix, &lcm));
+    auto wsg_command_sub =
+        builder.AddSystem(std::make_unique<systems::lcm::LcmSubscriberSystem>(
+            "SCHUNK_WSG_COMMAND" + suffix, wsg_cmd_to_vec, &lcm));
     builder.Connect(wsg_command_sub->get_output_port(),
                     plant->get_input_port_wsg_command(i));
   }

--- a/examples/kuka_iiwa_arm/dev/pick_and_place/lcm_plant.cc
+++ b/examples/kuka_iiwa_arm/dev/pick_and_place/lcm_plant.cc
@@ -84,8 +84,8 @@ LcmPlant::LcmPlant(
     iiwa_command_receiver->set_name("iiwa_command_receiver" + suffix);
 
     // Export iiwa command input port.
-    input_port_iiwa_command_.push_back(
-        builder.ExportInput(iiwa_command_receiver->get_input_port(0)));
+    input_port_iiwa_command_.push_back(builder.ExportInput(
+        iiwa_command_receiver->GetInputPort("command_message")));
     builder.Connect(iiwa_command_receiver->get_commanded_state_output_port(),
                     iiwa_and_wsg_plant_->get_input_port_iiwa_state_command(i));
 
@@ -117,8 +117,8 @@ LcmPlant::LcmPlant(
     auto wsg_controller = builder.AddSystem<SchunkWsgController>();
     wsg_controller->set_name("wsg_controller" + suffix);
     builder.Connect(iiwa_and_wsg_plant_->get_output_port_wsg_state(i),
-                    wsg_controller->get_state_input_port());
-    builder.Connect(wsg_controller->get_output_port(0),
+                    wsg_controller->GetInputPort("state"));
+    builder.Connect(wsg_controller->GetOutputPort("force"),
                     iiwa_and_wsg_plant_->get_input_port_wsg_command(i));
 
     auto wsg_status_sender = builder.AddSystem<SchunkWsgStatusSender>();
@@ -142,7 +142,7 @@ LcmPlant::LcmPlant(
 
     // Export WSG command input port.
     input_port_wsg_command_.push_back(
-        builder.ExportInput(wsg_controller->get_command_input_port()));
+        builder.ExportInput(wsg_controller->GetInputPort("command_message")));
   }
 
   // Build the system.

--- a/examples/kuka_iiwa_arm/iiwa_wsg_simulation.cc
+++ b/examples/kuka_iiwa_arm/iiwa_wsg_simulation.cc
@@ -160,9 +160,10 @@ int DoMain() {
   visualizer->set_publish_period(kIiwaLcmStatusPeriod);
 
   // Create the command subscriber and status publisher.
-  auto iiwa_command_sub = builder.AddSystem(
-      systems::lcm::LcmSubscriberSystem::Make<lcmt_iiwa_command>("IIWA_COMMAND",
-                                                                 &lcm));
+  IiwaCommandTranslator iiwa_cmd_to_vec;
+  auto iiwa_command_sub =
+      builder.AddSystem(std::make_unique<systems::lcm::LcmSubscriberSystem>(
+          "IIWA_COMMAND", iiwa_cmd_to_vec, &lcm));
   iiwa_command_sub->set_name("iiwa_command_subscriber");
   auto iiwa_command_receiver = builder.AddSystem<IiwaCommandReceiver>();
   iiwa_command_receiver->set_name("iwwa_command_receiver");
@@ -188,7 +189,7 @@ int DoMain() {
   iiwa_zero_acceleration_source->set_name("zero_acceleration");
 
   builder.Connect(iiwa_command_sub->get_output_port(),
-                  iiwa_command_receiver->get_input_port(0));
+                  iiwa_command_receiver->GetInputPort("command_vector"));
   builder.Connect(iiwa_command_receiver->get_commanded_state_output_port(),
                   model->get_input_port_iiwa_state_command());
   builder.Connect(iiwa_zero_acceleration_source->get_output_port(),
@@ -209,9 +210,10 @@ int DoMain() {
   builder.Connect(iiwa_status_sender->get_output_port(0),
                   iiwa_status_pub->get_input_port());
 
-  auto wsg_command_sub = builder.AddSystem(
-      systems::lcm::LcmSubscriberSystem::Make<lcmt_schunk_wsg_command>(
-          "SCHUNK_WSG_COMMAND", &lcm));
+  manipulation::schunk_wsg::SchunkWsgCommandTranslator wsg_cmd_to_vec;
+  auto wsg_command_sub =
+      builder.AddSystem(std::make_unique<systems::lcm::LcmSubscriberSystem>(
+          "SCHUNK_WSG_COMMAND", wsg_cmd_to_vec, &lcm));
   wsg_command_sub->set_name("wsg_command_subscriber");
   auto wsg_controller = builder.AddSystem<SchunkWsgController>();
 
@@ -230,8 +232,8 @@ int DoMain() {
   wsg_status_sender->set_name("wsg_status_sender");
 
   builder.Connect(wsg_command_sub->get_output_port(),
-                  wsg_controller->get_command_input_port());
-  builder.Connect(wsg_controller->get_output_port(0),
+                  wsg_controller->GetInputPort("command_vector"));
+  builder.Connect(wsg_controller->GetOutputPort("force"),
                   model->get_input_port_wsg_command());
   builder.Connect(model->get_output_port_wsg_state(),
                   mbp_state_to_wsg_state->get_input_port());
@@ -242,7 +244,7 @@ int DoMain() {
   builder.Connect(mbp_force_to_wsg_force->get_output_port(),
                   wsg_status_sender->get_force_input_port());
   builder.Connect(model->get_output_port_wsg_state(),
-                  wsg_controller->get_state_input_port());
+                  wsg_controller->GetInputPort("state"));
   builder.Connect(*wsg_status_sender, *wsg_status_pub);
 
   auto iiwa_state_pub = builder.AddSystem(

--- a/examples/kuka_iiwa_arm/kuka_simulation.cc
+++ b/examples/kuka_iiwa_arm/kuka_simulation.cc
@@ -109,9 +109,10 @@ int DoMain() {
 
   // Create the command subscriber and status publisher.
   systems::DiagramBuilder<double>* base_builder = builder.get_mutable_builder();
+  IiwaCommandTranslator iiwa_cmd_to_vec(num_joints);
   auto command_sub = base_builder->AddSystem(
-      systems::lcm::LcmSubscriberSystem::Make<lcmt_iiwa_command>("IIWA_COMMAND",
-                                                                 &lcm));
+      std::make_unique<systems::lcm::LcmSubscriberSystem>(
+          "IIWA_COMMAND", iiwa_cmd_to_vec, &lcm));
   command_sub->set_name("command_subscriber");
   auto command_receiver =
       base_builder->AddSystem<IiwaCommandReceiver>(num_joints);

--- a/examples/kuka_iiwa_arm/test/iiwa_lcm_test.cc
+++ b/examples/kuka_iiwa_arm/test/iiwa_lcm_test.cc
@@ -48,14 +48,16 @@ GTEST_TEST(IiwaLcmTest, IiwaCommandReceiverTest) {
   delta << 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007;
 
   lcmt_iiwa_command command{};
+  command.utime = 1;
   command.num_joints = kNumJoints;
   command.joint_position.resize(kNumJoints);
   for (int i = 0; i < kNumJoints; i++) {
     command.joint_position[i] = position(i) + delta(i);
   }
-
+  const int message_input_id = dut.GetInputPort("command_message").get_index();
   context->FixInputPort(
-      0, std::make_unique<systems::Value<lcmt_iiwa_command>>(command));
+      message_input_id,
+      std::make_unique<systems::Value<lcmt_iiwa_command>>(command));
 
   std::unique_ptr<systems::DiscreteValues<double>> update =
       dut.AllocateDiscreteVariables();
@@ -86,7 +88,9 @@ GTEST_TEST(IiwaLcmTest, IiwaCommandReceiverTest) {
     expected_torque[i] = command.joint_torque[i];
   }
   context->FixInputPort(
-      0, std::make_unique<systems::Value<lcmt_iiwa_command>>(command));
+      message_input_id,
+      std::make_unique<systems::Value<lcmt_iiwa_command>>(command));
+
   update = dut.AllocateDiscreteVariables();
   dut.CalcDiscreteVariableUpdates(*context, update.get());
   context->get_mutable_discrete_state().SetFrom(*update);

--- a/examples/manipulation_station/mock_station_simulation.cc
+++ b/examples/manipulation_station/mock_station_simulation.cc
@@ -67,12 +67,13 @@ int do_main(int argc, char* argv[]) {
 
   // TODO(russt): IiwaCommandReceiver should output positions, not
   // state.  (We are adding delay twice in this current implementation).
-  auto iiwa_command_subscriber = builder.AddSystem(
-      systems::lcm::LcmSubscriberSystem::Make<drake::lcmt_iiwa_command>(
-          "IIWA_COMMAND", &lcm));
+  kuka_iiwa_arm::IiwaCommandTranslator iiwa_cmd_to_vec(7);
+  auto iiwa_command_subscriber =
+      builder.AddSystem(std::make_unique<systems::lcm::LcmSubscriberSystem>(
+          "IIWA_COMMAND", iiwa_cmd_to_vec, &lcm));
   auto iiwa_command = builder.AddSystem<kuka_iiwa_arm::IiwaCommandReceiver>();
   builder.Connect(iiwa_command_subscriber->get_output_port(),
-                  iiwa_command->get_input_port(0));
+                  iiwa_command->GetInputPort("command_vector"));
 
   // Pull the positions out of the state.
   auto demux = builder.AddSystem<systems::Demultiplexer>(14, 7);
@@ -108,13 +109,14 @@ int do_main(int argc, char* argv[]) {
                   iiwa_status_publisher->get_input_port());
 
   // Receive the WSG commands.
-  auto wsg_command_subscriber = builder.AddSystem(
-      systems::lcm::LcmSubscriberSystem::Make<drake::lcmt_schunk_wsg_command>(
-          "SCHUNK_WSG_COMMAND", &lcm));
+  manipulation::schunk_wsg::SchunkWsgCommandTranslator wsg_cmd_to_vec;
+  auto wsg_command_subscriber =
+      builder.AddSystem(std::make_unique<systems::lcm::LcmSubscriberSystem>(
+          "SCHUNK_WSG_COMMAND", wsg_cmd_to_vec, &lcm));
   auto wsg_command =
       builder.AddSystem<manipulation::schunk_wsg::SchunkWsgCommandReceiver>();
   builder.Connect(wsg_command_subscriber->get_output_port(),
-                  wsg_command->get_input_port(0));
+                  wsg_command->GetInputPort("command_vector"));
   builder.Connect(wsg_command->get_position_output_port(),
                   station->GetInputPort("wsg_position"));
   builder.Connect(wsg_command->get_force_limit_output_port(),

--- a/manipulation/schunk_wsg/BUILD.bazel
+++ b/manipulation/schunk_wsg/BUILD.bazel
@@ -19,6 +19,7 @@ package(
 drake_cc_package_library(
     name = "schunk_wsg",
     deps = [
+        ":schunk_wsg_command",
         ":schunk_wsg_constants",
         ":schunk_wsg_controller",
         ":schunk_wsg_lcm",
@@ -43,8 +44,10 @@ drake_cc_library(
     srcs = ["schunk_wsg_lcm.cc"],
     hdrs = ["schunk_wsg_lcm.h"],
     deps = [
+        ":schunk_wsg_command",
         "//lcmtypes:schunk",
         "//systems/framework:leaf_system",
+        "//systems/lcm:translator",
         "//systems/primitives:matrix_gain",
     ],
 )
@@ -52,6 +55,12 @@ drake_cc_library(
 drake_cc_vector_gen_library(
     name = "schunk_wsg_trajectory_generator_state_vector",
     srcs = ["schunk_wsg_trajectory_generator_state_vector.named_vector"],
+    visibility = [":__subpackages__"],
+)
+
+drake_cc_vector_gen_library(
+    name = "schunk_wsg_command",
+    srcs = ["schunk_wsg_command.named_vector"],
     visibility = [":__subpackages__"],
 )
 

--- a/manipulation/schunk_wsg/schunk_wsg_command.named_vector
+++ b/manipulation/schunk_wsg/schunk_wsg_command.named_vector
@@ -1,0 +1,20 @@
+namespace: "drake::manipulation::schunk_wsg"
+
+element {
+    name: "utime"
+    doc: "Timestamp"
+    doc_units: "microsecond"
+    default_value: "0.0"
+}
+element {
+    name: "target_position_mm"
+    doc: "Distance between fingers"
+    doc_units: "mm"
+    default_value: "0.0"
+}
+element {
+    name: "force"
+    doc: "Max total grasping force applied by both fingers."
+    doc_units: "N"
+    default_value: "0.0"
+}

--- a/manipulation/schunk_wsg/schunk_wsg_controller.cc
+++ b/manipulation/schunk_wsg/schunk_wsg_controller.cc
@@ -17,11 +17,13 @@ SchunkWsgController::SchunkWsgController(double kp, double ki, double kd) {
   auto state_pass_through = builder.AddSystem<systems::PassThrough<double>>(
       kSchunkWsgNumPositions + kSchunkWsgNumVelocities);
 
-  state_input_port_ = builder.ExportInput(state_pass_through->get_input_port());
+  builder.ExportInput(state_pass_through->get_input_port(), "state");
 
   auto command_receiver = builder.AddSystem<SchunkWsgCommandReceiver>();
-  command_input_port_ =
-      builder.ExportInput(command_receiver->get_command_input_port());
+  builder.ExportInput(command_receiver->GetInputPort("command_vector"),
+                      "command_vector");
+  builder.ExportInput(command_receiver->GetInputPort("command_message"),
+                      "command_message");
 
   auto wsg_trajectory_generator =
       builder.AddSystem<SchunkWsgTrajectoryGenerator>(
@@ -43,7 +45,7 @@ SchunkWsgController::SchunkWsgController(double kp, double ki, double kd) {
   builder.Connect(wsg_trajectory_generator->get_max_force_output_port(),
                   wsg_controller->get_input_port_max_force());
 
-  builder.ExportOutput(wsg_controller->get_output_port_control());
+  builder.ExportOutput(wsg_controller->get_output_port_control(), "force");
   builder.BuildInto(this);
 }
 

--- a/manipulation/schunk_wsg/schunk_wsg_controller.h
+++ b/manipulation/schunk_wsg/schunk_wsg_controller.h
@@ -8,12 +8,22 @@ namespace manipulation {
 namespace schunk_wsg {
 
 /// This class implements a controller for a Schunk WSG gripper.  It
-/// has two input ports which receive lcmt_schunk_wsg_command messages
-/// and the current state, and an output port which emits the target
-/// force for the actuated finger.  The internal implementation
-/// consists of a PID controller (which controls the target position
-/// from the command message) combined with a saturation block (which
-/// applies the force control from the command message).
+/// has three input ports: lcmt_schunk_wsg_command message, a vectorized
+/// representation of the same message (SchunkWsgCommand), and the current
+/// state, and an output port which emits the target force for the actuated
+/// finger. Note, only one of the command input ports should be connected,
+/// However, if both are connected, the message input will be ignored.
+/// The internal implementation consists of a PID controller (which controls
+/// the target position from the command message) combined with a saturation
+/// block (which applies the force control from the command message).
+///
+/// @system{
+///   @input_port{state}
+///   @input_port{command_vector}
+///   @input_port{command_message}
+///   @output_port{force}
+/// }
+///
 /// @ingroup manipulation_systems
 class SchunkWsgController : public systems::Diagram<double> {
  public:
@@ -24,18 +34,6 @@ class SchunkWsgController : public systems::Diagram<double> {
   // target.
   explicit SchunkWsgController(double kp = 2000.0, double ki = 0.0,
                                double kd = 5.0);
-
-  const systems::InputPort<double>& get_command_input_port() const {
-    return this->get_input_port(command_input_port_);
-  }
-
-  const systems::InputPort<double>& get_state_input_port() const {
-    return this->get_input_port(state_input_port_);
-  }
-
- private:
-  int command_input_port_{};
-  int state_input_port_{};
 };
 
 }  // namespace schunk_wsg

--- a/manipulation/schunk_wsg/schunk_wsg_lcm.cc
+++ b/manipulation/schunk_wsg/schunk_wsg_lcm.cc
@@ -16,33 +16,80 @@ namespace schunk_wsg {
 using systems::BasicVector;
 using systems::Context;
 
+void SchunkWsgCommandTranslator::Deserialize(
+    const void* lcm_message_bytes, int lcm_message_length,
+    systems::VectorBase<double>* vector_base) const {
+  auto command = dynamic_cast<SchunkWsgCommand<double>*>(vector_base);
+  DRAKE_THROW_UNLESS(command);
+
+  lcmt_schunk_wsg_command msg{};
+  const int length = msg.decode(lcm_message_bytes, 0, lcm_message_length);
+  DRAKE_THROW_UNLESS(length == lcm_message_length);
+
+  command->set_utime(msg.utime);
+  command->set_target_position_mm(msg.target_position_mm);
+  command->set_force(msg.force);
+}
+
+void SchunkWsgCommandTranslator::Serialize(double,
+                                           const systems::VectorBase<double>&,
+                                           std::vector<uint8_t>*) const {
+  throw std::runtime_error("Not implemented");
+}
+
+std::unique_ptr<systems::BasicVector<double>>
+SchunkWsgCommandTranslator::AllocateOutputVector() const {
+  return std::make_unique<SchunkWsgCommand<double>>();
+}
+
 SchunkWsgCommandReceiver::SchunkWsgCommandReceiver(double initial_position,
                                                    double initial_force)
-    : initial_position_(initial_position),
-      initial_force_(initial_force),
-      position_output_port_(
-          this->DeclareVectorOutputPort(
-                  "position", BasicVector<double>(1),
-                  &SchunkWsgCommandReceiver::CalcPositionOutput)
-              .get_index()),
-      force_limit_output_port_(
-          this->DeclareVectorOutputPort(
-                  "force_limit", BasicVector<double>(1),
-                  &SchunkWsgCommandReceiver::CalcForceLimitOutput)
-              .get_index()) {
-  this->DeclareAbstractInputPort("lcmt_schunk_wsg_command",
-                                 systems::Value<lcmt_schunk_wsg_command>());
+    : initial_position_(initial_position), initial_force_(initial_force) {
+  this->DeclareVectorOutputPort("position", BasicVector<double>(1),
+                                &SchunkWsgCommandReceiver::CalcPositionOutput);
+  this->DeclareVectorOutputPort(
+      "force_limit", BasicVector<double>(1),
+      &SchunkWsgCommandReceiver::CalcForceLimitOutput);
+
+  SchunkWsgCommand<double> uninitialized_vector;
+  this->DeclareVectorInputPort("command_vector", uninitialized_vector);
+
+  lcmt_schunk_wsg_command uninitialized_message{};
+  this->DeclareAbstractInputPort(
+      "command_message",
+      systems::Value<lcmt_schunk_wsg_command>(uninitialized_message));
+}
+
+void SchunkWsgCommandReceiver::EvalInput(
+    const Context<double>& context, SchunkWsgCommand<double>* result) const {
+  // Try the vector input port first.
+  const SchunkWsgCommand<double>* wsg_command =
+      this->template EvalVectorInput<SchunkWsgCommand>(context, 0);
+
+  // Maybe the vector input is not wired, try abstract input next.
+  SchunkWsgCommand<double> decoded_command;
+  if (!wsg_command) {
+    const systems::AbstractValue* input = this->EvalAbstractInput(context, 1);
+    DRAKE_THROW_UNLESS(input != nullptr);
+    const auto& command_msg = input->GetValue<lcmt_schunk_wsg_command>();
+    std::vector<uint8_t> bytes(command_msg.getEncodedSize());
+    command_msg.encode(bytes.data(), 0, bytes.size());
+    translator_.Deserialize(bytes.data(), bytes.size(), &decoded_command);
+    wsg_command = &decoded_command;
+  }
+  DRAKE_THROW_UNLESS(wsg_command != nullptr);
+
+  result->get_mutable_value() = wsg_command->get_value();
 }
 
 void SchunkWsgCommandReceiver::CalcPositionOutput(
     const Context<double>& context, BasicVector<double>* output) const {
-  const systems::AbstractValue* input = this->EvalAbstractInput(context, 0);
-  DRAKE_ASSERT(input != nullptr);
-  const auto& command = input->GetValue<lcmt_schunk_wsg_command>();
+  SchunkWsgCommand<double> wsg_command;
+  EvalInput(context, &wsg_command);
 
   double target_position = initial_position_;
-  if (command.utime != 0) {
-    target_position = command.target_position_mm / 1e3;
+  if (wsg_command.utime() != SchunkWsgCommand<double>().utime()) {
+    target_position = wsg_command.target_position_mm() / 1e3;
     if (std::isnan(target_position)) {
       target_position = 0;
     }
@@ -53,13 +100,12 @@ void SchunkWsgCommandReceiver::CalcPositionOutput(
 
 void SchunkWsgCommandReceiver::CalcForceLimitOutput(
     const Context<double>& context, BasicVector<double>* output) const {
-  const systems::AbstractValue* input = this->EvalAbstractInput(context, 0);
-  DRAKE_ASSERT(input != nullptr);
-  const auto& command = input->GetValue<lcmt_schunk_wsg_command>();
+  SchunkWsgCommand<double> wsg_command;
+  EvalInput(context, &wsg_command);
 
   double force_limit = initial_force_;
-  if (command.utime != 0) {
-    force_limit = command.force;
+  if (wsg_command.utime() != SchunkWsgCommand<double>().utime()) {
+    force_limit = wsg_command.force();
   }
 
   output->SetAtIndex(0, force_limit);

--- a/manipulation/schunk_wsg/schunk_wsg_lcm.h
+++ b/manipulation/schunk_wsg/schunk_wsg_lcm.h
@@ -3,25 +3,65 @@
 /// @file This file contains classes dealing with sending/receiving
 /// LCM messages related to the Schunk WSG gripper.
 
+#include <memory>
+#include <vector>
+
 #include "drake/common/drake_deprecated.h"
 #include "drake/lcmt_schunk_wsg_command.hpp"
 #include "drake/lcmt_schunk_wsg_status.hpp"
+#include "drake/manipulation/schunk_wsg/gen/schunk_wsg_command.h"
 #include "drake/systems/framework/leaf_system.h"
+#include "drake/systems/lcm/lcm_and_vector_base_translator.h"
 
 namespace drake {
 namespace manipulation {
 namespace schunk_wsg {
 
-/// Handles lcmt_schunk_wsg_command messages from a LcmSubscriberSystem.  Has
-/// two output ports: one for the commanded finger position represented as the
-/// desired distance between the fingers in meters, and one for the commanded
-/// force limit.  The commanded position and force limit are scalars
+/// A translator between the LCM message type lcmt_schunk_wsg_command and
+/// its vectorized representation, SchunkWsgCommand. This is intended
+/// to be used with systems::lcm::LcmPublisherSystem and
+/// systems::lcm::LcmSubscriberSystem.
+// TODO(siyuan.feng@tri.global) remove this with #10149 is resolved.
+class SchunkWsgCommandTranslator
+    : public systems::lcm::LcmAndVectorBaseTranslator {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SchunkWsgCommandTranslator)
+
+  SchunkWsgCommandTranslator() : LcmAndVectorBaseTranslator(3) {}
+
+  std::unique_ptr<systems::BasicVector<double>> AllocateOutputVector()
+      const override;
+
+  /// Translates @p lcm_message_bytes into @p vector_base.
+  /// @throws if @p lcm_message_bytes cannot be decoded as a
+  /// lcmt_schunk_wsg_command struct or @p vector_base is not a
+  /// SchunkWsgCommand<double>.
+  void Deserialize(const void* lcm_message_bytes, int lcm_message_length,
+                   systems::VectorBase<double>* vector_base) const override;
+
+  /// Not implemented.
+  /// @throws std::runtime_error.
+  void Serialize(double time, const systems::VectorBase<double>& vector_base,
+                 std::vector<uint8_t>* lcm_message_bytes) const override;
+};
+
+/// Handles the command for the Schunk WSG gripper from a LcmSubscriberSystem.
+/// It has two input ports for the lcmt_schunk_wsg_command message itself and
+/// a vectorized version (SchunkWsgCommand) of the message. Note, only one of
+/// the inputs should be connected. However, if both are connected, the
+/// message port will be ignored. It has two output ports: one for the
+/// commanded finger position represented as the desired distance between the
+/// fingers in meters, and one for the commanded force limit.
+/// The commanded position and force limit are scalars
 /// (BasicVector<double> of size 1).
 ///
 /// @system{ SchunkWsgCommandReceiver,
-///   @input_port{lcmt_schunk_wsg_command},
+///   @input_port{command_vector},
+///   @input_port{command_message},
 ///   @output_port{position}
 ///   @output_port{force_limit} }
+// TODO(siyuan.feng@tri.global) remove the vector input version after #10149 is
+// resolved.
 class SchunkWsgCommandReceiver : public systems::LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SchunkWsgCommandReceiver)
@@ -34,16 +74,12 @@ class SchunkWsgCommandReceiver : public systems::LeafSystem<double> {
   SchunkWsgCommandReceiver(double initial_position = 0.02,
                            double initial_force = 40);
 
-  const systems::InputPort<double>& get_command_input_port() const {
-    return this->get_input_port(0);
-  }
-
   const systems::OutputPort<double>& get_position_output_port() const {
-    return this->get_output_port(position_output_port_);
+    return this->GetOutputPort("position");
   }
 
   const systems::OutputPort<double>& get_force_limit_output_port() const {
-    return this->get_output_port(force_limit_output_port_);
+    return this->GetOutputPort("force_limit");
   }
 
  private:
@@ -53,11 +89,12 @@ class SchunkWsgCommandReceiver : public systems::LeafSystem<double> {
   void CalcForceLimitOutput(const systems::Context<double>& context,
                             systems::BasicVector<double>* output) const;
 
- private:
+  void EvalInput(const systems::Context<double>& context,
+                 SchunkWsgCommand<double>* result) const;
+
+  const SchunkWsgCommandTranslator translator_;
   const double initial_position_{};
   const double initial_force_{};
-  const systems::OutputPortIndex position_output_port_{};
-  const systems::OutputPortIndex force_limit_output_port_{};
 };
 
 

--- a/manipulation/schunk_wsg/test/schunk_wsg_controller_test.cc
+++ b/manipulation/schunk_wsg/test/schunk_wsg_controller_test.cc
@@ -26,13 +26,13 @@ std::pair<double, double> RunWsgControllerTestStep(
   std::unique_ptr<systems::SystemOutput<double>> output =
       dut.AllocateOutput();
   context->FixInputPort(
-      dut.get_command_input_port().get_index(),
+      dut.GetInputPort("command_message").get_index(),
       std::make_unique<systems::Value<lcmt_schunk_wsg_command>>(wsg_command));
   Eigen::VectorXd wsg_state_vec =
       Eigen::VectorXd::Zero(kSchunkWsgNumPositions + kSchunkWsgNumVelocities);
   wsg_state_vec(0) = -(wsg_position / 1e3) / 2.;
   wsg_state_vec(1) = (wsg_position / 1e3) / 2.;
-  context->FixInputPort(dut.get_state_input_port().get_index(), wsg_state_vec);
+  context->FixInputPort(dut.GetInputPort("state").get_index(), wsg_state_vec);
   systems::Simulator<double> simulator(dut, std::move(context));
   simulator.StepTo(1.0);
   dut.CalcOutput(simulator.get_context(), output.get());

--- a/manipulation/schunk_wsg/test/schunk_wsg_lcm_test.cc
+++ b/manipulation/schunk_wsg/test/schunk_wsg_lcm_test.cc
@@ -29,8 +29,9 @@ GTEST_TEST(SchunkWsgLcmTest, SchunkWsgCommandReceiverTest) {
   // Check that we get the initial position and force before receiving a
   // command.
   lcmt_schunk_wsg_command initial_command{};
+  const int message_input_id = dut.GetInputPort("command_message").get_index();
   context->FixInputPort(
-      0,
+      message_input_id,
       systems::AbstractValue::Make<lcmt_schunk_wsg_command>(initial_command));
   EXPECT_EQ(dut.get_position_output_port()
                 .Eval<BasicVector<double>>(*context)
@@ -47,7 +48,7 @@ GTEST_TEST(SchunkWsgLcmTest, SchunkWsgCommandReceiverTest) {
   initial_command.target_position_mm = 100;
   initial_command.force = 40;
   context->FixInputPort(
-      0,
+      message_input_id,
       systems::AbstractValue::Make<lcmt_schunk_wsg_command>(initial_command));
   EXPECT_EQ(dut.get_position_output_port()
                 .Eval<BasicVector<double>>(*context)


### PR DESCRIPTION
This is motivated by https://github.com/RobotLocomotion/drake/issues/10149. The performance slow down in one of the anzu example is from real time factor of 1 to 0.05 by just process the LCM commands. 

To avoid the expensive UnrestrictedUpdate, this PR changes the LcmSubscriberSystem for IIWA_COMMAND and WSG_COMMAND from doing UnrestrictedUpdate and outputting AbstractValue of the actual LCM message type to updating and outputting a vectorized version of the corresponding LCM message type. 

I had to change the input port types for IiwaCommandReceiver and WsgCommandReceiver to accommodate the verctorized inputs, and I decided to keep the AbstractValue input ports as well for backward compatibility. 

cc @RussTedrake because I had to touch some of manipulation station stuff.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10158)
<!-- Reviewable:end -->
