### PR TITLE
pydrake/common: Enable clang-format everywhere

### DIFF
--- a/bindings/pydrake/common/BUILD.bazel
+++ b/bindings/pydrake/common/BUILD.bazel
@@ -65,8 +65,6 @@ drake_cc_library(
     name = "type_pack",
     hdrs = ["type_pack.h"],
     declare_installed_headers = 0,
-    # TODO(jwnimmer-tri) We should enable this eventually.
-    tags = ["nolint_clang_format"],
     visibility = ["//visibility:public"],
 )
 
@@ -74,8 +72,6 @@ drake_cc_library(
     name = "wrap_function",
     hdrs = ["wrap_function.h"],
     declare_installed_headers = 0,
-    # TODO(jwnimmer-tri) We should enable this eventually.
-    tags = ["nolint_clang_format"],
     visibility = ["//visibility:public"],
 )
 
@@ -83,8 +79,6 @@ drake_cc_library(
     name = "wrap_pybind",
     hdrs = ["wrap_pybind.h"],
     declare_installed_headers = 0,
-    # TODO(jwnimmer-tri) We should enable this eventually.
-    tags = ["nolint_clang_format"],
     visibility = ["//visibility:public"],
     deps = [":wrap_function"],
 )
@@ -171,8 +165,6 @@ drake_cc_library(
     srcs = [],
     hdrs = ["cpp_template_pybind.h"],
     declare_installed_headers = 0,
-    # TODO(jwnimmer-tri) We should enable this eventually.
-    tags = ["nolint_clang_format"],
     visibility = ["//visibility:public"],
     deps = [
         ":cpp_param_pybind",
@@ -371,8 +363,6 @@ drake_pybind_cc_googletest(
         "//common/test_utilities:expect_throws_message",
     ],
     py_deps = [":cpp_template_py"],
-    # TODO(jwnimmer-tri) We should enable this eventually.
-    tags = ["nolint_clang_format"],
 )
 
 drake_pybind_cc_googletest(

--- a/bindings/pydrake/common/cpp_template_pybind.h
+++ b/bindings/pydrake/common/cpp_template_pybind.h
@@ -20,9 +20,9 @@ namespace internal {
 // Please see that function for common parameters.
 // @param template_cls_name Name of the template class in `cpp_template`,
 // resolves to class to be passed as `template_cls`.
-inline py::object GetOrInitTemplate(
+inline py::object GetOrInitTemplate(  // BR
     py::handle scope, const std::string& name,
-    const std::string& template_cls_name,
+    const std::string& template_cls_name,  // BR
     py::tuple args = py::tuple(), py::dict kwargs = py::dict()) {
   const char module_name[] = "pydrake.common.cpp_template";
   py::handle m = py::module::import(module_name);
@@ -59,9 +59,9 @@ std::string TemporaryClassName(const std::string& name = "TemporaryName") {
 /// names, consider constructing the class binding as
 /// `py::class_<Class, ...>(m, TemporaryClassName<Class>().c_str())`.
 /// @param param Parameters for the instantiation.
-inline py::object AddTemplateClass(
-    py::handle scope, const std::string& name,
-    py::handle py_class, py::tuple param) {
+inline py::object AddTemplateClass(  // BR
+    py::handle scope, const std::string& name, py::handle py_class,
+    py::tuple param) {
   py::object py_template =
       internal::GetOrInitTemplate(scope, name, "TemplateClass");
   internal::AddInstantiation(py_template, py_class, param);
@@ -74,7 +74,7 @@ inline py::object AddTemplateClass(
 /// named `default_name + template_suffix`.
 /// @return pybind11 class
 template <typename Class, typename... Options>
-py::class_<Class, Options...> DefineTemplateClassWithDefault(
+py::class_<Class, Options...> DefineTemplateClassWithDefault(  // BR
     py::handle scope, const std::string& default_name, py::tuple param,
     const char* doc_string = "", const std::string& template_suffix = "_") {
   const std::string template_name = default_name + template_suffix;
@@ -101,9 +101,9 @@ py::object AddTemplateFunction(
   // TODO(eric.cousineau): Use `py::sibling` if overloads are needed.
   py::object py_template =
       internal::GetOrInitTemplate(scope, name, "TemplateFunction");
-  py::object py_func = py::cpp_function(
-        std::forward<Func>(func),
-        py::name(internal::GetInstantiationName(py_template, param).c_str()));
+  py::object py_func = py::cpp_function(  // BR
+      std::forward<Func>(func),
+      py::name(internal::GetInstantiationName(py_template, param).c_str()));
   internal::AddInstantiation(py_template, py_func, param);
   return py_template;
 }
@@ -114,12 +114,12 @@ py::object AddTemplateFunction(
 /// @param method Method to be added.
 /// @param param Parameters for the instantiation.
 template <typename Method>
-py::object AddTemplateMethod(
+py::object AddTemplateMethod(  // BR
     py::handle scope, const std::string& name, Method&& method,
     py::tuple param) {
   py::object py_template = internal::GetOrInitTemplate(
       scope, name, "TemplateMethod", py::make_tuple(scope));
-  py::object py_func = py::cpp_function(
+  py::object py_func = py::cpp_function(  // BR
       std::forward<Method>(method),
       py::name(internal::GetInstantiationName(py_template, param).c_str()),
       py::is_method(scope));

--- a/bindings/pydrake/common/test/cpp_template_pybind_test.cc
+++ b/bindings/pydrake/common/test/cpp_template_pybind_test.cc
@@ -27,16 +27,14 @@ using test::SynchronizeGlobalsForPython3;
 
 template <typename... Ts>
 struct SimpleTemplate {
-  vector<string> GetNames() {
-    return {NiceTypeName::Get<Ts>()...};
-  }
+  vector<string> GetNames() { return {NiceTypeName::Get<Ts>()...}; }
 };
 
 template <typename... Ts>
 py::object BindSimpleTemplate(py::module m) {
   using Class = SimpleTemplate<Ts...>;
   py::class_<Class> py_class(m, TemporaryClassName<Class>().c_str());
-  py_class
+  py_class  // BR
       .def(py::init<>())
       .def("GetNames", &Class::GetNames);
   AddTemplateClass(m, "SimpleTemplate", py_class, GetPyParam<Ts...>());
@@ -69,8 +67,8 @@ GTEST_TEST(CppTemplateTest, TemplateClass) {
   // N.B. We use `[^\0]` because C++ regex does not have an equivalent of
   // Python re's DOTALL flag. `[\s\S]` *should* work, but Apple LLVM 10.0.0
   // does not work with it.
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      py::eval("simple_func('incorrect value')"), std::runtime_error,
+  DRAKE_EXPECT_THROWS_MESSAGE(py::eval("simple_func('incorrect value')"),
+      std::runtime_error,
       R"([^\0]*incompatible function arguments[^\0]*\(arg0: __main__\.SimpleTemplate\[int\]\)[^\0]*)");  // NOLINT
 }
 
@@ -82,11 +80,10 @@ vector<string> SimpleFunction() {
 GTEST_TEST(CppTemplateTest, TemplateFunction) {
   py::module m("__main__");
 
-  AddTemplateFunction(
-      m, "SimpleFunction", &SimpleFunction<int>, GetPyParam<int>());
-  AddTemplateFunction(
-      m, "SimpleFunction", &SimpleFunction<int, double>,
-      GetPyParam<int, double>());
+  AddTemplateFunction(m, "SimpleFunction",  // BR
+      &SimpleFunction<int>, GetPyParam<int>());
+  AddTemplateFunction(m, "SimpleFunction",  // BR
+      &SimpleFunction<int, double>, GetPyParam<int, double>());
 
   const vector<string> expected_1 = {"int"};
   const vector<string> expected_2 = {"int", "double"};
@@ -106,14 +103,12 @@ GTEST_TEST(CppTemplateTest, TemplateMethod) {
   py::module m("__main__");
 
   py::class_<SimpleType> py_class(m, "SimpleType");
-  py_class
+  py_class  // BR
       .def(py::init<>());
-  AddTemplateMethod(
-      py_class, "SimpleMethod", &SimpleType::SimpleMethod<int>,
+  AddTemplateMethod(py_class, "SimpleMethod", &SimpleType::SimpleMethod<int>,
       GetPyParam<int>());
-  AddTemplateMethod(
-      py_class, "SimpleMethod", &SimpleType::SimpleMethod<int, double>,
-      GetPyParam<int, double>());
+  AddTemplateMethod(py_class, "SimpleMethod",
+      &SimpleType::SimpleMethod<int, double>, GetPyParam<int, double>());
 
   const vector<string> expected_1 = {"int"};
   const vector<string> expected_2 = {"int", "double"};

--- a/bindings/pydrake/common/type_pack.h
+++ b/bindings/pydrake/common/type_pack.h
@@ -63,8 +63,8 @@ using DummyList = bool[];
 
 template <typename T>
 struct assert_default_constructible {
-  static_assert(std::is_default_constructible<T>::value,
-                "Must be default constructible");
+  static_assert(
+      std::is_default_constructible<T>::value, "Must be default constructible");
 };
 
 }  // namespace detail
@@ -164,17 +164,17 @@ struct type_check_different_from {
 /// @tparam Predicate Predicate operating on the type dictated by `VisitWith`.
 /// @param visitor Lambda or functor for visiting a type.
 template <class VisitWith = type_visit_with_default,
-          template <typename> class Predicate = type_check_always_true,
-          typename Visitor = void,
-          typename ... Ts>
-void type_visit(
-    Visitor&& visitor, type_pack<Ts...> = {},
+    template <typename> class Predicate = type_check_always_true,
+    typename Visitor = void, typename... Ts>
+void type_visit(Visitor&& visitor, type_pack<Ts...> = {},
     template_single_tag<Predicate> = {}) {
+  // clang-format off
   (void)detail::DummyList{(
       detail::type_visit_impl<VisitWith, Visitor>::
           template runner<Ts, Predicate<Ts>::value>::
               run(std::forward<Visitor>(visitor)),
       true)...};
+  // clang-format on
 }
 
 /// Provides short-hand for hashing a type.

--- a/bindings/pydrake/common/wrap_pybind.h
+++ b/bindings/pydrake/common/wrap_pybind.h
@@ -24,8 +24,7 @@ class MirrorDef {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MirrorDef);
 
-  MirrorDef(A* a, B* b)
-      : a_(a), b_(b) {}
+  MirrorDef(A* a, B* b) : a_(a), b_(b) {}
 
   /// Calls `def` for both `a` and `b`.
   template <typename... Args>
@@ -46,8 +45,8 @@ template <typename T, typename = void>
 struct wrap_ref_ptr : public wrap_arg_default<T> {};
 
 template <typename T>
-using is_generic_pybind =
-  std::is_base_of<py::detail::type_caster_generic, py::detail::make_caster<T>>;
+using is_generic_pybind = std::is_base_of<py::detail::type_caster_generic,
+    py::detail::make_caster<T>>;
 
 template <typename T>
 struct wrap_ref_ptr<T&, std::enable_if_t<is_generic_pybind<T>::value>> {
@@ -94,12 +93,11 @@ template <typename PyClass, typename Class, typename T>
 void DefReadWriteKeepAlive(PyClass* cls, const char* name, T Class::*member) {
   auto getter = [member](const Class* obj) { return obj->*member; };
   auto setter = [member](Class* obj, const T& value) { obj->*member = value; };
-  cls->def_property(
-    name,
-    py::cpp_function(getter),
-    py::cpp_function(setter,
-                     // Keep alive, reference: `self` keeps `value` alive.
-                     py::keep_alive<1, 2>()));
+  cls->def_property(name,  // BR
+      py::cpp_function(getter),
+      py::cpp_function(setter,
+          // Keep alive, reference: `self` keeps `value` alive.
+          py::keep_alive<1, 2>()));
 }
 
 }  // namespace pydrake


### PR DESCRIPTION
This involves running clang-format, reworking some clang-format choices, and removing all of the nolint tags.

Relates #4843.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10285)
<!-- Reviewable:end -->
