### PR TITLE
Updates documentation

### DIFF
--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -521,6 +521,10 @@ class Context : public ContextBase {
   /// modify the input port's value using the appropriate
   /// FixedInputPortValue method, which will ensure that invalidation
   /// notifications are delivered.
+  /// @note Calling this method on an already connected input port, i.e., an
+  /// input port that has previously been passed into a call to
+  /// DiagramBuilder::Connect(), causes FixedInputPortValue to override any
+  /// other value present on that port.
   FixedInputPortValue& FixInputPort(int index, const BasicVector<T>& vec) {
     return ContextBase::FixInputPort(
         index, std::make_unique<Value<BasicVector<T>>>(vec.Clone()));
@@ -528,6 +532,10 @@ class Context : public ContextBase {
 
   /// Same as above method but starts with an Eigen vector whose contents are
   /// used to initialize a BasicVector in the FixedInputPortValue.
+  /// @note Calling this method on an already connected input port, i.e., an
+  /// input port that has previously been passed into a call to
+  /// DiagramBuilder::Connect(), causes FixedInputPortValue to override any
+  /// other value present on that port.
   FixedInputPortValue& FixInputPort(
       int index, const Eigen::Ref<const VectorX<T>>& data) {
     return FixInputPort(index, BasicVector<T>(data));
@@ -537,6 +545,10 @@ class Context : public ContextBase {
   /// the vector is passed by unique_ptr instead of by const reference.  The
   /// caller must not retain any aliases to `vec`; within this method, `vec`
   /// is cloned and then deleted.
+  /// @note Calling this method on an already connected input port, i.e., an
+  /// input port that has previously been passed into a call to
+  /// DiagramBuilder::Connect(), causes FixedInputPortValue to override any
+  /// other value present on that port.
   /// @note This overload will become deprecated in the future, because it can
   /// mislead users to believe that they can retain an alias of `vec` to mutate
   /// the fixed value during a simulation.  Callers should prefer to use one of

--- a/systems/framework/context_base.h
+++ b/systems/framework/context_base.h
@@ -180,6 +180,11 @@ class ContextBase : public internal::ContextMessageInterface {
   unconnected input port. See `Context<T>` for more-convenient overloads of
   FixInputPort() for vector values with elements of type T.
 
+  @note Calling this method on an already connected input port, i.e., an
+  input port that has previously been passed into a call to
+  DiagramBuilder::Connect(), causes FixedInputPortValue to override any other
+  value present on that port.
+
   @pre `index` selects an existing input port of this Context. */
   FixedInputPortValue& FixInputPort(
       int index, std::unique_ptr<AbstractValue> value);
@@ -187,6 +192,11 @@ class ContextBase : public internal::ContextMessageInterface {
   /** Same as above method but the value is passed by const reference instead
   of by unique_ptr. The port will contain a copy of the `value` (not retain a
   pointer to the `value`).
+
+  @note Calling this method on an already connected input port, i.e., an
+  input port that has previously been passed into a call to
+  DiagramBuilder::Connect(), causes FixedInputPortValue to override any other
+  value present on that port.
 
   @exclude_from_pydrake_mkdoc{The prior overload's docstring is better, and we
   only need one of the two -- overloading on ownership doesn't make sense for

--- a/systems/framework/diagram_builder.h
+++ b/systems/framework/diagram_builder.h
@@ -136,6 +136,12 @@ class DiagramBuilder {
   }
 
   /// Declares that input port @p dest is connected to output port @p src.
+  /// @note The connection created between @p src and @p dest via a call to
+  /// this method can be effectively overridden by any subsequent call to
+  /// Context::FixInputPort(). That is, calling Context::FixInputPort() on an
+  /// already connected input port causes the resultant
+  /// FixedInputPortValue to override any other value present on that
+  /// port.
   void Connect(const OutputPort<T>& src,
                const InputPort<T>& dest) {
     InputPortLocator dest_id{dest.get_system(), dest.get_index()};
@@ -181,6 +187,12 @@ class DiagramBuilder {
 
   /// Declares that sole input port on the @p dest system is connected to sole
   /// output port on the @p src system.
+  /// @note The connection created between @p src and @p dest via a call to
+  /// this method can be effectively overridden by any subsequent call to
+  /// Context::FixInputPort(). That is, calling Context::FixInputPort() on an
+  /// already connected input port causes the resultant
+  /// FixedInputPortValue to override any other value present on that
+  /// port.
   /// @throws std::exception if the sole-port precondition is not met (i.e.,
   /// if @p dest has no input ports, or @p dest has more than one input port,
   /// or @p src has no output ports, or @p src has more than one output port).


### PR DESCRIPTION
for DiagramBuilder::Connect() and Context::FixInputPort() to describe 
the effects of fixing an input port that has been previously connected. 
Fixes #10516.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10665)
<!-- Reviewable:end -->
