### PR TITLE
Add open_browser flag to meshcat argparse

### DIFF
--- a/bindings/pydrake/systems/meshcat_visualizer.py
+++ b/bindings/pydrake/systems/meshcat_visualizer.py
@@ -56,7 +56,8 @@ class MeshcatVisualizer(LeafSystem):
 
             if args.meshcat:
                 meshcat = builder.AddSystem(MeshcatVisualizer(
-                        scene_graph, zmq_url=args.meshcat))
+                        scene_graph, zmq_url=args.meshcat,
+                        open_browser=args.open_browser))
         """
         parser.add_argument(
             "--meshcat", nargs='?', metavar='zmq_url', const="new",
@@ -67,6 +68,10 @@ class MeshcatVisualizer(LeafSystem):
                  "connect to an existing meshcat-server at the specified "
                  "url.  Use --meshcat=default to connect to the "
                  "meshcat-server running at the default url.")
+
+        parser.add_argument(
+            "--open_browser", action='store_true', default=False,
+            help="Open a browser when creating a new meshcat-server.")
 
     def __init__(self,
                  scene_graph,

--- a/examples/manipulation_station/end_effector_teleop.py
+++ b/examples/manipulation_station/end_effector_teleop.py
@@ -287,7 +287,8 @@ else:
                            station.GetOutputPort("pose_bundle"))
     if args.meshcat:
         meshcat = builder.AddSystem(MeshcatVisualizer(
-            station.get_scene_graph(), zmq_url=args.meshcat))
+            station.get_scene_graph(), zmq_url=args.meshcat,
+            open_browser=args.open_browser))
         builder.Connect(station.GetOutputPort("pose_bundle"),
                         meshcat.get_input_port(0))
 

--- a/examples/manipulation_station/joint_teleop.py
+++ b/examples/manipulation_station/joint_teleop.py
@@ -12,7 +12,7 @@ from pydrake.examples.manipulation_station import \
     (ManipulationStation, ManipulationStationHardwareInterface)
 from pydrake.geometry import ConnectDrakeVisualizer
 from pydrake.manipulation.simple_ui import JointSliders, SchunkWsgButtons
-from pydrake.multibody.parsing import Parser
+# from pydrake.multibody.parsing import Parser
 from pydrake.systems.framework import DiagramBuilder
 from pydrake.systems.analysis import Simulator
 from pydrake.systems.meshcat_visualizer import MeshcatVisualizer
@@ -55,7 +55,8 @@ else:
                            station.GetOutputPort("pose_bundle"))
     if args.meshcat:
         meshcat = builder.AddSystem(MeshcatVisualizer(
-                station.get_scene_graph(), zmq_url=args.meshcat))
+                station.get_scene_graph(), zmq_url=args.meshcat,
+                open_browser=args.open_browser))
         builder.Connect(station.GetOutputPort("pose_bundle"),
                         meshcat.get_input_port(0))
 

--- a/examples/manipulation_station/joint_teleop.py
+++ b/examples/manipulation_station/joint_teleop.py
@@ -12,7 +12,7 @@ from pydrake.examples.manipulation_station import \
     (ManipulationStation, ManipulationStationHardwareInterface)
 from pydrake.geometry import ConnectDrakeVisualizer
 from pydrake.manipulation.simple_ui import JointSliders, SchunkWsgButtons
-# from pydrake.multibody.parsing import Parser
+from pydrake.multibody.parsing import Parser
 from pydrake.systems.framework import DiagramBuilder
 from pydrake.systems.analysis import Simulator
 from pydrake.systems.meshcat_visualizer import MeshcatVisualizer


### PR DESCRIPTION
Adds an open_browser flag to the meshcat argparse. The examples under manipulation station were updated to use this new flag. Other uses do not need to be updated unless the desired behavior changes.

Resolves https://github.com/RobotLocomotion/drake/issues/10561

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10640)
<!-- Reviewable:end -->
