### PR TITLE
symbolic: ExtractDoubleOrThrow(NAN) should be NAN

### DIFF
--- a/common/symbolic_expression.cc
+++ b/common/symbolic_expression.cc
@@ -1035,6 +1035,14 @@ Variables GetDistinctVariables(const Eigen::Ref<const MatrixX<Expression>>& v) {
 }  // namespace symbolic
 
 double ExtractDoubleOrThrow(const symbolic::Expression& e) {
+  if (is_nan(e)) {
+    // If this was a literal NaN provided by the user or a dummy_value<T>, then
+    // it is sound to promote it as the "extracted value" during scalar
+    // conversion.  (In contrast, if an expression tree includes a NaN term,
+    // then it's still desirable to throw an exception and we should NOT return
+    // NaN in that case.)
+    return std::numeric_limits<double>::quiet_NaN();
+  }
   return e.Evaluate();
 }
 

--- a/common/test/symbolic_expression_test.cc
+++ b/common/test/symbolic_expression_test.cc
@@ -1927,6 +1927,13 @@ TEST_F(SymbolicExpressionTest, ExtractDoubleTest) {
   // 2x - 7 -2x + 2 => -5
   const Expression e3{2 * x_ - 7 - 2 * x_ + 2};
   EXPECT_EQ(ExtractDoubleOrThrow(e3), -5);
+
+  // Literal NaN should come through without an exception during Extract.
+  EXPECT_TRUE(std::isnan(ExtractDoubleOrThrow(e_nan_)));
+
+  // Computed NaN should still throw.
+  const Expression bogus = zero_ / e_nan_;
+  EXPECT_THROW(ExtractDoubleOrThrow(bogus), std::exception);
 }
 
 TEST_F(SymbolicExpressionTest, Jacobian) {


### PR DESCRIPTION
During transmogrification of a `Context<Expression>` to `Context<double>`, the user may have placed NAN bombs in state variables or parameters which should be unused by the computation in question (e.g., the dynamics may not depend on some output-scaling parameter).  In this case, we should just faithfully convert the Expression NAN to a double NAN, without throwing an exception.

This came up while discussing #10684.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10773)
<!-- Reviewable:end -->
