### PR TITLE
Speedup NewSosPolynomial

### DIFF
--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -190,9 +190,9 @@ MathematicalProgram::NewSosPolynomial(
   const MatrixXDecisionVariable Q{
       NewSymmetricContinuousVariables(monomial_basis.size())};
   const auto psd_binding = AddPositiveSemidefiniteConstraint(Q);
-  // TODO(hongkai.dai): ideally we should compute p in one line as
+  // TODO(hongkai.dai & soonho.kong): ideally we should compute p in one line as
   // monomial_basis.dot(Q * monomial_basis). But as explained in #10200, this
-  // one line version is too slow, so we use this double for loops to compute
+  // one line version is too slow, so we use this double for loop to compute
   // the matrix product by hand. I will revert to the one line version when it
   // is fast.
   symbolic::Polynomial p{};

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -2951,9 +2951,9 @@ GTEST_TEST(testMathematicalProgram, NewSosPolynomial) {
   auto t = prog.NewIndeterminates<4>();
   const auto m = symbolic::MonomialBasis<4, 2>(symbolic::Variables(t));
   const auto pair = prog.NewSosPolynomial(m);
-  const symbolic::Polynomial p = pair.first;
-  const Binding<PositiveSemidefiniteConstraint> psd_binding = pair.second;
-  const auto Q_flat = psd_binding.variables();
+  const symbolic::Polynomial& p = pair.first;
+  const Binding<PositiveSemidefiniteConstraint>& psd_binding = pair.second;
+  const auto& Q_flat = psd_binding.variables();
   MatrixX<symbolic::Polynomial> Q_poly(m.rows(), m.rows());
   const symbolic::Monomial monomial_one{};
   for (int i = 0; i < Q_poly.rows(); ++i) {


### PR DESCRIPTION
As mentioned in #10200 

This is a quick fix to speed up the function. But eventually we should find out why the matrix product `m' * Q * m` is slow, and use the matrix product syntax.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10201)
<!-- Reviewable:end -->
