### PR TITLE
multibody: Use modern default_scalars.h conventions

### DIFF
--- a/multibody/plant/contact_info.cc
+++ b/multibody/plant/contact_info.cc
@@ -1,7 +1,5 @@
 #include "drake/multibody/plant/contact_info.h"
 
-#include "drake/common/default_scalars.h"
-
 namespace drake {
 namespace multibody {
 

--- a/multibody/plant/contact_info.h
+++ b/multibody/plant/contact_info.h
@@ -4,6 +4,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
@@ -33,7 +34,7 @@ namespace multibody {
 template <typename T>
 class PointPairContactInfo {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PointPairContactInfo)
+  DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN(PointPairContactInfo)
   /**
    Constructs the contact information for a given pair of two colliding bodies.
    @param bodyA_index
@@ -111,6 +112,8 @@ class PointPairContactInfo {
   T slip_speed_;
 };
 
+DRAKE_DEFINE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN_T(PointPairContactInfo)
+
 #ifndef DRAKE_DOXYGEN_CXX
 // TODO(#9314) Remove this transitional namespace on or about 2019-03-01.
 namespace multibody_plant {
@@ -123,3 +126,6 @@ using PointPairContactInfo
 
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::PointPairContactInfo)

--- a/multibody/plant/contact_results.cc
+++ b/multibody/plant/contact_results.cc
@@ -2,8 +2,6 @@
 
 #include <utility>
 
-#include "drake/common/default_scalars.h"
-
 namespace drake {
 namespace multibody {
 

--- a/multibody/plant/contact_results.h
+++ b/multibody/plant/contact_results.h
@@ -2,6 +2,7 @@
 
 #include <vector>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
@@ -24,9 +25,9 @@ namespace multibody {
 template <typename T>
 class ContactResults {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ContactResults)
+  DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN(ContactResults)
 
-  ContactResults() = default;
+  ContactResults();
 
   /** Clears the set of contact information for when the old data becomes
    invalid. */
@@ -48,6 +49,12 @@ class ContactResults {
   std::vector<PointPairContactInfo<T>> point_pairs_info_;
 };
 
+// Workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57728 which
+// should be moved back into the class definition once we no longer need to
+// support GCC versions prior to 6.3.
+template <typename T> ContactResults<T>::ContactResults() = default;
+DRAKE_DEFINE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN_T(ContactResults)
+
 #ifndef DRAKE_DOXYGEN_CXX
 // TODO(#9314) Remove this transitional namespace on or about 2019-03-01.
 namespace multibody_plant {
@@ -58,3 +65,6 @@ using ContactResults = ::drake::multibody::ContactResults<T>;
 
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::ContactResults)

--- a/multibody/plant/contact_results_to_lcm.cc
+++ b/multibody/plant/contact_results_to_lcm.cc
@@ -2,7 +2,6 @@
 
 #include <memory>
 
-#include "drake/common/default_scalars.h"
 #include "drake/lcmt_contact_results_for_viz.hpp"
 #include "drake/systems/framework/value.h"
 
@@ -118,6 +117,5 @@ systems::lcm::LcmPublisherSystem* ConnectContactResultsToDrakeVisualizer(
 }  // namespace multibody
 }  // namespace drake
 
-// This should be kept in sync with the scalars that MultibodyPlant supports.
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
     class drake::multibody::ContactResultsToLcmSystem)

--- a/multibody/plant/contact_results_to_lcm.h
+++ b/multibody/plant/contact_results_to_lcm.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_deprecated.h"
 #include "drake/lcmt_contact_results_for_viz.hpp"
@@ -146,3 +147,6 @@ inline systems::lcm::LcmPublisherSystem* ConnectContactResultsToDrakeVisualizer(
 
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class drake::multibody::ContactResultsToLcmSystem)

--- a/multibody/plant/coulomb_friction.cc
+++ b/multibody/plant/coulomb_friction.cc
@@ -3,8 +3,6 @@
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 
-#include "drake/common/default_scalars.h"
-
 namespace drake {
 namespace multibody {
 

--- a/multibody/plant/coulomb_friction.h
+++ b/multibody/plant/coulomb_friction.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_bool.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_deprecated.h"
@@ -70,11 +71,11 @@ namespace multibody {
 template<typename T>
 class CoulombFriction {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CoulombFriction)
+  DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN(CoulombFriction)
 
   /// Default constructor for a frictionless surface, i.e. with zero static and
   /// dynamic coefficients of friction.
-  CoulombFriction() = default;
+  CoulombFriction();
 
   /// Specifies both the static and dynamic friction coefficients for a given
   /// surface.
@@ -103,6 +104,12 @@ class CoulombFriction {
   T static_friction_{0.0};
   T dynamic_friction_{0.0};
 };
+
+// Workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57728 which
+// should be moved back into the class definition once we no longer need to
+// support GCC versions prior to 6.3.
+template <typename T> CoulombFriction<T>::CoulombFriction() = default;
+DRAKE_DEFINE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN_T(CoulombFriction)
 
 /// Given the surface properties of two different surfaces, this method computes
 /// the Coulomb's law coefficients of friction characterizing the interaction by
@@ -165,3 +172,6 @@ using multibody::CalcContactFrictionFromSurfaceProperties;
 
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::CoulombFriction);

--- a/multibody/plant/implicit_stribeck_solver.cc
+++ b/multibody/plant/implicit_stribeck_solver.cc
@@ -6,7 +6,6 @@
 #include <utility>
 #include <vector>
 
-#include "drake/common/default_scalars.h"
 #include "drake/common/extract_double.h"
 
 namespace drake {
@@ -783,7 +782,6 @@ T ImplicitStribeckSolver<T>::ModifiedStribeckDerivative(
 }  // namespace multibody
 }  // namespace drake
 
-// Explicitly instantiates on the most common scalar types.
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
     struct ::drake::multibody::internal::DirectionChangeLimiter)
 

--- a/multibody/plant/implicit_stribeck_solver.h
+++ b/multibody/plant/implicit_stribeck_solver.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <vector>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_throw.h"
@@ -1155,3 +1156,9 @@ class ImplicitStribeckSolver {
 
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    struct ::drake::multibody::internal::DirectionChangeLimiter)
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::ImplicitStribeckSolver)

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -5,7 +5,6 @@
 #include <memory>
 #include <vector>
 
-#include "drake/common/default_scalars.h"
 #include "drake/common/drake_throw.h"
 #include "drake/geometry/frame_kinematics_vector.h"
 #include "drake/geometry/geometry_frame.h"

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -8,6 +8,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_deprecated.h"
 #include "drake/common/drake_optional.h"
 #include "drake/common/nice_type_name.h"
@@ -3427,6 +3428,14 @@ struct AddMultibodyPlantSceneGraphResult final {
   geometry::SceneGraph<T>* scene_graph_ptr{};
 };
 
+#ifndef DRAKE_DOXYGEN_CXX
+// Forward-declare specializations, prior to DRAKE_DECLARE... below.
+template <>
+std::vector<geometry::PenetrationAsPointPair<double>>
+MultibodyPlant<double>::CalcPointPairPenetrations(
+    const systems::Context<double>&) const;
+#endif
+
 }  // namespace multibody
 }  // namespace drake
 
