### PR TITLE
Use MPResult::is_success()

### DIFF
--- a/multibody/inverse_kinematics/test/inverse_kinematics_test.cc
+++ b/multibody/inverse_kinematics/test/inverse_kinematics_test.cc
@@ -231,8 +231,7 @@ TEST_F(TwoFreeSpheresTest, MinimalDistanceConstraintTest) {
   auto solve_and_check = [&]() {
     const solvers::MathematicalProgramResult result =
         Solve(ik.prog(), ik.prog().initial_guess());
-    EXPECT_EQ(result.get_solution_result(),
-              solvers::SolutionResult::kSolutionFound);
+    EXPECT_TRUE(result.is_success());
 
     const Eigen::Vector3d p_WB1 = result.GetSolution(ik.q().segment<3>(4));
     const Eigen::Quaterniond quat_WB1(

--- a/solvers/mathematical_program_result.cc
+++ b/solvers/mathematical_program_result.cc
@@ -25,6 +25,10 @@ const AbstractValue& MathematicalProgramResult::get_solver_details() const {
   return *solver_details_;
 }
 
+bool MathematicalProgramResult::is_success() const {
+  return solution_result_ == SolutionResult::kSolutionFound;
+}
+
 SolverResult MathematicalProgramResult::ConvertToSolverResult() const {
   SolverResult solver_result(solver_id_);
   if (x_val_.size() != 0) {

--- a/solvers/mathematical_program_result.h
+++ b/solvers/mathematical_program_result.h
@@ -28,8 +28,12 @@ class MathematicalProgramResult final {
    */
   MathematicalProgramResult();
 
-  /** Gets SolutionResult. */
-  SolutionResult get_solution_result() const { return solution_result_; }
+  /** Returns true if the optimization problem is solved successfully; false
+   * otherwise.
+   * For more information on the solution status, the user could call
+   * get_solver_details() to obtain the solver-specific solution status.
+   */
+  bool is_success() const;
 
   /**
    * Sets decision_variable_index mapping, that maps each decision variable to
@@ -48,6 +52,8 @@ class MathematicalProgramResult final {
 
   /** Gets the decision variable values. */
   const Eigen::VectorXd& get_x_val() const { return x_val_; }
+
+  SolutionResult get_solution_result() const { return solution_result_; }
 
   /** Sets the decision variable values. */
   void set_x_val(const Eigen::VectorXd& x_val);

--- a/solvers/mathematical_program_result.h
+++ b/solvers/mathematical_program_result.h
@@ -53,6 +53,7 @@ class MathematicalProgramResult final {
   /** Gets the decision variable values. */
   const Eigen::VectorXd& get_x_val() const { return x_val_; }
 
+  /** Gets SolutionResult. */
   SolutionResult get_solution_result() const { return solution_result_; }
 
   /** Sets the decision variable values. */

--- a/solvers/non_convex_optimization_util.cc
+++ b/solvers/non_convex_optimization_util.cc
@@ -45,7 +45,7 @@ std::pair<Eigen::MatrixXd, Eigen::MatrixXd> DecomposeNonConvexQuadraticForm(
   // Due to positive definiteness, both trace(Q1) and trace(Q2) are
   // non-negative, so min(max(trace(Q1), trace(Q2)) is lower bounded. Hence,
   // this optimal cost is not un-bounded.
-  DRAKE_DEMAND(result.get_solution_result() == SolutionResult::kSolutionFound);
+  DRAKE_DEMAND(result.is_success());
   auto Q1_sol = result.GetSolution(Q1);
   auto Q2_sol = result.GetSolution(Q2);
   return std::make_pair(Q1_sol, Q2_sol);

--- a/solvers/test/complementary_problem_test.cc
+++ b/solvers/test/complementary_problem_test.cc
@@ -84,7 +84,7 @@ GTEST_TEST(TestComplementaryProblem, flp2) {
   SnoptSolver snopt_solver;
   if (snopt_solver.available()) {
     MathematicalProgramResult result = Solve(prog);
-    EXPECT_EQ(result.get_solution_result(), SolutionResult::kSolutionFound);
+    EXPECT_TRUE(result.is_success());
     const auto x_val = result.GetSolution(x);
     const auto y_val = result.GetSolution(y);
     // Choose 1e-6 as the precision, since that is the default minor feasibility

--- a/solvers/test/diagonally_dominant_matrix_test.cc
+++ b/solvers/test/diagonally_dominant_matrix_test.cc
@@ -47,25 +47,21 @@ GTEST_TEST(DiagonallyDominantMatrixConstraint, FeasibilityCheck) {
   // [1 0.9;0.9 2] is diagonally dominant
   set_X_value(Eigen::Vector3d(1, 0.9, 2));
   MathematicalProgramResult result = Solve(prog);
-  EXPECT_EQ(result.get_solution_result(), SolutionResult::kSolutionFound);
+  EXPECT_TRUE(result.is_success());
 
   // [1 -0.9; -0.9 2] is diagonally dominant
   set_X_value(Eigen::Vector3d(1, -0.9, 2));
   result = Solve(prog);
-  EXPECT_EQ(result.get_solution_result(), SolutionResult::kSolutionFound);
+  EXPECT_TRUE(result.is_success());
 
   // [1 1.1; 1.1 2] is not diagonally dominant
   set_X_value(Eigen::Vector3d(1, 1.1, 2));
   result = Solve(prog);
-  EXPECT_TRUE(
-      result.get_solution_result() == SolutionResult::kInfeasibleConstraints ||
-      result.get_solution_result() == SolutionResult::kInfeasible_Or_Unbounded);
+  EXPECT_FALSE(result.is_success());
   // [1 -1.1; -1.1 2] is not diagonally dominant
   set_X_value(Eigen::Vector3d(1, -1.1, 2));
   result = Solve(prog);
-  EXPECT_TRUE(
-      result.get_solution_result() == SolutionResult::kInfeasibleConstraints ||
-      result.get_solution_result() == SolutionResult::kInfeasible_Or_Unbounded);
+  EXPECT_FALSE(result.is_success());
 }
 
 GTEST_TEST(DiagonallyDominantMatrixConstraint, three_by_three_vertices) {
@@ -100,7 +96,7 @@ GTEST_TEST(DiagonallyDominantMatrixConstraint, three_by_three_vertices) {
       // https://github.com/RobotLocomotion/drake/pull/9382
       // TODO(hongkai.dai): fix the problem in SnoptSolver wrapper and enable
       // this test with Snopt.
-      EXPECT_EQ(result.get_solution_result(), SolutionResult::kSolutionFound);
+      EXPECT_TRUE(result.is_success());
       EXPECT_TRUE(CompareMatrices(result.GetSolution(VectorDecisionVariable<3>(
                                       X(0, 1), X(0, 2), X(1, 2))),
                                   sol_expected, tol));

--- a/solvers/test/diagonally_dominant_matrix_test.cc
+++ b/solvers/test/diagonally_dominant_matrix_test.cc
@@ -58,10 +58,16 @@ GTEST_TEST(DiagonallyDominantMatrixConstraint, FeasibilityCheck) {
   set_X_value(Eigen::Vector3d(1, 1.1, 2));
   result = Solve(prog);
   EXPECT_FALSE(result.is_success());
+  EXPECT_TRUE(
+      result.get_solution_result() == SolutionResult::kInfeasibleConstraints ||
+      result.get_solution_result() == SolutionResult::kInfeasible_Or_Unbounded);
   // [1 -1.1; -1.1 2] is not diagonally dominant
   set_X_value(Eigen::Vector3d(1, -1.1, 2));
   result = Solve(prog);
   EXPECT_FALSE(result.is_success());
+  EXPECT_TRUE(
+      result.get_solution_result() == SolutionResult::kInfeasibleConstraints ||
+      result.get_solution_result() == SolutionResult::kInfeasible_Or_Unbounded);
 }
 
 GTEST_TEST(DiagonallyDominantMatrixConstraint, three_by_three_vertices) {

--- a/solvers/test/equality_constrained_qp_solver_test.cc
+++ b/solvers/test/equality_constrained_qp_solver_test.cc
@@ -132,7 +132,7 @@ GTEST_TEST(testEqualityConstrainedQPSolver,
   EqualityConstrainedQPSolver equality_qp_solver;
   MathematicalProgramResult result;
   equality_qp_solver.Solve(prog, {}, {}, &result);
-  EXPECT_EQ(result.get_solution_result(), SolutionResult::kSolutionFound);
+  EXPECT_TRUE(result.is_success());
   EXPECT_NEAR(result.GetSolution(x(0)), 0.5, 1E-10);
   EXPECT_NEAR(result.get_optimal_cost(), -0.25, 1E-10);
 }
@@ -334,8 +334,7 @@ GTEST_TEST(testEqualityConstrainedQPSolver, testFeasibilityTolerance) {
       EqualityConstrainedQPSolver::id(),
       EqualityConstrainedQPSolver::FeasibilityTolOptionName(), 0.1 * tol);
   equality_qp_solver.Solve(prog, {}, solver_options, &math_prog_result);
-  EXPECT_EQ(math_prog_result.get_solution_result(),
-            SolutionResult::kInfeasibleConstraints);
+  EXPECT_FALSE(math_prog_result.is_success());
 }
 
 // min x'*x + x0 + x1 + 1
@@ -351,7 +350,7 @@ GTEST_TEST(testEqualityConstrainedQPSolver, testLinearCost) {
 
   MathematicalProgramResult result;
   result = Solve(prog);
-  EXPECT_EQ(result.get_solution_result(), SolutionResult::kSolutionFound);
+  EXPECT_TRUE(result.is_success());
 
   EXPECT_TRUE(
       CompareMatrices(result.GetSolution(x), Eigen::Vector2d(-.5, -.5), 1e-6));

--- a/solvers/test/gurobi_solver_test.cc
+++ b/solvers/test/gurobi_solver_test.cc
@@ -53,8 +53,7 @@ TEST_F(UnboundedLinearProgramTest0, TestGurobiUnbounded) {
     solver_options.SetOption(GurobiSolver::id(), "DualReductions", 1);
     MathematicalProgramResult result;
     solver.Solve(*prog_, {}, solver_options, &result);
-    EXPECT_EQ(result.get_solution_result(),
-              SolutionResult::kInfeasible_Or_Unbounded);
+    EXPECT_FALSE(result.is_success());
     // This code is defined in
     // https://www.gurobi.com/documentation/8.0/refman/optimization_status_codes.html
     const int GRB_INF_OR_UNBD = 4;
@@ -65,7 +64,7 @@ TEST_F(UnboundedLinearProgramTest0, TestGurobiUnbounded) {
 
     solver_options.SetOption(GurobiSolver::id(), "DualReductions", 0);
     solver.Solve(*prog_, {}, solver_options, &result);
-    EXPECT_EQ(result.get_solution_result(), SolutionResult::kUnbounded);
+    EXPECT_FALSE(result.is_success());
     // This code is defined in
     // https://www.gurobi.com/documentation/8.0/refman/optimization_status_codes.html
     const int GRB_UNBOUNDED = 5;
@@ -119,7 +118,7 @@ GTEST_TEST(GurobiTest, TestInitialGuess) {
       x_expected[0] = x_expected0_to_test[i];
       prog.SetInitialGuess(x, x_expected);
       solver.Solve(prog, x_expected, {}, &result);
-      EXPECT_EQ(result.get_solution_result(), SolutionResult::kSolutionFound);
+      EXPECT_TRUE(result.is_success());
       const auto& x_value = result.GetSolution(x);
       EXPECT_TRUE(CompareMatrices(x_value, x_expected, 1E-6,
                                   MatrixCompareType::absolute));
@@ -222,7 +221,7 @@ GTEST_TEST(GurobiTest, TestCallbacks) {
 
       MathematicalProgramResult result;
       solver.Solve(prog, {}, {}, &result);
-      EXPECT_EQ(result.get_solution_result(), SolutionResult::kSolutionFound);
+      EXPECT_TRUE(result.is_success());
       const auto& x_value = result.GetSolution(x);
       EXPECT_TRUE(CompareMatrices(x_value, x_expected, 1E-6,
                                   MatrixCompareType::absolute));

--- a/solvers/test/gurobi_solver_test.cc
+++ b/solvers/test/gurobi_solver_test.cc
@@ -54,6 +54,8 @@ TEST_F(UnboundedLinearProgramTest0, TestGurobiUnbounded) {
     MathematicalProgramResult result;
     solver.Solve(*prog_, {}, solver_options, &result);
     EXPECT_FALSE(result.is_success());
+    EXPECT_EQ(result.get_solution_result(),
+              SolutionResult::kInfeasible_Or_Unbounded);
     // This code is defined in
     // https://www.gurobi.com/documentation/8.0/refman/optimization_status_codes.html
     const int GRB_INF_OR_UNBD = 4;
@@ -65,6 +67,7 @@ TEST_F(UnboundedLinearProgramTest0, TestGurobiUnbounded) {
     solver_options.SetOption(GurobiSolver::id(), "DualReductions", 0);
     solver.Solve(*prog_, {}, solver_options, &result);
     EXPECT_FALSE(result.is_success());
+    EXPECT_EQ(result.get_solution_result(), SolutionResult::kUnbounded);
     // This code is defined in
     // https://www.gurobi.com/documentation/8.0/refman/optimization_status_codes.html
     const int GRB_UNBOUNDED = 5;

--- a/solvers/test/integer_optimization_util_test.cc
+++ b/solvers/test/integer_optimization_util_test.cc
@@ -73,7 +73,7 @@ class IntegerOptimizationUtilTest : public ::testing::Test {
       b1_cnstr_.evaluator()->UpdateLowerBound(Vector1d(b_vals_[i](1)));
       b1_cnstr_.evaluator()->UpdateUpperBound(Vector1d(b_vals_[i](1)));
       MathematicalProgramResult result = Solve(prog_);
-      EXPECT_EQ(result.get_solution_result(), SolutionResult::kSolutionFound);
+      EXPECT_TRUE(result.is_success());
       double tol = 1E-3;
       if (result.get_solver_id() == OsqpSolver::id()) {
         // OSQP can solve linear program, but it is likely to fail in polishing,
@@ -88,7 +88,7 @@ class IntegerOptimizationUtilTest : public ::testing::Test {
       // The solution should be the same.
       cost.evaluator()->UpdateCoefficients(Vector1d(-1));
       result = Solve(prog_);
-      EXPECT_EQ(result.get_solution_result(), SolutionResult::kSolutionFound);
+      EXPECT_TRUE(result.is_success());
       EXPECT_NEAR(result.GetSolution(operand_result), operand_result_expected,
                   tol);
     }
@@ -137,21 +137,9 @@ GTEST_TEST(TestBinaryCodeMatchConstraint, Test) {
           match_constraint.evaluator()->UpdateLowerBound(Vector1d(match_val));
           const auto result = Solve(prog);
           if (b0_val == 0 && b1_val == 1 && b2_val == 1) {
-            if (match_val == 1.0) {
-              EXPECT_EQ(result.get_solution_result(),
-                        SolutionResult::kSolutionFound);
-            } else {
-              EXPECT_NE(result.get_solution_result(),
-                        SolutionResult::kSolutionFound);
-            }
+            EXPECT_EQ(result.is_success(), match_val == 1.0);
           } else {
-            if (match_val == 0.0) {
-              EXPECT_EQ(result.get_solution_result(),
-                        SolutionResult::kSolutionFound);
-            } else {
-              EXPECT_NE(result.get_solution_result(),
-                        SolutionResult::kSolutionFound);
-            }
+            EXPECT_EQ(result.is_success(), match_val == 0.0);
           }
         }
       }

--- a/solvers/test/ipopt_solver_test.cc
+++ b/solvers/test/ipopt_solver_test.cc
@@ -29,6 +29,8 @@ TEST_F(InfeasibleLinearProgramTest0, TestIpopt) {
     MathematicalProgramResult result;
     solver.Solve(*prog_, {}, {}, &result);
     EXPECT_FALSE(result.is_success());
+    EXPECT_EQ(result.get_solution_result(),
+              SolutionResult::kInfeasibleConstraints);
     // LOCAL_INFEASIBILITY is defined in IpAlgTypes.hpp from Ipopt source file.
     const int LOCAL_INFEASIBILITY = 5;
     EXPECT_EQ(result.get_solver_details().GetValue<IpoptSolverDetails>().status,
@@ -127,6 +129,7 @@ GTEST_TEST(IpoptSolverTest, AcceptableResult) {
       solver.Solve(prog, x_initial_guess, options, &result);
       // Expect to hit iteration limit
       EXPECT_FALSE(result.is_success());
+      EXPECT_EQ(result.get_solution_result(), SolutionResult::kIterationLimit);
       // MAXITER_EXCEEDED is defined in IpAlgTypes.hpp from Ipopt source code.
       const int MAXITER_EXCEEDED = 1;
       EXPECT_EQ(

--- a/solvers/test/linear_system_solver_test.cc
+++ b/solvers/test/linear_system_solver_test.cc
@@ -14,7 +14,7 @@ namespace test {
 namespace {
 void TestLinearSystemExample(LinearSystemExample1* example) {
   const MathematicalProgramResult result = Solve(*(example->prog()));
-  EXPECT_EQ(result.get_solution_result(), SolutionResult::kSolutionFound);
+  EXPECT_TRUE(result.is_success());
   example->CheckSolution(result);
 }
 }  // namespace
@@ -43,8 +43,7 @@ GTEST_TEST(testLinearSystemSolver, InfeasibleProblem) {
         x(0) - x(1) == 0);
 
   const MathematicalProgramResult result = Solve(prog);
-  EXPECT_EQ(result.get_solution_result(),
-            SolutionResult::kInfeasibleConstraints);
+  EXPECT_FALSE(result.is_success());
   // The solution should minimize the error ||b - A * x||₂
   // x_expected is computed as (Aᵀ*A)⁻¹*(Aᵀ*b)
   Eigen::Vector2d x_expected(12.0 / 27, 21.0 / 27);
@@ -65,7 +64,7 @@ GTEST_TEST(testLinearSystemSolver, UnderDeterminedProblem) {
   prog.AddLinearConstraint(3 * x(0) + x(1) == 1 && x(0) + x(2) == 2);
 
   const MathematicalProgramResult result = Solve(prog);
-  EXPECT_EQ(result.get_solution_result(), SolutionResult::kSolutionFound);
+  EXPECT_TRUE(result.is_success());
   // The solution should minimize the norm ||x||₂
   // x_expected is computed as the solution to
   // [2*I -Aᵀ] * [x] = [0]

--- a/solvers/test/mathematical_program_result_test.cc
+++ b/solvers/test/mathematical_program_result_test.cc
@@ -24,7 +24,7 @@ class MathematicalProgramResultTest : public ::testing::Test {
 
 TEST_F(MathematicalProgramResultTest, DefaultConstructor) {
   MathematicalProgramResult result;
-  EXPECT_EQ(result.get_solution_result(), SolutionResult::kUnknownError);
+  EXPECT_FALSE(result.is_success());
   EXPECT_EQ(result.get_x_val().size(), 0);
   EXPECT_TRUE(std::isnan(result.get_optimal_cost()));
   DRAKE_EXPECT_THROWS_MESSAGE(result.get_solver_details(), std::logic_error,
@@ -47,7 +47,7 @@ TEST_F(MathematicalProgramResultTest, Setters) {
   const double cost = 1;
   result.set_optimal_cost(cost);
   result.set_solver_id(SolverId("foo"));
-  EXPECT_EQ(result.get_solution_result(), SolutionResult::kSolutionFound);
+  EXPECT_TRUE(result.is_success());
   EXPECT_TRUE(CompareMatrices(result.get_x_val(), x_val));
   EXPECT_EQ(result.get_optimal_cost(), cost);
   EXPECT_EQ(result.get_solver_id().name(), "foo");

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -2820,7 +2820,7 @@ GTEST_TEST(testMathematicalProgram, testNonlinearExpressionConstraints) {
   prog.AddCost(x(0) + x(1));
   const MathematicalProgramResult result =
       Solve(prog, Eigen::Vector2d(-0.5, -0.5));
-  EXPECT_EQ(result.get_solution_result(), kSolutionFound);
+  EXPECT_TRUE(result.is_success());
   EXPECT_TRUE(CompareMatrices(result.get_x_val(),
                               Vector2d::Constant(-std::sqrt(2.) / 2.), 1e-6));
 }

--- a/solvers/test/mathematical_program_test_util.cc
+++ b/solvers/test/mathematical_program_test_util.cc
@@ -16,8 +16,8 @@ MathematicalProgramResult RunSolver(
 
   MathematicalProgramResult result{};
   solver.Solve(prog, initial_guess, {}, &result);
-  EXPECT_EQ(result.get_solution_result(), SolutionResult::kSolutionFound);
-  if (result.get_solution_result() != SolutionResult::kSolutionFound) {
+  EXPECT_TRUE(result.is_success());
+  if (!result.is_success()) {
     throw std::runtime_error(
         "Solver " + solver.solver_id().name() + " fails to find the solution");
   }

--- a/solvers/test/mixed_integer_rotation_constraint_internal_test.cc
+++ b/solvers/test/mixed_integer_rotation_constraint_internal_test.cc
@@ -222,7 +222,7 @@ GTEST_TEST(RotationTest, TestInnerFacetsAndHalfSpace) {
   prog.AddLinearConstraint(n.dot(x) >= d);
   prog.AddBoundingBoxConstraint(bmin, bmax, x);
   const MathematicalProgramResult result = Solve(prog);
-  EXPECT_EQ(result.get_solution_result(), SolutionResult::kSolutionFound);
+  EXPECT_TRUE(result.is_success());
 }
 
 // Test a number of closed-form solutions for the intersection of a box in the

--- a/solvers/test/mosek_solver_test.cc
+++ b/solvers/test/mosek_solver_test.cc
@@ -33,6 +33,7 @@ TEST_F(UnboundedLinearProgramTest0, Test) {
     solver.Solve(const_prog, {}, {}, &result);
     // Mosek can only detect dual infeasibility, not primal unboundedness.
     EXPECT_FALSE(result.is_success());
+    EXPECT_EQ(result.get_solution_result(), SolutionResult::kDualInfeasible);
     const MosekSolverDetails& mosek_solver_details =
         result.get_solver_details().GetValue<MosekSolverDetails>();
     EXPECT_EQ(mosek_solver_details.rescode, 0);

--- a/solvers/test/mosek_solver_test.cc
+++ b/solvers/test/mosek_solver_test.cc
@@ -32,9 +32,15 @@ TEST_F(UnboundedLinearProgramTest0, Test) {
     MathematicalProgramResult result;
     solver.Solve(const_prog, {}, {}, &result);
     // Mosek can only detect dual infeasibility, not primal unboundedness.
-    EXPECT_EQ(result.get_solution_result(), SolutionResult::kDualInfeasible);
-    EXPECT_EQ(
-        result.get_solver_details().GetValue<MosekSolverDetails>().rescode, 0);
+    EXPECT_FALSE(result.is_success());
+    const MosekSolverDetails& mosek_solver_details =
+        result.get_solver_details().GetValue<MosekSolverDetails>();
+    EXPECT_EQ(mosek_solver_details.rescode, 0);
+    // This problem status is defined in
+    // https://docs.mosek.com/8.1/capi/constants.html#mosek.prosta
+    const int MSK_SOL_STA_DUAL_INFEAS_CER = 6;
+    EXPECT_EQ(mosek_solver_details.solution_status,
+              MSK_SOL_STA_DUAL_INFEAS_CER);
   }
 }
 
@@ -164,13 +170,13 @@ GTEST_TEST(MosekTest, SolverOptionsTest) {
   MathematicalProgramResult result;
   MosekSolver mosek_solver;
   mosek_solver.Solve(prog, {}, solver_options, &result);
-  EXPECT_EQ(result.get_solution_result(), SolutionResult::kSolutionFound);
+  EXPECT_TRUE(result.is_success());
 
   // Now try a small positive semidefinite matrix tolerance.
   solver_options.SetOption(MosekSolver::id(),
                            "MSK_DPAR_SEMIDEFINITE_TOL_APPROX", 1E-10);
   mosek_solver.Solve(prog, {}, solver_options, &result);
-  EXPECT_NE(result.get_solution_result(), SolutionResult::kSolutionFound);
+  EXPECT_FALSE(result.is_success());
 }
 
 GTEST_TEST(MosekSolver, SolverOptionsErrorTest) {
@@ -195,7 +201,7 @@ GTEST_TEST(MosekSolver, SolverOptionsErrorTest) {
   const int MSK_PRO_STA_UNKNOWN = 0;
   EXPECT_EQ(solver_details.solution_status, MSK_PRO_STA_UNKNOWN);
 
-  EXPECT_EQ(result.get_solution_result(), SolutionResult::kUnknownError);
+  EXPECT_FALSE(result.is_success());
 }
 
 GTEST_TEST(MosekSolver, TestInitialGuess) {
@@ -231,14 +237,14 @@ GTEST_TEST(MosekSolver, TestInitialGuess) {
   MathematicalProgramResult result;
   solver.Solve(prog, prog.initial_guess(), solver_options, &result);
   const double tol = 1E-8;
-  EXPECT_EQ(result.get_solution_result(), SolutionResult::kSolutionFound);
+  EXPECT_TRUE(result.is_success());
   EXPECT_NEAR(result.get_optimal_cost(), 0.8, tol);
 
   // By setting y = (0, 0, 0, 1), point C is on the line segment A4A1. The
   // minimal squared distance is  1.0 / 17
   prog.SetInitialGuess(y, Eigen::Vector4d(0, 0, 0, 1));
   solver.Solve(prog, prog.initial_guess(), solver_options, &result);
-  EXPECT_EQ(result.get_solution_result(), SolutionResult::kSolutionFound);
+  EXPECT_TRUE(result.is_success());
   EXPECT_NEAR(result.get_optimal_cost(), 1.0 / 17, tol);
 }
 }  // namespace test

--- a/solvers/test/nlopt_solver_test.cc
+++ b/solvers/test/nlopt_solver_test.cc
@@ -16,7 +16,7 @@ TEST_F(UnboundedLinearProgramTest0, TestNlopt) {
   if (solver.available()) {
     MathematicalProgramResult result;
     solver.Solve(*prog_, {}, {}, &result);
-    EXPECT_EQ(result.get_solution_result(), SolutionResult::kUnbounded);
+    EXPECT_FALSE(result.is_success());
     EXPECT_EQ(result.get_optimal_cost(),
               -std::numeric_limits<double>::infinity());
     SolverOptions solver_options;

--- a/solvers/test/nonlinear_program_test.cc
+++ b/solvers/test/nonlinear_program_test.cc
@@ -59,8 +59,7 @@ void RunNonlinearProgram(const MathematicalProgram& prog,
     }
     ASSERT_NO_THROW(solver.second->Solve(prog, x_init, {}, result))
         << "Using solver: " << solver.first;
-    EXPECT_EQ(result->get_solution_result(), SolutionResult::kSolutionFound)
-        << "Using solver: " << solver.first;
+    EXPECT_TRUE(result->is_success()) << "Using solver: " << solver.first;
     EXPECT_NO_THROW(test_func()) << "Using solver: " << solver.first;
   }
 }
@@ -488,8 +487,7 @@ GTEST_TEST(testNonlinearProgram, CallbackTest) {
     num_calls = 0;
     ASSERT_NO_THROW(solver.second->Solve(prog, {}, {}, &result))
         << "Using solver: " << solver.first;
-    EXPECT_EQ(result.get_solution_result(), SolutionResult::kSolutionFound)
-        << "Using solver: " << solver.first;
+    EXPECT_TRUE(result.is_success()) << "Using solver: " << solver.first;
     EXPECT_GT(num_calls, 0);
   }
 }

--- a/solvers/test/rotation_constraint_test.cc
+++ b/solvers/test/rotation_constraint_test.cc
@@ -105,7 +105,7 @@ GTEST_TEST(RotationTest, TestSpectralPsd) {
   AddObjective(&prog, Rvar, 2 * Eigen::Matrix<double, 3, 3>::Ones());
   AddRotationMatrixSpectrahedralSdpConstraint(&prog, Rvar);
   MathematicalProgramResult result = Solve(prog);
-  ASSERT_EQ(result.get_solution_result(), kSolutionFound);
+  ASSERT_TRUE(result.is_success());
 
   Matrix3d R = result.GetSolution(Rvar);
 
@@ -154,7 +154,7 @@ GTEST_TEST(RotationTest, TestOrthonormal) {
   AddObjective(&prog, Rvar, 2 * Eigen::Matrix<double, 3, 3>::Ones());
   AddRotationMatrixOrthonormalSocpConstraint(&prog, Rvar);
   MathematicalProgramResult result = Solve(prog);
-  ASSERT_EQ(result.get_solution_result(), kSolutionFound);
+  ASSERT_TRUE(result.is_success());
 
   Matrix3d R = result.GetSolution(Rvar);
 

--- a/solvers/test/scaled_diagonally_dominant_matrix_test.cc
+++ b/solvers/test/scaled_diagonally_dominant_matrix_test.cc
@@ -94,6 +94,10 @@ void CheckSDDMatrix(const Eigen::Ref<const Eigen::MatrixXd>& X_val,
     EXPECT_TRUE(CompareMatrices(M_sum, X_val, tol));
   } else {
     EXPECT_FALSE(result.is_success());
+    EXPECT_TRUE(result.get_solution_result() ==
+                    SolutionResult::kInfeasibleConstraints ||
+                result.get_solution_result() ==
+                    SolutionResult::kInfeasible_Or_Unbounded);
   }
 }
 
@@ -230,6 +234,9 @@ GTEST_TEST(SdsosTest, NotSdsosPolynomial) {
 
   const MathematicalProgramResult result = Solve(prog);
   EXPECT_FALSE(result.is_success());
+  EXPECT_TRUE(
+      result.get_solution_result() == SolutionResult::kInfeasibleConstraints ||
+      result.get_solution_result() == SolutionResult::kInfeasible_Or_Unbounded);
 }
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/scaled_diagonally_dominant_matrix_test.cc
+++ b/solvers/test/scaled_diagonally_dominant_matrix_test.cc
@@ -61,7 +61,7 @@ void CheckSDDMatrix(const Eigen::Ref<const Eigen::MatrixXd>& X_val,
 
   const auto result = Solve(prog);
   if (is_sdd) {
-    EXPECT_EQ(result.get_solution_result(), SolutionResult::kSolutionFound);
+    EXPECT_TRUE(result.is_success());
     // Since X = ∑ᵢⱼ Mⁱʲ according to the definition of scaled diagonally
     // dominant matrix, we evaluate the summation of M, and compare that with X.
     std::vector<std::vector<Eigen::MatrixXd>> M_val(nx);
@@ -93,10 +93,7 @@ void CheckSDDMatrix(const Eigen::Ref<const Eigen::MatrixXd>& X_val,
     }
     EXPECT_TRUE(CompareMatrices(M_sum, X_val, tol));
   } else {
-    EXPECT_TRUE(result.get_solution_result() ==
-                    SolutionResult::kInfeasibleConstraints ||
-                result.get_solution_result() ==
-                    SolutionResult::kInfeasible_Or_Unbounded);
+    EXPECT_FALSE(result.is_success());
   }
 }
 
@@ -121,8 +118,7 @@ bool IsMatrixSDD(const Eigen::Ref<Eigen::MatrixXd>& X) {
   prog.AddBoundingBoxConstraint(1, std::numeric_limits<double>::infinity(), d);
 
   const auto result = Solve(prog);
-  return result.get_solution_result() ==
-         solvers::SolutionResult::kSolutionFound;
+  return result.is_success();
 }
 
 GTEST_TEST(ScaledDiagonallyDominantMatrixTest, TestSDDMatrix) {
@@ -212,7 +208,7 @@ GTEST_TEST(SdsosTest, SdsosPolynomial) {
   prog.AddLinearEqualityConstraint(p == p_expected);
 
   const MathematicalProgramResult result = Solve(prog);
-  EXPECT_EQ(result.get_solution_result(), SolutionResult::kSolutionFound);
+  EXPECT_TRUE(result.is_success());
 }
 
 GTEST_TEST(SdsosTest, NotSdsosPolynomial) {
@@ -233,9 +229,7 @@ GTEST_TEST(SdsosTest, NotSdsosPolynomial) {
   prog.AddLinearEqualityConstraint(p == non_sdsos_poly);
 
   const MathematicalProgramResult result = Solve(prog);
-  EXPECT_TRUE(
-      result.get_solution_result() == SolutionResult::kInfeasibleConstraints ||
-      result.get_solution_result() == SolutionResult::kInfeasible_Or_Unbounded);
+  EXPECT_FALSE(result.is_success());
 }
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/snopt_solver_test.cc
+++ b/solvers/test/snopt_solver_test.cc
@@ -268,7 +268,7 @@ GTEST_TEST(SnoptTest, MultiThreadTest) {
     // The MathematicalProgramResult should meet tolerances.
     for (const auto& per_thread_data_vec : {single_threaded, multi_threaded}) {
       const auto& result = per_thread_data_vec[i].result;
-      EXPECT_EQ(result.get_solution_result(), drake::solvers::kSolutionFound);
+      EXPECT_TRUE(result.is_success());
       EXPECT_TRUE(CompareMatrices(
           result.get_x_val(), Eigen::Vector2d(0, 1), 1E-6));
       EXPECT_NEAR(result.get_optimal_cost(), 2, 1E-6);

--- a/solvers/test/solve_test.cc
+++ b/solvers/test/solve_test.cc
@@ -15,7 +15,7 @@ GTEST_TEST(SolveTest, LinearSystemSolverTest) {
   prog.AddLinearEqualityConstraint(Eigen::Matrix2d::Identity(),
                                    Eigen::Vector2d(1, 2), x);
   auto result = Solve(prog, {}, {});
-  EXPECT_EQ(result.get_solution_result(), SolutionResult::kSolutionFound);
+  EXPECT_TRUE(result.is_success());
   EXPECT_TRUE(
       CompareMatrices(result.get_x_val(), Eigen::Vector2d(1, 2), 1E-12));
   EXPECT_EQ(result.get_optimal_cost(), 0);
@@ -24,8 +24,7 @@ GTEST_TEST(SolveTest, LinearSystemSolverTest) {
   // Now add an inconsistent constraint
   prog.AddLinearEqualityConstraint(x(0) + x(1), 5);
   result = Solve(prog, {}, {});
-  EXPECT_EQ(result.get_solution_result(),
-            SolutionResult::kInfeasibleConstraints);
+  EXPECT_FALSE(result.is_success());
   EXPECT_EQ(result.get_optimal_cost(),
             MathematicalProgram::kGlobalInfeasibleCost);
   EXPECT_EQ(result.get_solver_id(), LinearSystemSolver::id());

--- a/systems/analysis/lyapunov.cc
+++ b/systems/analysis/lyapunov.cc
@@ -107,7 +107,7 @@ Eigen::VectorXd SampleBasedLyapunovAnalysis(
 
   drake::log()->info("Solving program.");
   const solvers::MathematicalProgramResult result = Solve(prog);
-  if (result.get_solution_result() != solvers::SolutionResult::kSolutionFound) {
+  if (!result.is_success()) {
     drake::log()->error("No solution found.  SolutionResult = " +
                         to_string(result.get_solution_result()));
   }

--- a/systems/controllers/dynamic_programming.cc
+++ b/systems/controllers/dynamic_programming.cc
@@ -246,7 +246,7 @@ Eigen::VectorXd LinearProgrammingApproximateDynamicProgramming(
 
   drake::log()->info("Solving linear program.");
   const solvers::MathematicalProgramResult result = Solve(prog);
-  if (result.get_solution_result() != solvers::SolutionResult::kSolutionFound) {
+  if (!result.is_success()) {
     drake::log()->error("No solution found.  SolutionResult = " +
                         to_string(result.get_solution_result()));
   }


### PR DESCRIPTION
As mentioned in #8402 , we would like to replace `MPResult::get_solution_result()` to `MPResult::is_success()`.

@jwnimmer-tri I can't remove `MPResult::get_solution_result()` function, since the old MP::Solve() API still need to retrieve the SolutionResult from `MPResult`, and then return it in `MP::Solve()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10558)
<!-- Reviewable:end -->
