### PR TITLE
Add sugar for event declarations

### DIFF
--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -439,22 +439,26 @@ struct Impl {
                 .DeclareVectorOutputPort
                 // NOLINTNEXTLINE(whitespace/line_length)
                 .doc_4args_name_model_vector_vector_calc_function_prerequisites_of_calc)
-        .def("_DeclarePeriodicPublish", &PyLeafSystem::DeclarePeriodicPublish,
-            py::arg("period_sec"), py::arg("offset_sec") = 0.,
-            doc.LeafSystem.DeclarePeriodicPublish.doc)
         .def("_DeclareInitializationEvent",
             [](PyLeafSystem* self, const Event<T>& event) {
               self->DeclareInitializationEvent(event);
             },
             py::arg("event"), doc.LeafSystem.DeclareInitializationEvent.doc)
-        // Binding the *second* signature; first has no Event argument.
+        .def("_DeclarePeriodicPublish",
+            &LeafSystemPublic::DeclarePeriodicPublish, py::arg("period_sec"),
+            py::arg("offset_sec") = 0.,
+            doc.LeafSystem.DeclarePeriodicPublish.doc)
+        .def("_DeclarePeriodicDiscreteUpdate",
+            &LeafSystemPublic::DeclarePeriodicDiscreteUpdate,
+            py::arg("period_sec"), py::arg("offset_sec") = 0.,
+            doc.LeafSystem.DeclarePeriodicDiscreteUpdate.doc)
         .def("_DeclarePeriodicEvent",
             [](PyLeafSystem* self, double period_sec, double offset_sec,
                 const Event<T>& event) {
               self->DeclarePeriodicEvent(period_sec, offset_sec, event);
             },
             py::arg("period_sec"), py::arg("offset_sec"), py::arg("event"),
-            doc.LeafSystem.DeclarePeriodicEvent.doc_3args)
+            doc.LeafSystem.DeclarePeriodicEvent.doc)
         .def("_DeclarePerStepEvent",
             [](PyLeafSystem* self, const Event<T>& event) {
               self->DeclarePerStepEvent(event);
@@ -505,10 +509,6 @@ struct Impl {
             py::overload_cast<int>(&LeafSystemPublic::DeclareDiscreteState),
             py::arg("num_state_variables"),
             doc.LeafSystem.DeclareDiscreteState.doc_1args_num_state_variables)
-        .def("_DeclarePeriodicDiscreteUpdate",
-            &LeafSystemPublic::DeclarePeriodicDiscreteUpdate,
-            py::arg("period_sec"), py::arg("offset_sec") = 0.,
-            doc.LeafSystem.DeclarePeriodicDiscreteUpdate.doc)
         .def("_DoCalcTimeDerivatives", &LeafSystemPublic::DoCalcTimeDerivatives)
         .def("_DoCalcDiscreteVariableUpdates",
             &LeafSystemPublic::DoCalcDiscreteVariableUpdates,

--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -163,6 +163,7 @@ drake_cc_library(
     hdrs = [
         "event.h",
         "event_collection.h",
+        "event_status.h",
     ],
     deps = [
         ":abstract_values",
@@ -697,6 +698,13 @@ drake_cc_googletest(
     deps = [
         ":context_base",
         "//common",
+    ],
+)
+
+drake_cc_googletest(
+    name = "event_status_test",
+    deps = [
+        ":event_collection",
     ],
 )
 

--- a/systems/framework/event.h
+++ b/systems/framework/event.h
@@ -7,6 +7,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/continuous_state.h"
+#include "drake/systems/framework/event_status.h"
 #include "drake/systems/framework/value.h"
 
 namespace drake {
@@ -323,7 +324,7 @@ class Event {
 
   // Note: Users should not be calling this.
   #if !defined(DRAKE_DOXYGEN_CXX)
-  /// Constructs an Event with the specified @p trigger.
+  // Constructs an Event with the specified @p trigger.
   explicit Event(const TriggerType& trigger) : trigger_type_(trigger) {}
   #endif
 
@@ -346,8 +347,10 @@ class Event {
   std::unique_ptr<EventData> event_data_{nullptr};
 };
 
-/// Structure for comparing two PeriodicEventData objects for use in a map
-/// container, using an arbitrary comparison method.
+/**
+ * Structure for comparing two PeriodicEventData objects for use in a map
+ * container, using an arbitrary comparison method.
+ */
 struct PeriodicEventDataComparator {
   bool operator()(const PeriodicEventData& a,
     const PeriodicEventData& b) const {

--- a/systems/framework/event_status.h
+++ b/systems/framework/event_status.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <string>
+#include <utility>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
+
+namespace drake {
+namespace systems {
+
+class SystemBase;
+
+/** Holds the return status from execution of an event handler function, or the
+effective status after a series of handler executions due to dispatching of
+simultaneous events. Drake API users will typically use only the four factory
+methods below to return status, and optionally a human-readable message, from
+their event handlers. */
+
+// TODO(sherm1) Add the following text to the above doxygen comment when
+// EventStatus is propagated up from the handlers.
+/* (Advanced) In case you are writing an event dispatcher (that is, you are
+overriding LeafSystem::DoPublish(), LeafSystem::DoCalcDiscreteVariableUpdates(),
+or LeafSystem::DoCalcUnrestrictedUpdate()), the dispatcher's return
+status should be the returned status of highest severity in a series of event
+handlers invoked for simultaneous events. In case of multiple returns at the
+same severity, the first one should win. Simultaneous event handler dispatching
+should only return early (without processing all events), if an event handler
+returns EventStatus::kFailed. */
+class EventStatus {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(EventStatus)
+
+  /** The numerical values are ordered, with
+  did_nothing < success < terminate < fatal. */
+  enum Severity {
+    /** Successful, but nothing happened; no state update needed. */
+    kDidNothing = 0,
+    /** Handler executed successfully; state may have been updated. */
+    kSucceeded = 1,
+    /** Handler succeeded but detected a termination condition (has message). */
+    kReachedTermination = 2,
+    /** Handler was unable to perform its job (has message). */
+    kFailed = 3
+  };
+
+  /** Returns "did nothing" status, with no message. */
+  static EventStatus DidNothing() { return EventStatus(kDidNothing); }
+
+  /** Returns "succeeded" status, with no message. */
+  static EventStatus Succeeded() { return EventStatus(kSucceeded); }
+
+  /** Returns "reached termination" status, with a message explaining why. */
+  static EventStatus ReachedTermination(const SystemBase* system,
+                                        std::string message) {
+    return EventStatus(kReachedTermination, system, std::move(message));
+  }
+
+  /** Returns "failed" status, with a message explaining why. */
+  static EventStatus Failed(const SystemBase* system, std::string message) {
+    return EventStatus(kFailed, system, std::move(message));
+  }
+
+  /** Returns the severity of the current status. */
+  Severity severity() const { return severity_; }
+
+  /** Returns the optionally-provided subsystem that generated a status
+  return that can include a message (reached termination or failed). Returns
+  nullptr if no subsystem was provided. */
+  const SystemBase* system() const { return system_; }
+
+  /** Returns the optionally-provided human-readable message supplied by the
+  event handler that produced the current status. Returns an empty string if
+  no message was provided. */
+  const std::string& message() const { return message_; }
+
+  /** (Advanced) Replaces the contents of `this` with the more-severe status
+  if `candidate` is a more severe status than `this` one. Does nothing if
+  `candidate` severity is less than or equal to `this` severity. This method is
+  for use in event dispatchers for accumulating status returns from a series of
+  event handlers for a set of simultaneous events. */
+  EventStatus& KeepMoreSevere(EventStatus candidate) {
+    if (candidate.severity() > severity()) *this = candidate;
+    return *this;
+  }
+
+ private:
+  explicit EventStatus(Severity severity) : severity_(severity) {}
+  EventStatus(Severity severity, const SystemBase* system, std::string message)
+      : severity_(severity), system_(system), message_(std::move(message)) {}
+
+  Severity severity_{kFailed};
+  const SystemBase* system_{nullptr};
+  std::string message_;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -369,7 +369,10 @@ class LeafSystem : public System<T> {
 
   /// Computes the next update time based on the configured periodic events, for
   /// scalar types that are arithmetic, or aborts for scalar types that are not
-  /// arithmetic. Subclasses that require aperiodic events should override.
+  /// arithmetic. Subclasses that require aperiodic events should override, but
+  /// be sure to invoke the parent class implementation at the start of the
+  /// override if you want periodic events to continue to be handled.
+  ///
   /// @post `time` is set to a value greater than or equal to
   ///       `context.get_time()` on return.
   /// @warning If you override this method, think carefully before setting
@@ -381,9 +384,8 @@ class LeafSystem : public System<T> {
                             CompositeEventCollection<T>* events,
                             T* time) const override {
     T min_time = std::numeric_limits<double>::infinity();
-    // No periodic events.
+
     if (periodic_events_.empty()) {
-      // No discrete update.
       *time = min_time;
       return;
     }
@@ -392,11 +394,10 @@ class LeafSystem : public System<T> {
     // the set of registered events that will occur at that time.
     std::vector<const Event<T>*> next_events;
     for (const auto& event_pair : periodic_events_) {
-      const PeriodicEventData& event_data =
-          event_pair.first;
+      const PeriodicEventData& event_data = event_pair.first;
       const Event<T>* const event = event_pair.second.get();
-      const T t = leaf_system_detail::GetNextSampleTime(
-          event_data, context.get_time());
+      const T t =
+          leaf_system_detail::GetNextSampleTime(event_data, context.get_time());
       if (t < min_time) {
         min_time = t;
         next_events = {event};
@@ -634,50 +635,179 @@ class LeafSystem : public System<T> {
     return index;
   }
 
-  /// Declares that this System has a simple, fixed-period event specified with
-  /// no custom callback function, and its attribute field contains an
-  /// Event<T>::PeriodicAttribute constructed from the specified @p period_sec
-  /// and @p offset_sec. The first tick will occur at t = @p offset_sec, and it
-  /// will recur at every @p period_sec thereafter. Note that the periodic
-  /// events returned by system::CalcNextUpdateTime() will happen at a time
-  /// strictly after the querying time. E.g. if there is a periodic event with
-  /// offset = 0 and period = 5, when calling CalcNextUpdateTime() at t = 0,
-  /// the returned event will happen at t = 5 not t = 0.
+  // =========================================================================
+  /// @anchor declare_periodic_events
+  /// @name                  Declare periodic events
+  /// Methods in the this group declare that this System has an event that
+  /// is triggered periodically. The first periodic trigger will occur at
+  /// t = `offset_sec`, and it will recur at every `period_sec` thereafter.
+  /// Several signatures are provided to allow for a general Event object to be
+  /// triggered or for simpler class member functions to be invoked instead.
   ///
-  /// @tparam EventType A class derived from Event (e.g., PublishEvent,
-  /// DiscreteUpdateEvent, UnrestrictedUpdateEvent, etc.)
-  template <typename EventType>
-  void DeclarePeriodicEvent(double period_sec, double offset_sec) {
-    static_assert(std::is_base_of<Event<T>, EventType>::value,
-                  "EventType must be a subclass of Event<T>.");
-    EventType event(TriggerType::kPeriodic);
-    PeriodicEventData periodic_data;
-    periodic_data.set_period_sec(period_sec);
-    periodic_data.set_offset_sec(offset_sec);
-    event.set_event_data(std::make_unique<PeriodicEventData>(periodic_data));
-    periodic_events_.push_back(std::make_pair(periodic_data, event.Clone()));
+  /// Reaching a designated time causes a periodic event to be dispatched
+  /// to one of the three available types of event dispatcher: publish (read
+  /// only), discrete update, and unrestricted update.
+  ///
+  /// @note If you want to generate timed events that are _not_ periodic
+  /// (timers, alarms, etc.), overload DoCalcNextUpdateTime() rather than using
+  /// the methods in this section.
+  ///
+  /// Template arguments to these methods are inferred from the argument lists
+  /// and need not be specified explicitly.
+  /// @pre `period_sec` > 0 and `offset_sec` ≥ 0.
+  //@{
+
+  /// Declares that a Publish event should occur periodically and that it should
+  /// invoke the given event handler method. The handler should be a class
+  /// member function (method) with this signature:
+  /// @code
+  ///   EventStatus MySystem::MyPublish(const Context<T>&) const;
+  /// @endcode
+  /// where `MySystem` is a class derived from `LeafSystem<T>` and the method
+  /// name is arbitrary.
+  ///
+  /// See @ref declare_periodic_events "Declare periodic events" for more
+  /// information.
+  ///
+  /// @pre `this` must be dynamic_cast-able to MySystem.
+  /// @pre `publish` must not be null.
+  ///
+  /// @see DeclarePeriodicDiscreteUpdateEvent()
+  /// @see DeclarePeriodicUnrestrictedUpdateEvent()
+  /// @see DeclarePeriodicEvent()
+  template <class MySystem>
+  void DeclarePeriodicPublishEvent(
+      double period_sec, double offset_sec,
+      EventStatus (MySystem::*publish)(const Context<T>&) const) {
+    static_assert(std::is_base_of<LeafSystem<T>, MySystem>::value,
+                  "Expected to be invoked from a LeafSystem-derived System.");
+    auto this_ptr = dynamic_cast<const MySystem*>(this);
+    DRAKE_DEMAND(this_ptr != nullptr);
+    DRAKE_DEMAND(publish != nullptr);
+
+    DeclarePeriodicEvent(
+        period_sec, offset_sec,
+        PublishEvent<T>(TriggerType::kPeriodic, [this_ptr, publish](
+                                                    const Context<T>& context,
+                                                    const PublishEvent<T>&) {
+          // TODO(sherm1) Forward the return status.
+          (this_ptr->*publish)(context);  // Ignore return status for now.
+        }));
   }
 
-  /// Declares that this System has a simple, fixed-period event specified by
-  /// @p event. The first tick will occur at t = @p offset_sec, and it
-  /// will recur at every @p period_sec thereafter. Note that the periodic
-  /// events returned by system::CalcNextUpdateTime() will happen at a time
-  /// strictly after the querying time. E.g. if there is a periodic event with
-  /// offset = 0 and period = 5, when calling CalcNextUpdateTime() at t = 0,
-  /// the returned event will happen at t = 5 not t = 0.
+  /// Declares that a DiscreteUpdate event should occur periodically and that it
+  /// should invoke the given event handler method. The handler should be a
+  /// class member function (method) with this signature:
+  /// @code
+  ///   EventStatus MySystem::MyUpdate(const Context<T>&,
+  ///                                  DiscreteValues<T>*) const;
+  /// @endcode
+  /// where `MySystem` is a class derived from `LeafSystem<T>` and the method
+  /// name is arbitrary.
   ///
-  /// A deep copy of @p event will be made and maintained by `this`. The
-  /// trigger type in the clone will be set to kPeriodic, unless it is already
-  /// set in the source @p event in which case it must be kPeriodic already.
-  /// The @p event's attribute field is preserved.
+  /// See @ref declare_periodic_events "Declare periodic events" for more
+  /// information.
   ///
-  /// @tparam EventType A class derived from Event (e.g., PublishEvent,
-  /// DiscreteUpdateEvent, UnrestrictedUpdateEvent, etc.)
+  /// @pre `this` must be dynamic_cast-able to MySystem.
+  /// @pre `update` must not be null.
+  ///
+  /// @see DeclarePeriodicPublishEvent()
+  /// @see DeclarePeriodicUnrestrictedUpdateEvent()
+  /// @see DeclarePeriodicEvent()
+  template <class MySystem>
+  void DeclarePeriodicDiscreteUpdateEvent(
+      double period_sec, double offset_sec,
+      EventStatus (MySystem::*update)(const Context<T>&, DiscreteValues<T>*)
+          const) {
+    static_assert(std::is_base_of<LeafSystem<T>, MySystem>::value,
+                  "Expected to be invoked from a LeafSystem-derived System.");
+    auto this_ptr = dynamic_cast<const MySystem*>(this);
+    DRAKE_DEMAND(this_ptr != nullptr);
+    DRAKE_DEMAND(update != nullptr);
+
+    DeclarePeriodicEvent(
+        period_sec, offset_sec,
+        DiscreteUpdateEvent<T>(TriggerType::kPeriodic,
+                               [this_ptr, update](const Context<T>& context,
+                                                  const DiscreteUpdateEvent<T>&,
+                                                  DiscreteValues<T>* xd) {
+                                 // TODO(sherm1) Forward the return status.
+                                 (this_ptr->*update)(
+                                     context,
+                                     &*xd);  // Ignore return status for now.
+                               }));
+  }
+
+  /// Declares that an UnrestrictedUpdate event should occur periodically and
+  /// that it should invoke the given event handler method. The handler should
+  /// be a class member function (method) with this signature:
+  /// @code
+  ///   EventStatus MySystem::MyUpdate(const Context<T>&,
+  ///                                  State<T>*) const;
+  /// @endcode
+  /// where `MySystem` is a class derived from `LeafSystem<T>` and the method
+  /// name is arbitrary.
+  ///
+  /// See @ref declare_periodic_events "Declare periodic events" for more
+  /// information.
+  ///
+  /// @pre `this` must be dynamic_cast-able to MySystem.
+  /// @pre `update` must not be null.
+  ///
+  /// @see DeclarePeriodicPublishEvent()
+  /// @see DeclarePeriodicDiscreteUpdateEvent()
+  /// @see DeclarePeriodicEvent()
+  template <class MySystem>
+  void DeclarePeriodicUnrestrictedUpdateEvent(
+      double period_sec, double offset_sec,
+      EventStatus (MySystem::*update)(const Context<T>&, State<T>*) const) {
+    static_assert(std::is_base_of<LeafSystem<T>, MySystem>::value,
+                  "Expected to be invoked from a LeafSystem-derived System.");
+    auto this_ptr = dynamic_cast<const MySystem*>(this);
+    DRAKE_DEMAND(this_ptr != nullptr);
+    DRAKE_DEMAND(update != nullptr);
+
+    DeclarePeriodicEvent(
+        period_sec, offset_sec,
+        UnrestrictedUpdateEvent<T>(
+            TriggerType::kPeriodic,
+            [this_ptr, update](const Context<T>& context,
+                               const UnrestrictedUpdateEvent<T>&, State<T>* x) {
+              // TODO(sherm1) Forward the return status.
+              (this_ptr->*update)(context,
+                                  &*x);  // Ignore return status for now.
+            }));
+  }
+
+  /// (Advanced) Declares that a particular Event object should be dispatched
+  /// periodically. This is the most general form for declaring periodic events
+  /// and most users should use one of the other methods in this group instead.
+  ///
+  /// @see DeclarePeriodicPublishEvent()
+  /// @see DeclarePeriodicDiscreteUpdateEvent()
+  /// @see DeclarePeriodicUnrestrictedUpdateEvent()
+  ///
+  /// See @ref declare_periodic_events "Declare periodic events" for more
+  /// information.
+  ///
+  /// Depending on the type of `event`, when triggered it will be passed to
+  /// the Publish, DiscreteUpdate, or UnrestrictedUpdate event dispatcher. If
+  /// the `event` object contains a handler function, Drake's default
+  /// dispatchers will invoke that handler. If not, then no further action is
+  /// taken. Thus an `event` with no handler has no effect unless its dispatcher
+  /// has been overridden. We strongly recommend that you _do not_ override the
+  /// dispatcher and instead _do_ supply a handler.
+  ///
+  /// The given `event` object is deep-copied (cloned), and the copy is stored
+  /// internally so you do not need to keep the object around after this call.
+  ///
+  /// @pre `event`'s associated trigger type must be TriggerType::kUnknown or
+  /// already set to TriggerType::kPeriodic.
   template <typename EventType>
   void DeclarePeriodicEvent(double period_sec, double offset_sec,
                             const EventType& event) {
     DRAKE_DEMAND(event.get_trigger_type() == TriggerType::kUnknown ||
-                 event.get_trigger_type() == TriggerType::kPeriodic);
+        event.get_trigger_type() == TriggerType::kPeriodic);
     PeriodicEventData periodic_data;
     periodic_data.set_period_sec(period_sec);
     periodic_data.set_offset_sec(offset_sec);
@@ -687,54 +817,382 @@ class LeafSystem : public System<T> {
         std::make_pair(periodic_data, std::move(event_copy)));
   }
 
-  /// Declares a periodic discrete update event with period = @p period_sec and
-  /// offset = @p offset_sec. The event does not have a custom callback
-  /// function, and its trigger will be set to Event::TriggerType::kPeriodic.
-  /// Its attribute will be an Event<T>::PeriodicAttribute of @p offset_sec and
-  /// @p period_sec. Authors are encouraged to read @ref discrete_systems for
-  /// implications of mixing discrete and continuous systems.
-  void DeclarePeriodicDiscreteUpdate(double period_sec, double offset_sec = 0) {
-    DeclarePeriodicEvent<DiscreteUpdateEvent<T>>(period_sec, offset_sec);
+  /// (To be deprecated) Declares a periodic publish event that invokes the
+  /// Publish() dispatcher but does not provide a handler function. This does
+  /// guarantee that a Simulator step will end exactly at the publish time,
+  /// but otherwise has no effect unless the DoPublish() dispatcher has been
+  /// overloaded (not recommended).
+  void DeclarePeriodicPublish(double period_sec, double offset_sec = 0) {
+    DeclarePeriodicEvent(period_sec, offset_sec, PublishEvent<T>());
   }
 
-  /// Declares a periodic unrestricted update event with period = @p period_sec
-  /// and offset = @p offset_sec. The event does not have a custom callback
-  /// function, and its trigger will be set to Event::TriggerType::kPeriodic.
-  /// Its attribute will be an Event<T>::PeriodicAttribute of @p offset_sec and
-  /// @p period_sec.
+  /// (To be deprecated) Declares a periodic discrete update event that invokes
+  /// the DiscreteUpdate() dispatcher but does not provide a handler
+  /// function. This does guarantee that a Simulator step will end exactly at
+  /// the update time, but otherwise has no effect unless the
+  /// DoDiscreteUpdate() dispatcher has been overloaded (not recommended).
+  void DeclarePeriodicDiscreteUpdate(double period_sec, double offset_sec = 0) {
+    DeclarePeriodicEvent(period_sec, offset_sec, DiscreteUpdateEvent<T>());
+  }
+
+  /// (To be deprecated) Declares a periodic unrestricted update event that
+  /// invokes the UnrestrictedUpdate() dispatcher but does not provide a handler
+  /// function. This does guarantee that a Simulator step will end exactly at
+  /// the update time, but otherwise has no effect unless the
+  /// DoUnrestrictedUpdate() dispatcher has been overloaded (not recommended).
   void DeclarePeriodicUnrestrictedUpdate(double period_sec,
                                          double offset_sec = 0) {
-    DeclarePeriodicEvent<UnrestrictedUpdateEvent<T>>(period_sec, offset_sec);
+    DeclarePeriodicEvent(period_sec, offset_sec, UnrestrictedUpdateEvent<T>());
+  }
+  //@}
+
+  // =========================================================================
+  /// @anchor declare_per-step_events
+  /// @name                 Declare per-step events
+  /// These methods are used to declare events that are triggered whenever the
+  /// Drake Simulator::StepTo() method takes a substep that advances the
+  /// simulated trajectory. Note that each call to StepTo() typically generates
+  /// many trajectory-advancing substeps of varying time intervals; per-step
+  /// events are triggered for each of those substeps.
+  ///
+  /// Per-step events are useful for taking discrete action at every point of a
+  /// simulated trajectory (generally spaced irregularly in time) without
+  /// missing anything. For example, per-step events can be used to implement
+  /// a high-accuracy signal delay by maintaining a buffer of past signal
+  /// values, updated at each step. Because the steps are smaller in regions
+  /// of rapid change, the interpolated signal retains the accuracy provided
+  /// by the denser sampling. A periodic sampling would produce less-accurate
+  /// interpolations.
+  ///
+  /// As with any Drake event trigger type, a per-step event is
+  /// dispatched to one of the three available types of event dispatcher:
+  /// publish (read only), discrete state update, and unrestricted state update.
+  /// Several signatures are provided below to allow for a general Event object
+  /// to be triggered, or simpler class member functions to be invoked instead.
+  ///
+  /// Per-step events are issued as follows: First, the Simulator::Initialize()
+  /// method queries and records the set of declared per-step events, which set
+  /// does not change during a simulation. Then every StepTo() internal substep
+  /// dispatches unrestricted and discrete update events at the start of the
+  /// step, and dispatches publish events at the end of the step (that is,
+  /// after time advances). No per-step event is triggered during the
+  /// Initialize() call.
+  ///
+  /// Template arguments to these methods are inferred from the argument lists
+  /// and need not be specified explicitly.
+  //@{
+
+  /// Declares that a Publish event should occur every step and that it should
+  /// invoke the given event handler method. The handler should be a class
+  /// member function (method) with this signature:
+  /// @code
+  ///   EventStatus MySystem::MyPublish(const Context<T>&) const;
+  /// @endcode
+  /// where `MySystem` is a class derived from `LeafSystem<T>` and the method
+  /// name is arbitrary.
+  ///
+  /// See @ref declare_per-step_events "Declare per-step events" for more
+  /// information.
+  ///
+  /// @pre `this` must be dynamic_cast-able to MySystem.
+  /// @pre `publish` must not be null.
+  ///
+  /// @see DeclarePerStepDiscreteUpdateEvent()
+  /// @see DeclarePerStepUnrestrictedUpdateEvent()
+  /// @see DeclarePerStepEvent()
+  template <class MySystem>
+  void DeclarePerStepPublishEvent(
+      EventStatus (MySystem::*publish)(const Context<T>&) const) {
+    static_assert(std::is_base_of<LeafSystem<T>, MySystem>::value,
+                  "Expected to be invoked from a LeafSystem-derived System.");
+    auto this_ptr = dynamic_cast<const MySystem*>(this);
+    DRAKE_DEMAND(this_ptr != nullptr);
+    DRAKE_DEMAND(publish != nullptr);
+
+    DeclarePerStepEvent<PublishEvent<T>>(PublishEvent<T>(
+        TriggerType::kPerStep,
+        [this_ptr, publish](const Context<T>& context, const PublishEvent<T>&) {
+          // TODO(sherm1) Forward the return status.
+          (this_ptr->*publish)(context);  // Ignore return status for now.
+        }));
   }
 
-  /// Declares a periodic publish event with period = @p period_sec
-  /// and offset = @p offset_sec. The event does not have a custom callback
-  /// function, and its trigger will be set to Event::TriggerType::kPeriodic.
-  /// Its attribute will be an Event<T>::PeriodicAttribute of @p offset_sec and
-  /// @p period_sec.
-  void DeclarePeriodicPublish(double period_sec, double offset_sec = 0) {
-    DeclarePeriodicEvent<PublishEvent<T>>(period_sec, offset_sec);
+  /// Declares that a DiscreteUpdate event should occur every step and that it
+  /// should invoke the given event handler method. The handler should be a
+  /// class member function (method) with this signature:
+  /// @code
+  ///   EventStatus MySystem::MyUpdate(const Context<T>&,
+  ///                                  DiscreteValues<T>*) const;
+  /// @endcode
+  /// where `MySystem` is a class derived from `LeafSystem<T>` and the method
+  /// name is arbitrary.
+  ///
+  /// See @ref declare_per-step_events "Declare per-step events" for more
+  /// information.
+  ///
+  /// @pre `this` must be dynamic_cast-able to MySystem.
+  /// @pre `update` must not be null.
+  ///
+  /// @see DeclarePerStepPublishEvent()
+  /// @see DeclarePerStepUnrestrictedUpdateEvent()
+  /// @see DeclarePerStepEvent()
+  template <class MySystem>
+  void DeclarePerStepDiscreteUpdateEvent(EventStatus (MySystem::*update)(
+      const Context<T>&, DiscreteValues<T>*) const) {
+    static_assert(std::is_base_of<LeafSystem<T>, MySystem>::value,
+                  "Expected to be invoked from a LeafSystem-derived System.");
+    auto this_ptr = dynamic_cast<const MySystem*>(this);
+    DRAKE_DEMAND(this_ptr != nullptr);
+    DRAKE_DEMAND(update != nullptr);
+
+    DeclarePerStepEvent(DiscreteUpdateEvent<T>(
+        TriggerType::kPerStep, [this_ptr, update](const Context<T>& context,
+                                                  const DiscreteUpdateEvent<T>&,
+                                                  DiscreteValues<T>* xd) {
+          // TODO(sherm1) Forward the return status.
+          (this_ptr->*update)(context,
+                              &*xd);  // Ignore return status for now.
+        }));
   }
 
-  /// Declares a per-step event using @p event, which is deep copied (the
-  /// copy is maintained by `this`). @p event's associated trigger type must be
-  /// unknown or already set to Event::TriggerType::kPerStep. Aborts otherwise.
+  /// Declares that an UnrestrictedUpdate event should occur every step and that
+  /// it should invoke the given event handler method. The handler should be a
+  /// class member function (method) with this signature:
+  /// @code
+  ///   EventStatus MySystem::MyUpdate(const Context<T>&,
+  ///                                  State<T>*) const;
+  /// @endcode
+  /// where `MySystem` is a class derived from `LeafSystem<T>` and the method
+  /// name is arbitrary.
+  ///
+  /// See @ref declare_per-step_events "Declare per-step events" for more
+  /// information.
+  ///
+  /// @pre `this` must be dynamic_cast-able to MySystem.
+  /// @pre `update` must not be null.
+  ///
+  /// @see DeclarePerStepPublishEvent()
+  /// @see DeclarePerStepDiscreteUpdateEvent()
+  /// @see DeclarePerStepEvent()
+  template <class MySystem>
+  void DeclarePerStepUnrestrictedUpdateEvent(
+      EventStatus (MySystem::*update)(const Context<T>&, State<T>*) const) {
+    static_assert(std::is_base_of<LeafSystem<T>, MySystem>::value,
+                  "Expected to be invoked from a LeafSystem-derived System.");
+    auto this_ptr = dynamic_cast<const MySystem*>(this);
+    DRAKE_DEMAND(this_ptr != nullptr);
+    DRAKE_DEMAND(update != nullptr);
+
+    DeclarePerStepEvent(UnrestrictedUpdateEvent<T>(
+        TriggerType::kPerStep,
+        [this_ptr, update](const Context<T>& context,
+                           const UnrestrictedUpdateEvent<T>&, State<T>* x) {
+          // TODO(sherm1) Forward the return status.
+          (this_ptr->*update)(context,
+                              &*x);  // Ignore return status for now.
+        }));
+  }
+
+  /// (Advanced) Declares that a particular Event object should be dispatched at
+  /// every simulation step. This is the most general form for declaring
+  /// per-step events and most users should use one of the other methods in this
+  /// group instead.
+  ///
+  /// @see DeclarePerStepPublishEvent()
+  /// @see DeclarePerStepDiscreteUpdateEvent()
+  /// @see DeclarePerStepUnrestrictedUpdateEvent()
+  ///
+  /// See @ref declare_per-step_events "Declare per-step events" for more
+  /// information.
+  ///
+  /// Depending on the type of `event`, at each step it will be passed to
+  /// the Publish, DiscreteUpdate, or UnrestrictedUpdate event dispatcher. If
+  /// the `event` object contains a handler function, Drake's default
+  /// dispatchers will invoke that handler. If not, then no further action is
+  /// taken. Thus an `event` with no handler has no effect unless its dispatcher
+  /// has been overridden. We strongly recommend that you _do not_ override the
+  /// dispatcher and instead _do_ supply a handler.
+  ///
+  /// The given `event` object is deep-copied (cloned), and the copy is stored
+  /// internally so you do not need to keep the object around after this call.
+  ///
+  /// @pre `event`'s associated trigger type must be TriggerType::kUnknown or
+  /// already set to TriggerType::kPerStep.
   template <typename EventType>
   void DeclarePerStepEvent(const EventType& event) {
     DRAKE_DEMAND(event.get_trigger_type() == TriggerType::kUnknown ||
         event.get_trigger_type() == TriggerType::kPerStep);
     event.AddToComposite(TriggerType::kPerStep, &per_step_events_);
   }
+  //@}
 
-  /// Declares an initialization event by deep copying @p event and storing it
-  /// internally. @p event's associated trigger type must be unknown or already
-  /// set to Event::TriggerType::kInitialization. Aborts otherwise.
+  // =========================================================================
+  /// @anchor declare_initialization_events
+  /// @name                 Declare initialization events
+  /// These methods are used to declare events that occur when the Drake
+  /// Simulator::Initialize() method is invoked.
+  ///
+  /// During initialization, unrestricted update events are performed first for
+  /// the whole Diagram, then discrete update events for the whole Diagram.
+  /// Timed update events are not performed during initialization, even if they
+  /// are scheduled for the initial time; in that case they are done at the
+  /// beginning of the first Simulator::StepTo() call. On the other hand,
+  /// initialization publish events and timed publish events that are scheduled
+  /// for the initial time are dispatched together during initialization.
+  /// They are ordered such that each subsystem sees its initialization publish
+  /// events before its timed publish events.
+  ///
+  /// Template arguments to these methods are inferred from the argument lists
+  /// and need not be specified explicitly.
+  //@{
+
+  /// Declares that a Publish event should occur at initialization and that it
+  /// should invoke the given event handler method. The handler should be a
+  /// class member function (method) with this signature:
+  /// @code
+  ///   EventStatus MySystem::MyPublish(const Context<T>&) const;
+  /// @endcode
+  /// where `MySystem` is a class derived from `LeafSystem<T>` and the method
+  /// name is arbitrary.
+  ///
+  /// See @ref declare_initialization_events "Declare initialization events" for
+  /// more information.
+  ///
+  /// @pre `this` must be dynamic_cast-able to MySystem.
+  /// @pre `publish` must not be null.
+  ///
+  /// @see DeclareInitializationDiscreteUpdateEvent()
+  /// @see DeclareInitializationUnrestrictedUpdateEvent()
+  /// @see DeclareInitializationEvent()
+  template <class MySystem>
+  void DeclareInitializationPublishEvent(
+      EventStatus(MySystem::*publish)(const Context<T>&) const) {
+    static_assert(std::is_base_of<LeafSystem<T>, MySystem>::value,
+                  "Expected to be invoked from a LeafSystem-derived System.");
+    auto this_ptr = dynamic_cast<const MySystem*>(this);
+    DRAKE_DEMAND(this_ptr != nullptr);
+    DRAKE_DEMAND(publish != nullptr);
+
+    DeclareInitializationEvent<PublishEvent<T>>(PublishEvent<T>(
+        TriggerType::kInitialization,
+        [this_ptr, publish](const Context<T>& context,
+                            const PublishEvent<T>&) {
+          // TODO(sherm1) Forward the return status.
+          (this_ptr->*publish)(context);  // Ignore return status for now.
+        }));
+  }
+
+  /// Declares that a DiscreteUpdate event should occur at initialization
+  /// and that it should invoke the given event handler method. The handler
+  /// should be a class member function (method) with this signature:
+  /// @code
+  ///   EventStatus MySystem::MyUpdate(const Context<T>&,
+  ///                                  DiscreteValues<T>*) const;
+  /// @endcode
+  /// where `MySystem` is a class derived from `LeafSystem<T>` and the method
+  /// name is arbitrary.
+  ///
+  /// See @ref declare_initialization_events "Declare initialization events" for
+  /// more information.
+  ///
+  /// @pre `this` must be dynamic_cast-able to MySystem.
+  /// @pre `update` must not be null.
+  ///
+  /// @see DeclareInitializationPublishEvent()
+  /// @see DeclareInitializationUnrestrictedUpdateEvent()
+  /// @see DeclareInitializationEvent()
+  template <class MySystem>
+  void DeclareInitializationDiscreteUpdateEvent(
+      EventStatus(MySystem::*update)
+          (const Context<T>&, DiscreteValues<T>*) const) {
+    static_assert(std::is_base_of<LeafSystem<T>, MySystem>::value,
+                  "Expected to be invoked from a LeafSystem-derived System.");
+    auto this_ptr = dynamic_cast<const MySystem*>(this);
+    DRAKE_DEMAND(this_ptr != nullptr);
+    DRAKE_DEMAND(update != nullptr);
+
+    DeclareInitializationEvent(DiscreteUpdateEvent<T>(
+        TriggerType::kInitialization,
+        [this_ptr, update](const Context<T>& context,
+                           const DiscreteUpdateEvent<T>&,
+                           DiscreteValues<T>* xd) {
+          // TODO(sherm1) Forward the return status.
+          (this_ptr->*update)(context,
+                              &*xd);  // Ignore return status for now.
+        }));
+  }
+
+  /// Declares that an UnrestrictedUpdate event should occur at initialization
+  /// and that it should invoke the given event handler method. The handler
+  /// should be a class member function (method) with this signature:
+  /// @code
+  ///   EventStatus MySystem::MyUpdate(const Context<T>&,
+  ///                                  State<T>*) const;
+  /// @endcode
+  /// where `MySystem` is a class derived from `LeafSystem<T>` and the method
+  /// name is arbitrary.
+  ///
+  /// See @ref declare_initialization_events "Declare initialization events" for
+  /// more information.
+  ///
+  /// @pre `this` must be dynamic_cast-able to MySystem.
+  /// @pre `update` must not be null.
+  ///
+  /// @see DeclareInitializationPublishEvent()
+  /// @see DeclareInitializationDiscreteUpdateEvent()
+  /// @see DeclareInitializationEvent()
+  template <class MySystem>
+  void DeclareInitializationUnrestrictedUpdateEvent(
+      EventStatus(MySystem::*update)
+          (const Context<T>&, State<T>*) const) {
+    static_assert(std::is_base_of<LeafSystem<T>, MySystem>::value,
+                  "Expected to be invoked from a LeafSystem-derived System.");
+    auto this_ptr = dynamic_cast<const MySystem*>(this);
+    DRAKE_DEMAND(this_ptr != nullptr);
+    DRAKE_DEMAND(update != nullptr);
+
+    DeclareInitializationEvent(UnrestrictedUpdateEvent<T>(
+        TriggerType::kInitialization,
+        [this_ptr, update](const Context<T>& context,
+                           const UnrestrictedUpdateEvent<T>&, State<T>* x) {
+          // TODO(sherm1) Forward the return status.
+          (this_ptr->*update)(context,
+                              &*x);  // Ignore return status for now.
+        }));
+  }
+
+  /// (Advanced) Declares that a particular Event object should be dispatched at
+  /// initialization. This is the most general form for declaring initialization
+  /// events and most users should use one of the other methods in this group
+  /// instead.
+  ///
+  /// @see DeclareInitializationPublishEvent()
+  /// @see DeclareInitializationDiscreteUpdateEvent()
+  /// @see DeclareInitializationUnrestrictedUpdate()
+  ///
+  /// See @ref declare_initialization_events "Declare initialization events" for
+  /// more information.
+  ///
+  /// Depending on the type of `event`, on initialization it will be passed to
+  /// the Publish, DiscreteUpdate, or UnrestrictedUpdate event dispatcher. If
+  /// the `event` object contains a handler function, Drake's default
+  /// dispatchers will invoke that handler. If not, then no further action is
+  /// taken. Thus an `event` with no handler has no effect unless its dispatcher
+  /// has been overridden. We strongly recommend that you _do not_ override the
+  /// dispatcher and instead _do_ supply a handler.
+  ///
+  /// The given `event` object is deep-copied (cloned), and the copy is stored
+  /// internally so you do not need to keep the object around after this call.
+  ///
+  /// @pre `event`'s associated trigger type must be TriggerType::kUnknown or
+  /// already set to TriggerType::kInitialization.
   template <typename EventType>
   void DeclareInitializationEvent(const EventType& event) {
     DRAKE_DEMAND(event.get_trigger_type() == TriggerType::kUnknown ||
         event.get_trigger_type() == TriggerType::kInitialization);
     event.AddToComposite(TriggerType::kInitialization, &initialization_events_);
   }
+  //@}
 
   /// @name          Declare continuous state variables
   /// Continuous state consists of up to three kinds of variables: generalized
@@ -1577,14 +2035,16 @@ class LeafSystem : public System<T> {
         calc, count, SystemConstraintType::kInequality, description));
   }
 
-  /// Derived-class event handler for all simultaneous publish events
-  /// in @p events. Override this in your derived LeafSystem if your derived
-  /// LeafSystem requires a behavior other than the default behavior, which
-  /// traverses events in the arbitrary order they appear in @p events, and
-  /// for each event that has a callback function, it will invoke the callback
-  /// with @p context and that event. This can be used for tasks that need
-  /// read-only access to the context, such as sending messages, producing
-  /// console output, debugging, logging, saving the trajectory to a file, etc.
+  /// Derived-class event dispatcher for all simultaneous publish events
+  /// in @p events. Override this in your derived LeafSystem only if you require
+  /// behavior other than the default dispatch behavior (not common).
+  /// The default behavior is to traverse events in the arbitrary order they
+  /// appear in @p events, and for each event that has a callback function,
+  /// to invoke the callback with @p context and that event.
+  ///
+  /// Do not override this just to handle an event -- instead declare the event
+  /// and a handler callback for it using one of the `Declare...PublishEvent()`
+  /// methods.
   ///
   /// This method is called only from the virtual DispatchPublishHandler, which
   /// is only called from the public non-virtual Publish(), which will have
@@ -1600,14 +2060,18 @@ class LeafSystem : public System<T> {
     }
   }
 
-  /// Derived-class event handler for all simultaneous discrete update
-  /// events. This method updates the @p discrete_state on discrete update
-  /// events. The default implementation traverses events in the arbitrary
-  /// order they appear in @p events, and for each event that has a callback
-  /// function, it will invoke it with @p context, that event, and
-  /// @p discrete_state. Note that the same @p discrete_state is passed to
-  /// subsequent callbacks. Override this in your derived LeafSystem if your
-  /// derived LeafSystem requires a behavior other than the default.
+  /// Derived-class event dispatcher for all simultaneous discrete update
+  /// events. Override this in your derived LeafSystem only if you require
+  /// behavior other than the default dispatch behavior (not common).
+  /// The default behavior is to traverse events in the arbitrary order they
+  /// appear in @p events, and for each event that has a callback function,
+  /// to invoke the callback with @p context, that event, and @p discrete_state.
+  /// Note that the same (possibly modified) @p discrete_state is passed to
+  /// subsequent callbacks.
+  ///
+  /// Do not override this just to handle an event -- instead declare the event
+  /// and a handler callback for it using one of the
+  /// `Declare...DiscreteUpdateEvent()` methods.
   ///
   /// This method is called only from the virtual
   /// DispatchDiscreteVariableUpdateHandler(), which is only called from
@@ -1630,18 +2094,18 @@ class LeafSystem : public System<T> {
     }
   }
 
-  /// Derived-class event handler for all simultaneous unrestricted
-  /// update events. This function updates the @p state *in an unrestricted
-  /// fashion* on unrestricted update events. Override this function if you
-  /// need your System to update abstract variables or generally make changes
-  /// to state that cannot be made using CalcDiscreteVariableUpdates() or
-  /// via integration of continuous variables.
-  ///
-  /// The default implementation traverses events in the arbitrary order they
+  /// Derived-class event dispatcher for all simultaneous unrestricted update
+  /// events. Override this in your derived LeafSystem only if you require
+  /// behavior other than the default dispatch behavior (not common).
+  /// The default behavior is to traverse events in the arbitrary order they
   /// appear in @p events, and for each event that has a callback function,
-  /// it will invoke it with @p context, that event, and @p state. Note that
-  /// the same @p state is passed to subsequent callbacks. Override this if
-  /// your derived LeafSystem requires a behavior other than the default.
+  /// to invoke the callback with @p context, that event, and @p state.
+  /// Note that the same (possibly modified) @p state is passed to subsequent
+  /// callbacks.
+  ///
+  /// Do not override this just to handle an event -- instead declare the event
+  /// and a handler callback for it using one of the
+  /// `Declare...UnrestrictedUpdateEvent()` methods.
   ///
   /// This method is called only from the virtual
   /// DispatchUnrestrictedUpdateHandler(), which is only called from the

--- a/systems/framework/test/event_status_test.cc
+++ b/systems/framework/test/event_status_test.cc
@@ -1,0 +1,63 @@
+#include "drake/systems/framework/event_status.h"
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace systems {
+namespace {
+
+bool equal_status(const EventStatus& one, const EventStatus& two) {
+  return one.severity() == two.severity() && one.system() == two.system() &&
+         one.message() == two.message();
+}
+
+GTEST_TEST(EventStatusTest, ConstructionAndRetrieval) {
+  const SystemBase* dummy = reinterpret_cast<const SystemBase*>(0x1234);
+  // EventStatus can only be produced by factory methods.
+  const EventStatus did_nothing = EventStatus::DidNothing();
+  const EventStatus succeeded = EventStatus::Succeeded();
+  const EventStatus terminated =
+      EventStatus::ReachedTermination(dummy, "reached termination");
+  const EventStatus failed = EventStatus::Failed(dummy, "failed");
+
+  EXPECT_EQ(did_nothing.severity(), EventStatus::kDidNothing);
+  EXPECT_EQ(succeeded.severity(), EventStatus::kSucceeded);
+  EXPECT_EQ(terminated.severity(), EventStatus::kReachedTermination);
+  EXPECT_EQ(failed.severity(), EventStatus::kFailed);
+
+  EXPECT_EQ(did_nothing.system(), nullptr);
+  EXPECT_EQ(succeeded.system(), nullptr);
+  EXPECT_EQ(terminated.system(), dummy);
+  EXPECT_EQ(failed.system(), dummy);
+
+  EXPECT_EQ(did_nothing.message(), "");
+  EXPECT_EQ(succeeded.message(), "");
+  EXPECT_EQ(terminated.message(), "reached termination");
+  EXPECT_EQ(failed.message(), "failed");
+
+  // Make sure the statuses are ordered.
+  EXPECT_LT(EventStatus::kDidNothing, EventStatus::kSucceeded);
+  EXPECT_LT(EventStatus::kSucceeded, EventStatus::kReachedTermination);
+  EXPECT_LT(EventStatus::kReachedTermination, EventStatus::kFailed);
+
+  // Test that KeepMoreSevere() works properly.
+  EventStatus status = EventStatus::Succeeded();
+
+  // Should update when more severe, not when less severe.
+  status.KeepMoreSevere(terminated);
+  EXPECT_TRUE(equal_status(status, terminated));
+  status.KeepMoreSevere(did_nothing);
+  EXPECT_TRUE(equal_status(status, terminated));
+
+  // Should not update when same severity (first one wins).
+  const SystemBase* dummy2 = reinterpret_cast<const SystemBase*>(0x5678);
+  const EventStatus failed2 = EventStatus::Failed(dummy2, "failed again");
+  status.KeepMoreSevere(failed);  // Should update.
+  EXPECT_TRUE(equal_status(status, failed));
+  status.KeepMoreSevere(failed2);  // Should not update (same severity).
+  EXPECT_TRUE(equal_status(status, failed));
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
This PR contains just the new event declaration sugar methods and EventStatus type from #10132, without the additional modifications to the examples and tests there. Those will follow but the PR was getting too big.

Motivation: we prefer that events always be declared with associated handler callbacks, rather than overloading the dispatcher virtuals like DoPublish() and DoDiscreteUpdate(). For that approach to be palatable, we need some sugar similar to the sugar available for output port callbacks. This PR adds that sugar in the form of more Declare...() methods in LeafSystem.

This is also a step in the direction of being able to report status from event handlers as in #9292 -- the new sugar methods return status so that we don't have to change signature later, although that status does not yet percolate through the rest of the system.
```
Category            added  modified  removed  
----------------------------------------------
code                329    19        8        
comments            361    63        17       
blank               71     0         0        
----------------------------------------------
TOTAL               761    82        25
```    

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10321)
<!-- Reviewable:end -->
