### PR TITLE
Deprecate and remove all uses of DRAKE_ABORT

### DIFF
--- a/automotive/maliput/api/road_geometry.cc
+++ b/automotive/maliput/api/road_geometry.cc
@@ -56,8 +56,8 @@ Rotation OrientationOutFromLane(const LaneEnd& lane_end) {
     case LaneEnd::kFinish: {
       return lane_end.lane->GetOrientation({lane_end.lane->length(), 0., 0.});
     }
-    default: { DRAKE_ABORT(); }
   }
+  DRAKE_UNREACHABLE();
 }
 
 

--- a/automotive/maliput/geometry_base/lane.cc
+++ b/automotive/maliput/geometry_base/lane.cc
@@ -70,7 +70,7 @@ const api::BranchPoint* Lane::DoGetBranchPoint(
     case api::LaneEnd::kStart:  { return start_branch_point_; }
     case api::LaneEnd::kFinish: { return finish_branch_point_; }
   }
-  DRAKE_ABORT();
+  DRAKE_UNREACHABLE();
 }
 
 const api::LaneEndSet* Lane::DoGetConfluentBranches(

--- a/automotive/maliput/geometry_base/test_utilities/mock_geometry.cc
+++ b/automotive/maliput/geometry_base/test_utilities/mock_geometry.cc
@@ -13,50 +13,50 @@ api::RoadPosition MockRoadGeometry::DoToRoadPosition(
     const api::GeoPosition&, const api::RoadPosition*,
     api::GeoPosition*, double*) const {
   DRAKE_THROW_UNLESS(false);
-  DRAKE_ABORT();  // To avoid "control reaches end of non-void function" msg.
+  DRAKE_UNREACHABLE();
 }
 
 
 double MockLane::do_length() const {
   DRAKE_THROW_UNLESS(false);
-  DRAKE_ABORT();  // To avoid "control reaches end of non-void function" msg.
+  DRAKE_UNREACHABLE();
 }
 
 api::RBounds MockLane::do_lane_bounds(double) const {
   DRAKE_THROW_UNLESS(false);
-  DRAKE_ABORT();  // To avoid "control reaches end of non-void function" msg.
+  DRAKE_UNREACHABLE();
 }
 
 api::RBounds MockLane::do_driveable_bounds(double) const {
   DRAKE_THROW_UNLESS(false);
-  DRAKE_ABORT();  // To avoid "control reaches end of non-void function" msg.
+  DRAKE_UNREACHABLE();
 }
 
 api::HBounds MockLane::do_elevation_bounds(double, double) const {
   DRAKE_THROW_UNLESS(false);
-  DRAKE_ABORT();  // To avoid "control reaches end of non-void function" msg.
+  DRAKE_UNREACHABLE();
 }
 
 api::GeoPosition MockLane::DoToGeoPosition(const api::LanePosition&) const {
   DRAKE_THROW_UNLESS(false);
-  DRAKE_ABORT();  // To avoid "control reaches end of non-void function" msg.
+  DRAKE_UNREACHABLE();
 }
 
 api::Rotation MockLane::DoGetOrientation(const api::LanePosition&) const {
   DRAKE_THROW_UNLESS(false);
-  DRAKE_ABORT();  // To avoid "control reaches end of non-void function" msg.
+  DRAKE_UNREACHABLE();
 }
 
 api::LanePosition MockLane::DoEvalMotionDerivatives(
     const api::LanePosition&, const api::IsoLaneVelocity&) const {
   DRAKE_THROW_UNLESS(false);
-  DRAKE_ABORT();  // To avoid "control reaches end of non-void function" msg.
+  DRAKE_UNREACHABLE();
 }
 
 api::LanePosition MockLane::DoToLanePosition(
     const api::GeoPosition&, api::GeoPosition*, double*) const {
   DRAKE_THROW_UNLESS(false);
-  DRAKE_ABORT();  // To avoid "control reaches end of non-void function" msg.
+  DRAKE_UNREACHABLE();
 }
 
 

--- a/automotive/maliput/multilane/builder.cc
+++ b/automotive/maliput/multilane/builder.cc
@@ -326,8 +326,8 @@ Vector3<double> DirectionOutFromLane(const api::Lane* const lane,
       return lane->GetOrientation({lane->length(), r_offset, 0.}).matrix() *
              s_hat;
     }
-    default: { DRAKE_ABORT(); }
   }
+  DRAKE_UNREACHABLE();
 }
 
 
@@ -437,6 +437,7 @@ void Builder::AttachBranchPoint(
     std::map<Endpoint, BranchPoint*, EndpointFuzzyOrder>* bp_map) const {
   BranchPoint* bp = FindOrCreateBranchPoint(point, road_geometry, bp_map);
   // Tell the lane about its branch-point.
+  DRAKE_DEMAND((end == api::LaneEnd::kStart) || (end == api::LaneEnd::kFinish));
   switch (end) {
     case api::LaneEnd::kStart: {
       lane->SetStartBp(bp);
@@ -446,7 +447,6 @@ void Builder::AttachBranchPoint(
       lane->SetEndBp(bp);
       break;
     }
-    default: { DRAKE_ABORT(); }
   }
   // Now, tell the branch-point about the lane.
   //

--- a/automotive/maliput/multilane/builder.h
+++ b/automotive/maliput/multilane/builder.h
@@ -656,13 +656,13 @@ class Builder : public BuilderBase {
                 case -1: { return true; }
                 case 1: { return false; }
                 case 0: { return false; }
-                default: { DRAKE_ABORT(); }
+                default: { DRAKE_ABORT_MSG("fuzzy_compare domain error"); }
               }
             }
-            default: { DRAKE_ABORT(); }
+            default: { DRAKE_ABORT_MSG("fuzzy_compare domain error"); }
           }
         }
