### PR TITLE
py mp: Do not test lorentz cone constraint with SNOPT

### DIFF
--- a/bindings/pydrake/solvers/BUILD.bazel
+++ b/bindings/pydrake/solvers/BUILD.bazel
@@ -180,6 +180,7 @@ drake_py_unittest(
     deps = [
         ":gurobi_py",
         ":mathematicalprogram_py",
+        ":snopt_py",
     ],
 )
 

--- a/bindings/pydrake/solvers/BUILD.bazel
+++ b/bindings/pydrake/solvers/BUILD.bazel
@@ -92,6 +92,14 @@ drake_pybind_library(
     py_deps = [":mathematicalprogram_py"],
 )
 
+drake_pybind_library(
+    name = "snopt_py",
+    cc_deps = ["//bindings/pydrake:documentation_pybind"],
+    cc_srcs = ["snopt_py.cc"],
+    package_info = PACKAGE_INFO,
+    py_deps = [":mathematicalprogram_py"],
+)
+
 PY_LIBRARIES_ATTIC_ALIASES = [
     ":ik_py",
 ]
@@ -109,6 +117,7 @@ PY_LIBRARIES_WITH_INSTALL = [
     ":mathematicalprogram_py",
     ":mosek_py",
     ":osqp_py",
+    ":snopt_py",
 ]
 
 PY_LIBRARIES = PY_LIBRARIES_ATTIC_ALIASES + [

--- a/bindings/pydrake/solvers/all.py
+++ b/bindings/pydrake/solvers/all.py
@@ -12,3 +12,4 @@ from .gurobi import *  # noqa
 from .ipopt import *  # noqa
 from .mosek import *  # noqa
 from .osqp import *  # noqa
+from .snopt import *  # noqa

--- a/bindings/pydrake/solvers/snopt_py.cc
+++ b/bindings/pydrake/solvers/snopt_py.cc
@@ -1,0 +1,25 @@
+#include "pybind11/pybind11.h"
+
+#include "drake/bindings/pydrake/documentation_pybind.h"
+#include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/solvers/snopt_solver.h"
+
+namespace drake {
+namespace pydrake {
+
+PYBIND11_MODULE(snopt, m) {
+  // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
+  using namespace drake::solvers;
+  constexpr auto& doc = pydrake_doc.drake.solvers;
+
+  m.doc() = "SNOPT solver bindings for MathematicalProgram";
+
+  py::module::import("pydrake.solvers.mathematicalprogram");
+
+  py::class_<SnoptSolver, SolverInterface>(
+      m, "SnoptSolver", doc.SnoptSolver.doc)
+      .def(py::init<>(), doc.SnoptSolver.ctor.doc);
+}
+
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -2,6 +2,7 @@ from __future__ import print_function, absolute_import
 
 from pydrake.solvers import mathematicalprogram as mp
 from pydrake.solvers.gurobi import GurobiSolver
+from pydrake.solvers.snopt import SnoptSolver
 from pydrake.solvers.mathematicalprogram import SolverType
 
 import unittest
@@ -13,6 +14,8 @@ import pydrake
 from pydrake.common.deprecation import DrakeDeprecationWarning
 from pydrake.autodiffutils import AutoDiffXd
 import pydrake.symbolic as sym
+
+SNOPT_NO_GUROBI = SnoptSolver().available() and not GurobiSolver().available()
 
 
 class TestQP:
@@ -425,6 +428,9 @@ class TestMathematicalProgram(unittest.TestCase):
         prog.SetInitialGuessForAllVariables(x0)
         check_and_reset()
 
+    @unittest.skipIf(
+        SNOPT_NO_GUROBI,
+        "SNOPT is unable to solve this problem (#10653).")
     def test_lorentz_cone_constraint(self):
         # Set Up Mathematical Program
         prog = mp.MathematicalProgram()


### PR DESCRIPTION
Resolves the failures in weekly CI:
https://drake-cdash.csail.mit.edu/testDetails.php?test=26277180&build=1117432

```
======================================================================
FAIL: test_lorentz_cone_constraint (mathematicalprogram_test.TestMathematicalProgram)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./bindings/pydrake/solvers/test/mathematicalprogram_test.py", line 441, in test_lorentz_cone_constraint
    self.assertEqual(result, mp.SolutionResult.kSolutionFound)
AssertionError: SolutionResult.kInfeasibleConstraints != SolutionResult.kSolutionFound
```

\cc @hongkai-dai 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10652)
<!-- Reviewable:end -->
