### PR TITLE
Condense GetJointByName methods

### DIFF
--- a/bindings/pydrake/multibody/multibody_tree_py.cc
+++ b/bindings/pydrake/multibody/multibody_tree_py.cc
@@ -792,10 +792,10 @@ void init_multibody_plant(py::module m) {
             doc.MultibodyPlant.GetBodyByName.doc_2args)
         .def("GetJointByName",
             [](const Class* self, const string& name,
-                ModelInstanceIndex model_instance) -> auto& {
+                optional<ModelInstanceIndex> model_instance) -> auto& {
               return self->GetJointByName(name, model_instance);
             },
-            py::arg("name"), py::arg("model_instance") = ModelInstanceIndex{},
+            py::arg("name"), py::arg("model_instance") = nullopt,
             py_reference_internal, doc.MultibodyPlant.GetJointByName.doc)
         .def("GetJointActuatorByName",
             overload_cast_explicit<const JointActuator<T>&, const string&>(

--- a/bindings/pydrake/multibody/multibody_tree_py.cc
+++ b/bindings/pydrake/multibody/multibody_tree_py.cc
@@ -791,18 +791,12 @@ void init_multibody_plant(py::module m) {
             py::arg("name"), py::arg("model_instance"), py_reference_internal,
             doc.MultibodyPlant.GetBodyByName.doc_2args)
         .def("GetJointByName",
-            [](const Class* self, const string& name) -> auto& {
-              return self->GetJointByName(name);
-            },
-            py::arg("name"), py_reference_internal,
-            doc.MultibodyPlant.GetJointByName.doc)
-        .def("GetJointByName",
             [](const Class* self, const string& name,
                 ModelInstanceIndex model_instance) -> auto& {
               return self->GetJointByName(name, model_instance);
             },
-            py::arg("name"), py::arg("model_instance"), py_reference_internal,
-            doc.MultibodyPlant.GetJointByName.doc_2)
+            py::arg("name"), py::arg("model_instance") = ModelInstanceIndex{},
+            py_reference_internal, doc.MultibodyPlant.GetJointByName.doc)
         .def("GetJointActuatorByName",
             overload_cast_explicit<const JointActuator<T>&, const string&>(
                 &Class::GetJointActuatorByName),

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1025,7 +1025,7 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   template <template <typename> class JointType = Joint>
   const JointType<T>& GetJointByName(
       const std::string& name,
-      ModelInstanceIndex model_instance = ModelInstanceIndex{}) const {
+      optional<ModelInstanceIndex> model_instance = nullopt) const {
     return tree().template GetJointByName<JointType>(name, model_instance);
   }
 

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1012,46 +1012,9 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   }
 
   /// Returns a constant reference to a joint that is identified
-  /// by the string `name` in `this` %MultibodyPlant.
-  /// @throws std::logic_error if there is no joint with the requested name.
-  /// @throws std::logic_error if the joint name occurs in multiple model
-  /// instances.
-  /// @see HasJointNamed() to query if there exists a joint in `this`
-  /// %MultibodyPlant with a given specified name.
-  const Joint<T>& GetJointByName(const std::string& name) const {
-    return tree().GetJointByName(name);
-  }
-
-  /// Returns a constant reference to the joint that is uniquely identified
-  /// by the string `name` and @p model_instance in `this` %MultibodyPlant.
-  /// @throws std::logic_error if there is no joint with the requested name.
-  /// @throws std::exception if @p model_instance is not valid for this model.
-  /// @see HasJointNamed() to query if there exists a joint in `this`
-  /// %MultibodyPlant with a given specified name.
-  const Joint<T>& GetJointByName(
-      const std::string& name, ModelInstanceIndex model_instance) const {
-    return tree().GetJointByName(name, model_instance);
-  }
-
-  /// A templated version of GetJointByName() to return a constant reference of
-  /// the specified type `JointType` in place of the base Joint class. See
-  /// GetJointByName() for details.
-  /// @tparam JointType The specific type of the Joint to be retrieved. It must
-  /// be a subclass of Joint.
-  /// @throws std::logic_error if the named joint is not of type `JointType` or
-  /// if there is no Joint with that name.
-  /// @throws std::logic_error if the joint name occurs in multiple model
-  /// instances.
-  /// @see HasJointNamed() to query if there exists a joint in `this`
-  /// %MultibodyPlant with a given specified name.
-  template <template<typename> class JointType>
-  const JointType<T>& GetJointByName(const std::string& name) const {
-    return tree().template GetJointByName<JointType>(name);
-  }
-
-  /// A templated version of GetJointByName() to return a constant reference of
-  /// the specified type `JointType` in place of the base Joint class. See
-  /// GetJointByName() for details.
+  /// by the string `name` in `this` %MultibodyPlant.  If the optional
+  /// template argument is supplied, then the returned value is downcast to
+  /// the specified `JointType`.
   /// @tparam JointType The specific type of the Joint to be retrieved. It must
   /// be a subclass of Joint.
   /// @throws std::logic_error if the named joint is not of type `JointType` or
@@ -1059,9 +1022,10 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   /// @throws std::exception if @p model_instance is not valid for this model.
   /// @see HasJointNamed() to query if there exists a joint in `this`
   /// %MultibodyPlant with a given specified name.
-  template <template<typename> class JointType>
+  template <template <typename> class JointType = Joint>
   const JointType<T>& GetJointByName(
-      const std::string& name, ModelInstanceIndex model_instance) const {
+      const std::string& name,
+      ModelInstanceIndex model_instance = ModelInstanceIndex{}) const {
     return tree().template GetJointByName<JointType>(name, model_instance);
   }
 

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -1150,39 +1150,38 @@ class MultibodyTree {
   }
 
   /// See MultibodyPlant method.
-  template <template<typename> class JointType = Joint>
+  template <template <typename> class JointType = Joint>
   const JointType<T>& GetJointByName(
-      const std::string& name, ModelInstanceIndex model_instance =
-          ModelInstanceIndex{}) const {
+      const std::string& name,
+      optional<ModelInstanceIndex> model_instance = nullopt) const {
     static_assert(std::is_base_of<Joint<T>, JointType<T>>::value,
                   "JointType<T> must be a sub-class of Joint<T>.");
 
     const Joint<T>* joint = nullptr;
-    if (model_instance.is_valid()) {
-      DRAKE_THROW_UNLESS(model_instance < instance_name_to_index_.size());
+    if (model_instance) {
+      DRAKE_THROW_UNLESS(*model_instance < instance_name_to_index_.size());
       const auto range = joint_name_to_index_.equal_range(name);
       for (auto it = range.first; it != range.second; ++it) {
         const Joint<T>& this_joint = get_joint(it->second);
-        if (this_joint.model_instance() == model_instance) {
+        if (this_joint.model_instance() == *model_instance) {
           joint = &this_joint;
         }
       }
       if (joint == nullptr) {
         throw std::logic_error(
             "There is no joint named '" + name + "' in model instance '" +
-            instance_index_to_name_.at(model_instance) + "'.");
+            instance_index_to_name_.at(*model_instance) + "'.");
       }
     } else {
       joint = &get_joint(
           GetElementIndex<JointIndex>(name, "Joint", joint_name_to_index_));
     }
 
-    const JointType<T>* typed_joint =
-        dynamic_cast<const JointType<T>*>(joint);
+    const JointType<T>* typed_joint = dynamic_cast<const JointType<T>*>(joint);
     if (typed_joint == nullptr) {
       throw std::logic_error(
           "Joint '" + name + "' in model instance " +
-          instance_index_to_name_.at(model_instance) + " is not of type '" +
+          instance_index_to_name_.at(*model_instance) + " is not of type '" +
           NiceTypeName::Get<JointType<T>>() + "' but of type '" +
           NiceTypeName::Get(GetJointByName(name)) + "'.");
     }


### PR DESCRIPTION
Related to #10309 . 

Submitting this change by itself to make it clear that this has no change on any usages... it only condenses the implementation.  I believe that the performance should be similar (the dynamic_cast should be optimized out in the base case).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10311)
<!-- Reviewable:end -->
