### PR TITLE
doc: Add instructions for adding model artifacts

### DIFF
--- a/doc/developers.rst
+++ b/doc/developers.rst
@@ -335,4 +335,4 @@ Version Control
     :maxdepth: 1
 
     no_push_to_origin
-
+    model_version_control

--- a/doc/model_version_control.rst
+++ b/doc/model_version_control.rst
@@ -7,18 +7,19 @@ Model Version Control
 Adding Model Artifacts in Pull Requests
 =======================================
 
-If you are adding model artifacts, such as textures or meshes, that are small
-enough (<100KB in a given directory), then add them directly to Git.
+Model artifacts have the potential to be very large, and we should avoid
+committing large files directly to Git.
 
-Otherwise, you should add your models to
-`RobotLocomotion/models <https://github.com/RobotLocomotion/models>`_.
+If your model's files are small enough (<100KB in a given directory), then you
+may add them directly to Git in a PR to master.
 
-These artifacts *should* be things that are large and should change
-infrequently, e.g. ``*.obj``, ``*.stl``, ``*.png``. These should *not* be
-things that are small, e.g. ``*.sdf``, ``*.urdf``.
+Otherwise, you should add the large files to
+`RobotLocomotion/models <https://github.com/RobotLocomotion/models>`_. Please do
+not commit files that are generally small, like ``*.sdf`` or ``*.urdf`` files,
+in ``RobotLocomotion/models``; instead, please commit those directly.
 
 Before you decide to submit models, please ensure that you have tests that
-will use them. Do not submit a PR that adds models but has zero intent to use
+will need them. Do not submit a PR that adds models but has zero intent to use
 them, as Drake is not a model repository.
 
 See below for the suggested workflow.
@@ -29,13 +30,14 @@ Develop Changes Locally
 #. Clone ``RobotLocomotion/models`` locally
 #. Create a Git branch in your local checkouts of *both* ``models`` and
    ``drake``.
-#. Update ``tools/workspace/models/repository.bzl`` to point to your checkout
-   using ``github_archive(..., local_repository_override = <path>)``.
+#. Update ``drake/tools/workspace/models/repository.bzl`` to point to your
+   ``models`` checkout using
+   ``github_archive(..., local_repository_override = <path>)``.
 #. Update ``drake/tools/workspace/models/files.bzl`` to incorporate the models
    you want.
 #. Ensure that you use ``forward_files`` to make the files available inside
    the Drake bazel workspace. For an example, see
-   ``manipulation/models/ycb/BUILD.bazel``.
+   `drake/manipulation/models/ycb/BUILD.bazel <https://github.com/RobotLocomotion/drake/blob/master/manipulation/models/ycb/BUILD.bazel>`_.
 #. Ensure your tests pass under ``bazel test``.
 
 Submit Changes in a Pull Request
@@ -52,6 +54,6 @@ Submit Changes in a Pull Request
 #. Once both PRs are approved:
 
    #) Merge your ``models`` PR.
-   #) Update Drake's ``.../models/repository.bzl`` to the latest merge commit on
-      ``master`` for ``RobotLocomotion/models``.
+   #) Update ``drake/tools/workspace/models/repository.bzl`` to the latest
+      merge commit on ``master`` for ``RobotLocomotion/models``.
    #) Merge your ``drake`` PR.

--- a/doc/model_version_control.rst
+++ b/doc/model_version_control.rst
@@ -1,0 +1,52 @@
+.. model_version_control:
+
+*********************
+Model Version Control
+*********************
+
+Adding Model Artifacts in Pull Requests
+=======================================
+
+If you are adding model artifacts, such as textures or meshes, that are small
+enough (<100KB), and there are <10MB of such files in the source tree at any
+time, then add them directly to Git.
+
+Otherwise, you should add your models to
+`RobotLocomotion/models <https://github.com/RobotLocomotion/models>`_.
+
+These artifacts SHOULD be things that are large and should change infrequently,
+e.g. ``*.obj``, ``*.stl``, ``*.png``.
+
+These should NOT be things that are small, e.g. ``*.sdf``, ``*.urdf``.
+
+See below for the suggested workflow.
+
+Develop Changes Locally
+-----------------------
+
+#. Clone ``RobotLocomotion/models`` locally
+#. Update ``tools/workspace/models/repository.bzl`` to point to your checkout
+   using ``github_archive(..., local_repository_override = <path>)``.
+#. Update ``tools/workspace/models/files.bzl`` to incorporate the models you
+   want.
+#. Ensure that you use ``forward_files`` to make the files available inside
+   the Drake bazel workspace. For an example, see
+   ``manipulation/models/ycb/BUILD.bazel``.
+#. Write your unittest that uses these files. Do NOT submit PRs that only adds
+   models but has zero intent to use them; Drake is not a model repository!
+
+Submit Changes in a Pull Request
+--------------------------------
+
+#. Push your changes to your fork of ``RobotLocomotion/models``. Make a PR.
+#. Update ``.../models/repository.bzl`` to use the commit you pushed.
+#. Submit a PR to Drake, label it as ``do not merge``. Reference your ``models``
+   PR in this PR.
+#. Get review on your Drake PR first. Once it is generally approved, then
+   request review for your ``models`` PR.
+#. Once both PRs are approved:
+
+   #) Merge your ``models`` PR.
+   #) Update Drake's ``.../models/repository.bzl`` to the latest merge commit on
+      ``master`` for ``RobotLocomotion/models``.
+   #) Ensure your PR fully passes CI, then have your PR merged.

