### PR TITLE
Add a clutter clearing example with DOPE objects to ManipulationStation

### DIFF
--- a/bindings/pydrake/examples/manipulation_station_py.cc
+++ b/bindings/pydrake/examples/manipulation_station_py.cc
@@ -47,7 +47,11 @@ PYBIND11_MODULE(manipulation_station, m) {
       .def("SetupClutterClearingStation",
           &ManipulationStation<T>::SetupClutterClearingStation,
           py::arg("collision_model") = IiwaCollisionModel::kNoCollision,
-          doc.ManipulationStation.SetupDefaultStation.doc)
+          doc.ManipulationStation.SetupClutterClearingStation.doc)
+        .def("SetupDopeClutterClearingStation",
+        &ManipulationStation<T>::SetupDopeClutterClearingStation,
+        py::arg("collision_model") = IiwaCollisionModel::kNoCollision,
+        doc.ManipulationStation.SetupDopeClutterClearingStation.doc)
       .def("RegisterIiwaControllerModel",
           &ManipulationStation<T>::RegisterIiwaControllerModel,
           doc.ManipulationStation.RegisterIiwaControllerModel.doc)

--- a/bindings/pydrake/examples/manipulation_station_py.cc
+++ b/bindings/pydrake/examples/manipulation_station_py.cc
@@ -48,10 +48,10 @@ PYBIND11_MODULE(manipulation_station, m) {
           &ManipulationStation<T>::SetupClutterClearingStation,
           py::arg("collision_model") = IiwaCollisionModel::kNoCollision,
           doc.ManipulationStation.SetupClutterClearingStation.doc)
-        .def("SetupDopeClutterClearingStation",
-        &ManipulationStation<T>::SetupDopeClutterClearingStation,
-        py::arg("collision_model") = IiwaCollisionModel::kNoCollision,
-        doc.ManipulationStation.SetupDopeClutterClearingStation.doc)
+      .def("SetupDopeClutterClearingStation",
+          &ManipulationStation<T>::SetupDopeClutterClearingStation,
+          py::arg("collision_model") = IiwaCollisionModel::kNoCollision,
+          doc.ManipulationStation.SetupDopeClutterClearingStation.doc)
       .def("RegisterIiwaControllerModel",
           &ManipulationStation<T>::RegisterIiwaControllerModel,
           doc.ManipulationStation.RegisterIiwaControllerModel.doc)

