### PR TITLE
doc: Clarify present lack of Python 3 binaries

### DIFF
--- a/doc/python_bindings.rst
+++ b/doc/python_bindings.rst
@@ -44,7 +44,7 @@ See :ref:`below <using-python-bindings>` for usage instructions. If using
 macOS, pay special attention to :ref:`this note <using-python-mac-os-path>`.
 
 Python 2.7 is currently the only supported version for the bindings supplied
-by the binary packages.
+by the binary packages. To use Python 3.x, see below for building from source.
 
 Building the Python Bindings
 ----------------------------


### PR DESCRIPTION
Clarifies docs in light of #10408.