### PR TITLE
Fix caching problems in integrators

### DIFF
--- a/multibody/plant/test/floating_body_test.cc
+++ b/multibody/plant/test/floating_body_test.cc
@@ -70,6 +70,7 @@ GTEST_TEST(QuaternionFloatingMobilizer, Simulation) {
   // call to this system's SetDefaultState().
   systems::Simulator<double> simulator(free_body_plant);
   systems::Context<double>& context = simulator.get_mutable_context();
+  context.EnableCaching();
 
   // The expected initial velocities with non-zero components in all three
   // axes, where B is the free body frame and W is the world frame.

--- a/systems/analysis/implicit_euler_integrator.h
+++ b/systems/analysis/implicit_euler_integrator.h
@@ -91,9 +91,7 @@ class ImplicitEulerIntegrator final : public IntegratorBase<T> {
 
   explicit ImplicitEulerIntegrator(const System<T>& system,
                                    Context<T>* context = nullptr)
-      : IntegratorBase<T>(system, context) {
-    derivs_ = system.AllocateTimeDerivatives();
-  }
+      : IntegratorBase<T>(system, context) {}
 
   /// Selecting the wrong such Jacobian determination scheme will slow (possibly
   /// critically) the implicit integration process. Automatic differentiation is
@@ -256,30 +254,20 @@ class ImplicitEulerIntegrator final : public IntegratorBase<T> {
   VectorX<T> Solve(const VectorX<T>& rhs) const;
   bool AttemptStepPaired(const T& dt, VectorX<T>* xtplus_euler,
                          VectorX<T>* xtplus_trap);
-  bool StepAbstract(const T& dt,
-                    const std::function<VectorX<T>()>& g,
-                    int scale,
-                    VectorX<T>* xtplus, int trial = 1);
+  bool StepAbstract(const T& dt, const std::function<VectorX<T>()>& g,
+                    int scale, VectorX<T>* xtplus, int trial = 1);
   bool CalcMatrices(const T& tf, const T& dt, int scale,
                     const VectorX<T>& xtplus, int trial);
   MatrixX<T> CalcJacobian(const T& tf, const VectorX<T>& xtplus);
   bool DoStep(const T& dt) override;
-  bool StepImplicitEuler(const T& dt);
-  bool StepImplicitTrapezoid(const T& dt, const VectorX<T>& dx0,
+  bool StepImplicitEuler(const T& h);
+  bool StepImplicitTrapezoid(const T& h, const VectorX<T>& dx0,
                              VectorX<T>* xtplus);
-  MatrixX<T> ComputeForwardDiffJacobian(const System<T>&,
-                                        const Context<T>&,
-                                        ContinuousState<T>* state);
-  MatrixX<T> ComputeCentralDiffJacobian(const System<T>&,
-                                        const Context<T>&,
-                                        ContinuousState<T>* state);
+  MatrixX<T> ComputeForwardDiffJacobian(const System<T>&, Context<T>*);
+  MatrixX<T> ComputeCentralDiffJacobian(const System<T>&, Context<T>*);
   MatrixX<T> ComputeAutoDiffJacobian(const System<T>& system,
                                      const Context<T>& context);
-  VectorX<T> CalcTimeDerivativesUsingContext();
-
-  // This is a pre-allocated temporary for use by integration. It stores
-  // the derivatives computed at x(t+h).
-  std::unique_ptr<ContinuousState<T>> derivs_;
+  VectorX<T> EvalTimeDerivativesUsingContext();
 
   // A simple LU factorization is all that is needed; robustness in the solve
   // comes naturally as dt << 1. Keeping this data in the class definition

--- a/systems/analysis/runge_kutta2_integrator.h
+++ b/systems/analysis/runge_kutta2_integrator.h
@@ -34,7 +34,6 @@ class RungeKutta2Integrator final : public IntegratorBase<T> {
       IntegratorBase<T>(system, context) {
     IntegratorBase<T>::set_maximum_step_size(max_step_size);
     derivs0_ = IntegratorBase<T>::get_system().AllocateTimeDerivatives();
-    derivs1_ = IntegratorBase<T>::get_system().AllocateTimeDerivatives();
   }
 
   /**
@@ -46,40 +45,64 @@ class RungeKutta2Integrator final : public IntegratorBase<T> {
   int get_error_estimate_order() const override { return 0; }
 
  private:
-  bool DoStep(const T& dt) override;
+  bool DoStep(const T& h) override;
 
-  // These are pre-allocated temporaries for use by integration
-  std::unique_ptr<ContinuousState<T>> derivs0_, derivs1_;
+  // A pre-allocated temporary for use by integration.
+  std::unique_ptr<ContinuousState<T>> derivs0_;
 };
 
 /**
- * Integrates the system forward in time by dt. This value is determined
- * by IntegratorBase::Step().
+ * Integrates the system forward in time from the current time t₀ to
+ * t₁ = t₀ + dt. The value of dt is determined by IntegratorBase::Step().
+ *
+ * The Butcher tableaux for this integrator follows: <pre>
+ *
+ *     0  |
+ *     1  | 1
+ *     -----------------
+ *          1/2     1/2
+ * </pre>
  */
 template <class T>
-bool RungeKutta2Integrator<T>::DoStep(const T& dt) {
-  // Find the continuous state xc within the Context, just once.
-  auto context = IntegratorBase<T>::get_mutable_context();
-  VectorBase<T>& xc = context->get_mutable_continuous_state_vector();
+bool RungeKutta2Integrator<T>::DoStep(const T& h) {
+  Context<T>* const context = IntegratorBase<T>::get_mutable_context();
 
-  // TODO(sherm1) This should be calculating into the cache so that
-  // Publish() doesn't have to recalculate if it wants to output derivatives.
-  this->CalcTimeDerivatives(*context, derivs0_.get());
+  // TODO(sherm1) Consider moving this notation description to IntegratorBase
+  //              when it is more widely adopted.
+  // Notation: we're using numeric subscripts for times t₀ and t₁, and
+  // lower-case letter superscripts like t⁽ᵃ⁾ and t⁽ᵇ⁾ to indicate values
+  // for intermediate stages of which there is only one here, stage a.
+  // State x₀ = {xc₀, xd₀, xa₀}. We modify only t and xc here, but
+  // derivative calculations depend on everything in the context, including t,
+  // x and inputs u (which may depend on t and x).
+  // Define x⁽ᵃ⁾ ≜ {xc⁽ᵃ⁾, xd₀, xa₀} and u⁽ᵃ⁾ ≜ u(t⁽ᵃ⁾, x⁽ᵃ⁾).
 
-  // First stage is an explicit Euler step:
-  // xc(t+h) = xc(t) + dt * xcdot(t, xc(t), u(t))
-  const auto& xcdot0 = derivs0_->get_vector();
-  xc.PlusEqScaled(dt, xcdot0);  // xc += dt * xcdot0
-  T t = IntegratorBase<T>::get_context().get_time() + dt;
-  IntegratorBase<T>::get_mutable_context()->set_time(t);
+  // Evaluate derivative xcdot₀ ← xcdot(t₀, x(t₀), u(t₀)). Copy the result
+  // into a temporary since we'll be calculating another derivative below.
+  derivs0_->get_mutable_vector().SetFrom(
+      this->EvalTimeDerivatives(*context).get_vector());
+  const VectorBase<T>& xcdot0 = derivs0_->get_vector();
 
-  // use derivative at t+dt
-  this->CalcTimeDerivatives(*context, derivs1_.get());
-  const auto& xcdot1 = derivs1_->get_vector();
+  // First intermediate stage is an explicit Euler step.
+  // This call invalidates t- and xc-dependent cache entries.
+  VectorBase<T>& xc = context->SetTimeAndGetMutableContinuousStateVector(
+      context->get_time() + h);  // t⁽ᵃ⁾ ← t₁ = t₀ + h
+  xc.PlusEqScaled(h, xcdot0);    // xc⁽ᵃ⁾ ← xc₀ + h * xcdot₀
 
-  // TODO(sherm1) Use better operators when available.
-  xc.PlusEqScaled(dt / 2, xcdot1);
-  xc.PlusEqScaled(-dt / 2, xcdot0);
+  // Evaluate derivative xcdot⁽ᵃ⁾ ← xcdot(t⁽ᵃ⁾, x⁽ᵃ⁾, u⁽ᵃ⁾).
+  const VectorBase<T>& xcdot_a =
+      this->EvalTimeDerivatives(*context).get_vector();
+
+  // Because we captured a reference to xc above and now want to modify it in
+  // place and recalculate, we must manually tell the caching system that we've
+  // made that change since it is otherwise unobservable. There is an advanced
+  // method available for this purpose.
+
+  // Invalidates xc-dependent context entries; time doesn't change here.
+  context->NoteContinuousStateChange();
+  // xc₁ = xc₀ + h * (xcdot₀ + xcdot⁽ᵃ⁾)/2
+  //     = xc⁽ᵃ⁾ + h * (xcdot⁽ᵃ⁾ - xcdot₀)/2
+  xc.PlusEqScaled({{h / 2, xcdot_a}, {-h / 2, xcdot0}});
 
   // RK2 always succeeds at taking the step.
   return true;

--- a/systems/analysis/runge_kutta3_integrator.h
+++ b/systems/analysis/runge_kutta3_integrator.h
@@ -67,7 +67,8 @@ class RungeKutta3Integrator final : public IntegratorBase<T> {
       : IntegratorBase<T>(system, context) {
     derivs0_ = system.AllocateTimeDerivatives();
     derivs1_ = system.AllocateTimeDerivatives();
-    derivs2_ = system.AllocateTimeDerivatives();
+    err_est_vec_.resize(derivs0_->size());
+    save_xc0_.resize(derivs0_->size());
   }
 
   /**
@@ -80,15 +81,18 @@ class RungeKutta3Integrator final : public IntegratorBase<T> {
 
  private:
   void DoInitialize() override;
-  bool DoStep(const T& dt) override;
+  bool DoStep(const T& h) override;
 
   // Vector used in error estimate calculations.
   VectorX<T> err_est_vec_;
 
+  // Vector used to save initial value of xc.
+  VectorX<T> save_xc0_;
+
   // These are pre-allocated temporaries for use by integration. They store
   // the derivatives computed at various points within the integration
   // interval.
-  std::unique_ptr<ContinuousState<T>> derivs0_, derivs1_, derivs2_;
+  std::unique_ptr<ContinuousState<T>> derivs0_, derivs1_;
 };
 }  // namespace systems
 }  // namespace drake

--- a/systems/analysis/test/explicit_euler_integrator_test.cc
+++ b/systems/analysis/test/explicit_euler_integrator_test.cc
@@ -22,6 +22,9 @@ GTEST_TEST(IntegratorTest, MiscAPI) {
   auto context_dbl = spring_mass_dbl.CreateDefaultContext();
   auto context_ad = spring_mass_ad.CreateDefaultContext();
 
+  context_dbl->EnableCaching();
+  context_ad->EnableCaching();
+
   // Create the integrator as a double and as an autodiff type
   ExplicitEulerIntegrator<double> int_dbl(spring_mass_dbl, dt,
                                           context_dbl.get());
@@ -44,6 +47,7 @@ GTEST_TEST(IntegratorTest, ContextAccess) {
 
   // Create a context.
   auto context = spring_mass.CreateDefaultContext();
+  context->EnableCaching();
 
   // Create the integrator.
   ExplicitEulerIntegrator<double> integrator(
@@ -65,6 +69,8 @@ GTEST_TEST(IntegratorTest, InvalidDts) {
   SpringMassSystem<double> spring_mass(1., 1., 0.);
   const double dt = 1e-3;
   auto context = spring_mass.CreateDefaultContext();
+  context->EnableCaching();
+
   ExplicitEulerIntegrator<double> integrator(
       spring_mass, dt, context.get());
   integrator.Initialize();
@@ -86,6 +92,8 @@ GTEST_TEST(IntegratorTest, AccuracyEstAndErrorControl) {
   SpringMassSystem<double> spring_mass(1., 1., 0.);
   const double dt = 1e-3;
   auto context = spring_mass.CreateDefaultContext();
+  context->EnableCaching();
+
   ExplicitEulerIntegrator<double> integrator(
       spring_mass, dt, context.get());
 
@@ -107,6 +115,7 @@ GTEST_TEST(IntegratorTest, MagDisparity) {
 
   // Create a context.
   auto context = spring_mass.CreateDefaultContext();
+  context->EnableCaching();
 
   // Set a large magnitude time.
   context->set_time(1e10);
@@ -140,6 +149,7 @@ GTEST_TEST(IntegratorTest, SpringMassStep) {
 
   // Create a context.
   auto context = spring_mass.CreateDefaultContext();
+  context->EnableCaching();
 
   // Setup the integration size and infinity.
   const double dt = 1e-6;
@@ -197,6 +207,7 @@ GTEST_TEST(IntegratorTest, StepSize) {
   const double max_dt = .01;
   // Create a context.
   auto context = spring_mass.CreateDefaultContext();
+  context->EnableCaching();
   context->set_time(0.0);
   double t = 0.0;
   // Create the integrator.

--- a/systems/analysis/test/implicit_euler_integrator_test.cc
+++ b/systems/analysis/test/implicit_euler_integrator_test.cc
@@ -46,6 +46,7 @@ GTEST_TEST(ImplicitEulerIntegratorTest, Stationary) {
   std::unique_ptr<StationarySystem<double>> stationary =
     std::make_unique<StationarySystem<double>>();
   std::unique_ptr<Context<double>> context = stationary->CreateDefaultContext();
+  context->EnableCaching();
 
   // Set the initial condition for the stationary system.
   VectorBase<double>& state = context->get_mutable_continuous_state().
@@ -76,6 +77,7 @@ GTEST_TEST(ImplicitEulerIntegratorTest, Robertson) {
   std::unique_ptr<analysis::test::RobertsonSystem<double>> robertson =
     std::make_unique<analysis::test::RobertsonSystem<double>>();
   std::unique_ptr<Context<double>> context = robertson->CreateDefaultContext();
+  context->EnableCaching();
 
   // Set the initial conditions for Robertson's system.
   VectorBase<double>& state = context->get_mutable_continuous_state().
@@ -132,9 +134,11 @@ class ImplicitIntegratorTest : public ::testing::TestWithParam<bool> {
 
     // One context will be usable for three of the systems.
     context_ = spring_->CreateDefaultContext();
+    context_->EnableCaching();
 
     // Separate context necessary for the double spring mass system.
     dspring_context_ = stiff_double_system_->CreateDefaultContext();
+    dspring_context_->EnableCaching();
   }
 
   std::unique_ptr<Context<double>> context_;
@@ -185,6 +189,7 @@ TEST_F(ImplicitIntegratorTest, AutoDiff) {
   // Create the integrator for a System<AutoDiffXd>.
   auto system = spring_->ToAutoDiffXd();
   auto context = system->CreateDefaultContext();
+  context->EnableCaching();
   ImplicitEulerIntegrator<AutoDiffXd> integrator(*system, context.get());
 
   // Set reasonable integrator parameters.

--- a/systems/analysis/test/runge_kutta2_integrator_test.cc
+++ b/systems/analysis/test/runge_kutta2_integrator_test.cc
@@ -42,6 +42,7 @@ GTEST_TEST(IntegratorTest, ContextAccess) {
 
   // Create a context.
   auto context = spring_mass.CreateDefaultContext();
+  context->EnableCaching();
 
   // Setup integration step.
   const double dt  = 1e-3;
@@ -59,6 +60,7 @@ GTEST_TEST(IntegratorTest, ErrorEst) {
   SpringMassSystem<double> spring_mass(1., 1., 0.);
   const double dt = 1e-3;
   auto context = spring_mass.CreateDefaultContext();
+  context->EnableCaching();
   RungeKutta2Integrator<double> integrator(
       spring_mass, dt, context.get());
 
@@ -94,6 +96,7 @@ GTEST_TEST(IntegratorTest, SpringMassStep) {
 
   // Create a context.
   auto context = spring_mass.CreateDefaultContext();
+  context->EnableCaching();
 
   // Create the integrator.
   const double dt = 1.0/1024;

--- a/systems/analysis/test/runge_kutta3_integrator_test.cc
+++ b/systems/analysis/test/runge_kutta3_integrator_test.cc
@@ -39,6 +39,7 @@ class RK3IntegratorTest : public ::testing::Test {
   std::unique_ptr<Context<double>> MakePlantContext() const {
     std::unique_ptr<Context<double>> context =
         plant_->CreateDefaultContext();
+    context->EnableCaching();
 
     // Set body linear and angular velocity.
     Vector3<double> v0(1., 2., 3.);    // Linear velocity in body's frame.
@@ -103,6 +104,7 @@ TEST_F(RK3IntegratorTest, ComparisonWithRK2) {
 // Tests accuracy of integrator's dense output.
 TEST_F(RK3IntegratorTest, DenseOutputAccuracy) {
   std::unique_ptr<Context<double>> context = MakePlantContext();
+
   RungeKutta3Integrator<double> rk3(*plant_, context.get());
   rk3.set_maximum_step_size(0.1);
   rk3.set_target_accuracy(1e-6);

--- a/systems/analysis/test/semi_explicit_euler_integrator_test.cc
+++ b/systems/analysis/test/semi_explicit_euler_integrator_test.cc
@@ -23,6 +23,7 @@ GTEST_TEST(IntegratorTest, ContextAccess) {
 
   // Create a context.
   auto context = spring_mass.CreateDefaultContext();
+  context->EnableCaching();
 
   // Create the integrator.
   SemiExplicitEulerIntegrator<double> integrator(
@@ -44,6 +45,7 @@ GTEST_TEST(IntegratorTest, AccuracyEstAndErrorControl) {
   SpringMassSystem<double> spring_mass(1., 1., 0.);
   const double dt = 1e-3;
   auto context = spring_mass.CreateDefaultContext();
+  context->EnableCaching();
   SemiExplicitEulerIntegrator<double> integrator(
       spring_mass, dt, context.get());
 
@@ -68,6 +70,7 @@ GTEST_TEST(IntegratorTest, RigidBody) {
 
   // Set free_body to have zero translation, zero rotation, and zero velocity.
   auto context = plant.CreateDefaultContext();
+  context->EnableCaching();
   plant.SetDefaultState(*context, &context->get_mutable_state());
 
   // Update the velocity.
@@ -125,6 +128,7 @@ GTEST_TEST(IntegratorTest, SpringMassStep) {
 
   // Create a context.
   auto context = spring_mass.CreateDefaultContext();
+  context->EnableCaching();
 
   // Setup the integration size and infinity.
   const double dt = 1e-6;

--- a/systems/framework/context_base.cc
+++ b/systems/framework/context_base.cc
@@ -237,15 +237,14 @@ void ContextBase::CreateBuiltInTrackers() {
   // TODO(sherm1) Should track changes to configuration and velocity regardless
   // of how represented. See issue #9171. Until that is resolved, we must
   // assume that "configuration" results (like end effector location and PE)
-  // can be affected by anything *except* time, v, and u; and "kinematics"
+  // can be affected by anything *except* time, v, z, and u; and "kinematics"
   // results (like end effector velocity and KE) can be affected by anything
-  // except time and u.
+  // except time, z, and u.
   auto& configuration_tracker = graph.CreateNewDependencyTracker(
       DependencyTicket(internal::kConfigurationTicket), "configuration");
   // Compare with "all sources" above.
   configuration_tracker.SubscribeToPrerequisite(&accuracy_tracker);
-  configuration_tracker.SubscribeToPrerequisite(&q_tracker);  // Not v.
-  configuration_tracker.SubscribeToPrerequisite(&z_tracker);
+  configuration_tracker.SubscribeToPrerequisite(&q_tracker);  // Not v or z.
   configuration_tracker.SubscribeToPrerequisite(&xd_tracker);
   configuration_tracker.SubscribeToPrerequisite(&xa_tracker);
   configuration_tracker.SubscribeToPrerequisite(&p_tracker);

--- a/systems/framework/context_base.h
+++ b/systems/framework/context_base.h
@@ -338,6 +338,13 @@ class ContextBase : public internal::ContextMessageInterface {
   changed, likely because someone has asked to modify continuous state xc. */
   void NoteAllContinuousStateChanged(int64_t change_event) {
     NoteAllQChanged(change_event);
+    NoteAllVZChanged(change_event);
+  }
+
+  /** Notifies the local v and z trackers that each of them may have
+  changed, likely because someone has asked to modify just the first-order
+  state variables in xc. */
+  void NoteAllVZChanged(int64_t change_event) {
     NoteAllVChanged(change_event);
     NoteAllZChanged(change_event);
   }

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -646,10 +646,10 @@ class SystemBase : public internal::SystemMessageInterface {
 
   /** Returns a ticket indicating dependence on all source values that may
   affect configuration-dependent computations. In particular, this category
-  _does not_ include time, generalized velocities v, or input ports.
-  Generalized coordinates q are included, as well as any discrete state
-  variables that have been declared as configuration variables, and
-  configuration-affecting parameters. Finally we assume that
+  _does not_ include time, generalized velocities v, miscellaneous continuous
+  state variables z, or input ports. Generalized coordinates q are included, as
+  well as any discrete state variables that have been declared as configuration
+  variables, and configuration-affecting parameters. Finally we assume that
   the accuracy setting may affect some configuration-dependent computations.
   Examples: a parameter that affects length may change the computation of an
   end-effector location. A change in accuracy requirement may require
@@ -658,8 +658,8 @@ class SystemBase : public internal::SystemMessageInterface {
 
   @note Currently there is no way to declare specific variables and parameters
   to be configuration-affecting so we include all state variables and
-  parameters except for generalized velocities v. */
-  // TODO(sherm1) Remove the above bug notice once #9171 is resolved.
+  parameters except for state variables v and z. */
+  // TODO(sherm1) Remove the above note once #9171 is resolved.
   // The configuration_tracker implementation in ContextBase must be kept
   // up to date with the above API contract.
   static DependencyTicket configuration_ticket() {
@@ -674,8 +674,8 @@ class SystemBase : public internal::SystemMessageInterface {
 
   @note Currently there is no way to declare specific variables and parameters
   to be configuration- or velocity-affecting so we include all state variables
-  and parameters. */
-  // TODO(sherm1) Remove the above bug notice once #9171 is resolved.
+  and parameters except for state variables z. */
+  // TODO(sherm1) Remove the above note once #9171 is resolved.
   static DependencyTicket kinematics_ticket() {
     return DependencyTicket(internal::kKinematicsTicket);
   }

--- a/systems/framework/test/dependency_tracker_test.cc
+++ b/systems/framework/test/dependency_tracker_test.cc
@@ -135,9 +135,8 @@ GTEST_TEST(DependencyTracker, BuiltInTrackers) {
   EXPECT_EQ(v.subscribers()[0], &xc);
   EXPECT_EQ(v.subscribers()[1], &kinematics);
   EXPECT_EQ(z.prerequisites().size(), 0);
-  ASSERT_EQ(z.subscribers().size(), 2);
+  ASSERT_EQ(z.subscribers().size(), 1);
   EXPECT_EQ(z.subscribers()[0], &xc);
-  EXPECT_EQ(z.subscribers()[1], &configuration);
 
   // xc depends on q, v, and z and x subscribes.
   ASSERT_EQ(xc.prerequisites().size(), 3);
@@ -170,15 +169,14 @@ GTEST_TEST(DependencyTracker, BuiltInTrackers) {
   EXPECT_EQ(x.subscribers()[0], &all_sources);
 
   // Until #9171 is resolved, we don't know which states and parameters affect
-  // configuration so we have to assume they all do (except v).
+  // configuration so we have to assume they all do (except v and z).
   // TODO(sherm1) Revise after #9171 is resolved.
-  ASSERT_EQ(configuration.prerequisites().size(), 6);
+  ASSERT_EQ(configuration.prerequisites().size(), 5);
   EXPECT_EQ(configuration.prerequisites()[0], &accuracy);
   EXPECT_EQ(configuration.prerequisites()[1], &q);
-  EXPECT_EQ(configuration.prerequisites()[2], &z);
-  EXPECT_EQ(configuration.prerequisites()[3], &xd);
-  EXPECT_EQ(configuration.prerequisites()[4], &xa);
-  EXPECT_EQ(configuration.prerequisites()[5], &p);
+  EXPECT_EQ(configuration.prerequisites()[2], &xd);
+  EXPECT_EQ(configuration.prerequisites()[3], &xa);
+  EXPECT_EQ(configuration.prerequisites()[4], &p);
   ASSERT_EQ(configuration.subscribers().size(), 1);
   EXPECT_EQ(configuration.subscribers()[0], &kinematics);
 

--- a/systems/framework/test/subvector_test.cc
+++ b/systems/framework/test/subvector_test.cc
@@ -48,6 +48,14 @@ TEST_F(SubvectorTest, Copy) {
   Eigen::Vector2d expected;
   expected << 2, 3;
   EXPECT_EQ(expected, subvec.CopyToVector());
+
+  Eigen::Vector2d pre_sized_good;
+  subvec.CopyToPreSizedVector(pre_sized_good);
+  EXPECT_EQ(expected, pre_sized_good);
+
+  Eigen::Vector3d pre_sized_bad;
+  EXPECT_THROW(subvec.CopyToPreSizedVector(pre_sized_bad),
+      std::exception);
 }
 
 // Tests that writes to the subvector pass through to the sliced vector.

--- a/systems/framework/vector_base.h
+++ b/systems/framework/vector_base.h
@@ -93,7 +93,7 @@ class VectorBase {
     }
   }
 
-  /// Copies the entire state to a vector with no semantics.
+  /// Copies this entire %VectorBase into a contiguous Eigen Vector.
   ///
   /// Implementations should ensure this operation is O(N) in the size of the
   /// value and allocates only the O(N) memory that it returns.
@@ -103,6 +103,18 @@ class VectorBase {
       vec[i] = GetAtIndex(i);
     }
     return vec;
+  }
+
+  /// Copies this entire %VectorBase into a pre-sized Eigen Vector.
+  ///
+  /// Implementations should ensure this operation is O(N) in the size of the
+  /// value.
+  /// @throws std::exception if `vec` is the wrong size.
+  virtual void CopyToPreSizedVector(Eigen::Ref<VectorX<T>> vec) const {
+    DRAKE_THROW_UNLESS(vec.rows() == size());
+    for (int i = 0; i < size(); ++i) {
+      vec[i] = GetAtIndex(i);
+    }
   }
 
   /// Adds a scaled version of this vector to Eigen vector @p vec, which


### PR DESCRIPTION
This PR makes the integrators take advantage of, and avoid pitfalls of, caching.

Resolves #10621

I made a complete pass through all the integrators' stepping methods, cleaning up cache, temporary, and heap use where I found it. Here is an overview of the changes in this PR:
- Tweaked explicit/semi-explicit/implicit Euler, rk2, rk3 integrators to exploit caching and avoid unnecessary invalidations.
- Removed temp variables that aren't needed now since the cache can serve that role.
- Added a few advanced methods to Context to provide more granularity for cache invalidation and to avoid unnecessary multiple-pass invalidations (time and state should invalidate together for most purposes). Unit tests in leaf_context_test.cc.
- Added a few more integrator stats to simple_gripper output for manual integrator timing experiments.
- Enabled caching for all the integrator tests.
- Added some missing comments; renamed some dt's to h's to match documentation and equations.
- Removed z-dependence of configuration_ticket (didn't match docs and messed up semi-explicit's vz-only stage).
- Added a missing method to VectorBase to avoid unnecessary heap allocation in integrators (unit test is in subvector_test.cc).


```
Category            added  modified  removed  
----------------------------------------------
code                132    159       47       
comments            122    82        32       
blank               26     0         7        
----------------------------------------------
TOTAL               280    241       86           
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10638)
<!-- Reviewable:end -->
