### PR TITLE
py doc: Fix type signatures (for template instantiations)

### DIFF
--- a/bindings/pydrake/doc/gen_sphinx.py
+++ b/bindings/pydrake/doc/gen_sphinx.py
@@ -109,6 +109,9 @@ def main():
     input_dir = dirname(abspath(__file__))
     gen_main(
         input_dir=input_dir, strict=False, src_func=write_doc_modules)
+    # TODO(eric.cousineau): Do some simple linting if this is run under
+    # `bazel test` (e.g. scan for instances of `TemporaryName`, scan for raw
+    # C++ types in type signatures, etc).
 
 
 if __name__ == "__main__":

--- a/bindings/pydrake/systems/sensors_py.cc
+++ b/bindings/pydrake/systems/sensors_py.cc
@@ -123,6 +123,7 @@ PYBIND11_MODULE(sensors, m) {
       };
 
       py::class_<ImageT> image(m, TemporaryClassName<ImageT>().c_str());
+      AddTemplateClass(m, "Image", image, py_param);
       image  // BR
           .def(py::init<int, int>(), py::arg("width"), py::arg("height"),
               doc.Image.ctor.doc_2args)
@@ -142,7 +143,6 @@ PYBIND11_MODULE(sensors, m) {
       // Constants.
       image.attr("Traits") = traits;
       // - Do not duplicate aliases (e.g. `kNumChannels`) for now.
-      AddTemplateClass(m, "Image", image, py_param);
       // Add type alias for instantiation.
       const std::string suffix = pixel_type_name.substr(1);
       m.attr(("Image" + suffix).c_str()) = image;

--- a/bindings/pydrake/systems/systems_pybind.h
+++ b/bindings/pydrake/systems/systems_pybind.h
@@ -40,6 +40,9 @@ template <typename T, typename Class = drake::Value<T>>
 py::object AddValueInstantiation(py::module scope) {
   py::class_<Class, drake::AbstractValue> py_class(
       scope, TemporaryClassName<Class>().c_str());
+  // Register instantiation.
+  py::module py_framework = py::module::import("pydrake.systems.framework");
+  AddTemplateClass(py_framework, "Value", py_class, GetPyParam<T>());
   // Only use copy (clone) construction.
   // Ownership with `unique_ptr<T>` has some annoying caveats, and some are
   // simplified by always copying.
@@ -82,9 +85,6 @@ be destroyed when it is replaced, since it is stored using `unique_ptr<>`.
 )""";
   }
   py_class.def("set_value", &Class::set_value, set_value_docstring.c_str());
-  // Register instantiation.
-  py::module py_framework = py::module::import("pydrake.systems.framework");
-  AddTemplateClass(py_framework, "Value", py_class, GetPyParam<T>());
   return py_class;
 }
 


### PR DESCRIPTION
Fixes the issue that @kmuhlrad pointed out in this Slack convo: https://drakedevelopers.slack.com/archives/C3YB3EV5W/p1552009893013200

Before:

> ![image](https://user-images.githubusercontent.com/26719449/54044403-db368e00-419c-11e9-90ab-2bc56408080f.png)

After:

> ![image](https://user-images.githubusercontent.com/26719449/54044381-cd810880-419c-11e9-9ced-ecc83bb5185e.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10868)
<!-- Reviewable:end -->
