### PR TITLE
Fixes docstring for Bulb::type()

### DIFF
--- a/automotive/maliput/api/rules/traffic_lights.h
+++ b/automotive/maliput/api/rules/traffic_lights.h
@@ -94,7 +94,7 @@ class Bulb final {
   /// Returns the color of this bulb.
   const BulbColor& color() const { return color_; }
 
-  /// Returns the Bulb instances contained within this Bulb.
+  /// Returns the type of this bulb.
   const BulbType& type() const { return type_; }
 
   /// Returns the arrow's orientation. Only applicable if type() returns


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10801)
<!-- Reviewable:end -->
