### PR TITLE
common: Re-enable limit_malloc sanitizer tests 

### DIFF
--- a/common/test_utilities/BUILD.bazel
+++ b/common/test_utilities/BUILD.bazel
@@ -99,6 +99,10 @@ drake_cc_library(
     testonly = 1,
     srcs = ["limit_malloc.cc"],
     hdrs = ["limit_malloc.h"],
+    copts = [
+        # We shouldn't call __tsan_func_entry from allocations during dl_init.
+        "-fno-sanitize=thread",
+    ],
     tags = [
         # The limit_malloc library be used sparingly, and not by default.
         # Don't add this library into the ":test_utilities" package library.
@@ -135,24 +139,34 @@ drake_cc_library(
 
 drake_cc_googletest(
     name = "limit_malloc_test",
-    args = select({
-        "//tools/cc_toolchain:apple": [
-            # The code to enforce malloc limits is not implemented on macOS.
-            "--gtest_filter=-*DeathTest*",
-        ],
-        "//conditions:default": [],
-    }),
-    tags = [
-        # TODO(jwnimmer-tri) Clang ASan and TSan either segfault or abort with
-        # LimitMalloc.  Investigate, fix, and re-enable this test.
-        "no_asan",
-        "no_tsan",
-        # TODO(jwnimmer-tri) The DeathTests fail their test conditions when run
-        # under Valgrind.  Investigate, fix, and re-enable this test.
-        "no_memcheck",
+    args = [
+        # By default, we will skip the death tests because they only pass on
+        # non-Apple, non-Sanitizer, non-Memcheck builds.  We will explicitly
+        # run them (below) for the configurations that succeed.
+        "--gtest_filter=-*DeathTest*",
     ],
     deps = [
         ":limit_malloc",
+    ],
+)
+
+# N.B. All sh_tests are excluded from dynamic_analysis (sanitizer and memcheck)
+# build by default; these death tests are skipped under those configurations.
+sh_test(
+    name = "limit_malloc_death_test",
+    srcs = [":limit_malloc_test"],
+    args = select({
+        "//tools/cc_toolchain:apple": [
+            # The code to enforce malloc limits is not implemented on macOS.
+            "--gtest_filter=-*",
+        ],
+        "//conditions:default": [
+            # Run only the death tests, not the plain tests.
+            "--gtest_filter=*DeathTest*",
+        ],
+    }),
+    data = [
+        ":limit_malloc_test",
     ],
 )
 


### PR DESCRIPTION
The limit_malloc death tests are still excluded from all sanitizer and memcheck builds, but the non-death tests all pass now.

Relates #10821, #10812, #10650.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10830)
<!-- Reviewable:end -->
