### PR TITLE
workspace/snopt: Downgrade to SNOPT 7.4

### DIFF
--- a/doc/bazel.rst
+++ b/doc/bazel.rst
@@ -176,7 +176,7 @@ The Drake Bazel build currently supports the following proprietary solvers:
 
  * Gurobi 8.0.0
  * MOSEK 8.1
- * SNOPT 7.6
+ * SNOPT 7.4
 
 .. When upgrading SNOPT to a newer revision, re-enable TestPrintFile in
    solvers/test/snopt_solver_test.cc.
@@ -240,8 +240,8 @@ Using your own source archive
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 1. Download the SNOPT sources from the distributor in ``.tar.gz`` format (e.g.,
-   named ``snopt7.6.tar.gz``).
-2. ``export SNOPT_PATH=/home/username/Downloads/snopt7.6.tar.gz``
+   named ``snopt7.4.tar.gz``).
+2. ``export SNOPT_PATH=/home/username/Downloads/snopt7.4.tar.gz``
 
 Using the RobotLocomotion git repository
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tools/workspace/snopt/repository.bzl
+++ b/tools/workspace/snopt/repository.bzl
@@ -163,7 +163,7 @@ def _impl(repo_ctx):
 snopt_repository = repository_rule(
     attrs = {
         "remote": attr.string(default = "git@github.com:RobotLocomotion/snopt.git"),  # noqa
-        "commit": attr.string(default = "c17db3769e59d4a8d651631d5d79641cecca0504"),  # noqa
+        "commit": attr.string(default = "0254e961cb8c60193b0862a0428fd6a42bfb5243"),  # noqa
         "use_drake_build_rules": attr.bool(
             default = True,
             doc = ("When obtaining SNOPT via git, controls whether or not " +


### PR DESCRIPTION
When a user chooses to use RobotLocomotion/snopt, now we will compile the SNOPT 7.4-1.1 2015-02-26 release.  The f2c-generated sources in that release snapshot brand themselves as 7.4-1.2.

Prior to this commit, we would compile the SNOPT 7.6.1 2018-01-20 release.  The f2c-generated sources in that release brand themselves as 7.4-1.2 as well (no change).

Therefore, this commit should have no effect when using the f2c bindings for SNOPT (the default).

However, when using the Fortran bindings for SNOPT via our Bazel build's `--config snopt_fortran` option, now we will use the 7.4-era Fortran code, instead of 7.6.  For now, we prefer that choice so that swapping back and forth between the two bindings is decoupled from SNOPT's algorithmic changes that came in with revision 7.6 -- especially because the algorithms in 7.6 have several major regressions compared to 7.4, at insofar as we've observed via our bindings.

Relates #10422.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10430)
<!-- Reviewable:end -->
