### PR TITLE
Change non-MBP-dependendent geometry usage to explicitly use roles

### DIFF
--- a/attic/multibody/rigid_body_plant/BUILD.bazel
+++ b/attic/multibody/rigid_body_plant/BUILD.bazel
@@ -88,7 +88,7 @@ drake_cc_library(
     deps = [
         "//attic/multibody:rigid_body_tree",
         "//geometry:geometry_ids",
-        "//geometry:materials",
+        "//geometry:geometry_visualization",
         "//geometry:scene_graph",
     ],
 )

--- a/attic/multibody/rigid_body_plant/rigid_body_plant_bridge.h
+++ b/attic/multibody/rigid_body_plant/rigid_body_plant_bridge.h
@@ -145,9 +145,8 @@ class RigidBodyPlantBridge : public systems::LeafSystem<T> {
   int plant_state_port_{-1};
 
   // Registered frames. In this incarnation, body i's frame_id is stored in
-  // element i - 1. This is because *all* frames are currently being registered
-  // (regardless of weldedness or whether it has geometry) and we skip the
-  // world body (index 0).
+  // element i. This is because *all* frames are currently being registered
+  // (regardless of weldedness or whether it has geometry).
   std::vector<geometry::FrameId> body_ids_;
 };
 }  // namespace systems

