### PR TITLE
Clean up and modernize the ZeroOrderHold implementation

### DIFF
--- a/systems/primitives/BUILD.bazel
+++ b/systems/primitives/BUILD.bazel
@@ -593,8 +593,10 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "zero_order_hold_test",
     deps = [
+        ":sine",
         ":zero_order_hold",
         "//common/test_utilities:eigen_matrix_compare",
+        "//systems/analysis:simulator",
         "//systems/framework",
         "//systems/framework/test_utilities",
     ],

--- a/systems/primitives/test/zero_order_hold_test.cc
+++ b/systems/primitives/test/zero_order_hold_test.cc
@@ -1,5 +1,6 @@
 #include "drake/systems/primitives/zero_order_hold.h"
 
+#include <limits>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -8,17 +9,23 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"
+#include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/framework/fixed_input_port_value.h"
 #include "drake/systems/framework/system_output.h"
 #include "drake/systems/framework/test_utilities/scalar_conversion.h"
+#include "drake/systems/primitives/sine.h"
 
 namespace drake {
 namespace systems {
 namespace {
 
-const double kTenHertz = 0.1;
+const double kPeriod = 0.1;
 const int kLength = 3;
+
+// Define a very tight tolerance with just enough room for some roundoff.
+const double kMachineTol = 10 * std::numeric_limits<double>::epsilon();
 
 // A simple type containing a vector, to simplify checking expected values for
 // a vector-valued ZOH (`BasicValue`) and an abstract-valued ZOH
@@ -49,15 +56,16 @@ class ZeroOrderHoldTest : public ::testing::TestWithParam<bool> {
   ZeroOrderHoldTest()
       : is_abstract_(GetParam()) {}
   void SetUp() override {
+    DRAKE_DEMAND(kLength == 3);
     state_value_override_ << 1.0, 3.14, 2.18;
     input_value_ << 1.0, 1.0, 3.0;
 
     if (!is_abstract_) {
-      hold_ = std::make_unique<ZeroOrderHold<double>>(kTenHertz, kLength);
+      hold_ = std::make_unique<ZeroOrderHold<double>>(kPeriod, kLength);
     } else {
       // Initialize to zero.
       hold_ = std::make_unique<ZeroOrderHold<double>>(
-          kTenHertz, Value<SimpleAbstractType>(Eigen::Vector3d::Zero()));
+          kPeriod, Value<SimpleAbstractType>(Eigen::Vector3d::Zero()));
     }
     context_ = hold_->CreateDefaultContext();
     if (!is_abstract_) {
@@ -83,7 +91,7 @@ class ZeroOrderHoldTest : public ::testing::TestWithParam<bool> {
     }
   }
 
-  std::unique_ptr<System<double>> hold_;
+  std::unique_ptr<ZeroOrderHold<double>> hold_;
   std::unique_ptr<Context<double>> context_;
   std::unique_ptr<CompositeEventCollection<double>> event_info_;
   const LeafCompositeEventCollection<double>* leaf_info_;
@@ -126,61 +134,61 @@ TEST_P(ZeroOrderHoldTest, Output) {
   Eigen::Vector3d output;
   if (!is_abstract_) {
     BasicVector<double>& xd = context_->get_mutable_discrete_state(0);
-    xd.get_mutable_value() << output_expected;
-    output = hold_->get_output_port(0).Eval(*context_);
+    xd.SetFromVector(output_expected);
+    output = hold_->get_output_port().Eval(*context_);
   } else {
     SimpleAbstractType& state_value =
         context_->get_mutable_abstract_state<SimpleAbstractType>(0);
     state_value = SimpleAbstractType(output_expected);
-    output = hold_->get_output_port(0).
+    output = hold_->get_output_port().
         template Eval<SimpleAbstractType>(*context_).value();
   }
   EXPECT_EQ(output_expected, output);
 }
 
-// Tests that when the current time is exactly on the sampling period, a update
+// This test and the next one verify that the assumptions we make in ZOH about
+// the behavior of Drake's rather elaborate event system are correct. If Drake's
+// behavior were to change, ZOH couldn't deliver its contract so these unit
+// tests provide insurance against such a change.
+
+// Tests that when the current time is exactly on the sampling period, an update
 // is requested in the future.
 TEST_P(ZeroOrderHoldTest, NextUpdateTimeMustNotBeCurrentTime) {
-  // Calculate the next update time.
+  // Calculate the next update time *after* 0.
   context_->set_time(0.0);
-  double next_t = hold_->CalcNextUpdateTime(*context_, event_info_.get());
+  const double t_next = hold_->CalcNextUpdateTime(*context_, event_info_.get());
 
   // Check that the time is correct.
-  EXPECT_NEAR(0.1, next_t, 10e-8);
+  EXPECT_NEAR(kPeriod, t_next, kMachineTol);
 
   // Check that the action is to update.
   CheckForUpdateAction();
 }
 
-// Tests that when the current time is between updates, a update is requested
+// Tests that when the current time is between updates, an update is requested
 // at the appropriate time in the future.
 TEST_P(ZeroOrderHoldTest, NextUpdateTimeIsInTheFuture) {
   // Calculate the next update time.
-  context_->set_time(76.32);
+  context_->set_time(763.2 * kPeriod);
 
   // Check that the time is correct.
-  double next_t = hold_->CalcNextUpdateTime(*context_, event_info_.get());
-  EXPECT_NEAR(76.4, next_t, 10e-8);
+  const double t_next = hold_->CalcNextUpdateTime(*context_, event_info_.get());
+  EXPECT_NEAR(764 * kPeriod, t_next, kMachineTol);
 
   // Check that the action is to update.
   CheckForUpdateAction();
 }
 
-// Tests that discrete updates update the state.
+// Tests that LatchInputPortToState() updates the state.
 TEST_P(ZeroOrderHoldTest, Update) {
-  // Fire off an update event.
+  // Emulate an update event.
+  hold_->LatchInputPortToState(&*context_);
   Eigen::Vector3d value;
   if (!is_abstract_) {
-    std::unique_ptr<DiscreteValues<double>> update =
-        hold_->AllocateDiscreteVariables();
-    hold_->CalcDiscreteVariableUpdates(*context_, update.get());
-    // Check that the state has been updated to the input.
-    const BasicVector<double>& xd = update->get_vector(0);
-    value = xd.CopyToVector();
+    value = hold_->get_output_port().Eval(*context_);
   } else {
-    State<double>& state = context_->get_mutable_state();
-    hold_->CalcUnrestrictedUpdate(*context_, &state);
-    value = state.get_abstract_state<SimpleAbstractType>(0).value();
+    value =
+        hold_->get_output_port().Eval<SimpleAbstractType>(*context_).value();
   }
   EXPECT_EQ(input_value_, value);
 }
@@ -196,6 +204,72 @@ TEST_P(ZeroOrderHoldTest, ToSymbolic) {
 // Instantiate parameterized test cases for is_abstract_ = {false, true}
 INSTANTIATE_TEST_CASE_P(test, ZeroOrderHoldTest,
     ::testing::Values(false, true));
+
+// Create a simple Diagram like this:
+//    +-----------------------------------------------------+
+//    |                                                     |
+//    |  +------------+                  +-----------+      |
+//    |  |            |                  |           |      |
+//    |  |            | y=a sin(wt+p)    |           | y=x  |   y
+//    |  |    sine    +------------------> u  ZOH    +---------->
+//    |  |            |                  |           |      |
+//    |  |            |                  |     x     |      |
+//    |  +------------+                  +-----------+      |
+//    |                                                     |
+//    +-----------------------------------------------------+
+//
+// This test confirms the documented output port value is achieved both at
+// initialization and after time advancement (with updates) by the Simulator.
+GTEST_TEST(ZeroOrderHoldTest, UseInDiagram) {
+  const double amplitude = 10.;
+  const double frequency = 2. * M_PI;  // times t
+  const double phase = M_PI / 4;
+  const int size = 1;  // Just a 1-element output vector.
+
+  auto sine_eval = [&](double t) {
+    return amplitude * std::sin(frequency * t + phase);
+  };
+
+  DiagramBuilder<double> builder;
+  auto sine =
+      builder.AddSystem<Sine<double>>(amplitude, frequency, phase, size);
+  sine->set_name("sine");
+
+  auto dut = builder.AddSystem<ZeroOrderHold<double>>(
+      kPeriod,  // period
+      1);       // size
+  dut->set_name("zoh");
+
+  // Connect output of sine to input of zoh.
+  builder.Connect(sine->get_output_port(0), dut->get_input_port());
+  // Make zoh output be the output of the diagram.
+  builder.ExportOutput(dut->get_output_port(), "zoh_output");
+  auto diagram = builder.Build();
+
+  Simulator<double> simulator(*diagram);
+  const Context<double>& context = simulator.get_context();
+  simulator.Initialize();
+
+  auto eval = [&]() { return diagram->get_output_port(0).Eval(context)[0]; };
+
+  // No update should have occurred yet.
+  EXPECT_EQ(0., eval());
+
+  simulator.StepTo(0);  // Force an update at 0.
+
+  // Should have sampled at t=0.
+  EXPECT_NEAR(sine_eval(0.), eval(), kMachineTol);
+
+  simulator.StepTo(1.5 * kPeriod);
+  // Should have sampled at t=kPeriod, NOT 1.5 * kPeriod.
+  EXPECT_NEAR(sine_eval(kPeriod), eval(), kMachineTol);
+
+  simulator.StepTo(9.1 * kPeriod);  // Last sample at 9 * kPeriod.
+  EXPECT_NEAR(sine_eval(9 * kPeriod), eval(), kMachineTol);
+}
+
+// TODO(sherm1) There should be a unit test similar to the above for
+// abstract-valued ZOH.
 
 class SymbolicZeroOrderHoldTest : public ::testing::Test {
  protected:
@@ -226,9 +300,11 @@ TEST_F(SymbolicZeroOrderHoldTest, Output) {
 }
 
 TEST_F(SymbolicZeroOrderHoldTest, Update) {
-  hold_->CalcDiscreteVariableUpdates(*context_, update_.get());
-  const auto& xd = update_->get_vector(0);
-  EXPECT_EQ("u0", xd[0].to_string());
+  // Before latching the input, the output should just show the initial
+  // state value "x0".
+  EXPECT_EQ("x0", hold_->get_output_port().Eval(*context_)[0].to_string());
+  hold_->LatchInputPortToState(&*context_);
+  EXPECT_EQ("u0", hold_->get_output_port().Eval(*context_)[0].to_string());
 }
 
 }  // namespace

--- a/systems/primitives/zero_order_hold.h
+++ b/systems/primitives/zero_order_hold.h
@@ -13,26 +13,51 @@
 namespace drake {
 namespace systems {
 
-/// A ZeroOrderHold block with input `u`, which may be vector-valued (discrete
-/// or continuous) or abstract, and discrete output `y`, where the y is sampled
+/// A zero order hold block with input u, which may be vector-valued (discrete
+/// or continuous) or abstract, and discrete output y, where the y is sampled
 /// from u with a fixed period.
-/// @note For an abstract-valued ZeroOrderHold, transmografication is not
-/// supported since AbstractValue does not support it.
+///
+/// @system{ZeroOrderHold, @input_port{u}, @output_port{y}}
+///
+/// The discrete state space dynamics of %ZeroOrderHold is:
+/// ```
+///   xₙ₊₁ = uₙ     // update
+///   yₙ   = xₙ     // output
+///   x₀   = xᵢₙᵢₜ  // initialize
+/// ```
+/// where xᵢₙᵢₜ = 0 for vector-valued %ZeroOrderHold, and xᵢₙᵢₜ is a given
+/// value for abstract-valued %ZeroOrderHold.
+///
+/// See @ref discrete_systems "Discrete Systems" for general information about
+/// discrete systems in Drake, including how they interact with continuous
+/// systems.
+///
+/// @note This system uses a periodic update with zero offset, so the first
+///       update occurs at t=0. When used with a Simulator, the output port
+///       is equal to xᵢₙᵢₜ after Simulator.Initialize(), but is immediately
+///       updated to u₀ at the start of the first step. If you want to force
+///       that initial update, use Simulator.StepTo(0.).
+///
+/// @note For an abstract-valued ZeroOrderHold, scalar-type conversion is not
+///       supported since AbstractValue does not support it.
+///
 /// @ingroup primitive_systems
 template <typename T>
 class ZeroOrderHold final : public LeafSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ZeroOrderHold)
 
-  /// Constructs a ZeroOrderHold system with the given @p period_sec, over a
+  /// Constructs a ZeroOrderHold system with the given `period_sec`, over a
   /// vector-valued input of size `vector_size`. The default initial
-  /// value for this system will be zero.
+  /// value for this system will be zero. The offset is always zero, meaning
+  /// that the first update occurs at t=0.
   ZeroOrderHold(double period_sec, int vector_size)
       : ZeroOrderHold(period_sec, vector_size, nullptr) {}
 
-  /// Constructs a ZeroOrderHold system with the given @p period_sec, over a
+  /// Constructs a ZeroOrderHold system with the given `period_sec`, over a
   /// abstract-valued input `abstract_model_value`. The default initial value
-  /// for this system will be `abstract_model_value`.
+  /// for this system will be `abstract_model_value`. The offset is always
+  /// zero, meaning that the first update occurs at t=0.
   ZeroOrderHold(double period_sec, const AbstractValue& abstract_model_value)
       : ZeroOrderHold(period_sec, -1, abstract_model_value.Clone()) {}
 
@@ -48,16 +73,21 @@ class ZeroOrderHold final : public LeafSystem<T> {
     return LeafSystem<T>::get_input_port(0);
   }
 
-  // Don't use the indexed get_input_port when calling this system directly.
-  void get_input_port(int) = delete;
-
   /// Returns the sole output port.
   const OutputPort<T>& get_output_port() const {
     return LeafSystem<T>::get_output_port(0);
   }
 
-  // Don't use the indexed get_output_port when calling this system directly.
-  void get_output_port(int) = delete;
+  /// (Advanced) Manually sample the input port and copy ("latch") the value
+  /// into the state. This emulates an update event and is mostly useful for
+  /// testing.
+  void LatchInputPortToState(Context<T>* context) const {
+    if (is_abstract()) {
+      LatchInputAbstractValueToState(*context, &context->get_mutable_state());
+    } else {
+      LatchInputVectorToState(*context, &context->get_mutable_discrete_state());
+    }
+  }
 
  private:
   // Allow different specializations to access each other's private data.
@@ -73,26 +103,25 @@ class ZeroOrderHold final : public LeafSystem<T> {
 
   // Sets the output port value to the vector value that is currently
   // latched in the zero-order hold.
-  void DoCalcVectorOutput(
+  void CopyLatchedVector(
       const Context<T>& context,
       BasicVector<T>* output) const;
 
   // Latches the input port into the discrete vector-valued state.
-  void DoCalcDiscreteVariableUpdates(
+  void LatchInputVectorToState(
       const Context<T>& context,
-      const std::vector<const DiscreteUpdateEvent<T>*>& events,
-      DiscreteValues<T>* discrete_state) const final;
+      DiscreteValues<T>* discrete_state) const;
 
-  // Same as `DoCalcVectorOutput`, but for abstract values.
-  void DoCalcAbstractOutput(
+  // Sets the output port value to the abstract value that is currently
+  // latched in the zero-order hold.
+  void CopyLatchedAbstractValue(
       const Context<T>& context,
       AbstractValue* output) const;
 
-  // Same as `DoCalcDiscreteVariablesUpdate`, but for abstract values.
-  void DoCalcUnrestrictedUpdate(
+  // Latches the abstract input port into the abstract-valued state.
+  void LatchInputAbstractValueToState(
       const Context<T>& context,
-      const std::vector<const UnrestrictedUpdateEvent<T>*>& events,
-      State<T>* state) const final;
+      State<T>* state) const;
 
   bool is_abstract() const { return abstract_model_value_ != nullptr; }
 
@@ -112,27 +141,33 @@ ZeroOrderHold<T>::ZeroOrderHold(
     // TODO(david-german-tri): remove the size parameter from the constructor
     // once #3109 supporting automatic sizes is resolved.
     BasicVector<T> model_value(vector_size);
-    this->DeclareVectorInputPort(model_value);
-    this->DeclareVectorOutputPort(
-        model_value, &ZeroOrderHold::DoCalcVectorOutput);
+    this->DeclareVectorInputPort("u", model_value);
+    this->DeclareVectorOutputPort("y",
+        model_value, &ZeroOrderHold::CopyLatchedVector);
     this->DeclareDiscreteState(vector_size);
-    this->DeclarePeriodicDiscreteUpdate(period_sec_);
+    this->DeclarePeriodicDiscreteUpdateEvent(period_sec_, 0.,
+        &ZeroOrderHold::LatchInputVectorToState);
   } else {
     DRAKE_DEMAND(vector_size == -1);
     // TODO(eric.cousineau): Remove value parameter from the constructor once
     // the equivalent of #3109 for abstract values is also resolved.
-    this->DeclareAbstractInputPort(*abstract_model_value_);
-    // Use the std::function<> overloads to work with `AbstractValue` type
-    // directly and maintain type erasure.
-    auto abstract_value_allocator = [this]() {
-      return abstract_model_value_->Clone();
-    };
-    namespace sp = std::placeholders;
-    this->DeclareAbstractOutputPort(
-        abstract_value_allocator,
-        std::bind(&ZeroOrderHold::DoCalcAbstractOutput, this, sp::_1, sp::_2));
+    this->DeclareAbstractInputPort("u", *abstract_model_value_);
+
+    // Because we're working with type-erased AbstractValue objects directly
+    // (not typical), there isn't a nice sugar method available that takes
+    // class methods. We have to use the generic port declaration method that
+    // uses free functions.
+    this->DeclareAbstractOutputPort("y",
+        // Allocator function.
+        [this]() { return abstract_model_value_->Clone(); },
+        // Calculator function.
+        [this](const Context<T>& context, AbstractValue* output) {
+          this->CopyLatchedAbstractValue(context, &*output);
+        });
+
     this->DeclareAbstractState(abstract_model_value_->Clone());
-    this->DeclarePeriodicUnrestrictedUpdate(period_sec_, 0.);
+    this->DeclarePeriodicUnrestrictedUpdateEvent(period_sec_, 0.,
+        &ZeroOrderHold::LatchInputAbstractValueToState);
   }
 }
 
@@ -145,7 +180,7 @@ ZeroOrderHold<T>::ZeroOrderHold(const ZeroOrderHold<U>& other)
                                         : nullptr) {}
 
 template <typename T>
-void ZeroOrderHold<T>::DoCalcVectorOutput(
+void ZeroOrderHold<T>::CopyLatchedVector(
       const Context<T>& context,
       BasicVector<T>* output) const {
   DRAKE_ASSERT(!is_abstract());
@@ -154,9 +189,8 @@ void ZeroOrderHold<T>::DoCalcVectorOutput(
 }
 
 template <typename T>
-void ZeroOrderHold<T>::DoCalcDiscreteVariableUpdates(
+void ZeroOrderHold<T>::LatchInputVectorToState(
     const Context<T>& context,
-    const std::vector<const DiscreteUpdateEvent<T>*>&,
     DiscreteValues<T>* discrete_state) const {
   DRAKE_ASSERT(!is_abstract());
   const auto& input = get_input_port().Eval(context);
@@ -165,25 +199,19 @@ void ZeroOrderHold<T>::DoCalcDiscreteVariableUpdates(
 }
 
 template <typename T>
-void ZeroOrderHold<T>::DoCalcAbstractOutput(const Context<T>& context,
-                                            AbstractValue* output) const {
+void ZeroOrderHold<T>::CopyLatchedAbstractValue(const Context<T>& context,
+                                                AbstractValue* output) const {
   DRAKE_ASSERT(is_abstract());
-  // Do not use `get_abstract_state<AbstractValue>` since it would cast
-  // the value to `Value<AbstractValue>`, which is an invalid type by design.
-  const AbstractValue& state_value =
-      context.get_abstract_state().get_value(0);
+  const AbstractValue& state_value = context.get_abstract_state().get_value(0);
   output->SetFrom(state_value);
 }
 
 template <typename T>
-void ZeroOrderHold<T>::DoCalcUnrestrictedUpdate(
+void ZeroOrderHold<T>::LatchInputAbstractValueToState(
     const Context<T>& context,
-    const std::vector<const UnrestrictedUpdateEvent<T>*>&,
     State<T>* state) const {
   DRAKE_ASSERT(is_abstract());
   const auto& input = get_input_port().template Eval<AbstractValue>(context);
-  // See `DoCalcAbstractOutput` for rationale regarding non-templated value
-  // accessor.
   AbstractValue& state_value =
       state->get_mutable_abstract_state().get_mutable_value(0);
   state_value.SetFrom(input);


### PR DESCRIPTION
I saw many anachronisms while reviewing PR #10856. It turned out the author had very sensibly modeled his new primitive on our ZeroOrderHold.

This is an attempt to modernize ZeroOrderHold so it can serve as a better example next time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10904)
<!-- Reviewable:end -->
