### PR TITLE
Suppress numerous compiler warnings when using sanitizers on Mac

### DIFF
--- a/tools/macos.bazelrc
+++ b/tools/macos.bazelrc
@@ -11,3 +11,12 @@ build:python3 --action_env=DRAKE_PYTHON_BIN_PATH=/usr/local/bin/python3
 # Configure ${PATH} for actions.
 # N.B. Ensure this is consistent with `execute.bzl`.
 build --action_env=PATH=/usr/local/bin:/usr/bin:/bin
+
+# Suppress numerous "'_FORTIFY_SOURCE' macro redefined" warnings when using
+# sanitizers.
+build:asan --copt -Wno-macro-redefined
+build:asan_everything --copt -Wno-macro-redefined
+build:tsan --copt -Wno-macro-redefined
+build:tsan_everything --copt -Wno-macro-redefined
+build:ubsan --copt -Wno-macro-redefined
+build:ubsan_everything --copt -Wno-macro-redefined


### PR DESCRIPTION
The Bazel `CROSSTOOL` on Mac is missing `-U_FORTIFY_SOURCE` (similar to that in [unix_cc_configure.bzl](https://github.com/bazelbuild/bazel/blob/03035146fb041f815f496d71b99e4242beaa83db/tools/cpp/unix_cc_configure.bzl#L308-L310)), but since the `CROSSTOOL` template is allegedly [generated by an internal tool at Google](https://github.com/bazelbuild/bazel/blob/03035146fb041f815f496d71b99e4242beaa83db/tools/osx/crosstool/CROSSTOOL.tpl#L2-L3) and similar bugs have been long unfixed (e.g., https://github.com/bazelbuild/bazel/issues/5981), I do not see a path to fixing the issue there.
 
<!-- Reviewable:start -->
----
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10415)
<!-- Reviewable:end -->
