### PR TITLE
systems/lcm: Allow fixed-size messages to be smaller than promised

### DIFF
--- a/systems/lcm/lcm_subscriber_system.cc
+++ b/systems/lcm/lcm_subscriber_system.cc
@@ -76,7 +76,7 @@ LcmSubscriberSystem::LcmSubscriberSystem(
     if (translator_) {
       this->DeclareDiscreteState(*AllocateTranslatorOutputValue());
     } else {
-      this->DeclareDiscreteState(fixed_encoded_size_);
+      this->DeclareDiscreteState(1 + fixed_encoded_size_);
     }
     static_assert(kStateIndexMessageCount == 1, "");
     this->DeclareDiscreteState(1 /* size */);
@@ -127,11 +127,17 @@ void LcmSubscriberSystem::ProcessMessageAndStoreToDiscreteState(
           received_message_.data(), received_message_.size(),
           &discrete_state->get_mutable_vector(kStateIndexMessage));
     } else {
-      DRAKE_THROW_UNLESS(
-          static_cast<int>(received_message_.size()) == fixed_encoded_size_);
+      const int received_size = static_cast<int>(received_message_.size());
+      if (received_size > fixed_encoded_size_) {
+        throw std::runtime_error(fmt::format(
+            "LcmSubscriberSystem: Received {} message was {} bytes, not the "
+            "at-most-{} bytes that was promised to our constructor", channel_,
+            received_size, fixed_encoded_size_));
+      }
       auto& xd = discrete_state->get_mutable_vector(kStateIndexMessage);
+      xd[0] = received_size;
       for (int i = 0; i < fixed_encoded_size_; ++i) {
-        xd[i] = received_message_[i];
+        xd[i + 1] = received_message_[i];
       }
     }
   }
@@ -245,13 +251,13 @@ void LcmSubscriberSystem::CalcSerializerOutputValue(
   } else {
     if (GetMessageCount(context) > 0) {
       const auto& xd = context.get_discrete_state(kStateIndexMessage);
+      const int size = xd[0];
       std::vector<uint8_t> buffer;
-      buffer.resize(fixed_encoded_size_);
-      for (int i = 0; i < fixed_encoded_size_; ++i) {
-        buffer[i] = xd[i];
+      buffer.resize(size);
+      for (int i = 0; i < size; ++i) {
+        buffer[i] = xd[i + 1];
       }
-      serializer_->Deserialize(
-          buffer.data(), fixed_encoded_size_, output_value);
+      serializer_->Deserialize(buffer.data(), size, output_value);
     }
   }
 }

--- a/systems/lcm/lcm_subscriber_system.h
+++ b/systems/lcm/lcm_subscriber_system.h
@@ -65,7 +65,7 @@ class LcmSubscriberSystem : public LeafSystem<double> {
 
   /**
    * (Experimental.) Factory method like Make(channel, lcm), but the result
-   * only accepts fixed-size LCM messages.  The subscriber returned by this
+   * only accepts bounded-size LCM messages.  The subscriber returned by this
    * method may perform better than the subscriber returned by a plain Make.
    * (To avoid issue #10149, this fixed-size subscriber will store the message
    * as discrete-state bytes, instead of a deserialized abstract value.)  Once
@@ -73,7 +73,7 @@ class LcmSubscriberSystem : public LeafSystem<double> {
    * deprecation period.
    *
    * @param exemplar A sample message value; all messages received by this
-   * System must be exactly this encoded size.
+   * System must be no larger than this encoded size.
    */
   template <typename LcmMessage>
   static std::unique_ptr<LcmSubscriberSystem> MakeFixedSize(

--- a/systems/lcm/test/lcm_subscriber_system_test.cc
+++ b/systems/lcm/test/lcm_subscriber_system_test.cc
@@ -138,7 +138,7 @@ GTEST_TEST(LcmSubscriberSystemTest, ReceiveTestUsingDictionary) {
 }
 
 struct SampleData {
-  const lcmt_drake_signal value{2, {1.0, 2.0}, {"x", "y"}, 12345};
+  lcmt_drake_signal value{2, {1.0, 2.0}, {"x", "y"}, 12345};
 
   void MockPublish(
       drake::lcm::DrakeMockLcm* lcm, const std::string& channel_name) const {
@@ -198,6 +198,16 @@ GTEST_TEST(LcmSubscriberSystemTest, FixedSizeSerializerTest) {
   ASSERT_NE(abstract_value, nullptr);
   auto value = abstract_value->GetValueOrThrow<lcmt_drake_signal>();
   EXPECT_TRUE(CompareLcmtDrakeSignalMessages(value, sample_data.value));
+
+  // Smaller messages should also work.
+  SampleData smaller_data;
+  smaller_data.value = lcmt_drake_signal{1, {1.0}, {"x"}, 12345};
+  smaller_data.MockPublish(&lcm, channel_name);
+  EvalOutputHelper(*dut, context.get(), output.get());
+  const AbstractValue* small_abstract_value = output->get_data(0);
+  ASSERT_NE(small_abstract_value, nullptr);
+  auto small_value = small_abstract_value->GetValueOrThrow<lcmt_drake_signal>();
+  EXPECT_TRUE(CompareLcmtDrakeSignalMessages(small_value, smaller_data.value));
 }
 
 GTEST_TEST(LcmSubscriberSystemTest, WaitTest) {


### PR DESCRIPTION
This is required for kuka_simulation (and related), where we don't know ahead of time whether the `num_torques` will be `==num_joints` or else `0`.

---

I broke this in #10429.  The error message shows up as
```
terminate called after throwing an instance of 'drake::detail::assertion_error'
 what():  Failure at systems/lcm/lcm_subscriber_system.cc:113 in ProcessMessageAndStoreToDiscreteState(): condition 'static_cast<int>(received_message_.size()) == fixed_encoded_size_' failed.
```

The `fixed_encoded_size_` was  136 bytes but the `received_message_.size()` was only 80 bytes.  The missing 56 bytes (`7  * sizeof(double)`) were the `num_torques` being 0, not 7.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10485)
<!-- Reviewable:end -->
