### PR TITLE
zap multibody SetDefaultContext

### DIFF
--- a/bindings/pydrake/multibody/multibody_tree_py.cc
+++ b/bindings/pydrake/multibody/multibody_tree_py.cc
@@ -980,11 +980,6 @@ void init_multibody_plant(py::module m) {
             py_reference, py::arg("context"), py::arg("model_instance"),
             py::arg("q_v"),
             doc.MultibodyPlant.SetPositionsAndVelocities.doc_3args)
-        .def("SetDefaultContext",
-            [](const Class* self, Context<T>* context) {
-              self->SetDefaultContext(context);
-            },
-            py::arg("context"), doc.MultibodyPlant.SetDefaultContext.doc)
         .def("SetDefaultState",
             [](const Class* self, const Context<T>& context, State<T>* state) {
               self->SetDefaultState(context, state);

--- a/bindings/pydrake/multibody/test/multibody_tree_test.py
+++ b/bindings/pydrake/multibody/test/multibody_tree_test.py
@@ -396,7 +396,6 @@ class TestMultibodyTree(unittest.TestCase):
             tree.GetPositionsAndVelocities(context), x0))
 
         # Test existence of context resetting methods.
-        plant.SetDefaultContext(context)
         plant.SetDefaultState(context, state=context.get_mutable_state())
 
     def test_model_instance_port_access(self):

--- a/examples/multibody/bouncing_ball/bouncing_ball_run_dynamics.cc
+++ b/examples/multibody/bouncing_ball/bouncing_ball_run_dynamics.cc
@@ -109,7 +109,6 @@ int do_main() {
   // Set at height z0 with random orientation.
   std::mt19937 generator(41);
   std::uniform_real_distribution<double> uniform(-1.0, 1.0);
-  tree.SetDefaultContext(&plant_context);
   Matrix3d R_WB = math::UniformlyRandomRotationMatrix(&generator).matrix();
   Isometry3d X_WB = Isometry3d::Identity();
   X_WB.linear() = R_WB;

--- a/examples/multibody/cylinder_with_multicontact/cylinder_run_dynamics.cc
+++ b/examples/multibody/cylinder_with_multicontact/cylinder_run_dynamics.cc
@@ -116,7 +116,6 @@ int do_main() {
       diagram->GetMutableSubsystemContext(plant, diagram_context.get());
 
   // Set at height z0.
-  tree.SetDefaultContext(&plant_context);
   Isometry3d X_WB = Isometry3d::Identity();
   X_WB.translation() = Vector3d(0.0, 0.0, FLAGS_z0);
   const auto& cylinder = tree.GetBodyByName("Cylinder");

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -2652,14 +2652,6 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   }
   /// @}
 
-  /// Sets default values in the context. For mobilizers, this method sets them
-  /// to their _zero_ state according to Mobilizer::set_zero_state().
-  void SetDefaultContext(systems::Context<T>* context) const {
-    DRAKE_MBP_THROW_IF_NOT_FINALIZED();
-    DRAKE_DEMAND(context != nullptr);
-    tree().SetDefaultContext(context);
-  }
-
   /// Sets the state in `context` so that generalized positions and velocities
   /// are zero.
   /// @throws std::exception if called pre-finalize. See Finalize().

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -306,11 +306,6 @@ void MultibodyTree<T>::CreateModelInstances() {
 }
 
 template <typename T>
-void MultibodyTree<T>::SetDefaultContext(systems::Context<T> *context) const {
-  SetDefaultState(*context, &context->get_mutable_state());
-}
-
-template <typename T>
 void MultibodyTree<T>::SetDefaultState(
     const systems::Context<T>& context, systems::State<T>* state) const {
   for (const auto& mobilizer : owned_mobilizers_) {

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -1382,9 +1382,6 @@ class MultibodyTree {
   }
 
   /// See MultibodyPlant method.
-  void SetDefaultContext(systems::Context<T>* context) const;
-
-  /// See MultibodyPlant method.
   void SetDefaultState(const systems::Context<T>& context,
                        systems::State<T>* state) const;
 


### PR DESCRIPTION
The documentation for SetDefaultContext on System specifically says "User code should not override."  MultibodyPlant/Tree both override it -- and do no meaningful work (in fact skipping some meaningful work).  Removing these should only be better; the default implementation makes the same calls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10295)
<!-- Reviewable:end -->
