### PR TITLE
common/yaml: Mark private to placate our install

### DIFF
--- a/common/yaml/dev/BUILD.bazel
+++ b/common/yaml/dev/BUILD.bazel
@@ -9,10 +9,11 @@ load(
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//visibility:private"])
 
 drake_cc_package_library(
     name = "dev",
+    visibility = ["//visibility:private"],
     deps = [
         ":visitor",
         ":yaml_read_archive",

--- a/tools/install/libdrake/build_components.bzl
+++ b/tools/install/libdrake/build_components.bzl
@@ -44,7 +44,6 @@ LIBDRAKE_COMPONENTS = [
     "//common",
     "//common/proto",
     "//common/trajectories",
-    "//common/yaml/dev",
     "//common:drake_marker_shared_library",  # unpackaged
     "//common:text_logging_gflags_h",  # unpackaged
     "//examples/acrobot:acrobot_input",  # unpackaged


### PR DESCRIPTION
Adding a new header dependency involves annotating various release meta-data; we'll defer that to future work, to unbreak macOS CI.