### PR TITLE
Add default_coulomb_friction_ to MultibodyPlant copy ctor.

### DIFF
--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -222,6 +222,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     geometry_id_to_body_index_ = other.geometry_id_to_body_index_;
     geometry_id_to_visual_index_ = other.geometry_id_to_visual_index_;
     geometry_id_to_collision_index_ = other.geometry_id_to_collision_index_;
+    default_coulomb_friction_ = other.default_coulomb_friction_;
     visual_geometries_ = other.visual_geometries_;
     collision_geometries_ = other.collision_geometries_;
     if (geometry_source_is_registered())

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -1495,6 +1495,14 @@ GTEST_TEST(MultibodyPlantTest, ScalarConversionConstructor) {
       plant_autodiff.GetBodyByName("link2")).size(), link2_num_visuals);
   EXPECT_EQ(plant_autodiff.GetVisualGeometriesForBody(
       plant_autodiff.GetBodyByName("link3")).size(), link3_num_visuals);
+  for (const auto& link_name : {"link1", "link2", "link3"}) {
+    auto collision_geometries = plant_autodiff.GetCollisionGeometriesForBody(
+        plant_autodiff.GetBodyByName(link_name));
+    for (const auto& geometry : collision_geometries) {
+      EXPECT_EQ(plant_autodiff.default_coulomb_friction(geometry),
+                plant.default_coulomb_friction(geometry));
+    }
+  }
 
   // Make sure the geometry ports were included in the autodiffed plant.
   EXPECT_NO_THROW(plant_autodiff.get_geometry_query_input_port());


### PR DESCRIPTION
Also adds test points that fails without the change to the constructor.

Resolves #10942.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10943)
<!-- Reviewable:end -->
