### PR TITLE
Adds variant that set/get the state when only the State is mutable

### DIFF
--- a/bindings/pydrake/multibody/multibody_tree_py.cc
+++ b/bindings/pydrake/multibody/multibody_tree_py.cc
@@ -295,7 +295,7 @@ void init_module(py::module m) {
             py_reference,
             // Keep alive, ownership: `return` keeps `Context` alive.
             py::keep_alive<0, 2>(), py::arg("context"),
-            cls_doc.GetMutablePositionsAndVelocities.doc)
+            cls_doc.GetMutablePositionsAndVelocities.doc_1args)
         .def("CalcPointsPositions",
             [](const Class* self, const Context<T>& context,
                 const Frame<T>& frame_B,
@@ -885,7 +885,7 @@ void init_multibody_plant(py::module m) {
             py_reference,
             // Keep alive, ownership: `return` keeps `Context` alive.
             py::keep_alive<0, 2>(), py::arg("context"),
-            doc.MultibodyPlant.GetMutablePositions.doc)
+            doc.MultibodyPlant.GetMutablePositions.doc_1args)
         .def("GetMutableVelocities",
             [](const MultibodyPlant<T>* self,
                 Context<T>* context) -> Eigen::Ref<VectorX<T>> {
@@ -894,7 +894,7 @@ void init_multibody_plant(py::module m) {
             py_reference,
             // Keep alive, ownership: `return` keeps `Context` alive.
             py::keep_alive<0, 2>(), py::arg("context"),
-            doc.MultibodyPlant.GetMutableVelocities.doc)
+            doc.MultibodyPlant.GetMutableVelocities.doc_1args)
         .def("GetPositions",
             [](const MultibodyPlant<T>* self, const Context<T>& context)
                 -> VectorX<T> { return self->GetPositions(context); },

--- a/manipulation/schunk_wsg/schunk_wsg_position_controller.cc
+++ b/manipulation/schunk_wsg/schunk_wsg_position_controller.cc
@@ -119,9 +119,9 @@ SchunkWsgPositionController::SchunkWsgPositionController(double time_step,
 }
 
 void SchunkWsgPositionController::set_initial_position(
-    drake::systems::Context<double>* context, double desired_position) const {
+    drake::systems::State<double>* state, double desired_position) const {
   state_interpolator_->set_initial_position(
-      &this->GetMutableSubsystemContext(*state_interpolator_, context),
+      &this->GetMutableSubsystemState(*state_interpolator_, state),
       Vector1d(desired_position));
 }
 

--- a/manipulation/schunk_wsg/schunk_wsg_position_controller.h
+++ b/manipulation/schunk_wsg/schunk_wsg_position_controller.h
@@ -137,8 +137,15 @@ class SchunkWsgPositionController : public systems::Diagram<double> {
 
   // The controller stores the last commanded desired position as state.
   // This is a helper method to reset that state.
-  void set_initial_position(systems::Context<double>* context,
+  void set_initial_position(systems::State<double>* state,
                                     double desired_position) const;
+
+  // The controller stores the last commanded desired position as state.
+  // This is a helper method to reset that state.
+  void set_initial_position(systems::Context<double>* context,
+                            double desired_position) const {
+    set_initial_position(&context->get_mutable_state(), desired_position);
+  }
 
   const systems::InputPort<double>& get_desired_position_input_port() const {
     return get_input_port(desired_position_input_port_);

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -475,6 +475,26 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
         head(num_positions());
   }
 
+  /// (Advanced) Returns a mutable vector reference containing the vector
+  /// of generalized positions (**see warning**).
+  /// @note This method returns a reference to existing data, exhibits constant
+  ///       i.e., O(1) time complexity, and runs very quickly.
+  /// @warning You should use SetPositions() instead of this method
+  ///          unless you are fully aware of the possible interactions with the
+  ///          caching mechanism (see @ref dangerous_get_mutable).
+  /// @throws std::exception if the `state` is nullptr or if the context does
+  ///         not correspond to the context for a multibody model.
+  Eigen::VectorBlock<VectorX<T>> GetMutablePositions(
+      const systems::Context<T>& context, systems::State<T>* state) const {
+    // Note: the nestedExpression() is necessary to treat the VectorBlock<T>
+    // returned from GetMutablePositionsAndVelocities() as a VectorX<T> so that
+    // we can call head() on it.
+    return tree()
+        .GetMutablePositionsAndVelocities(context, state)
+        .nestedExpression()
+        .head(num_positions());
+  }
+
   /// Sets all generalized positions from the given vector.
   /// @throws std::exception if the `context` is nullptr, if the context does
   /// not correspond to the context for a multibody model, or if the length of
@@ -492,6 +512,18 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
       systems::Context<T>* context,
       ModelInstanceIndex model_instance, const VectorX<T>& q_instance) const {
     Eigen::VectorBlock<VectorX<T>> q = GetMutablePositions(context);
+    tree().SetPositionsInArray(model_instance, q_instance, &q);
+  }
+
+  /// Sets the positions for a particular model instance from the given vector.
+  /// @throws std::exception if the `state` is nullptr, if the context does
+  /// not correspond to the context for a multibody model, if the model instance
+  /// index is invalid, or if the length of `q_instance` is not equal to
+  /// `num_positions(model_instance)`.
+  void SetPositions(const systems::Context<T>& context,
+                    systems::State<T>* state, ModelInstanceIndex model_instance,
+                    const VectorX<T>& q_instance) const {
+    Eigen::VectorBlock<VectorX<T>> q = GetMutablePositions(context, state);
     tree().SetPositionsInArray(model_instance, q_instance, &q);
   }
 
@@ -530,12 +562,20 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   /// @throws std::exception if the `context` is nullptr or the context does
   /// not correspond to the context for a multibody model.
   Eigen::VectorBlock<VectorX<T>> GetMutableVelocities(
-      systems::Context<T>* context) const {
+      const systems::Context<T>& context, systems::State<T>* state) const {
     // Note: the nestedExpression() is necessary to treat the VectorBlock<T>
     // returned from GetMutablePositionsAndVelocities() as a VectorX<T> so that
     // we can call tail() on it.
-    return GetMutablePositionsAndVelocities(context).nestedExpression().
-        tail(num_velocities());
+    return tree()
+        .GetMutablePositionsAndVelocities(context, state)
+        .nestedExpression()
+        .tail(num_velocities());
+  }
+
+  /// See GetMutableVelocities() method above.
+  Eigen::VectorBlock<VectorX<T>> GetMutableVelocities(
+      systems::Context<T>* context) const {
+    return GetMutableVelocities(*context, &context->get_mutable_state());
   }
 
   /// Sets all generalized velocities from the given vector.
@@ -544,6 +584,19 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   /// `v` is not equal to `num_velocities()`.
   void SetVelocities(systems::Context<T>* context, const VectorX<T>& v) const {
     GetMutableVelocities(context) = v;
+  }
+
+  /// Sets the generalized velocities for a particular model instance from the
+  /// given vector.
+  /// @throws std::exception if the `context` is nullptr, if the context does
+  /// not correspond to the context for a multibody model, if the model instance
+  /// index is invalid, or if the length of `v_instance` is not equal to
+  /// `num_velocities(model_instance)`.
+  void SetVelocities(
+      const systems::Context<T>& context, systems::State<T>* state,
+      ModelInstanceIndex model_instance, const VectorX<T>& v_instance) const {
+    Eigen::VectorBlock<VectorX<T>> v = GetMutableVelocities(context, state);
+    tree().SetVelocitiesInArray(model_instance, v_instance, &v);
   }
 
   /// Sets the generalized velocities for a particular model instance from the

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -354,14 +354,14 @@ VectorX<T> MultibodyTree<T>::GetPositionsAndVelocities(
 template <typename T>
 Eigen::VectorBlock<VectorX<T>>
 MultibodyTree<T>::GetMutablePositionsAndVelocities(
-    systems::Context<T>* context) const {
-  DRAKE_DEMAND(context != nullptr);
-  auto* mbt_context = dynamic_cast<MultibodyTreeContext<T>*>(context);
+    const systems::Context<T>& context, systems::State<T>* state) const {
+  DRAKE_DEMAND(state != nullptr);
+  auto* mbt_context = dynamic_cast<const MultibodyTreeContext<T>*>(&context);
   if (mbt_context == nullptr) {
     throw std::runtime_error(
         "The context provided is not compatible with a multibody model.");
   }
-  return mbt_context->get_mutable_state_vector();
+  return mbt_context->get_mutable_state_vector(state);
 }
 
 template <typename T>

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -1455,7 +1455,15 @@ class MultibodyTree {
   /// @note This method returns a reference to existing data, exhibits constant
   ///       i.e., O(1) time complexity, and runs very quickly.
   Eigen::VectorBlock<VectorX<T>> GetMutablePositionsAndVelocities(
-      systems::Context<T>* context) const;
+      const systems::Context<T>& context, systems::State<T>* state) const;
+
+  /// See GetMutablePositionsAndVelocities(context, state) above.
+  Eigen::VectorBlock<VectorX<T>> GetMutablePositionsAndVelocities(
+      systems::Context<T>* context) const {
+    return GetMutablePositionsAndVelocities(*context,
+        &context->get_mutable_state());
+  }
+
 
   #ifndef DRAKE_DOXYGEN_CXX
   // TODO(edrumwri) Remove this method after 2/7/19 (3 months).

--- a/multibody/tree/multibody_tree_context.h
+++ b/multibody/tree/multibody_tree_context.h
@@ -90,11 +90,20 @@ class MultibodyTreeContext: public systems::LeafContext<T> {
   /// Returns a mutable reference to the state vector stored in `this` context
   /// as an `Eigen::VectorBlock<VectorX<T>>`.
   Eigen::VectorBlock<VectorX<T>> get_mutable_state_vector() {
+    return get_mutable_state_vector(&this->get_mutable_state());
+  }
+
+  /// Returns a mutable reference to the state vector stored in `state` which
+  /// must be the state associated with `this` context, as an
+  /// `Eigen::VectorBlock<VectorX<T>>`.
+  Eigen::VectorBlock<VectorX<T>> get_mutable_state_vector(
+      systems::State<T>* state) const {
+    DRAKE_ASSERT(&this->get_state() == state);
     DRAKE_ASSERT(this->get_num_discrete_state_groups() <= 1);
     systems::BasicVector<T>& state_vector =
-        (is_state_discrete()) ? this->get_mutable_discrete_state(0) :
+        (is_state_discrete()) ? state->get_mutable_discrete_state(0) :
         dynamic_cast<systems::BasicVector<T>&>(
-            this->get_mutable_continuous_state().get_mutable_vector());
+            state->get_mutable_continuous_state().get_mutable_vector());
     return state_vector.get_mutable_value();
   }
 

--- a/systems/primitives/discrete_derivative.cc
+++ b/systems/primitives/discrete_derivative.cc
@@ -32,14 +32,15 @@ DiscreteDerivative<T>::DiscreteDerivative(int num_inputs, double time_step)
 
 template <typename T>
 void DiscreteDerivative<T>::set_input_history(
-    drake::systems::Context<T>* context,
-    const Eigen::Ref<const drake::VectorX<T>>& u_n, const Eigen::Ref<const
-    drake::VectorX<T>>& u_n_minus_1) const {
+    drake::systems::State<T>* state,
+    const Eigen::Ref<const drake::VectorX<T>>& u_n,
+    const Eigen::Ref<const drake::VectorX<T>>& u_n_minus_1) const {
   DRAKE_DEMAND(u_n.size() == n_);
   DRAKE_DEMAND(u_n_minus_1.size() == n_);
 
-  context->get_mutable_discrete_state_vector().get_mutable_value()
-    << u_n, u_n_minus_1;
+  state->get_mutable_discrete_state().get_mutable_vector().get_mutable_value()
+      << u_n,
+      u_n_minus_1;
 }
 
 template <typename T>
@@ -91,24 +92,23 @@ StateInterpolatorWithDiscreteDerivative<
 
 template <typename T>
 void StateInterpolatorWithDiscreteDerivative<T>::set_initial_position(
-    systems::Context<T>* context,
+    systems::State<T>* state,
     const Eigen::Ref<const VectorX<T>>& position) const {
   derivative_->set_input_history(
-      &this->GetMutableSubsystemContext(*derivative_, context), position);
+      &this->GetMutableSubsystemState(*derivative_, state), position,
+      position);
 }
 
 template <typename T>
 void StateInterpolatorWithDiscreteDerivative<T>::set_initial_state(
-    systems::Context<T>* context,
-    const Eigen::Ref<const VectorX<T>>& position, const Eigen::Ref<const
-    VectorX<T>>& velocity) const {
+    systems::State<T>* state, const Eigen::Ref<const VectorX<T>>& position,
+    const Eigen::Ref<const VectorX<T>>& velocity) const {
   // The derivative block implements y(t) = (u[n]-u[n-1])/h, so we want
   // u[n] = position, u[n-1] = u[n] - h*velocity
   derivative_->set_input_history(
-      &this->GetMutableSubsystemContext(*derivative_, context), position,
-      position - derivative_->time_step()*velocity);
+      &this->GetMutableSubsystemState(*derivative_, state), position,
+      position - derivative_->time_step() * velocity);
 }
-
 
 }  // namespace systems
 }  // namespace drake


### PR DESCRIPTION
to implement, e.g. SetRandomState(), one only has a mutable pointer to State (not the entire Context).

I've only touched the methods I needed for @rcory 's bin-picking PR.  There will be others, as well.  

There is a painful lesson here.  Probably most of our setters, etc, should take only the State (not the Context).  I've elected to leave the Context variant as "sugar" instead of deprecating old methods, but I think we should probably remember to use State going forward when possible.