### PR TITLE
Separate out value --> abstract value policy as an internal:: class

### DIFF
--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -52,6 +52,7 @@ drake_cc_package_library(
         ":system_symbolic_inspector",
         ":value_checker",
         ":value_deprecated",
+        ":value_to_abstract_value",
         ":vector",
         ":vector_system",
     ],
@@ -77,6 +78,19 @@ drake_cc_library(
         "//common:dummy_value",
         "//common:essential",
         "//common:symbolic",
+    ],
+)
+
+drake_cc_library(
+    name = "value_to_abstract_value",
+    hdrs = [
+        "value_to_abstract_value.h",
+    ],
+    deps = [
+        ":vector",
+        "//common:essential",
+        "//common:value",
+        "@fmt",
     ],
 )
 
@@ -909,6 +923,17 @@ drake_cc_googletest(
     name = "value_checker_test",
     deps = [
         ":value_checker",
+    ],
+)
+
+drake_cc_googletest(
+    name = "value_to_abstract_value_test",
+    deps = [
+        ":value_to_abstract_value",
+        "//common:essential",
+        "//common:unused",
+        "//common/test_utilities:expect_throws_message",
+        "//systems/framework/test_utilities",
     ],
 )
 

--- a/systems/framework/test/value_to_abstract_value_test.cc
+++ b/systems/framework/test/value_to_abstract_value_test.cc
@@ -1,0 +1,387 @@
+#include "drake/systems/framework/value_to_abstract_value.h"
+
+#include <memory>
+#include <type_traits>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/systems/framework/test_utilities/my_vector.h"
+
+namespace drake {
+namespace systems {
+namespace internal {
+namespace {
+
+// Define a collection of classes that exhibit all the copy/clone variants
+// that ValueToAbstractValue is supposed to handle correctly.
+
+class NotCopyableOrCloneable {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(NotCopyableOrCloneable)
+  explicit NotCopyableOrCloneable(double value) : value_{value} {}
+  double value() const { return value_; }
+
+ private:
+  double value_{};
+};
+
+class CopyConstructible {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CopyConstructible)
+  explicit CopyConstructible(double value) : value_{value} {}
+  double value() const { return value_; }
+
+ private:
+  double value_{};
+};
+
+// When both copy and clone are around, we're supposed to prefer copy.
+class CopyableAndCloneable {
+ public:
+  explicit CopyableAndCloneable(double value) : value_{value} {}
+  CopyableAndCloneable(const CopyableAndCloneable& src)
+      : value_(src.value()), was_copy_constructed_(true) {}
+  CopyableAndCloneable& operator=(const CopyableAndCloneable& src) = default;
+
+  std::unique_ptr<CopyableAndCloneable> Clone() const {
+    ++num_clones_;
+    return std::make_unique<CopyableAndCloneable>(value());
+  }
+
+  double value() const { return value_; }
+  int num_clones() const { return num_clones_; }
+  bool was_copy_constructed() const { return was_copy_constructed_; }
+
+ private:
+  double value_{};
+  bool was_copy_constructed_{false};
+  mutable int num_clones_{0};
+};
+
+class JustCloneable {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(JustCloneable)
+  virtual ~JustCloneable() = default;
+  explicit JustCloneable(double value) : value_{value} {}
+  std::unique_ptr<JustCloneable> Clone() const { return DoClone(); }
+  double value() const { return value_; }
+
+ private:
+  virtual std::unique_ptr<JustCloneable> DoClone() const {
+    return std::make_unique<JustCloneable>(value_);
+  }
+  double value_{};
+};
+
+// This derived class is cloneable via its base class but doesn't have its own
+// public Clone() method. The Value<T> we create for it should use the
+// base class type for T.
+class BaseClassCloneable : public JustCloneable {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BaseClassCloneable)
+  BaseClassCloneable(std::string name, double value)
+      : JustCloneable(value), name_(std::move(name)) {}
+  std::string name() const { return name_; }
+
+ private:
+  std::unique_ptr<JustCloneable> DoClone() const final {
+    return std::make_unique<BaseClassCloneable>(name_, value());
+  }
+
+  std::string name_;
+};
+
+// This derived class is cloneable via its own public Clone() method. The
+// Value<T> we create for it should use the derived class type for T.
+class DerivedClassCloneable : public JustCloneable {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DerivedClassCloneable)
+  DerivedClassCloneable(std::string name, double value)
+      : JustCloneable(value), name_(std::move(name)) {}
+  std::unique_ptr<DerivedClassCloneable> Clone() const {
+    return std::make_unique<DerivedClassCloneable>(name_, value());
+  }
+  std::string name() const { return name_; }
+
+ private:
+  std::unique_ptr<JustCloneable> DoClone() const final {
+    return std::make_unique<DerivedClassCloneable>(name_, value());
+  }
+
+  std::string name_;
+};
+
+// Test each of the four ToAbstract() methods implemented for AbstractPolicy.
+// For reference:
+// (1) ToAbstract(AbstractValue) cloned directly without wrapping in Value<>
+// (2) ToAbstract(const char*) special-cased shorthand for std::string
+// (3) ToAbstract(Eigen expression) eval'ed and stored as the eval() type
+// (4) ToAbstract<V>(V) creates Value<V> for copyable or cloneable types V,
+//                      or Value<B> if V's clone returns a base type B.
+// Method (4) is supposed to prefer the copy constructor if it and Clone() are
+// both available.
+//
+// No runtime errors occur with this policy. A compilation failure occurs
+// if a non-copyable, non-cloneable type is provided.
+GTEST_TEST(ValueToAbstractValue, AbstractPolicy) {
+  // All methods return std::unique_ptr<AbstractValue>.
+  using AbstractPolicy = ValueToAbstractValue;
+
+  // First check handling of given AbstractValue objects (signature (1)).
+
+  // Pass a value already of AbstractValue type.
+  Value<std::string> value_str("hello");
+  Value<double> value_double(1.25);
+  AbstractValue& absval_double = value_double;
+
+  const auto value_str_copy =
+      AbstractPolicy::ToAbstract(value_str);  // (1, with conversion)
+  const auto absval_double_copy =
+      AbstractPolicy::ToAbstract(absval_double);  // (1)
+
+  EXPECT_EQ(value_str_copy->get_value<std::string>(), "hello");
+  EXPECT_EQ(absval_double_copy->get_value<double>(), 1.25);
+
+  // Make sure we're not just looking at the same objects.
+  value_str.get_mutable_value() = "goodbye";
+  EXPECT_EQ(value_str_copy->get_value<std::string>(), "hello");  // no change
+
+  absval_double.get_mutable_value<double>() = 2.5;
+  EXPECT_EQ(absval_double_copy->get_value<double>(), 1.25);  // no change
+
+  // Check char* sugar signature (2).
+
+  // char* values are stored in std::string AbstractValues.
+  const auto char_ptr_val = AbstractPolicy::ToAbstract("char*");
+  EXPECT_EQ(char_ptr_val->get_value<std::string>(), "char*");  // (2)
+
+  // Check signature (4) handling of simple objects.
+
+  const auto int_val = AbstractPolicy::ToAbstract(5);  // (4)
+  EXPECT_EQ(int_val->get_value<int>(), 5);
+
+  const auto str_val =
+      AbstractPolicy::ToAbstract(std::string("string"));  // (4)
+  EXPECT_EQ(str_val->get_value<std::string>(), "string");
+
+  // Check signature (4) handling of objects that are: just copyable,
+  // just cloneable (to self or base class), and both copyable and cloneable.
+
+  const auto copyable_val =
+      AbstractPolicy::ToAbstract(CopyConstructible(1.25));  // (4, copy)
+  EXPECT_EQ(copyable_val->get_value<CopyConstructible>().value(), 1.25);
+
+  const auto cloneable_val =
+      AbstractPolicy::ToAbstract(JustCloneable(0.75));  // (4, clone)
+  EXPECT_EQ(cloneable_val->get_value<JustCloneable>().value(), 0.75);
+
+  // Here ToAbstract() has to discover that the available Clone() method
+  // returns a base class-typed object (here a JustCloneable), rather than the
+  // concrete type we give it, so we have to store it in a Value<BaseType>.
+  const auto base_cloneable_val = AbstractPolicy::ToAbstract(
+      BaseClassCloneable("base_cloneable", 1.5));  // (4, clone-to-base)
+  EXPECT_EQ(base_cloneable_val->get_value<JustCloneable>().value(), 1.5);
+  EXPECT_EQ(dynamic_cast<const BaseClassCloneable&>(
+                base_cloneable_val->get_value<JustCloneable>()).name(),
+            "base_cloneable");
+
+  // Here ToAbstract() should discover that the available Clone() method
+  // returns the derived class-typed object, so we can store that directly
+  // in a Value<DerivedType>.
+  const auto derived_cloneable_val =
+      AbstractPolicy::ToAbstract(
+          DerivedClassCloneable("derived_cloneable", 0.25));  // (4, clone)
+  EXPECT_EQ(derived_cloneable_val->get_value<DerivedClassCloneable>().value(),
+            0.25);
+  EXPECT_EQ(derived_cloneable_val->get_value<DerivedClassCloneable>().name(),
+            "derived_cloneable");
+
+  // When the value object is both copyable and cloneable, we expect the copy
+  // constructor to be used.
+  CopyableAndCloneable cc_value(2.25);
+  EXPECT_EQ(cc_value.num_clones(), 0);
+  EXPECT_FALSE(cc_value.was_copy_constructed());
+
+  const auto cc_val_abstract_copy =
+      AbstractPolicy::ToAbstract(cc_value);  // (4, prefer copy)
+  const auto& cc_val_copy =
+      cc_val_abstract_copy->get_value<CopyableAndCloneable>();
+  EXPECT_EQ(cc_val_copy.value(), 2.25);
+  EXPECT_EQ(cc_value.num_clones(), 0);
+  EXPECT_TRUE(cc_val_copy.was_copy_constructed());
+  EXPECT_EQ(cc_val_copy.num_clones(), 0);
+
+  // These are also (4) but should trigger a nice static_assert message if
+  // uncommented, similar to:
+  //   static assertion failed: ValueToAbstractValue(): value type must be
+  //   copy constructible or have an accessible Clone() method that returns
+  //   std::unique_ptr.
+  // AbstractPolicy::ToAbstract(NotCopyableOrCloneable(2.));
+}
+
+// AbstractPolicy should store vector objects as themselves, but Eigen vector
+// expressions must get eval()'ed first and then stored as the eval() type.
+GTEST_TEST(ValueToAbstractValue, AbstractPolicyOnVectors) {
+  using AbstractPolicy = ValueToAbstractValue;
+
+  const Eigen::Vector3d expected_vec(10., 20., 30.);
+  const double expected_scalar = 3.125;
+
+  // A scalar should not get turned into a Vector1.
+  const auto scalar_val = AbstractPolicy::ToAbstract(expected_scalar);  // (4)
+  EXPECT_EQ(scalar_val->get_value<double>(), expected_scalar);
+
+  // An Eigen vector should not be stored in a BasicVector.
+  const auto vec3_val = AbstractPolicy::ToAbstract(expected_vec);  // (3)
+  EXPECT_EQ(vec3_val->get_value<Eigen::Vector3d>(), expected_vec);
+
+  // More complicated Eigen objects should be stored using the type produced
+  // when the object is eval()'ed, minus const and reference if any.
+  // Also check that AbstractPolicy::NiceEigenType returns the right type.
+  const Eigen::Vector4d long_vec(.25, .5, .75, 1.);
+  auto tail3_val = AbstractPolicy::ToAbstract(long_vec.tail(3));  // (3)
+  using Tail3StorageType = std::remove_const_t<
+      std::remove_reference_t<decltype(long_vec.tail(3).eval())>>;
+  const bool has_expected_type =
+      std::is_same<AbstractPolicy::NiceEigenType<decltype(long_vec.tail(3))>,
+                   Tail3StorageType>::value;
+  EXPECT_TRUE(has_expected_type);
+  EXPECT_EQ(tail3_val->get_value<Tail3StorageType>(),
+            Eigen::Vector3d(.5, .75, 1.));
+
+  // Fixed-size Eigen expressions eval() more predictably.
+  auto segment_val = AbstractPolicy::ToAbstract(long_vec.segment<2>(1));  // (3)
+  EXPECT_EQ(segment_val->get_value<Eigen::Vector2d>(),
+            Eigen::Vector2d(.5, .75));
+
+  // A plain BasicVector is stored as a Value<BasicVector>, just as it is
+  // under the VectorPolicy.
+  const BasicVector<double> basic_vector3({7., 8., 9.});
+  const auto basic_vector_val =
+      AbstractPolicy::ToAbstract(basic_vector3);  // (4)
+  EXPECT_EQ(basic_vector_val->get_value<BasicVector<double>>().get_value(),
+            Eigen::Vector3d(7., 8., 9.));
+
+  // MyVector derives from BasicVector and has its own Clone() method
+  // that returns unique_ptr<MyVector>. Under the AbstractPolicy, this is
+  // handled like any other cloneable object by signature (4) and stored as
+  // Value<MyVector>. That's different from the VectorPolicy treatment.
+  const MyVector3d my_vector3(expected_vec);
+  auto my_vector3_val = AbstractPolicy::ToAbstract(my_vector3);  // (4)
+  const MyVector3d& my_vector3_from_abstract =
+      my_vector3_val->get_value<MyVector3d>();
+  EXPECT_EQ(my_vector3_from_abstract.get_value(), expected_vec);
+}
+
+// Test each of the five ToAbstract() methods implemented for VectorPolicy.
+// For reference:
+// (1) ToAbstract(Eigen::Ref) should convert to BasicVector.
+// (2) ToAbstract(scalar) should be treated like and Eigen Vector1.
+// (3) ToAbstract(BasicVector) special-cased to make concrete vector types work
+//         regardless of whether they overload Clone().
+// (4) ToAbstract(AbstractValue) cloned directly without wrapping in Value<>,
+//         but must resolve to Value<BasicVector>.
+// (5) ToAbstract<V>(V) issues an std::logic_error since only the above types
+//         are acceptable for vector objects.
+
+// Test the non-vector signatures (4) and (5) here. These can produce runtime
+// errors which should include the supplied API name. (All methods must take
+// the name.)
+GTEST_TEST(ValueToVectorValue, GenericObjects) {
+  // All methods return std::unique_ptr<AbstractValue>.
+
+  using VectorPolicy = ValueToVectorValue<double>;
+
+  // Check that AbstractValue objects are acceptable to signature (4) only if
+  // they resolve to Value<BasicVector>.
+  const Value<int> bad_val(1);
+  const Value<BasicVector<double>> good_val(Eigen::Vector3d(1., 2., 3.));
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      VectorPolicy::ToAbstract("MyApi", bad_val), std::logic_error,
+      ".*MyApi.*AbstractValue.*type int is not.*vector quantity.*");
+
+  const auto good_val_copy = VectorPolicy::ToAbstract("MyApi", good_val);
+  EXPECT_EQ(good_val_copy->get_value<BasicVector<double>>().get_value(),
+            Eigen::Vector3d(1., 2., 3.));
+
+  // Non-vector objects should throw via signature (5).
+  DRAKE_EXPECT_THROWS_MESSAGE(VectorPolicy::ToAbstract("MyApi", 5),
+                              std::logic_error,
+                              ".*MyApi.*type int is not.*vector quantity.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      VectorPolicy::ToAbstract("MyApi", std::string("string")),
+      std::logic_error, ".*MyApi.*type std::string is not.*vector quantity.*");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      VectorPolicy::ToAbstract("MyApi", CopyConstructible(1.25)),
+      std::logic_error, ".*MyApi.*CopyConstructible is not.*vector quantity.*");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      VectorPolicy::ToAbstract("MyApi", JustCloneable(0.75)), std::logic_error,
+      ".*MyApi.*JustCloneable is not.*vector quantity.*");
+}
+
+// Test signature (1), (2), and (3) which deal with Eigen vectors, scalars, and
+// BasicVectors, respectively, under VectorPolicy. (Under AbstractPolicy,
+// none of these get special treatment.)
+GTEST_TEST(ValueToVectorValue, VectorPolicy) {
+  const Eigen::Vector3d expected_vec(10., 20., 30.);
+  const double expected_scalar = 3.125;
+
+  // VectorPolicy handles Eigen vector, scalar, and BasicVector-derived objects
+  // V by putting them in a Value<BasicVector>.
+  using VectorPolicy = ValueToVectorValue<double>;
+
+  // VectorPolicy puts a scalar into a 1-element Value<BasicVector<T>>, while
+  // AbstractPolicy simply puts it in a Value<T>.
+  auto scalar_val = VectorPolicy::ToAbstract("MyApi", expected_scalar);  // (2)
+  EXPECT_EQ(scalar_val->get_value<BasicVector<double>>()[0], expected_scalar);
+
+  // Any Eigen vector type should be stored as a BasicVector.
+  auto vec3_val = VectorPolicy::ToAbstract("MyApi", expected_vec);  // (1)
+  EXPECT_EQ(vec3_val->get_value<BasicVector<double>>().get_value(),
+            expected_vec);
+
+  // Pass a more complicated Eigen object; should still work.
+  const Eigen::Vector4d long_vec(.25, .5, .75, 1.);
+  auto tail3_val = VectorPolicy::ToAbstract("MyApi", long_vec.tail(3));  // (1)
+  EXPECT_EQ(tail3_val->get_value<BasicVector<double>>().get_value(),
+            Eigen::Vector3d(.5, .75, 1.));
+
+  auto segment2_val =
+      VectorPolicy::ToAbstract("MyApi", long_vec.segment<2>(1));  // (1)
+  EXPECT_EQ(segment2_val->get_value<BasicVector<double>>().get_value(),
+            Eigen::Vector2d(.5, .75));
+
+  // A plain BasicVector is stored as a Value<BasicVector>. It is handled
+  // by the BasicVector overload (3).
+  const BasicVector<double> basic_vector3({7., 8., 9.});
+  const auto basic_vector_val =
+      VectorPolicy::ToAbstract(__func__, basic_vector3);  // (3)
+  EXPECT_EQ(basic_vector_val->get_value<BasicVector<double>>().get_value(),
+            Eigen::Vector3d(7., 8., 9.));
+
+  // MyVector derives from BasicVector and has its own Clone() method
+  // that returns unique_ptr<MyVector>. *Despite that*, under the VectorPolicy
+  // it should be stored as a Value<BasicVector>, which is why signature (3)
+  // exists for this policy. (AbstractPolicy would store this as a
+  // Value<MyVector>.) However, the concrete type must be preserved.
+  const MyVector3d my_vector3(expected_vec);
+  auto my_vector3_val = VectorPolicy::ToAbstract("MyApi", my_vector3);  // (3)
+  const BasicVector<double>& basic_vector =
+      my_vector3_val->get_value<BasicVector<double>>();
+  EXPECT_EQ(basic_vector.get_value(), expected_vec);
+
+  // Check that the concrete type was preserved.
+  EXPECT_EQ(dynamic_cast<const MyVector3d&>(basic_vector).get_value(),
+            expected_vec);
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace systems
+}  // namespace drake

