### PR TITLE
Some steps towards making System/Context APIs consistent

### DIFF
--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -129,8 +129,10 @@ void DefineFrameworkPySemantics(py::module m) {
     DefineTemplateClassWithDefault<Context<T>>(
         m, "Context", GetPyParam<T>(), doc.Context.doc)
         .def("__str__", &Context<T>::to_string, doc.Context.to_string.doc)
+        .def("num_input_ports", &Context<T>::num_input_ports,
+            doc.ContextBase.num_input_ports.doc)
         .def("get_num_input_ports", &Context<T>::get_num_input_ports,
-            doc.ContextBase.get_num_input_ports.doc)
+            "Use num_input_ports() instead.")
         .def("FixInputPort",
             py::overload_cast<int, const BasicVector<T>&>(
                 &Context<T>::FixInputPort),
@@ -148,9 +150,12 @@ void DefineFrameworkPySemantics(py::module m) {
             py::arg("index"), py::arg("data"), py_reference_internal,
             doc.Context.FixInputPort.doc_2args_index_data)
         .def("get_time", &Context<T>::get_time, doc.Context.get_time.doc)
-        .def("set_time", &Context<T>::set_time, doc.Context.set_time.doc)
+        .def("SetTime", &Context<T>::SetTime, doc.Context.SetTime.doc)
+        .def("set_time", &Context<T>::set_time, "Use SetTime() instead.")
+        .def("SetAccuracy", &Context<T>::SetAccuracy,
+            doc.Context.SetAccuracy.doc)
         .def("set_accuracy", &Context<T>::set_accuracy,
-            doc.Context.set_accuracy.doc)
+            "Use SetAccuracy() instead.")
         .def("get_accuracy", &Context<T>::get_accuracy,
             doc.Context.get_accuracy.doc)
         .def("Clone", &Context<T>::Clone, doc.Context.Clone.doc)
@@ -163,6 +168,8 @@ void DefineFrameworkPySemantics(py::module m) {
             py_reference_internal, doc.Context.get_mutable_state.doc)
         // Sugar methods
         // - Continuous.
+        .def("num_continuous_states", &Context<T>::num_continuous_states,
+            doc.Context.num_continuous_states.doc)
         .def("get_continuous_state", &Context<T>::get_continuous_state,
             py_reference_internal, doc.Context.get_continuous_state.doc)
         .def("get_mutable_continuous_state",
@@ -178,9 +185,12 @@ void DefineFrameworkPySemantics(py::module m) {
             py_reference_internal,
             doc.Context.get_mutable_continuous_state_vector.doc)
         // - Discrete.
+        .def("num_discrete_state_groups",
+            &Context<T>::num_discrete_state_groups,
+            doc.Context.num_discrete_state_groups.doc)
         .def("get_num_discrete_state_groups",
             &Context<T>::get_num_discrete_state_groups,
-            doc.Context.get_num_discrete_state_groups.doc)
+            "Use num_discrete_state_groups() instead.")
         .def("get_discrete_state",
             overload_cast_explicit<const DiscreteValues<T>&>(
                 &Context<T>::get_discrete_state),
@@ -217,8 +227,10 @@ void DefineFrameworkPySemantics(py::module m) {
             py_reference_internal,
             doc.Context.get_mutable_discrete_state.doc_1args)
         // - Abstract.
+        .def("num_abstract_states", &Context<T>::num_abstract_states,
+            doc.Context.num_abstract_states.doc)
         .def("get_num_abstract_states", &Context<T>::get_num_abstract_states,
-            doc.Context.get_num_abstract_states.doc)
+            "Use num_abstract_states() instead.")
         .def("get_abstract_state",
             static_cast<const AbstractValues& (Context<T>::*)() const>(
                 &Context<T>::get_abstract_state),
@@ -353,8 +365,10 @@ void DefineFrameworkPySemantics(py::module m) {
     auto system_output = DefineTemplateClassWithDefault<SystemOutput<T>>(
         m, "SystemOutput", GetPyParam<T>(), doc.SystemOutput.doc);
     system_output
+        .def("num_ports", &SystemOutput<T>::num_ports,
+            doc.SystemOutput.num_ports.doc)
         .def("get_num_ports", &SystemOutput<T>::get_num_ports,
-            doc.SystemOutput.get_num_ports.doc)
+            "Use num_ports() instead.")
         .def("get_data", &SystemOutput<T>::get_data, py_reference_internal,
             doc.SystemOutput.get_data.doc)
         .def("get_vector_data", &SystemOutput<T>::get_vector_data,

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -272,15 +272,19 @@ struct Impl {
         m, "System", GetPyParam<T>(), doc.SystemBase.doc)
         .def("set_name", &System<T>::set_name, doc.SystemBase.set_name.doc)
         // Topology.
+        .def("num_input_ports", &System<T>::num_input_ports,
+            doc.SystemBase.num_input_ports.doc)
         .def("get_num_input_ports", &System<T>::get_num_input_ports,
-            doc.SystemBase.get_num_input_ports.doc)
+            "Use num_input_ports() instead.")
         .def("get_input_port", &System<T>::get_input_port,
             py_reference_internal, py::arg("port_index"),
             doc.System.get_input_port.doc)
         .def("GetInputPort", &System<T>::GetInputPort, py_reference_internal,
             py::arg("port_name"), doc.System.GetInputPort.doc)
+        .def("num_output_ports", &System<T>::num_output_ports,
+            doc.SystemBase.num_output_ports.doc)
         .def("get_num_output_ports", &System<T>::get_num_output_ports,
-            doc.SystemBase.get_num_output_ports.doc)
+            "Use num_output_ports() instead.")
         .def("get_output_port", &System<T>::get_output_port,
             py_reference_internal, py::arg("port_index"),
             doc.System.get_output_port.doc)

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -57,7 +57,7 @@ class CustomAdder(LeafSystem):
         # since they are not stored densely.
         sum = sum_data.get_mutable_value()
         sum[:] = 0
-        for i in range(context.get_num_input_ports()):
+        for i in range(context.num_input_ports()):
             input_vector = self.EvalVectorInput(context, i)
             sum += input_vector.get_value()
 
@@ -123,15 +123,15 @@ class TestCustom(unittest.TestCase):
         return system
 
     def _fix_adder_inputs(self, context):
-        self.assertEqual(context.get_num_input_ports(), 2)
+        self.assertEqual(context.num_input_ports(), 2)
         context.FixInputPort(0, BasicVector([1, 2, 3]))
         context.FixInputPort(1, BasicVector([4, 5, 6]))
 
     def test_diagram_adder(self):
         system = CustomDiagram(2, 3)
-        self.assertEqual(system.get_num_input_ports(), 2)
+        self.assertEqual(system.num_input_ports(), 2)
         self.assertEqual(system.get_input_port(0).size(), 3)
-        self.assertEqual(system.get_num_output_ports(), 1)
+        self.assertEqual(system.num_output_ports(), 1)
         self.assertEqual(system.get_output_port(0).size(), 3)
 
     def test_adder_execution(self):
@@ -139,7 +139,7 @@ class TestCustom(unittest.TestCase):
         context = system.CreateDefaultContext()
         self._fix_adder_inputs(context)
         output = system.AllocateOutput()
-        self.assertEqual(output.get_num_ports(), 1)
+        self.assertEqual(output.num_ports(), 1)
         system.CalcOutput(context, output)
         value = output.get_vector_data(0).get_value()
         self.assertTrue(np.allclose([5, 7, 9], value))
@@ -354,10 +354,11 @@ class TestCustom(unittest.TestCase):
         context = system.CreateDefaultContext()
         self.assertTrue(
             context.get_state() is context.get_mutable_state())
+        self.assertEqual(context.num_continuous_states(), 1)
         self.assertTrue(
             context.get_continuous_state_vector() is
             context.get_mutable_continuous_state_vector())
-        self.assertEqual(context.get_num_discrete_state_groups(), 1)
+        self.assertEqual(context.num_discrete_state_groups(), 1)
         self.assertTrue(
             context.get_discrete_state_vector() is
             context.get_mutable_discrete_state_vector())
@@ -373,7 +374,7 @@ class TestCustom(unittest.TestCase):
         self.assertTrue(
             context.get_mutable_discrete_state(0) is
             context.get_mutable_discrete_state().get_vector(0))
-        self.assertEqual(context.get_num_abstract_states(), 1)
+        self.assertEqual(context.num_abstract_states(), 1)
         self.assertTrue(
             context.get_abstract_state() is
             context.get_mutable_abstract_state())
@@ -507,10 +508,10 @@ class TestCustom(unittest.TestCase):
             system = CustomAbstractSystem()
             context = system.CreateDefaultContext()
 
-            self.assertEqual(context.get_num_input_ports(), 1)
+            self.assertEqual(context.num_input_ports(), 1)
             context.FixInputPort(0, AbstractValue.Make(expected_input_value))
             output = system.AllocateOutput()
-            self.assertEqual(output.get_num_ports(), 1)
+            self.assertEqual(output.num_ports(), 1)
             system.CalcOutput(context, output)
             value = output.get_data(0)
             self.assertEqual(value.get_value(), expected_output_value)

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -76,14 +76,14 @@ class TestGeneral(unittest.TestCase):
     def _compare_system_instances(self, lhs, rhs):
         # Compares two different scalar type instantiation instances of a
         # system.
-        self.assertEqual(lhs.get_num_input_ports(), rhs.get_num_input_ports())
+        self.assertEqual(lhs.num_input_ports(), rhs.num_input_ports())
         self.assertEqual(
-            lhs.get_num_output_ports(), rhs.get_num_output_ports())
-        for i in range(lhs.get_num_input_ports()):
+            lhs.num_output_ports(), rhs.num_output_ports())
+        for i in range(lhs.num_input_ports()):
             lhs_port = lhs.get_input_port(i)
             rhs_port = rhs.get_input_port(i)
             self.assertEqual(lhs_port.size(), rhs_port.size())
-        for i in range(lhs.get_num_output_ports()):
+        for i in range(lhs.num_output_ports()):
             lhs_port = lhs.get_output_port(i)
             rhs_port = rhs.get_output_port(i)
             self.assertEqual(lhs_port.size(), rhs_port.size())
@@ -91,8 +91,8 @@ class TestGeneral(unittest.TestCase):
     def test_system_base_api(self):
         # Test a system with a different number of inputs from outputs.
         system = Adder(3, 10)
-        self.assertEqual(system.get_num_input_ports(), 3)
-        self.assertEqual(system.get_num_output_ports(), 1)
+        self.assertEqual(system.num_input_ports(), 3)
+        self.assertEqual(system.num_output_ports(), 1)
         self.assertEqual(system.GetInputPort("u1").get_index(), 1)
         self.assertEqual(system.GetOutputPort("sum").get_index(), 0)
         # TODO(eric.cousineau): Consolidate the main API tests for `System`
@@ -227,7 +227,7 @@ class TestGeneral(unittest.TestCase):
             def check_output(context):
                 # Check number of output ports and value for a given context.
                 output = system.AllocateOutput()
-                self.assertEqual(output.get_num_ports(), 1)
+                self.assertEqual(output.num_ports(), 1)
                 system.CalcOutput(context, output)
                 if T == float:
                     value = output.get_vector_data(0).get_value()
@@ -253,9 +253,9 @@ class TestGeneral(unittest.TestCase):
 
             # Create simulator specifying context.
             context = system.CreateDefaultContext()
-            context.set_time(0.)
+            context.SetTime(0.)
 
-            context.set_accuracy(1e-4)
+            context.SetAccuracy(1e-4)
             self.assertEqual(context.get_accuracy(), 1e-4)
 
             # @note `simulator` now owns `context`.

--- a/bindings/pydrake/systems/test/lcm_test.py
+++ b/bindings/pydrake/systems/test/lcm_test.py
@@ -227,7 +227,7 @@ class TestSystemsLcm(unittest.TestCase):
         publish_proc.start()
         # Initialize to first message.
         first_msg = dut.WaitForMessage()
-        dut.get_mutable_context().set_time(utime.GetTimeInSeconds(first_msg))
+        dut.get_mutable_context().SetTime(utime.GetTimeInSeconds(first_msg))
         # Run to desired amount. (Anything more will cause interpreter to
         # "freeze".)
         dut.RunToSecondsAssumingInitialized(t_end)

--- a/bindings/pydrake/systems/test/primitives_test.py
+++ b/bindings/pydrake/systems/test/primitives_test.py
@@ -260,7 +260,7 @@ class TestGeneral(unittest.TestCase):
         output = system.AllocateOutput()
 
         def mytest(input, expected):
-            context.set_time(input)
+            context.SetTime(input)
             system.CalcOutput(context, output)
             self.assertTrue(np.allclose(output.get_vector_data(
                 0).CopyToVector(), expected))
@@ -288,8 +288,8 @@ class TestGeneral(unittest.TestCase):
         # Test demultiplexer with scalar outputs.
         demux = Demultiplexer(size=4)
         context = demux.CreateDefaultContext()
-        self.assertEqual(demux.get_num_input_ports(), 1)
-        self.assertEqual(demux.get_num_output_ports(), 4)
+        self.assertEqual(demux.num_input_ports(), 1)
+        self.assertEqual(demux.num_output_ports(), 4)
 
         input_vec = np.array([1., 2., 3., 4.])
         context.FixInputPort(0, BasicVector(input_vec))
@@ -304,8 +304,8 @@ class TestGeneral(unittest.TestCase):
         # Test demultiplexer with vector outputs.
         demux = Demultiplexer(size=4, output_ports_sizes=2)
         context = demux.CreateDefaultContext()
-        self.assertEqual(demux.get_num_input_ports(), 1)
-        self.assertEqual(demux.get_num_output_ports(), 2)
+        self.assertEqual(demux.num_input_ports(), 1)
+        self.assertEqual(demux.num_output_ports(), 2)
 
         context.FixInputPort(0, BasicVector(input_vec))
         output = demux.AllocateOutput()
@@ -333,7 +333,7 @@ class TestGeneral(unittest.TestCase):
             context = mux.CreateDefaultContext()
             output = mux.AllocateOutput()
             num_ports = len(case['data'])
-            self.assertEqual(context.get_num_input_ports(), num_ports)
+            self.assertEqual(context.num_input_ports(), num_ports)
             for j, vec in enumerate(case['data']):
                 context.FixInputPort(j, BasicVector(vec))
             mux.CalcOutput(context, output)

