### PR TITLE
py meshcat_visualizer: Ignore import warnings in Python 3

### DIFF
--- a/bindings/pydrake/systems/meshcat_visualizer.py
+++ b/bindings/pydrake/systems/meshcat_visualizer.py
@@ -6,10 +6,8 @@ package, Meshcat:
 from __future__ import print_function
 import argparse
 import math
+import warnings
 import webbrowser
-
-import meshcat
-import meshcat.transformations as tf
 
 from drake import lcmt_viewer_load_robot
 from pydrake.common.eigen_geometry import Quaternion
@@ -20,6 +18,15 @@ from pydrake.systems.framework import (
     AbstractValue, LeafSystem, PublishEvent, TriggerType
 )
 from pydrake.systems.rendering import PoseBundle
+
+# TODO(eric.cousineau): Move this back to "third party" import positions
+# if/when PyCQA/pycodestyle#834 lands and is incorporated.
+with warnings.catch_warnings():
+    warnings.filterwarnings(
+        "ignore", category=ImportWarning,
+        message="can't resolve package from __spec__")
+    import meshcat
+import meshcat.transformations as tf  # noqa
 
 
 class MeshcatVisualizer(LeafSystem):


### PR DESCRIPTION
Resolves #10527 (as a workaround)

This can be benefited by https://github.com/PyCQA/pycodestyle/pull/834 when it comes to filtering import warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10536)
<!-- Reviewable:end -->
