### PR TITLE
Reset YCB inertial poses to 0

### DIFF
--- a/manipulation/models/ycb/sdf/003_cracker_box.sdf
+++ b/manipulation/models/ycb/sdf/003_cracker_box.sdf
@@ -11,7 +11,7 @@
   -->
   <link name="base_link_cracker">
     <inertial>
-      <pose frame=''>-0.014 0.103 0.013 1.57 -1.57 0</pose>
+      <pose frame=''>0 0 0 0 0 0</pose>
       <mass>0.411</mass>
         <inertia>
           <ixx>0.001736</ixx>

--- a/manipulation/models/ycb/sdf/003_cracker_box.sdf
+++ b/manipulation/models/ycb/sdf/003_cracker_box.sdf
@@ -9,18 +9,23 @@
     Origin:
       (0, 0, 0) at the center of the box.
   -->
+
+  <!--
+    The inertial properties were calculated from the mass and dimensions given
+    with the YCB dataset. The cracker box is treated as a constant density box,
+    which matches the collision shape.
+  -->
   <link name="base_link_cracker">
     <inertial>
-      <pose frame=''>0 0 0 0 0 0</pose>
       <mass>0.411</mass>
-        <inertia>
-          <ixx>0.001736</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>0.001098</iyy>
-          <iyz>0</iyz>
-          <izz>0.002481</izz>
-        </inertia>
+      <inertia>
+        <ixx>0.001736</ixx>
+        <ixy>0</ixy>
+        <ixz>0</ixz>
+        <iyy>0.001098</iyy>
+        <iyz>0</iyz>
+        <izz>0.002481</izz>
+      </inertia>
     </inertial>
 
     <visual name='base_link_cracker'>

--- a/manipulation/models/ycb/sdf/004_sugar_box.sdf
+++ b/manipulation/models/ycb/sdf/004_sugar_box.sdf
@@ -11,7 +11,7 @@
   -->
   <link name="base_link_sugar">
     <inertial>
-      <pose frame=''>-0.018  0.088  0.0039 -0.77 -1.52 2.36</pose>
+      <pose frame=''>0 0 0 0 0 0</pose>
       <mass>0.514000</mass>
         <inertia>
           <ixx>0.001418</ixx>

--- a/manipulation/models/ycb/sdf/004_sugar_box.sdf
+++ b/manipulation/models/ycb/sdf/004_sugar_box.sdf
@@ -9,18 +9,23 @@
     Origin:
       (0, 0, 0) at the center of the box.
   -->
+
+  <!--
+    The inertial properties were calculated from the mass and dimensions given
+    with the YCB dataset. The sugar box is treated as a constant density box,
+    which matches the collision shape.
+   -->
   <link name="base_link_sugar">
     <inertial>
-      <pose frame=''>0 0 0 0 0 0</pose>
       <mass>0.514000</mass>
-        <inertia>
-          <ixx>0.001418</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>0.000455</iyy>
-          <iyz>0</iyz>
-          <izz>0.001699</izz>
-        </inertia>
+      <inertia>
+        <ixx>0.001418</ixx>
+        <ixy>0</ixy>
+        <ixz>0</ixz>
+        <iyy>0.000455</iyy>
+        <iyz>0</iyz>
+        <izz>0.001699</izz>
+      </inertia>
     </inertial>
 
     <visual name='base_link_sugar'>

--- a/manipulation/models/ycb/sdf/005_tomato_soup_can.sdf
+++ b/manipulation/models/ycb/sdf/005_tomato_soup_can.sdf
@@ -9,18 +9,23 @@
     Origin:
       (0, 0, 0) at the center of the can.
   -->
+
+  <!--
+    The inertial properties were calculated from the mass and dimensions given
+    with the YCB dataset. The tomato soup can is treated as a constant density
+    cylinder, which matches the collision shape.
+  -->
   <link name="base_link_soup">
     <inertial>
-      <pose frame=''>0 0 0 0 0 0</pose>
       <mass>0.349000</mass>
-        <inertia>
-          <ixx>0.000402</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>0.000200</iyy>
-          <iyz>0</iyz>
-          <izz>0.000402</izz>
-        </inertia>
+      <inertia>
+        <ixx>0.000402</ixx>
+        <ixy>0</ixy>
+        <ixz>0</ixz>
+        <iyy>0.000200</iyy>
+        <iyz>0</iyz>
+        <izz>0.000402</izz>
+      </inertia>
     </inertial>
 
     <visual name='base_link_soup'>

--- a/manipulation/models/ycb/sdf/005_tomato_soup_can.sdf
+++ b/manipulation/models/ycb/sdf/005_tomato_soup_can.sdf
@@ -11,7 +11,7 @@
   -->
   <link name="base_link_soup">
     <inertial>
-      <pose frame=''>-0.0018  0.051 -0.084 1.57 0.13 0.0</pose>
+      <pose frame=''>0 0 0 0 0 0</pose>
       <mass>0.349000</mass>
         <inertia>
           <ixx>0.000402</ixx>

--- a/manipulation/models/ycb/sdf/006_mustard_bottle.sdf
+++ b/manipulation/models/ycb/sdf/006_mustard_bottle.sdf
@@ -9,18 +9,24 @@
     Origin:
       (0, 0, 0) at the center of the bottle's bounding box.
   -->
