### PR TITLE
Use Simulator::AdvanceTo() instead of StepTo()

### DIFF
--- a/attic/manipulation/dev/quasistatic_iiwa_pick_and_place_demo.cc
+++ b/attic/manipulation/dev/quasistatic_iiwa_pick_and_place_demo.cc
@@ -287,7 +287,7 @@ int do_main() {
   simulator.set_target_realtime_rate(0);
   simulator.get_mutable_integrator()->set_maximum_step_size(h);
   simulator.Initialize();
-  simulator.StepTo(kTimes.back());
+  simulator.AdvanceTo(kTimes.back());
 
   // Comparing the final position and orientation of the object in world frame
   // to expected values.

--- a/attic/manipulation/dev/test/rod2d_time_stepping.cc
+++ b/attic/manipulation/dev/test/rod2d_time_stepping.cc
@@ -204,7 +204,7 @@ VectorXd RunSimulation(const bool is_analytic) {
   const double h = rod2d->get_period_sec();
   simulator.get_mutable_integrator()->set_maximum_step_size(h);
   simulator.Initialize();
-  simulator.StepTo(7.5);
+  simulator.AdvanceTo(7.5);
 
   VectorXd q_final = log_state->data().topRightCorner(n1, 1);
   return q_final;

--- a/attic/manipulation/scene_generation/simulate_plant_to_rest.cc
+++ b/attic/manipulation/scene_generation/simulate_plant_to_rest.cc
@@ -95,7 +95,7 @@ VectorX<double> SimulatePlantToRest::Run(const VectorX<double>& q_ik,
     step_time = 1.0;
     step_delta = 0.1;
     do {
-      simulator.StepTo(step_time);
+      simulator.AdvanceTo(step_time);
       step_time += step_delta;
       x = simulator.get_context().get_continuous_state_vector().CopyToVector();
       v = x.tail(num_velocities);

--- a/attic/manipulation/util/test/sim_diagram_builder_test.cc
+++ b/attic/manipulation/util/test/sim_diagram_builder_test.cc
@@ -176,7 +176,7 @@ GTEST_TEST(SimDiagramBuilderTest, TestSimulation) {
   plant->set_state_vector(&plant_context, state0);
 
   simulator.Initialize();
-  simulator.StepTo(0.02);
+  simulator.AdvanceTo(0.02);
 
   auto state_output = diagram->AllocateOutput();
   diagram->CalcOutput(simulator.get_context(), state_output.get());

--- a/attic/multibody/rigid_body_plant/test/drake_visualizer_test.cc
+++ b/attic/multibody/rigid_body_plant/test/drake_visualizer_test.cc
@@ -513,7 +513,7 @@ GTEST_TEST(DrakeVisualizerTests, TestPublishPeriod) {
   VerifyLoadMessage(lcm.get_last_published_message("DRAKE_VIEWER_LOAD_ROBOT"));
 
   for (double time = 0; time < 4; time += 0.01) {
-    simulator.StepTo(time);
+    simulator.AdvanceTo(time);
     EXPECT_NEAR(simulator.get_mutable_context().get_time(), time, 1e-10);
     // Note that the expected time is in milliseconds.
     const double expected_time =

--- a/attic/multibody/test/rigid_body_tree/rigid_body_tree_clone_test.cc
+++ b/attic/multibody/test/rigid_body_tree/rigid_body_tree_clone_test.cc
@@ -197,8 +197,8 @@ TEST_F(RigidBodyTreeCloneTest, PendulumDynamicsTest) {
   const SignalLogger<double>& original_logger = original_diagram.get_logger();
   const SignalLogger<double>& cloned_logger = cloned_diagram.get_logger();
 
-  original_simulator.StepTo(swing_period);
-  cloned_simulator.StepTo(swing_period);
+  original_simulator.AdvanceTo(swing_period);
+  cloned_simulator.AdvanceTo(swing_period);
   ASSERT_TRUE(CompareMatrices(original_logger.data(), cloned_logger.data()));
 }
 

--- a/attic/systems/controllers/qp_inverse_dynamics/test/qp_inverse_dynamics_system_test.cc
+++ b/attic/systems/controllers/qp_inverse_dynamics/test/qp_inverse_dynamics_system_test.cc
@@ -103,7 +103,7 @@ GTEST_TEST(testQpInverseDynamicsSystem, IiwaInverseDynamics) {
   std::unique_ptr<SystemOutput<double>> output =
       diagram->AllocateOutput();
   sim.Initialize();
-  sim.StepTo(controller->get_control_dt());
+  sim.AdvanceTo(controller->get_control_dt());
 
   // Gets the output from the plan eval block.
   diagram->CalcOutput(sim.get_context(), output.get());

--- a/attic/systems/sensors/test/accelerometer_test/accelerometer_example.cc
+++ b/attic/systems/sensors/test/accelerometer_test/accelerometer_example.cc
@@ -46,7 +46,7 @@ int exec(int argc, char* argv[]) {
   Simulator<double> simulator(diagram, std::move(context));
   simulator.Initialize();
   simulator.set_target_realtime_rate(1);
-  simulator.StepTo(FLAGS_simulation_sec);
+  simulator.AdvanceTo(FLAGS_simulation_sec);
   return 0;
 }
 

--- a/attic/systems/sensors/test/accelerometer_test/accelerometer_test.cc
+++ b/attic/systems/sensors/test/accelerometer_test/accelerometer_test.cc
@@ -155,7 +155,7 @@ GTEST_TEST(TestAccelerometer, TestSensorAttachedToSwingingPendulum) {
   const RigidBodyTree<double>& tree = diagram.get_tree();
 
   const double kStepToTime = 0.01;
-  simulator.StepTo(kStepToTime);
+  simulator.AdvanceTo(kStepToTime);
 
   const Context<double>& simulator_context = simulator.get_context();
   const Context<double>& logger_context =

--- a/automotive/automotive_simulator.cc
+++ b/automotive/automotive_simulator.cc
@@ -796,7 +796,7 @@ template <typename T>
 void AutomotiveSimulator<T>::StepBy(const T& time_step) {
   const T time = simulator_->get_context().get_time();
   SPDLOG_TRACE(drake::log(), "Time is now {}", time);
-  simulator_->StepTo(time + time_step);
+  simulator_->AdvanceTo(time + time_step);
 }
 
 template <typename T>

--- a/automotive/test/automotive_simulator_test.cc
+++ b/automotive/test/automotive_simulator_test.cc
@@ -377,14 +377,14 @@ GTEST_TEST(AutomotiveSimulatorTest, TestIdmControlledSimpleCarAutoDiff) {
   auto plant_simulator =
       std::make_unique<systems::Simulator<double>>(plant);
 
-  plant_simulator->StepTo(0.5);
+  plant_simulator->AdvanceTo(0.5);
 
   // Converts to AutoDiffXd.
   auto plant_ad = plant.ToAutoDiffXd();
   auto plant_ad_simulator =
       std::make_unique<systems::Simulator<AutoDiffXd>>(*plant_ad);
 
-  plant_ad_simulator->StepTo(0.5);
+  plant_ad_simulator->AdvanceTo(0.5);
 }
 
 // Returns the x-position of the vehicle based on an lcmt_viewer_draw message.

--- a/automotive/test/trajectory_car_test.cc
+++ b/automotive/test/trajectory_car_test.cc
@@ -123,7 +123,7 @@ TYPED_TEST(TrajectoryCarTest, ConstantSpeedTest) {
     simulator.Initialize();
 
     for (double time = start_time; time <= end_time; time += 0.1) {
-      simulator.StepTo(time - start_time);
+      simulator.AdvanceTo(time - start_time);
 
       const double fractional_progress =
           std::min(std::max(0.0, (time * it.speed) / total_distance), 1.0);

--- a/automotive/test/trajectory_follower_test.cc
+++ b/automotive/test/trajectory_follower_test.cc
@@ -93,7 +93,7 @@ GTEST_TEST(TrajectoryFollowerTest, Outputs) {
 
     const double end_time = it.distance / kSpeed;
     for (double time = 0.; time <= end_time; time += 0.1) {
-      simulator.StepTo(time);
+      simulator.AdvanceTo(time);
 
       const double scalar =
           std::min(std::max(0.0, (time * kSpeed) / it.distance), 1.);

--- a/bindings/pydrake/examples/multibody/cart_pole_passive_simulation.py
+++ b/bindings/pydrake/examples/multibody/cart_pole_passive_simulation.py
@@ -65,7 +65,7 @@ def main():
     simulator.set_publish_every_time_step(False)
     simulator.set_target_realtime_rate(args.target_realtime_rate)
     simulator.Initialize()
-    simulator.StepTo(args.simulation_time)
+    simulator.AdvanceTo(args.simulation_time)
 
 
 if __name__ == "__main__":

--- a/bindings/pydrake/examples/test/acrobot_test.py
+++ b/bindings/pydrake/examples/test/acrobot_test.py
@@ -76,7 +76,7 @@ class TestAcrobot(unittest.TestCase):
 
         # Simulate (and make sure the state actually changes).
         initial_state = state.CopyToVector()
-        simulator.StepTo(1.0)
+        simulator.AdvanceTo(1.0)
 
         self.assertLessEqual(acrobot.CalcPotentialEnergy(context) +
                              acrobot.CalcKineticEnergy(context),

--- a/bindings/pydrake/examples/test/compass_gait_test.py
+++ b/bindings/pydrake/examples/test/compass_gait_test.py
@@ -55,5 +55,5 @@ class TestCompassGait(unittest.TestCase):
 
         # Simulate (and make sure the state actually changes).
         initial_state = state.CopyToVector()
-        simulator.StepTo(1.0)
+        simulator.AdvanceTo(1.0)
         self.assertFalse((state.CopyToVector() == initial_state).any())

--- a/bindings/pydrake/examples/test/pendulum_test.py
+++ b/bindings/pydrake/examples/test/pendulum_test.py
@@ -57,5 +57,5 @@ class TestPendulum(unittest.TestCase):
 
         # Simulate (and make sure the state actually changes).
         initial_state = state.CopyToVector()
-        simulator.StepTo(1.0)
+        simulator.AdvanceTo(1.0)
         self.assertFalse((state.CopyToVector() == initial_state).any())

--- a/bindings/pydrake/examples/test/rimless_wheel_test.py
+++ b/bindings/pydrake/examples/test/rimless_wheel_test.py
@@ -47,5 +47,5 @@ class TestRimlessWheel(unittest.TestCase):
 
         # Simulate (and make sure the state actually changes).
         initial_state = state.CopyToVector()
-        simulator.StepTo(1.0)
+        simulator.AdvanceTo(1.0)
         self.assertFalse((state.CopyToVector() == initial_state).any())

--- a/bindings/pydrake/examples/test/van_der_pol_test.py
+++ b/bindings/pydrake/examples/test/van_der_pol_test.py
@@ -21,7 +21,7 @@ class TestVanDerPol(unittest.TestCase):
 
         # Simulate (and make sure the state actually changes).
         initial_state = state.CopyToVector()
-        simulator.StepTo(1.0)
+        simulator.AdvanceTo(1.0)
         self.assertFalse((state.CopyToVector() == initial_state).any())
 
     def test_ports(self):

--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -82,7 +82,8 @@ PYBIND11_MODULE(analysis, m) {
             py::keep_alive<3, 1>(), doc.Simulator.ctor.doc)
         .def("Initialize", &Simulator<T>::Initialize,
             doc.Simulator.Initialize.doc)
-        .def("StepTo", &Simulator<T>::StepTo, doc.Simulator.StepTo.doc)
+        .def("AdvanceTo", &Simulator<T>::AdvanceTo, doc.Simulator.AdvanceTo.doc)
+        .def("StepTo", &Simulator<T>::StepTo, "Use AdvanceTo() instead.")
         .def("get_context", &Simulator<T>::get_context, py_reference_internal,
             doc.Simulator.get_context.doc)
         .def("get_integrator", &Simulator<T>::get_integrator,

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -161,7 +161,7 @@ class TestCustom(unittest.TestCase):
 
         simulator = Simulator(diagram, context)
         simulator.Initialize()
-        simulator.StepTo(1)
+        simulator.AdvanceTo(1)
         # Ensure that we have the outputs we want.
         value = (diagram.GetMutableSubsystemContext(zoh, context)
                  .get_discrete_state_vector().get_value())
@@ -297,7 +297,7 @@ class TestCustom(unittest.TestCase):
         system = TrivialSystem()
         simulator = Simulator(system)
         # Stepping to 0.99 so that we get exactly one periodic event.
-        simulator.StepTo(0.99)
+        simulator.AdvanceTo(0.99)
         self.assertTrue(system.called_per_step)
         self.assertTrue(system.called_periodic)
 

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -249,7 +249,7 @@ class TestGeneral(unittest.TestCase):
             self.assertTrue(simulator.get_context() is
                             simulator.get_mutable_context())
             check_output(simulator.get_context())
-            simulator.StepTo(1)
+            simulator.AdvanceTo(1)
 
             # Create simulator specifying context.
             context = system.CreateDefaultContext()
@@ -262,7 +262,7 @@ class TestGeneral(unittest.TestCase):
             simulator = Simulator_[T](system, context)
             self.assertTrue(simulator.get_context() is context)
             check_output(context)
-            simulator.StepTo(1)
+            simulator.AdvanceTo(1)
 
     def test_copy(self):
         # Copy a context using `deepcopy` or `clone`.
@@ -337,7 +337,7 @@ class TestGeneral(unittest.TestCase):
         times = np.linspace(0, 1, n)
         context_log = []
         for t in times:
-            simulator.StepTo(t)
+            simulator.AdvanceTo(t)
             # Record snapshot of *entire* context.
             context_log.append(context.Clone())
 

--- a/bindings/pydrake/systems/test/meshcat_visualizer_test.py
+++ b/bindings/pydrake/systems/test/meshcat_visualizer_test.py
@@ -79,7 +79,7 @@ class TestMeshcat(unittest.TestCase):
 
         simulator = Simulator(diagram, diagram_context)
         simulator.set_publish_every_time_step(False)
-        simulator.StepTo(.1)
+        simulator.AdvanceTo(.1)
 
     def test_kuka(self):
         """Kuka IIWA with mesh geometry."""
@@ -110,7 +110,7 @@ class TestMeshcat(unittest.TestCase):
 
         simulator = Simulator(diagram, diagram_context)
         simulator.set_publish_every_time_step(False)
-        simulator.StepTo(.1)
+        simulator.AdvanceTo(.1)
 
     def test_contact_force(self):
         """A block sitting on a table."""
@@ -179,7 +179,7 @@ class TestMeshcat(unittest.TestCase):
 
         simulator = Simulator(diagram, diagram_context)
         simulator.set_publish_every_time_step(False)
-        simulator.StepTo(1.0)
+        simulator.AdvanceTo(1.0)
 
         contact_viz_context = (
             diagram.GetMutableSubsystemContext(contact_viz, diagram_context))
@@ -218,7 +218,7 @@ class TestMeshcat(unittest.TestCase):
 
         simulator = Simulator(diagram, diagram_context)
         simulator.set_publish_every_time_step(False)
-        simulator.StepTo(1.0)
+        simulator.AdvanceTo(1.0)
 
     def test_point_cloud_visualization(self):
         """A small point cloud"""
@@ -255,7 +255,7 @@ class TestMeshcat(unittest.TestCase):
                 AbstractValue.Make(pc))
             simulator = Simulator(diagram, diagram_context)
             simulator.set_publish_every_time_step(False)
-            simulator.StepTo(sim_time)
+            simulator.AdvanceTo(sim_time)
 
         # Generate some random points that are visually noticeable.
         # ~300000 makes the visualizer less responsive on my (Eric) machine.

--- a/bindings/pydrake/systems/test/primitives_test.py
+++ b/bindings/pydrake/systems/test/primitives_test.py
@@ -112,7 +112,7 @@ class TestGeneral(unittest.TestCase):
         diagram = builder.Build()
         simulator = Simulator(diagram)
         kTime = 1.
-        simulator.StepTo(kTime)
+        simulator.AdvanceTo(kTime)
 
         # Verify outputs of the every-step logger
         t = logger_per_step.sample_times()

--- a/bindings/pydrake/test/automotive_test.py
+++ b/bindings/pydrake/test/automotive_test.py
@@ -251,7 +251,7 @@ class TestAutomotive(unittest.TestCase):
         # Initialize all the states to zero and take a simulation step.
         state = context.get_mutable_continuous_state_vector()
         state.SetFromVector([0.] * state.size())
-        simulator.StepTo(1.0)
+        simulator.AdvanceTo(1.0)
 
         # Verify the outputs.
         simple_car.CalcOutput(context, output)

--- a/examples/acrobot/run_lqr.cc
+++ b/examples/acrobot/run_lqr.cc
@@ -68,7 +68,7 @@ int do_main() {
 
   simulator.set_target_realtime_rate(FLAGS_realtime_factor);
   simulator.Initialize();
-  simulator.StepTo(FLAGS_simulation_sec);
+  simulator.AdvanceTo(FLAGS_simulation_sec);
   return 0;
 }
 

--- a/examples/acrobot/run_lqr_w_estimator.cc
+++ b/examples/acrobot/run_lqr_w_estimator.cc
@@ -137,7 +137,7 @@ int do_main() {
   simulator.get_mutable_integrator()->set_maximum_step_size(0.01);
   simulator.get_mutable_integrator()->set_fixed_step_mode(true);
   simulator.Initialize();
-  simulator.StepTo(FLAGS_simulation_sec);
+  simulator.AdvanceTo(FLAGS_simulation_sec);
 
   // Plot the results (launch call_matlab_client to see the plots).
   using common::CallMatlab;

--- a/examples/acrobot/run_passive.cc
+++ b/examples/acrobot/run_passive.cc
@@ -62,7 +62,7 @@ int do_main() {
 
   simulator.set_target_realtime_rate(FLAGS_realtime_factor);
   simulator.Initialize();
-  simulator.StepTo(FLAGS_simulation_sec);
+  simulator.AdvanceTo(FLAGS_simulation_sec);
   return 0;
 }
 

--- a/examples/acrobot/run_plant_w_lcm.cc
+++ b/examples/acrobot/run_plant_w_lcm.cc
@@ -96,7 +96,7 @@ int DoMain() {
 
   simulator.set_target_realtime_rate(FLAGS_realtime_factor);
   simulator.Initialize();
-  simulator.StepTo(FLAGS_simulation_sec);
+  simulator.AdvanceTo(FLAGS_simulation_sec);
 
   lcm.StopReceiveThread();
   return 0;

--- a/examples/acrobot/run_swing_up.cc
+++ b/examples/acrobot/run_swing_up.cc
@@ -61,7 +61,7 @@ int do_main() {
   state->set_theta2dot(0.02);
 
   simulator.set_target_realtime_rate(FLAGS_realtime_factor);
-  simulator.StepTo(FLAGS_simulation_sec);
+  simulator.AdvanceTo(FLAGS_simulation_sec);
 
   DRAKE_DEMAND(std::abs(math::wrap_to(state->theta1(), 0., 2. * M_PI) - M_PI) <
                1e-2);

--- a/examples/acrobot/test/run_swing_up_traj_optimization.cc
+++ b/examples/acrobot/test/run_swing_up_traj_optimization.cc
@@ -101,7 +101,7 @@ int do_main() {
 
   simulator.set_target_realtime_rate(FLAGS_realtime_factor);
   simulator.Initialize();
-  simulator.StepTo(pp_xtraj.end_time());
+  simulator.AdvanceTo(pp_xtraj.end_time());
   return 0;
 }
 

--- a/examples/allegro_hand/joint_control/allegro_single_object_simulation.cc
+++ b/examples/allegro_hand/joint_control/allegro_single_object_simulation.cc
@@ -199,7 +199,7 @@ void DoMain() {
                                            &simulator.get_mutable_context()),
       VectorX<double>::Zero(plant.num_actuators()));
 
-  simulator.StepTo(FLAGS_simulation_time);
+  simulator.AdvanceTo(FLAGS_simulation_time);
 
   lcm.StopReceiveThread();
 }

--- a/examples/allegro_hand/run_allegro_constant_load_demo.cc
+++ b/examples/allegro_hand/run_allegro_constant_load_demo.cc
@@ -131,7 +131,7 @@ void DoMain() {
   simulator.set_publish_every_time_step(true);
   simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
   simulator.Initialize();
-  simulator.StepTo(FLAGS_simulation_time);
+  simulator.AdvanceTo(FLAGS_simulation_time);
 }
 
 }  // namespace allegro_hand

--- a/examples/bouncing_ball/test/bouncing_ball_test.cc
+++ b/examples/bouncing_ball/test/bouncing_ball_test.cc
@@ -177,7 +177,7 @@ TEST_F(BouncingBallTest, Simulate) {
   xc.SetAtIndex(1, v0);
 
   // Integrate.
-  simulator.StepTo(t_final);
+  simulator.AdvanceTo(t_final);
   EXPECT_EQ(simulator.get_mutable_context().get_time(), t_final);
 
   // Check against closed form solution for the bouncing ball. We anticipate

--- a/examples/compass_gait/simulate.cc
+++ b/examples/compass_gait/simulate.cc
@@ -77,7 +77,7 @@ int DoMain() {
 
   simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
   simulator.get_mutable_context().set_accuracy(1e-4);
-  simulator.StepTo(10);
+  simulator.AdvanceTo(10);
 
   return 0;
 }

--- a/examples/contact_model/bowling_ball.cc
+++ b/examples/contact_model/bowling_ball.cc
@@ -202,7 +202,7 @@ int main() {
 
   plant.set_state_vector(&plant_context, initial_state);
 
-  simulator.StepTo(FLAGS_sim_duration);
+  simulator.AdvanceTo(FLAGS_sim_duration);
 
   return 0;
 }

--- a/examples/contact_model/rigid_gripper.cc
+++ b/examples/contact_model/rigid_gripper.cc
@@ -160,7 +160,7 @@ int main() {
   for (int i = 1; i <= step_count; ++i) {
     double t = context.get_time();
     std::cout << "time: " << t << "\n";
-    simulator.StepTo(i * kPrintPeriod);
+    simulator.AdvanceTo(i * kPrintPeriod);
   }
 
   while (FLAGS_playback) viz_publisher->ReplayCachedSimulation();

--- a/examples/contact_model/sliding_bricks.cc
+++ b/examples/contact_model/sliding_bricks.cc
@@ -157,7 +157,7 @@ int main() {
                    FLAGS_v, 0, 0, 0, 0, 0;     // brick 2 velocity
   plant.set_state_vector(&plant_context, initial_state);
 
-  simulator.StepTo(FLAGS_sim_duration);
+  simulator.AdvanceTo(FLAGS_sim_duration);
 
   return 0;
 }

--- a/examples/double_pendulum/double_pendulum_demo.cc
+++ b/examples/double_pendulum/double_pendulum_demo.cc
@@ -62,7 +62,7 @@ int main(int argc, char* argv[]) {
   simulator->Initialize();
   // Run simulation.
   lcm_interface->StartReceiveThread();
-  simulator->StepTo(FLAGS_simulation_time);
+  simulator->AdvanceTo(FLAGS_simulation_time);
   lcm_interface->StopReceiveThread();
   return 0;
 }

--- a/examples/fibonacci/run_fibonacci.cc
+++ b/examples/fibonacci/run_fibonacci.cc
@@ -29,7 +29,7 @@ int main(int argc, char* argv[]) {
 
   // Create a Simulator and use it to advance time until t=steps*h.
   systems::Simulator<double> simulator(*diagram);
-  simulator.StepTo(FLAGS_steps * FibonacciDifferenceEquation::kPeriod);
+  simulator.AdvanceTo(FLAGS_steps * FibonacciDifferenceEquation::kPeriod);
 
   // Print out the contents of the log.
   for (int n = 0; n < logger->sample_times().size(); ++n) {

--- a/examples/fibonacci/test/fibonacci_difference_equation_test.cc
+++ b/examples/fibonacci/test/fibonacci_difference_equation_test.cc
@@ -24,7 +24,7 @@ GTEST_TEST(Fibonacci, CheckSequence) {
   systems::Simulator<double> simulator(*diagram);
 
   // Simulate forward to fibonacci(6): 0 1 1 2 3 5 8
-  simulator.StepTo(6 * FibonacciDifferenceEquation::kPeriod);
+  simulator.AdvanceTo(6 * FibonacciDifferenceEquation::kPeriod);
 
   Eigen::VectorXd expected(7);
   expected << 0, 1, 1, 2, 3, 5, 8;

--- a/examples/kinova_jaco_arm/run_controlled_jaco_demo.cc
+++ b/examples/kinova_jaco_arm/run_controlled_jaco_demo.cc
@@ -215,7 +215,7 @@ int DoMain() {
   simulator.Initialize();
   simulator.set_target_realtime_rate(1);
 
-  simulator.StepTo(FLAGS_simulation_sec);
+  simulator.AdvanceTo(FLAGS_simulation_sec);
 
   return 0;
 }

--- a/examples/kinova_jaco_arm/run_passive_jaco_demo.cc
+++ b/examples/kinova_jaco_arm/run_passive_jaco_demo.cc
@@ -87,7 +87,7 @@ int DoMain() {
 
   // Simulate for the desired duration.
   simulator.set_target_realtime_rate(1);
-  simulator.StepTo(FLAGS_simulation_sec);
+  simulator.AdvanceTo(FLAGS_simulation_sec);
 
   // Ensures the simulation was successful.
   const Context<double>& context = simulator.get_context();

--- a/examples/kinova_jaco_arm/run_setpose_jaco_demo.cc
+++ b/examples/kinova_jaco_arm/run_setpose_jaco_demo.cc
@@ -108,7 +108,7 @@ int DoMain() {
   simulator.Initialize();
   simulator.set_target_realtime_rate(1);
 
-  simulator.StepTo(FLAGS_simulation_sec);
+  simulator.AdvanceTo(FLAGS_simulation_sec);
 
   return 0;
 }

--- a/examples/kuka_iiwa_arm/controlled_kuka/controlled_kuka_demo.cc
+++ b/examples/kuka_iiwa_arm/controlled_kuka/controlled_kuka_demo.cc
@@ -75,7 +75,7 @@ int DoMain() {
   simulator.Initialize();
   simulator.set_target_realtime_rate(1.0);
 
-  simulator.StepTo(FLAGS_simulation_sec);
+  simulator.AdvanceTo(FLAGS_simulation_sec);
 
   return 0;
 }

--- a/examples/kuka_iiwa_arm/controlled_kuka/controlled_kuka_multibody_demo.cc
+++ b/examples/kuka_iiwa_arm/controlled_kuka/controlled_kuka_multibody_demo.cc
@@ -103,7 +103,7 @@ int DoMain() {
   simulator.set_target_realtime_rate(1.0);
   simulator.get_mutable_integrator()->set_target_accuracy(1e-3);
 
-  simulator.StepTo(FLAGS_simulation_sec);
+  simulator.AdvanceTo(FLAGS_simulation_sec);
   return 0;
 }
 

--- a/examples/kuka_iiwa_arm/iiwa_world/multi_arm_with_gripper_demo.cc
+++ b/examples/kuka_iiwa_arm/iiwa_world/multi_arm_with_gripper_demo.cc
@@ -155,7 +155,7 @@ void main() {
   systems::Simulator<double> simulator(*diagram);
   simulator.Initialize();
   simulator.set_target_realtime_rate(1.0);
-  simulator.StepTo(FLAGS_simulation_sec);
+  simulator.AdvanceTo(FLAGS_simulation_sec);
 }
 
 }  // namespace

--- a/examples/kuka_iiwa_arm/iiwa_wsg_simulation.cc
+++ b/examples/kuka_iiwa_arm/iiwa_wsg_simulation.cc
@@ -282,7 +282,7 @@ int DoMain() {
   simulator.reset_integrator<RungeKutta2Integrator<double>>(*sys,
       FLAGS_dt, &simulator.get_mutable_context());
   simulator.set_publish_every_time_step(false);
-  simulator.StepTo(FLAGS_simulation_sec);
+  simulator.AdvanceTo(FLAGS_simulation_sec);
 
   lcm.StopReceiveThread();
   return 0;

--- a/examples/kuka_iiwa_arm/kuka_simulation.cc
+++ b/examples/kuka_iiwa_arm/kuka_simulation.cc
@@ -205,7 +205,7 @@ int DoMain() {
       VectorX<double>::Zero(tree.get_num_positions()));
 
   // Simulate for a very long time.
-  simulator.StepTo(FLAGS_simulation_sec);
+  simulator.AdvanceTo(FLAGS_simulation_sec);
 
   lcm.StopReceiveThread();
   return 0;

--- a/examples/manipulation_station/end_effector_teleop_mouse.py
+++ b/examples/manipulation_station/end_effector_teleop_mouse.py
@@ -355,4 +355,4 @@ simulator.set_publish_every_time_step(False)
 simulator.set_target_realtime_rate(args.target_realtime_rate)
 
 print_instructions()
-simulator.StepTo(args.duration)
+simulator.AdvanceTo(args.duration)

--- a/examples/manipulation_station/end_effector_teleop_sliders.py
+++ b/examples/manipulation_station/end_effector_teleop_sliders.py
@@ -296,4 +296,4 @@ differential_ik.SetPositions(diagram.GetMutableSubsystemContext(
 simulator.set_publish_every_time_step(False)
 
 simulator.set_target_realtime_rate(args.target_realtime_rate)
-simulator.StepTo(args.duration)
+simulator.AdvanceTo(args.duration)

--- a/examples/manipulation_station/joint_teleop.py
+++ b/examples/manipulation_station/joint_teleop.py
@@ -97,4 +97,4 @@ filter.set_initial_output_value(diagram.GetMutableSubsystemContext(
 simulator.set_publish_every_time_step(False)
 
 simulator.set_target_realtime_rate(args.target_realtime_rate)
-simulator.StepTo(args.duration)
+simulator.AdvanceTo(args.duration)

--- a/examples/manipulation_station/mock_station_simulation.cc
+++ b/examples/manipulation_station/mock_station_simulation.cc
@@ -145,7 +145,7 @@ int do_main(int argc, char* argv[]) {
 
   simulator.set_publish_every_time_step(false);
   simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
-  simulator.StepTo(FLAGS_duration);
+  simulator.AdvanceTo(FLAGS_duration);
 
   return 0;
 }

--- a/examples/manipulation_station/proof_of_life.cc
+++ b/examples/manipulation_station/proof_of_life.cc
@@ -110,7 +110,7 @@ int do_main(int argc, char* argv[]) {
   }
 
   simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
-  simulator.StepTo(FLAGS_duration);
+  simulator.AdvanceTo(FLAGS_duration);
 
   // Check that the arm is (very roughly) in the commanded position.
   VectorXd q = station->GetIiwaPosition(station_context);

--- a/examples/multibody/acrobot/passive_simulation.cc
+++ b/examples/multibody/acrobot/passive_simulation.cc
@@ -129,7 +129,7 @@ int do_main() {
   simulator.set_publish_every_time_step(false);
   simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
   simulator.Initialize();
-  simulator.StepTo(simulation_time);
+  simulator.AdvanceTo(simulation_time);
 
   // Some sanity checks:
   if (FLAGS_integration_scheme == "semi_explicit_euler") {

--- a/examples/multibody/acrobot/run_lqr.cc
+++ b/examples/multibody/acrobot/run_lqr.cc
@@ -173,7 +173,7 @@ int do_main() {
                                             &generator);
 
     simulator.Initialize();
-    simulator.StepTo(FLAGS_simulation_time);
+    simulator.AdvanceTo(FLAGS_simulation_time);
   }
 
   return 0;

--- a/examples/multibody/bouncing_ball/bouncing_ball_run_dynamics.cc
+++ b/examples/multibody/bouncing_ball/bouncing_ball_run_dynamics.cc
@@ -145,7 +145,7 @@ int do_main() {
   simulator.set_publish_every_time_step(false);
   simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
   simulator.Initialize();
-  simulator.StepTo(FLAGS_simulation_time);
+  simulator.AdvanceTo(FLAGS_simulation_time);
 
   // Some sanity checks:
   if (FLAGS_integration_scheme == "semi_explicit_euler") {

--- a/examples/multibody/cart_pole/cart_pole_passive_simulation.cc
+++ b/examples/multibody/cart_pole/cart_pole_passive_simulation.cc
@@ -99,7 +99,7 @@ int do_main() {
   simulator.set_publish_every_time_step(false);
   simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
   simulator.Initialize();
-  simulator.StepTo(FLAGS_simulation_time);
+  simulator.AdvanceTo(FLAGS_simulation_time);
 
   return 0;
 }

--- a/examples/multibody/cylinder_with_multicontact/cylinder_run_dynamics.cc
+++ b/examples/multibody/cylinder_with_multicontact/cylinder_run_dynamics.cc
@@ -130,7 +130,7 @@ int do_main() {
   simulator.set_publish_every_time_step(true);
   simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
   simulator.Initialize();
-  simulator.StepTo(FLAGS_simulation_time);
+  simulator.AdvanceTo(FLAGS_simulation_time);
 
   return 0;
 }

--- a/examples/multibody/inclined_plane/inclined_plane_run_dynamics.cc
+++ b/examples/multibody/inclined_plane/inclined_plane_run_dynamics.cc
@@ -93,7 +93,7 @@ int do_main() {
   simulator.set_publish_every_time_step(false);
   simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
   simulator.Initialize();
-  simulator.StepTo(FLAGS_simulation_time);
+  simulator.AdvanceTo(FLAGS_simulation_time);
 
   return 0;
 }

--- a/examples/multibody/pendulum/passive_simulation.cc
+++ b/examples/multibody/pendulum/passive_simulation.cc
@@ -124,7 +124,7 @@ int do_main() {
   simulator.set_publish_every_time_step(false);
   simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
   simulator.Initialize();
-  simulator.StepTo(simulation_time);
+  simulator.AdvanceTo(simulation_time);
 
   // Some sanity checks:
   if (FLAGS_integration_scheme == "semi_explicit_euler") {

--- a/examples/particles/uniformly_accelerated_particle.cc
+++ b/examples/particles/uniformly_accelerated_particle.cc
@@ -145,7 +145,7 @@ int main(int argc, char* argv[]) {
   simulator->set_target_realtime_rate(FLAGS_realtime_rate);
   simulator->Initialize();
   // Run simulation.
-  simulator->StepTo(FLAGS_simulation_time);
+  simulator->AdvanceTo(FLAGS_simulation_time);
   interface->StopReceiveThread();
   return 0;
 }

--- a/examples/pendulum/energy_shaping_simulation.cc
+++ b/examples/pendulum/energy_shaping_simulation.cc
@@ -101,7 +101,7 @@ int DoMain() {
   // Run the simulation.
   simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
   simulator.Initialize();
-  simulator.StepTo(10);
+  simulator.AdvanceTo(10);
 
   // Compute the final (total) energy.
   const double final_energy = pendulum->CalcTotalEnergy(pendulum_context);

--- a/examples/pendulum/lqr_simulation.cc
+++ b/examples/pendulum/lqr_simulation.cc
@@ -76,7 +76,7 @@ int DoMain() {
 
   simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
   simulator.Initialize();
-  simulator.StepTo(10);
+  simulator.AdvanceTo(10);
 
   // Adds a numerical test to make sure we're stabilizing the fixed point.
   DRAKE_DEMAND(is_approx_equal_abstol(state.get_value(),

--- a/examples/pendulum/passive_simulation.cc
+++ b/examples/pendulum/passive_simulation.cc
@@ -53,7 +53,7 @@ int DoMain() {
 
   simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
   simulator.Initialize();
-  simulator.StepTo(10);
+  simulator.AdvanceTo(10);
 
   const double final_energy = pendulum->CalcTotalEnergy(pendulum_context);
 

--- a/examples/pendulum/trajectory_optimization_simulation.cc
+++ b/examples/pendulum/trajectory_optimization_simulation.cc
@@ -120,7 +120,7 @@ int DoMain() {
   systems::Simulator<double> simulator(*diagram);
   simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
   simulator.Initialize();
-  simulator.StepTo(pp_xtraj.end_time());
+  simulator.AdvanceTo(pp_xtraj.end_time());
 
   const auto& pendulum_state =
       PendulumPlant<double>::get_state(diagram->GetSubsystemContext(

--- a/examples/pr2/pr2_passive_simulation.cc
+++ b/examples/pr2/pr2_passive_simulation.cc
@@ -109,7 +109,7 @@ int DoMain() {
   // Start the simulation.
   lcm.StartReceiveThread();
   simulator.Initialize();
-  simulator.StepTo(FLAGS_simulation_sec);
+  simulator.AdvanceTo(FLAGS_simulation_sec);
 
   lcm.StopReceiveThread();
   return 0;

--- a/examples/quadrotor/run_quadrotor_dynamics.cc
+++ b/examples/quadrotor/run_quadrotor_dynamics.cc
@@ -107,7 +107,7 @@ int do_main(int argc, char* argv[]) {
   simulator.reset_integrator<systems::RungeKutta2Integrator<double>>(
       model, max_step_size, &simulator.get_mutable_context());
   simulator.Initialize();
-  simulator.StepTo(FLAGS_duration);
+  simulator.AdvanceTo(FLAGS_duration);
   return 0;
 }
 

--- a/examples/quadrotor/run_quadrotor_lqr.cc
+++ b/examples/quadrotor/run_quadrotor_lqr.cc
@@ -78,7 +78,7 @@ int do_main() {
     // The following accuracy is necessary for the example to satisfy its
     // ending state tolerances.
     simulator.get_mutable_integrator()->set_target_accuracy(5e-5);
-    simulator.StepTo(FLAGS_trial_duration);
+    simulator.AdvanceTo(FLAGS_trial_duration);
 
     // Goal state verification.
     const Context<double>& context = simulator.get_context();

--- a/examples/quadrotor/test/quadrotor_dynamics_test.cc
+++ b/examples/quadrotor/test/quadrotor_dynamics_test.cc
@@ -138,8 +138,8 @@ class QuadrotorTest: public ::testing::Test {
     ge_simulator_->Initialize();
     rb_simulator_->Initialize();
 
-    ge_simulator_->StepTo(t);
-    rb_simulator_->StepTo(t);
+    ge_simulator_->AdvanceTo(t);
+    rb_simulator_->AdvanceTo(t);
   }
 
   VectorX<double> GetState(systems::Simulator<double> *simulator) {

--- a/examples/rimless_wheel/simulate.cc
+++ b/examples/rimless_wheel/simulate.cc
@@ -89,7 +89,7 @@ int DoMain() {
 
   simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
   simulator.get_mutable_context().set_accuracy(FLAGS_accuracy);
-  simulator.StepTo(10);
+  simulator.AdvanceTo(10);
 
   // Check that the state is still inside the expected region (I did not miss
   // any collisions).

--- a/examples/rimless_wheel/test/rimless_wheel_test.cc
+++ b/examples/rimless_wheel/test/rimless_wheel_test.cc
@@ -66,7 +66,7 @@ GTEST_TEST(RimlessWheelTest, StepTest) {
   toe = 0.0;
   double_support = false;
   set_thetadot_to_achieve_energy(rw, steady_state_energy, &context);
-  simulator.StepTo(.2);
+  simulator.AdvanceTo(.2);
   // Theta should now be on the other side of zero.
   EXPECT_LT(state.theta(), 0.0);
   // Should have taken one step forward.
@@ -87,7 +87,7 @@ GTEST_TEST(RimlessWheelTest, StepTest) {
   set_thetadot_to_achieve_energy(rw, steady_state_energy, &context);
   state.set_thetadot(state.thetadot() + 0.2);
   double initial_energy = rw.CalcTotalEnergy(context);
-  simulator.StepTo(.2);
+  simulator.AdvanceTo(.2);
   // Theta should now be on the other side of zero.
   EXPECT_LT(state.theta(), 0.0);
   // Should have taken one step forward.
@@ -103,7 +103,7 @@ GTEST_TEST(RimlessWheelTest, StepTest) {
   set_thetadot_to_achieve_energy(rw, steady_state_energy, &context);
   state.set_thetadot(state.thetadot() - 0.2);
   initial_energy = rw.CalcTotalEnergy(context);
-  simulator.StepTo(.2);
+  simulator.AdvanceTo(.2);
   // Theta should now be on the other side of zero.
   EXPECT_LT(state.theta(), 0.);
   // Should have taken one step forward.
@@ -119,7 +119,7 @@ GTEST_TEST(RimlessWheelTest, StepTest) {
   toe = 0.0;
   double_support = false;
   initial_energy = rw.CalcTotalEnergy(context);
-  simulator.StepTo(.2);
+  simulator.AdvanceTo(.2);
   // Theta should now be on the other side of zero.
   EXPECT_GT(state.theta(), 0.);
   // Should have taken one step backward.
@@ -156,7 +156,7 @@ GTEST_TEST(RimlessWheelTest, FixedPointTest) {
   state.set_thetadot(0.0);
   toe = 0.0;
   double_support = false;
-  simulator.StepTo(0.2);
+  simulator.AdvanceTo(0.2);
   EXPECT_TRUE(double_support);
   EXPECT_NEAR(std::abs(state.theta() - params.slope()), alpha, 1e-8);
   EXPECT_EQ(state.thetadot(), 0.0);
@@ -167,7 +167,7 @@ GTEST_TEST(RimlessWheelTest, FixedPointTest) {
   state.set_thetadot(0.0);
   toe = 0.0;
   double_support = false;
-  simulator.StepTo(0.2);
+  simulator.AdvanceTo(0.2);
   EXPECT_TRUE(double_support);
   EXPECT_NEAR(std::abs(state.theta() - params.slope()), alpha, 1e-8);
   EXPECT_EQ(state.thetadot(), 0.0);

--- a/examples/rod2d/rod2d_sim.cc
+++ b/examples/rod2d/rod2d_sim.cc
@@ -143,6 +143,6 @@ int main(int argc, char* argv[]) {
   simulator.set_target_realtime_rate(1.0);
   while (simulator.get_context().get_time() < FLAGS_sim_duration) {
     const double t = simulator.get_context().get_time();
-    simulator.StepTo(std::min(t + 1, FLAGS_sim_duration));
+    simulator.AdvanceTo(std::min(t + 1, FLAGS_sim_duration));
   }
 }

--- a/examples/rod2d/test/rod2d_test.cc
+++ b/examples/rod2d/test/rod2d_test.cc
@@ -821,7 +821,7 @@ TEST_F(Rod2DDiscretizedTest, RodGoesToRest) {
 
   // Integrate forward to a point where the rod should be at rest.
   const double t_final = 10;
-  simulator.StepTo(t_final);
+  simulator.AdvanceTo(t_final);
 
   // Get angular orientation and velocity.
   const auto xd = simulator.get_context().get_discrete_state(0).get_value();
@@ -877,7 +877,7 @@ GTEST_TEST(Rod2DCrossValidationTest, OneStepSolutionSliding) {
   // Integrate forward by a single *large* dt. Note that the update rate
   // is set by the time stepping system, so stepping to dt should yield
   // exactly one step.
-  simulator_ts.StepTo(dt);
+  simulator_ts.AdvanceTo(dt);
   EXPECT_EQ(simulator_ts.get_num_discrete_updates(), 1);
 
   // Manually integrate the continuous state forward for the piecewise DAE
@@ -949,7 +949,7 @@ GTEST_TEST(Rod2DCrossValidationTest, OneStepSolutionSticking) {
   // Integrate forward by a single *large* dt. Note that the update rate
   // is set by the discretized system, so stepping to dt should yield
   // exactly one step.
-  simulator_ts.StepTo(dt);
+  simulator_ts.AdvanceTo(dt);
   EXPECT_EQ(simulator_ts.get_num_discrete_updates(), 1);
 
   // TODO(edrumwri): Manually integrate the continuous state forward for the

--- a/examples/scene_graph/bouncing_ball_run_dynamics.cc
+++ b/examples/scene_graph/bouncing_ball_run_dynamics.cc
@@ -92,7 +92,7 @@ int do_main() {
   simulator.get_mutable_integrator()->set_maximum_step_size(0.002);
   simulator.set_target_realtime_rate(1.f);
   simulator.Initialize();
-  simulator.StepTo(FLAGS_simulation_time);
+  simulator.AdvanceTo(FLAGS_simulation_time);
 
   return 0;
 }

--- a/examples/scene_graph/dev/bouncing_ball_run_dynamics.cc
+++ b/examples/scene_graph/dev/bouncing_ball_run_dynamics.cc
@@ -180,7 +180,7 @@ int do_main() {
   simulator.Initialize();
   simulator.set_publish_every_time_step(false);
   simulator.set_publish_at_initialization(false);
-  simulator.StepTo(FLAGS_simulation_time);
+  simulator.AdvanceTo(FLAGS_simulation_time);
 
   return 0;
 }

--- a/examples/scene_graph/dev/solar_system_run_dynamics.cc
+++ b/examples/scene_graph/dev/solar_system_run_dynamics.cc
@@ -41,7 +41,7 @@ int do_main() {
   simulator.set_publish_every_time_step(false);
   simulator.set_target_realtime_rate(1);
   simulator.Initialize();
-  simulator.StepTo(FLAGS_simulation_time);
+  simulator.AdvanceTo(FLAGS_simulation_time);
 
   return 0;
 }

--- a/examples/scene_graph/solar_system_run_dynamics.cc
+++ b/examples/scene_graph/solar_system_run_dynamics.cc
@@ -40,7 +40,7 @@ int do_main() {
   simulator.set_publish_every_time_step(false);
   simulator.set_target_realtime_rate(1);
   simulator.Initialize();
-  simulator.StepTo(FLAGS_simulation_time);
+  simulator.AdvanceTo(FLAGS_simulation_time);
 
   return 0;
 }

--- a/examples/schunk_wsg/schunk_wsg_simulation.cc
+++ b/examples/schunk_wsg/schunk_wsg_simulation.cc
@@ -92,7 +92,7 @@ int DoMain() {
 
   lcm.StartReceiveThread();
   simulator.Initialize();
-  simulator.StepTo(FLAGS_simulation_sec);
+  simulator.AdvanceTo(FLAGS_simulation_sec);
   lcm.StopReceiveThread();
   return 0;
 }

--- a/examples/schunk_wsg/test/schunk_wsg_lift_test.cc
+++ b/examples/schunk_wsg/test/schunk_wsg_lift_test.cc
@@ -422,7 +422,7 @@ TEST_P(SchunkWsgLiftTest, BoxLiftTest) {
   const double kSimDuration = lift_breaks[lift_breaks.size() - 1] + 1.0;
 
   // Simulation in two pieces -- see notes below on the test for details.
-  simulator.StepTo(kLiftStart);
+  simulator.AdvanceTo(kLiftStart);
 
   // Capture the "initial" positions of the box and the gripper finger as
   // discussed in the test notes below.
@@ -439,7 +439,7 @@ TEST_P(SchunkWsgLiftTest, BoxLiftTest) {
       interim_kinematics_results.get_body_position(finger_index);
 
   // Now run to the end of the simulation.
-  simulator.StepTo(kSimDuration);
+  simulator.AdvanceTo(kSimDuration);
 
   // Extract and log the state of the robot.
   model->CalcOutput(simulator.get_context(), state_output.get());

--- a/examples/schunk_wsg/test/simulated_schunk_wsg_system_test.cc
+++ b/examples/schunk_wsg/test/simulated_schunk_wsg_system_test.cc
@@ -123,7 +123,7 @@ GTEST_TEST(SimulatedSchunkWsgSystemTest, OpenGripper) {
 
   // Simulate for 1 second.  In real life this takes <1 second but this gives
   // time for any bouncy dynamics to settle.
-  simulator.StepTo(1.0);
+  simulator.AdvanceTo(1.0);
 
   // Extract and log the final state of the robot.
   auto final_output = model->AllocateOutput();

--- a/examples/simple_continuous_time_system.cc
+++ b/examples/simple_continuous_time_system.cc
@@ -53,7 +53,7 @@ int main() {
   state[0] = 0.9;
 
   // Simulate for 10 seconds.
-  simulator.StepTo(10);
+  simulator.AdvanceTo(10);
 
   // Make sure the simulation converges to the stable fixed point at x=0.
   DRAKE_DEMAND(state[0] < 1.0e-4);

--- a/examples/simple_discrete_time_system.cc
+++ b/examples/simple_discrete_time_system.cc
@@ -53,7 +53,7 @@ int main() {
   state[0] = 0.99;
 
   // Simulate for 10 seconds.
-  simulator.StepTo(10);
+  simulator.AdvanceTo(10);
 
   // Make sure the simulation converges to the stable fixed point at x=0.
   DRAKE_DEMAND(state[0] < 1.0e-4);

--- a/examples/simple_gripper/simple_gripper.cc
+++ b/examples/simple_gripper/simple_gripper.cc
@@ -381,7 +381,7 @@ int do_main() {
   simulator.set_publish_every_time_step(true);
   simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
   simulator.Initialize();
-  simulator.StepTo(FLAGS_simulation_time);
+  simulator.AdvanceTo(FLAGS_simulation_time);
 
   if (FLAGS_time_stepping) {
     fmt::print("Used time stepping with dt={}\n", FLAGS_max_time_step);

--- a/examples/simple_mixed_continuous_and_discrete_time_system.cc
+++ b/examples/simple_mixed_continuous_and_discrete_time_system.cc
@@ -73,7 +73,7 @@ int main() {
   xc[0] = 0.9;  // xc(0)
 
   // Simulate for 10 seconds.
-  simulator.StepTo(10);
+  simulator.AdvanceTo(10);
 
   // Make sure the simulation converges to the stable fixed point at x=0.
   DRAKE_DEMAND(xd[0] < 1.0e-4);

--- a/examples/valkyrie/test/valkyrie_simulation_test.cc
+++ b/examples/valkyrie/test/valkyrie_simulation_test.cc
@@ -49,7 +49,7 @@ GTEST_TEST(ValkyrieSimulationTest, TestIfRuns) {
   plant->set_state_vector(&plant_context, initial_state);
   lcm.StartReceiveThread();
 
-  simulator.StepTo(0.01);
+  simulator.AdvanceTo(0.01);
 }
 
 }  // namespace valkyrie

--- a/examples/valkyrie/valkyrie_simulation.cc
+++ b/examples/valkyrie/valkyrie_simulation.cc
@@ -50,7 +50,7 @@ int main() {
   plant->set_state_vector(&plant_context, initial_state);
   lcm.StartReceiveThread();
 
-  simulator.StepTo(std::numeric_limits<double>::infinity());
+  simulator.AdvanceTo(std::numeric_limits<double>::infinity());
 
   lcm.StopReceiveThread();
   return 0;

--- a/examples/van_der_pol/van_der_pol.cc
+++ b/examples/van_der_pol/van_der_pol.cc
@@ -56,7 +56,7 @@ Eigen::Matrix2Xd VanDerPolOscillator<T>::CalcLimitCycle() {
 
   // Simulate for the approximate period (acquired by inspection of numerical
   // simulation results) of the cycle for μ=1.
-  simulator.StepTo(6.667);
+  simulator.AdvanceTo(6.667);
 
   return logger->data();
 }

--- a/manipulation/schunk_wsg/test/schunk_wsg_controller_test.cc
+++ b/manipulation/schunk_wsg/test/schunk_wsg_controller_test.cc
@@ -34,7 +34,7 @@ std::pair<double, double> RunWsgControllerTestStep(
   wsg_state_vec(1) = (wsg_position / 1e3) / 2.;
   context->FixInputPort(dut.GetInputPort("state").get_index(), wsg_state_vec);
   systems::Simulator<double> simulator(dut, std::move(context));
-  simulator.StepTo(1.0);
+  simulator.AdvanceTo(1.0);
   dut.CalcOutput(simulator.get_context(), output.get());
   return {output->get_vector_data(0)->GetAtIndex(0),
           output->get_vector_data(0)->GetAtIndex(1)};

--- a/manipulation/schunk_wsg/test/schunk_wsg_position_controller_test.cc
+++ b/manipulation/schunk_wsg/test/schunk_wsg_position_controller_test.cc
@@ -100,7 +100,7 @@ GTEST_TEST(SchunkWsgPositionControllerTest, SimTest) {
 
   auto wsg_state = wsg->GetMutablePositionsAndVelocities(&wsg_context);
   wsg_state = Vector4d::Zero();
-  simulator.StepTo(1.0);
+  simulator.AdvanceTo(1.0);
 
   const double kTolerance = 1e-12;
 
@@ -119,7 +119,7 @@ GTEST_TEST(SchunkWsgPositionControllerTest, SimTest) {
   force_limit = 20;
   FixInputsAndHistory(*controller, desired_position, force_limit,
                       &controller_context);
-  simulator.StepTo(2.0);
+  simulator.AdvanceTo(2.0);
   EXPECT_TRUE(CompareMatrices(
       wsg_state,
       Vector4d(-desired_position / 2, desired_position / 2, 0.0, 0.0),
@@ -134,7 +134,7 @@ GTEST_TEST(SchunkWsgPositionControllerTest, SimTest) {
   force_limit = 20;
   FixInputsAndHistory(*controller, desired_position, force_limit,
                       &controller_context);
-  simulator.StepTo(3.0);
+  simulator.AdvanceTo(3.0);
   EXPECT_NEAR(controller->get_grip_force_output_port().
                   Eval(controller_context)[0],
               force_limit, kTolerance);

--- a/manipulation/schunk_wsg/test/schunk_wsg_trajectory_generator_test.cc
+++ b/manipulation/schunk_wsg/test/schunk_wsg_trajectory_generator_test.cc
@@ -34,13 +34,13 @@ GTEST_TEST(SchunkWsgTrajectoryGeneratorTest, BasicTest) {
   // trajectory wider than zero, but not to the target yet.
   const double expected_target = -0.05;  // 50mm
   systems::Simulator<double> simulator(dut, std::move(context));
-  simulator.StepTo(0.1);
+  simulator.AdvanceTo(0.1);
   dut.CalcOutput(simulator.get_context(), output.get());
   EXPECT_LT(output->get_vector_data(0)->GetAtIndex(0), 0);
   EXPECT_GT(output->get_vector_data(0)->GetAtIndex(0), expected_target);
 
   // Step quite a bit longer and see that we get there.
-  simulator.StepTo(2.0);
+  simulator.AdvanceTo(2.0);
   dut.CalcOutput(simulator.get_context(), output.get());
   EXPECT_FLOAT_EQ(output->get_vector_data(0)->GetAtIndex(0), expected_target);
 }

--- a/manipulation/util/geometry_inspector.py
+++ b/manipulation/util/geometry_inspector.py
@@ -122,10 +122,10 @@ def main():
 
     if args.test:
         sliders.window.withdraw()
-        simulator.StepTo(0.1)
+        simulator.AdvanceTo(0.1)
     else:
         simulator.set_target_realtime_rate(1.0)
-        simulator.StepTo(np.inf)
+        simulator.AdvanceTo(np.inf)
 
 
 if __name__ == '__main__':

--- a/multibody/plant/test/box_test.cc
+++ b/multibody/plant/test/box_test.cc
@@ -106,7 +106,7 @@ GTEST_TEST(Box, UnderStiction) {
   Simulator<double> simulator(*diagram, std::move(diagram_context));
   simulator.set_publish_every_time_step(true);
   simulator.Initialize();
-  simulator.StepTo(simulation_time);
+  simulator.AdvanceTo(simulation_time);
 
   auto VerifyContactResults = [&](const MultibodyPlant<double>& the_plant,
                                   const Context<double>& the_context) {

--- a/multibody/plant/test/floating_body_test.cc
+++ b/multibody/plant/test/floating_body_test.cc
@@ -163,7 +163,7 @@ GTEST_TEST(QuaternionFloatingMobilizer, Simulation) {
   EXPECT_EQ(integrator->get_target_accuracy(), kAccuracy);
 
   // Simulate:
-  simulator.StepTo(kEndTime);
+  simulator.AdvanceTo(kEndTime);
 
   // Get solution:
   const math::RigidTransformd X_WB =

--- a/multibody/plant/test/inclined_plane_test.cc
+++ b/multibody/plant/test/inclined_plane_test.cc
@@ -121,7 +121,7 @@ TEST_P(InclinedPlaneTest, RollingSphereTest) {
   integrator->set_target_accuracy(target_accuracy);
   simulator.set_publish_every_time_step(true);
   simulator.Initialize();
-  simulator.StepTo(simulation_time);
+  simulator.AdvanceTo(simulation_time);
 
   // Compute the kinetic energy of B (in frame W) from V_WB.
   const SpatialVelocity<double>& V_WB =

--- a/multibody/plant/test/joint_limits_test.cc
+++ b/multibody/plant/test/joint_limits_test.cc
@@ -90,7 +90,7 @@ GTEST_TEST(JointLimitsTest, PrismaticJointConvergenceTest) {
       plant.get_actuation_input_port().get_index(),
       Vector1<double>::Constant(-10.0));
     simulator.Initialize();
-    simulator.StepTo(simulation_time);
+    simulator.AdvanceTo(simulation_time);
 
     // We expect a second order convergence with the time step. That is, we
     // expect the error to be lower than:
@@ -108,7 +108,7 @@ GTEST_TEST(JointLimitsTest, PrismaticJointConvergenceTest) {
       plant.get_actuation_input_port().get_index(),
       Vector1<double>::Constant(10.0));
     context.set_time(0.0);
-    simulator.StepTo(simulation_time);
+    simulator.AdvanceTo(simulation_time);
 
     // Verify we are at rest near the upper limit.
     EXPECT_NEAR(slider.get_translation(context), slider.position_upper_limit(),
@@ -166,7 +166,7 @@ GTEST_TEST(JointLimitsTest, RevoluteJoint) {
       plant.get_actuation_input_port().get_index(),
       Vector1<double>::Constant(1.5));
     simulator.Initialize();
-    simulator.StepTo(simulation_time);
+    simulator.AdvanceTo(simulation_time);
 
     // We expect a second order convergence with the time step. That is, we
     // expect the error to be lower than:
@@ -184,7 +184,7 @@ GTEST_TEST(JointLimitsTest, RevoluteJoint) {
       plant.get_actuation_input_port().get_index(),
       Vector1<double>::Constant(-1.5));
     context.set_time(0.0);
-    simulator.StepTo(simulation_time);
+    simulator.AdvanceTo(simulation_time);
 
     // Verify we are at rest near the lower limit.
     EXPECT_NEAR(pin.get_angle(context), pin.position_lower_limit(),
@@ -267,7 +267,7 @@ GTEST_TEST(JointLimitsTest, KukaArm) {
     plant.get_actuation_input_port().get_index(),
     VectorX<double>::Constant(nq, 0.4));
   simulator.Initialize();
-  simulator.StepTo(simulation_time);
+  simulator.AdvanceTo(simulation_time);
 
   for (int joint_number = 1; joint_number <= nq; ++joint_number) {
     const std::string joint_name = "iiwa_joint_" + std::to_string(joint_number);
@@ -285,7 +285,7 @@ GTEST_TEST(JointLimitsTest, KukaArm) {
     VectorX<double>::Constant(nq, -0.4));
   plant.SetDefaultContext(&context);
   context.set_time(0.0);
-  simulator.StepTo(simulation_time);
+  simulator.AdvanceTo(simulation_time);
   for (int joint_number = 1; joint_number <= nq; ++joint_number) {
     const std::string joint_name = "iiwa_joint_" + std::to_string(joint_number);
     const auto& joint = plant.GetJointByName<RevoluteJoint>(joint_name);

--- a/multibody/plant/test/spring_mass_system_test.cc
+++ b/multibody/plant/test/spring_mass_system_test.cc
@@ -142,7 +142,7 @@ TEST_F(SpringMassSystemTest, UnDampedCase) {
   slider_->set_translation_rate(&context, 0.0);
   simulator.Initialize();
   simulator.get_mutable_integrator()->set_target_accuracy(integration_accuracy);
-  simulator.StepTo(simulation_time);
+  simulator.AdvanceTo(simulation_time);
 
   const double x_analytic = CalcAnalyticSolution(
       period, damping_ratio, amplitude, 0.0, simulation_time);
@@ -173,7 +173,7 @@ TEST_F(SpringMassSystemTest, UnderDampedCase) {
   slider_->set_translation_rate(&context, 0.0);
   simulator.Initialize();
   simulator.get_mutable_integrator()->set_target_accuracy(integration_accuracy);
-  simulator.StepTo(simulation_time);
+  simulator.AdvanceTo(simulation_time);
 
   const double x_analytic = CalcAnalyticSolution(
       period, damping_ratio, amplitude, 0.0, simulation_time);
@@ -204,7 +204,7 @@ TEST_F(SpringMassSystemTest, OverDampedCase) {
   slider_->set_translation_rate(&context, 0.0);
   simulator.Initialize();
   simulator.get_mutable_integrator()->set_target_accuracy(integration_accuracy);
-  simulator.StepTo(simulation_time);
+  simulator.AdvanceTo(simulation_time);
 
   const double x_analytic = CalcAnalyticSolution(
       period, damping_ratio, amplitude, 0.0, simulation_time);

--- a/multibody/tree/test/free_rotating_body_test.cc
+++ b/multibody/tree/test/free_rotating_body_test.cc
@@ -83,7 +83,7 @@ GTEST_TEST(RollPitchYawTest, TimeDerivatives) {
   EXPECT_EQ(integrator->get_target_accuracy(), kAccuracy);
 
   // Simulate:
-  simulator.StepTo(kEndTime);
+  simulator.AdvanceTo(kEndTime);
 
   // Get solution:
   math::RigidTransformd X_WB = free_body_plant.CalcPoseInWorldFrame(context);

--- a/systems/analysis/integrator_base.h
+++ b/systems/analysis/integrator_base.h
@@ -562,7 +562,7 @@ class IntegratorBase {
    * @return The reason for the integration step ending.
    * @warning Users should generally not call this function directly; within
    *          simulation circumstances, users will typically call
-   *          `Simulator::StepTo()`. In other circumstances, users will
+   *          `Simulator::AdvanceTo()`. In other circumstances, users will
    *          typically call
    *          `IntegratorBase::IntegrateWithMultipleStepsToTime()`.
    *
@@ -590,7 +590,7 @@ class IntegratorBase {
   /// discontinuous, mid-interval updates. This method will step the integrator
   /// multiple times, as necessary, to attain requested error tolerances and
   /// to ensure the integrator converges.
-  /// @warning Users should simulate systems using `Simulator::StepTo()` in
+  /// @warning Users should simulate systems using `Simulator::AdvanceTo()` in
   ///          place of this function (which was created for off-simulation
   ///          purposes), generally.
   /// @param t_final The current or future time to integrate to.
@@ -631,7 +631,7 @@ class IntegratorBase {
   /// semantics of this function, error controlled integration is not supported
   /// (though error estimates will be computed for integrators that support that
   /// feature), which is a minimal requirement for "consistency".
-  /// @warning Users should simulate systems using `Simulator::StepTo()` in
+  /// @warning Users should simulate systems using `Simulator::AdvanceTo()` in
   ///          place of this function (which was created for off-simulation
   ///          purposes), generally.
   /// @param t_target The current or future time to integrate to.
@@ -1927,12 +1927,12 @@ typename IntegratorBase<T>::StepResult
   // and boundary times, may both conceptually be deemed events, the distinction
   // is made for a reason. If both an update and a boundary time occur
   // simultaneously, the following behavior should result:
-  // (1) kReachedUpdateTime is returned, (2) Simulator::StepTo() performs the
+  // (1) kReachedUpdateTime is returned, (2) Simulator::AdvanceTo() performs the
   // necessary update, (3) IntegrateNoFurtherThanTime() is called with
   // boundary_time equal to the current time in the context and returns
   // kReachedBoundaryTime, and (4) the simulation terminates. This sequence of
   // operations will ensure that the simulation state is valid if
-  // Simulator::StepTo() is called again to advance time further.
+  // Simulator::AdvanceTo() is called again to advance time further.
 
   // We now analyze the following simultaneous cases with respect to Simulator:
   //
@@ -1947,18 +1947,18 @@ typename IntegratorBase<T>::StepResult
   // { publish, boundary time, max step }
   // kReachedPublishTime will be returned, a publish will be performed followed
   // by another call to this function, which should return kReachedBoundaryTime
-  // (followed in rapid succession by StepTo(.) return).
+  // (followed in rapid succession by AdvanceTo(.) return).
   //
   // { publish, boundary time, max step }
   // kReachedPublishTime will be returned, a publish will be performed followed
   // by another call to this function, which should return kReachedBoundaryTime
-  // (followed in rapid succession by StepTo(.) return).
+  // (followed in rapid succession by AdvanceTo(.) return).
   //
   // { publish, update, boundary time, maximum step size }
   // kUpdateTimeReached will be returned, an update followed by a publish
   // will then be performed followed by another call to this function, which
   // should return kReachedBoundaryTime (followed in rapid succession by
-  // StepTo(.) return).
+  // AdvanceTo(.) return).
 
   // By default, the target time is that of the the next discrete update event.
   StepResult candidate_result = IntegratorBase<T>::kReachedUpdateTime;

--- a/systems/analysis/monte_carlo.cc
+++ b/systems/analysis/monte_carlo.cc
@@ -15,7 +15,7 @@ double RandomSimulation(const SimulatorFactory& make_simulator,
   const System<double>& system = simulator->get_system();
   system.SetRandomContext(&simulator->get_mutable_context(), generator);
 
-  simulator->StepTo(final_time);
+  simulator->AdvanceTo(final_time);
 
   return output(system, simulator->get_context());
 }

--- a/systems/analysis/monte_carlo.h
+++ b/systems/analysis/monte_carlo.h
@@ -51,7 +51,7 @@ typedef std::function<double(const System<double>& system,
  * @code
  *   simulator = make_simulator(generator)
  *   simulator.get_system().SetRandomContext(generator)
- *   simulator.StepTo(final_time)
+ *   simulator.AdvanceTo(final_time)
  *   return output(simulator.get_context())
  * @endcode
  *

--- a/systems/analysis/simulator.cc
+++ b/systems/analysis/simulator.cc
@@ -35,7 +35,7 @@ double Simulator<T>::get_actual_realtime_rate() const {
 template <typename T>
 void Simulator<T>::ResetStatistics() {
   integrator_->ResetStatistics();
-  num_substeps_taken_ = 0;
+  num_steps_taken_ = 0;
   num_discrete_updates_ = 0;
   num_unrestricted_updates_ = 0;
   num_publishes_ = 0;

--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -93,15 +93,13 @@ value of an individual partition at a particular stage of the stepping
 algorithm.
 
 The following pseudocode uses the above notation to describe the algorithm
-"Advance()" that the %Simulator uses to incrementally advance the system
-trajectory (time t and state x). We refer to such an advancement as a "substep"
-to make it clear that we are not talking about a StepTo() call, which may cause
-many substeps to occur. (We'll define StepTo() in terms of Advance() below.) In
-general, the length of a substep is not known a priori and is determined by
-the Advance() algorithm. Each substep consists of zero or more unrestricted
-updates, followed by zero or more discrete updates, followed by (possibly
-zero-length) continuous time and state advancement, followed by zero or more
-publishes.
+"Step()" that the %Simulator uses to incrementally advance the system
+trajectory (time t and state x). The Simulator's AdvanceTo() method will be
+defined in terms of Step below. In general, the length of a step is not known a
+priori and is determined by the Step() algorithm. Each step consists of zero or
+more unrestricted updates, followed by zero or more discrete updates, followed
+by (possibly zero-length) continuous time and state advancement, followed by
+zero or more publishes.
 
 The pseudocode will clarify the effects on time and state of each of the update
 stages above. This algorithm is given a starting Context value `{tₛ, x⁻(tₛ)}`
@@ -110,7 +108,7 @@ given tₘₐₓ.
 ```
 // Advance the trajectory (time and state) from start value {tₛ, x⁻(tₛ)} to an
 // end value {tₑ, x⁻(tₑ)}, where tₛ ≤ tₑ ≤ tₘₐₓ.
-procedure Advance(tₛ, x⁻(tₛ), tₘₐₓ)
+procedure Step(tₛ, x⁻(tₛ), tₘₐₓ)
 
   // Update any variables (no restrictions).
   x*(tₛ) ← DoAnyUnrestrictedUpdates(tₛ, x⁻(tₛ))
@@ -149,22 +147,29 @@ procedure Advance(tₛ, x⁻(tₛ), tₘₐₓ)
   return {tₑ, x⁻(tₑ)}
 ```
 
-We can use the notation and pseudocode to flesh out the StepTo() and
-Initialize() functions:
+We can use the notation and pseudocode to flesh out the AdvanceTo(),
+AdvancePendingEvents(), and Initialize() functions:
 ```
 // Advance the simulation until time tₘₐₓ.
-procedure StepTo(tₘₐₓ)
+procedure AdvanceTo(tₘₐₓ)
   t ← current_time
   while t < tₘₐₓ
-    {tₑ, x⁻(tₑ)} ← Advance(t, x⁻(t), tₘₐₓ)
+    {tₑ, x⁻(tₑ)} ← Step(t, x⁻(t), tₘₐₓ)
     {t, x⁻(t)} ← {tₑ, x⁻(tₑ)}
   endwhile
 
+// AdvancePendingEvents() is an advanced method, not commonly used.
+// Perform just the start-of-step update to advance from x⁻(t) to x⁺(t).
+procedure AdvancePendingEvents()
+  t ≜ current_time, x⁻(t) ≜ current_state
+  x⁺(t) ← DoAnyPendingUpdates(t, x⁻(t)) as in Step()
+  x(t) ← x⁺(t)  // No continuous update needed.
+
 // Update time and state to {t₀, x⁻(t₀)}, which is the starting value of the
 // trajectory, and thus the value the Context should contain at the start of the
-// first simulation substep.
+// first simulation step.
 procedure Initialize(t₀, x₀)
-  x⁺(t₀) ← DoAnyUpdates as in Advance()
+  x⁺(t₀) ← DoAnyInitializationUpdates as in Step()
   x⁻(t₀) ← x⁺(t₀)  // No continuous update needed.
 
   // ----------------------------------
@@ -173,11 +178,11 @@ procedure Initialize(t₀, x₀)
 
   DoAnyPublishes(t₀, x⁻(t₀))
 ```
-Initialize() can be viewed as a "0ᵗʰ substep" that occurs before the first
-Advance() substep as described above. Like Advance(), Initialize() first
+Initialize() can be viewed as a "0ᵗʰ step" that occurs before the first
+Step() call as described above. Like Step(), Initialize() first
 performs pending updates (in this case only initialization events can be
 "pending"). Time doesn't advance so there is no continuous update phase and
-witnesses cannot trigger. Finally, again like Advance(), the initial trajectory
+witnesses cannot trigger. Finally, again like Step(), the initial trajectory
 point `{t₀, x⁻(t₀)}` is provided to the handlers for any triggered publish
 events. That includes initialization publish events, per-step publish events,
 and periodic or timed publish events that trigger at t₀.
@@ -191,9 +196,6 @@ available to link against in the containing library:
 
 Other instantiations are permitted but take longer to compile.
 */
-
-// TODO(sherm1) When API stabilizes, should list the methods above in addition
-// to describing them.
 template <typename T>
 class Simulator {
  public:
@@ -222,6 +224,9 @@ class Simulator {
   Simulator(std::unique_ptr<const System<T>> system,
             std::unique_ptr<Context<T>> context = nullptr);
 
+  // TODO(sherm1) Make Initialize() attempt to satisfy constraints.
+  // TODO(sherm1) Add a ReInitialize() or Resume() method that is called
+  //              automatically by AdvanceTo() if the Context has changed.
   /// Prepares the %Simulator for a simulation. In order, the sequence of
   /// actions taken here are:
   /// - The active integrator's Initialize() method is invoked.
@@ -236,12 +241,13 @@ class Simulator {
   /// See the class documentation for more information. We recommend calling
   /// Initialize() explicitly prior to beginning a simulation so that error
   /// conditions will be discovered early. However, Initialize() will be called
-  /// automatically by the first StepTo() call if it hasn't already been called.
+  /// automatically by the first AdvanceTo() call if it hasn't already been
+  /// called.
   ///
   /// @note If you make a change to the Context or to Simulator options between
-  /// StepTo() calls you should consider whether to call Initialize() before
-  /// resuming; StepTo() will not do that automatically for you. Whether to do
-  /// so depends on whether you want the above initialization operations
+  /// AdvanceTo() calls you should consider whether to call Initialize() before
+  /// resuming; AdvanceTo() will not do that automatically for you. Whether to
+  /// do so depends on whether you want the above initialization operations
   /// performed. For example, if you changed the time you will likely want the
   /// time-triggered events to be recalculated in case one is due at the new
   /// starting time.
@@ -253,9 +259,7 @@ class Simulator {
   /// This method will throw `std::logic_error` if the combination of options
   /// doesn't make sense. Other failures are possible from the System and
   /// integrator in use.
-  // TODO(sherm1) Make Initialize() attempt to satisfy constraints.
-  // TODO(sherm1) Add a ReInitialize() or Resume() method that is called
-  //              automatically by StepTo() if the Context has changed.
+  /// @see AdvanceTo(), AdvancePendingEvents()
   void Initialize();
 
   /// Advances the System's trajectory until `boundary_time` is reached in
@@ -266,20 +270,47 @@ class Simulator {
   /// and display the `what()` message.
   ///
   /// We recommend that you call Initialize() prior to making the first call
-  /// to StepTo(). However, if you don't it will be called for you the first
+  /// to AdvanceTo(). However, if you don't it will be called for you the first
   /// time that you attempt a step, possibly resulting in unexpected error
   /// conditions. See documentation for `Initialize()` for the error conditions
   /// it might produce.
   ///
   /// @warning You should consider calling Initialize() if you alter the
-  /// the Context or Simulator options between successive StepTo() calls. See
+  /// the Context or Simulator options between successive AdvanceTo() calls. See
   /// Initialize() for more information.
   ///
   /// @param boundary_time The time to advance the context to.
   /// @pre The internal Context satisfies all System constraints or will after
   ///      pending Context updates are performed.
-  void StepTo(const T& boundary_time);
+  /// @see Initialize(), AdvancePendingEvents()
+  void AdvanceTo(const T &boundary_time);
 
+  /// (Advanced) Handles discrete and abstract state update events that are
+  /// pending from the previous AdvanceTo() call, without advancing time.
+  /// See the %Simulator class description for details about how %Simulator
+  /// advances time and handles events. In the terminology used there, this
+  /// method advances the internal Context from `{t, x⁻(t)}` to `{t, x⁺(t)}`.
+  ///
+  /// Normally, these update events would be handled at the start of the next
+  /// AdvanceTo() call, so this method is rarely needed. It can be useful
+  /// at the end of a simulation or to get intermediate results when you are
+  /// specifically interested in the `x⁺(t)` result.
+  ///
+  /// This method is equivalent to `AdvanceTo(current_time)`, where
+  /// `current_time=simulator.get_context().get_time())`. If there are no
+  /// pending events, nothing happens.
+  /// @see AdvanceTo(), Initialize()
+  void AdvancePendingEvents() {
+    AdvanceTo(get_context().get_time());
+  }
+
+#ifndef DRAKE_DOXYGEN_CXX
+  // To be deprecated -- use AdvanceTo() instead.
+  void StepTo(const T& boundary_time) { AdvanceTo(boundary_time); }
+#endif
+
+  // TODO(sherm1): Provide options for issuing a warning or aborting the
+  // simulation if the desired rate cannot be achieved.
   /// Slow the simulation down to *approximately* synchronize with real time
   /// when it would otherwise run too fast. Normally the %Simulator takes steps
   /// as quickly as it can. You can request that it slow down to synchronize
@@ -303,8 +334,6 @@ class Simulator {
   ///   run twice as fast as real time, 0.5 for half speed, etc. Zero or
   ///   negative restores the rate to its default of 0, meaning the simulation
   ///   will proceed as fast as possible.
-  // TODO(sherm1): Provide options for issuing a warning or aborting the
-  // simulation if the desired rate cannot be achieved.
   void set_target_realtime_rate(double realtime_rate) {
     target_realtime_rate_ = std::max(realtime_rate, 0.);
   }
@@ -338,7 +367,7 @@ class Simulator {
   double get_actual_realtime_rate() const;
 
   /// Sets whether the simulation should trigger a forced-Publish event on the
-  /// System under simulation at the end of every trajectory-advancing substep.
+  /// System under simulation at the end of every trajectory-advancing step.
   /// Specifically, that means the System::Publish() event dispatcher will be
   /// invoked on each subsystem of the System and passed the current Context
   /// and a forced-publish Event. If a subsystem has declared a forced-publish
@@ -421,9 +450,10 @@ class Simulator {
   /// ResetStatistics() call.
   int64_t get_num_publishes() const { return num_publishes_; }
 
-  /// Gets the number of substeps since the last Initialize() call. (We're
-  /// not counting the Initialize() 0-length "substep".)
-  int64_t get_num_steps_taken() const { return num_substeps_taken_; }
+  /// Gets the number of steps since the last Initialize() call. (We're
+  /// not counting the Initialize() 0-length "step".) Note that every
+  /// AdvanceTo() call can potentially take many steps.
+  int64_t get_num_steps_taken() const { return num_steps_taken_; }
 
   /// Gets the number of discrete variable updates performed since the last
   /// Initialize() call.
@@ -586,8 +616,8 @@ class Simulator {
   // The number of publishes since the last statistics reset.
   int64_t num_publishes_{0};
 
-  // The number of integration substeps since the last statistics reset.
-  int64_t num_substeps_taken_{0};
+  // The number of integration steps since the last statistics reset.
+  int64_t num_steps_taken_{0};
 
   // Set by Initialize() and reset by various traumas.
   bool initialization_done_{false};
@@ -600,7 +630,7 @@ class Simulator {
   bool redetermine_active_witnesses_{true};
 
   // Per step events that are to be handled on every "major time step" (i.e.,
-  // every successful completion of a substep). This collection is constructed
+  // every successful completion of a step). This collection is constructed
   // within Initialize().
   std::unique_ptr<CompositeEventCollection<T>> per_step_events_;
 
@@ -609,15 +639,15 @@ class Simulator {
   std::unique_ptr<CompositeEventCollection<T>> timed_events_;
 
   // Witnessed events are triggered as a witness function crosses zero during
-  // StepTo(). This collection is constructed within Initialize().
+  // AdvanceTo(). This collection is constructed within Initialize().
   std::unique_ptr<CompositeEventCollection<T>> witnessed_events_;
 
   // Indicates when a timed or witnessed event needs to be handled on the next
-  // call to StepTo().
+  // call to AdvanceTo().
   bool timed_or_witnessed_event_triggered_{false};
 
   // The time that the next timed event is to be handled. This value is set in
-  // both Initialize() and StepTo().
+  // both Initialize() and AdvanceTo().
   T next_timed_event_time_{std::numeric_limits<double>::quiet_NaN()};
 
   // Pre-allocated temporaries for updated discrete states.
@@ -848,15 +878,8 @@ void Simulator<T>::HandlePublish(
   }
 }
 
-// TODO(edrumwri): Consider adding a special function to "complete" a simulation
-//                 by calling, in effect, StepTo(get_context().get_time()) to
-//                 process any events that have triggered but not been processed
-//                 at the conclusion to a StepTo() call. At the present time, we
-//                 believe the issue of remaining, unprocessed events is rarely
-//                 likely to be important and can be circumvented in multiple
-//                 ways, like calling StepTo(get_context().get_time()).
 template <typename T>
-void Simulator<T>::StepTo(const T& boundary_time) {
+void Simulator<T>::AdvanceTo(const T &boundary_time) {
   if (!initialization_done_) Initialize();
 
   DRAKE_THROW_UNLESS(boundary_time >= context_->get_time());
@@ -878,9 +901,9 @@ void Simulator<T>::StepTo(const T& boundary_time) {
   }
 
   while (true) {
-    // Starting a new substep on the trajectory.
+    // Starting a new step on the trajectory.
     const T step_start_time = context_->get_time();
-    SPDLOG_TRACE(log(), "Starting a simulation substep at {}", step_start_time);
+    SPDLOG_TRACE(log(), "Starting a simulation step at {}", step_start_time);
 
     // Delay to match target realtime rate if requested and possible.
     PauseIfTooFast();
@@ -920,8 +943,8 @@ void Simulator<T>::StepTo(const T& boundary_time) {
         boundary_time,
         witnessed_events_.get());
 
-    // Update the number of simulation substeps taken.
-    ++num_substeps_taken_;
+    // Update the number of simulation steps taken.
+    ++num_steps_taken_;
 
     // TODO(sherm1) Constraint projection goes here.
 

--- a/systems/analysis/test/simulator_test.cc
+++ b/systems/analysis/test/simulator_test.cc
@@ -129,7 +129,7 @@ GTEST_TEST(SimulatorTest, NoUnexpectedDoCalcTimeDerivativesCall) {
   Context<double>& context = simulator.get_mutable_context();
   simulator.reset_integrator<RungeKutta2Integrator<double>>(system, dt,
                                                             &context);
-  simulator.StepTo(final_time);
+  simulator.AdvanceTo(final_time);
 
   // Verify no derivative calculations.
   EXPECT_FALSE(system.was_do_calc_time_derivatives_called());
@@ -151,7 +151,7 @@ GTEST_TEST(SimulatorTest, NoContinuousStateYieldsSingleStep) {
   Context<double>& context = simulator.get_mutable_context();
   simulator.reset_integrator<RungeKutta2Integrator<double>>(system, dt,
       &context);
-  simulator.StepTo(final_time);
+  simulator.AdvanceTo(final_time);
 
   EXPECT_EQ(simulator.get_num_steps_taken(), 1);
 }
@@ -181,7 +181,7 @@ GTEST_TEST(SimulatorTest, DiagramWitness) {
   simulator.set_publish_every_time_step(false);
 
   context.SetTime(0);
-  simulator.StepTo(1);
+  simulator.AdvanceTo(1);
 
   // Publication should occur at witness function crossing.
   EXPECT_EQ(1, num_publishes);
@@ -340,7 +340,7 @@ GTEST_TEST(SimulatorTest, FixedStepNoIsolation) {
 
   Context<double>& context = simulator.get_mutable_context();
   context.get_mutable_continuous_state()[0] = -1;
-  simulator.StepTo(dt);
+  simulator.AdvanceTo(dt);
 
   // Verify that no witness isolation is done.
   EXPECT_FALSE(simulator.GetCurrentWitnessTimeIsolation());
@@ -432,7 +432,7 @@ GTEST_TEST(SimulatorTest, FixedStepIncreasingIsolationAccuracy) {
     context.SetTime(0);
 
     // Simulate to dt.
-    simulator.StepTo(dt);
+    simulator.AdvanceTo(dt);
 
     // CalcWitnessValue the witness function.
     context.SetTime(publish_time);
@@ -497,7 +497,7 @@ GTEST_TEST(SimulatorTest, MultipleWitnesses) {
   context.SetAccuracy(tol);
 
   // Simulate.
-  simulator.StepTo(0.1);
+  simulator.AdvanceTo(0.1);
 
   // We expect exactly two triggerings.
   ASSERT_EQ(triggers.size(), 2);
@@ -549,7 +549,7 @@ GTEST_TEST(SimulatorTest, MultipleWitnessesIdentical) {
   simulator->get_mutable_context().SetAccuracy(tol);
 
   // Simulate.
-  simulator->StepTo(10);
+  simulator->AdvanceTo(10);
 
   // Verify one publish.
   EXPECT_TRUE(published);
@@ -592,7 +592,7 @@ GTEST_TEST(SimulatorTest, MultipleWitnessesStaggered) {
   EXPECT_TRUE(iso_tol);
 
   // Simulate to right after the second one should have triggered.
-  simulator.StepTo(2.1);
+  simulator.AdvanceTo(2.1);
 
   // Verify two publishes.
   EXPECT_EQ(publish_times.size(), 2);
@@ -620,7 +620,7 @@ GTEST_TEST(SimulatorTest, WitnessTestCountSimpleNegToZero) {
   InitFixedStepIntegratorForWitnessTesting(&simulator, dt);
   Context<double>& context = simulator.get_mutable_context();
   context.SetTime(0);
-  simulator.StepTo(1);
+  simulator.AdvanceTo(1);
 
   // Publication should occur at witness function crossing.
   EXPECT_EQ(1, num_publishes);
@@ -644,7 +644,7 @@ GTEST_TEST(SimulatorTest, WitnessTestCountSimpleZeroToPos) {
   InitFixedStepIntegratorForWitnessTesting(&simulator, dt);
   Context<double>& context = simulator.get_mutable_context();
   context.SetTime(0);
-  simulator.StepTo(1);
+  simulator.AdvanceTo(1);
 
   // Verify that no publication is performed when stepping to 1.
   EXPECT_EQ(0, num_publishes);
@@ -667,7 +667,7 @@ GTEST_TEST(SimulatorTest, WitnessTestCountSimplePositiveToNegative) {
   InitFixedStepIntegratorForWitnessTesting(&simulator, dt);
   Context<double>& context = simulator.get_mutable_context();
   context.SetTime(0);
-  simulator.StepTo(2);
+  simulator.AdvanceTo(2);
 
   // Publication should not occur (witness function should initially evaluate
   // to a negative value, then will evolve to a positive value).
@@ -690,7 +690,7 @@ GTEST_TEST(SimulatorTest, WitnessTestCountSimpleNegativeToPositive) {
   InitFixedStepIntegratorForWitnessTesting(&simulator, dt);
   Context<double>& context = simulator.get_mutable_context();
   context.SetTime(-1);
-  simulator.StepTo(1);
+  simulator.AdvanceTo(1);
 
   // Publication should occur at witness function crossing.
   EXPECT_EQ(1, num_publishes);
@@ -713,7 +713,7 @@ GTEST_TEST(SimulatorTest, WitnessTestCountChallenging) {
   InitFixedStepIntegratorForWitnessTesting(&simulator, dt);
   Context<double>& context = simulator.get_mutable_context();
   context.get_mutable_continuous_state()[0] = -1;
-  simulator.StepTo(1e-4);
+  simulator.AdvanceTo(1e-4);
 
   // Publication should occur only at witness function crossing.
   EXPECT_EQ(1, num_publishes);
@@ -820,7 +820,7 @@ GTEST_TEST(SimulatorTest, SpringMassNoSample) {
                                                               &context);
 
   simulator.set_target_realtime_rate(0.5);
-  // Request forced-publishes at every internal substep.
+  // Request forced-publishes at every internal step.
   simulator.set_publish_at_initialization(true);
   simulator.set_publish_every_time_step(true);
 
@@ -828,7 +828,7 @@ GTEST_TEST(SimulatorTest, SpringMassNoSample) {
   simulator.Initialize();
 
   // Simulate for 1 second.
-  simulator.StepTo(1.);
+  simulator.AdvanceTo(1.);
 
   EXPECT_NEAR(context.get_time(), 1., 1e-8);
   EXPECT_EQ(simulator.get_num_steps_taken(), 1000);
@@ -838,7 +838,7 @@ GTEST_TEST(SimulatorTest, SpringMassNoSample) {
   EXPECT_EQ(spring_mass.get_update_count(), 0);
 
   // Current time is 1. An earlier final time should fail.
-  EXPECT_THROW(simulator.StepTo(0.5), std::runtime_error);
+  EXPECT_THROW(simulator.AdvanceTo(0.5), std::runtime_error);
 }
 
 // Test ability to swap integrators mid-stream.
@@ -868,14 +868,14 @@ GTEST_TEST(SimulatorTest, ResetIntegratorTest) {
   simulator.Initialize();
 
   // Simulate for 1/2 second.
-  simulator.StepTo(0.5);
+  simulator.AdvanceTo(0.5);
 
   // Reset the integrator.
   simulator.reset_integrator<RungeKutta2Integrator<double>>(
       simulator.get_system(), dt, &simulator.get_mutable_context());
 
   // Simulate to 1 second..
-  simulator.StepTo(1.);
+  simulator.AdvanceTo(1.);
 
   EXPECT_NEAR(context.get_time(), 1., 1e-8);
 
@@ -894,13 +894,13 @@ GTEST_TEST(SimulatorTest, RealtimeRate) {
   simulator.get_mutable_integrator()->set_maximum_step_size(0.001);
   simulator.get_mutable_context().SetTime(0.);
   simulator.Initialize();
-  simulator.StepTo(1.);  // Simulate for 1 simulated second.
+  simulator.AdvanceTo(1.);  // Simulate for 1 simulated second.
   EXPECT_TRUE(simulator.get_actual_realtime_rate() <= 1.1);
 
   simulator.set_target_realtime_rate(5.);  // No faster than 5X real time.
   simulator.get_mutable_context().SetTime(0.);
   simulator.Initialize();
-  simulator.StepTo(1.);  // Simulate for 1 more simulated second.
+  simulator.AdvanceTo(1.);  // Simulate for 1 more simulated second.
   EXPECT_TRUE(simulator.get_actual_realtime_rate() <= 5.1);
 }
 
@@ -918,7 +918,7 @@ GTEST_TEST(SimulatorTest, DisablePublishEveryTimestep) {
   EXPECT_EQ(1, simulator.get_num_publishes());
 
   // Simulate for 1 simulated second.  Publish should not happen.
-  simulator.StepTo(1.);
+  simulator.AdvanceTo(1.);
   EXPECT_EQ(1, simulator.get_num_publishes());
 }
 
@@ -951,7 +951,7 @@ GTEST_TEST(SimulatorTest, SpringMass) {
   simulator.Initialize();
 
   // Simulate to one second.
-  simulator.StepTo(1.);
+  simulator.AdvanceTo(1.);
 
   EXPECT_GT(simulator.get_num_steps_taken(), 1000);
   EXPECT_EQ(simulator.get_num_discrete_updates(), 30);
@@ -1024,7 +1024,7 @@ GTEST_TEST(SimulatorTest, ExampleDiscreteSystem) {
 
   // Create a Simulator and use it to advance time until t=3*h.
   Simulator<double> simulator(*diagram);
-  simulator.StepTo(3 * ExampleDiscreteSystem::kPeriod);
+  simulator.AdvanceTo(3 * ExampleDiscreteSystem::kPeriod);
 
   testing::internal::CaptureStdout();  // Not in example.
 
@@ -1103,7 +1103,7 @@ GTEST_TEST(SimulatorTest, SinusoidalHybridSystem) {
 
   simulator.get_mutable_context().get_mutable_discrete_state()[0] =
       initial_value;
-  simulator.StepTo(t_final);
+  simulator.AdvanceTo(t_final);
 
   // Set a very tight tolerance value.
   const double eps = 1e-14;
@@ -1196,9 +1196,9 @@ GTEST_TEST(SimulatorTest, SimpleHybridSystemTestOffsetZero) {
   simulator.get_mutable_context().get_mutable_discrete_state()[0] =
       initial_condition;
 
-  // Simulate forward. The first update occurs at t=0, meaning StepTo(1) updates
-  // the discrete state to x⁺(0) (i.e., x_1) before updating time to 1.0.
-  simulator.StepTo(1.0);
+  // Simulate forward. The first update occurs at t=0, meaning AdvanceTo(1)
+  // updates the discrete state to x⁺(0) (i.e., x_1) before updating time to 1.
+  simulator.AdvanceTo(1.0);
 
   // Check that the expected state value was attained. The value should be
   // x_0 + u(0) since we expect the discrete update to occur at t = 0 when
@@ -1319,21 +1319,21 @@ GTEST_TEST(SimulatorTest, SpikeTest) {
   // Test with spike time = 0.
   delta->set_spike_time(0);
   simulator.Initialize();
-  simulator.StepTo(5 * DiscreteInputAccumulator::kPeriod);
+  simulator.AdvanceTo(5 * DiscreteInputAccumulator::kPeriod);
   EXPECT_EQ(hybrid_system->result(), std::vector<double>({0, 1, 1, 1, 1, 1}));
 
   // Test with spike time = 3*h.
   delta->set_spike_time(3 * DiscreteInputAccumulator::kPeriod);
   simulator.get_mutable_context().SetTime(0.);
   simulator.Initialize();
-  simulator.StepTo(5 * DiscreteInputAccumulator::kPeriod);
+  simulator.AdvanceTo(5 * DiscreteInputAccumulator::kPeriod);
   EXPECT_EQ(hybrid_system->result(), std::vector<double>({0, 0, 0, 0, 1, 1}));
 
   // Test with spike time not coinciding with a sample time.
   delta->set_spike_time(2.7 * DiscreteInputAccumulator::kPeriod);
   simulator.get_mutable_context().SetTime(0.);
   simulator.Initialize();
-  simulator.StepTo(5 * DiscreteInputAccumulator::kPeriod);
+  simulator.AdvanceTo(5 * DiscreteInputAccumulator::kPeriod);
   EXPECT_EQ(hybrid_system->result(), std::vector<double>({0, 0, 0, 0, 0, 0}));
 }
 
@@ -1408,7 +1408,7 @@ GTEST_TEST(SimulatorTest, ExactUpdateTime) {
 
   // Simulate forward.
   simulator.Initialize();
-  simulator.StepTo(1.);
+  simulator.AdvanceTo(1.);
 
   // Check that the update occurs at exactly the desired time.
   EXPECT_EQ(updates.size(), 1u);
@@ -1501,7 +1501,7 @@ GTEST_TEST(SimulatorTest, ControlledSpringMass) {
   }
 
   // Simulates to final_time.
-  simulator.StepTo(final_time);
+  simulator.AdvanceTo(final_time);
 
   EXPECT_EQ(simulator.get_num_steps_taken(), 200);
 
@@ -1610,7 +1610,7 @@ GTEST_TEST(SimulatorTest, DiscreteUpdateAndPublish) {
   Simulator<double> simulator(system);
   simulator.set_publish_at_initialization(false);
   simulator.set_publish_every_time_step(false);
-  simulator.StepTo(0.5);
+  simulator.AdvanceTo(0.5);
 
   // Update occurs at 1000Hz, at the beginning of each step (there is no
   // discrete event update during initialization nor a final update at the
@@ -1648,7 +1648,7 @@ GTEST_TEST(SimulatorTest, UpdateThenPublishThenIntegrate) {
   // Run a simulation with per-step forced-publishing enabled.
   simulator.set_publish_at_initialization(true);
   simulator.set_publish_every_time_step(true);
-  simulator.StepTo(0.5);
+  simulator.AdvanceTo(0.5);
 
   // Verify that at least one of each event type was triggered.
   bool triggers[kTypeCount] = { false, false, false };
@@ -1675,7 +1675,7 @@ GTEST_TEST(SimulatorTest, AutodiffBasic) {
   SpringMassSystem<AutoDiffXd> spring_mass(1., 1., 0.);
   Simulator<AutoDiffXd> simulator(spring_mass);
   simulator.Initialize();
-  simulator.StepTo(1);
+  simulator.AdvanceTo(1);
 }
 
 // Verifies that an integrator will stretch its integration step in the case
@@ -1705,7 +1705,7 @@ GTEST_TEST(SimulatorTest, StretchedStep) {
   spring_mass.set_velocity(&simulator.get_mutable_context(), 0);
 
   // Now step.
-  simulator.StepTo(expected_t_final);
+  simulator.AdvanceTo(expected_t_final);
 
   // Verify that the step size was stretched and that exactly one "step" was
   // taken to integrate the continuous variables forward.
@@ -1755,7 +1755,7 @@ GTEST_TEST(SimulatorTest, Issue10443) {
 
   // Simulate.
   const int kTime = 1;
-  simulator.StepTo(static_cast<double>(kTime));
+  simulator.AdvanceTo(static_cast<double>(kTime));
 
   // Should log exactly once every kPeriod, up to and including
   // kTime.
@@ -1790,7 +1790,7 @@ GTEST_TEST(SimulatorTest, NoStretchedStep) {
   spring_mass.set_velocity(&simulator.get_mutable_context(), 0);
 
   // Now step.
-  simulator.StepTo(event_t_final);
+  simulator.AdvanceTo(event_t_final);
 
   // Verify that the step size was not stretched and that exactly two "steps"
   // were taken to integrate the continuous variables forward.
@@ -1896,17 +1896,17 @@ GTEST_TEST(SimulatorTest, StretchedStepPerfectStorm) {
   // Activate exceptions on violating the minimum step size to verify that
   // error control is a limiting factor.
   integrator->set_throw_on_minimum_step_size_violation(true);
-  EXPECT_THROW(simulator.StepTo(expected_t_final), std::runtime_error);
+  EXPECT_THROW(simulator.AdvanceTo(expected_t_final), std::runtime_error);
 
   // Now disable exceptions on violating the minimum step size and step again.
-  // Since we are changing the state between successive StepTo(.) calls, it is
-  // wise to call Initialize() prior to the second call.
+  // Since we are changing the state between successive AdvanceTo(.) calls, it
+  // is wise to call Initialize() prior to the second call.
   simulator.get_mutable_context().SetTime(0);
   spring_mass.set_position(&simulator.get_mutable_context(), 0.1);
   spring_mass.set_velocity(&simulator.get_mutable_context(), 0);
   integrator->set_throw_on_minimum_step_size_violation(false);
   simulator.Initialize();
-  simulator.StepTo(expected_t_final);
+  simulator.AdvanceTo(expected_t_final);
 
   // Verify that the step size was stretched and that exactly one "step" was
   // taken to integrate the continuous variables forward.
@@ -2018,7 +2018,7 @@ GTEST_TEST(SimulatorTest, PerStepAction) {
   sim.set_publish_at_initialization(false);
   sim.set_publish_every_time_step(false);
   sim.Initialize();
-  sim.StepTo(0.1);
+  sim.AdvanceTo(0.1);
 
   const double dt = sim.get_integrator()->get_maximum_step_size();
   const int N = static_cast<int>(0.1 / dt);
@@ -2113,7 +2113,7 @@ GTEST_TEST(SimulatorTest, Initialization) {
 
   InitializationTestSystem sys;
   Simulator<double> simulator(sys);
-  simulator.StepTo(1);
+  simulator.AdvanceTo(1);
 
   EXPECT_TRUE(sys.get_pub_init());
   EXPECT_TRUE(sys.get_dis_update_init());
@@ -2175,12 +2175,12 @@ GTEST_TEST(SimulatorTest, EvalDerivativesCounter) {
   Context<double>& context = simulator.get_mutable_context();
   context.DisableCaching();
   simulator.reset_integrator<WastefulIntegrator>(spring_mass, 0.125, &context);
-  simulator.StepTo(1.);  // 8 steps, but 16 evaluations since no caching.
+  simulator.AdvanceTo(1.);  // 8 steps, but 16 evaluations since no caching.
   EXPECT_EQ(simulator.get_integrator()->get_num_steps_taken(), 8);
   EXPECT_EQ(simulator.get_integrator()->get_num_derivative_evaluations(), 16);
 
   context.EnableCaching();
-  simulator.StepTo(2.);  // 8 more steps, but only 8 more evaluations.
+  simulator.AdvanceTo(2.);  // 8 more steps, but only 8 more evaluations.
   EXPECT_EQ(simulator.get_integrator()->get_num_steps_taken(), 16);
   EXPECT_EQ(simulator.get_integrator()->get_num_derivative_evaluations(), 24);
 }

--- a/systems/controllers/dynamic_programming.cc
+++ b/systems/controllers/dynamic_programming.cc
@@ -94,7 +94,7 @@ FittedValueIteration(
 
       cost[input](state) = timestep * cost_function(context);
 
-      simulator->StepTo(timestep);
+      simulator->AdvanceTo(timestep);
       state_vec = sim_state.CopyToVector();
 
       for (const auto& b : options.periodic_boundary_conditions) {
@@ -224,7 +224,7 @@ Eigen::VectorXd LinearProgrammingApproximateDynamicProgramming(
 
       const double cost = timestep * cost_function(context);
 
-      simulator->StepTo(timestep);
+      simulator->AdvanceTo(timestep);
       next_state_vec = sim_state.CopyToVector();
 
       for (const auto& b : options.periodic_boundary_conditions) {

--- a/systems/controllers/test/linear_model_predictive_controller_test.cc
+++ b/systems/controllers/test/linear_model_predictive_controller_test.cc
@@ -206,7 +206,7 @@ class TestMpcWithCubicSystem : public ::testing::Test {
 
     simulator_->set_target_realtime_rate(1.);
     simulator_->Initialize();
-    simulator_->StepTo(time_horizon_);
+    simulator_->AdvanceTo(time_horizon_);
   }
 
   const double time_step_ = 0.1;

--- a/systems/discrete_systems.h
+++ b/systems/discrete_systems.h
@@ -91,7 +91,7 @@ The following code fragment can be used to step this system forward:
 
   // Create a Simulator and use it to advance time until t=3*h.
   Simulator<double> simulator(*diagram);
-  simulator.StepTo(3 * ExampleDiscreteSystem::kPeriod);
+  simulator.AdvanceTo(3 * ExampleDiscreteSystem::kPeriod);
 
   // Print out the contents of the log.
   for (int n = 0; n < logger->sample_times().size(); ++n) {

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -935,9 +935,9 @@ class LeafSystem : public System<T> {
   /// @name                 Declare per-step events
   /// These methods are used to declare events that are triggered whenever the
   /// Drake Simulator advances the simulated trajectory. Note that each call to
-  /// Simulator::StepTo() typically generates many trajectory-advancing substeps
-  /// of varying time intervals; per-step events are triggered for each of those
-  /// substeps.
+  /// Simulator::AdvanceTo() typically generates many trajectory-advancing
+  /// steps of varying time intervals; per-step events are triggered for each
+  /// of those steps.
   ///
   /// Per-step events are useful for taking discrete action at every point of a
   /// simulated trajectory (generally spaced irregularly in time) without
@@ -958,10 +958,10 @@ class LeafSystem : public System<T> {
   /// method queries and records the set of declared per-step events. That set
   /// does not change during a simulation. Any per-step publish events are
   /// dispatched at the end of Initialize() to publish the initial value of the
-  /// trajectory. Then every StepTo() internal substep dispatches unrestricted
-  /// and discrete update events at the start of the substep, and dispatches
-  /// publish events at the end of the substep (that is, after time advances).
-  /// This means that a per-step event at fixed substep size h behaves
+  /// trajectory. Then every AdvanceTo() internal step dispatches unrestricted
+  /// and discrete update events at the start of the step, and dispatches
+  /// publish events at the end of the step (that is, after time advances).
+  /// This means that a per-step event at fixed step size h behaves
   /// identically to a periodic event of period h, offset 0.
   ///
   /// Template arguments to these methods are inferred from the argument lists
@@ -969,7 +969,7 @@ class LeafSystem : public System<T> {
   //@{
 
   /// Declares that a Publish event should occur at initialization and at the
-  /// end of every trajectory-advancing substep and that it should invoke the
+  /// end of every trajectory-advancing step and that it should invoke the
   /// given event handler method. The handler should be a class member function
   /// (method) with this signature:
   /// @code
@@ -1012,7 +1012,7 @@ class LeafSystem : public System<T> {
   }
 
   /// Declares that a DiscreteUpdate event should occur at the start of every
-  /// trajectory-advancing substep and that it should invoke the given event
+  /// trajectory-advancing step and that it should invoke the given event
   /// handler method. The handler should be a class member function (method)
   /// with this signature:
   /// @code
@@ -1051,7 +1051,7 @@ class LeafSystem : public System<T> {
   }
 
   /// Declares that an UnrestrictedUpdate event should occur at the start of
-  /// every trajectory-advancing substep and that it should invoke the given
+  /// every trajectory-advancing step and that it should invoke the given
   /// event handler method. The handler should be a class member function
   /// (method) with this signature:
   /// @code
@@ -1090,9 +1090,9 @@ class LeafSystem : public System<T> {
   }
 
   /// (Advanced) Declares that a particular Event object should be dispatched at
-  /// every trajectory-advancing substep. Publish events are dispatched at
-  /// the end of initialization and at the end of each substep. Discrete- and
-  /// unrestricted update events are dispatched at the start of each substep.
+  /// every trajectory-advancing step. Publish events are dispatched at
+  /// the end of initialization and at the end of each step. Discrete- and
+  /// unrestricted update events are dispatched at the start of each step.
   /// This is the most general form for declaring per-step events and most users
   /// should use one of the other methods in this group instead.
   ///
@@ -1299,7 +1299,7 @@ class LeafSystem : public System<T> {
   /// or System::CalcUnrestrictedUpdate(const Context&, State<T>*),
   /// rather than as a response to some computation-related event (e.g.,
   /// the beginning of a period of time was reached, a trajectory advancing
-  /// substep was performed, etc.) One useful application of a forced publish:
+  /// step was performed, etc.) One useful application of a forced publish:
   /// a process receives a network message and wants to trigger message
   /// emissions in various systems embedded within a Diagram in response.
   ///

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -797,8 +797,8 @@ class System : public SystemBase {
     return time;
   }
 
-  /// This method is called by Simulator::Initialize() to gather all
-  /// update and publish events that are to be handled in StepTo() at the point
+  /// This method is called by Simulator::Initialize() to gather all update
+  /// and publish events that are to be handled in AdvanceTo() at the point
   /// before Simulator integrates continuous state. It is assumed that these
   /// events remain constant throughout the simulation. The "step" here refers
   /// to the major time step taken by the Simulator. During every simulation

--- a/systems/lcm/lcm_driven_loop.cc
+++ b/systems/lcm/lcm_driven_loop.cc
@@ -64,7 +64,7 @@ void LcmDrivenLoop::RunToSecondsAssumingInitialized(double stop_time) {
     msg_time = time_converter_->GetTimeInSeconds(WaitForMessage());
     if (msg_time >= stop_time) break;
 
-    stepper_->StepTo(msg_time);
+    stepper_->AdvanceTo(msg_time);
 
     // Explicitly publish after we are done with all the intermediate
     // computation.

--- a/systems/lcm/lcm_driven_loop.h
+++ b/systems/lcm/lcm_driven_loop.h
@@ -71,7 +71,7 @@ class UtimeMessageToSeconds : public LcmMessageToTimeInterface {
  * <pre>
  * while(context.time < stop_time) {
  *   msg = wait_for_message("channel");
- *   simulator.StepTo(msg.time);
+ *   simulator.AdvanceTo(msg.time);
  *   if (publish) {
  *     system.Publish(simulator.context);
  *   }
@@ -86,7 +86,7 @@ class UtimeMessageToSeconds : public LcmMessageToTimeInterface {
  * real time. One would observe 200 such actions occur in rapid succession
  * followed by nearly one second of silence. This is because
  * `msg = wait_for_message("channel")` takes about one second in real time,
- * and `simulator.StepTo(msg.time)`, which forwards the simulator's clock by
+ * and `simulator.AdvanceTo(msg.time)`, which forwards the simulator's clock by
  * one second and performs 200 actions takes about 0 seconds in real time.
  * The root cause is that the 200Hz rate of the handler system is tied to the
  * internal virtual clock rather than real time. This problem is less

--- a/systems/lcm/test/lcm_log_playback_test.cc
+++ b/systems/lcm/test/lcm_log_playback_test.cc
@@ -163,7 +163,7 @@ void CheckLog() {
   auto diagram = builder.Build();
 
   Simulator<double> sim(*diagram);
-  sim.StepTo(0.5);
+  sim.AdvanceTo(0.5);
 
   // printer0 should have msg at t = [0.1, 0.3], with val = [1, 5].
   CheckLog({0.1, 0.3}, {1, 5}, "Ch0", printer0->get_received_msgs(),

--- a/systems/lcm/test/lcm_publisher_system_test.cc
+++ b/systems/lcm/test/lcm_publisher_system_test.cc
@@ -251,7 +251,7 @@ GTEST_TEST(LcmPublisherSystemTest, TestPerStepPublish) {
 
   // Ensure that the integrator takes at least a few steps.
   for (double time = 0; time < 1; time += 0.25)
-    simulator.StepTo(time);
+    simulator.AdvanceTo(time);
 
   // Check that we get exactly the number of publishes desired: one (at
   // initialization) plus another for each step.
@@ -290,7 +290,7 @@ GTEST_TEST(LcmPublisherSystemTest, TestPerStepPublishTrigger) {
   // Since there is no internal continuous state for the system, the integrator
   // will not subdivide its steps.
   for (double time = 0.0; time < 1; time += 0.25)
-    simulator.StepTo(time);
+    simulator.AdvanceTo(time);
 
   // Check that we get exactly the number of publishes desired: one (at
   // initialization) plus another for each step.
@@ -356,7 +356,7 @@ GTEST_TEST(LcmPublisherSystemTest, TestPublishPeriod) {
   EXPECT_EQ(transmission_count, 1);
 
   for (double time = 0; time < 4; time += 0.01) {
-    simulator.StepTo(time);
+    simulator.AdvanceTo(time);
     EXPECT_NEAR(simulator.get_mutable_context().get_time(), time, 1e-10);
     // Note that the expected time is in milliseconds.
     const double expected_time =
@@ -402,7 +402,7 @@ GTEST_TEST(LcmPublisherSystemTest, TestPublishPeriodTrigger) {
   EXPECT_EQ(transmission_count, 1);
 
   for (double time = 0.0; time < 4; time += 0.01) {
-    simulator.StepTo(time);
+    simulator.AdvanceTo(time);
     EXPECT_NEAR(simulator.get_mutable_context().get_time(), time, 1e-10);
   }
 
@@ -448,7 +448,7 @@ GTEST_TEST(LcmPublisherSystemTest, TestPublishPeriodDeprecated) {
 
   // Step the simulator to one second.
   const double time = 1.0;
-  simulator.StepTo(time);
+  simulator.AdvanceTo(time);
   EXPECT_NEAR(simulator.get_mutable_context().get_time(), time, 1e-10);
   // Note that the expected time is in milliseconds.
   const double expected_time =

--- a/systems/primitives/test/discrete_derivative_test.cc
+++ b/systems/primitives/test/discrete_derivative_test.cc
@@ -44,7 +44,7 @@ GTEST_TEST(DiscreteDerivativeTest, FirstOrderHold) {
   Simulator<double> simulator(*diagram);
   simulator.set_publish_at_initialization(false);
   simulator.set_publish_every_time_step(false);
-  simulator.StepTo(kDuration);
+  simulator.AdvanceTo(kDuration);
 
   for (int i = 0; i < log->sample_times().size(); i++) {
     if (log->sample_times()(i) == 0.0) {

--- a/systems/primitives/test/discrete_time_delay_test.cc
+++ b/systems/primitives/test/discrete_time_delay_test.cc
@@ -218,20 +218,20 @@ GTEST_TEST(DiscreteTimeDelayTest, DiscreteSimulation) {
   simulator.Initialize();
   EXPECT_EQ(0., eval());  // No update should have occurred yet.
 
-  simulator.StepTo(0);  // Force an update at 0.
+  simulator.AdvancePendingEvents();  // Force an update at 0.
   EXPECT_EQ(0, eval());  // Should output initial value.
 
   // Should output initial value until delay has passed.
-  simulator.StepTo(0.49);
+  simulator.AdvanceTo(0.49);
   EXPECT_EQ(0, eval());
 
   // Should start outputing delayed input.
-  simulator.StepTo(0.5);
-  simulator.StepTo(0.5);
+  simulator.AdvanceTo(0.5);
+  simulator.AdvancePendingEvents();
   EXPECT_NEAR(count_eval(0), eval(), kMachineTol);
 
   // Last sample at 0.9, will output value from 0.4.
-  simulator.StepTo(0.91);
+  simulator.AdvanceTo(0.91);
   EXPECT_NEAR(count_eval(0.4), eval(), kMachineTol);
 }
 
@@ -281,20 +281,20 @@ GTEST_TEST(DiscreteTimeDelayTest, ContinuousSimulation) {
   simulator.Initialize();
   EXPECT_EQ(0., eval());  // No update should have occurred yet.
 
-  simulator.StepTo(0);  // Force an update at 0.
+  simulator.AdvancePendingEvents();  // Force an update at 0.
   EXPECT_EQ(0, eval());  // Should output initial value.
 
   // Should output initial value until delay has passed.
-  simulator.StepTo(0.49);
+  simulator.AdvanceTo(0.49);
   EXPECT_EQ(0, eval());
 
   // Should start outputing delayed input.
-  simulator.StepTo(0.5);
-  simulator.StepTo(0.5);
+  simulator.AdvanceTo(0.5);
+  simulator.AdvancePendingEvents();
   EXPECT_NEAR(sine_eval(0), eval(), kMachineTol);
 
   // Last sample at 0.9, will output value from 0.4.
-  simulator.StepTo(0.91);
+  simulator.AdvanceTo(0.91);
   EXPECT_NEAR(sine_eval(0.4), eval(), kMachineTol);
 }
 

--- a/systems/primitives/test/random_source_test.cc
+++ b/systems/primitives/test/random_source_test.cc
@@ -43,7 +43,7 @@ void CheckStatistics(
   }
 
   simulator.Initialize();
-  simulator.StepTo(20);
+  simulator.AdvanceTo(20);
 
   const auto& x = logger->data();
 
@@ -214,7 +214,7 @@ GTEST_TEST(RandomSourceTest, CorrelationTest) {
 
   systems::Simulator<double> simulator(*diagram);
   simulator.Initialize();
-  simulator.StepTo(20);
+  simulator.AdvanceTo(20);
 
   const auto& x1 = log1->data();
   const auto& x2 = log2->data();

--- a/systems/primitives/test/signal_logger_test.cc
+++ b/systems/primitives/test/signal_logger_test.cc
@@ -50,7 +50,7 @@ GTEST_TEST(TestSignalLogger, LinearSystemTest) {
   simulator.Initialize();
   // The Simulator schedules SignalLogger's default per-step event, which
   // performs data logging.
-  simulator.StepTo(3);
+  simulator.AdvanceTo(3);
 
   // Gets the time stamps when each data point is saved.
   const auto& t = logger->sample_times();
@@ -78,7 +78,7 @@ GTEST_TEST(TestSignalLogger, LinearSystemTest) {
   EXPECT_EQ(logger->sample_times().size(), 0);
   EXPECT_EQ(logger->data().cols(), 0);
 
-  simulator.StepTo(4.);
+  simulator.AdvanceTo(4.);
   EXPECT_EQ(logger->data().cols(), logger->num_samples());
 }
 
@@ -96,7 +96,7 @@ GTEST_TEST(TestSignalLogger, SetPublishPeriod) {
   Simulator<double> simulator(*diagram);
 
   // Run simulation
-  simulator.StepTo(1);
+  simulator.AdvanceTo(1);
 
   EXPECT_EQ(logger->num_samples(), 11);
 

--- a/systems/primitives/test/zero_order_hold_test.cc
+++ b/systems/primitives/test/zero_order_hold_test.cc
@@ -254,16 +254,16 @@ GTEST_TEST(ZeroOrderHoldTest, UseInDiagram) {
   // No update should have occurred yet.
   EXPECT_EQ(0., eval());
 
-  simulator.StepTo(0);  // Force an update at 0.
+  simulator.AdvancePendingEvents();  // Force an update at 0.
 
   // Should have sampled at t=0.
   EXPECT_NEAR(sine_eval(0.), eval(), kMachineTol);
 
-  simulator.StepTo(1.5 * kPeriod);
+  simulator.AdvanceTo(1.5 * kPeriod);
   // Should have sampled at t=kPeriod, NOT 1.5 * kPeriod.
   EXPECT_NEAR(sine_eval(kPeriod), eval(), kMachineTol);
 
-  simulator.StepTo(9.1 * kPeriod);  // Last sample at 9 * kPeriod.
+  simulator.AdvanceTo(9.1 * kPeriod);  // Last sample at 9 * kPeriod.
   EXPECT_NEAR(sine_eval(9 * kPeriod), eval(), kMachineTol);
 }
 

--- a/systems/primitives/zero_order_hold.h
+++ b/systems/primitives/zero_order_hold.h
@@ -34,9 +34,9 @@ namespace systems {
 ///
 /// @note This system uses a periodic update with zero offset, so the first
 ///       update occurs at t=0. When used with a Simulator, the output port
-///       is equal to xᵢₙᵢₜ after Simulator.Initialize(), but is immediately
+///       is equal to xᵢₙᵢₜ after simulator.Initialize(), but is immediately
 ///       updated to u₀ at the start of the first step. If you want to force
-///       that initial update, use Simulator.StepTo(0.).
+///       that initial update, use simulator.AdvanceTo(0.).
 ///
 /// @note For an abstract-valued ZeroOrderHold, scalar-type conversion is not
 ///       supported since AbstractValue does not support it.

--- a/systems/sensors/lcm_image_array_receive_example.cc
+++ b/systems/sensors/lcm_image_array_receive_example.cc
@@ -69,7 +69,7 @@ int DoMain() {
   simulator->set_publish_every_time_step(false);
   simulator->set_target_realtime_rate(1.0);
   simulator->Initialize();
-  simulator->StepTo(FLAGS_duration);
+  simulator->AdvanceTo(FLAGS_duration);
 
   return 0;
 }

--- a/systems/sensors/test/beam_model_test.cc
+++ b/systems/sensors/test/beam_model_test.cc
@@ -122,7 +122,7 @@ GTEST_TEST(BeamModelTest, TestProbabilityDensity) {
   };
 
   simulator.Initialize();
-  simulator.StepTo(50);
+  simulator.AdvanceTo(50);
 
   const auto& x = logger->data();
 


### PR DESCRIPTION
Replaces Simulator's StepTo() method (which has caused much confusion by taking an arbitrary number of steps internally) with AdvanceTo() which is more accurate and lets us use "step" in the conventional way meaning just the smallest increment of time advancement.

Also adds an (Advanced) method AdvancePendingEvents() that is equivalent to AdvanceTo(now) and is necessary occasionally, especially in unit tests.

At @RussTedrake's request StepTo() is not yet deprecated but dispreferred.

Resolves #10842

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11055)
<!-- Reviewable:end -->
