### PR TITLE
framework: Relocate a Constraint TODO

### DIFF
--- a/systems/framework/system_constraint.h
+++ b/systems/framework/system_constraint.h
@@ -148,8 +148,6 @@ class SystemConstraint {
 
   /// Evaluates the function pointer, and check if all of the outputs
   /// are within the desired bounds.
-  // TODO(russt): Resolve names differences across the codebase. The vector
-  // gen scripts call this IsValid, but Constraint calls it CheckSatisfied.
   boolean<T> CheckSatisfied(const Context<T>& context, double tol) const {
     DRAKE_DEMAND(tol >= 0.0);
     VectorX<T> value(size());

--- a/tools/vector_gen/lcm_vector_gen.py
+++ b/tools/vector_gen/lcm_vector_gen.py
@@ -292,6 +292,9 @@ GET_COORDINATE_NAMES = """
    }
 """
 
+# TODO(russt): Resolve names differences across the codebase. The vector gen
+# scripts call this IsValid, but the system and solvers Constraint classes call
+# it CheckSatisfied.
 IS_VALID_BEGIN = """
   /// Returns whether the current values of this vector are well-formed.
   drake::boolean<T> IsValid() const {


### PR DESCRIPTION
The fix for this should happen in vector_gen -- given the preponderance of uses of solvers::Constraint and SystemConstraint, we should let those names win, and just fix vector_gen to use that naming convention.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10401)
<!-- Reviewable:end -->