-        default: { DRAKE_ABORT(); }
+        default: { DRAKE_ABORT_MSG("fuzzy_compare domain error"); }
       }
     }
 

--- a/automotive/maliput/multilane/connection.cc
+++ b/automotive/maliput/multilane/connection.cc
@@ -262,10 +262,8 @@ std::unique_ptr<RoadCurve> Connection::CreateRoadCurve() const {
           center, radius_, theta0_, d_theta_, elevation, superelevation,
           linear_tolerance_, scale_length_, computation_policy_);
     };
-    default: {
-      DRAKE_ABORT();
-    }
   }
+  DRAKE_UNREACHABLE();
 }
 
 }  // namespace multilane

--- a/automotive/maliput/multilane/lane.cc
+++ b/automotive/maliput/multilane/lane.cc
@@ -17,7 +17,7 @@ const api::BranchPoint* Lane::DoGetBranchPoint(
     case api::LaneEnd::kStart:  { return start_bp_; }
     case api::LaneEnd::kFinish: { return end_bp_; }
   }
-  DRAKE_ABORT();
+  DRAKE_UNREACHABLE();
 }
 
 const api::LaneEndSet* Lane::DoGetConfluentBranches(

--- a/automotive/maliput/multilane/loader.cc
+++ b/automotive/maliput/multilane/loader.cc
@@ -173,7 +173,7 @@ ComputationPolicy ParseComputationPolicy(const YAML::Node& node) {
   if (policy == "prefer-speed") {
     return ComputationPolicy::kPreferSpeed;
   }
-  DRAKE_ABORT();
+  throw std::runtime_error("Unknown ComputationPolicy");
 }
 
 // Builds a LaneLayout based `node`'s lane node, the left and right shoulders.
@@ -230,9 +230,8 @@ Direction ResolveDirection(const std::string& direction_key) {
     return Direction::kForward;
   } else if (direction_key == "reverse") {
     return Direction::kReverse;
-  } else {
-    DRAKE_ABORT();
   }
+  throw std::runtime_error("Unknown direction_key");
 }
 
 // Returns the Direction that `end_key` sets to the Endpoint / EndpointZ.
@@ -242,9 +241,8 @@ api::LaneEnd::Which ResolveEnd(const std::string& end_key) {
     return api::LaneEnd::Which::kStart;
   } else if (end_key == "end") {
     return api::LaneEnd::Which::kFinish;
-  } else {
-    DRAKE_ABORT();
   }
+  throw std::runtime_error("Unknown end_key");
 }
 
 // Returns a ParsedReference structure by extracting keywords from
@@ -280,7 +278,7 @@ ParsedReference ResolveEndpointReference(const std::string& endpoint_key) {
     parsed_reference.lane_id = pieces_match[3].str() == "ref"
         ? nullopt : optional<int>(std::atoi(pieces_match[3].str().c_str()));
   } else {
-    DRAKE_ABORT();
+    throw std::runtime_error("Unknown endpoint reference");
   }
   return parsed_reference;
 }
@@ -363,7 +361,7 @@ optional<std::pair<ParsedAnchorPoint, StartSpec>> ResolveEndpoint(
           parsed_reference.end.value(), parsed_reference.direction);
     }
   } else {
-    DRAKE_ABORT();
+    throw std::runtime_error("Unknown endpoint");
   }
   return {{parsed_anchor_point, spec}};
 }
@@ -435,10 +433,10 @@ optional<std::pair<ParsedAnchorPoint, EndSpec>> ResolveEndpointZ(
             parsed_reference.end.value(), parsed_reference.direction);
       }
     } else {
-      DRAKE_ABORT();
+      throw std::runtime_error("Unknown EndpointZ scalar");
     }
   } else {
-    DRAKE_ABORT();
+    throw std::runtime_error("Unknown EndpointZ node type");
   }
   return {{parsed_anchor_point, spec}};
 }
@@ -523,10 +521,8 @@ const Connection* MaybeMakeConnection(
                                   ParseArcOffset(node["arc"]),
                                   *(end_spec->second.ref_spec));
         }
-        default: {
-          DRAKE_ABORT();
-        }
       }
+      DRAKE_UNREACHABLE();
     }
     case AnchorPointType::kLane: {
       switch (geometry_type) {
@@ -542,15 +538,11 @@ const Connection* MaybeMakeConnection(
                                   ParseArcOffset(node["arc"]),
                                   *(end_spec->second.lane_spec));
         }
-        default: {
-          DRAKE_ABORT();
-        }
       }