@@ -3441,3 +3450,8 @@ struct Traits<drake::multibody::MultibodyPlant> :
 }  // namespace scalar_conversion
 }  // namespace systems
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class drake::multibody::MultibodyPlant)
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    struct drake::multibody::AddMultibodyPlantSceneGraphResult)

--- a/multibody/tree/acceleration_kinematics_cache.cc
+++ b/multibody/tree/acceleration_kinematics_cache.cc
@@ -1,15 +1,4 @@
 #include "drake/multibody/tree/acceleration_kinematics_cache.h"
 
-#include "drake/common/autodiff.h"
-
-namespace drake {
-namespace multibody {
-namespace internal {
-
-// Explicitly instantiates on the most common scalar types.
-template class AccelerationKinematicsCache<double>;
-template class AccelerationKinematicsCache<AutoDiffXd>;
-
-}  // namespace internal
-}  // namespace multibody
-}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::internal::AccelerationKinematicsCache)

--- a/multibody/tree/acceleration_kinematics_cache.h
+++ b/multibody/tree/acceleration_kinematics_cache.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <vector>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_deprecated.h"
@@ -36,7 +37,7 @@ namespace internal {
 template <typename T>
 class AccelerationKinematicsCache {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(AccelerationKinematicsCache)
+  DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN(AccelerationKinematicsCache)
 
   /// Constructs an acceleration kinematics cache entry for the given
   /// MultibodyTreeTopology.
@@ -121,6 +122,8 @@ class AccelerationKinematicsCache {
   SpatialAcceleration_PoolType A_WB_pool_;   // Indexed by BodyNodeIndex.
 };
 
+DRAKE_DEFINE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN_T(AccelerationKinematicsCache);
+
 }  // namespace internal
 
 /// WARNING: This will be removed on or around 2019/03/01.
@@ -132,3 +135,6 @@ DRAKE_DEPRECATED(
 
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::internal::AccelerationKinematicsCache)

--- a/multibody/tree/articulated_body_inertia.cc
+++ b/multibody/tree/articulated_body_inertia.cc
@@ -1,6 +1,4 @@
 #include "drake/multibody/tree/articulated_body_inertia.h"
 
-#include "drake/common/default_scalars.h"
-
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class drake::multibody::ArticulatedBodyInertia)

