### PR TITLE
Patch the dev version of the bouncing balls demo

### DIFF
--- a/examples/scene_graph/dev/bouncing_ball_plant.cc
+++ b/examples/scene_graph/dev/bouncing_ball_plant.cc
@@ -6,6 +6,7 @@
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/geometry_frame.h"
 #include "drake/geometry/geometry_instance.h"
+#include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/query_results/penetration_as_point_pair.h"
 #include "drake/geometry/shape_specification.h"
 
@@ -17,7 +18,9 @@ namespace bouncing_ball {
 using geometry::FramePoseVector;
 using geometry::GeometryFrame;
 using geometry::GeometryInstance;
+using geometry::IllustrationProperties;
 using geometry::PenetrationAsPointPair;
+using geometry::ProximityProperties;
 using geometry::SceneGraph;
 using geometry::SourceId;
 using geometry::Sphere;
@@ -52,6 +55,9 @@ BouncingBallPlant<T>::BouncingBallPlant(SourceId source_id,
       make_unique<GeometryInstance>(Isometry3<double>::Identity(), /*X_FG*/
                                     make_unique<Sphere>(diameter_ / 2.0),
                                     "ball"));
+  // Use the default material.
+  scene_graph->AssignRole(source_id, ball_id_, IllustrationProperties());
+  scene_graph->AssignRole(source_id, ball_id_, ProximityProperties());
 
   // Allocate the output port now that the frame has been registered.
   geometry_pose_port_ = this->DeclareAbstractOutputPort(


### PR DESCRIPTION
This addresses one problem and provides infrastructure for solving another.

1) It got left behind in an earlier PR (#10233) such that it's geometry wasn't being illustrated or perceived. This explicitly introduces the role assignments that had been implicitly deleted.
2) Add some command-line arguments to test performance. This enables execution with variants of rendering. For example:

### Run without any rendering at all
`bazel run examples/scene_graph/dev/bouncing_ball_run_dynamics -- --render_on=false`

### Run with only rendering color
`bazel run examples/scene_graph/dev/bouncing_ball_run_dynamics -- --depth=false --label=false`

### Run with only rendering depth
`bazel run examples/scene_graph/dev/bouncing_ball_run_dynamics -- --color=false --label=false`

### Run with only rendering label
`bazel run examples/scene_graph/dev/bouncing_ball_run_dynamics -- --depth=false --color=false`

### Render only color at 100 fps
`bazel run examples/scene_graph/dev/bouncing_ball_run_dynamics -- --depth=false --label=false --render_fps 100`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10389)
<!-- Reviewable:end -->