-    }
-    default: {
-      DRAKE_ABORT();
+      DRAKE_UNREACHABLE();
     }
   }
+  DRAKE_UNREACHABLE();
 }
 
 // Parses a YAML `node` that represents a RoadGeometry.

--- a/automotive/maliput/rndf/builder.cc
+++ b/automotive/maliput/rndf/builder.cc
@@ -82,8 +82,8 @@ double HeadingIntoLane(const api::Lane* const lane,
     case api::LaneEnd::kFinish: {
       return lane->GetOrientation({lane->length(), 0., 0.}).yaw() + M_PI;
     }
-    default: { DRAKE_ABORT(); }
   }
+  DRAKE_UNREACHABLE();
 }
 
 // Computes the Euclidean distance between @p base and @p target,
@@ -327,6 +327,7 @@ void AttachLaneEndToBranchPoint(const api::LaneEnd::Which end, Lane* lane,
   DRAKE_DEMAND(lane != nullptr);
   DRAKE_DEMAND(branch_point != nullptr);
   // Tells the lane about its branch-point.
+  DRAKE_DEMAND((end == api::LaneEnd::kStart) || (end == api::LaneEnd::kFinish));
   switch (end) {
     case api::LaneEnd::kStart: {
       lane->SetStartBp(branch_point);
@@ -336,7 +337,6 @@ void AttachLaneEndToBranchPoint(const api::LaneEnd::Which end, Lane* lane,
       lane->SetEndBp(branch_point);
       break;
     }
-    default: { DRAKE_ABORT(); }
   }
   // Tells the BranchPoint about the lane. When the A-Side is empty, it adds
   // the LaneEnd to it.

--- a/automotive/maliput/rndf/lane.cc
+++ b/automotive/maliput/rndf/lane.cc
@@ -18,7 +18,7 @@ const api::BranchPoint* Lane::DoGetBranchPoint(
       return end_bp_;
     }
   }
-  DRAKE_ABORT_MSG("which_end value is not supported.");
+  DRAKE_UNREACHABLE();
 }
 
 const api::LaneEndSet* Lane::DoGetConfluentBranches(

--- a/automotive/maliput/rndf/road_geometry.cc
+++ b/automotive/maliput/rndf/road_geometry.cc
@@ -1,5 +1,7 @@
 #include "drake/automotive/maliput/rndf/road_geometry.h"
 
+#include <stdexcept>
+
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_throw.h"
 
@@ -33,7 +35,8 @@ api::RoadPosition RoadGeometry::DoToRoadPosition(const api::GeoPosition&,
                                                  api::GeoPosition*,
                                                  double*) const {
   // TODO(@agalbachicar) We need to find a way of implement this.
-  DRAKE_ABORT();
+  throw std::runtime_error(
+      "RoadGeometry::DoToRoadPosition is not implemented");
 }
 
 }  // namespace rndf

