### PR TITLE
common: Forbid overriding AbstractValue's setters

### DIFF
--- a/common/value.h
+++ b/common/value.h
@@ -366,15 +366,15 @@ class Value : public AbstractValue {
     return std::make_unique<Value<T>>(get_value());
   }
 
-  void SetFrom(const AbstractValue& other) override {
+  void SetFrom(const AbstractValue& other) final {
     value_ = Traits::to_storage(other.GetValue<T>());
   }
 
-  void SetFromOrThrow(const AbstractValue& other) override {
+  void SetFromOrThrow(const AbstractValue& other) final {
     value_ = Traits::to_storage(other.GetValueOrThrow<T>());
   }
 
-  const std::type_info& type_info() const override {
+  const std::type_info& type_info() const final {
     return typeid(get_value());
   }
 

--- a/geometry/dev/geometry_context.cc
+++ b/geometry/dev/geometry_context.cc
@@ -12,15 +12,15 @@ GeometryContext<T>::GeometryContext(int geometry_state_index)
       geometry_state_index_(geometry_state_index) {}
 
 template<typename T>
-GeometryState<T>& GeometryContext<T>::get_mutable_geometry_state() {
+GeometryState<double>& GeometryContext<T>::get_mutable_geometry_state() {
   return this->get_mutable_state()
-      .template get_mutable_abstract_state<GeometryState<T>>(
+      .template get_mutable_abstract_state<GeometryState<double>>(
           geometry_state_index_);
 }
 
 template<typename T>
-const GeometryState<T>& GeometryContext<T>::get_geometry_state() const {
-  return this->get_state().template get_abstract_state<GeometryState<T>>(
+const GeometryState<double>& GeometryContext<T>::get_geometry_state() const {
+  return this->get_state().template get_abstract_state<GeometryState<double>>(
       geometry_state_index_);
 }
 

--- a/geometry/dev/geometry_context.h
+++ b/geometry/dev/geometry_context.h
@@ -28,10 +28,10 @@ class GeometryContext final : public systems::LeafContext<T> {
   explicit GeometryContext(int geometry_state_index);
 
   /** Returns a mutable reference of the underlying geometry state. */
-  GeometryState<T>& get_mutable_geometry_state();
+  GeometryState<double>& get_mutable_geometry_state();
 
   /** Returns a const reference of the underlying geometry state. */
-  const GeometryState<T>& get_geometry_state() const;
+  const GeometryState<double>& get_geometry_state() const;
 
  private:
   // The index of the geometry state abstract state.

--- a/geometry/dev/query_object.cc
+++ b/geometry/dev/query_object.cc
@@ -26,21 +26,22 @@ QueryObject<T>& QueryObject<T>::operator=(const QueryObject<T>&) {
 }
 
 template <typename T>
-const Isometry3<T>& QueryObject<T>::GetPoseInWorld(FrameId frame_id) const {
+const Isometry3<double>& QueryObject<T>::GetPoseInWorld(
+    FrameId frame_id) const {
   ThrowIfDefault();
   // TODO(SeanCurtis-TRI): Modify this when the cache system is in place.
   scene_graph_->FullPoseUpdate(*context_);
-  const GeometryState<T>& state = context_->get_geometry_state();
+  const GeometryState<double>& state = context_->get_geometry_state();
   return state.get_pose_in_world(frame_id);
 }
 
 template <typename T>
-const Isometry3<T>& QueryObject<T>::GetPoseInWorld(
+const Isometry3<double>& QueryObject<T>::GetPoseInWorld(
     GeometryId geometry_id) const {
   ThrowIfDefault();
   // TODO(SeanCurtis-TRI): Modify this when the cache system is in place.
   scene_graph_->FullPoseUpdate(*context_);
-  const GeometryState<T>& state = context_->get_geometry_state();
+  const GeometryState<double>& state = context_->get_geometry_state();
   return state.get_pose_in_world(geometry_id);
 }
 
@@ -67,7 +68,7 @@ void QueryObject<T>::RenderColorImage(const CameraProperties& camera,
 
   // TODO(SeanCurtis-TRI): Modify this when the cache system is in place.
   scene_graph_->FullPoseUpdate(*context_);
-  const GeometryState<T>& state = context_->get_geometry_state();
+  const GeometryState<double>& state = context_->get_geometry_state();
   return state.RenderColorImage(camera, X_WC, color_image_out, show_window);
 }
 
@@ -81,7 +82,7 @@ void QueryObject<T>::RenderColorImage(const CameraProperties& camera,
 
   // TODO(SeanCurtis-TRI): Modify this when the cache system is in place.
   scene_graph_->FullPoseUpdate(*context_);
-  const GeometryState<T>& state = context_->get_geometry_state();
+  const GeometryState<double>& state = context_->get_geometry_state();
   return state.RenderColorImage(camera, parent_frame, X_PC, color_image_out,
                                 show_window);
 }
@@ -94,7 +95,7 @@ void QueryObject<T>::RenderDepthImage(
 
   // TODO(SeanCurtis-TRI): Modify this when the cache system is in place.
   scene_graph_->FullPoseUpdate(*context_);
-  const GeometryState<T>& state = context_->get_geometry_state();
+  const GeometryState<double>& state = context_->get_geometry_state();
   return state.RenderDepthImage(camera, X_WC, depth_image_out);
 }
 
@@ -107,7 +108,7 @@ void QueryObject<T>::RenderDepthImage(const DepthCameraProperties& camera,
 
   // TODO(SeanCurtis-TRI): Modify this when the cache system is in place.
   scene_graph_->FullPoseUpdate(*context_);
-  const GeometryState<T>& state = context_->get_geometry_state();
+  const GeometryState<double>& state = context_->get_geometry_state();
   return state.RenderDepthImage(camera, parent_frame, X_PC, depth_image_out);
 }
 
@@ -120,7 +121,7 @@ void QueryObject<T>::RenderLabelImage(const CameraProperties& camera,
 
   // TODO(SeanCurtis-TRI): Modify this when the cache system is in place.
   scene_graph_->FullPoseUpdate(*context_);
-  const GeometryState<T>& state = context_->get_geometry_state();
+  const GeometryState<double>& state = context_->get_geometry_state();
   return state.RenderLabelImage(camera, X_WC, label_image_out, show_window);
 }
 
@@ -134,13 +135,13 @@ void QueryObject<T>::RenderLabelImage(const CameraProperties& camera,
 
   // TODO(SeanCurtis-TRI): Modify this when the cache system is in place.
   scene_graph_->FullPoseUpdate(*context_);
-  const GeometryState<T>& state = context_->get_geometry_state();
+  const GeometryState<double>& state = context_->get_geometry_state();
   return state.RenderLabelImage(camera, parent_frame, X_PC, label_image_out,
                                 show_window);
 }
 
 template <typename T>
-const GeometryState<T>& QueryObject<T>::geometry_state() const {
+const GeometryState<double>& QueryObject<T>::geometry_state() const {
   // TODO(SeanCurtis-TRI): Handle the "baked" query object case.
   DRAKE_DEMAND(scene_graph_ != nullptr);
   DRAKE_DEMAND(context_ != nullptr);

--- a/geometry/dev/query_object.h
+++ b/geometry/dev/query_object.h
@@ -79,7 +79,7 @@ class QueryObject {
 
   /** Provides an inspector for the topological structure of the underlying
    scene graph data (see SceneGraphInspector for details).  */
-  const SceneGraphInspector<T>& inspector() const {
+  const SceneGraphInspector<double>& inspector() const {
     return inspector_;
   }
 
@@ -92,12 +92,12 @@ class QueryObject {
   /** Reports the pose of the given frame relative to the world frame (i.e.,
    `X_WF`.
    @throws std::logic_error if `frame_id` is not a valid frame.   */
-  const Isometry3<T>& GetPoseInWorld(FrameId frame_id) const;
+  const Isometry3<double>& GetPoseInWorld(FrameId frame_id) const;
 
   /** Reports the pose of the given geometry relative to the world frame (i.e.,
    `X_WG`.
    @throws std::logic_error if `geometry_id` is not a valid frame.   */
-  const Isometry3<T>& GetPoseInWorld(GeometryId geometry_id) const;
+  const Isometry3<double>& GetPoseInWorld(GeometryId geometry_id) const;
 
   //@}
 
@@ -271,7 +271,7 @@ class QueryObject {
   // Convenience class for testing.
   friend class QueryObjectTester;
 
-  const GeometryState<T>& geometry_state() const;
+  const GeometryState<double>& geometry_state() const;
 
   void set(const GeometryContext<T>* context,
            const SceneGraph<T>* scene_graph) {
@@ -313,7 +313,7 @@ class QueryObject {
   // context).
   const GeometryContext<T>* context_{nullptr};
   const SceneGraph<T>* scene_graph_{nullptr};
-  SceneGraphInspector<T> inspector_;
+  SceneGraphInspector<double> inspector_;
 };
 
 }  // namespace dev

--- a/geometry/dev/scene_graph.h
+++ b/geometry/dev/scene_graph.h
@@ -449,7 +449,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
 
   /** Returns an inspector on the system's *model* scene graph data.
    @throw std::logic_error If a context has been allocated.*/
-  const SceneGraphInspector<T>& model_inspector() const;
+  const SceneGraphInspector<double>& model_inspector() const;
 
   /** @name         Collision filtering
    @anchor scene_graph_collision_filtering
@@ -579,8 +579,8 @@ class SceneGraph final : public systems::LeafSystem<T> {
   // A raw pointer to the default geometry state (which serves as the model for
   // allocating contexts for this system). The instance is owned by
   // model_abstract_states_.
-  GeometryState<T>* initial_state_{};
-  SceneGraphInspector<T> model_inspector_;
+  GeometryState<double>* initial_state_{};
+  SceneGraphInspector<double> model_inspector_;
 
   // TODO(SeanCurtis-TRI): Get rid of this.
   mutable bool context_has_been_allocated_{false};

--- a/geometry/dev/scene_graph_inspector.h
+++ b/geometry/dev/scene_graph_inspector.h
@@ -154,8 +154,8 @@ class SceneGraphInspector {
  private:
   // Only SceneGraph and QueryObject instances can construct
   // SceneGraphInspector instances.
-  friend class SceneGraph<T>;
-  friend class QueryObject<T>;
+  template <typename> friend class SceneGraph;
+  template <typename> friend class QueryObject;
 
   // Testing utility.
   friend class SceneGraphInspectorTester;

--- a/geometry/geometry_context.cc
+++ b/geometry/geometry_context.cc
@@ -11,15 +11,15 @@ GeometryContext<T>::GeometryContext(int geometry_state_index)
       geometry_state_index_(geometry_state_index) {}
 
 template <typename T>
-GeometryState<T>& GeometryContext<T>::get_mutable_geometry_state() {
+GeometryState<double>& GeometryContext<T>::get_mutable_geometry_state() {
   return this->get_mutable_state()
-      .template get_mutable_abstract_state<GeometryState<T>>(
+      .template get_mutable_abstract_state<GeometryState<double>>(
           geometry_state_index_);
 }
 
 template <typename T>
-const GeometryState<T>& GeometryContext<T>::get_geometry_state() const {
-  return this->get_state().template get_abstract_state<GeometryState<T>>(
+const GeometryState<double>& GeometryContext<T>::get_geometry_state() const {
+  return this->get_state().template get_abstract_state<GeometryState<double>>(
       geometry_state_index_);
 }
 

--- a/geometry/geometry_context.h
+++ b/geometry/geometry_context.h
@@ -27,10 +27,10 @@ class GeometryContext final : public systems::LeafContext<T> {
   explicit GeometryContext(int geometry_state_index);
 
   /** Returns a mutable reference of the underlying geometry state. */
-  GeometryState<T>& get_mutable_geometry_state();
+  GeometryState<double>& get_mutable_geometry_state();
 
   /** Returns a const reference of the underlying geometry state. */
-  const GeometryState<T>& get_geometry_state() const;
+  const GeometryState<double>& get_geometry_state() const;
 
  private:
   // The index of the geometry state abstract state.

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -505,7 +505,7 @@ class GeometryState {
   friend class internal::GeometryVisualizationImpl;
 
   // Allow SceneGraph unique access to the state members to perform queries.
-  friend class SceneGraph<T>;
+  template <typename> friend class SceneGraph;
 
   // Friend declaration so that the internals of the state can be confirmed in
   // unit tests.
@@ -541,6 +541,26 @@ class GeometryState {
   // @throws std::logic_error  If the ids are invalid as defined by
   // ValidateFrameIds().
   void SetFramePoses(const FramePoseVector<T>& poses);
+
+  // Sets the kinematics poses, but with scalar conversion.
+  template <typename U>
+  std::enable_if_t<!std::is_same<U, T>::value>
+  SetFramePoses(const FramePoseVector<U>& other) {
+    std::vector<FrameId> ids;
+    ids.reserve(other.size());
+    for (FrameId id : other.frame_ids()) {
+      ids.push_back(id);
+    }
+    FramePoseVector<T> poses(other.source_id(), ids);
+    poses.clear();
+    for (FrameId id : other.frame_ids()) {
+      const Isometry3<U>& other_value = other.value(id);
+      const Isometry3<T> value(other_value.matrix().unaryExpr(
+          [](const auto& elem) { return ExtractDoubleOrThrow(elem); }));
+      poses.set_value(id, value);
+    }
+    SetFramePoses(poses);
+  }
 
   // Confirms that the set of ids provided include _all_ of the frames
   // registered to the set's source id and that no extra frames are included.

--- a/geometry/query_object.cc
+++ b/geometry/query_object.cc
@@ -25,7 +25,7 @@ QueryObject<T>::ComputePointPairPenetration() const {
 
   // TODO(SeanCurtis-TRI): Modify this when the cache system is in place.
   scene_graph_->FullPoseUpdate(*context_);
-  const GeometryState<T>& state = geometry_state();
+  const GeometryState<double>& state = geometry_state();
   return state.ComputePointPairPenetration();
 }
 
@@ -36,7 +36,7 @@ QueryObject<T>::ComputeSignedDistancePairwiseClosestPoints() const {
 
   // TODO(SeanCurtis-TRI): Modify this when the cache system is in place.
   scene_graph_->FullPoseUpdate(*context_);
-  const GeometryState<T>& state = context_->get_geometry_state();
+  const GeometryState<double>& state = context_->get_geometry_state();
   return state.ComputeSignedDistancePairwiseClosestPoints();
 }
 
@@ -48,12 +48,12 @@ QueryObject<T>::ComputeSignedDistanceToPoint(
   ThrowIfDefault();
 
   scene_graph_->FullPoseUpdate(*context_);
-  const GeometryState<T>& state = context_->get_geometry_state();
+  const GeometryState<double>& state = context_->get_geometry_state();
   return state.ComputeSignedDistanceToPoint(p_WQ, threshold);
 }
 
 template <typename T>
-const GeometryState<T>& QueryObject<T>::geometry_state() const {
+const GeometryState<double>& QueryObject<T>::geometry_state() const {
   // TODO(SeanCurtis-TRI): Handle the "baked" query object case.
   DRAKE_DEMAND(scene_graph_ != nullptr);
   DRAKE_DEMAND(context_ != nullptr);

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -80,7 +80,7 @@ class QueryObject {
 
   /** Provides an inspector for the topological structure of the underlying
    scene graph data (see SceneGraphInspector for details).  */
-  const SceneGraphInspector<T>& inspector() const {
+  const SceneGraphInspector<double>& inspector() const {
     return inspector_;
   }
 
@@ -266,7 +266,7 @@ class QueryObject {
   // Convenience class for testing.
   friend class QueryObjectTester;
 
-  const GeometryState<T>& geometry_state() const;
+  const GeometryState<double>& geometry_state() const;
 
   void set(const GeometryContext<T>* context,
            const SceneGraph<T>* scene_graph) {
@@ -308,7 +308,7 @@ class QueryObject {
   // context).
   const GeometryContext<T>* context_{nullptr};
   const SceneGraph<T>* scene_graph_{nullptr};
-  SceneGraphInspector<T> inspector_;
+  SceneGraphInspector<double> inspector_;
 };
 
 }  // namespace geometry

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -31,53 +31,12 @@ using std::vector;
 // https://github.com/RobotLocomotion/drake/issues/8959
 #define GS_THROW_IF_CONTEXT_ALLOCATED ThrowIfContextAllocated(__FUNCTION__);
 
-namespace {
-template <typename T>
-class GeometryStateValue final : public Value<GeometryState<T>> {
- public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(GeometryStateValue)
-
-  GeometryStateValue() = default;
-  explicit GeometryStateValue(const GeometryState<T>& state)
-      : Value<GeometryState<T>>(state) {}
-
-  std::unique_ptr<AbstractValue> Clone() const override {
-    return make_unique<GeometryStateValue<T>>(this->get_value());
-  }
-
-  void SetFrom(const AbstractValue& other) override {
-    if (!do_double_assign(other)) {
-      Value<GeometryState<T>>::SetFrom(other);
-    }
-  }
-
-  void SetFromOrThrow(const AbstractValue& other) override {
-    if (!do_double_assign(other)) {
-      Value<GeometryState<T>>::SetFromOrThrow(other);
-    }
-  }
-
- private:
-  bool do_double_assign(const AbstractValue& other) {
-    const GeometryStateValue<double>* double_value =
-        dynamic_cast<const GeometryStateValue<double>*>(&other);
-    if (double_value) {
-      this->get_mutable_value() = double_value->get_value();
-      return true;
-    }
-    return false;
-  }
-
-  template <typename>
-  friend class GeometryStateValue;
-};
-}  // namespace
-
 template <typename T>
 SceneGraph<T>::SceneGraph()
     : LeafSystem<T>(SystemTypeTag<geometry::SceneGraph>{}) {
-  auto state_value = make_unique<GeometryStateValue<T>>();
-  initial_state_ = &state_value->template GetMutableValue<GeometryState<T>>();
+  auto state_value = make_unique<Value<GeometryState<double>>>();
+  initial_state_ =
+      &state_value->template GetMutableValue<GeometryState<double>>();
   model_inspector_.set(initial_state_);
   geometry_state_index_ = this->DeclareAbstractState(std::move(state_value));
 
@@ -98,7 +57,7 @@ SceneGraph<T>::SceneGraph(const SceneGraph<U>& other) : SceneGraph() {
   // system that hasn't had its context allocated yet. We want the converted
   // system to persist the same state.
   if (other.initial_state_ != nullptr) {
-    *initial_state_ = *(other.initial_state_->ToAutoDiffXd());
+    *initial_state_ = *other.initial_state_;
     model_inspector_.set(initial_state_);
   }
   context_has_been_allocated_ = other.context_has_been_allocated_;
@@ -364,7 +323,8 @@ void SceneGraph<T>::CalcPoseBundle(const Context<T>& context,
   }
 
   for (FrameId f_id : dynamic_frames) {
-    output->set_pose(i, g_state.get_pose_in_world(f_id));
+    const Isometry3<double>& X_WF = g_state.get_pose_in_world(f_id);
+    output->set_pose(i, X_WF.template cast<T>());
     // TODO(SeanCurtis-TRI): Handle velocity.
     ++i;
   }
@@ -379,8 +339,9 @@ void SceneGraph<T>::FullPoseUpdate(const GeometryContext<T>& context) const {
 
   using std::to_string;
 
-  const GeometryState<T>& state = context.get_geometry_state();
-  GeometryState<T>& mutable_state = const_cast<GeometryState<T>&>(state);
+  const GeometryState<double>& state = context.get_geometry_state();
+  GeometryState<double>& mutable_state =
+      const_cast<GeometryState<double>&>(state);
 
   auto throw_error = [](SourceId source_id, const std::string& origin) {
     throw std::logic_error("Source " + to_string(source_id) +

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -639,7 +639,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
   // A raw pointer to the default geometry state (which serves as the model for
   // allocating contexts for this system). The instance is owned by
   // model_abstract_states_.
-  GeometryState<T>* initial_state_{};
+  GeometryState<double>* initial_state_{};
   SceneGraphInspector<T> model_inspector_;
 
   // TODO(SeanCurtis-TRI): Get rid of this.

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -87,7 +87,7 @@ class SceneGraphInspector {
    @endcode
 
    This includes the id for the world frame.  */
-  typename GeometryState<T>::FrameIdRange all_frame_ids() const {
+  typename GeometryState<double>::FrameIdRange all_frame_ids() const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->get_frame_ids();
   }
@@ -346,8 +346,8 @@ class SceneGraphInspector {
  private:
   // Only SceneGraph and QueryObject instances can construct
   // SceneGraphInspector instances.
-  friend class SceneGraph<T>;
-  friend class QueryObject<T>;
+  template <typename> friend class SceneGraph;
+  template <typename> friend class QueryObject;
 
   // Testing utility.
   friend class SceneGraphInspectorTester;
@@ -358,9 +358,9 @@ class SceneGraphInspector {
   // Sets the scene graph data to inspect -- the inspector does _not_ own the
   // data and expects that the lifespan of the provided data is longer than
   // the inspector.
-  void set(const GeometryState<T>* state) { state_ = state; }
+  void set(const GeometryState<double>* state) { state_ = state; }
 
-  const GeometryState<T>* state_{nullptr};
+  const GeometryState<double>* state_{nullptr};
 };
 
 }  // namespace geometry

--- a/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
@@ -79,7 +79,7 @@ AutoDiffVecXd EvalMinimumDistanceConstraintAutoDiff(
       const double sign = distance > 0 ? 1 : -1;
 
       Vector3<AutoDiffXd> p_WCa, p_WCb;
-      const geometry::SceneGraphInspector<AutoDiffXd>& inspector =
+      const geometry::SceneGraphInspector<double>& inspector =
           query_object.inspector();
       const geometry::FrameId frame_A_id =
           inspector.GetFrameId(signed_distance_pair.id_A);


### PR DESCRIPTION
As a result, the poses in GeometryState no longer track the scalar type -- they are always doubles (no derivatives).  It is not (yet) supported to have T-dependent abstract state (or parameters, etc.) in a System.  Hacking around it by overriding the type-erasure framework just makes every else's life awful, and we should not do it.

Reworks #7421.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10674)
<!-- Reviewable:end -->
