### PR TITLE
Remove DoPublish() overloads from Drake

### DIFF
--- a/attic/multibody/rigid_body_plant/drake_visualizer.h
+++ b/attic/multibody/rigid_body_plant/drake_visualizer.h
@@ -117,14 +117,20 @@ class DrakeVisualizer : public LeafSystem<double> {
   void PublishLoadRobot() const;
 
  private:
-  // TODO(siyuan): Split DoPublish into individual callbacks for different
-  // events. Since the desired behaviors for different triggers are exclusive.
+  EventStatus PublishInitialMessage(
+      const systems::Context<double>&) const {
+    PublishLoadRobot();
+    return EventStatus::Succeeded();
+  }
 
-  // If @p events has only 1 kInitialization trigger typed event, calls
-  // PublishLoadRobot. Otherwise it publishes a draw message.
-  void DoPublish(const systems::Context<double>& context,
-                 const std::vector<const PublishEvent<double>*>& events)
-                 const override;
+  EventStatus PerStepPublishDrawMessage(
+      const systems::Context<double>& context) const {
+    if (!publish_per_step_) return EventStatus::DidNothing();
+    return PublishDrawMessage(context);
+  }
+
+  EventStatus PublishDrawMessage(
+      const systems::Context<double>& context) const;
 
   // A pointer to the LCM subsystem. It is through this object that LCM messages
   // are published.
@@ -143,6 +149,9 @@ class DrakeVisualizer : public LeafSystem<double> {
   // The RigidBodyTree with which the poses of each RigidBody can be
   // determined given the state vector of the RigidBodyTree.
   const RigidBodyTree<double>& tree_;
+
+  // Visualize every step by default; disabled if a period is specified.
+  bool publish_per_step_{true};
 };
 
 }  // namespace systems

