### PR TITLE
Copy R_AbarA and R_BbarB in multibody::OrientationConstraint ctor.

### DIFF
--- a/multibody/inverse_kinematics/orientation_constraint.h
+++ b/multibody/inverse_kinematics/orientation_constraint.h
@@ -83,8 +83,8 @@ class OrientationConstraint : public solvers::Constraint {
   const MultibodyPlant<double>& plant_;
   const FrameIndex frameAbar_index_;
   const FrameIndex frameBbar_index_;
-  const math::RotationMatrix<double>& R_AbarA_;
-  const math::RotationMatrix<double>& R_BbarB_;
+  const math::RotationMatrix<double> R_AbarA_;
+  const math::RotationMatrix<double> R_BbarB_;
   systems::Context<double>* const context_;
 };
 }  // namespace multibody


### PR DESCRIPTION
The constraint object should not depend on the lifetime of those arguments.
Updated the test such that it would fail with the code prior to this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10261)
<!-- Reviewable:end -->
