### PR TITLE
Removes debug code from random_clutter_demo.cc

### DIFF
--- a/attic/manipulation/scene_generation/random_clutter_demo.cc
+++ b/attic/manipulation/scene_generation/random_clutter_demo.cc
@@ -84,11 +84,6 @@ int DoMain() {
 
   auto scene_tree = GenerateSceneTree(&clutter_instances, FLAGS_repetitions);
 
-  std::stringstream clutter_instances_string;
-  for (auto& it : clutter_instances) {
-    clutter_instances_string << it << ",";
-  }
-
   VectorX<double> q_nominal =
       VectorX<double>::Random(scene_tree->get_num_positions());
 


### PR DESCRIPTION
A std::stringstream was being instantiated and filled but not used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10822)
<!-- Reviewable:end -->
