### PR TITLE
Permit late addition of prerequisites to already-declared cache entries

### DIFF
--- a/systems/framework/cache_entry.h
+++ b/systems/framework/cache_entry.h
@@ -90,10 +90,30 @@ class CacheEntry {
              AllocCallback alloc_function, CalcCallback calc_function,
              std::set<DependencyTicket> prerequisites_of_calc);
 
-  /** Returns a reference to the list of prerequisites needed by this cache
+  /** Returns a reference to the set of prerequisites needed by this cache
   entry's Calc() function. These are all within the same subsystem that
   owns this %CacheEntry. */
   const std::set<DependencyTicket>& prerequisites() const {
+    return prerequisites_of_calc_;
+  }
+
+  /** (Advanced) Returns a mutable reference to the set of prerequisites needed
+  by this entry's Calc() function. Any tickets in this set are interpreted as
+  referring to prerequisites within the same subsystem that owns this
+  %CacheEntry. Modifications take effect the next time the containing System is
+  asked to create a Context.
+
+  A cache entry should normally be given its complete set of prerequisites
+  at the time it is declared (typically in a System constructor). If
+  possible, defer declaration of cache entries until all their prerequisites
+  have been declared so that all necessary tickets are available. In Systems
+  with complicated extended construction phases it may be awkward or impossible
+  to know all the prerequisites at that time. In that case, consider choosing
+  a comprehensive prerequisite like `all_input_ports_ticket()` that can include
+  as-yet-undeclared prerequisites. If performance requirements preclude that
+  approach, then an advanced user may use this method to add more prerequisites
+  as their tickets become available. */
+  std::set<DependencyTicket>& mutable_prerequisites() {
     return prerequisites_of_calc_;
   }
 
@@ -312,7 +332,7 @@ class CacheEntry {
   // changes, the cache value must be recalculated. Note that all possible
   // prerequisites are internal to the containing subsystem, so the ticket
   // alone is a unique specification of a prerequisite.
-  const std::set<DependencyTicket> prerequisites_of_calc_;
+  std::set<DependencyTicket> prerequisites_of_calc_;
 };
 
 }  // namespace systems

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -217,8 +217,16 @@ class SystemBase : public internal::SystemMessageInterface {
     return static_cast<int>(cache_entries_.size());
   }
 
-  /** Return a reference to a CacheEntry given its `index`. */
+  /** Returns a reference to a CacheEntry given its `index`. */
   const CacheEntry& get_cache_entry(CacheIndex index) const {
+    DRAKE_ASSERT(0 <= index && index < num_cache_entries());
+    return *cache_entries_[index];
+  }
+
+  /** (Advanced) Returns a mutable reference to a CacheEntry given its `index`.
+  Note that you do not need mutable access to a CacheEntry to modify its value
+  in a Context, so most users should not use this method. */
+  CacheEntry& get_mutable_cache_entry(CacheIndex index) {
     DRAKE_ASSERT(0 <= index && index < num_cache_entries());
     return *cache_entries_[index];
   }


### PR DESCRIPTION
Normally all cache entry prerequisites are provided at the time a cache entry is declared. That is difficult in
some Systems with complicated construction sequences, such as SceneGraph (see #11035).

This PR adds an `(Advanced)` method to CacheEntry that permits modification of the prerequisites set after initial declaration. This is not technically difficult because a CacheEntry simply maintains an `std::set` of ticket numbers that is not used until Context creation time. Modifying that set any time prior to that is fine. This should be done cautiously though because it makes it difficult to determine by inspection of the code what the actual prerequisites of a cache entry are. Careful documentation and descriptive naming of the cache entry should be used to clarify.

Resolves #11035.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11049)
<!-- Reviewable:end -->
