### PR TITLE
Change the default for Simulator per-step and initialization forced-publish events.

### DIFF
--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -337,23 +337,34 @@ class Simulator {
   /// @see set_target_realtime_rate()
   double get_actual_realtime_rate() const;
 
-  /// Sets whether the simulation should invoke Publish on the System under
-  /// simulation during every time step. If enabled, Publish will be invoked
-  /// after discrete updates and before continuous integration. Regardless of
-  /// whether publishing every time step is enabled, Publish will be invoked at
-  /// Simulator initialize time, and as System<T>::CalcNextUpdateTime requests.
+  /// Sets whether the simulation should trigger a forced-Publish event on the
+  /// System under simulation at the end of every trajectory-advancing substep.
+  /// Specifically, that means the System::Publish() event dispatcher will be
+  /// invoked on each subsystem of the System and passed the current Context
+  /// and a forced-publish Event. If a subsystem has declared a forced-publish
+  /// event handler, that will be called. Otherwise, nothing will happen unless
+  /// the DoPublish() dispatcher has been overridden.
+  ///
+  /// Enabling this option does not cause a forced-publish to be triggered at
+  /// initialization; if you want that you should also call
+  /// `set_publish_at_initialization(true)`. If you want a forced-publish at the
+  /// end of every step, you will usually also want one at the end of
+  /// initialization, requiring both options to be enabled.
+  ///
+  /// @see LeafSystem::DeclareForcedPublishEvent()
   void set_publish_every_time_step(bool publish) {
     publish_every_time_step_ = publish;
   }
 
-  /// Sets whether the simulation should invoke Publish in Initialize().
+  /// Sets whether the simulation should trigger a forced-Publish at the end
+  /// of Initialize(). See set_publish_every_time_step() documentation for
+  /// more information.
   void set_publish_at_initialization(bool publish) {
     publish_at_initialization_ = publish;
   }
 
-  /// Returns true if the simulation should invoke Publish on the System under
-  /// simulation every time step.  By default, returns true.
-  // TODO(sherm1, edrumwri): Consider making this false by default.
+  /// Returns true if the set_publish_every_time_step() option has been
+  /// enabled. By default, returns false.
   bool get_publish_every_time_step() const { return publish_every_time_step_; }
 
   /// Returns a const reference to the internally-maintained Context holding the
@@ -558,9 +569,9 @@ class Simulator {
   // Slow down to this rate if possible (user settable).
   double target_realtime_rate_{0.};
 
-  bool publish_every_time_step_{true};
+  bool publish_every_time_step_{false};
 
-  bool publish_at_initialization_{true};
+  bool publish_at_initialization_{false};
 
   // These are recorded at initialization or statistics reset.
   double initial_simtime_{nan()};  // Simulated time at start of period.

--- a/systems/analysis/test/simulator_test.cc
+++ b/systems/analysis/test/simulator_test.cc
@@ -813,6 +813,9 @@ GTEST_TEST(SimulatorTest, SpringMassNoSample) {
                                                               &context);
 
   simulator.set_target_realtime_rate(0.5);
+  simulator.set_publish_at_initialization(true);
+  simulator.set_publish_every_time_step(true);
+
   // Set the integrator and initialize the simulator.
   simulator.Initialize();
 
@@ -893,11 +896,12 @@ GTEST_TEST(SimulatorTest, RealtimeRate) {
   EXPECT_TRUE(simulator.get_actual_realtime_rate() <= 5.1);
 }
 
-// Tests that if publishing every timestep is disabled, publish only happens
-// on initialization.
+// Tests that if publishing every timestep is disabled and publish on
+// initialization is enabled, publish only happens on initialization.
 GTEST_TEST(SimulatorTest, DisablePublishEveryTimestep) {
   analysis_test::MySpringMassSystem<double> spring_mass(1., 1., 0.);
   Simulator<double> simulator(spring_mass);  // Use default Context.
+  simulator.set_publish_at_initialization(true);
   simulator.set_publish_every_time_step(false);
 
   simulator.get_mutable_context().set_time(0.);


### PR DESCRIPTION
Previously the Simulator default for per-step and initialization forced-publish events was `true`; this PR changes the defaults to `false`. This is a change we have been planning for a long time; we're doing it now because 
- recent PRs switching from DoPublish() overrides to Event-callback make these no-ops for most use cases, and
- issue #10387 shows a 400X speedup with these disabled! (Not the kind of thing we want users to run into accidentally.)

Although this is a potentially breaking change, other than a few Simulator unit tests there were no test failures in Drake or Anzu caused by this change. 

How can I tell if my code needs to be updated?
-----------------------------------------------
If you are
- using a `LeafSystem` that overrides the `DoPublish()` dispatcher* (not best practice any more), and
- you are using the `Simulator` without turning off per-step publish or publish-at-initialization.

The easiest fix is to add:
```c++
simulator.set_publish_every_time_step(true);
simulator.set_publish_at_initialization(true);
```
to your main program.  A better fix would be to fix the out-of-date `LeafSystem` to use a per-step `Event` with a specified handler rather than override `DoPublish()`. See `LeafSystem::DeclarePerStepPublishEvent()` and `LeafSystem::DeclarePeriodicPublishEvent()` for the recommended alternative.

 *Code that uses `DeclareForcePublishEvent()` would also be affected, but that method was just introduced a few days ago so you aren't using it!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10428)
<!-- Reviewable:end -->
