### PR TITLE
bazelrc: Prevent LCM messages from leaking out of tests

### DIFF
--- a/automotive/test/steering_command_driver_test.py
+++ b/automotive/test/steering_command_driver_test.py
@@ -1,4 +1,3 @@
-import lcm
 import unittest
 
 from drake.lcmt_driving_command_t import lcmt_driving_command_t as lcm_msg
@@ -8,24 +7,11 @@ from drake.automotive.steering_command_driver import make_driving_command
 class SteeringCommandDriverTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super(SteeringCommandDriverTest, self).__init__(*args, **kwargs)
-        self.lcm_tag = "EXAMPLE"
         self.acceleration = 0.5
         self.steering_angle = 0.2
         self.is_handler_run = False
 
-    def handler(self, channel, data):
-        msg = lcm_msg.decode(data)
+    def test_make_driving_command(self):
+        msg = make_driving_command(self.acceleration, self.steering_angle)
         self.assertEqual(msg.acceleration, self.acceleration)
         self.assertEqual(msg.steering_angle, self.steering_angle)
-        self.is_handler_run = True
-
-    def test_make_driving_command(self):
-        receiver = lcm.LCM()
-        subscription = receiver.subscribe(self.lcm_tag, self.handler)
-        sender = lcm.LCM()
-        sender.publish(self.lcm_tag,
-                       make_driving_command(self.acceleration,
-                                            self.steering_angle).encode())
-        receiver.handle()
-        receiver.unsubscribe(subscription)
-        self.assertTrue(self.is_handler_run)

--- a/systems/lcm/test/lcm_driven_loop_test.cc
+++ b/systems/lcm/test/lcm_driven_loop_test.cc
@@ -16,6 +16,9 @@ namespace {
 
 const int kStart = 3;
 const int kEnd = 10;
+// Use a slight perturbation of the default URL.
+// TODO(eric.cousineau): Make this URL be unique to each workspace / test run.
+const char kLcmUrl[] = "udpm://239.255.76.67:7668";
 
 // Converts millisecond timestamp field to second.
 class MilliSecTimeStampMessageToSeconds : public LcmMessageToTimeInterface {
@@ -53,7 +56,7 @@ class DummySys : public systems::LeafSystem<double> {
 // Dummy publish thread. Usleeps so that the dut thread has enough time to
 // process.
 void publish() {
-  ::lcm::LCM lcm;
+  ::lcm::LCM lcm(kLcmUrl);
   lcmt_drake_signal msg;
   msg.dim = 0;
   msg.val.resize(msg.dim);
@@ -78,7 +81,7 @@ void publish() {
 // a DummySys and a SignalLogger. The intended behavior is that every time
 // a new Lcm message arrives, its timestamp will be logged by the SignalLogger.
 GTEST_TEST(LcmDrivenLoopTest, TestLoop) {
-  drake::lcm::DrakeLcm lcm;
+  drake::lcm::DrakeLcm lcm(kLcmUrl);
   DiagramBuilder<double> builder;
 
   // Makes the test system.

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -34,6 +34,13 @@ test --test_env=GRB_LICENSE_FILE
 # caching performance.
 test --test_env=MOSEKLM_LICENSE_FILE
 
+# Prevent LCM messages from leaking outside of tests.
+# See documentation: https://lcm-proj.github.io/group__LcmC__lcm__t.html#gaf29963ef43edadf45296d5ad82c18d4b  # noqa
+# WARNING: If your LCM test depends on communication between separate LCM
+# instances (and you cannot easily mock the LCM instances), make sure that each
+# instance has a consistent, but non-default, LCM URL.
+test --test_env=LCM_DEFAULT_URL=memq://
+
 ### A configuration that enables Gurobi. ###
 # -- To use this config, the GRB_LICENSE_FILE environment variable must be set
 # -- to the location of the Gurobi license key file. On Ubuntu, the GUROBI_PATH


### PR DESCRIPTION
Resolves #5782 

This may be less than ideal, because `memq://` will prevent multiple LCM instances from talking to each other, thus someone will get mysterious failures when using `bazel test` vs. `bazel run`, so it'd be crappy to make this happen without some sort of announcement or whatever.

Alternatively, we could just try to obfuscate the `LCM_DEFAULT_URL` to something non-default, but that means we may still have tests collide or leak their information out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10172)
<!-- Reviewable:end -->
