### PR TITLE
Adds the missing template overload for declaring a typed vector of fixed size.

### DIFF
--- a/common/eigen_types.h
+++ b/common/eigen_types.h
@@ -41,6 +41,10 @@ using Vector4 = Eigen::Matrix<Scalar, 4, 1>;
 template <typename Scalar>
 using Vector6 = Eigen::Matrix<Scalar, 6, 1>;
 
+/// A column vector templated on the number of rows.
+template <typename Scalar, int Rows>
+using Vector = Eigen::Matrix<Scalar, Rows, 1>;
+
 /// A column vector of any size, templated on scalar type.
 template <typename Scalar>
 using VectorX = Eigen::Matrix<Scalar, Eigen::Dynamic, 1>;
@@ -65,6 +69,10 @@ using RowVector4 = Eigen::Matrix<Scalar, 1, 4>;
 /// A row vector of size 6.
 template <typename Scalar>
 using RowVector6 = Eigen::Matrix<Scalar, 1, 6>;
+
+/// A row vector templated on the number of columns.
+template <typename Scalar, int Cols>
+using RowVector = Eigen::Matrix<Scalar, 1, Cols>;
 
 /// A row vector of any size, templated on scalar type.
 template <typename Scalar>

--- a/common/test/eigen_types_test.cc
+++ b/common/test/eigen_types_test.cc
@@ -209,5 +209,15 @@ GTEST_TEST(EigenTypesTest, EigenPtr_Assignment) {
   EXPECT_FALSE(mutable_ptr);
 }
 
+GTEST_TEST(EigenTypesTest, FixedSizeVector) {
+  Vector<double, 2> col;
+  EXPECT_EQ(col.rows(), 2);
+  EXPECT_EQ(col.cols(), 1);
+
+  RowVector<double, 2> row;
+  EXPECT_EQ(row.rows(), 1);
+  EXPECT_EQ(row.cols(), 2);
+}
+
 }  // namespace
 }  // namespace drake


### PR DESCRIPTION
(Previously we had to abort to e.g., Eigen::Matrix<T,Rows,1>)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10316)
<!-- Reviewable:end -->
