### PR TITLE
Remove deprecated methods (2019-04)

### DIFF
--- a/attic/systems/controllers/qp_inverse_dynamics/test/qp_inverse_dynamics_system_test.cc
+++ b/attic/systems/controllers/qp_inverse_dynamics/test/qp_inverse_dynamics_system_test.cc
@@ -61,7 +61,7 @@ GTEST_TEST(testQpInverseDynamicsSystem, IiwaInverseDynamics) {
   robot_status.UpdateKinematics(0 /* time */, q, v);
   ConstantValueSource<double>* state_source =
       builder.AddSystem<ConstantValueSource<double>>(
-          AbstractValue::Make<RobotKinematicState<double>>(robot_status));
+          Value<RobotKinematicState<double>>(robot_status));
   state_source->set_name("state_source");
 
   // Makes a source for qp input.
@@ -84,7 +84,7 @@ GTEST_TEST(testQpInverseDynamicsSystem, IiwaInverseDynamics) {
 
   ConstantValueSource<double>* qp_input_source =
       builder.AddSystem<ConstantValueSource<double>>(
-          AbstractValue::Make<QpInput>(input));
+          Value<QpInput>(input));
   qp_input_source->set_name("qp_input_source");
 
   // Connects the diagram.

--- a/automotive/automotive_simulator.cc
+++ b/automotive/automotive_simulator.cc
@@ -425,7 +425,7 @@ int AutomotiveSimulator<T>::AddIdmControlledCar(
   const LaneDirection lane_direction(goal_lane, initial_with_s);
   auto lane_source =
       builder_->template AddSystem<systems::ConstantValueSource<T>>(
-          AbstractValue::Make<LaneDirection>(lane_direction));
+          Value<LaneDirection>(lane_direction));
 
   auto simple_car = builder_->template AddSystem<SimpleCar<T>>();
   simple_car->set_name(name + "_simple_car");

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -150,14 +150,6 @@ PYBIND11_MODULE(tree, m) {
             doc.Joint.acceleration_lower_limits.doc)
         .def("acceleration_upper_limits", &Class::acceleration_upper_limits,
             doc.Joint.acceleration_upper_limits.doc);
