### PR TITLE
Allow explicitly setting the rotation distribution for free bodies.

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -53,6 +53,7 @@ drake_cc_library(
         "//geometry:geometry_ids",
         "//geometry:geometry_visualization",
         "//geometry:scene_graph",
+        "//math:geometric_transform",
         "//math:orthonormal_basis",
         "//multibody/tree",
         "//systems/framework:diagram_builder",

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -11,6 +11,7 @@
 #include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/geometry_visualization.h"
 #include "drake/math/orthonormal_basis.h"
+#include "drake/math/random_rotation.h"
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/plant/externally_applied_spatial_force.h"
 #include "drake/multibody/tree/prismatic_joint.h"
@@ -252,6 +253,15 @@ MultibodyPlant<T>::MultibodyPlant(
   DRAKE_THROW_UNLESS(time_step >= 0);
   visual_geometries_.emplace_back();  // Entries for the "world" body.
   collision_geometries_.emplace_back();
+}
+
+template<typename T>
+void MultibodyPlant<T>::SetFreeBodyRandomRotationDistributionToUniform(
+    const Body<T>& body) {
+  RandomGenerator generator;
+  auto q_FM =
+      math::UniformlyRandomQuaternion<symbolic::Expression>(&generator);
+  SetFreeBodyRandomRotationDistribution(body, q_FM);
 }
 
 template<typename T>

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -419,6 +419,9 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
         body, V_WB, context, state);
   }
 
+  // TODO(sammy-tri) We should also be able to set the default pose of a free
+  // body.  See https://github.com/RobotLocomotion/drake/issues/10713
+
   /// Sets the distribution used by SetRandomState() to populate the
   /// x-y-z `position` component of the floating-base state.
   /// @throws std::exception if `body` is not a free body in the model.
@@ -430,14 +433,22 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   }
 
   /// Sets the distribution used by SetRandomState() to populate the
+  /// rotation component of the floating-base state.
+  /// @throws std::exception if `body` is not a free body in the model.
+  /// @throws std::exception if called pre-finalize.
+  void SetFreeBodyRandomRotationDistribution(
+      const Body<T>& body,
+      const Eigen::Quaternion<symbolic::Expression>& rotation) {
+    this->mutable_tree().SetFreeBodyRandomRotationDistributionOrThrow(
+        body, rotation);
+  }
+
+  /// Sets the distribution used by SetRandomState() to populate the
   /// rotation component of the floating-base state using uniformly random
   /// rotations.
   /// @throws std::exception if `body` is not a free body in the model.
   /// @throws std::exception if called pre-finalize.
-  void SetFreeBodyRandomRotationDistributionToUniform(const Body<T>& body) {
-    this->mutable_tree().SetFreeBodyRandomRotationDistributionToUniformOrThrow(
-        body);
-  }
+  void SetFreeBodyRandomRotationDistributionToUniform(const Body<T>& body);
 
   /// Sets all generalized positions and velocities from the given vector
   /// [q; v].

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -2407,7 +2407,7 @@ GTEST_TEST(SetRandomTest, FloatingBodies) {
       plant.GetFreeBodyPose(*context, body);
 
   plant.SetRandomContext(context.get(), &generator);
-  const math::RigidTransform<double> X_WB =
+  math::RigidTransform<double> X_WB =
       plant.GetFreeBodyPose(*context, body);
 
   // Just make sure that the rotation matrices have changed. (Testing that
@@ -2428,6 +2428,21 @@ GTEST_TEST(SetRandomTest, FloatingBodies) {
   // z is drawn from [3, 4).
   EXPECT_GE(X_WB.translation()[2], 3.0);
   EXPECT_LT(X_WB.translation()[2], 4.0);
+
+  // Check that we can set the rotation to a specific distribution (in this
+  // case it's just constant).
+  const math::RotationMatrix<double> X_WB_new(
+      math::RollPitchYaw<double>(0.3, 0.4, 0.5));
+  plant.SetFreeBodyRandomRotationDistribution(
+      body, X_WB_new.cast<symbolic::Expression>().ToQuaternion());
+
+  plant.SetRandomContext(context.get(), &generator);
+  X_WB = plant.GetFreeBodyPose(*context, body);
+
+  const double kTolerance = 5 * std::numeric_limits<double>::epsilon();
+  EXPECT_TRUE(CompareMatrices(
+      X_WB_new.matrix(), X_WB.rotation().matrix(),
+      kTolerance, MatrixCompareType::relative));
 }
 
 }  // namespace

--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -355,6 +355,7 @@ drake_cc_googletest(
         ":mobilizer_tester",
         ":tree",
         "//common/test_utilities:eigen_matrix_compare",
+        "//math:geometric_transform",
     ],
 )
 

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -424,12 +424,13 @@ void MultibodyTree<T>::SetFreeBodyRandomPositionDistributionOrThrow(
 }
 
 template <typename T>
