### PR TITLE
pydrake: Bind LCM contact results, inverse dynamics controllers, and sine.

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -11,6 +11,7 @@
 #include "drake/geometry/scene_graph.h"
 #include "drake/multibody/plant/contact_info.h"
 #include "drake/multibody/plant/contact_results.h"
+#include "drake/multibody/plant/contact_results_to_lcm.h"
 #include "drake/multibody/plant/multibody_plant.h"
 
 namespace drake {
@@ -603,6 +604,19 @@ PYBIND11_MODULE(plant, m) {
     pysystems::AddValueInstantiation<Class>(m);
   }
 
+  // ContactResultsToLcmSystem
+  {
+    using Class = ContactResultsToLcmSystem<T>;
+    py::class_<Class, systems::LeafSystem<T>>(m, "ContactResultsToLcmSystem")
+        .def(py::init<const MultibodyPlant<double>&>(), py::arg("plant"),
+            // Keep alive, reference: `self` keeps `plant` alive.
+            py::keep_alive<1, 2>())
+        .def("get_contact_result_input_port",
+            &Class::get_contact_result_input_port, py_reference_internal)
+        .def("get_lcm_message_output_port", &Class::get_lcm_message_output_port,
+            py_reference_internal);
+  }
+
   m.def("AddMultibodyPlantSceneGraph",
       [](systems::DiagramBuilder<T>* builder,
           std::unique_ptr<MultibodyPlant<T>> plant,
@@ -621,6 +635,20 @@ PYBIND11_MODULE(plant, m) {
       },
       py::arg("builder"), py::arg("plant") = nullptr,
       py::arg("scene_graph") = nullptr, doc.AddMultibodyPlantSceneGraph.doc);
+
+  m.def("ConnectContactResultsToDrakeVisualizer",
+      [](systems::DiagramBuilder<T>* builder,
+          const MultibodyPlant<double>& plant, lcm::DrakeLcmInterface* lcm) {
+        return drake::multibody::ConnectContactResultsToDrakeVisualizer(
+            builder, plant, lcm);
+      },
+      // Keep alive, ownership: `return` keeps `builder` alive.
+      py::keep_alive<0, 1>(),
+      // Keep alive, reference transfer: `plant` keeps `builder` alive.
+      py::keep_alive<2, 1>(),
+      // Keep alive, reference transfer: `lcm` keeps `builder` alive.
+      py::keep_alive<3, 1>(), py_reference, py::arg("builder"),
+      py::arg("plant"), py::arg("lcm") = nullptr);
 }  // NOLINT(readability/fn_size)
 
 }  // namespace pydrake

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -233,6 +233,7 @@ drake_pybind_library(
         ":framework_py",
         ":module_py",
         "//bindings/pydrake:lcm_py",
+        "//lcmtypes:lcmtypes_drake_py",
         "@lcmtypes_robotlocomotion//:lcmtypes_robotlocomotion_py",
     ],
     py_srcs = ["_lcm_extra.py"],

--- a/bindings/pydrake/systems/controllers_py.cc
+++ b/bindings/pydrake/systems/controllers_py.cc
@@ -84,7 +84,24 @@ PYBIND11_MODULE(controllers, m) {
           py::keep_alive<1, 2>(), doc.InverseDynamicsController.ctor.doc)
       .def("set_integral_value",
           &InverseDynamicsController<double>::set_integral_value,
-          doc.InverseDynamicsController.set_integral_value.doc);
+          doc.InverseDynamicsController.set_integral_value.doc)
+      .def("get_input_port_desired_acceleration",
+          &InverseDynamicsController<
+              double>::get_input_port_desired_acceleration,
+          py_reference_internal,
+          doc.InverseDynamicsController.get_input_port_desired_acceleration.doc)
+      .def("get_input_port_estimated_state",
+          &InverseDynamicsController<double>::get_input_port_estimated_state,
+          py_reference_internal,
+          doc.InverseDynamicsController.get_input_port_estimated_state.doc)
+      .def("get_input_port_desired_state",
+          &InverseDynamicsController<double>::get_input_port_desired_state,
+          py_reference_internal,
+          doc.InverseDynamicsController.get_input_port_desired_state.doc)
+      .def("get_output_port_control",
+          &InverseDynamicsController<double>::get_output_port_control,
+          py_reference_internal,
+          doc.InverseDynamicsController.get_output_port_control.doc);
 
   m.def("FittedValueIteration", WrapCallbacks(&FittedValueIteration),
       doc.FittedValueIteration.doc);

--- a/bindings/pydrake/systems/lcm_py_bind_cpp_serializers.cc
+++ b/bindings/pydrake/systems/lcm_py_bind_cpp_serializers.cc
@@ -3,6 +3,7 @@
 #include "robotlocomotion/quaternion_t.hpp"
 
 #include "drake/bindings/pydrake/systems/lcm_pybind.h"
