### PR TITLE
Removes TODO comment from fast_math_test build rule

### DIFF
--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -201,7 +201,7 @@ drake_cc_test(
 
 drake_cc_googletest(
     name = "fast_math_test",
-    tags = ["no_kcov"],  # TODO(liang.fok) Remove this, see #10788.
+    tags = ["no_kcov"],  # See #10788.
     deps = [
         "//:drake_shared_library",
     ],


### PR DESCRIPTION
We decided to leave the no_kcov tag long term.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10797)
<!-- Reviewable:end -->
