### PR TITLE
Update and clean up SceneGraphInspector

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -358,6 +358,14 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "scene_graph_inspector_test",
+    deps = [
+        ":geometry_frame",
+        ":scene_graph_inspector",
+    ],
+)
+
+drake_cc_googletest(
     name = "shape_specification_test",
     deps = [
         ":shape_specification",

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -159,8 +159,8 @@ const std::string& GeometryState<T>::get_source_name(SourceId id) const {
 
 template <typename T>
 int GeometryState<T>::NumFramesForSource(SourceId source_id) const {
-  if (source_frame_id_map_.count(source_id) == 0) return 0;
-  return static_cast<int>(source_frame_id_map_.at(source_id).size());
+  const auto& frame_set = GetValueOrThrow(source_id, source_frame_id_map_);
+  return static_cast<int>(frame_set.size());
 }
 
 template <typename T>

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -146,11 +146,11 @@ class GeometryState {
   /** @name              Frames and their properties  */
   //@{
 
-  /** Implementation of SceneGraphInspector::BelongsToSource(FrameId, SourceId).
-   */
+  /** Implementation of
+   SceneGraphInspector::BelongsToSource(FrameId, SourceId) const.  */
   bool BelongsToSource(FrameId frame_id, SourceId source_id) const;
 
-  /** Implementation of SceneGraphInspector::GetName(FrameId).  */
+  /** Implementation of SceneGraphInspector::GetName(FrameId) const.  */
   const std::string& get_frame_name(FrameId frame_id) const;
 
   /** Implementation of SceneGraphInspector::GetFrameGroup().  */
@@ -170,7 +170,7 @@ class GeometryState {
    @throws std::logic_error if the `frame_id` does not map to a valid frame.  */
   int NumGeometriesWithRole(FrameId frame_id, Role role) const;
 
-  /** Implementation of SceneGraphInspector::GetGeometryFromName().  */
+  /** Implementation of SceneGraphInspector::GetGeometryIdByName().  */
   GeometryId GetGeometryFromName(FrameId frame_id,
                                  Role role,
                                  const std::string& name) const;
@@ -181,13 +181,13 @@ class GeometryState {
   //@{
 
   /** Implementation of
-   SceneGraphInspector::BelongsToSource(GeometryId, SourceId).  */
+   SceneGraphInspector::BelongsToSource(GeometryId, SourceId) const.  */
   bool BelongsToSource(GeometryId geometry_id, SourceId source_id) const;
 
   /** Implementation of SceneGraphInspector::GetFrameId().  */
   FrameId GetFrameId(GeometryId geometry_id) const;
 
-  /** Implementation of SceneGraphInspector::GetName(GeometryId).  */
+  /** Implementation of SceneGraphInspector::GetName(GeometryId) const.  */
   const std::string& get_name(GeometryId geometry_id) const;
 
   /** Implementation of SceneGraphInspector::X_FG().  */

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -92,25 +92,15 @@ class GeometryState {
   /** @name        Scene-graph wide introspection  */
   //@{
 
-  /** Reports the number of registered sources -- whether they have frames or
-   not.  */
+  /** Implementation of SceneGraphInspector::num_sources().  */
   int get_num_sources() const {
     return static_cast<int>(source_frame_id_map_.size());
   }
 
-  /** Reports the total number of frames -- across all sources.  */
+  /** Implementation of SceneGraphInspector::num_frames().  */
   int get_num_frames() const { return static_cast<int>(frames_.size()); }
 
-  /** Provides a range object for all of the frame ids in the scene graph. The
-   order is not generally guaranteed; but it will be consistent as long as there
-   are no changes to the topology. This is intended to be used as:
-   @code
-   for (FrameId id : state.get_frame_ids()) {
-    ...
-   }
-   @endcode
-
-   This will include the id for the world frame.  */
+  /** Implementation of SceneGraphInspector::all_frame_ids().  */
   FrameIdRange get_frame_ids() const {
     return FrameIdRange(&frames_);
   }
@@ -120,10 +110,7 @@ class GeometryState {
     return static_cast<int>(geometries_.size());
   }
 
-  /** The set of all dynamic geometries registered to the world. The order is
-   _not_ guaranteed to have any particular semantic meaning. But the order is
-   guaranteed to remain fixed between topological changes (e.g., removal or
-   addition of geometry/frames).  */
+  /** Implementation of SceneGraphInspector::all_geometry_ids().  */
   const std::vector<GeometryId>& get_geometry_ids() const {
     return geometry_index_to_id_map_;
   }
@@ -131,12 +118,10 @@ class GeometryState {
   /** Implementation of SceneGraphInspector::NumGeometriesWithRole().  */
   int GetNumGeometriesWithRole(Role role) const;
 
-  /** Reports the total number of *dynamic* geometries in the scene graph.  */
+  /** Implementation of SceneGraphInspector::GetNumDynamicGeometries().  */
   int GetNumDynamicGeometries() const;
 
-  /** Reports the total number of _anchored_ geometries. This should provide
-   the same answer as calling GetNumFrameGeometries() with the world frame id.
-   */
+  /** Implementation of SceneGraphInspector::GetNumAnchoredGeometries().  */
   int GetNumAnchoredGeometries() const;
 
   //@}
@@ -144,7 +129,7 @@ class GeometryState {
   /** @name          Sources and source-related data  */
   //@{
 
-  /** Reports true if the given `source_id` references a registered source.  */
+  /** Implementation of SceneGraphInspector::SourceIsRegistered().  */
   bool source_is_registered(SourceId source_id) const;
 
   /** Implementation of SceneGraphInspector::GetSourceName().  */
@@ -153,11 +138,7 @@ class GeometryState {
   /** Implementation of SceneGraphInspector::NumFramesForSource().  */
   int NumFramesForSource(SourceId source_id) const;
 
-  /** Returns the set of frames registered to the given source.
-   @param source_id     The identifier of the source to query.
-   @return  The set of frames associated with the id.
-   @throws std::logic_error If the `source_id` does _not_ map to a registered
-                            source.  */
+  /** Implementation of SceneGraphInspector::FramesForSource().  */
   const FrameIdSet& GetFramesForSource(SourceId source_id) const;
 
   //@}
@@ -165,22 +146,14 @@ class GeometryState {
   /** @name              Frames and their properties  */
   //@{
 
-  /** Reports if the given frame id was registered to the given source id.
-   @param frame_id      The query frame id.
-   @param source_id     The query source id.
-   @returns True if `frame_id` was registered on `source_id`.
-   @throws std::logic_error  If the `frame_id` does _not_ map to a frame or the
-                             identified source is not registered.  */
+  /** Implementation of SceneGraphInspector::BelongsToSource(FrameId, SourceId).
+   */
   bool BelongsToSource(FrameId frame_id, SourceId source_id) const;
 
   /** Implementation of SceneGraphInspector::GetName(FrameId).  */
   const std::string& get_frame_name(FrameId frame_id) const;
 
-  /** Reports the frame group for the given frame.
-   @param frame_id  The identifier of the queried frame.
-   @returns The frame group of the identified frame.
-   @throws std::logic_error if the frame id is not valid.
-   @internal This is equivalent to the old "model instance id".  */
+  /** Implementation of SceneGraphInspector::GetFrameGroup().  */
   int get_frame_group(FrameId frame_id) const;
 
   /** Implementation of SceneGraphInspector::NumGeometriesForFrame().  */
@@ -207,14 +180,8 @@ class GeometryState {
   /** @name           Geometries and their properties  */
   //@{
 
-  /** Reports if the given geometry id was ultimately registered to the given
-   source id.
-   @param geometry_id   The query geometry id.
-   @param source_id     The query source id.
-   @returns True if `geometry_id` was registered on `source_id`.
-   @throws std::logic_error  If the `geometry_id` does _not_ map to a valid
-                             geometry or the identified source is not
-                             registered  */
+  /** Implementation of
+   SceneGraphInspector::BelongsToSource(GeometryId, SourceId).  */
   bool BelongsToSource(GeometryId geometry_id, SourceId source_id) const;
 
   /** Implementation of SceneGraphInspector::GetFrameId().  */
@@ -223,21 +190,10 @@ class GeometryState {
   /** Implementation of SceneGraphInspector::GetName(GeometryId).  */
   const std::string& get_name(GeometryId geometry_id) const;
 
-  /** Reports the pose, relative to the registered _frame_, for the geometry
-   the given identifier refers to.
-   @param geometry_id     The id of the queried geometry.
-   @return The geometry's pose relative to its frame.
-   @throws std::logic_error  If the `geometry_id` does _not_ map to a valid
-                             GeometryInstance.  */
+  /** Implementation of SceneGraphInspector::X_FG().  */
   const Isometry3<double>& GetPoseInFrame(GeometryId geometry_id) const;
 
-  /** Reports the pose of identified dynamic geometry, relative to its
-   registered parent. If the geometry was registered directly to a frame, this
-   _must_ produce the same pose as GetPoseInFrame().
-   @param geometry_id     The id of the queried geometry.
-   @return The geometry's pose relative to its registered parent.
-   @throws std::logic_error  If the `geometry_id` does _not_ map to a valid
-                             GeometryInstance.  */
+  /** Implementation of SceneGraphInspector::X_PG().  */
   const Isometry3<double>& GetPoseInParent(GeometryId geometry_id) const;
 
   /** Implementation of SceneGraphInspector::GetProximityProperties().  */

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -115,7 +115,7 @@ class GeometryState {
     return FrameIdRange(&frames_);
   }
 
-  /** Reports the total number of geometries.  */
+  /** Implementation of SceneGraphInspector::num_frames().  */
   int get_num_geometries() const {
     return static_cast<int>(geometries_.size());
   }
@@ -128,7 +128,7 @@ class GeometryState {
     return geometry_index_to_id_map_;
   }
 
-  /** Reports the total number of geometries with the given role.  */
+  /** Implementation of SceneGraphInspector::NumGeometriesWithRole().  */
   int GetNumGeometriesWithRole(Role role) const;
 
   /** Reports the total number of *dynamic* geometries in the scene graph.  */
@@ -147,14 +147,10 @@ class GeometryState {
   /** Reports true if the given `source_id` references a registered source.  */
   bool source_is_registered(SourceId source_id) const;
 
-  /** Reports the source name for the given source id.
-   @param id  The identifier of the source.
-   @return The name of the source.
-   @throws std::logic_error if the id does _not_ map to a registered source.  */
+  /** Implementation of SceneGraphInspector::GetSourceName().  */
   const std::string& get_source_name(SourceId id) const;
 
-  /** Reports the number of frames registered to the given `source_id`. Returns
-   zero if the source is not valid.  */
+  /** Implementation of SceneGraphInspector::NumFramesForSource().  */
   int NumFramesForSource(SourceId source_id) const;
 
   /** Returns the set of frames registered to the given source.
@@ -177,10 +173,7 @@ class GeometryState {
                              identified source is not registered.  */
   bool BelongsToSource(FrameId frame_id, SourceId source_id) const;
 
-  /** Reports the name of the frame.
-   @param frame_id  The identifier of the queried frame.
-   @returns The name of the identified frame.
-   @throws std::logic_error if the frame id is not valid.  */
+  /** Implementation of SceneGraphInspector::GetName(FrameId).  */
   const std::string& get_frame_name(FrameId frame_id) const;
 
   /** Reports the frame group for the given frame.
@@ -190,15 +183,11 @@ class GeometryState {
    @internal This is equivalent to the old "model instance id".  */
   int get_frame_group(FrameId frame_id) const;
 
-  /** Reports the total number of geometries directly registered to the given
-   frame. This count does _not_ include geometries attached to frames that are
-   descendants of this frame.
-   @throws std::runtime_error if the `frame_id` is invalid.  */
+  /** Implementation of SceneGraphInspector::NumGeometriesForFrame().  */
   int GetNumFrameGeometries(FrameId frame_id) const;
 
-  /** Reports the total number of geometries for the given frame with the given
-   role.
-   @throws std::runtime_error if the `frame_id` is invalid.  */
+  /** Implementation of SceneGraphInspector::NumGeometriesForFrameWithRole().
+   */
   int GetNumFrameGeometriesWithRole(FrameId frame_id, Role role) const;
 
   // TODO(SeanCurtis-TRI): Redundant w.r.t. GetNumFrameGeometriesWithRole().
@@ -208,17 +197,7 @@ class GeometryState {
    @throws std::logic_error if the `frame_id` does not map to a valid frame.  */
   int NumGeometriesWithRole(FrameId frame_id, Role role) const;
 
-  /** Reports the id for the uniquely named geometry affixed to the indicated
-   frame with the given role.
-   @param frame_id  The id of the parent frame.
-   @param role      The assigned role of the desired geometry.
-   @param name      The name of the geometry to query for. The name will be
-                    canonicalized prior to lookup (see
-                    @ref canonicalized_geometry_names "GeometryInstance" for
-                    details).
-   @return The id of the requested geometry.
-   @throws std::logic_error if no such geometry exists, multiple geometries have
-                            that name, or if the frame doesn't exist.  */
+  /** Implementation of SceneGraphInspector::GetGeometryFromName().  */
   GeometryId GetGeometryFromName(FrameId frame_id,
                                  Role role,
                                  const std::string& name) const;
@@ -238,18 +217,10 @@ class GeometryState {
                              registered  */
   bool BelongsToSource(GeometryId geometry_id, SourceId source_id) const;
 
-  /** Retrieves the frame id on which the given geometry id is registered.
-   @param geometry_id   The query geometry id.
-   @returns An optional FrameId based on a successful lookup.
-   @throws std::logic_error  If the `geometry_id` does _not_ map to a geometry
-                             which belongs to an existing frame.*/
+  /** Implementation of SceneGraphInspector::GetFrameId().  */
   FrameId GetFrameId(GeometryId geometry_id) const;
 
-  /** Reports the stored, canonical name of the geometry (see
-   @ref canonicalized_geometry_names "GeometryInstance" for details).
-   @param geometry_id  The identifier of the queried geometry.
-   @returns The name of the identified geometry.
-   @throws std::logic_error if the geometry id is not valid.  */
+  /** Implementation of SceneGraphInspector::GetName(GeometryId).  */
   const std::string& get_name(GeometryId geometry_id) const;
 
   /** Reports the pose, relative to the registered _frame_, for the geometry
@@ -269,23 +240,14 @@ class GeometryState {
                              GeometryInstance.  */
   const Isometry3<double>& GetPoseInParent(GeometryId geometry_id) const;
 
-  /** Returns the proximity properties for the given geometry, if the geometry
-   has the proximity role (nullptr otherwise).
-   @throws std::logic_error if the `geometry_id` does not map to a valid
-                            geometry instance.  */
+  /** Implementation of SceneGraphInspector::GetProximityProperties().  */
   const ProximityProperties* get_proximity_properties(GeometryId id) const;
 
-  /** Returns the illustration properties for the given geometry, if the
-   geometry has the illustration role (nullptr otherwise).
-   @throws std::logic_error if the `geometry_id` does not map to a valid
-                            geometry instance.  */
+  /** Implementation of SceneGraphInspector::GetIllustrationProperties().  */
   const IllustrationProperties* get_illustration_properties(
       GeometryId id) const;
 
-  /** Reports true if the collision pair (id1, id2) has been filtered out.
-   @throws std::logic_error if either id does not reference a registered
-                            geometry or if the geometries do not have
-                            a proximity role.  */
+  /** Implementation of SceneGraphInspector::CollisionFiltered().  */
   bool CollisionFiltered(GeometryId id1, GeometryId id2) const;
 
   //@}

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -105,7 +105,7 @@ class GeometryState {
     return FrameIdRange(&frames_);
   }
 
-  /** Implementation of SceneGraphInspector::num_frames().  */
+  /** Implementation of SceneGraphInspector::num_geometries().  */
   int get_num_geometries() const {
     return static_cast<int>(geometries_.size());
   }

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -116,14 +116,7 @@ class SceneGraphInspector {
    frame. This count does _not_ include geometries attached to frames that are
    descendants of this frame.
    @throws std::runtime_error if the `frame_id` is invalid.  */
-  int NumFrameGeometries(FrameId frame_id) const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->GetNumFrameGeometries(frame_id);
-  }
-
-  /** Reports the number of geometries assigned to the given frame with the
-   given role.  */
-  int NumFrameGeometriesWithRole(FrameId frame_id, Role role) const {
+  int NumGeometriesForFrameWithRole(FrameId frame_id, Role role) const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->GetNumFrameGeometriesWithRole(frame_id, role);
   }

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <string>
+#include <unordered_set>
+#include <vector>
 
 #include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/geometry_state.h"
@@ -60,10 +62,49 @@ class SceneGraphInspector {
   /** @name              Scene-graph wide data  */
   //@{
 
+  /** Reports the number of registered sources -- whether they have registered
+   frames/geometries or not. This will always be at least 1; the SceneGraph
+   itself counts as a source.  */
+  int num_sources() const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->get_num_sources();
+  }
+
+  /** Reports the *total* number of frames registered in the scene graph
+   (including the world frame).  */
+  int num_frames() const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->get_num_frames();
+  }
+
+  /** Provides a range object for all of the frame ids in the scene graph. The
+   order is not generally guaranteed; but it will be consistent as long as there
+   are no changes to the topology. This is intended to be used as:
+   @code
+   for (FrameId id : inspector.all_frame_ids()) {
+    ...
+   }
+   @endcode
+
+   This includes the id for the world frame.  */
+  typename GeometryState<T>::FrameIdRange all_frame_ids() const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->get_frame_ids();
+  }
+
   /** Reports the *total* number of geometries in the scene graph.  */
   int num_geometries() const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->get_num_geometries();
+  }
+
+  /** The set of all ids for registered geometries. The order is_not_ guaranteed
+   to have any particular semantic meaning. But the order is guaranteed to
+   remain fixed between topological changes (e.g., removal or addition of
+   geometry/frames).  */
+  const std::vector<GeometryId>& all_geometry_ids() const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->get_geometry_ids();
   }
 
   /** Reports the *total* number of geometries in the scene graph with the
@@ -73,11 +114,30 @@ class SceneGraphInspector {
     return state_->GetNumGeometriesWithRole(role);
   }
 
+  /** Reports the total number of *dynamic* geometries in the scene graph.  */
+  int GetNumDynamicGeometries() const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->GetNumDynamicGeometries();
+  }
+
+  /** Reports the total number of _anchored_ geometries. This should provide
+   the same answer as calling GetNumFrameGeometries() with the world frame id.
+   */
+  int GetNumAnchoredGeometries() const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->GetNumAnchoredGeometries();
+  }
+
   //@}
 
   /** @name                Sources and source-related data  */
   //@{
 
+  /** Reports `true` if the given `id` references a registered source.  */
+  bool SourceIsRegistered(SourceId id) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->source_is_registered(id);
+  }
 
   /** Reports the name for the given source id.
    @throws std::logic_error if the identifier is invalid.  */
@@ -94,16 +154,43 @@ class SceneGraphInspector {
     return state_->NumFramesForSource(source_id);
   }
 
+  /** Reports the ids of all of the frames registered to the source indicated by
+   the given `source_id`.
+   @throws std::logic_error if `source_id` is invalid.  */
+  const std::unordered_set<FrameId>& FramesForSource(SourceId source_id) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->GetFramesForSource(source_id);
+  }
+
   //@}
 
   /** @name              Frames and their properties  */
   //@{
+
+  /** Reports if the given frame id was registered to the given source id.
+   @param frame_id      The query frame id.
+   @param source_id     The query source id.
+   @returns True if `frame_id` was registered on `source_id`.
+   @throws std::logic_error  If the `frame_id` does _not_ map to a frame or the
+                             identified source is not registered.  */
+  bool BelongsToSource(FrameId frame_id, SourceId source_id) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->BelongsToSource(frame_id, source_id);
+  }
 
   /** Reports the name of the frame indicated by the given id.
    @throws std::logic_error if `frame_id` doesn't refer to a valid frame.  */
   const std::string& GetName(FrameId frame_id) const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->get_frame_name(frame_id);
+  }
+
+  /** Reports the frame group for the frame indicated by the given `id`.
+   @throws  std::logic_error if `frame_id` doesn't refer to a valid frame.
+   @internal This value is equivalent to the old "model instance id".  */
+  int GetFrameGroup(FrameId frame_id) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->get_frame_group(frame_id);
   }
 
   /** Reports the number of geometries affixed to the given frame id. This count
@@ -146,6 +233,19 @@ class SceneGraphInspector {
   /** @name           Geometries and their properties  */
   //@{
 
+  /** Reports if the given geometry id was ultimately registered to the given
+   source id.
+   @param geometry_id   The query geometry id.
+   @param source_id     The query source id.
+   @returns True if `geometry_id` was registered on `source_id`.
+   @throws std::logic_error  If the `geometry_id` does _not_ map to a valid
+                             geometry or the identified source is not
+                             registered  */
+  bool BelongsToSource(GeometryId geometry_id, SourceId source_id) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->BelongsToSource(geometry_id, source_id);
+  }
+
   /** Reports the id of the frame to which the given geometry id is registered.
    @throws std::logic_error if the geometry id is invalid.  */
   FrameId GetFrameId(GeometryId geometry_id) const {
@@ -161,6 +261,24 @@ class SceneGraphInspector {
   const std::string& GetName(GeometryId geometry_id) const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->get_name(geometry_id);
+  }
+
+  /** Reports the pose of the geometry G (indicated by `id`) in its registered
+   _parent_ frame P. If the geometry was registered directly to the frame F,
+   then `X_PG = X_FG`.
+   @throws std::logic_error if the `id` is invalid.  */
+  const Isometry3<double> X_PG(GeometryId id) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->GetPoseInParent(id);
+  }
+
+  /** Reports the pose of the geometry G (indicated by `id`) in its registered
+   frame F (regardless of whether it was registered to another geometry or not).
+   If the geometry was registered directly to the frame F, then X_PG = X_FG.
+   @throws std::logic_error if the `id` is invalid.  */
+  const Isometry3<double> X_FG(GeometryId id) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->GetPoseInFrame(id);
   }
 
   /** Returns a pointer to the const proximity properties of the geometry

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -51,9 +51,14 @@ class SceneGraphInspector {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SceneGraphInspector)
 
+  // NOTE: An inspector should never be released into the wild without having
+  // set the state variable. Every query should start by demanding that state_
+  // is defined.
+
   //----------------------------------------------------------------------------
 
   /** @name              Scene-graph wide data  */
+  //@{
 
   /** Reports the *total* number of geometries in the scene graph.  */
   int num_geometries() const {
@@ -73,9 +78,6 @@ class SceneGraphInspector {
   /** @name                Sources and source-related data  */
   //@{
 
-  // NOTE: An inspector should never be released into the wild without having
-  // set the state variable. Every query should start by demanding that state_
-  // is defined.
 
   /** Reports the name for the given source id.
    @throws std::logic_error if the identifier is invalid.  */
@@ -95,13 +97,6 @@ class SceneGraphInspector {
 
   /** @name              Frames and their properties  */
   //@{
-
-  /** Reports the id of the frame to which the given geometry id is registered.
-   @throws std::logic_error if the geometry id is invalid.  */
-  FrameId GetFrameId(GeometryId geometry_id) const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->GetFrameId(geometry_id);
-  }
 
   /** Reports the name of the frame indicated by the given id.
    @throws std::logic_error if `frame_id` doesn't refer to a valid frame.  */
@@ -133,11 +128,6 @@ class SceneGraphInspector {
     return state_->GetNumFrameGeometriesWithRole(frame_id, role);
   }
 
-  //@}
-
-  /** @name           Geometries and their properties  */
-  //@{
-
   /** Reports the id of the geometry with the given name, attached to the
    indicated frame with the given role.
    @param frame_id  The frame whose geometry is being queried.
@@ -153,6 +143,18 @@ class SceneGraphInspector {
                                  const std::string& name) const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->GetGeometryFromName(frame_id, role, name);
+  }
+
+  //@}
+
+  /** @name           Geometries and their properties  */
+  //@{
+
+  /** Reports the id of the frame to which the given geometry id is registered.
+   @throws std::logic_error if the geometry id is invalid.  */
+  FrameId GetFrameId(GeometryId geometry_id) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->GetFrameId(geometry_id);
   }
 
   /** Reports the name of the geometry indicated by the given id.

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -17,7 +17,7 @@ class QueryObject;
 
 /** The %SceneGraphInspector serves as a mechanism to query the topological
  structure of a SceneGraph instance. The topological structure consists of all
- of the SceneGraph data that does *not* depend on input pose data. Including,
+ of the SceneGraph data that does _not_ depend on input pose data. Including,
  but not limited to:
 
  - names of frames and geometries
@@ -26,7 +26,7 @@ class QueryObject;
  - fixed poses of geometries relative to frames
 
  In contrast, the following pieces of data *do* depend on input pose data and
- *cannot* be performed with the %SceneGraphInspector (see the QueryObject
+ _cannot_ be performed with the %SceneGraphInspector (see the QueryObject
  instead):
 
  - world pose of frames or geometry
@@ -34,7 +34,7 @@ class QueryObject;
  - proximity queries
 
  A %SceneGraphInspector cannot be instantiated explicitly. Nor can it be copied
- or moved. A *reference* to a %SceneGraphInspector instance can be acquired from
+ or moved. A _reference_ to a %SceneGraphInspector instance can be acquired from
 
  - a SceneGraph instance (to inspect the state of the system's _model_), or
  - a QueryObject instance (to inspect the state of the scene graph data stored
@@ -70,7 +70,7 @@ class SceneGraphInspector {
     return state_->get_num_sources();
   }
 
-  /** Reports the *total* number of frames registered in the scene graph
+  /** Reports the _total_ number of frames registered in the scene graph
    (including the world frame).  */
   int num_frames() const {
     DRAKE_DEMAND(state_ != nullptr);
@@ -92,29 +92,29 @@ class SceneGraphInspector {
     return state_->get_frame_ids();
   }
 
-  /** Reports the *total* number of geometries in the scene graph.  */
+  /** Reports the _total_ number of geometries in the scene graph.  */
   int num_geometries() const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->get_num_geometries();
   }
 
-  /** The set of all ids for registered geometries. The order is_not_ guaranteed
-   to have any particular semantic meaning. But the order is guaranteed to
-   remain fixed between topological changes (e.g., removal or addition of
-   geometry/frames).  */
+  /** The set of all ids for registered geometries. The order is _not_
+   guaranteed to have any particular meaning. But the order is
+   guaranteed to remain fixed between topological changes (e.g., removal or
+   addition of geometry/frames).  */
   const std::vector<GeometryId>& all_geometry_ids() const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->get_geometry_ids();
   }
 
-  /** Reports the *total* number of geometries in the scene graph with the
+  /** Reports the _total_ number of geometries in the scene graph with the
    indicated role.  */
   int NumGeometriesWithRole(Role role) const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->GetNumGeometriesWithRole(role);
   }
 
-  /** Reports the total number of *dynamic* geometries in the scene graph.  */
+  /** Reports the total number of _dynamic_ geometries in the scene graph.  */
   int GetNumDynamicGeometries() const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->GetNumDynamicGeometries();
@@ -133,33 +133,32 @@ class SceneGraphInspector {
   /** @name                Sources and source-related data  */
   //@{
 
-  /** Reports `true` if the given `id` references a registered source.  */
+  /** Reports `true` if the given `id` maps to a registered source.  */
   bool SourceIsRegistered(SourceId id) const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->source_is_registered(id);
   }
 
-  /** Reports the name for the given source id.
-   @throws std::logic_error if the identifier is invalid.  */
+  /** Reports the name for the source with the given `id`.
+   @throws std::logic_error if `id` does not map to a registered source.  */
   const std::string& GetSourceName(SourceId id) const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->get_source_name(id);
   }
 
-  /** Reports the number of frames registered to the given source id. Returns
-   zero for unregistered source ids.
-   @throws std::logic_error if `source_id` is invalid.  */
-  int NumFramesForSource(SourceId source_id) const {
+  /** Reports the number of frames registered to the source with the given `id`.
+   @throws std::logic_error if `id` does not map to a registered source.  */
+  int NumFramesForSource(SourceId id) const {
     DRAKE_DEMAND(state_ != nullptr);
-    return state_->NumFramesForSource(source_id);
+    return state_->NumFramesForSource(id);
   }
 
-  /** Reports the ids of all of the frames registered to the source indicated by
-   the given `source_id`.
-   @throws std::logic_error if `source_id` is invalid.  */
-  const std::unordered_set<FrameId>& FramesForSource(SourceId source_id) const {
+  /** Reports the ids of all of the frames registered to the source with the
+   given source `id`.
+   @throws std::logic_error if `id` does not map to a registered source.  */
+  const std::unordered_set<FrameId>& FramesForSource(SourceId id) const {
     DRAKE_DEMAND(state_ != nullptr);
-    return state_->GetFramesForSource(source_id);
+    return state_->GetFramesForSource(id);
   }
 
   //@}
@@ -167,53 +166,55 @@ class SceneGraphInspector {
   /** @name              Frames and their properties  */
   //@{
 
-  /** Reports if the given frame id was registered to the given source id.
+  /** Reports if the frame with given `frame_id` was registered to the source
+   with the given `source_id`.
    @param frame_id      The query frame id.
    @param source_id     The query source id.
    @returns True if `frame_id` was registered on `source_id`.
-   @throws std::logic_error  If the `frame_id` does _not_ map to a frame or the
-                             identified source is not registered.  */
+   @throws std::logic_error  If `frame_id` does not map to a registered frame
+                             or `source_id` does not map to a registered source.
+   */
   bool BelongsToSource(FrameId frame_id, SourceId source_id) const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->BelongsToSource(frame_id, source_id);
   }
 
-  /** Reports the name of the frame indicated by the given id.
-   @throws std::logic_error if `frame_id` doesn't refer to a valid frame.  */
-  const std::string& GetName(FrameId frame_id) const {
+  /** Reports the name of the frame with the given `id`.
+   @throws std::logic_error if `id` does not map to a registered frame.  */
+  const std::string& GetName(FrameId id) const {
     DRAKE_DEMAND(state_ != nullptr);
-    return state_->get_frame_name(frame_id);
+    return state_->get_frame_name(id);
   }
 
-  /** Reports the frame group for the frame indicated by the given `id`.
-   @throws  std::logic_error if `frame_id` doesn't refer to a valid frame.
+  /** Reports the frame group for the frame with the given `id`.
+   @throws  std::logic_error if `id` does not map to a registered frame.
    @internal This value is equivalent to the old "model instance id".  */
-  int GetFrameGroup(FrameId frame_id) const {
+  int GetFrameGroup(FrameId id) const {
     DRAKE_DEMAND(state_ != nullptr);
-    return state_->get_frame_group(frame_id);
+    return state_->get_frame_group(id);
   }
 
-  /** Reports the number of geometries affixed to the given frame id. This count
-   does _not_ include geometries attached to frames that are descendants of this
-   frame.
-   @throws std::runtime_error if `frame_id` is invalid.  */
-  int NumGeometriesForFrame(FrameId frame_id) const {
-    DRAKE_DEMAND(state_ != nullptr);
-    return state_->GetNumFrameGeometries(frame_id);
-  }
-
-  /** Reports the total number of geometries directly registered to the given
-   frame. This count does _not_ include geometries attached to frames that are
+  /** Reports the number of geometries affixed to the frame with the given `id`.
+   This count does _not_ include geometries attached to frames that are
    descendants of this frame.
-   @throws std::runtime_error if the `frame_id` is invalid.  */
-  int NumGeometriesForFrameWithRole(FrameId frame_id, Role role) const {
+   @throws std::logic_error if `id` does not map to a registered frame.  */
+  int NumGeometriesForFrame(FrameId id) const {
     DRAKE_DEMAND(state_ != nullptr);
-    return state_->GetNumFrameGeometriesWithRole(frame_id, role);
+    return state_->GetNumFrameGeometries(id);
   }
 
-  /** Reports the id of the geometry with the given name, attached to the
-   indicated frame with the given role.
-   @param frame_id  The frame whose geometry is being queried.
+  /** Reports the total number of geometries directly registered to the frame
+   with the given `id`. This count does _not_ include geometries attached to
+   frames that are descendants of this frame.
+   @throws std::logic_error if `id` does not map to a registered frame.  */
+  int NumGeometriesForFrameWithRole(FrameId id, Role role) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->GetNumFrameGeometriesWithRole(id, role);
+  }
+
+  /** Reports the id of the geometry with the given `name` and `role`, attached
+   to the frame with the given frame `id`.
+   @param id        The id of the frame whose geometry is being queried.
    @param role      The assigned role of the desired geometry.
    @param name      The name of the geometry to query for. The name will be
                     canonicalized prior to lookup (see
@@ -221,11 +222,12 @@ class SceneGraphInspector {
                     details).
    @return The id of the queried geometry.
    @throws std::logic_error if no such geometry exists, multiple geometries have
-                            that name, or if the frame doesn't exist.  */
-  GeometryId GetGeometryIdByName(FrameId frame_id, Role role,
+                            that name, or if the `id` does not map to a
+                            registered frame.  */
+  GeometryId GetGeometryIdByName(FrameId id, Role role,
                                  const std::string& name) const {
     DRAKE_DEMAND(state_ != nullptr);
-    return state_->GetGeometryFromName(frame_id, role, name);
+    return state_->GetGeometryFromName(id, role, name);
   }
 
   //@}
@@ -233,78 +235,81 @@ class SceneGraphInspector {
   /** @name           Geometries and their properties  */
   //@{
 
-  /** Reports if the given geometry id was ultimately registered to the given
-   source id.
+  /** Reports if the given geometry id was registered to the source with the
+   given source id.
    @param geometry_id   The query geometry id.
    @param source_id     The query source id.
    @returns True if `geometry_id` was registered on `source_id`.
-   @throws std::logic_error  If the `geometry_id` does _not_ map to a valid
-                             geometry or the identified source is not
-                             registered  */
+   @throws std::logic_error  If `geometry_id` does not map to a registered
+                             geometry or `source_id` does not map to a
+                             registered source.  */
   bool BelongsToSource(GeometryId geometry_id, SourceId source_id) const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->BelongsToSource(geometry_id, source_id);
   }
 
-  /** Reports the id of the frame to which the given geometry id is registered.
-   @throws std::logic_error if the geometry id is invalid.  */
-  FrameId GetFrameId(GeometryId geometry_id) const {
+  /** Reports the id of the frame to which the given geometry with the given
+   `id` is registered.
+   @throws std::logic_error if `id` does not map to a registered geometry.  */
+  FrameId GetFrameId(GeometryId id) const {
     DRAKE_DEMAND(state_ != nullptr);
-    return state_->GetFrameId(geometry_id);
+    return state_->GetFrameId(id);
   }
 
-  /** Reports the stored, canonical name of the geometry indicated by the given
-   `id` (see  @ref canonicalized_geometry_names "GeometryInstance" for details).
-   Reports the name of the geometry indicated by the given id.
-   @throws std::logic_error if `geometry_id` doesn't refer to a valid geometry.
-  */
-  const std::string& GetName(GeometryId geometry_id) const {
+  /** Reports the stored, canonical name of the geometry with the given `id`
+   (see  @ref canonicalized_geometry_names "GeometryInstance" for details).
+   @throws std::logic_error if `id` does not map to a registered geometry.  */
+  const std::string& GetName(GeometryId id) const {
     DRAKE_DEMAND(state_ != nullptr);
-    return state_->get_name(geometry_id);
+    return state_->get_name(id);
   }
 
-  /** Reports the pose of the geometry G (indicated by `id`) in its registered
-   _parent_ frame P. If the geometry was registered directly to the frame F,
-   then `X_PG = X_FG`.
-   @throws std::logic_error if the `id` is invalid.  */
+  /** Reports the pose of the geometry G with the given `id` in its registered
+   _topological parent_ P. That topological parent may be a frame F or another
+   geometry. If the geometry was registered directly to F, then `X_PG = X_FG`.
+   @throws std::logic_error if `id` does not map to a registered geometry.  */
   const Isometry3<double> X_PG(GeometryId id) const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->GetPoseInParent(id);
   }
 
-  /** Reports the pose of the geometry G (indicated by `id`) in its registered
-   frame F (regardless of whether it was registered to another geometry or not).
-   If the geometry was registered directly to the frame F, then X_PG = X_FG.
-   @throws std::logic_error if the `id` is invalid.  */
+  /** Reports the pose of the geometry G with the given `id` in its registered
+   frame F (regardless of whether its _topological parent_ is another geometry P
+   or not). If the geometry was registered directly to the frame F, then
+   `X_PG = X_FG`.
+   @throws std::logic_error if `id` does not map to a registered geometry.  */
   const Isometry3<double> X_FG(GeometryId id) const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->GetPoseInFrame(id);
   }
 
-  /** Returns a pointer to the const proximity properties of the geometry
-   identified by `geometry_id`.
-   @param geometry_id   The identifier for the queried geometry.
+  /** Returns a pointer to the const proximity properties of the geometry with
+   the given `id`.
+   @param id   The identifier for the queried geometry.
    @return A pointer to the properties (or nullptr if there are no such
-           properties).  */
+           properties).
+   @throws std::logic_error if `id` does not map to a registered geometry.  */
   const ProximityProperties* GetProximityProperties(
-      GeometryId geometry_id) const {
+      GeometryId id) const {
     DRAKE_DEMAND(state_ != nullptr);
-    return state_->get_proximity_properties(geometry_id);
+    return state_->get_proximity_properties(id);
   }
 
   /** Returns a pointer to the const illustration properties of the geometry
-   identified by `geometry_id`.
-   @param geometry_id   The identifier for the queried geometry.
+   with the given `id`.
+   @param id   The identifier for the queried geometry.
    @return A pointer to the properties (or nullptr if there are no such
-           properties.  */
+           properties).
+   @throws std::logic_error if `id` does not map to a registered geometry.  */
   const IllustrationProperties* GetIllustrationProperties(
-      GeometryId geometry_id) const {
+      GeometryId id) const {
     DRAKE_DEMAND(state_ != nullptr);
-    return state_->get_illustration_properties(geometry_id);
+    return state_->get_illustration_properties(id);
   }
 
-  /** Reports true if the collision pair (id1, id2) has been filtered out.
-   @throws std::logic_error if either id does not reference a registered
+  /** Reports true if the two geometries with given ids `id1` and `id2`, define
+   a collision pair that has been filtered out.
+   @throws std::logic_error if either id does not map to a registered
                             geometry or if any of the geometries do not have
                             a proximity role.  */
   bool CollisionFiltered(GeometryId id1, GeometryId id2) const {
@@ -326,7 +331,7 @@ class SceneGraphInspector {
   // Simple default constructor to be used by SceneGraph and QueryObject.
   SceneGraphInspector() = default;
 
-  // Sets the scene graph data to inspect -- the inspector does *not* own the
+  // Sets the scene graph data to inspect -- the inspector does _not_ own the
   // data and expects that the lifespan of the provided data is longer than
   // the inspector.
   void set(const GeometryState<T>* state) { state_ = state; }

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -87,7 +87,8 @@ class SceneGraphInspector {
   }
 
   /** Reports the number of frames registered to the given source id. Returns
-   zero for unregistered source ids.  */
+   zero for unregistered source ids.
+   @throws std::logic_error if `source_id` is invalid.  */
   int NumFramesForSource(SourceId source_id) const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->NumFramesForSource(source_id);
@@ -105,7 +106,9 @@ class SceneGraphInspector {
     return state_->get_frame_name(frame_id);
   }
 
-  /** Reports the number of geometries affixed to the given frame id.
+  /** Reports the number of geometries affixed to the given frame id. This count
+   does _not_ include geometries attached to frames that are descendants of this
+   frame.
    @throws std::runtime_error if `frame_id` is invalid.  */
   int NumGeometriesForFrame(FrameId frame_id) const {
     DRAKE_DEMAND(state_ != nullptr);
@@ -150,7 +153,9 @@ class SceneGraphInspector {
     return state_->GetFrameId(geometry_id);
   }
 
-  /** Reports the name of the geometry indicated by the given id.
+  /** Reports the stored, canonical name of the geometry indicated by the given
+   `id` (see  @ref canonicalized_geometry_names "GeometryInstance" for details).
+   Reports the name of the geometry indicated by the given id.
    @throws std::logic_error if `geometry_id` doesn't refer to a valid geometry.
   */
   const std::string& GetName(GeometryId geometry_id) const {
@@ -180,8 +185,10 @@ class SceneGraphInspector {
     return state_->get_illustration_properties(geometry_id);
   }
 
-  /** Reports true if collision between the two indicated geometries has been
-   filtered out.  */
+  /** Reports true if the collision pair (id1, id2) has been filtered out.
+   @throws std::logic_error if either id does not reference a registered
+                            geometry or if any of the geometries do not have
+                            a proximity role.  */
   bool CollisionFiltered(GeometryId id1, GeometryId id2) const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->CollisionFiltered(id1, id2);

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -98,7 +98,7 @@ class SceneGraphInspector {
     return state_->get_num_geometries();
   }
 
-  /** The set of all ids for registered geometries. The order is _not_
+  /** Returns the set of all ids for registered geometries. The order is _not_
    guaranteed to have any particular meaning. But the order is
    guaranteed to remain fixed between topological changes (e.g., removal or
    addition of geometry/frames).  */
@@ -203,9 +203,9 @@ class SceneGraphInspector {
     return state_->GetNumFrameGeometries(id);
   }
 
-  /** Reports the total number of geometries directly registered to the frame
-   with the given `id`. This count does _not_ include geometries attached to
-   frames that are descendants of this frame.
+  /** Reports the total number of geometries with the given `role` directly
+   registered to the frame with the given `id`. This count does _not_ include
+   geometries attached to frames that are descendants of this frame.
    @throws std::logic_error if `id` does not map to a registered frame.  */
   int NumGeometriesForFrameWithRole(FrameId id, Role role) const {
     DRAKE_DEMAND(state_ != nullptr);

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -393,7 +393,9 @@ TEST_F(GeometryStateTest, GeometryStatistics) {
   EXPECT_EQ(geometry_state_.get_num_frames(), single_tree_frame_count());
   EXPECT_EQ(geometry_state_.NumFramesForSource(source_id_),
             single_tree_frame_count() - 1);  // subtract the world frame.
-  EXPECT_EQ(geometry_state_.NumFramesForSource(SourceId::get_new_id()), 0);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      geometry_state_.NumFramesForSource(SourceId::get_new_id()),
+      std::logic_error, "Referenced geometry source .* is not registered.");
   EXPECT_EQ(geometry_state_.GetNumDynamicGeometries(),
             single_tree_dynamic_geometry_count());
   EXPECT_EQ(geometry_state_.GetNumAnchoredGeometries(),

--- a/geometry/test/scene_graph_inspector_test.cc
+++ b/geometry/test/scene_graph_inspector_test.cc
@@ -11,7 +11,7 @@ namespace drake {
 namespace geometry {
 
 // Helper class for testing the SceneGraphInspector; specifically to create
-// a geometry state with interesting data and instantiate the inspector.
+// a geometry state and instantiate the inspector.
 class SceneGraphInspectorTester {
  public:
   SceneGraphInspectorTester() { inspector_.set(&state_); }
@@ -32,7 +32,9 @@ using std::make_unique;
 // Simply exercises all the methods to confirm there's no build or execution
 // problems. NOTE: All methods on SceneGraphInspector should be invoked here.
 // Because these are thin wrappers of GeometryState methods, the *correctness*
-// of these methods is left to be tested directly on GeometryState.
+// of these methods is left to be tested directly on GeometryState. NOTE: if
+// SceneGraphInspector adds methods that actually have meaningful internal
+// logic, they should be tested explicitly for correctness of that logic.
 GTEST_TEST(SceneGraphInspector, ExerciseEverything) {
   SceneGraphInspectorTester tester;
   const SceneGraphInspector<double>& inspector = tester.inspector();

--- a/geometry/test/scene_graph_inspector_test.cc
+++ b/geometry/test/scene_graph_inspector_test.cc
@@ -1,0 +1,100 @@
+#include "drake/geometry/scene_graph_inspector.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/geometry/geometry_frame.h"
+#include "drake/geometry/geometry_instance.h"
+
+namespace drake {
+namespace geometry {
+
+// Helper class for testing the SceneGraphInspector; specifically to create
+// a geometry state with interesting data and instantiate the inspector.
+class SceneGraphInspectorTester {
+ public:
+  SceneGraphInspectorTester() { inspector_.set(&state_); }
+
+  const SceneGraphInspector<double>& inspector() const { return inspector_; }
+
+  GeometryState<double>& mutable_state() { return state_; }
+
+ private:
+  GeometryState<double> state_;
+  SceneGraphInspector<double> inspector_;
+};
+
+namespace {
+
+using std::make_unique;
+
+// Simply exercises all the methods to confirm there's no build or execution
+// problems. NOTE: All methods on SceneGraphInspector should be invoked here.
+// Because these are thin wrappers of GeometryState methods, the *correctness*
+// of these methods is left to be tested directly on GeometryState.
+GTEST_TEST(SceneGraphInspector, ExerciseEverything) {
+  SceneGraphInspectorTester tester;
+  const SceneGraphInspector<double>& inspector = tester.inspector();
+
+  // Scene-graph wide data methods.
+  inspector.num_sources();
+
+  inspector.num_frames();
+  inspector.all_frame_ids();
+  inspector.num_geometries();
+  inspector.all_geometry_ids();
+  inspector.NumGeometriesWithRole(Role::kUnassigned);
+  inspector.GetNumDynamicGeometries();
+  inspector.GetNumAnchoredGeometries();
+
+  // Source and source-related data methods.
+  // Register a source to prevent exceptions being thrown.
+  const SourceId source_id = tester.mutable_state().RegisterNewSource("name");
+  inspector.SourceIsRegistered(source_id);
+  inspector.GetSourceName(source_id);
+  inspector.NumFramesForSource(source_id);
+  inspector.FramesForSource(source_id);
+
+  // Frames and their properties.
+  // Register a frame to prevent exceptions being thrown.
+  const FrameId frame_id = tester.mutable_state().RegisterFrame(
+      source_id, GeometryFrame("frame", Isometry3<double>::Identity()));
+  inspector.BelongsToSource(frame_id, source_id);
+  inspector.GetName(frame_id);
+  inspector.GetFrameGroup(frame_id);
+  inspector.NumGeometriesForFrame(frame_id);
+  inspector.NumGeometriesForFrameWithRole(frame_id, Role::kUnassigned);
+  // Register a geometry to prevent an exception being thrown.
+  const GeometryId geometry_id =
+      tester.mutable_state().RegisterGeometry(
+          source_id, frame_id,
+          make_unique<GeometryInstance>(Isometry3<double>::Identity(),
+                                        make_unique<Sphere>(1.0), "sphere"));
+  inspector.GetGeometryIdByName(frame_id, Role::kUnassigned, "sphere");
+
+  // Geometries and their properties.
+  inspector.BelongsToSource(geometry_id, source_id);
+  inspector.GetFrameId(geometry_id);
+  inspector.GetName(geometry_id);
+  inspector.X_PG(geometry_id);
+  inspector.X_FG(geometry_id);
+  inspector.GetProximityProperties(geometry_id);
+  inspector.GetIllustrationProperties(geometry_id);
+  // Register an *additional* geometry and assign proximity properties to both
+  // to prevent an exception being thrown.
+  const GeometryId geometry_id2 =
+      tester.mutable_state().RegisterGeometry(
+          source_id, frame_id,
+          make_unique<GeometryInstance>(Isometry3<double>::Identity(),
+                                        make_unique<Sphere>(1.0), "sphere2"));
+  tester.mutable_state().AssignRole(source_id, geometry_id,
+                                    ProximityProperties());
+  tester.mutable_state().AssignRole(source_id, geometry_id2,
+                                    ProximityProperties());
+  inspector.CollisionFiltered(geometry_id, geometry_id2);
+}
+
+}  // namespace
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
This PR is attempting something new.

The clean up of scene graph inspector includes *moving* a bunch of existing code in a well-principled way as well as adding code. In a single commit, it would be difficult to distinguish the various actions. As such, this PR has been decomposed into a number of commits. I'd recommend doing the initial review commit by commit.

The commits are as follows:
  1. Move existing code around inside their files. No change to the blocks moved, just reorganized.
  2. Removal of a redundant function (revealed by reorganizing the code) in `scene_graph_inspector.h`
  3. Consolidation of redundant documentation between `geometry_state` and `scene_graph_inspector`.h In this case, only doxygen should have changed with the detailed doxygen heading into the public API (`scene_graph_inspector`) and the internal implementation referencing it (`geometry_state.h`)
  4. Expose the introspection methods in `GeometryState` in `SceneGraphInspector`. Methods added to `SceneGraphInspector` and documentation reduced in `GeometryState`.
  5. Added a smoke unit test to confirm that `SceneGraphInspector` builds and runs.

Let me know if this decomposition helps at all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10263)
<!-- Reviewable:end -->
