### PR TITLE
py: Support `@` Python 3 operator

### DIFF
--- a/bindings/pydrake/common/eigen_geometry_py.cc
+++ b/bindings/pydrake/common/eigen_geometry_py.cc
@@ -151,12 +151,18 @@ PYBIND11_MODULE(eigen_geometry, m) {
             })
         .def("__str__",
             [](py::object self) { return py::str(self.attr("matrix")()); })
-        // Do not define operator `__mul__` until we have the Python3 `@`
-        // operator so that operations are similar to those of arrays.
         .def("multiply",
             [](const Class& self, const Class& other) { return self * other; },
             py::arg("other"))
+        .def("__matmul__",
+            [](const Class& self, const Class& other) { return self * other; },
+            py::arg("other"))
         .def("multiply",
+            [](const Class& self, const Vector3<T>& position) {
+              return self * position;
+            },
+            py::arg("position"))
+        .def("__matmul__",
             [](const Class& self, const Vector3<T>& position) {
               return self * position;
             },
@@ -242,11 +248,16 @@ PYBIND11_MODULE(eigen_geometry, m) {
                   .format(py_class_obj.attr("__name__"), self->w(), self->x(),
                       self->y(), self->z());
             })
-        // Do not define operator `__mul__` until we have the Python3 `@`
-        // operator so that operations are similar to those of arrays.
         .def("multiply",
             [](const Class& self, const Class& other) { return self * other; })
+        .def("__matmul__",
+            [](const Class& self, const Class& other) { return self * other; })
         .def("multiply",
+            [](const Class& self, const Vector3<T>& position) {
+              return self * position;
+            },
+            py::arg("position"))
+        .def("__matmul__",
             [](const Class& self, const Vector3<T>& position) {
               return self * position;
             },
@@ -326,9 +337,9 @@ PYBIND11_MODULE(eigen_geometry, m) {
                   .format(py_class_obj.attr("__name__"), self->angle(),
                       self->axis());
             })
-        // Do not define operator `__mul__` until we have the Python3 `@`
-        // operator so that operations are similar to those of arrays.
         .def("multiply",
+            [](const Class& self, const Class& other) { return self * other; })
+        .def("__matmul__",
             [](const Class& self, const Class& other) { return self * other; })
         .def("inverse", [](const Class* self) { return self->inverse(); });
   }

--- a/bindings/pydrake/common/test/eigen_geometry_test.py
+++ b/bindings/pydrake/common/test/eigen_geometry_test.py
@@ -1,6 +1,7 @@
 import pydrake.common.eigen_geometry as mut
 
 import numpy as np
+import six
 import unittest
 
 import pydrake.common.test.eigen_geometry_test_util as test_util
@@ -73,6 +74,9 @@ class TestEigenGeometry(unittest.TestCase):
             (q.multiply(position=[1, 2, 3]) == [3, 1, 2]).all())
         q_I = q.inverse().multiply(q)
         self.assertTrue(np.allclose(q_I.wxyz(), [1, 0, 0, 0]))
+        if six.PY3:
+            self.assertTrue(np.allclose(
+                eval("q.inverse() @ q").wxyz(), [1, 0, 0, 0]))
         q_conj = q.conjugate()
         self.assertTrue(np.allclose(q_conj.wxyz(), [0.5, -0.5, -0.5, -0.5]))
 
@@ -81,7 +85,7 @@ class TestEigenGeometry(unittest.TestCase):
         self.assertTrue(isinstance(value, mut.Quaternion))
         test_util.check_quaternion(value)
 
-    def test_transform(self):
+    def test_isometry3(self):
         # - Default constructor
         transform = mut.Isometry3()
         X = np.eye(4, 4)
@@ -133,6 +137,11 @@ class TestEigenGeometry(unittest.TestCase):
         self.assertTrue(np.allclose(transform_I.matrix(), np.eye(4)))
         self.assertTrue((
             transform.multiply(position=[10, 20, 30]) == [21, -8, 33]).all())
+        if six.PY3:
+            self.assertTrue(np.allclose(
+                eval("transform.inverse() @ transform").matrix(), np.eye(4)))
+            self.assertTrue((
+                eval("transform @ [10, 20, 30]") == [21, -8, 33]).all())
 
     def test_translation(self):
         # Test `type_caster`s.
@@ -157,6 +166,10 @@ class TestEigenGeometry(unittest.TestCase):
         self.assertTrue(np.allclose(
             value.multiply(value.inverse()).rotation(), np.eye(3),
             atol=1e-15, rtol=0))
