### PR TITLE
Modernize event handling in SignalLogger

### DIFF
--- a/examples/fibonacci/test/fibonacci_difference_equation_test.cc
+++ b/examples/fibonacci/test/fibonacci_difference_equation_test.cc
@@ -22,8 +22,6 @@ GTEST_TEST(Fibonacci, CheckSequence) {
   auto diagram = builder.Build();
 
   systems::Simulator<double> simulator(*diagram);
-  simulator.set_publish_every_time_step(false);
-  simulator.set_publish_at_initialization(false);
 
   // Simulate forward to fibonacci(6): 0 1 1 2 3 5 8
   simulator.StepTo(6 * FibonacciDifferenceEquation::kPeriod);

--- a/systems/analysis/test/simulator_test.cc
+++ b/systems/analysis/test/simulator_test.cc
@@ -1012,8 +1012,6 @@ GTEST_TEST(SimulatorTest, ExampleDiscreteSystem) {
 
   // Create a Simulator and use it to advance time until t=3*h.
   Simulator<double> simulator(*diagram);
-  simulator.set_publish_every_time_step(false);
-  simulator.set_publish_at_initialization(false);
   simulator.StepTo(3 * ExampleDiscreteSystem::kPeriod);
 
   testing::internal::CaptureStdout();  // Not in example.
@@ -1090,10 +1088,6 @@ GTEST_TEST(SimulatorTest, SinusoidalHybridSystem) {
   const double t_final = 10.0;
   const double initial_value = std::sin(-f * h);  // = sin(f*-1*h)
   Simulator<double> simulator(*diagram);
-
-  // TODO(sherm1) Remove these when #10269 lands (fix to SignalLogger).
-  simulator.set_publish_at_initialization(false);
-  simulator.set_publish_every_time_step(false);
 
   simulator.get_mutable_context().get_mutable_discrete_state()[0] =
       initial_value;

--- a/systems/discrete_systems.h
+++ b/systems/discrete_systems.h
@@ -91,8 +91,6 @@ The following code fragment can be used to step this system forward:
 
   // Create a Simulator and use it to advance time until t=3*h.
   Simulator<double> simulator(*diagram);
-  simulator.set_publish_every_time_step(false);
-  simulator.set_publish_at_initialization(false);
   simulator.StepTo(3 * ExampleDiscreteSystem::kPeriod);
 
   // Print out the contents of the log.

--- a/systems/lcm/test/lcm_driven_loop_test.cc
+++ b/systems/lcm/test/lcm_driven_loop_test.cc
@@ -90,8 +90,11 @@ GTEST_TEST(LcmDrivenLoopTest, TestLoop) {
   sub->set_name("subscriber");
   auto dummy = builder.AddSystem<DummySys>();
   dummy->set_name("dummy");
+
   auto logger = builder.AddSystem<SignalLogger<double>>(1);
   logger->set_name("logger");
+  logger->set_forced_publish_only();  // Log only when told to do so.
+
   builder.Connect(*sub, *dummy);
   builder.Connect(*dummy, *logger);
   auto sys = builder.Build();
@@ -99,9 +102,9 @@ GTEST_TEST(LcmDrivenLoopTest, TestLoop) {
   // Makes the lcm driven loop.
   lcm::LcmDrivenLoop dut(*sys, *sub, nullptr, &lcm,
       std::make_unique<MilliSecTimeStampMessageToSeconds>());
-  // This ensures that dut calls sys->Publish() every time it handles a
-  // message, which triggers the logger to save its input (message time stamp)
-  // to the log.
+  // This ensures that dut calls sys->Publish() (a.k.a. "forced publish")
+  // every time it handles a message, which triggers the logger to save its
+  // input (message time stamp) to the log.
   dut.set_publish_on_every_received_message(true);
 
   // Starts the publishing thread.

--- a/systems/primitives/BUILD.bazel
+++ b/systems/primitives/BUILD.bazel
@@ -542,6 +542,7 @@ drake_cc_googletest(
         ":linear_system",
         ":signal_logger",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
         "//systems/analysis:simulator",
         "//systems/framework",
     ],

--- a/systems/primitives/signal_log.h
+++ b/systems/primitives/signal_log.h
@@ -7,7 +7,10 @@ namespace drake {
 namespace systems {
 
 /**
- This class serves as an in-memory cache of time-dependent vector values.
+ This utility class serves as an in-memory cache of time-dependent vector
+ values. Note that this is a standalone class, not a Drake System. It is
+ primarily intended to support the Drake System primitive SignalLogger, but can
+ be used independently.
 
  @tparam T The vector element type, which must be a valid Eigen scalar.
  */
@@ -23,6 +26,9 @@ class SignalLog {
   */
   explicit SignalLog(int input_size, int batch_allocation_size = 1000);
 
+  /** Returns the number of samples taken since construction or last reset(). */
+  int num_samples() const { return num_samples_; }
+
   /** Accesses the logged time stamps. */
   Eigen::VectorBlock<const VectorX<T>> sample_times() const {
     return const_cast<const VectorX<T>&>(sample_times_).head(num_samples_);
@@ -34,7 +40,7 @@ class SignalLog {
     return const_cast<const MatrixX<T>&>(data_).leftCols(num_samples_);
   }
 
-  /** Reset the logged data. */
+  /** Clears the logged data. */
   void reset() {
     // Resetting num_samples_ is sufficient to have all future writes and
     // reads re-initialized to the beginning of the data.

--- a/systems/primitives/signal_logger.cc
+++ b/systems/primitives/signal_logger.cc
@@ -9,24 +9,56 @@ template <typename T>
 SignalLogger<T>::SignalLogger(int input_size, int batch_allocation_size)
     : log_(input_size, batch_allocation_size) {
   this->DeclareInputPort("data", kVectorValued, input_size);
+
+  // Use a per-step event by default; disabled by set_publish_period() or
+  // set_forced_publish_only().
+  this->DeclarePerStepPublishEvent(&SignalLogger<T>::PerStepWriteToLog);
+  logging_mode_ = kPerStep;
 }
 
 template <typename T>
 void SignalLogger<T>::set_publish_period(double period) {
-  this->DeclarePeriodicPublish(period);
+  switch (logging_mode_) {
+    case kPeriodic:
+      throw std::logic_error(
+          "SignalLogger::set_publish_period(): can only be called once.");
+    case kForced:
+      throw std::logic_error(
+          "SignalLogger::set_publish_period(): cannot be called if "
+          "set_forced_publish_only() has been called.");
+    case kPerStep:
+      this->DeclarePeriodicPublishEvent(period, 0.,  // period, offset
+                                        &SignalLogger<T>::WriteToLog);
+      logging_mode_ = kPeriodic;
+      return;
+  }
 }
 
 template <typename T>
-void SignalLogger<T>::DoPublish(const Context<T>& context,
-                                const std::vector<const PublishEvent<T>*>&)
-                                const {
+void SignalLogger<T>::set_forced_publish_only() {
+  switch (logging_mode_) {
+    case kForced:
+      return;  // Already forced-publishing.
+    case kPeriodic:
+      throw std::logic_error(
+          "SignalLogger::set_forced_publish_only(): "
+          "cannot be called if set_publish_period() has been called.");
+    case kPerStep:
+      this->DeclareForcedPublishEvent(&SignalLogger<T>::WriteToLog);
+      logging_mode_ = kForced;
+      return;
+  }
+}
+
+template <typename T>
+EventStatus SignalLogger<T>::WriteToLog(const Context<T>& context) const {
   log_.AddData(context.get_time(),
                this->EvalVectorInput(context, 0)->get_value());
+  return EventStatus::Succeeded();
 }
 
 template <typename T>
-const InputPort<T>& SignalLogger<T>::get_input_port()
-const {
+const InputPort<T>& SignalLogger<T>::get_input_port() const {
   return System<T>::get_input_port(0);
 }
 


### PR DESCRIPTION
Rather than overriding the DoPublish() dispatcher, this provides for per-step, periodic, or forced-event logging with a local handler. Also improves documentation to mention existing flaws in performance and thread safety.

This change was motivated by #10346, where the pedagogical examples are still saddled with this unwanted boilerplate:
```
simulator.set_publish_every_time_step(false);
simulator.set_publish_at_initialization(false);
```
That's to avoid getting extra per-step log entries when SignalLogger is set to publish periodically. With the change here per-step, publish, and forced events are mutually exclusive and the above lines are no longer necessary in the examples. They are removed here.

The forced-event-only feature is present for backwards compatibility with existing code (LcmDrivenLoop depends on it); it is not expected to be used much in practice. However, it is now using the recommended local-method handling so is not deprecated and is fine to leave in place.

```
Category            added  modified  removed  
----------------------------------------------
code                60     13        13       
comments            50     19        3        
blank               20     0         1        
----------------------------------------------
TOTAL               130    32        17       
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10269)
<!-- Reviewable:end -->
