### PR TITLE
[geometry/dev] Add RemoveRole API to dev SceneGraph

### DIFF
--- a/geometry/dev/geometry_state.h
+++ b/geometry/dev/geometry_state.h
@@ -467,6 +467,12 @@ class GeometryState {
   void AssignRole(SourceId source_id, GeometryId geometry_id,
                   IllustrationProperties properties);
 
+  /** Implementation of SceneGraph::RemoveRole(SourceId,GeometryId,Role).  */
+  int RemoveRole(SourceId source_id, GeometryId geometry_id, Role role);
+
+  /** Implementation of SceneGraph::RemoveRole(SourceId,FrameId,Role).  */
+  int RemoveRole(SourceId source_id, FrameId frame_id, Role role);
+
   //@}
 
   /** @name       Relationship queries
@@ -809,6 +815,15 @@ class GeometryState {
   template <typename PropertyType>
   void AssignRoleInternal(SourceId source_id, GeometryId geometry_id,
                           PropertyType properties, Role role);
+
+  // Removes the indicated `role` from the indicated geometry. Returns 1 if the
+  // geometry formerly had that role, and 0 if not. This does no checking on
+  // ownership.
+  // @pre geometry_id is a valid geometry.
+  int RemoveRoleUnchecked(GeometryId geometry_id, Role role);
+
+  int RemoveIllustrationRole(GeometryId geometry_id);
+  int RemovePerceptionRole(GeometryId geometry_id);
 
   // Retrieves the requested renderer (if supported), throwing otherwise.
   render::RenderEngine* GetRenderEngineOrThrow(

--- a/geometry/dev/internal_geometry.h
+++ b/geometry/dev/internal_geometry.h
@@ -232,6 +232,19 @@ class InternalGeometry {
   ProximityIndex proximity_index() const { return proximity_index_; }
   void set_proximity_index(ProximityIndex index) { proximity_index_ = index; }
 
+  /** Removes the illustration role assigned to this geometry -- if there was
+   no illustration role previously, this has no effect.  */
+  void RemoveIllustrationRole() {
+    illustration_props_ = nullopt;
+  }
+
+  /** Removes the perception role assigned to this geometry -- if there was
+   no perception role previously, this has no effect.  */
+  void RemovePerceptionRole() {
+    perception_props_ = nullopt;
+    render_index_ = RenderIndex();
+  }
+
   //@}
 
  private:

--- a/geometry/dev/render/render_engine.h
+++ b/geometry/dev/render/render_engine.h
@@ -65,6 +65,13 @@ class RenderEngine : public ShapeReifier {
       const Shape& shape, const PerceptionProperties& properties,
       const Isometry3<double>& X_FG) = 0;
 
+  /** Removes the visual geometry with the indicated index from `this` render
+   engine. The render engine _can_ move another geometry to inherit this newly
+   freed up index. If it does so, it will return the _old_ index of the geometry
+   it moved.
+   @pre `index` must be a valid index.  */
+  virtual optional<RenderIndex> RemoveVisual(RenderIndex index) = 0;
+
   // TODO(SeanCurtis-TRI): I need a super-secret RegisterVisual in which the
   // index is specified.
 

--- a/geometry/dev/render/render_engine_vtk.h
+++ b/geometry/dev/render/render_engine_vtk.h
@@ -115,6 +115,9 @@ class RenderEngineVtk final : public RenderEngine,
                              const PerceptionProperties& properties,
                              const Isometry3<double>& X_FG) override;
 
+  /** Inherits RenderEngine::RemoveVisual().  */
+  optional<RenderIndex> RemoveVisual(RenderIndex index) override;
+
   // TODO(SeanCurtis-TRI): I need a super-secret RegisterVisual in which the
   // index is specified.
 

--- a/geometry/dev/render/test/render_engine_vtk_test.cc
+++ b/geometry/dev/render/test/render_engine_vtk_test.cc
@@ -1,6 +1,7 @@
 #include "drake/geometry/dev/render/render_engine_vtk.h"
 
 #include <string>