-void MultibodyTree<T>::SetFreeBodyRandomRotationDistributionToUniformOrThrow(
-    const Body<T>& body) {
+void MultibodyTree<T>::SetFreeBodyRandomRotationDistributionOrThrow(
+    const Body<T>& body,
+    const Eigen::Quaternion<symbolic::Expression>& rotation) {
   DRAKE_MBT_THROW_IF_NOT_FINALIZED();
   QuaternionFloatingMobilizer<T>& mobilizer =
       get_mutable_variant(GetFreeBodyMobilizerOrThrow(body));
-  mobilizer.set_random_quaternion_distribution_to_uniform();
+  mobilizer.set_random_quaternion_distribution(rotation);
 }
 
 template <typename T>

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -1184,9 +1184,10 @@ class MultibodyTree {
       const Body<T>& body,
       const Vector3<symbolic::Expression>& position);
 
-  /// See MultibodyPlant::SetFreeBodyRandomRotationDistributionToUniform.
-  void SetFreeBodyRandomRotationDistributionToUniformOrThrow(
-      const Body<T>& body);
+  /// See MultibodyPlant::SetFreeBodyRandomRotationDistribution.
+  void SetFreeBodyRandomRotationDistributionOrThrow(
+      const Body<T>& body,
+      const Eigen::Quaternion<symbolic::Expression>& rotation);
 
   /// @name Kinematic computations
   /// Kinematics computations are concerned with the motion of bodies in the

--- a/multibody/tree/quaternion_floating_mobilizer.cc
+++ b/multibody/tree/quaternion_floating_mobilizer.cc
@@ -4,7 +4,6 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/math/quaternion.h"
-#include "drake/math/random_rotation.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/tree/multibody_tree.h"
 
@@ -97,16 +96,14 @@ void QuaternionFloatingMobilizer<T>::set_random_position_distribution(
 
 template <typename T>
 void QuaternionFloatingMobilizer<
-    T>::set_random_quaternion_distribution_to_uniform() {
+    T>::set_random_quaternion_distribution(
+        const Eigen::Quaternion<symbolic::Expression>& q_FM) {
   Vector<symbolic::Expression, kNq> positions;
   if (this->get_random_state_distribution()) {
     positions = this->get_random_state_distribution()->template head<kNq>();
   } else {
     positions = get_zero_position().template cast<symbolic::Expression>();
   }
-  RandomGenerator generator;
-  auto q_FM =
-      math::UniformlyRandomQuaternion<symbolic::Expression>(&generator);
   positions[0] = q_FM.w();
   positions.template segment<3>(1) = q_FM.vec();
   MobilizerBase::set_random_position_distribution(positions);

--- a/multibody/tree/quaternion_floating_mobilizer.h
+++ b/multibody/tree/quaternion_floating_mobilizer.h
@@ -94,9 +94,10 @@ class QuaternionFloatingMobilizer final : public MobilizerImpl<T, 7, 6> {
       const systems::Context<T>& context,
       const Quaternion<T>& q_FM, systems::State<T>* state) const;
 
-  /// Specifies that random samples for the rotation elements of the state
-  /// should be drawn as uniformly random quaternions.
-  void set_random_quaternion_distribution_to_uniform();
+  /// Sets the distribution governing the random samples of the rotation
+  /// component of the mobilizer state.
+  void set_random_quaternion_distribution(
+      const Eigen::Quaternion<symbolic::Expression>& q_FM);
 
   /// Sets `context` to store the position `p_FM` of frame M's origin `Mo`
   /// measured and expressed in frame F.

--- a/multibody/tree/test/quaternion_floating_mobilizer_test.cc
+++ b/multibody/tree/test/quaternion_floating_mobilizer_test.cc
@@ -4,6 +4,7 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/math/random_rotation.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/tree/multibody_tree-inl.h"
@@ -100,7 +101,8 @@ TEST_F(QuaternionFloatingMobilizerTest, RandomState) {
   }
 
   // Set position to be random, but not velocity (yet).
-  mutable_mobilizer->set_random_quaternion_distribution_to_uniform();
+  mutable_mobilizer->set_random_quaternion_distribution(
+      math::UniformlyRandomQuaternion<symbolic::Expression>(&generator));
   mutable_mobilizer->set_random_position_distribution(position_distribution);
   mutable_mobilizer->set_random_state(*context_, &context_->get_mutable_state(),
                                       &generator);


### PR DESCRIPTION
I originally felt a bit bad about this because:

 * The uniform quaternion is probably the only value which really makes sense
 * My actual use case is for setting a constant rotation to go along with a random position, which is not obvious from this change.

However some further discussion pointed out that setting state from a distribution seems generally like a good idea.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10693)
<!-- Reviewable:end -->
