### PR TITLE
tools: Enable Werror=unused-result

### DIFF
--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -15,6 +15,7 @@ CXX_FLAGS = [
     "-Werror=old-style-cast",
     "-Werror=overloaded-virtual",
     "-Werror=shadow",
+    "-Werror=unused-result",
 ]
 
 # The CLANG_FLAGS will be enabled for all C++ rules in the project when


### PR DESCRIPTION
This enforces `DRAKE_NODISCARD` from #10926 at compile-time (for first-party builds).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11036)
<!-- Reviewable:end -->
