### PR TITLE
py multibody: Add shims for updated spelling

### DIFF
--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -61,6 +61,11 @@ drake_pybind_library(
         "//bindings/pydrake/systems:framework_py",
         "//bindings/pydrake/util:eigen_geometry_py",
     ],
+    py_srcs = [
+        "math.py",
+        "plant.py",
+        "tree.py",
+    ],
 )
 
 # This covers //attic/multibody/parsers.

--- a/bindings/pydrake/multibody/all.py
+++ b/bindings/pydrake/multibody/all.py
@@ -1,12 +1,21 @@
+# Legacy / soon-to-be-deprecated symbols.
+# - Attic (#9314)
 from .collision import *
-from .inverse_kinematics import *
 from .joints import *
 from .parsers import *
 from .rigid_body_plant import *
 from .rigid_body_tree import *
 from .rigid_body import *
 from .shapes import *
+# - Shuffle (#9314. #9366)
+from .multibody_tree.all import *
+
+# Normal symbols.
+from .inverse_kinematics import *
+from .math import *
+from .parsing import *
+from .plant import *
+from .tree import *
 
 # Submodules.
 from .benchmarks.all import *
-from .multibody_tree.all import *

--- a/bindings/pydrake/multibody/math.py
+++ b/bindings/pydrake/multibody/math.py
@@ -1,0 +1,9 @@
+"""
+Bindings for multibody math.
+
+Note:
+    The documentation is not yet populated with symbols, but will be soon.
+"""
+# TODO(eric.cousineau): Replace with actual bindings.
+
+from pydrake.multibody.multibody_tree.math import *

