### PR TITLE
pydrake: Use new `attic` and `multibody` spellings

### DIFF
--- a/bindings/pydrake/examples/multibody/cart_pole_passive_simulation.py
+++ b/bindings/pydrake/examples/multibody/cart_pole_passive_simulation.py
@@ -5,8 +5,8 @@ import argparse
 from pydrake.common import FindResourceOrThrow
 from pydrake.geometry import (ConnectDrakeVisualizer, SceneGraph)
 from pydrake.lcm import DrakeLcm
-from pydrake.multibody.multibody_tree import UniformGravityFieldElement
-from pydrake.multibody.multibody_tree.multibody_plant import MultibodyPlant
+from pydrake.multibody.tree import UniformGravityFieldElement
+from pydrake.multibody.plant import MultibodyPlant
 from pydrake.multibody.parsing import Parser
 from pydrake.systems.framework import DiagramBuilder
 from pydrake.systems.analysis import Simulator

--- a/bindings/pydrake/examples/test/manipulation_station_test.py
+++ b/bindings/pydrake/examples/test/manipulation_station_test.py
@@ -9,8 +9,8 @@ from pydrake.examples.manipulation_station import (
     ManipulationStationHardwareInterface
 )
 from pydrake.math import RigidTransform
-from pydrake.multibody.multibody_tree.multibody_plant import MultibodyPlant
-from pydrake.multibody.multibody_tree import ModelInstanceIndex
+from pydrake.multibody.plant import MultibodyPlant
+from pydrake.multibody.tree import ModelInstanceIndex
 from pydrake.multibody.parsing import Parser
 
 

--- a/bindings/pydrake/manipulation/simple_ui.py
+++ b/bindings/pydrake/manipulation/simple_ui.py
@@ -9,8 +9,8 @@ except ImportError:
     import Tkinter as tk
 import numpy as np
 
-from pydrake.multibody.multibody_tree.multibody_plant import MultibodyPlant
-from pydrake.multibody.multibody_tree import JointIndex
+from pydrake.multibody.plant import MultibodyPlant
+from pydrake.multibody.tree import JointIndex
 from pydrake.systems.framework import BasicVector, LeafSystem, VectorSystem
 
 

--- a/bindings/pydrake/manipulation/test/planner_test.py
+++ b/bindings/pydrake/manipulation/test/planner_test.py
@@ -6,7 +6,7 @@ import unittest
 import numpy as np
 
 from pydrake.common import FindResourceOrThrow
-from pydrake.multibody.multibody_tree.multibody_plant import MultibodyPlant
+from pydrake.multibody.plant import MultibodyPlant
 from pydrake.multibody.parsing import Parser
 from pydrake.common.eigen_geometry import Isometry3
 

--- a/bindings/pydrake/manipulation/test/simple_ui_test.py
+++ b/bindings/pydrake/manipulation/test/simple_ui_test.py
@@ -11,7 +11,7 @@ except ImportError:
     import Tkinter as tk
 
 from pydrake.common import FindResourceOrThrow
-from pydrake.multibody.multibody_tree.multibody_plant import MultibodyPlant
+from pydrake.multibody.plant import MultibodyPlant
 from pydrake.multibody.parsing import Parser
 from pydrake.systems.framework import BasicVector
 

--- a/bindings/pydrake/multibody/test/inverse_kinematics_test.py
+++ b/bindings/pydrake/multibody/test/inverse_kinematics_test.py
@@ -10,7 +10,7 @@ from numpy.linalg import norm
 from pydrake.common import FindResourceOrThrow
 from pydrake.common.eigen_geometry import Quaternion, AngleAxis, Isometry3
 from pydrake.math import RotationMatrix
