### PR TITLE
primitives: Tidy up some access modifiers

### DIFF
--- a/systems/primitives/barycentric_system.h
+++ b/systems/primitives/barycentric_system.h
@@ -22,7 +22,7 @@ namespace systems {
 ///
 /// @see math::BarycentricMesh
 template <typename T>
-class BarycentricMeshSystem : public VectorSystem<T> {
+class BarycentricMeshSystem final : public VectorSystem<T> {
   // TODO(russt): Could generalize this to systems with state.
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BarycentricMeshSystem);
@@ -48,8 +48,8 @@ class BarycentricMeshSystem : public VectorSystem<T> {
   /// Returns a reference to the output values.
   const MatrixX<T>& get_output_values() const { return output_values_; }
 
- protected:
-  /// Evaluates the BarycentricMesh at the input and writes it to the output.
+ private:
+  // Evaluates the BarycentricMesh at the input and writes it to the output.
   virtual void DoCalcVectorOutput(
       const Context<T>& context,
       const Eigen::VectorBlock<const VectorX<T>>& input,
@@ -59,7 +59,6 @@ class BarycentricMeshSystem : public VectorSystem<T> {
     mesh_.Eval(output_values_, input, output);
   }
 
- private:
   const math::BarycentricMesh<T> mesh_;
   const MatrixX<T> output_values_;
 };

--- a/systems/primitives/constant_value_source.h
+++ b/systems/primitives/constant_value_source.h
@@ -24,7 +24,7 @@ namespace systems {
 ///
 /// They are already available to link against in the containing library.
 template <typename T>
-class ConstantValueSource : public LeafSystem<T> {
+class ConstantValueSource final : public LeafSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ConstantValueSource)
 

--- a/systems/primitives/constant_vector_source.h
+++ b/systems/primitives/constant_vector_source.h
@@ -56,7 +56,7 @@ class ConstantVectorSource final : public SingleOutputVectorSource<T> {
   template <typename U>
   explicit ConstantVectorSource(const ConstantVectorSource<U>& other);
 
-  ~ConstantVectorSource() override;
+  ~ConstantVectorSource() final;
 
   /// Return a read-only reference to the source value of this block in the
   /// given @p context.
@@ -76,7 +76,7 @@ class ConstantVectorSource final : public SingleOutputVectorSource<T> {
   // Outputs a signal with a fixed value as specified by the user.
   void DoCalcVectorOutput(
       const Context<T>& context,
-      Eigen::VectorBlock<VectorX<T>>* output) const override;
+      Eigen::VectorBlock<VectorX<T>>* output) const final;
 
   const int source_value_index_;
 };

--- a/systems/primitives/discrete_derivative.h
+++ b/systems/primitives/discrete_derivative.h
@@ -89,12 +89,11 @@ class DiscreteDerivative final : public LeafSystem<T> {
 
   double time_step() const { return time_step_; }
 
- protected:
+ private:
   optional<bool> DoHasDirectFeedthrough(int, int) const {
     return false;
   }
 
- private:
   void DoCalcDiscreteVariableUpdates(
       const Context<T>& context,
       const std::vector<const DiscreteUpdateEvent<T>*>&,

--- a/systems/primitives/first_order_low_pass_filter.h
+++ b/systems/primitives/first_order_low_pass_filter.h
@@ -80,18 +80,18 @@ class FirstOrderLowPassFilter final : public VectorSystem<T> {
   void set_initial_output_value(Context<T>* context,
                                 const Eigen::Ref<const VectorX<T>>& z0) const;
 
- protected:
+ private:
   void DoCalcVectorTimeDerivatives(
       const Context<T>& context,
       const Eigen::VectorBlock<const VectorX<T>>& input,
       const Eigen::VectorBlock<const VectorX<T>>& state,
-      Eigen::VectorBlock<VectorX<T>>* derivatives) const override;
+      Eigen::VectorBlock<VectorX<T>>* derivatives) const final;
 
   void DoCalcVectorOutput(
       const Context<T>& context,
       const Eigen::VectorBlock<const VectorX<T>>& input,
       const Eigen::VectorBlock<const VectorX<T>>& state,
-      Eigen::VectorBlock<VectorX<T>>* output) const override;
+      Eigen::VectorBlock<VectorX<T>>* output) const final;
 
   const VectorX<double> time_constants_;
 };

--- a/systems/primitives/gain.h
+++ b/systems/primitives/gain.h
@@ -62,12 +62,12 @@ class Gain final : public VectorSystem<T> {
   /// Returns the gain vector constant.
   const Eigen::VectorXd& get_gain_vector() const;
 
- protected:
+ private:
   void DoCalcVectorOutput(
       const Context<T>& context,
       const Eigen::VectorBlock<const VectorX<T>>& input,
       const Eigen::VectorBlock<const VectorX<T>>& state,
-      Eigen::VectorBlock<VectorX<T>>* output) const override;
+      Eigen::VectorBlock<VectorX<T>>* output) const final;
 
   const Eigen::VectorXd k_;
 };

--- a/systems/primitives/integrator.cc
+++ b/systems/primitives/integrator.cc
@@ -19,7 +19,7 @@ Integrator<T>::Integrator(const Integrator<U>& other)
     : Integrator<T>(other.get_input_port().size()) {}
 
 template <typename T>
-Integrator<T>::~Integrator() {}
+Integrator<T>::~Integrator() = default;
 
 template <typename T>
 void Integrator<T>::set_integral_value(

--- a/systems/primitives/integrator.h
+++ b/systems/primitives/integrator.h
@@ -32,27 +32,27 @@ class Integrator final : public VectorSystem<T> {
   template <typename U>
   explicit Integrator(const Integrator<U>&);
 
-  ~Integrator() override;
+  ~Integrator() final;
 
   /// Sets the value of the integral modifying the state in the context.
   /// @p value must be a column vector of the appropriate size.
   void set_integral_value(Context<T>* context,
                           const Eigen::Ref<const VectorX<T>>& value) const;
 
- protected:
+ private:
   // VectorSystem<T> override.
   void DoCalcVectorOutput(
       const Context<T>& context,
       const Eigen::VectorBlock<const VectorX<T>>& input,
       const Eigen::VectorBlock<const VectorX<T>>& state,
-      Eigen::VectorBlock<VectorX<T>>* output) const override;
+      Eigen::VectorBlock<VectorX<T>>* output) const final;
 
   // VectorSystem<T> override.
   void DoCalcVectorTimeDerivatives(
       const Context<T>& context,
       const Eigen::VectorBlock<const VectorX<T>>& input,
       const Eigen::VectorBlock<const VectorX<T>>& state,
-      Eigen::VectorBlock<VectorX<T>>* derivatives) const override;
+      Eigen::VectorBlock<VectorX<T>>* derivatives) const final;
 };
 
 }  // namespace systems

--- a/systems/primitives/pass_through.h
+++ b/systems/primitives/pass_through.h
@@ -58,7 +58,7 @@ class PassThrough final : public LeafSystem<T> {
   template <typename U>
   explicit PassThrough(const PassThrough<U>&);
 
-  virtual ~PassThrough() {}
+  virtual ~PassThrough() = default;
 
   // TODO(eric.cousineau): Possibly share single port interface with
   // ZeroOrderHold (#6490).
@@ -79,7 +79,14 @@ class PassThrough final : public LeafSystem<T> {
   // Don't use the indexed get_output_port when calling this system directly.
   void get_output_port(int) = delete;
 
- protected:
+ private:
+  // Allow different specializations to access each other's private data.
+  template <typename U> friend class PassThrough;
+
+  // All of the other constructors delegate here.
+  PassThrough(int vector_size,
+              std::unique_ptr<const AbstractValue> abstract_model_value);
+
   /// Sets the output port to equal the input port.
   void DoCalcVectorOutput(
       const Context<T>& context,
@@ -92,17 +99,9 @@ class PassThrough final : public LeafSystem<T> {
 
   // Override feedthrough detection to avoid the need for `DoToSymbolic()`.
   optional<bool> DoHasDirectFeedthrough(
-      int input_port, int output_port) const override;
+      int input_port, int output_port) const final;
 
- private:
   bool is_abstract() const { return abstract_model_value_ != nullptr; }
-
-  // Delegated constructor so that we may clone properly at run-time.
-  PassThrough(int vector_size,
-              std::unique_ptr<const AbstractValue> abstract_model_value);
-
-  // Allow different specializations to access each other's private data.
-  template <typename U> friend class PassThrough;
 
   const std::unique_ptr<const AbstractValue> abstract_model_value_;
 };

--- a/systems/primitives/piecewise_polynomial_affine_system.h
+++ b/systems/primitives/piecewise_polynomial_affine_system.h
@@ -42,9 +42,10 @@ class PiecewisePolynomialAffineSystem final
   ///  time_period=0.0 to denote a continuous time system.  @default 0.0
   PiecewisePolynomialAffineSystem(const TimeVaryingData& data,
                                   double time_period = 0.)
-      : PiecewisePolynomialAffineSystem<T>(
-            SystemTypeTag<systems::PiecewisePolynomialAffineSystem>{}, data,
-            time_period) {}
+      : TimeVaryingAffineSystem<T>(
+            SystemTypeTag<systems::PiecewisePolynomialAffineSystem>{},
+            data.A.rows(), data.B.cols(), data.C.rows(), time_period),
+        data_(data) {}
 
   /// Scalar-converting copy constructor.  See @ref system_scalar_conversion.
   template <typename U>
@@ -74,19 +75,6 @@ class PiecewisePolynomialAffineSystem final
     return data_.y0.value(ExtractDoubleOrThrow(t));
   }
   /// @}
-
- protected:
-  /// Constructor that specifies scalar-type conversion support.
-  /// @param converter scalar-type conversion support helper (i.e., AutoDiff,
-  /// etc.); pass a default-constructed object if such support is not desired.
-  /// See @ref system_scalar_conversion and examples related to scalar-type
-  /// conversion support for more details.
-  PiecewisePolynomialAffineSystem(SystemScalarConverter converter,
-                                  const TimeVaryingData& data,
-                                  double time_period)
-      : TimeVaryingAffineSystem<T>(std::move(converter), data.A.rows(),
-                                   data.B.cols(), data.C.rows(), time_period),
-        data_(data) {}
 
  private:
   // Allow different specializations to access each other's private data.

--- a/systems/primitives/piecewise_polynomial_linear_system.h
+++ b/systems/primitives/piecewise_polynomial_linear_system.h
@@ -42,9 +42,10 @@ class PiecewisePolynomialLinearSystem final
   ///  time_period=0.0 to denote a continuous time system.  @default 0.0
   PiecewisePolynomialLinearSystem(const LinearTimeVaryingData& data,
                                   double time_period = 0.)
-      : PiecewisePolynomialLinearSystem<T>(
-            SystemTypeTag<systems::PiecewisePolynomialLinearSystem>{}, data,
-            time_period) {}
+      : TimeVaryingLinearSystem<T>(
+            SystemTypeTag<systems::PiecewisePolynomialLinearSystem>{},
+            data.A.rows(), data.B.cols(), data.C.rows(), time_period),
+        data_(data) {}
 
   /// Scalar-converting copy constructor.  See @ref system_scalar_conversion.
   template <typename U>
@@ -68,19 +69,6 @@ class PiecewisePolynomialLinearSystem final
     return data_.D.value(ExtractDoubleOrThrow(t));
   }
   /// @}
-
- protected:
-  /// Constructor that specifies scalar-type conversion support.
-  /// @param converter scalar-type conversion support helper (i.e., AutoDiff,
-  /// etc.); pass a default-constructed object if such support is not desired.
-  /// See @ref system_scalar_conversion and examples related to scalar-type
-  /// conversion support for more details.
-  PiecewisePolynomialLinearSystem(SystemScalarConverter converter,
-                                  const LinearTimeVaryingData& data,
-                                  double time_period)
-      : TimeVaryingLinearSystem<T>(std::move(converter), data.A.rows(),
-                                   data.B.cols(), data.C.rows(), time_period),
-        data_(data) {}
 
  private:
   // Allow different specializations to access each other's private data.

--- a/systems/primitives/random_source.h
+++ b/systems/primitives/random_source.h
@@ -64,7 +64,7 @@ class RandomState {
 ///
 /// @ingroup primitive_systems
 template <typename Distribution, typename Generator = RandomGenerator>
-class RandomSource : public LeafSystem<double> {
+class RandomSource final : public LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RandomSource)
 
@@ -88,7 +88,7 @@ class RandomSource : public LeafSystem<double> {
   void DoCalcUnrestrictedUpdate(
       const Context<double>&,
       const std::vector<const UnrestrictedUpdateEvent<double>*>&,
-      State<double>* state) const override {
+      State<double>* state) const final {
     auto& random_state =
         state->template get_mutable_abstract_state<RandomState>(0);
     auto& updates = state->get_mutable_discrete_state();
@@ -97,13 +97,13 @@ class RandomSource : public LeafSystem<double> {
     }
   }
 
-  std::unique_ptr<AbstractValues> AllocateAbstractState() const override {
+  std::unique_ptr<AbstractValues> AllocateAbstractState() const final {
     return std::make_unique<AbstractValues>(
         AbstractValue::Make(RandomState(seed_)));
   }
 
   void SetDefaultState(const Context<double>& context,
-                       State<double>* state) const override {
+                       State<double>* state) const final {
     unused(context);
     auto& random_state =
         state->template get_mutable_abstract_state<RandomState>(0);
@@ -115,7 +115,7 @@ class RandomSource : public LeafSystem<double> {
   }
 
   void SetRandomState(const Context<double>& context, State<double>* state,
-                      RandomGenerator* generator) const override {
+                      RandomGenerator* generator) const final {
     unused(context);
     auto& random_state =
         state->template get_mutable_abstract_state<RandomState>(0);

--- a/systems/primitives/saturation.h
+++ b/systems/primitives/saturation.h
@@ -40,7 +40,7 @@ namespace systems {
 ///
 /// @ingroup primitive_systems
 template <typename T>
-class Saturation : public LeafSystem<T> {
+class Saturation final : public LeafSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Saturation)
 

--- a/systems/primitives/signal_logger.h
+++ b/systems/primitives/signal_logger.h
@@ -56,7 +56,7 @@ namespace systems {
 ///
 /// @ingroup primitive_systems
 template <typename T>
-class SignalLogger : public LeafSystem<T> {
+class SignalLogger final : public LeafSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SignalLogger)
 

--- a/systems/primitives/sine.h
+++ b/systems/primitives/sine.h
@@ -104,7 +104,7 @@ class Sine final : public LeafSystem<T> {
   /// Returns the phase vector constant.
   const Eigen::VectorXd& phase_vector() const;
 
- protected:
+ private:
   void CalcValueOutput(const Context<T>& context,
                        BasicVector<T>* output) const;
   void CalcFirstDerivativeOutput(const Context<T>& context,

--- a/systems/primitives/test/piecewise_linear_affine_test.h
+++ b/systems/primitives/test/piecewise_linear_affine_test.h
@@ -13,7 +13,8 @@ static constexpr double kDiscreteTimeStep = 0.1;
 
 // A helper for accessing the underlying PiecewisePolynomial data.
 struct MatrixData {
-  MatrixData() {}
+  MatrixData() = default;
+
   /// Fully-parameterized constructor.
   MatrixData(const std::vector<double>& times_in,
              const std::vector<Eigen::MatrixXd>& Avec_in,

--- a/systems/primitives/trajectory_source.h
+++ b/systems/primitives/trajectory_source.h
@@ -26,7 +26,7 @@ namespace systems {
 /// No other values for T are currently supported.
 /// @ingroup primitive_systems
 template <typename T>
-class TrajectorySource : public SingleOutputVectorSource<T> {
+class TrajectorySource final : public SingleOutputVectorSource<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(TrajectorySource)
 
@@ -39,9 +39,9 @@ class TrajectorySource : public SingleOutputVectorSource<T> {
                             int output_derivative_order = 0,
                             bool zero_derivatives_beyond_limits = true);
 
-  ~TrajectorySource() override = default;
+  ~TrajectorySource() final = default;
 
- protected:
+ private:
   /// Outputs a vector of values evaluated at the context time of the trajectory
   /// and up to its Nth derivatives, where the trajectory and N are passed to
   /// the constructor. The size of the vector is:
@@ -49,9 +49,8 @@ class TrajectorySource : public SingleOutputVectorSource<T> {
   /// constructor.
   void DoCalcVectorOutput(
       const Context<T>& context,
-      Eigen::VectorBlock<VectorX<T>>* output) const override;
+      Eigen::VectorBlock<VectorX<T>>* output) const final;
 
- private:
   const std::unique_ptr<trajectories::Trajectory<T>> trajectory_;
   const bool clamp_derivatives_;
   std::vector<std::unique_ptr<trajectories::Trajectory<T>>> derivatives_;

--- a/systems/primitives/wrap_to_system.h
+++ b/systems/primitives/wrap_to_system.h
@@ -25,7 +25,7 @@ namespace systems {
 ///
 /// @ingroup primitive_systems
 template <typename T>
-class WrapToSystem : public LeafSystem<T> {
+class WrapToSystem final : public LeafSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(WrapToSystem)
 


### PR DESCRIPTION
Some classes were missing `final`; add it.  (Any primitive System that does not offer a SystemScalarConverter protected constructor must be marked final.)

Some final classes has protected members; demote them to private, because protected is meaningless (and thus misleading) when subclassing is not permitted.  This also has the advantage of hiding it from Doxygen.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10707)
<!-- Reviewable:end -->
