### PR TITLE
MathematicalProgram can add new sdsos or dsos polynomials

### DIFF
--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -256,15 +256,14 @@ PYBIND11_MODULE(mathematicalprogram, m) {
           py::arg("coeff_name") = "a",
           doc.MathematicalProgram.NewFreePolynomial.doc)
       .def("NewSosPolynomial",
-          static_cast<std::pair<Polynomial,
-              MatrixXDecisionVariable> (MathematicalProgram::*)(
+          static_cast<std::pair<Polynomial, MatrixXDecisionVariable> (
+              MathematicalProgram::*)(
               const Eigen::Ref<const VectorX<Monomial>>&)>(
               &MathematicalProgram::NewSosPolynomial),
           doc.MathematicalProgram.NewSosPolynomial.doc_1args)
       .def("NewSosPolynomial",
-          static_cast<
-              std::pair<Polynomial, MatrixXDecisionVariable> (
-                  MathematicalProgram::*)(const Variables&, int)>(
+          static_cast<std::pair<Polynomial, MatrixXDecisionVariable> (
+              MathematicalProgram::*)(const Variables&, int)>(
               &MathematicalProgram::NewSosPolynomial),
           doc.MathematicalProgram.NewSosPolynomial.doc_2args)
       .def("NewIndeterminates",

--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -257,13 +257,13 @@ PYBIND11_MODULE(mathematicalprogram, m) {
           doc.MathematicalProgram.NewFreePolynomial.doc)
       .def("NewSosPolynomial",
           static_cast<std::pair<Polynomial,
-              Binding<PositiveSemidefiniteConstraint>> (MathematicalProgram::*)(
+              MatrixXDecisionVariable> (MathematicalProgram::*)(
               const Eigen::Ref<const VectorX<Monomial>>&)>(
               &MathematicalProgram::NewSosPolynomial),
           doc.MathematicalProgram.NewSosPolynomial.doc_1args)
       .def("NewSosPolynomial",
           static_cast<
-              std::pair<Polynomial, Binding<PositiveSemidefiniteConstraint>> (
+              std::pair<Polynomial, MatrixXDecisionVariable> (
                   MathematicalProgram::*)(const Variables&, int)>(
               &MathematicalProgram::NewSosPolynomial),
           doc.MathematicalProgram.NewSosPolynomial.doc_2args)
@@ -423,24 +423,24 @@ PYBIND11_MODULE(mathematicalprogram, m) {
           py::arg("A"), py::arg("b"), py::arg("vars"),
           doc.MathematicalProgram.AddL2NormCost.doc)
       .def("AddSosConstraint",
-          static_cast<std::pair<Binding<PositiveSemidefiniteConstraint>,
+          static_cast<std::pair<MatrixXDecisionVariable,
               Binding<LinearEqualityConstraint>> (MathematicalProgram::*)(
               const Polynomial&, const Eigen::Ref<const VectorX<Monomial>>&)>(
               &MathematicalProgram::AddSosConstraint),
           doc.MathematicalProgram.AddSosConstraint.doc_2args_p_monomial_basis)
       .def("AddSosConstraint",
-          static_cast<std::pair<Binding<PositiveSemidefiniteConstraint>,
+          static_cast<std::pair<MatrixXDecisionVariable,
               Binding<LinearEqualityConstraint>> (MathematicalProgram::*)(
               const Polynomial&)>(&MathematicalProgram::AddSosConstraint),
           doc.MathematicalProgram.AddSosConstraint.doc_1args_p)
       .def("AddSosConstraint",
-          static_cast<std::pair<Binding<PositiveSemidefiniteConstraint>,
+          static_cast<std::pair<MatrixXDecisionVariable,
               Binding<LinearEqualityConstraint>> (MathematicalProgram::*)(
               const Expression&, const Eigen::Ref<const VectorX<Monomial>>&)>(
               &MathematicalProgram::AddSosConstraint),
           doc.MathematicalProgram.AddSosConstraint.doc_2args_e_monomial_basis)
       .def("AddSosConstraint",
-          static_cast<std::pair<Binding<PositiveSemidefiniteConstraint>,
+          static_cast<std::pair<MatrixXDecisionVariable,
               Binding<LinearEqualityConstraint>> (MathematicalProgram::*)(
               const Expression&)>(&MathematicalProgram::AddSosConstraint),
           doc.MathematicalProgram.AddSosConstraint.doc_1args_e)

--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -214,6 +214,15 @@ MathematicalProgram::NewSosPolynomial(const Variables& indeterminates,
   return NewSosPolynomial(x);
 }
 
+namespace {
+symbolic::Polynomial NewNonnegativePolynomial(const Eigen::Ref<const VectorX<symbolic::Monomial>>& monomial_basis, MathematicalProgram* prog, MatrixXDecisionVariable* Q) {
+  *Q = prog->NewSymmetricContinuousVariables(monomial_basis.size());
+}
+}  // namespace
+symbolic::Polynomial MathematicalProgram::NewSdsosPolynomial(const Eigen::Ref<const VectorX<symbolic::Monomial>>& monomial_basis) {
+  
+}
+
 MatrixXIndeterminate MathematicalProgram::NewIndeterminates(
     int rows, int cols, const vector<string>& names) {
   MatrixXIndeterminate indeterminates_matrix(rows, cols);

--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -185,7 +185,7 @@ symbolic::Polynomial MathematicalProgram::NewFreePolynomial(
 }
 
 // This is the utility function for creating new nonnegative polynomials
-// (sos-polynomial, sdsos-polynomial, dsos-polynomial, etc). It creates a
+// (sos-polynomial, sdsos-polynomial, dsos-polynomial). It creates a
 // symmetric matrix Q as decision variables, and return m' * Q * m as the new
 // polynomial, where m is the monomial basis.
 pair<symbolic::Polynomial, MatrixXDecisionVariable>

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -593,14 +593,17 @@ class MathematicalProgram {
   /**
    * Returns a pair of nonnegative polynomial p = mᵀQm and the coefficient
    * matrix Q, where m is the monomial basis, containing all monomials of @p
-   * indeterminates of total order up to @p degree / 2. Depending on the type of
-   * the polynomial, we will impose different constraint on Q.
+   * indeterminates of total order up to @p degree / 2, hence the polynomial p
+   * contains all the monomials of total order up to @p degree, as p is
+   * quadratic in m.
+   * Depending on the type of the polynomial, we will impose different
+   * constraint on Q.
    * if type = kSos, we impose Q being positive semidefinite.
    * if type = kSdsos, we impose Q being scaled diagonally dominant.
    * if type = kDsos, we impose Q being positive diagonally dominant.
    * @param indeterminates All the indeterminates in the polynomial p.
    * @param degree The polynomial p will contain all the monomials up to order
-   * @p degree.
+   * @p degree
    * @param type The type of the nonnegative polynomial.
    * @return (p, Q) The polynomial p and the coefficient matrix Q. Q has been
    * added as decision variables to the program.
@@ -2144,7 +2147,7 @@ class MathematicalProgram {
    * that is, @p p can be decomposed into `mᵀQm`, where m is the @p
    * monomial_basis. It returns a pair expressing:
    *
-   *  - The coefficients matrix Q. This matrix should be positive semidefinite.
+   *  - The coefficients matrix Q, which is positive semidefinite.
    *  - The coefficients matching conditions in linear equality constraint.
    */
   std::pair<MatrixXDecisionVariable, Binding<LinearEqualityConstraint>>
@@ -2158,7 +2161,7 @@ class MathematicalProgram {
    * basis of all indeterminates in the program with degree equal to half the
    * TotalDegree of @p p. It returns a pair of constraint bindings expressing:
    *
-   *  - The coefficients matrix Q. This matrix should be positive semidefinite.
+   *  - The coefficients matrix Q, which is positive semidefinite.
    *  - The coefficients matching conditions in linear equality constraint.
    */
   std::pair<MatrixXDecisionVariable, Binding<LinearEqualityConstraint>>
@@ -2171,7 +2174,7 @@ class MathematicalProgram {
    * polynomial with respect to `indeterminates()` in this mathematical
    * program. It returns a pair of constraint bindings expressing:
    *
-   *  - The coefficients matrix Q. This matrix should be positive semidefinite.
+   *  - The coefficients matrix Q, which is positive semidefinite.
    *  - The coefficients matching conditions in linear equality constraint.
    */
   std::pair<MatrixXDecisionVariable, Binding<LinearEqualityConstraint>>
@@ -2186,7 +2189,7 @@ class MathematicalProgram {
    * mathematical program. It returns a pair of
    * constraint bindings expressing:
    *
-   *  - The coefficients matrix Q. This matrix should be positive semidefinite.
+   *  - The coefficients matrix Q, which is positive semidefinite.
    *  - The coefficients matching conditions in linear equality constraint.
    */
   std::pair<MatrixXDecisionVariable, Binding<LinearEqualityConstraint>>

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -558,34 +558,81 @@ class MathematicalProgram {
       const symbolic::Variables& indeterminates, int degree,
       const std::string& coeff_name = "a");
 
-  /** Returns a pair of a SOS polynomial p = mᵀQm and a PSD constraint for
-   * a new coefficients matrix Q, where m is the @p monomial basis.
+  /**
+   * Types of non-negative polynomial that can be found through conic
+   * optimization. We currently support SOS, SDSOS and DSOS. For more
+   * information about these polynomial types, please refer to
+   * "DSOS and SDSOS Optimization: More Tractable
+   * Alternatives to Sum of Squares and Semidefinite Optimization" by Amir Ali
+   * Ahmadi and Anirudha Majumdar, with arXiv link
+   * https://arxiv.org/abs/1706.02586
+   */
+  enum class NonnegativePolynomial {
+    kSos,    ///< A sum-of-squares polynomial.
+    kSdsos,  ///< A scaled-diagonally dominant sum-of-squares polynomial.
+    kDsos,   ///< A diagonally dominant sum-of-squares polynomial.
+  };
+
+  /**
+   * Returns a pair of nonnegative polynomial p = mᵀQm and the coefficient
+   * matrix Q, where m is @p monomial_basis. Depending on the type of the
+   * polynomial, we will impose different constraint on Q.
+   * if type = kSos, we impose Q being positive semidefinite.
+   * if type = kSdsos, we impose Q being scaled diagonally dominant.
+   * if type = kDsos, we impose Q being positive diagonally dominant.
+   * @param monomial_basis The monomial basis.
+   * @param type The type of the nonnegative polynomial.
+   * @return (p, Q) The polynomial p and the coefficient matrix Q. Q has been
+   * added as decision variables to the program.
+   */
+  std::pair<symbolic::Polynomial, MatrixXDecisionVariable>
+  NewNonnegativePolynomial(
+      const Eigen::Ref<const VectorX<symbolic::Monomial>>& monomial_basis,
+      NonnegativePolynomial type);
+
+  /**
+   * Returns a pair of nonnegative polynomial p = mᵀQm and the coefficient
+   * matrix Q, where m is the monomial basis, containing all monomials of @p
+   * indeterminates of total order up to @p degree / 2. Depending on the type of
+   * the polynomial, we will impose different constraint on Q.
+   * if type = kSos, we impose Q being positive semidefinite.
+   * if type = kSdsos, we impose Q being scaled diagonally dominant.
+   * if type = kDsos, we impose Q being positive diagonally dominant.
+   * @param indeterminates All the indeterminates in the polynomial p.
+   * @param degree The polynomial p will contain all the monomials up to order
+   * @p degree.
+   * @param type The type of the nonnegative polynomial.
+   * @return (p, Q) The polynomial p and the coefficient matrix Q. Q has been
+   * added as decision variables to the program.
+   */
+  std::pair<symbolic::Polynomial, MatrixXDecisionVariable>
+  NewNonnegativePolynomial(const symbolic::Variables& indeterminates,
+                           int degree, NonnegativePolynomial type);
+
+  /** Returns a pair of a SOS polynomial p = mᵀQm and the coefficient matrix Q,
+   * where m is the @p monomial basis.
    * For example, `NewSosPolynomial(Vector2<Monomial>{x,y})` returns a
    * polynomial
    *   p = Q₍₀,₀₎x² + 2Q₍₁,₀₎xy + Q₍₁,₁₎y²
-   * and a PSD constraint over Q.
+   * and Q.
    * @note Q is a symmetric monomial_basis.rows() x monomial_basis.rows()
    * matrix.
    */
-  std::pair<symbolic::Polynomial, Binding<PositiveSemidefiniteConstraint>>
-  NewSosPolynomial(
+  std::pair<symbolic::Polynomial, MatrixXDecisionVariable> NewSosPolynomial(
       const Eigen::Ref<const VectorX<symbolic::Monomial>>& monomial_basis);
 
   /** Returns a pair of a SOS polynomial p = m(x)ᵀQm(x) of degree @p degree
-   * and a PSD constraint for the coefficients matrix Q, where m(x) is the
+   * and the coefficient matrix Q that should be PSD, where m(x) is the
    * result of calling `MonomialBasis(indeterminates, degree/2)`. For example,
    * `NewSosPolynomial({x}, 4)` returns a pair of a polynomial
    *   p = Q₍₀,₀₎x⁴ + 2Q₍₁,₀₎ x³ + (2Q₍₂,₀₎ + Q₍₁,₁₎)x² + 2Q₍₂,₁₎x + Q₍₂,₂₎
-   * and a PSD constraint over Q.
+   * and Q.
    *
    * @throws std::runtime_error if @p degree is not a positive even integer.
    * @see MonomialBasis.
    */
-  std::pair<symbolic::Polynomial, Binding<PositiveSemidefiniteConstraint>>
-  NewSosPolynomial(const symbolic::Variables& indeterminates, int degree);
-
-  symbolic::Polynomial NewSdsosPolynomial(
-      const Eigen::Ref<const VectorX<symbolic::Monomial>>& monomial_basis);
+  std::pair<symbolic::Polynomial, MatrixXDecisionVariable> NewSosPolynomial(
+      const symbolic::Variables& indeterminates, int degree);
 
   /**
    * Adds indeterminates, appending them to an internal vector of any
@@ -2095,13 +2142,12 @@ class MathematicalProgram {
   /**
    * Adds constraints that a given polynomial @p p is a sums-of-squares (SOS),
    * that is, @p p can be decomposed into `mᵀQm`, where m is the @p
-   * monomial_basis. It returns a pair of constraint bindings expressing:
+   * monomial_basis. It returns a pair expressing:
    *
-   *  - The coefficients matrix Q is PSD (positive semidefinite).
+   *  - The coefficients matrix Q. This matrix should be positive semidefinite.
    *  - The coefficients matching conditions in linear equality constraint.
    */
-  std::pair<Binding<PositiveSemidefiniteConstraint>,
-            Binding<LinearEqualityConstraint>>
+  std::pair<MatrixXDecisionVariable, Binding<LinearEqualityConstraint>>
   AddSosConstraint(
       const symbolic::Polynomial& p,
       const Eigen::Ref<const VectorX<symbolic::Monomial>>& monomial_basis);
@@ -2115,8 +2161,7 @@ class MathematicalProgram {
    *  - The coefficients matrix Q is PSD (positive semidefinite).
    *  - The coefficients matching conditions in linear equality constraint.
    */
-  std::pair<Binding<PositiveSemidefiniteConstraint>,
-            Binding<LinearEqualityConstraint>>
+  std::pair<MatrixXDecisionVariable, Binding<LinearEqualityConstraint>>
   AddSosConstraint(const symbolic::Polynomial& p);
 
   /**
@@ -2129,8 +2174,7 @@ class MathematicalProgram {
    *  - The coefficients matrix Q is PSD (positive semidefinite).
    *  - The coefficients matching conditions in linear equality constraint.
    */
-  std::pair<Binding<PositiveSemidefiniteConstraint>,
-            Binding<LinearEqualityConstraint>>
+  std::pair<MatrixXDecisionVariable, Binding<LinearEqualityConstraint>>
   AddSosConstraint(
       const symbolic::Expression& e,
       const Eigen::Ref<const VectorX<symbolic::Monomial>>& monomial_basis);
@@ -2145,8 +2189,7 @@ class MathematicalProgram {
    *  - The coefficients matrix Q is PSD (positive semidefinite).
    *  - The coefficients matching conditions in linear equality constraint.
    */
-  std::pair<Binding<PositiveSemidefiniteConstraint>,
-            Binding<LinearEqualityConstraint>>
+  std::pair<MatrixXDecisionVariable, Binding<LinearEqualityConstraint>>
   AddSosConstraint(const symbolic::Expression& e);
 
   // template <typename FunctionType>

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -575,8 +575,9 @@ class MathematicalProgram {
 
   /**
    * Returns a pair of nonnegative polynomial p = mᵀQm and the coefficient
-   * matrix Q, where m is @p monomial_basis. Depending on the type of the
-   * polynomial, we will impose different constraint on Q.
+   * matrix Q, where m is @p monomial_basis. Adds Q as decision variables to the
+   * program. Depending on the type of the polynomial, we will impose different
+   * constraint on Q.
    * if type = kSos, we impose Q being positive semidefinite.
    * if type = kSdsos, we impose Q being scaled diagonally dominant.
    * if type = kDsos, we impose Q being positive diagonally dominant.
@@ -595,7 +596,7 @@ class MathematicalProgram {
    * matrix Q, where m is the monomial basis, containing all monomials of @p
    * indeterminates of total order up to @p degree / 2, hence the polynomial p
    * contains all the monomials of total order up to @p degree, as p is
-   * quadratic in m.
+   * quadratic in m. Adds Q as decision variables to the program.
    * Depending on the type of the polynomial, we will impose different
    * constraint on Q.
    * if type = kSos, we impose Q being positive semidefinite.
@@ -603,10 +604,11 @@ class MathematicalProgram {
    * if type = kDsos, we impose Q being positive diagonally dominant.
    * @param indeterminates All the indeterminates in the polynomial p.
    * @param degree The polynomial p will contain all the monomials up to order
-   * @p degree
+   * @p degree.
    * @param type The type of the nonnegative polynomial.
    * @return (p, Q) The polynomial p and the coefficient matrix Q. Q has been
    * added as decision variables to the program.
+   * @pre @p degree is a positive even number.
    */
   std::pair<symbolic::Polynomial, MatrixXDecisionVariable>
   NewNonnegativePolynomial(const symbolic::Variables& indeterminates,

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -584,6 +584,9 @@ class MathematicalProgram {
   std::pair<symbolic::Polynomial, Binding<PositiveSemidefiniteConstraint>>
   NewSosPolynomial(const symbolic::Variables& indeterminates, int degree);
 
+  symbolic::Polynomial NewSdsosPolynomial(
+      const Eigen::Ref<const VectorX<symbolic::Monomial>>& monomial_basis);
+
   /**
    * Adds indeterminates, appending them to an internal vector of any
    * existing indeterminates.

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -2158,7 +2158,7 @@ class MathematicalProgram {
    * basis of all indeterminates in the program with degree equal to half the
    * TotalDegree of @p p. It returns a pair of constraint bindings expressing:
    *
-   *  - The coefficients matrix Q is PSD (positive semidefinite).
+   *  - The coefficients matrix Q. This matrix should be positive semidefinite.
    *  - The coefficients matching conditions in linear equality constraint.
    */
   std::pair<MatrixXDecisionVariable, Binding<LinearEqualityConstraint>>
@@ -2171,7 +2171,7 @@ class MathematicalProgram {
    * polynomial with respect to `indeterminates()` in this mathematical
    * program. It returns a pair of constraint bindings expressing:
    *
-   *  - The coefficients matrix Q is PSD (positive semidefinite).
+   *  - The coefficients matrix Q. This matrix should be positive semidefinite.
    *  - The coefficients matching conditions in linear equality constraint.
    */
   std::pair<MatrixXDecisionVariable, Binding<LinearEqualityConstraint>>
@@ -2186,7 +2186,7 @@ class MathematicalProgram {
    * mathematical program. It returns a pair of
    * constraint bindings expressing:
    *
-   *  - The coefficients matrix Q is PSD (positive semidefinite).
+   *  - The coefficients matrix Q. This matrix should be positive semidefinite.
    *  - The coefficients matching conditions in linear equality constraint.
    */
   std::pair<MatrixXDecisionVariable, Binding<LinearEqualityConstraint>>

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -2945,25 +2945,34 @@ GTEST_TEST(testMathematicalProgram, TestGetSolution) {
   EXPECT_THROW(prog.GetSolution(x(0), result), std::invalid_argument);
 }
 
-GTEST_TEST(testMathematicalProgram, NewSosPolynomial) {
-  // Check if the newly created sos polynomial can be computed as m' * Q * m.
+void CheckNewNonnegativePolynomial(MathematicalProgram::NonnegativePolynomial type) {
+  // Check if the newly created nonnegative polynomial can be computed as m' * Q
+  // * m.
   MathematicalProgram prog;
   auto t = prog.NewIndeterminates<4>();
   const auto m = symbolic::MonomialBasis<4, 2>(symbolic::Variables(t));
-  const auto pair = prog.NewSosPolynomial(m);
+  const auto pair = prog.NewNonnegativePolynomial(m, type);
   const symbolic::Polynomial& p = pair.first;
-  const Binding<PositiveSemidefiniteConstraint>& psd_binding = pair.second;
-  const auto& Q_flat = psd_binding.variables();
+  const MatrixXDecisionVariable& Q = pair.second;
   MatrixX<symbolic::Polynomial> Q_poly(m.rows(), m.rows());
   const symbolic::Monomial monomial_one{};
   for (int i = 0; i < Q_poly.rows(); ++i) {
     for (int j = 0; j < Q_poly.cols(); ++j) {
       Q_poly(i, j) =
-          symbolic::Polynomial({{monomial_one, Q_flat(j * Q_poly.rows() + i)}});
+          symbolic::Polynomial({{monomial_one, Q(j * Q_poly.rows() + i)}});
     }
   }
   const symbolic::Polynomial p_expected(m.dot(Q_poly * m));
   EXPECT_TRUE(p.EqualTo(p_expected));
+}
+
+GTEST_TEST(testMathematicalProgram, NewNonnegativePolynomial) {
+  CheckNewNonnegativePolynomial(
+      MathematicalProgram::NonnegativePolynomial::kSos);
+  CheckNewNonnegativePolynomial(
+      MathematicalProgram::NonnegativePolynomial::kSdsos);
+  CheckNewNonnegativePolynomial(
+      MathematicalProgram::NonnegativePolynomial::kDsos);
 }
 }  // namespace test
 }  // namespace solvers

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -2945,7 +2945,8 @@ GTEST_TEST(testMathematicalProgram, TestGetSolution) {
   EXPECT_THROW(prog.GetSolution(x(0), result), std::invalid_argument);
 }
 
-void CheckNewNonnegativePolynomial(MathematicalProgram::NonnegativePolynomial type) {
+void CheckNewNonnegativePolynomial(
+    MathematicalProgram::NonnegativePolynomial type) {
   // Check if the newly created nonnegative polynomial can be computed as m' * Q
   // * m.
   MathematicalProgram prog;

--- a/solvers/test/scaled_diagonally_dominant_matrix_test.cc
+++ b/solvers/test/scaled_diagonally_dominant_matrix_test.cc
@@ -49,6 +49,8 @@ void CheckSDDMatrix(const Eigen::Ref<const Eigen::MatrixXd>& X_val,
   const auto result = prog.Solve();
   if (is_sdd) {
     EXPECT_EQ(result, SolutionResult::kSolutionFound);
+    // Since X = ∑ᵢⱼ Mⁱʲ according to the definition of scaled diagonally
+    // dominant matrix, we evaluate the summation of M, and compare that with X.
     std::vector<std::vector<Eigen::MatrixXd>> M_val(nx);
     symbolic::Environment env;
     for (int i = 0; i < prog.num_vars(); ++i) {
@@ -69,7 +71,7 @@ void CheckSDDMatrix(const Eigen::Ref<const Eigen::MatrixXd>& X_val,
         M_sum += M_val[i][j];
       }
     }
-    double tol = 1E-6;
+    const double tol = 1E-6;
     EXPECT_TRUE(CompareMatrices(M_sum, X_val, tol));
   } else {
     EXPECT_TRUE(result == SolutionResult::kInfeasibleConstraints ||

--- a/solvers/test/sos_constraint_test.cc
+++ b/solvers/test/sos_constraint_test.cc
@@ -39,10 +39,10 @@ class SosConstraintTest : public ::testing::Test {
     }
   }
 
-  void CheckNewSosPolynomial(
-      const symbolic::Polynomial& p,
-      const Binding<PositiveSemidefiniteConstraint>& psd_binding,
-      const Variables& indeterminates, const int degree) {
+  void CheckNewSosPolynomial(const symbolic::Polynomial& p,
+                             const MatrixXDecisionVariable& Q,
+                             const Variables& indeterminates,
+                             const int degree) {
     // p = xᵀ*Q*x.
     // where x = monomial_basis(indeterminates, degree) and
     //       Q is p.s.d.
@@ -54,21 +54,22 @@ class SosConstraintTest : public ::testing::Test {
     EXPECT_EQ(p.decision_variables().size(),
               monomial_basis.size() * (monomial_basis.size() + 1) / 2);
     // Q is the coefficient matrix of p.
-    EXPECT_EQ(p.decision_variables(), Variables(psd_binding.variables()));
+    VectorXDecisionVariable Q_flat(Q.size());
+    for (int i = 0; i < Q.cols(); ++i) {
+      Q_flat.segment(i * Q.rows(), Q.rows()) = Q.col(i);
+    }
+    EXPECT_EQ(p.decision_variables(), Variables(Q_flat));
     prog_.Solve();
-    CheckPsdBinding(psd_binding);
+    CheckPositiveDefiniteMatrix(Q);
   }
 
   // Checks Q has all eigen values as approximately non-negatives.
   // Precondition: prog_.Solve() has been called.
-  void CheckPsdBinding(
-      const Binding<PositiveSemidefiniteConstraint>& psd_binding,
-      const double eps = 1e-07) {
-    const VectorXDecisionVariable& variables{psd_binding.variables()};
-    const auto values = prog_.GetSolution(variables);
-    Eigen::VectorXd eigen_values;
-    psd_binding.evaluator()->Eval(values, &eigen_values);
-    EXPECT_TRUE((eigen_values.array() >= -eps).all());
+  void CheckPositiveDefiniteMatrix(const MatrixXDecisionVariable& Q,
+                       const double eps = 1e-07) {
+    const Eigen::MatrixXd Q_val = prog_.GetSolution(Q);
+    Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> es(Q_val);
+    EXPECT_TRUE((es.eigenvalues().array() >= -eps).all());
   }
 
  protected:
@@ -126,8 +127,8 @@ TEST_F(SosConstraintTest, NewSosPolynomialUnivariate1) {
   const int degree{2};
   const auto p = prog_.NewSosPolynomial(indeterminates, degree);
   const symbolic::Polynomial& poly{p.first};
-  const Binding<PositiveSemidefiniteConstraint>& psd_binding{p.second};
-  CheckNewSosPolynomial(poly, psd_binding, indeterminates, degree);
+  const MatrixXDecisionVariable& Q{p.second};
+  CheckNewSosPolynomial(poly, Q, indeterminates, degree);
 }
 
 TEST_F(SosConstraintTest, NewSosPolynomialUnivariate2) {
@@ -136,8 +137,8 @@ TEST_F(SosConstraintTest, NewSosPolynomialUnivariate2) {
   const int degree{4};
   const auto p = prog_.NewSosPolynomial(indeterminates, degree);
   const symbolic::Polynomial& poly{p.first};
-  const Binding<PositiveSemidefiniteConstraint>& psd_binding{p.second};
-  CheckNewSosPolynomial(poly, psd_binding, indeterminates, degree);
+  const MatrixXDecisionVariable& Q{p.second};
+  CheckNewSosPolynomial(poly, Q, indeterminates, degree);
 }
 
 TEST_F(SosConstraintTest, NewSosPolynomialMultivariate1) {
@@ -147,8 +148,8 @@ TEST_F(SosConstraintTest, NewSosPolynomialMultivariate1) {
   const int degree{2};
   const auto p = prog_.NewSosPolynomial(indeterminates, degree);
   const symbolic::Polynomial& poly{p.first};
-  const Binding<PositiveSemidefiniteConstraint>& psd_binding{p.second};
-  CheckNewSosPolynomial(poly, psd_binding, indeterminates, degree);
+  const MatrixXDecisionVariable& Q{p.second};
+  CheckNewSosPolynomial(poly, Q, indeterminates, degree);
 }
 
 TEST_F(SosConstraintTest, NewSosPolynomialMultivariate2) {
@@ -159,8 +160,8 @@ TEST_F(SosConstraintTest, NewSosPolynomialMultivariate2) {
   const int degree{4};
   const auto p = prog_.NewSosPolynomial(indeterminates, degree);
   const symbolic::Polynomial& poly{p.first};
-  const Binding<PositiveSemidefiniteConstraint>& psd_binding{p.second};
-  CheckNewSosPolynomial(poly, psd_binding, indeterminates, degree);
+  const MatrixXDecisionVariable& Q{p.second};
+  CheckNewSosPolynomial(poly, Q, indeterminates, degree);
 }
 
 TEST_F(SosConstraintTest, NewSosPolynomialViaMonomialBasis) {
@@ -169,10 +170,11 @@ TEST_F(SosConstraintTest, NewSosPolynomialViaMonomialBasis) {
   Vector2<Monomial> basis{ x0, x1 };
   const auto p = prog_.NewSosPolynomial(basis);
   const symbolic::Polynomial& poly{p.first};
-  const VectorXDecisionVariable& Qvec = p.second.variables();
-  const symbolic::Polynomial expected_poly{ Qvec(0)*x0*x0 + 2*Qvec(1)*x0*x1 +
-                                                Qvec(3)*x1*x1 };
-  EXPECT_TRUE(poly.ToExpression().EqualTo(expected_poly.ToExpression()));
+  const MatrixXDecisionVariable& Q = p.second;
+  const symbolic::Polynomial expected_poly{
+      Q(0, 0) * x0 * x0 + 2 * Q(0, 1) * x0 * x1 + Q(1, 1) * x1 * x1,
+      symbolic::Variables({x0, x1})};
+  EXPECT_TRUE(poly.EqualTo(expected_poly));
 }
 
 // Shows that f(x) = x² + 2x + 1 is SOS.
@@ -181,7 +183,7 @@ TEST_F(SosConstraintTest, AddSosConstraintUnivariate1) {
   const auto binding_pair = prog_.AddSosConstraint(2 * pow(x, 2) + 2 * x + 1);
   const auto result = prog_.Solve();
   EXPECT_EQ(result, SolutionResult::kSolutionFound);
-  CheckPsdBinding(binding_pair.first);
+  CheckPositiveDefiniteMatrix(binding_pair.first);
 }
 
 // Finds the global minimum of f(x) = x⁶ − 10x⁵ + 51x⁴ − 166x³ + 342x² − 400x +
@@ -197,7 +199,7 @@ TEST_F(SosConstraintTest, AddSosConstraintUnivariate2) {
   const auto result = prog_.Solve();
   ASSERT_EQ(result, SolutionResult::kSolutionFound);
   EXPECT_LE(prog_.GetSolution(c), 1E-4);
-  CheckPsdBinding(binding_pair.first, 1E-6 /* eps */);
+  CheckPositiveDefiniteMatrix(binding_pair.first, 1E-6 /* eps */);
 }
 
 // Shows that f(x₀, x₁) = 2x₀⁴ + 2x₀³x₁ - x₀²x₁² + 5x₁⁴ is SOS.
@@ -209,7 +211,7 @@ TEST_F(SosConstraintTest, AddSosConstraintMultivariate1) {
                              pow(x0, 2) * pow(x1, 2) + 5 * pow(x1, 4));
   const auto result = prog_.Solve();
   EXPECT_EQ(result, SolutionResult::kSolutionFound);
-  CheckPsdBinding(binding_pair.first);
+  CheckPositiveDefiniteMatrix(binding_pair.first);
 }
 
 
@@ -220,7 +222,7 @@ TEST_F(SosConstraintTest, AddSosPolynomialViaMonomialBasis) {
                                                    basis);
   const auto result = prog_.Solve();
   EXPECT_EQ(result, SolutionResult::kSolutionFound);
-  CheckPsdBinding(binding_pair.first);
+  CheckPositiveDefiniteMatrix(binding_pair.first);
 }
 
 // Finds the global minimum of the non-convex polynomial f(x₀, x₁) = 4 * x₀² −
@@ -240,7 +242,7 @@ TEST_F(SosConstraintTest, AddSosConstraintMultivariate2) {
   const auto result = prog_.Solve();
   ASSERT_EQ(result, SolutionResult::kSolutionFound);
   EXPECT_NEAR(prog_.GetSolution(c), -1.0316, 1E-4);
-  CheckPsdBinding(binding_pair.first);
+  CheckPositiveDefiniteMatrix(binding_pair.first);
 }
 
 TEST_F(SosConstraintTest, SynthesizeLyapunovFunction) {


### PR DESCRIPTION
As mentioned in #9334 

cc @shensquared

I also changed the return type for adding Sos constraint. Instead of returning `Binding<PositiveSemidefiniteConstraint>` on the matrix `Q`, I return Q directly. There are two reasons for this change

1. Returning the matrix directly is cheaper than copying and returning the binding, which includes the matrix.
2. In the binding, the matrix `Q` has to be stored in a stacked column vector (because `Binding` class mandates a column vector). But almost always I will use the square matrix `Q`, so I always had to recompute `Q` from the stacked column vector. This recomputation is unnecessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10208)
<!-- Reviewable:end -->
