### PR TITLE
Maliput: Modifies Intersection to hold a RightOfWayPhaseRing::Id

### DIFF
--- a/automotive/maliput/api/intersection.cc
+++ b/automotive/maliput/api/intersection.cc
@@ -5,11 +5,9 @@ namespace maliput {
 namespace api {
 
 Intersection::Intersection(const Id& id,
-    const std::vector<rules::LaneSRange>& region,
-    const rules::RightOfWayPhaseRing* ring)
-    : id_(id), region_(region), ring_(ring) {
-  DRAKE_THROW_UNLESS(ring != nullptr);
-}
+                           const std::vector<rules::LaneSRange>& region,
+                           const rules::RightOfWayPhaseRing::Id& ring_id)
+    : id_(id), region_(region), ring_id_(ring_id) {}
 
 }  // namespace api
 }  // namespace maliput

--- a/automotive/maliput/api/intersection.h
+++ b/automotive/maliput/api/intersection.h
@@ -31,10 +31,10 @@ class Intersection {
   /// @param region The region of the road network that should be considered
   /// part of the intersection.
   ///
-  /// @param ring The ring that defines the phases within the intersection. The
-  /// pointer must remain valid throughout this class instance's lifetime.
+  /// @param ring_id The ID of the ring that defines the phases within the
+  /// intersection.
   Intersection(const Id& id, const std::vector<rules::LaneSRange>& region,
-               const rules::RightOfWayPhaseRing* ring);
+               const rules::RightOfWayPhaseRing::Id& ring_id);
 
   virtual ~Intersection() = default;
 
@@ -48,14 +48,15 @@ class Intersection {
   /// Returns the region. See constructor parameter @p region for more details.
   const std::vector<rules::LaneSRange>& region() const { return region_; }
 
-  /// Returns the rules::RightOfWayPhaseRing that applies to this intersection.
-  /// See constructor parameter @p ring for more details.
-  const rules::RightOfWayPhaseRing* ring() const { return ring_; }
+  /// Returns the rules::RightOfWayPhaseRing::Id of the
+  /// rules::RightOfWayPhaseRing that applies to this intersection.
+  /// See constructor parameter @p ring_id for more details.
+  const rules::RightOfWayPhaseRing::Id& ring_id() const { return ring_id_; }
 
  private:
   const Id id_;
   const std::vector<rules::LaneSRange> region_;
-  const rules::RightOfWayPhaseRing* ring_{};
+  const rules::RightOfWayPhaseRing::Id ring_id_;
 };
 
 }  // namespace api

--- a/automotive/maliput/api/test/mock.cc
+++ b/automotive/maliput/api/test/mock.cc
@@ -128,8 +128,8 @@ class MockIntersection final : public Intersection {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MockIntersection)
   explicit MockIntersection(const Intersection::Id& id,
-                            const rules::RightOfWayPhaseRing* ring)
-      : Intersection(id, {}, ring) {}
+                            const rules::RightOfWayPhaseRing::Id& ring_id)
+      : Intersection(id, {}, ring_id) {}
 
  private:
   const optional<rules::RightOfWayPhaseProvider::Result> Phase()
@@ -189,8 +189,8 @@ CreateRightOfWayPhaseProvider() {
 }
 
 std::unique_ptr<Intersection> CreateIntersection(
-    const Intersection::Id& id, const rules::RightOfWayPhaseRing* ring) {
-  return std::make_unique<MockIntersection>(id, ring);
+    const Intersection::Id& id, const rules::RightOfWayPhaseRing::Id& ring_id) {
+  return std::make_unique<MockIntersection>(id, ring_id);
 }
 
 }  // namespace test

--- a/automotive/maliput/api/test/mock.h
+++ b/automotive/maliput/api/test/mock.h
@@ -49,7 +49,7 @@ std::unique_ptr<rules::RightOfWayPhaseProvider> CreateRightOfWayPhaseProvider();
 
 /// Returns an arbitrary Intersection.
 std::unique_ptr<Intersection> CreateIntersection(
-    const Intersection::Id& id, const rules::RightOfWayPhaseRing* ring);
+    const Intersection::Id& id, const rules::RightOfWayPhaseRing::Id& ring_id);
 
 }  // namespace test
 }  // namespace api

