### PR TITLE
Fix error in geometry removal

### DIFF
--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -652,18 +652,15 @@ class GeometryState {
   // This contains internal indices into X_WG_. If a _dynamic_ geometry G has a
   // proximity role, in addition to its internal index, it will
   // also have a proximity index. It must be the case that
-  // G.internal_index == X_WG_proximity_[G.proximity_index] if it has a
-  // proximity role.
+  // G.internal_index ==
+  //      dynamic_proximity_index_to_internal_map_[G.proximity_index]
+  // if it has a proximity role.
   // Generally, internal_index is not equal to the role index. This allows
   // just those geometries with the proximity role to be provided to
   // the proximity engine.
   // NOTE: There is no equivalent for anchored geometries because anchored
   // geometries do not need updating.
-
-  // For proximity, the mapping from ProximityIndex to InternalIndex is implicit
-  // because anchored and dynamic geometries are segregated; they draw from
-  // independent index sets.
-  std::vector<GeometryIndex> X_WG_proximity_;
+  std::vector<GeometryIndex> dynamic_proximity_index_to_internal_map_;
 
   // ---------------------------------------------------------------------
   // These values depend on time-dependent input values (e.g., current frame


### PR DESCRIPTION
The mapping from proximity index to geometry index for dynamic geometries
was not being updated and leading to crashes when collision queries were
made after geometry removal.

- Add a test that exercises the failure point.
- Add some additional tests to look at more correlated results
- Fix the bug

fixes #10436

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10441)
<!-- Reviewable:end -->
