### PR TITLE
Remove flaky test tags related to usage of non-mock LCM

### DIFF
--- a/automotive/BUILD.bazel
+++ b/automotive/BUILD.bazel
@@ -533,8 +533,6 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "automotive_simulator_test",
     data = ["//automotive/models:prod_models"],
-    # Flaky because LCM self-test can fail (PR #7311)
-    flaky = 1,
     deps = [
         "//automotive:automotive_simulator",
         "//automotive:create_trajectory_params",
@@ -757,7 +755,6 @@ drake_cc_googletest(
 
 drake_py_unittest(
     name = "steering_command_driver_test",
-    flaky = 1,
     deps = [
         ":steering_command_driver",
         "@lcm//:lcm-python",

--- a/examples/acrobot/BUILD.bazel
+++ b/examples/acrobot/BUILD.bazel
@@ -230,7 +230,6 @@ drake_cc_binary(
         "-simulation_sec=1.0",
         "-realtime_factor=0.0",
     ],
-    test_rule_flaky = 1,
     test_rule_size = "medium",
     deps = [
         ":acrobot_lcm",

--- a/examples/kuka_iiwa_arm/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/BUILD.bazel
@@ -133,8 +133,6 @@ drake_cc_binary(
     # causes timeouts in kcov.
     tags = ["no_kcov"],
     test_rule_args = ["--simulation_sec=0.01"],
-    # Flaky because LCM self-test can fail (PR #7311)
-    test_rule_flaky = 1,
     deps = [
         ":iiwa_common",
         ":iiwa_lcm",
@@ -159,8 +157,6 @@ drake_cc_binary(
     # causes timeouts in kcov.
     tags = ["no_kcov"],
     test_rule_args = ["--simulation_sec=0.1 --target_realtime_rate=0.0"],
-    # Flaky because LCM self-test can fail (PR #7311)
-    test_rule_flaky = 1,
     deps = [
         ":iiwa_common",
         ":iiwa_lcm",
@@ -279,8 +275,6 @@ sh_test(
     data = [
         ":dual_iiwa14_polytope_collision.urdf",
     ],
-    # Flaky because LCM self-test can fail (PR #7311)
-    flaky = 1,
     # TODO(kyle.edwards@kitware.com): Re-enable this test when it no longer
     # causes timeouts in kcov.
     tags = ["no_kcov"],

--- a/examples/kuka_iiwa_arm/dev/box_rotation/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/dev/box_rotation/BUILD.bazel
@@ -61,8 +61,6 @@ drake_cc_binary(
         "//manipulation/models/iiwa_description:models",
     ],
     test_rule_args = ["--simulation_sec=0.01"],
-    # Flaky because LCM self-test can fail (PR #7311)
-    test_rule_flaky = 1,
     deps = [
         ":iiwa_box_diagram_factory",
         "//attic/manipulation/util:frame_pose_tracker",

--- a/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/BUILD.bazel
@@ -45,8 +45,6 @@ drake_cc_binary(
         "no_tsan",
     ],
     test_rule_args = ["--quick"],
-    # Flaky because LCM self-test can fail (PR #7311)
-    test_rule_flaky = 1,
     deps = [
         ":kuka_pick_and_place_monolithic",
         "//common:find_resource",

--- a/examples/schunk_wsg/BUILD.bazel
+++ b/examples/schunk_wsg/BUILD.bazel
@@ -28,8 +28,6 @@ drake_cc_binary(
         "//manipulation/models/wsg_50_description:models",
     ],
     test_rule_args = ["--simulation_sec=0.1"],
-    # Flaky because LCM self-test can fail (PR #7311)
-    test_rule_flaky = 1,
     deps = [
         ":simulated_schunk_wsg_system",
         "//attic/multibody/rigid_body_plant",

--- a/examples/valkyrie/BUILD.bazel
+++ b/examples/valkyrie/BUILD.bazel
@@ -163,8 +163,6 @@ drake_cc_googletest(
     name = "valkyrie_simulation_test",
     srcs = ["test/valkyrie_simulation_test.cc"],
     data = [":models"],
-    # Flaky because LCM self-test can fail (PR #7311)
-    flaky = 1,
     deps = [":valkyrie_simulator"],
 )
 

--- a/lcm/BUILD.bazel
+++ b/lcm/BUILD.bazel
@@ -108,8 +108,6 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "drake_lcm_test",
-    # Flaky because LCM self-test can fail (PR #7311)
-    flaky = 1,
     deps = [
         ":lcmt_drake_signal_utils",
         ":real",

--- a/systems/lcm/BUILD.bazel
+++ b/systems/lcm/BUILD.bazel
@@ -135,6 +135,7 @@ drake_cc_googletest(
         "no_asan",
         "no_memcheck",
         "no_tsan",
+        "requires-network",
     ],
     deps = [
         "//common/test_utilities:eigen_matrix_compare",


### PR DESCRIPTION
Cleanup after #10172. That these used the network and now do not follows in part from the pre-#10172 version of a branch I have that blocked network access by default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10272)
<!-- Reviewable:end -->
