### PR TITLE
pybind: Add `py_keep_alive` as a workaround for keep alive behavior

### DIFF
--- a/bindings/pydrake/attic/multibody/rigid_body_tree_py.cc
+++ b/bindings/pydrake/attic/multibody/rigid_body_tree_py.cc
@@ -121,8 +121,9 @@ PYBIND11_MODULE(rigid_body_tree, m) {
             // behavior.
             py::object self = py::cast(&tree);
             for (auto& body_unique_ptr : body_unique_ptrs) {
-              py_bodies.append(
-                  py::cast(body_unique_ptr.get(), py_reference_internal, self));
+              py::object body_py =
+                  py::cast(body_unique_ptr.get(), py_reference);
+              py_bodies.append(py_keep_alive(body_py, self));
             }
             return py_bodies;
           },

--- a/bindings/pydrake/pydrake_pybind.h
+++ b/bindings/pydrake/pydrake_pybind.h
@@ -317,6 +317,15 @@ const auto py_reference = py::return_value_policy::reference;
 /// implies "Keep alive, reference: `return` keeps` self` alive".
 const auto py_reference_internal = py::return_value_policy::reference_internal;
 
+/// Use this when you must do manual casting - e.g. lists or tuples of nurses,
+/// where the container may get discarded but the items kept. Prefer this over
+/// `py::cast(obj, reference_internal, parent)` (pending full resolution of
+/// #11046).
+inline py::object py_keep_alive(py::object nurse, py::object patient) {
+  py::detail::keep_alive_impl(nurse, patient);
+  return nurse;
+}
+
 // Implementation for `overload_cast_explicit`. We must use this structure so
 // that we can constrain what is inferred. Otherwise, the ambiguity confuses
 // the compiler.


### PR DESCRIPTION
Works around #11046 - after this merges, I'll change the title to be generic.

I still don't know what the root cause is, but I won't be able to dig too far any time soon.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11047)
<!-- Reviewable:end -->
