### PR TITLE
multibody/plant: Compile for symbolic::Expression scalar

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -198,6 +198,16 @@ drake_cc_googletest(
     ],
 )
 
+drake_cc_googletest(
+    name = "multibody_plant_symbolic_test",
+    deps = [
+        ":plant",
+        "//common/test_utilities:symbolic_test_util",
+        "//multibody/benchmarks/pendulum",
+        "//systems/framework/test_utilities:scalar_conversion",
+    ],
+)
+
 drake_cc_library(
     name = "kuka_iiwa_model_tests",
     testonly = 1,
@@ -331,7 +341,9 @@ drake_cc_googletest(
     timeout = "moderate",
     deps = [
         ":plant",
+        "//common/test_utilities:symbolic_test_util",
         "//systems/analysis:simulator",
+        "//systems/framework/test_utilities:scalar_conversion",
     ],
 )
 

--- a/multibody/plant/contact_info.cc
+++ b/multibody/plant/contact_info.cc
@@ -21,5 +21,5 @@ PointPairContactInfo<T>::PointPairContactInfo(
 }  // namespace drake
 
 // Explicitly instantiates on the most common scalar types.
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::PointPairContactInfo)

--- a/multibody/plant/contact_info.h
+++ b/multibody/plant/contact_info.h
@@ -24,12 +24,7 @@ namespace multibody {
     - Separation speed.
     - Slip speed.
 
- @tparam T      The scalar type. It must be a valid Eigen scalar.
-
- Instantiated templates for the following ScalarTypes are provided:
-
- - double
- - AutoDiffXd
+ @tparam T Must be one of drake's default scalar types.
  */
 template <typename T>
 class PointPairContactInfo {
@@ -127,5 +122,5 @@ using PointPairContactInfo
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::PointPairContactInfo)

--- a/multibody/plant/contact_results.cc
+++ b/multibody/plant/contact_results.cc
@@ -29,5 +29,5 @@ const PointPairContactInfo<T>& ContactResults<T>::contact_info(int i) const {
 }  // namespace drake
 
 // Explicitly instantiates on the most common scalar types.
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::ContactResults)

