### PR TITLE
framework: Allow for zero-sized ports, state, etc.

### DIFF
--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -2466,15 +2466,15 @@ class LeafSystem : public System<T> {
     };
 
     return CreateCachedLeafOutputPort(
-        std::move(name), 0 /* size */, std::move(allocator),
+        std::move(name), nullopt /* size */, std::move(allocator),
         std::move(cache_calc_function), std::move(calc_prerequisites));
   }
 
   // Creates a new cached LeafOutputPort in this LeafSystem and returns a
-  // reference to it. Pass fixed_size == 0 for abstract ports, or non-zero
-  // for vector ports. Prerequisites list must not be empty.
+  // reference to it. Pass fixed_size == nullopt for abstract ports, or the
+  // port size for vector ports. Prerequisites list must not be empty.
   LeafOutputPort<T>& CreateCachedLeafOutputPort(
-      std::string name, int fixed_size,
+      std::string name, const optional<int>& fixed_size,
       typename CacheEntry::AllocCallback allocator,
       typename CacheEntry::CalcCallback calculator,
       std::set<DependencyTicket> calc_prerequisites) {
@@ -2495,7 +2495,8 @@ class LeafSystem : public System<T> {
         this,  // implicit_cast<const SystemBase*>(this)
         std::move(name),
         oport_index, this->assign_next_dependency_ticket(),
-        fixed_size == 0 ? kAbstractValued : kVectorValued, fixed_size,
+        fixed_size.has_value() ? kVectorValued : kAbstractValued,
+        fixed_size.value_or(0),
         &cache_entry);
     LeafOutputPort<T>* const port_ptr = port.get();
     this->AddOutputPort(std::move(port));

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -127,6 +127,8 @@ class TestSystem : public LeafSystem<T> {
   ~TestSystem() override {}
 
   using LeafSystem<T>::DeclareContinuousState;
+  using LeafSystem<T>::DeclareDiscreteState;
+  using LeafSystem<T>::DeclareNumericParameter;
   using LeafSystem<T>::DeclareVectorInputPort;
   using LeafSystem<T>::DeclareAbstractInputPort;
   using LeafSystem<T>::DeclareVectorOutputPort;
@@ -1530,6 +1532,36 @@ GTEST_TEST(NonModelLeafSystemTest, NonModelPortsOutput) {
   EXPECT_EQ(dut.calc_POD_calls(), 2);
   out4.Eval<SomePOD>(*context);
   EXPECT_EQ(dut.calc_POD_calls(), 2);  // Should have been cached.
+}
+
+// Tests that zero-sized vectors can be declared and used.
+GTEST_TEST(ZeroSizeSystemTest, AcceptanceTest) {
+  TestSystem<double> dut;
+
+  // Input.
+  const auto& in0 = dut.DeclareVectorInputPort(
+      kUseDefaultName, BasicVector<double>(0));
+  EXPECT_EQ(in0.get_data_type(), kVectorValued);
+  EXPECT_EQ(in0.size(), 0);
+
+  // Output.
+  const auto& out0 = dut.DeclareVectorOutputPort(
+      kUseDefaultName, BasicVector<double>(0),
+      [](const Context<double>&, BasicVector<double>*) {});
+  EXPECT_EQ(out0.get_data_type(), kVectorValued);
+  EXPECT_EQ(out0.size(), 0);
+
+  // State.
+  dut.DeclareContinuousState(0);
+  const auto& disc0 = dut.DeclareDiscreteState(0);
+
+  // Parameters.
+  const auto& param0 = dut.DeclareNumericParameter(BasicVector<double>(0));
+
+  auto context = dut.CreateDefaultContext();
+  EXPECT_EQ(context->get_continuous_state_vector().size(), 0);
+  EXPECT_EQ(context->get_discrete_state(disc0).size(), 0);
+  EXPECT_EQ(context->get_numeric_parameter(param0).size(), 0);
 }
 
 // Tests both that an unrestricted update callback is called and that


### PR DESCRIPTION
Closes #10864.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10865)
<!-- Reviewable:end -->
