### PR TITLE
Kinematic constraints use MultibodyPlant<double>

### DIFF
--- a/multibody/inverse_kinematics/BUILD.bazel
+++ b/multibody/inverse_kinematics/BUILD.bazel
@@ -46,7 +46,6 @@ drake_cc_library(
         "//math:geometric_transform",
         "//math:gradient",
         "//multibody/plant",
-        "//multibody/tree",
         "//solvers:constraint",
     ],
 )

--- a/multibody/inverse_kinematics/BUILD.bazel
+++ b/multibody/inverse_kinematics/BUILD.bazel
@@ -41,7 +41,6 @@ drake_cc_library(
         "orientation_constraint.h",
         "position_constraint.h",
     ],
-    visibility = ["//visibility:private"],
     deps = [
         "//math:geometric_transform",
         "//math:gradient",

--- a/multibody/inverse_kinematics/BUILD.bazel
+++ b/multibody/inverse_kinematics/BUILD.bazel
@@ -45,6 +45,7 @@ drake_cc_library(
     deps = [
         "//math:geometric_transform",
         "//math:gradient",
+        "//multibody/plant",
         "//multibody/tree",
         "//solvers:constraint",
     ],

--- a/multibody/inverse_kinematics/angle_between_vectors_constraint.cc
+++ b/multibody/inverse_kinematics/angle_between_vectors_constraint.cc
@@ -7,21 +7,19 @@ namespace drake {
 namespace multibody {
 namespace internal {
 AngleBetweenVectorsConstraint::AngleBetweenVectorsConstraint(
-    const MultibodyTree<AutoDiffXd>& tree, FrameIndex frameA_idx,
-    const Eigen::Ref<const Eigen::Vector3d>& na_A, FrameIndex frameB_idx,
-    const Eigen::Ref<const Eigen::Vector3d>& nb_B, double angle_lower,
-    double angle_upper, MultibodyTreeContext<AutoDiffXd>* context)
-    : solvers::Constraint(1, tree.num_positions(),
+    const multibody_plant::MultibodyPlant<double>& plant,
+    const Frame<double>& frameA, const Eigen::Ref<const Eigen::Vector3d>& na_A,
+    const Frame<double>& frameB, const Eigen::Ref<const Eigen::Vector3d>& nb_B,
+    double angle_lower, double angle_upper, systems::Context<double>* context)
+    : solvers::Constraint(1, plant.num_positions(),
                           Vector1d(std::cos(angle_upper)),
                           Vector1d(std::cos(angle_lower))),
-      tree_(tree),
-      frameA_(tree_.get_frame(frameA_idx)),
+      plant_(plant),
+      frameA_(frameA),
       na_unit_A_(NormalizeVector(na_A)),
-      frameB_(tree_.get_frame(frameB_idx)),
+      frameB_(frameB),
       nb_unit_B_(NormalizeVector(nb_B)),
       context_(context) {
-  // TODO(hongkai.dai): use MultibodyTree<double> and LeafContext<double> when
-  // MBT provides the API for computing analytical Jacobian.
   if (!(angle_lower >= 0 && angle_upper >= angle_lower &&
         angle_upper <= M_PI)) {
     throw std::invalid_argument(
@@ -39,11 +37,40 @@ void AngleBetweenVectorsConstraint::DoEval(
 
 void AngleBetweenVectorsConstraint::DoEval(
     const Eigen::Ref<const AutoDiffVecXd>& x, AutoDiffVecXd* y) const {
+  // The constraint function is
+  //   g(q) = na_unit_Aᵀ * R_AB(q) * nb_unit_B.
+  // To derive the Jacobian of g w.r.t. q, ∂g/∂q, we first differentiate w.r.t.
+  // time to obtain
+  //   ġ = na_unit_Aᵀ Ṙ_AB nb_unit_B,
+  // where we have dropped the dependence on q for readability. Next we expand
+  // Ṙ_AB to yield
+  //   ġ =  na_unit_Aᵀ ω̂_AB R_AB nb_unit_B,
+  // where ω̂_AB is the skew-symmetric, cross-product matrix such that
+  // ω̂_AB r = ω_AB × r ∀ r ∈ ℝ³. Applying R_AB to nb_unit_B gives the following
+  // triple product
+  //   ġ = na_unit_A ⋅ ω_AB × nb_unit_A,
+  // which can then be rearranged to yield
+  //   ġ = nb_unit_A ⋅ na_unit_A × ω_AB  (circular shift)
+  //     = nb_unit_A × na_unit_A ⋅ ω_AB  (swap operators).
+  // The angular velocity of B relative to A can be written as
+  //   ω_AB = Jq_w_AB(q) q̇,
+  // where Jq_w_AB is the Jacobian of ω_AB with respect to q̇. Therefore,
+  //   ġ = (nb_unit_A × na_unit_A)ᵀ Jq_w_AB q̇.
+  // By the chain rule, ġ = ∂g/∂q q̇. Comparing this with the previous equation,
+  // we see that
+  //   ∂g/∂q = (nb_unit_A × na_unit_A)ᵀ Jq_w_AB.
   y->resize(1);
-  UpdateContextConfiguration(x, context_);
-  (*y)(0) = na_unit_A_.dot(
-      tree_.CalcRelativeTransform(*context_, frameA_, frameB_).linear() *
-      nb_unit_B_);
+  UpdateContextConfiguration(context_, plant_, math::autoDiffToValueMatrix(x));
+  const Matrix3<double> R_AB =
+      plant_.tree().CalcRelativeTransform(*context_, frameA_, frameB_).linear();
+  Eigen::MatrixXd Jq_V_AB(6, plant_.num_positions());
+  plant_.tree().CalcJacobianSpatialVelocity(
+      *context_, JacobianWrtVariable::kQDot, frameB_,
+      Eigen::Vector3d::Zero() /* p_BQ */, frameA_, frameA_, &Jq_V_AB);
+  Eigen::Vector3d nb_unit_A = R_AB * nb_unit_B_;
+  *y = math::initializeAutoDiffGivenGradientMatrix(
+      na_unit_A_.transpose() * nb_unit_A,
+      nb_unit_A.cross(na_unit_A_).transpose() * Jq_V_AB.topRows<3>());
 }
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/inverse_kinematics/angle_between_vectors_constraint.cc
+++ b/multibody/inverse_kinematics/angle_between_vectors_constraint.cc
@@ -32,6 +32,7 @@ AngleBetweenVectorsConstraint::AngleBetweenVectorsConstraint(
 
 void AngleBetweenVectorsConstraint::DoEval(
     const Eigen::Ref<const Eigen::VectorXd>& x, Eigen::VectorXd* y) const {
+  // TODO(avalenzu): Re-work to avoid round-trip through AutoDiffXd (#10205).
   AutoDiffVecXd y_t;
   Eval(math::initializeAutoDiff(x), &y_t);
   *y = math::autoDiffToValueMatrix(y_t);
@@ -72,7 +73,8 @@ void AngleBetweenVectorsConstraint::DoEval(
   const Eigen::Vector3d nb_unit_A = R_AB * nb_unit_B_;
   *y = math::initializeAutoDiffGivenGradientMatrix(
       na_unit_A_.transpose() * nb_unit_A,
-      nb_unit_A.cross(na_unit_A_).transpose() * Jq_V_AB.topRows<3>());
+      nb_unit_A.cross(na_unit_A_).transpose() * Jq_V_AB.topRows<3>() *
+          math::autoDiffToGradientMatrix(x));
 }
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/angle_between_vectors_constraint.cc
+++ b/multibody/inverse_kinematics/angle_between_vectors_constraint.cc
@@ -4,6 +4,7 @@
 #include "drake/multibody/inverse_kinematics/kinematic_constraint_utilities.h"
 
 using drake::multibody::internal::NormalizeVector;
+using drake::multibody::internal::RefFromPtrOrThrow;
 using drake::multibody::internal::UpdateContextConfiguration;
 
 namespace drake {
@@ -13,16 +14,15 @@ AngleBetweenVectorsConstraint::AngleBetweenVectorsConstraint(
     const Frame<double>& frameA, const Eigen::Ref<const Eigen::Vector3d>& a_A,
     const Frame<double>& frameB, const Eigen::Ref<const Eigen::Vector3d>& b_B,
     double angle_lower, double angle_upper, systems::Context<double>* context)
-    : solvers::Constraint(1, plant->num_positions(),
+    : solvers::Constraint(1, RefFromPtrOrThrow(plant).num_positions(),
                           Vector1d(std::cos(angle_upper)),
                           Vector1d(std::cos(angle_lower))),
-      plant_(*plant),
+      plant_(RefFromPtrOrThrow(plant)),
       frameA_index_(frameA.index()),
       a_unit_A_(NormalizeVector(a_A)),
       frameB_index_(frameB.index()),
       b_unit_B_(NormalizeVector(b_B)),
       context_(context) {
-  DRAKE_DEMAND(plant != nullptr);
   if (!(angle_lower >= 0 && angle_upper >= angle_lower &&
         angle_upper <= M_PI)) {
     throw std::invalid_argument(

--- a/multibody/inverse_kinematics/angle_between_vectors_constraint.cc
+++ b/multibody/inverse_kinematics/angle_between_vectors_constraint.cc
@@ -9,7 +9,7 @@ using drake::multibody::internal::UpdateContextConfiguration;
 namespace drake {
 namespace multibody {
 AngleBetweenVectorsConstraint::AngleBetweenVectorsConstraint(
-    const multibody_plant::MultibodyPlant<double>* plant,
+    const multibody_plant::MultibodyPlant<double>* const plant,
     const Frame<double>& frameA, const Eigen::Ref<const Eigen::Vector3d>& a_A,
     const Frame<double>& frameB, const Eigen::Ref<const Eigen::Vector3d>& b_B,
     double angle_lower, double angle_upper, systems::Context<double>* context)
@@ -22,6 +22,7 @@ AngleBetweenVectorsConstraint::AngleBetweenVectorsConstraint(
       frameB_index_(frameB.index()),
       b_unit_B_(NormalizeVector(b_B)),
       context_(context) {
+  DRAKE_DEMAND(plant != nullptr);
   if (!(angle_lower >= 0 && angle_upper >= angle_lower &&
         angle_upper <= M_PI)) {
     throw std::invalid_argument(

--- a/multibody/inverse_kinematics/angle_between_vectors_constraint.cc
+++ b/multibody/inverse_kinematics/angle_between_vectors_constraint.cc
@@ -19,10 +19,13 @@ AngleBetweenVectorsConstraint::AngleBetweenVectorsConstraint(
                           Vector1d(std::cos(angle_lower))),
       plant_(RefFromPtrOrThrow(plant)),
       frameA_index_(frameA.index()),
-      a_unit_A_(NormalizeVector(a_A)),
       frameB_index_(frameB.index()),
+      a_unit_A_(NormalizeVector(a_A)),
       b_unit_B_(NormalizeVector(b_B)),
       context_(context) {
+  if (context == nullptr) throw std::invalid_argument("context is nullptr.");
+  frameA.HasThisParentTreeOrThrow(&plant_.tree());
+  frameB.HasThisParentTreeOrThrow(&plant_.tree());
   if (!(angle_lower >= 0 && angle_upper >= angle_lower &&
         angle_upper <= M_PI)) {
     throw std::invalid_argument(

--- a/multibody/inverse_kinematics/angle_between_vectors_constraint.h
+++ b/multibody/inverse_kinematics/angle_between_vectors_constraint.h
@@ -8,38 +8,43 @@
 namespace drake {
 namespace multibody {
 namespace internal {
-// Constrains that the angle between a vector na and another vector nb is
-// between [θ_lower, θ_upper]. na is fixed to a frame A, while nb is fixed
-// to a frame B.
-// Mathematically, if we denote na_unit_A as na expressed in frame A after
-// normalization (na_unit_A has unit length), and nb_unit_B as nb expressed in
-// frame B after normalization, the constraint is
-// cos(θ_upper) ≤ na_unit_Aᵀ * R_AB * nb_unit_B ≤ cos(θ_lower)
+/**
+ * Constrains that the angle between a vector na and another vector nb is
+ * between [θ_lower, θ_upper]. na is fixed to a frame A, while nb is fixed
+ * to a frame B.
+ * Mathematically, if we denote na_unit_A as na expressed in frame A after
+ * normalization (na_unit_A has unit length), and nb_unit_B as nb expressed in
+ * frame B after normalization, the constraint is
+ * cos(θ_upper) ≤ na_unit_Aᵀ * R_AB * nb_unit_B ≤ cos(θ_lower)
+ */
 class AngleBetweenVectorsConstraint : public solvers::Constraint {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(AngleBetweenVectorsConstraint)
 
-  // @param tree The MultibodyTree on which the constraint is imposed. @p tree
-  // should be alive during the lifetime of this constraint.
-  // @param frameA_idx The index of frame A.
-  // @param na_A The vector na_A fixed to frame A, expressed in frame A.
-  // @pre na_A should be a non-zero vector.
-  // @throws std::logic_error if na_A is close to zero.
-  // @param frameB_idx The index of frame B.
-  // @param nb_B The vector nb fixed to frame B, expressed in frameB.
-  // @pre nb_B should be a non-zero vector.
-  // @throws std::logic_error if nb_B is close to zero.
-  // @param angle_lower The lower bound on the angle between na and nb. It is
-  // denoted as θ_lower in the class documentation.
-  // @pre angle_lower >= 0.
-  // @throws std::invalid_argument error if angle_lower is negative.
-  // @param angle_upper The upper bound on the angle between na and nb. it is
-  // denoted as θ_upper in the class documentation.
-  // @pre angle_lower <= angle_upper <= pi.
-  // @throws std::invalid_argument if angle_upper is outside the bounds.
-  // @param context The Context that has been allocated for this @p tree. We
-  // will update the context when evaluating the constraint. @p context should
-  // be alive during the lifetime of this constraint.
+  /**
+   * Constructs an AngleBetweenVectorsConstraint.
+   * @param tree The MultibodyTree on which the constraint is imposed. @p tree
+   * should be alive during the lifetime of this constraint.
+   * @param frameA_idx The index of frame A.
+   * @param na_A The vector na_A fixed to frame A, expressed in frame A.
+   * @pre na_A should be a non-zero vector.
+   * @throws std::logic_error if na_A is close to zero.
+   * @param frameB_idx The index of frame B.
+   * @param nb_B The vector nb fixed to frame B, expressed in frameB.
+   * @pre nb_B should be a non-zero vector.
+   * @throws std::logic_error if nb_B is close to zero.
+   * @param angle_lower The lower bound on the angle between na and nb. It is
+   * denoted as θ_lower in the class documentation.
+   * @pre angle_lower >= 0.
+   * @throws std::invalid_argument error if angle_lower is negative.
+   * @param angle_upper The upper bound on the angle between na and nb. it is
+   * denoted as θ_upper in the class documentation.
+   * @pre angle_lower <= angle_upper <= pi.
+   * @throws std::invalid_argument if angle_upper is outside the bounds.
+   * @param context The Context that has been allocated for this @p tree. We
+   * will update the context when evaluating the constraint. @p context should
+   * be alive during the lifetime of this constraint.
+   */
   AngleBetweenVectorsConstraint(
       const multibody_plant::MultibodyPlant<double>& plant,
       const Frame<double>& frameA,

--- a/multibody/inverse_kinematics/angle_between_vectors_constraint.h
+++ b/multibody/inverse_kinematics/angle_between_vectors_constraint.h
@@ -2,7 +2,7 @@
 
 #include <memory>
 
-#include "drake/multibody/tree/multibody_tree.h"
+#include "drake/multibody/plant/multibody_plant.h"
 #include "drake/solvers/constraint.h"
 
 namespace drake {
@@ -40,13 +40,13 @@ class AngleBetweenVectorsConstraint : public solvers::Constraint {
   // @param context The Context that has been allocated for this @p tree. We
   // will update the context when evaluating the constraint. @p context should
   // be alive during the lifetime of this constraint.
-  AngleBetweenVectorsConstraint(const MultibodyTree<AutoDiffXd>& tree,
-                                FrameIndex frameA_idx,
-                                const Eigen::Ref<const Eigen::Vector3d>& na_A,
-                                FrameIndex frameB_idx,
-                                const Eigen::Ref<const Eigen::Vector3d>& nb_B,
-                                double angle_lower, double angle_upper,
-                                MultibodyTreeContext<AutoDiffXd>* context);
+  AngleBetweenVectorsConstraint(
+      const multibody_plant::MultibodyPlant<double>& plant,
+      const Frame<double>& frameA,
+      const Eigen::Ref<const Eigen::Vector3d>& na_A,
+      const Frame<double>& frameB,
+      const Eigen::Ref<const Eigen::Vector3d>& nb_B, double angle_lower,
+      double angle_upper, systems::Context<double>* context);
 
   ~AngleBetweenVectorsConstraint() override {}
 
@@ -63,12 +63,12 @@ class AngleBetweenVectorsConstraint : public solvers::Constraint {
         "AngleBetweenVectorsConstraint::DoEval() does not work for symbolic "
         "variables.");
   }
-  const MultibodyTree<AutoDiffXd>& tree_;
-  const Frame<AutoDiffXd>& frameA_;
+  const multibody_plant::MultibodyPlant<double>& plant_;
+  const Frame<double>& frameA_;
   const Eigen::Vector3d na_unit_A_;
-  const Frame<AutoDiffXd>& frameB_;
+  const Frame<double>& frameB_;
   const Eigen::Vector3d nb_unit_B_;
-  MultibodyTreeContext<AutoDiffXd>* context_;
+  systems::Context<double>* const context_;
 };
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/inverse_kinematics/angle_between_vectors_constraint.h
+++ b/multibody/inverse_kinematics/angle_between_vectors_constraint.h
@@ -36,10 +36,12 @@ class AngleBetweenVectorsConstraint : public solvers::Constraint {
    *   update the context when evaluating the constraint. `context` should be
    *   alive during the lifetime of this constraint.
    * @pre `frameA` and `frameB` must belong to `plant`.
-   * @throws std::logic_error if `a_A` is close to zero.
-   * @throws std::logic_error if `b_B` is close to zero.
-   * @throws std::logic_error if `angle_lower` is negative.
-   * @throws std::logic_error if `angle_upper` ∉ [`angle_lower`, π].
+   * @throws std::invalid_argument if `plant` is nullptr.
+   * @throws std::invalid_argument if `a_A` is close to zero.
+   * @throws std::invalid_argument if `b_B` is close to zero.
+   * @throws std::invalid_argument if `angle_lower` is negative.
+   * @throws std::invalid_argument if `angle_upper` ∉ [`angle_lower`, π].
+   * @throws std::invalid_argument if `context` is nullptr.
    */
   AngleBetweenVectorsConstraint(
       const multibody_plant::MultibodyPlant<double>* const plant,
@@ -65,8 +67,8 @@ class AngleBetweenVectorsConstraint : public solvers::Constraint {
   }
   const multibody_plant::MultibodyPlant<double>& plant_;
   const FrameIndex frameA_index_;
-  const Eigen::Vector3d a_unit_A_;
   const FrameIndex frameB_index_;
+  const Eigen::Vector3d a_unit_A_;
   const Eigen::Vector3d b_unit_B_;
   systems::Context<double>* const context_;
 };

--- a/multibody/inverse_kinematics/angle_between_vectors_constraint.h
+++ b/multibody/inverse_kinematics/angle_between_vectors_constraint.h
@@ -7,7 +7,6 @@
 
 namespace drake {
 namespace multibody {
-namespace internal {
 /**
  * Constrains that the angle between a vector na and another vector nb is
  * between [θ_lower, θ_upper]. na is fixed to a frame A, while nb is fixed
@@ -23,27 +22,27 @@ class AngleBetweenVectorsConstraint : public solvers::Constraint {
 
   /**
    * Constructs an AngleBetweenVectorsConstraint.
-   * @param tree The MultibodyTree on which the constraint is imposed. @p tree
-   * should be alive during the lifetime of this constraint.
-   * @param frameA_idx The index of frame A.
+   * @param plant The MultibodyPlant on which the constraint is imposed.
+   *   @p plant should be alive during the lifetime of this constraint.
+   * @param frameA The Frame object for frame A.
    * @param na_A The vector na_A fixed to frame A, expressed in frame A.
-   * @pre na_A should be a non-zero vector.
-   * @throws std::logic_error if na_A is close to zero.
-   * @param frameB_idx The index of frame B.
+   * @param frameB The Frame object for frame B.
    * @param nb_B The vector nb fixed to frame B, expressed in frameB.
-   * @pre nb_B should be a non-zero vector.
-   * @throws std::logic_error if nb_B is close to zero.
    * @param angle_lower The lower bound on the angle between na and nb. It is
-   * denoted as θ_lower in the class documentation.
-   * @pre angle_lower >= 0.
-   * @throws std::invalid_argument error if angle_lower is negative.
+   *   denoted as θ_lower in the class documentation.
    * @param angle_upper The upper bound on the angle between na and nb. it is
-   * denoted as θ_upper in the class documentation.
+   *   denoted as θ_upper in the class documentation.
+   * @param context The Context that has been allocated for this @p plant. We
+   *   will update the context when evaluating the constraint. @p context should
+   *   be alive during the lifetime of this constraint.
+   * @pre na_A should be a non-zero vector.
+   * @pre nb_B should be a non-zero vector.
+   * @pre angle_lower >= 0.
    * @pre angle_lower <= angle_upper <= pi.
+   * @throws std::logic_error if na_A is close to zero.
+   * @throws std::logic_error if nb_B is close to zero.
+   * @throws std::invalid_argument error if angle_lower is negative.
    * @throws std::invalid_argument if angle_upper is outside the bounds.
-   * @param context The Context that has been allocated for this @p tree. We
-   * will update the context when evaluating the constraint. @p context should
-   * be alive during the lifetime of this constraint.
    */
   AngleBetweenVectorsConstraint(
       const multibody_plant::MultibodyPlant<double>& plant,
@@ -75,6 +74,5 @@ class AngleBetweenVectorsConstraint : public solvers::Constraint {
   const Eigen::Vector3d nb_unit_B_;
   systems::Context<double>* const context_;
 };
-}  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/angle_between_vectors_constraint.h
+++ b/multibody/inverse_kinematics/angle_between_vectors_constraint.h
@@ -33,12 +33,12 @@ class AngleBetweenVectorsConstraint : public solvers::Constraint {
      update the context when evaluating the constraint. `context` should be
      alive during the lifetime of this constraint.
    @pre `frameA` and `frameB` must belong to `plant`.
-   @throws std::invalid_argument if `a_A` is close to zero.
-   @throws std::invalid_argument if `b_B` is close to zero.
-   @throws std::invalid_argument error if `angle_lower` is negative.
-   @throws std::invalid_argument if `angle_upper` ∉ [`angle_lower`, π].*/
+   @throws std::logic_error if `a_A` is close to zero.
+   @throws std::logic_error if `b_B` is close to zero.
+   @throws std::logic_error if `angle_lower` is negative.
+   @throws std::logic_error if `angle_upper` ∉ [`angle_lower`, π].*/
   AngleBetweenVectorsConstraint(
-      const multibody_plant::MultibodyPlant<double>* plant,
+      const multibody_plant::MultibodyPlant<double>* const plant,
       const Frame<double>& frameA, const Eigen::Ref<const Eigen::Vector3d>& a_A,
       const Frame<double>& frameB, const Eigen::Ref<const Eigen::Vector3d>& b_B,
       double angle_lower, double angle_upper,

--- a/multibody/inverse_kinematics/angle_between_vectors_constraint.h
+++ b/multibody/inverse_kinematics/angle_between_vectors_constraint.h
@@ -7,50 +7,42 @@
 
 namespace drake {
 namespace multibody {
-/**
- * Constrains that the angle between a vector na and another vector nb is
- * between [θ_lower, θ_upper]. na is fixed to a frame A, while nb is fixed
- * to a frame B.
- * Mathematically, if we denote na_unit_A as na expressed in frame A after
- * normalization (na_unit_A has unit length), and nb_unit_B as nb expressed in
- * frame B after normalization, the constraint is
- * cos(θ_upper) ≤ na_unit_Aᵀ * R_AB * nb_unit_B ≤ cos(θ_lower)
- */
+/** Constrains that the angle between a vector `a` and another vector `b` is
+ between [θ_lower, θ_upper]. `a` is fixed to a frame A, while `b` is fixed
+ to a frame B.
+ Mathematically, if we denote a_unit_A as `a` expressed in frame A after
+ normalization (a_unit_A has unit length), and b_unit_B as `b` expressed in
+ frame B after normalization, the constraint is
+ cos(θ_upper) ≤ a_unit_Aᵀ * R_AB * b_unit_B ≤ cos(θ_lower) */
 class AngleBetweenVectorsConstraint : public solvers::Constraint {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(AngleBetweenVectorsConstraint)
 
-  /**
-   * Constructs an AngleBetweenVectorsConstraint.
-   * @param plant The MultibodyPlant on which the constraint is imposed.
-   *   @p plant should be alive during the lifetime of this constraint.
-   * @param frameA The Frame object for frame A.
-   * @param na_A The vector na_A fixed to frame A, expressed in frame A.
-   * @param frameB The Frame object for frame B.
-   * @param nb_B The vector nb fixed to frame B, expressed in frameB.
-   * @param angle_lower The lower bound on the angle between na and nb. It is
-   *   denoted as θ_lower in the class documentation.
-   * @param angle_upper The upper bound on the angle between na and nb. it is
-   *   denoted as θ_upper in the class documentation.
-   * @param context The Context that has been allocated for this @p plant. We
-   *   will update the context when evaluating the constraint. @p context should
-   *   be alive during the lifetime of this constraint.
-   * @pre na_A should be a non-zero vector.
-   * @pre nb_B should be a non-zero vector.
-   * @pre angle_lower >= 0.
-   * @pre angle_lower <= angle_upper <= pi.
-   * @throws std::logic_error if na_A is close to zero.
-   * @throws std::logic_error if nb_B is close to zero.
-   * @throws std::invalid_argument error if angle_lower is negative.
-   * @throws std::invalid_argument if angle_upper is outside the bounds.
-   */
+  /** Constructs an AngleBetweenVectorsConstraint.
+   @param plant The MultibodyPlant on which the constraint is imposed. `plant`
+     should be alive during the lifetime of this constraint.
+   @param frameA The Frame object for frame A.
+   @param a_A The vector `a` fixed to frame A, expressed in frame A.
+   @param frameB The Frame object for frame B.
+   @param b_B The vector `b` fixed to frame B, expressed in frameB.
+   @param angle_lower The lower bound on the angle between `a` and `b`. It is
+     denoted as θ_lower in the class documentation.
+   @param angle_upper The upper bound on the angle between `a` and `b`. it is
+     denoted as θ_upper in the class documentation.
+   @param context The Context that has been allocated for this `plant`. We will
+     update the context when evaluating the constraint. `context` should be
+     alive during the lifetime of this constraint.
+   @pre `frameA` and `frameB` must belong to `plant`.
+   @throws std::invalid_argument if `a_A` is close to zero.
+   @throws std::invalid_argument if `b_B` is close to zero.
+   @throws std::invalid_argument error if `angle_lower` is negative.
+   @throws std::invalid_argument if `angle_upper` ∉ [`angle_lower`, π].*/
   AngleBetweenVectorsConstraint(
-      const multibody_plant::MultibodyPlant<double>& plant,
-      const Frame<double>& frameA,
-      const Eigen::Ref<const Eigen::Vector3d>& na_A,
-      const Frame<double>& frameB,
-      const Eigen::Ref<const Eigen::Vector3d>& nb_B, double angle_lower,
-      double angle_upper, systems::Context<double>* context);
+      const multibody_plant::MultibodyPlant<double>* plant,
+      const Frame<double>& frameA, const Eigen::Ref<const Eigen::Vector3d>& a_A,
+      const Frame<double>& frameB, const Eigen::Ref<const Eigen::Vector3d>& b_B,
+      double angle_lower, double angle_upper,
+      systems::Context<double>* context);
 
   ~AngleBetweenVectorsConstraint() override {}
 
@@ -68,10 +60,10 @@ class AngleBetweenVectorsConstraint : public solvers::Constraint {
         "variables.");
   }
   const multibody_plant::MultibodyPlant<double>& plant_;
-  const Frame<double>& frameA_;
-  const Eigen::Vector3d na_unit_A_;
-  const Frame<double>& frameB_;
-  const Eigen::Vector3d nb_unit_B_;
+  const FrameIndex frameA_index_;
+  const Eigen::Vector3d a_unit_A_;
+  const FrameIndex frameB_index_;
+  const Eigen::Vector3d b_unit_B_;
   systems::Context<double>* const context_;
 };
 }  // namespace multibody

--- a/multibody/inverse_kinematics/angle_between_vectors_constraint.h
+++ b/multibody/inverse_kinematics/angle_between_vectors_constraint.h
@@ -7,36 +7,40 @@
 
 namespace drake {
 namespace multibody {
-/** Constrains that the angle between a vector `a` and another vector `b` is
- between [θ_lower, θ_upper]. `a` is fixed to a frame A, while `b` is fixed
- to a frame B.
- Mathematically, if we denote a_unit_A as `a` expressed in frame A after
- normalization (a_unit_A has unit length), and b_unit_B as `b` expressed in
- frame B after normalization, the constraint is
- cos(θ_upper) ≤ a_unit_Aᵀ * R_AB * b_unit_B ≤ cos(θ_lower) */
+/**
+ * Constrains that the angle between a vector `a` and another vector `b` is
+ * between [θ_lower, θ_upper]. `a` is fixed to a frame A, while `b` is fixed to
+ * a frame B.
+ * Mathematically, if we denote a_unit_A as `a` expressed in frame A after
+ * normalization (a_unit_A has unit length), and b_unit_B as `b` expressed in
+ * frame B after normalization, the constraint is
+ *   cos(θ_upper) ≤ a_unit_Aᵀ * R_AB * b_unit_B ≤ cos(θ_lower)
+ */
 class AngleBetweenVectorsConstraint : public solvers::Constraint {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(AngleBetweenVectorsConstraint)
 
-  /** Constructs an AngleBetweenVectorsConstraint.
-   @param plant The MultibodyPlant on which the constraint is imposed. `plant`
-     should be alive during the lifetime of this constraint.
-   @param frameA The Frame object for frame A.
-   @param a_A The vector `a` fixed to frame A, expressed in frame A.
-   @param frameB The Frame object for frame B.
-   @param b_B The vector `b` fixed to frame B, expressed in frameB.
-   @param angle_lower The lower bound on the angle between `a` and `b`. It is
-     denoted as θ_lower in the class documentation.
-   @param angle_upper The upper bound on the angle between `a` and `b`. it is
-     denoted as θ_upper in the class documentation.
-   @param context The Context that has been allocated for this `plant`. We will
-     update the context when evaluating the constraint. `context` should be
-     alive during the lifetime of this constraint.
-   @pre `frameA` and `frameB` must belong to `plant`.
-   @throws std::logic_error if `a_A` is close to zero.
-   @throws std::logic_error if `b_B` is close to zero.
-   @throws std::logic_error if `angle_lower` is negative.
-   @throws std::logic_error if `angle_upper` ∉ [`angle_lower`, π].*/
+  /**
+   * Constructs an AngleBetweenVectorsConstraint.
+   * @param plant The MultibodyPlant on which the constraint is imposed. `plant`
+   *   should be alive during the lifetime of this constraint.
+   * @param frameA The Frame object for frame A.
+   * @param a_A The vector `a` fixed to frame A, expressed in frame A.
+   * @param frameB The Frame object for frame B.
+   * @param b_B The vector `b` fixed to frame B, expressed in frameB.
+   * @param angle_lower The lower bound on the angle between `a` and `b`. It is
+   *   denoted as θ_lower in the class documentation.
+   * @param angle_upper The upper bound on the angle between `a` and `b`. it is
+   *   denoted as θ_upper in the class documentation.
+   * @param context The Context that has been allocated for this `plant`. We will
+   *   update the context when evaluating the constraint. `context` should be
+   *   alive during the lifetime of this constraint.
+   * @pre `frameA` and `frameB` must belong to `plant`.
+   * @throws std::logic_error if `a_A` is close to zero.
+   * @throws std::logic_error if `b_B` is close to zero.
+   * @throws std::logic_error if `angle_lower` is negative.
+   * @throws std::logic_error if `angle_upper` ∉ [`angle_lower`, π].
+   */
   AngleBetweenVectorsConstraint(
       const multibody_plant::MultibodyPlant<double>* const plant,
       const Frame<double>& frameA, const Eigen::Ref<const Eigen::Vector3d>& a_A,

--- a/multibody/inverse_kinematics/angle_between_vectors_constraint.h
+++ b/multibody/inverse_kinematics/angle_between_vectors_constraint.h
@@ -32,9 +32,9 @@ class AngleBetweenVectorsConstraint : public solvers::Constraint {
    *   denoted as θ_lower in the class documentation.
    * @param angle_upper The upper bound on the angle between `a` and `b`. it is
    *   denoted as θ_upper in the class documentation.
-   * @param context The Context that has been allocated for this `plant`. We will
-   *   update the context when evaluating the constraint. `context` should be
-   *   alive during the lifetime of this constraint.
+   * @param context The Context that has been allocated for this `plant`. We
+   *   will update the context when evaluating the constraint. `context` should
+   *   be alive during the lifetime of this constraint.
    * @pre `frameA` and `frameB` must belong to `plant`.
    * @throws std::invalid_argument if `plant` is nullptr.
    * @throws std::invalid_argument if `a_A` is close to zero.

--- a/multibody/inverse_kinematics/gaze_target_constraint.cc
+++ b/multibody/inverse_kinematics/gaze_target_constraint.cc
@@ -36,6 +36,7 @@ GazeTargetConstraint::GazeTargetConstraint(
 
 void GazeTargetConstraint::DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
                                   Eigen::VectorXd* y) const {
+  // TODO(avalenzu): Re-work to avoid round-trip through AutoDiffXd (#10205).
   AutoDiffVecXd y_t;
   Eval(math::initializeAutoDiff(x), &y_t);
   *y = math::autoDiffToValueMatrix(y_t);

--- a/multibody/inverse_kinematics/gaze_target_constraint.cc
+++ b/multibody/inverse_kinematics/gaze_target_constraint.cc
@@ -21,14 +21,17 @@ GazeTargetConstraint::GazeTargetConstraint(
           2, RefFromPtrOrThrow(plant).num_positions(), Eigen::Vector2d::Zero(),
           Eigen::Vector2d::Constant(std::numeric_limits<double>::infinity())),
       plant_{RefFromPtrOrThrow(plant)},
-      frameA_{frameA},
+      frameA_index_{frameA.index()},
+      frameB_index_{frameB.index()},
       p_AS_{p_AS},
       n_A_{NormalizeVector(n_A)},
-      frameB_{frameB},
       p_BT_{p_BT},
       cone_half_angle_{cone_half_angle},
       cos_cone_half_angle_{std::cos(cone_half_angle_)},
       context_{context} {
+  if (context == nullptr) throw std::invalid_argument("context is nullptr.");
+  frameA.HasThisParentTreeOrThrow(&plant_.tree());
+  frameB.HasThisParentTreeOrThrow(&plant_.tree());
   if (cone_half_angle < 0 || cone_half_angle > M_PI) {
     throw std::invalid_argument(
         "GazeTargetConstraint: cone_half_angle should be within [0, pi]");
@@ -46,20 +49,22 @@ void GazeTargetConstraint::DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
 void GazeTargetConstraint::DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
                                   AutoDiffVecXd* y) const {
   // The constraint values are
-  //   g(q)  = ⎡ p_ST_A(q) · n_unit_A                                 ⎤
-  //           ⎣(p_ST_A(q) · n_unit_A)² - (cosθ)²p_ST_A(q) · p_ST_A(q)⎦
-  // The partial derivative of g, ∂g/∂q, is therefore given by
+  //   g(q)  = ⎡ p · n_unit_A                                 ⎤
+  //           ⎣(p · n_unit_A)² - (cosθ)²p · p⎦
+  // where p is an abbreviation for p_ST_A(q). The partial derivative of g,
+  // ∂g/∂q, is therefore given by
   //   ∂g/∂q = ⎡n_unit_Aᵀ                               ⎤ ∂p/∂q,
   //           ⎣2 [(p · n_unit_A) n_unit_A -  (cosθ)²p]ᵀ⎦
-  // where p is an abbreviation for p_ST_A(q).
   UpdateContextConfiguration(context_, plant_, math::autoDiffToValueMatrix(x));
+  const Frame<double>& frameA = plant_.get_frame(frameA_index_);
+  const Frame<double>& frameB = plant_.get_frame(frameB_index_);
   // Position of target point T measured and expressed in A frame.
   Vector3<double> p_AT;
-  plant_.tree().CalcPointsPositions(*context_, frameB_, p_BT_, frameA_, &p_AT);
+  plant_.tree().CalcPointsPositions(*context_, frameB, p_BT_, frameA, &p_AT);
   Eigen::MatrixXd Jq_V_ABt(6, plant_.num_positions());
   plant_.tree().CalcJacobianSpatialVelocity(*context_,
-                                            JacobianWrtVariable::kQDot, frameB_,
-                                            p_BT_, frameA_, frameA_, &Jq_V_ABt);
+                                            JacobianWrtVariable::kQDot, frameB,
+                                            p_BT_, frameA, frameA, &Jq_V_ABt);
   // Jq_p = Jq_v_ABt = ∂p/∂q.
   const Matrix3X<double> Jq_p = Jq_V_ABt.bottomRows<3>();
   const Vector3<double> p_ST_A = p_AT - p_AS_;

--- a/multibody/inverse_kinematics/gaze_target_constraint.cc
+++ b/multibody/inverse_kinematics/gaze_target_constraint.cc
@@ -53,9 +53,9 @@ void GazeTargetConstraint::DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
   Vector3<double> p_AT;
   plant_.tree().CalcPointsPositions(*context_, frameB_, p_BT_, frameA_, &p_AT);
   Eigen::MatrixXd Jq_V_ABt(6, plant_.num_positions());
-  plant_.tree().CalcJacobianSpatialVelocity(
-      *context_, JacobianWrtVariable::kQDot, frameB_, p_BT_, frameA_, frameA_,
-      &Jq_V_ABt);
+  plant_.tree().CalcJacobianSpatialVelocity(*context_,
+                                            JacobianWrtVariable::kQDot, frameB_,
+                                            p_BT_, frameA_, frameA_, &Jq_V_ABt);
   // J_p_q = Jq_v_ABt = ∂p/∂q.
   const Matrix3X<double> Jq_p = Jq_V_ABt.bottomRows<3>();
   const Vector3<double> p_ST_A = p_AT - p_AS_;

--- a/multibody/inverse_kinematics/gaze_target_constraint.cc
+++ b/multibody/inverse_kinematics/gaze_target_constraint.cc
@@ -5,21 +5,22 @@
 #include "drake/math/autodiff_gradient.h"
 #include "drake/multibody/inverse_kinematics/kinematic_constraint_utilities.h"
 
-using drake::multibody::internal::UpdateContextConfiguration;
 using drake::multibody::internal::NormalizeVector;
+using drake::multibody::internal::RefFromPtrOrThrow;
+using drake::multibody::internal::UpdateContextConfiguration;
 
 namespace drake {
 namespace multibody {
 GazeTargetConstraint::GazeTargetConstraint(
-    const multibody_plant::MultibodyPlant<double>& plant,
+    const multibody_plant::MultibodyPlant<double>* const plant,
     const Frame<double>& frameA, const Eigen::Ref<const Eigen::Vector3d>& p_AS,
     const Eigen::Ref<const Eigen::Vector3d>& n_A, const Frame<double>& frameB,
     const Eigen::Ref<const Eigen::Vector3d>& p_BT, double cone_half_angle,
     systems::Context<double>* context)
     : solvers::Constraint(
-          2, plant.num_positions(), Eigen::Vector2d::Zero(),
+          2, RefFromPtrOrThrow(plant).num_positions(), Eigen::Vector2d::Zero(),
           Eigen::Vector2d::Constant(std::numeric_limits<double>::infinity())),
-      plant_{plant},
+      plant_{RefFromPtrOrThrow(plant)},
       frameA_{frameA},
       p_AS_{p_AS},
       n_A_{NormalizeVector(n_A)},

--- a/multibody/inverse_kinematics/gaze_target_constraint.h
+++ b/multibody/inverse_kinematics/gaze_target_constraint.h
@@ -8,42 +8,46 @@
 namespace drake {
 namespace multibody {
 namespace internal {
-// Constrains a target point T to be within a cone K. The point T ("T" stands
-// for "target") is fixed in a frame B, with position p_BT. The cone
-// originates from a point S ("S" stands for "source"), fixed in frame A with
-// position p_AS, with the axis of the cone being n, also fixed
-// in frame A. The half angle of the cone is θ. A common usage of this
-// constraint is that a camera should gaze at some target; namely the target
-// falls within a gaze cone, originating from the camera eye.
-//
-// Mathematically the constraint is
-// p_ST_Aᵀ * n_unit_A ≥ 0
-// (p_ST_Aᵀ * n_unit_A)² ≥ (cosθ)²p_ST_Aᵀ * p_ST_A
-// where p_ST_A is the vector from S to T, expressed in frame A. n_unit_A is the
-// unit length directional vector representing the center ray of the cone.
+/**
+ * Constrains a target point T to be within a cone K. The point T ("T" stands
+ * for "target") is fixed in a frame B, with position p_BT. The cone
+ * originates from a point S ("S" stands for "source"), fixed in frame A with
+ * position p_AS, with the axis of the cone being n, also fixed
+ * in frame A. The half angle of the cone is θ. A common usage of this
+ * constraint is that a camera should gaze at some target; namely the target
+ * falls within a gaze cone, originating from the camera eye.
+ *
+ * Mathematically the constraint is
+ *    p_ST_Aᵀ * n_unit_A   ≥ 0
+ *   (p_ST_Aᵀ * n_unit_A)² ≥ (cosθ)²p_ST_Aᵀ * p_ST_A
+ * where p_ST_A is the vector from S to T, expressed in frame A. n_unit_A is the
+ * unit length directional vector representing the center ray of the cone.
+ */
 class GazeTargetConstraint : public solvers::Constraint {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(GazeTargetConstraint)
 
-  // @param tree The MultibodyTree on which the constraint is imposed. @p tree
-  // should be alive during the lifetime of this constraint.
-  // @param frameA_idx The frame where the gaze cone is fixed to.
-  // @param p_AS The position of the cone source point S, measured and expressed
-  // in frame A.
-  // @param n_A The directional vector representing the center ray of the cone,
-  // expressed in frame A.
-  // @pre @p n_A cannot be a zero vector.
-  // @throws std::invalid_argument is n_A is close to a zero vector.
-  // @param frameB_idx The frame where the target point T is fixed to.
-  // @param p_BT The position of the target point T, measured and expressed in
-  // frame B.
-  // @param cone_half_angle The half angle of the cone. We denote it as θ in the
-  // class documentation. @p cone_half_angle is in radians.
-  // @pre @p 0 <= cone_half_angle <= pi.
-  // @throws std::invalid_argument if cone_half_angle is outside of the bound.
-  // @param context The Context that has been allocated for this @p tree. We
-  // will update the context when evaluating the constraint. @p context should
-  // be alive during the lifetime of this constraint.
+  /**
+   * @param tree The MultibodyTree on which the constraint is imposed. @p tree
+   *   should be alive during the lifetime of this constraint.
+   * @param frameA_idx The frame where the gaze cone is fixed to.
+   * @param p_AS The position of the cone source point S, measured and expressed
+   *   in frame A.
+   * @param n_A The directional vector representing the center ray of the cone,
+   *   expressed in frame A.
+   * @pre @p n_A cannot be a zero vector.
+   * @throws std::invalid_argument is n_A is close to a zero vector.
+   * @param frameB_idx The frame where the target point T is fixed to.
+   * @param p_BT The position of the target point T, measured and expressed in
+   *   frame B.
+   * @param cone_half_angle The half angle of the cone. We denote it as θ in the
+   *   class documentation. @p cone_half_angle is in radians.
+   * @pre @p 0 <= cone_half_angle <= pi.
+   * @throws std::invalid_argument if cone_half_angle is outside of the bound.
+   * @param context The Context that has been allocated for this @p tree. We
+   *   will update the context when evaluating the constraint. @p context should
+   *   be alive during the lifetime of this constraint.
+   */
   GazeTargetConstraint(const multibody_plant::MultibodyPlant<double>& plant,
                        const Frame<double>& frameA,
                        const Eigen::Ref<const Eigen::Vector3d>& p_AS,

--- a/multibody/inverse_kinematics/gaze_target_constraint.h
+++ b/multibody/inverse_kinematics/gaze_target_constraint.h
@@ -17,7 +17,7 @@ namespace multibody {
  * falls within a gaze cone, originating from the camera eye.
  *
  * Mathematically the constraint is
- *    p_ST_Aᵀ * n_unit_A   ≥ 0
+ *      p_ST_Aᵀ * n_unit_A ≥ 0
  *   (p_ST_Aᵀ * n_unit_A)² ≥ (cosθ)²p_ST_Aᵀ * p_ST_A
  * where p_ST_A is the vector from S to T, expressed in frame A. n_unit_A is the
  * unit length directional vector representing the center ray of the cone.
@@ -28,7 +28,7 @@ class GazeTargetConstraint : public solvers::Constraint {
 
   /**
    * @param plant The MultibodyPlant on which the constraint is imposed.
-   *   @p plant should be alive during the lifetime of this constraint.
+   *   `plant` should be alive during the lifetime of this constraint.
    * @param frameA The frame to which the gaze cone is fixed.
    * @param p_AS The position of the cone source point S, measured and expressed
    *   in frame A.
@@ -38,14 +38,15 @@ class GazeTargetConstraint : public solvers::Constraint {
    * @param p_BT The position of the target point T, measured and expressed in
    *   frame B.
    * @param cone_half_angle The half angle of the cone. We denote it as θ in the
-   *   class documentation. @p cone_half_angle is in radians.
-   * @param context The Context that has been allocated for this @p plant. We
-   *   will update the context when evaluating the constraint. @p context should
+   *   class documentation. `cone_half_angle` is in radians.
+   * @param context The Context that has been allocated for this `plant`. We
+   *   will update the context when evaluating the constraint. `context` should
    *   be alive during the lifetime of this constraint.
-   * @pre @p n_A cannot be a zero vector.
-   * @pre @p 0 <= cone_half_angle <= pi.
-   * @throws std::invalid_argument is n_A is close to a zero vector.
-   * @throws std::invalid_argument if cone_half_angle is outside of the bound.
+   * @pre `frameA` and `frameB` must belong to `plant`.
+   * @throws std::invalid_argument if `plant` is nullptr.
+   * @throws std::invalid_argument if `n_A` is close to zero.
+   * @throws std::invalid_argument if `cone_half_angle` ∉ [0, π].
+   * @throws std::invalid_argument if `context` is nullptr.
    */
   GazeTargetConstraint(
       const multibody_plant::MultibodyPlant<double>* const plant,
@@ -70,10 +71,10 @@ class GazeTargetConstraint : public solvers::Constraint {
         "GazeTargetConstraint::DoEval() does not work for symbolic variables.");
   }
   const multibody_plant::MultibodyPlant<double>& plant_;
-  const Frame<double>& frameA_;
+  const FrameIndex frameA_index_;
+  const FrameIndex frameB_index_;
   const Eigen::Vector3d p_AS_;
   const Eigen::Vector3d n_A_;
-  const Frame<double>& frameB_;
   const Eigen::Vector3d p_BT_;
   const double cone_half_angle_;
   const double cos_cone_half_angle_;

--- a/multibody/inverse_kinematics/gaze_target_constraint.h
+++ b/multibody/inverse_kinematics/gaze_target_constraint.h
@@ -47,14 +47,13 @@ class GazeTargetConstraint : public solvers::Constraint {
    * @throws std::invalid_argument is n_A is close to a zero vector.
    * @throws std::invalid_argument if cone_half_angle is outside of the bound.
    */
-  GazeTargetConstraint(const multibody_plant::MultibodyPlant<double>& plant,
-                       const Frame<double>& frameA,
-                       const Eigen::Ref<const Eigen::Vector3d>& p_AS,
-                       const Eigen::Ref<const Eigen::Vector3d>& n_A,
-                       const Frame<double>& frameB,
-                       const Eigen::Ref<const Eigen::Vector3d>& p_BT,
-                       double cone_half_angle,
-                       systems::Context<double>* context);
+  GazeTargetConstraint(
+      const multibody_plant::MultibodyPlant<double>* const plant,
+      const Frame<double>& frameA,
+      const Eigen::Ref<const Eigen::Vector3d>& p_AS,
+      const Eigen::Ref<const Eigen::Vector3d>& n_A, const Frame<double>& frameB,
+      const Eigen::Ref<const Eigen::Vector3d>& p_BT, double cone_half_angle,
+      systems::Context<double>* context);
 
   ~GazeTargetConstraint() override{};
 

--- a/multibody/inverse_kinematics/gaze_target_constraint.h
+++ b/multibody/inverse_kinematics/gaze_target_constraint.h
@@ -7,7 +7,6 @@
 
 namespace drake {
 namespace multibody {
-namespace internal {
 /**
  * Constrains a target point T to be within a cone K. The point T ("T" stands
  * for "target") is fixed in a frame B, with position p_BT. The cone
@@ -28,25 +27,25 @@ class GazeTargetConstraint : public solvers::Constraint {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(GazeTargetConstraint)
 
   /**
-   * @param tree The MultibodyTree on which the constraint is imposed. @p tree
-   *   should be alive during the lifetime of this constraint.
-   * @param frameA_idx The frame where the gaze cone is fixed to.
+   * @param plant The MultibodyPlant on which the constraint is imposed.
+   *   @p plant should be alive during the lifetime of this constraint.
+   * @param frameA The frame to which the gaze cone is fixed.
    * @param p_AS The position of the cone source point S, measured and expressed
    *   in frame A.
    * @param n_A The directional vector representing the center ray of the cone,
    *   expressed in frame A.
-   * @pre @p n_A cannot be a zero vector.
-   * @throws std::invalid_argument is n_A is close to a zero vector.
-   * @param frameB_idx The frame where the target point T is fixed to.
+   * @param frameB The frame to which the target point T is fixed.
    * @param p_BT The position of the target point T, measured and expressed in
    *   frame B.
    * @param cone_half_angle The half angle of the cone. We denote it as θ in the
    *   class documentation. @p cone_half_angle is in radians.
-   * @pre @p 0 <= cone_half_angle <= pi.
-   * @throws std::invalid_argument if cone_half_angle is outside of the bound.
-   * @param context The Context that has been allocated for this @p tree. We
+   * @param context The Context that has been allocated for this @p plant. We
    *   will update the context when evaluating the constraint. @p context should
    *   be alive during the lifetime of this constraint.
+   * @pre @p n_A cannot be a zero vector.
+   * @pre @p 0 <= cone_half_angle <= pi.
+   * @throws std::invalid_argument is n_A is close to a zero vector.
+   * @throws std::invalid_argument if cone_half_angle is outside of the bound.
    */
   GazeTargetConstraint(const multibody_plant::MultibodyPlant<double>& plant,
                        const Frame<double>& frameA,
@@ -81,6 +80,5 @@ class GazeTargetConstraint : public solvers::Constraint {
   const double cos_cone_half_angle_;
   systems::Context<double>* const context_;
 };
-}  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/gaze_target_constraint.h
+++ b/multibody/inverse_kinematics/gaze_target_constraint.h
@@ -2,7 +2,7 @@
 
 #include <memory>
 
-#include "drake/multibody/tree/multibody_tree.h"
+#include "drake/multibody/plant/multibody_plant.h"
 #include "drake/solvers/constraint.h"
 
 namespace drake {
@@ -44,14 +44,14 @@ class GazeTargetConstraint : public solvers::Constraint {
   // @param context The Context that has been allocated for this @p tree. We
   // will update the context when evaluating the constraint. @p context should
   // be alive during the lifetime of this constraint.
-  GazeTargetConstraint(const MultibodyTree<AutoDiffXd>& tree,
-                       const FrameIndex& frameA_idx,
+  GazeTargetConstraint(const multibody_plant::MultibodyPlant<double>& plant,
+                       const Frame<double>& frameA,
                        const Eigen::Ref<const Eigen::Vector3d>& p_AS,
                        const Eigen::Ref<const Eigen::Vector3d>& n_A,
-                       const FrameIndex& frameB_idx,
+                       const Frame<double>& frameB,
                        const Eigen::Ref<const Eigen::Vector3d>& p_BT,
                        double cone_half_angle,
-                       MultibodyTreeContext<AutoDiffXd>* context);
+                       systems::Context<double>* context);
 
   ~GazeTargetConstraint() override{};
 
@@ -67,15 +67,15 @@ class GazeTargetConstraint : public solvers::Constraint {
     throw std::logic_error(
         "GazeTargetConstraint::DoEval() does not work for symbolic variables.");
   }
-  const MultibodyTree<AutoDiffXd>& tree_;
-  const Frame<AutoDiffXd>& frameA_;
+  const multibody_plant::MultibodyPlant<double>& plant_;
+  const Frame<double>& frameA_;
   const Eigen::Vector3d p_AS_;
   const Eigen::Vector3d n_A_;
-  const Frame<AutoDiffXd>& frameB_;
-  const Vector3<AutoDiffXd> p_BT_;
+  const Frame<double>& frameB_;
+  const Eigen::Vector3d p_BT_;
   const double cone_half_angle_;
   const double cos_cone_half_angle_;
-  MultibodyTreeContext<AutoDiffXd>* const context_;
+  systems::Context<double>* const context_;
 };
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/inverse_kinematics/inverse_kinematics.cc
+++ b/multibody/inverse_kinematics/inverse_kinematics.cc
@@ -42,7 +42,7 @@ solvers::Binding<solvers::Constraint> InverseKinematics::AddPositionConstraint(
     const Eigen::Ref<const Eigen::Vector3d>& p_AQ_lower,
     const Eigen::Ref<const Eigen::Vector3d>& p_AQ_upper) {
   auto constraint = std::make_shared<PositionConstraint>(
-      plant_, frameB, p_BQ, frameA, p_AQ_lower, p_AQ_upper,
+      &plant_, frameB, p_BQ, frameA, p_AQ_lower, p_AQ_upper,
       get_mutable_context());
   return prog_->AddConstraint(constraint, q_);
 }
@@ -53,7 +53,7 @@ InverseKinematics::AddOrientationConstraint(
     const Frame<double>& frameBbar, const math::RotationMatrix<double>& R_BbarB,
     double angle_bound) {
   auto constraint = std::make_shared<OrientationConstraint>(
-      plant_, frameAbar, R_AbarA, frameBbar, R_BbarB, angle_bound,
+      &plant_, frameAbar, R_AbarA, frameBbar, R_BbarB, angle_bound,
       get_mutable_context());
   return prog_->AddConstraint(constraint, q_);
 }
@@ -64,7 +64,7 @@ InverseKinematics::AddGazeTargetConstraint(
     const Eigen::Ref<const Eigen::Vector3d>& n_A, const Frame<double>& frameB,
     const Eigen::Ref<const Eigen::Vector3d>& p_BT, double cone_half_angle) {
   auto constraint = std::make_shared<GazeTargetConstraint>(
-      plant_, frameA, p_AS, n_A, frameB, p_BT, cone_half_angle,
+      &plant_, frameA, p_AS, n_A, frameB, p_BT, cone_half_angle,
       get_mutable_context());
   return prog_->AddConstraint(constraint, q_);
 }

--- a/multibody/inverse_kinematics/inverse_kinematics.cc
+++ b/multibody/inverse_kinematics/inverse_kinematics.cc
@@ -66,8 +66,8 @@ InverseKinematics::AddGazeTargetConstraint(
     const Eigen::Ref<const Eigen::Vector3d>& n_A, const Frame<double>& frameB,
     const Eigen::Ref<const Eigen::Vector3d>& p_BT, double cone_half_angle) {
   auto constraint = std::make_shared<internal::GazeTargetConstraint>(
-      system_.tree(), frameA.index(), p_AS, n_A, frameB.index(), p_BT,
-      cone_half_angle, get_mutable_context_autodiff());
+      plant_, frameA, p_AS, n_A, frameB, p_BT, cone_half_angle,
+      get_mutable_context());
   return prog_->AddConstraint(constraint, q_);
 }
 

--- a/multibody/inverse_kinematics/inverse_kinematics.cc
+++ b/multibody/inverse_kinematics/inverse_kinematics.cc
@@ -55,8 +55,8 @@ InverseKinematics::AddOrientationConstraint(
     const Frame<double>& frameBbar, const math::RotationMatrix<double>& R_BbarB,
     double angle_bound) {
   auto constraint = std::make_shared<internal::OrientationConstraint>(
-      system_.tree(), frameAbar.index(), R_AbarA, frameBbar.index(), R_BbarB,
-      angle_bound, get_mutable_context_autodiff());
+      plant_, frameAbar, R_AbarA, frameBbar, R_BbarB, angle_bound,
+      get_mutable_context());
   return prog_->AddConstraint(constraint, q_);
 }
 

--- a/multibody/inverse_kinematics/inverse_kinematics.cc
+++ b/multibody/inverse_kinematics/inverse_kinematics.cc
@@ -77,8 +77,8 @@ InverseKinematics::AddAngleBetweenVectorsConstraint(
     const Frame<double>& frameB, const Eigen::Ref<const Eigen::Vector3d>& nb_B,
     double angle_lower, double angle_upper) {
   auto constraint = std::make_shared<internal::AngleBetweenVectorsConstraint>(
-      system_.tree(), frameA.index(), na_A, frameB.index(), nb_B, angle_lower,
-      angle_upper, get_mutable_context_autodiff());
+      plant_, frameA, na_A, frameB, nb_B, angle_lower, angle_upper,
+      get_mutable_context());
   return prog_->AddConstraint(constraint, q_);
 }
 }  // namespace multibody

--- a/multibody/inverse_kinematics/inverse_kinematics.cc
+++ b/multibody/inverse_kinematics/inverse_kinematics.cc
@@ -42,7 +42,7 @@ solvers::Binding<solvers::Constraint> InverseKinematics::AddPositionConstraint(
     const Eigen::Ref<const Eigen::Vector3d>& p_AQ_lower,
     const Eigen::Ref<const Eigen::Vector3d>& p_AQ_upper) {
   auto constraint = std::make_shared<PositionConstraint>(
-      &plant_, frameB, p_BQ, frameA, p_AQ_lower, p_AQ_upper,
+      &plant_, frameA, p_AQ_lower, p_AQ_upper, frameB, p_BQ,
       get_mutable_context());
   return prog_->AddConstraint(constraint, q_);
 }

--- a/multibody/inverse_kinematics/inverse_kinematics.cc
+++ b/multibody/inverse_kinematics/inverse_kinematics.cc
@@ -41,7 +41,7 @@ solvers::Binding<solvers::Constraint> InverseKinematics::AddPositionConstraint(
     const Frame<double>& frameA,
     const Eigen::Ref<const Eigen::Vector3d>& p_AQ_lower,
     const Eigen::Ref<const Eigen::Vector3d>& p_AQ_upper) {
-  auto constraint = std::make_shared<internal::PositionConstraint>(
+  auto constraint = std::make_shared<PositionConstraint>(
       plant_, frameB, p_BQ, frameA, p_AQ_lower, p_AQ_upper,
       get_mutable_context());
   return prog_->AddConstraint(constraint, q_);
@@ -52,7 +52,7 @@ InverseKinematics::AddOrientationConstraint(
     const Frame<double>& frameAbar, const math::RotationMatrix<double>& R_AbarA,
     const Frame<double>& frameBbar, const math::RotationMatrix<double>& R_BbarB,
     double angle_bound) {
-  auto constraint = std::make_shared<internal::OrientationConstraint>(
+  auto constraint = std::make_shared<OrientationConstraint>(
       plant_, frameAbar, R_AbarA, frameBbar, R_BbarB, angle_bound,
       get_mutable_context());
   return prog_->AddConstraint(constraint, q_);
@@ -63,7 +63,7 @@ InverseKinematics::AddGazeTargetConstraint(
     const Frame<double>& frameA, const Eigen::Ref<const Eigen::Vector3d>& p_AS,
     const Eigen::Ref<const Eigen::Vector3d>& n_A, const Frame<double>& frameB,
     const Eigen::Ref<const Eigen::Vector3d>& p_BT, double cone_half_angle) {
-  auto constraint = std::make_shared<internal::GazeTargetConstraint>(
+  auto constraint = std::make_shared<GazeTargetConstraint>(
       plant_, frameA, p_AS, n_A, frameB, p_BT, cone_half_angle,
       get_mutable_context());
   return prog_->AddConstraint(constraint, q_);
@@ -74,7 +74,7 @@ InverseKinematics::AddAngleBetweenVectorsConstraint(
     const Frame<double>& frameA, const Eigen::Ref<const Eigen::Vector3d>& na_A,
     const Frame<double>& frameB, const Eigen::Ref<const Eigen::Vector3d>& nb_B,
     double angle_lower, double angle_upper) {
-  auto constraint = std::make_shared<internal::AngleBetweenVectorsConstraint>(
+  auto constraint = std::make_shared<AngleBetweenVectorsConstraint>(
       plant_, frameA, na_A, frameB, nb_B, angle_lower, angle_upper,
       get_mutable_context());
   return prog_->AddConstraint(constraint, q_);

--- a/multibody/inverse_kinematics/inverse_kinematics.cc
+++ b/multibody/inverse_kinematics/inverse_kinematics.cc
@@ -75,7 +75,7 @@ InverseKinematics::AddAngleBetweenVectorsConstraint(
     const Frame<double>& frameB, const Eigen::Ref<const Eigen::Vector3d>& nb_B,
     double angle_lower, double angle_upper) {
   auto constraint = std::make_shared<AngleBetweenVectorsConstraint>(
-      plant_, frameA, na_A, frameB, nb_B, angle_lower, angle_upper,
+      &plant_, frameA, na_A, frameB, nb_B, angle_lower, angle_upper,
       get_mutable_context());
   return prog_->AddConstraint(constraint, q_);
 }

--- a/multibody/inverse_kinematics/inverse_kinematics.cc
+++ b/multibody/inverse_kinematics/inverse_kinematics.cc
@@ -14,8 +14,6 @@ InverseKinematics::InverseKinematics(
     : prog_{new solvers::MathematicalProgram()},
       plant_(plant),
       context_(plant_.CreateDefaultContext()),
-      system_(plant_.tree().ToAutoDiffXd()),
-      context_autodiff_(system_.CreateDefaultContext()),
       q_(prog_->NewContinuousVariables(plant_.num_positions(), "q")) {
   // Initialize the lower and upper bounds to -inf/inf. A free floating body
   // does not increment `num_joints()` (A single free floating body has
@@ -23,9 +21,9 @@ InverseKinematics::InverseKinematics(
   // body. The initialization below guarantees proper bounds on the
   // generalized positions for the free floating body.
   Eigen::VectorXd q_lower = Eigen::VectorXd::Constant(
-      system_.tree().num_positions(), -std::numeric_limits<double>::infinity());
+      plant_.num_positions(), -std::numeric_limits<double>::infinity());
   Eigen::VectorXd q_upper = Eigen::VectorXd::Constant(
-      system_.tree().num_positions(), std::numeric_limits<double>::infinity());
+      plant_.num_positions(), std::numeric_limits<double>::infinity());
   for (JointIndex i{0}; i < plant_.tree().num_joints(); ++i) {
     const auto& joint = plant_.tree().get_joint(i);
     q_lower.segment(joint.position_start(), joint.num_positions()) =

--- a/multibody/inverse_kinematics/inverse_kinematics.h
+++ b/multibody/inverse_kinematics/inverse_kinematics.h
@@ -160,17 +160,11 @@ class InverseKinematics {
   solvers::MathematicalProgram* get_mutable_prog() const { return prog_.get(); }
 
  private:
-  MultibodyTreeContext<AutoDiffXd>* get_mutable_context_autodiff() {
-    return dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(
-        context_autodiff_.get());
-  }
   systems::Context<double>* get_mutable_context() { return context_.get(); }
 
   std::unique_ptr<solvers::MathematicalProgram> prog_;
   const multibody_plant::MultibodyPlant<double>& plant_;
   std::unique_ptr<systems::Context<double>> const context_;
-  const MultibodyTreeSystem<AutoDiffXd> system_;
-  std::unique_ptr<systems::Context<AutoDiffXd>> const context_autodiff_;
   solvers::VectorXDecisionVariable q_;
 };
 }  // namespace multibody

--- a/multibody/inverse_kinematics/inverse_kinematics.h
+++ b/multibody/inverse_kinematics/inverse_kinematics.h
@@ -160,14 +160,17 @@ class InverseKinematics {
   solvers::MathematicalProgram* get_mutable_prog() const { return prog_.get(); }
 
  private:
-  MultibodyTreeContext<AutoDiffXd>* get_mutable_context() {
-    return dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(context_.get());
+  MultibodyTreeContext<AutoDiffXd>* get_mutable_context_autodiff() {
+    return dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(
+        context_autodiff_.get());
   }
+  systems::Context<double>* get_mutable_context() { return context_.get(); }
 
   std::unique_ptr<solvers::MathematicalProgram> prog_;
   const multibody_plant::MultibodyPlant<double>& plant_;
+  std::unique_ptr<systems::Context<double>> const context_;
   const MultibodyTreeSystem<AutoDiffXd> system_;
-  std::unique_ptr<systems::Context<AutoDiffXd>> const context_;
+  std::unique_ptr<systems::Context<AutoDiffXd>> const context_autodiff_;
   solvers::VectorXDecisionVariable q_;
 };
 }  // namespace multibody

--- a/multibody/inverse_kinematics/kinematic_constraint_utilities.cc
+++ b/multibody/inverse_kinematics/kinematic_constraint_utilities.cc
@@ -39,7 +39,7 @@ void UpdateContextConfiguration(
 
 const multibody_plant::MultibodyPlant<double>& RefFromPtrOrThrow(
     const multibody_plant::MultibodyPlant<double>* const plant) {
-  DRAKE_THROW_UNLESS(plant != nullptr);
+  if (plant == nullptr) throw std::invalid_argument("plant is nullptr.");
   return *plant;
 }
 

--- a/multibody/inverse_kinematics/kinematic_constraint_utilities.cc
+++ b/multibody/inverse_kinematics/kinematic_constraint_utilities.cc
@@ -27,6 +27,16 @@ void UpdateContextConfiguration(const Eigen::Ref<const VectorX<AutoDiffXd>>& q,
   }
 }
 
+void UpdateContextConfiguration(
+    drake::systems::Context<double>* context,
+    const drake::multibody::multibody_plant::MultibodyPlant<double>& plant,
+    const Eigen::Ref<const VectorX<double>>& q) {
+  DRAKE_ASSERT(context);
+  if (q != plant.GetPositions(*context)) {
+    plant.SetPositions(context, q);
+  }
+}
+
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/kinematic_constraint_utilities.cc
+++ b/multibody/inverse_kinematics/kinematic_constraint_utilities.cc
@@ -37,6 +37,12 @@ void UpdateContextConfiguration(
   }
 }
 
+const multibody_plant::MultibodyPlant<double>& RefFromPtrOrThrow(
+    const multibody_plant::MultibodyPlant<double>* const plant) {
+  DRAKE_THROW_UNLESS(plant != nullptr);
+  return *plant;
+}
+
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/kinematic_constraint_utilities.h
+++ b/multibody/inverse_kinematics/kinematic_constraint_utilities.h
@@ -3,7 +3,9 @@
 #include <limits>
 
 #include "drake/math/autodiff_gradient.h"
+#include "drake/multibody/plant/multibody_plant.h"
 #include "drake/multibody/tree/multibody_tree_context.h"
+#include "drake/systems/framework/context.h"
 
 namespace drake {
 namespace multibody {
@@ -26,6 +28,18 @@ bool AreAutoDiffVecXdEqual(const Eigen::Ref<const AutoDiffVecXd>& a,
  */
 void UpdateContextConfiguration(const Eigen::Ref<const VectorX<AutoDiffXd>>& q,
                                 MultibodyTreeContext<AutoDiffXd>* mbt_context);
+
+/**
+ * Check if the generalized positions in @p context are the same as @p q.
+ * If they are not the same, then reset @p context's generalized positions
+ * to @p q. Otherwise, leave @p context unchanged.
+ * The intention is to avoid dirtying the computation cache, given it is
+ * ticket-based rather than hash-based.
+ */
+void UpdateContextConfiguration(
+    drake::systems::Context<double>* context,
+    const multibody_plant::MultibodyPlant<double>& plant,
+    const Eigen::Ref<const VectorX<double>>& q);
 
 /**
  * Normalize an Eigen vector of doubles. Throw a logic error if the vector is

--- a/multibody/inverse_kinematics/kinematic_constraint_utilities.h
+++ b/multibody/inverse_kinematics/kinematic_constraint_utilities.h
@@ -42,9 +42,9 @@ void UpdateContextConfiguration(
     const Eigen::Ref<const VectorX<double>>& q);
 
 /**
- * Normalize an Eigen vector of doubles. Throw a logic error if the vector is
- * close to zero. This function is used in the constructor of some kinematic
- * constraints.
+ * Normalize an Eigen vector of doubles. This function is used in the
+ * constructor of some kinematic constraints.
+ * @throws std::invalid_argument if the vector is close to zero.
  */
 template <typename DerivedA>
 typename std::enable_if<
@@ -60,7 +60,8 @@ NormalizeVector(const Eigen::MatrixBase<DerivedA>& a) {
 
 /**
  * If `plant` is not nullptr, return a reference to the MultibodyPlant to which
- * it points. Otherwise, throw.
+ * it points.
+ * @throws std::invalid_argument if `plant` is nullptr.
  */
 const multibody_plant::MultibodyPlant<double>& RefFromPtrOrThrow(
     const multibody_plant::MultibodyPlant<double>* const plant);

--- a/multibody/inverse_kinematics/kinematic_constraint_utilities.h
+++ b/multibody/inverse_kinematics/kinematic_constraint_utilities.h
@@ -57,6 +57,14 @@ NormalizeVector(const Eigen::MatrixBase<DerivedA>& a) {
   }
   return a / a_norm;
 }
+
+/**
+ * If `plant` is not nullptr, return a reference to the MultibodyPlant to which
+ * it points. Otherwise, throw.
+ */
+const multibody_plant::MultibodyPlant<double>& RefFromPtrOrThrow(
+    const multibody_plant::MultibodyPlant<double>* const plant);
+
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/orientation_constraint.cc
+++ b/multibody/inverse_kinematics/orientation_constraint.cc
@@ -3,9 +3,10 @@
 #include "drake/math/autodiff_gradient.h"
 #include "drake/multibody/inverse_kinematics/kinematic_constraint_utilities.h"
 
+using drake::multibody::internal::UpdateContextConfiguration;
+
 namespace drake {
 namespace multibody {
-namespace internal {
 OrientationConstraint::OrientationConstraint(
     const multibody_plant::MultibodyPlant<double>& plant,
     const Frame<double>& frameAbar, const math::RotationMatrix<double>& R_AbarA,
@@ -22,8 +23,6 @@ OrientationConstraint::OrientationConstraint(
   frameBbar.HasThisParentTreeOrThrow(&plant_.tree());
   frameAbar.HasThisParentTreeOrThrow(&plant_.tree());
   DRAKE_DEMAND(context);
-  // TODO(avalenzu): Switch to analytical Jacobian and drop nq == nv requirement
-  // when MBT provides the API for computing analytical Jacobian.
   if (theta_bound < 0) {
     throw std::invalid_argument(
         "OrientationConstraint: theta_bound should be non-negative.\n");
@@ -86,6 +85,5 @@ void OrientationConstraint::DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
                                                    r_AB.transpose() * Jq_w_AB);
 }
 
-}  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/orientation_constraint.cc
+++ b/multibody/inverse_kinematics/orientation_constraint.cc
@@ -77,8 +77,7 @@ void OrientationConstraint::DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
   Eigen::MatrixXd Jq_V_AbarBbar(6, plant_.num_positions());
   plant_.tree().CalcJacobianSpatialVelocity(
       *context_, JacobianWrtVariable::kQDot, frameBbar,
-      Eigen::Vector3d::Zero() /* p_BQ */, frameAbar, frameAbar,
-      &Jq_V_AbarBbar);
+      Eigen::Vector3d::Zero() /* p_BQ */, frameAbar, frameAbar, &Jq_V_AbarBbar);
   // Since we're only concerned with the rotational portion,
   // Jq_w_AB = Jq_w_AbarBbar_A.
   const Eigen::MatrixXd Jq_w_AB =

--- a/multibody/inverse_kinematics/orientation_constraint.cc
+++ b/multibody/inverse_kinematics/orientation_constraint.cc
@@ -7,21 +7,23 @@ namespace drake {
 namespace multibody {
 namespace internal {
 OrientationConstraint::OrientationConstraint(
-    const MultibodyTree<AutoDiffXd>& tree, FrameIndex frameAbar_idx,
-    const math::RotationMatrix<double>& R_AbarA, FrameIndex frameBbar_idx,
-    const math::RotationMatrix<double>& R_BbarB, double theta_bound,
-    MultibodyTreeContext<AutoDiffXd>* context)
-    : solvers::Constraint(1, tree.num_positions(),
+    const multibody_plant::MultibodyPlant<double>& plant,
+    const Frame<double>& frameAbar, const math::RotationMatrix<double>& R_AbarA,
+    const Frame<double>& frameBbar, const math::RotationMatrix<double>& R_BbarB,
+    double theta_bound, systems::Context<double>* context)
+    : solvers::Constraint(1, plant.num_positions(),
                           Vector1d(2 * std::cos(theta_bound) + 1), Vector1d(3)),
-      tree_{tree},
-      frameAbar_{tree.get_frame(frameAbar_idx)},
-      R_AbarA_{R_AbarA.matrix().cast<AutoDiffXd>()},
-      frameBbar_{tree.get_frame(frameBbar_idx)},
-      R_BbarB_{R_BbarB.matrix().cast<AutoDiffXd>()},
+      plant_{plant},
+      frameAbar_{frameAbar},
+      frameBbar_{frameBbar},
+      R_AbarA_{R_AbarA},
+      R_BbarB_{R_BbarB},
       context_(context) {
+  frameBbar.HasThisParentTreeOrThrow(&plant_.tree());
+  frameAbar.HasThisParentTreeOrThrow(&plant_.tree());
   DRAKE_DEMAND(context);
-  // TODO(hongkai.dai): use MultibodyTree<double> and LeafContext<double> when
-  // MBT provides the API for computing analytical Jacobian.
+  // TODO(avalenzu): Switch to analytical Jacobian and drop nq == nv requirement
+  // when MBT provides the API for computing analytical Jacobian.
   if (theta_bound < 0) {
     throw std::invalid_argument(
         "OrientationConstraint: theta_bound should be non-negative.\n");
@@ -37,12 +39,51 @@ void OrientationConstraint::DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
 
 void OrientationConstraint::DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
                                    AutoDiffVecXd* y) const {
+  // The constraint function is
+  //  g(q) = tr(R_AB).
+  // To derive the Jacobian of g, ∂g/∂q, we first differentiate
+  // w.r.t. time to obtain
+  //   ġ = tr(Ṙ_AB),
+  // where we have dropped the dependence on q for readability. Next we expand
+  // Ṙ_AB to yield
+  //   ġ = tr(ω̂_AB R_AB).
+  //         ⎛⎡ 0  -ω₃  ω₂⎤⎡R₁₁ R₁₂ R₁₃⎤⎞
+  //     = tr⎜⎢ ω₃  0  -ω₁⎥⎢R₂₁ R₂₂ R₂₃⎥⎟
+  //         ⎝⎣-ω₂  ω₁  0 ⎦⎣R₃₁ R₃₂ R₃₃⎦⎠
+  //     = (R₂₃ - R₃₂)ω₁ + (R₃₁ - R₁₃)ω₂ + (R₁₂ - R₂₁)ω₃,
+  // where we have dropped the _AB for brevity. Let
+  //   r = (R₂₃ - R₃₂, R₃₁ - R₁₃, R₁₂ - R₂₁)ᵀ.
+  // Then,
+  //   ġ = r_ABᵀ ω_AB.
+  // The angular velocity of B relative to A can be written as
+  //   ω_AB = Jq_w_AB(q) q̇,
+  // where Jq_w_AB is the Jacobian of ω_AB with respect to q̇. Therefore,
+  //   ġ = r_ABᵀ Jq_w_AB q̇.
+  // By the chain rule, ġ = ∂g/∂q q̇. Comparing this with the previous equation,
+  // we see that
+  //   ∂g/∂q = r_ABᵀ Jq_w_AB.
   y->resize(1);
-  UpdateContextConfiguration(x, context_);
-  const Matrix3<AutoDiffXd> R_AbarBbar =
-      tree_.CalcRelativeTransform(*context_, frameAbar_, frameBbar_).linear();
-  const Matrix3<AutoDiffXd> R_AB = R_AbarA_.transpose() * R_AbarBbar * R_BbarB_;
-  (*y)(0) = R_AB.trace();
+  UpdateContextConfiguration(context_, plant_, math::autoDiffToValueMatrix(x));
+  //
+  const Matrix3<double> R_AbarBbar =
+      plant_.tree()
+          .CalcRelativeTransform(*context_, frameAbar_, frameBbar_)
+          .linear();
+  const Matrix3<double> R_AB =
+      R_AbarA_.inverse().matrix() * R_AbarBbar * R_BbarB_.matrix();
+  Eigen::MatrixXd Jq_V_AbarBbar(6, plant_.num_positions());
+  plant_.tree().CalcJacobianSpatialVelocity(
+      *context_, JacobianWrtVariable::kQDot, frameBbar_,
+      Eigen::Vector3d::Zero() /* p_BQ */, frameAbar_, frameAbar_,
+      &Jq_V_AbarBbar);
+  // Since we're only concerned with the rotational portion,
+  // Jq_w_AB = Jq_w_AbarBbar_A.
+  const Eigen::MatrixXd Jq_w_AB =
+      R_AbarA_.inverse().matrix() * Jq_V_AbarBbar.topRows<3>();
+  const Vector3<double> r_AB{R_AB(1, 2) - R_AB(2, 1), R_AB(2, 0) - R_AB(0, 2),
+                             R_AB(0, 1) - R_AB(1, 0)};
+  *y = math::initializeAutoDiffGivenGradientMatrix(Vector1d(R_AB.trace()),
+                                                   r_AB.transpose() * Jq_w_AB);
 }
 
 }  // namespace internal

--- a/multibody/inverse_kinematics/orientation_constraint.cc
+++ b/multibody/inverse_kinematics/orientation_constraint.cc
@@ -3,18 +3,19 @@
 #include "drake/math/autodiff_gradient.h"
 #include "drake/multibody/inverse_kinematics/kinematic_constraint_utilities.h"
 
+using drake::multibody::internal::RefFromPtrOrThrow;
 using drake::multibody::internal::UpdateContextConfiguration;
 
 namespace drake {
 namespace multibody {
 OrientationConstraint::OrientationConstraint(
-    const multibody_plant::MultibodyPlant<double>& plant,
+    const multibody_plant::MultibodyPlant<double>* const plant,
     const Frame<double>& frameAbar, const math::RotationMatrix<double>& R_AbarA,
     const Frame<double>& frameBbar, const math::RotationMatrix<double>& R_BbarB,
     double theta_bound, systems::Context<double>* context)
-    : solvers::Constraint(1, plant.num_positions(),
+    : solvers::Constraint(1, RefFromPtrOrThrow(plant).num_positions(),
                           Vector1d(2 * std::cos(theta_bound) + 1), Vector1d(3)),
-      plant_{plant},
+      plant_{RefFromPtrOrThrow(plant)},
       frameAbar_{frameAbar},
       frameBbar_{frameBbar},
       R_AbarA_{R_AbarA},

--- a/multibody/inverse_kinematics/orientation_constraint.h
+++ b/multibody/inverse_kinematics/orientation_constraint.h
@@ -3,7 +3,7 @@
 #include <memory>
 
 #include "drake/math/rotation_matrix.h"
-#include "drake/multibody/tree/multibody_tree.h"
+#include "drake/multibody/plant/multibody_plant.h"
 #include "drake/solvers/constraint.h"
 
 namespace drake {
@@ -49,13 +49,12 @@ class OrientationConstraint : public solvers::Constraint {
   // @param context The Context that has been allocated for this @p tree. We
   // will update the context when evaluating the constraint. @p context should
   // be alive during the lifetime of this constraint.
-  OrientationConstraint(const MultibodyTree<AutoDiffXd>& tree,
-                        FrameIndex frameAbar_idx,
+  OrientationConstraint(const multibody_plant::MultibodyPlant<double>& plant,
+                        const Frame<double>& frameAbar,
                         const math::RotationMatrix<double>& R_AbarA,
-                        FrameIndex frameBbar_idx,
+                        const Frame<double>& frameBbar,
                         const math::RotationMatrix<double>& R_BbarB,
-                        double theta_bound,
-                        MultibodyTreeContext<AutoDiffXd>* context);
+                        double theta_bound, systems::Context<double>* context);
 
   ~OrientationConstraint() override {}
 
@@ -73,12 +72,12 @@ class OrientationConstraint : public solvers::Constraint {
         "variables.");
   }
 
-  const MultibodyTree<AutoDiffXd>& tree_;
-  const Frame<AutoDiffXd>& frameAbar_;
-  const Matrix3<AutoDiffXd> R_AbarA_;
-  const Frame<AutoDiffXd>& frameBbar_;
-  const Matrix3<AutoDiffXd> R_BbarB_;
-  MultibodyTreeContext<AutoDiffXd>* const context_;
+  const multibody_plant::MultibodyPlant<double>& plant_;
+  const Frame<double>& frameAbar_;
+  const Frame<double>& frameBbar_;
+  const math::RotationMatrix<double>& R_AbarA_;
+  const math::RotationMatrix<double>& R_BbarB_;
+  systems::Context<double>* const context_;
 };
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/inverse_kinematics/orientation_constraint.h
+++ b/multibody/inverse_kinematics/orientation_constraint.h
@@ -9,46 +9,51 @@
 namespace drake {
 namespace multibody {
 namespace internal {
-// Constrains that the angle difference θ between the orientation of frame A
-// and the orientation of frame B to satisfy θ ≤ θ_bound. The angle
-// difference between frame A's orientation R_WA and B's orientation R_WB is θ
-// (θ ∈ [0, π]), if there exists a rotation axis a, such that rotating frame
-// A by angle θ about axis a aligns it with frame B. Namely
-// R_AB = I + sinθ â + (1-cosθ)â²   (1)
-// where R_AB is the orientation of frame B expressed in frame A. â is the skew
-// symmetric matrix of the rotation axis a. Equation (1) is the Rodrigues
-// formula that computes the rotation matrix froma rotation axis a and an angle
-// θ, https://en.wikipedia.org/wiki/Rodrigues%27_rotation_formula
-// If the users want frame A and frame B to align perfectly, they can set
-// θ_bound = 0.
-// Mathematically, this constraint is imposed as
-// trace(R_AB) ≥ 2cos(θ_bound) + 1   (1)
-// To derive (1), using Rodrigues formula
-// R_AB = I + sinθ â + (1-cosθ)â²
-// where
-// trace(R_AB) = 2cos(θ) + 1 ≥ 2cos(θ_bound) + 1
+/**
+ * Constrains that the angle difference θ between the orientation of frame A
+ * and the orientation of frame B to satisfy θ ≤ θ_bound. The angle
+ * difference between frame A's orientation R_WA and B's orientation R_WB is θ
+ *   (θ ∈ [0, π]), if there exists a rotation axis a, such that rotating frame
+ * A by angle θ about axis a aligns it with frame B. Namely
+ *   R_AB = I + sinθ â + (1-cosθ)â²   (1)
+ * where R_AB is the orientation of frame B expressed in frame A. â is the skew
+ * symmetric matrix of the rotation axis a. Equation (1) is the Rodrigues
+ * formula that computes the rotation matrix froma rotation axis a and an angle
+ * θ, https://en.wikipedia.org/wiki/Rodrigues%27_rotation_formula
+ * If the users want frame A and frame B to align perfectly, they can set
+ *   θ_bound = 0.
+ * Mathematically, this constraint is imposed as
+ *   trace(R_AB) ≥ 2cos(θ_bound) + 1   (1)
+ * To derive (1), using Rodrigues formula
+ *   R_AB = I + sinθ â + (1-cosθ)â²
+ * where
+ *   trace(R_AB) = 2cos(θ) + 1 ≥ 2cos(θ_bound) + 1
+ */
 class OrientationConstraint : public solvers::Constraint {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(OrientationConstraint)
 
-  // The frame A is fixed to a frame A̅, with orientatation R_AbarA measured
-  // in frame A̅. The frame B is fixed to a frame B̅, with orientation R_BbarB
-  // measured in frame B. We constrain the angle between frame A and B to be
-  // less than theta_bound.
-  // @param tree The MultibodyTree on which the constraint is imposed. @p tree
-  // should be alive during the lifetime of this constraint.
-  // @param frameAbar_idx The index of frame A̅.
-  // @param R_AbarA The orientation of frame A measured in frame A̅.
-  // @param frameBbar_idx The index of frame B̅.
-  // @param R_BbarB The orientation of frame B measured in frame B̅.
-  // @param theta_bound The bound on the angle difference between frame A's
-  // orientation and frame B's orientation. It is denoted as θ_bound in the
-  // class documentation. @p theta_bound is in radians.
-  // @pre angle_bound >= 0.
-  // @throws std::invalid_argument if angle_bound < 0.
-  // @param context The Context that has been allocated for this @p tree. We
-  // will update the context when evaluating the constraint. @p context should
-  // be alive during the lifetime of this constraint.
+  /**
+   * Constructs an OrientationConstraint object.
+   * The frame A is fixed to a frame A̅, with orientatation R_AbarA measured
+   * in frame A̅. The frame B is fixed to a frame B̅, with orientation R_BbarB
+   * measured in frame B. We constrain the angle between frame A and B to be
+   * less than theta_bound.
+   * @param tree The MultibodyTree on which the constraint is imposed. @p tree
+   *   should be alive during the lifetime of this constraint.
+   * @param frameAbar_idx The index of frame A̅.
+   * @param R_AbarA The orientation of frame A measured in frame A̅.
+   * @param frameBbar_idx The index of frame B̅.
+   * @param R_BbarB The orientation of frame B measured in frame B̅.
+   * @param theta_bound The bound on the angle difference between frame A's
+   *   orientation and frame B's orientation. It is denoted as θ_bound in the
+   *   class documentation. @p theta_bound is in radians.
+   * @pre angle_bound >= 0.
+   * @throws std::invalid_argument if angle_bound < 0.
+   * @param context The Context that has been allocated for this @p tree. We
+   *   will update the context when evaluating the constraint. @p context should
+   *   be alive during the lifetime of this constraint.
+   */
   OrientationConstraint(const multibody_plant::MultibodyPlant<double>& plant,
                         const Frame<double>& frameAbar,
                         const math::RotationMatrix<double>& R_AbarA,

--- a/multibody/inverse_kinematics/orientation_constraint.h
+++ b/multibody/inverse_kinematics/orientation_constraint.h
@@ -34,11 +34,11 @@ class OrientationConstraint : public solvers::Constraint {
 
   /**
    * Constructs an OrientationConstraint object.
-   * The frame A is fixed to a frame A̅, with orientatation R_AbarA measured
-   * in frame A̅. The frame B is fixed to a frame B̅, with orientation R_BbarB
+   * The frame A is fixed to a frame A̅, with orientatation `R_AbarA` measured
+   * in frame A̅. The frame B is fixed to a frame B̅, with orientation `R_BbarB`
    * measured in frame B. We constrain the angle between frame A and B to be
-   * less than theta_bound.
-   * @param plant The MultibodyPlant on which the constraint is imposed. @p plant
+   * less than `theta_bound`.
+   * @param plant The MultibodyPlant on which the constraint is imposed. `plant`
    *   should be alive during the lifetime of this constraint.
    * @param frameAbar The frame A̅ in the model to which frame A is fixed.
    * @param R_AbarA The orientation of frame A measured in frame A̅.
@@ -46,12 +46,15 @@ class OrientationConstraint : public solvers::Constraint {
    * @param R_BbarB The orientation of frame B measured in frame B̅.
    * @param theta_bound The bound on the angle difference between frame A's
    *   orientation and frame B's orientation. It is denoted as θ_bound in the
-   *   class documentation. @p theta_bound is in radians.
-   * @param context The Context that has been allocated for this @p tree. We
-   *   will update the context when evaluating the constraint. @p context should
+   *   class documentation. `theta_bound` is in radians.
+   * @param context The Context that has been allocated for this `tree`. We
+   *   will update the context when evaluating the constraint. `context` should
    *   be alive during the lifetime of this constraint.
-   * @pre angle_bound >= 0.
+   * @throws std::invalid_argument if `plant` is nullptr.
+   * @throws std::logic_error if `frameAbar` or `frameBbar` does not belong to
+   *   `plant`.
    * @throws std::invalid_argument if angle_bound < 0.
+   * @throws std::invalid_argument if `context` is nullptr.
    */
   OrientationConstraint(
       const multibody_plant::MultibodyPlant<double>* const plant,
@@ -78,8 +81,8 @@ class OrientationConstraint : public solvers::Constraint {
   }
 
   const multibody_plant::MultibodyPlant<double>& plant_;
-  const Frame<double>& frameAbar_;
-  const Frame<double>& frameBbar_;
+  const FrameIndex frameAbar_index_;
+  const FrameIndex frameBbar_index_;
   const math::RotationMatrix<double>& R_AbarA_;
   const math::RotationMatrix<double>& R_BbarB_;
   systems::Context<double>* const context_;

--- a/multibody/inverse_kinematics/orientation_constraint.h
+++ b/multibody/inverse_kinematics/orientation_constraint.h
@@ -8,7 +8,6 @@
 
 namespace drake {
 namespace multibody {
-namespace internal {
 /**
  * Constrains that the angle difference θ between the orientation of frame A
  * and the orientation of frame B to satisfy θ ≤ θ_bound. The angle
@@ -48,11 +47,11 @@ class OrientationConstraint : public solvers::Constraint {
    * @param theta_bound The bound on the angle difference between frame A's
    *   orientation and frame B's orientation. It is denoted as θ_bound in the
    *   class documentation. @p theta_bound is in radians.
-   * @pre angle_bound >= 0.
-   * @throws std::invalid_argument if angle_bound < 0.
    * @param context The Context that has been allocated for this @p tree. We
    *   will update the context when evaluating the constraint. @p context should
    *   be alive during the lifetime of this constraint.
+   * @pre angle_bound >= 0.
+   * @throws std::invalid_argument if angle_bound < 0.
    */
   OrientationConstraint(const multibody_plant::MultibodyPlant<double>& plant,
                         const Frame<double>& frameAbar,
@@ -84,6 +83,5 @@ class OrientationConstraint : public solvers::Constraint {
   const math::RotationMatrix<double>& R_BbarB_;
   systems::Context<double>* const context_;
 };
-}  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/orientation_constraint.h
+++ b/multibody/inverse_kinematics/orientation_constraint.h
@@ -53,12 +53,13 @@ class OrientationConstraint : public solvers::Constraint {
    * @pre angle_bound >= 0.
    * @throws std::invalid_argument if angle_bound < 0.
    */
-  OrientationConstraint(const multibody_plant::MultibodyPlant<double>& plant,
-                        const Frame<double>& frameAbar,
-                        const math::RotationMatrix<double>& R_AbarA,
-                        const Frame<double>& frameBbar,
-                        const math::RotationMatrix<double>& R_BbarB,
-                        double theta_bound, systems::Context<double>* context);
+  OrientationConstraint(
+      const multibody_plant::MultibodyPlant<double>* const plant,
+      const Frame<double>& frameAbar,
+      const math::RotationMatrix<double>& R_AbarA,
+      const Frame<double>& frameBbar,
+      const math::RotationMatrix<double>& R_BbarB, double theta_bound,
+      systems::Context<double>* context);
 
   ~OrientationConstraint() override {}
 

--- a/multibody/inverse_kinematics/orientation_constraint.h
+++ b/multibody/inverse_kinematics/orientation_constraint.h
@@ -38,11 +38,11 @@ class OrientationConstraint : public solvers::Constraint {
    * in frame A̅. The frame B is fixed to a frame B̅, with orientation R_BbarB
    * measured in frame B. We constrain the angle between frame A and B to be
    * less than theta_bound.
-   * @param tree The MultibodyTree on which the constraint is imposed. @p tree
+   * @param plant The MultibodyPlant on which the constraint is imposed. @p plant
    *   should be alive during the lifetime of this constraint.
-   * @param frameAbar_idx The index of frame A̅.
+   * @param frameAbar The frame A̅ in the model to which frame A is fixed.
    * @param R_AbarA The orientation of frame A measured in frame A̅.
-   * @param frameBbar_idx The index of frame B̅.
+   * @param frameBbar The frame B̅ in the model to which frame B is fixed.
    * @param R_BbarB The orientation of frame B measured in frame B̅.
    * @param theta_bound The bound on the angle difference between frame A's
    *   orientation and frame B's orientation. It is denoted as θ_bound in the

--- a/multibody/inverse_kinematics/position_constraint.cc
+++ b/multibody/inverse_kinematics/position_constraint.cc
@@ -27,6 +27,7 @@ PositionConstraint::PositionConstraint(
 
 void PositionConstraint::DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
                                 Eigen::VectorXd* y) const {
+  // TODO(avalenzu): Re-work to avoid round-trip through AutoDiffXd (#10205).
   AutoDiffVecXd y_t;
   Eval(math::initializeAutoDiff(x), &y_t);
   *y = math::autoDiffToValueMatrix(y_t);
@@ -42,8 +43,8 @@ void PositionConstraint::DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
   plant_.tree().CalcJacobianSpatialVelocity(*context_,
                                             JacobianWrtVariable::kQDot, frameB_,
                                             p_BQ_, frameA_, frameA_, &Jq_V_ABq);
-  *y = math::initializeAutoDiffGivenGradientMatrix(p_AQ,
-                                                   Jq_V_ABq.bottomRows<3>());
+  *y = math::initializeAutoDiffGivenGradientMatrix(
+      p_AQ, Jq_V_ABq.bottomRows<3>() * math::autoDiffToGradientMatrix(x));
 }
 
 }  // namespace multibody

--- a/multibody/inverse_kinematics/position_constraint.cc
+++ b/multibody/inverse_kinematics/position_constraint.cc
@@ -38,9 +38,9 @@ void PositionConstraint::DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
   Eigen::Vector3d p_AQ{};
   plant_.tree().CalcPointsPositions(*context_, frameB_, p_BQ_, frameA_, &p_AQ);
   Eigen::MatrixXd Jq_V_ABq(6, plant_.num_positions());
-  plant_.tree().CalcJacobianSpatialVelocity(
-      *context_, JacobianWrtVariable::kQDot, frameB_, p_BQ_, frameA_, frameA_,
-      &Jq_V_ABq);
+  plant_.tree().CalcJacobianSpatialVelocity(*context_,
+                                            JacobianWrtVariable::kQDot, frameB_,
+                                            p_BQ_, frameA_, frameA_, &Jq_V_ABq);
   *y = math::initializeAutoDiffGivenGradientMatrix(p_AQ,
                                                    Jq_V_ABq.bottomRows<3>());
 }

--- a/multibody/inverse_kinematics/position_constraint.cc
+++ b/multibody/inverse_kinematics/position_constraint.cc
@@ -3,9 +3,10 @@
 #include "drake/math/autodiff_gradient.h"
 #include "drake/multibody/inverse_kinematics/kinematic_constraint_utilities.h"
 
+using drake::multibody::internal::UpdateContextConfiguration;
+
 namespace drake {
 namespace multibody {
-namespace internal {
 PositionConstraint::PositionConstraint(
     const multibody_plant::MultibodyPlant<double>& plant,
     const Frame<double>& frameB, const Eigen::Ref<const Eigen::Vector3d>& p_BQ,
@@ -45,6 +46,5 @@ void PositionConstraint::DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
                                                    Jq_V_ABq.bottomRows<3>());
 }
 
-}  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/position_constraint.cc
+++ b/multibody/inverse_kinematics/position_constraint.cc
@@ -7,18 +7,20 @@ namespace drake {
 namespace multibody {
 namespace internal {
 PositionConstraint::PositionConstraint(
-    const multibody::MultibodyTree<AutoDiffXd>& tree,
-    const FrameIndex& frameB_idx, const Eigen::Ref<const Eigen::Vector3d>& p_BQ,
-    const FrameIndex& frameA_idx,
+    const multibody_plant::MultibodyPlant<double>& plant,
+    const Frame<double>& frameB, const Eigen::Ref<const Eigen::Vector3d>& p_BQ,
+    const Frame<double>& frameA,
     const Eigen::Ref<const Eigen::Vector3d>& p_AQ_lower,
     const Eigen::Ref<const Eigen::Vector3d>& p_AQ_upper,
-    MultibodyTreeContext<AutoDiffXd>* context)
-    : solvers::Constraint(3, tree.num_positions(), p_AQ_lower, p_AQ_upper),
-      tree_(tree),
-      frameB_{tree_.get_frame(frameB_idx)},
-      frameA_{tree_.get_frame(frameA_idx)},
+    systems::Context<double>* context)
+    : solvers::Constraint(3, plant.num_positions(), p_AQ_lower, p_AQ_upper),
+      plant_(plant),
+      frameB_{frameB},
+      frameA_{frameA},
       p_BQ_{p_BQ},
       context_{context} {
+  frameB_.HasThisParentTreeOrThrow(&plant_.tree());
+  frameA_.HasThisParentTreeOrThrow(&plant_.tree());
   DRAKE_DEMAND(context);
 }
 
@@ -32,9 +34,15 @@ void PositionConstraint::DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
 void PositionConstraint::DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
                                 AutoDiffVecXd* y) const {
   y->resize(3);
-  UpdateContextConfiguration(x, context_);
-  tree_.CalcPointsPositions(*context_, frameB_, p_BQ_.cast<AutoDiffXd>(),
-                            frameA_, y);
+  UpdateContextConfiguration(context_, plant_, math::autoDiffToValueMatrix(x));
+  Eigen::Vector3d p_AQ{};
+  plant_.tree().CalcPointsPositions(*context_, frameB_, p_BQ_, frameA_, &p_AQ);
+  Eigen::MatrixXd Jq_V_ABq(6, plant_.num_positions());
+  plant_.tree().CalcJacobianSpatialVelocity(
+      *context_, JacobianWrtVariable::kQDot, frameB_, p_BQ_, frameA_, frameA_,
+      &Jq_V_ABq);
+  *y = math::initializeAutoDiffGivenGradientMatrix(p_AQ,
+                                                   Jq_V_ABq.bottomRows<3>());
 }
 
 }  // namespace internal

--- a/multibody/inverse_kinematics/position_constraint.cc
+++ b/multibody/inverse_kinematics/position_constraint.cc
@@ -3,19 +3,21 @@
 #include "drake/math/autodiff_gradient.h"
 #include "drake/multibody/inverse_kinematics/kinematic_constraint_utilities.h"
 
+using drake::multibody::internal::RefFromPtrOrThrow;
 using drake::multibody::internal::UpdateContextConfiguration;
 
 namespace drake {
 namespace multibody {
 PositionConstraint::PositionConstraint(
-    const multibody_plant::MultibodyPlant<double>& plant,
+    const multibody_plant::MultibodyPlant<double>* const plant,
     const Frame<double>& frameB, const Eigen::Ref<const Eigen::Vector3d>& p_BQ,
     const Frame<double>& frameA,
     const Eigen::Ref<const Eigen::Vector3d>& p_AQ_lower,
     const Eigen::Ref<const Eigen::Vector3d>& p_AQ_upper,
     systems::Context<double>* context)
-    : solvers::Constraint(3, plant.num_positions(), p_AQ_lower, p_AQ_upper),
-      plant_(plant),
+    : solvers::Constraint(3, RefFromPtrOrThrow(plant).num_positions(),
+                          p_AQ_lower, p_AQ_upper),
+      plant_(RefFromPtrOrThrow(plant)),
       frameB_{frameB},
       frameA_{frameA},
       p_BQ_{p_BQ},

--- a/multibody/inverse_kinematics/position_constraint.h
+++ b/multibody/inverse_kinematics/position_constraint.h
@@ -33,7 +33,7 @@ class PositionConstraint : public solvers::Constraint {
    *   will update the context when evaluating the constraint. @p context should
    *   be alive during the lifetime of this constraint.
    */
-  PositionConstraint(const multibody_plant::MultibodyPlant<double>& plant,
+  PositionConstraint(const multibody_plant::MultibodyPlant<double>* const plant,
                      const Frame<double>& frameB,
                      const Eigen::Ref<const Eigen::Vector3d>& p_BQ,
                      const Frame<double>& frameA,

--- a/multibody/inverse_kinematics/position_constraint.h
+++ b/multibody/inverse_kinematics/position_constraint.h
@@ -19,26 +19,30 @@ class PositionConstraint : public solvers::Constraint {
 
   /**
    * Constructs PositionConstraint object.
-   * @param tree The multibody tree on which the constraint is imposed. @p tree
-   *   should be alive during the whole lifetime of this constraint.
-   * @param frameB Frame B.
-   * @param p_BQ The position of the point Q, rigidly attached to frame B,
-   *   measured and expressed in frame B.
-   * @param frameA_idx Frame A.
+   * @param plant The MultibodyPlant on which the constraint is imposed. `plant`
+   *   should be alive during the lifetime of this constraint.
+   * @param frameA The frame in which point Q's position is measured.
    * @param p_AQ_lower The lower bound on the position of point Q, measured and
    *   expressed in frame A.
    * @param p_AQ_upper The upper bound on the position of point Q, measured and
    *   expressed in frame A.
-   * @param context The Context that has been allocated for this @p tree. We
-   *   will update the context when evaluating the constraint. @p context should
+   * @param frameB The frame to which point Q is rigidly attached.
+   * @param p_BQ The position of the point Q, rigidly attached to frame B,
+   *   measured and expressed in frame B.
+   * @param context The Context that has been allocated for this `plant`. We
+   *   will update the context when evaluating the constraint. `context` should
    *   be alive during the lifetime of this constraint.
+   * @pre `frameA` and `frameB` must belong to `plant`.
+   * @pre p_AQ_lower(i) <= p_AQ_upper(i) for i = 1, 2, 3.
+   * @throws std::invalid_argument if `plant` is nullptr.
+   * @throws std::invalid_argument if `context` is nullptr.
    */
   PositionConstraint(const multibody_plant::MultibodyPlant<double>* const plant,
-                     const Frame<double>& frameB,
-                     const Eigen::Ref<const Eigen::Vector3d>& p_BQ,
                      const Frame<double>& frameA,
                      const Eigen::Ref<const Eigen::Vector3d>& p_AQ_lower,
                      const Eigen::Ref<const Eigen::Vector3d>& p_AQ_upper,
+                     const Frame<double>& frameB,
+                     const Eigen::Ref<const Eigen::Vector3d>& p_BQ,
                      systems::Context<double>* context);
 
   ~PositionConstraint() override {}
@@ -57,8 +61,8 @@ class PositionConstraint : public solvers::Constraint {
   }
 
   const multibody_plant::MultibodyPlant<double>& plant_;
-  const Frame<double>& frameB_;
-  const Frame<double>& frameA_;
+  const FrameIndex frameA_index_;
+  const FrameIndex frameB_index_;
   const Eigen::Vector3d p_BQ_;
   systems::Context<double>* const context_;
 };

--- a/multibody/inverse_kinematics/position_constraint.h
+++ b/multibody/inverse_kinematics/position_constraint.h
@@ -8,7 +8,6 @@
 
 namespace drake {
 namespace multibody {
-namespace internal {
 /**
  * Constrains the position of a point Q, rigidly attached to a frame B, to be
  * within a bounding box measured and expressed in frame A. Namely
@@ -21,20 +20,18 @@ class PositionConstraint : public solvers::Constraint {
   /**
    * Constructs PositionConstraint object.
    * @param tree The multibody tree on which the constraint is imposed. @p tree
-   * should be alive during the whole lifetime of this constraint.
+   *   should be alive during the whole lifetime of this constraint.
    * @param frameB Frame B.
    * @param p_BQ The position of the point Q, rigidly attached to frame B,
-   * measured and expressed in frame B.
+   *   measured and expressed in frame B.
    * @param frameA_idx Frame A.
    * @param p_AQ_lower The lower bound on the position of point Q, measured and
-   * expressed in frame A.
+   *   expressed in frame A.
    * @param p_AQ_upper The upper bound on the position of point Q, measured and
-   * expressed in frame A.
+   *   expressed in frame A.
    * @param context The Context that has been allocated for this @p tree. We
-   * will update the context when evaluating the constraint. @p context should
-   * be alive during the lifetime of this constraint.
-   * TODO(avalenzu): Switch to analytical Jacobian and drop nq == nv requirement
-   * when MBT provides the API for computing analytical Jacobian.
+   *   will update the context when evaluating the constraint. @p context should
+   *   be alive during the lifetime of this constraint.
    */
   PositionConstraint(const multibody_plant::MultibodyPlant<double>& plant,
                      const Frame<double>& frameB,
@@ -65,6 +62,5 @@ class PositionConstraint : public solvers::Constraint {
   const Eigen::Vector3d p_BQ_;
   systems::Context<double>* const context_;
 };
-}  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/position_constraint.h
+++ b/multibody/inverse_kinematics/position_constraint.h
@@ -2,8 +2,9 @@
 
 #include <memory>
 
-#include "drake/multibody/tree/multibody_tree.h"
+#include "drake/multibody/plant/multibody_plant.h"
 #include "drake/solvers/constraint.h"
+#include "drake/systems/framework/context.h"
 
 namespace drake {
 namespace multibody {
@@ -17,10 +18,10 @@ class PositionConstraint : public solvers::Constraint {
 
   // @param tree The multibody tree on which the constraint is imposed. @p tree
   // should be alive during the whole lifetime of this constraint.
-  // @param frameB_idx The index of frame B.
+  // @param frameB Frame B.
   // @param p_BQ The position of the point Q, rigidly attached to frame B,
   // measured and expressed in frame B.
-  // @param frameA_idx The index of frame A.
+  // @param frameA_idx Frame A.
   // @param p_AQ_lower The lower bound on the position of point Q, measured and
   // expressed in frame A.
   // @param p_AQ_upper The upper bound on the position of point Q, measured and
@@ -28,15 +29,15 @@ class PositionConstraint : public solvers::Constraint {
   // @param context The Context that has been allocated for this @p tree. We
   // will update the context when evaluating the constraint. @p context should
   // be alive during the lifetime of this constraint.
-  // TODO(hongkai.dai): use MultibodyTree<double> and LeafContext<double> when
-  // MBT provides the API for computing analytical Jacobian.
-  PositionConstraint(const multibody::MultibodyTree<AutoDiffXd>& tree,
-                     const FrameIndex& frameB_idx,
+  // TODO(avalenzu): Switch to analytical Jacobian and drop nq == nv requirement
+  // when MBT provides the API for computing analytical Jacobian.
+  PositionConstraint(const multibody_plant::MultibodyPlant<double>& plant,
+                     const Frame<double>& frameB,
                      const Eigen::Ref<const Eigen::Vector3d>& p_BQ,
-                     const FrameIndex& frameA_idx,
+                     const Frame<double>& frameA,
                      const Eigen::Ref<const Eigen::Vector3d>& p_AQ_lower,
                      const Eigen::Ref<const Eigen::Vector3d>& p_AQ_upper,
-                     MultibodyTreeContext<AutoDiffXd>* context);
+                     systems::Context<double>* context);
 
   ~PositionConstraint() override {}
 
@@ -53,11 +54,11 @@ class PositionConstraint : public solvers::Constraint {
         "PositionConstraint::DoEval() does not work for symbolic variables.");
   }
 
-  const MultibodyTree<AutoDiffXd>& tree_;
-  const Frame<AutoDiffXd>& frameB_;
-  const Frame<AutoDiffXd>& frameA_;
+  const multibody_plant::MultibodyPlant<double>& plant_;
+  const Frame<double>& frameB_;
+  const Frame<double>& frameA_;
   const Eigen::Vector3d p_BQ_;
-  MultibodyTreeContext<AutoDiffXd>* const context_;
+  systems::Context<double>* const context_;
 };
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/inverse_kinematics/position_constraint.h
+++ b/multibody/inverse_kinematics/position_constraint.h
@@ -9,28 +9,33 @@
 namespace drake {
 namespace multibody {
 namespace internal {
-// Constrains the position of a point Q, rigidly attached to a frame B, to be
-// within a bounding box measured and expressed in frame A. Namely
-// p_AQ_lower <= p_AQ <= p_AQ_upper.
+/**
+ * Constrains the position of a point Q, rigidly attached to a frame B, to be
+ * within a bounding box measured and expressed in frame A. Namely
+ * p_AQ_lower <= p_AQ <= p_AQ_upper.
+ */
 class PositionConstraint : public solvers::Constraint {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PositionConstraint)
 
-  // @param tree The multibody tree on which the constraint is imposed. @p tree
-  // should be alive during the whole lifetime of this constraint.
-  // @param frameB Frame B.
-  // @param p_BQ The position of the point Q, rigidly attached to frame B,
-  // measured and expressed in frame B.
-  // @param frameA_idx Frame A.
-  // @param p_AQ_lower The lower bound on the position of point Q, measured and
-  // expressed in frame A.
-  // @param p_AQ_upper The upper bound on the position of point Q, measured and
-  // expressed in frame A.
-  // @param context The Context that has been allocated for this @p tree. We
-  // will update the context when evaluating the constraint. @p context should
-  // be alive during the lifetime of this constraint.
-  // TODO(avalenzu): Switch to analytical Jacobian and drop nq == nv requirement
-  // when MBT provides the API for computing analytical Jacobian.
+  /**
+   * Constructs PositionConstraint object.
+   * @param tree The multibody tree on which the constraint is imposed. @p tree
+   * should be alive during the whole lifetime of this constraint.
+   * @param frameB Frame B.
+   * @param p_BQ The position of the point Q, rigidly attached to frame B,
+   * measured and expressed in frame B.
+   * @param frameA_idx Frame A.
+   * @param p_AQ_lower The lower bound on the position of point Q, measured and
+   * expressed in frame A.
+   * @param p_AQ_upper The upper bound on the position of point Q, measured and
+   * expressed in frame A.
+   * @param context The Context that has been allocated for this @p tree. We
+   * will update the context when evaluating the constraint. @p context should
+   * be alive during the lifetime of this constraint.
+   * TODO(avalenzu): Switch to analytical Jacobian and drop nq == nv requirement
+   * when MBT provides the API for computing analytical Jacobian.
+   */
   PositionConstraint(const multibody_plant::MultibodyPlant<double>& plant,
                      const Frame<double>& frameB,
                      const Eigen::Ref<const Eigen::Vector3d>& p_BQ,

--- a/multibody/inverse_kinematics/test/angle_between_vectors_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/angle_between_vectors_constraint_test.cc
@@ -10,12 +10,11 @@ TEST_F(IiwaKinematicConstraintTest, AngleBetweenVectorsConstraint) {
   const Eigen::Vector3d n_B(1.6, -3.2, 1.2);
   const double angle_lower{0.1};
   const double angle_upper{0.5 * M_PI};
-  const FrameIndex frameA_index = GetFrameIndex("iiwa_link_3");
-  const FrameIndex frameB_index = GetFrameIndex("iiwa_link_7");
-  AngleBetweenVectorsConstraint constraint(
-      iiwa_autodiff_.tree(), frameA_index, n_A, frameB_index, n_B, angle_lower,
-      angle_upper,
-      dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(context_autodiff_.get()));
+  const Frame<double>& frameA = plant_->GetFrameByName("iiwa_link_3");
+  const Frame<double>& frameB = plant_->GetFrameByName("iiwa_link_7");
+  AngleBetweenVectorsConstraint constraint(*plant_, frameA, n_A, frameB, n_B,
+                                           angle_lower, angle_upper,
+                                           plant_context_);
 
   EXPECT_EQ(constraint.num_constraints(), 1);
   EXPECT_EQ(constraint.num_vars(), iiwa_autodiff_.tree().num_positions());
@@ -27,15 +26,19 @@ TEST_F(IiwaKinematicConstraintTest, AngleBetweenVectorsConstraint) {
   Eigen::VectorXd q(iiwa_autodiff_.tree().num_positions());
   q << 0.2, -0.5, 0.1, 0.25, -0.4, 0.35, 0.24;
   const AutoDiffVecXd q_autodiff = math::initializeAutoDiff(q);
+  auto mbt_context_autodiff =
+      dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(context_autodiff_.get());
+  mbt_context_autodiff->get_mutable_positions() = q_autodiff;
   AutoDiffVecXd y_autodiff;
   constraint.Eval(q_autodiff, &y_autodiff);
 
   Vector1<AutoDiffXd> y_autodiff_expected;
   y_autodiff_expected(0) = n_A.normalized().dot(
       iiwa_autodiff_.tree()
-          .CalcRelativeTransform(*context_autodiff_,
-                                 iiwa_autodiff_.tree().get_frame(frameA_index),
-                                 iiwa_autodiff_.tree().get_frame(frameB_index))
+          .CalcRelativeTransform(
+              *context_autodiff_,
+              iiwa_autodiff_.tree().GetFrameByName(frameA.name()),
+              iiwa_autodiff_.tree().GetFrameByName(frameB.name()))
           .linear() *
       n_B.normalized());
   CompareAutoDiffVectors(y_autodiff, y_autodiff_expected, 1E-12);
@@ -60,61 +63,49 @@ TEST_F(TwoFreeBodiesConstraintTest, AngleBetweenVectorsConstraint) {
       QuaternionToVectorWxyz(body2_quaternion), body2_position;
   {
     AngleBetweenVectorsConstraint good_constraint(
-        two_bodies_autodiff_.tree(), body1_index_, n_A, body2_index_, n_B,
-        angle - 0.01, angle + 0.01,
-        dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(
-            context_autodiff_.get()));
+        *plant_, plant_->tree().get_frame(body1_index_), n_A,
+        plant_->tree().get_frame(body2_index_), n_B, angle - 0.01, angle + 0.01,
+        plant_context_);
     EXPECT_TRUE(good_constraint.CheckSatisfied(q));
   }
 
   {
     AngleBetweenVectorsConstraint bad_constraint(
-        two_bodies_autodiff_.tree(), body1_index_, n_A, body2_index_, n_B,
-        angle - 0.02, angle - 0.01,
-        dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(
-            context_autodiff_.get()));
+        *plant_, plant_->tree().get_frame(body1_index_), n_A,
+        plant_->tree().get_frame(body2_index_), n_B, angle - 0.02, angle - 0.01,
+        plant_context_);
     EXPECT_FALSE(bad_constraint.CheckSatisfied(q));
   }
 }
 
 TEST_F(IiwaKinematicConstraintTest,
        AngleBetweenVectorsConstraintConstructorError) {
-  const FrameIndex frameA_index = GetFrameIndex("iiwa_link_3");
-  const FrameIndex frameB_index = GetFrameIndex("iiwa_link_7");
+  const Frame<double>& frameA = plant_->GetFrameByName("iiwa_link_3");
+  const Frame<double>& frameB = plant_->GetFrameByName("iiwa_link_7");
   // n_A being zero vector.
   EXPECT_THROW(AngleBetweenVectorsConstraint(
-                   iiwa_autodiff_.tree(), frameA_index, Eigen::Vector3d::Zero(),
-                   frameB_index, Eigen::Vector3d::Ones(), 0.1, 0.2,
-                   dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(
-                       context_autodiff_.get())),
+                   *plant_, frameA, Eigen::Vector3d::Zero(), frameB,
+                   Eigen::Vector3d::Ones(), 0.1, 0.2, plant_context_),
                std::invalid_argument);
   // n_B being zero vector.
   EXPECT_THROW(AngleBetweenVectorsConstraint(
-                   iiwa_autodiff_.tree(), frameA_index, Eigen::Vector3d::Ones(),
-                   frameB_index, Eigen::Vector3d::Zero(), 0.1, 0.2,
-                   dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(
-                       context_autodiff_.get())),
+                   *plant_, frameA, Eigen::Vector3d::Ones(), frameB,
+                   Eigen::Vector3d::Zero(), 0.1, 0.2, plant_context_),
                std::invalid_argument);
   // angle_lower < 0
   EXPECT_THROW(AngleBetweenVectorsConstraint(
-                   iiwa_autodiff_.tree(), frameA_index, Eigen::Vector3d::Ones(),
-                   frameB_index, Eigen::Vector3d::Ones(), -0.1, 0.2,
-                   dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(
-                       context_autodiff_.get())),
+                   *plant_, frameA, Eigen::Vector3d::Ones(), frameB,
+                   Eigen::Vector3d::Ones(), -0.1, 0.2, plant_context_),
                std::invalid_argument);
   // angle_upper < angle_lower
   EXPECT_THROW(AngleBetweenVectorsConstraint(
-                   iiwa_autodiff_.tree(), frameA_index, Eigen::Vector3d::Ones(),
-                   frameB_index, Eigen::Vector3d::Zero(), 0.1, 0.09,
-                   dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(
-                       context_autodiff_.get())),
+                   *plant_, frameA, Eigen::Vector3d::Ones(), frameB,
+                   Eigen::Vector3d::Zero(), 0.1, 0.09, plant_context_),
                std::invalid_argument);
   // angle_upper > pi
   EXPECT_THROW(AngleBetweenVectorsConstraint(
-                   iiwa_autodiff_.tree(), frameA_index, Eigen::Vector3d::Ones(),
-                   frameB_index, Eigen::Vector3d::Zero(), 0.1, 1.1 * M_PI,
-                   dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(
-                       context_autodiff_.get())),
+                   *plant_, frameA, Eigen::Vector3d::Ones(), frameB,
+                   Eigen::Vector3d::Zero(), 0.1, 1.1 * M_PI, plant_context_),
                std::invalid_argument);
 }
 }  // namespace internal

--- a/multibody/inverse_kinematics/test/angle_between_vectors_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/angle_between_vectors_constraint_test.cc
@@ -28,7 +28,7 @@ TEST_F(IiwaKinematicConstraintTest, AngleBetweenVectorsConstraint) {
   const double angle_upper{0.5 * M_PI};
   const Frame<double>& frameA = plant_->GetFrameByName("iiwa_link_3");
   const Frame<double>& frameB = plant_->GetFrameByName("iiwa_link_7");
-  AngleBetweenVectorsConstraint constraint(*plant_, frameA, n_A, frameB, n_B,
+  AngleBetweenVectorsConstraint constraint(plant_, frameA, n_A, frameB, n_B,
                                            angle_lower, angle_upper,
                                            plant_context_);
 
@@ -85,7 +85,7 @@ TEST_F(TwoFreeBodiesConstraintTest, AngleBetweenVectorsConstraint) {
       QuaternionToVectorWxyz(body2_quaternion), body2_position;
   {
     AngleBetweenVectorsConstraint good_constraint(
-        *plant_, plant_->tree().get_frame(body1_index_), n_A,
+        plant_, plant_->tree().get_frame(body1_index_), n_A,
         plant_->tree().get_frame(body2_index_), n_B, angle - 0.01, angle + 0.01,
         plant_context_);
     EXPECT_TRUE(good_constraint.CheckSatisfied(q));
@@ -93,7 +93,7 @@ TEST_F(TwoFreeBodiesConstraintTest, AngleBetweenVectorsConstraint) {
 
   {
     AngleBetweenVectorsConstraint bad_constraint(
-        *plant_, plant_->tree().get_frame(body1_index_), n_A,
+        plant_, plant_->tree().get_frame(body1_index_), n_A,
         plant_->tree().get_frame(body2_index_), n_B, angle - 0.02, angle - 0.01,
         plant_context_);
     EXPECT_FALSE(bad_constraint.CheckSatisfied(q));
@@ -106,27 +106,27 @@ TEST_F(IiwaKinematicConstraintTest,
   const Frame<double>& frameB = plant_->GetFrameByName("iiwa_link_7");
   // n_A being zero vector.
   EXPECT_THROW(AngleBetweenVectorsConstraint(
-                   *plant_, frameA, Eigen::Vector3d::Zero(), frameB,
+                   plant_, frameA, Eigen::Vector3d::Zero(), frameB,
                    Eigen::Vector3d::Ones(), 0.1, 0.2, plant_context_),
                std::invalid_argument);
   // n_B being zero vector.
   EXPECT_THROW(AngleBetweenVectorsConstraint(
-                   *plant_, frameA, Eigen::Vector3d::Ones(), frameB,
+                   plant_, frameA, Eigen::Vector3d::Ones(), frameB,
                    Eigen::Vector3d::Zero(), 0.1, 0.2, plant_context_),
                std::invalid_argument);
   // angle_lower < 0
   EXPECT_THROW(AngleBetweenVectorsConstraint(
-                   *plant_, frameA, Eigen::Vector3d::Ones(), frameB,
+                   plant_, frameA, Eigen::Vector3d::Ones(), frameB,
                    Eigen::Vector3d::Ones(), -0.1, 0.2, plant_context_),
                std::invalid_argument);
   // angle_upper < angle_lower
   EXPECT_THROW(AngleBetweenVectorsConstraint(
-                   *plant_, frameA, Eigen::Vector3d::Ones(), frameB,
+                   plant_, frameA, Eigen::Vector3d::Ones(), frameB,
                    Eigen::Vector3d::Zero(), 0.1, 0.09, plant_context_),
                std::invalid_argument);
   // angle_upper > pi
   EXPECT_THROW(AngleBetweenVectorsConstraint(
-                   *plant_, frameA, Eigen::Vector3d::Ones(), frameB,
+                   plant_, frameA, Eigen::Vector3d::Ones(), frameB,
                    Eigen::Vector3d::Zero(), 0.1, 1.1 * M_PI, plant_context_),
                std::invalid_argument);
 }

--- a/multibody/inverse_kinematics/test/angle_between_vectors_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/angle_between_vectors_constraint_test.cc
@@ -2,9 +2,12 @@
 
 #include "drake/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h"
 
+using drake::multibody::internal::IiwaKinematicConstraintTest;
+using drake::multibody::internal::TwoFreeBodiesConstraintTest;
+
 namespace drake {
 namespace multibody {
-namespace internal {
+namespace {
 TEST_F(IiwaKinematicConstraintTest, AngleBetweenVectorsConstraint) {
   const Eigen::Vector3d n_A(0.2, -0.3, 0.9);
   const Eigen::Vector3d n_B(1.6, -3.2, 1.2);
@@ -108,6 +111,6 @@ TEST_F(IiwaKinematicConstraintTest,
                    Eigen::Vector3d::Zero(), 0.1, 1.1 * M_PI, plant_context_),
                std::invalid_argument);
 }
-}  // namespace internal
+}  // namespace
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/test/gaze_target_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/gaze_target_constraint_test.cc
@@ -36,7 +36,7 @@ TEST_F(IiwaKinematicConstraintTest, GazeTargetConstraint) {
   const Eigen::Vector3d n_A(-0.1, 0.3, 0.4);
   const Eigen::Vector3d p_BT(0.4, 0.2, -0.3);
   const double cone_half_angle{0.1 * M_PI};
-  GazeTargetConstraint constraint(*plant_, frameA, p_AS, n_A, frameB, p_BT,
+  GazeTargetConstraint constraint(plant_, frameA, p_AS, n_A, frameB, p_BT,
                                   cone_half_angle, plant_context_);
 
   EXPECT_EQ(constraint.num_constraints(), 2);
@@ -101,14 +101,14 @@ TEST_F(TwoFreeBodiesConstraintTest, GazeTargetConstraint) {
 
   {
     GazeTargetConstraint good_constraint(
-        *plant_, plant_->tree().get_frame(body1_index_), p_AS, n_A,
+        plant_, plant_->tree().get_frame(body1_index_), p_AS, n_A,
         plant_->tree().get_frame(body2_index_), p_BT, angle + 0.01 * M_PI,
         plant_context_);
     EXPECT_TRUE(good_constraint.CheckSatisfied(q));
   }
   {
     GazeTargetConstraint bad_constraint(
-        *plant_, plant_->tree().get_frame(body1_index_), p_AS, n_A,
+        plant_, plant_->tree().get_frame(body1_index_), p_AS, n_A,
         plant_->tree().get_frame(body2_index_), p_BT, angle - 0.01 * M_PI,
         plant_context_);
     EXPECT_FALSE(bad_constraint.CheckSatisfied(q));
@@ -124,13 +124,13 @@ TEST_F(IiwaKinematicConstraintTest, GazeTargetConstraintConstructorError) {
   const Frame<double>& frameB = plant_->GetFrameByName("iiwa_link_4");
   // zero n_A
   EXPECT_THROW(
-      GazeTargetConstraint(*plant_, frameA, p_AS, Eigen::Vector3d::Zero(),
+      GazeTargetConstraint(plant_, frameA, p_AS, Eigen::Vector3d::Zero(),
                            frameB, p_BT, 0.1, plant_context_),
       std::invalid_argument);
 
   // wrong cone_half_angle
   EXPECT_THROW(
-      GazeTargetConstraint(*plant_, frameA, p_AS, Eigen::Vector3d::Ones(),
+      GazeTargetConstraint(plant_, frameA, p_AS, Eigen::Vector3d::Ones(),
                            frameB, p_BT, -0.1, plant_context_),
       std::invalid_argument);
 }

--- a/multibody/inverse_kinematics/test/gaze_target_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/gaze_target_constraint_test.cc
@@ -6,16 +6,14 @@ namespace drake {
 namespace multibody {
 namespace internal {
 TEST_F(IiwaKinematicConstraintTest, GazeTargetConstraint) {
-  const FrameIndex frameA_idx{GetFrameIndex("iiwa_link_7")};
+  const Frame<double>& frameA = plant_->GetFrameByName("iiwa_link_7");
+  const Frame<double>& frameB = plant_->GetFrameByName("iiwa_link_3");
   const Eigen::Vector3d p_AS(0.1, 0.2, 0.3);
   const Eigen::Vector3d n_A(-0.1, 0.3, 0.4);
-  const FrameIndex frameB_idx{GetFrameIndex("iiwa_link_3")};
   const Eigen::Vector3d p_BT(0.4, 0.2, -0.3);
   const double cone_half_angle{0.1 * M_PI};
-  GazeTargetConstraint constraint(
-      iiwa_autodiff_.tree(), frameA_idx, p_AS, n_A, frameB_idx, p_BT,
-      cone_half_angle,
-      dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(context_autodiff_.get()));
+  GazeTargetConstraint constraint(*plant_, frameA, p_AS, n_A, frameB, p_BT,
+                                  cone_half_angle, plant_context_);
 
   EXPECT_EQ(constraint.num_constraints(), 2);
   EXPECT_EQ(constraint.num_vars(), iiwa_autodiff_.tree().num_positions());
@@ -32,11 +30,14 @@ TEST_F(IiwaKinematicConstraintTest, GazeTargetConstraint) {
   AutoDiffVecXd y_autodiff;
   constraint.Eval(q_autodiff, &y_autodiff);
 
+  auto mbt_context_autodiff =
+      dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(context_autodiff_.get());
+  mbt_context_autodiff->get_mutable_positions() = q_autodiff;
   Vector3<AutoDiffXd> p_AT;
   iiwa_autodiff_.tree().CalcPointsPositions(
-      *context_autodiff_, iiwa_autodiff_.tree().get_frame(frameB_idx),
-      p_BT.cast<AutoDiffXd>(), iiwa_autodiff_.tree().get_frame(frameA_idx),
-      &p_AT);
+      *context_autodiff_, iiwa_autodiff_.tree().GetFrameByName(frameB.name()),
+      p_BT.cast<AutoDiffXd>(),
+      iiwa_autodiff_.tree().GetFrameByName(frameA.name()), &p_AT);
   const Vector3<AutoDiffXd> p_ST_A = p_AT - p_AS;
   Vector2<AutoDiffXd> y_autodiff_expected;
   const Eigen::Vector3d n_A_normalized = n_A.normalized();
@@ -71,18 +72,16 @@ TEST_F(TwoFreeBodiesConstraintTest, GazeTargetConstraint) {
 
   {
     GazeTargetConstraint good_constraint(
-        two_bodies_autodiff_.tree(), body1_index_, p_AS, n_A, body2_index_,
-        p_BT, angle + 0.01 * M_PI,
-        dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(
-            context_autodiff_.get()));
+        *plant_, plant_->tree().get_frame(body1_index_), p_AS, n_A,
+        plant_->tree().get_frame(body2_index_), p_BT, angle + 0.01 * M_PI,
+        plant_context_);
     EXPECT_TRUE(good_constraint.CheckSatisfied(q));
   }
   {
     GazeTargetConstraint bad_constraint(
-        two_bodies_autodiff_.tree(), body1_index_, p_AS, n_A, body2_index_,
-        p_BT, angle - 0.01 * M_PI,
-        dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(
-            context_autodiff_.get()));
+        *plant_, plant_->tree().get_frame(body1_index_), p_AS, n_A,
+        plant_->tree().get_frame(body2_index_), p_BT, angle - 0.01 * M_PI,
+        plant_context_);
     EXPECT_FALSE(bad_constraint.CheckSatisfied(q));
   }
 }
@@ -92,22 +91,18 @@ TEST_F(IiwaKinematicConstraintTest, GazeTargetConstraintConstructorError) {
   // inputs are incorrect.
   const Eigen::Vector3d p_AS(1, 2, 3);
   const Eigen::Vector3d p_BT(2, 3, 4);
-  const FrameIndex frameA_index = GetFrameIndex("iiwa_link_3");
-  const FrameIndex frameB_index = GetFrameIndex("iiwa_link_4");
+  const Frame<double>& frameA = plant_->GetFrameByName("iiwa_link_3");
+  const Frame<double>& frameB = plant_->GetFrameByName("iiwa_link_4");
   // zero n_A
   EXPECT_THROW(
-      GazeTargetConstraint(iiwa_autodiff_.tree(), frameA_index, p_AS,
-                           Eigen::Vector3d::Zero(), frameB_index, p_BT, 0.1,
-                           dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(
-                               context_autodiff_.get())),
+      GazeTargetConstraint(*plant_, frameA, p_AS, Eigen::Vector3d::Zero(),
+                           frameB, p_BT, 0.1, plant_context_),
       std::invalid_argument);
 
   // wrong cone_half_angle
   EXPECT_THROW(
-      GazeTargetConstraint(iiwa_autodiff_.tree(), frameA_index, p_AS,
-                           Eigen::Vector3d::Ones(), frameB_index, p_BT, -0.1,
-                           dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(
-                               context_autodiff_.get())),
+      GazeTargetConstraint(*plant_, frameA, p_AS, Eigen::Vector3d::Ones(),
+                           frameB, p_BT, -0.1, plant_context_),
       std::invalid_argument);
 }
 

--- a/multibody/inverse_kinematics/test/inverse_kinematics_test.cc
+++ b/multibody/inverse_kinematics/test/inverse_kinematics_test.cc
@@ -95,7 +95,8 @@ GTEST_TEST(InverseKinematicsTest, ConstructorWithJointLimits) {
     EXPECT_FALSE(check_q_test(q_bad));
   }
 }
-
+// TODO(avalenzu): Re-enable once we allow nv != nq.
+#if (0)
 TEST_F(TwoFreeBodiesTest, PositionConstraint) {
   const Eigen::Vector3d p_BQ(0.2, 0.3, 0.5);
   const Eigen::Vector3d p_AQ_lower(-0.1, -0.2, -0.3);
@@ -201,5 +202,6 @@ TEST_F(TwoFreeBodiesTest, AngleBetweenVectorsConstraint) {
       std::acos(n_A_W.dot(n_B_W) / (n_A_W.norm() * n_B_W.norm()));
   EXPECT_NEAR(angle, angle_lower, 1E-6);
 }
+#endif
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/test/inverse_kinematics_test.cc
+++ b/multibody/inverse_kinematics/test/inverse_kinematics_test.cc
@@ -95,8 +95,7 @@ GTEST_TEST(InverseKinematicsTest, ConstructorWithJointLimits) {
     EXPECT_FALSE(check_q_test(q_bad));
   }
 }
-// TODO(avalenzu): Re-enable once we allow nv != nq.
-#if (0)
+
 TEST_F(TwoFreeBodiesTest, PositionConstraint) {
   const Eigen::Vector3d p_BQ(0.2, 0.3, 0.5);
   const Eigen::Vector3d p_AQ_lower(-0.1, -0.2, -0.3);
@@ -202,6 +201,5 @@ TEST_F(TwoFreeBodiesTest, AngleBetweenVectorsConstraint) {
       std::acos(n_A_W.dot(n_B_W) / (n_A_W.norm() * n_B_W.norm()));
   EXPECT_NEAR(angle, angle_lower, 1E-6);
 }
-#endif
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.cc
+++ b/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.cc
@@ -50,8 +50,12 @@ IiwaKinematicConstraintTest::IiwaKinematicConstraintTest()
                      plant_->GetFrameByName("iiwa_link_0"));
   plant_->Finalize();
 
+  drake::log()->info("plant_->num_positions = {}", plant_->num_positions());
+
   diagram_ = builder.Build();
-  context_ = diagram_->CreateDefaultContext();
+  diagram_context_ = diagram_->CreateDefaultContext();
+  plant_context_ =
+      &diagram_->GetMutableSubsystemContext(*plant_, diagram_context_.get());
 }
 
 TwoFreeBodiesConstraintTest::TwoFreeBodiesConstraintTest()

--- a/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h
+++ b/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h
@@ -6,10 +6,12 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/geometry/scene_graph.h"
 #include "drake/math/autodiff_gradient.h"
 #include "drake/multibody/benchmarks/kuka_iiwa_robot/make_kuka_iiwa_model.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/multibody/tree/multibody_tree.h"
+#include "drake/systems/framework/diagram.h"
 
 namespace drake {
 namespace multibody {
@@ -63,13 +65,7 @@ class IiwaKinematicConstraintTest : public ::testing::Test {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(IiwaKinematicConstraintTest)
 
-  IiwaKinematicConstraintTest()
-      : iiwa_autodiff_(benchmarks::kuka_iiwa_robot::MakeKukaIiwaModel<
-            AutoDiffXd>(true /* finalized model. */)),
-        iiwa_double_(benchmarks::kuka_iiwa_robot::MakeKukaIiwaModel<double>(
-            true /* finalized model. */)),
-        context_autodiff_(iiwa_autodiff_.CreateDefaultContext()),
-        context_double_(iiwa_double_.CreateDefaultContext()) {}
+  IiwaKinematicConstraintTest();
 
   FrameIndex GetFrameIndex(const std::string& name) {
     // TODO(hongkai.dai): call GetFrameByName() directly.
@@ -77,6 +73,10 @@ class IiwaKinematicConstraintTest : public ::testing::Test {
   }
 
  protected:
+  std::unique_ptr<systems::Diagram<double>> diagram_{};
+  multibody_plant::MultibodyPlant<double>* plant_{};
+  geometry::SceneGraph<double>* scene_graph_{};
+  std::unique_ptr<systems::Context<double>> context_;
   MultibodyTreeSystem<AutoDiffXd> iiwa_autodiff_;
   MultibodyTreeSystem<double> iiwa_double_;
   std::unique_ptr<systems::Context<AutoDiffXd>> context_autodiff_;
@@ -88,23 +88,15 @@ class TwoFreeBodiesConstraintTest : public ::testing::Test {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(TwoFreeBodiesConstraintTest)
 
-  TwoFreeBodiesConstraintTest()
-      : two_bodies_autodiff_(ConstructTwoFreeBodies<AutoDiffXd>()),
-        two_bodies_double_(ConstructTwoFreeBodies<double>()),
-        body1_index_(two_bodies_autodiff_.tree()
-                         .GetBodyByName("body1")
-                         .body_frame()
-                         .index()),
-        body2_index_(two_bodies_autodiff_.tree()
-                         .GetBodyByName("body2")
-                         .body_frame()
-                         .index()),
-        context_autodiff_(two_bodies_autodiff_.CreateDefaultContext()),
-        context_double_(two_bodies_double_.CreateDefaultContext()) {}
+  TwoFreeBodiesConstraintTest();
 
   ~TwoFreeBodiesConstraintTest() override {}
 
  protected:
+  std::unique_ptr<systems::Diagram<double>> diagram_{};
+  multibody_plant::MultibodyPlant<double>* plant_{};
+  std::unique_ptr<systems::Context<double>> diagram_context_;
+  systems::Context<double>* plant_context_;
   MultibodyTreeSystem<AutoDiffXd> two_bodies_autodiff_;
   MultibodyTreeSystem<double> two_bodies_double_;
   FrameIndex body1_index_;

--- a/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h
+++ b/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h
@@ -76,7 +76,8 @@ class IiwaKinematicConstraintTest : public ::testing::Test {
   std::unique_ptr<systems::Diagram<double>> diagram_{};
   multibody_plant::MultibodyPlant<double>* plant_{};
   geometry::SceneGraph<double>* scene_graph_{};
-  std::unique_ptr<systems::Context<double>> context_;
+  std::unique_ptr<systems::Context<double>> diagram_context_;
+  systems::Context<double>* plant_context_;
   MultibodyTreeSystem<AutoDiffXd> iiwa_autodiff_;
   MultibodyTreeSystem<double> iiwa_double_;
   std::unique_ptr<systems::Context<AutoDiffXd>> context_autodiff_;

--- a/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h
+++ b/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h
@@ -94,7 +94,7 @@ class TwoFreeBodiesConstraintTest : public ::testing::Test {
   ~TwoFreeBodiesConstraintTest() override {}
 
  protected:
-  std::unique_ptr<systems::Diagram<double>> diagram_{};
+  std::unique_ptr<systems::Diagram<double>> diagram_;
   multibody_plant::MultibodyPlant<double>* plant_{};
   std::unique_ptr<systems::Context<double>> diagram_context_;
   systems::Context<double>* plant_context_;

--- a/multibody/inverse_kinematics/test/orientation_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/orientation_constraint_test.cc
@@ -35,7 +35,7 @@ TEST_F(IiwaKinematicConstraintTest, OrientationConstraint) {
       0.2 * M_PI, Eigen::Vector3d(0.2, 0.4, -0.5).normalized()));
   const math::RotationMatrix<double> R_BbarB(Eigen::AngleAxisd(
       -0.4 * M_PI, Eigen::Vector3d(0.1, 1.2, -0.7).normalized()));
-  OrientationConstraint constraint(*plant_, frameAbar, R_AbarA, frameBbar,
+  OrientationConstraint constraint(plant_, frameAbar, R_AbarA, frameBbar,
                                    R_BbarB, angle_bound, plant_context_);
 
   EXPECT_EQ(constraint.num_constraints(), 1);
@@ -96,13 +96,13 @@ TEST_F(TwoFreeBodiesConstraintTest, OrientationConstraint) {
   const double theta = R_AB.ToAngleAxis().angle();
 
   OrientationConstraint good_constraint(
-      *plant_, plant_->tree().get_frame(body1_index_), R_AbarA,
+      plant_, plant_->tree().get_frame(body1_index_), R_AbarA,
       plant_->tree().get_frame(body2_index_), R_BbarB, theta * 1.01,
       plant_context_);
   EXPECT_TRUE(good_constraint.CheckSatisfied(q));
 
   OrientationConstraint bad_constraint(
-      *plant_, plant_->tree().get_frame(body1_index_), R_AbarA,
+      plant_, plant_->tree().get_frame(body1_index_), R_AbarA,
       plant_->tree().get_frame(body2_index_), R_BbarB, theta * 0.99,
       plant_context_);
   EXPECT_FALSE(bad_constraint.CheckSatisfied(q));
@@ -110,7 +110,7 @@ TEST_F(TwoFreeBodiesConstraintTest, OrientationConstraint) {
 TEST_F(IiwaKinematicConstraintTest, OrientationConstraintConstructionError) {
   // Throws a logic error for negative angle bound.
   EXPECT_THROW(
-      OrientationConstraint(*plant_, plant_->GetFrameByName("iiwa_link_7"),
+      OrientationConstraint(plant_, plant_->GetFrameByName("iiwa_link_7"),
                             math::RotationMatrix<double>::Identity(),
                             plant_->GetFrameByName("iiwa_link_3"),
                             math::RotationMatrix<double>::Identity(), -0.01,

--- a/multibody/inverse_kinematics/test/orientation_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/orientation_constraint_test.cc
@@ -55,8 +55,7 @@ TEST_F(IiwaKinematicConstraintTest, OrientationConstraint) {
       dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(context_autodiff_.get());
   mbt_context_autodiff->get_mutable_positions() = q_autodiff;
   AutoDiffVecXd y_autodiff_expected = EvalOrientationConstraintAutoDiff(
-      *context_autodiff_,
-      iiwa_autodiff_.tree(),
+      *context_autodiff_, iiwa_autodiff_.tree(),
       iiwa_autodiff_.tree().GetFrameByName(frameAbar.name()), R_AbarA,
       iiwa_autodiff_.tree().GetFrameByName(frameBbar.name()), R_BbarB);
   CompareAutoDiffVectors(y_autodiff, y_autodiff_expected, 1E-12);
@@ -67,8 +66,7 @@ TEST_F(IiwaKinematicConstraintTest, OrientationConstraint) {
   mbt_context_autodiff->get_mutable_positions() = q_autodiff;
   constraint.Eval(q_autodiff, &y_autodiff);
   y_autodiff_expected = EvalOrientationConstraintAutoDiff(
-      *context_autodiff_,
-      iiwa_autodiff_.tree(),
+      *context_autodiff_, iiwa_autodiff_.tree(),
       iiwa_autodiff_.tree().GetFrameByName(frameAbar.name()), R_AbarA,
       iiwa_autodiff_.tree().GetFrameByName(frameBbar.name()), R_BbarB);
   CompareAutoDiffVectors(y_autodiff, y_autodiff_expected, 1E-12);

--- a/multibody/inverse_kinematics/test/orientation_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/orientation_constraint_test.cc
@@ -1,11 +1,16 @@
 #include "drake/multibody/inverse_kinematics/orientation_constraint.h"
 
 #include "drake/math/rotation_matrix.h"
+#include <gtest/gtest.h>
+
 #include "drake/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h"
+
+using drake::multibody::internal::IiwaKinematicConstraintTest;
+using drake::multibody::internal::TwoFreeBodiesConstraintTest;
 
 namespace drake {
 namespace multibody {
-namespace internal {
+namespace {
 TEST_F(IiwaKinematicConstraintTest, OrientationConstraint) {
   const double angle_bound{0.1 * M_PI};
   const Frame<double>& frameAbar = plant_->GetFrameByName("iiwa_link_7");
@@ -92,6 +97,6 @@ TEST_F(IiwaKinematicConstraintTest, OrientationConstraintConstructionError) {
       std::invalid_argument);
 }
 
-}  // namespace internal
+}  // namespace
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/test/orientation_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/orientation_constraint_test.cc
@@ -8,16 +8,14 @@ namespace multibody {
 namespace internal {
 TEST_F(IiwaKinematicConstraintTest, OrientationConstraint) {
   const double angle_bound{0.1 * M_PI};
-  const FrameIndex frameAbar_index{GetFrameIndex("iiwa_link_7")};
+  const Frame<double>& frameAbar = plant_->GetFrameByName("iiwa_link_7");
+  const Frame<double>& frameBbar = plant_->GetFrameByName("iiwa_link_3");
   const math::RotationMatrix<double> R_AbarA(Eigen::AngleAxisd(
       0.2 * M_PI, Eigen::Vector3d(0.2, 0.4, -0.5).normalized()));
-  const FrameIndex frameBbar_index{GetFrameIndex("iiwa_link_3")};
   const math::RotationMatrix<double> R_BbarB(Eigen::AngleAxisd(
       -0.4 * M_PI, Eigen::Vector3d(0.1, 1.2, -0.7).normalized()));
-  OrientationConstraint constraint(
-      iiwa_autodiff_.tree(), frameAbar_index, R_AbarA, frameBbar_index, R_BbarB,
-      angle_bound,
-      dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(context_autodiff_.get()));
+  OrientationConstraint constraint(*plant_, frameAbar, R_AbarA, frameBbar,
+                                   R_BbarB, angle_bound, plant_context_);
 
   EXPECT_EQ(constraint.num_constraints(), 1);
   EXPECT_EQ(constraint.num_vars(), iiwa_autodiff_.tree().num_positions());
@@ -33,12 +31,15 @@ TEST_F(IiwaKinematicConstraintTest, OrientationConstraint) {
   constraint.Eval(q_autodiff, &y_autodiff);
 
   AutoDiffVecXd y_autodiff_expected(1);
+  auto mbt_context_autodiff =
+      dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(context_autodiff_.get());
+  mbt_context_autodiff->get_mutable_positions() = q_autodiff;
   const Matrix3<AutoDiffXd> R_AbarBbar =
       iiwa_autodiff_.tree()
           .CalcRelativeTransform(
               *context_autodiff_,
-              iiwa_autodiff_.tree().get_frame(frameAbar_index),
-              iiwa_autodiff_.tree().get_frame(frameBbar_index))
+              iiwa_autodiff_.tree().GetFrameByName(frameAbar.name()),
+              iiwa_autodiff_.tree().GetFrameByName(frameBbar.name()))
           .linear();
   const Matrix3<AutoDiffXd> R_AB =
       R_AbarA.matrix().cast<AutoDiffXd>().transpose() * R_AbarBbar *
@@ -69,27 +70,25 @@ TEST_F(TwoFreeBodiesConstraintTest, OrientationConstraint) {
   const double theta = R_AB.ToAngleAxis().angle();
 
   OrientationConstraint good_constraint(
-      two_bodies_autodiff_.tree(), body1_index_, R_AbarA, body2_index_, R_BbarB,
-      theta * 1.01,
-      dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(context_autodiff_.get()));
+      *plant_, plant_->tree().get_frame(body1_index_), R_AbarA,
+      plant_->tree().get_frame(body2_index_), R_BbarB, theta * 1.01,
+      plant_context_);
   EXPECT_TRUE(good_constraint.CheckSatisfied(q));
 
   OrientationConstraint bad_constraint(
-      two_bodies_autodiff_.tree(), body1_index_, R_AbarA, body2_index_, R_BbarB,
-      theta * 0.99,
-      dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(context_autodiff_.get()));
+      *plant_, plant_->tree().get_frame(body1_index_), R_AbarA,
+      plant_->tree().get_frame(body2_index_), R_BbarB, theta * 0.99,
+      plant_context_);
   EXPECT_FALSE(bad_constraint.CheckSatisfied(q));
 }
-
 TEST_F(IiwaKinematicConstraintTest, OrientationConstraintConstructionError) {
   // Throws a logic error for negative angle bound.
   EXPECT_THROW(
-      OrientationConstraint(iiwa_autodiff_.tree(), GetFrameIndex("iiwa_link_7"),
+      OrientationConstraint(*plant_, plant_->GetFrameByName("iiwa_link_7"),
                             math::RotationMatrix<double>::Identity(),
-                            GetFrameIndex("iiwa_link_3"),
+                            plant_->GetFrameByName("iiwa_link_3"),
                             math::RotationMatrix<double>::Identity(), -0.01,
-                            dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(
-                                context_autodiff_.get())),
+                            plant_context_),
       std::invalid_argument);
 }
 

--- a/multibody/inverse_kinematics/test/orientation_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/orientation_constraint_test.cc
@@ -1,8 +1,8 @@
 #include "drake/multibody/inverse_kinematics/orientation_constraint.h"
 
-#include "drake/math/rotation_matrix.h"
 #include <gtest/gtest.h>
 
+#include "drake/math/rotation_matrix.h"
 #include "drake/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h"
 
 using drake::math::RotationMatrixd;

--- a/multibody/inverse_kinematics/test/position_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/position_constraint_test.cc
@@ -1,9 +1,15 @@
 #include "drake/multibody/inverse_kinematics/position_constraint.h"
 
+#include <gtest/gtest.h>
+
 #include "drake/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h"
+
+using drake::multibody::internal::IiwaKinematicConstraintTest;
+using drake::multibody::internal::TwoFreeBodiesConstraintTest;
+
 namespace drake {
 namespace multibody {
-namespace internal {
+namespace {
 TEST_F(IiwaKinematicConstraintTest, PositionConstraint) {
   const Eigen::Vector3d p_BQ(0.1, 0.2, 0.3);
   const Eigen::Vector3d p_AQ_lower(-0.2, -0.3, -0.4);
@@ -84,6 +90,6 @@ TEST_F(TwoFreeBodiesConstraintTest, PositionConstraint) {
     EXPECT_FALSE(bad_constraint.CheckSatisfied(q));
   }
 }
-}  // namespace internal
+}  // namespace
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/test/position_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/position_constraint_test.cc
@@ -6,29 +6,39 @@
 
 using drake::multibody::internal::IiwaKinematicConstraintTest;
 using drake::multibody::internal::TwoFreeBodiesConstraintTest;
+using drake::systems::Context;
 
 namespace drake {
 namespace multibody {
 namespace {
+AutoDiffVecXd EvalPositionConstraintAutoDiff(
+    const Context<AutoDiffXd>& context, const MultibodyTree<AutoDiffXd>& tree,
+    const Frame<AutoDiffXd>& frameA, const Frame<AutoDiffXd>& frameB,
+    const Vector3<double>& p_BQ) {
+  Vector3<AutoDiffXd> y_autodiff;
+  tree.CalcPointsPositions(context, frameB, p_BQ.cast<AutoDiffXd>(), frameA,
+                           &y_autodiff);
+  return y_autodiff;
+}
 TEST_F(IiwaKinematicConstraintTest, PositionConstraint) {
   const Eigen::Vector3d p_BQ(0.1, 0.2, 0.3);
   const Eigen::Vector3d p_AQ_lower(-0.2, -0.3, -0.4);
   const Eigen::Vector3d p_AQ_upper(0.2, 0.3, 0.4);
   const Frame<double>& frameB = plant_->GetFrameByName("iiwa_link_7");
   const Frame<double>& frameA = plant_->GetFrameByName("iiwa_link_3");
-  PositionConstraint constraint1(*plant_, frameB, p_BQ, frameA, p_AQ_lower,
+  PositionConstraint constraint(*plant_, frameB, p_BQ, frameA, p_AQ_lower,
                                  p_AQ_upper, plant_context_);
 
-  EXPECT_EQ(constraint1.num_vars(), iiwa_autodiff_.tree().num_positions());
-  EXPECT_EQ(constraint1.num_constraints(), 3);
-  EXPECT_EQ(constraint1.lower_bound(), p_AQ_lower);
-  EXPECT_EQ(constraint1.upper_bound(), p_AQ_upper);
+  EXPECT_EQ(constraint.num_vars(), iiwa_autodiff_.tree().num_positions());
+  EXPECT_EQ(constraint.num_constraints(), 3);
+  EXPECT_EQ(constraint.lower_bound(), p_AQ_lower);
+  EXPECT_EQ(constraint.upper_bound(), p_AQ_upper);
 
   // Now check if Eval function computes the right result.
   Eigen::VectorXd q(7);
   q << 0.1, 0.2, 0.3, 0.4, -0.1, -0.2, -0.3;
   Eigen::VectorXd y;
-  constraint1.Eval(q, &y);
+  constraint.Eval(q, &y);
 
   Eigen::MatrixXd y_expected(3, 1);
 
@@ -38,19 +48,28 @@ TEST_F(IiwaKinematicConstraintTest, PositionConstraint) {
   const double tol = 1E-12;
   EXPECT_TRUE(CompareMatrices(y, y_expected, tol));
 
-  const VectorX<AutoDiffXd> q_autodiff = math::initializeAutoDiff(q);
+  VectorX<AutoDiffXd> q_autodiff = math::initializeAutoDiff(q);
   AutoDiffVecXd y_autodiff;
-  constraint1.Eval(q_autodiff, &y_autodiff);
-  Vector3<AutoDiffXd> y_autodiff_expected;
+  constraint.Eval(q_autodiff, &y_autodiff);
   auto mbt_context_autodiff =
       dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(context_autodiff_.get());
   mbt_context_autodiff->get_mutable_positions() = q_autodiff;
-  iiwa_autodiff_.tree().CalcPointsPositions(
-      *context_autodiff_, iiwa_autodiff_.tree().GetFrameByName(frameB.name()),
-      p_BQ.cast<AutoDiffXd>(),
+  Vector3<AutoDiffXd> y_autodiff_expected = EvalPositionConstraintAutoDiff(
+      *context_autodiff_, iiwa_autodiff_.tree(),
       iiwa_autodiff_.tree().GetFrameByName(frameA.name()),
-      &y_autodiff_expected);
+      iiwa_autodiff_.tree().GetFrameByName(frameB.name()), p_BQ);
   CompareAutoDiffVectors(y_autodiff, y_autodiff_expected, tol);
+
+  // Test with non-identity gradient for q_autodiff.
+  q_autodiff = math::initializeAutoDiffGivenGradientMatrix(
+      q, MatrixX<double>::Ones(q.size(), 2));
+  mbt_context_autodiff->get_mutable_positions() = q_autodiff;
+  constraint.Eval(q_autodiff, &y_autodiff);
+  y_autodiff_expected = EvalPositionConstraintAutoDiff(
+      *context_autodiff_, iiwa_autodiff_.tree(),
+      iiwa_autodiff_.tree().GetFrameByName(frameA.name()),
+      iiwa_autodiff_.tree().GetFrameByName(frameB.name()), p_BQ);
+  CompareAutoDiffVectors(y_autodiff, y_autodiff_expected, 1E-12);
 }
 
 TEST_F(TwoFreeBodiesConstraintTest, PositionConstraint) {

--- a/multibody/inverse_kinematics/test/position_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/position_constraint_test.cc
@@ -26,7 +26,7 @@ TEST_F(IiwaKinematicConstraintTest, PositionConstraint) {
   const Eigen::Vector3d p_AQ_upper(0.2, 0.3, 0.4);
   const Frame<double>& frameB = plant_->GetFrameByName("iiwa_link_7");
   const Frame<double>& frameA = plant_->GetFrameByName("iiwa_link_3");
-  PositionConstraint constraint(*plant_, frameB, p_BQ, frameA, p_AQ_lower,
+  PositionConstraint constraint(plant_, frameB, p_BQ, frameA, p_AQ_lower,
                                  p_AQ_upper, plant_context_);
 
   EXPECT_EQ(constraint.num_vars(), iiwa_autodiff_.tree().num_positions());
@@ -94,7 +94,7 @@ TEST_F(TwoFreeBodiesConstraintTest, PositionConstraint) {
 
   {
     PositionConstraint good_constraint(
-        *plant_, plant_->tree().get_frame(body1_index_), p_BQ,
+        plant_, plant_->tree().get_frame(body1_index_), p_BQ,
         plant_->tree().get_frame(body2_index_),
         p_AQ - Eigen::Vector3d::Constant(0.001),
         p_AQ + Eigen::Vector3d::Constant(0.001), plant_context_);
@@ -102,7 +102,7 @@ TEST_F(TwoFreeBodiesConstraintTest, PositionConstraint) {
   }
   {
     PositionConstraint bad_constraint(
-        *plant_, plant_->tree().get_frame(body1_index_), p_BQ,
+        plant_, plant_->tree().get_frame(body1_index_), p_BQ,
         plant_->tree().get_frame(body2_index_),
         p_AQ - Eigen::Vector3d::Constant(0.002),
         p_AQ - Eigen::Vector3d::Constant(0.001), plant_context_);

--- a/multibody/inverse_kinematics/test/position_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/position_constraint_test.cc
@@ -26,8 +26,8 @@ TEST_F(IiwaKinematicConstraintTest, PositionConstraint) {
   const Eigen::Vector3d p_AQ_upper(0.2, 0.3, 0.4);
   const Frame<double>& frameB = plant_->GetFrameByName("iiwa_link_7");
   const Frame<double>& frameA = plant_->GetFrameByName("iiwa_link_3");
-  PositionConstraint constraint(plant_, frameB, p_BQ, frameA, p_AQ_lower,
-                                 p_AQ_upper, plant_context_);
+  PositionConstraint constraint(plant_, frameA, p_AQ_lower, p_AQ_upper, frameB,
+                                p_BQ, plant_context_);
 
   EXPECT_EQ(constraint.num_vars(), iiwa_autodiff_.tree().num_positions());
   EXPECT_EQ(constraint.num_constraints(), 3);
@@ -94,18 +94,18 @@ TEST_F(TwoFreeBodiesConstraintTest, PositionConstraint) {
 
   {
     PositionConstraint good_constraint(
-        plant_, plant_->tree().get_frame(body1_index_), p_BQ,
-        plant_->tree().get_frame(body2_index_),
+        plant_, plant_->tree().get_frame(body2_index_),
         p_AQ - Eigen::Vector3d::Constant(0.001),
-        p_AQ + Eigen::Vector3d::Constant(0.001), plant_context_);
+        p_AQ + Eigen::Vector3d::Constant(0.001),
+        plant_->tree().get_frame(body1_index_), p_BQ, plant_context_);
     EXPECT_TRUE(good_constraint.CheckSatisfied(q));
   }
   {
     PositionConstraint bad_constraint(
-        plant_, plant_->tree().get_frame(body1_index_), p_BQ,
-        plant_->tree().get_frame(body2_index_),
+        plant_, plant_->tree().get_frame(body2_index_),
         p_AQ - Eigen::Vector3d::Constant(0.002),
-        p_AQ - Eigen::Vector3d::Constant(0.001), plant_context_);
+        p_AQ - Eigen::Vector3d::Constant(0.001),
+        plant_->tree().get_frame(body1_index_), p_BQ, plant_context_);
     EXPECT_FALSE(bad_constraint.CheckSatisfied(q));
   }
 }


### PR DESCRIPTION
We initially hid the kinematic constraint classes because they were such heavy users of `MultibodyPlant<AutoDiffXd>`. This PR moves them over to use `MultibodyPlant<double>` and makes them visible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10161)
<!-- Reviewable:end -->