+#include <tuple>
 
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
@@ -523,6 +524,117 @@ TEST_F(RenderEngineVtkTest, TextureMeshTest) {
   // changes, the expected color would likewise have to change.
   expected_color_ = RgbaColor(ColorI{4, 241, 33}, 255);
   PerformCenterShapeTest(renderer_.get(), "Mesh test");
+}
+
+// This confirms that geometries are correctly removed from the render engine.
+// We add two new geometries (testing the rendering after each addition).
+// By removing the first of the added geometries, we can confirm that the
+// remaining geometries are re-ordered appropriately. Then by removing the,
+// second we should restore the original default image.
+//
+// The default image is based on a sphere sitting on a plane at z = 0 with the
+// camera located above the sphere's center and aimed at that center.
+// THe default sphere is drawn with `●`, the first added sphere with `x`, and
+// the second with `o`. The height of the top of each sphere and its depth in
+// the camera's depth sensors are indicated as zᵢ and dᵢ, i ∈ {0, 1, 2},
+// respectively.
+//
+//             /|\       <---- camera_z = 3
+//              v
+//
+//
+//
+//
+//            ooooo       <---- z₂ = 4r = 2, d₂ = 1
+//          oo     oo
+//         o         o
+//        o           o
+//        o           o
+//        o   xxxxx   o   <---- z₁ = 3r = 1.5, d₁ = 1.5
+//         oxx     xxo
+//         xoo     oox
+//        x   ooooo   x
+//        x   ●●●●●   x   <---- z₀ = 2r = 1, d₀ = 2
+//        x ●●     ●● x
+//         ●         ●
+//        ● xx     xx ●
+// z      ●   xxxxx   ●
+// ^      ●           ●
+// |       ●         ●
+// |        ●●     ●●
+// |__________●●●●●____________
+//
+TEST_F(RenderEngineVtkTest, RemoveVisual) {
+  SetUp(X_WR_, true);
+  PopulateSphereTest(renderer_.get());
+  RgbaColor default_color = expected_color_;
+  RenderLabel default_label = expected_label_;
+  float default_depth = expected_object_depth_;
+
+  // Positions a sphere centered at <0, 0, z> with the given color.
+  auto add_sphere = [this](const RgbaColor& diffuse, double z) {
+    const double kRadius = 0.5;
+    Sphere sphere{kRadius};
+    const float depth = kDefaultDistance - kRadius - z;
+    Vector4d norm_diffuse{diffuse.r / 255., diffuse.g / 255., diffuse.b / 255.,
+                          diffuse.a / 255.};
+    RenderLabel label = RenderLabel::new_label();
+    PerceptionProperties material;
+    material.AddGroup("phong");
+    material.AddProperty("phong", "diffuse", norm_diffuse);
+    material.AddGroup("label");
+    material.AddProperty("label", "id", label);
+    RenderIndex index =
+        renderer_->RegisterVisual(sphere, material, Isometry3d::Identity());
+    Isometry3d X_WV{Eigen::Translation3d(0, 0, z)};
+    renderer_->UpdateVisualPose(X_WV, index);
+    return std::make_tuple(index, label, depth);
+  };
+
+  // Sets the expected values prior to calling PerformCenterShapeTest().
+  auto set_expectations = [this](const RgbaColor& color, float depth,
+                                 RenderLabel label) {
+    expected_color_ = color;
+    expected_label_ = label;
+    expected_object_depth_ = depth;
+  };
+
+  // Add another sphere of a different color in front of the default sphere
+  const RgbaColor color1(Color<int>{128, 128, 255}, 255);
+  float depth1{};
+  RenderLabel label1{};
+  RenderIndex index1{};
+  std::tie(index1, label1, depth1) = add_sphere(color1, 0.75);
+  set_expectations(color1, depth1, label1);
+  PerformCenterShapeTest(renderer_.get(), "First sphere added in remove test");
+
+  // Add a _third_ sphere in front of the second.
+  const RgbaColor color2(Color<int>{128, 255, 128}, 255);
+  float depth2{};
+  RenderLabel label2{};
+  RenderIndex index2{};
+  std::tie(index2, label2, depth2) = add_sphere(color2, 1.0);
+  set_expectations(color2, depth2, label2);
+  PerformCenterShapeTest(renderer_.get(), "Second sphere added in remove test");
+
+  // Remove the first sphere added:
+  //  1. index2 should be returned as the index of the shape that got moved.
+  //  2. The test should pass without changing expectations.
+  optional<RenderIndex> moved = renderer_->RemoveVisual(index1);
+  EXPECT_TRUE(moved);
+  EXPECT_EQ(*moved, index2);
+  PerformCenterShapeTest(renderer_.get(), "First added sphere removed");
+
+  // Remove the second added sphere (now indexed by index1):
+  //  1. There should be no returned index.
+  //  2. The rendering should match the default sphere test results.
+  // Confirm restoration to original image.
+  moved = nullopt;
+  moved = renderer_->RemoveVisual(index1);
+  EXPECT_FALSE(moved);
+  set_expectations(default_color, default_depth, default_label);
+  PerformCenterShapeTest(renderer_.get(),
+                         "Default image restored by removing extra geometries");
 }
 
 // All of the clone tests use the PerformCenterShapeTest() with the sphere setup

