### PR TITLE
multibody: Deprecate Isometry3 usages of `SetFreeBodyPose`

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -54,9 +54,10 @@ PYBIND11_MODULE(plant, m) {
   py::module::import("pydrake.multibody.tree");
   py::module::import("pydrake.systems.framework");
 
-  const char* doc_iso3_deprecation =
-      "This API using Isometry3 will be deprecated soon with the resolution of "
-      "#9865. We only offer it for backwards compatibility. DO NOT USE!.";
+  constexpr char doc_iso3_deprecation[] =
+      "This API using Isometry3 is / will be deprecated soon with the "
+      "resolution of #9865. We only offer it for backwards compatibility. DO "
+      "NOT USE!.";
 
   {
     using Class = MultibodyPlant<T>;
@@ -177,14 +178,18 @@ PYBIND11_MODULE(plant, m) {
         // association that is less awkward than implicit BodyNodeIndex.
         .def("SetFreeBodyPose",
             overload_cast_explicit<void, Context<T>*, const Body<T>&,
-                const Isometry3<T>&>(&Class::SetFreeBodyPose),
-            py::arg("context"), py::arg("body"), py::arg("X_WB"),
-            doc_iso3_deprecation)
-        .def("SetFreeBodyPose",
-            overload_cast_explicit<void, Context<T>*, const Body<T>&,
                 const RigidTransform<T>&>(&Class::SetFreeBodyPose),
             py::arg("context"), py::arg("body"), py::arg("X_WB"),
             doc.MultibodyPlant.SetFreeBodyPose.doc_3args)
+        .def("SetFreeBodyPose",
+            [doc_iso3_deprecation](const Class* self, Context<T>* context,
+                const Body<T>& body, const Isometry3<T>& X_WB) {
+              WarnDeprecated(doc_iso3_deprecation);
+              return self->SetFreeBodyPose(
+                  context, body, RigidTransform<T>(X_WB));
+            },
+            py::arg("context"), py::arg("body"), py::arg("X_WB"),
+            doc_iso3_deprecation)
         .def("SetActuationInArray",
             [](const Class* self, multibody::ModelInstanceIndex model_instance,
                 const Eigen::Ref<const VectorX<T>> u_instance,

--- a/bindings/pydrake/multibody/test/inverse_kinematics_test.py
+++ b/bindings/pydrake/multibody/test/inverse_kinematics_test.py
@@ -11,7 +11,7 @@ from numpy.linalg import norm
 from pydrake.common import FindResourceOrThrow
 from pydrake.common.eigen_geometry import Quaternion, AngleAxis, Isometry3
 from pydrake.common.test_utilities.deprecation import catch_drake_warnings
-from pydrake.math import RotationMatrix
+from pydrake.math import RigidTransform, RotationMatrix
 from pydrake.multibody.plant import (
     MultibodyPlant, AddMultibodyPlantSceneGraph)
 from pydrake.multibody.parsing import Parser
@@ -242,11 +242,10 @@ class TestInverseKinematics(unittest.TestCase):
 
         ik.AddMinimumDistanceConstraint(minimal_distance=min_distance)
         context = self.plant.CreateDefaultContext()
-        R_I = np.eye(3)
         self.plant.SetFreeBodyPose(
-            context, B1.body(), Isometry3(R_I, [0, 0, 0.01]))
+            context, B1.body(), RigidTransform([0, 0, 0.01]))
         self.plant.SetFreeBodyPose(
-            context, B2.body(), Isometry3(R_I, [0, 0, -0.01]))
+            context, B2.body(), RigidTransform([0, 0, -0.01]))
 
         def get_min_distance_actual():
             X = partial(self.plant.CalcRelativeTransform, context)

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -664,7 +664,7 @@ class TestPlant(unittest.TestCase):
         plant.SetFreeBodyPose(
             context, plant.GetBodyByName("iiwa_link_0"),
             RigidTransform(RollPitchYaw([0.1, 0.2, 0.3]),
-                           p=[0.4, 0.5, 0.6]).GetAsIsometry3())
+                           p=[0.4, 0.5, 0.6]))
         v_expected = np.linspace(start=-1.0, stop=-nv, num=nv)
         qdot = plant.MapVelocityToQDot(context, v_expected)
         v_remap = plant.MapQDotToVelocity(context, qdot)

--- a/examples/allegro_hand/joint_control/allegro_single_object_simulation.cc
+++ b/examples/allegro_hand/joint_control/allegro_single_object_simulation.cc
@@ -38,7 +38,9 @@ namespace examples {
 namespace allegro_hand {
 namespace {
 
-using drake::multibody::MultibodyPlant;
+using math::RigidTransformd;
+using math::RollPitchYawd;
+using multibody::MultibodyPlant;
 
 DEFINE_double(simulation_time, std::numeric_limits<double>::infinity(),
               "Desired duration of the simulation in seconds");
@@ -177,12 +179,9 @@ void DoMain() {
   // Initialize the mug pose to be right in the middle between the fingers.
   const Eigen::Vector3d& p_WHand =
       plant.EvalBodyPoseInWorld(plant_context, hand).translation();
-  Eigen::Isometry3d X_WM;
-  Eigen::Vector3d rpy(M_PI / 2, 0, 0);
-  X_WM.linear() =
-      math::RotationMatrix<double>(math::RollPitchYaw<double>(rpy)).matrix();
-  X_WM.translation() = p_WHand + Eigen::Vector3d(0.095, 0.062, 0.095);
-  X_WM.makeAffine();
+  RigidTransformd X_WM(
+      RollPitchYawd(M_PI / 2, 0, 0),
+      p_WHand + Eigen::Vector3d(0.095, 0.062, 0.095));
   plant.SetFreeBodyPose(&plant_context, mug, X_WM);
 
   // Set up simulator.

--- a/examples/manipulation_station/manipulation_station.cc
+++ b/examples/manipulation_station/manipulation_station.cc
@@ -31,8 +31,6 @@ namespace drake {
 namespace examples {
 namespace manipulation_station {
 
-using Eigen::Isometry3d;
-using Eigen::MatrixXd;
 using Eigen::Vector3d;
 using Eigen::VectorXd;
 using geometry::SceneGraph;
@@ -138,7 +136,7 @@ template <typename T>
 multibody::ModelInstanceIndex AddAndWeldModelFrom(
     const std::string& model_path, const std::string& model_name,
     const multibody::Frame<T>& parent, const std::string& child_frame_name,
-    const Isometry3<double>& X_PC, MultibodyPlant<T>* plant) {
+    const RigidTransform<double>& X_PC, MultibodyPlant<T>* plant) {
   DRAKE_THROW_UNLESS(!plant->HasModelInstanceNamed(model_name));
 
   multibody::Parser parser(plant);
@@ -188,7 +186,7 @@ void ManipulationStation<T>::AddManipulandFromFile(
 
 template <typename T>
 void ManipulationStation<T>::SetupClutterClearingStation(
-    const optional<const math::RigidTransformd>& X_WCameraBody,
+    const optional<const math::RigidTransform<double>>& X_WCameraBody,
     IiwaCollisionModel collision_model) {
   DRAKE_DEMAND(setup_ == Setup::kNone);
   setup_ = Setup::kClutterClearing;
@@ -198,16 +196,13 @@ void ManipulationStation<T>::SetupClutterClearingStation(
     const std::string sdf_path = FindResourceOrThrow(
         "drake/examples/manipulation_station/models/bin.sdf");
 
-    Isometry3<double> X_WC =
-        RigidTransform<double>(RotationMatrix<double>::MakeZRotation(M_PI_2),
-                               Vector3d(-0.145, -0.63, 0.235))
-            .GetAsIsometry3();
+    RigidTransform<double> X_WC(RotationMatrix<double>::MakeZRotation(M_PI_2),
+                                Vector3d(-0.145, -0.63, 0.235));
     internal::AddAndWeldModelFrom(sdf_path, "bin1", plant_->world_frame(),
                                   "bin_base", X_WC, plant_);
 
     X_WC = RigidTransform<double>(RotationMatrix<double>::MakeZRotation(M_PI),
-                                  Vector3d(0.5, -0.1, 0.235))
-               .GetAsIsometry3();
+                                  Vector3d(0.5, -0.1, 0.235));
     internal::AddAndWeldModelFrom(sdf_path, "bin2", plant_->world_frame(),
                                   "bin_base", X_WC, plant_);
   }
@@ -231,7 +226,7 @@ void ManipulationStation<T>::SetupClutterClearingStation(
         kWidth, kHeight, fov_y, default_renderer_name_, 0.1, 2.0);
 
     RegisterRgbdCamera("0", plant_->world_frame(),
-                       X_WCameraBody.value_or(math::RigidTransformd(
+                       X_WCameraBody.value_or(math::RigidTransform<double>(
                            math::RollPitchYaw<double>(-0.3, 0.8, 1.5),
                            Eigen::Vector3d(0, -1.5, 1.5))),
                        camera_properties);
@@ -255,10 +250,8 @@ void ManipulationStation<T>::SetupDefaultStation(
         "drake/examples/manipulation_station/models/"
         "amazon_table_simplified.sdf");
 
-    const Isometry3<double> X_WT =
-        RigidTransform<double>(Vector3d(dx_table_center_to_robot_base, 0,
-                                        -dz_table_top_robot_base))
-            .GetAsIsometry3();
+    RigidTransform<double> X_WT(Vector3d(dx_table_center_to_robot_base, 0,
+                                  -dz_table_top_robot_base));
     internal::AddAndWeldModelFrom(sdf_path, "table", plant_->world_frame(),
                                   "amazon_table", X_WT, plant_);
   }
@@ -274,14 +267,12 @@ void ManipulationStation<T>::SetupDefaultStation(
     const std::string sdf_path = FindResourceOrThrow(
         "drake/examples/manipulation_station/models/cupboard.sdf");
 
-    const Isometry3<double> X_WC =
-        RigidTransform<double>(
+    RigidTransform<double> X_WC(
             RotationMatrix<double>::MakeZRotation(M_PI),
             Vector3d(
                 dx_table_center_to_robot_base + dx_cupboard_to_table_center, 0,
                 dz_cupboard_to_table_center + cupboard_height / 2.0 -
-                    dz_table_top_robot_base))
-            .GetAsIsometry3();
+                    dz_table_top_robot_base));
     internal::AddAndWeldModelFrom(sdf_path, "cupboard", plant_->world_frame(),
                                   "cupboard_body", X_WC, plant_);
   }
@@ -349,7 +340,7 @@ void ManipulationStation<T>::SetDefaultState(
   for (uint64_t i = 0; i < object_ids_.size(); i++) {
     plant_->SetFreeBodyPose(plant_context, &plant_state,
                             plant_->get_body(object_ids_[i]),
-                            object_poses_[i].GetAsIsometry3());
+                            object_poses_[i]);
   }
 
   // Use SetIiwaPosition to make sure the controller state is initialized to
@@ -384,8 +375,7 @@ void ManipulationStation<T>::SetRandomState(
     pose.set_translation(pose.translation() + Vector3d{0, 0, z_offset});
     z_offset += 0.1;
     plant_->SetFreeBodyPose(plant_context, &plant_state,
-                            plant_->get_body(body_index),
-                            pose.GetAsIsometry3());
+                            plant_->get_body(body_index), pose);
   }
 
   // Use SetIiwaPosition to make sure the controller state is initialized to
@@ -907,7 +897,7 @@ void ManipulationStation<T>::AddDefaultIiwa(
   const auto X_WI = RigidTransform<double>::Identity();
   auto iiwa_instance = internal::AddAndWeldModelFrom(
       sdf_path, "iiwa", plant_->world_frame(), "iiwa_link_0",
-      X_WI.GetAsIsometry3(), plant_);
+      X_WI, plant_);
   RegisterIiwaControllerModel(
       sdf_path, iiwa_instance, plant_->world_frame(),
       plant_->GetFrameByName("iiwa_link_0", iiwa_instance), X_WI);
@@ -923,7 +913,7 @@ void ManipulationStation<T>::AddDefaultWsg() {
   const RigidTransform<double> X_7G(RollPitchYaw<double>(M_PI_2, 0, M_PI_2),
                                     Vector3d(0, 0, 0.114));
   auto wsg_instance = internal::AddAndWeldModelFrom(
-      sdf_path, "gripper", link7, "body", X_7G.GetAsIsometry3(), plant_);
+      sdf_path, "gripper", link7, "body", X_7G, plant_);
   RegisterWsgControllerModel(sdf_path, wsg_instance, link7,
                              plant_->GetFrameByName("body", wsg_instance),
                              X_7G);

--- a/examples/multibody/bouncing_ball/bouncing_ball_run_dynamics.cc
+++ b/examples/multibody/bouncing_ball/bouncing_ball_run_dynamics.cc
@@ -35,7 +35,6 @@ DEFINE_double(simulation_time, 10.0,
               "Desired duration of the simulation in seconds.");
 
 using Eigen::AngleAxisd;
-using Eigen::Isometry3d;
 using Eigen::Matrix3d;
 using Eigen::Vector3d;
 using geometry::SceneGraph;
@@ -105,10 +104,8 @@ int do_main() {
   // Set at height z0 with random orientation.
   std::mt19937 generator(41);
   std::uniform_real_distribution<double> uniform(-1.0, 1.0);
-  Matrix3d R_WB = math::UniformlyRandomRotationMatrix(&generator).matrix();
-  Isometry3d X_WB = Isometry3d::Identity();
-  X_WB.linear() = R_WB;
-  X_WB.translation() = Vector3d(0.0, 0.0, z0);
+  math::RotationMatrixd R_WB = math::UniformlyRandomRotationMatrix(&generator);
+  math::RigidTransformd X_WB(R_WB, Vector3d(0.0, 0.0, z0));
   plant.SetFreeBodyPose(
       &plant_context, plant.GetBodyByName("Ball"), X_WB);
 

--- a/examples/multibody/cylinder_with_multicontact/cylinder_run_dynamics.cc
+++ b/examples/multibody/cylinder_with_multicontact/cylinder_run_dynamics.cc
@@ -51,8 +51,6 @@ DEFINE_double(time_step, 1.0e-3,
               "for the plant modeled as a discrete system."
               "This parameter must be non-negative.");
 
-using Eigen::Isometry3d;
-using Eigen::Matrix3d;
 using Eigen::Vector3d;
 using geometry::SceneGraph;
 using lcm::DrakeLcm;
@@ -115,8 +113,7 @@ int do_main() {
       diagram->GetMutableSubsystemContext(plant, diagram_context.get());
 
   // Set at height z0.
-  Isometry3d X_WB = Isometry3d::Identity();
-  X_WB.translation() = Vector3d(0.0, 0.0, FLAGS_z0);
+  math::RigidTransformd X_WB(Vector3d(0.0, 0.0, FLAGS_z0));
   const auto& cylinder = plant.GetBodyByName("Cylinder");
   plant.SetFreeBodyPose(&plant_context, cylinder, X_WB);
   plant.SetFreeBodySpatialVelocity(

--- a/examples/simple_gripper/simple_gripper.cc
+++ b/examples/simple_gripper/simple_gripper.cc
@@ -31,14 +31,12 @@ namespace examples {
 namespace simple_gripper {
 namespace {
 
-using Eigen::Isometry3d;
 using Eigen::Vector3d;
 using geometry::SceneGraph;
 using geometry::Sphere;
 using lcm::DrakeLcm;
 using math::RigidTransformd;
-using math::RollPitchYaw;
-using math::RotationMatrix;
+using math::RollPitchYawd;
 using multibody::Body;
 using multibody::CoulombFriction;
 using multibody::ConnectContactResultsToDrakeVisualizer;
@@ -332,12 +330,10 @@ int do_main() {
       plant_context, left_finger).translation();
   const double mug_y_W = (p_WBr(1) + p_WBl(1)) / 2.0;
 
-  Isometry3d X_WM;
-  Vector3d rpy(FLAGS_rx * M_PI / 180,
-               FLAGS_ry * M_PI / 180,
-               (FLAGS_rz * M_PI / 180) + M_PI);
-  X_WM.linear() = RotationMatrix<double>(RollPitchYaw<double>(rpy)).matrix();
-  X_WM.translation() = Vector3d(0.0, mug_y_W, 0.0);
+  RigidTransformd X_WM(
+      RollPitchYawd(FLAGS_rx * M_PI / 180, FLAGS_ry * M_PI / 180,
+                    (FLAGS_rz * M_PI / 180) + M_PI),
+      Vector3d(0.0, mug_y_W, 0.0));
   plant.SetFreeBodyPose(&plant_context, mug, X_WM);
 
   // Set the initial height of the gripper and its initial velocity so that with

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -2942,11 +2942,19 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // These APIs using Isometry3 will be deprecated soon with the resolution of
   // #9865. Right now we offer them for backwards compatibility.
 
+  DRAKE_DEPRECATED(
+      "2019-06-15",
+      "This Isometry3 overload will be removed pending the resolution of "
+      "#9865. Use the RigidTransform overload instead.")
   void SetFreeBodyPose(systems::Context<T>* context, const Body<T>& body,
                        const Isometry3<T>& X_WB) const {
     SetFreeBodyPose(context, body, math::RigidTransform<T>(X_WB));
   }
 
+  DRAKE_DEPRECATED(
+      "2019-06-15",
+      "This Isometry3 overload will be removed pending the resolution of "
+      "#9865. Use the RigidTransform overload instead.")
   void SetFreeBodyPose(const systems::Context<T>& context,
                        systems::State<T>* state, const Body<T>& body,
                        const Isometry3<T>& X_WB) const {

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -1149,7 +1149,7 @@ GTEST_TEST(MultibodyPlantTest, CollisionGeometryRegistration) {
   // Place sphere 2 on top of the ground, with offset x = x_offset.
   plant.SetFreeBodyPose(
       context.get(), sphere2,
-      Isometry3d(Translation3d(x_offset, radius, 0.0)));
+      RigidTransformd(Vector3d(x_offset, radius, 0.0)));
 
   unique_ptr<AbstractValue> poses_value =
       plant.get_geometry_poses_output_port().Allocate();
@@ -1362,8 +1362,7 @@ GTEST_TEST(MultibodyPlantTest, MapVelocityToQdotAndBack) {
        2.0 * Vector3d::UnitY() +
        3.0 * Vector3d::UnitZ()).normalized();
   const math::RigidTransformd X_WB(AngleAxisd(M_PI / 3.0, axis_W), p_WB);
-  plant.SetFreeBodyPose(
-      context.get(), body, X_WB.GetAsIsometry3());
+  plant.SetFreeBodyPose(context.get(), body, X_WB);
 
   // Set an arbitrary, non-zero, spatial velocity of B in W.
   const SpatialVelocity<double> V_WB(Vector3d(1.0, 2.0, 3.0),
@@ -1596,10 +1595,8 @@ class MultibodyPlantContactJacobianTests : public ::testing::Test {
         RigidTransform<double>(RotationMatrix<double>::Identity(),
                Vector3<double>(0, small_box_size_ / 2.0 - penetration_, 0));
 
-    plant_.SetFreeBodyPose(
-        context, large_box, X_WLb.GetAsIsometry3());
-    plant_.SetFreeBodyPose(
-        context, small_box, X_WSb.GetAsIsometry3());
+    plant_.SetFreeBodyPose(context, large_box, X_WLb);
+    plant_.SetFreeBodyPose(context, small_box, X_WSb);
   }
 
   // Generate a valid set of penetrations for this particular setup that


### PR DESCRIPTION
Towards #11064

WIP Branch (with procedure): https://github.com/EricCousineau-TRI/drake/commits/issue/11064_SetFreeBodyPose-wip

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11074)
<!-- Reviewable:end -->
