### PR TITLE
common: Add internal::TypeHash<T>

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -145,6 +145,7 @@ drake_cc_library(
 
 drake_cc_library(
     name = "hash",
+    srcs = ["hash.cc"],
     hdrs = ["hash.h"],
     deps = [
         ":essential",
@@ -484,6 +485,7 @@ drake_cc_library(
     deps = [
         ":copyable_unique_ptr",
         ":essential",
+        ":hash",
         ":is_cloneable",
         ":nice_type_name",
     ],

--- a/common/hash.cc
+++ b/common/hash.cc
@@ -1,0 +1,9 @@
+#include "drake/common/hash.h"
+
+namespace drake {
+namespace internal {
+
+constexpr size_t FNV1aHasher::kFnvPrime;
+
+}  // namespace internal
+}  // namespace drake


### PR DESCRIPTION
Relates #10678, which shows the PR train where this is fully integrated.

This soon (#10727) will be used in AbstractValue to guard downcasts, instead of comparing the typeinfo objects.  Unlike typeinfo checks, this mechanism does not have the hazard of falling back to string-comparison slow paths.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10718)
<!-- Reviewable:end -->
