### PR TITLE
Solve(prog) uses the initial guess stored in prog.

### DIFF
--- a/solvers/solve.cc
+++ b/solvers/solve.cc
@@ -25,7 +25,7 @@ MathematicalProgramResult Solve(
 }
 
 MathematicalProgramResult Solve(const MathematicalProgram& prog) {
-  return Solve(prog, {}, {});
+  return Solve(prog, prog.initial_guess(), {});
 }
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/solve.h
+++ b/solvers/solve.h
@@ -21,12 +21,18 @@ MathematicalProgramResult Solve(const MathematicalProgram& prog,
                                 const optional<SolverOptions>& solver_options);
 
 /**
- * Solves an optimization program with a given initial guess.
+ * Solves an optimization program with a given initial guess, and the options
+ * stored inside @p prog.
  */
 MathematicalProgramResult Solve(
     const MathematicalProgram& prog,
     const Eigen::Ref<const Eigen::VectorXd>& initial_guess);
 
+/**
+ * Solves an optimization program with the initial guess and options stored in
+ * @p prog. The initial guess can be accessed through prog.initial_guess(), and
+ * the options can be accessed through prog.GetSolverOptionsDouble/Int/Str().
+ */
 MathematicalProgramResult Solve(const MathematicalProgram& prog);
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/solve_test.cc
+++ b/solvers/test/solve_test.cc
@@ -47,6 +47,17 @@ GTEST_TEST(SolveTest, TestInitialGuessAndOptions) {
     x_expected(0) = 1;
     MathematicalProgramResult result = Solve(prog, x_expected, solver_options);
     EXPECT_TRUE(CompareMatrices(result.GetSolution(x), x_expected, 1E-6));
+
+    // Test Solve(prog). It should use the initial guess and options set in
+    // @p prog.
+    for (double x_val : {0, 1}) {
+      prog.SetSolverOption(GurobiSolver::id(), "Presolve", 0);
+      prog.SetSolverOption(GurobiSolver::id(), "Heuristics", 0.0);
+      x_expected(0) = x_val;
+      prog.SetInitialGuess(x, x_expected);
+      result = Solve(prog);
+      EXPECT_TRUE(CompareMatrices(result.GetSolution(x), x_expected, 1E-6));
+    }
   }
 }
 


### PR DESCRIPTION
It would be confusing to ask the user to set the initial guess through `prog.SetInitialGuess()`, but not using this initial guess in `Solve(prog)` method.

This problem was exposed by Russ's PR https://github.com/russtedrake/underactuated/pull/166

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10746)
<!-- Reviewable:end -->
