### PR TITLE
Correct GeometryState converting copy constructor

### DIFF
--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -454,6 +454,9 @@ class GeometryState {
 
   // Conversion constructor. In the initial implementation, this is only
   // intended to be used to clone an AutoDiffXd instance from a double instance.
+  // It is _vitally_ important that all members are _explicitly_ accounted for
+  // (either in the initialization list or in the body). Failure to do so will
+  // lead to errors in the converted GeometryState instance.
   template <typename U>
   GeometryState(const GeometryState<U>& source)
       : self_source_(source.self_source_),
@@ -465,6 +468,8 @@ class GeometryState {
         geometries_(source.geometries_),
         geometry_index_to_id_map_(source.geometry_index_to_id_map_),
         frame_index_to_id_map_(source.frame_index_to_id_map_),
+        dynamic_proximity_index_to_internal_map_(
+            source.dynamic_proximity_index_to_internal_map_),
         geometry_engine_(std::move(source.geometry_engine_->ToAutoDiffXd())) {
     // NOTE: Can't assign Isometry3<double> to Isometry3<AutoDiff>. But we _can_
     // assign Matrix<double> to Matrix<AutoDiff>, so that's what we're doing.
@@ -594,11 +599,14 @@ class GeometryState {
   void AssignRoleInternal(SourceId source_id, GeometryId geometry_id,
                           PropertyType properties, Role role);
 
+  // NOTE: If adding a member it is important that it be _explicitly_ copied
+  // in the converting copy constructor and likewise tested in the unit test
+  // for that constructor.
+
   // The GeometryState gets its own source so it can own entities (such as the
   // world frame).
   SourceId self_source_;
 
-  // ---------------------------------------------------------------------
   // Maps from registered source ids to the entities registered to those
   // sources (e.g., frames and geometries). This lives in the state to support
   // runtime topology changes. This data should only change at _discrete_

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -35,6 +35,10 @@ class GeometryStateTester {
     return internal::InternalFrame::world_frame_id();
   }
 
+  SourceId get_self_source_id() const {
+    return state_->self_source_;
+  }
+
   const std::unordered_map<SourceId, std::string>& get_source_name_map() const {
     return state_->source_names_;
   }
@@ -68,8 +72,12 @@ class GeometryStateTester {
     return state_->geometry_index_to_id_map_;
   }
 
-  const vector<FrameId>& get_pose_index_frame_id_map() const {
+  const vector<FrameId>& get_frame_index_id_map() const {
     return state_->frame_index_to_id_map_;
+  }
+
+  const vector<GeometryIndex>& get_dynamic_pose_index_id_map() const {
+    return state_->dynamic_proximity_index_to_internal_map_;
   }
 
   const vector<Isometry3<T>>& get_geometry_world_poses() const {
@@ -416,7 +424,7 @@ void ExpectSuccessfulTransmogrification(
     const GeometryStateTester<double>& d_tester) {
 
   // 1. Test all of the identifier -> trivially testable value maps
-  EXPECT_EQ(ad_tester.get_source_name_map(), d_tester.get_source_name_map());
+  EXPECT_EQ(ad_tester.get_self_source_id(), d_tester.get_self_source_id());
   EXPECT_EQ(ad_tester.get_source_name_map(), d_tester.get_source_name_map());
   EXPECT_EQ(ad_tester.get_source_frame_id_map(),
             d_tester.get_source_frame_id_map());
@@ -430,10 +438,10 @@ void ExpectSuccessfulTransmogrification(
   // 2. Test the vectors of ids
   EXPECT_EQ(ad_tester.get_geometry_index_id_map(),
             d_tester.get_geometry_index_id_map());
-  EXPECT_EQ(ad_tester.get_geometry_index_id_map(),
-            d_tester.get_geometry_index_id_map());
-  EXPECT_EQ(ad_tester.get_pose_index_frame_id_map(),
-            d_tester.get_pose_index_frame_id_map());
+  EXPECT_EQ(ad_tester.get_frame_index_id_map(),
+            d_tester.get_frame_index_id_map());
+  EXPECT_EQ(ad_tester.get_dynamic_pose_index_id_map(),
+            d_tester.get_dynamic_pose_index_id_map());
 
   // 3. Compare Isometry3<double> with Isometry3<double>
   for (GeometryId id : ad_tester.get_geometry_index_id_map()) {


### PR DESCRIPTION
1. The map from proximity index to internal index wasn't being copied.
2. Also updated the tests to capture this issue and shore up some other missing tests.

resolves #10453

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10465)
<!-- Reviewable:end -->
