### PR TITLE
Handle return-std-move and self-assign-overload warnings from Apple LLVM 10.0.1

### DIFF
--- a/bindings/pydrake/common/test/cpp_template_pybind_test.cc
+++ b/bindings/pydrake/common/test/cpp_template_pybind_test.cc
@@ -5,6 +5,7 @@
 // `cpp_template_pybind.h`.
 
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -38,7 +39,9 @@ py::object BindSimpleTemplate(py::module m) {
       .def(py::init<>())
       .def("GetNames", &Class::GetNames);
   AddTemplateClass(m, "SimpleTemplate", py_class, GetPyParam<Ts...>());
-  return py_class;
+  // We use move here because the type of py_class differs from our declared
+  // return type.
+  return std::move(py_class);
 }
 
 template <typename T>

--- a/bindings/pydrake/symbolic_py.cc
+++ b/bindings/pydrake/symbolic_py.cc
@@ -13,6 +13,16 @@
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/symbolic_types_pybind.h"
 
+#pragma GCC diagnostic push
+// Apple LLVM version 10.0.1 (clang-1001.0.46.3) adds `-Wself-assign-overloaded`
+// to `-Wall`, which generates warnings on Pybind11's operator-overloading idiom
+// that is using py::self (example: `def(py::self + py::self)`).
+// Here, we suppress the warning using `#pragma diagnostic`.
+#if (__APPLE__) && (__clang__) && (__clang_major__ >= 10) && \
+    (__clang_minor__ >= 0) && (__clang_patchlevel__ >= 1)
+#pragma GCC diagnostic ignored "-Wself-assign-overloaded"
+#endif
+
 namespace drake {
 namespace pydrake {
 
@@ -594,3 +604,5 @@ PYBIND11_MODULE(symbolic, m) {
 
 }  // namespace pydrake
 }  // namespace drake
+
+#pragma GCC diagnostic pop

--- a/bindings/pydrake/systems/lcm_pybind.h
+++ b/bindings/pydrake/systems/lcm_pybind.h
@@ -4,6 +4,7 @@
 /// Helpers for defining C++ LCM type serializers.
 
 #include <string>
+#include <utility>
 
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
@@ -35,7 +36,9 @@ py::object BindCppSerializer(const std::string& lcm_package) {
       DefineTemplateClassWithDefault<Serializer<CppType>, SerializerInterface>(
           lcm_py, "_Serializer", py::make_tuple(py_type));
   py_cls.def(py::init());
-  return py_cls;
+  // We use move here because the type of py_class differs from our declared
+  // return type.
+  return std::move(py_cls);
 }
 
 }  // namespace pylcm

--- a/common/test/reset_on_copy_test.cc
+++ b/common/test/reset_on_copy_test.cc
@@ -156,7 +156,8 @@ GTEST_TEST(ResetOnCopyTest, Copy) {
   EXPECT_EQ(w, 4);
 
   // Self copy assignment preserves value.
-  w = w;
+  auto const& other = w;
+  w = other;
   EXPECT_EQ(w, 4);
 
   // Make sure the example works.

--- a/systems/rendering/test/frame_velocity_test.cc
+++ b/systems/rendering/test/frame_velocity_test.cc
@@ -43,7 +43,8 @@ GTEST_TEST(FrameVelocityTest, CopyAndAssign) {
   vec[2] = 42;
 
   // Self-assignment.
-  vec = vec;
+  const auto& other = vec;
+  vec = other;
   EXPECT_EQ(42, vec[2]);
 
   // Copying.


### PR DESCRIPTION
Close #11037

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11060)
<!-- Reviewable:end -->
