### PR TITLE
Converted fibonacci and discrete_system example to use signal logger

### DIFF
--- a/examples/fibonacci/BUILD.bazel
+++ b/examples/fibonacci/BUILD.bazel
@@ -27,6 +27,7 @@ drake_cc_binary(
     deps = [
         ":fibonacci_difference_equation",
         "//systems/analysis:simulator",
+        "//systems/primitives:signal_logger",
         "@gflags",
     ],
 )
@@ -38,6 +39,7 @@ drake_cc_googletest(
     deps = [
         ":fibonacci_difference_equation",
         "//systems/analysis",
+        "//systems/primitives:signal_logger",
     ],
 )
 

--- a/examples/fibonacci/fibonacci_difference_equation.h
+++ b/examples/fibonacci/fibonacci_difference_equation.h
@@ -10,14 +10,16 @@ namespace drake {
 namespace examples {
 namespace fibonacci {
 
-/** A pure discrete system that generates the Fibonacci sequence Fₙ using
+/** A pure discrete system that generates the Fibonacci sequence F_n using
 a difference equation.
+
+@system{ FibonacciDifferenceEquation, , @output_port{Fn} }
 
 In general, a discrete system has a difference equation (update function),
 output function, and (for simulation) an initial value:
-- _update_ function `xₙ₊₁ = f(n, xₙ, uₙ)`, and
-- _output_ function `yₙ = g(n, xₙ, uₙ)`, and
-- `x₀ ≜ xᵢₙᵢₜ`.
+- _update_ function `x_{n+1} = f(n, x_n, u_n)`, and
+- _output_ function `y_n = g(n, x_n, u_n)`, and
+- `x_0 ≜ x_init`.
 
 where x is a vector of discrete variables, u is a vector of external inputs,
 and y is a vector of values that constitute the desired output of the discrete
@@ -26,19 +28,19 @@ n is an integer 0, 1, 2, ... .
 
 The Fibonacci sequence is defined by the second-order difference equation
 ```
-    Fₙ₊₁ = Fₙ + Fₙ₋₁, with F₀ ≜ 0, F₁ ≜ 1,
+    F_{n+1} = F_n + F_{n-1}, with F₀ ≜ 0, F₁ ≜ 1,
 ```
 which uses no input.
 
 We can write this second order system as a pair of first-order difference
 equations, using two state variables `x = {x[0], x[1]}` (we're using square
 brackets for indexing the 2-element vector x, _not_ for step number!). In this
-case xₙ[0] holds Fₙ (the value of F at step n) while xₙ[1] holds Fₙ₋₁ (the
+case x_n[0] holds F_n (the value of F at step n) while x_n[1] holds F_{n-1} (the
 previous value, i.e. the value of F at step n-1). Here is the discrete system:
 ```
-    xₙ₊₁ = {xₙ[0] + xₙ[1], xₙ[0]}   // f()
-      yₙ = xₙ[0]                    // g()
-      x₀ ≜ {0, 1}                   // xᵢₙᵢₜ
+  x_{n+1} = {x_n[0] + x_n[1], x_n[0]}  // f()
+      y_n =  x_n[0]                    // g()
+       x₀ ≜ {0, 1}                     // x_init
 ```
 
 We want to show how to emulate this difference equation in Drake's hybrid
@@ -46,19 +48,13 @@ simulator, which advances a continuous time variable t rather than a discrete
 step number n. To do that, we pick an arbitrary discrete period h, and show that
 publishing at `t = n*h` produces the expected result
 ```
-    n  0  1  2  3  4  5  6  7  8
-    Fₙ 0  1  1  2  3  5  8 13 21 ...
+     n  0  1  2  3  4  5  6  7  8
+   F_n  0  1  1  2  3  5  8 13 21 ...
 ```
 
-The code required to produce the above sequence (see run_fibonacci.cc) is just
-@code{.cpp}
-  FibonacciDifferenceEquation fibonacci;
-  systems::Simulator<double> simulator(fibonacci);
-  simulator.StepTo(8 * FibonacciDifferenceEquation::kPeriod);
-@endcode
+See run_fibonacci.cc for the code required to output the above sequence.
+
 */
-// TODO(sherm1) Simplify the periodic event specifications here when
-// PR #10132 lands.
 class FibonacciDifferenceEquation : public systems::LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FibonacciDifferenceEquation)
@@ -67,48 +63,34 @@ class FibonacciDifferenceEquation : public systems::LeafSystem<double> {
     // Set default initial conditions to produce the above sequence.
     DeclareDiscreteState(Eigen::Vector2d(0., 1.));
 
-    // Output yₙ using a Drake "publish" event (occurs at the end of step n).
-    DeclarePeriodicEvent(kPeriod, 0.,  // period, offset
-                         systems::PublishEvent<double>(
-                             [this](const systems::Context<double>& context,
-                                    const systems::PublishEvent<double>&) {
-                               PrintResult(context);
-                             }));
-
-    // Update to xₙ₊₁, using a Drake "discrete update" event (occurs
+    // Update to x_{n+1}, using a Drake "discrete update" event (occurs
     // at the beginning of step n+1).
-    DeclarePeriodicEvent(kPeriod, 0.,
-                         systems::DiscreteUpdateEvent<double>(
-                             [this](const systems::Context<double>& context,
-                                    const systems::DiscreteUpdateEvent<double>&,
-                                    systems::DiscreteValues<double>* xd) {
-                               Update(context, xd);
-                             }));
+    DeclarePeriodicDiscreteUpdateEvent(kPeriod, 0.,  // First update is at t=0.
+                                       &FibonacciDifferenceEquation::Update);
+
+    // Output y_n. This will be the Fibonacci element F_n if queried at `t=n*h`.
+    DeclareVectorOutputPort("Fn", systems::BasicVector<double>(1),
+                            &FibonacciDifferenceEquation::Output);
   }
 
   /// Update period (in seconds) for the system.
-  static constexpr double kPeriod = 0.7;  // Arbitrary, e.g. 0.1234 works too!
+  static constexpr double kPeriod = 0.25;  // Arbitrary, e.g. 0.1234 works too!
 
  private:
-  // Update function xₙ₊₁ = f(n, xₙ).
+  // Update function x_{n+1} = f(n, x_n).
   void Update(const systems::Context<double>& context,
-                              systems::DiscreteValues<double>* xd) const {
+              systems::DiscreteValues<double>* xd) const {
     const auto& x_n = context.get_discrete_state();
     (*xd)[0] = x_n[0] + x_n[1];
     (*xd)[1] = x_n[0];
   }
 
-  // Print the result of the output function yₙ = g(n, xₙ) to cout.
-  void PrintResult(const systems::Context<double>& context) const {
-    const double t = context.get_time();
-    // Because of finite floating point precision, t / kPeriod will yield the
-    // desired step (n) plus or minus some error. For example, (3 * 0.7) / 0.7
-    // in double precision evalutes to 2.9999999999999996, but we want int n = 3
-    // (rounded), not n = 2 (truncated). Using round() first ensures that
-    // casting to an int gives the correct step number.
-    const int n = static_cast<int>(std::round(t / kPeriod));
-    const int F_n = context.get_discrete_state()[0];  // xₙ[0]
-    std::cout << n << ": " << F_n << "\n";
+  // Returns the result of the output function y_n = g(n, x_n) when the output
+  // port is evaluated at t=n*h.
+  void Output(const systems::Context<double>& context,
+              systems::BasicVector<double>* result) const {
+    const double F_n = context.get_discrete_state()[0];  // x_n[0]
+    (*result)[0] = F_n;
   }
 };
 

--- a/examples/fibonacci/run_fibonacci.cc
+++ b/examples/fibonacci/run_fibonacci.cc
@@ -2,23 +2,41 @@
 
 #include "drake/examples/fibonacci/fibonacci_difference_equation.h"
 #include "drake/systems/analysis/simulator.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/primitives/signal_logger.h"
+
+DEFINE_int32(steps, 10, "Length of Fibonacci sequence to generate.");
 
 namespace drake {
 namespace examples {
 namespace fibonacci {
 namespace {
 
-DEFINE_int32(steps, 10, "Length of Fibonacci sequence to generate.");
-
 // Use Drake's hybrid Simulator to produce the Fibonacci sequence up to
 // the step number supplied on the command line (default 10).
-int DoMain() {
-  FibonacciDifferenceEquation fibonacci;
+int main(int argc, char* argv[]) {
+  // Handle the command line "steps" argument.
+  gflags::SetUsageMessage("usage: run_fibonacci [--steps=n]");
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
 
-  systems::Simulator<double> simulator(fibonacci);
+  // Build a Diagram containing the Fibonacci system and a data logger that
+  // samples the Fibonacci output port exactly at the update times.
+  systems::DiagramBuilder<double> builder;
+  auto fibonacci = builder.AddSystem<FibonacciDifferenceEquation>();
+  auto logger = LogOutput(fibonacci->GetOutputPort("Fn"), &builder);
+  logger->set_publish_period(FibonacciDifferenceEquation::kPeriod);
+  auto diagram = builder.Build();
 
-  // Simulate forward until t=h*steps.
+  // Create a Simulator and use it to advance time until t=steps*h.
+  systems::Simulator<double> simulator(*diagram);
   simulator.StepTo(FLAGS_steps * FibonacciDifferenceEquation::kPeriod);
+
+  // Print out the contents of the log.
+  for (int n = 0; n < logger->sample_times().size(); ++n) {
+    const double t = logger->sample_times()[n];
+    std::cout << n << ": " << logger->data()(0, n)
+              << " (t=" << t << ")\n";
+  }
 
   return 0;
 }
@@ -28,8 +46,6 @@ int DoMain() {
 }  // namespace examples
 }  // namespace drake
 
-int main(int argc, char* argv[]) {
-  gflags::SetUsageMessage("usage: run_fibonacci [--steps=n]");
-  gflags::ParseCommandLineFlags(&argc, &argv, true);
-  return drake::examples::fibonacci::DoMain();
+int main(int argc, char **argv) {
+  return drake::examples::fibonacci::main(argc, argv);
 }

--- a/examples/fibonacci/test/fibonacci_difference_equation_test.cc
+++ b/examples/fibonacci/test/fibonacci_difference_equation_test.cc
@@ -3,6 +3,8 @@
 #include <gtest/gtest.h>
 
 #include "drake/systems/analysis/simulator.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/primitives/signal_logger.h"
 
 namespace drake {
 namespace examples {
@@ -11,23 +13,25 @@ namespace {
 
 // Verify that we get the right sequence for one sequence length.
 GTEST_TEST(Fibonacci, CheckSequence) {
-  FibonacciDifferenceEquation fibonacci;
+  systems::DiagramBuilder<double> builder;
+  auto fibonacci = builder.AddSystem<FibonacciDifferenceEquation>();
+  auto logger =
+      builder.AddSystem<systems::SignalLogger<double>>(1);  // Size of input.
+  logger->set_publish_period(FibonacciDifferenceEquation::kPeriod);
+  builder.Connect(fibonacci->GetOutputPort("Fn"), logger->GetInputPort("data"));
+  auto diagram = builder.Build();
 
-  systems::Simulator<double> simulator(fibonacci);
+  systems::Simulator<double> simulator(*diagram);
+  simulator.set_publish_every_time_step(false);
+  simulator.set_publish_at_initialization(false);
 
   // Simulate forward to fibonacci(6): 0 1 1 2 3 5 8
-  testing::internal::CaptureStdout();
   simulator.StepTo(6 * FibonacciDifferenceEquation::kPeriod);
-  std::string output = testing::internal::GetCapturedStdout();
 
-  EXPECT_EQ(output,
-            "0: 0\n"
-            "1: 1\n"
-            "2: 1\n"
-            "3: 2\n"
-            "4: 3\n"
-            "5: 5\n"
-            "6: 8\n");
+  Eigen::VectorXd expected(7);
+  expected << 0, 1, 1, 2, 3, 5, 8;
+
+  EXPECT_EQ(logger->data().transpose(), expected);
 }
 
 }  // namespace

--- a/examples/simple_discrete_time_system.cc
+++ b/examples/simple_discrete_time_system.cc
@@ -1,48 +1,42 @@
-
 // Simple Discrete Time System Example
 //
 // This is meant to be a sort of "hello world" example for the
 // drake::system classes.  It defines a very simple discrete time system,
-// simulates it from a given initial condition, and plots the result.
+// simulates it from a given initial condition, and checks the result.
 
-#include "drake/common/unused.h"
 #include "drake/systems/analysis/simulator.h"
-#include "drake/systems/framework/vector_system.h"
+#include "drake/systems/framework/leaf_system.h"
 
-// TODO(edrumwri): This system needs to use some sugar and the same workflow
-// as fibonacci_difference_equation. Revisit after event declaration sugar
-// PR (#10132) lands.
+namespace drake {
+namespace systems {
+namespace {
 
 // Simple Discrete Time System
-//   x[n+1] = x[n]^3
-//   y = x
-class SimpleDiscreteTimeSystem : public drake::systems::VectorSystem<double> {
+//   x_{n+1} = x_n³
+//         y = x
+class SimpleDiscreteTimeSystem : public LeafSystem<double> {
  public:
-  SimpleDiscreteTimeSystem()
-      : drake::systems::VectorSystem<double>(0, 1) {  // Zero inputs, 1 output.
-    this->DeclarePeriodicDiscreteUpdate(1.0);
-    this->DeclareDiscreteState(1);  // One state variable.
+  SimpleDiscreteTimeSystem() {
+    DeclarePeriodicDiscreteUpdateEvent(1.0, 0.0,
+                                       &SimpleDiscreteTimeSystem::Update);
+    DeclareVectorOutputPort("y", BasicVector<double>(1),
+                            &SimpleDiscreteTimeSystem::CopyStateOut);
+    DeclareDiscreteState(1);  // One state variable.
   }
 
  private:
-  // x[n+1] = x[n]^3
-  virtual void DoCalcVectorDiscreteVariableUpdates(
-      const drake::systems::Context<double>& context,
-      const Eigen::VectorBlock<const Eigen::VectorXd>& input,
-      const Eigen::VectorBlock<const Eigen::VectorXd>& state,
-      Eigen::VectorBlock<Eigen::VectorXd>* next_state) const {
-    drake::unused(context, input);
-    (*next_state)[0] = std::pow(state[0], 3.0);
+  // x_{n+1} = x_n³
+  void Update(const Context<double>& context,
+              DiscreteValues<double>* next_state) const {
+    const double x_n = context.get_discrete_state()[0];
+    (*next_state)[0] = std::pow(x_n, 3.0);
   }
 
   // y = x
-  virtual void DoCalcVectorOutput(
-      const drake::systems::Context<double>& context,
-      const Eigen::VectorBlock<const Eigen::VectorXd>& input,
-      const Eigen::VectorBlock<const Eigen::VectorXd>& state,
-      Eigen::VectorBlock<Eigen::VectorXd>* output) const {
-    drake::unused(context, input);
-    *output = state;
+  void CopyStateOut(const Context<double>& context,
+                    BasicVector<double>* output) const {
+    const double x = context.get_discrete_state()[0];
+    (*output)[0] = x;
   }
 };
 
@@ -51,10 +45,10 @@ int main() {
   SimpleDiscreteTimeSystem system;
 
   // Create the simulator.
-  drake::systems::Simulator<double> simulator(system);
+  Simulator<double> simulator(system);
 
-  // Set the initial conditions x(0).
-  drake::systems::DiscreteValues<double>& state =
+  // Set the initial conditions x₀.
+  DiscreteValues<double>& state =
       simulator.get_mutable_context().get_mutable_discrete_state();
   state[0] = 0.99;
 
@@ -67,4 +61,12 @@ int main() {
   // TODO(russt): make a plot of the resulting trajectory.
 
   return 0;
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake
+
+int main() {
+  return drake::systems::main();
 }

--- a/systems/analysis/test/simulator_test.cc
+++ b/systems/analysis/test/simulator_test.cc
@@ -953,14 +953,15 @@ GTEST_TEST(SimulatorTest, SpringMass) {
 
 // This is the example from discrete_systems.h. Let's make sure it works
 // as advertised there! The discrete system is:
-//    xₙ₊₁ = xₙ + 1
-//    yₙ   = 10 xₙ
-//    x₀   = 0
+//    x_{n+1} = x_n + 1
+//    y_n     = 10 x_n
+//    x_0     = 0
 // which should produce 0 10 20 30 ... .
 //
 // Don't change this unit test without making a corresponding change to the
 // doxygen example in the systems/discrete_systems.h module. This class should
-// be copypasta identical to the code there.
+// be as identical to the code there as possible; ideally, just a
+// copy-and-paste.
 class ExampleDiscreteSystem : public LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ExampleDiscreteSystem)
@@ -968,60 +969,64 @@ class ExampleDiscreteSystem : public LeafSystem<double> {
   ExampleDiscreteSystem() {
     DeclareDiscreteState(1);  // Just one state variable, x[0], default=0.
 
-    // Output yₙ using a Drake "publish" event (occurs at the end of step n,
-    // where step 0 is "initialize" and StepTo(kPeriod) yields step 1).
-    DeclarePeriodicEvent(kPeriod, kPublishOffset,
-                         systems::PublishEvent<double>(
-                             [this](const systems::Context<double>& context,
-                                    const systems::PublishEvent<double>&) {
-                               PrintResult(context);
-                             }));
+    // Update to x_{n+1} using a Drake "discrete update" event (occurs
+    // at the beginning of step n+1).
+    DeclarePeriodicDiscreteUpdateEvent(kPeriod, kOffset,
+                                       &ExampleDiscreteSystem::Update);
 
-    // Update to xₙ₊₁, using a Drake "discrete update" event (occurs at the
-    // beginning of step n+1).
-    DeclarePeriodicEvent(kPeriod, kPublishOffset,
-                         systems::DiscreteUpdateEvent<double>(
-                             [this](const systems::Context<double>& context,
-                                    const systems::DiscreteUpdateEvent<double>&,
-                                    systems::DiscreteValues<double>* xd) {
-                               Update(context, xd);
-                             }));
+    // Present y_n (=S_n) at the output port.
+    DeclareVectorOutputPort("Sn", systems::BasicVector<double>(1),
+                            &ExampleDiscreteSystem::Output);
   }
 
-  static constexpr double kPeriod = 1/50.;  // Update at 50Hz (h=1/50).
-  static constexpr double kPublishOffset = 0.;  // Trigger events at n=0.
+  static constexpr double kPeriod = 1 / 50.;  // Update at 50Hz (h=1/50).
+  static constexpr double kOffset = 0.;       // Trigger events at n=0.
 
  private:
-  // Update function xₙ₊₁ = f(n, xₙ).
-  void Update(const systems::Context<double>& context,
-              systems::DiscreteValues<double>* xd) const {
-    const double x_n = GetX(context);
+  systems::EventStatus Update(const systems::Context<double>& context,
+                              systems::DiscreteValues<double>* xd) const {
+    const double x_n = context.get_discrete_state()[0];
     (*xd)[0] = x_n + 1.;
+    return systems::EventStatus::Succeeded();
   }
 
-  // Prints the result of output function yₙ = g(n, xₙ) to cout.
-  void PrintResult(const systems::Context<double>& context) const {
-    const double t = context.get_time();
-    const int n = static_cast<int>(std::round(t / kPeriod));
-    const double S_n = 10 * GetX(context);  // 10 xₙ[0]
-    std::cout << n << ": " << S_n << " (" << t << ")\n";
-  }
-
-  double GetX(const Context<double>& context) const {
-    return context.get_discrete_state()[0];
+  void Output(const systems::Context<double>& context,
+              systems::BasicVector<double>* result) const {
+    const double x_n = context.get_discrete_state()[0];
+    const double S_n = 10 * x_n;
+    (*result)[0] = S_n;
   }
 };
 
+// Tests the code fragment shown in the systems/discrete_systems.h module. Make
+// this as copypasta-identical as possible to the code there, and make matching
+// changes there if you change anything here.
 GTEST_TEST(SimulatorTest, ExampleDiscreteSystem) {
-  ExampleDiscreteSystem system;
+  // Build a Diagram containing the Example system and a data logger that
+  // samples the Sn output port exactly at the update times.
+  DiagramBuilder<double> builder;
+  auto example = builder.AddSystem<ExampleDiscreteSystem>();
+  auto logger = LogOutput(example->GetOutputPort("Sn"), &builder);
+  logger->set_publish_period(ExampleDiscreteSystem::kPeriod);
+  auto diagram = builder.Build();
 
-  Simulator<double> simulator(system);
-
-  // Simulate forward.
-  testing::internal::CaptureStdout();
+  // Create a Simulator and use it to advance time until t=3*h.
+  Simulator<double> simulator(*diagram);
+  simulator.set_publish_every_time_step(false);
+  simulator.set_publish_at_initialization(false);
   simulator.StepTo(3 * ExampleDiscreteSystem::kPeriod);
-  std::string output = testing::internal::GetCapturedStdout();
 
+  testing::internal::CaptureStdout();  // Not in example.
+
+  // Print out the contents of the log.
+  for (int n = 0; n < logger->sample_times().size(); ++n) {
+    const double t = logger->sample_times()[n];
+    std::cout << n << ": " << logger->data()(0, n)
+              << " (" << t << ")\n";
+  }
+
+  // Not in example (although the expected output is there).
+  std::string output = testing::internal::GetCapturedStdout();
   EXPECT_EQ(output, "0: 0 (0)\n"
                     "1: 10 (0.02)\n"
                     "2: 20 (0.04)\n"
@@ -1029,16 +1034,17 @@ GTEST_TEST(SimulatorTest, ExampleDiscreteSystem) {
 }
 
 // A hybrid discrete-continuous system:
-//   xₙ₊₁ = sin(1.234*t)
-//   yₙ = xₙ
+//   x_{n+1} = sin(1.234*t)
+//   y_n     = x_n
 // With proper initial conditions, this should produce a one-step-delayed
-// sample of the periodic function, so that yₙ = sin(1.234 * (n-1)*h).
+// sample of the periodic function, so that y_n = sin(1.234 * (n-1)*h).
 class SinusoidalDelayHybridSystem : public LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SinusoidalDelayHybridSystem)
 
   SinusoidalDelayHybridSystem() {
-    this->DeclarePeriodicDiscreteUpdate(kUpdatePeriod, 0.0);
+    this->DeclarePeriodicDiscreteUpdateEvent(
+        kUpdatePeriod, 0.0, &SinusoidalDelayHybridSystem::Update);
     this->DeclareDiscreteState(1 /* single state variable */);
     this->DeclareVectorOutputPort("y", BasicVector<double>(1),
                                   &SinusoidalDelayHybridSystem::CalcOutput);
@@ -1048,12 +1054,11 @@ class SinusoidalDelayHybridSystem : public LeafSystem<double> {
   static constexpr double kUpdatePeriod = 0.25;
 
  private:
-  void DoCalcDiscreteVariableUpdates(
-      const Context<double>& context,
-      const std::vector<const DiscreteUpdateEvent<double>*>&,
-      DiscreteValues<double>* x_next) const override {
+  EventStatus Update(const Context<double>& context,
+                     DiscreteValues<double>* x_next) const {
     const double t = context.get_time();
     (*x_next)[0] = std::sin(kSinusoidalFrequency * t);
+    return EventStatus::Succeeded();
   }
 
   void CalcOutput(const Context<double>& context,
@@ -1064,9 +1069,9 @@ class SinusoidalDelayHybridSystem : public LeafSystem<double> {
 
 // Tests that sinusoidal hybrid system that is not periodic in the update period
 // produces the result from simulating the discrete system:
-//   xₙ₊₁ = sin(f * n * h)
-//   yₙ = xₙ
-//   x₀ = sin(f * -1 * h)
+//   x_{n+1} = sin(f * n * h)
+//   y_n     = x_n
+//   x_0     = sin(f * -1 * h)
 // where h is the update period and f is the frequency of the sinusoid.
 // This should be a one-step delayed discrete sampling of the sinusoid.
 GTEST_TEST(SimulatorTest, SinusoidalHybridSystem) {
@@ -1085,8 +1090,11 @@ GTEST_TEST(SimulatorTest, SinusoidalHybridSystem) {
   const double t_final = 10.0;
   const double initial_value = std::sin(-f * h);  // = sin(f*-1*h)
   Simulator<double> simulator(*diagram);
-  simulator.set_publish_at_initialization(false);  // Remove these when #10132
-  simulator.set_publish_every_time_step(false);    // lands.
+
+  // TODO(sherm1) Remove these when #10269 lands (fix to SignalLogger).
+  simulator.set_publish_at_initialization(false);
+  simulator.set_publish_every_time_step(false);
+
   simulator.get_mutable_context().get_mutable_discrete_state()[0] =
       initial_value;
   simulator.StepTo(t_final);
@@ -1136,28 +1144,29 @@ class ShiftedTimeOutputter : public LeafSystem<double> {
 };
 
 // A hybrid discrete-continuous system:
-// x[n+1] = x[n] + u(t)
-// x[0] = 0
+//   x_{n+1} = x_n + u(t)
+//   x_0     = 0
 class SimpleHybridSystem : public LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SimpleHybridSystem)
 
   explicit SimpleHybridSystem(double offset) {
-    this->DeclarePeriodicDiscreteUpdate(kPeriod, offset);
+    this->DeclarePeriodicDiscreteUpdateEvent(kPeriod, offset,
+        &SimpleHybridSystem::Update);
     this->DeclareDiscreteState(1 /* single state variable */);
     this->DeclareVectorInputPort("u", systems::BasicVector<double>(1));
   }
 
  private:
-  void DoCalcDiscreteVariableUpdates(
+  EventStatus Update(
       const Context<double>& context,
-      const std::vector<const DiscreteUpdateEvent<double>*>&,
-      DiscreteValues<double>* x_next) const override {
-    double x = context.get_discrete_state()[0];
+      DiscreteValues<double>* x_next) const {
     const BasicVector<double>* input = this->EvalVectorInput(context, 0);
     DRAKE_DEMAND(input);
-    const double u = input->get_value()[0];
+    const double u = input->get_value()[0];  // u(t)
+    double x = context.get_discrete_state()[0];  // x_n
     (*x_next)[0] = x + u;
+    return EventStatus::Succeeded();
   }
 
   const double kPeriod = 1.0;
@@ -1168,7 +1177,7 @@ class SimpleHybridSystem : public LeafSystem<double> {
 GTEST_TEST(SimulatorTest, SimpleHybridSystemTestOffsetZero) {
   DiagramBuilder<double> builder;
   // Connect a system that outputs u(t) = t to the hybrid system
-  // x[n+1] = x[n] + u(t).
+  // x_{n+1} = x_n + u(t).
   auto shifted_time_outputter = builder.AddSystem<ShiftedTimeOutputter>();
   const double updating_offset_time = 0.0;
   auto hybrid_system = builder.AddSystem<SimpleHybridSystem>(
@@ -1177,18 +1186,18 @@ GTEST_TEST(SimulatorTest, SimpleHybridSystemTestOffsetZero) {
   auto diagram = builder.Build();
   Simulator<double> simulator(*diagram);
 
-  // Set the initial condition x₀ (the subscript notation reflects the
+  // Set the initial condition x_0 (the subscript notation reflects the
   // discrete step number as described in discrete_systems.h).
   const double initial_condition = 0.0;
   simulator.get_mutable_context().get_mutable_discrete_state()[0] =
       initial_condition;
 
   // Simulate forward. The first update occurs at t=0, meaning StepTo(1) updates
-  // the discrete state to x⁺(0) (i.e., x₁) before updating time to 1.0.
+  // the discrete state to x⁺(0) (i.e., x_1) before updating time to 1.0.
   simulator.StepTo(1.0);
 
   // Check that the expected state value was attained. The value should be
-  // x₀ + u(0) since we expect the discrete update to occur at t = 0 when
+  // x_0 + u(0) since we expect the discrete update to occur at t = 0 when
   // u(t) = 1.
   const double u0 = 1;
   EXPECT_EQ(simulator.get_context().get_discrete_state()[0],
@@ -1227,9 +1236,9 @@ class DeltaFunction : public LeafSystem<double> {
 };
 
 // This is a mixed continuous/discrete system:
-//    xₙ₊₁ = xₙ + u(t)
-//    yₙ   = xₙ
-//    x₀   = 0
+//    x_{n+1} = x_n + u(t)
+//    y_n     = x_n
+//    x_0     = 0
 // By plugging interesting things into the input we can test whether we're
 // sampling the continuous input at the appropriate times.
 class DiscreteInputAccumulator : public LeafSystem<double> {
@@ -1241,7 +1250,7 @@ class DiscreteInputAccumulator : public LeafSystem<double> {
 
     DeclareVectorInputPort("u", BasicVector<double>(1));
 
-    // Set initial condition x₀ = 0, and clear the result.
+    // Set initial condition x_0 = 0, and clear the result.
     DeclareInitializationEvent(
         DiscreteUpdateEvent<double>([this](const Context<double>&,
                                            const DiscreteUpdateEvent<double>&,
@@ -1250,16 +1259,16 @@ class DiscreteInputAccumulator : public LeafSystem<double> {
           result_.clear();
         }));
 
-    // Output yₙ using a Drake "publish" event (occurs at the end of step n).
+    // Output y_n using a Drake "publish" event (occurs at the end of step n).
     DeclarePeriodicEvent(
         kPeriod, kPublishOffset,
         PublishEvent<double>(
             [this](const Context<double>& context,
                    const PublishEvent<double>&) {
-              result_.push_back(get_x(context));  // yₙ = xₙ
+              result_.push_back(get_x(context));  // y_n = x_n
             }));
 
-    // Update to xₙ₊₁ (x_np1), using a Drake "discrete update" event (occurs
+    // Update to x_{n+1} (x_np1), using a Drake "discrete update" event (occurs
     // at the beginning of step n+1).
     DeclarePeriodicEvent(
         kPeriod, kPublishOffset,
@@ -1268,7 +1277,7 @@ class DiscreteInputAccumulator : public LeafSystem<double> {
                                            DiscreteValues<double>* x_np1) {
           const double x_n = get_x(context);
           const double u = EvalVectorInput(context, 0)->GetAtIndex(0);
-          x_np1->get_mutable_vector()[0] = x_n + u;  // xₙ₊₁ = xₙ + u(t)
+          x_np1->get_mutable_vector()[0] = x_n + u;  // x_{n+1} = x_n + u(t)
         }));
   }
 
@@ -1287,13 +1296,13 @@ class DiscreteInputAccumulator : public LeafSystem<double> {
 
 // Build a diagram that takes a DeltaFunction input and then simulates this
 // mixed discrete/continuous system:
-//    xₙ₊₁ = xₙ + u(t)
-//    yₙ   = xₙ
-//    x₀   = 0
-// Let tₛ be the chosen "spike time" for the delta function. We expect the
-// output yₙ to be zero for all n unless a sample at k*h occurs exactly at
-// tₛ for some k. In that case yₙ=0, n ≤ k and yₙ=1, n > k. Important cases
-// to check are: tₛ=0, tₛ=k*h for some k>0, and tₛ≠k*h for any k.
+//    x_{n+1} = x_n + u(t)
+//    y_n     = x_n
+//    x_0     = 0
+// Let t_s be the chosen "spike time" for the delta function. We expect the
+// output y_n to be zero for all n unless a sample at k*h occurs exactly at
+// tₛ for some k. In that case y_n=0, n ≤ k and y_n=1, n > k. Important cases
+// to check are: t_s=0, t_s=k*h for some k>0, and t_s≠k*h for any k.
 GTEST_TEST(SimulatorTest, SpikeTest) {
   DiagramBuilder<double> builder;
 

--- a/systems/discrete_systems.h
+++ b/systems/discrete_systems.h
@@ -14,32 +14,33 @@ as well as considerations for implementing these systems in Drake.
 
 The state space dynamics of a discrete system is:
 ```
-    xₙ₊₁ = f(n, xₙ, uₙ)    // update
-    yₙ   = g(n, xₙ, uₙ)    // output
-    x₀   = xᵢₙᵢₜ           // initialize
+    x_{n+1} = f(n, x_n, u_n)    // update
+    y_n     = g(n, x_n, u_n)    // output
+    x_0     = x_init            // initialize
 ```
+(We're using LaTeX underscore notation for subscripts, where x_0 means x₀.)
 
-where n ∈ ℕ is the step number (typically starting at zero), x is the discrete
-state variable ("discrete" refers to the countability of the elements of the
-sequence, x₀, x₁, ..., xₙ and not the values that x can take), y is the desired
+Here n ∈ ℕ is the step number (typically starting at zero), x is the
+discrete-time state variable ("discrete time" refers to the countability of the
+elements of the sequence, x_0, x_1, ..., x_n and not the values that x can
+take), y is the desired
 output, and u is an external input. f(.) and g(.) are the _update_ and _output_
 functions, respectively. Any of these quantities can be vector-valued. The
-subscript notation (e.g., x₀) is used to show that the state, input, and output
+subscript notation (e.g., x_0) is used to show that the state, input, and output
 result from a discrete process. We use square bracket notation, e.g. x[1] to
 designate particular elements of a vector-valued quantity (indexing from 0).
-Combined, x₁[3] would be the value of the fourth element of the x vector,
-evaluated at step n=1. In code we use a Latex-like underscore to indicate the
-step number, so we write x_1[3] to represent x₁[3].
+Combined, x_1[3] would be the value of the fourth element of the x vector,
+evaluated at step n=1.
 
 <h3>A pedagogical example: simple difference equation</h3>
 
 The following class implements in Drake the simple discrete system
 ```
-    xₙ₊₁ = xₙ + 1
-    yₙ   = 10 xₙ
-    x₀   = 0
+    x_{n+1} = x_n + 1
+    y_n     = 10 x_n
+    x_0     = 0
 ```
-which should generate the sequence `S = 0 10 20 30 ...` (that is, `Sₙ = 10*n`).
+which should generate the sequence `S = 0 10 20 30 ...` (that is, `S_n = 10*n`).
 
 @code{.cpp}
 class ExampleDiscreteSystem : public LeafSystem<double> {
@@ -49,57 +50,59 @@ class ExampleDiscreteSystem : public LeafSystem<double> {
   ExampleDiscreteSystem() {
     DeclareDiscreteState(1);  // Just one state variable, x[0], default=0.
 
-    // Output yₙ using a Drake "publish" event (occurs at the end of step n).
-    DeclarePeriodicEvent(kPeriod, kOffset,
-                         systems::PublishEvent<double>(
-                             [this](const systems::Context<double>& context,
-                                    const systems::PublishEvent<double>&) {
-                               PrintResult(context);
-                             }));
+    // Update to x_{n+1}, using a Drake "discrete update" event (occurs
+    // at the beginning of step n+1).
+    DeclarePeriodicDiscreteUpdateEvent(kPeriod, kOffset,
+                                       &ExampleDiscreteSystem::Update);
 
-    // Update to xₙ₊₁, using a Drake "discrete update" event (occurs at the
-    // beginning of step n+1).
-    DeclarePeriodicEvent(kPeriod, kOffset,
-                         systems::DiscreteUpdateEvent<double>(
-                             [this](const systems::Context<double>& context,
-                                    const systems::DiscreteUpdateEvent<double>&,
-                                    systems::DiscreteValues<double>* xd) {
-                               Update(context, xd);
-                             }));
+    // Present y_n (=S_n) at the output port.
+    DeclareVectorOutputPort("Sn", systems::BasicVector<double>(1),
+                            &ExampleDiscreteSystem::Output);
   }
 
-  static constexpr double kPeriod = 1/50.;  // Update at 50Hz (h=1/50).
-  static constexpr double kOffset = 0.;  // Trigger events at n=0.
+  static constexpr double kPeriod = 1 / 50.;  // Update at 50Hz (h=1/50).
+  static constexpr double kOffset = 0.;       // Trigger events at n=0.
 
  private:
-  // Update function xₙ₊₁ = f(n, xₙ).
   void Update(const systems::Context<double>& context,
               systems::DiscreteValues<double>* xd) const {
-    const double x_n = GetX(context);
+    const double x_n = context.get_discrete_state()[0];
     (*xd)[0] = x_n + 1.;
   }
 
-  // Prints the result of output function yₙ = g(n, xₙ) to cout.
-  void PrintResult(const systems::Context<double>& context) const {
-    const double t = context.get_time();
-    const int n = static_cast<int>(std::round(t / kPeriod));
-    const double S_n = 10 * GetX(context);  // 10 xₙ[0]
-    std::cout << n << ": " << S_n << " (" << t << ")\n";
-  }
-
-  double GetX(const Context<double>& context) const {
-    return context.get_discrete_state()[0];
+  void Output(const systems::Context<double>& context,
+              systems::BasicVector<double>* result) const {
+    const double x_n = context.get_discrete_state()[0];
+    const double S_n = 10 * x_n;
+    (*result)[0] = S_n;
   }
 };
 @endcode
 
-Stepping this system forward using the following code fragment:
+The following code fragment can be used to step this system forward:
 @code
-  ExampleDiscreteSystem system;
-  Simulator<double> simulator(system);
+  // Build a Diagram containing the Example system and a data logger that
+  // samples the Sn output port exactly at the update times.
+  DiagramBuilder<double> builder;
+  auto example = builder.AddSystem<ExampleDiscreteSystem>();
+  auto logger = LogOutput(example->GetOutputPort("Sn"), &builder);
+  logger->set_publish_period(ExampleDiscreteSystem::kPeriod);
+  auto diagram = builder.Build();
+
+  // Create a Simulator and use it to advance time until t=3*h.
+  Simulator<double> simulator(*diagram);
+  simulator.set_publish_every_time_step(false);
+  simulator.set_publish_at_initialization(false);
   simulator.StepTo(3 * ExampleDiscreteSystem::kPeriod);
+
+  // Print out the contents of the log.
+  for (int n = 0; n < logger->sample_times().size(); ++n) {
+    const double t = logger->sample_times()[n];
+    std::cout << n << ": " << logger->data()(0, n)
+        << " (" << t << ")\n";
+  }
 @endcode
-yields the following output:
+The above yields the following output:
 ```
     0: 0 (0)
     1: 10 (0.02)
@@ -112,7 +115,7 @@ yields the following output:
 Purely-discrete systems produce values only intermittently. For example, the
 system above generates values only at integer values of n: <pre>
 
-     yₙ
+     y_n
       |
    30 |              ●
       |              ┆             Figure 1. The discrete-valued system
@@ -171,7 +174,7 @@ You might expect that 2(b) would be the most natural mapping from the
 discrete system to a continuous one. In practice, however, it is problematic
 for mixed discrete/continuous (hybrid) systems so Drake uses the mapping in
 2(a). The advantage of 2(a) is that the hybrid update function
-`xₙ₊₁ = f(t,n,xₙ,u(t))` is invoked at time `t=n*h`, while in 2(b) it would be
+`x_{n+1} = f(t,n,x_n,u(t))` is invoked at time `t=n*h`, while in 2(b) it would be
 invoked at time `t=(n+1)*h`. That would make it difficult to coordinate discrete
 and continuous signals.
 
@@ -179,7 +182,7 @@ Drake's choice of 2(a) dictates what value a discrete quantity will have when
 evaluated at times _between_ update times. In particular, consider a discrete
 variable x evaluated during a simulation from a publish, update, or derivative
 function at times `t ∈ (n*h, (n+1)*h]`. x will be seen to have value
-`x(t) = xₙ₊₁` (_not_ `xₙ`). You can see that clearly by inspection of
+`x(t) = x_{n+1}` (_not_ `x_n`). You can see that clearly by inspection of
 Figure 2(a).
 
 <h3>Timing of publish vs. discrete update events in Drake</h3>
@@ -191,7 +194,7 @@ denote the "pre-update" value of the state x, and x⁺(t) to denote the
 "post-update" value of x. So x⁻(t) is the value of x at time t _before_ discrete
 variables are updated, and x⁺(t) the value of x at time t _after_ they are
 updated. Thus if we have `t = n*h` as in the discussion above, then
-`x⁻(t) = xₙ` and `x⁺(t) = xₙ₊₁`. State-dependent computations are affected
+`x⁻(t) = x_n` and `x⁺(t) = x_{n+1}`. State-dependent computations are affected
 by the scheduling of these updates. For example, evaluating an input u(t) yields
 u⁻(t) before discrete updates, and u⁺(t) afterwards, meaning that the input
 evaluation is carried out using x⁻(t) or x⁺(t), respectively.

--- a/systems/lcm/lcm_driven_loop.h
+++ b/systems/lcm/lcm_driven_loop.h
@@ -65,7 +65,7 @@ class UtimeMessageToSeconds : public LcmMessageToTimeInterface {
  * the concrete type of the message, and is able to supply a time converter.
  *
  * This class uses the Simulator class internally for event handling
- * (kPublishAction, kDiscreteUpdateAction, kUnrestrictedUpdateAction) and
+ * (publish, discrete update, and unrestricted update) and
  * continuous state integration (e.g. the I term in a PID). The main message
  * handling loop conceptually is:
  * <pre>
@@ -96,7 +96,7 @@ class UtimeMessageToSeconds : public LcmMessageToTimeInterface {
  * This implementation relies on several assumptions:
  *
  * 1. The loop is blocked only on one Lcm message.
- * 2. It's pointless to for the handler system to perform any computation
+ * 2. It's pointless for the handler system to perform any computation
  *    without a new Lcm message, thus the handler loop is blocking.
  * 3. The computation for the given system should be faster than the incoming
  *    message rate.


### PR DESCRIPTION
Per discussion in #9766, this uses the new event sugar from #10321 (and adds some more) to improve several pedagogical examples. Also switches the examples introduced in #9766 from console output to using output ports and SignalLogger.

There is still some ugliness here due to SignalLogger still using the DoPublish() override rather than declaring an explicit publish Event. Specifically, these lines are required now but shouldn't be:
```c++
  simulator.set_publish_every_time_step(false);
  simulator.set_publish_at_initialization(false);
```
When #10269 lands those can be removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10346)
<!-- Reviewable:end -->
