### PR TITLE
py mbp: Split test into `plant_test` and `math_test`

### DIFF
--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -256,7 +256,7 @@ drake_py_unittest(
 )
 
 drake_py_unittest(
-    name = "multibody_tree_test",
+    name = "plant_test",
     data = [
         ":models",
         "//examples/double_pendulum:models",
@@ -267,7 +267,14 @@ drake_py_unittest(
     deps = [
         ":benchmarks_py",
         ":multibody_tree_py",
+        ":plant_py",
+        ":tree_py",
     ],
+)
+
+drake_py_unittest(
+    name = "math_test",
+    deps = [":math_py"],
 )
 
 drake_py_unittest(

--- a/bindings/pydrake/multibody/test/math_test.py
+++ b/bindings/pydrake/multibody/test/math_test.py
@@ -1,0 +1,33 @@
+import unittest
+
+import numpy as np
+
+from pydrake.multibody.math import (
+    SpatialAcceleration,
+    SpatialVelocity,
+)
+
+
+class TestMultibodyTreeMath(unittest.TestCase):
+    def check_spatial_vector(self, cls, rotation_name, translation_name):
+        vec = cls()
+        # - Accessors.
+        self.assertTrue(isinstance(vec.rotational(), np.ndarray))
+        self.assertTrue(isinstance(vec.translational(), np.ndarray))
+        self.assertEqual(vec.rotational().shape, (3,))
+        self.assertEqual(vec.translational().shape, (3,))
+        # - Fully-parameterized constructor.
+        rotation_expected = [0.1, 0.3, 0.5]
+        translation_expected = [0., 1., 2.]
+        kwargs = {
+            rotation_name: rotation_expected,
+            translation_name: translation_expected,
+        }
+        vec1 = cls(**kwargs)
+        self.assertTrue(np.allclose(vec1.rotational(), rotation_expected))
+        self.assertTrue(
+            np.allclose(vec1.translational(), translation_expected))
+
+    def test_spatial_vector_types(self):
+        self.check_spatial_vector(SpatialVelocity, 'w', 'v')
+        self.check_spatial_vector(SpatialAcceleration, 'alpha', 'a')

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -2,7 +2,6 @@
 
 from pydrake.multibody.tree import (
     Body,
-    BodyFrame,
     BodyIndex,
     ForceElement,
     ForceElementIndex,
@@ -20,10 +19,7 @@ from pydrake.multibody.tree import (
     WeldJoint,
     world_index,
 )
-from pydrake.multibody.math import (
-    SpatialAcceleration,
-    SpatialVelocity,
-)
+from pydrake.multibody.math import SpatialVelocity
 from pydrake.multibody.plant import (
     AddMultibodyPlantSceneGraph,
     ContactResults,
@@ -87,32 +83,7 @@ def get_index_class(cls):
     raise RuntimeError("Unknown class: {}".format(cls))
 
 
-class TestMultibodyTreeMath(unittest.TestCase):
-    def check_spatial_vector(self, cls, rotation_name, translation_name):
-        vec = cls()
-        # - Accessors.
-        self.assertTrue(isinstance(vec.rotational(), np.ndarray))
-        self.assertTrue(isinstance(vec.translational(), np.ndarray))
-        self.assertEqual(vec.rotational().shape, (3,))
-        self.assertEqual(vec.translational().shape, (3,))
-        # - Fully-parameterized constructor.
-        rotation_expected = [0.1, 0.3, 0.5]
-        translation_expected = [0., 1., 2.]
-        kwargs = {
-            rotation_name: rotation_expected,
-            translation_name: translation_expected,
-        }
-        vec1 = cls(**kwargs)
-        self.assertTrue(np.allclose(vec1.rotational(), rotation_expected))
-        self.assertTrue(
-            np.allclose(vec1.translational(), translation_expected))
-
-    def test_spatial_vector_types(self):
-        self.check_spatial_vector(SpatialVelocity, 'w', 'v')
-        self.check_spatial_vector(SpatialAcceleration, 'alpha', 'a')
-
-
-class TestMultibodyTree(unittest.TestCase):
+class TestPlant(unittest.TestCase):
     def test_type_safe_indices(self):
         self.assertEqual(world_index(), BodyIndex(0))
 
@@ -847,16 +818,6 @@ class TestMultibodyTree(unittest.TestCase):
         self.assertSetEqual(
             bodies,
             {plant.GetBodyByName("body1"), plant.GetBodyByName("body2")})
-
-    def test_new_spellings(self):
-        from pydrake.multibody import math
-        math.SpatialVelocity
-        from pydrake.multibody import plant
-        plant.MultibodyPlant
-        from pydrake.multibody import tree
-        tree.Body
-        # Check for soon-to-be deprecated symbols (#9366).
-        self.assertFalse(hasattr(tree, "MultibodyTree"))
 
     def test_deprecated_tree_api(self):
         plant = MultibodyPlant()


### PR DESCRIPTION
Addresses MBP test-splitting bullet in #10207

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10594)
<!-- Reviewable:end -->