--- a/multibody/tree/articulated_body_inertia.h
+++ b/multibody/tree/articulated_body_inertia.h
@@ -2,6 +2,7 @@
 
 #include <limits>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/nice_type_name.h"
@@ -97,11 +98,11 @@ namespace multibody {
 template<typename T>
 class ArticulatedBodyInertia {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ArticulatedBodyInertia)
+  DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN(ArticulatedBodyInertia)
 
   /// Default ArticulatedBodyInertia constructor initializes all matrix values
   /// to NaN for a quick detection of uninitialized values.
-  ArticulatedBodyInertia() = default;
+  ArticulatedBodyInertia();
 
   /// Constructs an articulated body inertia for an articulated body consisting
   /// of a single rigid body given its spatial inertia. From an input spatial
@@ -363,5 +364,15 @@ class ArticulatedBodyInertia {
   }
 };
 
+// Workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57728 which
+// should be moved back into the class definition once we no longer need to
+// support GCC versions prior to 6.3.
+template <typename T>
+ArticulatedBodyInertia<T>::ArticulatedBodyInertia() = default;
+DRAKE_DEFINE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN_T(ArticulatedBodyInertia)
+
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class drake::multibody::ArticulatedBodyInertia)

--- a/multibody/tree/articulated_body_inertia_cache.cc
+++ b/multibody/tree/articulated_body_inertia_cache.cc
@@ -1,6 +1,4 @@
 #include "drake/multibody/tree/articulated_body_inertia_cache.h"
 
-#include "drake/common/default_scalars.h"
-
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
     class drake::multibody::internal::ArticulatedBodyInertiaCache)

--- a/multibody/tree/articulated_body_inertia_cache.h
+++ b/multibody/tree/articulated_body_inertia_cache.h
@@ -2,6 +2,7 @@
 
 #include <vector>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_deprecated.h"
 #include "drake/multibody/tree/articulated_body_inertia.h"
@@ -34,7 +35,7 @@ namespace internal {
 template<typename T>
 class ArticulatedBodyInertiaCache {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ArticulatedBodyInertiaCache)
+  DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN(ArticulatedBodyInertiaCache)
 
   /// Constructs an articulated body cache entry for the given
   /// MultibodyTreeTopology.
@@ -75,6 +76,8 @@ class ArticulatedBodyInertiaCache {
   ABI_PoolType Pplus_PB_W_{};  // Indexed by BodyNodeIndex.
 };
 
+DRAKE_DEFINE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN_T(ArticulatedBodyInertiaCache);
+
 }  // namespace internal
 
 /// WARNING: This will be removed on or around 2019/03/01.
@@ -86,3 +89,6 @@ DRAKE_DEPRECATED(
 
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class drake::multibody::internal::ArticulatedBodyInertiaCache)

--- a/multibody/tree/body.cc
+++ b/multibody/tree/body.cc
@@ -2,7 +2,6 @@
 
 #include <memory>
 
-#include "drake/common/autodiff.h"
 #include "drake/multibody/tree/multibody_tree.h"
 
 namespace drake {
@@ -32,9 +31,8 @@ std::unique_ptr<Frame<AutoDiffXd>> BodyFrame<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
-// Explicitly instantiates on the most common scalar types.
-template class BodyFrame<double>;
-template class BodyFrame<AutoDiffXd>;
-
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class drake::multibody::BodyFrame)

--- a/multibody/tree/body.h
+++ b/multibody/tree/body.h
@@ -4,7 +4,7 @@
 #include <string>
 #include <vector>
 
-#include "drake/common/autodiff.h"
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/unused.h"
 #include "drake/multibody/tree/frame.h"
@@ -346,3 +346,6 @@ class Body : public MultibodyTreeElement<Body<T>, BodyIndex> {
 
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class drake::multibody::BodyFrame)

--- a/multibody/tree/body_node_impl.cc
+++ b/multibody/tree/body_node_impl.cc
@@ -1,6 +1,6 @@
 #include "drake/multibody/tree/body_node_impl.h"
 
