### PR TITLE
multibody/plant: Opt-out from subtype checking in scalar conversion

### DIFF
--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -228,7 +228,10 @@ template <typename T>
 MultibodyPlant<T>::MultibodyPlant(
     std::unique_ptr<internal::MultibodyTree<T>> tree_in, double time_step)
     : internal::MultibodyTreeSystem<T>(
-          systems::SystemTypeTag<multibody::MultibodyPlant>{},
+          systems::SystemScalarConverter(
+              systems::SystemTypeTag<multibody::MultibodyPlant>{},
+              systems::SystemScalarConverter::
+                GuaranteedSubtypePreservation::kDisabled),
           std::move(tree_in), time_step > 0),
       time_step_(time_step) {
   DRAKE_THROW_UNLESS(time_step >= 0);

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -1405,6 +1405,26 @@ GTEST_TEST(MultibodyPlantTest, ScalarConversionConstructor) {
   EXPECT_NO_THROW(plant_autodiff.get_geometry_poses_output_port());
 }
 
+// In general, we strongly discourage users from subclassing MultibodyPlant.
+// However, until we mark it `final`, we should test that subclassing works as
+// expected.
+template <typename T>
+class SubclassPlant final : public MultibodyPlant<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SubclassPlant)
+
+  SubclassPlant() : multibody::MultibodyPlant<T>() {
+    this->Finalize();
+  }
+};
+
+// Verifies that subclasses of MBP can be scalar-converted.
+GTEST_TEST(MultibodyPlantTest, SubclassScalarConversion) {
+  // Confirm that the constructor disables the subtype preservation checks.
+  const SubclassPlant<double> dut;
+  ASSERT_NO_THROW(dut.ToAutoDiffXd());
+}
+
 // This test is used to verify the correctness of the methods to compute the
 // normal Jacobian N and the tangent Jacobian D.
 // We do this for the particular case of a small box sitting on top of a larger


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10414)
<!-- Reviewable:end -->
