### PR TITLE
Add ParseLinearConstraintIfPossible

### DIFF
--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -1014,6 +1014,7 @@ drake_cc_googletest(
     name = "create_constraint_test",
     deps = [
         ":create_constraint",
+        "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:symbolic_test_util",
     ],
 )

--- a/solvers/create_constraint.cc
+++ b/solvers/create_constraint.cc
@@ -132,7 +132,7 @@ Binding<Constraint> ParseConstraint(
   return CreateBinding(make_shared<LinearConstraint>(A, new_lb, new_ub), vars);
 }
 
-std::unique_ptr<Binding<Constraint>> ParseLinearConstraintIfPossible(
+std::unique_ptr<Binding<Constraint>> MaybeParseLinearConstraint(
     const symbolic::Expression& e, double lb, double ub) {
   if (!e.is_polynomial()) {
     return std::unique_ptr<Binding<Constraint>>{nullptr};
@@ -143,9 +143,10 @@ std::unique_ptr<Binding<Constraint>> ParseLinearConstraintIfPossible(
   }
   // If p only has one indeterminates, then we can always return a bounding box
   // constraint.
-  double constant_term = 0;
   if (p.indeterminates().size() == 1) {
+    // We decompose the polynomial `p` into `constant_term + coeff * var`.
     double coeff = 0;
+    double constant_term = 0;
     for (const auto& term : p.monomial_to_coefficient_map()) {
       if (term.first.total_degree() == 0) {
         constant_term += get_constant_value(term.second);

--- a/solvers/create_constraint.cc
+++ b/solvers/create_constraint.cc
@@ -158,7 +158,7 @@ std::unique_ptr<Binding<Constraint>> MaybeParseLinearConstraint(
     // when the coefficient is 0, and remove it from
     // monomial_to_coefficient_map.
     DRAKE_DEMAND(coeff != 0);
-    double var_lower, var_upper;
+    double var_lower{}, var_upper{};
     if (coeff > 0) {
       var_lower = (lb - constant_term) / coeff;
       var_upper = (ub - constant_term) / coeff;

--- a/solvers/create_constraint.h
+++ b/solvers/create_constraint.h
@@ -42,6 +42,18 @@ inline Binding<Constraint> ParseConstraint(
                          Vector1<double>(ub));
 }
 
+/**
+ * Parse the constraint lb <= e <= ub to linear constraint types, including
+ * BoundingBoxConstraint, LinearEqualityConstraint and LinearConstraint. If @p
+ * e is not a linear expression, then return a null pointer.
+ * If the constraint lb <= e <= ub can be parsed as a BoundingBoxConstraint,
+ * then we return a BoundingBoxConstraint pointer. For example, the constraint
+ * 1 <= 2 * x + 3 <= 4 is equivalent to the bounding box constraint -1 <= x <=
+ * 0.5. Hence we will return the BoundingBoxConstraint in this case.
+ */
+std::unique_ptr<Binding<Constraint>> ParseLinearConstraintIfPossible(
+    const symbolic::Expression& e, double lb, double ub);
+
 /*
  * Assist MathematicalProgram::AddLinearConstraint(...).
  */

--- a/solvers/create_constraint.h
+++ b/solvers/create_constraint.h
@@ -43,15 +43,15 @@ inline Binding<Constraint> ParseConstraint(
 }
 
 /**
- * Parse the constraint lb <= e <= ub to linear constraint types, including
- * BoundingBoxConstraint, LinearEqualityConstraint and LinearConstraint. If @p
+ * Parses the constraint lb <= e <= ub to linear constraint types, including
+ * BoundingBoxConstraint, LinearEqualityConstraint, and LinearConstraint. If @p
  * e is not a linear expression, then return a null pointer.
  * If the constraint lb <= e <= ub can be parsed as a BoundingBoxConstraint,
  * then we return a BoundingBoxConstraint pointer. For example, the constraint
  * 1 <= 2 * x + 3 <= 4 is equivalent to the bounding box constraint -1 <= x <=
  * 0.5. Hence we will return the BoundingBoxConstraint in this case.
  */
-std::unique_ptr<Binding<Constraint>> ParseLinearConstraintIfPossible(
+std::unique_ptr<Binding<Constraint>> MaybeParseLinearConstraint(
     const symbolic::Expression& e, double lb, double ub);
 
 /*

--- a/solvers/test/create_constraint_test.cc
+++ b/solvers/test/create_constraint_test.cc
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/symbolic_test_util.h"
 
 using drake::symbolic::Expression;
@@ -263,6 +264,141 @@ TEST_F(ParseRotatedLorentzConeConstraintTest, Test3) {
   EXPECT_THROW(internal::ParseRotatedLorentzConeConstraint(x_(0), x_(1),
                                                            x_(2) * x_(2) - 1),
                std::runtime_error);
+}
+
+class ParseLinearConstraintIfPossibleTest : public ::testing::Test {
+ public:
+  ParseLinearConstraintIfPossibleTest() { x_ << x0_, x1_, x2_; }
+
+ protected:
+  symbolic::Variable x0_{"x0"};
+  symbolic::Variable x1_{"x1"};
+  symbolic::Variable x2_{"x2"};
+  Vector3<symbolic::Variable> x_;
+};
+
+TEST_F(ParseLinearConstraintIfPossibleTest, TestBoundingBoxConstraint) {
+  // Parse a bounding box constraint
+
+  auto check_bounding_box_constraint = [](
+      const Binding<Constraint>& constraint, double lower_expected,
+      double upper_expected, const symbolic::Variable& var) {
+    const Binding<BoundingBoxConstraint> bounding_box_constraint =
+        internal::BindingDynamicCast<BoundingBoxConstraint>(constraint);
+    EXPECT_EQ(bounding_box_constraint.variables().size(), 1);
+    EXPECT_EQ(bounding_box_constraint.variables()(0), var);
+    EXPECT_EQ(bounding_box_constraint.evaluator()->num_constraints(), 1);
+    EXPECT_EQ(bounding_box_constraint.evaluator()->lower_bound()(0),
+              lower_expected);
+    EXPECT_EQ(bounding_box_constraint.evaluator()->upper_bound()(0),
+              upper_expected);
+  };
+
+  check_bounding_box_constraint(
+      *(internal::ParseLinearConstraintIfPossible(x0_, 1, 2)), 1, 2, x0_);
+  check_bounding_box_constraint(
+      *(internal::ParseLinearConstraintIfPossible(-x0_, 1, 2)), -2, -1, x0_);
+  check_bounding_box_constraint(
+      *(internal::ParseLinearConstraintIfPossible(2 * x0_, 1, 2)), 0.5, 1, x0_);
+  check_bounding_box_constraint(
+      *(internal::ParseLinearConstraintIfPossible(-2 * x0_, 1, 2)), -1, -0.5,
+      x0_);
+  check_bounding_box_constraint(
+      *(internal::ParseLinearConstraintIfPossible(x0_ + 1, 1, 2)), 0, 1, x0_);
+  check_bounding_box_constraint(
+      *(internal::ParseLinearConstraintIfPossible(x0_ + 1 + 2, 1, 2)), -2, -1,
+      x0_);
+  check_bounding_box_constraint(
+      *(internal::ParseLinearConstraintIfPossible(2 * x0_ + 1 + 2, 1, 2)), -1,
+      -0.5, x0_);
+  check_bounding_box_constraint(
+      *(internal::ParseLinearConstraintIfPossible(-2 * x0_ + 1 + 2, 1, 2)), 0.5,
+      1, x0_);
+}
+
+TEST_F(ParseLinearConstraintIfPossibleTest, TestLinearEqualityConstraint) {
+  // Parse linear equality constraint.
+  auto check_linear_equality_constraint = [](
+      const Binding<Constraint>& constraint,
+      const Eigen::Ref<const Eigen::RowVectorXd>& a,
+      const Eigen::Ref<const VectorX<symbolic::Variable>>& vars, double bound,
+      double tol = 1E-14) {
+    const Binding<LinearEqualityConstraint> linear_eq_constraint =
+        internal::BindingDynamicCast<LinearEqualityConstraint>(constraint);
+    if (vars.size() != 0) {
+      EXPECT_EQ(linear_eq_constraint.variables(), vars);
+    } else {
+      EXPECT_EQ(linear_eq_constraint.variables().size(), 0);
+    }
+    EXPECT_EQ(linear_eq_constraint.evaluator()->num_constraints(), 1);
+    EXPECT_TRUE(CompareMatrices(linear_eq_constraint.evaluator()->A(), a, tol));
+    EXPECT_NEAR(linear_eq_constraint.evaluator()->lower_bound()(0), bound, tol);
+  };
+
+  // without a constant term in the expression.
+  check_linear_equality_constraint(
+      *internal::ParseLinearConstraintIfPossible(x_(0) + 2 * x_(1), 1, 1),
+      Eigen::RowVector2d(1, 2), Vector2<symbolic::Variable>(x_(0), x_(1)), 1);
+
+  // with a constant term in the expression.
+  check_linear_equality_constraint(
+      *internal::ParseLinearConstraintIfPossible(x_(0) + 2 * x_(1) + 2 + 1, 3,
+                                                 3),
+      Eigen::RowVector2d(1, 2), Vector2<symbolic::Variable>(x_(0), x_(1)), 0);
+
+  // Check a constant expression.
+  check_linear_equality_constraint(
+      *internal::ParseLinearConstraintIfPossible(2, 3, 3),
+      Eigen::RowVectorXd(0), VectorX<symbolic::Variable>(0), 1);
+}
+
+TEST_F(ParseLinearConstraintIfPossibleTest, TestLinearConstraint) {
+  // Parse linear inequality constraint.
+  auto check_linear_constraint = [](
+      const Binding<Constraint>& constraint,
+      const Eigen::Ref<const Eigen::RowVectorXd>& a,
+      const Eigen::Ref<const VectorX<symbolic::Variable>>& vars, double lb,
+      double ub, double tol = 1E-14) {
+    const Binding<LinearConstraint> linear_constraint =
+        internal::BindingDynamicCast<LinearConstraint>(constraint);
+    if (vars.size() != 0) {
+      EXPECT_EQ(linear_constraint.variables(), vars);
+    } else {
+      EXPECT_EQ(linear_constraint.variables().size(), 0);
+    }
+    EXPECT_EQ(linear_constraint.evaluator()->num_constraints(), 1);
+    EXPECT_TRUE(CompareMatrices(linear_constraint.evaluator()->A(), a, tol));
+    EXPECT_NEAR(linear_constraint.evaluator()->lower_bound()(0), lb, tol);
+    EXPECT_NEAR(linear_constraint.evaluator()->upper_bound()(0), ub, tol);
+  };
+
+  // without a constant term in the expression.
+  check_linear_constraint(
+      *internal::ParseLinearConstraintIfPossible(x_(0) + 2 * x_(1), 1, 2),
+      Eigen::RowVector2d(1, 2), Vector2<symbolic::Variable>(x_(0), x_(1)), 1,
+      2);
+
+  // with a constant term in the expression.
+  check_linear_constraint(*internal::ParseLinearConstraintIfPossible(
+                              x_(0) + 2 * x_(1) + 2 + 1, 3, 4),
+                          Eigen::RowVector2d(1, 2),
+                          Vector2<symbolic::Variable>(x_(0), x_(1)), 0, 1);
+
+  // Check a constant expression.
+  check_linear_constraint(*internal::ParseLinearConstraintIfPossible(2, 3, 4),
+                          Eigen::RowVectorXd(0), VectorX<symbolic::Variable>(0),
+                          1, 2);
+  check_linear_constraint(
+      *internal::ParseLinearConstraintIfPossible(0 * x_(0) + 2, 3, 4),
+      Eigen::RowVectorXd(0), VectorX<symbolic::Variable>(0), 1, 2);
+}
+
+TEST_F(ParseLinearConstraintIfPossibleTest, NonlinearConstraint) {
+  EXPECT_EQ(
+      internal::ParseLinearConstraintIfPossible(x_(0) * x_(0), 1, 2).get(),
+      nullptr);
+  EXPECT_EQ(internal::ParseLinearConstraintIfPossible(sin(x_(0)), 1, 2).get(),
+            nullptr);
 }
 }  // namespace
 }  // namespace solvers


### PR DESCRIPTION
This feature is going to be used when converting a SystemConstraint to a solvers::Constraint. We will first try to convert the SystemConstraint to linear constraint. If fails, we will then convert it to the generic nonlinear constraint SystemConstraintWrapper.

This is also related to #10579 , that in this PR we use the symbolic::Polynomial directly to extract the coefficient of the variables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10580)
<!-- Reviewable:end -->
