### PR TITLE
common: TypeHasher handles non-type template parameters

### DIFF
--- a/common/test/value_test.cc
+++ b/common/test/value_test.cc
@@ -403,16 +403,33 @@ void CheckHash(const std::string& name) {
 }
 
 namespace {
+
 struct AnonStruct {};
 class AnonClass {};
 enum class AnonEnum { kFoo, kBar };
-template <AnonEnum K> class AnonEnumTemplate {};
+
+// A class with a non-type template argument is not hashable.
+template <AnonEnum K>
+class UnadornedAnonEnumTemplate {};
+
+// To enable hashing, the user can add a `using` statement like this.
+template <AnonEnum K>
+class NiceAnonEnumTemplate {
+ public:
+  using NonTypeTemplateParameter = std::integral_constant<AnonEnum, K>;
+};
+
 }  // namespace
 
 #ifdef __APPLE__
 constexpr bool kApple = true;
 #else
 constexpr bool kApple = false;
+#endif
+#ifdef __clang__
+constexpr bool kClang = true;
+#else
+constexpr bool kClang = false;
 #endif
 
 GTEST_TEST(TypeHashTest, WellKnownValues) {
@@ -451,16 +468,21 @@ GTEST_TEST(TypeHashTest, WellKnownValues) {
       fmt::arg("std", stdcc)));
 
   // Eigen classes.
-  CheckHash<Eigen::VectorXd>("Eigen::Matrix<double,-1,1,0,-1,1>");
-  CheckHash<Eigen::MatrixXd>("Eigen::Matrix<double,-1,-1,0,-1,-1>");
-  CheckHash<Eigen::Vector3d>("Eigen::Matrix<double,3,1,0,3,1>");
-  CheckHash<Eigen::Matrix3d>("Eigen::Matrix<double,3,3,0,3,3>");
+  CheckHash<Eigen::VectorXd>(
+      "Eigen::Matrix<double,int=-1,int=1,int=0,int=-1,int=1>");
+  CheckHash<Eigen::MatrixXd>(
+      "Eigen::Matrix<double,int=-1,int=-1,int=0,int=-1,int=-1>");
+  CheckHash<Eigen::Vector3d>(
+      "Eigen::Matrix<double,int=3,int=1,int=0,int=3,int=1>");
+  CheckHash<Eigen::Matrix3d>(
+      "Eigen::Matrix<double,int=3,int=3,int=0,int=3,int=3>");
 
   // Vectors of Eigens.
   CheckHash<std::vector<Eigen::VectorXd>>(fmt::format(
       "{std}::vector<{eigen},{std}::allocator<{eigen}>>",
       fmt::arg("std", stdcc),
-      fmt::arg("eigen", "Eigen::Matrix<double,-1,1,0,-1,1>")));
+      fmt::arg("eigen",
+          "Eigen::Matrix<double,int=-1,int=1,int=0,int=-1,int=1>")));
 
   // Everything together at once works.
   using BigType = std::vector<std::pair<
@@ -469,28 +491,42 @@ GTEST_TEST(TypeHashTest, WellKnownValues) {
       "{std}::vector<"
         "{std}::pair<"
           "const double,"
-          "{std}::shared_ptr<Eigen::Matrix<double,3,3,0,3,3>>>,"
+          "{std}::shared_ptr<{eigen}>>,"
         "{std}::allocator<{std}::pair<"
           "const double,"
-          "{std}::shared_ptr<Eigen::Matrix<double,3,3,0,3,3>>>>>",
-      fmt::arg("std", stdcc)));
+          "{std}::shared_ptr<{eigen}>>>>",
+      fmt::arg("std", stdcc),
+      fmt::arg("eigen",
+          "Eigen::Matrix<double,int=3,int=3,int=0,int=3,int=3>")));
 
