### PR TITLE
Add RenderLabel and RenderLabel manager

### DIFF
--- a/geometry/render/BUILD.bazel
+++ b/geometry/render/BUILD.bazel
@@ -1,0 +1,74 @@
+# -*- python -*-
+
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_googletest",
+    "drake_cc_library",
+    "drake_cc_package_library",
+)
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+package(default_visibility = ["//visibility:public"])
+
+drake_cc_package_library(
+    name = "render",
+    deps = [
+        ":render_label",
+        ":render_label_class",
+        ":render_label_manager",
+    ],
+)
+
+drake_cc_library(
+    name = "render_label",
+    srcs = ["render_label.cc"],
+    hdrs = ["render_label.h"],
+    deps = [
+        "//common:essential",
+        "//common:hash",
+        "//systems/sensors:image",
+    ],
+)
+
+drake_cc_library(
+    name = "render_label_class",
+    srcs = ["render_label_class.cc"],
+    hdrs = ["render_label_class.h"],
+    deps = [
+        ":render_label",
+        "//common:essential",
+        "//geometry:geometry_ids",
+    ],
+)
+
+drake_cc_library(
+    name = "render_label_manager",
+    srcs = ["render_label_manager.cc"],
+    hdrs = ["render_label_manager.h"],
+    deps = [
+        ":render_label",
+        ":render_label_class",
+        "@fmt",
+    ],
+)
+
+# === test/ ===
+
+drake_cc_googletest(
+    name = "render_label_test",
+    deps = [
+        ":render_label",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
+    name = "render_label_manager_test",
+    deps = [
+        ":render_label_manager",
+        "//common:value",
+        "//common/test_utilities",
+    ],
+)
+
+add_lint_tests()

--- a/geometry/render/render_label.cc
+++ b/geometry/render/render_label.cc
@@ -1,0 +1,26 @@
+#include "drake/geometry/render/render_label.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+
+// Note: relies on the default constructor to define the unspecified value.
+const RenderLabel RenderLabel::kUnspecified;
+const RenderLabel RenderLabel::kEmpty(kUnspecified.value_ - 1, false);
+const RenderLabel RenderLabel::kDoNotRender(kUnspecified.value_ - 2, false);
+const RenderLabel RenderLabel::kDontCare(kUnspecified.value_ - 3, false);
+const RenderLabel::ValueType RenderLabel::kMaxUnreserved(
+    kUnspecified.value_ - 4);
+
+std::ostream& operator<<(std::ostream& out, const RenderLabel& label) {
+  out << label.value_;
+  return out;
+}
+
+std::string to_string(const RenderLabel& label) {
+  return std::to_string(label.value_);
+}
+
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/render_label.h
+++ b/geometry/render/render_label.h
@@ -1,0 +1,185 @@
+#pragma once
+
+#include <cstdint>
+#include <iostream>
+#include <limits>
+#include <string>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/hash.h"
+#include "drake/systems/sensors/pixel_types.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+
+/**
+ Class representing object "labels" for rendering.
+
+ In a "label image" (see RenderEngine::RenderLabelImage() for details) each
+ pixel value indicates the classification of the object that rendered into that
+ pixel. The %RenderLabel class provides that value and one label is associated
+ with each rendered geometry.
+
+ The labels could be unique for each geometry, or multiple geometries could all
+ share the same label (becoming indistinguishable in the label image).
+ Ultimately, it is the user's responsibility to assign labels in a manner that
+ is meaningful for their application.
+
+ @anchor reserved_render_label
+ <h3>Reserved labels</h3>
+
+ There are several %RenderLabels that are reserved. They have specific meaning
+ in the context of the rendering ecosystem and are globally available to all
+ applications. They are:
+
+ - `empty`: a pixel with the `empty` %RenderLabel value indicates that _no_
+   geometry rendered to that pixel. Assigning this label to geometry is _highly_
+   inadvisable and will typically lead to undesirable results.
+ - `do_not_render`: any geometry assigned the `do_not_render` tag will _not_ be
+   rendered into a label image. This is a clear declaration that a geometry
+   should be omitted. Useful for marking, e.g., glass windows so that the
+   visible geometry behind the glass is what is included in the label image.
+ - `dont_care`: the `dont_care` label is intended as a convenient dumping
+   ground. This would be for geometry that _should_ render into the label image,
+   but whose class is irrelevant (e.g., the walls of a room a robot is working
+   in or the background terrain in driving simulation).
+ - `unspecified`: in the absence of an explicitly assigned render label, a
+   geometry receives the `unspecified` label. RenderEngine implementations will
+   throw an exception if they are given a geometry with an `unspecified`
+   %RenderLabel, because it is considered to be a likely a defect for an
+   application not to explicitly assign a label to every rendered geometry.
+
+ <h2>Usage</h2>
+
+ For a label image to be _meaningful_, every pixel value should admit an
+ unambiguous interpretation. To do that, %RenderLabels need to be coordinated
+ to avoid accidental overloading. An application can achieve this in one of two
+ ways: the application can rely on SceneGraph to allocate and coordinate
+ %RenderLabel values across multiple geometry sources or the application can
+ manage its own %RenderLabel values. Mixing the two strategies is highly
+ inadvisable; the responsibility for guaranteeing unique %RenderLabel values
+ does not survive sharing well.
+
+ <h3>Allocation of %RenderLabel values from SceneGraph</h3>
+
+ An application defines a semantic class with a name (e.g., "car", "robot",
+ "table", etc.) and associated source id -- if two sources were both to define
+ their own semantic class named "robot", they would be considered distinct
+ classes by virtue of their different source ids.
+
+ The application associates a %RenderLabel with its semantic class by
+ invoking SceneGraph::GetRenderLabel(). SceneGraph maintains a mapping between
+ %RenderLabel and all registered semantic classes. They can be queried via
+ SceneGraphInspector::GetSemanticClassNameFromLabel().
+
+ <h3>Manual %RenderLabel allocation</h3>
+
+ An application can simply instantiate %RenderLabel with an arbitrary value.
+ This allows the application to define a particular mapping from render label
+ class to a preferred %RenderLabel value. The application bears _full_
+ responsibility in making sure that a single value is not inadvertently
+ associated with multiple render classes. Finally, a %RenderLabel cannot be
+ explicitly constructed with a reserved value -- those can only be accessed
+ through the static methods provided.
+
+ @note The %RenderLabel class is based on a 16-bit integer. This makes the label
+ image more compact but means there are only, approximately, 32,000 unique
+ %RenderLabel values.  */
+class RenderLabel {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(RenderLabel)
+
+  // TODO(SeanCurtis-TRI): Change this to an unsigned int by defining the
+  // kLabel16U pixel type (and accompanying ImageTraits). Change the @note in
+  // the class documentation to match.
+  using ValueType = systems::sensors::ImageTraits<
+      systems::sensors::PixelType::kLabel16I>::ChannelType;
+
+  /** Constructs a label with the reserved `unspecified` value.  */
+  RenderLabel() = default;
+
+  /** Constructs a label with the given `value`.
+   @throws std::logic_error if a) is negative, or b) the `value` is one of the
+                               reserved values.  */
+  explicit RenderLabel(int value) : RenderLabel(value, true) {}
+
+  /** Compares this label with the `other` label. Reports true if they have the
+   same value.  */
+  bool operator==(const RenderLabel& other) const {
+    return value_ == other.value_;
+  }
+
+  /** Compares this label with the `other` label. Reports true if they have
+   different values.  */
+  bool operator!=(const RenderLabel& other) const {
+    return value_ != other.value_;
+  }
+
+  /** Allows the labels to be compared to imply a total ordering -- facilitates
+   use in data structures which require ordering (e.g., std::set). The ordering
+   has no particular meaning for applications.  */
+  bool operator<(const RenderLabel& other) const {
+    return value_ < other.value_;
+  }
+
+  /** @name  The reserved render labels
+
+   See class documentation on
+   @ref reserved_render_label "reserved labels" for details.  */
+  //@{
+
+  static const RenderLabel kEmpty;
+  static const RenderLabel kDoNotRender;
+  static const RenderLabel kDontCare;
+  static const RenderLabel kUnspecified;
+
+  /** The largest value that a %RenderLabel can be instantiated on. */
+  static const ValueType kMaxUnreserved;
+
+  //@}
+
+  /** Reports if the label is a reserved label.  */
+  bool is_reserved() const { return value_ > kMaxUnreserved; }
+
+  /** Implicit conversion to its underlying integer representation.  */
+  operator ValueType() const { return value_; }
+
+  /** Enables use of labels with the streaming operator.  */
+  friend std::ostream& operator<<(std::ostream& out, const RenderLabel& label);
+
+  /** Converts the RenderLabel value to a string representation.  */
+  friend std::string to_string(const RenderLabel& label);
+
+ private:
+  // Private constructor precludes general construction except by the approved
+  // factories (see above).
+  RenderLabel(int value, bool needs_testing)
+      : value_(static_cast<ValueType>(value)) {
+    if (value < 0 || (needs_testing && value > kMaxUnreserved)) {
+      throw std::logic_error(
+          "Invalid construction of RenderLabel with invalid value: " +
+          std::to_string(value));
+    }
+  }
+
+  static constexpr ValueType kMaxValue = std::numeric_limits<ValueType>::max();
+
+  // The underlying value; this implicitly defines the unspecified value to be
+  // the maximum value.
+  ValueType value_{kMaxValue};
+};
+
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake
+
+namespace std {
+
+/** Enables use of the label to serve as a key in STL containers.
+ @relates RenderLabel  */
+template <>
+struct hash<drake::geometry::render::RenderLabel>
+ : public hash<drake::geometry::render::RenderLabel::ValueType> {};
+
+}  // namespace std

--- a/geometry/render/render_label_class.cc
+++ b/geometry/render/render_label_class.cc
@@ -1,0 +1,1 @@
+#include "drake/geometry/render/render_label_class.h"

--- a/geometry/render/render_label_class.h
+++ b/geometry/render/render_label_class.h
@@ -1,0 +1,59 @@
+#pragma once
+
+// Exclude internal class from doxygen's view.
+#if !defined(DRAKE_DOXYGEN_CXX)
+
+#include <iostream>
+#include <string>
+#include <utility>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/render/render_label.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace internal {
+
+/** The definition of a semantic render class. As documented in RenderLabel,
+ it is the association of a semantic class (a (source id, name) pair) with the
+ allocated RenderLabel value.  */
+struct RenderLabelClass {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(RenderLabelClass)
+
+  RenderLabelClass(std::string name_in, SourceId id_in, RenderLabel label_in) :
+      name(std::move(name_in)), source_id(id_in), label(label_in) {}
+
+  /** The source-local unique name of the class. The name may be shared by
+   multiple sources.  */
+  std::string name;
+
+  // TODO(SeanCurtis-TRI): This is a potential leak of the SourceId. This class
+  // is internal and isn't part of the public API, so it's not a leak today. If
+  // it ever becomes part of the public API, it *cannot* contain a SourceId to
+  // avoid becoming a leak.
+  /** The source id that requested the render label.  */
+  SourceId source_id;
+
+  /** The label associated with the class.  */
+  RenderLabel label;
+
+  bool operator==(const RenderLabelClass& c2) const {
+    return label == c2.label && source_id == c2.source_id && name == c2.name;
+  }
+
+  friend std::ostream& operator<<(std::ostream& out,
+                                  const RenderLabelClass& c) {
+    out << "(" << c.name << ", Source(" << c.source_id << ")) --> " << c.label;
+    return out;
+  }
+};
+
+}  // namespace internal
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake
+
+#endif  // DRAKE_DOXYGEN_CXX

