### PR TITLE
Add DiscreteTimeDelay system block

### DIFF
--- a/systems/primitives/BUILD.bazel
+++ b/systems/primitives/BUILD.bazel
@@ -20,6 +20,7 @@ drake_cc_package_library(
         ":constant_vector_source",
         ":demultiplexer",
         ":discrete_derivative",
+        ":discrete_time_delay",
         ":first_order_low_pass_filter",
         ":gain",
         ":integrator",
@@ -111,6 +112,17 @@ drake_cc_library(
         ":linear_system",
         ":multiplexer",
         ":pass_through",
+        "//systems/framework",
+    ],
+)
+
+drake_cc_library(
+    name = "discrete_time_delay",
+    srcs = ["discrete_time_delay.cc"],
+    hdrs = ["discrete_time_delay.h"],
+    deps = [
+        "//common:default_scalars",
+        "//common:essential",
         "//systems/framework",
     ],
 )
@@ -395,6 +407,19 @@ drake_cc_googletest(
         ":trajectory_source",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/trajectories:piecewise_polynomial",
+        "//systems/analysis:simulator",
+        "//systems/framework",
+        "//systems/framework/test_utilities",
+    ],
+)
+
+drake_cc_googletest(
+    name = "discrete_time_delay_test",
+    deps = [
+        ":affine_system",
+        ":discrete_time_delay",
+        ":sine",
+        "//common/test_utilities:eigen_matrix_compare",
         "//systems/analysis:simulator",
         "//systems/framework",
         "//systems/framework/test_utilities",

--- a/systems/primitives/discrete_time_delay.cc
+++ b/systems/primitives/discrete_time_delay.cc
@@ -1,0 +1,75 @@
+#include "drake/systems/primitives/discrete_time_delay.h"
+
+#include <utility>
+
+#include "drake/common/default_scalars.h"
+
+namespace drake {
+namespace systems {
+
+template <typename T>
+DiscreteTimeDelay<T>::DiscreteTimeDelay(double update_sec, int delay_timesteps,
+                                        int vector_size)
+    : LeafSystem<T>(SystemTypeTag<systems::DiscreteTimeDelay>()),
+      update_sec_(update_sec),
+      // Delay buffer must be one element longer to properly delay signal
+      delay_buffer_size_(delay_timesteps + 1),
+      vector_size_(vector_size) {
+  DRAKE_DEMAND(vector_size >= 0);
+  // TODO(mpetersen94): remove the size parameter from the constructor
+  // once #3109 supporting automatic sizes is resolved.
+  BasicVector<T> model_value(vector_size);
+  this->DeclareVectorInputPort("u", model_value);
+  this->DeclareVectorOutputPort("delayed_u", model_value,
+                                &DiscreteTimeDelay::CopyDelayedVector);
+  this->DeclareDiscreteState(vector_size_ * delay_buffer_size_);
+  this->DeclarePeriodicDiscreteUpdateEvent(
+      update_sec_, 0., &DiscreteTimeDelay::SaveInputVectorToBuffer);
+}
+
+template <typename T>
+template <typename U>
+DiscreteTimeDelay<T>::DiscreteTimeDelay(const DiscreteTimeDelay<U>& other)
+    : DiscreteTimeDelay(other.update_sec_, other.delay_buffer_size_ - 1,
+                        other.vector_size_) {}
+
+template <typename T>
+void DiscreteTimeDelay<T>::CopyDelayedVector(
+    const Context<T>& context, BasicVector<T>* output) const {
+  const BasicVector<T>& state_value = context.get_discrete_state(0);
+  output->SetFromVector(state_value.get_value().head(vector_size_));
+}
+
+template <typename T>
+void DiscreteTimeDelay<T>::SaveInputVectorToBuffer(
+    const Context<T>& context, DiscreteValues<T>* discrete_state) const {
+  // Copies the current state of the delay buffer from the context to the
+  // discrete state, sliding the buffer forward one step, dropping the oldest
+  // value and adding the value on the input port to the end of the buffer.
+  // TODO(mpetersen94): consider revising to avoid possibly expensive buffer
+  // copy operation.
+  const auto& input = get_input_port().Eval(context);
+  Eigen::VectorBlock<VectorX<T>> updated_state_value =
+      discrete_state->get_mutable_vector(0).get_mutable_value();
+  Eigen::VectorBlock<const VectorX<T>> old_state_value =
+      context.get_discrete_state(0).get_value();
+  updated_state_value.head((delay_buffer_size_ - 1) * vector_size_) =
+      old_state_value.tail((delay_buffer_size_ - 1) * vector_size_);
+  updated_state_value.tail(vector_size_) = input;
+}
+
+template <typename T>
+optional<bool> DiscreteTimeDelay<T>::DoHasDirectFeedthrough(
+    int input_port, int output_port) const {
+  DRAKE_DEMAND(input_port == 0);
+  DRAKE_DEMAND(output_port == 0);
+  // By definition, a time delay will not have direct feedthrough, as the
+  // output only depends on the state, not the input.
+  return false;
+}
+
+}  // namespace systems
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::DiscreteTimeDelay)

--- a/systems/primitives/discrete_time_delay.h
+++ b/systems/primitives/discrete_time_delay.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include "drake/common/drake_copyable.h"
+#include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/context.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace systems {
+
+/// A discrete time delay block with input u, which is vector-valued (discrete
+/// or continuous), and output delayed_u which is previously received input,
+/// delayed by the given amount.  The initial output will be a vector of zeros
+/// until the delay time has passed.
+///
+/// @ingroup primitive_systems
+/// @system{DiscreteTimeDelay, @input_port{u}, @output_port{delayed_u}}
+///
+/// Let t,z ∈ ℕ be the number of delay time steps and the input vector size.
+/// The state x ∈ ℝ⁽ᵗ⁺¹⁾ᶻ is partitioned into t+1 blocks x[0] x[1] ... x[t],
+/// each of size z. The input and output are u,y ∈ ℝᶻ.
+/// The discrete state space dynamics of %DiscreteTimeDelay is:
+/// ```
+///   xₙ₊₁ = xₙ[1] xₙ[2] ... xₙ[t] uₙ  // update
+///   yₙ = xₙ[0]                       // output
+///   x₀ = xᵢₙᵢₜ                       // initialize
+/// ```
+/// where xᵢₙᵢₜ = 0 for vector-valued %DiscreteTimeDelay.
+///
+/// See @ref discrete_systems "Discrete Systems" for general information about
+/// discrete systems in Drake, including how they interact with continuous
+/// systems.
+///
+/// @note While the output port can be sampled at any continuous time, this
+///       system does not interpolate.
+///
+/// @tparam T Must be one of drake's default scalar types.
+template <typename T>
+class DiscreteTimeDelay final : public LeafSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DiscreteTimeDelay)
+
+  /// Constructs a DiscreteTimeDelay system updating every `update_sec` and
+  /// delaying a vector-valued input of size `vector_size` for
+  /// `delay_timesteps` number of updates.
+  DiscreteTimeDelay(double update_sec, int delay_timesteps, int vector_size);
+
+  /// Scalar-type converting copy constructor.
+  /// See @ref system_scalar_conversion.
+  template <typename U>
+  explicit DiscreteTimeDelay(const DiscreteTimeDelay<U>& other);
+
+  ~DiscreteTimeDelay() final = default;
+
+  /// Returns the sole input port.
+  const InputPort<T>& get_input_port() const {
+    return LeafSystem<T>::get_input_port(0);
+  }
+
+  /// Returns the sole output port.
+  const OutputPort<T>& get_output_port() const {
+    return LeafSystem<T>::get_output_port(0);
+  }
+
+  /// (Advanced) Manually samples the input port and updates the state of the
+  /// block, sliding the delay buffer forward and placing the sampled input at
+  /// the end. This emulates an update event and is mostly useful for testing.
+  void SaveInputToBuffer(Context<T>* context) const {
+    SaveInputVectorToBuffer(*context, &context->get_mutable_discrete_state());
+  }
+
+ private:
+  // Allow different specializations to access each other's private data.
+  template <typename U> friend class DiscreteTimeDelay;
+
+  // Override feedthrough detection to avoid the need for `DoToSymbolic()`.
+  optional<bool> DoHasDirectFeedthrough(int input_port,
+                                        int output_port) const final;
+
+  // Sets the output port value to the properly delayed vector value.
+  void CopyDelayedVector(const Context<T>& context,
+                         BasicVector<T>* output) const;
+
+  // Saves the input port into the discrete vector-valued state,
+  void SaveInputVectorToBuffer(const Context<T>& context,
+                               DiscreteValues<T>* discrete_state) const;
+
+  const double update_sec_{};
+  const int delay_buffer_size_{};
+  const int vector_size_{};
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/primitives/test/discrete_time_delay_test.cc
+++ b/systems/primitives/test/discrete_time_delay_test.cc
@@ -1,0 +1,283 @@
+#include "drake/systems/primitives/discrete_time_delay.h"
+
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <string>
+
+#include <Eigen/Dense>
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/systems/analysis/simulator.h"
+#include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/diagram.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/framework/fixed_input_port_value.h"
+#include "drake/systems/framework/system_output.h"
+#include "drake/systems/framework/test_utilities/scalar_conversion.h"
+#include "drake/systems/primitives/affine_system.h"
+#include "drake/systems/primitives/sine.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+// Define a very tight tolerance with just enough room for some roundoff.
+const double kMachineTol = 10 * std::numeric_limits<double>::epsilon();
+
+const double kUpdatePeriod = 0.1;
+const double kBuffer = 5;  // Number of timesteps the signal is delayed.
+const int kLength = 3;  // Length of vector passing through the block.
+
+class DiscreteTimeDelayTest : public ::testing::TestWithParam<bool> {
+ protected:
+  DiscreteTimeDelayTest() : is_abstract_(GetParam()) {}
+  void SetUp() override {
+    state_value_override_ << 1.0, 3.14, 2.18;
+    input_value_ << 1.0, 1.0, 3.0;
+
+    delay_ = std::make_unique<DiscreteTimeDelay<double>>(
+        kUpdatePeriod, kBuffer, kLength);
+    context_ = delay_->CreateDefaultContext();
+    context_->FixInputPort(
+        0, std::make_unique<BasicVector<double>>(input_value_));
+  }
+
+  std::unique_ptr<DiscreteTimeDelay<double>> delay_;
+  std::unique_ptr<Context<double>> context_;
+
+  const bool is_abstract_{};
+  Eigen::Vector3d state_value_override_;
+  Eigen::Vector3d input_value_;
+};
+
+// Tests that the time delay has one input, one output and no direct
+// feedthrough.
+TEST_P(DiscreteTimeDelayTest, Topology) {
+  EXPECT_EQ(1, delay_->get_num_input_ports());
+  EXPECT_EQ(1, context_->get_num_input_ports());
+
+  EXPECT_EQ(1, delay_->get_num_output_ports());
+
+  EXPECT_FALSE(delay_->HasAnyDirectFeedthrough());
+}
+
+// Tests that the time delay has correct type of state with the desired initial
+// value.
+TEST_P(DiscreteTimeDelayTest, InitialState) {
+  const Eigen::VectorXd value_expected =
+      Eigen::VectorXd::Zero(kLength * (kBuffer + 1));
+  const BasicVector<double>& xd = context_->get_discrete_state(0);
+  EXPECT_EQ(kLength * (kBuffer + 1), xd.size());
+  Eigen::VectorXd value = xd.CopyToVector();
+  EXPECT_EQ(value_expected, value);
+}
+
+// Tests that the output is the delayed input (head of the state vector.
+TEST_P(DiscreteTimeDelayTest, Output) {
+  const Eigen::Vector3d output_expected = state_value_override_;
+  BasicVector<double>& xd = context_->get_mutable_discrete_state(0);
+  xd.get_mutable_value().head(kLength) = output_expected;
+  Eigen::Vector3d output = delay_->get_output_port().Eval(*context_);
+  EXPECT_EQ(output_expected, output);
+}
+
+// Tests that SaveInputVectorToBuffer updates the state.
+TEST_P(DiscreteTimeDelayTest, Update) {
+  // Emulate an update event.
+  delay_->SaveInputToBuffer(&*context_);
+  Eigen::VectorXd value_expected =
+      Eigen::VectorXd::Zero(kLength * (kBuffer + 1));
+  value_expected.tail(kLength) = input_value_;
+  // Check that the state has been updated to the input.
+  const BasicVector<double>& xd = context_->get_discrete_state(0);
+  Eigen::VectorXd value = xd.CopyToVector();
+  EXPECT_EQ(value_expected, value);
+}
+
+TEST_P(DiscreteTimeDelayTest, ToAutoDiff) {
+  EXPECT_TRUE(is_autodiffxd_convertible(*delay_));
+}
+
+TEST_P(DiscreteTimeDelayTest, ToSymbolic) {
+  EXPECT_TRUE(is_symbolic_convertible(*delay_));
+}
+
+// Instantiate parameterized test cases for is_abstract_ = {false, true}
+INSTANTIATE_TEST_CASE_P(test, DiscreteTimeDelayTest, ::testing::Values(false));
+
+// Create a simple Diagram to simulate:
+//    +----------------------------------------------------------+
+//    |                                                          |
+//    |  +---------------+              +-----------+            |
+//    |  |               |              |           |            |
+//    |  |               | y=x        u |           | delayed_u  |
+//    |  |    Counter    +-------------->   Delay   +----------------->
+//    |  |               |              |           |            |
+//    |  | xₖ₊₁ = xₖ + 1 |              |     x     |            |
+//    |  +---------------+              +-----------+            |
+//    |                                                          |
+//    +----------------------------------------------------------+
+// Then simulate for various intervals and make sure DiscreteTimeDelay sampled
+// its discrete input at the expected times and returns the properly delayed
+// signal.
+GTEST_TEST(DiscreteTimeDelayTest, DiscreteSimulation) {
+  DiagramBuilder<double> builder;
+  // x[k+1] = x[k] + 1.  y[k] = x[k].  x[0] = 1.  (No inputs).
+  auto counter = builder.AddSystem<AffineSystem<double>>(
+      Vector1d::Constant(1.0),      // A.
+      Eigen::MatrixXd::Zero(1, 0),  // B.
+      Vector1d::Constant(1.0),      // f0.
+      Vector1d::Constant(1.0),      // C.
+      Eigen::MatrixXd::Zero(1, 0),  // D.
+      Vector1d::Constant(0.0),      // y0.
+      kUpdatePeriod / 2);
+  counter->set_name("counter");
+
+  auto delay =
+      builder.AddSystem<DiscreteTimeDelay<double>>(kUpdatePeriod, kBuffer, 1);
+  delay->set_name("delay");
+
+  builder.Connect(counter->get_output_port(), delay->get_input_port());
+  builder.ExportOutput(delay->get_output_port(), "delay_output");
+  auto diagram = builder.Build();
+
+  Simulator<double> simulator(*diagram);
+  Context<double>& context = simulator.get_mutable_context();
+  context.get_mutable_discrete_state(0).SetAtIndex(0, 1.0);
+
+  auto count_eval = [&](double t) {
+    return std::floor(2 * (t + kMachineTol) / kUpdatePeriod) + 1;
+  };
+
+  auto eval = [&]() { return diagram->get_output_port(0).Eval(context)[0]; };
+
+  simulator.Initialize();
+  EXPECT_EQ(0., eval());  // No update should have occurred yet.
+
+  simulator.StepTo(0);  // Force an update at 0.
+  EXPECT_EQ(0, eval());  // Should output initial value.
+
+  // Should output initial value until delay has passed.
+  simulator.StepTo(0.49);
+  EXPECT_EQ(0, eval());
+
+  // Should start outputing delayed input.
+  simulator.StepTo(0.5);
+  simulator.StepTo(0.5);
+  EXPECT_NEAR(count_eval(0), eval(), kMachineTol);
+
+  // Last sample at 0.9, will output value from 0.4.
+  simulator.StepTo(0.91);
+  EXPECT_NEAR(count_eval(0.4), eval(), kMachineTol);
+}
+
+// Create a simple Diagram to simulate:
+//    +-----------------------------------------------------------+
+//    |                                                           |
+//    |  +------------+                  +-----------+            |
+//    |  |            |                  |           |            |
+//    |  |            | y=a sin(wt+p)  u |           | delayed_u  |
+//    |  |    sine    +------------------>   Delay   +----------------->
+//    |  |            |                  |           |            |
+//    |  |            |                  |     x     |            |
+//    |  +------------+                  +-----------+            |
+//    |                                                           |
+//    +-----------------------------------------------------------+
+// Then simulate for various intervals and make sure DiscreteTimeDelay sampled
+// its continuous input at the expected times and returns the properly delayed
+// signal.
+GTEST_TEST(DiscreteTimeDelayTest, ContinuousSimulation) {
+  const double sine_amplitude = 10.;
+  const double sine_frequency = 2. * M_PI;
+  const double sine_phase = M_PI / 4;
+  const int size = 1;
+
+  DiagramBuilder<double> builder;
+  auto sine = builder.AddSystem<Sine<double>>(sine_amplitude, sine_frequency,
+                                              sine_phase, size);
+  sine->set_name("sine");
+
+  auto delay = builder.AddSystem<DiscreteTimeDelay<double>>(kUpdatePeriod,
+                                                            kBuffer, size);
+  delay->set_name("delay");
+
+  builder.Connect(sine->get_output_port(0), delay->get_input_port());
+  builder.ExportOutput(delay->get_output_port(), "delay_output");
+  auto diagram = builder.Build();
+
+  Simulator<double> simulator(*diagram);
+  const Context<double>& context = simulator.get_context();
+
+  auto sine_eval = [&](double t) {
+    return sine_amplitude * std::sin(sine_frequency * t + sine_phase);
+  };
+
+  auto eval = [&]() { return diagram->get_output_port(0).Eval(context)[0]; };
+
+  simulator.Initialize();
+  EXPECT_EQ(0., eval());  // No update should have occurred yet.
+
+  simulator.StepTo(0);  // Force an update at 0.
+  EXPECT_EQ(0, eval());  // Should output initial value.
+
+  // Should output initial value until delay has passed.
+  simulator.StepTo(0.49);
+  EXPECT_EQ(0, eval());
+
+  // Should start outputing delayed input.
+  simulator.StepTo(0.5);
+  simulator.StepTo(0.5);
+  EXPECT_NEAR(sine_eval(0), eval(), kMachineTol);
+
+  // Last sample at 0.9, will output value from 0.4.
+  simulator.StepTo(0.91);
+  EXPECT_NEAR(sine_eval(0.4), eval(), kMachineTol);
+}
+
+class SymbolicDiscreteTimeDelayTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const int size = 1;
+    delay_ = std::make_unique<DiscreteTimeDelay<symbolic::Expression>>(
+        kUpdatePeriod, kBuffer, size);
+
+    // Initialize the context with symbolic variables.
+    context_ = delay_->CreateDefaultContext();
+    context_->FixInputPort(
+        0, BasicVector<symbolic::Expression>::Make(symbolic::Variable("u0")));
+    auto& xd = context_->get_mutable_discrete_state(0);
+    for (int ii = 0; ii < (kBuffer + 1); ii++) {
+      xd[ii] = symbolic::Variable("x" + std::to_string(ii));
+    }
+  }
+
+  std::unique_ptr<DiscreteTimeDelay<symbolic::Expression>> delay_;
+  std::unique_ptr<Context<symbolic::Expression>> context_;
+};
+
+// Test that the oldest (first) entry of the buffer is outputted.
+TEST_F(SymbolicDiscreteTimeDelayTest, Output) {
+  const auto& out = delay_->get_output_port().Eval(*context_);
+  EXPECT_EQ("x0", out[0].to_string());
+}
+
+// Tests that SaveInputVectorToBuffer updates the state (i.e. slides the buffer
+// forward, adding the input value to the end of the buffer).
+TEST_F(SymbolicDiscreteTimeDelayTest, Update) {
+  const auto& xd = context_->get_discrete_state(0);
+  for (int ii = 0; ii < (kBuffer + 1); ii++) {
+    EXPECT_EQ("x" + std::to_string(ii), xd[ii].to_string());
+  }
+  delay_->SaveInputToBuffer(&*context_);
+  for (int ii = 0; ii < kBuffer; ii++) {
+    EXPECT_EQ("x" + std::to_string(ii + 1), xd[ii].to_string());
+  }
+  EXPECT_EQ("u0", xd[kBuffer].to_string());
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
I'm opening this pull request to get feedback on the design of this system before implementing the abstract version and adding python bindings.  I'm also curious about thought on the best suite of tests for this system.  The test (and the system as a whole) are currently based off the ZeroOrderHold system.

cc @sherm1, @RussTedrake

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10856)
<!-- Reviewable:end -->