-  // Templated on a value (instead of a typename).  We cannot (yet) compute a
-  // compile-time typename hash for this case.
-  EXPECT_EQ(internal::TypeHash<AnonEnumTemplate<AnonEnum::kFoo>>::value, 0);
+  // Templated on a value, but with the 'using NonTypeTemplateParameter'
+  // decoration so that the hash works.
+  const std::string kfoo =
+      kClang ? "drake::test::{anonymous}::AnonEnum::kFoo" : "0";
+  CheckHash<NiceAnonEnumTemplate<AnonEnum::kFoo>>(
+      "drake::test::{anonymous}::NiceAnonEnumTemplate<"
+        "drake::test::{anonymous}::AnonEnum=" + kfoo + ">");
 }
 
 // Tests that a type mismatched is detected for a mismatched non-type template
 // parameter, even in Release builds.  When the TypeHash fails (is zero), it's
 // important that AbstractValue fall back to using typeinfo comparison instead.
 GTEST_TEST(ValueTest, NonTypeTemplateParameter) {
-  using T1 = AnonEnumTemplate<AnonEnum::kFoo>;
-  using T2 = AnonEnumTemplate<AnonEnum::kBar>;
+  // We cannot compute hashes for non-type template parameters when the user
+  // hasn't added a `using` statement to guide us.
+  using T1 = UnadornedAnonEnumTemplate<AnonEnum::kFoo>;
+  using T2 = UnadornedAnonEnumTemplate<AnonEnum::kBar>;
+  ASSERT_EQ(internal::TypeHash<T1>::value, 0);
+  ASSERT_EQ(internal::TypeHash<T2>::value, 0);
+
+  // However, our getters and setters still catch type mismatches (by using the
+  // std::typeinfo comparison).
   Value<T1> foo_value;
   Value<T2> bar_value;
   AbstractValue& foo = foo_value;
   EXPECT_NO_THROW(foo.get_value<T1>());
   EXPECT_THROW(foo.get_value<T2>(), std::exception);
+  EXPECT_THROW(foo.get_value<int>(), std::exception);
   EXPECT_THROW(foo.SetFrom(bar_value), std::exception);
 }
 

--- a/common/value.cc
+++ b/common/value.cc
@@ -1,8 +1,37 @@
 #include "drake/common/value.h"
 
+#include <atomic>
+
 #include <fmt/format.h>
 