-#include "drake/common/autodiff.h"
+#include "drake/common/default_scalars.h"
 
 namespace drake {
 namespace multibody {
@@ -17,6 +17,7 @@ template class BodyNodeImpl<T, 6, 6>; \
 template class BodyNodeImpl<T, 7, 6>;
 
 // Explicitly instantiates on the most common scalar types.
+// These should be kept in sync with the NONSYMBOLIC list in default_scalars.h
 EXPLICITLY_INSTANTIATE_IMPLS(double);
 EXPLICITLY_INSTANTIATE_IMPLS(AutoDiffXd);
 

--- a/multibody/tree/fixed_offset_frame.cc
+++ b/multibody/tree/fixed_offset_frame.cc
@@ -3,7 +3,6 @@
 #include <exception>
 #include <memory>
 
-#include "drake/common/autodiff.h"
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/tree/body.h"
 #include "drake/multibody/tree/multibody_tree.h"
@@ -47,9 +46,8 @@ std::unique_ptr<Frame<AutoDiffXd>> FixedOffsetFrame<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
-// Explicitly instantiates on the most common scalar types.
-template class FixedOffsetFrame<double>;
-template class FixedOffsetFrame<AutoDiffXd>;
-
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class drake::multibody::FixedOffsetFrame)

--- a/multibody/tree/fixed_offset_frame.h
+++ b/multibody/tree/fixed_offset_frame.h
@@ -3,7 +3,7 @@
 #include <memory>
 #include <string>
 
-#include "drake/common/autodiff.h"
+#include "drake/common/default_scalars.h"
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/tree/frame.h"
 #include "drake/multibody/tree/multibody_tree_forward_decl.h"
@@ -124,3 +124,6 @@ class FixedOffsetFrame final : public Frame<T> {
 
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class drake::multibody::FixedOffsetFrame)

--- a/multibody/tree/joint_actuator.cc
+++ b/multibody/tree/joint_actuator.cc
@@ -1,6 +1,5 @@
 #include "drake/multibody/tree/joint_actuator.h"
 
-#include "drake/common/default_scalars.h"
 #include "drake/multibody/tree/joint.h"
 #include "drake/multibody/tree/multibody_tree.h"
 

--- a/multibody/tree/joint_actuator.h
+++ b/multibody/tree/joint_actuator.h
@@ -4,7 +4,7 @@
 #include <string>
 #include <vector>
 
-#include "drake/common/autodiff.h"
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/multibody/tree/multibody_forces.h"
 #include "drake/multibody/tree/multibody_tree_element.h"
@@ -153,3 +153,6 @@ class JointActuator final
 
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::JointActuator)

--- a/multibody/tree/linear_spring_damper.cc
+++ b/multibody/tree/linear_spring_damper.cc
@@ -4,7 +4,6 @@
 #include <utility>
 #include <vector>
 
-#include "drake/common/autodiff.h"
 #include "drake/multibody/tree/body.h"
 #include "drake/multibody/tree/multibody_tree.h"
 
@@ -221,9 +220,8 @@ T LinearSpringDamper<T>::CalcLengthTimeDerivative(
   return length_dot;
 }
 
-// Explicitly instantiates on the most common scalar types.
-template class LinearSpringDamper<double>;
-template class LinearSpringDamper<AutoDiffXd>;
-
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::LinearSpringDamper)

--- a/multibody/tree/linear_spring_damper.h
+++ b/multibody/tree/linear_spring_damper.h
@@ -3,7 +3,7 @@
 #include <memory>
 #include <vector>
 
-#include "drake/common/autodiff.h"
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/multibody/tree/force_element.h"
 
@@ -153,3 +153,6 @@ class LinearSpringDamper final : public ForceElement<T> {
 
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::LinearSpringDamper)

--- a/multibody/tree/model_instance.cc
+++ b/multibody/tree/model_instance.cc
@@ -1,6 +1,5 @@
 #include "drake/multibody/tree/model_instance.h"
 
-#include "drake/common/default_scalars.h"
 #include "drake/multibody/tree/joint.h"
 #include "drake/multibody/tree/multibody_tree.h"
 

--- a/multibody/tree/model_instance.h
+++ b/multibody/tree/model_instance.h
@@ -2,6 +2,7 @@
 
 #include <vector>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/tree/joint_actuator.h"
@@ -180,3 +181,6 @@ class ModelInstance :
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::internal::ModelInstance)

--- a/multibody/tree/multibody_forces.cc
+++ b/multibody/tree/multibody_forces.cc
@@ -1,6 +1,5 @@
 #include "drake/multibody/tree/multibody_forces.h"
 
-#include "drake/common/default_scalars.h"
 #include "drake/multibody/tree/multibody_tree.h"
 
 namespace drake {

--- a/multibody/tree/multibody_forces.h
+++ b/multibody/tree/multibody_forces.h
@@ -2,6 +2,7 @@
 
 #include <vector>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/math/spatial_force.h"
@@ -27,7 +28,7 @@ namespace multibody {
 template <typename T>
 class MultibodyForces {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(MultibodyForces)
+  DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN(MultibodyForces)
 
   // TODO(amcastro-tri): replace with MultibodyPlant once dependency becomes
   // logical.
@@ -108,5 +109,10 @@ class MultibodyForces {
   VectorX<T> tau_;
 };
 
+DRAKE_DEFINE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN_T(MultibodyForces)
+
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::MultibodyForces)

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -6,7 +6,6 @@
 #include <unordered_set>
 #include <utility>
 
-#include "drake/common/autodiff.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
@@ -1649,10 +1648,9 @@ VectorX<double> MultibodyTree<T>::GetAccelerationUpperLimits() const {
   return vd_upper;
 }
 
-// Explicitly instantiates on the most common scalar types.
-template class MultibodyTree<double>;
-template class MultibodyTree<AutoDiffXd>;
-
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::internal::MultibodyTree)

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -10,7 +10,7 @@
 #include <utility>
 #include <vector>
 
-#include "drake/common/autodiff.h"
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_deprecated.h"
 #include "drake/common/drake_optional.h"
@@ -2649,3 +2649,6 @@ class MultibodyTree {
 
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::internal::MultibodyTree)

--- a/multibody/tree/multibody_tree_context.cc
+++ b/multibody/tree/multibody_tree_context.cc
@@ -1,6 +1,4 @@
 #include "drake/multibody/tree/multibody_tree_context.h"
 
-#include "drake/common/default_scalars.h"
-
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::internal::MultibodyTreeContext)

