### PR TITLE
Add safe methods for setting discrete and abstract state variables

### DIFF
--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -311,6 +311,7 @@ drake_py_unittest(
         ":framework_py",
         ":primitives_py",
         "//bindings/pydrake/examples:pendulum_py",
+        "//bindings/pydrake/examples:rimless_wheel_py",
     ],
 )
 

--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -185,6 +185,16 @@ void DefineFrameworkPySemantics(py::module m) {
             overload_cast_explicit<const DiscreteValues<T>&>(
                 &Context<T>::get_discrete_state),
             py_reference_internal, doc.Context.get_discrete_state.doc_0args)
+        .def("SetDiscreteState",
+            overload_cast_explicit<void, const Eigen::Ref<const VectorX<T>>&>(
+                &Context<T>::SetDiscreteState),
+            py::arg("xd"), doc.Context.SetDiscreteState.doc_1args)
+        .def("SetDiscreteState",
+            overload_cast_explicit<void, int,
+                const Eigen::Ref<const VectorX<T>>&>(
+                &Context<T>::SetDiscreteState),
+            py::arg("group_index"), py::arg("xd"),
+            doc.Context.SetDiscreteState.doc_2args)
         .def("get_mutable_discrete_state",
             overload_cast_explicit<DiscreteValues<T>&>(
                 &Context<T>::get_mutable_discrete_state),
@@ -231,6 +241,15 @@ void DefineFrameworkPySemantics(py::module m) {
             },
             py_reference_internal,
             doc.Context.get_mutable_abstract_state.doc_1args)
+        .def("SetAbstractState",
+            [](py::object self, int index, py::object value) {
+              // Use type erasure from Python bindings of Value[T].set_value.
+              py::object abstract_value =
+                  self.attr("get_mutable_abstract_state")(index);
+              abstract_value.attr("set_value")(value);
+            },
+            py::arg("index"), py::arg("value"),
+            doc.Context.SetAbstractState.doc)
         .def("get_parameters", &Context<T>::get_parameters,
             py_reference_internal, doc.Context.get_parameters.doc)
         .def("num_numeric_parameter_groups",

--- a/bindings/pydrake/systems/framework_py_values.cc
+++ b/bindings/pydrake/systems/framework_py_values.cc
@@ -122,6 +122,9 @@ void DefineFrameworkPyValues(py::module m) {
   // Add `Value<std::string>` instantiation (visible in Python as `Value[str]`).
   AddValueInstantiation<string>(m);
 
+  // Add `Value<bool>` instantiation (visible in Python as `Value[bool]`).
+  AddValueInstantiation<bool>(m);
+
   // Add `Value<>` instantiations for basic vectors templated on common scalar
   // types.
   auto bind_abstract_basic_vectors = [m](auto dummy) {

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -14,6 +14,7 @@ from pydrake.autodiffutils import (
     AutoDiffXd,
     )
 from pydrake.examples.pendulum import PendulumPlant
+from pydrake.examples.rimless_wheel import RimlessWheel
 from pydrake.symbolic import (
     Expression,
     )
@@ -124,6 +125,25 @@ class TestGeneral(unittest.TestCase):
         context.SetContinuousState(x)
         np.testing.assert_equal(
             context.get_continuous_state_vector().CopyToVector(), x)
+
+        # RimlessWheel has a single discrete variable and a bool abstract
+        # variable.
+        rimless = RimlessWheel()
+        context = rimless.CreateDefaultContext()
+        x = np.array([1.125])
+        context.SetDiscreteState(xd=2 * x)
+        np.testing.assert_equal(
+            context.get_discrete_state_vector().CopyToVector(), 2 * x)
+        context.SetDiscreteState(group_index=0, xd=3 * x)
+        np.testing.assert_equal(
+            context.get_discrete_state_vector().CopyToVector(), 3 * x)
+
+        context.SetAbstractState(index=0, value=True)
+        value = context.get_abstract_state(0)
+        self.assertTrue(value.get_value())
+        context.SetAbstractState(index=0, value=False)
+        value = context.get_abstract_state(0)
+        self.assertFalse(value.get_value())
 
     def test_event_api(self):
         # TriggerType - existence check.


### PR DESCRIPTION
Adds `SetDiscreteState()` and `SetAbstractState()` methods to `Context` for safety and consistency with `SetContinuousState()`.

Resolves #10908

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10946)
<!-- Reviewable:end -->
