### PR TITLE
Adds the ability to introspect collision candidates

### DIFF
--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -146,6 +146,29 @@ int GeometryState<T>::GetNumAnchoredGeometries() const {
 }
 
 template <typename T>
+std::set<std::pair<GeometryId, GeometryId>>
+GeometryState<T>::GetCollisionCandidates() const {
+  std::set<std::pair<GeometryId, GeometryId>> pairs;
+  for (const auto& pairA : geometries_) {
+    const GeometryId idA = pairA.first;
+    const InternalGeometry& geometryA = pairA.second;
+    if (!geometryA.has_proximity_role()) continue;
+    for (const auto& pairB : geometries_) {
+      const GeometryId idB = pairB.first;
+      if (idB < idA) continue;  // Only consider the pair (A, B) and not (B, A).
+      const InternalGeometry& geometryB = pairB.second;
+      if (!geometryB.has_proximity_role()) continue;
+      // This relies on CollisionFiltered() to handle if A == B, if they
+      // are both anchored, etc.
+      if (!CollisionFiltered(idA, idB)) {
+        pairs.insert({idA, idB});
+      }
+    }
+  }
+  return pairs;
+}
+
+template <typename T>
 bool GeometryState<T>::source_is_registered(SourceId source_id) const {
   return source_frame_id_map_.find(source_id) != source_frame_id_map_.end();
 }

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <set>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -123,6 +124,9 @@ class GeometryState {
 
   /** Implementation of SceneGraphInspector::GetNumAnchoredGeometries().  */
   int GetNumAnchoredGeometries() const;
+
+  /** Implementation of SceneGraphInspector::GetCollisionCandidates().  */
+  std::set<std::pair<GeometryId, GeometryId>> GetCollisionCandidates() const;
 
   //@}
 

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <set>
 #include <string>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "drake/geometry/geometry_roles.h"
@@ -126,6 +128,19 @@ class SceneGraphInspector {
   int GetNumAnchoredGeometries() const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->GetNumAnchoredGeometries();
+  }
+
+  /** Returns all pairs of geometries that are candidates for collision (in no
+   particular order). See SceneGraph::ExcludeCollisionsBetween() or
+   SceneGraph::ExcludeCollisionsWithin() for information on why a particular
+   pair may _not_ be a candidate. For candidate pair (A, B), the candidate is
+   always guaranteed to be reported in a fixed order (i.e., always (A, B) and
+   _never_ (B, A)). This is the same ordering as would be returned by, e.g.,
+   QueryObject::ComputePointPairPenetration().  */
+  std::set<std::pair<GeometryId, GeometryId>> GetCollisionCandidates()
+      const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->GetCollisionCandidates();
   }
 
   //@}

--- a/geometry/test/scene_graph_inspector_test.cc
+++ b/geometry/test/scene_graph_inspector_test.cc
@@ -49,6 +49,7 @@ GTEST_TEST(SceneGraphInspector, ExerciseEverything) {
   inspector.NumGeometriesWithRole(Role::kUnassigned);
   inspector.GetNumDynamicGeometries();
   inspector.GetNumAnchoredGeometries();
+  inspector.GetCollisionCandidates();
 
   // Source and source-related data methods.
   // Register a source to prevent exceptions being thrown.


### PR DESCRIPTION
A collision candidate is a pair of geometry ids which will be considered for collision. I.e., the pair hasn't been excluded because:
  - the pair consists of the same geometry twice,
  - both ids do not refer to anchored geometries
  - both ids do not refer to geometries affixed to the same frame
  - the pair hasn't be explicitly filtered.

The new method returns all of the candidate pairs.

Resolves #10730

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10732)
<!-- Reviewable:end -->
