### PR TITLE
Remove empty inertial tag on generated road network urdf

### DIFF
--- a/automotive/maliput/utility/generate_urdf.cc
+++ b/automotive/maliput/utility/generate_urdf.cc
@@ -33,7 +33,6 @@ void GenerateUrdfFile(const api::RoadGeometry* road_geometry,
   </joint>
 
   <link name="surface">
-    <inertial/>
     <visual name="v1">
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>

--- a/automotive/maliput/utility/test/generate_urdf_test.cc
+++ b/automotive/maliput/utility/test/generate_urdf_test.cc
@@ -103,7 +103,6 @@ TEST_F(GenerateUrdfTest, AtLeastRunIt) {
   </joint>
 
   <link name="surface">
-    <inertial/>
     <visual name="v1">
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>


### PR DESCRIPTION
We found this while porting some prius vis RBT code to MBT (the parser was complaining). Also, removing this doesn't seem to cause any issues with current RBT implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10434)
<!-- Reviewable:end -->