+#include "drake/common/text_logging.h"
+
 namespace drake {
+
+namespace internal {
+int ReportZeroHash(const std::type_info& detail) {
+  // Log a debug message noting the possible performance impairment.  Elevate
+  // it to a warning the first time it happens -- but only elevate it at most
+  // once per process, to avoid spamming.
+  static std::atomic<bool> g_has_warned{false};
+  const bool has_warned = g_has_warned.exchange(true);
+  const std::string message = fmt::format(
+      "TypeHash<T> cannot operate on T={}; Value<T> may suffer from slightly"
+      " impaired performance. If T uses a single non-type template parameter,"
+      " adding 'using NonTypeTemplateParameter = ...;' will enable hashing."
+      " See drake/common/test/value_test.cc for an example.",
+      NiceTypeName::Get(detail));
+  if (!has_warned) {
+    log()->warn(message +
+        " This is the first instance of an impaired T within this process."
+        " Additional instances will not be warned about, but you may set"
+        " the drake::log() level to 'debug' to see all instances.");
+  } else {
+    log()->debug(message);
+  }
+  return 0;
+}
+}  // namespace internal
 
 AbstractValue::~AbstractValue() = default;
 

--- a/common/value.h
+++ b/common/value.h
@@ -300,11 +300,15 @@ namespace internal {
 // Extracts a hash of the type `T` in a __PRETTY_FUNCTION__ templated on T.
 //
 // For, e.g., TypeHash<int> the pretty_func string `pretty` looks like this:
-//  GCC   7.3: "... calc() [with T = int; size_t = ..."
+//  GCC   7.3: "... calc() [with T = int; size_t K = 16; ..."
 //  Clang 6.0: "... calc() [T = int]"
 //
 // We grab the characters for T's type (e.g., "int") and hash them using FNV1a.
 //  https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+//
+// The value of @p which_argument chooses the which pretty template argument to
+// hash.  (Only one argument at a time is ever hashed.)  In the GCC example
+// above, which_argument of 0 hashes "int" and 1 hashes "16".
 //
 // If T is a template type like "std::vector<U>", we only hash "std::vector"
 // here.  We stop when we reach a '<' because each template argument is hashed
@@ -315,6 +319,18 @@ namespace internal {
 // hash "std::vector" then "U" then "std::allocator" then "U" and so it doesn't
 // matter exactly how templates end up being spelled in __PRETTY_FUNCTION__.
 //
+// When @p discard_nested is true, then stopping at '<' means our success-return
+// value will be true; if discard_nested is false then seeing any '<' is an
+// error.  Thus, we can detect and fail-fast when our specializations for
+// template parameters fail to match.
+//
+// When @p discard_cast is true, we will omit a leading cast-expression after
+// the equals sign, e.g., when pretty looks like "... [with K = (MyEnum)0]".
+// If we see any other open-paren than this possibly-skipped cast, then our
+// success-return value will be false.  Thus, we can detect and fail-fast when
+// our specializations for non-type template parameters fail to match, or when
+// T's like function pointer signatures appear.
+//
 // Note that the compiler is required to inform us at compile-time if there are
 // undefined operations in the below, such as running off the end of a string.
 // Therefore, so as long as this function compiles, we know that `pretty` had
@@ -322,12 +338,25 @@ namespace internal {
 //
 // Returns true on success / false on failure.
 constexpr bool hash_template_argument_from_pretty_func(
-    const char* pretty, bool discard_nested, FNV1aHasher* result) {
-  // Advance to the typename after the "T = ".
+    const char* pretty, int which_argument,
+    bool discard_nested, bool discard_cast,
+    FNV1aHasher* result) {
+  // Advance to the desired template argument.  For example, if which_argument
+  // is 0 and pretty == "... calc() [T = int]", then advance to the typename
+  // after the "T = " so that the cursor `p` is pointing at the 'i' in "int".
   const char* p = pretty;
-  for (; (*p != '='); ++p) {}  // Advance to '='.
-  ++p;                         // Advance to ' '.
-  ++p;                         // Advance to the typename we want.
+  for (int n = 0; n <= which_argument; ++n) {
+    for (; (*p != '='); ++p) {}  // Advance to the '=' that we want.
+    ++p;                         // Advance to ' '.
+    ++p;                         // Advance to the typename we want.
+  }
+
+  // For enums, GCC's pretty says "(MyEnum)0" not "MyEnum::kFoo".  We'll strip
+  // off the useless parenthetical.
+  if (discard_cast && (*p == '(')) {
+    for (; (*p != ')'); ++p) {}  // Advance to the ')'.
+    ++p;
+  }
 
   // Hash the characters in the typename, ending either when the typename ends
   // (';' or ']') or maybe when the first template argument begins ('<').
@@ -361,7 +390,7 @@ constexpr bool hash_template_argument_from_pretty_func(
     }
 
     // If the type has parens (such as a function pointer or std::function),
-    // then we can't handle it.  Add support for function types involves not
+    // then we can't handle it.  Adding support for function types involves not
     // only unpacking the return and argument types, but also adding support
     // for const / volatile / reference / etc.).
     if (*p == '(') {
@@ -375,21 +404,39 @@ constexpr bool hash_template_argument_from_pretty_func(
   return true;
 }
 
+// Akin to C++17 std::void_t<>.
+template <typename...>
+using typehasher_void_t = void;
+
+// Traits type to ask whether T::NonTypeTemplateParameter exists.
+template <typename T, typename U = void>
+struct TypeHasherHasNonTypeTemplateParameter {
+  static constexpr bool value = false;
+};
+template <typename T>
+struct TypeHasherHasNonTypeTemplateParameter<
+    T, typehasher_void_t<typename T::NonTypeTemplateParameter>> {
+  static constexpr bool value = true;
+};
+
 // Provides a struct templated on T so that __PRETTY_FUNCTION__ will express T
 // at compile time.  The calc() function feeds the string representation of T
 // to `result`.  Returns true on success / false on failure.  This base struct
 // handles non-templated values (e.g., int); in a specialization down below, we
 // handle template template T's.
-template <typename T>
+template <typename T, bool = TypeHasherHasNonTypeTemplateParameter<T>::value>
 struct TypeHasher {
   // Returns true on success / false on failure.
   static constexpr bool calc(FNV1aHasher* result) {
     // With discard_nested disabled here, the hasher will fail if it sees a
     // '<' in the typename.  If that happens, it means that the parameter pack
     // specialization(s) below did not match as expected.
+    const int which_argument = 0;
     const bool discard_nested = false;
+    const bool discard_cast = false;
     return hash_template_argument_from_pretty_func(
-        __PRETTY_FUNCTION__, discard_nested, result);
+        __PRETTY_FUNCTION__, which_argument,
+        discard_nested, discard_cast, result);
   }
 };
 
@@ -420,12 +467,15 @@ struct ParameterPackHasher<A, B...> {
 // each template argument separately from T's outer type (as explained in the
 // overview above).
 template <template <typename...> class T, class... Args>
-struct TypeHasher<T<Args...>> {
+struct TypeHasher<T<Args...>, false> {
   static constexpr bool calc(FNV1aHasher* result) {
     // First, hash just the "T" template template type, not the "<Args...>".
+    const int which_argument = 0;
     const bool discard_nested = true;
+    const bool discard_cast = false;
     bool success = hash_template_argument_from_pretty_func(
-        __PRETTY_FUNCTION__, discard_nested, result);
+        __PRETTY_FUNCTION__, which_argument,
+        discard_nested, discard_cast, result);
     // Then, hash the "<Args...>".  Add delimiters so that parameter pack
     // nesting is correctly hashed.
     result->add_byte('<');
@@ -435,16 +485,45 @@ struct TypeHasher<T<Args...>> {
   }
 };
 
-// Provides a struct templated on an `int`, similar to TypeHasher<T> but where
-// the template parameters are int(s), not typenames.
-template <int N>
-struct IntHasher {
+// Provides a struct templated on `Typename Konstant`, similar to TypeHasher<T>
+// but here the "Konstant"'s string is hashed, not a typename.
+template <typename T, T K>
+struct ValueHasher {
   static constexpr bool calc(FNV1aHasher* result) {
+    const int which_argument = 1;
     const bool discard_nested = false;
+    const bool discard_cast = true;
     return hash_template_argument_from_pretty_func(
-        __PRETTY_FUNCTION__, discard_nested, result);
+        __PRETTY_FUNCTION__, which_argument,
+        discard_nested, discard_cast, result);
   }
 };
+
+// Specializes TypeHasher for a non-type template value so that we have the
+// value of the template argument separately from T's outer type (as explained
+// in the overview above).
+template <typename T>
+struct TypeHasher<T, true> {
+  static constexpr bool calc(FNV1aHasher* result) {
+    // First, hash just the "T" template template type, not the "<U u>".
+    const int which_argument = 0;
+    const bool discard_nested = true;
+    const bool discard_cast = false;
+    hash_template_argument_from_pretty_func(
+        __PRETTY_FUNCTION__, which_argument,
+        discard_nested, discard_cast, result);
+    // Then, hash the "<U=u>".
+    using U = typename T::NonTypeTemplateParameter::value_type;
+    result->add_byte('<');
+    bool success = TypeHasher<U>::calc(result);
+    result->add_byte('=');
+    success = success &&
+        ValueHasher<U, T::NonTypeTemplateParameter::value>::calc(result);
+    result->add_byte('>');
+    return success;
+  }
+};
+
 // Provides a struct templated on Ns... with a calc() that hashes a sequence of
 // ints (an int parameter pack).
 template <int... Ns>
@@ -458,7 +537,11 @@ struct IntPackHasher<> {
 template <int N, int... Ns>
 struct IntPackHasher<N, Ns...> {
   static constexpr bool calc(FNV1aHasher* result) {
-    bool success = IntHasher<N>::calc(result);
+    result->add_byte('i');
+    result->add_byte('n');
+    result->add_byte('t');
+    result->add_byte('=');
+    bool success = ValueHasher<int, N>::calc(result);
     if (sizeof...(Ns)) {
       result->add_byte(',');
       success = success && IntPackHasher<Ns...>::calc(result);
@@ -470,12 +553,15 @@ struct IntPackHasher<N, Ns...> {
 // Specializes TypeHasher for Eigen-like types.
 template <template <typename, int, int...> class T,
           typename U, int N, int... Ns>
-struct TypeHasher<T<U, N, Ns...>> {
+struct TypeHasher<T<U, N, Ns...>, false> {
   static constexpr bool calc(FNV1aHasher* result) {
     // First, hash just the "T" template template type, not the "<U, N, Ns...>".
+    const int which_argument = 0;
     const bool discard_nested = true;
+    const bool discard_cast = false;
     bool success = hash_template_argument_from_pretty_func(
-        __PRETTY_FUNCTION__, discard_nested, result);
+        __PRETTY_FUNCTION__, which_argument,
+        discard_nested, discard_cast, result);
     // Then, hash the "<U, N, Ns...>".  Add delimiters so that parameter pack
     // nesting is correctly hashed.
     result->add_byte('<');
@@ -515,6 +601,25 @@ struct TypeHash {
 };
 template <typename T>
 constexpr size_t TypeHash<T>::value;
+
+// This is called once per process per T whose type_hash is 0.  It logs a
+// TypeHash failure message to Drake's text log.
+int ReportZeroHash(const std::type_info& detail);
+
+// Any code in this file that uses TypeHash::value calls us for its T.
+template <typename T, size_t hash>
+struct ReportUseOfTypeHash {
+  static void used() {
+    // By default, do nothing.
+  }
+};
+template <typename T>
+struct ReportUseOfTypeHash<T, 0> {
+  static void used() {
+    static int dummy = ReportZeroHash(typeid(T));
+    (void)(dummy);
+  }
+};
 
 // For copyable types, we can store a T directly within Value<T> and we don't
 // need any special tricks to create or retrieve it.
@@ -625,6 +730,7 @@ void AbstractValue::SetValueOrThrow(const T& value_to_set) {
 template <typename T>
 bool AbstractValue::is_maybe_matched() const {
   constexpr auto hash = internal::TypeHash<T>::value;
+  internal::ReportUseOfTypeHash<T, hash>::used();
   return (kDrakeAssertIsArmed || !hash) ? (typeid(T) == static_type_info()) :
       (hash == type_hash_);
 }
@@ -655,20 +761,25 @@ template <typename T1, typename T2>
 Value<T>::Value()
     : AbstractValue(Wrap{internal::TypeHash<T>::value}),
       value_{} {
+  internal::ReportUseOfTypeHash<T, internal::TypeHash<T>::value>::used();
   Traits::reinitialize_if_necessary(&value_);
 }
 
 template <typename T>
 Value<T>::Value(const T& v)
     : AbstractValue(Wrap{internal::TypeHash<T>::value}),
-      value_(Traits::to_storage(v)) {}
+      value_(Traits::to_storage(v)) {
+  internal::ReportUseOfTypeHash<T, internal::TypeHash<T>::value>::used();
+}
 
 // We construct-in-place into our Storage value_.
 template <typename T>
 template <typename Arg1, typename... Args, typename>
 Value<T>::Value(Arg1&& arg1, Args&&... args)
     : AbstractValue(Wrap{internal::TypeHash<T>::value}),
-      value_{std::forward<Arg1>(arg1), std::forward<Args>(args)...} {}
+      value_{std::forward<Arg1>(arg1), std::forward<Args>(args)...} {
+  internal::ReportUseOfTypeHash<T, internal::TypeHash<T>::value>::used();
+}
 
 // We move a unique_ptr into our Storage value_.
 template <typename T>
@@ -676,7 +787,9 @@ template <typename Arg1, typename... Args, typename, typename>
 Value<T>::Value(Arg1&& arg1, Args&&... args)
     : AbstractValue(Wrap{internal::TypeHash<T>::value}),
       value_{std::make_unique<T>(
-          std::forward<Arg1>(arg1), std::forward<Args>(args)...)} {}
+          std::forward<Arg1>(arg1), std::forward<Args>(args)...)} {
+  internal::ReportUseOfTypeHash<T, internal::TypeHash<T>::value>::used();
+}
 
 // An explanation of the this constructor:
 //
@@ -700,7 +813,9 @@ Value<T>::Value(Arg1&& arg1, Args&&... args)
 template <typename T>
 Value<T>::Value(std::unique_ptr<T> v)
     : AbstractValue(Wrap{internal::TypeHash<T>::value}),
-      value_{Traits::to_storage(std::move(v))} {}
+      value_{Traits::to_storage(std::move(v))} {
+  internal::ReportUseOfTypeHash<T, internal::TypeHash<T>::value>::used();
+}
 
 template <typename T>
 const T& Value<T>::get_value() const {

--- a/systems/sensors/image.h
+++ b/systems/sensors/image.h
@@ -58,6 +58,11 @@ class Image {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Image)
 
+  /// This is used by generic helpers such as drake::Value to deduce a non-type
+  /// template argument.
+  using NonTypeTemplateParameter =
+      std::integral_constant<PixelType, kPixelType>;
+
   /// An alias for ImageTraits that contains the data type for a channel,
   /// the number of channels and the pixel format in it.
   using Traits = ImageTraits<kPixelType>;


### PR DESCRIPTION
(Amends #10727 with the opportunity for more speed and/or better diagnostics.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10814)
<!-- Reviewable:end -->
