### PR TITLE
py symbolic: Filter updated warning message for == comparison

### DIFF
--- a/bindings/pydrake/common/deprecation.py
+++ b/bindings/pydrake/common/deprecation.py
@@ -165,10 +165,10 @@ def install_numpy_warning_filters(force=False):
         return
     _installed_numpy_warning_filters = True
     # Warnings specific to comparison with `dtype=object` should be raised to
-    # errors (#8315, #8491). Without them, NumPy will return effectively
-    # garbage values (e.g. comparison based on object ID): either a scalar bool
-    # or an array of bools (based on what objects are present and the NumPy
-    # version).
+    # errors (#8315, #8491). Without them, NumPy will swallow the errors and
+    # make a DeprecationWarning, while returning effectively garbage values
+    # (e.g. comparison based on object ID): either a scalar bool or an array of
+    # bools (based on what objects are present and the NumPy version).
     # N.B. Using a `module=` regex filter does not work, as the warning is
     # raised from C code, and thus inherits the calling module, which may not
     # be "numpy\..*" (numpy/numpy#10861).
@@ -177,6 +177,10 @@ def install_numpy_warning_filters(force=False):
     warnings.filterwarnings(
         "error", category=DeprecationWarning,
         message="elementwise == comparison failed")
+    # Error changed in 1.16.0
+    warnings.filterwarnings(
+        "error", category=DeprecationWarning,
+        message="elementwise comparison failed")
 
 
 warnings.simplefilter('once', DrakeDeprecationWarning)

--- a/common/test_utilities/drake_py_unittest_main.py
+++ b/common/test_utilities/drake_py_unittest_main.py
@@ -100,9 +100,13 @@ if __name__ == '__main__':
              "client (non-batch), output may be mixed, so piping makes " +
              "the output more readable.")
     parser.add_argument(
-        "--drake_deprecation_action", type=str, default="error",
-        help="Action for Drake deprecation warnings. See " +
+        "--deprecation_action", type=str, default="once",
+        help="Action for any deprecation warnings. See " +
              "`warnings.simplefilter()`.")
+    parser.add_argument(
+        "--drake_deprecation_action", type=str, default="error",
+        help="Action for Drake deprecation warnings. Applied after " +
+             "--deprecation_action.")
     args, remaining = parser.parse_known_args()
     sys.argv = sys.argv[:1] + remaining
 
@@ -119,6 +123,9 @@ if __name__ == '__main__':
         sys.stdout.flush()
         sys.stdout = sys.stderr
 
+    # Ensure deprecation warnings are always shown at least once.
+    warnings.simplefilter(args.deprecation_action, DeprecationWarning)
+    # Handle Drake-specific deprecations.
     if has_pydrake:
         warnings.simplefilter(
             args.drake_deprecation_action, DrakeDeprecationWarning)


### PR DESCRIPTION
Resolves #10411

Tested locally using base commit from #10411:
> Can reproduce on Bionic with [this commit](https://github.com/EricCousineau-TRI/drake/commit/676d68efe997c897eb3521470eccbd5caee03706), and this command:
> ```
> $ source tmp/venv_setup.sh
> $ bazel run //bindings/pydrake:py/symbolic_test
> ```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10412)
<!-- Reviewable:end -->
