### PR TITLE
framework: Add OutputPort EvalEigenVector sugar

### DIFF
--- a/systems/framework/output_port.h
+++ b/systems/framework/output_port.h
@@ -89,6 +89,16 @@ class OutputPort : public OutputPortBase {
     return ExtractValueOrThrow<ValueType>(__func__, abstract_value);
   }
 
+  /** Returns a reference to the up-to-date vector value of this output port
+  contained in the given Context.  See Eval() for the full description of the
+  computational semantics; this method is just sugar that casts the Eval()
+  result to an Eigen type.
+  @pre This is vector-valued output port. */
+  Eigen::VectorBlock<const VectorX<T>> EvalEigenVector(
+      const Context<T>& context) const {
+    return Eval<BasicVector<T>>(context).get_value();
+  }
+
   /** Allocates a concrete object suitable for holding the value to be exposed
   by this output port, and returns that as an AbstractValue. The returned object
   will never be null. If Drake assertions are enabled (typically only in Debug

--- a/systems/framework/test/output_port_test.cc
+++ b/systems/framework/test/output_port_test.cc
@@ -247,6 +247,12 @@ void VectorPortCheck(const Context<double>& context,
   port.Calc(context, val.get());
   // Should have written into the underlying MyVector3d.
   EXPECT_EQ(myvector3.get_value(), Vector3d(99., 100., 101.));
+
+  // Check that Eval runs to completion without error.
+  const auto& eval_basic = port.Eval<BasicVector<double>>(context);
+  const auto& eval_eigen = port.EvalEigenVector(context);
+  EXPECT_EQ(eval_basic.size(), 3);
+  EXPECT_EQ(eval_eigen.size(), 3);
 }
 
 // Check for proper construction and functioning of vector-valued


### PR DESCRIPTION
To be used by #9620 soon.  I ended up with only a couple uses that needed this, but it seemed potentially useful enough to sugar up within the framework.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10342)
<!-- Reviewable:end -->