--- a/automotive/maliput/rndf/road_geometry.h
+++ b/automotive/maliput/rndf/road_geometry.h
@@ -66,7 +66,9 @@ class RoadGeometry : public api::RoadGeometry {
   const api::BranchPoint* do_branch_point(int index) const override;
 
   // TODO(maddog@tri.global) Implement when someone needs it.
-  const IdIndex& DoById() const override { DRAKE_ABORT(); }
+  const IdIndex& DoById() const override {
+    throw std::runtime_error("RoadGeometry::DoById is not implemented");
+  }
 
   // This function will abort as it's not implemented and should not be called.
   api::RoadPosition DoToRoadPosition(const api::GeoPosition& geo_pos,

--- a/automotive/maliput/rndf/spline_lane.cc
+++ b/automotive/maliput/rndf/spline_lane.cc
@@ -1,5 +1,6 @@
 #include "drake/automotive/maliput/rndf/spline_lane.h"
 
+#include <stdexcept>
 #include <utility>
 
 #include "drake/common/drake_assert.h"
@@ -38,7 +39,7 @@ api::LanePosition SplineLane::DoToLanePosition(const api::GeoPosition&,
                                                api::GeoPosition*,
                                                double*) const {
   // TODO(@agalbachicar) We need to find a way to implement it.
-  DRAKE_ABORT();
+  throw std::runtime_error("SplineLane::DoToLanePosition is not implemented");
 }
 
 api::GeoPosition SplineLane::DoToGeoPosition(

--- a/automotive/maliput/simplerulebook/simple_rulebook.cc
+++ b/automotive/maliput/simplerulebook/simple_rulebook.cc
@@ -211,7 +211,7 @@ QueryResults SimpleRulebook::DoFindRules(
       } else if (id.s) {
         result.speed_limit.push_back(speed_limits_.at(*id.s));
       } else {
-        DRAKE_ABORT();
+        DRAKE_ABORT_MSG("IdVariant is empty");
       }
     }
   }

--- a/automotive/maliput/utility/yaml_to_obj.cc
+++ b/automotive/maliput/utility/yaml_to_obj.cc
@@ -82,10 +82,9 @@ int main(int argc, char* argv[]) {
       drake::log()->info("Loaded a multilane road geometry.");
       break;
     }
-    default: {
+    case MaliputImplementation::kUnknown: {
       drake::log()->error("Unknown map.");
-      DRAKE_ABORT();
-      break;
+      return 1;
     }
   }
 

--- a/automotive/road_path.cc
+++ b/automotive/road_path.cc
@@ -1,5 +1,6 @@
 #include "drake/automotive/road_path.h"
 
+#include <stdexcept>
 #include <vector>
 
 #include "drake/automotive/maliput/api/branch_point.h"
@@ -40,7 +41,8 @@ template <typename T>
 const T RoadPath<T>::GetClosestPathPosition(const Vector3<T>& geo_pos,
                                             const T& s_guess) const {
   unused(geo_pos, s_guess);
-  DRAKE_ABORT();
+  throw std::runtime_error(
+      "RoadPath<T>::GetClosestPathPosition is not implemented");
 }
 
 template <typename T>

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -32,9 +32,8 @@ int GetVariableSize(const multibody::MultibodyPlant<T>& plant,
       return plant.num_positions();
     case multibody::JacobianWrtVariable::kV:
       return plant.num_velocities();
-    default:
-      DRAKE_ABORT();
   }
+  DRAKE_UNREACHABLE();
 }
 
 PYBIND11_MODULE(plant, m) {

--- a/common/symbolic_expression_visitor.h
+++ b/common/symbolic_expression_visitor.h
@@ -70,13 +70,11 @@ Result VisitPolynomial(Visitor* v, const Expression& e, Args&&... args) {
     case ExpressionKind::Floor:
     case ExpressionKind::IfThenElse:
     case ExpressionKind::UninterpretedFunction:
-      // Should not be reachable because of `DRAKE_DEMAND(e.is_polynomial())` at
-      // the top.
-      DRAKE_ABORT();
+      // Unreachable because of `DRAKE_DEMAND(e.is_polynomial())` at the top.
+      DRAKE_ABORT_MSG("Unexpected Kind was is_polynomial");
   }
-  // Should not be reachable. But we need the following to avoid "control
-  // reaches end of non-void function" gcc-warning.
-  DRAKE_ABORT();
+  // Unreachable because all switch cases are accounted for above.
+  DRAKE_UNREACHABLE();
 }
 
 /// Calls visitor object @p v with a symbolic-expression @p e, and arguments @p
@@ -173,9 +171,7 @@ Result VisitExpression(Visitor* v, const Expression& e, Args&&... args) {
     case ExpressionKind::UninterpretedFunction:
       return v->VisitUninterpretedFunction(e, std::forward<Args>(args)...);
   }
-  // Should not be reachable. But we need the following to avoid "control
-  // reaches end of non-void function" gcc-warning.
-  DRAKE_ABORT();
+  DRAKE_UNREACHABLE();
 }
 
 }  // namespace symbolic

--- a/common/symbolic_formula_visitor.h
+++ b/common/symbolic_formula_visitor.h
@@ -57,9 +57,7 @@ Result VisitFormula(Visitor* v, const Formula& f, Args&&... args) {
     case FormulaKind::PositiveSemidefinite:
       return v->VisitPositiveSemidefinite(f, std::forward<Args>(args)...);
   }
-  // Should not be reachable. But we need the following to avoid "control
-  // reaches end of non-void function" gcc-warning.
-  DRAKE_ABORT();
+  DRAKE_UNREACHABLE();
 }
 
 }  // namespace symbolic

--- a/common/symbolic_variable.cc
+++ b/common/symbolic_variable.cc
@@ -66,8 +66,7 @@ ostream& operator<<(ostream& os, Variable::Type type) {
     case Variable::Type::RANDOM_EXPONENTIAL:
       return os << "Random Exponential";
   }
-  // Should be unreachable.
-  DRAKE_ABORT();
+  DRAKE_UNREACHABLE();
 }
 
 MatrixX<Variable> MakeMatrixVariable(const int rows, const int cols,

--- a/common/test/drake_assert_test.cc
+++ b/common/test/drake_assert_test.cc
@@ -9,9 +9,20 @@ namespace {
 
 GTEST_TEST(DrakeAssertDeathTest, AbortTest) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   ASSERT_DEATH(
       { DRAKE_ABORT(); },
       "abort: Failure at .*drake_assert_test.cc:.. in TestBody");
+#pragma GCC diagnostic pop
+}
+
+GTEST_TEST(DrakeAssertDeathTest, AbortMsgTest) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  ASSERT_DEATH(
+      { DRAKE_ABORT_MSG("stuff"); },
+      "abort: Failure at .*drake_assert_test.cc:.. in TestBody..: "
+      "condition 'stuff' failed");
 }
 
 GTEST_TEST(DrakeAssertDeathTest, DemandTest) {

--- a/common/test/symbolic_simplification_test.cc
+++ b/common/test/symbolic_simplification_test.cc
@@ -292,8 +292,7 @@ std::function<Expression(const Variable& x)>UnaryOpToFunction(UnaryTestOp op) {
     case Ceil:  return [](const Variable& x) { return ceil(x); };
     case Floor: return [](const Variable& x) { return floor(x); };
   }
-  // Should not be reachable.
-  DRAKE_ABORT();
+  DRAKE_UNREACHABLE();
 }
 
 class SymbolicUnificationTestUnary
