### PR TITLE
py mbp: Deprecate `multibody_tree` modules

### DIFF
--- a/bindings/pydrake/multibody/all.py
+++ b/bindings/pydrake/multibody/all.py
@@ -11,9 +11,8 @@ with warnings.catch_warnings():
     from .rigid_body_tree import *
     from .rigid_body import *
     from .shapes import *
-
-# - Shuffle (#9314. #9366)
-from .multibody_tree.all import *  # noqa
+    # - Shuffle (#9314. #9366)
+    from .multibody_tree.all import *  # noqa
 
 # Normal symbols.
 from .inverse_kinematics import *  # noqa

--- a/bindings/pydrake/multibody/multibody_tree_py.cc
+++ b/bindings/pydrake/multibody/multibody_tree_py.cc
@@ -32,10 +32,13 @@ void ForwardSymbols(py::module from, py::module m) {
   py::dict vars = m.attr("__dict__");
   py::exec(py::str("from {} import *").format(from.attr("__name__")),
       py::globals(), vars);
-  m.doc() = py::str(
-      "Warning:\n   ``{}`` will soon be deprecated. Please use ``{}`` "
-      "instead")
-                .format(m.attr("__name__"), from.attr("__name__"));
+
+  py::str deprecation = py::str(
+      "``{}`` is deprecated and will be removed on or around "
+      "2019-05-01. Please use ``{}`` instead")
+                            .format(m.attr("__name__"), from.attr("__name__"));
+  WarnDeprecated(deprecation);
+  m.doc() = py::str("Warning:\n    {}").format(deprecation);
 }
 
 // Bind deprecated symbols.
@@ -222,8 +225,8 @@ void init_parsing_deprecated(py::module m) {
 
   m.doc() =
       "Multibody parsing functionality.\n\n"
-      "Warning:\n   This module will soon be deprecated. Please use "
-      "``pydrake.multibody.parsing`` instead.";
+      "Warning:\n   This module is deprecated, and will be removed on or "
+      "around 2019-05-01. Please use ``pydrake.multibody.parsing`` instead.";
 
   // N.B. This module is deprecated; add all new methods to `parsing_py.cc`.
 
@@ -266,9 +269,10 @@ void init_all(py::module m) {
       "from pydrake.multibody.multibody_tree.multibody_plant import *\n"
       "from pydrake.multibody.multibody_tree.parsing import *\n",
       py::globals(), vars);
+  // N.B. Deprecation will have been emitted by `multibody_tree` module already.
   m.doc() =
-      "Warning:\n   ``pydrake.multibody.multibody_tree.all`` will soon "
-      "be deprecated.";
+      "Warning:\n   ``pydrake.multibody.multibody_tree.all`` is deprecated "
+      "and will be removed on or around 2019-05-01.";
 }
 
 }  // namespace

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -33,13 +33,6 @@ from pydrake.multibody.benchmarks.acrobot import (
     AcrobotParameters,
     MakeAcrobotPlant,
 )
-# Soon to be deprecated modules.
-from pydrake.multibody.multibody_tree import (
-    BodyNodeIndex,
-    MobilizerIndex,
-    MultibodyTree,
-)
-from pydrake.multibody.multibody_tree.parsing import AddModelFromSdfFile
 
 from pydrake.common.eigen_geometry import Isometry3
 from pydrake.geometry import (
@@ -66,6 +59,21 @@ from pydrake.common.eigen_geometry import Isometry3
 from pydrake.systems.framework import InputPort, OutputPort
 from pydrake.math import RigidTransform, RollPitchYaw
 from pydrake.systems.lcm import LcmPublisherSystem
+
+# Deprecated modules.
+# N.B. Place `with` afterwards to avoid needing to place `#noqa` on other
+# modules. Additionally, assert length of warnings here rather than in the test
+# so that we do not have to worry about whether a module has already been
+# loaded.
+with warnings.catch_warnings(record=True) as w:
+    warnings.simplefilter("default", DrakeDeprecationWarning)
+    from pydrake.multibody.multibody_tree import (
+        BodyNodeIndex,
+        MobilizerIndex,
+        MultibodyTree,
+    )
+    from pydrake.multibody.multibody_tree.parsing import AddModelFromSdfFile
+    assert len(w) == 3, len(w)
 
 
 def get_index_class(cls):


### PR DESCRIPTION
Addresses last bullet point, and thus: Resolves #10207.

Requires:
- [x] #10599

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10603)
<!-- Reviewable:end -->
