### PR TITLE
Querying for anchored world pose now valid

### DIFF
--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -411,9 +411,6 @@ const Isometry3<T>& GeometryState<T>::get_pose_in_world(
 template <typename T>
 const Isometry3<T>& GeometryState<T>::get_pose_in_world(
     GeometryId geometry_id) const {
-  // TODO(SeanCurtis-TRI): This is a BUG! If you pass in the id of an
-  // anchored geometry, this will throw an exception. See
-  // https://github.com/RobotLocomotion/drake/issues/9145.
   FindOrThrow(geometry_id, geometries_, [geometry_id]() {
     return "No world pose available for invalid geometry id: " +
            to_string(geometry_id);
@@ -540,7 +537,11 @@ GeometryId GeometryState<T>::RegisterGeometry(
   // compactly distributed. Is there a more robust way to do this?
   DRAKE_ASSERT(geometry_index_to_id_map_.size() == X_WG_.size());
   FrameIndex index(static_cast<int>(X_WG_.size()));
-  X_WG_.push_back(Isometry3<T>::Identity());
+  // NOTE: No implicit conversion from Isometry3<double> to Isometry3<AutoDiff>.
+  // However, we can implicitly assign Matrix<double> to Matrix<AutoDiff>.
+  Isometry3<T> X_WG;
+  X_WG.matrix() = geometry->pose().matrix();
+  X_WG_.push_back(X_WG);
   geometry_index_to_id_map_.push_back(geometry_id);
 
   geometries_.emplace(geometry_id,

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -1688,6 +1688,9 @@ TEST_F(GeometryStateTest, QueryFrameProperties) {
       geometry_state_.get_pose_in_world(GeometryId::get_new_id()),
       std::logic_error,
       "No world pose available for invalid geometry id: \\d+");
+  EXPECT_TRUE(CompareMatrices(
+      geometry_state_.get_pose_in_world(anchored_geometry_).matrix(),
+      X_WA_.matrix()));
 
   EXPECT_TRUE(
       CompareMatrices(geometry_state_.get_pose_in_parent(frames_[0]).matrix(),


### PR DESCRIPTION
The original bug shown in issue 9145 was for a *different* reason. Originally, GeometryState segregated anchored and dynamic geometries and the implementation of GeometryState::get_pose_in_world() didn't consider both groups. A previous PR merged the geometry types, but failed to update the newly common registration method to capture the anchored pose.

So, the "same" bug but for different reasons. Now it is properly tested and the alternative form of the bug has been corrected.

resolves #9145

```
Category            added  modified  removed  
----------------------------------------------
code                5      1         0        
comments            2      0         0        
blank               0      0         0        
----------------------------------------------
TOTAL               7      1         0  
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11025)
<!-- Reviewable:end -->
