### PR TITLE
Modify multibody code to use geometry-role-based interface

### DIFF
--- a/examples/multibody/bouncing_ball/make_bouncing_ball_plant.cc
+++ b/examples/multibody/bouncing_ball/make_bouncing_ball_plant.cc
@@ -10,7 +10,6 @@ namespace bouncing_ball {
 using geometry::Sphere;
 using geometry::HalfSpace;
 using geometry::SceneGraph;
-using geometry::VisualMaterial;
 using drake::multibody::multibody_plant::CoulombFriction;
 using drake::multibody::multibody_plant::MultibodyPlant;
 using drake::multibody::RigidBody;
@@ -54,7 +53,7 @@ MakeBouncingBallPlant(double radius, double mass,
             surface_friction);
 
     // Add visual for the ball.
-    const VisualMaterial orange(Vector4<double>(1.0, 0.55, 0.0, 1.0));
+    const Vector4<double> orange(1.0, 0.55, 0.0, 1.0);
     plant->RegisterVisualGeometry(
         ball,
         /* Pose X_BG of the geometry frame G in the ball frame B. */

--- a/examples/multibody/cylinder_with_multicontact/make_cylinder_plant.cc
+++ b/examples/multibody/cylinder_with_multicontact/make_cylinder_plant.cc
@@ -11,7 +11,6 @@ using geometry::Cylinder;
 using geometry::HalfSpace;
 using geometry::SceneGraph;
 using geometry::Sphere;
-using geometry::VisualMaterial;
 using drake::multibody::multibody_plant::CoulombFriction;
 using drake::multibody::multibody_plant::MultibodyPlant;
 using drake::multibody::RigidBody;
@@ -24,8 +23,8 @@ void AddCylinderWithMultiContact(
     MultibodyPlant<double>* plant, const RigidBody<double>& body,
     double radius, double length, const CoulombFriction<double>& friction,
     double contact_spheres_radius, int num_contacts) {
-  const VisualMaterial orange(Vector4<double>(1.0, 0.55, 0.0, 1.0));
-  const VisualMaterial red(Vector4<double>(1.0, 0.0, 0.0, 1.0));
+  const Vector4<double> orange(1.0, 0.55, 0.0, 1.0);
+  const Vector4<double> red(1.0, 0.0, 0.0, 1.0);
 
   // Visual for the Cylinder
   plant->RegisterVisualGeometry(

--- a/examples/simple_gripper/simple_gripper.cc
+++ b/examples/simple_gripper/simple_gripper.cc
@@ -157,7 +157,7 @@ void AddGripperPads(MultibodyPlant<double>* plant,
     plant->RegisterCollisionGeometry(finger, X_FS, Sphere(kPadMinorRadius),
                                      "collision" + std::to_string(i), friction);
 
-    const geometry::VisualMaterial red(Vector4<double>(1.0, 0.0, 0.0, 1.0));
+    const Vector4<double> red(1.0, 0.0, 0.0, 1.0);
     plant->RegisterVisualGeometry(finger, X_FS, Sphere(kPadMinorRadius),
                                   "visual" + std::to_string(i), red);
   }

--- a/geometry/dev/geometry_state.cc
+++ b/geometry/dev/geometry_state.cc
@@ -319,8 +319,11 @@ GeometryState<T>& GeometryState<T>::operator=(
   for (GeometryId geometry_id : ordered_geometry) {
     const geometry::internal::InternalGeometry& geometry =
         tester.geometries().at(geometry_id);
-    const Vector4<double>& diffuse = geometry.visual_material().diffuse();
-    if (diffuse(3) > 0) {
+    // NOTE: Geometry only gets registered into *this* scene graph if it is
+    // "visualizable" (which means has an illustration role in the main
+    // scene graph.
+    if (geometry.has_illustration_role()) {
+      const Vector4<double>& diffuse = geometry.visual_material().diffuse();
       internal::InternalGeometry* parent_geometry = nullptr;
       if (geometry.parent_id()) {
         GeometryId parent_id = *geometry.parent_id();

--- a/multibody/benchmarks/inclined_plane/make_inclined_plane_plant.cc
+++ b/multibody/benchmarks/inclined_plane/make_inclined_plane_plant.cc
@@ -11,7 +11,6 @@ namespace inclined_plane {
 using geometry::HalfSpace;
 using geometry::SceneGraph;
 using geometry::Sphere;
-using geometry::VisualMaterial;
 using multibody_plant::CoulombFriction;
 using multibody::multibody_plant::MultibodyPlant;
 using multibody::RigidBody;
@@ -65,13 +64,13 @@ std::unique_ptr<MultibodyPlant<double>> MakeInclinedPlanePlant(
       surface_friction);
 
   // Visual for the ball.
-  const VisualMaterial orange(Vector4<double>(1.0, 0.55, 0.0, 1.0));
+  const Vector4<double> orange(1.0, 0.55, 0.0, 1.0);
   plant->RegisterVisualGeometry(
       ball,
       X_BG.GetAsIsometry3(), Sphere(radius), "visual1", orange);
 
-  // Add little spherical spokes to highlight the sphere's rotation.
-  const VisualMaterial red(Vector4<double>(1.0, 0.0, 0.0, 1.0));
+  // Adds little spherical spokes to highlight the sphere's rotation.
+  const Vector4<double> red(1.0, 0.0, 0.0, 1.0);
   plant->RegisterVisualGeometry(
       ball,
       // Pose of 1st spoke frame in the ball frame B.

--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -106,6 +106,7 @@ drake_cc_library(
     deps = [
         ":detail_misc",
         ":package_map",
+        "//geometry:geometry_visualization",
         "//geometry:scene_graph",
         "//multibody/multibody_tree/multibody_plant:coulomb_friction",
         "@sdformat",

--- a/multibody/parsing/detail_scene_graph.cc
+++ b/multibody/parsing/detail_scene_graph.cc
@@ -20,7 +20,7 @@ namespace detail {
 using Eigen::Isometry3d;
 using Eigen::Vector3d;
 using geometry::GeometryInstance;
-using geometry::VisualMaterial;
+using geometry::IllustrationProperties;
 using multibody_plant::CoulombFriction;
 using std::make_unique;
 
@@ -194,7 +194,7 @@ std::unique_ptr<GeometryInstance> MakeGeometryInstanceFromSdfVisual(
       break;
     }
     case sdf::GeometryType::PLANE: {
-      const sdf::Plane &shape = *sdf_geometry.PlaneShape();
+      const sdf::Plane& shape = *sdf_geometry.PlaneShape();
       // TODO(amcastro-tri): we assume the normal is in the frame of the visual
       // geometry G. Verify this with @nkoenig.
       const Vector3d normal_G = ToVector3(shape.Normal());
@@ -213,16 +213,22 @@ std::unique_ptr<GeometryInstance> MakeGeometryInstanceFromSdfVisual(
     }
   }
 
-  const VisualMaterial material = MakeVisualMaterialFromSdfVisual(sdf_visual);
-  return make_unique<GeometryInstance>(X_LC,
-                                       MakeShapeFromSdfGeometry(sdf_geometry),
-                                       sdf_visual.Name(), material);
+  auto instance = make_unique<GeometryInstance>(
+      X_LC, MakeShapeFromSdfGeometry(sdf_geometry), sdf_visual.Name());
+  instance->set_illustration_properties(
+      MakeVisualPropertiesFromSdfVisual(sdf_visual));
+  return instance;
 }
 
-VisualMaterial MakeVisualMaterialFromSdfVisual(const sdf::Visual& sdf_visual) {
+IllustrationProperties MakeVisualPropertiesFromSdfVisual(
+    const sdf::Visual& sdf_visual) {
   // TODO(SeanCurtis-TRI): Update this to use the sdf API when
   // https://bitbucket.org/osrf/sdformat/pull-requests/445/material-dom/diff
   // merges.
+  // The existence of a visual element will *always* require an
+  // IllustrationProperties instance. How we populate it depends on the material
+  // values.
+  IllustrationProperties properties;
 
   const sdf::ElementPtr visual_element = sdf_visual.Element();
   // Element pointers can only be nullptr if Load() was not called on the sdf::
@@ -232,23 +238,28 @@ VisualMaterial MakeVisualMaterialFromSdfVisual(const sdf::Visual& sdf_visual) {
   const sdf::Element* const material_element =
       MaybeGetChildElement(*visual_element, "material");
 
-  const VisualMaterial default_material;
-  if (material_element == nullptr ||
-      !material_element->HasElement("diffuse")) {
-    return default_material;
+  if (material_element != nullptr) {
+    auto add_property = [material_element](
+        const char* property, IllustrationProperties* props) {
+      if (!material_element->HasElement(property)) return;
+      using ignition::math::Color;
+      const std::pair<Color, bool> value_pair =
+          material_element->Get<Color>(property, Color());
+      if (value_pair.second == false) return;
+      const Color& sdf_color = value_pair.first;
+
+      Vector4<double> color{sdf_color.R(), sdf_color.G(), sdf_color.B(),
+                            sdf_color.A()};
+      props->AddProperty("phong", property, color);
+    };
+
+    add_property("diffuse", &properties);
+    add_property("ambient", &properties);
+    add_property("specular", &properties);
+    add_property("emissive", &properties);
   }
 
-  // If the diffuse tag exists, rely on sdformat's rules for resolving strange
-  // <diffuse> values.
-  using ignition::math::Color;
-  const std::pair<Color, bool> value_pair =
-      material_element->Get<Color>("diffuse", Color());
-  if (value_pair.second == false) return default_material;
-  const Color& sdf_diffuse = value_pair.first;
-
-  Vector4<double> diffuse{sdf_diffuse.R(), sdf_diffuse.G(), sdf_diffuse.B(),
-                          sdf_diffuse.A()};
-  return VisualMaterial(diffuse);
+  return properties;
 }
 
 Isometry3d MakeGeometryPoseFromSdfCollision(

--- a/multibody/parsing/detail_scene_graph.h
+++ b/multibody/parsing/detail_scene_graph.h
@@ -13,75 +13,96 @@ namespace drake {
 namespace multibody {
 namespace detail {
 
-/// Given an sdf::Geometry object representing a <geometry> element from an SDF
-/// file, this method makes a new drake::geometry::Shape object from this
-/// specification.
-/// For `sdf_geometry.Type() == sdf::GeometryType::EMPTY`, corresponding to the
-/// <empty/> SDF tag, it returns `nullptr`.
+/** Given an sdf::Geometry object representing a <geometry> element from an SDF
+ file, this method makes a new drake::geometry::Shape object from this
+ specification.
+ For `sdf_geometry.Type() == sdf::GeometryType::EMPTY`, corresponding to the
+ <empty/> SDF tag, it returns `nullptr`.  */
 std::unique_ptr<geometry::Shape> MakeShapeFromSdfGeometry(
     const sdf::Geometry& sdf_geometry);
 
-/// Given an sdf::Visual object representing a <visual> element from an SDF
-/// file, this method makes a new drake::geometry::GeometryInstance object from
-/// this specification.
-/// This method returns nullptr when the given SDF specification corresponds
-/// to a geometry of type `sdf::GeometryType::EMPTY` (<empty/> SDF tag.)
+/** Given an sdf::Visual object representing a <visual> element from an SDF
+ file, this method makes a new drake::geometry::GeometryInstance object from
+ this specification.
+ This method returns nullptr when the given SDF specification corresponds
+ to a geometry of type `sdf::GeometryType::EMPTY` (<empty/> SDF tag.)  */
 std::unique_ptr<geometry::GeometryInstance> MakeGeometryInstanceFromSdfVisual(
     const sdf::Visual& sdf_visual);
 
-/// Given an sdf::Visual object representing a <visual> element from an SDF
-/// file, this method makes a new @ref drake::geometry::VisualMaterial
-/// "VisualMaterial" object from the specification.
-///
-/// The visual material comes from the child <material> tag. E.g.,
-/// ```xml
-/// <visual>
-///   <geometry>
-///   ...
-///   </geometry>
-///   <material>
-///     <ambient>r_a g_a b_a a_a</ambient>
-///     <diffuse>r_d g_d b_d a_d</diffuse>
-///     <specular>r_s g_s b_s a_s</specular>
-///     <emissive>r_e g_e b_e a_e</emissive>
-///   </material>
-/// </visual>
-/// ```
-/// If there is no material tag, the supported material tags are missing, or
-/// there is an error parsing the supported values, the instantiated
-/// VisualMaterial will use default values. (See geometry::VisualMaterial for
-/// description of the default color.)
-///
-/// @note Currently, only the diffuse value is included in the VisualMaterial.
-geometry::VisualMaterial MakeVisualMaterialFromSdfVisual(
+/** Extracts the material properties from the given sdf::Visual object.
+ The sdf::Visual object represents a corresponding <visual> tag from an SDF
+ file. The material properties are placed into a
+ geometry::IllustrationProperties as follows:
+
+ <!-- NOTE: Lines longer than 80 columns required for the doxygen tables. -->
+ | Group |   Name   |      Type       | Description |
+ | :---: | :------: | :-------------: | :---------- |
+ | phong | diffuse  | Vector4<double> | The normalized rgba values for the diffuse color |
+ | phong | ambient  | Vector4<double> | The normalized rgba values for the ambient color |
+ | phong | specular | Vector4<double> | The normalized rgba values for the specular color |
+ | phong | emissive | Vector4<double> | The normalized rgba values for the emissive color |
+
+ These are properties to be used in the
+ <a href="https://en.wikipedia.org/wiki/Phong_reflection_model">Phong
+ lighting model</a> and are taken from the similarly named property tags (see
+ below). If any of `ambient`, `diffuse`, `specular`, or `emissive` tags are
+ missing, that property will be omitted from the property set and the impact
+ of those missing properties will depend on the downstream consumers documented
+ handling of missing parameters.
+
+ <!-- TODO(SeanCurtis-TRI): Consider changing the behavior for unspecified tags
+ to provide the material value as specified in the current (12/11/18) sdf
+ specification (http://sdformat.org/spec?ver=1.6&elem=material).
+ This is captured in the issue:
+ https://github.com/RobotLocomotion/drake/issues/10193 -->
+
+ The material properties come from the child <material> tag. E.g.,
+ ```xml
+ <visual>
+   <geometry>
+   ...
+   </geometry>
+   <material>
+     <ambient>r_a g_a b_a a_a</ambient>
+     <diffuse>r_d g_d b_d a_d</diffuse>
+     <specular>r_s g_s b_s a_s</specular>
+     <emissive>r_e g_e b_e a_e</emissive>
+   </material>
+ </visual>
+ ```
+
+ An instance of geometry::IllustrationProperties will always be returned. If
+ there is no material tag, no material property tags, or no successfully
+ parsed material property tags, the property set will be empty.  */
+geometry::IllustrationProperties MakeVisualPropertiesFromSdfVisual(
     const sdf::Visual& sdf_visual);
 
-/// Given `sdf_collision` stemming from the parsing of a `<collision>` element
-/// in an SDF file, this method makes the pose `X_LG` of frame G for the
-/// geometry of that collision element in the frame L of the link it belongs to.
+/** Given `sdf_collision` stemming from the parsing of a `<collision>` element
+ in an SDF file, this method makes the pose `X_LG` of frame G for the geometry
+ of that collision element in the frame L of the link it belongs to.  */
 Eigen::Isometry3d MakeGeometryPoseFromSdfCollision(
     const sdf::Collision& sdf_collision);
 
-/// Parses friction coefficients from `sdf_collision`.
-/// This method looks for the definitions specific to ODE, as given by the SDF
-/// specification in `<collision><surface><friction><ode>`. Drake understands
-/// `<mu>` as the static coefficient of friction and `<mu2>` as the dynamic
-/// coefficient of friction. Consider the example below:
-/// ```xml
-///   <collision>
-///     <surface>
-///       <friction>
-///         <ode>
-///           <mu>0.8</mu>
-///           <mu2>0.3</mu2>
-///         </ode>
-///       </friction>
-///     </surface>
-///   </collision>
-/// ```
-/// If a `<surface>` is not found, it returns the coefficients for a
-/// frictionless surface. If `<surface>` is found, all other nested elements
-/// are required and an exception is thrown if not present.
+/** Parses friction coefficients from `sdf_collision`.
+ This method looks for the definitions specific to ODE, as given by the SDF
+ specification in `<collision><surface><friction><ode>`. Drake understands
+ `<mu>` as the static coefficient of friction and `<mu2>` as the dynamic
+ coefficient of friction. Consider the example below:
+ ```xml
+   <collision>
+     <surface>
+       <friction>
+         <ode>
+           <mu>0.8</mu>
+           <mu2>0.3</mu2>
+         </ode>
+       </friction>
+     </surface>
+   </collision>
+ ```
+ If a `<surface>` is not found, it returns the coefficients for a
+ frictionless surface. If `<surface>` is found, all other nested elements
+ are required and an exception is thrown if not present.  */
 multibody_plant::CoulombFriction<double> MakeCoulombFrictionFromSdfCollisionOde(
     const sdf::Collision& sdf_collision);
 
@@ -89,14 +110,14 @@ multibody_plant::CoulombFriction<double> MakeCoulombFrictionFromSdfCollisionOde(
 // is overly specific since we're going to be parsing collision meshes
 // at some point.
 
-/// Given an sdf::Visual object representing a <visual> element from
-/// an SDF file, this method makes a new Visual object which resolves
-/// the uri for the mesh element, if present.  If the mesh element is
-/// not present, the new object will be identical to the original.
-/// See parsers::ResolveFilename() for more detail on this operation.
-///
-/// @throws std::runtime_error if the <mesh> tag is present but
-/// missing <uri> or if the file referenced in <uri> can not be found.
+/** Given an sdf::Visual object representing a <visual> element from
+ an SDF file, this method makes a new Visual object which resolves
+ the uri for the mesh element, if present.  If the mesh element is
+ not present, the new object will be identical to the original.
+ See parsers::ResolveFilename() for more detail on this operation.
+
+ @throws std::runtime_error if the <mesh> tag is present but
+ missing <uri> or if the file referenced in <uri> can not be found.  */
 sdf::Visual ResolveVisualUri(const sdf::Visual& original,
                              const multibody::PackageMap& package_map,
                              const std::string& root_dir);

--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -388,10 +388,15 @@ void AddLinksFromSpecification(
         // We check for nullptr in case someone decided to specify an SDF
         // <empty/> geometry.
         if (geometry_instance) {
+          // The parsing should *always* produce an IllustrationProperties
+          // instance, even if it is empty.
+          DRAKE_DEMAND(
+              geometry_instance->illustration_properties() != nullptr);
+
           plant->RegisterVisualGeometry(
               body, geometry_instance->pose(), geometry_instance->shape(),
-              geometry_instance->name(), geometry_instance->visual_material(),
-              scene_graph);
+              geometry_instance->name(),
+              *geometry_instance->illustration_properties());
         }
       }
 

--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -7,7 +7,6 @@
 #include <Eigen/Dense>
 #include <tinyxml2.h>
 
-#include "drake/geometry/visual_material.h"
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/multibody_tree/fixed_offset_frame.h"
 #include "drake/multibody/multibody_tree/joints/prismatic_joint.h"
@@ -26,7 +25,6 @@ using Eigen::Isometry3d;
 using Eigen::Matrix3d;
 using Eigen::Vector3d;
 using Eigen::Vector4d;
-using geometry::VisualMaterial;
 using multibody_plant::CoulombFriction;
 using multibody_plant::MultibodyPlant;
 using tinyxml2::XMLDocument;
@@ -127,10 +125,14 @@ void ParseBody(const multibody::PackageMap& package_map,
          visual_node = visual_node->NextSiblingElement("visual")) {
       geometry::GeometryInstance geometry_instance =
           ParseVisual(body_name, package_map, root_dir, visual_node, materials);
+      // The parsing should *always* produce an IllustrationProperties
+      // instance, even if it is empty.
+      DRAKE_DEMAND(
+          geometry_instance.illustration_properties() != nullptr);
       plant->RegisterVisualGeometry(
           body, geometry_instance.pose(), geometry_instance.shape(),
-          geometry_instance.name(), geometry_instance.visual_material(),
-          scene_graph);
+          geometry_instance.name(),
+          *geometry_instance.illustration_properties(), scene_graph);
     }
 
     for (XMLElement* collision_node = node->FirstChildElement("collision");

--- a/multibody/parsing/test/detail_scene_graph_test.cc
+++ b/multibody/parsing/test/detail_scene_graph_test.cc
@@ -2,10 +2,12 @@
 
 #include <limits>
 #include <memory>
+#include <sstream>
 
 #include <gtest/gtest.h>
 #include "fmt/ostream.h"
 
+#include "drake/common/drake_optional.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/geometry_instance.h"
@@ -25,13 +27,18 @@ using geometry::Box;
 using geometry::Cylinder;
 using geometry::GeometryInstance;
 using geometry::HalfSpace;
+using geometry::IllustrationProperties;
 using geometry::Mesh;
 using geometry::SceneGraph;
 using geometry::Shape;
 using geometry::Sphere;
 using math::RollPitchYaw;
 using math::RotationMatrix;
-using multibody_plant::CoulombFriction;
+using multibody::detail::MakeCoulombFrictionFromSdfCollisionOde;
+using multibody::detail::MakeGeometryInstanceFromSdfVisual;
+using multibody::detail::MakeGeometryPoseFromSdfCollision;
+using multibody::detail::MakeShapeFromSdfGeometry;
+using multibody::detail::MakeVisualPropertiesFromSdfVisual;
 using std::make_unique;
 using std::unique_ptr;
 using systems::Context;
@@ -421,63 +428,171 @@ GTEST_TEST(SceneGraphParserDetail, MakeEmptyGeometryInstanceFromSdfVisual) {
 
 // Verify visual material parsing: default for unspecified, and diffuse color
 // given where specified in the SDF.
-GTEST_TEST(SceneGraphParserDetail, ParseVisualMaterialDiffuse) {
-  using geometry::VisualMaterial;
+GTEST_TEST(SceneGraphParserDetail, ParseVisualMaterial) {
+  using Eigen::Vector4d;
 
-  const VisualMaterial default_material;
+  // Searches the illustration properties for an optional phong material
+  // specification with optional color values.
+  auto expect_phong = [](
+      const IllustrationProperties& dut, bool has_group,
+      const optional<Vector4d> diffuse, const optional<Vector4d> specular,
+      const optional<Vector4d> ambient,
+      const optional<Vector4d> emissive) -> ::testing::AssertionResult {
+    ::testing::AssertionResult failure = ::testing::AssertionFailure();
+    bool success = true;
+    if (has_group) {
+      if (dut.HasGroup("phong")) {
+        auto test_color = [&failure, &success, &dut](
+            const char* name, const optional<Vector4d> ref_color) {
+          const bool has_property = dut.HasProperty("phong", name);
+          if (ref_color) {
+            if (has_property) {
+              const Vector4d& color = dut.GetProperty<Vector4d>("phong", name);
+              auto result = CompareMatrices(*ref_color, color);
+              if (result == ::testing::AssertionFailure()) {
+                success = false;
+                failure << "Incorrect values for '" << name << "':"
+                        << "\n expected: " << (*ref_color)
+                        << "\n found:    " << color;
+              }
+            } else {
+              success = false;
+              failure << ", missing expected property '" << name << "'";
+            }
+          } else {
+            if (has_property) {
+              success = false;
+              failure << ", found unexpected property '" << name << "'";
+            }
+          }
+        };
+        test_color("diffuse", diffuse);
+        test_color("specular", specular);
+        test_color("ambient", ambient);
+        test_color("emissive", emissive);
+      } else {
+        failure << ", missing the expected 'phong' group";
+        success = false;
+      }
+    } else {
+      if (dut.HasGroup("phong")) {
+        failure << ", found unexpected 'phong' group";
+        success = false;
+      }
+    }
+    if (success) {
+      return ::testing::AssertionSuccess();
+    } else {
+      return failure;
+    }
+  };
 
-  // Case: No material defined -- default visual material.
+  // Builds a visual XML tag with an optional <material> tag and optional
+  // color values.
+  auto make_xml = [](bool has_material, Vector4d* diffuse, Vector4d* specular,
+                     Vector4d* ambient, Vector4d* emissive) {
+    std::stringstream ss;
+    ss << "<visual name='some_link_visual'>"
+       << "  <pose>0 0 0 0 0 0</pose>"
+       << "  <geometry>"
+       << "    <sphere>"
+       << "      <radius>1</radius>"
+       << "    </sphere>"
+       << "  </geometry>";
+    if (has_material) {
+      auto write_color = [&ss](const char* name, const Vector4d* color) {
+        if (color) {
+          const Vector4d& c = *color;
+          ss << fmt::format("    <{0}>{1} {2} {3} {4}</{0}>", name,
+                            c(0), c(1), c(2), c(3));
+        }
+      };
+      ss << "  <material>";
+      write_color("diffuse", diffuse);
+      write_color("specular", specular);
+      write_color("ambient", ambient);
+      write_color("emissive", emissive);
+      ss << "  </material>";
+    }
+    ss << "</visual>";
+
+    return ss.str();
+  };
+
+  // Case: No material defined -- empty illustration properties.
   {
     unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(
-        "<visual name='some_link_visual'>"
-        "  <pose>0 0 0 0 0 0</pose>"
-        "  <geometry>"
-        "    <sphere>"
-        "      <radius>1</radius>"
-        "    </sphere>"
-        "  </geometry>"
-        "</visual>");
-    VisualMaterial material = MakeVisualMaterialFromSdfVisual(*sdf_visual);
-    EXPECT_TRUE(CompareMatrices(material.diffuse(), default_material.diffuse(),
-                                0.0, MatrixCompareType::absolute));
+        make_xml(false, nullptr, nullptr, nullptr, nullptr));
+    IllustrationProperties material =
+        MakeVisualPropertiesFromSdfVisual(*sdf_visual);
+    EXPECT_TRUE(
+        expect_phong(material, false, {}, {}, {}, {}));
   }
 
-  // Case: No diffuse defined -- default visual material.
+  // Case: Material tag defined, but no material properties -- empty
+  // illustration properties.
   {
     unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(
-        "<visual name='some_link_visual'>"
-        "  <pose>0 0 0 0 0 0</pose>"
-        "  <geometry>"
-        "    <sphere>"
-        "      <radius>1</radius>"
-        "    </sphere>"
-        "  </geometry>"
-        "  <material>"
-        "  </material>"
-        "</visual>");
-    VisualMaterial material = MakeVisualMaterialFromSdfVisual(*sdf_visual);
-    EXPECT_TRUE(CompareMatrices(material.diffuse(), default_material.diffuse(),
-                                0.0, MatrixCompareType::absolute));
+        make_xml(true, nullptr, nullptr, nullptr, nullptr));
+    IllustrationProperties material =
+        MakeVisualPropertiesFromSdfVisual(*sdf_visual);
+    EXPECT_TRUE(
+        expect_phong(material, false, {}, {}, {}, {}));
   }
 
-  // Case: Valid diffuse material -- visual material as specified.
+  Vector4<double> diffuse{0.25, 0.5, 0.75, 1.0};
+  Vector4<double> specular{0.5, 0.75, 1.0, 0.25};
+  Vector4<double> ambient{0.75, 1.0, 0.25, 0.5};
+  Vector4<double> emissive{1.0, 0.25, 0.5, 0.75};
+
+  // Case: Only valid diffuse material.
   {
     unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(
-        "<visual name='some_link_visual'>"
-        "  <pose>0 0 0 0 0 0</pose>"
-        "  <geometry>"
-        "    <sphere>"
-        "      <radius>1</radius>"
-        "    </sphere>"
-        "  </geometry>"
-        "  <material>"
-        "    <diffuse>0.25 0.5 0.75 1</diffuse>"
-        "  </material>"
-        "</visual>");
-    VisualMaterial material = MakeVisualMaterialFromSdfVisual(*sdf_visual);
-    Vector4<double> expected_diffuse{0.25, 0.5, 0.75, 1.0};
-    EXPECT_TRUE(CompareMatrices(material.diffuse(), expected_diffuse,
-                                0.0, MatrixCompareType::absolute));
+        make_xml(true, &diffuse, nullptr, nullptr, nullptr));
+    IllustrationProperties material =
+        MakeVisualPropertiesFromSdfVisual(*sdf_visual);
+    EXPECT_TRUE(
+        expect_phong(material, true, diffuse, {}, {}, {}));
+  }
+
+  // Case: Only valid specular defined.
+  {
+    unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(
+        make_xml(true, nullptr, &specular, nullptr, nullptr));
+    IllustrationProperties material =
+        MakeVisualPropertiesFromSdfVisual(*sdf_visual);
+    EXPECT_TRUE(
+        expect_phong(material, true, {}, specular, {}, {}));
+  }
+
+  // Case: Only valid ambient defined.
+  {
+    unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(
+        make_xml(true, nullptr, nullptr, &ambient, nullptr));
+    IllustrationProperties material =
+        MakeVisualPropertiesFromSdfVisual(*sdf_visual);
+    EXPECT_TRUE(
+        expect_phong(material, true, {}, {}, ambient, {}));
+  }
+
+  // Case: Only valid emissive defined.
+  {
+    unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(
+        make_xml(true, nullptr, nullptr, nullptr, &emissive));
+    IllustrationProperties material =
+        MakeVisualPropertiesFromSdfVisual(*sdf_visual);
+    EXPECT_TRUE(
+        expect_phong(material, true, {}, {}, {}, emissive));
+  }
+
+  // Case: All four
+  {
+    unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(
+        make_xml(true, &diffuse, &specular, &ambient, &emissive));
+    IllustrationProperties material =
+        MakeVisualPropertiesFromSdfVisual(*sdf_visual);
+    EXPECT_TRUE(
+        expect_phong(material, true, diffuse, specular, ambient, emissive));
   }
 
   // TODO(SeanCurtis-TRI): The following tests capture current behavior for
@@ -506,10 +621,10 @@ GTEST_TEST(SceneGraphParserDetail, ParseVisualMaterialDiffuse) {
         "    <diffuse>0.25 1 0.5 0.25 2</diffuse>"
         "  </material>"
         "</visual>");
-    VisualMaterial material = MakeVisualMaterialFromSdfVisual(*sdf_visual);
+    IllustrationProperties material =
+        MakeVisualPropertiesFromSdfVisual(*sdf_visual);
     Vector4<double> expected_diffuse{0.25, 1, 0.5, 0.25};
-    EXPECT_TRUE(CompareMatrices(material.diffuse(), expected_diffuse,
-                                0.0, MatrixCompareType::absolute));
+    EXPECT_TRUE(expect_phong(material, true, expected_diffuse, {}, {}, {}));
   }
 
   // Case: Too few channel values -- fill in with 0 for b and 1 for alpha.
@@ -526,10 +641,10 @@ GTEST_TEST(SceneGraphParserDetail, ParseVisualMaterialDiffuse) {
         "    <diffuse>0 1</diffuse>"
         "  </material>"
         "</visual>");
-    VisualMaterial material = MakeVisualMaterialFromSdfVisual(*sdf_visual);
+    IllustrationProperties material =
+        MakeVisualPropertiesFromSdfVisual(*sdf_visual);
     Vector4<double> expected_diffuse{0, 1, 0, 1};
-    EXPECT_TRUE(CompareMatrices(material.diffuse(), expected_diffuse,
-                                0.0, MatrixCompareType::absolute));
+    EXPECT_TRUE(expect_phong(material, true, expected_diffuse, {}, {}, {}));
   }
 
   // Case: Values out of range:
@@ -550,10 +665,10 @@ GTEST_TEST(SceneGraphParserDetail, ParseVisualMaterialDiffuse) {
         "    <diffuse>-0.1 255 65025 2</diffuse>"
         "  </material>"
         "</visual>");
-    VisualMaterial material = MakeVisualMaterialFromSdfVisual(*sdf_visual);
+    IllustrationProperties material =
+        MakeVisualPropertiesFromSdfVisual(*sdf_visual);
     Vector4<double> expected_diffuse{0, 1, 255, 1};
-    EXPECT_TRUE(CompareMatrices(material.diffuse(), expected_diffuse, 0.0,
-                                MatrixCompareType::absolute));
+    EXPECT_TRUE(expect_phong(material, true, expected_diffuse, {}, {}, {}));
   }
 }
 

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -49,6 +49,7 @@ drake_cc_library(
         ":implicit_stribeck_solver",
         "//common:default_scalars",
         "//geometry:geometry_ids",
+        "//geometry:geometry_visualization",
         "//geometry:scene_graph",
         "//math:orthonormal_basis",
         "//multibody/multibody_tree",

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -10,6 +10,7 @@
 #include "drake/geometry/frame_kinematics_vector.h"
 #include "drake/geometry/geometry_frame.h"
 #include "drake/geometry/geometry_instance.h"
+#include "drake/geometry/geometry_visualization.h"
 #include "drake/math/orthonormal_basis.h"
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/multibody_tree/joints/prismatic_joint.h"
@@ -258,15 +259,26 @@ geometry::GeometryId MultibodyPlant<T>::RegisterVisualGeometry(
     const Body<T>& body, const Isometry3<double>& X_BG,
     const geometry::Shape& shape, const std::string& name,
     geometry::SceneGraph<T>* scene_graph) {
-  return RegisterVisualGeometry(body, X_BG, shape, name,
-                                geometry::VisualMaterial(), scene_graph);
+  return RegisterVisualGeometry(
+      body, X_BG, shape, name, geometry::IllustrationProperties(), scene_graph);
 }
 
 template <typename T>
 geometry::GeometryId MultibodyPlant<T>::RegisterVisualGeometry(
     const Body<T>& body, const Isometry3<double>& X_BG,
     const geometry::Shape& shape, const std::string& name,
-    const geometry::VisualMaterial& material,
+    const Vector4<double>& diffuse_color,
+    SceneGraph<T>* scene_graph) {
+  return RegisterVisualGeometry(
+      body, X_BG, shape, name,
+      geometry::MakeDrakeVisualizerProperties(diffuse_color), scene_graph);
+}
+
+template <typename T>
+geometry::GeometryId MultibodyPlant<T>::RegisterVisualGeometry(
+    const Body<T>& body, const Isometry3<double>& X_BG,
+    const geometry::Shape& shape, const std::string& name,
+    const geometry::IllustrationProperties& properties,
     SceneGraph<T>* scene_graph) {
   // TODO(SeanCurtis-TRI): Consider simply adding an interface that takes a
   // unique pointer to an already instantiated GeometryInstance. This will
@@ -280,8 +292,8 @@ geometry::GeometryId MultibodyPlant<T>::RegisterVisualGeometry(
   // TODO(amcastro-tri): Consider doing this after finalize so that we can
   // register geometry that has a fixed path to world to the world body (i.e.,
   // as anchored geometry).
-  GeometryId id = RegisterGeometry(body, X_BG, shape, name, material,
-      scene_graph_);
+  GeometryId id = RegisterGeometry(body, X_BG, shape, name, scene_graph_);
+  scene_graph_->AssignRole(*source_id_, id, properties);
   const int visual_index = geometry_id_to_visual_index_.size();
   geometry_id_to_visual_index_[id] = visual_index;
   DRAKE_ASSERT(num_bodies() == static_cast<int>(visual_geometries_.size()));
@@ -305,18 +317,14 @@ geometry::GeometryId MultibodyPlant<T>::RegisterCollisionGeometry(
   DRAKE_THROW_UNLESS(geometry_source_is_registered());
   CheckUserProvidedSceneGraph(scene_graph);
 
-  // We use an "invisible" color with alpha channel set to zero so that
-  // collision geometry does not render on top of visual geometry in our
-  // visualizer.
-  // TODO(amcastro-tri): Remove this "invisible" color once "roles" land in
-  // SceneGraph.
-  const geometry::VisualMaterial invisible_material(
-      Vector4<double>(0.0, 0.0, 0.0, 0.0));
   // TODO(amcastro-tri): Consider doing this after finalize so that we can
   // register geometry that has a fixed path to world to the world body (i.e.,
   // as anchored geometry).
-  GeometryId id = RegisterGeometry(body, X_BG, shape, name, invisible_material,
-      scene_graph_);
+  GeometryId id = RegisterGeometry(body, X_BG, shape, name, scene_graph_);
+  // TODO(SeanCurtis-TRI): Push the contact parameters into the
+  // ProximityProperties.
+  scene_graph_->AssignRole(*source_id_, id, geometry::ProximityProperties());
+
   const int collision_index = geometry_id_to_collision_index_.size();
   geometry_id_to_collision_index_[id] = collision_index;
   DRAKE_ASSERT(
@@ -379,7 +387,6 @@ geometry::GeometryId MultibodyPlant<T>::RegisterGeometry(
     const Body<T>& body, const Isometry3<double>& X_BG,
     const geometry::Shape& shape,
     const std::string& name,
-    const optional<geometry::VisualMaterial>& material,
     SceneGraph<T>* scene_graph) {
   DRAKE_ASSERT(!is_finalized());
   DRAKE_ASSERT(geometry_source_is_registered());
@@ -400,15 +407,9 @@ geometry::GeometryId MultibodyPlant<T>::RegisterGeometry(
   }
 
   // Register geometry in the body frame.
-  std::unique_ptr<geometry::GeometryInstance> geometry_instance;
-  if (material) {
-    geometry_instance = std::make_unique<GeometryInstance>(
-        X_BG, shape.Clone(), name, material.value());
-  } else {
-    geometry_instance =
-        std::make_unique<GeometryInstance>(X_BG, shape.Clone(), name);
-  }
-  GeometryId geometry_id = scene_graph_->RegisterGeometry(
+  std::unique_ptr<geometry::GeometryInstance> geometry_instance =
+      std::make_unique<GeometryInstance>(X_BG, shape.Clone(), name);
+  GeometryId geometry_id = scene_graph->RegisterGeometryWithoutRole(
       source_id_.value(), body_index_to_frame_id_[body.index()],
       std::move(geometry_instance));
   geometry_id_to_body_index_[geometry_id] = body.index();

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1080,8 +1080,8 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   /// @param[in] name
   ///   The name for the geometry. It must satisfy the requirements defined in
   ///   drake::geometry::GeometryInstance.
-  /// @param[in] material
-  ///   The visual material to assign to the geometry.
+  /// @param[in] properties
+  ///   The illustration properties for this geometry.
   /// @param[out] scene_graph
   ///   (Deprecated) A valid non nullptr to a SceneGraph on which geometry will
   ///   get registered.
@@ -1092,11 +1092,22 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   geometry::GeometryId RegisterVisualGeometry(
       const Body<T>& body, const Isometry3<double>& X_BG,
       const geometry::Shape& shape, const std::string& name,
-      const geometry::VisualMaterial& material,
+      const geometry::IllustrationProperties& properties,
       geometry::SceneGraph<T>* scene_graph = nullptr);
 
-  /// Overload for visual geometry registration; it implicitly assigns the
-  /// default material.
+  /// Overload for visual geometry registration; it converts the `diffuse_color`
+  /// (RGBA with values in the range [0, 1]) into a
+  /// geometry::ConnectDrakeVisualizer()-compatible set of
+  /// geometry::IllustrationProperties.
+  geometry::GeometryId RegisterVisualGeometry(
+      const Body<T>& body, const Isometry3<double>& X_BG,
+      const geometry::Shape& shape, const std::string& name,
+      const Vector4<double>& diffuse_color,
+      geometry::SceneGraph<T>* scene_graph = nullptr);
+
+  /// Overload for visual geometry registration; it relies on the downstream
+  /// geometry::IllustrationProperties _consumer_ to provide default parameter
+  /// values (see @ref geometry_roles for details).
   geometry::GeometryId RegisterVisualGeometry(
       const Body<T>& body, const Isometry3<double>& X_BG,
       const geometry::Shape& shape, const std::string& name,
@@ -1759,7 +1770,6 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
       const Body<T>& body, const Isometry3<double>& X_BG,
       const geometry::Shape& shape,
       const std::string& name,
-      const optional<geometry::VisualMaterial>& material,
       geometry::SceneGraph<T>* scene_graph);
 
   bool body_has_registered_frame(const Body<T>& body) const {


### PR DESCRIPTION
This modifies:

1. How MutlibodyPlant interacts with SceneGraph in registering geometry.
2. How parsing (urdf and sdf) parses materials and provides them to MBP.
3. Updates benchmark and examples for MBP.
4. Touch the dev GeometryState conversion -- key on illustration role instead of diffuse value.

```
Category            added  modified  removed  
----------------------------------------------
code                177    85        52       
comments            39     73        8        
blank               18     0         0        
----------------------------------------------
TOTAL               234    158       60  
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10165)
<!-- Reviewable:end -->
