### PR TITLE
Enable caching by default

### DIFF
--- a/manipulation/schunk_wsg/test/schunk_wsg_position_controller_test.cc
+++ b/manipulation/schunk_wsg/test/schunk_wsg_position_controller_test.cc
@@ -98,15 +98,14 @@ GTEST_TEST(SchunkWsgPositionControllerTest, SimTest) {
                 Eval(controller_context)[0],
             -force_limit);
 
-  auto wsg_state = wsg->GetMutablePositionsAndVelocities(&wsg_context);
-  wsg_state = Vector4d::Zero();
+  wsg->SetPositionsAndVelocities(&wsg_context, Vector4d::Zero());
   simulator.AdvanceTo(1.0);
 
   const double kTolerance = 1e-12;
 
   // Check that we achieved the desired position.
   EXPECT_TRUE(CompareMatrices(
-      wsg_state,
+      wsg->GetPositionsAndVelocities(wsg_context),
       Vector4d(-desired_position / 2, desired_position / 2, 0.0, 0.0),
       kTolerance));
   // The steady-state force should be near zero.
@@ -121,7 +120,7 @@ GTEST_TEST(SchunkWsgPositionControllerTest, SimTest) {
                       &controller_context);
   simulator.AdvanceTo(2.0);
   EXPECT_TRUE(CompareMatrices(
-      wsg_state,
+      wsg->GetPositionsAndVelocities(wsg_context),
       Vector4d(-desired_position / 2, desired_position / 2, 0.0, 0.0),
       kTolerance));
   // The steady-state force should be near zero.
@@ -140,7 +139,8 @@ GTEST_TEST(SchunkWsgPositionControllerTest, SimTest) {
               force_limit, kTolerance);
 
   // Set the position to the target and observe zero force.
-  wsg_state = Vector4d(-desired_position / 2, desired_position / 2, 0.0, 0.0);
+  wsg->SetPositionsAndVelocities(&wsg_context,
+      Vector4d(-desired_position / 2, desired_position / 2, 0.0, 0.0));
 
   EXPECT_EQ(controller->get_grip_force_output_port().
                 Eval(controller_context)[0],

--- a/systems/controllers/inverse_dynamics.cc
+++ b/systems/controllers/inverse_dynamics.cc
@@ -59,7 +59,7 @@ void InverseDynamics<T>::CalcOutputForce(const Context<T>& context,
 
   auto& plant = *multibody_plant_;
   // Set the position and velocity in the context.
-  plant.GetMutablePositionsAndVelocities(multibody_plant_context_.get()) = x;
+  plant.SetPositionsAndVelocities(multibody_plant_context_.get(), x);
 
   if (this->is_pure_gravity_compensation()) {
     output->get_mutable_value() =

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -1004,10 +1004,6 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
           i, ConvertToContextPortIdentifier(id));
     }
 
-    // TODO(sherm1) Remove this line and the corresponding one in
-    // LeafSystem to enable caching by default in Drake (issue #9205).
-    context->DisableCaching();
-
     return context;
   }
 

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -180,10 +180,6 @@ class LeafSystem : public System<T> {
     // Allow derived LeafSystem to validate allocated Context.
     DoValidateAllocatedLeafContext(*context);
 
-    // TODO(sherm1) Remove this line and the corresponding one in
-    // Diagram to enable caching by default in Drake.
-    context->DisableCaching();
-
     return context;
   }
 


### PR DESCRIPTION
This PR makes `context.EnableCaching()` the default. You can still turn it off with `context.DisableCaching()` if you want (but please don't, except for debugging).

Two tests failed with caching on and are repaired here:
 1. **IiwaCommandReceiver** declared an explicit CacheEntry with a dependency list including only input ports. In fact at initialization it depended on a parameter to provide the default configuration. I added the parameter to the dependency list. Note that although this went out of its way to use a CacheEntry, it was in fact never tested with caching enabled! Had it been, the bug would have been found immediately.
 2. **schunk_wsg_position_controller_test** used MBP's `GetMutablePositionsAndVelocities()` method to obtain a mutable reference to the state, which it then wrote on twice (the second time invisible to the caching system). The excellent documentation for that method says:
```
  /// @warning You should use SetPositionsAndVelocities() instead of this method
  ///          unless you are fully aware of the interactions with the caching
  ///          mechanism (see @ref dangerous_get_mutable).
```
so that's what I did!

I also removed the only other use of `GetMutablePositionsAndVelocities()` outside of MBP/MBT (in inverse_dynamics.cc), although it was not being misused in that case.

Resolves #9251
Knocks off a checkbox in #9205.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10979)
<!-- Reviewable:end -->
