### PR TITLE
Declare ImplicitStribeckSolverResults discrete state dependent ONLY.

### DIFF
--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1764,10 +1764,11 @@ void MultibodyPlant<T>::DeclareCacheEntries() {
         this->CalcImplicitStribeckResults(context,
                                           &implicit_stribeck_solver_cache);
       },
-      // We explicitly declare the kinematics (q and v) dependence even though
-      // the Eval() above implicitly evaluates kinematics dependent cache
-      // entries.
-      {this->kinematics_ticket()});
+      // The implicit Stribeck computations are only valid when the plant is
+      // discrete. Therefore we mark this computation not a function of the full
+      // kinematics (which currently also include continuous state variables)
+      // but a function of the discrete variables only.
+      {this->xd_ticket()});
   cache_indexes_.implicit_stribeck_solver_results_ =
       implicit_stribeck_solver_cache_entry.cache_index();
 


### PR DESCRIPTION
Implicit Stribeck computations are only available when the plant is discrete. Therefore we declare this computations dependent on the discrete state only.

Relates to #10860. Bumps Anzu sim to 1.15X (pre #10783 that was at 1.6X).

**Why does this incur in a speed bump?**

It seems our integrators are broken also. They access (and invalidate) the entire continuous state of a diagram (see [here](https://github.com/RobotLocomotion/drake/blob/109d0564603faf02c95c9e51ac670ab77923414a/systems/analysis/runge_kutta2_integrator.h#L97) and [here](https://github.com/RobotLocomotion/drake/blob/109d0564603faf02c95c9e51ac670ab77923414a/systems/analysis/runge_kutta2_integrator.h#L116) for instance). 

Pre this PR, implicit Stribeck cache entries are declared dependent on `kinematics_ticket`, which essentially gets invalidated if the continuous state gets invalidated. As far as I understand, all systems have a "continuous state tracker" regardless of whether they have continuous state or not. Therefore, when an integrator says "mutate diagram continuous state", that has the side effect of invalidating the kinematics ticket.

Note that the case we are investigating is that of a discrete state plant (no continuous state at all) however the invalidation triggered from the integrators propagated down the pipeline to something discrete.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10879)
<!-- Reviewable:end -->
