### PR TITLE
multibody/parsing: Move helpers to detail namespace

### DIFF
--- a/attic/multibody/parsers/sdf_parser.cc
+++ b/attic/multibody/parsers/sdf_parser.cc
@@ -50,9 +50,9 @@ using tinyxml2::XMLDocument;
 
 using math::RigidTransformd;
 using math::RollPitchYawd;
+using multibody::detail::GetFullPath;
+using multibody::detail::ResolveFilename;
 using multibody::joints::FloatingBaseType;
-using multibody::parsing::GetFullPath;
-using multibody::parsing::ResolveFilename;
 
 void ParseSdfInertial(
     RigidBody<double>* body, XMLElement* node,

--- a/attic/multibody/parsers/urdf_parser.cc
+++ b/attic/multibody/parsers/urdf_parser.cc
@@ -44,10 +44,10 @@ using tinyxml2::XMLDocument;
 using tinyxml2::XMLElement;
 
 using drake::parsers::ModelInstanceIdTable;
+using drake::multibody::detail::GetFullPath;
+using drake::multibody::detail::ResolveFilename;
 using drake::multibody::joints::FloatingBaseType;
 using drake::multibody::joints::kRollPitchYaw;
-using drake::multibody::parsing::GetFullPath;
-using drake::multibody::parsing::ResolveFilename;
 
 namespace {
 

--- a/multibody/parsing/package_map.cc
+++ b/multibody/parsing/package_map.cc
@@ -15,6 +15,9 @@
 #include "drake/common/drake_throw.h"
 #include "drake/common/text_logging.h"
 
+namespace drake {
+namespace multibody {
+
 using std::cerr;
 using std::endl;
 using std::getenv;
@@ -24,9 +27,6 @@ using std::string;
 using std::vector;
 using tinyxml2::XMLDocument;
 using tinyxml2::XMLElement;
-
-namespace drake {
-namespace multibody {
 
 PackageMap::PackageMap() {}
 

--- a/multibody/parsing/parser.cc
+++ b/multibody/parsing/parser.cc
@@ -8,9 +8,9 @@
 namespace drake {
 namespace multibody {
 
-using parsing::detail::AddModelFromSdfFile;
-using parsing::detail::AddModelFromUrdfFile;
-using parsing::detail::AddModelsFromSdfFile;
+using detail::AddModelFromSdfFile;
+using detail::AddModelFromUrdfFile;
+using detail::AddModelsFromSdfFile;
 
 Parser::Parser(
     multibody_plant::MultibodyPlant<double>* plant,

--- a/multibody/parsing/parser_common.h
+++ b/multibody/parsing/parser_common.h
@@ -4,7 +4,7 @@
 
 namespace drake {
 namespace multibody {
-namespace parsing {
+namespace detail {
 
 // Note:
 //   static global variables are strongly discouraged by the C++ style guide:
@@ -17,6 +17,6 @@ inline multibody_plant::CoulombFriction<double> default_friction() {
   return multibody_plant::CoulombFriction<double>(1.0, 1.0);
 }
 
-}  // namespace parsing
+}  // namespace detail
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/parser_path_utils.cc
+++ b/multibody/parsing/parser_path_utils.cc
@@ -8,11 +8,12 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/text_logging.h"
 
-using std::string;
-
 namespace drake {
 namespace multibody {
-namespace parsing {
+namespace detail {
+
+using std::string;
+
 namespace {
 bool IsAbsolutePath(const string& filename) {
   const string prefix = "/";
@@ -55,7 +56,7 @@ namespace {
 // associated value in the string pointed to by package_path and then returns
 // true. It returns false otherwise.
 bool GetPackagePath(const string& package,
-                    const multibody::PackageMap& package_map,
+                    const PackageMap& package_map,
                     string* package_path) {
   if (package_map.Contains(package)) {
     *package_path = package_map.GetPath(package);
@@ -69,7 +70,7 @@ bool GetPackagePath(const string& package,
 }  // namespace
 
 string ResolveFilename(const string& filename,
-                       const multibody::PackageMap& package_map,
+                       const PackageMap& package_map,
                        const string& root_dir) {
   spruce::path full_filename_spruce;
   spruce::path raw_filename_spruce(filename);
@@ -129,6 +130,6 @@ string ResolveFilename(const string& filename,
   return full_filename_spruce.getStr();
 }
 
-}  // namespace parsing
+}  // namespace detail
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/parser_path_utils.h
+++ b/multibody/parsing/parser_path_utils.h
@@ -6,7 +6,7 @@
 
 namespace drake {
 namespace multibody {
-namespace parsing {
+namespace detail {
 
 /// Obtains the full path of @file_name. If @p file_name is already a
 /// full path (i.e., it starts with a "/"), the path is not modified.
@@ -36,9 +36,9 @@ std::string GetFullPath(const std::string& file_name);
 /// @return The file's full path or an empty string if the file is not
 /// found or does not exist.
 std::string ResolveFilename(const std::string& filename,
-                            const multibody::PackageMap& package_map,
+                            const PackageMap& package_map,
                             const std::string& root_dir);
 
-}  // namespace parsing
+}  // namespace detail
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/scene_graph_parser_detail.cc
+++ b/multibody/parsing/scene_graph_parser_detail.cc
@@ -15,7 +15,6 @@
 
 namespace drake {
 namespace multibody {
-namespace parsing {
 namespace detail {
 
 using Eigen::Isometry3d;
@@ -338,7 +337,7 @@ CoulombFriction<double> MakeCoulombFrictionFromSdfCollisionOde(
 }
 
 sdf::Visual ResolveVisualUri(const sdf::Visual& original,
-                             const multibody::PackageMap& package_map,
+                             const PackageMap& package_map,
                              const std::string& root_dir) {
   std::shared_ptr<sdf::Element> visual_element = original.Element()->Clone();
   sdf::Element* geom_element =
@@ -350,7 +349,7 @@ sdf::Visual ResolveVisualUri(const sdf::Visual& original,
       if (uri_element) {
         const std::string uri = uri_element->Get<std::string>();
         const std::string resolved_name =
-            parsing::ResolveFilename(uri, package_map, root_dir);
+            ResolveFilename(uri, package_map, root_dir);
         if (!resolved_name.empty()) {
           uri_element->Set(resolved_name);
         } else {
@@ -373,7 +372,5 @@ sdf::Visual ResolveVisualUri(const sdf::Visual& original,
 }
 
 }  // namespace detail
-
-}  // namespace parsing
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/scene_graph_parser_detail.h
+++ b/multibody/parsing/scene_graph_parser_detail.h
@@ -11,7 +11,6 @@
 
 namespace drake {
 namespace multibody {
-namespace parsing {
 namespace detail {
 
 /// Given an sdf::Geometry object representing a <geometry> element from an SDF
@@ -103,6 +102,5 @@ sdf::Visual ResolveVisualUri(const sdf::Visual& original,
                              const std::string& root_dir);
 
 }  // namespace detail
-}  // namespace parsing
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/sdf_parser.cc
+++ b/multibody/parsing/sdf_parser.cc
@@ -20,24 +20,16 @@
 
 namespace drake {
 namespace multibody {
-namespace parsing {
 namespace detail {
 
 using Eigen::Isometry3d;
 using Eigen::Matrix3d;
 using Eigen::Translation3d;
 using Eigen::Vector3d;
-using drake::geometry::GeometryInstance;
-using drake::geometry::SceneGraph;
-using drake::multibody::multibody_plant::CoulombFriction;
-using drake::multibody::multibody_plant::MultibodyPlant;
-using drake::multibody::parsing::detail::ToIsometry3;
-using drake::multibody::parsing::detail::ToVector3;
-using drake::multibody::RevoluteJoint;
-using drake::multibody::SpatialInertia;
-using drake::multibody::UniformGravityFieldElement;
-using drake::multibody::UnitInertia;
-using drake::multibody::WeldJoint;
+using geometry::GeometryInstance;
+using geometry::SceneGraph;
+using multibody_plant::CoulombFriction;
+using multibody_plant::MultibodyPlant;
 using std::unique_ptr;
 
 // Unnamed namespace for free functions local to this file.
@@ -327,10 +319,10 @@ void AddJointFromSpecification(
 // object.
 std::string LoadSdf(
     sdf::Root* root,
-    multibody::PackageMap* package_map,
+    PackageMap* package_map,
     const std::string& file_name) {
 
-  const std::string full_path = parsing::GetFullPath(file_name);
+  const std::string full_path = GetFullPath(file_name);
 
   // Load the SDF file.
   sdf::Errors errors = root->Load(full_path);
@@ -364,7 +356,7 @@ void AddLinksFromSpecification(
     const sdf::Model& model,
     multibody_plant::MultibodyPlant<double>* plant,
     geometry::SceneGraph<double>* scene_graph,
-    const multibody::PackageMap& package_map,
+    const PackageMap& package_map,
     const std::string& root_dir) {
 
   // Add all the links
@@ -389,10 +381,10 @@ void AddLinksFromSpecification(
     if (plant->geometry_source_is_registered()) {
       for (uint64_t visual_index = 0; visual_index < link.VisualCount();
            ++visual_index) {
-        const sdf::Visual sdf_visual = detail::ResolveVisualUri(
+        const sdf::Visual sdf_visual = ResolveVisualUri(
             *link.VisualByIndex(visual_index), package_map, root_dir);
         unique_ptr<GeometryInstance> geometry_instance =
-            detail::MakeGeometryInstanceFromSdfVisual(sdf_visual);
+            MakeGeometryInstanceFromSdfVisual(sdf_visual);
         // We check for nullptr in case someone decided to specify an SDF
         // <empty/> geometry.
         if (geometry_instance) {
@@ -410,11 +402,11 @@ void AddLinksFromSpecification(
         const sdf::Geometry& sdf_geometry = *sdf_collision.Geom();
         if (sdf_geometry.Type() != sdf::GeometryType::EMPTY) {
           const Isometry3d X_LG =
-              detail::MakeGeometryPoseFromSdfCollision(sdf_collision);
+              MakeGeometryPoseFromSdfCollision(sdf_collision);
           std::unique_ptr<geometry::Shape> shape =
-              detail::MakeShapeFromSdfGeometry(sdf_geometry);
+              MakeShapeFromSdfGeometry(sdf_geometry);
           const CoulombFriction<double> coulomb_friction =
-              detail::MakeCoulombFrictionFromSdfCollisionOde(sdf_collision);
+              MakeCoulombFrictionFromSdfCollisionOde(sdf_collision);
           plant->RegisterCollisionGeometry(body, X_LG, *shape,
                                            sdf_collision.Name(),
                                            coulomb_friction, scene_graph);
@@ -475,7 +467,7 @@ ModelInstanceIndex AddModelFromSpecification(
     const std::string& model_name,
     multibody_plant::MultibodyPlant<double>* plant,
     geometry::SceneGraph<double>* scene_graph,
-    const multibody::PackageMap& package_map,
+    const PackageMap& package_map,
     const std::string& root_dir) {
 
   const ModelInstanceIndex model_instance =
@@ -526,7 +518,7 @@ ModelInstanceIndex AddModelFromSdfFile(
   DRAKE_THROW_UNLESS(!plant->is_finalized());
 
   sdf::Root root;
-  multibody::PackageMap package_map;
+  PackageMap package_map;
 
   std::string root_dir = LoadSdf(&root, &package_map, file_name);
 
@@ -556,7 +548,7 @@ std::vector<ModelInstanceIndex> AddModelsFromSdfFile(
   DRAKE_THROW_UNLESS(!plant->is_finalized());
 
   sdf::Root root;
-  multibody::PackageMap package_map;
+  PackageMap package_map;
 
   std::string root_dir = LoadSdf(&root, &package_map, file_name);
 
@@ -610,6 +602,5 @@ std::vector<ModelInstanceIndex> AddModelsFromSdfFile(
 }
 
 }  // namespace detail
-}  // namespace parsing
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/sdf_parser.h
+++ b/multibody/parsing/sdf_parser.h
@@ -10,7 +10,6 @@
 
 namespace drake {
 namespace multibody {
-namespace parsing {
 namespace detail {
 
 /// Parses a `<model>` element from the SDF file specified by `file_name` and
@@ -74,6 +73,7 @@ std::vector<ModelInstanceIndex> AddModelsFromSdfFile(
 
 #ifndef DRAKE_DOXYGEN_CXX
 // TODO(jwnimmer-tri) Remove these forwarders on or about 2019-03-01.
+namespace parsing {
 
 DRAKE_DEPRECATED(
     "AddModelFromSdfFile is deprecated; please use the class "
@@ -108,8 +108,8 @@ inline std::vector<ModelInstanceIndex> AddModelsFromSdfFile(
   return detail::AddModelsFromSdfFile(file_name, plant, scene_graph);
 }
 
+}  // namespace parsing
 #endif  // DRAKE_DOXYGEN_CXX
 
-}  // namespace parsing
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/sdf_parser_common.cc
+++ b/multibody/parsing/sdf_parser_common.cc
@@ -2,7 +2,6 @@
 
 namespace drake {
 namespace multibody {
-namespace parsing {
 namespace detail {
 
 using Eigen::Isometry3d;
@@ -20,6 +19,5 @@ Isometry3d ToIsometry3(const ignition::math::Pose3d& pose) {
 }
 
 }  // namespace detail
-}  // namespace parsing
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/sdf_parser_common.h
+++ b/multibody/parsing/sdf_parser_common.h
@@ -6,7 +6,6 @@
 
 namespace drake {
 namespace multibody {
-namespace parsing {
 namespace detail {
 
 /// Helper function to express an ignition::math::Vector3d instance as
@@ -18,6 +17,5 @@ Eigen::Vector3d ToVector3(const ignition::math::Vector3d& vector);
 Eigen::Isometry3d ToIsometry3(const ignition::math::Pose3d& pose);
 
 }  // namespace detail
-}  // namespace parsing
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/test/acrobot_parser_test.cc
+++ b/multibody/parsing/test/acrobot_parser_test.cc
@@ -20,10 +20,7 @@
 
 namespace drake {
 namespace multibody {
-namespace parsing {
 namespace {
-
-using multibody_plant::MultibodyPlant;
 
 class AcrobotModelTests :
       public testing::TestWithParam<test::ModelLoadFunction> {
@@ -177,6 +174,5 @@ INSTANTIATE_TEST_CASE_P(UrdfAcrobatModelTests,
 
 
 }  // namespace
-}  // namespace parsing
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/test/common_parser_test.cc
+++ b/multibody/parsing/test/common_parser_test.cc
@@ -17,7 +17,7 @@
 
 namespace drake {
 namespace multibody {
-namespace parsing {
+namespace detail {
 namespace {
 
 using geometry::GeometryId;
@@ -144,7 +144,7 @@ TEST_P(MultibodyPlantLinkTests, LinksWithCollisions) {
   // not specify them in the SDF file.
   EXPECT_TRUE(
       plant_.default_coulomb_friction(link3_collision_geometry_ids[0]) ==
-      parsing::default_friction());
+      default_friction());
 }
 
 
@@ -157,6 +157,6 @@ INSTANTIATE_TEST_CASE_P(UrdfMultibodyPlantLinkTests,
                         ::testing::Values(test::LoadFromUrdf));
 
 }  // namespace
-}  // namespace parsing
+}  // namespace detail
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/test/parser_path_utils_test.cc
+++ b/multibody/parsing/test/parser_path_utils_test.cc
@@ -10,7 +10,7 @@ using std::string;
 
 namespace drake {
 namespace multibody {
-namespace parsing {
+namespace detail {
 namespace {
 
 // Verifies that GetFullPath() promotes a relative path to an absolute path,
@@ -49,6 +49,6 @@ GTEST_TEST(ParserPathUtilsTest, TestGetFullPathOfEmptyPath) {
 }
 
 }  // namespace
-}  // namespace parsing
+}  // namespace detail
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/test/scene_graph_parser_detail_test.cc
+++ b/multibody/parsing/test/scene_graph_parser_detail_test.cc
@@ -15,7 +15,7 @@
 
 namespace drake {
 namespace multibody {
-namespace multibody_plant {
+namespace detail {
 namespace {
 
 using Eigen::Isometry3d;
@@ -31,11 +31,7 @@ using geometry::Shape;
 using geometry::Sphere;
 using math::RollPitchYaw;
 using math::RotationMatrix;
-using multibody::parsing::detail::MakeCoulombFrictionFromSdfCollisionOde;
-using multibody::parsing::detail::MakeGeometryInstanceFromSdfVisual;
-using multibody::parsing::detail::MakeGeometryPoseFromSdfCollision;
-using multibody::parsing::detail::MakeShapeFromSdfGeometry;
-using multibody::parsing::detail::MakeVisualMaterialFromSdfVisual;
+using multibody_plant::CoulombFriction;
 using std::make_unique;
 using std::unique_ptr;
 using systems::Context;
@@ -785,7 +781,7 @@ GTEST_TEST(SceneGraphParserDetail,
 }
 
 }  // namespace
-}  // namespace multibody_plant
+}  // namespace detail
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/parsing/test/sdf_parser_test.cc
+++ b/multibody/parsing/test/sdf_parser_test.cc
@@ -13,10 +13,12 @@
 #include "drake/math/rigid_transform.h"
 #include "drake/math/roll_pitch_yaw.h"
 #include "drake/multibody/multibody_tree/multibody_plant/multibody_plant.h"
-#include "drake/multibody/parsing/sdf_parser_common.h"
 #include "drake/systems/framework/context.h"
 
 namespace drake {
+namespace multibody {
+namespace detail {
+namespace {
 
 using Eigen::Isometry3d;
 using Eigen::Vector3d;
@@ -27,17 +29,8 @@ using math::RigidTransform;
 using math::RigidTransformd;
 using math::RollPitchYaw;
 using math::RollPitchYawd;
-using multibody::Body;
-using multibody::parsing::detail::AddModelFromSdfFile;
-using multibody::parsing::detail::AddModelsFromSdfFile;
-using multibody::parsing::detail::ToIsometry3;
-using multibody::multibody_plant::MultibodyPlant;
+using multibody_plant::MultibodyPlant;
 using systems::Context;
-
-namespace multibody {
-namespace parsing {
-namespace detail {
-namespace {
 
 // Verifies model instances are correctly created in the plant.
 GTEST_TEST(MultibodyPlantSdfParserTest, ModelInstanceTest) {
@@ -280,6 +273,5 @@ GTEST_TEST(SdfParser, TestOptionalSceneGraph) {
 
 }  // namespace
 }  // namespace detail
-}  // namespace parsing
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/test/test_loaders.cc
+++ b/multibody/parsing/test/test_loaders.cc
@@ -6,7 +6,6 @@
 
 namespace drake {
 namespace multibody {
-namespace parsing {
 namespace test {
 
 void LoadFromSdf(
@@ -17,7 +16,7 @@ void LoadFromSdf(
   // the "name" attribute of the SDF.  This is a sensible default for the unit
   // tests that call us.
   const std::string sdf_path = FindResourceOrThrow(base_name + ".sdf");
-  parsing::detail::AddModelFromSdfFile(sdf_path, "", plant, scene_graph);
+  detail::AddModelFromSdfFile(sdf_path, "", plant, scene_graph);
 }
 
 void LoadFromUrdf(
@@ -28,10 +27,9 @@ void LoadFromUrdf(
   // the "name" attribute of the URDF.  This is a sensible default for the unit
   // tests that call us.
   const std::string urdf_path = FindResourceOrThrow(base_name + ".urdf");
-  parsing::detail::AddModelFromUrdfFile(urdf_path, "", plant, scene_graph);
+  detail::AddModelFromUrdfFile(urdf_path, "", plant, scene_graph);
 }
 
 }  // namespace test
-}  // namespace parsing
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/test/test_loaders.h
+++ b/multibody/parsing/test/test_loaders.h
@@ -8,7 +8,6 @@
 
 namespace drake {
 namespace multibody {
-namespace parsing {
 namespace test {
 
 /// This is a function signature used to parameterize unit tests by which
@@ -33,6 +32,5 @@ void LoadFromUrdf(
     geometry::SceneGraph<double>* scene_graph);
 
 }  // namespace test
-}  // namespace parsing
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/test/tinyxml_util_test.cc
+++ b/multibody/parsing/test/tinyxml_util_test.cc
@@ -11,7 +11,6 @@ using tinyxml2::XMLElement;
 
 namespace drake {
 namespace multibody {
-namespace parsing {
 namespace detail {
 namespace {
 
@@ -115,6 +114,5 @@ GTEST_TEST(TinyxmlUtilTest, ThreeVectorAttributeTest) {
 
 }  // namespace
 }  // namespace detail
-}  // namespace parsing
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/test/urdf_geometry_test.cc
+++ b/multibody/parsing/test/urdf_geometry_test.cc
@@ -13,7 +13,6 @@
 
 namespace drake {
 namespace multibody {
-namespace parsing {
 namespace detail {
 namespace {
 
@@ -24,13 +23,12 @@ using geometry::GeometryInstance;
 using geometry::VisualMaterial;
 using multibody_plant::CoulombFriction;
 
-
 class UrdfGeometryTests : public testing::Test {
  public:
   // Loads a URDF file and parses the minimal amount of it which
   // urdf_geometry.cc handles.
   void ParseUrdfGeometry(const std::string& file_name) {
-    const std::string full_path = parsing::GetFullPath(file_name);
+    const std::string full_path = GetFullPath(file_name);
 
     xml_doc_.LoadFile(full_path.c_str());
     ASSERT_FALSE(xml_doc_.ErrorID()) << xml_doc_.ErrorName();
@@ -252,6 +250,5 @@ TEST_F(UrdfGeometryTests, TestWrongElementType) {
 
 }  // namespace
 }  // namespace detail
-}  // namespace parsing
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/test/urdf_parser_test.cc
+++ b/multibody/parsing/test/urdf_parser_test.cc
@@ -5,20 +5,16 @@
 #include "drake/common/find_resource.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/math/rigid_transform.h"
-#include "drake/multibody/parsing/parser_common.h"
 
 namespace drake {
+namespace multibody {
+namespace detail {
+namespace {
 
 using Eigen::Vector3d;
 using geometry::GeometryId;
 using geometry::SceneGraph;
-using multibody::parsing::default_friction;
-using multibody::multibody_plant::MultibodyPlant;
-
-namespace multibody {
-namespace parsing {
-namespace detail {
-namespace {
+using multibody_plant::MultibodyPlant;
 
 GTEST_TEST(MultibodyPlantUrdfParserTest, DoublePendulum) {
   MultibodyPlant<double> plant;
@@ -111,6 +107,5 @@ GTEST_TEST(MultibodyPlantUrdfParserTest, TestOptionalSceneGraph) {
 
 }  // namespace
 }  // namespace detail
-}  // namespace parsing
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/tinyxml_util.cc
+++ b/multibody/parsing/tinyxml_util.cc
@@ -9,10 +9,9 @@
 
 namespace drake {
 namespace multibody {
-namespace parsing {
 namespace detail {
-namespace {
 
+namespace {
 std::vector<double> ConvertToDoubles(const std::string& str) {
   std::istringstream ss(str);
 
@@ -23,7 +22,6 @@ std::vector<double> ConvertToDoubles(const std::string& str) {
   }
   return out;
 }
-
 }  // namespace
 
 bool ParseStringAttribute(const tinyxml2::XMLElement* node,
@@ -128,6 +126,5 @@ bool ParseThreeVectorAttribute(const tinyxml2::XMLElement* node,
 }
 
 }  // namespace detail
-}  // namespace parsing
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/tinyxml_util.h
+++ b/multibody/parsing/tinyxml_util.h
@@ -7,7 +7,6 @@
 
 namespace drake {
 namespace multibody {
-namespace parsing {
 namespace detail {
 
 /// Parses a string attribute of @p node named @p attribute_name into @p val.
@@ -79,6 +78,5 @@ bool ParseThreeVectorAttribute(const tinyxml2::XMLElement* node,
                                Eigen::Vector3d* val);
 
 }  // namespace detail
-}  // namespace parsing
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/urdf_geometry.cc
+++ b/multibody/parsing/urdf_geometry.cc
@@ -15,14 +15,12 @@
 
 namespace drake {
 namespace multibody {
-namespace parsing {
 namespace detail {
 
 using Eigen::Isometry3d;
 using Eigen::Vector3d;
 using Eigen::Vector4d;
 using tinyxml2::XMLElement;
-
 using multibody_plant::CoulombFriction;
 
 namespace {
@@ -96,7 +94,7 @@ void ParseMaterial(const XMLElement* node, MaterialMap* materials) {
   const XMLElement* color_node = node->FirstChildElement("color");
 
   if (color_node) {
-    if (!detail::ParseVectorAttribute(color_node, "rgba", &rgba)) {
+    if (!ParseVectorAttribute(color_node, "rgba", &rgba)) {
       throw std::runtime_error("Color tag is missing rgba attribute.");
     }
     AddMaterialToMaterialMap(name, rgba, true /* abort_if_name_clash */,
@@ -169,7 +167,7 @@ std::unique_ptr<geometry::Shape> ParseCylinder(const XMLElement* shape_node) {
 }
 
 std::unique_ptr<geometry::Shape> ParseMesh(
-    const XMLElement* shape_node, const multibody::PackageMap& package_map,
+    const XMLElement* shape_node, const PackageMap& package_map,
     const std::string& root_dir) {
   std::string filename;
   if (!ParseStringAttribute(shape_node, "filename", &filename)) {
@@ -203,7 +201,7 @@ std::unique_ptr<geometry::Shape> ParseMesh(
 }
 
 std::unique_ptr<geometry::Shape> ParseGeometry(
-    const XMLElement* node, const multibody::PackageMap& package_map,
+    const XMLElement* node, const PackageMap& package_map,
     const std::string& root_dir) {
   if (node->FirstChildElement("box")) {
     return ParseBox(node->FirstChildElement("box"));
@@ -245,7 +243,7 @@ std::string MakeGeometryName(const std::string& basename,
 // Parses a "visual" element in @p node.
 geometry::GeometryInstance ParseVisual(
     const std::string& parent_element_name,
-    const multibody::PackageMap& package_map,
+    const PackageMap& package_map,
     const std::string& root_dir, const XMLElement* node,
     MaterialMap* materials) {
   if (std::string(node->Name()) != "visual") {
@@ -363,7 +361,7 @@ geometry::GeometryInstance ParseVisual(
 // @param[out] friction Coulomb friction for the associated geometry.
 geometry::GeometryInstance ParseCollision(
     const std::string& parent_element_name,
-    const multibody::PackageMap& package_map,
+    const PackageMap& package_map,
     const std::string& root_dir, const XMLElement* node,
     CoulombFriction<double>* friction) {
   if (std::string(node->Name()) != "collision") {
@@ -458,6 +456,5 @@ geometry::GeometryInstance ParseCollision(
 }
 
 }  // namespace detail
-}  // namespace parsing
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/urdf_geometry.h
+++ b/multibody/parsing/urdf_geometry.h
@@ -14,7 +14,6 @@
 
 namespace drake {
 namespace multibody {
-namespace parsing {
 namespace detail {
 
 /// A map from the name of a material to its color. The color is specified in
@@ -40,7 +39,7 @@ void ParseMaterial(const tinyxml2::XMLElement* node, MaterialMap* materials);
 /// repeated if the material properties are identical.
 geometry::GeometryInstance ParseVisual(
     const std::string& parent_element_name,
-    const multibody::PackageMap& package_map,
+    const PackageMap& package_map,
     const std::string& root_dir, const tinyxml2::XMLElement* node,
     MaterialMap* materials);
 
@@ -51,11 +50,10 @@ geometry::GeometryInstance ParseVisual(
 /// @param[out] friction Coulomb friction for the associated geometry.
 geometry::GeometryInstance ParseCollision(
     const std::string& parent_element_name,
-    const multibody::PackageMap& package_map,
+    const PackageMap& package_map,
     const std::string& root_dir, const tinyxml2::XMLElement* node,
     multibody_plant::CoulombFriction<double>* friction);
 
 }  /// namespace detail
-}  /// namespace parsing
 }  /// namespace multibody
 }  /// namespace drake

--- a/multibody/parsing/urdf_parser.h
+++ b/multibody/parsing/urdf_parser.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <string>
-#include <vector>
 
 #include "drake/common/drake_deprecated.h"
 #include "drake/geometry/scene_graph.h"
@@ -10,7 +9,6 @@
 
 namespace drake {
 namespace multibody {
-namespace parsing {
 namespace detail {
 
 /// Parses a `<robot>` element from the URDF file specified by @p file_name and
@@ -42,6 +40,7 @@ ModelInstanceIndex AddModelFromUrdfFile(
 
 #ifndef DRAKE_DOXYGEN_CXX
 // TODO(jwnimmer-tri) Remove these forwarders on or about 2019-03-01.
+namespace parsing {
 
 DRAKE_DEPRECATED(
     "AddModelFromUrdfFile is deprecated; please use the class "
@@ -66,8 +65,8 @@ inline ModelInstanceIndex AddModelFromUrdfFile(
       file_name, "", plant, scene_graph);
 }
 
+}  // namespace parsing
 #endif  // DRAKE_DOXYGEN_CXX
 
-}  // namespace parsing
 }  // namespace multibody
 }  // namespace drake


### PR DESCRIPTION
This removes the `multibody::parsing` namespace (with the exception of a few deprecation forwarders).

The next (and final) parsing PR after this one will rename all of these files to have "detail" and be package-private in the build system.

Relates #9314.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10166)
<!-- Reviewable:end -->