--- a/geometry/dev/scene_graph.cc
+++ b/geometry/dev/scene_graph.cc
@@ -281,6 +281,19 @@ void SceneGraph<T>::AssignRole(SourceId source_id,
 }
 
 template <typename T>
+int SceneGraph<T>::RemoveRole(SourceId source_id, FrameId frame_id, Role role) {
+  GS_THROW_IF_CONTEXT_ALLOCATED
+  return initial_state_->RemoveRole(source_id, frame_id, role);
+}
+
+template <typename T>
+int SceneGraph<T>::RemoveRole(SourceId source_id, GeometryId geometry_id,
+                              Role role) {
+  GS_THROW_IF_CONTEXT_ALLOCATED
+  return initial_state_->RemoveRole(source_id, geometry_id, role);
+}
+
+template <typename T>
 const SceneGraphInspector<T>& SceneGraph<T>::model_inspector() const {
   GS_THROW_IF_CONTEXT_ALLOCATED
   return model_inspector_;

--- a/geometry/dev/scene_graph.h
+++ b/geometry/dev/scene_graph.h
@@ -421,6 +421,25 @@ class SceneGraph final : public systems::LeafSystem<T> {
   void AssignRole(SourceId source_id, GeometryId geometry_id,
                   IllustrationProperties properties);
 
+  /** Removes the indicated `role` from any geometry directly registered to the
+   frame indicated by `frame_id` which has that role.
+   @return The number of geometries affected by the removed role.
+   @throws std::logic_error if 1) the `source_id` is invalid, 2) the `frame_id`
+                            is invalid, 3) `frame_id` does not belong to
+                            `source_id` (unless `frame_id` is the world frame
+                            id), or 4) the context has already been
+                            allocated.  */
+  int RemoveRole(SourceId source_id, FrameId frame_id, Role role);
+
+  /** Removes the indicated `role` from the geometry indicated by `geometry_id`.
+   @returns 1 if the geometry had the role removed and zero if the geometry did
+            not have the role assigned in the first place.
+   @throws std::logic_error if 1) the `source_id` is invalid, 2) the
+                            `geometry_id` is invalid, 3) `geometry_id` does
+                            not belong to `source_id`, or 4) the context has
+                            already been allocated.  */
+  int RemoveRole(SourceId source_id, GeometryId geometry_id, Role role);
+
   //@}
 
   /** Reports the identifier for the world frame. */


### PR DESCRIPTION
Extends the dev/SceneGraph to give the ability to remove illustration or perception roles from particular geometries (or to all of the relevant geometries affixed to a frame).

Because this is dev/SceneGraph, it does _not_ enable the ability to remove proximity roles (as dev/SceneGraph doesn't actually do proximity).

This should be considered a stop-gap while the full code comes in to play.

```
Category            added  modified  removed  
----------------------------------------------
code                384    0         0        
comments            156    0         0        
blank               59     0         0        
----------------------------------------------
TOTAL               599    0         0  
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10230)
<!-- Reviewable:end -->
