### PR TITLE
Expose the SG used for rendering from manip station. 

### DIFF
--- a/examples/manipulation_station/manipulation_station.cc
+++ b/examples/manipulation_station/manipulation_station.cc
@@ -447,12 +447,12 @@ void ManipulationStation<T>::Finalize() {
                        "iiwa_torque_external");
 
   {  // RGB-D Cameras
-    auto render_scene_graph =
+    render_scene_graph_ =
         builder.template AddSystem<geometry::dev::SceneGraph>(*scene_graph_);
-    render_scene_graph->set_name("dev_scene_graph_for_rendering");
+    render_scene_graph_->set_name("dev_scene_graph_for_rendering");
 
     builder.Connect(plant_->get_geometry_poses_output_port(),
-                    render_scene_graph->get_source_pose_port(
+                    render_scene_graph_->get_source_pose_port(
                         plant_->get_source_id().value()));
 
     for (const auto& info_pair : camera_information_) {
@@ -470,7 +470,7 @@ void ManipulationStation<T>::Finalize() {
           builder.template AddSystem<systems::sensors::dev::RgbdCamera>(
               camera_name, parent_body_id.value(), X_PC, info.properties,
               false);
-      builder.Connect(render_scene_graph->get_query_output_port(),
+      builder.Connect(render_scene_graph_->get_query_output_port(),
                       camera->query_object_input_port());
 
       builder.ExportOutput(camera->color_image_output_port(),

--- a/examples/manipulation_station/manipulation_station.h
+++ b/examples/manipulation_station/manipulation_station.h
@@ -259,26 +259,28 @@ class ManipulationStation : public systems::Diagram<T> {
   /// add additional elements into the world before calling Finalize().
   geometry::SceneGraph<T>& get_mutable_scene_graph() { return *scene_graph_; }
 
-  /// Returns a const pointer to the SceneGraph that's being used to render
+  /// Returns a const reference to the SceneGraph used for rendering
   /// camera images. Since the SceneGraph for rendering is constructed in
-  /// Finalize(), this returns nullptr before Finalize() is called.
+  /// Finalize(), this throws when called before Finalize().
   /// Note: the current implementation of the manipulation station uses a
   /// separate development version of SceneGraph for rendering (as opposed to
   /// the one returned by get_scene_graph() used for contact detection and
   /// visualization). This method will be deprecated soon.
-  const geometry::dev::SceneGraph<T>* get_render_scene_graph() const {
-    return render_scene_graph_;
+  const geometry::dev::SceneGraph<T>& get_render_scene_graph() const {
+    DRAKE_THROW_UNLESS(render_scene_graph_);
+    return *render_scene_graph_;
   }
 
-  /// Returns a mutable pointer to the SceneGraph that's being used to render
+  /// Returns a mutable reference to the SceneGraph used for rendering
   /// camera images. Since the SceneGraph for rendering is constructed in
-  /// Finalize(), this returns nullptr before Finalize() is called.
+  /// Finalize(), this throws when called before Finalize().
   /// Note: the current implementation of the manipulation station uses a
   /// separate development version of SceneGraph for rendering (as opposed to
   /// the one returned by get_scene_graph() used for contact detection and
   /// visualization). This method will be deprecated soon.
-  geometry::dev::SceneGraph<T>* get_mutable_render_scene_graph() {
-    return render_scene_graph_;
+  geometry::dev::SceneGraph<T>& get_mutable_render_scene_graph() {
+    DRAKE_THROW_UNLESS(render_scene_graph_);
+    return *render_scene_graph_;
   }
 
   /// Return a reference to the plant used by the inverse dynamics controller

--- a/examples/manipulation_station/manipulation_station.h
+++ b/examples/manipulation_station/manipulation_station.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "drake/common/eigen_types.h"
+#include "drake/geometry/dev/scene_graph.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/plant/multibody_plant.h"
@@ -258,6 +259,28 @@ class ManipulationStation : public systems::Diagram<T> {
   /// add additional elements into the world before calling Finalize().
   geometry::SceneGraph<T>& get_mutable_scene_graph() { return *scene_graph_; }
 
+  /// Returns a const pointer to the SceneGraph that's being used to render
+  /// camera images. Since the SceneGraph for rendering is constructed in
+  /// Finalize(), this returns nullptr before Finalize() is called.
+  /// Note: the current implementation of the manipulation station uses a
+  /// separate development version of SceneGraph for rendering (as opposed to
+  /// the one returned by get_scene_graph() used for contact detection and
+  /// visualization). This method will be deprecated soon.
+  const geometry::dev::SceneGraph<T>* get_render_scene_graph() const {
+    return render_scene_graph_;
+  }
+
+  /// Returns a mutable pointer to the SceneGraph that's being used to render
+  /// camera images. Since the SceneGraph for rendering is constructed in
+  /// Finalize(), this returns nullptr before Finalize() is called.
+  /// Note: the current implementation of the manipulation station uses a
+  /// separate development version of SceneGraph for rendering (as opposed to
+  /// the one returned by get_scene_graph() used for contact detection and
+  /// visualization). This method will be deprecated soon.
+  geometry::dev::SceneGraph<T>* get_mutable_render_scene_graph() {
+    return render_scene_graph_;
+  }
+
   /// Return a reference to the plant used by the inverse dynamics controller
   /// (which contains only a model of the iiwa + equivalent mass of the
   /// gripper).
@@ -371,6 +394,8 @@ class ManipulationStation : public systems::Diagram<T> {
   std::unique_ptr<multibody::MultibodyPlant<T>> owned_controller_plant_;
   multibody::MultibodyPlant<T>* plant_;
   geometry::SceneGraph<T>* scene_graph_;
+  // This is made in Finalize().
+  geometry::dev::SceneGraph<T>* render_scene_graph_{};
 
   // Populated by RegisterIiwaControllerModel() and
   // RegisterWsgControllerModel().


### PR DESCRIPTION
- expose the scene graph for rendering camera images.
- fixed a bug in num_x querries for dev scene graph inspector.

cc @SeanCurtis-TRI if you want, i can take out the changes to the inspector.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10239)
<!-- Reviewable:end -->
