### PR TITLE
py mbp: Latent fix for deprecated `multibody_tree` imports

### DIFF
--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -41,7 +41,7 @@ class TestGeometry(unittest.TestCase):
     def test_query_object_api(self):
         # TODO(eric.cousineau): Create self-contained unittests (#9899).
         # Pending that, the relevant API is exercised via
-        # `test_scene_graph_queries` in `multibody_tree_test.py`.
+        # `test_scene_graph_queries` in `plant_test.py`.
         pass
 
     def test_identifier_api(self):

--- a/examples/manipulation_station/end_effector_teleop.py
+++ b/examples/manipulation_station/end_effector_teleop.py
@@ -11,7 +11,7 @@ from pydrake.common import FindResourceOrThrow
 from pydrake.examples.manipulation_station import (
     ManipulationStation, ManipulationStationHardwareInterface)
 from pydrake.geometry import ConnectDrakeVisualizer
-from pydrake.multibody.multibody_tree.multibody_plant import MultibodyPlant
+from pydrake.multibody.plant import MultibodyPlant
 from pydrake.manipulation.simple_ui import SchunkWsgButtons
 from pydrake.manipulation.planner import (
     DifferentialInverseKinematicsParameters, DoDifferentialInverseKinematics)

--- a/manipulation/util/geometry_inspector.py
+++ b/manipulation/util/geometry_inspector.py
@@ -30,9 +30,8 @@ import numpy as np
 
 from pydrake.geometry import ConnectDrakeVisualizer, SceneGraph
 from pydrake.manipulation.simple_ui import JointSliders
-from pydrake.multibody.multibody_tree.multibody_plant import MultibodyPlant
-from pydrake.multibody.parsing import Parser
-from pydrake.multibody.parsing import PackageMap
+from pydrake.multibody.parsing import PackageMap, Parser
+from pydrake.multibody.plant import MultibodyPlant
 from pydrake.systems.analysis import Simulator
 from pydrake.systems.framework import DiagramBuilder
 from pydrake.systems.rendering import MultibodyPositionToGeometryPose

--- a/manipulation/util/show_model.py
+++ b/manipulation/util/show_model.py
@@ -34,8 +34,8 @@ import sys
 
 from pydrake.lcm import DrakeLcm
 from pydrake.geometry import ConnectDrakeVisualizer, SceneGraph
-from pydrake.multibody.multibody_tree.multibody_plant import MultibodyPlant
 from pydrake.multibody.parsing import Parser
+from pydrake.multibody.plant import MultibodyPlant
 from pydrake.systems.analysis import Simulator
 from pydrake.systems.framework import DiagramBuilder
 from pydrake.systems.meshcat_visualizer import MeshcatVisualizer


### PR DESCRIPTION
See comment here: https://github.com/RobotLocomotion/drake/commit/58c5a873413616d83c525f9682430ffc461152a7#commitcomment-32450559

\cc @RussTedrake

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10754)
<!-- Reviewable:end -->