+
+  <!--
+    The inertial properties were calculated from the mass and dimensions given
+    with the YCB dataset. The mustard bottle is treated as a constant density
+    box from the base of the bottle to the bottom of the cap, which matches the
+    collision shape.
+  -->
   <link name="base_link_mustard">
     <inertial>
-      <pose frame=''>0 0 0 0 0 0</pose>
       <mass>0.603000</mass>
-        <inertia>
-          <ixx>0.002009</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>0.000633</iyy>
-          <iyz>0</iyz>
-          <izz>0.002302</izz>
-        </inertia>
+      <inertia>
+        <ixx>0.002009</ixx>
+        <ixy>0</ixy>
+        <ixz>0</ixz>
+        <iyy>0.000633</iyy>
+        <iyz>0</iyz>
+        <izz>0.002302</izz>
+      </inertia>
     </inertial>
     <visual name='base_link_mustard'>
       <pose frame=''>0.0049 0.092 0.027 1.57 -0.40 0.0</pose>

--- a/manipulation/models/ycb/sdf/006_mustard_bottle.sdf
+++ b/manipulation/models/ycb/sdf/006_mustard_bottle.sdf
@@ -11,7 +11,7 @@
   -->
   <link name="base_link_mustard">
     <inertial>
-      <pose frame=''>0.0049 0.092 0.027 1.57 -0.40 0.0</pose>
+      <pose frame=''>0 0 0 0 0 0</pose>
       <mass>0.603000</mass>
         <inertia>
           <ixx>0.002009</ixx>

--- a/manipulation/models/ycb/sdf/009_gelatin_box.sdf
+++ b/manipulation/models/ycb/sdf/009_gelatin_box.sdf
@@ -9,18 +9,23 @@
     Origin:
       (0, 0, 0) at the center of the box.
   -->
+
+  <!--
+    The inertial properties were calculated from the mass and dimensions given
+    with the YCB dataset. The gelatin box is treated as a constant density box,
+    which matches the collision shape.
+  -->
   <link name="base_link_gelatin">
     <inertial>
-      <pose frame=''>0 0 0 0 0 0</pose>
       <mass>0.097000</mass>
-        <inertia>
-          <ixx>0.000050</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>0.000072</iyy>
-          <iyz>0</iyz>
-          <izz>0.000108</izz>
-        </inertia>
+      <inertia>
+        <ixx>0.000050</ixx>
+        <ixy>0</ixy>
+        <ixz>0</ixz>
+        <iyy>0.000072</iyy>
+        <iyz>0</iyz>
+        <izz>0.000108</izz>
+      </inertia>
     </inertial>
 
     <visual name='base_link_gelatin'>

--- a/manipulation/models/ycb/sdf/009_gelatin_box.sdf
+++ b/manipulation/models/ycb/sdf/009_gelatin_box.sdf
@@ -11,7 +11,7 @@
   -->
   <link name="base_link_gelatin">
     <inertial>
-      <pose frame=''>-0.0029 0.024 -0.015 -0.0085 -0.002 1.34</pose>
+      <pose frame=''>0 0 0 0 0 0</pose>
       <mass>0.097000</mass>
         <inertia>
           <ixx>0.000050</ixx>

--- a/manipulation/models/ycb/sdf/010_potted_meat_can.sdf
+++ b/manipulation/models/ycb/sdf/010_potted_meat_can.sdf
@@ -11,7 +11,7 @@
   -->
   <link name="base_link_meat">
     <inertial>
-      <pose frame=''>0.034 0.039 0.025 1.57 0.052 0.0</pose>
+      <pose frame=''>0 0 0 0 0 0</pose>
       <mass>0.370000</mass>
         <inertia>
           <ixx>0.000317</ixx>

--- a/manipulation/models/ycb/sdf/010_potted_meat_can.sdf
+++ b/manipulation/models/ycb/sdf/010_potted_meat_can.sdf
@@ -9,18 +9,23 @@
     Origin:
       (0, 0, 0) at the center of the can.
   -->
+
+  <!--
+    The inertial properties were calculated from the mass and dimensions given
+    with the YCB dataset. The pottted meat can is treated as a constant density
+    box, which matches the collision shape.
+  -->
   <link name="base_link_meat">
     <inertial>
-      <pose frame=''>0 0 0 0 0 0</pose>
       <mass>0.370000</mass>
-        <inertia>
-          <ixx>0.000317</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>0.000421</iyy>
-          <iyz>0</iyz>
-          <izz>0.000533</izz>
-        </inertia>
+      <inertia>
+        <ixx>0.000317</ixx>
+        <ixy>0</ixy>
+        <ixz>0</ixz>
+        <iyy>0.000421</iyy>
+        <iyz>0</iyz>
+        <izz>0.000533</izz>
+      </inertia>
     </inertial>
 
     <visual name='base_link_meat'>


### PR DESCRIPTION
The inertial frames of the YCB objects were aligned with the visual geometry and not the contact geometry, which led to weird behavior. This fixes that and was tested in drake-visualizer. I don't know if there's a software test we can add against this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10702)
<!-- Reviewable:end -->