--- a/multibody/tree/multibody_tree_context.h
+++ b/multibody/tree/multibody_tree_context.h
@@ -5,7 +5,7 @@
 #include <utility>
 #include <vector>
 
-#include "drake/common/autodiff.h"
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
@@ -213,7 +213,7 @@ class MultibodyTreeContext final : public systems::LeafContext<T> {
   }
 
  private:
-  MultibodyTreeContext(const MultibodyTreeContext& source) = default;
+  MultibodyTreeContext(const MultibodyTreeContext& source);
 
   const MultibodyTreeTopology topology_;
 
@@ -221,6 +221,13 @@ class MultibodyTreeContext final : public systems::LeafContext<T> {
   // stored as continuous state.
   bool is_state_discrete_{false};
 };
+
+// Workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57728 which
+// should be moved back into the class definition once we no longer need to
+// support GCC versions prior to 6.3.
+template <typename T>
+MultibodyTreeContext<T>::MultibodyTreeContext(const MultibodyTreeContext&)
+    = default;
 
 }  // namespace internal
 
@@ -233,3 +240,6 @@ DRAKE_DEPRECATED(
 
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::internal::MultibodyTreeContext)

--- a/multibody/tree/multibody_tree_forward_decl.h
+++ b/multibody/tree/multibody_tree_forward_decl.h
@@ -19,8 +19,5 @@ DRAKE_DEPRECATED(
     "This will soon be internal. Please use `MultibodyPlant` instead.")
     = internal::MultibodyTree<T>;
 
-// // Forward declaration.
-// template <typename T> class MultibodyPlant;
-
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/multibody_tree_system.cc
+++ b/multibody/tree/multibody_tree_system.cc
@@ -4,8 +4,6 @@
 #include <utility>
 #include <vector>
 
-#include "drake/common/autodiff.h"
-#include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/multibody/tree/multibody_tree.h"
 

--- a/multibody/tree/multibody_tree_system.h
+++ b/multibody/tree/multibody_tree_system.h
@@ -5,6 +5,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/tree/multibody_tree_forward_decl.h"
@@ -235,3 +236,6 @@ struct Traits<drake::multibody::internal::MultibodyTreeSystem> :
 }  // namespace scalar_conversion
 }  // namespace systems
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class drake::multibody::internal::MultibodyTreeSystem)

--- a/multibody/tree/position_kinematics_cache.cc
+++ b/multibody/tree/position_kinematics_cache.cc
@@ -1,15 +1,4 @@
 #include "drake/multibody/tree/position_kinematics_cache.h"
 
-#include "drake/common/autodiff.h"
-
-namespace drake {
-namespace multibody {
-namespace internal {
-
-// Explicitly instantiates on the most common scalar types.
-template class PositionKinematicsCache<double>;
-template class PositionKinematicsCache<AutoDiffXd>;
-
-}  // namespace internal
-}  // namespace multibody
-}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::internal::PositionKinematicsCache)

--- a/multibody/tree/position_kinematics_cache.h
+++ b/multibody/tree/position_kinematics_cache.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_deprecated.h"
@@ -36,7 +37,7 @@ namespace internal {
 template <typename T>
 class PositionKinematicsCache {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PositionKinematicsCache)
+  DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN(PositionKinematicsCache)
 
   /// Constructs a position kinematics cache entry for the given
   /// MultibodyTreeTopology.
@@ -140,6 +141,8 @@ class PositionKinematicsCache {
   X_PoolType X_MB_pool_;  // Indexed by BodyNodeIndex.
 };
 
+DRAKE_DEFINE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN_T(PositionKinematicsCache)
+
 }  // namespace internal
 
 /// WARNING: This will be removed on or around 2019/03/01.
@@ -151,3 +154,6 @@ DRAKE_DEPRECATED(
 
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::internal::PositionKinematicsCache)

--- a/multibody/tree/prismatic_joint.cc
+++ b/multibody/tree/prismatic_joint.cc
@@ -2,7 +2,6 @@
 
 #include <memory>
 
