### PR TITLE
framework: Ports should be self-service

### DIFF
--- a/attic/systems/sensors/test/depth_sensor_to_lcm_point_cloud_message_test.cc
+++ b/attic/systems/sensors/test/depth_sensor_to_lcm_point_cloud_message_test.cc
@@ -34,7 +34,6 @@ class TestDepthSensorToLcmPointCloudMessage : public ::testing::Test {
     EXPECT_EQ(dut.get_num_output_ports(), 1);
     const InputPort<double>& sensor_data_input_port =
         dut.depth_readings_input_port();
-    EXPECT_EQ(sensor_data_input_port.get_system(), &dut);
     EXPECT_EQ(sensor_data_input_port.size(), spec_.num_depth_readings());
     const InputPort<double>& pose_input_port =
         dut.pose_input_port();

--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -27,6 +27,28 @@ namespace pydrake {
 
 using pysystems::DefClone;
 
+namespace {
+// Given an InputPort or OutputPort as self, return self.Eval(context).  In
+// python, always returns either a numpy.ndarray (when vector-valued) or the
+// unwrapped T in a Value<T> (when abstract-valued).
+template <typename SomeObject, typename T>
+py::object DoEval(const SomeObject* self, const systems::Context<T>& context) {
+  switch (self->get_data_type()) {
+    case systems::kVectorValued: {
+      const VectorX<T> eigen_copy = self->Eval(context);
+      return py::cast(eigen_copy);
+    }
+    case systems::kAbstractValued: {
+      const auto& abstract = self->template Eval<AbstractValue>(context);
+      // TODO(#9398): Figure out why `py_reference` is necessary.
+      py::object value_ref = py::cast(&abstract, py_reference);
+      return value_ref.attr("get_value")();
+    }
+  }
+  DRAKE_UNREACHABLE();
+}
+}  // namespace
+
 void DefineFrameworkPySemantics(py::module m) {
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
   using namespace drake::systems;
@@ -258,25 +280,34 @@ void DefineFrameworkPySemantics(py::module m) {
 
     DefineTemplateClassWithDefault<OutputPort<T>>(
         m, "OutputPort", GetPyParam<T>(), doc.OutputPort.doc)
-        .def("size", &OutputPort<T>::size, doc.OutputPortBase.size.doc)
+        .def("size", &OutputPort<T>::size, doc.PortBase.size.doc)
+        .def("get_data_type", &OutputPort<T>::get_data_type,
+            doc.PortBase.get_data_type.doc)
         .def("get_index", &OutputPort<T>::get_index,
             doc.OutputPortBase.get_index.doc)
-        .def("EvalAbstract", &OutputPort<T>::EvalAbstract,
-            doc.OutputPort.EvalAbstract.doc, py_reference_internal)
         .def("Eval",
             [](const OutputPort<T>* self, const Context<T>& context) {
-              // Use type-erased signature to get value.
-              // TODO(eric.cousineau): Figure out why `py_reference` is
-              // necessary below (#9398).
-              py::object value_ref =
-                  py::cast(&self->EvalAbstract(context), py_reference);
-              return value_ref.attr("get_value")();
+              return DoEval(self, context);
             },
             doc.OutputPort.Eval.doc)
+        .def("EvalAbstract",
+            [](const OutputPort<T>* self, const Context<T>& c) {
+              const auto& abstract = self->template Eval<AbstractValue>(c);
+              // TODO(#9398): Figure out why `py_reference` is necessary.
+              return py::cast(&abstract, py_reference);
+            },
+            py::arg("context"),
+            "(Advanced.) Returns the value of this output port, typed "
+            "as an AbstractValue. Most users should call Eval() instead. "
+            "This method is only needed when the result will be passed "
+            "into some other API that only accepts an AbstractValue.",
+            py_reference_internal)
         .def("EvalBasicVector",
-            static_cast<const BasicVector<T>& (
-                OutputPort<T>::*)(const Context<T>&)const>(
-                &OutputPort<T>::Eval),
+            [](const OutputPort<T>* self, const Context<T>& c) {
+              const auto& basic = self->template Eval<BasicVector<T>>(c);
+              // TODO(#9398): Figure out why `py_reference` is necessary.
+              return py::cast(&basic, py_reference);
+            },
             py::arg("context"),
             "(Advanced.) Returns the value of this output port, typed "
             "as a BasicVector. Most users should call Eval() instead. "
@@ -296,11 +327,41 @@ void DefineFrameworkPySemantics(py::module m) {
 
     DefineTemplateClassWithDefault<InputPort<T>>(
         m, "InputPort", GetPyParam<T>(), doc.InputPort.doc)
-        .def("size", &InputPort<T>::size, doc.InputPortBase.size.doc)
+        .def("size", &InputPort<T>::size, doc.PortBase.size.doc)
         .def("get_data_type", &InputPort<T>::get_data_type,
-            doc.InputPortBase.get_data_type.doc)
+            doc.PortBase.get_data_type.doc)
         .def("get_index", &InputPort<T>::get_index,
-            doc.InputPortBase.get_index.doc);
+            doc.InputPortBase.get_index.doc)
+        .def("Eval",
+            [](const InputPort<T>* self, const Context<T>& context) {
+              return DoEval(self, context);
+              DRAKE_UNREACHABLE();
+            },
+            doc.InputPort.Eval.doc)
+        .def("EvalAbstract",
+            [](const InputPort<T>* self, const Context<T>& c) {
+              const auto& abstract = self->template Eval<AbstractValue>(c);
+              // TODO(#9398): Figure out why `py_reference` is necessary.
+              return py::cast(&abstract, py_reference);
+            },
+            py::arg("context"),
+            "(Advanced.) Returns the value of this input port, typed "
+            "as an AbstractValue. Most users should call Eval() instead. "
+            "This method is only needed when the result will be passed "
+            "into some other API that only accepts an AbstractValue.",
+            py_reference_internal)
+        .def("EvalBasicVector",
+            [](const InputPort<T>* self, const Context<T>& c) {
+              const auto& basic = self->template Eval<BasicVector<T>>(c);
+              // TODO(#9398): Figure out why `py_reference` is necessary.
+              return py::cast(&basic, py_reference);
+            },
+            py::arg("context"),
+            "(Advanced.) Returns the value of this input port, typed "
+            "as a BasicVector. Most users should call Eval() instead. "
+            "This method is only needed when the result will be passed "
+            "into some other API that only accepts a BasicVector.",
+            py_reference_internal);
 
     // Parameters.
     auto parameters = DefineTemplateClassWithDefault<Parameters<T>>(

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -55,6 +55,7 @@ from pydrake.systems.primitives import (
     ConstantVectorSource, ConstantVectorSource_,
     Integrator,
     LinearSystem,
+    PassThrough,
     SignalLogger,
     )
 
@@ -400,9 +401,8 @@ class TestGeneral(unittest.TestCase):
         output_port = source.get_output_port(0)
 
         value = output_port.Eval(context)
-        self.assertEqual(type(value), type(model_value.get_value()))
-        self.assertEqual(type(value.get_value()), np.ndarray)
-        np.testing.assert_equal(value.get_value(), np_value)
+        self.assertEqual(type(value), np.ndarray)
+        np.testing.assert_equal(value, np_value)
 
         value_abs = output_port.EvalAbstract(context)
         self.assertEqual(type(value_abs), type(model_value))
@@ -410,6 +410,43 @@ class TestGeneral(unittest.TestCase):
         np.testing.assert_equal(value_abs.get_value().get_value(), np_value)
 
         basic = output_port.EvalBasicVector(context)
+        self.assertEqual(type(basic), BasicVector)
+        self.assertEqual(type(basic.get_value()), np.ndarray)
+        np.testing.assert_equal(basic.get_value(), np_value)
+
+    def test_abstract_input_port_eval(self):
+        model_value = AbstractValue.Make("Hello World")
+        system = PassThrough(copy.copy(model_value))
+        context = system.CreateDefaultContext()
+        context.FixInputPort(0, copy.copy(model_value))
+        input_port = system.get_input_port(0)
+
+        value = input_port.Eval(context)
+        self.assertEqual(type(value), type(model_value.get_value()))
+        self.assertEqual(value, model_value.get_value())
+
+        value_abs = input_port.EvalAbstract(context)
+        self.assertEqual(type(value_abs), type(model_value))
+        self.assertEqual(value_abs.get_value(), model_value.get_value())
+
+    def test_vector_input_port_eval(self):
+        np_value = np.array([1., 2., 3.])
+        model_value = AbstractValue.Make(BasicVector(np_value))
+        system = PassThrough(len(np_value))
+        context = system.CreateDefaultContext()
+        context.FixInputPort(0, np_value)
+        input_port = system.get_input_port(0)
+
+        value = input_port.Eval(context)
+        self.assertEqual(type(value), np.ndarray)
+        np.testing.assert_equal(value, np_value)
+
+        value_abs = input_port.EvalAbstract(context)
+        self.assertEqual(type(value_abs), type(model_value))
+        self.assertEqual(type(value_abs.get_value().get_value()), np.ndarray)
+        np.testing.assert_equal(value_abs.get_value().get_value(), np_value)
+
+        basic = input_port.EvalBasicVector(context)
         self.assertEqual(type(basic), BasicVector)
         self.assertEqual(type(basic.get_value()), np.ndarray)
         np.testing.assert_equal(basic.get_value(), np_value)

--- a/bindings/pydrake/systems/test/rendering_test.py
+++ b/bindings/pydrake/systems/test/rendering_test.py
@@ -151,6 +151,8 @@ class TestRendering(unittest.TestCase):
         self.assertEqual(port3.get_data_type(), PortDataType.kAbstractValued)
 
         # - CalcOutput.
+        self.assertEqual(aggregator.get_output_port(0).get_data_type(),
+                         PortDataType.kAbstractValued)
         context = aggregator.CreateDefaultContext()
         output = aggregator.AllocateOutput()
 

--- a/examples/manipulation_station/end_effector_teleop.py
+++ b/examples/manipulation_station/end_effector_teleop.py
@@ -337,7 +337,7 @@ station_context.FixInputPort(station.GetInputPort(
     "iiwa_feedforward_torque").get_index(), np.zeros(7))
 
 q0 = station.GetOutputPort("iiwa_position_measured").Eval(
-    station_context).get_value()
+    station_context)
 differential_ik.parameters.set_nominal_joint_position(q0)
 
 teleop.SetPose(differential_ik.ForwardKinematics(q0))
@@ -345,7 +345,7 @@ filter.set_initial_output_value(
     diagram.GetMutableSubsystemContext(
         filter, simulator.get_mutable_context()),
     teleop.get_output_port(0).Eval(diagram.GetMutableSubsystemContext(
-        teleop, simulator.get_mutable_context())).get_value())
+        teleop, simulator.get_mutable_context())))
 differential_ik.SetPositions(diagram.GetMutableSubsystemContext(
     differential_ik, simulator.get_mutable_context()), q0)
 

--- a/examples/manipulation_station/joint_teleop.py
+++ b/examples/manipulation_station/joint_teleop.py
@@ -87,7 +87,7 @@ station_context.FixInputPort(station.GetInputPort(
 
 # Eval the output port once to read the initial positions of the IIWA.
 q0 = station.GetOutputPort("iiwa_position_measured").Eval(
-    station_context).get_value()
+    station_context)
 teleop.set_position(q0)
 filter.set_initial_output_value(diagram.GetMutableSubsystemContext(
     filter, simulator.get_mutable_context()), q0)

--- a/manipulation/kuka_iiwa/iiwa_status_receiver.cc
+++ b/manipulation/kuka_iiwa/iiwa_status_receiver.cc
@@ -93,9 +93,9 @@ void IiwaStatusReceiver::CalcStateOutput(
     const Context<double>& context, BasicVector<double>* output) const {
   auto output_block = output->get_mutable_value();
   output_block.head(num_joints_) =
-      get_position_measured_output_port().EvalEigenVector(context);
+      get_position_measured_output_port().Eval(context);
   output_block.tail(num_joints_) =
-      get_velocity_estimated_output_port().EvalEigenVector(context);
+      get_velocity_estimated_output_port().Eval(context);
 }
 
 }  // namespace kuka_iiwa

--- a/manipulation/kuka_iiwa/test/iiwa_command_receiver_test.cc
+++ b/manipulation/kuka_iiwa/test/iiwa_command_receiver_test.cc
@@ -71,19 +71,19 @@ class IiwaCommandReceiverTest : public testing::TestWithParam<int> {
 
   VectorXd position() const {
     const auto& port = dut_.get_commanded_position_output_port();
-    const VectorXd result = port.EvalEigenVector(context_);
+    const VectorXd result = port.Eval(context_);
     EXPECT_EQ(state().head(N), result);  // Sanity check the deprecated output.
     return result;
   }
 
   VectorXd torque() const {
-    return dut_.get_commanded_torque_output_port().EvalEigenVector(context_);
+    return dut_.get_commanded_torque_output_port().Eval(context_);
   }
 
   VectorXd state() const {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    return dut_.get_commanded_state_output_port().EvalEigenVector(context_);
+    return dut_.get_commanded_state_output_port().Eval(context_);
 #pragma GCC diagnostic pop
   }
 

--- a/manipulation/kuka_iiwa/test/iiwa_status_receiver_test.cc
+++ b/manipulation/kuka_iiwa/test/iiwa_status_receiver_test.cc
@@ -52,7 +52,7 @@ TEST_F(IiwaStatusReceiverTest, AcceptanceTest) {
     const auto& port = leaf.get_output_port(i);
     const int size = (&port == &state_port()) ? (2 * N) : N;
     EXPECT_TRUE(CompareMatrices(
-        port.EvalEigenVector(context_),
+        port.Eval(context_),
         VectorXd::Zero(size)));
   }
 
@@ -77,28 +77,28 @@ TEST_F(IiwaStatusReceiverTest, AcceptanceTest) {
 
   // Confirm that real message values are output correctly.
   EXPECT_TRUE(CompareMatrices(
-      dut_.get_position_commanded_output_port().EvalEigenVector(context_),
+      dut_.get_position_commanded_output_port().Eval(context_),
       position_commanded));
   EXPECT_TRUE(CompareMatrices(
-      dut_.get_position_measured_output_port().EvalEigenVector(context_),
+      dut_.get_position_measured_output_port().Eval(context_),
       position_measured));
   EXPECT_TRUE(CompareMatrices(
-      dut_.get_velocity_estimated_output_port().EvalEigenVector(context_),
+      dut_.get_velocity_estimated_output_port().Eval(context_),
       velocity_estimated));
   EXPECT_TRUE(CompareMatrices(
-      dut_.get_torque_commanded_output_port().EvalEigenVector(context_),
+      dut_.get_torque_commanded_output_port().Eval(context_),
       torque_commanded));
   EXPECT_TRUE(CompareMatrices(
-      dut_.get_torque_measured_output_port().EvalEigenVector(context_),
+      dut_.get_torque_measured_output_port().Eval(context_),
       torque_measured));
   EXPECT_TRUE(CompareMatrices(
-      dut_.get_torque_external_output_port().EvalEigenVector(context_),
+      dut_.get_torque_external_output_port().Eval(context_),
       torque_external));
   EXPECT_TRUE(CompareMatrices(
-      state_port().EvalEigenVector(context_).head(N),
+      state_port().Eval(context_).head(N),
       position_measured));
   EXPECT_TRUE(CompareMatrices(
-      state_port().EvalEigenVector(context_).tail(N),
+      state_port().Eval(context_).tail(N),
       velocity_estimated));
 }
 

--- a/systems/analysis/test/simulator_test.cc
+++ b/systems/analysis/test/simulator_test.cc
@@ -1167,9 +1167,7 @@ class SimpleHybridSystem : public LeafSystem<double> {
   EventStatus Update(
       const Context<double>& context,
       DiscreteValues<double>* x_next) const {
-    const BasicVector<double>* input = this->EvalVectorInput(context, 0);
-    DRAKE_DEMAND(input);
-    const double u = input->get_value()[0];  // u(t)
+    const double u = this->get_input_port(0).Eval(context)[0];  // u(t)
     double x = context.get_discrete_state()[0];  // x_n
     (*x_next)[0] = x + u;
     return EventStatus::Succeeded();
@@ -1282,7 +1280,7 @@ class DiscreteInputAccumulator : public LeafSystem<double> {
                                            const DiscreteUpdateEvent<double>&,
                                            DiscreteValues<double>* x_np1) {
           const double x_n = get_x(context);
-          const double u = EvalVectorInput(context, 0)->GetAtIndex(0);
+          const double u = get_input_port(0).Eval(context)[0];
           x_np1->get_mutable_vector()[0] = x_n + u;  // x_{n+1} = x_n + u(t)
         }));
   }

--- a/systems/controllers/inverse_dynamics.cc
+++ b/systems/controllers/inverse_dynamics.cc
@@ -52,7 +52,7 @@ template <typename T>
 void InverseDynamics<T>::CalcOutputForce(const Context<T>& context,
                                           BasicVector<T>* output) const {
   // State input.
-  VectorX<T> x = this->EvalEigenVectorInput(context, input_port_index_state_);
+  VectorX<T> x = get_input_port_estimated_state().Eval(context);
 
   // Desired acceleration input.
   VectorX<T> desired_vd = VectorX<T>::Zero(v_dim_);
@@ -60,8 +60,7 @@ void InverseDynamics<T>::CalcOutputForce(const Context<T>& context,
   if (!this->is_pure_gravity_compensation()) {
     // Only eval acceleration input port when we are not in pure gravity
     // compensation mode.
-    desired_vd = this->EvalEigenVectorInput(
-        context, input_port_index_desired_acceleration_);
+    desired_vd = get_input_port_desired_acceleration().Eval(context);
   } else {
     // Sets velocity to zero in pure gravity compensation.
     x.tail(v_dim_).setZero();

--- a/systems/controllers/linear_model_predictive_controller.cc
+++ b/systems/controllers/linear_model_predictive_controller.cc
@@ -73,12 +73,12 @@ template <typename T>
 void LinearModelPredictiveController<T>::CalcControl(
     const Context<T>& context, BasicVector<T>* control) const {
   const Eigen::VectorBlock<const VectorX<T>> current_state =
-      this->EvalEigenVectorInput(context, state_input_index_);
+      get_state_port().Eval(context);
 
   const Eigen::VectorXd current_input =
       SetupAndSolveQp(*base_context_, current_state);
 
-  const VectorX<T> input_ref = model_->EvalEigenVectorInput(*base_context_, 0);
+  const VectorX<T> input_ref = model_->get_input_port(0).Eval(*base_context_);
 
   control->SetFromVector(current_input + input_ref);
 

--- a/systems/controllers/linear_quadratic_regulator.cc
+++ b/systems/controllers/linear_quadratic_regulator.cc
@@ -149,7 +149,7 @@ std::unique_ptr<systems::AffineSystem<double>> LinearQuadraticRegulator(
           ? context.get_continuous_state_vector().CopyToVector()
           : context.get_discrete_state(0).CopyToVector();
 
-  const auto& u0 = system.EvalEigenVectorInput(context, 0);
+  const auto& u0 = system.get_input_port(0).Eval(context);
 
   // Return the affine controller: u = u0 - K(x-x0).
   return std::make_unique<systems::AffineSystem<double>>(

--- a/systems/controllers/pid_controller.cc
+++ b/systems/controllers/pid_controller.cc
@@ -81,9 +81,9 @@ template <typename T>
 void PidController<T>::DoCalcTimeDerivatives(
     const Context<T>& context, ContinuousState<T>* derivatives) const {
   const Eigen::VectorBlock<const VectorX<T>> state =
-      this->EvalEigenVectorInput(context, input_index_state_);
+      get_input_port_estimated_state().Eval(context);
   const Eigen::VectorBlock<const VectorX<T>> state_d =
-      this->EvalEigenVectorInput(context, input_index_desired_state_);
+      get_input_port_desired_state().Eval(context);
 
   // The derivative of the continuous state is the instantaneous position error.
   VectorBase<T>& derivatives_vector = derivatives->get_mutable_vector();
@@ -97,9 +97,9 @@ template <typename T>
 void PidController<T>::CalcControl(const Context<T>& context,
                                    BasicVector<T>* control) const {
   const Eigen::VectorBlock<const VectorX<T>> state =
-      this->EvalEigenVectorInput(context, input_index_state_);
+      get_input_port_estimated_state().Eval(context);
   const Eigen::VectorBlock<const VectorX<T>> state_d =
-      this->EvalEigenVectorInput(context, input_index_desired_state_);
+      get_input_port_desired_state().Eval(context);
 
   // State error.
   const VectorX<T> controlled_state_diff =

--- a/systems/controllers/test/dynamic_programming_test.cc
+++ b/systems/controllers/test/dynamic_programming_test.cc
@@ -147,7 +147,7 @@ GTEST_TEST(FittedValueIteration, DoubleIntegrator) {
   // minimum time cost function (1 for all non-zero states).
   const auto cost_function = [&sys, &Q, &R](const Context<double>& context) {
     const Eigen::Vector2d x = context.get_continuous_state().CopyToVector();
-    const double u = sys.EvalVectorInput(context, 0)->GetAtIndex(0);
+    const double u = sys.get_input_port().Eval(context)[0];
     return x.dot(Q * x) + u * R * u;
   };
 

--- a/systems/controllers/test/linear_model_predictive_controller_test.cc
+++ b/systems/controllers/test/linear_model_predictive_controller_test.cc
@@ -113,7 +113,7 @@ class CubicPolynomialSystem final : public LeafSystem<T> {
       DiscreteValues<T>* next_state) const final {
     using std::pow;
     const T& x1 = context.get_discrete_state(0).get_value()[0];
-    const T& u = this->EvalVectorInput(context, 0)->get_value()[0];
+    const T& u = this->get_input_port(0).Eval(context)[0];
     next_state->get_mutable_vector(0).SetAtIndex(0, u);
     next_state->get_mutable_vector(0).SetAtIndex(1, pow(x1, 3.));
   }

--- a/systems/controllers/test/pid_controlled_system_test.cc
+++ b/systems/controllers/test/pid_controlled_system_test.cc
@@ -22,7 +22,7 @@ class TestPlant : public LeafSystem<double> {
   TestPlant() {}
 
   double GetInputValue(const Context<double>& context) {
-    return EvalEigenVectorInput(context, 0)(0);
+    return get_input_port(0).Eval(context)[0];
   }
 };
 

--- a/systems/estimators/luenberger_observer.cc
+++ b/systems/estimators/luenberger_observer.cc
@@ -83,7 +83,7 @@ void LuenbergerObserver<T>::DoCalcTimeDerivatives(
     // TODO(russt): Avoid this dynamic allocation by fixing the input port once
     // and updating it here.
     observed_system_context_->FixInputPort(
-        0, this->EvalVectorInput(context, 1)->CopyToVector());
+        0, this->get_input_port(1).Eval(context));
   }
   // Set observed system state.
   observed_system_context_->get_mutable_continuous_state_vector().SetFrom(
@@ -96,7 +96,7 @@ void LuenbergerObserver<T>::DoCalcTimeDerivatives(
                                         observed_system_derivatives_.get());
 
   // Get the measurements.
-  auto y = this->EvalVectorInput(context, 0)->CopyToVector();
+  auto y = this->get_input_port(0).Eval(context);
   auto yhat = observed_system_output_->GetMutableVectorData(0)->CopyToVector();
 
   // Add in the observed gain terms.

--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -41,6 +41,7 @@ drake_cc_package_library(
         ":output_port",
         ":output_port_base",
         ":parameters",
+        ":port_base",
         ":single_output_vector_source",
         ":state",
         ":system",
@@ -254,6 +255,21 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "port_base",
+    srcs = [
+        "port_base.cc",
+    ],
+    hdrs = [
+        "port_base.h",
+    ],
+    deps = [
+        ":framework_common",
+        ":vector",
+        "//common:nice_type_name",
+    ],
+)
+
+drake_cc_library(
     name = "input_port_base",
     srcs = [
         "input_port_base.cc",
@@ -262,7 +278,10 @@ drake_cc_library(
         "input_port_base.h",
     ],
     deps = [
+        ":context_base",
         ":framework_common",
+        ":port_base",
+        "//common:nice_type_name",
         "//common:random",
     ],
 )
@@ -277,6 +296,8 @@ drake_cc_library(
     ],
     deps = [
         ":framework_common",
+        ":port_base",
+        "//common:nice_type_name",
     ],
 )
 
@@ -349,6 +370,7 @@ drake_cc_library(
         "input_port.h",
     ],
     deps = [
+        ":context",
         ":input_port_base",
         "//common:default_scalars",
         "//common:essential",
@@ -802,6 +824,16 @@ drake_cc_googletest(
     deps = [
         ":system_output",
         "//common:essential",
+        "//systems/framework/test_utilities",
+    ],
+)
+
+drake_cc_googletest(
+    name = "input_port_test",
+    deps = [
+        ":input_port",
+        ":leaf_system",
+        "//common/test_utilities:expect_throws_message",
         "//systems/framework/test_utilities",
     ],
 )

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -536,7 +536,7 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
   void GetGraphvizInputPortToken(const InputPort<T>& port,
                                  int max_depth,
                                  std::stringstream* dot) const final {
-    DRAKE_DEMAND(port.get_system() == this);
+    DRAKE_DEMAND(&port.get_system() == this);
     // Note: ports are rendered in a fundamentally different way depending on
     // max_depth.
     if (max_depth > 0) {
@@ -1488,7 +1488,7 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
     const int port_index = port.second;
     const auto& source_output_port = sys->get_output_port(port_index);
     // TODO(sherm1) Use implicit_cast when available (from abseil).
-    auto diagram_port = std::make_unique<DiagramOutputPort<T>>(
+    auto diagram_port = internal::FrameworkFactory::Make<DiagramOutputPort<T>>(
         this,  // implicit_cast<const System<T>*>(this)
         this,  // implicit_cast<SystemBase*>(this)
         std::move(name), OutputPortIndex(this->get_num_output_ports()),
@@ -1509,7 +1509,7 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
     SPDLOG_TRACE(log(), "Evaluating output for subsystem {}, port {}",
                  system->GetSystemPathname(), port_index);
     const Context<T>& subsystem_context = context.GetSubsystemContext(i);
-    return port.EvalAbstract(subsystem_context);
+    return port.template Eval<AbstractValue>(subsystem_context);
   }
 
   // Converts an InputPortLocator to a DiagramContext::InputPortIdentifier.

--- a/systems/framework/diagram_builder.h
+++ b/systems/framework/diagram_builder.h
@@ -138,10 +138,10 @@ class DiagramBuilder {
   /// Declares that input port @p dest is connected to output port @p src.
   void Connect(const OutputPort<T>& src,
                const InputPort<T>& dest) {
-    InputPortLocator dest_id{dest.get_system(), dest.get_index()};
+    InputPortLocator dest_id{&dest.get_system(), dest.get_index()};
     OutputPortLocator src_id{&src.get_system(), src.get_index()};
     ThrowIfSystemNotRegistered(&src.get_system());
-    ThrowIfSystemNotRegistered(dest.get_system());
+    ThrowIfSystemNotRegistered(&dest.get_system());
     ThrowIfInputAlreadyWired(dest_id);
     if (src.get_data_type() != dest.get_data_type()) {
       throw std::logic_error(fmt::format(
@@ -149,7 +149,7 @@ class DiagramBuilder {
           "valued ports while connecting output port {} of System {} to "
           "input port {} of System {}",
           src.get_name(), src.get_system().get_name(),
-          dest.get_name(), dest.get_system()->get_name()));
+          dest.get_name(), dest.get_system().get_name()));
     }
     if ((src.get_data_type() != kAbstractValued) &&
         (src.size() != dest.size())) {
@@ -158,11 +158,11 @@ class DiagramBuilder {
           "output port {} of System {} (size {}) to "
           "input port {} of System {} (size {})",
           src.get_name(), src.get_system().get_name(), src.size(),
-          dest.get_name(), dest.get_system()->get_name(), dest.size()));
+          dest.get_name(), dest.get_system().get_name(), dest.size()));
     }
     if (src.get_data_type() == kAbstractValued) {
       auto model_output = src.Allocate();
-      auto model_input = dest.get_system()->AllocateInputAbstract(dest);
+      auto model_input = dest.get_system().AllocateInputAbstract(dest);
       const std::type_info& output_type = model_output->static_type_info();
       const std::type_info& input_type = model_input->static_type_info();
       if (output_type != input_type) {
@@ -172,7 +172,7 @@ class DiagramBuilder {
             "input port {} of System {} (type {})",
             src.get_name(), src.get_system().get_name(),
             NiceTypeName::Get(output_type),
-            dest.get_name(), dest.get_system()->get_name(),
+            dest.get_name(), dest.get_system().get_name(),
             NiceTypeName::Get(input_type)));
       }
     }
@@ -209,9 +209,9 @@ class DiagramBuilder {
   InputPortIndex ExportInput(
       const InputPort<T>& input,
       variant<std::string, UseDefaultName> name = kUseDefaultName) {
-    InputPortLocator id{input.get_system(), input.get_index()};
+    InputPortLocator id{&input.get_system(), input.get_index()};
     ThrowIfInputAlreadyWired(id);
-    ThrowIfSystemNotRegistered(input.get_system());
+    ThrowIfSystemNotRegistered(&input.get_system());
     InputPortIndex return_id(input_port_ids_.size());
     input_port_ids_.push_back(id);
 
@@ -219,7 +219,7 @@ class DiagramBuilder {
     // of the port names.
     std::string port_name =
         name == kUseDefaultName
-            ? input.get_system()->get_name() + "_" + input.get_name()
+            ? input.get_system().get_name() + "_" + input.get_name()
             : get<std::string>(std::move(name));
     DRAKE_DEMAND(!port_name.empty());
     input_port_names_.emplace_back(std::move(port_name));

--- a/systems/framework/diagram_output_port.h
+++ b/systems/framework/diagram_output_port.h
@@ -35,29 +35,42 @@ class DiagramOutputPort final : public OutputPort<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DiagramOutputPort)
 
-  /** (Internal use only) Constructs a %DiagramOutputPort that exports an
-  output port of one of the diagram's child subsystems.
+  ~DiagramOutputPort() final = default;
 
-  @param diagram The Diagram that will own this port.
-  @param system_base The same Diagram cast to its base class.
-  @param name A name for the port.  Output ports names must be unique
-      within the `diagram` System.
-  @param index The output port index to be assigned to the new port.
-  @param ticket The DependencyTicket to be assigned to the new port.
-  @param source_output_port An output port of one of this diagram's child
-      subsystems that is to be forwarded to the new port.
-  @param source_subsystem_index The index of the child subsystem that owns
-      `source_output_port`.
+  /** Obtains a reference to the subsystem output port that was exported to
+  create this diagram port. Note that the source may itself be a diagram
+  output port. */
+  const OutputPort<T>& get_source_output_port() const {
+    return *source_output_port_;
+  }
 
-  @pre The `diagram` System must actually be a Diagram.
-  @pre `diagram` lifetime must exceed the port's; we retain the pointer here.
-  @pre `diagram` and `system_base` must be the same object.
-  @pre `source_output_port` must be owned by a child of `diagram`.
-  @pre `source_subsystem_index` must be the index of that child in `diagram`.
+ private:
+  friend class internal::FrameworkFactory;
 
-  This is intended only for use by Diagram and we depend on the caller to
-  meet the above preconditions, not all of which can be independently
-  verified here. */
+  // Constructs a %DiagramOutputPort that exports an output port of one of the
+  // diagram's child subsystems.
+  //
+  // @param diagram The Diagram that will own this port.
+  // @param system_base The same Diagram cast to its base class.
+  // @param name A name for the port.  Output ports names must be unique
+  //     within the `diagram` System.
+  // @param index The output port index to be assigned to the new port.
+  // @param ticket The DependencyTicket to be assigned to the new port.
+  // @param source_output_port An output port of one of this diagram's child
+  //     subsystems that is to be forwarded to the new port.
+  // @param source_subsystem_index The index of the child subsystem that owns
+  //     `source_output_port`.
+  //
+  // @pre The `diagram` System must actually be a Diagram.
+  // @pre `diagram` lifetime must exceed the port's; we retain the pointer here.
+  // @pre `diagram` and `system_base` must be the same object.
+  // @pre `source_output_port` must be owned by a child of `diagram`.
+  // @pre `source_subsystem_index` must be the index of that child in `diagram`.
+  //
+  // This is intended only for use by Diagram and we depend on the caller to
+  // meet the above preconditions, not all of which can be independently
+  // verified here.
+  //
   // To avoid a Diagram <=> DiagramOutputPort physical dependency, this class
   // doesn't have access to a declaration of Diagram<T> so would not be able
   // to static_cast up to System<T> as is required by OutputPort. We expect
@@ -79,16 +92,6 @@ class DiagramOutputPort final : public OutputPort<T> {
     DRAKE_DEMAND(source_output_port != nullptr);
   }
 
-  ~DiagramOutputPort() final = default;
-
-  /** Obtains a reference to the subsystem output port that was exported to
-  create this diagram port. Note that the source may itself be a diagram
-  output port. */
-  const OutputPort<T>& get_source_output_port() const {
-    return *source_output_port_;
-  }
-
- private:
   // Asks the source system output port to allocate an appropriate object.
   std::unique_ptr<AbstractValue> DoAllocate() const final {
     return source_output_port_->Allocate();
@@ -106,7 +109,7 @@ class DiagramOutputPort final : public OutputPort<T> {
   // delegates to the source output port.
   const AbstractValue& DoEval(const Context<T>& diagram_context) const final {
     const Context<T>& subcontext = get_subcontext(diagram_context);
-    return source_output_port_->EvalAbstract(subcontext);
+    return source_output_port_->template Eval<AbstractValue>(subcontext);
   }
 
   // Returns the source output port's subsystem, and the ticket for that

--- a/systems/framework/framework_common.h
+++ b/systems/framework/framework_common.h
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "drake/common/drake_assert.h"
@@ -99,6 +100,19 @@ class ContextBase;
 class InputPortBase;
 
 namespace internal {
+
+// A utility to call the package-private constructor of some framework classes.
+class FrameworkFactory {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FrameworkFactory)
+  FrameworkFactory() = delete;
+  ~FrameworkFactory() = delete;
+
+  template <typename T, typename... Args>
+  static std::unique_ptr<T> Make(Args... args) {
+    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+  }
+};
 
 // TODO(sherm1) These interface classes shouldn't be here -- split into their
 // own headers. As written they obscure the limited use of these interfaces

--- a/systems/framework/input_port.h
+++ b/systems/framework/input_port.h
@@ -1,55 +1,133 @@
 #pragma once
 
 #include <string>
+#include <type_traits>
 #include <utility>
 
 #include "drake/common/constants.h"
 #include "drake/common/default_scalars.h"
-#include "drake/common/drake_deprecated.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/drake_optional.h"
+#include "drake/common/eigen_types.h"
+#include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/context.h"
 #include "drake/systems/framework/framework_common.h"
 #include "drake/systems/framework/input_port_base.h"
 
 namespace drake {
 namespace systems {
 
+// Break the System <=> InputPort physical dependency cycle.  InputPorts are
+// decorated with a back-pointer to their owning System<T>, but that pointer is
+// forward-declared here and never dereferenced within this file.
 template <typename T>
 class System;
 
-/// This extends InputPortBase with some scalar type-dependent methods.
-///
-/// @tparam T The mathematical type of the context, which must be a valid Eigen
-///           scalar.
+/** An InputPort is a System resource that describes the kind of input a
+System accepts, on a given port. It does not directly contain any runtime
+input port data; that is always contained in a Context. The actual value will
+be either the value of an OutputPort to which this is connected, or a fixed
+value set in a Context.
+
+@tparam T The mathematical type of the context, which must be a valid Eigen
+          scalar.
+*/
 template <typename T>
 class InputPort final : public InputPortBase {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(InputPort)
 
-  /// (Internal use only)
-  /// Constructs a type-specific input port. See InputPortBase::InputPortBase()
-  /// for the meaning of these parameters. The additional `system` parameter
-  /// here must be the same object as the `system_base` parameter. The
-  /// `name` must not be empty.
-  // The System and SystemBase are provided separately since we don't have
-  // access to System's declaration here so can't cast but the caller can.
-  InputPort(const System<T>* system, SystemBase* system_base, std::string name,
-            InputPortIndex index, DependencyTicket ticket,
-            PortDataType data_type, int size,
-            const optional<RandomDistribution>& random_type)
+  /** Returns a reference to the up-to-date value of this input port contained
+  in the given Context. This is the preferred way to obtain an input port's
+  value since it will not be recalculated once up to date.
+
+  If the value is not already up to date with respect to its prerequisites, it
+  will recalculate an up-to-date value before the reference is returned. The
+  recalculation may be arbitrarily expensive, but Eval() is constant time and
+  _very_ fast if the value is already up to date.
+
+  @tparam ValueType The type of the const-reference returned by this method.
+  When omitted, the return type is an `Eigen::VectorBlock` (this is only valid
+  when this is a vector-valued port).  For abstract ports, the `ValueType`
+  either can be the declared type of the port (e.g., `lcmt_iiwa_status`), or
+  else in advanced use cases can be `AbstractValue` to get the type-erased
+  value.
+
+  @return reference to the up-to-date value; if a ValueType is provided, the
+  return type is `const ValueType&`; if a ValueType is omitted, the return type
+  is `Eigen::VectorBlock<const VectorX<T>>`.
+
+  @throw std::exception if the port is not connected.  (Use HasValue() to check
+  first, if necessary.)
+
+  @pre The input port is vector-valued (when no ValueType is provided).
+  @pre The input port is of type ValueType (when ValueType is provided).
+  */
+#ifdef DRAKE_DOXYGEN_CXX
+  template <typename ValueType = Eigen::VectorBlock<const VectorX<T>>>
+  const ValueType& Eval(const Context<T>& context) const;
+#else
+  // Without a template -- return Eigen.
+  Eigen::VectorBlock<const VectorX<T>> Eval(const Context<T>& context) const {
+    return Eval<BasicVector<T>>(context).get_value();
+  }
+  // With ValueType == AbstractValue, we don't need to downcast.
+  template <typename ValueType, typename = std::enable_if_t<
+      std::is_same<AbstractValue, ValueType>::value>>
+  const AbstractValue& Eval(const Context<T>& context) const {
+    DRAKE_ASSERT_VOID(get_system_base().ThrowIfContextNotCompatible(context));
+    return DoEvalRequired(context);
+  }
+  // With anything but a BasicVector subclass, we can just DoEval then cast.
+  template <typename ValueType, typename = std::enable_if_t<
+      !std::is_same<AbstractValue, ValueType>::value && (
+        !std::is_base_of<BasicVector<T>, ValueType>::value ||
+        std::is_same<BasicVector<T>, ValueType>::value)>>
+  const ValueType& Eval(const Context<T>& context) const {
+    DRAKE_ASSERT_VOID(get_system_base().ThrowIfContextNotCompatible(context));
+    return PortEvalCast<ValueType>(DoEvalRequired(context));
+  }
+  // With a BasicVector subclass, we need to downcast twice.
+  template <typename ValueType, typename = std::enable_if_t<
+      std::is_base_of<BasicVector<T>, ValueType>::value &&
+      !std::is_same<BasicVector<T>, ValueType>::value>>
+  const ValueType& Eval(const Context<T>& context, int = 0) const {
+    return PortEvalCast<ValueType>(Eval<BasicVector<T>>(context));
+  }
+#endif  // DRAKE_DOXYGEN_CXX
+
+  /** Returns true iff this port is connected.  Beware that at the moment, this
+  could be an expensive operation, because the value is brought up-to-date as
+  part of this operation. */
+  bool HasValue(const Context<T>& context) const {
+    DRAKE_ASSERT_VOID(get_system_base().ThrowIfContextNotCompatible(context));
+    return DoEvalOptional(context);
+  }
+
+  /** Returns a reference to the System that owns this input port. Note that
+  for a Diagram input port this will be the Diagram, not the LeafSystem whose
+  input port was exported. */
+  const System<T>& get_system() const { return system_; }
+
+ private:
+  friend class internal::FrameworkFactory;
+
+  // See InputPortBase for the meaning of these parameters. The additional
+  // `system` parameter must point to the same object as `system_base`.
+  // (They're separate because System is forward-declared so we can't cast.)
+  InputPort(
+      const System<T>* system, internal::SystemMessageInterface* system_base,
+      std::string name, InputPortIndex index, DependencyTicket ticket,
+      PortDataType data_type, int size,
+      const optional<RandomDistribution>& random_type,
+      EvalAbstractCallback eval)
       : InputPortBase(system_base, std::move(name), index, ticket, data_type,
-                      size, random_type),
+                      size, random_type, std::move(eval)),
         system_(*system) {
     DRAKE_DEMAND(system != nullptr);
     DRAKE_DEMAND(static_cast<const void*>(system) == system_base);
   }
 
-  /// Returns a reference to the System that owns this input port. Note that
-  /// for a Diagram input port this will be the Diagram, not the LeafSystem
-  /// whose input port was exported.
-  // TODO(sherm1) Switch to an actual reference.
-  const System<T>* get_system() const { return &system_; }
-
- private:
   const System<T>& system_;
 };
 

--- a/systems/framework/leaf_output_port.h
+++ b/systems/framework/leaf_output_port.h
@@ -59,8 +59,17 @@ class LeafOutputPort final : public OutputPort<T> {
   using CalcVectorCallback =
   std::function<void(const Context<T>&, BasicVector<T>*)>;
 
-  /** Constructs a cached output port. The `system` parameter must be the same
-  object as the `system_base` parameter. */
+  /** Returns the cache entry associated with this output port. */
+  const CacheEntry& cache_entry() const {
+    DRAKE_ASSERT(cache_entry_ != nullptr);
+    return *cache_entry_;
+  }
+
+ private:
+  friend class internal::FrameworkFactory;
+
+  // Constructs a cached output port. The `system` parameter must be the same
+  // object as the `system_base` parameter.
   LeafOutputPort(const System<T>* system, SystemBase* system_base,
                  std::string name, OutputPortIndex index,
                  DependencyTicket ticket, PortDataType data_type, int size,
@@ -71,13 +80,6 @@ class LeafOutputPort final : public OutputPort<T> {
     DRAKE_DEMAND(cache_entry != nullptr);
   }
 
-  /** Returns the cache entry associated with this output port. */
-  const CacheEntry& cache_entry() const {
-    DRAKE_ASSERT(cache_entry_ != nullptr);
-    return *cache_entry_;
-  }
-
- private:
   // Invokes the cache entry's allocation function.
   std::unique_ptr<AbstractValue> DoAllocate() const final {
     return cache_entry().Allocate();

--- a/systems/framework/output_port.h
+++ b/systems/framework/output_port.h
@@ -11,6 +11,7 @@
 #include "drake/common/autodiff.h"
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/nice_type_name.h"
 #include "drake/common/type_safe_index.h"
 #include "drake/systems/framework/basic_vector.h"
@@ -79,26 +80,61 @@ class OutputPort : public OutputPortBase {
 
   /** Returns a reference to the up-to-date value of this output port contained
   in the given Context. This is the preferred way to obtain an output port's
-  value since it will not be recalculated once up to date. If the value is not
-  already up to date with respect to its prerequisites, this port's Calc()
-  method is used first to update the value before the reference is returned. The
-  Calc() method may be arbitrarily expensive, but Eval() is constant time and
-  _very_ fast if the value is already up to date. */
-  template <typename ValueType>
-  const ValueType& Eval(const Context<T>& context) const {
-    const AbstractValue& abstract_value = EvalAbstract(context);
-    return ExtractValueOrThrow<ValueType>(__func__, abstract_value);
-  }
+  value since it will not be recalculated once up to date.
 
-  /** Returns a reference to the up-to-date vector value of this output port
-  contained in the given Context.  See Eval() for the full description of the
-  computational semantics; this method is just sugar that casts the Eval()
-  result to an Eigen type.
-  @pre This is vector-valued output port. */
-  Eigen::VectorBlock<const VectorX<T>> EvalEigenVector(
-      const Context<T>& context) const {
+  If the value is not already up to date with respect to its prerequisites, it
+  will recalculate an up-to-date value before the reference is returned. The
+  recalculation may be arbitrarily expensive, but Eval() is constant time and
+  _very_ fast if the value is already up to date.
+
+  @tparam ValueType The type of the const-reference returned by this method.
+  When omitted, the return type is an `Eigen::VectorBlock` (this is only valid
+  when this is a vector-valued port).  For abstract ports, the `ValueType`
+  either can be the declared type of the port (e.g., `lcmt_iiwa_status`), or
+  else in advanced use cases can be `AbstractValue` to get the type-erased
+  value.
+
+  @return reference to the up-to-date value; if a ValueType is provided, the
+  return type is `const ValueType&`; if a ValueType is omitted, the return type
+  is `Eigen::VectorBlock<const VectorX<T>>`.
+
+  @throw std::exception if the port is not connected.
+
+  @pre The output port is vector-valued (when no ValueType is provided).
+  @pre The output port is of type ValueType (when ValueType is provided).
+  */
+#ifdef DRAKE_DOXYGEN_CXX
+  template <typename ValueType = Eigen::VectorBlock<const VectorX<T>>>
+  const ValueType& Eval(const Context<T>& context) const;
+#else
+  // Without a template -- return Eigen.
+  Eigen::VectorBlock<const VectorX<T>> Eval(const Context<T>& context) const {
     return Eval<BasicVector<T>>(context).get_value();
   }
+  // With ValueType == AbstractValue, we don't need to downcast.
+  template <typename ValueType, typename = std::enable_if_t<
+      std::is_same<AbstractValue, ValueType>::value>>
+  const AbstractValue& Eval(const Context<T>& context) const {
+    DRAKE_ASSERT_VOID(get_system_base().ThrowIfContextNotCompatible(context));
+    return DoEval(context);
+  }
+  // With anything but a BasicVector subclass, we can just DoEval then cast.
+  template <typename ValueType, typename = std::enable_if_t<
+      !std::is_same<AbstractValue, ValueType>::value && (
+        !std::is_base_of<BasicVector<T>, ValueType>::value ||
+        std::is_same<BasicVector<T>, ValueType>::value)>>
+  const ValueType& Eval(const Context<T>& context) const {
+    DRAKE_ASSERT_VOID(get_system_base().ThrowIfContextNotCompatible(context));
+    return PortEvalCast<ValueType>(DoEval(context));
+  }
+  // With a BasicVector subclass, we need to downcast twice.
+  template <typename ValueType, typename = std::enable_if_t<
+      std::is_base_of<BasicVector<T>, ValueType>::value &&
+      !std::is_same<BasicVector<T>, ValueType>::value>>
+  const ValueType& Eval(const Context<T>& context, int = 0) const {
+    return PortEvalCast<ValueType>(Eval<BasicVector<T>>(context));
+  }
+#endif  // DRAKE_DOXYGEN_CXX
 
   /** Allocates a concrete object suitable for holding the value to be exposed
   by this output port, and returns that as an AbstractValue. The returned object
@@ -113,7 +149,7 @@ class OutputPort : public OutputPortBase {
     if (value == nullptr) {
       throw std::logic_error(fmt::format(
           "OutputPort::Allocate(): allocator returned a nullptr for {}.",
-          GetPortIdString()));
+          GetFullDescription()));
     }
     DRAKE_ASSERT_VOID(CheckValidAllocation(*value));
     return value;
@@ -127,21 +163,10 @@ class OutputPort : public OutputPortBase {
   the Allocate() method. */
   void Calc(const Context<T>& context, AbstractValue* value) const {
     DRAKE_DEMAND(value != nullptr);
-    DRAKE_ASSERT_VOID(
-        get_system_base().ThrowIfContextNotCompatible(context));
+    DRAKE_ASSERT_VOID(get_system_base().ThrowIfContextNotCompatible(context));
     DRAKE_ASSERT_VOID(CheckValidOutputType(*value));
 
     DoCalc(context, value);
-  }
-
-  /** Returns a reference to the value of this output port contained in the
-  given Context. If that value is not up to date with respect to its
-  prerequisites, the Calc() method above is used first to update the value
-  before the reference is returned. */
-  const AbstractValue& EvalAbstract(const Context<T>& context) const {
-    DRAKE_ASSERT_VOID(
-        get_system_base().ThrowIfContextNotCompatible(context));
-    return DoEval(context);
   }
 
   /** Returns a reference to the System that owns this output port. Note that
@@ -149,6 +174,19 @@ class OutputPort : public OutputPortBase {
   output port was forwarded. */
   const System<T>& get_system() const {
     return system_;
+  }
+
+  DRAKE_DEPRECATED(
+      "Use Eval() instead. This method will be removed on 2019-06-01.")
+  const AbstractValue& EvalAbstract(const Context<T>& context) const {
+    return this->template Eval<AbstractValue>(context);
+  }
+
+  DRAKE_DEPRECATED(
+      "Use Eval() instead. This method will be removed on 2019-06-01.")
+  Eigen::VectorBlock<const VectorX<T>> EvalEigenVector(
+      const Context<T>& context) const {
+    return this->Eval(context);
   }
 
  protected:
@@ -195,16 +233,6 @@ class OutputPort : public OutputPortBase {
                  the System whose output port this is. */
   virtual const AbstractValue& DoEval(const Context<T>& context) const = 0;
 
-  /** This is useful for error messages and produces a human-readable
-  identification of an offending output port. */
-  std::string GetPortIdString() const {
-    return fmt::format("OutputPort[{}] of System {} ({})",
-                       this->get_index(),
-                       this->get_system_base().GetSystemPathname(),
-                       NiceTypeName::RemoveNamespaces(
-                           this->get_system_base().GetSystemType()));
-  }
-
  private:
   // If this is a vector-valued port, we can check that the returned abstract
   // value actually holds a BasicVector-derived object, and for fixed-size ports
@@ -214,17 +242,6 @@ class OutputPort : public OutputPortBase {
   // Check that an AbstractValue provided to Calc() is suitable for this port.
   // (Very expensive; use in Debug only.)
   void CheckValidOutputType(const AbstractValue&) const;
-
-  // User said output port would have a particular concrete type but it doesn't.
-  template <typename ValueType>
-  [[noreturn]] void ThrowBadValueType(const char* func,
-                                      const AbstractValue& abstract) const;
-
-  // Pull a value of a given type from an abstract value or issue a nice
-  // message if the type is not correct.
-  template <typename ValueType>
-  const ValueType& ExtractValueOrThrow(const char* func,
-                                       const AbstractValue& abstract) const;
 
   const System<T>& system_;
 };
@@ -239,7 +256,7 @@ void OutputPort<T>::CheckValidAllocation(const AbstractValue& proposed) const {
     throw std::logic_error(
         fmt::format("OutputPort::Allocate(): expected BasicVector output type "
                     "but got {} for {}.",
-                    proposed.GetNiceTypeName(), GetPortIdString()));
+                    proposed.GetNiceTypeName(), GetFullDescription()));
   }
 
   if (this->size() == kAutoSize) return;  // Any size is acceptable.
@@ -249,7 +266,7 @@ void OutputPort<T>::CheckValidAllocation(const AbstractValue& proposed) const {
     throw std::logic_error(
         fmt::format("OutputPort::Allocate(): expected vector output type of "
                     "size {} but got a vector of size {} for {}.",
-                    this->size(), proposed_size, GetPortIdString()));
+                    this->size(), proposed_size, GetFullDescription()));
   }
 }
 
@@ -266,29 +283,8 @@ void OutputPort<T>::CheckValidOutputType(const AbstractValue& proposed) const {
         fmt::format("OutputPort::Calc(): expected output type {} "
                     "but got {} for {}.",
                     good->GetNiceTypeName(), proposed.GetNiceTypeName(),
-                    GetPortIdString()));
+                    GetFullDescription()));
   }
-}
-
-template <typename T>
-template <typename ValueType>
-void OutputPort<T>::ThrowBadValueType(const char* func_name,
-                                      const AbstractValue& abstract) const {
-  throw std::logic_error(
-      fmt::format("OutputPort::{}(): wrong value type {} "
-                  "specified but actual type was {} for {}.",
-                  func_name, NiceTypeName::Get<ValueType>(),
-                  abstract.GetNiceTypeName(), GetPortIdString()));
-}
-
-template <typename T>
-template <typename ValueType>
-const ValueType& OutputPort<T>::ExtractValueOrThrow(
-    const char* func, const AbstractValue& abstract) const {
-  const ValueType* value = abstract.MaybeGetValue<ValueType>();
-  if (!value)
-    ThrowBadValueType<ValueType>(func, abstract);
-  return *value;
 }
 
 // Workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57728 which

--- a/systems/framework/output_port_base.cc
+++ b/systems/framework/output_port_base.cc
@@ -2,25 +2,17 @@
 
 #include <utility>
 
-#include "drake/common/drake_assert.h"
-#include "drake/systems/framework/framework_common.h"
-
 namespace drake {
 namespace systems {
 
-OutputPortBase::~OutputPortBase() = default;
+OutputPortBase::OutputPortBase(
+    internal::SystemMessageInterface* owning_system, std::string name,
+    OutputPortIndex index, DependencyTicket ticket, PortDataType data_type,
+    int size)
+    : PortBase("Output", owning_system, std::move(name), index, ticket,
+               data_type, size) {}
 
-OutputPortBase::OutputPortBase(SystemBase* owning_system, std::string name,
-                               OutputPortIndex index, DependencyTicket ticket,
-                               PortDataType data_type, int size)
-    : owning_system_(*owning_system),
-      name_(std::move(name)), index_(index), ticket_(ticket),
-            data_type_(data_type), size_(size) {
-  DRAKE_DEMAND(owning_system != nullptr);
-  DRAKE_DEMAND(!name_.empty());
-  if (size_ == kAutoSize)
-    DRAKE_ABORT_MSG("Auto-size ports are not yet implemented.");
-}
+OutputPortBase::~OutputPortBase() = default;
 
 }  // namespace systems
 }  // namespace drake

--- a/systems/framework/output_port_base.h
+++ b/systems/framework/output_port_base.h
@@ -3,53 +3,26 @@
 #include <string>
 
 #include "drake/systems/framework/framework_common.h"
+#include "drake/systems/framework/port_base.h"
 
 namespace drake {
 namespace systems {
 
-// Break the SystemBase <=> OutputPortBase physical dependency cycle. An
-// OutputPortBase contains a back-pointer to its owning SystemBase, but that
-// pointer is forward-declared here and never dereferenced within this file.
-class SystemBase;
-
 /** %OutputPortBase handles the scalar type-independent aspects of an
 OutputPort. An OutputPort belongs to a System and represents the properties of
 one of that System's output ports. */
-class OutputPortBase {
+class OutputPortBase : public PortBase {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(OutputPortBase)
 
-  virtual ~OutputPortBase();
+  ~OutputPortBase() override;
 
   /** Returns the index of this output port within the owning System. For a
   Diagram, this will be the index within the Diagram, _not_ the index within
   the LeafSystem whose output port was forwarded. */
   OutputPortIndex get_index() const {
-    return index_;
+    return OutputPortIndex(get_int_index());
   }
-
-  /** Returns the DependencyTicket for this output port within the owning
-  System. */
-  DependencyTicket ticket() const {
-    return ticket_;
-  }
-
-  /** Gets the port data type specified at port construction. */
-  PortDataType get_data_type() const { return data_type_; }
-
-  /** Returns the fixed size expected for a vector-valued output port. Not
-  meaningful for abstract output ports. */
-  int size() const { return size_; }
-
-  /** Returns a reference to the System that owns this output port. Note that
-  for a diagram output port this will be the diagram, not the leaf system whose
-  output port was forwarded. */
-  const SystemBase& get_system_base() const {
-    return owning_system_;
-  }
-
-  /** Gets port name. */
-  const std::string& get_name() const { return name_; }
 
 #ifndef DRAKE_DOXYGEN_CXX
   // Internal use only. Returns the prerequisite for this output port -- either
@@ -77,29 +50,15 @@ class OutputPortBase {
   @param size
     If the port described is vector-valued, the number of elements expected,
     otherwise ignored. */
-  OutputPortBase(SystemBase* owning_system, std::string name,
-                 OutputPortIndex index, DependencyTicket ticket,
-                 PortDataType data_type, int size);
-
-  SystemBase& get_mutable_system_base() {
-    return owning_system_;
-  }
+  OutputPortBase(
+      internal::SystemMessageInterface* owning_system, std::string name,
+      OutputPortIndex index, DependencyTicket ticket, PortDataType data_type,
+      int size);
 
   /** Concrete output ports must implement this to return the prerequisite
   dependency ticket for this port, which may be in the current System or one
   of its immediate child subsystems. */
   virtual internal::OutputPortPrerequisite DoGetPrerequisite() const = 0;
-
- private:
-  // Associated System and System resources.
-  SystemBase& owning_system_;
-  const std::string name_;
-  const OutputPortIndex index_;
-  const DependencyTicket ticket_;
-
-  // Port details.
-  const PortDataType data_type_;
-  const int size_;
 };
 
 }  // namespace systems

--- a/systems/framework/port_base.cc
+++ b/systems/framework/port_base.cc
@@ -1,0 +1,50 @@
+#include "drake/systems/framework/port_base.h"
+
+#include <utility>
+
+#include <fmt/format.h>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/nice_type_name.h"
+
+namespace drake {
+namespace systems {
+
+PortBase::PortBase(
+    const char* kind_string, internal::SystemMessageInterface* owning_system,
+    std::string name, int index, DependencyTicket ticket,
+    PortDataType data_type, int size)
+    : kind_string_(kind_string),
+      owning_system_(*owning_system),
+      index_(index),
+      ticket_(ticket),
+      data_type_(data_type),
+      size_(size),
+      name_(std::move(name)) {
+  DRAKE_DEMAND(kind_string != nullptr);
+  DRAKE_DEMAND(owning_system != nullptr);
+  DRAKE_DEMAND(!name_.empty());
+  if (size_ == kAutoSize) {
+    DRAKE_ABORT_MSG("Auto-size ports are not yet implemented.");
+  }
+}
+
+PortBase::~PortBase() = default;
+
+std::string PortBase::GetFullDescription() const {
+  return fmt::format(
+      "{}Port[{}] ({}) of System {} ({})",
+      kind_string_, index_, name_, get_system_base().GetSystemPathname(),
+      NiceTypeName::RemoveNamespaces(get_system_base().GetSystemType()));
+}
+
+void PortBase::ThrowBadCast(
+    const std::string& value_typename, const std::string& eval_typename) const {
+  throw std::logic_error(fmt::format(
+      "{}Port::Eval(): wrong value type {} specified; "
+      "actual type was {} for {}.",
+      kind_string_, eval_typename, value_typename, GetFullDescription()));
+}
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/framework/port_base.h
+++ b/systems/framework/port_base.h
@@ -1,0 +1,138 @@
+#pragma once
+
+#include <string>
+
+#include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/framework_common.h"
+
+namespace drake {
+namespace systems {
+
+/** A PortBase is base class for System ports; users will typically use the the
+ InputPort<T> or OutputPort<T> types, not this base class. */
+class PortBase {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PortBase)
+
+  virtual ~PortBase();
+
+  /** Get port name. */
+  const std::string& get_name() const { return name_; }
+
+  /** Returns the port data type. */
+  PortDataType get_data_type() const { return data_type_; }
+
+  /** Returns the fixed size expected for a vector-valued port. Not
+  meaningful for abstract-valued ports. */
+  int size() const { return size_; }
+
+  /** Returns a verbose human-readable description of port. This is useful for
+  error messages or debugging. */
+  std::string GetFullDescription() const;
+
+#ifndef DRAKE_DOXYGEN_CXX
+  // Returns a reference to the system that owns this port. Note that for a
+  // diagram port this will be the diagram, not the leaf system whose port was
+  // exported.
+  const internal::SystemMessageInterface& get_system_base() const {
+    return owning_system_;
+  }
+#endif
+
+  /** (Advanced.) Returns the DependencyTicket for this port within the owning
+  System. */
+  DependencyTicket ticket() const {
+    return ticket_;
+  }
+
+ protected:
+  /** Provides derived classes the ability to set the base
+  class members at construction.
+
+  @param kind_string
+    Either "Input" or "Output", depending on the kind of subclass.
+  @param owning_system
+    The System that owns this port.
+  @param name
+    A name for the port. Port names should be non-empty and unique within a
+    single System.
+  @param index
+    The index to be assigned to this port.  Input ports and output ports each
+    have their own pool of indices (InputPortIndex and OutputPortIndex); this
+    is just that TypeSafeIndex passed as a bare int.
+  @param ticket
+    The DependencyTicket to be assigned to this port.
+  @param data_type
+    Whether the port described is vector- or abstract-valued.
+  @param size
+    If the port described is vector-valued, the number of elements, or kAutoSize
+    if determined by connections. Ignored for abstract-valued ports.
+  */
+  PortBase(
+      const char* kind_string, internal::SystemMessageInterface* owning_system,
+      std::string name, int index, DependencyTicket ticket,
+      PortDataType data_type, int size);
+
+  /** Returns the index of this port within the owning System (i.e., an
+  InputPortIndex or OutputPortIndex, but as a bare integer). For a Diagram,
+  this will be the index within the Diagram, _not_ the index within the
+  LeafSystem whose output port was forwarded. */
+  int get_int_index() const { return index_; }
+
+  /** Returns get_system_base(), but without the const. */
+  internal::SystemMessageInterface& get_mutable_system_base() {
+    return owning_system_;
+  }
+
+  /** Pull a value of a given type from an abstract value or issue a nice
+  message if the type is not correct. */
+  template <typename ValueType>
+  const ValueType& PortEvalCast(const AbstractValue& abstract) const;
+
+  /** Downcast a basic vector to a more specific subclass (e.g., as generated
+  by //tools/vector_gen) or issue a nice message if the type is not correct. */
+  template <typename ValueType, typename T>
+  const ValueType& PortEvalCast(const BasicVector<T>& basic) const;
+
+  /** Reports that user provided a bad ValueType argument to Eval.  The
+  value_typename is the type of the port's current value; the eval_typename is
+  the type the user asked for. */
+  [[noreturn]] void ThrowBadCast(
+      const std::string& value_typename,
+      const std::string& eval_typename) const;
+
+ private:
+  // "Input" or "Output" (used for human-readable debugging strings).
+  const char* const kind_string_;
+
+  // Associated System and System resources.
+  internal::SystemMessageInterface& owning_system_;
+  const int index_;
+  const DependencyTicket ticket_;
+
+  // Port details.
+  const PortDataType data_type_;
+  const int size_;
+  const std::string name_;
+};
+
+template <typename ValueType>
+const ValueType& PortBase::PortEvalCast(const AbstractValue& abstract) const {
+  const ValueType* const value = abstract.MaybeGetValue<ValueType>();
+  if (!value) {
+    ThrowBadCast(abstract.GetNiceTypeName(), NiceTypeName::Get<ValueType>());
+  }
+  return *value;
+}
+
+template <typename ValueType, typename T>
+const ValueType& PortBase::PortEvalCast(const BasicVector<T>& basic) const {
+  const ValueType* const value = dynamic_cast<const ValueType*>(&basic);
+  if (!value) {
+    ThrowBadCast(NiceTypeName::Get(basic), NiceTypeName::Get<ValueType>());
+  }
+  return *value;
+}
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -492,6 +492,7 @@ class System : public SystemBase {
     return entry.Eval<T>(context);
   }
 
+  // TODO(jwnimmer-tri) Deprecate me.
   /// Returns the value of the vector-valued input port with the given
   /// `port_index` as a BasicVector or a specific subclass `Vec` derived from
   /// BasicVector. Causes the value to become up to date first if necessary. See
@@ -534,6 +535,7 @@ class System : public SystemBase {
     return value;
   }
 
+  // TODO(jwnimmer-tri) Deprecate me.
   /// Returns the value of the vector-valued input port with the given
   /// `port_index` as an %Eigen vector. Causes the value to become up to date
   /// first if necessary. See EvalAbstractInput() for more information.
@@ -1714,9 +1716,12 @@ class System : public SystemBase {
     const InputPortIndex port_index(get_num_input_ports());
 
     const DependencyTicket port_ticket(this->assign_next_dependency_ticket());
-    this->AddInputPort(std::make_unique<InputPort<T>>(
+    auto eval = [this, port_index](const ContextBase& context_base) {
+      return this->EvalAbstractInput(context_base, port_index);
+    };
+    this->AddInputPort(internal::FrameworkFactory::Make<InputPort<T>>(
         this, this, NextInputPortName(std::move(name)), port_index, port_ticket,
-        type, size, random_type));
+        type, size, random_type, std::move(eval)));
     return get_input_port(port_index);
   }
 

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -114,6 +114,7 @@ class SystemBase : public internal::SystemMessageInterface {
   scalar type-specific input port access. */
   //@{
 
+  // TODO(jwnimmer-tri) Deprecate me.
   /** Returns the value of the input port with the given `port_index` as an
   AbstractValue, which is permitted for ports of any type. Causes the value to
   become up to date first if necessary, delegating to our parent Diagram.
@@ -133,6 +134,7 @@ class SystemBase : public internal::SystemMessageInterface {
     return EvalAbstractInputImpl(__func__, context, port);
   }
 
+  // TODO(jwnimmer-tri) Deprecate me.
   /** Returns the value of an abstract-valued input port with the given
   `port_index` as a value of known type `V`. Causes the value to become
   up to date first if necessary. See EvalAbstractInput() for

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -576,7 +576,7 @@ TEST_F(DiagramTest, Topology) {
   ASSERT_EQ(kSize, diagram_->get_num_input_ports());
   for (int i = 0; i < kSize; ++i) {
     const auto& input_port = diagram_->get_input_port(i);
-    EXPECT_EQ(diagram_.get(), input_port.get_system());
+    EXPECT_EQ(diagram_.get(), &input_port.get_system());
     EXPECT_EQ(kVectorValued, input_port.get_data_type());
     EXPECT_EQ(kSize, input_port.size());
   }

--- a/systems/framework/test/input_port_test.cc
+++ b/systems/framework/test/input_port_test.cc
@@ -1,0 +1,151 @@
+#include "drake/systems/framework/input_port.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/systems/framework/leaf_system.h"
+#include "drake/systems/framework/test_utilities/my_vector.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+class DummySystem final : public LeafSystem<double> {};
+
+// The mocked-up return value for our DoEval stub, below.
+const AbstractValue* g_do_eval_result = nullptr;
+
+// Returns g_do_eval_result.
+const AbstractValue* DoEval(const ContextBase&) {
+  return g_do_eval_result;
+}
+
+GTEST_TEST(InputPortTest, VectorTest) {
+  using T = double;
+
+  DummySystem dummy_system;
+  dummy_system.set_name("dummy");
+  const auto context_ptr = dummy_system.CreateDefaultContext();
+  const auto& context = *context_ptr;
+  const System<T>* const system = &dummy_system;
+  internal::SystemMessageInterface* const system_base = &dummy_system;
+  const std::string name{"port_name"};
+  const InputPortIndex index{2};
+  const DependencyTicket ticket;
+  const PortDataType data_type = kVectorValued;
+  const int size = 3;
+  const optional<RandomDistribution> random_type = nullopt;
+
+  auto dut = internal::FrameworkFactory::Make<InputPort<T>>(
+      system, system_base, name, index, ticket, data_type, size, random_type,
+      &DoEval);
+
+  // Check basic getters.
+  EXPECT_EQ(dut->get_name(), name);
+  EXPECT_EQ(dut->get_data_type(), data_type);
+  EXPECT_EQ(dut->size(), size);
+  EXPECT_EQ(dut->GetFullDescription(),
+            "InputPort[2] (port_name) of System ::dummy (DummySystem)");
+  EXPECT_EQ(&dut->get_system_base(), system_base);
+  EXPECT_EQ(&dut->get_system(), system);
+
+  // Check HasValue.
+  g_do_eval_result = nullptr;
+  EXPECT_EQ(dut->HasValue(context), false);
+  const Vector3<T> data(1.0, 2.0, 3.0);
+  const Value<BasicVector<T>> new_value{MyVector3d(data)};
+  g_do_eval_result = &new_value;
+  EXPECT_EQ(dut->HasValue(context), true);
+
+  // Check Eval with various ValueType possibilities.
+  const auto& eval_eigen = dut->Eval(context);
+  const BasicVector<T>& eval_basic = dut->Eval<BasicVector<T>>(context);
+  const MyVector3d& eval_myvec3 = dut->Eval<MyVector3d>(context);
+  const AbstractValue& eval_abs = dut->Eval<AbstractValue>(context);
+  EXPECT_EQ(eval_eigen, data);
+  EXPECT_EQ(eval_basic.CopyToVector(), data);
+  EXPECT_EQ(eval_myvec3.CopyToVector(), data);
+  EXPECT_EQ(eval_abs.GetValueOrThrow<BasicVector<T>>().CopyToVector(), data);
+
+  // Check error messages.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dut->Eval<std::string>(context), std::exception,
+      "InputPort::Eval..: wrong value type std::string specified; "
+      "actual type was drake::systems::MyVector<3,double> "
+      "for InputPort.*2.*of.*dummy.*DummySystem.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dut->Eval<MyVector2d>(context), std::exception,
+      "InputPort::Eval..: wrong value type .*MyVector<2,double> specified; "
+      "actual type was .*MyVector<3,double> "
+      "for InputPort.*2.*of.*dummy.*DummySystem.*");
+}
+
+GTEST_TEST(InputPortTest, AbstractTest) {
+  using T = double;
+
+  DummySystem dummy_system;
+  dummy_system.set_name("dummy");
+  const auto context_ptr = dummy_system.CreateDefaultContext();
+  const auto& context = *context_ptr;
+  const System<T>* const system = &dummy_system;
+  internal::SystemMessageInterface* const system_base = &dummy_system;
+  const std::string name{"port_name"};
+  const InputPortIndex index{2};
+  const DependencyTicket ticket;
+  const PortDataType data_type = kAbstractValued;
+  const int size = 0;
+  const optional<RandomDistribution> random_type = nullopt;
+
+  auto dut = internal::FrameworkFactory::Make<InputPort<T>>(
+      system, system_base, name, index, ticket, data_type, size, random_type,
+      &DoEval);
+
+  // Check basic getters.
+  EXPECT_EQ(dut->get_name(), name);
+  EXPECT_EQ(dut->get_data_type(), data_type);
+  EXPECT_EQ(dut->size(), size);
+  EXPECT_EQ(dut->GetFullDescription(),
+            "InputPort[2] (port_name) of System ::dummy (DummySystem)");
+  EXPECT_EQ(&dut->get_system_base(), system_base);
+  EXPECT_EQ(&dut->get_system(), system);
+
+  // Check HasValue.
+  g_do_eval_result = nullptr;
+  EXPECT_EQ(dut->HasValue(context), false);
+  const std::string data{"foo"};
+  const Value<std::string> new_value{data};
+  g_do_eval_result = &new_value;
+  EXPECT_EQ(dut->HasValue(context), true);
+
+  // Check Eval with various ValueType possibilities.
+  const std::string& eval_str = dut->Eval<std::string>(context);
+  const AbstractValue& eval_abs = dut->Eval<AbstractValue>(context);
+  EXPECT_EQ(eval_str, data);
+  EXPECT_EQ(eval_abs.GetValueOrThrow<std::string>(), data);
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dut->Eval(context), std::exception,
+      "InputPort::Eval..: wrong value type .*BasicVector<double> specified; "
+      "actual type was std::string "
+      "for InputPort.*2.*of.*dummy.*DummySystem.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dut->Eval<BasicVector<T>>(context), std::exception,
+      "InputPort::Eval..: wrong value type .*BasicVector<double> specified; "
+      "actual type was std::string "
+      "for InputPort.*2.*of.*dummy.*DummySystem.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dut->Eval<MyVector3d>(context), std::exception,
+      "InputPort::Eval..: wrong value type .*BasicVector<double> specified; "
+      "actual type was std::string "
+      "for InputPort.*2.*of.*dummy.*DummySystem.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dut->Eval<int>(context), std::exception,
+      "InputPort::Eval..: wrong value type int specified; "
+      "actual type was std::string "
+      "for InputPort.*2.*of.*dummy.*DummySystem.*");
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake
+

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -1185,10 +1185,10 @@ GTEST_TEST(ModelLeafSystemTest, ModelPortsCalcOutput) {
   context->set_time(context->get_time() + 1.);
   EXPECT_TRUE(cache2.is_out_of_date(*context));
   EXPECT_EQ(cacheval2.serial_number(), 2);  // Unchanged since invalid.
-  (void)port2.EvalAbstract(*context);  // Recalculate.
+  (void)port2.template Eval<AbstractValue>(*context);  // Recalculate.
   EXPECT_FALSE(cache2.is_out_of_date(*context));
   EXPECT_EQ(cacheval2.serial_number(), 3);
-  (void)port2.EvalAbstract(*context);  // "Recalculate" (should do nothing).
+  (void)port2.template Eval<AbstractValue>(*context);  // Should do nothing.
   EXPECT_EQ(cacheval2.serial_number(), 3);
 
   // Should invalidate accuracy- and everything-dependents. Note that the
@@ -1196,7 +1196,7 @@ GTEST_TEST(ModelLeafSystemTest, ModelPortsCalcOutput) {
   EXPECT_FALSE(context->get_accuracy());  // None set initially.
   context->set_accuracy(.000025);  // This is a change.
   EXPECT_TRUE(cache2.is_out_of_date(*context));
-  (void)port2.EvalAbstract(*context);  // Recalculate.
+  (void)port2.template Eval<AbstractValue>(*context);  // Recalculate.
   EXPECT_FALSE(cache2.is_out_of_date(*context));
   EXPECT_EQ(cacheval2.serial_number(), 4);
 

--- a/systems/framework/test/output_port_test.cc
+++ b/systems/framework/test/output_port_test.cc
@@ -192,22 +192,26 @@ class LeafOutputPortTest : public ::testing::Test {
   // Create abstract- and vector-valued ports.
   DummySystem dummy_;
   // TODO(sherm1) Use implicit_cast when available (from abseil).
-  LeafOutputPort<double> absport_general_{
-      &dummy_,  // implicit_cast<const System<T>*>(&dummy_)
-      &dummy_,  // implicit_cast<SystemBase*>(&dummy_)
-      "absport",
-      OutputPortIndex(dummy_.get_num_output_ports()),
-      dummy_.assign_next_dependency_ticket(), kAbstractValued, 0 /* size */,
-      &dummy_.DeclareCacheEntry(
-          "absport", alloc_string, calc_string)};
-  LeafOutputPort<double> vecport_general_{
-      &dummy_,  // implicit_cast<const System<T>*>(&dummy_)
-      &dummy_,  // implicit_cast<SystemBase*>(&dummy_)
-      "vecport",
-      OutputPortIndex(dummy_.get_num_output_ports()),
-      dummy_.assign_next_dependency_ticket(), kVectorValued, 3 /* size */,
-      &dummy_.DeclareCacheEntry(
-          "vecport", alloc_myvector3, calc_vector3)};
+  std::unique_ptr<LeafOutputPort<double>> absport_general_ptr_ =
+      internal::FrameworkFactory::Make<LeafOutputPort<double>>(
+          &dummy_,  // implicit_cast<const System<T>*>(&dummy_)
+          &dummy_,  // implicit_cast<SystemBase*>(&dummy_)
+          "absport",
+          OutputPortIndex(dummy_.get_num_output_ports()),
+          dummy_.assign_next_dependency_ticket(), kAbstractValued, 0 /* size */,
+          &dummy_.DeclareCacheEntry(
+              "absport", alloc_string, calc_string));
+  LeafOutputPort<double>& absport_general_ = *absport_general_ptr_;
+  std::unique_ptr<LeafOutputPort<double>> vecport_general_ptr_ =
+      internal::FrameworkFactory::Make<LeafOutputPort<double>>(
+          &dummy_,  // implicit_cast<const System<T>*>(&dummy_)
+          &dummy_,  // implicit_cast<SystemBase*>(&dummy_)
+          "vecport",
+          OutputPortIndex(dummy_.get_num_output_ports()),
+          dummy_.assign_next_dependency_ticket(), kVectorValued, 3 /* size */,
+          &dummy_.DeclareCacheEntry(
+              "vecport", alloc_myvector3, calc_vector3));
+  LeafOutputPort<double>& vecport_general_ = *vecport_general_ptr_;
   unique_ptr<Context<double>> context_{dummy_.CreateDefaultContext()};
 };
 
@@ -218,8 +222,11 @@ void AbstractPortCheck(const Context<double>& context,
   unique_ptr<AbstractValue> val = port.Allocate();
   EXPECT_EQ(val->GetValueOrThrow<string>(), alloc_string);
   port.Calc(context, val.get());
-  EXPECT_EQ(val->GetValueOrThrow<string>(), string("from calc_string"));
-  EXPECT_EQ(port.Eval<string>(context), string("from calc_string"));
+  const string new_value("from calc_string");
+  EXPECT_EQ(val->GetValueOrThrow<string>(), new_value);
+  EXPECT_EQ(port.Eval<string>(context), new_value);
+  EXPECT_EQ(port.Eval<AbstractValue>(context).GetValueOrThrow<string>(),
+            new_value);
 
   // Can't Eval into the wrong type.
   DRAKE_EXPECT_THROWS_MESSAGE(
@@ -246,13 +253,21 @@ void VectorPortCheck(const Context<double>& context,
   EXPECT_EQ(myvector3.get_value(), alloc_value);
   port.Calc(context, val.get());
   // Should have written into the underlying MyVector3d.
-  EXPECT_EQ(myvector3.get_value(), Vector3d(99., 100., 101.));
+  const Vector3d new_value(99., 100., 101.);
+  EXPECT_EQ(myvector3.get_value(), new_value);
 
-  // Check that Eval runs to completion without error.
-  const auto& eval_basic = port.Eval<BasicVector<double>>(context);
-  const auto& eval_eigen = port.EvalEigenVector(context);
-  EXPECT_EQ(eval_basic.size(), 3);
-  EXPECT_EQ(eval_eigen.size(), 3);
+  // Check that Eval is correct, for many ValueType choices.
+  const auto& eval_eigen = port.Eval(context);
+  const BasicVector<double>& eval_basic =
+      port.Eval<BasicVector<double>>(context);
+  const MyVector3d& eval_myvec3 = port.Eval<MyVector3d>(context);
+  const AbstractValue& eval_abs = port.Eval<AbstractValue>(context);
+  EXPECT_EQ(eval_eigen, new_value);
+  EXPECT_EQ(eval_basic.CopyToVector(), new_value);
+  EXPECT_EQ(eval_myvec3.CopyToVector(), new_value);
+  EXPECT_EQ(
+      eval_abs.GetValueOrThrow<BasicVector<double>>().CopyToVector(),
+      new_value);
 }
 
 // Check for proper construction and functioning of vector-valued
@@ -271,14 +286,14 @@ unique_ptr<AbstractValue> alloc_null() {
 TEST_F(LeafOutputPortTest, ThrowIfNullAlloc) {
   // Create an abstract port with an allocator that returns null.
   // TODO(sherm1) Use implicit_cast when available (from abseil).
-  LeafOutputPort<double> null_port{
+  auto null_port = internal::FrameworkFactory::Make<LeafOutputPort<double>>(
       &dummy_,  // implicit_cast<const System<T>*>(&dummy_)
       &dummy_,  // implicit_cast<SystemBase*>(&dummy_),
       "null_port",
       OutputPortIndex(dummy_.get_num_output_ports()),
       dummy_.assign_next_dependency_ticket(),
       kAbstractValued, 0 /* size */,
-      &dummy_.DeclareCacheEntry("null", alloc_null, calc_string)};
+      &dummy_.DeclareCacheEntry("null", alloc_null, calc_string));
 
   // Creating a context for this system should fail when it tries to allocate
   // a cache entry for null_port.

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -81,7 +81,7 @@ class TestSystem : public System<double> {
         [](const ContextBase&, AbstractValue*) {});
     // TODO(sherm1) Use implicit_cast when available (from abseil). Several
     // places in this test.
-    auto port = std::make_unique<LeafOutputPort<double>>(
+    auto port = internal::FrameworkFactory::Make<LeafOutputPort<double>>(
         this,  // implicit_cast<const System<T>*>(this)
         this,  // implicit_cast<const SystemBase*>(this)
         "y" + std::to_string(get_num_output_ports()),
@@ -463,7 +463,7 @@ class ValueIOTestSystem : public System<T> {
 
     this->DeclareInputPort(kUseDefaultName, kAbstractValued, 0);
 
-    this->AddOutputPort(std::make_unique<LeafOutputPort<T>>(
+    this->AddOutputPort(internal::FrameworkFactory::Make<LeafOutputPort<T>>(
         this,  // implicit_cast<const System<T>*>(this)
         this,  // implicit_cast<const SystemBase*>(this)
         "absport",
@@ -481,7 +481,7 @@ class ValueIOTestSystem : public System<T> {
                            RandomDistribution::kUniform);
     this->DeclareInputPort("gaussian", kVectorValued, 1,
                            RandomDistribution::kGaussian);
-    this->AddOutputPort(std::make_unique<LeafOutputPort<T>>(
+    this->AddOutputPort(internal::FrameworkFactory::Make<LeafOutputPort<T>>(
         this,  // implicit_cast<const System<T>*>(this)
         this,  // implicit_cast<const SystemBase*>(this)
         "vecport",

--- a/systems/framework/vector_system.h
+++ b/systems/framework/vector_system.h
@@ -93,7 +93,7 @@ class VectorSystem : public LeafSystem<T> {
       const Context<T>& context) const {
     // Obtain the block form of u (or the empty vector).
     if (this->get_num_input_ports() > 0) {
-      return this->EvalEigenVectorInput(context, 0);
+      return this->get_input_port().Eval(context);
     }
     static const never_destroyed<VectorX<T>> empty_vector(0);
     return empty_vector.access().segment(0, 0);

--- a/systems/lcm/lcm_publisher_system.cc
+++ b/systems/lcm/lcm_publisher_system.cc
@@ -16,10 +16,6 @@ namespace lcm {
 using drake::lcm::DrakeLcmInterface;
 using drake::lcm::DrakeLcm;
 
-namespace {
-const int kPortIndex = 0;
-}  // namespace
-
 // TODO(jwnimmer-tri) The "serializer xor translator" disjoint implementations
 // within the method bodies below are not ideal, because of the code smell, and
 // because it is likely confusing for users.  We should take further steps to
@@ -164,15 +160,11 @@ EventStatus LcmPublisherSystem::PublishInputAsLcmMessage(
   // Converts the input into LCM message bytes.
   std::vector<uint8_t> message_bytes;
   if (translator_ != nullptr) {
-    const VectorBase<double>* const input_vector =
-        this->EvalVectorInput(context, kPortIndex);
-    DRAKE_ASSERT(input_vector != nullptr);
-    translator_->Serialize(context.get_time(), *input_vector, &message_bytes);
+    const auto& input = get_input_port().Eval<BasicVector<double>>(context);
+    translator_->Serialize(context.get_time(), input, &message_bytes);
   } else {
-    const AbstractValue* const input_value =
-        this->EvalAbstractInput(context, kPortIndex);
-    DRAKE_ASSERT(input_value != nullptr);
-    serializer_->Serialize(*input_value, &message_bytes);
+    const AbstractValue& input = get_input_port().Eval<AbstractValue>(context);
+    serializer_->Serialize(input, &message_bytes);
   }
 
   // Publishes onto the specified LCM channel.

--- a/systems/lcm/test/lcm_driven_loop_test.cc
+++ b/systems/lcm/test/lcm_driven_loop_test.cc
@@ -45,11 +45,10 @@ class DummySys : public systems::LeafSystem<double> {
 
   void CalcTimestamp(const systems::Context<double>& context,
                      systems::BasicVector<double>* output) const {
-    const lcmt_drake_signal* msg =
-        EvalInputValue<lcmt_drake_signal>(context, 0);
-
+    const lcmt_drake_signal& msg =
+        this->get_input_port(0).Eval<lcmt_drake_signal>(context);
     auto out_vector = output->get_mutable_value();
-    out_vector(0) = static_cast<double>(msg->timestamp) / 1e3;
+    out_vector(0) = static_cast<double>(msg.timestamp) / 1e3;
   }
 };
 

--- a/systems/lcm/test/lcm_log_playback_test.cc
+++ b/systems/lcm/test/lcm_log_playback_test.cc
@@ -50,18 +50,18 @@ class DummySys : public LeafSystem<double> {
 
  private:
   EventStatus SaveMessage(const Context<double>& context) const {
-    const lcmt_drake_signal* msg =
-        EvalInputValue<lcmt_drake_signal>(context, 0);
+    const lcmt_drake_signal& msg =
+        this->get_input_port(0).Eval<lcmt_drake_signal>(context);
 
     bool is_new_msg = false;
-    if (received_msgs_.empty() && msg->timestamp != 0) is_new_msg = true;
+    if (received_msgs_.empty() && msg.timestamp != 0) is_new_msg = true;
     if (!received_msgs_.empty() &&
-        (msg->timestamp != received_msgs_.back().timestamp)) {
+        (msg.timestamp != received_msgs_.back().timestamp)) {
       is_new_msg = true;
     }
 
     if (is_new_msg) {
-      received_msgs_.push_back(*msg);
+      received_msgs_.push_back(msg);
 
       // The diagram that this system is embedded in works the following way:
       // The LCM Subscriber system receives a message and then requests an

--- a/systems/lcm/test/lcm_subscriber_system_test.cc
+++ b/systems/lcm/test/lcm_subscriber_system_test.cc
@@ -81,7 +81,7 @@ void TestSubscriber(drake::lcm::DrakeMockLcm* lcm,
   // way to read messages.
   auto new_context = dut->CreateDefaultContext();
   dut->CopyLatestMessageInto(&new_context->get_mutable_state());
-  const auto& new_y = dut->get_output_port().EvalEigenVector(*new_context);
+  const auto& new_y = dut->get_output_port().Eval(*new_context);
   for (int i = 0; i < kDim; ++i) {
     EXPECT_EQ(new_y[i], i);
   }

--- a/systems/lcm/translator_system.h
+++ b/systems/lcm/translator_system.h
@@ -27,10 +27,7 @@ struct DataTypeTraits<DataType, true> {
   // and is of type DataType.
   static const DataType& get_data(const System<double>& sys,
                                   const Context<double>& context) {
-    const DataType* const vector =
-        dynamic_cast<const DataType*>(sys.EvalVectorInput(context, 0));
-    DRAKE_DEMAND(vector != nullptr);
-    return *vector;
+    return sys.get_input_port(0).template Eval<DataType>(context);
   }
 };
 /// @endcond

--- a/systems/plants/spring_mass_system/spring_mass_system.h
+++ b/systems/plants/spring_mass_system/spring_mass_system.h
@@ -124,7 +124,7 @@ class SpringMassSystem : public LeafSystem<T> {
     T external_force = 0;
     DRAKE_ASSERT(system_is_forced_ == (context.get_num_input_ports() == 1));
     if (system_is_forced_) {
-      external_force = this->EvalVectorInput(context, 0)->GetAtIndex(0);
+      external_force = get_force_port().Eval(context)[0];
     }
     return external_force;
   }

--- a/systems/primitives/adder.cc
+++ b/systems/primitives/adder.cc
@@ -32,8 +32,7 @@ void Adder<T>::CalcSum(const Context<T>& context,
 
   // Sum each input port into the output.
   for (int i = 0; i < context.get_num_input_ports(); i++) {
-    const BasicVector<T>* input_vector = this->EvalVectorInput(context, i);
-    sum_vector += input_vector->get_value();
+    sum_vector += this->get_input_port(i).Eval(context);
   }
 }
 

--- a/systems/primitives/affine_system.cc
+++ b/systems/primitives/affine_system.cc
@@ -80,9 +80,7 @@ void TimeVaryingAffineSystem<T>::CalcOutputY(
   }
 
   if (num_inputs_ > 0) {
-    const BasicVector<T>* input = this->EvalVectorInput(context, 0);
-    DRAKE_DEMAND(input);
-    const auto& u = input->get_value();
+    const auto& u = get_input_port().Eval(context);
     const MatrixX<T> Dt = D(t);
     DRAKE_DEMAND(Dt.rows() == num_outputs_ && Dt.cols() == num_inputs_);
     y += Dt * u;
@@ -109,9 +107,7 @@ void TimeVaryingAffineSystem<T>::DoCalcTimeDerivatives(
   xdot += At * x;
 
   if (num_inputs_ > 0) {
-    const BasicVector<T>* input = this->EvalVectorInput(context, 0);
-    DRAKE_DEMAND(input);
-    const auto& u = input->get_value();
+    const auto& u = get_input_port().Eval(context);
 
     const MatrixX<T> Bt = B(t);
     DRAKE_DEMAND(Bt.rows() == num_states_ && Bt.cols() == num_inputs_);
@@ -142,9 +138,7 @@ void TimeVaryingAffineSystem<T>::DoCalcDiscreteVariableUpdates(
   xn += At * x;
 
   if (num_inputs_ > 0) {
-    const BasicVector<T>* input = this->EvalVectorInput(context, 0);
-    DRAKE_DEMAND(input);
-    const auto& u = input->get_value();
+    const auto& u = get_input_port().Eval(context);
 
     const MatrixX<T> Bt = B(t);
     DRAKE_DEMAND(Bt.rows() == num_states_ && Bt.cols() == num_inputs_);
@@ -251,9 +245,7 @@ void AffineSystem<T>::CalcOutputY(const Context<T>& context,
   y = C_ * x + y0_;
 
   if (this->num_inputs()) {
-    const BasicVector<T>* input = this->EvalVectorInput(context, 0);
-    DRAKE_DEMAND(input);
-    const auto& u = input->get_value();
+    const auto& u = this->get_input_port().Eval(context);
     y += D_ * u;
   }
 }
@@ -270,9 +262,7 @@ void AffineSystem<T>::DoCalcTimeDerivatives(
   VectorX<T> xdot = A_ * x + f0_;
 
   if (this->num_inputs() > 0) {
-    const BasicVector<T>* input = this->EvalVectorInput(context, 0);
-    DRAKE_DEMAND(input);
-    const auto& u = input->get_value();
+    const auto& u = this->get_input_port().Eval(context);
 
     xdot += B_ * u;
   }
@@ -291,9 +281,7 @@ void AffineSystem<T>::DoCalcDiscreteVariableUpdates(
   VectorX<T> xnext = A_ * x + f0_;
 
   if (this->num_inputs() > 0) {
-    const BasicVector<T>* input = this->EvalVectorInput(context, 0);
-    DRAKE_DEMAND(input);
-    const auto& u = input->get_value();
+    const auto& u = this->get_input_port().Eval(context);
 
     xnext += B_ * u;
   }

--- a/systems/primitives/demultiplexer.cc
+++ b/systems/primitives/demultiplexer.cc
@@ -42,7 +42,7 @@ void Demultiplexer<T>::CopyToOutput(const Context<T>& context,
 
   // TODO(amcastro-tri): the output should simply reference the input port's
   // value to avoid copy.
-  auto in_vector = System<T>::EvalEigenVectorInput(context, 0);
+  auto in_vector = this->get_input_port(0).Eval(context);
   auto out_vector = output->get_mutable_value();
   out_vector = in_vector.segment(port_index * out_size, out_size);
 }

--- a/systems/primitives/discrete_derivative.cc
+++ b/systems/primitives/discrete_derivative.cc
@@ -50,7 +50,7 @@ void DiscreteDerivative<T>::DoCalcDiscreteVariableUpdates(
     drake::systems::DiscreteValues<T>* discrete_state) const {
   // x₀[n+1] = u[n].
   discrete_state->get_mutable_vector().get_mutable_value().head(n_) =
-      this->EvalEigenVectorInput(context, 0);
+      get_input_port().Eval(context);
 
   // x₁[n+1] = x₀[n].
   discrete_state->get_mutable_vector().get_mutable_value().tail(n_) =

--- a/systems/primitives/linear_system.cc
+++ b/systems/primitives/linear_system.cc
@@ -156,13 +156,13 @@ std::unique_ptr<AffineSystem<double>> DoFirstOrderTaylorApproximation(
         PortDataType::kAbstractValued) {
       continue;
     }
-    Eigen::VectorXd u = system.EvalEigenVectorInput(context, index);
+    Eigen::VectorXd u = system.get_input_port(index).Eval(context);
     autodiff_context->FixInputPort(index, u.cast<AutoDiffXd>());
   }
 
   Eigen::VectorXd u0 = Eigen::VectorXd::Zero(num_inputs);
   if (input_port) {
-    u0 = system.EvalEigenVectorInput(context, input_port->get_index());
+    u0 = system.get_input_port(input_port->get_index()).Eval(context);
   }
 
   auto autodiff_args = math::initializeAutoDiffTuple(x0, u0);

--- a/systems/primitives/multiplexer.cc
+++ b/systems/primitives/multiplexer.cc
@@ -58,7 +58,7 @@ void Multiplexer<T>::CombineInputsToOutput(const Context<T>& context,
   for (int i = 0; i < this->get_num_input_ports(); ++i) {
     const int input_size = input_sizes_[i];
     output_vector.segment(output_vector_index, input_size) =
-        this->EvalEigenVectorInput(context, i);
+        this->get_input_port(i).Eval(context);
     output_vector_index += input_size;
   }
 }

--- a/systems/primitives/pass_through.h
+++ b/systems/primitives/pass_through.h
@@ -150,18 +150,16 @@ void PassThrough<T>::DoCalcVectorOutput(
       const Context<T>& context,
       BasicVector<T>* output) const {
   DRAKE_ASSERT(!is_abstract());
-  const BasicVector<T>& input = *this->EvalVectorInput(context, 0);
+  const auto& input = get_input_port().Eval(context);
   DRAKE_ASSERT(input.size() == output->size());
-  output->SetFrom(input);
+  output->SetFromVector(input);
 }
 
 template <typename T>
 void PassThrough<T>::DoCalcAbstractOutput(const Context<T>& context,
                                           AbstractValue* output) const {
   DRAKE_ASSERT(is_abstract());
-  const AbstractValue& input =
-      *this->EvalAbstractInput(context, 0);
-  output->SetFrom(input);
+  output->SetFrom(this->get_input_port().template Eval<AbstractValue>(context));
 }
 
 template <typename T>

--- a/systems/primitives/random_source.cc
+++ b/systems/primitives/random_source.cc
@@ -33,7 +33,7 @@ int AddRandomInputs(double sampling_interval_sec,
 
       typedef typename Diagram<double>::InputPortLocator InputPortLocator;
       // Check if the input is already wired up.
-      InputPortLocator id{port.get_system(), port.get_index()};
+      InputPortLocator id{&port.get_system(), port.get_index()};
       if (builder->connection_map_.count(id) > 0 ||
           builder->diagram_input_set_.count(id) > 0) {
         continue;

--- a/systems/primitives/signal_logger.cc
+++ b/systems/primitives/signal_logger.cc
@@ -52,8 +52,7 @@ void SignalLogger<T>::set_forced_publish_only() {
 
 template <typename T>
 EventStatus SignalLogger<T>::WriteToLog(const Context<T>& context) const {
-  log_.AddData(context.get_time(),
-               this->EvalVectorInput(context, 0)->get_value());
+  log_.AddData(context.get_time(), get_input_port().Eval(context));
   return EventStatus::Succeeded();
 }
 

--- a/systems/primitives/sine.h
+++ b/systems/primitives/sine.h
@@ -280,7 +280,7 @@ void Sine<T>::CalcArg(
     *arg = frequency_.array() * time_vec.array() + phase_.array();
   } else {
     Eigen::VectorBlock<const VectorX<T>> input =
-        this->EvalEigenVectorInput(context, 0);
+        this->get_input_port(0).Eval(context);
     *arg = frequency_.array() * input.array() + phase_.array();
   }
 }

--- a/systems/primitives/test/linear_system_test.cc
+++ b/systems/primitives/test/linear_system_test.cc
@@ -606,8 +606,8 @@ class MimoSystem final : public LeafSystem<T> {
 
   void DoCalcTimeDerivatives(const Context<T>& context,
                              ContinuousState<T>* derivatives) const final {
-    Vector1<T> u0 = this->EvalVectorInput(context, 0)->CopyToVector();
-    Vector3<T> u1 = this->EvalVectorInput(context, 1)->CopyToVector();
+    Vector1<T> u0 = this->get_input_port(0).Eval(context);
+    Vector3<T> u1 = this->get_input_port(1).Eval(context);
     Vector2<T> x = get_state_vector(context);
 
     derivatives->SetFromVector(A_ * x + B0_ * u0 + B1_ * u1);
@@ -617,8 +617,8 @@ class MimoSystem final : public LeafSystem<T> {
       const Context<T>& context,
       const std::vector<const DiscreteUpdateEvent<T>*>&,
       DiscreteValues<T>* discrete_state) const final {
-    Vector1<T> u0 = this->EvalVectorInput(context, 0)->CopyToVector();
-    Vector3<T> u1 = this->EvalVectorInput(context, 1)->CopyToVector();
+    Vector1<T> u0 = this->get_input_port(0).Eval(context);
+    Vector3<T> u1 = this->get_input_port(1).Eval(context);
     Vector2<T> x = get_state_vector(context);
 
     discrete_state->get_mutable_vector(0).SetFromVector(A_ * x + B0_ * u0 +
@@ -626,16 +626,16 @@ class MimoSystem final : public LeafSystem<T> {
   }
 
   void CalcOutput0(const Context<T>& context, BasicVector<T>* output) const {
-    Vector1<T> u0 = this->EvalVectorInput(context, 0)->CopyToVector();
-    Vector3<T> u1 = this->EvalVectorInput(context, 1)->CopyToVector();
+    Vector1<T> u0 = this->get_input_port(0).Eval(context);
+    Vector3<T> u1 = this->get_input_port(1).Eval(context);
     Vector2<T> x = get_state_vector(context);
 
     output->SetFromVector(C0_ * x + D00_ * u0 + D01_ * u1);
   }
 
   void CalcOutput1(const Context<T>& context, BasicVector<T>* output) const {
-    Vector1<T> u0 = this->EvalVectorInput(context, 0)->CopyToVector();
-    Vector3<T> u1 = this->EvalVectorInput(context, 1)->CopyToVector();
+    Vector1<T> u0 = this->get_input_port(0).Eval(context);
+    Vector3<T> u1 = this->get_input_port(1).Eval(context);
     Vector2<T> x = get_state_vector(context);
 
     output->SetFromVector(C1_ * x + D10_ * u0 + D11_ * u1);

--- a/systems/primitives/test/random_source_test.cc
+++ b/systems/primitives/test/random_source_test.cc
@@ -175,27 +175,24 @@ GTEST_TEST(RandomSourceTest, AddToDiagramBuilderTest) {
   auto context = diagram->CreateDefaultContext();
 
   // Check that the uniform input port is connected.
-  EXPECT_NE(
-      sys1->EvalVectorInput(diagram->GetSubsystemContext(*sys1, *context), 0),
-      nullptr);
+  EXPECT_TRUE(sys1->get_input_port(0).HasValue(
+      diagram->GetSubsystemContext(*sys1, *context)));
 
   // Check that the exponential input port is connected.
-  EXPECT_NE(
-      sys1->EvalVectorInput(diagram->GetSubsystemContext(*sys1, *context), 1),
-      nullptr);
+  EXPECT_TRUE(sys1->get_input_port(1).HasValue(
+      diagram->GetSubsystemContext(*sys1, *context)));
 
   // Check that the Gaussian input port is connected.
-  EXPECT_NE(
-      sys2->EvalVectorInput(diagram->GetSubsystemContext(*sys2, *context), 0),
-      nullptr);
+  EXPECT_TRUE(sys2->get_input_port(0).HasValue(
+      diagram->GetSubsystemContext(*sys2, *context)));
 
   // Check that the exported input remained exported.
   EXPECT_EQ(diagram->get_num_input_ports(), 1);
   EXPECT_EQ(diagram->get_input_port(0).size(), 2);
 
   // Check that the previously connected input remained connected.
-  EXPECT_EQ(sys2->EvalEigenVectorInput(
-                diagram->GetSubsystemContext(*sys2, *context), 2)[0],
+  EXPECT_EQ(sys2->get_input_port(2).Eval(
+                diagram->GetSubsystemContext(*sys2, *context))[0],
             14.0);
 }
 

--- a/systems/primitives/wrap_to_system.cc
+++ b/systems/primitives/wrap_to_system.cc
@@ -27,7 +27,7 @@ void WrapToSystem<T>::set_interval(int index, const T& low, const T& high) {
 template <typename T>
 void WrapToSystem<T>::CalcWrappedOutput(const Context<T>& context,
                                   BasicVector<T>* output) const {
-  const VectorX<T> input = this->EvalVectorInput(context, 0)->CopyToVector();
+  const auto& input = this->get_input_port(0).Eval(context);
   output->SetFromVector(input);
 
   // Loop through and set the saturation values.

--- a/systems/primitives/zero_order_hold.h
+++ b/systems/primitives/zero_order_hold.h
@@ -163,9 +163,9 @@ void ZeroOrderHold<T>::DoCalcDiscreteVariableUpdates(
     const std::vector<const DiscreteUpdateEvent<T>*>&,
     DiscreteValues<T>* discrete_state) const {
   DRAKE_ASSERT(!is_abstract());
-  const BasicVector<T>& input_value = *this->EvalVectorInput(context, 0);
+  const auto& input = get_input_port().Eval(context);
   BasicVector<T>& state_value = discrete_state->get_mutable_vector(0);
-  state_value.SetFrom(input_value);
+  state_value.SetFromVector(input);
 }
 
 template <typename T>
@@ -185,12 +185,12 @@ void ZeroOrderHold<T>::DoCalcUnrestrictedUpdate(
     const std::vector<const UnrestrictedUpdateEvent<T>*>&,
     State<T>* state) const {
   DRAKE_ASSERT(is_abstract());
-  const AbstractValue& input_value = *this->EvalAbstractInput(context, 0);
+  const auto& input = get_input_port().template Eval<AbstractValue>(context);
   // See `DoCalcAbstractOutput` for rationale regarding non-templated value
   // accessor.
   AbstractValue& state_value =
       state->get_mutable_abstract_state().get_mutable_value(0);
-  state_value.SetFrom(input_value);
+  state_value.SetFrom(input);
 }
 
 template <typename T>

--- a/systems/rendering/multibody_position_to_geometry_pose.cc
+++ b/systems/rendering/multibody_position_to_geometry_pose.cc
@@ -40,7 +40,7 @@ void MultibodyPositionToGeometryPose<T>::CalcGeometryPose(
   // TODO(eric.cousineau): Place `plant_context_` in the cache of `context`,
   // and remove mutable member.
   plant_.GetMutablePositions(plant_context_.get()) =
-      this->EvalEigenVectorInput(context, 0);
+      get_input_port().Eval(context);
 
   // Evaluate the plant's output port.
   plant_.get_geometry_poses_output_port().Calc(*plant_context_, output);

--- a/systems/rendering/pose_bundle_to_draw_message.cc
+++ b/systems/rendering/pose_bundle_to_draw_message.cc
@@ -19,8 +19,7 @@ PoseBundleToDrawMessage::~PoseBundleToDrawMessage() {}
 void PoseBundleToDrawMessage::CalcViewerDrawMessage(
     const Context<double>& context, lcmt_viewer_draw* output) const {
   const PoseBundle<double>& poses =
-      this->EvalAbstractInput(context, 0)
-          ->template GetValue<PoseBundle<double>>();
+      this->get_input_port(0).Eval<PoseBundle<double>>(context);
 
   lcmt_viewer_draw& message = *output;
 

--- a/systems/rendering/render_pose_to_geometry_pose.cc
+++ b/systems/rendering/render_pose_to_geometry_pose.cc
@@ -28,12 +28,10 @@ RenderPoseToGeometryPose<T>::RenderPoseToGeometryPose(
         return Value<Output>::Make(result);
       },
       [this, frame_id](const Context<T>& context, AbstractValue* calculated) {
-        const Input* input =
-            this->template EvalVectorInput<PoseVector>(context, 0);
-        DRAKE_DEMAND(input != nullptr);
+        const Input& input = get_input_port().template Eval<Input>(context);
         Output& output = calculated->GetMutableValueOrThrow<Output>();
         output.clear();
-        output.set_value(frame_id, input->get_isometry());
+        output.set_value(frame_id, input.get_isometry());
       });
 }
 

--- a/systems/sensors/beam_model.cc
+++ b/systems/sensors/beam_model.cc
@@ -66,11 +66,11 @@ void BeamModel<T>::CalcOutput(const systems::Context<T>& context,
   const auto params = dynamic_cast<const BeamModelParams<T>*>(
       &context.get_numeric_parameter(0));
   DRAKE_DEMAND(params != nullptr);
-  const auto& depth = this->EvalEigenVectorInput(context, 0);
-  const auto& w_event = this->EvalEigenVectorInput(context, 1);
-  const auto& w_hit = this->EvalEigenVectorInput(context, 2);
-  const auto& w_short = this->EvalEigenVectorInput(context, 3);
-  const auto& w_uniform = this->EvalEigenVectorInput(context, 4);
+  const auto& depth = get_depth_input_port().Eval(context);
+  const auto& w_event = get_event_random_input_port().Eval(context);
+  const auto& w_hit = get_hit_random_input_port().Eval(context);
+  const auto& w_short = get_short_random_input_port().Eval(context);
+  const auto& w_uniform = get_uniform_random_input_port().Eval(context);
 
   auto measurement = output->get_mutable_value();
 

--- a/systems/sensors/image_to_lcm_image_array_t.cc
+++ b/systems/sensors/image_to_lcm_image_array_t.cc
@@ -187,10 +187,11 @@ void ImageToLcmImageArrayT::CalcImageArray(
   msg->images.clear();
 
   for (int i = 0; i < get_num_input_ports(); i++) {
-    const AbstractValue* image_value = this->EvalAbstractInput(context, i);
+    const auto& image_value = this->get_input_port(i).
+        template Eval<AbstractValue>(context);
 
     image_t image_msg;
-    PackImageToLcmImageT(*image_value, input_port_pixel_type_[i],
+    PackImageToLcmImageT(image_value, input_port_pixel_type_[i],
                          msg->header.utime, this->get_input_port(i).get_name(),
                          &image_msg, do_compress_);
     msg->images.push_back(image_msg);

--- a/systems/sensors/image_writer.cc
+++ b/systems/sensors/image_writer.cc
@@ -160,19 +160,12 @@ const InputPort<double>& ImageWriter::DeclareImageInputPort(
 
 template <PixelType kPixelType>
 void ImageWriter::WriteImage(const Context<double>& context, int index) const {
+  const auto& port = get_input_port(index);
   const ImagePortInfo& data = port_info_[index];
-  const Image<kPixelType>* image =
-      this->EvalInputValue<Image<kPixelType>>(context, index);
-  if (image) {
-    const std::string& port_name = get_input_port(index).get_name();
-    SaveToFileHelper(
-        *image, MakeFileName(data.format, data.pixel_type, context.get_time(),
-                             port_name, data.count++));
-    return;
-  }
-  throw std::logic_error(
-      fmt::format("ImageWriter: {} image input port {} is not connected",
-                  labels_.at(data.pixel_type), index));
+  const Image<kPixelType>& image = port.Eval<Image<kPixelType>>(context);
+  SaveToFileHelper(
+      image, MakeFileName(data.format, data.pixel_type, context.get_time(),
+                          port.get_name(), data.count++));
 }
 
 std::string ImageWriter::MakeFileName(const std::string& format,

--- a/systems/sensors/lcm_image_array_to_images.cc
+++ b/systems/sensors/lcm_image_array_to_images.cc
@@ -227,10 +227,7 @@ LcmImageArrayToImages::LcmImageArrayToImages()
 
 void LcmImageArrayToImages::CalcColorImage(
     const Context<double>& context, ImageRgba8U* color_image) const {
-  const systems::AbstractValue* input =
-      this->EvalAbstractInput(context, image_array_t_input_port_index_);
-  DRAKE_ASSERT(input != nullptr);
-  const auto& images = input->GetValue<image_array_t>();
+  const auto& images = image_array_t_input_port().Eval<image_array_t>(context);
 
   // Look through the image array and just grab the first color image.
   const image_t* lcm_image = nullptr;
@@ -270,10 +267,7 @@ void LcmImageArrayToImages::CalcColorImage(
 
 void LcmImageArrayToImages::CalcDepthImage(
     const Context<double>& context, ImageDepth32F* depth_image) const {
-  const systems::AbstractValue* input =
-      this->EvalAbstractInput(context, image_array_t_input_port_index_);
-  DRAKE_ASSERT(input != nullptr);
-  const auto& images = input->GetValue<image_array_t>();
+  const auto& images = image_array_t_input_port().Eval<image_array_t>(context);
 
   // Look through the image array and just grab the first depth image.
   const image_t* lcm_image = nullptr;

--- a/systems/sensors/optitrack_sender.cc
+++ b/systems/sensors/optitrack_sender.cc
@@ -46,13 +46,12 @@ void OptitrackLcmFrameSender::PopulatePoseMessage(
   output->num_rigid_bodies = num_rigid_bodies_;
   output->rigid_bodies.resize(static_cast<size_t>(num_rigid_bodies_));
 
-  const geometry::FramePoseVector<double>* poses =
-      this->EvalInputValue<geometry::FramePoseVector<double>>(
-          context, pose_input_port_index_);
+  const auto& poses = get_optitrack_input_port().
+      Eval<geometry::FramePoseVector<double>>(context);
 
   int output_index = 0;
   for (const auto& frame : frame_map_) {
-    const Eigen::Isometry3d& pose = poses->value(frame.first);
+    const Eigen::Isometry3d& pose = poses.value(frame.first);
     output->rigid_bodies[output_index].id = frame.second.second;
     PopulateRigidBody(pose, &(output->rigid_bodies[output_index++]));
   }

--- a/systems/sensors/test/image_writer_test.cc
+++ b/systems/sensors/test/image_writer_test.cc
@@ -618,7 +618,7 @@ TEST_F(ImageWriterTest, SingleConfiguredPort) {
       // in an error.
       DRAKE_EXPECT_THROWS_MESSAGE(
           writer.Publish(*context, events->get_publish_events()),
-          std::logic_error, ".* image input port \\d+ is not connected");
+          std::logic_error, ".*InputPort.* is not connected");
 
       // Confirms that a valid publish increments the counter.
       context->FixInputPort(


### PR DESCRIPTION
This is a WIP prototyping branch for now.  Pushing to Drake for visibility / discussion.

This was motivated by my recent work with IIWA examples, in the systems framework.  The boilerplate is still too much.  I suspect that this will be one useful improvement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10592)
<!-- Reviewable:end -->
