### PR TITLE
Parse SystemConstraint symbolically

### DIFF
--- a/systems/optimization/BUILD.bazel
+++ b/systems/optimization/BUILD.bazel
@@ -35,6 +35,8 @@ drake_cc_library(
     hdrs = ["system_constraint_adapter.h"],
     deps = [
         ":system_constraint_wrapper",
+        "//solvers:binding",
+        "//solvers:create_constraint",
     ],
 )
 

--- a/systems/optimization/system_constraint_adapter.cc
+++ b/systems/optimization/system_constraint_adapter.cc
@@ -18,9 +18,8 @@ bool SystemConstraintAdapter::MaybeCreateConstraintSymbolically(
     SystemConstraintIndex index, const Context<symbolic::Expression>& context,
     std::vector<solvers::Binding<solvers::Constraint>>* constraints) const {
   if (!system_symbolic_) {
-    throw std::runtime_error(
-        "SystemConstraintAdapter: cannot create the constraint symbolically, "
-        "since the system is not instantiated with symbolic expression.");
+    constraints->clear();
+    return false;
   }
   DRAKE_DEMAND(constraints->empty());
   const SystemConstraint<symbolic::Expression>& system_constraint =

--- a/systems/optimization/system_constraint_adapter.cc
+++ b/systems/optimization/system_constraint_adapter.cc
@@ -14,54 +14,55 @@ SystemConstraintAdapter::SystemConstraintAdapter(
   DRAKE_DEMAND(system);
 }
 
-struct UpdateSymbolicContextFromDecisionVariablesFunction {
-  
-};
-std::vector<solvers::Binding<solvers::Constraint>>
-SystemConstraintAdapter::CreateConstraintSymbolically(
-    SystemConstraintIndex index,
-    const Context<symbolic::Expression>& context) const {
+bool SystemConstraintAdapter::MaybeCreateConstraintSymbolically(
+    SystemConstraintIndex index, const Context<symbolic::Expression>& context,
+    std::vector<solvers::Binding<solvers::Constraint>>* constraints) const {
   if (!system_symbolic_) {
     throw std::runtime_error(
         "SystemConstraintAdapter: cannot create the constraint symbolically, "
         "since the system is not instantiated with symbolic expression.");
   }
+  DRAKE_DEMAND(constraints->empty());
   const SystemConstraint<symbolic::Expression>& system_constraint =
       system_symbolic_->get_constraint(index);
   VectorX<symbolic::Expression> constraint_val(system_constraint.size());
   // Evaluate the constraint as symbolic expressions.
   system_constraint.Calc(context, &constraint_val);
-  std::vector<solvers::Binding<solvers::Constraint>> constraints;
-  constraints.reserve(constraint_val.size());
+  constraints->reserve(constraint_val.size());
   // Parse the symbolic expression to constraint.
   // If the symbolic expression have some special structures (for example, being
   // linear), then we can create a
-  // LinearConstraint/LinearEqualityConstraint/BoundingBoxConstraint. If the
-  // symbolic expression exhibits no structure that can be parsed to a special
-  // derived class of solvers::Constraint, then we will return a
-  // SystemConstraintWrapper as a generic nonlinear constraint, which contains
-  // *all* the rows in @p constraint_val, that cannot be parsed to special
-  // derived class of solvers::Constraint.
+  // LinearConstraint/LinearEqualityConstraint/BoundingBoxConstraint.
 
-  // generic_constraint_rows stores the rows in @p constraint_val, whose
-  // symbolic expression will be regarded as generic constraint.
-  std::vector<int> generic_constraint_rows;
-  generic_constraint_rows.reserve(constraint_val.size());
+  bool is_success = true;
   for (int i = 0; i < constraint_val.size(); ++i) {
     std::unique_ptr<solvers::Binding<solvers::Constraint>> linear_constraint =
         solvers::internal::MaybeParseLinearConstraint(
             constraint_val(i), system_constraint.bounds().lower()(i),
             system_constraint.bounds().upper()(i));
     if (linear_constraint) {
-      constraints.push_back(*linear_constraint);
+      constraints->push_back(*linear_constraint);
     } else {
       // TODO(hongkai.dai): parse second order cone constraint.
-      generic_constraint_rows.push_back(i);
+      is_success = false;
+      break;
     }
   }
-  if (!generic_constraint_rows.empty()) {
+  if (!is_success) {
+    constraints->clear();
   }
-  return constraints;
+  return is_success;
+}
+
+const System<symbolic::Expression>& SystemConstraintAdapter::system_symbolic()
+    const {
+  if (system_symbolic_) {
+    return *system_symbolic_;
+  } else {
+    throw std::runtime_error(
+        "SystemConstraintAdapter: the system cannot be instantiated with"
+        "symbolic::Expression.");
+  }
 }
 
 }  // namespace systems

--- a/systems/optimization/system_constraint_adapter.cc
+++ b/systems/optimization/system_constraint_adapter.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/optimization/system_constraint_adapter.h"
 
+#include "drake/solvers/create_constraint.h"
+
 namespace drake {
 namespace systems {
 SystemConstraintAdapter::SystemConstraintAdapter(
@@ -10,6 +12,31 @@ SystemConstraintAdapter::SystemConstraintAdapter(
       // symbolic form.
       system_symbolic_{system_double_->ToSymbolicMaybe()} {
   DRAKE_DEMAND(system);
+}
+
+std::vector<solvers::Binding<solvers::Constraint>>
+SystemConstraintAdapter::CreateConstraintSymbolically(
+    SystemConstraintIndex index,
+    const Context<symbolic::Expression>& context) const {
+  if (!system_symbolic_) {
+    throw std::runtime_error(
+        "SystemConstraintAdapter: cannot create the constraint symbolically, "
+        "since the system is not instantiated with symbolic expression.");
+  }
+  const SystemConstraint<symbolic::Expression>& system_constraint =
+      system_symbolic_->get_constraint(index);
+  VectorX<symbolic::Expression> constraint_val(system_constraint.size());
+  // Evaluate the constraint as symbolic expressions.
+  system_constraint.Calc(context, &constraint_val);
+  std::vector<solvers::Binding<solvers::Constraint>> symbolic_constraints;
+  symbolic_constraints.reserve(constraint_val.size());
+  // Parse the symbolic expression to constraint.
+  for (int i = 0; i < constraint_val.size(); ++i) {
+    solvers::internal::ParseConstraint(constraint_val(i),
+                                       system_constraint.bounds().lower()(i),
+                                       system_constraint.bounds().upper()(i));
+  }
+  return symbolic_constraints;
 }
 
 }  // namespace systems

--- a/systems/optimization/system_constraint_adapter.h
+++ b/systems/optimization/system_constraint_adapter.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include "drake/solvers/binding.h"
 #include "drake/systems/optimization/system_constraint_wrapper.h"
 
 namespace drake {
@@ -51,6 +52,19 @@ class SystemConstraintAdapter {
             updater),
         x_size);
   }
+
+  /**
+   * Given a SystemConstraint and the Context to evaluate this SystemConstraint,
+   * parse the constraint in the symbolic forms. Currently we support parsing
+   * the following symbolic forms:
+   * (1) bounding box ( lower <= x <= uppeer )
+   * (2) linear equality aᵀx = b
+   * (3) linear inequality lower <= aᵀx <= upper.
+   */
+  std::vector<solvers::Binding<solvers::Constraint>>
+  CreateConstraintSymbolically(
+      SystemConstraintIndex index,
+      const Context<symbolic::Expression>& context) const;
 
  private:
   const System<double>* const system_double_;

--- a/systems/optimization/system_constraint_adapter.h
+++ b/systems/optimization/system_constraint_adapter.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <vector>
 
+#include "drake/common/drake_optional.h"
 #include "drake/solvers/binding.h"
 #include "drake/systems/optimization/system_constraint_wrapper.h"
 
@@ -52,29 +53,32 @@ class SystemConstraintAdapter {
         x_size);
   }
 
+  // TODO(hongkai.dai): support parsing second-order-cone or quadratic
+  // constraint.
   /**
    * Given a SystemConstraint and the Context to evaluate this SystemConstraint,
    * parse the constraint in the symbolic forms. Currently we support parsing
    * the following forms:
-   * (1) bounding box ( lower <= x <= uppeer )
-   * (2) linear equality ( aᵀx = b )
-   * (3) linear inequality ( lower <= aᵀx <= upper )
+   *
+   *  1. bounding box ( lower <= x <= upper )
+   *  2. linear equality ( aᵀx = b )
+   *  3. linear inequality ( lower <= aᵀx <= upper )
+   *
    * If the SystemConstraint cannot be parsed to the forms above, then return
    * false, and clear @p constraints. Otherwise return true.
    * @param index The index of the constraint in the System object.
    * @param context The context used to evaluate the SystemConstraint.
-   * @param constraints constraints[i] is the i'th row of the SystemConstraint
-   * evaluation result.
-   * @return is_success If the SystemConstraint can be parsed symbolically to
-   * the form above. The failure could come from either the system is not
-   * instantiated in the symbolic::Expression, or the constraint cannot be
-   * parsed to the form above.
+   * @retval constraints If the SystemConstraint can be parsed to the constraint
+   * in the above forms, then constraints.value()[i] is the i'th row of the
+   * SystemConstraint evaluation result; if the SystemConstraint cannot be
+   * parsed in the above forms (either due to the System is not instantiated
+   * with symbolic::Expression, or the constraint is not linear), then
+   * constraints.has_value() = false.
    */
-  // TODO(hongkai.dai): support parsing second-order-cone or quadratic
-  // constraint.
-  bool MaybeCreateConstraintSymbolically(
-      SystemConstraintIndex index, const Context<symbolic::Expression>& context,
-      std::vector<solvers::Binding<solvers::Constraint>>* constraints) const;
+  optional<std::vector<solvers::Binding<solvers::Constraint>>>
+  MaybeCreateConstraintSymbolically(
+      SystemConstraintIndex index,
+      const Context<symbolic::Expression>& context) const;
 
   /**
    * Returns the symbolic system. Throws a runtime error if the system cannot be

--- a/systems/optimization/system_constraint_adapter.h
+++ b/systems/optimization/system_constraint_adapter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include "drake/solvers/binding.h"
 #include "drake/systems/optimization/system_constraint_wrapper.h"
@@ -60,12 +61,24 @@ class SystemConstraintAdapter {
    * (1) bounding box ( lower <= x <= uppeer )
    * (2) linear equality aᵀx = b
    * (3) linear inequality lower <= aᵀx <= upper.
-   * (4) generic nonlinear constraint lower <= f(x) <= upper
+   * If the SystemConstraint cannot be parsed to the forms above, then return
+   * false, and clear @p constraints. Otherwise return true.
+   * @param index The index of the constraint in the System object.
+   * @param context The context used to evaluate the SystemConstraint.
+   * @param constraints constraints[i] is the i'th row of the SystemConstraint
+   * evaluation result.
+   * @return is_success If the SystemConstraint can be parsed symbolically to
+   * the form above.
    */
-  std::vector<solvers::Binding<solvers::Constraint>>
-  CreateConstraintSymbolically(
-      SystemConstraintIndex index,
-      const Context<symbolic::Expression>& context) const;
+  bool MaybeCreateConstraintSymbolically(
+      SystemConstraintIndex index, const Context<symbolic::Expression>& context,
+      std::vector<solvers::Binding<solvers::Constraint>>* constraints) const;
+
+  /**
+   * Returns the symbolic system. Throws a runtime error if the system cannot be
+   * instantiated with symbolic::Expression.
+   */
+  const System<symbolic::Expression>& system_symbolic() const;
 
  private:
   const System<double>* const system_double_;

--- a/systems/optimization/system_constraint_adapter.h
+++ b/systems/optimization/system_constraint_adapter.h
@@ -56,10 +56,11 @@ class SystemConstraintAdapter {
   /**
    * Given a SystemConstraint and the Context to evaluate this SystemConstraint,
    * parse the constraint in the symbolic forms. Currently we support parsing
-   * the following symbolic forms:
+   * the following forms:
    * (1) bounding box ( lower <= x <= uppeer )
    * (2) linear equality aᵀx = b
    * (3) linear inequality lower <= aᵀx <= upper.
+   * (4) generic nonlinear constraint lower <= f(x) <= upper
    */
   std::vector<solvers::Binding<solvers::Constraint>>
   CreateConstraintSymbolically(

--- a/systems/optimization/system_constraint_adapter.h
+++ b/systems/optimization/system_constraint_adapter.h
@@ -37,8 +37,6 @@ class SystemConstraintAdapter {
    * context. Hence we use @p UpdateContextFromDecisionVariablesGeneric to
    * select the decision variables inside @p context. The unselected variables
    * will remain to its values stored in @p context.
-   * TODO(hongkai.dai): add another function to parse the system constraint to
-   * linear/quadratic/second-order-cone etc using symbolic expression.
    */
   template <typename UpdateContextFromDecisionVariablesGenericFunction>
   std::shared_ptr<SystemConstraintWrapper> Create(
@@ -59,8 +57,8 @@ class SystemConstraintAdapter {
    * parse the constraint in the symbolic forms. Currently we support parsing
    * the following forms:
    * (1) bounding box ( lower <= x <= uppeer )
-   * (2) linear equality aᵀx = b
-   * (3) linear inequality lower <= aᵀx <= upper.
+   * (2) linear equality ( aᵀx = b )
+   * (3) linear inequality ( lower <= aᵀx <= upper )
    * If the SystemConstraint cannot be parsed to the forms above, then return
    * false, and clear @p constraints. Otherwise return true.
    * @param index The index of the constraint in the System object.
@@ -68,8 +66,12 @@ class SystemConstraintAdapter {
    * @param constraints constraints[i] is the i'th row of the SystemConstraint
    * evaluation result.
    * @return is_success If the SystemConstraint can be parsed symbolically to
-   * the form above.
+   * the form above. The failure could come from either the system is not
+   * instantiated in the symbolic::Expression, or the constraint cannot be
+   * parsed to the form above.
    */
+  // TODO(hongkai.dai): support parsing second-order-cone or quadratic
+  // constraint.
   bool MaybeCreateConstraintSymbolically(
       SystemConstraintIndex index, const Context<symbolic::Expression>& context,
       std::vector<solvers::Binding<solvers::Constraint>>* constraints) const;

--- a/systems/optimization/test/system_constraint_adapter_test.cc
+++ b/systems/optimization/test/system_constraint_adapter_test.cc
@@ -23,7 +23,7 @@ struct DummySystemUpdater1 {
   }
 };
 
-GTEST_TEST(SystemConstraintAdapter, CreateSystemConstraintWrapper) {
+GTEST_TEST(SystemConstraintAdapterTest, CreateSystemConstraintWrapper) {
   DummySystem<double> system;
 
   SystemConstraintAdapter adapter(&system);
@@ -72,7 +72,7 @@ GTEST_TEST(SystemConstraintAdapter, CreateSystemConstraintWrapper) {
   EXPECT_TRUE(CompareMatrices(y_val2, y_val2_expected, 3 * kEps));
 }
 
-GTEST_TEST(SystemConstraintAdapter, SolveDummySystemConstraint) {
+GTEST_TEST(SystemConstraintAdapterTest, SolveDummySystemConstraint) {
   DummySystem<double> system;
 
   SystemConstraintAdapter adapter(&system);
@@ -144,6 +144,126 @@ GTEST_TEST(SystemConstraintAdapterTest, ExternalSystemConstraint) {
   const double tol{1E-6};
   EXPECT_LE(result.GetSolution(x(1)), 5 + tol);
   EXPECT_GE(result.GetSolution(x(1)), -5 - tol);
+}
+
+void CheckBoundingBoxConstraint(
+    const solvers::Binding<solvers::Constraint>& constraint,
+    const symbolic::Variable& var, double lower, double upper,
+    double tol = 1E-14) {
+  const auto bounding_box =
+      solvers::internal::BindingDynamicCast<solvers::BoundingBoxConstraint>(
+          constraint);
+  EXPECT_EQ(bounding_box.variables().size(), 1);
+  EXPECT_EQ(bounding_box.variables()(0), var);
+  EXPECT_NEAR(bounding_box.evaluator()->lower_bound()(0), lower, tol);
+  EXPECT_NEAR(bounding_box.evaluator()->upper_bound()(0), upper, tol);
+}
+
+void CheckLinearConstraint(
+    const solvers::Binding<solvers::Constraint>& constraint,
+    const Eigen::Ref<const VectorX<symbolic::Variable>>& vars,
+    const Eigen::Ref<const Eigen::MatrixXd>& A,
+    const Eigen::Ref<const Eigen::VectorXd>& lower,
+    const Eigen::Ref<const Eigen::VectorXd>& upper, double tol = 1E-14) {
+  const auto linear_constraint =
+      solvers::internal::BindingDynamicCast<solvers::LinearConstraint>(
+          constraint);
+  EXPECT_EQ(linear_constraint.variables(), vars);
+  EXPECT_TRUE(CompareMatrices(linear_constraint.evaluator()->A(), A, tol));
+  EXPECT_TRUE(CompareMatrices(linear_constraint.evaluator()->lower_bound(),
+                              lower, tol));
+  EXPECT_TRUE(CompareMatrices(linear_constraint.evaluator()->upper_bound(),
+                              upper, tol));
+}
+
+void CheckLinearEqualityConstraint(
+    const solvers::Binding<solvers::Constraint>& constraint,
+    const Eigen::Ref<const VectorX<symbolic::Variable>>& vars,
+    const Eigen::Ref<const Eigen::MatrixXd>& A,
+    const Eigen::Ref<const Eigen::VectorXd>& rhs, double tol = 1E-14) {
+  const auto linear_eq_constraint =
+      solvers::internal::BindingDynamicCast<solvers::LinearEqualityConstraint>(
+          constraint);
+  EXPECT_EQ(linear_eq_constraint.variables(), vars);
+  EXPECT_TRUE(CompareMatrices(linear_eq_constraint.evaluator()->A(), A, tol));
+  EXPECT_TRUE(CompareMatrices(linear_eq_constraint.evaluator()->lower_bound(),
+                              rhs, tol));
+}
+
+GTEST_TEST(SystemConstraintAdapterTest, MaybeCreateConstraintSymbolically1) {
+  Eigen::Matrix2d A;
+  A << 0, 1, 0, 0;
+  LinearSystem<double> double_integrator(A, Eigen::Vector2d(0, 1),
+                                         Eigen::Matrix2d::Identity(),
+                                         Eigen::Vector2d::Zero());
+
+  // Create an arbitrary external constraint with linear forms.
+  // 0 <= x(0) + 1 <= 5
+  // 1 <= 2 * x(0) + x(1) <= 4
+  // x(0) + 2 * x(1) = 3
+  ExternalSystemConstraint system_constraint =
+      ExternalSystemConstraint::MakeForAllScalars(
+          "constraint", SystemConstraintBounds(Eigen::Vector3d(0, 1, 3),
+                                               Eigen::Vector3d(5, 4, 3)),
+          [](const auto& system, const auto& context, auto* value) {
+            auto x = context.get_continuous_state_vector().CopyToVector();
+            (*value)(0) = x(0) + 1;
+            (*value)(1) = 2 * x(0) + x(1);
+            (*value)(2) = x(0) + 2 * x(1);
+          });
+
+  const SystemConstraintIndex system_constraint_index =
+      double_integrator.AddExternalConstraint(system_constraint);
+
+  SystemConstraintAdapter adapter(&double_integrator);
+
+  auto context_symbolic = adapter.system_symbolic().CreateDefaultContext();
+
+  const symbolic::Variable x0("x0");
+  const symbolic::Variable x1("x1");
+
+  context_symbolic->get_mutable_continuous_state_vector().SetFromVector(
+      Vector2<symbolic::Expression>(x0, x1));
+
+  std::vector<solvers::Binding<solvers::Constraint>> constraints;
+  EXPECT_TRUE(adapter.MaybeCreateConstraintSymbolically(
+      system_constraint_index, *context_symbolic, &constraints));
+  EXPECT_EQ(constraints.size(), 3);
+  CheckBoundingBoxConstraint(constraints[0], x0, -1, 4);
+  CheckLinearConstraint(constraints[1], Vector2<symbolic::Variable>(x0, x1),
+                        Eigen::RowVector2d(2, 1), Vector1d(1), Vector1d(4));
+  CheckLinearEqualityConstraint(constraints[2],
+                                Vector2<symbolic::Variable>(x0, x1),
+                                Eigen::RowVector2d(1, 2), Vector1d(3));
+
+  // Now test context.x = [x0 + x1; 1]. Namely it contains both expression
+  // and constant.
+  context_symbolic->get_mutable_continuous_state().SetFromVector(
+      Vector2<symbolic::Expression>(x0 + x1, 1));
+  // The newly generated constraint should be
+  // -1 <= x0 + x1 <= 4
+  // 0 <= 2 * x0 + 2 * x1 <= 3
+  // x0 + x1 = 1
+  constraints.clear();
+  EXPECT_TRUE(adapter.MaybeCreateConstraintSymbolically(
+      system_constraint_index, *context_symbolic, &constraints));
+  EXPECT_EQ(constraints.size(), 3);
+  CheckLinearConstraint(constraints[0], Vector2<symbolic::Variable>(x0, x1),
+                        Eigen::RowVector2d(1, 1), Vector1d(-1), Vector1d(4));
+  CheckLinearConstraint(constraints[1], Vector2<symbolic::Variable>(x0, x1),
+                        Eigen::RowVector2d(2, 2), Vector1d(0), Vector1d(3));
+  CheckLinearEqualityConstraint(constraints[2],
+                                Vector2<symbolic::Variable>(x0, x1),
+                                Eigen::RowVector2d(1, 1), Vector1d(1));
+
+  // Now test a new context with context.x = [x0^2, 1]. Hence the constraints
+  // are nonlinear
+  context_symbolic->get_mutable_continuous_state().SetFromVector(
+      Vector2<symbolic::Expression>(x0 * x0, 1));
+  constraints.clear();
+  EXPECT_FALSE(adapter.MaybeCreateConstraintSymbolically(
+      system_constraint_index, *context_symbolic, &constraints));
+  EXPECT_TRUE(constraints.empty());
 }
 }  // namespace systems
 }  // namespace drake


### PR DESCRIPTION
This PR parses SystemConstraint symbolically to linear constraint. There will be following PRs to parse it to second order cone constraint if possible. Another extension will be to parse SystemConstraint symbolically to generic nonlinear constraint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10613)
<!-- Reviewable:end -->
