### PR TITLE
Added getters and setters for the actuation input in MultibodyPlant.

### DIFF
--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1705,7 +1705,7 @@ VectorX<T> MultibodyPlant<T>::GetActuationInput(
 
 template <typename T>
 void MultibodyPlant<T>::SetActuationInput(Context<T>* context,
-                                          const VectorX<T> u) const {
+                                          const VectorX<T>& u) const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
   DRAKE_THROW_UNLESS(actuated_instance_.is_valid());
   SetActuationInput(context, u, actuated_instance_);
@@ -1713,7 +1713,7 @@ void MultibodyPlant<T>::SetActuationInput(Context<T>* context,
 
 template <typename T>
 void MultibodyPlant<T>::SetActuationInput(
-    Context<T>* context, const VectorX<T> u,
+    Context<T>* context, const VectorX<T>& u,
     ModelInstanceIndex model_instance) const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
   DRAKE_THROW_UNLESS(model_instance.is_valid());

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1682,6 +1682,49 @@ void MultibodyPlant<T>::DeclareStateCacheAndPorts() {
 }
 
 template <typename T>
+VectorX<T> MultibodyPlant<T>::GetActuationInput(
+    const Context<T>& context) const {
+  DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+  DRAKE_THROW_UNLESS(actuated_instance_.is_valid());
+  return GetActuationInput(context, actuated_instance_);
+}
+
+template <typename T>
+VectorX<T> MultibodyPlant<T>::GetActuationInput(
+    const Context<T>& context, ModelInstanceIndex model_instance) const {
+  DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+  DRAKE_THROW_UNLESS(model_instance.is_valid());
+  DRAKE_THROW_UNLESS(model_instance < num_model_instances());
+
+  if (num_actuated_dofs(model_instance) == 0) {
+    return VectorX<T>(0);
+  } else {
+    return get_actuation_input_port(model_instance).Eval(context);
+  }
+}
+
+template <typename T>
+void MultibodyPlant<T>::SetActuationInput(Context<T>* context,
+                                          const VectorX<T> u) const {
+  DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+  DRAKE_THROW_UNLESS(actuated_instance_.is_valid());
+  SetActuationInput(context, u, actuated_instance_);
+}
+
+template <typename T>
+void MultibodyPlant<T>::SetActuationInput(
+    Context<T>* context, const VectorX<T> u,
+    ModelInstanceIndex model_instance) const {
+  DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+  DRAKE_THROW_UNLESS(model_instance.is_valid());
+  DRAKE_THROW_UNLESS(model_instance < num_model_instances());
+  if (num_actuated_dofs(model_instance) > 0) {
+    context->FixInputPort(get_actuation_input_port(model_instance).get_index(),
+                          u);
+  }
+}
+
+template <typename T>
 const systems::BasicVector<T>& MultibodyPlant<T>::GetStateVector(
     const Context<T>& context) const {
   if (is_discrete()) {

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -308,7 +308,7 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   }
 
   /// Returns the vector `u` of the model corresponding to the actuation
-  /// input corresponding to the given model instance
+  /// input.
   /// Unlike get_actuation_input_port, this can be called even if there are
   /// no actuators, in which case it will return 0-length vector
   /// @pre Finalize() was already called on `this` plant.
@@ -331,14 +331,14 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   /// @throws std::exception if called before Finalize()
   /// @throws std::exception if u has incorrect dimensions
   void SetActuationInput(systems::Context<T>* context,
-                         const VectorX<T> u) const;
+                         const VectorX<T>& u) const;
 
   /// Sets the vector `u` in the context corresponding to the actuation
   /// input corresponding to the given model instance.
   /// @pre Finalize() was already called on `this` plant.
   /// @throws std::exception if called before Finalize()
   /// @throws std::exception if u has incorrect dimensions
-  void SetActuationInput(systems::Context<T>* context, const VectorX<T> u,
+  void SetActuationInput(systems::Context<T>* context, const VectorX<T>& u,
                          ModelInstanceIndex model_instance) const;
 
   /// @name Position and velocity state component accessors and mutators.

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -307,6 +307,40 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
     return internal_tree().num_actuated_dofs(model_instance);
   }
 
+  /// Returns the vector `u` of the model corresponding to the actuation
+  /// input corresponding to the given model instance
+  /// Unlike get_actuation_input_port, this can be called even if there are
+  /// no actuators, in which case it will return 0-length vector
+  /// @pre Finalize() was already called on `this` plant.
+  /// @throws std::exception if called before Finalize()
+  VectorX<T> GetActuationInput(const systems::Context<T>& context) const;
+
+  /// Returns the vector `u` of the model corresponding to the actuation
+  /// input corresponding to the given model instance.
+  /// Unlike get_actuation_input_port, this can be called even if there are
+  /// no actuators, in which case it will return 0-length vector
+  /// @pre Finalize() was already called on `this` plant.
+  /// @throws std::exception if called before Finalize()
+  /// @throws std::exception if the model instance does not exist.
+  VectorX<T> GetActuationInput(const systems::Context<T>& context,
+                               ModelInstanceIndex model_instance) const;
+
+  /// Sets the vector `u` in the context corresponding to the actuation
+  /// input.
+  /// @pre Finalize() was already called on `this` plant.
+  /// @throws std::exception if called before Finalize()
+  /// @throws std::exception if u has incorrect dimensions
+  void SetActuationInput(systems::Context<T>* context,
+                         const VectorX<T> u) const;
+
+  /// Sets the vector `u` in the context corresponding to the actuation
+  /// input corresponding to the given model instance.
+  /// @pre Finalize() was already called on `this` plant.
+  /// @throws std::exception if called before Finalize()
+  /// @throws std::exception if u has incorrect dimensions
+  void SetActuationInput(systems::Context<T>* context, const VectorX<T> u,
+                         ModelInstanceIndex model_instance) const;
+
   /// @name Position and velocity state component accessors and mutators.
   /// Various methods for accessing and mutating `[q; v]`, where `q` is the
   /// vector of generalized positions and `v` is the vector of generalized


### PR DESCRIPTION
These are syntatic sugar to make translation between a Context and the `u` vector easier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10685)
<!-- Reviewable:end -->
