### PR TITLE
Adds the ability to do a "raw" update to the Context.

### DIFF
--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -182,6 +182,11 @@ point `{t₀, x⁻(t₀)}` is provided to the handlers for any triggered publish
 events. That includes initialization publish events, per-step publish events,
 and periodic or timed publish events that trigger at t₀.
 
+@note As indicated in System::CalcRawContextUpdate(), raw Context updates
+are just a special form of unrestricted update. When Simulator performs
+the unrestricted updates, the raw Context updates are performed first and
+the "regular" unrestricted updates follow.
+
 @tparam T The vector element type, which must be a valid Eigen scalar.
 
 Instantiated templates for the following kinds of T's are provided and

--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -907,7 +907,9 @@ void Simulator<T>::StepTo(const T& boundary_time) {
   auto merged_events = system_.AllocateCompositeEventCollection();
   DRAKE_DEMAND(timed_events_ != nullptr);
   DRAKE_DEMAND(witnessed_events_ != nullptr);
-  DRAKE_DEMAND(merged_events != nullptr  // Clear events for the loop iteration.
+  DRAKE_DEMAND(merged_events != nullptr);
+
+  // Clear events for the loop iteration.
   merged_events->Clear();
   merged_events->Merge(*per_step_events_);
 

--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -111,7 +111,7 @@ given tₘₐₓ.
 // Advance the trajectory (time and state) from start value {tₛ, x⁻(tₛ)} to an
 // end value {tₑ, x⁻(tₑ)}, where tₛ ≤ tₑ ≤ tₘₐₓ.
 procedure Advance(tₛ, x⁻(tₛ), tₘₐₓ)
-  // Update any variables (no restrictions).
+  // Update any state variables immediately, subsystem by subsystem.
   x^(tₛ) ← DoAnyRawContextUpdates(tₛ, x⁻(tₛ))
 
   // Update any variables (no restrictions).
@@ -186,10 +186,13 @@ and periodic or timed publish events that trigger at t₀.
 
 @note As indicated in System::CalcRawContextUpdate(), raw Context updates
 are just a special form of unrestricted update. When Simulator performs
-the unrestricted updates, the raw Context updates are performed first and
-the "regular" unrestricted updates (using the state variables newly updated
-in the raw Context updates) follow. See caveat on ordering-dependent
-computation in System::CalcRawContextUpdate().
+the unrestricted updates, the raw Context updates are performed first (subsystem
+by subsystem, for Diagram systems) and the "regular" unrestricted updates (using
+the state variables newly updated in the raw Context updates) follow. See caveat
+on ordering-dependent computation in System::CalcRawContextUpdate(). Contrast
+the behavior of the raw Context updates, in which every event handler sees a
+different state (potentially) with unrestricted updates, in which every event
+handler sees the same input state.
 
 @tparam T The vector element type, which must be a valid Eigen scalar.
 
@@ -904,9 +907,7 @@ void Simulator<T>::StepTo(const T& boundary_time) {
   auto merged_events = system_.AllocateCompositeEventCollection();
   DRAKE_DEMAND(timed_events_ != nullptr);
   DRAKE_DEMAND(witnessed_events_ != nullptr);
-  DRAKE_DEMAND(merged_events != nullptr);
-
-  // Clear events for the loop iteration.
+  DRAKE_DEMAND(merged_events != nullptr  // Clear events for the loop iteration.
   merged_events->Clear();
   merged_events->Merge(*per_step_events_);
 

--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -924,8 +924,12 @@ void Simulator<T>::StepTo(const T& boundary_time) {
     // "violence" to the state, i.e. unrestricted -> discrete -> continuous ->
     // publish. The "timed" actions happen before the "per step" ones.
 
-    // Do unrestricted updates first.
+    // Do raw Context updates first.
+    HandleRawContextUpdate(merged_events->get_raw_context_update_events());
+
+    // Do unrestricted updates next.
     HandleUnrestrictedUpdate(merged_events->get_unrestricted_update_events());
+
     // Do restricted (discrete variable) updates next.
     HandleDiscreteUpdate(merged_events->get_discrete_update_events());
 

--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -111,9 +111,11 @@ given tₘₐₓ.
 // Advance the trajectory (time and state) from start value {tₛ, x⁻(tₛ)} to an
 // end value {tₑ, x⁻(tₑ)}, where tₛ ≤ tₑ ≤ tₘₐₓ.
 procedure Advance(tₛ, x⁻(tₛ), tₘₐₓ)
+  // Update any variables (no restrictions).
+  x^(tₛ) ← DoAnyRawContextUpdates(tₛ, x⁻(tₛ))
 
   // Update any variables (no restrictions).
-  x*(tₛ) ← DoAnyUnrestrictedUpdates(tₛ, x⁻(tₛ))
+  x*(tₛ) ← DoAnyUnrestrictedUpdates(tₛ, x^(tₛ))
 
   // ----------------------------------
   // Time and state are at {tₛ, x*(tₛ)}
@@ -185,7 +187,9 @@ and periodic or timed publish events that trigger at t₀.
 @note As indicated in System::CalcRawContextUpdate(), raw Context updates
 are just a special form of unrestricted update. When Simulator performs
 the unrestricted updates, the raw Context updates are performed first and
-the "regular" unrestricted updates follow.
+the "regular" unrestricted updates (using the state variables newly updated
+in the raw Context updates) follow. See caveat on ordering-dependent
+computation in System::CalcRawContextUpdate().
 
 @tparam T The vector element type, which must be a valid Eigen scalar.
 

--- a/systems/analysis/test/simulator_test.cc
+++ b/systems/analysis/test/simulator_test.cc
@@ -1945,8 +1945,10 @@ GTEST_TEST(SimulatorTest, PerStepAction) {
     void AddPerStepRawContextUpdateEvent() {
       RawContextUpdateEvent<double> update_event(
           TriggerType::kPerStep,
-          std::bind(&PerStepActionTestSystem::RawUpdate, this,
-                    std::placeholders::_1, std::placeholders::_2));
+          [this](Context<double>* context,
+              const RawContextUpdateEvent<double>& event) {
+            RawUpdate(context, event);
+          });
       this->DeclarePerStepEvent(update_event);
     }
 
@@ -2074,8 +2076,10 @@ GTEST_TEST(SimulatorTest, Initialization) {
     InitializationTestSystem() {
       PublishEvent<double> pub_event(
           TriggerType::kInitialization,
-          std::bind(&InitializationTestSystem::InitPublish, this,
-                    std::placeholders::_1, std::placeholders::_2));
+          [this](const Context<double>& context,
+              const PublishEvent<double>& event) {
+            InitPublish(context, event);
+          });
       DeclareInitializationEvent(pub_event);
 
       DeclareInitializationEvent(DiscreteUpdateEvent<double>(
@@ -2090,8 +2094,11 @@ GTEST_TEST(SimulatorTest, Initialization) {
 
       RawContextUpdateEvent<double> update_event(
           TriggerType::kInitialization,
-          std::bind(&InitializationTestSystem::RawUpdate, this,
-                    std::placeholders::_1, std::placeholders::_2));
+          [this](Context<double>* context,
+              const RawContextUpdateEvent<double>& event) {
+            RawUpdate(context, event);
+          });
+
       DeclareInitializationEvent(update_event);
     }
 

--- a/systems/analysis/test/simulator_test.cc
+++ b/systems/analysis/test/simulator_test.cc
@@ -1994,7 +1994,7 @@ GTEST_TEST(SimulatorTest, PerStepAction) {
       publish_times_.push_back(context.get_time());
     }
 
-    // No method can be override for raw Context updates.
+    // The dispatcher cannot be overriden for raw Context updates.
     void RawUpdate(
         Context<double>* context,
         const RawContextUpdateEvent<double>& e) const {

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -1182,7 +1182,7 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
     }
   }
 
-  // For each subsystem, if there is an unrestricted update event in its
+  // For each subsystem, if there is a raw Context update event in its
   // corresponding subevent collection, calls its CalcRawContextUpdate
   // method with the appropriate subcontext, subevent collection and substate.
   void DispatchRawContextUpdateHandler(

--- a/systems/framework/event.h
+++ b/systems/framework/event.h
@@ -596,7 +596,9 @@ UnrestrictedUpdateEvent<T>::UnrestrictedUpdateEvent(
     const UnrestrictedUpdateEvent<T>&) = default;
 
 /**
- * This class represents a raw Context update event. It has an optional
+ * This class represents a raw Context update event. As noted in
+ * System::CalcRawContextUpdate(), this kind of update is just a special
+ * unrestricted update. This event has an optional
  * callback function to do custom handling of this event given a Context pointer
  * and a const RawContextUpdateEvent object reference. See strong warnings about
  * raw updates to the Context in System::CalcRawContextUpdate().

--- a/systems/framework/event.h
+++ b/systems/framework/event.h
@@ -562,8 +562,8 @@ class UnrestrictedUpdateEvent final : public Event<T> {
   #endif
 
   /**
-   * Calls the optional callback function, if one exists, with @p context,
-   * `this` and @p discrete_state.
+   * Calls the optional callback function, if one exists, with `context`,
+   * `this`, and `discrete_state`.
    */
   void handle(const Context<T>& context, State<T>* state) const {
     if (callback_ != nullptr) callback_(context, *this, state);
@@ -598,7 +598,8 @@ UnrestrictedUpdateEvent<T>::UnrestrictedUpdateEvent(
 /**
  * This class represents a raw Context update event. It has an optional
  * callback function to do custom handling of this event given a Context pointer
- * and a const RawContextUpdateEvent object reference.
+ * and a const RawContextUpdateEvent object reference. See strong warnings about
+ * raw updates to the Context in System::CalcRawContextUpdate().
  */
 template <typename T>
 class RawContextUpdateEvent final : public Event<T> {
@@ -609,7 +610,7 @@ class RawContextUpdateEvent final : public Event<T> {
   bool is_discrete_update() const override { return false; }
 
   /**
-   * Callback function that processes an unrestricted update event.
+   * Callback function that processes a raw Context update event.
    */
   typedef std::function<void(Context<T>*, const RawContextUpdateEvent<T>&)>
       RawContextUpdateCallback;
@@ -631,7 +632,7 @@ class RawContextUpdateEvent final : public Event<T> {
                         const RawContextUpdateCallback& callback)
       : Event<T>(trigger_type), callback_(callback) {}
 
-  // Makes an UnrestrictedUpateEvent with @p trigger_type, no optional data, and
+  // Makes a RawContextUpateEvent with `trigger_type`, no optional data, and
   // no callback function.
   explicit RawContextUpdateEvent(
       const TriggerType& trigger_type)
@@ -639,8 +640,8 @@ class RawContextUpdateEvent final : public Event<T> {
   #endif
 
   /**
-   * Calls the optional callback function, if one exists, with @p context,
-   * `this` and @p discrete_state.
+   * Calls the optional callback function, if one exists, with `context`,
+   * and `this`.
    */
   void handle(Context<T>* context) const {
     if (callback_ != nullptr) callback_(context, *this);

--- a/systems/framework/event.h
+++ b/systems/framework/event.h
@@ -598,7 +598,7 @@ UnrestrictedUpdateEvent<T>::UnrestrictedUpdateEvent(
 /**
  * This class represents a raw Context update event. As noted in
  * System::CalcRawContextUpdate(), this kind of update is just a special
- * unrestricted update. This event has an optional
+ * unrestricted update that takes place immediately. This event has an optional
  * callback function to do custom handling of this event given a Context pointer
  * and a const RawContextUpdateEvent object reference. See strong warnings about
  * raw updates to the Context in System::CalcRawContextUpdate().
@@ -617,12 +617,16 @@ class RawContextUpdateEvent final : public Event<T> {
   typedef std::function<void(Context<T>*, const RawContextUpdateEvent<T>&)>
       RawContextUpdateCallback;
 
-  /// Makes an RawContextUpdateEvent with no trigger type, no event data, and
-  /// no specified callback function.
+  /**
+   * Makes an RawContextUpdateEvent with no trigger type, no event data, and
+   * no specified callback function.
+   */
   RawContextUpdateEvent() : Event<T>() {}
 
-  /// Makes a RawContextUpdateEvent with no trigger type, no event data, and
-  /// the specified callback function.
+  /**
+   * Makes a RawContextUpdateEvent with no trigger type, no event data, and
+   * the specified callback function.
+   */
   explicit RawContextUpdateEvent(const RawContextUpdateCallback& callback)
       : Event<T>(), callback_(callback) {}
 

--- a/systems/framework/event.h
+++ b/systems/framework/event.h
@@ -629,10 +629,10 @@ class RawContextUpdateEvent final : public Event<T> {
    */
   explicit RawContextUpdateEvent(const RawContextUpdateCallback& callback)
       : Event<T>(), callback_(callback) {}
-
+`
   // Note: Users should not be calling these.
   #if !defined(DRAKE_DOXYGEN_CXX)
-  // Makes an RawContextUpdateEvent with `trigger_type` and callback function
+  // Makes a RawContextUpdateEvent with `trigger_type` and callback function
   // `callback`. `callback` can be null.
   RawContextUpdateEvent(const TriggerType& trigger_type,
                         const RawContextUpdateCallback& callback)

--- a/systems/framework/event.h
+++ b/systems/framework/event.h
@@ -629,7 +629,7 @@ class RawContextUpdateEvent final : public Event<T> {
    */
   explicit RawContextUpdateEvent(const RawContextUpdateCallback& callback)
       : Event<T>(), callback_(callback) {}
-`
+
   // Note: Users should not be calling these.
   #if !defined(DRAKE_DOXYGEN_CXX)
   // Makes a RawContextUpdateEvent with `trigger_type` and callback function

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -2300,9 +2300,9 @@ class LeafSystem : public System<T> {
   ///                        resulting update to the state.
   /// @param[in]     events All the raw Context update events that need
   ///                       handling.
-  virtual void DoCalcRawContextUpdate(
+  void DoCalcRawContextUpdate(
       Context<T>* context,
-      const std::vector<const RawContextUpdateEvent<T>*>& events) const final {
+      const std::vector<const RawContextUpdateEvent<T>*>& events) const {
     for (const RawContextUpdateEvent<T>* event : events) {
       event->handle(context);
     }

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -2292,10 +2292,10 @@ class LeafSystem : public System<T> {
   /// events. Override this in your derived LeafSystem only if you require
   /// behavior other than the default dispatch behavior (not common).
   /// The default behavior is to traverse events in the arbitrary order they
-  /// appear in @p events, and for each event that has a callback function,
-  /// to invoke the callback with @p context and that event.
-  /// Note that the same (possibly modified) @p context is passed to subsequent
-  /// callbacks.
+  /// appear in `events` (see related warning in
+  /// System::CalcRawContextUpdate()), and for each event that has a callback
+  /// function, to invoke the callback with `context` and that event. Note that
+  /// the same (possibly modified) `context` is passed to subsequent callbacks.
   ///
   /// Do not override this just to handle an event -- instead declare the event
   /// and a handler callback for it.
@@ -2306,10 +2306,10 @@ class LeafSystem : public System<T> {
   /// error-checked the parameters so you don't have to. In particular,
   /// implementations may assume that the `context` is valid.
   ///
-  /// @param[in,out] context The "before" and "after" state that used both for
+  /// @param[in,out] context The "before" and "after" state used both for
   ///                        calculating the update to the state and holding the
   ///                        resulting update to the state.
-  /// @param[in]     events All the unrestricted update events that need
+  /// @param[in]     events All the raw Context update events that need
   ///                       handling.
   virtual void DoCalcRawContextUpdate(
       Context<T>* context,

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -2289,22 +2289,11 @@ class LeafSystem : public System<T> {
   }
 
   /// Derived-class event dispatcher for all simultaneous raw Context update
-  /// events. Override this in your derived LeafSystem only if you require
-  /// behavior other than the default dispatch behavior (not common).
-  /// The default behavior is to traverse events in the arbitrary order they
+  /// events.  This method traverses events in the arbitrary order they
   /// appear in `events` (see related warning in
   /// System::CalcRawContextUpdate()), and for each event that has a callback
   /// function, to invoke the callback with `context` and that event. Note that
   /// the same (possibly modified) `context` is passed to subsequent callbacks.
-  ///
-  /// Do not override this just to handle an event -- instead declare the event
-  /// and a handler callback for it.
-  ///
-  /// This method is called only from the virtual
-  /// DispatchRawContextUpdateHandler(), which is only called from the
-  /// non-virtual public CalcRawContextUpdate(), which will already have
-  /// error-checked the parameters so you don't have to. In particular,
-  /// implementations may assume that the `context` is valid.
   ///
   /// @param[in,out] context The "before" and "after" state used both for
   ///                        calculating the update to the state and holding the
@@ -2313,7 +2302,7 @@ class LeafSystem : public System<T> {
   ///                       handling.
   virtual void DoCalcRawContextUpdate(
       Context<T>* context,
-      const std::vector<const RawContextUpdateEvent<T>*>& events) const {
+      const std::vector<const RawContextUpdateEvent<T>*>& events) const final {
     for (const RawContextUpdateEvent<T>* event : events) {
       event->handle(context);
     }

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -773,8 +773,8 @@ class System : public SystemBase {
 
   /// (Advanced) This method is the public entry point for dispatching all "raw"
   /// Context update event handlers. Raw Context updates are a very fast type
-  /// of unrestricted update- where the @System can update the Context directly
-  /// instead of updating copies of state- but has a high potential for danger
+  /// of unrestricted update where the @System can update the Context directly
+  /// instead of updating copies of state, but it has high potential for danger
   /// because the state becomes dependent upon the order that subsystems are
   /// updated in a Diagram.
   ///
@@ -788,8 +788,7 @@ class System : public SystemBase {
   ///
   /// CalcRawContextUpdate(.) updates `context` using all of the
   /// raw-Context-update handlers in `events`. The method does not allow time,
-  /// parameters, or the dimensionality of the state variables to change. See
-  /// the documentation for DispatchRawContextUpdateHandler() for more details.
+  /// parameters, or the dimensionality of the state variables to change.
   ///
   /// @throws std::logic_error if the dimensionality of the state variables
   ///         changes or if the time in the Context changes in the callback.

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -779,7 +779,7 @@ class System : public SystemBase {
   /// instead of updating a copy of the state, but it is dangerous
   /// because the final state becomes dependent upon the order that subsystems
   /// are updated in a Diagram (and we do not promise to update in any
-  /// particular order).`
+  /// particular order).
   ///
   /// Functionally, the raw Context update has the same power as an
   /// unrestricted update: it can modify any part of the state.
@@ -787,7 +787,7 @@ class System : public SystemBase {
   /// require frequent unrestricted updates to be simulated more quickly when
   /// the state is large; Simulator currently copies the state twice on
   /// unrestricted updates, which is slow (and motivated the introduction of the
-  /// raw Context updating strategy). Note that if any subsystem in a Diagram
+  /// raw Context updating strategy). Note that if *any* subsystem in a Diagram
   /// does an unrestricted update, the entire state is copied. To see a
   /// performance benefit from using RawContextUpdate, *all* of the
   /// high-frequency unrestricted updates in a diagram must be replaced with

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -726,7 +726,7 @@ class System : public SystemBase {
   }
 
   /// This method is the public entry point for dispatching all unrestricted
-  /// update event handlers. Using all the unrestricted update handers in
+  /// update event handlers. Using all the unrestricted update handlers in
   /// @p events, it updates *any* state variables in the @p context, and
   /// outputs the results to @p state. It does not allow the dimensionality
   /// of the state variables to change. See the documentation for
@@ -771,14 +771,22 @@ class System : public SystemBase {
         context, this->get_forced_unrestricted_update_events(), state);
   }
 
-  /// This method is the public entry point for dispatching all raw Context
-  /// update event handlers. Using all the raw Context handers in
-  /// @p events, it updates `context`. It does not allow time, parameters, or
-  /// the dimensionality of the state variables to change. See the documentation
-  /// for DispatchRawContextUpdateHandler() for more details.
+  /// (Advanced) This method is the public entry point for dispatching all "raw"
+  /// Context update event handlers. Raw context updates are very fast- the
+  /// @System can update the Context directly instead of updating copies of
+  /// state- but has a high potential for danger because the state becomes
+  /// dependent upon the order that subsystems are updated in a Diagram.
+  ///
+  /// This particular method updates `context` using all of the
+  /// raw-Context-update handlers in `events`. The method does not allow time,
+  /// parameters, or the dimensionality of the state variables to change. See
+  /// the documentation for DispatchRawContextUpdateHandler() for more details.
   ///
   /// @throws std::logic_error if the dimensionality of the state variables
   ///         changes or if the time in the Context changes in the callback.
+  /// @warning This method should be avoided to the greatest extent possible.
+  ///          Your computation can become nondeterministic if a Diagram
+  ///          contains multiple subsystems that do raw Context updates.
   void CalcRawContextUpdate(
       Context<T>* context,
       const EventCollection<RawContextUpdateEvent<T>>& events) const {

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -779,16 +779,16 @@ class System : public SystemBase {
   /// updated in a Diagram.
   ///
   /// Functionally, the raw Context update has the same power as an
-  /// unrestricted update: it can modify any part of the state, *but only
-  /// parts of the state*, not time or parameters. This method exists only
-  /// to allow certain subsystems that require frequent unrestricted updates
-  /// to be simulated more quickly when the state is large; Simulator
-  /// currently copies the state twice on unrestricted updates, which is slow
-  /// (and motivated the introduction of the raw Context update strategy).
+  /// unrestricted update: it can modify any part of the state.
+  /// This method exists only to allow certain subsystems that
+  /// require frequent unrestricted updates to be simulated more quickly when
+  /// the state is large; Simulator currently copies the state twice on
+  /// unrestricted updates, which is slow (and motivated the introduction of the
+  /// raw Context updating strategy).
   ///
   /// CalcRawContextUpdate(.) updates `context` using all of the
-  /// raw-Context-update handlers in `events`. The method does not allow time,
-  /// parameters, or the dimensionality of the state variables to change.
+  /// raw-Context-update handlers in `events`. Time, parameters, and the
+  /// dimensionality of the state variables should not be changed.
   ///
   /// @throws std::logic_error if the dimensionality of the state variables
   ///         changes or if the time in the Context changes in the callback.

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -772,12 +772,21 @@ class System : public SystemBase {
   }
 
   /// (Advanced) This method is the public entry point for dispatching all "raw"
-  /// Context update event handlers. Raw context updates are very fast- the
-  /// @System can update the Context directly instead of updating copies of
-  /// state- but has a high potential for danger because the state becomes
-  /// dependent upon the order that subsystems are updated in a Diagram.
+  /// Context update event handlers. Raw Context updates are a very fast type
+  /// of unrestricted update- where the @System can update the Context directly
+  /// instead of updating copies of state- but has a high potential for danger
+  /// because the state becomes dependent upon the order that subsystems are
+  /// updated in a Diagram.
   ///
-  /// This particular method updates `context` using all of the
+  /// Functionally, the raw Context update has the same power as an
+  /// unrestricted update: it can modify any part of the state, *but only
+  /// parts of the state*, not time or parameters. This method exists only
+  /// to allow certain subsystems that require frequent unrestricted updates
+  /// to be simulated more quickly when the state is large; Simulator
+  /// currently copies the state twice on unrestricted updates, which is slow
+  /// (and motivated the introduction of the raw Context update strategy).
+  ///
+  /// CalcRawContextUpdate(.) updates `context` using all of the
   /// raw-Context-update handlers in `events`. The method does not allow time,
   /// parameters, or the dimensionality of the state variables to change. See
   /// the documentation for DispatchRawContextUpdateHandler() for more details.

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -1979,6 +1979,8 @@ TEST_F(AbstractStateDiagramTest, CalcUnrestrictedUpdate) {
   EXPECT_EQ(get_sys1_abstract_data_as_double(), (time + 1));
 }
 
+// NOTE: This class is nearly identical to SystemWithAbstractState, but with
+// unrestricted updates replaced by raw Context updates.
 class SystemWithAbstractStateUpdatedRaw : public LeafSystem<double> {
  public:
   SystemWithAbstractStateUpdatedRaw(int id, double update_period) : id_(id) {
@@ -2009,6 +2011,8 @@ class SystemWithAbstractStateUpdatedRaw : public LeafSystem<double> {
   int id_{0};
 };
 
+// NOTE: This class is nearly identical to AbstractStateDiagram, but using
+// SystemWithAbstractStateUpdatedRaw rather than SystemWithAbstractState.
 class AbstractStateDiagramUpdatedRaw : public Diagram<double> {
  public:
   AbstractStateDiagramUpdatedRaw() : Diagram<double>() {
@@ -2043,6 +2047,8 @@ class AbstractStateDiagramUpdatedRaw : public Diagram<double> {
   SystemWithAbstractStateUpdatedRaw* sys1_{nullptr};
 };
 
+// NOTE: This class is nearly identical to AbstractStateDiagramTest but with
+// using AbstractStateDiagramUpdatedRaw replaced by AbstractStateDiagram.
 class AbstractStateDiagramUpdatedRawTest : public ::testing::Test {
  protected:
   void SetUp() override { context_ = diagram_.CreateDefaultContext(); }

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -1985,8 +1985,10 @@ class SystemWithAbstractStateUpdatedRaw : public LeafSystem<double> {
  public:
   SystemWithAbstractStateUpdatedRaw(int id, double update_period) : id_(id) {
     RawContextUpdateEvent<double> raw_event(
-        std::bind(&SystemWithAbstractStateUpdatedRaw::RawUpdate, this,
-                  std::placeholders::_1, std::placeholders::_2));
+        [this](Context<double>* context,
+            const RawContextUpdateEvent<double>& event) {
+              RawUpdate(context, event);
+            });
     DeclarePeriodicEvent(update_period, 0 /* offset */, raw_event);
     DeclareAbstractState(AbstractValue::Make<double>(id_));
 
@@ -2024,13 +2026,6 @@ class AbstractStateDiagramUpdatedRaw : public Diagram<double> {
         1, 3.);
     sys1_->set_name("sys1");
     builder.BuildInto(this);
-  }
-
-  // Note: we define this here so that we do not have to support
-  // forced-raw-Context-updates generally.
-  void CalcRawContextUpdate(Context<double>* context,
-      const EventCollection<RawContextUpdateEvent<double>>& events) const {
-    System<double>::CalcRawContextUpdate(context, events);
   }
 
   const SystemWithAbstractStateUpdatedRaw& get_sys(int i) const {

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -141,6 +141,12 @@ class TestSystem : public System<double> {
       const Context<double>& context,
       ContinuousState<double>* derivatives) const override {}
 
+  void DispatchRawContextUpdateHandler(
+      Context<double>* context,
+      const EventCollection<RawContextUpdateEvent<double>>&) const final {
+    ADD_FAILURE() << "Implementation is required, but unused here.";
+  }
+
   void DispatchPublishHandler(
       const Context<double>& context,
       const EventCollection<PublishEvent<double>>& events) const final {
@@ -597,6 +603,12 @@ class ValueIOTestSystem : public System<T> {
     ADD_FAILURE() << "Implementation is required, but unused here.";
   }
 
+  void DispatchRawContextUpdateHandler(
+      Context<T>* context,
+      const EventCollection<RawContextUpdateEvent<T>>&) const final {
+    ADD_FAILURE() << "Implementation is required, but unused here.";
+  }
+
   std::unique_ptr<EventCollection<PublishEvent<T>>>
   AllocateForcedPublishEventCollection() const override {
     return LeafEventCollection<PublishEvent<T>>::MakeForcedEventCollection();
@@ -940,6 +952,11 @@ class ComputationTestSystem final : public System<double> {
       const Context<double>&,
       const EventCollection<UnrestrictedUpdateEvent<double>>&,
       State<double>*) const final {
+    ADD_FAILURE() << "Implementation is required, but unused here.";
+  }
+  void DispatchRawContextUpdateHandler(
+      Context<double>*,
+      const EventCollection<RawContextUpdateEvent<double>>&) const final {
     ADD_FAILURE() << "Implementation is required, but unused here.";
   }
   std::map<PeriodicEventData, std::vector<const Event<double>*>,


### PR DESCRIPTION
Resolves #10149 (unsatisfactorily IMO) by adding the ability to write directly into the Context using a new kind of "raw" Context update event.

Sugar is limited to discourage the use of this feature. Copy-on-write functionality needs to be implemented asap so that we can remove this feature post haste.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10916)
<!-- Reviewable:end -->
