### PR TITLE
Make Drake's notation documentation easier to find

### DIFF
--- a/doc/doxygen.h
+++ b/doc/doxygen.h
@@ -40,8 +40,19 @@ only updated nightly.</p>
 /**
   @defgroup solvers Formulating and Solving Optimization Problems
   @defgroup systems Modeling Dynamical Systems
+  @defgroup multibody Multibody Kinematics and Dynamics
   @defgroup algorithms Algorithms
   @defgroup technical_notes Technical Notes
+*/
+
+/**
+  @defgroup multibody_notation Terminology and Notation
+  @ingroup multibody
+*/
+
+/**
+  @defgroup constraint_overview Multibody Dynamics Constraints
+  @ingroup multibody
 */
 
 // TODO(russt): Take a thorough pass through the algorithms group
@@ -49,7 +60,6 @@ only updated nightly.</p>
 // algorithms throughout the code.
 /** @addtogroup algorithms
  @{
-   @defgroup multibody Multibody Dynamics
    @defgroup simulation Simulation
    @defgroup analysis Analysis
    @defgroup planning Planning

--- a/multibody/constraint/constraint_doxygen.h
+++ b/multibody/constraint/constraint_doxygen.h
@@ -1,5 +1,4 @@
 /** @addtogroup constraint_overview
-    @ingroup multibody
 
 This documentation describes the types of multibody constraints supported in
 Drake, including specialized constraint types- namely point-based contact

--- a/multibody/multibody_doxygen.h
+++ b/multibody/multibody_doxygen.h
@@ -7,9 +7,7 @@
 
 
 //------------------------------------------------------------------------------
-/** @addtogroup multibody Multibody Dynamics
-@{
-    @ingroup algorithms
+/** @addtogroup multibody_notation
 
 Translating from the mathematics of multibody mechanics to correct code is a
 difficult process and requires careful discipline to ensure that the resulting
@@ -19,7 +17,8 @@ these observations:
 - Good abstractions lead to good code.
 - You can't reason properly about spatial algorithms if you treat translation
 and rotation separately.
-- Coded algorithms should be comparable line-by-line against the typeset
+- Disciplined notation is essential to prevent coordinate frame errors.
+- Coded algorithms should be comparable equation-by-equation against the typeset
 literature sources from which they are derived.
 - We need a shared, unambiguous notation in code that can employ programmers'
 awesome pattern-matching skills to make errors visible.
@@ -34,37 +33,6 @@ source code used to generate it (for example, ASCII drawings instead of image
 files, simple Markdown tables rather than fancy-but-unreadable html ones).
 However, much of this can be useful to users of the Drake API also so it
 is included in the external documentation.
-
-@warning Drake is under development and these concepts have not yet been
-adopted consistently throughout the code. New code uses these concepts and
-older code will be retrofitted over time. The documentation here applies to
-the new @ref drake::multibody::MultibodyTree "MultibodyTree "/
-@ref drake::multibody::MultibodyPlant "MultibodyPlant"
-family of classes; there are some differences from the earlier `RigidBodyTree`
-family.
-
-<em><b>Developers</b>: you can link directly to specific discussion topics here
-from your Doxygen comments; instructions are at the top of the source file used
-to generate them.</em>
-
-Next topic: @ref multibody_notation
-
-  @defgroup multibody_notation Terminology and Notation
-  @defgroup multibody_spatial_algebra Spatial Algebra
-  @defgroup constraint_overview Multibody dynamics constraints
-@}
-*/
-
-
-//------------------------------------------------------------------------------
-/** @addtogroup multibody_notation
-@ingroup multibody
-
-Drake uses consistent terminology and notation for multibody mechanics
-- for clear communication among Drake programmers and users,
-- to reduce the likelihood of errors in translating mathematical algorithms
-  into code, and
-- to facilitate verification of the code's correctness.
 
 Where possible, we refer to published literature to supplement our code
 documentation. That literature can provide clear, concise, and unambiguous
@@ -104,6 +72,10 @@ decide to format a complicated equation in LaTeX, where it will appear in
 a typeset font like @f$A@f$ (which appears in the source as @c \@f\$A\@f\$),
 but then refer in the text to A (source: just @c A) using the
 default font that is much easier to write and to read in the source.
+
+<em><b>Developers</b>: you can link directly to specific discussion topics here
+from your Doxygen comments; instructions are at the top of the source file used
+to generate them.</em>
 
 Next topic: @ref multibody_notation_basics
 */
@@ -439,8 +411,8 @@ Next topic: @ref multibody_spatial_algebra
 */
 
 //------------------------------------------------------------------------------
-/** @addtogroup multibody_spatial_algebra
-@ingroup multibody
+/** @defgroup multibody_spatial_algebra Spatial Algebra
+@ingroup multibody_notation
 
 Multibody dynamics involves both rotational and translational quantities, for
 motion, forces, and mass properties. It is much more effective to group

--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -25,21 +25,21 @@
 namespace drake {
 namespace systems {
 
-/**
- A class for advancing the state of hybrid dynamic systems, represented by
- `System<T>` objects, forward in time. Starting with an initial Context for a
- given System, %Simulator advances time and produces a series of Context
- values that forms a trajectory satisfying the system's dynamic equations to
- a specified accuracy. Only the Context is modified by a %Simulator; the
- System is const.
+/** @ingroup simulation
+A class for advancing the state of hybrid dynamic systems, represented by
+`System<T>` objects, forward in time. Starting with an initial Context for a
+given System, %Simulator advances time and produces a series of Context
+values that forms a trajectory satisfying the system's dynamic equations to
+a specified accuracy. Only the Context is modified by a %Simulator; the
+System is const.
 
- A Drake System is a continuous/discrete/hybrid dynamic system where the
- continuous part is a DAE, that is, it is expected to consist of a set of
- differential equations and bilateral algebraic constraints. The set of
- active constraints may change as a result of particular events, such as
- contact.
+A Drake System is a continuous/discrete/hybrid dynamic system where the
+continuous part is a DAE, that is, it is expected to consist of a set of
+differential equations and bilateral algebraic constraints. The set of
+active constraints may change as a result of particular events, such as
+contact.
 
- Given a current Context, we expect a System to provide us with
+Given a current Context, we expect a System to provide us with
  - derivatives for the continuous differential equations that already satisfy
    the differentiated form of the constraints (typically, acceleration
    constraints),


### PR DESCRIPTION
Per #10921 it can be difficult to find our generally-useful documentation for Drake's Monogram Notation, which is currently buried several levels down under doxygen Modules. This PR proposes to move it to a more visible location, just under Modeling Dynamical Systems:

![image](https://user-images.githubusercontent.com/4088016/55131639-af902f00-50dc-11e9-81d0-c899f97d4203.png)


Resolves #10921

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11062)
<!-- Reviewable:end -->