-
-    // Add deprecated methods.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    cls.def("num_dofs", &Class::num_dofs, doc.Joint.num_dofs.doc);
-#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
-    cls.attr("message_num_dofs") = "Please use num_velocities().";
-    DeprecateAttribute(cls, "num_dofs", cls.attr("message_num_dofs"));
   }
 
   {

--- a/common/drake_deprecated.h
+++ b/common/drake_deprecated.h
@@ -45,6 +45,11 @@ Sample uses: @code
   class DRAKE_DEPRECATED("2038-01-19", "Use MyNewClass instead.")
   MyClass {
   };
+
+  // Type alias goes before the '='.
+  using NewType
+      DRAKE_DEPRECATED("2038-01-19", "Use NewType instead.")
+      = OldType;
 @endcode
 */
 #define DRAKE_DEPRECATED(removal_date, message)

--- a/examples/humanoid_controller/test/humanoid_plan_eval_system_test.cc
+++ b/examples/humanoid_controller/test/humanoid_plan_eval_system_test.cc
@@ -75,13 +75,12 @@ class HumanoidPlanEvalAndQpInverseDynamicsTest : public ::testing::Test {
     HumanoidStatus robot_status(&robot, alias_groups);
     robot_status.UpdateKinematics(0, q, v);
     auto state_source = builder.AddSystem<systems::ConstantValueSource<double>>(
-        AbstractValue::Make<RobotKinematicState<double>>(
-            robot_status));
+        Value<RobotKinematicState<double>>(robot_status));
 
     // Adds a dummy plan message.
     robotlocomotion::robot_plan_t msg{};
     auto plan_source = builder.AddSystem<systems::ConstantValueSource<double>>(
-        AbstractValue::Make<robotlocomotion::robot_plan_t>(msg));
+        Value<robotlocomotion::robot_plan_t>(msg));
 
     // State -> qp inverse dynamics.
     builder.Connect(state_source->get_output_port(0),

--- a/examples/manipulation_station/manipulation_station.h
+++ b/examples/manipulation_station/manipulation_station.h
@@ -365,13 +365,6 @@ class ManipulationStation : public systems::Diagram<T> {
     SetIiwaPosition(*station_context, &station_context->get_mutable_state(), q);
   }
 
-  DRAKE_DEPRECATED("2019-04-01",
-      "Prefer the version with the Context as the first argument.")
-  void SetIiwaPosition(const Eigen::Ref<const VectorX<T>>& q,
-                       systems::Context<T>* station_context) const {
-    SetIiwaPosition(station_context, q);
-  }
-
   /// Convenience method for getting all of the joint velocities of the Kuka
   // IIWA.  This does not include the gripper.
   VectorX<T> GetIiwaVelocity(const systems::Context<T>& station_context) const;
@@ -389,13 +382,6 @@ class ManipulationStation : public systems::Diagram<T> {
   void SetIiwaVelocity(systems::Context<T>* station_context,
                        const Eigen::Ref<const VectorX<T>>& v) const {
     SetIiwaVelocity(*station_context, &station_context->get_mutable_state(), v);
-  }
-
-  DRAKE_DEPRECATED("2019-04-01",
-      "Prefer the version with the Context as the first argument.")
-  void SetIiwaVelocity(const Eigen::Ref<const VectorX<T>>& v,
-                       systems::Context<T>* station_context) const {
-    SetIiwaVelocity(station_context, v);
   }
 
   /// Convenience method for getting the position of the Schunk WSG. Note
@@ -423,12 +409,6 @@ class ManipulationStation : public systems::Diagram<T> {
     SetWsgPosition(*station_context, &station_context->get_mutable_state(), q);
   }
 
-  DRAKE_DEPRECATED("2019-04-01",
-      "Prefer the version with the Context as the first argument.")
-  void SetWsgPosition(const T& q, systems::Context<T>* station_context) const {
-    SetWsgPosition(station_context, q);
-  }
-
   /// Convenience method for setting the velocity of the Schunk WSG.
   /// @pre `state` must be the systems::State<T> object contained in
   /// `station_context`.
@@ -438,12 +418,6 @@ class ManipulationStation : public systems::Diagram<T> {
   /// Convenience method for setting the velocity of the Schunk WSG.
   void SetWsgVelocity(systems::Context<T>* station_context, const T& v) const {
     SetWsgVelocity(*station_context, &station_context->get_mutable_state(), v);
-  }
-
-  DRAKE_DEPRECATED("2019-04-01",
-      "Prefer the version with the Context as the first argument.")
-  void SetWsgVelocity(const T& v, systems::Context<T>* station_context) const {
-    SetWsgVelocity(station_context, v);
   }
 
   /// Returns a map from camera name to X_WCameraBody for all the static

--- a/examples/valkyrie/test/robot_command_to_desired_effort_converter_test.cc
+++ b/examples/valkyrie/test/robot_command_to_desired_effort_converter_test.cc
@@ -32,9 +32,9 @@ void TestCommandToDesiredEffortConverter(
   }
 
   // Constant LCM message source.
-  auto robot_command = make_unique<Value<bot_core::atlas_command_t>>(message);
   auto& robot_command_source =
-      *builder.AddSystem<ConstantValueSource<double>>(move(robot_command));
+      *builder.AddSystem<ConstantValueSource<double>>(
+          Value<bot_core::atlas_command_t>(message));
   robot_command_source.set_name("command_source");
 
   // Device under test.

--- a/examples/valkyrie/test/robot_state_encoder_decoder_test.cc
+++ b/examples/valkyrie/test/robot_state_encoder_decoder_test.cc
@@ -125,7 +125,7 @@ void TestEncodeThenDecode(FloatingBaseType floating_base_type) {
 
   auto& kinematics_results_source =
       *builder.AddSystem<ConstantValueSource<double>>(
-          move(kinematics_results_value));
+          *kinematics_results_value);
   kinematics_results_source.set_name("kinematics_results_source");
 
   // Effort sources.
@@ -190,7 +190,7 @@ void TestEncodeThenDecode(FloatingBaseType floating_base_type) {
 
   auto& contact_results_source =
       *builder.AddSystem<ConstantValueSource<double>>(
-          move(contact_results_value));
+          *contact_results_value);
   contact_results_source.set_name("contact_results_source");
 
   // RobotStateEncoder and RobotStateDecoder.

--- a/geometry/geometry_set.h
+++ b/geometry/geometry_set.h
@@ -4,7 +4,6 @@
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_deprecated.h"
 #include "drake/geometry/geometry_ids.h"
 
 namespace drake {
@@ -244,39 +243,6 @@ class GeometrySet {
 
   //@}
 
-  // TODO(SeanCurtis-TRI): Remove these deprecated methods and rename the
-  // private methods below to the simpler names - 2018-02-15.
-
-  /** Returns the frame ids in the set. */
-  DRAKE_DEPRECATED("2018-02-15", "Test-only utility function.")
-  const std::unordered_set<FrameId> frames() const { return frames_; }
-
-  /** Reports the number of frames in the set. */
-  DRAKE_DEPRECATED("2018-02-15", "Test-only utility function.")
-  int num_frames() const { return static_cast<int>(frames_.size()); }
-
-  /** Returns the geometry ids in the set. */
-  DRAKE_DEPRECATED("2018-02-15", "Test-only utility function.")
-  const std::unordered_set<GeometryId> geometries() const {
-    return geometries_;
-  }
-
-  /** Reports the number of geometries _explicitly_ in the set. It does
-   _not_ count the geometries that belong to the added frames.  */
-  DRAKE_DEPRECATED("2018-02-15", "Test-only utility function.")
-  int num_geometries() const { return static_cast<int>(geometries_.size()); }
-
-  /** Reports if the given `frame_id` has been added to the group. */
-  DRAKE_DEPRECATED("2018-02-15", "Test-only utility function.")
-  bool contains(FrameId frame_id) const { return frames_.count(frame_id) > 0; }
-
-  /** Reports if the given `geometry_id` has been *explicitly* added to the
-   group. It will *not* capture geometry ids affixed to added frames.  */
-  DRAKE_DEPRECATED("2018-02-15", "Test-only utility function.")
-  bool contains(GeometryId geometry_id) const {
-    return geometries_.count(geometry_id) > 0;
-  }
-
  private:
   // Provide access to the two entities that need access to the set's internals.
   friend class GeometrySetTester;
@@ -284,31 +250,31 @@ class GeometrySet {
   friend class GeometryState;
 
   // Returns the frame ids in the set.
-  const std::unordered_set<FrameId> frames_internal() const { return frames_; }
+  const std::unordered_set<FrameId> frames() const { return frames_; }
 
   // Reports the number of frames in the set.
-  int num_frames_internal() const { return static_cast<int>(frames_.size()); }
+  int num_frames() const { return static_cast<int>(frames_.size()); }
 
   // Returns the geometry ids in the set -- these are only the geometry ids
   // explicitly added to the set and _not_ those implied by added frames.
-  const std::unordered_set<GeometryId> geometries_internal() const {
+  const std::unordered_set<GeometryId> geometries() const {
     return geometries_;
   }
 
   // Reports the number of geometries _explicitly_ in the set. It does _not_
   // count the geometries that belong to the added frames.
-  int num_geometries_internal() const {
+  int num_geometries() const {
     return static_cast<int>(geometries_.size());
   }
 
   // Reports if the given `frame_id` has been added to the group.
-  bool contains_internal(FrameId frame_id) const {
+  bool contains(FrameId frame_id) const {
     return frames_.count(frame_id) > 0;
   }
 
   // Reports if the given `geometry_id` has been *explicitly* added to the
   // group. It will *not* capture geometry ids affixed to added frames.
-  bool contains_internal(GeometryId geometry_id) const {
+  bool contains(GeometryId geometry_id) const {
     return geometries_.count(geometry_id) > 0;
   }
 

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -761,8 +761,8 @@ void GeometryState<T>::ExcludeCollisionsWithin(const GeometrySet& set) {
   //   1. the set contains a single frame and no geometries -- geometries *on*
   //      that single frame have already been handled, or
   //   2. there are no frames and a single geometry.
-  if ((set.num_frames_internal() == 1 && set.num_geometries_internal() == 0) ||
-      (set.num_frames_internal() == 0 && set.num_geometries_internal() == 1)) {
+  if ((set.num_frames() == 1 && set.num_geometries() == 0) ||
+      (set.num_frames() == 0 && set.num_geometries() == 1)) {
     return;
   }
 
@@ -800,7 +800,7 @@ void GeometryState<T>::CollectIndices(
   // TODO(SeanCurtis-TRI): Consider expanding this to include Role if it proves
   // that collecting indices for *other* role-related tasks prove necessary.
   std::unordered_set<GeometryIndex>* target;
-  for (auto frame_id : geometry_set.frames_internal()) {
+  for (auto frame_id : geometry_set.frames()) {
     const auto& frame = GetValueOrThrow(frame_id, frames_);
     target = frame.is_world() ? anchored : dynamic;
     for (auto geometry_id : frame.child_geometries()) {
@@ -811,7 +811,7 @@ void GeometryState<T>::CollectIndices(
     }
   }
 
-  for (auto geometry_id : geometry_set.geometries_internal()) {
+  for (auto geometry_id : geometry_set.geometries()) {
     const InternalGeometry* geometry = GetGeometry(geometry_id);
     if (geometry == nullptr) {
       throw std::logic_error(

--- a/geometry/test_utilities/geometry_set_tester.h
+++ b/geometry/test_utilities/geometry_set_tester.h
@@ -13,22 +13,22 @@ class GeometrySetTester {
   explicit GeometrySetTester(const GeometrySet* set) : set_(*set) {}
 
   const std::unordered_set<FrameId> frames() const {
-    return set_.frames_internal();
+    return set_.frames();
   }
 
-  int num_frames() const { return set_.num_frames_internal(); }
+  int num_frames() const { return set_.num_frames(); }
 
   const std::unordered_set<GeometryId> geometries() const {
-    return set_.geometries_internal();
+    return set_.geometries();
   }
 
-  int num_geometries() const { return set_.num_geometries_internal(); }
+  int num_geometries() const { return set_.num_geometries(); }
 
   bool contains(FrameId frame_id) const {
-    return set_.contains_internal(frame_id); }
+    return set_.contains(frame_id); }
 
   bool contains(GeometryId geometry_id) const {
-    return set_.contains_internal(geometry_id);;
+    return set_.contains(geometry_id);;
   }
 
  private:

--- a/multibody/tree/joint.h
+++ b/multibody/tree/joint.h
@@ -8,7 +8,6 @@
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_deprecated.h"
 #include "drake/multibody/tree/fixed_offset_frame.h"
 #include "drake/multibody/tree/mobilizer.h"
 #include "drake/multibody/tree/multibody_forces.h"
@@ -163,13 +162,6 @@ class Joint : public MultibodyTreeElement<Joint<T>, JointIndex>  {
   /// Returns a const reference to the frame M attached on the child body B.
   const Frame<T>& frame_on_child() const {
     return frame_on_child_;
-  }
-
-  /// Returns the number of degrees of freedom for `this` joint.
-  /// E.g., one for a revolute joint and three for a ball joint.
-  DRAKE_DEPRECATED("2019-04-01", "Please use num_velocities().")
-  int num_dofs() const {
-    return num_velocities();
   }
 
   /// Returns the index to the first generalized velocity for this joint

--- a/systems/framework/system_constraint.h
+++ b/systems/framework/system_constraint.h
@@ -9,7 +9,6 @@
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_bool.h"
-#include "drake/common/drake_deprecated.h"
 #include "drake/common/drake_optional.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
@@ -153,11 +152,6 @@ template <typename T>
 class SystemConstraint final {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SystemConstraint)
-
-  using CalcCallback
-      DRAKE_DEPRECATED("2019-04-01",
-          "Use drake::systems::ContextConstraintCalc instead.")
-      = ContextConstraintCalc<T>;
 
   /// (Advanced) Constructs a default (zero-sized) SystemConstraint.
   ///

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -430,8 +430,7 @@ class ExampleDiagram : public Diagram<double> {
     builder.ExportOutput(integrator1_->get_output_port());
 
     if (use_abstract) {
-      builder.AddSystem<ConstantValueSource<double>>(
-          std::make_unique<Value<int>>(0));
+      builder.AddSystem<ConstantValueSource<double>>(Value<int>(0));
     }
     if (use_double_only) {
       builder.AddSystem<DoubleOnlySystem>();

--- a/systems/primitives/constant_value_source.h
+++ b/systems/primitives/constant_value_source.h
@@ -5,7 +5,6 @@
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_deprecated.h"
 #include "drake/systems/framework/leaf_system.h"
 
 namespace drake {
@@ -30,10 +29,6 @@ class ConstantValueSource final : public LeafSystem<T> {
 
   /// @param value The constant value to emit which is copied by this system.
   explicit ConstantValueSource(const AbstractValue& value);
-
-  DRAKE_DEPRECATED("2018-04-01",
-      "Use the ConstantValueSource(const AbstractValue&) constructor instead")
-  explicit ConstantValueSource(std::unique_ptr<AbstractValue> value);
 
   /// Scalar-converting copy constructor. See @ref system_scalar_conversion.
   template <typename U>
@@ -60,11 +55,6 @@ ConstantValueSource<T>::ConstantValueSource(const AbstractValue& value)
         output->SetFrom(*source_value_);
       });
 }
-
-template <typename T>
-ConstantValueSource<T>::ConstantValueSource(
-    std::unique_ptr<AbstractValue> value)
-    : ConstantValueSource<T>(*value) {}
 
 template <typename T>
 template <typename U>


### PR DESCRIPTION
The `GeometrySet::geometries` deadline is extended for another month; we are still using it within TRI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11067)
<!-- Reviewable:end -->