--- a/attic/multibody/rigid_body_plant/frame_visualizer.h
+++ b/attic/multibody/rigid_body_plant/frame_visualizer.h
@@ -42,7 +42,9 @@ class FrameVisualizer : public LeafSystem<double> {
    * parameter `period`.
    */
   void set_publish_period(double period) {
-    this->DeclarePeriodicPublish(period);
+    this->DeclarePeriodicPublishEvent(period, 0.,
+        &FrameVisualizer::PublishFramePose);
+    publish_per_step_ = false;  // Disable default per-step publish.
   }
 
   /**
@@ -53,9 +55,14 @@ class FrameVisualizer : public LeafSystem<double> {
   }
 
  private:
-  void DoPublish(
-      const systems::Context<double>& context,
-      const std::vector<const PublishEvent<double>*>&) const override;
+  EventStatus PerStepPublishFramePose(
+      const systems::Context<double>& context) const {
+    if (!publish_per_step_) return EventStatus::DidNothing();
+    return PublishFramePose(context);
+  }
+
+  EventStatus PublishFramePose(
+      const systems::Context<double>& context) const;
 
   const RigidBodyTree<double>& tree_;
   drake::lcm::DrakeLcmInterface* const lcm_;
@@ -63,6 +70,9 @@ class FrameVisualizer : public LeafSystem<double> {
 
   drake::lcmt_viewer_draw default_msg_{};
   std::string lcm_channel_{"DRAKE_DRAW_FRAMES"};
+
+  // Visualize every step by default; disabled if a period is specified.
+  bool publish_per_step_{true};
 };
 
 }  // namespace systems

--- a/attic/systems/sensors/test/accelerometer_test/accelerometer_test_logger.cc
+++ b/attic/systems/sensors/test/accelerometer_test/accelerometer_test_logger.cc
@@ -21,10 +21,12 @@ AccelerometerTestLogger::AccelerometerTestLogger(int plant_state_size) {
       this->DeclareInputPort(kVectorValued, plant_state_size).get_index();
   acceleration_port_index_ =
       this->DeclareInputPort(kVectorValued, 3).get_index();
+
+  DeclarePerStepPublishEvent(&AccelerometerTestLogger::WriteToLog);
 }
 
-void AccelerometerTestLogger::DoPublish(const Context<double>& context,
-        const std::vector<const systems::PublishEvent<double>*>&) const {
+EventStatus AccelerometerTestLogger::WriteToLog(
+    const Context<double>& context) const {
   if (log_to_console_) {
     std::stringstream buffer;
     buffer <<
@@ -35,7 +37,9 @@ void AccelerometerTestLogger::DoPublish(const Context<double>& context,
             << get_plant_state_derivative(context).transpose() << "\n"
         "  - acceleration = " << get_acceleration(context).transpose();
     drake::log()->info(buffer.str());
+    return EventStatus::Succeeded();
   }
+  return EventStatus::DidNothing();
 }
 
 const InputPort<double>&

--- a/attic/systems/sensors/test/accelerometer_test/accelerometer_test_logger.h
+++ b/attic/systems/sensors/test/accelerometer_test/accelerometer_test_logger.h
@@ -36,8 +36,7 @@ class AccelerometerTestLogger : public LeafSystem<double> {
 
  private:
   // Logging is done in this method.
-  void DoPublish(const Context<double>& context,
-       const std::vector<const systems::PublishEvent<double>*>&) const override;
+  EventStatus WriteToLog(const Context<double>& context) const;
 
   bool log_to_console_{false};
   int plant_state_derivative_port_index_{};

--- a/systems/analysis/test_utilities/logistic_system.h
+++ b/systems/analysis/test_utilities/logistic_system.h
@@ -21,13 +21,12 @@ class LogisticSystem : public LeafSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LogisticSystem)
 
-  LogisticSystem(double k, double alpha, double nu) : k_(k), alpha_(alpha),
-      nu_(nu) {
+  LogisticSystem(double k, double alpha, double nu)
+      : k_(k), alpha_(alpha), nu_(nu) {
     this->DeclareContinuousState(1);
-    witness_ = this->DeclareWitnessFunction("Logistic witness",
-        WitnessFunctionDirection::kCrossesZero,
-        &LogisticSystem::GetStateValue,
-        PublishEvent<T>());
+    witness_ = this->DeclareWitnessFunction(
+        "Logistic witness", WitnessFunctionDirection::kCrossesZero,
+        &LogisticSystem::GetStateValue, &LogisticSystem::InvokePublishCallback);
   }
 
   void set_publish_callback(
@@ -56,10 +55,9 @@ class LogisticSystem : public LeafSystem<T> {
     w->push_back(witness_.get());
   }
 
-  void DoPublish(
-      const drake::systems::Context<double>& context,
-      const std::vector<const systems::PublishEvent<double>*>&) const override {
-    if (publish_callback_ != nullptr) publish_callback_(context);
+  void InvokePublishCallback(const Context<T>& context,
+                             const PublishEvent<T>&) const {
+    if (this->publish_callback_ != nullptr) this->publish_callback_(context);
   }
 
  private:

--- a/systems/analysis/test_utilities/my_spring_mass_system.h
+++ b/systems/analysis/test_utilities/my_spring_mass_system.h
@@ -16,11 +16,17 @@ class MySpringMassSystem : public SpringMassSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MySpringMassSystem)
 
-  // Pass through to SpringMassSystem, except add update rate
+  // Pass through to SpringMassSystem, except add events and handlers.
   MySpringMassSystem(double stiffness, double mass, double update_rate)
       : SpringMassSystem<T>(stiffness, mass, false /*no input force*/) {
+
+    // This forced-publish event is necessary for any simulator_test case that
+    // needs to verify that the publish_every_time_step feature works.
+    this->DeclareForcedPublishEvent(&MySpringMassSystem::CountPublishes);
+
     if (update_rate > 0.0) {
-      this->DeclarePeriodicDiscreteUpdate(1.0 / update_rate);
+      this->DeclarePeriodicDiscreteUpdateEvent(1.0 / update_rate, 0.0,
+          &MySpringMassSystem::CountDiscreteUpdates);
     }
   }
 
