### PR TITLE
Adds BulbStates to RightOfWayPhase

### DIFF
--- a/automotive/maliput/api/BUILD.bazel
+++ b/automotive/maliput/api/BUILD.bazel
@@ -110,6 +110,8 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "rules_test",
     srcs = [
+        "test/right_of_way_phase_ring_test.cc",
+        "test/right_of_way_phase_test.cc",
         "test/right_of_way_state_provider_test.cc",
         "test/rules_regions_test.cc",
         "test/rules_right_of_way_test.cc",

--- a/automotive/maliput/api/rules/right_of_way_phase.cc
+++ b/automotive/maliput/api/rules/right_of_way_phase.cc
@@ -1,12 +1,17 @@
 #include "drake/automotive/maliput/api/rules/right_of_way_phase.h"
 
+#include <utility>
+
 namespace drake {
 namespace maliput {
 namespace api {
 namespace rules {
 
-RightOfWayPhase::RightOfWayPhase(const Id& id, const RuleStates& rule_states)
-    : id_(id), rule_states_(rule_states) {}
+RightOfWayPhase::RightOfWayPhase(const Id& id, const RuleStates& rule_states,
+                                 optional<BulbStates> bulb_states)
+    : id_(id),
+      rule_states_(std::move(rule_states)),
+      bulb_states_(std::move(bulb_states)) {}
 
 }  // namespace rules
 }  // namespace api

--- a/automotive/maliput/api/rules/right_of_way_phase.h
+++ b/automotive/maliput/api/rules/right_of_way_phase.h
@@ -3,16 +3,24 @@
 #include <unordered_map>
 
 #include "drake/automotive/maliput/api/rules/right_of_way_rule.h"
+#include "drake/automotive/maliput/api/rules/traffic_lights.h"
 #include "drake/automotive/maliput/api/type_specific_identifier.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_optional.h"
 
 namespace drake {
 namespace maliput {
 namespace api {
 namespace rules {
 
+/// A mapping from a RightOfWayRule::Id to a RightOfWayRule::State::Id. Just an
+/// alias for user convenience.
 using RuleStates =
     std::unordered_map<RightOfWayRule::Id, RightOfWayRule::State::Id>;
+
+/// A mapping from a Bulb::Id to a BulbState. Just an alias for user
+/// convenience.
+using BulbStates = std::unordered_map<Bulb::Id, BulbState>;
 
 /// A group of RightOfWayRule instances and their states. It models coupling
 /// between these rules due to, for example, spatial co-location at
@@ -27,9 +35,14 @@ class RightOfWayPhase final {
   /// Constructs a RightOfWayPhase.
   ///
   /// @param id the unique ID of the phase (in the RightOfWayRulePhaseRing)
+  ///
   /// @param rule_states the RightOfWayRules and their states when the phase is
   /// applied, e.g., to an intersection.
-  RightOfWayPhase(const Id& id, const RuleStates& rule_states);
+  ///
+  /// @param bulb_states the states of the bulbs when this phase is applied,
+  /// e.g., to an intersection.
+  RightOfWayPhase(const Id& id, const RuleStates& rule_states,
+                  optional<BulbStates> bulb_states = nullopt);
 
   /// Returns the phase's identifier.
   const Id& id() const { return id_; }
@@ -37,9 +50,13 @@ class RightOfWayPhase final {
   /// Returns the phase's RightOfWayRule instances and their states.
   const RuleStates& rule_states() const { return rule_states_; }
 
+  /// Returns the phase's bulb states.
+  const optional<BulbStates>& bulb_states() const { return bulb_states_; }
+
  private:
   Id id_;
   RuleStates rule_states_;
+  optional<BulbStates> bulb_states_;
 };
 
 }  // namespace rules

--- a/automotive/maliput/api/rules/right_of_way_phase_ring.cc
+++ b/automotive/maliput/api/rules/right_of_way_phase_ring.cc
@@ -8,11 +8,12 @@ namespace api {
 namespace rules {
 namespace {
 
-/// Tests for completeness. The set of RightOfWayRule::Id referenced by every
-/// phase must be the same. In other words, every Rule::Id referenced in any one
-/// phase must be referenced in all phases. This is because every phase must
-/// specify the complete state of all the rules mentioned by the ring.
-void VerifyAllPhasesHaveSameRuleCoverage(
+/// Tests for completeness. The set of RightOfWayRule::Id and Bulb::Id
+/// referenced by every phase must be the same. In other words, every Rule::Id
+/// or Bulb::Id referenced in any one phase must be referenced in all phases.
+/// This is because every phase must specify the complete state of all the rules
+/// and bulb states mentioned by the ring.
+void VerifyAllPhasesHaveSameCoverage(
     const std::vector<RightOfWayPhase>& phases) {
   DRAKE_THROW_UNLESS(phases.size() >= 1);
   const auto& r = phases.at(0);  // The reference phase.
@@ -21,20 +22,32 @@ void VerifyAllPhasesHaveSameRuleCoverage(
     for (const auto& s : phase.rule_states()) {
       DRAKE_THROW_UNLESS(r.rule_states().count(s.first) == 1);
     }
+    // Require both set of bulb states to be defined or undefined together.
+    DRAKE_THROW_UNLESS(
+        (r.bulb_states() == nullopt && phase.bulb_states() == nullopt) ||
+        (r.bulb_states() != nullopt && phase.bulb_states() != nullopt));
+    if (r.bulb_states() != nullopt) {
+      DRAKE_THROW_UNLESS(phase.bulb_states()->size() ==
+                         r.bulb_states()->size());
+      for (const auto& s : *phase.bulb_states()) {
+        DRAKE_THROW_UNLESS(r.bulb_states()->count(s.first) == 1);
+      }
+    }
   }
 }
 
 }  // namespace
 
-RightOfWayPhaseRing::RightOfWayPhaseRing(const Id& id,
-    const std::vector<RightOfWayPhase>& phases) : id_(id) {
+RightOfWayPhaseRing::RightOfWayPhaseRing(
+    const Id& id, const std::vector<RightOfWayPhase>& phases)
+    : id_(id) {
   DRAKE_THROW_UNLESS(phases.size() >= 1);
   for (const RightOfWayPhase& phase : phases) {
     // Construct index of phases by ID, ensuring uniqueness of ID's.
     auto result = phases_.emplace(phase.id(), phase);
     DRAKE_THROW_UNLESS(result.second);
   }
-  VerifyAllPhasesHaveSameRuleCoverage(phases);
+  VerifyAllPhasesHaveSameCoverage(phases);
 }
 
 }  // namespace rules

--- a/automotive/maliput/api/rules/right_of_way_phase_ring.h
+++ b/automotive/maliput/api/rules/right_of_way_phase_ring.h
@@ -27,8 +27,8 @@ class RightOfWayPhaseRing final {
   /// @param phases the phases within this ring.
   ///
   /// @throws std::exception if `phases` is empty, `phases` contains duplicate
-  /// RightOfWayPhase::Id's, or the phases define different sets of
-  /// RightOfWayRule::Ids.
+  /// RightOfWayPhase::Id's, the phases define different sets of
+  /// RightOfWayRule::Ids, or the phases define different sets of bulb states.
   RightOfWayPhaseRing(const Id& id, const std::vector<RightOfWayPhase>& phases);
 
   /// Returns the phase ring's identifier.
@@ -36,7 +36,9 @@ class RightOfWayPhaseRing final {
 
   /// Returns the catalog of phases.
   const std::unordered_map<RightOfWayPhase::Id, RightOfWayPhase>& phases()
-      const { return phases_; }
+      const {
+    return phases_;
+  }
 
  private:
   Id id_;

--- a/automotive/maliput/api/test/right_of_way_phase_ring_test.cc
+++ b/automotive/maliput/api/test/right_of_way_phase_ring_test.cc
@@ -1,0 +1,86 @@
+/* clang-format off to disable clang-format-includes */
+#include "drake/automotive/maliput/api/rules/right_of_way_phase_ring.h"
+/* clang-format on */
+// TODO(liang.fok) Satisfy clang-format via rules tests directory reorg.
+
+#include <exception>
+
+#include <gtest/gtest.h>
+
+#include "drake/automotive/maliput/api/rules/right_of_way_phase.h"
+#include "drake/automotive/maliput/api/rules/right_of_way_rule.h"
+#include "drake/automotive/maliput/api/rules/traffic_lights.h"
+#include "drake/automotive/maliput/api/test_utilities/rules_test_utilities.h"
+
+namespace drake {
+namespace maliput {
+namespace api {
+namespace rules {
+namespace {
+
+RightOfWayPhase CreateFullPhase(const RightOfWayPhase::Id& id) {
+  return RightOfWayPhase{
+      id,
+      {{RightOfWayRule::Id("rule_a"), RightOfWayRule::State::Id("GO")},
+       {RightOfWayRule::Id("rule_b"), RightOfWayRule::State::Id("STOP")}},
+      {{{Bulb::Id("rule_a_green"), BulbState::kOn},
+        {Bulb::Id("rule_a_red"), BulbState::kOff},
+        {Bulb::Id("rule_b_green"), BulbState::kOff},
+        {Bulb::Id("rule_b_red"), BulbState::kOn}}}};
+}
+
+RightOfWayPhase CreatePhaseWithMissingRuleStates(
+    const RightOfWayPhase::Id& id) {
+  const RightOfWayPhase mock_phase = CreateFullPhase(id);
+  RuleStates rule_states = mock_phase.rule_states();
+  rule_states.erase(rule_states.begin());
+  return RightOfWayPhase(id, rule_states, mock_phase.bulb_states());
+}
+
+RightOfWayPhase CreatePhaseWithMissingBulbStates(
+    const RightOfWayPhase::Id& id) {
+  const RightOfWayPhase mock_phase = CreateFullPhase(id);
+  BulbStates bulb_states = *mock_phase.bulb_states();
+  bulb_states.erase(bulb_states.begin());
+  return RightOfWayPhase(id, mock_phase.rule_states(), bulb_states);
+}
+
+GTEST_TEST(RightOfWayPhaseRingTest, Constructor) {
+  EXPECT_NO_THROW(RightOfWayPhaseRing(
+      RightOfWayPhaseRing::Id("dut"),
+      {CreateFullPhase(RightOfWayPhase::Id("my_phase_1")),
+       CreateFullPhase(RightOfWayPhase::Id("my_phase_2"))}));
+
+  // No phases.
+  EXPECT_THROW(RightOfWayPhaseRing(RightOfWayPhaseRing::Id("dut"), {}),
+               std::exception);
+
+  // Duplicate phases.
+  EXPECT_THROW(
+      RightOfWayPhaseRing(RightOfWayPhaseRing::Id("dut"),
+                          {CreateFullPhase(RightOfWayPhase::Id("my_phase")),
+                           CreateFullPhase(RightOfWayPhase::Id("my_phase"))}),
+      std::exception);
+
+  // Phases that differ in RightOfWayRule coverage.
+  EXPECT_THROW(
+      RightOfWayPhaseRing(RightOfWayPhaseRing::Id("dut"),
+                          {CreateFullPhase(RightOfWayPhase::Id("full")),
+                           CreatePhaseWithMissingRuleStates(
+                               RightOfWayPhase::Id("missing_rules"))}),
+      std::exception);
+
+  // Phases that differ in bulb state coverage.
+  EXPECT_THROW(
+      RightOfWayPhaseRing(RightOfWayPhaseRing::Id("dut"),
+                          {CreateFullPhase(RightOfWayPhase::Id("full")),
+                           CreatePhaseWithMissingBulbStates(
+                               RightOfWayPhase::Id("missing_rules"))}),
+      std::exception);
+}
+
+}  // namespace
+}  // namespace rules
+}  // namespace api
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/api/test/right_of_way_phase_test.cc
+++ b/automotive/maliput/api/test/right_of_way_phase_test.cc
@@ -1,0 +1,63 @@
+/* clang-format off to disable clang-format-includes */
+#include "drake/automotive/maliput/api/rules/right_of_way_phase.h"
+/* clang-format on */
+// TODO(liang.fok) Satisfy clang-format via rules tests directory reorg.
+
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "drake/automotive/maliput/api/test_utilities/rules_test_utilities.h"
+
+namespace drake {
+namespace maliput {
+namespace api {
+namespace rules {
+namespace {
+
+class RightOfWayPhaseTest : public ::testing::Test {
+ protected:
+  RightOfWayPhaseTest()
+      : id_("test_id"),
+        rule_states_{{RightOfWayRule::Id("northbound-forward"),
+                      RightOfWayRule::State::Id("GO")},
+                     {RightOfWayRule::Id("southbound-left-turn"),
+                      RightOfWayRule::State::Id("STOP")}},
+        bulb_states_{{{Bulb::Id("northbound-forward-green"), BulbState::kOn},
+                      {Bulb::Id("northbound-forward-red"), BulbState::kOff},
+                      {Bulb::Id("southbound-left-turn-green"), BulbState::kOff},
+                      {Bulb::Id("southbound-left-turn-red"), BulbState::kOn}}},
+        phase_{id_, rule_states_, bulb_states_} {}
+
+  const RightOfWayPhase::Id id_;
+  const RuleStates rule_states_;
+  const optional<BulbStates> bulb_states_;
+  const RightOfWayPhase phase_;
+};
+
+TEST_F(RightOfWayPhaseTest, Accessors) {
+  for (const optional<BulbStates>& bulb_states :
+       std::vector<optional<BulbStates>>{nullopt, bulb_states_}) {
+    RightOfWayPhase dut(id_, rule_states_, bulb_states);
+    EXPECT_EQ(dut.id(), id_);
+    EXPECT_EQ(dut.rule_states(), rule_states_);
+    EXPECT_EQ(dut.bulb_states(), bulb_states);
+  }
+}
+
+TEST_F(RightOfWayPhaseTest, Copying) {
+  const RightOfWayPhase dut(phase_);
+  EXPECT_TRUE(MALIPUT_IS_EQUAL(dut, phase_));
+}
+
+TEST_F(RightOfWayPhaseTest, Assignment) {
+  RightOfWayPhase dut(RightOfWayPhase::Id("other_dut_id"), RuleStates());
+  dut = phase_;
+  EXPECT_TRUE(MALIPUT_IS_EQUAL(dut, phase_));
+}
+
+}  // namespace
+}  // namespace rules
+}  // namespace api
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/api/test_utilities/rules_test_utilities.h
+++ b/automotive/maliput/api/test_utilities/rules_test_utilities.h
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/automotive/maliput/api/rules/regions.h"
+#include "drake/automotive/maliput/api/rules/right_of_way_phase.h"
 #include "drake/automotive/maliput/api/rules/traffic_lights.h"
 #include "drake/common/unused.h"
 
@@ -298,6 +299,53 @@ inline ::testing::AssertionResult IsEqual(const char* a_expression,
   }
   return c.result();
 }
+
+/// Predicate-formatter which tests equality of RuleStates.
+inline ::testing::AssertionResult IsEqual(const char* a_expression,
+                                          const char* b_expression,
+                                          const RuleStates& a,
+                                          const RuleStates& b) {
+  unused(a_expression, b_expression);
+  AssertionResultCollector c;
+  MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a.size(), b.size()));
+  for (const auto& rule_state : a) {
+    MALIPUT_ADD_RESULT(
+        c, MALIPUT_IS_EQUAL(b.at(rule_state.first), rule_state.second));
+  }
+  return c.result();
+}
+
+/// Predicate-formatter which tests equality of optional<BulbStates>.
+inline ::testing::AssertionResult IsEqual(const char* a_expression,
+                                          const char* b_expression,
+                                          const optional<BulbStates>& a,
+                                          const optional<BulbStates>& b) {
+  unused(a_expression, b_expression);
+  AssertionResultCollector c;
+  MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a.has_value(), b.has_value()));
+  if (a.has_value()) {
+    MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a->size(), b->size()));
+    for (const auto& bulb_state : *a) {
+      MALIPUT_ADD_RESULT(
+          c, MALIPUT_IS_EQUAL(b->at(bulb_state.first), bulb_state.second));
+    }
+  }
+  return c.result();
+}
+
+/// Predicate-formatter which tests equality of RightOfWayPhase.
+inline ::testing::AssertionResult IsEqual(const char* a_expression,
+                                          const char* b_expression,
+                                          const RightOfWayPhase& a,
+                                          const RightOfWayPhase& b) {
+  unused(a_expression, b_expression);
+  AssertionResultCollector c;
+  MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a.id(), b.id()));
+  MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a.rule_states(), b.rule_states()));
+  MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a.bulb_states(), b.bulb_states()));
+  return c.result();
+}
+
 }  // namespace test
 }  // namespace rules
 }  // namespace api


### PR DESCRIPTION
This PR also updates RightOfWayRing to ensure consistency in bulb state
coverage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10899)
<!-- Reviewable:end -->
