### PR TITLE
linear_system: Respect input vector subtypes

### DIFF
--- a/examples/pendulum/pendulum_parameters_derivatives.cc
+++ b/examples/pendulum/pendulum_parameters_derivatives.cc
@@ -21,7 +21,7 @@ int DoMain() {
   // The plant and its context.
   PendulumPlant<AutoDiffXd> system;
   auto context = system.CreateDefaultContext();
-  context->FixInputPort(0, Vector1<AutoDiffXd>::Constant(0.0));
+  context->FixInputPort(0, PendulumInput<AutoDiffXd>{}.with_tau(0.0));
 
   // Retrieve the (mutable) state from context so that we can set it.
   PendulumState<AutoDiffXd>& state =

--- a/examples/pendulum/pendulum_plant.h
+++ b/examples/pendulum/pendulum_plant.h
@@ -71,7 +71,7 @@ class PendulumPlant final : public systems::LeafSystem<T> {
   /// Evaluates the input port and returns the scalar value
   /// of the commanded torque.
   T get_tau(const systems::Context<T>& context) const {
-    return this->EvalVectorInput(context, 0)->GetAtIndex(0);
+    return this->template EvalVectorInput<PendulumInput>(context, 0)->tau();
   }
 
   static const PendulumState<T>& get_state(

--- a/examples/pendulum/print_symbolic_dynamics.cc
+++ b/examples/pendulum/print_symbolic_dynamics.cc
@@ -16,7 +16,8 @@ int DoMain() {
 
   auto context = system.CreateDefaultContext();
   context->FixInputPort(
-      0, Vector1<symbolic::Expression>::Constant(symbolic::Variable("tau")));
+      0, PendulumInput<symbolic::Expression>{}.
+             with_tau(symbolic::Variable("tau")));
   context->get_mutable_continuous_state_vector().SetAtIndex(
       0, symbolic::Variable("theta"));
   context->get_mutable_continuous_state_vector().SetAtIndex(

--- a/examples/pendulum/test/urdf_dynamics_test.cc
+++ b/examples/pendulum/test/urdf_dynamics_test.cc
@@ -27,7 +27,7 @@ GTEST_TEST(UrdfDynamicsTest, AllTests) {
   auto context_p = p.CreateDefaultContext();
 
   auto& u_rbp = context_rbp->FixInputPort(0, Vector1d::Zero());
-  auto& u_p = context_p->FixInputPort(0, Vector1d::Zero());
+  auto& u_p = context_p->FixInputPort(0, PendulumInput<double>{}.with_tau(0.0));
 
   Eigen::Vector2d x;
   Vector1d u;

--- a/systems/analysis/test/lyapunov_test.cc
+++ b/systems/analysis/test/lyapunov_test.cc
@@ -14,6 +14,7 @@ namespace {
 
 using symbolic::Variable;
 using symbolic::Expression;
+using examples::pendulum::PendulumInput;
 
 /// Cubic Polynomial System:
 ///   ẋ = -x + x³
@@ -71,7 +72,7 @@ VectorX<T> pendulum_bases(const VectorX<T>& x) {
 GTEST_TEST(LyapunovTest, PendulumSampleBasedLyapunov) {
   examples::pendulum::PendulumPlant<double> pendulum;
   auto context = pendulum.CreateDefaultContext();
-  context->FixInputPort(0, Vector1d{0.0});
+  context->FixInputPort(0, PendulumInput<double>{}.with_tau(0.0));
 
   Eigen::VectorXd q_samples =
       Eigen::VectorXd::LinSpaced(31, -1.5 * M_PI, 1.5 * M_PI);


### PR DESCRIPTION
I discovered this problem while working on #9669, though it is still a problem even if we decide to keep FixInputPort's semantics weaker and WONTFIX that issue.  Here, if we are providing vector inputs to a `System<AutoDiffXd>` that being linearized, we must always ask the System to allocate storage for those inputs, in case computing using a mere BasicVector isn't good enough.

The existing unit test is sufficient to cover this change once the PendulumPlant demands that its input port has the correct subtype.

FYI I plan to squash the commits after the reviews have progressed a bit more (ending up with only a single commit).

FYI LuenbergerObserver has the same problem, but I'll file that fix as a separate PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10343)
<!-- Reviewable:end -->