@@ -344,7 +343,7 @@ std::function<Expression(const Variable&, const Variable&)>
       return [](const Variable& x, const Variable& y) { return atan2(x, y); };
   }
   // Should not be reachable.
-  DRAKE_ABORT();
+  DRAKE_UNREACHABLE();
 }
 
 class SymbolicUnificationTestBinary

--- a/examples/bouncing_ball/test/bouncing_ball_test.cc
+++ b/examples/bouncing_ball/test/bouncing_ball_test.cc
@@ -40,31 +40,27 @@ std::pair<double, double> CalcClosedFormHeightAndVelocity(double g,
       // Ball has hit the ground.
       return std::make_pair(0.0, 0.0);
     }
-  } else {
-    if (e == 1.0) {
-      // Get the number of phases that have passed.
-      int num_phases = static_cast<int>(std::floor(tf / drop_time));
-
-      // Get the time within the phase.
-      const double t = tf - num_phases*drop_time;
-
-      // Even phases mean that the ball is falling, odd phases mean that it is
-      // rising.
-      if ((num_phases & 1) == 0) {
-        return std::make_pair(g*t*t/2 + x0, g*t);
-      } else {
-        // Get the ball velocity at the time of impact.
-        const double vf = g*drop_time;
-        return std::make_pair(g*t*t/2 - vf*t, g*t - vf);
-      }
-    } else {
-      throw std::logic_error("Invalid restitution coefficient!");
-    }
-
-    // Should never reach here.
-    DRAKE_ABORT();
-    return std::make_pair(0.0, 0.0);
   }
+
+  if (e == 1.0) {
+    // Get the number of phases that have passed.
+    int num_phases = static_cast<int>(std::floor(tf / drop_time));
+
+    // Get the time within the phase.
+    const double t = tf - num_phases*drop_time;
+
+    // Even phases mean that the ball is falling, odd phases mean that it is
+    // rising.
+    if ((num_phases & 1) == 0) {
+      return std::make_pair(g*t*t/2 + x0, g*t);
+    } else {
+      // Get the ball velocity at the time of impact.
+      const double vf = g*drop_time;
+      return std::make_pair(g*t*t/2 - vf*t, g*t - vf);
+    }
+  }
+
+  throw std::logic_error("Invalid restitution coefficient!");
 }
 
 class BouncingBallTest : public ::testing::Test {

--- a/examples/kuka_iiwa_arm/pick_and_place/pick_and_place_state_machine.cc
+++ b/examples/kuka_iiwa_arm/pick_and_place/pick_and_place_state_machine.cc
@@ -636,9 +636,8 @@ std::ostream& operator<<(std::ostream& os, const PickAndPlaceState value) {
       return os << "kReset";
     case (PickAndPlaceState::kDone):
       return os << "kDone";
-    default:
-      DRAKE_ABORT();
   }
+  DRAKE_UNREACHABLE();
 }
 
 PickAndPlaceStateMachine::PickAndPlaceStateMachine(

--- a/examples/rod2d/rod2d-inl.h
+++ b/examples/rod2d/rod2d-inl.h
@@ -83,7 +83,7 @@ int Rod2D<T>::DetermineNumWitnessFunctions(
     return 0;
 
   // TODO(edrumwri): Flesh out this stub.
-  DRAKE_ABORT();
+  DRAKE_ABORT_MSG("Rod2D<T>::DetermineNumWitnessFunctions is stubbed");
   return 0;
 }
 
@@ -1037,7 +1037,8 @@ void Rod2D<T>::DoCalcTimeDerivatives(
     return CalcAccelerationsCompliantContactAndBallistic(context, derivatives);
   } else {
     // TODO(edrumwri): Implement the piecewise DAE approach.
-    DRAKE_ABORT();
+    DRAKE_ABORT_MSG(
+        "Rod2D<T>::DoCalcTimeDerivatives: piecewise DAE isn't implemented yet");
   }
 }
 

--- a/manipulation/planner/differential_inverse_kinematics.cc
+++ b/manipulation/planner/differential_inverse_kinematics.cc
@@ -55,9 +55,8 @@ std::ostream& operator<<(std::ostream& os,
       return os << "No solution found.";
     case (DifferentialInverseKinematicsStatus::kStuck):
       return os << "Stuck!";
-    default:
-      DRAKE_ABORT();
   }
+  DRAKE_UNREACHABLE();
 }
 
 const std::vector<std::shared_ptr<solvers::LinearConstraint>>&

--- a/multibody/parsing/detail_scene_graph.cc
+++ b/multibody/parsing/detail_scene_graph.cc
@@ -156,7 +156,7 @@ std::unique_ptr<geometry::Shape> MakeShapeFromSdfGeometry(
     }
   }
 
