### PR TITLE
Fix the broadphase culling in proximity engine

### DIFF
--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -729,6 +729,7 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     DRAKE_DEMAND(indices.size() == dynamic_objects_.size());
     for (size_t i = 0; i < indices.size(); ++i) {
       dynamic_objects_[i]->setTransform(convert(X_WG[indices[i]]));
+      dynamic_objects_[i]->computeAABB();
     }
     dynamic_tree_.update();
   }


### PR DESCRIPTION
In FCL, setting the transform of an object does not invalidate the world-space AABB for that object. The computation must be explicitly invoked. Without doing so, all of the AABBs are posed in canonical space and they all trivially overlap.

For wont of a nail...

resolves #9439 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10184)
<!-- Reviewable:end -->
