### PR TITLE
py common: Add bindings for setting log level

### DIFF
--- a/bindings/pydrake/common/module_py.cc
+++ b/bindings/pydrake/common/module_py.cc
@@ -30,6 +30,11 @@ PYBIND11_MODULE(_module_py, m) {
   constexpr auto& doc = pydrake_doc.drake;
   m.attr("_HAVE_SPDLOG") = logging::kHaveSpdlog;
 
+  // TODO(eric.cousineau): Provide a Pythonic spdlog sink that connects to
+  // Python's `logging` module; possibly use `pyspdlog`.
+  m.def("set_log_level", &logging::set_log_level, py::arg("level"),
+      doc.logging.set_log_level.doc);
+
   py::enum_<drake::RandomDistribution>(
       m, "RandomDistribution", doc.RandomDistribution.doc)
       .value("kUniform", drake::RandomDistribution::kUniform,

--- a/bindings/pydrake/common/test/module_test.py
+++ b/bindings/pydrake/common/test/module_test.py
@@ -4,6 +4,7 @@ import os
 import unittest
 
 import six
+from six import text_type as unicode
 
 import pydrake.common
 
@@ -45,8 +46,10 @@ class TestCommon(unittest.TestCase):
         pydrake.common.RandomDistribution.kGaussian
         pydrake.common.RandomDistribution.kExponential
 
-    def test_logging_enabled(self):
+    def test_logging(self):
         self.assertTrue(pydrake.common._module_py._HAVE_SPDLOG)
+        self.assertIsInstance(
+            pydrake.common.set_log_level(level="unchanged"), unicode)
 
     def test_random_generator(self):
         g1 = pydrake.common.RandomGenerator()

--- a/common/test/text_logging_test.cc
+++ b/common/test/text_logging_test.cc
@@ -135,6 +135,26 @@ GTEST_TEST(TextLoggingTest, DrakeMacrosDontEvaluateArguments) {
   debugarg = 0;
 }
 
+GTEST_TEST(TextLoggingTest, SetLogLevel) {
+  using drake::logging::set_log_level;
+
+  #if TEXT_LOGGING_TEST_SPDLOG
+    EXPECT_THROW(set_log_level("bad"), std::runtime_error);
+    const std::vector<std::string> levels = {
+        "trace", "debug", "info", "warn", "err", "critical", "off"};
+    const std::string first_level = set_log_level("unchanged");
+    std::string prev_level = "off";
+    set_log_level(prev_level);
+    for (const std::string& level : levels) {
+      EXPECT_EQ(set_log_level(level), prev_level);
+      prev_level = level;
+    }
+    set_log_level(first_level);
+  #else
+    ASSERT_EQ(drake::logging::set_log_level("anything really"), "");
+  #endif
+}
+
 // We must run this test last because it changes the default configuration.
 GTEST_TEST(TextLoggingTest, ZZZ_ChangeDefaultSink) {
   // The getter should never return nullptr, even with spdlog disabled.

--- a/common/text_logging.cc
+++ b/common/text_logging.cc
@@ -55,6 +55,46 @@ logging::sink* logging::get_dist_sink() {
   return result;
 }
 
+std::string logging::set_log_level(const std::string& level) {
+  spdlog::level::level_enum prev_value = drake::log()->level();
+  spdlog::level::level_enum value{};
+  if (level == "trace") {
+    value = spdlog::level::trace;
+  } else if (level == "debug") {
+    value = spdlog::level::debug;
+  } else if (level == "info") {
+    value = spdlog::level::info;
+  } else if (level == "warn") {
+    value = spdlog::level::warn;
+  } else if (level == "err") {
+    value = spdlog::level::err;
+  } else if (level == "critical") {
+    value = spdlog::level::critical;
+  } else if (level == "off") {
+    value = spdlog::level::off;
+  } else if (level == "unchanged") {
+    value = prev_value;
+  } else {
+    throw std::runtime_error(fmt::format("Unknown spdlog level: {}", level));
+  }
+  drake::log()->set_level(value);
+  switch (prev_value) {
+    case spdlog::level::trace: return "trace";
+    case spdlog::level::debug: return "debug";
+    case spdlog::level::info: return "info";
+    case spdlog::level::warn: return "warn";
+    case spdlog::level::err: return "err";
+    case spdlog::level::critical: return "critical";
+    case spdlog::level::off: return "off";
+    default: {
+      // N.B. `spdlog::level::level_enum` is not a `enum class`, so the
+      // compiler does not know that it has a closed set of values. For
+      // simplicity in linking, we do not use `DRAKE_UNREACHABLE`.
+      throw std::runtime_error("Should not reach here!");
+    }
+  }
+}
+
 #else  // HAVE_SPDLOG
 
 logging::logger::logger() {}
@@ -71,6 +111,10 @@ logging::sink* logging::get_dist_sink() {
   // An empty sink instance.
   static logging::sink g_sink;
   return &g_sink;
+}
+
+std::string logging::set_log_level(const std::string&) {
+  return "";
 }
 
 #endif  // HAVE_SPDLOG

--- a/common/text_logging.h
+++ b/common/text_logging.h
@@ -28,6 +28,8 @@ In particular, any class that overloads `operator<<` for `ostream` can be
 printed without any special handling.
 */
 
+#include <string>
+
 #ifndef DRAKE_DOXYGEN_CXX
 #ifdef HAVE_SPDLOG
 // Before including spdlog, activate the SPDLOG_DEBUG and SPDLOG_TRACE macros
@@ -188,6 +190,14 @@ struct Warn {
     drake::log()->warn(a, b...);
   }
 };
+
+/// Invokes `drake::log()->set_level(level)`.
+/// @param level Must be a string from spdlog enumerations: `trace`, `debug`,
+/// `info`, `warn`, `err`, `critical`, `off`, or `unchanged` (not an enum, but
+/// useful for command-line).
+/// @return The string value of the previous log level. If SPDLOG is disabled,
+/// then this returns an empty string.
+std::string set_log_level(const std::string& level);
 
 }  // namespace logging
 }  // namespace drake

