### PR TITLE
common: Twain Value<T> definitions for readability

### DIFF
--- a/common/value.cc
+++ b/common/value.cc
@@ -2,6 +2,11 @@
 
 namespace drake {
 
-AbstractValue::~AbstractValue() {}
+AbstractValue::~AbstractValue() = default;
+
+std::string AbstractValue::GetNiceTypeName() const {
+  return NiceTypeName::Canonicalize(
+      NiceTypeName::Demangle(type_info().name()));
+}
 
 }  // namespace drake

--- a/common/value.h
+++ b/common/value.h
@@ -15,24 +15,237 @@
 namespace drake {
 
 #if !defined(DRAKE_DOXYGEN_CXX)
-class AbstractValue;
-
 template <typename T>
 class Value;
 
-// Declare some private helper structs.
-namespace value_detail {
+namespace internal {
 
 // A traits type for Value<T>, where use_copy is true when T's copy constructor
 // and copy-assignment operator are used and false when T's Clone is used.
 template <typename T, bool use_copy>
 struct ValueTraitsImpl {};
+template <typename T>
+using ValueTraits = ValueTraitsImpl<T, std::is_copy_constructible<T>::value>;
+
+// SFINAE type for whether Value<T>(Arg1, Args...) should be a forwarding ctor.
+// In our ctor overload that copies into the storage, choose_copy == true.
+template <bool choose_copy, typename T, typename Arg1, typename... Args>
+using ValueForwardingCtorEnabled = typename std::enable_if_t<
+  // There must be such a constructor.
+  std::is_constructible<T, Arg1, Args...>::value &&
+  // Disable this ctor when given T directly; in that case, we
+  // should call our Value(const T&) ctor above, not try to copy-
+  // construct a T(const T&).
+  !std::is_same<T, Arg1>::value &&
+  !std::is_same<T&, Arg1>::value &&
+  // Only allow real ctors, not POD "constructor"s.
+  !std::is_fundamental<T>::value &&
+  // Disambiguate our copy implementation from our clone implementation.
+  (choose_copy == std::is_copy_constructible<T>::value)>;
+
+}  // namespace internal
+#endif
+
+/// A fully type-erased container class.
+///
+/// Only Value<T> should inherit directly from AbstractValue. User-defined
+/// classes that define additional type-erased features should inherit from
+/// Value<T>.
+///
+/// Most methods offer two variants, e.g., SetFrom and SetFromOrThrow.  The
+/// former variants are optimized to use static_casts in Release builds but
+/// will not throw exceptions when concrete Value types are mismatched; the
+/// latter variants are guaranteed to throw on mismatched types, but may be
+/// slower at runtime.  Prefer using the faster version only in performance-
+/// sensitive code (e.g., inner loops), and the safer version otherwise.
+class AbstractValue {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(AbstractValue)
+
+  virtual ~AbstractValue();
+
+  /// Returns an AbstractValue containing the given @p value.
+  template <typename T>
+  static std::unique_ptr<AbstractValue> Make(const T& value);
+
+  // TODO(david-german-tri): Once this uses static_cast under the hood in
+  // Release builds, lower-case it.
+  /// Returns the value wrapped in this AbstractValue, which must be of
+  /// exactly type T.  T cannot be a superclass, abstract or otherwise.
+  /// In Debug builds, if the types don't match, an std::logic_error will be
+  /// thrown with a helpful error message. In Release builds, this is not
+  /// guaranteed.
+  template <typename T>
+  const T& GetValue() const;
+
+  /// Like GetValue, but throws std::logic_error on mismatched types even in
+  /// Release builds.
+  template <typename T>
+  const T& GetValueOrThrow() const;
+
+  /// Like GetValue, but quietly returns nullptr on mismatched types,
+  /// even in Release builds.
+  /// @returns A pointer to the stored value if T is the right type,
+  ///          otherwise nullptr.
+  template <typename T>
+  const T* MaybeGetValue() const;
+
+  /// Returns the value wrapped in this AbstractValue, which must be of
+  /// exactly type T.  T cannot be a superclass, abstract or otherwise.
+  /// In Debug builds, if the types don't match, an std::logic_error will be
+  /// thrown with a helpful error message. In Release builds, this is not
+  /// guaranteed. Intentionally not const: holders of const references to the
+  /// AbstractValue should not be able to mutate the value it contains.
+  template <typename T>
+  T& GetMutableValue();
+
+  /// Like GetMutableValue, but throws std::logic_error on mismatched types even
+  /// in Release builds.
+  template <typename T>
+  T& GetMutableValueOrThrow();
+
+  /// Sets the value wrapped in this AbstractValue, which must be of
+  /// exactly type T.  T cannot be a superclass, abstract or otherwise.
+  /// @param value_to_set The value to be copied or cloned into this
+  /// AbstractValue. In Debug builds, if the types don't match,
+  /// an std::logic_error will be thrown with a helpful error message. In
+  /// Release builds, this is not guaranteed.
+  template <typename T>
+  void SetValue(const T& value_to_set);
+
+  /// Like SetValue, but throws on mismatched types even in Release builds.
+  template <typename T>
+  void SetValueOrThrow(const T& value_to_set);
+
+  /// Returns a copy of this AbstractValue.
+  virtual std::unique_ptr<AbstractValue> Clone() const = 0;
+
+  /// Copies or clones the value in @p other to this value.
+  /// In Debug builds, if the types don't match, an std::logic_error will be
+  /// thrown with a helpful error message. In Release builds, this is not
+  /// guaranteed.
+  virtual void SetFrom(const AbstractValue& other) = 0;
+
+  /// Like SetFrom, but throws std::logic_error on mismatched types even in
+  /// Release builds.
+  virtual void SetFromOrThrow(const AbstractValue& other) = 0;
+
+  /// Returns typeid of the contained object of type T. If T is polymorphic,
+  /// this returns the typeid of the most-derived type of the contained object.
+  virtual const std::type_info& type_info() const = 0;
+
+  /// Returns typeid(T) for this Value<T> object. If T is polymorphic, this
+  /// does NOT reflect the typeid of the most-derived type of the contained
+  /// object; the result is always the base type T.
+  const std::type_info& static_type_info() const { return static_type_info_; }
+
+  /// Returns a human-readable name for the underlying type T. This may be
+  /// slow but is useful for error messages. If T is polymorphic, this returns
+  /// the typeid of the most-derived type of the contained object.
+  std::string GetNiceTypeName() const;
+
+ protected:
+#if !defined(DRAKE_DOXYGEN_CXX)
+  explicit AbstractValue(const std::type_info& static_type_info)
+    : static_type_info_(static_type_info) {}
+#endif
+
+ private:
+  template <typename T>
+  bool is_matched() const;
+
+  template <typename T>
+  Value<T>* DownCastMutableOrThrow();
+
+  template <typename T>
+  Value<T>* DownCastMutableOrMaybeThrow();
+
+  template <typename T>
+  const Value<T>* DownCastOrThrow() const;
+
+  template <typename T>
+  const Value<T>* DownCastOrMaybeThrow() const;
+
+  const std::type_info& static_type_info_;
+};
+
+/// A container class for an arbitrary type T. User-defined classes that
+/// require additional type-erased features should subclass Value<T>, taking
+/// care to define the copy constructors and override Clone().
+/// @tparam T Must be copy-constructible or cloneable.
+template <typename T>
+class Value : public AbstractValue {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Value)
+
+  /// Constructs a Value<T> using T's default constructor, if available.
+  /// This is only available for T's that support default construction.
+#if !defined(DRAKE_DOXYGEN_CXX)
+  // T1 is template boilerplate; do not specify it at call sites.
+  template <typename T1 = T,
+            typename = typename std::enable_if_t<
+                std::is_default_constructible<T1>::value>>
+#endif
+  Value();
+
+  /// Constructs a Value<T> by copying or cloning the given value @p v.
+  explicit Value(const T& v);
+
+  /// Constructs a Value<T> by forwarding the given @p args to T's constructor,
+  /// if available.  This is only available for non-primitive T's that are
+  /// constructible from @p args.
+#if defined(DRAKE_DOXYGEN_CXX)
+  template <typename... Args>
+  explicit Value(Args&&... args);
+#else
+  // This overload is for copyable T.
+  template <typename Arg1, typename... Args, typename =
+      typename internal::ValueForwardingCtorEnabled<true, T, Arg1, Args...>>
+  explicit Value(Arg1&& arg1, Args&&... args);
+  // This overload is for cloneable T.
+  template <typename Arg1, typename... Args, typename = void, typename =
+      typename internal::ValueForwardingCtorEnabled<false, T, Arg1, Args...>>
+  explicit Value(Arg1&& arg1, Args&&... args);
+#endif
+
+  /// Constructs a Value<T> by copying or moving the given value @p v.
+  /// @pre v is non-null.
+  explicit Value(std::unique_ptr<T> v);
+
+  ~Value() override {}
+
+  /// Returns a const reference to the stored value.
+  const T& get_value() const;
+
+  /// Returns a mutable reference to the stored value.
+  T& get_mutable_value();
+
+  /// Replaces the stored value with a new one.
+  void set_value(const T& v);
+
+  // AbstractValue overrides.
+  std::unique_ptr<AbstractValue> Clone() const override;
+  void SetFrom(const AbstractValue& other) override;
+  void SetFromOrThrow(const AbstractValue& other) override;
+  const std::type_info& type_info() const override;
+
+  // A using-declaration adds these methods into our class's Doxygen.
+  using AbstractValue::static_type_info;
+  using AbstractValue::GetNiceTypeName;
+
+ private:
+  using Traits = internal::ValueTraits<T>;
+  typename Traits::Storage value_;
+};
+
+#if !defined(DRAKE_DOXYGEN_CXX)
+// Declare some private helper structs.
+namespace internal {
 
 // For copyable types, we can store a T directly within Value<T> and we don't
 // need any special tricks to create or retrieve it.
 template <typename T>
 struct ValueTraitsImpl<T, true> {
-  using UseCopy = std::true_type;
   using Storage = T;
   static void reinitialize_if_necessary(Storage*) {}
   static const T& to_storage(const T& other) { return other; }
@@ -62,7 +275,6 @@ struct ValueTraitsImpl<T, false> {
   static_assert(!std::is_same<T, std::remove_cv<AbstractValue>::type>::value,
                 "T in Value<T> cannot be AbstractValue.");
 
-  using UseCopy = std::false_type;
   using Storage = typename drake::copyable_unique_ptr<T>;
   static void reinitialize_if_necessary(Storage* value) {
     *value = std::make_unique<T>();
@@ -79,317 +291,179 @@ struct ValueTraitsImpl<T, false> {
   static T& access(Storage& storage) { return *storage; }
 };
 
+}  // namespace internal
+
 template <typename T>
-using ValueTraits = ValueTraitsImpl<T, std::is_copy_constructible<T>::value>;
+std::unique_ptr<AbstractValue> AbstractValue::Make(const T& value) {
+  return std::unique_ptr<AbstractValue>(new Value<T>(value));
+}
 
-}  // namespace value_detail
-#endif
-
-/// A fully type-erased container class.
-///
-/// Only Value<T> should inherit directly from AbstractValue. User-defined
-/// classes that define additional type-erased features should inherit from
-/// Value<T>.
-///
-/// Most methods offer two variants, e.g., SetFrom and SetFromOrThrow.  The
-/// former variants are optimized to use static_casts in Release builds but
-/// will not throw exceptions when concrete Value types are mismatched; the
-/// latter variants are guaranteed to throw on mismatched types, but may be
-/// slower at runtime.  Prefer using the faster version only in performance-
-/// sensitive code (e.g., inner loops), and the safer version otherwise.
-class AbstractValue {
- public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(AbstractValue)
-
-  virtual ~AbstractValue();
-
-  /// Returns a copy of this AbstractValue.
-  virtual std::unique_ptr<AbstractValue> Clone() const = 0;
-
-  /// Copies or clones the value in @p other to this value.
-  /// In Debug builds, if the types don't match, an std::logic_error will be
-  /// thrown with a helpful error message. In Release builds, this is not
-  /// guaranteed.
-  virtual void SetFrom(const AbstractValue& other) = 0;
-
-  /// Like SetFrom, but throws std::logic_error on mismatched types even in
-  /// Release builds.
-  virtual void SetFromOrThrow(const AbstractValue& other) = 0;
-
-  /// Returns typeid of the contained object of type T. If T is polymorphic,
-  /// this returns the typeid of the most-derived type of the contained object.
-  virtual const std::type_info& type_info() const = 0;
-
-  /// Returns typeid(T) for this Value<T> object. If T is polymorphic, this
-  /// does NOT reflect the typeid of the most-derived type of the contained
-  /// object; the result is always the base type T.
-  const std::type_info& static_type_info() const {
-    return static_type_info_;
-  }
-
-  /// Returns a human-readable name for the underlying type T. This may be
-  /// slow but is useful for error messages. If T is polymorphic, this returns
-  /// the typeid of the most-derived type of the contained object.
-  std::string GetNiceTypeName() const {
-    return NiceTypeName::Canonicalize(
-        NiceTypeName::Demangle(type_info().name()));
-  }
-
-  // TODO(david-german-tri): Once this uses static_cast under the hood in
-  // Release builds, lower-case it.
-  /// Returns the value wrapped in this AbstractValue, which must be of
-  /// exactly type T.  T cannot be a superclass, abstract or otherwise.
-  /// In Debug builds, if the types don't match, an std::logic_error will be
-  /// thrown with a helpful error message. In Release builds, this is not
-  /// guaranteed.
-  template <typename T>
-  const T& GetValue() const {
-    return DownCastOrMaybeThrow<T>()->get_value();
-  }
-
-  /// Like GetValue, but throws std::logic_error on mismatched types even in
-  /// Release builds.
-  template <typename T>
-  const T& GetValueOrThrow() const {
-    return DownCastOrThrow<T>()->get_value();
-  }
-
-  /// Like GetValue, but quietly returns nullptr on mismatched types,
-  /// even in Release builds.
-  /// @returns A pointer to the stored value if T is the right type,
-  ///          otherwise nullptr.
-  template <typename T>
-  const T* MaybeGetValue() const {
-    if (!is_matched<T>()) { return nullptr; }
-    auto* value = static_cast<const Value<T>*>(this);
-    return &value->get_value();
-  }
-
-  /// Returns the value wrapped in this AbstractValue, which must be of
-  /// exactly type T.  T cannot be a superclass, abstract or otherwise.
-  /// In Debug builds, if the types don't match, an std::logic_error will be
-  /// thrown with a helpful error message. In Release builds, this is not
-  /// guaranteed. Intentionally not const: holders of const references to the
-  /// AbstractValue should not be able to mutate the value it contains.
-  template <typename T>
-  T& GetMutableValue() {
-    return DownCastMutableOrMaybeThrow<T>()->get_mutable_value();
-  }
-
-  /// Like GetMutableValue, but throws std::logic_error on mismatched types even
-  /// in Release builds.
-  template <typename T>
-  T& GetMutableValueOrThrow() {
-    return DownCastMutableOrThrow<T>()->get_mutable_value();
-  }
-
-  /// Sets the value wrapped in this AbstractValue, which must be of
-  /// exactly type T.  T cannot be a superclass, abstract or otherwise.
-  /// @param value_to_set The value to be copied or cloned into this
-  /// AbstractValue. In Debug builds, if the types don't match,
-  /// an std::logic_error will be thrown with a helpful error message. In
-  /// Release builds, this is not guaranteed.
-  template <typename T>
-  void SetValue(const T& value_to_set) {
-    DownCastMutableOrMaybeThrow<T>()->set_value(value_to_set);
-  }
-
-  /// Like SetValue, but throws on mismatched types even in Release builds.
-  template <typename T>
-  void SetValueOrThrow(const T& value_to_set) {
-    DownCastMutableOrThrow<T>()->set_value(value_to_set);
-  }
-
-  /// Returns an AbstractValue containing the given @p value.
-  template <typename T>
-  static std::unique_ptr<AbstractValue> Make(const T& value) {
-    return std::unique_ptr<AbstractValue>(new Value<T>(value));
-  }
-
- protected:
-  explicit AbstractValue(const std::type_info& static_type_info)
-      : static_type_info_(static_type_info) {}
-
- private:
-  // Returns true iff `this` is-a `Value<T>`.
-  template <typename T>
-  bool is_matched() const {
-    return typeid(T) == static_type_info_;
-  }
-
-  // Casts this to a Value<T>*. Throws if the cast fails.
-  template <typename T>
-  Value<T>* DownCastMutableOrThrow() {
-    // We cast away const in this private non-const method so that we can reuse
-    // DownCastOrThrow. This is equivalent to duplicating the logic of
-    // DownCastOrThrow with a non-const target type.
-    return const_cast<Value<T>*>(DownCastOrThrow<T>());
-  }
-
-  // Casts this to a Value<T>*. In Debug builds, throws if the
-  // cast fails.
-  template <typename T>
-  Value<T>* DownCastMutableOrMaybeThrow() {
-    // We cast away const in this private non-const method so that we can reuse
-    // DownCastOrMaybeThrow. This is equivalent to duplicating the logic of
-    // DownCastOrMaybeThrow with a non-const target type.
-    return const_cast<Value<T>*>(DownCastOrMaybeThrow<T>());
-  }
-
-  // Casts this to a const Value<T>*. Throws if the cast fails.
-  template <typename T>
-  const Value<T>* DownCastOrThrow() const {
-    if (!is_matched<T>()) {
-      throw std::logic_error(
-          "AbstractValue: a request to extract a value of type '" +
-          NiceTypeName::Get<T>() + "' failed because the actual type was '" +
-          GetNiceTypeName() + "'.");
-    }
-    return static_cast<const Value<T>*>(this);
-  }
-
-  // Casts this to a const Value<T>*. In Debug builds, throws if
-  // the cast fails.
-  template <typename T>
-  const Value<T>* DownCastOrMaybeThrow() const {
-    // TODO(david-german-tri): Use static_cast in Release builds for speed.
-    return DownCastOrThrow<T>();
-  }
-
-  const std::type_info& static_type_info_;
-};
-
-/// A container class for an arbitrary type T. User-defined classes that
-/// require additional type-erased features should subclass Value<T>, taking
-/// care to define the copy constructors and override Clone().
-/// @tparam T Must be copy-constructible or cloneable.
 template <typename T>
-class Value : public AbstractValue {
- public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Value)
+const T& AbstractValue::GetValue() const {
+  return DownCastOrMaybeThrow<T>()->get_value();
+}
 
-  /// Constructs a Value<T> using T's default constructor, if available.
-  /// This is only available for T's that support default construction.
-#if !defined(DRAKE_DOXYGEN_CXX)
-  // T1 is template boilerplate; do not specify it at call sites.
-  template <typename T1 = T,
-            typename = typename std::enable_if_t<
-                std::is_default_constructible<T1>::value>>
-#endif
-  Value()
-      : AbstractValue(typeid(T)),
-        value_{} {
-    Traits::reinitialize_if_necessary(&value_);
+template <typename T>
+const T& AbstractValue::GetValueOrThrow() const {
+  return DownCastOrThrow<T>()->get_value();
+}
+
+template <typename T>
+const T* AbstractValue::MaybeGetValue() const {
+  if (!is_matched<T>()) { return nullptr; }
+  auto* value = static_cast<const Value<T>*>(this);
+  return &value->get_value();
+}
+
+template <typename T>
+T& AbstractValue::GetMutableValue() {
+  return DownCastMutableOrMaybeThrow<T>()->get_mutable_value();
+}
+
+template <typename T>
+T& AbstractValue::GetMutableValueOrThrow() {
+  return DownCastMutableOrThrow<T>()->get_mutable_value();
+}
+
+template <typename T>
+void AbstractValue::SetValue(const T& value_to_set) {
+  DownCastMutableOrMaybeThrow<T>()->set_value(value_to_set);
+}
+
+template <typename T>
+void AbstractValue::SetValueOrThrow(const T& value_to_set) {
+  DownCastMutableOrThrow<T>()->set_value(value_to_set);
+}
+
+// Returns true iff `this` is-a `Value<T>`.
+template <typename T>
+bool AbstractValue::is_matched() const {
+  return typeid(T) == static_type_info_;
+}
+
+// Casts this to a Value<T>*. Throws if the cast fails.
+template <typename T>
+Value<T>* AbstractValue::DownCastMutableOrThrow() {
+  // We cast away const in this private non-const method so that we can reuse
+  // DownCastOrThrow. This is equivalent to duplicating the logic of
+  // DownCastOrThrow with a non-const target type.
+  return const_cast<Value<T>*>(DownCastOrThrow<T>());
+}
+
+// Casts this to a Value<T>*. In Debug builds, throws if the cast fails.
+template <typename T>
+Value<T>* AbstractValue::DownCastMutableOrMaybeThrow() {
+  // We cast away const in this private non-const method so that we can reuse
+  // DownCastOrMaybeThrow. This is equivalent to duplicating the logic of
+  // DownCastOrMaybeThrow with a non-const target type.
+  return const_cast<Value<T>*>(DownCastOrMaybeThrow<T>());
+}
+
+// Casts this to a const Value<T>*. Throws if the cast fails.
+template <typename T>
+const Value<T>* AbstractValue::DownCastOrThrow() const {
+  if (!is_matched<T>()) {
+    throw std::logic_error(
+        "AbstractValue: a request to extract a value of type '" +
+        NiceTypeName::Get<T>() + "' failed because the actual type was '" +
+        GetNiceTypeName() + "'.");
   }
+  return static_cast<const Value<T>*>(this);
+}
 
-  /// Constructs a Value<T> by copying or cloning the given value @p v.
-  explicit Value(const T& v)
-      : AbstractValue(typeid(T)),
-        value_(Traits::to_storage(v)) {}
+// Casts this to a const Value<T>*. In Debug builds, throws if the cast fails.
+template <typename T>
+const Value<T>* AbstractValue::DownCastOrMaybeThrow() const {
+  // TODO(david-german-tri): Use static_cast in Release builds for speed.
+  return DownCastOrThrow<T>();
+}
 
-  /// Constructs a Value<T> by forwarding the given @p args to T's constructor,
-  /// if available.  This is only available for non-primitive T's that are
-  /// constructible from @p args.
-#if defined(DRAKE_DOXYGEN_CXX)
-  template <typename... Args>
-  explicit Value(Args&&... args);
-#else
-  // This overload is for copyable T; we construct value_ in-place as Storage.
-  template <typename Arg1,
-            typename... Args,
-            typename = typename std::enable_if_t<
-                // There must be such a constructor.
-                std::is_constructible<T, Arg1, Args...>::value &&
-                // Disable this ctor when given T directly; in that case, we
-                // should call our Value(const T&) ctor above, not try to copy-
-                // construct a T(const T&).
-                !std::is_same<T, Arg1>::value &&
-                !std::is_same<T&, Arg1>::value &&
-                // Only allow real ctors, not POD "constructor"s.
-                !std::is_fundamental<T>::value &&
-                // Use this only for copyable T's.
-                value_detail::ValueTraits<T>::UseCopy::value
-              >>
-  explicit Value(Arg1&& arg1, Args&&... args)
-      : AbstractValue(typeid(T)),
-        value_{std::forward<Arg1>(arg1), std::forward<Args>(args)...} {}
+template <typename T>
+template <typename T1, typename T2>
+Value<T>::Value()
+    : AbstractValue(typeid(T)),
+      value_{} {
+  Traits::reinitialize_if_necessary(&value_);
+}
 
-  // This overload is for cloneable T; we move a unique_ptr into our Storage.
-  template <typename Arg1,
-            typename... Args,
-            typename = typename std::enable_if_t<
-                // These predicates are the same as above ...
-                std::is_constructible<T, Arg1, Args...>::value &&
-                !std::is_same<T, Arg1>::value &&
-                !std::is_same<T&, Arg1>::value &&
-                !std::is_fundamental<T>::value &&
-                // ... except only for cloneable T.
-                !value_detail::ValueTraits<T>::UseCopy::value
-              >,
-            // Dummy to disambiguate this method from the above overload.
-            typename = void>
-  explicit Value(Arg1&& arg1, Args&&... args)
-      : AbstractValue(typeid(T)),
-        value_{std::make_unique<T>(
-            std::forward<Arg1>(arg1), std::forward<Args>(args)...)} {}
-#endif
+template <typename T>
+Value<T>::Value(const T& v)
+    : AbstractValue(typeid(T)),
+      value_(Traits::to_storage(v)) {}
 
-  /// Constructs a Value<T> by copying or moving the given value @p v.
-  /// @pre v is non-null
-  explicit Value(std::unique_ptr<T> v)
-      : AbstractValue(typeid(T)),
-        value_{Traits::to_storage(std::move(v))} {}
-  // An explanation of the above constructor:
-  //
-  // We start with a unique_ptr<T> v.  We std::move it to get an xvalue
-  // unique_ptr<T>&& that we pass to to_storage.
-  //
-  // In the copyable case, that matches to_storage(const unique_ptr<T>&), which
-  // does a nonnull check and then returns an alias to the owned const T&
-  // within v.  Back in the Value constructor, the value_ member constructor is
-  // offered const T& so it does T::T(const T&) copy construction.  As the
-  // constructor returns, the v argument goes out of scope and the T owned by v
-  // is deleted.  The users's unique_ptr<T> was transferred to Value<T> with a
-  // single copy.
-  //
-  // In the cloneable case, that matches to_storage(unique_ptr<T>), which means
-  // v is moved into other. The to_storage does a nonnull check, then
-  // std::moves other into an xvalue unique_ptr<T>&& again, then constructs a
-  // copyable_unique_ptr<T> from the xvalue which moves the owned T resource
-  // into that temporary, then returns the temporary by-value.  By RVO, the
-  // return value was already directly place into value_ and we are done.  The
-  // user's unique_ptr<T> was transferred to Value<T> without any Clone.
+// We construct-in-place into our Storage value_.
+template <typename T>
+template <typename Arg1, typename... Args, typename>
+Value<T>::Value(Arg1&& arg1, Args&&... args)
+    : AbstractValue(typeid(T)),
+      value_{std::forward<Arg1>(arg1), std::forward<Args>(args)...} {}
 
-  ~Value() override {}
+// We move a unique_ptr into our Storage value_.
+template <typename T>
+template <typename Arg1, typename... Args, typename, typename>
+Value<T>::Value(Arg1&& arg1, Args&&... args)
+    : AbstractValue(typeid(T)),
+      value_{std::make_unique<T>(
+          std::forward<Arg1>(arg1), std::forward<Args>(args)...)} {}
 
-  std::unique_ptr<AbstractValue> Clone() const override {
-    return std::make_unique<Value<T>>(get_value());
-  }
+// An explanation of the this constructor:
+//
+// We start with a unique_ptr<T> v.  We std::move it to get an xvalue
+// unique_ptr<T>&& that we pass to to_storage.
+//
+// In the copyable case, that matches to_storage(const unique_ptr<T>&), which
+// does a nonnull check and then returns an alias to the owned const T& within
+// v.  Back in the Value constructor, the value_ member constructor is offered
+// const T& so it does T::T(const T&) copy construction.  As the constructor
+// returns, the v argument goes out of scope and the T owned by v is deleted.
+// The users's unique_ptr<T> was transferred to Value<T> with a single copy.
+//
+// In the cloneable case, that matches to_storage(unique_ptr<T>), which means v
+// is moved into other. The to_storage does a nonnull check, then std::moves
+// other into an xvalue unique_ptr<T>&& again, then constructs a
+// copyable_unique_ptr<T> from the xvalue which moves the owned T resource into
+// that temporary, then returns the temporary by-value.  By RVO, the return
+// value was already directly place into value_ and we are done.  The user's
+// unique_ptr<T> was transferred to Value<T> without any Clone.
+template <typename T>
+Value<T>::Value(std::unique_ptr<T> v)
+    : AbstractValue(typeid(T)),
+      value_{Traits::to_storage(std::move(v))} {}
 
-  void SetFrom(const AbstractValue& other) override {
-    value_ = Traits::to_storage(other.GetValue<T>());
-  }
+template <typename T>
+const T& Value<T>::get_value() const {
+  return Traits::access(value_);
+}
 
-  void SetFromOrThrow(const AbstractValue& other) override {
-    value_ = Traits::to_storage(other.GetValueOrThrow<T>());
-  }
+template <typename T>
+T& Value<T>::get_mutable_value() {
+  return Traits::access(value_);
+}
 
-  const std::type_info& type_info() const override {
-    return typeid(get_value());
-  }
+template <typename T>
+void Value<T>::set_value(const T& v) {
+  value_ = Traits::to_storage(v);
+}
 
-  /// Returns a const reference to the stored value.
-  const T& get_value() const { return Traits::access(value_); }
+template <typename T>
+std::unique_ptr<AbstractValue> Value<T>::Clone() const {
+  return std::make_unique<Value<T>>(get_value());
+}
 
-  /// Returns a mutable reference to the stored value.
-  T& get_mutable_value() { return Traits::access(value_); }
+template <typename T>
+void Value<T>::SetFrom(const AbstractValue& other) {
+  value_ = Traits::to_storage(other.GetValue<T>());
+}
 
-  /// Replaces the stored value with a new one.
-  void set_value(const T& v) { value_ = Traits::to_storage(v); }
+template <typename T>
+void Value<T>::SetFromOrThrow(const AbstractValue& other) {
+  value_ = Traits::to_storage(other.GetValueOrThrow<T>());
+}
 
- private:
-  using Traits = value_detail::ValueTraits<T>;
-  typename Traits::Storage value_;
-};
+template <typename T>
+const std::type_info& Value<T>::type_info() const {
+  return typeid(get_value());
+}
 
+#endif  // DRAKE_DOXYGEN_CXX
 }  // namespace drake


### PR DESCRIPTION
This PR is _only_ a code shuffle, except for the addition of the `ValueForwardingCtorEnabled` boilerplate alias and a few new `using` statements for Doxygen goodness.

Relates #10678.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10712)
<!-- Reviewable:end -->
