### PR TITLE
primitives: Stop using OutputPort::Calc

### DIFF
--- a/systems/framework/test/single_output_vector_source_test.cc
+++ b/systems/framework/test/single_output_vector_source_test.cc
@@ -34,25 +34,17 @@ class SingleOutputVectorSourceTest : public ::testing::Test {
   void SetUp() override {
     source_ = std::make_unique<TestSource>();
     context_ = source_->CreateDefaultContext();
-    output_ = source_->AllocateOutput();
   }
 
   std::unique_ptr<System<double>> source_;
   std::unique_ptr<Context<double>> context_;
-  std::unique_ptr<SystemOutput<double>> output_;
 };
 
 // Tests that the output is correct.
 TEST_F(SingleOutputVectorSourceTest, OutputTest) {
   ASSERT_EQ(context_->get_num_input_ports(), 0);
-  ASSERT_EQ(output_->get_num_ports(), 1);
-
-  std::unique_ptr<AbstractValue> output =
-      source_->get_output_port(0).Allocate();
-  source_->get_output_port(0).Calc(*context_, output.get());
-
-  const auto& output_vector = output->GetValueOrThrow<BasicVector<double>>();
-  EXPECT_EQ(output_vector.get_value(), Eigen::Vector3d::Ones());
+  EXPECT_EQ(source_->get_output_port(0).Eval(*context_),
+            Eigen::Vector3d::Ones());
 }
 
 // Tests that the state is empty.

--- a/systems/primitives/linear_system.cc
+++ b/systems/primitives/linear_system.cc
@@ -269,17 +269,12 @@ std::unique_ptr<AffineSystem<double>> DoFirstOrderTaylorApproximation(
   Eigen::VectorXd y0 = Eigen::VectorXd::Zero(num_outputs);
 
   if (output_port) {
-    std::unique_ptr<AbstractValue> autodiff_y0 = output_port->Allocate();
-    output_port->Calc(*autodiff_context, autodiff_y0.get());
-
-    auto autodiff_y0_vec =
-        autodiff_y0->GetValue<BasicVector<AutoDiffXd>>().CopyToVector();
-
-    const Eigen::MatrixXd CD = math::autoDiffToGradientMatrix(autodiff_y0_vec);
+    const auto& autodiff_y0 = output_port->Eval(*autodiff_context);
+    const Eigen::MatrixXd CD = math::autoDiffToGradientMatrix(autodiff_y0);
     C = CD.leftCols(num_states);
     D = CD.rightCols(num_inputs);
 
-    const Eigen::VectorXd y = math::autoDiffToValueMatrix(autodiff_y0_vec);
+    const Eigen::VectorXd y = math::autoDiffToValueMatrix(autodiff_y0);
 
     // Note: No tolerance check needed here.  We have defined that the output
     // for the system produced by Linearize is in the coordinates (y-y0).

--- a/systems/primitives/test/adder_test.cc
+++ b/systems/primitives/test/adder_test.cc
@@ -21,14 +21,12 @@ class AdderTest : public ::testing::Test {
   void SetUp() override {
     adder_.reset(new Adder<double>(2 /* inputs */, 3 /* size */));
     context_ = adder_->CreateDefaultContext();
-    output_ = adder_->get_output_port().Allocate();
     input0_.reset(new BasicVector<double>(3 /* size */));
     input1_.reset(new BasicVector<double>(3 /* size */));
   }
 
   std::unique_ptr<Adder<double>> adder_;
   std::unique_ptr<Context<double>> context_;
-  std::unique_ptr<AbstractValue> output_;
   std::unique_ptr<BasicVector<double>> input0_;
   std::unique_ptr<BasicVector<double>> input1_;
 };
@@ -59,11 +57,8 @@ TEST_F(AdderTest, AddTwoVectors) {
   context_->FixInputPort(0, std::move(input0_));
   context_->FixInputPort(1, std::move(input1_));
 
-  adder_->get_output_port().Calc(*context_, output_.get());
-  const auto& output_vector = output_->GetValueOrThrow<BasicVector<double>>();
-
   Eigen::Vector3d expected(5, 7, 9);
-  EXPECT_EQ(expected, output_vector.get_value());
+  EXPECT_EQ(expected, adder_->get_output_port().Eval(*context_));
 }
 
 // Tests that Adder allocates no state variables in the context_.

--- a/systems/primitives/test/affine_linear_test.h
+++ b/systems/primitives/test/affine_linear_test.h
@@ -49,7 +49,6 @@ class AffineLinearSystemTest : public ::testing::Test {
 
  protected:
   std::unique_ptr<Context<double>> context_;
-  std::unique_ptr<SystemOutput<double>> system_output_;
 
   ContinuousState<double>* state_{};
   std::unique_ptr<BasicVector<double>> state_vector_;

--- a/systems/primitives/test/barycentric_system_test.cc
+++ b/systems/primitives/test/barycentric_system_test.cc
@@ -42,24 +42,17 @@ GTEST_TEST(BarycentricSystemTest, MatrixGain) {
   auto gain_context = gain.CreateDefaultContext();
   auto bary_context = bary_sys.CreateDefaultContext();
 
-  auto gain_output = gain.get_output_port().Allocate();
-  auto bary_output = bary_sys.get_output_port().Allocate();
   for (double x : {-1., -.5, .3, .7}) {
     for (double y : {-.24, .4, .8}) {
       test = Vector2d{x, y};
       gain_context->FixInputPort(0, test);
-      gain.get_output_port().Calc(*gain_context, gain_output.get());
-
       bary_context->FixInputPort(0, test);
-      bary_sys.get_output_port().Calc(*bary_context, bary_output.get());
 
-      EXPECT_TRUE(CompareMatrices(
-          gain_output->GetValue<BasicVector<double>>().CopyToVector(), A * test,
-          1e-8));
+      const auto& gain_output = gain.get_output_port().Eval(*gain_context);
+      const auto& bary_output = bary_sys.get_output_port().Eval(*bary_context);
 
-      EXPECT_TRUE(CompareMatrices(
-          gain_output->GetValue<BasicVector<double>>().CopyToVector(),
-          bary_output->GetValue<BasicVector<double>>().CopyToVector(), 1e-8));
+      EXPECT_TRUE(CompareMatrices(gain_output, A * test, 1e-8));
+      EXPECT_TRUE(CompareMatrices(gain_output, bary_output, 1e-8));
     }
   }
 }

--- a/systems/primitives/test/constant_value_source_test.cc
+++ b/systems/primitives/test/constant_value_source_test.cc
@@ -22,22 +22,16 @@ class ConstantValueSourceTest : public ::testing::Test {
     source_ = make_unique<ConstantValueSource<double>>(
         Value<std::string>("foo"));
     context_ = source_->CreateDefaultContext();
-    output_ = source_->get_output_port(0).Allocate();
     input_ = make_unique<BasicVector<double>>(3 /* size */);
   }
 
   std::unique_ptr<System<double>> source_;
   std::unique_ptr<Context<double>> context_;
-  std::unique_ptr<AbstractValue> output_;
   std::unique_ptr<BasicVector<double>> input_;
 };
 
 TEST_F(ConstantValueSourceTest, Output) {
   ASSERT_EQ(source_->get_num_input_ports(), context_->get_num_input_ports());
-
-  // Check Calc() method.
-  source_->get_output_port(0).Calc(*context_, output_.get());
-  EXPECT_EQ("foo", output_->GetValue<std::string>());
 
   // Check Eval() method.
   auto& cached_value = source_->get_output_port(0).Eval<std::string>(*context_);

--- a/systems/primitives/test/constant_vector_source_test.cc
+++ b/systems/primitives/test/constant_vector_source_test.cc
@@ -22,22 +22,19 @@ class ConstantVectorSourceTest : public ::testing::Test {
   void SetUpEigenModel() {
     source_ = make_unique<ConstantVectorSource<double>>(kConstantVectorSource);
     context_ = source_->CreateDefaultContext();
-    output_ = source_->get_output_port().Allocate();
   }
 
   void SetUpBasicVectorModel() {
-    MyVector<3, double> vec;
+    MyVector3d vec;
     vec.get_mutable_value() << 42.0, 43.0, 44.0;
 
     source_ = make_unique<ConstantVectorSource<double>>(vec);
     context_ = source_->CreateDefaultContext();
-    output_ = source_->get_output_port().Allocate();
   }
 
   const Matrix<double, 2, 1, Eigen::DontAlign> kConstantVectorSource{2.0, 1.5};
   std::unique_ptr<ConstantVectorSource<double>> source_;
   std::unique_ptr<Context<double>> context_;
-  std::unique_ptr<AbstractValue> output_;
 };
 
 // Tests that the output of the ConstantVectorSource is correct with an Eigen
@@ -47,11 +44,9 @@ TEST_F(ConstantVectorSourceTest, EigenModel) {
   ASSERT_EQ(source_->get_num_input_ports(), 0);
   ASSERT_EQ(source_->get_num_output_ports(), 1);
 
-  source_->get_output_port().Calc(*context_, output_.get());
-
-  const auto& output_basic = output_->GetValueOrThrow<BasicVector<double>>();
   EXPECT_TRUE(kConstantVectorSource.isApprox(
-      output_basic.get_value(), Eigen::NumTraits<double>::epsilon()));
+      source_->get_output_port().Eval(*context_),
+      Eigen::NumTraits<double>::epsilon()));
 
   // Tests that the output reflects changes to the parameter value in the
   // context.
@@ -59,11 +54,9 @@ TEST_F(ConstantVectorSourceTest, EigenModel) {
       source_->get_mutable_source_value(context_.get());
   source_value.SetFromVector(2.0 * source_value.get_value());
 
-  source_->get_output_port().Calc(*context_, output_.get());
-
-  const auto& output_basic_2 = output_->GetValueOrThrow<BasicVector<double>>();
   EXPECT_TRUE(kConstantVectorSource.isApprox(
-      0.5 * output_basic_2.get_value(), Eigen::NumTraits<double>::epsilon()));
+      0.5 * source_->get_output_port().Eval(*context_),
+      Eigen::NumTraits<double>::epsilon()));
 }
 
 // Tests that the output of the ConstantVectorSource is correct with a
