### PR TITLE
Avoid double-counting for cached derivative evals in integrators

### DIFF
--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -380,12 +380,17 @@ class System : public SystemBase {
   /// @retval xcdot The time derivatives of `xc` returned as a reference to an
   ///               object of the same type and size as this %Context's
   ///               continuous state.
-  /// @see CalcTimeDerivatives()
+  /// @see CalcTimeDerivatives(), get_time_derivatives_cache_entry()
   const ContinuousState<T>& EvalTimeDerivatives(
       const Context<T>& context) const {
-    const CacheEntry& entry =
-        this->get_cache_entry(time_derivatives_cache_index_);
+    const CacheEntry& entry = get_time_derivatives_cache_entry();
     return entry.Eval<ContinuousState<T>>(context);
+  }
+
+  /// (Advanced) Returns the CacheEntry used to cache time derivatives for
+  /// EvalTimeDerivatives().
+  const CacheEntry& get_time_derivatives_cache_entry() const {
+    return this->get_cache_entry(time_derivatives_cache_index_);
   }
 
   /// Returns a reference to the cached value of the potential energy (PE),

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -1031,6 +1031,15 @@ TEST_F(ComputationTest, Eval) {
   test_sys_.ExpectCount(4, 3, 3, 3, 3);
   EXPECT_EQ(test_sys_.EvalNonConservativePower(*context_), 8.);  // Again.
   test_sys_.ExpectCount(4, 3, 3, 3, 4);
+
+  // Check that the reported time derivatives cache entry is the right one.
+  context_->SetTime(3.);  // Invalidate.
+  const CacheEntry& entry = test_sys_.get_time_derivatives_cache_entry();
+  const int64_t serial_number =
+      entry.get_cache_entry_value(*context_).serial_number();
+  test_sys_.EvalTimeDerivatives(*context_);
+  EXPECT_NE(entry.get_cache_entry_value(*context_).serial_number(),
+            serial_number);
 }
 
 }  // namespace


### PR DESCRIPTION
Resolves #10992
- Adds (Advanced) method to get time derivative cache entry.
- Use that method to avoid double counting of cached evaluations in integrators for statistics reporting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11028)
<!-- Reviewable:end -->
