### PR TITLE
Quiet logging noise when using messages

### DIFF
--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -1096,14 +1096,9 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     TakeShapeOwnership(fcl_box, user_data);
   }
 
-  void ImplementGeometry(const Mesh&, void* user_data) override {
-    // TODO(SeanCurtis-TRI): Replace this with a legitimate fcl mesh. This
-    // assumes that a zero-radius sphere has no interesting interactions with
-    // other meshes. However, it *does* increase the collision space. :(
-    auto fcl_sphere = make_shared<fcl::Sphered>(0.0);
-    TakeShapeOwnership(fcl_sphere, user_data);
+  void ImplementGeometry(const Mesh&, void*) override {
+    DRAKE_ABORT_MSG("The proximity engine does not support meshes yet");
   }
-
 
   //
   // Convert vertices from tinyobj format to FCL format.

--- a/geometry/shape_specification.cc
+++ b/geometry/shape_specification.cc
@@ -1,7 +1,5 @@
 #include "drake/geometry/shape_specification.h"
 
-#include "drake/common/text_logging.h"
-
 namespace drake {
 namespace geometry {
 
@@ -69,11 +67,7 @@ Box Box::MakeCube(double edge_size) {
 }
 
 Mesh::Mesh(const std::string& absolute_filename, double scale)
-    : Shape(ShapeTag<Mesh>()), filename_(absolute_filename), scale_(scale) {
-  // TODO(SeanCurtis-TRI): Remove this when meshes are properly supported.
-  drake::log()->warn("Meshes are only supported for drake_visualizer ({})",
-                     filename_);
-}
+    : Shape(ShapeTag<Mesh>()), filename_(absolute_filename), scale_(scale) {}
 
 Convex::Convex(const std::string& absolute_filename, double scale)
     : Shape(ShapeTag<Convex>()), filename_(absolute_filename), scale_(scale) {}

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -2386,6 +2386,24 @@ TEST_F(GeometryStateTest, RoleAssignExceptions) {
       "role.");
 }
 
+// Confirms that assigning a proximity role to a mesh is a no-op. If it
+// *weren't* no-op, the ProximityEngine would abort; so not aborting is
+// correlated with its no-op-ness. This test will go away when meshes are fully
+// supported in collision.
+TEST_F(GeometryStateTest, ProximityRoleOnMesh) {
+  SetUpSingleSourceTree();
+
+  // Add a mesh to a frame.
+  GeometryId mesh_id = geometry_state_.RegisterGeometry(
+      source_id_, frames_[0],
+      make_unique<GeometryInstance>(Isometry3d::Identity(),
+                                    make_unique<Mesh>("path", 1.0), "mesh"));
+  const InternalGeometry* mesh = gs_tester_.GetGeometry(mesh_id);
+  ASSERT_FALSE(mesh->has_proximity_role());
+  geometry_state_.AssignRole(source_id_, mesh_id, ProximityProperties());
+  ASSERT_FALSE(mesh->has_proximity_role());
+}
+
 // Tests the functionality that counts the number of children geometry a frame
 // has for each role.
 TEST_F(GeometryStateTest, ChildGeometryRoleCount) {

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -2283,6 +2283,29 @@ TEST_F(BoxPenetrationTest, TangentConvex2) {
   TestCollision2(TangentConvex, 1e-3);
 }
 
+// Attempting to add a dynamic Mesh should cause an abort.
+GTEST_TEST(ProximityEngineTests, AddDynamicMesh) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  ProximityEngine<double> engine;
+  Mesh mesh{"invalid/path/thing.obj", 1.0};
+  ASSERT_DEATH(
+      engine.AddDynamicGeometry(mesh, GeometryIndex(0)),
+      "abort: .*proximity_engine.*"
+      "The proximity engine does not support meshes yet.*");
+}
+
+// Attempting to add a anchored Mesh should cause an abort.
+GTEST_TEST(ProximityEngineTests, AddAnchoredMesh) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  ProximityEngine<double> engine;
+  Mesh mesh{"invalid/path/thing.obj", 1.0};
+  ASSERT_DEATH(
+      engine.AddAnchoredGeometry(mesh, Isometry3d::Identity(),
+                                 GeometryIndex(0)),
+      "abort: .*proximity_engine.*"
+      "The proximity engine does not support meshes yet.*");
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace geometry


### PR DESCRIPTION
Previously, every creation of a mesh would spew a warning that meshes were only supported by drake_visualizer. This has become overly noisy and anachronistic. This changes things to only complain if one attempts to assign the proximity role on the mesh geometry. No proximity role --> no warnings.

```
Category            added  modified  removed  
----------------------------------------------
code                59     3         5        
comments            11     0         4        
blank               7      0         2        
----------------------------------------------
TOTAL               77     3         11 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10515)
<!-- Reviewable:end -->
