### PR TITLE
framework: Prefer EigenPtr to mutable EigenRef

### DIFF
--- a/systems/analysis/runge_kutta3_integrator-inl.h
+++ b/systems/analysis/runge_kutta3_integrator-inl.h
@@ -78,9 +78,9 @@ bool RungeKutta3Integrator<T>::DoStep(const T& h) {
   // (at t⁽ᵃ⁾=t₀+h/2, x⁽ᵃ⁾, u⁽ᵃ⁾).
   // This call invalidates t- and xc-dependent cache entries.
   VectorBase<T>& xc = context.SetTimeAndGetMutableContinuousStateVector(
-      t0 + h / 2);                     // t⁽ᵃ⁾ ← t₀ + h/2
-  xc.CopyToPreSizedVector(save_xc0_);  // Save xc₀ while we can.
-  xc.PlusEqScaled(h / 2, xcdot0);      // xc⁽ᵃ⁾ ← xc₀ + h/2 xcdot₀
+      t0 + h / 2);                      // t⁽ᵃ⁾ ← t₀ + h/2
+  xc.CopyToPreSizedVector(&save_xc0_);  // Save xc₀ while we can.
+  xc.PlusEqScaled(h / 2, xcdot0);       // xc⁽ᵃ⁾ ← xc₀ + h/2 xcdot₀
 
   derivs1_->get_mutable_vector().SetFrom(
       this->EvalTimeDerivatives(context).get_vector());