--- a/geometry/render/render_label_manager.cc
+++ b/geometry/render/render_label_manager.cc
@@ -1,0 +1,63 @@
+#include "drake/geometry/render/render_label_manager.h"
+
+#include <fmt/format.h>
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace internal {
+
+using std::move;
+using std::pair;
+using std::string;
+using std::unordered_multimap;
+using std::vector;
+
+RenderLabelManager::RenderLabelManager(SourceId id)
+    : maximum_value_(RenderLabel::kMaxUnreserved) {
+  // The reserved labels all belong to the provided source id.
+  name_label_map_.insert(
+      {"empty", RenderLabelClass("empty", id, RenderLabel::kEmpty)});
+  name_label_map_.insert(
+      {"do_not_render",
+       RenderLabelClass("do_not_render", id, RenderLabel::kDoNotRender)});
+  name_label_map_.insert(
+      {"dont_care", RenderLabelClass("dont_care", id, RenderLabel::kDontCare)});
+  name_label_map_.insert(
+      {"unspecified",
+       RenderLabelClass("unspecified", id, RenderLabel::kUnspecified)});
+}
+
+RenderLabel RenderLabelManager::GetRenderLabel(SourceId source_id,
+                                               string class_name) {
+  // Check to see if this name has been used by the source id already.
+  auto range = name_label_map_.equal_range(class_name);
+  for (auto it = range.first; it != range.second; ++it) {
+    if (it->second.source_id == source_id) return it->second.label;
+  }
+
+  // It hasn't been used; create a label and record usage.
+  if (next_value_ <= maximum_value_) {
+    RenderLabel label(next_value_++);
+    name_label_map_.insert(
+        {class_name, RenderLabelClass(class_name, source_id, label)});
+    return label;
+  } else {
+    throw std::logic_error(fmt::format(
+        "All {} render labels have been allocated", maximum_value_));
+  }
+}
+
+vector<RenderLabelClass> RenderLabelManager::GetRenderLabelClasses() const {
+  vector<RenderLabelClass> classes;
+  for (auto it = name_label_map_.begin(); it != name_label_map_.end(); ++it) {
+    const RenderLabelClass& label_class = it->second;
+    classes.push_back(label_class);
+  }
+  return classes;
+}
+
+}  // namespace internal
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/render_label_manager.h
+++ b/geometry/render/render_label_manager.h
@@ -1,0 +1,71 @@
+#pragma once
+
+// Exclude internal class from doxygen's view.
+#if !defined(DRAKE_DOXYGEN_CXX)
+
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/render/render_label.h"
+#include "drake/geometry/render/render_label_class.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace internal {
+
+/** The class responsible for allocating render labels and tracking those that
+ have been allocated by SceneGraph.
+
+ A new RenderLabel is allocated for every unique semantic class (name and source
+ id pair). If GetRenderLabel() is called multiple times with the same name and
+ source id, the same RenderLabel value will be returned each time.
+
+ The %RenderLabelManager is copyable to facilitate SceneGraph cloning. Each copy
+ contains the same record of allocated labels up to the point of copying, but
+ subsequent allocations will be independent.
+
+ @see RenderLabel  */
+class RenderLabelManager {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(RenderLabelManager)
+
+  /** Constructs the manager attributing ownership of the reserved semantic
+   classes to the source with the given `id` (expected to be the id of the
+   owning SceneGraph).
+   */
+  explicit RenderLabelManager(SourceId id);
+
+  /** Implementation of SceneGraph::GetRenderLabel().  */
+  RenderLabel GetRenderLabel(SourceId source_id, std::string class_name);
+
+  /** Provides a report of all the allocated RenderLabel values and their
+   semantic classes (in no particular order).  */
+  std::vector<RenderLabelClass> GetRenderLabelClasses() const;
+
+ private:
+  friend class RenderLabelManagerTester;
+
+  // A map from the name of the label to each of the semantic classes associated
+  // with that name (they *must* all have different source ids).
+  std::unordered_multimap<std::string, RenderLabelClass> name_label_map_;
+
+  using ValueType = RenderLabel::ValueType;
+
+  // The next value to provide when allocating a RenderLabel.
+  ValueType next_value_{0};
+
+  // The maximum allowable render label value. This is mostly a convenience
+  // lever to test logic.
+  ValueType maximum_value_{RenderLabel::kMaxUnreserved};
+};
+
+}  // namespace internal
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake
+
+#endif  // DRAKE_DOXYGEN_CXX

