### PR TITLE
Add comments explaining tricky use of cache entries in integrators

### DIFF
--- a/systems/analysis/explicit_euler_integrator.h
+++ b/systems/analysis/explicit_euler_integrator.h
@@ -59,14 +59,27 @@ template <class T>
 bool ExplicitEulerIntegrator<T>::DoStep(const T& dt) {
   Context<T>& context = *this->get_mutable_context();
 
+  // CAUTION: This is performance-sensitive inner loop code that uses dangerous
+  // long-lived references into state and cache to avoid unnecessary copying and
+  // cache invalidation. Be careful not to insert calls to methods that could
+  // invalidate any of these references before they are used.
+
   // Evaluate derivative xcdot₀ ← xcdot(t₀, x(t₀), u(t₀)).
   const ContinuousState<T>& xc_deriv = this->EvalTimeDerivatives(context);
   const VectorBase<T>& xcdot0 = xc_deriv.get_vector();
 
-  // Update continuous state and time.
-  // This call invalidates t- and xc-dependent cache entries.
+  // Cache: xcdot0 references the live derivative cache value, currently
+  // up to date but about to be marked out of date. We do not want to make
+  // an unnecessary copy of this data.
+
+  // Update continuous state and time. This call marks t- and xc-dependent
+  // cache entries out of date, including xcdot0.
   VectorBase<T>& xc = context.SetTimeAndGetMutableContinuousStateVector(
       context.get_time() + dt);  // t ← t₀ + h
+
+  // Cache: xcdot0 still references the derivative cache value, which is
+  // unchanged, although it is marked out of date.
+
   xc.PlusEqScaled(dt, xcdot0);   // xc(t₀ + h) ← xc(t₀) + dt * xcdot₀
 
   // This integrator always succeeds at taking the step.

--- a/systems/analysis/implicit_euler_integrator-inl.h
+++ b/systems/analysis/implicit_euler_integrator-inl.h
@@ -166,7 +166,7 @@ MatrixX<T> ImplicitEulerIntegrator<T>::ComputeForwardDiffJacobian(
   MatrixX<T> J(n, n);
 
   // Evaluate f(t+h,xtplus) for the current state (current xtplus).
-  VectorX<T> f = EvalTimeDerivativesUsingContext();
+  const VectorX<T> f = EvalTimeDerivativesUsingContext();
 
   // Compute the Jacobian.
   VectorX<T> xtplus_prime = xtplus;
@@ -438,9 +438,6 @@ bool ImplicitEulerIntegrator<T>::StepAbstract(const T& dt,
   Context<T>* context = this->get_mutable_context();
   DRAKE_ASSERT(xtplus &&
                xtplus->size() == context->get_continuous_state_vector().size());
-
-  // Get the initial state.
-  VectorX<T> xt0 = context->get_continuous_state_vector().CopyToVector();
 
   SPDLOG_DEBUG(drake::log(), "StepAbstract() entered for t={}, h={}, trial={}",
                context->get_time(), dt, trial);

--- a/systems/analysis/runge_kutta3_integrator-inl.h
+++ b/systems/analysis/runge_kutta3_integrator-inl.h
@@ -58,6 +58,11 @@ bool RungeKutta3Integrator<T>::DoStep(const T& h) {
   const T t0 = context.get_time();
   const T t1 = t0 + h;
 
+  // CAUTION: This is performance-sensitive inner loop code that uses dangerous
+  // long-lived references into state and cache to avoid unnecessary copying and
+  // cache invalidation. Be careful not to insert calls to methods that could
+  // invalidate any of these references before they are used.
+
   // TODO(sherm1) Consider moving this notation description to IntegratorBase
   //              when it is more widely adopted.
   // Notation: we're using numeric subscripts for times t₀ and t₁, and
@@ -74,9 +79,16 @@ bool RungeKutta3Integrator<T>::DoStep(const T& h) {
       this->EvalTimeDerivatives(context).get_vector());
   const VectorBase<T>& xcdot0 = derivs0_->get_vector();
 
+  // Cache: xcdot0 references a *copy* of the derivative result so is immune
+  // to subsequent evaluations.
+
   // Compute the first intermediate state and derivative
   // (at t⁽ᵃ⁾=t₀+h/2, x⁽ᵃ⁾, u⁽ᵃ⁾).
-  // This call invalidates t- and xc-dependent cache entries.
+
+  // This call marks t- and xc-dependent cache entries out of date, including
+  // the derivative cache entry. Note that xc is a live reference into the
+  // context -- subsequent changes through that reference are unobservable so
+  // will require manual out-of-date notifications.
   VectorBase<T>& xc = context.SetTimeAndGetMutableContinuousStateVector(
       t0 + h / 2);                      // t⁽ᵃ⁾ ← t₀ + h/2
   xc.CopyToPreSizedVector(&save_xc0_);  // Save xc₀ while we can.
@@ -86,21 +98,41 @@ bool RungeKutta3Integrator<T>::DoStep(const T& h) {
       this->EvalTimeDerivatives(context).get_vector());
   const VectorBase<T>& xcdot_a = derivs1_->get_vector();  // xcdot⁽ᵃ⁾
 
+  // Cache: xcdot_a references a *copy* of the derivative result so is immune
+  // to subsequent evaluations.
+
   // Compute the second intermediate state and derivative
   // (at t⁽ᵇ⁾=t₁, x⁽ᵇ⁾, u⁽ᵇ⁾).
-  // This call invalidates t- and xc-dependent cache entries.
+
+  // This call marks t- and xc-dependent cache entries out of date, including
+  // the derivative cache entry. (We already have the xc reference but must
+  // issue the out-of-date notification here since we're about to change it.)
   context.SetTimeAndNoteContinuousStateChange(t1);
+
   // xcⱼ ← xc₀ - h xcdot₀ + 2 h xcdot⁽ᵃ⁾
   xc.SetFromVector(save_xc0_);  // Restore xc ← xc₀.
   xc.PlusEqScaled({{-h, xcdot0}, {2 * h, xcdot_a}});
+
   const VectorBase<T>& xcdot_b =  // xcdot⁽ᵇ⁾
       this->EvalTimeDerivatives(context).get_vector();
 
-  // Calculate the final O(h³) state at t₁.
+  // Cache: xcdot_b references the live derivative cache value, currently
+  // up to date but about to be marked out of date. We do not want to make
+  // an unnecessary copy of this data.
+
+  // Cache: we're about to write through the xc reference again, so need to
+  // mark xc-dependent cache entries out of date, including xcdot_b; time
+  // doesn't change here.
   context.NoteContinuousStateChange();
+
+  // Calculate the final O(h³) state at t₁.
   // xc₁ ← xc₀ + h/6 xcdot₀ + 2/3 h xcdot⁽ᵃ⁾ + h/6 xcdot⁽ᵇ⁾
   xc.SetFromVector(save_xc0_);  // Restore xc ← xc₀.
   const T h6 = h / 6.0;
+
+  // Cache: xcdot_b still references the derivative cache value, which is
+  // unchanged, although it is marked out of date. xcdot0 and xcdot_a are
+  // unaffected.
   xc.PlusEqScaled({{h6,     xcdot0},
                    {4 * h6, xcdot_a},
                    {h6,     xcdot_b}});
@@ -113,7 +145,11 @@ bool RungeKutta3Integrator<T>::DoStep(const T& h) {
   // continuous state vector, where the various state components can be
   // analyzed.
   // ε = | xc₁ - (xc₀ + h xcdot⁽ᵃ⁾) | = | xc₀ + h xcdot⁽ᵃ⁾ - xc₁ |
+
+  // TODO(sherm1) Set err_est_vec_ to xc0 at the start and use it above to
+  //              avoid the need for save_xc0_ and this copy altogether.
   err_est_vec_ = save_xc0_;  // ε ← xc₀
+
   // TODO(sherm1) This is xcdot₀, not xcdot⁽ᵃ⁾! Should be xcdot_a; issue #10633.
   xcdot0.ScaleAndAddToVector(h, &err_est_vec_);      // ε += h xcdot₀   (WRONG!)
   // xcdot_a.ScaleAndAddToVector(h, &err_est_vec_);  // ε += h xcdot⁽ᵃ⁾ (RIGHT!)


### PR DESCRIPTION
Per discussion in PR #10638, adds comments explaining use of the Context cache in the integrators' lowest-level stepping methods. Those use tricky cache features to avoid per-step unnecessary copies and unnecessary cache invalidations.

The intent here is to scare future programmers into thinking carefully about the state of the cache before touching any of these methods.

There are two opportunistic code changes here also: I made a local variable const, and deleted an unused temporary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10854)
<!-- Reviewable:end -->