@@ -115,9 +115,9 @@ bool RungeKutta3Integrator<T>::DoStep(const T& h) {
   // ε = | xc₁ - (xc₀ + h xcdot⁽ᵃ⁾) | = | xc₀ + h xcdot⁽ᵃ⁾ - xc₁ |
   err_est_vec_ = save_xc0_;  // ε ← xc₀
   // TODO(sherm1) This is xcdot₀, not xcdot⁽ᵃ⁾! Should be xcdot_a; issue #10633.
-  xcdot0.ScaleAndAddToVector(h, err_est_vec_);      // ε += h xcdot₀   (WRONG!)
-  // xcdot_a.ScaleAndAddToVector(h, err_est_vec_);  // ε += h xcdot⁽ᵃ⁾ (RIGHT!)
-  xc.ScaleAndAddToVector(-1.0, err_est_vec_);       // ε -= xc₁
+  xcdot0.ScaleAndAddToVector(h, &err_est_vec_);      // ε += h xcdot₀   (WRONG!)
+  // xcdot_a.ScaleAndAddToVector(h, &err_est_vec_);  // ε += h xcdot⁽ᵃ⁾ (RIGHT!)
+  xc.ScaleAndAddToVector(-1.0, &err_est_vec_);       // ε -= xc₁
   err_est_vec_ = err_est_vec_.cwiseAbs();
   this->get_mutable_error_estimate()->SetFromVector(err_est_vec_);
 

--- a/systems/framework/basic_vector.h
+++ b/systems/framework/basic_vector.h
@@ -109,16 +109,17 @@ class BasicVector : public VectorBase<T> {
   VectorX<T> CopyToVector() const override { return values_; }
 
   void ScaleAndAddToVector(const T& scale,
-                           Eigen::Ref<VectorX<T>> vec) const override {
-    if (vec.rows() != size()) {
+                           EigenPtr<VectorX<T>> vec) const override {
+    DRAKE_THROW_UNLESS(vec != nullptr);
+    if (vec->rows() != size()) {
       throw std::out_of_range("Addends must be the same size.");
     }
-    vec += scale * values_;
+    *vec += scale * values_;
   }
 
   void SetZero() override { values_.setZero(); }
 
-  /// Computes the infinity norm for this vector.
+  DRAKE_DEPRECATED("2019-06-01", "Use get_value() + Eigen lpNorm.")
   T NormInf() const override {
     return values_.template lpNorm<Eigen::Infinity>();
   }
@@ -179,7 +180,7 @@ class BasicVector : public VectorBase<T> {
       const std::initializer_list<std::pair<T, const VectorBase<T>&>>& rhs_scal)
       override {
     for (const auto& operand : rhs_scal)
-      operand.second.ScaleAndAddToVector(operand.first, values_);
+      operand.second.ScaleAndAddToVector(operand.first, &values_);
   }
 
   // The column vector of T values.

--- a/systems/framework/test/basic_vector_test.cc
+++ b/systems/framework/test/basic_vector_test.cc
@@ -151,13 +151,18 @@ GTEST_TEST(BasicVectorTest, ReinitializeInvalid) {
 
 // Tests the infinity norm computation
 GTEST_TEST(BasicVectorTest, NormInf) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   BasicVector<double> vec(2);
   vec.get_mutable_value() << 3, -4;
   EXPECT_EQ(vec.NormInf(), 4);
+#pragma GCC diagnostic pop
 }
 
 // Tests the infinity norm for an autodiff type.
 GTEST_TEST(BasicVectorTest, NormInfAutodiff) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   // Set up the device under test ("dut").
   // The DUT is a vector with two values [-11.5, 22.5].
   // The ∂/∂t of DUT is [1.5, 3.5] (where t is some arbitrary variable).
@@ -187,6 +192,7 @@ GTEST_TEST(BasicVectorTest, NormInfAutodiff) {
   expected_norminf.derivatives() = Vector1d(-1.5);
   EXPECT_EQ(dut.NormInf().value(), expected_norminf.value());
   EXPECT_EQ(dut.NormInf().derivatives(), expected_norminf.derivatives());
+#pragma GCC diagnostic pop
 }
 
 // Tests all += * operations for BasicVector.

--- a/systems/framework/test/subvector_test.cc
+++ b/systems/framework/test/subvector_test.cc
@@ -50,11 +50,11 @@ TEST_F(SubvectorTest, Copy) {
   EXPECT_EQ(expected, subvec.CopyToVector());
 
   Eigen::Vector2d pre_sized_good;
-  subvec.CopyToPreSizedVector(pre_sized_good);
+  subvec.CopyToPreSizedVector(&pre_sized_good);
   EXPECT_EQ(expected, pre_sized_good);
 
   Eigen::Vector3d pre_sized_bad;
-  EXPECT_THROW(subvec.CopyToPreSizedVector(pre_sized_bad),
+  EXPECT_THROW(subvec.CopyToPreSizedVector(&pre_sized_bad),
       std::exception);
 }
 
@@ -110,11 +110,18 @@ TEST_F(SubvectorTest, ScaleAndAddToVector) {
   target << 100, 1000;
 
   Subvector<double> subvec(vector_.get(), 1, kSubVectorLength);
-  subvec.ScaleAndAddToVector(1, target);
+  subvec.ScaleAndAddToVector(1, &target);
 
   Eigen::Vector2d expected;
   expected << 102, 1003;
   EXPECT_EQ(expected, target);
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  subvec.ScaleAndAddToVector(1, target);
+  expected << 104, 1006;
+  EXPECT_EQ(expected, target);
+#pragma GCC diagnostic pop
 }
 
 // TODO(david-german-tri): Once GMock is available in the Drake build, add a
@@ -130,7 +137,7 @@ TEST_F(SubvectorTest, PlusEqInvalidSize) {
 TEST_F(SubvectorTest, AddToVectorInvalidSize) {
   VectorX<double> target(3);
   Subvector<double> subvec(vector_.get(), 1, kSubVectorLength);
-  EXPECT_THROW(subvec.ScaleAndAddToVector(1, target), std::out_of_range);
+  EXPECT_THROW(subvec.ScaleAndAddToVector(1, &target), std::out_of_range);
 }
 
 // Tests SetZero functionality in VectorBase.
@@ -142,12 +149,17 @@ TEST_F(SubvectorTest, SetZero) {
 
 // Tests the infinity norm.
 TEST_F(SubvectorTest, InfNorm) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   Subvector<double> subvec(vector_.get(), 0, kSubVectorLength);
   EXPECT_EQ(subvec.NormInf(), 2);
+#pragma GCC diagnostic pop
 }
 
 // Tests the infinity norm for an autodiff type.
 TEST_F(SubvectorTest, InfNormAutodiff) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   AutoDiffXd element0;
   element0.value() = -11.5;
   element0.derivatives() = Eigen::Vector2d(1.5, -2.5);
@@ -172,6 +184,7 @@ TEST_F(SubvectorTest, InfNormAutodiff) {
   expected_norminf.derivatives() = Eigen::Vector2d(-1.5, 2.5);
   EXPECT_EQ(subvec.NormInf().value(), expected_norminf.value());
   EXPECT_EQ(subvec.NormInf().derivatives(), expected_norminf.derivatives());
+#pragma GCC diagnostic pop
 }
 
 // Tests all += * operations for VectorBase.


### PR DESCRIPTION
CopyToPreSizedVector is only a day old (#10638), so is changed directly rather than deprecated.

Also deprecate unused NormInf -- we should not reimplement Eigen on top of VectorBase.  That's what Eigen is for.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10819)
<!-- Reviewable:end -->
