### PR TITLE
logging: Allow the user access to the default sink

### DIFF
--- a/common/test/text_logging_test.cc
+++ b/common/test/text_logging_test.cc
@@ -1,9 +1,11 @@
 #include "drake/common/text_logging.h"
 
 #include <ostream>
+#include <sstream>
 #include <string>
 #include <vector>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 // The BUILD.bazel rules must supply this flag.  This test code is compiled and
@@ -22,6 +24,11 @@
     #error Unwanted HAVE_SPDLOG.
   #endif
 #endif
+
+#ifdef HAVE_SPDLOG
+#include <spdlog/sinks/dist_sink.h>
+#include <spdlog/sinks/ostream_sink.h>
+#endif  // HAVE_SPDLOG
 
 namespace {
 
@@ -122,6 +129,29 @@ GTEST_TEST(TextLoggingTest, DrakeMacrosDontEvaluateArguments) {
   #endif
   tracearg = 0;
   debugarg = 0;
+}
+
+// We must run this test last because it changes the default configuration.
+GTEST_TEST(TextLoggingTest, ZZZ_ChangeDefaultSink) {
+  // The getter should never return nullptr, even with spdlog disabled.
+  drake::logging::sink* const sink_base = drake::logging::get_dist_sink();
+  ASSERT_NE(sink_base, nullptr);
+
+  // The remainder of the test case only makes sense when spdlog is enabled.
+  #if TEXT_LOGGING_TEST_SPDLOG
+    // Our API promises that the result always has this subtype.
+    auto* const sink = dynamic_cast<spdlog::sinks::dist_sink_mt*>(sink_base);
+    ASSERT_NE(sink, nullptr);
+
+    // Redirect all logs to a memory stream.
+    std::ostringstream messages;
+    auto custom_sink = std::make_shared<spdlog::sinks::ostream_sink_st>(
+        messages, true /* flush */);
+    sink->set_sinks({custom_sink});
+    drake::log()->info("This is some good info!");
+    EXPECT_THAT(messages.str(), testing::EndsWith(
+        "[console] [info] This is some good info!\n"));
+  #endif
 }
 
 }  // anon namespace

--- a/common/text_logging.cc
+++ b/common/text_logging.cc
@@ -2,8 +2,10 @@
 
 #include <memory>
 #include <mutex>
+#include <utility>
 
 #ifdef HAVE_SPDLOG
+#include <spdlog/sinks/dist_sink.h>
 #include <spdlog/sinks/stdout_sinks.h>
 #endif
 
@@ -21,10 +23,14 @@ std::shared_ptr<logging::logger> onetime_create_log() {
   // will just return it; if not, we'll create our own default one.
   std::shared_ptr<logging::logger> result(spdlog::get("console"));
   if (!result) {
-    // We use the logger_mt (instead of logger_st) so more than one thread can
-    // use this logger and have their messages be staggered by line, instead of
-    // co-mingling their character bytes.
-    result = spdlog::stderr_logger_mt("console");
+    // We wrap our stderr sink in a dist_sink so that users can atomically swap
+    // out the sinks used by all Drake logging, via dist_sink_mt's APIs.
+    auto wrapper = std::make_shared<spdlog::sinks::dist_sink_mt>();
+    // We use the stderr_sink_mt (instead of stderr_sink_st) so more than one
+    // thread can use this logger and have their messages be staggered by line,
+    // instead of co-mingling their character bytes.
+    wrapper->add_sink(std::make_shared<spdlog::sinks::stderr_sink_mt>());
+    result = std::make_shared<logging::logger>("console", std::move(wrapper));
   }
   return result;
 }
@@ -36,14 +42,34 @@ logging::logger* log() {
   return g_logger.access().get();
 }
 
+logging::sink* logging::get_dist_sink() {
+  // Extract the dist_sink_mt from Drake's logger instance.
+  auto* sink = log()->sinks().empty() ? nullptr : log()->sinks().front().get();
+  auto* result = dynamic_cast<spdlog::sinks::dist_sink_mt*>(sink);
+  if (result == nullptr) {
+    throw std::logic_error(
+        "drake::logging::get_sink(): error: the spdlog sink configuration has"
+        "unexpectedly changed.");
+  }
+  return result;
+}
+
 #else  // HAVE_SPDLOG
 
 logging::logger::logger() {}
+
+logging::sink::sink() {}
 
 logging::logger* log() {
   // A do-nothing logger instance.
   static logging::logger g_logger;
   return &g_logger;
+}
+
+logging::sink* logging::get_dist_sink() {
+  // An empty sink instance.
+  static logging::sink g_sink;
+  return &g_sink;
 }
 
 #endif  // HAVE_SPDLOG

--- a/common/text_logging.h
+++ b/common/text_logging.h
@@ -98,6 +98,10 @@ namespace logging {
 /// See the text_logging.h documentation for a short tutorial.
 using logger = spdlog::logger;
 
+/// When spdlog is enabled in this build, drake::logging::sink is an alias for
+/// spdlog::sinks::sink.  When spdlog is disabled, it is an empty class.
+using spdlog::sinks::sink;
+
 /// True only if spdlog is enabled in this build.
 constexpr bool kHaveSpdlog = true;
 
@@ -138,6 +142,14 @@ class logger {
   template <typename T> void critical(const T&) {}
 };
 
+// A stubbed-out version of `spdlog::sinks::sink`.
+class sink {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(sink)
+
+  sink();
+};
+
 }  // namespace logging
 
 #define SPDLOG_TRACE(logger, ...)
@@ -155,4 +167,14 @@ class logger {
 /// See the text_logging.h documentation for a short tutorial.
 logging::logger* log();
 
+namespace logging {
+
+/// (Advanced) Retrieves the default sink for all Drake logs.  When spdlog is
+/// enabled, the return value can be cast to spdlog::sinks::dist_sink_mt and
+/// thus allows consumers of Drake to redirect Drake's text logs to locations
+/// other than the default of stderr.  When spdlog is disabled, the return
+/// value is an empty class.
+sink* get_dist_sink();
+
+}  // namespace logging
 }  // namespace drake


### PR DESCRIPTION
This permits Drake users to redirect Drake's text logs.

This was inspired by discussions last summer about hooking up Drake to other logging back-ends (#8955).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10356)
<!-- Reviewable:end -->
