### PR TITLE
py attic: Deprecate forwarding symbols

### DIFF
--- a/bindings/pydrake/all.py
+++ b/bindings/pydrake/all.py
@@ -22,11 +22,13 @@ To see example usages, please see `doc/python_bindings.rst`.
 from __future__ import absolute_import
 import warnings
 
-# Legacy / soon-to-be-deprecated symbols.
+# Deprecated symbols.
 with warnings.catch_warnings():
     warnings.simplefilter("ignore", DeprecationWarning)
-    from .attic.all import *
     from .util.all import *
+
+# Legacy symbols.
+from .attic.all import *
 
 # Normal symbols.
 from . import getDrakePath

--- a/bindings/pydrake/attic/systems/all.py
+++ b/bindings/pydrake/attic/systems/all.py
@@ -1,2 +1,3 @@
+from __future__ import absolute_import
 from .controllers import *
 from .sensors import *

--- a/bindings/pydrake/attic/test/attic_forwarding_test.py
+++ b/bindings/pydrake/attic/test/attic_forwarding_test.py
@@ -2,26 +2,55 @@
 Tests existence of all relevant attic forwarding symbols.
 """
 
+from contextlib import contextmanager
 import unittest
+import warnings
+
+from pydrake.common.deprecation import DrakeDeprecationWarning
 
 
 class TestAtticForwarding(unittest.TestCase):
+    @contextmanager
+    def expect_deprecation(self):
+        with warnings.catch_warnings():
+            with self.assertRaises(DrakeDeprecationWarning):
+                warnings.simplefilter("error", DrakeDeprecationWarning)
+                yield
+
     def test_multibody_modules(self):
-        from pydrake.multibody import (
-            collision,
-            joints,
-            parsers,
-            rigid_body_plant,
-            rigid_body,
-            rigid_body_tree,
-            shapes,
-        )
+        with self.expect_deprecation():
+            import pydrake.multibody.collision
+        with self.expect_deprecation():
+            import pydrake.multibody.joints
+        with self.expect_deprecation():
+            import pydrake.multibody.parsers
+        with self.expect_deprecation():
+            import pydrake.multibody.rigid_body_plant
+        with self.expect_deprecation():
+            import pydrake.multibody.rigid_body
+        with self.expect_deprecation():
+            import pydrake.multibody.rigid_body_tree
+        with self.expect_deprecation():
+            import pydrake.multibody.shapes
 
     def test_solvers_modules(self):
-        from pydrake.solvers import ik
+        with self.expect_deprecation():
+            import pydrake.solvers.ik
 
     def test_systems_symbols(self):
         from pydrake.systems.controllers import (
             RbtInverseDynamics, RbtInverseDynamicsController,
         )
         from pydrake.systems.sensors import RgbdCamera, RgbdCameraDiscrete
+        callable_list = [
+            RbtInverseDynamics,
+            RbtInverseDynamicsController,
+            RgbdCamera,
+            RgbdCameraDiscrete,
+        ]
+        for c in callable_list:
+            with self.expect_deprecation():
+                # N.B. This will emit a deprecation warning before it tries to
+                # call the original constructor, so we need not worry about the
+                # specific arguments.
+                c()

--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -152,6 +152,8 @@ PY_LIBRARIES_ATTIC_ALIASES = [
 
 drake_py_library_aliases(
     actual_subdir = "bindings/pydrake/attic/multibody",
+    add_deprecation_warning = 1,
+    deprecation_removal_date = "2019-05-01",
     relative_labels = PY_LIBRARIES_ATTIC_ALIASES,
 )
 

--- a/bindings/pydrake/multibody/all.py
+++ b/bindings/pydrake/multibody/all.py
@@ -1,21 +1,26 @@
-# Legacy / soon-to-be-deprecated symbols.
-# - Attic (#9314)
-from .collision import *
-from .joints import *
-from .parsers import *
-from .rigid_body_plant import *
-from .rigid_body_tree import *
-from .rigid_body import *
-from .shapes import *
+import warnings
+
+# Deprecated symbols.
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
+    # - Attic (#9314)
+    from .collision import *
+    from .joints import *
+    from .parsers import *
+    from .rigid_body_plant import *
+    from .rigid_body_tree import *
+    from .rigid_body import *
+    from .shapes import *
+
 # - Shuffle (#9314. #9366)
-from .multibody_tree.all import *
+from .multibody_tree.all import *  # noqa
 
 # Normal symbols.
-from .inverse_kinematics import *
-from .math import *
-from .parsing import *
-from .plant import *
-from .tree import *
+from .inverse_kinematics import *  # noqa
+from .math import *  # noqa
+from .parsing import *  # noqa
+from .plant import *  # noqa
+from .tree import *  # noqa
 
 # Submodules.
-from .benchmarks.all import *
+from .benchmarks.all import *  # noqa

--- a/bindings/pydrake/solvers/BUILD.bazel
+++ b/bindings/pydrake/solvers/BUILD.bazel
@@ -98,6 +98,8 @@ PY_LIBRARIES_ATTIC_ALIASES = [
 
 drake_py_library_aliases(
     actual_subdir = "bindings/pydrake/attic/solvers",
+    add_deprecation_warning = 1,
+    deprecation_removal_date = "2019-05-01",
     relative_labels = PY_LIBRARIES_ATTIC_ALIASES,
 )
 

--- a/bindings/pydrake/solvers/all.py
+++ b/bindings/pydrake/solvers/all.py
@@ -1,10 +1,14 @@
 from __future__ import absolute_import
+import warnings
 
-# TODO(eric.cousineau): Move `ik` to `multibody`.
-from .ik import *
-from .mathematicalprogram import *
+# Deprecated symbols.
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
+    from .ik import *
+
+from .mathematicalprogram import *  # noqa
 # TODO(eric.cousineau): Merge these into `mathematicalprogram`.
-from .gurobi import *
-from .ipopt import *
-from .mosek import *
-from .osqp import *
+from .gurobi import *  # noqa
+from .ipopt import *  # noqa
+from .mosek import *  # noqa
+from .osqp import *  # noqa

--- a/bindings/pydrake/systems/_controllers_extra.py
+++ b/bindings/pydrake/systems/_controllers_extra.py
@@ -1,5 +1,8 @@
+from pydrake.common.deprecation import _forward_callables_as_deprecated
+
 # Only try to import attic symbols if they're available.
 try:
-    from pydrake.attic.systems.controllers import *
+    from pydrake.attic.systems import controllers as _attic
+    _forward_callables_as_deprecated(locals(), _attic, "2019-05-01")
 except ImportError:
     pass

--- a/bindings/pydrake/systems/_sensors_extra.py
+++ b/bindings/pydrake/systems/_sensors_extra.py
@@ -1,5 +1,8 @@
+from pydrake.common.deprecation import _forward_callables_as_deprecated
+
 # Only try to import attic symbols if they're available.
 try:
-    from pydrake.attic.systems.sensors import *
+    from pydrake.attic.systems import sensors as _attic
+    _forward_callables_as_deprecated(locals(), _attic, "2019-05-01")
 except ImportError:
     pass

--- a/tools/skylark/alias.bzl
+++ b/tools/skylark/alias.bzl
@@ -133,14 +133,15 @@ from {module} import *
 
 _PY_TEMPLATE_DEPRECATED = r'''"""
 Warning:
