### PR TITLE
Deprecate and remove all uses of DRAKE_ABORT_MSG

### DIFF
--- a/attic/manipulation/dev/quasistatic_system.cc
+++ b/attic/manipulation/dev/quasistatic_system.cc
@@ -386,7 +386,7 @@ void QuasistaticSystem<Scalar>::DoCalcWnWfJnJfPhiAnalytic(
   static_cast<void>(Jn_ptr);
   static_cast<void>(Jf_ptr);
   static_cast<void>(phi_ptr);
-  DRAKE_ABORT_MSG(
+  throw std::logic_error(
       "Analytic expressions for Wn, Wf, Jn, Jf and phi are not "
       "available.");
 }

--- a/attic/manipulation/util/robot_state_msg_translator.cc
+++ b/attic/manipulation/util/robot_state_msg_translator.cc
@@ -164,7 +164,8 @@ void RobotStateLcmMessageTranslator::DecodeMessageKinematics(
       v.segment<3>(velocity_start) =  R_BJ * V_WB_J.head<3>();     // Rotate.
       v.segment<3>(velocity_start + 3) = R_BJ * V_WB_J.tail<3>();  // Translate.
     } else {
-      DRAKE_ABORT_MSG("Floating joint is neither a RPY or a Quaternion joint.");
+      throw std::domain_error(
+          "Floating joint is neither a RPY or a Quaternion joint.");
     }
   }
 
@@ -276,7 +277,8 @@ void RobotStateLcmMessageTranslator::EncodeMessageKinematics(
       V_JB.head<3>() = R_JB * v.segment<3>(velocity_start);
       V_JB.tail<3>() = R_JB * v.segment<3>(velocity_start + 3);
     } else {
-      DRAKE_ABORT_MSG("Floating joint is neither a RPY or a Quaternion joint.");
+      throw std::domain_error(
+          "Floating joint is neither a RPY or a Quaternion joint.");
     }
   } else {
     // Fixed base, the transformation is the joint's pose in the world frame.

--- a/attic/multibody/collision/drake_collision.cc
+++ b/attic/multibody/collision/drake_collision.cc
@@ -31,9 +31,8 @@ unique_ptr<Model> newModel(ModelType type) {
       return unique_ptr<Model>(new BulletModel());
     }
 #endif
-    default:
-      DRAKE_ABORT_MSG("Unexpected collision model type.");
   }
+  DRAKE_UNREACHABLE();
 }
 
 }  // namespace collision

--- a/attic/multibody/collision/fcl_model.cc
+++ b/attic/multibody/collision/fcl_model.cc
@@ -1,5 +1,6 @@
 #include "drake/multibody/collision/fcl_model.h"
 
+#include <stdexcept>
 #include <utility>
 
 #include <Eigen/Dense>
@@ -98,8 +99,7 @@ void FclModel::DoAddElement(const Element& element) {
           std::make_shared<fcl::Cylinderd>(cylinder.radius, cylinder.length);
     } break;
     default:
-      DRAKE_ABORT_MSG("Not implemented.");
-      break;
+      throw std::logic_error("Not implemented.");
   }
 
   auto fcl_object = std::make_unique<fcl::CollisionObjectd>(fcl_geometry);
