### PR TITLE
Extracts RightOfWayStateProvider into its own file

### DIFF
--- a/automotive/maliput/api/BUILD.bazel
+++ b/automotive/maliput/api/BUILD.bazel
@@ -43,6 +43,7 @@ drake_cc_library(
         "rules/right_of_way_phase_provider.h",
         "rules/right_of_way_phase_ring.h",
         "rules/right_of_way_rule.h",
+        "rules/right_of_way_state_provider.h",
         "rules/road_rulebook.h",
         "rules/speed_limit_rule.h",
         "rules/traffic_lights.h",
@@ -84,6 +85,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "rules_test",
     srcs = [
+        "test/right_of_way_state_provider_test.cc",
         "test/rules_regions_test.cc",
         "test/rules_right_of_way_test.cc",
         "test/rules_road_rulebook_test.cc",

--- a/automotive/maliput/api/rules/right_of_way_rule.h
+++ b/automotive/maliput/api/rules/right_of_way_rule.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <unordered_map>
-#include <utility>
 #include <vector>
 
 #include "drake/automotive/maliput/api/rules/regions.h"
@@ -168,55 +167,6 @@ class RightOfWayRule final {
   ZoneType zone_type_{};
   std::unordered_map<State::Id, State> states_;
 };
-
-
-/// Abstract interface for the provider of the state of a dynamic
-/// (multiple state) RightOfWayRule.
-class RightOfWayStateProvider {
- public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RightOfWayStateProvider)
-
-  virtual ~RightOfWayStateProvider() = default;
-
-  /// Result returned by GetState().
-  struct Result {
-    /// Information about a subsequent State.
-    struct Next {
-      /// ID of the State.
-      RightOfWayRule::State::Id id;
-      /// If known, estimated time until the transition to the State.
-      drake::optional<double> duration_until;
-    };
-
-    /// ID of the rule's current State.
-    RightOfWayRule::State::Id current_id;
-    /// Information about the rule's upcoming State if a state transition
-    /// is anticipated.
-    drake::optional<Next> next;
-  };
-
-  /// Gets the state of the RightOfWayRule identified by `id`.
-  ///
-  /// Returns a Result struct bearing the State::Id of the rule's current
-  /// state.  If a transition to a new state is anticipated,
-  /// Result::next will be populated and bear the State::Id of the next
-  /// state.  If the time until the transition is known, then
-  /// Result::next.duration_until will be populated with that duration.
-  ///
-  /// Returns nullopt if `id` is unrecognized, which would be the case
-  /// if no such rule exists or if the rule has only static semantics.
-  drake::optional<Result> GetState(const RightOfWayRule::Id& id) const {
-    return DoGetState(id);
-  }
-
- protected:
-  RightOfWayStateProvider() = default;
-
- private:
-  virtual drake::optional<Result> DoGetState(
-      const RightOfWayRule::Id& id) const = 0;
-};
-
 
 }  // namespace rules
 }  // namespace api

