### PR TITLE
framework: Advocate for operator[] over GetAtIndex/SetAtIndex

### DIFF
--- a/bindings/pydrake/systems/framework_py_values.cc
+++ b/bindings/pydrake/systems/framework_py_values.cc
@@ -82,7 +82,7 @@ void DefineFrameworkPyValues(py::module m) {
             [](BasicVector<T>* self, int index) -> T& {
               return self->GetAtIndex(index);
             },
-            py_reference_internal, doc.BasicVector.GetAtIndex.doc)
+            py_reference_internal, doc.VectorBase.GetAtIndex.doc)
         .def("SetZero", &BasicVector<T>::SetZero, doc.BasicVector.SetZero.doc);
 
     DefineTemplateClassWithDefault<Supervector<T>, VectorBase<T>>(

--- a/systems/framework/basic_vector.h
+++ b/systems/framework/basic_vector.h
@@ -47,7 +47,7 @@ class BasicVector : public VectorBase<T> {
       : BasicVector<T>(init.size()) {
     int i = 0;
     for (const T& datum : init) {
-      this->SetAtIndex(i++, datum);
+      (*this)[i++] = datum;
     }
   }
 
@@ -68,7 +68,7 @@ class BasicVector : public VectorBase<T> {
     return data;
   }
 
-  int size() const override { return static_cast<int>(values_.rows()); }
+  int size() const final { return static_cast<int>(values_.rows()); }
 
   /// Sets the vector to the given value. After a.set_value(b.get_value()), a
   /// must be identical to b.
@@ -93,24 +93,14 @@ class BasicVector : public VectorBase<T> {
     return values_.head(values_.rows());
   }
 
-  const T& GetAtIndex(int index) const override {
-    DRAKE_THROW_UNLESS(index < size());
-    return values_[index];
-  }
-
-  T& GetAtIndex(int index) override {
-    DRAKE_THROW_UNLESS(index < size());
-    return values_[index];
-  }
-
-  void SetFromVector(const Eigen::Ref<const VectorX<T>>& value) override {
+  void SetFromVector(const Eigen::Ref<const VectorX<T>>& value) final {
     set_value(value);
   }
 
-  VectorX<T> CopyToVector() const override { return values_; }
+  VectorX<T> CopyToVector() const final { return values_; }
 
   void ScaleAndAddToVector(const T& scale,
-                           EigenPtr<VectorX<T>> vec) const override {
+                           EigenPtr<VectorX<T>> vec) const final {
     DRAKE_THROW_UNLESS(vec != nullptr);
     if (vec->rows() != size()) {
       throw std::out_of_range("Addends must be the same size.");
@@ -118,10 +108,10 @@ class BasicVector : public VectorBase<T> {
     *vec += scale * values_;
   }
 
-  void SetZero() override { values_.setZero(); }
+  void SetZero() final { values_.setZero(); }
 
   DRAKE_DEPRECATED("2019-06-01", "Use get_value() + Eigen lpNorm.")
-  T NormInf() const override {
+  T NormInf() const final {
     return values_.template lpNorm<Eigen::Infinity>();
   }
 
@@ -137,6 +127,16 @@ class BasicVector : public VectorBase<T> {
   }
 
  protected:
+  const T& DoGetAtIndex(int index) const final {
+    DRAKE_THROW_UNLESS(index < size());
+    return values_[index];
+  }
+
+  T& DoGetAtIndex(int index) final {
+    DRAKE_THROW_UNLESS(index < size());
+    return values_[index];
+  }
+
   /// Returns a new BasicVector containing a copy of the entire vector.
   /// Caller must take ownership, and may rely on the NVI wrapper to initialize
   /// the clone elementwise.
@@ -154,7 +154,7 @@ class BasicVector : public VectorBase<T> {
   template<typename F, typename... Fargs>
   static void MakeRecursive(BasicVector<T>* data, int index,
                             F constructor_arg, Fargs&&... recursive_args) {
-    data->SetAtIndex(index++, T(constructor_arg));
+    (*data)[index++] = T(constructor_arg);
     BasicVector<T>::MakeRecursive(data, index, recursive_args...);
   }
 
@@ -162,7 +162,7 @@ class BasicVector : public VectorBase<T> {
   template<typename F, typename... Fargs>
   static void MakeRecursive(BasicVector<T>* data, int index,
                             F constructor_arg) {
-    data->SetAtIndex(index++, T(constructor_arg));
+    (*data)[index++] = T(constructor_arg);
   }
 
   /// Provides const access to the element storage.
@@ -179,7 +179,7 @@ class BasicVector : public VectorBase<T> {
   // is also (i.e., in addition to 'this') a contiguous vector.
   void DoPlusEqScaled(
       const std::initializer_list<std::pair<T, const VectorBase<T>&>>& rhs_scal)
-      override {
+      final {
     for (const auto& operand : rhs_scal)
       operand.second.ScaleAndAddToVector(operand.first, &values_);
   }

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -2563,7 +2563,7 @@ class LeafSystem : public System<T> {
           const VectorBase<T>& model_vec = get_vector_from_context(context);
           value->resize(indices.size());
           for (int i = 0; i < static_cast<int>(indices.size()); ++i) {
-            (*value)(i) = model_vec.GetAtIndex(indices[i]);
+            (*value)[i] = model_vec[indices[i]];
           }
         },
         {constraint_lower_bound, constraint_upper_bound},

--- a/systems/framework/subvector.h
+++ b/systems/framework/subvector.h
@@ -46,14 +46,15 @@ class Subvector : public VectorBase<T> {
 
   int size() const override { return num_elements_; }
 
-  const T& GetAtIndex(int index) const override {
+ protected:
+  const T& DoGetAtIndex(int index) const override {
     DRAKE_THROW_UNLESS(index < size());
-    return vector_->GetAtIndex(first_element_ + index);
+    return (*vector_)[first_element_ + index];
   }
 
-  T& GetAtIndex(int index) override {
+  T& DoGetAtIndex(int index) override {
     DRAKE_THROW_UNLESS(index < size());
-    return vector_->GetAtIndex(first_element_ + index);
+    return (*vector_)[first_element_ + index];
   }
 
  private:

--- a/systems/framework/supervector.h
+++ b/systems/framework/supervector.h
@@ -41,14 +41,15 @@ class Supervector : public VectorBase<T> {
     return lookup_table_.empty() ? 0 : lookup_table_.back();
   }
 
-  const T& GetAtIndex(int index) const override {
+ protected:
+  const T& DoGetAtIndex(int index) const override {
     const auto target = GetSubvectorAndOffset(index);
-    return target.first->GetAtIndex(target.second);
+    return (*target.first)[target.second];
   }
 
-  T& GetAtIndex(int index) override {
+  T& DoGetAtIndex(int index) override {
     const auto target = GetSubvectorAndOffset(index);
-    return target.first->GetAtIndex(target.second);
+    return (*target.first)[target.second];
   }
 
  private:

--- a/systems/framework/test/basic_vector_test.cc
+++ b/systems/framework/test/basic_vector_test.cc
@@ -59,9 +59,9 @@ GTEST_TEST(BasicVectorTest, DoubleInitiallyNaN) {
 // Tests that the BasicVector<AutoDiffXd> is initialized to NaN.
 GTEST_TEST(BasicVectorTest, AutodiffInitiallyNaN) {
   BasicVector<AutoDiffXd> vec(3);
-  EXPECT_TRUE(std::isnan(vec.GetAtIndex(0).value()));
-  EXPECT_TRUE(std::isnan(vec.GetAtIndex(1).value()));
-  EXPECT_TRUE(std::isnan(vec.GetAtIndex(2).value()));
+  EXPECT_TRUE(std::isnan(vec[0].value()));
+  EXPECT_TRUE(std::isnan(vec[1].value()));
+  EXPECT_TRUE(std::isnan(vec[2].value()));
 }
 
 // Tests that the BasicVector<symbolic::Expression> is initialized to NaN.
@@ -187,7 +187,7 @@ GTEST_TEST(BasicVectorTest, NormInfAutodiff) {
   // The norminf(DUT) is now 33.5 and the ∂/∂t of norminf(DUT) is -3.5.
   // The element0 has the max absolute value of the AutoDiffScalar's scalar.
   // It is negative, so the sign of its derivatives gets flipped.
-  dut.GetAtIndex(0).value() = -33.5;
+  dut[0].value() = -33.5;
   expected_norminf.value() = 33.5;
   expected_norminf.derivatives() = Vector1d(-1.5);
   EXPECT_EQ(dut.NormInf().value(), expected_norminf.value());

--- a/systems/framework/test/continuous_state_test.cc
+++ b/systems/framework/test/continuous_state_test.cc
@@ -64,22 +64,22 @@ TEST_F(ContinuousStateTest, Access) {
   EXPECT_EQ(kLength, continuous_state_->size());
   EXPECT_EQ(kPositionLength,
             continuous_state_->get_generalized_position().size());
-  EXPECT_EQ(1, continuous_state_->get_generalized_position().GetAtIndex(0));
-  EXPECT_EQ(2, continuous_state_->get_generalized_position().GetAtIndex(1));
+  EXPECT_EQ(1, continuous_state_->get_generalized_position()[0]);
+  EXPECT_EQ(2, continuous_state_->get_generalized_position()[1]);
 
   EXPECT_EQ(kVelocityLength,
             continuous_state_->get_generalized_velocity().size());
-  EXPECT_EQ(3, continuous_state_->get_generalized_velocity().GetAtIndex(0));
+  EXPECT_EQ(3, continuous_state_->get_generalized_velocity()[0]);
 
   EXPECT_EQ(kMiscLength, continuous_state_->get_misc_continuous_state().size());
-  EXPECT_EQ(4, continuous_state_->get_misc_continuous_state().GetAtIndex(0));
+  EXPECT_EQ(4, continuous_state_->get_misc_continuous_state()[0]);
 }
 
 TEST_F(ContinuousStateTest, Mutation) {
-  continuous_state_->get_mutable_generalized_position().SetAtIndex(0, 5);
-  continuous_state_->get_mutable_generalized_position().SetAtIndex(1, 6);
-  continuous_state_->get_mutable_generalized_velocity().SetAtIndex(0, 7);
-  continuous_state_->get_mutable_misc_continuous_state().SetAtIndex(0, 8);
+  continuous_state_->get_mutable_generalized_position()[0] = 5;
+  continuous_state_->get_mutable_generalized_position()[1] = 6;
+  continuous_state_->get_mutable_generalized_velocity()[0] = 7;
+  continuous_state_->get_mutable_misc_continuous_state()[0] = 8;
 
   EXPECT_EQ(5, continuous_state_->get_vector()[0]);
   EXPECT_EQ(6, continuous_state_->get_vector()[1]);

--- a/systems/framework/test/diagram_context_test.cc
+++ b/systems/framework/test/diagram_context_test.cc
@@ -113,14 +113,14 @@ class DiagramContextTest : public ::testing::Test {
 
     context_->set_time(kTime);
     ContinuousState<double>& xc = context_->get_mutable_continuous_state();
-    xc.get_mutable_vector().SetAtIndex(0, 42.0);
-    xc.get_mutable_vector().SetAtIndex(1, 43.0);
+    xc.get_mutable_vector()[0] = 42.0;
+    xc.get_mutable_vector()[1] = 43.0;
 
     DiscreteValues<double>& xd = context_->get_mutable_discrete_state();
-    xd.get_mutable_vector(0).SetAtIndex(0, 44.0);
+    xd.get_mutable_vector(0)[0] = 44.0;
 
-    context_->get_mutable_numeric_parameter(0).SetAtIndex(0, 76.0);
-    context_->get_mutable_numeric_parameter(0).SetAtIndex(1, 77.0);
+    context_->get_mutable_numeric_parameter(0)[0] = 76.0;
+    context_->get_mutable_numeric_parameter(0)[1] = 77.0;
 
     // Sanity checks: tests below count on these dimensions.
     EXPECT_EQ(context_->get_continuous_state().size(), 2);
@@ -274,11 +274,11 @@ namespace {
 void VerifyClonedState(const State<double>& clone) {
   // - Continuous
   const ContinuousState<double>& xc = clone.get_continuous_state();
-  EXPECT_EQ(42.0, xc.get_vector().GetAtIndex(0));
-  EXPECT_EQ(43.0, xc.get_vector().GetAtIndex(1));
+  EXPECT_EQ(42.0, xc.get_vector()[0]);
+  EXPECT_EQ(43.0, xc.get_vector()[1]);
   // - Discrete
   const DiscreteValues<double>& xd = clone.get_discrete_state();
-  EXPECT_EQ(44.0, xd.get_vector(0).GetAtIndex(0));
+  EXPECT_EQ(44.0, xd.get_vector(0)[0]);
   // - Abstract
   const AbstractValues& xa = clone.get_abstract_state();
   EXPECT_EQ(42, xa.get_value(0).get_value<int>());
@@ -288,8 +288,8 @@ void VerifyClonedState(const State<double>& clone) {
 // DiagramContextTest::SetUp.
 void VerifyClonedParameters(const Parameters<double>& params) {
   ASSERT_EQ(1, params.num_numeric_parameter_groups());
-  EXPECT_EQ(76.0, params.get_numeric_parameter(0).GetAtIndex(0));
-  EXPECT_EQ(77.0, params.get_numeric_parameter(0).GetAtIndex(1));
+  EXPECT_EQ(76.0, params.get_numeric_parameter(0)[0]);
+  EXPECT_EQ(77.0, params.get_numeric_parameter(0)[1]);
   ASSERT_EQ(1, params.num_abstract_parameters());
   EXPECT_EQ(2048, UnpackIntValue(params.get_abstract_parameter(0)));
 }
@@ -519,7 +519,7 @@ TEST_F(DiagramContextTest, MutableEverythingNotifications) {
   clone->set_time(new_time);
   clone->set_accuracy(new_accuracy);
   clone->SetContinuousState(new_xc);
-  clone->get_mutable_discrete_state(0).SetAtIndex(0, new_xd);
+  clone->get_mutable_discrete_state(0)[0] = new_xd;
   clone->get_mutable_abstract_state<int>(0) = new_xa;
   clone->get_mutable_numeric_parameter(0).SetAtIndex(0, new_pn);
   clone->get_mutable_abstract_parameter(0).set_value<int>(new_pa);
@@ -607,21 +607,21 @@ TEST_F(DiagramContextTest, State) {
   ContinuousState<double>& integrator1_xc =
       context_->GetMutableSubsystemContext(SubsystemIndex(3))
           .get_mutable_continuous_state();
-  EXPECT_EQ(42.0, integrator0_xc.get_vector().GetAtIndex(0));
-  EXPECT_EQ(43.0, integrator1_xc.get_vector().GetAtIndex(0));
+  EXPECT_EQ(42.0, integrator0_xc.get_vector()[0]);
+  EXPECT_EQ(43.0, integrator1_xc.get_vector()[0]);
   // - Discrete
   DiscreteValues<double>& discrete_xd =
       context_->GetMutableSubsystemContext(SubsystemIndex(4))
           .get_mutable_discrete_state();
-  EXPECT_EQ(44.0, discrete_xd.get_vector(0).GetAtIndex(0));
+  EXPECT_EQ(44.0, discrete_xd.get_vector(0)[0]);
 
   // Changes to constituent system states appear in the diagram state.
   // - Continuous
-  integrator1_xc.get_mutable_vector().SetAtIndex(0, 1000.0);
-  EXPECT_EQ(1000.0, xc.get_vector().GetAtIndex(1));
+  integrator1_xc.get_mutable_vector()[0] = 1000.0;
+  EXPECT_EQ(1000.0, xc.get_vector()[1]);
   // - Discrete
-  discrete_xd.get_mutable_vector(0).SetAtIndex(0, 1001.0);
-  EXPECT_EQ(1001.0, xd.get_vector(0).GetAtIndex(0));
+  discrete_xd.get_mutable_vector(0)[0] = 1001.0;
+  EXPECT_EQ(1001.0, xd.get_vector(0)[0]);
 }
 
 // Tests that the pointers to substates in the DiagramState are equal to the
@@ -711,7 +711,7 @@ TEST_F(DiagramContextTest, Clone) {
 
   // Verify that changes to the state do not write through to the original
   // context.
-  clone->get_mutable_continuous_state_vector().SetAtIndex(0, 1024.0);
+  clone->get_mutable_continuous_state_vector()[0] = 1024.0;
   EXPECT_EQ(1024.0, clone->get_continuous_state()[0]);
   EXPECT_EQ(42.0, context_->get_continuous_state()[0]);
 

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -473,14 +473,14 @@ class DiagramTest : public ::testing::Test {
 
     // Initialize the integrator states.
     auto& integrator0_xc = GetMutableContinuousState(integrator0());
-    integrator0_xc.get_mutable_vector().SetAtIndex(0, 3);
-    integrator0_xc.get_mutable_vector().SetAtIndex(1, 9);
-    integrator0_xc.get_mutable_vector().SetAtIndex(2, 27);
+    integrator0_xc.get_mutable_vector()[0] = 3;
+    integrator0_xc.get_mutable_vector()[1] = 9;
+    integrator0_xc.get_mutable_vector()[2] = 27;
 
     auto& integrator1_xc = GetMutableContinuousState(integrator1());
-    integrator1_xc.get_mutable_vector().SetAtIndex(0, 81);
-    integrator1_xc.get_mutable_vector().SetAtIndex(1, 243);
-    integrator1_xc.get_mutable_vector().SetAtIndex(2, 729);
+    integrator1_xc.get_mutable_vector()[0] = 81;
+    integrator1_xc.get_mutable_vector()[1] = 243;
+    integrator1_xc.get_mutable_vector()[2] = 729;
   }
 
   // Returns the continuous state of the given @p system.
@@ -773,16 +773,16 @@ TEST_F(DiagramTest, CalcTimeDerivatives) {
   // The derivative of the first integrator is A.
   const ContinuousState<double>& integrator0_xcdot =
       diagram_->GetSubsystemDerivatives(*integrator0(), *derivatives);
-  EXPECT_EQ(1 + 8, integrator0_xcdot.get_vector().GetAtIndex(0));
-  EXPECT_EQ(2 + 16, integrator0_xcdot.get_vector().GetAtIndex(1));
-  EXPECT_EQ(4 + 32, integrator0_xcdot.get_vector().GetAtIndex(2));
+  EXPECT_EQ(1 + 8, integrator0_xcdot.get_vector()[0]);
+  EXPECT_EQ(2 + 16, integrator0_xcdot.get_vector()[1]);
+  EXPECT_EQ(4 + 32, integrator0_xcdot.get_vector()[2]);
 
   // The derivative of the second integrator is the state of the first.
   const ContinuousState<double>& integrator1_xcdot =
       diagram_->GetSubsystemDerivatives(*integrator1(), *derivatives);
-  EXPECT_EQ(3, integrator1_xcdot.get_vector().GetAtIndex(0));
-  EXPECT_EQ(9, integrator1_xcdot.get_vector().GetAtIndex(1));
-  EXPECT_EQ(27, integrator1_xcdot.get_vector().GetAtIndex(2));
+  EXPECT_EQ(3, integrator1_xcdot.get_vector()[0]);
+  EXPECT_EQ(9, integrator1_xcdot.get_vector()[1]);
+  EXPECT_EQ(27, integrator1_xcdot.get_vector()[2]);
 }
 
 // Tests the AllocateInput logic.
@@ -1048,22 +1048,22 @@ class DiagramOfDiagramsTest : public ::testing::Test {
     State<double>& integrator0_x = subdiagram0_->GetMutableSubsystemState(
         *subdiagram0_->integrator0(), &d0_context);
     integrator0_x.get_mutable_continuous_state()
-        .get_mutable_vector().SetAtIndex(0, 3);
+        .get_mutable_vector()[0] = 3;
 
     State<double>& integrator1_x = subdiagram0_->GetMutableSubsystemState(
         *subdiagram0_->integrator1(), &d0_context);
     integrator1_x.get_mutable_continuous_state()
-        .get_mutable_vector().SetAtIndex(0, 9);
+        .get_mutable_vector()[0] = 9;
 
     State<double>& integrator2_x = subdiagram1_->GetMutableSubsystemState(
         *subdiagram1_->integrator0(), &d1_context);
     integrator2_x.get_mutable_continuous_state()
-        .get_mutable_vector().SetAtIndex(0, 27);
+        .get_mutable_vector()[0] = 27;
 
     State<double>& integrator3_x = subdiagram1_->GetMutableSubsystemState(
         *subdiagram1_->integrator1(), &d1_context);
     integrator3_x.get_mutable_continuous_state()
-        .get_mutable_vector().SetAtIndex(0, 81);
+        .get_mutable_vector()[0] = 81;
   }
 
   const int kSize = 1;
@@ -1136,21 +1136,21 @@ TEST_F(DiagramOfDiagramsTest, EvalOutput) {
   FixedInputPortValue& port_value =
       context_->FixInputPort(0, std::move(value10));
   EXPECT_EQ(1255, diagram_->get_output_port(0).
-      Eval<BasicVector<double>>(*context_).GetAtIndex(0));
+      Eval<BasicVector<double>>(*context_)[0]);
   EXPECT_EQ(2501, diagram_->get_output_port(1).
-      Eval<BasicVector<double>>(*context_).GetAtIndex(0));
+      Eval<BasicVector<double>>(*context_)[0]);
   EXPECT_EQ(81, diagram_->get_output_port(2).
-      Eval<BasicVector<double>>(*context_).GetAtIndex(0));
+      Eval<BasicVector<double>>(*context_)[0]);
 
   // Now change the value back to 8 using mutable access to the port_value
   // object. Should also cause re-evaluation.
   port_value.GetMutableVectorData<double>()->SetAtIndex(0, 8.0);
   EXPECT_EQ(1249, diagram_->get_output_port(0).
-      Eval<BasicVector<double>>(*context_).GetAtIndex(0));
+      Eval<BasicVector<double>>(*context_)[0]);
   EXPECT_EQ(2489, diagram_->get_output_port(1).
-      Eval<BasicVector<double>>(*context_).GetAtIndex(0));
+      Eval<BasicVector<double>>(*context_)[0]);
   EXPECT_EQ(81, diagram_->get_output_port(2).
-      Eval<BasicVector<double>>(*context_).GetAtIndex(0));
+      Eval<BasicVector<double>>(*context_)[0]);
 }
 
 TEST_F(DiagramOfDiagramsTest, DirectFeedthrough) {
@@ -1581,14 +1581,14 @@ GTEST_TEST(SecondOrderStateTest, MapVelocityToQDot) {
 
   // The order of these derivatives is defined to be the same as the order
   // subsystems are added.
-  EXPECT_EQ(qdot.GetAtIndex(0), 26);
-  EXPECT_EQ(qdot.GetAtIndex(1), 34);
+  EXPECT_EQ(qdot[0], 26);
+  EXPECT_EQ(qdot[1], 34);
 
   // Now map the configuration derivatives back to v.
   BasicVector<double> vmutable(v.size());
   diagram.MapQDotToVelocity(*context, qdot, &vmutable);
-  EXPECT_EQ(vmutable.GetAtIndex(0), 13);
-  EXPECT_EQ(vmutable.GetAtIndex(1), 17);
+  EXPECT_EQ(vmutable[0], 13);
+  EXPECT_EQ(vmutable[1], 17);
 }
 
 // Test for GetSystems.
@@ -1754,10 +1754,10 @@ TEST_F(DiscreteStateTest, UpdateDiscreteVariables) {
   // Initialize the zero-order holds to different values than their input ports.
   Context<double>& ctx1 =
       diagram_.GetMutableSubsystemContext(*diagram_.hold1(), context_.get());
-  ctx1.get_mutable_discrete_state(0).SetAtIndex(0, 1001.0);
+  ctx1.get_mutable_discrete_state(0)[0] = 1001.0;
   Context<double>& ctx2 =
       diagram_.GetMutableSubsystemContext(*diagram_.hold2(), context_.get());
-  ctx2.get_mutable_discrete_state(0).SetAtIndex(0, 1002.0);
+  ctx2.get_mutable_discrete_state(0)[0] = 1002.0;
 
   // Allocate the discrete variables.
   std::unique_ptr<DiscreteValues<double>> updates =
@@ -1787,11 +1787,11 @@ TEST_F(DiscreteStateTest, UpdateDiscreteVariables) {
 
   // Apply the updates to the context_.
   context_->get_mutable_discrete_state().SetFrom(*updates);
-  EXPECT_EQ(1001.0, ctx1.get_discrete_state(0).GetAtIndex(0));
-  EXPECT_EQ(23.0, ctx2.get_discrete_state(0).GetAtIndex(0));
+  EXPECT_EQ(1001.0, ctx1.get_discrete_state(0)[0]);
+  EXPECT_EQ(23.0, ctx2.get_discrete_state(0)[0]);
 
   // Restore hold2 to its original value.
-  ctx2.get_mutable_discrete_state(0).SetAtIndex(0, 1002.0);
+  ctx2.get_mutable_discrete_state(0)[0] = 1002.0;
   // Set the time to 11.5, so both hold1 and hold2 update.
   context_->set_time(11.5);
   time = diagram_.CalcNextUpdateTime(*context_, events.get());
@@ -2070,34 +2070,26 @@ TEST_F(NestedDiagramContextTest, GetSubsystemContext) {
   EXPECT_EQ(big_output_->get_vector_data(3)->GetAtIndex(0), 0);
 
   big_diagram_->GetMutableSubsystemContext(*integrator0_, big_context_.get())
-      .get_mutable_continuous_state_vector()
-      .SetAtIndex(0, 1);
+      .get_mutable_continuous_state_vector()[0] = 1;
   big_diagram_->GetMutableSubsystemContext(*integrator1_, big_context_.get())
-      .get_mutable_continuous_state_vector()
-      .SetAtIndex(0, 2);
+      .get_mutable_continuous_state_vector()[0] = 2;
   big_diagram_->GetMutableSubsystemContext(*integrator2_, big_context_.get())
-      .get_mutable_continuous_state_vector()
-      .SetAtIndex(0, 3);
+      .get_mutable_continuous_state_vector()[0] = 3;
   big_diagram_->GetMutableSubsystemContext(*integrator3_, big_context_.get())
-      .get_mutable_continuous_state_vector()
-      .SetAtIndex(0, 4);
+      .get_mutable_continuous_state_vector()[0] = 4;
 
   // Checks states.
   EXPECT_EQ(big_diagram_->GetSubsystemContext(*integrator0_, *big_context_)
-                .get_continuous_state_vector()
-                .GetAtIndex(0),
+                .get_continuous_state_vector()[0],
             1);
   EXPECT_EQ(big_diagram_->GetSubsystemContext(*integrator1_, *big_context_)
-                .get_continuous_state_vector()
-                .GetAtIndex(0),
+                .get_continuous_state_vector()[0],
             2);
   EXPECT_EQ(big_diagram_->GetSubsystemContext(*integrator2_, *big_context_)
-                .get_continuous_state_vector()
-                .GetAtIndex(0),
+                .get_continuous_state_vector()[0],
             3);
   EXPECT_EQ(big_diagram_->GetSubsystemContext(*integrator3_, *big_context_)
-                .get_continuous_state_vector()
-                .GetAtIndex(0),
+                .get_continuous_state_vector()[0],
             4);
 
   // Checks output.
@@ -2123,23 +2115,19 @@ TEST_F(NestedDiagramContextTest, GetSubsystemState) {
   big_diagram_
       ->GetMutableSubsystemState(*integrator0_, &big_state)
       .get_mutable_continuous_state()
-      .get_mutable_vector()
-      .SetAtIndex(0, 1);
+      .get_mutable_vector()[0] = 1;
   big_diagram_
       ->GetMutableSubsystemState(*integrator1_, &big_state)
       .get_mutable_continuous_state()
-      .get_mutable_vector()
-      .SetAtIndex(0, 2);
+      .get_mutable_vector()[0] = 2;
   big_diagram_
       ->GetMutableSubsystemState(*integrator2_, &big_state)
       .get_mutable_continuous_state()
-      .get_mutable_vector()
-      .SetAtIndex(0, 3);
+      .get_mutable_vector()[0] = 3;
   big_diagram_
       ->GetMutableSubsystemState(*integrator3_, &big_state)
       .get_mutable_continuous_state()
-      .get_mutable_vector()
-      .SetAtIndex(0, 4);
+      .get_mutable_vector()[0] = 4;
 
   // Checks state.
   EXPECT_EQ(big_diagram_->GetSubsystemState(*integrator0_, big_state)
@@ -2423,7 +2411,7 @@ class PerStepActionTestSystem : public LeafSystem<double> {
       const Context<double>& context,
       const std::vector<const DiscreteUpdateEvent<double>*>& events,
       DiscreteValues<double>* discrete_state) const override {
-    (*discrete_state)[0] = context.get_discrete_state(0).GetAtIndex(0) + 1;
+    (*discrete_state)[0] = context.get_discrete_state(0)[0] + 1;
   }
 
   void DoCalcUnrestrictedUpdate(
@@ -2431,7 +2419,7 @@ class PerStepActionTestSystem : public LeafSystem<double> {
       const std::vector<const UnrestrictedUpdateEvent<double>*>& events,
       State<double>* state) const override {
     int int_num =
-        static_cast<int>(context.get_discrete_state(0).GetAtIndex(0));
+        static_cast<int>(context.get_discrete_state(0)[0]);
     state->get_mutable_abstract_state<std::string>(0) =
         "wow" + std::to_string(int_num);
   }
@@ -2511,17 +2499,17 @@ GTEST_TEST(DiagramPerStepActionTest, TestEverything) {
 
   // sys0 doesn't have any updates.
   auto& sys0_context = diagram->GetSubsystemContext(*sys0, *context);
-  EXPECT_EQ(sys0_context.get_discrete_state(0).GetAtIndex(0), 0);
+  EXPECT_EQ(sys0_context.get_discrete_state(0)[0], 0);
   EXPECT_EQ(sys0_context.get_abstract_state<std::string>(0), "wow");
 
   // sys1 should have an unrestricted update then a discrete update.
   auto& sys1_context = diagram->GetSubsystemContext(*sys1, *context);
-  EXPECT_EQ(sys1_context.get_discrete_state(0).GetAtIndex(0), 1);
+  EXPECT_EQ(sys1_context.get_discrete_state(0)[0], 1);
   EXPECT_EQ(sys1_context.get_abstract_state<std::string>(0), "wow0");
 
   // sys2 should have a unrestricted update then a publish.
   auto& sys2_context = diagram->GetSubsystemContext(*sys2, *context);
-  EXPECT_EQ(sys2_context.get_discrete_state(0).GetAtIndex(0), 0);
+  EXPECT_EQ(sys2_context.get_discrete_state(0)[0], 0);
   EXPECT_EQ(sys2_context.get_abstract_state<std::string>(0), "wow0");
 }
 
@@ -2662,7 +2650,7 @@ class ConstraintTestSystem : public LeafSystem<T> {
 
   void CalcState0Constraint(const Context<T>& context,
                             VectorX<T>* value) const {
-    *value = Vector1<T>(context.get_continuous_state_vector().GetAtIndex(0));
+    *value = Vector1<T>(context.get_continuous_state_vector()[0]);
   }
   void CalcStateConstraint(const Context<T>& context, VectorX<T>* value) const {
     *value = context.get_continuous_state_vector().CopyToVector();
@@ -2829,8 +2817,8 @@ class RandomContextTestSystem : public LeafSystem<double> {
                            RandomGenerator* generator) const override {
     std::uniform_real_distribution<double> uniform;
     for (int i = 0; i < context.get_numeric_parameter(0).size(); i++) {
-      params->get_mutable_numeric_parameter(0).SetAtIndex(i,
-                                                          uniform(*generator));
+      params->get_mutable_numeric_parameter(0).SetAtIndex(
+          i, uniform(*generator));
     }
   }
 };

--- a/systems/framework/test/discrete_values_test.cc
+++ b/systems/framework/test/discrete_values_test.cc
@@ -158,8 +158,8 @@ GTEST_TEST(DiscreteValuesSingleGroupTest, ConvenienceSugar) {
   EXPECT_EQ(42.0, xd[0]);
   EXPECT_EQ(43.0, xd[1]);
   xd[0] = 100.0;
-  EXPECT_EQ(100.0, xd.get_vector().GetAtIndex(0));
-  xd.get_mutable_vector().SetAtIndex(1, 1000.0);
+  EXPECT_EQ(100.0, xd.get_vector()[0]);
+  xd.get_mutable_vector()[1] = 1000.0;
   EXPECT_EQ(1000.0, xd[1]);
 }
 

--- a/systems/framework/test/fixed_input_port_value_test.cc
+++ b/systems/framework/test/fixed_input_port_value_test.cc
@@ -166,8 +166,8 @@ TEST_F(FixedInputPortTest, Clone) {
   // Make sure changing a value in the old context doesn't change a value
   // in the new one, and vice versa.
   port0_value_->GetMutableVectorData<double>()->SetAtIndex(0, 99);
-  EXPECT_EQ(port0_value_->get_vector_value<double>().GetAtIndex(0), 99);
-  EXPECT_EQ(free0->get_vector_value<double>().GetAtIndex(0), 5);
+  EXPECT_EQ(port0_value_->get_vector_value<double>()[0], 99);
+  EXPECT_EQ(free0->get_vector_value<double>()[0], 5);
 
   free1->GetMutableData()->get_mutable_value<std::string>() = "hello";
   EXPECT_EQ(free1->get_value().get_value<std::string>(), "hello");

--- a/systems/framework/test/leaf_context_test.cc
+++ b/systems/framework/test/leaf_context_test.cc
@@ -245,15 +245,15 @@ void VerifyClonedState(const State<double>& clone) {
 
   // Verify that the second-order structure was preserved.
   EXPECT_EQ(kGeneralizedPositionSize, xc.get_generalized_position().size());
-  EXPECT_EQ(1.0, xc.get_generalized_position().GetAtIndex(0));
-  EXPECT_EQ(2.0, xc.get_generalized_position().GetAtIndex(1));
+  EXPECT_EQ(1.0, xc.get_generalized_position()[0]);
+  EXPECT_EQ(2.0, xc.get_generalized_position()[1]);
 
   EXPECT_EQ(kGeneralizedVelocitySize, xc.get_generalized_velocity().size());
-  EXPECT_EQ(3.0, xc.get_generalized_velocity().GetAtIndex(0));
-  EXPECT_EQ(5.0, xc.get_generalized_velocity().GetAtIndex(1));
+  EXPECT_EQ(3.0, xc.get_generalized_velocity()[0]);
+  EXPECT_EQ(5.0, xc.get_generalized_velocity()[1]);
 
   EXPECT_EQ(kMiscContinuousStateSize, xc.get_misc_continuous_state().size());
-  EXPECT_EQ(8.0, xc.get_misc_continuous_state().GetAtIndex(0));
+  EXPECT_EQ(8.0, xc.get_misc_continuous_state()[0]);
 }
 
 TEST_F(LeafContextTest, CheckPorts) {
@@ -511,20 +511,20 @@ TEST_F(LeafContextTest, Clone) {
   // Verify that changes to the cloned state do not affect the original state.
   // -- Continuous
   ContinuousState<double>& xc = clone->get_mutable_continuous_state();
-  xc.get_mutable_generalized_velocity().SetAtIndex(1, 42.0);
+  xc.get_mutable_generalized_velocity()[1] = 42.0;
   EXPECT_EQ(42.0, xc[3]);
-  EXPECT_EQ(5.0, context_.get_continuous_state_vector().GetAtIndex(3));
+  EXPECT_EQ(5.0, context_.get_continuous_state_vector()[3]);
 
   // -- Discrete
   BasicVector<double>& xd1 = clone->get_mutable_discrete_state(1);
-  xd1.SetAtIndex(0, 1024.0);
-  EXPECT_EQ(1024.0, clone->get_discrete_state(1).GetAtIndex(0));
-  EXPECT_EQ(256.0, context_.get_discrete_state(1).GetAtIndex(0));
+  xd1[0] = 1024.0;
+  EXPECT_EQ(1024.0, clone->get_discrete_state(1)[0]);
+  EXPECT_EQ(256.0, context_.get_discrete_state(1)[0]);
 
   // Check State indexed discrete methods too.
   State<double>& state = clone->get_mutable_state();
-  EXPECT_EQ(1024.0, state.get_discrete_state(1).GetAtIndex(0));
-  EXPECT_EQ(1024.0, state.get_mutable_discrete_state(1).GetAtIndex(0));
+  EXPECT_EQ(1024.0, state.get_discrete_state(1)[0]);
+  EXPECT_EQ(1024.0, state.get_mutable_discrete_state(1)[0]);
 
   // -- Abstract (even though it's not owned in context_)
   clone->get_mutable_abstract_state<int>(0) = 2048;
@@ -551,7 +551,7 @@ TEST_F(LeafContextTest, Clone) {
 
   // Verify that changes to the cloned parameters do not affect the originals.
   leaf_clone->get_mutable_numeric_parameter(0)[0] = 76.0;
-  EXPECT_EQ(1.0, context_.get_numeric_parameter(0).GetAtIndex(0));
+  EXPECT_EQ(1.0, context_.get_numeric_parameter(0)[0]);
 }
 
 // Tests that a LeafContext can provide a clone of its State.
@@ -625,10 +625,10 @@ TEST_F(LeafContextTest, SetTimeStateAndParametersFrom) {
   EXPECT_EQ(kGeneralizedPositionSize, xc.get_generalized_position().size());
   EXPECT_EQ(5.0, xc.get_generalized_velocity()[1].value());
   EXPECT_EQ(0, xc.get_generalized_velocity()[1].derivatives().size());
-  EXPECT_EQ(128.0, target.get_discrete_state(0).GetAtIndex(0));
+  EXPECT_EQ(128.0, target.get_discrete_state(0)[0]);
   // Verify that parameters were set.
   target.get_numeric_parameter(0);
-  EXPECT_EQ(2.0, (target.get_numeric_parameter(0).GetAtIndex(1).value()));
+  EXPECT_EQ(2.0, (target.get_numeric_parameter(0)[1].value()));
 
   // Set the accuracy in the context.
   context_.set_accuracy(accuracy);

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -717,7 +717,7 @@ TEST_F(LeafSystemTest, NumericParameters) {
   EXPECT_EQ(7.0, vec[1]);
   BasicVector<double>& mutable_vec =
       system_.GetVanillaMutableNumericParameters(context.get());
-  mutable_vec.SetAtIndex(1, 42.0);
+  mutable_vec[1] = 42.0;
   EXPECT_EQ(42.0, vec[1]);
 
   EXPECT_EQ(system_.num_numeric_parameter_groups(), 1);
@@ -1230,8 +1230,8 @@ GTEST_TEST(ModelLeafSystemTest, ModelNumericParams) {
   // Check that type was preserved.
   ASSERT_TRUE(is_dynamic_castable<const MyVector2d>(&param));
   EXPECT_EQ(2, param.size());
-  EXPECT_EQ(1.1, param.GetAtIndex(0));
-  EXPECT_EQ(2.2, param.GetAtIndex(1));
+  EXPECT_EQ(1.1, param[0]);
+  EXPECT_EQ(2.2, param[1]);
 }
 
 // Tests that various DeclareDiscreteState() signatures work correctly and
@@ -2189,7 +2189,7 @@ class ConstraintTestSystem : public LeafSystem<double> {
 
   void CalcState0Constraint(const Context<double>& context,
                             Eigen::VectorXd* value) const {
-    *value = Vector1d(context.get_continuous_state_vector().GetAtIndex(0));
+    *value = Vector1d(context.get_continuous_state_vector()[0]);
   }
   void CalcStateConstraint(const Context<double>& context,
                            Eigen::VectorXd* value) const {
@@ -2264,7 +2264,7 @@ GTEST_TEST(SystemConstraintTest, FunctionHandleTest) {
 
   ContextConstraintCalc<double> calc0 = [](
       const Context<double>& context, Eigen::VectorXd* value) {
-    *value = Vector1d(context.get_continuous_state_vector().GetAtIndex(1));
+    *value = Vector1d(context.get_continuous_state_vector()[1]);
   };
   EXPECT_EQ(dut.DeclareInequalityConstraint(calc0,
                                             { Vector1d::Zero(), nullopt },
@@ -2275,8 +2275,8 @@ GTEST_TEST(SystemConstraintTest, FunctionHandleTest) {
   ContextConstraintCalc<double> calc1 = [](
       const Context<double>& context, Eigen::VectorXd* value) {
     *value =
-        Eigen::Vector2d(context.get_continuous_state_vector().GetAtIndex(1),
-                        context.get_continuous_state_vector().GetAtIndex(0));
+        Eigen::Vector2d(context.get_continuous_state_vector()[1],
+                        context.get_continuous_state_vector()[0]);
   };
   EXPECT_EQ(dut.DeclareInequalityConstraint(calc1,
                                             { nullopt, Eigen::Vector2d(2, 3) },
@@ -2388,20 +2388,20 @@ GTEST_TEST(SystemConstraintTest, ModelVectorTest) {
   auto context = dut.CreateDefaultContext();
 
   // `param0[0] >= 11.0` with `param0[0] == 1.0` produces `1.0 >= 11.0`.
-  context->get_mutable_numeric_parameter(0).SetAtIndex(0, 1.0);
+  context->get_mutable_numeric_parameter(0)[0] = 1.0;
   Eigen::VectorXd value0;
   constraint0.Calc(*context, &value0);
   EXPECT_TRUE(CompareMatrices(value0, Vector1<double>::Constant(1.0)));
 
   // `xc[0] >= 22.0` with `xc[0] == 2.0` produces `2.0 >= 22.0`.
-  context->get_mutable_continuous_state_vector().SetAtIndex(0, 2.0);
+  context->get_mutable_continuous_state_vector()[0] = 2.0;
   Eigen::VectorXd value1;
   constraint1.Calc(*context, &value1);
   EXPECT_TRUE(CompareMatrices(value1, Vector1<double>::Constant(2.0)));
 
   // `u0[0] >= 33.0` with `u0[0] == 3.0` produces `3.0 >= 33.0`.
   InputVector input;
-  input.SetAtIndex(0, 3.0);
+  input[0] = 3.0;
   dut.get_input_port(0).FixValue(&*context, input);
   Eigen::VectorXd value2;
   constraint2.Calc(*context, &value2);
@@ -2436,8 +2436,8 @@ class RandomContextTestSystem : public LeafSystem<double> {
                            RandomGenerator* generator) const override {
     std::uniform_real_distribution<double> uniform;
     for (int i = 0; i < context.get_numeric_parameter(0).size(); i++) {
-      params->get_mutable_numeric_parameter(0).SetAtIndex(i,
-                                                          uniform(*generator));
+      params->get_mutable_numeric_parameter(0).SetAtIndex(
+          i, uniform(*generator));
     }
   }
 };

--- a/systems/framework/test/parameters_test.cc
+++ b/systems/framework/test/parameters_test.cc
@@ -43,13 +43,13 @@ class ParametersTest : public ::testing::Test {
 TEST_F(ParametersTest, Numeric) {
   ASSERT_EQ(2, params_->num_numeric_parameter_groups());
   ASSERT_EQ(2, params_->get_numeric_parameters().num_groups());
-  EXPECT_EQ(3.0, params_->get_numeric_parameter(0).GetAtIndex(0));
-  EXPECT_EQ(6.0, params_->get_numeric_parameter(0).GetAtIndex(1));
-  EXPECT_EQ(9.0, params_->get_numeric_parameter(1).GetAtIndex(0));
-  EXPECT_EQ(12.0, params_->get_numeric_parameter(1).GetAtIndex(1));
+  EXPECT_EQ(3.0, params_->get_numeric_parameter(0)[0]);
+  EXPECT_EQ(6.0, params_->get_numeric_parameter(0)[1]);
+  EXPECT_EQ(9.0, params_->get_numeric_parameter(1)[0]);
+  EXPECT_EQ(12.0, params_->get_numeric_parameter(1)[1]);
 
-  params_->get_mutable_numeric_parameter(0).SetAtIndex(1, 42.0);
-  EXPECT_EQ(42.0, params_->get_numeric_parameter(0).GetAtIndex(1));
+  params_->get_mutable_numeric_parameter(0)[1] = 42.0;
+  EXPECT_EQ(42.0, params_->get_numeric_parameter(0)[1]);
 }
 
 TEST_F(ParametersTest, Abstract) {
@@ -64,14 +64,14 @@ TEST_F(ParametersTest, Abstract) {
 TEST_F(ParametersTest, Clone) {
   // Test that data is copied into the clone.
   auto clone = params_->Clone();
-  EXPECT_EQ(3.0, clone->get_numeric_parameter(0).GetAtIndex(0));
+  EXPECT_EQ(3.0, clone->get_numeric_parameter(0)[0]);
   EXPECT_EQ(72, UnpackIntValue(clone->get_abstract_parameter(0)));
   EXPECT_EQ(144, UnpackIntValue(clone->get_abstract_parameter(1)));
 
   // Test that changes to the clone don't write through to the original.
   // - numeric
-  clone->get_mutable_numeric_parameter(0).SetAtIndex(1, 42.0);
-  EXPECT_EQ(6.0, params_->get_numeric_parameter(0).GetAtIndex(1));
+  clone->get_mutable_numeric_parameter(0)[1] = 42.0;
+  EXPECT_EQ(6.0, params_->get_numeric_parameter(0)[1]);
   // - abstract
   clone->get_mutable_abstract_parameter(0).set_value<int>(256);
   EXPECT_EQ(72, UnpackIntValue(params_->get_abstract_parameter(0)));
@@ -84,11 +84,11 @@ TEST_F(ParametersTest, SetSymbolicFromDouble) {
 
   // The numeric parameters have been converted to symbolic constants.
   const auto& p0 = symbolic_params->get_numeric_parameter(0);
-  EXPECT_EQ("3", p0.GetAtIndex(0).to_string());
-  EXPECT_EQ("6", p0.GetAtIndex(1).to_string());
+  EXPECT_EQ("3", p0[0].to_string());
+  EXPECT_EQ("6", p0[1].to_string());
   const auto& p1 = symbolic_params->get_numeric_parameter(1);
-  EXPECT_EQ("9", p1.GetAtIndex(0).to_string());
-  EXPECT_EQ("12", p1.GetAtIndex(1).to_string());
+  EXPECT_EQ("9", p1[0].to_string());
+  EXPECT_EQ("12", p1[1].to_string());
 
   // The abstract parameters have simply been cloned.
   EXPECT_EQ(72, UnpackIntValue(symbolic_params->get_abstract_parameter(0)));
@@ -122,11 +122,11 @@ TEST_F(ParametersTest, SetAutodiffFromDouble) {
 
   // The numeric parameters have been converted to autodiff.
   const auto& p0 = autodiff_params->get_numeric_parameter(0);
-  EXPECT_EQ(3.0, p0.GetAtIndex(0).value());
-  EXPECT_EQ(6.0, p0.GetAtIndex(1).value());
+  EXPECT_EQ(3.0, p0[0].value());
+  EXPECT_EQ(6.0, p0[1].value());
   const auto& p1 = autodiff_params->get_numeric_parameter(1);
-  EXPECT_EQ(9.0, p1.GetAtIndex(0).value());
-  EXPECT_EQ(12.0, p1.GetAtIndex(1).value());
+  EXPECT_EQ(9.0, p1[0].value());
+  EXPECT_EQ(12.0, p1[1].value());
 
   // The abstract parameters have simply been cloned.
   EXPECT_EQ(72, UnpackIntValue(autodiff_params->get_abstract_parameter(0)));

--- a/systems/framework/test/subvector_test.cc
+++ b/systems/framework/test/subvector_test.cc
@@ -144,7 +144,9 @@ TEST_F(SubvectorTest, AddToVectorInvalidSize) {
 TEST_F(SubvectorTest, SetZero) {
   Subvector<double> subvec(vector_.get(), 0, kSubVectorLength);
   subvec.SetZero();
-  for (int i = 0; i < subvec.size(); i++) EXPECT_EQ(subvec.GetAtIndex(i), 0);
+  for (int i = 0; i < subvec.size(); i++) {
+    EXPECT_EQ(subvec.GetAtIndex(i), 0);
+  }
 }
 
 // Tests the infinity norm.

--- a/systems/framework/test/system_constraint_test.cc
+++ b/systems/framework/test/system_constraint_test.cc
@@ -84,7 +84,7 @@ GTEST_TEST(SystemConstraintBoundsTest, BadSizes) {
 GTEST_TEST(SystemConstraintTest, Basic) {
   ContextConstraintCalc<double> calc = [](
       const Context<double>& context, Eigen::VectorXd* value) {
-    *value = Vector1d(context.get_continuous_state_vector().GetAtIndex(1));
+    *value = Vector1d(context.get_continuous_state_vector()[1]);
   };
   ContextConstraintCalc<double> calc2 = [](
       const Context<double>& context, Eigen::VectorXd* value) {
@@ -106,14 +106,14 @@ GTEST_TEST(SystemConstraintTest, Basic) {
   SystemConstraint<double> equality_constraint(
       &system, calc, SystemConstraintBounds::Equality(1),
       "equality constraint");
-  context->get_mutable_continuous_state_vector().SetAtIndex(1, 5.0);
+  context->get_mutable_continuous_state_vector()[1] = 5.0;
   equality_constraint.Calc(*context, &value);
   EXPECT_EQ(value[0], 5.0);
   EXPECT_TRUE(CompareMatrices(equality_constraint.lower_bound(), Vector1d(0)));
   EXPECT_TRUE(CompareMatrices(equality_constraint.upper_bound(), Vector1d(0)));
   EXPECT_FALSE(equality_constraint.CheckSatisfied(*context, tol));
 
-  context->get_mutable_continuous_state_vector().SetAtIndex(1, 0.0);
+  context->get_mutable_continuous_state_vector()[1] = 0.0;
   equality_constraint.Calc(*context, &value);
   EXPECT_EQ(value[0], 0.0);
   EXPECT_TRUE(equality_constraint.CheckSatisfied(*context, tol));
@@ -129,14 +129,14 @@ GTEST_TEST(SystemConstraintTest, Basic) {
                               Eigen::Vector2d::Ones()));
   EXPECT_TRUE(CompareMatrices(inequality_constraint.upper_bound(),
                               Eigen::Vector2d(4, 6)));
-  context->get_mutable_continuous_state_vector().SetAtIndex(0, 3.0);
-  context->get_mutable_continuous_state_vector().SetAtIndex(1, 5.0);
+  context->get_mutable_continuous_state_vector()[0] = 3.0;
+  context->get_mutable_continuous_state_vector()[1] = 5.0;
   inequality_constraint.Calc(*context, &value);
   EXPECT_EQ(value[0], 3.0);
   EXPECT_EQ(value[1], 5.0);
   EXPECT_TRUE(inequality_constraint.CheckSatisfied(*context, tol));
 
-  context->get_mutable_continuous_state_vector().SetAtIndex(1, -0.5);
+  context->get_mutable_continuous_state_vector()[1] = -0.5;
   inequality_constraint.Calc(*context, &value);
   EXPECT_EQ(value[1], -0.5);
   EXPECT_FALSE(inequality_constraint.CheckSatisfied(*context, tol));

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -244,15 +244,15 @@ TEST_F(SystemTest, MapVelocityToConfigurationDerivatives) {
   BasicVector<double> state_vec2(kSize);
 
   system_.MapVelocityToQDot(context_, *state_vec1, &state_vec2);
-  EXPECT_EQ(1.0, state_vec2.GetAtIndex(0));
-  EXPECT_EQ(2.0, state_vec2.GetAtIndex(1));
-  EXPECT_EQ(3.0, state_vec2.GetAtIndex(2));
+  EXPECT_EQ(1.0, state_vec2[0]);
+  EXPECT_EQ(2.0, state_vec2[1]);
+  EXPECT_EQ(3.0, state_vec2[2]);
 
   // Test Eigen specialized function specially.
   system_.MapVelocityToQDot(context_, state_vec1->CopyToVector(), &state_vec2);
-  EXPECT_EQ(1.0, state_vec2.GetAtIndex(0));
-  EXPECT_EQ(2.0, state_vec2.GetAtIndex(1));
-  EXPECT_EQ(3.0, state_vec2.GetAtIndex(2));
+  EXPECT_EQ(1.0, state_vec2[0]);
+  EXPECT_EQ(2.0, state_vec2[1]);
+  EXPECT_EQ(3.0, state_vec2[2]);
 }
 
 TEST_F(SystemTest, MapConfigurationDerivativesToVelocity) {
@@ -260,15 +260,15 @@ TEST_F(SystemTest, MapConfigurationDerivativesToVelocity) {
   BasicVector<double> state_vec2(kSize);
 
   system_.MapQDotToVelocity(context_, *state_vec1, &state_vec2);
-  EXPECT_EQ(1.0, state_vec2.GetAtIndex(0));
-  EXPECT_EQ(2.0, state_vec2.GetAtIndex(1));
-  EXPECT_EQ(3.0, state_vec2.GetAtIndex(2));
+  EXPECT_EQ(1.0, state_vec2[0]);
+  EXPECT_EQ(2.0, state_vec2[1]);
+  EXPECT_EQ(3.0, state_vec2[2]);
 
   // Test Eigen specialized function specially.
   system_.MapQDotToVelocity(context_, state_vec1->CopyToVector(), &state_vec2);
-  EXPECT_EQ(1.0, state_vec2.GetAtIndex(0));
-  EXPECT_EQ(2.0, state_vec2.GetAtIndex(1));
-  EXPECT_EQ(3.0, state_vec2.GetAtIndex(2));
+  EXPECT_EQ(1.0, state_vec2[0]);
+  EXPECT_EQ(2.0, state_vec2[1]);
+  EXPECT_EQ(3.0, state_vec2[2]);
 }
 
 TEST_F(SystemTest, ConfigurationDerivativeVelocitySizeMismatch) {

--- a/systems/framework/test/vector_system_test.cc
+++ b/systems/framework/test/vector_system_test.cc
@@ -307,8 +307,8 @@ TEST_F(VectorSystemTest, TimeDerivatives) {
   dut.CalcTimeDerivatives(*context, derivatives.get());
   EXPECT_EQ(dut.get_last_context(), context.get());
   EXPECT_EQ(dut.get_time_derivatives_count(), 1);
-  EXPECT_EQ(derivatives->get_vector().GetAtIndex(0), 2.0);
-  EXPECT_EQ(derivatives->get_vector().GetAtIndex(1), 3.0);
+  EXPECT_EQ(derivatives->get_vector()[0], 2.0);
+  EXPECT_EQ(derivatives->get_vector()[1], 3.0);
 
   // Nothing else weird happened.
   EXPECT_EQ(dut.get_discrete_variable_updates_count(), 0);
@@ -336,8 +336,8 @@ TEST_F(VectorSystemTest, DiscreteVariableUpdates) {
   dut.CalcDiscreteVariableUpdates(*context, discrete_updates.get());
   EXPECT_EQ(dut.get_last_context(), context.get());
   EXPECT_EQ(dut.get_discrete_variable_updates_count(), 1);
-  EXPECT_EQ(discrete_updates->get_vector(0).GetAtIndex(0), 2.0);
-  EXPECT_EQ(discrete_updates->get_vector(0).GetAtIndex(1), 3.0);
+  EXPECT_EQ(discrete_updates->get_vector(0)[0], 2.0);
+  EXPECT_EQ(discrete_updates->get_vector(0)[1], 3.0);
 
   // Nothing else weird happened.
   EXPECT_EQ(dut.get_time_derivatives_count(), 0);
@@ -428,7 +428,7 @@ TEST_F(VectorSystemTest, NoInputContinuousTimeSystemTest) {
   std::unique_ptr<ContinuousState<double>> derivatives =
       dut.AllocateTimeDerivatives();
   dut.CalcTimeDerivatives(*context, derivatives.get());
-  EXPECT_EQ(derivatives->get_vector().GetAtIndex(0), -1.0);
+  EXPECT_EQ(derivatives->get_vector()[0], -1.0);
 
   const auto& output = dut.get_output_port();
   EXPECT_EQ(output.Eval(*context)[0], 1.0);
@@ -465,7 +465,7 @@ TEST_F(VectorSystemTest, NoInputNoOutputDiscreteTimeSystemTest) {
 
   auto discrete_updates = dut.AllocateDiscreteVariables();
   dut.CalcDiscreteVariableUpdates(*context, discrete_updates.get());
-  EXPECT_EQ(discrete_updates->get_vector(0).GetAtIndex(0), 8.0);
+  EXPECT_EQ(discrete_updates->get_vector(0)[0], 8.0);
 
   EXPECT_EQ(dut.get_num_output_ports(), 0);
 }

--- a/systems/framework/test_utilities/test/my_vector_test.cc
+++ b/systems/framework/test_utilities/test/my_vector_test.cc
@@ -59,7 +59,7 @@ GTEST_TEST(MyVectorTest, Clone) {
   auto clone = vector3.Clone();
 
   // Changing the original should not affect the clone.
-  vector3.SetAtIndex(1, 20.);
+  vector3[1] = 20.;
   EXPECT_EQ(vector3.get_value(), Vector3d(1., 20., 3.));
 
   EXPECT_EQ(clone->get_value(), Vector3d(1., 2., 3.));


### PR DESCRIPTION
Improve the documentation so that `operator[]` is highlighted, and port some unit tests to use it so that developers and users have good examples.

User code that says `GetAtIndex` and `SetAtIndex` is awkward and unconventional.  We should encourage the subscription operator where practical.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10968)
<!-- Reviewable:end -->
