### PR TITLE
Added LcmSubscriberSystem.WaitForMessageTimeout

### DIFF
--- a/bindings/pydrake/systems/lcm_py.cc
+++ b/bindings/pydrake/systems/lcm_py.cc
@@ -173,7 +173,7 @@ PYBIND11_MODULE(lcm, m) {
             py::arg("state"), cls_doc.CopyLatestMessageInto.doc)
         .def("WaitForMessage", &Class::WaitForMessage,
             py::arg("old_message_count"), py::arg("message") = nullptr,
-            cls_doc.WaitForMessage.doc);
+            py::arg("timeout") = -1, cls_doc.WaitForMessage.doc);
   }
 
   {

--- a/bindings/pydrake/systems/test/lcm_test.py
+++ b/bindings/pydrake/systems/test/lcm_test.py
@@ -123,6 +123,14 @@ class TestSystemsLcm(unittest.TestCase):
             sub.WaitForMessage(i, value)
             self.assertEqual(value.get_value().utime, i)
 
+    def test_subscriber_wait_for_message_with_timeout(self):
+        """Confirms that the subscriber times out."""
+        lcm = DrakeLcm("memq://")
+        lcm.StartReceiveThread()
+        sub = mut.LcmSubscriberSystem.Make("TEST_LOOP", header_t, lcm)
+        sub.WaitForMessage(0, timeout=0.02)
+        # This test fails if the test hangs.
+
     def _fix_and_publish(self, dut, value):
         context = dut.CreateDefaultContext()
         context.FixInputPort(0, value)

--- a/systems/lcm/lcm_subscriber_system.cc
+++ b/systems/lcm/lcm_subscriber_system.cc
@@ -278,40 +278,49 @@ void LcmSubscriberSystem::HandleMessage(const void* buffer, int size) {
 }
 
 int LcmSubscriberSystem::WaitForMessage(
-    int old_message_count, AbstractValue* message) const {
-  return WaitForMessageTimeout(old_message_count,
-      std::chrono::duration<double>::max(), message);
-}
-
-int LcmSubscriberSystem::WaitForMessageTimeout(
-    int old_message_count, const std::chrono::duration<double> timeout,
-    AbstractValue* message) const {
+    int old_message_count, AbstractValue* message, double timeout) const {
   DRAKE_ASSERT(serializer_ != nullptr);
 
-  auto wakeup = std::chrono::steady_clock::now() + timeout;
-  // If duration was max, set to max clock. Needed because max duration<double>
-  // is represented as inf, and this leads to issues with wait_until.
-  if (timeout == std::chrono::duration<double>::max()) {
-    wakeup = std::chrono::time_point<std::chrono::steady_clock>::max();
-  }
+// NOLINTNEXTLINE(build/namespaces): The chrono literals are just so convenient.
+  using namespace std::chrono_literals;
+  using Clock = std::chrono::steady_clock;
+  using Duration = Clock::duration;
+  using TimePoint = Clock::time_point;
 
   // The message buffer and counter are updated in HandleMessage(), which is
   // a callback function invoked by a different thread owned by the
   // drake::lcm::DrakeLcmInterface instance passed to the constructor. Thus,
   // for thread safety, these need to be properly protected by a mutex.
   std::unique_lock<std::mutex> lock(received_message_mutex_);
-  // This while loop is necessary to guard for spurious wakeup:
-  // https://en.wikipedia.org/wiki/Spurious_wakeup
-  while (old_message_count >= received_message_count_) {
-    // When wait returns, lock is atomically acquired. So it's thread safe to
-    // read received_message_count_.
-    if (received_message_condition_variable_.wait_until(lock, wakeup) ==
-            std::cv_status::timeout &&
-        old_message_count >= received_message_count_) {
-      // If a timeout occurred without meeting the message goal, then return
+
+  // Predicate to handle spurious wakeup -- in other words, we can stop if we
+  // detect a message has *actually* been received.
+  auto message_received = [&]() {
+    return received_message_count_ > old_message_count;
+  };
+  if (timeout <= 0) {
+    // No timeout.
+    received_message_condition_variable_.wait(lock, message_received);
+  } else {
+    // With timeout.
+
+    const Duration requested = std::chrono::duration_cast<Duration>(
+        std::chrono::duration<double>(timeout));
+    // Hour-encoding of ten years. Empirical evidence suggests that
+    // condition_variable::wait_* doesn't work over the full domain of otherwise
+    // valid Duration values (i.e., it can be "too large"). So, for
+    // exceptionally "large" timeouts, we cap it, silently, at ten years; if
+    // this proves too short for any given process, we can modify it later.
+    const Duration kMaxDuration(87600h);
+    const Duration duration =
+        requested < kMaxDuration ? requested : kMaxDuration;
+    DRAKE_ASSERT(TimePoint::max() - duration > Clock::now());
+    if (!received_message_condition_variable_.wait_for(lock, duration,
+                                                       message_received)) {
       return received_message_count_;
     }
   }
+
   if (message) {
       serializer_->Deserialize(
           received_message_.data(), received_message_.size(), message);

--- a/systems/lcm/lcm_subscriber_system.cc
+++ b/systems/lcm/lcm_subscriber_system.cc
@@ -304,29 +304,30 @@ int LcmSubscriberSystem::WaitForMessage(
   return new_message_count;
 }
 
-template <typename Rep, typename Period>
 int LcmSubscriberSystem::WaitForMessageTimeout(
-    int old_message_count, const std::chrono::duration<Rep, Period> timeout,
+    int old_message_count, const std::chrono::duration<double> timeout,
     AbstractValue* message) const {
   DRAKE_ASSERT(serializer_ != nullptr);
 
-  auto start = std::chrono::steady_clock::now();
+  auto wakeup = std::chrono::steady_clock::now() + timeout;
 
   // The message buffer and counter are updated in HandleMessage(), which is
   // a callback function invoked by a different thread owned by the
   // drake::lcm::DrakeLcmInterface instance passed to the constructor. Thus,
   // for thread safety, these need to be properly protected by a mutex.
   std::unique_lock<std::mutex> lock(received_message_mutex_);
-
   // This while loop is necessary to guard for spurious wakeup:
   // https://en.wikipedia.org/wiki/Spurious_wakeup
   while (old_message_count >= received_message_count_) {
     // When wait returns, lock is atomically acquired. So it's thread safe to
     // read received_message_count_.
-    if (received_message_condition_variable_.wait_until(lock, start + timeout)
-        == std::cv_status::timeout) {
-      // If a timeout occurred, return -1 for no new message
-      return received_message_count_;
+    if (received_message_condition_variable_.wait_until(lock, wakeup)
+        == std::cv_status::timeout &&
+        old_message_count >= received_message_count_) {
+      // If a timeout occurred without meeting the message goal, then return
+      int new_message_count = received_message_count_;
+      lock.unlock();
+      return new_message_count;
     }
   }
   int new_message_count = received_message_count_;

--- a/systems/lcm/lcm_subscriber_system.cc
+++ b/systems/lcm/lcm_subscriber_system.cc
@@ -304,6 +304,41 @@ int LcmSubscriberSystem::WaitForMessage(
   return new_message_count;
 }
 
+template <typename Rep, typename Period>
+int LcmSubscriberSystem::WaitForMessageTimeout(
+    int old_message_count, const std::chrono::duration<Rep, Period> timeout,
+    AbstractValue* message) const {
+  DRAKE_ASSERT(serializer_ != nullptr);
+
+  auto start = std::chrono::steady_clock::now();
+
+  // The message buffer and counter are updated in HandleMessage(), which is
+  // a callback function invoked by a different thread owned by the
+  // drake::lcm::DrakeLcmInterface instance passed to the constructor. Thus,
+  // for thread safety, these need to be properly protected by a mutex.
+  std::unique_lock<std::mutex> lock(received_message_mutex_);
+
+  // This while loop is necessary to guard for spurious wakeup:
+  // https://en.wikipedia.org/wiki/Spurious_wakeup
+  while (old_message_count >= received_message_count_) {
+    // When wait returns, lock is atomically acquired. So it's thread safe to
+    // read received_message_count_.
+    if (received_message_condition_variable_.wait_until(lock, start + timeout)
+        == std::cv_status::timeout) {
+      // If a timeout occurred, return -1 for no new message
+      return received_message_count_;
+    }
+  }
+  int new_message_count = received_message_count_;
+  if (message) {
+      serializer_->Deserialize(
+          received_message_.data(), received_message_.size(), message);
+  }
+  lock.unlock();
+
+  return new_message_count;
+}
+
 int LcmSubscriberSystem::GetInternalMessageCount() const {
   std::unique_lock<std::mutex> lock(received_message_mutex_);
   return received_message_count_;

--- a/systems/lcm/lcm_subscriber_system.h
+++ b/systems/lcm/lcm_subscriber_system.h
@@ -159,9 +159,8 @@ class LcmSubscriberSystem : public LeafSystem<double> {
    *   this will be less than or equal to old_message_count
    * @pre If `message` is specified, this system must be abstract-valued.
    */
-  template <typename Rep, typename Period>
   int WaitForMessageTimeout(
-      int old_message_count, const std::chrono::duration<Rep, Period> timeout,
+      int old_message_count, const std::chrono::duration<double> timeout,
       AbstractValue* message = nullptr) const;
 
   /**

--- a/systems/lcm/lcm_subscriber_system.h
+++ b/systems/lcm/lcm_subscriber_system.h
@@ -141,27 +141,21 @@ class LcmSubscriberSystem : public LeafSystem<double> {
 
   /**
    * Blocks the caller until its internal message count exceeds
-   * `old_message_count`.
+   * `old_message_count` with an optional timeout.
    * @param old_message_count Internal message counter.
+   *
    * @param message If non-null, will return the received message.
-   * @pre If `message` is specified, this system must be abstract-valued.
-   */
-  int WaitForMessage(
-      int old_message_count, AbstractValue* message = nullptr) const;
-
-  /**
-   * Blocks the caller until its internal message count exceeds
-   * `old_message_count` or until the timeout elapses.
-   * @param old_message_count Internal message counter.
-   * @param timeout The duration to wait before returning.
-   * @param message If non-null, will return the received message.
+   *
+   * @param timeout The duration (in seconds) to wait before returning; a
+   * non-positive duration will not time out.
+   *
    * @return Returns the new count of received messages. If a timeout occurred,
-   *   this will be less than or equal to old_message_count.
+   * this will be less than or equal to old_message_count.
+   *
    * @pre If `message` is specified, this system must be abstract-valued.
    */
-  int WaitForMessageTimeout(
-      int old_message_count, const std::chrono::duration<double> timeout,
-      AbstractValue* message = nullptr) const;
+  int WaitForMessage(int old_message_count, AbstractValue* message = nullptr,
+                     double timeout = -1.) const;
 
   /**
    * (Advanced.) Writes the most recently received message (and message count)

--- a/systems/lcm/lcm_subscriber_system.h
+++ b/systems/lcm/lcm_subscriber_system.h
@@ -150,6 +150,21 @@ class LcmSubscriberSystem : public LeafSystem<double> {
       int old_message_count, AbstractValue* message = nullptr) const;
 
   /**
+   * Blocks the caller until its internal message count exceeds
+   * `old_message_count` or until the timeout elapses
+   * @param old_message_count Internal message counter.
+   * @param timeout the duration to wait before returning
+   * @param message If non-null, will return the received message.
+   * @return Returns the new count of received messages. If a timeout occurred,
+   *   this will be less than or equal to old_message_count
+   * @pre If `message` is specified, this system must be abstract-valued.
+   */
+  template <typename Rep, typename Period>
+  int WaitForMessageTimeout(
+      int old_message_count, const std::chrono::duration<Rep, Period> timeout,
+      AbstractValue* message = nullptr) const;
+
+  /**
    * (Advanced.) Writes the most recently received message (and message count)
    * into @p state.  If no messages have been received, only the message count
    * is updated.  This is primarily useful for unit testing.

--- a/systems/lcm/lcm_subscriber_system.h
+++ b/systems/lcm/lcm_subscriber_system.h
@@ -151,12 +151,12 @@ class LcmSubscriberSystem : public LeafSystem<double> {
 
   /**
    * Blocks the caller until its internal message count exceeds
-   * `old_message_count` or until the timeout elapses
+   * `old_message_count` or until the timeout elapses.
    * @param old_message_count Internal message counter.
-   * @param timeout the duration to wait before returning
+   * @param timeout The duration to wait before returning.
    * @param message If non-null, will return the received message.
    * @return Returns the new count of received messages. If a timeout occurred,
-   *   this will be less than or equal to old_message_count
+   *   this will be less than or equal to old_message_count.
    * @pre If `message` is specified, this system must be abstract-valued.
    */
   int WaitForMessageTimeout(

--- a/systems/lcm/test/lcm_subscriber_system_test.cc
+++ b/systems/lcm/test/lcm_subscriber_system_test.cc
@@ -263,7 +263,7 @@ GTEST_TEST(LcmSubscriberSystemTest, WaitTest) {
   started = false;
   auto timeout_count = std::async(std::launch::async, [&]() {
     started = true;
-    return dut->WaitForMessageTimeout(old_count, std::chrono::milliseconds(10));
+    return dut->WaitForMessage(old_count, nullptr, 0.01 /** 10 ms */);
   });
   wait();
   // Expect a timeout, since no message has been sent
@@ -278,7 +278,7 @@ GTEST_TEST(LcmSubscriberSystemTest, WaitTest) {
   auto second_timeout_count = std::async(std::launch::async, [&]() {
     EXPECT_EQ(dut->GetInternalMessageCount(), old_count);
     started = true;
-    return dut->WaitForMessageTimeout(old_count, std::chrono::milliseconds(20));
+    return dut->WaitForMessage(old_count, nullptr, 0.02 /** 20 ms */);
   });
   wait();
   sample_data.MockPublish(&lcm, channel_name);


### PR DESCRIPTION
`LcmSubscriberSystem.WaitForMessageTimeout` is a version of ``LcmSubscriberSystem.WaitForMessage` with a specified timeout. I'm very open to the API and precise implementation here, but this functionality would be useful to avoid indefinite blocking on a bad call to `WaitForMessage`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10871)
<!-- Reviewable:end -->
