### PR TITLE
py math, values: Enable copy for types; Add instantiations for mathy bits

### DIFF
--- a/bindings/pydrake/common/eigen_geometry_py.cc
+++ b/bindings/pydrake/common/eigen_geometry_py.cc
@@ -15,16 +15,17 @@ namespace drake {
 namespace pydrake {
 namespace {
 
-// TODO(eric.cousineau): There is validation from Python to C++, but no
-// validation in the other direction. Consider intercepting this.
-
-// TODO(eric.cousineau): Add operator overloads.
+// TODO(eric.cousineau): Do not require only SE(3) for isometries because this
+// makes it a misnomer: SE(3) ⊂ Isometry(3) b/c Isometry admits reflection.
+// Additionally, do not validate for Quaternion, b/c it will break parity with
+// C++ and cause odd edge cases when attempting to do projections from non-unit
+// quaternions to unit quaternions (e.g. for use with `RigidTransform`).
 
 // TODO(eric.cousineau): Disable tolerance checks for the symbolic case.
 
 // N.B. This could potentially interfere with another library's bindings of
-// Eigen types. If/when this happens, this should be addressed for both these
-// and AutoDiff types.
+// Eigen types. If/when this happens, this should be addressed for both double
+// and AutoDiff types, most likely using `py::module_local()`.
 
 // N.B. Use a loose tolerance, so that we don't have to be super strict with
 // C++.
@@ -45,7 +46,7 @@ void CheckRotMat(const Matrix3<T>& R) {
 }
 
 template <typename T>
-void CheckIsometry(const Isometry3<T>& X) {
+void CheckSe3(const Isometry3<T>& X) {
   CheckRotMat<T>(X.linear());
   Eigen::Matrix<T, 1, 4> bottom_expected;
   bottom_expected << 0, 0, 0, 1;
@@ -86,13 +87,15 @@ PYBIND11_MODULE(eigen_geometry, m) {
   // @note `linear` implies rotation, and `affine` implies translation.
   {
     using Class = Isometry3<T>;
-    py::class_<Class> py_class(m, "Isometry3");
-    py_class  // BR
+    py::class_<Class> cls(m, "Isometry3",
+        "Provides bindings of Eigen::Isometry3<> that only admit SE(3) "
+        "(no reflections).");
+    cls  // BR
         .def(py::init([]() { return Class::Identity(); }))
         .def_static("Identity", []() { return Class::Identity(); })
         .def(py::init([](const Matrix4<T>& matrix) {
           Class out(matrix);
-          CheckIsometry(out);
+          CheckSe3(out);
           return out;
         }),
             py::arg("matrix"))
@@ -115,7 +118,7 @@ PYBIND11_MODULE(eigen_geometry, m) {
         }),
             py::arg("quaternion"), py::arg("translation"))
         .def(py::init([](const Class& other) {
-          CheckIsometry(other);
+          CheckSe3(other);
           return other;
         }),
             py::arg("other"))
@@ -124,7 +127,7 @@ PYBIND11_MODULE(eigen_geometry, m) {
         .def("set_matrix",
             [](Class* self, const Matrix4<T>& matrix) {
               Class update(matrix);
-              CheckIsometry(update);
+              CheckSe3(update);
               *self = update;
             })
         .def("translation",
@@ -169,6 +172,7 @@ PYBIND11_MODULE(eigen_geometry, m) {
             py::arg("position"))
         .def("inverse", [](const Class* self) { return self->inverse(); });
     py::implicitly_convertible<Matrix4<T>, Class>();
+    DefCopyAndDeepCopy(&cls);
   }
 
   // Quaternion.
@@ -177,11 +181,10 @@ PYBIND11_MODULE(eigen_geometry, m) {
   // TODO(eric.cousineau): Should this not be restricted to a unit quaternion?
   {
     using Class = Eigen::Quaternion<T>;
-    py::class_<Class> py_class(m, "Quaternion");
-    py_class.attr("__doc__") =
-        "Provides a unit quaternion binding of Eigen::Quaternion<>.";
-    py::object py_class_obj = py_class;
-    py_class  // BR
+    py::class_<Class> cls(m, "Quaternion",
+        "Provides a unit quaternion binding of Eigen::Quaternion<>.");
+    py::object py_class_obj = cls;
+    cls  // BR
         .def(py::init([]() { return Class::Identity(); }))
         .def_static("Identity", []() { return Class::Identity(); })
         .def(py::init([](const Vector4<T>& wxyz) {
@@ -264,15 +267,15 @@ PYBIND11_MODULE(eigen_geometry, m) {
             py::arg("position"))
         .def("inverse", [](const Class* self) { return self->inverse(); })
         .def("conjugate", [](const Class* self) { return self->conjugate(); });
+    DefCopyAndDeepCopy(&cls);
   }
 
   // Angle-axis.
   {
     using Class = Eigen::AngleAxis<T>;
-    py::class_<Class> py_class(m, "AngleAxis");
-    py_class.attr("__doc__") = "Bindings for Eigen::AngleAxis<>.";
-    py::object py_class_obj = py_class;
-    py_class  // BR
+    py::class_<Class> cls(m, "AngleAxis", "Bindings for Eigen::AngleAxis<>.");
+    py::object py_class_obj = cls;
+    cls  // BR
         .def(py::init([]() { return Class::Identity(); }))
         .def_static("Identity", []() { return Class::Identity(); })
         .def(py::init([](const T& angle, const Vector3<T>& axis) {
@@ -342,6 +345,7 @@ PYBIND11_MODULE(eigen_geometry, m) {
         .def("__matmul__",
             [](const Class& self, const Class& other) { return self * other; })
         .def("inverse", [](const Class* self) { return self->inverse(); });
+    DefCopyAndDeepCopy(&cls);
   }
 }
 

--- a/bindings/pydrake/common/test/eigen_geometry_test.py
+++ b/bindings/pydrake/common/test/eigen_geometry_test.py
@@ -1,8 +1,10 @@
 import pydrake.common.eigen_geometry as mut
 
+import copy
+import unittest
+
 import numpy as np
 import six
-import unittest
 
 import pydrake.common.test.eigen_geometry_test_util as test_util
 
@@ -16,6 +18,8 @@ class TestEigenGeometry(unittest.TestCase):
         # Simple API.
         q_identity = mut.Quaternion()
         self.assertTrue(np.allclose(q_identity.wxyz(), [1, 0, 0, 0]))
+        self.assertTrue(np.allclose(
+            copy.copy(q_identity).wxyz(), [1, 0, 0, 0]))
         self.assertTrue(np.allclose(
             q_identity.wxyz(), mut.Quaternion.Identity().wxyz()))
         self.assertEqual(
@@ -90,6 +94,7 @@ class TestEigenGeometry(unittest.TestCase):
         transform = mut.Isometry3()
         X = np.eye(4, 4)
         self.assertTrue(np.allclose(transform.matrix(), X))
+        self.assertTrue(np.allclose(copy.copy(transform).matrix(), X))
         self.assertEqual(str(transform), str(X))
         # - Constructor with (X)
         transform = mut.Isometry3(matrix=X)
@@ -161,6 +166,8 @@ class TestEigenGeometry(unittest.TestCase):
             [0, 0, 1]])
         value = mut.AngleAxis(rotation=R)
         self.assertTrue(np.allclose(value.rotation(), R, atol=1e-15, rtol=0))
+        self.assertTrue(np.allclose(
+            copy.copy(value).rotation(), R, atol=1e-15, rtol=0))
         self.assertTrue(np.allclose(
             value.inverse().rotation(), R.T, atol=1e-15, rtol=0))
         self.assertTrue(np.allclose(

--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -74,131 +74,128 @@ PYBIND11_MODULE(math, m) {
       .def("MeshValuesFrom", &BarycentricMesh<T>::MeshValuesFrom,
           doc.BarycentricMesh.MeshValuesFrom.doc);
 
-  py::class_<RigidTransform<T>>(m, "RigidTransform", doc.RigidTransform.doc)
-      .def(py::init(), doc.RigidTransform.ctor.doc_0args)
-      .def(py::init<const RigidTransform<T>&>(), py::arg("other"))
-      .def(py::init<const RotationMatrix<T>&, const Vector3<T>&>(),
-          py::arg("R"), py::arg("p"), doc.RigidTransform.ctor.doc_2args_R_p)
-      .def(py::init<const RollPitchYaw<T>&, const Vector3<T>&>(),
-          py::arg("rpy"), py::arg("p"), doc.RigidTransform.ctor.doc_2args_rpy_p)
-      .def(py::init<const Eigen::Quaternion<T>&, const Vector3<T>&>(),
-          py::arg("quaternion"), py::arg("p"),
-          doc.RigidTransform.ctor.doc_2args_quaternion_p)
-      .def(py::init<const Eigen::AngleAxis<T>&, const Vector3<T>&>(),
-          py::arg("theta_lambda"), py::arg("p"),
-          doc.RigidTransform.ctor.doc_2args_theta_lambda_p)
-      .def(py::init<const RotationMatrix<T>&>(), py::arg("R"),
-          doc.RigidTransform.ctor.doc_1args_R)
-      .def(py::init<const Vector3<T>&>(), py::arg("p"),
-          doc.RigidTransform.ctor.doc_1args_p)
-      .def(py::init<const Isometry3<T>&>(), py::arg("pose"),
-          doc.RigidTransform.ctor.doc_1args_pose)
-      .def("set", &RigidTransform<T>::set, py::arg("R"), py::arg("p"),
-          doc.RigidTransform.set.doc)
-      .def("SetFromIsometry3", &RigidTransform<T>::SetFromIsometry3,
-          py::arg("pose"), doc.RigidTransform.SetFromIsometry3.doc)
-      .def_static("Identity", &RigidTransform<T>::Identity,
-          doc.RigidTransform.Identity.doc)
-      .def("rotation", &RigidTransform<T>::rotation, py_reference_internal,
-          doc.RigidTransform.rotation.doc)
-      .def("set_rotation", &RigidTransform<T>::set_rotation, py::arg("R"),
-          doc.RigidTransform.set_rotation.doc)
-      .def("translation", &RigidTransform<T>::translation,
-          py_reference_internal, doc.RigidTransform.translation.doc)
-      .def("set_translation", &RigidTransform<T>::set_translation, py::arg("p"),
-          doc.RigidTransform.set_translation.doc)
-      .def("GetAsMatrix4", &RigidTransform<T>::GetAsMatrix4,
-          doc.RigidTransform.GetAsMatrix4.doc)
-      .def("GetAsMatrix34", &RigidTransform<T>::GetAsMatrix34,
-          doc.RigidTransform.GetAsMatrix34.doc)
-      .def("GetAsIsometry3", &RigidTransform<T>::GetAsIsometry3,
-          doc.RigidTransform.GetAsIsometry3.doc)
-      .def("SetIdentity", &RigidTransform<T>::SetIdentity,
-          doc.RigidTransform.SetIdentity.doc)
-      // .def("IsExactlyIdentity", ...)
-      // .def("IsIdentityToEpsilon", ...)
-      .def("inverse", &RigidTransform<T>::inverse,
-          doc.RigidTransform.inverse.doc)
-      .def("multiply",
-          [](const RigidTransform<T>* self, const RigidTransform<T>& other) {
-            return *self * other;
-          },
-          py::arg("other"), doc.RigidTransform.operator_mul.doc_1args_other)
-      .def("__matmul__",
-          [](const RigidTransform<T>* self, const RigidTransform<T>& other) {
-            return *self * other;
-          },
-          py::arg("other"), "See ``multiply``.")
-      .def("multiply",
-          [](const RigidTransform<T>* self, const Vector3<T>& p_BoQ_B) {
-            return *self * p_BoQ_B;
-          },
-          py::arg("p_BoQ_B"), doc.RigidTransform.operator_mul.doc_1args_p_BoQ_B)
-      .def("__matmul__",
-          [](const RigidTransform<T>* self, const Vector3<T>& p_BoQ_B) {
-            return *self * p_BoQ_B;
-          },
-          py::arg("p_BoQ_B"), "See ``multiply``.");
-  // .def("IsNearlyEqualTo", ...)
-  // .def("IsExactlyEqualTo", ...)
+  {
+    using Class = RigidTransform<T>;
+    constexpr auto& cls_doc = doc.RigidTransform;
+    py::class_<Class> cls(m, "RigidTransform", cls_doc.doc);
+    cls  // BR
+        .def(py::init(), cls_doc.ctor.doc_0args)
+        .def(py::init<const Class&>(), py::arg("other"))
+        .def(py::init<const RotationMatrix<T>&, const Vector3<T>&>(),
+            py::arg("R"), py::arg("p"), cls_doc.ctor.doc_2args_R_p)
+        .def(py::init<const RollPitchYaw<T>&, const Vector3<T>&>(),
+            py::arg("rpy"), py::arg("p"), cls_doc.ctor.doc_2args_rpy_p)
+        .def(py::init<const Eigen::Quaternion<T>&, const Vector3<T>&>(),
+            py::arg("quaternion"), py::arg("p"),
+            cls_doc.ctor.doc_2args_quaternion_p)
+        .def(py::init<const Eigen::AngleAxis<T>&, const Vector3<T>&>(),
+            py::arg("theta_lambda"), py::arg("p"),
+            cls_doc.ctor.doc_2args_theta_lambda_p)
+        .def(py::init<const RotationMatrix<T>&>(), py::arg("R"),
+            cls_doc.ctor.doc_1args_R)
+        .def(py::init<const Vector3<T>&>(), py::arg("p"),
+            cls_doc.ctor.doc_1args_p)
+        .def(py::init<const Isometry3<T>&>(), py::arg("pose"),
+            cls_doc.ctor.doc_1args_pose)
+        .def("set", &Class::set, py::arg("R"), py::arg("p"), cls_doc.set.doc)
+        .def("SetFromIsometry3", &Class::SetFromIsometry3, py::arg("pose"),
+            cls_doc.SetFromIsometry3.doc)
+        .def_static("Identity", &Class::Identity, cls_doc.Identity.doc)
+        .def("rotation", &Class::rotation, py_reference_internal,
+            cls_doc.rotation.doc)
+        .def("set_rotation", &Class::set_rotation, py::arg("R"),
+            cls_doc.set_rotation.doc)
+        .def("translation", &Class::translation, py_reference_internal,
+            cls_doc.translation.doc)
+        .def("set_translation", &Class::set_translation, py::arg("p"),
+            cls_doc.set_translation.doc)
+        .def("GetAsMatrix4", &Class::GetAsMatrix4, cls_doc.GetAsMatrix4.doc)
+        .def("GetAsMatrix34", &Class::GetAsMatrix34, cls_doc.GetAsMatrix34.doc)
+        .def("GetAsIsometry3", &Class::GetAsIsometry3,
+            cls_doc.GetAsIsometry3.doc)
+        .def("SetIdentity", &Class::SetIdentity, cls_doc.SetIdentity.doc)
+        // .def("IsExactlyIdentity", ...)
+        // .def("IsIdentityToEpsilon", ...)
+        .def("inverse", &Class::inverse, cls_doc.inverse.doc)
+        .def("multiply",
+            [](const Class* self, const Class& other) { return *self * other; },
+            py::arg("other"), cls_doc.operator_mul.doc_1args_other)
+        .def("__matmul__",
+            [](const Class* self, const Class& other) { return *self * other; },
+            py::arg("other"), "See ``multiply``.")
+        .def("multiply",
+            [](const Class* self, const Vector3<T>& p_BoQ_B) {
+              return *self * p_BoQ_B;
+            },
+            py::arg("p_BoQ_B"), cls_doc.operator_mul.doc_1args_p_BoQ_B)
+        .def("__matmul__",
+            [](const Class* self, const Vector3<T>& p_BoQ_B) {
+              return *self * p_BoQ_B;
+            },
+            py::arg("p_BoQ_B"), "See ``multiply``.");
+    DefCopyAndDeepCopy(&cls);
+    // .def("IsNearlyEqualTo", ...)
+    // .def("IsExactlyEqualTo", ...)
+  }
 
-  py::class_<RollPitchYaw<T>>(m, "RollPitchYaw", doc.RollPitchYaw.doc)
-      .def(py::init<const RollPitchYaw<T>&>(), py::arg("other"))
-      .def(py::init<const Vector3<T>>(), py::arg("rpy"),
-          doc.RollPitchYaw.ctor.doc_1args_rpy)
-      .def(py::init<const T&, const T&, const T&>(), py::arg("roll"),
-          py::arg("pitch"), py::arg("yaw"),
-          doc.RollPitchYaw.ctor.doc_3args_roll_pitch_yaw)
-      .def(py::init<const RotationMatrix<T>&>(), py::arg("R"),
-          doc.RollPitchYaw.ctor.doc_1args_R)
-      .def(py::init<const Eigen::Quaternion<T>&>(), py::arg("quaternion"),
-          doc.RollPitchYaw.ctor.doc_1args_quaternion)
-      .def(py::init([](const Matrix3<T>& matrix) {
-        return RollPitchYaw<T>(RotationMatrix<T>(matrix));
-      }),
-          py::arg("matrix"),
-          "Construct from raw rotation matrix. See RotationMatrix overload "
-          "for more information.")
-      .def("vector", &RollPitchYaw<T>::vector, doc.RollPitchYaw.vector.doc)
-      .def("roll_angle", &RollPitchYaw<T>::roll_angle,
-          doc.RollPitchYaw.roll_angle.doc)
-      .def("pitch_angle", &RollPitchYaw<T>::pitch_angle,
-          doc.RollPitchYaw.pitch_angle.doc)
-      .def("yaw_angle", &RollPitchYaw<T>::yaw_angle,
-          doc.RollPitchYaw.yaw_angle.doc)
-      .def("ToQuaternion", &RollPitchYaw<T>::ToQuaternion,
-          doc.RollPitchYaw.ToQuaternion.doc)
-      .def("ToRotationMatrix", &RollPitchYaw<T>::ToRotationMatrix,
-          doc.RollPitchYaw.ToRotationMatrix.doc);
+  {
+    using Class = RollPitchYaw<T>;
+    constexpr auto& cls_doc = doc.RollPitchYaw;
+    py::class_<Class> cls(m, "RollPitchYaw", cls_doc.doc);
+    cls  // BR
+        .def(py::init<const Class&>(), py::arg("other"))
+        .def(py::init<const Vector3<T>>(), py::arg("rpy"),
+            cls_doc.ctor.doc_1args_rpy)
+        .def(py::init<const T&, const T&, const T&>(), py::arg("roll"),
+            py::arg("pitch"), py::arg("yaw"),
+            cls_doc.ctor.doc_3args_roll_pitch_yaw)
+        .def(py::init<const RotationMatrix<T>&>(), py::arg("R"),
+            cls_doc.ctor.doc_1args_R)
+        .def(py::init<const Eigen::Quaternion<T>&>(), py::arg("quaternion"),
+            cls_doc.ctor.doc_1args_quaternion)
+        .def(py::init([](const Matrix3<T>& matrix) {
+          return Class(RotationMatrix<T>(matrix));
+        }),
+            py::arg("matrix"),
+            "Construct from raw rotation matrix. See RotationMatrix overload "
+            "for more information.")
+        .def("vector", &Class::vector, cls_doc.vector.doc)
+        .def("roll_angle", &Class::roll_angle, cls_doc.roll_angle.doc)
+        .def("pitch_angle", &Class::pitch_angle, cls_doc.pitch_angle.doc)
+        .def("yaw_angle", &Class::yaw_angle, cls_doc.yaw_angle.doc)
+        .def("ToQuaternion", &Class::ToQuaternion, cls_doc.ToQuaternion.doc)
+        .def("ToRotationMatrix", &Class::ToRotationMatrix,
+            cls_doc.ToRotationMatrix.doc);
+    DefCopyAndDeepCopy(&cls);
+  }
 
-  py::class_<RotationMatrix<T>>(m, "RotationMatrix", doc.RotationMatrix.doc)
-      .def(py::init(), doc.RotationMatrix.ctor.doc_0args)
-      .def(py::init<const RotationMatrix<T>&>(), py::arg("other"))
-      .def(py::init<const Matrix3<T>&>(), py::arg("R"),
-          doc.RotationMatrix.ctor.doc_1args_R)
-      .def(py::init<Eigen::Quaternion<T>>(), py::arg("quaternion"),
-          doc.RotationMatrix.ctor.doc_1args_quaternion)
-      .def(py::init<const RollPitchYaw<T>&>(), py::arg("rpy"),
-          doc.RotationMatrix.ctor.doc_1args_rpy)
-      .def("matrix", &RotationMatrix<T>::matrix, doc.RotationMatrix.matrix.doc)
-      .def("multiply",
-          [](const RotationMatrix<T>& self, const RotationMatrix<T>& other) {
-            return self * other;
-          },
-          doc.RotationMatrix.operator_mul.doc_1args_other)
-      .def("__matmul__",
-          [](const RotationMatrix<T>& self, const RotationMatrix<T>& other) {
-            return self * other;
-          },
-          "See ``multiply``")
-      .def("inverse", &RotationMatrix<T>::inverse,
-          doc.RotationMatrix.inverse.doc)
-      .def("ToQuaternion",
-          overload_cast_explicit<Eigen::Quaternion<T>>(
-              &RotationMatrix<T>::ToQuaternion),
-          doc.RotationMatrix.ToQuaternion.doc_0args)
-      .def_static("Identity", &RotationMatrix<T>::Identity,
-          doc.RotationMatrix.Identity.doc);
+  {
+    using Class = RotationMatrix<T>;
+    constexpr auto& cls_doc = doc.RotationMatrix;
+    py::class_<Class> cls(m, "RotationMatrix", cls_doc.doc);
+    cls  // BR
+        .def(py::init(), cls_doc.ctor.doc_0args)
+        .def(py::init<const Class&>(), py::arg("other"))
+        .def(py::init<const Matrix3<T>&>(), py::arg("R"),
+            cls_doc.ctor.doc_1args_R)
+        .def(py::init<Eigen::Quaternion<T>>(), py::arg("quaternion"),
+            cls_doc.ctor.doc_1args_quaternion)
+        .def(py::init<const RollPitchYaw<T>&>(), py::arg("rpy"),
+            cls_doc.ctor.doc_1args_rpy)
+        .def("matrix", &Class::matrix, cls_doc.matrix.doc)
+        .def("multiply",
+            [](const Class& self, const Class& other) { return self * other; },
+            cls_doc.operator_mul.doc_1args_other)
+        .def("__matmul__",
+            [](const Class& self, const Class& other) { return self * other; },
+            "See ``multiply``")
+        .def("inverse", &Class::inverse, cls_doc.inverse.doc)
+        .def("ToQuaternion",
+            overload_cast_explicit<Eigen::Quaternion<T>>(&Class::ToQuaternion),
+            cls_doc.ToQuaternion.doc_0args)
+        .def_static("Identity", &Class::Identity, cls_doc.Identity.doc);
+    DefCopyAndDeepCopy(&cls);
+  }
 
   // Quadratic Form.
   m  // BR

--- a/bindings/pydrake/systems/framework_py_values.cc
+++ b/bindings/pydrake/systems/framework_py_values.cc
@@ -11,6 +11,8 @@
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/systems/systems_pybind.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/math/roll_pitch_yaw.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/subvector.h"
 #include "drake/systems/framework/supervector.h"
@@ -19,6 +21,34 @@ using std::string;
 
 namespace drake {
 namespace pydrake {
+
+namespace {
+
+using pysystems::AddValueInstantiation;
+
+// Add instantiations of primitive types on an as-needed basis; Please be
+// conservative.
+void AddPrimitiveValueInstantiations(py::module m) {
+  AddValueInstantiation<string>(m);
+  AddValueInstantiation<bool>(m);
+}
+
+// Same as above, but for templated types.
+template <typename T>
+void AddPrimitiveValueTemplateInstantiations(py::module m) {
+  // Imports for the relevant types.
+  py::module::import("pydrake.common.eigen_geometry");
+  py::module::import("pydrake.math");
+  // TODO(eric): When `Value[]` moves to `pydrake.common`, move these to their
+  // respective modules.
+  AddValueInstantiation<math::RigidTransform<T>>(m);
+  AddValueInstantiation<math::RotationMatrix<T>>(m);
+  // TODO(eric): Consider deprecating / removing `Isometry3` pending resolution
+  // of #9865.
+  AddValueInstantiation<Isometry3<T>>(m);
+}
+
+}  // namespace
 
 using pysystems::AddValueInstantiation;
 using pysystems::DefClone;
@@ -119,11 +149,12 @@ void DefineFrameworkPyValues(py::module m) {
       .def("set_value", abstract_stub("set_value"),
           pydrake_doc.drake.AbstractValue.SetValue.doc);
 
-  // Add `Value<std::string>` instantiation (visible in Python as `Value[str]`).
-  AddValueInstantiation<string>(m);
-
-  // Add `Value<bool>` instantiation (visible in Python as `Value[bool]`).
-  AddValueInstantiation<bool>(m);
+  // Add value instantiations for nominal data types. Types that require more
+  // pizazz are listed below.
+  AddPrimitiveValueInstantiations(m);
+  // TODO(eric.cousineau): Move inside loop once bindings support other
+  // scalars.
+  AddPrimitiveValueTemplateInstantiations<double>(m);
 
   // Add `Value<>` instantiations for basic vectors templated on common scalar
   // types.

--- a/bindings/pydrake/systems/test/value_test.py
+++ b/bindings/pydrake/systems/test/value_test.py
@@ -7,6 +7,8 @@ import unittest
 import numpy as np
 
 from pydrake.autodiffutils import AutoDiffXd
+from pydrake.common.eigen_geometry import Isometry3
+from pydrake.math import RigidTransform, RotationMatrix
 from pydrake.symbolic import Expression
 from pydrake.systems.framework import (
     AbstractValue,
@@ -151,6 +153,17 @@ class TestValue(unittest.TestCase):
                 "get_value",
                 "AddValueInstantiation",
             ]), cm.exception)
+
+    def test_value_registration(self):
+        # Existience check.
+        Value[object]
+        Value[str]
+        Value[bool]
+        Value[RigidTransform]
+        Value[RotationMatrix]
+        Value[Isometry3]
+        for T in [float, AutoDiffXd, Expression]:
+            Value[BasicVector_[T]]
 
     def test_parameters_api(self):
 

--- a/bindings/pydrake/test/math_test.py
+++ b/bindings/pydrake/test/math_test.py
@@ -4,11 +4,12 @@ import pydrake.math as mut
 from pydrake.math import (BarycentricMesh, wrap_to)
 from pydrake.common.eigen_geometry import Isometry3, Quaternion, AngleAxis
 
-import numpy as np
-import six
+import copy
+import math
 import unittest
 
-import math
+import numpy as np
+import six
 
 
 class TestBarycentricMesh(unittest.TestCase):
@@ -103,6 +104,7 @@ class TestMath(unittest.TestCase):
         X_I = np.eye(4)
         check_equality(mut.RigidTransform(), X_I)
         check_equality(mut.RigidTransform(other=mut.RigidTransform()), X_I)
+        check_equality(copy.copy(mut.RigidTransform()), X_I)
         R_I = mut.RotationMatrix()
         p_I = np.zeros(3)
         rpy_I = mut.RollPitchYaw(0, 0, 0)
@@ -143,6 +145,7 @@ class TestMath(unittest.TestCase):
         self.assertTrue(np.allclose(
             mut.RotationMatrix(other=R).matrix(), np.eye(3)))
         self.assertTrue(np.allclose(R.matrix(), np.eye(3)))
+        self.assertTrue(np.allclose(copy.copy(R).matrix(), np.eye(3)))
         self.assertTrue(np.allclose(
             mut.RotationMatrix.Identity().matrix(), np.eye(3)))
         R = mut.RotationMatrix(R=np.eye(3))


### PR DESCRIPTION
Quick enough, added it in.
See Slack convo: https://drakedevelopers.slack.com/archives/C3YB3EV5W/p1553185712025600

\cc @kmuhlrad 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10989)
<!-- Reviewable:end -->
