### PR TITLE
Update more code to use InputPort::Eval

### DIFF
--- a/automotive/bicycle_car.cc
+++ b/automotive/bicycle_car.cc
@@ -94,13 +94,11 @@ void BicycleCar<T>::DoCalcTimeDerivatives(
       dynamic_cast<const BicycleCarState<T>*>(&context_state);
   DRAKE_ASSERT(state != nullptr);
 
-  const systems::BasicVector<T>* steering =
-      this->EvalVectorInput(context, get_steering_input_port().get_index());
-  DRAKE_ASSERT(steering != nullptr);
+  const systems::BasicVector<T>& steering =
+      get_steering_input_port().template Eval<systems::BasicVector<T>>(context);
 
-  const systems::BasicVector<T>* force =
-      this->EvalVectorInput(context, get_force_input_port().get_index());
-  DRAKE_ASSERT(force != nullptr);
+  const systems::BasicVector<T>& force =
+      get_force_input_port().template Eval<systems::BasicVector<T>>(context);
 
   DRAKE_ASSERT(derivatives != nullptr);
   systems::VectorBase<T>& derivative_vector = derivatives->get_mutable_vector();
@@ -108,7 +106,7 @@ void BicycleCar<T>::DoCalcTimeDerivatives(
       dynamic_cast<BicycleCarState<T>*>(&derivative_vector);
   DRAKE_ASSERT(state_derivatives != nullptr);
 
-  ImplCalcTimeDerivatives(params, *state, *steering, *force, state_derivatives);
+  ImplCalcTimeDerivatives(params, *state, steering, force, state_derivatives);
 }
 
 template <typename T>

--- a/automotive/driving_command_mux.cc
+++ b/automotive/driving_command_mux.cc
@@ -40,14 +40,12 @@ DrivingCommandMux<T>::acceleration_input() const {
 template <typename T>
 void DrivingCommandMux<T>::CombineInputsToOutput(
     const systems::Context<T>& context, DrivingCommand<T>* output) const {
-  const systems::BasicVector<T>* steering =
-      this->EvalVectorInput(context, steering_port_index_);
-  DRAKE_DEMAND(steering->size() == 1);
-  output->set_steering_angle(steering->GetAtIndex(0));
-  const systems::BasicVector<T>* acceleration =
-      this->EvalVectorInput(context, acceleration_port_index_);
-  DRAKE_DEMAND(acceleration->size() == 1);
-  output->set_acceleration(acceleration->GetAtIndex(0));
+  const auto& steering = steering_input().Eval(context);
+  DRAKE_DEMAND(steering.size() == 1);
+  output->set_steering_angle(steering[0]);
+  const auto& acceleration = acceleration_input().Eval(context);
+  DRAKE_DEMAND(acceleration.size() == 1);
+  output->set_acceleration(acceleration[0]);
 }
 
 }  // namespace automotive

--- a/automotive/dynamic_bicycle_car.h
+++ b/automotive/dynamic_bicycle_car.h
@@ -118,15 +118,15 @@ class DynamicBicycleCar final : public systems::LeafSystem<T> {
   // Evaluates the input port and returns the scalar value of the steering
   // angle.
   const T get_steer(const systems::Context<T>& context) const {
-    return this->EvalVectorInput(context, 0)
-        ->GetAtIndex(DynamicBicycleCarInputIndices::kSteerCd);
+    return get_input_port().Eval(context)[
+        DynamicBicycleCarInputIndices::kSteerCd];
   }
 
   // Evaluates the input port and returns the scalar value of the longitudinal
   // force.
   const T get_longitudinal_force(const systems::Context<T>& context) const {
-    return this->EvalVectorInput(context, 0)
-        ->GetAtIndex(DynamicBicycleCarInputIndices::kFCpX);
+    return get_input_port().Eval(context)[
+        DynamicBicycleCarInputIndices::kFCpX];
   }
 
   // Copies the state out to the output port.

--- a/geometry/dev/scene_graph.cc
+++ b/geometry/dev/scene_graph.cc
@@ -431,16 +431,13 @@ void SceneGraph<T>::FullPoseUpdate(const GeometryContext<T>& context) const {
       const auto itr = input_source_ids_.find(source_id);
       // The source id *could* be the internal source and we skip it.
       if (itr != input_source_ids_.end()) {
-        const int pose_port = itr->second.pose_port;
-        const auto pose_port_value =
-            this->EvalAbstractInput(context, pose_port);
-        if (pose_port_value) {
-          const auto& poses =
-              pose_port_value->template GetValue<FramePoseVector<T>>();
-          mutable_state.SetFramePoses(poses);
-        } else {
+        const auto& pose_port = this->get_input_port(itr->second.pose_port);
+        if (!pose_port.HasValue(context)) {
           throw_error(source_id, "pose");
         }
+        const auto& poses =
+            pose_port.template Eval<FramePoseVector<T>>(context);
+        mutable_state.SetFramePoses(poses);
       }
     }
   }

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -397,16 +397,13 @@ void SceneGraph<T>::FullPoseUpdate(const GeometryContext<T>& context) const {
       SourceId source_id = pair.first;
       const auto itr = input_source_ids_.find(source_id);
       if (itr != input_source_ids_.end()) {
-        const int pose_port = itr->second.pose_port;
-        const auto pose_port_value =
-            this->EvalAbstractInput(context, pose_port);
-        if (pose_port_value) {
-          const auto& poses =
-              pose_port_value->template GetValue<FramePoseVector<T>>();
-          mutable_state.SetFramePoses(poses);
-        } else {
+        const auto& pose_port = this->get_input_port(itr->second.pose_port);
+        if (!pose_port.HasValue(context)) {
           throw_error(source_id, "pose");
         }
+        const auto& poses =
+            pose_port.template Eval<FramePoseVector<T>>(context);
+        mutable_state.SetFramePoses(poses);
       }
     }
   }

--- a/multibody/inverse_kinematics/minimum_distance_constraint.cc
+++ b/multibody/inverse_kinematics/minimum_distance_constraint.cc
@@ -130,9 +130,8 @@ void MinimumDistanceConstraint::DoEvalGeneric(
   y->resize(1);
 
   internal::UpdateContextConfiguration(plant_context_, plant_, x);
-  const AbstractValue* plant_geometry_query_object = plant_.EvalAbstractInput(
-      *plant_context_, plant_.get_geometry_query_input_port().get_index());
-  if (plant_geometry_query_object == nullptr) {
+  const auto& query_port = plant_.get_geometry_query_input_port();
+  if (!query_port.HasValue(*plant_context_)) {
     throw std::invalid_argument(
         "MinimumDistanceConstraint: Cannot get a valid geometry::QueryObject. "
         "Either the plant geometry_query_input_port() is not properly "
@@ -140,8 +139,8 @@ void MinimumDistanceConstraint::DoEvalGeneric(
         "incorrect. Please refer to AddMultibodyPlantSceneGraph on connecting "
         "MultibodyPlant to SceneGraph.");
   }
-  const geometry::QueryObject<double>& query_object =
-      plant_geometry_query_object->GetValue<geometry::QueryObject<double>>();
+  const auto& query_object =
+      query_port.Eval<geometry::QueryObject<double>>(*plant_context_);
 
   const std::vector<geometry::SignedDistancePair<double>>
       signed_distance_pairs =

--- a/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
@@ -63,11 +63,8 @@ AutoDiffVecXd EvalMinimumDistanceConstraintAutoDiff(
   y(0).derivatives().resize(
       math::autoDiffToGradientMatrix(plant.GetPositions(context)).cols());
   y(0).derivatives().setZero();
-  const geometry::QueryObject<AutoDiffXd>& query_object =
-      plant
-          .EvalAbstractInput(context,
-                             plant.get_geometry_query_input_port().get_index())
-          ->GetValue<geometry::QueryObject<AutoDiffXd>>();
+  const auto& query_object = plant.get_geometry_query_input_port().
+      Eval<geometry::QueryObject<AutoDiffXd>>(context);
 
   const std::vector<geometry::SignedDistancePair<double>>
       signed_distance_pairs =

--- a/multibody/plant/contact_results_to_lcm.cc
+++ b/multibody/plant/contact_results_to_lcm.cc
@@ -47,9 +47,8 @@ template <typename T>
 void ContactResultsToLcmSystem<T>::CalcLcmContactOutput(
     const Context<T>& context, lcmt_contact_results_for_viz* output) const {
   // Get input / output.
-  const auto& contact_results =
-      this->EvalAbstractInput(context, contact_result_input_port_index_)
-          ->template GetValue<ContactResults<T>>();
+  const auto& contact_results = get_contact_result_input_port().
+      template Eval<ContactResults<T>>(context);
   auto& msg = *output;
 
   // Time in microseconds.

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -912,9 +912,8 @@ MultibodyPlant<double>::CalcPointPairPenetrations(
           "However its query input port (get_geometry_query_input_port()) "
           "is not connected.");
     }
-    const geometry::QueryObject<double>& query_object =
-        this->EvalAbstractInput(context, geometry_query_port_)
-            ->template GetValue<geometry::QueryObject<double>>();
+    const auto& query_object = get_geometry_query_input_port().
+        Eval<geometry::QueryObject<double>>(context);
     return query_object.ComputePointPairPenetration();
   }
   return std::vector<PenetrationAsPointPair<double>>();
@@ -1239,9 +1238,9 @@ VectorX<T> MultibodyPlant<T>::AssembleActuationInput(
     if (instance_num_dofs == 0) {
       continue;
     }
-    Eigen::VectorBlock<const VectorX<T>> u_instance =
-        this->EvalEigenVectorInput(
-            context, instance_actuation_ports_[model_instance_index]);
+    const auto& input_port = this->get_input_port(
+        instance_actuation_ports_[model_instance_index]);
+    const auto& u_instance = input_port.Eval(context);
     actuation_input.segment(u_offset, instance_num_dofs) = u_instance;
     u_offset += instance_num_dofs;
   }

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -868,13 +868,8 @@ class SphereChainScenario {
   std::vector<geometry::PenetrationAsPointPair<double>>
   ComputePointPairPenetration() const {
     // Grab query object to test for collisions.
-    const geometry::QueryObject<double>& query_object =
-        plant_
-            ->EvalAbstractInput(
-                *plant_context_,
-                plant_->get_geometry_query_input_port().get_index())
-            ->GetValue<geometry::QueryObject<double>>();
-
+    const auto& query_object = plant_->get_geometry_query_input_port().
+        Eval<geometry::QueryObject<double>>(*plant_context_);
     return query_object.ComputePointPairPenetration();
   }
 

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -1525,9 +1525,8 @@ class LeafSystem : public System<T> {
     MaybeDeclareVectorBaseInequalityConstraint(
         "input " + std::to_string(index), model_vector,
         [this, index](const Context<T>& context) -> const VectorBase<T>& {
-          const BasicVector<T>* input = this->EvalVectorInput(context, index);
-          DRAKE_DEMAND(input != nullptr);
-          return *input;
+          return this->get_input_port(index).
+              template Eval<BasicVector<T>>(context);
         });
     return this->DeclareInputPort(NextInputPortName(std::move(name)),
                                   kVectorValued, size, random_type);

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -1446,25 +1446,26 @@ class System : public SystemBase {
 
     for (int i = 0; i < get_num_input_ports(); ++i) {
       const auto& input_port = get_input_port(i);
+      const auto& other_port = other_system.get_input_port(i);
+      if (!other_port.HasValue(other_context)) {
+        continue;
+      }
 
       if (input_port.get_data_type() == kVectorValued) {
         // For vector-valued input ports, we placewise initialize a fixed input
         // vector using the explicit conversion from double to T.
-        const BasicVector<double>* other_vec =
-            other_system.EvalVectorInput(other_context, i);
-        if (other_vec == nullptr) continue;
+        const Eigen::VectorBlock<const VectorX<double>> other_vec =
+            other_port.Eval(other_context);
         auto our_vec = this->AllocateInputVector(input_port);
         for (int j = 0; j < our_vec->size(); ++j) {
-          our_vec->SetAtIndex(j, T(other_vec->GetAtIndex(j)));
+          (*our_vec)[j] = T(other_vec[j]);
         }
         target_context->FixInputPort(i, *our_vec);
       } else if (input_port.get_data_type() == kAbstractValued) {
         // For abstract-valued input ports, we just clone the value and fix
         // it to the port.
-        const AbstractValue* other_value =
-            other_system.EvalAbstractInput(other_context, i);
-        if (other_value == nullptr) continue;
-        target_context->FixInputPort(i, other_value->Clone());
+        const auto& other_value = other_port.Eval<AbstractValue>(other_context);
+        target_context->FixInputPort(i, other_value);
       } else {
         DRAKE_ABORT_MSG("Unknown input port type.");
       }

--- a/systems/framework/test/diagram_builder_test.cc
+++ b/systems/framework/test/diagram_builder_test.cc
@@ -46,7 +46,7 @@ class ConstAndEcho final : public LeafSystem<T> {
   template <typename U>
   explicit ConstAndEcho(const ConstAndEcho<U>&) : ConstAndEcho() {}
 
-  const systems::InputPort<T>& get_vec_input_port() {
+  const systems::InputPort<T>& get_vec_input_port() const {
     return this->get_input_port(0);
   }
 
@@ -64,8 +64,8 @@ class ConstAndEcho final : public LeafSystem<T> {
   }
 
   void CalcEcho(const Context<T>& context, BasicVector<T>* echo) const {
-    const BasicVector<T>* input_vector = this->EvalVectorInput(context, 0);
-    echo->get_mutable_value() = input_vector->get_value();
+    const auto& input = this->get_vec_input_port().Eval(context);
+    echo->get_mutable_value() = input;
   }
 };
 

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -342,16 +342,10 @@ GTEST_TEST(BadDiagramTest, UnconnectedInsideInputPort) {
       diagram.GetSubsystemContext(diagram.inside(), *context);
 
   // This should get the value we just fixed above.
-  const AbstractValue* value0 =
-      diagram.inside().EvalAbstractInput(inside_context, 0);
+  EXPECT_EQ(diagram.inside().get_input_port(0).Eval(inside_context)[0], 1);
 
-  // This is neither exported, connected, nor fixed so should be null.
-  const AbstractValue* value1 =
-      diagram.inside().EvalAbstractInput(inside_context, 1);
-
-  ASSERT_NE(value0, nullptr);
-  EXPECT_EQ(value0->GetValue<BasicVector<double>>()[0], 1);
-  EXPECT_EQ(value1, nullptr);
+  // This is neither exported, connected, nor fixed so shouldn't have a value.
+  EXPECT_FALSE(diagram.inside().get_input_port(1).HasValue(inside_context));
 }
 
 /* ExampleDiagram has the following structure:
@@ -796,20 +790,14 @@ TEST_F(DiagramTest, AllocateInputs) {
   auto context = diagram_->CreateDefaultContext();
 
   for (int port = 0; port < 3; port++) {
-    const BasicVector<double>* vec = diagram_->EvalVectorInput(*context, port);
-    EXPECT_EQ(vec, nullptr);
+    EXPECT_FALSE(diagram_->get_input_port(port).HasValue(*context));
   }
-
-  // Also check that abstract evaluation returns nullptr.
-  const AbstractValue* value = diagram_->EvalAbstractInput(*context, 0);
-  EXPECT_EQ(value, nullptr);
 
   diagram_->AllocateFixedInputs(context.get());
 
   for (int port = 0; port < 3; port++) {
-    const BasicVector<double>* vec = diagram_->EvalVectorInput(*context, port);
-    EXPECT_NE(vec, nullptr);
-    EXPECT_EQ(vec->size(), kSize);
+    EXPECT_TRUE(diagram_->get_input_port(port).HasValue(*context));
+    EXPECT_EQ(diagram_->get_input_port(port).Eval(*context).size(), kSize);
   }
 }
 
@@ -1112,9 +1100,9 @@ TEST_F(DiagramOfDiagramsTest, Graphviz) {
 TEST_F(DiagramOfDiagramsTest, EvalOutput) {
   context_->EnableCaching();  // Just to be sure.
 
-  EXPECT_EQ(diagram_->EvalVectorInput(*context_, 0)->GetAtIndex(0), 8.);
-  EXPECT_EQ(diagram_->EvalVectorInput(*context_, 1)->GetAtIndex(0), 64.);
-  EXPECT_EQ(diagram_->EvalVectorInput(*context_, 2)->GetAtIndex(0), 512.);
+  EXPECT_EQ(diagram_->get_input_port(0).Eval(*context_)[0], 8.);
+  EXPECT_EQ(diagram_->get_input_port(1).Eval(*context_)[0], 64.);
+  EXPECT_EQ(diagram_->get_input_port(2).Eval(*context_)[0], 512.);
 
   // The outputs of subsystem0_ are:
   //   output0 = 8 + 64 + 512 = 584
@@ -1125,12 +1113,9 @@ TEST_F(DiagramOfDiagramsTest, EvalOutput) {
   //   output0 = 584 + 656 + 9 = 1249
   //   output1 = output0 + 584 + 656 = 2489
   //   output2 = 81 (state of integrator1_)
-  EXPECT_EQ(1249, diagram_->get_output_port(0).
-      Eval<BasicVector<double>>(*context_).GetAtIndex(0));
-  EXPECT_EQ(2489, diagram_->get_output_port(1).
-      Eval<BasicVector<double>>(*context_).GetAtIndex(0));
-  EXPECT_EQ(81, diagram_->get_output_port(2).
-      Eval<BasicVector<double>>(*context_).GetAtIndex(0));
+  EXPECT_EQ(1249, diagram_->get_output_port(0).Eval(*context_)[0]);
+  EXPECT_EQ(2489, diagram_->get_output_port(1).Eval(*context_)[0]);
+  EXPECT_EQ(81, diagram_->get_output_port(2).Eval(*context_)[0]);
 
   // Check that invalidation flows through input ports properly, either due
   // to replacing the fixed value or by modifying it.
@@ -1225,7 +1210,7 @@ GTEST_TEST(DiagramSubclassTest, TwelvePlusSevenIsNineteen) {
 // double to a function provided in the constructor.
 class PublishingSystem : public LeafSystem<double> {
  public:
-  explicit PublishingSystem(std::function<void(int)> callback)
+  explicit PublishingSystem(std::function<void(double)> callback)
       : callback_(callback) {
     this->DeclareInputPort(kVectorValued, 1);
   }
@@ -1234,7 +1219,7 @@ class PublishingSystem : public LeafSystem<double> {
   void DoPublish(
       const Context<double>& context,
       const std::vector<const PublishEvent<double>*>&) const override {
-    callback_(this->EvalVectorInput(context, 0)->get_value()[0]);
+    callback_(this->get_input_port(0).Eval(context)[0]);
   }
 
  private:
@@ -1391,19 +1376,18 @@ class Reduce : public LeafSystem<double> {
                                   &Reduce::CalcFeedthrough);
   }
 
-  const systems::InputPort<double>& get_sink_input() {
+  const systems::InputPort<double>& get_sink_input() const {
     return this->get_input_port(sink_input_);
   }
 
-  const systems::InputPort<double>& get_feedthrough_input() {
+  const systems::InputPort<double>& get_feedthrough_input() const {
     return this->get_input_port(feedthrough_input_);
   }
 
   void CalcFeedthrough(const Context<double>& context,
                        BasicVector<double>* output) const {
-    const BasicVector<double>* input_vector =
-        this->EvalVectorInput(context, feedthrough_input_);
-    output->get_mutable_value() = input_vector->get_value();
+    const auto& input = get_feedthrough_input().Eval(context);
+    output->get_mutable_value() = input;
   }
 
   optional<bool> DoHasDirectFeedthrough(int input_port, int) const override {

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -1822,14 +1822,14 @@ class SymbolicSparsitySystem : public LeafSystem<T> {
  private:
   void CalcY0(const Context<T>& context,
                     BasicVector<T>* y0) const {
-    const auto& u1 = *(this->EvalVectorInput(context, 1));
-    y0->set_value(u1.get_value());
+    const auto& u1 = this->get_input_port(1).Eval(context);
+    y0->set_value(u1);
   }
 
   void CalcY1(const Context<T>& context,
               BasicVector<T>* y1) const {
-    const auto& u0 = *(this->EvalVectorInput(context, 0));
-    y1->set_value(u0.get_value());
+    const auto& u0 = this->get_input_port(0).Eval(context);
+    y1->set_value(u0);
   }
 
   const int kSize = 1;

--- a/systems/framework/test/system_scalar_converter_test.cc
+++ b/systems/framework/test/system_scalar_converter_test.cc
@@ -49,7 +49,7 @@ class NonSymbolicSystem : public LeafSystem<T> {
     this->DeclareVectorOutputPort(
         BasicVector<T>(1),
         [this](const Context<T>& context, BasicVector<T>* output) {
-          const BasicVector<T>& input = *(this->EvalVectorInput(context, 0));
+          const auto& input = this->get_input_port(0).Eval(context);
           (*output)[0] = test::copysign_int_to_non_symbolic_scalar(
               this->magic(), input[0]);
         });

--- a/systems/lcm/translator_system.h
+++ b/systems/lcm/translator_system.h
@@ -12,43 +12,6 @@ namespace drake {
 namespace systems {
 namespace lcm {
 
-/// @cond
-namespace translator_system_detail {
-
-template <typename DataType, bool is_vector>
-struct DataTypeTraits {};
-
-// Convenience IO port getters for DataType derived from
-// systems::VectorBase<double>.
-template <typename DataType>
-struct DataTypeTraits<DataType, true> {
-  // Returns a const reference of DataType that corresponds to the first
-  // input port in @p context. Assumes that the input port is vector valued,
-  // and is of type DataType.
-  static const DataType& get_data(const System<double>& sys,
-                                  const Context<double>& context) {
-    return sys.get_input_port(0).template Eval<DataType>(context);
-  }
-};
-/// @endcond
-
-// Convenience IO port getters for DataType not derived from
-// systems::VectorBase<double>.
-template <typename DataType>
-struct DataTypeTraits<DataType, false> {
-  // Returns a const reference of DataType that corresponds to the first
-  // input port in @p context. Assumes that the input port is abstract valued,
-  // and is of type DataType.
-  static const DataType& get_data(const System<double>& sys,
-                                  const Context<double>& context) {
-    const AbstractValue* const value = sys.EvalAbstractInput(context, 0);
-    DRAKE_DEMAND(value != nullptr);
-    return value->GetValue<DataType>();
-  }
-};
-
-}  // namespace translator_system_detail
-
 /**
  * An encoding system that converts data of DataType to a Lcm message of
  * MsgType. This system has exactly one input port and one output port. The
@@ -114,9 +77,7 @@ class
 
  private:
   void EncodeMsg(const Context<double>& context, MsgType* msg) const {
-    const DataType& data = translator_system_detail::DataTypeTraits<
-        DataType, std::is_base_of<VectorBase<double>,
-                                  DataType>::value>::get_data(*this, context);
+    const auto& data = this->get_input_port(0).template Eval<DataType>(context);
     translator_->Encode(data, msg);
     translator_->EncodeTime(context.get_time(), msg);
   }
@@ -190,8 +151,7 @@ class
 
  private:
   void DecodeMsg(const Context<double>& context, DataType* vector) const {
-    const MsgType& msg =
-        this->EvalAbstractInput(context, 0)->template GetValue<MsgType>();
+    const auto& msg = this->get_input_port(0).template Eval<MsgType>(context);
     translator_->Decode(msg, vector);
   }
 

--- a/systems/primitives/test/random_source_test.cc
+++ b/systems/primitives/test/random_source_test.cc
@@ -122,7 +122,6 @@ class TestSystem : public LeafSystem<double> {
  public:
   // Make methods available.
   using LeafSystem::DeclareInputPort;
-  using LeafSystem::EvalVectorInput;
 };
 
 //      +-------------------------+

--- a/systems/sensors/dev/rgbd_camera.h
+++ b/systems/sensors/dev/rgbd_camera.h
@@ -196,9 +196,8 @@ class RgbdCamera final : public LeafSystem<double> {
 
   const geometry::dev::QueryObject<double>& get_query_object(
       const Context<double>& context) const {
-    return this
-        ->EvalAbstractInput(context, query_object_input_port_->get_index())
-        ->template GetValue<geometry::dev::QueryObject<double>>();
+    return query_object_input_port().
+        Eval<geometry::dev::QueryObject<double>>(context);
   }
 
   const InputPort<double>* query_object_input_port_{};


### PR DESCRIPTION
Builds on #10592, stepping towards resolving the TODO there to deprecate the `System::EvalInput` family of methods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10670)
<!-- Reviewable:end -->
