### PR TITLE
Pass a lambda function to unaryExpr

### DIFF
--- a/common/symbolic_ldlt.cc
+++ b/common/symbolic_ldlt.cc
@@ -22,8 +22,8 @@ void DoCompute(
   if (!GetDistinctVariables(a).empty()) {
     throw std::logic_error("Symbolic LDLT is not supported yet");
   }
-  double (*extractor)(const E&) = &drake::ExtractDoubleOrThrow;
-  const MatrixXd new_a = a.unaryExpr(extractor);
+  const MatrixXd new_a =
+      a.unaryExpr([](const E& e) { return drake::ExtractDoubleOrThrow(e); });
   auto ldlt = new_a.ldlt();
   *matrix = ldlt.matrixLDLT();
   *l1_norm = NAN;  // We could recompute this, if we really needed it.


### PR DESCRIPTION
To fix a build problem when we compile Drake with a later version of Eigen (`201802XX`).

See 'https://eigen.tuxfamily.org/dox/classEigen_1_1ArrayBase.html#aca566bdbfe7449eb675864caa6689009'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10810)
<!-- Reviewable:end -->
