### PR TITLE
[geometry] Clean up/extend GeometrySet API

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -315,6 +315,7 @@ drake_cc_googletest(
     deps = [
         ":geometry_ids",
         ":geometry_set",
+        "//geometry/test_utilities:geometry_set_tester",
     ],
 )
 

--- a/geometry/dev/BUILD.bazel
+++ b/geometry/dev/BUILD.bazel
@@ -86,6 +86,7 @@ drake_cc_library(
         "//geometry:internal_geometry",
         "//geometry/dev/render:fidelity",
         "//geometry/dev/render:render_engine_impl",
+        "//geometry/test_utilities:geometry_set_tester",
     ],
 )
 

--- a/geometry/dev/geometry_state.cc
+++ b/geometry/dev/geometry_state.cc
@@ -16,6 +16,7 @@
 #include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/internal_frame.h"
 #include "drake/geometry/internal_geometry.h"
+#include "drake/geometry/test_utilities/geometry_set_tester.h"
 #include "drake/geometry/utilities.h"
 
 namespace drake {
@@ -893,12 +894,13 @@ const FrameIdSet& GeometryState<T>::GetFramesForSource(
 
 template <typename T>
 void GeometryState<T>::ExcludeCollisionsWithin(const GeometrySet& set) {
+  GeometrySetTester tester(&set);
   // There is no work to be done if:
   //   1. the set contains a single frame and no geometries -- geometries *on*
   //      that single frame have already been handled, or
   //   2. there are no frames and a single geometry.
-  if ((set.num_frames() == 1 && set.num_geometries() == 0) ||
-      (set.num_frames() == 0 && set.num_geometries() == 1)) {
+  if ((tester.num_frames() == 1 && tester.num_geometries() == 0) ||
+      (tester.num_frames() == 0 && tester.num_geometries() == 1)) {
     return;
   }
 
@@ -972,8 +974,9 @@ template <typename T>
 void GeometryState<T>::CollectIndices(
     const GeometrySet& geometry_set, std::unordered_set<InternalIndex>* dynamic,
     std::unordered_set<InternalIndex>* anchored) {
+  GeometrySetTester tester(&geometry_set);
   std::unordered_set<InternalIndex>* target;
-  for (auto frame_id : geometry_set.frames()) {
+  for (auto frame_id : tester.frames()) {
     const auto& frame = GetValueOrThrow(frame_id, frames_);
     target = frame.is_world() ? anchored : dynamic;
     for (auto geometry_id : frame.child_geometries()) {
@@ -984,7 +987,7 @@ void GeometryState<T>::CollectIndices(
     }
   }
 
-  for (auto geometry_id : geometry_set.geometries()) {
+  for (auto geometry_id : tester.geometries()) {
     const InternalGeometry* geometry = GetGeometry(geometry_id);
     if (geometry == nullptr) {
       throw std::logic_error(

--- a/geometry/geometry_set.h
+++ b/geometry/geometry_set.h
@@ -4,10 +4,14 @@
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/geometry/geometry_ids.h"
 
 namespace drake {
 namespace geometry {
+
+template <typename T>
+class GeometryState;
 
 /** The %GeometrySet, as its name implies, is a convenience class for defining a
  set of geometries. What makes it unique from a simple `std::set<GeometryId>`
@@ -240,31 +244,74 @@ class GeometrySet {
 
   //@}
 
+  // TODO(SeanCurtis-TRI): Remove these deprecated methods and rename the
+  // private methods below to the simpler names - 2018-02-15.
+
   /** Returns the frame ids in the set. */
+  DRAKE_DEPRECATED("Test-only utility function to be removed after 2018-02-15")
   const std::unordered_set<FrameId> frames() const { return frames_; }
 
   /** Reports the number of frames in the set. */
+  DRAKE_DEPRECATED("Test-only utility function to be removed after 2018-02-15")
   int num_frames() const { return static_cast<int>(frames_.size()); }
 
   /** Returns the geometry ids in the set. */
+  DRAKE_DEPRECATED("Test-only utility function to be removed after 2018-02-15")
   const std::unordered_set<GeometryId> geometries() const {
     return geometries_;
   }
 
   /** Reports the number of geometries _explicitly_ in the set. It does
    _not_ count the geometries that belong to the added frames.  */
+  DRAKE_DEPRECATED("Test-only utility function to be removed after 2018-02-15")
   int num_geometries() const { return static_cast<int>(geometries_.size()); }
 
   /** Reports if the given `frame_id` has been added to the group. */
+  DRAKE_DEPRECATED("Test-only utility function to be removed after 2018-02-15")
   bool contains(FrameId frame_id) const { return frames_.count(frame_id) > 0; }
 
   /** Reports if the given `geometry_id` has been *explicitly* added to the
    group. It will *not* capture geometry ids affixed to added frames.  */
+  DRAKE_DEPRECATED("Test-only utility function to be removed after 2018-02-15")
   bool contains(GeometryId geometry_id) const {
     return geometries_.count(geometry_id) > 0;
   }
 
  private:
+  // Provide access to the two entities that need access to the set's internals.
+  friend class GeometrySetTester;
+  template <typename>
+  friend class GeometryState;
+
+  // Returns the frame ids in the set.
+  const std::unordered_set<FrameId> frames_internal() const { return frames_; }
+
+  // Reports the number of frames in the set.
+  int num_frames_internal() const { return static_cast<int>(frames_.size()); }
+
+  // Returns the geometry ids in the set -- these are only the geometry ids
+  // explicitly added to the set and _not_ those implied by added frames.
+  const std::unordered_set<GeometryId> geometries_internal() const {
+    return geometries_;
+  }
+
+  // Reports the number of geometries _explicitly_ in the set. It does _not_
+  // count the geometries that belong to the added frames.
+  int num_geometries_internal() const {
+    return static_cast<int>(geometries_.size());
+  }
+
+  // Reports if the given `frame_id` has been added to the group.
+  bool contains_internal(FrameId frame_id) const {
+    return frames_.count(frame_id) > 0;
+  }
+
+  // Reports if the given `geometry_id` has been *explicitly* added to the
+  // group. It will *not* capture geometry ids affixed to added frames.
+  bool contains_internal(GeometryId geometry_id) const {
+    return geometries_.count(geometry_id) > 0;
+  }
+
   std::unordered_set<FrameId> frames_;
   std::unordered_set<GeometryId> geometries_;
 };

--- a/geometry/geometry_set.h
+++ b/geometry/geometry_set.h
@@ -154,6 +154,7 @@ class GeometrySet {
      - an iterable object containing frame ids
      - two iterable objects, the first containing geometry ids, the second
        containing frame ids.
+     - another %GeometrySet instance.
 
    NOTE: the iterable objects don't have to be the same type. The "iterable"
    can also be an initializer list. All of the following invocations are valid
@@ -230,6 +231,11 @@ class GeometrySet {
   Add(const ContainerG& geometries, std::initializer_list<FrameId> frames) {
     Add(geometries);
     Add(frames);
+  }
+
+  void Add(const GeometrySet& other) {
+    frames_.insert(other.frames_.begin(), other.frames_.end());
+    geometries_.insert(other.geometries_.begin(), other.geometries_.end());
   }
 
   //@}

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -679,8 +679,8 @@ void GeometryState<T>::ExcludeCollisionsWithin(const GeometrySet& set) {
   //   1. the set contains a single frame and no geometries -- geometries *on*
   //      that single frame have already been handled, or
   //   2. there are no frames and a single geometry.
-  if ((set.num_frames() == 1 && set.num_geometries() == 0) ||
-      (set.num_frames() == 0 && set.num_geometries() == 1)) {
+  if ((set.num_frames_internal() == 1 && set.num_geometries_internal() == 0) ||
+      (set.num_frames_internal() == 0 && set.num_geometries_internal() == 1)) {
     return;
   }
 
@@ -718,7 +718,7 @@ void GeometryState<T>::CollectIndices(
   // TODO(SeanCurtis-TRI): Consider expanding this to include Role if it proves
   // that collecting indices for *other* role-related tasks prove necessary.
   std::unordered_set<GeometryIndex>* target;
-  for (auto frame_id : geometry_set.frames()) {
+  for (auto frame_id : geometry_set.frames_internal()) {
     const auto& frame = GetValueOrThrow(frame_id, frames_);
     target = frame.is_world() ? anchored : dynamic;
     for (auto geometry_id : frame.child_geometries()) {
@@ -729,7 +729,7 @@ void GeometryState<T>::CollectIndices(
     }
   }
 
-  for (auto geometry_id : geometry_set.geometries()) {
+  for (auto geometry_id : geometry_set.geometries_internal()) {
     const InternalGeometry* geometry = GetGeometry(geometry_id);
     if (geometry == nullptr) {
       throw std::logic_error(

--- a/geometry/test/geometry_set_test.cc
+++ b/geometry/test/geometry_set_test.cc
@@ -6,6 +6,8 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/geometry/test_utilities/geometry_set_tester.h"
+
 namespace drake {
 namespace geometry {
 namespace {
@@ -14,23 +16,24 @@ namespace {
 // in the GeometrySet.
 
 template <typename IdContainer>
-void ExpectContainsAll(const GeometrySet& geometry_set, const IdContainer& ids,
-                       const char* failure_message) {
+void ExpectContainsAll(const GeometrySetTester& set_tester,
+                       const IdContainer& ids, const char* failure_message) {
   for (auto id : ids) {
-    EXPECT_TRUE(geometry_set.contains(id)) << failure_message;
+    EXPECT_TRUE(set_tester.contains(id)) << failure_message;
   }
 }
 
 GTEST_TEST(GeometrySetTests, DefaultConstructor) {
   GeometrySet geometry_set;
+  GeometrySetTester set_tester(&geometry_set);
 
   // Should report containing no frames or geometries.
-  EXPECT_EQ(geometry_set.num_frames(), 0);
-  EXPECT_EQ(geometry_set.num_geometries(), 0);
+  EXPECT_EQ(set_tester.num_frames(), 0);
+  EXPECT_EQ(set_tester.num_geometries(), 0);
 
   // A random frame/geometry id will not be reported as being *in* the set.
-  EXPECT_FALSE(geometry_set.contains(GeometryId::get_new_id()));
-  EXPECT_FALSE(geometry_set.contains(FrameId::get_new_id()));
+  EXPECT_FALSE(set_tester.contains(GeometryId::get_new_id()));
+  EXPECT_FALSE(set_tester.contains(FrameId::get_new_id()));
 }
 
 GTEST_TEST(GeometrySetTests, ConversionConstructor) {
@@ -57,9 +60,10 @@ GTEST_TEST(GeometrySetTests, ConversionConstructor) {
   auto test_single_source_constructor = [](
       const GeometrySet& set, const auto& source, int expected_frame_count,
       int expected_geometry_count, const char* message) {
-    EXPECT_EQ(set.num_frames(), expected_frame_count) << message;
-    EXPECT_EQ(set.num_geometries(), expected_geometry_count) << message;
-    ExpectContainsAll(set, source, message);
+    GeometrySetTester set_tester(&set);
+    EXPECT_EQ(set_tester.num_frames(), expected_frame_count) << message;
+    EXPECT_EQ(set_tester.num_geometries(), expected_geometry_count) << message;
+    ExpectContainsAll(set_tester, source, message);
   };
 
   GeometrySet set1(g_id);
@@ -109,56 +113,63 @@ GTEST_TEST(GeometrySetTests, ConversionConstructor) {
 
   // Constructors using geometry and frame id sets.
   GeometrySet set10(geometry_list, frame_vector);
-  EXPECT_EQ(set10.num_frames(), static_cast<int>(frame_vector.size()));
-  EXPECT_EQ(set10.num_geometries(), static_cast<int>(geometry_vector.size()));
-  ExpectContainsAll(set10, geometry_vector,
+  GeometrySetTester tester10(&set10);
+  EXPECT_EQ(tester10.num_frames(), static_cast<int>(frame_vector.size()));
+  EXPECT_EQ(tester10.num_geometries(),
+            static_cast<int>(geometry_vector.size()));
+  ExpectContainsAll(tester10, geometry_vector,
                     "Geometry initializer list, frame vector constructor");
-  ExpectContainsAll(set10, frame_vector,
+  ExpectContainsAll(tester10, frame_vector,
                     "Geometry initializer list, frame vector constructor");
 
   GeometrySet set11(geometry_vector, {frame_vector[0], frame_vector[1]});
-  EXPECT_EQ(set11.num_frames(), static_cast<int>(frame_vector.size()));
-  EXPECT_EQ(set11.num_geometries(), static_cast<int>(geometry_vector.size()));
-  ExpectContainsAll(set11, geometry_vector,
+  GeometrySetTester tester11(&set11);
+  EXPECT_EQ(tester11.num_frames(), static_cast<int>(frame_vector.size()));
+  EXPECT_EQ(tester11.num_geometries(),
+            static_cast<int>(geometry_vector.size()));
+  ExpectContainsAll(tester11, geometry_vector,
                     "Geometry vector, frame initializer list constructor");
-  ExpectContainsAll(set11, frame_vector,
+  ExpectContainsAll(tester11, frame_vector,
                     "Geometry vector, frame initializer list constructor");
 }
 
 GTEST_TEST(GeometrySetTests, SingleFrameAdd) {
   GeometrySet geometry_set;
+  GeometrySetTester tester(&geometry_set);
 
   FrameId f = FrameId::get_new_id();
-  EXPECT_FALSE(geometry_set.contains(f));
+  EXPECT_FALSE(tester.contains(f));
   geometry_set.Add(f);
-  EXPECT_EQ(geometry_set.num_frames(), 1);
-  EXPECT_TRUE(geometry_set.contains(f));
+  EXPECT_EQ(tester.num_frames(), 1);
+  EXPECT_TRUE(tester.contains(f));
 
   // Adding a frame redundantly should not be a problem.
   EXPECT_NO_THROW(geometry_set.Add(f));
   // It should also not change the membership.
-  EXPECT_EQ(geometry_set.num_frames(), 1);
-  EXPECT_TRUE(geometry_set.contains(f));
+  EXPECT_EQ(tester.num_frames(), 1);
+  EXPECT_TRUE(tester.contains(f));
 }
 
 GTEST_TEST(GeometrySetTests, SingleGeometryAdd) {
   GeometrySet geometry_set;
+  GeometrySetTester tester(&geometry_set);
 
   GeometryId g = GeometryId::get_new_id();
-  EXPECT_FALSE(geometry_set.contains(g));
+  EXPECT_FALSE(tester.contains(g));
   geometry_set.Add(g);
-  EXPECT_EQ(geometry_set.num_geometries(), 1);
-  EXPECT_TRUE(geometry_set.contains(g));
+  EXPECT_EQ(tester.num_geometries(), 1);
+  EXPECT_TRUE(tester.contains(g));
 
   // Adding a geometry redundantly should not be a problem.
   EXPECT_NO_THROW(geometry_set.Add(g));
   // It should also not change the membership.
-  EXPECT_EQ(geometry_set.num_geometries(), 1);
-  EXPECT_TRUE(geometry_set.contains(g));
+  EXPECT_EQ(tester.num_geometries(), 1);
+  EXPECT_TRUE(tester.contains(g));
 }
 
 GTEST_TEST(GeometrySetTests, IterableFrameAdd) {
   GeometrySet geometry_set;
+  GeometrySetTester tester(&geometry_set);
 
   // Each has a *different* number of frames so that the result of each can be
   // easily distinguished by count.
@@ -171,34 +182,34 @@ GTEST_TEST(GeometrySetTests, IterableFrameAdd) {
       FrameId::get_new_id()};
 
   int expected_num_frames = 0;
-  EXPECT_EQ(geometry_set.num_frames(), expected_num_frames);
+  EXPECT_EQ(tester.num_frames(), expected_num_frames);
 
   geometry_set.Add(frames_vector);
   expected_num_frames += static_cast<int>(frames_vector.size());
-  EXPECT_EQ(geometry_set.num_frames(), expected_num_frames);
-  ExpectContainsAll(geometry_set, frames_vector,
-                    "IterableFrameAdd - frames_vector");
+  EXPECT_EQ(tester.num_frames(), expected_num_frames);
+  ExpectContainsAll(tester, frames_vector, "IterableFrameAdd - frames_vector");
 
   geometry_set.Add(frames_set);
   expected_num_frames += static_cast<int>(frames_set.size());
-  EXPECT_EQ(geometry_set.num_frames(), expected_num_frames);
-  ExpectContainsAll(geometry_set, frames_set, "IterableFrameAdd - frames_set");
+  EXPECT_EQ(tester.num_frames(), expected_num_frames);
+  ExpectContainsAll(tester, frames_set, "IterableFrameAdd - frames_set");
 
   geometry_set.Add(frames_hash);
   expected_num_frames += static_cast<int>(frames_hash.size());
-  EXPECT_EQ(geometry_set.num_frames(), expected_num_frames);
-  ExpectContainsAll(geometry_set, frames_hash,
-                    "IterableFrameAdd - frames_hash");
+  EXPECT_EQ(tester.num_frames(), expected_num_frames);
+  ExpectContainsAll(tester, frames_hash, "IterableFrameAdd - frames_hash");
 
   GeometrySet geometry_set2;
+  GeometrySetTester tester2(&geometry_set2);
   geometry_set2.Add({frames_vector[0], frames_vector[1]});
-  EXPECT_EQ(geometry_set2.num_frames(), 2);
-  ExpectContainsAll(geometry_set, frames_vector,
+  EXPECT_EQ(tester2.num_frames(), 2);
+  ExpectContainsAll(tester2, frames_vector,
                     "IterableFrameAdd - initializer_list");
 }
 
 GTEST_TEST(GeometrySetTests, IterableGeometryAdd) {
   GeometrySet geometry_set;
+  GeometrySetTester tester(&geometry_set);
 
   // Each has a *different* number of geometries so that the result of each can
   // be easily distinguished by count.
@@ -212,80 +223,87 @@ GTEST_TEST(GeometrySetTests, IterableGeometryAdd) {
       GeometryId::get_new_id(), GeometryId::get_new_id()};
 
   int expected_num_geometries = 0;
-  EXPECT_EQ(geometry_set.num_frames(), expected_num_geometries);
+  EXPECT_EQ(tester.num_frames(), expected_num_geometries);
 
   geometry_set.Add(geometry_id_vector);
   expected_num_geometries += static_cast<int>(geometry_id_vector.size());
-  EXPECT_EQ(geometry_set.num_geometries(), expected_num_geometries);
-  ExpectContainsAll(geometry_set, geometry_id_vector,
+  EXPECT_EQ(tester.num_geometries(), expected_num_geometries);
+  ExpectContainsAll(tester, geometry_id_vector,
                     "IterableGeometryAdd - geometry_id_vector");
 
   geometry_set.Add(geometry_id_set);
   expected_num_geometries += static_cast<int>(geometry_id_set.size());
-  EXPECT_EQ(geometry_set.num_geometries(), expected_num_geometries);
-  ExpectContainsAll(geometry_set, geometry_id_set,
+  EXPECT_EQ(tester.num_geometries(), expected_num_geometries);
+  ExpectContainsAll(tester, geometry_id_set,
                     "IterableGeometryAdd - geometry_id_set");
 
   geometry_set.Add(geometry_id_hash);
   expected_num_geometries += static_cast<int>(geometry_id_hash.size());
-  EXPECT_EQ(geometry_set.num_geometries(), expected_num_geometries);
-  ExpectContainsAll(geometry_set, geometry_id_hash,
+  EXPECT_EQ(tester.num_geometries(), expected_num_geometries);
+  ExpectContainsAll(tester, geometry_id_hash,
                     "IterableGeometryAdd - geometry_id_hash");
 
   GeometrySet geometry_set2;
+  GeometrySetTester tester2(&geometry_set2);
   geometry_set2.Add({geometry_id_vector[0], geometry_id_vector[1]});
-  EXPECT_EQ(geometry_set2.num_geometries(), 2);
-  ExpectContainsAll(geometry_set, geometry_id_vector,
+  EXPECT_EQ(tester2.num_geometries(), 2);
+  ExpectContainsAll(tester2, geometry_id_vector,
                     "IterableGeometryAdd - initializer_list");
 }
 
 GTEST_TEST(GeometrySetTests, IterableGeometryAndFrames) {
   GeometrySet geometry_set;
+  GeometrySetTester tester(&geometry_set);
+
   std::vector<GeometryId> geometry_id_vector{GeometryId::get_new_id(),
                                              GeometryId::get_new_id()};
   std::set<FrameId> frame_id_set{FrameId::get_new_id(), FrameId::get_new_id()};
 
   geometry_set.Add(geometry_id_vector, frame_id_set);
-  EXPECT_EQ(geometry_set.num_frames(), static_cast<int>(frame_id_set.size()));
-  EXPECT_EQ(geometry_set.num_geometries(),
+  EXPECT_EQ(tester.num_frames(), static_cast<int>(frame_id_set.size()));
+  EXPECT_EQ(tester.num_geometries(),
             static_cast<int>(geometry_id_vector.size()));
-  ExpectContainsAll(geometry_set, geometry_id_vector,
+  ExpectContainsAll(tester, geometry_id_vector,
                     "IterableGeometryAndFrames - both containers - "
                     "geometry_id_vector");
   ExpectContainsAll(
-      geometry_set, frame_id_set,
+      tester, frame_id_set,
       "IterableGeometryAndFrames - both containers - frame_id_set");
 
   GeometrySet geometry_set2;
+  GeometrySetTester tester2(&geometry_set2);
   geometry_set2.Add({geometry_id_vector[0], geometry_id_vector[1]},
                     frame_id_set);
-  EXPECT_EQ(geometry_set2.num_frames(), static_cast<int>(frame_id_set.size()));
-  EXPECT_EQ(geometry_set2.num_geometries(),
+  EXPECT_EQ(tester2.num_frames(), static_cast<int>(frame_id_set.size()));
+  EXPECT_EQ(tester2.num_geometries(),
             static_cast<int>(geometry_id_vector.size()));
   ExpectContainsAll(
-      geometry_set2, geometry_id_vector,
+      tester2, geometry_id_vector,
       "IterableGeometryAndFrames - geometry initializer list - geometry");
-  ExpectContainsAll(geometry_set2, frame_id_set,
+  ExpectContainsAll(tester2, frame_id_set,
                     "IterableGeometryAndFrames - geometry initializer list - "
                     "frame_id_set");
 
   GeometrySet geometry_set3;
+  GeometrySetTester tester3(&geometry_set3);
   geometry_set3.Add(geometry_id_vector,
                     {*frame_id_set.begin(), *(++frame_id_set.begin())});
-  EXPECT_EQ(geometry_set3.num_frames(), static_cast<int>(frame_id_set.size()));
-  EXPECT_EQ(geometry_set3.num_geometries(),
+  EXPECT_EQ(tester3.num_frames(), static_cast<int>(frame_id_set.size()));
+  EXPECT_EQ(tester3.num_geometries(),
             static_cast<int>(geometry_id_vector.size()));
-  ExpectContainsAll(geometry_set3, geometry_id_vector,
+  ExpectContainsAll(tester3, geometry_id_vector,
                     "IterableGeometryAndFrames - frame initializer list - "
                     "geometry_id_vector");
-  ExpectContainsAll(geometry_set3, frame_id_set,
+  ExpectContainsAll(tester3, frame_id_set,
                     "IterableGeometryAndFrames - frame initializer list - "
                     "frame initializer list");
 }
 
 GTEST_TEST(GeometrySetTests, GeometrySetAdd) {
   GeometrySet set1;
+  GeometrySetTester tester1(&set1);
   GeometrySet set2;
+  GeometrySetTester tester2(&set2);
 
   std::vector<FrameId> frame_ids{FrameId::get_new_id(), FrameId::get_new_id()};
   std::vector<GeometryId> geometry_ids{GeometryId::get_new_id(),
@@ -294,11 +312,11 @@ GTEST_TEST(GeometrySetTests, GeometrySetAdd) {
   // Set 1 contains all of the created ids.
   set1.Add(frame_ids);
   set1.Add(geometry_ids);
-  EXPECT_EQ(set1.num_frames(), static_cast<int>(frame_ids.size()));
-  EXPECT_EQ(set1.num_geometries(), static_cast<int>(geometry_ids.size()));
-  ExpectContainsAll(set1, frame_ids,
+  EXPECT_EQ(tester1.num_frames(), static_cast<int>(frame_ids.size()));
+  EXPECT_EQ(tester1.num_geometries(), static_cast<int>(geometry_ids.size()));
+  ExpectContainsAll(tester1, frame_ids,
                     "GeometrySetAdd - set1 initial contents - frames");
-  ExpectContainsAll(set1, geometry_ids,
+  ExpectContainsAll(tester1, geometry_ids,
                     "GeometrySetAdd - set1 initial contents - geometries");
 
   // Set 2 contains some unique ids and *some* ids from the created sets (so
@@ -308,11 +326,11 @@ GTEST_TEST(GeometrySetTests, GeometrySetAdd) {
                                          GeometryId::get_new_id()};
   set2.Add(frame_ids_2);
   set2.Add(geometry_ids_2);
-  EXPECT_EQ(set2.num_frames(), static_cast<int>(frame_ids_2.size()));
-  EXPECT_EQ(set2.num_geometries(), static_cast<int>(geometry_ids_2.size()));
-  ExpectContainsAll(set2, frame_ids_2,
+  EXPECT_EQ(tester2.num_frames(), static_cast<int>(frame_ids_2.size()));
+  EXPECT_EQ(tester2.num_geometries(), static_cast<int>(geometry_ids_2.size()));
+  ExpectContainsAll(tester2, frame_ids_2,
                     "GeometrySetAdd - set2 initial contents - frames");
-  ExpectContainsAll(set2, geometry_ids_2,
+  ExpectContainsAll(tester2, geometry_ids_2,
                     "GeometrySetAdd - set2 initial contents - geometries");
 
   // Adds set2 into set1. There should be an increase of a *single* frame and
@@ -324,11 +342,11 @@ GTEST_TEST(GeometrySetTests, GeometrySetAdd) {
 
   set1.Add(set2);
 
-  EXPECT_EQ(set1.num_frames(), static_cast<int>(frame_union.size()));
-  EXPECT_EQ(set1.num_geometries(), static_cast<int>(geometry_union.size()));
-  ExpectContainsAll(set1, frame_union,
+  EXPECT_EQ(tester1.num_frames(), static_cast<int>(frame_union.size()));
+  EXPECT_EQ(tester1.num_geometries(), static_cast<int>(geometry_union.size()));
+  ExpectContainsAll(tester1, frame_union,
                     "GeometrySetAdd - set1 merged - frames");
-  ExpectContainsAll(set1, geometry_union,
+  ExpectContainsAll(tester1, geometry_union,
                     "GeometrySetAdd - set1 merged - geometries");
 }
 

--- a/geometry/test/geometry_set_test.cc
+++ b/geometry/test/geometry_set_test.cc
@@ -283,6 +283,56 @@ GTEST_TEST(GeometrySetTests, IterableGeometryAndFrames) {
                     "frame initializer list");
 }
 
+GTEST_TEST(GeometrySetTests, GeometrySetAdd) {
+  GeometrySet set1;
+  GeometrySet set2;
+
+  std::vector<FrameId> frame_ids{FrameId::get_new_id(), FrameId::get_new_id()};
+  std::vector<GeometryId> geometry_ids{GeometryId::get_new_id(),
+                                       GeometryId::get_new_id()};
+
+  // Set 1 contains all of the created ids.
+  set1.Add(frame_ids);
+  set1.Add(geometry_ids);
+  EXPECT_EQ(set1.num_frames(), static_cast<int>(frame_ids.size()));
+  EXPECT_EQ(set1.num_geometries(), static_cast<int>(geometry_ids.size()));
+  ExpectContainsAll(set1, frame_ids,
+                    "GeometrySetAdd - set1 initial contents - frames");
+  ExpectContainsAll(set1, geometry_ids,
+                    "GeometrySetAdd - set1 initial contents - geometries");
+
+  // Set 2 contains some unique ids and *some* ids from the created sets (so
+  // that there is a non-empty intersection between the two sets).
+  std::vector<FrameId> frame_ids_2{*frame_ids.begin(), FrameId::get_new_id()};
+  std::vector<GeometryId> geometry_ids_2{*geometry_ids.begin(),
+                                         GeometryId::get_new_id()};
+  set2.Add(frame_ids_2);
+  set2.Add(geometry_ids_2);
+  EXPECT_EQ(set2.num_frames(), static_cast<int>(frame_ids_2.size()));
+  EXPECT_EQ(set2.num_geometries(), static_cast<int>(geometry_ids_2.size()));
+  ExpectContainsAll(set2, frame_ids_2,
+                    "GeometrySetAdd - set2 initial contents - frames");
+  ExpectContainsAll(set2, geometry_ids_2,
+                    "GeometrySetAdd - set2 initial contents - geometries");
+
+  // Adds set2 into set1. There should be an increase of a *single* frame and
+  // geometry in set 1.
+  std::vector<FrameId> frame_union(frame_ids);
+  frame_union.push_back(frame_ids_2.back());
+  std::vector<GeometryId> geometry_union(geometry_ids);
+  geometry_union.push_back(geometry_ids_2.back());
+
+  set1.Add(set2);
+
+  EXPECT_EQ(set1.num_frames(), static_cast<int>(frame_union.size()));
+  EXPECT_EQ(set1.num_geometries(), static_cast<int>(geometry_union.size()));
+  ExpectContainsAll(set1, frame_union,
+                    "GeometrySetAdd - set1 merged - frames");
+  ExpectContainsAll(set1, geometry_union,
+                    "GeometrySetAdd - set1 merged - geometries");
+}
+
 }  // namespace
 }  // namespace geometry
 }  // namespace drake
+

--- a/geometry/test_utilities/BUILD.bazel
+++ b/geometry/test_utilities/BUILD.bazel
@@ -1,0 +1,22 @@
+# -*- python -*-
+# This file contains rules for Bazel; see drake/doc/bazel.rst.
+
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_googletest",
+    "drake_cc_library",
+)
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+package(default_visibility = ["//visibility:public"])
+
+drake_cc_library(
+    name = "geometry_set_tester",
+    # TODO(SeanCurtis-TRI): Make this `testonly = 1` once dev/GeometryState is
+    # removed.
+    srcs = [],
+    hdrs = ["geometry_set_tester.h"],
+    deps = ["//geometry:geometry_set"],
+)
+
+add_lint_tests()

--- a/geometry/test_utilities/geometry_set_tester.h
+++ b/geometry/test_utilities/geometry_set_tester.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <unordered_set>
+
+#include "drake/geometry/geometry_set.h"
+
+namespace drake {
+namespace geometry {
+
+// Utility class for testing the implementation details of the GeometrySet.
+class GeometrySetTester {
+ public:
+  explicit GeometrySetTester(const GeometrySet* set) : set_(*set) {}
+
+  const std::unordered_set<FrameId> frames() const {
+    return set_.frames_internal();
+  }
+
+  int num_frames() const { return set_.num_frames_internal(); }
+
+  const std::unordered_set<GeometryId> geometries() const {
+    return set_.geometries_internal();
+  }
+
+  int num_geometries() const { return set_.num_geometries_internal(); }
+
+  bool contains(FrameId frame_id) const {
+    return set_.contains_internal(frame_id); }
+
+  bool contains(GeometryId geometry_id) const {
+    return set_.contains_internal(geometry_id);;
+  }
+
+ private:
+  const GeometrySet& set_;
+};
+
+}  // namespace geometry
+}  // namespace drake

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -161,6 +161,7 @@ drake_cc_googletest(
         "//common:find_resource",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
+        "//geometry/test_utilities:geometry_set_tester",
         "//math:geometric_transform",
         "//math:gradient",
         "//multibody/benchmarks/acrobot",

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -19,6 +19,7 @@
 #include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/query_object.h"
 #include "drake/geometry/scene_graph.h"
+#include "drake/geometry/test_utilities/geometry_set_tester.h"
 #include "drake/math/autodiff_gradient.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/math/roll_pitch_yaw.h"
@@ -934,6 +935,7 @@ GTEST_TEST(MultibodyPlantTest, CollectRegisteredGeometriesErrors) {
 // will be included.
 GTEST_TEST(MultibodyPlantTest, CollectRegisteredGeometries) {
   using geometry::GeometrySet;
+  using geometry::GeometrySetTester;
 
   SphereChainScenario scenario(5);
 
@@ -942,25 +944,28 @@ GTEST_TEST(MultibodyPlantTest, CollectRegisteredGeometries) {
   // Case: Empty vector produces empty geometry set.
   {
     GeometrySet set = plant.CollectRegisteredGeometries({});
-    EXPECT_EQ(set.num_geometries(), 0);
-    EXPECT_EQ(set.num_frames(), 0);
+    GeometrySetTester tester(&set);
+    EXPECT_EQ(tester.num_geometries(), 0);
+    EXPECT_EQ(tester.num_frames(), 0);
   }
 
   // Case: Single body produces single, corresponding frame.
   {
     GeometrySet set = plant.CollectRegisteredGeometries({&scenario.sphere(0)});
-    EXPECT_EQ(set.num_geometries(), 0);
-    EXPECT_EQ(set.num_frames(), 1);
+    GeometrySetTester tester(&set);
+    EXPECT_EQ(tester.num_geometries(), 0);
+    EXPECT_EQ(tester.num_frames(), 1);
     FrameId id_0 = plant.GetBodyFrameIdOrThrow(scenario.sphere(0).index());
-    EXPECT_TRUE(set.contains(id_0));
+    EXPECT_TRUE(tester.contains(id_0));
   }
 
   // Case: Body with no corresponding geometry frame.
   {
     GeometrySet set =
         plant.CollectRegisteredGeometries({&scenario.no_geometry_body()});
-    EXPECT_EQ(set.num_geometries(), 0);
-    EXPECT_EQ(set.num_frames(), 0);
+    GeometrySetTester tester(&set);
+    EXPECT_EQ(tester.num_geometries(), 0);
+    EXPECT_EQ(tester.num_frames(), 0);
   }
 
   // Case: Include the world body.
@@ -968,9 +973,10 @@ GTEST_TEST(MultibodyPlantTest, CollectRegisteredGeometries) {
     GeometrySet set =
         plant.CollectRegisteredGeometries(
             {&scenario.mutable_plant()->world_body()});
-    EXPECT_EQ(set.num_frames(), 1);
-    EXPECT_EQ(set.num_geometries(), 0);
-    EXPECT_FALSE(set.contains(scenario.ground_id()));
+    GeometrySetTester tester(&set);
+    EXPECT_EQ(tester.num_frames(), 1);
+    EXPECT_EQ(tester.num_geometries(), 0);
+    EXPECT_FALSE(tester.contains(scenario.ground_id()));
   }
 }
 


### PR DESCRIPTION
This does two things in two commits:

1. Adds the interface for merging one `GeometrySet` into another.
2. Deprecates the misleading introspection methods so that it doesn't imply that users should try to poke in the internals of GeometrySet.

~relates to #10413~
EDIT (eric): Resolves #10413

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10417)
<!-- Reviewable:end -->
