### PR TITLE
multibody: Remove implicit_stribeck namespace

### DIFF
--- a/multibody/plant/implicit_stribeck_solver.cc
+++ b/multibody/plant/implicit_stribeck_solver.cc
@@ -11,7 +11,6 @@
 
 namespace drake {
 namespace multibody {
-namespace implicit_stribeck {
 namespace internal {
 template <typename T>
 T DirectionChangeLimiter<T>::CalcAlpha(
@@ -601,7 +600,7 @@ T ImplicitStribeckSolver<T>::CalcAlpha(
 }
 
 template <typename T>
-ComputationInfo ImplicitStribeckSolver<T>::SolveWithGuess(
+ImplicitStribeckSolverResult ImplicitStribeckSolver<T>::SolveWithGuess(
     double dt, const VectorX<T>& v_guess) const {
   DRAKE_THROW_UNLESS(v_guess.size() == nv_);
 
@@ -622,7 +621,7 @@ ComputationInfo ImplicitStribeckSolver<T>::SolveWithGuess(
     v = M.ldlt().solve(p_star);
     // "One iteration" with exactly "zero" vt_error.
     statistics_.Update(0.0);
-    return ComputationInfo::Success;
+    return ImplicitStribeckSolverResult::kSuccess;
   }
 
   // Solver parameters.
@@ -695,7 +694,7 @@ ComputationInfo ImplicitStribeckSolver<T>::SolveWithGuess(
       // Update generalized forces and return.
       tau_f = Jt.transpose() * ft;
       tau = tau_f + Jn.transpose() * fn;
-      return ComputationInfo::Success;
+      return ImplicitStribeckSolverResult::kSuccess;
     }
 
     // Newton-Raphson residual.
@@ -722,7 +721,7 @@ ComputationInfo ImplicitStribeckSolver<T>::SolveWithGuess(
       auto& J_ldlt = fixed_size_workspace_.mutable_J_ldlt();
       J_ldlt.compute(J);  // Update factorization.
       if (J_ldlt.info() != Eigen::Success) {
-        return ComputationInfo::LinearSolverFailed;
+        return ImplicitStribeckSolverResult::kLinearSolverFailed;
       }
       Delta_v = J_ldlt.solve(-residual);
     }
@@ -757,7 +756,7 @@ ComputationInfo ImplicitStribeckSolver<T>::SolveWithGuess(
 
   // If we are here is because we reached the maximum number of iterations
   // without converging to the specified tolerance.
-  return ComputationInfo::MaxIterationsReached;
+  return ImplicitStribeckSolverResult::kMaxIterationsReached;
 }
 
 template <typename T>
@@ -781,14 +780,12 @@ T ImplicitStribeckSolver<T>::ModifiedStribeckDerivative(
   }
 }
 
-}  // namespace implicit_stribeck
 }  // namespace multibody
 }  // namespace drake
 
 // Explicitly instantiates on the most common scalar types.
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
-    struct
-    ::drake::multibody::implicit_stribeck::internal::DirectionChangeLimiter)
+    struct ::drake::multibody::internal::DirectionChangeLimiter)
 
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
-    class ::drake::multibody::implicit_stribeck::ImplicitStribeckSolver)
+    class ::drake::multibody::ImplicitStribeckSolver)

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -2643,7 +2643,7 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
     // parameter. Pre-Finalize the solver is not yet created and therefore we
     // check for nullptr.
     if (is_discrete() && implicit_stribeck_solver_ != nullptr) {
-      implicit_stribeck::Parameters solver_parameters =
+      ImplicitStribeckSolverParameters solver_parameters =
           implicit_stribeck_solver_->get_solver_parameters();
       solver_parameters.stiction_tolerance =
           stribeck_model_.stiction_tolerance();
@@ -2789,7 +2789,7 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   // to perform the update using a step size dt_substep = dt/num_substeps.
   // During the time span dt the problem data M, Jn, Jt and minus_tau, are
   // approximated to be constant, a first order approximation.
-  implicit_stribeck::ComputationInfo SolveUsingSubStepping(
+  ImplicitStribeckSolverResult SolveUsingSubStepping(
       int num_substeps,
       const MatrixX<T>& M0, const MatrixX<T>& Jn, const MatrixX<T>& Jt,
       const VectorX<T>& minus_tau,
@@ -3137,8 +3137,7 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   double time_step_{0};
 
   // The solver used when the plant is modeled as a discrete system.
-  std::unique_ptr<implicit_stribeck::ImplicitStribeckSolver<T>>
-      implicit_stribeck_solver_;
+  std::unique_ptr<ImplicitStribeckSolver<T>> implicit_stribeck_solver_;
 
   // TODO(sherm1) Add CacheIndex members here for cache entries that belong to
   //              MBPlant, not MBTree.

--- a/multibody/plant/test/implicit_stribeck_solver_test.cc
+++ b/multibody/plant/test/implicit_stribeck_solver_test.cc
@@ -9,7 +9,6 @@
 
 namespace drake {
 namespace multibody {
-namespace implicit_stribeck {
 
 // This class has friend access to ImplicitStribeckSolver so that we can test
 // its internals.
@@ -524,17 +523,17 @@ TEST_F(PizzaSaver, SmallAppliedMoment) {
 
   SetProblem(v0, tau, mu, theta, dt);
 
-  Parameters parameters;  // Default parameters.
+  ImplicitStribeckSolverParameters parameters;  // Default parameters.
   parameters.stiction_tolerance = 1.0e-6;
   parameters.relative_tolerance = 1.0e-4;
   solver_.set_solver_parameters(parameters);
 
-  ComputationInfo info = solver_.SolveWithGuess(dt, v0);
-  ASSERT_EQ(info, ComputationInfo::Success);
+  ImplicitStribeckSolverResult info = solver_.SolveWithGuess(dt, v0);
+  ASSERT_EQ(info, ImplicitStribeckSolverResult::kSuccess);
 
   VectorX<double> tau_f = solver_.get_generalized_friction_forces();
 
-  const IterationStats& stats = solver_.get_iteration_statistics();
+  const auto& stats = solver_.get_iteration_statistics();
 
   const double vt_tolerance =
       // Dimensionless relative (to the stiction tolerance) tolerance.
@@ -626,17 +625,17 @@ TEST_F(PizzaSaver, LargeAppliedMoment) {
 
   SetProblem(v0, tau, mu, theta, dt);
 
-  Parameters parameters;  // Default parameters.
+  ImplicitStribeckSolverParameters parameters;  // Default parameters.
   parameters.stiction_tolerance = 1.0e-6;
   parameters.relative_tolerance = 1.0e-4;
   solver_.set_solver_parameters(parameters);
 
-  ComputationInfo info = solver_.SolveWithGuess(dt, v0);
-  ASSERT_EQ(info, ComputationInfo::Success);
+  ImplicitStribeckSolverResult info = solver_.SolveWithGuess(dt, v0);
+  ASSERT_EQ(info, ImplicitStribeckSolverResult::kSuccess);
 
   VectorX<double> tau_f = solver_.get_generalized_friction_forces();
 
-  const IterationStats& stats = solver_.get_iteration_statistics();
+  const auto& stats = solver_.get_iteration_statistics();
 
   const double vt_tolerance =
       // Dimensionless relative (to the stiction tolerance) tolerance.
@@ -723,12 +722,12 @@ TEST_F(PizzaSaver, NoContact) {
 
   SetNoContactProblem(v0, tau, dt);
 
-  ComputationInfo info = solver_.SolveWithGuess(dt, v0);
-  ASSERT_EQ(info, ComputationInfo::Success);
+  ImplicitStribeckSolverResult info = solver_.SolveWithGuess(dt, v0);
+  ASSERT_EQ(info, ImplicitStribeckSolverResult::kSuccess);
 
   EXPECT_EQ(solver_.get_generalized_friction_forces(), Vector3<double>::Zero());
 
-  const IterationStats& stats = solver_.get_iteration_statistics();
+  const auto& stats = solver_.get_iteration_statistics();
   EXPECT_EQ(stats.vt_residual(), 0);
   EXPECT_EQ(stats.num_iterations, 1);
 
@@ -927,16 +926,16 @@ TEST_F(RollingCylinder, StictionAfterImpact) {
 
   SetImpactProblem(v0, tau, mu, h0, dt);
 
-  Parameters parameters;  // Default parameters.
+  ImplicitStribeckSolverParameters parameters;  // Default parameters.
   parameters.stiction_tolerance = 1.0e-6;
   solver_.set_solver_parameters(parameters);
 
-  ComputationInfo info = solver_.SolveWithGuess(dt, v0);
-  ASSERT_EQ(info, ComputationInfo::Success);
+  ImplicitStribeckSolverResult info = solver_.SolveWithGuess(dt, v0);
+  ASSERT_EQ(info, ImplicitStribeckSolverResult::kSuccess);
 
   VectorX<double> tau_f = solver_.get_generalized_friction_forces();
 
-  const IterationStats& stats = solver_.get_iteration_statistics();
+  const auto& stats = solver_.get_iteration_statistics();
 
   const double vt_tolerance =
       solver_.get_solver_parameters().relative_tolerance *
@@ -1017,16 +1016,16 @@ TEST_F(RollingCylinder, SlidingAfterImpact) {
 
   SetImpactProblem(v0, tau, mu, h0, dt);
 
-  Parameters parameters;  // Default parameters.
+  ImplicitStribeckSolverParameters parameters;  // Default parameters.
   parameters.stiction_tolerance = 1.0e-6;
   solver_.set_solver_parameters(parameters);
 
-  ComputationInfo info = solver_.SolveWithGuess(dt, v0);
-  ASSERT_EQ(info, ComputationInfo::Success);
+  ImplicitStribeckSolverResult info = solver_.SolveWithGuess(dt, v0);
+  ASSERT_EQ(info, ImplicitStribeckSolverResult::kSuccess);
 
   VectorX<double> tau_f = solver_.get_generalized_friction_forces();
 
-  const IterationStats& stats = solver_.get_iteration_statistics();
+  const auto& stats = solver_.get_iteration_statistics();
 
   const double vt_tolerance =
       solver_.get_solver_parameters().relative_tolerance *
@@ -1082,7 +1081,6 @@ TEST_F(RollingCylinder, SlidingAfterImpact) {
 }
 
 }  // namespace
-}  // namespace implicit_stribeck
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/plant/test/implicit_stribeck_solver_test_util.h
+++ b/multibody/plant/test/implicit_stribeck_solver_test_util.h
@@ -8,13 +8,10 @@
 
 #include <memory>
 
-#include <gtest/gtest.h>
-
 #include "drake/math/autodiff_gradient.h"
 
 namespace drake {
 namespace multibody {
-namespace implicit_stribeck {
 namespace test {
 
 // Computes the normal force as a function of the signed penetration depth x
@@ -197,7 +194,6 @@ MatrixX<double> CalcOneWayCoupledJacobianWithAutoDiff(
 }
 
 }  // namespace test
-}  // namespace implicit_stribeck
 }  // namespace multibody
 }  // namespace drake
 


### PR DESCRIPTION
We do not provide deprecation aliases; this class is unlikely to be widely used outside of MultibodyPlant.

Relates #9314.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10287)
<!-- Reviewable:end -->
