### PR TITLE
call_python: Add example of using Jupyter as a client

### DIFF
--- a/common/proto/call_python.h
+++ b/common/proto/call_python.h
@@ -12,8 +12,8 @@
 /// Provides functionality similar to `call_matlab` (i.e., one-directional RPC),
 /// leveraging an API similar to `pybind11`.
 ///
-/// @see call_python_test.cc for C++ examples.
-// TODO(eric.cousineau): Add (untested) example usage in IPython notebook.
+/// For command-line examples, see the documentation in `call_python_client.py`.
+/// For C++ examples, see `call_python_test.cc`.
 
 namespace drake {
 namespace common {

--- a/common/proto/call_python_client_notebook.ipynb
+++ b/common/proto/call_python_client_notebook.ipynb
@@ -1,0 +1,77 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# N.B. Explicitly initialize backend. Otherwise, plots may not show up the\n",
+    "# first time.\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example Python client.\n",
+    "from drake.common.proto.call_python_client import CallPythonClient"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "# Using `locals()` permits the C++ client to use functions defined here\n",
+    "# and overwrite variables.\n",
+    "client = CallPythonClient(scope_locals=locals())\n",
+    "client.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Print some values.\n",
+    "print(b1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Was reviving some old C++ code that used to just show stuff in Drake Visualizer. Decided that the data (trajectories) were more useful in Python, so I set that up.

[Notebook on GitHub](https://github.com/RobotLocomotion/drake/blob/92c178158d90545bbaecf0205f8b8ff4ccbd8d01/common/proto/call_python_client_notebook.ipynb)
A snapshot of what it looks like with these example steps:
> ![image](https://user-images.githubusercontent.com/26719449/51434930-67671300-1c3a-11e9-8842-cba2b0528900.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10457)
<!-- Reviewable:end -->
