### PR TITLE
framework: Swap template params of MyVector<T,N>

### DIFF
--- a/common/test/value_test.cc
+++ b/common/test/value_test.cc
@@ -163,7 +163,7 @@ GTEST_TEST(ValueTest, NiceTypeName) {
 
   // Must return the name of the most-derived type.
   EXPECT_EQ(base_value->GetNiceTypeName(),
-            "drake::systems::MyVector<2,double>");
+            "drake::systems::MyVector<double,2>");
 }
 
 GTEST_TEST(ValueTest, TypeInfo) {

--- a/systems/framework/test/basic_vector_test.cc
+++ b/systems/framework/test/basic_vector_test.cc
@@ -262,7 +262,7 @@ GTEST_TEST(BasicVectorTest, DefaultCalcInequalityConstraint) {
 
 // Tests the protected `::values()` methods.
 GTEST_TEST(BasicVectorTest, ValuesAccess) {
-  MyVector<2, double> dut;
+  MyVector2d dut;
   dut[0] = 11.0;
   dut[1] = 22.0;
 

--- a/systems/framework/test/continuous_state_test.cc
+++ b/systems/framework/test/continuous_state_test.cc
@@ -208,7 +208,7 @@ TEST_F(ContinuousStateTest, Clone) {
 
   // Make sure underlying BasicVector type, and 2nd-order structure,
   // is preserved in the clone.
-  ContinuousState<double> state(MyVector<3, double>::Make(1.25, 1.5, 1.75),
+  ContinuousState<double> state(MyVector3d::Make(1.25, 1.5, 1.75),
                                 2, 1, 0);
   clone_ptr = state.Clone();
   const ContinuousState<double>& clone2 = *clone_ptr;
@@ -222,7 +222,7 @@ TEST_F(ContinuousStateTest, Clone) {
   EXPECT_EQ(clone2.get_generalized_position()[1], 1.5);
   EXPECT_EQ(clone2.get_generalized_velocity()[0], 1.75);
 
-  auto vector = dynamic_cast<const MyVector<3, double>*>(&clone2.get_vector());
+  auto vector = dynamic_cast<const MyVector3d*>(&clone2.get_vector());
   ASSERT_NE(vector, nullptr);
   EXPECT_EQ((*vector)[0], 1.25);
   EXPECT_EQ((*vector)[1], 1.5);

--- a/systems/framework/test/input_port_test.cc
+++ b/systems/framework/test/input_port_test.cc
@@ -71,12 +71,12 @@ GTEST_TEST(InputPortTest, VectorTest) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       dut->Eval<std::string>(context), std::exception,
       "InputPort::Eval..: wrong value type std::string specified; "
-      "actual type was drake::systems::MyVector<3,double> "
+      "actual type was drake::systems::MyVector<double,3> "
       "for InputPort.*2.*of.*dummy.*DummySystem.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
       dut->Eval<MyVector2d>(context), std::exception,
-      "InputPort::Eval..: wrong value type .*MyVector<2,double> specified; "
-      "actual type was .*MyVector<3,double> "
+      "InputPort::Eval..: wrong value type .*MyVector<double,2> specified; "
+      "actual type was .*MyVector<double,3> "
       "for InputPort.*2.*of.*dummy.*DummySystem.*");
 }
 

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -809,7 +809,7 @@ TEST_F(LeafSystemTest, DeclareVanillaContinuousState) {
 // Tests that the leaf system reserved the declared continuous state with
 // second-order structure of interesting custom type.
 TEST_F(LeafSystemTest, DeclareTypedContinuousState) {
-  using MyVector9d = MyVector<4 + 3 + 2, double>;
+  using MyVector9d = MyVector<double, 4 + 3 + 2>;
   system_.DeclareContinuousState(MyVector9d(), 4, 3, 2);
 
   // Tests get_num_continuous_states without a context.

--- a/systems/framework/test/output_port_test.cc
+++ b/systems/framework/test/output_port_test.cc
@@ -315,7 +315,7 @@ TEST_F(LeafOutputPortTest, ThrowIfBadCalcOutput) {
       absport_general_.Calc(*context_, bad_out.get()), std::logic_error,
       "OutputPort::Calc().*expected.*std::string.*got.*int.*");
 
-  // The vector port is a MyVector<3,double>, we'll give it a BasicVector.
+  // The vector port is a MyVector3d, we'll give it a BasicVector.
   auto good_vec = vecport_general_.Allocate();
   auto bad_vec = AbstractValue::Make(BasicVector<double>(2));
   EXPECT_NO_THROW(vecport_general_.Calc(*context_, good_vec.get()));

--- a/systems/framework/test/system_output_test.cc
+++ b/systems/framework/test/system_output_test.cc
@@ -25,7 +25,7 @@ class SystemOutputTest : public ::testing::Test {
 
     // Vector output port 1 is derived from BasicVector<double>. The concrete
     // type should be preserved when copying.
-    auto my_vec = MyVector<3, double>::Make(125, 625, 3125);
+    auto my_vec = MyVector3d::Make(125, 625, 3125);
     auto my_basic_vec =
         std::make_unique<Value<BasicVector<double>>>(std::move(my_vec));
     output_.add_port(std::move(my_basic_vec));
@@ -77,7 +77,7 @@ TEST_F(SystemOutputTest, Copy) {
 
   // The type and value should be preserved.
   const BasicVector<double>* basic = copy.get_vector_data(1);
-  ASSERT_TRUE((is_dynamic_castable<const MyVector<3, double>>(basic)));
+  ASSERT_TRUE((is_dynamic_castable<const MyVector3d>(basic)));
 
   expected.resize(3);
   expected << 125, 625, 3125;

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -442,7 +442,7 @@ TEST_F(SystemTest, TransmogrifyNotSupported) {
 }
 
 template <typename T>
-using TestTypedVector = MyVector<1, T>;
+using TestTypedVector = MyVector<T, 1>;
 
 // A shell System for AbstractValue IO test.
 template <typename T>
@@ -635,9 +635,9 @@ class SystemInputErrorTest : public ::testing::Test {
 
 // A BasicVector-derived type we can complain about in the next test.
 template <typename T>
-class WrongVector : public MyVector<2, T> {
+class WrongVector : public MyVector<T, 2> {
  public:
-  using MyVector<2, T>::MyVector;
+  using MyVector<T, 2>::MyVector;
 };
 
 // Test error messages from the EvalInput methods.

--- a/systems/framework/test/userscalar_acceptance_test.cc
+++ b/systems/framework/test/userscalar_acceptance_test.cc
@@ -29,8 +29,8 @@ class TestSystem : public LeafSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(TestSystem)
 
-  using StateVector = MyVector<2, T>;
-  using OutputVector = MyVector<1, T>;
+  using StateVector = MyVector<T, 2>;
+  using OutputVector = MyVector<T, 1>;
 
   TestSystem() {
     this->DeclareContinuousState(StateVector{});

--- a/systems/framework/test_utilities/my_vector.h
+++ b/systems/framework/test_utilities/my_vector.h
@@ -14,7 +14,7 @@ namespace systems {
 
 /// A simple subclass of BasicVector<T> for testing, particularly for cases
 /// where BasicVector subtyping must be preserved through the framework.
-template <int N, typename T>
+template <typename T, int N>
 class MyVector : public BasicVector<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MyVector)
@@ -50,8 +50,8 @@ class MyVector : public BasicVector<T> {
   // type-erased!
   /// Shadows the base class Clone() method to change the return type, so that
   /// this can be used in `copyable_unique_ptr<MyVector>` and `Value<MyVector>`.
-  std::unique_ptr<MyVector<N, T>> Clone() const {
-    return dynamic_pointer_cast_or_throw<MyVector<N, T>>(
+  std::unique_ptr<MyVector<T, N>> Clone() const {
+    return dynamic_pointer_cast_or_throw<MyVector<T, N>>(
         BasicVector<T>::Clone());
   }
 
@@ -66,10 +66,10 @@ class MyVector : public BasicVector<T> {
   }
 };
 
-using MyVector1d = MyVector<1, double>;
-using MyVector2d = MyVector<2, double>;
-using MyVector3d = MyVector<3, double>;
-using MyVector4d = MyVector<4, double>;
+using MyVector1d = MyVector<double, 1>;
+using MyVector2d = MyVector<double, 2>;
+using MyVector3d = MyVector<double, 3>;
+using MyVector4d = MyVector<double, 4>;
 
 }  // namespace systems
 }  // namespace drake

--- a/systems/lcm/test/custom_drake_signal_translator.h
+++ b/systems/lcm/test/custom_drake_signal_translator.h
@@ -20,7 +20,7 @@ class CustomDrakeSignalTranslator : public LcmAndVectorBaseTranslator {
 
   // An output vector type that tests that subscribers permit non-default
   // types.
-  using CustomVector = MyVector<kDim, double>;
+  using CustomVector = MyVector<double, kDim>;
 
   CustomDrakeSignalTranslator() : LcmAndVectorBaseTranslator(kDim) {}
 

--- a/systems/primitives/test/multiplexer_test.cc
+++ b/systems/primitives/test/multiplexer_test.cc
@@ -26,7 +26,7 @@ class MultiplexerTest : public ::testing::Test {
   }
 
   void InitializeFromMyVector() {
-    mux_ = make_unique<Multiplexer<double>>(MyVector<2, double>());
+    mux_ = make_unique<Multiplexer<double>>(MyVector2d());
     context_ = mux_->CreateDefaultContext();
   }
 
@@ -88,11 +88,10 @@ TEST_F(MultiplexerTest, ModelVectorConstructor) {
   ASSERT_EQ(1, mux_->get_num_output_ports());
   ASSERT_EQ(2, mux_->get_output_port(0).size());
 
-  // Confirm that the vector is truly MyVector<2, double>.
+  // Confirm that the vector is truly MyVector2d.
   context_->FixInputPort(0, {0.0});
   context_->FixInputPort(1, {0.0});
-  typedef MyVector<2, double> MyVectorSizeTwo;
-  ASSERT_NO_THROW(mux_->get_output_port(0).Eval<MyVectorSizeTwo>(*context_));
+  ASSERT_NO_THROW(mux_->get_output_port(0).Eval<MyVector2d>(*context_));
 }
 
 TEST_F(MultiplexerTest, IsStateless) {


### PR DESCRIPTION
By placing T first, we match how Eigen naturally spells things.

(This has been bugging me for a while; finally called to my attention in #10727 diaganostics.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10793)
<!-- Reviewable:end -->
