### PR TITLE
[geometry] Make context-modifying SceneGraph methods const.

### DIFF
--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -175,7 +175,7 @@ GeometryId SceneGraph<T>::RegisterGeometry(
 template <typename T>
 GeometryId SceneGraph<T>::RegisterGeometry(
     Context<T>* context, SourceId source_id, FrameId frame_id,
-    std::unique_ptr<GeometryInstance> geometry) {
+    std::unique_ptr<GeometryInstance> geometry) const {
   auto* g_context = static_cast<GeometryContext<T>*>(context);
   auto& g_state = g_context->get_mutable_geometry_state();
   return g_state.RegisterGeometry(source_id, frame_id, std::move(geometry));
@@ -193,7 +193,7 @@ GeometryId SceneGraph<T>::RegisterGeometry(
 template <typename T>
 GeometryId SceneGraph<T>::RegisterGeometry(
     Context<T>* context, SourceId source_id, GeometryId geometry_id,
-    std::unique_ptr<GeometryInstance> geometry) {
+    std::unique_ptr<GeometryInstance> geometry) const {
   auto* g_context = static_cast<GeometryContext<T>*>(context);
   auto& g_state = g_context->get_mutable_geometry_state();
   return g_state.RegisterGeometryWithParent(source_id, geometry_id,
@@ -216,7 +216,7 @@ void SceneGraph<T>::RemoveGeometry(SourceId source_id, GeometryId geometry_id) {
 
 template <typename T>
 void SceneGraph<T>::RemoveGeometry(Context<T>* context, SourceId source_id,
-                                   GeometryId geometry_id) {
+                                   GeometryId geometry_id) const {
   auto* g_context = static_cast<GeometryContext<T>*>(context);
   auto& g_state = g_context->get_mutable_geometry_state();
   g_state.RemoveGeometry(source_id, geometry_id);
@@ -251,8 +251,8 @@ void SceneGraph<T>::ExcludeCollisionsWithin(const GeometrySet& geometry_set) {
 }
 
 template <typename T>
-void SceneGraph<T>::ExcludeCollisionsWithin(Context<T>* context,
-                                            const GeometrySet& geometry_set) {
+void SceneGraph<T>::ExcludeCollisionsWithin(
+    Context<T>* context, const GeometrySet& geometry_set) const {
   auto* g_context = static_cast<GeometryContext<T>*>(context);
   auto& g_state = g_context->get_mutable_geometry_state();
   g_state.ExcludeCollisionsWithin(geometry_set);
@@ -268,7 +268,7 @@ void SceneGraph<T>::ExcludeCollisionsBetween(const GeometrySet& setA,
 template <typename T>
 void SceneGraph<T>::ExcludeCollisionsBetween(Context<T>* context,
                                              const GeometrySet& setA,
-                                             const GeometrySet& setB) {
+                                             const GeometrySet& setB) const {
   auto* g_context = static_cast<GeometryContext<T>*>(context);
   auto& g_state = g_context->get_mutable_geometry_state();
   g_state.ExcludeCollisionsBetween(setA, setB);

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -375,7 +375,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
    the provided context.  */
   GeometryId RegisterGeometry(systems::Context<T>* context, SourceId source_id,
                               FrameId frame_id,
-                              std::unique_ptr<GeometryInstance> geometry);
+                              std::unique_ptr<GeometryInstance> geometry) const;
 
   /** Registers a new geometry G for this source. This hangs geometry G on a
    previously registered geometry P (indicated by `geometry_id`). The pose of
@@ -405,7 +405,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
    the provided context.  */
   GeometryId RegisterGeometry(systems::Context<T>* context, SourceId source_id,
                               GeometryId geometry_id,
-                              std::unique_ptr<GeometryInstance> geometry);
+                              std::unique_ptr<GeometryInstance> geometry) const;
 
   /** Registers a new _anchored_ geometry G for this source. This hangs geometry
    G from the world frame (W). Its pose is defined in that frame (i.e., `X_WG`).
@@ -441,7 +441,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
    modifying %SceneGraph's model, it modifies the copy of the model stored in
    the provided context.  */
   void RemoveGeometry(systems::Context<T>* context, SourceId source_id,
-                      GeometryId geometry_id);
+                      GeometryId geometry_id) const;
 
   //@}
 
@@ -533,7 +533,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
    than modifying %SceneGraph's model, it modifies the copy of the model stored
    in the provided context.  */
   void ExcludeCollisionsWithin(systems::Context<T>* context,
-                               const GeometrySet& set);
+                               const GeometrySet& set) const;
 
   /** Excludes geometry pairs from collision evaluation by updating the
    candidate pair set `C = C - P`, where `P = {(a, b)}, ∀ a ∈ A, b ∈ B` and
@@ -557,7 +557,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
    in the provided context.  */
   void ExcludeCollisionsBetween(systems::Context<T>* context,
                                 const GeometrySet& setA,
-                                const GeometrySet& setB);
+                                const GeometrySet& setB) const;
   //@}
 
  private:


### PR DESCRIPTION
As stated in [this comment](https://github.com/RobotLocomotion/drake/issues/10329#issuecomment-450934293) the methods of `SceneGraph` that modify a context should be `const`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10425)
<!-- Reviewable:end -->
