### PR TITLE
workspace: Bump ccd to latest upstream commit

### DIFF
--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -770,64 +770,72 @@ bool SingleCollisionCallback(fcl::CollisionObjectd* fcl_object_A_ptr,
   const bool can_collide = collision_data.collision_filter.CanCollideWith(
       encoding_A.encoded_data(), encoding_B.encoded_data());
 
-  if (can_collide) {
-    // Unpack the callback data
-    const fcl::CollisionRequestd& request = collision_data.request;
+  // NOTE: Here and below, false is returned regardless of whether collision
+  // is detected or not because true tells the broadphase manager to terminate.
+  // Since we want *all* collisions, we return false.
+  if (!can_collide) return false;
 
-    // This callback only works for a single contact, this confirms a request
-    // hasn't been made for more contacts.
-    DRAKE_ASSERT(request.num_max_contacts == 1);
-    fcl::CollisionResultd result;
+  // Unpack the callback data
+  const fcl::CollisionRequestd& request = collision_data.request;
 
-    // Perform nearphase collision detection
-    fcl::collide(&fcl_object_A, &fcl_object_B, request, result);
+  // This callback only works for a single contact, this confirms a request
+  // hasn't been made for more contacts.
+  DRAKE_ASSERT(request.num_max_contacts == 1);
+  fcl::CollisionResultd result;
 
-    // Process the contact points
-    if (result.isCollision()) {
-      // NOTE: This assumes that the request is configured to use a single
-      // contact.
-      const fcl::Contactd& contact = result.getContact(0);
-      //  By convention, Drake requires the contact normal to point out of B and
-      //  into A. FCL uses the opposite convention.
-      Vector3d drake_normal = -contact.normal;
+  // Perform nearphase collision detection
+  fcl::collide(&fcl_object_A, &fcl_object_B, request, result);
 
-      // Signed distance is negative when penetration depth is positive.
-      double depth = contact.penetration_depth;
+  if (!result.isCollision()) return false;
 
-      // FCL returns a single contact point centered between the two penetrating
-      // surfaces. PenetrationAsPointPair expects
-      // two, one on the surface of body A (Ac) and one on the surface of body B
-      // (Bc). Choose points along the line defined by the contact point and
-      // normal, equidistant to the contact point. Recall that signed_distance
-      // is strictly non-positive, so signed_distance * drake_normal points out
-      // of A and into B.
-      Vector3d p_WAc = contact.pos - 0.5 * depth * drake_normal;
-      Vector3d p_WBc = contact.pos + 0.5 * depth * drake_normal;
+  // Process the contact points
+  // NOTE: This assumes that the request is configured to use a single
+  // contact.
+  const fcl::Contactd& contact = result.getContact(0);
 
-      PenetrationAsPointPair<double> penetration;
-      penetration.depth = depth;
-      // The engine doesn't know geometry ids; it returns engine indices. The
-      // caller must map engine indices to geometry ids.
-      const std::vector<GeometryId>& geometry_map = collision_data.geometry_map;
-      penetration.id_A = encoding_A.id(geometry_map);
-      penetration.id_B = encoding_B.id(geometry_map);
-      penetration.p_WCa = p_WAc;
-      penetration.p_WCb = p_WBc;
-      penetration.nhat_BA_W = drake_normal;
-      // Guarantee fixed ordering of pair (A, B). Swap the ids and points on
-      // surfaces and then flip the normal.
-      if (penetration.id_B < penetration.id_A) {
-        std::swap(penetration.id_A, penetration.id_B);
-        std::swap(penetration.p_WCa, penetration.p_WCb);
-        penetration.nhat_BA_W = -penetration.nhat_BA_W;
-      }
-      collision_data.contacts->emplace_back(std::move(penetration));
-    }
+  // Signed distance is negative when penetration depth is positive.
+  const double depth = contact.penetration_depth;
+
+  // TODO(SeanCurtis-TRI): Remove this test when FCL issue 375 is fixed.
+  // FCL returns osculation as contact but doesn't guarantee a non-zero
+  // normal. Drake isn't really in a position to define that normal from the
+  // geometry or contact results so, if the geometry is sufficiently close
+  // to osculation, we consider the geometries to be non-penetrating.
+  if (depth <= std::numeric_limits<double>::epsilon()) return false;
+
+  // By convention, Drake requires the contact normal to point out of B
+  // and into A. FCL uses the opposite convention.
+  Vector3d drake_normal = -contact.normal;
+
+  // FCL returns a single contact point centered between the two
+  // penetrating surfaces. PenetrationAsPointPair expects
+  // two, one on the surface of body A (Ac) and one on the surface of body
+  // B (Bc). Choose points along the line defined by the contact point and
+  // normal, equidistant to the contact point. Recall that signed_distance
+  // is strictly non-positive, so signed_distance * drake_normal points
+  // out of A and into B.
+  Vector3d p_WAc = contact.pos - 0.5 * depth * drake_normal;
+  Vector3d p_WBc = contact.pos + 0.5 * depth * drake_normal;
+
+  PenetrationAsPointPair<double> penetration;
+  penetration.depth = depth;
+  // The engine doesn't know geometry ids; it returns engine indices. The
+  // caller must map engine indices to geometry ids.
+  const std::vector<GeometryId>& geometry_map = collision_data.geometry_map;
+  penetration.id_A = encoding_A.id(geometry_map);
+  penetration.id_B = encoding_B.id(geometry_map);
+  penetration.p_WCa = p_WAc;
+  penetration.p_WCb = p_WBc;
+  penetration.nhat_BA_W = drake_normal;
+  // Guarantee fixed ordering of pair (A, B). Swap the ids and points on
+  // surfaces and then flip the normal.
+  if (penetration.id_B < penetration.id_A) {
+    std::swap(penetration.id_A, penetration.id_B);
+    std::swap(penetration.p_WCa, penetration.p_WCb);
+    penetration.nhat_BA_W = -penetration.nhat_BA_W;
   }
+  collision_data.contacts->emplace_back(std::move(penetration));
 
-  // Returning true would tell the broadphase manager to terminate early. Since
-  // we want to find all the collisions present in the model's current
-  // configuration, we return false.
   return false;
 }
 

--- a/geometry/proximity_engine.h
+++ b/geometry/proximity_engine.h
@@ -208,12 +208,20 @@ class ProximityEngine {
   //@{
 
   // NOTE: This maps to Model::ComputeMaximumDepthCollisionPoints().
+  // The definition that touching is not penetrating is due to an FCL issue
+  // described in https://github.com/flexible-collision-library/fcl/issues/375
+  // and drake issue #10577. Once that is resolved, this definition can be
+  // revisited (and ProximityEngineTest::Issue10577Regression_Osculation can
+  // be updated).
   /** Computes the penetrations across all pairs of geometries in the world.
    Only reports results for _penetrating_ geometries; if two geometries are
-   separated, there will be no result for that pair.
+   not penetrating, there will be no result for that pair. Geometries whose
+   surfaces are just touching (osculating) are not considered in penetration.
+   Surfaces whose penetration is within an epsilon of osculation, are likewise
+   not considered penetrating.
 
    The penetrations are characterized by pairs of points (providing some measure
-   of the penetration "depth" of the two objects -- but _not_ the overlapping
+   of the penetration "depth" of the two objects), but _not_ the overlapping
    volume.
 
    This method is affected by collision filtering; geometry pairs that

--- a/tools/workspace/ccd/repository.bzl
+++ b/tools/workspace/ccd/repository.bzl
@@ -8,8 +8,8 @@ def ccd_repository(
     github_archive(
         name = name,
         repository = "danfis/libccd",
-        commit = "63d3a911f016465a2ecf169d0c8bff8b601f1715",
-        sha256 = "1032cae04202330c5bcc9a652d75bef64669656bf4ea6cab74c5ff11c3f7a301",  # noqa
+        commit = "7931e764a19ef6b21b443376c699bbc9c6d4fba8",
+        sha256 = "479994a86d32e2effcaad64204142000ee6b6b291fd1859ac6710aee8d00a482",  # noqa
         build_file = "@drake//tools/workspace/ccd:package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
This includes modifications to `ProximityEngine::ComputePointPairPenetration()`. CCD modified FCL's behavior which left Drake in a bad place. This modification protects Drake from this flaw until FCL is fixed (see fcl issue [#375](https://github.com/flexible-collision-library/fcl/issues/375)).

This replaces PR #10578 and resolves #10577.

For reviewers:
  - The change in proximity_engine.cc is mostly just the inclusion of the tested on line 807 (and the preceding documentation). Everything just got indented.
  - `proximity_engine.h` - a documentation change, clarifying what "penetration" means.
  - `proximity_engine_test.cc` - the test for the instigating failure condition and the current patch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10740)
<!-- Reviewable:end -->
