### PR TITLE
py2and3: Minor compatibility updates

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -91,6 +91,14 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "test_util_pybind",
+    testonly = 1,
+    hdrs = ["test/test_util_pybind.h"],
+    declare_installed_headers = 0,
+    visibility = ["//visibility:public"],
+)
+
+drake_cc_library(
     name = "autodiff_types_pybind",
     hdrs = ["autodiff_types_pybind.h"],
     declare_installed_headers = 0,

--- a/bindings/pydrake/common/BUILD.bazel
+++ b/bindings/pydrake/common/BUILD.bazel
@@ -340,7 +340,10 @@ drake_py_unittest(
 
 drake_pybind_cc_googletest(
     name = "cpp_param_pybind_test",
-    cc_deps = [":cpp_param_pybind"],
+    cc_deps = [
+        ":cpp_param_pybind",
+        "//bindings/pydrake:test_util_pybind",
+    ],
     py_deps = [":cpp_param_py"],
 )
 
@@ -355,6 +358,7 @@ drake_pybind_cc_googletest(
     name = "cpp_template_pybind_test",
     cc_deps = [
         ":cpp_template_pybind",
+        "//bindings/pydrake:test_util_pybind",
         "//common:nice_type_name",
         "//common/test_utilities:expect_throws_message",
     ],
@@ -365,6 +369,7 @@ drake_pybind_cc_googletest(
     name = "drake_variant_pybind_test",
     cc_deps = [
         ":drake_variant_pybind",
+        "//bindings/pydrake:test_util_pybind",
     ],
 )
 
@@ -391,6 +396,7 @@ drake_pybind_cc_googletest(
     name = "type_safe_index_pybind_test",
     cc_deps = [
         ":type_safe_index_pybind",
+        "//bindings/pydrake:test_util_pybind",
         "//common:nice_type_name",
     ],
 )

--- a/bindings/pydrake/common/test/cpp_param_pybind_test.cc
+++ b/bindings/pydrake/common/test/cpp_param_pybind_test.cc
@@ -11,6 +11,8 @@
 #include "pybind11/eval.h"
 #include "pybind11/pybind11.h"
 
+#include "drake/bindings/pydrake/test/test_util_pybind.h"
+
 using std::string;
 
 namespace drake {
@@ -86,8 +88,7 @@ int main(int argc, char** argv) {
   // Define custom class only once here.
   py::class_<CustomCppType>(m, "CustomCppType");
 
-  // For Python3
-  py::globals().attr("update")(m.attr("__dict__"));
+  test::SynchronizeGlobalsForPython3(m);
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/bindings/pydrake/common/test/drake_variant_pybind_test.cc
+++ b/bindings/pydrake/common/test/drake_variant_pybind_test.cc
@@ -36,6 +36,7 @@ GTEST_TEST(VariantTest, CheckCasting) {
   py::module m("__main__");
 
   m.def("VariantToString", &VariantToString, py::arg("value"));
+  py::globals().attr("update")(m.attr("__dict__"));
   ExpectString("VariantToString(1)", "int(1)");
   ExpectString("VariantToString(0.5)", "double(0.5)");
   ExpectString("VariantToString('foo')", "string(foo)");

--- a/bindings/pydrake/common/test/drake_variant_pybind_test.cc
+++ b/bindings/pydrake/common/test/drake_variant_pybind_test.cc
@@ -10,12 +10,15 @@
 #include "pybind11/pybind11.h"
 
 #include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/bindings/pydrake/test/test_util_pybind.h"
 
 using std::string;
 
 namespace drake {
 namespace pydrake {
 namespace {
+
+using test::SynchronizeGlobalsForPython3;
 
 string VariantToString(const variant<int, double, string>& value) {
   const bool is_int = holds_alternative<int>(value);
@@ -36,7 +39,7 @@ GTEST_TEST(VariantTest, CheckCasting) {
   py::module m("__main__");
 
   m.def("VariantToString", &VariantToString, py::arg("value"));
-  py::globals().attr("update")(m.attr("__dict__"));
+  SynchronizeGlobalsForPython3(m);
   ExpectString("VariantToString(1)", "int(1)");
   ExpectString("VariantToString(0.5)", "double(0.5)");
   ExpectString("VariantToString('foo')", "string(foo)");

--- a/bindings/pydrake/common/test/type_safe_index_pybind_test.cc
+++ b/bindings/pydrake/common/test/type_safe_index_pybind_test.cc
@@ -11,12 +11,16 @@
 #include "pybind11/eval.h"
 #include "pybind11/pybind11.h"
 
+#include "drake/bindings/pydrake/test/test_util_pybind.h"
+
 using std::string;
 using std::vector;
 
 namespace drake {
 namespace pydrake {
 namespace {
+
+using test::SynchronizeGlobalsForPython3;
 
 template <typename T>
 void CheckValue(const string& expr, const T& expected) {
@@ -34,7 +38,7 @@ GTEST_TEST(TypeSafeIndexTest, CheckCasting) {
     EXPECT_EQ(x, 10);
     return x;
   });
-  py::globals().attr("update")(m.attr("__dict__"));  // For Python3
+  SynchronizeGlobalsForPython3(m);
   CheckValue("pass_thru_int(10)", 10);
   CheckValue("pass_thru_int(Index(10))", 10);
   // TypeSafeIndex<> is not implicitly constructible from an int.
@@ -46,7 +50,7 @@ GTEST_TEST(TypeSafeIndexTest, CheckCasting) {
     return x;
   });
 
-  py::globals().attr("update")(m.attr("__dict__"));  // For Python3
+  SynchronizeGlobalsForPython3(m);
 
   // TypeSafeIndex<> is not implicitly constructible from an int.
   // TODO(eric.cousineau): Consider relaxing this to *only* accept `int`s, and

--- a/bindings/pydrake/manipulation/simple_ui.py
+++ b/bindings/pydrake/manipulation/simple_ui.py
@@ -3,7 +3,10 @@ Provides a number of tcl/tk-based user interfaces helpful for manipulation (
 and potentially other robotics) applications.
 """
 
-import Tkinter as tk
+try:
+    import tkinter as tk
+except ImportError:
+    import Tkinter as tk
 import numpy as np
 
 from pydrake.multibody.multibody_tree.multibody_plant import MultibodyPlant

--- a/bindings/pydrake/manipulation/test/simple_ui_test.py
+++ b/bindings/pydrake/manipulation/test/simple_ui_test.py
@@ -5,7 +5,10 @@ from pydrake.manipulation.simple_ui import JointSliders, SchunkWsgButtons
 import unittest
 
 import numpy as np
-import Tkinter as tk
+try:
+    import tkinter as tk
+except ImportError:
+    import Tkinter as tk
 
 from pydrake.common import FindResourceOrThrow
 from pydrake.multibody.multibody_tree.multibody_plant import MultibodyPlant

--- a/bindings/pydrake/systems/drawing.py
+++ b/bindings/pydrake/systems/drawing.py
@@ -6,7 +6,6 @@ Note:
     installed.
 """
 
-from sys import maxint
 from tempfile import NamedTemporaryFile
 
 import matplotlib.pyplot as plt
@@ -38,6 +37,6 @@ def plot_graphviz(dot_text):
     return plt.imshow(plt.imread(f.name), aspect="equal")
 
 
-def plot_system_graphviz(system, max_depth=maxint):
+def plot_system_graphviz(system, **kwargs):
     """Renders a System's Graphviz representation in `matplotlib`."""
-    return plot_graphviz(system.GetGraphvizString(max_depth))
+    return plot_graphviz(system.GetGraphvizString(**kwargs))

--- a/bindings/pydrake/systems/meshcat_visualizer.py
+++ b/bindings/pydrake/systems/meshcat_visualizer.py
@@ -3,6 +3,7 @@ Provides utilities for communicating with the browser-based visualization
 package, Meshcat:
       https://github.com/rdeits/meshcat
 """
+from __future__ import print_function
 import argparse
 import math
 import webbrowser
@@ -179,8 +180,8 @@ class MeshcatVisualizer(LeafSystem):
                         meshcat.geometry.ObjMeshGeometry.from_file(
                             geom.string_data[0:-3] + "obj")
                 else:
-                    print "UNSUPPORTED GEOMETRY TYPE ", \
-                        geom.type, " IGNORED"
+                    print("UNSUPPORTED GEOMETRY TYPE {} IGNORED".format(
+                          geom.type))
                     continue
 
                 # Turn a list of R,G,B elements (any indexable list of >= 3

--- a/bindings/pydrake/test/test_util_pybind.h
+++ b/bindings/pydrake/test/test_util_pybind.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "pybind11/pybind11.h"
+
+#include "drake/bindings/pydrake/pydrake_pybind.h"
+
+namespace drake {
+namespace pydrake {
+namespace test {
+
+// TODO(eric.cousineau): Figure out if there is a better solution than this
+// hack.
+/// pybind11's Python3 implementation seems to disconnect the `globals()` from
+/// an embedded interpreter's `__main__` module. To remedy this, we must
+/// manually synchronize these variables.
+inline void SynchronizeGlobalsForPython3(py::module m) {
+  py::globals().attr("update")(m.attr("__dict__"));
+}
+
+}  // namespace test
+}  // namespace pydrake
+}  // namespace drake

--- a/common/test_utilities/drake_py_unittest_main.py
+++ b/common/test_utilities/drake_py_unittest_main.py
@@ -5,6 +5,7 @@ should NOT be called directly by anything else.
 
 import argparse
 import imp
+import io
 import os
 import re
 import sys
@@ -33,7 +34,7 @@ if __name__ == '__main__':
     if not found_filename:
         raise RuntimeError("No such file found {}!".format(
             test_filename))
-    with open(found_filename, "r") as infile:
+    with io.open(found_filename, "r", encoding="utf8") as infile:
         for line in infile.readlines():
             if any([line.startswith("if __name__ =="),
                     line.strip().startswith("unittest.main")]):

--- a/examples/manipulation_station/end_effector_teleop.py
+++ b/examples/manipulation_station/end_effector_teleop.py
@@ -1,7 +1,10 @@
 
 import argparse
 
-import Tkinter as tk
+try:
+    import tkinter as tk
+except ImportError:
+    import Tkinter as tk
 import numpy as np
 
 from pydrake.common import FindResourceOrThrow


### PR DESCRIPTION
Towards #8352.

This comes primarily from #9614 (with some minor whitespace change). If you'd like to test it with Python3, this README has instructions on how to do so with that branch:
https://github.com/EricCousineau-TRI/drake/blob/feature/py3-wip/py3.README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10175)
<!-- Reviewable:end -->
