### PR TITLE
Correct anchored geometry initialization

### DIFF
--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -1017,7 +1017,9 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     std::unique_ptr<fcl::CollisionObject<double>> fcl_object;
     shape.Reify(this, &fcl_object);
     fcl_object->setTransform(X_WG);
+    fcl_object->computeAABB();
     anchored_tree_.registerObject(fcl_object.get());
+    anchored_tree_.update();
     ProximityIndex proximity_index(static_cast<int>(anchored_objects_.size()));
     EncodedData encoding(index, false /* is dynamic */);
     encoding.store_in(fcl_object.get());

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -2562,6 +2562,43 @@ GTEST_TEST(ProximityEngineTests, Issue10577Regression_Osculation) {
   EXPECT_EQ(pairs.size(), 0);
 }
 
+// When anchored geometry is added to the proximity engine, the broadphase
+// algorithm needs to be properly updated, otherwise it assumes all of the
+// anchored geometry has the identity transformation. This test confirms that
+// this configuration occurs; the dynamic sphere and anchored sphere are
+// configured away from the origin in collision. Without proper broadphase
+// initialization for the anchored geometry, no collision is reported.
+GTEST_TEST(ProximityEngineTests, AnchoredBroadPhaseInitialization) {
+  ProximityEngine<double> engine;
+  GeometryId id_D = GeometryId::get_new_id();
+  GeometryId id_A = GeometryId::get_new_id();
+  GeometryIndex index_D(0);
+  GeometryIndex index_A(1);
+  ProximityIndex engine_index_D =
+      engine.AddDynamicGeometry(Sphere(0.5), index_D);
+
+  Isometry3<double> X_WA{Translation3d{-3, 0, 0}};
+  ProximityIndex engine_index_A =
+      engine.AddAnchoredGeometry(Sphere(0.5), X_WA, index_A);
+
+  // These should have the same index value because one draws from the dynamic
+  // set, the other from the anchored.
+  ASSERT_EQ(engine_index_D, 0);
+  ASSERT_EQ(engine_index_A, 0);
+
+  Isometry3<double> X_WD{Translation3d{-3, 0.75, 0}};
+  // NOTE: The vector of indicies should *only* be the indices of the dynamic
+  // geometry. The only requirement for the vector of poses is that the
+  // poses[indices[i]] must be defined and should map to the geometry with
+  // index indices[i]. In this case, a single dynamic geometry with index 0,
+  // means it is sufficient to create a pose vector with a single pose.
+  engine.UpdateWorldPoses({X_WD}, {index_D});
+  std::vector<GeometryId> geometry_map{id_D, id_A};
+  auto pairs = engine.ComputePointPairPenetration(geometry_map);
+  EXPECT_EQ(pairs.size(), 1);
+}
+
+
 }  // namespace
 }  // namespace internal
 }  // namespace geometry


### PR DESCRIPTION
The broadphase tree for anchored geometry was treating all anchored
geometry in its canonical frame. This led to erroneous broadphase results
(in which narrowphase results weren't even considered). This corrects
that oversight.

Fixes #10826

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10845)
<!-- Reviewable:end -->
