### PR TITLE
multibody/tree: Compile for symbolic::Expression 

### DIFF
--- a/common/symbolic_expression.h
+++ b/common/symbolic_expression.h
@@ -1280,6 +1280,32 @@ struct ScalarBinaryOpTraits<double, drake::symbolic::Expression, BinaryOp> {
   typedef drake::symbolic::Expression ReturnType;
 };
 
+// Provide explicit (full) template specialization for LLDT::compute when the
+// Scalar is symbolic::Expression.  We have to list out all of the matrix sizes
+// that Drake happens to use (symbolically), because we cannot partially
+// specialize a template class template method.
+#define DRAKE_DISAVOW_LDLT(SomeMatrix)                          \
+template <>                                                     \
+template <>                                                     \
+inline                                                          \
+Eigen::LDLT<SomeMatrix>&                                        \
+Eigen::LDLT<SomeMatrix>::compute<SomeMatrix>(                   \
+    const EigenBase<SomeMatrix>&) {                             \
+  throw std::logic_error(                                       \
+      "Expression does not support LDLT decomposition ");       \
+}                                                               \
+template <>                                                     \
+template <>                                                     \
+inline                                                          \
+Eigen::LDLT<SomeMatrix>&                                        \
+Eigen::LDLT<SomeMatrix>::compute<Eigen::Ref<const SomeMatrix>>( \
+    const EigenBase<Eigen::Ref<const SomeMatrix>>&) {           \
+  throw std::logic_error(                                       \
+      "Expression does not support LDLT decomposition ");       \
+}
+DRAKE_DISAVOW_LDLT(drake::MatrixUpTo6<drake::symbolic::Expression>)
+#undef DRAKE_DISAVOW_LDLT
+
 }  // namespace Eigen
 #endif  // !defined(DRAKE_DOXYGEN_CXX)
 

--- a/multibody/tree/acceleration_kinematics_cache.cc
+++ b/multibody/tree/acceleration_kinematics_cache.cc
@@ -1,4 +1,4 @@
 #include "drake/multibody/tree/acceleration_kinematics_cache.h"
 
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::internal::AccelerationKinematicsCache)

--- a/multibody/tree/acceleration_kinematics_cache.h
+++ b/multibody/tree/acceleration_kinematics_cache.h
@@ -136,5 +136,5 @@ DRAKE_DEPRECATED(
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::internal::AccelerationKinematicsCache)

--- a/multibody/tree/articulated_body_inertia_cache.cc
+++ b/multibody/tree/articulated_body_inertia_cache.cc
@@ -1,4 +1,4 @@
 #include "drake/multibody/tree/articulated_body_inertia_cache.h"
 
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class drake::multibody::internal::ArticulatedBodyInertiaCache)

--- a/multibody/tree/articulated_body_inertia_cache.h
+++ b/multibody/tree/articulated_body_inertia_cache.h
@@ -90,5 +90,5 @@ DRAKE_DEPRECATED(
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class drake::multibody::internal::ArticulatedBodyInertiaCache)

--- a/multibody/tree/body.cc
+++ b/multibody/tree/body.cc
@@ -31,8 +31,14 @@ std::unique_ptr<Frame<AutoDiffXd>> BodyFrame<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
+template <typename T>
+std::unique_ptr<Frame<symbolic::Expression>> BodyFrame<T>::DoCloneToScalar(
+    const internal::MultibodyTree<symbolic::Expression>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class drake::multibody::BodyFrame)