--- a/multibody/plant/contact_results.h
+++ b/multibody/plant/contact_results.h
@@ -15,12 +15,7 @@ namespace multibody {
  A container class storing the contact results information for each contact
  pair for a given state of the simulation.
 
- @tparam T      The scalar type. It must be a valid Eigen scalar.
-
- Instantiated templates for the following ScalarTypes are provided:
-
- - double
- - AutoDiffXd
+ @tparam T Must be one of drake's default scalar types.
  */
 template <typename T>
 class ContactResults {
@@ -66,5 +61,5 @@ using ContactResults = ::drake::multibody::ContactResults<T>;
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::ContactResults)

--- a/multibody/plant/contact_results_to_lcm.cc
+++ b/multibody/plant/contact_results_to_lcm.cc
@@ -117,5 +117,5 @@ systems::lcm::LcmPublisherSystem* ConnectContactResultsToDrakeVisualizer(
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class drake::multibody::ContactResultsToLcmSystem)

--- a/multibody/plant/contact_results_to_lcm.h
+++ b/multibody/plant/contact_results_to_lcm.h
@@ -22,15 +22,7 @@ namespace multibody {
  message. It has a single input port with type ContactResults<T> and a single
  output port with lcmt_contact_results_for_viz.
 
- @tparam T The scalar type. Must be a valid Eigen scalar.
-
- Instantiated templates for the following kinds of T's are provided:
-
- - double
- - AutoDiffXd
-
- They are already available to link against in the containing library. No other
- values for T are currently supported.
+ @tparam T Must be one of drake's default scalar types.
  */
 template <typename T>
 class ContactResultsToLcmSystem final : public systems::LeafSystem<T> {
@@ -148,5 +140,5 @@ inline systems::lcm::LcmPublisherSystem* ConnectContactResultsToDrakeVisualizer(
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class drake::multibody::ContactResultsToLcmSystem)

--- a/multibody/plant/coulomb_friction.h
+++ b/multibody/plant/coulomb_friction.h
@@ -58,16 +58,7 @@ namespace multibody {
 /// combination law model for tires, will have a different set of requirements
 /// from the ones stated above.
 ///
-/// @tparam T The scalar type. Must be a valid Eigen scalar.
-///
-/// Instantiated templates for the following kinds of T's are provided:
-///
-/// - double
-/// - AutoDiffXd
-/// - symbolic::Expression
-///
-/// They are already available to link against in the containing library.
-/// No other values for T are currently supported.
+/// @tparam T Must be one of drake's default scalar types.
 template<typename T>
 class CoulombFriction {
  public:

--- a/multibody/plant/implicit_stribeck_solver.cc
+++ b/multibody/plant/implicit_stribeck_solver.cc
@@ -663,8 +663,8 @@ ImplicitStribeckSolverResult ImplicitStribeckSolver<T>::SolveWithGuess(
 
   // Initialize vt_error to an arbitrary value larger than tolerance so that the
   // solver at least performs one iteration.
-  T vt_error = 2 * v_contact_tolerance;
-  T vn_error = 2 * v_contact_tolerance;
+  double vt_error = 2 * v_contact_tolerance;
+  double vn_error = 2 * v_contact_tolerance;
 
   // Initialize iteration with the guess provided.
   v = v_guess;
@@ -740,8 +740,8 @@ ImplicitStribeckSolverResult ImplicitStribeckSolver<T>::SolveWithGuess(
     Delta_vn = Jn * Delta_v;
 
     // We monitor convergence in both normal and tangential velocities.
-    vn_error = Delta_vn.norm();
-    vt_error = Delta_vt.norm();
+    vn_error = ExtractDoubleOrThrow(Delta_vn.norm());
+    vt_error = ExtractDoubleOrThrow(Delta_vt.norm());
 
     // Limit the angle change between vₜᵏ⁺¹ and vₜᵏ for all contact points.
     T alpha = CalcAlpha(vt, Delta_vt);
@@ -750,7 +750,7 @@ ImplicitStribeckSolverResult ImplicitStribeckSolver<T>::SolveWithGuess(
     v = v + alpha * Delta_v;
 
     // Save iteration statistics.
-    statistics_.Update(ExtractDoubleOrThrow(vt_error));
+    statistics_.Update(vt_error);
   }
 
   // If we are here is because we reached the maximum number of iterations
@@ -782,8 +782,8 @@ T ImplicitStribeckSolver<T>::ModifiedStribeckDerivative(
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     struct ::drake::multibody::internal::DirectionChangeLimiter)
 
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::ImplicitStribeckSolver)

--- a/multibody/plant/implicit_stribeck_solver.h
+++ b/multibody/plant/implicit_stribeck_solver.h
@@ -493,13 +493,8 @@ expansion of `fₙ` with an order of approximation consistent with the
 first order scheme as needed. Therefore, it propagates into a `O(δt²)`
 term exactly as needed in Eq. (16).
 
-@tparam T The type of mathematical object being added.
-Instantiated templates for the following kinds of T's are provided:
-- double
-- AutoDiffXd
-
-They are already available to link against in the containing library.
-No other values for T are currently supported. */
+@tparam T Must be one of drake's default scalar types.
+*/
 template <typename T>
 class ImplicitStribeckSolver {
  public:
@@ -1157,8 +1152,8 @@ class ImplicitStribeckSolver {
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     struct ::drake::multibody::internal::DirectionChangeLimiter)
 
-DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::ImplicitStribeckSolver)

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -266,12 +266,14 @@ geometry::SourceId MultibodyPlant<T>::RegisterAsSourceForSceneGraph(
     SceneGraph<T>* scene_graph) {
   DRAKE_THROW_UNLESS(scene_graph != nullptr);
   DRAKE_THROW_UNLESS(!geometry_source_is_registered());
-  source_id_ = scene_graph->RegisterSource();
   // Save the GS pointer so that on later geometry registrations can use this
   // instance. This will be nullified at Finalize().
   scene_graph_ = scene_graph;
-  body_index_to_frame_id_[world_index()] = scene_graph->world_frame_id();
-  frame_id_to_body_index_[scene_graph->world_frame_id()] = world_index();
+  source_id_ = member_scene_graph().RegisterSource();
+  const geometry::FrameId world_frame_id =
+      member_scene_graph().world_frame_id();
+  body_index_to_frame_id_[world_index()] = world_frame_id;
+  frame_id_to_body_index_[world_frame_id] = world_index();
   DeclareSceneGraphPorts();
   return source_id_.value();
 }
@@ -315,9 +317,8 @@ geometry::GeometryId MultibodyPlant<T>::RegisterVisualGeometry(
   // register geometry that has a fixed path to world to the world body (i.e.,
   // as anchored geometry).
   GeometryId id = RegisterGeometry(
-      body, X_BG, shape, GetScopedName(*this, body.model_instance(), name),
-      scene_graph_);
-  scene_graph_->AssignRole(*source_id_, id, properties);
+      body, X_BG, shape, GetScopedName(*this, body.model_instance(), name));
+  member_scene_graph().AssignRole(*source_id_, id, properties);
   const int visual_index = geometry_id_to_visual_index_.size();
   geometry_id_to_visual_index_[id] = visual_index;
   DRAKE_ASSERT(num_bodies() == static_cast<int>(visual_geometries_.size()));
@@ -345,12 +346,12 @@ geometry::GeometryId MultibodyPlant<T>::RegisterCollisionGeometry(
   // register geometry that has a fixed path to world to the world body (i.e.,
   // as anchored geometry).
   GeometryId id = RegisterGeometry(
-      body, X_BG, shape, GetScopedName(*this, body.model_instance(), name),
-      scene_graph_);
+      body, X_BG, shape, GetScopedName(*this, body.model_instance(), name));
 
   // TODO(SeanCurtis-TRI): Push the contact parameters into the
   // ProximityProperties.
-  scene_graph_->AssignRole(*source_id_, id, geometry::ProximityProperties());
+  member_scene_graph().AssignRole(
+      *source_id_, id, geometry::ProximityProperties());
   const int collision_index = geometry_id_to_collision_index_.size();
   geometry_id_to_collision_index_[id] = collision_index;
   DRAKE_ASSERT(
@@ -412,14 +413,12 @@ template <typename T>
 geometry::GeometryId MultibodyPlant<T>::RegisterGeometry(
     const Body<T>& body, const Isometry3<double>& X_BG,
     const geometry::Shape& shape,
-    const std::string& name,
-    SceneGraph<T>* scene_graph) {
+    const std::string& name) {
   DRAKE_ASSERT(!is_finalized());
   DRAKE_ASSERT(geometry_source_is_registered());
-  CheckUserProvidedSceneGraph(scene_graph);
   // If not already done, register a frame for this body.
   if (!body_has_registered_frame(body)) {
-    FrameId frame_id = scene_graph_->RegisterFrame(
+    FrameId frame_id = member_scene_graph().RegisterFrame(
         source_id_.value(),
         GeometryFrame(
             GetScopedName(*this, body.model_instance(), body.name()),
@@ -435,7 +434,7 @@ geometry::GeometryId MultibodyPlant<T>::RegisterGeometry(
   // Register geometry in the body frame.
   std::unique_ptr<geometry::GeometryInstance> geometry_instance =
       std::make_unique<GeometryInstance>(X_BG, shape.Clone(), name);
-  GeometryId geometry_id = scene_graph->RegisterGeometry(
+  GeometryId geometry_id = member_scene_graph().RegisterGeometry(
       source_id_.value(), body_index_to_frame_id_[body.index()],
       std::move(geometry_instance));
   geometry_id_to_body_index_[geometry_id] = body.index();
@@ -643,6 +642,47 @@ MatrixX<T> MultibodyPlant<T>::MakeActuationMatrix() const {
 }
 
 template <typename T>
+struct MultibodyPlant<T>::SceneGraphStub {
+  static void Throw(const char* operation_name) {
+    throw std::logic_error(fmt::format(
+        "Cannot {} on a SceneGraph<symbolic::Expression>", operation_name));
+  }
+
+  static FrameId world_frame_id() {
+    return SceneGraph<double>::world_frame_id();
+  }
+
+#define DRAKE_STUB(Ret, Name)                   \
+  template <typename... Args>                   \
+  Ret Name(Args...) const { Throw(#Name); return Ret(); }
+
+  DRAKE_STUB(void, AssignRole)
+  DRAKE_STUB(void, ExcludeCollisionsBetween)
+  DRAKE_STUB(void, ExcludeCollisionsWithin)
+  DRAKE_STUB(FrameId, RegisterFrame)
+  DRAKE_STUB(GeometryId, RegisterGeometry)
+  DRAKE_STUB(SourceId, RegisterSource)
+
+#undef DRAKE_STUB
+};
+
+template <typename T>
+typename MultibodyPlant<T>::MemberSceneGraph&
+MultibodyPlant<T>::member_scene_graph() {
+  DRAKE_THROW_UNLESS(scene_graph_ != nullptr);
+  return *scene_graph_;
+}
+
+// Specialize this function so that we can use our Stub class; we cannot call
+// methods on SceneGraph<Expression> because they do not exist.
+template <>
+typename MultibodyPlant<symbolic::Expression>::MemberSceneGraph&
+MultibodyPlant<symbolic::Expression>::member_scene_graph() {
+  static never_destroyed<SceneGraphStub> stub_;
+  return stub_.access();
+}
+
+template <typename T>
 void MultibodyPlant<T>::CheckUserProvidedSceneGraph(
     const geometry::SceneGraph<T>* scene_graph) const {
   if (scene_graph != nullptr) {
@@ -688,7 +728,7 @@ void MultibodyPlant<T>::FilterAdjacentBodies() {
     optional<FrameId> parent_id = GetBodyFrameIdIfExists(parent.index());
 
     if (child_id && parent_id) {
-      scene_graph_->ExcludeCollisionsBetween(
+      member_scene_graph().ExcludeCollisionsBetween(
           geometry::GeometrySet(*child_id),
           geometry::GeometrySet(*parent_id));
     }
@@ -706,8 +746,8 @@ void MultibodyPlant<T>::ExcludeCollisionsWithVisualGeometry() {
   for (const auto& body_geometries : collision_geometries_) {
     collision.Add(body_geometries);
   }
-  scene_graph_->ExcludeCollisionsWithin(visual);
-  scene_graph_->ExcludeCollisionsBetween(visual, collision);
+  member_scene_graph().ExcludeCollisionsWithin(visual);
+  member_scene_graph().ExcludeCollisionsBetween(visual, collision);
 }
 
 template<typename T>
@@ -858,6 +898,8 @@ void MultibodyPlant<T>::set_penetration_allowance(
   penalty_method_contact_parameters_.time_scale = time_scale;
 }
 
+// Specialize this function so that *only* double is supported; we cannot
+// compute penetrations for AutoDiff or Expression currently.
 template <>
 std::vector<PenetrationAsPointPair<double>>
 MultibodyPlant<double>::CalcPointPairPenetrations(
@@ -867,7 +909,7 @@ MultibodyPlant<double>::CalcPointPairPenetrations(
       throw std::logic_error(
           "This MultibodyPlant registered geometry for contact handling. "
           "However its query input port (get_geometry_query_input_port()) "
-          "is not connected. ");
+          "is not connected.");
     }
     const geometry::QueryObject<double>& query_object =
         this->EvalAbstractInput(context, geometry_query_port_)
@@ -1741,10 +1783,20 @@ MultibodyPlant<T>::get_contact_results_output_port() const {
   return this->get_output_port(contact_results_port_);
 }
 
+namespace {
+// A dummy, placeholder type.
+struct SymbolicGeometryValue {};
+// An alias for QueryObject<T>, except when T = Expression.
+template <typename T>
+using ModelQueryObject = typename std::conditional<
+    std::is_same<T, symbolic::Expression>::value,
+    SymbolicGeometryValue, geometry::QueryObject<T>>::type;
+}  // namespace
+
 template <typename T>
 void MultibodyPlant<T>::DeclareSceneGraphPorts() {
   geometry_query_port_ = this->DeclareAbstractInputPort(
-      "geometry_query", systems::Value<geometry::QueryObject<T>>{}).get_index();
+      "geometry_query", systems::Value<ModelQueryObject<T>>{}).get_index();
   // Allocate pose port.
   // TODO(eric.cousineau): Simplify this logic.
   typename systems::LeafOutputPort<T>::AllocCallback pose_alloc = [this]() {
@@ -1880,6 +1932,7 @@ AddMultibodyPlantSceneGraph(
 }
 
 // Add explicit instantiations for `AddMultibodyPlantSceneGraph`.
+// This does *not* support symbolic::Expression.
 template
 AddMultibodyPlantSceneGraphResult<double>
 AddMultibodyPlantSceneGraph(
@@ -1897,7 +1950,7 @@ AddMultibodyPlantSceneGraph(
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class drake::multibody::MultibodyPlant)
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     struct drake::multibody::AddMultibodyPlantSceneGraphResult)

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <string>
 #include <tuple>
+#include <type_traits>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -187,15 +188,8 @@ namespace multibody {
 ///     Minimal formulation of joint motion for biomechanisms.
 ///     Nonlinear dynamics, 62(1), pp.291-303.
 ///
-/// @tparam T The scalar type. Must be a valid Eigen scalar.
+/// @tparam T Must be one of drake's default scalar types.
 ///
-/// Instantiated templates for the following kinds of T's are provided:
-///
-/// - double
-/// - AutoDiffXd
-///
-/// They are already available to link against in the containing library.
-/// No other values for T are currently supported.
 /// @ingroup systems
 template <typename T>
 class MultibodyPlant : public MultibodyTreeSystem<T> {
@@ -2870,6 +2864,19 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   // MultibodyTree::Finalize() was called.
   void FinalizePlantOnly();
 
+  // MemberSceneGraph is an alias for SceneGraph<T>, except when T = Expression.
+  struct SceneGraphStub;
+  using MemberSceneGraph = typename std::conditional<
+      std::is_same<T, symbolic::Expression>::value,
+      SceneGraphStub, geometry::SceneGraph<T>>::type;
+
+  // Returns the SceneGraph that pre-Finalize geometry operations should
+  // interact with.  In most cases, that will be whatever the user has passed
+  // into RegisterAsSourceForSceneGraph.  However, when T = Expression, the
+  // result will be a stub type instead.  (We can get rid of the stub once
+  // SceneGraph supports symbolic::Expression.)
+  MemberSceneGraph& member_scene_graph();
+
   // Helper to check when a deprecated user-provided `scene_graph` pointer is
   // passed in via public API (aside form `RegisterAsSourceForSceneGraph`).
   // @throws std::logic_error if `scene_graph` is non-null (non-default) and
@@ -2993,8 +3000,7 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   geometry::GeometryId RegisterGeometry(
       const Body<T>& body, const Isometry3<double>& X_BG,
       const geometry::Shape& shape,
-      const std::string& name,
-      geometry::SceneGraph<T>* scene_graph);
+      const std::string& name);
 
   bool body_has_registered_frame(const Body<T>& body) const {
     return body_index_to_frame_id_.find(body.index()) !=
@@ -3448,6 +3454,10 @@ struct AddMultibodyPlantSceneGraphResult final {
 
 #ifndef DRAKE_DOXYGEN_CXX
 // Forward-declare specializations, prior to DRAKE_DECLARE... below.
+// See the .cc file for an explanation why we specialize these methods.
+template <>
+typename MultibodyPlant<symbolic::Expression>::SceneGraphStub&
+MultibodyPlant<symbolic::Expression>::member_scene_graph();
 template <>
 std::vector<geometry::PenetrationAsPointPair<double>>
 MultibodyPlant<double>::CalcPointPairPenetrations(
@@ -3457,19 +3467,7 @@ MultibodyPlant<double>::CalcPointPairPenetrations(
 }  // namespace multibody
 }  // namespace drake
 
-// Disable support for symbolic evaluation.
-// TODO(amcastro-tri): Allow symbolic evaluation once MultibodyTree supports it.
-namespace drake {
-namespace systems {
-namespace scalar_conversion {
-template <>
-struct Traits<drake::multibody::MultibodyPlant> :
-    public NonSymbolicTraits {};
-}  // namespace scalar_conversion
-}  // namespace systems
-}  // namespace drake
-
-DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class drake::multibody::MultibodyPlant)
-DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     struct drake::multibody::AddMultibodyPlantSceneGraphResult)

--- a/multibody/plant/test/multibody_plant_symbolic_test.cc
+++ b/multibody/plant/test/multibody_plant_symbolic_test.cc
@@ -1,0 +1,50 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/symbolic_test_util.h"
+#include "drake/multibody/benchmarks/pendulum/make_pendulum_plant.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/systems/framework/test_utilities/scalar_conversion.h"
+
+using drake::multibody::benchmarks::pendulum::MakePendulumPlant;
+using drake::multibody::benchmarks::pendulum::PendulumParameters;
+
+namespace drake {
+namespace multibody {
+namespace {
+
+GTEST_TEST(MultibodyPlantSymbolicTest, Pendulum) {
+  // Make the double-valued system.
+  PendulumParameters params;
+  const double m = params.m();
+  const double g = params.g();
+  const double l = params.l();
+  const double damping = params.damping();
+  auto pendulum_double = MakePendulumPlant(params);
+  ASSERT_TRUE(is_symbolic_convertible(*pendulum_double));
+
+  // Make the symbolic system.
+  auto dut = MultibodyPlant<double>::ToSymbolic(*pendulum_double);
+  auto context = dut->CreateDefaultContext();
+
+  // Set the input and state to variables.
+  using T = symbolic::Expression;
+  const symbolic::Variable tau("tau");
+  const symbolic::Variable theta("theta");
+  const symbolic::Variable thetadot("thetadot");
+  context->FixInputPort(
+      pendulum_double->get_actuation_input_port().get_index(),
+      Vector1<T>::Constant(tau));
+  dut->SetPositionsAndVelocities(context.get(), Vector2<T>(theta, thetadot));
+
+  // Check the symbolic derivatives.
+  const auto& derivatives = dut->EvalTimeDerivatives(*context);
+  ASSERT_EQ(derivatives.size(), 2);
+  EXPECT_PRED2(symbolic::test::ExprEqual, derivatives[0], thetadot);
+  EXPECT_PRED2(symbolic::test::ExprEqual, derivatives[1],
+      (tau - m * g * l * sin(theta) - damping * thetadot) / std::pow(l, 2));
+}
+
+}  // namespace
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/test/spring_mass_system_test.cc
+++ b/multibody/plant/test/spring_mass_system_test.cc
@@ -4,12 +4,14 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/test_utilities/symbolic_test_util.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/multibody/tree/linear_spring_damper.h"
 #include "drake/multibody/tree/prismatic_joint.h"
 #include "drake/multibody/tree/rigid_body.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/context.h"
+#include "drake/systems/framework/test_utilities/scalar_conversion.h"
 
 namespace drake {
 
@@ -208,6 +210,32 @@ TEST_F(SpringMassSystemTest, OverDampedCase) {
 
   EXPECT_NEAR(
       slider_->get_translation(context), x_analytic, integration_accuracy);
+}
+
+TEST_F(SpringMassSystemTest, Symbolic) {
+  // Make the double-valued system.
+  const double mass = 1.0;             // Mass of the body, [kg].
+  const double period = 1.0;           // Period of oscillation, [s].
+  const double damping_ratio = 0.0;    // Damping ratio, dimensionless.
+  MakeSpringMassSystem(mass, period, damping_ratio);
+  ASSERT_TRUE(is_symbolic_convertible(plant_));
+
+  // Make the symbolic system.
+  auto dut = MultibodyPlant<double>::ToSymbolic(plant_);
+  auto context = dut->CreateDefaultContext();
+
+  // Set the input and state to variables.
+  using T = symbolic::Expression;
+  const symbolic::Variable x("x");
+  const symbolic::Variable v("v");
+  dut->SetPositionsAndVelocities(context.get(), Vector2<T>(x, v));
+
+  // Check the symbolic derivatives.  (For now, just check that xdd only
+  // depends on x; we don't check its full expression.)
+  const auto& derivatives = dut->EvalTimeDerivatives(*context);
+  ASSERT_EQ(derivatives.size(), 2);
+  EXPECT_PRED2(symbolic::test::ExprEqual, derivatives[0], v);
+  EXPECT_EQ(derivatives[1].GetVariables(), symbolic::Variables{x});
 }
 
 }  // namespace

--- a/multibody/tree/linear_spring_damper.cc
+++ b/multibody/tree/linear_spring_damper.cc
@@ -183,7 +183,7 @@ T LinearSpringDamper<T>::SafeSoftNorm(const Vector3<T> &x) const {
       std::numeric_limits<double>::epsilon() * free_length();
   const double epsilon_length_squared = epsilon_length * epsilon_length;
   const T x2 = x.squaredNorm();
-  if (x2 < epsilon_length_squared) {
+  if (scalar_predicate<T>::is_bool && (x2 < epsilon_length_squared)) {
     throw std::runtime_error("The length of the spring became nearly zero. "
                                  "Revisit your model to avoid this situation.");
   }


### PR DESCRIPTION
The main benefit here (other than having cool symbolic forms of various computations) is to allow for `Context<Expression>` to be used to set decision variables for optimization programs that include a plant.  (Though, it doesn't support contact yet, because SceneGraph isn't symbolic.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10439)
<!-- Reviewable:end -->
