### PR TITLE
Adding Shape introspection

### DIFF
--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -290,6 +290,15 @@ const std::string& GeometryState<T>::get_name(GeometryId geometry_id) const {
 }
 
 template <typename T>
+const Shape& GeometryState<T>::GetShape(GeometryId id) const {
+  const InternalGeometry* geometry = GetGeometry(id);
+  if (geometry != nullptr) return geometry->shape();
+
+  throw std::logic_error("No geometry available for invalid geometry id: " +
+      to_string(id));
+}
+
+template <typename T>
 const Isometry3<double>& GeometryState<T>::GetPoseInFrame(
     GeometryId geometry_id) const {
   const auto& geometry = GetValueOrThrow(geometry_id, geometries_);

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -190,6 +190,9 @@ class GeometryState {
   /** Implementation of SceneGraphInspector::GetName(GeometryId) const.  */
   const std::string& get_name(GeometryId geometry_id) const;
 
+  /** Implementation of SceneGraphInspector::GetShape().  */
+  const Shape& GetShape(GeometryId id) const;
+
   /** Implementation of SceneGraphInspector::X_FG().  */
   const Isometry3<double>& GetPoseInFrame(GeometryId geometry_id) const;
 

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -264,6 +264,14 @@ class SceneGraphInspector {
     return state_->get_name(id);
   }
 
+  /** Returns the shape specified for the geometry with the given `id`. In order
+   to extract the details of the shape, it should be passed through an
+   implementation of a ShapeReifier.  */
+  const Shape& GetShape(GeometryId id) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->GetShape(id);
+  }
+
   /** Reports the pose of the geometry G with the given `id` in its registered
    _topological parent_ P. That topological parent may be a frame F or another
    geometry. If the geometry was registered directly to F, then `X_PG = X_FG`.

--- a/geometry/test/scene_graph_inspector_test.cc
+++ b/geometry/test/scene_graph_inspector_test.cc
@@ -79,6 +79,7 @@ GTEST_TEST(SceneGraphInspector, ExerciseEverything) {
   inspector.BelongsToSource(geometry_id, source_id);
   inspector.GetFrameId(geometry_id);
   inspector.GetName(geometry_id);
+  inspector.GetShape(geometry_id);
   inspector.X_PG(geometry_id);
   inspector.X_FG(geometry_id);
   inspector.GetProximityProperties(geometry_id);


### PR DESCRIPTION
1. SceneGraphInspector and GeometryState provide interface to support querying the specified Shape for a registered geometry.
2. Simple smoke test in SceneGraphInspectorTest
3. Full test of Shape introspection on SceneGraph.

The vast majority of this change is in test.

fixes #9128

```
Category            added  modified  removed  
----------------------------------------------
code                179    0         0        
comments            24     0         0        
blank               20     0         0        
----------------------------------------------
TOTAL               223    0         0  
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10446)
<!-- Reviewable:end -->
