### PR TITLE
Remove the "before context allocation" requirement from SceneGraph

### DIFF
--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -25,10 +25,6 @@ using systems::SystemTypeTag;
 using std::make_unique;
 using std::vector;
 
-// TODO(SeanCurtis-TRI): Fix this so that it's invocation ends with ();.
-// https://github.com/RobotLocomotion/drake/issues/8959
-#define GS_THROW_IF_CONTEXT_ALLOCATED ThrowIfContextAllocated(__FUNCTION__);
-
 namespace {
 template <typename T>
 class GeometryStateValue final : public Value<GeometryState<T>> {
@@ -93,7 +89,6 @@ SceneGraph<T>::SceneGraph(const SceneGraph<U>& other) : SceneGraph() {
     *initial_state_ = *(other.initial_state_->ToAutoDiffXd());
     model_inspector_.set(initial_state_);
   }
-  context_has_been_allocated_ = other.context_has_been_allocated_;
 
   // We need to guarantee that the same source ids map to the same port indices.
   // We'll do this by processing the source ids in monotonically increasing
@@ -123,7 +118,6 @@ SceneGraph<T>::SceneGraph(const SceneGraph<U>& other) : SceneGraph() {
 
 template <typename T>
 SourceId SceneGraph<T>::RegisterSource(const std::string& name) {
-  GS_THROW_IF_CONTEXT_ALLOCATED
   SourceId source_id = initial_state_->RegisterNewSource(name);
   MakeSourcePorts(source_id);
   return source_id;
@@ -144,14 +138,12 @@ const systems::InputPort<T>& SceneGraph<T>::get_source_pose_port(
 template <typename T>
 FrameId SceneGraph<T>::RegisterFrame(SourceId source_id,
                                      const GeometryFrame& frame) {
-  GS_THROW_IF_CONTEXT_ALLOCATED
   return initial_state_->RegisterFrame(source_id, frame);
 }
 
 template <typename T>
 FrameId SceneGraph<T>::RegisterFrame(SourceId source_id, FrameId parent_id,
                                      const GeometryFrame& frame) {
-  GS_THROW_IF_CONTEXT_ALLOCATED
   return initial_state_->RegisterFrame(source_id, parent_id, frame);
 }
 
@@ -159,7 +151,6 @@ template <typename T>
 GeometryId SceneGraph<T>::RegisterGeometry(
     SourceId source_id, FrameId frame_id,
     std::unique_ptr<GeometryInstance> geometry) {
-  GS_THROW_IF_CONTEXT_ALLOCATED
   return initial_state_->RegisterGeometry(source_id, frame_id,
                                           std::move(geometry));
 }
@@ -177,7 +168,6 @@ template <typename T>
 GeometryId SceneGraph<T>::RegisterGeometry(
     SourceId source_id, GeometryId geometry_id,
     std::unique_ptr<GeometryInstance> geometry) {
-  GS_THROW_IF_CONTEXT_ALLOCATED
   return initial_state_->RegisterGeometryWithParent(source_id, geometry_id,
                                                     std::move(geometry));
 }
@@ -195,14 +185,12 @@ GeometryId SceneGraph<T>::RegisterGeometry(
 template <typename T>
 GeometryId SceneGraph<T>::RegisterAnchoredGeometry(
     SourceId source_id, std::unique_ptr<GeometryInstance> geometry) {
-  GS_THROW_IF_CONTEXT_ALLOCATED
   return initial_state_->RegisterAnchoredGeometry(source_id,
                                                   std::move(geometry));
 }
 
 template <typename T>
 void SceneGraph<T>::RemoveGeometry(SourceId source_id, GeometryId geometry_id) {
-  GS_THROW_IF_CONTEXT_ALLOCATED
   initial_state_->RemoveGeometry(source_id, geometry_id);
 }
 
@@ -218,7 +206,6 @@ template <typename T>
 void SceneGraph<T>::AssignRole(SourceId source_id,
                                GeometryId geometry_id,
                                ProximityProperties properties) {
-  GS_THROW_IF_CONTEXT_ALLOCATED
   initial_state_->AssignRole(source_id, geometry_id, std::move(properties));
 }
 
@@ -226,19 +213,16 @@ template <typename T>
 void SceneGraph<T>::AssignRole(SourceId source_id,
                                GeometryId geometry_id,
                                IllustrationProperties properties) {
-  GS_THROW_IF_CONTEXT_ALLOCATED
   initial_state_->AssignRole(source_id, geometry_id, std::move(properties));
 }
 
 template <typename T>
 const SceneGraphInspector<T>& SceneGraph<T>::model_inspector() const {
-  GS_THROW_IF_CONTEXT_ALLOCATED
   return model_inspector_;
 }
 
 template <typename T>
 void SceneGraph<T>::ExcludeCollisionsWithin(const GeometrySet& geometry_set) {
-  GS_THROW_IF_CONTEXT_ALLOCATED
   initial_state_->ExcludeCollisionsWithin(geometry_set);
 }
 
@@ -253,7 +237,6 @@ void SceneGraph<T>::ExcludeCollisionsWithin(
 template <typename T>
 void SceneGraph<T>::ExcludeCollisionsBetween(const GeometrySet& setA,
                                              const GeometrySet& setB) {
-  GS_THROW_IF_CONTEXT_ALLOCATED
   initial_state_->ExcludeCollisionsBetween(setA, setB);
 }
 
@@ -408,19 +391,8 @@ void SceneGraph<T>::FullPoseUpdate(const GeometryContext<T>& context) const {
 
 template <typename T>
 std::unique_ptr<LeafContext<T>> SceneGraph<T>::DoMakeLeafContext() const {
-  // Disallow further geometry source additions.
-  context_has_been_allocated_ = true;
   DRAKE_ASSERT(geometry_state_index_ >= 0);
   return make_unique<GeometryContext<T>>(geometry_state_index_);
-}
-
-template <typename T>
-void SceneGraph<T>::ThrowIfContextAllocated(const char* source_method) const {
-  if (context_has_been_allocated_) {
-    throw std::logic_error("The call to " + std::string(source_method) +
-                           " is invalid; a "
-                           "context has already been allocated.");
-  }
 }
 
 template <typename T>
@@ -435,9 +407,6 @@ void SceneGraph<T>::ThrowUnlessRegistered(SourceId source_id,
 // Explicitly instantiates on the most common scalar types.
 template class SceneGraph<double>;
 template class SceneGraph<AutoDiffXd>;
-
-// Don't leave the macro defined.
-#undef GS_THROW_IF_CONTEXT_ALLOCATED
 
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -192,6 +192,11 @@ class QueryObject;
  The second variant causes %SceneGraph to modify the data stored in the provided
  Context to be modified _instead of the internal model_.
 
+ The two interfaces _can_ be used interchangeably. However, modifications to
+ `this` %SceneGraph's underlying model will _not_ affect previously allocated
+ Context instances. A new Context should be allocated after modifying the
+ model.
+
  @note In this initial version, the only methods with the Context-modifying
  variant are those methods that _do not_ change the the semantics of the input
  or output ports. Modifications that make such changes must be coordinated
@@ -251,12 +256,14 @@ class SceneGraph final : public systems::LeafSystem<T> {
    dynamic geometry is registered (via RegisterGeometry/RegisterFrame), then
    the context-dependent pose values must be provided on an input port.
    See get_source_pose_port().
+
+   This method modifies the underlying model and requires a new Context to be
+   allocated.
+
    @param name          The optional name of the source. If none is provided
-                        (or the empty string) a unique name will be defined by
+                        (or the empty string) a default name will be defined by
                         SceneGraph's logic.
-   @throws std::logic_error if a context has already been allocated for this
-                            %SceneGraph.
-   @see GeometryState::RegisterNewSource()  */
+   @throws std::logic_error if the name is not unique.  */
   SourceId RegisterSource(const std::string& name = "");
 
   /** Reports if the given source id is registered.
@@ -285,8 +292,8 @@ class SceneGraph final : public systems::LeafSystem<T> {
 
   /** @name             Topology Manipulation
    Topology manipulation consists of changing the data contained in the world.
-   This includes registering a new geometry source, adding or
-   removing frames, and adding or removing geometries.
+   This includes registering a new geometry source, adding frames, adding or
+   removing geometries, modifying geometry properties, etc.
 
    The work flow for adding geometry to the SceneGraph is as follows:
 
@@ -322,29 +329,36 @@ class SceneGraph final : public systems::LeafSystem<T> {
    registration yet, as these methods modify the port semantics.  */
   //@{
 
-  /** Registers a new frame F on for this source. This hangs frame F on the
+  /** Registers a new frame F for this source. This hangs frame F on the
    world frame (W). Its pose is defined relative to the world frame (i.e,
    `X_WF`). Returns the corresponding unique frame id.
+
+   This method modifies the underlying model and requires a new Context to be
+   allocated.
+
    @param source_id     The id for the source registering the frame.
    @param frame         The definition of the frame to add.
-   @returns  A newly allocated frame id.
+   @returns A unique identifier for the added frame.
    @throws std::logic_error  If the `source_id` does _not_ map to a registered
-                             source or if a context has been allocated.  */
+                             source.  */
   FrameId RegisterFrame(SourceId source_id, const GeometryFrame& frame);
 
   /** Registers a new frame F for this source. This hangs frame F on another
    previously registered frame P (indicated by `parent_id`). The pose of the new
    frame is defined relative to the parent frame (i.e., `X_PF`).  Returns the
    corresponding unique frame id.
+
+   This method modifies the underlying model and requires a new Context to be
+   allocated.
+
    @param source_id    The id for the source registering the frame.
    @param parent_id    The id of the parent frame P.
    @param frame        The frame to register.
-   @returns  A newly allocated frame id.
-   @throws std::logic_error  1. If the `source_id` does _not_ map to a
-                             registered source,
-                             2. If the `parent_id` does _not_ map to a known
-                             frame or does not belong to the source, or
-                             3. a context has been allocated.  */
+   @returns A unique identifier for the added frame.
+   @throws std::logic_error  if a) the `source_id` does _not_ map to a
+                             registered source, or
+                             b) If the `parent_id` does _not_ map to a known
+                             frame or does not belong to the source.  */
   FrameId RegisterFrame(SourceId source_id, FrameId parent_id,
                         const GeometryFrame& frame);
 
@@ -353,19 +367,21 @@ class SceneGraph final : public systems::LeafSystem<T> {
    geometry is defined in a fixed pose relative to F (i.e., `X_FG`).
    Returns the corresponding unique geometry id.
 
-   Roles will be assigned to the geometry if the corresponding properties have
-   been assigned to the instance.
+   Roles will be assigned to the registered geometry if the corresponding
+   GeometryInstance `geometry` has had properties assigned.
+
+   This method modifies the underlying model and requires a new Context to be
+   allocated.
 
    @param source_id   The id for the source registering the geometry.
    @param frame_id    The id for the frame F to hang the geometry on.
    @param geometry    The geometry G to affix to frame F.
    @return A unique identifier for the added geometry.
-   @throws std::logic_error  1. the `source_id` does _not_ map to a registered
-                             source,
-                             2. the `frame_id` doesn't belong to the source,
-                             3. the `geometry` is equal to `nullptr`,
-                             4. a context has been allocated, or
-                             5. the geometry's name doesn't satisfy the
+   @throws std::logic_error  if a) the `source_id` does _not_ map to a
+                             registered source,
+                             b) the `frame_id` doesn't belong to the source,
+                             c) the `geometry` is equal to `nullptr`, or
+                             d) the geometry's name doesn't satisfy the
                              requirements outlined in GeometryInstance.  */
   GeometryId RegisterGeometry(SourceId source_id, FrameId frame_id,
                               std::unique_ptr<GeometryInstance> geometry);
@@ -383,19 +399,21 @@ class SceneGraph final : public systems::LeafSystem<T> {
    `X_PG`). By induction, this geometry is effectively rigidly affixed to the
    frame that P is affixed to. Returns the corresponding unique geometry id.
 
-   Roles will be assigned to the geometry if the corresponding properties have
-   been assigned to the instance.
+   Roles will be assigned to the registered geometry if the corresponding
+   GeometryInstance `geometry` has had properties assigned.
+
+   This method modifies the underlying model and requires a new Context to be
+   allocated.
 
    @param source_id    The id for the source registering the geometry.
    @param geometry_id  The id for the parent geometry P.
    @param geometry     The geometry G to add.
    @return A unique identifier for the added geometry.
-   @throws std::logic_error 1. the `source_id` does _not_ map to a registered
+   @throws std::logic_error if a) the `source_id` does _not_ map to a registered
                             source,
-                            2. the `geometry_id` doesn't belong to the source,
-                            3. the `geometry` is equal to `nullptr`,
-                            4. a context has been allocated, or
-                            5. the geometry's name doesn't satisfy the
+                            b) the `geometry_id` doesn't belong to the source,
+                            c) the `geometry` is equal to `nullptr`, or
+                            d) the geometry's name doesn't satisfy the
                             requirements outlined in GeometryInstance.  */
   GeometryId RegisterGeometry(SourceId source_id, GeometryId geometry_id,
                               std::unique_ptr<GeometryInstance> geometry);
@@ -411,16 +429,18 @@ class SceneGraph final : public systems::LeafSystem<T> {
    G from the world frame (W). Its pose is defined in that frame (i.e., `X_WG`).
    Returns the corresponding unique geometry id.
 
-   Roles will be assigned to the geometry if the corresponding properties have
-   been assigned to the instance.
+   Roles will be assigned to the registered geometry if the corresponding
+   GeometryInstance `geometry` has had properties assigned.
+
+   This method modifies the underlying model and requires a new Context to be
+   allocated.
 
    @param source_id     The id for the source registering the frame.
    @param geometry      The anchored geometry G to add to the world.
-   @returns The index for the added geometry.
-   @throws std::logic_error  1. the `source_id` does _not_ map to a registered
-                             source,
-                             2. a context has been allocated, or
-                             3. the geometry's name doesn't satisfy the
+   @return A unique identifier for the added geometry.
+   @throws std::logic_error  if a) the `source_id` does _not_ map to a
+                             registered source or
+                             b) the geometry's name doesn't satisfy the
                              requirements outlined in GeometryInstance.  */
   GeometryId RegisterAnchoredGeometry(
       SourceId source_id, std::unique_ptr<GeometryInstance> geometry);