--- a/multibody/tree/body.h
+++ b/multibody/tree/body.h
@@ -90,6 +90,9 @@ class BodyFrame final : public Frame<T> {
   std::unique_ptr<Frame<AutoDiffXd>> DoCloneToScalar(
       const internal::MultibodyTree<AutoDiffXd>& tree_clone) const override;
 
+  std::unique_ptr<Frame<symbolic::Expression>> DoCloneToScalar(
+      const internal::MultibodyTree<symbolic::Expression>&) const override;
+
  private:
   // Body<T> and BodyFrame<T> are natural allies. A BodyFrame object is created
   // every time a Body object is created and they are associated with each
@@ -305,6 +308,10 @@ class Body : public MultibodyTreeElement<Body<T>, BodyIndex> {
   virtual std::unique_ptr<Body<AutoDiffXd>> DoCloneToScalar(
       const internal::MultibodyTree<AutoDiffXd>& tree_clone) const = 0;
 
+  /// Clones this %Body (templated on T) to a body templated on Expression.
+  virtual std::unique_ptr<Body<symbolic::Expression>> DoCloneToScalar(
+      const internal::MultibodyTree<symbolic::Expression>&) const = 0;
+
   /// @}
 
  private:
@@ -347,5 +354,5 @@ class Body : public MultibodyTreeElement<Body<T>, BodyIndex> {
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class drake::multibody::BodyFrame)

--- a/multibody/tree/body_node_impl.cc
+++ b/multibody/tree/body_node_impl.cc
@@ -17,9 +17,10 @@ template class BodyNodeImpl<T, 6, 6>; \
 template class BodyNodeImpl<T, 7, 6>;
 
 // Explicitly instantiates on the most common scalar types.
-// These should be kept in sync with the NONSYMBOLIC list in default_scalars.h
+// These should be kept in sync with the list in default_scalars.h
 EXPLICITLY_INSTANTIATE_IMPLS(double);
 EXPLICITLY_INSTANTIATE_IMPLS(AutoDiffXd);
+EXPLICITLY_INSTANTIATE_IMPLS(symbolic::Expression);
 
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/tree/fixed_offset_frame.cc
+++ b/multibody/tree/fixed_offset_frame.cc
@@ -46,8 +46,15 @@ std::unique_ptr<Frame<AutoDiffXd>> FixedOffsetFrame<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
+template <typename T>
+std::unique_ptr<Frame<symbolic::Expression>>
+FixedOffsetFrame<T>::DoCloneToScalar(
+    const internal::MultibodyTree<symbolic::Expression>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class drake::multibody::FixedOffsetFrame)

--- a/multibody/tree/fixed_offset_frame.h
+++ b/multibody/tree/fixed_offset_frame.h
@@ -106,6 +106,9 @@ class FixedOffsetFrame final : public Frame<T> {
   /// @pre The parent frame to this frame already has a clone in `tree_clone`.
   std::unique_ptr<Frame<AutoDiffXd>> DoCloneToScalar(
       const internal::MultibodyTree<AutoDiffXd>& tree_clone) const override;
+
+  std::unique_ptr<Frame<symbolic::Expression>> DoCloneToScalar(
+      const internal::MultibodyTree<symbolic::Expression>&) const override;
   /// @}
 
  private:
@@ -125,5 +128,5 @@ class FixedOffsetFrame final : public Frame<T> {
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class drake::multibody::FixedOffsetFrame)

--- a/multibody/tree/force_element.h
+++ b/multibody/tree/force_element.h
@@ -240,6 +240,9 @@ class ForceElement : public
   /// AutoDiffXd.
   virtual std::unique_ptr<ForceElement<AutoDiffXd>> DoCloneToScalar(
       const internal::MultibodyTree<AutoDiffXd>& tree_clone) const = 0;
+
+  virtual std::unique_ptr<ForceElement<symbolic::Expression>> DoCloneToScalar(
+      const internal::MultibodyTree<symbolic::Expression>&) const = 0;
   /// @}
 
  private:

--- a/multibody/tree/frame.h
+++ b/multibody/tree/frame.h
@@ -203,6 +203,9 @@ class Frame : public FrameBase<T> {
   /// Clones this %Frame (templated on T) to a frame templated on AutoDiffXd.
   virtual std::unique_ptr<Frame<AutoDiffXd>> DoCloneToScalar(
       const internal::MultibodyTree<AutoDiffXd>& tree_clone) const = 0;
+
+  virtual std::unique_ptr<Frame<symbolic::Expression>> DoCloneToScalar(
+      const internal::MultibodyTree<symbolic::Expression>&) const = 0;
   /// @}
 
  private:

--- a/multibody/tree/joint.h
+++ b/multibody/tree/joint.h
@@ -492,6 +492,9 @@ class Joint : public MultibodyTreeElement<Joint<T>, JointIndex>  {
   /// Clones this %Joint (templated on T) to a joint templated on AutoDiffXd.
   virtual std::unique_ptr<Joint<AutoDiffXd>> DoCloneToScalar(
       const internal::MultibodyTree<AutoDiffXd>& tree_clone) const = 0;
+
+  virtual std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
+      const internal::MultibodyTree<symbolic::Expression>&) const = 0;
   /// @}
 
   /// This method must be implemented by derived classes in order to provide

--- a/multibody/tree/joint_actuator.cc
+++ b/multibody/tree/joint_actuator.cc
@@ -63,6 +63,14 @@ JointActuator<T>::DoCloneToScalar(
       new JointActuator<AutoDiffXd>(name_, joint_index_));
 }
 
+template <typename T>
+std::unique_ptr<JointActuator<symbolic::Expression>>
+JointActuator<T>::DoCloneToScalar(
+    const internal::MultibodyTree<symbolic::Expression>&) const {
+  return std::unique_ptr<JointActuator<symbolic::Expression>>(
+      new JointActuator<symbolic::Expression>(name_, joint_index_));
+}
+
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/joint_actuator.h
+++ b/multibody/tree/joint_actuator.h
@@ -136,6 +136,9 @@ class JointActuator final
   std::unique_ptr<JointActuator<AutoDiffXd>> DoCloneToScalar(
       const internal::MultibodyTree<AutoDiffXd>& tree_clone) const;
 
+  std::unique_ptr<JointActuator<symbolic::Expression>> DoCloneToScalar(
+      const internal::MultibodyTree<symbolic::Expression>& tree_clone) const;
+
   // Implementation for MultibodyTreeElement::DoSetTopology().
   // At MultibodyTree::Finalize() time, each actuator retrieves its topology
   // from the parent MultibodyTree.

--- a/multibody/tree/linear_spring_damper.cc
+++ b/multibody/tree/linear_spring_damper.cc
@@ -170,6 +170,13 @@ LinearSpringDamper<T>::DoCloneToScalar(
 }
 
 template <typename T>
+std::unique_ptr<ForceElement<symbolic::Expression>>
+LinearSpringDamper<T>::DoCloneToScalar(
+    const internal::MultibodyTree<symbolic::Expression>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
+template <typename T>
 T LinearSpringDamper<T>::SafeSoftNorm(const Vector3<T> &x) const {
   using std::sqrt;
   const double epsilon_length =
@@ -223,5 +230,5 @@ T LinearSpringDamper<T>::CalcLengthTimeDerivative(
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::LinearSpringDamper)

--- a/multibody/tree/linear_spring_damper.h
+++ b/multibody/tree/linear_spring_damper.h
@@ -119,6 +119,9 @@ class LinearSpringDamper final : public ForceElement<T> {
   std::unique_ptr<ForceElement<AutoDiffXd>> DoCloneToScalar(
       const internal::MultibodyTree<AutoDiffXd>& tree_clone) const override;
 
+  std::unique_ptr<ForceElement<symbolic::Expression>> DoCloneToScalar(
+      const internal::MultibodyTree<symbolic::Expression>&) const override;
+
  private:
   // Helper method to make a clone templated on ToScalar.
   template <typename ToScalar>
@@ -154,5 +157,5 @@ class LinearSpringDamper final : public ForceElement<T> {
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::LinearSpringDamper)

--- a/multibody/tree/mobilizer.h
+++ b/multibody/tree/mobilizer.h
@@ -656,6 +656,9 @@ class Mobilizer : public MultibodyTreeElement<Mobilizer<T>, MobilizerIndex> {
   /// in `tree_clone`.
   virtual std::unique_ptr<Mobilizer<AutoDiffXd>> DoCloneToScalar(
       const MultibodyTree<AutoDiffXd>& tree_clone) const = 0;
+
+  virtual std::unique_ptr<Mobilizer<symbolic::Expression>> DoCloneToScalar(
+      const MultibodyTree<symbolic::Expression>& tree_clone) const = 0;
   /// @}
 
  private:

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -1652,5 +1652,5 @@ VectorX<double> MultibodyTree<T>::GetAccelerationUpperLimits() const {
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::internal::MultibodyTree)

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -2663,5 +2663,5 @@ class MultibodyTree {
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::internal::MultibodyTree)

--- a/multibody/tree/multibody_tree_system.cc
+++ b/multibody/tree/multibody_tree_system.cc
@@ -17,6 +17,32 @@ namespace multibody {
 namespace internal {
 
 template <typename T>
+MultibodyTreeSystem<T>::MultibodyTreeSystem(
+    std::unique_ptr<MultibodyTree<T>> tree,
+    bool is_discrete)
+    : MultibodyTreeSystem(
+          systems::SystemTypeTag<internal::MultibodyTreeSystem>{},
+          false,  // Null tree is not allowed here.
+          std::move(tree), is_discrete) {}
+
+template <typename T>
+MultibodyTreeSystem<T>::MultibodyTreeSystem(bool is_discrete)
+    : MultibodyTreeSystem(
+          systems::SystemTypeTag<internal::MultibodyTreeSystem>{},
+          true,  // Null tree is OK.
+          nullptr, is_discrete) {}
+
+template <typename T>
+MultibodyTreeSystem<T>::MultibodyTreeSystem(
+    systems::SystemScalarConverter converter,
+    std::unique_ptr<MultibodyTree<T>> tree,
+    bool is_discrete)
+    : MultibodyTreeSystem(
+          std::move(converter),
+          true,  // Null tree is OK.
+          std::move(tree), is_discrete) {}
+
+template <typename T>
 template <typename U>
 MultibodyTreeSystem<T>::MultibodyTreeSystem(const MultibodyTreeSystem<U>& other)
     : MultibodyTreeSystem(
@@ -152,18 +178,9 @@ MultibodyTreeSystem<T>::DoMakeLeafContext() const {
                                                    is_discrete_);
 }
 
-// Instantiate supported conversion methods.
-// TODO(sherm1) Move definitions of these methods to an -inl.h file so that
-// they don't require explicit instantiation here.
-template MultibodyTreeSystem<AutoDiffXd>::MultibodyTreeSystem(
-    const MultibodyTreeSystem<double>& other);
-
-template MultibodyTreeSystem<double>::MultibodyTreeSystem(
-    const MultibodyTreeSystem<AutoDiffXd>& other);
-
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class drake::multibody::internal::MultibodyTreeSystem)

--- a/multibody/tree/multibody_tree_system.h
+++ b/multibody/tree/multibody_tree_system.h
@@ -64,11 +64,7 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
 
   @throws std::logic_error if `tree` is null. */
   explicit MultibodyTreeSystem(std::unique_ptr<MultibodyTree<T>> tree,
-                               bool is_discrete = false)
-      : MultibodyTreeSystem(
-            systems::SystemTypeTag<internal::MultibodyTreeSystem>{},
-            false,  // Null tree is not allowed here.
-            std::move(tree), is_discrete) {}
+                               bool is_discrete = false);
 
   /** Scalar-converting copy constructor. See @ref system_scalar_conversion. */
   template <typename U>
@@ -132,11 +128,7 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
   /** Default constructor allocates a MultibodyTree, with the intent that it
   will be filled in later, using mutable_tree() for access. You must call
   Finalize() when done before performing any computations. */
-  explicit MultibodyTreeSystem(bool is_discrete = false)
-      : MultibodyTreeSystem(
-            systems::SystemTypeTag<internal::MultibodyTreeSystem>{},
-            true,  // Null tree is OK.
-            nullptr, is_discrete) {}
+  explicit MultibodyTreeSystem(bool is_discrete = false);
 
   /**  Constructor that specifies scalar-type conversion support.
   If `tree` is given, we'll finalize it. Otherwise, we'll allocate an
@@ -148,9 +140,7 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
       kinematics. Otherwise uses continuous state variables q and v. */
   MultibodyTreeSystem(systems::SystemScalarConverter converter,
                       std::unique_ptr<MultibodyTree<T>> tree,
-                      bool is_discrete = false)
-      : MultibodyTreeSystem(converter, true,  // Null tree is OK here.
-                            std::move(tree), is_discrete) {}
+                      bool is_discrete = false);
 
   template <typename U>
   friend const MultibodyTree<U>& GetInternalTree(
@@ -225,17 +215,5 @@ DRAKE_DEPRECATED(
 }  // namespace multibody
 }  // namespace drake
 
-// Disable support for symbolic evaluation.
-// TODO(amcastro-tri): Allow symbolic evaluation once MultibodyTree supports it.
-namespace drake {
-namespace systems {
-namespace scalar_conversion {
-template <>
-struct Traits<drake::multibody::internal::MultibodyTreeSystem> :
-    public NonSymbolicTraits {};
-}  // namespace scalar_conversion
-}  // namespace systems
-}  // namespace drake
-
-DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class drake::multibody::internal::MultibodyTreeSystem)

--- a/multibody/tree/position_kinematics_cache.cc
+++ b/multibody/tree/position_kinematics_cache.cc
@@ -1,4 +1,4 @@
 #include "drake/multibody/tree/position_kinematics_cache.h"
 
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::internal::PositionKinematicsCache)

--- a/multibody/tree/position_kinematics_cache.h
+++ b/multibody/tree/position_kinematics_cache.h
@@ -155,5 +155,5 @@ DRAKE_DEPRECATED(
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::internal::PositionKinematicsCache)

--- a/multibody/tree/prismatic_joint.cc
+++ b/multibody/tree/prismatic_joint.cc
@@ -42,8 +42,14 @@ std::unique_ptr<Joint<AutoDiffXd>> PrismaticJoint<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
+template <typename T>
+std::unique_ptr<Joint<symbolic::Expression>> PrismaticJoint<T>::DoCloneToScalar(
+    const internal::MultibodyTree<symbolic::Expression>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::PrismaticJoint)

--- a/multibody/tree/prismatic_joint.h
+++ b/multibody/tree/prismatic_joint.h
@@ -279,6 +279,9 @@ class PrismaticJoint final : public Joint<T> {
   std::unique_ptr<Joint<AutoDiffXd>> DoCloneToScalar(
       const internal::MultibodyTree<AutoDiffXd>& tree_clone) const final;
 
+  std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
+      const internal::MultibodyTree<symbolic::Expression>&) const final;
+
   // Make PrismaticJoint templated on every other scalar type a friend of
   // PrismaticJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can access
   // private members of PrismaticJoint<T>.
@@ -325,5 +328,5 @@ class PrismaticJoint final : public Joint<T> {
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::PrismaticJoint)

--- a/multibody/tree/prismatic_mobilizer.cc
+++ b/multibody/tree/prismatic_mobilizer.cc
@@ -148,9 +148,16 @@ std::unique_ptr<Mobilizer<AutoDiffXd>> PrismaticMobilizer<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
+template <typename T>
+std::unique_ptr<Mobilizer<symbolic::Expression>>
+PrismaticMobilizer<T>::DoCloneToScalar(
+    const MultibodyTree<symbolic::Expression>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::internal::PrismaticMobilizer)

--- a/multibody/tree/prismatic_mobilizer.h
+++ b/multibody/tree/prismatic_mobilizer.h
@@ -178,6 +178,9 @@ class PrismaticMobilizer final : public MobilizerImpl<T, 1, 1> {
   std::unique_ptr<Mobilizer<AutoDiffXd>> DoCloneToScalar(
       const MultibodyTree<AutoDiffXd>& tree_clone) const final;
 
+  std::unique_ptr<Mobilizer<symbolic::Expression>> DoCloneToScalar(
+      const MultibodyTree<symbolic::Expression>& tree_clone) const final;
+
  private:
   typedef MobilizerImpl<T, 1, 1> MobilizerBase;
   // Bring the handy number of position and velocities MobilizerImpl enums into
@@ -210,5 +213,5 @@ DRAKE_DEPRECATED(
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::internal::PrismaticMobilizer)

--- a/multibody/tree/quaternion_floating_mobilizer.cc
+++ b/multibody/tree/quaternion_floating_mobilizer.cc
@@ -393,9 +393,16 @@ QuaternionFloatingMobilizer<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
+template <typename T>
+std::unique_ptr<Mobilizer<symbolic::Expression>>
+QuaternionFloatingMobilizer<T>::DoCloneToScalar(
+    const MultibodyTree<symbolic::Expression>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::internal::QuaternionFloatingMobilizer)

--- a/multibody/tree/quaternion_floating_mobilizer.h
+++ b/multibody/tree/quaternion_floating_mobilizer.h
@@ -230,6 +230,9 @@ class QuaternionFloatingMobilizer final : public MobilizerImpl<T, 7, 6> {
   std::unique_ptr<Mobilizer<AutoDiffXd>> DoCloneToScalar(
       const MultibodyTree<AutoDiffXd>& tree_clone) const override;
 
+  std::unique_ptr<Mobilizer<symbolic::Expression>> DoCloneToScalar(
+      const MultibodyTree<symbolic::Expression>& tree_clone) const override;
+
  private:
   typedef MobilizerImpl<T, 7, 6> MobilizerBase;
   // Bring the handy number of position and velocities MobilizerImpl enums into
@@ -275,5 +278,5 @@ DRAKE_DEPRECATED(
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::internal::QuaternionFloatingMobilizer)

--- a/multibody/tree/revolute_joint.cc
+++ b/multibody/tree/revolute_joint.cc
@@ -43,6 +43,12 @@ std::unique_ptr<Joint<AutoDiffXd>> RevoluteJoint<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
+template <typename T>
+std::unique_ptr<Joint<symbolic::Expression>> RevoluteJoint<T>::DoCloneToScalar(
+    const internal::MultibodyTree<symbolic::Expression>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
 // N.B. Due to esoteric linking errors on Mac (see #9345) involving
 // `MobilizerImpl`, we must place this implementation in the source file, not
 // in the header file.
@@ -59,5 +65,5 @@ RevoluteJoint<T>::MakeImplementationBlueprint() const {
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::RevoluteJoint)

--- a/multibody/tree/revolute_joint.h
+++ b/multibody/tree/revolute_joint.h
@@ -319,6 +319,9 @@ class RevoluteJoint final : public Joint<T> {
   std::unique_ptr<Joint<AutoDiffXd>> DoCloneToScalar(
       const internal::MultibodyTree<AutoDiffXd>& tree_clone) const override;
 
+  std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
+      const internal::MultibodyTree<symbolic::Expression>&) const override;
+
   // Make RevoluteJoint templated on every other scalar type a friend of
   // RevoluteJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can access
   // private members of RevoluteJoint<T>.
@@ -364,5 +367,5 @@ class RevoluteJoint final : public Joint<T> {
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::RevoluteJoint)

--- a/multibody/tree/revolute_mobilizer.cc
+++ b/multibody/tree/revolute_mobilizer.cc
@@ -149,9 +149,16 @@ std::unique_ptr<Mobilizer<AutoDiffXd>> RevoluteMobilizer<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
+template <typename T>
+std::unique_ptr<Mobilizer<symbolic::Expression>>
+RevoluteMobilizer<T>::DoCloneToScalar(
+    const MultibodyTree<symbolic::Expression>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::internal::RevoluteMobilizer)

--- a/multibody/tree/revolute_mobilizer.h
+++ b/multibody/tree/revolute_mobilizer.h
@@ -178,6 +178,9 @@ class RevoluteMobilizer final : public MobilizerImpl<T, 1, 1> {
   std::unique_ptr<Mobilizer<AutoDiffXd>> DoCloneToScalar(
       const MultibodyTree<AutoDiffXd>& tree_clone) const override;
 
+  std::unique_ptr<Mobilizer<symbolic::Expression>> DoCloneToScalar(
+      const MultibodyTree<symbolic::Expression>& tree_clone) const override;
+
  private:
   typedef MobilizerImpl<T, 1, 1> MobilizerBase;
   // Bring the handy number of position and velocities MobilizerImpl enums into
@@ -210,5 +213,5 @@ DRAKE_DEPRECATED(
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::internal::RevoluteMobilizer)

--- a/multibody/tree/rigid_body.cc
+++ b/multibody/tree/rigid_body.cc
@@ -28,5 +28,5 @@ RigidBody<T>::RigidBody(const std::string& body_name,
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::RigidBody)

--- a/multibody/tree/rigid_body.h
+++ b/multibody/tree/rigid_body.h
@@ -274,6 +274,12 @@ class RigidBody : public Body<T> {
     return TemplatedDoCloneToScalar(tree_clone);
   }
 
+  std::unique_ptr<Body<symbolic::Expression>> DoCloneToScalar(
+      const internal::MultibodyTree<symbolic::Expression>& tree_clone) const
+      final {
+    return TemplatedDoCloneToScalar(tree_clone);
+  }
+
  private:
   // Helper method to make a clone templated on ToScalar.
   template <typename ToScalar>
@@ -291,5 +297,5 @@ class RigidBody : public Body<T> {
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::RigidBody)

--- a/multibody/tree/space_xyz_mobilizer.cc
+++ b/multibody/tree/space_xyz_mobilizer.cc
@@ -358,9 +358,16 @@ SpaceXYZMobilizer<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
+template <typename T>
+std::unique_ptr<Mobilizer<symbolic::Expression>>
+SpaceXYZMobilizer<T>::DoCloneToScalar(
+    const MultibodyTree<symbolic::Expression>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::internal::SpaceXYZMobilizer)

--- a/multibody/tree/space_xyz_mobilizer.h
+++ b/multibody/tree/space_xyz_mobilizer.h
@@ -270,6 +270,9 @@ class SpaceXYZMobilizer final : public MobilizerImpl<T, 3, 3> {
   std::unique_ptr<Mobilizer<AutoDiffXd>> DoCloneToScalar(
       const MultibodyTree<AutoDiffXd>& tree_clone) const override;
 
+  std::unique_ptr<Mobilizer<symbolic::Expression>> DoCloneToScalar(
+      const MultibodyTree<symbolic::Expression>& tree_clone) const override;
+
  private:
   typedef MobilizerImpl<T, 3, 3> MobilizerBase;
   // Bring the handy number of position and velocities MobilizerImpl enums into
@@ -299,5 +302,5 @@ DRAKE_DEPRECATED(
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::internal::SpaceXYZMobilizer)

--- a/multibody/tree/test/articulated_body_algorithm_test.cc
+++ b/multibody/tree/test/articulated_body_algorithm_test.cc
@@ -133,6 +133,11 @@ class FeatherstoneMobilizer final : public MobilizerImpl<T, 2, 2> {
     return TemplatedDoCloneToScalar(tree_clone);
   }
 
+  std::unique_ptr<Mobilizer<symbolic::Expression>> DoCloneToScalar(
+      const MultibodyTree<symbolic::Expression>& tree_clone) const override {
+    return TemplatedDoCloneToScalar(tree_clone);
+  }
+
  private:
   typedef MobilizerImpl<T, 2, 2> MobilizerBase;
 

--- a/multibody/tree/test/free_rotating_body_plant.cc
+++ b/multibody/tree/test/free_rotating_body_plant.cc
@@ -152,5 +152,5 @@ SpatialVelocity<T> FreeRotatingBodyPlant<T>::CalcSpatialVelocityInWorldFrame(
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::test::FreeRotatingBodyPlant)

--- a/multibody/tree/test/multibody_tree_creation_test.cc
+++ b/multibody/tree/test/multibody_tree_creation_test.cc
@@ -520,6 +520,29 @@ TEST_F(TreeTopologyTests, ToAutoDiffXd) {
   VerifyTopology(autodiff_topology);
 }
 
+// Verifies that the symbolic version of a given MultibodyTree model created
+// with MultibodyTree::ToSymbolic() has exactly the same topology as the
+// original model.
+TEST_F(TreeTopologyTests, ToSymbolic) {
+  model_->Finalize();
+  EXPECT_EQ(model_->num_bodies(), 8);
+  EXPECT_EQ(model_->num_mobilizers(), 7);
+  const MultibodyTreeTopology& topology = model_->get_topology();
+
+  auto symbolic_model = model_->CloneToScalar<symbolic::Expression>();
+  EXPECT_EQ(symbolic_model->num_bodies(), 8);
+  const MultibodyTreeTopology& symbolic_topology =
+      symbolic_model->get_topology();
+
+  // The topology of the clone must be exactly equal to the topology of the
+  // original MultibodyTree.
+  EXPECT_EQ(topology, symbolic_topology);
+
+  // Even though the test above confirms the two topologies are exactly equal,
+  // we perform a number of additional tests.
+  VerifyTopology(symbolic_topology);
+}
+
 // Verifies the correctness of the method
 // MultibodyTreeTopology::GetKinematicPathToWorld() by computing the path from a
 // given body to the world (root) of the tree on a known topology.

--- a/multibody/tree/test/multibody_tree_test.cc
+++ b/multibody/tree/test/multibody_tree_test.cc
@@ -484,6 +484,13 @@ TEST_F(KukaIiwaModelTests, VerifyScalarConversionToAutoDiffXd) {
   VerifyModelBasics(tree_autodiff());
 }
 
+// Verifies the integrity of a scalar converted MultibodyTree from <double> to
+// <symbolic::Expression>.
+TEST_F(KukaIiwaModelTests, VerifyScalarConversionToSymbolic) {
+  auto dut = tree().CloneToScalar<symbolic::Expression>();
+  VerifyModelBasics(*dut);
+}
+
 // This test is used to verify the correctness of the method
 // MultibodyTree::CalcPointsGeometricJacobianExpressedInWorld().
 // The test computes the end effector geometric Jacobian Jv_WE (in the world

--- a/multibody/tree/uniform_gravity_field_element.cc
+++ b/multibody/tree/uniform_gravity_field_element.cc
@@ -186,8 +186,16 @@ UniformGravityFieldElement<T>::DoCloneToScalar(
       gravity_vector());
 }
 
+template <typename T>
+std::unique_ptr<ForceElement<symbolic::Expression>>
+UniformGravityFieldElement<T>::DoCloneToScalar(
+    const internal::MultibodyTree<symbolic::Expression>&) const {
+  return std::make_unique<UniformGravityFieldElement<symbolic::Expression>>(
+      gravity_vector());
+}
+
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::UniformGravityFieldElement)

--- a/multibody/tree/uniform_gravity_field_element.h
+++ b/multibody/tree/uniform_gravity_field_element.h
@@ -105,6 +105,9 @@ class UniformGravityFieldElement : public ForceElement<T> {
   std::unique_ptr<ForceElement<AutoDiffXd>> DoCloneToScalar(
       const internal::MultibodyTree<AutoDiffXd>& tree_clone) const override;
 
+  std::unique_ptr<ForceElement<symbolic::Expression>> DoCloneToScalar(
+      const internal::MultibodyTree<symbolic::Expression>&) const override;
+
  private:
   Vector3<double> g_W_;
 };
@@ -112,5 +115,5 @@ class UniformGravityFieldElement : public ForceElement<T> {
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::UniformGravityFieldElement)

--- a/multibody/tree/velocity_kinematics_cache.cc
+++ b/multibody/tree/velocity_kinematics_cache.cc
@@ -1,4 +1,4 @@
 #include "drake/multibody/tree/velocity_kinematics_cache.h"
 
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::internal::VelocityKinematicsCache)

--- a/multibody/tree/velocity_kinematics_cache.h
+++ b/multibody/tree/velocity_kinematics_cache.h
@@ -164,5 +164,5 @@ DRAKE_DEPRECATED(
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::internal::VelocityKinematicsCache)

--- a/multibody/tree/weld_joint.cc
+++ b/multibody/tree/weld_joint.cc
@@ -37,6 +37,12 @@ std::unique_ptr<Joint<AutoDiffXd>> WeldJoint<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
+template <typename T>
+std::unique_ptr<Joint<symbolic::Expression>> WeldJoint<T>::DoCloneToScalar(
+    const internal::MultibodyTree<symbolic::Expression>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
 // N.B. Due to esoteric linking errors on Mac (see #9345) involving
 // `MobilizerImpl`, we must place this implementation in the source file, not
 // in the header file.

--- a/multibody/tree/weld_joint.h
+++ b/multibody/tree/weld_joint.h
@@ -98,6 +98,9 @@ class WeldJoint final : public Joint<T> {
   std::unique_ptr<Joint<AutoDiffXd>> DoCloneToScalar(
       const internal::MultibodyTree<AutoDiffXd>& tree_clone) const override;
 
+  std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
+      const internal::MultibodyTree<symbolic::Expression>&x) const override;
+
   // Make WeldJoint templated on every other scalar type a friend of
   // WeldJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can access
   // private members of WeldJoint<T>.

--- a/multibody/tree/weld_mobilizer.cc
+++ b/multibody/tree/weld_mobilizer.cc
@@ -90,6 +90,13 @@ std::unique_ptr<Mobilizer<AutoDiffXd>> WeldMobilizer<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
+template <typename T>
+std::unique_ptr<Mobilizer<symbolic::Expression>>
+WeldMobilizer<T>::DoCloneToScalar(
+    const MultibodyTree<symbolic::Expression>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/weld_mobilizer.h
+++ b/multibody/tree/weld_mobilizer.h
@@ -100,6 +100,9 @@ class WeldMobilizer final : public MobilizerImpl<T, 0, 0> {
   std::unique_ptr<Mobilizer<AutoDiffXd>> DoCloneToScalar(
       const MultibodyTree<AutoDiffXd>& tree_clone) const final;
 
+  std::unique_ptr<Mobilizer<symbolic::Expression>> DoCloneToScalar(
+      const MultibodyTree<symbolic::Expression>& tree_clone) const final;
+
  private:
   typedef MobilizerImpl<T, 0, 0> MobilizerBase;
   // Bring the handy number of position and velocities MobilizerImpl enums into


### PR DESCRIPTION
I explored adding Expression support to MBP, to see how difficult it would be -- in case we want to start using `Context<Expression>` as a way to formulate optimization problems.  Since the changes to multibody/tree were not onerous, we should probably support it.

Most of the changes are either removing NONSYMBOLIC from our default_scalars use, or dealing with the new joint or body virtual methods for the new scalar.

Also, to allow multibody/tree to compile, we needed to add support to compile `Eigen::LDLT` for `T = Expression`.  Alternatively, we could have made `operator bool` on `symbolic::Formula` implicit (instead of `explicit`), but for now just working around LDLT seems sufficient -- especially because the only MBT use of LDLT in buried inside a pile of dead code.

(The multibody/plant support for `T = Expression` is future work, filed as #10439.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10535)
<!-- Reviewable:end -->
