### PR TITLE
geometry: Visualization should not depend on Gurobi

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -209,7 +209,7 @@ drake_cc_library(
         "//lcmtypes:viewer",
         "//math:geometric_transform",
         "//systems/framework:diagram_builder",
-        "//systems/lcm",
+        "//systems/lcm:lcm_pubsub_system",
         "//systems/rendering:pose_bundle_to_draw_message",
     ],
 )

--- a/manipulation/models/ycb/BUILD.bazel
+++ b/manipulation/models/ycb/BUILD.bazel
@@ -35,6 +35,7 @@ drake_cc_googletest(
         "//common:find_resource",
         "//multibody/parsing",
         "//multibody/plant",
+        "//systems/analysis:simulator",
     ],
 )
 

--- a/multibody/inverse_kinematics/BUILD.bazel
+++ b/multibody/inverse_kinematics/BUILD.bazel
@@ -141,6 +141,7 @@ drake_cc_googletest(
         ":inverse_kinematics_core",
         ":inverse_kinematics_test_utilities",
         "//math:geometric_transform",
+        "//solvers:solve",
     ],
 )
 

--- a/systems/lcm/BUILD.bazel
+++ b/systems/lcm/BUILD.bazel
@@ -112,7 +112,7 @@ drake_cc_library(
     deps = [
         ":lcm_pubsub_system",
         "//lcm",
-        "//systems/analysis",
+        "//systems/analysis:simulator",
     ],
 )
 


### PR DESCRIPTION
``` console
$ bazel query 'allpaths(//geometry, //solvers:gurobi_solver)'
//geometry:geometry
//geometry:geometry_visualization
//systems/lcm:lcm
//systems/lcm:lcm_driven_loop
//systems/analysis:analysis
//systems/analysis:lyapunov
//solvers:solve
//solvers:mathematical_program
//solvers:choose_best_solver
//solvers:gurobi_solver
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10705)
<!-- Reviewable:end -->
