### PR TITLE
Maliput: Adds DirectionUsageRule to RoadRulebook

### DIFF
--- a/automotive/maliput/api/basic_id_index.cc
+++ b/automotive/maliput/api/basic_id_index.cc
@@ -58,6 +58,11 @@ const Lane* BasicIdIndex::DoGetLane(const LaneId& id) const {
   return find_or_nullptr(lane_map_, id);
 }
 
+const std::unordered_map<LaneId, const Lane*>& BasicIdIndex::DoGetLanes()
+    const {
+  return lane_map_;
+}
+
 
 const Segment* BasicIdIndex::DoGetSegment(const SegmentId& id) const {
   return find_or_nullptr(segment_map_, id);

--- a/automotive/maliput/api/basic_id_index.h
+++ b/automotive/maliput/api/basic_id_index.h
@@ -58,6 +58,7 @@ class BasicIdIndex : public RoadGeometry::IdIndex {
 
  private:
   const Lane* DoGetLane(const LaneId& id) const final;
+  const std::unordered_map<LaneId, const Lane*>& DoGetLanes() const override;
   const Segment* DoGetSegment(const SegmentId& id) const final;
   const Junction* DoGetJunction(const JunctionId& id) const final;
   const BranchPoint* DoGetBranchPoint(const BranchPointId& id) const final;

--- a/automotive/maliput/api/road_geometry.h
+++ b/automotive/maliput/api/road_geometry.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "drake/automotive/maliput/api/branch_point.h"
@@ -182,6 +183,11 @@ class RoadGeometry::IdIndex {
   /// Returns the Lane identified by @p id, or `nullptr` if @p id is unknown.
   const Lane* GetLane(const LaneId& id) const { return DoGetLane(id); }
 
+  // Returns all of the Lane instances.
+  const std::unordered_map<LaneId, const Lane*>& GetLanes() const {
+    return DoGetLanes();
+  }
+
   /// Returns the Segment identified by @p id, or `nullptr` if @p id is
   /// unknown.
   const Segment* GetSegment(const SegmentId& id) const {
@@ -205,6 +211,7 @@ class RoadGeometry::IdIndex {
 
  private:
   virtual const Lane* DoGetLane(const LaneId& id) const = 0;
+  virtual const std::unordered_map<LaneId, const Lane*>& DoGetLanes() const = 0;
   virtual const Segment* DoGetSegment(const SegmentId& id) const = 0;
   virtual const Junction* DoGetJunction(const JunctionId& id) const = 0;
   virtual const BranchPoint* DoGetBranchPoint(

--- a/automotive/maliput/api/road_network.cc
+++ b/automotive/maliput/api/road_network.cc
@@ -2,6 +2,7 @@
 
 #include <utility>
 
+#include "drake/automotive/maliput/api/lane.h"
 #include "drake/common/drake_throw.h"
 
 namespace drake {
@@ -15,14 +16,16 @@ RoadNetwork::RoadNetwork(
     std::unique_ptr<rules::RightOfWayPhaseBook> phase_book,
     std::unique_ptr<rules::RightOfWayStateProvider> state_provider,
     std::unique_ptr<rules::RightOfWayPhaseProvider> phase_provider,
-    std::vector<rules::SpeedLimitRule> speed_limits)
+    std::vector<rules::SpeedLimitRule> speed_limits,
+    std::vector<rules::DirectionUsageRule> direction_usage_rules)
     : road_geometry_(std::move(road_geometry)),
       rulebook_(std::move(rulebook)),
       intersections_(std::move(intersections)),
       phase_book_(std::move(phase_book)),
       state_provider_(std::move(state_provider)),
       phase_provider_(std::move(phase_provider)),
-      speed_limits_(std::move(speed_limits)) {
+      speed_limits_(std::move(speed_limits)),
+      direction_usage_rules_(std::move(direction_usage_rules)) {
   DRAKE_THROW_UNLESS(road_geometry_.get() != nullptr);
   DRAKE_THROW_UNLESS(rulebook_.get() != nullptr);
   DRAKE_THROW_UNLESS(phase_book_.get() != nullptr);
@@ -30,6 +33,22 @@ RoadNetwork::RoadNetwork(
   DRAKE_THROW_UNLESS(phase_provider_.get() != nullptr);
   for (int i = 0; i < static_cast<int>(intersections_.size()); ++i) {
     intersections_map_[intersections_.at(i)->id()] = intersections_.at(i).get();
+  }
+
+  // Confirms full DirectionUsageRule coverage. Currently, this is determined by
+  // verifying that each Lane within the RoadGeometry has an associated
+  // DirectionUsageRule. In the future, this check could be made even more
+  // rigorous by confirming that the union of all DirectionUsageRule zones
+  // covers the whole RoadGeometry.
+  const auto& lanes_map = road_geometry_->ById().GetLanes();
+  for (const auto& lane_map : lanes_map) {
+    const LaneId lane_id = lane_map.first;
+    const auto RuleIdMatchesLaneId = [&](rules::DirectionUsageRule& rule) {
+      return rule.zone().lane_id() == lane_id;
+    };
+    const auto lane_rule = std::find_if(direction_usage_rules_.begin(),
+        direction_usage_rules_.end(), RuleIdMatchesLaneId);
+    DRAKE_THROW_UNLESS(lane_rule != direction_usage_rules_.end());
   }
 }
 

--- a/automotive/maliput/api/road_network.h
+++ b/automotive/maliput/api/road_network.h
@@ -6,6 +6,7 @@
 
 #include "drake/automotive/maliput/api/intersection.h"
 #include "drake/automotive/maliput/api/road_geometry.h"
+#include "drake/automotive/maliput/api/rules/direction_usage_rule.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_phase_book.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_phase_provider.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_state_provider.h"
@@ -24,13 +25,15 @@ class RoadNetwork {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RoadNetwork)
 
   /// Constructs an RoadNetwork instance. All parameters are required.
+  /// @p direction_usage_rules must cover the whole @p road_geometry.
   RoadNetwork(std::unique_ptr<const RoadGeometry> road_geometry,
               std::unique_ptr<const rules::RoadRulebook> rulebook,
               std::vector<std::unique_ptr<Intersection>> intersections,
               std::unique_ptr<rules::RightOfWayPhaseBook> phase_book,
               std::unique_ptr<rules::RightOfWayStateProvider> state_provider,
               std::unique_ptr<rules::RightOfWayPhaseProvider> phase_provider,
-              std::vector<rules::SpeedLimitRule> speed_limits);
+              std::vector<rules::SpeedLimitRule> speed_limits,
+              std::vector<rules::DirectionUsageRule> direction_usage_rules);
 
   virtual ~RoadNetwork() = default;
 
@@ -58,6 +61,10 @@ class RoadNetwork {
     return &speed_limits_;
   }
 
+  const std::vector<rules::DirectionUsageRule>* direction_usage_rules() const {
+    return &direction_usage_rules_;
+  }
+
  private:
   std::unique_ptr<const RoadGeometry> road_geometry_;
   std::unique_ptr<const rules::RoadRulebook> rulebook_;
@@ -67,6 +74,7 @@ class RoadNetwork {
   std::unique_ptr<rules::RightOfWayStateProvider> state_provider_;
   std::unique_ptr<rules::RightOfWayPhaseProvider> phase_provider_;
   std::vector<rules::SpeedLimitRule> speed_limits_;
+  std::vector<rules::DirectionUsageRule> direction_usage_rules_;
 };
 
 }  // namespace api

--- a/automotive/maliput/api/rules/road_rulebook.h
+++ b/automotive/maliput/api/rules/road_rulebook.h
@@ -2,6 +2,7 @@
 
 #include <vector>
 
+#include "drake/automotive/maliput/api/rules/direction_usage_rule.h"
 #include "drake/automotive/maliput/api/rules/regions.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_rule.h"
 #include "drake/automotive/maliput/api/rules/speed_limit_rule.h"
@@ -32,6 +33,7 @@ class RoadRulebook {
   struct QueryResults {
     std::vector<RightOfWayRule> right_of_way;
     std::vector<SpeedLimitRule> speed_limit;
+    std::vector<rules::DirectionUsageRule> direction_usage;
   };
 
   /// Returns a QueryResults structure which contains any rules which are
@@ -64,6 +66,13 @@ class RoadRulebook {
     return DoGetRule(id);
   }
 
+  /// Returns the DirectionUsageRule with the specified `id`.
+  ///
+  /// @throws std::out_of_range if `id` is unknown.
+  DirectionUsageRule GetRule(const DirectionUsageRule::Id& id) const {
+    return DoGetRule(id);
+  }
+
  protected:
   RoadRulebook() = default;
 
@@ -76,6 +85,8 @@ class RoadRulebook {
       const std::vector<LaneSRange>& ranges, double tolerance) const = 0;
   virtual RightOfWayRule DoGetRule(const RightOfWayRule::Id& id) const = 0;
   virtual SpeedLimitRule DoGetRule(const SpeedLimitRule::Id& id) const = 0;
+  virtual DirectionUsageRule DoGetRule(
+    const DirectionUsageRule::Id& id) const = 0;
   //@}
 };
 

--- a/automotive/maliput/api/test/mock.cc
+++ b/automotive/maliput/api/test/mock.cc
@@ -1,5 +1,6 @@
 #include "drake/automotive/maliput/api/test/mock.h"
 
+#include <unordered_map>
 #include <vector>
 
 #include "drake/automotive/maliput/api/branch_point.h"
@@ -16,8 +17,9 @@ namespace api {
 namespace test {
 namespace {
 
-using rules::LaneSRange;
+using rules::DirectionUsageRule;
 using rules::RightOfWayRule;
+using rules::SpeedLimitRule;
 
 class MockIdIndex final : public RoadGeometry::IdIndex {
  public:
@@ -26,6 +28,11 @@ class MockIdIndex final : public RoadGeometry::IdIndex {
 
  private:
   const Lane* DoGetLane(const LaneId&) const override { return nullptr; }
+
+  const std::unordered_map<LaneId, const Lane*>& DoGetLanes() const override {
+    return lane_map_;
+  }
+
   const Segment* DoGetSegment(const SegmentId&) const override {
     return nullptr;
   };
@@ -35,6 +42,8 @@ class MockIdIndex final : public RoadGeometry::IdIndex {
   const BranchPoint* DoGetBranchPoint(const BranchPointId&) const override {
     return nullptr;
   }
+
+  const std::unordered_map<LaneId, const Lane*> lane_map_;
 };
 
 class MockRoadGeometry final : public RoadGeometry {
@@ -69,16 +78,19 @@ class MockRoadRulebook final : public rules::RoadRulebook {
                            double) const override {
     return {{}, {}};
   }
-  rules::RightOfWayRule DoGetRule(
-      const rules::RightOfWayRule::Id&) const override {
+  RightOfWayRule DoGetRule(
+      const RightOfWayRule::Id&) const override {
     return Rule();
   }
-  rules::SpeedLimitRule DoGetRule(
-      const rules::SpeedLimitRule::Id&) const override {
-    const rules::LaneSRange kZone(rules::LaneSRange(LaneId("a"), {0., 9.}));
-    return rules::SpeedLimitRule(rules::SpeedLimitRule::Id("some_id"), kZone,
-                                 rules::SpeedLimitRule::Severity::kStrict, 33.,
-                                 77.);
+  SpeedLimitRule DoGetRule(const SpeedLimitRule::Id&) const override {
+    return SpeedLimitRule(rules::SpeedLimitRule::Id("some_id"),
+                          CreateLaneSRange(),
+                          rules::SpeedLimitRule::Severity::kStrict, 33.,
+                          77.);
+  }
+
+  DirectionUsageRule DoGetRule(const DirectionUsageRule::Id&) const override {
+    return CreateDirectionUsageRule();
   }
 };
 
@@ -140,9 +152,14 @@ class MockIntersection final : public Intersection {
 
 }  // namespace
 
-rules::LaneSRoute LaneSRoute() {
+rules::LaneSRoute CreateLaneSRoute() {
   return rules::LaneSRoute(
-      {LaneSRange(LaneId("a"), {0., 9.}), LaneSRange(LaneId("b"), {17., 12.})});
+      {rules::LaneSRange(LaneId("a"), {0., 9.}),
+       rules::LaneSRange(LaneId("b"), {17., 12.})});
+}
+
+rules::LaneSRange CreateLaneSRange() {
+  return rules::LaneSRange(LaneId("a"), {0., 9.});
 }
 
 RightOfWayRule::State::YieldGroup YieldGroup2() {
@@ -161,9 +178,22 @@ RightOfWayRule::State YieldState() {
 }
 
 RightOfWayRule Rule() {
-  return RightOfWayRule(RightOfWayRule::Id("mock_id"), LaneSRoute(),
+  return RightOfWayRule(RightOfWayRule::Id("mock_id"), CreateLaneSRoute(),
                         RightOfWayRule::ZoneType::kStopExcluded,
                         {NoYieldState(), YieldState()});
+}
+
+DirectionUsageRule::State CreateDirectionUsageRuleState() {
+  return DirectionUsageRule::State(
+    DirectionUsageRule::State::Id("dur_state"),
+    DirectionUsageRule::State::Type::kWithS,
+    DirectionUsageRule::State::Severity::kStrict);
+}
+
+DirectionUsageRule CreateDirectionUsageRule() {
+  return DirectionUsageRule(DirectionUsageRule::Id("dur_id"),
+                            CreateLaneSRange(),
+                            {CreateDirectionUsageRuleState()});
 }
 
 std::unique_ptr<RoadGeometry> CreateRoadGeometry() {

--- a/automotive/maliput/api/test/mock.h
+++ b/automotive/maliput/api/test/mock.h
@@ -4,6 +4,7 @@
 
 #include "drake/automotive/maliput/api/intersection.h"
 #include "drake/automotive/maliput/api/road_geometry.h"
+#include "drake/automotive/maliput/api/rules/direction_usage_rule.h"
 #include "drake/automotive/maliput/api/rules/regions.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_phase_book.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_phase_provider.h"
@@ -18,7 +19,10 @@ namespace api {
 namespace test {
 
 /// Returns a rules::LaneSRoute containing an arbitrary route.
-rules::LaneSRoute LaneSRoute();
+rules::LaneSRoute CreateLaneSRoute();
+
+/// Returns a rules::LaneSRange containing an arbitrary range.
+rules::LaneSRange CreateLaneSRange();
 
 /// Returns a rules::RightOfWayRule::State::YieldGroup of size two.
 rules::RightOfWayRule::State::YieldGroup YieldGroup2();
@@ -31,6 +35,12 @@ rules::RightOfWayRule::State YieldState();
 
 /// Returns a rules::RightOfWayRule containing arbitrary state.
 rules::RightOfWayRule Rule();
+
+/// Returns a rules::DirectionUsageRule::State containing an arbitrary state.
+rules::DirectionUsageRule::State CreateDirectionUsageRuleState();
+
+/// Returns a rules::DirectionUsageRule containing an arbitrary state.
+rules::DirectionUsageRule CreateDirectionUsageRule();
 
 /// Returns an arbitrary RoadGeometry.
 std::unique_ptr<RoadGeometry> CreateRoadGeometry();

--- a/automotive/maliput/api/test/road_network_test.cc
+++ b/automotive/maliput/api/test/road_network_test.cc
@@ -12,6 +12,7 @@ namespace maliput {
 namespace api {
 namespace {
 
+using rules::DirectionUsageRule;
 using rules::LaneSRange;
 using rules::RightOfWayPhaseBook;
 using rules::RightOfWayPhaseProvider;
@@ -53,23 +54,23 @@ class RoadNetworkTest : public ::testing::Test {
 TEST_F(RoadNetworkTest, MissingParameters) {
   EXPECT_THROW(RoadNetwork(nullptr, std::move(road_rulebook_), {},
                            std::move(phase_book_), std::move(state_provider_),
-                           std::move(phase_provider_), {}),
+                           std::move(phase_provider_), {}, {}),
                std::exception);
   EXPECT_THROW(RoadNetwork(std::move(road_geometry_), nullptr, {},
                            std::move(phase_book_), std::move(state_provider_),
-                           std::move(phase_provider_), {}),
+                           std::move(phase_provider_), {}, {}),
                std::exception);
   EXPECT_THROW(RoadNetwork(std::move(road_geometry_), std::move(road_rulebook_),
                            {}, nullptr, std::move(state_provider_),
-                           std::move(phase_provider_), {}),
+                           std::move(phase_provider_), {}, {}),
                std::exception);
   EXPECT_THROW(RoadNetwork(std::move(road_geometry_), std::move(road_rulebook_),
                            {}, std::move(phase_book_), nullptr,
-                           std::move(phase_provider_), {}),
+                           std::move(phase_provider_), {}, {}),
                std::exception);
   EXPECT_THROW(RoadNetwork(std::move(road_geometry_), std::move(road_rulebook_),
                            {}, std::move(phase_book_),
-                           std::move(state_provider_), nullptr, {}),
+                           std::move(state_provider_), nullptr, {}, {}),
                std::exception);
 }
 
@@ -90,12 +91,15 @@ TEST_F(RoadNetworkTest, InstantiateAndUseAccessors) {
   std::vector<SpeedLimitRule> speed_limits;
   const SpeedLimitRule::Id speed_limit_id("speed_limit_id");
   speed_limits.emplace_back(SpeedLimitRule(
-      speed_limit_id, LaneSRange(LaneId("the_lane"), SRange(13., 15.)),
+      speed_limit_id, test::CreateLaneSRange(),
       SpeedLimitRule::Severity::kStrict, 0, 30.));
+  const DirectionUsageRule direction_usage_rule =
+      test::CreateDirectionUsageRule();
+  std::vector<DirectionUsageRule> direction_usage_rules{direction_usage_rule};
   RoadNetwork dut(std::move(road_geometry_), std::move(road_rulebook_),
                   std::move(intersections), std::move(phase_book_),
                   std::move(state_provider_), std::move(phase_provider_),
-                  std::move(speed_limits));
+                  std::move(speed_limits), std::move(direction_usage_rules));
 
   EXPECT_EQ(dut.road_geometry(), road_geometry_ptr_);
   EXPECT_EQ(dut.rulebook(), road_rulebook_ptr_);
@@ -108,6 +112,9 @@ TEST_F(RoadNetworkTest, InstantiateAndUseAccessors) {
   EXPECT_EQ(dut.phase_provider(), phase_provider_ptr_);
   EXPECT_EQ(dut.speed_limits()->size(), 1);
   EXPECT_EQ(dut.speed_limits()->at(0).id(), speed_limit_id);
+  EXPECT_EQ(dut.direction_usage_rules()->size(), 1);
+  EXPECT_EQ(dut.direction_usage_rules()->at(0).id(),
+            direction_usage_rule.id());
 }
 
 }  // namespace

--- a/automotive/maliput/api/test/rules_right_of_way_test.cc
+++ b/automotive/maliput/api/test/rules_right_of_way_test.cc
@@ -59,23 +59,26 @@ GTEST_TEST(RightOfWayRuleStateTest, Assignment) {
 
 GTEST_TEST(RightOfWayRuleTest, Construction) {
   EXPECT_NO_THROW(
-      RightOfWayRule(RightOfWayRule::Id("some_id"), api::test::LaneSRoute(),
+      RightOfWayRule(RightOfWayRule::Id("some_id"),
+                     api::test::CreateLaneSRoute(),
                      RightOfWayRule::ZoneType::kStopExcluded,
                      {api::test::NoYieldState(), api::test::YieldState()}));
   EXPECT_NO_THROW(RightOfWayRule(
-      RightOfWayRule::Id("some_id"), api::test::LaneSRoute(),
+      RightOfWayRule::Id("some_id"), api::test::CreateLaneSRoute(),
       RightOfWayRule::ZoneType::kStopExcluded, {api::test::NoYieldState()}));
 
   // At least one State must be provided.
   EXPECT_THROW(
-      RightOfWayRule(RightOfWayRule::Id("some_id"), api::test::LaneSRoute(),
+      RightOfWayRule(RightOfWayRule::Id("some_id"),
+                     api::test::CreateLaneSRoute(),
                      RightOfWayRule::ZoneType::kStopExcluded, {}),
       std::exception);
   // At least one State::Id's must be unique.
   const RightOfWayRule::State kDupIdState(RightOfWayRule::State::Id("s1"),
                                           RightOfWayRule::State::Type::kGo, {});
   EXPECT_THROW(
-      RightOfWayRule(RightOfWayRule::Id("some_id"), api::test::LaneSRoute(),
+      RightOfWayRule(RightOfWayRule::Id("some_id"),
+                     api::test::CreateLaneSRoute(),
                      RightOfWayRule::ZoneType::kStopExcluded,
                      {api::test::NoYieldState(), kDupIdState}),
       std::exception);
@@ -83,11 +86,11 @@ GTEST_TEST(RightOfWayRuleTest, Construction) {
 
 GTEST_TEST(RightOfWayRuleTest, Accessors) {
   const RightOfWayRule dut(
-      RightOfWayRule::Id("dut_id"), api::test::LaneSRoute(),
+      RightOfWayRule::Id("dut_id"), api::test::CreateLaneSRoute(),
       RightOfWayRule::ZoneType::kStopExcluded,
       {api::test::NoYieldState(), api::test::YieldState()});
   EXPECT_EQ(dut.id(), RightOfWayRule::Id("dut_id"));
-  EXPECT_TRUE(MALIPUT_IS_EQUAL(dut.zone(), api::test::LaneSRoute()));
+  EXPECT_TRUE(MALIPUT_IS_EQUAL(dut.zone(), api::test::CreateLaneSRoute()));
   EXPECT_EQ(dut.zone_type(), RightOfWayRule::ZoneType::kStopExcluded);
   EXPECT_EQ(dut.states().size(), 2);
   EXPECT_TRUE(MALIPUT_IS_EQUAL(dut.states().at(RightOfWayRule::State::Id("s1")),
@@ -101,7 +104,7 @@ GTEST_TEST(RightOfWayRuleTest, Accessors) {
 // Specifically test the different results for a static (single state) rule.
 GTEST_TEST(RightOfWayRuleTest, StaticRuleOnlyAccessors) {
   const RightOfWayRule dut(
-      RightOfWayRule::Id("dut_id"), api::test::LaneSRoute(),
+      RightOfWayRule::Id("dut_id"), api::test::CreateLaneSRoute(),
       RightOfWayRule::ZoneType::kStopExcluded, {api::test::YieldState()});
   EXPECT_TRUE(dut.is_static());
   EXPECT_NO_THROW(dut.static_state());
@@ -110,7 +113,7 @@ GTEST_TEST(RightOfWayRuleTest, StaticRuleOnlyAccessors) {
 
 GTEST_TEST(RightOfWayRuleTest, Copying) {
   const RightOfWayRule source(
-      RightOfWayRule::Id("source_id"), api::test::LaneSRoute(),
+      RightOfWayRule::Id("source_id"), api::test::CreateLaneSRoute(),
       RightOfWayRule::ZoneType::kStopExcluded,
       {api::test::NoYieldState(), api::test::YieldState()});
 
@@ -120,11 +123,12 @@ GTEST_TEST(RightOfWayRuleTest, Copying) {
 
 GTEST_TEST(RightOfWayRuleTest, Assignment) {
   const RightOfWayRule source(
-      RightOfWayRule::Id("source_id"), api::test::LaneSRoute(),
+      RightOfWayRule::Id("source_id"), api::test::CreateLaneSRoute(),
       RightOfWayRule::ZoneType::kStopExcluded,
       {api::test::NoYieldState(), api::test::YieldState()});
 
-  RightOfWayRule dut(RightOfWayRule::Id("some_id"), api::test::LaneSRoute(),
+  RightOfWayRule dut(RightOfWayRule::Id("some_id"),
+                     api::test::CreateLaneSRoute(),
                      RightOfWayRule::ZoneType::kStopAllowed,
                      {api::test::NoYieldState()});
 

--- a/automotive/maliput/api/test/rules_road_rulebook_test.cc
+++ b/automotive/maliput/api/test/rules_road_rulebook_test.cc
@@ -5,6 +5,7 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/automotive/maliput/api/rules/direction_usage_rule.h"
 #include "drake/automotive/maliput/api/rules/regions.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_rule.h"
 #include "drake/automotive/maliput/api/rules/speed_limit_rule.h"
@@ -16,24 +17,29 @@ namespace api {
 namespace rules {
 namespace {
 
-const LaneSRange kZone(LaneId("some_lane"), {10., 20.});
-
-const RightOfWayRule kRightOfWay(
+// This class does not provide any semblance of useful functionality.
+// It merely exercises the RoadRulebook abstract interface.
+class MockRulebook : public RoadRulebook {
+ public:
+  const LaneSRange kZone{LaneId("some_lane"), {10., 20.}};
+  const RightOfWayRule kRightOfWay{
     RightOfWayRule::Id("rowr_id"),
     LaneSRoute({kZone}), RightOfWayRule::ZoneType::kStopExcluded,
     {RightOfWayRule::State(
         RightOfWayRule::State::Id("green"),
         RightOfWayRule::State::Type::kGo,
-        {})});
+        {})}};
+  const SpeedLimitRule kSpeedLimit{SpeedLimitRule::Id("slr_id"),
+                                   kZone,
+                                   SpeedLimitRule::Severity::kStrict,
+                                   0., 44.};
+  const DirectionUsageRule kDirectionUsage{
+    DirectionUsageRule::Id("dur_id"), kZone,
+    {DirectionUsageRule::State(
+      DirectionUsageRule::State::Id("dur_state"),
+      DirectionUsageRule::State::Type::kWithS,
+      DirectionUsageRule::State::Severity::kPreferred)}};
 
-const SpeedLimitRule kSpeedLimit(SpeedLimitRule::Id("slr_id"),
-                                 kZone,
-                                 SpeedLimitRule::Severity::kStrict,
-                                 0., 44.);
-
-// This class does not provide any semblance of useful functionality.
-// It merely exercises the RoadRulebook abstract interface.
-class MockRulebook : public RoadRulebook {
  private:
   virtual QueryResults DoFindRules(
       const std::vector<LaneSRange>& ranges, double) const {
@@ -44,6 +50,7 @@ class MockRulebook : public RoadRulebook {
         (ranges[0].s_range().s1() == kZone.s_range().s1())) {
       results.right_of_way.push_back(kRightOfWay);
       results.speed_limit.push_back(kSpeedLimit);
+      results.direction_usage.push_back(kDirectionUsage);
     }
     return results;
   }
@@ -61,6 +68,13 @@ class MockRulebook : public RoadRulebook {
     }
     return kSpeedLimit;
   }
+
+  virtual DirectionUsageRule DoGetRule(const DirectionUsageRule::Id& id) const {
+    if (id != kDirectionUsage.id()) {
+      throw std::out_of_range("");
+    }
+    return kDirectionUsage;
+  }
 };
 
 
@@ -69,22 +83,30 @@ GTEST_TEST(RoadRulebookTest, ExerciseInterface) {
 
   const double kZeroTolerance = 0.;
 
-  RoadRulebook::QueryResults nonempty = dut.FindRules({kZone}, kZeroTolerance);
+  RoadRulebook::QueryResults nonempty = dut.FindRules({dut.kZone},
+                                                      kZeroTolerance);
   EXPECT_EQ(nonempty.right_of_way.size(), 1);
   EXPECT_EQ(nonempty.speed_limit.size(), 1);
+  EXPECT_EQ(nonempty.direction_usage.size(), 1);
   RoadRulebook::QueryResults empty = dut.FindRules({}, kZeroTolerance);
   EXPECT_EQ(empty.right_of_way.size(), 0);
   EXPECT_EQ(empty.speed_limit.size(), 0);
+  EXPECT_EQ(empty.direction_usage.size(), 0);
 
   const double kNegativeTolerance = -1.;
   EXPECT_THROW(dut.FindRules({}, kNegativeTolerance),
                std::runtime_error);
 
-  EXPECT_EQ(dut.GetRule(kRightOfWay.id()).id(), kRightOfWay.id());
+  EXPECT_EQ(dut.GetRule(dut.kRightOfWay.id()).id(), dut.kRightOfWay.id());
   EXPECT_THROW(dut.GetRule(RightOfWayRule::Id("xxx")), std::out_of_range);
 
-  EXPECT_EQ(dut.GetRule(kSpeedLimit.id()).id(), kSpeedLimit.id());
+  EXPECT_EQ(dut.GetRule(dut.kSpeedLimit.id()).id(), dut.kSpeedLimit.id());
   EXPECT_THROW(dut.GetRule(SpeedLimitRule::Id("xxx")), std::out_of_range);
+
+  EXPECT_EQ(dut.GetRule(dut.kDirectionUsage.id()).id(),
+                        dut.kDirectionUsage.id());
+  EXPECT_THROW(dut.GetRule(DirectionUsageRule::Id("xxx")),
+                           std::out_of_range);
 }
 
 

--- a/automotive/maliput/base/simple_rulebook.h
+++ b/automotive/maliput/base/simple_rulebook.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <vector>
 
+#include "drake/automotive/maliput/api/rules/direction_usage_rule.h"
 #include "drake/automotive/maliput/api/rules/regions.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_rule.h"
 #include "drake/automotive/maliput/api/rules/road_rulebook.h"
@@ -48,6 +49,17 @@ class SimpleRulebook : public api::rules::RoadRulebook {
   /// @throws std::runtime_error if no such rule exists.
   void RemoveRule(const api::rules::SpeedLimitRule::Id& id);
 
+  /// Adds a new DirectionUsageRule.
+  ///
+  /// @throws std::runtime_error if a rule with the same ID already exists
+  /// in the SimpleRulebook.
+  void AddRule(const api::rules::DirectionUsageRule& rule);
+
+  /// Removes the DirectionUsageRule labeled by `id`.
+  ///
+  /// @throws std::runtime_error if no such rule exists.
+  void RemoveRule(const api::rules::DirectionUsageRule::Id& id);
+
  private:
   api::rules::RoadRulebook::QueryResults DoFindRules(
       const std::vector<api::rules::LaneSRange>& ranges,
@@ -56,6 +68,8 @@ class SimpleRulebook : public api::rules::RoadRulebook {
       const api::rules::RightOfWayRule::Id& id) const override;
   api::rules::SpeedLimitRule DoGetRule(
       const api::rules::SpeedLimitRule::Id& id) const override;
+  api::rules::DirectionUsageRule DoGetRule(
+      const api::rules::DirectionUsageRule::Id& id) const override;
 
   class Impl;
   std::unique_ptr<Impl> impl_;

--- a/automotive/maliput/base/test/simple_rulebook_test.cc
+++ b/automotive/maliput/base/test/simple_rulebook_test.cc
@@ -5,6 +5,7 @@
 #include "drake/automotive/maliput/api/rules/regions.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_rule.h"
 #include "drake/automotive/maliput/api/rules/speed_limit_rule.h"
+#include "drake/automotive/maliput/api/test_utilities/rules_direction_usage_compare.h"
 #include "drake/automotive/maliput/api/test_utilities/rules_right_of_way_compare.h"
 #include "drake/automotive/maliput/api/test_utilities/rules_speed_limit_compare.h"
 #include "drake/automotive/maliput/api/test_utilities/rules_test_utilities.h"
@@ -14,34 +15,45 @@ namespace maliput {
 namespace {
 
 using api::LaneId;
+using api::rules::DirectionUsageRule;
 using api::rules::LaneSRange;
 using api::rules::LaneSRoute;
 using api::rules::RightOfWayRule;
 using api::rules::RoadRulebook;
 using api::rules::SpeedLimitRule;
 
-const LaneSRange kZone(LaneId("a"), {10., 20.});
 
-const RightOfWayRule kRightOfWay(
-    RightOfWayRule::Id("rowr_id"),
-    LaneSRoute({kZone}),
-    RightOfWayRule::ZoneType::kStopExcluded,
-    {RightOfWayRule::State{RightOfWayRule::State::Id("rowr_state_id"),
-                           RightOfWayRule::State::Type::kStopThenGo,
-                           {}}});
+class SimpleRulebookTest : public ::testing::Test {
+ protected:
+  const LaneSRange kZone{LaneId("a"), {10., 20.}};
 
-const SpeedLimitRule kSpeedLimit(SpeedLimitRule::Id("slr_id"),
-                                 kZone,
-                                 SpeedLimitRule::Severity::kStrict,
-                                 0., 44.);
+  const RightOfWayRule kRightOfWay{
+      RightOfWayRule::Id("rowr_id"),
+      LaneSRoute({kZone}),
+      RightOfWayRule::ZoneType::kStopExcluded,
+      {RightOfWayRule::State{RightOfWayRule::State::Id("rowr_state_id"),
+                             RightOfWayRule::State::Type::kStopThenGo,
+                             {}}}};
+
+  const SpeedLimitRule kSpeedLimit{SpeedLimitRule::Id("slr_id"),
+                                   kZone,
+                                   SpeedLimitRule::Severity::kStrict,
+                                   0., 44.};
+
+  const DirectionUsageRule kDirectionUsage{
+    DirectionUsageRule::Id("dur_id"), kZone,
+    {DirectionUsageRule::State(DirectionUsageRule::State::Id("dur_state"),
+     DirectionUsageRule::State::Type::kWithS,
+     DirectionUsageRule::State::Severity::kStrict)}};
+};
 
 
-GTEST_TEST(SimpleRulebookTest, DefaultConstructor) {
+TEST_F(SimpleRulebookTest, DefaultConstructor) {
   SimpleRulebook dut;
 }
 
 
-GTEST_TEST(SimpleRulebookTest, AddGetRemoveRightOfWay) {
+TEST_F(SimpleRulebookTest, AddGetRemoveRightOfWay) {
   SimpleRulebook dut;
 
   EXPECT_THROW(dut.GetRule(kRightOfWay.id()), std::out_of_range);
@@ -54,7 +66,7 @@ GTEST_TEST(SimpleRulebookTest, AddGetRemoveRightOfWay) {
 }
 
 
-GTEST_TEST(SimpleRulebookTest, AddGetRemoveSpeedLimit) {
+TEST_F(SimpleRulebookTest, AddGetRemoveSpeedLimit) {
   SimpleRulebook dut;
 
   EXPECT_THROW(dut.GetRule(kSpeedLimit.id()), std::out_of_range);
@@ -66,29 +78,49 @@ GTEST_TEST(SimpleRulebookTest, AddGetRemoveSpeedLimit) {
   EXPECT_THROW(dut.RemoveRule(kSpeedLimit.id()), std::runtime_error);
 }
 
+TEST_F(SimpleRulebookTest, AddGetRemoveDirectionUsage) {
+  SimpleRulebook dut;
 
-GTEST_TEST(SimpleRulebookTest, RemoveAll) {
+  EXPECT_THROW(dut.GetRule(kDirectionUsage.id()), std::out_of_range);
+  dut.AddRule(kDirectionUsage);
+  EXPECT_TRUE(MALIPUT_IS_EQUAL(dut.GetRule(kDirectionUsage.id()),
+                               kDirectionUsage));
+  EXPECT_THROW(dut.AddRule(kDirectionUsage), std::runtime_error);
+  dut.RemoveRule(kDirectionUsage.id());
+  EXPECT_THROW(dut.GetRule(kDirectionUsage.id()), std::out_of_range);
+  EXPECT_THROW(dut.RemoveRule(kDirectionUsage.id()), std::runtime_error);
+}
+
+TEST_F(SimpleRulebookTest, RemoveAll) {
   SimpleRulebook dut;
   dut.RemoveAll();  // I.e., should work on empty rulebook.
   dut.AddRule(kRightOfWay);
   dut.AddRule(kSpeedLimit);
+  dut.AddRule(kDirectionUsage);
   dut.RemoveAll();
   EXPECT_THROW(dut.GetRule(kRightOfWay.id()), std::out_of_range);
   EXPECT_THROW(dut.RemoveRule(kRightOfWay.id()), std::runtime_error);
   EXPECT_THROW(dut.GetRule(kSpeedLimit.id()), std::out_of_range);
   EXPECT_THROW(dut.RemoveRule(kSpeedLimit.id()), std::runtime_error);
+  EXPECT_THROW(dut.GetRule(kDirectionUsage.id()), std::out_of_range);
+  EXPECT_THROW(dut.RemoveRule(kDirectionUsage.id()), std::runtime_error);
+
   // Since the original rules are gone, it should be possible to re-add them.
   dut.AddRule(kRightOfWay);
   dut.AddRule(kSpeedLimit);
+  dut.AddRule(kDirectionUsage);
   EXPECT_TRUE(MALIPUT_IS_EQUAL(dut.GetRule(kRightOfWay.id()), kRightOfWay));
   EXPECT_TRUE(MALIPUT_IS_EQUAL(dut.GetRule(kSpeedLimit.id()), kSpeedLimit));
+  EXPECT_TRUE(MALIPUT_IS_EQUAL(dut.GetRule(kDirectionUsage.id()),
+                               kDirectionUsage));
 }
 
 
-GTEST_TEST(SimpleRulebookTest, FindRules) {
+TEST_F(SimpleRulebookTest, FindRules) {
   SimpleRulebook dut;
   dut.AddRule(kSpeedLimit);
   dut.AddRule(kRightOfWay);
+  dut.AddRule(kDirectionUsage);
 
   const double kZeroTolerance = 0.;
 
@@ -100,6 +132,7 @@ GTEST_TEST(SimpleRulebookTest, FindRules) {
                                                             kZeroTolerance);
   EXPECT_EQ(nonempty.right_of_way.size(), 1);
   EXPECT_EQ(nonempty.speed_limit.size(), 1);
+  EXPECT_EQ(nonempty.direction_usage.size(), 1);
 
   const LaneSRange kReversedZone(kZone.lane_id(),
                                  {kZone.s_range().s1(), kZone.s_range().s0()});
@@ -107,6 +140,7 @@ GTEST_TEST(SimpleRulebookTest, FindRules) {
                                                             kZeroTolerance);
   EXPECT_EQ(reversed.right_of_way.size(), 1);
   EXPECT_EQ(reversed.speed_limit.size(), 1);
+  EXPECT_EQ(reversed.direction_usage.size(), 1);
 
   const double kNonzeroTolerance = 0.1;
 
@@ -121,6 +155,7 @@ GTEST_TEST(SimpleRulebookTest, FindRules) {
                                                           kNonzeroTolerance);
   EXPECT_EQ(nearby.right_of_way.size(), 1);
   EXPECT_EQ(nearby.speed_limit.size(), 1);
+  EXPECT_EQ(nearby.direction_usage.size(), 1);
 
   // Construct a range that sits just outside of the kNonzeroTolerance band
   // of kZone.s1.
@@ -132,6 +167,7 @@ GTEST_TEST(SimpleRulebookTest, FindRules) {
                                                           kNonzeroTolerance);
   EXPECT_EQ(toofar.right_of_way.size(), 0);
   EXPECT_EQ(toofar.speed_limit.size(), 0);
+  EXPECT_EQ(toofar.direction_usage.size(), 0);
 }
 
 


### PR DESCRIPTION
Towards #10917.

Adds the new DirectionUsageRule class to the RoadNetwork and RoadRulebook.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10951)
<!-- Reviewable:end -->