-#include "drake/common/autodiff.h"
 #include "drake/multibody/tree/multibody_tree.h"
 
 namespace drake {
@@ -43,9 +42,8 @@ std::unique_ptr<Joint<AutoDiffXd>> PrismaticJoint<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
-// Explicitly instantiates on the most common scalar types.
-template class PrismaticJoint<double>;
-template class PrismaticJoint<AutoDiffXd>;
-
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::PrismaticJoint)

--- a/multibody/tree/prismatic_joint.h
+++ b/multibody/tree/prismatic_joint.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <utility>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/multibody/tree/joint.h"
 #include "drake/multibody/tree/multibody_forces.h"
@@ -323,3 +324,6 @@ class PrismaticJoint final : public Joint<T> {
 
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::PrismaticJoint)

--- a/multibody/tree/prismatic_mobilizer.cc
+++ b/multibody/tree/prismatic_mobilizer.cc
@@ -148,10 +148,9 @@ std::unique_ptr<Mobilizer<AutoDiffXd>> PrismaticMobilizer<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
-// Explicitly instantiates on the most common scalar types.
-template class PrismaticMobilizer<double>;
-template class PrismaticMobilizer<AutoDiffXd>;
-
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::internal::PrismaticMobilizer)

--- a/multibody/tree/prismatic_mobilizer.h
+++ b/multibody/tree/prismatic_mobilizer.h
@@ -3,6 +3,7 @@
 #include <limits>
 #include <memory>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_deprecated.h"
@@ -208,3 +209,6 @@ DRAKE_DEPRECATED(
 
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::internal::PrismaticMobilizer)

--- a/multibody/tree/quaternion_floating_mobilizer.cc
+++ b/multibody/tree/quaternion_floating_mobilizer.cc
@@ -2,7 +2,6 @@
 
 #include <memory>
 
-#include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/eigen_types.h"
 #include "drake/math/quaternion.h"
 #include "drake/math/random_rotation.h"
@@ -394,10 +393,9 @@ QuaternionFloatingMobilizer<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
-// Explicitly instantiates on the most common scalar types.
-template class QuaternionFloatingMobilizer<double>;
-template class QuaternionFloatingMobilizer<AutoDiffXd>;
-
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::internal::QuaternionFloatingMobilizer)

--- a/multibody/tree/quaternion_floating_mobilizer.h
+++ b/multibody/tree/quaternion_floating_mobilizer.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
@@ -273,3 +274,6 @@ DRAKE_DEPRECATED(
 
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::internal::QuaternionFloatingMobilizer)

--- a/multibody/tree/revolute_joint.cc
+++ b/multibody/tree/revolute_joint.cc
@@ -3,7 +3,6 @@
 #include <memory>
 #include <stdexcept>
 
-#include "drake/common/autodiff.h"
 #include "drake/multibody/tree/multibody_tree.h"
 
 namespace drake {
@@ -57,9 +56,8 @@ RevoluteJoint<T>::MakeImplementationBlueprint() const {
   return std::move(blue_print);
 }
 
-// Explicitly instantiates on the most common scalar types.
-template class RevoluteJoint<double>;
-template class RevoluteJoint<AutoDiffXd>;
-
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::RevoluteJoint)

--- a/multibody/tree/revolute_joint.h
+++ b/multibody/tree/revolute_joint.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <utility>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/multibody/tree/joint.h"
 #include "drake/multibody/tree/multibody_forces.h"
@@ -358,3 +359,6 @@ class RevoluteJoint final : public Joint<T> {
 
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::RevoluteJoint)

--- a/multibody/tree/revolute_mobilizer.cc
+++ b/multibody/tree/revolute_mobilizer.cc
@@ -3,7 +3,6 @@
 #include <memory>
 #include <stdexcept>
 
-#include "drake/common/autodiff.h"
 #include "drake/multibody/tree/multibody_tree.h"
 
 namespace drake {
@@ -150,10 +149,9 @@ std::unique_ptr<Mobilizer<AutoDiffXd>> RevoluteMobilizer<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
-// Explicitly instantiates on the most common scalar types.
-template class RevoluteMobilizer<double>;
-template class RevoluteMobilizer<AutoDiffXd>;
-
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::internal::RevoluteMobilizer)

--- a/multibody/tree/revolute_mobilizer.h
+++ b/multibody/tree/revolute_mobilizer.h
@@ -3,6 +3,7 @@
 #include <limits>
 #include <memory>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_deprecated.h"
@@ -208,3 +209,6 @@ DRAKE_DEPRECATED(
 
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::internal::RevoluteMobilizer)

--- a/multibody/tree/rigid_body.cc
+++ b/multibody/tree/rigid_body.cc
@@ -2,7 +2,6 @@
 
 #include <memory>
 
