### PR TITLE
Python bindings for non-parser-based MBP construction

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -379,6 +379,9 @@ drake_py_unittest(
 
 drake_py_unittest(
     name = "geometry_test",
+    data = [
+        "//systems/sensors:test_models",
+    ],
     deps = [
         ":geometry_py",
     ],

--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -10,6 +10,7 @@
 #include "drake/geometry/geometry_visualization.h"
 #include "drake/geometry/query_results/penetration_as_point_pair.h"
 #include "drake/geometry/scene_graph.h"
+#include "drake/geometry/shape_specification.h"
 
 namespace drake {
 namespace pydrake {
@@ -138,6 +139,27 @@ PYBIND11_MODULE(geometry, m) {
           doc.PenetrationAsPointPair.nhat_BA_W.doc)
       .def_readwrite("depth", &PenetrationAsPointPair<T>::depth,
           doc.PenetrationAsPointPair.depth.doc);
+
+  // Shape constructors
+  {
+    py::class_<Shape>(m, "Shape", doc.Shape.doc);
+    py::class_<Sphere, Shape>(m, "Sphere", doc.Sphere.doc)
+        .def(py::init<double>(), py::arg("radius"), doc.Sphere.ctor.doc);
+    py::class_<Cylinder, Shape>(m, "Cylinder", doc.Cylinder.doc)
+        .def(py::init<double, double>(), py::arg("radius"), py::arg("length"),
+            doc.Cylinder.ctor.doc);
+    py::class_<Box, Shape>(m, "Box", doc.Box.doc)
+        .def(py::init<double, double, double>(), py::arg("width"),
+            py::arg("depth"), py::arg("height"), doc.Box.ctor.doc);
+    py::class_<HalfSpace, Shape>(m, "HalfSpace", doc.HalfSpace.doc)
+        .def(py::init<>(), doc.HalfSpace.ctor.doc);
+    py::class_<Mesh, Shape>(m, "Mesh", doc.Mesh.doc)
+        .def(py::init<std::string, double>(), py::arg("absolute_filename"),
+            py::arg("scale") = 1.0, doc.Mesh.ctor.doc);
+    py::class_<Convex, Shape>(m, "Convex", doc.Convex.doc)
+        .def(py::init<std::string, double>(), py::arg("absolute_filename"),
+            py::arg("scale") = 1.0, doc.Convex.ctor.doc);
+  }
 }
 
 }  // namespace

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -13,6 +13,7 @@
 #include "drake/multibody/plant/contact_results.h"
 #include "drake/multibody/plant/contact_results_to_lcm.h"
 #include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/tree/spatial_inertia.h"
 
 namespace drake {
 namespace pydrake {
@@ -101,6 +102,11 @@ PYBIND11_MODULE(plant, m) {
             },
             py_reference_internal, py::arg("frame"),
             doc.MultibodyPlant.AddFrame.doc)
+        .def("AddRigidBody",
+            py::overload_cast<const std::string&,
+                const SpatialInertia<double>&>(&Class::AddRigidBody),
+            py::arg("name"), py::arg("M_BBo_B"), py_reference_internal,
+            doc.MultibodyPlant.AddRigidBody.doc_2args)
         .def("WeldFrames", &Class::WeldFrames, py::arg("A"), py::arg("B"),
             py::arg("X_AB") = Isometry3<double>::Identity(),
             py_reference_internal, doc.MultibodyPlant.WeldFrames.doc)
@@ -395,6 +401,19 @@ PYBIND11_MODULE(plant, m) {
         .def("RegisterAsSourceForSceneGraph",
             &Class::RegisterAsSourceForSceneGraph, py::arg("scene_graph"),
             doc.MultibodyPlant.RegisterAsSourceForSceneGraph.doc)
+        .def("RegisterVisualGeometry",
+            py::overload_cast<const Body<T>&, const Isometry3<double>&,
+                const geometry::Shape&, const std::string&,
+                const Vector4<double>&, geometry::SceneGraph<T>*>(
+                &Class::RegisterVisualGeometry),
+            py::arg("body"), py::arg("X_BG"), py::arg("shape"), py::arg("name"),
+            py::arg("diffuse_color"), py::arg("scene_graph") = nullptr,
+            doc.MultibodyPlant.RegisterVisualGeometry
+                .doc_6args_body_X_BG_shape_name_diffuse_color_scene_graph)
+        .def("RegisterCollisionGeometry", &Class::RegisterCollisionGeometry,
+            py::arg("body"), py::arg("X_BG"), py::arg("shape"), py::arg("name"),
+            py::arg("coulomb_friction"), py::arg("scene_graph") = nullptr,
+            doc.MultibodyPlant.RegisterCollisionGeometry.doc)
         .def("get_source_id", &Class::get_source_id,
             doc.MultibodyPlant.get_source_id.doc)
         .def("get_geometry_query_input_port",
@@ -607,6 +626,14 @@ PYBIND11_MODULE(plant, m) {
             &Class::get_contact_result_input_port, py_reference_internal)
         .def("get_lcm_message_output_port", &Class::get_lcm_message_output_port,
             py_reference_internal);
+  }
+
+  // CoulombFriction
+  {
+    using Class = CoulombFriction<T>;
+    py::class_<Class>(m, "CoulombFriction")
+        .def(py::init<const T&, const T&>(), py::arg("static_friction"),
+            py::arg("dynamic_friction"), doc.CoulombFriction.ctor.doc_2args);
   }
 
   m.def("AddMultibodyPlantSceneGraph",

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -165,6 +165,15 @@ PYBIND11_MODULE(tree, m) {
     py::class_<Class, Joint<T>> cls(
         m, "PrismaticJoint", doc.PrismaticJoint.doc);
     cls  // BR
+        .def(py::init<const string&, const Frame<T>&, const Frame<T>&,
+                 const Vector3<T>&, double, double, double>(),
+            py::arg("name"), py::arg("frame_on_parent"),
+            py::arg("frame_on_child"), py::arg("axis"),
+            py::arg("pos_lower_limit") =
+                -std::numeric_limits<double>::infinity(),
+            py::arg("pos_upper_limit") =
+                std::numeric_limits<double>::infinity(),
+            py::arg("damping") = 0, doc.RevoluteJoint.ctor.doc_7args)
         .def("get_translation", &Class::get_translation, py::arg("context"),
             doc.PrismaticJoint.get_translation.doc)
         .def("set_translation", &Class::set_translation, py::arg("context"),
@@ -250,6 +259,28 @@ PYBIND11_MODULE(tree, m) {
     enum_py  // BR
         .value("kQDot", Enum::kQDot, enum_doc.kQDot.doc)
         .value("kV", Enum::kV, enum_doc.kV.doc);
+  }
+
+  // Inertias
+  {
+    using Class = UnitInertia<T>;
+    constexpr auto& cls_doc = doc.UnitInertia;
+    py::class_<Class> cls(m, "UnitInertia", cls_doc.doc);
+    cls  // BR
+        .def(py::init(), cls_doc.ctor.doc_0args)
+        .def(py::init<const T&, const T&, const T&>(), py::arg("Ixx"),
+            py::arg("Iyy"), py::arg("Izz"), cls_doc.ctor.doc_3args);
+  }
+  {
+    using Class = SpatialInertia<T>;
+    constexpr auto& cls_doc = doc.SpatialInertia;
+    py::class_<Class> cls(m, "SpatialInertia", cls_doc.doc);
+    cls  // BR
+        .def(py::init(), cls_doc.ctor.doc_0args)
+        .def(py::init<const T&, const Eigen::Ref<const Vector3<T>>&,
+                 const UnitInertia<T>&>(),
+            py::arg("mass"), py::arg("p_PScm_E"), py::arg("G_SP_E"),
+            cls_doc.ctor.doc_3args);
   }
 }
 

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -3,6 +3,7 @@ import pydrake.geometry as mut
 import unittest
 import warnings
 
+from pydrake.common import FindResourceOrThrow
 from pydrake.lcm import DrakeMockLcm
 from pydrake.systems.framework import DiagramBuilder, InputPort, OutputPort
 from pydrake.common.deprecation import DrakeDeprecationWarning
@@ -77,3 +78,17 @@ class TestGeometry(unittest.TestCase):
         self.assertTupleEqual(obj.p_ACa.shape, (3,))
         self.assertTupleEqual(obj.p_BCb.shape, (3,))
         self.assertIsInstance(obj.distance, float)
+
+    def test_shape_constructors(self):
+        box_mesh_path = FindResourceOrThrow(
+            "drake/systems/sensors/test/models/meshes/box.obj")
+        shapes = [
+            mut.Sphere(radius=1.0),
+            mut.Cylinder(radius=1.0, length=2.0),
+            mut.Box(width=1.0, depth=2.0, height=3.0),
+            mut.HalfSpace(),
+            mut.Mesh(absolute_filename=box_mesh_path, scale=1.0),
+            mut.Convex(absolute_filename=box_mesh_path, scale=1.0)
+        ]
+        for shape in shapes:
+            self.assertIsInstance(shape, mut.Shape)


### PR DESCRIPTION
@EricCousineau-TRI, I'd be happy to drop very simplistic versions of tests for some or all of these functions, but I'd love to take you up on your offer of help if you're willing. In particular, this is related to your TODO in `bindings/pydrake/multibody/test/plant_test.py::test_multibody_plant_api_via_parsing`, which is currently pretty monolithic and might be simplify-able with this PR. Any preference for how to do this?
 (Again, I'm totally OK with you punting, and I can drop in some really simplistic coverage of these functions to prove they can be called without exploding.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10887)
<!-- Reviewable:end -->
