### PR TITLE
drake_visualizer: Deprecate old scripts

### DIFF
--- a/multibody/rigid_body_plant/visualization/contact_viz.py
+++ b/multibody/rigid_body_plant/visualization/contact_viz.py
@@ -1,4 +1,7 @@
-from drake.tools.workspace.drake_visualizer.plugin import show_contact
+from drake.tools.workspace.drake_visualizer.plugin import (
+    show_contact, warn_old_script)
+
+warn_old_script(new_module=show_contact)
 
 # Activate the plugin if this script is run directly; store the results to keep
 # the plugin objects in scope.

--- a/multibody/rigid_body_plant/visualization/show_frames.py
+++ b/multibody/rigid_body_plant/visualization/show_frames.py
@@ -1,4 +1,7 @@
-from drake.tools.workspace.drake_visualizer.plugin import show_frame
+from drake.tools.workspace.drake_visualizer.plugin import (
+    show_frame, warn_old_script)
+
+warn_old_script(new_module=show_frame)
 
 # Activate the plugin if this script is run directly; store the results to keep
 # the plugin objects in scope.

--- a/multibody/rigid_body_plant/visualization/show_time.py
+++ b/multibody/rigid_body_plant/visualization/show_time.py
@@ -1,4 +1,7 @@
-from drake.tools.workspace.drake_visualizer.plugin import show_time
+from drake.tools.workspace.drake_visualizer.plugin import (
+    show_time, warn_old_script)
+
+warn_old_script(new_module=show_time)
 
 # Activate the plugin if this script is run directly; store the results to keep
 # the plugin objects in scope.

--- a/systems/sensors/visualization/show_images.py
+++ b/systems/sensors/visualization/show_images.py
@@ -1,4 +1,7 @@
-from drake.tools.workspace.drake_visualizer.plugin import show_image
+from drake.tools.workspace.drake_visualizer.plugin import (
+    show_image, warn_old_script)
+
+warn_old_script(new_module=show_image)
 
 # Activate the plugin if this script is run directly; store the results to keep
 # the plugin objects in scope.

--- a/tools/workspace/drake_visualizer/plugin/__init__.py
+++ b/tools/workspace/drake_visualizer/plugin/__init__.py
@@ -26,3 +26,14 @@ def scoped_singleton_func(f):
         return result
 
     return wrapped
+
+
+def warn_old_script(new_module):
+    """Warns that the current script is deprecated, and instead the given
+    new module should be imported."""
+    # N.B. Use the default warning class, `UserWarning`, instead of
+    # `DeprecationWarning`, so that this warning shows up by default.
+    warn(
+        ("This file will be removed on or around 2019-03-01. Please import "
+         "from the module '{}' instead.").format(new_module.__name__),
+        stacklevel=2)


### PR DESCRIPTION
Forgot to do this, may have to wait to remove these scripts :(

Preview:
```
$ ./bazel-bin/tools/drake_visualizer --script ./systems/sensors/visualization/show_images.py 
./systems/sensors/visualization/show_images.py:4: UserWarning: This file will be removed on or around 2019-03-01. Please import from the module 'drake.tools.workspace.drake_visualizer.plugin.show_image' instead.
  warn_old_script(new_module=show_image)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10396)
<!-- Reviewable:end -->