--- a/bindings/pydrake/multibody/multibody_tree_py.cc
+++ b/bindings/pydrake/multibody/multibody_tree_py.cc
@@ -70,6 +70,11 @@ void init_module(py::module m) {
   using namespace drake::multibody;
   constexpr auto& doc = pydrake_doc.drake.multibody;
 
+  m.doc() =
+      "Bindings for MultibodyTree.\n\n"
+      "Warning:\n   This module will soon be deprecated. Please use "
+      "``pydrake.multibody.tree`` instead.";
+
   // To simplify checking binding coverage, these are defined in the same order
   // as `multibody_tree_indexes.h`.
   // TODO(jamiesnape): Extract documentation automatically.
@@ -443,7 +448,10 @@ void init_math(py::module m) {
   using namespace drake::multibody;
   constexpr auto& doc = pydrake_doc.drake.multibody;
 
-  m.doc() = "MultibodyTree math functionality.";
+  m.doc() =
+      "Multibody math functionality.\n\n"
+      "Warning:\n    This module will soon be deprecated. Please use "
+      "``pydrake.multibody.math`` instead.";
 
   {
     using Class = SpatialVelocity<T>;
@@ -473,6 +481,11 @@ void init_multibody_plant(py::module m) {
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
   using namespace drake::multibody;
   constexpr auto& doc = pydrake_doc.drake.multibody;
+
+  m.doc() =
+      "Multibody plant functionality.\n\n"
+      "Warning:\n   This module will soon be deprecated. Please use "
+      "``pydrake.multibody.plant`` instead.";
 
   py::module::import("pydrake.geometry");
   py::module::import("pydrake.systems.framework");
@@ -1021,10 +1034,17 @@ void init_multibody_plant(py::module m) {
   }
 }  // NOLINT(readability/fn_size)
 
-void init_parsing(py::module m) {
+void init_parsing_deprecated(py::module m) {
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
   using namespace drake::multibody;
   constexpr auto& doc = pydrake_doc.drake.multibody.parsing;
+
+  m.doc() =
+      "Multibody parsing functionality.\n\n"
+      "Warning:\n   This module will soon be deprecated. Please use "
+      "``pydrake.multibody.parsing`` instead.";
+
+  // N.B. This module is deprecated; add all new methods to `parsing_py.cc`.
 
   // Stub in a deprecation shim for the Parser class.
   // TODO(jwnimmer-tri) Remove this stub on or about 2019-01-01.
@@ -1085,20 +1105,22 @@ void init_all(py::module m) {
       "from pydrake.multibody.multibody_tree.multibody_plant import *\n"
       "from pydrake.multibody.multibody_tree.parsing import *\n",
       py::globals(), vars);
+  m.doc() =
+      "Warning:\n   ``pydrake.multibody.multibody_tree.all`` will soon "
+      "be deprecated.";
 }
 
 }  // namespace
 
 PYBIND11_MODULE(multibody_tree, m) {
   PYDRAKE_PREVENT_PYTHON3_MODULE_REIMPORT(m);
-  m.doc() = "MultibodyTree functionality.";
 
   // TODO(eric.cousineau): Split this into separate files. See discussion in
   // #8282 for info relating to the current implementation.
   init_module(m);
   init_math(m.def_submodule("math"));
   init_multibody_plant(m.def_submodule("multibody_plant"));
-  init_parsing(m.def_submodule("parsing"));
+  init_parsing_deprecated(m.def_submodule("parsing"));
   init_all(m.def_submodule("all"));
 }
 

--- a/bindings/pydrake/multibody/plant.py
+++ b/bindings/pydrake/multibody/plant.py
@@ -1,0 +1,9 @@
+"""
+Bindings for MultibodyPlant and related classes.
+
+Note:
+    The documentation is not yet populated with symbols, but will be soon.
+"""
+# TODO(eric.cousineau): Replace with actual bindings.
+
+from pydrake.multibody.multibody_tree.multibody_plant import *

--- a/bindings/pydrake/multibody/test/multibody_tree_test.py
+++ b/bindings/pydrake/multibody/test/multibody_tree_test.py
@@ -853,3 +853,13 @@ class TestMultibodyTree(unittest.TestCase):
         self.assertSetEqual(
             bodies,
             {plant.GetBodyByName("body1"), plant.GetBodyByName("body2")})
+
+    def test_new_spellings(self):
+        from pydrake.multibody import math
+        math.SpatialVelocity
+        from pydrake.multibody import plant
+        plant.MultibodyPlant
+        from pydrake.multibody import tree
+        tree.Body
+        # Check for soon-to-be deprecated symbols (#9366).
+        self.assertFalse(hasattr(tree, "MultibodyTree"))

--- a/bindings/pydrake/multibody/tree.py
+++ b/bindings/pydrake/multibody/tree.py
@@ -1,0 +1,14 @@
+"""
+Bindings for multibody tree components.
+
+Note:
+    The documentation is not yet populated with symbols, but will be soon.
+"""
+# TODO(eric.cousineau): Replace with actual bindings.
+
+from pydrake.multibody.multibody_tree import *
+
+# Do not import soon-to-be deprecated symbols (#9366).
+del BodyNodeIndex
+del MobilizerIndex
+del MultibodyTree

--- a/bindings/pydrake/pydrake_pybind.h
+++ b/bindings/pydrake/pydrake_pybind.h
@@ -27,12 +27,12 @@ classes derived from `pybind11` classes.
 The structure of the bindings generally follow the *directory structure*, not
 the namespace structure. As an example, if in C++  you do:
 
-    #include <drake/multibody/multibody_tree/multibody_plant/{header}.h>
-    using drake::multibody::multibody_plant::{symbol};
+    #include <drake/multibody/plant/{header}.h>
+    using drake::multibody::{symbol};
 
 then in Python you would do:
 
-    from pydrake.multibody.multibody_tree.multibody_plant import {symbol}
+    from pydrake.multibody.plant import {symbol}
 
 Some (but not all) exceptions:
 


### PR DESCRIPTION
Addresses first step in #10207.

I had tried to shuffle bindings around, but found that to be too much overhead for the simplicity of this first step, so I stuck with just forwarding from old -> new, rather than moving.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10254)
<!-- Reviewable:end -->
