### PR TITLE
ComputeSignedDistancePairwiseClosestPoints to compute sphere-to-sphere and sphere-to-box distance in the closed form.

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -53,6 +53,7 @@ drake_cc_library(
         "//geometry/query_results:penetration_as_point_pair",
         "//geometry/query_results:signed_distance_pair",
         "//geometry/query_results:signed_distance_to_point",
+        "//math",
         "@fcl",
         "@tinyobjloader",
     ],

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -22,17 +22,22 @@
 #include "drake/common/drake_variant.h"
 #include "drake/common/sorted_vectors_have_intersection.h"
 #include "drake/geometry/utilities.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/math/rotation_matrix.h"
 
 namespace drake {
 namespace geometry {
 namespace internal {
 
 using Eigen::Vector3d;
+using Eigen::Isometry3d;
 using std::make_shared;
 using std::make_unique;
 using std::move;
 using std::shared_ptr;
 using std::unique_ptr;
+using math::RigidTransformd;
+using math::RotationMatrixd;
 
 namespace {
 
@@ -266,6 +271,247 @@ struct CollisionData {
   std::vector<PenetrationAsPointPair<double>>* contacts{};
 };
 
+// An internal functor to support DistanceFromPointCallback() and
+// ComputeNearphaseDistance(). It computes the signed distance to a query
+// point from a supported geometry. Each overload to the call operator
+// reports the signed distance (encoded as SignedDistanceToPoint) between the
+// functor's stored query point and the given geometry argument.
+class DistanceToPoint {
+ public:
+  // Constructs the functor DistanceToPoint.
+  // @param id    the id of the geometry G,
+  // @param X_WG  pose of the geometry G in World frame,
+  // @param p_WQ  position of the query point Q in World frame.
+  // @note Some parts of the geometry (id, pose) are initialized in this
+  // constructor, and the remaining part of the geometry (shape) is a parameter
+  // to the call operator() below.
+  DistanceToPoint(const GeometryId id,
+                  const RigidTransformd& X_WG,
+                  const Vector3d& p_WQ) :
+      geometry_id_(id), X_WG_(X_WG), p_WQ_(p_WQ) {}
+
+  // Overload for Sphere.
+  SignedDistanceToPoint<double> operator()(const fcl::Sphered& sphere);
+
+  // Overload for Box.
+  SignedDistanceToPoint<double> operator()(const fcl::Boxd& box);
+
+ private:
+  // Calculate a tolerance relative to a given `size` parameter with a lower
+  // bound of 1e-14 meter. If the `size` parameter is larger than 1 meter, we
+  // use the relative tolerance of 1e-14 times the `size`.  If the `size` is
+  // smaller than 1 meter, we use the absolute tolerance 1e-14 meter. The
+  // 1e-14-meter lower bound helps us handle possible round off errors arising
+  // from applying a pose X_WG to a geometry G. Given a query point Q exactly
+  // on the boundary ∂G, if we apply X_WG to both Q and G, the point Q is likely
+  // to deviate from ∂G more than the machine epsilon, which is around 2e-16.
+  static double RelativeTolerance(double size) {
+    return 1e-14 * std::max(1., size);
+  }
+  // This version of Sign(x) returns +1.0 for zero.
+  static double Sign(double x) { return (x < 0.0) ? -1. : 1.; }
+  // Picks the axis i whose coordinate p(i) is closest to the boundary value
+  // ±bounds(i). If there are ties, we prioritize according to an arbitrary
+  // ordering: +x,-x,+y,-y,+z,-z.
+  static int ExtremalAxis(const Vector3d& p, const Vector3d& bounds) {
+    double min_dist = std::numeric_limits<double>::infinity();
+    int axis = -1;
+    for (int i = 0; i < 3; ++i) {
+      for (const auto bound : {bounds(i), -bounds(i)}) {
+        const double dist = std::abs(bound - p(i));
+        if (dist < min_dist) {
+          min_dist = dist;
+          axis = i;
+        }
+      }
+    }
+    return axis;
+  }
+
+  // The id of the geometry G.
+  const GeometryId geometry_id_;
+  // The pose of the geometry G in World frame.
+  const RigidTransformd X_WG_;
+  // The position of the query point Q in World frame.
+  const Vector3d p_WQ_;
+};
+
+// An internal functor to compute sphere-sphere signed distance and sphere-box
+// signed distance.
+class DistancePairGeometry {
+ public:
+  DistancePairGeometry(const GeometryId& id_A, const GeometryId& id_B,
+                       const RigidTransformd& X_WA, const RigidTransformd& X_WB,
+                       fcl::DistanceResultd* result)
+      : id_A_(id_A), id_B_(id_B), X_WA_(X_WA), X_WB_(X_WB), result_(result) {}
+
+  // Given a sphere A centered at Ao with radius r and another geometry B,
+  // we want to compute
+  // 1. φ_A,B = the signed distance between the two objects, which is positive
+  //    for non-overlapping objects and equals the negative penetration depth
+  //    for overlapping objects.
+  // 2. Na, Nb = a pair of witness points, Na ∈ ∂A, Nb ∈ ∂B (not necessarily
+  //    unique), |Na-Nb| = |φ_A,B|.
+  //
+  // Define these functions: (available from SignedDistanceToPoint)
+  //   φ_B:ℝ³→ℝ, φ_B(p)  = signed distance to point p from B.
+  //   η_B:ℝ³→ℝ³, η_B(p) = a nearest point to p on the boundary ∂B (not
+  //                       necessarily unique).
+  //   ∇φ_B:ℝ³→ℝ³, ∇φ_B(p) = gradient vector of φ_B with respect to p.
+  //                         It has unit length by construction.
+  // Algorithm:
+  // 1. φ_A,B = φ_B(Ao) - r
+  // 2. Nb = η_B(Ao)
+  // 3. Na = Ao - r * ∇φ_B(Ao)
+  void operator()(const fcl::Sphered* sphere_A, const fcl::Sphered* sphere_B);
+  void operator()(const fcl::Sphered* sphere_A, const fcl::Boxd* box_B);
+  void operator()(const fcl::Boxd* box_A, const fcl::Sphered* sphere_B);
+
+ private:
+  // Performs step 3. Na = Ao - r * ∇φ_B(Ao).
+  // @param radius_A the radius of the sphere A.
+  // @param X_WA the pose of the sphere A.
+  // @param gradB_W the gradient vector ∇φ_B(Ao).
+  // @retval p_WNa the witness point Na ∈ ∂A expressed in World frame.
+  Vector3d WitnessPointOnSphere(
+      const double radius_A, const RigidTransformd& X_WA,
+      const Vector3d& gradB_W) const;
+
+  GeometryId id_A_;
+  GeometryId id_B_;
+  RigidTransformd X_WA_;
+  RigidTransformd X_WB_;
+  fcl::DistanceResultd* result_;
+};
+
+Vector3d DistancePairGeometry::WitnessPointOnSphere(
+    const double radius_A, const RigidTransformd& X_WA,
+    const Vector3d& gradB_W) const {
+  // Notation:
+  // gradB_W = ∇φ_B(Ao) expressed in World frame.
+  // gradB_A = ∇φ_B(Ao) expressed in A's frame.
+  const RotationMatrixd& R_WA = X_WA.rotation();
+  const RotationMatrixd R_AW = R_WA.transpose();
+  const Vector3d gradB_A = R_AW * gradB_W;
+  // By construction gradB_A has unit length.
+  const Vector3d p_ANa = -radius_A * gradB_A;
+  const Vector3d p_WNa = X_WA * p_ANa;
+  return p_WNa;
+}
+
+// Signed distance between two spheres.
+void DistancePairGeometry::operator()(const fcl::Sphered* sphere_A,
+                                      const fcl::Sphered* sphere_B) {
+  const SignedDistanceToPoint<double> sphere_B_to_point_Ao =
+      DistanceToPoint{id_B_, X_WB_, X_WA_.translation()}(*sphere_B);
+  const double distance = sphere_B_to_point_Ao.distance - sphere_A->radius;
+  // Nb is the witness point on ∂B.
+  const Vector3d& p_BNb = sphere_B_to_point_Ao.p_GN;
+  const Vector3d p_WNb = X_WB_ * p_BNb;
+  // Na is the witness point on ∂A.
+  const Vector3d& gradB_W = sphere_B_to_point_Ao.grad_W;
+  const Vector3d p_WNa = WitnessPointOnSphere(sphere_A->radius, X_WA_, gradB_W);
+  // fcl::DistanceResult expects -1 for geometry shapes (triangle id or
+  // point id for meshes or point clouds, and cell id for octrees).
+  result_->update(distance, sphere_A, sphere_B, -1, -1, p_WNa, p_WNb);
+}
+
+// Signed distance between a sphere and a box.
+void DistancePairGeometry::operator()(const fcl::Sphered* sphere_A,
+                                      const fcl::Boxd* box_B) {
+  SignedDistanceToPoint<double> box_B_to_point_Ao =
+      DistanceToPoint{id_B_, X_WB_, X_WA_.translation()}(*box_B);
+  const double distance = box_B_to_point_Ao.distance - sphere_A->radius;
+  // Nb is the witness point on ∂B.
+  const Vector3d& p_BNb = box_B_to_point_Ao.p_GN;
+  const Vector3d p_WNb = X_WB_ * p_BNb;
+  // Na is the witness point on ∂A.
+  const Vector3d& gradB_W = box_B_to_point_Ao.grad_W;
+  const Vector3d p_WNa = WitnessPointOnSphere(sphere_A->radius, X_WA_, gradB_W);
+  // fcl::DistanceResult expects -1 for geometry shapes (triangle id or
+  // point id for meshes or point clouds, and cell id for octrees).
+  result_->update(distance, sphere_A, box_B, -1, -1, p_WNa, p_WNb);
+}
+
+// Signed distance between a box and a sphere. Instead of calling
+// operator()(sphere_B, box_A), we repeat almost the same computation again.
+// The reason is that to call operator()(sphere_B, box_A), we have to swap
+// the pose X_WA_ v.s. X_WB_ and id_A_ v.s. id_B_ before and after the call,
+// and we have to swap o1 v.s. o2 and the two nearest_points[2] in the result_
+// variable after the call. I think the overhead from swap() is not worth it.
+void DistancePairGeometry::operator()(const fcl::Boxd* box_A,
+                                      const fcl::Sphered* sphere_B) {
+  SignedDistanceToPoint<double> box_A_to_point_Bo =
+      DistanceToPoint{id_A_, X_WA_, X_WB_.translation()}(*box_A);
+  const double distance = box_A_to_point_Bo.distance - sphere_B->radius;
+  // Na is the witness point on ∂A.
+  const Vector3d& p_ANa = box_A_to_point_Bo.p_GN;
+  const Vector3d p_WNa = X_WA_ * p_ANa;
+  // Nb is the witness point on ∂B.
+  const Vector3d& gradA_W = box_A_to_point_Bo.grad_W;
+  const Vector3d p_WNb = WitnessPointOnSphere(sphere_B->radius, X_WB_, gradA_W);
+  // fcl::DistanceResult expects -1 for geometry shapes (triangle id or
+  // point id for meshes or point clouds, and cell id for octrees).
+  result_->update(distance, box_A, sphere_B, -1, -1, p_WNa, p_WNb);
+}
+
+// Helps DistanceCallback(). Do it in closed forms for sphere-sphere or
+// sphere-box. Otherwise, use FCL GJK/EPA.
+void ComputeNearphaseDistance(const fcl::CollisionObjectd* a,
+                              const fcl::CollisionObjectd* b,
+                              const std::vector<GeometryId>& geometry_map,
+                              const fcl::DistanceRequestd& request,
+                              fcl::DistanceResultd* result) {
+  const fcl::CollisionGeometryd* a_geometry = a->collisionGeometry().get();
+  const fcl::CollisionGeometryd* b_geometry = b->collisionGeometry().get();
+  const RigidTransformd X_WA(a->getTransform());
+  const RigidTransformd X_WB(b->getTransform());
+  const auto id_A = EncodedData(*a).id(geometry_map);
+  const auto id_B = EncodedData(*b).id(geometry_map);
+
+  DistancePairGeometry distance_pair(id_A, id_B, X_WA, X_WB, result);
+
+  switch (a_geometry->getNodeType()) {
+    case fcl::GEOM_SPHERE: {
+      switch (b_geometry->getNodeType()) {
+        case fcl::GEOM_SPHERE: {
+          auto sphere_A = static_cast<const fcl::Sphered*>(a_geometry);
+          auto sphere_B = static_cast<const fcl::Sphered*>(b_geometry);
+          distance_pair(sphere_A, sphere_B);
+          break;
+        }
+        case fcl::GEOM_BOX: {
+          auto sphere_A = static_cast<const fcl::Sphered*>(a_geometry);
+          auto box_B = static_cast<const fcl::Boxd*>(b_geometry);
+          distance_pair(sphere_A, box_B);
+          break;
+        }
+        default: {
+          fcl::distance(a, b, request, *result);
+        }
+      }
+      break;
+    }
+    case fcl::GEOM_BOX: {
+      switch (b_geometry->getNodeType()) {
+        case fcl::GEOM_SPHERE: {
+          auto box_A = static_cast<const fcl::Boxd*>(a_geometry);
+          auto sphere_B = static_cast<const fcl::Sphered*>(b_geometry);
+          distance_pair(box_A, sphere_B);
+          break;
+        }
+        default: {
+          fcl::distance(a, b, request, *result);
+        }
+      }
+      break;
+    }
+    default: {
+      fcl::distance(a, b, request, *result);
+    }
+  }
+}
+
 // The callback function in fcl::distance request. The final unnamed parameter
 // is `dist`, which is used in fcl::distance, that if the distance between two
 // geometries is proved to be greater than `dist` (for example, the smallest
@@ -301,12 +547,12 @@ bool DistanceCallback(fcl::CollisionObjectd* fcl_object_A_ptr,
     // Unpack the callback data
     auto& distance_data = *static_cast<DistanceData*>(callback_data);
     const fcl::DistanceRequestd& request = distance_data.request;
-    const std::vector<GeometryId> geometry_map = distance_data.geometry_map;
+    const std::vector<GeometryId>& geometry_map = distance_data.geometry_map;
 
     fcl::DistanceResultd result;
 
-    // Perform nearphase distance computation.
-    fcl::distance(&fcl_object_A, &fcl_object_B, request, result);
+    ComputeNearphaseDistance(&fcl_object_A, &fcl_object_B,
+                             geometry_map, request, &result);
 
     SignedDistancePair<double> nearest_pair;
     nearest_pair.id_A = EncodedData(fcl_object_A).id(geometry_map);
@@ -335,186 +581,129 @@ bool DistanceCallback(fcl::CollisionObjectd* fcl_object_A_ptr,
   return false;
 }
 
-// A functor to support DistanceFromPointCallback(). It computes the signed
-// distance to a query point from a supported geometry.
-// Each overload to the call operator reports the signed distance (encoded as
-// SignedDistanceToPoint) between the functor's stored query point and the
-// given geometry argument.
-class DistanceToPoint {
- public:
-  // Constructs the functor DistanceToPoint.
-  // @param id    the id of the geometry G,
-  // @param X_WG  pose of the geometry G in World frame,
-  // @param p_WQ  position of the query point Q in World frame.
-  // @note Some parts of the geometry (id, pose) are initialized in this
-  // constructor, and the remaining part of the geometry (shape) is a parameter
-  // to the call operator() below.
-  DistanceToPoint(const GeometryId id,
-                  const Isometry3<double>& X_WG,
-                  const Vector3d& p_WQ) :
-                  geometry_id_(id), X_WG_(X_WG), p_WQ_(p_WQ) {}
+// Overload for Sphere.
+SignedDistanceToPoint<double> DistanceToPoint::operator()(
+    const fcl::Sphered& sphere) {
+  // TODO(DamrongGuoy): Move most code of this function into FCL.
+  const double radius = sphere.radius;
+  const Vector3d p_GQ_G = X_WG_.inverse() * p_WQ_;
+  const double dist_GQ = p_GQ_G.norm();
+  const double distance = dist_GQ - radius;
 
-  // Overload for Sphere.
-  SignedDistanceToPoint<double> operator()(const fcl::Sphered& sphere) {
-    // TODO(DamrongGuoy): Move most code of this function into FCL.
-    const double radius = sphere.radius;
-    const Vector3d p_GQ_G = X_WG_.inverse() * p_WQ_;
-    const double dist_GQ = p_GQ_G.norm();
-    const double distance = dist_GQ - radius;
+  // The gradient is always in the direction from the center of the sphere to
+  // the query point Q, regardless of whether the point Q is outside or inside
+  // the sphere G.  The gradient is undefined if the query point Q is at the
+  // center of the sphere G.
+  //
+  // If the query point Q is near the center of the sphere G within a
+  // tolerance, we arbitrarily set the gradient vector as documented in
+  // query_object.h (QueryObject::ComputeSignedDistanceToPoint).
+  const double tolerance = RelativeTolerance(radius);
+  // Unit vector in x-direction of G's frame.
+  const Vector3d Gx(1., 0., 0.);
+  // Gradient vector expressed in G's frame.
+  Vector3d grad_G = (dist_GQ > tolerance) ? p_GQ_G / dist_GQ : Gx;
 
-    // The gradient is always in the direction from the center of the sphere to
-    // the query point Q, regardless of whether the point Q is outside or inside
-    // the sphere G.  The gradient is undefined if the query point Q is at the
-    // center of the sphere G.
-    //
-    // If the query point Q is near the center of the sphere G within a
-    // tolerance, we arbitrarily set the gradient vector as documented in
-    // query_object.h (QueryObject::ComputeSignedDistanceToPoint).
-    const double tolerance = RelativeTolerance(radius);
-    // Unit vector in x-direction of G's frame.
-    const Vector3d Gx(1., 0., 0.);
-    // Gradient vector expressed in G's frame.
-    Vector3d grad_G = (dist_GQ > tolerance) ? p_GQ_G / dist_GQ : Gx;
+  // Position vector of the nearest point N on G's surface from the query
+  // point Q, expressed in G's frame.
+  const Vector3d p_GN_G = radius * grad_G;
+  // Gradient vector expressed in World frame.
+  const Vector3d grad_W = X_WG_.rotation() * grad_G;
 
-    // Position vector of the nearest point N on G's surface from the query
-    // point Q, expressed in G's frame.
-    const Vector3d p_GN_G = radius * grad_G;
-    // Gradient vector expressed in World frame.
-    const Vector3d grad_W = X_WG_.rotation() * grad_G;
+  return SignedDistanceToPoint<double>{geometry_id_, p_GN_G, distance,
+                                       grad_W};
+}
 
-    return SignedDistanceToPoint<double>{geometry_id_, p_GN_G, distance,
-                                         grad_W};
-  }
+// Overload for Box.
+SignedDistanceToPoint<double> DistanceToPoint::operator()(
+    const fcl::Boxd& box) {
+  // TODO(DamrongGuoy): Move most code of this function into FCL.
+  // Express the given query point Q in the frame of the box geometry G.
+  const Vector3d p_GQ_G = X_WG_.inverse() * p_WQ_;
 
-  // Overload for Box.
-  SignedDistanceToPoint<double> operator()(const fcl::Boxd& box) {
-    // TODO(DamrongGuoy): Move most code of this function into FCL.
-    // Express the given query point Q in the frame of the box geometry G.
-    const Vector3d p_GQ_G = X_WG_.inverse() * p_WQ_;
+  // The box B is an axis-aligned box [-h(0),h(0)]x[-h(1),h(1)]x[-h(2),h(2)]
+  // centered at the origin, where h(i) is half the size of the box in the
+  // i-th coordinate.
+  const Vector3d half_size = box.side / 2.0;
 
-    // The box B is an axis-aligned box [-h(0),h(0)]x[-h(1),h(1)]x[-h(2),h(2)]
-    // centered at the origin, where h(i) is half the size of the box in the
-    // i-th coordinate.
-    const Vector3d half_size = box.side / 2.0;
-
-    // We need to classify Q as inside, outside, or on the boundary of B,
-    // where 'on the boundary' means within a tolerance of the boundary.
-    // This helper function takes the i-th coordinate `coord` of p_GQ_G.
-    // It returns the clamped value of `coord` within ±h(i). It also returns
-    // an enum to indicate whether the i-th coordinate is inside the interval
-    // (-h(i),+h(i)), or within a tolerance of the bounded value ±h(i), or
-    // outside the interval.
-    enum class Location {kInside, kBoundary, kOutside};
-    auto clamp = [&half_size](const int i, const double coord,
-                              Location* location) -> double {
-      const double tolerance = RelativeTolerance(half_size(i));
-      if (std::abs(coord) > half_size(i) + tolerance) {
-        *location = Location::kOutside;
-        return Sign(coord) * half_size(i);
-      } else if (std::abs(coord) >= half_size(i) - tolerance) {
-        *location = Location::kBoundary;
-        return Sign(coord) * half_size(i);
-      } else {
-        *location = Location::kInside;
-        return coord;
-      }
-    };
-
-    // The clamp point C has coordinates of Q clamped onto the box.
-    // Note that:
-    // 1. C is the nearest point to Q on ∂B if Q is classified as outside B.
-    // 2. C is at the same position as Q if Q is classified as inside B.
-    // 3. C is exactly on ∂B if Q is within a tolerance from ∂B.
-    Vector3d p_GC_G;
-    Vector3<Location> locations;
-    for (int i = 0; i < 3; ++i)
-      p_GC_G(i) = clamp(i, p_GQ_G(i), &locations(i));
-
-    // Initialize the position of the nearest point N on ∂B as that of C.
-    Vector3d p_GN_G = p_GC_G;
-    double distance;
-    Vector3d grad_G{0., 0., 0.};
-
-    if ((locations(0) == Location::kOutside)||
-        (locations(1) == Location::kOutside)||
-        (locations(2) == Location::kOutside)) {
-      // Q is outside the box.
-      Vector3d p_NQ_G = p_GQ_G - p_GN_G;
-      distance = p_NQ_G.norm();
-      DRAKE_DEMAND(distance != 0.);
-      grad_G = p_NQ_G / distance;
-    } else if ((locations(0) == Location::kBoundary)||
-               (locations(1) == Location::kBoundary)||
-               (locations(2) == Location::kBoundary)) {
-      // Q is on the boundary of the box.
-      distance = 0.0;
-      // A point on a face, on an edge, or on a vertex of the box has one, two,
-      // or three of locations(i) on boundary respectively.  The gradient
-      // at a point on an edge or a vertex of the box is undefined. Here, the
-      // calculation is equivalent to averaging outward unit normals of the
-      // faces that contain the point.
-      for (int i = 0; i < 3; ++i) {
-        if (locations(i) == Location::kBoundary)
-          grad_G(i) = Sign(p_GC_G(i));
-      }
-      grad_G.normalize();
+  // We need to classify Q as inside, outside, or on the boundary of B,
+  // where 'on the boundary' means within a tolerance of the boundary.
+  // This helper function takes the i-th coordinate `coord` of p_GQ_G.
+  // It returns the clamped value of `coord` within ±h(i). It also returns
+  // an enum to indicate whether the i-th coordinate is inside the interval
+  // (-h(i),+h(i)), or within a tolerance of the bounded value ±h(i), or
+  // outside the interval.
+  enum class Location {kInside, kBoundary, kOutside};
+  auto clamp = [&half_size](const int i, const double coord,
+                            Location* location) -> double {
+    const double tolerance = RelativeTolerance(half_size(i));
+    if (std::abs(coord) > half_size(i) + tolerance) {
+      *location = Location::kOutside;
+      return Sign(coord) * half_size(i);
+    } else if (std::abs(coord) >= half_size(i) - tolerance) {
+      *location = Location::kBoundary;
+      return Sign(coord) * half_size(i);
     } else {
-      // Q is inside the box.
-      // The nearest point N is the axis-aligned projection of Q onto one of
-      // the faces of the box.  The gradient vector is along that direction.
-      int axis = ExtremalAxis(p_GQ_G, half_size);
-      double sign = Sign(p_GQ_G(axis));
-      p_GN_G(axis) = sign * half_size(axis);
-      grad_G(axis) = sign;
-      distance = std::abs(p_GQ_G(axis)) - half_size(axis);
+      *location = Location::kInside;
+      return coord;
     }
+  };
 
-    // Use R_WG for vectors. Use X_WG for points.
-    const auto& R_WG = X_WG_.rotation();
-    Vector3d grad_W = R_WG * grad_G;
-    return SignedDistanceToPoint<double>{geometry_id_, p_GN_G, distance,
-                                         grad_W};
-  }
+  // The clamp point C has coordinates of Q clamped onto the box.
+  // Note that:
+  // 1. C is the nearest point to Q on ∂B if Q is classified as outside B.
+  // 2. C is at the same position as Q if Q is classified as inside B.
+  // 3. C is exactly on ∂B if Q is within a tolerance from ∂B.
+  Vector3d p_GC_G;
+  Vector3<Location> locations;
+  for (int i = 0; i < 3; ++i)
+    p_GC_G(i) = clamp(i, p_GQ_G(i), &locations(i));
 
- private:
-  // Calculate a tolerance relative to a given `size` parameter with a lower
-  // bound of 1e-14 meter. If the `size` parameter is larger than 1 meter, we
-  // use the relative tolerance of 1e-14 times the `size`.  If the `size` is
-  // smaller than 1 meter, we use the absolute tolerance 1e-14 meter. The
-  // 1e-14-meter lower bound help us handle possible round off errors arising
-  // from applying a pose X_WG to a geometry G. Given a query point Q exactly
-  // on the boundary ∂G, if we apply X_WG to both Q and G, the point Q is likely
-  // to deviate from ∂G more than the machine epsilon, which is around 2e-16.
-  static double RelativeTolerance(double size) {
-    return 1e-14 * std::max(1., size);
-  }
-  // This version of Sign(x) returns +1.0 for zero.
-  static double Sign(double x) { return (x < 0.0) ? -1. : 1.; }
-  // Picks the axis i whose coordinate p(i) is closest to the boundary value
-  // ±bounds(i). If there are ties, we prioritize according to an arbitrary
-  // ordering: +x,-x,+y,-y,+z,-z.
-  static int ExtremalAxis(const Vector3d& p, const Vector3d& bounds) {
-    double min_dist = std::numeric_limits<double>::infinity();
-    int axis = -1;
+  // Initialize the position of the nearest point N on ∂B as that of C.
+  Vector3d p_GN_G = p_GC_G;
+  double distance;
+  Vector3d grad_G{0., 0., 0.};
+
+  if ((locations(0) == Location::kOutside)||
+      (locations(1) == Location::kOutside)||
+      (locations(2) == Location::kOutside)) {
+    // Q is outside the box.
+    Vector3d p_NQ_G = p_GQ_G - p_GN_G;
+    distance = p_NQ_G.norm();
+    DRAKE_DEMAND(distance != 0.);
+    grad_G = p_NQ_G / distance;
+  } else if ((locations(0) == Location::kBoundary)||
+      (locations(1) == Location::kBoundary)||
+      (locations(2) == Location::kBoundary)) {
+    // Q is on the boundary of the box.
+    distance = 0.0;
+    // A point on a face, on an edge, or on a vertex of the box has one, two,
+    // or three of locations(i) on boundary respectively.  The gradient
+    // at a point on an edge or a vertex of the box is undefined. Here, the
+    // calculation is equivalent to averaging outward unit normals of the
+    // faces that contain the point.
     for (int i = 0; i < 3; ++i) {
-      for (auto bound : {bounds(i), -bounds(i)}) {
-        double dist = std::abs(bound - p(i));
-        if (dist < min_dist) {
-          min_dist = dist;
-          axis = i;
-        }
-      }
+      if (locations(i) == Location::kBoundary)
+        grad_G(i) = Sign(p_GC_G(i));
     }
-    return axis;
+    grad_G.normalize();
+  } else {
+    // Q is inside the box.
+    // The nearest point N is the axis-aligned projection of Q onto one of
+    // the faces of the box.  The gradient vector is along that direction.
+    int axis = ExtremalAxis(p_GQ_G, half_size);
+    double sign = Sign(p_GQ_G(axis));
+    p_GN_G(axis) = sign * half_size(axis);
+    grad_G(axis) = sign;
+    distance = std::abs(p_GQ_G(axis)) - half_size(axis);
   }
 
-  // The id of the geometry G.
-  const GeometryId geometry_id_;
-  // The pose of the geometry G in World frame.
-  const Isometry3<double> X_WG_;
-  // The position of the query point Q in World frame.
-  const Vector3d p_WQ_;
-};
+  // Use R_WG for vectors. Use X_WG for points.
+  const auto& R_WG = X_WG_.rotation();
+  Vector3d grad_W = R_WG * grad_G;
+  return SignedDistanceToPoint<double>{geometry_id_, p_GN_G, distance,
+                                       grad_W};
+}
 
 // Callback function from fcl::distance to help ComputeSignedDistanceToPoint.
 bool DistanceFromPointCallback(fcl::CollisionObjectd* fcl_object_A_ptr,
@@ -543,9 +732,9 @@ bool DistanceFromPointCallback(fcl::CollisionObjectd* fcl_object_A_ptr,
   // TODO(DamrongGuoy): Replace this custom code when FCL does this for us with
   // the required accuracy and performance.
   //
-  DistanceToPoint distance_to_point{geometry_id,
-                                    geometry_object->getTransform(),
-                                    point_object->getTranslation()};
+  DistanceToPoint distance_to_point(geometry_id,
+      RigidTransformd(geometry_object->getTransform()),
+      point_object->getTranslation());
 
   SignedDistanceToPoint<double> distance;
   switch (collision_geometry->getNodeType()) {

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -403,7 +403,7 @@ Vector3d DistancePairGeometry::WitnessPointOnSphere(
 void DistancePairGeometry::operator()(const fcl::Sphered* sphere_A,
                                       const fcl::Sphered* sphere_B) {
   const SignedDistanceToPoint<double> sphere_B_to_point_Ao =
-      DistanceToPoint{id_B_, X_WB_, X_WA_.translation()}(*sphere_B);
+      DistanceToPoint {id_B_, X_WB_, X_WA_.translation()}(*sphere_B);
   const double distance = sphere_B_to_point_Ao.distance - sphere_A->radius;
   // Nb is the witness point on ∂B.
   const Vector3d& p_BNb = sphere_B_to_point_Ao.p_GN;
@@ -420,7 +420,7 @@ void DistancePairGeometry::operator()(const fcl::Sphered* sphere_A,
 void DistancePairGeometry::operator()(const fcl::Sphered* sphere_A,
                                       const fcl::Boxd* box_B) {
   SignedDistanceToPoint<double> box_B_to_point_Ao =
-      DistanceToPoint{id_B_, X_WB_, X_WA_.translation()}(*box_B);
+      DistanceToPoint {id_B_, X_WB_, X_WA_.translation()}(*box_B);
   const double distance = box_B_to_point_Ao.distance - sphere_A->radius;
   // Nb is the witness point on ∂B.
   const Vector3d& p_BNb = box_B_to_point_Ao.p_GN;
@@ -442,7 +442,7 @@ void DistancePairGeometry::operator()(const fcl::Sphered* sphere_A,
 void DistancePairGeometry::operator()(const fcl::Boxd* box_A,
                                       const fcl::Sphered* sphere_B) {
   SignedDistanceToPoint<double> box_A_to_point_Bo =
-      DistanceToPoint{id_A_, X_WA_, X_WB_.translation()}(*box_A);
+      DistanceToPoint {id_A_, X_WA_, X_WB_.translation()}(*box_A);
   const double distance = box_A_to_point_Bo.distance - sphere_B->radius;
   // Na is the witness point on ∂A.
   const Vector3d& p_ANa = box_A_to_point_Bo.p_GN;

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -814,11 +814,8 @@ class SimplePenetrationTest : public ::testing::Test {
       std::swap(expected_distance.p_ACa, expected_distance.p_BCb);
     }
     EXPECT_LT(distance.id_A, distance.id_B);
-    // TODO(hongkai.dai): Set the FCL solver tolerance, and check the distance
-    // against that tolerance, when the PR
-    // https://github.com/flexible-collision-library/fcl/pull/314 is merged into
-    // FCL upstream.
-    CompareSignedDistancePair(distance, expected_distance, 2e-3);
+    CompareSignedDistancePair(distance, expected_distance,
+        std::numeric_limits<double>::epsilon());
   }
 
   // The two spheres collides, but are ignored due to the setting in the
@@ -868,7 +865,8 @@ class SimplePenetrationTest : public ::testing::Test {
     expected_distance.p_ACa = origin_is_A ? p_OCo : p_CCc;
     expected_distance.p_BCb = origin_is_A ? p_CCc : p_OCo;
 
-    CompareSignedDistancePair(distance, expected_distance, 2e-3);
+    CompareSignedDistancePair(distance, expected_distance,
+        std::numeric_limits<double>::epsilon());
   }
 
   ProximityEngine<double> engine_;
@@ -1153,6 +1151,584 @@ TEST_F(SimplePenetrationTest, ExcludeCollisionsBetween) {
       engine_.ToAutoDiffXd();
   ExpectIgnoredPenetration(origin_id, collide_id, ad_engine.get());
 }
+
+// Test ComputeSignedDistancePairwiseClosestPoints with sphere-sphere pairs and
+// sphere-box pairs.  The definition of this test suite consists of four
+// sections.
+// 1. Generate test data as a vector of SignedDistancePairTestData. Each
+//    record consists of both input and expected result.  See the function
+//    GenDistancePairTestSphereSphere(), for example.
+// 2. Define a test fixture parameterized by the test data.  It initializes
+//    each test according to the test data. See the class
+//    SignedDistancePairTest below.
+// 3. Define one or more test procedures for the same test fixture. We call
+//    ComputeSignedDistancePairwiseClosestPoints() from here.
+//    See TEST_P(SignedDistancePairTest, SinglePair), for example.
+// 4. Initiate all the tests by specifying the test fixture and the test data.
+//    See INSTANTIATE_TEST_CASE_P() below.
+class SignedDistancePairTestData {
+ public:
+  SignedDistancePairTestData(shared_ptr<const Shape> a,
+                             shared_ptr<const Shape> b,
+                             const RigidTransformd& X_WA,
+                             const RigidTransformd& X_WB,
+                             const SignedDistancePair<double>& expect)
+      : a_(a),
+        b_(b),
+        X_WA_(X_WA),
+        X_WB_(X_WB),
+        expected_result_(expect) {}
+
+  // Generates new test data by swapping geometry A and geometry B. It will
+  // help us test the symmetric interface. For example, we can generate the
+  // test data for test(box_B, sphere_A) from the test data for
+  // test(sphere_A, box_B).
+  SignedDistancePairTestData GenSwapAB() const {
+    auto& id_A = expected_result_.id_A;
+    auto& id_B = expected_result_.id_B;
+    auto& p_ACa = expected_result_.p_ACa;
+    auto& p_BCb = expected_result_.p_BCb;
+    auto& distance = expected_result_.distance;
+    return SignedDistancePairTestData(
+        b_, a_, X_WB_, X_WA_,
+        SignedDistancePair<double>(id_B, id_A, p_BCb, p_ACa, distance));
+  }
+
+  // Google Test uses this operator to report the test data in the log file
+  // when a test fails.
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const SignedDistancePairTestData& obj) {
+    return os << "{\n"
+              << " geometry A: (not printed)\n"
+              << " geometry B: (not printed)\n"
+              << " X_WA: (not printed)\n"
+              << " X_WB: (not printed)\n"
+              << " expected_result.id_A: "
+              << obj.expected_result_.id_A << "\n"
+              << " expected_result.id_B: "
+              << obj.expected_result_.id_B << "\n"
+              << " expected_result.distance: "
+              << obj.expected_result_.distance << "\n"
+              << " expected_result.p_ACa: "
+              << obj.expected_result_.p_ACa.transpose() << "\n"
+              << " expected_result.p_BCb: "
+              << obj.expected_result_.p_BCb.transpose() << "\n"
+              << "}" << std::flush;
+  }
+
+  shared_ptr<const Shape> a_;
+  shared_ptr<const Shape> b_;
+  const RigidTransformd X_WA_;
+  const RigidTransformd X_WB_;
+  const SignedDistancePair<double> expected_result_;
+};
+
+// Two spheres with varying degrees of overlapping.  The first sphere A is
+// smaller than the second sphere B. We model the configurations in the frame
+// of the first sphere A.  First we place B's center far enough to the right
+// on the positive x-axis of A's frame that A and B do not overlap. Then, we
+// move B's center towards A's center along the x-axis of A's frame until B
+// covers A. The expressions of the witness points Ca ∈ ∂A and Cb ∈ ∂B in
+// A's frame and B's frame respectively do not change during this motion.
+//
+// @param X_WA specifies the pose of A in world.
+// @param R_WB specifies the rotation of B in world.
+std::vector<SignedDistancePairTestData> GenDistancePairTestSphereSphere(
+    const RigidTransformd& X_WA = RigidTransformd::Identity(),
+    const RotationMatrixd& R_WB = RotationMatrixd::Identity()) {
+  auto sphere_A = make_shared<const Sphere>(1.0);
+  auto sphere_B = make_shared<const Sphere>(2.0);
+  double radius_A = sphere_A->get_radius();
+  double radius_B = sphere_B->get_radius();
+  // Set up R_AB and R_BA from X_WA and R_WB.
+  const RotationMatrixd& R_WA = X_WA.rotation();
+  const RotationMatrixd R_AW = R_WA.transpose();
+  const RotationMatrixd R_AB = R_AW * R_WB;
+  const RotationMatrixd R_BA = R_AB.transpose();
+  struct Configuration {
+    // Center of B in A's frame
+    Vector3d p_ABo;
+    double pair_distance;
+  };
+  const std::vector<Configuration> configurations {
+      // Non-overlapping
+      {Vector3d(4., 0., 0.), 1.},
+      // B kisses A.
+      {Vector3d(3., 0., 0.), 0.},
+      // B overlaps A.
+      {Vector3d(2.5, 0., 0.), -0.5},
+      // B covers A.
+      {Vector3d(1, 0., 0.), -2.}};
+  const Vector3d p_ACa_A(radius_A, 0., 0.);
+  // Position from Bo to Cb expressed in A's frame.
+  const Vector3d p_BCb_A(-radius_B, 0., 0.);
+  const Vector3d p_BCb_B = R_BA * p_BCb_A;
+  std::vector<SignedDistancePairTestData> test_data;
+  for (auto config : configurations) {
+    const RigidTransformd X_AB(R_AB, config.p_ABo);
+    const RigidTransformd X_WB = X_WA * X_AB;
+    test_data.emplace_back(
+        sphere_A, sphere_B, X_WA, X_WB,
+        SignedDistancePair<double>(GeometryId::get_new_id(),
+                                   GeometryId::get_new_id(), p_ACa_A, p_BCb_B,
+                                   config.pair_distance));
+  }
+  return test_data;
+}
+
+std::vector<SignedDistancePairTestData> GenDistPairTestSphereSphereTransform() {
+  return GenDistancePairTestSphereSphere(
+      RigidTransformd(RollPitchYawd(5. * M_PI / 8., M_PI / 6., M_PI / 12.),
+                      Vector3d(1., 2., 3.)),
+      RotationMatrixd(RollPitchYawd(M_PI / 4., 5. * M_PI / 6., M_PI / 3)));
+}
+
+// Two spheres with more general position. Here, we describe the configuration
+// in the frame of the first sphere A.  The second sphere B is centered at
+// (1,4,8) in A's frame.  We use these identities to design the configuration.
+//     0.25^2 + 1^2 + 2^2 = 2.25^2   (1)
+//        1^2 + 4^2 + 8^2 = 9^2      (2)
+//
+//              x x x x x
+//           x             x
+//         x                 x
+//       x                     x
+//     x                         x
+//    x                           x
+//   x                             x
+//  x                               x
+//  x                               x
+//  x                               x
+//  x              Bo               x
+//  x             /                 x
+//  x            /                  x
+//  x           /                   x
+//   x         /                   x
+//    x  ooo  /                   x
+//    ox     Ca                  x
+//   o   x  /  o               x
+//   o  Ao=Cb  o             x
+//   o       x o           x
+//    o       o x x x x x
+//       ooo
+//
+// From (1), we set A to have radius r_A 2.25 and will have the witness point
+// Ca ∈ ∂A at (0.25,1,2) in A's frame.  From (2), we set B to have radius
+// r_B 9.0 with the center Bo (1,4,8) in A's frame. The boundary ∂B passes
+// through A's center Ao, which is at the same position as the witness point
+// Cb ∈ ∂B.  The signed distance between the two spheres equals -2.25, is the
+// negative of the radius of A.
+//
+// @param X_WA the pose of A in world.
+// @param R_WB the rotation matrix of B in world.
+std::vector<SignedDistancePairTestData> GenDistPairTestSphereSphereNonAligned(
+    const RigidTransformd& X_WA = RigidTransformd::Identity(),
+    const RotationMatrixd& R_WB = RotationMatrixd::Identity()) {
+  auto sphere_A = make_shared<const Sphere>(2.25);
+  auto sphere_B = make_shared<const Sphere>(9.);
+  const double radius_A = sphere_A->get_radius();
+  // Set up Ca and Bo in A's frame.
+  const Vector3d p_ACa(0.25, 1., 2.);
+  const Vector3d p_ABo(1., 4., 8.);
+  // Set up X_AB and X_BA from the position of B's center p_ABo in A's frame,
+  // the given R_WB, and the given X_WA.
+  const RotationMatrixd& R_WA = X_WA.rotation();
+  const RotationMatrixd R_AW = R_WA.transpose();
+  const RotationMatrixd R_AB = R_AW * R_WB;
+  const RigidTransformd X_AB(R_AB, p_ABo);
+  const RigidTransformd X_BA = X_AB.inverse();
+  // Set up X_WB
+  const RigidTransformd X_WB = X_WA * X_AB;
+  // Set up Cb = Ao.
+  const Vector3d p_AAo(0., 0., 0.);
+  const Vector3d p_ACb = p_AAo;
+  const Vector3d p_BCb = X_BA * p_ACb;
+
+  std::vector<SignedDistancePairTestData> test_data{
+      {sphere_A, sphere_B, X_WA, X_WB,
+       SignedDistancePair<double>(GeometryId::get_new_id(),
+                                  GeometryId::get_new_id(), p_ACa, p_BCb,
+                                  -radius_A)}};
+  return test_data;
+}
+
+std::vector<SignedDistancePairTestData>
+GenDistPairTestSphereSphereNonAlignedTransform() {
+  return GenDistPairTestSphereSphereNonAligned(
+      RigidTransformd(RollPitchYawd(3. * M_PI / 8., 5 * M_PI / 6., M_PI / 12.),
+                      Vector3d(1., 2., 3.)),
+      RotationMatrixd(RollPitchYawd(M_PI, 5.*M_PI/6., 7*M_PI/12.)));
+}
+
+// Sphere-box data for testing ComputeSignedDistancePairwiseClosestPoints.
+// We move a small sphere through different configurations:-
+// 1. outside the box,
+// 2. touching the box,
+// 3. slightly overlap the box,
+// 4, half inside half outside the box,
+// 5. more than half inside the box,
+// 6. completely inside and osculating the box, and
+// 7. deeply inside the box.
+// The sphere's center always stays on the box's positive x-axis, and the
+// witness points as expressed in the frames of the sphere and the box stay
+// the same in all cases.
+//
+// @param R_WA specifies the rotation of the sphere A in world.
+// @param X_WB specifies the pose of the box B in world.
+// @return the test data for testing sphere-box pairwise signed distances.
+std::vector<SignedDistancePairTestData> GenDistPairTestSphereBox(
+    const RotationMatrixd& R_WA = RotationMatrixd::Identity(),
+    const RigidTransformd& X_WB = RigidTransformd::Identity()) {
+  auto sphere_A = make_shared<const Sphere>(2.);
+  auto box_B = make_shared<const Box>(16., 12., 8.);
+  const double radius = sphere_A->get_radius();
+  const double half_x = box_B->size()(0) / 2.;
+  struct Configuration {
+    Vector3d p_BAo;
+    double pair_distance;
+  };
+  const std::vector<Configuration> configurations{
+      // The sphere is outside the box.
+      {Vector3d(14., 0., 0.), 4.},
+      // The sphere touches the box.
+      {Vector3d(10., 0., 0.), 0.},
+      // The sphere slightly overlaps the box.
+      {Vector3d(9., 0., 0.), -1.},
+      // The sphere is half inside and half outside the box.
+      {Vector3d(8., 0., 0.), -2.},
+      // More than half of the sphere is inside the box.
+      {Vector3d(7., 0., 0.), -3.},
+      // The sphere is completely inside and osculating the box.
+      {Vector3d(6., 0., 0.), -4.},
+      // The sphere is deeply inside the box.
+      {Vector3d(5., 0., 0.), -5.}};
+  const Vector3d p_BCb(half_x, 0., 0.);
+  std::vector<SignedDistancePairTestData> test_data;
+  for (auto config : configurations) {
+    // Set up the pose of A from the translation vector in the configuration
+    // and the given rotation parameter R_WA.
+    const Vector3d p_WAo = X_WB * config.p_BAo;
+    const RigidTransformd X_WA(R_WA, p_WAo);
+    // Set up the transformation from B's frame to A's frame.
+    const RigidTransformd X_AW = X_WA.inverse();
+    const RigidTransformd X_AB = X_AW * X_WB;
+    // Calculate Ca in B's frame then change to A's frame.
+    const Vector3d p_BCa = config.p_BAo + Vector3d(-radius, 0, 0);
+    const Vector3d p_ACa = X_AB * p_BCa;
+
+    test_data.emplace_back(
+        sphere_A, box_B, X_WA, X_WB,
+        SignedDistancePair<double>(GeometryId::get_new_id(),
+                                   GeometryId::get_new_id(), p_ACa, p_BCb,
+                                   config.pair_distance));
+  }
+  return test_data;
+}
+
+std::vector<SignedDistancePairTestData> GenDistPairTestSphereBoxTransform() {
+  return GenDistPairTestSphereBox(
+      RotationMatrixd(RollPitchYawd(M_PI / 8., M_PI / 6., 2. * M_PI / 3)),
+      RigidTransformd(RollPitchYawd(3. * M_PI / 8., 5 * M_PI / 6., M_PI / 12.),
+                      Vector3d(1., 2., 3.)));
+}
+
+// Test pitch = pi/2 when the roll-pitch-yaw is in singular configuration.
+std::vector<SignedDistancePairTestData>
+GenDistPairTestSphereBoxTransformSingularPitch() {
+  return GenDistPairTestSphereBox(
+      RotationMatrixd(RollPitchYawd(M_PI / 8., M_PI_2, 2. * M_PI / 3)),
+      RigidTransformd(RollPitchYawd(3. * M_PI / 8., M_PI_2, M_PI / 12.),
+                      Vector3d(1., 2., 3.)));
+}
+
+std::vector<SignedDistancePairTestData> GenDistPairTestBoxSphere() {
+  std::vector<SignedDistancePairTestData> test_data;
+  for (const auto& sphere_box : GenDistPairTestSphereBox()) {
+    test_data.emplace_back(sphere_box.GenSwapAB());
+  }
+  return test_data;
+}
+
+std::vector<SignedDistancePairTestData> GenDistPairTestBoxSphereTransform() {
+  std::vector<SignedDistancePairTestData> test_data;
+  for (const auto& sphere_box : GenDistPairTestSphereBoxTransform()) {
+    test_data.emplace_back(sphere_box.GenSwapAB());
+  }
+  return test_data;
+}
+
+// Generates test data for a sphere A with center Ao on the boundary ∂B of a
+// box B. The 26 positions of Ao on ∂B can be expressed in B's frame as:-
+//   p_BAo ∈ {-h(x),0,+h(x)} x {-h(y),0,+h(y)} x {-h(z),0,+h(z)} - {(0,0,0)},
+// where h(x), h(y), and h(z) are the half width, half depth, and half height
+// of B respectively. These positions are at the 8 corners, in the middle
+// of the 12 edges, and in the middle of the 6 faces of B.
+//
+// The positions of Ao above is parameterized by the sign vector s expressed
+// in B's frame as:
+//     s_B = (sx,sy,sz) ∈ {-1,0,+1} x {-1,0,+1} x {-1,0,+1} - {(0,0,0)},
+//     p_BAo(s) = (sx * h(x), sy * h(y), sz * h(z)).
+//
+// For these test cases, the signed distance between A and B is always -r,
+// where r is the radius of A. The witness point Cb on ∂B is at Ao.
+// The witness point Ca on ∂A is
+//     Ca = Ao - r * s/|s|,
+// whose position p_ACa in A's frame is expressed as
+//     p_ACa = - r * s_A/|s_A|,
+// where s_A is the sign vector s expressed in A's frame.
+//
+// @param R_WA specifies rotation of the sphere in world.
+// @param X_WB specifies the pose of the box in world.
+// @return  the test data for testing sphere-box pairwise signed distances.
+//
+std::vector<SignedDistancePairTestData> GenDistPairTestSphereBoxBoundary(
+    const RotationMatrixd& R_WA = RotationMatrixd::Identity(),
+    const RigidTransformd& X_WB = RigidTransformd::Identity()) {
+  auto sphere_A = make_shared<const Sphere>(2.);
+  auto box_B = make_shared<const Box>(16., 12., 8.);
+  const double radius_A = sphere_A->get_radius();
+  const Vector3d half_B = box_B->size() / 2.;
+  std::vector<SignedDistancePairTestData> test_data;
+  // We use sign_x, sign_y, and sign_z to parameterize the positions on the
+  // boundary of the box.
+  for (const double sign_x : {-1., 0., 1.}) {
+    for (const double sign_y : {-1., 0., 1.}) {
+      for (const double sign_z : {-1., 0., 1.}) {
+        if (sign_x == 0. && sign_y == 0. && sign_z == 0.) continue;
+        const Vector3d sign_B(sign_x, sign_y, sign_z);
+        // A's center is on ∂B.
+        const Vector3d p_BAo = sign_B.array() * half_B.array();
+        const Vector3d p_WAo = X_WB * p_BAo;
+        const RigidTransformd X_WA(R_WA, p_WAo);
+        // The expected witness point Cb on ∂B at A's center.
+        const Vector3d p_BCb = p_BAo;
+        // Set up the rotation matrix for vectors from B's frame to A's frame.
+        const RotationMatrixd& R_WB = X_WB.rotation();
+        const RotationMatrixd R_AW = R_WA.transpose();
+        const RotationMatrixd R_AB = R_AW * R_WB;
+        // Change the expression of the sign vector from sign_B in B's frame
+        // to sign_A in A's frame.
+        const Vector3d sign_A = R_AB * sign_B;
+        // The expected witness point Ca on ∂A expressed in A's frame.
+        const Vector3d p_ACa = -radius_A * sign_A.normalized();
+        test_data.emplace_back(
+            sphere_A, box_B, X_WA, X_WB,
+            SignedDistancePair<double>(GeometryId::get_new_id(),
+                                       GeometryId::get_new_id(), p_ACa, p_BCb,
+                                       -radius_A));
+      }
+    }
+  }
+  return test_data;
+}
+
+std::vector<SignedDistancePairTestData>
+GenDistPairTestSphereBoxBoundaryTransform() {
+  return GenDistPairTestSphereBoxBoundary(
+      RotationMatrixd(RollPitchYawd(M_PI, M_PI / 6., M_PI / 3.)),
+      RigidTransformd(RollPitchYawd(3. * M_PI / 8., 5 * M_PI / 6., M_PI / 12.),
+                      Vector3d(1., 2., 3.)));
+}
+
+class SignedDistancePairTest
+    : public testing::TestWithParam<SignedDistancePairTestData> {
+ public:
+  SignedDistancePairTest() {
+    auto data = GetParam();
+    engine_.AddAnchoredGeometry(*(data.a_), data.X_WA_.GetAsIsometry3(),
+                                GeometryIndex(0));
+    geometry_map_.push_back(data.expected_result_.id_A);
+    engine_.AddDynamicGeometry(*(data.b_), GeometryIndex(1));
+    geometry_map_.push_back(data.expected_result_.id_B);
+    engine_.UpdateWorldPoses({data.X_WB_.GetAsIsometry3()}, {GeometryIndex(0)});
+  }
+
+ protected:
+  ProximityEngine<double> engine_;
+  std::vector<GeometryId> geometry_map_;
+
+ public:
+  // The tolerance value for determining equivalency between expected and
+  // tested results. The underlying algorithms have an empirically-determined,
+  // hard-coded tolerance of 1e-14 to account for loss of precision due to
+  // rigid transformations and this tolerance reflects that.
+  static constexpr double tolerance_ = 1e-14;
+};
+
+TEST_P(SignedDistancePairTest, SinglePair) {
+  const auto& data = GetParam();
+  const auto results =
+      engine_.ComputeSignedDistancePairwiseClosestPoints(geometry_map_);
+  ASSERT_EQ(results.size(), 1);
+  const auto& result = results[0];
+
+  EXPECT_NEAR(result.distance, data.expected_result_.distance, tolerance_)
+            << "Incorrect signed distance";
+
+  const bool a_then_b = (result.id_A == data.expected_result_.id_A)&&
+                        (result.id_B == data.expected_result_.id_B);
+  const bool b_then_a = (result.id_B == data.expected_result_.id_A)&&
+                        (result.id_A == data.expected_result_.id_B);
+  ASSERT_TRUE(a_then_b ^ b_then_a);
+  const Vector3d& p_ACa = a_then_b? result.p_ACa : result.p_BCb;
+  const Vector3d& p_BCb = a_then_b? result.p_BCb : result.p_ACa;
+
+  EXPECT_TRUE(CompareMatrices(p_ACa, data.expected_result_.p_ACa, tolerance_))
+    << "Incorrect witness point.";
+  EXPECT_TRUE(CompareMatrices(p_BCb, data.expected_result_.p_BCb, tolerance_))
+    << "Incorrect witness point.";
+
+  // Check the invariance that the distance between the two witness points
+  // equal the signed distance.
+  const Vector3d p_WCb = data.X_WB_ * p_BCb;
+  const RigidTransformd X_AW = data.X_WA_.inverse();
+  const Vector3d p_ACb = X_AW * p_WCb;
+  const double distance_between_witnesses = (p_ACa-p_ACb).norm();
+  EXPECT_NEAR(distance_between_witnesses, std::abs(result.distance), tolerance_)
+    << "Distance between witness points do not equal the signed distance.";
+}
+
+INSTANTIATE_TEST_CASE_P(SphereSphere, SignedDistancePairTest,
+    testing::ValuesIn(GenDistancePairTestSphereSphere()));
+INSTANTIATE_TEST_CASE_P(SphereSphereTransform, SignedDistancePairTest,
+    testing::ValuesIn(GenDistPairTestSphereSphereTransform()));
+INSTANTIATE_TEST_CASE_P(SphereSphreNonAligned, SignedDistancePairTest,
+    testing::ValuesIn(GenDistPairTestSphereSphereNonAligned()));
+INSTANTIATE_TEST_CASE_P(SphereSphreNonAlignedTransform, SignedDistancePairTest,
+    testing::ValuesIn(GenDistPairTestSphereSphereNonAlignedTransform()));
+INSTANTIATE_TEST_CASE_P(SphereBox, SignedDistancePairTest,
+    testing::ValuesIn(GenDistPairTestSphereBox()));
+INSTANTIATE_TEST_CASE_P(SphereBoxTransform, SignedDistancePairTest,
+    testing::ValuesIn(GenDistPairTestSphereBoxTransform()));
+INSTANTIATE_TEST_CASE_P(SphereBoxTransformSingularPitch, SignedDistancePairTest,
+    testing::ValuesIn(GenDistPairTestSphereBoxTransformSingularPitch()));
+INSTANTIATE_TEST_CASE_P(BoxSphere, SignedDistancePairTest,
+    testing::ValuesIn(GenDistPairTestBoxSphere()));
+INSTANTIATE_TEST_CASE_P(BoxSphereTransform, SignedDistancePairTest,
+    testing::ValuesIn(GenDistPairTestBoxSphereTransform()));
+INSTANTIATE_TEST_CASE_P(SphereBoxBoundary, SignedDistancePairTest,
+    testing::ValuesIn(GenDistPairTestSphereBoxBoundary()));
+INSTANTIATE_TEST_CASE_P(SphereBoxBoundaryTransform, SignedDistancePairTest,
+    testing::ValuesIn(GenDistPairTestSphereBoxBoundaryTransform()));
+
+// Concentric geometries A, B do not have a unique pair of witness points
+// Na, Nb. We inherit another test fixture from SignedDistancePairTest, so we
+// can define another TEST_P that checks |Na-Nb| = -signed_distance but does
+// not check the locations of Na and Nb individually.
+class SignedDistancePairConcentricTest : public SignedDistancePairTest {};
+
+TEST_P(SignedDistancePairConcentricTest, DistanceInvariance) {
+  const auto& data = GetParam();
+  const auto results =
+      engine_.ComputeSignedDistancePairwiseClosestPoints(geometry_map_);
+  ASSERT_EQ(results.size(), 1);
+  const auto& result = results[0];
+
+  EXPECT_NEAR(result.distance, data.expected_result_.distance, tolerance_)
+    << "Incorrect signed distance";
+
+  const bool a_then_b = (result.id_A == data.expected_result_.id_A)&&
+      (result.id_B == data.expected_result_.id_B);
+  const bool b_then_a = (result.id_B == data.expected_result_.id_A)&&
+      (result.id_A == data.expected_result_.id_B);
+  ASSERT_TRUE(a_then_b ^ b_then_a);
+  const Vector3d& p_ACa = a_then_b? result.p_ACa : result.p_BCb;
+  const Vector3d& p_BCb = a_then_b? result.p_BCb : result.p_ACa;
+
+  // Check the invariance that the distance between the two witness points
+  // equal the signed distance.
+  const Vector3d p_WCb = data.X_WB_ * p_BCb;
+  const RigidTransformd X_AW = data.X_WA_.inverse();
+  const Vector3d p_ACb = X_AW * p_WCb;
+  const double distance_between_witnesses = (p_ACa-p_ACb).norm();
+  EXPECT_NEAR(distance_between_witnesses, -result.distance, tolerance_)
+    << "Incorrect distance between witness points.";
+}
+
+std::vector<SignedDistancePairTestData>
+GenDistPairTestSphereSphereConcentric(
+    const RigidTransformd& X_WA = RigidTransformd::Identity(),
+    const RotationMatrixd& R_WB = RotationMatrixd::Identity()) {
+  const double radius_A = 3.0;
+  const double radius_B = 7.0;
+  auto sphere_A = make_shared<const Sphere>(radius_A);
+  auto sphere_B = make_shared<const Sphere>(radius_B);
+  const RigidTransformd X_WB(R_WB, X_WA.translation());
+  const RigidTransformd X_AW = X_WA.inverse();
+  const RigidTransformd X_AB = X_AW * X_WB;
+
+  // Since the two spheres are concentric, we arbitrarily pick the witness
+  // point Cb at (radius_B,0,0) in B's frame and calculate the corresponding
+  // witness point Ca in A's frame, but the TEST_P will ignore them.
+  const Vector3d p_BCb(radius_B, 0.0, 0.0);
+  const Vector3d p_ACb = X_AB * p_BCb;
+  const Vector3d p_ACa = -(radius_A / radius_B) * p_ACb;
+
+  std::vector<SignedDistancePairTestData> test_data{
+      {sphere_A, sphere_B, X_WA, X_WB,
+       SignedDistancePair<double>(
+           GeometryId::get_new_id(), GeometryId::get_new_id(),
+           p_ACa, p_BCb, -radius_A - radius_B)}
+  };
+  return test_data;
+}
+
+std::vector<SignedDistancePairTestData>
+GenDistPairTestSphereSphereConcentricTransform() {
+  return GenDistPairTestSphereSphereConcentric(
+      RigidTransformd(RollPitchYawd(M_PI_4, M_PI_2, M_PI),
+                      Vector3d(1., 2., 3.)),
+      RotationMatrixd(RollPitchYawd(M_PI, M_PI/6., M_PI)));
+}
+
+std::vector<SignedDistancePairTestData>
+GenDistPairTestSphereBoxConcentric(
+    const RigidTransformd& X_WA = RigidTransformd::Identity(),
+    const RotationMatrixd& R_WB = RotationMatrixd::Identity()) {
+  auto sphere_A = make_shared<const Sphere>(2.);
+  auto box_B = make_shared<const Box>(4., 8., 16.);
+  const double radius_A = sphere_A->get_radius();
+  const Vector3d half_B = box_B->size() / 2.;
+  const RigidTransformd X_WB(R_WB, X_WA.translation());
+  const RigidTransformd X_AW = X_WA.inverse();
+  const RigidTransformd X_AB = X_AW * X_WB;
+
+  // Since A and B are concentric, we arbitrarily pick the witness point Cb
+  // at (half_B.x, 0, 0) in B's frame and calculate the corresponding witness
+  // point Ca in A's frame, but the TEST_P will ignore them.
+  const Vector3d p_BCb(half_B(0), 0., 0.);
+  const Vector3d p_ACb = X_AB * p_BCb;
+  const Vector3d p_ACa = -(radius_A / half_B(0)) * p_ACb;
+
+  std::vector<SignedDistancePairTestData> test_data{
+      {sphere_A, box_B, X_WA, X_WB,
+       SignedDistancePair<double>(
+           GeometryId::get_new_id(), GeometryId::get_new_id(),
+           p_ACa, p_BCb, -radius_A - half_B(0))}
+  };
+  return test_data;
+}
+
+std::vector<SignedDistancePairTestData>
+GenDistPairTestSphereBoxConcentricTransform() {
+  return GenDistPairTestSphereBoxConcentric(
+      RigidTransformd(RollPitchYawd(M_PI_4, M_PI_2, M_PI),
+                      Vector3d(1., 2., 3.)),
+      RotationMatrixd(RollPitchYawd(M_PI, M_PI/6., M_PI)));
+}
+
+INSTANTIATE_TEST_CASE_P(SphereSphereConcentric,
+    SignedDistancePairConcentricTest,
+    testing::ValuesIn(GenDistPairTestSphereSphereConcentric()));
+INSTANTIATE_TEST_CASE_P(SphereSphereConcentricTransform,
+    SignedDistancePairConcentricTest,
+    testing::ValuesIn(GenDistPairTestSphereSphereConcentricTransform()));
+INSTANTIATE_TEST_CASE_P(SphereBoxConcentric,
+    SignedDistancePairConcentricTest,
+    testing::ValuesIn(GenDistPairTestSphereBoxConcentric()));
+INSTANTIATE_TEST_CASE_P(SphereBoxConcentricTransform,
+    SignedDistancePairConcentricTest,
+    testing::ValuesIn(GenDistPairTestSphereBoxConcentricTransform()));
 
 // Given a sphere S and box B. The box's height and depth are large (much larger
 // than the diameter of the sphere), but the box's *width* is *less* than the


### PR DESCRIPTION
Relate to #10270.  

Adapt code for sphere-to-point and box-to-point signed distances to sphere-to-sphere and sphere-to-box signed distances.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10281)
<!-- Reviewable:end -->
