### PR TITLE
mbp sdf: Fail fast on unsupported `<pose frame='{non-empty}'/>`

### DIFF
--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -50,6 +50,21 @@ RotationalInertia<double> ExtractRotationalInertiaAboutBcmExpressedInBi(
                                    I(1, 0), I(2, 0), I(2, 1));
 }
 
+// Fails fast if a user attempts to specify `<pose frame='...'/>` in an
+// unsupported location.
+// See https://bitbucket.org/osrf/sdformat/issues/200 (tracked by #10590).
+void ThrowIfPoseFrameSpecified(sdf::ElementPtr element) {
+  if (element->HasElement("pose")) {
+    sdf::ElementPtr pose = element->GetElement("pose");
+    const std::string frame_name = pose->Get<std::string>("frame");
+    if (!frame_name.empty()) {
+      throw std::runtime_error(
+          "<pose frame='{non-empty}'/> is presently not supported outside of "
+          "the <frame/> tag.");
+    }
+  }
+}
+
 // Helper method to extract the SpatialInertia M_BBo_B of body B, about its body
 // frame origin Bo and, expressed in body frame B, from an ignition::Inertial
 // object.
@@ -124,6 +139,7 @@ Vector3d ExtractJointAxis(const sdf::Model& model_spec,
   Vector3d axis_J = ToVector3(axis->Xyz());
   if (axis->UseParentModelFrame()) {
     // Pose of the joint frame J in the frame of the child link C.
+    ThrowIfPoseFrameSpecified(joint_spec.Element());
     const Isometry3d X_CJ = ToIsometry3(joint_spec.Pose());
     // Get the pose of the child link C in the model frame M.
     const Isometry3d X_MC =
@@ -238,19 +254,14 @@ void AddJointFromSpecification(
 
   // Get the pose of frame J in the frame of the child link C, as specified in
   // <joint> <pose> ... </pose></joint>.
-  // TODO(amcastro-tri): Verify sdformat supports frame specifications
+  // TODO(eric.cousineau): Verify sdformat supports frame specifications
   // correctly.
-  // There are many ways by which a joint frame pose can be specified in SDF:
-  //  - <joint> <pose> </pose></joint>.
-  //  - <joint> <pose> <frame/> </pose></joint>.
-  //  - <joint> <frame> <pose> <frame/> </pose> </frame> </joint>.
-  // And combinations of the above?
-  // There is no way to verify at this level which one is supported or not.
-  // Here we trust that no mather how a user specified the file, joint.Pose()
-  // will ALWAYS return X_CJ.
+  ThrowIfPoseFrameSpecified(joint_spec.Element());
   const Isometry3d X_CJ = ToIsometry3(joint_spec.Pose());
 
   // Get the pose of the child link C in the model frame M.
+  // TODO(eric.cousineau): Figure out how to use link poses when they are NOT
+  // connected to a joint.
   const Isometry3d X_MC =
       ToIsometry3(model_spec.LinkByName(joint_spec.ChildLinkName())->Pose());
 
@@ -357,12 +368,18 @@ void AddLinksFromSpecification(
   for (uint64_t link_index = 0; link_index < model.LinkCount(); ++link_index) {
     const sdf::Link& link = *model.LinkByIndex(link_index);
 
+    // Fail fast for `<pose frame='...'/>`.
+    ThrowIfPoseFrameSpecified(link.Element());
+
     // Get the link's inertia relative to the Bcm frame.
     // sdf::Link::Inertial() provides a representation for the SpatialInertia
     // M_Bcm_Bi of body B, about its center of mass Bcm, and expressed in an
     // inertial frame Bi as defined in <inertial> <pose></pose> </inertial>.
     // Per SDF specification, Bi's origin is at the COM Bcm, but Bi is not
     // necessarily aligned with B.
+    if (link.Element()->HasElement("inertial")) {
+      ThrowIfPoseFrameSpecified(link.Element()->GetElement("inertial"));
+    }
     const ignition::math::Inertiald& Inertial_Bcm_Bi = link.Inertial();
 
     const SpatialInertia<double> M_BBo_B =
@@ -379,6 +396,7 @@ void AddLinksFromSpecification(
             *link.VisualByIndex(visual_index), package_map, root_dir);
         unique_ptr<GeometryInstance> geometry_instance =
             MakeGeometryInstanceFromSdfVisual(sdf_visual);
+        ThrowIfPoseFrameSpecified(sdf_visual.Element());
         // We check for nullptr in case someone decided to specify an SDF
         // <empty/> geometry.
         if (geometry_instance) {
@@ -399,6 +417,7 @@ void AddLinksFromSpecification(
         const sdf::Collision& sdf_collision =
             *link.CollisionByIndex(collision_index);
         const sdf::Geometry& sdf_geometry = *sdf_collision.Geom();
+        ThrowIfPoseFrameSpecified(sdf_collision.Element());
         if (sdf_geometry.Type() != sdf::GeometryType::EMPTY) {
           const Isometry3d X_LG =
               MakeGeometryPoseFromSdfCollision(sdf_collision);
@@ -475,6 +494,7 @@ ModelInstanceIndex AddModelFromSpecification(
   // TODO(eric.cousineau): Ensure this generalizes to cases when the parent
   // frame is not the world. At present, we assume the parent frame is the
   // world.
+  ThrowIfPoseFrameSpecified(model.Element());
   const Isometry3d X_WM = ToIsometry3(model.Pose());
   // Add the SDF "model frame" given the model name so that way any frames added
   // to the plant are associated with this current model instance.


### PR DESCRIPTION
Partially addresses some frame issues in #10590 

@pangtao22 had asked about the semantics of adding frames to SDF, and I realized that this the current parser kind just silently leaves unsupported data behind.

This does two things:
* Warn about unused `<pose/>` in `<link/>` (\cc @hidmic)
* Fail fast on unsupported `<pose frame='{non-empty}'/>`

FYI @scpeters

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10589)
<!-- Reviewable:end -->
