### PR TITLE
Add automatic png texture overrides to MeshcatVisualizer

### DIFF
--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -398,6 +398,7 @@ drake_py_unittest(
         "//examples/kuka_iiwa_arm:models",
         "//examples/multibody/cart_pole:models",
         "//manipulation/models/iiwa_description:models",
+        "//systems/sensors:test_models",
     ],
     deps = [
         ":analysis_py",

--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -248,6 +248,7 @@ filegroup(
     srcs = [
         "test/models/background.jpg",
         "test/models/box.sdf",
+        "test/models/box_with_mesh.sdf",
         "test/models/meshes/box.json",
         "test/models/meshes/box.obj",
         "test/models/meshes/box.png",

--- a/systems/sensors/test/models/box_with_mesh.sdf
+++ b/systems/sensors/test/models/box_with_mesh.sdf
@@ -1,0 +1,35 @@
+<?xml version="1.0" ?>
+<!--
+  This SDF describes a single box with geometry specified by
+  meshes/box.obj. This mesh is a 2x2x2 box centered at the
+  origin.
+  This box is *not* the same size as box.sdf.
+-->
+<sdf version="1.4">
+  <model name="box">
+    <pose>0 0 0.5 0 0 0</pose>
+    <link name="box">
+      <pose>0 0 0 0 0 0</pose>
+        <inertial>
+          <mass>1.</mass>
+          <inertia>
+            <ixx>8.41666666</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>8.41666666</iyy>
+            <iyz>0</iyz>
+            <izz>16.6666666</izz>
+          </inertia>
+        </inertial>
+        <visual name="box">
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <mesh>
+              <uri>meshes/box.obj</uri>
+            </mesh>
+          </geometry>
+        </visual>
+    </link>
+    <static>1</static>
+  </model>
+</sdf>


### PR DESCRIPTION
In cases when the MeshcatVisualizer is loading an `.obj` file with  `.png` file available next to it, tells meshcat to draw the object with that texture. Motivated by @kmuhlrad and the YCB objects, which have nice textures that currently only appear in Director (which does an automatic texture override like the one done here).

![image](https://user-images.githubusercontent.com/3066703/53274352-f4cbd600-36c4-11e9-96bc-fae1591a589b.png)

I'm sticking to just the `png` file here as `mtl`s seem more complex to parse from the meshcat/ThreeJS side (since they require their own ThreeJS loader type and are not supported by meshcat yet).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10749)
<!-- Reviewable:end -->