+        if six.PY3:
+            self.assertTrue(np.allclose(
+                eval("value @ value.inverse()").rotation(), np.eye(3),
+                atol=1e-15, rtol=0))
         value.set_rotation(np.eye(3))
         self.assertTrue((value.rotation() == np.eye(3)).all())
 

--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -118,18 +118,26 @@ PYBIND11_MODULE(math, m) {
       // .def("IsIdentityToEpsilon", ...)
       .def("inverse", &RigidTransform<T>::inverse,
           doc.RigidTransform.inverse.doc)
-      // TODO(eric.cousineau): Use `matmul` operator once we support Python3.
       .def("multiply",
           [](const RigidTransform<T>* self, const RigidTransform<T>& other) {
             return *self * other;
           },
           py::arg("other"), doc.RigidTransform.operator_mul.doc_1args_other)
+      .def("__matmul__",
+          [](const RigidTransform<T>* self, const RigidTransform<T>& other) {
+            return *self * other;
+          },
+          py::arg("other"), "See ``multiply``.")
       .def("multiply",
           [](const RigidTransform<T>* self, const Vector3<T>& p_BoQ_B) {
             return *self * p_BoQ_B;
           },
-          py::arg("p_BoQ_B"),
-          doc.RigidTransform.operator_mul.doc_1args_p_BoQ_B);
+          py::arg("p_BoQ_B"), doc.RigidTransform.operator_mul.doc_1args_p_BoQ_B)
+      .def("__matmul__",
+          [](const RigidTransform<T>* self, const Vector3<T>& p_BoQ_B) {
+            return *self * p_BoQ_B;
+          },
+          py::arg("p_BoQ_B"), "See ``multiply``.");
   // .def("IsNearlyEqualTo", ...)
   // .def("IsExactlyEqualTo", ...)
 
@@ -172,13 +180,16 @@ PYBIND11_MODULE(math, m) {
       .def(py::init<const RollPitchYaw<T>&>(), py::arg("rpy"),
           doc.RotationMatrix.ctor.doc_1args_rpy)
       .def("matrix", &RotationMatrix<T>::matrix, doc.RotationMatrix.matrix.doc)
-      // Do not define an operator until we have the Python3 `@` operator so
-      // that operations are similar to those of arrays.
       .def("multiply",
           [](const RotationMatrix<T>& self, const RotationMatrix<T>& other) {
             return self * other;
           },
           doc.RotationMatrix.operator_mul.doc_1args_other)
+      .def("__matmul__",
+          [](const RotationMatrix<T>& self, const RotationMatrix<T>& other) {
+            return self * other;
+          },
+          "See ``multiply``")
       .def("inverse", &RotationMatrix<T>::inverse,
           doc.RotationMatrix.inverse.doc)
       .def("ToQuaternion",

--- a/bindings/pydrake/test/math_test.py
+++ b/bindings/pydrake/test/math_test.py
@@ -4,8 +4,9 @@ import pydrake.math as mut
 from pydrake.math import (BarycentricMesh, wrap_to)
 from pydrake.common.eigen_geometry import Isometry3, Quaternion, AngleAxis
 
-import unittest
 import numpy as np
+import six
+import unittest
 
 import math
 
@@ -131,6 +132,10 @@ class TestMath(unittest.TestCase):
         self.assertIsInstance(
             X.multiply(other=mut.RigidTransform()), mut.RigidTransform)
         self.assertIsInstance(X.multiply(p_BoQ_B=p_I), np.ndarray)
+        if six.PY3:
+            self.assertIsInstance(
+                eval("X @ mut.RigidTransform()"), mut.RigidTransform)
+            self.assertIsInstance(eval("X @ [0, 0, 0]"), np.ndarray)
 
     def test_rotation_matrix(self):
         # - Constructors.
@@ -154,6 +159,9 @@ class TestMath(unittest.TestCase):
         # - Inverse.
         R_I = R.inverse().multiply(R)
         self.assertTrue(np.allclose(R_I.matrix(), np.eye(3)))
+        if six.PY3:
+            self.assertTrue(np.allclose(
+                eval("R.inverse() @ R").matrix(), np.eye(3)))
 
     def test_roll_pitch_yaw(self):
         # - Constructors.


### PR DESCRIPTION
Resolves #10460 

Got tired of writing stuff like this in Anzu:
```
def mult(*args):
   return reduce(Isometry3.multiply, args)
```

\cc @RussTedrake

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10831)
<!-- Reviewable:end -->
