### PR TITLE
workspace/lcm: Disable all compiler warnings

### DIFF
--- a/tools/workspace/lcm/package.BUILD.bazel
+++ b/tools/workspace/lcm/package.BUILD.bazel
@@ -40,9 +40,7 @@ generate_export_header(
 # These options are used when building all LCM C/C++ code.
 # They do not flow downstream to LCM-using libraries.
 LCM_COPTS = [
-    "-Wno-all",
-    "-Wno-deprecated-declarations",
-    "-Wno-format-zero-length",
+    "-w",
     "-std=gnu11",
     "-fvisibility=hidden",
 ]


### PR DESCRIPTION
Without this, on gcc-7.3 we have `lcm_logger.c:150:64: warning: '%02d' directive output may be truncated writing between 2 and 11 bytes ...`.

The toggle -Wno-format-truncation is not supported by clang, so it's easiest to just disable everything.

Closes #9946.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10363)
<!-- Reviewable:end -->
