### PR TITLE
snopt: Fix two data races

### DIFF
--- a/solvers/test/snopt_solver_test.cc
+++ b/solvers/test/snopt_solver_test.cc
@@ -1,6 +1,8 @@
 #include "drake/solvers/snopt_solver.h"
 
+#include <fstream>
 #include <iostream>
+#include <regex>
 
 #include <gtest/gtest.h>
 #include <spruce.hh>
@@ -189,6 +191,118 @@ GTEST_TEST(SnoptTest, DistanceToTetrahedron) {
   EXPECT_TRUE(
       ((prog.A_tetrahedron() * p_BQ).array() <= prog.b_tetrahedron().array())
           .all());
+}
+
+// Test if we can run several snopt solvers simultaneously on multiple threads.
+// We create a convex QP problem with a unique global optimal, starting from
+// different initial guesses, snopt should output the same result.
+// min (x₀-1)² + (x₁-2)²
+// s.t x₀ + x₁ = 1
+// The optimal solution is x*=(0, 1)
+GTEST_TEST(SnoptTest, MultiThreadTest) {
+  // Skip this test when SNOPT does not support multi-threading.
+  if (!SnoptSolver::is_thread_safe()) {
+    return;
+  }
+
+  // Formulate the problem (shared by all threads).
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<2>();
+  const Eigen::Vector2d c(1, 2);
+  prog.AddQuadraticCost((x - c).squaredNorm());
+  prog.AddLinearConstraint(x(0) + x(1) == 1);
+  const MathematicalProgram& const_prog = prog;
+
+  // Each thread will have its own distinct data.
+  struct PerThreadData {
+    // Input
+    Eigen::Vector2d x_init;
+    std::string print_file;
+    // Output
+    MathematicalProgramResult result;
+  };
+
+  // We first will solve each guess one at a time, and then solve them all in
+  // parallel.  The two sets of results should match.
+  const int num_threads = 10;
+  std::vector<PerThreadData> single_threaded(num_threads);
+  std::vector<PerThreadData> multi_threaded(num_threads);
+
+  // Set up the arbitrary initial guesses and print file names.
+  const std::string temp_dir = temp_directory();
+  for (int i = 0; i < num_threads; ++i) {
+    const Eigen::Vector2d guess_i(i + 1, (i - 2.0) / 10);
+    single_threaded[i].x_init = guess_i;
+    multi_threaded[i].x_init = guess_i;
+    single_threaded[i].print_file = fmt::format(
+        "{}/snopt_single_thread_{}.out", temp_dir, i);
+    multi_threaded[i].print_file =  fmt::format(
+        "{}/snopt_multi_thread_{}.out", temp_dir, i);
+  }
+
+  // Create a functor that solves the problem.
+  const SnoptSolver snopt_solver;
+  auto run_solver = [&snopt_solver, &const_prog](PerThreadData* thread_data) {
+    SolverOptions options;
+    options.SetOption(SnoptSolver::id(), "Print file", thread_data->print_file);
+    snopt_solver.Solve(const_prog, {thread_data->x_init}, options,
+                       &thread_data->result);
+  };
+
+  // Solve without using threads.
+  for (int i = 0; i < num_threads; ++i) {
+    run_solver(&single_threaded[i]);
+  }
+
+  // Solve using threads.
+  std::vector<std::thread> test_threads;
+  for (int i = 0; i < num_threads; ++i) {
+    test_threads.emplace_back(run_solver, &multi_threaded[i]);
+  }
+  for (int i = 0; i < num_threads; ++i) {
+    test_threads[i].join();
+  }
+
+  // All solutions should be the same.
+  for (int i = 0; i < num_threads; ++i) {
+    // The MathematicalProgramResult should meet tolerances.
+    for (const auto& per_thread_data_vec : {single_threaded, multi_threaded}) {
+      const auto& result = per_thread_data_vec[i].result;
+      EXPECT_EQ(result.get_solution_result(), drake::solvers::kSolutionFound);
+      EXPECT_TRUE(CompareMatrices(
+          result.get_x_val(), Eigen::Vector2d(0, 1), 1E-6));
+      EXPECT_NEAR(result.get_optimal_cost(), 2, 1E-6);
+      // TODO(jwnimmer-tri) Once we port SnoptSolverDetails from Anzu to Drake,
+      // then we should check that EXPECT_EQ(details.snopt_status, 1) here.
+    }
+
+    // The print file contents should be the same for single vs multi.
+    std::string contents_single;
+    {
+      std::ifstream input(single_threaded[i].print_file, std::ios::binary);
+      ASSERT_TRUE(input);
+      std::stringstream buffer;
+      buffer << input.rdbuf();
+      contents_single = buffer.str();
+    }
+    std::string contents_multi;
+    {
+      std::ifstream input(multi_threaded[i].print_file, std::ios::binary);
+      ASSERT_TRUE(input);
+      std::stringstream buffer;
+      buffer << input.rdbuf();
+      contents_multi = buffer.str();
+    }
+    for (auto* contents : {&contents_single, &contents_multi}) {
+      // Scrub some volatile text output.
+      *contents = std::regex_replace(
+          *contents, std::regex("..... seconds"), "##### seconds");
+      *contents = std::regex_replace(
+          *contents, std::regex(".Printer........................\\d"),
+          "(Printer)..............      ####");
+    }
+    EXPECT_EQ(contents_single, contents_multi);
+  }
 }
 
 }  // namespace test

--- a/tools/workspace/snopt/fortran-macos.bzl
+++ b/tools/workspace/snopt/fortran-macos.bzl
@@ -23,7 +23,7 @@ def fortran_library(
             srcs = [src],
             outs = [public_obj],
             tools = [compiler],
-            cmd = "$(location {}) -fPIC -c $< -o $@".format(compiler),
+            cmd = "$(location {}) -fopenmp -fPIC -c $< -o $@".format(compiler),
             visibility = ["//visibility:private"],
         )
         private_obj = "hidden_" + src + ".pic.o"

--- a/tools/workspace/snopt/fortran-ubuntu.bzl
+++ b/tools/workspace/snopt/fortran-ubuntu.bzl
@@ -23,7 +23,7 @@ def fortran_library(
             srcs = [src],
             outs = [obj],
             tools = [compiler],
-            cmd = "$(location {}) -fPIC -c $< -o $@".format(compiler),
+            cmd = "$(location {}) -fopenmp -fPIC -c $< -o $@".format(compiler),
             visibility = ["//visibility:private"],
         )
 

--- a/tools/workspace/snopt/snopt-openmp.patch
+++ b/tools/workspace/snopt/snopt-openmp.patch
@@ -1,0 +1,13 @@
+We patch the snopt_interface to mark the character workspace as threadprivate.
+Otherwise, solving distinct problems in multiple threads still has data races.
+
+--- interfaces/src/snopt_wrapper.f90.orig	2019-01-28 17:12:02.415160931 -0500
++++ interfaces/src/snopt_wrapper.f90	2019-01-28 17:10:52.610244839 -0500
+@@ -192,6 +192,7 @@
+   ! Character arrays don't work well with Fortran/C/C++ so have a dummy one here.
+   integer, parameter :: lencw = 500
+   character*8        :: cw(lencw)
++!$OMP THREADPRIVATE(cw)
+ 
+ contains
+ 


### PR DESCRIPTION
Otherwise, solving distinct problems in multiple threads still has data races (because they'd all read and write to the same character workspace).

Relates #4893.

I've submitted the fortran patch upsteam as snopt/snopt-interface#26, but we'll still need to apply the patch as per this PR, because in general user builds won't always have the latest upstream sources.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10522)
<!-- Reviewable:end -->
