### PR TITLE
Use real velocity limits for end effector teleop demo

### DIFF
--- a/examples/manipulation_station/end_effector_teleop.py
+++ b/examples/manipulation_station/end_effector_teleop.py
@@ -254,7 +254,7 @@ parser.add_argument(
     help="Time constant for the first order low pass filter applied to"
          "the teleop commands")
 parser.add_argument(
-    "--velocity_limit_factor", type=float, default=0.15,
+    "--velocity_limit_factor", type=float, default=1.0,
     help="This value, typically between 0 and 1, further limits the iiwa14 "
          "joint velocities. It multiplies each of the seven pre-defined "
          "joint velocity limits. "


### PR DESCRIPTION
They were set very conservatively (0.15 of the true limits) to keep people from breaking the hardware.  But I want people's first experience in sim to be more positive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10574)
<!-- Reviewable:end -->
