### PR TITLE
framework: Hoist the constraint calc typedef to top-level

### DIFF
--- a/examples/van_der_pol/van_der_pol.cc
+++ b/examples/van_der_pol/van_der_pol.cc
@@ -27,7 +27,7 @@ VanDerPolOscillator<T>::VanDerPolOscillator()
   this->DeclareNumericParameter(systems::BasicVector<T>(Vector1<T>(1.0)));
 
   // Declare μ≥0 constraint.
-  typename systems::SystemConstraint<T>::CalcCallback mu =
+  systems::ContextConstraintCalc<T> mu =
       [](const systems::Context<T>& context, VectorX<T>* value) {
         // Extract μ from the parameters.
         *value = Vector1<T>(context.get_numeric_parameter(0).GetAtIndex(0));

--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -552,6 +552,7 @@ drake_cc_library(
     srcs = ["system_constraint.cc"],
     hdrs = ["system_constraint.h"],
     deps = [
+        ":context",
         "//common:default_scalars",
         "//common:essential",
         "//common:symbolic",

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -1416,7 +1416,7 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
       const auto sys = registered_systems_[i].get();
       for (SystemConstraintIndex j(0); j < sys->get_num_constraints(); ++j) {
         const auto c = &(sys->get_constraint(j));
-        typename SystemConstraint<T>::CalcCallback diagram_calc =
+        ContextConstraintCalc<T> diagram_calc =
             [this, sys, c](const Context<T>& context, VectorX<T>* value) {
               c->Calc(this->GetSubsystemContext(*sys, context), value);
             };

--- a/systems/framework/framework_common.h
+++ b/systems/framework/framework_common.h
@@ -62,6 +62,9 @@ using NumericParameterIndex = TypeSafeIndex<class NumericParameterTag>;
 and its corresponding Context. */
 using AbstractParameterIndex = TypeSafeIndex<class AbstractParameterTag>;
 
+/** Serves as the local index for constraints declared on a given System. */
+using SystemConstraintIndex = TypeSafeIndex<class SystemConstraintTag>;
+
 /** All system ports are either vectors of Eigen scalars, or black-box
 AbstractValues which may contain any type. */
 typedef enum {

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -2142,7 +2142,7 @@ class LeafSystem : public System<T> {
   /// @see SystemConstraint<T> for more information about the meaning of
   /// these constraints.
   SystemConstraintIndex DeclareEqualityConstraint(
-      typename SystemConstraint<T>::CalcCallback calc, int count,
+      ContextConstraintCalc<T> calc, int count,
       std::string description) {
     return DeclareInequalityConstraint(
         std::move(calc), SystemConstraintBounds::Equality(count),
@@ -2192,7 +2192,7 @@ class LeafSystem : public System<T> {
   /// @see SystemConstraint<T> for more information about the meaning of
   /// these constraints.
   SystemConstraintIndex DeclareInequalityConstraint(
-      typename SystemConstraint<T>::CalcCallback calc,
+      ContextConstraintCalc<T> calc,
       SystemConstraintBounds bounds,
       std::string description) {
     return this->AddConstraint(std::make_unique<SystemConstraint<T>>(

--- a/systems/framework/system_constraint.h
+++ b/systems/framework/system_constraint.h
@@ -14,15 +14,10 @@
 #include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/type_safe_index.h"
-#include "drake/common/unused.h"
+#include "drake/systems/framework/context.h"
 
 namespace drake {
 namespace systems {
-
-template <typename T>
-class Context;
-
-using SystemConstraintIndex = TypeSafeIndex<class SystemConstraintTag>;
 
 /// The form of a SystemConstraint.
 enum class SystemConstraintType {

--- a/systems/framework/system_constraint.h
+++ b/systems/framework/system_constraint.h
@@ -9,6 +9,7 @@
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_bool.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/drake_optional.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
@@ -80,6 +81,16 @@ class SystemConstraintBounds final {
   Eigen::VectorXd upper_;
 };
 
+/// This is the signature of a stateless function that evaluates the value of
+/// the constraint function f:
+///   value = f(context)
+///
+/// Note that in the std::function signature, the computed value is an output
+/// parameter, not a return value.
+template <typename T>
+using ContextConstraintCalc =
+    std::function<void(const Context<T>& context, VectorX<T>* value)>;
+
 /// A SystemConstraint is a generic base-class for constraints on Systems.
 ///
 /// A SystemConstraint is a means to inform our algorithms *about*
@@ -116,21 +127,18 @@ class SystemConstraint {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SystemConstraint)
 
-  /// This is the signature of a stateless function that evaluates the value of
-  /// the constraint function f:
-  ///   value = f(context),
-  /// where value has the dimension specified in the constructor.
-  // TODO(russt): replace the argument VectorX<T>* with an Eigen::Ref* using
-  // whatever magic jwnimmer and soonho figured out a few weeks back.
-  using CalcCallback =
-      std::function<void(const Context<T>& context, VectorX<T>* value)>;
+  // TODO(jwnimmer-tri) Remove this alias on or about 2019-04-01.
+  using CalcCallback
+      DRAKE_DEPRECATED("Use drake::systems::ContextConstraintCalc instead.")
+      = ContextConstraintCalc<T>;
 
   /// Constructs a SystemConstraint.  Depending on the `bounds` it could be an
   /// equality constraint f(x) = 0, or an inequality constraint lower_bound <=
   /// f(x) <= upper_bound.
   ///
   /// @param description a human-readable description useful for debugging.
-  SystemConstraint(CalcCallback calc_function, SystemConstraintBounds bounds,
+  SystemConstraint(ContextConstraintCalc<T> calc_function,
+                   SystemConstraintBounds bounds,
                    std::string description)
       : calc_function_(std::move(calc_function)),
         bounds_(std::move(bounds)),
@@ -185,7 +193,7 @@ class SystemConstraint {
   const std::string& description() const { return description_; }
 
  private:
-  const CalcCallback calc_function_;
+  const ContextConstraintCalc<T> calc_function_;
   const SystemConstraintBounds bounds_;
   const std::string description_;
 };

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -2231,7 +2231,7 @@ GTEST_TEST(SystemConstraintTest, FunctionHandleTest) {
   ConstraintTestSystem dut;
   EXPECT_EQ(dut.get_num_constraints(), 0);
 
-  SystemConstraint<double>::CalcCallback calc0 = [](
+  ContextConstraintCalc<double> calc0 = [](
       const Context<double>& context, Eigen::VectorXd* value) {
     *value = Vector1d(context.get_continuous_state_vector().GetAtIndex(1));
   };
@@ -2241,7 +2241,7 @@ GTEST_TEST(SystemConstraintTest, FunctionHandleTest) {
             0);
   EXPECT_EQ(dut.get_num_constraints(), 1);
 
-  SystemConstraint<double>::CalcCallback calc1 = [](
+  ContextConstraintCalc<double> calc1 = [](
       const Context<double>& context, Eigen::VectorXd* value) {
     *value =
         Eigen::Vector2d(context.get_continuous_state_vector().GetAtIndex(1),

--- a/systems/framework/test/system_constraint_test.cc
+++ b/systems/framework/test/system_constraint_test.cc
@@ -65,11 +65,11 @@ GTEST_TEST(SystemConstraintTest, BoundsBadSizes) {
 
 // Just a simple test to call each of the public methods.
 GTEST_TEST(SystemConstraintTest, BasicTest) {
-  SystemConstraint<double>::CalcCallback calc = [](
+  ContextConstraintCalc<double> calc = [](
       const Context<double>& context, Eigen::VectorXd* value) {
     *value = Vector1d(context.get_continuous_state_vector().GetAtIndex(1));
   };
-  SystemConstraint<double>::CalcCallback calc2 = [](
+  ContextConstraintCalc<double> calc2 = [](
       const Context<double>& context, Eigen::VectorXd* value) {
     *value =
         Eigen::Vector2d(context.get_continuous_state_vector().CopyToVector());

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -383,7 +383,7 @@ TEST_F(SystemTest, SystemConstraintTest) {
   EXPECT_THROW(system_.get_constraint(SystemConstraintIndex(0)),
                std::out_of_range);
 
-  SystemConstraint<double>::CalcCallback calc = [](
+  ContextConstraintCalc<double> calc = [](
       const Context<double>& context, Eigen::VectorXd* value) {
     unused(context);
     (*value)[0] = 1.0;
@@ -399,7 +399,7 @@ TEST_F(SystemTest, SystemConstraintTest) {
 
   const double tol = 1e-6;
   EXPECT_TRUE(system_.CheckSystemConstraintsSatisfied(context_, tol));
-  SystemConstraint<double>::CalcCallback calc_false = [](
+  ContextConstraintCalc<double> calc_false = [](
       const Context<double>& context, Eigen::VectorXd* value) {
     unused(context);
     (*value)[0] = -1.0;

--- a/systems/sensors/beam_model.cc
+++ b/systems/sensors/beam_model.cc
@@ -38,7 +38,7 @@ BeamModel<T>::BeamModel(int num_depth_readings, double max_range)
   // one.   Since probability_hit() is defined implicitly, this becomes the
   // inequality constraint:
   //   1 - probability_short() - probability_miss() - probability_uniform() ≥ 0.
-  typename SystemConstraint<T>::CalcCallback
+  ContextConstraintCalc<T>
       calc_event_probabilities_constraint =
           [](const Context<T>& context, VectorX<T>* value) {
             const auto* params = dynamic_cast<const BeamModelParams<T>*>(


### PR DESCRIPTION
We use this functor type widely (and it will increase over time), so we should have a standalone spelling for it.  Also, we will soon (#10394) support a few kinds of functors, so we can't camp on the sole "CalcCallback" name.

Also tidy up SystemConstraint declarations: for consistency, put the Index typedef into system_common; per GSG, disprefer forward declarations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10404)
<!-- Reviewable:end -->
