### PR TITLE
framework: Destroy Diagram's Systems in reverse order

### DIFF
--- a/systems/framework/diagram_builder.h
+++ b/systems/framework/diagram_builder.h
@@ -473,7 +473,7 @@ class DiagramBuilder {
   // registered_systems_. Used for fast membership queries.
   std::unordered_set<const System<T>*> systems_;
   // The Systems in this DiagramBuilder, in the order they were registered.
-  std::vector<std::unique_ptr<System<T>>> registered_systems_;
+  internal::OwnedSystems<T> registered_systems_;
 
   friend int AddRandomInputs(double, systems::DiagramBuilder<double>*);
 };


### PR DESCRIPTION
In rare cases, a System might have cleanup actions in its destructor.

(In my case, LcmSubscriberSystem will remove itself from its DrakeLcmInterface service, which will have been added earlier into the same Diagram.)

We should probably follow the conventional C++ order that resources are destroyed in the opposite order they are created -- here, by using "order they were added" as a proxy for "order they were created".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10970)
<!-- Reviewable:end -->
