### PR TITLE
py controllers: Separate out attic components

### DIFF
--- a/bindings/pydrake/attic/systems/BUILD.bazel
+++ b/bindings/pydrake/attic/systems/BUILD.bazel
@@ -36,6 +36,7 @@ drake_pybind_library(
     cc_srcs = ["sensors_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
+        "//bindings/pydrake/multibody:rigid_body_tree_py",
         "//bindings/pydrake/systems:sensors_py",
     ],
 )

--- a/bindings/pydrake/attic/systems/BUILD.bazel
+++ b/bindings/pydrake/attic/systems/BUILD.bazel
@@ -31,6 +31,20 @@ drake_py_library(
 )
 
 drake_pybind_library(
+    name = "controllers_py",
+    cc_deps = [
+        "//bindings/pydrake:documentation_pybind",
+    ],
+    cc_srcs = ["controllers_py.cc"],
+    package_info = PACKAGE_INFO,
+    py_deps = [
+        ":module_py",
+        "//bindings/pydrake/attic/multibody:rigid_body_tree_py",
+        "//bindings/pydrake/systems:framework_py",
+    ],
+)
+
+drake_pybind_library(
     name = "sensors_py",
     cc_deps = ["//bindings/pydrake:documentation_pybind"],
     cc_srcs = ["sensors_py.cc"],
@@ -42,6 +56,7 @@ drake_pybind_library(
 )
 
 PY_LIBRARIES_WITH_INSTALL = [
+    ":controllers_py",
     ":sensors_py",
 ]
 

--- a/bindings/pydrake/attic/systems/all.py
+++ b/bindings/pydrake/attic/systems/all.py
@@ -1,1 +1,2 @@
+from .controllers import *
 from .sensors import *

--- a/bindings/pydrake/attic/systems/controllers_py.cc
+++ b/bindings/pydrake/attic/systems/controllers_py.cc
@@ -1,0 +1,59 @@
+#include "pybind11/eigen.h"
+#include "pybind11/pybind11.h"
+
+#include "drake/bindings/pydrake/documentation_pybind.h"
+#include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/multibody/rigid_body_tree.h"
+#include "drake/systems/controllers/rbt_inverse_dynamics.h"
+#include "drake/systems/controllers/rbt_inverse_dynamics_controller.h"
+
+namespace drake {
+namespace pydrake {
+
+PYBIND11_MODULE(controllers, m) {
+  // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
+  using namespace drake::systems::controllers;
+  constexpr auto& doc = pydrake_doc.drake.systems.controllers;
+  using drake::systems::Diagram;
+  using drake::systems::LeafSystem;
+
+  py::module::import("pydrake.attic.multibody.rigid_body_tree");
+  py::module::import("pydrake.systems.framework");
+
+  py::class_<rbt::InverseDynamics<double>, LeafSystem<double>> rbt_idyn(
+      m, "RbtInverseDynamics", doc.rbt.InverseDynamics.doc);
+  rbt_idyn  // BR
+      .def(py::init<const RigidBodyTree<double>*,
+               rbt::InverseDynamics<double>::InverseDynamicsMode>(),
+          py::arg("tree"), py::arg("mode"), doc.rbt.InverseDynamics.ctor.doc)
+      .def("is_pure_gravity_compensation",
+          &rbt::InverseDynamics<double>::is_pure_gravity_compensation,
+          doc.rbt.InverseDynamics.is_pure_gravity_compensation.doc);
+
+  py::enum_<rbt::InverseDynamics<double>::InverseDynamicsMode>(  // BR
+      rbt_idyn, "InverseDynamicsMode")
+      .value("kInverseDynamics", rbt::InverseDynamics<double>::kInverseDynamics,
+          doc.rbt.InverseDynamics.InverseDynamicsMode.doc)
+      .value("kGravityCompensation",
+          rbt::InverseDynamics<double>::kGravityCompensation,
+          doc.rbt.InverseDynamics.InverseDynamicsMode.kGravityCompensation.doc)
+      .export_values();
+
+  py::class_<rbt::InverseDynamicsController<double>, Diagram<double>>(
+      m, "RbtInverseDynamicsController", doc.rbt.InverseDynamicsController.doc)
+      .def(py::init<std::unique_ptr<RigidBodyTree<double>>,
+               const VectorX<double>&, const VectorX<double>&,
+               const VectorX<double>&, bool>(),
+          py::arg("robot"), py::arg("kp"), py::arg("ki"), py::arg("kd"),
+          py::arg("has_reference_acceleration"),
+          // Keep alive, ownership: RigidBodyTree keeps this alive.
+          // See "Keep Alive Behavior" in pydrake_pybind.h for details.
+          py::keep_alive<2 /* Nurse */, 1 /* Patient */>(),
+          doc.rbt.InverseDynamicsController.ctor.doc)
+      .def("set_integral_value",
+          &rbt::InverseDynamicsController<double>::set_integral_value,
+          doc.rbt.InverseDynamicsController.set_integral_value.doc);
+}
+
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -171,7 +171,6 @@ drake_pybind_library(
     py_deps = [
         ":framework_py",
         ":module_py",
-        "//bindings/pydrake/multibody:rigid_body_tree_py",
         "//bindings/pydrake/common:cpp_template_py",
         "//bindings/pydrake/common:eigen_geometry_py",
     ],

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -137,7 +137,9 @@ drake_pybind_library(
         ":primitives_py",
         "//bindings/pydrake:math_py",
         "//bindings/pydrake:symbolic_py",
+        "//bindings/pydrake/multibody:multibody_tree_py",
     ],
+    py_srcs = ["_controllers_extra.py"],
 )
 
 drake_pybind_library(
@@ -383,6 +385,7 @@ drake_py_unittest(
     ],
     deps = [
         ":controllers_py",
+        "//bindings/pydrake/attic/systems:controllers_py",
         "//bindings/pydrake/examples:pendulum_py",
         "//bindings/pydrake/multibody:multibody_tree_py",
         "//bindings/pydrake/multibody:rigid_body_tree_py",

--- a/bindings/pydrake/systems/_controllers_extra.py
+++ b/bindings/pydrake/systems/_controllers_extra.py
@@ -1,0 +1,1 @@
+from pydrake.attic.systems.controllers import *

--- a/bindings/pydrake/systems/controllers_py.cc
+++ b/bindings/pydrake/systems/controllers_py.cc
@@ -28,6 +28,7 @@ PYBIND11_MODULE(controllers, m) {
   constexpr auto& doc = pydrake_doc.drake.systems.controllers;
 
   py::module::import("pydrake.math");
+  py::module::import("pydrake.multibody.plant");
   py::module::import("pydrake.symbolic");
   py::module::import("pydrake.systems.framework");
   py::module::import("pydrake.systems.primitives");
@@ -53,44 +54,6 @@ PYBIND11_MODULE(controllers, m) {
       .def_readwrite("visualization_callback",
           &DynamicProgrammingOptions::visualization_callback,
           doc.DynamicProgrammingOptions.visualization_callback.doc);
-
-  // The RBT flavor of inverse dynamics.
-
-  py::class_<rbt::InverseDynamics<double>, LeafSystem<double>> rbt_idyn(
-      m, "RbtInverseDynamics", doc.rbt.InverseDynamics.doc);
-  rbt_idyn  // BR
-      .def(py::init<const RigidBodyTree<double>*,
-               rbt::InverseDynamics<double>::InverseDynamicsMode>(),
-          py::arg("tree"), py::arg("mode"), doc.rbt.InverseDynamics.ctor.doc)
-      .def("is_pure_gravity_compensation",
-          &rbt::InverseDynamics<double>::is_pure_gravity_compensation,
-          doc.rbt.InverseDynamics.is_pure_gravity_compensation.doc);
-
-  py::enum_<rbt::InverseDynamics<double>::InverseDynamicsMode>(  // BR
-      rbt_idyn, "InverseDynamicsMode")
-      .value("kInverseDynamics", rbt::InverseDynamics<double>::kInverseDynamics,
-          doc.rbt.InverseDynamics.InverseDynamicsMode.doc)
-      .value("kGravityCompensation",
-          rbt::InverseDynamics<double>::kGravityCompensation,
-          doc.rbt.InverseDynamics.InverseDynamicsMode.kGravityCompensation.doc)
-      .export_values();
-
-  py::class_<rbt::InverseDynamicsController<double>, Diagram<double>>(
-      m, "RbtInverseDynamicsController", doc.rbt.InverseDynamicsController.doc)
-      .def(py::init<std::unique_ptr<RigidBodyTree<double>>,
-               const VectorX<double>&, const VectorX<double>&,
-               const VectorX<double>&, bool>(),
-          py::arg("robot"), py::arg("kp"), py::arg("ki"), py::arg("kd"),
-          py::arg("has_reference_acceleration"),
-          // Keep alive, ownership: RigidBodyTree keeps this alive.
-          // See "Keep Alive Behavior" in pydrake_pybind.h for details.
-          py::keep_alive<2 /* Nurse */, 1 /* Patient */>(),
-          doc.rbt.InverseDynamicsController.ctor.doc)
-      .def("set_integral_value",
-          &rbt::InverseDynamicsController<double>::set_integral_value,
-          doc.rbt.InverseDynamicsController.set_integral_value.doc);
-
-  // The MBP flavor of inverse dynamics.
 
   py::class_<InverseDynamics<double>, LeafSystem<double>> idyn(
       m, "InverseDynamics", doc.InverseDynamics.doc);
@@ -172,6 +135,8 @@ PYBIND11_MODULE(controllers, m) {
       py::arg("system"), py::arg("context"), py::arg("Q"), py::arg("R"),
       py::arg("N") = Eigen::Matrix<double, 0, 0>::Zero(),
       doc.LinearQuadraticRegulator.doc_5args_system_context_Q_R_N);
+
+  ExecuteExtraPythonCode(m);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/systems/sensors_py.cc
+++ b/bindings/pydrake/systems/sensors_py.cc
@@ -46,8 +46,8 @@ PYBIND11_MODULE(sensors, m) {
 
   m.doc() = "Bindings for the sensors portion of the Systems framework.";
 
-  py::module::import("pydrake.systems.framework");
   py::module::import("pydrake.common.eigen_geometry");
+  py::module::import("pydrake.systems.framework");
 
   // Expose only types that are used.
   py::enum_<PixelFormat>(m, "PixelFormat")

--- a/bindings/pydrake/test/all_test.py
+++ b/bindings/pydrake/test/all_test.py
@@ -79,6 +79,8 @@ class TestAll(unittest.TestCase):
             # - solvers
             "RigidBodyConstraint",
             # - systems
+            # - - controllers
+            "RbtInverseDynamics",
             # - - sensors
             "RgbdCamera",
             # autodiffutils
@@ -153,6 +155,8 @@ class TestAll(unittest.TestCase):
             "LeafSystem",
             # - analysis
             "Simulator",
+            # - controllers
+            "InverseDynamics",
             # - lcm
             "PySerializer",
             # - primitives


### PR DESCRIPTION
Address `controllers` checkbox in #10207

After this, outside of `pydrake/attic`, the only explicitly declared dependencies on any `rigid_body(\w*)_py` targets are test-only items (and `rgbd_camera_example.py` - which can be considered a usage)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10523)
<!-- Reviewable:end -->