@@ -428,13 +448,15 @@ class SceneGraph final : public systems::LeafSystem<T> {
   /** Removes the given geometry G (indicated by `geometry_id`) from the given
    source's registered geometries. All registered geometries hanging from
    this geometry will also be removed.
+
+   This method modifies the underlying model and requires a new Context to be
+   allocated.
+
    @param source_id   The identifier for the owner geometry source.
    @param geometry_id The identifier of the geometry to remove.
-   @throws std::logic_error If:
-                            1. The `source_id` is not a registered source,
-                            2. the `geometry_id` doesn't belong to the source,
-                               or
-                            3. a context has been allocated.  */
+   @throws std::logic_error if a) the `source_id` is not a registered source, or
+                            b) the `geometry_id` doesn't belong to the source.
+   */
   void RemoveGeometry(SourceId source_id, GeometryId geometry_id);
 
   /** systems::Context-modifying variant of RemoveGeometry(). Rather than
@@ -459,8 +481,9 @@ class SceneGraph final : public systems::LeafSystem<T> {
      - The geometry id is invalid.
      - The geometry id is not owned by the given source id.
      - The indicated role has already been assigned to the geometry.
-     - A context has been allocated.
-   */
+
+   This methods modify the underlying model and require a new Context to be
+   allocated.  */
 
   // TODO(SeanCurtis-TRI): Provide mechanism for modifying properties and/or
   // removing roles.