--- a/doc/model_version_control.rst
+++ b/doc/model_version_control.rst
@@ -8,16 +8,18 @@ Adding Model Artifacts in Pull Requests
 =======================================
 
 If you are adding model artifacts, such as textures or meshes, that are small
-enough (<100KB), and there are <10MB of such files in the source tree at any
-time, then add them directly to Git.
+enough (<100KB in a given directory), then add them directly to Git.
 
 Otherwise, you should add your models to
 `RobotLocomotion/models <https://github.com/RobotLocomotion/models>`_.
 
-These artifacts SHOULD be things that are large and should change infrequently,
-e.g. ``*.obj``, ``*.stl``, ``*.png``.
+These artifacts *should* be things that are large and should change
+infrequently, e.g. ``*.obj``, ``*.stl``, ``*.png``. These should *not* be
+things that are small, e.g. ``*.sdf``, ``*.urdf``.
 
-These should NOT be things that are small, e.g. ``*.sdf``, ``*.urdf``.
+Before you decide to submit models, please ensure that you have tests that
+will use them. Do not submit a PR that adds models but has zero intent to use
+them, as Drake is not a model repository.
 
 See below for the suggested workflow.
 
@@ -25,23 +27,26 @@ Develop Changes Locally
 -----------------------
 
 #. Clone ``RobotLocomotion/models`` locally
+#. Create a Git branch in your local checkouts of *both* ``models`` and
+   ``drake``.
 #. Update ``tools/workspace/models/repository.bzl`` to point to your checkout
    using ``github_archive(..., local_repository_override = <path>)``.
-#. Update ``tools/workspace/models/files.bzl`` to incorporate the models you
-   want.
+#. Update ``drake/tools/workspace/models/files.bzl`` to incorporate the models
+   you want.
 #. Ensure that you use ``forward_files`` to make the files available inside
    the Drake bazel workspace. For an example, see
    ``manipulation/models/ycb/BUILD.bazel``.
-#. Write your unittest that uses these files. Do NOT submit PRs that only adds
-   models but has zero intent to use them; Drake is not a model repository!
+#. Ensure your tests pass under ``bazel test``.
 
 Submit Changes in a Pull Request
 --------------------------------
 
 #. Push your changes to your fork of ``RobotLocomotion/models``. Make a PR.
-#. Update ``.../models/repository.bzl`` to use the commit you pushed.
-#. Submit a PR to Drake, label it as ``do not merge``. Reference your ``models``
-   PR in this PR.
+#. Update ``drake/tools/workspace/models/models/repository.bzl`` to use the
+   commit you pushed.
+#. Submit a PR to Drake, and add a self-blocking discussion thread, such as
+   ``"Working temporary SHA1 until the models PR <LINK> is merged."``,
+   where ``<LINK>`` references your ``models`` PR.
 #. Get review on your Drake PR first. Once it is generally approved, then
    request review for your ``models`` PR.
 #. Once both PRs are approved:
@@ -49,4 +54,4 @@ Submit Changes in a Pull Request
    #) Merge your ``models`` PR.
    #) Update Drake's ``.../models/repository.bzl`` to the latest merge commit on
       ``master`` for ``RobotLocomotion/models``.
-   #) Ensure your PR fully passes CI, then have your PR merged.
+   #) Merge your ``drake`` PR.


### PR DESCRIPTION
Modeled after workflow in #10532 + https://github.com/RobotLocomotion/models/pull/5

Relates #6124 in that it is a workaround for large data storage specific to models.
(We are using Girder for Anzu, but are not yet ready to commit to this for use in Drake.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10811)
<!-- Reviewable:end -->