@@ -147,8 +147,7 @@ bool FclModel::ClosestPointsAllToAll(
     const std::vector<ElementId>& ids_to_check, bool use_margins,
     std::vector<PointPair<double>>* closest_points) {
   drake::unused(ids_to_check, use_margins, closest_points);
-  DRAKE_ABORT_MSG("Not implemented.");
-  return false;
+  throw std::logic_error("Not implemented.");
 }
 
 bool FclModel::ComputeMaximumDepthCollisionPoints(
@@ -165,20 +164,19 @@ bool FclModel::ClosestPointsPairwise(
     const std::vector<ElementIdPair>& id_pairs, bool use_margins,
     std::vector<PointPair<double>>* closest_points) {
   drake::unused(id_pairs, use_margins, closest_points);
-  DRAKE_ABORT_MSG("Not implemented.");
-  return false;
+  throw std::logic_error("Not implemented.");
 }
 
 void FclModel::CollisionDetectFromPoints(
     const Eigen::Matrix3Xd& points, bool use_margins,
     std::vector<PointPair<double>>* closest_points) {
   drake::unused(points, use_margins, closest_points);
-  DRAKE_ABORT_MSG("Not implemented.");
+  throw std::logic_error("Not implemented.");
 }
 
 void FclModel::ClearCachedResults(bool use_margins) {
   drake::unused(use_margins);
-  DRAKE_ABORT_MSG("Not implemented.");
+  throw std::logic_error("Not implemented.");
 }
 
 bool FclModel::CollisionRaycast(const Eigen::Matrix3Xd& origins,
@@ -186,24 +184,21 @@ bool FclModel::CollisionRaycast(const Eigen::Matrix3Xd& origins,
                                 bool use_margins, Eigen::VectorXd* distances,
                                 Eigen::Matrix3Xd* normals) {
   drake::unused(origins, ray_endpoints, use_margins, distances, normals);
-  DRAKE_ABORT_MSG("Not implemented.");
-  return false;
+  throw std::logic_error("Not implemented.");
 }
 
 bool FclModel::CollidingPointsCheckOnly(
     const std::vector<Eigen::Vector3d>& input_points,
     double collision_threshold) {
   drake::unused(input_points, collision_threshold);
-  DRAKE_ABORT_MSG("Not implemented.");
-  return false;
+  throw std::logic_error("Not implemented.");
 }
 
 std::vector<size_t> FclModel::CollidingPoints(
     const std::vector<Eigen::Vector3d>& input_points,
     double collision_threshold) {
   drake::unused(input_points, collision_threshold);
-  DRAKE_ABORT_MSG("Not implemented.");
-  return std::vector<size_t>();
+  throw std::logic_error("Not implemented.");
 }
 
 }  // namespace collision

--- a/attic/multibody/collision/test/model_test.cc
+++ b/attic/multibody/collision/test/model_test.cc
@@ -162,11 +162,12 @@ INSTANTIATE_TEST_CASE_P(UsableModelTypesTests, UsableModelTypesTests,
 
 #ifndef DRAKE_DISABLE_FCL
 // Fixture for locking down FclModel's not-yet-implemented functions.
-class FclModelDeathTests : public ModelTestBase,
-                           public ::testing::WithParamInterface<
-                               std::function<void(FclModelDeathTests*)>> {
+class FclModelNotImplementedTests :
+    public ModelTestBase,
+    public ::testing::WithParamInterface<
+        std::function<void(FclModelNotImplementedTests*)>> {
  public:
-  FclModelDeathTests() {
+  FclModelNotImplementedTests() {
     model_ = drake::multibody::collision::newModel(ModelType::kFcl);
   }
 
@@ -219,22 +220,22 @@ class FclModelDeathTests : public ModelTestBase,
   }
 };
 
-TEST_P(FclModelDeathTests, NotImplemented) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-  EXPECT_DEATH(GetParam()(this), "Not implemented.");
+TEST_P(FclModelNotImplementedTests, NotImplemented) {
+  EXPECT_THROW(GetParam()(this), std::exception);
 }
 
 INSTANTIATE_TEST_CASE_P(
-    NotImplementedTest, FclModelDeathTests,
-    ::testing::Values(&FclModelDeathTests::CallAddBox,
-                      &FclModelDeathTests::CallAddCapsule,
-                      &FclModelDeathTests::CallAddMesh,
-                      &FclModelDeathTests::CallClosestPointsAllToAll,
-                      &FclModelDeathTests::CallCollisionDetectFromPoints,
-                      &FclModelDeathTests::CallClearCachedResults,
-                      &FclModelDeathTests::CallCollisionRaycast,
-                      &FclModelDeathTests::CallCollidingPointsCheckOnly,
-                      &FclModelDeathTests::CallCollidingPoints));
+    NotImplementedTest, FclModelNotImplementedTests,
+    ::testing::Values(
+       &FclModelNotImplementedTests::CallAddBox,
+       &FclModelNotImplementedTests::CallAddCapsule,
+       &FclModelNotImplementedTests::CallAddMesh,
+       &FclModelNotImplementedTests::CallClosestPointsAllToAll,
+       &FclModelNotImplementedTests::CallCollisionDetectFromPoints,
+       &FclModelNotImplementedTests::CallClearCachedResults,
+       &FclModelNotImplementedTests::CallCollisionRaycast,
+       &FclModelNotImplementedTests::CallCollidingPointsCheckOnly,
+       &FclModelNotImplementedTests::CallCollidingPoints));
 #endif
 
 // Fixture for testing collision queries involving pairs of collision

--- a/attic/multibody/collision/unusable_model.cc
+++ b/attic/multibody/collision/unusable_model.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/collision/unusable_model.h"
 
+#include <stdexcept>
+
 #include "drake/common/drake_assert.h"
 
 namespace drake {
@@ -7,48 +9,48 @@ namespace multibody {
 namespace collision {
 
 void UnusableModel::UpdateModel() {
-  DRAKE_ABORT_MSG(
+  throw std::domain_error(
       "Compile Drake with a collision library backend for collision support!");
   return;
 }
 
 bool UnusableModel::UpdateElementWorldTransform(
     ElementId, const Eigen::Isometry3d&) {
-  DRAKE_ABORT_MSG(
+  throw std::domain_error(
       "Compile Drake with a collision library backend for collision support!");
   return false;
 }
 
 bool UnusableModel::ClosestPointsAllToAll(const std::vector<ElementId>&, bool,
                                           std::vector<PointPair<double>>*) {
-  DRAKE_ABORT_MSG(
+  throw std::domain_error(
       "Compile Drake with a collision library backend for collision support!");
   return false;
 }
 
 bool UnusableModel::ComputeMaximumDepthCollisionPoints(
     bool, std::vector<PointPair<double>>*) {
-  DRAKE_ABORT_MSG(
+  throw std::domain_error(
       "Compile Drake with a collision library backend for collision support!");
   return false;
 }
 
 bool UnusableModel::ClosestPointsPairwise(
     const std::vector<ElementIdPair>&, bool, std::vector<PointPair<double>>*) {
-  DRAKE_ABORT_MSG(
+  throw std::domain_error(
       "Compile Drake with a collision library backend for collision support!");
   return false;
 }
 
 void UnusableModel::CollisionDetectFromPoints(
     const Eigen::Matrix3Xd&, bool, std::vector<PointPair<double>>*) {
-  DRAKE_ABORT_MSG(
+  throw std::domain_error(
       "Compile Drake with a collision library backend for collision support!");
   return;
 }
 
 void UnusableModel::ClearCachedResults(bool) {
-  DRAKE_ABORT_MSG(
+  throw std::domain_error(
       "Compile Drake with a collision library backend for collision support!");
   return;
 }
@@ -58,21 +60,21 @@ bool UnusableModel::CollisionRaycast(const Eigen::Matrix3Xd&,
                                      bool,
                                      Eigen::VectorXd*,
                                      Eigen::Matrix3Xd*) {
-  DRAKE_ABORT_MSG(
+  throw std::domain_error(
       "Compile Drake with a collision library backend for collision support!");
   return false;
 }
 
 bool UnusableModel::CollidingPointsCheckOnly(
     const std::vector<Eigen::Vector3d>&, double) {
-  DRAKE_ABORT_MSG(
+  throw std::domain_error(
       "Compile Drake with a collision library backend for collision support!");
   return false;
 }
 
 std::vector<size_t> UnusableModel::CollidingPoints(
     const std::vector<Eigen::Vector3d>&, double) {
-  DRAKE_ABORT_MSG(
+  throw std::domain_error(
       "Compile Drake with a collision library backend for collision support!");
   return std::vector<size_t>();
 }

--- a/attic/multibody/rigid_body.h
+++ b/attic/multibody/rigid_body.h
@@ -4,6 +4,7 @@
 #include <map>
 #include <memory>
 #include <set>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -113,7 +114,7 @@ class RigidBody {
   template<typename JointType>
   JointType* add_joint(RigidBody* parent, std::unique_ptr<JointType> joint) {
     if (joint_ != nullptr) {
-      DRAKE_ABORT_MSG(
+      throw std::logic_error(
           "Attempting to assign a new joint to a body that already has one");
     }
     set_parent(parent);

--- a/attic/multibody/rigid_body_plant/viewer_draw_translator.cc
+++ b/attic/multibody/rigid_body_plant/viewer_draw_translator.cc
@@ -29,7 +29,7 @@ ViewerDrawTranslator::ViewerDrawTranslator(const RigidBodyTree<double>& tree)
 
 void ViewerDrawTranslator::Deserialize(
     const void*, int, VectorBase<double>*) const {
-  DRAKE_ABORT_MSG(
+  throw std::logic_error(
     "The translator that converts from a drake::lcmt_viewer_draw message to "
     "a VectorBase object that contains the RigidBodyTree's state vector has not"
     "been implemented yet.");

--- a/attic/systems/sensors/rgbd_renderer_ospray.cc
+++ b/attic/systems/sensors/rgbd_renderer_ospray.cc
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <limits>
 #include <map>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -83,7 +84,7 @@ using ActorCollection = std::vector<vtkSmartPointer<vtkActor>>;
 std::string RemoveFileExtension(const std::string& filepath) {
   const size_t last_dot = filepath.find_last_of(".");
   if (last_dot == std::string::npos) {
-    DRAKE_ABORT_MSG("File has no extension.");
+    throw std::logic_error("File has no extension.");
   }
   return filepath.substr(0, last_dot);
 }

--- a/attic/systems/sensors/rgbd_renderer_vtk.cc
+++ b/attic/systems/sensors/rgbd_renderer_vtk.cc
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <limits>
 #include <map>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -85,7 +86,7 @@ struct ModuleInitVtkRenderingOpenGL2 {
 std::string RemoveFileExtension(const std::string& filepath) {
   const size_t last_dot = filepath.find_last_of(".");
   if (last_dot == std::string::npos) {
-    DRAKE_ABORT_MSG("File has no extension.");
+    throw std::logic_error("File has no extension.");
   }
   return filepath.substr(0, last_dot);
 }

--- a/automotive/maliput/multilane/builder.h
+++ b/automotive/maliput/multilane/builder.h
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <map>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -656,14 +657,12 @@ class Builder : public BuilderBase {
                 case -1: { return true; }
                 case 1: { return false; }
                 case 0: { return false; }
-                default: { DRAKE_ABORT_MSG("fuzzy_compare domain error"); }
               }
             }
-            default: { DRAKE_ABORT_MSG("fuzzy_compare domain error"); }
           }
         }
-        default: { DRAKE_ABORT_MSG("fuzzy_compare domain error"); }
       }
+      throw std::domain_error("fuzzy_compare domain error");
     }
 
    private:

--- a/automotive/maliput/simplerulebook/simple_rulebook.cc
+++ b/automotive/maliput/simplerulebook/simple_rulebook.cc
@@ -1,6 +1,7 @@
 #include "drake/automotive/maliput/simplerulebook/simple_rulebook.h"
 
 #include <algorithm>
+#include <stdexcept>
 #include <string>
 
 #include "drake/common/drake_optional.h"
@@ -211,7 +212,7 @@ QueryResults SimpleRulebook::DoFindRules(
       } else if (id.s) {
         result.speed_limit.push_back(speed_limits_.at(*id.s));
       } else {
-        DRAKE_ABORT_MSG("IdVariant is empty");
+        throw std::domain_error("SimpleRulebook: IdVariant is empty");
       }
     }
   }

--- a/automotive/maliput_railcar.cc
+++ b/automotive/maliput_railcar.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <stdexcept>
 #include <utility>
 #include <vector>
 
@@ -449,7 +450,8 @@ void MaliputRailcar<T>::DoCalcUnrestrictedUpdate(
     }
 
     if (!next_branch) {
-      DRAKE_ABORT_MSG("MaliputRailcar::DoCalcUnrestrictedUpdate: ERROR: "
+      throw std::logic_error(
+          "MaliputRailcar::DoCalcUnrestrictedUpdate: ERROR: "
           "Vehicle should switch lanes but no default or ongoing branch "
           "exists.");
     } else {

--- a/common/drake_assert.h
+++ b/common/drake_assert.h
@@ -62,8 +62,8 @@
 /// to silence false positive warnings.  When in doubt, throw an exception
 /// manually instead of using this macro.
 #define DRAKE_UNREACHABLE()
-/// Aborts the program (via ::abort) with a message showing at least the
-/// given message (macro argument), function name, file, and line.
+/// (Deprecated.)  Aborts the program (via ::abort) with a message showing at
+/// least the given message (macro argument), function name, file, and line.
 #define DRAKE_ABORT_MSG(message)
 #else  //  DRAKE_DOXYGEN_CXX
 
@@ -93,10 +93,11 @@ __attribute__((noreturn)) /* gcc is ok with [[noreturn]]; clang is not. */
 void Abort(const char* condition, const char* func, const char* file, int line);
 __attribute__((noreturn))
 __attribute__((deprecated(
-    "\nDRAKE DEPRECATED: DRAKE_ABORT() is deprecated; use DRAKE_ABORT_MSG(); "
-    "this macro will be removed on 2019-05-01.")))
-inline void DeprecatedAbort(const char* func, const char* file, int line) {
-  Abort(nullptr, func, file, line);
+    "\nDRAKE DEPRECATED: DRAKE_ABORT() and DRAKE_ABORT_MSG() are deprecated; "
+    "use 'throw' instead; this macro will be removed on 2019-06-01.")))
+inline void DeprecatedAbort(
+    const char* condition, const char* func, const char* file, int line) {
+  Abort(condition, func, file, line);
 }
 // Report an assertion failure; will either Abort(...) or throw.
 __attribute__((noreturn)) /* gcc is ok with [[noreturn]]; clang is not. */
@@ -120,7 +121,7 @@ struct ConditionTraits {
 }  // namespace drake
 
 #define DRAKE_ABORT()                                                   \
-  ::drake::detail::DeprecatedAbort(__func__, __FILE__, __LINE__)
+  ::drake::detail::DeprecatedAbort(nullptr, __func__, __FILE__, __LINE__)
 
 #define DRAKE_UNREACHABLE()                                             \
   ::drake::detail::Abort(                                               \
@@ -138,7 +139,7 @@ struct ConditionTraits {
   } while (0)
 
 #define DRAKE_ABORT_MSG(msg)                                    \
-  ::drake::detail::Abort(msg, __func__, __FILE__, __LINE__)
+  ::drake::detail::DeprecatedAbort(msg, __func__, __FILE__, __LINE__)
 
 #ifdef DRAKE_ASSERT_IS_ARMED
 // Assertions are enabled.

--- a/common/symbolic_expression_visitor.h
+++ b/common/symbolic_expression_visitor.h
@@ -71,7 +71,8 @@ Result VisitPolynomial(Visitor* v, const Expression& e, Args&&... args) {
     case ExpressionKind::IfThenElse:
     case ExpressionKind::UninterpretedFunction:
       // Unreachable because of `DRAKE_DEMAND(e.is_polynomial())` at the top.
-      DRAKE_ABORT_MSG("Unexpected Kind was is_polynomial");
+      throw std::domain_error(
+          "Unexpected Kind was is_polynomial in VisitPolynomial");
   }
   // Unreachable because all switch cases are accounted for above.
   DRAKE_UNREACHABLE();

--- a/common/test/drake_assert_test.cc
+++ b/common/test/drake_assert_test.cc
@@ -36,10 +36,13 @@ GTEST_TEST(DrakeAssertDeathTest, AbortTest) {
 
 GTEST_TEST(DrakeAssertDeathTest, AbortMsgTest) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   ASSERT_DEATH(
       { DRAKE_ABORT_MSG("stuff"); },
       "abort: Failure at .*drake_assert_test.cc:.. in TestBody..: "
       "condition 'stuff' failed");
+#pragma GCC diagnostic pop
 }
 
 GTEST_TEST(DrakeAssertDeathTest, DemandTest) {

--- a/examples/bead_on_a_wire/bead_on_a_wire-inl.h
+++ b/examples/bead_on_a_wire/bead_on_a_wire-inl.h
@@ -169,7 +169,10 @@ Eigen::VectorXd BeadOnAWire<T>::DoCalcVelocityChangeFromConstraintImpulses(
 
   // TODO(edrumwri): Test this method as soon as DAE solver is available,
   //                 (necessarily removing abort() first).
-  DRAKE_ABORT_MSG("This method requires testing.");
+  if (true) {
+    throw std::logic_error(
+        "DoCalcVelocityChangeFromConstraintImpulses requires testing.");
+  }
 
   // The bead on the wire is unit mass, so the velocity change is equal to
   // simply Jᵀλ

--- a/examples/double_pendulum/sdf_helpers.cc
+++ b/examples/double_pendulum/sdf_helpers.cc
@@ -78,7 +78,7 @@ void ParseGeometry(sdf::ElementPtr sdf_geometry_element,
     return;
   }
   // TODO(hidmic): Support mesh and sphere geometries.
-  DRAKE_ABORT_MSG("Unsupported geometry!");
+  throw std::domain_error("Unsupported geometry!");
 }
 
 // Parses a visual geometry from the given SDF element and adds a
@@ -258,7 +258,7 @@ ParseJointType(sdf::ElementPtr sdf_joint_element,
     return std::move(joint);
   }
   // TODO(hidmic): Support prismatic and fixed joints.
-  DRAKE_ABORT_MSG("Unsupported joint type!");
+  throw std::domain_error("Unsupported joint type!");
 }
 
 // Parses a joint from the given SDF element and adds a DrakeJoint instance

--- a/examples/kuka_iiwa_arm/iiwa_controller.cc
+++ b/examples/kuka_iiwa_arm/iiwa_controller.cc
@@ -2,6 +2,7 @@
 ///
 /// Implements a controller for a KUKA iiwa arm.
 
+#include <iostream>
 #include <memory>
 
 #include <gflags/gflags.h>
@@ -75,10 +76,11 @@ int DoMain() {
   } else if (interp_str == "pchip") {
     interpolator_type = InterpolatorType::Pchip;
   } else {
-    DRAKE_ABORT_MSG(
+    std::cerr <<
         "Robot plan interpolation type not recognized. "
         "Use the gflag --helpshort to display "
-        "flag options for interpolator type.");
+        "flag options for interpolator type.\n";
+    return EXIT_FAILURE;
   }
   auto plan_interpolator =
       builder.AddSystem<LcmPlanInterpolator>(urdf, interpolator_type);

--- a/examples/manipulation_station/manipulation_station.cc
+++ b/examples/manipulation_station/manipulation_station.cc
@@ -909,7 +909,7 @@ void ManipulationStation<T>::AddDefaultIiwa(
           "iiwa7_with_box_collision.sdf");
       break;
     default:
-      DRAKE_ABORT_MSG("Unrecognized collision_model.");
+      throw std::domain_error("Unrecognized collision_model.");
   }
   const auto X_WI = RigidTransform<double>::Identity();
   auto iiwa_instance = internal::AddAndWeldModelFrom(

--- a/examples/manipulation_station/mock_station_simulation.cc
+++ b/examples/manipulation_station/mock_station_simulation.cc
@@ -54,8 +54,8 @@ int do_main(int argc, char* argv[]) {
   } else if (FLAGS_setup == "clutter_clearing") {
     station->SetupClutterClearingStation();
   } else {
-    DRAKE_ABORT_MSG("Unrecognized station type. Options are "
-                    "{default, clutter_clearing}.");
+    throw std::domain_error(
+        "Unrecognized station type. Options are {default, clutter_clearing}.");
   }
   // TODO(russt): Load sdf objects specified at the command line.  Requires
   // #9747.

--- a/examples/manipulation_station/proof_of_life.cc
+++ b/examples/manipulation_station/proof_of_life.cc
@@ -100,8 +100,9 @@ int do_main(int argc, char* argv[]) {
   // Check that the arm is (very roughly) in the commanded position.
   VectorXd q = station->GetIiwaPosition(station_context);
   if (!is_approx_equal_abstol(q, q0, 1.e-3)) {
-    std::cout << "q - q0  = " << (q - q0).transpose() << std::endl;
-    DRAKE_ABORT_MSG("q is not sufficiently close to q0.");
+    std::cout << "q is not sufficiently close to q0.\n";
+    std::cout << "q - q0  = " << (q - q0).transpose() << "\n";
+    return EXIT_FAILURE;
   }
 
   return 0;

--- a/examples/rod2d/rod2d-inl.h
+++ b/examples/rod2d/rod2d-inl.h
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <limits>
 #include <memory>
+#include <stdexcept>
 #include <utility>
 #include <vector>
 
@@ -82,8 +83,7 @@ int Rod2D<T>::DetermineNumWitnessFunctions(
     return 0;
 
   // TODO(edrumwri): Flesh out this stub.
-  DRAKE_ABORT_MSG("Rod2D<T>::DetermineNumWitnessFunctions is stubbed");
-  return 0;
+  throw std::domain_error("Rod2D<T>::DetermineNumWitnessFunctions is stubbed");
 }
 
 /// Gets the integer variable 'k' used to determine the point of contact
@@ -1036,7 +1036,7 @@ void Rod2D<T>::DoCalcTimeDerivatives(
     return CalcAccelerationsCompliantContactAndBallistic(context, derivatives);
   } else {
     // TODO(edrumwri): Implement the piecewise DAE approach.
-    DRAKE_ABORT_MSG(
+    throw std::domain_error(
         "Rod2D<T>::DoCalcTimeDerivatives: piecewise DAE isn't implemented yet");
   }
 }

--- a/geometry/dev/render/render_engine_vtk.cc
+++ b/geometry/dev/render/render_engine_vtk.cc
@@ -1,6 +1,7 @@
 #include "drake/geometry/dev/render/render_engine_vtk.h"
 
 #include <limits>
+#include <stdexcept>
 #include <utility>
 
 #include <vtkCamera.h>
@@ -99,7 +100,7 @@ struct RegistrationData {
 std::string RemoveFileExtension(const std::string& filepath) {
   const size_t last_dot = filepath.find_last_of(".");
   if (last_dot == std::string::npos) {
-    DRAKE_ABORT_MSG("File has no extension.");
+    throw std::logic_error("File has no extension.");
   }
   return filepath.substr(0, last_dot);
 }

--- a/geometry/internal_geometry.cc
+++ b/geometry/internal_geometry.cc
@@ -29,7 +29,7 @@ bool InternalGeometry::has_role(Role role) const {
     case Role::kUnassigned:
       return !(has_proximity_role() || has_illustration_role());
   }
-  DRAKE_ABORT_MSG("Unreachable code; switch on enum had unexpected value");
+  DRAKE_UNREACHABLE();
 }
 
 }  // namespace internal

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <cstdint>
 #include <iterator>
+#include <stdexcept>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -1102,7 +1103,7 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
   }
 
   void ImplementGeometry(const Mesh&, void*) override {
-    DRAKE_ABORT_MSG("The proximity engine does not support meshes yet");
+    throw std::domain_error("The proximity engine does not support meshes yet");
   }
 
   //

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -2489,25 +2489,23 @@ TEST_F(BoxPenetrationTest, TangentConvex2) {
 
 // Attempting to add a dynamic Mesh should cause an abort.
 GTEST_TEST(ProximityEngineTests, AddDynamicMesh) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   ProximityEngine<double> engine;
   Mesh mesh{"invalid/path/thing.obj", 1.0};
-  ASSERT_DEATH(
+  DRAKE_EXPECT_THROWS_MESSAGE(
       engine.AddDynamicGeometry(mesh, GeometryIndex(0)),
-      "abort: .*proximity_engine.*"
-      "The proximity engine does not support meshes yet.*");
+      std::exception,
+      ".*The proximity engine does not support meshes yet.*");
 }
 
 // Attempting to add a anchored Mesh should cause an abort.
 GTEST_TEST(ProximityEngineTests, AddAnchoredMesh) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   ProximityEngine<double> engine;
   Mesh mesh{"invalid/path/thing.obj", 1.0};
-  ASSERT_DEATH(
+  DRAKE_EXPECT_THROWS_MESSAGE(
       engine.AddAnchoredGeometry(mesh, Isometry3d::Identity(),
                                  GeometryIndex(0)),
-      "abort: .*proximity_engine.*"
-      "The proximity engine does not support meshes yet.*");
+      std::exception,
+      ".*The proximity engine does not support meshes yet.*");
 }
 
 // This is a one-off test. Exposed in issue #10577. A point penetration pair

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <limits>
 #include <memory>
+#include <stdexcept>
 #include <vector>
 
 #include "drake/common/drake_throw.h"
@@ -933,7 +934,7 @@ template<typename T>
 std::vector<PenetrationAsPointPair<T>>
 MultibodyPlant<T>::CalcPointPairPenetrations(
     const systems::Context<T>&) const {
-  DRAKE_ABORT_MSG("This method only supports T = double.");
+  throw std::domain_error("This method only supports T = double.");
 }
 
 template<typename T>

--- a/multibody/tree/joint.h
+++ b/multibody/tree/joint.h
@@ -2,6 +2,7 @@
 
 #include <limits>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -439,7 +440,8 @@ class Joint : public MultibodyTreeElement<Joint<T>, JointIndex>  {
   /// Revolute and prismatic are examples of joints that will want to implement
   /// this method.
   virtual const T& DoGetOnePosition(const systems::Context<T>&) const {
-    DRAKE_ABORT_MSG("This method can only be called on single-dof joints.");
+    throw std::domain_error(
+        "GetOnePosition can only be called on single-dof joints.");
   }
 
   /// Implementation to the NVI GetOneVelocity() that must only be implemented
@@ -449,7 +451,8 @@ class Joint : public MultibodyTreeElement<Joint<T>, JointIndex>  {
   /// Revolute and prismatic are examples of joints that will want to implement
   /// this method.
   virtual const T& DoGetOneVelocity(const systems::Context<T>&) const {
-    DRAKE_ABORT_MSG("This method can only be called on single-dof joints.");
+    throw std::domain_error(
+        "GetOneVelocity can only be called on single-dof joints.");
   }
 
   /// Adds into `forces` a force along the one of the joint's degrees of

--- a/solvers/mixed_integer_optimization_util.cc
+++ b/solvers/mixed_integer_optimization_util.cc
@@ -16,9 +16,7 @@ std::string to_string(IntervalBinning binning) {
       return "logarithmic_binning";
     }
   }
-  // The following line should not be reached. We add it due to a compiler
-  // defect.
-  DRAKE_ABORT_MSG("Should not reach this part of the code.");
+  DRAKE_UNREACHABLE();
 }
 
 std::ostream& operator<<(std::ostream& os, const IntervalBinning& binning) {

--- a/solvers/moby_lcp_solver.cc
+++ b/solvers/moby_lcp_solver.cc
@@ -7,6 +7,7 @@
 #include <limits>
 #include <memory>
 #include <sstream>
+#include <stdexcept>
 #include <vector>
 
 #include <Eigen/LU>
@@ -152,7 +153,7 @@ template <>
 void MobyLCPSolver<Eigen::AutoDiffScalar<Vector1d>>::DoSolve(
     const MathematicalProgram&, const Eigen::VectorXd&,
     const SolverOptions&, MathematicalProgramResult*) const {
-  DRAKE_ABORT_MSG(
+  throw std::logic_error(
       "MobyLCPSolver cannot yet be used in a MathematicalProgram "
       "while templatized as an AutoDiff");
 }

--- a/solvers/unrevised_lemke_solver.cc
+++ b/solvers/unrevised_lemke_solver.cc
@@ -7,6 +7,7 @@
 #include <limits>
 #include <memory>
 #include <sstream>
+#include <stdexcept>
 #include <utility>
 #include <vector>
 
@@ -80,7 +81,7 @@ template <>
 void UnrevisedLemkeSolver<AutoDiffXd>::DoSolve(
     const MathematicalProgram&, const Eigen::VectorXd&,
     const SolverOptions&, MathematicalProgramResult*) const {
-  DRAKE_ABORT_MSG(
+  throw std::logic_error(
       "UnrevisedLemkeSolver cannot yet be used in a "
       "MathematicalProgram while templatized as an AutoDiff");
 }

--- a/systems/analysis/implicit_euler_integrator-inl.h
+++ b/systems/analysis/implicit_euler_integrator-inl.h
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <limits>
 #include <memory>
+#include <stdexcept>
 #include <utility>
 
 #include "drake/common/text_logging.h"
@@ -397,7 +398,7 @@ bool ImplicitEulerIntegrator<T>::CalcMatrices(const T& tf, const T& dt,
       }
 
       default:
-        DRAKE_ABORT_MSG("Unexpected trial number.");
+        throw std::domain_error("Unexpected trial number.");
     }
   }
 }

--- a/systems/framework/input_port_base.cc
+++ b/systems/framework/input_port_base.cc
@@ -1,5 +1,6 @@
 #include "drake/systems/framework/input_port_base.h"
 
+#include <stdexcept>
 #include <utility>
 
 #include <fmt/format.h>
@@ -20,7 +21,7 @@ InputPortBase::InputPortBase(
       eval_(std::move(eval)),
       random_type_(random_type) {
   if (is_random() && data_type != kVectorValued) {
-    DRAKE_ABORT_MSG("Random input ports must be vector valued.");
+    throw std::logic_error("Random input ports must be vector valued.");
   }
   DRAKE_DEMAND(eval_ != nullptr);
 }

--- a/systems/framework/port_base.cc
+++ b/systems/framework/port_base.cc
@@ -25,7 +25,7 @@ PortBase::PortBase(
   DRAKE_DEMAND(owning_system != nullptr);
   DRAKE_DEMAND(!name_.empty());
   if (size_ == kAutoSize) {
-    DRAKE_ABORT_MSG("Auto-size ports are not yet implemented.");
+    throw std::domain_error("Auto-size ports are not yet implemented.");
   }
 }
 

--- a/systems/primitives/first_order_low_pass_filter.cc
+++ b/systems/primitives/first_order_low_pass_filter.cc
@@ -1,6 +1,7 @@
 #include "drake/systems/primitives/first_order_low_pass_filter.h"
 
 #include <sstream>
+#include <stdexcept>
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
@@ -39,7 +40,7 @@ double FirstOrderLowPassFilter<T>::get_time_constant() const {
     s << "The time constants vector, [" << time_constants_ << "], cannot be "
          "represented as a scalar value. Please use "
          "FirstOrderLowPassFilter::get_time_constants_vector() instead.";
-    DRAKE_ABORT_MSG(s.str().c_str());
+    throw std::domain_error(s.str());
   }
   return time_constants_[0];
 }

--- a/systems/primitives/linear_system.cc
+++ b/systems/primitives/linear_system.cc
@@ -125,7 +125,7 @@ std::unique_ptr<AffineSystem<double>> DoFirstOrderTaylorApproximation(
              input_port_index < system.get_num_input_ports()) {
     input_port = &(autodiff_system->get_input_port(input_port_index));
   } else if (input_port_index != kNoInput) {
-    DRAKE_ABORT_MSG("Invalid input_port_index specified.");
+    throw std::domain_error("Invalid input_port_index specified.");
   }
 
   // By default, use the first input / output ports (if they exist).
@@ -138,7 +138,7 @@ std::unique_ptr<AffineSystem<double>> DoFirstOrderTaylorApproximation(
              output_port_index < system.get_num_output_ports()) {
     output_port = &(autodiff_system->get_output_port(output_port_index));
   } else if (output_port_index != kNoOutput) {
-    DRAKE_ABORT_MSG("Invalid output_port_index specified.");
+    throw std::domain_error("Invalid output_port_index specified.");
   }
 
   // Verify that the input port is not abstract valued.

--- a/systems/primitives/random_source.cc
+++ b/systems/primitives/random_source.cc
@@ -39,28 +39,28 @@ int AddRandomInputs(double sampling_interval_sec,
         continue;
       }
 
+      count++;
       switch (port.get_random_type().value()) {
         case RandomDistribution::kUniform: {
           const auto* uniform = builder->AddSystem<UniformRandomSource>(
               port.size(), sampling_interval_sec);
           builder->Connect(uniform->get_output_port(0), port);
-        } break;
+          continue;
+        }
         case RandomDistribution::kGaussian: {
           const auto* gaussian = builder->AddSystem<GaussianRandomSource>(
               port.size(), sampling_interval_sec);
           builder->Connect(gaussian->get_output_port(0), port);
-        } break;
+          continue;
+        }
         case RandomDistribution::kExponential: {
           const auto* exponential = builder->AddSystem<ExponentialRandomSource>(
               port.size(), sampling_interval_sec);
           builder->Connect(exponential->get_output_port(0), port);
-        } break;
-        default: {
-          DRAKE_ABORT_MSG(
-              "InputPort has an unsupported RandomDistribution.");
+          continue;
         }
       }
-      count++;
+      DRAKE_UNREACHABLE();
     }
   }
   return count;

--- a/systems/rendering/pose_aggregator.cc
+++ b/systems/rendering/pose_aggregator.cc
@@ -78,7 +78,7 @@ void PoseAggregator<T>::CalcPoseBundle(const Context<T>& context,
         bundle.set_pose(pose_index, value.get_isometry());
         bundle.set_model_instance_id(pose_index, record.model_instance_id);
         pose_index++;
-        break;
+        continue;
       }
       case InputRecord::kSingleVelocity: {
         // Single velocities are associated with the single pose that must
@@ -97,7 +97,7 @@ void PoseAggregator<T>::CalcPoseBundle(const Context<T>& context,
         // Write the velocity to the previous pose_index, and do not increment
         // the pose_index, because this input was not a pose.
         bundle.set_velocity(prev_pose_index, value);
-        break;
+        continue;
       }
       case InputRecord::kBundle: {
         // Concatenate the poses of the input pose bundle into the output.
@@ -115,10 +115,10 @@ void PoseAggregator<T>::CalcPoseBundle(const Context<T>& context,
                                        value.get_model_instance_id(j));
           pose_index++;
         }
-        break;
+        continue;
       }
-      default: { DRAKE_ABORT_MSG("Unknown PoseInputType."); }
     }
+    DRAKE_UNREACHABLE();
   }
 }
 
@@ -183,10 +183,8 @@ PoseAggregator<T>::DeclareInput(const InputRecord& record) {
     case InputRecord::kBundle:
       return this->DeclareAbstractInputPort(
           kUseDefaultName, Value<PoseBundle<T>>());
-    case InputRecord::kUnknown:
-      break;
   }
-  DRAKE_ABORT_MSG("Invariant failure");
+  DRAKE_UNREACHABLE();
 }
 
 }  // namespace rendering

--- a/systems/rendering/pose_aggregator.h
+++ b/systems/rendering/pose_aggregator.h
@@ -158,13 +158,12 @@ namespace pose_aggregator_detail {
 // parameter @p T.
 struct InputRecord {
   enum PoseInputType {
-    kUnknown = 0,
     kSinglePose = 1,
     kSingleVelocity = 2,
     kBundle = 3,
   };
 
-  PoseInputType type{kUnknown};
+  PoseInputType type{kSinglePose};
   int num_poses{0};
   // name is only valid if type is kSingle{Pose, Velocity} or kBundle.
   std::string name{};

--- a/systems/sensors/image_to_lcm_image_array_t.cc
+++ b/systems/sensors/image_to_lcm_image_array_t.cc
@@ -129,7 +129,7 @@ void PackImageToLcmImageT(const AbstractValue& untyped_image,
       break;
     }
     case PixelType::kExpr:
-      DRAKE_ABORT_MSG("PixelType::kExpr is not supported.");
+      throw std::domain_error("PixelType::kExpr is not supported.");
   }
 }
 

--- a/systems/sensors/image_writer.cc
+++ b/systems/sensors/image_writer.cc
@@ -111,20 +111,19 @@ const InputPort<double>& ImageWriter::DeclareImageInputPort(
       DirectoryFromFormat(file_name_format, port_name, kPixelType)};
   FolderState folder_state = ValidateDirectory(test_dir.getStr());
   if (folder_state != FolderState::kValid) {
-    std::string reason;
-    switch (folder_state) {
-      case FolderState::kMissing:
-        reason = "the directory does not exist";
-        break;
-      case FolderState::kIsFile:
-        reason = "the directory is actually a file";
-        break;
-      case FolderState::kUnwritable:
-        reason = "no permissions to write the directory";
-        break;
-      default:
-        DRAKE_ABORT_MSG("Directory is not valid; unhandled failure condition");
-    }
+    const char* const reason = [folder_state]() {
+      switch (folder_state) {
+        case FolderState::kValid:
+          DRAKE_UNREACHABLE();
+        case FolderState::kMissing:
+          return "the directory does not exist";
+        case FolderState::kIsFile:
+          return "the directory is actually a file";
+        case FolderState::kUnwritable:
+          return "no permissions to write the directory";
+      }
+      DRAKE_UNREACHABLE();
+    }();
     throw std::logic_error(
         fmt::format("ImageWriter: The format string `{}` implied the invalid "
                     "directory: '{}'; {}",


### PR DESCRIPTION
We want to remove DRAKE_ABORT_MSG, because in pydrake we should never take down the interpreter.

Many uses are replaced by throwing an exception, or else perhaps by using the DRAKE_UNREACHABLE macro.

Closes #10097.

Relates #5268.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10781)
<!-- Reviewable:end -->
