### PR TITLE
geometry: API for normal direction from pairwise signed distances.

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -109,7 +109,7 @@ PYBIND11_MODULE(geometry, m) {
 
   // SignedDistancePair
   py::class_<SignedDistancePair<T>>(m, "SignedDistancePair")
-      .def(py::init<>(), doc.SignedDistancePair.ctor.doc)
+      .def(py::init<>(), doc.SignedDistancePair.ctor.doc_6args)
       .def_readwrite(
           "id_A", &SignedDistancePair<T>::id_A, doc.SignedDistancePair.id_A.doc)
       .def_readwrite(
@@ -119,7 +119,9 @@ PYBIND11_MODULE(geometry, m) {
       .def_readwrite("p_BCb", &SignedDistancePair<T>::p_BCb,
           doc.SignedDistancePair.p_BCb.doc)
       .def_readwrite("distance", &SignedDistancePair<T>::distance,
-          doc.SignedDistancePair.distance.doc);
+          doc.SignedDistancePair.distance.doc)
+      .def_readwrite("nhat_BA_W", &SignedDistancePair<T>::nhat_BA_W,
+          doc.SignedDistancePair.nhat_BA_W.doc);
 
   // PenetrationAsPointPair
   py::class_<PenetrationAsPointPair<T>>(m, "PenetrationAsPointPair")

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -559,12 +559,13 @@ bool DistanceCallback(fcl::CollisionObjectd* fcl_object_A_ptr,
     fcl::DistanceResultd result;
     ComputeNarrowPhaseDistance(&fcl_object_A, &fcl_object_B, geometry_map,
                                distance_data.request, &result);
-    const Vector3d p_ACa =
-        fcl_object_A.getTransform().inverse() * result.nearest_points[0];
-    const Vector3d p_BCb =
-        fcl_object_B.getTransform().inverse() * result.nearest_points[1];
+    const Vector3d p_WCa = result.nearest_points[0];
+    const Vector3d p_WCb = result.nearest_points[1];
+    const Vector3d p_ACa = fcl_object_A.getTransform().inverse() * p_WCa;
+    const Vector3d p_BCb = fcl_object_B.getTransform().inverse() * p_WCb;
+    const Vector3d nhat_BA_W = (p_WCa - p_WCb) / result.min_distance;
     distance_data.nearest_pairs->emplace_back(id_A, id_B, p_ACa, p_BCb,
-                                              result.min_distance);
+                                              result.min_distance, nhat_BA_W);
   }
 
   // Returning true would tell the broadphase manager to terminate early. Since

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -566,10 +566,12 @@ bool DistanceCallback(fcl::CollisionObjectd* fcl_object_A_ptr,
     // TODO(DamrongGuoy): For sphere-{sphere,box,cylinder} we will start
     //  working on the right nhat when min_distance is 0 or almost 0 after
     //  PR #10813 lands to avoid conflicts with this PR #10823. For now,
-    //  we simply return nan in nhat when min_distance is 0 or almost 0.
+    //  we simply return NaN in nhat when min_distance is 0 or almost 0.
     const Vector3d nhat_BA_W =
         (std::abs(result.min_distance) < std::numeric_limits<double>::epsilon())
-            ? Vector3d(std::nan(""), std::nan(""), std::nan(""))
+            ? Vector3d(std::numeric_limits<double>::quiet_NaN(),
+                       std::numeric_limits<double>::quiet_NaN(),
+                       std::numeric_limits<double>::quiet_NaN())
             : (p_WCa - p_WCb) / result.min_distance;
     distance_data.nearest_pairs->emplace_back(id_A, id_B, p_ACa, p_BCb,
                                               result.min_distance, nhat_BA_W);

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -563,7 +563,14 @@ bool DistanceCallback(fcl::CollisionObjectd* fcl_object_A_ptr,
     const Vector3d p_WCb = result.nearest_points[1];
     const Vector3d p_ACa = fcl_object_A.getTransform().inverse() * p_WCa;
     const Vector3d p_BCb = fcl_object_B.getTransform().inverse() * p_WCb;
-    const Vector3d nhat_BA_W = (p_WCa - p_WCb) / result.min_distance;
+    // TODO(DamrongGuoy): We will compute the right nhat when min_distance is
+    //  0 or almost 0 after PR #10813 lands to avoid conflicts with this
+    //  PR #10823. For now, we simply return nan in nhat when min_distance
+    //  is 0 or almost 0.
+    const Vector3d nhat_BA_W =
+        (std::abs(result.min_distance) < 1e-14)
+            ? Vector3d(std::nan(""), std::nan(""), std::nan(""))
+            : (p_WCa - p_WCb) / result.min_distance;
     distance_data.nearest_pairs->emplace_back(id_A, id_B, p_ACa, p_BCb,
                                               result.min_distance, nhat_BA_W);
   }

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -559,16 +559,16 @@ bool DistanceCallback(fcl::CollisionObjectd* fcl_object_A_ptr,
     fcl::DistanceResultd result;
     ComputeNarrowPhaseDistance(&fcl_object_A, &fcl_object_B, geometry_map,
                                distance_data.request, &result);
-    const Vector3d p_WCa = result.nearest_points[0];
-    const Vector3d p_WCb = result.nearest_points[1];
+    const Vector3d& p_WCa = result.nearest_points[0];
+    const Vector3d& p_WCb = result.nearest_points[1];
     const Vector3d p_ACa = fcl_object_A.getTransform().inverse() * p_WCa;
     const Vector3d p_BCb = fcl_object_B.getTransform().inverse() * p_WCb;
-    // TODO(DamrongGuoy): We will compute the right nhat when min_distance is
-    //  0 or almost 0 after PR #10813 lands to avoid conflicts with this
-    //  PR #10823. For now, we simply return nan in nhat when min_distance
-    //  is 0 or almost 0.
+    // TODO(DamrongGuoy): For sphere-{sphere,box,cylinder} we will start
+    //  working on the right nhat when min_distance is 0 or almost 0 after
+    //  PR #10813 lands to avoid conflicts with this PR #10823. For now,
+    //  we simply return nan in nhat when min_distance is 0 or almost 0.
     const Vector3d nhat_BA_W =
-        (std::abs(result.min_distance) < 1e-14)
+        (std::abs(result.min_distance) < std::numeric_limits<double>::epsilon())
             ? Vector3d(std::nan(""), std::nan(""), std::nan(""))
             : (p_WCa - p_WCb) / result.min_distance;
     distance_data.nearest_pairs->emplace_back(id_A, id_B, p_ACa, p_BCb,

--- a/geometry/query_results/signed_distance_pair.h
+++ b/geometry/query_results/signed_distance_pair.h
@@ -62,12 +62,12 @@ struct SignedDistancePair{
   SignedDistancePair() {}
 
   /** Constructor
-   @param a         The id of the first geometry (A).
-   @param b         The id of the second geometry (B).
-   @param p_ACa_in  The witness point on geometry A's surface, in A's frame.
-   @param p_BCb_in  The witness point on geometry B's surface, in B's frame.
-   @param dist      The signed distance between p_A and p_B.
-   @param nhat_BA_W_in  ∇φ_B(c_B) expressed in the world frame.
+   @param a            The id of the first geometry (A).
+   @param b            The id of the second geometry (B).
+   @param p_ACa_in     The witness point on geometry A's surface, in A's frame.
+   @param p_BCb_in     The witness point on geometry B's surface, in B's frame.
+   @param dist         The signed distance between p_A and p_B.
+   @param nhat_BA_W_in ∇φ_B(c_B) expressed in the world frame.
    @pre nhat_BA_W_in is unit-length. */
   SignedDistancePair(GeometryId a, GeometryId b, const Vector3<T>& p_ACa_in,
                      const Vector3<T>& p_BCb_in, T dist,
@@ -95,7 +95,7 @@ struct SignedDistancePair{
    @param b         The id of the second geometry (B).
    @param p_ACa_in  The witness point on geometry A's surface, in A's frame.
    @param p_BCb_in  The witness point on geometry B's surface, in B's frame.
-   @param dist    The signed distance between p_A and p_B.*/
+   @param dist      The signed distance between p_A and p_B.*/
   SignedDistancePair(GeometryId a, GeometryId b, const Vector3<T>& p_ACa_in,
                      const Vector3<T>& p_BCb_in, T dist)
       : id_A(a),

--- a/geometry/query_results/signed_distance_pair.h
+++ b/geometry/query_results/signed_distance_pair.h
@@ -70,7 +70,7 @@ struct SignedDistancePair{
    @param nhat_BA_W_in ∇φ_B(c_B) expressed in the world frame.
    @pre nhat_BA_W_in is unit-length. */
   SignedDistancePair(GeometryId a, GeometryId b, const Vector3<T>& p_ACa_in,
-                     const Vector3<T>& p_BCb_in, T dist,
+                     const Vector3<T>& p_BCb_in, const T& dist,
                      const Vector3<T>& nhat_BA_W_in)
       : id_A(a),
         id_B(b),
@@ -97,7 +97,7 @@ struct SignedDistancePair{
    @param p_BCb_in  The witness point on geometry B's surface, in B's frame.
    @param dist      The signed distance between p_A and p_B.*/
   SignedDistancePair(GeometryId a, GeometryId b, const Vector3<T>& p_ACa_in,
-                     const Vector3<T>& p_BCb_in, T dist)
+                     const Vector3<T>& p_BCb_in, const T& dist)
       : id_A(a),
         id_B(b),
         p_ACa(p_ACa_in),

--- a/geometry/query_results/signed_distance_pair.h
+++ b/geometry/query_results/signed_distance_pair.h
@@ -22,16 +22,39 @@ struct SignedDistancePair{
    @param p_B     The witness point on geometry B's surface, in B's frame.
    @param dist    The signed distance between p_A and p_B. When A and B are
    separated, dist > 0; when A and B are touching or penetrating, dist <= 0.
-   @param n_WAB   The unit normal vector between witness points from A to B,
-                  in world frame.*/
+   @param n_BA_W  The unit direction of the gradient of the signed distance
+                  field of B evaluated at p_B, expressed in world frame. By
+                  definition, the unit direction of the gradient of the signed
+                  distance field of A evaluated at Ca must be in the opposite
+                  direction.*/
   SignedDistancePair(GeometryId a, GeometryId b, const Vector3<T>& p_A,
-                     const Vector3<T>& p_B, T dist, const Vector3<T>& n_WAB)
+                     const Vector3<T>& p_B, T dist, const Vector3<T>& n_BA_W)
       : id_A(a),
         id_B(b),
         p_ACa(p_A),
         p_BCb(p_B),
         distance(dist),
-        normal_WAB(n_WAB) {}
+        nhat_BA_W(n_BA_W) {}
+
+  // TODO(DamrongGuoy): Remove this constructor when it's not needed.  Right
+  //   now the unit tests need it.
+  /** Constructor.
+   We keep this constructor tempoarily for backward compatibility.
+   @param a       The id of the first geometry (A).
+   @param b       The id of the second geometry (B).
+   @param p_A     The witness point on geometry A's surface, in A's frame.
+   @param p_B     The witness point on geometry B's surface, in B's frame.
+   @param dist    The signed distance between p_A and p_B. When A and B are
+   separated, dist > 0; when A and B are touching or penetrating, dist <= 0.*/
+  SignedDistancePair(GeometryId a, GeometryId b, const Vector3<T>& p_A,
+                     const Vector3<T>& p_B, T dist)
+      : id_A(a),
+        id_B(b),
+        p_ACa(p_A),
+        p_BCb(p_B),
+        distance(dist),
+        nhat_BA_W(Vector3<T>::Zero()) {}
+
 
   /** The id of the first geometry in the pair. */
   GeometryId id_A;
@@ -49,16 +72,28 @@ struct SignedDistancePair{
   Vector3<T> p_ACa;
   /** The witness point on geometry B's surface, expressed in B's frame. */
   Vector3<T> p_BCb;
-  /** The distance between p_A_A and p_B_B (measured in a common frame). */
+  /** The signed distance between p_ACa and p_BCb (measured in a common frame).
+   When A and B are separated, distance > 0; when A and B are touching or
+   penetrating, distance <= 0.
+   */
   T distance{};
-  /** The unit normal vector from Ca to Cb, expressed in world frame,
-   *  normal_WAB = (p_WCb - p_WCa) / |p_WCb - p_WCa|.
-   *  @note When A and B are touching, defined as the signed distance = 0, we
-   *  define normal_WAB as the direction through which moving B will maximize
-   *  the distance. It is the outward unit normal vector to the surface of A
-   *  at Ca, if the surface is smooth at Ca.
-   *    */
-  Vector3<T> normal_WAB;
+  /** The unit direction of the gradient of the signed distance field of B
+   evaluated at Cb, expressed in world frame. By definition, the unit direction
+   of the gradient of the signed distance field of A evaluated at Ca must be
+   in the opposite direction.
+   @note For non-touching objects, nhat_BA_W points from Cb to Ca, i.e.,
+   nhat_BA_W = (p_WCa - p_WCb) / (signed)distance.
+   @note Guaranteed to be defined, even when the objects are touching.
+   @note It is always an outward unit normal vector to the surface of B
+   at Cb whether A and B are separated, touching, or penetrating.
+   @note If the normal vector to the surface of B at Cb is not unique but the
+   outward normal vector n_A to the surface of A at Ca is unique, nhat_BA_W
+   will be in the opposite direction of n_A.
+   @note If both the normal vector to the surface of B at Cb and that of A at
+   Ca are not unique, nhat_BA_W will be one of the valid outward unit normal
+   vector to the surface of B at Cb.
+   */
+  Vector3<T> nhat_BA_W;
 };
 
 }  // namespace geometry

--- a/geometry/query_results/signed_distance_pair.h
+++ b/geometry/query_results/signed_distance_pair.h
@@ -21,7 +21,8 @@ struct SignedDistancePair{
    @param p_A     The witness point on geometry A's surface, in A's frame.
    @param p_B     The witness point on geometry B's surface, in B's frame.
    @param dist    The signed distance between p_A and p_B. When A and B are
-   separated, dist > 0; when A and B are touching or penetrating, dist <= 0.
+                  separated, dist > 0; when A and B are touching or
+                  penetrating, dist <= 0.
    @param n_BA_W  The unit direction of the gradient of the signed distance
                   field of B evaluated at p_B, expressed in world frame. By
                   definition, the unit direction of the gradient of the signed
@@ -45,7 +46,8 @@ struct SignedDistancePair{
    @param p_A     The witness point on geometry A's surface, in A's frame.
    @param p_B     The witness point on geometry B's surface, in B's frame.
    @param dist    The signed distance between p_A and p_B. When A and B are
-   separated, dist > 0; when A and B are touching or penetrating, dist <= 0.*/
+                  separated, dist > 0; when A and B are touching or
+                  penetrating, dist <= 0.*/
   SignedDistancePair(GeometryId a, GeometryId b, const Vector3<T>& p_A,
                      const Vector3<T>& p_B, T dist)
       : id_A(a),

--- a/geometry/query_results/signed_distance_pair.h
+++ b/geometry/query_results/signed_distance_pair.h
@@ -15,7 +15,6 @@ namespace geometry {
 
  - When A and B are separated, distance > 0; when A and B are touching or
  penetrating, distance <= 0.
-                 __                      __
  - By definition, the unit direction nhat_AB_W of ∇φ_A(c_A) must be in the
    opposite direction of nhat_BA_W.
  - For non-touching (separating or penetrating) objects, nhat_BA_W points
@@ -25,15 +24,27 @@ namespace geometry {
  - In some cases, the gradient of the signed distance field of object B may
    not have a unique value. For example, at the corner of a box, movement in
    any direction in the vertex's Voronoi region is equally valid.
+
+```
+     ┆░░░░░░  Voronoi region of corner vertex C_b
+     ┆░░░░░░
+┌────⚫┄┄┄┄┄
+│    │ C_b
+└────┘
+```
+
  - If this is the case, we exploit the fact that nhat_BA_W = -nhat_AB_W and
    evaluate nhat_AB_W = ∇φ_A(c_A). For example, a corner of a box B touches a
    sphere A, or the corner of a box B touches a planar side of a box A. In
    these examples, we evaluate ∇φ_A(c_A) of the sphere A and the box A.
 
+```
+                 __                      __
                 |  | box B     box B /\ |  |
               __|__|                /  \|  |
              /  \                   \  /|  | box A
     sphere A \__/                    \/ |__|
+```
 
  - In the case where ∇φ_A(c_A) is also not unique, we select a direction such
    that nhat_BA_W and nhat_AB_W would both be valid directions for the two

--- a/geometry/query_results/signed_distance_pair.h
+++ b/geometry/query_results/signed_distance_pair.h
@@ -9,14 +9,14 @@ namespace geometry {
 
 /** The data for reporting the signed distance between two geometries, A and B.
  It provides the id's of the two geometries, the witness points Ca and Cb on
- the surfaces of A and B, the signed distance, and the unit direction nhat_BA_W
- of ∇φ_B(c_B) the gradient of the signed distance field of B evaluated at Cb
- (always pointing outward from B's surface).
+ the surfaces of A and B, the signed distance, and nhat_BA_W = ∇φ_B(c_B), the
+ gradient of the signed distance field of B evaluated at Cb (always unit
+ length and always point outward from B's surface).
 
- - When A and B are separated, distance > 0; when A and B are touching or
- penetrating, distance <= 0.
- - By definition, the unit direction nhat_AB_W of ∇φ_A(c_A) must be in the
-   opposite direction of nhat_BA_W.
+ - When A and B are separated, distance > 0.
+ - When A and B are touching or penetrating, distance <= 0.
+ - By definition, nhat_AB_W = ∇φ_A(c_A) must be in the opposite direction of
+   nhat_BA_W.
  - For non-touching (separating or penetrating) objects, nhat_BA_W points
    from Cb to Ca, i.e., nhat_BA_W = (p_WCa - p_WCb) / distance.
  - In all cases (separation, osculation, or penetration), we have the invariant
@@ -34,8 +34,8 @@ namespace geometry {
 ```
 
  - If this is the case, we exploit the fact that nhat_BA_W = -nhat_AB_W and
-   evaluate nhat_AB_W = ∇φ_A(c_A). For example, a corner of a box B touches a
-   sphere A, or the corner of a box B touches a planar side of a box A. In
+   set nhat_BA_W equal to -∇φ_A(c_A). For example, a corner of a box B touches
+   a sphere A, or the corner of a box B touches a planar side of a box A. In
    these examples, we evaluate ∇φ_A(c_A) of the sphere A and the box A.
 
 ```

--- a/geometry/query_results/signed_distance_pair.h
+++ b/geometry/query_results/signed_distance_pair.h
@@ -38,7 +38,9 @@ struct SignedDistancePair{
         nhat_BA_W(n_BA_W) {}
 
   // TODO(DamrongGuoy): Remove this constructor when it's not needed.  Right
-  //   now the unit tests need it.
+  //   now the unit tests need it.  The downside is that Python binder calls
+  //   the doc for the above constructor ctor.doc_6args and this one
+  //   ctor.doc_5args.
   /** Constructor.
    We keep this constructor tempoarily for backward compatibility.
    @param a       The id of the first geometry (A).

--- a/geometry/query_results/signed_distance_pair.h
+++ b/geometry/query_results/signed_distance_pair.h
@@ -59,14 +59,21 @@ struct SignedDistancePair{
         p_ACa(p_ACa_in),
         p_BCb(p_BCb_in),
         distance(dist),
-        nhat_BA_W(nhat_BA_W_in) {}
+        nhat_BA_W(nhat_BA_W_in)
+  // TODO(DamrongGuoy): When we have a full implementation of computing
+  //  nhat_BA_W in ComputeSignedDistancePairwiseClosestPoints, add document:
+  //      @pre nhat_BA_W_in is unit-length.
+  //  and check a condition like this (within epsilon):
+  //      DRAKE_DEMAND(nhat_BA_W.norm() == T(1.));
+  {}
 
-  // TODO(DamrongGuoy): Remove this constructor when it's not needed.  Right
-  //   now the unit tests need it.  The downside is that Python binder calls
-  //   the doc for the above constructor ctor.doc_6args and this one
-  //   ctor.doc_5args.
+  // TODO(DamrongGuoy): Remove this constructor when we have a full
+  //  implementation of computing nhat_BA_W in
+  //  ComputeSignedDistancePairwiseClosestPoints.  Right now many unit tests
+  //  need it.  The downside is that Python binder calls the doc for the
+  //  above constructor ctor.doc_6args and this one ctor.doc_5args.
   /** Constructor.
-   We keep this constructor tempoarily for backward compatibility.
+   We keep this constructor temporarily for backward compatibility.
    @param a       The id of the first geometry (A).
    @param b       The id of the second geometry (B).
    @param p_ACa_in  The witness point on geometry A's surface, in A's frame.

--- a/geometry/query_results/signed_distance_pair.h
+++ b/geometry/query_results/signed_distance_pair.h
@@ -21,11 +21,17 @@ struct SignedDistancePair{
    @param p_A     The witness point on geometry A's surface, in A's frame.
    @param p_B     The witness point on geometry B's surface, in B's frame.
    @param dist    The signed distance between p_A and p_B. When A and B are
-   separated, dist > 0; when A and B are touching or penetrating, dist <= 0.*/
+   separated, dist > 0; when A and B are touching or penetrating, dist <= 0.
+   @param n_WAB   The unit normal vector between witness points from A to B,
+                  in world frame.*/
   SignedDistancePair(GeometryId a, GeometryId b, const Vector3<T>& p_A,
-              const Vector3<T>& p_B, T dist) : id_A(a), id_B(b),
-                                               p_ACa(p_A), p_BCb(p_B),
-                                               distance(dist) {}
+                     const Vector3<T>& p_B, T dist, const Vector3<T>& n_WAB)
+      : id_A(a),
+        id_B(b),
+        p_ACa(p_A),
+        p_BCb(p_B),
+        distance(dist),
+        normal_WAB(n_WAB) {}
 
   /** The id of the first geometry in the pair. */
   GeometryId id_A;
@@ -45,6 +51,14 @@ struct SignedDistancePair{
   Vector3<T> p_BCb;
   /** The distance between p_A_A and p_B_B (measured in a common frame). */
   T distance{};
+  /** The unit normal vector from Ca to Cb, expressed in world frame,
+   *  normal_WAB = (p_WCb - p_WCa) / |p_WCb - p_WCa|.
+   *  @note When A and B are touching, defined as the signed distance = 0, we
+   *  define normal_WAB as the direction through which moving B will maximize
+   *  the distance. It is the outward unit normal vector to the surface of A
+   *  at Ca, if the surface is smooth at Ca.
+   *    */
+  Vector3<T> normal_WAB;
 };
 
 }  // namespace geometry


### PR DESCRIPTION
API to return normal direction in SignedDistancePair when we call ComputeSignedDistancePairwiseClosestPoints().

This version only provides the normal direction when the two objects are not touching.  When the two objects are touching, we return nan Vector3d for now.  We will fix it after #10813 is done because the two PRs touch common code.

For now the main purpose of this PR is to agree on API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10823)
<!-- Reviewable:end -->
