### PR TITLE
manipulation: Use new Eval sugars

### DIFF
--- a/manipulation/kuka_iiwa/iiwa_status_receiver.cc
+++ b/manipulation/kuka_iiwa/iiwa_status_receiver.cc
@@ -72,9 +72,7 @@ const OutPort& IiwaStatusReceiver::get_state_output_port() const {
 template <std::vector<double> drake::lcmt_iiwa_status::* field_ptr>
 void IiwaStatusReceiver::CalcLcmOutput(
     const Context<double>& context, BasicVector<double>* output) const {
-  const auto* input = this->EvalInputValue<lcmt_iiwa_status>(context, 0);
-  DRAKE_THROW_UNLESS(input != nullptr);
-  const auto& status = *input;
+  const auto& status = get_input_port().Eval<lcmt_iiwa_status>(context);
 
   // If we're using a default constructed message (i.e., we haven't received
   // any status message yet), output zero.

--- a/manipulation/kuka_iiwa/iiwa_status_sender.h
+++ b/manipulation/kuka_iiwa/iiwa_status_sender.h
@@ -110,7 +110,7 @@ class IiwaStatusSender : public systems::LeafSystem<double> {
   void CalcOutput(const systems::Context<double>&, lcmt_iiwa_status*) const;
 
   const int num_joints_;
-  const systems::BasicVector<double> zero_vector_;
+  const Eigen::VectorXd zero_vector_;
 };
 
 }  // namespace kuka_iiwa

--- a/manipulation/perception/optitrack_pose_extractor.cc
+++ b/manipulation/perception/optitrack_pose_extractor.cc
@@ -15,8 +15,6 @@ namespace manipulation {
 namespace perception {
 
 using systems::Context;
-using systems::DiscreteValues;
-using systems::BasicVector;
 
 Isometry3<double> ExtractOptitrackPose(
     const optitrack::optitrack_rigid_body_t& body) {
@@ -79,7 +77,7 @@ OptitrackPoseExtractor::OptitrackPoseExtractor(
 }
 
 void OptitrackPoseExtractor::DoCalcUnrestrictedUpdate(
-    const systems::Context<double>& context,
+    const Context<double>& context,
     const std::vector<const systems::UnrestrictedUpdateEvent<double>*>&,
     systems::State<double>* state) const {
   // Extract Internal state.
@@ -87,9 +85,8 @@ void OptitrackPoseExtractor::DoCalcUnrestrictedUpdate(
       state->get_mutable_abstract_state<Isometry3<double>>(0);
 
   // Update world state from inputs.
-  const AbstractValue* input = this->EvalAbstractInput(context, 0);
-  DRAKE_ASSERT(input != nullptr);
-  auto& message = input->GetValue<optitrack::optitrack_frame_t>();
+  const auto& input = this->get_input_port(0);
+  const auto& message = input.Eval<optitrack::optitrack_frame_t>(context);
   auto body = FindOptitrackBody(message, object_id_);
   if (!body.has_value()) {
     throw std::runtime_error(fmt::format(

--- a/manipulation/perception/pose_smoother.cc
+++ b/manipulation/perception/pose_smoother.cc
@@ -129,9 +129,7 @@ void PoseSmoother::DoCalcUnrestrictedUpdate(
       state->get_mutable_abstract_state<InternalState>(0);
 
   // Update world state from inputs.
-  const AbstractValue* input = this->EvalAbstractInput(context, 0);
-  DRAKE_ASSERT(input != nullptr);
-  const auto& input_pose = input->GetValue<Isometry3d>();
+  const auto& input_pose = this->get_input_port(0).Eval<Isometry3d>(context);
 
   double current_time = context.get_time();
 

--- a/manipulation/schunk_wsg/schunk_wsg_lcm.cc
+++ b/manipulation/schunk_wsg/schunk_wsg_lcm.cc
@@ -67,30 +67,19 @@ SchunkWsgCommandReceiver::SchunkWsgCommandReceiver(double initial_position,
 void SchunkWsgCommandReceiver::EvalInput(
     const Context<double>& context, SchunkWsgCommand<double>* result) const {
   // Try the vector input port first.
-  const SchunkWsgCommand<double>* wsg_command =
-      this->template EvalVectorInput<SchunkWsgCommand>(context, 0);
-
-  // Maybe the vector input is not wired, try abstract input next.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  SchunkWsgCommand<double> decoded_command;
-#pragma GCC diagnostic pop
-  if (!wsg_command) {
-    const AbstractValue* input = this->EvalAbstractInput(context, 1);
-    DRAKE_THROW_UNLESS(input != nullptr);
-    const auto& command_msg = input->GetValue<lcmt_schunk_wsg_command>();
-    std::vector<uint8_t> bytes(command_msg.getEncodedSize());
-    command_msg.encode(bytes.data(), 0, bytes.size());
+  if (this->get_input_port(0).HasValue(context)) {
+    *result = this->get_input_port(0).Eval<SchunkWsgCommand<double>>(context);
+  } else {
+    const auto& message =
+        this->get_input_port(1).Eval<lcmt_schunk_wsg_command>(context);
+    std::vector<uint8_t> bytes(message.getEncodedSize());
+    message.encode(bytes.data(), 0, bytes.size());
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     const SchunkWsgCommandTranslator translator;
 #pragma GCC diagnostic pop
-    translator.Deserialize(bytes.data(), bytes.size(), &decoded_command);
-    wsg_command = &decoded_command;
+    translator.Deserialize(bytes.data(), bytes.size(), result);
   }
-  DRAKE_THROW_UNLESS(wsg_command != nullptr);
-
-  result->get_mutable_value() = wsg_command->get_value();
 }
 
 void SchunkWsgCommandReceiver::CalcPositionOutput(
@@ -148,13 +137,8 @@ void SchunkWsgCommandSender::CalcCommandOutput(
   lcmt_schunk_wsg_command& command = *output;
 
   command.utime = context.get_time() * 1e6;
-  const double position =
-      this->EvalVectorInput(context, position_input_port_)->GetAtIndex(0);
-
-  command.target_position_mm = position * 1e3;
-
-  command.force =
-      this->EvalVectorInput(context, force_limit_input_port_)->GetAtIndex(0);
+  command.target_position_mm = get_position_input_port().Eval(context)[0] * 1e3;
+  command.force = get_force_limit_input_port().Eval(context)[0];
 }
 
 SchunkWsgStatusReceiver::SchunkWsgStatusReceiver()
@@ -173,10 +157,8 @@ SchunkWsgStatusReceiver::SchunkWsgStatusReceiver()
 void SchunkWsgStatusReceiver::CopyStateOut(
     const drake::systems::Context<double>& context,
     drake::systems::BasicVector<double>* output) const {
-  const AbstractValue* input = this->EvalAbstractInput(context, 0);
-  DRAKE_ASSERT(input != nullptr);
-  const auto& status = input->GetValue<lcmt_schunk_wsg_status>();
-
+  const auto& status =
+      get_status_input_port().Eval<lcmt_schunk_wsg_status>(context);
   output->SetAtIndex(0, status.actual_position_mm / 1e3);
   output->SetAtIndex(1, status.actual_speed_mm_per_s / 1e3);
 }
@@ -184,10 +166,8 @@ void SchunkWsgStatusReceiver::CopyStateOut(
 void SchunkWsgStatusReceiver::CopyForceOut(
     const drake::systems::Context<double>& context,
     drake::systems::BasicVector<double>* output) const {
-  const AbstractValue* input = this->EvalAbstractInput(context, 0);
-  DRAKE_ASSERT(input != nullptr);
-  const auto& status = input->GetValue<lcmt_schunk_wsg_status>();
-
+  const auto& status =
+      get_status_input_port().Eval<lcmt_schunk_wsg_status>(context);
   output->SetAtIndex(0, status.actual_force);
 }
 
@@ -232,25 +212,22 @@ void SchunkWsgStatusSender::OutputStatus(const Context<double>& context,
 
   // Maintain the deprecated mode for now.
   if (input_port_wsg_state_.is_valid()) {
-    DRAKE_DEMAND(!state_input_port_.is_valid());
-    const systems::BasicVector<double>* state =
-        this->EvalVectorInput(context, input_port_wsg_state_);
-    status.actual_position_mm = -2 * state->GetAtIndex(position_index_) * 1e3;
-    status.actual_speed_mm_per_s =
-        -2 * state->GetAtIndex(velocity_index_) * 1e3;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    const auto& state = get_input_port_wsg_state().Eval(context);
+#pragma GCC diagnostic pop
+    status.actual_position_mm = -2 * state[position_index_] * 1e3;
+    status.actual_speed_mm_per_s = -2 * state[velocity_index_] * 1e3;
   } else {
-    const systems::BasicVector<double>* state =
-        this->EvalVectorInput(context, state_input_port_);
+    const auto& state = get_state_input_port().Eval(context);
     // The position and speed reported in this message are between the
     // two fingers rather than the position/speed of a single finger
     // (so effectively doubled).
-    status.actual_position_mm = state->GetAtIndex(0) * 1e3;
-    status.actual_speed_mm_per_s = state->GetAtIndex(1) * 1e3;
+    status.actual_position_mm = state[0] * 1e3;
+    status.actual_speed_mm_per_s = state[1] * 1e3;
   }
 
-  const systems::BasicVector<double>* force =
-      this->EvalVectorInput(context, force_input_port_);
-  if (force) {
+  if (get_force_input_port().HasValue(context)) {
     // In drake-schunk-driver, the driver attempts to apply a sign to the
     // force value based on the last reported direction of gripper movement
     // (the gripper always reports positive values).  This does not work very
@@ -261,8 +238,8 @@ void SchunkWsgStatusSender::OutputStatus(const Context<double>& context,
     // replicate it here and instead report positive forces.
 
     // TODO(sammy-tri) once the deprecated constructor/ports are removed, this
-    // can just use force->GetAtIndex(0).
-    status.actual_force = force->get_value().cwiseAbs().sum();
+    // can just use Eval(context)[0] here.
+    status.actual_force = get_force_input_port().Eval(context).cwiseAbs().sum();
   } else {
     status.actual_force = 0;
   }

--- a/manipulation/schunk_wsg/schunk_wsg_position_controller.cc
+++ b/manipulation/schunk_wsg/schunk_wsg_position_controller.cc
@@ -53,13 +53,11 @@ SchunkWsgPdController::SchunkWsgPdController(double kp_command,
 Vector2d SchunkWsgPdController::CalcGeneralizedForce(
     const drake::systems::Context<double>& context) const {
   // Read the input ports.
-  const auto& desired_state =
-      this->EvalEigenVectorInput(context, desired_state_input_port_);
-  const double force_limit =
-      this->EvalEigenVectorInput(context, force_limit_input_port_)[0];
+  const auto& desired_state = get_desired_state_input_port().Eval(context);
+  const double force_limit = get_force_limit_input_port().Eval(context)[0];
   // TODO(russt): Declare a proper input constraint.
   DRAKE_DEMAND(force_limit > 0);
-  const auto& state = this->EvalEigenVectorInput(context, state_input_port_);
+  const auto& state = get_state_input_port().Eval(context);
 
   // f₀+f₁ = -kp_constraint*(q₀+q₁) - kd_constraint*(v₀+v₁).
   const double f0_plus_f1 = -kp_constraint_ * (state[0] + state[1]) -

--- a/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.cc
+++ b/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.cc
@@ -64,7 +64,7 @@ void SchunkWsgTrajectoryGenerator::DoCalcDiscreteVariableUpdates(
     const std::vector<const systems::DiscreteUpdateEvent<double>*>&,
     DiscreteValues<double>* discrete_state) const {
   const double desired_position =
-      this->EvalEigenVectorInput(context, desired_position_input_port_)[0];
+      get_desired_position_input_port().Eval(context)[0];
 
   // The desired position input is the distance between the fingers in meters.
   // This class generates trajectories for the negative of the distance
@@ -72,9 +72,8 @@ void SchunkWsgTrajectoryGenerator::DoCalcDiscreteVariableUpdates(
 
   double target_position = -desired_position;
 
-  const systems::BasicVector<double>* state =
-      this->EvalVectorInput(context, state_input_port_);
-  const double cur_position = 2 * state->GetAtIndex(position_index_);
+  const auto& state = get_state_input_port().Eval(context);
+  const double cur_position = 2 * state[position_index_];
 
   const SchunkWsgTrajectoryGeneratorStateVector<double>* last_traj_state =
       dynamic_cast<const SchunkWsgTrajectoryGeneratorStateVector<double>*>(
@@ -84,8 +83,7 @@ void SchunkWsgTrajectoryGenerator::DoCalcDiscreteVariableUpdates(
           &discrete_state->get_mutable_vector(0));
   new_traj_state->set_last_position(cur_position);
 
-  const double max_force =
-      this->EvalEigenVectorInput(context, force_limit_input_port_)[0];
+  const double max_force = get_force_limit_input_port().Eval(context)[0];
   new_traj_state->set_max_force(max_force);
 
   if (std::abs(last_traj_state->last_target_position() - target_position) >

--- a/manipulation/schunk_wsg/test/schunk_wsg_lcm_test.cc
+++ b/manipulation/schunk_wsg/test/schunk_wsg_lcm_test.cc
@@ -33,13 +33,9 @@ GTEST_TEST(SchunkWsgLcmTest, SchunkWsgCommandReceiverTest) {
   context->FixInputPort(
       message_input_id,
       AbstractValue::Make<lcmt_schunk_wsg_command>(initial_command));
-  EXPECT_EQ(dut.get_position_output_port()
-                .Eval<BasicVector<double>>(*context)
-                .GetAtIndex(0),
+  EXPECT_EQ(dut.get_position_output_port().Eval(*context)[0],
             initial_position);
-  EXPECT_EQ(dut.get_force_limit_output_port()
-                .Eval<BasicVector<double>>(*context)
-                .GetAtIndex(0),
+  EXPECT_EQ(dut.get_force_limit_output_port().Eval(*context)[0],
             initial_force);
 
   // Start off with the gripper closed (zero) and a command to open to
@@ -50,13 +46,9 @@ GTEST_TEST(SchunkWsgLcmTest, SchunkWsgCommandReceiverTest) {
   context->FixInputPort(
       message_input_id,
       AbstractValue::Make<lcmt_schunk_wsg_command>(initial_command));
-  EXPECT_EQ(dut.get_position_output_port()
-                .Eval<BasicVector<double>>(*context)
-                .GetAtIndex(0),
+  EXPECT_EQ(dut.get_position_output_port().Eval(*context)[0],
             0.1);
-  EXPECT_EQ(dut.get_force_limit_output_port()
-                .Eval<BasicVector<double>>(*context)
-                .GetAtIndex(0),
+  EXPECT_EQ(dut.get_force_limit_output_port().Eval(*context)[0],
             40);
 }
 
@@ -89,13 +81,9 @@ GTEST_TEST(SchunkWsgLcmTest, SchunkWsgStatusReceiverTest) {
   lcmt_schunk_wsg_status status{};
   context->FixInputPort(
       0, AbstractValue::Make<lcmt_schunk_wsg_status>(status));
-  EXPECT_TRUE(CompareMatrices(dut.get_state_output_port()
-                                  .Eval<BasicVector<double>>(*context)
-                                  .get_value(),
+  EXPECT_TRUE(CompareMatrices(dut.get_state_output_port().Eval(*context),
                               Vector2d::Zero()));
-  EXPECT_EQ(dut.get_force_output_port()
-                .Eval<BasicVector<double>>(*context)
-                .GetAtIndex(0),
+  EXPECT_EQ(dut.get_force_output_port().Eval(*context)[0],
             0.0);
 
   // Check that we can read out valid input.
@@ -105,13 +93,9 @@ GTEST_TEST(SchunkWsgLcmTest, SchunkWsgStatusReceiverTest) {
   status.actual_force = 40;
   context->FixInputPort(
       0, AbstractValue::Make<lcmt_schunk_wsg_status>(status));
-  EXPECT_TRUE(CompareMatrices(dut.get_state_output_port()
-                                  .Eval<BasicVector<double>>(*context)
-                                  .get_value(),
+  EXPECT_TRUE(CompareMatrices(dut.get_state_output_port().Eval(*context),
                               Vector2d(.1, .324)));
-  EXPECT_EQ(dut.get_force_output_port()
-                .Eval<BasicVector<double>>(*context)
-                .GetAtIndex(0),
+  EXPECT_EQ(dut.get_force_output_port().Eval(*context)[0],
             40.0);
 }
 

--- a/manipulation/schunk_wsg/test/schunk_wsg_position_controller_test.cc
+++ b/manipulation/schunk_wsg/test/schunk_wsg_position_controller_test.cc
@@ -91,13 +91,11 @@ GTEST_TEST(SchunkWsgPositionControllerTest, SimTest) {
   double force_limit = 40;
   FixInputsAndHistory(*controller, desired_position, force_limit,
                       &controller_context);
-  EXPECT_LE(controller->get_grip_force_output_port()
-                .Eval<BasicVector<double>>(controller_context)
-                .GetAtIndex(0),
+  EXPECT_LE(controller->get_grip_force_output_port().
+                Eval(controller_context)[0],
             force_limit);
-  EXPECT_GE(controller->get_grip_force_output_port()
-                .Eval<BasicVector<double>>(controller_context)
-                .GetAtIndex(0),
+  EXPECT_GE(controller->get_grip_force_output_port().
+                Eval(controller_context)[0],
             -force_limit);
 
   auto wsg_state = wsg->GetMutablePositionsAndVelocities(&wsg_context);
@@ -112,9 +110,8 @@ GTEST_TEST(SchunkWsgPositionControllerTest, SimTest) {
       Vector4d(-desired_position / 2, desired_position / 2, 0.0, 0.0),
       kTolerance));
   // The steady-state force should be near zero.
-  EXPECT_NEAR(controller->get_grip_force_output_port()
-                  .Eval<BasicVector<double>>(controller_context)
-                  .GetAtIndex(0),
+  EXPECT_NEAR(controller->get_grip_force_output_port().
+                  Eval(controller_context)[0],
               0.0, kTolerance);
 
   // Move in toward the middle of the range with lower force from the outside.
@@ -128,9 +125,8 @@ GTEST_TEST(SchunkWsgPositionControllerTest, SimTest) {
       Vector4d(-desired_position / 2, desired_position / 2, 0.0, 0.0),
       kTolerance));
   // The steady-state force should be near zero.
-  EXPECT_NEAR(controller->get_grip_force_output_port()
-                  .Eval<BasicVector<double>>(controller_context)
-                  .GetAtIndex(0),
+  EXPECT_NEAR(controller->get_grip_force_output_port().
+                  Eval(controller_context)[0],
               0.0, kTolerance);
 
   // Move to more than closed, and see that the force is at the limit.
@@ -139,17 +135,15 @@ GTEST_TEST(SchunkWsgPositionControllerTest, SimTest) {
   FixInputsAndHistory(*controller, desired_position, force_limit,
                       &controller_context);
   simulator.StepTo(3.0);
-  EXPECT_NEAR(controller->get_grip_force_output_port()
-                  .Eval<BasicVector<double>>(controller_context)
-                  .GetAtIndex(0),
+  EXPECT_NEAR(controller->get_grip_force_output_port().
+                  Eval(controller_context)[0],
               force_limit, kTolerance);
 
   // Set the position to the target and observe zero force.
   wsg_state = Vector4d(-desired_position / 2, desired_position / 2, 0.0, 0.0);
 
-  EXPECT_EQ(controller->get_grip_force_output_port()
-                .Eval<BasicVector<double>>(controller_context)
-                .GetAtIndex(0),
+  EXPECT_EQ(controller->get_grip_force_output_port().
+                Eval(controller_context)[0],
             0.0);
 }
 


### PR DESCRIPTION
Builds on #10592, stepping towards resolving the TODO there to deprecate the `System::EvalInput` family of methods.

(These systems were my original inspiration for #10592 in the first place.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10668)
<!-- Reviewable:end -->
