### PR TITLE
Add the ability to introspect the owning geometry source's name

### DIFF
--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -180,6 +180,12 @@ bool GeometryState<T>::BelongsToSource(FrameId frame_id,
 }
 
 template <typename T>
+const std::string& GeometryState<T>::GetOwningSourceName(FrameId id) const {
+  SourceId source_id = get_source_id(id);
+  return source_names_.at(source_id);
+}
+
+template <typename T>
 const std::string& GeometryState<T>::get_frame_name(FrameId frame_id) const {
   FindOrThrow(frame_id, frames_, [frame_id]() {
     return "No frame name available for invalid frame id: " +
@@ -272,6 +278,12 @@ bool GeometryState<T>::BelongsToSource(GeometryId geometry_id,
   // If this fails, the geometry_id is not valid and an exception is thrown.
   const auto& geometry = GetValueOrThrow(geometry_id, geometries_);
   return geometry.belongs_to_source(source_id);
+}
+
+template <typename T>
+const std::string& GeometryState<T>::GetOwningSourceName(GeometryId id) const {
+  SourceId source_id = get_source_id(id);
+  return source_names_.at(source_id);
 }
 
 template <typename T>
@@ -795,6 +807,16 @@ template <typename T>
 SourceId GeometryState<T>::get_source_id(FrameId frame_id) const {
   const auto& frame = GetValueOrThrow(frame_id, frames_);
   return frame.source_id();
+}
+
+template <typename T>
+SourceId GeometryState<T>::get_source_id(GeometryId id) const {
+  const InternalGeometry* geometry = GetGeometry(id);
+  if (geometry == nullptr) {
+    throw std::logic_error("Geometry id " + to_string(id) +
+                           " does not map to a registered geometry");
+  }
+  return geometry->source_id();
 }
 
 template <typename T>

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -150,6 +150,10 @@ class GeometryState {
    SceneGraphInspector::BelongsToSource(FrameId, SourceId) const.  */
   bool BelongsToSource(FrameId frame_id, SourceId source_id) const;
 
+  /** Implementation of
+   SceneGraphInspector::GetOwningSourceName(FrameId) const.  */
+  const std::string& GetOwningSourceName(FrameId id) const;
+
   /** Implementation of SceneGraphInspector::GetName(FrameId) const.  */
   const std::string& get_frame_name(FrameId frame_id) const;
 
@@ -183,6 +187,11 @@ class GeometryState {
   /** Implementation of
    SceneGraphInspector::BelongsToSource(GeometryId, SourceId) const.  */
   bool BelongsToSource(GeometryId geometry_id, SourceId source_id) const;
+
+  /** Implementation of
+   SceneGraphInspector::GetOwningSourceName(GeometryId) const.  */
+  const std::string& GetOwningSourceName(GeometryId id) const;
+
 
   /** Implementation of SceneGraphInspector::GetFrameId().  */
   FrameId GetFrameId(GeometryId geometry_id) const;
@@ -539,6 +548,10 @@ class GeometryState {
   // Gets the source id for the given frame id. Throws std::logic_error if the
   // frame belongs to no registered source.
   SourceId get_source_id(FrameId frame_id) const;
+
+  // Gets the source id for the given frame id. Throws std::logic_error if the
+  // geometry belongs to no registered source.
+  SourceId get_source_id(GeometryId frame_id) const;
 
   // The origin from where an invocation of RemoveGeometryUnchecked was called.
   // The origin changes the work that is required.

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -179,6 +179,14 @@ class SceneGraphInspector {
     return state_->BelongsToSource(frame_id, source_id);
   }
 
+  /** Reports the _name_ of the geometry source that registered the frame with
+   the given `id`.
+   @throws std::logic_error  If `id` does not map to a registered frame.  */
+  const std::string& GetOwningSourceName(FrameId id) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->GetOwningSourceName(id);
+  }
+
   /** Reports the name of the frame with the given `id`.
    @throws std::logic_error if `id` does not map to a registered frame.  */
   const std::string& GetName(FrameId id) const {
@@ -246,6 +254,14 @@ class SceneGraphInspector {
   bool BelongsToSource(GeometryId geometry_id, SourceId source_id) const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->BelongsToSource(geometry_id, source_id);
+  }
+
+  /** Reports the _name_ of the geometry source that registered the geometry
+   with the given `id`.
+   @throws std::logic_error  If `id` does not map to a registered geometry.  */
+  const std::string& GetOwningSourceName(GeometryId id) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->GetOwningSourceName(id);
   }
 
   /** Reports the id of the frame to which the given geometry with the given

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -409,6 +409,23 @@ TEST_F(GeometryStateTest, GeometryStatistics) {
   EXPECT_FALSE(geometry_state_.source_is_registered(false_id));
 }
 
+TEST_F(GeometryStateTest, GetOwningSourceName) {
+  SetUpSingleSourceTree();
+
+  EXPECT_EQ(kSourceName, geometry_state_.GetOwningSourceName(frames_[0]));
+  EXPECT_EQ(kSourceName, geometry_state_.GetOwningSourceName(geometries_[0]));
+  EXPECT_EQ(kSourceName,
+            geometry_state_.GetOwningSourceName(anchored_geometry_));
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      geometry_state_.GetOwningSourceName(FrameId::get_new_id()),
+      std::logic_error, "Referenced frame .* has not been registered.");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      geometry_state_.GetOwningSourceName(GeometryId::get_new_id()),
+      std::logic_error, "Geometry id .* does not map to a registered geometry");
+}
+
 // Compares the autodiff geometry state (embedded in its tester) against the
 // double state to confirm they have the same values/topology.
 void ExpectSuccessfulTransmogrification(

--- a/geometry/test/scene_graph_inspector_test.cc
+++ b/geometry/test/scene_graph_inspector_test.cc
@@ -63,6 +63,7 @@ GTEST_TEST(SceneGraphInspector, ExerciseEverything) {
   const FrameId frame_id = tester.mutable_state().RegisterFrame(
       source_id, GeometryFrame("frame", Isometry3<double>::Identity()));
   inspector.BelongsToSource(frame_id, source_id);
+  inspector.GetOwningSourceName(frame_id);
   inspector.GetName(frame_id);
   inspector.GetFrameGroup(frame_id);
   inspector.NumGeometriesForFrame(frame_id);
@@ -77,6 +78,7 @@ GTEST_TEST(SceneGraphInspector, ExerciseEverything) {
 
   // Geometries and their properties.
   inspector.BelongsToSource(geometry_id, source_id);
+  inspector.GetOwningSourceName(geometry_id);
   inspector.GetFrameId(geometry_id);
   inspector.GetName(geometry_id);
   inspector.X_PG(geometry_id);


### PR DESCRIPTION
1. SceneGraphInspector gets two new queries: GetOwningSourceName()  (one takes a FrameId, one a Geometryid)
2. GeometryState provides implementation.
3. Unit tests.

related to #10482

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10484)
<!-- Reviewable:end -->
