### PR TITLE
math: Compile roll_pitch_yaw for symbolic::Expression

### DIFF
--- a/common/autodiff_overloads.h
+++ b/common/autodiff_overloads.h
@@ -54,6 +54,13 @@ bool isinf(const Eigen::AutoDiffScalar<DerType>& x) {
   return isinf(x.value());
 }
 
+/// Overloads isfinite to mimic std::isfinite from <cmath>.
+template <typename DerType>
+bool isfinite(const Eigen::AutoDiffScalar<DerType>& x) {
+  using std::isfinite;
+  return isfinite(x.value());
+}
+
 /// Overloads isnan to mimic std::isnan from <cmath>.
 template <typename DerType>
 bool isnan(const Eigen::AutoDiffScalar<DerType>& x) {

--- a/common/test/autodiff_overloads_test.cc
+++ b/common/test/autodiff_overloads_test.cc
@@ -81,12 +81,23 @@ GTEST_TEST(AutodiffOverloadsTest, NextToward) {
   EXPECT_EQ(nexttoward(x, inf) - 1, eps);
 }
 
+// Tests correctness of isfinite.
+GTEST_TEST(AutodiffOverloadsTest, IsFinite) {
+  Eigen::AutoDiffScalar<Eigen::Vector2d> x;
+  x.value() = 1.0 / 0.0;
+  EXPECT_EQ(isfinite(x), false);
+  x.value() = 0.0;
+  x.derivatives()[0] = 1.0 / 0.0;
+  EXPECT_EQ(isfinite(x), true);
+}
+
 // Tests correctness of isinf.
 GTEST_TEST(AutodiffOverloadsTest, IsInf) {
   Eigen::AutoDiffScalar<Eigen::Vector2d> x;
   x.value() = 1.0 / 0.0;
   EXPECT_EQ(isinf(x), true);
   x.value() = 0.0;
+  x.derivatives()[0] = 1.0 / 0.0;
   EXPECT_EQ(isinf(x), false);
 }
 

--- a/math/roll_pitch_yaw.cc
+++ b/math/roll_pitch_yaw.cc
@@ -5,7 +5,6 @@
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 
-#include "drake/common/default_scalars.h"
 #include "drake/math/rotation_matrix.h"
 
 namespace drake {
@@ -173,10 +172,10 @@ Vector3<T> CalcRollPitchYawFromQuaternionAndRotationMatrix(
   const T yA = e1 + e3, xA = e0 - e2;
   const T yB = e3 - e1, xB = e0 + e2;
   const T epsilon = Eigen::NumTraits<T>::epsilon();
-  const bool isSingularA = abs(yA) <= epsilon && abs(xA) <= epsilon;
-  const bool isSingularB = abs(yB) <= epsilon && abs(xB) <= epsilon;
-  const T zA = isSingularA ? 0.0 : atan2(yA, xA);
-  const T zB = isSingularB ? 0.0 : atan2(yB, xB);
+  const auto isSingularA = abs(yA) <= epsilon && abs(xA) <= epsilon;
+  const auto isSingularB = abs(yB) <= epsilon && abs(xB) <= epsilon;
+  const T zA = if_then_else(isSingularA, T{0.0}, atan2(yA, xA));
+  const T zB = if_then_else(isSingularB, T{0.0}, atan2(yB, xB));
   T q1 = zA - zB;  // First angle in rotation sequence.
   T q3 = zA + zB;  // Third angle in rotation sequence.
 
@@ -192,8 +191,8 @@ Vector3<T> CalcRollPitchYawFromQuaternionAndRotationMatrix(
 }
 
 template <typename T>
-bool RollPitchYaw<T>::IsNearlySameOrientation(const RollPitchYaw<T>& other,
-                                              double tolerance) const {
+boolean<T> RollPitchYaw<T>::IsNearlySameOrientation(
+    const RollPitchYaw<T>& other, double tolerance) const {
   // Note: When pitch is close to PI/2 or -PI/2, derivative calculations for
   // Euler angles can encounter numerical problems (dividing by nearly 0).
   // Although values of angles may "jump around" (difficult derivatives), the
@@ -225,9 +224,5 @@ void RollPitchYaw<T>::ThrowPitchAngleViolatesGimbalLockTolerance(
 }  // namespace math
 }  // namespace drake
 
-// Explicitly instantiate on non-symbolic scalar types.
-// TODO(Mitiguy) Ensure this class handles RollPitchYaw<symbolic::Expression>.
-// To enable symbolic expressions, remove _NONSYMBOLIC in next line.
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::math::RollPitchYaw)
-

--- a/math/roll_pitch_yaw.h
+++ b/math/roll_pitch_yaw.h
@@ -5,10 +5,10 @@
 
 #include <Eigen/Dense>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
-#include "drake/common/symbolic.h"
 
 namespace drake {
 namespace math {
@@ -57,9 +57,9 @@ class RotationMatrix;
 ///
 /// - double
 /// - AutoDiffXd
+/// - symbolic::Expression
 ///
 // TODO(@mitiguy) Add Sherm/Goldstein's way to visualize rotation sequences.
-// TODO(Mitiguy) Ensure this class handles RotationMatrix<symbolic::Expression>.
 template <typename T>
 class RollPitchYaw {
  public:
@@ -200,17 +200,14 @@ class RollPitchYaw {
     return ToRotationMatrix().matrix();
   }
 
-  // TODO(jwnimmer-tri) Nearly all of the bool-valued predicates ("IsFoo...")
-  // in this class should return boolean<T>, to be consistent with the
-  // RotationMatrix methods.
-
   /// Compares each element of `this` to the corresponding element of `other`
   /// to check if they are the same to within a specified `tolerance`.
   /// @param[in] other %RollPitchYaw to compare to `this`.
   /// @param[in] tolerance maximum allowable absolute difference between the
   /// matrix elements in `this` and `other`.
   /// @returns `true` if `‖this - other‖∞ <= tolerance`.
-  bool IsNearlyEqualTo(const RollPitchYaw<T>& other, double tolerance) const {
+  boolean<T> IsNearlyEqualTo(
+      const RollPitchYaw<T>& other, double tolerance) const {
     const Vector3<T> difference = vector() - other.vector();
     return difference.template lpNorm<Eigen::Infinity>() <= tolerance;
   }
@@ -221,12 +218,12 @@ class RollPitchYaw {
   /// @param[in] other %RollPitchYaw to compare to `this`.
   /// @param[in] tolerance maximum allowable absolute difference between R1, R2.
   /// @returns `true` if `‖R1 - R2‖∞ <= tolerance`.
-  bool IsNearlySameOrientation(const RollPitchYaw<T>& other,
-                               double tolerance) const;
+  boolean<T> IsNearlySameOrientation(const RollPitchYaw<T>& other,
+                                     double tolerance) const;
 
   /// Returns true if roll-pitch-yaw angles `[r, p, y]` are in the range
   /// `-π <= r <= π`, `-π/2 <= p <= π/2, `-π <= y <= π`.
-  bool IsRollPitchYawInCanonicalRange() const {
+  boolean<T> IsRollPitchYawInCanonicalRange() const {
     const T& r = roll_angle();
     const T& p = pitch_angle();
     const T& y = yaw_angle();
@@ -241,7 +238,7 @@ class RollPitchYaw {
   /// @param[in] cos_pitch_angle cosine of the pitch angle, i.e., `cos(p)`.
   /// @note Pitch-angles close to gimbal-lock can can cause problems with
   /// numerical precision and numerical integration.
-  static bool DoesCosPitchAngleViolateGimbalLockTolerance(
+  static boolean<T> DoesCosPitchAngleViolateGimbalLockTolerance(
       const T& cos_pitch_angle) {
     using std::abs;
     return abs(cos_pitch_angle) < kGimbalLockToleranceCosPitchAngle;
@@ -253,7 +250,7 @@ class RollPitchYaw {
   /// @note To improve efficiency when cos(pitch_angle()) is already calculated,
   /// instead use the function DoesCosPitchAngleViolateGimbalLockTolerance().
   /// @see DoesCosPitchAngleViolateGimbalLockTolerance()
-  bool DoesPitchAngleViolateGimbalLockTolerance() const {
+  boolean<T> DoesPitchAngleViolateGimbalLockTolerance() const {
     using std::cos;
     return DoesCosPitchAngleViolateGimbalLockTolerance(cos(pitch_angle()));
   }
@@ -268,7 +265,10 @@ class RollPitchYaw {
   /// Returns true if `rpy` contains valid roll, pitch, yaw angles.
   /// @param[in] rpy allegedly valid roll, pitch, yaw angles.
   /// @note an angle is invalid if it is NaN or infinite.
-  static bool IsValid(const Vector3<T>& rpy) { return rpy.allFinite(); }
+  static boolean<T> IsValid(const Vector3<T>& rpy) {
+    using std::isfinite;
+    return isfinite(rpy[0]) && isfinite(rpy[1]) && isfinite(rpy[2]);
+  }
 
   /// Forms Ṙ, the ordinary derivative of the %RotationMatrix `R` with respect
   /// to an independent variable `t` (`t` usually denotes time) and `R` is the


### PR DESCRIPTION
This the only major stumbling block for MultibodyTree to compile against symbolic::Expression (#10439).
