### PR TITLE
py math: Ensure RollPitchYaw class doc shows up

### DIFF
--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -133,7 +133,7 @@ PYBIND11_MODULE(math, m) {
   // .def("IsNearlyEqualTo", ...)
   // .def("IsExactlyEqualTo", ...)
 
-  py::class_<RollPitchYaw<T>>(m, "RollPitchYaw")
+  py::class_<RollPitchYaw<T>>(m, "RollPitchYaw", doc.RollPitchYaw.doc)
       .def(py::init<const RollPitchYaw<T>&>(), py::arg("other"))
       .def(py::init<const Vector3<T>>(), py::arg("rpy"),
           doc.RollPitchYaw.ctor.doc_1args_rpy)

--- a/math/roll_pitch_yaw.h
+++ b/math/roll_pitch_yaw.h
@@ -16,6 +16,7 @@ namespace math {
 template <typename T>
 class RotationMatrix;
 
+// TODO(@mitiguy) Add Sherm/Goldstein's way to visualize rotation sequences.
 /// This class represents the orientation between two arbitrary frames A and D
 /// associated with a Space-fixed (extrinsic) X-Y-Z rotation by "roll-pitch-yaw"
 /// angles `[r, p, y]`, which is equivalent to a Body-fixed (intrinsic) Z-Y-X
@@ -58,8 +59,6 @@ class RotationMatrix;
 /// - double
 /// - AutoDiffXd
 /// - symbolic::Expression
-///
-// TODO(@mitiguy) Add Sherm/Goldstein's way to visualize rotation sequences.
 template <typename T>
 class RollPitchYaw {
  public:


### PR DESCRIPTION
Realized that our current Python API docs don't have the class docs for `RollPitchYaw`, which are super useful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10660)
<!-- Reviewable:end -->