@@ -482,8 +505,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
     return internal::InternalFrame::world_frame_id();
   }
 
-  /** Returns an inspector on the system's *model* scene graph data.
-   @throws std::logic_error If a context has been allocated.*/
+  /** Returns an inspector on the system's _model_ scene graph data.  */
   const SceneGraphInspector<T>& model_inspector() const;
 
   /** @name         Collision filtering
@@ -511,8 +533,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
    These filter methods essentially create new sets of pairs and then subtract
    them from the candidate set C. See each method for details.
 
-   Modifications to C _must_ be performed before context allocation.
-   */
+   Modifications to C _must_ be performed before context allocation.  */
   //@{
 
   /** Excludes geometry pairs from collision evaluation by updating the
@@ -524,6 +545,9 @@ class SceneGraph final : public systems::LeafSystem<T> {
    assigned, those geometries will _still_ not be part of any collision filters.
    Proximity roles should _generally_ be assigned prior to collision filter
    configuration.
+
+   This method modifies the underlying model and requires a new Context to be
+   allocated.
 
    @throws std::logic_error if the set includes ids that don't exist in the
                             scene graph.  */
@@ -546,6 +570,9 @@ class SceneGraph final : public systems::LeafSystem<T> {
    assigned, those geometries will _still_ not be part of any collision filters.
    Proximity roles should _generally_ be assigned prior to collision filter
    configuration.
+
+   This method modifies the underlying model and requires a new Context to be
+   allocated.
 
    @throws std::logic_error if the groups include ids that don't exist in the
                             scene graph.   */
@@ -611,11 +638,6 @@ class SceneGraph final : public systems::LeafSystem<T> {
   //      above.
   std::unique_ptr<systems::LeafContext<T>> DoMakeLeafContext() const override;
 
-  // Helper method for throwing an exception if a context has *ever* been
-  // allocated by this system. The invoking method should pass it's name so
-  // that the error message can include that detail.
-  void ThrowIfContextAllocated(const char* source_method) const;
-
   // Asserts the given source_id is registered, throwing an exception whose
   // message is the given message with the source_id appended if not.
   void ThrowUnlessRegistered(SourceId source_id, const char* message) const;
@@ -641,9 +663,6 @@ class SceneGraph final : public systems::LeafSystem<T> {
   // model_abstract_states_.
   GeometryState<T>* initial_state_{};
   SceneGraphInspector<T> model_inspector_;
-
-  // TODO(SeanCurtis-TRI): Get rid of this.
-  mutable bool context_has_been_allocated_{false};
 
   // The index of the geometry state in the context's abstract state.
   int geometry_state_index_{-1};

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -48,8 +48,7 @@ class QueryObjectTester {
   static void set_query_object(QueryObject<T>* q_object,
                                const SceneGraph<T>* scene_graph,
                                const GeometryContext<T>* context) {
-    q_object->context_ = context;
-    q_object->scene_graph_ = scene_graph;
+    q_object->set(context, scene_graph);
   }
 };
 
@@ -144,15 +143,12 @@ class SceneGraphTest : public ::testing::Test {
 // Test sources.
 
 // Tests registration using a default source name. Confirms that the source
-// registered and that a name is available.
+// registered.
 TEST_F(SceneGraphTest, RegisterSourceDefaultName) {
   SourceId id = scene_graph_.RegisterSource();
   EXPECT_TRUE(id.is_valid());
-  EXPECT_NO_THROW(scene_graph_.model_inspector().GetSourceName(id));
-  AllocateContext();
-  EXPECT_THROW(scene_graph_.model_inspector().GetSourceName(id),
-               std::logic_error);
   EXPECT_TRUE(scene_graph_.SourceIsRegistered(id));
+  EXPECT_TRUE(scene_graph_.model_inspector().SourceIsRegistered(id));
 }
 
 // Tests registration using a specified source name. Confirms that the source
@@ -161,18 +157,26 @@ TEST_F(SceneGraphTest, RegisterSourceSpecifiedName) {
   std::string name = "some_unique_name";
   SourceId id = scene_graph_.RegisterSource(name);
   EXPECT_TRUE(id.is_valid());
-  EXPECT_EQ(scene_graph_.model_inspector().GetSourceName(id), name);
-  AllocateContext();
   EXPECT_TRUE(scene_graph_.SourceIsRegistered(id));
+  EXPECT_EQ(scene_graph_.model_inspector().GetSourceName(id), name);
 }
 
-// Tests that sources cannot be registered after context allocation.
-TEST_F(SceneGraphTest, PoseContextSourceRegistration) {
+// Tests that sources can be registered after context allocation; it should be
+// considered registered by the scene graph, but *not* the previously
+// allocated context.. It also implicitly tests that the model inspector is
+// available _after_ allocation.
+TEST_F(SceneGraphTest, RegisterSourcePostContext) {
   AllocateContext();
+  const std::string new_source_name = "register_source_post_context";
+  SourceId new_source = scene_graph_.RegisterSource(new_source_name);
+  EXPECT_TRUE(scene_graph_.SourceIsRegistered(new_source));
+  // Contained in scene graph.
+  EXPECT_EQ(scene_graph_.model_inspector().GetSourceName(new_source),
+            new_source_name);
+  // Not found in allocated context.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      scene_graph_.RegisterSource(), std::logic_error,
-      "The call to RegisterSource is invalid; a context has already been "
-      "allocated.");
+      query_object().inspector().GetSourceName(new_source),
+      std::logic_error, "Querying source name for an invalid source id.*");
 }
 
 // Tests ability to report if a source is registered or not.
@@ -204,56 +208,61 @@ TEST_F(SceneGraphTest, AcquireInputPortsAfterAllocation) {
   EXPECT_NO_THROW(scene_graph_.get_source_pose_port(id));
 }
 
-// Test topology changes (registration, removal, clearing, etc.)
-
-// Tests that topology operations (registration, removal, clearing, etc.) after
-// allocation is not allowed -- and an exception with an intelligible message is
-// thrown. The underlying handling of the *values* of the parameters is handled
-// in the GeometryState unit tests. SceneGraph merely confirms the context
-// hasn't been allocated.
+// Tests that topology operations after allocation _are_ allowed. This compares
+// the GeometryState instances of the original context and the new context.
+// This doesn't check the details of each of the registered members -- just that
+// it was registered. It relies on the GeometryState tests to confirm that the
+// details are correct.
 TEST_F(SceneGraphTest, TopologyAfterAllocation) {
   SourceId id = scene_graph_.RegisterSource();
+  FrameId old_frame_id = scene_graph_.RegisterFrame(
+      id, GeometryFrame("old_frame", Isometry3<double>::Identity()));
+  // This geometry will be removed after allocation.
+  GeometryId old_geometry_id = scene_graph_.RegisterGeometry(id, old_frame_id,
+      make_sphere_instance());
+
   AllocateContext();
 
-  // Attach frame to world.
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      scene_graph_.RegisterFrame(
-          id, GeometryFrame("frame", Isometry3<double>::Identity())),
-      std::logic_error,
-      "The call to RegisterFrame is invalid; a context has already been "
-      "allocated.");
+  FrameId parent_frame_id = scene_graph_.RegisterFrame(
+      id, GeometryFrame("frame", Isometry3<double>::Identity()));
+  FrameId child_frame_id = scene_graph_.RegisterFrame(
+      id, parent_frame_id,
+      GeometryFrame("frame", Isometry3<double>::Identity()));
+  GeometryId parent_geometry_id = scene_graph_.RegisterGeometry(
+      id, parent_frame_id, make_sphere_instance());
+  GeometryId child_geometry_id = scene_graph_.RegisterGeometry(
+      id, parent_geometry_id, make_sphere_instance());
+  GeometryId anchored_id =
+      scene_graph_.RegisterAnchoredGeometry(id, make_sphere_instance());
+  scene_graph_.RemoveGeometry(id, old_geometry_id);
 
-  // Attach frame to another frame.
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      scene_graph_.RegisterFrame(
-          id, FrameId::get_new_id(),
-          GeometryFrame("frame", Isometry3<double>::Identity())),
-      std::logic_error,
-      "The call to RegisterFrame is invalid; a context has already been "
-      "allocated.");
+  const SceneGraphInspector<double>& model_inspector =
+      scene_graph_.model_inspector();
+  const SceneGraphInspector<double>& context_inspector =
+      query_object().inspector();
 
-  // Attach geometry to frame.
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      scene_graph_.RegisterGeometry(id, FrameId::get_new_id(),
-                                    make_sphere_instance()),
-      std::logic_error,
-      "The call to RegisterGeometry is invalid; a context has already been "
-      "allocated.");
+  // Now test registration (non-registration) in the new (old) state,
+  // respectively.
+  EXPECT_TRUE(model_inspector.BelongsToSource(parent_frame_id, id));
+  EXPECT_TRUE(model_inspector.BelongsToSource(child_frame_id, id));
+  EXPECT_TRUE(model_inspector.BelongsToSource(parent_geometry_id, id));
+  EXPECT_TRUE(model_inspector.BelongsToSource(child_geometry_id, id));
+  EXPECT_TRUE(model_inspector.BelongsToSource(anchored_id, id));
+  // Removed geometry from SceneGraph; "invalid" id throws.
+  EXPECT_THROW(model_inspector.BelongsToSource(old_geometry_id, id),
+               std::logic_error);
 
-  // Attach geometry to another geometry.
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      scene_graph_.RegisterGeometry(id, GeometryId::get_new_id(),
-                                    make_sphere_instance()),
-      std::logic_error,
-      "The call to RegisterGeometry is invalid; a context has already been "
-      "allocated.");
-
-  // Attach anchored geometry to world.
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      scene_graph_.RegisterAnchoredGeometry(id, make_sphere_instance()),
-      std::logic_error,
-      "The call to RegisterAnchoredGeometry is invalid; a context has already "
-      "been allocated.");
+  EXPECT_THROW(context_inspector.BelongsToSource(parent_frame_id, id),
+               std::logic_error);
+  EXPECT_THROW(context_inspector.BelongsToSource(child_frame_id, id),
+               std::logic_error);
+  EXPECT_THROW(context_inspector.BelongsToSource(parent_geometry_id, id),
+               std::logic_error);
+  EXPECT_THROW(context_inspector.BelongsToSource(child_geometry_id, id),
+               std::logic_error);
+  EXPECT_THROW(context_inspector.BelongsToSource(anchored_id, id),
+               std::logic_error);
+  EXPECT_TRUE(context_inspector.BelongsToSource(old_geometry_id, id));
 }
 
 // Confirms that the direct feedthrough logic is correct -- there is total
