### PR TITLE
Adds zero-dimensional actuation ports to MultibodyPlant.

### DIFF
--- a/examples/pendulum/print_symbolic_dynamics.cc
+++ b/examples/pendulum/print_symbolic_dynamics.cc
@@ -55,7 +55,8 @@ VectorX<Expression> MultibodyPlantDynamics() {
   // Obtain the symbolic dynamics.
   auto context = symbolic_plant.CreateDefaultContext();
   context->FixInputPort(
-      0, Vector1<Expression>::Constant(Variable("tau")));
+      symbolic_plant.get_actuation_input_port().get_index(),
+      Vector1<Expression>::Constant(Variable("tau")));
   symbolic_plant.SetPositionsAndVelocities(
       context.get(), Vector2<Expression>(
           Variable("theta"), Variable("thetadot")));

--- a/multibody/benchmarks/free_body/BUILD.bazel
+++ b/multibody/benchmarks/free_body/BUILD.bazel
@@ -8,9 +8,7 @@ load(
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
-# Because there are no meaninfully distinct components in this package, the
-# only public target we will offer is our drake_cc_package_library.
-package(default_visibility = ["//visibility:private"])
+package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "models",

--- a/multibody/benchmarks/free_body/BUILD.bazel
+++ b/multibody/benchmarks/free_body/BUILD.bazel
@@ -13,13 +13,13 @@ package(default_visibility = ["//visibility:private"])
 filegroup(
     name = "models",
     testonly = 1,
-    visibility = ["//visibility:public"],
     srcs = glob([
         "**/*.obj",
         "**/*.sdf",
         "**/*.urdf",
         "**/*.xml",
     ]),
+    visibility = ["//visibility:public"],
 )
 
 drake_cc_package_library(

--- a/multibody/benchmarks/free_body/BUILD.bazel
+++ b/multibody/benchmarks/free_body/BUILD.bazel
@@ -8,11 +8,12 @@ load(
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//visibility:private"])
 
 filegroup(
     name = "models",
     testonly = 1,
+    visibility = ["//visibility:public"],
     srcs = glob([
         "**/*.obj",
         "**/*.sdf",

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -193,6 +193,7 @@ drake_cc_googletest(
         "//manipulation/models/iiwa_description:models",
         "//manipulation/models/wsg_50_description:models",
         "//multibody/benchmarks/acrobot:models",
+        "//multibody/benchmarks/free_body:models",
         "//multibody/parsing:test_models",
     ],
     deps = [

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1246,8 +1246,7 @@ VectorX<T> MultibodyPlant<T>::AssembleActuationInput(
     // Ignore the port if the model instance has no actuated DoFs.
     const int instance_num_dofs =
         internal_tree().num_actuated_dofs(model_instance_index);
-    if (instance_num_dofs == 0)
-      continue;
+    if (instance_num_dofs == 0) continue;
 
     const auto& input_port = this->get_input_port(
         instance_actuation_ports_[model_instance_index]);
@@ -1624,8 +1623,7 @@ void MultibodyPlant<T>::DeclareStateCacheAndPorts() {
             .get_index();
   }
 
-  if (num_actuated_instances == 1)
-    actuated_instance_ = last_actuated_instance;
+  if (num_actuated_instances == 1) actuated_instance_ = last_actuated_instance;
 
   // Declare the generalized force input port.
   applied_generalized_force_input_port_ = this->DeclareVectorInputPort(

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1243,22 +1243,12 @@ VectorX<T> MultibodyPlant<T>::AssembleActuationInput(
   int u_offset = 0;
   for (ModelInstanceIndex model_instance_index(0);
        model_instance_index < num_model_instances(); ++model_instance_index) {
+    // Ignore the port if the model instance has no actuated DoFs.
     const int instance_num_dofs =
         internal_tree().num_actuated_dofs(model_instance_index);
-    if (instance_num_dofs == 0) {
-      // Verify that the input port is either unconnected or holds a
-      // zero-dimensional vector.
-      const auto& input_port = this->get_input_port(
-          instance_actuation_ports_[model_instance_index]);
-      if (input_port.HasValue(context) && input_port.Eval(context).size() > 0) {
-        throw std::logic_error(fmt::format("Actuation input port for model "
-            "instance {} must either be unconnected or connected to a "
-            "zero-dimensional vector source.",
-            GetModelInstanceName(model_instance_index)));
-      }
-
+    if (instance_num_dofs == 0)
       continue;
-    }
+
     const auto& input_port = this->get_input_port(
         instance_actuation_ports_[model_instance_index]);
     if (!input_port.HasValue(context)) {

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -2578,8 +2578,7 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   /// a specific model instance.  This input port is a vector valued port, which
   /// can be set with JointActuator::set_actuation_vector().
   /// @pre Finalize() was already called on `this` plant.
-  /// @throws std::exception if called before Finalize() or if the model
-  /// instance does not contain any actuators.
+  /// @throws std::exception if called before Finalize().
   /// @throws std::exception if the model instance does not exist.
   const systems::InputPort<T>& get_actuation_input_port(
       ModelInstanceIndex model_instance) const;
@@ -3381,8 +3380,7 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
 
   // Input/Output port indexes:
   // A vector containing actuation ports for each model instance indexed by
-  // ModelInstanceIndex.  An invalid value indicates that the model instance has
-  // no actuated dofs.
+  // ModelInstanceIndex.
   std::vector<systems::InputPortIndex> instance_actuation_ports_;
 
   // If only one model instance has actuated dofs, remember it here.  If

--- a/multibody/plant/test/joint_limits_test.cc
+++ b/multibody/plant/test/joint_limits_test.cc
@@ -85,7 +85,9 @@ GTEST_TEST(JointLimitsTest, PrismaticJointConvergenceTest) {
 
     Simulator<double> simulator(plant);
     Context<double>& context = simulator.get_mutable_context();
-    context.FixInputPort(0, Vector1<double>::Constant(-10.0));
+    context.FixInputPort(
+      plant.get_actuation_input_port().get_index(),
+      Vector1<double>::Constant(-10.0));
     simulator.Initialize();
     simulator.StepTo(simulation_time);
 
@@ -101,7 +103,9 @@ GTEST_TEST(JointLimitsTest, PrismaticJointConvergenceTest) {
     EXPECT_NEAR(slider.get_translation_rate(context), 0.0, kVelocityTolerance);
 
     // Set the force to be positive and re-start the simulation.
-    context.FixInputPort(0, Vector1<double>::Constant(10.0));
+    context.FixInputPort(
+      plant.get_actuation_input_port().get_index(),
+      Vector1<double>::Constant(10.0));
     context.set_time(0.0);
     simulator.StepTo(simulation_time);
 
@@ -157,7 +161,9 @@ GTEST_TEST(JointLimitsTest, RevoluteJoint) {
 
     Simulator<double> simulator(plant);
     Context<double>& context = simulator.get_mutable_context();
-    context.FixInputPort(0, Vector1<double>::Constant(1.5));
+    context.FixInputPort(
+      plant.get_actuation_input_port().get_index(),
+      Vector1<double>::Constant(1.5));
     simulator.Initialize();
     simulator.StepTo(simulation_time);
 
@@ -173,7 +179,9 @@ GTEST_TEST(JointLimitsTest, RevoluteJoint) {
     EXPECT_NEAR(pin.get_angular_rate(context), 0.0, kVelocityTolerance);
 
     // Set the torque to be negative and re-start the simulation.
-    context.FixInputPort(0, Vector1<double>::Constant(-1.5));
+    context.FixInputPort(
+      plant.get_actuation_input_port().get_index(),
+      Vector1<double>::Constant(-1.5));
     context.set_time(0.0);
     simulator.StepTo(simulation_time);
 
@@ -254,7 +262,9 @@ GTEST_TEST(JointLimitsTest, KukaArm) {
   Context<double>& context = simulator.get_mutable_context();
 
   // Drive all the joints to their upper limit by applying a positive torque.
-  context.FixInputPort(0, VectorX<double>::Constant(nq, 0.4));
+  context.FixInputPort(
+    plant.get_actuation_input_port().get_index(),
+    VectorX<double>::Constant(nq, 0.4));
   simulator.Initialize();
   simulator.StepTo(simulation_time);
 
@@ -269,7 +279,9 @@ GTEST_TEST(JointLimitsTest, KukaArm) {
   }
 
   // Drive all the joints to their lower limit by applying a negative torque.
-  context.FixInputPort(0, VectorX<double>::Constant(nq, -0.4));
+  context.FixInputPort(
+    plant.get_actuation_input_port().get_index(),
+    VectorX<double>::Constant(nq, -0.4));
   plant.SetDefaultContext(&context);
   context.set_time(0.0);
   simulator.StepTo(simulation_time);

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -318,6 +318,10 @@ GTEST_TEST(ActuationPortsTest, CheckActuation) {
   auto cylinder_instance = Parser(&plant).AddModelFromFile(cylinder_path);
   plant.Finalize();
 
+  // Verify the number of actuators.
+  EXPECT_EQ(plant.num_actuated_dofs(acrobot_instance), 1);
+  EXPECT_EQ(plant.num_actuated_dofs(cylinder_instance), 0);
+
   // Verify that we can get the actuation input ports.
   EXPECT_NO_THROW(plant.get_actuation_input_port());
   EXPECT_NO_THROW(plant.get_actuation_input_port(acrobot_instance));

--- a/systems/controllers/linear_quadratic_regulator.cc
+++ b/systems/controllers/linear_quadratic_regulator.cc
@@ -128,7 +128,7 @@ std::unique_ptr<systems::AffineSystem<double>> LinearQuadraticRegulator(
           ? context.get_continuous_state_vector().CopyToVector()
           : context.get_discrete_state(0).CopyToVector();
 
-  const auto& u0 = system.get_input_port(0).Eval(context);
+  const auto& u0 = system.get_input_port(input_port_index).Eval(context);
 
   // Return the affine controller: u = u0 - K(x-x0).
   return std::make_unique<systems::AffineSystem<double>>(

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -2150,7 +2150,8 @@ class System : public SystemBase {
   std::function<void(const AbstractValue&)> MakeFixInputPortTypeChecker(
       InputPortIndex port_index) const final {
     const InputPort<T>& port = this->get_input_port(port_index);
-    const std::string pathname = this->GetSystemPathname();
+    const std::string& port_name = port.get_name();
+    const std::string path_name = this->GetSystemPathname();
 
     // Note that our lambdas below will capture all necessary items by-value,
     // so that they do not rely on this System still being alive.  (We do not
@@ -2166,11 +2167,11 @@ class System : public SystemBase {
         // fine to let them also handle detailed error reporting on their own.
         const std::type_info& expected_type =
             this->AllocateInputAbstract(port)->static_type_info();
-        return [&expected_type, port_index, pathname](
+        return [&expected_type, port_index, path_name, port_name](
             const AbstractValue& actual) {
           if (actual.static_type_info() != expected_type) {
             SystemBase::ThrowInputPortHasWrongType(
-                "FixInputPortTypeCheck", pathname, port_index,
+                "FixInputPortTypeCheck", path_name, port_index, port_name,
                 NiceTypeName::Get(expected_type),
                 NiceTypeName::Get(actual.type_info()));
           }
@@ -2182,20 +2183,20 @@ class System : public SystemBase {
         const std::unique_ptr<BasicVector<T>> model_vector =
             this->AllocateInputVector(port);
         const int expected_size = model_vector->size();
-        return [expected_size, port_index, pathname](
+        return [expected_size, port_index, path_name, port_name](
             const AbstractValue& actual) {
           const BasicVector<T>* const actual_vector =
               actual.MaybeGetValue<BasicVector<T>>();
           if (actual_vector == nullptr) {
             SystemBase::ThrowInputPortHasWrongType(
-                "FixInputPortTypeCheck", pathname, port_index,
+                "FixInputPortTypeCheck", path_name, port_index, port_name,
                 NiceTypeName::Get<Value<BasicVector<T>>>(),
                 NiceTypeName::Get(actual));
           }
           // Check that vector sizes match.
           if (actual_vector->size() != expected_size) {
             SystemBase::ThrowInputPortHasWrongType(
-                "FixInputPortTypeCheck", pathname, port_index,
+                "FixInputPortTypeCheck", path_name, port_index, port_name,
                 fmt::format("{} with size={}",
                             NiceTypeName::Get<BasicVector<T>>(),
                             expected_size),

--- a/systems/framework/system_base.cc
+++ b/systems/framework/system_base.cc
@@ -195,7 +195,7 @@ void SystemBase::ThrowNegativePortIndex(const char* func,
 void SystemBase::ThrowInputPortIndexOutOfRange(const char* func,
                                                InputPortIndex port) const {
   throw std::out_of_range(fmt::format(
-      "{}: there is no input port {} because there "
+      "{}: there is no input port with index {} because there "
       "are only {} input ports in system {}.",
       FmtFunc(func),  port, get_num_input_ports(), GetSystemPathname()));
 }
@@ -203,9 +203,9 @@ void SystemBase::ThrowInputPortIndexOutOfRange(const char* func,
 void SystemBase::ThrowOutputPortIndexOutOfRange(const char* func,
                                                 OutputPortIndex port) const {
   throw std::out_of_range(fmt::format(
-      "{}: there is no output port {} because there "
+      "{}: there is no output port with index {} because there "
       "are only {} output ports in system {}.",
-      FmtFunc(func),  port,
+      FmtFunc(func), port,
       get_num_output_ports(), GetSystemPathname()));
 }
 

--- a/systems/framework/system_base.cc
+++ b/systems/framework/system_base.cc
@@ -195,51 +195,57 @@ void SystemBase::ThrowNegativePortIndex(const char* func,
 void SystemBase::ThrowInputPortIndexOutOfRange(const char* func,
                                                InputPortIndex port) const {
   throw std::out_of_range(fmt::format(
-      "{}: there is no input port with index {} because there "
+      "{}: there is no input port {} because there "
       "are only {} input ports in system {}.",
-      FmtFunc(func), port, get_num_input_ports(), GetSystemPathname()));
+      FmtFunc(func),  port, get_num_input_ports(), GetSystemPathname()));
 }
 
 void SystemBase::ThrowOutputPortIndexOutOfRange(const char* func,
                                                 OutputPortIndex port) const {
   throw std::out_of_range(fmt::format(
-      "{}: there is no output port with index {} because there "
+      "{}: there is no output port {} because there "
       "are only {} output ports in system {}.",
-      FmtFunc(func), port, get_num_output_ports(), GetSystemPathname()));
+      FmtFunc(func),  port,
+      get_num_output_ports(), GetSystemPathname()));
 }
 
 void SystemBase::ThrowNotAVectorInputPort(const char* func,
                                           InputPortIndex port) const {
   throw std::logic_error(fmt::format(
-      "{}: vector port required, but input port[{}] was declared abstract. "
-          "Even if the actual value is a vector, use EvalInputValue<V> "
-          "instead for an abstract port containing a vector of type V. "
-          "(System {})",
-      FmtFunc(func), port, GetSystemPathname()));
+      "{}: vector port required, but input port {} (index {}) was declared "
+          "abstract. Even if the actual value is a vector, use "
+          "EvalInputValue<V> instead for an abstract port containing a vector "
+          "of type V. (System {})",
+      FmtFunc(func),  get_input_port_base(port).get_name(), port,
+      GetSystemPathname()));
 }
 
 void SystemBase::ThrowInputPortHasWrongType(
     const char* func, InputPortIndex port, const std::string& expected_type,
     const std::string& actual_type) const {
   ThrowInputPortHasWrongType(
-      func, GetSystemPathname(), port, expected_type, actual_type);
+      func, GetSystemPathname(), port, get_input_port_base(port).get_name(),
+      expected_type, actual_type);
 }
 
 void SystemBase::ThrowInputPortHasWrongType(
     const char* func, const std::string& system_pathname, InputPortIndex port,
-    const std::string& expected_type, const std::string& actual_type) {
+    const std::string& port_name, const std::string& expected_type,
+    const std::string& actual_type) {
   throw std::logic_error(fmt::format(
-      "{}: expected value of type {} for input port[{}] "
+      "{}: expected value of type {} for input port {} (index {}) "
           "but the actual type was {}. (System {})",
-      FmtFunc(func), expected_type, port, actual_type, system_pathname));
+      FmtFunc(func), expected_type, port_name, port, actual_type,
+      system_pathname));
 }
 
 void SystemBase::ThrowCantEvaluateInputPort(const char* func,
                                             InputPortIndex port) const {
   throw std::logic_error(
-      fmt::format("{}: input port[{}] is neither connected nor fixed so "
-                      "cannot be evaluated. (System {})",
-                  FmtFunc(func), port, GetSystemPathname()));
+      fmt::format("{}: input port {} (index {}) is neither connected nor fixed "
+                      "so cannot be evaluated. (System {})",
+                  FmtFunc(func), get_input_port_base(port).get_name(), port,
+                  GetSystemPathname()));
 }
 
 }  // namespace systems

--- a/systems/framework/system_base.cc
+++ b/systems/framework/system_base.cc
@@ -212,7 +212,7 @@ void SystemBase::ThrowOutputPortIndexOutOfRange(const char* func,
 void SystemBase::ThrowNotAVectorInputPort(const char* func,
                                           InputPortIndex port) const {
   throw std::logic_error(fmt::format(
-      "{}: vector port required, but input port {} (index {}) was declared "
+      "{}: vector port required, but input port '{}' (index {}) was declared "
           "abstract. Even if the actual value is a vector, use "
           "EvalInputValue<V> instead for an abstract port containing a vector "
           "of type V. (System {})",
@@ -233,7 +233,7 @@ void SystemBase::ThrowInputPortHasWrongType(
     const std::string& port_name, const std::string& expected_type,
     const std::string& actual_type) {
   throw std::logic_error(fmt::format(
-      "{}: expected value of type {} for input port {} (index {}) "
+      "{}: expected value of type {} for input port '{}' (index {}) "
           "but the actual type was {}. (System {})",
       FmtFunc(func), expected_type, port_name, port, actual_type,
       system_pathname));
@@ -242,8 +242,8 @@ void SystemBase::ThrowInputPortHasWrongType(
 void SystemBase::ThrowCantEvaluateInputPort(const char* func,
                                             InputPortIndex port) const {
   throw std::logic_error(
-      fmt::format("{}: input port {} (index {}) is neither connected nor fixed "
-                      "so cannot be evaluated. (System {})",
+      fmt::format("{}: input port '{}' (index {}) is neither connected nor "
+                      "fixed so cannot be evaluated. (System {})",
                   FmtFunc(func), get_input_port_base(port).get_name(), port,
                   GetSystemPathname()));
 }

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -962,7 +962,8 @@ class SystemBase : public internal::SystemMessageInterface {
   the input port had some value type that was wrong. */
   [[noreturn]] static void ThrowInputPortHasWrongType(
       const char* func, const std::string& system_pathname, InputPortIndex,
-      const std::string& expected_type, const std::string& actual_type);
+      const std::string& port_name, const std::string& expected_type,
+      const std::string& actual_type);
 
   /** Throws std::logic_error because someone called API method `func`, that
   requires this input port to be evaluatable, but the port was neither

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -1052,7 +1052,7 @@ GTEST_TEST(ModelLeafSystemTest, ModelInputGovernsFixedInput) {
       std::exception,
       "System::FixInputPortTypeCheck\\(\\): expected value of type "
       "drake::systems::BasicVector<double> with size=1 "
-      "for input port input \\(index 0\\) but the actual type was "
+      "for input port 'input' \\(index 0\\) but the actual type was "
       "drake::systems::BasicVector<double> with size=2. "
       "\\(System ::dut\\)");
   DRAKE_EXPECT_THROWS_MESSAGE(
@@ -1060,7 +1060,7 @@ GTEST_TEST(ModelLeafSystemTest, ModelInputGovernsFixedInput) {
       std::exception,
       "System::FixInputPortTypeCheck\\(\\): expected value of type "
       "drake::Value<drake::systems::BasicVector<double>> "
-      "for input port input \\(index 0\\) but the actual type was "
+      "for input port 'input' \\(index 0\\) but the actual type was "
       "drake::Value<std::string>. "
       "\\(System ::dut\\)");
 
@@ -1071,7 +1071,7 @@ GTEST_TEST(ModelLeafSystemTest, ModelInputGovernsFixedInput) {
       std::exception,
       "System::FixInputPortTypeCheck\\(\\): expected value of type "
       "int "
-      "for input port abstract_input \\(index 2\\) but the actual type was "
+      "for input port 'abstract_input' \\(index 2\\) but the actual type was "
       "std::string. "
       "\\(System ::dut\\)");
 }

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -1052,7 +1052,7 @@ GTEST_TEST(ModelLeafSystemTest, ModelInputGovernsFixedInput) {
       std::exception,
       "System::FixInputPortTypeCheck\\(\\): expected value of type "
       "drake::systems::BasicVector<double> with size=1 "
-      "for input port .* \\(index 0\\) but the actual type was "
+      "for input port input \\(index 0\\) but the actual type was "
       "drake::systems::BasicVector<double> with size=2. "
       "\\(System ::dut\\)");
   DRAKE_EXPECT_THROWS_MESSAGE(
@@ -1060,7 +1060,7 @@ GTEST_TEST(ModelLeafSystemTest, ModelInputGovernsFixedInput) {
       std::exception,
       "System::FixInputPortTypeCheck\\(\\): expected value of type "
       "drake::Value<drake::systems::BasicVector<double>> "
-      "for input port .* \\(index 0\\) but the actual type was "
+      "for input port input \\(index 0\\) but the actual type was "
       "drake::Value<std::string>. "
       "\\(System ::dut\\)");
 
@@ -1071,7 +1071,7 @@ GTEST_TEST(ModelLeafSystemTest, ModelInputGovernsFixedInput) {
       std::exception,
       "System::FixInputPortTypeCheck\\(\\): expected value of type "
       "int "
-      "for input port .* \\(index 2\\) but the actual type was "
+      "for input port abstract_input \\(index 2\\) but the actual type was "
       "std::string. "
       "\\(System ::dut\\)");
 }

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -1052,7 +1052,7 @@ GTEST_TEST(ModelLeafSystemTest, ModelInputGovernsFixedInput) {
       std::exception,
       "System::FixInputPortTypeCheck\\(\\): expected value of type "
       "drake::systems::BasicVector<double> with size=1 "
-      "for input port\\[0\\] but the actual type was "
+      "for input port .* \\(index 0\\) but the actual type was "
       "drake::systems::BasicVector<double> with size=2. "
       "\\(System ::dut\\)");
   DRAKE_EXPECT_THROWS_MESSAGE(
@@ -1060,7 +1060,7 @@ GTEST_TEST(ModelLeafSystemTest, ModelInputGovernsFixedInput) {
       std::exception,
       "System::FixInputPortTypeCheck\\(\\): expected value of type "
       "drake::Value<drake::systems::BasicVector<double>> "
-      "for input port\\[0\\] but the actual type was "
+      "for input port .* \\(index 0\\) but the actual type was "
       "drake::Value<std::string>. "
       "\\(System ::dut\\)");
 
@@ -1071,7 +1071,7 @@ GTEST_TEST(ModelLeafSystemTest, ModelInputGovernsFixedInput) {
       std::exception,
       "System::FixInputPortTypeCheck\\(\\): expected value of type "
       "int "
-      "for input port\\[2\\] but the actual type was "
+      "for input port .* \\(index 2\\) but the actual type was "
       "std::string. "
       "\\(System ::dut\\)");
 }

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -688,8 +688,8 @@ TEST_F(SystemInputErrorTest, CheckMessages) {
 
   DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(
       system_.EvalEigenVectorInput(*context_, 1), std::logic_error,
-      ".*EvalEigenVectorInput.*input port u1 .*index 1.* is neither connected "
-      "nor fixed.*");
+      ".*EvalEigenVectorInput.*input port 'u1' .*index 1.* is neither "
+      "connected nor fixed.*");
 
   // Assign values to all ports. All but port 0 are BasicVector ports.
   system_.AllocateFixedInputs(context_.get());

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -688,8 +688,8 @@ TEST_F(SystemInputErrorTest, CheckMessages) {
 
   DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(
       system_.EvalEigenVectorInput(*context_, 1), std::logic_error,
-      ".*EvalEigenVectorInput.*input port\\[1\\].*neither connected nor "
-          "fixed.*");
+      ".*EvalEigenVectorInput.*input port u1 .*index 1.* is neither connected "
+      "nor fixed.*");
 
   // Assign values to all ports. All but port 0 are BasicVector ports.
   system_.AllocateFixedInputs(context_.get());

--- a/systems/primitives/linear_system.cc
+++ b/systems/primitives/linear_system.cc
@@ -176,14 +176,18 @@ std::unique_ptr<AffineSystem<double>> DoFirstOrderTaylorApproximation(
       continue;
     }
 
-    // Must be a vector valued port. First look to see whether it's connected.
-    if (!input_port_i.HasValue(context)) {
-      throw std::logic_error(fmt::format(
-          "Vector-valued input port {} must be either fixed or connected to "
-          "the output of another system.", input_port_i.get_name()));
+    // Must be a vector valued port. First look to see whether it's connected
+    // or zero-dimensional.
+    if (input_port_i.size() > 0) {
+      if (!input_port_i.HasValue(context)) {
+        throw std::logic_error(fmt::format(
+            "Vector-valued input port {} must be either fixed or connected to "
+            "the output of another system.", input_port_i.get_name()));
+      }
+
+      Eigen::VectorBlock<const VectorX<double>> u = input_port_i.Eval(context);
+      autodiff_context->FixInputPort(i, u.cast<AutoDiffXd>());
     }
-    Eigen::VectorBlock<const VectorX<double>> u = input_port_i.Eval(context);
-    autodiff_context->FixInputPort(i, u.cast<AutoDiffXd>());
   }
 
   Eigen::VectorXd u0 = Eigen::VectorXd::Zero(num_inputs);

--- a/systems/primitives/test/linear_system_test.cc
+++ b/systems/primitives/test/linear_system_test.cc
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/eigen_types.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/examples/pendulum/pendulum_plant.h"
@@ -12,10 +13,49 @@
 
 using std::make_unique;
 using std::unique_ptr;
+using MatrixXd = drake::MatrixX<double>;
 
 namespace drake {
 namespace systems {
 namespace {
+
+class LinearSystemPlusEmptyVectorPort : public LinearSystem<double> {
+ public:
+  LinearSystemPlusEmptyVectorPort(
+        const Eigen::Ref<const Eigen::MatrixXd>& A,
+        const Eigen::Ref<const Eigen::MatrixXd>& B,
+        const Eigen::Ref<const Eigen::MatrixXd>& C,
+        const Eigen::Ref<const Eigen::MatrixXd>& D) : LinearSystem(A, B, C, D) {
+    this->DeclareInputPort(kVectorValued, 0);
+  }
+};
+
+GTEST_TEST(LinearSystemTestWithEmptyPort, EmptyPort) {
+  // Set linear system matrices as simply as possible while using a non-empty
+  // vector input.
+  const int num_states = 1;
+  const int num_inputs = 1;
+  MatrixXd B(num_states, num_inputs);
+  B << 0;
+  const MatrixXd A = B;
+  const MatrixXd C = B;
+  const MatrixXd D = B;
+  LinearSystemPlusEmptyVectorPort dut(A, B, C, D);
+
+  // Get the system as a System<double>.
+  auto& system = dynamic_cast<System<double>&>(dut);
+
+  // Verify that the first two vector input ports have expected sizes.
+  ASSERT_EQ(system.get_input_port(0).size(), num_inputs);
+  ASSERT_EQ(system.get_input_port(1).size(), 0);
+
+  // Verify that computing derivatives does not cause an exception to be thrown
+  // when the empty vector port is unconnected.
+  auto context = dut.CreateDefaultContext();
+  auto derivatives = dut.AllocateTimeDerivatives();
+  context->FixInputPort(0, Vector1d(0));
+  EXPECT_NO_THROW(dut.CalcTimeDerivatives(*context, derivatives.get()));
+}
 
 class LinearSystemTest : public AffineLinearSystemTest {
  public:

--- a/systems/primitives/test/linear_system_test.cc
+++ b/systems/primitives/test/linear_system_test.cc
@@ -42,8 +42,11 @@ GTEST_TEST(LinearSystemTestWithEmptyPort, EmptyPort) {
   const MatrixXd D = B;
   LinearSystemPlusEmptyVectorPort dut(A, B, C, D);
 
-  // Get the system as a System<double>.
-  auto& system = dynamic_cast<System<double>&>(dut);
+  // Get the system as a System<double>. This is necessary because the
+  // grandparent (TimeVaryingAffineSystem) shadows System::get_input_port(int)
+  // with TimeVaryingAffineSystem::get_input_port(), which makes the former
+  // inaccessible.
+  System<double>& system = dut;
 
   // Verify that the first two vector input ports have expected sizes.
   ASSERT_EQ(system.get_input_port(0).size(), num_inputs);


### PR DESCRIPTION
Resolves #10694 

Also:
- improves error messages to include port names on input port exceptions
- cleans up a few unit tests that used hard coded input port indices for FixInputPort(.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10738)
<!-- Reviewable:end -->
