### PR TITLE
py unittest: Turn Drake deprecations into errors by default

### DIFF
--- a/bindings/pydrake/common/test/deprecation_test.py
+++ b/bindings/pydrake/common/test/deprecation_test.py
@@ -135,10 +135,9 @@ class TestDeprecation(unittest.TestCase):
         # At this point, no other deprecations should have been thrown, so we
         # will test with the default `once` filter.
         with warnings.catch_warnings(record=True) as w:
-            if six.PY3:
-                # Recreate warning environment.
-                warnings.simplefilter('ignore', DeprecationWarning)
-                warnings.simplefilter('once', DrakeDeprecationWarning)
+            # Recreate warning environment.
+            warnings.simplefilter('ignore', DeprecationWarning)
+            warnings.simplefilter('once', DrakeDeprecationWarning)
             # TODO(eric.cousineau): Also different behavior here...
             # Is `unittest` setting a non-standard warning filter???
             base_deprecation()  # Should not appear.
@@ -210,6 +209,7 @@ class TestDeprecation(unittest.TestCase):
         """Test C++ usage in `deprecation_pybind.h`."""
         from deprecation_example.cc_module import ExampleCppClass
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("once", DrakeDeprecationWarning)
             # This is a descriptor, so it will trigger on class access.
             ExampleCppClass.DeprecatedMethod
             self.assertEqual(len(w), 1)

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -9,6 +9,7 @@ import warnings
 import numpy as np
 
 import pydrake
+from pydrake.common.deprecation import DrakeDeprecationWarning
 import pydrake.symbolic as sym
 
 
@@ -169,6 +170,7 @@ class TestMathematicalProgram(unittest.TestCase):
 
         # Test deprecated method.
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('once', DrakeDeprecationWarning)
             c = binding.constraint()
             self.assertEqual(len(w), 1)
 

--- a/bindings/pydrake/test/all_test.py
+++ b/bindings/pydrake/test/all_test.py
@@ -10,8 +10,8 @@ class TestAll(unittest.TestCase):
     def test_import_warnings(self):
         """Prints if we encounter any warnings (primarily from `pybind11`) when
         importing `pydrake.all`."""
-        # Ensure that we haven't imported anything from `pydrake`.
-        self.assertTrue("pydrake" not in sys.modules)
+        # Ensure that we haven't yet imported `pydrake.all`.
+        self.assertTrue("pydrake.all" not in sys.modules)
         # - While this may be redundant, let's do it for good measure.
         self.assertTrue("pydrake.all" not in sys.modules)
         # Enable *all* warnings, and ensure that we don't trigger them.

--- a/common/test_utilities/drake_py_unittest_main.py
+++ b/common/test_utilities/drake_py_unittest_main.py
@@ -11,6 +11,14 @@ import re
 import sys
 import trace
 import unittest
+import warnings
+
+try:
+    from pydrake.common.deprecation import DrakeDeprecationWarning
+    has_pydrake = True
+except ImportError:
+    has_pydrake = False
+
 
 if __name__ == '__main__':
     # Obtain the full path for this test case; it looks a bit like this:
@@ -91,6 +99,10 @@ if __name__ == '__main__':
         help="Do not pipe stdout to stderr. When running from the Bazel " +
              "client (non-batch), output may be mixed, so piping makes " +
              "the output more readable.")
+    parser.add_argument(
+        "--drake_deprecation_action", type=str, default="error",
+        help="Action for Drake deprecation warnings. See " +
+             "`warnings.simplefilter()`.")
     args, remaining = parser.parse_known_args()
     sys.argv = sys.argv[:1] + remaining
 
@@ -106,6 +118,10 @@ if __name__ == '__main__':
     if not args.nostdout_to_stderr:
         sys.stdout.flush()
         sys.stdout = sys.stderr
+
+    if has_pydrake:
+        warnings.simplefilter(
+            args.drake_deprecation_action, DrakeDeprecationWarning)
 
     if args.trace != "none":
         if args.trace == "user":


### PR DESCRIPTION
Portion of #10307

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10332)
<!-- Reviewable:end -->