-  DRAKE_ABORT_MSG("NOTREACHED");
+  DRAKE_UNREACHABLE();
 }
 
 std::unique_ptr<GeometryInstance> MakeGeometryInstanceFromSdfVisual(

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -1111,7 +1111,7 @@ void MultibodyTree<T>::CalcJacobianSpatialVelocity(
       case JacobianWrtVariable::kV:
         return false;
     }
-    DRAKE_ABORT();  // NOTREACHED
+    DRAKE_UNREACHABLE();
   }();
   const int num_columns = wrt_qdot ? num_positions() : num_velocities();
   DRAKE_THROW_UNLESS(Jw_V_ABp_E->cols() == num_columns);

--- a/solvers/branch_and_bound.cc
+++ b/solvers/branch_and_bound.cc
@@ -271,9 +271,7 @@ bool MixedIntegerBranchAndBoundNode::optimal_solution_is_integral() const {
           "function.");
     }
   }
-  // It is impossible to reach this DRAKE_ABORT(), but gcc throws the error
-  // Werror=return-type, if we do not have it here.
-  DRAKE_ABORT();
+  DRAKE_UNREACHABLE();
 }
 
 bool IsVariableInList(const std::list<symbolic::Variable>& variable_list,
@@ -496,9 +494,7 @@ MixedIntegerBranchAndBoundNode* MixedIntegerBranchAndBound::PickBranchingNode()
       }
     }
   }
-  // It is impossible to reach this DRAKE_ABORT(), but gcc throws the error
-  // Werror=return-type, if we do not have it here.
-  DRAKE_ABORT();
+  DRAKE_UNREACHABLE();
 }
 
 namespace {
@@ -650,9 +646,7 @@ const symbolic::Variable* MixedIntegerBranchAndBound::PickBranchingVariable(
           "SetUserDefinedVariableSelectionFunction to provide the user-defined "
           "function for selecting the branching variable.");
   }
-  // It is impossible to reach this DRAKE_ABORT(), but gcc throws the error
-  // Werror=return-type, if we do not have it here.
-  DRAKE_ABORT();
+  DRAKE_UNREACHABLE();
 }
 
 bool MixedIntegerBranchAndBound::IsLeafNodeFathomed(

--- a/solvers/create_constraint.cc
+++ b/solvers/create_constraint.cc
@@ -452,14 +452,13 @@ shared_ptr<Constraint> MakePolynomialConstraint(
         if (monomial.terms.size() == 0) {
           linear_constraint_lb[poly_num] -= monomial.coefficient;
           linear_constraint_ub[poly_num] -= monomial.coefficient;
-        } else if (monomial.terms.size() == 1) {
+        } else {
+          DRAKE_DEMAND(monomial.terms.size() == 1);  // Because isAffine().
           const Polynomiald::VarType term_var = monomial.terms[0].var;
           int var_num = (find(poly_vars.begin(), poly_vars.end(), term_var) -
                          poly_vars.begin());
           DRAKE_ASSERT(var_num < static_cast<int>(poly_vars.size()));
           linear_constraint_matrix(poly_num, var_num) = monomial.coefficient;
-        } else {
-          DRAKE_ABORT();  // Can't happen (unless isAffine() lied to us).
         }
       }
     }

--- a/solvers/solver_type_converter.cc
+++ b/solvers/solver_type_converter.cc
@@ -44,7 +44,7 @@ SolverId SolverTypeConverter::TypeToId(SolverType solver_type) {
     case SolverType::kUnrevisedLemke:
       return UnrevisedLemkeSolverId::id();
   }
-  DRAKE_ABORT();
+  DRAKE_UNREACHABLE();
 }
 
 optional<SolverType> SolverTypeConverter::IdToType(SolverId solver_id) {

--- a/solvers/test/solver_type_converter_test.cc
+++ b/solvers/test/solver_type_converter_test.cc
@@ -40,7 +40,7 @@ optional<SolverType> successor(optional<SolverType> solver_type) {
     case SolverType::kUnrevisedLemke:
       return nullopt;
   }
-  DRAKE_ABORT();
+  DRAKE_UNREACHABLE();
 }
 
 GTEST_TEST(SolverId, RoundTrip) {

--- a/systems/analysis/implicit_euler_integrator-inl.h
+++ b/systems/analysis/implicit_euler_integrator-inl.h
@@ -684,24 +684,19 @@ MatrixX<T> ImplicitEulerIntegrator<T>::CalcJacobian(const T& t,
       get_mutable_continuous_state();
 
   // TODO(edrumwri): Give the caller the option to provide their own Jacobian.
-  MatrixX<T> J;
-  switch (jacobian_scheme_) {
-    case JacobianComputationScheme::kForwardDifference:
-      J = ComputeForwardDiffJacobian(system, *context, &continuous_state);
-      break;
+  const MatrixX<T> J = [&]() {
+    switch (jacobian_scheme_) {
+      case JacobianComputationScheme::kForwardDifference:
+        return ComputeForwardDiffJacobian(system, *context, &continuous_state);
 
-    case JacobianComputationScheme::kCentralDifference:
-      J = ComputeCentralDiffJacobian(system, *context, &continuous_state);
-      break;
+      case JacobianComputationScheme::kCentralDifference:
+        return ComputeCentralDiffJacobian(system, *context, &continuous_state);
 
-    case JacobianComputationScheme::kAutomatic:
-      J = ComputeAutoDiffJacobian(system, *context);
-      break;
-
-    default:
-      // Should never get here.
-      DRAKE_ABORT();
-  }
+      case JacobianComputationScheme::kAutomatic:
+        return ComputeAutoDiffJacobian(system, *context);
+    }
+    DRAKE_UNREACHABLE();
+  }();
 
   // Use the new number of ODE evaluations to determine the number of Jacobian
   // evaluations.

--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -1231,16 +1231,15 @@ bool Simulator<T>::IntegrateContinuousState(
     case IntegratorBase<T>::kTimeHasAdvanced:
     case IntegratorBase<T>::kReachedBoundaryTime:
       return false;           // Did not hit a time for a timed event.
-      break;
 
-    default:DRAKE_ABORT_MSG("Unexpected integrator result.");
+    case IntegratorBase<T>::kReachedZeroCrossing:
+    case IntegratorBase<T>::kReachedStepLimit:
+      throw std::logic_error("Unexpected integrator result");
   }
 
   // TODO(sherm1) Constraint projection goes here.
 
-  // Should never get here.
-  DRAKE_ABORT();
-  return false;
+  DRAKE_UNREACHABLE();
 }
 
 }  // namespace systems

