### PR TITLE
mbp: Bugfix `HasFrameNamed` when frame instances are different from bodies

### DIFF
--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -1027,7 +1027,7 @@ class MultibodyTree {
     // See notes in `HasBodyNamed`.
     const auto range = frame_name_to_index_.equal_range(name);
     for (auto it = range.first; it != range.second; ++it) {
-      if (get_frame(it->second).body().model_instance() == model_instance) {
+      if (get_frame(it->second).model_instance() == model_instance) {
         return true;
       }
     }

--- a/multibody/tree/test/frames_test.cc
+++ b/multibody/tree/test/frames_test.cc
@@ -209,6 +209,19 @@ TEST_F(FrameTests, ModelInstanceOverride) {
   EXPECT_EQ(frameSChild_->model_instance(), extra_instance_);
 }
 
+// Verifies that `HasFrameNamed` has model instances correctly mapped for named
+// frames.
+TEST_F(FrameTests, HasFrameNamed) {
+  for (FrameIndex i{0}; i < tree().num_frames(); ++i) {
+    auto& frame = tree().get_frame(i);
+    if (!frame.name().empty()) {
+      EXPECT_TRUE(
+          tree().HasFrameNamed(frame.name(), frame.model_instance()))
+          << frame.name();
+    }
+  }
+}
+
 }  // namespace
 }  // namespace multibody
 }  // namespace drake


### PR DESCRIPTION
I thought I had fixed this a while back, but apparently not!

The added test fails without the change to MBT.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10369)
<!-- Reviewable:end -->