--- a/geometry/render/test/render_label_manager_test.cc
+++ b/geometry/render/test/render_label_manager_test.cc
@@ -1,0 +1,225 @@
+#include "drake/geometry/render/render_label_manager.h"
+
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/common/value.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace internal {
+
+// Simple class with friend access to RenderLabelManager for testing the
+// internal state in tests.
+class RenderLabelManagerTester {
+ public:
+  RenderLabelManagerTester() = default;
+
+  // Allocates a label manager with the source id but limits the allocatable
+  // number of labels to the given `max_value`.
+  RenderLabelManager make_manager(SourceId source_id,
+                                  RenderLabel::ValueType max_value) {
+    RenderLabelManager manager(source_id);
+    manager.maximum_value_ = max_value;
+    return manager;
+  }
+
+  // Reports the manager's maximum valid value.
+  RenderLabel::ValueType maximum_value(
+      const RenderLabelManager& manager) const {
+    return manager.maximum_value_;
+  }
+
+  // Consistency check; confirms that every render label associated with a name
+  // *stores* that name.
+  ::testing::AssertionResult HasConsistentNames(
+      const RenderLabelManager& manager) const {
+    for (auto it = manager.name_label_map_.begin();
+         it != manager.name_label_map_.end(); ++it) {
+      const std::string& label_name = it->first;
+      const RenderLabelClass& label_class = it->second;
+      if (label_name != label_class.name) {
+        return ::testing::AssertionFailure()
+            << "Render label class has name '" << label_class.name
+            << "' stored in the collection named '" << label_name << "'";
+      }
+    }
+    return ::testing::AssertionSuccess();
+  }
+
+  // Confirms that the given render label class is in the manager.
+  ::testing::AssertionResult HasRenderLabelClass(
+      const RenderLabelManager& manager,
+      const RenderLabelClass label_class) const {
+    if (manager.name_label_map_.count(label_class.name) == 0) {
+      return ::testing::AssertionFailure()
+             << "No labels allocated with the name '" << label_class.name
+             << "'";
+    }
+    auto range = manager.name_label_map_.equal_range(label_class.name);
+    for (auto it = range.first; it != range.second; ++it) {
+      const RenderLabelClass& test_class = it->second;
+      if (test_class.source_id == label_class.source_id) {
+        if (test_class.label == label_class.label) {
+          // We don't need to check names; we'll already have tested for name
+          // consistency.
+          return ::testing::AssertionSuccess();
+        } else {
+          return ::testing::AssertionFailure()
+                 << "Found render label class with the name '"
+                 << label_class.name << "' and matching source id "
+                 << label_class.source_id
+                 << ", but the label value doesn't match. Expected "
+                 << label_class.label << ", found " << test_class.label;
+        }
+      }
+    }
+    return ::testing::AssertionFailure()
+           << "Unable to find a render label class with name '"
+           << label_class.name << "' and source id " << label_class.source_id;
+  }
+
+  // Reports the number of labels registered in `manager`.
+  int LabelCount(const RenderLabelManager& manager) const {
+    return static_cast<int>(manager.name_label_map_.size());
+  }
+
+  // Confirms that the reserved labels are in the manager (and recorded
+  // correctly). In the case of multiple points of failure, only the first
+  // detected is reported.
+  ::testing::AssertionResult HasReservedLabels(
+      const RenderLabelManager& manager, SourceId source_id) const {
+    ::testing::AssertionResult result = HasRenderLabelClass(
+        manager, RenderLabelClass("empty", source_id, RenderLabel::kEmpty));
+    if (result) {
+      result = HasRenderLabelClass(
+          manager, RenderLabelClass("do_not_render", source_id,
+                                    RenderLabel::kDoNotRender));
+      if (result) {
+        result = HasRenderLabelClass(
+            manager, RenderLabelClass("unspecified", source_id,
+                                      RenderLabel::kUnspecified));
+        if (result) {
+          result = HasRenderLabelClass(
+              manager,
+              RenderLabelClass("dont_care", source_id, RenderLabel::kDontCare));
+        }
+      }
+    }
+    return result;
+  }
+};
+
+namespace {
+
+using ValueType = RenderLabel::ValueType;
+
+// Simple test confirming that the construction is consistent and coherent.
+GTEST_TEST(RenderLabelManagerTest, Constructor) {
+  RenderLabelManagerTester tester;
+  SourceId source_id = SourceId::get_new_id();
+  RenderLabelManager manager(source_id);
+  EXPECT_EQ(4, tester.LabelCount(manager));
+  EXPECT_TRUE(tester.HasConsistentNames(manager));
+  EXPECT_TRUE(tester.HasReservedLabels(manager, source_id));
+  EXPECT_EQ(RenderLabel::kMaxUnreserved, tester.maximum_value(manager));
+
+  // Copy constructor.
+  RenderLabelManager copy(manager);
+  EXPECT_EQ(4, tester.LabelCount(copy));
+  EXPECT_TRUE(tester.HasConsistentNames(copy));
+  EXPECT_TRUE(tester.HasReservedLabels(copy, source_id));
+  EXPECT_EQ(RenderLabel::kMaxUnreserved, tester.maximum_value(copy));
+}
+
+GTEST_TEST(RenderLabelManagerTest, GetRenderLabel) {
+  RenderLabelManagerTester tester;
+  SourceId source_id = SourceId::get_new_id();
+  RenderLabelManager manager(source_id);
+
+  // Case: Request with new source (which means implicitly new name) -->
+  // produces new label.
+  SourceId new_source = SourceId::get_new_id();
+  RenderLabel label1;
+  EXPECT_NO_THROW({ label1 = manager.GetRenderLabel(new_source, "case1"); });
+  EXPECT_TRUE(tester.HasConsistentNames(manager));
+
+  // Case: Request with previously used source and new name --> produces new
+  // label.
+  RenderLabel label2;
+  EXPECT_NO_THROW({ label2 = manager.GetRenderLabel(new_source, "case2"); });
+  EXPECT_TRUE(tester.HasConsistentNames(manager));
+  EXPECT_NE(label1, label2);
+
+  // Case: Request with previously used source and name --> produces previous
+  // label.
+  RenderLabel label3;
+  EXPECT_NO_THROW({ label3 = manager.GetRenderLabel(new_source, "case2"); });
+  EXPECT_TRUE(tester.HasConsistentNames(manager));
+  EXPECT_EQ(label2, label3);
+
+  // Case: Exhaust labels.
+  // Confirm ability to set maximum value works to facilitate label exhaustion.
+  const ValueType max_value = 5;
+  RenderLabelManager small_manager = tester.make_manager(source_id, max_value);
+  EXPECT_EQ(max_value, tester.maximum_value(small_manager));
+
+  for (int i = 0; i <= max_value; ++i) {
+    small_manager.GetRenderLabel(new_source, std::to_string(i));
+    EXPECT_TRUE(tester.HasConsistentNames(small_manager));
+  }
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      small_manager.GetRenderLabel(new_source, "too many"), std::logic_error,
+      "All \\d+ render labels have been allocated");
+}
+
+GTEST_TEST(RenderLabelManagerTest, GetRenderLabelClasses) {
+  SourceId manager_id = SourceId::get_new_id();
+  SourceId source1 = SourceId::get_new_id();
+  SourceId source2 = SourceId::get_new_id();
+
+  RenderLabelManager manager(manager_id);
+  std::vector<RenderLabelClass> expected_classes;
+  auto add_label = [&expected_classes, &manager](const std::string& name,
+                                                 SourceId source_id) {
+    expected_classes.emplace_back(name, source_id,
+                                  manager.GetRenderLabel(source_id, name));
+  };
+  // Reserved labels.
+  expected_classes.emplace_back("empty", manager_id, RenderLabel::kEmpty);
+  expected_classes.emplace_back("unspecified", manager_id,
+                                RenderLabel::kUnspecified);
+  expected_classes.emplace_back("dont_care", manager_id,
+                                RenderLabel::kDontCare);
+  expected_classes.emplace_back("do_not_render", manager_id,
+                                RenderLabel::kDoNotRender);
+  add_label("common", source1);
+  add_label("common", source2);
+  add_label("unique1", source1);
+  add_label("unique2", source2);
+
+  std::vector<RenderLabelClass> classes = manager.GetRenderLabelClasses();
+  EXPECT_EQ(classes.size(), expected_classes.size());
+
+  for (const auto& label_class : classes) {
+    bool found = false;
+    for (const auto& expected_class : expected_classes) {
+      if (label_class == expected_class) {
+        found = true;
+        break;
+      }
+    }
+    EXPECT_TRUE(found) << "Reported label class not found in expected classes: "
+                       << label_class;
+  }
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/test/render_label_test.cc
+++ b/geometry/render/test/render_label_test.cc
@@ -1,0 +1,148 @@
+#include "drake/geometry/render/render_label.h"
+
+#include <set>
+#include <unordered_set>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+
+namespace  {
+
+class RenderLabelTests : public ::testing::Test {
+ protected:
+  // Each test has the same labels drawn from an independent pool.
+  void SetUp() override {
+    for (RenderLabel::ValueType i = 0; i < kLabelCount; ++i) {
+      labels_.emplace_back(i);
+      // This does two things:
+      //  1. Confirms the labels are what the rest of the tests think they are,
+      //  2. Tests comparisons between labels and ints.
+      ASSERT_EQ(labels_[i], static_cast<int>(i));
+    }
+  }
+  static constexpr int kLabelCount = 4;
+  std::vector<RenderLabel> labels_;
+};
+
+// Confirms that default labels are unclassified labels.
+TEST_F(RenderLabelTests, Construction) {
+  // Defaults to unclassified.
+  EXPECT_EQ(RenderLabel(), RenderLabel::kUnspecified);
+
+  // Bad values throw an exception.
+  using ValueType = RenderLabel::ValueType;
+
+  std::vector<ValueType> bad_values{
+      -1, RenderLabel::kUnspecified, RenderLabel::kDoNotRender,
+      RenderLabel::kDontCare, RenderLabel::kEmpty};
+  for (ValueType value : bad_values) {
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        RenderLabel{value}, std::logic_error,
+        "Invalid construction of RenderLabel with invalid value: .+");
+  }
+
+  // Range of good values.
+  EXPECT_NO_THROW(RenderLabel{0});
+  EXPECT_NO_THROW(RenderLabel{RenderLabel::kMaxUnreserved});
+}
+
+// Confirms that the reserved labels report correctly, and that generated labels
+// do not report as reserved.
+TEST_F(RenderLabelTests, TestForReservedLabels) {
+  for (RenderLabel label : labels_) {
+    EXPECT_FALSE(label.is_reserved());
+  }
+  EXPECT_TRUE(RenderLabel::kEmpty.is_reserved());
+  EXPECT_EQ(RenderLabel::kEmpty, RenderLabel::kEmpty);
+  EXPECT_TRUE(RenderLabel::kDontCare.is_reserved());
+  EXPECT_EQ(RenderLabel::kDontCare, RenderLabel::kDontCare);
+  EXPECT_TRUE(RenderLabel::kDoNotRender.is_reserved());
+  EXPECT_EQ(RenderLabel::kDoNotRender, RenderLabel::kDoNotRender);
+  EXPECT_TRUE(RenderLabel::kUnspecified.is_reserved());
+  EXPECT_EQ(RenderLabel::kUnspecified, RenderLabel::kUnspecified);
+
+  // Note: This assumes that the A != B is commutative.
+
+  EXPECT_NE(RenderLabel::kEmpty, RenderLabel::kDontCare);
+  EXPECT_NE(RenderLabel::kEmpty, RenderLabel::kDoNotRender);
+  EXPECT_NE(RenderLabel::kEmpty, RenderLabel::kUnspecified);
+  EXPECT_NE(RenderLabel::kDontCare, RenderLabel::kDoNotRender);
+  EXPECT_NE(RenderLabel::kDontCare, RenderLabel::kUnspecified);
+  EXPECT_NE(RenderLabel::kDoNotRender, RenderLabel::kUnspecified);
+}
+
+// Confirms that assignment behaves correctly. This also implicitly tests
+// equality and inequality.
+TEST_F(RenderLabelTests, AssignmentAndComparison) {
+  EXPECT_TRUE(labels_[0] != labels_[1]);
+  RenderLabel temp = labels_[1];
+  EXPECT_EQ(temp, labels_[1]);
+  temp = labels_[2];
+  EXPECT_EQ(temp, labels_[2]);
+  // This exploits the knowledge that labels were allocated in a monotonically
+  // increasing order, while the reserved labels occupy the highest label
+  // values.
+  EXPECT_TRUE(labels_[0] < labels_[1]);
+  EXPECT_TRUE(labels_[0] < RenderLabel::kEmpty);
+  EXPECT_TRUE(labels_[0] < RenderLabel::kDoNotRender);
+  EXPECT_TRUE(labels_[0] < RenderLabel::kUnspecified);
+}
+
+// Confirms that RenderLabels can be used as hashable entries in STL containers
+// (e.g., unordered_set and unordered_map).
+TEST_F(RenderLabelTests, ServeAsMapKey) {
+  std::unordered_set<RenderLabel> label_set;
+
+  // This is a *different* label with the *same* value as labels_[0]. It should
+  // *not* introduce a new value to the set.
+  RenderLabel same_as_label0 = labels_[0];
+
+  EXPECT_EQ(label_set.size(), 0);
+  label_set.insert(labels_[0]);
+  EXPECT_NE(label_set.find(labels_[0]), label_set.end());
+  EXPECT_NE(label_set.find(same_as_label0), label_set.end());
+
+  EXPECT_EQ(label_set.size(), 1);
+  label_set.insert(labels_[1]);
+  EXPECT_EQ(label_set.size(), 2);
+
+  label_set.insert(same_as_label0);
+  EXPECT_EQ(label_set.size(), 2);
+
+  EXPECT_EQ(label_set.find(labels_[2]), label_set.end());
+}
+
+// Confirms that RenderLabels can be used as orderable entries in STL containers
+// (e.g., set and map).
+TEST_F(RenderLabelTests, ServeAsSetMember) {
+  std::set<RenderLabel> label_set;
+
+  // This is a *different* label with the *same* value as labels_[0]. It should
+  // *not* introduce a new value to the set.
+  RenderLabel same_as_label0 = labels_[0];
+
+  EXPECT_EQ(label_set.size(), 0);
+  label_set.insert(labels_[0]);
+  EXPECT_NE(label_set.find(labels_[0]), label_set.end());
+  EXPECT_NE(label_set.find(same_as_label0), label_set.end());
+
+  EXPECT_EQ(label_set.size(), 1);
+  label_set.insert(labels_[1]);
+  EXPECT_EQ(label_set.size(), 2);
+
+  label_set.insert(same_as_label0);
+  EXPECT_EQ(label_set.size(), 2);
+
+  EXPECT_EQ(label_set.find(labels_[2]), label_set.end());
+}
+
+}  // namespace
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
This simply defines the RenderLabel type and the class responsible for allocating them. Eventually, the SceneGraph will own an instance of RenderLabelManager and dole out and report on allocated RenderLabel values.

This is *not* a global identifier (akin to `GeometryId` or `FrameId`). This introduces the internal classes:

  - `RenderLabelManager` (internal) -- allocates render labels in a monotonically increasing manner. Associating each render label with the geometry source that requested it and the name ascribed to the label class.
  - `RenderLabelClass` (internal) -- book keeping struct for the manager. 
  - `RenderLabel` -- public API. The actual value that will be found in a label image. Allocated from a manager (ultimately, via a SceneGraph instance).

Due to PR size, the SceneGraph component will come later. This merely documents the render labels and what not, so that the RenderEngine interface can make use of it.

This is the result of long discussions in #10351.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11042)
<!-- Reviewable:end -->