--- a/automotive/maliput/api/rules/right_of_way_state_provider.h
+++ b/automotive/maliput/api/rules/right_of_way_state_provider.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "drake/automotive/maliput/api/rules/right_of_way_rule.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/drake_optional.h"
+
+namespace drake {
+namespace maliput {
+namespace api {
+namespace rules {
+
+/// Abstract interface for the provider of the state of a dynamic
+/// (multiple state) RightOfWayRule.
+class RightOfWayStateProvider {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RightOfWayStateProvider)
+
+  virtual ~RightOfWayStateProvider() = default;
+
+  /// Result returned by GetState().
+  struct Result {
+    /// Information about a subsequent State.
+    struct Next {
+      /// ID of the State.
+      RightOfWayRule::State::Id id;
+      /// If known, estimated time until the transition to the State.
+      drake::optional<double> duration_until;
+    };
+
+    /// ID of the rule's current State.
+    RightOfWayRule::State::Id current_id;
+
+    /// Information about the rule's upcoming State if a state transition
+    /// is anticipated.
+    drake::optional<Next> next;
+  };
+
+  /// Gets the state of the RightOfWayRule identified by `id`.
+  ///
+  /// Returns a Result struct bearing the State::Id of the rule's current
+  /// state.  If a transition to a new state is anticipated,
+  /// Result::next will be populated and bear the State::Id of the next
+  /// state.  If the time until the transition is known, then
+  /// Result::next.duration_until will be populated with that duration.
+  ///
+  /// Returns nullopt if `id` is unrecognized, which would be the case
+  /// if no such rule exists or if the rule has only static semantics.
+  drake::optional<Result> GetState(const RightOfWayRule::Id& id) const {
+    return DoGetState(id);
+  }
+
+ protected:
+  RightOfWayStateProvider() = default;
+
+ private:
+  virtual drake::optional<Result> DoGetState(
+      const RightOfWayRule::Id& id) const = 0;
+};
+
+
+}  // namespace rules
+}  // namespace api
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/api/test/right_of_way_state_provider_test.cc
+++ b/automotive/maliput/api/test/right_of_way_state_provider_test.cc
@@ -1,0 +1,63 @@
+/* clang-format off to disable clang-format-includes */
+#include "drake/automotive/maliput/api/rules/right_of_way_state_provider.h"
+/* clang-format on */
+// TODO(liang.fok) Satisfy clang-format via rules tests directory reorg.
+
+#include <gtest/gtest.h>
+
+#include "drake/automotive/maliput/api/test_utilities/rules_right_of_way_compare.h"
+
+namespace drake {
+namespace maliput {
+namespace api {
+namespace rules {
+namespace {
+
+class RightOfWayStateProviderTest : public ::testing::Test {
+ protected:
+  const RightOfWayRule::Id kExistingId{"aye"};
+  const RightOfWayRule::Id kNonExistingId{"nay"};
+
+  const RightOfWayRule::State::Id kCurrentStateId{"state"};
+  const RightOfWayRule::State::Id kNextStateId{"next"};
+  const double kDurationUntil{99.};
+
+  class MockStateProvider : public RightOfWayStateProvider {
+   public:
+    explicit MockStateProvider(const RightOfWayStateProviderTest* fixture)
+        : fixture_(fixture) {}
+   private:
+    drake::optional<Result> DoGetState(
+        const RightOfWayRule::Id& id) const final {
+      if (id == fixture_->kExistingId) {
+        return Result{fixture_->kCurrentStateId,
+                      Result::Next{fixture_->kNextStateId,
+                                   fixture_->kDurationUntil}};
+      }
+      return nullopt;
+    }
+
+    const RightOfWayStateProviderTest* const fixture_;
+  };
+};
+
+
+TEST_F(RightOfWayStateProviderTest, ExerciseInterface) {
+  using Result = RightOfWayStateProvider::Result;
+
+  const MockStateProvider dut(this);
+
+  EXPECT_TRUE(dut.GetState(kExistingId).has_value());
+  EXPECT_TRUE(MALIPUT_IS_EQUAL(
+      dut.GetState(kExistingId).value(),
+      (Result{kCurrentStateId,
+              Result::Next{kNextStateId, kDurationUntil}})));
+
+  EXPECT_FALSE(dut.GetState(kNonExistingId).has_value());
+}
+
+}  // namespace
+}  // namespace rules
+}  // namespace api
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/api/test/rules_right_of_way_test.cc
+++ b/automotive/maliput/api/test/rules_right_of_way_test.cc
@@ -163,51 +163,6 @@ GTEST_TEST(RightOfWayRuleTest, Assignment) {
   EXPECT_TRUE(MALIPUT_IS_EQUAL(dut, source));
 }
 
-
-class RightOfWayStateProviderTest : public ::testing::Test {
- protected:
-  const RightOfWayRule::Id kExistingId{"aye"};
-  const RightOfWayRule::Id kNonExistingId{"nay"};
-
-  const RightOfWayRule::State::Id kCurrentStateId{"state"};
-  const RightOfWayRule::State::Id kNextStateId{"next"};
-  const double kDurationUntil{99.};
-
-  class MockStateProvider : public RightOfWayStateProvider {
-   public:
-    explicit MockStateProvider(const RightOfWayStateProviderTest* fixture)
-        : fixture_(fixture) {}
-   private:
-    drake::optional<Result> DoGetState(
-        const RightOfWayRule::Id& id) const final {
-      if (id == fixture_->kExistingId) {
-        return Result{fixture_->kCurrentStateId,
-                      Result::Next{fixture_->kNextStateId,
-                                   fixture_->kDurationUntil}};
-      }
-      return nullopt;
-    }
-
-    const RightOfWayStateProviderTest* const fixture_;
-  };
-};
-
-
-TEST_F(RightOfWayStateProviderTest, ExerciseInterface) {
-  using Result = RightOfWayStateProvider::Result;
-
-  const MockStateProvider dut(this);
-
-  EXPECT_TRUE(dut.GetState(kExistingId).has_value());
-  EXPECT_TRUE(MALIPUT_IS_EQUAL(
-      dut.GetState(kExistingId).value(),
-      (Result{kCurrentStateId,
-              Result::Next{kNextStateId, kDurationUntil}})));
-
-  EXPECT_FALSE(dut.GetState(kNonExistingId).has_value());
-}
-
-
 }  // namespace
 }  // namespace rules
 }  // namespace api

--- a/automotive/maliput/api/test_utilities/rules_right_of_way_compare.h
+++ b/automotive/maliput/api/test_utilities/rules_right_of_way_compare.h
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/automotive/maliput/api/rules/right_of_way_rule.h"
+#include "drake/automotive/maliput/api/rules/right_of_way_state_provider.h"
 #include "drake/automotive/maliput/api/test_utilities/rules_test_utilities.h"
 
 namespace drake {

--- a/automotive/maliput/base/phase_based_right_of_way_state_provider.h
+++ b/automotive/maliput/base/phase_based_right_of_way_state_provider.h
@@ -3,6 +3,7 @@
 #include "drake/automotive/maliput/api/rules/right_of_way_phase_book.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_phase_provider.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_rule.h"
+#include "drake/automotive/maliput/api/rules/right_of_way_state_provider.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_optional.h"
 

--- a/automotive/maliput/base/trivial_right_of_way_state_provider.h
+++ b/automotive/maliput/base/trivial_right_of_way_state_provider.h
@@ -3,6 +3,7 @@
 #include <unordered_map>
 
 #include "drake/automotive/maliput/api/rules/right_of_way_rule.h"
+#include "drake/automotive/maliput/api/rules/right_of_way_state_provider.h"
 #include "drake/common/drake_copyable.h"
 
 namespace drake {


### PR DESCRIPTION
For consistency with most other files in maliput/api where the file name
matches the class name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10825)
<!-- Reviewable:end -->
