### PR TITLE
Fix assumption on global locale in URDF parser

### DIFF
--- a/multibody/parsing/detail_tinyxml.cc
+++ b/multibody/parsing/detail_tinyxml.cc
@@ -1,5 +1,6 @@
 #include "drake/multibody/parsing/detail_tinyxml.h"
 
+#include <locale>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -14,6 +15,12 @@ namespace detail {
 namespace {
 std::vector<double> ConvertToDoubles(const std::string& str) {
   std::istringstream ss(str);
+  // Every real number in a URDF file needs to be parsed assuming that the
+  // decimal point separator is the period, as specified in XML Schema
+  // definition of xs:double. The call to imbue ensures that a suitable
+  // locale is used, instead of using the current C++ global locale.
+  // Related PR: https://github.com/ros/urdfdom_headers/pull/42 .
+  ss.imbue(std::locale::classic());
 
   double val{};
   std::vector<double> out;


### PR DESCRIPTION
Before this fix, the URDF parser was silently failing to parse the decimal part of any real number parsed from XML if the C++ global locale was set to have a decimal separator different from the point.

Related issues in other projects :
* https://github.com/ros/urdfdom/issues/98
* https://github.com/robotology/idyntree/issues/288
* https://bitbucket.org/osrf/sdformat/issues/60

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10326)
<!-- Reviewable:end -->
