### PR TITLE
python3, install: Minor tweaks for meshcat

### DIFF
--- a/common/proto/test/call_python_test.py
+++ b/common/proto/test/call_python_test.py
@@ -100,7 +100,7 @@ class TestCallPython(unittest.TestCase):
 
     def test_help(self):
         text = subprocess.check_output(
-            [client_bin, "--help"], stderr=subprocess.STDOUT)
+            [client_bin, "--help"], stderr=subprocess.STDOUT).decode("utf8")
         # Print output, since `assertIn` does not provide user-friendly
         # multiline error messages.
         print(text)

--- a/examples/manipulation_station/end_effector_teleop.py
+++ b/examples/manipulation_station/end_effector_teleop.py
@@ -83,7 +83,7 @@ class EndEffectorTeleop(LeafSystem):
         # be active, the teleop slider window must be the active window.
 
         def update(scale, value):
-            return lambda(event): scale.set(scale.get() + value)
+            return lambda event: scale.set(scale.get() + value)
 
         # Delta displacements for motion via keyboard teleop.
         rotation_delta = 0.05  # rad

--- a/tools/install/test/install_meta_test.py
+++ b/tools/install/test/install_meta_test.py
@@ -55,13 +55,14 @@ class TestInstallMeta(unittest.TestCase):
         strip_substr = "-- Symbols will NOT be stripped"
         # - Without.
         text_without = check_output(
-            [self.BINARY, "-v", install_dir], stderr=STDOUT)
+            [self.BINARY, "-v", install_dir], stderr=STDOUT).decode("utf8")
         # N.B. `assertIn` error messages are not great for multiline, so just
         # print and use nominal asserts.
         print(text_without)
         self.assertTrue(strip_substr not in text_without)
         # - With.
         text_with = check_output(
-            [self.BINARY, install_dir, "-v", "--no_strip"], stderr=STDOUT)
+            [self.BINARY, install_dir, "-v", "--no_strip"],
+            stderr=STDOUT).decode("utf8")
         print(text_with)
         self.assertTrue(strip_substr in text_with)

--- a/tools/workspace/meshcat_python/BUILD.bazel
+++ b/tools/workspace/meshcat_python/BUILD.bazel
@@ -1,13 +1,48 @@
 # -*- python -*-
 
 load("//tools/lint:lint.bzl", "add_lint_tests")
+load("//tools/workspace:generate_file.bzl", "generate_file")
 load("@drake//tools/skylark:drake_py.bzl", "drake_py_unittest")
+load(
+    "@python//:version.bzl",
+    "PYTHON_SITE_PACKAGES_RELPATH",
+    "PYTHON_VERSION",
+)
 
 MESHCAT_SERVER_FILES = [
     "meshcat-server.py",
-    "meshcat-server",
     "test/meshcat-server-install-test.py",
 ]
+
+# Branch install script to ensure that consistent dependencies are used.
+# TODO(eric.cousineau): Generalize this for other binaries.
+generate_file(
+    name = "meshcat-server",
+    # N.B. This is for install. For Bazel, see `meshcat-server.py`.
+    content = """#!/usr/bin/env python{major}
+# -*- coding: utf-8 -*-
+from os.path import abspath, dirname, join
+import sys
+
+
+def main():
+    prefix = dirname(dirname(abspath(__file__)))
+    sys.path.insert(0, join(prefix, '{site_packages}'))
+
+    from meshcat.servers.zmqserver import main as server_main
+
+    server_main()
+
+
+if __name__ == '__main__':
+    main()
+""".format(
+        major = PYTHON_VERSION.split(".")[0],
+        site_packages = PYTHON_SITE_PACKAGES_RELPATH,
+    ),
+    is_executable = 1,
+    visibility = ["//visibility:public"],
+)
 
 exports_files(
     MESHCAT_SERVER_FILES,
@@ -27,4 +62,6 @@ drake_py_unittest(
     deps = ["@meshcat_python//:meshcat-server"],
 )
 
-add_lint_tests(python_lint_extra_srcs = MESHCAT_SERVER_FILES)
+add_lint_tests(
+    python_lint_extra_srcs = MESHCAT_SERVER_FILES + ["meshcat-server"],
+)

--- a/tools/workspace/meshcat_python/meshcat-server.py
+++ b/tools/workspace/meshcat_python/meshcat-server.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
+from meshcat.servers.zmqserver import main as server_main
+
+# N.B. This is the binary for Bazel. For install, see `meshcat-server`.
 
 
 def main():
-    import meshcat.servers.zmqserver
-
-    meshcat.servers.zmqserver.main()
+    server_main()
 
 
 if __name__ == '__main__':

--- a/tools/workspace/optitrack_driver/BUILD.bazel
+++ b/tools/workspace/optitrack_driver/BUILD.bazel
@@ -12,6 +12,8 @@ load("//tools/lint:lint.bzl", "add_lint_tests")
 
 package(default_visibility = ["//visibility:public"])
 
+# N.B. We do not need to branch on Python3 since we have Python2 lcmtypes
+# available.
 install_files(
     name = "install_optitrack_client",
     dest = "bin",

--- a/tools/workspace/python/repository.bzl
+++ b/tools/workspace/python/repository.bzl
@@ -102,7 +102,7 @@ def _repository_python_info(repository_ctx):
         python_config = python_config,
         site_packages_relpath = site_packages_relpath,
         version = version,
-        version_major = version,
+        version_major = version_major,
         os = os_result,
     )
 


### PR DESCRIPTION
Also has some other minor fixes.

For `meshcat`, arguably we will still be installing Python2 dependencies and won't branch the prereqs, so I guess the `meshcat` install changes aren't uber necessary. I'd be fine with removing them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10216)
<!-- Reviewable:end -->
