### PR TITLE
test_utilities: Teach drake_py_unittest where the source lives

### DIFF
--- a/manipulation/util/BUILD.bazel
+++ b/manipulation/util/BUILD.bazel
@@ -124,9 +124,8 @@ drake_py_unittest(
 
 drake_py_unittest(
     name = "meshlab_to_sdf_test",
-    srcs = [
+    data = [
         "meshlab_to_sdf.py",
-        "test/meshlab_to_sdf_test.py",
     ],
 )
 

--- a/tools/install/install.bzl
+++ b/tools/install/install.bzl
@@ -1,7 +1,7 @@
 # -*- python -*-
 
 load("@drake//tools/skylark:drake_java.bzl", "MainClassInfo")
-load("@drake//tools/skylark:drake_py.bzl", "drake_py_unittest")
+load("@drake//tools/skylark:drake_py.bzl", "drake_py_test")
 load(
     "@drake//tools/skylark:pathutils.bzl",
     "dirname",
@@ -926,17 +926,22 @@ def install_test(
 
     src = "//tools/install:install_test.py"
 
-    drake_py_unittest(
+    # We can't use drake_py_unittest here, because the srcs path is atypical.
+    drake_py_test(
         name = name,
         # This is an integration test with significant I/O that requires an
-        # "eternal" timeout so that debug builds are successful.
-        # Therefore, the test size is increased to "medium", and the timeout to
-        # "eternal".
+        # "eternal" timeout so that debug builds are successful.  Therefore,
+        # the test size is increased to "medium", and the timeout to "eternal".
         # TODO(jamiesnape): Try to shorten the duration of this test.
         size = "medium",
         srcs = [src],
         timeout = "eternal",
         deps = ["//tools/install:install_test_helper"],
+        # The commands in our "list of commands" use unittest themselves, so we
+        # do the same for our own test rig.  That means that both our rig and
+        # the "list of commands" python programs must have a __main__ clause
+        # (i.e., they must all be binaries, not libraries).
+        allow_import_unittest = True,
         **kwargs
     )
 

--- a/tools/install/install_test.py
+++ b/tools/install/install_test.py
@@ -6,6 +6,11 @@ import unittest
 
 class TestInstall(unittest.TestCase):
     def test_install(self):
+        # Fail (on purpose) if not given exactly one command line argument.
+        self.assertEqual(len(sys.argv), 2)
+        with open(sys.argv[1], 'r') as f:
+            lines = f.readlines()
+
         # Install into bazel read-only temporary directory. The temporary
         # directory does not need to be removed as bazel tests are run in a
         # scratch space.
@@ -17,15 +22,12 @@ class TestInstall(unittest.TestCase):
         content = set(os.listdir(installation_folder))
         self.assertSetEqual(set(['bin', 'include', 'lib', 'share']), content)
 
-        # Will fail (on purpose) if not exactly one command line argument
-        # given.
-        self.assertEqual(len(sys.argv), 2)
-
-        with open(sys.argv[1], 'r') as f:
-            lines = f.readlines()
-
         # Execute the install actions.
         for cmd in lines:
             cmd = cmd.strip()
             print("+ {}".format(cmd))
             install_test_helper.check_call([os.path.join(os.getcwd(), cmd)])
+
+
+if __name__ == '__main__':
+    unittest.main(argv=["TestInstall"])

--- a/tools/skylark/drake_py.bzl
+++ b/tools/skylark/drake_py.bzl
@@ -158,7 +158,6 @@ def drake_py_binary(
 
 def drake_py_unittest(
         name,
-        srcs = [],
         **kwargs):
     """Declares a `unittest`-based python test.
 
@@ -168,11 +167,13 @@ def drake_py_unittest(
     to "small" to indicate a unit test.
     """
     helper = "//common/test_utilities:drake_py_unittest_main.py"
-    if not srcs:
-        srcs = ["test/%s.py" % name]
+    if kwargs.pop("srcs", None):
+        fail("Changing srcs= is not allowed by drake_py_unittest." +
+             " Use drake_py_test instead, if you need something weird.")
+    srcs = ["test/%s.py" % name, helper]
     drake_py_test(
         name = name,
-        srcs = srcs + [helper],
+        srcs = srcs,
         main = helper,
         allow_import_unittest = True,
         **kwargs


### PR DESCRIPTION
Previously, we were searching in "." for the source code.  That is dangerous when running a test manually from bazel-bin (instead of via bazel test), and is ambiguous for reused basenames like lcm_test.

Without this PR, running `bazel-bin/bindings/pydrake/py/lcm_test` by hand fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10969)
<!-- Reviewable:end -->
