### PR TITLE
Fixes error in geometry removal (with proximity role)

### DIFF
--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -852,9 +852,14 @@ void GeometryState<T>::RemoveGeometryUnchecked(GeometryId geometry_id,
         swap(X_WG_[proximity_index], X_WG_[moved_proximity_index]);
         swap(dynamic_proximity_index_to_internal_map_[proximity_index],
              dynamic_proximity_index_to_internal_map_[moved_proximity_index]);
-        dynamic_proximity_index_to_internal_map_.pop_back();
       }
       geometries_[moved_id].set_proximity_index(proximity_index);
+    }
+    if (geometry.is_dynamic()) {
+      // We've removed a dynamic geometry -- it was either the last or it has
+      // been moved to be last -- so, we pop the map to reflect the removed
+      // state.
+      dynamic_proximity_index_to_internal_map_.pop_back();
     }
   }
 

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -1018,6 +1018,14 @@ TEST_F(GeometryStateTest, RemoveGeometry) {
   // Only dynamic geometries have this index; highest index is total number
   EXPECT_EQ(added_geo.proximity_index(),
             ProximityIndex(single_tree_dynamic_geometry_count() - 1));
+
+  // Now remove the *final* geometry; even though it doesn't require re-ordering
+  // proximity indices, it should still keep things valid -- in other words,
+  // the mapping from proximity index to internal index for *dynamic* geometries
+  // should shrink appropriately.
+  geometry_state_.RemoveGeometry(s_id, added_id);
+  // Confirm that, post removal, updating poses still works.
+  EXPECT_NO_THROW(gs_tester_.FinalizePoseUpdate());
 }
 
 // Tests the RemoveGeometry functionality in which the geometry removed has


### PR DESCRIPTION
GeometryState maintains a map between ProximityIndex and GeometryIndex for dynamic geometries. When a dynamic geometry with a proximity role is removed, that map should decrease in size.

Prior to this commit, that size reduction would only occur in the case of a re-ordering. This repairs it to occur whether or not a reordering occurs.