### PR TITLE
common: Add constexpr to RandomGenerator min/max

### DIFF
--- a/common/random.h
+++ b/common/random.h
@@ -19,8 +19,8 @@ class RandomGenerator {
   RandomGenerator() = default;
   explicit RandomGenerator(result_type value) : generator_(value) {}
 
-  static result_type min() { return std::mt19937::min(); }
-  static result_type max() { return std::mt19937::max(); }
+  static constexpr result_type min() { return std::mt19937::min(); }
+  static constexpr result_type max() { return std::mt19937::max(); }
   result_type operator()() { return generator_(); }
 
   static constexpr result_type default_seed = std::mt19937::default_seed;


### PR DESCRIPTION
This is required on macOS.

Repairs #10794.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10800)
<!-- Reviewable:end -->
