### PR TITLE
implement default positions in mobilizers

### DIFF
--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -658,6 +658,26 @@ TEST_F(AcrobotPlantTests, VisualGeometryRegistration) {
 #endif
 }
 
+TEST_F(AcrobotPlantTests, SetDefaulState) {
+  EXPECT_EQ(shoulder_->get_angle(*context_), 0.0);
+  EXPECT_EQ(elbow_->get_angle(*context_), 0.0);
+
+  // Set the default joint angles for the acrobot.
+  shoulder_->set_default_angle(0.05);
+  elbow_->set_default_angle(1.2);
+
+  // New contexts should get the default angles.
+  auto test_context = plant_->CreateDefaultContext();
+  EXPECT_EQ(shoulder_->get_angle(*test_context), 0.05);
+  EXPECT_EQ(elbow_->get_angle(*test_context), 1.2);
+
+  shoulder_->set_default_angle(4.2);
+
+  // Calling SetDefaultContext directly works, too.
+  plant_->SetDefaultContext(context_.get());
+  EXPECT_EQ(shoulder_->get_angle(*context_), 4.2);
+}
+
 TEST_F(AcrobotPlantTests, SetRandomState) {
   RandomGenerator generator;
   auto random_context = plant_->CreateDefaultContext();

--- a/multibody/tree/mobilizer.h
+++ b/multibody/tree/mobilizer.h
@@ -335,6 +335,10 @@ class Mobilizer : public MultibodyTreeElement<Mobilizer<T>, MobilizerIndex> {
   /// represent a mathematicaly valid one. Consider for instance a quaternion
   /// mobilizer, for which its _zero_ position corresponds to the quaternion
   /// [1, 0, 0, 0].
+  ///
+  /// Note that the zero state may fall outside of the limits for any joints
+  /// associated with this mobilizer.
+  /// @see set_default_state().
   virtual void set_zero_state(const systems::Context<T>& context,
                               systems::State<T>* state) const = 0;
 
@@ -343,6 +347,16 @@ class Mobilizer : public MultibodyTreeElement<Mobilizer<T>, MobilizerIndex> {
   void set_zero_configuration(systems::Context<T>* context) const {
     set_zero_state(*context, &context->get_mutable_state());
   }
+
+  /// Sets the `state` to the _default_ state (position and velocity) for
+  /// `this` mobilizer.  For example, the zero state for our standard IIWA
+  /// model has the arm pointing directly up; this is the correct definition of
+  /// the zero state (it is where our joint angles measure zero).  But we also
+  /// support a default state (perhaps a more comfortable initial configuration
+  /// of the IIWA), which need not be the zero state, that describes a state of
+  /// the Mobilizer to be used in e.g. MultibodyPlant::SetDefaultContext().
+  virtual void set_default_state(const systems::Context<T>& context,
+                                 systems::State<T>* state) const = 0;
 
   /// Sets the `state` to a (potentially) random position and velocity, by
   /// evaluating any random distributions that were declared (via e.g.

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -310,7 +310,7 @@ template <typename T>
 void MultibodyTree<T>::SetDefaultState(
     const systems::Context<T>& context, systems::State<T>* state) const {
   for (const auto& mobilizer : owned_mobilizers_) {
-    mobilizer->set_zero_state(context, state);
+    mobilizer->set_default_state(context, state);
   }
 }
 

--- a/multibody/tree/quaternion_floating_mobilizer.cc
+++ b/multibody/tree/quaternion_floating_mobilizer.cc
@@ -192,9 +192,9 @@ QuaternionFloatingMobilizer<T>::set_translational_velocity(
 }
 
 template <typename T>
-Eigen::Matrix<double, 7, 1> QuaternionFloatingMobilizer<T>::get_zero_position()
+Vector<double, 7> QuaternionFloatingMobilizer<T>::get_zero_position()
     const {
-  Eigen::Matrix<double, 7, 1> q = Eigen::Matrix<double, 7, 1>::Zero();
+  Vector<double, 7> q = Vector<double, 7>::Zero();
   const Quaternion<double> quaternion = Quaternion<double>::Identity();
   q[0] = quaternion.w();
   q.template segment<3>(1) = quaternion.vec();

--- a/multibody/tree/quaternion_floating_mobilizer.h
+++ b/multibody/tree/quaternion_floating_mobilizer.h
@@ -215,7 +215,7 @@ class QuaternionFloatingMobilizer final : public MobilizerImpl<T, 7, 6> {
  protected:
   /// Sets `state` to store a configuration in which M coincides with F (i.e.
   /// q_FM is the identity quaternion).
-  Eigen::Matrix<double, 7, 1> get_zero_position() const override;
+  Vector<double, 7> get_zero_position() const override;
 
   void DoCalcNMatrix(const MultibodyTreeContext<T>& context,
                      EigenPtr<MatrixX<T>> N) const final;

--- a/multibody/tree/revolute_joint.h
+++ b/multibody/tree/revolute_joint.h
@@ -194,6 +194,10 @@ class RevoluteJoint final : public Joint<T> {
     return *this;
   }
 
+  void set_default_angle(double angle) {
+    get_mutable_mobilizer()->set_default_position(Vector1d{angle});
+  }
+
   void set_random_angle_distribution(const symbolic::Expression& angle) {
     get_mutable_mobilizer()->set_random_position_distribution(
         Vector1<symbolic::Expression>{angle});

--- a/multibody/tree/test/revolute_mobilizer_test.cc
+++ b/multibody/tree/test/revolute_mobilizer_test.cc
@@ -80,6 +80,18 @@ TEST_F(RevoluteMobilizerTest, ZeroState) {
   EXPECT_EQ(mobilizer_->get_angular_rate(*context_), 0);
 }
 
+TEST_F(RevoluteMobilizerTest, DefaultPosition) {
+  RevoluteMobilizer<double>* mutable_mobilizer =
+      &mutable_tree().get_mutable_variant(*mobilizer_);
+
+  EXPECT_EQ(mobilizer_->get_angle(*context_), 0);
+
+  mutable_mobilizer->set_default_position(Vector1d{.4});
+  mobilizer_->set_default_state(*context_, &context_->get_mutable_state());
+
+  EXPECT_EQ(mobilizer_->get_angle(*context_), .4);
+}
+
 TEST_F(RevoluteMobilizerTest, RandomState) {
   RandomGenerator generator;
   std::uniform_real_distribution<symbolic::Expression> uniform;


### PR DESCRIPTION
and add one public api for setting them for revolute joints

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10490)
<!-- Reviewable:end -->
