### PR TITLE
doc python: Move Anaconda disclaimer to installation

### DIFF
--- a/doc/python_bindings.rst
+++ b/doc/python_bindings.rst
@@ -4,11 +4,6 @@
 Using Drake from Python
 ***********************
 
-.. warning::
-   Drake is incompatible with the Python environment supplied by Anaconda.
-   Please uninstall Anaconda or remove the Anaconda ``bin`` directory from the
-   ``PATH`` before building or using the Drake Python bindings.
-
 A limited subset of the Drake C++ functionality is available from Python. The
 Drake Python bindings are generated using `pybind11
 <https://github.com/pybind/pybind11>`_, which means that every function or
@@ -23,6 +18,11 @@ Installation
 
 Binary Installation for Python
 ------------------------------
+
+.. warning::
+   Drake is incompatible with the Python environment supplied by Anaconda.
+   Please uninstall Anaconda or remove the Anaconda ``bin`` directory from the
+   ``PATH`` before building or using the Drake Python bindings.
 
 First, download and extract an :ref:`available binary package
 <binary-installation>`.


### PR DESCRIPTION
Follow-up to #10961 - didn't realize that this was at the very top, ahead of installation.
Moved this to a more appropriate spot.

\cc @jamiesnape

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11045)
<!-- Reviewable:end -->
