### PR TITLE
Bind parameter accessor methods in the context.

### DIFF
--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -289,6 +289,7 @@ drake_py_unittest(
         ":analysis_py",
         ":framework_py",
         ":primitives_py",
+        "//bindings/pydrake/examples:pendulum_py",
     ],
 )
 

--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -192,7 +192,20 @@ void DefineFrameworkPySemantics(py::module m) {
                   index);
             },
             py_reference_internal,
-            doc.Context.get_mutable_abstract_state.doc_1args);
+            doc.Context.get_mutable_abstract_state.doc_1args)
+        .def("get_parameters", &Context<T>::get_parameters,
+            py_reference_internal, doc.Context.get_parameters.doc)
+        .def("num_numeric_parameter_groups",
+            &Context<T>::num_numeric_parameter_groups,
+            doc.Context.num_numeric_parameter_groups.doc)
+        .def("get_numeric_parameter", &Context<T>::get_numeric_parameter,
+            py::arg("index"), py_reference_internal,
+            doc.Context.get_numeric_parameter.doc)
+        .def("num_abstract_parameters", &Context<T>::num_abstract_parameters,
+            doc.Context.num_abstract_parameters.doc)
+        .def("get_abstract_parameter", &Context<T>::get_abstract_parameter,
+            py::arg("index"), py_reference_internal,
+            doc.Context.get_numeric_parameter.doc);
 
     DefineTemplateClassWithDefault<LeafContext<T>, Context<T>>(
         m, "LeafContext", GetPyParam<T>(), doc.LeafContext.doc);

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -13,6 +13,7 @@ import numpy as np
 from pydrake.autodiffutils import (
     AutoDiffXd,
     )
+from pydrake.examples.pendulum import PendulumPlant
 from pydrake.symbolic import (
     Expression,
     )
@@ -47,7 +48,6 @@ from pydrake.systems.framework import (
     TriggerType,
     VectorSystem_,
     )
-from pydrake.systems import primitives
 from pydrake.systems.primitives import (
     Adder, Adder_,
     AffineSystem,
@@ -108,6 +108,17 @@ class TestGeneral(unittest.TestCase):
         self.assertIsInstance(
             context.get_mutable_continuous_state_vector(), VectorBase)
         # TODO(eric.cousineau): Consolidate main API tests for `Context` here.
+
+        pendulum = PendulumPlant()
+        context = pendulum.CreateDefaultContext()
+        self.assertEqual(context.num_numeric_parameter_groups(), 1)
+        self.assertTrue(
+            context.get_parameters().get_numeric_parameter(0) is
+            context.get_numeric_parameter(index=0))
+        self.assertEqual(context.num_abstract_parameters(), 0)
+        # TODO(russt): Bind _Declare*Parameter or find an example with an
+        # abstract parameter to actually call this method.
+        self.assertTrue(hasattr(context, "get_abstract_parameter"))
 
     def test_event_api(self):
         # TriggerType - existence check.


### PR DESCRIPTION
(there was no way to actually retrieve them before).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10336)
<!-- Reviewable:end -->
