### PR TITLE
Corrects cloning of anchored tree

### DIFF
--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -896,6 +896,7 @@ unique_ptr<fcl::CollisionObjectd> CopyFclObjectOrThrow(
   auto copy = make_unique<fcl::CollisionObjectd>(geometry_copy);
   copy->setUserData(object.getUserData());
   copy->setTransform(object.getTransform());
+  copy->computeAABB();
   return copy;
 }
 
@@ -931,6 +932,7 @@ void BuildTreeFromReference(
   for (auto* other_object : other_objects) {
     target->registerObject(copy_map.at(other_object));
   }
+  target->update();
 }
 
 }  // namespace

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -2594,6 +2594,12 @@ GTEST_TEST(ProximityEngineTests, AnchoredBroadPhaseInitialization) {
   std::vector<GeometryId> geometry_map{id_D, id_A};
   auto pairs = engine.ComputePointPairPenetration(geometry_map);
   EXPECT_EQ(pairs.size(), 1);
+
+  // Confirm that it survives copying.
+  ProximityEngine<double> engine_copy(engine);
+  engine_copy.UpdateWorldPoses({X_WD}, {index_D});
+  auto pairs_copy = engine_copy.ComputePointPairPenetration(geometry_map);
+  EXPECT_EQ(pairs_copy.size(), 1);
 }
 
 


### PR DESCRIPTION
The anchored tree was properly configured during registration, but it didn't survive copying. This corrects that oversight.

This is the missing piece that prevents #10845 from being a *complete* fix. Proper initialization *and* proper copying.

This makes #10758 perfectly happy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10866)
<!-- Reviewable:end -->