@@ -291,8 +300,8 @@ TEST_F(SceneGraphTest, FullPoseUpdateAnchoredOnly) {
       SceneGraphTester::FullPoseUpdate(scene_graph_, *geom_context_));
 }
 
-// Tests transmogrification of SceneGraph in the case where a Context has
-// *not* been allocated yet. Registration should still be possible.
+// Tests operations on a transmogrified SceneGraph. Whether a context has been
+// allocated or not, subsequent operations should be allowed.
 TEST_F(SceneGraphTest, TransmogrifyWithoutAllocation) {
   SourceId s_id = scene_graph_.RegisterSource();
   // This should allow additional geometry registration.
@@ -303,14 +312,13 @@ TEST_F(SceneGraphTest, TransmogrifyWithoutAllocation) {
   EXPECT_NO_THROW(
       scene_graph_ad.RegisterAnchoredGeometry(s_id, make_sphere_instance()));
 
-  // After allocation, registration should *not* be valid.
+  // After allocation, registration should _still_ be valid.
   AllocateContext();
   system_ad = scene_graph_.ToAutoDiffXd();
   SceneGraph<AutoDiffXd>& scene_graph_ad2 =
       *dynamic_cast<SceneGraph<AutoDiffXd>*>(system_ad.get());
-  EXPECT_THROW(
-      scene_graph_ad2.RegisterAnchoredGeometry(s_id, make_sphere_instance()),
-      std::logic_error);
+  EXPECT_NO_THROW(
+      scene_graph_ad2.RegisterAnchoredGeometry(s_id, make_sphere_instance()));
 }
 
 // Tests that the ports are correctly mapped.
@@ -354,23 +362,19 @@ TEST_F(SceneGraphTest, TransmogrifyContext) {
                std::logic_error);
 }
 
