### PR TITLE
pydrake: Add OutputPort.EvalBasicVector 

### DIFF
--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -272,7 +272,17 @@ void DefineFrameworkPySemantics(py::module m) {
                   py::cast(&self->EvalAbstract(context), py_reference);
               return value_ref.attr("get_value")();
             },
-            doc.OutputPort.Eval.doc);
+            doc.OutputPort.Eval.doc)
+        .def("EvalBasicVector",
+            static_cast<const BasicVector<T>& (
+                OutputPort<T>::*)(const Context<T>&)const>(
+                &OutputPort<T>::Eval),
+            py::arg("context"),
+            "(Advanced.) Returns the value of this output port, typed "
+            "as a BasicVector. Most users should call Eval() instead. "
+            "This method is only needed when the result will be passed "
+            "into some other API that only accepts a BasicVector.",
+            py_reference_internal);
 
     auto system_output = DefineTemplateClassWithDefault<SystemOutput<T>>(
         m, "SystemOutput", GetPyParam<T>(), doc.SystemOutput.doc);

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -408,3 +408,8 @@ class TestGeneral(unittest.TestCase):
         self.assertEqual(type(value_abs), type(model_value))
         self.assertEqual(type(value_abs.get_value().get_value()), np.ndarray)
         np.testing.assert_equal(value_abs.get_value().get_value(), np_value)
+
+        basic = output_port.EvalBasicVector(context)
+        self.assertEqual(type(basic), BasicVector)
+        self.assertEqual(type(basic.get_value()), np.ndarray)
+        np.testing.assert_equal(basic.get_value(), np_value)

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -378,32 +378,33 @@ class TestGeneral(unittest.TestCase):
                 system=system,
                 context=simulator.get_mutable_context()))
 
-    def test_eval(self):
-        """Tests evaluation (e.g. caching, API sugars, etc.)."""
-        # `Eval` and `EvalAbstract`: Test with constant systems.
-        model_values = [
-            AbstractValue.Make("Hello World"),
-            AbstractValue.Make(BasicVector([1., 2., 3.])),
-        ]
-        for model_value in model_values:
-            is_abstract = not isinstance(model_value.get_value(), BasicVector)
-            if is_abstract:
-                zoh = ConstantValueSource(copy.copy(model_value))
-            else:
-                zoh = ConstantVectorSource(model_value.get_value().get_value())
-            context = zoh.CreateDefaultContext()
-            output_port = zoh.get_output_port(0)
-            value_abstract = output_port.EvalAbstract(context)
-            value = output_port.Eval(context)
-            self.assertEqual(type(value_abstract), type(model_value))
-            self.assertEqual(type(value), type(model_value.get_value()))
-            if is_abstract:
-                check = self.assertEqual
-            else:
+    def test_abstract_output_port_eval(self):
+        model_value = AbstractValue.Make("Hello World")
+        source = ConstantValueSource(copy.copy(model_value))
+        context = source.CreateDefaultContext()
+        output_port = source.get_output_port(0)
 
-                def check(a, b):
-                    self.assertEqual(type(a.get_value()), type(b.get_value()))
-                    np.testing.assert_equal(a.get_value(), b.get_value())
+        value = output_port.Eval(context)
+        self.assertEqual(type(value), type(model_value.get_value()))
+        self.assertEqual(value, model_value.get_value())
 
-            check(value_abstract.get_value(), model_value.get_value())
-            check(value, model_value.get_value())
+        value_abs = output_port.EvalAbstract(context)
+        self.assertEqual(type(value_abs), type(model_value))
+        self.assertEqual(value_abs.get_value(), model_value.get_value())
+
+    def test_vector_output_port_eval(self):
+        np_value = np.array([1., 2., 3.])
+        model_value = AbstractValue.Make(BasicVector(np_value))
+        source = ConstantVectorSource(np_value)
+        context = source.CreateDefaultContext()
+        output_port = source.get_output_port(0)
+
+        value = output_port.Eval(context)
+        self.assertEqual(type(value), type(model_value.get_value()))
+        self.assertEqual(type(value.get_value()), np.ndarray)
+        np.testing.assert_equal(value.get_value(), np_value)
+
+        value_abs = output_port.EvalAbstract(context)
+        self.assertEqual(type(value_abs), type(model_value))
+        self.assertEqual(type(value_abs.get_value().get_value()), np.ndarray)
+        np.testing.assert_equal(value_abs.get_value().get_value(), np_value)


### PR DESCRIPTION
This capability will be required once Eval changes its semantics to return a numpy.ndarray by default (#10625), instead of a BasicVector.  We're adding it now to allow for a brief transition window.

Relates #10592.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10623)
<!-- Reviewable:end -->