-from pydrake.multibody.multibody_tree.multibody_plant import (
+from pydrake.multibody.plant import (
     MultibodyPlant, AddMultibodyPlantSceneGraph)
 from pydrake.multibody.parsing import Parser
 from pydrake.multibody.benchmarks.acrobot import (

--- a/bindings/pydrake/multibody/test/multibody_tree_test.py
+++ b/bindings/pydrake/multibody/test/multibody_tree_test.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 
-from pydrake.multibody.multibody_tree import (
+from pydrake.multibody.tree import (
     Body,
     BodyFrame,
     BodyIndex,
-    BodyNodeIndex,  # Deprecated
     ForceElement,
     ForceElementIndex,
     Frame,
@@ -14,37 +13,37 @@ from pydrake.multibody.multibody_tree import (
     JointActuator,
     JointActuatorIndex,
     JointIndex,
-    MobilizerIndex,  # Deprecated
     ModelInstanceIndex,
     MultibodyForces,
-    MultibodyTree,  # Deprecated
     RevoluteJoint,
     UniformGravityFieldElement,
     WeldJoint,
     world_index,
 )
-
-from pydrake.multibody.multibody_tree.math import (
+from pydrake.multibody.math import (
     SpatialAcceleration,
     SpatialVelocity,
 )
-from pydrake.multibody.multibody_tree.multibody_plant import (
+from pydrake.multibody.plant import (
     AddMultibodyPlantSceneGraph,
     ContactResults,
     MultibodyPlant,
     PointPairContactInfo,
 )
-from pydrake.multibody.multibody_tree.parsing import (
-    AddModelFromSdfFile,
-)
-from pydrake.multibody.parsing import (
-    Parser,
-)
+from pydrake.multibody.parsing import Parser
 from pydrake.multibody.benchmarks.acrobot import (
     AcrobotParameters,
     MakeAcrobotPlant,
 )
+# Soon to be deprecated modules.
+from pydrake.multibody.multibody_tree import (
+    BodyNodeIndex,
+    MobilizerIndex,
+    MultibodyTree,
+)
+from pydrake.multibody.multibody_tree.parsing import AddModelFromSdfFile
 
+from pydrake.common.eigen_geometry import Isometry3
 from pydrake.geometry import (
     GeometryId,
     PenetrationAsPointPair,
@@ -52,14 +51,6 @@ from pydrake.geometry import (
     SceneGraph,
 )
 from pydrake.systems.framework import DiagramBuilder
-
-# Test new module layout.
-# TODO(eric.cousineau): Use only these modules once the old modules are
-# deprecated.
-import pydrake.multibody.math
-import pydrake.multibody.tree
-import pydrake.multibody.plant
-
 
 import copy
 import math

--- a/bindings/pydrake/multibody/test/parsers_test.py
+++ b/bindings/pydrake/multibody/test/parsers_test.py
@@ -5,8 +5,8 @@ import os.path
 
 from pydrake import getDrakePath
 from pydrake.common import FindResourceOrThrow
-from pydrake.multibody.parsers import PackageMap
-from pydrake.multibody.rigid_body_tree import (
+from pydrake.attic.multibody.parsers import PackageMap
+from pydrake.attic.multibody.rigid_body_tree import (
     AddModelInstanceFromUrdfFile,
     AddModelInstanceFromUrdfStringSearchingInRosPackages,
     AddModelInstancesFromSdfFile,

--- a/bindings/pydrake/multibody/test/parsing_test.py
+++ b/bindings/pydrake/multibody/test/parsing_test.py
@@ -9,10 +9,10 @@ import os
 import unittest
 
 from pydrake.common import FindResourceOrThrow
-from pydrake.multibody.multibody_tree import (
+from pydrake.multibody.tree import (
     ModelInstanceIndex,
 )
-from pydrake.multibody.multibody_tree.multibody_plant import (
+from pydrake.multibody.plant import (
     MultibodyPlant,
 )
 

--- a/bindings/pydrake/multibody/test/rigid_body_plant_test.py
+++ b/bindings/pydrake/multibody/test/rigid_body_plant_test.py
@@ -2,12 +2,14 @@ import numpy as np
 import os
 import unittest
 
-import pydrake.multibody.rigid_body_plant as mut
+import pydrake.attic.multibody.rigid_body_plant as mut
 
 from pydrake.common import FindResourceOrThrow
 from pydrake.lcm import DrakeMockLcm
 from pydrake.systems.framework import BasicVector
-from pydrake.multibody.rigid_body_tree import RigidBodyTree, FloatingBaseType
+from pydrake.attic.multibody.rigid_body_tree import (
+    RigidBodyTree, FloatingBaseType
+)
 
 
 class TestRigidBodyPlant(unittest.TestCase):

--- a/bindings/pydrake/multibody/test/rigid_body_tree_test.py
+++ b/bindings/pydrake/multibody/test/rigid_body_tree_test.py
@@ -9,17 +9,17 @@ import pydrake
 from pydrake.autodiffutils import AutoDiffXd
 from pydrake.common import FindResourceOrThrow
 from pydrake.forwarddiff import jacobian
-from pydrake.multibody.collision import CollisionElement
-from pydrake.multibody.joints import PrismaticJoint, RevoluteJoint
-from pydrake.multibody.parsers import PackageMap
-from pydrake.multibody.rigid_body import RigidBody
-from pydrake.multibody.rigid_body_tree import (
+from pydrake.attic.multibody.collision import CollisionElement
+from pydrake.attic.multibody.joints import PrismaticJoint, RevoluteJoint
+from pydrake.attic.multibody.parsers import PackageMap
+from pydrake.attic.multibody.rigid_body import RigidBody
+from pydrake.attic.multibody.rigid_body_tree import (
     AddFlatTerrainToWorld,
     RigidBodyFrame,
     RigidBodyTree,
     FloatingBaseType
     )
-import pydrake.multibody.shapes as shapes
+import pydrake.attic.multibody.shapes as shapes
 from pydrake.common.eigen_geometry import Isometry3
 
 

--- a/bindings/pydrake/multibody/test/shapes_test.py
+++ b/bindings/pydrake/multibody/test/shapes_test.py
@@ -4,7 +4,7 @@ import unittest
 import numpy as np
 
 import pydrake
-from pydrake.multibody import shapes
+from pydrake.attic.multibody import shapes
 from pydrake.common.eigen_geometry import Isometry3
 
 

--- a/bindings/pydrake/solvers/test/pr2_ik_test.py
+++ b/bindings/pydrake/solvers/test/pr2_ik_test.py
@@ -3,14 +3,14 @@ from __future__ import absolute_import, division, print_function
 import os
 import numpy as np
 import pydrake
-from pydrake.multibody.parsers import PackageMap
-from pydrake.multibody.rigid_body_tree import (
+from pydrake.attic.multibody.parsers import PackageMap
+from pydrake.attic.multibody.rigid_body_tree import (
     AddModelInstanceFromUrdfStringSearchingInRosPackages,
     FloatingBaseType,
     RigidBodyFrame,
     RigidBodyTree,
 )
-from pydrake.solvers import ik
+from pydrake.attic.solvers import ik
 
 # TODO(eric.cousineau): Use `unittest` (after moving `ik` into `multibody`),
 # declaring this as a drake_py_unittest in the BUILD.bazel file.

--- a/bindings/pydrake/solvers/test/rbt_ik_test.py
+++ b/bindings/pydrake/solvers/test/rbt_ik_test.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import, division, print_function
 import unittest
 import numpy as np
 import pydrake
-from pydrake.multibody.rigid_body_tree import RigidBodyTree
-from pydrake.solvers import ik
+from pydrake.attic.multibody.rigid_body_tree import RigidBodyTree
+from pydrake.attic.solvers import ik
 import os.path
 
 

--- a/bindings/pydrake/systems/drawing_graphviz_example.py
+++ b/bindings/pydrake/systems/drawing_graphviz_example.py
@@ -3,8 +3,8 @@ import matplotlib.pyplot as plt
 from pydrake.common import FindResourceOrThrow
 from pydrake.geometry import (ConnectDrakeVisualizer, SceneGraph)
 from pydrake.lcm import DrakeLcm
-from pydrake.multibody.multibody_tree import UniformGravityFieldElement
-from pydrake.multibody.multibody_tree.multibody_plant import MultibodyPlant
+from pydrake.multibody.tree import UniformGravityFieldElement
+from pydrake.multibody.plant import MultibodyPlant
 from pydrake.multibody.parsing import Parser
 from pydrake.systems.drawing import plot_system_graphviz
 from pydrake.systems.framework import DiagramBuilder

--- a/bindings/pydrake/systems/test/controllers_test.py
+++ b/bindings/pydrake/systems/test/controllers_test.py
@@ -6,22 +6,25 @@ import unittest
 
 from pydrake.common import FindResourceOrThrow
 from pydrake.examples.pendulum import PendulumPlant
-from pydrake.multibody.multibody_tree import MultibodyForces
-from pydrake.multibody.multibody_tree.multibody_plant import MultibodyPlant
+from pydrake.multibody.tree import MultibodyForces
+from pydrake.multibody.plant import MultibodyPlant
 from pydrake.multibody.parsing import Parser
-from pydrake.multibody.rigid_body_tree import (FloatingBaseType, RigidBodyTree)
+from pydrake.attic.multibody.rigid_body_tree import (
+    FloatingBaseType, RigidBodyTree)
 from pydrake.systems.analysis import Simulator
 from pydrake.systems.controllers import (
     DiscreteTimeLinearQuadraticRegulator, DynamicProgrammingOptions,
     FittedValueIteration,
     InverseDynamicsController, InverseDynamics,
-    RbtInverseDynamicsController, RbtInverseDynamics,
     LinearQuadraticRegulator,
     LinearProgrammingApproximateDynamicProgramming,
     PeriodicBoundaryCondition
 )
+from pydrake.attic.systems.controllers import (
+    RbtInverseDynamicsController, RbtInverseDynamics,
+)
 from pydrake.systems.framework import BasicVector
-from pydrake.systems.primitives import (Integrator, LinearSystem)
+from pydrake.systems.primitives import Integrator, LinearSystem
 
 
 class TestControllers(unittest.TestCase):

--- a/bindings/pydrake/systems/test/meshcat_visualizer_test.py
+++ b/bindings/pydrake/systems/test/meshcat_visualizer_test.py
@@ -4,8 +4,8 @@ import numpy as np
 
 from pydrake.common import FindResourceOrThrow
 from pydrake.geometry import SceneGraph
-from pydrake.multibody.multibody_tree import UniformGravityFieldElement
-from pydrake.multibody.multibody_tree.multibody_plant import (
+from pydrake.multibody.tree import UniformGravityFieldElement
+from pydrake.multibody.plant import (
     AddMultibodyPlantSceneGraph)
 from pydrake.multibody.parsing import Parser
 from pydrake.systems.analysis import Simulator

--- a/bindings/pydrake/systems/test/rendering_test.py
+++ b/bindings/pydrake/systems/test/rendering_test.py
@@ -14,8 +14,8 @@ import numpy as np
 
 from pydrake.common import FindResourceOrThrow
 from pydrake.geometry import SceneGraph
-from pydrake.multibody.multibody_tree.multibody_plant import MultibodyPlant
-from pydrake.multibody.multibody_tree.math import (
+from pydrake.multibody.plant import MultibodyPlant
+from pydrake.multibody.math import (
     SpatialVelocity,
 )
 from pydrake.multibody.parsing import Parser

--- a/bindings/pydrake/systems/test/sensors_test.py
+++ b/bindings/pydrake/systems/test/sensors_test.py
@@ -1,12 +1,13 @@
 from __future__ import division
 
 import pydrake.systems.sensors as mut
+import pydrake.attic.systems.sensors as attic_mut
 
 import numpy as np
 import unittest
 
 from pydrake.common import FindResourceOrThrow
-from pydrake.multibody.rigid_body_tree import (
+from pydrake.attic.multibody.rigid_body_tree import (
     AddModelInstancesFromSdfString,
     FloatingBaseType,
     RigidBodyTree,
@@ -224,7 +225,7 @@ class TestSensors(unittest.TestCase):
         width = 1280
         height = 720
 
-        camera = mut.RgbdCamera(
+        camera = attic_mut.RgbdCamera(
             name="camera", tree=tree, frame=frame,
             z_near=0.5, z_far=5.0,
             fov_y=np.pi / 4, show_window=False,
@@ -245,8 +246,8 @@ class TestSensors(unittest.TestCase):
         self._check_ports(camera)
 
         # Test discrete camera.
-        period = mut.RgbdCameraDiscrete.kDefaultPeriod
-        discrete = mut.RgbdCameraDiscrete(
+        period = attic_mut.RgbdCameraDiscrete.kDefaultPeriod
+        discrete = attic_mut.RgbdCameraDiscrete(
             camera=camera, period=period, render_label_image=True)
         self.assertTrue(discrete.camera() is camera)
         self.assertTrue(discrete.mutable_camera() is camera)

--- a/bindings/pydrake/test/automotive_test.py
+++ b/bindings/pydrake/test/automotive_test.py
@@ -26,7 +26,7 @@ from pydrake.maliput.api import (
 from pydrake.maliput.dragway import (
     create_dragway,
 )
-from pydrake.multibody.multibody_tree.math import (
+from pydrake.multibody.math import (
     SpatialVelocity,
 )
 from pydrake.systems.analysis import (


### PR DESCRIPTION
Addresses spelling checkbox in #10207

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10534)
<!-- Reviewable:end -->