+#include "drake/lcmt_contact_results_for_viz.hpp"
 
 namespace drake {
 namespace pydrake {
@@ -11,7 +12,9 @@ namespace pylcm {
 
 void BindCppSerializers() {
   // N.B. At least one type should be bound to ensure the template is defined.
+  // N.B. These should be placed in the same order has the headers.
   BindCppSerializer<robotlocomotion::quaternion_t>("robotlocomotion");
+  BindCppSerializer<drake::lcmt_contact_results_for_viz>("drake");
 }
 
 }  // namespace pylcm

--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -22,6 +22,7 @@
 #include "drake/systems/primitives/random_source.h"
 #include "drake/systems/primitives/saturation.h"
 #include "drake/systems/primitives/signal_logger.h"
+#include "drake/systems/primitives/sine.h"
 #include "drake/systems/primitives/trajectory_source.h"
 #include "drake/systems/primitives/wrap_to_system.h"
 #include "drake/systems/primitives/zero_order_hold.h"
@@ -118,6 +119,18 @@ PYBIND11_MODULE(primitives, m) {
             doc.Gain.ctor.doc_2args)
         .def(py::init<const Eigen::Ref<const VectorXd>&>(), py::arg("k"),
             doc.Gain.ctor.doc_1args);
+
+    DefineTemplateClassWithDefault<Sine<T>, LeafSystem<T>>(
+        m, "Sine", GetPyParam<T>(), doc.Sine.doc)
+        .def(py::init<double, double, double, int, bool>(),
+            py::arg("amplitude"), py::arg("frequency"), py::arg("phase"),
+            py::arg("size"), py::arg("is_time_based") = true,
+            doc.Sine.ctor.doc_5args)
+        .def(py::init<const Eigen::Ref<const VectorXd>&,
+                 const Eigen::Ref<const VectorXd>&,
+                 const Eigen::Ref<const VectorXd>&, bool>(),
+            py::arg("amplitudes"), py::arg("frequencies"), py::arg("phases"),
+            py::arg("is_time_based") = true, doc.Sine.ctor.doc_4args);
 
     DefineTemplateClassWithDefault<Integrator<T>, LeafSystem<T>>(
         m, "Integrator", GetPyParam<T>(), doc.Integrator.doc)

--- a/bindings/pydrake/systems/test/primitives_test.py
+++ b/bindings/pydrake/systems/test/primitives_test.py
@@ -38,6 +38,7 @@ from pydrake.systems.primitives import (
     PassThrough, PassThrough_,
     Saturation, Saturation_,
     SignalLogger, SignalLogger_,
+    Sine, Sine_,
     UniformRandomSource,
     TrajectorySource,
     WrapToSystem, WrapToSystem_,
@@ -78,6 +79,7 @@ class TestGeneral(unittest.TestCase):
         self._check_instantiations(PassThrough_)
         self._check_instantiations(Saturation_)
         self._check_instantiations(SignalLogger_)
+        self._check_instantiations(Sine_)
         self._check_instantiations(WrapToSystem_)
         self._check_instantiations(ZeroOrderHold_)
 
@@ -371,3 +373,24 @@ class TestGeneral(unittest.TestCase):
         ZeroOrderHold(
             period_sec=0.1,
             abstract_model_value=AbstractValue.Make("Hello world"))
+
+    def test_sine(self):
+        # Test scalar output.
+        sine_source = Sine(amplitude=1, frequency=2, phase=3,
+                           size=1, is_time_based=True)
+        self.assertEqual(sine_source.get_output_port(0).size(), 1)
+        self.assertEqual(sine_source.get_output_port(1).size(), 1)
+        self.assertEqual(sine_source.get_output_port(2).size(), 1)
+
+        # Test vector output.
+        sine_source = Sine(amplitude=1, frequency=2, phase=3,
+                           size=3, is_time_based=True)
+        self.assertEqual(sine_source.get_output_port(0).size(), 3)
+        self.assertEqual(sine_source.get_output_port(1).size(), 3)
+        self.assertEqual(sine_source.get_output_port(2).size(), 3)
+
+        sine_source = Sine(amplitudes=np.ones(2), frequencies=np.ones(2),
+                           phases=np.ones(2), is_time_based=True)
+        self.assertEqual(sine_source.get_output_port(0).size(), 2)
+        self.assertEqual(sine_source.get_output_port(1).size(), 2)
+        self.assertEqual(sine_source.get_output_port(2).size(), 2)


### PR DESCRIPTION
 for lcm contact results, inverse dynamics controller, and sine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10538)
<!-- Reviewable:end -->