--- a/automotive/automotive_simulator.cc
+++ b/automotive/automotive_simulator.cc
@@ -123,8 +123,9 @@ void AutomotiveSimulator<T>::ConnectCarOutputsAndPriusVis(
   // Add visualization geometry.
   // TODO(jeremy.nimmer) These hard-coded shapes duplicate the contents of the
   // SDF.  We should try to load the SDF instead, but there is not any geometry
-  // code exposed for that yet.
-  scene_graph_->RegisterGeometry(
+  // code exposed for that yet. Related to this is the assignment of default
+  // illustration properties.
+  geometry::GeometryId geometry_id = scene_graph_->RegisterGeometryWithoutRole(
       source_id, frame_id,
       std::make_unique<geometry::GeometryInstance>(
           Isometry3d(Eigen::Translation3d(
@@ -132,8 +133,12 @@ void AutomotiveSimulator<T>::ConnectCarOutputsAndPriusVis(
           std::make_unique<geometry::Mesh>(
               FindResourceOrThrow("drake/automotive/models/prius/prius.obj")),
           "prius_body"));
-  const geometry::VisualMaterial gray(Eigen::Vector4d(0.2, 0.2, 0.2, 1.0));
-  scene_graph_->RegisterGeometry(
+  scene_graph_->AssignRole(source_id, geometry_id,
+                           geometry::IllustrationProperties());
+  const geometry::IllustrationProperties grey =
+      geometry::MakeDrakeVisualizerProperties(
+          Eigen::Vector4d(0.2, 0.2, 0.2, 1.0));
+  geometry_id = scene_graph_->RegisterGeometryWithoutRole(
       source_id, frame_id,
       std::make_unique<geometry::GeometryInstance>(
           math::RigidTransformd(
@@ -141,8 +146,9 @@ void AutomotiveSimulator<T>::ConnectCarOutputsAndPriusVis(
               Eigen::Vector3d(1.409 + kVisOffsetInX, 0.802, 0.316))
           .GetAsIsometry3(),
           std::make_unique<geometry::Cylinder>(0.323, 0.215),
-          "left_wheel", gray));
-  scene_graph_->RegisterGeometry(
+          "left_wheel"));
+  scene_graph_->AssignRole(source_id, geometry_id, grey);
+  geometry_id = scene_graph_->RegisterGeometryWithoutRole(
       source_id, frame_id,
       std::make_unique<geometry::GeometryInstance>(
           math::RigidTransformd(
@@ -150,8 +156,9 @@ void AutomotiveSimulator<T>::ConnectCarOutputsAndPriusVis(
               Eigen::Vector3d(1.409 + kVisOffsetInX, -0.802, 0.316))
           .GetAsIsometry3(),
           std::make_unique<geometry::Cylinder>(0.323, 0.215),
-          "right_wheel", gray));
-  scene_graph_->RegisterGeometry(
+          "right_wheel"));
+  scene_graph_->AssignRole(source_id, geometry_id, grey);
+  geometry_id = scene_graph_->RegisterGeometryWithoutRole(
       source_id, frame_id,
       std::make_unique<geometry::GeometryInstance>(
           math::RigidTransformd(
@@ -159,8 +166,9 @@ void AutomotiveSimulator<T>::ConnectCarOutputsAndPriusVis(
               Eigen::Vector3d(-1.409 + kVisOffsetInX, 0.802, 0.323))
           .GetAsIsometry3(),
           std::make_unique<geometry::Cylinder>(0.323, 0.215),
-          "left_wheel_rear", gray));
-  scene_graph_->RegisterGeometry(
+          "left_wheel_rear"));
+  scene_graph_->AssignRole(source_id, geometry_id, grey);
+  geometry_id = scene_graph_->RegisterGeometryWithoutRole(
       source_id, frame_id,
       std::make_unique<geometry::GeometryInstance>(
           math::RigidTransformd(
@@ -168,7 +176,8 @@ void AutomotiveSimulator<T>::ConnectCarOutputsAndPriusVis(
               Eigen::Vector3d(-1.409 + kVisOffsetInX, -0.802, 0.323))
           .GetAsIsometry3(),
           std::make_unique<geometry::Cylinder>(0.323, 0.215),
-          "right_wheel_rear", gray));
+          "right_wheel_rear"));
+  scene_graph_->AssignRole(source_id, geometry_id, grey);
 
   // Convert PoseVector into FramePoseVector.
   using Converter = systems::rendering::RenderPoseToGeometryPose<T>;

--- a/examples/pendulum/BUILD.bazel
+++ b/examples/pendulum/BUILD.bazel
@@ -32,6 +32,7 @@ drake_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":pendulum_vector_types",
+        "//geometry:geometry_visualization",
         "//geometry:scene_graph",
         "//math:geometric_transform",
         "//systems/framework",

--- a/examples/pendulum/pendulum_plant.cc
+++ b/examples/pendulum/pendulum_plant.cc
@@ -4,7 +4,9 @@
 
 #include "drake/common/default_scalars.h"
 #include "drake/geometry/geometry_frame.h"
+#include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/geometry_instance.h"
+#include "drake/geometry/geometry_visualization.h"
 #include "drake/math/rotation_matrix.h"
 
 namespace drake {
@@ -17,9 +19,10 @@ using Eigen::Vector4d;
 using geometry::Box;
 using geometry::Cylinder;
 using geometry::GeometryFrame;
+using geometry::GeometryId;
 using geometry::GeometryInstance;
+using geometry::MakeDrakeVisualizerProperties;
 using geometry::Sphere;
-using geometry::VisualMaterial;
 using std::make_unique;
 
 template <typename T>
@@ -126,30 +129,33 @@ void PendulumPlant<T>::RegisterGeometry(
   source_id_ = scene_graph->RegisterSource("pendulum");
 
   // The base.
-  scene_graph->RegisterAnchoredGeometry(
+  GeometryId id = scene_graph->RegisterAnchoredGeometryWithoutRole(
       source_id_,
       make_unique<GeometryInstance>(Isometry3d(Translation3d(0., 0., .025)),
-                                    make_unique<Box>(.05, 0.05, 0.05), "base",
-                                    VisualMaterial(Vector4d(.3, .6, .4, 1))));
+                                    make_unique<Box>(.05, 0.05, 0.05), "base"));
+  scene_graph->AssignRole(
+      source_id_, id, MakeDrakeVisualizerProperties(Vector4d(.3, .6, .4, 1)));
 
   frame_id_ = scene_graph->RegisterFrame(
       source_id_, GeometryFrame("arm", Isometry3d::Identity()));
 
   // The arm.
-  scene_graph->RegisterGeometry(
+  id = scene_graph->RegisterGeometryWithoutRole(
       source_id_, frame_id_,
       make_unique<GeometryInstance>(
           Isometry3d(Translation3d(0, 0, -params.length() / 2.)),
-          make_unique<Cylinder>(0.01, params.length()), "arm",
-          VisualMaterial(Vector4d(.9, .1, 0, 1))));
+          make_unique<Cylinder>(0.01, params.length()), "arm"));
+  scene_graph->AssignRole(
+      source_id_, id, MakeDrakeVisualizerProperties(Vector4d(.9, .1, 0, 1)));
 
   // The mass at the end of the arm.
-  scene_graph->RegisterGeometry(
+  id = scene_graph->RegisterGeometryWithoutRole(
       source_id_, frame_id_,
       make_unique<GeometryInstance>(
           Isometry3d(Translation3d(0, 0, -params.length())),
-          make_unique<Sphere>(params.mass() / 40.), "arm point mass",
-          VisualMaterial(Vector4d(0, 0, 1, 1))));
+          make_unique<Sphere>(params.mass() / 40.), "arm point mass"));
+  scene_graph->AssignRole(
+      source_id_, id, MakeDrakeVisualizerProperties(Vector4d(0, 0, 1, 1)));
 
   // Now allocate the output port.
   geometry_pose_port_ = AllocateGeometryPoseOutputPort();

--- a/examples/scene_graph/BUILD.bazel
+++ b/examples/scene_graph/BUILD.bazel
@@ -67,6 +67,7 @@ drake_cc_library(
     deps = [
         "//common",
         "//geometry:geometry_ids",
+        "//geometry:geometry_visualization",
         "//geometry:scene_graph",
         "//math:geometric_transform",
         "//systems/framework:leaf_system",

--- a/examples/scene_graph/bouncing_ball_plant.cc
+++ b/examples/scene_graph/bouncing_ball_plant.cc
@@ -6,6 +6,7 @@
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/geometry_frame.h"
 #include "drake/geometry/geometry_instance.h"
+#include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/query_results/penetration_as_point_pair.h"
 #include "drake/geometry/shape_specification.h"
 
@@ -17,7 +18,9 @@ namespace bouncing_ball {
 using geometry::FramePoseVector;
 using geometry::GeometryFrame;
 using geometry::GeometryInstance;
+using geometry::IllustrationProperties;
 using geometry::PenetrationAsPointPair;
+using geometry::ProximityProperties;
 using geometry::SceneGraph;
 using geometry::SourceId;
 using geometry::Sphere;
@@ -47,11 +50,14 @@ BouncingBallPlant<T>::BouncingBallPlant(SourceId source_id,
 
   ball_frame_id_ = scene_graph->RegisterFrame(
       source_id, GeometryFrame("ball_frame", Isometry3<double>::Identity()));
-  ball_id_ = scene_graph->RegisterGeometry(
+  ball_id_ = scene_graph->RegisterGeometryWithoutRole(
       source_id, ball_frame_id_,
       make_unique<GeometryInstance>(Isometry3<double>::Identity(), /*X_FG*/
                                     make_unique<Sphere>(diameter_ / 2.0),
                                     "ball"));
+  // Use the default material.
+  scene_graph->AssignRole(source_id, ball_id_, IllustrationProperties());
+  scene_graph->AssignRole(source_id, ball_id_, ProximityProperties());
 
   // Allocate the output port now that the frame has been registered.
   geometry_pose_port_ = this->DeclareAbstractOutputPort(

--- a/examples/scene_graph/bouncing_ball_run_dynamics.cc
+++ b/examples/scene_graph/bouncing_ball_run_dynamics.cc
@@ -24,7 +24,10 @@ namespace {
 
 using geometry::GeometryInstance;
 using geometry::SceneGraph;
+using geometry::GeometryId;
 using geometry::HalfSpace;
+using geometry::IllustrationProperties;
+using geometry::ProximityProperties;
 using geometry::SourceId;
 using lcm::DrakeLcm;
 using systems::InputPort;
@@ -54,10 +57,12 @@ int do_main() {
   // X_WH will be the identity.
   Vector3<double> Hz_W(0, 0, 1);
   Vector3<double> p_WH(0, 0, 0);
-  scene_graph->RegisterAnchoredGeometry(
+  GeometryId ground_id = scene_graph->RegisterAnchoredGeometryWithoutRole(
       global_source,
       make_unique<GeometryInstance>(HalfSpace::MakePose(Hz_W, p_WH),
                                     make_unique<HalfSpace>(), "ground"));
+  scene_graph->AssignRole(global_source, ground_id, ProximityProperties());
+  scene_graph->AssignRole(global_source, ground_id, IllustrationProperties());
 
   builder.Connect(bouncing_ball1->get_geometry_pose_output_port(),
                   scene_graph->get_source_pose_port(ball_source_id1));


### PR DESCRIPTION
These are the call sites that register geometry that are unaffiliated with MBP. This updates those call sites to make use of the new (temporary) API that registers geometry without roles (explicitly adding them as
appropriate). This is a pre-cursor to the next PR removing the temporary API and merging the role-less behavior into the main API.

(There's also a modicum of clean up in the same neighborhood.)

```
Category            added  modified  removed  
----------------------------------------------
code                114    74        36       
comments            9      11        1        
blank               7      0         0        
----------------------------------------------
TOTAL               130    85        37 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10164)
<!-- Reviewable:end -->
