### PR TITLE
mbp: Introduce `AddMultibodyPlantSceneGraph` sugar

### DIFF
--- a/bindings/pydrake/multibody/multibody_tree_py.cc
+++ b/bindings/pydrake/multibody/multibody_tree_py.cc
@@ -1024,6 +1024,25 @@ void init_multibody_plant(py::module m) {
         .def("contact_info", &Class::contact_info, py::arg("i"));
     pysystems::AddValueInstantiation<Class>(m);
   }
+
+  m.def("AddMultibodyPlantSceneGraph",
+      [](systems::DiagramBuilder<T>* builder,
+          std::unique_ptr<MultibodyPlant<T>> plant,
+          std::unique_ptr<SceneGraph<T>> scene_graph) {
+        auto pair = AddMultibodyPlantSceneGraph(
+            builder, std::move(plant), std::move(scene_graph));
+        // Must do manual keep alive to dig into tuple.
+        py::object builder_py = py::cast(builder, py_reference);
+        // Keep alive, ownership: `plant` keeps `builder` alive.
+        py::object plant_py =
+            py::cast(pair.plant, py_reference_internal, builder_py);
+        // Keep alive, ownership: `scene_graph` keeps `builder` alive.
+        py::object scene_graph_py =
+            py::cast(pair.scene_graph, py_reference_internal, builder_py);
+        return py::make_tuple(plant_py, scene_graph_py);
+      },
+      py::arg("builder"), py::arg("plant") = nullptr,
+      py::arg("scene_graph") = nullptr, doc.AddMultibodyPlantSceneGraph.doc);
 }  // NOLINT(readability/fn_size)
 
 void init_parsing_deprecated(py::module m) {

--- a/bindings/pydrake/multibody/test/multibody_tree_test.py
+++ b/bindings/pydrake/multibody/test/multibody_tree_test.py
@@ -26,6 +26,7 @@ from pydrake.multibody.multibody_tree.math import (
     SpatialVelocity,
 )
 from pydrake.multibody.multibody_tree.multibody_plant import (
+    AddMultibodyPlantSceneGraph,
     ContactResults,
     MultibodyPlant,
     PointPairContactInfo,
@@ -81,20 +82,6 @@ def get_index_class(cls):
         if issubclass(cls, key_cls):
             return index_cls
     raise RuntimeError("Unknown class: {}".format(cls))
-
-
-def add_plant_and_scene_graph(builder):
-    # TODO(eric.cousineau): Hoist to C++.
-    plant = builder.AddSystem(MultibodyPlant())
-    scene_graph = builder.AddSystem(SceneGraph())
-    plant.RegisterAsSourceForSceneGraph(scene_graph)
-    builder.Connect(
-        scene_graph.get_query_output_port(),
-        plant.get_geometry_query_input_port())
-    builder.Connect(
-        plant.get_geometry_poses_output_port(),
-        scene_graph.get_source_pose_port(plant.get_source_id()))
-    return plant, scene_graph
 
 
 class TestMultibodyTreeMath(unittest.TestCase):
@@ -828,7 +815,7 @@ class TestMultibodyTree(unittest.TestCase):
 
     def test_scene_graph_queries(self):
         builder = DiagramBuilder()
-        plant, scene_graph = add_plant_and_scene_graph(builder)
+        plant, scene_graph = AddMultibodyPlantSceneGraph(builder)
         parser = Parser(plant=plant, scene_graph=scene_graph)
         parser.AddModelFromFile(
             FindResourceOrThrow(

--- a/bindings/pydrake/systems/test/meshcat_visualizer_test.py
+++ b/bindings/pydrake/systems/test/meshcat_visualizer_test.py
@@ -5,7 +5,8 @@ import numpy as np
 from pydrake.common import FindResourceOrThrow
 from pydrake.geometry import SceneGraph
 from pydrake.multibody.multibody_tree import UniformGravityFieldElement
-from pydrake.multibody.multibody_tree.multibody_plant import MultibodyPlant
+from pydrake.multibody.multibody_tree.multibody_plant import (
+    AddMultibodyPlantSceneGraph)
 from pydrake.multibody.parsing import Parser
 from pydrake.systems.analysis import Simulator
 from pydrake.systems.framework import DiagramBuilder
@@ -19,17 +20,11 @@ class TestMeshcat(unittest.TestCase):
             "drake/examples/multibody/cart_pole/cart_pole.sdf")
 
         builder = DiagramBuilder()
-        scene_graph = builder.AddSystem(SceneGraph())
-        cart_pole = builder.AddSystem(MultibodyPlant())
-        parser = Parser(plant=cart_pole, scene_graph=scene_graph)
-        parser.AddModelFromFile(file_name)
+        cart_pole, scene_graph = AddMultibodyPlantSceneGraph(builder)
+        Parser(plant=cart_pole).AddModelFromFile(file_name)
         cart_pole.AddForceElement(UniformGravityFieldElement([0, 0, -9.81]))
-        cart_pole.Finalize(scene_graph)
+        cart_pole.Finalize()
         assert cart_pole.geometry_source_is_registered()
-
-        builder.Connect(
-            cart_pole.get_geometry_poses_output_port(),
-            scene_graph.get_source_pose_port(cart_pole.get_source_id()))
 
         visualizer = builder.AddSystem(MeshcatVisualizer(scene_graph,
                                                          zmq_url=None,
@@ -61,17 +56,10 @@ class TestMeshcat(unittest.TestCase):
             "drake/manipulation/models/iiwa_description/sdf/"
             "iiwa14_no_collision.sdf")
         builder = DiagramBuilder()
-        scene_graph = builder.AddSystem(SceneGraph())
-        kuka = builder.AddSystem(MultibodyPlant())
-        parser = Parser(plant=kuka, scene_graph=scene_graph)
-        parser.AddModelFromFile(file_name)
+        kuka, scene_graph = AddMultibodyPlantSceneGraph(builder)
+        Parser(plant=kuka).AddModelFromFile(file_name)
         kuka.AddForceElement(UniformGravityFieldElement([0, 0, -9.81]))
-        kuka.Finalize(scene_graph)
-        assert kuka.geometry_source_is_registered()
-
-        builder.Connect(
-            kuka.get_geometry_poses_output_port(),
-            scene_graph.get_source_pose_port(kuka.get_source_id()))
+        kuka.Finalize()
 
         visualizer = builder.AddSystem(MeshcatVisualizer(scene_graph,
                                                          zmq_url=None,

--- a/multibody/benchmarks/inclined_plane/make_inclined_plane_plant.cc
+++ b/multibody/benchmarks/inclined_plane/make_inclined_plane_plant.cc
@@ -13,22 +13,16 @@ using geometry::SceneGraph;
 using geometry::Sphere;
 using Eigen::AngleAxisd;
 
-std::unique_ptr<MultibodyPlant<double>> MakeInclinedPlanePlant(
+void AddInclinedPlaneToPlant(
     double radius, double mass, double slope,
     const CoulombFriction<double>& surface_friction, double gravity,
-    double time_step,
-    SceneGraph<double>* scene_graph) {
-  DRAKE_THROW_UNLESS(scene_graph != nullptr);
-  DRAKE_THROW_UNLESS(time_step >= 0);
-
-  auto plant = std::make_unique<MultibodyPlant<double>>(time_step);
+    MultibodyPlant<double>* plant) {
+  DRAKE_THROW_UNLESS(plant != nullptr);
 
   UnitInertia<double> G_Bcm = UnitInertia<double>::SolidSphere(radius);
   SpatialInertia<double> M_Bcm(mass, Vector3<double>::Zero(), G_Bcm);
 
   const RigidBody<double>& ball = plant->AddRigidBody("Ball", M_Bcm);
-
-  plant->RegisterAsSourceForSceneGraph(scene_graph);
 
   // Orientation of a plane frame P with its z axis normal to the plane and its
   // x axis pointing down the plane.
@@ -89,11 +83,6 @@ std::unique_ptr<MultibodyPlant<double>> MakeInclinedPlanePlant(
   // Gravity acting in the -z direction.
   plant->AddForceElement<UniformGravityFieldElement>(
       -gravity * Vector3<double>::UnitZ());
-
-  // We are done creating the plant.
-  plant->Finalize();
-
-  return plant;
 }
 
 }  // namespace inclined_plane

--- a/multibody/benchmarks/inclined_plane/make_inclined_plane_plant.h
+++ b/multibody/benchmarks/inclined_plane/make_inclined_plane_plant.h
@@ -10,8 +10,7 @@ namespace multibody {
 namespace benchmarks {
 namespace inclined_plane {
 
-/// This method makes a MultibodyPlant model for a sphere rolling down an
-/// inclined plane.
+/// This method adds a sphere rolling down an inclined plane.
 ///
 /// @param[in] radius
 ///   The radius in meters of the sphere.
@@ -24,21 +23,15 @@ namespace inclined_plane {
 ///   surface properties for both the inclined plane and the sphere.
 /// @param[in] gravity
 ///   The acceleration of gravity, in m/s². Points in the minus z direction.
-/// @param[in] time_step
-///   If `time_step = 0`, the plant is modeled as a continuous system. Otherwise
-///   when `time_step > 0` the plant is modeled as a discrete system with
-///   periodic updates of period `time_step`. `time_step` must be non-negative.
-/// @param scene_graph
-///   This factory method will register the new multibody plant to be a source
-///   for this geometry system and it will also register geometry for contact
-///   modeling.
-/// @throws std::exception if time_step is negative.
-/// @throws std::exception if scene_graph is nullptr.
-std::unique_ptr<MultibodyPlant<double>> MakeInclinedPlanePlant(
+/// @param[out] plant
+///   Plant to contain the sphere and plane.
+/// @throws std::exception if plant is nullptr.
+/// @pre plant must be registered with a scene graph.
+void AddInclinedPlaneToPlant(
     double radius, double mass, double slope,
     const CoulombFriction<double>& surface_friction,
-    double gravity, double time_step,
-    geometry::SceneGraph<double>* scene_graph);
+    double gravity,
+    MultibodyPlant<double>* plant);
 
 }  // namespace inclined_plane
 }  // namespace benchmarks

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -53,6 +53,7 @@ drake_cc_library(
         "//geometry:scene_graph",
         "//math:orthonormal_basis",
         "//multibody/tree",
+        "//systems/framework:diagram_builder",
         "//systems/framework:leaf_system",
     ],
 )

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1820,4 +1820,4 @@ AddMultibodyPlantSceneGraph(
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
     class drake::multibody::MultibodyPlant)
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
-    class drake::multibody::AddMultibodyPlantSceneGraphResult)
+    struct drake::multibody::AddMultibodyPlantSceneGraphResult)

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3258,16 +3258,13 @@ struct AddMultibodyPlantSceneGraphResult final {
  private:
   // Deter external usage by hiding construction.
   friend AddMultibodyPlantSceneGraphResult AddMultibodyPlantSceneGraph<T>(
-    systems::DiagramBuilder<T>* builder,
-    std::unique_ptr<MultibodyPlant<T>> plant,
+    systems::DiagramBuilder<T>*, std::unique_ptr<MultibodyPlant<T>>,
     std::unique_ptr<geometry::SceneGraph<T>>);
 
-#ifndef DRAKE_DOXYGEN_CXX
   AddMultibodyPlantSceneGraphResult(
       MultibodyPlant<T>* plant_in, geometry::SceneGraph<T>* scene_graph_in)
       : plant(*plant_in), scene_graph(*scene_graph_in),
         plant_ptr(plant_in), scene_graph_ptr(scene_graph_in) {}
-#endif
 
   // Pointers to enable implicit casts for `std::tie()` assignments using
   // `T*&`.

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -255,19 +255,36 @@ GTEST_TEST(MultibodyPlant, SimpleModelCreation) {
   // type throws an exception. We need another joint type to do so.
 }
 
+GTEST_TEST(MultibodyPlantTest, AddMultibodyPlantSceneGraph) {
+  systems::DiagramBuilder<double> builder;
+  auto pair = AddMultibodyPlantSceneGraph(&builder);
+
+  MultibodyPlant<double>* plant{};
+  geometry::SceneGraph<double>* scene_graph{};
+  // Check `tie` assignment.
+  std::tie(plant, scene_graph) = pair;
+  EXPECT_NE(plant, nullptr);
+  EXPECT_NE(scene_graph, nullptr);
+  // Check referencing.
+  MultibodyPlant<double>& plant_ref = pair;
+  EXPECT_EQ(&plant_ref, plant);
+
+  // These should fail:
+  // AddMultibodyPlantSceneGraphResult<double> extra(plant, scene_graph);
+  // AddMultibodyPlantSceneGraphResult<double> extra{*plant, *scene_graph};
+}
+
 // Fixture to perform a number of computational tests on an acrobot model.
 class AcrobotPlantTests : public ::testing::Test {
  public:
   // Creates MultibodyPlant for an acrobot model.
   void SetUp() override {
     systems::DiagramBuilder<double> builder;
-    scene_graph_ = builder.AddSystem<SceneGraph>();
     // Make a non-finalized plant so that we can tests methods with pre/post
     // Finalize() conditions.
     const std::string full_name = FindResourceOrThrow(
         "drake/multibody/benchmarks/acrobot/acrobot.sdf");
-    plant_ = builder.AddSystem<MultibodyPlant>();
-    plant_->RegisterAsSourceForSceneGraph(scene_graph_);
+    std::tie(plant_, scene_graph_) = AddMultibodyPlantSceneGraph(&builder);
     Parser(plant_).AddModelFromFile(full_name);
     // Add gravity to the model.
     plant_->AddForceElement<UniformGravityFieldElement>(
@@ -279,10 +296,6 @@ class AcrobotPlantTests : public ::testing::Test {
     // Ensure that we can access the geometry ports pre-finalize.
     EXPECT_NO_THROW(plant_->get_geometry_query_input_port());
     EXPECT_NO_THROW(plant_->get_geometry_poses_output_port());
-
-    builder.Connect(
-        plant_->get_geometry_poses_output_port(),
-        scene_graph_->get_source_pose_port(plant_->get_source_id().value()));
 
     DRAKE_EXPECT_THROWS_MESSAGE(
         plant_->get_continuous_state_output_port(),
@@ -697,10 +710,7 @@ class SphereChainScenario {
       std::function<void(SphereChainScenario*)> apply_filters = nullptr) {
     using std::to_string;
     systems::DiagramBuilder<double> builder;
-    scene_graph_ = builder.AddSystem<SceneGraph<double>>();
-    plant_ = builder.AddSystem<MultibodyPlant<double>>();
-
-    plant_->RegisterAsSourceForSceneGraph(scene_graph_);
+    std::tie(plant_, scene_graph_) = AddMultibodyPlantSceneGraph(&builder);
 
     // A half-space for the ground geometry.
     ground_id_ = plant_->RegisterCollisionGeometry(
@@ -746,12 +756,6 @@ class SphereChainScenario {
 
     // We are done defining the model.
     plant_->Finalize();
-
-    builder.Connect(
-        plant_->get_geometry_poses_output_port(),
-        scene_graph_->get_source_pose_port(*plant_->get_source_id()));
-    builder.Connect(scene_graph_->get_query_output_port(),
-                    plant_->get_geometry_query_input_port());
 
     if (apply_filters != nullptr) apply_filters(this);
 


### PR DESCRIPTION
Minor sugar for #9691.

This is a simplified version of what we use in Anzu, which assumes that all meaningful uses of MBP+SG will involve only one SG talking to one and only one MBP.
Ditched semantically named pair, as I don't want it to creep into any user APIs.
Tweaked some benchmark items to simplify the workflow with this approach.

\cc @amcastro-tri 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10251)
<!-- Reviewable:end -->