@@ -73,12 +66,7 @@ TEST_F(ConstantVectorSourceTest, BasicVectorModel) {
   ASSERT_EQ(source_->get_num_input_ports(), 0);
   ASSERT_EQ(source_->get_num_output_ports(), 1);
 
-  source_->get_output_port().Calc(*context_, output_.get());
-  const auto& output_basic = output_->GetValueOrThrow<BasicVector<double>>();
-
-  auto output_vector = dynamic_cast<const MyVector<3, double>*>(&output_basic);
-  ASSERT_NE(nullptr, output_vector);
-  EXPECT_EQ(43.0, output_vector->GetAtIndex(1));
+  EXPECT_EQ(43.0, source_->get_output_port().Eval<MyVector3d>(*context_)[1]);
 
   // Tests that the output reflects changes to the parameter value in the
   // context.
@@ -86,14 +74,8 @@ TEST_F(ConstantVectorSourceTest, BasicVectorModel) {
       static_cast<ConstantVectorSource<double>*>(source_.get())
           ->get_mutable_source_value(context_.get());
   source_value.SetFromVector(2.0 * source_value.get_value());
-
-  source_->get_output_port().Calc(*context_, output_.get());
-
-  const auto& output_basic_2 = output_->GetValueOrThrow<BasicVector<double>>();
-  auto output_vector_2 =
-      dynamic_cast<const MyVector<3, double>*>(&output_basic_2);
-  ASSERT_NE(nullptr, output_vector_2);
-  EXPECT_EQ(43.0, 0.5 * output_vector_2->GetAtIndex(1));
+  EXPECT_EQ(
+      43.0, 0.5 * source_->get_output_port().Eval<MyVector3d>(*context_)[1]);
 }
 
 // Tests that ConstantVectorSource allocates no state variables in its context.

--- a/systems/primitives/test/gain_scalartype_test.cc
+++ b/systems/primitives/test/gain_scalartype_test.cc
@@ -41,7 +41,6 @@ GTEST_TEST(GainScalarTypeTest, AutoDiff) {
   const double kGain = 2.0;
   auto gain = make_unique<Gain<T>>(kGain /* gain */, 3 /* size */);
   auto context = gain->CreateDefaultContext();
-  auto output = gain->AllocateOutput();
   auto input = make_unique<BasicVector<T>>(3 /* size */);
 
   // Sets the input values.
@@ -57,10 +56,8 @@ GTEST_TEST(GainScalarTypeTest, AutoDiff) {
 
   context->FixInputPort(0, std::move(input));
 
-  gain->CalcOutput(*context, output.get());
-
-  ASSERT_EQ(1, output->get_num_ports());
-  const auto& output_vector = output->get_vector_data(0)->get_value();
+  const auto& output_vector =
+      gain->get_output_port().Eval(*context);
 
   // The expected output value is the gain times the input vector.
   VectorX<T> expected = kGain * input_vector;
@@ -87,14 +84,12 @@ class SymbolicGainTest : public ::testing::Test {
     gain_ = make_unique<Gain<symbolic::Expression>>(kGain_ /* gain */,
                                                     3 /* length */);
     context_ = gain_->CreateDefaultContext();
-    output_ = gain_->AllocateOutput();
     input_ = make_unique<BasicVector<symbolic::Expression>>(3 /* length */);
   }
 
   double kGain_{2.0};
   unique_ptr<System<symbolic::Expression>> gain_;
   unique_ptr<Context<symbolic::Expression>> context_;
-  unique_ptr<SystemOutput<symbolic::Expression>> output_;
   unique_ptr<BasicVector<symbolic::Expression>> input_;
 };
 
@@ -110,16 +105,12 @@ TEST_F(SymbolicGainTest, VectorThroughGainSystem) {
 
   // Hook input of the expected size.
   context_->FixInputPort(0, move(input_));
-  gain_->CalcOutput(*context_, output_.get());
 
   // Checks that the number of output ports in the Gain system and the
   // SystemOutput are consistent.
-  EXPECT_EQ(1, output_->get_num_ports());
   EXPECT_EQ(1, gain_->get_num_output_ports());
-  const auto* output_vector(output_->get_vector_data(0));
-  EXPECT_NE(nullptr, output_vector);
   Eigen::Matrix<symbolic::Expression, 3, 1> expected{kGain_ * input_vector};
-  EXPECT_EQ(expected, output_vector->get_value());
+  EXPECT_EQ(expected, gain_->get_output_port(0).Eval(*context_));
   EXPECT_EQ(expected(0).Evaluate(), kGain_ * 1.0);
   EXPECT_EQ(expected(1).Evaluate(), kGain_ * 3.14);
   EXPECT_EQ(expected(2).Evaluate(), kGain_ * 2.18);

--- a/systems/primitives/test/gain_test.cc
+++ b/systems/primitives/test/gain_test.cc
@@ -25,7 +25,6 @@ void TestGainSystem(const Gain<T>& gain_system,
 
   // Verifies that Gain allocates no state variables in the context.
   EXPECT_EQ(0, context->get_continuous_state().size());
-  auto output = gain_system.AllocateOutput();
   auto input =
       make_unique<BasicVector<double>>(gain_system.get_gain_vector().size());
 
@@ -39,15 +38,9 @@ void TestGainSystem(const Gain<T>& gain_system,
   // Hook input of the expected size.
   context->FixInputPort(0, std::move(input));
 
-  gain_system.CalcOutput(*context, output.get());
-
-  // Checks that the number of output ports in the Gain system and the
-  // SystemOutput are consistent.
-  ASSERT_EQ(1, output->get_num_ports());
+  // Checks the output.
   ASSERT_EQ(1, gain_system.get_num_output_ports());
-  const BasicVector<double>* output_vector = output->get_vector_data(0);
-  ASSERT_NE(nullptr, output_vector);
-  EXPECT_EQ(expected_output, output_vector->get_value());
+  EXPECT_EQ(expected_output, gain_system.get_output_port().Eval(*context));
 }
 
 // Tests the ability to use a double as the gain.

--- a/systems/primitives/test/integrator_test.cc
+++ b/systems/primitives/test/integrator_test.cc
@@ -23,7 +23,6 @@ class IntegratorTest : public ::testing::Test {
     integrator_.reset(new Integrator<double>(kLength));
     context_ = integrator_->CreateDefaultContext();
     derivatives_ = integrator_->AllocateTimeDerivatives();
-    output_ = integrator_->AllocateOutput();
 
     // Set the state to zero initially.
     ContinuousState<double>& xc = continuous_state();
@@ -39,7 +38,6 @@ class IntegratorTest : public ::testing::Test {
   std::unique_ptr<System<double>> integrator_;
   std::unique_ptr<Context<double>> context_;
   std::unique_ptr<ContinuousState<double>> derivatives_;
-  std::unique_ptr<SystemOutput<double>> output_;
 };
 
 // Tests that the system exports the correct topology.
@@ -60,19 +58,12 @@ TEST_F(IntegratorTest, Output) {
   ASSERT_EQ(1, context_->get_num_input_ports());
   context_->FixInputPort(0, BasicVector<double>::Make({1.0, 2.0, 3.0}));
 
-  integrator_->CalcOutput(*context_, output_.get());
-
-  ASSERT_EQ(1, output_->get_num_ports());
-  const BasicVector<double>* output_port = output_->get_vector_data(0);
-  ASSERT_NE(nullptr, output_port);
-
   Eigen::Vector3d expected = Eigen::Vector3d::Zero();
-  EXPECT_EQ(expected, output_port->get_value());
+  EXPECT_EQ(expected, integrator_->get_output_port(0).Eval(*context_));
 
   continuous_state().get_mutable_vector().SetAtIndex(1, 42.0);
   expected << 0.0, 42.0, 0.0;
-  integrator_->CalcOutput(*context_, output_.get());
-  EXPECT_EQ(expected, output_port->get_value());
+  EXPECT_EQ(expected, integrator_->get_output_port(0).Eval(*context_));
 }
 
 // Tests that the derivatives of an integrator's state are its input.
@@ -97,7 +88,6 @@ class SymbolicIntegratorTest : public IntegratorTest {
     symbolic_integrator_ = integrator_->ToSymbolic();
     symbolic_context_ = symbolic_integrator_->CreateDefaultContext();
     symbolic_derivatives_ = symbolic_integrator_->AllocateTimeDerivatives();
-    symbolic_output_ = symbolic_integrator_->AllocateOutput();
 
     ASSERT_EQ(1, symbolic_context_->get_num_input_ports());
     symbolic_context_->FixInputPort(
@@ -115,15 +105,11 @@ class SymbolicIntegratorTest : public IntegratorTest {
   std::unique_ptr<System<symbolic::Expression>> symbolic_integrator_;
   std::unique_ptr<Context<symbolic::Expression>> symbolic_context_;
   std::unique_ptr<ContinuousState<symbolic::Expression>> symbolic_derivatives_;
-  std::unique_ptr<SystemOutput<symbolic::Expression>> symbolic_output_;
 };
 
 TEST_F(SymbolicIntegratorTest, Output) {
-  symbolic_integrator_->CalcOutput(*symbolic_context_, symbolic_output_.get());
-
-  ASSERT_EQ(1, symbolic_output_->get_num_ports());
-  const auto& out = *symbolic_output_->get_vector_data(0);
-
+  const auto& out =
+      symbolic_integrator_->get_output_port(0).Eval(*symbolic_context_);
   EXPECT_EQ("x0", out[0].to_string());
   EXPECT_EQ("x1", out[1].to_string());
   EXPECT_EQ("x2", out[2].to_string());

--- a/systems/primitives/test/linear_system_test.cc
+++ b/systems/primitives/test/linear_system_test.cc
@@ -28,7 +28,6 @@ class LinearSystemTest : public AffineLinearSystemTest {
     dut_->set_name("test_linear_system");
     context_ = dut_->CreateDefaultContext();
     input_vector_ = make_unique<BasicVector<double>>(2 /* size */);
-    system_output_ = dut_->AllocateOutput();
     state_ = &context_->get_mutable_continuous_state();
     derivatives_ = dut_->AllocateTimeDerivatives();
   }
@@ -78,11 +77,8 @@ TEST_F(LinearSystemTest, Output) {
   Eigen::Vector2d x(0.8, -22.1);
   state_->SetFromVector(x);
 
-  dut_->CalcOutput(*context_, system_output_.get());
-
   Eigen::VectorXd expected_output = C_ * x + D_ * u;
-
-  EXPECT_EQ(expected_output, system_output_->get_vector_data(0)->get_value());
+  EXPECT_EQ(expected_output, dut_->get_output_port().Eval(*context_));
 }
 
 // Tests converting to different scalar types.

--- a/systems/primitives/test/matrix_gain_test.cc
+++ b/systems/primitives/test/matrix_gain_test.cc
@@ -21,7 +21,6 @@ class MatrixGainTest : public AffineLinearSystemTest {
     dut_->set_name("test_matrix_gain_system");
     context_ = dut_->CreateDefaultContext();
     input_vector_ = make_unique<BasicVector<double>>(2 /* size */);
-    system_output_ = dut_->AllocateOutput();
   }
 
  protected:
@@ -69,12 +68,9 @@ TEST_F(MatrixGainTest, Output) {
   Eigen::Vector2d u(2.17, 5.99);
   SetInput(u);
 
-  dut_->CalcOutput(*context_, system_output_.get());
-
   Eigen::VectorXd expected_output(2);
   expected_output = D_ * u;
-
-  EXPECT_EQ(system_output_->get_vector_data(0)->get_value(), expected_output);
+  EXPECT_EQ(dut_->get_output_port().Eval(*context_), expected_output);
 }
 
 // Tests converting to different scalar types.

--- a/systems/primitives/test/multiplexer_test.cc
+++ b/systems/primitives/test/multiplexer_test.cc
@@ -23,18 +23,15 @@ class MultiplexerTest : public ::testing::Test {
   void InitializeFromSizes(std::vector<int> input_sizes) {
     mux_ = make_unique<Multiplexer<double>>(input_sizes);
     context_ = mux_->CreateDefaultContext();
-    output_ = mux_->AllocateOutput();
   }
 
   void InitializeFromMyVector() {
     mux_ = make_unique<Multiplexer<double>>(MyVector<2, double>());
     context_ = mux_->CreateDefaultContext();
-    output_ = mux_->AllocateOutput();
   }
 
   std::unique_ptr<System<double>> mux_;
   std::unique_ptr<Context<double>> context_;
-  std::unique_ptr<SystemOutput<double>> output_;
 };
 
 TEST_F(MultiplexerTest, Basic) {
@@ -48,8 +45,6 @@ TEST_F(MultiplexerTest, Basic) {
   ASSERT_EQ(3, context_->get_num_input_ports());
   ASSERT_EQ(1, mux_->get_num_output_ports());
   ASSERT_EQ(6, mux_->get_output_port(0).size());
-  ASSERT_EQ(1, output_->get_num_ports());
-  ASSERT_EQ(6, output_->get_vector_data(0)->size());
 
   // Provide input data.
   context_->FixInputPort(0, BasicVector<double>::Make({11.0, 22.0}));
@@ -57,9 +52,8 @@ TEST_F(MultiplexerTest, Basic) {
   context_->FixInputPort(2, BasicVector<double>::Make({31.0, 32.0, 33.0}));
 
   // Confirm output data.
-  mux_->CalcOutput(*context_, output_.get());
-  ASSERT_EQ(6, output_->get_vector_data(0)->size());
-  auto value = output_->get_vector_data(0)->get_value();
+  const auto& value = mux_->get_output_port(0).Eval(*context_);
+  ASSERT_EQ(6, value.size());
   ASSERT_EQ(11.0, value[0]);
   ASSERT_EQ(22.0, value[1]);
   ASSERT_EQ(21.0, value[2]);
@@ -71,7 +65,6 @@ TEST_F(MultiplexerTest, Basic) {
 TEST_F(MultiplexerTest, ScalarConstructor) {
   mux_ = make_unique<Multiplexer<double>>(4);
   context_ = mux_->CreateDefaultContext();
-  output_ = mux_->AllocateOutput();
 
   // Confirm the shape.
   ASSERT_EQ(4, mux_->get_num_input_ports());
@@ -82,8 +75,6 @@ TEST_F(MultiplexerTest, ScalarConstructor) {
   ASSERT_EQ(4, context_->get_num_input_ports());
   ASSERT_EQ(1, mux_->get_num_output_ports());
   ASSERT_EQ(4, mux_->get_output_port(0).size());
-  ASSERT_EQ(1, output_->get_num_ports());
-  ASSERT_EQ(4, output_->get_vector_data(0)->size());
 }
 
 TEST_F(MultiplexerTest, ModelVectorConstructor) {
@@ -96,13 +87,12 @@ TEST_F(MultiplexerTest, ModelVectorConstructor) {
   ASSERT_EQ(2, context_->get_num_input_ports());
   ASSERT_EQ(1, mux_->get_num_output_ports());
   ASSERT_EQ(2, mux_->get_output_port(0).size());
-  ASSERT_EQ(1, output_->get_num_ports());
-  ASSERT_EQ(2, output_->get_vector_data(0)->size());
 
   // Confirm that the vector is truly MyVector<2, double>.
+  context_->FixInputPort(0, {0.0});
+  context_->FixInputPort(1, {0.0});
   typedef MyVector<2, double> MyVectorSizeTwo;
-  ASSERT_TRUE(is_dynamic_castable<const MyVectorSizeTwo>(
-      output_->get_vector_data(0)));
+  ASSERT_NO_THROW(mux_->get_output_port(0).Eval<MyVectorSizeTwo>(*context_));
 }
 
 TEST_F(MultiplexerTest, IsStateless) {

--- a/systems/primitives/test/pass_through_scalartype_test.cc
+++ b/systems/primitives/test/pass_through_scalartype_test.cc
@@ -29,7 +29,6 @@ GTEST_TEST(PassThroughScalarTypeTest, AutoDiff) {
   // Set a PassThrough system with input and output of size 3.
   auto buffer = make_unique<PassThrough<T>>(3 /* size */);
   auto context = buffer->CreateDefaultContext();
-  auto output = buffer->AllocateOutput();
   auto input = make_unique<BasicVector<T>>(3 /* size */);
 
   // Sets the input values.
@@ -44,11 +43,6 @@ GTEST_TEST(PassThroughScalarTypeTest, AutoDiff) {
 
   context->FixInputPort(0, std::move(input));
 
-  buffer->CalcOutput(*context, output.get());
-
-  ASSERT_EQ(1, output->get_num_ports());
-  auto output_vector = output->get_vector_data(0)->get_value();
-
   // The expected output value equals the input.
   Vector3<T> expected;
   expected = input_vector;
@@ -58,6 +52,7 @@ GTEST_TEST(PassThroughScalarTypeTest, AutoDiff) {
   expected(1).derivatives() << 0.0, 1.0, 0.0;
   expected(2).derivatives() << 0.0, 0.0, 1.0;
 
+  const auto& output_vector = buffer->get_output_port().Eval(*context);
   for (int i = 0; i < 3; ++i) {
     // Checks output value.
     EXPECT_EQ(expected(i).value(), output_vector(i).value());

--- a/systems/primitives/test/piecewise_polynomial_affine_system_test.cc
+++ b/systems/primitives/test/piecewise_polynomial_affine_system_test.cc
@@ -37,7 +37,6 @@ class PiecewisePolynomialAffineSystemTest
     }
     context_ = dut_->CreateDefaultContext();
     input_vector_ = make_unique<BasicVector<double>>(2 /* size */);
-    system_output_ = dut_->AllocateOutput();
     continuous_state_ = &context_->get_mutable_continuous_state();
     discrete_state_ = &context_->get_mutable_discrete_state();
     derivatives_ = dut_->AllocateTimeDerivatives();
@@ -48,7 +47,6 @@ class PiecewisePolynomialAffineSystemTest
   // The Device Under Test (DUT) is a PiecewisePolynomialAffineSystem<double>.
   unique_ptr<PiecewisePolynomialAffineSystem<double>> dut_;
   unique_ptr<Context<double>> context_;
-  unique_ptr<SystemOutput<double>> system_output_;
 
   ContinuousState<double>* continuous_state_{nullptr};
   DiscreteValues<double>* discrete_state_{nullptr};
@@ -146,13 +144,11 @@ TEST_P(PiecewisePolynomialAffineSystemTest, Output) {
   for (const double t : mat_data_.times) {
     context_->set_time(t);
 
-    dut_->CalcOutput(*context_, system_output_.get());
     const Eigen::Matrix2d C = ltv_data_.C.value(t);
     const Eigen::Matrix2d D = ltv_data_.D.value(t);
     const Eigen::Vector2d y0 = ltv_data_.y0.value(t);
-
     EXPECT_TRUE(CompareMatrices(C * x + D * u + y0,
-                                system_output_->get_vector_data(0)->get_value(),
+                                dut_->get_output_port().Eval(*context_),
                                 tol));
   }
 }

--- a/systems/primitives/test/piecewise_polynomial_linear_system_test.cc
+++ b/systems/primitives/test/piecewise_polynomial_linear_system_test.cc
@@ -37,7 +37,6 @@ class PiecewisePolynomialLinearSystemTest
     }
     context_ = dut_->CreateDefaultContext();
     input_vector_ = make_unique<BasicVector<double>>(2 /* size */);
-    system_output_ = dut_->AllocateOutput();
     continuous_state_ = &context_->get_mutable_continuous_state();
     discrete_state_ = &context_->get_mutable_discrete_state();
     derivatives_ = dut_->AllocateTimeDerivatives();
@@ -48,7 +47,6 @@ class PiecewisePolynomialLinearSystemTest
   // The Device Under Test (DUT) is a PiecewisePolynomialLinearSystem<double>.
   unique_ptr<PiecewisePolynomialLinearSystem<double>> dut_;
   unique_ptr<Context<double>> context_;
-  unique_ptr<SystemOutput<double>> system_output_;
 
   ContinuousState<double>* continuous_state_{nullptr};
   DiscreteValues<double>* discrete_state_{nullptr};
@@ -145,12 +143,10 @@ TEST_P(PiecewisePolynomialLinearSystemTest, Output) {
   for (const double t : times) {
     context_->set_time(t);
 
-    dut_->CalcOutput(*context_, system_output_.get());
     const Eigen::Matrix2d C = ltv_data_.C.value(t);
     const Eigen::Matrix2d D = ltv_data_.D.value(t);
-
     EXPECT_TRUE(CompareMatrices(
-        C * x + D * u, system_output_->get_vector_data(0)->get_value(), tol));
+        C * x + D * u, dut_->get_output_port().Eval(*context_), tol));
   }
 }
 

--- a/systems/primitives/test/random_source_test.cc
+++ b/systems/primitives/test/random_source_test.cc
@@ -235,25 +235,23 @@ GTEST_TEST(RandomSourceTest, CorrelationTest) {
 // SetDefaultContext returns it to the original (default) output.
 GTEST_TEST(RandomSourceTest, SetRandomContextTest) {
   UniformRandomSource random_source(2, 0.0025);
-  auto output = random_source.get_output_port(0).Allocate();
-  const BasicVector<double>& output_values =
-      output->GetValueOrThrow<systems::BasicVector<double>>();
 
   auto context = random_source.CreateDefaultContext();
-
-  random_source.get_output_port(0).Calc(*context, output.get());
-  Eigen::Vector2d default_values = output_values.CopyToVector();
+  const Eigen::Vector2d default_values =
+      random_source.get_output_port(0).Eval(*context);
 
   RandomGenerator generator;
   random_source.SetRandomContext(context.get(), &generator);
-  random_source.get_output_port(0).Calc(*context, output.get());
-  EXPECT_NE(default_values[0], output_values.GetAtIndex(0));
-  EXPECT_NE(default_values[1], output_values.GetAtIndex(1));
+  const Eigen::Vector2d novel_values =
+      random_source.get_output_port(0).Eval(*context);
+  EXPECT_NE(default_values[0], novel_values[0]);
+  EXPECT_NE(default_values[1], novel_values[1]);
 
   random_source.SetDefaultContext(context.get());
-  random_source.get_output_port(0).Calc(*context, output.get());
-  EXPECT_EQ(default_values[0], output_values.GetAtIndex(0));
-  EXPECT_EQ(default_values[1], output_values.GetAtIndex(1));
+  const Eigen::Vector2d default_values_again =
+      random_source.get_output_port(0).Eval(*context);
+  EXPECT_EQ(default_values[0], default_values_again[0]);
+  EXPECT_EQ(default_values[1], default_values_again[1]);
 }
 
 }  // namespace

--- a/systems/primitives/test/saturation_test.cc
+++ b/systems/primitives/test/saturation_test.cc
@@ -21,7 +21,6 @@ void TestInputAndOutput(const Saturation<T>& saturation_system,
 
   // Verifies that Saturation allocates no state variables in the context.
   EXPECT_EQ(context->get_continuous_state().size(), 0);
-  auto output = saturation_system.AllocateOutput();
   auto input = std::make_unique<BasicVector<T>>(port_size);
 
   input->get_mutable_value() << input_vector;
@@ -30,15 +29,11 @@ void TestInputAndOutput(const Saturation<T>& saturation_system,
   context->FixInputPort(saturation_system.get_input_port().get_index(),
                         std::move(input));
 
-  saturation_system.CalcOutput(*context, output.get());
-
   // Checks that the number of output ports in the Saturation system and the
   // SystemOutput are consistent.
-  ASSERT_EQ(output->get_num_ports(), 1);
   ASSERT_EQ(saturation_system.get_num_output_ports(), 1);
-  const BasicVector<T>* output_vector = output->get_vector_data(0);
-  ASSERT_NE(output_vector, nullptr);
-  EXPECT_EQ(output_vector->get_value(), expected_output);
+  EXPECT_EQ(saturation_system.get_output_port().Eval(*context),
+            expected_output);
 }
 
 template <typename T>

--- a/systems/primitives/test/sine_test.cc
+++ b/systems/primitives/test/sine_test.cc
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/fixed_input_port_value.h"
 #include "drake/systems/framework/test_utilities/scalar_conversion.h"
@@ -32,7 +33,6 @@ void TestSineSystem(const Sine<T>& sine_system,
 
   // Verifies that Sine allocates no state variables in the context.
   EXPECT_EQ(0, context->get_continuous_state().size());
-  auto output = sine_system.AllocateOutput();
 
   if (sine_system.is_time_based()) {
     // If the system is time based, the input_vectors Matrix should only contain
@@ -46,40 +46,17 @@ void TestSineSystem(const Sine<T>& sine_system,
       // Initialize the time in seconds to be used by the Sine system.
       context->set_time(input_vectors(0, i));
 
-      // Calculate the Sine system output.
-      sine_system.CalcOutput(*context, output.get());
-
-      // Checks that the number of output ports in the Sine system and the
-      // system output are consistent.
-      ASSERT_EQ(3, output->get_num_ports());
+      // Check the Sine output.
       ASSERT_EQ(3, sine_system.get_num_output_ports());
-
-      const BasicVector<double>* output_vector = output->get_vector_data(0);
-      const BasicVector<double>* first_deriv_vector =
-          output->get_vector_data(1);
-      const BasicVector<double>* second_deriv_vector =
-          output->get_vector_data(2);
-      ASSERT_NE(nullptr, output_vector);
-      ASSERT_NE(nullptr, first_deriv_vector);
-      ASSERT_NE(nullptr, second_deriv_vector);
-
-      Eigen::VectorXd expected_output = expected_outputs.col(i);
-      Eigen::VectorXd expected_first_deriv = expected_first_derivs.col(i);
-      Eigen::VectorXd expected_second_deriv = expected_second_derivs.col(i);
-
-      Eigen::VectorXd out_diff = expected_output - output_vector->get_value();
-      EXPECT_TRUE(
-          out_diff.template lpNorm<Eigen::Infinity>() < ktest_tolerance);
-
-      Eigen::VectorXd deriv1_diff =
-          expected_first_deriv - first_deriv_vector->get_value();
-      EXPECT_TRUE(
-          deriv1_diff.template lpNorm<Eigen::Infinity>() < ktest_tolerance);
-
-      Eigen::VectorXd deriv2_diff =
-          expected_second_deriv - second_deriv_vector->get_value();
-      EXPECT_TRUE(
-          deriv2_diff.template lpNorm<Eigen::Infinity>() < ktest_tolerance);
+      EXPECT_TRUE(CompareMatrices(
+          sine_system.get_output_port(0).Eval(*context),
+          expected_outputs.col(i), ktest_tolerance));
+      EXPECT_TRUE(CompareMatrices(
+          sine_system.get_output_port(1).Eval(*context),
+          expected_first_derivs.col(i), ktest_tolerance));
+      EXPECT_TRUE(CompareMatrices(
+          sine_system.get_output_port(2).Eval(*context),
+          expected_second_derivs.col(i), ktest_tolerance));
     }
   } else {
     // Loop over the input vectors and check that the Sine system outputs match
@@ -101,40 +78,17 @@ void TestSineSystem(const Sine<T>& sine_system,
       input->get_mutable_value() << input_vectors.col(i);
       context->FixInputPort(0, std::move(input));
 
-      // Calculate the Sine system output.
-      sine_system.CalcOutput(*context, output.get());
-
-      // Checks that the number of output ports in the Sine system and the
-      // system output are consistent.
-      ASSERT_EQ(3, output->get_num_ports());
+      // Check the Sine output.
       ASSERT_EQ(3, sine_system.get_num_output_ports());
-
-      const BasicVector<double>* output_vector = output->get_vector_data(0);
-      const BasicVector<double>* first_deriv_vector =
-          output->get_vector_data(1);
-      const BasicVector<double>* second_deriv_vector =
-          output->get_vector_data(2);
-      ASSERT_NE(nullptr, output_vector);
-      ASSERT_NE(nullptr, first_deriv_vector);
-      ASSERT_NE(nullptr, second_deriv_vector);
-
-      Eigen::VectorXd expected_output = expected_outputs.col(i);
-      Eigen::VectorXd expected_first_deriv = expected_first_derivs.col(i);
-      Eigen::VectorXd expected_second_deriv = expected_second_derivs.col(i);
-
-      Eigen::VectorXd out_diff = expected_output - output_vector->get_value();
-      EXPECT_TRUE(
-          out_diff.template lpNorm<Eigen::Infinity>() < ktest_tolerance);
-
-      Eigen::VectorXd deriv1_diff =
-          expected_first_deriv - first_deriv_vector->get_value();
-      EXPECT_TRUE(
-          deriv1_diff.template lpNorm<Eigen::Infinity>() < ktest_tolerance);
-
-      Eigen::VectorXd deriv2_diff =
-          expected_second_deriv - second_deriv_vector->get_value();
-      EXPECT_TRUE(
-          deriv2_diff.template lpNorm<Eigen::Infinity>() < ktest_tolerance);
+      EXPECT_TRUE(CompareMatrices(
+          sine_system.get_output_port(0).Eval(*context),
+          expected_outputs.col(i), ktest_tolerance));
+      EXPECT_TRUE(CompareMatrices(
+          sine_system.get_output_port(1).Eval(*context),
+          expected_first_derivs.col(i), ktest_tolerance));
+      EXPECT_TRUE(CompareMatrices(
+          sine_system.get_output_port(2).Eval(*context),
+          expected_second_derivs.col(i), ktest_tolerance));
     }
   }
 }

--- a/systems/primitives/test/trajectory_source_test.cc
+++ b/systems/primitives/test/trajectory_source_test.cc
@@ -30,14 +30,12 @@ class TrajectorySourceTest : public ::testing::Test {
     source_ = make_unique<TrajectorySource<double>>(*kppTraj_, kDerivativeOrder,
                                                     true);
     context_ = source_->CreateDefaultContext();
-    output_ = source_->AllocateOutput();
     input_ = make_unique<BasicVector<double>>(3 /* length */);
   }
 
   std::unique_ptr<PiecewisePolynomial<double>> kppTraj_;
   std::unique_ptr<System<double>> source_;
   std::unique_ptr<Context<double>> context_;
-  std::unique_ptr<SystemOutput<double>> output_;
   std::unique_ptr<BasicVector<double>> input_;
 };
 
@@ -48,30 +46,25 @@ TEST_F(TrajectorySourceTest, OutputTest) {
   Reset(PiecewisePolynomial<double>(p_vec, {0.0, 3}));
 
   ASSERT_EQ(0, context_->get_num_input_ports());
-  ASSERT_EQ(1, output_->get_num_ports());
 
   const double kTestTime = 1.75;
   context_->set_time(kTestTime);
 
-  source_->CalcOutput(*context_, output_.get());
-
-  const BasicVector<double>* output_vector = output_->get_vector_data(0);
-  ASSERT_NE(nullptr, output_vector);
+  const auto& output = source_->get_output_port(0).Eval(*context_);
 
   int len = kppTraj_->rows();
-  EXPECT_EQ(kppTraj_->value(kTestTime),
-            output_vector->get_value().segment(0, len));
+  EXPECT_EQ(kppTraj_->value(kTestTime), output.segment(0, len));
 
   for (size_t i = 1; i <= kDerivativeOrder; ++i) {
     EXPECT_TRUE(
         CompareMatrices(kppTraj_->derivative(i).value(kTestTime),
-                        output_vector->get_value().segment(len * i, len), 1e-10,
+                        output.segment(len * i, len), 1e-10,
                         MatrixCompareType::absolute));
   }
 
   // Test first derivative (which is in second segment):
   // f`(yyyy) = f`(y^4) = 4 * y^3.  y = kTestTime.
-  EXPECT_NEAR(output_vector->get_value().segment(len, len)(0), 21.4375, 1e-6);
+  EXPECT_NEAR(output.segment(len, len)(0), 21.4375, 1e-6);
 }
 
 // Tests that ConstantVectorSource allocates no state variables in the context_.

--- a/systems/primitives/test/wrap_to_system_test.cc
+++ b/systems/primitives/test/wrap_to_system_test.cc
@@ -19,10 +19,8 @@ void CheckOutput(const System<T>& dut,
                  const Eigen::Ref<const VectorX<T>>& input,
                  const Eigen::Ref<const VectorX<T>>& expected_output) {
   auto context = dut.CreateDefaultContext();
-  auto output = dut.AllocateOutput();
   context->FixInputPort(0, input);
-  dut.CalcOutput(*context, output.get());
-  EXPECT_TRUE(CompareMatrices(output->get_vector_data(0)->CopyToVector(),
+  EXPECT_TRUE(CompareMatrices(dut.get_output_port(0).Eval(*context),
                               expected_output, 1e-12));
 }
 

--- a/systems/primitives/test/zero_order_hold_test.cc
+++ b/systems/primitives/test/zero_order_hold_test.cc
@@ -60,7 +60,6 @@ class ZeroOrderHoldTest : public ::testing::TestWithParam<bool> {
           kTenHertz, Value<SimpleAbstractType>(Eigen::Vector3d::Zero()));
     }
     context_ = hold_->CreateDefaultContext();
-    output_ = hold_->AllocateOutput();
     if (!is_abstract_) {
       context_->FixInputPort(
           0, std::make_unique<BasicVector<double>>(input_value_));
@@ -86,7 +85,6 @@ class ZeroOrderHoldTest : public ::testing::TestWithParam<bool> {
 
   std::unique_ptr<System<double>> hold_;
   std::unique_ptr<Context<double>> context_;
-  std::unique_ptr<SystemOutput<double>> output_;
   std::unique_ptr<CompositeEventCollection<double>> event_info_;
   const LeafCompositeEventCollection<double>* leaf_info_;
 
@@ -100,7 +98,6 @@ TEST_P(ZeroOrderHoldTest, Topology) {
   EXPECT_EQ(1, hold_->get_num_input_ports());
   EXPECT_EQ(1, context_->get_num_input_ports());
 
-  EXPECT_EQ(1, output_->get_num_ports());
   EXPECT_EQ(1, hold_->get_num_output_ports());
 
   EXPECT_FALSE(hold_->HasAnyDirectFeedthrough());
@@ -130,20 +127,13 @@ TEST_P(ZeroOrderHoldTest, Output) {
   if (!is_abstract_) {
     BasicVector<double>& xd = context_->get_mutable_discrete_state(0);
     xd.get_mutable_value() << output_expected;
-
-    hold_->CalcOutput(*context_, output_.get());
-
-    const BasicVector<double>* output_vector = output_->get_vector_data(0);
-    ASSERT_NE(nullptr, output_vector);
-    output = output_vector->CopyToVector();
+    output = hold_->get_output_port(0).Eval(*context_);
   } else {
     SimpleAbstractType& state_value =
         context_->get_mutable_abstract_state<SimpleAbstractType>(0);
     state_value = SimpleAbstractType(output_expected);
-
-    hold_->CalcOutput(*context_, output_.get());
-
-    output = output_->get_data(0)->GetValue<SimpleAbstractType>().value();
+    output = hold_->get_output_port(0).
+        template Eval<SimpleAbstractType>(*context_).value();
   }
   EXPECT_EQ(output_expected, output);
 }
@@ -222,20 +212,16 @@ class SymbolicZeroOrderHoldTest : public ::testing::Test {
     auto& xd = context_->get_mutable_discrete_state(0);
     xd[0] = symbolic::Variable("x0");
 
-    output_ = hold_->AllocateOutput();
     update_ = hold_->AllocateDiscreteVariables();
   }
 
   std::unique_ptr<ZeroOrderHold<symbolic::Expression>> hold_;
   std::unique_ptr<Context<symbolic::Expression>> context_;
-  std::unique_ptr<SystemOutput<symbolic::Expression>> output_;
   std::unique_ptr<DiscreteValues<symbolic::Expression>> update_;
 };
 
 TEST_F(SymbolicZeroOrderHoldTest, Output) {
-  hold_->CalcOutput(*context_, output_.get());
-  ASSERT_EQ(1, output_->get_num_ports());
-  const auto& out = *output_->get_vector_data(0);
+  const auto& out = hold_->get_output_port().Eval(*context_);
   EXPECT_EQ("x0", out[0].to_string());
 }
 


### PR DESCRIPTION
Eventually we might deprecate Calc, but at least for now we should prefer to use Eval because it leads to more concise code, especially as BasicVector and/or AbstractValue APIs evolve.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10708)
<!-- Reviewable:end -->
