### PR TITLE
lint: Make 'clang-format-includes --all' work again

### DIFF
--- a/tools/lint/BUILD.bazel
+++ b/tools/lint/BUILD.bazel
@@ -81,7 +81,10 @@ drake_py_binary(
     name = "clang-format-includes",
     srcs = ["clang_format_includes.py"],
     main = "clang_format_includes.py",
-    deps = [":formatter"],
+    deps = [
+        ":formatter",
+        ":util",
+    ],
 )
 
 drake_py_binary(

--- a/tools/lint/clang_format_includes.py
+++ b/tools/lint/clang_format_includes.py
@@ -9,9 +9,10 @@ import os
 import sys
 
 from drake.tools.lint.formatter import IncludeFormatter
+from drake.tools.lint.util import find_all_sources
 
 
-def main():
+def main(workspace_name="drake"):
     parser = argparse.ArgumentParser(
         prog='clang-format-includes',
         description=__doc__)
@@ -27,18 +28,14 @@ def main():
     args = parser.parse_args()
 
     if args.all:
-        # TODO(jwnimmer-tri) Consolidate this logic with the cpplint_wrapper
-        # tree searching logic, including some way to unit test "all" search.
+        workspace_dir, relpaths = find_all_sources(workspace_name)
         extensions = ["cc", "h", "cpp"]
-        pathnames = ["drake"]
         filenames = [
-            os.path.join(dirpath, filename)
-            for pathname in pathnames
-            for dirpath, _, filenames in os.walk(pathname)
-            for filename in filenames
-            if os.path.splitext(filename)[1][1:] in extensions and
-            "/third_party/" not in dirpath and
-            "/matlab/" not in dirpath
+            os.path.join(workspace_dir, relpath)
+            for relpath in relpaths
+            if os.path.splitext(relpath)[1][1:] in extensions and
+            not relpath.startswith("third_party") and
+            not relpath.startswith("matlab")
         ]
     else:
         filenames = args.filenames

--- a/tools/lint/util.py
+++ b/tools/lint/util.py
@@ -5,7 +5,6 @@ import os
 import sys
 
 
-# TODO(jwnimmer-tri) Port clang-format-includes & cpplint_wrapper to use this.
 def find_all_sources(workspace_name):
     """Return [workspace, paths] list, where `workspace` is a path to the root
     of the given `workspace_name`, and `paths` are relative paths under it that


### PR DESCRIPTION
This takes the "find all sources" logic already used in `tools/lint/buildifier`, and applies it to `tools/lint/clang-format-includes`.