### PR TITLE
pydrake lcm: Add bindings for LcmDrivenLoop

### DIFF
--- a/bindings/pydrake/lcm_py.cc
+++ b/bindings/pydrake/lcm_py.cc
@@ -46,6 +46,8 @@ PYBIND11_MODULE(lcm, m) {
     using Class = DrakeLcm;
     py::class_<Class, DrakeLcmInterface>(m, "DrakeLcm", doc.DrakeLcm.doc)
         .def(py::init<>(), doc.DrakeLcm.ctor.doc_0args)
+        .def(py::init<std::string>(), py::arg("lcm_url"),
+            doc.DrakeLcm.ctor.doc_1args)
         .def("StartReceiveThread", &Class::StartReceiveThread,
             doc.DrakeLcm.StartReceiveThread.doc)
         .def("StopReceiveThread", &Class::StopReceiveThread,

--- a/bindings/pydrake/systems/_lcm_extra.py
+++ b/bindings/pydrake/systems/_lcm_extra.py
@@ -26,6 +26,21 @@ class PySerializer(SerializerInterface):
         return message.encode()
 
 
+class PyUtimeMessageToSeconds(LcmMessageToTimeInterface):
+    """Provides a Python implementation of `UtimeMessageToSeconds` for use
+    with `LcmDrivenLoop`.
+    """
+    def __init__(self, lcm_type):
+        LcmMessageToTimeInterface.__init__(self)
+        self._lcm_type = lcm_type
+
+    def GetTimeInSeconds(self, abstract_value):
+        assert isinstance(abstract_value, AbstractValue)
+        message = abstract_value.get_value()
+        assert isinstance(message, self._lcm_type)
+        return message.utime / 1.0e6
+
+
 @staticmethod
 def _make_lcm_subscriber(channel, lcm_type, lcm, use_cpp_serializer=False):
     """Convenience to create an LCM subscriber system with a concrete type.

--- a/bindings/pydrake/systems/lcm_py.cc
+++ b/bindings/pydrake/systems/lcm_py.cc
@@ -8,8 +8,10 @@
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/systems/lcm_py_bind_cpp_serializers.h"
 #include "drake/bindings/pydrake/systems/systems_pybind.h"
+#include "drake/lcm/drake_lcm.h"
 #include "drake/lcm/drake_lcm_interface.h"
 #include "drake/systems/lcm/connect_lcm_scope.h"
+#include "drake/systems/lcm/lcm_driven_loop.h"
 #include "drake/systems/lcm/lcm_publisher_system.h"
 #include "drake/systems/lcm/lcm_subscriber_system.h"
 #include "drake/systems/lcm/serializer.h"
@@ -17,9 +19,11 @@
 namespace drake {
 namespace pydrake {
 
+using lcm::DrakeLcm;
 using lcm::DrakeLcmInterface;
 using pysystems::pylcm::BindCppSerializers;
 using systems::AbstractValue;
+using systems::lcm::LcmMessageToTimeInterface;
 using systems::lcm::SerializerInterface;
 
 namespace {
@@ -62,6 +66,19 @@ class PySerializerInterface : public py::wrapper<SerializerInterface> {
     std::string str = wrapped();
     message_bytes->resize(str.size());
     std::copy(str.data(), str.data() + str.size(), message_bytes->data());
+  }
+};
+
+class PyLcmMessageToTimeInterface
+    : public py::wrapper<LcmMessageToTimeInterface> {
+ public:
+  using Base = py::wrapper<LcmMessageToTimeInterface>;
+
+  PyLcmMessageToTimeInterface() : Base() {}
+
+  double GetTimeInSeconds(const AbstractValue& abstract_value) const override {
+    PYBIND11_OVERLOAD_PURE(
+        double, LcmMessageToTimeInterface, GetTimeInSeconds, &abstract_value);
   }
 };
 
@@ -113,6 +130,16 @@ PYBIND11_MODULE(lcm, m) {
   }
 
   {
+    using Class = LcmMessageToTimeInterface;
+    py::class_<Class, PyLcmMessageToTimeInterface>(
+        m, "LcmMessageToTimeInterface")
+        .def(py::init([]() {
+          return std::make_unique<PyLcmMessageToTimeInterface>();
+        }),
+            doc.LcmMessageToTimeInterface.doc);
+  }
+
+  {
     using Class = LcmPublisherSystem;
     constexpr auto& cls_doc = doc.LcmPublisherSystem;
     py::class_<Class, LeafSystem<double>> cls(m, "LcmPublisherSystem");
@@ -145,7 +172,40 @@ PYBIND11_MODULE(lcm, m) {
             py::keep_alive<1, 3>(),
             cls_doc.ctor.doc_3args_channel_serializer_lcm)
         .def("CopyLatestMessageInto", &Class::CopyLatestMessageInto,
-            py::arg("state"), cls_doc.CopyLatestMessageInto.doc);
+            py::arg("state"), cls_doc.CopyLatestMessageInto.doc)
+        .def("WaitForMessage", &Class::WaitForMessage,
+            py::arg("old_message_count"), py::arg("message") = nullptr,
+            cls_doc.WaitForMessage.doc);
+  }
+
+  {
+    using Class = LcmDrivenLoop;
+    py::class_<Class>(m, "LcmDrivenLoop")
+        .def(py::init<const System<double>&, const LcmSubscriberSystem&,
+                 std::unique_ptr<Context<double>>, DrakeLcm*,
+                 std::unique_ptr<LcmMessageToTimeInterface>>(),
+            py::arg("system"), py::arg("driving_subscriber"),
+            py::arg("context"), py::arg("lcm"), py::arg("time_converter"),
+            // Keep alive, ownership: `Context` keeps `self` alive.
+            py::keep_alive<4, 1>(),
+            // Keep alive, reference: `self` keeps `DrakeLcm` alive.
+            py::keep_alive<1, 5>(),
+            // Keep alive, ownership: `time_converter` keeps `self` alive.
+            py::keep_alive<6, 1>(), doc.LcmDrivenLoop.ctor.doc)
+        .def("WaitForMessage", &Class::WaitForMessage, py_reference_internal,
+            doc.LcmDrivenLoop.WaitForMessage.doc)
+        .def("RunToSecondsAssumingInitialized",
+            &Class::RunToSecondsAssumingInitialized,
+            py::arg("stop_time") = std::numeric_limits<double>::infinity(),
+            doc.LcmDrivenLoop.RunToSecondsAssumingInitialized.doc)
+        .def("set_publish_on_every_received_message",
+            &Class::set_publish_on_every_received_message,
+            doc.LcmDrivenLoop.set_publish_on_every_received_message.doc)
+        .def("get_mutable_context", &Class::get_mutable_context,
+            py_reference_internal, doc.LcmDrivenLoop.get_mutable_context.doc)
+        .def("get_message_to_time_converter",
+            &Class::get_message_to_time_converter, py_reference_internal,
+            doc.LcmDrivenLoop.get_message_to_time_converter.doc);
   }
 
   m.def("ConnectLcmScope", &ConnectLcmScope, py::arg("src"), py::arg("channel"),

--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -162,6 +162,11 @@ PYBIND11_MODULE(primitives, m) {
         m, "SignalLogger", GetPyParam<T>(), doc.SignalLogger.doc)
         .def(py::init<int, int>(), py::arg("input_size"),
             py::arg("batch_allocation_size") = 1000, doc.SignalLogger.ctor.doc)
+        .def("set_publish_period", &SignalLogger<T>::set_publish_period,
+            py::arg("period"), doc.SignalLogger.set_publish_period.doc)
+        .def("set_forced_publish_only",
+            &SignalLogger<T>::set_forced_publish_only,
+            doc.SignalLogger.set_forced_publish_only.doc)
         .def("sample_times", &SignalLogger<T>::sample_times,
             doc.SignalLogger.sample_times.doc)
         .def("data", &SignalLogger<T>::data, doc.SignalLogger.data.doc)

--- a/bindings/pydrake/systems/test/lcm_test.py
+++ b/bindings/pydrake/systems/test/lcm_test.py
@@ -1,16 +1,19 @@
 import pydrake.systems.lcm as mut
 
 import collections
+from multiprocessing import Process
+import time
 import unittest
 
 import numpy as np
 from six import text_type as unicode
 
-from robotlocomotion import quaternion_t
+from robotlocomotion import header_t, quaternion_t
 
-from pydrake.lcm import DrakeMockLcm
-from pydrake.systems.framework import AbstractValue, DiagramBuilder
-from pydrake.systems.primitives import ConstantVectorSource
+from pydrake.lcm import DrakeLcm, DrakeMockLcm
+from pydrake.systems.framework import (
+    AbstractValue, BasicVector, DiagramBuilder, LeafSystem)
+from pydrake.systems.primitives import ConstantVectorSource, LogOutput
 
 
 # TODO(eric.cousieau): Move this to more generic code when another piece of
@@ -104,6 +107,22 @@ class TestSystemsLcm(unittest.TestCase):
         actual_message = self._cpp_value_to_py_message(self._calc_output(dut))
         self.assert_lcm_equal(actual_message, model_message)
 
+    def test_subscriber_wait_for_message(self):
+        """Ensures that `WaitForMessage` threading works in a Python workflow
+        that is not threaded."""
+        # N.B. This will fail with `threading`. See below for using
+        # `multithreading`.
+        lcm = DrakeLcm("memq://")
+        lcm.StartReceiveThread()
+        sub = mut.LcmSubscriberSystem.Make("TEST_LOOP", header_t, lcm)
+        value = AbstractValue.Make(header_t())
+        for i in range(3):
+            message = header_t()
+            message.utime = i
+            lcm.Publish("TEST_LOOP", message.encode())
+            sub.WaitForMessage(i, value)
+            self.assertEqual(value.get_value().utime, i)
+
     def _fix_and_publish(self, dut, value):
         context = dut.CreateDefaultContext()
         context.FixInputPort(0, value)
@@ -139,3 +158,76 @@ class TestSystemsLcm(unittest.TestCase):
                             channel="TEST_CHANNEL",
                             builder=builder,
                             lcm=DrakeMockLcm())
+
+    def test_utime_to_seconds(self):
+        msg = header_t()
+        msg.utime = int(1e6)
+        dut = mut.PyUtimeMessageToSeconds(header_t)
+        t_sec = dut.GetTimeInSeconds(AbstractValue.Make(msg))
+        self.assertEqual(t_sec, 1)
+
+    def test_lcm_driven_loop(self):
+        """Duplicates the test logic in `lcm_driven_loop_test.cc`."""
+        lcm_url = "udpm://239.255.76.67:7669"
+        t_start = 3.
+        t_end = 10.
+
+        def publish_loop():
+            # Publishes a set of messages for the driven loop. This should be
+            # run from a separate process.
+            # N.B. Because of this, care should be taken not to share C++
+            # objects between process boundaries.
+            t = t_start
+            while t <= t_end:
+                message = header_t()
+                message.utime = int(1e6 * t)
+                lcm.Publish("TEST_LOOP", message.encode())
+                time.sleep(0.1)
+                t += 1
+
+        class DummySys(LeafSystem):
+            # Converts message to time in seconds.
+            def __init__(self):
+                LeafSystem.__init__(self)
+                self._DeclareAbstractInputPort(
+                    "header_t", AbstractValue.Make(header_t))
+                self._DeclareVectorOutputPort(
+                    BasicVector(1), self._calc_output)
+
+            def _calc_output(self, context, output):
+                message = self.EvalAbstractInput(context, 0).get_value()
+                y = output.get_mutable_value()
+                y[:] = message.utime / 1e6
+
+        # Construct diagram for LcmDrivenLoop.
+        lcm = DrakeLcm(lcm_url)
+        utime = mut.PyUtimeMessageToSeconds(header_t)
+        sub = mut.LcmSubscriberSystem.Make("TEST_LOOP", header_t, lcm)
+        builder = DiagramBuilder()
+        builder.AddSystem(sub)
+        dummy = builder.AddSystem(DummySys())
+        builder.Connect(sub.get_output_port(0), dummy.get_input_port(0))
+        logger = LogOutput(dummy.get_output_port(0), builder)
+        logger.set_forced_publish_only()
+        diagram = builder.Build()
+        dut = mut.LcmDrivenLoop(diagram, sub, None, lcm, utime)
+        dut.set_publish_on_every_received_message(True)
+
+        # N.B. Use `multiprocessing` instead of `threading` so that we may
+        # avoid issues with GIL deadlocks.
+        publish_proc = Process(target=publish_loop)
+        publish_proc.start()
+        # Initialize to first message.
+        first_msg = dut.WaitForMessage()
+        dut.get_mutable_context().set_time(utime.GetTimeInSeconds(first_msg))
+        # Run to desired amount. (Anything more will cause interpreter to
+        # "freeze".)
+        dut.RunToSecondsAssumingInitialized(t_end)
+        publish_proc.join()
+
+        # Check expected values.
+        log_t_expected = np.array([4, 5, 6, 7, 8, 9])
+        log_t = logger.sample_times()
+        self.assertTrue(np.allclose(log_t_expected, log_t))
+        log_y = logger.data()
+        self.assertTrue(np.allclose(log_t_expected, log_y))

--- a/systems/lcm/lcm_driven_loop.h
+++ b/systems/lcm/lcm_driven_loop.h
@@ -142,6 +142,8 @@ class LcmDrivenLoop {
    * time) has already been properly initialized by the caller if necessary.
    * @param stop_time End time in seconds relative to the time stamp in the
    * driving Lcm message.
+   * @note If the latest driving time is the same as `stop_time`, then no
+   * stepping will occur.
    */
   void RunToSecondsAssumingInitialized(
       double stop_time = std::numeric_limits<double>::infinity());


### PR DESCRIPTION
I've added bindings for both a python lcmtype implementation of `UtimeMessageToSeconds` and LcmDrivenLoop but I have only added tests for the first thing.  Advice on the right way to test LcmDrivenLoop would be greatly appreciated.

Using CI to test the bindings work on the latest drake.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10479)
<!-- Reviewable:end -->
