### PR TITLE
py mp: Fix overload order for `AddContraint(func, ...)`.

### DIFF
--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -306,9 +306,9 @@ PYBIND11_MODULE(mathematicalprogram, m) {
                     vars.size(), func, lb, ub, description),
                 vars);
           },
-          py::arg("func"), py::arg("vars"), py::arg("lb"), py::arg("ub"),
+          py::arg("func"), py::arg("lb"), py::arg("ub"), py::arg("vars"),
           py::arg("description") = "",
-          doc.MathematicalProgram.AddConstraint.doc_1args_binding)
+          "Adds a constraint using a Python function.")
       .def("AddConstraint",
           static_cast<Binding<Constraint> (MathematicalProgram::*)(
               const Expression&, double, double)>(

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -366,8 +366,8 @@ class TestMathematicalProgram(unittest.TestCase):
         def constraint(x):
             return x
 
-        prog.AddCost(cost, x)
-        prog.AddConstraint(constraint, [0.], [2.], x)
+        prog.AddCost(cost, vars=x)
+        prog.AddConstraint(constraint, lb=[0.], ub=[2.], vars=x)
         prog.Solve()
         self.assertAlmostEqual(prog.GetSolution(x)[0], 1.)
 


### PR DESCRIPTION
At present, `vars` and `lb` are incorrectly named for `AddConstraint(func, ...)`.

@manuelli Had run into this, where the overload for `(func, lb, ub, vars)` mis-reported its order:
```
>>> prog.AddConstraint(constraint, x, [1.0], [2.0])
TypeError: AddConstraint(): incompatible function arguments. The following argument types are supported:
    1. (self: pydrake.solvers.mathematicalprogram.MathematicalProgram, func: function, vars: numpy.ndarray[float64[m, 1]], lb: numpy.ndarray[float64[m, 1]], ub: numpy.ndarray[object[m, 1]], description: unicode = u'') -> drake::solvers::Binding<drake::solvers::Constraint>
...

Invoked with: <pydrake.solvers.mathematicalprogram.MathematicalProgram object at 0x7fe726ee9230>, <function constraint at 0x7fe726eaaaa0>, array([Variable('x(0)', Continuous)], dtype=object), [1.0], [2.0]
```

The mismatch can be seen in `vars: numpy.ndarray[float64[m, 1]]` <-> `ub: numpy.ndarray[object[m, 1]]`.
FTR, I'll make sure we test the args when calling, as that would've caught this.

\cc @RussTedrake

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10450)
<!-- Reviewable:end -->
