### PR TITLE
systems/lcm: Don't read past vector bounds with undersized messages

### DIFF
--- a/systems/lcm/lcm_subscriber_system.cc
+++ b/systems/lcm/lcm_subscriber_system.cc
@@ -136,7 +136,7 @@ void LcmSubscriberSystem::ProcessMessageAndStoreToDiscreteState(
       }
       auto& xd = discrete_state->get_mutable_vector(kStateIndexMessage);
       xd[0] = received_size;
-      for (int i = 0; i < fixed_encoded_size_; ++i) {
+      for (int i = 0; i < received_size; ++i) {
         xd[i + 1] = received_message_[i];
       }
     }


### PR DESCRIPTION
This repairs a bug in commit e199ed09b0a066cad912d5754f58f6baa2ac41c8 (#10485), as noted by ASan.

Closes #10498.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10499)
<!-- Reviewable:end -->