--- a/systems/framework/event_collection.h
+++ b/systems/framework/event_collection.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <stdexcept>
 #include <utility>
 #include <vector>
 
@@ -172,9 +173,11 @@ class DiagramEventCollection final : public EventCollection<EventType> {
         owned_subevent_collection_(num_subsystems) {}
 
   /**
-   * Aborts if called, because no events should be added at the Diagram level.
+   * Throws if called, because no events should be added at the Diagram level.
    */
-  void add_event(std::unique_ptr<EventType>) override { DRAKE_ABORT(); }
+  void add_event(std::unique_ptr<EventType>) override {
+    throw std::logic_error("DiagramEventCollection::add_event is not allowed");
+  }
 
   /**
    * Returns the number of constituent EventCollection objects that correspond

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -2200,7 +2200,7 @@ class System : public SystemBase {
         };
       }
     }
-    DRAKE_ABORT();
+    DRAKE_UNREACHABLE();
   }
 
   // Shared code for updating a vector input port and returning a pointer to its

--- a/systems/framework/system_scalar_converter.h
+++ b/systems/framework/system_scalar_converter.h
@@ -250,7 +250,7 @@ static std::unique_ptr<System<T>> Make(
     bool, const System<U>&, std::false_type) {
   // AddIfSupported is guaranteed not to call us, but we *will* be compiled,
   // so we have to have some kind of function body.
-  DRAKE_ABORT();
+  throw std::logic_error("system_scalar_converter_detail");
 }
 }  // namespace system_scalar_converter_detail
 

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -2574,7 +2574,7 @@ class MyEventTestSystem : public LeafSystem<double> {
           TriggerType::kPerStep) {
         per_step_count_++;
       } else {
-        DRAKE_ABORT();
+        ADD_FAILURE() << "MyEventTestSystem doesn't support this trigger type";
       }
     }
   }

--- a/systems/framework/test/output_port_test.cc
+++ b/systems/framework/test/output_port_test.cc
@@ -69,9 +69,9 @@ class MyOutputPort : public OutputPort<double> {
     return *temp.access();
   }
 
-  // We won't call this.
   internal::OutputPortPrerequisite DoGetPrerequisite() const override {
-    DRAKE_ABORT();
+    ADD_FAILURE() << "We won't call this.";
+    return {};
   };
 };
 

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -43,9 +43,9 @@ class TestSystem : public System<double> {
     this->set_name("TestSystem");
   }
 
-  // Implementation is required, but unused here.
   int get_num_continuous_states() const final {
-    DRAKE_ABORT();
+    ADD_FAILURE() << "Implementation is required, but unused here.";
+    return {};
   }
 
   ~TestSystem() override {}
@@ -115,15 +115,14 @@ class TestSystem : public System<double> {
 
   double DoCalcWitnessValue(const Context<double>&,
                             const WitnessFunction<double>&) const override {
-    // This system uses no witness functions.
-    DRAKE_ABORT();
+    ADD_FAILURE() << "This system uses no witness functions.";
+    return {};
   }
 
   void AddTriggeredWitnessFunctionToCompositeEventCollection(
       Event<double>*,
       CompositeEventCollection<double>*) const override {
-    // This system uses no witness functions.
-    DRAKE_ABORT();
+    ADD_FAILURE() << "This system uses no witness functions.";
   }
 
   // The default publish function.
@@ -169,7 +168,7 @@ class TestSystem : public System<double> {
       const Context<double>&,
       const EventCollection<UnrestrictedUpdateEvent<double>>&,
       State<double>*) const final {
-    DRAKE_ABORT_MSG("test should not get here");
+    ADD_FAILURE() << "Implementation is required, but unused here.";
   }
 
   // Sets up an arbitrary mapping from the current time to the next discrete
@@ -499,24 +498,23 @@ class ValueIOTestSystem : public System<T> {
     this->set_name("ValueIOTestSystem");
   }
 
-  // Implementation is required, but unused here.
   int get_num_continuous_states() const final {
-    DRAKE_ABORT();
+    ADD_FAILURE() << "Implementation is required, but unused here.";
+    return {};
   }
 
     ~ValueIOTestSystem() override {}
 
   T DoCalcWitnessValue(const Context<T>&,
                        const WitnessFunction<T>&) const override {
-    // This system uses no witness functions.
-    DRAKE_ABORT();
+    ADD_FAILURE() << "This system uses no witness functions.";
+    return {};
   }
 
   void AddTriggeredWitnessFunctionToCompositeEventCollection(
       Event<T>*,
       CompositeEventCollection<T>*) const override {
-    // This system uses no witness functions.
-    DRAKE_ABORT();
+    ADD_FAILURE() << "This system uses no witness functions.";
   }
 
   std::unique_ptr<AbstractValue> DoAllocateInput(
@@ -582,21 +580,21 @@ class ValueIOTestSystem : public System<T> {
   void DispatchPublishHandler(
       const Context<T>& context,
       const EventCollection<PublishEvent<T>>& event_info) const final {
-    DRAKE_ABORT_MSG("test should not get here");
+    ADD_FAILURE() << "Implementation is required, but unused here.";
   }
 
   void DispatchDiscreteVariableUpdateHandler(
       const Context<T>& context,
       const EventCollection<DiscreteUpdateEvent<T>>& event_info,
       DiscreteValues<T>* discrete_state) const final {
-    DRAKE_ABORT_MSG("test should not get here");
+    ADD_FAILURE() << "Implementation is required, but unused here.";
   }
 
   void DispatchUnrestrictedUpdateHandler(
       const Context<T>& context,
       const EventCollection<UnrestrictedUpdateEvent<T>>& event_info,
       State<T>* state) const final {
-    DRAKE_ABORT_MSG("test should not get here");
+    ADD_FAILURE() << "Implementation is required, but unused here.";
   }
 
   std::unique_ptr<EventCollection<PublishEvent<T>>>
@@ -843,9 +841,9 @@ class ComputationTestSystem final : public System<double> {
     EXPECT_EQ(pnc, pnc_count_);
   }
 
-  // Implementation is required, but unused here.
   int get_num_continuous_states() const final {
-    DRAKE_ABORT();
+    ADD_FAILURE() << "Implementation is required, but unused here.";
+    return {};
   }
 
  private:
@@ -916,11 +914,12 @@ class ComputationTestSystem final : public System<double> {
   std::multimap<int, int> GetDirectFeedthroughs() const final { return {}; }
   double DoCalcWitnessValue(const Context<double>&,
                             const WitnessFunction<double>&) const final {
-    DRAKE_ABORT_MSG("test should not get here");
+    ADD_FAILURE() << "Implementation is required, but unused here.";
+    return {};
   }
   void AddTriggeredWitnessFunctionToCompositeEventCollection(
       Event<double>*, CompositeEventCollection<double>*) const final {
-    DRAKE_ABORT_MSG("test should not get here");
+    ADD_FAILURE() << "Implementation is required, but unused here.";
   }
   std::unique_ptr<AbstractValue> DoAllocateInput(
       const InputPort<double>&) const final {
@@ -929,19 +928,19 @@ class ComputationTestSystem final : public System<double> {
   void DispatchPublishHandler(
       const Context<double>& context,
       const EventCollection<PublishEvent<double>>& events) const final {
-    DRAKE_ABORT_MSG("test should not get here");
+    ADD_FAILURE() << "Implementation is required, but unused here.";
   }
   void DispatchDiscreteVariableUpdateHandler(
       const Context<double>& context,
       const EventCollection<DiscreteUpdateEvent<double>>& events,
       DiscreteValues<double>* discrete_state) const final {
-    DRAKE_ABORT_MSG("test should not get here");
+    ADD_FAILURE() << "Implementation is required, but unused here.";
   }
   void DispatchUnrestrictedUpdateHandler(
       const Context<double>&,
       const EventCollection<UnrestrictedUpdateEvent<double>>&,
       State<double>*) const final {
-    DRAKE_ABORT_MSG("test should not get here");
+    ADD_FAILURE() << "Implementation is required, but unused here.";
   }
   std::map<PeriodicEventData, std::vector<const Event<double>*>,
            PeriodicEventDataComparator>

--- a/systems/framework/witness_function.h
+++ b/systems/framework/witness_function.h
@@ -209,10 +209,8 @@ class WitnessFunction final {
       case WitnessFunctionDirection::kCrossesZero:
         return ((w0 > zero && wf <= zero) ||
                 (w0 < zero && wf >= zero));
-
-      default:
-        DRAKE_ABORT();
     }
+    DRAKE_UNREACHABLE();
   }
 
   /// Sets the event that will be dispatched when the witness function


### PR DESCRIPTION
We want to remove `DRAKE_ABORT`, because all errors should have a useful message.

Many uses are replaced by a new `DRAKE_UNREACHABLE` macro.

(We may also end up removing "abort" entirely from Drake, since it is inappropriate for library code.  But that's still future work and up for debate.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10545)
<!-- Reviewable:end -->
