### PR TITLE
systems/lcm: Use model value for publisher input

### DIFF
--- a/systems/lcm/BUILD.bazel
+++ b/systems/lcm/BUILD.bazel
@@ -127,6 +127,7 @@ drake_cc_library(
 )
 
 # === test ===
+
 drake_cc_googletest(
     name = "lcm_driven_loop_test",
     # TODO(jamiesnape, siyuanfeng-tri): Remove flaky flag, see #5936.
@@ -147,9 +148,22 @@ drake_cc_googletest(
     ],
 )
 
+drake_cc_library(
+    name = "custom_drake_signal_translator",
+    testonly = 1,
+    hdrs = ["test/custom_drake_signal_translator.h"],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":translator",
+        "//lcmtypes:drake_signal",
+        "//systems/framework/test_utilities:my_vector",
+    ],
+)
+
 drake_cc_googletest(
     name = "lcm_publisher_system_test",
     deps = [
+        ":custom_drake_signal_translator",
         ":lcm_pubsub_system",
         ":lcmt_drake_signal_translator",
         "//common/test_utilities:is_dynamic_castable",
@@ -171,11 +185,11 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "lcm_subscriber_system_test",
     deps = [
+        ":custom_drake_signal_translator",
         ":lcm_pubsub_system",
         ":lcmt_drake_signal_translator",
         "//lcm:lcmt_drake_signal_utils",
         "//lcm:mock",
-        "//systems/framework/test_utilities:my_vector",
     ],
 )
 

--- a/systems/lcm/test/custom_drake_signal_translator.h
+++ b/systems/lcm/test/custom_drake_signal_translator.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "drake/lcmt_drake_signal.hpp"
+#include "drake/systems/framework/test_utilities/my_vector.h"
+#include "drake/systems/lcm/lcm_and_vector_base_translator.h"
+
+namespace drake {
+namespace systems {
+namespace lcm {
+namespace test {
+
+// A lcmt_drake_signal translator that preserves coordinate names.
+class CustomDrakeSignalTranslator : public LcmAndVectorBaseTranslator {
+ public:
+  enum : int { kDim = 3 };
+
+  // An output vector type that tests that subscribers permit non-default
+  // types.
+  using CustomVector = MyVector<kDim, double>;
+
+  CustomDrakeSignalTranslator() : LcmAndVectorBaseTranslator(kDim) {}
+
+  std::unique_ptr<BasicVector<double>> AllocateOutputVector() const override {
+    return std::make_unique<CustomVector>();
+  }
+
+  static std::string NameFor(int index) {
+    return std::to_string(index) + "_name";
+  }
+
+  void Deserialize(const void* lcm_message_bytes, int lcm_message_length,
+                   VectorBase<double>* vector_base) const override {
+    CustomVector* const custom_vector =
+        dynamic_cast<CustomVector*>(vector_base);
+    ASSERT_NE(nullptr, custom_vector);
+
+    // Decode the LCM message.
+    drake::lcmt_drake_signal message;
+    int status = message.decode(lcm_message_bytes, 0, lcm_message_length);
+    ASSERT_GE(status, 0);
+    ASSERT_EQ(kDim, message.dim);
+
+    // Copy message into our custom_vector.
+    for (int i = 0; i < kDim; ++i) {
+      EXPECT_EQ(message.coord[i], NameFor(i));
+      custom_vector->SetAtIndex(i, message.val[i]);
+    }
+  }
+
+  void Serialize(double time, const VectorBase<double>& vector_base,
+                 std::vector<uint8_t>* lcm_message_bytes) const override {
+    const CustomVector* const custom_vector =
+        dynamic_cast<const CustomVector*>(&vector_base);
+    ASSERT_NE(nullptr, custom_vector);
+    ASSERT_NE(nullptr, lcm_message_bytes);
+
+    // Copy custom_vector into the message.
+    drake::lcmt_drake_signal message;
+    message.dim = kDim;
+    message.val.resize(kDim);
+    message.coord.resize(kDim);
+    message.timestamp = static_cast<int64_t>(time * 1000);
+
+    for (int i = 0; i < kDim; ++i) {
+      message.val.at(i) = custom_vector->GetAtIndex(i);
+      message.coord.at(i) = NameFor(i);
+    }
+
+    // Encode the LCM message.
+    const int lcm_message_length = message.getEncodedSize();
+    lcm_message_bytes->resize(lcm_message_length);
+    message.encode(lcm_message_bytes->data(), 0, lcm_message_length);
+  }
+};
+
+}  // namespace test
+}  // namespace lcm
+}  // namespace systems
+}  // namespace drake

--- a/systems/lcm/test/lcm_publisher_system_test.cc
+++ b/systems/lcm/test/lcm_publisher_system_test.cc
@@ -14,6 +14,7 @@
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/lcm/lcm_translator_dictionary.h"
 #include "drake/systems/lcm/lcmt_drake_signal_translator.h"
+#include "drake/systems/lcm/test/custom_drake_signal_translator.h"
 
 using std::make_unique;
 using std::unique_ptr;
@@ -249,6 +250,22 @@ GTEST_TEST(LcmPublisherSystemTest, OwnedTranslatorTest) {
   LcmPublisherSystem dut(channel_name, std::move(translator), &lcm);
 
   TestPublisher(channel_name, &lcm, &dut);
+}
+
+// Publish from a custom VectorBase type.
+GTEST_TEST(LcmSubscriberSystemTest, CustomVectorBaseTest) {
+  const std::string channel_name = "dummy";
+
+  test::CustomDrakeSignalTranslator translator;
+  drake::lcm::DrakeMockLcm lcm;
+  LcmPublisherSystem dut(channel_name, translator, &lcm);
+
+  // Test that the System has declared the correct allocator, based on the
+  // user's translator.
+  using Expected = test::CustomDrakeSignalTranslator::CustomVector;
+  std::unique_ptr<BasicVector<double>> input_storage =
+      dut.AllocateInputVector(dut.get_input_port());
+  EXPECT_TRUE(is_dynamic_castable<Expected>(input_storage.get()));
 }
 
 }  // namespace


### PR DESCRIPTION
Discovered while working on #9669.

This is important when the basic vector subtype has intrinsic constraints (e.g., a bounding box on its values), and to enable type-checking for diagram wiring or FixInputPort cross-checks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10359)
<!-- Reviewable:end -->
