### PR TITLE
py math: Add RollPitchYaw(matrix) constructor

### DIFF
--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -144,6 +144,12 @@ PYBIND11_MODULE(math, m) {
           doc.RollPitchYaw.ctor.doc_1args_R)
       .def(py::init<const Eigen::Quaternion<T>&>(), py::arg("quaternion"),
           doc.RollPitchYaw.ctor.doc_1args_quaternion)
+      .def(py::init([](const Matrix3<T>& matrix) {
+        return RollPitchYaw<T>(RotationMatrix<T>(matrix));
+      }),
+          py::arg("matrix"),
+          "Construct from raw rotation matrix. See RotationMatrix overload "
+          "for more information.")
       .def("vector", &RollPitchYaw<T>::vector, doc.RollPitchYaw.vector.doc)
       .def("roll_angle", &RollPitchYaw<T>::roll_angle,
           doc.RollPitchYaw.roll_angle.doc)

--- a/bindings/pydrake/test/math_test.py
+++ b/bindings/pydrake/test/math_test.py
@@ -167,6 +167,8 @@ class TestMath(unittest.TestCase):
             (0, 0, 0))
         rpy = mut.RollPitchYaw(R=mut.RotationMatrix())
         self.assertTrue(np.allclose(rpy.vector(), [0, 0, 0]))
+        rpy = mut.RollPitchYaw(matrix=np.eye(3))
+        self.assertTrue(np.allclose(rpy.vector(), [0, 0, 0]))
         q_I = Quaternion()
         rpy_q_I = mut.RollPitchYaw(quaternion=q_I)
         self.assertTrue(np.allclose(rpy_q_I.vector(), [0, 0, 0]))

--- a/math/test/roll_pitch_yaw_test.cc
+++ b/math/test/roll_pitch_yaw_test.cc
@@ -19,6 +19,11 @@ using Eigen::Matrix3d;
 
 const double kEpsilon = std::numeric_limits<double>::epsilon();
 
+// This data structure is used in symbolic and automotive code. If a `Matrix3`
+// overload is added to the constructors, then it creates an ambiguous overload
+// for types like this one (and things like `Eigen::Ref<>`).
+using Vector3dUnaligned = Eigen::Matrix<double, 3, 1, Eigen::DontAlign>;
+
 // This tests the RollPitchYaw constructors and IsNearlyEqualTo().
 GTEST_TEST(RollPitchYaw, testConstructorsAndIsNearlyEqualTo) {
   const RollPitchYaw<double> a(0.1, 0.2, -0.3);
@@ -28,6 +33,15 @@ GTEST_TEST(RollPitchYaw, testConstructorsAndIsNearlyEqualTo) {
   EXPECT_TRUE(a.IsNearlyEqualTo(c, kEpsilon));
   EXPECT_FALSE(a.IsNearlyEqualTo(b, 0.1 - 10*kEpsilon));
   EXPECT_TRUE(a.IsNearlyEqualTo(b, 0.1 + 10*kEpsilon));
+
+  // Test additional constructors.
+  const RotationMatrix<double> R = a.ToRotationMatrix();
+  const RollPitchYaw<double> d(R);
+  EXPECT_TRUE(a.IsNearlyEqualTo(d, kEpsilon));
+  const RollPitchYaw<double> e(R.ToQuaternion());
+  EXPECT_TRUE(a.IsNearlyEqualTo(e, kEpsilon));
+  const RollPitchYaw<double> f(Vector3dUnaligned(0.1, 0.2, -0.3));
+  EXPECT_TRUE(a.IsNearlyEqualTo(f, kEpsilon));
 }
 
 // Test typedef (using) RollPitchYawd.


### PR DESCRIPTION
math: Ensure all RollPitchYaw constructors are explicitly tested

Found it very hard to add `RollPitchYaw(Matrix3<T>)` due to ambiguity with Eigen type explosions. However, it's still a pain point to me that I have to do stuff like `RollPitchYaw(RotationMatrix(R))` when I'm interfacing with another Python library.

\cc @mitiguy

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10723)
<!-- Reviewable:end -->