--- a/automotive/maliput/api/test/road_network_test.cc
+++ b/automotive/maliput/api/test/road_network_test.cc
@@ -84,9 +84,9 @@ TEST_F(RoadNetworkTest, InstantiateAndUseAccessors) {
       rules::RightOfWayPhaseRing::Id("ring2_id"),
       {rules::RightOfWayPhase(rules::RightOfWayPhase::Id("phase_id_2"), {})});
   intersections.emplace_back(
-      test::CreateIntersection(intersection_id_1, &mock_ring_1));
+      test::CreateIntersection(intersection_id_1, mock_ring_1.id()));
   intersections.emplace_back(
-      test::CreateIntersection(intersection_id_2, &mock_ring_2));
+      test::CreateIntersection(intersection_id_2, mock_ring_2.id()));
   std::vector<SpeedLimitRule> speed_limits;
   const SpeedLimitRule::Id speed_limit_id("speed_limit_id");
   speed_limits.emplace_back(SpeedLimitRule(

--- a/automotive/maliput/base/intersection.cc
+++ b/automotive/maliput/base/intersection.cc
@@ -5,19 +5,19 @@ namespace maliput {
 
 Intersection::Intersection(const Id& id,
                            const std::vector<api::rules::LaneSRange>& region,
-                           const api::rules::RightOfWayPhaseRing* ring,
+                           const api::rules::RightOfWayPhaseRing::Id& ring_id,
                            SimpleRightOfWayPhaseProvider* phase_provider)
-    : api::Intersection(id, region, ring), phase_provider_(phase_provider) {
+    : api::Intersection(id, region, ring_id), phase_provider_(phase_provider) {
   DRAKE_THROW_UNLESS(phase_provider_ != nullptr);
 }
 
 const optional<api::rules::RightOfWayPhaseProvider::Result>
 Intersection::Phase() const {
-  return phase_provider_->GetPhase(ring()->id());
+  return phase_provider_->GetPhase(ring_id());
 }
 
 void Intersection::SetPhase(const api::rules::RightOfWayPhase::Id& phase_id) {
-  phase_provider_->SetPhase(ring()->id(), phase_id);
+  phase_provider_->SetPhase(ring_id(), phase_id);
 }
 
 }  // namespace maliput

--- a/automotive/maliput/base/intersection.h
+++ b/automotive/maliput/base/intersection.h
@@ -28,14 +28,14 @@ class Intersection : public api::Intersection {
   /// @param region The region of the road network that is part of the
   /// intersection.
   ///
-  /// @param ring The ring that defines the phases within the intersection. The
-  /// pointer must remain valid throughout this class instance's lifetime.
+  /// @param ring_id The ID of the ring that defines the phases within the
+  /// intersection.
   ///
   /// @param phase_provider Enables the current phase within @p ring to be
   /// specified and obtained. The pointer must remain valid throughout this
   /// class instance's lifetime.
   Intersection(const Id& id, const std::vector<api::rules::LaneSRange>& region,
-               const api::rules::RightOfWayPhaseRing* ring,
+               const api::rules::RightOfWayPhaseRing::Id& ring_id,
                SimpleRightOfWayPhaseProvider* phase_provider);
 
   virtual ~Intersection() = default;

--- a/automotive/maliput/base/test/intersection_test.cc
+++ b/automotive/maliput/base/test/intersection_test.cc
@@ -10,11 +10,6 @@ namespace drake {
 namespace maliput {
 namespace {
 
-GTEST_TEST(IntersectionInstantiationTest, InvalidInstantiationTest) {
-  EXPECT_THROW(Intersection(Intersection::Id("foo"), {}, nullptr, nullptr),
-               std::exception);
-}
-
 class IntersectionTest : public ::testing::Test {
  public:
   IntersectionTest()
@@ -44,7 +39,7 @@ class IntersectionTest : public ::testing::Test {
 TEST_F(IntersectionTest, BasicTest) {
   const Intersection::Id intersection_id("foo");
   SimpleRightOfWayPhaseProvider phase_provider;
-  Intersection dut(intersection_id, ranges_, &dummy_ring_, &phase_provider);
+  Intersection dut(intersection_id, ranges_, dummy_ring_.id(), &phase_provider);
   EXPECT_EQ(dut.id(), intersection_id);
   EXPECT_EQ(dut.Phase(), nullopt);
   phase_provider.AddPhaseRing(dummy_ring_.id(), dummy_phase_1_.id());
@@ -53,7 +48,7 @@ TEST_F(IntersectionTest, BasicTest) {
   EXPECT_EQ(dut.Phase()->id, dummy_phase_2_.id());
   EXPECT_EQ(dut.region().size(), ranges_.size());
   EXPECT_EQ(dut.region().at(0).lane_id(), ranges_.at(0).lane_id());
-  EXPECT_EQ(dut.ring(), &dummy_ring_);
+  EXPECT_EQ(dut.ring_id(), dummy_ring_.id());
 }
 
 }  // namespace


### PR DESCRIPTION
The Intersection should hold a RightOfWayPhaseRing::Id instead of a
pointer to a RightOfWayPhaseRing because RightOfWayPhaseBook doesn't
provide access to a pointer to a RightOfWayPhaseRing.

If a derivative class of api::Intersection needs access to the
RightOfWayPhaseRing, it can hold a pointer to a RightOfWayPhaseBook,
just like how base::Intersection holds a pointer to a
SimpleRightOfWayPhaseProvider.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11001)
<!-- Reviewable:end -->
