### PR TITLE
vector_gen: Add read-only View subclass

### DIFF
--- a/examples/pendulum/pendulum_plant.cc
+++ b/examples/pendulum/pendulum_plant.cc
@@ -12,7 +12,9 @@ template <typename T>
 PendulumPlant<T>::PendulumPlant()
     : systems::LeafSystem<T>(
           systems::SystemTypeTag<pendulum::PendulumPlant>{}) {
-  this->DeclareVectorInputPort("tau", PendulumInput<T>());
+  this->DeclareVectorInputPort(
+      "tau",
+      systems::BasicVector<T>{PendulumInputIndices::kNumCoordinates});
   this->DeclareVectorOutputPort("state", &PendulumPlant::CopyStateOut,
                                 {this->all_state_ticket()});
   this->DeclareContinuousState(PendulumState<T>(), 1 /* num_q */, 1 /* num_v */,

--- a/examples/pendulum/pendulum_plant.h
+++ b/examples/pendulum/pendulum_plant.h
@@ -50,7 +50,8 @@ class PendulumPlant final : public systems::LeafSystem<T> {
   /// Evaluates the input port and returns the scalar value
   /// of the commanded torque.
   T get_tau(const systems::Context<T>& context) const {
-    return this->get_input_port().Eval(context)(0);
+    const auto& port = this->get_input_port();
+    return PendulumInputView<T>(port.Eval(context)).tau();
   }
 
   static const PendulumState<T>& get_state(

--- a/systems/estimators/test/luenberger_observer_test.cc
+++ b/systems/estimators/test/luenberger_observer_test.cc
@@ -93,8 +93,7 @@ GTEST_TEST(LuenbergerObserverTest, DerivedTypes) {
 
   // The second input is the input of the plant.
   auto input1 = observer->AllocateInputVector(observer->get_input_port(1));
-  EXPECT_TRUE(is_dynamic_castable<examples::pendulum::PendulumInput<double>>(
-      input1.get()));
+  EXPECT_EQ(input1->size(), 1);
 
   // Would love to make the state and output have type PendulumState, but it
   // is not that way yet (see #6998).

--- a/tools/vector_gen/test/goal/sample.cc
+++ b/tools/vector_gen/test/goal/sample.cc
@@ -1,5 +1,9 @@
 #include "drake/tools/vector_gen/test/gen/sample.h"
 
+#include <stdexcept>
+
+#include <fmt/format.h>
+
 // GENERATED GOAL DO NOT EDIT
 // See drake/tools/lcm_vector_gen.py.
 
@@ -24,6 +28,13 @@ const std::vector<std::string>& SampleIndices::GetCoordinateNames() {
   return coordinates.access();
 }
 
+void SampleIndices::ThrowIfWrongSize(int size) {
+  if (size != kNumCoordinates) {
+    throw std::logic_error(fmt::format(
+        "SampleIndices: wanted a vector of size {}, but got size {}",
+        kNumCoordinates, size));
+  }
+}
 }  // namespace test
 }  // namespace tools
 }  // namespace drake


### PR DESCRIPTION
Use generated view for `PendulumInput` as an example.  For the pendulum, we don't need to enforce runtime type checking of its input value -- any 1-d vector value should be acceptable.

Relates #9497, #9620.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10520)
<!-- Reviewable:end -->
