### PR TITLE
Remove redundant comments about default_scalars

### DIFF
--- a/attic/multibody/rigid_body_plant/compliant_contact_model.cc
+++ b/attic/multibody/rigid_body_plant/compliant_contact_model.cc
@@ -278,6 +278,5 @@ double CompliantContactModel<T>::CalcContactParameters(
 }  // namespace systems
 }  // namespace drake
 
-// Explicitly instantiates on the most common scalar types.
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
     class ::drake::systems::CompliantContactModel)

--- a/attic/multibody/rigid_body_plant/contact_detail.cc
+++ b/attic/multibody/rigid_body_plant/contact_detail.cc
@@ -14,6 +14,5 @@ ContactDetail<T>::~ContactDetail() {}
 }  // namespace systems
 }  // namespace drake
 
-// Explicitly instantiates on the most common scalar types.
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
     class ::drake::systems::ContactDetail)

--- a/attic/multibody/rigid_body_plant/contact_force.cc
+++ b/attic/multibody/rigid_body_plant/contact_force.cc
@@ -45,6 +45,5 @@ ContactForce<T>::ContactForce(const Vector3<T>& application_point,
 }  // namespace systems
 }  // namespace drake
 
-// Explicitly instantiates on the most common scalar types.
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
     class ::drake::systems::ContactForce)

--- a/attic/multibody/rigid_body_plant/contact_info.cc
+++ b/attic/multibody/rigid_body_plant/contact_info.cc
@@ -18,6 +18,5 @@ ContactInfo<T>::ContactInfo(drake::multibody::collision::ElementId element1,
 }  // namespace systems
 }  // namespace drake
 
-// Explicitly instantiates on the most common scalar types.
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
     class ::drake::systems::ContactInfo)

--- a/attic/multibody/rigid_body_plant/contact_resultant_force_calculator.cc
+++ b/attic/multibody/rigid_body_plant/contact_resultant_force_calculator.cc
@@ -207,6 +207,5 @@ void ContactResultantForceCalculator<T>::AccumulateForce(
 }  // namespace systems
 }  // namespace drake
 
-// Explicitly instantiates on the most common scalar types.
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
     class ::drake::systems::ContactResultantForceCalculator)

--- a/attic/multibody/rigid_body_plant/contact_results.cc
+++ b/attic/multibody/rigid_body_plant/contact_results.cc
@@ -36,6 +36,5 @@ ContactInfo<T>& ContactResults<T>::AddContact(
 }  // namespace systems
 }  // namespace drake
 
-// Explicitly instantiates on the most common scalar types.
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
     class ::drake::systems::ContactResults)

--- a/attic/multibody/rigid_body_plant/kinematics_results.cc
+++ b/attic/multibody/rigid_body_plant/kinematics_results.cc
@@ -115,6 +115,5 @@ Eigen::VectorBlock<const VectorX<T>> KinematicsResults<T>::get_joint_velocity(
 }  // namespace systems
 }  // namespace drake
 
-// Explicitly instantiates on the most common scalar types.
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
     class ::drake::systems::KinematicsResults)

--- a/attic/multibody/rigid_body_plant/point_contact_detail.cc
+++ b/attic/multibody/rigid_body_plant/point_contact_detail.cc
@@ -20,6 +20,5 @@ unique_ptr<ContactDetail<T>> PointContactDetail<T>::Clone() const {
 }  // namespace systems
 }  // namespace drake
 
-// Explicitly instantiates on the most common scalar types.
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
     class ::drake::systems::PointContactDetail)

--- a/attic/multibody/rigid_body_plant/rigid_body_plant.cc
+++ b/attic/multibody/rigid_body_plant/rigid_body_plant.cc
@@ -1431,6 +1431,5 @@ VectorX<T> RigidBodyPlant<T>::EvaluateActuatorInputs(
 }  // namespace systems
 }  // namespace drake
 
-// Explicitly instantiates on the most common scalar types.
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
     class ::drake::systems::RigidBodyPlant)

--- a/automotive/dynamic_bicycle_car.cc
+++ b/automotive/dynamic_bicycle_car.cc
@@ -180,6 +180,5 @@ void DynamicBicycleCar<T>::DoCalcTimeDerivatives(
 }  // namespace automotive
 }  // namespace drake
 
-// Explicitly instantiate on default scalar types.
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::automotive::DynamicBicycleCar)

--- a/math/rigid_transform.cc
+++ b/math/rigid_transform.cc
@@ -2,6 +2,5 @@
 
 #include "drake/common/default_scalars.h"
 
-// Explicitly instantiate on non-symbolic scalar types.
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::math::RigidTransform)

--- a/multibody/plant/contact_info.cc
+++ b/multibody/plant/contact_info.cc
@@ -20,6 +20,5 @@ PointPairContactInfo<T>::PointPairContactInfo(
 }  // namespace multibody
 }  // namespace drake
 
-// Explicitly instantiates on the most common scalar types.
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::PointPairContactInfo)

--- a/multibody/plant/contact_jacobians.cc
+++ b/multibody/plant/contact_jacobians.cc
@@ -2,6 +2,5 @@
 
 #include "drake/common/default_scalars.h"
 
-// Explicitly instantiates on the most common scalar types.
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     struct ::drake::multibody::internal::ContactJacobians)

--- a/multibody/plant/contact_results.cc
+++ b/multibody/plant/contact_results.cc
@@ -28,6 +28,5 @@ const PointPairContactInfo<T>& ContactResults<T>::contact_info(int i) const {
 }  // namespace multibody
 }  // namespace drake
 
-// Explicitly instantiates on the most common scalar types.
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::ContactResults)

--- a/multibody/plant/externally_applied_spatial_force.cc
+++ b/multibody/plant/externally_applied_spatial_force.cc
@@ -2,6 +2,5 @@
 
 #include "drake/common/default_scalars.h"
 
-// Explicitly instantiates on the most common scalar types.
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     struct ::drake::multibody::ExternallyAppliedSpatialForce)

--- a/multibody/plant/implicit_stribeck_solver_results.cc
+++ b/multibody/plant/implicit_stribeck_solver_results.cc
@@ -2,6 +2,5 @@
 
 #include "drake/common/default_scalars.h"
 
-// Explicitly instantiates on the most common scalar types.
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     struct ::drake::multibody::internal::ImplicitStribeckSolverResults)

--- a/solvers/unrevised_lemke_solver.cc
+++ b/solvers/unrevised_lemke_solver.cc
@@ -935,6 +935,5 @@ bool UnrevisedLemkeSolver<T>::ProgramAttributesSatisfied(
 }  // namespace solvers
 }  // namespace drake
 
-// Instantiate templates.
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
     class ::drake::solvers::UnrevisedLemkeSolver)


### PR DESCRIPTION
... as identified by `find . -name .git -prune -o -type f -print0 | xargs -0 perl -ne 'BEGIN { undef $/; } if (m|[^\n]\nDRAKE_DEFINE_CLASS|) { print $ARGV, "\n"; }'`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10861)
<!-- Reviewable:end -->