--- a/common/text_logging_gflags.h
+++ b/common/text_logging_gflags.h
@@ -26,46 +26,7 @@ namespace logging {
 /// Check the gflags settings for validity.  If spdlog is enabled, update its
 /// configuration to match the flags.
 inline void HandleSpdlogGflags() {
-  const bool want_unchanged = (FLAGS_spdlog_level == "unchanged");
-  const bool want_trace = (FLAGS_spdlog_level == "trace");
-  const bool want_debug = (FLAGS_spdlog_level == "debug");
-  const bool want_info = (FLAGS_spdlog_level == "info");
-  const bool want_warn = (FLAGS_spdlog_level == "warn");
-  const bool want_err = (FLAGS_spdlog_level == "err");
-  const bool want_critical = (FLAGS_spdlog_level == "critical");
-  const bool want_off = (FLAGS_spdlog_level == "off");
-
-  const bool any_matched =
-      want_unchanged ||
-      want_trace ||
-      want_debug ||
-      want_info ||
-      want_warn ||
-      want_err ||
-      want_critical ||
-      want_off;
-  if (!any_matched) {
-    log()->critical("Unknown spdlog_level {}", FLAGS_spdlog_level);
-    throw std::runtime_error("Unknown spdlog level");
-  }
-
-#ifdef HAVE_SPDLOG
-  if (want_trace) {
-    log()->set_level(spdlog::level::trace);
-  } else if (want_debug) {
-    log()->set_level(spdlog::level::debug);
-  } else if (want_info) {
-    log()->set_level(spdlog::level::info);
-  } else if (want_warn) {
-    log()->set_level(spdlog::level::warn);
-  } else if (want_err) {
-    log()->set_level(spdlog::level::err);
-  } else if (want_critical) {
-    log()->set_level(spdlog::level::critical);
-  } else if (want_off) {
-    log()->set_level(spdlog::level::off);
-  }
-#endif
+  drake::logging::set_log_level(FLAGS_spdlog_level);
 }
 
 }  // namespace logging


### PR DESCRIPTION
I've had to hack `common/module_py.cc` to set the log level quite a few times; I believe @avalenzu also requested this at some point but I, uh, hadn't done it yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11044)
<!-- Reviewable:end -->
