### PR TITLE
pydrake: Enforce clang-format in common by default

### DIFF
--- a/bindings/pydrake/common/BUILD.bazel
+++ b/bindings/pydrake/common/BUILD.bazel
@@ -65,6 +65,8 @@ drake_cc_library(
     name = "type_pack",
     hdrs = ["type_pack.h"],
     declare_installed_headers = 0,
+    # TODO(jwnimmer-tri) We should enable this eventually.
+    tags = ["nolint_clang_format"],
     visibility = ["//visibility:public"],
 )
 
@@ -72,6 +74,8 @@ drake_cc_library(
     name = "wrap_function",
     hdrs = ["wrap_function.h"],
     declare_installed_headers = 0,
+    # TODO(jwnimmer-tri) We should enable this eventually.
+    tags = ["nolint_clang_format"],
     visibility = ["//visibility:public"],
 )
 
@@ -79,6 +83,8 @@ drake_cc_library(
     name = "wrap_pybind",
     hdrs = ["wrap_pybind.h"],
     declare_installed_headers = 0,
+    # TODO(jwnimmer-tri) We should enable this eventually.
+    tags = ["nolint_clang_format"],
     visibility = ["//visibility:public"],
     deps = [":wrap_function"],
 )
@@ -165,6 +171,8 @@ drake_cc_library(
     srcs = [],
     hdrs = ["cpp_template_pybind.h"],
     declare_installed_headers = 0,
+    # TODO(jwnimmer-tri) We should enable this eventually.
+    tags = ["nolint_clang_format"],
     visibility = ["//visibility:public"],
     deps = [
         ":cpp_param_pybind",
@@ -363,6 +371,8 @@ drake_pybind_cc_googletest(
         "//common/test_utilities:expect_throws_message",
     ],
     py_deps = [":cpp_template_py"],
+    # TODO(jwnimmer-tri) We should enable this eventually.
+    tags = ["nolint_clang_format"],
 )
 
 drake_pybind_cc_googletest(
@@ -441,6 +451,5 @@ drake_py_unittest(
 
 add_lint_tests(
     cpplint_data = ["//bindings/pydrake:.clang-format"],
-    # TODO(jwnimmer-tri) We should enable this eventually.
-    enable_clang_format_lint = False,
+    enable_clang_format_lint = True,
 )

--- a/bindings/pydrake/common/drake_optional_pybind.h
+++ b/bindings/pydrake/common/drake_optional_pybind.h
@@ -19,7 +19,7 @@ struct type_caster<stx::optional<T>>
     : public optional_caster<stx::optional<T>> {};
 
 template <>
-struct type_caster<stx::nullopt_t>
+struct type_caster<stx::nullopt_t>  // BR
     : public void_caster<stx::nullopt_t> {};
 
 }  // namespace detail

--- a/bindings/pydrake/common/eigen_geometry_py.cc
+++ b/bindings/pydrake/common/eigen_geometry_py.cc
@@ -87,7 +87,7 @@ PYBIND11_MODULE(eigen_geometry, m) {
   {
     using Class = Isometry3<T>;
     py::class_<Class> py_class(m, "Isometry3");
-    py_class
+    py_class  // BR
         .def(py::init([]() { return Class::Identity(); }))
         .def_static("Identity", []() { return Class::Identity(); })
         .def(py::init([](const Matrix4<T>& matrix) {
@@ -175,7 +175,7 @@ PYBIND11_MODULE(eigen_geometry, m) {
     py_class.attr("__doc__") =
         "Provides a unit quaternion binding of Eigen::Quaternion<>.";
     py::object py_class_obj = py_class;
-    py_class
+    py_class  // BR
         .def(py::init([]() { return Class::Identity(); }))
         .def_static("Identity", []() { return Class::Identity(); })
         .def(py::init([](const Vector4<T>& wxyz) {
@@ -261,7 +261,7 @@ PYBIND11_MODULE(eigen_geometry, m) {
     py::class_<Class> py_class(m, "AngleAxis");
     py_class.attr("__doc__") = "Bindings for Eigen::AngleAxis<>.";
     py::object py_class_obj = py_class;
-    py_class
+    py_class  // BR
         .def(py::init([]() { return Class::Identity(); }))
         .def_static("Identity", []() { return Class::Identity(); })
         .def(py::init([](const T& angle, const Vector3<T>& axis) {

--- a/bindings/pydrake/common/test/deprecation_example/cc_module_py.cc
+++ b/bindings/pydrake/common/test/deprecation_example/cc_module_py.cc
@@ -27,7 +27,7 @@ PYBIND11_MODULE(cc_module, m) {
   cls.attr("message_method") = "Deprecated method";
   cls.attr("message_prop") = "Deprecated property";
   // Add deprecated members.
-  cls
+  cls  // BR
       .def(py::init())
       .def("DeprecatedMethod", &ExampleCppClass::DeprecatedMethod)
       .def_readwrite("deprecated_prop", &ExampleCppClass::deprecated_prop)

--- a/bindings/pydrake/common/test/drake_variant_pybind_test.cc
+++ b/bindings/pydrake/common/test/drake_variant_pybind_test.cc
@@ -24,11 +24,10 @@ string VariantToString(const variant<int, double, string>& value) {
   const bool is_int = holds_alternative<int>(value);
   const bool is_double = holds_alternative<double>(value);
   const bool is_string = holds_alternative<string>(value);
-  return
-      is_int ? fmt::format("int({})", get<int>(value)) :
-      is_double ? fmt::format("double({})", get<double>(value)) :
-      is_string ? fmt::format("string({})", get<string>(value)) :
-      "FAILED";
+  if (is_int) return fmt::format("int({})", get<int>(value));
+  if (is_double) return fmt::format("double({})", get<double>(value));
+  if (is_string) return fmt::format("string({})", get<string>(value));
+  return "FAILED";
 }
 
 void ExpectString(const string& expr, const string& expected) {

--- a/bindings/pydrake/common/test/eigen_geometry_test_util_py.cc
+++ b/bindings/pydrake/common/test/eigen_geometry_test_util_py.cc
@@ -23,26 +23,25 @@ PYBIND11_MODULE(eigen_geometry_test_util, m) {
 
   using T = double;
 
+  // Given an Eigen `x`, return max(abs(x[:])).
+  auto max_abs = [](const auto& x) { return x.array().abs().maxCoeff(); };
+
   m.def("create_isometry", []() { return Isometry3<T>::Identity(); });
-  m.def("check_isometry", [](const Isometry3d& X) {
-    const T error =
-        (X.matrix() - Isometry3<T>::Identity().matrix())
-        .array().abs().maxCoeff();
+  m.def("check_isometry", [max_abs](const Isometry3d& X) {
+    const T error = max_abs(X.matrix() - Isometry3<T>::Identity().matrix());
     DRAKE_THROW_UNLESS(error < kTolerance);
   });
 
   m.def("create_translation",
       []() { return Translation3<T>(Vector3<T>::Zero()); });
-  m.def("check_translation", [](const Translation3<T>& p) {
-    const T error = p.vector().array().abs().maxCoeff();
+  m.def("check_translation", [max_abs](const Translation3<T>& p) {
+    const T error = max_abs(p.vector());
     DRAKE_THROW_UNLESS(error < kTolerance);
   });
 
   m.def("create_quaternion", []() { return Quaternion<T>::Identity(); });
-  m.def("check_quaternion", [](const Quaternion<T>& q) {
-    const T error =
-        (q.coeffs() - Quaternion<T>::Identity().coeffs())
-        .array().abs().maxCoeff();
+  m.def("check_quaternion", [max_abs](const Quaternion<T>& q) {
+    const T error = max_abs(q.coeffs() - Quaternion<T>::Identity().coeffs());
     DRAKE_THROW_UNLESS(error < kTolerance);
   });
 }

--- a/bindings/pydrake/common/test/type_pack_test.cc
+++ b/bindings/pydrake/common/test/type_pack_test.cc
@@ -38,23 +38,22 @@ GTEST_TEST(TypeUtilTest, TypeAt) {
 GTEST_TEST(TypeUtilTest, TypeTags) {
   // Ensure that we can default-construct tags for types that are not
   // default-constructible.
-  auto tag_check = type_tag<void>{};
-  EXPECT_TRUE((std::is_same<decltype(tag_check), type_tag<void>>::value));
-  auto pack_check_empty = type_pack<>{};
-  EXPECT_TRUE((std::is_same<decltype(pack_check_empty), type_pack<>>::value));
-  auto pack_check = type_pack<void, void>{};
-  EXPECT_TRUE(
-      (std::is_same<decltype(pack_check), type_pack<void, void>>::value));
+  auto tag_obj = type_tag<void>{};
+  EXPECT_TRUE((std::is_same<decltype(tag_obj), type_tag<void>>::value));
+  auto pack_obj_empty = type_pack<>{};
+  EXPECT_TRUE((std::is_same<decltype(pack_obj_empty), type_pack<>>::value));
+  auto pack_obj = type_pack<void, void>{};
+  EXPECT_TRUE((std::is_same<decltype(pack_obj), type_pack<void, void>>::value));
 }
 
 GTEST_TEST(TypeUtilTest, Bind) {
   using T_0 = Pack::bind<SimpleTemplate>;
-  EXPECT_TRUE(
-      (std::is_same<T_0, SimpleTemplate<int, double, char, void>>::value));
+  using T_0_expected = SimpleTemplate<int, double, char, void>;
+  EXPECT_TRUE((std::is_same<T_0, T_0_expected>::value));
   Pack pack;
   using T_1 = decltype(type_bind<SimpleTemplate>(pack));
-  EXPECT_TRUE(
-      (std::is_same<T_1, SimpleTemplate<int, double, char, void>>::value));
+  using T_1_expected = SimpleTemplate<int, double, char, void>;
+  EXPECT_TRUE((std::is_same<T_1, T_1_expected>::value));
 }
 
 GTEST_TEST(TypeUtilTest, Extract) {
@@ -64,7 +63,10 @@ GTEST_TEST(TypeUtilTest, Extract) {
 }
 
 GTEST_TEST(TypeUtilTest, Visit) {
-  using PackTags = type_pack<type_tag<int>, type_tag<double>, type_tag<char>,
+  using PackTags = type_pack<  // BR
+      type_tag<int>,           //
+      type_tag<double>,        //
+      type_tag<char>,          //
       type_tag<void>>;
   vector<string> names;
   const vector<string> names_expected = {"int", "double", "char", "void"};

--- a/bindings/pydrake/common/test/wrap_test_util_py.cc
+++ b/bindings/pydrake/common/test/wrap_test_util_py.cc
@@ -25,7 +25,7 @@ PYBIND11_MODULE(wrap_test_util, m) {
       .def_readwrite("value", &MyValue::value, py_reference_internal);
 
   py::class_<MyContainer> my_container(m, "MyContainer");
-  my_container
+  my_container  // BR
       .def(py::init<>());
   DefReadWriteKeepAlive(&my_container, "member", &MyContainer::member);
 }

--- a/bindings/pydrake/common/type_safe_index_pybind.h
+++ b/bindings/pydrake/common/type_safe_index_pybind.h
@@ -16,7 +16,7 @@ template <typename Type>
 auto BindTypeSafeIndex(
     py::module m, const std::string& name, const std::string& class_doc = "") {
   py::class_<Type> cls(m, name.c_str(), class_doc.c_str());
-  cls
+  cls  // BR
       .def(py::init<int>(), pydrake_doc.drake.TypeSafeIndex.ctor.doc_2)
       .def("__int__", &Type::operator int)
       .def("__eq__",

--- a/tools/lint/cpplint.bzl
+++ b/tools/lint/cpplint.bzl
@@ -131,6 +131,9 @@ def cpplint(
         if "nolint" in rule.get("tags"):
             # Disable linting when requested (e.g., for generated code).
             continue
+        use_clang_lint = enable_clang_format_lint and (
+            "nolint_clang_format" not in rule.get("tags")
+        )
 
         # Extract the list of C++ source code labels and convert to filenames.
         candidate_labels = (
@@ -151,7 +154,7 @@ def cpplint(
                 source_filenames,
                 name = rule["name"],
                 data = data,
-                enable_clang_format_lint = enable_clang_format_lint,
+                enable_clang_format_lint = use_clang_lint,
             )
 
     # Lint all of the extra_srcs separately in a single rule.

--- a/tools/skylark/pybind.bzl
+++ b/tools/skylark/pybind.bzl
@@ -259,7 +259,7 @@ def drake_pybind_cc_googletest(
             "@python//:python_direct_link",
         ],
         # Add 'manual', because we only want to run it with Python present.
-        tags = ["manual"],
+        tags = ["manual"] + tags,
         visibility = visibility,
     )
 


### PR DESCRIPTION
Opt-out of the linter on some files that should be fixed more carefully, in a future PR.