### PR TITLE
Check system processor in CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,12 @@ if(CYGWIN OR NOT UNIX)
   message(FATAL_ERROR "Cygwin and non-Unix platforms are NOT supported")
 endif()
 
+if(NOT CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64)
+  message(FATAL_ERROR
+    "System processor ${CMAKE_SYSTEM_PROCESSOR} is NOT supported"
+  )
+endif()
+
 set(UNIX_DISTRIBUTION_ID)
 set(UNIX_DISTRIBUTION_CODENAME)
 


### PR DESCRIPTION
We know the CMake build will fail as it always requires a precompiled VTK and Drake Visualizer and we do not offer an easy way to opt out of those. We probably should not error out in Bazel unless a precompiled binary is required, and since that #10435 is backlog, adding that functionality will need to wait (FTR CMake just checks `uname -m` on our supported platforms).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10478)
<!-- Reviewable:end -->
