### PR TITLE
tools: Disable clang_format_lint on macOS by default

### DIFF
--- a/tools/macos.bazelrc
+++ b/tools/macos.bazelrc
@@ -11,3 +11,10 @@ build:python3 --action_env=DRAKE_PYTHON_BIN_PATH=/usr/local/bin/python3
 # Configure ${PATH} for actions.
 # N.B. Ensure this is consistent with `execute.bzl`.
 build --action_env=PATH=/usr/local/bin:/usr/bin:/bin
+
+# TODO(#10370) Disable some linter tests on macOS until we can repair its
+# clang-format.  We should remove this section once the linter works again.
+test --test_tag_filters=-gurobi,-mosek,-snopt,-clang_format_lint
+test:everything --test_tag_filters=-no_everything,-clang_format_lint
+test:asan --test_tag_filters=-gurobi,-mosek,-snopt,-no_asan,-no_lsan,-clang_format_lint
+test:asan_everything --test_tag_filters=-no_asan,-no_lsan,-clang_format_lint


### PR DESCRIPTION
The version of clang-format on macOS homebrew has been upgraded, and now the formatter wants to make adjustments to pydrake bindings. The version that we're using on Ubuntu disagrees.

Relates #10370.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10371)
<!-- Reviewable:end -->