@@ -29,20 +35,17 @@ class MySpringMassSystem : public SpringMassSystem<T> {
   int get_update_count() const { return update_count_; }
 
  private:
-  // Publish t q u to standard output.
-  void DoPublish(const Context<T>&,
-                 const std::vector<const systems::PublishEvent<T>*>&)
-      const override {
+  EventStatus CountPublishes(const Context<T>&) const {
     ++publish_count_;
+    return EventStatus::Succeeded();
   }
 
   // The discrete equation update here is for the special case of zero
   // discrete variables- in other words, this is just a counter.
-  void DoCalcDiscreteVariableUpdates(
-      const Context<T>&,
-      const std::vector<const systems::DiscreteUpdateEvent<T>*>&,
-      DiscreteValues<T>*) const override {
+  EventStatus CountDiscreteUpdates(const Context<T>&,
+                                   DiscreteValues<T>*) const {
     ++update_count_;
+    return EventStatus::Succeeded();
   }
 
   mutable int publish_count_{0};

--- a/systems/analysis/test_utilities/stateless_system.h
+++ b/systems/analysis/test_utilities/stateless_system.h
@@ -23,7 +23,7 @@ class StatelessSystem final : public LeafSystem<T> {
         offset_(offset) {
     witness_ = this->DeclareWitnessFunction(
         "clock witness", dir_type, &StatelessSystem::CalcClockWitness,
-            PublishEvent<T>());
+        &StatelessSystem::InvokePublishCallback);
   }
 
   /// Scalar-converting copy constructor. See @ref system_scalar_conversion.
@@ -50,19 +50,18 @@ class StatelessSystem final : public LeafSystem<T> {
     w->push_back(witness_.get());
   }
 
-  void DoPublish(
-      const Context<T>& context,
-      const std::vector<const PublishEvent<T>*>&) const override {
-    if (publish_callback_ != nullptr) publish_callback_(context);
-  }
-
  private:
   // Allow different specializations to access each other's private data.
   template <typename> friend class StatelessSystem;
 
-  // The witness function is the time value itself plus the offset value.
+  // The witness function is the time value itself less the offset value.
   T CalcClockWitness(const Context<T>& context) const {
     return context.get_time() - offset_;
+  }
+
+  void InvokePublishCallback(const Context<T>& context,
+                             const PublishEvent<T>&) const {
+    if (this->publish_callback_ != nullptr) this->publish_callback_(context);
   }
 
   const double offset_;

--- a/systems/lcm/test/lcm_log_playback_test.cc
+++ b/systems/lcm/test/lcm_log_playback_test.cc
@@ -32,7 +32,8 @@ class DummySys : public LeafSystem<double> {
 
   DummySys() {
     DeclareAbstractInputPort("lcmt_drake_signal", Value<lcmt_drake_signal>());
-    DeclarePeriodicPublish(1.0 / publish_freq_, 0.0 /* no time offset */);
+    DeclarePeriodicPublishEvent(1.0 / publish_freq_, 0.0 /* no time offset */,
+        &DummySys::SaveMessage);
   }
 
   const std::vector<lcmt_drake_signal>& get_received_msgs() const {
@@ -48,10 +49,7 @@ class DummySys : public LeafSystem<double> {
   }
 
  private:
-  void DoPublish(
-      const Context<double>& context,
-      const std::vector<const systems::PublishEvent<double>*>&)
-  const override {
+  EventStatus SaveMessage(const Context<double>& context) const {
     const lcmt_drake_signal* msg =
         EvalInputValue<lcmt_drake_signal>(context, 0);
 
@@ -77,6 +75,7 @@ class DummySys : public LeafSystem<double> {
       // "tick" behind.
       received_time_.push_back(context.get_time() - 1.0 / publish_freq_);
     }
+    return EventStatus::Succeeded();
   }
 
   const double publish_freq_{100.0};  // In Hz.


### PR DESCRIPTION
Stop overloading the DoPublish() dispatcher in Drake in preparation for deprecating it. This PR removes all the C++ `DoPublish()` mentions I could find except those in the System framework and analysis classes and tests.

One concern I have is that there could be examples that are broken by these changes but for which there are no unit tests that can tell. I spot checked some (acrobot and quadrotor) and they seem fine. The kuka_simulation example has trouble showing frames, but that seemed to be true before the attic/FrameVisualizer change here and may be a long standing problem, see #7314. Reviewers should check some other examples if possible.

Relates #10445

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10458)
<!-- Reviewable:end -->
