### PR TITLE
solvers: Tidy up the SolverDetails APIs

### DIFF
--- a/solvers/gurobi_solver.cc
+++ b/solvers/gurobi_solver.cc
@@ -931,9 +931,8 @@ SolutionResult GurobiSolver::Solve(MathematicalProgram& prog) const {
   MathematicalProgramResult result;
   Solve(prog, {}, {}, &result);
   SolverResult solver_result = result.ConvertToSolverResult();
-  const double objective_bound = result.get_solver_details()
-                                     .GetValue<GurobiSolverDetails>()
-                                     .objective_bound;
+  const double objective_bound =
+      result.get_solver_details<GurobiSolver>().objective_bound;
   if (!std::isnan(objective_bound)) {
     solver_result.set_optimal_cost_lower_bound(objective_bound);
   }

--- a/solvers/gurobi_solver.h
+++ b/solvers/gurobi_solver.h
@@ -12,28 +12,34 @@
 namespace drake {
 namespace solvers {
 
+/// The Gurobi solver details after calling Solve() function. The user can call
+/// MathematicalProgramResult::get_solver_details<GurobiSolver>() to obtain the
+/// details.
 struct GurobiSolverDetails {
-  // The gurobi optimization time. Please refer to
-  // https://www.gurobi.com/documentation/8.0/refman/runtime.html
+  /// The gurobi optimization time. Please refer to
+  /// https://www.gurobi.com/documentation/8.0/refman/runtime.html
   double optimizer_time{};
 
-  // The error message returned from Gurobi call. Please refer to
-  // https://www.gurobi.com/documentation/8.0/refman/error_codes.html
+  /// The error message returned from Gurobi call. Please refer to
+  /// https://www.gurobi.com/documentation/8.0/refman/error_codes.html
   int error_code{};
 
-  // The status code when the optimize call has returned. Please refer to
-  // https://www.gurobi.com/documentation/8.0/refman/optimization_status_codes.html
+  /// The status code when the optimize call has returned. Please refer to
+  /// https://www.gurobi.com/documentation/8.0/refman/optimization_status_codes.html
   int optimization_status{};
 
-  // The best known bound on the optimal objective. This is used in mixed
-  // integer optimization. Please refer to
-  // https://www.gurobi.com/documentation/8.0/refman/objbound.html
+  /// The best known bound on the optimal objective. This is used in mixed
+  /// integer optimization. Please refer to
+  /// https://www.gurobi.com/documentation/8.0/refman/objbound.html
   double objective_bound{NAN};
 };
 
 class GurobiSolver final : public SolverBase {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(GurobiSolver)
+
+  /// Type of details stored in MathematicalProgramResult.
+  using Details = GurobiSolverDetails;
 
   GurobiSolver();
   ~GurobiSolver() final;

--- a/solvers/ipopt_solver.h
+++ b/solvers/ipopt_solver.h
@@ -12,9 +12,9 @@ namespace drake {
 namespace solvers {
 
 /**
- * The details of IPOPT solvers after calling Solve function. The users can get
- * the details by
- * MathematicalProgramResult::get_solver_details().GetValue<IpoptSolverDetails>();
+ * The Ipopt solver details after calling Solve() function. The user can call
+ * MathematicalProgramResult::get_solver_details<IpoptSolver>() to obtain the
+ * details.
  */
 struct IpoptSolverDetails {
   /**
@@ -43,6 +43,9 @@ struct IpoptSolverDetails {
 class IpoptSolver final : public SolverBase {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(IpoptSolver)
+
+  /// Type of details stored in MathematicalProgramResult.
+  using Details = IpoptSolverDetails;
 
   IpoptSolver();
   ~IpoptSolver() final;

--- a/solvers/mathematical_program_result.cc
+++ b/solvers/mathematical_program_result.cc
@@ -15,10 +15,10 @@ MathematicalProgramResult::MathematicalProgramResult()
       x_val_{0},
       optimal_cost_{NAN},
       solver_id_{UnknownId()},
-      solver_details_type_{nullptr},
       solver_details_{nullptr} {}
 
-const AbstractValue& MathematicalProgramResult::get_solver_details() const {
+const AbstractValue& MathematicalProgramResult::get_abstract_solver_details()
+    const {
   if (!solver_details_) {
     throw std::logic_error("The solver_details has not been set yet.");
   }

--- a/solvers/mosek_solver.h
+++ b/solvers/mosek_solver.h
@@ -11,6 +11,11 @@
 
 namespace drake {
 namespace solvers {
+/**
+ * The Mosek solver details after calling Solve() function. The user can call
+ * MathematicalProgramResult::get_solver_details<MosekSolver>() to obtain the
+ * details.
+ */
 struct MosekSolverDetails {
   /// The mosek optimization time. Please refer to MSK_DINF_OPTIMIZER_TIME in
   /// https://docs.mosek.com/8.1/capi/constants.html?highlight=msk_dinf_optimizer_time
@@ -39,6 +44,9 @@ struct MosekSolverDetails {
 class MosekSolver final : public SolverBase {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MosekSolver)
+
+  /// Type of details stored in MathematicalProgramResult.
+  using Details = MosekSolverDetails;
 
   MosekSolver();
   ~MosekSolver() final;

--- a/solvers/nlopt_solver.h
+++ b/solvers/nlopt_solver.h
@@ -8,19 +8,22 @@
 namespace drake {
 namespace solvers {
 /**
- * The NLopt solver details after calling Solve() function. The users can call
- * MathematicalProgramResult::get_solver_details().GetValue<NloptSolverDetails>()
- * to obtain the details.
+ * The NLopt solver details after calling Solve() function. The user can call
+ * MathematicalProgramResult::get_solver_details<NloptSolver>() to obtain the
+ * details.
  */
 struct NloptSolverDetails {
-  // The return status of NLopt solver. Please refer to
-  // https://nlopt.readthedocs.io/en/latest/NLopt_Reference/#return-values.
+  /// The return status of NLopt solver. Please refer to
+  /// https://nlopt.readthedocs.io/en/latest/NLopt_Reference/#return-values.
   int status{};
 };
 
 class NloptSolver final : public SolverBase {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(NloptSolver)
+
+  /// Type of details stored in MathematicalProgramResult.
+  using Details = NloptSolverDetails;
 
   NloptSolver();
   ~NloptSolver() final;

--- a/solvers/osqp_solver.h
+++ b/solvers/osqp_solver.h
@@ -6,9 +6,9 @@
 namespace drake {
 namespace solvers {
 /**
- * The OSQP solver details after calling Solve function in OsqpSolver. The user
- * can obtain the details from
- * MathematicalProgramResult.get_solver_details().GetValue<OsqpSolverDetails>();
+ * The OSQP solver details after calling Solve() function. The user can call
+ * MathematicalProgramResult::get_solver_details<OsqpSolver>() to obtain the
+ * details.
  */
 struct OsqpSolverDetails {
   /// Number of iterations taken.
@@ -33,6 +33,9 @@ struct OsqpSolverDetails {
 class OsqpSolver final : public SolverBase {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(OsqpSolver)
+
+  /// Type of details stored in MathematicalProgramResult.
+  using Details = OsqpSolverDetails;
 
   OsqpSolver();
   ~OsqpSolver() final;

--- a/solvers/scs_solver.h
+++ b/solvers/scs_solver.h
@@ -6,9 +6,10 @@
 
 namespace drake {
 namespace solvers {
-/** The SCS solver details after calling Solve function in ScsSolver. The user
- * can obtain the details from
- * MathematicalProgramResult.get_solver_details().GetValue<ScsSolverDetails>();
+/**
+ * The SCS solver details after calling Solve() function. The user can call
+ * MathematicalProgramResult::get_solver_details<ScsSolver>() to obtain the
+ * details.
  */
 struct ScsSolverDetails {
   /// The status of the solver at termination. Please refer to
@@ -57,6 +58,9 @@ struct ScsSolverDetails {
 class ScsSolver final : public SolverBase {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ScsSolver)
+
+  /// Type of details stored in MathematicalProgramResult.
+  using Details = ScsSolverDetails;
 
   ScsSolver();
   ~ScsSolver() final;

--- a/solvers/snopt_solver.h
+++ b/solvers/snopt_solver.h
@@ -9,9 +9,9 @@ namespace drake {
 namespace solvers {
 
 /**
- * The details of SNOPT solvers after calling Solve function. The users can get
- * the details by
- * MathematicalProgramResult::get_solver_details().GetValue<SnoptSolverDetails>();
+ * The SNOPT solver details after calling Solve() function. The user can call
+ * MathematicalProgramResult::get_solver_details<SnoptSolver>() to obtain the
+ * details.
  */
 struct SnoptSolverDetails {
   /**
@@ -37,6 +37,9 @@ struct SnoptSolverDetails {
 class SnoptSolver final : public SolverBase  {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SnoptSolver)
+
+  /// Type of details stored in MathematicalProgramResult.
+  using Details = SnoptSolverDetails;
 
   SnoptSolver();
   ~SnoptSolver() final;

--- a/solvers/test/gurobi_solver_test.cc
+++ b/solvers/test/gurobi_solver_test.cc
@@ -60,9 +60,7 @@ TEST_F(UnboundedLinearProgramTest0, TestGurobiUnbounded) {
     // This code is defined in
     // https://www.gurobi.com/documentation/8.0/refman/optimization_status_codes.html
     const int GRB_INF_OR_UNBD = 4;
-    EXPECT_EQ(result.get_solver_details()
-                  .GetValue<GurobiSolverDetails>()
-                  .optimization_status,
+    EXPECT_EQ(result.get_solver_details<GurobiSolver>().optimization_status,
               GRB_INF_OR_UNBD);
 
     solver_options.SetOption(GurobiSolver::id(), "DualReductions", 0);
@@ -72,9 +70,7 @@ TEST_F(UnboundedLinearProgramTest0, TestGurobiUnbounded) {
     // This code is defined in
     // https://www.gurobi.com/documentation/8.0/refman/optimization_status_codes.html
     const int GRB_UNBOUNDED = 5;
-    EXPECT_EQ(result.get_solver_details()
-                  .GetValue<GurobiSolverDetails>()
-                  .optimization_status,
+    EXPECT_EQ(result.get_solver_details<GurobiSolver>().optimization_status,
               GRB_UNBOUNDED);
     EXPECT_EQ(result.get_optimal_cost(), MathematicalProgram::kUnboundedCost);
   }
@@ -346,9 +342,8 @@ GTEST_TEST(GurobiTest, GurobiErrorCode) {
     // The error code is listed in
     // https://www.gurobi.com/documentation/8.0/refman/error_codes.html
     const int UNKNOWN_PARAMETER{10007};
-    EXPECT_EQ(
-        result.get_solver_details().GetValue<GurobiSolverDetails>().error_code,
-        UNKNOWN_PARAMETER);
+    EXPECT_EQ(result.get_solver_details<GurobiSolver>().error_code,
+              UNKNOWN_PARAMETER);
 
     // Report error if the Q matrix in the QP cost is not positive semidefinite.
     prog.AddQuadraticCost(x(0) * x(0) - x(1) * x(1));
@@ -356,9 +351,8 @@ GTEST_TEST(GurobiTest, GurobiErrorCode) {
     // The error code is listed in
     // https://www.gurobi.com/documentation/8.0/refman/error_codes.html
     const int Q_NOT_PSD{10020};
-    EXPECT_EQ(
-        result.get_solver_details().GetValue<GurobiSolverDetails>().error_code,
-        Q_NOT_PSD);
+    EXPECT_EQ(result.get_solver_details<GurobiSolver>().error_code,
+              Q_NOT_PSD);
   }
 }
 

--- a/solvers/test/ipopt_solver_test.cc
+++ b/solvers/test/ipopt_solver_test.cc
@@ -32,14 +32,14 @@ TEST_F(InfeasibleLinearProgramTest0, TestIpopt) {
               SolutionResult::kInfeasibleConstraints);
     // LOCAL_INFEASIBILITY is defined in IpAlgTypes.hpp from Ipopt source file.
     const int LOCAL_INFEASIBILITY = 5;
-    EXPECT_EQ(result.get_solver_details().GetValue<IpoptSolverDetails>().status,
+    EXPECT_EQ(result.get_solver_details<IpoptSolver>().status,
               LOCAL_INFEASIBILITY);
     const Eigen::Vector2d x_val =
         result.GetSolution(prog_->decision_variables());
     EXPECT_NEAR(result.get_optimal_cost(), -x_val(0) - x_val(1), 1E-7);
     // local infeasibility is defined in Ipopt::SolverReturn in IpAlgTypes.hpp
     const int kIpoptLocalInfeasibility = 5;
-    EXPECT_EQ(result.get_solver_details().GetValue<IpoptSolverDetails>().status,
+    EXPECT_EQ(result.get_solver_details<IpoptSolver>().status,
               kIpoptLocalInfeasibility);
   }
 }
@@ -130,9 +130,8 @@ GTEST_TEST(IpoptSolverTest, AcceptableResult) {
       EXPECT_EQ(result.get_solution_result(), SolutionResult::kIterationLimit);
       // MAXITER_EXCEEDED is defined in IpAlgTypes.hpp from Ipopt source code.
       const int MAXITER_EXCEEDED = 1;
-      EXPECT_EQ(
-          result.get_solver_details().GetValue<IpoptSolverDetails>().status,
-          MAXITER_EXCEEDED);
+      EXPECT_EQ(result.get_solver_details<IpoptSolver>().status,
+                MAXITER_EXCEEDED);
     }
     options.SetOption(IpoptSolver::id(), "acceptable_tol", 1e-3);
     options.SetOption(IpoptSolver::id(), "acceptable_dual_inf_tol", 1e-3);
@@ -146,9 +145,7 @@ GTEST_TEST(IpoptSolverTest, AcceptableResult) {
       auto result = solver.Solve(prog, x_initial_guess, options);
       // Expect Ipopt status to be "STOP_AT_ACCEPTABLE_POINT."
       const int kIpoptStopAtAcceptablePoint{4};  // Defined in IpAlgTypes.hpp.
-      EXPECT_EQ(result.get_solver_details()
-                    .GetValueOrThrow<IpoptSolverDetails>()
-                    .status,
+      EXPECT_EQ(result.get_solver_details<IpoptSolver>().status,
                 kIpoptStopAtAcceptablePoint);
       // Expect Ipopt's "STOP_AT_ACCEPTABLE_POINT" to be translated to success.
       EXPECT_TRUE(result.is_success());

--- a/solvers/test/mosek_solver_test.cc
+++ b/solvers/test/mosek_solver_test.cc
@@ -35,7 +35,7 @@ TEST_F(UnboundedLinearProgramTest0, Test) {
     EXPECT_FALSE(result.is_success());
     EXPECT_EQ(result.get_solution_result(), SolutionResult::kDualInfeasible);
     const MosekSolverDetails& mosek_solver_details =
-        result.get_solver_details().GetValue<MosekSolverDetails>();
+        result.get_solver_details<MosekSolver>();
     EXPECT_EQ(mosek_solver_details.rescode, 0);
     // This problem status is defined in
     // https://docs.mosek.com/8.1/capi/constants.html#mosek.prosta
@@ -191,8 +191,7 @@ GTEST_TEST(MosekSolver, SolverOptionsErrorTest) {
   SolverOptions solver_options;
   solver_options.SetOption(MosekSolver::id(), "non-existing options", 42);
   mosek_solver.Solve(prog, {}, solver_options, &result);
-  const MosekSolverDetails solver_details =
-      result.get_solver_details().GetValue<MosekSolverDetails>();
+  const auto& solver_details = result.get_solver_details<MosekSolver>();
   // This response code is defined in
   // https://docs.mosek.com/8.1/capi/response-codes.html#mosek.rescode
   const int MSK_RES_ERR_PARAM_NAME_INT = 1207;

--- a/solvers/test/nlopt_solver_test.cc
+++ b/solvers/test/nlopt_solver_test.cc
@@ -23,7 +23,7 @@ TEST_F(UnboundedLinearProgramTest0, TestNlopt) {
     solver_options.SetOption(solver.solver_id(), NloptSolver::MaxEvalName(), 1);
     solver.Solve(*prog_, {}, solver_options, &result);
     const int NLOPT_MAXEVAL_REACHED = 5;
-    EXPECT_EQ(result.get_solver_details().GetValue<NloptSolverDetails>().status,
+    EXPECT_EQ(result.get_solver_details<NloptSolver>().status,
               NLOPT_MAXEVAL_REACHED);
   }
 }

--- a/solvers/test/osqp_solver_test.cc
+++ b/solvers/test/osqp_solver_test.cc
@@ -121,28 +121,22 @@ GTEST_TEST(OsqpSolverTest, SolverOptionsTest) {
   if (osqp_solver.available()) {
     osqp_solver.Solve(prog, {}, {}, &result);
     const int OSQP_SOLVED = 1;
-    EXPECT_EQ(
-        result.get_solver_details().GetValue<OsqpSolverDetails>().status_val,
-        OSQP_SOLVED);
+    EXPECT_EQ(result.get_solver_details<OsqpSolver>().status_val, OSQP_SOLVED);
 
     // Now only allow half the iterations in the OSQP solver. The solver should
     // not be able to solve the problem accurately.
     const int half_iterations =
-        result.get_solver_details().GetValue<OsqpSolverDetails>().iter / 2;
+        result.get_solver_details<OsqpSolver>().iter / 2;
     SolverOptions solver_options;
     solver_options.SetOption(osqp_solver.solver_id(), "max_iter",
                              half_iterations);
     osqp_solver.Solve(prog, {}, solver_options, &result);
-    EXPECT_NE(
-        result.get_solver_details().GetValue<OsqpSolverDetails>().status_val,
-        OSQP_SOLVED);
+    EXPECT_NE(result.get_solver_details<OsqpSolver>().status_val, OSQP_SOLVED);
 
     // Now set the options in prog.
     prog.SetSolverOption(osqp_solver.solver_id(), "max_iter", half_iterations);
     osqp_solver.Solve(prog, {}, {}, &result);
-    EXPECT_NE(
-        result.get_solver_details().GetValue<OsqpSolverDetails>().status_val,
-        OSQP_SOLVED);
+    EXPECT_NE(result.get_solver_details<OsqpSolver>().status_val, OSQP_SOLVED);
   }
 }
 }  // namespace test

--- a/solvers/test/scs_solver_test.cc
+++ b/solvers/test/scs_solver_test.cc
@@ -258,17 +258,15 @@ GTEST_TEST(TestScs, SetOptions) {
 
   ScsSolver solver;
   auto result = solver.Solve(prog, {}, {});
-  const int iter_solve =
-      result.get_solver_details().GetValue<ScsSolverDetails>().iter;
-  const int solved_status =
-      result.get_solver_details().GetValue<ScsSolverDetails>().scs_status;
+  const int iter_solve = result.get_solver_details<ScsSolver>().iter;
+  const int solved_status = result.get_solver_details<ScsSolver>().scs_status;
   DRAKE_DEMAND(iter_solve >= 2);
   SolverOptions solver_options;
   // Now we require that SCS can only take half of the iterations before
   // termination. We expect now SCS cannot solve the problem.
   solver_options.SetOption(solver.solver_id(), "max_iters", iter_solve / 2);
   solver.Solve(prog, {}, solver_options, &result);
-  EXPECT_NE(result.get_solver_details().GetValue<ScsSolverDetails>().scs_status,
+  EXPECT_NE(result.get_solver_details<ScsSolver>().scs_status,
             solved_status);
 }
 }  // namespace test

--- a/solvers/test/snopt_solver_test.cc
+++ b/solvers/test/snopt_solver_test.cc
@@ -91,7 +91,7 @@ GTEST_TEST(SnoptTest, TestSetOption) {
   auto result = solver.Solve(prog, x_init, {});
   EXPECT_TRUE(result.is_success());
   SnoptSolverDetails solver_details =
-      result.get_solver_details().GetValue<SnoptSolverDetails>();
+      result.get_solver_details<SnoptSolver>();
   EXPECT_TRUE(CompareMatrices(solver_details.F,
                               Eigen::Vector2d(-std::sqrt(3), 1), 1E-6));
 
@@ -101,7 +101,7 @@ GTEST_TEST(SnoptTest, TestSetOption) {
   EXPECT_EQ(result.get_solution_result(), SolutionResult::kIterationLimit);
   // This exit condition is defined in Snopt user guide.
   const int kMajorIterationLimitReached = 32;
-  solver_details = result.get_solver_details().GetValue<SnoptSolverDetails>();
+  solver_details = result.get_solver_details<SnoptSolver>();
   EXPECT_EQ(solver_details.info, kMajorIterationLimitReached);
   EXPECT_EQ(solver_details.xmul.size(), 3);
   EXPECT_EQ(solver_details.Fmul.size(), 2);
@@ -286,7 +286,7 @@ GTEST_TEST(SnoptTest, MultiThreadTest) {
       EXPECT_TRUE(CompareMatrices(
           result.get_x_val(), Eigen::Vector2d(0, 1), 1E-6));
       EXPECT_NEAR(result.get_optimal_cost(), 2, 1E-6);
-      EXPECT_EQ(result.get_solver_details().GetValue<SnoptSolverDetails>().info,
+      EXPECT_EQ(result.get_solver_details<SnoptSolver>().info,
                 1);
     }
 


### PR DESCRIPTION
This is more elegant C++ (terser call sites, compile-time checking for plausible Details types), and will better match the pydrake bindings.

Excerpt:
```c++
EXPECT_EQ(result.get_solver_details<SnoptSolver>().info, 1);
```

Relates #9633 and #10696.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10699)
<!-- Reviewable:end -->