--- a/systems/framework/value_to_abstract_value.h
+++ b/systems/framework/value_to_abstract_value.h
@@ -1,0 +1,296 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+#include <fmt/format.h>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/eigen_types.h"
+#include "drake/common/unused.h"
+#include "drake/common/value.h"
+#include "drake/systems/framework/basic_vector.h"
+
+namespace drake {
+namespace systems {
+namespace internal {
+
+// is_eigen_refable() returns a constexpr bool saying whether its template
+// argument is any Eigen expression acceptable to Eigen::Ref. That includes
+// all the Eigen things we care about.
+
+// This overload is chosen for the int argument if the Ref type exists,
+// otherwise there is an SFINAE failure here.
+template <typename ValueType>
+static constexpr bool is_eigen_refable_helper(
+    // That's a comma expression below, returning an int.
+    decltype(std::declval<Eigen::Ref<ValueType>>(), int())) {
+  return true;
+}
+
+// When the above method can't be instantiated, the int argument converts to
+// a char and this method is invoked instead.
+template <typename ValueType>
+static constexpr bool is_eigen_refable_helper(char) {
+  return false;
+}
+
+// Returns true iff ValueType is compatible with Eigen::Ref.
+template <typename ValueType>
+static constexpr bool is_eigen_refable() {
+  return is_eigen_refable_helper<ValueType>(1);  // Any int will do here.
+}
+
+/** Implements Drake policy for taking a concrete value object and storing it in
+a Drake abstract object (for example, an abstract-valued port) as a type-erased
+AbstractValue. We call this "AbstractPolicy" to distinguish it from the
+"VectorPolicy" implemented by ValueToVectorValue.
+
+<h4>Usage</h4>
+
+This class can be used in conjunction with ValueToVectorValue to store an
+arbitrary value object into a Drake abstract or vector object, using the
+appropriate policy. Here is an example:
+```
+  std::unique_ptr<AbstractValue> abstract_value =
+    is_vector_port
+        ? internal::ValueToVectorValue<T>::ToAbstract(__func__, value)
+        : internal::ValueToAbstractValue::ToAbstract(value);
+```
+Note that for this to work _both_ ToAbstract() methods must compile
+successfully, even though the VectorPolicy is much more restrictive. Thus
+the VectorPolicy must issue runtime errors for values that are unacceptable.
+
+@see ValueToVectorValue
+
+<h4>AbstractPolicy</h4>
+
+ 1. Any given AbstractValue object is simply cloned.
+ 2. A `char *` type is copied into a Value<std::string>.
+ 3. Any Eigen expression type is simplified using `.eval()`, and then stored
+    in a Value<E> where E is the type returned by `.eval()` (without const).
+ 4. For any other type V
+    - if V is copy-constructible it is copied into a `Value<V>`;
+    - if V has an accessible Clone() method that returns `unique_ptr<V>` it is
+      cloned into a `Value<V>`;
+    - if V has an accessible `Clone()` method that returns `unique_ptr<B>`,
+      where B is a base class of V, then V is cloned into a `Value<B>`;
+    - otherwise, compilation fails with a `static_assert` message.
+
+@warning Eigen expressions typically don't have simple Vector types. That
+doesn't matter under the VectorPolicy. However, under the AbstractPolicy you
+will get Value<E> where E is the type of V.eval(). If you need to know E's
+type, use `ValueToAbstractValue::NiceEigenType<V>`. Better, put your expression
+V into an Eigen vector of known type before storing it in an AbstractValue. */
+class ValueToAbstractValue {
+ public:
+  // Signature (1): used for AbstractValue or Value<U> arguments.
+  static std::unique_ptr<AbstractValue> ToAbstract(const AbstractValue& value) {
+    return value.Clone();
+  }
+
+  // Signature (2): special case char* to std::string to avoid ugly compilation
+  // messages for this case, where the user's intent is obvious.
+  static std::unique_ptr<AbstractValue> ToAbstract(const char* c_string) {
+    return std::make_unique<Value<std::string>>(c_string);
+  }
+
+  // This is the storage type we'll use for an Eigen vector type.
+  template <typename ValueType,
+            typename = std::enable_if_t<is_eigen_refable<ValueType>()>>
+  using NiceEigenType = std::remove_const_t<
+      std::remove_reference_t<decltype(std::declval<ValueType>().eval())>>;
+
+  // Signature (3): special case any Eigen vector expression so that we
+  // can invoke eval() on it and store it as the simpler result type. If
+  // you need to know how it was stored, use NiceEigenType above.
+
+  // Note that we're assuming that MatrixBase<Derived> will instantiate under
+  // the same conditions as is_eigen_refable() returns true.
+  // TODO(sherm1) Figure out some way to make this explicitly dependent on
+  // is_eigen_refable<ValueType>().
+  template <typename Derived>
+  static std::unique_ptr<AbstractValue> ToAbstract(
+      const Eigen::MatrixBase<Derived>& eigen_expr) {
+    // Can't use NiceEigenType here because we don't have the original
+    // ValueType.
+    using TypeAfterEval = std::remove_const_t<
+        std::remove_reference_t<decltype(eigen_expr.eval())>>;
+    return std::make_unique<Value<TypeAfterEval>>(eigen_expr.eval());
+  }
+
+  // Returns true iff ValueType has an accessible Clone() method that
+  // returns a unique_ptr<ValueType> or one of ValueType's base classes.
+  template <typename ValueType>
+  static constexpr bool has_accessible_clone() {
+    return has_accessible_clone_helper<ValueType>(1);  // Any int will do here.
+  }
+
+  // Signature (4): This signature won't instantiate if signature (1) or (3)
+  // can be used (after possible conversions). If we allowed this to instantiate
+  // it would be chosen instead of performing those conversions. Note that for
+  // the AbstractPolicy, BasicVector ValueTypes are handled with this generic
+  // method rather than by a specialized method as for VectorPolicy.
+  template <typename ValueType,
+            typename = std::enable_if_t<
+                !(std::is_base_of<AbstractValue, ValueType>::value ||
+                  is_eigen_refable<ValueType>())>>
+  static std::unique_ptr<AbstractValue> ToAbstract(const ValueType& value) {
+    static_assert(
+        std::is_copy_constructible<ValueType>::value ||
+            has_accessible_clone<ValueType>(),
+        "ValueToAbstractValue(): value type must be copy constructible or "
+        "have an accessible Clone() method that returns std::unique_ptr.");
+    return ValueHelper(value, 1, 1);
+  }
+
+ private:
+  template <typename ValueType>
+  using CopyReturnType =
+      decltype(ValueType(std::declval<const ValueType>()));
+
+  template <typename ValueType>
+  using CloneReturnType = std::remove_pointer_t<
+      decltype(std::declval<const ValueType>().Clone().release())>;
+
+  // This overload is chosen for the int argument if the Ref type exists,
+  // otherwise there is an SFINAE failure here.
+  template <typename ValueType, typename = CloneReturnType<ValueType>>
+  static constexpr bool has_accessible_clone_helper(int) {
+    return true;
+  }
+
+  // When the above method can't be instantiated, the int argument converts to
+  // a char and this method is invoked instead.
+  template <typename ValueType>
+  static constexpr bool has_accessible_clone_helper(char) {
+    return false;
+  }
+
+  // This is instantiated if ValueType has a copy constructor. If it is also
+  // cloneable, this method still gets invoked; we prefer use of the the copy
+  // constructor.
+  template <typename ValueType, typename = CopyReturnType<ValueType>>
+  static std::unique_ptr<AbstractValue> ValueHelper(const ValueType& value, int,
+                                                    int) {
+    return std::make_unique<Value<CopyReturnType<ValueType>>>(value);
+  }
+
+  // This is available if ValueType is cloneable, but is dispreferred if there
+  // is also a copy constructor because the `int, int` args above are a better
+  // match than the `int, ...` args here. The Clone() must return a unique_ptr
+  // but the type could be a base type of ValueType rather than ValueType
+  // itself. In that case we store the value using the base type, although
+  // presumably the concrete type has been properly cloned.
+  template <typename ValueType,
+      typename ClonedValueType = CloneReturnType<ValueType>>
+  static std::unique_ptr<AbstractValue> ValueHelper(const ValueType& value, int,
+                                                    ...) {
+    static_assert(
+        std::is_base_of<ClonedValueType, ValueType>::value,
+        "ValueToAbstractValue::ToAbstract(): accessible Clone() method must "
+        "return ValueType or a base class of ValueType.");
+    return std::make_unique<Value<ClonedValueType>>(value.Clone());
+  }
+
+  // This signature exists for non-copyable, non-cloneable ValueType just to
+  // avoid spurious compilation errors. A static_assert above will have provided
+  // a good message already; this method just needs to compile peacefully.
+  template <typename ValueType>
+  static std::unique_ptr<AbstractValue> ValueHelper(const ValueType&, ...) {
+    DRAKE_UNREACHABLE();
+  }
+};
+
+
+/** Implements Drake policy for taking a concrete vector type and storing it in
+a Drake numerical vector object as an AbstractValue of concrete type
+`Value<BasicVector<T>>`. We call this "VectorPolicy" to distinguish it from
+the "AbstractPolicy" implemented by ValueToAbstractValue.
+
+@see ValueToAbstractValue for usage information and some restrictions.
+
+<h4>VectorPolicy</h4>
+
+ 1. Any Eigen vector type is copied into a `Value<BasicVector<T>>`.
+ 2. A scalar of type T is treated as though it were an Eigen Vector1<T>.
+ 3. Any BasicVector or type derived from BasicVector is cloned into a
+    `Value<BasicVector<T>>` although the stored object still has the
+    most-derived type.
+ 4. Any AbstractValue object is simply cloned. The resulting clone must have
+    exactly type `Value<BasicVector<T>>` or an std::logic_error is thrown.
+
+Any other type results in an std::logic_error being thrown (at runtime). This
+internal class is intended to be invoked by different user-visible APIs so
+provides for the API name to be included in any generated runtime error
+messages.
+
+@tparam T The scalar type in use for vector objects. */
+template <typename T>
+class ValueToVectorValue {
+ public:
+  // Signature (1): used for any Eigen vector type, but the argument is copied
+  // to a BasicVector for the returned abstract value.
+  static std::unique_ptr<AbstractValue> ToAbstract(const char* api_name,
+      const Eigen::Ref<const VectorX<T>>& vector) {
+    unused(api_name);
+    return std::make_unique<Value<BasicVector<T>>>(vector);
+  }
+
+  // Signature (2): used for a scalar of type T. The argument is copied
+  // to a 1-element BasicVector for the returned abstract value.
+  static std::unique_ptr<AbstractValue> ToAbstract(const char* api_name,
+                                                   const T& scalar) {
+    return ToAbstract(api_name, Vector1<T>(scalar));  // Use signature (1).
+  }
+
+  // Signature (3): BasicVector must be special-cased so that we use a
+  // Value<BasicVector> to store a copy of the given object, even if it is from
+  // a subclass of BasicVector, and even if it has its own Clone() method. The
+  // actual type is preserved regardless.
+  static std::unique_ptr<AbstractValue> ToAbstract(const char* api_name,
+      const BasicVector<T>& vector) {
+    unused(api_name);
+    return std::make_unique<Value<BasicVector<T>>>(vector.Clone());
+  }
+
+  // Signature (4): used for AbstractValue or Value<U> arguments. After cloning,
+  // this must be exactly type Value<BasicVector<T>>.
+  static std::unique_ptr<AbstractValue> ToAbstract(const char* api_name,
+      const AbstractValue& value) {
+    auto cloned = value.Clone();
+    if (cloned->maybe_get_value<BasicVector<T>>() != nullptr)
+      return cloned;
+
+    throw std::logic_error(
+        fmt::format("{}(): the given AbstractValue containing type {} is not "
+                    "suitable for storage as a Drake vector quantity.",
+                    api_name, value.GetNiceTypeName()));
+  }
+
+  // The final signature exists just so we can throw an error message.
+
+  // Signature (5): This signature won't instantiate if any of the
+  // non-templatized signatures above can be used (after possible conversions).
+  // If we allowed this to instantiate it would be chosen instead of performing
+  // those conversions.
+  template <typename ValueType,
+            typename = std::enable_if_t<
+                !(is_eigen_refable<ValueType>() ||
+                  std::is_base_of<BasicVector<T>, ValueType>::value ||
+                  std::is_base_of<AbstractValue, ValueType>::value)>>
+  static std::unique_ptr<AbstractValue> ToAbstract(const char* api_name,
+                                                   const ValueType& value) {
+    throw std::logic_error(
+        fmt::format("{}(): the given value of type {} is not "
+                    "suitable for storage as a Drake vector quantity.",
+                    api_name, NiceTypeName::Get<ValueType>()));
+  }
+};
+
+}  // namespace internal
+}  // namespace systems
+}  // namespace drake
+


### PR DESCRIPTION
This PR is a lemma (yak-shave?) for in-progress PR #10759, which in turn addresses issue #10692.

As suggested in review of #10759, this isolates Drake's System Framework policy for taking an arbitrary value and storing it in an AbstractValue, by creating new `internal::ValueToAbstractValue` and `internal::ValueToVectorValue<T>` classes where the policy-implementing SFINAE incantations are hidden. This allows straightforward single-method implementations elsewhere. In particular, `input_port.FixValue(&context, value)` is implemented in #10759 using just this one signature:
```c++
  template <typename ValueType>
  FixedInputPortValue& FixValue(Context<T>* context,
                                const ValueType& value) const;
``` 

The implemented policy is spelled out in the class doc for ValueToAbstractValue and ValueToVectorValue. We should discuss whether these are the right policies, as well as whether the implementation is correct.

```
Category            added  modified  removed  
----------------------------------------------
code                394    0         0        
comments            189    0         0        
blank               107    0         0        
----------------------------------------------
TOTAL               690    0         0        
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10838)
<!-- Reviewable:end -->