--- a/examples/manipulation_station/BUILD.bazel
+++ b/examples/manipulation_station/BUILD.bazel
@@ -24,6 +24,7 @@ drake_cc_library(
         ":models",
         "//manipulation/models/iiwa_description:models",
         "//manipulation/models/wsg_50_description:models",
+        "//manipulation/models/ycb:models",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/examples/manipulation_station/manipulation_station.cc
+++ b/examples/manipulation_station/manipulation_station.cc
@@ -252,7 +252,6 @@ void ManipulationStation<T>::SetupDopeClutterClearingStation(
     const std::list<std::string> models{
         "drake/manipulation/models/ycb/sdf/003_cracker_box.sdf",
         "drake/manipulation/models/ycb/sdf/004_sugar_box.sdf",
-//        "drake/examples/manipulation_station/models/sugar_box_collision.sdf",
         "drake/manipulation/models/ycb/sdf/005_tomato_soup_can.sdf",
         "drake/manipulation/models/ycb/sdf/006_mustard_bottle.sdf",
         "drake/manipulation/models/ycb/sdf/009_gelatin_box.sdf",

--- a/examples/manipulation_station/manipulation_station.cc
+++ b/examples/manipulation_station/manipulation_station.cc
@@ -252,6 +252,7 @@ void ManipulationStation<T>::SetupDopeClutterClearingStation(
     const std::list<std::string> models{
         "drake/manipulation/models/ycb/sdf/003_cracker_box.sdf",
         "drake/manipulation/models/ycb/sdf/004_sugar_box.sdf",
+//        "drake/examples/manipulation_station/models/sugar_box_collision.sdf",
         "drake/manipulation/models/ycb/sdf/005_tomato_soup_can.sdf",
         "drake/manipulation/models/ycb/sdf/006_mustard_bottle.sdf",
         "drake/manipulation/models/ycb/sdf/009_gelatin_box.sdf",
@@ -454,22 +455,30 @@ void ManipulationStation<T>::SetDefaultState(
 
       break;
     case Setup::kDopeClutterClearing:
-      DRAKE_DEMAND(object_ids_.size() == 5);
+      DRAKE_DEMAND(object_ids_.size() == 6);
 
       // Place the cracker box.
-      X_WObject.set_translation(Eigen::Vector3d(-0.3, -0.55, 0.4));
+      X_WObject.set_translation(Eigen::Vector3d(-0.3, -0.55, 0.36));
       X_WObject.set_rotation(RotationMatrix<double>(
           RollPitchYaw<double>(-1.57, 0, 3)));
       plant_->SetFreeBodyPose(plant_context, &plant_state,
                               plant_->get_body(object_ids_[0]),
                               X_WObject.GetAsIsometry3());
 
-      // Place the soup can.
-      X_WObject.set_translation(Eigen::Vector3d(-0.03, -0.57, 0.3));
+      // Place the sugar box.
+      X_WObject.set_translation(Eigen::Vector3d(-0.3, -0.7, 0.33));
+      X_WObject.set_rotation(RotationMatrix<double>(
+          RollPitchYaw<double>(1.57, 1.57, 0)));
+      plant_->SetFreeBodyPose(plant_context, &plant_state,
+                              plant_->get_body(object_ids_[1]),
+                              X_WObject.GetAsIsometry3());
+
+      // Place the tomato soup can.
+      X_WObject.set_translation(Eigen::Vector3d(-0.03, -0.57, 0.31));
       X_WObject.set_rotation(RotationMatrix<double>(
           RollPitchYaw<double>(-1.57, 0, 3.14)));
       plant_->SetFreeBodyPose(plant_context, &plant_state,
-                              plant_->get_body(object_ids_[1]),
+                              plant_->get_body(object_ids_[2]),
                               X_WObject.GetAsIsometry3());
 
       // Place the mustard bottle.
@@ -477,29 +486,21 @@ void ManipulationStation<T>::SetDefaultState(
       X_WObject.set_rotation(RotationMatrix<double>(
           RollPitchYaw<double>(-1.57, 0, 3.3)));
       plant_->SetFreeBodyPose(plant_context, &plant_state,
-                              plant_->get_body(object_ids_[2]),
+                              plant_->get_body(object_ids_[3]),
                               X_WObject.GetAsIsometry3());
 
       // Place the gelatin box.
-      X_WObject.set_translation(Eigen::Vector3d(-0.15, -0.62, 0.35));
+      X_WObject.set_translation(Eigen::Vector3d(-0.15, -0.62, 0.38));
       X_WObject.set_rotation(RotationMatrix<double>(
           RollPitchYaw<double>(-1.57, 0, 3.7)));
       plant_->SetFreeBodyPose(plant_context, &plant_state,
-                              plant_->get_body(object_ids_[3]),
+                              plant_->get_body(object_ids_[4]),
                               X_WObject.GetAsIsometry3());
 
       // Place the potted meat can.
       X_WObject.set_translation(Eigen::Vector3d(-0.15, -0.62, 0.3));
       X_WObject.set_rotation(RotationMatrix<double>(
           RollPitchYaw<double>(-1.57, 0, 2.5)));
-      plant_->SetFreeBodyPose(plant_context, &plant_state,
-                              plant_->get_body(object_ids_[4]),
-                              X_WObject.GetAsIsometry3());
-
-      // Place the sugar box.
-      X_WObject.set_translation(Eigen::Vector3d(-0.3, -0.7, 0.32));
-      X_WObject.set_rotation(RotationMatrix<double>(
-          RollPitchYaw<double>(1.57, 1.57, 0)));
       plant_->SetFreeBodyPose(plant_context, &plant_state,
                               plant_->get_body(object_ids_[5]),
                               X_WObject.GetAsIsometry3());
@@ -631,14 +632,14 @@ void ManipulationStation<T>::Finalize() {
       // the picking bin.
       q0_iiwa << -1.57, 0.1, 0, -1.2, 0, 1.6, 0;
 
-//      std::uniform_real_distribution<symbolic::Expression> x(-.35, 0.05),
-//          y(-0.8, -.55), z(0.3, 0.35);
-//      const Vector3<symbolic::Expression> xyz{x(), y(), z()};
-//      for (const auto body_index : object_ids_) {
-//        const multibody::Body<T>& body = plant_->get_body(body_index);
-//        plant_->SetFreeBodyRandomPositionDistribution(body, xyz);
-//        plant_->SetFreeBodyRandomRotationDistributionToUniform(body);
-//      }
+      std::uniform_real_distribution<symbolic::Expression> x(-.35, 0.05),
+          y(-0.8, -.55), z(0.3, 0.35);
+      const Vector3<symbolic::Expression> xyz{x(), y(), z()};
+      for (const auto body_index : object_ids_) {
+        const multibody::Body<T>& body = plant_->get_body(body_index);
+        plant_->SetFreeBodyRandomPositionDistribution(body, xyz);
+        plant_->SetFreeBodyRandomRotationDistributionToUniform(body);
+      }
       break;
     }
   }

--- a/examples/manipulation_station/manipulation_station.h
+++ b/examples/manipulation_station/manipulation_station.h
@@ -139,6 +139,7 @@ class ManipulationStation : public systems::Diagram<T> {
   ///   command inputs.
   explicit ManipulationStation(double time_step = 0.002);
 
+  // TODO(kmuhlrad): possibly delete
   /// Adds a default iiwa, wsg, two bins, and object clutter, then calls
   /// RegisterIiwaControllerModel() and RegisterWsgControllerModel() with
   /// the appropriate arguments.
@@ -148,13 +149,21 @@ class ManipulationStation : public systems::Diagram<T> {
   void SetupClutterClearingStation(
       IiwaCollisionModel collision_model = IiwaCollisionModel::kNoCollision);
 
-  /// Adds an iiwa, wsg, two bins, and YCB object clutter, then calls
+  /// Adds a default iiwa, wsg, two bins, and custom object clutter, then calls
   /// RegisterIiwaControllerModel() and RegisterWsgControllerModel() with
   /// the appropriate arguments.
   /// @note Must be called before Finalize().
   /// @note Only one of the `Setup___()` methods should be called.
+  /// @param model_files A list of sdf model files to render.
+  /// @param model_poses A list of world poses for each object. It must be the
+  /// same length as `model_files`.
+  /// @param render_rgbd_camera If true, add an RgbdCamera looking at the
+  /// clutter.
   /// @param collision_model Determines which sdf is loaded for the IIWA.
-  void SetupDopeClutterClearingStation(
+  void SetupClutterClearingStation(
+      const std::list<std::string>& model_files,
+      const std::vector<math::RigidTransform<T>>& model_poses,
+      const bool render_rgbd_camera = false,
       IiwaCollisionModel collision_model = IiwaCollisionModel::kNoCollision);
 
   /// Adds a default iiwa, wsg, cupboard, and 8020 frame for the MIT
@@ -514,6 +523,7 @@ class ManipulationStation : public systems::Diagram<T> {
   // Store references to objects as *body* indices instead of model indices,
   // because this is needed for MultibodyPlant::SetFreeBodyPose(), etc.
   std::vector<multibody::BodyIndex> object_ids_;
+  std::vector<math::RigidTransform<T>> object_poses_;
 
   // Registered camera related information.
   std::map<std::string, CameraInformation> camera_information_;

--- a/examples/manipulation_station/manipulation_station.h
+++ b/examples/manipulation_station/manipulation_station.h
@@ -21,7 +21,7 @@ namespace manipulation_station {
 enum class IiwaCollisionModel { kNoCollision, kBoxCollision };
 
 /// Determines which manipulation station is simulated.
-enum class Setup { kNone, kDefault, kClutterClearing };
+enum class Setup { kNone, kDefault, kClutterClearing, kDopeClutterClearing };
 
 /// @defgroup manipulation_station_systems Manipulation Station
 /// @{
@@ -146,6 +146,15 @@ class ManipulationStation : public systems::Diagram<T> {
   /// @note Only one of the `Setup___()` methods should be called.
   /// @param collision_model Determines which sdf is loaded for the IIWA.
   void SetupClutterClearingStation(
+      IiwaCollisionModel collision_model = IiwaCollisionModel::kNoCollision);
+
+  /// Adds an iiwa, wsg, two bins, and YCB object clutter, then calls
+  /// RegisterIiwaControllerModel() and RegisterWsgControllerModel() with
+  /// the appropriate arguments.
+  /// @note Must be called before Finalize().
+  /// @note Only one of the `Setup___()` methods should be called.
+  /// @param collision_model Determines which sdf is loaded for the IIWA.
+  void SetupDopeClutterClearingStation(
       IiwaCollisionModel collision_model = IiwaCollisionModel::kNoCollision);
 
   /// Adds a default iiwa, wsg, cupboard, and 8020 frame for the MIT

--- a/examples/manipulation_station/manipulation_station.h
+++ b/examples/manipulation_station/manipulation_station.h
@@ -21,7 +21,7 @@ namespace manipulation_station {
 enum class IiwaCollisionModel { kNoCollision, kBoxCollision };
 
 /// Determines which manipulation station is simulated.
-enum class Setup { kNone, kDefault, kClutterClearing, kDopeClutterClearing };
+enum class Setup { kNone, kDefault, kClutterClearing };
 
 /// @defgroup manipulation_station_systems Manipulation Station
 /// @{
@@ -139,7 +139,6 @@ class ManipulationStation : public systems::Diagram<T> {
   ///   command inputs.
   explicit ManipulationStation(double time_step = 0.002);
 
-  // TODO(kmuhlrad): possibly delete
   /// Adds a default iiwa, wsg, two bins, and object clutter, then calls
   /// RegisterIiwaControllerModel() and RegisterWsgControllerModel() with
   /// the appropriate arguments.
@@ -163,7 +162,7 @@ class ManipulationStation : public systems::Diagram<T> {
   void SetupClutterClearingStation(
       const std::list<std::string>& model_files,
       const std::vector<math::RigidTransform<T>>& model_poses,
-      const bool render_rgbd_camera = false,
+      bool render_rgbd_camera = false,
       IiwaCollisionModel collision_model = IiwaCollisionModel::kNoCollision);
 
   /// Adds a default iiwa, wsg, cupboard, and 8020 frame for the MIT

--- a/examples/manipulation_station/proof_of_life.cc
+++ b/examples/manipulation_station/proof_of_life.cc
@@ -29,6 +29,7 @@ DEFINE_double(target_realtime_rate, 1.0,
               "Simulator::set_target_realtime_rate() for details.");
 DEFINE_double(duration, 4.0, "Simulation duration.");
 DEFINE_bool(test, false, "Disable random initial conditions in test mode.");
+DEFINE_bool(dope, false, "Use DOPE clutter clearing example.");
 
 int do_main(int argc, char* argv[]) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
@@ -37,7 +38,12 @@ int do_main(int argc, char* argv[]) {
 
   // Create the "manipulation station".
   auto station = builder.AddSystem<ManipulationStation>();
-  station->SetupDopeClutterClearingStation(); // CHANGED from normal clutter clearing
+  // CHANGED from normal clutter clearing
+  if (FLAGS_dope) {
+    station->SetupDopeClutterClearingStation();
+  } else {
+    station->SetupClutterClearingStation();
+  }
   station->Finalize();
 
   geometry::ConnectDrakeVisualizer(&builder, station->get_mutable_scene_graph(),

--- a/examples/manipulation_station/proof_of_life.cc
+++ b/examples/manipulation_station/proof_of_life.cc
@@ -23,6 +23,9 @@ namespace {
 // (e.g. picking up an object) and perhaps a slightly more descriptive name.
 
 using Eigen::VectorXd;
+using math::RigidTransform;
+using math::RollPitchYaw;
+using math::RotationMatrix;
 
 DEFINE_double(target_realtime_rate, 1.0,
               "Playback speed.  See documentation for "
@@ -39,7 +42,55 @@ int do_main(int argc, char* argv[]) {
   // Create the "manipulation station".
   auto station = builder.AddSystem<ManipulationStation>();
   if (FLAGS_setup == "dope") {
-    station->SetupDopeClutterClearingStation();
+    // station->SetupDopeClutterClearingStation();
+    const std::list<std::string> model_files{
+        "drake/manipulation/models/ycb/sdf/003_cracker_box.sdf",
+        "drake/manipulation/models/ycb/sdf/004_sugar_box.sdf",
+        "drake/manipulation/models/ycb/sdf/005_tomato_soup_can.sdf",
+        "drake/manipulation/models/ycb/sdf/006_mustard_bottle.sdf",
+        "drake/manipulation/models/ycb/sdf/009_gelatin_box.sdf",
+        "drake/manipulation/models/ycb/sdf/010_potted_meat_can.sdf"};
+
+    std::vector<RigidTransform<double>> model_poses;
+    RigidTransform<double> X_WObject;
+
+    // The cracker box pose.
+    X_WObject.set_translation(Eigen::Vector3d(-0.3, -0.55, 0.36));
+    X_WObject.set_rotation(RotationMatrix<double>(
+        RollPitchYaw<double>(-1.57, 0, 3)));
+    model_poses.push_back(X_WObject);
+
+    // The sugar box pose.
+    X_WObject.set_translation(Eigen::Vector3d(-0.3, -0.7, 0.33));
+    X_WObject.set_rotation(RotationMatrix<double>(
+        RollPitchYaw<double>(1.57, 1.57, 0)));
+    model_poses.push_back(X_WObject);
+
+    // The tomato soup can pose.
+    X_WObject.set_translation(Eigen::Vector3d(-0.03, -0.57, 0.31));
+    X_WObject.set_rotation(RotationMatrix<double>(
+        RollPitchYaw<double>(-1.57, 0, 3.14)));
+    model_poses.push_back(X_WObject);
+
+    // The mustard bottle pose.
+    X_WObject.set_translation(Eigen::Vector3d(0.05, -0.66, 0.35));
+    X_WObject.set_rotation(RotationMatrix<double>(
+        RollPitchYaw<double>(-1.57, 0, 3.3)));
+    model_poses.push_back(X_WObject);
+
+    // The gelatin box pose.
+    X_WObject.set_translation(Eigen::Vector3d(-0.15, -0.62, 0.38));
+    X_WObject.set_rotation(RotationMatrix<double>(
+        RollPitchYaw<double>(-1.57, 0, 3.7)));
+    model_poses.push_back(X_WObject);
+
+    // The potted meat can pose.
+    X_WObject.set_translation(Eigen::Vector3d(-0.15, -0.62, 0.3));
+    X_WObject.set_rotation(RotationMatrix<double>(
+        RollPitchYaw<double>(-1.57, 0, 2.5)));
+    model_poses.push_back(X_WObject);
+
+    station->SetupClutterClearingStation(model_files, model_poses, true);
   } else if (FLAGS_setup == "clutter_clearing") {
     station->SetupClutterClearingStation();
   } else if (FLAGS_setup == "default") {

--- a/examples/manipulation_station/proof_of_life.cc
+++ b/examples/manipulation_station/proof_of_life.cc
@@ -29,7 +29,7 @@ DEFINE_double(target_realtime_rate, 1.0,
               "Simulator::set_target_realtime_rate() for details.");
 DEFINE_double(duration, 4.0, "Simulation duration.");
 DEFINE_bool(test, false, "Disable random initial conditions in test mode.");
-DEFINE_bool(dope, false, "Use DOPE clutter clearing example.");
+DEFINE_string(setup, "clutter_clearing", "Manipulation Station setup option.");
 
 int do_main(int argc, char* argv[]) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
@@ -38,11 +38,15 @@ int do_main(int argc, char* argv[]) {
 
   // Create the "manipulation station".
   auto station = builder.AddSystem<ManipulationStation>();
-  // CHANGED from normal clutter clearing
-  if (FLAGS_dope) {
+  if (FLAGS_setup == "dope") {
     station->SetupDopeClutterClearingStation();
-  } else {
+  } else if (FLAGS_setup == "clutter_clearing") {
     station->SetupClutterClearingStation();
+  } else if (FLAGS_setup == "default") {
+    station->SetupDefaultStation();
+  } else {
+    DRAKE_ABORT_MSG("Invalid option for flag setup.  Valid options are: "
+                    "default, clutter_clearing, dope.");
   }
   station->Finalize();
 

--- a/examples/manipulation_station/proof_of_life.cc
+++ b/examples/manipulation_station/proof_of_life.cc
@@ -41,63 +41,13 @@ int do_main(int argc, char* argv[]) {
 
   // Create the "manipulation station".
   auto station = builder.AddSystem<ManipulationStation>();
-  if (FLAGS_setup == "dope") {
-    // station->SetupDopeClutterClearingStation();
-    const std::list<std::string> model_files{
-        "drake/manipulation/models/ycb/sdf/003_cracker_box.sdf",
-        "drake/manipulation/models/ycb/sdf/004_sugar_box.sdf",
-        "drake/manipulation/models/ycb/sdf/005_tomato_soup_can.sdf",
-        "drake/manipulation/models/ycb/sdf/006_mustard_bottle.sdf",
-        "drake/manipulation/models/ycb/sdf/009_gelatin_box.sdf",
-        "drake/manipulation/models/ycb/sdf/010_potted_meat_can.sdf"};
-
-    std::vector<RigidTransform<double>> model_poses;
-    RigidTransform<double> X_WObject;
-
-    // The cracker box pose.
-    X_WObject.set_translation(Eigen::Vector3d(-0.3, -0.55, 0.36));
-    X_WObject.set_rotation(RotationMatrix<double>(
-        RollPitchYaw<double>(-1.57, 0, 3)));
-    model_poses.push_back(X_WObject);
-
-    // The sugar box pose.
-    X_WObject.set_translation(Eigen::Vector3d(-0.3, -0.7, 0.33));
-    X_WObject.set_rotation(RotationMatrix<double>(
-        RollPitchYaw<double>(1.57, 1.57, 0)));
-    model_poses.push_back(X_WObject);
-
-    // The tomato soup can pose.
-    X_WObject.set_translation(Eigen::Vector3d(-0.03, -0.57, 0.31));
-    X_WObject.set_rotation(RotationMatrix<double>(
-        RollPitchYaw<double>(-1.57, 0, 3.14)));
-    model_poses.push_back(X_WObject);
-
-    // The mustard bottle pose.
-    X_WObject.set_translation(Eigen::Vector3d(0.05, -0.66, 0.35));
-    X_WObject.set_rotation(RotationMatrix<double>(
-        RollPitchYaw<double>(-1.57, 0, 3.3)));
-    model_poses.push_back(X_WObject);
-
-    // The gelatin box pose.
-    X_WObject.set_translation(Eigen::Vector3d(-0.15, -0.62, 0.38));
-    X_WObject.set_rotation(RotationMatrix<double>(
-        RollPitchYaw<double>(-1.57, 0, 3.7)));
-    model_poses.push_back(X_WObject);
-
-    // The potted meat can pose.
-    X_WObject.set_translation(Eigen::Vector3d(-0.15, -0.62, 0.3));
-    X_WObject.set_rotation(RotationMatrix<double>(
-        RollPitchYaw<double>(-1.57, 0, 2.5)));
-    model_poses.push_back(X_WObject);
-
-    station->SetupClutterClearingStation(model_files, model_poses, true);
-  } else if (FLAGS_setup == "clutter_clearing") {
+  if (FLAGS_setup == "clutter_clearing") {
     station->SetupClutterClearingStation();
   } else if (FLAGS_setup == "default") {
     station->SetupDefaultStation();
   } else {
     DRAKE_ABORT_MSG("Invalid option for flag setup.  Valid options are: "
-                    "default, clutter_clearing, dope.");
+                    "default, clutter_clearing.");
   }
   station->Finalize();
 

--- a/examples/manipulation_station/proof_of_life.cc
+++ b/examples/manipulation_station/proof_of_life.cc
@@ -37,7 +37,7 @@ int do_main(int argc, char* argv[]) {
 
   // Create the "manipulation station".
   auto station = builder.AddSystem<ManipulationStation>();
-  station->SetupClutterClearingStation();
+  station->SetupDopeClutterClearingStation(); // CHANGED from normal clutter clearing
   station->Finalize();
 
   geometry::ConnectDrakeVisualizer(&builder, station->get_mutable_scene_graph(),

--- a/examples/manipulation_station/test/manipulation_station_test.cc
+++ b/examples/manipulation_station/test/manipulation_station_test.cc
@@ -262,6 +262,19 @@ GTEST_TEST(ManipulationStationTest, SetupClutterClearingStation) {
   station.SetRandomContext(context.get(), &generator);
 }
 
+GTEST_TEST(ManipulationStationTest, SetupDopeClutterClearingStation) {
+  ManipulationStation<double> station(0.002);
+  station.SetupDopeClutterClearingStation(IiwaCollisionModel::kNoCollision);
+  station.Finalize();
+
+  // Make sure we get through the setup and initialization.
+  auto context = station.CreateDefaultContext();
+
+  // Check that domain randomization works.
+  RandomGenerator generator;
+  station.SetRandomContext(context.get(), &generator);
+}
+
 // Check that making many stations does not exhaust resources.
 GTEST_TEST(ManipulationStationTest, MultipleInstanceTest) {
   for (int i = 0; i < 20; ++i) {

--- a/examples/manipulation_station/test/manipulation_station_test.cc
+++ b/examples/manipulation_station/test/manipulation_station_test.cc
@@ -16,6 +16,9 @@ namespace {
 
 using Eigen::Vector2d;
 using Eigen::VectorXd;
+using math::RigidTransform;
+using math::RollPitchYaw;
+using math::RotationMatrix;
 using multibody::RevoluteJoint;
 using systems::BasicVector;
 
@@ -249,7 +252,7 @@ GTEST_TEST(ManipulationStationTest, CheckCollisionVariants) {
   EXPECT_EQ(station2.get_controller_plant().num_collision_geometries(), 0);
 }
 
-GTEST_TEST(ManipulationStationTest, SetupClutterClearingStation) {
+GTEST_TEST(ManipulationStationTest, SetupClutterClearingStationDefault) {
   ManipulationStation<double> station(0.002);
   station.SetupClutterClearingStation(IiwaCollisionModel::kNoCollision);
   station.Finalize();
@@ -262,9 +265,22 @@ GTEST_TEST(ManipulationStationTest, SetupClutterClearingStation) {
   station.SetRandomContext(context.get(), &generator);
 }
 
-GTEST_TEST(ManipulationStationTest, SetupDopeClutterClearingStation) {
+GTEST_TEST(ManipulationStationTest, SetupClutterClearingStationCustom) {
+  const std::list<std::string> model_files{
+      "drake/manipulation/models/ycb/sdf/003_cracker_box.sdf"};
+
+  std::vector<RigidTransform<double>> model_poses;
+  RigidTransform<double> X_WObject;
+
+  // The cracker box pose.
+  X_WObject.set_translation(Eigen::Vector3d(-0.3, -0.55, 0.36));
+  X_WObject.set_rotation(RotationMatrix<double>(
+      RollPitchYaw<double>(-1.57, 0, 3)));
+  model_poses.push_back(X_WObject);
+
   ManipulationStation<double> station(0.002);
-  station.SetupDopeClutterClearingStation(IiwaCollisionModel::kNoCollision);
+  station.SetupClutterClearingStation(
+      model_files, model_poses, true, IiwaCollisionModel::kNoCollision);
   station.Finalize();
 
   // Make sure we get through the setup and initialization.

--- a/manipulation/models/ycb/sdf/003_cracker_box.sdf
+++ b/manipulation/models/ycb/sdf/003_cracker_box.sdf
@@ -9,18 +9,23 @@
     Origin:
       (0, 0, 0) at the center of the box.
   -->
+
+  <!--
+    The inertial properties were calculated from the mass and dimensions given
+    with the YCB dataset. The cracker box is treated as a constant density box,
+    which matches the collision shape.
+  -->
   <link name="base_link_cracker">
     <inertial>
-      <pose frame=''>-0.014 0.103 0.013 1.57 -1.57 0</pose>
       <mass>0.411</mass>
-        <inertia>
-          <ixx>0.001736</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>0.001098</iyy>
-          <iyz>0</iyz>
-          <izz>0.002481</izz>
-        </inertia>
+      <inertia>
+        <ixx>0.001736</ixx>
+        <ixy>0</ixy>
+        <ixz>0</ixz>
+        <iyy>0.001098</iyy>
+        <iyz>0</iyz>
+        <izz>0.002481</izz>
+      </inertia>
     </inertial>
 
     <visual name='base_link_cracker'>

--- a/manipulation/models/ycb/sdf/004_sugar_box.sdf
+++ b/manipulation/models/ycb/sdf/004_sugar_box.sdf
@@ -9,18 +9,23 @@
     Origin:
       (0, 0, 0) at the center of the box.
   -->
+
+  <!--
+    The inertial properties were calculated from the mass and dimensions given
+    with the YCB dataset. The sugar box is treated as a constant density box,
+    which matches the collision shape.
+   -->
   <link name="base_link_sugar">
     <inertial>
-      <pose frame=''>-0.018  0.088  0.0039 -0.77 -1.52 2.36</pose>
       <mass>0.514000</mass>
-        <inertia>
-          <ixx>0.001418</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>0.000455</iyy>
-          <iyz>0</iyz>
-          <izz>0.001699</izz>
-        </inertia>
+      <inertia>
+        <ixx>0.001418</ixx>
+        <ixy>0</ixy>
+        <ixz>0</ixz>
+        <iyy>0.000455</iyy>
+        <iyz>0</iyz>
+        <izz>0.001699</izz>
+      </inertia>
     </inertial>
 
     <visual name='base_link_sugar'>

--- a/manipulation/models/ycb/sdf/005_tomato_soup_can.sdf
+++ b/manipulation/models/ycb/sdf/005_tomato_soup_can.sdf
@@ -9,18 +9,23 @@
     Origin:
       (0, 0, 0) at the center of the can.
   -->
+
+  <!--
+    The inertial properties were calculated from the mass and dimensions given
+    with the YCB dataset. The tomato soup can is treated as a constant density
+    cylinder, which matches the collision shape.
+  -->
   <link name="base_link_soup">
     <inertial>
-      <pose frame=''>-0.0018  0.051 -0.084 1.57 0.13 0.0</pose>
       <mass>0.349000</mass>
-        <inertia>
-          <ixx>0.000402</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>0.000200</iyy>
-          <iyz>0</iyz>
-          <izz>0.000402</izz>
-        </inertia>
+      <inertia>
+        <ixx>0.000402</ixx>
+        <ixy>0</ixy>
+        <ixz>0</ixz>
+        <iyy>0.000200</iyy>
+        <iyz>0</iyz>
+        <izz>0.000402</izz>
+      </inertia>
     </inertial>
 
     <visual name='base_link_soup'>

--- a/manipulation/models/ycb/sdf/006_mustard_bottle.sdf
+++ b/manipulation/models/ycb/sdf/006_mustard_bottle.sdf
@@ -9,18 +9,24 @@
     Origin:
       (0, 0, 0) at the center of the bottle's bounding box.
   -->
+
+  <!--
+    The inertial properties were calculated from the mass and dimensions given
+    with the YCB dataset. The mustard bottle is treated as a constant density
+    box from the base of the bottle to the bottom of the cap, which matches the
+    collision shape.
+  -->
   <link name="base_link_mustard">
     <inertial>
-      <pose frame=''>0.0049 0.092 0.027 1.57 -0.40 0.0</pose>
       <mass>0.603000</mass>
-        <inertia>
-          <ixx>0.002009</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>0.000633</iyy>
-          <iyz>0</iyz>
-          <izz>0.002302</izz>
-        </inertia>
+      <inertia>
+        <ixx>0.002009</ixx>
+        <ixy>0</ixy>
+        <ixz>0</ixz>
+        <iyy>0.000633</iyy>
+        <iyz>0</iyz>
+        <izz>0.002302</izz>
+      </inertia>
     </inertial>
     <visual name='base_link_mustard'>
       <pose frame=''>0.0049 0.092 0.027 1.57 -0.40 0.0</pose>

--- a/manipulation/models/ycb/sdf/009_gelatin_box.sdf
+++ b/manipulation/models/ycb/sdf/009_gelatin_box.sdf
@@ -9,18 +9,23 @@
     Origin:
       (0, 0, 0) at the center of the box.
   -->
+
+  <!--
+    The inertial properties were calculated from the mass and dimensions given
+    with the YCB dataset. The gelatin box is treated as a constant density box,
+    which matches the collision shape.
+  -->
   <link name="base_link_gelatin">
     <inertial>
-      <pose frame=''>-0.0029 0.024 -0.015 -0.0085 -0.002 1.34</pose>
       <mass>0.097000</mass>
-        <inertia>
-          <ixx>0.000050</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>0.000072</iyy>
-          <iyz>0</iyz>
-          <izz>0.000108</izz>
-        </inertia>
+      <inertia>
+        <ixx>0.000050</ixx>
+        <ixy>0</ixy>
+        <ixz>0</ixz>
+        <iyy>0.000072</iyy>
+        <iyz>0</iyz>
+        <izz>0.000108</izz>
+      </inertia>
     </inertial>
 
     <visual name='base_link_gelatin'>

--- a/manipulation/models/ycb/sdf/010_potted_meat_can.sdf
+++ b/manipulation/models/ycb/sdf/010_potted_meat_can.sdf
@@ -9,18 +9,23 @@
     Origin:
       (0, 0, 0) at the center of the can.
   -->
+
+  <!--
+    The inertial properties were calculated from the mass and dimensions given
+    with the YCB dataset. The pottted meat can is treated as a constant density
+    box, which matches the collision shape.
+  -->
   <link name="base_link_meat">
     <inertial>
-      <pose frame=''>0.034 0.039 0.025 1.57 0.052 0.0</pose>
       <mass>0.370000</mass>
-        <inertia>
-          <ixx>0.000317</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>0.000421</iyy>
-          <iyz>0</iyz>
-          <izz>0.000533</izz>
-        </inertia>
+      <inertia>
+        <ixx>0.000317</ixx>
+        <ixy>0</ixy>
+        <ixz>0</ixz>
+        <iyy>0.000421</iyy>
+        <iyz>0</iyz>
+        <izz>0.000533</izz>
+      </inertia>
     </inertial>
 
     <visual name='base_link_meat'>


### PR DESCRIPTION
This adds another setup option to `ManipulationStation` similar to the `ClutterClearing` option, but with the YCB objects from DOPE instead of abstract objects. There is a Python binding to the new method, as well as tests. `proof_of_life.cc` includes the option of using this new setup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10703)
<!-- Reviewable:end -->
