### PR TITLE
Add static equilibrium constraint.

### DIFF
--- a/multibody/optimization/BUILD.bazel
+++ b/multibody/optimization/BUILD.bazel
@@ -44,6 +44,7 @@ drake_cc_library(
     testonly = 1,
     srcs = ["test/optimization_with_contact_utilities.cc"],
     hdrs = ["test/optimization_with_contact_utilities.h"],
+    visibility = ["//visibility:private"],
     deps = [
         "//geometry:scene_graph",
         "//multibody/plant",

--- a/multibody/optimization/BUILD.bazel
+++ b/multibody/optimization/BUILD.bazel
@@ -1,0 +1,74 @@
+# -*- python -*-
+
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_googletest",
+    "drake_cc_library",
+    "drake_cc_package_library",
+)
+load(
+    "@drake//tools/skylark:drake_proto.bzl",
+    "drake_cc_proto_library",
+)
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+package(default_visibility = ["//visibility:public"])
+
+drake_cc_library(
+    name = "contact_wrench_evaluator",
+    srcs = ["contact_wrench_evaluator.cc"],
+    hdrs = ["contact_wrench_evaluator.h"],
+    deps = [
+        "//multibody/inverse_kinematics:kinematic_constraint",
+        "//multibody/plant",
+        "//solvers:evaluator_base",
+    ],
+)
+
+drake_cc_library(
+    name = "static_equilibrium_constraint",
+    srcs = ["static_equilibrium_constraint.cc"],
+    hdrs = ["static_equilibrium_constraint.h"],
+    deps = [
+        ":contact_wrench_evaluator",
+        "//geometry:scene_graph",
+        "//multibody/inverse_kinematics:kinematic_constraint",
+        "//multibody/plant",
+        "//solvers:binding",
+        "//solvers:constraint",
+    ],
+)
+
+drake_cc_library(
+    name = "optimization_with_contact_utilities",
+    testonly = 1,
+    srcs = ["test/optimization_with_contact_utilities.cc"],
+    hdrs = ["test/optimization_with_contact_utilities.h"],
+    deps = [
+        "//geometry:scene_graph",
+        "//multibody/plant",
+        "//systems/framework:diagram",
+    ],
+)
+
+drake_cc_googletest(
+    name = "contact_wrench_evaluator_test",
+    deps = [
+        ":contact_wrench_evaluator",
+        ":optimization_with_contact_utilities",
+        "//common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "static_equilibrium_constraint_test",
+    deps = [
+        ":optimization_with_contact_utilities",
+        ":static_equilibrium_constraint",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//solvers:mathematical_program",
+        "//solvers:solve",
+    ],
+)
+
+add_lint_tests()

--- a/multibody/optimization/contact_wrench_evaluator.cc
+++ b/multibody/optimization/contact_wrench_evaluator.cc
@@ -1,0 +1,32 @@
+#include "drake/multibody/optimization/contact_wrench_evaluator.h"
+
+namespace drake {
+namespace multibody {
+template <typename T, typename U>
+void ContactWrenchFromForceInWorldFrameEvaluator::DoEvalGeneric(
+    const Eigen::Ref<const VectorX<T>>& x, VectorX<U>* y) const {
+  y->template resize(6);
+  y->template head<3>().setZero();
+  const auto lambda_val = lambda(x);
+  (*y)(3) = static_cast<U>(lambda_val(0));
+  (*y)(4) = static_cast<U>(lambda_val(1));
+  (*y)(5) = static_cast<U>(lambda_val(2));
+}
+
+void ContactWrenchFromForceInWorldFrameEvaluator::DoEval(
+    const Eigen::Ref<const Eigen::VectorXd>& x, Eigen::VectorXd* y) const {
+  DoEvalGeneric(x, y);
+}
+
+void ContactWrenchFromForceInWorldFrameEvaluator::DoEval(
+    const Eigen::Ref<const AutoDiffVecXd>& x, AutoDiffVecXd* y) const {
+  DoEvalGeneric(x, y);
+}
+
+void ContactWrenchFromForceInWorldFrameEvaluator::DoEval(
+    const Eigen::Ref<const VectorX<symbolic::Variable>>& x,
+    VectorX<symbolic::Expression>* y) const {
+  DoEvalGeneric(x, y);
+}
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/optimization/contact_wrench_evaluator.cc
+++ b/multibody/optimization/contact_wrench_evaluator.cc
@@ -5,7 +5,7 @@ namespace multibody {
 template <typename T, typename U>
 void ContactWrenchFromForceInWorldFrameEvaluator::DoEvalGeneric(
     const Eigen::Ref<const VectorX<T>>& x, VectorX<U>* y) const {
-  y->template resize(6);
+  y->resize(6);
   y->template head<3>().setZero();
   const auto lambda_val = lambda(x);
   (*y)(3) = static_cast<U>(lambda_val(0));

--- a/multibody/optimization/contact_wrench_evaluator.h
+++ b/multibody/optimization/contact_wrench_evaluator.h
@@ -124,10 +124,10 @@ class ContactWrenchFromForceInWorldFrameEvaluator final
       const MultibodyPlant<AutoDiffXd>* plant,
       systems::Context<AutoDiffXd>* context,
       const std::pair<geometry::GeometryId, geometry::GeometryId>&
-          geometry_id_pair,
-      const std::string& description = "")
-      : ContactWrenchEvaluator(plant, context, 3, geometry_id_pair,
-                               description) {}
+          geometry_id_pair)
+      : ContactWrenchEvaluator(
+            plant, context, 3, geometry_id_pair,
+            "contact_wrench_from_pure_force_in_world_frame") {}
 
  private:
   void DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,

--- a/multibody/optimization/contact_wrench_evaluator.h
+++ b/multibody/optimization/contact_wrench_evaluator.h
@@ -64,6 +64,8 @@ class ContactWrenchEvaluator : public solvers::EvaluatorBase {
     return x.tail(num_lambda_);
   }
 
+  systems::Context<AutoDiffXd>* get_mutable_context() const { return context_; }
+
  private:
   const MultibodyPlant<AutoDiffXd>* plant_;
   systems::Context<AutoDiffXd>* context_;

--- a/multibody/optimization/contact_wrench_evaluator.h
+++ b/multibody/optimization/contact_wrench_evaluator.h
@@ -1,0 +1,104 @@
+#pragma once
+
+#include <utility>
+
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/solvers/evaluator_base.h"
+
+namespace drake {
+namespace multibody {
+// An abstract class that computes the contact wrench between a pair of
+// geometry. The input to the Eval function is λ, the user-specified
+// parameterization of the contact wrench. The output is the Fapp_B_W, namely
+// the wrench (torque/force) applied at the witness point of geometry B from
+// geometryA, expressed in the world frame.
+class ContactWrenchEvaluator : public solvers::EvaluatorBase {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ContactWrenchEvaluator)
+
+  /**
+   * Set the value of the variable `x` in Eval(x, &y) function, based on the
+   * context and value of lambda.
+   */
+  template <typename T, typename Derived>
+  typename std::enable_if<std::is_same<T, typename Derived::Scalar>::value,
+                          VectorX<T>>::type
+  SetVariableValues(const systems::Context<T>& context,
+                    const Derived& lambda_value) const {
+    VectorX<T> x(num_vars());
+    x.template head(plant_->num_positions()) = plant_->GetPositions(context);
+    x.template tail(num_lambda_) = lambda_value;
+    return x;
+  }
+
+  /**
+   * Returns the size of lambda.
+   */
+  int num_lambda() const { return num_lambda_; }
+
+  const std::pair<geometry::GeometryId, geometry::GeometryId>&
+  geometry_id_pair() const {
+    return geometry_id_pair_;
+  }
+
+ protected:
+  ContactWrenchEvaluator(
+      const MultibodyPlant<AutoDiffXd>* plant,
+      systems::Context<AutoDiffXd>* context, int num_lambda,
+      const std::pair<geometry::GeometryId, geometry::GeometryId>&
+          geometry_id_pair)
+      : solvers::EvaluatorBase(6, plant->num_positions() + num_lambda),
+        plant_(plant),
+        context_(context),
+        geometry_id_pair_{geometry_id_pair},
+        num_lambda_{num_lambda} {}
+
+ protected:
+  template <typename Derived>
+  Eigen::VectorBlock<const Derived> q(const Derived& x) const {
+    return x.head(plant_->num_positions());
+  }
+
+  template <typename Derived>
+  Eigen::VectorBlock<const Derived> lambda(const Derived& x) const {
+    return x.tail(num_lambda_);
+  }
+
+ private:
+  const MultibodyPlant<AutoDiffXd>* plant_;
+  systems::Context<AutoDiffXd>* context_;
+  const std::pair<geometry::GeometryId, geometry::GeometryId> geometry_id_pair_;
+  int num_lambda_;
+};
+
+/**
+ * The contact wrench is τ_B_W = 0, f_B_W = λ
+ */
+class ContactWrenchFromForceInWorldFrameEvaluator
+    : public ContactWrenchEvaluator {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ContactWrenchFromForceInWorldFrameEvaluator)
+
+  ContactWrenchFromForceInWorldFrameEvaluator(
+      const MultibodyPlant<AutoDiffXd>* plant,
+      systems::Context<AutoDiffXd>* context,
+      const std::pair<geometry::GeometryId, geometry::GeometryId>&
+          geometry_id_pair)
+      : ContactWrenchEvaluator(plant, context, 3, geometry_id_pair) {}
+
+ private:
+  void DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
+              Eigen::VectorXd* y) const override;
+
+  void DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
+              AutoDiffVecXd* y) const override;
+
+  void DoEval(const Eigen::Ref<const VectorX<symbolic::Variable>>& x,
+              VectorX<symbolic::Expression>* y) const override;
+
+  template <typename T, typename U>
+  void DoEvalGeneric(const Eigen::Ref<const VectorX<T>>& x,
+                     VectorX<U>* y) const;
+};
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/optimization/contact_wrench_evaluator.h
+++ b/multibody/optimization/contact_wrench_evaluator.h
@@ -8,7 +8,7 @@
 namespace drake {
 namespace multibody {
 // An abstract class that computes the contact wrench between a pair of
-// geometries. The input to the Eval function is q and λ, where λ is the
+// geometries. The input to the Eval function are q and λ, where λ is the
 // user-specified parameterization of the contact wrench. The output is the
 // Fapp_AB_W, namely the 6 x 1 wrench (torque/force) applied at the witness
 // point of geometry B from geometry A, expressed in the world frame.
@@ -24,7 +24,7 @@ class ContactWrenchEvaluator : public solvers::EvaluatorBase {
   typename std::enable_if<std::is_same<T, typename Derived::Scalar>::value,
                           VectorX<T>>::type
   ComposeVariableValues(const systems::Context<T>& context,
-                    const Derived& lambda_value) const {
+                        const Derived& lambda_value) const {
     VectorX<T> x(num_vars());
     x.template head(plant_->num_positions()) = plant_->GetPositions(context);
     x.template tail(num_lambda_) = lambda_value;
@@ -47,7 +47,7 @@ class ContactWrenchEvaluator : public solvers::EvaluatorBase {
  protected:
   /**
    * Each derived class should call this constructor.
-   * @param plant The robot on which the contact wrench is computed.
+   * @param plant The MultibodyPlant on which the contact wrench is computed.
    * @param geometry_id_pair The pair of geometries for which the contact wrench
    * is computed. Notice that the order of the geometries in the pair should
    * match with that in SceneGraphInspector::GetCollisionCandidates().
@@ -98,14 +98,14 @@ class ContactWrenchEvaluator : public solvers::EvaluatorBase {
  * Namely we assume that λ is the contact force from A to B, applied directly
  * at B's witness point.
  */
-class ContactWrenchFromForceInWorldFrameEvaluator
+class ContactWrenchFromForceInWorldFrameEvaluator final
     : public ContactWrenchEvaluator {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ContactWrenchFromForceInWorldFrameEvaluator)
 
   /**
-   * @param plant The robot on which the contact wrench is computed.
-   * @param context The context of the robot.
+   * @param plant The MultibodyPlant on which the contact wrench is computed.
+   * @param context The context of the MultibodyPlant.
    * @param geometry_id_pair The pair of geometries for which the contact wrench
    * is computed. Notice that the order of the geometries in the pair should
    * match with that in SceneGraphInspector::GetCollisionCandidates().

--- a/multibody/optimization/static_equilibrium_constraint.cc
+++ b/multibody/optimization/static_equilibrium_constraint.cc
@@ -78,10 +78,16 @@ void StaticEquilibriumConstraint::DoEval(
         plant_->GetBodyFromFrameId(frame_B_id)->body_frame();
 
     // Compute the Jacobian.
-    const Vector3<double> p_ACa =
-        inspector.X_FG(signed_distance_pair.id_A) * signed_distance_pair.p_ACa;
-    const Vector3<double> p_BCb =
-        inspector.X_FG(signed_distance_pair.id_B) * signed_distance_pair.p_BCb;
+    // Define Body A's frame as A, the geometry attached to body A has frame Ga,
+    // and the witness point on geometry Ga is Ca.
+    const auto& X_AGa = inspector.X_FG(signed_distance_pair.id_A);
+    const auto& p_GaCa = signed_distance_pair.p_ACa;
+    const Vector3<double> p_ACa = X_AGa * p_GaCa;
+    // Define Body B's frame as B, the geometry attached to body B has frame Gb,
+    // and the witness point on geometry Ga is Cb.
+    const auto& X_BGb = inspector.X_FG(signed_distance_pair.id_B);
+    const auto& p_GbCb = signed_distance_pair.p_BCb;
+    const Vector3<double> p_BCb = X_BGb * p_GbCb;
     Eigen::Matrix<AutoDiffXd, 6, Eigen::Dynamic> Jv_V_WCa(
         6, plant_->num_velocities());
     Eigen::Matrix<AutoDiffXd, 6, Eigen::Dynamic> Jv_V_WCb(

--- a/multibody/optimization/static_equilibrium_constraint.cc
+++ b/multibody/optimization/static_equilibrium_constraint.cc
@@ -1,0 +1,182 @@
+#include "drake/multibody/optimization/static_equilibrium_constraint.h"
+
+#include "drake/multibody/inverse_kinematics/kinematic_constraint_utilities.h"
+
+namespace drake {
+namespace multibody {
+namespace {
+int GetLambdaSize(
+    const std::map<std::pair<geometry::GeometryId, geometry::GeometryId>,
+                   GeometryPairContactWrenchEvaluatorBinding>&
+        contact_pair_to_wrench_evaluator) {
+  int num_lambda = 0;
+  for (const auto& term : contact_pair_to_wrench_evaluator) {
+    num_lambda += term.second.contact_wrench_evaluator->num_lambda();
+  }
+  return num_lambda;
+}
+}  // namespace
+StaticEquilibriumConstraint::StaticEquilibriumConstraint(
+    const MultibodyPlant<AutoDiffXd>* plant,
+    systems::Context<AutoDiffXd>* context,
+    const std::map<std::pair<geometry::GeometryId, geometry::GeometryId>,
+                   GeometryPairContactWrenchEvaluatorBinding>&
+        contact_pair_to_wrench_evaluator)
+    : solvers::Constraint(plant->num_velocities(),
+                          plant->num_positions() + plant->num_actuated_dofs() +
+                              GetLambdaSize(contact_pair_to_wrench_evaluator),
+                          Eigen::VectorXd::Zero(plant->num_velocities()),
+                          Eigen::VectorXd::Zero(plant->num_velocities())),
+      plant_{plant},
+      context_{context},
+      contact_pair_to_wrench_evaluator_(contact_pair_to_wrench_evaluator),
+      B_actuation_{plant_->MakeActuationMatrix()} {}
+
+void StaticEquilibriumConstraint::DoEval(
+    const Eigen::Ref<const Eigen::VectorXd>& x, Eigen::VectorXd* y) const {
+  AutoDiffVecXd y_autodiff(num_constraints());
+  DoEval(x.cast<AutoDiffXd>(), &y_autodiff);
+  *y = math::autoDiffToValueMatrix(y_autodiff);
+}
+
+void StaticEquilibriumConstraint::DoEval(
+    const Eigen::Ref<const AutoDiffVecXd>& x, AutoDiffVecXd* y) const {
+  const auto& q = x.head(plant_->num_positions());
+  const auto& u =
+      x.segment(plant_->num_positions(), plant_->num_actuated_dofs());
+  *y = B_actuation_ * u;
+  if (internal::AreAutoDiffVecXdEqual(q, plant_->GetPositions(*context_))) {
+    plant_->SetPositions(context_, q);
+  }
+  *y += plant_->CalcGravityGeneralizedForces(*context_);
+  const auto& query_port = plant_->get_geometry_query_input_port();
+  if (!query_port.HasValue(*context_)) {
+    throw std::invalid_argument(
+        "StaticEquilibriumConstraint: Cannot get a valid "
+        "geometry::QueryObject. Please refer to AddMultibodyPlantSceneGraph "
+        "on connecting MultibodyPlant to SceneGraph.");
+  }
+  const auto& query_object =
+      query_port.Eval<geometry::QueryObject<AutoDiffXd>>(*context_);
+  const std::vector<geometry::SignedDistancePair<double>>
+      signed_distance_pairs =
+          query_object.ComputeSignedDistancePairwiseClosestPoints();
+  const geometry::SceneGraphInspector<AutoDiffXd>& inspector =
+      query_object.inspector();
+  const int lambda_start_index_in_x =
+      plant_->num_positions() + plant_->num_actuated_dofs();
+  for (const auto& signed_distance_pair : signed_distance_pairs) {
+    const geometry::FrameId frame_A_id =
+        inspector.GetFrameId(signed_distance_pair.id_A);
+    const geometry::FrameId frame_B_id =
+        inspector.GetFrameId(signed_distance_pair.id_B);
+    const Frame<AutoDiffXd>& frameA =
+        plant_->GetBodyFromFrameId(frame_A_id)->body_frame();
+    const Frame<AutoDiffXd>& frameB =
+        plant_->GetBodyFromFrameId(frame_B_id)->body_frame();
+
+    // Compute the Jacobian.
+    const Vector3<double> p_ACa =
+        inspector.X_FG(signed_distance_pair.id_A) * signed_distance_pair.p_ACa;
+    const Vector3<double> p_BCb =
+        inspector.X_FG(signed_distance_pair.id_B) * signed_distance_pair.p_BCb;
+    Eigen::Matrix<AutoDiffXd, 6, Eigen::Dynamic> Jv_V_WCa(
+        6, plant_->num_velocities());
+    Eigen::Matrix<AutoDiffXd, 6, Eigen::Dynamic> Jv_V_WCb(
+        6, plant_->num_velocities());
+    plant_->CalcJacobianSpatialVelocity(
+        *context_, JacobianWrtVariable::kV, frameA, p_ACa.cast<AutoDiffXd>(),
+        plant_->world_frame(), plant_->world_frame(), &Jv_V_WCa);
+    plant_->CalcJacobianSpatialVelocity(
+        *context_, JacobianWrtVariable::kV, frameB, p_BCb.cast<AutoDiffXd>(),
+        plant_->world_frame(), plant_->world_frame(), &Jv_V_WCb);
+
+    // Find the lambda corresponding to the geometry pair (id_A, id_B).
+    const auto it = contact_pair_to_wrench_evaluator_.find(
+        std::make_pair(signed_distance_pair.id_A, signed_distance_pair.id_B));
+    if (it == contact_pair_to_wrench_evaluator_.end()) {
+      throw std::runtime_error(
+          "The input argument contact_pair_to_wrench_evaluator in the "
+          "StaticEquilibriumConstraint constructor doesn't include all "
+          "possible contact pairs.");
+    }
+
+    VectorX<AutoDiffXd> lambda(
+        it->second.contact_wrench_evaluator->num_lambda());
+
+    for (int i = 0; i < lambda.rows(); ++i) {
+      lambda(i) = x(lambda_start_index_in_x +
+                    it->second.lambda_indices_in_all_lambda[i]);
+    }
+
+    AutoDiffVecXd F_AB_W;
+    it->second.contact_wrench_evaluator->Eval(
+        it->second.contact_wrench_evaluator->SetVariableValues(*context_,
+                                                               lambda),
+        &F_AB_W);
+
+    // By definition, F_AB_W is the contact wrench applied to id_B from id_A,
+    // at the contact point. By Newton's third law, the contact wrench applied
+    // to id_A from id_B at the contact point is -lambda.
+    *y += Jv_V_WCa.transpose() * -F_AB_W + Jv_V_WCb.transpose() * F_AB_W;
+  }
+}
+void StaticEquilibriumConstraint::DoEval(
+    const Eigen::Ref<const VectorX<symbolic::Variable>>&,
+    VectorX<symbolic::Expression>*) const {
+  throw std::runtime_error(
+      "StaticEquilibriumConstraint: do not support Eval with symbolic variable "
+      "and expressions.");
+}
+
+solvers::Binding<StaticEquilibriumConstraint> CreateStaticEquilibriumConstraint(
+    const MultibodyPlant<AutoDiffXd>* plant,
+    systems::Context<AutoDiffXd>* context,
+    const std::vector<std::pair<std::shared_ptr<ContactWrenchEvaluator>,
+                                VectorX<symbolic::Variable>>>&
+        contact_wrench_evaluators_and_lambda,
+    const Eigen::Ref<const VectorX<symbolic::Variable>>& q_vars,
+    const Eigen::Ref<const VectorX<symbolic::Variable>>& u_vars) {
+  std::map<std::pair<geometry::GeometryId, geometry::GeometryId>,
+           GeometryPairContactWrenchEvaluatorBinding>
+      contact_pair_to_wrench_evaluator;
+  const int num_lambda = std::accumulate(
+      contact_wrench_evaluators_and_lambda.begin(),
+      contact_wrench_evaluators_and_lambda.end(), 0,
+      [](int a, const std::pair<std::shared_ptr<ContactWrenchEvaluator>,
+                                VectorX<symbolic::Variable>>&
+                    contact_wrench_evaluator_and_lambda) {
+        return a + contact_wrench_evaluator_and_lambda.second.rows();
+      });
+  VectorX<symbolic::Variable> all_lambda(num_lambda);
+  int lambda_count = 0;
+  for (const auto& contact_wrench_evaluator_and_lambda :
+       contact_wrench_evaluators_and_lambda) {
+    const auto& contact_wrench_evaluator =
+        contact_wrench_evaluator_and_lambda.first;
+    const auto& lambda_i = contact_wrench_evaluator_and_lambda.second;
+    DRAKE_DEMAND(contact_wrench_evaluator->num_lambda() == lambda_i.rows());
+    std::vector<int> lambda_indices_in_all_lambda(lambda_i.rows());
+    for (int j = 0; j < lambda_i.rows(); ++j) {
+      lambda_indices_in_all_lambda[j] = lambda_count + j;
+      all_lambda(lambda_count + j) = lambda_i(j);
+    }
+    contact_pair_to_wrench_evaluator.emplace(
+        contact_wrench_evaluator->geometry_id_pair(),
+        GeometryPairContactWrenchEvaluatorBinding{lambda_indices_in_all_lambda,
+                                                  contact_wrench_evaluator});
+    lambda_count += lambda_i.rows();
+  }
+  DRAKE_DEMAND(q_vars.rows() == plant->num_positions());
+  DRAKE_DEMAND(u_vars.rows() == plant->num_actuated_dofs());
+  VectorX<symbolic::Variable> q_u_lambda(
+      plant->num_positions() + plant->num_actuated_dofs() + num_lambda);
+  q_u_lambda << q_vars, u_vars, all_lambda;
+  auto static_equilibrium_constraint =
+      std::make_shared<StaticEquilibriumConstraint>(
+          plant, context, contact_pair_to_wrench_evaluator);
+  return solvers::Binding<StaticEquilibriumConstraint>(
+      static_equilibrium_constraint, q_u_lambda);
+}
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/optimization/static_equilibrium_constraint.cc
+++ b/multibody/optimization/static_equilibrium_constraint.cc
@@ -129,7 +129,8 @@ void StaticEquilibriumConstraint::DoEval(
       "and expressions.");
 }
 
-solvers::Binding<StaticEquilibriumConstraint> CreateStaticEquilibriumConstraint(
+solvers::Binding<StaticEquilibriumConstraint>
+StaticEquilibriumConstraint::MakeBinding(
     const MultibodyPlant<AutoDiffXd>* plant,
     systems::Context<AutoDiffXd>* context,
     const std::vector<std::pair<std::shared_ptr<ContactWrenchEvaluator>,
@@ -173,8 +174,11 @@ solvers::Binding<StaticEquilibriumConstraint> CreateStaticEquilibriumConstraint(
       plant->num_positions() + plant->num_actuated_dofs() + num_lambda);
   q_u_lambda << q_vars, u_vars, all_lambda;
   auto static_equilibrium_constraint =
-      std::make_shared<StaticEquilibriumConstraint>(
-          plant, context, contact_pair_to_wrench_evaluator);
+      // Do not call make_shared because the constructor
+      // StaticEquilibriumConstraint is private.
+      std::shared_ptr<StaticEquilibriumConstraint>(
+          new StaticEquilibriumConstraint(plant, context,
+                                          contact_pair_to_wrench_evaluator));
   return solvers::Binding<StaticEquilibriumConstraint>(
       static_equilibrium_constraint, q_u_lambda);
 }

--- a/multibody/optimization/static_equilibrium_constraint.h
+++ b/multibody/optimization/static_equilibrium_constraint.h
@@ -42,22 +42,22 @@ struct GeometryPairContactWrenchEvaluatorBinding {
 /**
  * Impose the static equilibrium constraint 0 = τ_g + Bu + ∑J_WBᵀ(q) * Fapp_B_W
  */
-class StaticEquilibriumConstraint : public solvers::Constraint {
+class StaticEquilibriumConstraint final : public solvers::Constraint {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(StaticEquilibriumConstraint)
 
   /**
    * Create a static equilibrium constraint
    * 0 = g(q) + Bu + ∑ᵢ JᵢᵀFᵢ_AB_W(λᵢ)
-   * This constraint depends on the variable q, u and λ.
+   * This constraint depends on the variables q, u and λ.
    * @param plant The plant on which the constraint is imposed.
    * @param context The context for the subsystem @p plant.
-   * @param contact_wrench_evaluators_and_lambda For each pair of contact, we
+   * @param contact_wrench_evaluators_and_lambda For each contact pair, we
    * need to compute the contact wrench applied at the point of contact,
-   * expressed in the world frame, namely Fᵢ_AB_W(λᵢ). @p
-   * contact_wrench_evaluators_and_lambda.first is the evaluator for computing
-   * this contact wrench from the variables λᵢ. @p
-   * contact_wrench_evaluators_and_lambda.second are the decision variable λᵢ
+   * expressed in the world frame, namely Fᵢ_AB_W(λᵢ).
+   * `contact_wrench_evaluators_and_lambda.first` is the evaluator for computing
+   * this contact wrench from the variables λᵢ.
+   * `contact_wrench_evaluators_and_lambda.second` are the decision variable λᵢ
    * used in computing the contact wrench. Notice the generalized position `q`
    * is not included in variables contact_wrench_evaluators_and_lambda.second.
    * @param q_vars The decision variables for q (the generalized position).
@@ -90,8 +90,9 @@ class StaticEquilibriumConstraint : public solvers::Constraint {
 
  private:
   /**
-   * The user should not call this constructor, as it is inconvenient to do so.
-   * The user should call MakeBinding().
+   * The user cannot call this constructor, as it is inconvenient to do so.
+   * The user must call MakeBinding() to construct a
+   * StaticEquilibriumConstraint.
    */
   StaticEquilibriumConstraint(
       const MultibodyPlant<AutoDiffXd>* plant,
@@ -101,11 +102,11 @@ class StaticEquilibriumConstraint : public solvers::Constraint {
           contact_pair_to_wrench_evaluator);
 
   void DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
-              Eigen::VectorXd* y) const override;
+              Eigen::VectorXd* y) const final;
   void DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
-              AutoDiffVecXd* y) const override;
+              AutoDiffVecXd* y) const final;
   void DoEval(const Eigen::Ref<const VectorX<symbolic::Variable>>& x,
-              VectorX<symbolic::Expression>* y) const override;
+              VectorX<symbolic::Expression>* y) const final;
 
   const MultibodyPlant<AutoDiffXd>* const plant_;
   systems::Context<AutoDiffXd>* const context_;

--- a/multibody/optimization/static_equilibrium_constraint.h
+++ b/multibody/optimization/static_equilibrium_constraint.h
@@ -1,0 +1,102 @@
+#pragma once
+
+#include <map>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "drake/geometry/scene_graph.h"
+#include "drake/multibody/optimization/contact_wrench_evaluator.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/solvers/binding.h"
+#include "drake/solvers/constraint.h"
+
+namespace drake {
+namespace multibody {
+
+struct GeometryPairContactWrenchEvaluatorBinding {
+  GeometryPairContactWrenchEvaluatorBinding(
+      std::vector<int> lambda_indices_in_all_lambda_in,
+      std::shared_ptr<ContactWrenchEvaluator> contact_wrench_evaluator_in)
+      : lambda_indices_in_all_lambda{std::move(
+            lambda_indices_in_all_lambda_in)},
+        contact_wrench_evaluator{std::move(contact_wrench_evaluator_in)} {
+    DRAKE_DEMAND(static_cast<int>(lambda_indices_in_all_lambda.size()) ==
+                 contact_wrench_evaluator->num_lambda());
+  }
+  std::vector<int> lambda_indices_in_all_lambda;
+  std::shared_ptr<ContactWrenchEvaluator> contact_wrench_evaluator;
+};
+
+/**
+ * Impose the constraint 0 = τ_g + Bu + ∑J_WBᵀ(q) Fapp_B_W
+ */
+class StaticEquilibriumConstraint : public solvers::Constraint {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(StaticEquilibriumConstraint)
+
+  StaticEquilibriumConstraint(
+      const MultibodyPlant<AutoDiffXd>* plant,
+      systems::Context<AutoDiffXd>* context,
+      const std::map<std::pair<geometry::GeometryId, geometry::GeometryId>,
+                     GeometryPairContactWrenchEvaluatorBinding>&
+          contact_pair_to_wrench_evaluator);
+
+  ~StaticEquilibriumConstraint() override {}
+
+  /**
+   * Getter for contact_pair_to_wrench_evaluator, passed in the constructor.
+   */
+  const std::map<std::pair<geometry::GeometryId, geometry::GeometryId>,
+                 GeometryPairContactWrenchEvaluatorBinding>&
+  contact_pair_to_wrench_evaluator() const {
+    return contact_pair_to_wrench_evaluator_;
+  }
+
+ private:
+  void DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
+              Eigen::VectorXd* y) const override;
+  void DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
+              AutoDiffVecXd* y) const override;
+  void DoEval(const Eigen::Ref<const VectorX<symbolic::Variable>>& x,
+              VectorX<symbolic::Expression>* y) const override;
+
+  const MultibodyPlant<AutoDiffXd>* const plant_;
+  systems::Context<AutoDiffXd>* const context_;
+  const std::map<std::pair<geometry::GeometryId, geometry::GeometryId>,
+                 GeometryPairContactWrenchEvaluatorBinding>
+      contact_pair_to_wrench_evaluator_;
+  const MatrixX<AutoDiffXd> B_actuation_;
+};
+
+/**
+ * Create a static equilibrium constraint
+ * 0 = g(q) + Bu + ∑ᵢ JᵢᵀFᵢ_AB_W(λᵢ)
+ * This constraint depends on the variable q, u and λ.
+ * @param plant The plant on which the constraint is imposed.
+ * @param context The context for the subsystem @p plant.
+ * @param contact_wrench_evaluators_and_lambda For each pair of contact, we need
+ * to compute the contact wrench applied at the point of contact, expressed in
+ * the world frame, namely Fᵢ_AB_W(λᵢ). @p
+ * contact_wrench_evaluators_and_lambda.first is the evaluator for computing
+ * this contact wrench from the variables λᵢ. @p
+ * contact_wrench_evaluators_and_lambda.second are the decision variable λᵢ used
+ * in computing the contact wrench.
+ * @param q_vars The decision variables for q (the generalized position).
+ * @param u_vars The decision variables for u (the input).
+ * @return binding The binding between the static equilibrium constraint and the
+ * variables q, u and λ.
+ * @pre @p plant must have been connected to a SceneGraph properly. You could
+ * refer to AddMultibodyPlantSceneGraph on how to connect a MultibodyPlant to a
+ * SceneGraph.
+ */
+solvers::Binding<StaticEquilibriumConstraint> CreateStaticEquilibriumConstraint(
+    const MultibodyPlant<AutoDiffXd>* plant,
+    systems::Context<AutoDiffXd>* context,
+    const std::vector<std::pair<std::shared_ptr<ContactWrenchEvaluator>,
+                                VectorX<symbolic::Variable>>>&
+        contact_wrench_evaluators_and_lambda,
+    const Eigen::Ref<const VectorX<symbolic::Variable>>& q_vars,
+    const Eigen::Ref<const VectorX<symbolic::Variable>>& u_vars);
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/optimization/static_equilibrium_constraint.h
+++ b/multibody/optimization/static_equilibrium_constraint.h
@@ -47,15 +47,35 @@ class StaticEquilibriumConstraint : public solvers::Constraint {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(StaticEquilibriumConstraint)
 
   /**
-   * The user should not call this constructor, as it is inconvenient to do so.
-   * The user is encouraged to call CreateStaticEquilibriumConstraint().
+   * Create a static equilibrium constraint
+   * 0 = g(q) + Bu + ∑ᵢ JᵢᵀFᵢ_AB_W(λᵢ)
+   * This constraint depends on the variable q, u and λ.
+   * @param plant The plant on which the constraint is imposed.
+   * @param context The context for the subsystem @p plant.
+   * @param contact_wrench_evaluators_and_lambda For each pair of contact, we
+   * need to compute the contact wrench applied at the point of contact,
+   * expressed in the world frame, namely Fᵢ_AB_W(λᵢ). @p
+   * contact_wrench_evaluators_and_lambda.first is the evaluator for computing
+   * this contact wrench from the variables λᵢ. @p
+   * contact_wrench_evaluators_and_lambda.second are the decision variable λᵢ
+   * used in computing the contact wrench. Notice the generalized position `q`
+   * is not included in variables contact_wrench_evaluators_and_lambda.second.
+   * @param q_vars The decision variables for q (the generalized position).
+   * @param u_vars The decision variables for u (the input).
+   * @return binding The binding between the static equilibrium constraint and
+   * the variables q, u and λ.
+   * @pre @p plant must have been connected to a SceneGraph properly. You could
+   * refer to AddMultibodyPlantSceneGraph on how to connect a MultibodyPlant to
+   * a SceneGraph.
    */
-  StaticEquilibriumConstraint(
+  static solvers::Binding<StaticEquilibriumConstraint> MakeBinding(
       const MultibodyPlant<AutoDiffXd>* plant,
       systems::Context<AutoDiffXd>* context,
-      const std::map<std::pair<geometry::GeometryId, geometry::GeometryId>,
-                     internal::GeometryPairContactWrenchEvaluatorBinding>&
-          contact_pair_to_wrench_evaluator);
+      const std::vector<std::pair<std::shared_ptr<ContactWrenchEvaluator>,
+                                  VectorX<symbolic::Variable>>>&
+          contact_wrench_evaluators_and_lambda,
+      const Eigen::Ref<const VectorX<symbolic::Variable>>& q_vars,
+      const Eigen::Ref<const VectorX<symbolic::Variable>>& u_vars);
 
   ~StaticEquilibriumConstraint() override {}
 
@@ -69,6 +89,17 @@ class StaticEquilibriumConstraint : public solvers::Constraint {
   }
 
  private:
+  /**
+   * The user should not call this constructor, as it is inconvenient to do so.
+   * The user should call MakeBinding().
+   */
+  StaticEquilibriumConstraint(
+      const MultibodyPlant<AutoDiffXd>* plant,
+      systems::Context<AutoDiffXd>* context,
+      const std::map<std::pair<geometry::GeometryId, geometry::GeometryId>,
+                     internal::GeometryPairContactWrenchEvaluatorBinding>&
+          contact_pair_to_wrench_evaluator);
+
   void DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
               Eigen::VectorXd* y) const override;
   void DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
@@ -84,35 +115,5 @@ class StaticEquilibriumConstraint : public solvers::Constraint {
   const MatrixX<AutoDiffXd> B_actuation_;
 };
 
-/**
- * Create a static equilibrium constraint
- * 0 = g(q) + Bu + ∑ᵢ JᵢᵀFᵢ_AB_W(λᵢ)
- * This constraint depends on the variable q, u and λ.
- * @param plant The plant on which the constraint is imposed.
- * @param context The context for the subsystem @p plant.
- * @param contact_wrench_evaluators_and_lambda For each pair of contact, we need
- * to compute the contact wrench applied at the point of contact, expressed in
- * the world frame, namely Fᵢ_AB_W(λᵢ). @p
- * contact_wrench_evaluators_and_lambda.first is the evaluator for computing
- * this contact wrench from the variables λᵢ. @p
- * contact_wrench_evaluators_and_lambda.second are the decision variable λᵢ used
- * in computing the contact wrench. Notice the generalized position `q` is not
- * included in variables contact_wrench_evaluators_and_lambda.second.
- * @param q_vars The decision variables for q (the generalized position).
- * @param u_vars The decision variables for u (the input).
- * @return binding The binding between the static equilibrium constraint and the
- * variables q, u and λ.
- * @pre @p plant must have been connected to a SceneGraph properly. You could
- * refer to AddMultibodyPlantSceneGraph on how to connect a MultibodyPlant to a
- * SceneGraph.
- */
-solvers::Binding<StaticEquilibriumConstraint> CreateStaticEquilibriumConstraint(
-    const MultibodyPlant<AutoDiffXd>* plant,
-    systems::Context<AutoDiffXd>* context,
-    const std::vector<std::pair<std::shared_ptr<ContactWrenchEvaluator>,
-                                VectorX<symbolic::Variable>>>&
-        contact_wrench_evaluators_and_lambda,
-    const Eigen::Ref<const VectorX<symbolic::Variable>>& q_vars,
-    const Eigen::Ref<const VectorX<symbolic::Variable>>& u_vars);
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/optimization/test/contact_wrench_evaluator_test.cc
+++ b/multibody/optimization/test/contact_wrench_evaluator_test.cc
@@ -1,0 +1,54 @@
+#include "drake/multibody/optimization/contact_wrench_evaluator.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/math/autodiff_gradient.h"
+#include "drake/multibody/optimization/test/optimization_with_contact_utilities.h"
+
+namespace drake {
+namespace multibody {
+class ContactWrenchEvaluatorTest : public ::testing::Test {
+ public:
+  ContactWrenchEvaluatorTest() {
+    std::vector<SphereSpecification> spheres;
+    spheres.emplace_back(0.1, 1E3, 0.5, 0.4);
+    spheres.emplace_back(0.2, 2E3, 1, 0.9);
+    spheres.emplace_back(0.3, 2E3, 1, 0.8);
+    std::vector<BoxSpecification> boxes;
+
+    const CoulombFriction<double> ground_friction(1.5, 0.9);
+    free_spheres_ = std::make_unique<FreeSpheresAndBoxes<AutoDiffXd>>(
+        spheres, boxes, ground_friction);
+  }
+
+ protected:
+  std::unique_ptr<FreeSpheresAndBoxes<AutoDiffXd>> free_spheres_;
+};
+
+TEST_F(ContactWrenchEvaluatorTest,
+       ContactWrenchFromForceInWorldFrameEvaluator) {
+  systems::Context<AutoDiffXd>* plant_context =
+      free_spheres_->get_mutable_plant_context();
+  ContactWrenchFromForceInWorldFrameEvaluator evaluator(
+      &(free_spheres_->plant()), plant_context,
+      std::make_pair(free_spheres_->sphere_geometry_ids()[0],
+                     free_spheres_->sphere_geometry_ids()[1]));
+
+  EXPECT_EQ(evaluator.num_lambda(), 3);
+  EXPECT_EQ(evaluator.num_vars(), free_spheres_->plant().num_positions() + 3);
+  EXPECT_EQ(evaluator.num_outputs(), 6);
+
+  const Vector3<AutoDiffXd> lambda_val =
+      math::initializeAutoDiff(Eigen::Vector3d(1, 2, 3));
+  const VectorX<AutoDiffXd> x_value =
+      evaluator.SetVariableValues(*plant_context, lambda_val);
+  AutoDiffVecXd y;
+  evaluator.Eval(x_value, &y);
+  EXPECT_EQ(math::autoDiffToValueMatrix(y.head<3>()), Eigen::Vector3d::Zero());
+  EXPECT_EQ(y.tail<3>(), lambda_val);
+  EXPECT_TRUE(CompareMatrices(math::autoDiffToGradientMatrix(y.tail<3>()),
+                              math::autoDiffToGradientMatrix(lambda_val)));
+}
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/optimization/test/contact_wrench_evaluator_test.cc
+++ b/multibody/optimization/test/contact_wrench_evaluator_test.cc
@@ -8,26 +8,30 @@
 
 namespace drake {
 namespace multibody {
+namespace {
 class ContactWrenchEvaluatorTest : public ::testing::Test {
  public:
   ContactWrenchEvaluatorTest() {
-    std::vector<SphereSpecification> spheres;
+    std::vector<test::SphereSpecification> spheres;
     spheres.emplace_back(0.1, 1E3, CoulombFriction<double>(0.5, 0.4));
     spheres.emplace_back(0.2, 2E3, CoulombFriction<double>(1, 0.9));
     spheres.emplace_back(0.3, 2E3, CoulombFriction<double>(1, 0.8));
-    std::vector<BoxSpecification> boxes;
+    std::vector<test::BoxSpecification> boxes;
 
     const CoulombFriction<double> ground_friction(1.5, 0.9);
-    free_spheres_ = std::make_unique<FreeSpheresAndBoxes<AutoDiffXd>>(
+    free_spheres_ = std::make_unique<test::FreeSpheresAndBoxes<AutoDiffXd>>(
         spheres, boxes, ground_friction);
   }
 
  protected:
-  std::unique_ptr<FreeSpheresAndBoxes<AutoDiffXd>> free_spheres_;
+  // Only add free spheres, no boxes yet, as we can't compute the signed
+  // distance between boxes with high precision yet.
+  std::unique_ptr<test::FreeSpheresAndBoxes<AutoDiffXd>> free_spheres_;
 };
 
 TEST_F(ContactWrenchEvaluatorTest,
        ContactWrenchFromForceInWorldFrameEvaluator) {
+  // Test the constructor, `ComposeVariableValues` and `Eval` functions.
   systems::Context<AutoDiffXd>* plant_context =
       free_spheres_->get_mutable_plant_context();
   ContactWrenchFromForceInWorldFrameEvaluator evaluator(
@@ -50,5 +54,6 @@ TEST_F(ContactWrenchEvaluatorTest,
   EXPECT_TRUE(CompareMatrices(math::autoDiffToGradientMatrix(y.tail<3>()),
                               math::autoDiffToGradientMatrix(lambda_val)));
 }
+}  // namespace
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/optimization/test/contact_wrench_evaluator_test.cc
+++ b/multibody/optimization/test/contact_wrench_evaluator_test.cc
@@ -12,9 +12,9 @@ class ContactWrenchEvaluatorTest : public ::testing::Test {
  public:
   ContactWrenchEvaluatorTest() {
     std::vector<SphereSpecification> spheres;
-    spheres.emplace_back(0.1, 1E3, 0.5, 0.4);
-    spheres.emplace_back(0.2, 2E3, 1, 0.9);
-    spheres.emplace_back(0.3, 2E3, 1, 0.8);
+    spheres.emplace_back(0.1, 1E3, CoulombFriction<double>(0.5, 0.4));
+    spheres.emplace_back(0.2, 2E3, CoulombFriction<double>(1, 0.9));
+    spheres.emplace_back(0.3, 2E3, CoulombFriction<double>(1, 0.8));
     std::vector<BoxSpecification> boxes;
 
     const CoulombFriction<double> ground_friction(1.5, 0.9);
@@ -42,7 +42,7 @@ TEST_F(ContactWrenchEvaluatorTest,
   const Vector3<AutoDiffXd> lambda_val =
       math::initializeAutoDiff(Eigen::Vector3d(1, 2, 3));
   const VectorX<AutoDiffXd> x_value =
-      evaluator.SetVariableValues(*plant_context, lambda_val);
+      evaluator.ComposeVariableValues(*plant_context, lambda_val);
   AutoDiffVecXd y;
   evaluator.Eval(x_value, &y);
   EXPECT_EQ(math::autoDiffToValueMatrix(y.head<3>()), Eigen::Vector3d::Zero());

--- a/multibody/optimization/test/optimization_with_contact_utilities.cc
+++ b/multibody/optimization/test/optimization_with_contact_utilities.cc
@@ -1,0 +1,61 @@
+#include "drake/multibody/optimization/test/optimization_with_contact_utilities.h"
+
+#include <utility>
+
+namespace drake {
+namespace multibody {
+template <typename T>
+FreeSpheresAndBoxes<T>::FreeSpheresAndBoxes(
+    std::vector<SphereSpecification> spheres,
+    std::vector<BoxSpecification> boxes,
+    CoulombFriction<double> ground_friction)
+    : spheres_{std::move(spheres)},
+      boxes_{std::move(boxes)},
+      ground_friction_{std::move(ground_friction)} {
+  const int num_spheres = static_cast<int>(spheres_.size());
+  const int num_boxes = static_cast<int>(boxes_.size());
+  systems::DiagramBuilder<T> builder;
+  std::tie(plant_, scene_graph_) = AddMultibodyPlantSceneGraph(&builder);
+  for (int i = 0; i < num_spheres; ++i) {
+    const auto& sphere =
+        plant_->AddRigidBody("sphere" + std::to_string(i), spheres_[i].inertia);
+    sphere_geometry_ids_.push_back(plant_->RegisterCollisionGeometry(
+        sphere, Eigen::Isometry3d::Identity(),
+        geometry::Sphere(spheres_[i].radius),
+        "sphere" + std::to_string(i) + "_collision", spheres_[i].friction,
+        scene_graph_));
+  }
+  for (int i = 0; i < num_boxes; ++i) {
+    const auto& box =
+        plant_->AddRigidBody("box" + std::to_string(i), boxes_[i].inertia);
+    box_geometry_ids_.push_back(plant_->RegisterCollisionGeometry(
+        box, Eigen::Isometry3d::Identity(),
+        geometry::Box(boxes_[i].size(0), boxes_[i].size(1), boxes_[i].size(2)),
+        "box" + std::to_string(i) + "_collision", boxes_[i].friction,
+        scene_graph_));
+  }
+  // Add the ground
+  const auto& ground = plant_->AddRigidBody(
+      "ground", SpatialInertia<double>(1, Eigen::Vector3d::Zero(),
+                                       UnitInertia<double>(1, 1, 1)));
+  const Eigen::Vector3d ground_box_size(100, 100, 100);
+  ground_geometry_id_ = plant_->RegisterCollisionGeometry(
+      ground, Eigen::Isometry3d::Identity(),
+      geometry::Box(ground_box_size(0), ground_box_size(1), ground_box_size(2)),
+      "ground", ground_friction_, scene_graph_);
+  Eigen::Isometry3d X_WG = Eigen::Isometry3d::Identity();
+  X_WG.translation()(2) = -ground_box_size(2) / 2;
+  plant_->WeldFrames(plant_->world_frame(), ground.body_frame(), X_WG);
+
+  plant_->Finalize();
+  diagram_ = builder.Build();
+
+  diagram_context_ = diagram_->CreateDefaultContext();
+  plant_context_ =
+      &(diagram_->GetMutableSubsystemContext(*plant_, diagram_context_.get()));
+}
+
+template class FreeSpheresAndBoxes<double>;
+template class FreeSpheresAndBoxes<AutoDiffXd>;
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/optimization/test/optimization_with_contact_utilities.cc
+++ b/multibody/optimization/test/optimization_with_contact_utilities.cc
@@ -2,6 +2,8 @@
 
 #include <utility>
 
+#include "drake/multibody/tree/uniform_gravity_field_element.h"
+
 namespace drake {
 namespace multibody {
 template <typename T>
@@ -47,6 +49,7 @@ FreeSpheresAndBoxes<T>::FreeSpheresAndBoxes(
   X_WG.translation()(2) = -ground_box_size(2) / 2;
   plant_->WeldFrames(plant_->world_frame(), ground.body_frame(), X_WG);
 
+  plant_->template AddForceElement<UniformGravityFieldElement>();
   plant_->Finalize();
   diagram_ = builder.Build();
 

--- a/multibody/optimization/test/optimization_with_contact_utilities.cc
+++ b/multibody/optimization/test/optimization_with_contact_utilities.cc
@@ -24,7 +24,7 @@ FreeSpheresAndBoxes<T>::FreeSpheresAndBoxes(
     const auto& sphere =
         plant_->AddRigidBody("sphere" + std::to_string(i), spheres_[i].inertia);
     sphere_geometry_ids_.push_back(plant_->RegisterCollisionGeometry(
-        sphere, Eigen::Isometry3d::Identity(),
+        sphere, math::RigidTransformd::Identity(),
         geometry::Sphere(spheres_[i].radius),
         "sphere" + std::to_string(i) + "_collision", spheres_[i].friction,
         scene_graph_));
@@ -34,7 +34,7 @@ FreeSpheresAndBoxes<T>::FreeSpheresAndBoxes(
     const auto& box =
         plant_->AddRigidBody("box" + std::to_string(i), boxes_[i].inertia);
     box_geometry_ids_.push_back(plant_->RegisterCollisionGeometry(
-        box, Eigen::Isometry3d::Identity(),
+        box, math::RigidTransformd::Identity(),
         geometry::Box(boxes_[i].size(0), boxes_[i].size(1), boxes_[i].size(2)),
         "box" + std::to_string(i) + "_collision", boxes_[i].friction,
         scene_graph_));
@@ -47,11 +47,11 @@ FreeSpheresAndBoxes<T>::FreeSpheresAndBoxes(
                                        UnitInertia<double>(1, 1, 1)));
   const Eigen::Vector3d ground_box_size(100, 100, 100);
   ground_geometry_id_ = plant_->RegisterCollisionGeometry(
-      ground, Eigen::Isometry3d::Identity(),
+      ground, math::RigidTransformd::Identity(),
       geometry::Box(ground_box_size(0), ground_box_size(1), ground_box_size(2)),
       "ground", ground_friction_, scene_graph_);
-  Eigen::Isometry3d X_WG = Eigen::Isometry3d::Identity();
-  X_WG.translation()(2) = -ground_box_size(2) / 2;
+  math::RigidTransformd X_WG = math::RigidTransformd::Identity();
+  X_WG.set_translation(Eigen::Vector3d(0, 0, -ground_box_size(2) / 2));
   plant_->WeldFrames(plant_->world_frame(), ground.body_frame(), X_WG);
 
   // Add gravity.

--- a/multibody/optimization/test/optimization_with_contact_utilities.h
+++ b/multibody/optimization/test/optimization_with_contact_utilities.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "drake/geometry/scene_graph.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/systems/framework/diagram.h"
+
+namespace drake {
+namespace multibody {
+// Create the test on free spheres/blocks and a ground
+struct SphereSpecification {
+  SphereSpecification(double radius_in, double density, double static_friction,
+                      double dynamic_friction)
+      : radius{radius_in}, friction{static_friction, dynamic_friction} {
+    const double mass = 4.0 / 3 * M_PI * std::pow(radius, 3) * density;
+    const double I = 2.0 / 5.0 * mass * std::pow(radius, 2);
+    inertia = SpatialInertia<double>(mass, Eigen::Vector3d::Zero(),
+                                     UnitInertia<double>(I, I, I));
+  }
+  double radius;
+  SpatialInertia<double> inertia;
+  CoulombFriction<double> friction;
+};
+
+struct BoxSpecification {
+  Eigen::Vector3d size;
+  SpatialInertia<double> inertia;
+  CoulombFriction<double> friction;
+};
+
+template <typename T>
+class FreeSpheresAndBoxes {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FreeSpheresAndBoxes)
+
+  FreeSpheresAndBoxes(std::vector<SphereSpecification> spheres,
+                      std::vector<BoxSpecification> boxes,
+                      CoulombFriction<double> ground_friction);
+
+  const systems::Diagram<T>& diagram() const { return *diagram_; }
+
+  const MultibodyPlant<T>& plant() const { return *plant_; }
+
+  const geometry::SceneGraph<T>& scene_graph() const { return *scene_graph_; }
+
+  const systems::Context<T>& diagram_context() const {
+    return *diagram_context_;
+  }
+
+  const systems::Context<T>& plant_context() const { return *plant_context_; }
+
+  systems::Context<T>* get_mutable_plant_context() const {
+    return plant_context_;
+  }
+
+  const std::vector<geometry::GeometryId>& sphere_geometry_ids() const {
+    return sphere_geometry_ids_;
+  }
+
+  const std::vector<geometry::GeometryId>& box_geometry_ids() const {
+    return box_geometry_ids_;
+  }
+
+  geometry::GeometryId ground_geometry_id() const {
+    return ground_geometry_id_;
+  }
+
+  const std::vector<SphereSpecification>& spheres() const { return spheres_; }
+
+  const std::vector<BoxSpecification>& boxes() const { return boxes_; }
+
+  const CoulombFriction<double>& ground_friction() const {
+    return ground_friction_;
+  }
+
+ private:
+  const std::vector<SphereSpecification> spheres_;
+  const std::vector<BoxSpecification> boxes_;
+  const CoulombFriction<double> ground_friction_;
+  std::vector<geometry::GeometryId> sphere_geometry_ids_;
+  std::vector<geometry::GeometryId> box_geometry_ids_;
+  geometry::GeometryId ground_geometry_id_;
+  std::unique_ptr<systems::Diagram<T>> diagram_;
+  MultibodyPlant<T>* plant_{nullptr};
+  geometry::SceneGraph<T>* scene_graph_{nullptr};
+  std::unique_ptr<systems::Context<T>> diagram_context_{nullptr};
+  systems::Context<T>* plant_context_{nullptr};
+};
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/optimization/test/optimization_with_contact_utilities.h
+++ b/multibody/optimization/test/optimization_with_contact_utilities.h
@@ -10,13 +10,14 @@
 
 namespace drake {
 namespace multibody {
+namespace test {
 // Create the test on free spheres/blocks and a ground
 struct SphereSpecification {
   SphereSpecification(double radius_in, double density,
                       CoulombFriction<double> friction_in)
       : radius{radius_in}, friction{std::move(friction_in)} {
     const double mass = 4.0 / 3 * M_PI * std::pow(radius, 3) * density;
-    const double I = 2.0 / 5.0 * mass * std::pow(radius, 2);
+    const double I = 2.0 / 5.0 * mass * std::pow(radius, 2);  // inertia
     inertia = SpatialInertia<double>(mass, Eigen::Vector3d::Zero(),
                                      UnitInertia<double>(I, I, I));
   }
@@ -26,6 +27,7 @@ struct SphereSpecification {
 };
 
 struct BoxSpecification {
+  // Full dimensions of a box (not the half dimensions).
   Eigen::Vector3d size;
   SpatialInertia<double> inertia;
   CoulombFriction<double> friction;
@@ -89,5 +91,6 @@ class FreeSpheresAndBoxes {
   std::unique_ptr<systems::Context<T>> diagram_context_{nullptr};
   systems::Context<T>* plant_context_{nullptr};
 };
+}  // namespace test
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/optimization/test/optimization_with_contact_utilities.h
+++ b/multibody/optimization/test/optimization_with_contact_utilities.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "drake/geometry/scene_graph.h"
@@ -11,9 +12,9 @@ namespace drake {
 namespace multibody {
 // Create the test on free spheres/blocks and a ground
 struct SphereSpecification {
-  SphereSpecification(double radius_in, double density, double static_friction,
-                      double dynamic_friction)
-      : radius{radius_in}, friction{static_friction, dynamic_friction} {
+  SphereSpecification(double radius_in, double density,
+                      CoulombFriction<double> friction_in)
+      : radius{radius_in}, friction{std::move(friction_in)} {
     const double mass = 4.0 / 3 * M_PI * std::pow(radius, 3) * density;
     const double I = 2.0 / 5.0 * mass * std::pow(radius, 2);
     inertia = SpatialInertia<double>(mass, Eigen::Vector3d::Zero(),

--- a/multibody/optimization/test/static_equilibrium_constraint_test.cc
+++ b/multibody/optimization/test/static_equilibrium_constraint_test.cc
@@ -1,0 +1,215 @@
+#include "drake/multibody/optimization/static_equilibrium_constraint.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/math/autodiff_gradient.h"
+#include "drake/multibody/optimization/test/optimization_with_contact_utilities.h"
+#include "drake/solvers/mathematical_program.h"
+#include "drake/solvers/solve.h"
+
+namespace drake {
+namespace multibody {
+const double kEps = std::numeric_limits<double>::epsilon();
+class TwoFreeSpheresTest : public ::testing::Test {
+ public:
+  TwoFreeSpheresTest() {
+    std::vector<SphereSpecification> spheres;
+    spheres.emplace_back(0.1, 1E3, 0.8, 0.7);
+    spheres.emplace_back(0.2, 1E3, 0.9, 0.7);
+    spheres_ = std::make_unique<FreeSpheresAndBoxes<AutoDiffXd>>(
+        spheres, std::vector<BoxSpecification>() /* no boxes */,
+        CoulombFriction<double>(1, 0.8));
+    spheres_double_ = std::make_unique<FreeSpheresAndBoxes<double>>(
+        spheres_->spheres(), spheres_->boxes(), spheres_->ground_friction());
+    const auto& query_port = spheres_->plant().get_geometry_query_input_port();
+    const auto& query_object =
+        query_port.Eval<geometry::QueryObject<AutoDiffXd>>(
+            spheres_->plant_context());
+    const std::set<std::pair<geometry::GeometryId, geometry::GeometryId>>
+        collision_candidate_pairs =
+            query_object.inspector().GetCollisionCandidates();
+    const auto& plant = spheres_->plant();
+    q_vars_ = prog_.NewContinuousVariables(plant.num_positions(), "q");
+    for (const auto& geometry_pair : collision_candidate_pairs) {
+      auto wrench_evaluator =
+          std::make_shared<ContactWrenchFromForceInWorldFrameEvaluator>(
+              &plant, spheres_->get_mutable_plant_context(), geometry_pair);
+      auto lambda_i = prog_.NewContinuousVariables(
+          wrench_evaluator->num_lambda(), "lambda");
+      contact_wrench_evaluators_and_lambda_.push_back(
+          std::make_pair(wrench_evaluator, lambda_i));
+    }
+  }
+
+  void CheckStaticEquilibriumConstraintEval(
+      const solvers::Binding<StaticEquilibriumConstraint>&
+          static_equilibrium_binding,
+      const Eigen::Ref<const AutoDiffVecXd>& q_autodiff,
+      const Eigen::Ref<const AutoDiffVecXd> lambda_autodiff) {
+    // Manually evaluates the static equilibrium constraint g(q) + J'*lambda
+    // Notice that since the spheres are un-actuated, we don't compute the term
+    // B * u.
+    spheres_->plant().SetPositions(spheres_->get_mutable_plant_context(),
+                                   q_autodiff);
+    const AutoDiffVecXd g_autodiff =
+        spheres_->plant().CalcGravityGeneralizedForces(
+            *(spheres_->get_mutable_plant_context()));
+
+    AutoDiffVecXd y_autodiff_expected = g_autodiff;
+
+    const auto& query_port = spheres_->plant().get_geometry_query_input_port();
+    const auto& query_object =
+        query_port.Eval<geometry::QueryObject<AutoDiffXd>>(
+            spheres_->plant_context());
+    const std::vector<geometry::SignedDistancePair<double>>
+        signed_distance_pairs =
+            query_object.ComputeSignedDistancePairwiseClosestPoints();
+    EXPECT_EQ(signed_distance_pairs.size(), 3);
+    const geometry::SceneGraphInspector<AutoDiffXd>& inspector =
+        query_object.inspector();
+    for (const auto& signed_distance_pair : signed_distance_pairs) {
+      const geometry::FrameId frame_A_id =
+          inspector.GetFrameId(signed_distance_pair.id_A);
+      const geometry::FrameId frame_B_id =
+          inspector.GetFrameId(signed_distance_pair.id_B);
+      const Frame<AutoDiffXd>& frameA =
+          spheres_->plant().GetBodyFromFrameId(frame_A_id)->body_frame();
+      const Frame<AutoDiffXd>& frameB =
+          spheres_->plant().GetBodyFromFrameId(frame_B_id)->body_frame();
+      Eigen::Matrix<AutoDiffXd, 6, Eigen::Dynamic> Jv_V_WCa(6, 12);
+      Eigen::Matrix<AutoDiffXd, 6, Eigen::Dynamic> Jv_V_WCb(6, 12);
+      spheres_->plant().CalcJacobianSpatialVelocity(
+          spheres_->plant_context(), JacobianWrtVariable::kV, frameA,
+          signed_distance_pair.p_ACa.cast<AutoDiffXd>(),
+          spheres_->plant().world_frame(), spheres_->plant().world_frame(),
+          &Jv_V_WCa);
+      spheres_->plant().CalcJacobianSpatialVelocity(
+          spheres_->plant_context(), JacobianWrtVariable::kV, frameB,
+          signed_distance_pair.p_BCb.cast<AutoDiffXd>(),
+          spheres_->plant().world_frame(), spheres_->plant().world_frame(),
+          &Jv_V_WCb);
+
+      AutoDiffVecXd F_AB_W(6);
+
+      auto lambda_indices_in_all_lambda =
+          static_equilibrium_binding.evaluator()
+              ->contact_pair_to_wrench_evaluator()
+              .at(std::make_pair(signed_distance_pair.id_A,
+                                 signed_distance_pair.id_B))
+              .lambda_indices_in_all_lambda;
+      for (int i = 0; i < 3; ++i) {
+        F_AB_W(i) = 0 * lambda_autodiff(lambda_indices_in_all_lambda[0]);
+      }
+      F_AB_W(3) = lambda_autodiff(lambda_indices_in_all_lambda[0]);
+      F_AB_W(4) = lambda_autodiff(lambda_indices_in_all_lambda[1]);
+      F_AB_W(5) = lambda_autodiff(lambda_indices_in_all_lambda[2]);
+      y_autodiff_expected +=
+          Jv_V_WCa.transpose() * -F_AB_W + Jv_V_WCb.transpose() * F_AB_W;
+    }
+
+    AutoDiffVecXd x_autodiff(23);
+    x_autodiff << q_autodiff, lambda_autodiff;
+    AutoDiffVecXd y_autodiff;
+    static_equilibrium_binding.evaluator()->Eval(x_autodiff, &y_autodiff);
+    EXPECT_TRUE(CompareMatrices(
+        math::autoDiffToValueMatrix(y_autodiff),
+        math::autoDiffToValueMatrix(y_autodiff_expected), 100 * kEps));
+    EXPECT_TRUE(CompareMatrices(
+        math::autoDiffToGradientMatrix(y_autodiff),
+        math::autoDiffToGradientMatrix(y_autodiff_expected), 100 * kEps));
+  }
+
+ protected:
+  std::unique_ptr<FreeSpheresAndBoxes<AutoDiffXd>> spheres_;
+  std::unique_ptr<FreeSpheresAndBoxes<double>> spheres_double_;
+  std::unique_ptr<solvers::Binding<StaticEquilibriumConstraint>>
+      static_equilibrium_binding_;
+  solvers::MathematicalProgram prog_;
+  VectorX<symbolic::Variable> q_vars_;
+  VectorX<symbolic::Variable> u_vars_{0};
+  std::vector<std::pair<std::shared_ptr<ContactWrenchEvaluator>,
+                        VectorX<symbolic::Variable>>>
+      contact_wrench_evaluators_and_lambda_;
+};
+
+TEST_F(TwoFreeSpheresTest, Constructor) {
+  const auto& plant = spheres_->plant();
+  const auto static_equilibrium_binding = CreateStaticEquilibriumConstraint(
+      &plant, spheres_->get_mutable_plant_context(),
+      contact_wrench_evaluators_and_lambda_, q_vars_, u_vars_);
+  // Test constructor of StaticEquilibriumConstraint
+  EXPECT_EQ(static_equilibrium_binding.evaluator()->num_vars(),
+            23 /* 14 for position, 9 for lambda */);
+  EXPECT_EQ(static_equilibrium_binding.evaluator()->num_constraints(), 12);
+  EXPECT_TRUE(
+      CompareMatrices(static_equilibrium_binding.evaluator()->lower_bound(),
+                      Eigen::VectorXd::Zero(12)));
+  EXPECT_TRUE(
+      CompareMatrices(static_equilibrium_binding.evaluator()->upper_bound(),
+                      Eigen::VectorXd::Zero(12)));
+}
+
+TEST_F(TwoFreeSpheresTest, Eval) {
+  const auto& plant = spheres_->plant();
+  const auto static_equilibrium_binding = CreateStaticEquilibriumConstraint(
+      &plant, spheres_->get_mutable_plant_context(),
+      contact_wrench_evaluators_and_lambda_, q_vars_, u_vars_);
+  math::RigidTransform<double> X_WS1, X_WS2;
+  // Set the sphere pose X_WS1 and X_WS2 arbitrarily.
+  X_WS1.set(math::RotationMatrix<double>(Eigen::AngleAxisd(
+                M_PI_4, Eigen::Vector3d(1.0 / 3, 2.0 / 3, 2.0 / 3))),
+            Eigen::Vector3d(0.1, 0.2, 0.3));
+  X_WS2.set(math::RotationMatrix<double>(Eigen::AngleAxisd(
+                -0.1, Eigen::Vector3d(0.1, 0.2, 0.3).normalized())),
+            Eigen::Vector3d(0.15, 0.25, 0.2));
+
+  Eigen::VectorXd q_val(14);
+  q_val.head<4>() = X_WS1.rotation().ToQuaternionAsVector4();
+  q_val.segment<3>(4) = X_WS1.translation();
+  q_val.segment<4>(7) = X_WS2.rotation().ToQuaternionAsVector4();
+  q_val.tail<3>() = X_WS2.translation();
+  Eigen::VectorXd lambda_val(9);
+  // Test lambda = 0.
+  lambda_val.setZero();
+  Eigen::VectorXd x_val(23);
+  x_val << q_val, lambda_val;
+  auto x_autodiff = math::initializeAutoDiff(x_val);
+  CheckStaticEquilibriumConstraintEval(
+      static_equilibrium_binding, x_autodiff.head<14>(), x_autodiff.tail<9>());
+  // Test lambda != 0
+  lambda_val << 2, 3, 4, 5, 6, 7, 8, 9, 10;
+  x_val << q_val, lambda_val;
+  x_autodiff = math::initializeAutoDiff(x_val);
+  CheckStaticEquilibriumConstraintEval(
+      static_equilibrium_binding, x_autodiff.head<14>(), x_autodiff.tail<9>());
+
+  // Solves the optimization problem
+  // Note that we don't impose the complementarity constraint signed_distance *
+  // contact_force = 0, or the friction cone constraint.
+  // First set the spheres position, such that they are both on the ground, and
+  // touching each other.
+  X_WS1.set_translation(Eigen::Vector3d(0, 0, spheres_->spheres()[0].radius));
+  X_WS2.set_translation(
+      Eigen::Vector3d(std::sqrt(4 * spheres_->spheres()[0].radius *
+                                spheres_->spheres()[1].radius),
+                      0, spheres_->spheres()[1].radius));
+  q_val.segment<3>(4) = X_WS1.translation();
+  q_val.tail<3>() = X_WS2.translation();
+
+  prog_.AddBoundingBoxConstraint(q_val, q_val, q_vars_);
+  prog_.AddConstraint(static_equilibrium_binding);
+
+  Eigen::VectorXd x_init(prog_.num_vars());
+  prog_.SetDecisionVariableValueInVector(q_vars_, q_val, &x_init);
+
+  auto result = solvers::Solve(prog_, x_init);
+  EXPECT_TRUE(result.is_success());
+
+  // TODO(hongkai.dai): Now check if the system is in static equilibrium.
+  spheres_double_->plant().SetPositions(
+      spheres_double_->get_mutable_plant_context(),
+      result.GetSolution(q_vars_));
+}
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/optimization/test/static_equilibrium_constraint_test.cc
+++ b/multibody/optimization/test/static_equilibrium_constraint_test.cc
@@ -15,8 +15,8 @@ class TwoFreeSpheresTest : public ::testing::Test {
  public:
   TwoFreeSpheresTest() {
     std::vector<SphereSpecification> spheres;
-    spheres.emplace_back(0.1, 1E3, 0.8, 0.7);
-    spheres.emplace_back(0.2, 1E3, 0.9, 0.7);
+    spheres.emplace_back(0.1, 1E3, CoulombFriction<double>(0.8, 0.7));
+    spheres.emplace_back(0.2, 1E3, CoulombFriction<double>(0.9, 0.7));
     spheres_ = std::make_unique<FreeSpheresAndBoxes<AutoDiffXd>>(
         spheres, std::vector<BoxSpecification>() /* no boxes */,
         CoulombFriction<double>(1, 0.8));
@@ -144,7 +144,8 @@ TEST_F(TwoFreeSpheresTest, Constructor) {
   // Test constructor of StaticEquilibriumConstraint
   EXPECT_EQ(static_equilibrium_binding.evaluator()->num_vars(),
             23 /* 14 for position, 9 for lambda */);
-  EXPECT_EQ(static_equilibrium_binding.evaluator()->num_constraints(), 12);
+  EXPECT_EQ(static_equilibrium_binding.evaluator()->num_constraints(),
+             plant.num_velocities());
   EXPECT_TRUE(
       CompareMatrices(static_equilibrium_binding.evaluator()->lower_bound(),
                       Eigen::VectorXd::Zero(12)));


### PR DESCRIPTION
In this PR, I want to add the static equilibrium constraint
`0 = g(q) + B * u + ∑ᵢ Jᵢᵀλᵢ`.

The tricky thing here is that there are many contact pairs in the robot, and each pair of contact will have its own Jacobian Jᵢ, together with some parameterization of the contact wrench λᵢ. λᵢ doesn't have to be the contact wrench itself, but it could be the weight of the friction cone edge, if we use a linearized friction cone.

To resolve these issues, I propose the following API

1. A ContactWrenchEvaluator class, that computes the contact wrench expressed in the world frame, from λᵢ.
2. In `StaticEquilibriumConstraint`, we store the mapping from the pair of geometry to the contact wrench evaluator, together with the indices of λᵢ.

The user is supposed to call the [function](https://github.com/hongkai-dai/drake/blob/73b0f78f63d4dfc93121cab259cdc10501c09d16/multibody/optimization/static_equilibrium_constraint.h#L93-L100) `CreateStaticEquilibriumConstraint` to return the `solvers::Binding` object, that binds the constraint with its decision variables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10944)
<!-- Reviewable:end -->
