### PR TITLE
[multibody] Add world frame to frame_id_to_body_index_.

### DIFF
--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -272,6 +272,7 @@ geometry::SourceId MultibodyPlant<T>::RegisterAsSourceForSceneGraph(
   // instance. This will be nullified at Finalize().
   scene_graph_ = scene_graph;
   body_index_to_frame_id_[world_index()] = scene_graph->world_frame_id();
+  frame_id_to_body_index_[scene_graph->world_frame_id()] = world_index();
   DeclareSceneGraphPorts();
   return source_id_.value();
 }

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -614,6 +614,11 @@ TEST_F(AcrobotPlantTests, VisualGeometryRegistration) {
   // Compute the poses for each geometry in the model.
   plant_->get_geometry_poses_output_port().Calc(*context, poses_value.get());
 
+  const FrameId world_frame_id =
+      plant_->GetBodyFrameIdOrThrow(plant_->world_body().index());
+  ASSERT_TRUE(plant_->GetBodyFromFrameId(world_frame_id) != nullptr);
+  EXPECT_EQ(plant_->GetBodyFromFrameId(world_frame_id)->index(),
+            plant_->world_body().index());
   const double kTolerance = 5 * std::numeric_limits<double>::epsilon();
   for (BodyIndex body_index(1);
        body_index < plant_->num_bodies(); ++body_index) {


### PR DESCRIPTION
Prior to this commit, `frame_id_to_body_index_` and `body_index_to_frame_id_`
were out of sync, since the latter contained an entry for the world frame/body,
and the former did not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10440)
<!-- Reviewable:end -->