-// Tests that exercising the collision filtering logic *after* allocation leads
-// to an exception being thrown.
+// Tests that exercising the collision filtering logic *after* allocation is
+// allowed.
 TEST_F(SceneGraphTest, PostAllocationCollisionFiltering) {
+  SourceId source_id = scene_graph_.RegisterSource("filter_after_allocation");
+  FrameId frame_id = scene_graph_.RegisterFrame(
+      source_id, GeometryFrame("dummy", Isometry3d::Identity()));
   AllocateContext();
 
-  GeometrySet geometry_set1{FrameId::get_new_id()};
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      scene_graph_.ExcludeCollisionsWithin(geometry_set1), std::logic_error,
-      "The call to ExcludeCollisionsWithin is invalid; a context has already "
-      "been allocated.");
+  GeometrySet geometry_set{frame_id};
+  EXPECT_NO_THROW(scene_graph_.ExcludeCollisionsWithin(geometry_set));
 
-  GeometrySet geometry_set2{FrameId::get_new_id()};
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      scene_graph_.ExcludeCollisionsBetween(geometry_set1, geometry_set2),
-      std::logic_error,
-      "The call to ExcludeCollisionsBetween is invalid; a context has already "
-      "been allocated.");
+  EXPECT_NO_THROW(
+      scene_graph_.ExcludeCollisionsBetween(geometry_set, geometry_set));
 }
 
 // Tests the model inspector. Exercises a token piece of functionality. The


### PR DESCRIPTION
SceneGraph previously had documented behavior that all changes must be made prior to the allocation of a Context. This was enforced with a runtime test.

This behavior is now deprecated in favor of documenting the difference between the SceneGraph model and the copy in the context. Behavior, documentation, and tests have been updated to reflect the new design.

It also cleaned up the `@throws` documentation to make it print better in doxygen (and be compatible with python documentation extraction). The throw criteria changed, so it made sense to hit the formatting as well.

resolves #8959
relates to #9912

```
Category            added  modified  removed  
----------------------------------------------
code                16     40        42       
comments            25     52        22       
blank               13     0         4        
----------------------------------------------
TOTAL               54     92        68  
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/10999)
<!-- Reviewable:end -->
