### PR TITLE
common: Add kDrakeAssertIsArmed globals

### DIFF
--- a/common/drake_assert.h
+++ b/common/drake_assert.h
@@ -29,6 +29,9 @@
 /// This header will define exactly one of either @p DRAKE_ASSERT_IS_ARMED or
 /// @p DRAKE_ASSERT_IS_DISARMED to indicate whether @p DRAKE_ASSERT is armed.
 ///
+/// This header will define both `constexpr bool drake::kDrakeAssertIsArmed`
+/// and `constexpr bool drake::kDrakeAssertIsDisarmed` globals.
+///
 /// One difference versus the standard @p assert(condition) is that the
 /// @p condition within @p DRAKE_ASSERT is always syntax-checked, even if
 /// Drake's assertions are disarmed.
@@ -139,6 +142,10 @@ struct ConditionTraits {
 
 #ifdef DRAKE_ASSERT_IS_ARMED
 // Assertions are enabled.
+namespace drake {
+constexpr bool kDrakeAssertIsArmed = true;
+constexpr bool kDrakeAssertIsDisarmed = false;
+}  // namespace drake
 # define DRAKE_ASSERT(condition) DRAKE_DEMAND(condition)
 # define DRAKE_ASSERT_VOID(expression) do {                     \
     static_assert(                                              \
@@ -148,6 +155,10 @@ struct ConditionTraits {
   } while (0)
 #else
 // Assertions are disabled, so just typecheck the expression.
+namespace drake {
+constexpr bool kDrakeAssertIsArmed = false;
+constexpr bool kDrakeAssertIsDisarmed = true;
+}  // namespace drake
 # define DRAKE_ASSERT(condition) static_assert(                        \
     ::drake::assert::ConditionTraits<                                  \
         typename std::remove_cv<decltype(condition)>::type>::is_valid, \

--- a/common/test/drake_assert_test.cc
+++ b/common/test/drake_assert_test.cc
@@ -7,6 +7,23 @@
 
 namespace {
 
+GTEST_TEST(DrakeAssertTest, MatchingConfigTest) {
+#ifdef DRAKE_ASSERT_IS_ARMED
+  EXPECT_TRUE(::drake::kDrakeAssertIsArmed);
+  EXPECT_FALSE(::drake::kDrakeAssertIsDisarmed);
+#else
+  EXPECT_FALSE(::drake::kDrakeAssertIsArmed);
+  EXPECT_TRUE(::drake::kDrakeAssertIsDisarmed);
+#endif
+#ifdef DRAKE_ASSERT_IS_DISARMED
+  EXPECT_FALSE(::drake::kDrakeAssertIsArmed);
+  EXPECT_TRUE(::drake::kDrakeAssertIsDisarmed);
+#else
+  EXPECT_TRUE(::drake::kDrakeAssertIsArmed);
+  EXPECT_FALSE(::drake::kDrakeAssertIsDisarmed);
+#endif
+}
+
 GTEST_TEST(DrakeAssertDeathTest, AbortTest) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 #pragma GCC diagnostic push
@@ -40,24 +57,27 @@ GTEST_TEST(DrakeAssertDeathTest, AssertSyntaxTest) {
   DRAKE_ASSERT(BoolConvertible());
 }
 
-// Only run these tests if assertions are armed.
-#ifdef DRAKE_ASSERT_IS_ARMED
-
 GTEST_TEST(DrakeAssertDeathTest, AssertFalseTest) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-  ASSERT_DEATH(
-      { DRAKE_ASSERT(2 + 2 == 5); },
-      "abort: Failure at .*drake_assert_test.cc:.. in TestBody..: "
-      "condition '2 \\+ 2 == 5' failed");
+  if (::drake::kDrakeAssertIsArmed) {
+    ASSERT_DEATH(
+        { DRAKE_ASSERT(2 + 2 == 5); },
+        "abort: Failure at .*drake_assert_test.cc:.. in TestBody..: "
+        "condition '2 \\+ 2 == 5' failed");
+  } else {
+    DRAKE_ASSERT(2 + 2 == 5);
+  }
 }
 
 GTEST_TEST(DrakeAssertDeathTest, AssertVoidTestArmed) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-  ASSERT_DEATH(
-      { DRAKE_ASSERT_VOID(::abort()); },
-      "");
+  if (::drake::kDrakeAssertIsArmed) {
+    ASSERT_DEATH(
+        { DRAKE_ASSERT_VOID(::abort()); },
+        "");
+  } else {
+    DRAKE_ASSERT_VOID(::abort());
+  }
 }
-
-#endif  //  DRAKE_ASSERT_IS_ARMED
 
 }  // namespace

