### PR TITLE
Speedup NewNonnegativePolynomial for sdsos polynomial

### DIFF
--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -786,11 +786,11 @@ MathematicalProgram::AddPositiveDiagonallyDominantMatrixConstraint(
 }
 
 namespace {
-// Add the slack variable for scaled diagonally dominant matrix constraint. The
-// only thing left in AddScaledDiagonallyDominantMatrixConstraint
-// is that the diagonal terms in the sdd matrix should match the summation of
-// the diagonally terms in the slack variable, and the rotated Lorentz cone
-// constraint on M.
+// Add the slack variable for scaled diagonally dominant matrix constraint. In
+// AddScaledDiagonallyDominantMatrixConstraint, we should add the constraint
+// that the diagonal terms in the sdd matrix should match the summation of
+// the diagonally terms in the slack variable, and the upper diagonal corner
+// in M[i][j] should satisfy the rotated Lorentz cone constraint.
 template <typename T>
 void AddSlackVariableForScaledDiagonallyDominantMatrixConstraint(
     const Eigen::Ref<const MatrixX<T>>& X, MathematicalProgram* prog,

--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -786,12 +786,11 @@ MathematicalProgram::AddPositiveDiagonallyDominantMatrixConstraint(
 }
 
 namespace {
-// Add the slack variable for scaled diagonally dominant matrix constraint. This
-// function also adds the rotated Lorentz cone constraint on the slack
-// variables. The only thing left in AddScaledDiagonallyDominantMatrixConstraint
+// Add the slack variable for scaled diagonally dominant matrix constraint. The
+// only thing left in AddScaledDiagonallyDominantMatrixConstraint
 // is that the diagonal terms in the sdd matrix should match the summation of
 // the diagonally terms in the slack variable, and the rotated Lorentz cone
-// constraint.
+// constraint on M.
 template <typename T>
 void AddSlackVariableForScaledDiagonallyDominantMatrixConstraint(
     const Eigen::Ref<const MatrixX<T>>& X, MathematicalProgram* prog,

--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -212,8 +212,7 @@ MathematicalProgram::NewNonnegativePolynomial(
       break;
     }
     case MathematicalProgram::NonnegativePolynomial::kSdsos: {
-      AddScaledDiagonallyDominantMatrixConstraint(
-          Q.cast<symbolic::Expression>());
+      AddScaledDiagonallyDominantMatrixConstraint(Q);
       break;
     }
     case MathematicalProgram::NonnegativePolynomial::kDsos: {

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -2114,21 +2114,29 @@ class MathematicalProgram {
       const Eigen::Ref<const MatrixX<symbolic::Expression>>& X);
 
   /**
+   * @anchor addsdd 
+   * @name     scaled diagonally dominant matrix constraint
    * Adds the constraint that a symmetric matrix is scaled diagonally dominant
    * (sdd). A matrix X is sdd if there exists a diagonal matrix D, such that
    * the product DXD is diagonally dominant with non-negative diagonal entries,
    * namely
    * d(i)X(i, i) ≥ ∑ⱼ |d(j)X(i, j)| ∀ j ≠ i
    * where d(i) = D(i, i).
-   * X being sdd is equivalent to the existence of symmetric matrices Mⁱʲ∈ ℝⁿˣⁿ
+   * X being sdd is equivalent to the existence of symmetric matrices Mⁱʲ∈ ℝⁿˣⁿ,
    * i < j, such that all entries in Mⁱʲ are 0, except Mⁱʲ(i, i), Mⁱʲ(i, j),
    * Mⁱʲ(j, j). (Mⁱʲ(i, i), Mⁱʲ(j, j), Mⁱʲ(i, j)) is in the rotated
-   * Lorentz cone, and X = ∑ᵢⱼ Mⁱʲ
+   * Lorentz cone, and X = ∑ᵢⱼ Mⁱʲ.
+   *
    * The users can refer to "DSOS and SDSOS Optimization: More Tractable
    * Alternatives to Sum of Squares and Semidefinite Optimization" by Amir Ali
    * Ahmadi and Anirudha Majumdar, with arXiv link
    * https://arxiv.org/abs/1706.02586.
-   * @param X The matrix X. We will use 0.5(X+Xᵀ) as the "symmetric version" of
+   */
+  //@{
+  /**
+   * This is an overloaded variance of @ref addsdd 
+   * "scaled diagonally dominant matrix constraint"
+   * @param X The matrix X to be constrained scaled diagonally dominant.
    * X.
    * @pre X(i, j) should be a linear expression of decision variables.
    * @return M A vector of vectors of 2 x 2 symmetric matrices M. For i < j,
@@ -2144,9 +2152,19 @@ class MathematicalProgram {
   AddScaledDiagonallyDominantMatrixConstraint(
       const Eigen::Ref<const MatrixX<symbolic::Expression>>& X);
 
+  /**
+   * This is an overloaded variance of @ref addsdd
+   * "scaled diagonally dominant matrix constraint"
+   * @param X The symmetric matrix X to be constrained scaled diagonally
+   * dominant.
+   * @return M For i < j M[i][j] contains the slack variables, mentioned in
+   * @ref addsdd "scaled diagonally dominant matrix constraint". For i >= j,
+   * M[i][j] contains dummy variables.
+   */
   std::vector<std::vector<Matrix2<symbolic::Variable>>>
   AddScaledDiagonallyDominantMatrixConstraint(
       const Eigen::Ref<const MatrixX<symbolic::Variable>>& X);
+  //@}
 
   /**
    * Adds constraints that a given polynomial @p p is a sums-of-squares (SOS),

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -2134,7 +2134,7 @@ class MathematicalProgram {
    */
   //@{
   /**
-   * This is an overloaded variance of @ref addsdd 
+   * This is an overloaded variant of @ref addsdd
    * "scaled diagonally dominant matrix constraint"
    * @param X The matrix X to be constrained scaled diagonally dominant.
    * X.
@@ -2153,7 +2153,7 @@ class MathematicalProgram {
       const Eigen::Ref<const MatrixX<symbolic::Expression>>& X);
 
   /**
-   * This is an overloaded variance of @ref addsdd
+   * This is an overloaded variant of @ref addsdd
    * "scaled diagonally dominant matrix constraint"
    * @param X The symmetric matrix X to be constrained scaled diagonally
    * dominant.

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -2144,6 +2144,10 @@ class MathematicalProgram {
   AddScaledDiagonallyDominantMatrixConstraint(
       const Eigen::Ref<const MatrixX<symbolic::Expression>>& X);
 
+  std::vector<std::vector<Matrix2<symbolic::Variable>>>
+  AddScaledDiagonallyDominantMatrixConstraint(
+      const Eigen::Ref<const MatrixX<symbolic::Variable>>& X);
+
   /**
    * Adds constraints that a given polynomial @p p is a sums-of-squares (SOS),
    * that is, @p p can be decomposed into `mᵀQm`, where m is the @p

--- a/solvers/test/scaled_diagonally_dominant_matrix_test.cc
+++ b/solvers/test/scaled_diagonally_dominant_matrix_test.cc
@@ -10,28 +10,41 @@ using drake::symbolic::test::ExprEqual;
 
 namespace drake {
 namespace solvers {
-GTEST_TEST(ScaledDiagonallyDominantMatrixTest, AddConstraint) {
-  MathematicalProgram prog;
-  auto X = prog.NewSymmetricContinuousVariables<4>();
+bool is_zero(const symbolic::Variable& v) { return v.is_dummy(); }
 
-  auto M = prog.AddScaledDiagonallyDominantMatrixConstraint(
-      X.cast<symbolic::Expression>());
-  for (int i = 0; i < 4; ++i) {
-    for (int j = 0; j < 4; ++j) {
+template <typename T>
+void CheckOffDiagonalTerms(int nx) {
+  MathematicalProgram prog;
+  auto X = prog.NewSymmetricContinuousVariables(nx);
+
+  auto M = prog.AddScaledDiagonallyDominantMatrixConstraint(X.cast<T>());
+  for (int i = 0; i < nx; ++i) {
+    for (int j = 0; j < nx; ++j) {
+      // M[i][j] should be a zero matrix if i >= j.
       if (i >= j) {
         for (int m = 0; m < 2; ++m) {
           for (int n = 0; n < 2; ++n) {
-            EXPECT_EQ(M[i][j](m, n), 0);
+            EXPECT_TRUE(is_zero(M[i][j](m, n)));
           }
         }
       } else {
-        EXPECT_PRED2(ExprEqual, M[i][j](0, 1).Expand(),
+        EXPECT_PRED2(ExprEqual, symbolic::Expression(M[i][j](0, 1)),
                      symbolic::Expression(X(i, j)));
+        EXPECT_PRED2(ExprEqual, symbolic::Expression(M[i][j](1, 0)),
+                     symbolic::Expression(X(j, i)));
       }
     }
   }
 }
 
+GTEST_TEST(ScaledDiagonallyDominantMatrixTest, AddConstraint) {
+  CheckOffDiagonalTerms<symbolic::Expression>(2);
+  CheckOffDiagonalTerms<symbolic::Variable>(2);
+  CheckOffDiagonalTerms<symbolic::Expression>(4);
+  CheckOffDiagonalTerms<symbolic::Variable>(4);
+}
+
+template <typename T>
 void CheckSDDMatrix(const Eigen::Ref<const Eigen::MatrixXd>& X_val,
                     bool is_sdd) {
   // Test if a sdd matrix satisfies the constraint.
@@ -39,8 +52,7 @@ void CheckSDDMatrix(const Eigen::Ref<const Eigen::MatrixXd>& X_val,
   DRAKE_DEMAND(X_val.cols() == nx);
   MathematicalProgram prog;
   auto X = prog.NewSymmetricContinuousVariables(nx);
-  auto M = prog.AddScaledDiagonallyDominantMatrixConstraint(
-      X);
+  auto M = prog.AddScaledDiagonallyDominantMatrixConstraint(X.cast<T>());
 
   for (int i = 0; i < nx; ++i) {
     prog.AddBoundingBoxConstraint(X_val.col(i), X_val.col(i), X.col(i));
@@ -61,13 +73,13 @@ void CheckSDDMatrix(const Eigen::Ref<const Eigen::MatrixXd>& X_val,
     M_sum.setZero();
     for (int i = 0; i < nx; ++i) {
       M_val[i].resize(nx);
-      for (int j = 0; j < nx; ++j) {
+      for (int j = i + 1; j < nx; ++j) {
         M_val[i][j].resize(nx, nx);
         M_val[i][j].setZero();
-        M_val[i][j](i, i) = M[i][j](0, 0).Evaluate(env);
-        M_val[i][j](i, j) = M[i][j](0, 1).Evaluate(env);
+        M_val[i][j](i, i) = symbolic::Expression(M[i][j](0, 0)).Evaluate(env);
+        M_val[i][j](i, j) = symbolic::Expression(M[i][j](0, 1)).Evaluate(env);
         M_val[i][j](j, i) = M_val[i][j](i, j);
-        M_val[i][j](j, j) = M[i][j](1, 1).Evaluate(env);
+        M_val[i][j](j, j) = symbolic::Expression(M[i][j](1, 1)).Evaluate(env);
         M_sum += M_val[i][j];
       }
     }
@@ -112,15 +124,18 @@ GTEST_TEST(ScaledDiagonallyDominantMatrixTest, TestSDDMatrix) {
            0.3, 0.5, 3, 2,
            -0.45, 1, 2, 4;
   // clang-format on
-  CheckSDDMatrix(dd_X, true);
+  CheckSDDMatrix<symbolic::Expression>(dd_X, true);
+  CheckSDDMatrix<symbolic::Variable>(dd_X, true);
 
   Eigen::Matrix4d D = Eigen::Vector4d(1, 2, 3, 4).asDiagonal();
   Eigen::Matrix4d sdd_X = D * dd_X * D;
-  CheckSDDMatrix(sdd_X, true);
+  CheckSDDMatrix<symbolic::Expression>(sdd_X, true);
+  CheckSDDMatrix<symbolic::Variable>(sdd_X, true);
 
   D = Eigen::Vector4d(0.2, -1, -0.5, 1.2).asDiagonal();
   sdd_X = D * dd_X * D;
-  CheckSDDMatrix(sdd_X, true);
+  CheckSDDMatrix<symbolic::Expression>(sdd_X, true);
+  CheckSDDMatrix<symbolic::Variable>(sdd_X, true);
 
   // not_dd_X is not diagonally dominant (dd), but is scaled diagonally
   // dominant.
@@ -128,7 +143,8 @@ GTEST_TEST(ScaledDiagonallyDominantMatrixTest, TestSDDMatrix) {
   not_dd_X << 1, -0.2, 0.3, -0.55, -0.2, 2, 0.5, 1, 0.3, 0.5, 3, 2, -0.55, 1, 2,
       4;
   DRAKE_DEMAND(IsMatrixSDD(not_dd_X));
-  CheckSDDMatrix(not_dd_X, true);
+  CheckSDDMatrix<symbolic::Expression>(not_dd_X, true);
+  CheckSDDMatrix<symbolic::Variable>(not_dd_X, true);
 }
 
 GTEST_TEST(ScaledDiagonallyDominantMatrixTest, TestNotSDDMatrix) {
@@ -141,15 +157,18 @@ GTEST_TEST(ScaledDiagonallyDominantMatrixTest, TestNotSDDMatrix) {
                -1.55, 1, 2, 4;
   // clang-format on
   DRAKE_DEMAND(!IsMatrixSDD(not_sdd_X));
-  CheckSDDMatrix(not_sdd_X, false);
+  CheckSDDMatrix<symbolic::Expression>(not_sdd_X, false);
+  CheckSDDMatrix<symbolic::Variable>(not_sdd_X, false);
 
   Eigen::Matrix4d D = Eigen::Vector4d(1, 2, 3, 4).asDiagonal();
   not_sdd_X = D * not_sdd_X * D;
-  CheckSDDMatrix(not_sdd_X, false);
+  CheckSDDMatrix<symbolic::Expression>(not_sdd_X, false);
+  CheckSDDMatrix<symbolic::Variable>(not_sdd_X, false);
 
   D = Eigen::Vector4d(0.2, -1, -0.5, 1.2).asDiagonal();
   not_sdd_X = D * not_sdd_X * D;
-  CheckSDDMatrix(not_sdd_X, false);
+  CheckSDDMatrix<symbolic::Expression>(not_sdd_X, false);
+  CheckSDDMatrix<symbolic::Variable>(not_sdd_X, false);
 }
 
 GTEST_TEST(SdsosTest, SdsosPolynomial) {

--- a/solvers/test/scaled_diagonally_dominant_matrix_test.cc
+++ b/solvers/test/scaled_diagonally_dominant_matrix_test.cc
@@ -40,7 +40,7 @@ void CheckSDDMatrix(const Eigen::Ref<const Eigen::MatrixXd>& X_val,
   MathematicalProgram prog;
   auto X = prog.NewSymmetricContinuousVariables(nx);
   auto M = prog.AddScaledDiagonallyDominantMatrixConstraint(
-      X.cast<symbolic::Expression>());
+      X);
 
   for (int i = 0; i < nx; ++i) {
     prog.AddBoundingBoxConstraint(X_val.col(i), X_val.col(i), X.col(i));


### PR DESCRIPTION
When we create an sdsos polynomial calling `MathematicalProgram::NewNonnegativePolynomial` for a large size monomial basis, the speed was very slow. In one of my test for a monomial basis of size 256, it took 200s in `NewNonnegativePolynomial`.

In this PR we speed up `NewNonnegativePolynomial` for sdsos polynomial. Now it takes 0.4s

The tricks are

1. Instead of declaring each new continuous variables in a double for loop as https://github.com/RobotLocomotion/drake/blob/fbc623dafa8e257a93f169d4ffe7962977f92ae0/solvers/mathematical_program.cc#L795-L801
we now declare all continuous variables in a batch as https://github.com/hongkai-dai/drake/blob/be65bfbda743a483420eef15e613a5cbd28cd590/solvers/mathematical_program.cc#L808-L809. This improves the computation time from 200s to 2s.
2. I created an overloaded the function `AddScaledDiagonallyDominantMatrixConstraint(X)` with `X` being a matrix of *symbolic::Variable*, in addition to a matrix of *symbolic::Expression*. This `symbolic::Variable` version is faster than the `Expression` version. This further improves the computation time from 2s to 0.4s.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10242)
<!-- Reviewable:end -->
