### PR TITLE
common: Add drake_copyable support for separate definition

### DIFF
--- a/common/drake_copyable.h
+++ b/common/drake_copyable.h
@@ -64,3 +64,49 @@ class Foo {
     (void) static_cast<Classname& (Classname::*)(               \
         const Classname&)>(&Classname::operator=);              \
   }
+
+/** DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN declares (but does not define) the
+special member functions for copy-construction, copy-assignment,
+move-construction, and move-assignment.  Drake's Doxygen is customized to
+render the declarations with appropriate comments.
+
+This is useful when paired with DRAKE_DEFINE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN_T
+to work around https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57728 whereby the
+declaration and definition must be split.  Once Drake no longer supports GCC
+versions prior to 6.3, this macro could be removed.
+
+Invoke this this macro in the public section of the class declaration, e.g.:
+<pre>
+template <typename T>
+class Foo {
+ public:
+  DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN(Foo)
+
+  // ...
+};
+DRAKE_DEFINE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN_T(Foo)
+</pre>
+*/
+#define DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN(Classname)       \
+  Classname(const Classname&);                                          \
+  Classname& operator=(const Classname&);                               \
+  Classname(Classname&&);                                               \
+  Classname& operator=(Classname&&);                                    \
+  /* Fails at compile-time if default-copy doesn't work. */             \
+  static void DRAKE_COPYABLE_DEMAND_COPY_CAN_COMPILE() {                \
+    (void) static_cast<Classname& (Classname::*)(                       \
+        const Classname&)>(&Classname::operator=);                      \
+  }
+
+/** Helper for DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN.  Provides defaulted
+definitions for the four special member functions of a templated class.
+*/
+#define DRAKE_DEFINE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN_T(Classname)      \
+  template <typename T>                                                 \
+  Classname<T>::Classname(const Classname<T>&) = default;               \
+  template <typename T>                                                 \
+  Classname<T>& Classname<T>::operator=(const Classname<T>&) = default; \
+  template <typename T>                                                 \
+  Classname<T>::Classname(Classname<T>&&) = default;                    \
+  template <typename T>                                                 \
+  Classname<T>& Classname<T>::operator=(Classname<T>&&) = default;

--- a/doc/Doxyfile_CXX.in
+++ b/doc/Doxyfile_CXX.in
@@ -314,6 +314,14 @@ X& operator=(const X&) = default; \
 X(X&&) = default; \
 X& operator=(X&&) = default; \
 /** \} */"
+PREDEFINED            += DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN(X):=" \
+/** \name Implements CopyConstructible, CopyAssignable, MoveConstructible, MoveAssignable */ \
+/** \{ */ \
+X(const X&) = default; \
+X& operator=(const X&) = default; \
+X(X&&) = default; \
+X& operator=(X&&) = default; \
+/** \} */"
 # =============================================================================
 EXPAND_AS_DEFINED      =
 SKIP_FUNCTION_MACROS   = YES

--- a/systems/framework/event.h
+++ b/systems/framework/event.h
@@ -91,7 +91,7 @@ template <class T>
 class WitnessTriggeredEventData : public EventData {
  public:
   WitnessTriggeredEventData() {}
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(WitnessTriggeredEventData);
+  DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN(WitnessTriggeredEventData);
 
   /// Gets the witness function that triggered the event handler.
   const WitnessFunction<T>* triggered_witness() const {
@@ -152,6 +152,8 @@ class WitnessTriggeredEventData : public EventData {
   const ContinuousState<T>* xc0_{nullptr};
   const ContinuousState<T>* xcf_{nullptr};
 };
+
+DRAKE_DEFINE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN_T(WitnessTriggeredEventData)
 
 /**
  * Predefined types of triggers for events. Used at run time to determine why
@@ -596,11 +598,8 @@ UnrestrictedUpdateEvent<T>::UnrestrictedUpdateEvent(
 }  // namespace systems
 }  // namespace drake
 
-// TODO(sammy-tri) I would like to use
-// DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS for
-// WitnessTriggeredEventData, but DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN
-// breaks due to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57728 with
-// extern templates.
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::WitnessTriggeredEventData)
 
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::systems::Event)

--- a/systems/framework/event_collection.cc
+++ b/systems/framework/event_collection.cc
@@ -14,6 +14,9 @@ DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
 // types without the collections available.  For that reason, we create the
 // instances for both in this file.
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::WitnessTriggeredEventData)
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::systems::Event)
 
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(

--- a/systems/framework/system_output.cc
+++ b/systems/framework/system_output.cc
@@ -1,6 +1,4 @@
 #include "drake/systems/framework/system_output.h"
 
-#include "drake/common/default_scalars.h"
-
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::systems::SystemOutput)

--- a/systems/framework/system_output.h
+++ b/systems/framework/system_output.h
@@ -4,6 +4,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/basic_vector.h"
@@ -29,9 +30,9 @@ A `SystemOutput<T>` object can only be obtained using
 template <typename T>
 class SystemOutput {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SystemOutput);
+  DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN(SystemOutput);
 
-  ~SystemOutput() = default;
+  ~SystemOutput();
 
   /** Returns the number of output ports specified for this %SystemOutput
   during allocation. */
@@ -81,7 +82,7 @@ class SystemOutput {
   friend class System<T>;
   friend class SystemOutputTest;
 
-  SystemOutput() = default;
+  SystemOutput();
 
   // Add a suitable object to hold values for the next output port.
   void add_port(std::unique_ptr<AbstractValue> model_value) {
@@ -91,10 +92,15 @@ class SystemOutput {
   std::vector<copyable_unique_ptr<AbstractValue>> port_values_;
 };
 
+// Workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57728 which
+// should be moved back into the class definition once we no longer need to
+// support GCC versions prior to 6.3.
+template <typename T> SystemOutput<T>::SystemOutput() = default;
+template <typename T> SystemOutput<T>::~SystemOutput() = default;
+DRAKE_DEFINE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN_T(SystemOutput);
+
 }  // namespace systems
 }  // namespace drake
 
-// TODO(sammy-tri) I would like to use
-// DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS here, but
-// DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN breaks due to
-// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57728 with extern templates.
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::SystemOutput)


### PR DESCRIPTION
Use the new tooling in systems/framework to resolve some TODOs

---

Relates to #10439 -- in our porting so far, we've only touched `//systems/...` stuff, which doesn't have too many default-copyable classes.  When porting `//multibody/...` though, there are a _lot_ more copyable classes, so we should really sugar up a solution we can live with.  This is my proposal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10480)
<!-- Reviewable:end -->