--- a/common/test/pointer_cast_test.cc
+++ b/common/test/pointer_cast_test.cc
@@ -114,7 +114,7 @@ GTEST_TEST(DynamicPointerCastOrThrowTest, FailedCastFromNullptr) {
       dynamic_pointer_cast_or_throw<MoreDerived>(std::move(u)),
       std::logic_error,
       "Cannot cast a unique_ptr<drake.*Base> containing nullptr "
-      "to unique_ptr<drake.*MoreDerived>.")
+      "to unique_ptr<drake.*MoreDerived>.");
   EXPECT_EQ(!!u, false);
 }
 
@@ -125,7 +125,7 @@ GTEST_TEST(DynamicPointerCastOrThrowTest, FailedDowncast) {
       dynamic_pointer_cast_or_throw<MoreDerived>(std::move(u)),
       std::logic_error,
       "Cannot cast a unique_ptr<drake.*Base> containing an object of type "
-      "drake.*Derived to unique_ptr<drake.*MoreDerived>.")
+      "drake.*Derived to unique_ptr<drake.*MoreDerived>.");
   EXPECT_EQ(!!u, true);
 }
 

--- a/common/test_utilities/BUILD.bazel
+++ b/common/test_utilities/BUILD.bazel
@@ -61,6 +61,7 @@ drake_cc_library(
     name = "expect_throws_message",
     testonly = 1,
     hdrs = ["expect_throws_message.h"],
+    deps = ["//common:essential"],
 )
 
 drake_cc_library(

--- a/geometry/test/frame_kinematics_vector_test.cc
+++ b/geometry/test/frame_kinematics_vector_test.cc
@@ -102,7 +102,7 @@ GTEST_TEST(FrameKinematicsVector, WorkingWithValues) {
   DRAKE_EXPECT_THROWS_MESSAGE(poses.value(FrameId::get_new_id()),
                               std::runtime_error,
                               "Can't acquire value for id \\d+. It is not part "
-                              "of the kinematics data id set.")
+                              "of the kinematics data id set.");
 }
 
 GTEST_TEST(FrameKinematicsVector, AutoDiffInstantiation) {

--- a/geometry/test/identifier_test.cc
+++ b/geometry/test/identifier_test.cc
@@ -193,13 +193,12 @@ TEST_F(IdentifierTests, Convertible) {
 }
 
 // Suite of tests to catch the debug-build assertions.
-#ifndef DRAKE_ASSERT_IS_DISARMED
-
 class IdentifierDeathTests : public IdentifierTests {};
 
 // Attempting to acquire the value is an error.
 TEST_F(IdentifierDeathTests, InvalidGetValueCall) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  if (kDrakeAssertIsDisarmed) { return; }
   AId invalid;
   int64_t value = -1;
   ASSERT_DEATH(
@@ -211,8 +210,9 @@ TEST_F(IdentifierDeathTests, InvalidGetValueCall) {
 }
 
 // Comparison of invalid ids is an error.
-TEST_F(IdentifierDeathTests, InvlalidEqualityCompare) {
+TEST_F(IdentifierDeathTests, InvalidEqualityCompare) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  if (kDrakeAssertIsDisarmed) { return; }
   AId invalid;
   bool result = true;
   EXPECT_DEATH(
@@ -224,8 +224,9 @@ TEST_F(IdentifierDeathTests, InvlalidEqualityCompare) {
 }
 
 // Comparison of invalid ids is an error.
-TEST_F(IdentifierDeathTests, InvlalidInequalityCompare) {
+TEST_F(IdentifierDeathTests, InvalidInequalityCompare) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  if (kDrakeAssertIsDisarmed) { return; }
   AId invalid;
   bool result = true;
   EXPECT_DEATH(
@@ -239,6 +240,7 @@ TEST_F(IdentifierDeathTests, InvlalidInequalityCompare) {
 // Hashing an invalid id is an error.
 TEST_F(IdentifierDeathTests, InvalidHash) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  if (kDrakeAssertIsDisarmed) { return; }
   std::unordered_set<AId> ids;
   AId invalid;
   ASSERT_DEATH({ids.insert(invalid);}, "");
@@ -247,12 +249,11 @@ TEST_F(IdentifierDeathTests, InvalidHash) {
 // Streaming an invalid id is an error.
 TEST_F(IdentifierDeathTests, InvalidStream) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  if (kDrakeAssertIsDisarmed) { return; }
   AId invalid;
   std::stringstream ss;
   ASSERT_DEATH({ss << invalid;}, "");
 }
-
-#endif  // DRAKE_ASSERT_IS_DISARMED
 
 }  // namespace
 }  // namespace geometry

--- a/math/rotation_matrix.h
+++ b/math/rotation_matrix.h
@@ -33,9 +33,9 @@ namespace math {
 /// @note This class does not store the frames associated with a rotation matrix
 /// nor does it enforce strict proper usage of this class with vectors.
 ///
-/// @note When DRAKE_ASSERT_IS_ARMED is defined, several methods in this class
+/// @note When assertions are enabled, several methods in this class
 /// do a validity check and throw an exception (std::logic_error) if the
-/// rotation matrix is invalid.  When DRAKE_ASSERT_IS_ARMED is not defined,
+/// rotation matrix is invalid.  When assertions are disabled,
 /// many of these validity checks are skipped (which helps improve speed).
 /// In addition, these validity tests are only performed for scalar types for
 /// which drake::scalar_predicate<T>::is_bool is `true`. For instance, validity

--- a/math/test/rigid_transform_test.cc
+++ b/math/test/rigid_transform_test.cc
@@ -55,7 +55,6 @@ RotationMatrix<double> GetRotationMatrixB() {
   return RotationMatrix<double>(m);
 }
 
-#ifdef DRAKE_ASSERT_IS_ARMED
 // Helper function to create an invalid rotation matrix.
 Matrix3d GetBadRotationMatrix() {
   const double theta = 0.5;
@@ -66,7 +65,6 @@ Matrix3d GetBadRotationMatrix() {
        0, -sin_theta, cos_theta;
   return m;
 }
-#endif
 
 // Helper functions to create generic position vectors.
 Vector3d GetPositionVectorA() { return Vector3d(2, 3, 4); }
@@ -108,7 +106,6 @@ GTEST_TEST(RigidTransform, ConstructorAndSet) {
   EXPECT_TRUE((zero_rotation.array() == 0).all());
   EXPECT_TRUE((zero_position.array() == 0).all());
 
-#ifdef DRAKE_ASSERT_IS_ARMED
   // Bad rotation matrix should throw exception.
   // Note: Although this test seems redundant with similar tests for the
   // RotationMatrix class, it is here due to the bug (mentioned below) in
@@ -116,9 +113,10 @@ GTEST_TEST(RigidTransform, ConstructorAndSet) {
   // an extra set of parentheses around its first argument) with the use of
   // EXPECT_THROW((RigidTransform<double>(isometryC)), std::logic_error); below.
   const Matrix3d bad = GetBadRotationMatrix();
-  EXPECT_THROW(RigidTransform<double>(RotationMatrix<double>(bad), p),
-               std::logic_error);
-#endif
+  if (kDrakeAssertIsArmed) {
+    EXPECT_THROW(RigidTransform<double>(RotationMatrix<double>(bad), p),
+                 std::logic_error);
+  }
 }
 
 // Tests constructing a RigidTransform from just a RotationMatrix.
@@ -259,7 +257,6 @@ GTEST_TEST(RigidTransform, Isometry3) {
   EXPECT_TRUE((zero_rotation.array() == 0).all());
   EXPECT_TRUE((zero_position.array() == 0).all());
 
-#ifdef DRAKE_ASSERT_IS_ARMED
   // Bad matrix should throw exception.
   const Matrix3d bad = GetBadRotationMatrix();
   Isometry3<double> isometryC;
@@ -269,8 +266,9 @@ GTEST_TEST(RigidTransform, Isometry3) {
   // The default RigidTransform constructor does not throw an exception which
   // means the EXPECT_THROW fails.  The fix (credit Sherm) was to add an extra
   // set of parentheses around the first argument of EXPECT_THROW.
-  EXPECT_THROW((RigidTransform<double>(isometryC)), std::logic_error);
-#endif
+  if (kDrakeAssertIsArmed) {
+    EXPECT_THROW((RigidTransform<double>(isometryC)), std::logic_error);
+  }
 }
 
 // Tests method Identity (identity rotation matrix and zero vector).

--- a/math/test/roll_pitch_yaw_test.cc
+++ b/math/test/roll_pitch_yaw_test.cc
@@ -123,7 +123,6 @@ GTEST_TEST(RollPitchYaw, testToQuaternion) {
   rpy2.SetFromQuaternionAndRotationMatrix(quat, R1);
   EXPECT_TRUE(rpy2.IsNearlySameOrientation(rpy, kEpsilon));
 
-#ifdef DRAKE_ASSERT_IS_ARMED
   // Test SetFromQuaternionAndRotationMatrix throws exception in debug builds
   // if quaternion is not consistent with rotation matrix.
   const char* expected_message =
@@ -132,10 +131,9 @@ GTEST_TEST(RollPitchYaw, testToQuaternion) {
       ".*differs by more than"
       ".*element of the RotationMatrix formed by the Quaternion.*";
   const Eigen::Quaterniond quat_inconsistent(1, 0, 0, 0);
-  DRAKE_EXPECT_THROWS_MESSAGE(
+  DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(
       rpy2.SetFromQuaternionAndRotationMatrix(quat_inconsistent, R1),
       std::logic_error, expected_message);
-#endif
 }
 
 // This tests the RollPitchYaw.IsValid() method.

--- a/math/test/rotation_matrix_test.cc
+++ b/math/test/rotation_matrix_test.cc
@@ -36,42 +36,45 @@ GTEST_TEST(RotationMatrix, RotationMatrixConstructor) {
   Matrix3d zero_matrix = m - R1.matrix();
   EXPECT_TRUE((zero_matrix.array() == 0).all());
 
-#ifdef DRAKE_ASSERT_IS_ARMED
-  // Really poor non-orthogonal matrix should throw an exception.
-  m << 1, 2,  3,
-       4, 5,  6,
-       7, 8, -10;
-  DRAKE_EXPECT_THROWS_MESSAGE(RotationMatrix<double>{m}, std::logic_error,
-                              "Error: Rotation matrix is not orthonormal.*")
+  if (kDrakeAssertIsArmed) {
+    // Really poor non-orthogonal matrix should throw an exception.
+    m << 1, 2,  3,
+         4, 5,  6,
+         7, 8, -10;
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        RotationMatrix<double>{m}, std::logic_error,
+        "Error: Rotation matrix is not orthonormal.*");
 
-  // Barely non-orthogonal matrix should throw an exception.
-  m << 1, 9000*kEpsilon, 9000*kEpsilon,
-       0, cos_theta, sin_theta,
-       0, -sin_theta, cos_theta;
-  DRAKE_EXPECT_THROWS_MESSAGE(RotationMatrix<double>{m}, std::logic_error,
-                              "Error: Rotation matrix is not orthonormal.*");
+    // Barely non-orthogonal matrix should throw an exception.
+    m << 1, 9000*kEpsilon, 9000*kEpsilon,
+         0, cos_theta, sin_theta,
+         0, -sin_theta, cos_theta;
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        RotationMatrix<double>{m}, std::logic_error,
+        "Error: Rotation matrix is not orthonormal.*");
 
-  // Orthogonal matrix with determinant = -1 should throw an exception.
-  m << 1, 0, 0,
-       0, 1, 0,
-       0, 0, -1;
-  DRAKE_EXPECT_THROWS_MESSAGE(RotationMatrix<double>{m}, std::logic_error,
-                            "Error: Rotation matrix determinant is negative.*");
+    // Orthogonal matrix with determinant = -1 should throw an exception.
+    m << 1, 0, 0,
+         0, 1, 0,
+         0, 0, -1;
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        RotationMatrix<double>{m}, std::logic_error,
+        "Error: Rotation matrix determinant is negative.*");
 
-  // Matrix with a NaN should throw an exception.
-  m << 1, 0, 0,
-       0, 1, 0,
-       0, 0, std::numeric_limits<double>::quiet_NaN();
-  DRAKE_EXPECT_THROWS_MESSAGE(RotationMatrix<double>{m}, std::logic_error,
+    // Matrix with a NaN should throw an exception.
+    m << 1, 0, 0,
+         0, 1, 0,
+         0, 0, std::numeric_limits<double>::quiet_NaN();
+    DRAKE_EXPECT_THROWS_MESSAGE(RotationMatrix<double>{m}, std::logic_error,
         "Error: Rotation matrix contains an element that is infinity or NaN.*");
 
-  // Matrix with an infinity should throw an exception.
-  m << 1, 0, 0,
-       0, 1, 0,
-       0, 0, std::numeric_limits<double>::infinity();
-  DRAKE_EXPECT_THROWS_MESSAGE(RotationMatrix<double>{m}, std::logic_error,
+    // Matrix with an infinity should throw an exception.
+    m << 1, 0, 0,
+         0, 1, 0,
+         0, 0, std::numeric_limits<double>::infinity();
+    DRAKE_EXPECT_THROWS_MESSAGE(RotationMatrix<double>{m}, std::logic_error,
         "Error: Rotation matrix contains an element that is infinity or NaN.*");
-#endif
+  }
 }
 
 // Test making a RotationMatrix from three right-handed orthogonal unit vectors.
@@ -126,10 +129,10 @@ GTEST_TEST(RotationMatrix, MakeFromOrthonormalRowsOrColumns) {
   // Non-orthogonal matrix should throw an exception (at least in debug builds).
   DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(
       R = RotationMatrix<double>::MakeFromOrthonormalRows(Fx, Fy, Fz),
-      std::logic_error, "Error: Rotation matrix is not orthonormal.*")
+      std::logic_error, "Error: Rotation matrix is not orthonormal.*");
   DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(
       R = RotationMatrix<double>::MakeFromOrthonormalColumns(Fx, Fy, Fz),
-      std::logic_error, "Error: Rotation matrix is not orthonormal.*")
+      std::logic_error, "Error: Rotation matrix is not orthonormal.*");
 
   // Non-right handed matrix with determinant < 0 should throw an exception.
   DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(
@@ -165,15 +168,15 @@ GTEST_TEST(RotationMatrix, MakeFromOrthonormalRowsOrColumns) {
           std::logic_error,
         "Error: Rotation matrix contains an element that is infinity or NaN.*");
 
-#ifndef DRAKE_ASSERT_IS_ARMED
-  // In release builds, check for invalid matrix.
-  EXPECT_NO_THROW(
-      R = RotationMatrix<double>::MakeFromOrthonormalRows(Fx, Fy, Fz));
-  EXPECT_FALSE(R.IsValid());
-  EXPECT_NO_THROW(
-      R = RotationMatrix<double>::MakeFromOrthonormalColumns(Fx, Fy, Fz));
-  EXPECT_FALSE(R.IsValid());
-#endif
+  if (kDrakeAssertIsDisarmed) {
+    // In release builds, check for invalid matrix.
+    EXPECT_NO_THROW(
+        R = RotationMatrix<double>::MakeFromOrthonormalRows(Fx, Fy, Fz));
+    EXPECT_FALSE(R.IsValid());
+    EXPECT_NO_THROW(
+        R = RotationMatrix<double>::MakeFromOrthonormalColumns(Fx, Fy, Fz));
+    EXPECT_FALSE(R.IsValid());
+  }
 }
 
 // Test setting a RotationMatrix from a Matrix3.
@@ -194,11 +197,11 @@ GTEST_TEST(RotationMatrix, SetRotationMatrix) {
   m << 1, 9000*kEpsilon, 9000*kEpsilon,
        0, cos_theta, sin_theta,
        0, -sin_theta, cos_theta;
-#ifdef DRAKE_ASSERT_IS_ARMED
-  EXPECT_THROW(R.set(m), std::logic_error);
-#else
-  EXPECT_NO_THROW(R.set(m));
-#endif
+  if (kDrakeAssertIsArmed) {
+    EXPECT_THROW(R.set(m), std::logic_error);
+  } else {
+    EXPECT_NO_THROW(R.set(m));
+  }
 }
 
 // Test setting a RotationMatrix to an identity matrix.
@@ -397,11 +400,11 @@ GTEST_TEST(RotationMatrix, IsExactlyIdentity) {
   m(0, 2) = 127 * kEpsilon;
   EXPECT_NO_THROW(R.set(m));
   m(0, 2) = 129 * kEpsilon;
-#ifdef DRAKE_ASSERT_IS_ARMED
-  EXPECT_THROW(R.set(m), std::logic_error);
-#else
-  EXPECT_NO_THROW(R.set(m));
-#endif
+  if (kDrakeAssertIsArmed) {
+    EXPECT_THROW(R.set(m), std::logic_error);
+  } else {
+    EXPECT_NO_THROW(R.set(m));
+  }
 
   const double cos_theta = std::cos(0.5);
   const double sin_theta = std::sin(0.5);
@@ -802,16 +805,16 @@ TEST_F(RotationMatrixConversionTests, QuaternionToRotationMatrix) {
     EXPECT_TRUE(R.IsNearlyEqualTo(R_expected, 40 * kEpsilon));
   }
 
-#ifdef DRAKE_ASSERT_IS_ARMED
-  // A zero quaternion should throw an exception.
-  const Eigen::Quaterniond q_zero(0, 0, 0, 0);
-  EXPECT_THROW(const RotationMatrix<double> R_bad(q_zero), std::logic_error);
+  if (kDrakeAssertIsArmed) {
+    // A zero quaternion should throw an exception.
+    const Eigen::Quaterniond q_zero(0, 0, 0, 0);
+    EXPECT_THROW(const RotationMatrix<double> R_bad(q_zero), std::logic_error);
 
-  // A quaternion containing a NaN throw an exception.
-  double nan = std::numeric_limits<double>::quiet_NaN();
-  const Eigen::Quaterniond q_nan(nan, 0, 0, 0);
-  EXPECT_THROW(const RotationMatrix<double> R_nan(q_nan), std::logic_error);
-#endif
+    // A quaternion containing a NaN throw an exception.
+    double nan = std::numeric_limits<double>::quiet_NaN();
+    const Eigen::Quaterniond q_nan(nan, 0, 0, 0);
+    EXPECT_THROW(const RotationMatrix<double> R_nan(q_nan), std::logic_error);
+  }
 }
 
 TEST_F(RotationMatrixConversionTests, AngleAxisToRotationMatrix) {
@@ -837,16 +840,17 @@ TEST_F(RotationMatrixConversionTests, AngleAxisToRotationMatrix) {
     EXPECT_TRUE(0 <= angle && angle <= M_PI);
   }
 
-#ifdef DRAKE_ASSERT_IS_ARMED
-  // An AngleAxis with a zero unit vector should throw an exception.
-  const Eigen::AngleAxisd aa_zero(5, Vector3d(0, 0, 0));
-  EXPECT_THROW(const RotationMatrix<double> R_zero(aa_zero), std::logic_error);
+  if (kDrakeAssertIsArmed) {
+    // An AngleAxis with a zero unit vector should throw an exception.
+    const Eigen::AngleAxisd aa_zero(5, Vector3d(0, 0, 0));
+    EXPECT_THROW(const RotationMatrix<double> R_zero(aa_zero),
+        std::logic_error);
 
-  // An AngleAxis containing a NaN should throw an exception.
-  double nan = std::numeric_limits<double>::quiet_NaN();
-  const Eigen::AngleAxisd aa_nan(nan, Vector3d(1, 0, 0));
-  EXPECT_THROW(const RotationMatrix<double> R_nan(aa_nan), std::logic_error);
-#endif
+    // An AngleAxis containing a NaN should throw an exception.
+    double nan = std::numeric_limits<double>::quiet_NaN();
+    const Eigen::AngleAxisd aa_nan(nan, Vector3d(1, 0, 0));
+    EXPECT_THROW(const RotationMatrix<double> R_nan(aa_nan), std::logic_error);
+  }
 }
 
 }  // namespace

--- a/multibody/tree/test/rotational_inertia_test.cc
+++ b/multibody/tree/test/rotational_inertia_test.cc
@@ -27,20 +27,15 @@ using std::sort;
 using symbolic::Expression;
 using symbolic::Variable;
 
-#ifdef DRAKE_ASSERT_IS_DISARMED
 // With assertion disarmed, expect no exception.
 #define EXPECT_THROW_IF_ARMED(expression, exception) \
-do {\
-  EXPECT_NO_THROW(expression); \
-} while (0)
-
-#else
-
-#define EXPECT_THROW_IF_ARMED(expression, exception) \
 do { \
-  EXPECT_THROW(expression, exception); \
+  if (kDrakeAssertIsArmed) { \
+    EXPECT_THROW(expression, exception); \
+  } else { \
+    EXPECT_NO_THROW(expression); \
+  } \
 } while (0)
-#endif
 
 constexpr double kEpsilon = std::numeric_limits<double>::epsilon();
 

--- a/systems/framework/test/cache_entry_test.cc
+++ b/systems/framework/test/cache_entry_test.cc
@@ -377,14 +377,14 @@ TEST_F(CacheEntryTest, ValueMethodsWork) {
   EXPECT_EQ(string_entry().GetKnownUpToDate<string>(context_), "initial");
   EXPECT_EQ(string_value.serial_number(), expected_serial_num);  // No change.
 
-// In Debug we have an expensive check that the output type provided to
-// Calc() has the right concrete type. Make sure it works.
-#ifdef DRAKE_ASSERT_IS_ARMED
-  auto bad_out = AbstractValue::Make<double>(3.14);
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      string_entry().Calc(context_, &*bad_out), std::logic_error,
-      ".*Calc().*expected.*type.*string.*but got.*double.*");
-#endif
+  // In Debug we have an expensive check that the output type provided to
+  // Calc() has the right concrete type. Make sure it works.
+  if (kDrakeAssertIsArmed) {
+    auto bad_out = AbstractValue::Make<double>(3.14);
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        string_entry().Calc(context_, &*bad_out), std::logic_error,
+        ".*Calc().*expected.*type.*string.*but got.*double.*");
+  }
 
   // The value is currently marked up to date, so Eval does nothing.
   const string& result = string_entry().Eval<string>(context_);
@@ -587,17 +587,18 @@ TEST_F(CacheEntryTest, CanSwapValue) {
   EXPECT_EQ(entry_value.get_value<string>(), "new value");
   EXPECT_EQ(string_entry().GetKnownUpToDate<string>(context_), "new value");
 
-// In Debug builds, try a bad swap and expect it to be caught.
-#ifdef DRAKE_ASSERT_IS_ARMED
-  std::unique_ptr<AbstractValue> empty_ptr;
-  DRAKE_EXPECT_THROWS_MESSAGE(entry_value.swap_value(&empty_ptr),
-                              std::logic_error,
-                              ".*swap_value().*value.*empty.*");
-  auto bad_value = AbstractValue::Make<int>(29);
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      entry_value.swap_value(&bad_value), std::logic_error,
-      ".*swap_value().*value.*wrong concrete type.*int.*[Ee]xpected.*string.*");
-#endif
+  // In Debug builds, try a bad swap and expect it to be caught.
+  if (kDrakeAssertIsArmed) {
+    std::unique_ptr<AbstractValue> empty_ptr;
+    DRAKE_EXPECT_THROWS_MESSAGE(entry_value.swap_value(&empty_ptr),
+                                std::logic_error,
+                                ".*swap_value().*value.*empty.*");
+    auto bad_value = AbstractValue::Make<int>(29);
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        entry_value.swap_value(&bad_value), std::logic_error,
+        ".*swap_value().*value.*wrong concrete type.*int.*"
+        "[Ee]xpected.*string.*");
+  }
 }
 
 TEST_F(CacheEntryTest, InvalidationIsRecursive) {

--- a/systems/framework/test/cache_test.cc
+++ b/systems/framework/test/cache_test.cc
@@ -367,12 +367,12 @@ TEST_F(CacheTest, CanSwapValue) {
   EXPECT_EQ(entry_value.get_value<string>(), "new value");
 
 // In Debug builds, try a bad swap and expect it to be caught.
-#ifdef DRAKE_ASSERT_IS_ARMED
-  std::unique_ptr<AbstractValue> empty_ptr;
-  EXPECT_THROW(entry_value.swap_value(&empty_ptr), std::logic_error);
-  auto bad_value = AbstractValue::Make<int>(29);
-  EXPECT_THROW(entry_value.swap_value(&bad_value), std::logic_error);
-#endif
+  if (kDrakeAssertIsArmed) {
+    std::unique_ptr<AbstractValue> empty_ptr;
+    EXPECT_THROW(entry_value.swap_value(&empty_ptr), std::logic_error);
+    auto bad_value = AbstractValue::Make<int>(29);
+    EXPECT_THROW(entry_value.swap_value(&bad_value), std::logic_error);
+  }
 }
 
 TEST_F(CacheTest, InvalidationIsRecursive) {
@@ -517,15 +517,15 @@ TEST_F(CacheTest, ValueMethodsWork) {
   EXPECT_THROW(value.PeekAbstractValueOrThrow(), std::logic_error);
   EXPECT_THROW(value.PeekValueOrThrow<int>(), std::logic_error);
 
-#ifdef DRAKE_ASSERT_IS_ARMED
-  EXPECT_THROW(value.get_abstract_value(), std::logic_error);
-  EXPECT_THROW(value.get_value<int>(), std::logic_error);
-  EXPECT_THROW(value.set_value<int>(5), std::logic_error);
-  EXPECT_THROW(value.is_out_of_date(), std::logic_error);
-  EXPECT_THROW(value.needs_recomputation(), std::logic_error);
-  EXPECT_THROW(value.mark_up_to_date(), std::logic_error);
-  EXPECT_THROW(value.swap_value(&swap_with_me), std::logic_error);
-#endif
+  if (kDrakeAssertIsArmed) {
+    EXPECT_THROW(value.get_abstract_value(), std::logic_error);
+    EXPECT_THROW(value.get_value<int>(), std::logic_error);
+    EXPECT_THROW(value.set_value<int>(5), std::logic_error);
+    EXPECT_THROW(value.is_out_of_date(), std::logic_error);
+    EXPECT_THROW(value.needs_recomputation(), std::logic_error);
+    EXPECT_THROW(value.mark_up_to_date(), std::logic_error);
+    EXPECT_THROW(value.swap_value(&swap_with_me), std::logic_error);
+  }
 
   // Now provide an initial value (not yet up to date).
   value.SetInitialValue(PackValue(42));
@@ -542,10 +542,10 @@ TEST_F(CacheTest, ValueMethodsWork) {
   EXPECT_NO_THROW(value.PeekAbstractValueOrThrow());
 
   // The fast "get" methods must check for up to date in Debug builds.
-#ifdef DRAKE_ASSERT_IS_ARMED
-  EXPECT_THROW(value.get_value<int>(), std::logic_error);
-  EXPECT_THROW(value.get_abstract_value(), std::logic_error);
-#endif
+  if (kDrakeAssertIsArmed) {
+    EXPECT_THROW(value.get_value<int>(), std::logic_error);
+    EXPECT_THROW(value.get_abstract_value(), std::logic_error);
+  }
 
   // Swap doesn't care about up to date or not, but always marks the swapped-in
   // value out of date.
@@ -574,9 +574,9 @@ TEST_F(CacheTest, ValueMethodsWork) {
   EXPECT_THROW(value.SetValueOrThrow<int>(5), std::logic_error);
 
   // The fast "set" method must check for up to date in Debug builds.
-#ifdef DRAKE_ASSERT_IS_ARMED
-  EXPECT_THROW(value.set_value<int>(5), std::logic_error);
-#endif
+  if (kDrakeAssertIsArmed) {
+    EXPECT_THROW(value.set_value<int>(5), std::logic_error);
+  }
 
   // And "swap" still doesn't care about up to date on entry.
   value.swap_value(&swap_with_me);

--- a/systems/framework/test/output_port_test.cc
+++ b/systems/framework/test/output_port_test.cc
@@ -143,16 +143,16 @@ GTEST_TEST(TestBaseClass, BadOutputType) {
 
   EXPECT_NO_THROW(port.Calc(*context, good_port_value.get()));
 
-// This message is thrown in Debug. In Release some other error may trigger
-// but not from OutputPort, so we can't use
-// DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED() which would insist that if any
-// message is thrown in Release it must be the expected one.
-#ifndef DRAKE_ASSERT_IS_DISARMED
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      port.Calc(*context, bad_port_value.get()), std::logic_error,
-      "OutputPort::Calc().*expected.*MyVector.*but got.*std::string"
-      ".*OutputPort\\[0\\].*");
-#endif
+  // This message is thrown in Debug. In Release some other error may trigger
+  // but not from OutputPort, so we can't use
+  // DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED() which would insist that if any
+  // message is thrown in Release it must be the expected one.
+  if (kDrakeAssertIsArmed) {
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        port.Calc(*context, bad_port_value.get()), std::logic_error,
+        "OutputPort::Calc().*expected.*MyVector.*but got.*std::string"
+        ".*OutputPort\\[0\\].*");
+  }
 }
 
 // These functions match the signatures required by LeafOutputPort.
@@ -302,8 +302,11 @@ TEST_F(LeafOutputPortTest, ThrowIfNullAlloc) {
 // Check that Debug builds catch bad output types. We can't run these tests
 // unchecked since the results would be indeterminate -- they may run to
 // completion or segfault depending on memory contents.
-#ifndef DRAKE_ASSERT_IS_DISARMED
 TEST_F(LeafOutputPortTest, ThrowIfBadCalcOutput) {
+  if (kDrakeAssertIsDisarmed) {
+    return;
+  }
+
   // The abstract port is a string; let's give it an int.
   auto good_out = absport_general_.Allocate();
   auto bad_out = AbstractValue::Make<int>(5);
@@ -320,7 +323,6 @@ TEST_F(LeafOutputPortTest, ThrowIfBadCalcOutput) {
       vecport_general_.Calc(*context_, bad_vec.get()), std::logic_error,
       "OutputPort::Calc().*expected.*MyVector.*got.*BasicVector.*");
 }
-#endif
 
 // For testing diagram output ports we need a couple of subsystems that have
 // recognizably different Contexts so we can verify that (1) the diagram exports


### PR DESCRIPTION
The preprocessor is all powerful, but too powerful for mere mortals like us.  Having code that is only conditionally compiled makes it too easy to accidentally break things with syntax errors.  We should use if-else whenever possible.

These constants also open up more fluent code like
```
  return kDrakeAssertIsArmed ? Expensive() : cheap();
```

Relates #10678.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10697)
<!-- Reviewable:end -->
