### PR TITLE
Restrict cone_half_angle to [0, pi/2] in GazeTargetConstraint ctor.

### DIFF
--- a/multibody/inverse_kinematics/gaze_target_constraint.cc
+++ b/multibody/inverse_kinematics/gaze_target_constraint.cc
@@ -36,9 +36,6 @@ GazeTargetConstraint::GazeTargetConstraint(
     throw std::invalid_argument(
         "GazeTargetConstraint: cone_half_angle should be within [0, pi/2]");
   }
-  drake::log()->debug("p_AS = {}", p_AS_.transpose());
-  drake::log()->debug("n_A = {}", n_A_.transpose());
-  drake::log()->debug("p_BT = {}", p_BT_.transpose());
 }
 
 void GazeTargetConstraint::DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
@@ -78,7 +75,6 @@ void GazeTargetConstraint::DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
   const Vector2<double> g{
       p_dot_n,
       p_dot_n * p_dot_n - cos_cone_half_angle_squared_times_p.dot(p_ST_A)};
-  drake::log()->debug("g = {}", g.transpose());
   // J_g_p = ∂g/∂p.
   const Eigen::Matrix<double, 2, 3> Jp_g =
       (Eigen::Matrix<double, 2, 3>() << n_A_.transpose(),

--- a/multibody/inverse_kinematics/gaze_target_constraint.cc
+++ b/multibody/inverse_kinematics/gaze_target_constraint.cc
@@ -32,10 +32,13 @@ GazeTargetConstraint::GazeTargetConstraint(
   if (context == nullptr) throw std::invalid_argument("context is nullptr.");
   frameA.HasThisParentTreeOrThrow(&plant_.tree());
   frameB.HasThisParentTreeOrThrow(&plant_.tree());
-  if (cone_half_angle < 0 || cone_half_angle > M_PI) {
+  if (cone_half_angle < 0 || cone_half_angle > M_PI_2) {
     throw std::invalid_argument(
-        "GazeTargetConstraint: cone_half_angle should be within [0, pi]");
+        "GazeTargetConstraint: cone_half_angle should be within [0, pi/2]");
   }
+  drake::log()->debug("p_AS = {}", p_AS_.transpose());
+  drake::log()->debug("n_A = {}", n_A_.transpose());
+  drake::log()->debug("p_BT = {}", p_BT_.transpose());
 }
 
 void GazeTargetConstraint::DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
@@ -75,6 +78,7 @@ void GazeTargetConstraint::DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
   const Vector2<double> g{
       p_dot_n,
       p_dot_n * p_dot_n - cos_cone_half_angle_squared_times_p.dot(p_ST_A)};
+  drake::log()->debug("g = {}", g.transpose());
   // J_g_p = ∂g/∂p.
   const Eigen::Matrix<double, 2, 3> Jp_g =
       (Eigen::Matrix<double, 2, 3>() << n_A_.transpose(),

--- a/multibody/inverse_kinematics/gaze_target_constraint.h
+++ b/multibody/inverse_kinematics/gaze_target_constraint.h
@@ -45,7 +45,7 @@ class GazeTargetConstraint : public solvers::Constraint {
    * @pre `frameA` and `frameB` must belong to `plant`.
    * @throws std::invalid_argument if `plant` is nullptr.
    * @throws std::invalid_argument if `n_A` is close to zero.
-   * @throws std::invalid_argument if `cone_half_angle` ∉ [0, π].
+   * @throws std::invalid_argument if `cone_half_angle` ∉ [0, π/2].
    * @throws std::invalid_argument if `context` is nullptr.
    */
   GazeTargetConstraint(

--- a/multibody/inverse_kinematics/test/gaze_target_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/gaze_target_constraint_test.cc
@@ -127,10 +127,16 @@ TEST_F(IiwaKinematicConstraintTest, GazeTargetConstraintConstructorError) {
                            frameB, p_BT, 0.1, plant_context_),
       std::invalid_argument);
 
-  // wrong cone_half_angle
+  // cone_half_angle < 0
   EXPECT_THROW(
       GazeTargetConstraint(plant_, frameA, p_AS, Eigen::Vector3d::Ones(),
                            frameB, p_BT, -0.1, plant_context_),
+      std::invalid_argument);
+
+  // cone_half_angle > π/2
+  EXPECT_THROW(
+      GazeTargetConstraint(plant_, frameA, p_AS, Eigen::Vector3d::Ones(),
+                           frameB, p_BT, 1.6, plant_context_),
       std::invalid_argument);
 }
 


### PR DESCRIPTION
Previously, users could set `cone_half_angle` to any value in the range [0, pi], but the constraint would implicitly enforce that `cone_half_angle` be less than pi/2. Now that restriction is documented and explicitly enforced.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10268)
<!-- Reviewable:end -->