-    This module is deprecated.
-    Please use ``{module}`` instead.
+    This module is deprecated and will be removed on or around
+    {deprecation_removal_date}. Please use ``{module}`` instead.
 """
 from pydrake.common.deprecation import _warn_deprecated
 from {module} import *
 
 _warn_deprecated(
-    "This module is deprecated; please use '{module}' instead.")
+    "This module is deprecated and will be removed on or around "
+    "{deprecation_removal_date}. Please use '{module}' instead.")
 '''
 
 def _strip_py_suffix(label):
@@ -153,6 +154,7 @@ def drake_py_library_aliases(
         relative_labels_map = {},
         actual_subdir = "",
         add_deprecation_warning = False,
+        deprecation_removal_date = None,
         tags = [],
         **kwargs):
     actual_subdir or fail("Missing required actual_subdir")
@@ -168,17 +170,27 @@ def drake_py_library_aliases(
         actual_name = _strip_py_suffix(actual_relative_label)
         actual_module = actual_package + "." + actual_name
         if add_deprecation_warning:
-            template = _PY_TEMPLATE_DEPRECATED
+            if deprecation_removal_date == None:
+                fail("`deprecation_removal_date` must be supplied.")
+            generate_file(
+                name = stub_file,
+                content = _PY_TEMPLATE_DEPRECATED.format(
+                    module = actual_module,
+                    deprecation_removal_date = deprecation_removal_date,
+                ),
+            )
         else:
-            template = _PY_TEMPLATE_NOT_DEPRECATED
-        generate_file(
-            name = stub_file,
-            content = template.format(module = actual_module),
-        )
+            generate_file(
+                name = stub_file,
+                content = _PY_TEMPLATE_NOT_DEPRECATED.format(
+                    module = actual_module,
+                ),
+            )
         actual_full_label = "//" + actual_subdir + actual_relative_label
         native.py_library(
             name = stub_relative_label[1:],
             deps = [actual_full_label],
             srcs = [stub_file],
             tags = tags + ["nolint"],
+            **kwargs
         )


### PR DESCRIPTION
Addresses attic portion of deprecation bullet in #10207

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10599)
<!-- Reviewable:end -->
