### PR TITLE
DNM [geometry/render] Abstract RenderEngine and related constructs

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -48,6 +48,7 @@ drake_cc_library(
         ":geometry_ids",
         ":geometry_index",
         ":shape_specification",
+        ":utilities",
         "//common",
         "//common:default_scalars",
         "//geometry/query_results:penetration_as_point_pair",
@@ -380,7 +381,10 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "utilities_test",
-    deps = ["utilities"],
+    deps = [
+        "utilities",
+        "//common/test_utilities",
+    ],
 )
 
 drake_cc_googletest(

--- a/geometry/dev/geometry_state.cc
+++ b/geometry/dev/geometry_state.cc
@@ -423,7 +423,8 @@ const std::string& GeometryState<T>::get_name(GeometryId geometry_id) const {
 template <typename T>
 GeometryId GeometryState<T>::GetGeometryFromName(
     FrameId frame_id, Role role, const std::string& name) const {
-  const std::string canonical_name = detail::CanonicalizeStringName(name);
+  const std::string canonical_name =
+      geometry::internal::CanonicalizeStringName(name);
 
   GeometryId result;
   int count = 0;
@@ -677,7 +678,8 @@ bool GeometryState<T>::IsValidGeometryName(
   FindOrThrow(frame_id, frames_, [frame_id]() {
     return "Given frame id is not valid: " + to_string(frame_id);
   });
-  const std::string name = detail::CanonicalizeStringName(candidate_name);
+  const std::string name =
+      geometry::internal::CanonicalizeStringName(candidate_name);
   if (name.empty()) return false;
   return NameIsUnique(frame_id, role, name);
 }

--- a/geometry/dev/proximity_engine.cc
+++ b/geometry/dev/proximity_engine.cc
@@ -495,7 +495,7 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
  public:
   Impl() = default;
 
-  Impl(const Impl& other) {
+  Impl(const Impl& other) : ShapeReifier(other) {
     dynamic_tree_.clear();
     dynamic_objects_.clear();
     anchored_tree_.clear();

--- a/geometry/geometry_index.h
+++ b/geometry/geometry_index.h
@@ -5,6 +5,8 @@
 namespace drake {
 namespace geometry {
 
+/** Type used to locate any geometry in the render engine. */
+using RenderIndex = TypeSafeIndex<class RenderTag>;
 
 /** Index used to identify a geometry in the proximity engine. The same index
  type applies to both anchored and dynamic geometries. They are distinguished

--- a/geometry/geometry_instance.cc
+++ b/geometry/geometry_instance.cc
@@ -17,7 +17,7 @@ GeometryInstance::GeometryInstance(const Isometry3<double>& X_PG,
     : id_(GeometryId::get_new_id()),
       X_PG_(X_PG),
       shape_(std::move(shape)),
-      name_(detail::CanonicalizeStringName(name)),
+      name_(internal::CanonicalizeStringName(name)),
       visual_material_(vis_material) {
   if (name_.empty()) {
     throw std::logic_error("GeometryInstance given the name '" + name +

--- a/geometry/geometry_roles.cc
+++ b/geometry/geometry_roles.cc
@@ -9,6 +9,8 @@ std::string to_string(const Role& role) {
   switch (role) {
     case Role::kProximity:
       return "proximity";
+    case Role::kPerception:
+      return "perception";
     case Role::kIllustration:
       return "illustration";
     case Role::kUnassigned:

--- a/geometry/geometry_roles.h
+++ b/geometry/geometry_roles.h
@@ -39,6 +39,8 @@ namespace geometry {
 
  - Display the progress of an interactive simulation of the arm in a GUI-based
    visualization tool.
+ - Simulate a perception system which estimates arm state based on RGB images
+   of the arm.
  - Compute contact forces between the virtual arm and its virtual environment.
  - Find clearances between objects.
  - Simulate what a camera or other sensor reports when exposed to the simulated
@@ -70,6 +72,8 @@ namespace geometry {
  Drake partitions its geometry operations into classes (in the non-C++ sense of
  the word) and defines a unique role for each class of operations.
 
+ <!-- TODO(SeanCurtis-TRI): Can we come up with a better name than "proximity"
+   akin to "Perception" and "Illustration"? -->
    - __Proximity role__: these are the operations that are related to
      evaluations of the signed distance between two geometries. When the
      objects are separated, the distance is positive, when penetrating, the
@@ -90,6 +94,11 @@ namespace geometry {
      can be requested from SceneGraph to, e.g., calculate forces. This role is
      unique in this regard -- the geometry parameters for the other roles
      affect the result of the geometric operation.
+   - __Perception role__: these are the operations that contribute to sensor
+     simulation. In other words, what can be seen? Typically, these are meshes
+     of medium to high fidelity (depending on the fidelity of the sensor). The
+     properties are models of the real world object's optical properties (its
+     color, shininess, opacity, etc.)
    - __Illustration role__: these are the operations that connect drake to some
      external visualizers. The intent is that geometries with this role don't
      contribute to system calculations, they provide the basis for visualizing,
@@ -104,6 +113,7 @@ namespace geometry {
  identifier (see SceneGraph::AssignRole()). The set _can_ be empty. Each
  role has a specific property set associated with it:
    - __Proximity role__: ProximityProperties
+   - __Perception role__: PerceptionProperties
    - __Illustration role__: IllustrationProperties
 
  Even for a single role, different consumers of a geometry may use different
@@ -145,6 +155,20 @@ class ProximityProperties final : public GeometryProperties {
   ProximityProperties() = default;
 };
 
+/** The set of properties for geometry used in a "perception" role.
+
+ Examples of functionality that depends on the perception role:
+   - n/a
+ */
+class PerceptionProperties final : public GeometryProperties{
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PerceptionProperties);
+  // TODO(SeanCurtis-TRI): Should this have a render label built in?
+
+  // TODO(SeanCurtis-TRI): Consider adding PerceptionIndex to this.
+  PerceptionProperties() = default;
+};
+
 /** The set of properties for geometry used in an "illustration" role.
 
  Examples of functionality that depends on the illustration role:
@@ -163,6 +187,7 @@ enum class Role {
   kUnassigned = 0x0,
   kProximity = 0x1,
   kIllustration = 0x2,
+  kPerception = 0x4
 };
 
 /** @name  Geometry role to string conversions

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -202,7 +202,7 @@ const std::string& GeometryState<T>::get_name(GeometryId geometry_id) const {
 template <typename T>
 GeometryId GeometryState<T>::GetGeometryFromName(
     FrameId frame_id, Role role, const std::string& name) const {
-  const std::string canonical_name = detail::CanonicalizeStringName(name);
+  const std::string canonical_name = internal::CanonicalizeStringName(name);
 
   GeometryId result;
   int count = 0;
@@ -623,7 +623,7 @@ bool GeometryState<T>::IsValidGeometryName(
     return "Given frame id is not valid: " + to_string(frame_id);
   });
   // TODO(SeanCurtis-TRI): Test for uniquness after geometry roles are added.
-  return !detail::CanonicalizeStringName(candidate_name).empty();
+  return !internal::CanonicalizeStringName(candidate_name).empty();
 }
 
 template <typename T>

--- a/geometry/internal_geometry.cc
+++ b/geometry/internal_geometry.cc
@@ -27,6 +27,8 @@ bool InternalGeometry::has_role(Role role) const {
       return has_proximity_role();
     case Role::kIllustration:
       return has_illustration_role();
+    case Role::kPerception:
+      throw std::logic_error("Unsupported internal geometry role: perception");
     case Role::kUnassigned:
       return !(has_proximity_role() || has_illustration_role());
   }

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -19,6 +19,7 @@
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/sorted_vectors_have_intersection.h"
+#include "drake/geometry/utilities.h"
 
 namespace drake {
 namespace geometry {
@@ -33,24 +34,7 @@ using std::unique_ptr;
 
 namespace {
 
-// TODO(SeanCurtis-TRI): Swap all Isometry3 for Transforms.
-
-// ADL-reliant helper functions for converting Isometry<T> to Isometry<double>.
-const Isometry3<double>& convert(const Isometry3<double>& transform) {
-  return transform;
-}
-
-template <class VectorType>
-Isometry3<double> convert(
-    const Isometry3<Eigen::AutoDiffScalar<VectorType>>& transform) {
-  Isometry3<double> result;
-  for (int r = 0; r < 4; ++r) {
-    for (int c = 0; c < 4; ++c) {
-      result.matrix()(r, c) = ExtractDoubleOrThrow(transform.matrix()(r, c));
-    }
-  }
-  return result;
-}
+// TODO(SeanCurtis-TRI): Swap all Isometry3 for RigidTransforms.
 
 // Utilities/functions for working with the encoding of collision object index
 // and mobility type in the fcl::CollisionObject user data field. The encoded
@@ -601,7 +585,7 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
  public:
   Impl() = default;
 
-  Impl(const Impl& other) {
+  Impl(const Impl& other) : ShapeReifier(other) {
     dynamic_tree_.clear();
     dynamic_objects_.clear();
     anchored_tree_.clear();

--- a/geometry/render/BUILD.bazel
+++ b/geometry/render/BUILD.bazel
@@ -1,0 +1,65 @@
+# -*- python -*-
+
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_googletest",
+    "drake_cc_library",
+    "drake_cc_package_library",
+)
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+package(default_visibility = ["//visibility:public"])
+
+drake_cc_package_library(
+    name = "render",
+    deps = [
+        ":render_engine",
+        ":render_label",
+    ],
+)
+
+# A build target for code that wants to interact with the *idea* of a render
+# engine but doesn't want any build dependencies on the implementation details.
+drake_cc_library(
+    name = "render_engine",
+    srcs = ["render_engine.cc"],
+    hdrs = [
+        "camera_properties.h",
+        "render_engine.h",
+    ],
+    deps = [
+        ":render_label",
+        "//geometry:geometry_index",
+        "//geometry:geometry_roles",
+        "//geometry:shape_specification",
+        "//geometry:utilities",
+        "//systems/sensors:image",
+    ],
+)
+
+drake_cc_library(
+    name = "render_label",
+    srcs = ["render_label.cc"],
+    hdrs = ["render_label.h"],
+    deps = [
+        "//common:essential",
+        "//common:hash",
+    ],
+)
+
+# === test/ ===
+
+drake_cc_googletest(
+    name = "render_engine_test",
+    deps = [
+        ":render_engine",
+        "//common/test_utilities",
+    ],
+)
+
+drake_cc_googletest(
+    name = "render_label_test",
+    deps = [":render_label"],
+)
+
+add_lint_tests()

--- a/geometry/render/camera_properties.h
+++ b/geometry/render/camera_properties.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <utility>
+
+namespace drake {
+namespace geometry {
+namespace render {
+
+// TODO(SeanCurtis-TRI): Allow for configuring the intrinsic matrix directly
+// with a projection matrix.
+/** The intrinsic properties for a render camera. The render system
+ uses a reduced set of intrinsic parameters by making some simplifying
+ assumptions:
+
+ - Zero skew coefficient between the x- and y-axes.
+ - The camera's principal point lies in the center of the image.
+
+ The focal length is inferred by the sensor format (width and height) and the
+ field of view along the y-axis. */
+struct CameraProperties {
+  CameraProperties(int width_in, int height_in, double fov_y_in,
+                   std::string renderer_name_in)
+      : width(width_in),
+        height(height_in),
+        fov_y(fov_y_in),
+        renderer_name(std::move(renderer_name_in)) {}
+
+  int width{};          ///< The width of the image (in pixels) to be rendered.
+  int height{};         ///< The height of the image (in pixels) to be rendered.
+  double fov_y{};       ///< The camera's vertical field of view (in radians).
+  std::string renderer_name;  ///< The render fidelity of this camera.
+};
+
+/** The intrinsic properties for a render _depth_ camera. Consists of all of the
+ intrinsic properties of the render camera but extended with additional
+ depth-specific parameters.
+ @see CameraProperties */
+struct DepthCameraProperties : public CameraProperties {
+  DepthCameraProperties(int width_in, int height_in, double fov_y_in,
+                        std::string renderer_name_in, double z_near_in,
+                        double z_far_in)
+      : CameraProperties(width_in, height_in, fov_y_in,
+                         std::move(renderer_name_in)),
+        z_near(z_near_in),
+        z_far(z_far_in) {}
+
+  double z_near{};  ///< The minimum reportable depth value. All surfaces closer
+                    ///< than this distance, saturate to this value.
+  double z_far{};   ///< The maximum reportable depth value. All surfaces
+                    ///< farther than this distance, saturate to this value.
+};
+
+// TODO(SeanCurtis-TRI): Add properties for structured-light depth sensor which
+// includes offsets from camera pose for both the emitter and sensor.
+
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/render_engine.cc
+++ b/geometry/render/render_engine.cc
@@ -1,0 +1,25 @@
+#include "drake/geometry/render/render_engine.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+
+std::unique_ptr<RenderEngine> RenderEngine::Clone() const {
+  return std::unique_ptr<RenderEngine>(DoClone());
+}
+
+optional<RenderIndex> RenderEngine::RegisterVisual(
+    GeometryIndex index, const drake::geometry::Shape& shape,
+    const PerceptionProperties& properties,
+    const Isometry3<double>& X_WG, bool needs_updates) {
+  optional<RenderIndex> render_index =
+      DoRegisterVisual(shape, properties, X_WG);
+  if (render_index && needs_updates) {
+    update_indices_.insert({*render_index, index});
+  }
+  return render_index;
+}
+
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/render_engine.h
+++ b/geometry/render/render_engine.h
@@ -1,0 +1,174 @@
+
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include <Eigen/Dense>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/drake_optional.h"
+#include "drake/geometry/geometry_index.h"
+#include "drake/geometry/geometry_roles.h"
+#include "drake/geometry/render/camera_properties.h"
+#include "drake/geometry/shape_specification.h"
+#include "drake/geometry/utilities.h"
+#include "drake/systems/sensors/image.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+
+/** The engine for performing rasterization operations on geometry. This
+ includes rgb images, depth images, and, more generally, operations that can
+ be performed in the OpenGL shader pipeline. The coordinate system of
+ %RenderEngine's viewpoint `R` is `X-right`, `Y-down` and `Z-forward`
+ with respect to the rendered images.
+
+ Output image format:
+   - RGB (ImageRgba8U) : the RGB image has four channels in the following
+     order: red, green, blue, and alpha. Each channel is represented by
+     a uint8_t.
+
+   - Depth (ImageDepth32F) : the depth image has a depth channel represented
+     by a float. For a point in space `P`, the value stored in the depth
+     channel holds *the Z-component of the position vector `p_RP`.*
+     Note that this is different from the range data used by laser
+     range finders (like that provided by DepthSensor) in which the depth
+     value represents the distance from the sensor origin to the object's
+     surface.
+
+   - Label (ImageLabel16I) : the label image has single channel represented
+     by a int16_t. The value stored in the channel holds a RenderLabel value
+     which corresponds to an object class in the scene. Pixels attributable to
+     no geometry contain the RenderLabel::empty_label() value. A special class
+     has already been defined for "terrain": RenderLabel::terrain_label().  */
+class RenderEngine : public ShapeReifier {
+ public:
+  // TODO(SeanCurtis-TRI): I should consider making this protected.
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(RenderEngine);
+
+  RenderEngine() = default;
+
+  virtual ~RenderEngine() {}
+
+  /** Clones the render engine -- making the RenderEngine compatible with
+   copyable_unique_ptr.  */
+  std::unique_ptr<RenderEngine> Clone() const;
+
+  /** Adds a flat terrain to the render engine; it renders to a default render
+   color and the RenderLabel::terrain_label() label value.  */
+  virtual void AddFlatTerrain() = 0;
+
+  /** Registers a shape specification and returns the optional index of the
+   corresponding render geometry. The geometry can be uniquely referenced in
+   this engine (and copies of this engine) by its geometry index. The renderer
+   is allowed to examine the given `properties` and choose to _not_ register
+   the geometry.
+
+   @param index          The global index of the shape to register.
+   @param shape          The shape specification to add to the render engine.
+   @param properties     The perception properties provided for this geometry.
+   @param X_WG           The pose of the geometry relative to the world frame W.
+   @param needs_updates  If true, the geometry's pose will be updated via
+                         UpdatePoses().
+   @returns A unique index for the resultant render geometry (nullopt if not
+            registered).
+   @throws std::runtime_error if the shape is an unsupported type.  */
+  optional<RenderIndex> RegisterVisual(
+      GeometryIndex index,
+      const Shape& shape, const PerceptionProperties& properties,
+      const Isometry3<double>& X_WG, bool needs_updates = true);
+
+  /** Given the poses of *all* geometries in SceneGraph (measured and expressed
+   in the world frame), updates the internal representations of the subset of
+   geometry that are registered with _this_ renderer.  */
+  template <typename T>
+  void UpdatePoses(const std::vector<Isometry3<T>>& X_WG) {
+    for (auto pair : update_indices_) {
+      RenderIndex render_index = pair.first;
+      GeometryIndex global_index = pair.second;
+      DoUpdateVisualPose(internal::convert(X_WG[global_index]), render_index);
+    }
+  }
+
+  /** Updates the renderer's viewpoint with given pose X_WR.
+
+   @param X_WR  The pose of renderer's viewpoint in the world coordinate
+                system.  */
+  virtual void UpdateViewpoint(const Eigen::Isometry3d& X_WR) const = 0;
+
+  // TODO(SeanCurtis-TRI): Determine if I like the fact that the images are
+  // output parameters when I have a void.  Do, I *know* the image is the right
+  // size?
+
+  /** Renders and outputs the rendered color image.
+
+   @param camera                The intrinsic properties of the camera.
+   @param[out] color_image_out  The rendered color image.
+   @param show_window           If true, the render window will be displayed.
+  */
+  virtual void RenderColorImage(const CameraProperties& camera,
+                                systems::sensors::ImageRgba8U* color_image_out,
+                                bool show_window) const = 0;
+
+  /** Renders and outputs the rendered depth image. In contrast to the other
+   rendering operations, depth images don't have an option to display the
+   window; generally, basic depth images are not readily communicative to
+   humans.
+
+   @param camera                The intrinsic properties of the camera.
+   @param[out] depth_image_out  The rendered depth image.  */
+  virtual void RenderDepthImage(
+      const DepthCameraProperties& camera,
+      systems::sensors::ImageDepth32F* depth_image_out) const = 0;
+
+  /** Renders and outputs the rendered label image.
+
+   @param camera                The intrinsic properties of the camera.
+   @param[out] label_image_out  The rendered label image.
+   @param show_window           If true, the render window will be displayed.
+  */
+  virtual void RenderLabelImage(
+      const CameraProperties& camera,
+      systems::sensors::ImageLabel16I* label_image_out,
+      bool show_window) const = 0;
+
+ protected:
+  /** The NVI-function for sub-classes to implement actual geometry
+   registration. If the derived class chooses not to register this particular
+   shape, it should return nullopt.
+
+   A derived render engine can choose not to register geometry because, e.g., it
+   doesn't have required properties. This is the primary mechanism which enables
+   different renderers to use different geometries for the same frame.
+   For example, a low-fidelity renderer may use simple geometry whereas a
+   high-fidelity renderer would require a very detailed geometry. Both
+   geometries would have PerceptionProperties, but, based on the provided
+   properties, one would be accepted and registered with one render engine
+   implementation and the other geometry with another render engine.  */
+  virtual optional<RenderIndex> DoRegisterVisual(
+      const Shape& shape, const PerceptionProperties& properties,
+      const Isometry3<double>& X_WG) = 0;
+
+  /** The NVI-function for updating the pose of a render geometry (identified
+   by index) to the given pose X_WG.
+
+   @param X_WG     The pose of the render geometry in the world frame.
+   @param index    The index of the render geometry whose pose is being set.  */
+  virtual void DoUpdateVisualPose(const Eigen::Isometry3d& X_WG,
+                                RenderIndex index) = 0;
+
+  /** The NVI-function for cloning this render engine.  */
+  virtual std::unique_ptr<RenderEngine> DoClone() const = 0;
+
+ private:
+  // Mapping from this renderer's RenderIndex to the global index in SceneGraph
+  // of the geometries that need updating.
+  std::unordered_map<RenderIndex, GeometryIndex> update_indices_;
+};
+
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/render_label.cc
+++ b/geometry/render/render_label.cc
@@ -1,0 +1,18 @@
+#include "drake/geometry/render/render_label.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+
+std::ostream& operator<<(std::ostream& out, const RenderLabel& label) {
+  out << label.value_;
+  return out;
+}
+
+std::string to_string(const RenderLabel& label) {
+  return std::to_string(label.value_);
+}
+
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/render_label.h
+++ b/geometry/render/render_label.h
@@ -1,0 +1,203 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <iostream>
+#include <limits>
+#include <string>
+
+#include "drake/common/hash.h"
+#include "drake/common/never_destroyed.h"
+
+namespace drake {
+
+// Forward declaration to support friend declaration.
+namespace systems {
+namespace sensors {
+
+template <typename IdType>
+class ColorPalette;
+
+}  // namespace sensors
+}  // namespace systems
+
+namespace geometry {
+namespace render {
+
+/**
+ Class representing object "labels" for rendering.
+
+ Geometry in the scene can be grouped into classifications. Each classification
+ is associated with a label value. For example, all links in a robot arm could
+ be classified as "robot", the static environment (tables, etc.) could be
+ classified as "environment", and manipulands would likewise get one or more
+ classes. Each of these would be associated with a label _value_.
+
+ These classes are used in the renderer in generating a "label image"
+ (@see RenderEngine::RenderLabelImage() for details).
+
+ This %RenderLabel class is responsible for guaranteeing *globally* unique
+ labels such that two geometry sources cannot accidentally assign the same label
+ value to different classes.
+
+ __Usage__
+
+ Geometry sources should invoke RenderLabel::new_label() to generate a
+ globally unique label. The _semantics_ of that label is defined by the
+ geometry source. That label should be stored and then applied to all of the
+ visual geometries which belong to that semantic class. The label image will
+ contain integer values which correspond to the set of __known__ labels. Those
+ values can be compared with the source's persisted labels to determine the
+ class of object that rendered to the corresponding pixel.
+
+ Multiple geometry sources can share a label to have a common semantic
+ interpretation. The label would be generated and then shared. The rendered
+ image can include labels defined by _all_ geometry sources. So, any particular
+ geometry source may encounter label values it did not generate. The
+ system must either ignore them, or have been given knowledge of those labels
+ from some other source.
+
+ The set of known labels always includes two universal labels: "empty" and
+ "terrain". The empty label is applied to pixels in which *no* geometry is
+ drawn. The "terrain" label is a generic catch all; it can be used to detect
+ that something rasterized to the pixel, but the geometry's nature is
+ unimportant. The name comes from driving in which the uncharacterized
+ background would be "terrain". The label values can be acquired by calling
+ RenderLabel::empty_label() and RenderLabel::terrain_label(),
+ respectively.
+
+ @note The renderer only supports approximately 1500 unique labels. Every call
+ to new_label() consumes one of those unique labels. Be careful not to
+ generate and then throw them away; they can't be recovered.
+
+ @cond
+ NOTE: In many ways, this is very similar to the TypeSafeIndex class. There are
+ several key differences:
+   - added static members,
+   - special values (empty and terrain),
+   - arbitrarily limited domain (kLabelCount).
+
+ // TODO(SeanCurtis-TRI):
+ //  1. Change the "default" labels to:
+ //      - "empty" (no object at that pixel)
+ //      - "ignored" (the former "terrain")
+ //      - "unclassified" (the default value which indicates that no label was
+ //        explicitly assigned -- indcating possible user error).
+ @endcond
+ */
+class RenderLabel {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(RenderLabel)
+
+  /** Default constructor; the result is the empty label value. */
+  RenderLabel() : value_(kEmptyValue) {}
+
+  /** Reports if the label is the empty label. */
+  bool is_empty() const { return value_ == kEmptyValue; }
+
+  /** Reports if the label is the terrain label. */
+  bool is_terrain() const { return value_ == kTerrainValue; }
+
+  /** Compares this label with the `other` label. Reports true if they have the
+   same value. */
+  bool operator==(const RenderLabel& other) const {
+    return value_ == other.value_;
+  }
+
+  /** Compares this label with the `other` label. Reports true if they have
+   different values. */
+  bool operator!=(const RenderLabel& other) const {
+    return value_ != other.value_;
+  }
+
+  /** Allows the labels to be compared to imply a total ordering -- facilitates
+   use in data structures which require ordering (e.g., std::set).  */
+  bool operator<(const RenderLabel& other) const {
+    return value_ < other.value_;
+  }
+
+  /** Generates a new identifier for this id type. This new identifier will be
+   different from all previous identifiers created. This method does _not_
+   make any guarantees about the values of ids from successive invocations.
+   This method is guaranteed to be thread safe.
+   @throws std::runtime_error if the number of calls to new_label() exceeds the
+   number of ids supported by Type.
+   */
+  static RenderLabel new_label() {
+    // Note that id 0 is empty, 1 is terrain.
+    static never_destroyed<std::atomic<int16_t>> next_label(0);
+    int16_t value = next_label.access()++;
+    if (value >= kLabelCount) {
+      throw std::runtime_error(
+          "Calls to new_label() have exhausted the available labels");
+    }
+    return RenderLabel(value);
+  }
+
+  /** Returns a label representing the "empty", or no object, label. */
+  static RenderLabel empty_label() {
+    return RenderLabel{kEmptyValue};
+  }
+
+  /** Returns a label representing the "terrain" label. */
+  static RenderLabel terrain_label() {
+    return RenderLabel{kTerrainValue};
+  }
+
+  /** Implements the @ref hash_append concept. */
+  template <class HashAlgorithm>
+  friend void hash_append(HashAlgorithm& hasher,
+                          const RenderLabel& item) noexcept {
+    using drake::hash_append;
+    hash_append(hasher, item.value_);
+  }
+
+  /** Implicit conversion to int16_t. */
+  operator int16_t() const { return value_; }
+
+  friend std::ostream& operator<<(std::ostream& out, const RenderLabel& label);
+
+  /** Enables use of labels with to_string. It requires ADL to work. So,
+   it should be invoked as: `to_string(label);` and should be preceded by
+   `using std::to_string`.*/
+  friend std::string to_string(const RenderLabel& label);
+
+ private:
+  // TODO(SeanCurtis-TRI): Modify how the color palette allocates colors to
+  // remove this artificial limit.
+  // The maximum number of labels available--dictated, currently, by the
+  // implementation of ColorPalette.
+  static constexpr int16_t kLabelCount = 256 * 6 - 1;
+  static constexpr int16_t kEmptyValue = kLabelCount + 1;
+  static constexpr int16_t kTerrainValue = kEmptyValue + 1;
+
+  static_assert(kLabelCount <= INT16_MAX,
+                "The maximum label value must be small enough to fit in an "
+                    "2-byte integer");
+
+  // Temporary support for the color palette to do pre-emptive color allocation.
+  template <typename T>
+  friend class systems::sensors::ColorPalette;
+
+  // Instantiates an identifier from the underlying representation type.
+  explicit RenderLabel(int val) : value_(val) {}
+
+  // The underlying value.
+  int16_t value_;
+};
+
+
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake
+
+namespace std {
+
+/** Enables use of the label to serve as a key in STL containers.
+ @relates RenderLabel
+ */
+template <>
+struct hash<drake::geometry::render::RenderLabel>
+    : public drake::DefaultHash {};
+
+}  // namespace std

--- a/geometry/render/test/render_engine_test.cc
+++ b/geometry/render/test/render_engine_test.cc
@@ -1,0 +1,143 @@
+#include "drake/geometry/render/render_engine.h"
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace {
+
+// Dummy implementation of the RenderEngine interface to facilitate testing
+// the specific RenderEngine functionality.
+class DummyRenderEngine final : public RenderEngine {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DummyRenderEngine);
+  DummyRenderEngine() = default;
+  void AddFlatTerrain() final {}
+  void UpdateViewpoint(const Eigen::Isometry3d&) const final {}
+  void RenderColorImage(const render::CameraProperties&,
+                        systems::sensors::ImageRgba8U*, bool) const final {}
+  void RenderDepthImage(const render::DepthCameraProperties&,
+                        systems::sensors::ImageDepth32F*) const final {}
+  void RenderLabelImage(const render::CameraProperties&,
+                        systems::sensors::ImageLabel16I*, bool) const final {}
+  void ImplementGeometry(const Sphere& sphere, void* user_data) final {}
+  void ImplementGeometry(const Cylinder& cylinder, void* user_data) final {}
+  void ImplementGeometry(const HalfSpace& half_space, void* user_data) final {}
+  void ImplementGeometry(const Box& box, void* user_data) final {}
+  void ImplementGeometry(const Mesh& mesh, void* user_data) final {}
+  void ImplementGeometry(const Convex& convex, void* user_data) final {}
+
+  // Test harness.
+
+  // Provide access to the group name that implies full registration.
+  const std::string& include_group_name() const { return include_group_name_; }
+
+  // Return the indices that have been updated via a call to UpdatePoses().
+  const std::map<RenderIndex, Eigen::Isometry3d>& updated_indices() const {
+    return updated_indices_;
+  }
+
+ protected:
+  // Conditionally register the visual based on the properties having an
+  // "in_test" group.
+  optional<RenderIndex> DoRegisterVisual(const Shape&,
+                                         const PerceptionProperties& properties,
+                                         const Isometry3<double>&) final {
+    if (properties.HasGroup(include_group_name_)) {
+      return RenderIndex(++register_count_);
+    }
+    return nullopt;
+  }
+
+  // Track all of the indices provided an update pose for.
+  void DoUpdateVisualPose(const Eigen::Isometry3d& X_WG,
+                          RenderIndex index) final {
+    updated_indices_[index] = X_WG;
+  }
+
+  std::unique_ptr<render::RenderEngine> DoClone() const final {
+    return std::make_unique<DummyRenderEngine>(*this);
+  }
+
+ private:
+  int register_count_{};
+  // Track each index and what it has been updated to (allows us to confirm
+  // RenderIndex and GeometryIndex association.
+  std::map<RenderIndex, Eigen::Isometry3d> updated_indices_;
+  // The group name whose presence will lead to a shape being added to the
+  // engine.
+  std::string include_group_name_{"in_test"};
+};
+
+// Tests the RenderEngine-specific functionality for managing registration of
+// geometry and its corresponding update behavior. The former should configure
+// each geometry correctly on whether it gets updated or not, and the latter
+// will confirm that the right geometries get updated.
+GTEST_TEST(RenderEngine, RegistrationAndUpdate) {
+  DummyRenderEngine engine;
+
+  // Configure parameters for registering visuals.
+  PerceptionProperties skip_properties;
+  PerceptionProperties add_properties;
+  add_properties.AddProperty(engine.include_group_name(), "ignored", 0);
+  Sphere sphere(1.0);
+  Isometry3<double> X_WG = Isometry3<double>::Identity();
+  // A collection of poses to provide to calls to UpdatePoses(). Configured
+  // to all identity transforms because the values generally don't matter. In
+  // the single case where it does matter, a value is explicitly set (see
+  // below).
+  std::vector<Isometry3<double>> X_WG_all{3, X_WG};
+
+  // These test cases are accumulative; re-ordering them will require
+  // refactoring.
+
+  // Case: the shape is configured to be ignored by the render engine. Returns
+  // nullopt (and other arguments do not matter).
+  optional<RenderIndex> optional_index = engine.RegisterVisual(
+      GeometryIndex(0), sphere, skip_properties, X_WG, false);
+  EXPECT_FALSE(optional_index);
+  optional_index = engine.RegisterVisual(GeometryIndex(0), sphere,
+                                         skip_properties, X_WG, true);
+  EXPECT_FALSE(optional_index);
+  // Confirm nothing is updated - because nothing is registered.
+  engine.UpdatePoses(X_WG_all);
+  EXPECT_EQ(engine.updated_indices().size(), 0);
+
+  // Case: the shape is configured for registration, but does *not* require
+  // updating. We get a valid render index, but it is _not_ included in
+  // UpdatePoses().
+  optional_index = engine.RegisterVisual(GeometryIndex(1), sphere,
+                                         add_properties, X_WG, false);
+  EXPECT_TRUE(optional_index);
+  engine.UpdatePoses(X_WG_all);
+  EXPECT_EQ(engine.updated_indices().size(), 0);
+
+  // Case: the shape is configured for registration *and* requires updating. We
+  // get a valid render index and it _is_ included in UpdatePoses().
+  GeometryIndex update_index{2};
+  // Configure the pose for index 2 to *not* be the identity so we can confirm
+  // that the registered GeometryIndex is properly associated with the resulting
+  // RenderIndex.
+  Vector3<double> p_WG(1, 2, 3);
+  X_WG_all[update_index].translation() << p_WG;
+  optional_index =
+      engine.RegisterVisual(update_index, sphere, add_properties, X_WG, true);
+  EXPECT_TRUE(optional_index);
+  engine.UpdatePoses(X_WG_all);
+  EXPECT_EQ(engine.updated_indices().size(), 1);
+  ASSERT_EQ(engine.updated_indices().count(*optional_index), 1);
+  EXPECT_TRUE(CompareMatrices(
+      engine.updated_indices().at(*optional_index).translation(), p_WG));
+}
+
+}  // namespace
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/test/render_label_test.cc
+++ b/geometry/render/test/render_label_test.cc
@@ -1,0 +1,88 @@
+#include "drake/geometry/render/render_label.h"
+
+#include <unordered_set>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace  {
+
+class RenderLabelTests : public ::testing::Test {
+ protected:
+  // Because the label counter is global, to get some *fixed* labels, we
+  // need to grab a number before any tests run.
+  static void SetUpTestCase() {
+    for (int i = 0; i < kLabelCount; ++i) {
+      labels_[i] = RenderLabel::new_label();
+      // This does two things:
+      //  1. Confirms the labels are what the rest of the tests think they are
+      //  2. Tests comparisons between labels and ints.
+      ASSERT_EQ(labels_[i], i);
+      ASSERT_EQ(i, labels_[i]);
+    }
+  }
+  static constexpr int kLabelCount = 4;
+  static std::vector<RenderLabel> labels_;
+};
+
+std::vector<RenderLabel> RenderLabelTests::labels_{kLabelCount};
+
+// Confirms that default labels are empty labels.
+TEST_F(RenderLabelTests, DefaultConstructor) {
+  EXPECT_EQ(RenderLabel(), RenderLabel::empty_label());
+}
+
+// Confirms that assignment behaves correctly. This also implicitly tests
+// equality and inequality.
+TEST_F(RenderLabelTests, AssignmentAndComparison) {
+  EXPECT_TRUE(labels_[0] != labels_[1]);
+  RenderLabel temp = labels_[1];
+  EXPECT_TRUE(temp == labels_[1]);
+  temp = labels_[2];
+  EXPECT_TRUE(temp == labels_[2]);
+  // This exploits the knowledge that labels are allocated in a monotonically
+  // increasing order. Also, all allocated labels are smaller than the special
+  // values.
+  EXPECT_TRUE(labels_[0] < labels_[1]);
+  EXPECT_TRUE(labels_[0] < RenderLabel::empty_label());
+  EXPECT_TRUE(labels_[0] < RenderLabel::terrain_label());
+}
+
+// Confirms that when I've acquired T - 1 labels (where T is the value of the
+// terrain label) that subsequent efforts to request a label will fail.
+TEST_F(RenderLabelTests, ConsumeAllLabels) {
+  // NOTE: This will require counting up to 2 billion.
+  EXPECT_THROW(while (true) RenderLabel::new_label(), std::runtime_error);
+}
+
+// Confirms that labels are configured to serve as unique keys in
+// STL containers.
+TEST_F(RenderLabelTests, ServeAsMapKey) {
+  std::unordered_set<RenderLabel> label_set;
+
+  // This is a *different* label with the *same* value as labels_[0]. It should
+  // *not* introduce a new value to the set.
+  RenderLabel temp = labels_[0];
+
+  EXPECT_EQ(label_set.size(), 0);
+  label_set.insert(labels_[0]);
+  EXPECT_NE(label_set.find(labels_[0]), label_set.end());
+  EXPECT_NE(label_set.find(temp), label_set.end());
+
+  EXPECT_EQ(label_set.size(), 1);
+  label_set.insert(labels_[1]);
+  EXPECT_EQ(label_set.size(), 2);
+
+  label_set.insert(temp);
+  EXPECT_EQ(label_set.size(), 2);
+
+  EXPECT_EQ(label_set.find(labels_[2]), label_set.end());
+}
+
+}  // namespace
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -293,6 +293,8 @@ class Convex final : public Shape {
  implementations require.  */
 class ShapeReifier {
  public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ShapeReifier)
+  ShapeReifier() = default;
   virtual ~ShapeReifier() {}
   virtual void ImplementGeometry(const Sphere& sphere, void* user_data) = 0;
   virtual void ImplementGeometry(const Cylinder& cylinder, void* user_data) = 0;

--- a/geometry/test/utilities_test.cc
+++ b/geometry/test/utilities_test.cc
@@ -4,9 +4,11 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+
 namespace drake {
 namespace geometry {
-namespace detail {
+namespace internal {
 namespace {
 
 GTEST_TEST(GeometryUtilities, CanonicalizeGeometryName) {
@@ -52,7 +54,22 @@ GTEST_TEST(GeometryUtilities, CanonicalizeGeometryName) {
   }
 }
 
+GTEST_TEST(GeometryUtilities, IsometryConversion) {
+  Isometry3<double> X_AB = Isometry3<double>::Identity();
+  X_AB.translation() << 1, 2, 3;
+  // NOTE: Not a valid transform; we're just looking for unique values.
+  X_AB.linear() << 10, 20, 30, 40, 50, 60, 70, 80, 90;
+  X_AB.makeAffine();
+
+  Isometry3<double> X_AB_converted = convert(X_AB);
+  EXPECT_TRUE(CompareMatrices(X_AB.matrix(), X_AB_converted.matrix()));
+
+  Isometry3<AutoDiffXd> X_AB_ad(X_AB);
+  Isometry3<double> X_AB_ad_converted = convert(X_AB_ad);
+  EXPECT_TRUE(CompareMatrices(X_AB.matrix(), X_AB_ad_converted.matrix()));
+}
+
 }  // namespace
-}  // namespace detail
+}  // namespace internal
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/utilities.cc
+++ b/geometry/utilities.cc
@@ -6,7 +6,7 @@
 
 namespace drake {
 namespace geometry {
-namespace detail {
+namespace internal {
 
 std::string CanonicalizeStringName(const std::string& name) {
   // The definition of "canonical" is based on SDF and the functionality in
@@ -29,6 +29,10 @@ std::string CanonicalizeStringName(const std::string& name) {
   return matches[1].str();
 }
 
-}  // namespace detail
+const Isometry3<double>& convert(const Isometry3<double>& transform) {
+  return transform;
+}
+
+}  // namespace internal
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/utilities.h
+++ b/geometry/utilities.h
@@ -3,23 +3,20 @@
 #include <string>
 #include <unordered_map>
 
+#include "drake/common/autodiff.h"
+#include "drake/common/autodiff_overloads.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
 
 namespace drake {
 namespace geometry {
-
-// TODO(SeanCurtis-TRI): Get rid of the "detail" namespace.
-namespace detail {
+namespace internal {
 
 /** Canonicalizes the given geometry *candidate* name. A canonicalized name may
  still not be valid (as it may duplicate a previously used name). See
  @ref canonicalized_geometry_names "documentation in GeometryInstance" for
  details. */
 std::string CanonicalizeStringName(const std::string& name);
-
-}  // namespace detail
-
-namespace internal {
 
 /// A const range iterator through the keys of an unordered map.
 template <typename K, typename V>
@@ -58,7 +55,33 @@ class MapKeyRange {
   const std::unordered_map<K, V>* map_;
 };
 
-}  // namespace internal
+/** @name Isometry scalar conversion
 
+ Some of SceneGraph's inner-workings are _not_ templated on scalar type and
+ always require Isometry3<double>. These functions work in an ADL-compatible
+ manner to allow SceneGraph to mindlessly convert templated Isometry3 to
+ double-valued transforms.  */
+//@{
+
+// TODO(SeanCurtis-TRI): Get rid of these when I finally swap for
+// RigidTransforms.
+
+const Isometry3<double>& convert(const Isometry3<double>& transform);
+
+template <class VectorType>
+Isometry3<double> convert(
+    const Isometry3<Eigen::AutoDiffScalar<VectorType>>& transform) {
+  Isometry3<double> result;
+  for (int r = 0; r < 4; ++r) {
+    for (int c = 0; c < 4; ++c) {
+      result.matrix()(r, c) = ExtractDoubleOrThrow(transform.matrix()(r, c));
+    }
+  }
+  return result;
+}
+
+//@}
+
+}  // namespace internal
 }  // namespace geometry
 }  // namespace drake


### PR DESCRIPTION
- Introduces the RenderEngine interface (strongly resembles the RgbdRenderer interface.
- Updates a number of constructs that the RenderEngine either produces or
  consumes:
  - PerceptionProperties - per-geometry rendering properties.
  - RenderLabel - the global label abstraction (replaces int in RgbdRenderer)
  - RenderIndex - internal index for accessing geometry in engine.
  - CameraProperties - the formulation of a camera for rendering purposes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10235)
<!-- Reviewable:end -->
