### PR TITLE
Bugfix in PyFunctionCost DoEval to allocate output container

### DIFF
--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -110,11 +110,13 @@ class PyFunctionCost : public Cost {
  protected:
   void DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
       Eigen::VectorXd* y) const override {
+    y->resize(1);
     (*y)[0] = double_func_(x);
   }
 
   void DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
       AutoDiffVecXd* y) const override {
+    y->resize(1);
     (*y)[0] = autodiff_func_(x);
   }
 
@@ -821,7 +823,7 @@ PYBIND11_MODULE(mathematicalprogram, m) {
       using T_y = decltype(dummy_y);
       cls.def("Eval",
           [](const Class& self, const Eigen::Ref<const VectorX<T_x>>& x) {
-            VectorX<T_y> y;
+            VectorX<T_y> y(self.num_outputs());
             self.Eval(x, &y);
             return y;
           },

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -439,10 +439,16 @@ class TestMathematicalProgram(unittest.TestCase):
         def constraint(x):
             return x
 
-        prog.AddCost(cost, vars=x)
-        prog.AddConstraint(constraint, lb=[0.], ub=[2.], vars=x)
+        cost_binding = prog.AddCost(cost, vars=x)
+        constraint_binding = prog.AddConstraint(
+            constraint, lb=[0.], ub=[2.], vars=x)
         result = mp.Solve(prog)
-        self.assertAlmostEqual(result.GetSolution(x)[0], 1.)
+        xstar = result.GetSolution(x)
+        self.assertAlmostEqual(xstar[0], 1.)
+
+        # Verify that they can be evaluated.
+        self.assertAlmostEqual(cost_binding.evaluator().Eval(xstar), 0.)
+        self.assertAlmostEqual(constraint_binding.evaluator().Eval(xstar), 1.)
 
     def test_addcost_symbolic(self):
         prog = mp.MathematicalProgram()


### PR DESCRIPTION
The supplied test fails before this change is applied (with a gnarly segfault) and passes afterward. Pretty sure what was happening is that the VectorX output container wasn't being allocated before it gets assigned to in PyFunctionCost::DoEval().

I'm not 100% clear whether it's PyFunctionCost or EvaluatorBase's job to do this allocation -- the C++ docs for EvaluatorBase and general usage pattern make it look like it's PyFunctionCost's job. I put in the resizing on both sides to be thorough, but I'm happy to undo one.

@EricCousineau-TRI mind taking a look?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10985)
<!-- Reviewable:end -->
