### PR TITLE
Generalize input/output port "selection"

### DIFF
--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -99,6 +99,7 @@ drake_pybind_library(
         ":systems_pybind",
         "//bindings/pydrake:documentation_pybind",
         "//bindings/pydrake/common:drake_optional_pybind",
+        "//bindings/pydrake/common:drake_variant_pybind",
     ],
     cc_srcs = ["primitives_py.cc"],
     package_info = PACKAGE_INFO,

--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -65,6 +65,15 @@ void DefineFrameworkPySemantics(py::module m) {
       .value("kVectorValued", kVectorValued)
       .value("kAbstractValued", kAbstractValued);
 
+  py::enum_<InputPortSelection>(m, "InputPortSelection")
+      .value("kNoInput", InputPortSelection::kNoInput)
+      .value("kUseFirstInputIfItExists",
+          InputPortSelection::kUseFirstInputIfItExists);
+  py::enum_<OutputPortSelection>(m, "OutputPortSelection")
+      .value("kNoOutput", OutputPortSelection::kNoOutput)
+      .value("kUseFirstOutputIfItExists",
+          OutputPortSelection::kUseFirstOutputIfItExists);
+
   BindTypeSafeIndex<DependencyTicket>(m, "DependencyTicket");
   BindTypeSafeIndex<CacheIndex>(m, "CacheIndex");
   BindTypeSafeIndex<SubsystemIndex>(m, "SubsystemIndex");

--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -3,6 +3,7 @@
 
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/drake_optional_pybind.h"
+#include "drake/bindings/pydrake/common/drake_variant_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/systems/systems_pybind.h"
@@ -255,14 +256,18 @@ PYBIND11_MODULE(primitives, m) {
       py::arg("builder"), doc.AddRandomInputs.doc);
 
   m.def("Linearize", &Linearize, py::arg("system"), py::arg("context"),
-      py::arg("input_port_index") = systems::kUseFirstInputIfItExists,
-      py::arg("output_port_index") = systems::kUseFirstOutputIfItExists,
+      py::arg("input_port_index") =
+          systems::InputPortSelection::kUseFirstInputIfItExists,
+      py::arg("output_port_index") =
+          systems::OutputPortSelection::kUseFirstOutputIfItExists,
       py::arg("equilibrium_check_tolerance") = 1e-6, doc.Linearize.doc);
 
   m.def("FirstOrderTaylorApproximation", &FirstOrderTaylorApproximation,
       py::arg("system"), py::arg("context"),
-      py::arg("input_port_index") = systems::kUseFirstInputIfItExists,
-      py::arg("output_port_index") = systems::kUseFirstOutputIfItExists,
+      py::arg("input_port_index") =
+          systems::InputPortSelection::kUseFirstInputIfItExists,
+      py::arg("output_port_index") =
+          systems::OutputPortSelection::kUseFirstOutputIfItExists,
       doc.FirstOrderTaylorApproximation.doc);
 
   m.def("ControllabilityMatrix", &ControllabilityMatrix,

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -1277,7 +1277,7 @@ GTEST_TEST(MultibodyPlantTest, LinearizePendulum) {
   unique_ptr<LinearSystem<double>> linearized_pendulum =
       Linearize(*pendulum, *context,
                 pendulum->get_actuation_input_port().get_index(),
-                systems::kNoOutput);
+                systems::OutputPortSelection::kNoOutput);
 
   // Compute the expected solution by hand.
   Eigen::Matrix2d A;
@@ -1296,7 +1296,8 @@ GTEST_TEST(MultibodyPlantTest, LinearizePendulum) {
   pin.set_angular_rate(context.get(), 0.0);
   linearized_pendulum = Linearize(
       *pendulum, *context,
-      pendulum->get_actuation_input_port().get_index(), systems::kNoOutput);
+      pendulum->get_actuation_input_port().get_index(),
+      systems::OutputPortSelection::kNoOutput);
   // Compute the expected solution by hand.
   A << 0.0, 1.0,
       -parameters.g() / parameters.l(), domegadot_domega;

--- a/systems/controllers/linear_quadratic_regulator.cc
+++ b/systems/controllers/linear_quadratic_regulator.cc
@@ -111,7 +111,7 @@ std::unique_ptr<systems::AffineSystem<double>> LinearQuadraticRegulator(
   // Use specified input and no outputs (the output dynamics are irrelevant for
   // LQR design).
   auto linear_system = Linearize(
-    system, context, input_port_index, kNoOutput);
+    system, context, input_port_index, OutputPortSelection::kNoOutput);
 
   // DiscreteTimeLinearQuadraticRegulator does not support N yet.
   DRAKE_DEMAND(linear_system->time_period() == 0.0 || N.rows() == 0);

--- a/systems/framework/framework_common.h
+++ b/systems/framework/framework_common.h
@@ -95,6 +95,15 @@ inline bool operator==(
   return holds_alternative<UseDefaultName>(value);
 }
 
+/** Intended for use in e.g. variant<InputPortSelection, InputPortIndex> for
+algorithms that support optional and/or default port indices. */
+enum class InputPortSelection { kNoInput = -1, kUseFirstInputIfItExists = -2 };
+
+/** Intended for use in e.g. variant<OutputPortSelection, OutputPortIndex> for
+algorithms that support optional and/or default port indices. */
+enum class OutputPortSelection { kNoOutput = -1, kUseFirstOutputIfItExists =
+    -2 };
+
 #ifndef DRAKE_DOXYGEN_CXX
 class ContextBase;
 class InputPortBase;

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -1099,6 +1099,28 @@ class System : public SystemBase {
         this->GetInputPortBaseOrThrow(__func__, port_index));
   }
 
+  /// Returns the typed input port specified by the InputPortSelection or by
+  /// the InputPortIndex.  Returns nullptr if no port is selected.  This is
+  /// provided as a convenience method since many algorithms provide the same
+  /// common default or optional port semantics.
+  const InputPort<T>* get_input_port_selection(
+      variant<InputPortSelection, InputPortIndex> port_index) const {
+    if (holds_alternative<InputPortIndex>(port_index)) {
+      return &get_input_port(get<InputPortIndex>(port_index));
+    }
+
+    switch (get<InputPortSelection>(port_index)) {
+      case InputPortSelection::kUseFirstInputIfItExists:
+        if (num_input_ports() > 0) {
+          return &get_input_port(0);
+        }
+        return nullptr;
+      case InputPortSelection::kNoInput:
+        return nullptr;
+    }
+    return nullptr;
+  }
+
   /// Returns the typed input port with the unique name @p port_name.
   /// The current implementation performs a linear search over strings; prefer
   /// get_input_port() when performance is a concern.
@@ -1119,6 +1141,27 @@ class System : public SystemBase {
   const OutputPort<T>& get_output_port(int port_index) const {
     return dynamic_cast<const OutputPort<T>&>(
         this->GetOutputPortBaseOrThrow(__func__, port_index));
+  }
+
+  /// Returns the typed output port specified by the OutputPortSelection or by
+  /// the OutputPortIndex.  Returns nullptr if no port is selected. This is
+  /// provided as a convenience method since many algorithms provide the same
+  /// common default or optional port semantics.
+  const OutputPort<T>* get_output_port_selection(
+      variant<OutputPortSelection, OutputPortIndex> port_index) const {
+    if (holds_alternative<OutputPortIndex>(port_index)) {
+      return &get_output_port(get<OutputPortIndex>(port_index));
+    }
+    switch (get<OutputPortSelection>(port_index)) {
+      case OutputPortSelection::kUseFirstOutputIfItExists:
+        if (num_output_ports() > 0) {
+          return &get_output_port(0);
+        }
+        return nullptr;
+      case OutputPortSelection::kNoOutput:
+        return nullptr;
+    }
+    return nullptr;
   }
 
   /// Returns the typed output port with the unique name @p port_name.

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -1003,7 +1003,7 @@ class SystemBase : public internal::SystemMessageInterface {
   }
 
   /** (Internal use only) Returns the OutputPortBase at index `port_index`,
-  throwing std::out_of_range we don't like the port index. The name of the
+  throwing std::out_of_range if we don't like the port index. The name of the
   public API method that received the bad index is provided in `func` and is
   included in the error message. */
   const OutputPortBase& GetOutputPortBaseOrThrow(const char* func,

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -376,6 +376,37 @@ TEST_F(SystemTest, PortNameTest) {
       std::logic_error, ".*does not have an output port named.*");
 }
 
+TEST_F(SystemTest, PortSelectionTest) {
+  // Input ports.
+  EXPECT_EQ(system_.get_input_port_selection(InputPortSelection::kNoInput),
+            nullptr);
+  EXPECT_EQ(system_.get_input_port_selection(
+                InputPortSelection::kUseFirstInputIfItExists),
+            nullptr);
+
+  const auto& input_port =
+      system_.DeclareInputPort("my_input", kVectorValued, 3);
+  EXPECT_EQ(system_.get_input_port_selection(
+                InputPortSelection::kUseFirstInputIfItExists),
+            &input_port);
+
+  EXPECT_EQ(system_.get_input_port_selection(0), &system_.get_input_port(0));
+
+  // Output ports.
+  EXPECT_EQ(system_.get_output_port_selection(OutputPortSelection::kNoOutput),
+            nullptr);
+  EXPECT_EQ(system_.get_output_port_selection(
+                OutputPortSelection::kUseFirstOutputIfItExists),
+            nullptr);
+
+  const auto& output_port = system_.AddAbstractOutputPort();
+  EXPECT_EQ(system_.get_output_port_selection(
+                OutputPortSelection::kUseFirstOutputIfItExists),
+            &output_port);
+
+  EXPECT_EQ(system_.get_output_port_selection(0), &system_.get_output_port(0));
+}
+
 // Tests the constraint list logic.
 TEST_F(SystemTest, SystemConstraintTest) {
   EXPECT_EQ(system_.num_constraints(), 0);

--- a/systems/primitives/linear_system.h
+++ b/systems/primitives/linear_system.h
@@ -149,16 +149,6 @@ class TimeVaryingLinearSystem : public TimeVaryingAffineSystem<T> {
   }
 };
 
-#ifndef DRAKE_DOXYGEN_CXX
-// LinearSystem special values for port indices.  Omitted from Doxygen because
-// we should really not be using `int`s here in the first place, and we don't
-// really want to leak these into the drake::systems namespace globally.
-const int kNoInput = -1;
-const int kUseFirstInputIfItExists = -2;
-const int kNoOutput = -3;
-const int kUseFirstOutputIfItExists = -4;
-#endif
-
 /// Takes the first-order Taylor expansion of a System around a nominal
 /// operating point (defined by the Context).
 ///
@@ -173,10 +163,10 @@ const int kUseFirstOutputIfItExists = -4;
 /// @param system The system or subsystem to linearize.
 /// @param context Defines the nominal operating point about which the system
 /// should be linearized.  See note below.
-/// @param input_port_index A valid input port index for @p system or kNoInput
-/// or (default) kUseFirstInputIfItExists.
+/// @param input_port_index A valid input port index for @p system or
+/// InputPortSelection @default kUseFirstInputIfItExists.
 /// @param output_port_index A valid output port index for @p system or
-/// kNoOutput or (default) kUseFirstOutputIfItExists.
+/// an OutputPortSelection. @default kUseFirstOutputIfItExists.
 /// @param equilibrium_check_tolerance Specifies the tolerance on ensuring that
 /// the derivative vector isZero at the nominal operating point.  @default 1e-6.
 /// @returns A LinearSystem that approximates the original system in the
@@ -202,8 +192,10 @@ const int kUseFirstOutputIfItExists = -4;
 ///
 std::unique_ptr<LinearSystem<double>> Linearize(
     const System<double>& system, const Context<double>& context,
-    int input_port_index = kUseFirstInputIfItExists,
-    int output_port_index = kUseFirstOutputIfItExists,
+    variant<InputPortSelection, InputPortIndex> input_port_index =
+        InputPortSelection::kUseFirstInputIfItExists,
+    variant<OutputPortSelection, OutputPortIndex> output_port_index =
+        OutputPortSelection::kUseFirstOutputIfItExists,
     double equilibrium_check_tolerance = 1e-6);
 
 /// A first-order Taylor series approximation to a @p system in the neighborhood
@@ -233,10 +225,10 @@ std::unique_ptr<LinearSystem<double>> Linearize(
 /// @param system The system or subsystem to linearize.
 /// @param context Defines the nominal operating point about which the system
 /// should be linearized.
-/// @param input_port_index A valid input port index for @p system or kNoInput
-/// or (default) kUseFirstInputIfItExists.
+/// @param input_port_index A valid input port index for @p system or
+/// InputPortSelection. @default kUseFirstInputIfItExists.
 /// @param output_port_index A valid output port index for @p system or
-/// kNoOutput or (default) kUseFirstOutputIfItExists.
+/// OutputPortSelection. @default kUseFirstOutputIfItExists.
 /// @returns An AffineSystem at this linearization point.
 /// @throws if any abstract inputs are connected, if any
 ///         vector-valued inputs are unconnected, if the system is not (only)
@@ -253,8 +245,10 @@ std::unique_ptr<LinearSystem<double>> Linearize(
 // me handle the additional options without a lot of boilerplate.
 std::unique_ptr<AffineSystem<double>> FirstOrderTaylorApproximation(
     const System<double>& system, const Context<double>& context,
-    int input_port_index = kUseFirstInputIfItExists,
-    int output_port_index = kUseFirstOutputIfItExists);
+    variant<InputPortSelection, InputPortIndex> input_port_index =
+        InputPortSelection::kUseFirstInputIfItExists,
+    variant<OutputPortSelection, OutputPortIndex> output_port_index =
+        OutputPortSelection::kUseFirstOutputIfItExists);
 
 /// Returns the controllability matrix:  R = [B, AB, ..., A^{n-1}B].
 /// @ingroup control_systems


### PR DESCRIPTION
In preparation for using it in trajectory optimization, sums of squares, etc, this PR starts by pulling the meaningful logic out of Linearize, and making it typesafe.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11039)
<!-- Reviewable:end -->
