### PR TITLE
lcm: Add new APIs and discourage use of threads

### DIFF
--- a/attic/manipulation/dev/remote_tree_viewer_wrapper.cc
+++ b/attic/manipulation/dev/remote_tree_viewer_wrapper.cc
@@ -9,6 +9,7 @@
 #include <stdexcept>
 #include <string>
 
+#include "lcm/lcm-cpp.hpp"
 #include "nlohmann/json.hpp"
 
 #include "drake/lcmt_viewer2_comms.hpp"

--- a/bindings/pydrake/lcm_py.cc
+++ b/bindings/pydrake/lcm_py.cc
@@ -63,9 +63,12 @@ PYBIND11_MODULE(lcm, m) {
         .def("Subscribe",
             [](Class* self, const std::string& channel,
                 PyHandlerFunction handler) {
-              self->Subscribe(channel, [handler](const void* data, int size) {
-                handler(py::bytes(static_cast<const char*>(data), size));
-              });
+              auto subscription = self->Subscribe(
+                  channel, [handler](const void* data, int size) {
+                    handler(py::bytes(static_cast<const char*>(data), size));
+                  });
+              // Unsubscribe is not supported by the mock.
+              DRAKE_DEMAND(subscription == nullptr);
             },
             py::arg("channel"), py::arg("handler"),
             doc.DrakeMockLcm.Subscribe.doc)

--- a/lcm/BUILD.bazel
+++ b/lcm/BUILD.bazel
@@ -14,8 +14,10 @@ package(default_visibility = ["//visibility:public"])
 drake_cc_package_library(
     name = "lcm",
     deps = [
+        ":drake_lcm",
         ":interface",
         ":lcm_log",
+        ":lcm_receive_thread",
         ":mock",
         ":real",
         ":translator_base",
@@ -24,9 +26,8 @@ drake_cc_package_library(
 
 drake_cc_library(
     name = "interface",
-    hdrs = [
-        "drake_lcm_interface.h",
-    ],
+    srcs = ["drake_lcm_interface.cc"],
+    hdrs = ["drake_lcm_interface.h"],
     deps = [
         "//common:essential",
     ],
@@ -41,16 +42,19 @@ drake_cc_library(
     ],
 )
 
+# TODO(jwnimmer-tri) Deprecate this compatibility shim.
 drake_cc_library(
     name = "real",
-    srcs = [
-        "drake_lcm.cc",
-        "lcm_receive_thread.cc",
+    deps = [
+        ":drake_lcm",
+        ":lcm_receive_thread",
     ],
-    hdrs = [
-        "drake_lcm.h",
-        "lcm_receive_thread.h",
-    ],
+)
+
+drake_cc_library(
+    name = "drake_lcm",
+    srcs = ["drake_lcm.cc"],
+    hdrs = ["drake_lcm.h"],
     deps = [
         ":interface",
         "//common:essential",
@@ -59,13 +63,19 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "lcm_receive_thread",
+    srcs = ["lcm_receive_thread.cc"],
+    hdrs = ["lcm_receive_thread.h"],
+    deps = [
+        "//common:essential",
+        "@lcm",
+    ],
+)
+
+drake_cc_library(
     name = "lcm_log",
-    srcs = [
-        "drake_lcm_log.cc",
-    ],
-    hdrs = [
-        "drake_lcm_log.h",
-    ],
+    srcs = ["drake_lcm_log.cc"],
+    hdrs = ["drake_lcm_log.h"],
     deps = [
         ":interface",
         "//common:essential",
@@ -86,9 +96,7 @@ drake_cc_library(
 
 drake_cc_library(
     name = "translator_base",
-    hdrs = [
-        "translator_base.h",
-    ],
+    hdrs = ["translator_base.h"],
     deps = [
         "//common:essential",
         "//common:unused",
@@ -108,9 +116,20 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "drake_lcm_test",
+    flaky = True,
     deps = [
+        ":drake_lcm",
         ":lcmt_drake_signal_utils",
-        ":real",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
+    name = "drake_lcm_thread_test",
+    flaky = True,
+    deps = [
+        ":drake_lcm",
+        ":lcmt_drake_signal_utils",
     ],
 )
 

--- a/lcm/drake_lcm.cc
+++ b/lcm/drake_lcm.cc
@@ -1,6 +1,11 @@
 #include "drake/lcm/drake_lcm.h"
 
+#include <algorithm>
+#include <atomic>
+#include <cstdlib>
+#include <thread>
 #include <utility>
+#include <vector>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
@@ -10,62 +15,267 @@ namespace drake {
 namespace lcm {
 namespace {
 
-void Callback(const ::lcm::ReceiveBuffer* buffer,
-              const std::string& /* channel */ ,
-              DrakeLcm::HandlerFunction* context) {
-  DRAKE_DEMAND(buffer != nullptr);
-  DRAKE_DEMAND(context != nullptr);
-  DrakeLcm::HandlerFunction& handler = *context;
-  handler(buffer->data, buffer->data_size);
-}
+// Keep this in sync with external/lcm/lcm.c.  Unfortunately, LCM does not
+// appear to provide *any* API to determine this.
+constexpr const char* const kLcmDefaultUrl = "udpm://239.255.76.67:7667?ttl=0";
+
+// Defined below.
+class DrakeSubscription;
 
 }  // namespace
+
+class DrakeLcm::Impl {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Impl)
+
+  explicit Impl(std::string lcm_url)
+      : requested_lcm_url_(std::move(lcm_url)),
+        lcm_url_(requested_lcm_url_),
+        lcm_(requested_lcm_url_) {
+    // This duplicates logic from external/lcm/lcm.c, but until LCM offers an
+    // API for this it's the best we can do.
+    if (lcm_url_.empty()) {
+      char* env_url = ::getenv("LCM_DEFAULT_URL");
+      if (env_url) {
+        lcm_url_ = env_url;
+      }
+      if (lcm_url_.empty()) {
+        lcm_url_ = kLcmDefaultUrl;
+      }
+    }
+  }
+
+  std::string requested_lcm_url_;
+  std::string lcm_url_;
+  ::lcm::LCM lcm_;
+  std::vector<std::weak_ptr<DrakeSubscription>> subscriptions_;
+
+  // TODO(jwnimmer-tri) To be removed once deprecated methods are gone.
+  std::unique_ptr<std::thread> receive_thread_;
+  // TODO(jwnimmer-tri) To be removed once deprecated methods are gone.
+  std::atomic_bool receive_thread_stopping_{false};
+};
 
 DrakeLcm::DrakeLcm() : DrakeLcm(std::string{}) {}
 
 DrakeLcm::DrakeLcm(std::string lcm_url)
-    : requested_lcm_url_(std::move(lcm_url)),
-      lcm_(requested_lcm_url_) {}
-
-DrakeLcm::~DrakeLcm() { receive_thread_.reset(); }
-
-void DrakeLcm::StartReceiveThread() {
-  DRAKE_DEMAND(receive_thread_ == nullptr);
-
-  // Ensure that LCM's self-test happens before our thread starts running.
-  // Without this, ThreadSanitizer builds may report false positives related to
-  // the self-test happening concurrently with the LCM publishing.
-  lcm_.getFileno();
-
-  // Now launch the thread.
-  receive_thread_ = std::make_unique<LcmReceiveThread>(&lcm_);
+    : impl_(std::make_unique<Impl>(std::move(lcm_url))) {
+  // Ensure that LCM's self-test happens deterministically (here in our ctor),
+  // and NOT in the receive thread or first HandleSubscriptions call.  Without
+  // this, ThreadSanitizer builds may report false positives related to the
+  // self-test happening concurrently with the LCM publishing.
+  impl_->lcm_.getFileno();
 }
 
+// TODO(jwnimmer-tri) To be deprecated.
+void DrakeLcm::StartReceiveThread() {
+  DRAKE_DEMAND(impl_->receive_thread_ == nullptr);
+  impl_->receive_thread_ = std::make_unique<std::thread>(
+      [this](){
+        while (!this->impl_->receive_thread_stopping_) {
+          this->HandleSubscriptions(300);
+        }
+      });
+}
+
+// TODO(jwnimmer-tri) To be deprecated.
 void DrakeLcm::StopReceiveThread() {
-  if (receive_thread_ != nullptr) {
-    receive_thread_->Stop();
-    receive_thread_.reset();
+  if (impl_->receive_thread_ != nullptr) {
+    impl_->receive_thread_stopping_ = true;
+    impl_->receive_thread_->join();
+    impl_->receive_thread_stopping_ = false;
+    impl_->receive_thread_.reset();
   }
 }
 
-::lcm::LCM* DrakeLcm::get_lcm_instance() { return &lcm_; }
+// TODO(jwnimmer-tri) To be deprecated.
+bool DrakeLcm::IsReceiveThreadRunning() const {
+  return impl_->receive_thread_ != nullptr;
+}
 
+// TODO(jwnimmer-tri) To be deprecated.
 std::string DrakeLcm::get_requested_lcm_url() const {
-  return requested_lcm_url_;
+  return impl_->requested_lcm_url_;
+}
+
+std::string DrakeLcm::get_lcm_url() const {
+  return impl_->lcm_url_;
+}
+
+::lcm::LCM* DrakeLcm::get_lcm_instance() {
+  return &impl_->lcm_;
 }
 
 void DrakeLcm::Publish(const std::string& channel, const void* data,
                        int data_size, optional<double>) {
   DRAKE_THROW_UNLESS(!channel.empty());
-  lcm_.publish(channel, data, data_size);
+  impl_->lcm_.publish(channel, data, data_size);
 }
 
-void DrakeLcm::Subscribe(const std::string& channel, HandlerFunction handler) {
+namespace {
+
+// The concrete implementation of DrakeSubscriptionInterface used by DrakeLcm.
+class DrakeSubscription final : public DrakeSubscriptionInterface {
+ public:
+  // We must disable copy/move/assign because we need our memory address to
+  // remain stable; the native LCM stack keeps a pointer to this object.
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DrakeSubscription)
+
+  using HandlerFunction = DrakeLcmInterface::HandlerFunction;
+
+  static std::shared_ptr<DrakeSubscription> Create(
+      ::lcm::LCM* native_instance, const std::string& channel,
+      HandlerFunction handler) {
+    DRAKE_DEMAND(native_instance != nullptr);
+
+    // Create the result.
+    auto result = std::make_shared<DrakeSubscription>();
+    result->native_instance_ = native_instance;
+    result->user_callback_ = std::move(handler);
+    result->weak_self_reference_ = result;
+    result->strong_self_reference_ = result;
+    result->native_subscription_ = native_instance->subscribeFunction(
+      channel, &DrakeSubscription::NativeCallback, result.get());
+    result->native_subscription_->setQueueCapacity(1);
+
+    // Sanity checks.  (The use_count will be 2 because both 'result' and
+    // 'strong_self_reference' keep the subscription alive.)
+    DRAKE_DEMAND(result->native_instance_ != nullptr);
+    DRAKE_DEMAND(result->native_subscription_ != nullptr);
+    DRAKE_DEMAND(result->user_callback_ != nullptr);
+    DRAKE_DEMAND(result->weak_self_reference_.use_count() == 2);
+    DRAKE_DEMAND(result->strong_self_reference_.use_count() == 2);
+    DRAKE_DEMAND(result->strong_self_reference_ != nullptr);
+
+    return result;
+  }
+
+  ~DrakeSubscription() {
+    DRAKE_DEMAND(strong_self_reference_ == nullptr);
+    if (native_subscription_) {
+      DRAKE_DEMAND(native_instance_ != nullptr);
+      native_instance_->unsubscribe(native_subscription_);
+    }
+  }
+
+  void set_unsubscribe_on_delete(bool enabled) final {
+    DRAKE_DEMAND(!weak_self_reference_.expired());
+    if (enabled) {
+      // The caller needs to keep this Subscription active.
+      strong_self_reference_.reset();
+    } else {
+      // This DrakeSubscription will keep itself active.
+      strong_self_reference_ = weak_self_reference_.lock();
+    }
+  }
+
+  void set_queue_capacity(int capacity) final {
+    DRAKE_DEMAND(!weak_self_reference_.expired());
+    if (native_subscription_) {
+      DRAKE_DEMAND(native_instance_ != nullptr);
+      native_subscription_->setQueueCapacity(capacity);
+    }
+  }
+
+  // This is ONLY called from the DrakeLcm dtor.  Thus, a HandleSubscriptions
+  // is never in flight, so we can freely change any/all of our member fields.
+  void Detach() {
+    DRAKE_DEMAND(!weak_self_reference_.expired());
+    if (native_subscription_) {
+      DRAKE_DEMAND(native_instance_ != nullptr);
+      native_instance_->unsubscribe(native_subscription_);
+    }
+    native_instance_ = {};
+    native_subscription_ = {};
+    user_callback_ = {};
+    weak_self_reference_ = {};
+    strong_self_reference_ = {};
+  }
+
+  // The native LCM stack calls into here.
+  static void NativeCallback(
+      const ::lcm::ReceiveBuffer* buffer,
+      const std::string& /* channel */ ,
+      DrakeSubscription* self) {
+    DRAKE_DEMAND(buffer != nullptr);
+    DRAKE_DEMAND(self != nullptr);
+    self->InstanceCallback(buffer);
+  }
+
+ private:
+  struct AsIfPrivateConstructor {};
+
+ public:
+  // Only use Create; don't call this directly.  (We use a private struct to
+  // prevent anyone but this class from calling the ctor.)
+  explicit DrakeSubscription(AsIfPrivateConstructor = {}) {}
+
+ private:
+  void InstanceCallback(const ::lcm::ReceiveBuffer* buffer) {
+    DRAKE_DEMAND(!weak_self_reference_.expired());
+    if (user_callback_ != nullptr) {
+      user_callback_(buffer->data, buffer->data_size);
+    }
+  }
+
+  // The native handle we can use to unsubscribe.
+  ::lcm::LCM* native_instance_{};
+  ::lcm::Subscription* native_subscription_{};
+
+  // The user's function that handles raw message data.
+  DrakeLcmInterface::HandlerFunction user_callback_;
+
+  // We can use "strong" to pretend a subscriber is still active.
+  std::weak_ptr<DrakeSubscriptionInterface> weak_self_reference_;
+  std::shared_ptr<DrakeSubscriptionInterface> strong_self_reference_;
+};
+
+}  // namespace
+
+std::shared_ptr<DrakeSubscriptionInterface> DrakeLcm::Subscribe(
+    const std::string& channel, HandlerFunction handler) {
   DRAKE_THROW_UNLESS(!channel.empty());
-  handlers_.emplace_back(std::move(handler));
-  // The handlers_ is a std::list so that the context pointers remain stable.
-  HandlerFunction* const context = &handlers_.back();
-  lcm_.subscribeFunction(channel, &Callback, context)->setQueueCapacity(1);
+  DRAKE_THROW_UNLESS(handler != nullptr);
+
+  // Some housekeeping: scrub any deallocated subscribers.
+  auto& subs = impl_->subscriptions_;
+  subs.erase(std::remove_if(
+      subs.begin(), subs.end(),
+      [](const auto& weak_subscription) {
+        return weak_subscription.expired();
+      }), subs.end());
+
+  // Add the new subscriber.
+  auto result = DrakeSubscription::Create(
+      &(impl_->lcm_), channel, std::move(handler));
+  subs.push_back(result);
+  DRAKE_DEMAND(!subs.back().expired());
+  return result;
+}
+
+int DrakeLcm::HandleSubscriptions(int timeout_millis) {
+  // Keep pumping handleTimeout until it's empty, but only pause for the
+  // timeout on the first attempt.
+  int total_messages = 0;
+  int zero_or_one = impl_->lcm_.handleTimeout(timeout_millis);
+  for (; zero_or_one > 0; zero_or_one = impl_->lcm_.handleTimeout(0)) {
+    DRAKE_DEMAND(zero_or_one == 1);
+    ++total_messages;
+  }
+  return total_messages;
+}
+
+DrakeLcm::~DrakeLcm() {
+  // Stop invoking the subscriptions, prior to destroying them.
+  StopReceiveThread();
+
+  // Invalidate our DrakeSubscription objects.
+  for (const auto& weak_subscription : impl_->subscriptions_) {
+    auto subscription = weak_subscription.lock();
+    if (subscription) {
+      subscription->Detach();
+    }
+  }
 }
 
 }  // namespace lcm

--- a/lcm/drake_lcm_interface.cc
+++ b/lcm/drake_lcm_interface.cc
@@ -1,0 +1,13 @@
+#include "drake/lcm/drake_lcm_interface.h"
+
+namespace drake {
+namespace lcm {
+
+DrakeLcmInterface::DrakeLcmInterface() = default;
+DrakeLcmInterface::~DrakeLcmInterface() = default;
+
+DrakeSubscriptionInterface::DrakeSubscriptionInterface() = default;
+DrakeSubscriptionInterface::~DrakeSubscriptionInterface() = default;
+
+}  // namespace lcm
+}  // namespace drake

--- a/lcm/drake_lcm_interface.h
+++ b/lcm/drake_lcm_interface.h
@@ -2,9 +2,10 @@
 
 #include <cstdint>
 #include <functional>
-#include <limits>
+#include <memory>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
@@ -14,13 +15,24 @@
 namespace drake {
 namespace lcm {
 
+// Declared later in this file.
+class DrakeSubscriptionInterface;
+
 /**
  * A pure virtual interface that enables LCM to be mocked.
+ *
+ * Because it must be pure, in general it will receive breaking API changes
+ * without notice.  Users should not subclass this interface directly, but
+ * rather use one of the existing subclasses instead.
+ *
+ * Similarly, method arguments will receive breaking API changes without
+ * notice.  Users should not call this interface directly, but rather use
+ * drake::lcm::Publish() or drake::lcm::Subscribe() instead.
  */
 class DrakeLcmInterface {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DrakeLcmInterface)
-  virtual ~DrakeLcmInterface() = default;
+  virtual ~DrakeLcmInterface();
 
   /**
    * A callback used by DrakeLcmInterface::Subscribe(), with arguments:
@@ -31,33 +43,100 @@ class DrakeLcmInterface {
   using HandlerFunction = std::function<void(const void*, int)>;
 
   /**
+   * Most users should use the drake::lcm::Publish() free function, instead of
+   * this interface method.
+   *
    * Publishes an LCM message on channel @p channel.
    *
-   * @param[in] channel The channel on which to publish the message.
+   * @param channel The channel on which to publish the message.
    * Must not be the empty string.
    *
-   * @param[in] data A buffer containing the serialized bytes of the message to
+   * @param data A buffer containing the serialized bytes of the message to
    * publish.
    *
-   * @param[in] data_size The length of @data in bytes.
+   * @param data_size The length of @data in bytes.
    *
-   * @param[in] time_sec Time in seconds when the publish event occurred.
+   * @param time_sec Time in seconds when the publish event occurred.
    * If unknown, use drake::nullopt or a default-constructed optional.
    */
   virtual void Publish(const std::string& channel, const void* data,
                        int data_size, optional<double> time_sec) = 0;
 
   /**
+   * Most users should use the drake::lcm::Subscribe() free function or the
+   * drake::lcm::Subscriber wrapper class, instead of this interface method.
+   *
    * Subscribes to an LCM channel without automatic message decoding. The
    * handler will be invoked when a message arrives on channel @p channel.
    *
    * @param channel The channel to subscribe to.
    * Must not be the empty string.
+   *
+   * @return the object used to manage the subscription if that is supported,
+   * or else nullptr if not supported.  The unsubscribe-on-delete default is
+   * `false`.  Refer to the DrakeSubscriptionInterface class overview for
+   * details.
    */
-  virtual void Subscribe(const std::string& channel, HandlerFunction) = 0;
+  virtual std::shared_ptr<DrakeSubscriptionInterface> Subscribe(
+      const std::string& channel, HandlerFunction) = 0;
+
+  /**
+   * Invokes the HandlerFunction callbacks for all subscriptions' pending
+   * messages.  If @p timeout_millis is >0, blocks for up to that long until at
+   * least one message is handled.
+   * @return the number of messages handled, or 0 on timeout.
+   * @throw std::exception when a subscribed handler throws.
+   */
+  virtual int HandleSubscriptions(int timeout_millis) = 0;
 
  protected:
-  DrakeLcmInterface() = default;
+  DrakeLcmInterface();
+};
+
+/**
+ * A helper class returned by DrakeLcmInterface::Subscribe() that allows for
+ * (possibly automatic) unsubscription and/or queue capacity control.  Refer to
+ * that method for additional details.
+ *
+ * Instance of this object are always stored in `std::shared_ptr` to manage
+ * them as resources.  When a particular DrakeLcmInterface implementation does
+ * not support subscription controls, the managed pointer will be `nullptr`
+ * instead of an instance of this object.
+ *
+ * To unsubscribe, induce a call to the %DrakeSubscriptionInterface destructor
+ * by bringing the `std::shared_ptr` use count to zero.  That usually means
+ * either a call to `subscription.reset()` or by allowing it to go out of
+ * scope.
+ *
+ * To *disable* unsubscription so that the pointer loss *never* causes
+ * unsubscription, call `subscription->set_unsubscribe_on_delete(false)`.
+ * To *enable* unsubscription, set it to `true`.  Which choice is active by
+ * default is specified by whatever method returns this object.
+ */
+class DrakeSubscriptionInterface {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DrakeSubscriptionInterface)
+  virtual ~DrakeSubscriptionInterface();
+
+  /**
+   * Sets whether or not the subscription on DrakeLcmInterface will be
+   * terminated when this object is deleted.  It is permitted to call this
+   * method many times, with a new `enabled` value each time.
+   */
+  virtual void set_unsubscribe_on_delete(bool enabled) = 0;
+
+  /**
+   * Sets this subscription's queue depth to store messages inbetween calls to
+   * DrakeLcmInterface::HandleSubscriptions.  When the queue becomes full, new
+   * received messages will be discarded.  The default depth is 1.
+   *
+   * @warning The memq:// LCM URL does not support per-channel queues, so this
+   * method has no effect when memq is being used, e.g., in Drake unit tests.
+   */
+  virtual void set_queue_capacity(int capacity) = 0;
+
+ protected:
+  DrakeSubscriptionInterface();
 };
 
 /**
@@ -88,7 +167,8 @@ void Publish(DrakeLcmInterface* lcm, const std::string& channel,
 
 /**
  * Subscribes to an LCM channel named @p channel and decodes messages of type
- * @p Message.
+ * @p Message.  See also drake::lcm::Subscriber for a simple way to passively
+ * observe received messages, without the need to write a handler function.
  *
  * @param lcm The LCM service on which to subscribe.
  * Must not be null.
@@ -102,15 +182,21 @@ void Publish(DrakeLcmInterface* lcm, const std::string& channel,
  * @param on_error The callback when a message is received and cannot be
  * decoded; if no error handler is given, an exception is thrown instead.
  *
+ * @return the object used to unsubscribe if that is supported, or else nullptr
+ * if unsubscribe is not supported.  The unsubscribe-on-delete default is
+ * `false`, so that ignoring this result leaves the subscription intact.  Refer
+ * to the DrakeSubscriptionInterface class overview for details.
+ *
  * @note Depending on the specific DrakeLcmInterface implementation, the
  * handler might be invoked on a different thread than this function.
  */
 template <typename Message>
-void Subscribe(DrakeLcmInterface* lcm, const std::string& channel,
-               std::function<void(const Message&)> handler,
-               std::function<void()> on_error = {}) {
+std::shared_ptr<DrakeSubscriptionInterface> Subscribe(
+    DrakeLcmInterface* lcm, const std::string& channel,
+    std::function<void(const Message&)> handler,
+    std::function<void()> on_error = {}) {
   DRAKE_THROW_UNLESS(lcm != nullptr);
-  lcm->Subscribe(channel, [=](const void* bytes, int size) {
+  auto result = lcm->Subscribe(channel, [=](const void* bytes, int size) {
     Message received{};
     const int size_decoded = received.decode(bytes, 0, size);
     if (size_decoded == size) {
@@ -121,7 +207,72 @@ void Subscribe(DrakeLcmInterface* lcm, const std::string& channel,
       throw std::runtime_error("Error decoding message on " + channel);
     }
   });
+  return result;
 }
+
+/**
+ * Subscribes to and stores a copy of the most recent message on a given
+ * channel, for some @p Message type.  All copies of a given Subscriber share
+ * the same underlying data.  This class does NOT provide any mutex behavior
+ * for multi-threaded locking; it should only be used in cases where the
+ * governing DrakeLcmInterface::HandleSubscriptions is called from the same
+ * thread that owns all copies of this object.
+ */
+template <typename Message>
+class Subscriber final {
+ public:
+  // Intentionally copyable so that it can be returned and stored by-value.
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Subscriber)
+
+  /**
+   * Subscribes to the (non-empty) @p channel_name on the given (non-null)
+   * @p lcm instance.  The `lcm` pointer is only used during construction; it
+   * is not retained by this object.  When a undecodable message is received,
+   * @p on_error handler is invoked; when `on_error` is not provided, an
+   * exception will be thrown instead.
+   */
+  Subscriber(DrakeLcmInterface* lcm, const std::string& channel_name,
+             std::function<void()> on_error = {}) {
+    subscription_ = drake::lcm::Subscribe<Message>(
+        lcm, channel_name, [data = data_](const Message& message) {
+          data->message = message;
+          data->count++;
+        }, std::move(on_error));
+    if (subscription_) {
+      subscription_->set_unsubscribe_on_delete(true);
+    }
+  }
+
+  /**
+   * Returns the most recently received message, or a value-initialized (zeros)
+   * message otherwise.
+   */
+  const Message& message() const { return data_->message; }
+  Message& message() { return data_->message; }
+
+  /** Returns the total number of received messages. */
+  int64_t count() const { return data_->count; }
+  int64_t& count() { return data_->count; }
+
+  /** Clears all data (sets the message and count to all zeros). */
+  void clear() {
+    data_->message = {};
+    data_->count = 0;
+  }
+
+ private:
+  struct Data {
+    Message message{};
+    int64_t count{0};
+  };
+  // Share a single copy of our (mutable) message storage, for all Subscribers
+  // to view or modify *and* for our subscription closure to write into.  This
+  // will not be destroyed until all Subscribers are gone AND the subscription
+  // closure has been destroyed.
+  std::shared_ptr<Data> data_{std::make_shared<Data>()};
+  // Keep our subscription active as long as a copy of this Subscriber remains.
+  std::shared_ptr<DrakeSubscriptionInterface> subscription_;
+};
 
 }  // namespace lcm
 }  // namespace drake

--- a/lcm/drake_lcm_log.cc
+++ b/lcm/drake_lcm_log.cc
@@ -51,15 +51,22 @@ void DrakeLcmLog::Publish(const std::string& channel, const void* data,
   }
 }
 
-void DrakeLcmLog::Subscribe(const std::string& channel,
-                            HandlerFunction handler) {
+std::shared_ptr<DrakeSubscriptionInterface> DrakeLcmLog::Subscribe(
+    const std::string& channel, HandlerFunction handler) {
   if (is_write_) {
     throw std::logic_error("Subscribe is only available for log playback.");
   }
-
   std::lock_guard<std::mutex> lock(mutex_);
-
   subscriptions_.emplace(channel, std::move(handler));
+  return nullptr;
+}
+
+int DrakeLcmLog::HandleSubscriptions(int) {
+  if (is_write_) {
+    throw std::logic_error(
+        "HandleSubscriptions is only available for log playback.");
+  }
+  return 0;
 }
 
 double DrakeLcmLog::GetNextMessageTime() const {

--- a/lcm/drake_lcm_log.h
+++ b/lcm/drake_lcm_log.h
@@ -69,8 +69,16 @@ class DrakeLcmLog : public DrakeLcmInterface {
    *
    * @throws std::logic_error if this instance is not constructed in read-only
    * mode.
+   *
+   * @return nullptr because this implementation does not support unsubscribe.
    */
-  void Subscribe(const std::string& channel, HandlerFunction handler) override;
+  std::shared_ptr<DrakeSubscriptionInterface> Subscribe(
+      const std::string& channel, HandlerFunction handler) override;
+
+  /**
+   * This is a no-op for Read mode, and an exception in Write mode.
+   */
+  int HandleSubscriptions(int) override;
 
   /**
    * Returns the time in seconds for the next logged message's occurrence time

--- a/lcm/drake_mock_lcm.cc
+++ b/lcm/drake_mock_lcm.cc
@@ -11,22 +11,21 @@ namespace lcm {
 
 DrakeMockLcm::DrakeMockLcm() {}
 
-
 void DrakeMockLcm::Publish(const std::string& channel, const void* data,
                            int data_size, optional<double> time_sec) {
   DRAKE_THROW_UNLESS(!channel.empty());
-  if (last_published_messages_.find(channel) ==
-      last_published_messages_.end()) {
-    last_published_messages_[channel] = LastPublishedMessage();
+  LastPublishedMessage* per_channel_data{};
+  auto iter = last_published_messages_.find(channel);
+  if (iter != last_published_messages_.end()) {
+    per_channel_data = &iter->second;
+  } else {
+    per_channel_data = &last_published_messages_[channel];
   }
-  LastPublishedMessage* saved_message{nullptr};
-  saved_message = &last_published_messages_[channel];
-
-  DRAKE_DEMAND(saved_message);
 
   const uint8_t* bytes = static_cast<const uint8_t*>(data);
-  saved_message->data = std::vector<uint8_t>(&bytes[0], &bytes[data_size]);
-  saved_message->time_sec = time_sec;
+  per_channel_data->data = std::vector<uint8_t>(&bytes[0], &bytes[data_size]);
+  per_channel_data->time_sec = time_sec;
+  per_channel_data->handled = false;
 
   if (enable_loop_back_) {
     InduceSubscriberCallback(channel, data, data_size);
@@ -58,10 +57,12 @@ optional<double> DrakeMockLcm::get_last_publication_time(
   return iter->second.time_sec;
 }
 
-void DrakeMockLcm::Subscribe(const std::string& channel,
-                             HandlerFunction handler) {
+std::shared_ptr<DrakeSubscriptionInterface> DrakeMockLcm::Subscribe(
+    const std::string& channel, HandlerFunction handler) {
   DRAKE_THROW_UNLESS(!channel.empty());
   subscriptions_.emplace(channel, std::move(handler));
+  // TODO(jwnimmer-tri) Handle unsubscribe.
+  return nullptr;
 }
 
 void DrakeMockLcm::InduceSubscriberCallback(const std::string& channel,
@@ -76,6 +77,24 @@ void DrakeMockLcm::InduceSubscriberCallback(const std::string& channel,
     const HandlerFunction& handler = iter->second;
     handler(data, data_size);
   }
+}
+
+int DrakeMockLcm::HandleSubscriptions(int) {
+  int result = 0;
+  for (auto& pub_iter : last_published_messages_) {
+    const std::string& channel = pub_iter.first;
+    LastPublishedMessage& per_channel_data = pub_iter.second;
+    if (!per_channel_data.handled) {
+      const auto& sub_range = subscriptions_.equal_range(channel);
+      for (auto iter = sub_range.first; iter != sub_range.second; ++iter) {
+        const HandlerFunction& handler = iter->second;
+        handler(per_channel_data.data.data(), per_channel_data.data.size());
+      }
+      ++result;
+      per_channel_data.handled = true;
+    }
+  }
+  return result;
 }
 
 }  // namespace lcm

--- a/lcm/lcm_receive_thread.cc
+++ b/lcm/lcm_receive_thread.cc
@@ -1,9 +1,5 @@
 #include "drake/lcm/lcm_receive_thread.h"
 
-#include <sys/select.h>
-
-#include <iostream>
-
 #include "drake/common/drake_assert.h"
 #include "drake/common/text_logging.h"
 
@@ -11,57 +7,21 @@ namespace drake {
 namespace lcm {
 
 LcmReceiveThread::LcmReceiveThread(::lcm::LCM* lcm) : lcm_(lcm) {
-  DRAKE_DEMAND(lcm);
-  lcm_thread_ = std::thread(&LcmReceiveThread::LoopWithSelect, this);
+  DRAKE_DEMAND(lcm != nullptr);
+  lcm_thread_ = std::thread(&LcmReceiveThread::Looper, this);
 }
 
 LcmReceiveThread::~LcmReceiveThread() {
-  // TODO(liang.fok) Refactor to not employ a blocking destructor. Prefer to use
-  // detach() after removing use of cross-thread bare pointers. Before this is
-  // done, do NOT use Drake in a safety critical system!
   Stop();
 }
 
-namespace {
-
-// Waits for an LCM message to arrive.
-bool WaitForLcm(::lcm::LCM* lcm, double timeout) {
-  int lcm_file_descriptor = lcm->getFileno();
-
-  struct timeval tv;
-  tv.tv_sec = 0;
-  tv.tv_usec = timeout * 1e6;
-
-  fd_set fds;
-  FD_ZERO(&fds);
-  FD_SET(lcm_file_descriptor, &fds);
-
-  int status = select(lcm_file_descriptor + 1, &fds, 0, 0, &tv);
-  int error_code = errno;
-  if (status == -1 && error_code != EINTR) {
-    drake::log()->trace("WaitForLcm: select() returned error: {}", error_code);
-  } else if (status == -1 && error_code == EINTR) {
-    drake::log()->trace("WaitForLcm: select() interrupted.");
-  }
-  return (status > 0 && FD_ISSET(lcm_file_descriptor, &fds));
-}
-
-}  // namespace
-
-void LcmReceiveThread::LoopWithSelect() {
+void LcmReceiveThread::Looper() {
   while (!stop_) {
-    const double timeout_in_seconds = 0.3;
-    bool lcm_ready = WaitForLcm(lcm_, timeout_in_seconds);
-
-    if (stop_) break;
-
-    if (lcm_ready) {
-      if (lcm_->handle() != 0) {
-        drake::log()->trace(
-            "LcmReceiverThread::LoopWithSelect: lcm->handle() "
-            "returned non-zero value.");
-        return;
-      }
+    const int timeout_millis = 300;
+    const int count = lcm_->handleTimeout(timeout_millis);
+    if (count < 0) {
+      drake::log()->error("lcm::handleTimeout() error");
+      return;
     }
   }
 }

--- a/lcm/lcm_receive_thread.h
+++ b/lcm/lcm_receive_thread.h
@@ -11,8 +11,11 @@ namespace drake {
 namespace lcm {
 
 /**
- * Maintains a thread that receives LCM messages and dispatches the messages to
- * the appropriate message handlers.
+ * (Advanced.)  Maintains a thread that receives LCM messages and dispatches
+ * the messages to the appropriate message handlers.
+ *
+ * @warning Almost no Drake uses of LCM should require a background thread.
+ * Please use DrakeLcmInterface::HandleSubscriptions() instead.
  */
 class LcmReceiveThread {
  public:
@@ -41,10 +44,10 @@ class LcmReceiveThread {
  private:
   // Loops waiting for LCM messages and dispatching them to the appropriate
   // subscriber message handlers when they arrive.
-  void LoopWithSelect();
+  void Looper();
 
   // Whether to stop lcm_thread_.
-  std::atomic<bool> stop_{false};
+  std::atomic_bool stop_{false};
 
   // A pointer to the LCM instance.
   ::lcm::LCM* const lcm_{nullptr};

--- a/lcm/test/drake_lcm_interface_test.cc
+++ b/lcm/test/drake_lcm_interface_test.cc
@@ -10,6 +10,13 @@
 #include "drake/lcm/lcmt_drake_signal_utils.h"
 #include "drake/lcmt_drake_signal.hpp"
 
+// This file contains acceptance tests of the sugar functions and classes
+// declared in drake_lcm_interface.h.
+//
+// Since DrakeLcmInterface and DrakeSubscription are pure virtual, we end up
+// using DrakeMockLcm's implementation of them and presuming DrakeMockLcm's
+// correctness in these test cases.
+
 namespace drake {
 namespace lcm {
 namespace {
@@ -19,8 +26,6 @@ class DrakeLcmInterfaceTest : public ::testing::Test {
   using Message = lcmt_drake_signal;
 
   DrakeLcmInterfaceTest() {
-    lcm_.EnableLoopBack();
-
     sample_.timestamp = 123;
     sample_.dim = 1;
     sample_.coord.emplace_back("x");
@@ -41,6 +46,7 @@ class DrakeLcmInterfaceTest : public ::testing::Test {
   std::vector<uint8_t> sample_bytes_;
 };
 
+// Tests the Subscribe + Publish free functions under nominal conditions.
 TEST_F(DrakeLcmInterfaceTest, FreeFunctionTest) {
   // Subscribe using the helper free-function.
   Message received{};
@@ -50,9 +56,11 @@ TEST_F(DrakeLcmInterfaceTest, FreeFunctionTest) {
 
   // Publish using the helper free-function.
   Publish(&lcm_, channel_, sample_);
+  EXPECT_EQ(lcm_.HandleSubscriptions(0), 1);
   EXPECT_TRUE(CompareLcmtDrakeSignalMessages(received, sample_));
 }
 
+// Tests the Subscribe free function's default error handling.
 TEST_F(DrakeLcmInterfaceTest, DefaultErrorHandlingTest) {
   // Subscribe using the helper free-function, using default error-handling.
   Message received{};
@@ -62,19 +70,22 @@ TEST_F(DrakeLcmInterfaceTest, DefaultErrorHandlingTest) {
 
   // Publish successfully.
   lcm_.Publish(channel_, sample_bytes_.data(), sample_bytes_.size(), {});
+  EXPECT_EQ(lcm_.HandleSubscriptions(0), 1);
   EXPECT_TRUE(CompareLcmtDrakeSignalMessages(received, sample_));
   received = {};
 
   // Corrupt the message.
   std::vector<uint8_t> corrupt_bytes = sample_bytes_;
   corrupt_bytes.at(0) = 0;
+  lcm_.Publish(channel_, corrupt_bytes.data(), corrupt_bytes.size(), {});
   DRAKE_EXPECT_THROWS_MESSAGE(
-      lcm_.Publish(channel_, corrupt_bytes.data(), corrupt_bytes.size(), {}),
+      lcm_.HandleSubscriptions(0),
       std::runtime_error,
       "Error decoding message on NAME");
   EXPECT_TRUE(CompareLcmtDrakeSignalMessages(received, Message{}));
 }
 
+// Tests the Subscribe free function's customizable error handling.
 TEST_F(DrakeLcmInterfaceTest, CustomErrorHandlingTest) {
   // Subscribe using the helper free-function, using default error-handling.
   Message received{};
@@ -87,6 +98,7 @@ TEST_F(DrakeLcmInterfaceTest, CustomErrorHandlingTest) {
 
   // Publish successfully.
   lcm_.Publish(channel_, sample_bytes_.data(), sample_bytes_.size(), {});
+  EXPECT_EQ(lcm_.HandleSubscriptions(0), 1);
   EXPECT_TRUE(CompareLcmtDrakeSignalMessages(received, sample_));
   EXPECT_FALSE(error);
   received = {};
@@ -95,8 +107,41 @@ TEST_F(DrakeLcmInterfaceTest, CustomErrorHandlingTest) {
   std::vector<uint8_t> corrupt_bytes = sample_bytes_;
   corrupt_bytes.at(0) = 0;
   lcm_.Publish(channel_, corrupt_bytes.data(), corrupt_bytes.size(), {});
+  EXPECT_EQ(lcm_.HandleSubscriptions(0), 1);
   EXPECT_TRUE(CompareLcmtDrakeSignalMessages(received, Message{}));
   EXPECT_TRUE(error);
+}
+
+// Tests the Subscriber class.
+TEST_F(DrakeLcmInterfaceTest, SubscriberTest) {
+  // Subscribe using the helper class.
+  Subscriber<Message> dut(&lcm_, channel_);
+  EXPECT_EQ(dut.count(), 0);
+  EXPECT_EQ(dut.message().timestamp, 0);
+
+  // Publish using the helper free-function.
+  Publish(&lcm_, channel_, sample_);
+  EXPECT_EQ(lcm_.HandleSubscriptions(0), 1);
+  EXPECT_EQ(dut.count(), 1);
+  EXPECT_TRUE(CompareLcmtDrakeSignalMessages(dut.message(), sample_));
+
+  // Second publish.
+  Publish(&lcm_, channel_, sample_);
+  EXPECT_EQ(lcm_.HandleSubscriptions(0), 1);
+  EXPECT_EQ(dut.count(), 2);
+  EXPECT_TRUE(CompareLcmtDrakeSignalMessages(dut.message(), sample_));
+
+  // Clear.
+  dut.clear();
+  EXPECT_EQ(dut.count(), 0);
+  EXPECT_EQ(dut.message().timestamp, 0);
+
+  // Another publish.
+  for (int i = 1; i <= 11; ++i) {
+    Publish(&lcm_, channel_, sample_);
+    EXPECT_EQ(lcm_.HandleSubscriptions(0), 1);
+    EXPECT_EQ(dut.count(), i);
+  }
 }
 
 }  // namespace

--- a/lcm/test/drake_lcm_test.cc
+++ b/lcm/test/drake_lcm_test.cc
@@ -1,14 +1,13 @@
 #include "drake/lcm/drake_lcm.h"
 
 #include <chrono>
-#include <mutex>
 #include <stdexcept>
 #include <thread>
 
 #include <gtest/gtest.h>
+#include "lcm/lcm-cpp.hpp"
 
-#include "drake/common/drake_copyable.h"
-#include "drake/lcm/lcm_receive_thread.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/lcm/lcmt_drake_signal_utils.h"
 #include "drake/lcmt_drake_signal.hpp"
 
@@ -16,62 +15,19 @@ namespace drake {
 namespace lcm {
 namespace {
 
-using std::chrono::milliseconds;
-using std::this_thread::sleep_for;
+// A udpm URL that is not the default.  We'll transmit here in our tests.
+constexpr const char* const kUdpmUrl = "udpm://239.255.76.67:7670";
 
-// Subscribes to LCM messages of type `drake::lcmt_drake_signal`. Provides an
-// accessor to the latest message received.
-class MessageSubscriber {
- public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MessageSubscriber)
+// @file
+// This file tests non-threaded use of DrakeLcm.
+// See drake_lcm_thread_test.cc for threaded use.
 
-  // A constructor that sets up the LCM message subscription and initializes the
-  // member variable that will be used to store received LCM messages.
-  MessageSubscriber(const std::string& channel_name, ::lcm::LCM* lcm)
-      : channel_name_(channel_name) {
-    ::lcm::Subscription* sub =
-        lcm->subscribe(channel_name, &MessageSubscriber::HandleMessage, this);
-    sub->setQueueCapacity(1);
+using drake::lcmt_drake_signal;
 
-    // Initializes the fields of received_message_ so the test logic below can
-    // determine whether the desired message was received.
-    received_message_.dim = 0;
-    received_message_.val.resize(received_message_.dim);
-    received_message_.coord.resize(received_message_.dim);
-    received_message_.timestamp = 0;
-  }
-
-  // Returns a copy of the most recently received message.
-  drake::lcmt_drake_signal GetReceivedMessage() {
-    drake::lcmt_drake_signal message_copy;
-    std::lock_guard<std::mutex> lock(message_mutex_);
-    message_copy = received_message_;
-    return message_copy;
-  }
-
- private:
-  // Saves a copy of the most recently received message.
-  void HandleMessage(const ::lcm::ReceiveBuffer* rbuf,
-                     const std::string& channel_name) {
-    if (channel_name_ == channel_name) {
-      std::lock_guard<std::mutex> lock(message_mutex_);
-      // Note: The call to decode() below returns the number of bytes decoded
-      // or a negative value indicating an error occurred. This error is
-      // ignored since the unit test below includes logic that checks every
-      // value within the received message for correctness.
-      received_message_.decode(rbuf->data, 0, rbuf->data_size);
-    }
-  }
-
-  const std::string channel_name_;
-  std::mutex message_mutex_;
-  drake::lcmt_drake_signal received_message_;
-};
-
-// This is a test fixture that defines a `drake::lcmt_drake_signal` message.
+// Test fixture.
 class DrakeLcmTest : public ::testing::Test {
  protected:
-  void SetUp() override {
+  DrakeLcmTest() {
     message_.dim = 2;
     message_.val.push_back(0.3739558136);
     message_.val.push_back(0.2801694990);
@@ -80,153 +36,181 @@ class DrakeLcmTest : public ::testing::Test {
     message_.timestamp = 142857;
   }
 
-  drake::lcmt_drake_signal message_;
-};
-
-// Tests DrakeLcm's ability to publish an LCM message.
-TEST_F(DrakeLcmTest, PublishTest) {
-  const std::string channel_name = "drake_lcm_test_publisher_channel_name";
-
-  // Instantiates the Device Under Test (DUT).
-  DrakeLcm dut;
-
-  MessageSubscriber subscriber(channel_name, dut.get_lcm_instance());
-
-  // Start the LCM receive thread after all objects it can potentially use like
-  // subscribers are instantiated. Since objects are destructed in the reverse
-  // order of construction, this ensures the LCM receive thread stops before any
-  // resources it uses are destroyed. If the Lcm receive thread is stopped after
-  // the resources it relies on are destroyed, a segmentation fault may occur.
-
-  EXPECT_FALSE(dut.IsReceiveThreadRunning());
-  dut.StartReceiveThread();
-  EXPECT_TRUE(dut.IsReceiveThreadRunning());
-
-  // Records whether the receiver received an LCM message published by the DUT.
-  bool done = false;
-
-  // Prevents this unit test from running indefinitely when the receiver fails
-  // to receive the LCM message published by the DUT.
-  int count = 0;
-
-  const int kMaxCount = 10;
-  const int kDelayMS = 500;
-
-  // We must periodically call dut.Publish(...) since we do not know when the
-  // receiver will actually receive the message.
-  while (!done && count++ < kMaxCount) {
-    Publish(&dut, channel_name, message_);
-
-    // Gets the received message.
-    const drake::lcmt_drake_signal received_message =
-        subscriber.GetReceivedMessage();
-
-    done = CompareLcmtDrakeSignalMessages(received_message, message_);
-
-    if (!done) sleep_for(milliseconds(kDelayMS));
+  // Call step() until the `received` matches our expected message.
+  void LoopUntilDone(lcmt_drake_signal* received, int retries,
+                     const std::function<void(void)>& step) {
+    // Try until we're either done, or we reach the retry limit.
+    bool message_was_received = false;
+    int count = 0;
+    while (!message_was_received && count++ < retries) {
+      step();
+      message_was_received =
+          CompareLcmtDrakeSignalMessages(*received, message_);
+    }
+    EXPECT_TRUE(message_was_received);
   }
 
-  dut.StopReceiveThread();
-  EXPECT_TRUE(done);
-  EXPECT_FALSE(dut.IsReceiveThreadRunning());
+  // The device under test.
+  std::unique_ptr<DrakeLcm> dut_ = std::make_unique<DrakeLcm>();
+
+  // A prototypical message with non-default values.
+  lcmt_drake_signal message_{};
+};
+
+TEST_F(DrakeLcmTest, DefaultUrlTest) {
+  EXPECT_EQ(dut_->get_requested_lcm_url(), "");
+  EXPECT_GT(dut_->get_lcm_url().size(), 0);
 }
 
-// Handles received LCM messages.
-class MessageHandler final {
- public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MessageHandler)
-
-  // A constructor that initializes the memory for storing received LCM
-  // messages.
-  MessageHandler() {
-    // Initializes the fields of received_message_ so the test logic can
-    // determine whether the desired message was received.
-    received_message_.dim = 0;
-    received_message_.val.resize(received_message_.dim);
-    received_message_.coord.resize(received_message_.dim);
-    received_message_.timestamp = 0;
-  }
-
-  void Subscribe(const std::string& channel, DrakeLcmInterface* dut) {
-    dut->Subscribe(channel, [this](const void* data, int size) {
-        this->HandleMessage(data, size);
-      });
-  }
-
-  // This is the callback method.
-  void HandleMessage(const void* message_buffer, int message_size) {
-    std::lock_guard<std::mutex> lock(message_mutex_);
-    received_message_.decode(message_buffer, 0, message_size);
-  }
-
-  // Returns a copy of the most recently received message.
-  drake::lcmt_drake_signal GetReceivedMessage() {
-    drake::lcmt_drake_signal message_copy;
-    std::lock_guard<std::mutex> lock(message_mutex_);
-    message_copy = received_message_;
-    return message_copy;
-  }
-
- private:
-  std::mutex message_mutex_;
-  drake::lcmt_drake_signal received_message_;
-};
-
-// Tests DrakeLcm's ability to subscribe to an LCM message.
-TEST_F(DrakeLcmTest, SubscribeTest) {
-  const std::string channel_name = "drake_lcm_subscriber_channel_name";
-
-  // Instantiates the Device Under Test (DUT).
-  DrakeLcm dut;
-
-  MessageHandler handler;
-  handler.Subscribe(channel_name, &dut);
-
-  // Starts the LCM receive thread after the subscribers are created.
-  dut.StartReceiveThread();
-  ::lcm::LCM* lcm = dut.get_lcm_instance();
-
-  // Prevents this unit test from running indefinitely when the receiver fails
-  // to receive the LCM message published by the DUT.
-  int count = 0;
-
-  const int kMaxCount = 10;
-  const int kDelayMS = 500;
-
-  bool done = false;
-
-  // We must periodically call dut.Publish(...) since we do not know when the
-  // receiver will actually receive the message.
-  while (!done && count++ < kMaxCount) {
-    lcm->publish(channel_name, &message_);
-    // Gets the received message.
-    const drake::lcmt_drake_signal received_message =
-        handler.GetReceivedMessage();
-    done = CompareLcmtDrakeSignalMessages(received_message, message_);
-    if (!done) sleep_for(milliseconds(kDelayMS));
-  }
-
-  dut.StopReceiveThread();
-  EXPECT_TRUE(done);
+TEST_F(DrakeLcmTest, CustomUrlTest) {
+  dut_ = std::make_unique<DrakeLcm>(kUdpmUrl);
+  EXPECT_EQ(dut_->get_requested_lcm_url(), kUdpmUrl);
+  EXPECT_EQ(dut_->get_lcm_url(), kUdpmUrl);
 }
 
 TEST_F(DrakeLcmTest, EmptyChannelTest) {
-  DrakeLcm dut;
-  EXPECT_EQ(dut.get_requested_lcm_url(), "");
+  auto noop = [](const void*, int) {};
+  DRAKE_EXPECT_THROWS_MESSAGE(dut_->Subscribe("", noop), std::exception,
+      ".*channel.empty.*");
 
-  MessageHandler handler;
-  EXPECT_THROW(handler.Subscribe("", &dut), std::exception);
-
-  lcmt_drake_signal message{};
-  EXPECT_THROW(Publish(&dut, "", message), std::exception);
+  char data[1] = {};
+  DRAKE_EXPECT_THROWS_MESSAGE(dut_->Publish("", data, 1, {}), std::exception,
+      ".*channel.empty.*");
 }
 
+// Tests DrakeLcm's ability to publish an LCM message.
+// We subscribe using the native LCM APIs.
+TEST_F(DrakeLcmTest, PublishTest) {
+  ::lcm::LCM* const native_lcm = dut_->get_lcm_instance();
+  const std::string channel_name = "DrakeLcmTest.PublishTest";
 
-TEST_F(DrakeLcmTest, UrlTest) {
-  const std::string custom_url = "udpm://239.255.66.66:6666?ttl=0";
-  const DrakeLcm dut(custom_url);
+  lcmt_drake_signal received{};
+  ::lcm::LCM::HandlerFunction<lcmt_drake_signal> handler = [&received](
+      const ::lcm::ReceiveBuffer*, const std::string&,
+      const lcmt_drake_signal* new_value) {
+    DRAKE_DEMAND(new_value != nullptr);
+    received = *new_value;
+  };
+  native_lcm->subscribe(channel_name, std::move(handler));
 
-  EXPECT_EQ(dut.get_requested_lcm_url(), custom_url);
+  LoopUntilDone(&received, 20 /* retries */, [&]() {
+    Publish(dut_.get(), channel_name, message_);
+    native_lcm->handleTimeout(50 /* millis */);
+  });
+}
+
+// Tests DrakeLcm's ability to subscribe to an LCM message.
+// We publish using the native LCM APIs.
+TEST_F(DrakeLcmTest, SubscribeTest) {
+  ::lcm::LCM* const native_lcm = dut_->get_lcm_instance();
+  const std::string channel_name = "DrakeLcmTest.SubscribeTest";
+
+  lcmt_drake_signal received{};
+  auto subscription = dut_->Subscribe(channel_name, [&received](
+      const void* data, int size) {
+    received.decode(data, 0, size);
+  });
+  subscription.reset();  // Deleting the subscription should be a no-op.
+
+  int total = 0;
+  LoopUntilDone(&received, 20 /* retries */, [&]() {
+    native_lcm->publish(channel_name, &message_);
+    total += dut_->HandleSubscriptions(50 /* millis */);
+  });
+  EXPECT_EQ(total, 1);
+}
+
+// Repeats the above test, but with explicit opt-out of unsubscribe.
+TEST_F(DrakeLcmTest, SubscribeTest2) {
+  ::lcm::LCM* const native_lcm = dut_->get_lcm_instance();
+  const std::string channel_name = "DrakeLcmTest.SubscribeTest2";
+
+  lcmt_drake_signal received{};
+  auto subscription = dut_->Subscribe(channel_name, [&received](
+      const void* data, int size) {
+    received.decode(data, 0, size);
+  });
+  subscription->set_unsubscribe_on_delete(false);  // We shall be explicit.
+  subscription.reset();
+
+  int total = 0;
+  LoopUntilDone(&received, 20 /* retries */, [&]() {
+    native_lcm->publish(channel_name, &message_);
+    total += dut_->HandleSubscriptions(50 /* millis */);
+  });
+  EXPECT_EQ(total, 1);
+}
+
+// Tests DrakeLcm's round-trip ability using DrakeLcmInterface's sugar,
+// without any native LCM APIs.
+TEST_F(DrakeLcmTest, AcceptanceTest) {
+  const std::string channel_name = "DrakeLcmTest.AcceptanceTest";
+  Subscriber<lcmt_drake_signal> subscriber(dut_.get(), channel_name);
+  LoopUntilDone(&subscriber.message(), 20 /* retries */, [&]() {
+    Publish(dut_.get(), channel_name, message_);
+    dut_->HandleSubscriptions(50 /* millis */);
+  });
+}
+
+// Tests DrakeLcm's unsubscribe.
+TEST_F(DrakeLcmTest, UnsubscribeTest) {
+  const std::string channel_name = "DrakeLcmTest.UnsubscribeTest";
+
+  // First, confirm that the subscriber is active.
+  lcmt_drake_signal received{};
+  auto subscription = dut_->Subscribe(channel_name, [&](
+      const void* data, int size) {
+    received.decode(data, 0, size);
+  });
+  subscription->set_unsubscribe_on_delete(true);
+  LoopUntilDone(&received, 20 /* retries */, [&]() {
+    Publish(dut_.get(), channel_name, message_);
+    dut_->HandleSubscriptions(50 /* millis */);
+  });
+
+  // Then, unsubscribe and make sure no more messages are delivered.
+  subscription.reset();
+  received = {};
+  Publish(dut_.get(), channel_name, message_);
+  ASSERT_EQ(dut_->HandleSubscriptions(1000 /* millis */), 0);
+  ASSERT_EQ(received.timestamp, 0);
+}
+
+// Tests DrakeLcm's queue-size controls.  These do not work with the memq URL,
+// but only with real udpm URLs.
+TEST_F(DrakeLcmTest, QueueCapacityTest) {
+  dut_ = std::make_unique<DrakeLcm>(kUdpmUrl);
+  const std::string channel_name = "DrakeLcmTest.QueueCapacityTest";
+
+  int count = 0;
+  auto subscription = dut_->Subscribe(channel_name, [&count](
+      const void* data, int size) {
+    ++count;
+  });
+  EXPECT_EQ(dut_->HandleSubscriptions(10 /* millis */), 0);
+
+  // Send three messages, but only one comes out.
+  for (int i = 0; i < 3; ++i) {
+    Publish(dut_.get(), channel_name, message_);
+    // Let lcm_udpm's receive thread get scheduled.
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  EXPECT_EQ(dut_->HandleSubscriptions(1000 /* millis */), 1);
+  ASSERT_EQ(dut_->HandleSubscriptions(1000 /* millis */), 0);
+  EXPECT_EQ(count, 1);
+  count = 0;
+
+  // Send five messages, but only three come out.
+  subscription->set_queue_capacity(3);
+  for (int i = 0; i < 5; ++i) {
+    Publish(dut_.get(), channel_name, message_);
+    // Let lcm_udpm's receive thread get scheduled.
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  EXPECT_EQ(dut_->HandleSubscriptions(1000 /* millis */), 3);
+  ASSERT_EQ(dut_->HandleSubscriptions(1000 /* millis */), 0);
+  EXPECT_EQ(count, 3);
+  count = 0;
 }
 
 }  // namespace

--- a/lcm/test/drake_lcm_thread_test.cc
+++ b/lcm/test/drake_lcm_thread_test.cc
@@ -1,0 +1,156 @@
+#include <chrono>
+#include <mutex>
+#include <stdexcept>
+#include <thread>
+
+#include <gtest/gtest.h>
+#include "lcm/lcm-cpp.hpp"
+
+#include "drake/common/drake_copyable.h"
+#include "drake/lcm/drake_lcm.h"
+#include "drake/lcm/lcmt_drake_signal_utils.h"
+#include "drake/lcmt_drake_signal.hpp"
+
+// @file
+// This file tests threaded use of DrakeLcm.
+// See drake_lcm_test.cc for non-threaded use.
+
+namespace drake {
+namespace lcm {
+namespace {
+
+using drake::lcmt_drake_signal;
+
+// Stores a message, guarded by a mutex.
+class MessageMailbox {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MessageMailbox)
+
+  lcmt_drake_signal GetMessage() const {
+    lcmt_drake_signal result{};
+    std::lock_guard<std::mutex> lock(mutex_);
+    result = message_;
+    return result;
+  }
+
+ protected:
+  MessageMailbox() = default;
+
+  void SetMessage(const lcmt_drake_signal& new_value) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    message_ = new_value;
+  }
+
+ private:
+  mutable std::mutex mutex_;
+  lcmt_drake_signal message_{};
+};
+
+// Subscribes to LCM without any DrakeLcmInterface sugar or mocks.
+class NativeMailbox final : public MessageMailbox {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(NativeMailbox)
+
+  // A constructor that adds the LCM message subscription.
+  NativeMailbox(const std::string& channel_name, ::lcm::LCM* lcm) {
+    lcm->subscribe(channel_name, &NativeMailbox::Handle, this);
+  }
+
+ private:
+  void Handle(const ::lcm::ReceiveBuffer*, const std::string&,
+              const lcmt_drake_signal* message) {
+    DRAKE_DEMAND(message != nullptr);
+    SetMessage(*message);
+  }
+};
+
+// Subscribes to LCM using DrakeLcm::Subscribe.
+class DutMailbox final : public MessageMailbox {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DutMailbox)
+
+  DutMailbox(const std::string& channel, DrakeLcm* dut) {
+    auto subscription = dut->Subscribe(
+        channel, [this](const void* data, int size) {
+          this->Handle(data, size);
+        });
+    // By default, deleting the subscription should not unsubscribe.
+    subscription.reset();
+  }
+
+ private:
+  void Handle(const void* data, int size) {
+    lcmt_drake_signal decoded{};
+    decoded.decode(data, 0, size);
+    SetMessage(decoded);
+  }
+};
+
+// Test fixture.
+class DrakeLcmThreadTest : public ::testing::Test {
+ protected:
+  DrakeLcmThreadTest() {
+    message_.dim = 2;
+    message_.val.push_back(0.3739558136);
+    message_.val.push_back(0.2801694990);
+    message_.coord.push_back("artin's constant");
+    message_.coord.push_back("bernstein's constant");
+    message_.timestamp = 142857;
+  }
+
+  // Call publish() until the mailbox matches our expected message.
+  void LoopUntilDone(const MessageMailbox& mailbox,
+                     const std::function<void(void)>& publish) {
+    EXPECT_FALSE(dut_.IsReceiveThreadRunning());
+    dut_.StartReceiveThread();
+    EXPECT_TRUE(dut_.IsReceiveThreadRunning());
+
+    // Try until we're either done, or we timeout (5 seconds).
+    const std::chrono::milliseconds kDelay(50);
+    const int kMaxCount = 100;
+    bool message_was_received = false;
+    int count = 0;
+    while (!message_was_received && count++ < kMaxCount) {
+      publish();
+      std::this_thread::sleep_for(kDelay);
+      message_was_received =
+          CompareLcmtDrakeSignalMessages(mailbox.GetMessage(), message_);
+    }
+    EXPECT_TRUE(message_was_received);
+
+    dut_.StopReceiveThread();
+    EXPECT_FALSE(dut_.IsReceiveThreadRunning());
+  }
+
+  // The device under test.
+  DrakeLcm dut_;
+
+  // A prototypical message with non-default values.
+  lcmt_drake_signal message_{};
+};
+
+// Tests DrakeLcm's ability to publish an LCM message.
+// We subscribe using the native LCM APIs.
+TEST_F(DrakeLcmThreadTest, PublishTest) {
+  ::lcm::LCM* const native_lcm = dut_.get_lcm_instance();
+  const std::string channel_name = "DrakeLcmThreadTest.PublishTest";
+  NativeMailbox mailbox(channel_name, native_lcm);
+  LoopUntilDone(mailbox, [&]() {
+    Publish(&dut_, channel_name, message_);
+  });
+}
+
+// Tests DrakeLcm's ability to subscribe to an LCM message.
+// We publish using the native LCM APIs.
+TEST_F(DrakeLcmThreadTest, SubscribeTest) {
+  ::lcm::LCM* const native_lcm = dut_.get_lcm_instance();
+  const std::string channel_name = "DrakeLcmThreadTest.SubscribeTest";
+  DutMailbox mailbox(channel_name, &dut_);
+  LoopUntilDone(mailbox, [&]() {
+    native_lcm->publish(channel_name, &message_);
+  });
+}
+
+}  // namespace
+}  // namespace lcm
+}  // namespace drake

--- a/systems/lcm/lcm_subscriber_system.cc
+++ b/systems/lcm/lcm_subscriber_system.cc
@@ -43,9 +43,13 @@ LcmSubscriberSystem::LcmSubscriberSystem(
   DRAKE_DEMAND((translator_ != nullptr) != (serializer_ != nullptr));
   DRAKE_DEMAND(lcm);
 
-  lcm->Subscribe(channel_, [this](const void* buffer, int size) {
-      this->HandleMessage(buffer, size);
-    });
+  auto subscription = lcm->Subscribe(
+      channel_, [this](const void* buffer, int size) {
+        this->HandleMessage(buffer, size);
+      });
+  // To retain historical behavior we don't subscription->unsubscribe_on_delete,
+  // but in the future we may choose to do so.
+  subscription.reset();
 
   // Declare the single output port.
   if (translator_ != nullptr) {


### PR DESCRIPTION
This is the first part of #10981.

Add `DrakeLcmInterface::HandleSubscriptions` to pump the receive queue on demand (instead of relying on the thread to do it).

Add new `Subscriber` sugar class to `DrakeLcmInterface`, where the user doesn't have to write any lambdas at all.

Add unsubscribe option to `DrakeLcmInterface` and its sugars.
Add queue_capacity option to `DrakeLcmInterface` and its sugars.

Add a Doxygen warning to `DrakeLcm` thread-management methods as well as the `LcmReceiveThread` class.

Condense the implementation of `LcmReceiveThread` to not duplicate logic that's already available from the LCM upstream.

Add `DrakeLcm::get_lcm_url` helper that reports the URL, even if it was defaulted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11041)
<!-- Reviewable:end -->
