### PR TITLE
Make per-step publish events trigger at end of Initialize()

### DIFF
--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -746,16 +746,19 @@ void Simulator<T>::Initialize() {
   // Allocate the witness function collection.
   witnessed_events_ = system_.AllocateCompositeEventCollection();
 
-  // Do any publishes last. Merge the initialization events with current_time
-  // timed events (if any). We expect all initialization events to precede
-  // any timed events in the merged collection.
+  // Do any publishes last. Merge the initialization events with per-step
+  // events and current_time timed events (if any). We expect all initialization
+  // events to precede any per-step or timed events in the merged collection.
+  // Note that per-step and timed discrete/unrestricted update events are *not*
+  // processed here; just publish events.
+  init_events->Merge(*per_step_events_);
   if (timed_or_witnessed_event_triggered_) {
     init_events->Merge(*timed_events_);
   }
   HandlePublish(init_events->get_publish_events());
 
   // TODO(siyuan): transfer publish entirely to individual systems.
-  // Do a publish before the simulation starts.
+  // Do a force-publish before the simulation starts.
   if (publish_at_initialization_) {
     system_.Publish(*context_);
     ++num_publishes_;

--- a/systems/analysis/test/simulator_test.cc
+++ b/systems/analysis/test/simulator_test.cc
@@ -1949,31 +1949,33 @@ GTEST_TEST(SimulatorTest, PerStepAction) {
   sim.get_mutable_integrator()->set_maximum_step_size(0.001);
 
   // Disables all simulator induced publish events, so that all publish calls
-  // are intiated by sys.
+  // are initiated by sys.
   sim.set_publish_at_initialization(false);
   sim.set_publish_every_time_step(false);
   sim.Initialize();
   sim.StepTo(0.1);
 
-  double dt = sim.get_integrator()->get_maximum_step_size();
-  int N = static_cast<int>(0.1 / dt);
-  // Need to change this if the default integrator step size is not 1ms.
+  const double dt = sim.get_integrator()->get_maximum_step_size();
+  const int N = static_cast<int>(0.1 / dt);
+  // Step size was set to 1ms above; make sure we don't have roundoff trouble.
   EXPECT_EQ(N, 100);
   ASSERT_EQ(sim.get_num_steps_taken(), N);
 
   auto& publish_times = sys.get_publish_times();
   auto& discrete_update_times = sys.get_discrete_update_times();
   auto& unrestricted_update_times = sys.get_unrestricted_update_times();
-  ASSERT_EQ(publish_times.size(), N);
+  ASSERT_EQ(publish_times.size(), N + 1);  // Once at end of Initialize().
   ASSERT_EQ(sys.get_discrete_update_times().size(), N);
   ASSERT_EQ(sys.get_unrestricted_update_times().size(), N);
-  for (size_t i = 0; i < publish_times.size(); ++i) {
-    // Publish happens at the end of a step; unrestricted and discrete
-    // updates happen at the beginning of a step.
-    EXPECT_NEAR(publish_times[i], (i + 1) * dt, 1e-12);
+  for (int i = 0; i < N; ++i) {
+    // Publish happens at the end of a step (including end of Initialize());
+    // unrestricted and discrete updates happen at the beginning of a step.
+    EXPECT_NEAR(publish_times[i], i * dt, 1e-12);
     EXPECT_NEAR(discrete_update_times[i], i * dt, 1e-12);
     EXPECT_NEAR(unrestricted_update_times[i], i * dt, 1e-12);
   }
+  // There is a final end-of-step publish, but no final updates.
+  EXPECT_NEAR(publish_times[N], N * dt, 1e-12);
 }
 
 // Tests initialization from the simulator.

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -850,10 +850,10 @@ class LeafSystem : public System<T> {
   /// @anchor declare_per-step_events
   /// @name                 Declare per-step events
   /// These methods are used to declare events that are triggered whenever the
-  /// Drake Simulator::StepTo() method takes a substep that advances the
-  /// simulated trajectory. Note that each call to StepTo() typically generates
-  /// many trajectory-advancing substeps of varying time intervals; per-step
-  /// events are triggered for each of those substeps.
+  /// Drake Simulator advances the simulated trajectory. Note that each call to
+  /// Simulator::StepTo() typically generates many trajectory-advancing substeps
+  /// of varying time intervals; per-step events are triggered for each of those
+  /// substeps.
   ///
   /// Per-step events are useful for taking discrete action at every point of a
   /// simulated trajectory (generally spaced irregularly in time) without
@@ -872,11 +872,11 @@ class LeafSystem : public System<T> {
   ///
   /// Per-step events are issued as follows: First, the Simulator::Initialize()
   /// method queries and records the set of declared per-step events, which set
-  /// does not change during a simulation. Then every StepTo() internal substep
-  /// dispatches unrestricted and discrete update events at the start of the
-  /// step, and dispatches publish events at the end of the step (that is,
-  /// after time advances). No per-step event is triggered during the
-  /// Initialize() call.
+  /// does not change during a simulation. Any per-step publish events are
+  /// dispatched at the end of Initialize(). Then every StepTo() internal
+  /// substep dispatches unrestricted and discrete update events at the start of
+  /// the step, and dispatches publish events at the end of the step (that is,
+  /// after time advances).
   ///
   /// Template arguments to these methods are inferred from the argument lists
   /// and need not be specified explicitly.


### PR DESCRIPTION
A System that declared a per-step publish Event would not see that Event triggered at the start time, although per-step discrete/unrestricted updates _are_ processed at start time. This PR fixes that by treating per-step publish the same way as periodic publish was fixed in #9766.

This change brings per-step events into line with periodic events as fixed in #9766, in this sense:
- Consider a periodic publish event with period 1ms, offset 0.
    - Simulate with a fixed time step of 1ms for 10 steps.
    - We get 11 publishes at times 0, 1, ..., 10. Everyone is happy.
- Now consider that same system with a per-step event.
    - Previously it would have published 10 times at 1, ..., 10.
    - With this PR we get 11 publishes exactly as for the periodic event.

This makes a per-step event with fixed step size h exactly the same as a periodic event with period h. That's a nice property -- IMO any other behavior would be a surprise and require justifying.

See open PR #10341 for more discussion -- this will eliminate some initialization events that had to be added there to obtain the first per-step publish.

Note that this affects only _explicit_ declarations of per-step publish events -- the behavior of the Simulator's optional per-step and initialize force-publish is unchanged. These explicit declarations are not yet in common use (tests only in Drake -- sugar to declare these was only added in #10321 a few days ago).

Fixes #10327