### PR TITLE
clean up virtual/default methods in mobilizer set_zero_state logic

### DIFF
--- a/multibody/tree/mobilizer_impl.h
+++ b/multibody/tree/mobilizer_impl.h
@@ -53,6 +53,12 @@ class MobilizerImpl : public Mobilizer<T> {
   /// Returns the number of generalized velocities granted by this mobilizer.
   int num_velocities() const final { return kNv;}
 
+  void set_zero_state(const systems::Context<T>& context,
+                      systems::State<T>* state) const final {
+    get_mutable_positions(context, state) = get_zero_position();
+    get_mutable_velocities(context, state).setZero();
+  };
+
   /// For MultibodyTree internal use only.
   std::unique_ptr<internal::BodyNode<T>> CreateBodyNode(
       const internal::BodyNode<T>* parent_node,
@@ -64,6 +70,10 @@ class MobilizerImpl : public Mobilizer<T> {
   // http://stackoverflow.com/questions/37259807/static-constexpr-int-vs-old-fashioned-enum-when-and-why
   enum : int {
     kNq = compile_time_num_positions, kNv = compile_time_num_velocities};
+
+  virtual Eigen::Matrix<T, kNq, 1> get_zero_position() const {
+    return Eigen::Matrix<T, kNq, 1>::Zero();
+  }
 
   /// @name Helper methods to retrieve entries from MultibodyTreeContext.
 
@@ -175,17 +185,6 @@ class MobilizerImpl : public Mobilizer<T> {
                              "drake::multibody::MultibodyTreeContext.");
     }
     return *mbt_context;
-  }
-
-  /// Helper to set `state` to a default zero state with all generalized
-  /// positions and generalized velocities related to this mobilizer to zero.
-  /// Be aware however that this default does not apply in general to all
-  /// mobilizers and specific subclasses (for instance for unit quaternions)
-  /// must override this method for correctness.
-  void set_default_zero_state(const systems::Context<T>& context,
-                              systems::State<T>* state) const {
-    get_mutable_positions(context, state).setZero();
-    get_mutable_velocities(context, state).setZero();
   }
 
  private:

--- a/multibody/tree/prismatic_mobilizer.cc
+++ b/multibody/tree/prismatic_mobilizer.cc
@@ -53,13 +53,6 @@ const PrismaticMobilizer<T>& PrismaticMobilizer<T>::set_translation_rate(
 }
 
 template <typename T>
-void PrismaticMobilizer<T>::set_zero_state(const systems::Context<T>& context,
-                                          systems::State<T>* state) const {
-  // The default Mobilizer state of zero positions and velocities is used.
-  this->set_default_zero_state(context, state);
-}
-
-template <typename T>
 Isometry3<T> PrismaticMobilizer<T>::CalcAcrossMobilizerTransform(
     const MultibodyTreeContext<T>& context) const {
   return Isometry3<T>(

--- a/multibody/tree/prismatic_mobilizer.h
+++ b/multibody/tree/prismatic_mobilizer.h
@@ -104,10 +104,6 @@ class PrismaticMobilizer final : public MobilizerImpl<T, 1, 1> {
   const PrismaticMobilizer<T>& set_translation_rate(
       systems::Context<T> *context, const T& translation_dot) const;
 
-  /// Sets `state` to store a zero translation and translational rate.
-  void set_zero_state(const systems::Context<T>& context,
-                      systems::State<T>* state) const final;
-
   /// Computes the across-mobilizer transform `X_FM(q)` between the inboard
   /// frame F and the outboard frame M as a function of the translation distance
   /// along this mobilizer's axis (see translation_axis().)

--- a/multibody/tree/quaternion_floating_mobilizer.cc
+++ b/multibody/tree/quaternion_floating_mobilizer.cc
@@ -160,12 +160,13 @@ QuaternionFloatingMobilizer<T>::set_translational_velocity(
 }
 
 template <typename T>
-void QuaternionFloatingMobilizer<T>::set_zero_state(
-    const systems::Context<T>& context, systems::State<T>* state) const {
-  set_quaternion(context, Quaternion<T>::Identity(), state);
-  set_position(context, Vector3<T>::Zero(), state);
-  set_angular_velocity(context, Vector3<T>::Zero(), state);
-  set_translational_velocity(context, Vector3<T>::Zero(), state);
+Eigen::Matrix<T, 7, 1> QuaternionFloatingMobilizer<T>::get_zero_position()
+    const {
+  Eigen::Matrix<T, 7, 1> q = Eigen::Matrix<T, 7, 1>::Zero();
+  const Quaternion<T> quaternion = Quaternion<T>::Identity();
+  q[0] = quaternion.w();
+  q.template segment<3>(1) = quaternion.vec();
+  return q;
 }
 
 template <typename T>

--- a/multibody/tree/quaternion_floating_mobilizer.h
+++ b/multibody/tree/quaternion_floating_mobilizer.h
@@ -64,7 +64,7 @@ class QuaternionFloatingMobilizer final : public MobilizerImpl<T, 7, 6> {
   ///   The context storing the state of the MultibodyTree this mobilizer
   ///   belongs to.
   /// @retval q_FM
-  ///   The quaternion representing the orientaiton of frame M in F.
+  ///   The quaternion representing the orientation of frame M in F.
   Quaternion<T> get_quaternion(const systems::Context<T>& context) const;
 
   /// Returns the position `p_FM` of the outboard frame M's origin as measured
@@ -169,12 +169,6 @@ class QuaternionFloatingMobilizer final : public MobilizerImpl<T, 7, 6> {
       const systems::Context<T>&, const Vector3<T>& v_FM,
       systems::State<T>* state) const;
 
-
-  /// Sets `state` to store a configuration in which M coincides with F (i.e.
-  /// q_FM is the identity quaternion) and the spatial velocity V_FM of M in F
-  /// is zero.
-  void set_zero_state(const systems::Context<T>& context,
-                      systems::State<T>* state) const override;
   /// @}
   // End of Doxygen section on methods to get/set from a context.
 
@@ -209,6 +203,10 @@ class QuaternionFloatingMobilizer final : public MobilizerImpl<T, 7, 6> {
   /// @}
 
  protected:
+  /// Sets `state` to store a configuration in which M coincides with F (i.e.
+  /// q_FM is the identity quaternion).
+  Eigen::Matrix<T, 7, 1> get_zero_position() const override;
+
   void DoCalcNMatrix(const MultibodyTreeContext<T>& context,
                      EigenPtr<MatrixX<T>> N) const final;
 

--- a/multibody/tree/revolute_mobilizer.cc
+++ b/multibody/tree/revolute_mobilizer.cc
@@ -53,12 +53,6 @@ const RevoluteMobilizer<T>& RevoluteMobilizer<T>::set_angular_rate(
 }
 
 template <typename T>
-void RevoluteMobilizer<T>::set_zero_state(const systems::Context<T>& context,
-                                          systems::State<T>* state) const {
-  this->set_default_zero_state(context, state);
-}
-
-template <typename T>
 Isometry3<T> RevoluteMobilizer<T>::CalcAcrossMobilizerTransform(
     const MultibodyTreeContext<T>& context) const {
   const auto& q = this->get_positions(context);

--- a/multibody/tree/revolute_mobilizer.h
+++ b/multibody/tree/revolute_mobilizer.h
@@ -107,10 +107,6 @@ class RevoluteMobilizer final : public MobilizerImpl<T, 1, 1> {
   const RevoluteMobilizer<T>& set_angular_rate(
       systems::Context<T> *context, const T& theta_dot) const;
 
-  /// Sets `state` to store a zero angle and angular rate.
-  void set_zero_state(const systems::Context<T>& context,
-                      systems::State<T>* state) const override;
-
   /// Computes the across-mobilizer transform `X_FM(q)` between the inboard
   /// frame F and the outboard frame M as a function of the rotation angle
   /// about this mobilizer's axis (@see revolute_axis().)

--- a/multibody/tree/space_xyz_mobilizer.cc
+++ b/multibody/tree/space_xyz_mobilizer.cc
@@ -71,12 +71,6 @@ const SpaceXYZMobilizer<T>& SpaceXYZMobilizer<T>::set_angular_velocity(
 }
 
 template <typename T>
-void SpaceXYZMobilizer<T>::set_zero_state(const systems::Context<T>& context,
-                                          systems::State<T>* state) const {
-  this->set_default_zero_state(context, state);
-}
-
-template <typename T>
 Isometry3<T> SpaceXYZMobilizer<T>::CalcAcrossMobilizerTransform(
     const MultibodyTreeContext<T>& context) const {
   const Eigen::Matrix<T, 3, 1>& rpy = this->get_positions(context);

--- a/multibody/tree/space_xyz_mobilizer.h
+++ b/multibody/tree/space_xyz_mobilizer.h
@@ -180,11 +180,6 @@ class SpaceXYZMobilizer final : public MobilizerImpl<T, 3, 3> {
       const systems::Context<T>& context, const Vector3<T>& w_FM,
       systems::State<T>* state) const;
 
-  /// Sets `state` to store zero space x-y-z angles θ₁, θ₂, θ₃ and zero across
-  /// mobilizer angular velocity `w_FM`.
-  void set_zero_state(const systems::Context<T>& context,
-                      systems::State<T>* state) const override;
-
   /// Computes the across-mobilizer transform `X_FM(q)` between the inboard
   /// frame F and the outboard frame M as a function of the space x-y-z angles
   /// θ₁, θ₂, θ₃ stored in `context`.

--- a/multibody/tree/test/articulated_body_algorithm_test.cc
+++ b/multibody/tree/test/articulated_body_algorithm_test.cc
@@ -41,12 +41,6 @@ class FeatherstoneMobilizer final : public MobilizerImpl<T, 2, 2> {
              0, 0;
   }
 
-  void set_zero_state(
-      const systems::Context<T>& context,
-      systems::State<T>* state) const override {
-    this->set_default_zero_state(context, state);
-  }
-
   const FeatherstoneMobilizer<T>& set_angles(
       systems::Context<T>* context,
       const Vector2<T>& angles) const {

--- a/multibody/tree/weld_mobilizer.cc
+++ b/multibody/tree/weld_mobilizer.cc
@@ -10,10 +10,6 @@ namespace multibody {
 namespace internal {
 
 template <typename T>
-void WeldMobilizer<T>::set_zero_state(const systems::Context<T>&,
-                                      systems::State<T>*) const {}
-
-template <typename T>
 Isometry3<T> WeldMobilizer<T>::CalcAcrossMobilizerTransform(
     const MultibodyTreeContext<T>&) const { return X_FM_.cast<T>(); }
 

--- a/multibody/tree/weld_mobilizer.h
+++ b/multibody/tree/weld_mobilizer.h
@@ -46,11 +46,6 @@ class WeldMobilizer final : public MobilizerImpl<T, 0, 0> {
   /// @retval X_FM The pose of the outboard frame M in the inboard frame F.
   const Isometry3<double>& get_X_FM() const { return X_FM_; }
 
-  /// This override is a no-op for this mobilizer since it has no state
-  /// associated with it.
-  void set_zero_state(const systems::Context<T>& context,
-                      systems::State<T>* state) const final;
-
   /// Computes the across-mobilizer transform `X_FM`, which for this mobilizer
   /// is independent of the state stored in `context`.
   Isometry3<T> CalcAcrossMobilizerTransform(


### PR DESCRIPTION
subclasses should not have to implement anything to get the default behavior.
Also moved the work of setting the non-zero quaternion to a `get_zero_position` method, because I need to be able to access it without making a context for the `SetRandomContext` use case that i'm building up to.

once again, this is purely a backend cleanup.  no functional changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10313)
<!-- Reviewable:end -->
