### PR TITLE
Added options to specifiy the publish triggers for LcmPublisherSystem.

### DIFF
--- a/bindings/pydrake/systems/lcm_py.cc
+++ b/bindings/pydrake/systems/lcm_py.cc
@@ -148,7 +148,7 @@ PYBIND11_MODULE(lcm, m) {
             py::arg("channel"), py::arg("serializer"), py::arg("lcm"),
             py::arg("publish_period") = 0.0,
             // Keep alive: `self` keeps `DrakeLcmInterface` alive.
-            py::keep_alive<1, 3>(), doc.LcmPublisherSystem.ctor.doc)
+            py::keep_alive<1, 3>(), doc.LcmPublisherSystem.ctor.doc4_args)
         .def("set_publish_period",
             [](Class* self, double period) {
               WarnDeprecated("set_publish_period() is deprecated");

--- a/bindings/pydrake/systems/lcm_py.cc
+++ b/bindings/pydrake/systems/lcm_py.cc
@@ -148,7 +148,7 @@ PYBIND11_MODULE(lcm, m) {
             py::arg("channel"), py::arg("serializer"), py::arg("lcm"),
             py::arg("publish_period") = 0.0,
             // Keep alive: `self` keeps `DrakeLcmInterface` alive.
-            py::keep_alive<1, 3>(), doc.LcmPublisherSystem.ctor.doc4_args)
+            py::keep_alive<1, 3>(), doc.LcmPublisherSystem.ctor.doc_4args)
         .def("set_publish_period",
             [](Class* self, double period) {
               WarnDeprecated("set_publish_period() is deprecated");

--- a/systems/lcm/lcm_publisher_system.cc
+++ b/systems/lcm/lcm_publisher_system.cc
@@ -83,7 +83,7 @@ LcmPublisherSystem::LcmPublisherSystem(
         &LcmPublisherSystem::PublishInputAsLcmMessage);
   } else {
     // publish_period > 0 without TriggerType::kPeriodic has no meaning and is
-    // likely a mistake
+    // likely a mistake.
     DRAKE_DEMAND(publish_period == 0);
   }
 

--- a/systems/lcm/lcm_publisher_system.cc
+++ b/systems/lcm/lcm_publisher_system.cc
@@ -30,7 +30,7 @@ LcmPublisherSystem::LcmPublisherSystem(
     std::unique_ptr<const LcmAndVectorBaseTranslator> owned_translator,
     std::unique_ptr<SerializerInterface> serializer,
     DrakeLcmInterface* lcm,
-    const TriggerTypes& publish_triggers,
+    const TriggerTypeSet& publish_triggers,
     double publish_period)
     : channel_(channel),
       translator_(owned_translator ? owned_translator.get() : translator),
@@ -43,9 +43,9 @@ LcmPublisherSystem::LcmPublisherSystem(
   DRAKE_DEMAND(publish_period >= 0.0);
   DRAKE_DEMAND(!publish_triggers.empty());
 
-  // Check that publish_triggers does not contain an unsupported trigger
+  // Check that publish_triggers does not contain an unsupported trigger.
   for (const auto& trigger : publish_triggers) {
-      DRAKE_DEMAND((trigger == TriggerType::kForced) ||
+      DRAKE_THROW_UNLESS((trigger == TriggerType::kForced) ||
         (trigger == TriggerType::kPeriodic) ||
         (trigger == TriggerType::kPerStep));
   }
@@ -76,7 +76,7 @@ LcmPublisherSystem::LcmPublisherSystem(
 
   set_name(make_name(channel_));
   if (publish_triggers.find(TriggerType::kPeriodic) != publish_triggers.end()) {
-    DRAKE_DEMAND(publish_period > 0);
+    DRAKE_THROW_UNLESS(publish_period > 0);
     const double offset = 0.0;
     this->DeclarePeriodicPublishEvent(
         publish_period, offset,
@@ -113,8 +113,8 @@ LcmPublisherSystem::LcmPublisherSystem(
     : LcmPublisherSystem(channel, translator, std::move(owned_translator),
       std::move(serializer), lcm,
       (publish_period > 0) ?
-      TriggerTypes({TriggerType::kForced, TriggerType::kPeriodic}) :
-      TriggerTypes({TriggerType::kForced, TriggerType::kPerStep}),
+      TriggerTypeSet({TriggerType::kForced, TriggerType::kPeriodic}) :
+      TriggerTypeSet({TriggerType::kForced, TriggerType::kPerStep}),
       publish_period) {}
 
 LcmPublisherSystem::LcmPublisherSystem(
@@ -127,7 +127,7 @@ LcmPublisherSystem::LcmPublisherSystem(
 LcmPublisherSystem::LcmPublisherSystem(
     const std::string& channel, std::unique_ptr<SerializerInterface> serializer,
     drake::lcm::DrakeLcmInterface* lcm,
-    const TriggerTypes& publish_triggers,
+    const TriggerTypeSet& publish_triggers,
     double publish_period)
     : LcmPublisherSystem(channel, nullptr, nullptr, std::move(serializer),
                          lcm, publish_triggers, publish_period) {}

--- a/systems/lcm/lcm_publisher_system.cc
+++ b/systems/lcm/lcm_publisher_system.cc
@@ -76,7 +76,7 @@ LcmPublisherSystem::LcmPublisherSystem(
 
   set_name(make_name(channel_));
   if (publish_triggers.find(TriggerType::kPeriodic) != publish_triggers.end()) {
-    DRAKE_THROW_UNLESS(publish_period > 0);
+    DRAKE_THROW_UNLESS(publish_period > 0.0);
     const double offset = 0.0;
     this->DeclarePeriodicPublishEvent(
         publish_period, offset,
@@ -84,7 +84,7 @@ LcmPublisherSystem::LcmPublisherSystem(
   } else {
     // publish_period > 0 without TriggerType::kPeriodic has no meaning and is
     // likely a mistake.
-    DRAKE_THROW_UNLESS(publish_period == 0);
+    DRAKE_THROW_UNLESS(publish_period == 0.0);
   }
 
   if (publish_triggers.find(TriggerType::kPerStep) != publish_triggers.end()) {
@@ -112,7 +112,7 @@ LcmPublisherSystem::LcmPublisherSystem(
     DrakeLcmInterface* lcm, double publish_period)
     : LcmPublisherSystem(channel, translator, std::move(owned_translator),
       std::move(serializer), lcm,
-      (publish_period > 0) ?
+      (publish_period > 0.0) ?
       TriggerTypeSet({TriggerType::kForced, TriggerType::kPeriodic}) :
       TriggerTypeSet({TriggerType::kForced, TriggerType::kPerStep}),
       publish_period) {}

--- a/systems/lcm/lcm_publisher_system.cc
+++ b/systems/lcm/lcm_publisher_system.cc
@@ -84,7 +84,7 @@ LcmPublisherSystem::LcmPublisherSystem(
   } else {
     // publish_period > 0 without TriggerType::kPeriodic has no meaning and is
     // likely a mistake.
-    DRAKE_DEMAND(publish_period == 0);
+    DRAKE_THROW_UNLESS(publish_period == 0);
   }
 
   if (publish_triggers.find(TriggerType::kPerStep) != publish_triggers.end()) {

--- a/systems/lcm/lcm_publisher_system.cc
+++ b/systems/lcm/lcm_publisher_system.cc
@@ -30,7 +30,7 @@ LcmPublisherSystem::LcmPublisherSystem(
     std::unique_ptr<const LcmAndVectorBaseTranslator> owned_translator,
     std::unique_ptr<SerializerInterface> serializer,
     DrakeLcmInterface* lcm,
-    const std::unordered_set<TriggerType>& publish_triggers,
+    const TriggerTypes& publish_triggers,
     double publish_period)
     : channel_(channel),
       translator_(owned_translator ? owned_translator.get() : translator),
@@ -112,10 +112,9 @@ LcmPublisherSystem::LcmPublisherSystem(
     DrakeLcmInterface* lcm, double publish_period)
     : LcmPublisherSystem(channel, translator, std::move(owned_translator),
       std::move(serializer), lcm,
-      (publish_period > 0) ? std::unordered_set<TriggerType>(
-          {TriggerType::kForced, TriggerType::kPeriodic}) :
-      std::unordered_set<TriggerType>(
-          {TriggerType::kForced, TriggerType::kPerStep}),
+      (publish_period > 0) ?
+      TriggerTypes({TriggerType::kForced, TriggerType::kPeriodic}) :
+      TriggerTypes({TriggerType::kForced, TriggerType::kPerStep}),
       publish_period) {}
 
 LcmPublisherSystem::LcmPublisherSystem(
@@ -128,7 +127,7 @@ LcmPublisherSystem::LcmPublisherSystem(
 LcmPublisherSystem::LcmPublisherSystem(
     const std::string& channel, std::unique_ptr<SerializerInterface> serializer,
     drake::lcm::DrakeLcmInterface* lcm,
-    const std::unordered_set<TriggerType>& publish_triggers,
+    const TriggerTypes& publish_triggers,
     double publish_period)
     : LcmPublisherSystem(channel, nullptr, nullptr, std::move(serializer),
                          lcm, publish_triggers, publish_period) {}

--- a/systems/lcm/lcm_publisher_system.h
+++ b/systems/lcm/lcm_publisher_system.h
@@ -26,7 +26,7 @@ class DrakeLcm;
 namespace systems {
 namespace lcm {
 
-using TriggerTypes = std::unordered_set<TriggerType, DefaultHash>;
+using TriggerTypeSet = std::unordered_set<TriggerType, DefaultHash>;
 
 /**
  * Publishes an LCM message containing information from its input port.
@@ -54,8 +54,8 @@ class LcmPublisherSystem : public LeafSystem<double> {
    * Value<LcmMessage> message objects on its sole abstract-valued input port.
    *
    * Sets the default set of publish triggers: 
-   *   if publish_period = 0, publishes on forced events and per step
-   *   if publish_period > 0, publishes on forced events and periodically
+   *   if publish_period = 0, publishes on forced events and per step,
+   *   if publish_period > 0, publishes on forced events and periodically.
    *
    * @tparam LcmMessage message type to serialize, e.g., lcmt_drake_signal.
    *
@@ -103,7 +103,7 @@ class LcmPublisherSystem : public LeafSystem<double> {
    *
    * @param publish_period Period that messages will be published (optional).
    * publish_period should only be non-zero if one of the publish_triggers is
-   * kPerStep.
+   * kPeriodic.
    *   
    * @pre publish_period is non-negative.
    * @pre trigger_types contains a subset of {kForced, kPeriodic, kPerStep}.
@@ -113,7 +113,7 @@ class LcmPublisherSystem : public LeafSystem<double> {
   static std::unique_ptr<LcmPublisherSystem> Make(
       const std::string& channel,
       drake::lcm::DrakeLcmInterface* lcm,
-      const TriggerTypes& publish_triggers,
+      const TriggerTypeSet& publish_triggers,
       double publish_period = 0.0) {
     return std::make_unique<LcmPublisherSystem>(
         channel, std::make_unique<Serializer<LcmMessage>>(), lcm,
@@ -164,21 +164,21 @@ class LcmPublisherSystem : public LeafSystem<double> {
    *
    * @param publish_triggers Set of triggers that determine when messages will
    * be published. Supported TriggerTypes are {kForced, kPeriodic, kPerStep}. 
-   * Will throw an error if empty or if unsupported types are provided.
+   * Will throw an exception if empty or if unsupported types are provided.
    *
    * @param publish_period Period that messages will be published (optional).
    * publish_period should only be non-zero if one of the publish_triggers is
    * kPerStep.
    *   
    * @pre publish_period is non-negative.
-   * @pre trigger_types contains a subset of {kForced, kPeriodic, kPerStep}.
    * @pre publish_period > 0 iff trigger_types contains kPeriodic.
+   * @pre trigger_types contains a subset of {kForced, kPeriodic, kPerStep}.
    */
   LcmPublisherSystem(const std::string& channel,
-                     std::unique_ptr<SerializerInterface> serializer,
-                     drake::lcm::DrakeLcmInterface* lcm,
-                     const TriggerTypes& publish_triggers,
-                     double publish_period = 0.0);
+      std::unique_ptr<SerializerInterface> serializer,
+      drake::lcm::DrakeLcmInterface* lcm,
+      const TriggerTypeSet& publish_triggers,
+      double publish_period = 0.0);
 
   DRAKE_DEPRECATED(
       "The LcmAndVectorBaseTranslator and its related code are deprecated, "
@@ -290,7 +290,7 @@ class LcmPublisherSystem : public LeafSystem<double> {
                          owned_translator,
                      std::unique_ptr<SerializerInterface> serializer,
                      drake::lcm::DrakeLcmInterface* lcm,
-                     const TriggerTypes& publish_triggers,
+                     const TriggerTypeSet& publish_triggers,
                      double publish_period);
 
   // Constructors which do not specify publish_triggers delegate to here.

--- a/systems/lcm/lcm_publisher_system.h
+++ b/systems/lcm/lcm_publisher_system.h
@@ -8,6 +8,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_deprecated.h"
 #include "drake/common/drake_throw.h"
+#include "drake/common/hash.h"
 #include "drake/lcm/drake_lcm_interface.h"
 #include "drake/systems/framework/event.h"
 #include "drake/systems/framework/leaf_system.h"
@@ -24,6 +25,8 @@ class DrakeLcm;
 
 namespace systems {
 namespace lcm {
+
+using TriggerTypes = std::unordered_set<TriggerType, DefaultHash>;
 
 /**
  * Publishes an LCM message containing information from its input port.
@@ -110,7 +113,7 @@ class LcmPublisherSystem : public LeafSystem<double> {
   static std::unique_ptr<LcmPublisherSystem> Make(
       const std::string& channel,
       drake::lcm::DrakeLcmInterface* lcm,
-      const std::unordered_set<TriggerType>& publish_triggers,
+      const TriggerTypes& publish_triggers,
       double publish_period = 0.0) {
     return std::make_unique<LcmPublisherSystem>(
         channel, std::make_unique<Serializer<LcmMessage>>(), lcm,
@@ -174,7 +177,7 @@ class LcmPublisherSystem : public LeafSystem<double> {
   LcmPublisherSystem(const std::string& channel,
                      std::unique_ptr<SerializerInterface> serializer,
                      drake::lcm::DrakeLcmInterface* lcm,
-                     const std::unordered_set<TriggerType>& publish_triggers,
+                     const TriggerTypes& publish_triggers,
                      double publish_period = 0.0);
 
   DRAKE_DEPRECATED(
@@ -287,7 +290,7 @@ class LcmPublisherSystem : public LeafSystem<double> {
                          owned_translator,
                      std::unique_ptr<SerializerInterface> serializer,
                      drake::lcm::DrakeLcmInterface* lcm,
-                     const std::unordered_set<TriggerType>& publish_triggers,
+                     const TriggerTypes& publish_triggers,
                      double publish_period);
 
   // Constructors which do not specify publish_triggers delegate to here.

--- a/systems/lcm/lcm_publisher_system.h
+++ b/systems/lcm/lcm_publisher_system.h
@@ -87,20 +87,6 @@ class LcmPublisherSystem : public LeafSystem<double> {
   }
 
   /**
-   * See full factory method above. Uses the default publish_period = 0
-   * for when publish_triggers does not contain kPeriodic.
-   */
-  template <typename LcmMessage>
-  static std::unique_ptr<LcmPublisherSystem> Make(
-      const std::string& channel,
-      drake::lcm::DrakeLcmInterface* lcm,
-      std::unordered_set<TriggerType> publish_triggers = {}) {
-    return std::make_unique<LcmPublisherSystem>(
-        channel, std::make_unique<Serializer<LcmMessage>>(), lcm,
-        0.0, publish_triggers);
-  }
-
-  /**
    * A constructor for an %LcmPublisherSystem that takes LCM message objects on
    * its sole abstract-valued input port. The LCM message type is determined by
    * the provided `serializer`.

--- a/systems/lcm/lcm_publisher_system.h
+++ b/systems/lcm/lcm_publisher_system.h
@@ -103,8 +103,8 @@ class LcmPublisherSystem : public LeafSystem<double> {
    * kPerStep.
    *   
    * @pre publish_period is non-negative.
-   * @pre trigger_types contains a subset of {kForced, kPeriodic, kPerStep}
-   * @pre publish_period > 0 iff trigger_types contains kPeriodic
+   * @pre trigger_types contains a subset of {kForced, kPeriodic, kPerStep}.
+   * @pre publish_period > 0 if and only if trigger_types contains kPeriodic.
    */
   template <typename LcmMessage>
   static std::unique_ptr<LcmPublisherSystem> Make(
@@ -168,8 +168,8 @@ class LcmPublisherSystem : public LeafSystem<double> {
    * kPerStep.
    *   
    * @pre publish_period is non-negative.
-   * @pre trigger_types contains a subset of {kForced, kPeriodic, kPerStep}
-   * @pre publish_period > 0 iff trigger_types contains kPeriodic
+   * @pre trigger_types contains a subset of {kForced, kPeriodic, kPerStep}.
+   * @pre publish_period > 0 iff trigger_types contains kPeriodic.
    */
   LcmPublisherSystem(const std::string& channel,
                      std::unique_ptr<SerializerInterface> serializer,

--- a/systems/lcm/test/lcm_publisher_system_test.cc
+++ b/systems/lcm/test/lcm_publisher_system_test.cc
@@ -289,7 +289,7 @@ GTEST_TEST(LcmPublisherSystemTest, TestPerStepPublishTrigger) {
   // Ensure that the integrator takes at least a few steps.
   // Since there is no internal continuous state for the system, the integrator
   // will not subdivide its steps.
-  for (double time = 0; time < 1; time += 0.25)
+  for (double time = 0.0; time < 1; time += 0.25)
     simulator.StepTo(time);
 
   // Check that we get exactly the number of publishes desired: one (at
@@ -321,7 +321,7 @@ GTEST_TEST(LcmPublisherSystemTest, TestForcedPublishTrigger) {
     dut->Publish(*context);
   }
 
-  // Check that we get exactly the number of publishes desired
+  // Check that we get exactly the number of publishes desired.
   EXPECT_EQ(transmission_count, force_publish_count);
 }
 
@@ -401,7 +401,7 @@ GTEST_TEST(LcmPublisherSystemTest, TestPublishPeriodTrigger) {
   // Check that a message was transmitted during initialization.
   EXPECT_EQ(transmission_count, 1);
 
-  for (double time = 0; time < 4; time += 0.01) {
+  for (double time = 0.0; time < 4; time += 0.01) {
     simulator.StepTo(time);
     EXPECT_NEAR(simulator.get_mutable_context().get_time(), time, 1e-10);
   }

--- a/systems/lcm/test/lcm_publisher_system_test.cc
+++ b/systems/lcm/test/lcm_publisher_system_test.cc
@@ -270,7 +270,7 @@ GTEST_TEST(LcmPublisherSystemTest, TestPerStepPublishTrigger) {
   lcm.EnableLoopBack();
 
   auto dut = LcmPublisherSystem::Make<lcmt_drake_signal>(channel_name,
-      &lcm, std::unordered_set<TriggerType>({TriggerType::kPerStep}));
+      &lcm, TriggerTypes({TriggerType::kPerStep}));
 
   unique_ptr<Context<double>> context = dut->AllocateContext();
 
@@ -355,7 +355,7 @@ GTEST_TEST(LcmPublisherSystemTest, TestPublishPeriodTrigger) {
 
   // Instantiates the "device under test".
   auto dut = LcmPublisherSystem::Make<lcmt_drake_signal>(channel_name,
-      &lcm, std::unordered_set<TriggerType>({TriggerType::kPeriodic}),
+      &lcm, TriggerTypes({TriggerType::kPeriodic}),
       kPublishPeriod);
   unique_ptr<Context<double>> context = dut->AllocateContext();
 

--- a/systems/lcm/test/lcm_publisher_system_test.cc
+++ b/systems/lcm/test/lcm_publisher_system_test.cc
@@ -270,7 +270,7 @@ GTEST_TEST(LcmPublisherSystemTest, TestPerStepPublishTrigger) {
   lcm.EnableLoopBack();
 
   auto dut = LcmPublisherSystem::Make<lcmt_drake_signal>(channel_name,
-      &lcm, TriggerTypes({TriggerType::kPerStep}));
+      &lcm, {TriggerType::kPerStep});
 
   unique_ptr<Context<double>> context = dut->AllocateContext();
 
@@ -287,12 +287,42 @@ GTEST_TEST(LcmPublisherSystemTest, TestPerStepPublishTrigger) {
   EXPECT_EQ(transmission_count, 1);
 
   // Ensure that the integrator takes at least a few steps.
+  // Since there is no internal continuous state for the system, the integrator
+  // will not subdivide its steps.
   for (double time = 0; time < 1; time += 0.25)
     simulator.StepTo(time);
 
   // Check that we get exactly the number of publishes desired: one (at
   // initialization) plus another for each step.
   EXPECT_EQ(transmission_count, 1 + simulator.get_num_steps_taken());
+}
+
+// When constructed via a publish_triggers set, tests that forced publish
+// generates the expected number of publishes.
+GTEST_TEST(LcmPublisherSystemTest, TestForcedPublishTrigger) {
+  lcm::DrakeMockLcm lcm;
+  const std::string channel_name = "channel_name";
+  int transmission_count = 0;
+  int force_publish_count = 3;
+  lcm.Subscribe(channel_name, [&transmission_count](const void*, int) {
+    ++transmission_count;
+  });
+  lcm.EnableLoopBack();
+
+  auto dut = LcmPublisherSystem::Make<lcmt_drake_signal>(channel_name,
+      &lcm, {TriggerType::kForced});
+
+  unique_ptr<Context<double>> context = dut->AllocateContext();
+
+  context->FixInputPort(kPortNumber,
+    AbstractValue::Make<lcmt_drake_signal>(lcmt_drake_signal()));
+
+  for (int i = 0; i < force_publish_count; i++) {
+    dut->Publish(*context);
+  }
+
+  // Check that we get exactly the number of publishes desired
+  EXPECT_EQ(transmission_count, force_publish_count);
 }
 
 // Tests that the published LCM message has the expected timestamps.
@@ -355,7 +385,7 @@ GTEST_TEST(LcmPublisherSystemTest, TestPublishPeriodTrigger) {
 
   // Instantiates the "device under test".
   auto dut = LcmPublisherSystem::Make<lcmt_drake_signal>(channel_name,
-      &lcm, TriggerTypes({TriggerType::kPeriodic}),
+      &lcm, {TriggerType::kPeriodic},
       kPublishPeriod);
   unique_ptr<Context<double>> context = dut->AllocateContext();
 


### PR DESCRIPTION
As a fix to #10716, enables accurate use of LcmDrivenLoop and allows us to split LCM publishing between local and remote traffic. Am very open to the API, and which constructors should be included/neglected. Current API came out of discussions with @edrumwri and @jwnimmer-tri

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10721)
<!-- Reviewable:end -->
