### PR TITLE
Replace PiecewisePolynomial w/ Trajectory in PlaybackTrajectory().

### DIFF
--- a/attic/multibody/rigid_body_plant/BUILD.bazel
+++ b/attic/multibody/rigid_body_plant/BUILD.bazel
@@ -133,7 +133,7 @@ drake_cc_library(
         ":create_load_robot_message",
         "//attic/multibody:rigid_body_tree",
         "//attic/systems/rendering:drake_visualizer_client",
-        "//common/trajectories:piecewise_polynomial",
+        "//common/trajectories",
         "//lcmtypes:viewer",
         "//systems/lcm:lcm_pubsub_system",
         "//systems/primitives:signal_log",

--- a/attic/multibody/rigid_body_plant/drake_visualizer.cc
+++ b/attic/multibody/rigid_body_plant/drake_visualizer.cc
@@ -5,6 +5,7 @@
 #include <utility>
 
 #include "drake/common/text_logging.h"
+#include "drake/common/trajectories/piecewise_polynomial.h"
 #include "drake/multibody/rigid_body_plant/create_load_robot_message.h"
 #include "drake/systems/rendering/drake_visualizer_client.h"
 
@@ -78,7 +79,7 @@ void DrakeVisualizer::ReplayCachedSimulation() const {
 }
 
 void DrakeVisualizer::PlaybackTrajectory(
-    const trajectories::PiecewisePolynomial<double>& input_trajectory) const {
+    const trajectories::Trajectory<double>& input_trajectory) const {
   using Clock = std::chrono::steady_clock;
   using Duration = std::chrono::duration<double>;
   using TimePoint = std::chrono::time_point<Clock, Duration>;

--- a/attic/multibody/rigid_body_plant/drake_visualizer.h
+++ b/attic/multibody/rigid_body_plant/drake_visualizer.h
@@ -4,7 +4,7 @@
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/common/trajectories/piecewise_polynomial.h"
+#include "drake/common/trajectories/trajectory.h"
 #include "drake/lcm/drake_lcm_interface.h"
 #include "drake/lcmt_viewer_draw.hpp"
 #include "drake/lcmt_viewer_load_robot.hpp"
@@ -106,7 +106,7 @@ class DrakeVisualizer : public LeafSystem<double> {
    * Plays back (at real time) a trajectory representing the input signal.
    */
   void PlaybackTrajectory(
-      const trajectories::PiecewisePolynomial<double>& input_trajectory) const;
+      const trajectories::Trajectory<double>& input_trajectory) const;
 
   /**
    * Publishes a lcmt_viewer_load_robot message containing a description


### PR DESCRIPTION
There's no reason to force callers to use the more-specific subclass.