### PR TITLE
docker: Fix entrypoint path

### DIFF
--- a/setup/ubuntu/docker/bionic/Dockerfile
+++ b/setup/ubuntu/docker/bionic/Dockerfile
@@ -8,4 +8,4 @@ RUN set -eux \
 COPY . .
 RUN set -eux \
   && bazel build //tools:drake_visualizer //examples/acrobot:run_passive
-ENTRYPOINT ["drake/setup/ubuntu/docker/entrypoint.sh"]
+ENTRYPOINT ["./setup/ubuntu/docker/entrypoint.sh"]

--- a/setup/ubuntu/docker/xenial/Dockerfile
+++ b/setup/ubuntu/docker/xenial/Dockerfile
@@ -8,4 +8,4 @@ RUN set -eux \
 COPY . .
 RUN set -eux \
   && bazel build //tools:drake_visualizer //examples/acrobot:run_passive
-ENTRYPOINT ["drake/setup/ubuntu/docker/entrypoint.sh"]
+ENTRYPOINT ["./setup/ubuntu/docker/entrypoint.sh"]

--- a/setup/ubuntu/docker/xenial/Dockerfile.nvidia-cuda-8.0-devel-ubuntu16.04
+++ b/setup/ubuntu/docker/xenial/Dockerfile.nvidia-cuda-8.0-devel-ubuntu16.04
@@ -8,4 +8,4 @@ RUN set -eux \
 COPY . .
 RUN set -eux \
   && bazel build //tools:drake_visualizer //examples/acrobot:run_passive
-ENTRYPOINT ["drake/setup/ubuntu/docker/entrypoint.sh"]
+ENTRYPOINT ["./setup/ubuntu/docker/entrypoint.sh"]


### PR DESCRIPTION
During my checkup, running through the instructions, ran into this error:
```
docker: Error response from daemon: OCI runtime create failed: container_linux.go:348: starting container process caused "exec: \"drake/setup/ubuntu/docker/entrypoint.sh\": stat drake/setup/ubuntu/docker/entrypoint.sh: no such file or directory": unknown.
```

Was able to avoid the error by adding this before `drake` in the `docker run` command:
`--entrypoint /drake/setup/ubuntu/docker/entrypoint.sh`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10586)
<!-- Reviewable:end -->