-#include "drake/common/autodiff.h"
 #include "drake/multibody/tree/model_instance.h"
 
 namespace drake {
@@ -26,9 +25,8 @@ RigidBody<T>::RigidBody(const std::string& body_name,
     : Body<T>(body_name, model_instance, M.get_mass()),
       default_spatial_inertia_(M) {}
 
-// Explicitly instantiates on the most common scalar types.
-template class RigidBody<double>;
-template class RigidBody<AutoDiffXd>;
-
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::RigidBody)

--- a/multibody/tree/rigid_body.h
+++ b/multibody/tree/rigid_body.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/unused.h"
@@ -289,3 +290,6 @@ class RigidBody : public Body<T> {
 
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::RigidBody)

--- a/multibody/tree/rotational_inertia.cc
+++ b/multibody/tree/rotational_inertia.cc
@@ -1,6 +1,4 @@
 #include "drake/multibody/tree/rotational_inertia.h"
 
-#include "drake/common/default_scalars.h"
-
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class drake::multibody::RotationalInertia)

--- a/multibody/tree/rotational_inertia.h
+++ b/multibody/tree/rotational_inertia.h
@@ -11,6 +11,7 @@
 
 #include <Eigen/Eigenvalues>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_bool.h"
 #include "drake/common/drake_copyable.h"
@@ -104,7 +105,7 @@ namespace multibody {
 template <typename T>
 class RotationalInertia {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(RotationalInertia)
+  DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN(RotationalInertia)
 
   /// Constructs a rotational inertia that has all its moments/products of
   /// inertia equal to NaN (helps quickly detect uninitialized values).
@@ -1015,5 +1016,10 @@ std::ostream& operator<<(std::ostream& o,
   return o;
 }
 
+DRAKE_DEFINE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN_T(RotationalInertia)
+
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class drake::multibody::RotationalInertia)

--- a/multibody/tree/space_xyz_mobilizer.cc
+++ b/multibody/tree/space_xyz_mobilizer.cc
@@ -3,7 +3,6 @@
 #include <memory>
 #include <stdexcept>
 
-#include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/eigen_types.h"
 #include "drake/math/roll_pitch_yaw.h"
 #include "drake/math/rotation_matrix.h"
@@ -359,10 +358,9 @@ SpaceXYZMobilizer<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
-// Explicitly instantiates on the most common scalar types.
-template class SpaceXYZMobilizer<double>;
-template class SpaceXYZMobilizer<AutoDiffXd>;
-
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::internal::SpaceXYZMobilizer)

--- a/multibody/tree/space_xyz_mobilizer.h
+++ b/multibody/tree/space_xyz_mobilizer.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_deprecated.h"
@@ -297,3 +298,6 @@ DRAKE_DEPRECATED(
 
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::internal::SpaceXYZMobilizer)

--- a/multibody/tree/spatial_inertia.cc
+++ b/multibody/tree/spatial_inertia.cc
@@ -1,6 +1,4 @@
 #include "drake/multibody/tree/spatial_inertia.h"
 
-#include "drake/common/default_scalars.h"
-
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class drake::multibody::SpatialInertia)

--- a/multibody/tree/spatial_inertia.h
+++ b/multibody/tree/spatial_inertia.h
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <limits>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_bool.h"
 #include "drake/common/drake_copyable.h"
@@ -97,7 +98,7 @@ namespace multibody {
 template <typename T>
 class SpatialInertia {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SpatialInertia)
+  DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN(SpatialInertia)
 
   /// Creates a spatial inertia for a physical body or composite body S about a
   /// point P from a given mass, center of mass, and central rotational inertia.
@@ -490,5 +491,10 @@ std::ostream& operator<<(std::ostream& o,
       << M.CalcRotationalInertia();
 }
 
+DRAKE_DEFINE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN_T(SpatialInertia)
+
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class drake::multibody::SpatialInertia)

--- a/multibody/tree/uniform_gravity_field_element.cc
+++ b/multibody/tree/uniform_gravity_field_element.cc
@@ -2,7 +2,6 @@
 
 #include <vector>
 
-#include "drake/common/autodiff.h"
 #include "drake/multibody/tree/body.h"
 #include "drake/multibody/tree/multibody_tree.h"
 
@@ -187,9 +186,8 @@ UniformGravityFieldElement<T>::DoCloneToScalar(
       gravity_vector());
 }
 
-// Explicitly instantiates on the most common scalar types.
-template class UniformGravityFieldElement<double>;
-template class UniformGravityFieldElement<AutoDiffXd>;
-
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::UniformGravityFieldElement)

--- a/multibody/tree/uniform_gravity_field_element.h
+++ b/multibody/tree/uniform_gravity_field_element.h
@@ -3,7 +3,7 @@
 #include <memory>
 #include <vector>
 
-#include "drake/common/autodiff.h"
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/multibody/tree/force_element.h"
 
@@ -111,3 +111,6 @@ class UniformGravityFieldElement : public ForceElement<T> {
 
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::UniformGravityFieldElement)

--- a/multibody/tree/unit_inertia.cc
+++ b/multibody/tree/unit_inertia.cc
@@ -1,6 +1,4 @@
 #include "drake/multibody/tree/unit_inertia.h"
 
-#include "drake/common/default_scalars.h"
-
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class drake::multibody::UnitInertia)

--- a/multibody/tree/unit_inertia.h
+++ b/multibody/tree/unit_inertia.h
@@ -2,6 +2,7 @@
 
 #include <limits>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
@@ -45,7 +46,7 @@ namespace multibody {
 template <typename T>
 class UnitInertia : public RotationalInertia<T> {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(UnitInertia)
+  DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN(UnitInertia)
 
   /// Default %UnitInertia constructor sets all entries to NaN for quick
   /// detection of uninitialized values.
@@ -463,5 +464,10 @@ class UnitInertia : public RotationalInertia<T> {
   //@}
 };
 
+DRAKE_DEFINE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN_T(UnitInertia)
+
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class drake::multibody::UnitInertia)

--- a/multibody/tree/velocity_kinematics_cache.cc
+++ b/multibody/tree/velocity_kinematics_cache.cc
@@ -1,15 +1,4 @@
 #include "drake/multibody/tree/velocity_kinematics_cache.h"
 
-#include "drake/common/autodiff.h"
-
-namespace drake {
-namespace multibody {
-namespace internal {
-
-// Explicitly instantiates on the most common scalar types.
-template class VelocityKinematicsCache<double>;
-template class VelocityKinematicsCache<AutoDiffXd>;
-
-}  // namespace internal
-}  // namespace multibody
-}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::internal::VelocityKinematicsCache)

--- a/multibody/tree/velocity_kinematics_cache.h
+++ b/multibody/tree/velocity_kinematics_cache.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <vector>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_deprecated.h"
@@ -40,7 +41,7 @@ namespace internal {
 template <typename T>
 class VelocityKinematicsCache {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(VelocityKinematicsCache)
+  DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN(VelocityKinematicsCache)
 
   /// Constructs a velocity kinematics cache entry for the given
   /// MultibodyTreeTopology.
@@ -149,6 +150,8 @@ class VelocityKinematicsCache {
   SpatialVelocity_PoolType V_PB_W_pool_;
 };
 
+DRAKE_DEFINE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN_T(VelocityKinematicsCache)
+
 }  // namespace internal
 
 /// WARNING: This will be removed on or around 2019/03/01.
@@ -160,3 +163,6 @@ DRAKE_DEPRECATED(
 
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::internal::VelocityKinematicsCache)

--- a/multibody/tree/weld_joint.cc
+++ b/multibody/tree/weld_joint.cc
@@ -2,7 +2,6 @@
 
 #include <memory>
 
-#include "drake/common/default_scalars.h"
 #include "drake/multibody/tree/multibody_tree.h"
 
 namespace drake {
@@ -54,5 +53,5 @@ WeldJoint<T>::MakeImplementationBlueprint() const {
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
     class ::drake::multibody::WeldJoint)

--- a/multibody/tree/weld_joint.h
+++ b/multibody/tree/weld_joint.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <utility>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/multibody/tree/joint.h"
 #include "drake/multibody/tree/multibody_forces.h"
@@ -138,3 +139,6 @@ class WeldJoint final : public Joint<T> {
 
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::WeldJoint)

--- a/multibody/tree/weld_mobilizer.cc
+++ b/multibody/tree/weld_mobilizer.cc
@@ -2,7 +2,6 @@
 
 #include <memory>
 
-#include "drake/common/default_scalars.h"
 #include "drake/multibody/tree/multibody_tree.h"
 
 namespace drake {
@@ -95,5 +94,5 @@ std::unique_ptr<Mobilizer<AutoDiffXd>> WeldMobilizer<T>::DoCloneToScalar(
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
     class ::drake::multibody::internal::WeldMobilizer)

--- a/multibody/tree/weld_mobilizer.h
+++ b/multibody/tree/weld_mobilizer.h
@@ -3,6 +3,7 @@
 #include <limits>
 #include <memory>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_deprecated.h"
@@ -130,3 +131,6 @@ DRAKE_DEPRECATED(
 
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::internal::WeldMobilizer)


### PR DESCRIPTION
This updates tree/ and plant/ to use the newest conventions.  The math/ and benchmarks/ remain unchanged.

We should update code to follow modern conventions no matter what, but this PR's timing is specifically motivated by #10439, where we want to make the "Remove NONSYMBOLIC exemption" as concisely stated as possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10489)
<!-- Reviewable:end -->
