### PR TITLE
multibody sdf: Do not pollute frame names with model instance name

### DIFF
--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -197,7 +197,8 @@ GTEST_TEST(MultibodyPlantSdfParserTest, ModelInstanceTest) {
       "model_scope_link1_frame", "model_scope_link1_frame_child", X_F1F2);
   const Isometry3d X_MF3 = RigidTransformd(
       Vector3d(0.7, 0.8, 0.9)).GetAsIsometry3();
-  check_frame("instance1", "model_scope_model_frame_implicit", X_MF3);
+  check_frame(
+      "_instance1_sdf_model_frame", "model_scope_model_frame_implicit", X_MF3);
 }
 
 // Verify that our SDF parser throws an exception when a user specifies a joint


### PR DESCRIPTION
It makes getting frame names painful because it may duplicate internal
frame names, and require model instances.

This is follow-up to #9352; I've really regretted adding this line, and would like to destroy it:
https://github.com/RobotLocomotion/drake/pull/9352/files#diff-7981cca60fd3f3c31dfcf0464ab46af2R478

It's a backwards incompatible change, but the implicit behavior is super annoying, so I'd deem it well worth the pain.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10563)
<!-- Reviewable:end -->
