### PR TITLE
Replace context.set_time() -> SetTime(), set_accuracy() -> SetAccuracy()

### DIFF
--- a/attic/manipulation/planner/test/robot_plan_interpolator_test.cc
+++ b/attic/manipulation/planner/test/robot_plan_interpolator_test.cc
@@ -150,7 +150,7 @@ void DoTrajectoryTest(InterpolatorType interp_type) {
   }
 
   for (const TrajectoryTestCase& kase : cases) {
-    context->set_time(kase.time);
+    context->SetTime(kase.time);
     dut.CalcUnrestrictedUpdate(*context, &context->get_mutable_state());
     dut.CalcOutput(*context, output.get());
     const double position =
@@ -176,7 +176,7 @@ void DoTrajectoryTest(InterpolatorType interp_type) {
   if (interp_type == InterpolatorType::Cubic ||
       interp_type == InterpolatorType::ZeroOrderHold ||
       interp_type == InterpolatorType::Pchip) {
-    context->set_time(t.back() + 0.01);
+    context->SetTime(t.back() + 0.01);
     dut.CalcUnrestrictedUpdate(*context, &context->get_mutable_state());
     dut.CalcOutput(*context, output.get());
     const double velocity =
@@ -193,7 +193,7 @@ void DoTrajectoryTest(InterpolatorType interp_type) {
 
   // Check that sending an empty plan causes us to continue to output
   // the same commanded position.
-  context->set_time(1);
+  context->SetTime(1);
   dut.CalcUnrestrictedUpdate(*context, &context->get_mutable_state());
   dut.CalcOutput(*context, output.get());
   double position =

--- a/attic/manipulation/scene_generation/simulate_plant_to_rest.cc
+++ b/attic/manipulation/scene_generation/simulate_plant_to_rest.cc
@@ -86,7 +86,7 @@ VectorX<double> SimulatePlantToRest::Run(const VectorX<double>& q_ik,
         .get_mutable_continuous_state_vector()
         .SetFromVector(x_initial);
     simulator.Initialize();
-    simulator.get_mutable_context().set_time(0.0);
+    simulator.get_mutable_context().SetTime(0.0);
 
     simulator.reset_integrator<systems::RungeKutta2Integrator<double>>(
         *diagram_, 0.0001, &simulator.get_mutable_context());

--- a/attic/systems/controllers/qp_inverse_dynamics/test/qp_output_translator_system_test.cc
+++ b/attic/systems/controllers/qp_inverse_dynamics/test/qp_output_translator_system_test.cc
@@ -32,7 +32,7 @@ GTEST_TEST(QpOutputTranslatorTest, QpOutputTranslatorTest) {
   auto context = dut->CreateDefaultContext();
   auto output = dut->AllocateOutput();
 
-  context->set_time(3.);
+  context->SetTime(3.);
 
   auto qp_output = std::make_unique<QpOutput>(GetDofNames(*robot));
   for (int i = 0; i < qp_output->dof_torques().size(); i++) {

--- a/automotive/test/maliput_railcar_test.cc
+++ b/automotive/test/maliput_railcar_test.cc
@@ -316,7 +316,7 @@ class MaliputRailcarTest : public ::testing::Test {
     params.set_velocity_limit_kp(8);
     SetParams(params);
 
-    context_->set_time(straight_lane->length() / kForwardSpeed);
+    context_->SetTime(straight_lane->length() / kForwardSpeed);
 
     // Verifies that MaliputRailcar::DoCalcUnrestrictedUpdate() switches to the
     // start of curved lane when it is traveling forward and reaches the end of
@@ -829,7 +829,7 @@ TEST_F(MaliputRailcarTest, DoCalcNextUpdateTimeDragwayWithS) {
 
   // Verifies that the time till reaching the end of the lane is equal to the
   // lane length divided by the vehicle's speed.
-  context_->set_time(0);
+  context_->SetTime(0);
   continuous_state()->set_s(0);
   continuous_state()->set_speed(kSpeed);
   systems::LeafCompositeEventCollection<double> events;
@@ -868,7 +868,7 @@ TEST_F(MaliputRailcarTest, DoCalcNextUpdateTimeDragwayAgainstS) {
   // Verifies that the time till reaching the end of the lane is equal to the
   // lane length divided by the vehicle's speed.
   systems::LeafCompositeEventCollection<double> events;
-  context_->set_time(0);
+  context_->SetTime(0);
   continuous_state()->set_s(lane->length());
   continuous_state()->set_speed(kSpeed);
   double t = dut_->CalcNextUpdateTime(*context_, &events);
@@ -909,7 +909,7 @@ TEST_F(MaliputRailcarTest, DoCalcNextUpdateTimeCurvedRoadWithS) {
 
   // Verifies that the time till reaching the end of the lane is equal to the
   // lane length divided by the vehicle's speed.
-  context_->set_time(0);
+  context_->SetTime(0);
   continuous_state()->set_s(0);
   continuous_state()->set_speed(kSpeed);
   systems::LeafCompositeEventCollection<double> events;
@@ -950,7 +950,7 @@ TEST_F(MaliputRailcarTest, DoCalcNextUpdateTimeCurvedRoadAgainstS) {
 
   // Verifies that the time till reaching the end of the lane is equal to the
   // lane length divided by the vehicle's speed.
-  context_->set_time(0);
+  context_->SetTime(0);
   continuous_state()->set_s(lane->length());
   continuous_state()->set_speed(kSpeed);
   systems::LeafCompositeEventCollection<double> events;

--- a/bindings/pydrake/attic/multibody/test/rigid_body_plant_test.py
+++ b/bindings/pydrake/attic/multibody/test/rigid_body_plant_test.py
@@ -226,10 +226,10 @@ class TestRigidBodyPlant(unittest.TestCase):
         context = viz.CreateDefaultContext()
         x0 = np.zeros(tree.get_num_positions() + tree.get_num_velocities())
         context.FixInputPort(0, BasicVector(x0))
-        context.set_time(0.)
+        context.SetTime(0.)
         viz.Publish(context)
         # Use a small time period, since it uses realtime playback.
-        context.set_time(0.01)
+        context.SetTime(0.01)
         viz.Publish(context)
         viz.ReplayCachedSimulation()
         # - Check that PublishLoadRobot can be called.

--- a/bindings/pydrake/examples/test/compass_gait_test.py
+++ b/bindings/pydrake/examples/test/compass_gait_test.py
@@ -44,7 +44,7 @@ class TestCompassGait(unittest.TestCase):
         # Create the simulator.
         simulator = Simulator(compass_gait)
         context = simulator.get_mutable_context()
-        context.set_accuracy(1e-8)
+        context.SetAccuracy(1e-8)
 
         # Set the initial state.
         state = context.get_mutable_continuous_state_vector()

--- a/bindings/pydrake/examples/test/rimless_wheel_test.py
+++ b/bindings/pydrake/examples/test/rimless_wheel_test.py
@@ -38,7 +38,7 @@ class TestRimlessWheel(unittest.TestCase):
         # Create the simulator.
         simulator = Simulator(rimless_wheel)
         context = simulator.get_mutable_context()
-        context.set_accuracy(1e-8)
+        context.SetAccuracy(1e-8)
 
         # Set the initial state.
         state = context.get_mutable_continuous_state_vector()

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -311,6 +311,7 @@ drake_py_unittest(
         ":analysis_py",
         ":framework_py",
         ":primitives_py",
+        "//bindings/pydrake/common/test_utilities",
         "//bindings/pydrake/examples:pendulum_py",
         "//bindings/pydrake/examples:rimless_wheel_py",
     ],

--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -159,11 +159,31 @@ void DefineFrameworkPySemantics(py::module m) {
             py::arg("index"), py::arg("data"), py_reference_internal,
             doc.Context.FixInputPort.doc_2args_index_data)
         .def("get_time", &Context<T>::get_time, doc.Context.get_time.doc)
-        .def("SetTime", &Context<T>::SetTime, doc.Context.SetTime.doc)
-        .def("set_time", &Context<T>::set_time, "Use SetTime() instead.")
-        .def("SetAccuracy", &Context<T>::SetAccuracy,
+        .def("SetTime", &Context<T>::SetTime, py::arg("time_sec"),
+            doc.Context.SetTime.doc)
+        .def("set_time",
+            [](Context<T>* self, const T& time) {
+              WarnDeprecated(
+                  "Use SetTime() instead. Will be removed on or after "
+                  "2019-07-01.");
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+              self->set_time(time);
+#pragma GCC diagnostic pop
+            },
+            "Use SetTime() instead.")
+        .def("SetAccuracy", &Context<T>::SetAccuracy, py::arg("accuracy"),
             doc.Context.SetAccuracy.doc)
-        .def("set_accuracy", &Context<T>::set_accuracy,
+        .def("set_accuracy",
+            [](Context<T>* self, const optional<double>& accuracy) {
+              WarnDeprecated(
+                  "Use SetAccuracy() instead. Will be removed on or after "
+                  "2019-07-01.");
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+              self->set_accuracy(accuracy);
+#pragma GCC diagnostic pop
+            },
             "Use SetAccuracy() instead.")
         .def("get_accuracy", &Context<T>::get_accuracy,
             doc.Context.get_accuracy.doc)

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -59,6 +59,7 @@ from pydrake.systems.primitives import (
     PassThrough,
     SignalLogger,
     )
+from pydrake.common.test_utilities.deprecation import catch_drake_warnings
 
 # TODO(eric.cousineau): The scope of this test file and and `custom_test.py`
 # is poor. Move these tests into `framework_test` and `analysis_test`, and
@@ -253,8 +254,12 @@ class TestGeneral(unittest.TestCase):
 
             # Create simulator specifying context.
             context = system.CreateDefaultContext()
+            with catch_drake_warnings(expected_count=1):
+                context.set_time(0.)
             context.SetTime(0.)
 
+            with catch_drake_warnings(expected_count=1):
+                context.set_accuracy(1e-4)
             context.SetAccuracy(1e-4)
             self.assertEqual(context.get_accuracy(), 1e-4)
 

--- a/examples/bouncing_ball/test/bouncing_ball_test.cc
+++ b/examples/bouncing_ball/test/bouncing_ball_test.cc
@@ -165,7 +165,7 @@ TEST_F(BouncingBallTest, Simulate) {
   drake::systems::Simulator<double> simulator(*dut_, std::move(context_));
   simulator.reset_integrator<systems::RungeKutta3Integrator<double>>(*dut_,
       &simulator.get_mutable_context());
-  simulator.get_mutable_context().set_accuracy(accuracy);
+  simulator.get_mutable_context().SetAccuracy(accuracy);
   simulator.get_mutable_integrator()->request_initial_step_size_target(1e-3);
   simulator.get_mutable_integrator()->set_target_accuracy(accuracy);
   simulator.Initialize();

--- a/examples/compass_gait/simulate.cc
+++ b/examples/compass_gait/simulate.cc
@@ -76,7 +76,7 @@ int DoMain() {
   state.set_swingdot(-2.0);
 
   simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
-  simulator.get_mutable_context().set_accuracy(1e-4);
+  simulator.get_mutable_context().SetAccuracy(1e-4);
   simulator.AdvanceTo(10);
 
   return 0;

--- a/examples/humanoid_controller/test/atlas_command_translator_system_test.cc
+++ b/examples/humanoid_controller/test/atlas_command_translator_system_test.cc
@@ -37,7 +37,7 @@ GTEST_TEST(JointLevelControllerTest, AtlasJointLevelControllerTest) {
   auto context = dut->CreateDefaultContext();
   auto output = dut->AllocateOutput();
 
-  context->set_time(3.);
+  context->SetTime(3.);
 
   auto qp_output = std::make_unique<QpOutput>(GetDofNames(*robot));
   for (int i = 0; i < qp_output->dof_torques().size(); i++) {

--- a/examples/humanoid_controller/test/humanoid_plan_eval_system_test.cc
+++ b/examples/humanoid_controller/test/humanoid_plan_eval_system_test.cc
@@ -105,7 +105,7 @@ class HumanoidPlanEvalAndQpInverseDynamicsTest : public ::testing::Test {
     diagram_ = builder.Build();
 
     context_ = diagram_->CreateDefaultContext();
-    context_->set_time(0);
+    context_->SetTime(0);
     output_ = diagram_->AllocateOutput();
 
     // Initializes.

--- a/examples/humanoid_controller/valkyrie_balancing_demo.cc
+++ b/examples/humanoid_controller/valkyrie_balancing_demo.cc
@@ -42,7 +42,7 @@ void controller_loop() {
   const AbstractValue& first_msg = loop.WaitForMessage();
   double msg_time =
       loop.get_message_to_time_converter().GetTimeInSeconds(first_msg);
-  loop.get_mutable_context().set_time(msg_time);
+  loop.get_mutable_context().SetTime(msg_time);
 
   // Decodes the message into q and v.
   const bot_core::robot_state_t& raw_msg =

--- a/examples/kinova_jaco_arm/jaco_controller.cc
+++ b/examples/kinova_jaco_arm/jaco_controller.cc
@@ -177,7 +177,7 @@ int DoMain() {
   status_sub->SetDefaultContext(&status_sub_context);
 
   // Explicit initialization.
-  diagram_context.set_time(msg_time);
+  diagram_context.SetTime(msg_time);
   auto& plan_source_context =
       diagram->GetMutableSubsystemContext(*plan_source, &diagram_context);
   plan_source->Initialize(msg_time, q0,

--- a/examples/kuka_iiwa_arm/iiwa_controller.cc
+++ b/examples/kuka_iiwa_arm/iiwa_controller.cc
@@ -136,7 +136,7 @@ int DoMain() {
   status_sub->SetDefaultContext(&status_sub_context);
 
   // Explicit initialization.
-  diagram_context.set_time(msg_time);
+  diagram_context.SetTime(msg_time);
   auto& plan_interpolator_context =
       diagram->GetMutableSubsystemContext(*plan_interpolator, &diagram_context);
   plan_interpolator->Initialize(msg_time, q0, &plan_interpolator_context);

--- a/examples/multibody/acrobot/run_lqr.cc
+++ b/examples/multibody/acrobot/run_lqr.cc
@@ -168,7 +168,7 @@ int do_main() {
   elbow.set_random_angle_distribution(0.05*gaussian(generator));
 
   for (int i = 0; i < 5; i++) {
-    simulator.get_mutable_context().set_time(0.0);
+    simulator.get_mutable_context().SetTime(0.0);
     simulator.get_system().SetRandomContext(&simulator.get_mutable_context(),
                                             &generator);
 

--- a/examples/qp_inverse_dynamics/test/manipulator_joint_space_controller_test.cc
+++ b/examples/qp_inverse_dynamics/test/manipulator_joint_space_controller_test.cc
@@ -116,7 +116,7 @@ class ManipulatorJointSpaceControllerTest : public ::testing::Test {
     diagram_ = builder.Build();
 
     context_ = diagram_->CreateDefaultContext();
-    context_->set_time(0);
+    context_->SetTime(0);
     output_ = diagram_->AllocateOutput();
 
     // Initializes.

--- a/examples/rimless_wheel/simulate.cc
+++ b/examples/rimless_wheel/simulate.cc
@@ -88,7 +88,7 @@ int DoMain() {
   state.set_thetadot(FLAGS_initial_angular_velocity);
 
   simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
-  simulator.get_mutable_context().set_accuracy(FLAGS_accuracy);
+  simulator.get_mutable_context().SetAccuracy(FLAGS_accuracy);
   simulator.AdvanceTo(10);
 
   // Check that the state is still inside the expected region (I did not miss

--- a/examples/rimless_wheel/test/rimless_wheel_test.cc
+++ b/examples/rimless_wheel/test/rimless_wheel_test.cc
@@ -41,7 +41,7 @@ GTEST_TEST(RimlessWheelTest, StepTest) {
 
   systems::Simulator<double> simulator(rw);
   auto& context = simulator.get_mutable_context();
-  context.set_accuracy(1e-8);
+  context.SetAccuracy(1e-8);
 
   RimlessWheelContinuousState<double>& state =
       rw.get_mutable_continuous_state(&context);
@@ -61,7 +61,7 @@ GTEST_TEST(RimlessWheelTest, StepTest) {
   const double step_length = 2 * params.length() * sin(alpha);
 
   // A point on that limit cycle just before a forward step:
-  context.set_time(0.0);
+  context.SetTime(0.0);
   state.set_theta(params.slope() + alpha / 2.0);
   toe = 0.0;
   double_support = false;
@@ -80,7 +80,7 @@ GTEST_TEST(RimlessWheelTest, StepTest) {
   const double threshold = 0.01;
 
   // Walking too fast should lose energy through impact.
-  context.set_time(0.0);
+  context.SetTime(0.0);
   state.set_theta(params.slope() + alpha / 2.0);
   toe = 0.0;
   double_support = false;
@@ -96,7 +96,7 @@ GTEST_TEST(RimlessWheelTest, StepTest) {
   EXPECT_LT(rw.CalcTotalEnergy(context), initial_energy - threshold);
 
   // Walking too slow should gain energy through impact.
-  context.set_time(0.0);
+  context.SetTime(0.0);
   state.set_theta(params.slope() + alpha / 2.0);
   toe = 0.0;
   double_support = false;
@@ -112,7 +112,7 @@ GTEST_TEST(RimlessWheelTest, StepTest) {
   EXPECT_GT(rw.CalcTotalEnergy(context), initial_energy + threshold);
 
   // Rolling uphill should always lose energy.
-  context.set_time(0.0);
+  context.SetTime(0.0);
   // Leaning uphill.
   state.set_theta(params.slope() - alpha / 2.0);
   state.set_thetadot(-4.);
@@ -135,7 +135,7 @@ GTEST_TEST(RimlessWheelTest, FixedPointTest) {
 
   systems::Simulator<double> simulator(rw);
   auto& context = simulator.get_mutable_context();
-  context.set_accuracy(1e-8);
+  context.SetAccuracy(1e-8);
 
   RimlessWheelContinuousState<double>& state =
       rw.get_mutable_continuous_state(&context);
@@ -151,7 +151,7 @@ GTEST_TEST(RimlessWheelTest, FixedPointTest) {
   const double angle_above_touchdown = 1e-5;
 
   // Front foot down.
-  context.set_time(0.0);
+  context.SetTime(0.0);
   state.set_theta(params.slope() + alpha - angle_above_touchdown);
   state.set_thetadot(0.0);
   toe = 0.0;
@@ -162,7 +162,7 @@ GTEST_TEST(RimlessWheelTest, FixedPointTest) {
   EXPECT_EQ(state.thetadot(), 0.0);
 
   // Back foot down.
-  context.set_time(0.0);
+  context.SetTime(0.0);
   state.set_theta(params.slope() - alpha + angle_above_touchdown);
   state.set_thetadot(0.0);
   toe = 0.0;

--- a/manipulation/perception/test/pose_smoother_test.cc
+++ b/manipulation/perception/test/pose_smoother_test.cc
@@ -55,7 +55,7 @@ class PoseSmootherTest : public ::testing::Test {
         AbstractValue::Make(Isometry3<double>::Identity()));
     input->set_value(input_pose);
     context_->FixInputPort(0 /* input port ID*/, std::move(input));
-    context_->set_time(input_time);
+    context_->SetTime(input_time);
 
     dut_->CalcUnrestrictedUpdate(*context_, &context_->get_mutable_state());
     dut_->CalcOutput(*context_, output_.get());

--- a/multibody/benchmarks/free_body/test/multibody_plant_free_body_test.cc
+++ b/multibody/benchmarks/free_body/test/multibody_plant_free_body_test.cc
@@ -238,7 +238,7 @@ void  TestDrakeSolutionForSpecificInitialValue(
   state_drake.SetFromVector(state_initial);
 
   // Ensure the time stored by context is set to 0.0 (initial value).
-  context->set_time(0.0);
+  context->SetTime(0.0);
 
   // Test Drake's calculated values for the time-derivative of the state at
   // time t = 0 versus the exact (closed-form) solution.

--- a/multibody/plant/test/joint_limits_test.cc
+++ b/multibody/plant/test/joint_limits_test.cc
@@ -107,7 +107,7 @@ GTEST_TEST(JointLimitsTest, PrismaticJointConvergenceTest) {
     context.FixInputPort(
       plant.get_actuation_input_port().get_index(),
       Vector1<double>::Constant(10.0));
-    context.set_time(0.0);
+    context.SetTime(0.0);
     simulator.AdvanceTo(simulation_time);
 
     // Verify we are at rest near the upper limit.
@@ -183,7 +183,7 @@ GTEST_TEST(JointLimitsTest, RevoluteJoint) {
     context.FixInputPort(
       plant.get_actuation_input_port().get_index(),
       Vector1<double>::Constant(-1.5));
-    context.set_time(0.0);
+    context.SetTime(0.0);
     simulator.AdvanceTo(simulation_time);
 
     // Verify we are at rest near the lower limit.
@@ -284,7 +284,7 @@ GTEST_TEST(JointLimitsTest, KukaArm) {
     plant.get_actuation_input_port().get_index(),
     VectorX<double>::Constant(nq, -0.4));
   plant.SetDefaultContext(&context);
-  context.set_time(0.0);
+  context.SetTime(0.0);
   simulator.AdvanceTo(simulation_time);
   for (int joint_number = 1; joint_number <= nq; ++joint_number) {
     const std::string joint_name = "iiwa_joint_" + std::to_string(joint_number);

--- a/systems/controllers/dynamic_programming.cc
+++ b/systems/controllers/dynamic_programming.cc
@@ -89,7 +89,7 @@ FittedValueIteration(
     context.FixInputPort(0, input_vec);
 
     for (int state = 0; state < num_states; state++) {
-      context.set_time(0.0);
+      context.SetTime(0.0);
       sim_state.SetFromVector(state_mesh.get_mesh_point(state));
 
       cost[input](state) = timestep * cost_function(context);
@@ -218,7 +218,7 @@ Eigen::VectorXd LinearProgrammingApproximateDynamicProgramming(
   for (int input = 0; input < num_inputs; input++) {
     context.FixInputPort(0, input_samples.col(input));
     for (int state = 0; state < num_states; state++) {
-      context.set_time(0.0);
+      context.SetTime(0.0);
       state_vec = state_samples.col(state);
       sim_state.SetFromVector(state_vec);
 

--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -547,8 +547,9 @@ class Context : public ContextBase {
   }
 
 #ifndef DRAKE_DOXYGEN_CXX
-  // These are to-be-deprecated. Use SetTime() and SetAccuracy() instead.
+  DRAKE_DEPRECATED("2019-07-01", "Use SetTime() instead.")
   void set_time(const T& time_sec) { SetTime(time_sec); }
+  DRAKE_DEPRECATED("2019-07-01", "Use SetAccuracy() instead.")
   void set_accuracy(const optional<double>& accuracy) { SetAccuracy(accuracy); }
 #endif
   //@}

--- a/systems/framework/system_symbolic_inspector.cc
+++ b/systems/framework/system_symbolic_inspector.cc
@@ -30,7 +30,7 @@ SystemSymbolicInspector::SystemSymbolicInspector(
 
   // Time.
   time_ = symbolic::Variable("t");
-  context_->set_time(time_);
+  context_->SetTime(time_);
 
   // Input.
   InitializeVectorInputs(system);

--- a/systems/lcm/test/lcm_driven_loop_test.cc
+++ b/systems/lcm/test/lcm_driven_loop_test.cc
@@ -113,7 +113,7 @@ GTEST_TEST(LcmDrivenLoopTest, TestLoop) {
   const AbstractValue& first_msg = dut.WaitForMessage();
   double msg_time =
       dut.get_message_to_time_converter().GetTimeInSeconds(first_msg);
-  dut.get_mutable_context().set_time(msg_time);
+  dut.get_mutable_context().SetTime(msg_time);
 
   // Starts the loop.
   dut.RunToSecondsAssumingInitialized(static_cast<double>(kEnd));

--- a/systems/lcm/test/lcm_log_playback_test.cc
+++ b/systems/lcm/test/lcm_log_playback_test.cc
@@ -22,7 +22,7 @@ void SetInput(double time, const std::string& name, double val,
   msg.val.resize(kDim, val);
   msg.coord.resize(kDim, name);
   msg.timestamp = time * 1e6;
-  context->set_time(time);
+  context->SetTime(time);
   context->FixInputPort(0, AbstractValue::Make<lcmt_drake_signal>(msg));
 }
 

--- a/systems/lcm/test/lcm_publisher_system_test.cc
+++ b/systems/lcm/test/lcm_publisher_system_test.cc
@@ -58,7 +58,7 @@ void TestPublisher(const std::string& channel_name, lcm::DrakeMockLcm* lcm,
   // Sets the timestamp within the context. This timestamp should be transmitted
   // by the LCM message.
   const double time = 1.41421356;
-  context->set_time(time);
+  context->SetTime(time);
 
   dut->Publish(*context.get());
 

--- a/systems/lcm/test/translator_test.cc
+++ b/systems/lcm/test/translator_test.cc
@@ -201,7 +201,7 @@ GTEST_TEST(TranslatorTest, EncodeBasicVectorVersion) {
   auto context = dut.CreateDefaultContext();
   auto output = dut.AllocateOutput();
   context->FixInputPort(0, vec.Clone());
-  context->set_time(233);
+  context->SetTime(233);
 
   dut.CalcOutput(*context, output.get());
   const lcmt_drake_signal& msg =
@@ -225,7 +225,7 @@ GTEST_TEST(TranslatorTest, EncodeAbstractValVersion) {
   auto context = dut.CreateDefaultContext();
   auto output = dut.AllocateOutput();
   context->FixInputPort(0, AbstractValue::Make<TestData>(data));
-  context->set_time(233);
+  context->SetTime(233);
 
   dut.CalcOutput(*context, output.get());
   const lcmt_drake_signal& msg =

--- a/systems/optimization/system_constraint_adapter.cc
+++ b/systems/optimization/system_constraint_adapter.cc
@@ -94,7 +94,7 @@ class UpdateContextForSymbolicSystemConstraint {
                   Context<T>* context) const {
     // Time.
     if (time_var_index_.has_value()) {
-      context->set_time(x(time_var_index_.value()));
+      context->SetTime(x(time_var_index_.value()));
     }
     for (const auto& item : context_indices_) {
       switch (item.kind) {
@@ -172,7 +172,7 @@ SystemConstraintAdapter::MaybeCreateGenericConstraintSymbolically(
   VectorX<symbolic::Variable> bound_variables;
   // context_fixed stores the constant values in @p context
   auto context_fixed = system_double_->CreateDefaultContext();
-  context_fixed->set_accuracy(context.get_accuracy());
+  context_fixed->SetAccuracy(context.get_accuracy());
 
   std::vector<ContextIndex> context_indices;
   optional<int> time_var_index{};
@@ -186,7 +186,7 @@ SystemConstraintAdapter::MaybeCreateGenericConstraintSymbolically(
     return {};
   }
   if (constant_val.has_value()) {
-    context_fixed->set_time(constant_val.value());
+    context_fixed->SetTime(constant_val.value());
   } else {
     time_var_index = variable_index.value();
   }

--- a/systems/optimization/test/system_constraint_adapter_test.cc
+++ b/systems/optimization/test/system_constraint_adapter_test.cc
@@ -120,7 +120,7 @@ GTEST_TEST(SystemConstraintAdapterTest,
       Vector3<symbolic::Expression>(a, x1_val, x2_val));
   context_symbolic->get_mutable_discrete_state_vector().SetAtIndex(0, c);
   context_symbolic->get_mutable_numeric_parameter(0).GetAtIndex(0) = b;
-  context_symbolic->set_time(t);
+  context_symbolic->SetTime(t);
 
   optional<solvers::Binding<solvers::Constraint>> binding =
       adapter.MaybeCreateGenericConstraintSymbolically(
@@ -175,8 +175,8 @@ GTEST_TEST(SystemConstraintAdapterTest,
   context_double->get_mutable_discrete_state_vector().SetAtIndex(0, c_val);
   context_autodiff->get_mutable_discrete_state_vector().GetAtIndex(0) =
       abct_autodiff(2);
-  context_double->set_time(t_val);
-  context_autodiff->set_time(abct_autodiff(3));
+  context_double->SetTime(t_val);
+  context_autodiff->SetTime(abct_autodiff(3));
   Eigen::VectorXd constraint_val_expected;
   DummySystemConstraintCalc(*context_double, &constraint_val_expected);
 

--- a/systems/plants/spring_mass_system/test/spring_mass_system_test.cc
+++ b/systems/plants/spring_mass_system/test/spring_mass_system_test.cc
@@ -284,7 +284,7 @@ void StepExplicitEuler(
       context.get_mutable_continuous_state_vector();
   const auto& dxc = derivs.get_vector();
   xc.PlusEqScaled(h, dxc);  // xc += h*dxc
-  context.set_time(t + h);
+  context.SetTime(t + h);
 }
 
 /* Semi-explicit Euler (neutrally stable):
@@ -310,7 +310,7 @@ void StepSemiExplicitEuler(
   const auto& dxv = derivs.get_generalized_velocity();
   xv.PlusEqScaled(h, dxv);  // xv += h*dxv
 
-  context.set_time(t + h);
+  context.SetTime(t + h);
 
   // Invalidate q-dependent quantities.
   VectorBase<double>& xq = xc.get_mutable_generalized_position();
@@ -341,7 +341,7 @@ void StepImplicitEuler(
   const auto vx0 = x1.CopyToVector();
   const auto& dx0 = derivs.get_vector();
   x1.PlusEqScaled(h, dx0);  // x1 += h*dx0 (initial guess)
-  context.set_time(t + h);   // t=t1
+  context.SetTime(t + h);   // t=t1
   const int nx = static_cast<int>(vx0.size());
   const auto I = MatrixX<double>::Identity(nx, nx);
 
@@ -400,7 +400,7 @@ TEST_F(SpringMassSystemTest, Integrate) {
 
   // Set initial conditions in each Context.
   for (auto& context : contexts) {
-    context->set_time(0);
+    context->SetTime(0);
     system_->set_position(context.get(), 0.1);  // Displacement 0.1m, vel. 0m/s.
     system_->set_velocity(context.get(), 0.);
   }
@@ -461,7 +461,7 @@ TEST_F(SpringMassSystemTest, IntegrateConservativePower) {
       system_->AllocateTimeDerivatives();
 
   // Set initial conditions..
-  context->set_time(0);
+  context->SetTime(0);
   system_->set_position(context.get(), 0.1);  // Displacement 0.1m, vel. 0m/s.
   system_->set_velocity(context.get(), 0.);
   system_->set_conservative_work(context.get(), 0.);  // W(0)=0

--- a/systems/primitives/test/affine_system_test.cc
+++ b/systems/primitives/test/affine_system_test.cc
@@ -248,7 +248,7 @@ GTEST_TEST(SimpleTimeVaryingAffineSystemTest, EvalTest) {
   Eigen::Vector2d x(1, 2);
 
   auto context = sys.CreateDefaultContext();
-  context->set_time(t);
+  context->SetTime(t);
   context->get_mutable_continuous_state_vector().SetFromVector(x);
   context->FixInputPort(0, BasicVector<double>::Make(42.0));
 
@@ -267,7 +267,7 @@ GTEST_TEST(SimpleTimeVaryingAffineSystemTest, DiscreteEvalTest) {
   Eigen::Vector2d x(1, 2);
 
   auto context = sys.CreateDefaultContext();
-  context->set_time(t);
+  context->SetTime(t);
   context->get_mutable_discrete_state().get_mutable_vector().SetFromVector(x);
   context->FixInputPort(0, BasicVector<double>::Make(42.0));
 
@@ -300,7 +300,7 @@ GTEST_TEST(IllegalTimeVaryingAffineSystemTest, EvalDeathTest) {
   const double t = 2.5;
 
   auto context = sys.CreateDefaultContext();
-  context->set_time(t);
+  context->SetTime(t);
 
   auto derivatives = sys.AllocateTimeDerivatives();
   ASSERT_DEATH(sys.CalcTimeDerivatives(*context, derivatives.get()), "rows");

--- a/systems/primitives/test/piecewise_polynomial_affine_system_test.cc
+++ b/systems/primitives/test/piecewise_polynomial_affine_system_test.cc
@@ -109,7 +109,7 @@ TEST_P(PiecewisePolynomialAffineSystemTest, DiscreteUpdates) {
 
   const double tol = 1e-10;
   for (const double t : mat_data_.times) {
-    context_->set_time(t);
+    context_->SetTime(t);
     const Eigen::Matrix2d A = ltv_data_.A.value(t);
     const Eigen::Matrix2d B = ltv_data_.B.value(t);
     const Eigen::Vector2d f0 = ltv_data_.f0.value(t);
@@ -142,7 +142,7 @@ TEST_P(PiecewisePolynomialAffineSystemTest, Output) {
 
   const double tol = 1e-10;
   for (const double t : mat_data_.times) {
-    context_->set_time(t);
+    context_->SetTime(t);
 
     const Eigen::Matrix2d C = ltv_data_.C.value(t);
     const Eigen::Matrix2d D = ltv_data_.D.value(t);

--- a/systems/primitives/test/piecewise_polynomial_linear_system_test.cc
+++ b/systems/primitives/test/piecewise_polynomial_linear_system_test.cc
@@ -106,7 +106,7 @@ TEST_P(PiecewisePolynomialLinearSystemTest, Derivatives) {
                             1.5 * kDiscreteTimeStep};
   const double tol = 1e-10;
   for (const double t : times) {
-    context_->set_time(t);
+    context_->SetTime(t);
     const Eigen::Matrix2d A = ltv_data_.A.value(t);
     const Eigen::Matrix2d B = ltv_data_.B.value(t);
     if (time_period_ == 0.) {
@@ -141,7 +141,7 @@ TEST_P(PiecewisePolynomialLinearSystemTest, Output) {
                             1.5 * kDiscreteTimeStep};
   const double tol = 1e-10;
   for (const double t : times) {
-    context_->set_time(t);
+    context_->SetTime(t);
 
     const Eigen::Matrix2d C = ltv_data_.C.value(t);
     const Eigen::Matrix2d D = ltv_data_.D.value(t);

--- a/systems/primitives/test/sine_test.cc
+++ b/systems/primitives/test/sine_test.cc
@@ -44,7 +44,7 @@ void TestSineSystem(const Sine<T>& sine_system,
 
     for (int i = 0; i < input_vectors.cols(); i++) {
       // Initialize the time in seconds to be used by the Sine system.
-      context->set_time(input_vectors(0, i));
+      context->SetTime(input_vectors(0, i));
 
       // Check the Sine output.
       ASSERT_EQ(3, sine_system.get_num_output_ports());

--- a/systems/primitives/test/symbolic_vector_system_test.cc
+++ b/systems/primitives/test/symbolic_vector_system_test.cc
@@ -147,7 +147,7 @@ GTEST_TEST(SymbolicVectorSystemTest, OutputScaledTime) {
   EXPECT_EQ(system.get_num_input_ports(), 0);
   EXPECT_EQ(system.get_output_port().size(), 1);
 
-  context->set_time(2.0);
+  context->SetTime(2.0);
   EXPECT_TRUE(CompareMatrices(system.get_output_port()
                                   .template Eval<BasicVector<double>>(*context)
                                   .CopyToVector(),
@@ -213,7 +213,7 @@ GTEST_TEST(SymbolicVectorSystemTest, ContinuousTimeSymbolic) {
   Vector2<Expression> xc{Variable{"xc0"}, Variable{"xc1"}};
   Vector2<Expression> uc{Variable{"uc0"}, Variable{"uc1"}};
 
-  context->set_time(tc);
+  context->SetTime(tc);
   context->SetContinuousState(xc);
   context->FixInputPort(0, uc);
 
@@ -247,7 +247,7 @@ GTEST_TEST(SymbolicVectorSystemTest, DiscreteTimeSymbolic) {
   Vector2<Expression> xc{Variable{"xc0"}, Variable{"xc1"}};
   Vector2<Expression> uc{Variable{"uc0"}, Variable{"uc1"}};
 
-  context->set_time(tc);
+  context->SetTime(tc);
   context->get_mutable_discrete_state_vector().SetFromVector(xc);
   context->FixInputPort(0, uc);
 
@@ -295,7 +295,7 @@ GTEST_TEST(SymbolicVectorSystemTest, TestAutodiffXd) {
 
   const VectorX<AutoDiffXd> txu = math::initializeAutoDiff(txuval);
 
-  context->set_time(txu[0]);
+  context->SetTime(txu[0]);
   context->SetContinuousState(txu.segment<1>(1));
   context->FixInputPort(0, txu.tail<2>());
   const auto xdotval =

--- a/systems/primitives/test/trajectory_source_test.cc
+++ b/systems/primitives/test/trajectory_source_test.cc
@@ -48,7 +48,7 @@ TEST_F(TrajectorySourceTest, OutputTest) {
   ASSERT_EQ(0, context_->get_num_input_ports());
 
   const double kTestTime = 1.75;
-  context_->set_time(kTestTime);
+  context_->SetTime(kTestTime);
 
   const auto& output = source_->get_output_port(0).Eval(*context_);
 

--- a/systems/primitives/test/zero_order_hold_test.cc
+++ b/systems/primitives/test/zero_order_hold_test.cc
@@ -154,7 +154,7 @@ TEST_P(ZeroOrderHoldTest, Output) {
 // is requested in the future.
 TEST_P(ZeroOrderHoldTest, NextUpdateTimeMustNotBeCurrentTime) {
   // Calculate the next update time *after* 0.
-  context_->set_time(0.0);
+  context_->SetTime(0.0);
   const double t_next = hold_->CalcNextUpdateTime(*context_, event_info_.get());
 
   // Check that the time is correct.
@@ -168,7 +168,7 @@ TEST_P(ZeroOrderHoldTest, NextUpdateTimeMustNotBeCurrentTime) {
 // at the appropriate time in the future.
 TEST_P(ZeroOrderHoldTest, NextUpdateTimeIsInTheFuture) {
   // Calculate the next update time.
-  context_->set_time(763.2 * kPeriod);
+  context_->SetTime(763.2 * kPeriod);
 
   // Check that the time is correct.
   const double t_next = hold_->CalcNextUpdateTime(*context_, event_info_.get());

--- a/systems/sensors/test/image_writer_test.cc
+++ b/systems/sensors/test/image_writer_test.cc
@@ -267,7 +267,7 @@ class ImageWriterTest : public ::testing::Test {
     auto context = writer.AllocateContext();
     context->FixInputPort(port.get_index(),
                           AbstractValue::Make<Image<kPixelType>>(image));
-    context->set_time(0.);
+    context->SetTime(0.);
     writer.CalcNextUpdateTime(*context, events.get());
 
     const std::string expected_name = tester.MakeFileName(
@@ -594,7 +594,7 @@ TEST_F(ImageWriterTest, SingleConfiguredPort) {
   {
     auto events = writer.AllocateCompositeEventCollection();
     auto context = writer.AllocateContext();
-    context->set_time(0.);
+    context->SetTime(0.);
     double next_time = writer.CalcNextUpdateTime(*context, events.get());
     // Confirm start time fed into the periodic event.
     EXPECT_EQ(start_time, next_time);
@@ -637,7 +637,7 @@ TEST_F(ImageWriterTest, SingleConfiguredPort) {
     }
 
     // Confirm period is correct.
-    context->set_time(start_time + 0.1 * period);
+    context->SetTime(start_time + 0.1 * period);
     events->Clear();
     next_time = writer.CalcNextUpdateTime(*context, events.get());
     EXPECT_EQ(start_time + period, next_time);

--- a/systems/trajectory_optimization/direct_transcription.cc
+++ b/systems/trajectory_optimization/direct_transcription.cc
@@ -75,7 +75,7 @@ class DiscreteTimeSystemConstraint : public solvers::Constraint {
     const auto state = x.segment(num_inputs_, num_states_);
     const auto next_state = x.tail(num_states_);
 
-    context_->set_time(evaluation_time_);
+    context_->SetTime(evaluation_time_);
     if (context_->get_num_input_ports() > 0) {
       input_port_value_->GetMutableVectorData<AutoDiffXd>()->SetFromVector(
           input);


### PR DESCRIPTION
The Context methods `set_time()` and `set_accuracy()` improperly had `fast_snake_case` names. Since they can cause cache invalidations, they were recently renamed `SetTime()` and `SetAccuracy()`.

This PR replaces all uses of the old names in Drake with the new ones and deprecates the old ones.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11077)
<!-- Reviewable:end -->
