### PR TITLE
(geometry) Fix SDF to point with threshold and broad-phase filter.

### DIFF
--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -1297,6 +1297,7 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     auto fcl_sphere = make_shared<fcl::Sphered>(0.0);  // sphere of zero radius
     fcl::CollisionObjectd query_point(fcl_sphere);
     query_point.setTranslation(p_WQ);
+    query_point.computeAABB();
 
     std::vector<SignedDistanceToPoint<double>> distances;
 


### PR DESCRIPTION
Previously in ComputeSignedDistanceToPoint(), I set coordinates (x,y,z) of p_WQ of the query point Q, but I forgot to set its zero-volume bounding box to [x,x]x[y,y]x[z,z], which is by default [0,0]x[0,0]x[0,0].  As a result, when these events happen at the same time:
1. There are more than one objects, so the bounding-box tree starts traversal.
2. Users use small enough threshold.
3. The object within the distance threshold from Q is far enough from the origin.
Then, ComputeSignedDistanceToPoint() mistakenly returns no result. 

This PR fixes the above problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10980)
<!-- Reviewable:end -->
