### PR TITLE
[geometry] Fix geometry removal bug - geometry with no proximity role

### DIFF
--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -864,9 +864,11 @@ void GeometryState<T>::RemoveGeometryUnchecked(GeometryId geometry_id,
     // removed_index.
     InternalGeometry& moved_geometry =
         geometries_[geometry_index_to_id_map_[removed_index]];
-    geometry_engine_->UpdateGeometryIndex(moved_geometry.proximity_index(),
-                                          moved_geometry.is_dynamic(),
-                                          removed_index);
+    if (moved_geometry.has_proximity_role()) {
+      geometry_engine_->UpdateGeometryIndex(moved_geometry.proximity_index(),
+                                            moved_geometry.is_dynamic(),
+                                            removed_index);
+    }
   }
 
   if (geometry.has_proximity_role()) {

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -1259,6 +1259,21 @@ TEST_F(GeometryStateTest, RemoveGeometry) {
   geometry_state_.RemoveGeometry(s_id, added_id);
   // Confirm that, post removal, updating poses still works.
   EXPECT_NO_THROW(gs_tester_.FinalizePoseUpdate());
+
+  // Test the case where a geometry gets re-ordered, but it has no roles. To
+  // make sure the geometry moves, it needs to _not_ be the last added geometry.
+  // So, we add the geometry we're going to remove _and_ an additional geometry
+  // after it.
+  GeometryId no_role_id = geometry_state_.RegisterGeometry(
+      source_id_, frames_[0],
+      make_unique<GeometryInstance>(
+          Isometry3d::Identity(), make_unique<Sphere>(1), "no_role_geometry"));
+  geometry_state_.RegisterGeometry(
+      source_id_, frames_[0],
+      make_unique<GeometryInstance>(
+          Isometry3d::Identity(), make_unique<Sphere>(1), "no_role_geometry2"));
+  EXPECT_NO_THROW(geometry_state_.RemoveGeometry(s_id, no_role_id));
+  EXPECT_NO_THROW(gs_tester_.FinalizePoseUpdate());
 }
 
 // Tests the RemoveGeometry functionality in which the geometry removed has


### PR DESCRIPTION
Removing a geometry without proximity properties would attempt to blindly remove the geometry from the engine. The engine doesn't respond well to that. The guard is in the GeometryState -- no proximity properties means no proximity engine processing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10530)
<!-- Reviewable:end -->
