### PR TITLE
Add FixValue method to InputPort

### DIFF
--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -412,6 +412,7 @@ drake_cc_library(
     deps = [
         ":context",
         ":input_port_base",
+        ":value_to_abstract_value",
         "//common:default_scalars",
         "//common:essential",
     ],

--- a/systems/framework/input_port.h
+++ b/systems/framework/input_port.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -13,6 +14,7 @@
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/framework_common.h"
 #include "drake/systems/framework/input_port_base.h"
+#include "drake/systems/framework/value_to_abstract_value.h"
 
 namespace drake {
 namespace systems {
@@ -96,9 +98,61 @@ class InputPort final : public InputPortBase {
   }
 #endif  // DRAKE_DOXYGEN_CXX
 
-  /** Returns true iff this port is connected.  Beware that at the moment, this
-  could be an expensive operation, because the value is brought up-to-date as
-  part of this operation. */
+  /** Provides a fixed value for this %InputPort in the given Context. If the
+  port is already connected, this value will override the connected source
+  value. (By "connected" we mean that the port appeared in a
+  DiagramBuilder::Connect() call.)
+
+  For vector-valued input ports, you can provide an Eigen vector expression,
+  a BasicVector object, or a scalar (treated as a Vector1). In each of these
+  cases the value is copied into a `Value<BasicVector>`. If the original
+  value was a BasicVector-derived object, its concrete type is maintained
+  although the stored type is still `Value<BasicVector>`. The supplied vector
+  must have the right size for the vector port or an std::logic_error is thrown.
+
+  For abstract-valued input ports, you can provide any ValueType that is
+  compatible with the model type provided when the port was declared. If the
+  type has a copy constructor it will be copied into a `Value<ValueType>`
+  object for storage. Otherwise it must have an accessible `Clone()` method and
+  it is stored using the type returned by that method, which must be ValueType
+  or a base class of ValueType. Eigen expressions are simplified using `.eval()`
+  before being stored as `Value<E>` where E is the type resulting
+  from `.eval()`.
+
+  The returned FixedInputPortValue reference may be used to modify the input
+  port's value subsequently using the appropriate FixedInputPortValue method,
+  which will ensure that cache invalidation notifications are delivered.
+
+  @tparam ValueType The type of the supplied `value` object. This will be
+      inferred so no template argument need be specified. The type must be
+      copy constructible or have an accessible `Clone()` method.
+
+  @param[in,out] context A Context that is compatible with the System that
+                         owns this port.
+  @param[in]     value   The fixed value for this port. Must be convertible
+                         to the input port's data type.
+  @returns a reference to the the FixedInputPortValue object in the Context
+           that contains this port's value.
+
+  @pre `context` is compatible with the System that owns this %InputPort.
+  @pre `value` is compatible with this %InputPort's data type. */
+  template <typename ValueType>
+  FixedInputPortValue& FixValue(Context<T>* context,
+                                const ValueType& value) const {
+    DRAKE_DEMAND(context != nullptr);
+    DRAKE_ASSERT_VOID(get_system_base().ThrowIfContextNotCompatible(*context));
+    const bool is_vector_port = (get_data_type() == kVectorValued);
+    std::unique_ptr<AbstractValue> abstract_value =
+        is_vector_port
+            ? internal::ValueToVectorValue<T>::ToAbstract(__func__, value)
+            : internal::ValueToAbstractValue::ToAbstract(__func__, value);
+    return context->FixInputPort(get_index(), std::move(abstract_value));
+  }
+
+  /** Returns true iff this port is connected or has had a fixed value provided
+  in the given Context.  Beware that at the moment, this could be an expensive
+  operation, because the value is brought up-to-date as part of this
+  operation. */
   bool HasValue(const Context<T>& context) const {
     DRAKE_ASSERT_VOID(get_system_base().ThrowIfContextNotCompatible(context));
     return DoEvalOptional(context);

--- a/systems/framework/test/input_port_test.cc
+++ b/systems/framework/test/input_port_test.cc
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/leaf_system.h"
 #include "drake/systems/framework/test_utilities/my_vector.h"
 
@@ -143,6 +144,165 @@ GTEST_TEST(InputPortTest, AbstractTest) {
       "InputPort::Eval..: wrong value type int specified; "
       "actual type was std::string "
       "for InputPort.*2.*of.*dummy.*DummySystem.*");
+}
+
+// This struct is for testing the FixValue() variants.
+struct SystemWithInputPorts final : public LeafSystem<double> {
+ public:
+  SystemWithInputPorts()
+      : basic_vec_port{DeclareVectorInputPort("basic_vec_port",
+                                              BasicVector<double>(3))},
+        derived_vec_port{DeclareVectorInputPort(
+            "derived_vec_port",
+            MyVector3d(Eigen::Vector3d(1., 2., 3.)))},
+        int_port{DeclareAbstractInputPort("int_port", Value<int>(5))},
+        double_port{
+            DeclareAbstractInputPort("double_port", Value<double>(1.25))},
+        string_port{DeclareAbstractInputPort("string_port",
+                                             Value<std::string>("hello"))} {}
+  const InputPort<double>& basic_vec_port;
+  const InputPort<double>& derived_vec_port;
+  const InputPort<double>& int_port;
+  const InputPort<double>& double_port;
+  const InputPort<double>& string_port;
+};
+
+// Test the FixValue() method. Note that the conversion of its value argument
+// to an AbstractValue is handled by internal::ValueToAbstractValue which has
+// its own unit tests. Here we need just check the input-port specific
+// behavior for vector and abstract intput ports.
+// Also for sanity, make sure the returned FixedInputPortValue object works,
+// although its API is so awful no one should use it.
+GTEST_TEST(InputPortTest, FixValueTests) {
+  SystemWithInputPorts dut;
+  std::unique_ptr<Context<double>> context = dut.CreateDefaultContext();
+
+  // None of the ports should have a value initially.
+  for (int i = 0; i < dut.get_num_input_ports(); ++i) {
+    EXPECT_FALSE(dut.get_input_port(i).HasValue(*context));
+  }
+
+  // First pound on the vector ports.
+
+  // An Eigen vector value should be stored as a BasicVector.
+  const Eigen::Vector3d expected_vec(10., 20., 30.);
+  dut.basic_vec_port.FixValue(&*context, expected_vec);
+  EXPECT_EQ(dut.basic_vec_port.Eval(*context), expected_vec);
+  EXPECT_EQ(
+      dut.basic_vec_port.Eval<BasicVector<double>>(*context).CopyToVector(),
+      expected_vec);
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dut.basic_vec_port.Eval<std::string>(*context), std::logic_error,
+      ".*wrong value type.*std::string.*actual type.*BasicVector.*");
+
+  // TODO(sherm1) It would be nice to make this work rather than throw.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dut.basic_vec_port.Eval<Eigen::Vector3d>(*context), std::logic_error,
+      ".*wrong value type.*Eigen.*actual type.*BasicVector.*");
+
+  // Pass a more complicated Eigen object; should still work.
+  const Eigen::Vector4d long_vec(.25, .5, .75, 1.);
+  dut.basic_vec_port.FixValue(&*context, 2. * long_vec.tail(3));
+  EXPECT_EQ(dut.basic_vec_port.Eval(*context),
+            2. * Eigen::Vector3d(.5, .75, 1.));
+
+  // Should return a runtime error if the size is wrong.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dut.basic_vec_port.FixValue(&*context, long_vec.segment<2>(1)),
+      std::logic_error, ".*expected.*size=3.*actual.*size=2.*");
+
+  // A BasicVector-derived type should be acceptable to vector ports with
+  // either a BasicVector model or the derived-type model (sizes must match).
+  const MyVector3d my_vector(expected_vec);
+  dut.basic_vec_port.FixValue(&*context, my_vector);
+  dut.derived_vec_port.FixValue(&*context, my_vector);
+
+  // Either way the concrete type should be preserved.
+  EXPECT_EQ(dut.basic_vec_port.Eval<MyVector3d>(*context).CopyToVector(),
+            expected_vec);
+  EXPECT_EQ(dut.derived_vec_port.Eval<MyVector3d>(*context).CopyToVector(),
+            expected_vec);
+
+  // A plain BasicVector should work in the BasicVector-modeled port but
+  // NOT in the MyVector3-modeled port.
+  const BasicVector<double> basic_vector3({7., 8., 9.});
+  dut.basic_vec_port.FixValue(&*context, basic_vector3);  // (2)
+
+  // TODO(sherm1) This shouldn't work, but does. See issue #9669.
+  dut.derived_vec_port.FixValue(&*context, basic_vector3);
+
+  // This is the right type, wrong size for the vector ports.
+  const MyVector2d my_vector2(Eigen::Vector2d{19., 20.});
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dut.basic_vec_port.FixValue(&*context, my_vector2), std::logic_error,
+      ".*expected.*size=3.*actual.*size=2.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dut.derived_vec_port.FixValue(&*context, my_vector2), std::logic_error,
+      ".*expected.*size=3.*actual.*size=2.*");
+
+  // Now try the abstract ports.
+
+  dut.int_port.FixValue(&*context, 17);
+  EXPECT_EQ(dut.int_port.Eval<int>(*context), 17);
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dut.int_port.FixValue(&*context, 1.25), std::logic_error,
+      ".*expected value of type int.*actual type was double.*");
+
+  dut.double_port.FixValue(&*context, 1.25);
+  EXPECT_EQ(dut.double_port.Eval<double>(*context), 1.25);
+
+  // Without an explicit template argument, FixValue() won't do numerical
+  // conversions.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dut.double_port.FixValue(&*context, 4), std::logic_error,
+      ".*expected value of type double.*actual type was int.*");
+
+  // But an explicit template argument can serve as a workaround.
+  dut.double_port.FixValue<double>(&*context, 4);
+  EXPECT_EQ(dut.double_port.Eval<double>(*context), 4.0);
+
+  // Use the string port for a variety of tests:
+  // - the port value can be set as a string or char* constant
+  // - the generic AbstractValue API works
+  // - we can use the returned FixedInputPortValue object to change the value
+
+  // Check the basics.
+  dut.string_port.FixValue(&*context, std::string("dummy"));
+  EXPECT_EQ(dut.string_port.Eval<std::string>(*context), "dummy");
+
+  // Test special case API for C string constant, treated as an std::string.
+  dut.string_port.FixValue(&*context, "a c string");
+  EXPECT_EQ(dut.string_port.Eval<std::string>(*context), "a c string");
+
+  // Test that we can take an AbstractValue or Value<T> object as input.
+  const Value<int> int_value(42);
+  const AbstractValue& int_value_as_abstract = Value<int>(43);
+  dut.int_port.FixValue(&*context, int_value);
+  EXPECT_EQ(dut.int_port.Eval<int>(*context), 42);
+  dut.int_port.FixValue(&*context, int_value_as_abstract);
+  EXPECT_EQ(dut.int_port.Eval<int>(*context), 43);
+
+  // We should only accept the right kind of abstract value.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dut.string_port.FixValue(&*context, int_value), std::logic_error,
+      ".*expected.*type std::string.*actual type was int.*");
+
+  auto& fixed_value =
+      dut.string_port.FixValue(&*context, Value<std::string>("abstract"));
+  EXPECT_EQ(dut.string_port.Eval<std::string>(*context), "abstract");
+
+  // FixedInputPortValue has a very clunky interface, but let's make sure we
+  // at least got the right object.
+  fixed_value.GetMutableData()->get_mutable_value<std::string>() =
+      "replacement string";
+  EXPECT_EQ(dut.string_port.Eval<std::string>(*context), "replacement string");
+
+  // All of the ports should have values by now.
+  for (int i = 0; i < dut.get_num_input_ports(); ++i) {
+    EXPECT_TRUE(dut.get_input_port(i).HasValue(*context));
+  }
 }
 
 }  // namespace

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -2402,7 +2402,7 @@ GTEST_TEST(SystemConstraintTest, ModelVectorTest) {
   // `u0[0] >= 33.0` with `u0[0] == 3.0` produces `3.0 >= 33.0`.
   InputVector input;
   input.SetAtIndex(0, 3.0);
-  context->FixInputPort(0, input);
+  dut.get_input_port(0).FixValue(&*context, input);
   Eigen::VectorXd value2;
   constraint2.Calc(*context, &value2);
   EXPECT_TRUE(CompareMatrices(value2, Vector1<double>::Constant(3.0)));

--- a/systems/framework/value_to_abstract_value.h
+++ b/systems/framework/value_to_abstract_value.h
@@ -57,11 +57,11 @@ appropriate policy. Here is an example:
   std::unique_ptr<AbstractValue> abstract_value =
     is_vector_port
         ? internal::ValueToVectorValue<T>::ToAbstract(__func__, value)
-        : internal::ValueToAbstractValue::ToAbstract(value);
+        : internal::ValueToAbstractValue::ToAbstract(__func__, value);
 ```
 Note that for this to work _both_ ToAbstract() methods must compile
-successfully, even though the VectorPolicy is much more restrictive. Thus
-the VectorPolicy must issue runtime errors for values that are unacceptable.
+successfully. Thus where one policy is more restrictive than the other, it must
+issue runtime (not compile time) errors for values that are unacceptable.
 
 @see ValueToVectorValue
 
@@ -69,8 +69,9 @@ the VectorPolicy must issue runtime errors for values that are unacceptable.
 
  1. Any given AbstractValue object is simply cloned.
  2. A `char *` type is copied into a Value<std::string>.
- 3. Any Eigen expression type is simplified using `.eval()`, and then stored
-    in a Value<E> where E is the type returned by `.eval()` (without const).
+ 3. Eigen objects and expressions are not accepted directly under AbstractPolicy
+    as they are under VectorPolicy. The caller must instead provide the storage
+    type explicitly via Value<EigenType>.
  4. For any other type V
     - if V is copy-constructible it is copied into a `Value<V>`;
     - if V has an accessible Clone() method that returns `unique_ptr<V>` it is
@@ -79,46 +80,40 @@ the VectorPolicy must issue runtime errors for values that are unacceptable.
       where B is a base class of V, then V is cloned into a `Value<B>`;
     - otherwise, compilation fails with a `static_assert` message.
 
-@warning Eigen expressions typically don't have simple Vector types. That
-doesn't matter under the VectorPolicy. However, under the AbstractPolicy you
-will get Value<E> where E is the type of V.eval(). If you need to know E's
-type, use `ValueToAbstractValue::NiceEigenType<V>`. Better, put your expression
-V into an Eigen vector of known type before storing it in an AbstractValue. */
+@warning Eigen expressions typically don't have simple Vector or Matrix types.
+That doesn't matter under the VectorPolicy (as long as the size and shape are
+acceptable). However, under the AbstractPolicy you must specify the storage
+type explicitly by suppling a Value<EigenType>(your_expression) object. */
 class ValueToAbstractValue {
  public:
   // Signature (1): used for AbstractValue or Value<U> arguments.
-  static std::unique_ptr<AbstractValue> ToAbstract(const AbstractValue& value) {
+  static std::unique_ptr<AbstractValue> ToAbstract(const char* api_name,
+      const AbstractValue& value) {
+    unused(api_name);
     return value.Clone();
   }
 
   // Signature (2): special case char* to std::string to avoid ugly compilation
   // messages for this case, where the user's intent is obvious.
-  static std::unique_ptr<AbstractValue> ToAbstract(const char* c_string) {
+  static std::unique_ptr<AbstractValue> ToAbstract(const char* api_name,
+      const char* c_string) {
+    unused(api_name);
     return std::make_unique<Value<std::string>>(c_string);
   }
 
-  // This is the storage type we'll use for an Eigen vector type.
+  // Signature (3): special case any Eigen vector expression so that we can
+  // issue a runtime error message.
   template <typename ValueType,
             typename = std::enable_if_t<is_eigen_refable<ValueType>()>>
-  using NiceEigenType = std::remove_const_t<
-      std::remove_reference_t<decltype(std::declval<ValueType>().eval())>>;
-
-  // Signature (3): special case any Eigen vector expression so that we
-  // can invoke eval() on it and store it as the simpler result type. If
-  // you need to know how it was stored, use NiceEigenType above.
-
-  // Note that we're assuming that MatrixBase<Derived> will instantiate under
-  // the same conditions as is_eigen_refable() returns true.
-  // TODO(sherm1) Figure out some way to make this explicitly dependent on
-  // is_eigen_refable<ValueType>().
-  template <typename Derived>
-  static std::unique_ptr<AbstractValue> ToAbstract(
-      const Eigen::MatrixBase<Derived>& eigen_expr) {
-    // Can't use NiceEigenType here because we don't have the original
-    // ValueType.
-    using TypeAfterEval = std::remove_const_t<
-        std::remove_reference_t<decltype(eigen_expr.eval())>>;
-    return std::make_unique<Value<TypeAfterEval>>(eigen_expr.eval());
+  static std::unique_ptr<AbstractValue> ToAbstract(const char* api_name,
+                                                   const ValueType& eigen_value,
+                                                   ...) {
+    unused(eigen_value);
+    throw std::logic_error(fmt::format(
+        "{}(): Eigen objects and expressions cannot automatically be stored "
+        "as a Drake abstract quantity. Specify the storage type explicitly "
+        "by providing an already-abstract object like a Value<MatrixXd>().",
+        api_name));
   }
 
   // Returns true iff ValueType has an accessible Clone() method that
@@ -137,12 +132,14 @@ class ValueToAbstractValue {
             typename = std::enable_if_t<
                 !(std::is_base_of<AbstractValue, ValueType>::value ||
                   is_eigen_refable<ValueType>())>>
-  static std::unique_ptr<AbstractValue> ToAbstract(const ValueType& value) {
+  static std::unique_ptr<AbstractValue> ToAbstract(const char* api_name,
+      const ValueType& value) {
     static_assert(
         std::is_copy_constructible<ValueType>::value ||
             has_accessible_clone<ValueType>(),
         "ValueToAbstractValue(): value type must be copy constructible or "
         "have an accessible Clone() method that returns std::unique_ptr.");
+    unused(api_name);
     return ValueHelper(value, 1, 1);
   }
 
@@ -203,7 +200,6 @@ class ValueToAbstractValue {
     DRAKE_UNREACHABLE();
   }
 };
-
 
 /** Implements Drake policy for taking a concrete vector type and storing it in
 a Drake numerical vector object as an AbstractValue of concrete type


### PR DESCRIPTION
Adds an `input_port.FixValue(&context, value)` method using the new ValueToAbstractValue & ValueToVectorValue policy classes from #10838.

This is a replacement for the uglier `context.FixInputValue(port_num, value)` method collection which caused @mposa some usability headaches.  

Resolves #10692.

```
Category            added  modified  removed  
----------------------------------------------
code                153    31        9        
comments            77     21        10       
blank               39     0         0        
----------------------------------------------
TOTAL               269    52        19        
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10759)
<!-- Reviewable:end -->
