### PR TITLE
py systems lcm: Ensure module is not reimported

### DIFF
--- a/bindings/pydrake/systems/lcm_py.cc
+++ b/bindings/pydrake/systems/lcm_py.cc
@@ -68,6 +68,7 @@ class PySerializerInterface : public py::wrapper<SerializerInterface> {
 }  // namespace
 
 PYBIND11_MODULE(lcm, m) {
+  PYDRAKE_PREVENT_PYTHON3_MODULE_REIMPORT(m);
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
   using namespace drake::systems;
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.


### PR DESCRIPTION
Hotfix for #10455 for Python3.
Can supersede #10470.

Relates pybind/pybind11#1559

\cc @BetsyMcPhail 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10472)
<!-- Reviewable:end -->