--- a/systems/analysis/implicit_euler_integrator-inl.h
+++ b/systems/analysis/implicit_euler_integrator-inl.h
@@ -150,7 +150,7 @@ MatrixX<T> ImplicitEulerIntegrator<T>::ComputeForwardDiffJacobian(
   const double eps = std::sqrt(std::numeric_limits<double>::epsilon());
 
   // Get the number of continuous state variables xc.
-  const int n = context->get_continuous_state().size();
+  const int n = context->num_continuous_states();
 
   // Get the current continuous state.
   const VectorX<T> xtplus = context->get_continuous_state().CopyToVector();
@@ -222,7 +222,7 @@ MatrixX<T> ImplicitEulerIntegrator<T>::ComputeCentralDiffJacobian(
   const double eps = std::pow(std::numeric_limits<double>::epsilon(), 5.0/12);
 
   // Get the number of continuous state variables xc.
-  const int n = context->get_continuous_state().size();
+  const int n = context->num_continuous_states();
 
   SPDLOG_DEBUG(drake::log(), "  IE Compute Centraldiff {}-Jacobian t={}",
                n, context->get_time());

--- a/systems/analysis/initial_value_problem-inl.h
+++ b/systems/analysis/initial_value_problem-inl.h
@@ -130,7 +130,7 @@ InitialValueProblem<T>::InitialValueProblem(
   // Allocates a new default integration context with the
   // given default initial time.
   context_ = system_->CreateDefaultContext();
-  context_->set_time(default_values_.t0.value());
+  context_->SetTime(default_values_.t0.value());
 
   // Instantiates an explicit RK3 integrator by default.
   integrator_ = std::make_unique<RungeKutta3Integrator<T>>(
@@ -176,7 +176,7 @@ template <typename T>
 void InitialValueProblem<T>::ResetCachedState(
     const SpecifiedValues& values) const {
   // Sets context (initial) time.
-  context_->set_time(values.t0.value());
+  context_->SetTime(values.t0.value());
 
   // Sets context (initial) state. This cast is safe because the
   // ContinuousState<T> of a LeafSystem<T> is flat i.e. it is just

--- a/systems/analysis/integrator_base.h
+++ b/systems/analysis/integrator_base.h
@@ -677,7 +677,7 @@ class IntegratorBase {
     const double tol = 10 * std::numeric_limits<double>::epsilon() *
         ExtractDoubleOrThrow(max(t_target, context_->get_time()));
     DRAKE_DEMAND(abs(context_->get_time() - t_target) < tol);
-    context_->set_time(t_target);
+    context_->SetTime(t_target);
   }
 
   /**
@@ -839,7 +839,7 @@ class IntegratorBase {
     if (!is_initialized()) {
       throw std::logic_error("Integrator was not initialized.");
     }
-    if (get_context().get_continuous_state().size() == 0) {
+    if (get_context().num_continuous_states() == 0) {
       throw std::logic_error("System has no continuous state,"
                              " no dense output can be built.");
     }
@@ -1710,7 +1710,7 @@ bool IntegratorBase<T>::StepOnceErrorControlledAtMost(const T& dt_max) {
       step_size_to_attempt = next_step_size;
 
       // Reset the time, state, and time derivative at t0.
-      get_mutable_context()->set_time(current_time);
+      get_mutable_context()->SetTime(current_time);
       xc.SetFromVector(xc0_save_);
       if (get_dense_output()) {
         // Take dense output one step back to undo
@@ -1974,9 +1974,9 @@ typename IntegratorBase<T>::StepResult
 
   // If there is no continuous state, there will be no need to limit the
   // integration step size.
-  if (get_context().get_continuous_state().size() == 0) {
+  if (get_context().num_continuous_states() == 0) {
     Context<T>* context = get_mutable_context();
-    context->set_time(target_time);
+    context->SetTime(target_time);
     return candidate_result;
   }
 
@@ -2027,7 +2027,7 @@ typename IntegratorBase<T>::StepResult
   if (full_step || context_->get_time() >= target_time) {
     // Correct any rounding error that may have caused the time to overrun
     // the target time.
-    context_->set_time(target_time);
+    context_->SetTime(target_time);
 
     // If the integrator took the entire maximum step size we allowed above,
     // we report to the caller that a step constraint was hit, which may

--- a/systems/analysis/lyapunov.cc
+++ b/systems/analysis/lyapunov.cc
@@ -42,7 +42,7 @@ Eigen::VectorXd SampleBasedLyapunovAnalysis(
 
   // TODO(russt): handle discrete state.
   DRAKE_DEMAND(context.has_only_continuous_state());
-  DRAKE_DEMAND(context.get_continuous_state().size() == state_size);
+  DRAKE_DEMAND(context.num_continuous_states() == state_size);
 
   // TODO(russt): check that the system is time-invariant.
 

--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -766,14 +766,14 @@ void Simulator<T>::Initialize() {
   const T current_time = context_->get_time();
   const T slightly_before_current_time = internal::GetPreviousNormalizedValue(
       current_time);
-  context_->set_time(slightly_before_current_time);
+  context_->SetTime(slightly_before_current_time);
 
   // Get the next timed event.
   next_timed_event_time_ =
       system_.CalcNextUpdateTime(*context_, timed_events_.get());
 
   // Reset the context time.
-  context_->set_time(current_time);
+  context_->SetTime(current_time);
 
   // Indicate a timed event is to be handled, if appropriate.
   timed_or_witnessed_event_triggered_ =
@@ -1048,7 +1048,7 @@ void Simulator<T>::IsolateWitnessTriggers(
   std::function<void(const T&)> integrate_forward =
       [&t0, &x0, &context, this](const T& t_des) {
     const T inf = std::numeric_limits<double>::infinity();
-    context.set_time(t0);
+    context.SetTime(t0);
     context.get_mutable_continuous_state().SetFromVector(x0);
     while (context.get_time() < t_des)
       integrator_->IntegrateNoFurtherThanTime(inf, inf, t_des);

--- a/systems/analysis/test/explicit_euler_integrator_test.cc
+++ b/systems/analysis/test/explicit_euler_integrator_test.cc
@@ -53,7 +53,7 @@ GTEST_TEST(IntegratorTest, ContextAccess) {
   ExplicitEulerIntegrator<double> integrator(
       spring_mass, dt, context.get());  // Use default Context.
 
-  integrator.get_mutable_context()->set_time(3.);
+  integrator.get_mutable_context()->SetTime(3.);
   EXPECT_EQ(integrator.get_context().get_time(), 3.);
   EXPECT_EQ(context->get_time(), 3.);\
   integrator.reset_context(nullptr);
@@ -118,7 +118,7 @@ GTEST_TEST(IntegratorTest, MagDisparity) {
   context->EnableCaching();
 
   // Set a large magnitude time.
-  context->set_time(1e10);
+  context->SetTime(1e10);
 
   // Setup the integration size and infinity.
   const double dt = 1e-6;
@@ -208,7 +208,7 @@ GTEST_TEST(IntegratorTest, StepSize) {
   // Create a context.
   auto context = spring_mass.CreateDefaultContext();
   context->EnableCaching();
-  context->set_time(0.0);
+  context->SetTime(0.0);
   double t = 0.0;
   // Create the integrator.
   ExplicitEulerIntegrator<double> integrator(

--- a/systems/analysis/test/implicit_euler_integrator_test.cc
+++ b/systems/analysis/test/implicit_euler_integrator_test.cc
@@ -272,7 +272,7 @@ TEST_F(ImplicitIntegratorTest, ContextAccess) {
   // Create the integrator.
   ImplicitEulerIntegrator<double> integrator(*spring_, context_.get());
 
-  integrator.get_mutable_context()->set_time(3.);
+  integrator.get_mutable_context()->SetTime(3.);
   EXPECT_EQ(integrator.get_context().get_time(), 3.);
   EXPECT_EQ(context_->get_time(), 3.);
   integrator.reset_context(nullptr);
@@ -419,7 +419,7 @@ TEST_P(ImplicitIntegratorTest, SpringMassDamperStiff) {
       kCentralDifference);
 
   // Reset the time, position, and velocity.
-  context_->set_time(0.0);
+  context_->SetTime(0.0);
   spring_damper_->set_position(context_.get(), initial_position);
   spring_damper_->set_velocity(context_.get(), initial_velocity);
 
@@ -440,7 +440,7 @@ TEST_P(ImplicitIntegratorTest, SpringMassDamperStiff) {
       kAutomatic);
 
   // Reset the time, position, and velocity.
-  context_->set_time(0.0);
+  context_->SetTime(0.0);
   spring_damper_->set_position(context_.get(), initial_position);
   spring_damper_->set_velocity(context_.get(), initial_velocity);
 
@@ -516,7 +516,7 @@ TEST_P(ImplicitIntegratorTest, SpringMassStep) {
       kCentralDifference);
 
   // Reset the time, position, and velocity.
-  context_->set_time(0.0);
+  context_->SetTime(0.0);
   spring_mass.set_position(context_.get(), initial_position);
   spring_mass.set_velocity(context_.get(), initial_velocity);
 
@@ -538,7 +538,7 @@ TEST_P(ImplicitIntegratorTest, SpringMassStep) {
       kAutomatic);
 
   // Reset the time, position, and velocity.
-  context_->set_time(0.0);
+  context_->SetTime(0.0);
   spring_mass.set_position(context_.get(), initial_position);
   spring_mass.set_velocity(context_.get(), initial_velocity);
 
@@ -608,7 +608,7 @@ TEST_P(ImplicitIntegratorTest, ErrorEstimation) {
   for (int j = 0; j < n_dts; ++j) {
     for (int i = 0; i < n_initial_conditions; ++i) {
       // Reset the time.
-      context_->set_time(0.0);
+      context_->SetTime(0.0);
 
       // Set initial condition.
       spring_mass.set_position(context_.get(), initial_position[i]);
@@ -692,7 +692,7 @@ TEST_P(ImplicitIntegratorTest, SpringMassStepAccuracyEffects) {
   EXPECT_NEAR(integrator.get_accuracy_in_use(), 100.0,
               std::numeric_limits<double>::epsilon());
   integrator.Initialize();
-  context_->set_time(0);
+  context_->SetTime(0);
   spring_mass.set_position(context_.get(), initial_position);
   spring_mass.set_velocity(context_.get(), initial_velocity);
   integrator.IntegrateWithMultipleStepsToTime(context_->get_time() + large_dt_);
@@ -751,7 +751,7 @@ TEST_P(ImplicitIntegratorTest, DiscontinuousSpringMassDamper) {
       kCentralDifference);
 
   // Reset the time, position, and velocity.
-  context_->set_time(0.0);
+  context_->SetTime(0.0);
   mod_spring_damper_->set_position(context_.get(), initial_position);
   mod_spring_damper_->set_velocity(context_.get(), initial_velocity);
 
@@ -771,7 +771,7 @@ TEST_P(ImplicitIntegratorTest, DiscontinuousSpringMassDamper) {
       kAutomatic);
 
   // Reset the time, position, and velocity.
-  context_->set_time(0.0);
+  context_->SetTime(0.0);
   mod_spring_damper_->set_position(context_.get(), initial_position);
   mod_spring_damper_->set_velocity(context_.get(), initial_velocity);
 

--- a/systems/analysis/test/runge_kutta2_integrator_test.cc
+++ b/systems/analysis/test/runge_kutta2_integrator_test.cc
@@ -49,7 +49,7 @@ GTEST_TEST(IntegratorTest, ContextAccess) {
 
   // Create the integrator
   RungeKutta2Integrator<double> integrator(spring_mass, dt, context.get());
-  integrator.get_mutable_context()->set_time(3.);
+  integrator.get_mutable_context()->SetTime(3.);
   EXPECT_EQ(integrator.get_context().get_time(), 3.);
   EXPECT_EQ(context->get_time(), 3.);
 }

--- a/systems/analysis/test/semi_explicit_euler_integrator_test.cc
+++ b/systems/analysis/test/semi_explicit_euler_integrator_test.cc
@@ -29,7 +29,7 @@ GTEST_TEST(IntegratorTest, ContextAccess) {
   SemiExplicitEulerIntegrator<double> integrator(
       spring_mass, dt, context.get());  // Use default Context.
 
-  integrator.get_mutable_context()->set_time(3.);
+  integrator.get_mutable_context()->SetTime(3.);
   EXPECT_EQ(integrator.get_context().get_time(), 3.);
   EXPECT_EQ(context->get_time(), 3.);
   integrator.reset_context(nullptr);
@@ -94,7 +94,7 @@ GTEST_TEST(IntegratorTest, RigidBody) {
       CopyToVector();
 
   // Re-integrate with semi-explicit Euler.
-  context->set_time(0.);
+  context->SetTime(0.);
   plant.SetDefaultState(*context, &context->get_mutable_state());
   plant.SetVelocities(context.get(), generalized_velocities);
   SemiExplicitEulerIntegrator<double> see(plant, small_dt, context.get());

--- a/systems/analysis/test/simulator_test.cc
+++ b/systems/analysis/test/simulator_test.cc
@@ -180,7 +180,7 @@ GTEST_TEST(SimulatorTest, DiagramWitness) {
   simulator.set_publish_at_initialization(false);
   simulator.set_publish_every_time_step(false);
 
-  context.set_time(0);
+  context.SetTime(0);
   simulator.StepTo(1);
 
   // Publication should occur at witness function crossing.
@@ -373,7 +373,7 @@ GTEST_TEST(SimulatorTest, VariableStepIsolation) {
 
   // Set the initial accuracy in the context.
   double accuracy = 1.0;
-  context.set_accuracy(accuracy);
+  context.SetAccuracy(accuracy);
 
   // Set the initial empty system evaluation.
   double eval = std::numeric_limits<double>::infinity();
@@ -391,7 +391,7 @@ GTEST_TEST(SimulatorTest, VariableStepIsolation) {
     // Increase the accuracy, which should shrink the isolation window when
     // next retrieved.
     accuracy *= 0.1;
-    context.set_accuracy(accuracy);
+    context.SetAccuracy(accuracy);
   }
 }
 
@@ -421,7 +421,7 @@ GTEST_TEST(SimulatorTest, FixedStepIncreasingIsolationAccuracy) {
 
   // Set the initial accuracy in the context.
   double accuracy = 1.0;
-  context.set_accuracy(accuracy);
+  context.SetAccuracy(accuracy);
 
   // Set the initial empty system evaluation.
   double eval = std::numeric_limits<double>::infinity();
@@ -429,13 +429,13 @@ GTEST_TEST(SimulatorTest, FixedStepIncreasingIsolationAccuracy) {
   // Loop, decreasing accuracy as we go.
   while (accuracy > 1e-8) {
     // (Re)set the time and initial state.
-    context.set_time(0);
+    context.SetTime(0);
 
     // Simulate to dt.
     simulator.StepTo(dt);
 
     // CalcWitnessValue the witness function.
-    context.set_time(publish_time);
+    context.SetTime(publish_time);
     double new_eval = witness.front()->CalcWitnessValue(context);
 
     // Verify that the new evaluation is closer to zero than the old one.
@@ -444,7 +444,7 @@ GTEST_TEST(SimulatorTest, FixedStepIncreasingIsolationAccuracy) {
 
     // Increase the accuracy.
     accuracy *= 0.1;
-    context.set_accuracy(accuracy);
+    context.SetAccuracy(accuracy);
   }
 }
 
@@ -490,11 +490,11 @@ GTEST_TEST(SimulatorTest, MultipleWitnesses) {
   // Set initial time and state.
   Context<double>& context = simulator.get_mutable_context();
   context.get_mutable_continuous_state()[0] = -1;
-  context.set_time(0);
+  context.SetTime(0);
 
   // Isolate witness functions to high accuracy.
   const double tol = 1e-10;
-  context.set_accuracy(tol);
+  context.SetAccuracy(tol);
 
   // Simulate.
   simulator.StepTo(0.1);
@@ -546,7 +546,7 @@ GTEST_TEST(SimulatorTest, MultipleWitnessesIdentical) {
 
   // Isolate witness functions to high accuracy.
   const double tol = 1e-12;
-  simulator->get_mutable_context().set_accuracy(tol);
+  simulator->get_mutable_context().SetAccuracy(tol);
 
   // Simulate.
   simulator->StepTo(10);
@@ -585,7 +585,7 @@ GTEST_TEST(SimulatorTest, MultipleWitnessesStaggered) {
 
   // Isolate witness functions to high accuracy.
   const double tol = 1e-12;
-  simulator.get_mutable_context().set_accuracy(tol);
+  simulator.get_mutable_context().SetAccuracy(tol);
 
   // Get the isolation interval tolerance.
   const optional<double> iso_tol = simulator.GetCurrentWitnessTimeIsolation();
@@ -619,7 +619,7 @@ GTEST_TEST(SimulatorTest, WitnessTestCountSimpleNegToZero) {
   Simulator<double> simulator(system);
   InitFixedStepIntegratorForWitnessTesting(&simulator, dt);
   Context<double>& context = simulator.get_mutable_context();
-  context.set_time(0);
+  context.SetTime(0);
   simulator.StepTo(1);
 
   // Publication should occur at witness function crossing.
@@ -643,7 +643,7 @@ GTEST_TEST(SimulatorTest, WitnessTestCountSimpleZeroToPos) {
   Simulator<double> simulator(system);
   InitFixedStepIntegratorForWitnessTesting(&simulator, dt);
   Context<double>& context = simulator.get_mutable_context();
-  context.set_time(0);
+  context.SetTime(0);
   simulator.StepTo(1);
 
   // Verify that no publication is performed when stepping to 1.
@@ -666,7 +666,7 @@ GTEST_TEST(SimulatorTest, WitnessTestCountSimplePositiveToNegative) {
   Simulator<double> simulator(system);
   InitFixedStepIntegratorForWitnessTesting(&simulator, dt);
   Context<double>& context = simulator.get_mutable_context();
-  context.set_time(0);
+  context.SetTime(0);
   simulator.StepTo(2);
 
   // Publication should not occur (witness function should initially evaluate
@@ -689,7 +689,7 @@ GTEST_TEST(SimulatorTest, WitnessTestCountSimpleNegativeToPositive) {
   Simulator<double> simulator(system);
   InitFixedStepIntegratorForWitnessTesting(&simulator, dt);
   Context<double>& context = simulator.get_mutable_context();
-  context.set_time(-1);
+  context.SetTime(-1);
   simulator.StepTo(1);
 
   // Publication should occur at witness function crossing.
@@ -728,7 +728,7 @@ GTEST_TEST(SimulatorTest, SecondConstructor) {
   auto context = spring_mass.CreateDefaultContext();
 
   // Mark the context with an arbitrary value.
-  context->set_time(3.);
+  context->SetTime(3.);
 
   /// Construct the simulator with the created context.
   Simulator<double> simulator(spring_mass, std::move(context));
@@ -781,7 +781,7 @@ GTEST_TEST(SimulatorTest, ContextAccess) {
   simulator.Initialize();
 
   // Try some other context stuff.
-  simulator.get_mutable_context().set_time(3.);
+  simulator.get_mutable_context().SetTime(3.);
   EXPECT_EQ(simulator.get_context().get_time(), 3.);
   EXPECT_TRUE(simulator.has_context());
   simulator.release_context();
@@ -790,7 +790,7 @@ GTEST_TEST(SimulatorTest, ContextAccess) {
 
   // Create another context.
   auto ucontext = spring_mass.CreateDefaultContext();
-  ucontext->set_time(3.);
+  ucontext->SetTime(3.);
   simulator.reset_context(std::move(ucontext));
   EXPECT_EQ(simulator.get_context().get_time(), 3.);
   EXPECT_TRUE(simulator.has_context());
@@ -892,13 +892,13 @@ GTEST_TEST(SimulatorTest, RealtimeRate) {
 
   simulator.set_target_realtime_rate(1.);  // No faster than 1X real time.
   simulator.get_mutable_integrator()->set_maximum_step_size(0.001);
-  simulator.get_mutable_context().set_time(0.);
+  simulator.get_mutable_context().SetTime(0.);
   simulator.Initialize();
   simulator.StepTo(1.);  // Simulate for 1 simulated second.
   EXPECT_TRUE(simulator.get_actual_realtime_rate() <= 1.1);
 
   simulator.set_target_realtime_rate(5.);  // No faster than 5X real time.
-  simulator.get_mutable_context().set_time(0.);
+  simulator.get_mutable_context().SetTime(0.);
   simulator.Initialize();
   simulator.StepTo(1.);  // Simulate for 1 more simulated second.
   EXPECT_TRUE(simulator.get_actual_realtime_rate() <= 5.1);
@@ -912,7 +912,7 @@ GTEST_TEST(SimulatorTest, DisablePublishEveryTimestep) {
   simulator.set_publish_at_initialization(true);
   simulator.set_publish_every_time_step(false);
 
-  simulator.get_mutable_context().set_time(0.);
+  simulator.get_mutable_context().SetTime(0.);
   simulator.Initialize();
   // Publish should happen on initialization.
   EXPECT_EQ(1, simulator.get_num_publishes());
@@ -1324,14 +1324,14 @@ GTEST_TEST(SimulatorTest, SpikeTest) {
 
   // Test with spike time = 3*h.
   delta->set_spike_time(3 * DiscreteInputAccumulator::kPeriod);
-  simulator.get_mutable_context().set_time(0.);
+  simulator.get_mutable_context().SetTime(0.);
   simulator.Initialize();
   simulator.StepTo(5 * DiscreteInputAccumulator::kPeriod);
   EXPECT_EQ(hybrid_system->result(), std::vector<double>({0, 0, 0, 0, 1, 1}));
 
   // Test with spike time not coinciding with a sample time.
   delta->set_spike_time(2.7 * DiscreteInputAccumulator::kPeriod);
-  simulator.get_mutable_context().set_time(0.);
+  simulator.get_mutable_context().SetTime(0.);
   simulator.Initialize();
   simulator.StepTo(5 * DiscreteInputAccumulator::kPeriod);
   EXPECT_EQ(hybrid_system->result(), std::vector<double>({0, 0, 0, 0, 0, 0}));
@@ -1397,7 +1397,7 @@ GTEST_TEST(SimulatorTest, ExactUpdateTime) {
 
   // Set time to an exact floating point representation; we want t_upd to
   // be much smaller in magnitude than the time, hence the negative time.
-  simulator.get_mutable_context().set_time(-1.0 / 1024);
+  simulator.get_mutable_context().SetTime(-1.0 / 1024);
 
   // Capture the time at which an update is done using a callback function.
   std::vector<double> updates;
@@ -1700,7 +1700,7 @@ GTEST_TEST(SimulatorTest, StretchedStep) {
   simulator.Initialize();
 
   // Set initial condition using the Simulator's internal Context.
-  simulator.get_mutable_context().set_time(0);
+  simulator.get_mutable_context().SetTime(0);
   spring_mass.set_position(&simulator.get_mutable_context(), 0.1);
   spring_mass.set_velocity(&simulator.get_mutable_context(), 0);
 
@@ -1785,7 +1785,7 @@ GTEST_TEST(SimulatorTest, NoStretchedStep) {
       directed_t_final, &simulator.get_mutable_context());
 
   // Set initial condition using the Simulator's internal Context.
-  simulator.get_mutable_context().set_time(0);
+  simulator.get_mutable_context().SetTime(0);
   spring_mass.set_position(&simulator.get_mutable_context(), 0.1);
   spring_mass.set_velocity(&simulator.get_mutable_context(), 0);
 
@@ -1844,7 +1844,7 @@ GTEST_TEST(SimulatorTest, ArtificalLimitingStep) {
   // Set the time to right before an event, which should trigger artificial
   // limiting.
   const double desired_dt = req_initial_step_size * 1e-2;
-  simulator.get_mutable_context().set_time(event_time - desired_dt);
+  simulator.get_mutable_context().SetTime(event_time - desired_dt);
 
   // Step to the event time.
   integrator->IntegrateNoFurtherThanTime(
@@ -1889,7 +1889,7 @@ GTEST_TEST(SimulatorTest, StretchedStepPerfectStorm) {
   integrator->set_target_accuracy(accuracy);
 
   // Set initial condition using the Simulator's internal Context.
-  simulator.get_mutable_context().set_time(0);
+  simulator.get_mutable_context().SetTime(0);
   spring_mass.set_position(&simulator.get_mutable_context(), 0.1);
   spring_mass.set_velocity(&simulator.get_mutable_context(), 0);
 
@@ -1901,7 +1901,7 @@ GTEST_TEST(SimulatorTest, StretchedStepPerfectStorm) {
   // Now disable exceptions on violating the minimum step size and step again.
   // Since we are changing the state between successive StepTo(.) calls, it is
   // wise to call Initialize() prior to the second call.
-  simulator.get_mutable_context().set_time(0);
+  simulator.get_mutable_context().SetTime(0);
   spring_mass.set_position(&simulator.get_mutable_context(), 0.1);
   spring_mass.set_velocity(&simulator.get_mutable_context(), 0);
   integrator->set_throw_on_minimum_step_size_violation(false);

--- a/systems/analysis/test_utilities/explicit_error_controlled_integrator_test.h
+++ b/systems/analysis/test_utilities/explicit_error_controlled_integrator_test.h
@@ -44,7 +44,7 @@ TYPED_TEST_P(ExplicitErrorControlledIntegratorTest, ReqInitialStepTarget) {
 }
 
 TYPED_TEST_P(ExplicitErrorControlledIntegratorTest, ContextAccess) {
-  this->integrator->get_mutable_context()->set_time(3.);
+  this->integrator->get_mutable_context()->SetTime(3.);
   EXPECT_EQ(this->integrator->get_context().get_time(), 3.);
   EXPECT_EQ(this->context->get_time(), 3.);
 }
@@ -61,7 +61,7 @@ TYPED_TEST_P(ExplicitErrorControlledIntegratorTest, ErrorEstSupport) {
 // Verifies that the stepping works with relatively small
 // magnitude step sizes.
 TYPED_TEST_P(ExplicitErrorControlledIntegratorTest, MagDisparity) {
-  this->context->set_time(0.0);
+  this->context->SetTime(0.0);
 
   // Set integrator parameters.
   this->integrator->set_maximum_step_size(0.1);
@@ -270,7 +270,7 @@ TYPED_TEST_P(ExplicitErrorControlledIntegratorTest, SpringMassStepEC) {
   this->integrator->Initialize();
 
   // Set initial conditions.
-  this->integrator->get_mutable_context()->set_time(0.);
+  this->integrator->get_mutable_context()->SetTime(0.);
   this->spring_mass->set_position(this->integrator->get_mutable_context(),
                              initial_position);
   this->spring_mass->set_velocity(this->integrator->get_mutable_context(),

--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -67,6 +67,7 @@ class Context : public ContextBase {
   //@{
 
   /// Returns the current time in seconds.
+  /// @see SetTime()
   const T& get_time() const { return get_step_info().time_sec; }
 
   /// Returns a const reference to the whole State.
@@ -76,39 +77,44 @@ class Context : public ContextBase {
 
   /// Returns true if the Context has no state.
   bool is_stateless() const {
-    const int nxc = get_continuous_state().size();
-    const int nxd = get_num_discrete_state_groups();
-    const int nxa = get_num_abstract_states();
+    const int nxc = num_continuous_states();
+    const int nxd = num_discrete_state_groups();
+    const int nxa = num_abstract_states();
     return nxc == 0 && nxd == 0 && nxa == 0;
   }
 
   /// Returns true if the Context has continuous state, but no discrete or
   /// abstract state.
   bool has_only_continuous_state() const {
-    const int nxc = get_continuous_state().size();
-    const int nxd = get_num_discrete_state_groups();
-    const int nxa = get_num_abstract_states();
+    const int nxc = num_continuous_states();
+    const int nxd = num_discrete_state_groups();
+    const int nxa = num_abstract_states();
     return nxc > 0 && nxd == 0 && nxa == 0;
   }
 
   /// Returns true if the Context has discrete state, but no continuous or
   /// abstract state.
   bool has_only_discrete_state() const {
-    const int nxc = get_continuous_state().size();
-    const int nxd = get_num_discrete_state_groups();
-    const int nxa = get_num_abstract_states();
+    const int nxc = num_continuous_states();
+    const int nxd = num_discrete_state_groups();
+    const int nxa = num_abstract_states();
     return nxd > 0 && nxc == 0 && nxa == 0;
   }
 
   /// Returns the total dimension of all of the basic vector states (as if they
   /// were muxed).
   /// @throws std::runtime_error if the system contains any abstract state.
-  int get_num_total_states() const {
-    DRAKE_THROW_UNLESS(get_num_abstract_states() == 0);
-    int count = get_continuous_state().size();
-    for (int i = 0; i < get_num_discrete_state_groups(); i++)
+  int num_total_states() const {
+    DRAKE_THROW_UNLESS(num_abstract_states() == 0);
+    int count = num_continuous_states();
+    for (int i = 0; i < num_discrete_state_groups(); i++)
       count += get_discrete_state(i).size();
     return count;
+  }
+
+  /// Returns the number of continuous state variables `xc = {q, v, z}`.
+  int num_continuous_states() const {
+    return get_continuous_state().size();
   }
 
   /// Returns a const reference to the continuous component of the state,
@@ -124,7 +130,7 @@ class Context : public ContextBase {
   }
 
   /// Returns the number of vectors (groups) in the discrete state.
-  int get_num_discrete_state_groups() const {
+  int num_discrete_state_groups() const {
     return get_state().get_discrete_state().num_groups();
   }
 
@@ -150,7 +156,7 @@ class Context : public ContextBase {
   }
 
   /// Returns the number of elements in the abstract state.
-  int get_num_abstract_states() const {
+  int num_abstract_states() const {
     return get_state().get_abstract_state().size();
   }
 
@@ -172,7 +178,7 @@ class Context : public ContextBase {
 
   /// Returns the accuracy setting (if any). Note that the return type is
   /// `optional<double>` rather than the double value itself.
-  /// @see set_accuracy() for details.
+  /// @see SetAccuracy() for details.
   const optional<double>& get_accuracy() const { return accuracy_; }
 
   /// Returns a const reference to this %Context's parameters.
@@ -199,8 +205,18 @@ class Context : public ContextBase {
   const AbstractValue& get_abstract_parameter(int index) const {
     return get_parameters().get_abstract_parameter(index);
   }
+
+#ifndef DRAKE_DOXYGEN_CXX
+  // These are to-be-deprecated. Use methods without the initial get_.
+  int get_num_discrete_state_groups() const {
+    return num_discrete_state_groups();
+  }
+  int get_num_abstract_states() const { return num_abstract_states(); }
+  int get_num_total_states() const { return num_total_states(); }
+#endif
   //@}
-  /** @anchor context_value_change_methods */
+
+  /// @anchor context_value_change_methods
   /// @name           Methods for changing locally-stored values
   /// Methods in this group allow changes to the values of quantities stored
   /// locally in this %Context. The changeable quantities are:
@@ -301,6 +317,9 @@ class Context : public ContextBase {
   /// sweep to occur. Instead, request the mutable reference again when
   /// you need it so that the necessary notification sweep can be performed.
   ///
+  /// The dangerous methods are segregated into their own
+  /// @ref dangerous_context_value_change_methods "documentation group".
+  ///
   /// <h4>Advanced context-modifying methods</h4>
   /// Specialized methods are provided for expert users implementing
   /// integrators and other state-modifying solvers. Those are segregated to
@@ -320,9 +339,6 @@ class Context : public ContextBase {
   /// notifications.
   //@{
 
-  // TODO(sherm1) All these methods perform invalidation sweeps so aren't
-  // entitled to lower_case_names. Deprecate and replace (see #9205).
-
   // TODO(sherm1) Consider whether this should avoid the notification sweep
   // if the new time is the same as the old time.
   /// Sets the current time in seconds. Sends out of date notifications for all
@@ -330,38 +346,10 @@ class Context : public ContextBase {
   /// Time must have the same value in every subcontext within the same Diagram
   /// context tree so may only be modified at the root context of the tree.
   /// @throws std::logic_error if this is not the root context.
-  void set_time(const T& time_sec) {
+  void SetTime(const T& time_sec) {
     ThrowIfNotRootContext(__func__, "Time");
     const int64_t change_event = this->start_new_change_event();
     PropagateTimeChange(this, time_sec, change_event);
-  }
-
-  /// Returns a mutable reference to the whole State, potentially invalidating
-  /// _all_ state-dependent computations so requiring out of date notifications
-  /// to be made for all such computations. If you don't mean to change the
-  /// whole state, use more focused methods to modify only a portion of the
-  /// state. See class documentation for more information.
-  State<T>& get_mutable_state() {
-    const int64_t change_event = this->start_new_change_event();
-    PropagateBulkChange(change_event, &Context<T>::NoteAllStateChanged);
-    return do_access_mutable_state();
-  }
-
-  /// Returns a mutable reference to the continuous component of the state,
-  /// which may be of size zero. Sends out of date notifications for all
-  /// continuous-state-dependent computations.
-  ContinuousState<T>& get_mutable_continuous_state() {
-    const int64_t change_event = this->start_new_change_event();
-    PropagateBulkChange(change_event,
-                        &Context<T>::NoteAllContinuousStateChanged);
-    return do_access_mutable_state().get_mutable_continuous_state();
-  }
-
-  /// Returns a mutable reference to the continuous state vector, devoid
-  /// of second-order structure. The vector may be of size zero. Sends out of
-  /// date notifications for all continuous-state-dependent computations.
-  VectorBase<T>& get_mutable_continuous_state_vector() {
-    return get_mutable_continuous_state().get_mutable_vector();
   }
 
   // TODO(sherm1) Add more-specific state "set" methods for smaller
@@ -396,11 +384,11 @@ class Context : public ContextBase {
   /// method if you have multiple discrete state groups.
   /// @pre There is exactly one discrete state group.
   void SetDiscreteState(const Eigen::Ref<const VectorX<T>>& xd) {
-    if (get_num_discrete_state_groups() != 1) {
+    if (num_discrete_state_groups() != 1) {
       throw std::logic_error(fmt::format(
           "Context::SetDiscreteState(): expected exactly 1 discrete state "
           "group but there were {} groups. Use the other signature if "
-          "you have multiple groups.", get_num_discrete_state_groups()));
+          "you have multiple groups.", num_discrete_state_groups()));
     }
     SetDiscreteState(DiscreteStateIndex(0), xd);
   }
@@ -418,36 +406,6 @@ class Context : public ContextBase {
         .SetFromVector(xd);
   }
 
-  /// Returns a mutable reference to the discrete component of the state,
-  /// which may be of size zero. Sends out of date notifications for all
-  /// discrete-state-dependent computations.
-  DiscreteValues<T>& get_mutable_discrete_state() {
-    const int64_t change_event = this->start_new_change_event();
-    PropagateBulkChange(change_event,
-                        &Context<T>::NoteAllDiscreteStateChanged);
-    return do_access_mutable_state().get_mutable_discrete_state();
-  }
-
-  /// Returns a mutable reference to the _only_ discrete state vector.
-  /// Sends out of date notifications for all discrete-state-dependent
-  /// computations.
-  /// @sa get_discrete_state_vector().
-  /// @pre There is only one discrete state group.
-  BasicVector<T>& get_mutable_discrete_state_vector() {
-    return get_mutable_discrete_state().get_mutable_vector();
-  }
-
-  // TODO(sherm1) Invalidate only dependents of this one discrete group.
-  /// Returns a mutable reference to group (vector) @p index of the discrete
-  /// state. Sends out of date notifications for all computations that depend
-  /// on this discrete state group.
-  /// @pre @p index must identify an existing group.
-  /// @note Currently notifies dependents of _all_ groups.
-  BasicVector<T>& get_mutable_discrete_state(int index) {
-    DiscreteValues<T>& xd = get_mutable_discrete_state();
-    return xd.get_mutable_vector(index);
-  }
-
   // TODO(sherm1) Invalidate only dependents of this one abstract variable.
   /// Sets the value of the abstract state variable selected by @p index. Sends
   /// out of date notifications for all computations that depend on that
@@ -460,66 +418,6 @@ class Context : public ContextBase {
   template <typename ValueType>
   void SetAbstractState(int index, const ValueType& value) {
     get_mutable_abstract_state<ValueType>(index) = value;
-  }
-
-  /// Returns a mutable reference to the abstract component of the state,
-  /// which may be of size zero. Sends out of date notifications for all
-  /// abstract-state-dependent computations.
-  AbstractValues& get_mutable_abstract_state() {
-    const int64_t change_event = this->start_new_change_event();
-    PropagateBulkChange(change_event,
-                        &Context<T>::NoteAllAbstractStateChanged);
-    return do_access_mutable_state().get_mutable_abstract_state();
-  }
-
-  // TODO(sherm1) Invalidate only dependents of this one abstract variable.
-  /// Returns a mutable reference to element @p index of the abstract state.
-  /// Sends out of date notifications for all computations that depend on this
-  /// abstract state variable.
-  /// @pre @p index must identify an existing element.
-  /// @pre the abstract state's type must match the template argument.
-  /// @note Currently notifies dependents of _any_ abstract state variable.
-  template <typename U>
-  U& get_mutable_abstract_state(int index) {
-    AbstractValues& xa = get_mutable_abstract_state();
-    return xa.get_mutable_value(index).get_mutable_value<U>();
-  }
-
-  /// Returns a mutable reference to this %Context's parameters. Sends out of
-  /// date notifications for all parameter-dependent computations. If you don't
-  /// mean to change all the parameters, use the indexed methods to modify only
-  /// some of the parameters so that fewer computations are invalidated and
-  /// fewer notifications need be sent.
-  Parameters<T>& get_mutable_parameters() {
-    const int64_t change_event = this->start_new_change_event();
-    PropagateBulkChange(change_event, &Context<T>::NoteAllParametersChanged);
-    return *parameters_;
-  }
-
-  // TODO(sherm1) Invalidate only dependents of this one parameter.
-  /// Returns a mutable reference to element @p index of the vector-valued
-  /// (numeric) parameters. Sends out of date notifications for all computations
-  /// dependent on this parameter.
-  /// @pre @p index must identify an existing numeric parameter.
-  /// @note Currently notifies dependents of _all_ numeric parameters.
-  BasicVector<T>& get_mutable_numeric_parameter(int index) {
-    const int64_t change_event = this->start_new_change_event();
-    PropagateBulkChange(change_event,
-                        &Context<T>::NoteAllNumericParametersChanged);
-    return parameters_->get_mutable_numeric_parameter(index);
-  }
-
-  // TODO(sherm1) Invalidate only dependents of this one parameter.
-  /// Returns a mutable reference to element @p index of the abstract-valued
-  /// parameters. Sends out of date notifications for all computations dependent
-  /// on this parameter.
-  /// @pre @p index must identify an existing abstract parameter.
-  /// @note Currently notifies dependents of _all_ abstract parameters.
-  AbstractValue& get_mutable_abstract_parameter(int index) {
-    const int64_t change_event = this->start_new_change_event();
-    PropagateBulkChange(change_event,
-                        &Context<T>::NoteAllAbstractParametersChanged);
-    return parameters_->get_mutable_abstract_parameter(index);
   }
 
   // TODO(sherm1) Should treat fixed input port values same as parameters.
@@ -642,14 +540,153 @@ class Context : public ContextBase {
   /// The common thread among these examples is that they all share the
   /// same %Context, so by keeping accuracy here it can be used effectively to
   /// control all accuracy-dependent computations.
-  void set_accuracy(const optional<double>& accuracy) {
+  void SetAccuracy(const optional<double>& accuracy) {
     ThrowIfNotRootContext(__func__, "Accuracy");
     const int64_t change_event = this->start_new_change_event();
     PropagateAccuracyChange(this, accuracy, change_event);
   }
+
+#ifndef DRAKE_DOXYGEN_CXX
+  // These are to-be-deprecated. Use SetTime() and SetAccuracy() instead.
+  void set_time(const T& time_sec) { SetTime(time_sec); }
+  void set_accuracy(const optional<double>& accuracy) { SetAccuracy(accuracy); }
+#endif
   //@}
 
-  /** @anchor advanced_context_value_change_methods */
+  /// @anchor dangerous_context_value_change_methods
+  /// @name    Dangerous methods for changing locally-stored values
+  /// Methods in this group return mutable references into the state and
+  /// parameters in the %Context. Although they do issue out-of-date
+  /// notifications when invoked, so you can safely write to the reference
+  /// _once_, there is no way to issue notifications if you make subsequent
+  /// changes. So you _must not_ hold these references for writing. See
+  /// @ref dangerous_get_mutable "Dangerous GetMutable methods"
+  /// for more information.
+  //@{
+
+  // TODO(sherm1) All these methods perform invalidation sweeps so aren't
+  // entitled to lower_case_names. Deprecate and replace (see #9205).
+
+  /// Returns a mutable reference to the whole State, potentially invalidating
+  /// _all_ state-dependent computations so requiring out of date notifications
+  /// to be made for all such computations. If you don't mean to change the
+  /// whole state, use more focused methods to modify only a portion of the
+  /// state. See class documentation for more information.
+  State<T>& get_mutable_state() {
+    const int64_t change_event = this->start_new_change_event();
+    PropagateBulkChange(change_event, &Context<T>::NoteAllStateChanged);
+    return do_access_mutable_state();
+  }
+
+  /// Returns a mutable reference to the continuous component of the state,
+  /// which may be of size zero. Sends out of date notifications for all
+  /// continuous-state-dependent computations.
+  ContinuousState<T>& get_mutable_continuous_state() {
+    const int64_t change_event = this->start_new_change_event();
+    PropagateBulkChange(change_event,
+                        &Context<T>::NoteAllContinuousStateChanged);
+    return do_access_mutable_state().get_mutable_continuous_state();
+  }
+
+  /// Returns a mutable reference to the continuous state vector, devoid
+  /// of second-order structure. The vector may be of size zero. Sends out of
+  /// date notifications for all continuous-state-dependent computations.
+  VectorBase<T>& get_mutable_continuous_state_vector() {
+    return get_mutable_continuous_state().get_mutable_vector();
+  }
+
+  /// Returns a mutable reference to the discrete component of the state,
+  /// which may be of size zero. Sends out of date notifications for all
+  /// discrete-state-dependent computations.
+  DiscreteValues<T>& get_mutable_discrete_state() {
+    const int64_t change_event = this->start_new_change_event();
+    PropagateBulkChange(change_event,
+                        &Context<T>::NoteAllDiscreteStateChanged);
+    return do_access_mutable_state().get_mutable_discrete_state();
+  }
+
+  /// Returns a mutable reference to the _only_ discrete state vector.
+  /// Sends out of date notifications for all discrete-state-dependent
+  /// computations.
+  /// @sa get_discrete_state_vector().
+  /// @pre There is only one discrete state group.
+  BasicVector<T>& get_mutable_discrete_state_vector() {
+    return get_mutable_discrete_state().get_mutable_vector();
+  }
+
+  // TODO(sherm1) Invalidate only dependents of this one discrete group.
+  /// Returns a mutable reference to group (vector) @p index of the discrete
+  /// state. Sends out of date notifications for all computations that depend
+  /// on this discrete state group.
+  /// @pre @p index must identify an existing group.
+  /// @note Currently notifies dependents of _all_ groups.
+  BasicVector<T>& get_mutable_discrete_state(int index) {
+    DiscreteValues<T>& xd = get_mutable_discrete_state();
+    return xd.get_mutable_vector(index);
+  }
+
+  /// Returns a mutable reference to the abstract component of the state,
+  /// which may be of size zero. Sends out of date notifications for all
+  /// abstract-state-dependent computations.
+  AbstractValues& get_mutable_abstract_state() {
+    const int64_t change_event = this->start_new_change_event();
+    PropagateBulkChange(change_event,
+                        &Context<T>::NoteAllAbstractStateChanged);
+    return do_access_mutable_state().get_mutable_abstract_state();
+  }
+
+  // TODO(sherm1) Invalidate only dependents of this one abstract variable.
+  /// Returns a mutable reference to element @p index of the abstract state.
+  /// Sends out of date notifications for all computations that depend on this
+  /// abstract state variable.
+  /// @pre @p index must identify an existing element.
+  /// @pre the abstract state's type must match the template argument.
+  /// @note Currently notifies dependents of _any_ abstract state variable.
+  template <typename U>
+  U& get_mutable_abstract_state(int index) {
+    AbstractValues& xa = get_mutable_abstract_state();
+    return xa.get_mutable_value(index).get_mutable_value<U>();
+  }
+
+  /// Returns a mutable reference to this %Context's parameters. Sends out of
+  /// date notifications for all parameter-dependent computations. If you don't
+  /// mean to change all the parameters, use the indexed methods to modify only
+  /// some of the parameters so that fewer computations are invalidated and
+  /// fewer notifications need be sent.
+  Parameters<T>& get_mutable_parameters() {
+    const int64_t change_event = this->start_new_change_event();
+    PropagateBulkChange(change_event, &Context<T>::NoteAllParametersChanged);
+    return *parameters_;
+  }
+
+  // TODO(sherm1) Invalidate only dependents of this one parameter.
+  /// Returns a mutable reference to element @p index of the vector-valued
+  /// (numeric) parameters. Sends out of date notifications for all computations
+  /// dependent on this parameter.
+  /// @pre @p index must identify an existing numeric parameter.
+  /// @note Currently notifies dependents of _all_ numeric parameters.
+  BasicVector<T>& get_mutable_numeric_parameter(int index) {
+    const int64_t change_event = this->start_new_change_event();
+    PropagateBulkChange(change_event,
+                        &Context<T>::NoteAllNumericParametersChanged);
+    return parameters_->get_mutable_numeric_parameter(index);
+  }
+
+  // TODO(sherm1) Invalidate only dependents of this one parameter.
+  /// Returns a mutable reference to element @p index of the abstract-valued
+  /// parameters. Sends out of date notifications for all computations dependent
+  /// on this parameter.
+  /// @pre @p index must identify an existing abstract parameter.
+  /// @note Currently notifies dependents of _all_ abstract parameters.
+  AbstractValue& get_mutable_abstract_parameter(int index) {
+    const int64_t change_event = this->start_new_change_event();
+    PropagateBulkChange(change_event,
+                        &Context<T>::NoteAllAbstractParametersChanged);
+    return parameters_->get_mutable_abstract_parameter(index);
+  }
+  //@}
+
+  /// @anchor advanced_context_value_change_methods
   /// @name    Advanced methods for changing locally-stored values
   /// Methods in this group are specialized for expert users writing numerical
   /// integrators and other context-modifying solvers where careful cache

--- a/systems/framework/context_base.cc
+++ b/systems/framework/context_base.cc
@@ -50,7 +50,7 @@ void ContextBase::AddInputPort(
     InputPortIndex expected_index, DependencyTicket ticket,
     std::function<void(const AbstractValue&)> fixed_input_type_checker) {
   DRAKE_DEMAND(expected_index.is_valid() && ticket.is_valid());
-  DRAKE_DEMAND(expected_index == get_num_input_ports());
+  DRAKE_DEMAND(expected_index == num_input_ports());
   DRAKE_DEMAND(input_port_tickets_.size() == input_port_values_.size());
   DRAKE_DEMAND(input_port_tickets_.size() == input_port_type_checkers_.size());
   if (!fixed_input_type_checker) {
@@ -70,7 +70,7 @@ void ContextBase::AddOutputPort(
     OutputPortIndex expected_index, DependencyTicket ticket,
     const internal::OutputPortPrerequisite& prerequisite) {
   DRAKE_DEMAND(expected_index.is_valid() && ticket.is_valid());
-  DRAKE_DEMAND(expected_index == get_num_output_ports());
+  DRAKE_DEMAND(expected_index == num_output_ports());
   auto& yi_tracker = graph_.CreateNewDependencyTracker(
       ticket, "y_" + std::to_string(expected_index));
   output_port_tickets_.push_back(ticket);
@@ -87,7 +87,7 @@ void ContextBase::AddOutputPort(
 void ContextBase::SetFixedInputPortValue(
     InputPortIndex index,
     std::unique_ptr<FixedInputPortValue> port_value) {
-  DRAKE_DEMAND(0 <= index && index < get_num_input_ports());
+  DRAKE_DEMAND(0 <= index && index < num_input_ports());
   DRAKE_DEMAND(port_value != nullptr);
 
   // Fail-fast if the user supplied the wrong type or size.

--- a/systems/framework/context_base.h
+++ b/systems/framework/context_base.h
@@ -147,25 +147,25 @@ class ContextBase : public internal::ContextMessageInterface {
   }
 
   /** Returns the number of input ports in this context. */
-  int get_num_input_ports() const {
+  int num_input_ports() const {
     DRAKE_ASSERT(input_port_tickets_.size() == input_port_values_.size());
     return static_cast<int>(input_port_tickets_.size());
   }
 
   /** Returns the number of output ports represented in this context. */
-  int get_num_output_ports() const {
+  int num_output_ports() const {
     return static_cast<int>(output_port_tickets_.size());
   }
 
   /** Returns the dependency ticket associated with a particular input port. */
   DependencyTicket input_port_ticket(InputPortIndex port_num) {
-    DRAKE_DEMAND(port_num < get_num_input_ports());
+    DRAKE_DEMAND(port_num < num_input_ports());
     return input_port_tickets_[port_num];
   }
 
   /** Returns the dependency ticket associated with a particular output port. */
   DependencyTicket output_port_ticket(OutputPortIndex port_num) {
-    DRAKE_DEMAND(port_num < get_num_output_ports());
+    DRAKE_DEMAND(port_num < num_output_ports());
     return output_port_tickets_[port_num];
   }
 
@@ -209,7 +209,7 @@ class ContextBase : public internal::ContextMessageInterface {
   fixed, otherwise nullptr.
   @pre `index` selects an existing input port of this Context. */
   const FixedInputPortValue* MaybeGetFixedInputPortValue(int index) const {
-    DRAKE_DEMAND(0 <= index && index < get_num_input_ports());
+    DRAKE_DEMAND(0 <= index && index < num_input_ports());
     return input_port_values_[index].get();
   }
 
@@ -217,7 +217,7 @@ class ContextBase : public internal::ContextMessageInterface {
   is fixed, otherwise nullptr.
   @pre `index` selects an existing input port of this Context. */
   FixedInputPortValue* MaybeGetMutableFixedInputPortValue(int index) {
-    DRAKE_DEMAND(0 <= index && index < get_num_input_ports());
+    DRAKE_DEMAND(0 <= index && index < num_input_ports());
     return input_port_values_[index].get_mutable();
   }
 
@@ -236,6 +236,12 @@ class ContextBase : public internal::ContextMessageInterface {
     DRAKE_ASSERT(context->current_change_event_ >= 0);
     return ++context->current_change_event_;
   }
+
+#ifndef DRAKE_DOXYGEN_CXX
+  // These are to-be-deprecated. Use methods without the initial get_.
+  int get_num_input_ports() const { return num_input_ports(); }
+  int get_num_output_ports() const { return num_output_ports(); }
+#endif
 
  protected:
   /** Default constructor creates an empty ContextBase but initializes all the

--- a/systems/framework/diagram_builder.h
+++ b/systems/framework/diagram_builder.h
@@ -199,8 +199,8 @@ class DiagramBuilder {
   ///
   /// @exclude_from_pydrake_mkdoc{Not bound in pydrake.}
   void Connect(const System<T>& src, const System<T>& dest) {
-    DRAKE_THROW_UNLESS(src.get_num_output_ports() == 1);
-    DRAKE_THROW_UNLESS(dest.get_num_input_ports() == 1);
+    DRAKE_THROW_UNLESS(src.num_output_ports() == 1);
+    DRAKE_THROW_UNLESS(dest.num_input_ports() == 1);
     Connect(src.get_output_port(0), dest.get_input_port(0));
   }
 

--- a/systems/framework/diagram_context.h
+++ b/systems/framework/diagram_context.h
@@ -167,7 +167,7 @@ class DiagramContext final : public Context<T> {
     const InputPortIndex subsystem_iport_index = subsystem_input_port.second;
     Context<T>& subcontext = GetMutableSubsystemContext(subsystem_index);
     DRAKE_DEMAND(0 <= subsystem_iport_index &&
-                 subsystem_iport_index < subcontext.get_num_input_ports());
+                 subsystem_iport_index < subcontext.num_input_ports());
 
     // Get this Diagram's input port that serves as the source.
     const DependencyTicket iport_ticket =
@@ -195,7 +195,7 @@ class DiagramContext final : public Context<T> {
     const OutputPortIndex subsystem_oport_index = subsystem_output_port.second;
     Context<T>& subcontext = GetMutableSubsystemContext(subsystem_index);
     DRAKE_DEMAND(0 <= subsystem_oport_index &&
-                 subsystem_oport_index < subcontext.get_num_output_ports());
+                 subsystem_oport_index < subcontext.num_output_ports());
 
     // Get the child subsystem's output port tracker that serves as the source.
     const DependencyTicket subcontext_oport_ticket =
@@ -227,14 +227,14 @@ class DiagramContext final : public Context<T> {
     const OutputPortIndex oport_index = output_port.second;
     Context<T>& oport_context = GetMutableSubsystemContext(oport_system_index);
     DRAKE_DEMAND(oport_index >= 0);
-    DRAKE_DEMAND(oport_index < oport_context.get_num_output_ports());
+    DRAKE_DEMAND(oport_index < oport_context.num_output_ports());
 
     // Identify and validate the destination input port.
     const SubsystemIndex iport_system_index = input_port.first;
     const InputPortIndex iport_index = input_port.second;
     Context<T>& iport_context = GetMutableSubsystemContext(iport_system_index);
     DRAKE_DEMAND(iport_index >= 0);
-    DRAKE_DEMAND(iport_index < iport_context.get_num_input_ports());
+    DRAKE_DEMAND(iport_index < iport_context.num_input_ports());
 
     // Dig out the dependency trackers for both ports so we can subscribe the
     // input port tracker to the output port tracker.
@@ -404,18 +404,18 @@ class DiagramContext final : public Context<T> {
 
     os << this->GetSystemPathname() << " Context (of a Diagram)\n";
     os << std::string(this->GetSystemPathname().size() + 24, '-') << "\n";
-    if (this->get_continuous_state().size())
-      os << this->get_continuous_state().size() << " total continuous states\n";
-    if (this->get_num_discrete_state_groups()) {
+    if (this->num_continuous_states())
+      os << this->num_continuous_states() << " total continuous states\n";
+    if (this->num_discrete_state_groups()) {
       int num_discrete_states = 0;
-      for (int i = 0; i < this->get_num_discrete_state_groups(); i++) {
+      for (int i = 0; i < this->num_discrete_state_groups(); i++) {
         num_discrete_states += this->get_discrete_state(i).size();
       }
       os << num_discrete_states << " total discrete states in "
-         << this->get_num_discrete_state_groups() << " groups\n";
+         << this->num_discrete_state_groups() << " groups\n";
     }
-    if (this->get_num_abstract_states())
-      os << this->get_num_abstract_states() << " total abstract states\n";
+    if (this->num_abstract_states())
+      os << this->num_abstract_states() << " total abstract states\n";
 
     if (this->num_numeric_parameter_groups()) {
       int num_numeric_parameters = 0;
@@ -432,8 +432,8 @@ class DiagramContext final : public Context<T> {
       const Context<T>& subcontext = this->GetSubsystemContext(i);
       // Only print this context if it has something useful to print.
       if (subcontext.get_continuous_state_vector().size() ||
-          subcontext.get_num_discrete_state_groups() ||
-          subcontext.get_num_abstract_states() ||
+          subcontext.num_discrete_state_groups() ||
+          subcontext.num_abstract_states() ||
           subcontext.num_numeric_parameter_groups() ||
           subcontext.num_abstract_parameters()) {
         os << "\n" << subcontext.to_string();

--- a/systems/framework/leaf_context.h
+++ b/systems/framework/leaf_context.h
@@ -117,19 +117,19 @@ class LeafContext : public Context<T> {
     os << std::string(this->GetSystemPathname().size() + 9, '-') << "\n";
     os << "Time: " << this->get_time() << "\n";
 
-    if (this->get_continuous_state().size() ||
-        this->get_num_discrete_state_groups() ||
-        this->get_num_abstract_states()) {
+    if (this->num_continuous_states() ||
+        this->num_discrete_state_groups() ||
+        this->num_abstract_states()) {
       os << "States:\n";
-      if (this->get_continuous_state().size()) {
-        os << "  " << this->get_continuous_state().size()
+      if (this->num_continuous_states()) {
+        os << "  " << this->num_continuous_states()
            << " continuous states\n";
         os << "    " << this->get_continuous_state_vector() << "\n";
       }
-      if (this->get_num_discrete_state_groups()) {
-        os << "  " << this->get_num_discrete_state_groups()
+      if (this->num_discrete_state_groups()) {
+        os << "  " << this->num_discrete_state_groups()
            << " discrete state groups with\n";
-        for (int i = 0; i < this->get_num_discrete_state_groups(); i++) {
+        for (int i = 0; i < this->num_discrete_state_groups(); i++) {
           os << "     " << this->get_discrete_state(i).size() << " states\n";
           os << "       " << this->get_discrete_state(i) << "\n";
         }

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -283,8 +283,8 @@ class LeafSystem : public System<T> {
 
     // Iterate all input-output pairs, populating the map with the "true" terms.
     std::multimap<int, int> pairs;
-    for (int u = 0; u < this->get_num_input_ports(); ++u) {
-      for (int v = 0; v < this->get_num_output_ports(); ++v) {
+    for (int u = 0; u < this->num_input_ports(); ++u) {
+      for (int v = 0; v < this->num_output_ports(); ++v) {
         // Ask our subclass whether it wants to directly express feedthrough.
         const optional<bool> overridden_feedthrough =
             DoHasDirectFeedthrough(u, v);
@@ -299,13 +299,6 @@ class LeafSystem : public System<T> {
     }
     return pairs;
   };
-
-  int get_num_continuous_states() const final {
-    int total = num_generalized_positions_ +
-                num_generalized_velocities_+
-                num_misc_continuous_states_;
-    return total;
-  }
 
  protected:
   // Promote so we don't need "this->" in defaults which show up in Doxygen.
@@ -455,7 +448,7 @@ class LeafSystem : public System<T> {
 
     // Append input ports to the label.
     *dot << "{";
-    for (int i = 0; i < this->get_num_input_ports(); ++i) {
+    for (int i = 0; i < this->num_input_ports(); ++i) {
       if (i != 0) *dot << "|";
       *dot << "<u" << i << ">" << this->get_input_port(i).get_name();
     }
@@ -463,7 +456,7 @@ class LeafSystem : public System<T> {
 
     // Append output ports to the label.
     *dot << " | {";
-    for (int i = 0; i < this->get_num_output_ports(); ++i) {
+    for (int i = 0; i < this->num_output_ports(); ++i) {
       if (i != 0) *dot << "|";
       *dot << "<y" << i << ">" << this->get_output_port(i).get_name();
     }
@@ -1520,7 +1513,7 @@ class LeafSystem : public System<T> {
       const BasicVector<T>& model_vector,
       optional<RandomDistribution> random_type = nullopt) {
     const int size = model_vector.size();
-    const int index = this->get_num_input_ports();
+    const int index = this->num_input_ports();
     model_input_values_.AddVectorModel(index, model_vector.Clone());
     MaybeDeclareVectorBaseInequalityConstraint(
         "input " + std::to_string(index), model_vector,
@@ -1542,7 +1535,7 @@ class LeafSystem : public System<T> {
   const InputPort<T>& DeclareAbstractInputPort(
       variant<std::string, UseDefaultName> name,
       const AbstractValue& model_value) {
-    const int next_index = this->get_num_input_ports();
+    const int next_index = this->num_input_ports();
     model_input_values_.AddModel(next_index, model_value.Clone());
     return this->DeclareInputPort(NextInputPortName(std::move(name)),
                                   kAbstractValued, 0 /* size */);
@@ -2292,6 +2285,13 @@ class LeafSystem : public System<T> {
   using SystemBase::NextInputPortName;
   using SystemBase::NextOutputPortName;
 
+  int do_get_num_continuous_states() const final {
+    int total = num_generalized_positions_ +
+        num_generalized_velocities_+
+        num_misc_continuous_states_;
+    return total;
+  }
+
   // Either clones the model_value, or else for vector ports allocates a
   // BasicVector, or else for abstract ports throws an exception.
   std::unique_ptr<AbstractValue> DoAllocateInput(
@@ -2480,7 +2480,7 @@ class LeafSystem : public System<T> {
       std::set<DependencyTicket> calc_prerequisites) {
     DRAKE_DEMAND(!calc_prerequisites.empty());
     // Create a cache entry for this output port.
-    const OutputPortIndex oport_index(this->get_num_output_ports());
+    const OutputPortIndex oport_index(this->num_output_ports());
     const CacheEntry& cache_entry = this->DeclareCacheEntry(
         "output port " + std::to_string(oport_index) + "(" + name + ") cache",
         std::move(allocator), std::move(calculator),

--- a/systems/framework/single_output_vector_source.h
+++ b/systems/framework/single_output_vector_source.h
@@ -94,8 +94,8 @@ class SingleOutputVectorSource : public LeafSystem<T> {
  private:
   // Confirms the single-output invariant when allocating the context.
   void DoValidateAllocatedLeafContext(const LeafContext<T>&) const final {
-    DRAKE_DEMAND(this->get_num_input_ports() == 0);
-    DRAKE_DEMAND(this->get_num_output_ports() == 1);
+    DRAKE_DEMAND(this->num_input_ports() == 0);
+    DRAKE_DEMAND(this->num_output_ports() == 1);
   }
 
   // Converts the parameters to Eigen::VectorBlock form, then delegates to

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -104,7 +104,7 @@ class System : public SystemBase {
       const InputPort<T>& input_port) const {
     DRAKE_THROW_UNLESS(input_port.get_data_type() == kVectorValued);
     const int index = input_port.get_index();
-    DRAKE_ASSERT(index >= 0 && index < get_num_input_ports());
+    DRAKE_ASSERT(index >= 0 && index < num_input_ports());
     DRAKE_ASSERT(get_input_port(index).get_data_type() == kVectorValued);
     std::unique_ptr<AbstractValue> value = DoAllocateInput(input_port);
     return value->get_value<BasicVector<T>>().Clone();
@@ -115,7 +115,7 @@ class System : public SystemBase {
   std::unique_ptr<AbstractValue> AllocateInputAbstract(
       const InputPort<T>& input_port) const {
     const int index = input_port.get_index();
-    DRAKE_ASSERT(index >= 0 && index < get_num_input_ports());
+    DRAKE_ASSERT(index >= 0 && index < num_input_ports());
     return DoAllocateInput(input_port);
   }
 
@@ -126,7 +126,7 @@ class System : public SystemBase {
   std::unique_ptr<SystemOutput<T>> AllocateOutput() const {
     // make_unique can't invoke this private constructor.
     auto output = std::unique_ptr<SystemOutput<T>>(new SystemOutput<T>());
-    for (int i = 0; i < this->get_num_output_ports(); ++i) {
+    for (int i = 0; i < this->num_output_ports(); ++i) {
       const OutputPort<T>& port = this->get_output_port(i);
       output->add_port(port.Allocate());
     }
@@ -175,15 +175,15 @@ class System : public SystemBase {
   void SetDefaultContext(Context<T>* context) const {
     // Set the default state, checking that the number of state variables does
     // not change.
-    const int n_xc = context->get_continuous_state().size();
-    const int n_xd = context->get_num_discrete_state_groups();
-    const int n_xa = context->get_num_abstract_states();
+    const int n_xc = context->num_continuous_states();
+    const int n_xd = context->num_discrete_state_groups();
+    const int n_xa = context->num_abstract_states();
 
     SetDefaultState(*context, &context->get_mutable_state());
 
-    DRAKE_DEMAND(n_xc == context->get_continuous_state().size());
-    DRAKE_DEMAND(n_xd == context->get_num_discrete_state_groups());
-    DRAKE_DEMAND(n_xa == context->get_num_abstract_states());
+    DRAKE_DEMAND(n_xc == context->num_continuous_states());
+    DRAKE_DEMAND(n_xd == context->num_discrete_state_groups());
+    DRAKE_DEMAND(n_xa == context->num_abstract_states());
 
     // Set the default parameters, checking that the number of parameters does
     // not change.
@@ -232,15 +232,15 @@ class System : public SystemBase {
   void SetRandomContext(Context<T>* context, RandomGenerator* generator) const {
     // Set the default state, checking that the number of state variables does
     // not change.
-    const int n_xc = context->get_continuous_state().size();
-    const int n_xd = context->get_num_discrete_state_groups();
-    const int n_xa = context->get_num_abstract_states();
+    const int n_xc = context->num_continuous_states();
+    const int n_xd = context->num_discrete_state_groups();
+    const int n_xa = context->num_abstract_states();
 
     SetRandomState(*context, &context->get_mutable_state(), generator);
 
-    DRAKE_DEMAND(n_xc == context->get_continuous_state().size());
-    DRAKE_DEMAND(n_xd == context->get_num_discrete_state_groups());
-    DRAKE_DEMAND(n_xa == context->get_num_abstract_states());
+    DRAKE_DEMAND(n_xc == context->num_continuous_states());
+    DRAKE_DEMAND(n_xd == context->num_discrete_state_groups());
+    DRAKE_DEMAND(n_xa == context->num_abstract_states());
 
     // Set the default parameters, checking that the number of parameters does
     // not change.
@@ -254,7 +254,7 @@ class System : public SystemBase {
   /// that this System requires, and binds it to the port, disconnecting any
   /// prior input. Does not assign any values to the fixed inputs.
   void AllocateFixedInputs(Context<T>* context) const {
-    for (InputPortIndex i(0); i < get_num_input_ports(); ++i) {
+    for (InputPortIndex i(0); i < num_input_ports(); ++i) {
       const InputPort<T>& port = get_input_port(i);
       if (port.get_data_type() == kVectorValued) {
         context->FixInputPort(port.get_index(), AllocateInputVector(port));
@@ -568,7 +568,7 @@ class System : public SystemBase {
   /// context (useful in case the number of constraints is dependent upon the
   /// current state (as might be the case with a system modeled using piecewise
   /// differential algebraic equations).
-  int get_num_constraint_equations(const Context<T>& context) const {
+  int num_constraint_equations(const Context<T>& context) const {
     return do_get_num_constraint_equations(context);
   }
 
@@ -577,7 +577,7 @@ class System : public SystemBase {
   /// allows the set of constraints to be dependent upon the current system
   /// state (as might be the case with a system modeled using piecewise
   /// differential algebraic equations).
-  /// @returns a vector of dimension get_num_constraint_equations(); the
+  /// @returns a vector of dimension num_constraint_equations(); the
   ///          zero vector indicates that the algebraic constraints are all
   ///          satisfied.
   Eigen::VectorXd EvalConstraintEquations(const Context<T>& context) const {
@@ -589,7 +589,7 @@ class System : public SystemBase {
   /// context. The context allows the set of constraints to be dependent upon
   /// the current system state (as might be the case with a system modeled using
   /// piecewise differential algebraic equations).
-  /// @returns a vector of dimension get_num_constraint_equations().
+  /// @returns a vector of dimension num_constraint_equations().
   Eigen::VectorXd EvalConstraintEquationsDot(const Context<T>& context) const {
     return DoEvalConstraintEquationsDot(context);
   }
@@ -618,8 +618,8 @@ class System : public SystemBase {
   Eigen::VectorXd CalcVelocityChangeFromConstraintImpulses(
       const Context<T>& context, const Eigen::MatrixXd& J,
       const Eigen::VectorXd& lambda) const {
-    DRAKE_ASSERT(lambda.size() == get_num_constraint_equations(context));
-    DRAKE_ASSERT(J.rows() == get_num_constraint_equations(context));
+    DRAKE_ASSERT(lambda.size() == num_constraint_equations(context));
+    DRAKE_ASSERT(J.rows() == num_constraint_equations(context));
     DRAKE_ASSERT(
         J.cols() ==
         context.get_continuous_state().get_generalized_velocity().size());
@@ -631,10 +631,10 @@ class System : public SystemBase {
   /// different state variable instances). This norm need be neither continuous
   /// nor differentiable.
   /// @throws std::logic_error if the dimension of @p err is not equivalent to
-  ///         the output of get_num_constraint_equations().
+  ///         the output of num_constraint_equations().
   double CalcConstraintErrorNorm(const Context<T>& context,
                                  const Eigen::VectorXd& error) const {
-    if (error.size() != get_num_constraint_equations(context))
+    if (error.size() != num_constraint_equations(context))
       throw std::logic_error("Error vector is mis-sized.");
     return DoCalcConstraintErrorNorm(context, error);
   }
@@ -871,7 +871,7 @@ class System : public SystemBase {
     DRAKE_DEMAND(outputs != nullptr);
     DRAKE_ASSERT_VOID(CheckValidContext(context));
     DRAKE_ASSERT_VOID(CheckValidOutput(outputs));
-    for (OutputPortIndex i(0); i < get_num_output_ports(); ++i) {
+    for (OutputPortIndex i(0); i < num_output_ports(); ++i) {
       // TODO(sherm1) Would be better to use Eval() here but we don't have
       // a generic abstract assignment capability that would allow us to
       // copy into existing memory in `outputs` (rather than clone). User
@@ -1088,9 +1088,9 @@ class System : public SystemBase {
                                            GetGraphvizId());
   }
 
-  // So we don't have to keep writing this->get_num_input_ports().
-  using SystemBase::get_num_input_ports;
-  using SystemBase::get_num_output_ports;
+  // So we don't have to keep writing this->num_input_ports().
+  using SystemBase::num_input_ports;
+  using SystemBase::num_output_ports;
 
   /// Returns the typed input port at index @p port_index.
   // TODO(sherm1) Make this an InputPortIndex.
@@ -1104,7 +1104,7 @@ class System : public SystemBase {
   /// get_input_port() when performance is a concern.
   /// @throws std::logic_error if port_name is not found.
   const InputPort<T>& GetInputPort(const std::string& port_name) const {
-    for (InputPortIndex i{0}; i < get_num_input_ports(); i++) {
+    for (InputPortIndex i{0}; i < num_input_ports(); i++) {
       if (port_name == get_input_port_base(i).get_name()) {
         return get_input_port(i);
       }
@@ -1126,7 +1126,7 @@ class System : public SystemBase {
   /// get_output_port() when performance is a concern.
   /// @throws std::logic_error if port_name is not found.
   const OutputPort<T>& GetOutputPort(const std::string& port_name) const {
-    for (OutputPortIndex i{0}; i < get_num_output_ports(); i++) {
+    for (OutputPortIndex i{0}; i < num_output_ports(); i++) {
       if (port_name == get_output_port_base(i).get_name()) {
         return get_output_port(i);
       }
@@ -1137,24 +1137,25 @@ class System : public SystemBase {
   }
 
   /// Returns the number of constraints specified for the system.
-  int get_num_constraints() const {
+  int num_constraints() const {
     return static_cast<int>(constraints_.size());
   }
 
-
   /// Returns the dimension of the continuous state vector that has been
   /// declared until now.
-  virtual int get_num_continuous_states() const = 0;
+  int num_continuous_states() const {
+    return do_get_num_continuous_states();
+  }
 
   /// Returns the constraint at index @p constraint_index.
   /// @throws std::out_of_range for an invalid constraint_index.
   const SystemConstraint<T>& get_constraint(
       SystemConstraintIndex constraint_index) const {
-    if (constraint_index < 0 || constraint_index >= get_num_constraints()) {
+    if (constraint_index < 0 || constraint_index >= num_constraints()) {
       throw std::out_of_range("System " + get_name() + ": Constraint index " +
                               std::to_string(constraint_index) +
                               " is out of range. There are only " +
-                              std::to_string(get_num_constraints()) +
+                              std::to_string(num_constraints()) +
                               " constraints.");
     }
     return *constraints_[constraint_index];
@@ -1190,10 +1191,10 @@ class System : public SystemBase {
 
     // Checks that the number of output ports in the system output is consistent
     // with the number of output ports declared by the System.
-    DRAKE_THROW_UNLESS(output->get_num_ports() == get_num_output_ports());
+    DRAKE_THROW_UNLESS(output->num_ports() == num_output_ports());
 
     // Checks the validity of each output port.
-    for (int i = 0; i < get_num_output_ports(); ++i) {
+    for (int i = 0; i < num_output_ports(); ++i) {
       // TODO(sherm1): consider adding (very expensive) validation of the
       // abstract ports also.
       if (get_output_port(i).get_data_type() == kVectorValued) {
@@ -1214,15 +1215,15 @@ class System : public SystemBase {
   void CheckValidContextT(const Context<T1>& context) const {
     // Checks that the number of input ports in the context is consistent with
     // the number of ports declared by the System.
-    DRAKE_THROW_UNLESS(context.get_num_input_ports() ==
-                       this->get_num_input_ports());
+    DRAKE_THROW_UNLESS(context.num_input_ports() ==
+                       this->num_input_ports());
 
-    DRAKE_THROW_UNLESS(context.get_num_output_ports() ==
-                       this->get_num_output_ports());
+    DRAKE_THROW_UNLESS(context.num_output_ports() ==
+                       this->num_output_ports());
 
     // Checks that the size of the fixed vector input ports in the context
     // matches the declarations made by the system.
-    for (InputPortIndex i(0); i < this->get_num_input_ports(); ++i) {
+    for (InputPortIndex i(0); i < this->num_input_ports(); ++i) {
       const FixedInputPortValue* port_value =
           context.MaybeGetFixedInputPortValue(i);
 
@@ -1444,7 +1445,7 @@ class System : public SystemBase {
     DRAKE_ASSERT_VOID(other_system.CheckValidContext(other_context));
     DRAKE_ASSERT_VOID(other_system.CheckValidContextT(*target_context));
 
-    for (int i = 0; i < get_num_input_ports(); ++i) {
+    for (int i = 0; i < num_input_ports(); ++i) {
       const auto& input_port = get_input_port(i);
       const auto& other_port = other_system.get_input_port(i);
       if (!other_port.HasValue(other_context)) {
@@ -1552,6 +1553,15 @@ class System : public SystemBase {
   using SystemBase::pnc_ticket;
 
   // Don't promote output_port_ticket() since it is for internal use only.
+
+#ifndef DRAKE_DOXYGEN_CXX
+  // These are to-be-deprecated. Use methods without the initial get_.
+  int get_num_continuous_states() const { return num_continuous_states(); }
+  int get_num_constraints() const { return num_constraints(); }
+  int get_num_constraint_equations(const Context<T>& context) const {
+    return num_constraint_equations(context);
+  }
+#endif
 
  protected:
   /// Derived classes will implement this method to evaluate a witness function
@@ -1720,7 +1730,7 @@ class System : public SystemBase {
   const InputPort<T>& DeclareInputPort(
       variant<std::string, UseDefaultName> name, PortDataType type, int size,
       optional<RandomDistribution> random_type = nullopt) {
-    const InputPortIndex port_index(get_num_input_ports());
+    const InputPortIndex port_index(num_input_ports());
 
     const DependencyTicket port_ticket(this->assign_next_dependency_ticket());
     auto eval = [this, port_index](const ContextBase& context_base) {
@@ -1995,12 +2005,15 @@ class System : public SystemBase {
   /// @name             Constraint-related functions (protected).
   //@{
 
+  /// Totals the number of continuous state variables in this System or Diagram.
+  virtual int do_get_num_continuous_states() const = 0;
+
   /// Gets the number of constraint equations for this system from the given
   /// context. The context is supplied in case the number of constraints is
   /// dependent upon the current state (as might be the case with a piecewise
   /// differential algebraic equation). Derived classes can override this
-  /// function, which is called by get_num_constraint_equations().
-  /// @sa get_num_constraint_equations() for parameter documentation.
+  /// function, which is called by num_constraint_equations().
+  /// @sa num_constraint_equations() for parameter documentation.
   /// @returns zero by default
   virtual int do_get_num_constraint_equations(const Context<T>& context) const {
     unused(context);
@@ -2015,12 +2028,12 @@ class System : public SystemBase {
   /// zero-dimensional vector. Derived classes can override this function,
   /// which is called by EvalConstraintEquations().
   /// @sa EvalConstraintEquations() for parameter documentation.
-  /// @returns a vector of dimension get_num_constraint_equations(); the
+  /// @returns a vector of dimension num_constraint_equations(); the
   ///          zero vector indicates that the algebraic constraints are all
   ///          satisfied.
   virtual Eigen::VectorXd DoEvalConstraintEquations(
       const Context<T>& context) const {
-    DRAKE_DEMAND(get_num_constraint_equations(context) == 0);
+    DRAKE_DEMAND(num_constraint_equations(context) == 0);
     return Eigen::VectorXd();
   }
 
@@ -2031,11 +2044,11 @@ class System : public SystemBase {
   /// differential algebraic equation). The default implementation of this
   /// function returns a zero-dimensional vector. Derived classes can override
   /// this function, which is called by EvalConstraintEquationsDot().
-  /// @returns a vector of dimension get_num_constraint_equations().
+  /// @returns a vector of dimension num_constraint_equations().
   /// @sa EvalConstraintEquationsDot() for parameter documentation.
   virtual Eigen::VectorXd DoEvalConstraintEquationsDot(
       const Context<T>& context) const {
-    DRAKE_DEMAND(get_num_constraint_equations(context) == 0);
+    DRAKE_DEMAND(num_constraint_equations(context) == 0);
     return Eigen::VectorXd();
   }
 
@@ -2050,7 +2063,7 @@ class System : public SystemBase {
       const Context<T>& context, const Eigen::MatrixXd& J,
       const Eigen::VectorXd& lambda) const {
     unused(J, lambda);
-    DRAKE_DEMAND(get_num_constraint_equations(context) == 0);
+    DRAKE_DEMAND(num_constraint_equations(context) == 0);
     const auto& gv = context.get_continuous_state().get_generalized_velocity();
     return Eigen::VectorXd::Zero(gv.size());
   }
@@ -2077,7 +2090,7 @@ class System : public SystemBase {
   /// may invalidate cache entries as a result.
   Eigen::VectorBlock<VectorX<T>> GetMutableOutputVector(SystemOutput<T>* output,
                                                         int port_index) const {
-    DRAKE_ASSERT(0 <= port_index && port_index < get_num_output_ports());
+    DRAKE_ASSERT(0 <= port_index && port_index < num_output_ports());
 
     BasicVector<T>* output_vector = output->GetMutableVectorData(port_index);
     DRAKE_ASSERT(output_vector != nullptr);

--- a/systems/framework/system_base.cc
+++ b/systems/framework/system_base.cc
@@ -164,7 +164,7 @@ void SystemBase::CreateSourceTrackers(ContextBase* context_ptr) const {
 const AbstractValue* SystemBase::EvalAbstractInputImpl(
     const char* func, const ContextBase& context,
     InputPortIndex port_index) const {
-  if (port_index >= get_num_input_ports())
+  if (port_index >= num_input_ports())
     ThrowInputPortIndexOutOfRange(func, port_index);
 
   const FixedInputPortValue* const free_port_value =
@@ -197,7 +197,7 @@ void SystemBase::ThrowInputPortIndexOutOfRange(const char* func,
   throw std::out_of_range(fmt::format(
       "{}: there is no input port with index {} because there "
       "are only {} input ports in system {}.",
-      FmtFunc(func),  port, get_num_input_ports(), GetSystemPathname()));
+      FmtFunc(func),  port, num_input_ports(), GetSystemPathname()));
 }
 
 void SystemBase::ThrowOutputPortIndexOutOfRange(const char* func,
@@ -206,7 +206,7 @@ void SystemBase::ThrowOutputPortIndexOutOfRange(const char* func,
       "{}: there is no output port with index {} because there "
       "are only {} output ports in system {}.",
       FmtFunc(func), port,
-      get_num_output_ports(), GetSystemPathname()));
+      num_output_ports(), GetSystemPathname()));
 }
 
 void SystemBase::ThrowNotAVectorInputPort(const char* func,

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -171,16 +171,17 @@ class SystemBase : public internal::SystemMessageInterface {
   //@}
 
   /** Returns the number of input ports currently allocated in this System.
-  These are indexed from 0 to %get_num_input_ports()-1. */
-  int get_num_input_ports() const {
+  These are indexed from 0 to %num_input_ports()-1. */
+  int num_input_ports() const {
     return static_cast<int>(input_ports_.size());
   }
 
   /** Returns the number of output ports currently allocated in this System.
-  These are indexed from 0 to %get_num_output_ports()-1. */
-  int get_num_output_ports() const {
+  These are indexed from 0 to %num_output_ports()-1. */
+  int num_output_ports() const {
     return static_cast<int>(output_ports_.size());
   }
+
 
   /** Returns a reference to an InputPort given its `port_index`.
   @pre `port_index` selects an existing input port of this System. */
@@ -196,7 +197,7 @@ class SystemBase : public internal::SystemMessageInterface {
 
   /** Returns the total dimension of all of the vector-valued input ports (as if
   they were muxed). */
-  int get_num_total_inputs() const {
+  int num_total_inputs() const {
     int count = 0;
     for (const auto& in : input_ports_) count += in->size();
     return count;
@@ -204,7 +205,7 @@ class SystemBase : public internal::SystemMessageInterface {
 
   /** Returns the total dimension of all of the vector-valued output ports (as
   if they were muxed). */
-  int get_num_total_outputs() const {
+  int num_total_outputs() const {
     int count = 0;
     for (const auto& out : output_ports_) count += out->size();
     return count;
@@ -615,7 +616,7 @@ class SystemBase : public internal::SystemMessageInterface {
   by `index`.
   @pre `index` selects an existing input port of this System. */
   DependencyTicket input_port_ticket(InputPortIndex index) {
-    DRAKE_DEMAND(0 <= index && index < get_num_input_ports());
+    DRAKE_DEMAND(0 <= index && index < num_input_ports());
     return input_ports_[index]->ticket();
   }
 
@@ -720,7 +721,7 @@ class SystemBase : public internal::SystemMessageInterface {
   meaningfully depend on that system's own output ports.
   @pre `index` selects an existing output port of this System. */
   DependencyTicket output_port_ticket(OutputPortIndex index) {
-    DRAKE_DEMAND(0 <= index && index < get_num_output_ports());
+    DRAKE_DEMAND(0 <= index && index < num_output_ports());
     return output_ports_[index]->ticket();
   }
 
@@ -747,6 +748,22 @@ class SystemBase : public internal::SystemMessageInterface {
   }
   //@}
 
+#ifndef DRAKE_DOXYGEN_CXX
+  // These are to-be-deprecated. Use methods without the initial get_.
+  int get_num_total_inputs() const {
+    return num_total_inputs();
+  }
+  int get_num_total_outputs() const {
+    return num_total_outputs();
+  }
+  int get_num_input_ports() const {
+    return num_input_ports();
+  }
+  int get_num_output_ports() const {
+    return num_output_ports();
+  }
+#endif
+
  protected:
   /** (Internal use only) Default constructor. */
   SystemBase() = default;
@@ -761,11 +778,11 @@ class SystemBase : public internal::SystemMessageInterface {
   void AddInputPort(std::unique_ptr<InputPortBase> port) {
     DRAKE_DEMAND(port != nullptr);
     DRAKE_DEMAND(&port->get_system_base() == this);
-    DRAKE_DEMAND(port->get_index() == get_num_input_ports());
+    DRAKE_DEMAND(port->get_index() == num_input_ports());
     DRAKE_DEMAND(!port->get_name().empty());
 
     // Check that name is unique.
-    for (InputPortIndex i{0}; i < get_num_input_ports(); i++) {
+    for (InputPortIndex i{0}; i < num_input_ports(); i++) {
       if (port->get_name() == get_input_port_base(i).get_name()) {
         throw std::logic_error("System " + GetSystemName() +
             " already has an input port named " +
@@ -786,11 +803,11 @@ class SystemBase : public internal::SystemMessageInterface {
   void AddOutputPort(std::unique_ptr<OutputPortBase> port) {
     DRAKE_DEMAND(port != nullptr);
     DRAKE_DEMAND(&port->get_system_base() == this);
-    DRAKE_DEMAND(port->get_index() == get_num_output_ports());
+    DRAKE_DEMAND(port->get_index() == num_output_ports());
     DRAKE_DEMAND(!port->get_name().empty());
 
     // Check that name is unique.
-    for (OutputPortIndex i{0}; i < get_num_output_ports(); i++) {
+    for (OutputPortIndex i{0}; i < num_output_ports(); i++) {
       if (port->get_name() == get_output_port_base(i).get_name()) {
         throw std::logic_error("System " + GetSystemName() +
                                " already has an output port named " +
@@ -809,7 +826,7 @@ class SystemBase : public internal::SystemMessageInterface {
       variant<std::string, UseDefaultName> given_name) const {
     const std::string result =
         given_name == kUseDefaultName
-           ? std::string("u") + std::to_string(get_num_input_ports())
+           ? std::string("u") + std::to_string(num_input_ports())
            : get<std::string>(std::move(given_name));
     DRAKE_DEMAND(!result.empty());
     return result;
@@ -823,7 +840,7 @@ class SystemBase : public internal::SystemMessageInterface {
       variant<std::string, UseDefaultName> given_name) const {
     const std::string result =
         given_name == kUseDefaultName
-           ? std::string("y") + std::to_string(get_num_output_ports())
+           ? std::string("y") + std::to_string(num_output_ports())
            : get<std::string>(std::move(given_name));
     DRAKE_DEMAND(!result.empty());
     return result;
@@ -980,7 +997,7 @@ class SystemBase : public internal::SystemMessageInterface {
     if (port_index < 0)
       ThrowNegativePortIndex(func, port_index);
     const InputPortIndex port(port_index);
-    if (port_index >= get_num_input_ports())
+    if (port_index >= num_input_ports())
       ThrowInputPortIndexOutOfRange(func, port);
     return *input_ports_[port];
   }
@@ -994,7 +1011,7 @@ class SystemBase : public internal::SystemMessageInterface {
     if (port_index < 0)
       ThrowNegativePortIndex(func, port_index);
     const OutputPortIndex port(port_index);
-    if (port_index >= get_num_output_ports())
+    if (port_index >= num_output_ports())
       ThrowOutputPortIndexOutOfRange(func, port);
     return *output_ports_[port_index];
   }

--- a/systems/framework/system_output.h
+++ b/systems/framework/system_output.h
@@ -36,7 +36,7 @@ class SystemOutput {
 
   /** Returns the number of output ports specified for this %SystemOutput
   during allocation. */
-  int get_num_ports() const { return static_cast<int>(port_values_.size()); }
+  int num_ports() const { return static_cast<int>(port_values_.size()); }
 
   // TODO(sherm1) All of these should return references. We don't need to
   // support missing entries.
@@ -44,7 +44,7 @@ class SystemOutput {
   /** Returns the last-saved value of output port `index` as an AbstractValue.
   This works for any output port regardless of it actual type. */
   const AbstractValue* get_data(int index) const {
-    DRAKE_ASSERT(0 <= index && index < get_num_ports());
+    DRAKE_ASSERT(0 <= index && index < num_ports());
     return port_values_[index].get();
   }
 
@@ -52,7 +52,7 @@ class SystemOutput {
   although the actual concrete type is preserved from the actual output port.
   @throws std::bad_cast if the port is not vector-valued. */
   const BasicVector<T>* get_vector_data(int index) const {
-    DRAKE_ASSERT(0 <= index && index < get_num_ports());
+    DRAKE_ASSERT(0 <= index && index < num_ports());
     return &port_values_[index]->template get_value<BasicVector<T>>();
   }
 
@@ -62,7 +62,7 @@ class SystemOutput {
   users should just call `System<T>::CalcOutputs()` to get all the output
   port values at once. */
   AbstractValue* GetMutableData(int index) {
-    DRAKE_ASSERT(0 <= index && index < get_num_ports());
+    DRAKE_ASSERT(0 <= index && index < num_ports());
     return port_values_[index].get_mutable();
   }
 
@@ -73,9 +73,14 @@ class SystemOutput {
   port values at once.
   @throws std::bad_cast if the port is not vector-valued. */
   BasicVector<T>* GetMutableVectorData(int index) {
-    DRAKE_ASSERT(0 <= index && index < get_num_ports());
+    DRAKE_ASSERT(0 <= index && index < num_ports());
     return &port_values_[index]->template get_mutable_value<BasicVector<T>>();
   }
+
+#ifndef DRAKE_DOXYGEN_CXX
+  // This is to-be-deprecated. Use num_ports() instead.
+  int get_num_ports() const { return num_ports(); }
+#endif
 
  private:
   friend class System<T>;

--- a/systems/framework/system_symbolic_inspector.cc
+++ b/systems/framework/system_symbolic_inspector.cc
@@ -15,14 +15,14 @@ using symbolic::Formula;
 SystemSymbolicInspector::SystemSymbolicInspector(
     const System<symbolic::Expression>& system)
     : context_(system.CreateDefaultContext()),
-      input_variables_(system.get_num_input_ports()),
-      continuous_state_variables_(context_->get_continuous_state().size()),
-      discrete_state_variables_(context_->get_num_discrete_state_groups()),
+      input_variables_(system.num_input_ports()),
+      continuous_state_variables_(context_->num_continuous_states()),
+      discrete_state_variables_(context_->num_discrete_state_groups()),
       numeric_parameters_(context_->num_numeric_parameter_groups()),
       output_(system.AllocateOutput()),
       derivatives_(system.AllocateTimeDerivatives()),
       discrete_updates_(system.AllocateDiscreteVariables()),
-      output_port_types_(system.get_num_output_ports()),
+      output_port_types_(system.num_output_ports()),
       context_is_abstract_(IsAbstract(system, *context_)) {
   // Stop analysis if the Context is in any way abstract, because we have no way
   // to initialize the abstract elements.
@@ -43,25 +43,25 @@ SystemSymbolicInspector::SystemSymbolicInspector(
   InitializeParameters();
 
   // Outputs.
-  for (int i = 0; i < system.get_num_output_ports(); ++i) {
+  for (int i = 0; i < system.num_output_ports(); ++i) {
     const OutputPort<symbolic::Expression>& port = system.get_output_port(i);
     output_port_types_[i] = port.get_data_type();
     port.Calc(*context_, output_->GetMutableData(i));
   }
 
   // Time derivatives.
-  if (context_->get_continuous_state().size() > 0) {
+  if (context_->num_continuous_states() > 0) {
     system.CalcTimeDerivatives(*context_, derivatives_.get());
   }
 
   // Discrete updates.
-  if (context_->get_num_discrete_state_groups() > 0) {
+  if (context_->num_discrete_state_groups() > 0) {
     system.CalcDiscreteVariableUpdates(*context_, discrete_updates_.get());
   }
 
   // Constraints.
   // TODO(russt): Maintain constraint descriptions.
-  for (int i = 0; i < system.get_num_constraints(); i++) {
+  for (int i = 0; i < system.num_constraints(); i++) {
     const SystemConstraint<Expression>& constraint =
         system.get_constraint(SystemConstraintIndex(i));
     const double tol = 0.0;
@@ -73,7 +73,7 @@ void SystemSymbolicInspector::InitializeVectorInputs(
     const System<symbolic::Expression>& system) {
   // For each input vector i, set each element j to a symbolic expression whose
   // value is the variable "ui_j".
-  for (int i = 0; i < system.get_num_input_ports(); ++i) {
+  for (int i = 0; i < system.num_input_ports(); ++i) {
     DRAKE_ASSERT(system.get_input_port(i).get_data_type() == kVectorValued);
     const int n = system.get_input_port(i).size();
     input_variables_[i].resize(n);
@@ -105,7 +105,7 @@ void SystemSymbolicInspector::InitializeDiscreteState() {
   // For each discrete state vector i, set each element j to a symbolic
   // expression whose value is the variable "xdi_j".
   auto& xd = context_->get_mutable_discrete_state();
-  for (int i = 0; i < context_->get_num_discrete_state_groups(); ++i) {
+  for (int i = 0; i < context_->num_discrete_state_groups(); ++i) {
     auto& xdi = xd.get_mutable_vector(i);
     discrete_state_variables_[i].resize(xdi.size());
     for (int j = 0; j < xdi.size(); ++j) {
@@ -137,7 +137,7 @@ bool SystemSymbolicInspector::IsAbstract(
     const Context<symbolic::Expression>& context) {
   // If any of the input ports are abstract, we cannot do sparsity analysis of
   // this Context.
-  for (int i = 0; i < system.get_num_input_ports(); ++i) {
+  for (int i = 0; i < system.num_input_ports(); ++i) {
     if (system.get_input_port(i).get_data_type() == kAbstractValued) {
       return true;
     }
@@ -145,7 +145,7 @@ bool SystemSymbolicInspector::IsAbstract(
 
   // If there is any abstract state or parameters, we cannot do sparsity
   // analysis of this Context.
-  if (context.get_num_abstract_states() > 0) {
+  if (context.num_abstract_states() > 0) {
     return true;
   }
   if (context.num_abstract_parameters() > 0) {
@@ -225,7 +225,7 @@ bool SystemSymbolicInspector::IsTimeInvariant() const {
       return false;
     }
   }
-  for (int i = 0; i < output_->get_num_ports(); ++i) {
+  for (int i = 0; i < output_->num_ports(); ++i) {
     if (output_port_types_[i] == kAbstractValued) {
       // Then I can't be sure.  Return the conservative answer.
       return false;

--- a/systems/framework/system_symbolic_inspector.h
+++ b/systems/framework/system_symbolic_inspector.h
@@ -113,7 +113,7 @@ class SystemSymbolicInspector {
   /// @param i The discrete state group number.
   Eigen::VectorBlock<const VectorX<symbolic::Expression>> discrete_update(
       int i) const {
-    DRAKE_DEMAND(i >= 0 && i < context_->get_num_discrete_state_groups());
+    DRAKE_DEMAND(i >= 0 && i < context_->num_discrete_state_groups());
     return discrete_updates_->get_vector(i).get_value();
   }
 

--- a/systems/framework/test/diagram_context_test.cc
+++ b/systems/framework/test/diagram_context_test.cc
@@ -111,7 +111,7 @@ class DiagramContextTest : public ::testing::Test {
     context_->MakeParameters();
     context_->SubscribeDiagramCompositeTrackersToChildrens();
 
-    context_->set_time(kTime);
+    context_->SetTime(kTime);
     ContinuousState<double>& xc = context_->get_mutable_continuous_state();
     xc.get_mutable_vector()[0] = 42.0;
     xc.get_mutable_vector()[1] = 43.0;
@@ -123,9 +123,9 @@ class DiagramContextTest : public ::testing::Test {
     context_->get_mutable_numeric_parameter(0)[1] = 77.0;
 
     // Sanity checks: tests below count on these dimensions.
-    EXPECT_EQ(context_->get_continuous_state().size(), 2);
-    EXPECT_EQ(context_->get_num_discrete_state_groups(), 1);
-    EXPECT_EQ(context_->get_num_abstract_states(), 1);
+    EXPECT_EQ(context_->num_continuous_states(), 2);
+    EXPECT_EQ(context_->num_discrete_state_groups(), 1);
+    EXPECT_EQ(context_->num_abstract_states(), 1);
     EXPECT_EQ(context_->num_numeric_parameter_groups(), 1);
     EXPECT_EQ(context_->num_abstract_parameters(), 1);
     EXPECT_EQ(context_->num_subcontexts(), kNumSystems);
@@ -315,7 +315,7 @@ TEST_F(DiagramContextTest, RetrieveConstituents) {
 TEST_F(DiagramContextTest, Time) {
   auto before = SaveNotifications(SystemBase::time_ticket());
 
-  context_->set_time(42.0);
+  context_->SetTime(42.0);
   VerifyTimeValue(42.);
   VerifyNotifications("Time", SystemBase::time_ticket(), &before);
 }
@@ -326,7 +326,7 @@ TEST_F(DiagramContextTest, Accuracy) {
   auto before = SaveNotifications(SystemBase::accuracy_ticket());
 
   const double new_accuracy = 1e-12;
-  context_->set_accuracy(new_accuracy);
+  context_->SetAccuracy(new_accuracy);
   VerifyAccuracyValue(new_accuracy);
   VerifyNotifications("Accuracy", SystemBase::accuracy_ticket(), &before);
 }
@@ -516,8 +516,8 @@ TEST_F(DiagramContextTest, MutableEverythingNotifications) {
   const double new_pn = -2;
   const int new_pa = 101;
 
-  clone->set_time(new_time);
-  clone->set_accuracy(new_accuracy);
+  clone->SetTime(new_time);
+  clone->SetAccuracy(new_accuracy);
   clone->SetContinuousState(new_xc);
   clone->get_mutable_discrete_state(0)[0] = new_xd;
   clone->get_mutable_abstract_state<int>(0) = new_xa;
@@ -647,7 +647,7 @@ TEST_F(DiagramContextTest, ConnectValid) {
 // Tests that input ports can be assigned to the DiagramContext and then
 // retrieved.
 TEST_F(DiagramContextTest, SetAndGetInputPorts) {
-  ASSERT_EQ(2, context_->get_num_input_ports());
+  ASSERT_EQ(2, context_->num_input_ports());
   AttachInputPorts();
   EXPECT_EQ(128, ReadVectorInputPort(*context_, 0)->get_value()[0]);
   EXPECT_EQ(256, ReadVectorInputPort(*context_, 1)->get_value()[0]);
@@ -717,7 +717,7 @@ TEST_F(DiagramContextTest, Clone) {
 
   // Verify that the cloned input ports contain the same data,
   // but are different pointers.
-  EXPECT_EQ(2, clone->get_num_input_ports());
+  EXPECT_EQ(2, clone->num_input_ports());
   for (int i = 0; i < 2; ++i) {
     const BasicVector<double>* orig_port = ReadVectorInputPort(*context_, i);
     const BasicVector<double>* clone_port = ReadVectorInputPort(*clone, i);
@@ -747,7 +747,7 @@ TEST_F(DiagramContextTest, CloneAccuracy) {
 
   // Verify that setting the accuracy is reflected in cloning.
   const double unity = 1.0;
-  context_->set_accuracy(unity);
+  context_->SetAccuracy(unity);
   std::unique_ptr<Context<double>> clone = context_->Clone();
   EXPECT_EQ(clone->get_accuracy().value(), unity);
 }

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -551,7 +551,7 @@ class DiagramTest : public ::testing::Test {
 // without a context. The class ExampleDiagram above contains two integrators,
 // each of which has three state variables.
 TEST_F(DiagramTest, NumberOfContinuousStates) {
-  EXPECT_EQ(3+3, diagram_->get_num_continuous_states());
+  EXPECT_EQ(3+3, diagram_->num_continuous_states());
 }
 
 // Tests that the diagram returns the correct number of witness functions and
@@ -567,7 +567,7 @@ TEST_F(DiagramTest, Witness) {
 
 // Tests that the diagram exports the correct topology.
 TEST_F(DiagramTest, Topology) {
-  ASSERT_EQ(kSize, diagram_->get_num_input_ports());
+  ASSERT_EQ(kSize, diagram_->num_input_ports());
   for (int i = 0; i < kSize; ++i) {
     const auto& input_port = diagram_->get_input_port(i);
     EXPECT_EQ(diagram_.get(), &input_port.get_system());
@@ -575,7 +575,7 @@ TEST_F(DiagramTest, Topology) {
     EXPECT_EQ(kSize, input_port.size());
   }
 
-  ASSERT_EQ(kSize, diagram_->get_num_output_ports());
+  ASSERT_EQ(kSize, diagram_->num_output_ports());
   for (int i = 0; i < kSize; ++i) {
     const auto& port = diagram_->get_output_port(i);
     EXPECT_EQ(diagram_.get(), &port.get_system());
@@ -736,7 +736,7 @@ TEST_F(DiagramTest, CalcOutput) {
   AttachInputs();
   diagram_->CalcOutput(*context_, output_.get());
 
-  ASSERT_EQ(kSize, output_->get_num_ports());
+  ASSERT_EQ(kSize, output_->num_ports());
   ExpectDefaultOutputs();
 }
 
@@ -748,9 +748,9 @@ TEST_F(DiagramTest, EvalOutput) {
   // Sanity check output port prerequisites. Diagram ports should designate
   // a subsystem since they are resolved internally. We don't know the right
   // dependency ticket, but at least it should be valid.
-  ASSERT_EQ(diagram_->get_num_output_ports(), 3);
+  ASSERT_EQ(diagram_->num_output_ports(), 3);
   const int expected_subsystem[] = {1, 2, 5};  // From drawing above.
-  for (OutputPortIndex i(0); i < diagram_->get_num_output_ports(); ++i) {
+  for (OutputPortIndex i(0); i < diagram_->num_output_ports(); ++i) {
     internal::OutputPortPrerequisite prereq =
         diagram_->get_output_port(i).GetPrerequisite();
     EXPECT_EQ(*prereq.child_subsystem, expected_subsystem[i]);
@@ -878,7 +878,7 @@ TEST_F(DiagramTest, ToAutoDiffXd) {
   context->FixInputPort(2, input2);
 
   ad_diagram->CalcOutput(*context, output.get());
-  ASSERT_EQ(kSize, output->get_num_ports());
+  ASSERT_EQ(kSize, output->num_ports());
 
   // Spot-check some values and gradients.
   // A = [1.0 + 2.0, 1.1 + 2.2, 1.2 + 2.4]
@@ -908,13 +908,13 @@ TEST_F(DiagramTest, ToAutoDiffXd) {
   }
 
   // Make sure that the input port names survive type conversion.
-  for (InputPortIndex i{0}; i < diagram_->get_num_input_ports(); i++) {
+  for (InputPortIndex i{0}; i < diagram_->num_input_ports(); i++) {
     EXPECT_EQ(diagram_->get_input_port(i).get_name(),
               ad_diagram->get_input_port(i).get_name());
   }
 
   // Make sure that the output port names survive type conversion.
-  for (OutputPortIndex i{0}; i < diagram_->get_num_output_ports(); i++) {
+  for (OutputPortIndex i{0}; i < diagram_->num_output_ports(); i++) {
     EXPECT_EQ(diagram_->get_output_port(i).get_name(),
               ad_diagram->get_output_port(i).get_name());
   }
@@ -1200,7 +1200,7 @@ GTEST_TEST(DiagramSubclassTest, TwelvePlusSevenIsNineteen) {
   context->FixInputPort(0, {12.0});
   plus_seven.CalcOutput(*context, output.get());
 
-  ASSERT_EQ(1, output->get_num_ports());
+  ASSERT_EQ(1, output->num_ports());
   const BasicVector<double>* output_vector = output->get_vector_data(0);
   EXPECT_EQ(1, output_vector->size());
   EXPECT_EQ(19.0, output_vector->get_value().x());
@@ -1714,7 +1714,7 @@ class DiscreteStateTest : public ::testing::Test {
 
 // Tests that the next update time after 0.05 is 2.0.
 TEST_F(DiscreteStateTest, CalcNextUpdateTimeHold1) {
-  context_->set_time(0.05);
+  context_->SetTime(0.05);
   auto events = diagram_.AllocateCompositeEventCollection();
   double time = diagram_.CalcNextUpdateTime(*context_, events.get());
 
@@ -1728,7 +1728,7 @@ TEST_F(DiscreteStateTest, CalcNextUpdateTimeHold1) {
 
 // Tests that the next update time after 5.1 is 6.0.
 TEST_F(DiscreteStateTest, CalcNextUpdateTimeHold2) {
-  context_->set_time(5.1);
+  context_->SetTime(5.1);
   auto events = diagram_.AllocateCompositeEventCollection();
   double time = diagram_.CalcNextUpdateTime(*context_, events.get());
 
@@ -1770,7 +1770,7 @@ TEST_F(DiscreteStateTest, UpdateDiscreteVariables) {
           .GetSubsystemDiscreteValues(*diagram_.hold2(), *updates);
 
       // Set the time to 8.5, so only hold2 updates.
-      context_->set_time(8.5);
+      context_->SetTime(8.5);
 
   // Request the next update time.
   auto events = diagram_.AllocateCompositeEventCollection();
@@ -1779,7 +1779,7 @@ TEST_F(DiscreteStateTest, UpdateDiscreteVariables) {
   EXPECT_TRUE(events->HasDiscreteUpdateEvents());
 
   // Fast forward to 9.0 sec and do the update.
-  context_->set_time(9.0);
+  context_->SetTime(9.0);
   diagram_.CalcDiscreteVariableUpdates(
       *context_, events->get_discrete_update_events(), updates.get());
   EXPECT_EQ(1001.0, updates1[0]);
@@ -1793,13 +1793,13 @@ TEST_F(DiscreteStateTest, UpdateDiscreteVariables) {
   // Restore hold2 to its original value.
   ctx2.get_mutable_discrete_state(0)[0] = 1002.0;
   // Set the time to 11.5, so both hold1 and hold2 update.
-  context_->set_time(11.5);
+  context_->SetTime(11.5);
   time = diagram_.CalcNextUpdateTime(*context_, events.get());
   EXPECT_EQ(12.0, time);
   EXPECT_TRUE(events->HasDiscreteUpdateEvents());
 
   // Fast forward to 12.0 sec and do the update again.
-  context_->set_time(12.0);
+  context_->SetTime(12.0);
   diagram_.CalcDiscreteVariableUpdates(
       *context_, events->get_discrete_update_events(), updates.get());
   EXPECT_EQ(17.0, updates1[0]);
@@ -1808,7 +1808,7 @@ TEST_F(DiscreteStateTest, UpdateDiscreteVariables) {
 
 // Tests that a publish action is taken at 19 sec.
 TEST_F(DiscreteStateTest, Publish) {
-  context_->set_time(18.5);
+  context_->SetTime(18.5);
   auto events = diagram_.AllocateCompositeEventCollection();
   double time = diagram_.CalcNextUpdateTime(*context_, events.get());
 
@@ -1817,7 +1817,7 @@ TEST_F(DiscreteStateTest, Publish) {
 
   // Fast forward to 19.0 sec and do the publish.
   EXPECT_EQ(false, diagram_.publisher()->published());
-  context_->set_time(19.0);
+  context_->SetTime(19.0);
   diagram_.Publish(*context_, events->get_publish_events());
   // Check that publication occurred.
   EXPECT_EQ(true, diagram_.publisher()->published());
@@ -1921,7 +1921,7 @@ class AbstractStateDiagramTest : public ::testing::Test {
 
 TEST_F(AbstractStateDiagramTest, CalcUnrestrictedUpdate) {
   double time = 1;
-  context_->set_time(time);
+  context_->SetTime(time);
 
   // The abstract data should be initialized to their ids.
   EXPECT_EQ(get_sys0_abstract_data_as_double(), 0);
@@ -1961,7 +1961,7 @@ TEST_F(AbstractStateDiagramTest, CalcUnrestrictedUpdate) {
 
   // Sets time to 5.5, both system should be updating at 6 sec.
   time = 5.5;
-  context_->set_time(time);
+  context_->SetTime(time);
   EXPECT_EQ(diagram_.CalcNextUpdateTime(*context_, events.get()), 6.);
   for (int i = 0; i < 2; i++) {
     const auto& subevent_collection =
@@ -2333,16 +2333,16 @@ GTEST_TEST(MutateSubcontextTest, DiagramRecalculatesOnSubcontextChange) {
   EXPECT_EQ(derivative_cache.serial_number(), expected_derivative_serial);
 
   // Time & accuracy changes are allowed at the root (diagram) level.
-  EXPECT_NO_THROW(diagram_context->set_time(1.));
+  EXPECT_NO_THROW(diagram_context->SetTime(1.));
   EXPECT_NO_THROW(diagram_context->SetTimeAndContinuousState(2., init_state));
   auto diagram_context_clone = diagram_context->Clone();
   EXPECT_NO_THROW(
       diagram_context->SetTimeStateAndParametersFrom(*diagram_context_clone));
-  EXPECT_NO_THROW(diagram_context->set_accuracy(1e-6));
+  EXPECT_NO_THROW(diagram_context->SetAccuracy(1e-6));
 
   // Time & accuracy changes NOT allowed at child (leaf) level.
-  DRAKE_EXPECT_THROWS_MESSAGE(context0.set_time(3.), std::logic_error,
-                              ".*set_time.*Time change allowed only.*root.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(context0.SetTime(3.), std::logic_error,
+                              ".*SetTime.*Time change allowed only.*root.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
       context0.SetTimeAndContinuousState(4., new_x0), std::logic_error,
       ".*SetTimeAndContinuousState.*Time change allowed only.*root.*");
@@ -2350,8 +2350,8 @@ GTEST_TEST(MutateSubcontextTest, DiagramRecalculatesOnSubcontextChange) {
       context0.SetTimeStateAndParametersFrom(context1), std::logic_error,
       ".*SetTimeStateAndParametersFrom.*Time change allowed only.*root.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
-      context0.set_accuracy(1e-7), std::logic_error,
-      ".*set_accuracy.*Accuracy change allowed only.*root.*");
+      context0.SetAccuracy(1e-7), std::logic_error,
+      ".*SetAccuracy.*Accuracy change allowed only.*root.*");
 }
 
 // Tests that an exception is thrown if the systems in a Diagram do not have
@@ -2561,7 +2561,7 @@ GTEST_TEST(MyEventTest, MyEventTestLeaf) {
   auto context = dut.CreateDefaultContext();
 
   double time = dut.CalcNextUpdateTime(*context, events.get());
-  context->set_time(time);
+  context->SetTime(time);
   dut.Publish(*context, events->get_publish_events());
 
   EXPECT_EQ(dut.get_periodic_count(), 1);
@@ -2607,7 +2607,7 @@ GTEST_TEST(MyEventTest, MyEventTestDiagram) {
   events->Merge(*periodic_events);
   events->Merge(*perstep_events);
 
-  context->set_time(time);
+  context->SetTime(time);
   dut->Publish(*context, events->get_publish_events());
 
   EXPECT_EQ(sys[0]->get_periodic_count(), 0);
@@ -2672,7 +2672,7 @@ GTEST_TEST(DiagramConstraintTest, SystemConstraintsTest) {
   auto sys2 = builder.AddSystem<ConstraintTestSystem<double>>();
 
   auto diagram = builder.Build();
-  EXPECT_EQ(diagram->get_num_constraints(), 4);  // two from each system
+  EXPECT_EQ(diagram->num_constraints(), 4);  // two from each system
 
   auto context = diagram->CreateDefaultContext();
 
@@ -2732,7 +2732,7 @@ GTEST_TEST(DiagramConstraintTest, SystemConstraintsTest) {
 
   // Check that constraints survive ToAutoDiffXd.
   auto autodiff_diagram = diagram->ToAutoDiffXd();
-  EXPECT_EQ(autodiff_diagram->get_num_constraints(), 4);
+  EXPECT_EQ(autodiff_diagram->num_constraints(), 4);
   auto autodiff_context = autodiff_diagram->CreateDefaultContext();
   autodiff_context->SetTimeStateAndParametersFrom(*context);
   const SystemConstraint<AutoDiffXd>& autodiff_constraint =
@@ -2743,7 +2743,7 @@ GTEST_TEST(DiagramConstraintTest, SystemConstraintsTest) {
 
   // Check that constraints survive ToSymbolic.
   auto symbolic_diagram = diagram->ToSymbolic();
-  EXPECT_EQ(symbolic_diagram->get_num_constraints(), 4);
+  EXPECT_EQ(symbolic_diagram->num_constraints(), 4);
   auto symbolic_context = symbolic_diagram->CreateDefaultContext();
   symbolic_context->SetTimeStateAndParametersFrom(*context);
   const SystemConstraint<symbolic::Expression>& symbolic_constraint =

--- a/systems/framework/test/input_port_test.cc
+++ b/systems/framework/test/input_port_test.cc
@@ -178,7 +178,7 @@ GTEST_TEST(InputPortTest, FixValueTests) {
   std::unique_ptr<Context<double>> context = dut.CreateDefaultContext();
 
   // None of the ports should have a value initially.
-  for (int i = 0; i < dut.get_num_input_ports(); ++i) {
+  for (int i = 0; i < dut.num_input_ports(); ++i) {
     EXPECT_FALSE(dut.get_input_port(i).HasValue(*context));
   }
 
@@ -300,7 +300,7 @@ GTEST_TEST(InputPortTest, FixValueTests) {
   EXPECT_EQ(dut.string_port.Eval<std::string>(*context), "replacement string");
 
   // All of the ports should have values by now.
-  for (int i = 0; i < dut.get_num_input_ports(); ++i) {
+  for (int i = 0; i < dut.num_input_ports(); ++i) {
     EXPECT_TRUE(dut.get_input_port(i).HasValue(*context));
   }
 }

--- a/systems/framework/test/leaf_context_test.cc
+++ b/systems/framework/test/leaf_context_test.cc
@@ -42,7 +42,7 @@ class TestAbstractType {
 class LeafContextTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    context_.set_time(kTime);
+    context_.SetTime(kTime);
 
     // Set up slots for input and output ports.
     AddInputPorts(kNumInputPorts, &context_);
@@ -257,8 +257,8 @@ void VerifyClonedState(const State<double>& clone) {
 }
 
 TEST_F(LeafContextTest, CheckPorts) {
-  ASSERT_EQ(kNumInputPorts, context_.get_num_input_ports());
-  ASSERT_EQ(kNumOutputPorts, context_.get_num_output_ports());
+  ASSERT_EQ(kNumInputPorts, context_.num_input_ports());
+  ASSERT_EQ(kNumOutputPorts, context_.num_output_ports());
 
   // The "all inputs" tracker should have been subscribed to each of the
   // input ports. And each input port should have subscribed to its fixed
@@ -293,11 +293,11 @@ TEST_F(LeafContextTest, CheckPorts) {
 }
 
 TEST_F(LeafContextTest, GetNumDiscreteStateGroups) {
-  EXPECT_EQ(2, context_.get_num_discrete_state_groups());
+  EXPECT_EQ(2, context_.num_discrete_state_groups());
 }
 
 TEST_F(LeafContextTest, GetNumAbstractStates) {
-  EXPECT_EQ(1, context_.get_num_abstract_states());
+  EXPECT_EQ(1, context_.num_abstract_states());
 }
 
 TEST_F(LeafContextTest, IsStateless) {
@@ -322,12 +322,12 @@ TEST_F(LeafContextTest, HasOnlyDiscreteState) {
 
 TEST_F(LeafContextTest, GetNumStates) {
   LeafContext<double> context;
-  EXPECT_EQ(context.get_num_total_states(), 0);
+  EXPECT_EQ(context.num_total_states(), 0);
 
   // Reserve a continuous state with five elements.
   context.init_continuous_state(std::make_unique<ContinuousState<double>>(
       BasicVector<double>::Make({1.0, 2.0, 3.0, 5.0, 8.0})));
-  EXPECT_EQ(context.get_num_total_states(), 5);
+  EXPECT_EQ(context.num_total_states(), 5);
 
   // Reserve a discrete state with two elements, of size 1 and size 2.
   std::vector<std::unique_ptr<BasicVector<double>>> xd;
@@ -335,14 +335,14 @@ TEST_F(LeafContextTest, GetNumStates) {
   xd.push_back(BasicVector<double>::Make({256.0, 512.0}));
   context.init_discrete_state(
       std::make_unique<DiscreteValues<double>>(std::move(xd)));
-  EXPECT_EQ(context.get_num_total_states(), 8);
+  EXPECT_EQ(context.num_total_states(), 8);
 
   // Reserve an abstract state with one element, which is not owned.
   std::unique_ptr<AbstractValue> abstract_state = PackValue(42);
   std::vector<AbstractValue*> xa;
   xa.push_back(abstract_state.get());
   context.init_abstract_state(std::make_unique<AbstractValues>(std::move(xa)));
-  EXPECT_THROW(context.get_num_total_states(), std::runtime_error);
+  EXPECT_THROW(context.num_total_states(), std::runtime_error);
 }
 
 TEST_F(LeafContextTest, GetVectorInput) {
@@ -495,7 +495,7 @@ TEST_F(LeafContextTest, Clone) {
 
   // Verify that the cloned input ports contain the same data,
   // but are different pointers.
-  EXPECT_EQ(kNumInputPorts, clone->get_num_input_ports());
+  EXPECT_EQ(kNumInputPorts, clone->num_input_ports());
   for (int i = 0; i < kNumInputPorts; ++i) {
     const BasicVector<double>* context_port = ReadVectorInputPort(context_, i);
     const BasicVector<double>* clone_port = ReadVectorInputPort(*clone, i);
@@ -610,7 +610,7 @@ TEST_F(LeafContextTest, SetTimeStateAndParametersFrom) {
   // Set the accuracy in the target- setting time, state, and parameters
   // should reset it.
   const double accuracy = 0.1;
-  target.set_accuracy(accuracy);
+  target.SetAccuracy(accuracy);
 
   // Set the target from the source.
   target.SetTimeStateAndParametersFrom(context_);
@@ -631,7 +631,7 @@ TEST_F(LeafContextTest, SetTimeStateAndParametersFrom) {
   EXPECT_EQ(2.0, (target.get_numeric_parameter(0)[1].value()));
 
   // Set the accuracy in the context.
-  context_.set_accuracy(accuracy);
+  context_.SetAccuracy(accuracy);
   target.SetTimeStateAndParametersFrom(context_);
   EXPECT_EQ(target.get_accuracy(), accuracy);
 }
@@ -643,7 +643,7 @@ TEST_F(LeafContextTest, Accuracy) {
 
   // Verify that setting the accuracy is reflected in cloning.
   const double unity = 1.0;
-  context_.set_accuracy(unity);
+  context_.SetAccuracy(unity);
   std::unique_ptr<Context<double>> clone = context_.Clone();
   EXPECT_EQ(clone->get_accuracy().value(), unity);
 }
@@ -692,14 +692,14 @@ TEST_F(LeafContextTest, Invalidation) {
 
   // Modify time.
   MarkAllCacheValuesUpToDate(&cache);
-  context_.set_time(context_.get_time() + 1);  // Ensure this is a change.
+  context_.SetTime(context_.get_time() + 1);  // Ensure this is a change.
   CheckAllCacheValuesUpToDateExcept(cache,
       {depends[internal::kTimeTicket],
        depends[internal::kAllSourcesTicket]});
 
   // Accuracy.
   MarkAllCacheValuesUpToDate(&cache);
-  context_.set_accuracy(7.123e-4);  // Ensure this is a change.
+  context_.SetAccuracy(7.123e-4);  // Ensure this is a change.
   CheckAllCacheValuesUpToDateExcept(cache,
       {depends[internal::kAccuracyTicket],
        depends[internal::kConfigurationTicket],
@@ -757,7 +757,7 @@ TEST_F(LeafContextTest, Invalidation) {
       context_.get_continuous_state_vector().CopyToVector());
   CheckAllCacheValuesUpToDateExcept(cache, t_and_xc_dependent);
 
-  context_.set_time(1.);
+  context_.SetTime(1.);
   MarkAllCacheValuesUpToDate(&cache);
   VectorBase<double>& xc1 =
       context_.SetTimeAndGetMutableContinuousStateVector(2.);

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -495,7 +495,7 @@ TEST_F(LeafSystemTest, WitnessDeclarations) {
 
 // Tests that if no update events are configured, none are reported.
 TEST_F(LeafSystemTest, NoUpdateEvents) {
-  context_.set_time(25.0);
+  context_.SetTime(25.0);
   double time = system_.CalcNextUpdateTime(context_, event_info_.get());
   EXPECT_EQ(std::numeric_limits<double>::infinity(), time);
   EXPECT_TRUE(!leaf_info_->HasEvents());
@@ -528,7 +528,7 @@ TEST_F(LeafSystemTest, MultipleNonUniquePeriods) {
 // Tests that if the current time is smaller than the offset, the next
 // update time is the offset.
 TEST_F(LeafSystemTest, OffsetHasNotArrivedYet) {
-  context_.set_time(2.0);
+  context_.SetTime(2.0);
   system_.AddPeriodicUpdate();
   double time = system_.CalcNextUpdateTime(context_, event_info_.get());
 
@@ -542,7 +542,7 @@ TEST_F(LeafSystemTest, OffsetHasNotArrivedYet) {
 // update time is the offset, DiscreteUpdate and UnrestrictedUpdate happen
 // at the same time.
 TEST_F(LeafSystemTest, EventsAtTheSameTime) {
-  context_.set_time(2.0);
+  context_.SetTime(2.0);
   // Both actions happen at t = 5.
   system_.AddPeriodicUpdate();
   system_.AddPeriodicUnrestrictedUpdate(3, 5);
@@ -565,7 +565,7 @@ TEST_F(LeafSystemTest, EventsAtTheSameTime) {
 // Tests that if the current time is exactly the offset, the next
 // update time is in the future.
 TEST_F(LeafSystemTest, ExactlyAtOffset) {
-  context_.set_time(5.0);
+  context_.SetTime(5.0);
   system_.AddPeriodicUpdate();
   double time = system_.CalcNextUpdateTime(context_, event_info_.get());
 
@@ -578,7 +578,7 @@ TEST_F(LeafSystemTest, ExactlyAtOffset) {
 // Tests that if the current time is larger than the offset, the next
 // update time is determined by the period.
 TEST_F(LeafSystemTest, OffsetIsInThePast) {
-  context_.set_time(23.0);
+  context_.SetTime(23.0);
   system_.AddPeriodicUpdate();
   double time = system_.CalcNextUpdateTime(context_, event_info_.get());
 
@@ -591,7 +591,7 @@ TEST_F(LeafSystemTest, OffsetIsInThePast) {
 // Tests that if the current time is exactly an update time, the next update
 // time is in the future.
 TEST_F(LeafSystemTest, ExactlyOnUpdateTime) {
-  context_.set_time(25.0);
+  context_.SetTime(25.0);
   system_.AddPeriodicUpdate();
   double time = system_.CalcNextUpdateTime(context_, event_info_.get());
 
@@ -605,15 +605,15 @@ TEST_F(LeafSystemTest, ExactlyOnUpdateTime) {
 TEST_F(LeafSystemTest, PeriodicUpdateZeroOffset) {
   system_.AddPeriodicUpdate(2.0);
 
-  context_.set_time(0.0);
+  context_.SetTime(0.0);
   double time = system_.CalcNextUpdateTime(context_, event_info_.get());
   EXPECT_EQ(2.0, time);
 
-  context_.set_time(1.0);
+  context_.SetTime(1.0);
   time = system_.CalcNextUpdateTime(context_, event_info_.get());
   EXPECT_EQ(2.0, time);
 
-  context_.set_time(2.1);
+  context_.SetTime(2.1);
   time = system_.CalcNextUpdateTime(context_, event_info_.get());
   EXPECT_EQ(4.0, time);
 }
@@ -625,7 +625,7 @@ TEST_F(LeafSystemTest, UpdateAndPublish) {
   system_.AddPublish(12.0);
 
   // The publish event fires at 12sec.
-  context_.set_time(9.0);
+  context_.SetTime(9.0);
   double time = system_.CalcNextUpdateTime(context_, event_info_.get());
   EXPECT_EQ(12.0, time);
   {
@@ -635,7 +635,7 @@ TEST_F(LeafSystemTest, UpdateAndPublish) {
   }
 
   // The update event fires at 15sec.
-  context_.set_time(14.0);
+  context_.SetTime(14.0);
   time = system_.CalcNextUpdateTime(context_, event_info_.get());
   EXPECT_EQ(15.0, time);
   {
@@ -645,7 +645,7 @@ TEST_F(LeafSystemTest, UpdateAndPublish) {
   }
 
   // Both events fire at 60sec.
-  context_.set_time(59.0);
+  context_.SetTime(59.0);
   time = system_.CalcNextUpdateTime(context_, event_info_.get());
   EXPECT_EQ(60.0, time);
   {
@@ -664,7 +664,7 @@ TEST_F(LeafSystemTest, UpdateAndPublish) {
 // time for that sample is slightly less than k * period due to floating point
 // rounding, the next sample time is (k + 1) * period.
 TEST_F(LeafSystemTest, FloatingPointRoundingZeroPointZeroOneFive) {
-  context_.set_time(0.015 * 11);  // Slightly less than 0.165.
+  context_.SetTime(0.015 * 11);  // Slightly less than 0.165.
   system_.AddPeriodicUpdate(0.015);
   double time = system_.CalcNextUpdateTime(context_, event_info_.get());
   // 0.015 * 12 = 0.18.
@@ -675,7 +675,7 @@ TEST_F(LeafSystemTest, FloatingPointRoundingZeroPointZeroOneFive) {
 // time for that sample is slightly less than k * period due to floating point
 // rounding, the next sample time is (k + 1) * period.
 TEST_F(LeafSystemTest, FloatingPointRoundingZeroPointZeroZeroTwoFive) {
-  context_.set_time(0.0025 * 977);  // Slightly less than 2.4425
+  context_.SetTime(0.0025 * 977);  // Slightly less than 2.4425
   system_.AddPeriodicUpdate(0.0025);
   double time = system_.CalcNextUpdateTime(context_, event_info_.get());
   EXPECT_NEAR(2.445, time, 1e-8);
@@ -762,8 +762,8 @@ TEST_F(LeafSystemTest, AbstractParameters) {
 TEST_F(LeafSystemTest, DeclareVanillaMiscContinuousState) {
   system_.DeclareContinuousState(2);
 
-  // Tests get_num_continuous_states without a context.
-  EXPECT_EQ(2, system_.get_num_continuous_states());
+  // Tests num_continuous_states without a context.
+  EXPECT_EQ(2, system_.num_continuous_states());
 
   std::unique_ptr<Context<double>> context = system_.CreateDefaultContext();
   const ContinuousState<double>& xc = context->get_continuous_state();
@@ -778,8 +778,8 @@ TEST_F(LeafSystemTest, DeclareVanillaMiscContinuousState) {
 TEST_F(LeafSystemTest, DeclareTypedMiscContinuousState) {
   system_.DeclareContinuousState(MyVector2d());
 
-  // Tests get_num_continuous_states without a context.
-  EXPECT_EQ(2, system_.get_num_continuous_states());
+  // Tests num_continuous_states without a context.
+  EXPECT_EQ(2, system_.num_continuous_states());
 
   std::unique_ptr<Context<double>> context = system_.CreateDefaultContext();
   const ContinuousState<double>& xc = context->get_continuous_state();
@@ -797,8 +797,8 @@ TEST_F(LeafSystemTest, DeclareTypedMiscContinuousState) {
 TEST_F(LeafSystemTest, DeclareVanillaContinuousState) {
   system_.DeclareContinuousState(4, 3, 2);
 
-  // Tests get_num_continuous_states without a context.
-  EXPECT_EQ(4 + 3 + 2, system_.get_num_continuous_states());
+  // Tests num_continuous_states without a context.
+  EXPECT_EQ(4 + 3 + 2, system_.num_continuous_states());
 
   std::unique_ptr<Context<double>> context = system_.CreateDefaultContext();
   const ContinuousState<double>& xc = context->get_continuous_state();
@@ -814,8 +814,8 @@ TEST_F(LeafSystemTest, DeclareTypedContinuousState) {
   using MyVector9d = MyVector<double, 4 + 3 + 2>;
   system_.DeclareContinuousState(MyVector9d(), 4, 3, 2);
 
-  // Tests get_num_continuous_states without a context.
-  EXPECT_EQ(4 + 3 + 2, system_.get_num_continuous_states());
+  // Tests num_continuous_states without a context.
+  EXPECT_EQ(4 + 3 + 2, system_.num_continuous_states());
 
   std::unique_ptr<Context<double>> context = system_.CreateDefaultContext();
   const ContinuousState<double>& xc = context->get_continuous_state();
@@ -933,8 +933,8 @@ class DeclaredModelPortsSystem : public LeafSystem<double> {
 GTEST_TEST(ModelLeafSystemTest, ModelPortsTopology) {
   DeclaredModelPortsSystem dut;
 
-  ASSERT_EQ(dut.get_num_input_ports(), 5);
-  ASSERT_EQ(dut.get_num_output_ports(), 4);
+  ASSERT_EQ(dut.num_input_ports(), 5);
+  ASSERT_EQ(dut.num_output_ports(), 4);
 
   // Check that SystemBase port APIs work properly.
   const InputPortBase& in3_base = dut.get_input_port_base(InputPortIndex(3));
@@ -951,7 +951,7 @@ GTEST_TEST(ModelLeafSystemTest, ModelPortsTopology) {
   auto context = dut.AllocateContext();
   const DependencyTracker& all_inputs_tracker =
       context->get_tracker(dut.all_input_ports_ticket());
-  for (InputPortIndex i(0); i < dut.get_num_input_ports(); ++i) {
+  for (InputPortIndex i(0); i < dut.num_input_ports(); ++i) {
     const DependencyTracker& tracker =
         context->get_tracker(dut.input_port_ticket(i));
     EXPECT_TRUE(all_inputs_tracker.HasPrerequisite(tracker));
@@ -1184,7 +1184,7 @@ GTEST_TEST(ModelLeafSystemTest, ModelPortsCalcOutput) {
   // *may* avoid invalidation if the time hasn't actually changed.
 
   // Should invalidate time- and everything-dependents.
-  context->set_time(context->get_time() + 1.);
+  context->SetTime(context->get_time() + 1.);
   EXPECT_TRUE(cache2.is_out_of_date(*context));
   EXPECT_EQ(cacheval2.serial_number(), 2);  // Unchanged since invalid.
   (void)port2.template Eval<AbstractValue>(*context);  // Recalculate.
@@ -1196,7 +1196,7 @@ GTEST_TEST(ModelLeafSystemTest, ModelPortsCalcOutput) {
   // Should invalidate accuracy- and everything-dependents. Note that the
   // method *may* avoid invalidation if the accuracy hasn't actually changed.
   EXPECT_FALSE(context->get_accuracy());  // None set initially.
-  context->set_accuracy(.000025);  // This is a change.
+  context->SetAccuracy(.000025);  // This is a change.
   EXPECT_TRUE(cache2.is_out_of_date(*context));
   (void)port2.template Eval<AbstractValue>(*context);  // Recalculate.
   EXPECT_FALSE(cache2.is_out_of_date(*context));
@@ -1438,8 +1438,8 @@ GTEST_TEST(NonModelLeafSystemTest, NonModelPortsOutput) {
   context->EnableCaching();
 
   // Check topology.
-  EXPECT_EQ(dut.get_num_input_ports(), 0);
-  EXPECT_EQ(dut.get_num_output_ports(), 5);
+  EXPECT_EQ(dut.num_input_ports(), 0);
+  EXPECT_EQ(dut.num_output_ports(), 5);
 
   auto& out0 = dut.get_output_port(0);
   auto& out1 = dut.get_output_port(1);
@@ -1455,7 +1455,7 @@ GTEST_TEST(NonModelLeafSystemTest, NonModelPortsOutput) {
   // Sanity check output port prerequisites. Leaf ports should not designate
   // a subsystem since they are resolved internally. We don't know the right
   // dependency ticket, but at least it should be valid.
-  for (OutputPortIndex i(0); i < dut.get_num_output_ports(); ++i) {
+  for (OutputPortIndex i(0); i < dut.num_output_ports(); ++i) {
     internal::OutputPortPrerequisite prereq =
         dut.get_output_port(i).GetPrerequisite();
     EXPECT_FALSE(prereq.child_subsystem.has_value());
@@ -1686,7 +1686,7 @@ GTEST_TEST(AutodiffLeafSystemTest, NextUpdateTimeAutodiff) {
   TestSystem<AutoDiffXd> system;
   LeafContext<AutoDiffXd> context;
 
-  context.set_time(21.0);
+  context.SetTime(21.0);
   system.AddPeriodicUpdate();
 
   auto event_info = system.AllocateCompositeEventCollection();
@@ -2216,12 +2216,12 @@ class ConstraintTestSystem : public LeafSystem<double> {
 // Tests adding constraints implemented as methods inside the System class.
 GTEST_TEST(SystemConstraintTest, ClassMethodTest) {
   ConstraintTestSystem dut;
-  EXPECT_EQ(dut.get_num_constraints(), 0);
+  EXPECT_EQ(dut.num_constraints(), 0);
 
   EXPECT_EQ(dut.DeclareEqualityConstraint(
                 &ConstraintTestSystem::CalcState0Constraint, 1, "x0"),
             0);
-  EXPECT_EQ(dut.get_num_constraints(), 1);
+  EXPECT_EQ(dut.num_constraints(), 1);
 
   EXPECT_EQ(
       dut.DeclareInequalityConstraint(
@@ -2229,7 +2229,7 @@ GTEST_TEST(SystemConstraintTest, ClassMethodTest) {
           { Eigen::Vector2d::Zero(), nullopt },
           "x"),
       1);
-  EXPECT_EQ(dut.get_num_constraints(), 2);
+  EXPECT_EQ(dut.num_constraints(), 2);
 
   auto context = dut.CreateDefaultContext();
   context->get_mutable_continuous_state_vector().SetFromVector(
@@ -2260,7 +2260,7 @@ GTEST_TEST(SystemConstraintTest, ClassMethodTest) {
 // Tests adding constraints implemented as function handles (lambda functions).
 GTEST_TEST(SystemConstraintTest, FunctionHandleTest) {
   ConstraintTestSystem dut;
-  EXPECT_EQ(dut.get_num_constraints(), 0);
+  EXPECT_EQ(dut.num_constraints(), 0);
 
   ContextConstraintCalc<double> calc0 = [](
       const Context<double>& context, Eigen::VectorXd* value) {
@@ -2270,7 +2270,7 @@ GTEST_TEST(SystemConstraintTest, FunctionHandleTest) {
                                             { Vector1d::Zero(), nullopt },
                                             "x1_lower"),
             0);
-  EXPECT_EQ(dut.get_num_constraints(), 1);
+  EXPECT_EQ(dut.num_constraints(), 1);
 
   ContextConstraintCalc<double> calc1 = [](
       const Context<double>& context, Eigen::VectorXd* value) {
@@ -2306,7 +2306,7 @@ GTEST_TEST(SystemConstraintTest, FunctionHandleTest) {
   EXPECT_EQ(inequality_constraint1.description(), "x_upper");
 
   EXPECT_EQ(dut.DeclareEqualityConstraint(calc0, 1, "x1eq"), 2);
-  EXPECT_EQ(dut.get_num_constraints(), 3);
+  EXPECT_EQ(dut.num_constraints(), 3);
 
   const SystemConstraint<double>& equality_constraint =
       dut.get_constraint(SystemConstraintIndex(2));
@@ -2320,13 +2320,13 @@ GTEST_TEST(SystemConstraintTest, FunctionHandleTest) {
 // Tests constraints implied by BasicVector subtypes.
 GTEST_TEST(SystemConstraintTest, ModelVectorTest) {
   ConstraintTestSystem dut;
-  EXPECT_EQ(dut.get_num_constraints(), 0);
+  EXPECT_EQ(dut.num_constraints(), 0);
 
   // Declaring a constrained model vector parameter should add constraints.
   // We want `vec[0] >= 11` on the parameter vector.
   using ParameterVector = ConstraintBasicVector<double, 11>;
   dut.DeclareNumericParameter(ParameterVector{});
-  ASSERT_EQ(dut.get_num_constraints(), 1);
+  ASSERT_EQ(dut.num_constraints(), 1);
   using Index = SystemConstraintIndex;
   const SystemConstraint<double>& constraint0 = dut.get_constraint(Index{0});
   const double kInf = std::numeric_limits<double>::infinity();
@@ -2340,7 +2340,7 @@ GTEST_TEST(SystemConstraintTest, ModelVectorTest) {
   // We want `vec[0] >= 22` on the state vector.
   using StateVector = ConstraintBasicVector<double, 22>;
   dut.DeclareContinuousState(StateVector{}, 0, 0, StateVector::kSize);
-  EXPECT_EQ(dut.get_num_constraints(), 2);
+  EXPECT_EQ(dut.num_constraints(), 2);
   const SystemConstraint<double>& constraint1 = dut.get_constraint(Index{1});
   EXPECT_TRUE(CompareMatrices(constraint1.lower_bound(), Vector1d(22)));
   EXPECT_TRUE(CompareMatrices(constraint1.upper_bound(), Vector1d(kInf)));
@@ -2352,7 +2352,7 @@ GTEST_TEST(SystemConstraintTest, ModelVectorTest) {
   // We want `vec[0] >= 33` on the input vector.
   using InputVector = ConstraintBasicVector<double, 33>;
   dut.DeclareVectorInputPort(InputVector{});
-  EXPECT_EQ(dut.get_num_constraints(), 3);
+  EXPECT_EQ(dut.num_constraints(), 3);
   const SystemConstraint<double>& constraint2 = dut.get_constraint(Index{2});
   EXPECT_TRUE(CompareMatrices(constraint2.lower_bound(), Vector1d(33)));
   EXPECT_TRUE(CompareMatrices(constraint2.upper_bound(), Vector1d(kInf)));
@@ -2363,7 +2363,7 @@ GTEST_TEST(SystemConstraintTest, ModelVectorTest) {
   // Declaring a constrained model vector output should add constraints.
   // We want `vec[0] >= 44` on the output vector.
   dut.DeclareVectorOutputPort(&ConstraintTestSystem::CalcOutput);
-  EXPECT_EQ(dut.get_num_constraints(), 4);
+  EXPECT_EQ(dut.num_constraints(), 4);
   const SystemConstraint<double>& constraint3 = dut.get_constraint(Index{3});
   EXPECT_TRUE(CompareMatrices(constraint3.lower_bound(), Vector1d(44)));
   EXPECT_TRUE(CompareMatrices(constraint3.upper_bound(), Vector1d(kInf)));
@@ -2375,7 +2375,7 @@ GTEST_TEST(SystemConstraintTest, ModelVectorTest) {
   // We want `vec[0] >= 55` on the state vector.
   using DiscreteStateVector = ConstraintBasicVector<double, 55>;
   dut.DeclareDiscreteState(DiscreteStateVector{});
-  EXPECT_EQ(dut.get_num_constraints(), 5);
+  EXPECT_EQ(dut.num_constraints(), 5);
   const SystemConstraint<double>& constraint4 = dut.get_constraint(Index{4});
   EXPECT_TRUE(CompareMatrices(constraint4.lower_bound(), Vector1d(55)));
   EXPECT_TRUE(CompareMatrices(constraint4.upper_bound(), Vector1d(kInf)));

--- a/systems/framework/test/output_port_test.cc
+++ b/systems/framework/test/output_port_test.cc
@@ -196,7 +196,7 @@ class LeafOutputPortTest : public ::testing::Test {
           &dummy_,  // implicit_cast<const System<T>*>(&dummy_)
           &dummy_,  // implicit_cast<SystemBase*>(&dummy_)
           "absport",
-          OutputPortIndex(dummy_.get_num_output_ports()),
+          OutputPortIndex(dummy_.num_output_ports()),
           dummy_.assign_next_dependency_ticket(), kAbstractValued, 0 /* size */,
           &dummy_.DeclareCacheEntry(
               "absport", alloc_string, calc_string));
@@ -206,7 +206,7 @@ class LeafOutputPortTest : public ::testing::Test {
           &dummy_,  // implicit_cast<const System<T>*>(&dummy_)
           &dummy_,  // implicit_cast<SystemBase*>(&dummy_)
           "vecport",
-          OutputPortIndex(dummy_.get_num_output_ports()),
+          OutputPortIndex(dummy_.num_output_ports()),
           dummy_.assign_next_dependency_ticket(), kVectorValued, 3 /* size */,
           &dummy_.DeclareCacheEntry(
               "vecport", alloc_myvector3, calc_vector3));
@@ -289,7 +289,7 @@ TEST_F(LeafOutputPortTest, ThrowIfNullAlloc) {
       &dummy_,  // implicit_cast<const System<T>*>(&dummy_)
       &dummy_,  // implicit_cast<SystemBase*>(&dummy_),
       "null_port",
-      OutputPortIndex(dummy_.get_num_output_ports()),
+      OutputPortIndex(dummy_.num_output_ports()),
       dummy_.assign_next_dependency_ticket(),
       kAbstractValued, 0 /* size */,
       &dummy_.DeclareCacheEntry("null", alloc_null, calc_string));
@@ -340,7 +340,7 @@ class SystemWithNStates : public LeafSystem<double> {
  private:
   void ReturnNumContinuous(const Context<double>& context, int* nc) const {
     ASSERT_NE(nc, nullptr);
-    *nc = context.get_state().get_continuous_state().size();
+    *nc = context.num_continuous_states();
   }
 };
 

--- a/systems/framework/test/single_output_vector_source_test.cc
+++ b/systems/framework/test/single_output_vector_source_test.cc
@@ -42,14 +42,14 @@ class SingleOutputVectorSourceTest : public ::testing::Test {
 
 // Tests that the output is correct.
 TEST_F(SingleOutputVectorSourceTest, OutputTest) {
-  ASSERT_EQ(context_->get_num_input_ports(), 0);
+  ASSERT_EQ(context_->num_input_ports(), 0);
   EXPECT_EQ(source_->get_output_port(0).Eval(*context_),
             Eigen::Vector3d::Ones());
 }
 
 // Tests that the state is empty.
 TEST_F(SingleOutputVectorSourceTest, IsStateless) {
-  EXPECT_EQ(context_->get_continuous_state().size(), 0);
+  EXPECT_EQ(context_->num_continuous_states(), 0);
 }
 
 // Some tag types used to select which constructor gets called.

--- a/systems/framework/test/system_constraint_test.cc
+++ b/systems/framework/test/system_constraint_test.cc
@@ -174,7 +174,7 @@ ExternalSystemConstraint ZeroStateDerivativeConstraint(
   // We don't handle discrete state yet, because to do so efficiently we'd
   // need a method like System::EvalDiscreteVariableUpdates, but only the Calc
   // flavor of that method currently exists.
-  DRAKE_DEMAND(dummy_context->get_num_discrete_state_groups() == 0);
+  DRAKE_DEMAND(dummy_context->num_discrete_state_groups() == 0);
   const int n_xc = dummy_context->get_continuous_state_vector().size();
   return ExternalSystemConstraint::MakeForAllScalars(
       "xc_dot = 0 and xd_{n+1} = 0",
@@ -196,7 +196,7 @@ ExternalSystemConstraint ZeroVelocityConstraint(
   auto dummy_context = shape.AllocateContext();
 
   // We can't handle discrete state yet, because of #9171.
-  DRAKE_DEMAND(dummy_context->get_num_discrete_state_groups() == 0);
+  DRAKE_DEMAND(dummy_context->num_discrete_state_groups() == 0);
   const int num_v = dummy_context->get_continuous_state().num_v();
   return ExternalSystemConstraint::MakeForAllScalars(
       "zero velocity", SystemConstraintBounds::Equality(num_v),

--- a/systems/framework/test/system_symbolic_inspector_test.cc
+++ b/systems/framework/test/system_symbolic_inspector_test.cc
@@ -159,8 +159,8 @@ TEST_F(SystemSymbolicInspectorTest, InputToOutput) {
 TEST_F(SystemSymbolicInspectorTest, AbstractContextThwartsSparsity) {
   system_.AddAbstractInputPort();
   inspector_ = std::make_unique<SystemSymbolicInspector>(system_);
-  for (int i = 0; i < system_.get_num_input_ports(); ++i) {
-    for (int j = 0; j < system_.get_num_output_ports(); ++j) {
+  for (int i = 0; i < system_.num_input_ports(); ++i) {
+    for (int j = 0; j < system_.num_output_ports(); ++j) {
       EXPECT_TRUE(inspector_->IsConnectedInputToOutput(i, j));
     }
   }

--- a/systems/framework/test/userscalar_acceptance_test.cc
+++ b/systems/framework/test/userscalar_acceptance_test.cc
@@ -45,8 +45,8 @@ class TestSystem : public LeafSystem<T> {
 TYPED_TEST(UserscalarAcceptanceTest, LeafSystemTest) {
   using T = TypeParam;
   const TestSystem<T> dut;
-  EXPECT_EQ(dut.get_num_input_ports(), 0);
-  EXPECT_EQ(dut.get_num_output_ports(), 1);
+  EXPECT_EQ(dut.num_input_ports(), 0);
+  EXPECT_EQ(dut.num_output_ports(), 1);
   auto context = dut.CreateDefaultContext();
   EXPECT_NE(context, nullptr);
 }

--- a/systems/framework/test/vector_system_test.cc
+++ b/systems/framework/test/vector_system_test.cc
@@ -148,20 +148,20 @@ TEST_F(VectorSystemTest, Topology) {
   TestVectorSystem dut;
 
   // One input port.
-  ASSERT_EQ(dut.get_num_input_ports(), 1);
+  ASSERT_EQ(dut.num_input_ports(), 1);
   const InputPort<double>& input_port = dut.get_input_port();
   EXPECT_EQ(input_port.get_data_type(), kVectorValued);
   EXPECT_EQ(input_port.size(), TestVectorSystem::kSize);
 
   // One output port.
-  ASSERT_EQ(dut.get_num_output_ports(), 1);
+  ASSERT_EQ(dut.num_output_ports(), 1);
   const OutputPort<double>& output_port = dut.get_output_port();
   EXPECT_EQ(output_port.get_data_type(), kVectorValued);
   EXPECT_EQ(output_port.size(), TestVectorSystem::kSize);
 
   // No state by default ...
   auto context = dut.CreateDefaultContext();
-  ASSERT_EQ(context->get_num_input_ports(), 1);
+  ASSERT_EQ(context->num_input_ports(), 1);
   EXPECT_TRUE(context->is_stateless());
 
   // ... but subclasses may declare it.
@@ -467,7 +467,7 @@ TEST_F(VectorSystemTest, NoInputNoOutputDiscreteTimeSystemTest) {
   dut.CalcDiscreteVariableUpdates(*context, discrete_updates.get());
   EXPECT_EQ(discrete_updates->get_vector(0)[0], 8.0);
 
-  EXPECT_EQ(dut.get_num_output_ports(), 0);
+  EXPECT_EQ(dut.num_output_ports(), 0);
 }
 
 /// A system that can use any scalar type: AutoDiff, symbolic form, etc.

--- a/systems/framework/vector_system.h
+++ b/systems/framework/vector_system.h
@@ -35,7 +35,7 @@ class VectorSystem : public LeafSystem<T> {
 
   /// Returns the sole input port.
   const InputPort<T>& get_input_port() const {
-    DRAKE_DEMAND(this->get_num_input_ports() == 1);
+    DRAKE_DEMAND(this->num_input_ports() == 1);
     return LeafSystem<T>::get_input_port(0);
   }
 
@@ -44,7 +44,7 @@ class VectorSystem : public LeafSystem<T> {
 
   /// Returns the sole output port.
   const OutputPort<T>& get_output_port() const {
-    DRAKE_DEMAND(this->get_num_output_ports() == 1);
+    DRAKE_DEMAND(this->num_output_ports() == 1);
     return LeafSystem<T>::get_output_port(0);
   }
 
@@ -92,7 +92,7 @@ class VectorSystem : public LeafSystem<T> {
   Eigen::VectorBlock<const VectorX<T>> EvalVectorInput(
       const Context<T>& context) const {
     // Obtain the block form of u (or the empty vector).
-    if (this->get_num_input_ports() > 0) {
+    if (this->num_input_ports() > 0) {
       return this->get_input_port().Eval(context);
     }
     static const never_destroyed<VectorX<T>> empty_vector(0);
@@ -104,9 +104,9 @@ class VectorSystem : public LeafSystem<T> {
   Eigen::VectorBlock<const VectorX<T>> GetVectorState(
       const Context<T>& context) const {
     // Obtain the block form of xc or xd.
-    DRAKE_ASSERT(context.get_num_abstract_states() == 0);
+    DRAKE_ASSERT(context.num_abstract_states() == 0);
     const BasicVector<T>* state_vector{};
-    if (context.get_num_discrete_state_groups() == 0) {
+    if (context.num_discrete_state_groups() == 0) {
       const VectorBase<T>& vector_base = context.get_continuous_state_vector();
       state_vector = dynamic_cast<const BasicVector<T>*>(&vector_base);
     } else {
@@ -182,13 +182,13 @@ class VectorSystem : public LeafSystem<T> {
   void CalcVectorOutput(const Context<T>& context,
                         BasicVector<T>* output) const {
     // Should only get here if we've declared an output.
-    DRAKE_ASSERT(this->get_num_output_ports() > 0);
+    DRAKE_ASSERT(this->num_output_ports() > 0);
 
     // Decide whether we should evaluate our input port and pass its value to
     // our subclass's DoCalcVectorOutput method.  When should_eval_input is
     // false, we will pass an empty vector instead of pulling on our input.
     bool should_eval_input = false;
-    if (this->get_num_input_ports() > 0) {
+    if (this->num_input_ports() > 0) {
       // We have an input port, but when our subclass's DoCalcVectorOutput is
       // not direct-feedthrough, then evaluating the input port might cause a
       // computational loop.  We should only evaluate the input when this
@@ -314,14 +314,14 @@ class VectorSystem : public LeafSystem<T> {
     // should be invariants guaranteed by the framework, so are asserted.
 
     // Exactly one input and output.
-    DRAKE_THROW_UNLESS(this->get_num_input_ports() <= 1);
-    DRAKE_THROW_UNLESS(this->get_num_output_ports() <= 1);
-    DRAKE_DEMAND(context.get_num_input_ports() <= 1);
+    DRAKE_THROW_UNLESS(this->num_input_ports() <= 1);
+    DRAKE_THROW_UNLESS(this->num_output_ports() <= 1);
+    DRAKE_DEMAND(context.num_input_ports() <= 1);
 
     // At most one of either continuous or discrete state.
-    DRAKE_THROW_UNLESS(context.get_num_abstract_states() == 0);
-    const int continuous_size = context.get_continuous_state().size();
-    const int num_discrete_groups = context.get_num_discrete_state_groups();
+    DRAKE_THROW_UNLESS(context.num_abstract_states() == 0);
+    const int continuous_size = context.num_continuous_states();
+    const int num_discrete_groups = context.num_discrete_state_groups();
     DRAKE_DEMAND(continuous_size >= 0);
     DRAKE_DEMAND(num_discrete_groups >= 0);
     DRAKE_THROW_UNLESS(num_discrete_groups <= 1);


### PR DESCRIPTION
This PR does two things, almost all trivial replace-all modifications and one case of doxygen regrouping (so much easier to review than you might think from the number of changes!). 

- Addresses some inconsistencies in the System/Context APIs.
    - adds Context::num_continuous_states() which was oddly absent
    - fixed all "count" methods in Context and System to begin with `num` rather then `get_num` (had a random assortment before).
    - provided camel-case `SetTime()` and `SetAccuracy()` methods to replace the misnamed snake_case ones (these are cache-invalidating). 
    - now-obsolete methods are still present but "pre-deprecated" (hidden from Doxygen). I removed all uses from systems/framework and systems/analysis but Drake-wide removal will take another PR (and isn't as urgent as providing the consistent names for use in examples)
- Groups the dangerous Context::get_mutable() methods together in Doxygen
    - This is the bulk of the change in context.h -- relocation only. That's to prepare for adding safer state modification methods as a necessary yak-shave before enabling caching-by-default.

Resolves #10993

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10995)
<!-- Reviewable:end -->
