### PR TITLE
Only update engine poses based on cache invalidation

### DIFF
--- a/geometry/dev/scene_graph.cc
+++ b/geometry/dev/scene_graph.cc
@@ -112,6 +112,11 @@ SceneGraph<T>::SceneGraph()
       this->DeclareAbstractOutputPort("query",
                                       &SceneGraph::CalcQueryObject)
           .get_index();
+
+  auto& pose_update_cache_entry = this->DeclareCacheEntry(
+      "Cache guard for pose updates", &SceneGraph::CalcPoseUpdate,
+      {this->all_input_ports_ticket()});
+  pose_update_index_ = pose_update_cache_entry.cache_index();
 }
 
 template <typename T>
@@ -398,8 +403,6 @@ void SceneGraph<T>::CalcPoseBundle(const Context<T>& context,
   int i = 0;
 
   const auto& g_context = static_cast<const GeometryContext<T>&>(context);
-  // TODO(SeanCurtis-TRI): Modify this when the cache is available to use the
-  // cache instead of this heavy-handed update.
   FullPoseUpdate(g_context);
   const auto& g_state = g_context.get_geometry_state();
 
@@ -422,7 +425,8 @@ void SceneGraph<T>::CalcPoseBundle(const Context<T>& context,
 }
 
 template <typename T>
-void SceneGraph<T>::FullPoseUpdate(const GeometryContext<T>& context) const {
+void SceneGraph<T>::CalcPoseUpdate(const GeometryContext<T>& context,
+                                   int*) const {
   // TODO(SeanCurtis-TRI): Update this when the cache is available.
   // This method is const and the context is const. Ultimately, this will pull
   // cached entities to do the query work. For now, we have to const cast the

--- a/geometry/dev/scene_graph.h
+++ b/geometry/dev/scene_graph.h
@@ -565,8 +565,16 @@ class SceneGraph final : public systems::LeafSystem<T> {
   void CalcPoseBundle(const systems::Context<T>& context,
                       systems::rendering::PoseBundle<T>* output) const;
 
-  // Updates the state of geometry world from *all* the inputs.
-  void FullPoseUpdate(const GeometryContext<T>& context) const;
+  // Refreshes the pose of the various engines which exploits the caching
+  // infrastructure.
+  void FullPoseUpdate(const GeometryContext<T>& context) const {
+    this->get_cache_entry(pose_update_index_).template Eval<int>(context);
+  }
+
+  // Updates the state of geometry world from *all* the inputs. This is the calc
+  // method for the corresponding cache entry. The entry *value* (the int) is
+  // strictly a dummy -- the value is unimportant; only the side effect matters.
+  void CalcPoseUpdate(const GeometryContext<T>& context, int*) const;
 
   // Override of construction to account for
   //    - instantiating a GeometryContext instance (as opposed to LeafContext),
@@ -610,6 +618,9 @@ class SceneGraph final : public systems::LeafSystem<T> {
 
   // The index of the geometry state in the context's abstract state.
   int geometry_state_index_{-1};
+
+  // The cache index for the pose update cache entry.
+  systems::CacheIndex pose_update_index_{};
 };
 
 }  // namespace dev

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -81,6 +81,11 @@ SceneGraph<T>::SceneGraph()
       this->DeclareAbstractOutputPort("query",
                                       &SceneGraph::CalcQueryObject)
           .get_index();
+
+  auto& pose_update_cache_entry = this->DeclareCacheEntry(
+      "Cache guard for pose updates", &SceneGraph::CalcPoseUpdate,
+      {this->all_input_ports_ticket()});
+  pose_update_index_ = pose_update_cache_entry.cache_index();
 }
 
 template <typename T>
@@ -339,8 +344,6 @@ void SceneGraph<T>::CalcPoseBundle(const Context<T>& context,
   int i = 0;
 
   const auto& g_context = static_cast<const GeometryContext<T>&>(context);
-  // TODO(SeanCurtis-TRI): Modify this when the cache is available to use the
-  // cache instead of this heavy-handed update.
   FullPoseUpdate(g_context);
   const auto& g_state = g_context.get_geometry_state();
 
@@ -363,7 +366,8 @@ void SceneGraph<T>::CalcPoseBundle(const Context<T>& context,
 }
 
 template <typename T>
-void SceneGraph<T>::FullPoseUpdate(const GeometryContext<T>& context) const {
+void SceneGraph<T>::CalcPoseUpdate(const GeometryContext<T>& context,
+                                   int*) const {
   // TODO(SeanCurtis-TRI): Update this when the cache is available.
   // This method is const and the context is const. Ultimately, this will pull
   // cached entities to do the query work. For now, we have to const cast the

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -602,8 +602,16 @@ class SceneGraph final : public systems::LeafSystem<T> {
   void CalcPoseBundle(const systems::Context<T>& context,
                       systems::rendering::PoseBundle<T>* output) const;
 
-  // Updates the state of geometry world from *all* the inputs.
-  void FullPoseUpdate(const GeometryContext<T>& context) const;
+  // Refreshes the pose of the various engines which exploits the caching
+  // infrastructure.
+  void FullPoseUpdate(const GeometryContext<T>& context) const {
+    this->get_cache_entry(pose_update_index_).template Eval<int>(context);
+  }
+
+  // Updates the state of geometry world from *all* the inputs. This is the calc
+  // method for the corresponding cache entry. The entry *value* (the int) is
+  // strictly a dummy -- the value is unimportant; only the side effect matters.
+  void CalcPoseUpdate(const GeometryContext<T>& context, int*) const;
 
   // Override of construction to account for
   //    - instantiating a GeometryContext instance (as opposed to LeafContext),
@@ -647,6 +655,9 @@ class SceneGraph final : public systems::LeafSystem<T> {
 
   // The index of the geometry state in the context's abstract state.
   int geometry_state_index_{-1};
+
+  // The cache index for the pose update cache entry.
+  systems::CacheIndex pose_update_index_{};
 };
 
 }  // namespace geometry


### PR DESCRIPTION
This creates a single cache entry with a meaningless value. Its sole purpose is to be a cache entry which gets dirtied by its upstream prerequisites and whose evaluation triggers a calc with *side effects*.
In this case, the side effect is to update the poses of *all* engines.

In the future, this will be broken down further with finer granularity so that only those components that need updating are done.

(This applies the same mechanism to geometry and geometry/dev).

resolves #10988

```
Category            added  modified  removed  
----------------------------------------------
code                18     4         0        
comments            6      0         4        
blank               6      0         0        
----------------------------------------------
TOTAL               30     4         4 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11019)
<!-- Reviewable:end -->
