### PR TITLE
Convert some context.FixInputPort() calls to port.FixValue() calls

### DIFF
--- a/examples/acrobot/acrobot_plant.cc
+++ b/examples/acrobot/acrobot_plant.cc
@@ -183,7 +183,7 @@ std::unique_ptr<systems::AffineSystem<double>> BalancingLQRController(
   auto context = acrobot.CreateDefaultContext();
 
   // Set nominal torque to zero.
-  context->FixInputPort(0, Vector1d::Constant(0.0));
+  acrobot.GetInputPort("elbow_torque").FixValue(context.get(), 0.0);
 
   // Set nominal state to the upright fixed point.
   AcrobotState<double>* x = dynamic_cast<AcrobotState<double>*>(

--- a/examples/acrobot/run_lqr_w_estimator.cc
+++ b/examples/acrobot/run_lqr_w_estimator.cc
@@ -66,7 +66,8 @@ int do_main() {
     x0.set_theta2(0.0);
     x0.set_theta1dot(0.0);
     x0.set_theta2dot(0.0);
-    observer_context->FixInputPort(0, Vector1d::Constant(0.0));
+    observer_acrobot->GetInputPort("elbow_torque")
+        .FixValue(observer_context.get(), 0.0);
   }
   // Make a linearization here for the exercise below.  Need to do it before I
   // std::move the pointers.

--- a/examples/acrobot/run_passive.cc
+++ b/examples/acrobot/run_passive.cc
@@ -47,8 +47,8 @@ int do_main() {
       diagram->GetMutableSubsystemContext(*acrobot,
                                           &simulator.get_mutable_context());
 
-  double tau = 0;
-  acrobot_context.FixInputPort(0, Eigen::Matrix<double, 1, 1>::Constant(tau));
+  const double tau = 0;
+  acrobot->GetInputPort("elbow_torque").FixValue(&acrobot_context, tau);
 
   // Set an initial condition that is sufficiently far from the downright fixed
   // point.

--- a/examples/acrobot/spong_controller.h
+++ b/examples/acrobot/spong_controller.h
@@ -39,7 +39,7 @@ class AcrobotSpongController : public systems::LeafSystem<T> {
                                   &AcrobotSpongController::CalcControlTorque);
 
     // Setup context for linearization.
-    acrobot_context_->FixInputPort(0, Vector1d(0));
+    acrobot_.GetInputPort("elbow_torque").FixValue(acrobot_context_.get(), 0.0);
 
     // Set nominal state to the upright fixed point.
     AcrobotState<T>& state =

--- a/examples/acrobot/test/urdf_dynamics_test.cc
+++ b/examples/acrobot/test/urdf_dynamics_test.cc
@@ -28,8 +28,8 @@ GTEST_TEST(UrdfDynamicsTest, AllTests) {
   auto context_rbp = rbp.CreateDefaultContext();
   auto context_p = p.CreateDefaultContext();
 
-  auto& u_rbp = context_rbp->FixInputPort(0, Vector1d::Zero());
-  auto& u_p = context_p->FixInputPort(0, Vector1d::Zero());
+  auto& u_rbp = rbp.get_input_port(0).FixValue(context_rbp.get(), 0.0);
+  auto& u_p = p.get_input_port(0).FixValue(context_p.get(), 0.0);
 
   Eigen::Vector4d x;
   Vector1d u;

--- a/examples/kinova_jaco_arm/test/jaco_lcm_test.cc
+++ b/examples/kinova_jaco_arm/test/jaco_lcm_test.cc
@@ -39,8 +39,7 @@ GTEST_TEST(JacoLcmTest, JacoCommandPassthroughTest) {
   command.finger_velocity = std::vector<double>{
     -10, -20, -30, -40, -50, -60, -70};
 
-  context->FixInputPort(
-      0, std::make_unique<Value<lcmt_jaco_command>>(command));
+  diagram->get_input_port(0).FixValue(context.get(), command);
 
   std::unique_ptr<systems::DiscreteValues<double>> update =
       diagram->AllocateDiscreteVariables();
@@ -109,8 +108,7 @@ GTEST_TEST(JacoLcmTest, JacoStatusPassthroughTest) {
     status.finger_current[i] = -i * 1000;
   }
 
-  context->FixInputPort(
-      0, std::make_unique<Value<lcmt_jaco_status>>(status));
+  diagram->get_input_port(0).FixValue(context.get(), status);
 
   std::unique_ptr<systems::DiscreteValues<double>> update =
       diagram->AllocateDiscreteVariables();

--- a/systems/estimators/luenberger_observer.cc
+++ b/systems/estimators/luenberger_observer.cc
@@ -82,8 +82,8 @@ void LuenbergerObserver<T>::DoCalcTimeDerivatives(
   if (observed_system_->get_num_input_ports() > 0) {
     // TODO(russt): Avoid this dynamic allocation by fixing the input port once
     // and updating it here.
-    observed_system_context_->FixInputPort(
-        0, this->get_input_port(1).Eval(context));
+    observed_system_->get_input_port(0).FixValue(
+        observed_system_context_.get(), this->get_input_port(1).Eval(context));
   }
   // Set observed system state.
   observed_system_context_->get_mutable_continuous_state_vector().SetFrom(

--- a/systems/framework/input_port.h
+++ b/systems/framework/input_port.h
@@ -115,9 +115,9 @@ class InputPort final : public InputPortBase {
   type has a copy constructor it will be copied into a `Value<ValueType>`
   object for storage. Otherwise it must have an accessible `Clone()` method and
   it is stored using the type returned by that method, which must be ValueType
-  or a base class of ValueType. Eigen expressions are simplified using `.eval()`
-  before being stored as `Value<E>` where E is the type resulting
-  from `.eval()`.
+  or a base class of ValueType. Eigen objects and expressions are not
+  accepted directly, but you can store then in abstract ports by providing
+  an already-abstract object like `Value<MatrixXd>(your_matrix)`.
 
   The returned FixedInputPortValue reference may be used to modify the input
   port's value subsequently using the appropriate FixedInputPortValue method,

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -223,7 +223,7 @@ class TestSystem : public System<double> {
  private:
   std::unique_ptr<ContextBase> DoAllocateContext() const final {
     auto context = std::make_unique<LeafContext<double>>();
-    InitializeContextBase(&*context);
+    InitializeContextBase(context.get());
     return context;
   }
 
@@ -532,7 +532,7 @@ class ValueIOTestSystem : public System<T> {
 
   std::unique_ptr<ContextBase> DoAllocateContext() const final {
     auto context = std::make_unique<LeafContext<T>>();
-    this->InitializeContextBase(&*context);
+    this->InitializeContextBase(context.get());
     return context;
   }
 
@@ -734,10 +734,10 @@ class SystemIOTest : public ::testing::Test {
     output_ = test_sys_.AllocateOutput();
 
     // make string input
-    context_->FixInputPort(0, Value<std::string>("input"));
+    test_sys_.get_input_port(0).FixValue(context_.get(), "input");
 
     // make vector input
-    context_->FixInputPort(1, {2.0});
+    test_sys_.get_input_port(1).FixValue(context_.get(), 2.0);
   }
 
   ValueIOTestSystem<double> test_sys_;
@@ -858,7 +858,7 @@ class ComputationTestSystem final : public System<double> {
 
   std::unique_ptr<ContextBase> DoAllocateContext() const final {
     auto context = std::make_unique<LeafContext<double>>();
-    InitializeContextBase(&*context);
+    InitializeContextBase(context.get());
     return context;
   }
 
@@ -994,7 +994,7 @@ TEST_F(ComputationTest, Eval) {
 
   // Each of the Calc methods should cause computation.
   auto derivatives = test_sys_.AllocateTimeDerivatives();
-  test_sys_.CalcTimeDerivatives(*context_, &*derivatives);
+  test_sys_.CalcTimeDerivatives(*context_, derivatives.get());
   test_sys_.ExpectCount(2, 1, 1, 1, 1);
   EXPECT_EQ((*derivatives)[1], -2.);
   EXPECT_EQ(test_sys_.CalcPotentialEnergy(*context_), 1.);

--- a/systems/primitives/test/integrator_test.cc
+++ b/systems/primitives/test/integrator_test.cc
@@ -56,7 +56,8 @@ TEST_F(IntegratorTest, Topology) {
 // Tests that the output of an integrator is its state.
 TEST_F(IntegratorTest, Output) {
   ASSERT_EQ(1, context_->get_num_input_ports());
-  context_->FixInputPort(0, BasicVector<double>::Make({1.0, 2.0, 3.0}));
+  integrator_->get_input_port(0).FixValue(context_.get(),
+      Eigen::Vector3d{1.0, 2.0, 3.0});
 
   Eigen::Vector3d expected = Eigen::Vector3d::Zero();
   EXPECT_EQ(expected, integrator_->get_output_port(0).Eval(*context_));
@@ -69,7 +70,8 @@ TEST_F(IntegratorTest, Output) {
 // Tests that the derivatives of an integrator's state are its input.
 TEST_F(IntegratorTest, Derivatives) {
   ASSERT_EQ(1, context_->get_num_input_ports());
-  context_->FixInputPort(0, BasicVector<double>::Make({1.0, 2.0, 3.0}));
+  integrator_->get_input_port(0).FixValue(context_.get(),
+                                          Eigen::Vector3d{1.0, 2.0, 3.0});
 
   integrator_->CalcTimeDerivatives(*context_, derivatives_.get());
   Eigen::Vector3d expected(1.0, 2.0, 3.0);
@@ -90,11 +92,10 @@ class SymbolicIntegratorTest : public IntegratorTest {
     symbolic_derivatives_ = symbolic_integrator_->AllocateTimeDerivatives();
 
     ASSERT_EQ(1, symbolic_context_->get_num_input_ports());
-    symbolic_context_->FixInputPort(
-        0, BasicVector<symbolic::Expression>::Make(
-            symbolic::Variable("u0"),
-            symbolic::Variable("u1"),
-            symbolic::Variable("u2")));
+    symbolic_integrator_->get_input_port(0).FixValue(symbolic_context_.get(),
+        Vector3<symbolic::Expression>{symbolic::Variable("u0"),
+                                      symbolic::Variable("u1"),
+                                      symbolic::Variable("u2")});
 
     auto& xc = symbolic_context_->get_mutable_continuous_state_vector();
     xc[0] = symbolic::Variable("x0");

--- a/systems/primitives/test/saturation_test.cc
+++ b/systems/primitives/test/saturation_test.cc
@@ -17,17 +17,11 @@ void TestInputAndOutput(const Saturation<T>& saturation_system,
                         std::unique_ptr<Context<T>> context,
                         const VectorX<T>& input_vector,
                         const VectorX<T>& expected_output) {
-  const int port_size = saturation_system.get_size();
-
   // Verifies that Saturation allocates no state variables in the context.
   EXPECT_EQ(context->get_continuous_state().size(), 0);
-  auto input = std::make_unique<BasicVector<T>>(port_size);
-
-  input->get_mutable_value() << input_vector;
 
   // Hook input of the expected size.
-  context->FixInputPort(saturation_system.get_input_port().get_index(),
-                        std::move(input));
+  saturation_system.get_input_port().FixValue(context.get(), input_vector);
 
   // Checks that the number of output ports in the Saturation system and the
   // SystemOutput are consistent.
@@ -59,8 +53,6 @@ void TestVariableSaturation(const Saturation<T>& saturation_system,
                             const VectorX<T>& expected_output) {
   auto context = saturation_system.CreateDefaultContext();
 
-  const int port_size = saturation_system.get_size();
-
   // Checks that the number of input ports in the Saturation system and the
   // Context are consistent.
   ASSERT_EQ(saturation_system.get_num_input_ports(), 3);
@@ -68,19 +60,15 @@ void TestVariableSaturation(const Saturation<T>& saturation_system,
 
   // Applies the min and max values as inputs to the context.
   if (min_value_vector.size() > 0) {
-    auto min_value = std::make_unique<BasicVector<T>>(port_size);
-    min_value->get_mutable_value() << min_value_vector;
     // Hook min value of the expected size.
-    context->FixInputPort(saturation_system.get_min_value_port().get_index(),
-                          std::move(min_value));
+    saturation_system.get_min_value_port().FixValue(context.get(),
+                                                    min_value_vector);
   }
 
   if (max_value_vector.size()) {
-    auto max_value = std::make_unique<BasicVector<T>>(port_size);
-    max_value->get_mutable_value() << max_value_vector;
     // Hook max value of the expected size.
-    context->FixInputPort(saturation_system.get_max_value_port().get_index(),
-                          std::move(max_value));
+    saturation_system.get_max_value_port().FixValue(context.get(),
+                                                    max_value_vector);
   }
 
   TestInputAndOutput<T>(saturation_system, std::move(context), input_vector,

--- a/systems/primitives/test/zero_order_hold_test.cc
+++ b/systems/primitives/test/zero_order_hold_test.cc
@@ -69,11 +69,10 @@ class ZeroOrderHoldTest : public ::testing::TestWithParam<bool> {
     }
     context_ = hold_->CreateDefaultContext();
     if (!is_abstract_) {
-      context_->FixInputPort(
-          0, std::make_unique<BasicVector<double>>(input_value_));
+      hold_->get_input_port().FixValue(&*context_, input_value_);
     } else {
-      context_->FixInputPort(
-          0, AbstractValue::Make(SimpleAbstractType(input_value_)));
+      hold_->get_input_port().FixValue(&*context_,
+                                       SimpleAbstractType(input_value_));
     }
 
     event_info_ = hold_->AllocateCompositeEventCollection();
@@ -281,8 +280,8 @@ class SymbolicZeroOrderHoldTest : public ::testing::Test {
 
     // Initialize the context with symbolic variables.
     context_ = hold_->CreateDefaultContext();
-    context_->FixInputPort(0, BasicVector<symbolic::Expression>::Make(
-        symbolic::Variable("u0")));
+    hold_->get_input_port().FixValue(context_.get(),
+        symbolic::Expression(symbolic::Variable("u0")));
     auto& xd = context_->get_mutable_discrete_state(0);
     xd[0] = symbolic::Variable("x0");
 
@@ -303,7 +302,7 @@ TEST_F(SymbolicZeroOrderHoldTest, Update) {
   // Before latching the input, the output should just show the initial
   // state value "x0".
   EXPECT_EQ("x0", hold_->get_output_port().Eval(*context_)[0].to_string());
-  hold_->LatchInputPortToState(&*context_);
+  hold_->LatchInputPortToState(context_.get());
   EXPECT_EQ("u0", hold_->get_output_port().Eval(*context_)[0].to_string());
 }
 


### PR DESCRIPTION
This PR modernizes a small, random assortment of context.FixInputPort() calls to use the new port.FixValue() sugar to show what it looks like in practice. This is by no means exhaustive but it's a start.

I also repaired an out-of-date comment regarding FixValue().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10964)
<!-- Reviewable:end -->
