### PR TITLE
Removes kcov from fast_math_test

### DIFF
--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -201,6 +201,7 @@ drake_cc_test(
 
 drake_cc_googletest(
     name = "fast_math_test",
+    tags = ["no_kcov"],  # TODO(liang.fok) Remove this, see #10788.
     deps = [
         "//:drake_shared_library",
     ],


### PR DESCRIPTION
This is a temporary fix to avoid a nightly production CI failure. See #10788.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10789)
<!-- Reviewable:end -->
