### PR TITLE
common: Restrict which RandomGenerator APIs we promise

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -368,7 +368,9 @@ drake_cc_library(
 
 drake_cc_library(
     name = "random",
+    srcs = ["random.cc"],
     hdrs = ["random.h"],
+    deps = [":essential"],
 )
 
 drake_cc_library(
@@ -583,6 +585,13 @@ drake_cc_googletest(
         ":drake_bool",
         ":symbolic",
         "//common/test_utilities:symbolic_test_util",
+    ],
+)
+
+drake_cc_googletest(
+    name = "random_test",
+    deps = [
+        ":random",
     ],
 )
 

--- a/common/random.cc
+++ b/common/random.cc
@@ -1,0 +1,7 @@
+#include "drake/common/random.h"
+
+namespace drake {
+
+constexpr RandomGenerator::result_type RandomGenerator::default_seed;
+
+}  // namespace drake

--- a/common/random.h
+++ b/common/random.h
@@ -2,21 +2,32 @@
 
 #include <random>
 
-namespace drake {
-// TODO(russt): As discussed with sammy-tri, we could replace this with a
-// a templated class that exposes the required methods from the concept.
+#include "drake/common/drake_copyable.h"
 
-// N.B. Denoting alias in docs for Python.
-/// Defines the implementation of the stdc++ concept UniformRandomBitGenerator
-/// to be used in Drake. This is provided as a work-around to enable the use of
-/// the generator in virtual methods (which cannot be templated on the generator
-/// type) of system classes.
-///
-/// @note This is an alias for mt19937, 32-bit Mersenne Twister by Matsumoto
-/// and Nishimura, 1998. See
-/// https://en.cppreference.com/w/cpp/numeric/random/mersenne_twister_engine for
-/// more information.
-using RandomGenerator = std::mt19937;
+namespace drake {
+/// Defines Drake's canonical implementation of the UniformRandomBitGenerator
+/// C++ concept (as well as a few conventional extras beyond the concept, e.g.,
+/// seeds).  This uses the 32-bit Mersenne Twister mt19937 by Matsumoto and
+/// Nishimura, 1998.  For more information, see
+/// https://en.cppreference.com/w/cpp/numeric/random/mersenne_twister_engine
+class RandomGenerator {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(RandomGenerator)
+
+  using result_type = std::mt19937::result_type;
+
+  RandomGenerator() = default;
+  explicit RandomGenerator(result_type value) : generator_(value) {}
+
+  static result_type min() { return std::mt19937::min(); }
+  static result_type max() { return std::mt19937::max(); }
+  result_type operator()() { return generator_(); }
+
+  static constexpr result_type default_seed = std::mt19937::default_seed;
+
+ private:
+  std::mt19937 generator_{};
+};
 
 /// Drake supports explicit reasoning about a few carefully chosen random
 /// distributions.

--- a/common/test/random_test.cc
+++ b/common/test/random_test.cc
@@ -1,0 +1,33 @@
+#include "drake/common/random.h"
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace {
+
+GTEST_TEST(RandomTest, CompareWith19337) {
+  std::mt19937 oracle;
+
+  RandomGenerator dut;
+  EXPECT_EQ(dut.min(), oracle.min());
+  EXPECT_EQ(dut.max(), oracle.max());
+
+  RandomGenerator::result_type first = dut();
+  auto oracle_first = oracle();
+  EXPECT_EQ(first, oracle_first);
+
+  for (int i = 0; i < 100; ++i) {
+    EXPECT_EQ(dut(), oracle());
+  }
+}
+
+GTEST_TEST(RandomTest, Seed) {
+  RandomGenerator dut1;
+  RandomGenerator dut2(RandomGenerator::default_seed);
+  for (int i = 0; i < 100; ++i) {
+    EXPECT_EQ(dut1(), dut2());
+  }
+}
+
+}  // namespace
+}  // namespace drake


### PR DESCRIPTION
We should only promote certain items, not offer all mt19337 APIs, so that we can be clear on the API surface we are promising to maintain, and clear about the soundness of the APIs our framework relies on.

This also has the advantage that the mangled symbols in our object code become much thinner for, e.g., primitives::RandomSource, and that the `Value<T>`'s TypeHasher can understand how to process a RandomGenerator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10794)
<!-- Reviewable:end -->
