### PR TITLE
common: Deprecate old Value APIs

### DIFF
--- a/common/value.h
+++ b/common/value.h
@@ -9,6 +9,7 @@
 
 #include "drake/common/copyable_unique_ptr.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/hash.h"
 #include "drake/common/is_cloneable.h"
 #include "drake/common/nice_type_name.h"
@@ -102,34 +103,29 @@ class AbstractValue {
   template <typename T>
   const T* maybe_get_value() const;
 
-  // TODO(jwnimmer-tri) Deprecate me.
-  /// (To be deprecated.)
   /// Returns the value wrapped in this AbstractValue, which must be of
   /// exactly type T.  T cannot be a superclass, abstract or otherwise.
   /// In Debug builds, if the types don't match, an std::logic_error will be
   /// thrown with a helpful error message. In Release builds, this is not
   /// guaranteed.
   template <typename T>
+  DRAKE_DEPRECATED("2019-07-01", "Use get_value<T>() instead.")
   const T& GetValue() const;
 
-  // TODO(jwnimmer-tri) Deprecate me.
-  /// (To be deprecated.)
   /// Like GetValue, but throws std::logic_error on mismatched types even in
   /// Release builds.
   template <typename T>
+  DRAKE_DEPRECATED("2019-07-01", "Use get_value<T>() instead.")
   const T& GetValueOrThrow() const;
 
-  // TODO(jwnimmer-tri) Deprecate me.
-  /// (To be deprecated.)
   /// Like GetValue, but quietly returns nullptr on mismatched types,
   /// even in Release builds.
   /// @returns A pointer to the stored value if T is the right type,
   ///          otherwise nullptr.
   template <typename T>
+  DRAKE_DEPRECATED("2019-07-01", "Use maybe_get_value<T>() instead.")
   const T* MaybeGetValue() const;
 
-  // TODO(jwnimmer-tri) Deprecate me.
-  /// (To be deprecated.)
   /// Returns the value wrapped in this AbstractValue, which must be of
   /// exactly type T.  T cannot be a superclass, abstract or otherwise.
   /// In Debug builds, if the types don't match, an std::logic_error will be
@@ -137,17 +133,15 @@ class AbstractValue {
   /// guaranteed. Intentionally not const: holders of const references to the
   /// AbstractValue should not be able to mutate the value it contains.
   template <typename T>
+  DRAKE_DEPRECATED("2019-07-01", "Use get_mutable_value<T>() instead.")
   T& GetMutableValue();
 
-  // TODO(jwnimmer-tri) Deprecate me.
-  /// (To be deprecated.)
   /// Like GetMutableValue, but throws std::logic_error on mismatched types even
   /// in Release builds.
   template <typename T>
+  DRAKE_DEPRECATED("2019-07-01", "Use get_mutable_value<T>() instead.")
   T& GetMutableValueOrThrow();
 
-  // TODO(jwnimmer-tri) Deprecate me.
-  /// (To be deprecated.)
   /// Sets the value wrapped in this AbstractValue, which must be of
   /// exactly type T.  T cannot be a superclass, abstract or otherwise.
   /// @param value_to_set The value to be copied or cloned into this
@@ -155,12 +149,12 @@ class AbstractValue {
   /// an std::logic_error will be thrown with a helpful error message. In
   /// Release builds, this is not guaranteed.
   template <typename T>
+  DRAKE_DEPRECATED("2019-07-01", "Use set_value<T>() instead.")
   void SetValue(const T& value_to_set);
 
-  // TODO(jwnimmer-tri) Deprecate me.
-  /// (To be deprecated.)
   /// Like SetValue, but throws on mismatched types even in Release builds.
   template <typename T>
+  DRAKE_DEPRECATED("2019-07-01", "Use set_value<T>() instead.")
   void SetValueOrThrow(const T& value_to_set);
 
   /// Returns a copy of this AbstractValue.
@@ -171,10 +165,9 @@ class AbstractValue {
   /// message.
   virtual void SetFrom(const AbstractValue& other) = 0;
 
-  // TODO(jwnimmer-tri) Deprecate me.
-  /// (To be deprecated.)
   /// Like SetFrom, but throws std::logic_error on mismatched types even in
   /// Release builds.
+  DRAKE_DEPRECATED("2019-07-01", "Use SetFrom() instead.")
   virtual void SetFromOrThrow(const AbstractValue& other) = 0;
 
   /// Returns typeid of the contained object of type T. If T is polymorphic,
@@ -736,7 +729,10 @@ void Value<T>::SetFrom(const AbstractValue& other) {
 
 template <typename T>
 void Value<T>::SetFromOrThrow(const AbstractValue& other) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   value_ = Traits::to_storage(other.GetValueOrThrow<T>());
+#pragma GCC diagnostic pop
 }
 
 template <typename T>

--- a/multibody/plant/test/box_test.cc
+++ b/multibody/plant/test/box_test.cc
@@ -106,9 +106,9 @@ GTEST_TEST(Box, UnderStiction) {
   std::unique_ptr<AbstractValue> contact_results_value =
       plant.get_contact_results_output_port().Allocate();
   EXPECT_NO_THROW(
-      contact_results_value->GetValueOrThrow<ContactResults<double>>());
+      contact_results_value->get_value<ContactResults<double>>());
   const ContactResults<double>& contact_results =
-      contact_results_value->GetValueOrThrow<ContactResults<double>>();
+      contact_results_value->get_value<ContactResults<double>>();
   // Compute the poses for each geometry in the model.
   plant.get_contact_results_output_port().Calc(
       plant_context, contact_results_value.get());

--- a/multibody/plant/test/inclined_plane_test.cc
+++ b/multibody/plant/test/inclined_plane_test.cc
@@ -180,9 +180,9 @@ TEST_P(InclinedPlaneTest, RollingSphereTest) {
     auto contact_forces_value = contact_forces_port.Allocate();
     // Verify the correct type.
     EXPECT_NO_THROW(
-        contact_forces_value->GetValueOrThrow<BasicVector<double>>());
+        contact_forces_value->get_value<BasicVector<double>>());
     const BasicVector<double>& contact_forces =
-        contact_forces_value->GetValueOrThrow<BasicVector<double>>();
+        contact_forces_value->get_value<BasicVector<double>>();
     EXPECT_EQ(contact_forces.size(), 6);
     // Compute the generalized contact forces using the system's API.
     contact_forces_port.Calc(plant_context, contact_forces_value.get());


### PR DESCRIPTION
The goal here is to remove the notion of accessors being either "checked" vs "unchecked" with respect to verifying the user-provided `T`.  All accessors all checked now, but with a very fast implementation that catches _almost_ all errors (it uses 64-bit hash mismatches to reject bad `Ts`) in Release mode, and _all_ errors in Debug mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10678)
<!-- Reviewable:end -->
