### PR TITLE
Renames RightOfWayPhaseRing to be PhaseRing

### DIFF
--- a/automotive/maliput/api/BUILD.bazel
+++ b/automotive/maliput/api/BUILD.bazel
@@ -26,8 +26,8 @@ drake_cc_library(
         "lane_data.cc",
         "road_geometry.cc",
         "road_network.cc",
+        "rules/phase_ring.cc",
         "rules/right_of_way_phase.cc",
-        "rules/right_of_way_phase_ring.cc",
         "rules/traffic_lights.cc",
     ],
     hdrs = [
@@ -40,11 +40,11 @@ drake_cc_library(
         "road_geometry.h",
         "road_network.h",
         "rules/direction_usage_rule.h",
+        "rules/phase_ring.h",
         "rules/regions.h",
         "rules/right_of_way_phase.h",
         "rules/right_of_way_phase_book.h",
         "rules/right_of_way_phase_provider.h",
-        "rules/right_of_way_phase_ring.h",
         "rules/right_of_way_rule.h",
         "rules/right_of_way_state_provider.h",
         "rules/road_rulebook.h",
@@ -111,7 +111,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "rules_test",
     srcs = [
-        "test/right_of_way_phase_ring_test.cc",
+        "test/phase_ring_test.cc",
         "test/right_of_way_phase_test.cc",
         "test/right_of_way_state_provider_test.cc",
         "test/rules_direction_usage_test.cc",

--- a/automotive/maliput/api/intersection.cc
+++ b/automotive/maliput/api/intersection.cc
@@ -6,7 +6,7 @@ namespace api {
 
 Intersection::Intersection(const Id& id,
                            const std::vector<rules::LaneSRange>& region,
-                           const rules::RightOfWayPhaseRing::Id& ring_id)
+                           const rules::PhaseRing::Id& ring_id)
     : id_(id), region_(region), ring_id_(ring_id) {}
 
 }  // namespace api

--- a/automotive/maliput/api/intersection.h
+++ b/automotive/maliput/api/intersection.h
@@ -2,9 +2,9 @@
 
 #include <vector>
 
+#include "drake/automotive/maliput/api/rules/phase_ring.h"
 #include "drake/automotive/maliput/api/rules/regions.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_phase_provider.h"
-#include "drake/automotive/maliput/api/rules/right_of_way_phase_ring.h"
 #include "drake/automotive/maliput/api/type_specific_identifier.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_optional.h"
@@ -34,7 +34,7 @@ class Intersection {
   /// @param ring_id The ID of the ring that defines the phases within the
   /// intersection.
   Intersection(const Id& id, const std::vector<rules::LaneSRange>& region,
-               const rules::RightOfWayPhaseRing::Id& ring_id);
+               const rules::PhaseRing::Id& ring_id);
 
   virtual ~Intersection() = default;
 
@@ -48,15 +48,14 @@ class Intersection {
   /// Returns the region. See constructor parameter @p region for more details.
   const std::vector<rules::LaneSRange>& region() const { return region_; }
 
-  /// Returns the rules::RightOfWayPhaseRing::Id of the
-  /// rules::RightOfWayPhaseRing that applies to this intersection.
-  /// See constructor parameter @p ring_id for more details.
-  const rules::RightOfWayPhaseRing::Id& ring_id() const { return ring_id_; }
+  /// Returns the rules::PhaseRing::Id of the rules::PhaseRing that applies to
+  /// this intersection. See constructor parameter @p ring_id for more details.
+  const rules::PhaseRing::Id& ring_id() const { return ring_id_; }
 
  private:
   const Id id_;
   const std::vector<rules::LaneSRange> region_;
-  const rules::RightOfWayPhaseRing::Id ring_id_;
+  const rules::PhaseRing::Id ring_id_;
 };
 
 }  // namespace api

--- a/automotive/maliput/api/rules/phase_ring.cc
+++ b/automotive/maliput/api/rules/phase_ring.cc
@@ -1,4 +1,4 @@
-#include "drake/automotive/maliput/api/rules/right_of_way_phase_ring.h"
+#include "drake/automotive/maliput/api/rules/phase_ring.h"
 
 #include "drake/common/drake_throw.h"
 
@@ -38,7 +38,7 @@ void VerifyAllPhasesHaveSameCoverage(
 
 }  // namespace
 
-RightOfWayPhaseRing::RightOfWayPhaseRing(
+PhaseRing::PhaseRing(
     const Id& id, const std::vector<RightOfWayPhase>& phases)
     : id_(id) {
   DRAKE_THROW_UNLESS(phases.size() >= 1);

--- a/automotive/maliput/api/rules/phase_ring.h
+++ b/automotive/maliput/api/rules/phase_ring.h
@@ -12,16 +12,16 @@ namespace maliput {
 namespace api {
 namespace rules {
 
-/// A set of mutually exclusive phases, e.g., that comprise the signalling
+/// A set of mutually exclusive phases, e.g., that comprise the signaling
 /// cycle for an intersection.
-class RightOfWayPhaseRing final {
+class PhaseRing final {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(RightOfWayPhaseRing);
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PhaseRing);
 
-  /// Unique identifier for a RightOfWayPhaseRing.
-  using Id = TypeSpecificIdentifier<class RightOfWayPhaseRing>;
+  /// Unique identifier for a PhaseRing.
+  using Id = TypeSpecificIdentifier<class PhaseRing>;
 
-  /// Constructs a RightOfWayPhaseRing.
+  /// Constructs a PhaseRing.
   ///
   /// @param id the unique ID of this phase ring
   /// @param phases the phases within this ring.
@@ -29,7 +29,7 @@ class RightOfWayPhaseRing final {
   /// @throws std::exception if `phases` is empty, `phases` contains duplicate
   /// RightOfWayPhase::Id's, the phases define different sets of
   /// RightOfWayRule::Ids, or the phases define different sets of bulb states.
-  RightOfWayPhaseRing(const Id& id, const std::vector<RightOfWayPhase>& phases);
+  PhaseRing(const Id& id, const std::vector<RightOfWayPhase>& phases);
 
   /// Returns the phase ring's identifier.
   const Id& id() const { return id_; }

--- a/automotive/maliput/api/rules/right_of_way_phase_book.h
+++ b/automotive/maliput/api/rules/right_of_way_phase_book.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "drake/automotive/maliput/api/rules/right_of_way_phase_ring.h"
+#include "drake/automotive/maliput/api/rules/phase_ring.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_rule.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_optional.h"
@@ -11,24 +11,22 @@ namespace api {
 namespace rules {
 
 /// Abstract interface for providing the mapping from RightOfWayRule::Id to
-/// RightOfWayPhaseRing.
+/// PhaseRing.
 class RightOfWayPhaseBook {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RightOfWayPhaseBook);
 
   virtual ~RightOfWayPhaseBook() = default;
 
-  /// Gets the specified RightOfWayPhaseRing. Returns nullopt if @p ring_id is
+  /// Gets the specified PhaseRing. Returns nullopt if @p ring_id is
   /// unrecognized.
-  optional<RightOfWayPhaseRing> GetPhaseRing(
-      const RightOfWayPhaseRing::Id& ring_id) const {
+  optional<PhaseRing> GetPhaseRing(const PhaseRing::Id& ring_id) const {
     return DoGetPhaseRing(ring_id);
   }
 
-  /// Finds and returns the RightOfWayPhaseRing containing the specified
+  /// Finds and returns the PhaseRing containing the specified
   /// RightOfWayRule. Returns nullopt if @p rule_id is unrecognized.
-  optional<RightOfWayPhaseRing> FindPhaseRing(
-      const RightOfWayRule::Id& rule_id) const {
+  optional<PhaseRing> FindPhaseRing(const RightOfWayRule::Id& rule_id) const {
     return DoFindPhaseRing(rule_id);
   }
 
@@ -36,11 +34,11 @@ class RightOfWayPhaseBook {
   RightOfWayPhaseBook() = default;
 
  private:
-  virtual optional<RightOfWayPhaseRing> DoGetPhaseRing(
-      const RightOfWayPhaseRing::Id& ring_id) const = 0;
+  virtual optional<PhaseRing> DoGetPhaseRing(const PhaseRing::Id& ring_id)
+      const = 0;
 
-  virtual optional<RightOfWayPhaseRing> DoFindPhaseRing(
-      const RightOfWayRule::Id& rule_id) const  = 0;
+  virtual optional<PhaseRing> DoFindPhaseRing(const RightOfWayRule::Id& rule_id)
+      const  = 0;
 };
 
 }  // namespace rules

--- a/automotive/maliput/api/rules/right_of_way_phase_provider.h
+++ b/automotive/maliput/api/rules/right_of_way_phase_provider.h
@@ -1,7 +1,7 @@
 #pragma once
 
+#include "drake/automotive/maliput/api/rules/phase_ring.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_phase.h"
-#include "drake/automotive/maliput/api/rules/right_of_way_phase_ring.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_optional.h"
 
@@ -11,7 +11,7 @@ namespace api {
 namespace rules {
 
 /// Abstract interface for providing the dynamic states (RightOfWayPhase::Id) of
-/// a collection of RightOfWayPhaseRings.
+/// a collection of PhaseRings.
 class RightOfWayPhaseProvider {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RightOfWayPhaseProvider);
@@ -35,9 +35,9 @@ class RightOfWayPhaseProvider {
     drake::optional<Next> next;
   };
 
-  /// Gets the phase within a specified RightOfWayPhaseRing. Returns nullopt if
+  /// Gets the phase within a specified PhaseRing. Returns nullopt if
   /// @p id is unrecognized.
-  const optional<Result> GetPhase(const RightOfWayPhaseRing::Id& id) const {
+  const optional<Result> GetPhase(const PhaseRing::Id& id) const {
     return DoGetPhase(id);
   }
 
@@ -45,7 +45,7 @@ class RightOfWayPhaseProvider {
   RightOfWayPhaseProvider() = default;
 
  private:
-  virtual optional<Result> DoGetPhase(const RightOfWayPhaseRing::Id& id)
+  virtual optional<Result> DoGetPhase(const PhaseRing::Id& id)
       const = 0;
 };
 

--- a/automotive/maliput/api/test/mock.cc
+++ b/automotive/maliput/api/test/mock.cc
@@ -6,8 +6,8 @@
 #include "drake/automotive/maliput/api/branch_point.h"
 #include "drake/automotive/maliput/api/junction.h"
 #include "drake/automotive/maliput/api/lane.h"
+#include "drake/automotive/maliput/api/rules/phase_ring.h"
 #include "drake/automotive/maliput/api/rules/regions.h"
-#include "drake/automotive/maliput/api/rules/right_of_way_phase_ring.h"
 #include "drake/automotive/maliput/api/segment.h"
 #include "drake/common/drake_optional.h"
 
@@ -100,13 +100,13 @@ class MockRightOfWayPhaseBook final : public rules::RightOfWayPhaseBook {
   MockRightOfWayPhaseBook() {}
 
  private:
-  optional<rules::RightOfWayPhaseRing> DoGetPhaseRing(
-      const rules::RightOfWayPhaseRing::Id&) const override {
+  optional<rules::PhaseRing> DoGetPhaseRing(const rules::PhaseRing::Id&) const
+      override {
     return nullopt;
   }
 
-  optional<rules::RightOfWayPhaseRing> DoFindPhaseRing(
-      const rules::RightOfWayRule::Id&) const override {
+  optional<rules::PhaseRing> DoFindPhaseRing(const rules::RightOfWayRule::Id&)
+      const override {
     return nullopt;
   }
 };
@@ -130,8 +130,7 @@ class MockRightOfWayPhaseProvider final
   MockRightOfWayPhaseProvider() {}
 
  private:
-  optional<Result> DoGetPhase(
-      const rules::RightOfWayPhaseRing::Id&) const override {
+  optional<Result> DoGetPhase(const rules::PhaseRing::Id&) const override {
     return nullopt;
   }
 };
@@ -140,7 +139,7 @@ class MockIntersection final : public Intersection {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MockIntersection)
   explicit MockIntersection(const Intersection::Id& id,
-                            const rules::RightOfWayPhaseRing::Id& ring_id)
+                            const rules::PhaseRing::Id& ring_id)
       : Intersection(id, {}, ring_id) {}
 
  private:
@@ -219,7 +218,7 @@ CreateRightOfWayPhaseProvider() {
 }
 
 std::unique_ptr<Intersection> CreateIntersection(
-    const Intersection::Id& id, const rules::RightOfWayPhaseRing::Id& ring_id) {
+    const Intersection::Id& id, const rules::PhaseRing::Id& ring_id) {
   return std::make_unique<MockIntersection>(id, ring_id);
 }
 

--- a/automotive/maliput/api/test/mock.h
+++ b/automotive/maliput/api/test/mock.h
@@ -5,10 +5,10 @@
 #include "drake/automotive/maliput/api/intersection.h"
 #include "drake/automotive/maliput/api/road_geometry.h"
 #include "drake/automotive/maliput/api/rules/direction_usage_rule.h"
+#include "drake/automotive/maliput/api/rules/phase_ring.h"
 #include "drake/automotive/maliput/api/rules/regions.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_phase_book.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_phase_provider.h"
-#include "drake/automotive/maliput/api/rules/right_of_way_phase_ring.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_rule.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_state_provider.h"
 #include "drake/automotive/maliput/api/rules/road_rulebook.h"
@@ -59,7 +59,7 @@ std::unique_ptr<rules::RightOfWayPhaseProvider> CreateRightOfWayPhaseProvider();
 
 /// Returns an arbitrary Intersection.
 std::unique_ptr<Intersection> CreateIntersection(
-    const Intersection::Id& id, const rules::RightOfWayPhaseRing::Id& ring_id);
+    const Intersection::Id& id, const rules::PhaseRing::Id& ring_id);
 
 }  // namespace test
 }  // namespace api

--- a/automotive/maliput/api/test/phase_ring_test.cc
+++ b/automotive/maliput/api/test/phase_ring_test.cc
@@ -1,5 +1,5 @@
 /* clang-format off to disable clang-format-includes */
-#include "drake/automotive/maliput/api/rules/right_of_way_phase_ring.h"
+#include "drake/automotive/maliput/api/rules/phase_ring.h"
 /* clang-format on */
 // TODO(liang.fok) Satisfy clang-format via rules tests directory reorg.
 
@@ -45,38 +45,34 @@ RightOfWayPhase CreatePhaseWithMissingBulbStates(
   return RightOfWayPhase(id, mock_phase.rule_states(), bulb_states);
 }
 
-GTEST_TEST(RightOfWayPhaseRingTest, Constructor) {
-  EXPECT_NO_THROW(RightOfWayPhaseRing(
-      RightOfWayPhaseRing::Id("dut"),
-      {CreateFullPhase(RightOfWayPhase::Id("my_phase_1")),
-       CreateFullPhase(RightOfWayPhase::Id("my_phase_2"))}));
+GTEST_TEST(PhaseRingTest, Constructor) {
+  EXPECT_NO_THROW(
+      PhaseRing(PhaseRing::Id("dut"),
+                {CreateFullPhase(RightOfWayPhase::Id("my_phase_1")),
+                 CreateFullPhase(RightOfWayPhase::Id("my_phase_2"))}));
 
   // No phases.
-  EXPECT_THROW(RightOfWayPhaseRing(RightOfWayPhaseRing::Id("dut"), {}),
-               std::exception);
+  EXPECT_THROW(PhaseRing(PhaseRing::Id("dut"), {}), std::exception);
 
   // Duplicate phases.
-  EXPECT_THROW(
-      RightOfWayPhaseRing(RightOfWayPhaseRing::Id("dut"),
-                          {CreateFullPhase(RightOfWayPhase::Id("my_phase")),
-                           CreateFullPhase(RightOfWayPhase::Id("my_phase"))}),
-      std::exception);
+  EXPECT_THROW(PhaseRing(PhaseRing::Id("dut"),
+                         {CreateFullPhase(RightOfWayPhase::Id("my_phase")),
+                          CreateFullPhase(RightOfWayPhase::Id("my_phase"))}),
+               std::exception);
 
   // Phases that differ in RightOfWayRule coverage.
-  EXPECT_THROW(
-      RightOfWayPhaseRing(RightOfWayPhaseRing::Id("dut"),
-                          {CreateFullPhase(RightOfWayPhase::Id("full")),
-                           CreatePhaseWithMissingRuleStates(
-                               RightOfWayPhase::Id("missing_rules"))}),
-      std::exception);
+  EXPECT_THROW(PhaseRing(PhaseRing::Id("dut"),
+                         {CreateFullPhase(RightOfWayPhase::Id("full")),
+                          CreatePhaseWithMissingRuleStates(
+                              RightOfWayPhase::Id("missing_rules"))}),
+               std::exception);
 
   // Phases that differ in bulb state coverage.
-  EXPECT_THROW(
-      RightOfWayPhaseRing(RightOfWayPhaseRing::Id("dut"),
-                          {CreateFullPhase(RightOfWayPhase::Id("full")),
-                           CreatePhaseWithMissingBulbStates(
-                               RightOfWayPhase::Id("missing_rules"))}),
-      std::exception);
+  EXPECT_THROW(PhaseRing(PhaseRing::Id("dut"),
+                         {CreateFullPhase(RightOfWayPhase::Id("full")),
+                          CreatePhaseWithMissingBulbStates(
+                              RightOfWayPhase::Id("missing_rules"))}),
+               std::exception);
 }
 
 }  // namespace

--- a/automotive/maliput/api/test/road_network_test.cc
+++ b/automotive/maliput/api/test/road_network_test.cc
@@ -78,11 +78,11 @@ TEST_F(RoadNetworkTest, InstantiateAndUseAccessors) {
   const Intersection::Id intersection_id_1("intersection_1");
   const Intersection::Id intersection_id_2("intersection_2");
   std::vector<std::unique_ptr<Intersection>> intersections;
-  const rules::RightOfWayPhaseRing mock_ring_1 = rules::RightOfWayPhaseRing(
-      rules::RightOfWayPhaseRing::Id("ring1_id"),
+  const rules::PhaseRing mock_ring_1 = rules::PhaseRing(
+      rules::PhaseRing::Id("ring1_id"),
       {rules::RightOfWayPhase(rules::RightOfWayPhase::Id("phase_id_1"), {})});
-  const rules::RightOfWayPhaseRing mock_ring_2 = rules::RightOfWayPhaseRing(
-      rules::RightOfWayPhaseRing::Id("ring2_id"),
+  const rules::PhaseRing mock_ring_2 = rules::PhaseRing(
+      rules::PhaseRing::Id("ring2_id"),
       {rules::RightOfWayPhase(rules::RightOfWayPhase::Id("phase_id_2"), {})});
   intersections.emplace_back(
       test::CreateIntersection(intersection_id_1, mock_ring_1.id()));

--- a/automotive/maliput/base/intersection.cc
+++ b/automotive/maliput/base/intersection.cc
@@ -5,7 +5,7 @@ namespace maliput {
 
 Intersection::Intersection(const Id& id,
                            const std::vector<api::rules::LaneSRange>& region,
-                           const api::rules::RightOfWayPhaseRing::Id& ring_id,
+                           const api::rules::PhaseRing::Id& ring_id,
                            SimpleRightOfWayPhaseProvider* phase_provider)
     : api::Intersection(id, region, ring_id), phase_provider_(phase_provider) {
   DRAKE_THROW_UNLESS(phase_provider_ != nullptr);

--- a/automotive/maliput/base/intersection.h
+++ b/automotive/maliput/base/intersection.h
@@ -3,9 +3,9 @@
 #include <vector>
 
 #include "drake/automotive/maliput/api/intersection.h"
+#include "drake/automotive/maliput/api/rules/phase_ring.h"
 #include "drake/automotive/maliput/api/rules/regions.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_phase_provider.h"
-#include "drake/automotive/maliput/api/rules/right_of_way_phase_ring.h"
 #include "drake/automotive/maliput/base/simple_right_of_way_phase_provider.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_optional.h"
@@ -35,7 +35,7 @@ class Intersection : public api::Intersection {
   /// specified and obtained. The pointer must remain valid throughout this
   /// class instance's lifetime.
   Intersection(const Id& id, const std::vector<api::rules::LaneSRange>& region,
-               const api::rules::RightOfWayPhaseRing::Id& ring_id,
+               const api::rules::PhaseRing::Id& ring_id,
                SimpleRightOfWayPhaseProvider* phase_provider);
 
   virtual ~Intersection() = default;

--- a/automotive/maliput/base/phase_based_right_of_way_state_provider.cc
+++ b/automotive/maliput/base/phase_based_right_of_way_state_provider.cc
@@ -1,16 +1,16 @@
 #include "drake/automotive/maliput/base/phase_based_right_of_way_state_provider.h"
 
+#include "drake/automotive/maliput/api/rules/phase_ring.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_phase.h"
-#include "drake/automotive/maliput/api/rules/right_of_way_phase_ring.h"
 #include "drake/common/drake_assert.h"
 
 namespace drake {
 namespace maliput {
 
+using api::rules::PhaseRing;
 using api::rules::RightOfWayPhase;
 using api::rules::RightOfWayPhaseBook;
 using api::rules::RightOfWayPhaseProvider;
-using api::rules::RightOfWayPhaseRing;
 using api::rules::RightOfWayRule;
 using api::rules::RightOfWayStateProvider;
 
@@ -25,7 +25,7 @@ PhaseBasedRightOfWayStateProvider::PhaseBasedRightOfWayStateProvider(
 optional<RightOfWayStateProvider::Result>
 PhaseBasedRightOfWayStateProvider::DoGetState(const RightOfWayRule::Id& rule_id)
     const {
-  optional<RightOfWayPhaseRing> ring = phase_book_->FindPhaseRing(rule_id);
+  optional<PhaseRing> ring = phase_book_->FindPhaseRing(rule_id);
   if (ring.has_value()) {
     const optional<RightOfWayPhaseProvider::Result> phase_result
         = phase_provider_->GetPhase(ring->id());

--- a/automotive/maliput/base/phase_ring_book_loader.cc
+++ b/automotive/maliput/base/phase_ring_book_loader.cc
@@ -5,9 +5,9 @@
 
 #include "yaml-cpp/yaml.h"
 
+#include "drake/automotive/maliput/api/rules/phase_ring.h"
 #include "drake/automotive/maliput/api/rules/regions.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_phase.h"
-#include "drake/automotive/maliput/api/rules/right_of_way_phase_ring.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_rule.h"
 #include "drake/automotive/maliput/base/simple_right_of_way_phase_book.h"
 #include "drake/common/drake_assert.h"
@@ -18,9 +18,9 @@ namespace maliput {
 namespace {
 
 using api::rules::LaneSRange;
+using api::rules::PhaseRing;
 using api::rules::RightOfWayPhase;
 using api::rules::RightOfWayPhaseBook;
-using api::rules::RightOfWayPhaseRing;
 using api::rules::RightOfWayRule;
 using api::rules::RoadRulebook;
 using api::rules::RuleStates;
@@ -81,11 +81,10 @@ RuleStates CreateDefaultRuleStates(
   return result;
 }
 
-RightOfWayPhaseRing BuildPhaseRing(const RoadRulebook* rulebook,
-                                   const YAML::Node& phase_ring_node) {
+PhaseRing BuildPhaseRing(const RoadRulebook* rulebook,
+                         const YAML::Node& phase_ring_node) {
   DRAKE_DEMAND(phase_ring_node.IsMap());
-  const RightOfWayPhaseRing::Id ring_id(
-      phase_ring_node["ID"].as<std::string>());
+  const PhaseRing::Id ring_id(phase_ring_node["ID"].as<std::string>());
   const std::unordered_map<RightOfWayRule::Id, RightOfWayRule> rules =
       GetRules(rulebook, phase_ring_node["Rules"]);
 
@@ -112,7 +111,7 @@ RightOfWayPhaseRing BuildPhaseRing(const RoadRulebook* rulebook,
     }
     phases.push_back(RightOfWayPhase(phase_id, rule_states));
   }
-  return RightOfWayPhaseRing(ring_id, phases);
+  return PhaseRing(ring_id, phases);
 }
 
 std::unique_ptr<api::rules::RightOfWayPhaseBook> BuildFrom(

--- a/automotive/maliput/base/simple_right_of_way_phase_book.cc
+++ b/automotive/maliput/base/simple_right_of_way_phase_book.cc
@@ -10,9 +10,9 @@
 namespace drake {
 namespace maliput {
 
+using api::rules::PhaseRing;
 using api::rules::RightOfWayRule;
 using api::rules::RightOfWayPhase;
-using api::rules::RightOfWayPhaseRing;
 
 class SimpleRightOfWayPhaseBook::Impl {
  public:
@@ -21,11 +21,11 @@ class SimpleRightOfWayPhaseBook::Impl {
   Impl() {}
   ~Impl() {}
 
-  void AddPhaseRing(const RightOfWayPhaseRing& ring) {
+  void AddPhaseRing(const PhaseRing& ring) {
     auto result = ring_book_.emplace(ring.id(), ring);
     if (!result.second) {
-      throw std::logic_error("Attempted to add multiple RightOfWayPhaseRing "
-                             "instances with ID " + ring.id().string());
+      throw std::logic_error("Attempted to add multiple PhaseRing instances "
+                             "with ID " + ring.id().string());
     }
     const RightOfWayPhase& phase = ring.phases().begin()->second;
     for (const auto& element : phase.rule_states()) {
@@ -33,16 +33,16 @@ class SimpleRightOfWayPhaseBook::Impl {
       if (!r.second) {
         throw std::logic_error("RightOfWayRule with ID " +
                                element.first.string() + " is part of more than "
-                               "one RightOfWayPhaseRing.");
+                               "one PhaseRing.");
       }
     }
   }
 
-  void RemovePhaseRing(const RightOfWayPhaseRing::Id& ring_id) {
-    const optional<RightOfWayPhaseRing> ring = DoGetPhaseRing(ring_id);
+  void RemovePhaseRing(const PhaseRing::Id& ring_id) {
+    const optional<PhaseRing> ring = DoGetPhaseRing(ring_id);
     if (ring == nullopt) {
-      throw std::logic_error("Attempted to remove unknown RightOfWayPhaseRing "
-                             "with ID " + ring_id.string());
+      throw std::logic_error("Attempted to remove unknown PhaseRing with ID " +
+                             ring_id.string());
     }
     DRAKE_THROW_UNLESS(ring_book_.erase(ring_id) == 1);
     const RightOfWayPhase& phase = ring->phases().begin()->second;
@@ -51,8 +51,7 @@ class SimpleRightOfWayPhaseBook::Impl {
     }
   }
 
-  optional<RightOfWayPhaseRing> DoGetPhaseRing(
-      const RightOfWayPhaseRing::Id& ring_id) const {
+  optional<PhaseRing> DoGetPhaseRing(const PhaseRing::Id& ring_id) const {
     auto it = ring_book_.find(ring_id);
     if (it == ring_book_.end()) {
       return nullopt;
@@ -60,8 +59,7 @@ class SimpleRightOfWayPhaseBook::Impl {
     return it->second;
   }
 
-  optional<RightOfWayPhaseRing> DoFindPhaseRing(
-      const RightOfWayRule::Id& rule_id) const {
+  optional<PhaseRing> DoFindPhaseRing(const RightOfWayRule::Id& rule_id) const {
     auto it = rule_book_.find(rule_id);
     if (it == rule_book_.end()) {
       return nullopt;
@@ -70,10 +68,8 @@ class SimpleRightOfWayPhaseBook::Impl {
   }
 
  private:
-  std::unordered_map<RightOfWayPhaseRing::Id, const RightOfWayPhaseRing>
-      ring_book_;
-  std::unordered_map<RightOfWayRule::Id, const RightOfWayPhaseRing::Id>
-      rule_book_;
+  std::unordered_map<PhaseRing::Id, const PhaseRing> ring_book_;
+  std::unordered_map<RightOfWayRule::Id, const PhaseRing::Id> rule_book_;
 };
 
 SimpleRightOfWayPhaseBook::SimpleRightOfWayPhaseBook()
@@ -81,21 +77,20 @@ SimpleRightOfWayPhaseBook::SimpleRightOfWayPhaseBook()
 
 SimpleRightOfWayPhaseBook::~SimpleRightOfWayPhaseBook() = default;
 
-void SimpleRightOfWayPhaseBook::AddPhaseRing(const RightOfWayPhaseRing& ring) {
+void SimpleRightOfWayPhaseBook::AddPhaseRing(const PhaseRing& ring) {
   impl_->AddPhaseRing(ring);
 }
 
-void SimpleRightOfWayPhaseBook::RemovePhaseRing(
-    const RightOfWayPhaseRing::Id& ring_id) {
+void SimpleRightOfWayPhaseBook::RemovePhaseRing(const PhaseRing::Id& ring_id) {
   impl_->RemovePhaseRing(ring_id);
 }
 
-optional<RightOfWayPhaseRing> SimpleRightOfWayPhaseBook::DoGetPhaseRing(
-    const RightOfWayPhaseRing::Id& ring_id) const {
+optional<PhaseRing> SimpleRightOfWayPhaseBook::DoGetPhaseRing(
+    const PhaseRing::Id& ring_id) const {
   return impl_->DoGetPhaseRing(ring_id);
 }
 
-optional<RightOfWayPhaseRing> SimpleRightOfWayPhaseBook::DoFindPhaseRing(
+optional<PhaseRing> SimpleRightOfWayPhaseBook::DoFindPhaseRing(
     const RightOfWayRule::Id& rule_id) const {
   return impl_->DoFindPhaseRing(rule_id);
 }

--- a/automotive/maliput/base/simple_right_of_way_phase_book.h
+++ b/automotive/maliput/base/simple_right_of_way_phase_book.h
@@ -2,8 +2,8 @@
 
 #include <memory>
 
+#include "drake/automotive/maliput/api/rules/phase_ring.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_phase_book.h"
-#include "drake/automotive/maliput/api/rules/right_of_way_phase_ring.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_rule.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_optional.h"
@@ -13,7 +13,7 @@ namespace maliput {
 
 /// A simple concrete implementation of the api::rules::RightOfWayPhaseBook
 /// abstract interface. It allows users to obtain the ID of the
-/// RightOfWayPhaseRing that includes a particular RightOfWayRule.
+/// PhaseRing that includes a particular RightOfWayRule.
 class SimpleRightOfWayPhaseBook : public api::rules::RightOfWayPhaseBook {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SimpleRightOfWayPhaseBook);
@@ -24,23 +24,23 @@ class SimpleRightOfWayPhaseBook : public api::rules::RightOfWayPhaseBook {
 
   /// Adds @p ring to this SimpleRightOfWayPhaseBook.
   ///
-  /// @throws std::exception if an api::rules::RightOfWayPhaseRing with the same
-  /// ID already exists, or if @p ring contains a rule that already exists in a
-  /// previously added api::rules::RightOfWayPhaseRing.
-  void AddPhaseRing(const api::rules::RightOfWayPhaseRing& ring);
+  /// @throws std::exception if an api::rules::PhaseRing with the same ID
+  /// already exists, or if @p ring contains a rule that already exists in a
+  /// previously added api::rules::PhaseRing.
+  void AddPhaseRing(const api::rules::PhaseRing& ring);
 
-  /// Removes an api::rules::RightOfWayPhaseRing with an ID of @p ring_id from
-  /// this SimpleRightOfWayPhaseBook.
+  /// Removes an api::rules::PhaseRing with an ID of @p ring_id from this
+  /// SimpleRightOfWayPhaseBook.
   ///
-  /// @throws std::exception if the specified api::rules::RightOfWayPhaseRing
-  /// does not exist.
-  void RemovePhaseRing(const api::rules::RightOfWayPhaseRing::Id& ring_id);
+  /// @throws std::exception if the specified api::rules::PhaseRing does not
+  /// exist.
+  void RemovePhaseRing(const api::rules::PhaseRing::Id& ring_id);
 
  private:
-  optional<api::rules::RightOfWayPhaseRing> DoGetPhaseRing(
-      const api::rules::RightOfWayPhaseRing::Id& ring_id) const override;
+  optional<api::rules::PhaseRing> DoGetPhaseRing(
+      const api::rules::PhaseRing::Id& ring_id) const override;
 
-  optional<api::rules::RightOfWayPhaseRing> DoFindPhaseRing(
+  optional<api::rules::PhaseRing> DoFindPhaseRing(
       const api::rules::RightOfWayRule::Id& rule_id) const override;
 
   class Impl;

--- a/automotive/maliput/base/simple_right_of_way_phase_provider.cc
+++ b/automotive/maliput/base/simple_right_of_way_phase_provider.cc
@@ -10,7 +10,7 @@ namespace maliput {
 using api::rules::RightOfWayPhaseProvider;
 
 void SimpleRightOfWayPhaseProvider::AddPhaseRing(
-    const api::rules::RightOfWayPhaseRing::Id& id,
+    const api::rules::PhaseRing::Id& id,
     const api::rules::RightOfWayPhase::Id& initial_phase) {
   auto result = phases_.emplace(id, initial_phase);
   if (!result.second) {
@@ -21,14 +21,14 @@ void SimpleRightOfWayPhaseProvider::AddPhaseRing(
 
 
 void SimpleRightOfWayPhaseProvider::SetPhase(
-    const api::rules::RightOfWayPhaseRing::Id& id,
+    const api::rules::PhaseRing::Id& id,
     const api::rules::RightOfWayPhase::Id& phase) {
   phases_.at(id) = phase;
 }
 
 optional<RightOfWayPhaseProvider::Result>
 SimpleRightOfWayPhaseProvider::DoGetPhase(
-    const api::rules::RightOfWayPhaseRing::Id& id) const {
+    const api::rules::PhaseRing::Id& id) const {
   auto it = phases_.find(id);
   if (it == phases_.end()) {
     return nullopt;

--- a/automotive/maliput/base/simple_right_of_way_phase_provider.h
+++ b/automotive/maliput/base/simple_right_of_way_phase_provider.h
@@ -2,9 +2,9 @@
 
 #include <unordered_map>
 
+#include "drake/automotive/maliput/api/rules/phase_ring.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_phase.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_phase_provider.h"
-#include "drake/automotive/maliput/api/rules/right_of_way_phase_ring.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_optional.h"
 
@@ -25,25 +25,24 @@ class SimpleRightOfWayPhaseProvider
 
   /// Adds a phase ring to this provider.
   ///
-  /// @throws std::exception if a RightOfWayPhaseRing with an ID of @p id
-  /// already exists in this provider.
-  void AddPhaseRing(const api::rules::RightOfWayPhaseRing::Id& id,
+  /// @throws std::exception if a PhaseRing with an ID of @p id already exists
+  /// in this provider.
+  void AddPhaseRing(const api::rules::PhaseRing::Id& id,
                     const api::rules::RightOfWayPhase::Id& initial_phase);
 
-  /// Sets the current phase of a RightOfWayPhaseRing.
+  /// Sets the current phase of a PhaseRing.
   ///
-  /// @throws std::exception if no RightOfWayPhaseRing with ID @p id exists
-  /// in this provider.
-  void SetPhase(const api::rules::RightOfWayPhaseRing::Id& id,
+  /// @throws std::exception if no PhaseRing with ID @p id exists in this
+  /// provider.
+  void SetPhase(const api::rules::PhaseRing::Id& id,
                 const api::rules::RightOfWayPhase::Id& phase);
 
  private:
   optional<api::rules::RightOfWayPhaseProvider::Result> DoGetPhase(
-      const api::rules::RightOfWayPhaseRing::Id& id) const override;
+      const api::rules::PhaseRing::Id& id) const override;
 
-  std::unordered_map<
-    maliput::api::rules::RightOfWayPhaseRing::Id,
-    maliput::api::rules::RightOfWayPhase::Id> phases_;
+  std::unordered_map<maliput::api::rules::PhaseRing::Id,
+                     maliput::api::rules::RightOfWayPhase::Id> phases_;
 };
 
 }  // namespace maliput

--- a/automotive/maliput/base/test/intersection_test.cc
+++ b/automotive/maliput/base/test/intersection_test.cc
@@ -17,7 +17,7 @@ class IntersectionTest : public ::testing::Test {
                        rule_states_1_),
         dummy_phase_2_(api::rules::RightOfWayPhase::Id("dummy_phase_2"),
                        rule_states_2_),
-        dummy_ring_(api::rules::RightOfWayPhaseRing::Id("dummy_ring"),
+        dummy_ring_(api::rules::PhaseRing::Id("dummy_ring"),
                     {dummy_phase_1_, dummy_phase_2_}) {}
 
   const api::rules::RuleStates rule_states_1_{
@@ -30,7 +30,7 @@ class IntersectionTest : public ::testing::Test {
   const api::rules::RightOfWayPhase dummy_phase_1_;
   const api::rules::RightOfWayPhase dummy_phase_2_;
 
-  const api::rules::RightOfWayPhaseRing dummy_ring_;
+  const api::rules::PhaseRing dummy_ring_;
 
   const std::vector<api::rules::LaneSRange> ranges_{api::rules::LaneSRange(
       api::LaneId("road A"), api::rules::SRange(0, 100))};

--- a/automotive/maliput/base/test/phase_based_right_of_way_state_provider_test.cc
+++ b/automotive/maliput/base/test/phase_based_right_of_way_state_provider_test.cc
@@ -9,8 +9,8 @@ namespace drake {
 namespace maliput {
 namespace {
 
+using maliput::api::rules::PhaseRing;
 using maliput::api::rules::RightOfWayPhase;
-using maliput::api::rules::RightOfWayPhaseRing;
 using maliput::api::rules::RightOfWayRule;
 using maliput::api::rules::RightOfWayStateProvider;
 
@@ -30,8 +30,8 @@ GTEST_TEST(PhaseBasedRightOfWayStateProviderTest, BasicTest) {
       {{rule_id_a, state_id_stop},
        {rule_id_b, state_id_go}});
 
-  const RightOfWayPhaseRing::Id ring_id("ring");
-  const RightOfWayPhaseRing ring(ring_id, {phase1, phase2});
+  const PhaseRing::Id ring_id("ring");
+  const PhaseRing ring(ring_id, {phase1, phase2});
 
   SimpleRightOfWayPhaseBook phase_book;
   phase_book.AddPhaseRing(ring);

--- a/automotive/maliput/base/test/phase_ring_book_loader_test.cc
+++ b/automotive/maliput/base/test/phase_ring_book_loader_test.cc
@@ -7,8 +7,8 @@
 #include <gtest/gtest.h>
 
 #include "drake/automotive/maliput/api/road_geometry.h"
+#include "drake/automotive/maliput/api/rules/phase_ring.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_phase.h"
-#include "drake/automotive/maliput/api/rules/right_of_way_phase_ring.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_rule.h"
 #include "drake/automotive/maliput/api/rules/road_rulebook.h"
 #include "drake/automotive/maliput/api/test_utilities/rules_test_utilities.h"
@@ -24,9 +24,9 @@ namespace maliput {
 namespace {
 
 using api::RoadGeometry;
+using api::rules::PhaseRing;
 using api::rules::RightOfWayPhase;
 using api::rules::RightOfWayPhaseBook;
-using api::rules::RightOfWayPhaseRing;
 using api::rules::RightOfWayRule;
 using api::rules::RoadRulebook;
 
@@ -102,9 +102,9 @@ TEST_F(TestLoading2x2IntersectionPhasebook, LoadFromFile) {
   std::unique_ptr<RightOfWayPhaseBook> phasebook =
       LoadPhaseRingBookFromFile(rulebook_.get(), filepath_);
   EXPECT_NE(phasebook, nullptr);
-  const RightOfWayPhaseRing::Id ring_id("2x2Intersection");
-  const optional<RightOfWayPhaseRing> ring =
-      phasebook->GetPhaseRing(RightOfWayPhaseRing::Id(ring_id));
+  const PhaseRing::Id ring_id("2x2Intersection");
+  const optional<PhaseRing> ring =
+      phasebook->GetPhaseRing(PhaseRing::Id(ring_id));
   EXPECT_NE(ring, nullopt);
   EXPECT_EQ(ring->id(), ring_id);
   const auto& phases = ring->phases();

--- a/automotive/maliput/base/test/simple_right_of_way_phase_book_test.cc
+++ b/automotive/maliput/base/test/simple_right_of_way_phase_book_test.cc
@@ -4,8 +4,8 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/automotive/maliput/api/rules/phase_ring.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_phase.h"
-#include "drake/automotive/maliput/api/rules/right_of_way_phase_ring.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_rule.h"
 #include "drake/common/drake_optional.h"
 
@@ -13,9 +13,9 @@ namespace drake {
 namespace maliput {
 namespace {
 
+using api::rules::PhaseRing;
 using api::rules::RightOfWayRule;
 using api::rules::RightOfWayPhase;
-using api::rules::RightOfWayPhaseRing;
 
 struct SimpleRightOfWayPhaseBookTest : public ::testing::Test {
   SimpleRightOfWayPhaseBookTest()
@@ -30,17 +30,17 @@ struct SimpleRightOfWayPhaseBookTest : public ::testing::Test {
   const RightOfWayRule::Id rule_id_a;
   const RightOfWayRule::Id rule_id_b;
   const RightOfWayPhase phase;
-  const RightOfWayPhaseRing::Id ring_id;
-  const RightOfWayPhaseRing ring;
+  const PhaseRing::Id ring_id;
+  const PhaseRing ring;
 };
 
 TEST_F(SimpleRightOfWayPhaseBookTest, BasicTest) {
   SimpleRightOfWayPhaseBook dut;
   EXPECT_NO_THROW(dut.AddPhaseRing(ring));
-  optional<RightOfWayPhaseRing> result = dut.GetPhaseRing(ring_id);
+  optional<PhaseRing> result = dut.GetPhaseRing(ring_id);
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result->id(), ring_id);
-  const RightOfWayPhaseRing::Id unknown_ring_id("unknown ring");
+  const PhaseRing::Id unknown_ring_id("unknown ring");
   EXPECT_EQ(dut.GetPhaseRing(unknown_ring_id), nullopt);
   for (const auto rule_id : {rule_id_a, rule_id_b}) {
     result = dut.FindPhaseRing(rule_id);
@@ -58,8 +58,7 @@ TEST_F(SimpleRightOfWayPhaseBookTest, BasicTest) {
 }
 
 // Verifies that an exception is thrown when the user attempts to add a
-// different RightOfWayPhaseRing that has the same ID as a previously
-// added RightOfWayPhaseRing.
+// different PhaseRing that has the same ID as a previously added PhaseRing.
 TEST_F(SimpleRightOfWayPhaseBookTest, RingWithSameId) {
   SimpleRightOfWayPhaseBook dut;
   dut.AddPhaseRing(ring);
@@ -67,23 +66,21 @@ TEST_F(SimpleRightOfWayPhaseBookTest, RingWithSameId) {
   const RightOfWayPhase different_phase(
       RightOfWayPhase::Id("different phase with different rules"),
       {{rule_id_c, RightOfWayRule::State::Id("c")}});
-  const RightOfWayPhaseRing ring_with_same_id(ring_id, {different_phase});
+  const PhaseRing ring_with_same_id(ring_id, {different_phase});
   EXPECT_THROW(dut.AddPhaseRing(ring_with_same_id), std::logic_error);
 }
 
 // Verifies that an exception is thrown when the user attempts to add a
-// RightOfWayPhaseRing with a unique ID but contains a phase with a
-// RightOfWayRule::Id that overlaps the rules covered by a previously added
-// RightOfWayPhaseRing.
+// PhaseRing with a unique ID but contains a phase with a RightOfWayRule::Id
+// that overlaps the rules covered by a previously added PhaseRing.
 TEST_F(SimpleRightOfWayPhaseBookTest, RingWithOverlappingRule) {
   SimpleRightOfWayPhaseBook dut;
   dut.AddPhaseRing(ring);
   const RightOfWayPhase phase_with_overlapping_rule(
       RightOfWayPhase::Id("different phase with overlapping rules"),
       {{rule_id_a, RightOfWayRule::State::Id("a")}});
-  const RightOfWayPhaseRing ring_with_overlapping_rule(
-      RightOfWayPhaseRing::Id("unique phase ID"),
-      {phase_with_overlapping_rule});
+  const PhaseRing ring_with_overlapping_rule(PhaseRing::Id("unique phase ID"),
+                                             {phase_with_overlapping_rule});
   EXPECT_THROW(dut.AddPhaseRing(ring_with_overlapping_rule), std::logic_error);
 }
 

--- a/automotive/maliput/base/test/simple_right_of_way_phase_provider_test.cc
+++ b/automotive/maliput/base/test/simple_right_of_way_phase_provider_test.cc
@@ -4,9 +4,9 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/automotive/maliput/api/rules/phase_ring.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_phase.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_phase_provider.h"
-#include "drake/automotive/maliput/api/rules/right_of_way_phase_ring.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_rule.h"
 #include "drake/common/drake_optional.h"
 
@@ -14,10 +14,10 @@ namespace drake {
 namespace maliput {
 namespace {
 
+using api::rules::PhaseRing;
 using api::rules::RightOfWayRule;
 using api::rules::RightOfWayPhase;
 using api::rules::RightOfWayPhaseProvider;
-using api::rules::RightOfWayPhaseRing;
 using api::rules::RuleStates;
 
 // Fixture for testing the SimpleRightOfWayPhaseProvider.
@@ -28,7 +28,7 @@ struct SimpleRightOfWayPhaseProviderTest : public ::testing::Test {
 
   const RightOfWayPhase::Id phase_id_1;
   const RightOfWayPhase::Id phase_id_2;
-  const RightOfWayPhaseRing::Id phase_ring_id;
+  const PhaseRing::Id phase_ring_id;
   SimpleRightOfWayPhaseProvider dut;
 };
 
@@ -51,9 +51,9 @@ TEST_F(SimpleRightOfWayPhaseProviderTest, CurrentPhaseOnly) {
   EXPECT_EQ(returned_phase->next, nullopt);
 }
 
-// Tests that an exception is thrown if the phases within a RightOfWayPhaseRing
-// cover different sets of RightOfWayRules.
-GTEST_TEST(RightOfWayPhaseRingTest, InvalidPhases) {
+// Tests that an exception is thrown if the phases within a PhaseRing cover
+// different sets of RightOfWayRules.
+GTEST_TEST(PhaseRingTest, InvalidPhases) {
   const RuleStates rule_states_1 {{RightOfWayRule::Id("a"),
                                    RightOfWayRule::State::Id("1")},
                                   {RightOfWayRule::Id("b"),
@@ -63,8 +63,7 @@ GTEST_TEST(RightOfWayPhaseRingTest, InvalidPhases) {
   RightOfWayPhase phase_1(RightOfWayPhase::Id("bar"), rule_states_1);
   RightOfWayPhase phase_2(RightOfWayPhase::Id("baz"), rule_states_2);
   const std::vector<RightOfWayPhase> phases{phase_1, phase_2};
-  EXPECT_THROW(RightOfWayPhaseRing(RightOfWayPhaseRing::Id("foo"), phases),
-               std::exception);
+  EXPECT_THROW(PhaseRing(PhaseRing::Id("foo"), phases), std::exception);
 }
 
 }  // namespace


### PR DESCRIPTION
There shouldn't be any confusion since there are no other types of
phase rings but RightOfWay.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11024)
<!-- Reviewable:end -->
