### PR TITLE
Revert "py mp: Bind `EvaluatorBase.Eval`"

### DIFF
--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -609,28 +609,12 @@ PYBIND11_MODULE(mathematicalprogram, m) {
       .value("kDualInfeasible", SolutionResult::kDualInfeasible,
           doc.SolutionResult.kDualInfeasible.doc);
 
-  {
-    using Class = EvaluatorBase;
-    constexpr auto& cls_doc = doc.EvaluatorBase;
-    py::class_<Class, std::shared_ptr<EvaluatorBase>> cls(m, "EvaluatorBase");
-    cls  // BR
-        .def("num_outputs", &Class::num_outputs, cls_doc.num_outputs.doc)
-        .def("num_vars", &Class::num_vars, cls_doc.num_vars.doc);
-    auto bind_eval = [&cls, &cls_doc](auto dummy_x, auto dummy_y) {
-      using T_x = decltype(dummy_x);
-      using T_y = decltype(dummy_y);
-      cls.def("Eval",
-          [](const Class& self, const Eigen::Ref<const VectorX<T_x>>& x) {
-            VectorX<T_y> y;
-            self.Eval(x, &y);
-            return y;
-          },
-          py::arg("x"), cls_doc.Eval.doc);
-    };
-    bind_eval(double{}, double{});
-    bind_eval(AutoDiffXd{}, AutoDiffXd{});
-    bind_eval(symbolic::Variable{}, symbolic::Expression{});
-  }
+  // TODO(eric.cousineau): Expose Eval() in a Python-friendly fashion.
+  py::class_<EvaluatorBase, std::shared_ptr<EvaluatorBase>>(m, "EvaluatorBase")
+      .def("num_outputs", &EvaluatorBase::num_outputs,
+          doc.EvaluatorBase.num_outputs.doc)
+      .def(
+          "num_vars", &EvaluatorBase::num_vars, doc.EvaluatorBase.num_vars.doc);
 
   RegisterBinding<EvaluatorBase>(&m, "EvaluatorBase")
       .def(py::init([](py::object binding) {

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -261,14 +261,6 @@ class TestMathematicalProgram(unittest.TestCase):
             prog.EvalBindings(prog.GetAllConstraints(), x_expected),
             np.ndarray)
 
-        # Bindings for `Eval`.
-        x_list = (float(1.), AutoDiffXd(1.), sym.Variable("x"))
-        T_y_list = (float, AutoDiffXd, sym.Expression)
-        evaluator = costs[0].evaluator()
-        for x_i, T_y_i in zip(x_list, T_y_list):
-            y_i = evaluator.Eval(x=[x_i])
-            self.assertIsInstance(y_i[0], T_y_i)
-
     def test_matrix_variables(self):
         prog = mp.MathematicalProgram()
         x = prog.NewContinuousVariables(2, 2, "x")

--- a/solvers/evaluator_base.h
+++ b/solvers/evaluator_base.h
@@ -33,34 +33,34 @@ class EvaluatorBase {
 
   virtual ~EvaluatorBase() {}
 
-  // TODO(bradking): consider using a Ref for `y`.  This will require the client
-  // to do allocation, but also allows it to choose stack allocation instead.
   /**
-   * Evaluates the expression.
-   * @param[in] x A `num_vars` x 1 input vector.
+   * Evaluates the expression with a scalar type of double.
+   * @param x A `num_vars` x 1 input vector.
    * @param[out] y A `num_outputs` x 1 output vector.
    */
+  // TODO(bradking): consider using a Ref for `y`.  This will require the client
+  // to do allocation, but also allows it to choose stack allocation instead.
   void Eval(const Eigen::Ref<const Eigen::VectorXd>& x,
             Eigen::VectorXd* y) const {
     DRAKE_ASSERT(x.rows() == num_vars_ || num_vars_ == Eigen::Dynamic);
     DoEval(x, y);
   }
 
+  /**
+   * Evaluates the expression with a scalar type of AutoDiffXd.
+   * @param x A `num_vars` x 1 input vector.
+   * @param[out] y A `num_outputs` x 1 output vector.
+   */
   // TODO(eric.cousineau): Move this to DifferentiableConstraint derived class
   // if/when we need to support non-differentiable functions (at least, if
   // DifferentiableConstraint is ever implemented).
-  /**
-   * Evaluates the expression.
-   * @param[in] x A `num_vars` x 1 input vector.
-   * @param[out] y A `num_outputs` x 1 output vector.
-   */
   void Eval(const Eigen::Ref<const AutoDiffVecXd>& x, AutoDiffVecXd* y) const {
     DRAKE_ASSERT(x.rows() == num_vars_ || num_vars_ == Eigen::Dynamic);
     DoEval(x, y);
   }
 
   /**
-   * Evaluates the expression.
+   * Evaluates the expression with a scalar type of symbolic::Expression.
    * @param[in] x A `num_vars` x 1 input vector.
    * @param[out] y A `num_outputs` x 1 output vector.
    */


### PR DESCRIPTION
Dear @gizatt,

The on-call build cop, @jamiesnape, believes that your PR #10566. may have
broken one or more of Drake's continuous integration builds [1]. It is
possible to break a build even if your PR passed continuous integration
pre-merge because additional platforms are tested post-merge.

The specific build failures under investigation are:
* https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-bionic-clang-bazel-continuous-debug/381/
* https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-bionic-clang-bazel-continuous-everything-debug/379/
* https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-bionic-clang-bazel-continuous-everything-python3-debug/173/
* https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-bionic-clang-bazel-continuous-python3-debug/174/
* https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-bionic-gcc-bazel-continuous-debug/379/
* https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-bionic-gcc-bazel-continuous-python3-debug/172/
* https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-xenial-clang-bazel-continuous-debug/381/
* https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-xenial-clang-bazel-continuous-everything-debug/378/

Therefore, the build cop has created this revert PR and started a complete
post-merge build to determine whether your PR was in fact the cause of the
problem. If that build passes, this revert PR will be merged 60 minutes from
now. You can then fix the problem at your leisure, and send a new PR to
reinstate your change.

If you believe your original PR did not actually break the build, please
explain on this thread.

If you believe you can fix the break promptly in lieu of a revert, please
explain on this thread, and send a PR to the build cop for review ASAP.

If you believe your original PR definitely did break the build and should be
reverted, please review and LGTM this PR. This allows the build cop to merge
without waiting for CI results.

For advice on how to handle a build cop revert, see [2].

Thanks!
Your Friendly On-call Build Cop

[1] CI Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Production/
[2] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert