### PR TITLE
Replace deprecated calls: get_num_xxx -> num_xxx

### DIFF
--- a/attic/manipulation/dev/quasistatic_iiwa_pick_and_place_demo.cc
+++ b/attic/manipulation/dev/quasistatic_iiwa_pick_and_place_demo.cc
@@ -242,7 +242,7 @@ int do_main() {
           gripper_traj, 0);
 
   // picks the qdot from iiwa_traj_src output using matrix gain
-  const int n_qa_dot = iiwa_traj_src->get_num_total_outputs() / 2;
+  const int n_qa_dot = iiwa_traj_src->num_total_outputs() / 2;
   MatrixXd D2(n_qa_dot, n_qa_dot * 2);
   D2.setZero();
   D2.block(0, n_qa_dot, n_qa_dot, n_qa_dot).setIdentity();

--- a/attic/multibody/rigid_body_plant/kinematics_results.cc
+++ b/attic/multibody/rigid_body_plant/kinematics_results.cc
@@ -82,7 +82,7 @@ void KinematicsResults<T>::UpdateFromContext(const Context<T>& context) {
   const int nv = tree_->get_num_velocities();
 
   VectorX<T> x;
-  if (context.get_state().get_continuous_state().size() > 0) {
+  if (context.num_continuous_states() > 0) {
     // TODO(amcastro-tri): provide nicer accessor to an Eigen representation for
     // LeafSystems.
     x = dynamic_cast<const BasicVector<T>&>(

--- a/attic/multibody/rigid_body_plant/test/drake_visualizer_test.cc
+++ b/attic/multibody/rigid_body_plant/test/drake_visualizer_test.cc
@@ -470,7 +470,7 @@ GTEST_TEST(DrakeVisualizerTests, BasicTest) {
 
   auto context = dut.CreateDefaultContext();
 
-  EXPECT_EQ(1, context->get_num_input_ports());
+  EXPECT_EQ(1, context->num_input_ports());
 
   // Initializes the system's input vector to contain all zeros.
   const int vector_size =

--- a/attic/multibody/rigid_body_plant/test/frame_visualizer_test.cc
+++ b/attic/multibody/rigid_body_plant/test/frame_visualizer_test.cc
@@ -48,7 +48,7 @@ GTEST_TEST(FrameVisualizerTests, TestMessageGeneration) {
     }
 
     auto context = dut.CreateDefaultContext();
-    EXPECT_EQ(1, context->get_num_input_ports());
+    EXPECT_EQ(1, context->num_input_ports());
 
     // Initializes the system's input vector to contain all zeros.
     const int vector_size =

--- a/attic/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
+++ b/attic/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
@@ -290,8 +290,8 @@ TEST_P(KukaArmTest, EvalOutput) {
 
   // Checks that the number of input and output ports in the system and context
   // are consistent.
-  ASSERT_EQ(1, kuka_plant_->get_num_input_ports());
-  ASSERT_EQ(1, context_->get_num_input_ports());
+  ASSERT_EQ(1, kuka_plant_->num_input_ports());
+  ASSERT_EQ(1, context_->num_input_ports());
   ASSERT_EQ(1, kuka_plant_->get_num_model_instances());
 
   const int kModelInstanceId =
@@ -346,9 +346,9 @@ TEST_P(KukaArmTest, EvalOutput) {
   // (In this context, there is only one model instance and thus only one model
   // instance state port.)
   if (kuka_plant_->is_state_discrete()) {
-    ASSERT_EQ(5, output_->get_num_ports());
+    ASSERT_EQ(5, output_->num_ports());
   } else {
-    ASSERT_EQ(6, output_->get_num_ports());
+    ASSERT_EQ(6, output_->num_ports());
   }
 
   kuka_plant_->CalcOutput(*context_, output_.get());
@@ -567,7 +567,7 @@ GTEST_TEST(rigid_body_plant_test, BasicTimeSteppingTest) {
   // but as discrete state.
   EXPECT_TRUE(continuous_context->has_only_continuous_state());
   EXPECT_TRUE(time_stepping_context->has_only_discrete_state());
-  EXPECT_EQ(continuous_context->get_continuous_state().size(),
+  EXPECT_EQ(continuous_context->num_continuous_states(),
             time_stepping_context->get_discrete_state(0).size());
 
   // Check that the dynamics of the time-stepping model match the

--- a/attic/systems/controllers/test/rbt_inverse_dynamics_test.cc
+++ b/attic/systems/controllers/test/rbt_inverse_dynamics_test.cc
@@ -45,20 +45,20 @@ class InverseDynamicsTest : public ::testing::Test {
     // Checks that the number of input ports in the Gravity Compensator system
     // and the Context are consistent.
     if (mode == InverseDynamics<double>::kGravityCompensation) {
-      EXPECT_EQ(inverse_dynamics_->get_num_input_ports(), 1);
-      EXPECT_EQ(inverse_dynamics_context_->get_num_input_ports(), 1);
+      EXPECT_EQ(inverse_dynamics_->num_input_ports(), 1);
+      EXPECT_EQ(inverse_dynamics_context_->num_input_ports(), 1);
     } else {
-      EXPECT_EQ(inverse_dynamics_->get_num_input_ports(), 2);
-      EXPECT_EQ(inverse_dynamics_context_->get_num_input_ports(), 2);
+      EXPECT_EQ(inverse_dynamics_->num_input_ports(), 2);
+      EXPECT_EQ(inverse_dynamics_context_->num_input_ports(), 2);
     }
 
     // Checks that no state variables are allocated in the context.
-    EXPECT_EQ(inverse_dynamics_context_->get_continuous_state().size(), 0);
+    EXPECT_EQ(inverse_dynamics_context_->num_continuous_states(), 0);
 
     // Checks that the number of output ports in the Gravity Compensator system
     // and the SystemOutput are consistent.
-    EXPECT_EQ(output_->get_num_ports(), 1);
-    EXPECT_EQ(inverse_dynamics_->get_num_output_ports(), 1);
+    EXPECT_EQ(output_->num_ports(), 1);
+    EXPECT_EQ(inverse_dynamics_->num_output_ports(), 1);
   }
 
   void CheckGravityTorque(const Eigen::VectorXd& position) {

--- a/attic/systems/sensors/test/accelerometer_test/accelerometer_test.cc
+++ b/attic/systems/sensors/test/accelerometer_test/accelerometer_test.cc
@@ -63,7 +63,7 @@ void TestAccelerometerFreeFall(const Eigen::Vector3d& xyz,
   Accelerometer dut(kSensorName, *sensor_frame, *tree);
 
   unique_ptr<Context<double>> dut_context = dut.CreateDefaultContext();
-  EXPECT_EQ(dut_context->get_num_input_ports(), 2);
+  EXPECT_EQ(dut_context->num_input_ports(), 2);
   EXPECT_EQ(dut_context->get_continuous_state_vector().size(), 0);
 
   const int num_positions = tree->get_num_positions();
@@ -86,7 +86,7 @@ void TestAccelerometerFreeFall(const Eigen::Vector3d& xyz,
       make_unique<BasicVector<double>>(VectorX<double>::Zero(num_states)));
 
   unique_ptr<SystemOutput<double>> output = dut.AllocateOutput();
-  ASSERT_EQ(output->get_num_ports(), 1);
+  ASSERT_EQ(output->num_ports(), 1);
   dut.CalcOutput(*dut_context, output.get());
 
   // The frame of the RigidBody to which the sensor is attached is coincident

--- a/attic/systems/sensors/test/depth_sensor_test.cc
+++ b/attic/systems/sensors/test/depth_sensor_test.cc
@@ -40,8 +40,8 @@ GTEST_TEST(TestDepthSensor, AccessorsAndToStringTest) {
 
   DepthSensor dut(kSensorName, tree, frame, specification);
   EXPECT_EQ(dut.get_specification(), specification);
-  EXPECT_EQ(dut.get_num_input_ports(), 1);
-  EXPECT_EQ(dut.get_num_output_ports(), 2);
+  EXPECT_EQ(dut.num_input_ports(), 1);
+  EXPECT_EQ(dut.num_output_ports(), 2);
 
   stringstream string_buffer;
   string_buffer << dut;

--- a/attic/systems/sensors/test/depth_sensor_to_lcm_point_cloud_message_test.cc
+++ b/attic/systems/sensors/test/depth_sensor_to_lcm_point_cloud_message_test.cc
@@ -30,8 +30,8 @@ class TestDepthSensorToLcmPointCloudMessage : public ::testing::Test {
       bool fix_pose_input_port = true) {
     // The Device Under Test (DUT).
     DepthSensorToLcmPointCloudMessage dut(spec_);
-    EXPECT_EQ(dut.get_num_input_ports(), 2);
-    EXPECT_EQ(dut.get_num_output_ports(), 1);
+    EXPECT_EQ(dut.num_input_ports(), 2);
+    EXPECT_EQ(dut.num_output_ports(), 1);
     const InputPort<double>& sensor_data_input_port =
         dut.depth_readings_input_port();
     EXPECT_EQ(sensor_data_input_port.size(), spec_.num_depth_readings());

--- a/attic/systems/sensors/test/gyroscope_test.cc
+++ b/attic/systems/sensors/test/gyroscope_test.cc
@@ -51,7 +51,7 @@ class TestGyroscope : public ::testing::Test {
     dut_ = make_unique<Gyroscope>(kSensorName, *frame, *tree_);
 
     context_ = dut_->CreateDefaultContext();
-    EXPECT_EQ(context_->get_num_input_ports(), 1);
+    EXPECT_EQ(context_->num_input_ports(), 1);
     EXPECT_EQ(context_->get_continuous_state_vector().size(), 0);
 
     num_positions_ = tree_->get_num_positions();
@@ -84,7 +84,7 @@ TEST_F(TestGyroscope, TestFreeFall) {
       make_unique<BasicVector<double>>(state_vector));
 
   unique_ptr<SystemOutput<double>> output = dut_->AllocateOutput();
-  ASSERT_EQ(output->get_num_ports(), 1);
+  ASSERT_EQ(output->num_ports(), 1);
   dut_->CalcOutput(*context_, output.get());
 
   const GyroscopeOutput<double>* gyroscope_output =
@@ -120,7 +120,7 @@ TEST_F(TestGyroscope, TestNonZeroRotationalVelocity) {
       make_unique<BasicVector<double>>(state_vector));
 
   unique_ptr<SystemOutput<double>> output = dut_->AllocateOutput();
-  ASSERT_EQ(output->get_num_ports(), 1);
+  ASSERT_EQ(output->num_ports(), 1);
   dut_->CalcOutput(*context_, output.get());
 
   const GyroscopeOutput<double>* gyroscope_output =

--- a/automotive/idm_controller.cc
+++ b/automotive/idm_controller.cc
@@ -106,7 +106,7 @@ void IdmController<T>::CalcAcceleration(
   // Obtain the state if we've allocated it.
   RoadPosition ego_rp;
   if (context.get_state().get_abstract_state().size() != 0) {
-    DRAKE_ASSERT(context.get_num_abstract_states() == 1);
+    DRAKE_ASSERT(context.num_abstract_states() == 1);
     ego_rp = context.template get_abstract_state<RoadPosition>(0);
   }
 
@@ -167,7 +167,7 @@ void IdmController<T>::DoCalcUnrestrictedUpdate(
     const systems::Context<T>& context,
     const std::vector<const systems::UnrestrictedUpdateEvent<T>*>&,
     systems::State<T>* state) const {
-  DRAKE_ASSERT(context.get_num_abstract_states() == 1);
+  DRAKE_ASSERT(context.num_abstract_states() == 1);
 
   // Obtain the input and state data.
   const PoseVector<T>* const ego_pose =

--- a/automotive/mobil_planner.cc
+++ b/automotive/mobil_planner.cc
@@ -121,7 +121,7 @@ void MobilPlanner<T>::CalcLaneDirection(const systems::Context<T>& context,
   // Obtain the state if we've allocated it.
   RoadPosition ego_rp;
   if (context.get_state().get_abstract_state().size() != 0) {
-    DRAKE_ASSERT(context.get_num_abstract_states() == 1);
+    DRAKE_ASSERT(context.num_abstract_states() == 1);
     ego_rp = context.template get_abstract_state<RoadPosition>(0);
   }
 
@@ -305,7 +305,7 @@ void MobilPlanner<T>::DoCalcUnrestrictedUpdate(
     const systems::Context<T>& context,
     const std::vector<const systems::UnrestrictedUpdateEvent<T>*>&,
     systems::State<T>* state) const {
-  DRAKE_ASSERT(context.get_num_abstract_states() == 1);
+  DRAKE_ASSERT(context.num_abstract_states() == 1);
 
   // Obtain the input and state data.
   const PoseVector<T>* const ego_pose =

--- a/automotive/test/bicycle_car_test.cc
+++ b/automotive/test/bicycle_car_test.cc
@@ -67,7 +67,7 @@ class BicycleCarTest : public ::testing::Test {
 };
 
 TEST_F(BicycleCarTest, Topology) {
-  ASSERT_EQ(2, dut_->get_num_input_ports()); /* steering angle, force input */
+  ASSERT_EQ(2, dut_->num_input_ports()); /* steering angle, force input */
 
   const auto& steering_input_port = dut_->get_steering_input_port();
   EXPECT_EQ(systems::kVectorValued, steering_input_port.get_data_type());
@@ -77,7 +77,7 @@ TEST_F(BicycleCarTest, Topology) {
   EXPECT_EQ(systems::kVectorValued, force_input_port.get_data_type());
   EXPECT_EQ(kForceInputDimension, force_input_port.size());
 
-  ASSERT_EQ(1, dut_->get_num_output_ports()); /* state vector */
+  ASSERT_EQ(1, dut_->num_output_ports()); /* state vector */
 
   const auto& state_port = dut_->get_output_port(0);
   EXPECT_EQ(systems::kVectorValued, state_port.get_data_type());

--- a/automotive/test/driving_command_mux_test.cc
+++ b/automotive/test/driving_command_mux_test.cc
@@ -29,10 +29,10 @@ class DrivingCommandMuxTest : public ::testing::Test {
 
 TEST_F(DrivingCommandMuxTest, Basic) {
   // Confirm the shape.
-  ASSERT_EQ(2, mux_->get_num_input_ports());
+  ASSERT_EQ(2, mux_->num_input_ports());
   ASSERT_EQ(1, mux_->steering_input().size());
   ASSERT_EQ(1, mux_->acceleration_input().size());
-  ASSERT_EQ(1, mux_->get_num_output_ports());
+  ASSERT_EQ(1, mux_->num_output_ports());
   ASSERT_EQ(2, mux_->get_output_port(0).size());
 
   // Confirm the output is indeed a DrivingCommand.
@@ -53,14 +53,14 @@ TEST_F(DrivingCommandMuxTest, Basic) {
 }
 
 TEST_F(DrivingCommandMuxTest, IsStateless) {
-  EXPECT_EQ(0, context_->get_continuous_state().size());
+  EXPECT_EQ(0, context_->num_continuous_states());
 }
 
 // Tests conversion to AutoDiffXd.
 TEST_F(DrivingCommandMuxTest, ToAutoDiff) {
   EXPECT_TRUE(is_autodiffxd_convertible(*mux_, [&](const auto& converted) {
-    EXPECT_EQ(2, converted.get_num_input_ports());
-    EXPECT_EQ(1, converted.get_num_output_ports());
+    EXPECT_EQ(2, converted.num_input_ports());
+    EXPECT_EQ(1, converted.num_output_ports());
 
     EXPECT_EQ(1, converted.get_input_port(0).size());
     EXPECT_EQ(1, converted.get_input_port(1).size());
@@ -78,8 +78,8 @@ TEST_F(DrivingCommandMuxTest, ToAutoDiff) {
 // Tests conversion to symbolic::Expression.
 TEST_F(DrivingCommandMuxTest, ToSymbolic) {
   EXPECT_TRUE(is_symbolic_convertible(*mux_, [&](const auto& converted) {
-    EXPECT_EQ(2, converted.get_num_input_ports());
-    EXPECT_EQ(1, converted.get_num_output_ports());
+    EXPECT_EQ(2, converted.num_input_ports());
+    EXPECT_EQ(1, converted.num_output_ports());
 
     EXPECT_EQ(1, converted.get_input_port(0).size());
     EXPECT_EQ(1, converted.get_input_port(1).size());

--- a/automotive/test/dynamic_bicycle_car_test.cc
+++ b/automotive/test/dynamic_bicycle_car_test.cc
@@ -264,8 +264,8 @@ class DynamicBicycleCarTest : public ::testing::Test {
 
 TEST_F(DynamicBicycleCarTest, Construction) {
   // Test that the system has one input port and one output port.
-  EXPECT_EQ(1, test_car_->get_num_input_ports());
-  EXPECT_EQ(1, test_car_->get_num_output_ports());
+  EXPECT_EQ(1, test_car_->num_input_ports());
+  EXPECT_EQ(1, test_car_->num_output_ports());
 
   // Test if the input and output ports are vectors of Eigen scalars.
   EXPECT_EQ(systems::kVectorValued,

--- a/automotive/test/idm_controller_test.cc
+++ b/automotive/test/idm_controller_test.cc
@@ -59,11 +59,11 @@ class IdmControllerTest
                        const double relative_sdot = 0.,
                        const double relative_rdot = 0.) {
     DRAKE_DEMAND(ego_pose_input_index_ >= 0 &&
-                 ego_pose_input_index_ < dut_->get_num_input_ports());
+                 ego_pose_input_index_ < dut_->num_input_ports());
     DRAKE_DEMAND(ego_velocity_input_index_ >= 0 &&
-                 ego_velocity_input_index_ < dut_->get_num_input_ports());
+                 ego_velocity_input_index_ < dut_->num_input_ports());
     DRAKE_DEMAND(traffic_input_index_ >= 0 &&
-                 traffic_input_index_ < dut_->get_num_input_ports());
+                 traffic_input_index_ < dut_->num_input_ports());
 
     auto ego_pose = std::make_unique<PoseVector<double>>();
     auto ego_velocity = std::make_unique<FrameVelocity<double>>();
@@ -115,7 +115,7 @@ class IdmControllerTest
 TEST_P(IdmControllerTest, Topology) {
   SetUpIdm(ScanStrategy::kPath);
 
-  ASSERT_EQ(3, dut_->get_num_input_ports());
+  ASSERT_EQ(3, dut_->num_input_ports());
   const auto& ego_pose_input_port =
       dut_->get_input_port(ego_pose_input_index_);
   EXPECT_EQ(systems::kVectorValued, ego_pose_input_port.get_data_type());
@@ -129,7 +129,7 @@ TEST_P(IdmControllerTest, Topology) {
       dut_->get_input_port(traffic_input_index_);
   EXPECT_EQ(systems::kAbstractValued, traffic_input_port.get_data_type());
 
-  ASSERT_EQ(1, dut_->get_num_output_ports());
+  ASSERT_EQ(1, dut_->num_output_ports());
   const auto& output_port = dut_->get_output_port(acceleration_output_index_);
   EXPECT_EQ(systems::kVectorValued, output_port.get_data_type());
   EXPECT_EQ(1 /* acceleration output */, output_port.size());
@@ -140,7 +140,7 @@ TEST_P(IdmControllerTest, Topology) {
 TEST_P(IdmControllerTest, UnrestrictedUpdate) {
   SetUpIdm(ScanStrategy::kPath);
   if (cache_or_search_ == RoadPositionStrategy::kCache) {
-    EXPECT_EQ(1, context_->get_num_abstract_states());
+    EXPECT_EQ(1, context_->num_abstract_states());
 
     SetDefaultPoses(10. /* ego_speed */, 0. /* s_offset */, -5. /* rel_sdot */);
 

--- a/automotive/test/maliput_railcar_test.cc
+++ b/automotive/test/maliput_railcar_test.cc
@@ -391,9 +391,9 @@ class MaliputRailcarTest : public ::testing::Test {
 
 TEST_F(MaliputRailcarTest, Topology) {
   EXPECT_NO_FATAL_FAILURE(InitializeDragwayLane());
-  ASSERT_EQ(dut_->get_num_input_ports(), 1);
+  ASSERT_EQ(dut_->num_input_ports(), 1);
 
-  ASSERT_EQ(dut_->get_num_output_ports(), 4);
+  ASSERT_EQ(dut_->num_output_ports(), 4);
   const auto& state_output = dut_->state_output();
   EXPECT_EQ(systems::kVectorValued, state_output.get_data_type());
   EXPECT_EQ(MaliputRailcarStateIndices::kNumCoordinates, state_output.size());

--- a/automotive/test/mobil_planner_test.cc
+++ b/automotive/test/mobil_planner_test.cc
@@ -157,7 +157,7 @@ TEST_P(MobilPlannerTest, Topology) {
   InitializeDragway(2 /* num_lanes */);
   InitializeMobilPlanner(true /* initial_with_s */);
 
-  ASSERT_EQ(4, dut_->get_num_input_ports());
+  ASSERT_EQ(4, dut_->num_input_ports());
   const auto& ego_pose_input_port =
       dut_->get_input_port(ego_pose_input_index_);
   EXPECT_EQ(systems::kVectorValued, ego_pose_input_port.get_data_type());
@@ -177,7 +177,7 @@ TEST_P(MobilPlannerTest, Topology) {
       dut_->get_input_port(traffic_input_index_);
   EXPECT_EQ(systems::kAbstractValued, traffic_input_port.get_data_type());
 
-  ASSERT_EQ(1, dut_->get_num_output_ports());
+  ASSERT_EQ(1, dut_->num_output_ports());
   const auto& lane_output_port = dut_->get_output_port(lane_output_index_);
   EXPECT_EQ(systems::kAbstractValued, lane_output_port.get_data_type());
 }
@@ -210,7 +210,7 @@ TEST_P(MobilPlannerTest, UnrestrictedUpdate) {
   InitializeMobilPlanner(true /* initial_with_s */);
 
   if (cache_or_search_ == RoadPositionStrategy::kCache) {
-    EXPECT_EQ(1, context_->get_num_abstract_states());
+    EXPECT_EQ(1, context_->num_abstract_states());
 
     // Arrange the ego car in the right lane with a traffic car placed
     // arbitrarily.

--- a/automotive/test/pure_pursuit_controller_test.cc
+++ b/automotive/test/pure_pursuit_controller_test.cc
@@ -67,7 +67,7 @@ class PurePursuitControllerTest : public ::testing::Test {
 };
 
 TEST_F(PurePursuitControllerTest, Topology) {
-  ASSERT_EQ(2, dut_->get_num_input_ports());
+  ASSERT_EQ(2, dut_->num_input_ports());
   const auto& lane_input_port =
       dut_->get_input_port(dut_->lane_input().get_index());
   EXPECT_EQ(systems::kAbstractValued, lane_input_port.get_data_type());
@@ -76,7 +76,7 @@ TEST_F(PurePursuitControllerTest, Topology) {
   EXPECT_EQ(systems::kVectorValued, ego_input_port.get_data_type());
   EXPECT_EQ(7 /* PoseVector input */, ego_input_port.size());
 
-  ASSERT_EQ(1, dut_->get_num_output_ports());
+  ASSERT_EQ(1, dut_->num_output_ports());
   const auto& command_output_port =
       dut_->get_output_port(dut_->steering_command_output().get_index());
   EXPECT_EQ(systems::kVectorValued, command_output_port.get_data_type());

--- a/automotive/test/simple_car_test.cc
+++ b/automotive/test/simple_car_test.cc
@@ -108,12 +108,12 @@ class SimpleCarTest : public ::testing::Test {
 };
 
 TEST_F(SimpleCarTest, Topology) {
-  ASSERT_EQ(1, dut_->get_num_input_ports());
+  ASSERT_EQ(1, dut_->num_input_ports());
   const auto& input_port = dut_->get_input_port(0);
   EXPECT_EQ(systems::kVectorValued, input_port.get_data_type());
   EXPECT_EQ(DrivingCommandIndices::kNumCoordinates, input_port.size());
 
-  ASSERT_EQ(3, dut_->get_num_output_ports());
+  ASSERT_EQ(3, dut_->num_output_ports());
   const auto& state_output = dut_->state_output();
   EXPECT_EQ(systems::kVectorValued, state_output.get_data_type());
   EXPECT_EQ(SimpleCarStateIndices::kNumCoordinates, state_output.size());
@@ -398,7 +398,7 @@ TEST_F(SimpleCarTest, TestConstraints) {
   EXPECT_TRUE(params);
   SimpleCarState<double>* state = continuous_state();
 
-  ASSERT_EQ(dut_->get_num_constraints(), 4);
+  ASSERT_EQ(dut_->num_constraints(), 4);
   const SystemConstraint<double>& params_constraint =
       dut_->get_constraint(SystemConstraintIndex(0));
   const SystemConstraint<double>& steering_constraint =

--- a/automotive/test/trajectory_car_test.cc
+++ b/automotive/test/trajectory_car_test.cc
@@ -134,7 +134,7 @@ TYPED_TEST(TrajectoryCarTest, ConstantSpeedTest) {
 
       car_dut.CalcOutput(context, all_output.get());
 
-      ASSERT_EQ(3, all_output->get_num_ports());
+      ASSERT_EQ(3, all_output->num_ports());
 
       // Tests the raw pose output.
       const SimpleCarState<T>* raw_pose =

--- a/automotive/test/trajectory_follower_test.cc
+++ b/automotive/test/trajectory_follower_test.cc
@@ -28,8 +28,8 @@ GTEST_TEST(TrajectoryFollowerTest, Topology) {
   const TrajectoryFollower<double> follower(
       Trajectory::Make(times, rotations, translations));
 
-  ASSERT_EQ(0, follower.get_num_input_ports());
-  ASSERT_EQ(3, follower.get_num_output_ports());
+  ASSERT_EQ(0, follower.num_input_ports());
+  ASSERT_EQ(3, follower.num_output_ports());
 
   const auto& state_output = follower.state_output();
   EXPECT_EQ(systems::kVectorValued, state_output.get_data_type());

--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -140,8 +140,19 @@ void DefineFrameworkPySemantics(py::module m) {
         .def("__str__", &Context<T>::to_string, doc.Context.to_string.doc)
         .def("num_input_ports", &Context<T>::num_input_ports,
             doc.ContextBase.num_input_ports.doc)
-        .def("get_num_input_ports", &Context<T>::get_num_input_ports,
+        .def("get_num_input_ports",
+            [](const Context<T>* self) {
+              WarnDeprecated(
+                  "Use num_input_ports() instead. Will be removed on or after "
+                  "2019-07-01.");
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+              self->get_num_input_ports();
+#pragma GCC diagnostic pop
+            },
             "Use num_input_ports() instead.")
+        .def("num_output_ports", &Context<T>::num_output_ports,
+            doc.ContextBase.num_output_ports.doc)
         .def("FixInputPort",
             py::overload_cast<int, const BasicVector<T>&>(
                 &Context<T>::FixInputPort),
@@ -218,7 +229,15 @@ void DefineFrameworkPySemantics(py::module m) {
             &Context<T>::num_discrete_state_groups,
             doc.Context.num_discrete_state_groups.doc)
         .def("get_num_discrete_state_groups",
-            &Context<T>::get_num_discrete_state_groups,
+            [](const Context<T>* self) {
+              WarnDeprecated(
+                  "Use num_discrete_state_groups() instead. Will be removed "
+                  "on or after 2019-07-01.");
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+              self->get_num_discrete_state_groups();
+#pragma GCC diagnostic pop
+            },
             "Use num_discrete_state_groups() instead.")
         .def("get_discrete_state",
             overload_cast_explicit<const DiscreteValues<T>&>(
@@ -258,7 +277,16 @@ void DefineFrameworkPySemantics(py::module m) {
         // - Abstract.
         .def("num_abstract_states", &Context<T>::num_abstract_states,
             doc.Context.num_abstract_states.doc)
-        .def("get_num_abstract_states", &Context<T>::get_num_abstract_states,
+        .def("get_num_abstract_states",
+            [](const Context<T>* self) {
+              WarnDeprecated(
+                  "Use num_abstract_states() instead. Will be removed on or "
+                  "after 2019-07-01.");
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+              self->get_num_abstract_states();
+#pragma GCC diagnostic pop
+            },
             "Use num_abstract_states() instead.")
         .def("get_abstract_state",
             static_cast<const AbstractValues& (Context<T>::*)() const>(
@@ -396,7 +424,16 @@ void DefineFrameworkPySemantics(py::module m) {
     system_output
         .def("num_ports", &SystemOutput<T>::num_ports,
             doc.SystemOutput.num_ports.doc)
-        .def("get_num_ports", &SystemOutput<T>::get_num_ports,
+        .def("get_num_ports",
+            [](const SystemOutput<T>* self) {
+              WarnDeprecated(
+                  "Use num_ports() instead. Will be removed on or after "
+                  "2019-07-01.");
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+              self->get_num_ports();
+#pragma GCC diagnostic pop
+            },
             "Use num_ports() instead.")
         .def("get_data", &SystemOutput<T>::get_data, py_reference_internal,
             doc.SystemOutput.get_data.doc)
@@ -584,7 +621,7 @@ void DefineFrameworkPySemantics(py::module m) {
             doc.DiscreteValues.get_mutable_vector.doc_1args);
   };
   type_visit(bind_common_scalar_types, pysystems::CommonScalarPack{});
-}
+}  // NOLINT(readability/fn_size)
 
 }  // namespace pydrake
 }  // namespace drake

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -274,7 +274,16 @@ struct Impl {
         // Topology.
         .def("num_input_ports", &System<T>::num_input_ports,
             doc.SystemBase.num_input_ports.doc)
-        .def("get_num_input_ports", &System<T>::get_num_input_ports,
+        .def("get_num_input_ports",
+            [](const System<T>* self) {
+              WarnDeprecated(
+                  "Use num_input_ports() instead. Will be removed on or after "
+                  "2019-07-01.");
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+              self->get_num_input_ports();
+#pragma GCC diagnostic pop
+            },
             "Use num_input_ports() instead.")
         .def("get_input_port", &System<T>::get_input_port,
             py_reference_internal, py::arg("port_index"),
@@ -283,7 +292,16 @@ struct Impl {
             py::arg("port_name"), doc.System.GetInputPort.doc)
         .def("num_output_ports", &System<T>::num_output_ports,
             doc.SystemBase.num_output_ports.doc)
-        .def("get_num_output_ports", &System<T>::get_num_output_ports,
+        .def("get_num_output_ports",
+            [](const System<T>* self) {
+              WarnDeprecated(
+                  "Use num_output_ports() instead. Will be removed on or "
+                  "after 2019-07-01.");
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+              self->get_num_output_ports();
+#pragma GCC diagnostic pop
+            },
             "Use num_output_ports() instead.")
         .def("get_output_port", &System<T>::get_output_port,
             py_reference_internal, py::arg("port_index"),

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -124,19 +124,26 @@ class TestCustom(unittest.TestCase):
 
     def _fix_adder_inputs(self, context):
         self.assertEqual(context.num_input_ports(), 2)
+        with catch_drake_warnings(expected_count=1):
+            context.get_num_input_ports()
         context.FixInputPort(0, BasicVector([1, 2, 3]))
         context.FixInputPort(1, BasicVector([4, 5, 6]))
 
     def test_diagram_adder(self):
         system = CustomDiagram(2, 3)
         self.assertEqual(system.num_input_ports(), 2)
+        with catch_drake_warnings(expected_count=1):
+            system.get_num_input_ports()
         self.assertEqual(system.get_input_port(0).size(), 3)
         self.assertEqual(system.num_output_ports(), 1)
+        with catch_drake_warnings(expected_count=1):
+            system.get_num_output_ports()
         self.assertEqual(system.get_output_port(0).size(), 3)
 
     def test_adder_execution(self):
         system = self._create_adder_system()
         context = system.CreateDefaultContext()
+        self.assertEqual(context.num_output_ports(), 1)
         self._fix_adder_inputs(context)
         output = system.AllocateOutput()
         self.assertEqual(output.num_ports(), 1)
@@ -359,6 +366,8 @@ class TestCustom(unittest.TestCase):
             context.get_continuous_state_vector() is
             context.get_mutable_continuous_state_vector())
         self.assertEqual(context.num_discrete_state_groups(), 1)
+        with catch_drake_warnings(expected_count=1):
+            context.get_num_discrete_state_groups()
         self.assertTrue(
             context.get_discrete_state_vector() is
             context.get_mutable_discrete_state_vector())
@@ -375,6 +384,8 @@ class TestCustom(unittest.TestCase):
             context.get_mutable_discrete_state(0) is
             context.get_mutable_discrete_state().get_vector(0))
         self.assertEqual(context.num_abstract_states(), 1)
+        with catch_drake_warnings(expected_count=1):
+            context.get_num_abstract_states()
         self.assertTrue(
             context.get_abstract_state() is
             context.get_mutable_abstract_state())
@@ -512,6 +523,8 @@ class TestCustom(unittest.TestCase):
             context.FixInputPort(0, AbstractValue.Make(expected_input_value))
             output = system.AllocateOutput()
             self.assertEqual(output.num_ports(), 1)
+            with catch_drake_warnings(expected_count=1):
+                output.get_num_ports()
             system.CalcOutput(context, output)
             value = output.get_data(0)
             self.assertEqual(value.get_value(), expected_output_value)

--- a/bindings/pydrake/systems/test/primitives_test.py
+++ b/bindings/pydrake/systems/test/primitives_test.py
@@ -281,8 +281,8 @@ class TestGeneral(unittest.TestCase):
                                       time_period=0.0)
         context = system.CreateDefaultContext()
 
-        self.assertEqual(context.get_continuous_state().size(), 2)
-        self.assertEqual(context.get_num_discrete_state_groups(), 0)
+        self.assertEqual(context.num_continuous_states(), 2)
+        self.assertEqual(context.num_discrete_state_groups(), 0)
         self.assertEqual(system.get_input_port(0).size(), 2)
         self.assertEqual(system.get_output_port(0).size(), 1)
 

--- a/examples/bouncing_ball/test/bouncing_ball_test.cc
+++ b/examples/bouncing_ball/test/bouncing_ball_test.cc
@@ -100,9 +100,9 @@ TEST_F(BouncingBallTest, Transmogrification) {
 }
 
 TEST_F(BouncingBallTest, Topology) {
-  ASSERT_EQ(0, dut_->get_num_input_ports());
+  ASSERT_EQ(0, dut_->num_input_ports());
 
-  ASSERT_EQ(1, dut_->get_num_output_ports());
+  ASSERT_EQ(1, dut_->num_output_ports());
   const auto& output_port = dut_->get_output_port(0);
   EXPECT_EQ(systems::kVectorValued, output_port.get_data_type());
 }

--- a/examples/kuka_iiwa_arm/iiwa_world/test/iiwa_wsg_diagram_factory_test.cc
+++ b/examples/kuka_iiwa_arm/iiwa_world/test/iiwa_wsg_diagram_factory_test.cc
@@ -94,7 +94,7 @@ void CheckNumPorts(
   // Check the number of input/output ports
   const int num_input_ports_per_iiwa = 2;
   const int num_input_ports_per_wsg = 1;
-  EXPECT_EQ(iiwa_and_wsg_plant.get_num_input_ports(),
+  EXPECT_EQ(iiwa_and_wsg_plant.num_input_ports(),
             num_iiwas * num_input_ports_per_iiwa +
                 num_wsgs * num_input_ports_per_wsg);
   const int num_output_ports_per_iiwa = 4;
@@ -105,7 +105,7 @@ void CheckNumPorts(
   //  - a port for the contact results of the RigidBodyPlant
   //  - a port for the kinematics results of the RigidBodyPlant
   const int num_other_output_ports = 3;
-  EXPECT_EQ(iiwa_and_wsg_plant.get_num_output_ports(),
+  EXPECT_EQ(iiwa_and_wsg_plant.num_output_ports(),
             num_iiwas * num_output_ports_per_iiwa +
                 num_wsgs * num_output_ports_per_wsg +
                 num_objects * num_output_ports_per_object +

--- a/examples/manipulation_station/test/manipulation_station_test.cc
+++ b/examples/manipulation_station/test/manipulation_station_test.cc
@@ -130,10 +130,10 @@ GTEST_TEST(ManipulationStationTest, CheckDynamics) {
 
   // Expect state from the velocity interpolators in the iiwa and the wsg and
   // from the multibody state of the plant.
-  EXPECT_EQ(context->get_num_discrete_state_groups(), 3);
+  EXPECT_EQ(context->num_discrete_state_groups(), 3);
   // Expect continuous state from the integral term in the PID from the
   // inverse dynamics controller.
-  EXPECT_EQ(context->get_continuous_state().size(), 7);
+  EXPECT_EQ(context->num_continuous_states(), 7);
 
   const auto& plant = station.get_multibody_plant();
 

--- a/examples/quadrotor/test/quadrotor_dynamics_test.cc
+++ b/examples/quadrotor/test/quadrotor_dynamics_test.cc
@@ -44,7 +44,7 @@ class GenericQuadrotor: public systems::Diagram<T> {
     plant_ = builder.template AddSystem<QuadrotorPlant<T>>();
     plant_->set_name("plant");
 
-    VectorX<T> hover_input(plant_->get_num_total_inputs());
+    VectorX<T> hover_input(plant_->num_total_inputs());
     hover_input.setZero();
     systems::ConstantVectorSource<T>* source =
         builder.template AddSystem<systems::ConstantVectorSource<T>>(

--- a/geometry/dev/test/scene_graph_test.cc
+++ b/geometry/dev/test/scene_graph_test.cc
@@ -326,8 +326,8 @@ TEST_F(SceneGraphTest, TransmogrifyPorts) {
       scene_graph_.ToAutoDiffXd();
   SceneGraph<AutoDiffXd>& scene_graph_ad =
       *dynamic_cast<SceneGraph<AutoDiffXd>*>(system_ad.get());
-  EXPECT_EQ(scene_graph_ad.get_num_input_ports(),
-            scene_graph_.get_num_input_ports());
+  EXPECT_EQ(scene_graph_ad.num_input_ports(),
+            scene_graph_.num_input_ports());
   EXPECT_EQ(scene_graph_ad.get_source_pose_port(s_id).get_index(),
             scene_graph_.get_source_pose_port(s_id).get_index());
   std::unique_ptr<systems::Context<AutoDiffXd>> context_ad =

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -329,8 +329,8 @@ TEST_F(SceneGraphTest, TransmogrifyPorts) {
       scene_graph_.ToAutoDiffXd();
   SceneGraph<AutoDiffXd>& scene_graph_ad =
       *dynamic_cast<SceneGraph<AutoDiffXd>*>(system_ad.get());
-  EXPECT_EQ(scene_graph_ad.get_num_input_ports(),
-            scene_graph_.get_num_input_ports());
+  EXPECT_EQ(scene_graph_ad.num_input_ports(),
+            scene_graph_.num_input_ports());
   EXPECT_EQ(scene_graph_ad.get_source_pose_port(s_id).get_index(),
             scene_graph_.get_source_pose_port(s_id).get_index());
   std::unique_ptr<systems::Context<AutoDiffXd>> context_ad =

--- a/manipulation/kuka_iiwa/test/iiwa_status_receiver_test.cc
+++ b/manipulation/kuka_iiwa/test/iiwa_status_receiver_test.cc
@@ -45,7 +45,7 @@ class IiwaStatusReceiverTest : public testing::Test {
 
 TEST_F(IiwaStatusReceiverTest, AcceptanceTest) {
   // Confirm that output is zero for uninitialized lcm input.
-  const int num_output_ports = dut_.get_num_output_ports();
+  const int num_output_ports = dut_.num_output_ports();
   EXPECT_EQ(num_output_ports, 7);
   for (int i = 0; i < num_output_ports; ++i) {
     const systems::LeafSystem<double>& leaf = dut_;

--- a/manipulation/perception/test/optitrack_pose_extractor_test.cc
+++ b/manipulation/perception/test/optitrack_pose_extractor_test.cc
@@ -30,8 +30,8 @@ class OptitrackPoseTest : public ::testing::Test {
     context_ = dut_->CreateDefaultContext();
     output_ = dut_->AllocateOutput();
 
-    EXPECT_EQ(dut_->get_num_input_ports(), 1);
-    EXPECT_EQ(dut_->get_num_output_ports(), 1);
+    EXPECT_EQ(dut_->num_input_ports(), 1);
+    EXPECT_EQ(dut_->num_output_ports(), 1);
   }
 
   Isometry3<double> UpdateStateCalcOutput(

--- a/manipulation/perception/test/pose_smoother_test.cc
+++ b/manipulation/perception/test/pose_smoother_test.cc
@@ -45,8 +45,8 @@ class PoseSmootherTest : public ::testing::Test {
     context_ = dut_->CreateDefaultContext();
     output_ = dut_->AllocateOutput();
 
-    EXPECT_EQ(dut_->get_num_input_ports(), 1);
-    EXPECT_EQ(dut_->get_num_output_ports(), 2);
+    EXPECT_EQ(dut_->num_input_ports(), 1);
+    EXPECT_EQ(dut_->num_output_ports(), 2);
   }
 
   CombinedState UpdateStateCalcOutput(

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1405,8 +1405,8 @@ void MultibodyPlant<T>::CalcImplicitStribeckResults(
     const drake::systems::Context<T>& context0,
     internal::ImplicitStribeckSolverResults<T>* results) const {
   // Assert this method was called on a context storing discrete state.
-  DRAKE_ASSERT(context0.get_num_discrete_state_groups() == 1);
-  DRAKE_ASSERT(context0.get_continuous_state().size() == 0);
+  DRAKE_ASSERT(context0.num_discrete_state_groups() == 1);
+  DRAKE_ASSERT(context0.num_continuous_states() == 0);
 
   const int nq = this->num_positions();
   const int nv = this->num_velocities();

--- a/multibody/plant/test/floating_body_test.cc
+++ b/multibody/plant/test/floating_body_test.cc
@@ -137,7 +137,7 @@ GTEST_TEST(QuaternionFloatingMobilizer, Simulation) {
       mobilizer.get_position(context), Vector3d::Zero(),
       kEpsilon, MatrixCompareType::relative));
 
-  EXPECT_EQ(context.get_continuous_state().size(), 13);
+  EXPECT_EQ(context.num_continuous_states(), 13);
 
   // Retrieve the angular velocity from the context, which ultimately was set by
   // FreeRotatingBodyPlant::SetDefaultState().

--- a/multibody/tree/multibody_tree-inl.h
+++ b/multibody/tree/multibody_tree-inl.h
@@ -580,7 +580,7 @@ Eigen::VectorBlock<const VectorX<T>>
 MultibodyTree<T>::get_discrete_state_vector(
     const systems::Context<T>& context) const {
   DRAKE_ASSERT(is_state_discrete());
-  DRAKE_ASSERT(context.get_num_discrete_state_groups() == 1);
+  DRAKE_ASSERT(context.num_discrete_state_groups() == 1);
   const systems::BasicVector<T>& discrete_state_vector =
       context.get_discrete_state(0);  // Only q and v.
   DRAKE_ASSERT(discrete_state_vector.size() ==
@@ -594,7 +594,7 @@ MultibodyTree<T>::get_mutable_discrete_state_vector(
     systems::Context<T>* context) const {
   DRAKE_ASSERT(context != nullptr);
   DRAKE_ASSERT(is_state_discrete());
-  DRAKE_ASSERT(context->get_num_discrete_state_groups() == 1);
+  DRAKE_ASSERT(context->num_discrete_state_groups() == 1);
   systems::BasicVector<T>& discrete_state_vector =
       context->get_mutable_discrete_state(0);  // Only q and v.
   DRAKE_ASSERT(discrete_state_vector.size() ==

--- a/multibody/tree/test/multibody_tree_test.cc
+++ b/multibody/tree/test/multibody_tree_test.cc
@@ -514,8 +514,8 @@ TEST_F(KukaIiwaModelTests, CalcPointsGeometricJacobianExpressedInWorld) {
   ASSERT_EQ(tree_autodiff().num_positions(), kNumPositions);
   ASSERT_EQ(tree_autodiff().num_states(), kNumStates);
 
-  ASSERT_EQ(context_->get_continuous_state().size(), kNumStates);
-  ASSERT_EQ(context_autodiff_->get_continuous_state().size(), kNumStates);
+  ASSERT_EQ(context_->num_continuous_states(), kNumStates);
+  ASSERT_EQ(context_autodiff_->num_continuous_states(), kNumStates);
 
   // Numerical tolerance used to verify numerical results.
   const double kTolerance = 10 * std::numeric_limits<double>::epsilon();
@@ -832,8 +832,8 @@ TEST_F(KukaIiwaModelTests, CalcFrameGeometricJacobianExpressedInWorld) {
   ASSERT_EQ(tree_autodiff().num_positions(), kNumPositions);
   ASSERT_EQ(tree_autodiff().num_states(), kNumStates);
 
-  ASSERT_EQ(context_->get_continuous_state().size(), kNumStates);
-  ASSERT_EQ(context_autodiff_->get_continuous_state().size(), kNumStates);
+  ASSERT_EQ(context_->num_continuous_states(), kNumStates);
+  ASSERT_EQ(context_autodiff_->num_continuous_states(), kNumStates);
 
   // Numerical tolerance used to verify numerical results.
   const double kTolerance = 10 * std::numeric_limits<double>::epsilon();
@@ -1037,8 +1037,8 @@ TEST_F(KukaIiwaModelTests, CalcRelativeFrameGeometricJacobian) {
   ASSERT_EQ(tree_autodiff().num_positions(), kNumPositions);
   ASSERT_EQ(tree_autodiff().num_states(), kNumStates);
 
-  ASSERT_EQ(context_->get_continuous_state().size(), kNumStates);
-  ASSERT_EQ(context_autodiff_->get_continuous_state().size(), kNumStates);
+  ASSERT_EQ(context_->num_continuous_states(), kNumStates);
+  ASSERT_EQ(context_autodiff_->num_continuous_states(), kNumStates);
 
   // Numerical tolerance used to verify numerical results.
   const double kTolerance = 10 * std::numeric_limits<double>::epsilon();
@@ -1216,7 +1216,7 @@ class WeldMobilizerTest : public ::testing::Test {
 TEST_F(WeldMobilizerTest, StateHasZeroSize) {
   EXPECT_EQ(tree().num_positions(), 0);
   EXPECT_EQ(tree().num_velocities(), 0);
-  EXPECT_EQ(context_->get_continuous_state().size(), 0);
+  EXPECT_EQ(context_->num_continuous_states(), 0);
 }
 
 TEST_F(WeldMobilizerTest, PositionKinematics) {

--- a/systems/analysis/test_utilities/test/controlled_spring_mass_system_test.cc
+++ b/systems/analysis/test_utilities/test/controlled_spring_mass_system_test.cc
@@ -50,7 +50,7 @@ TEST_F(SpringMassSystemTest, EvalOutput) {
   model_->set_position(model_context_.get(), x0);
   model_->set_velocity(model_context_.get(), v0);
 
-  ASSERT_EQ(1, output_->get_num_ports());
+  ASSERT_EQ(1, output_->num_ports());
   model_->CalcOutput(*model_context_, output_.get());
 
   // Output equals the state of the spring-mass plant being controlled which

--- a/systems/controllers/dynamic_programming.cc
+++ b/systems/controllers/dynamic_programming.cc
@@ -46,10 +46,10 @@ FittedValueIteration(
 
   // TODO(russt): handle discrete state.
   DRAKE_DEMAND(context.has_only_continuous_state());
-  DRAKE_DEMAND(context.get_continuous_state().size() == state_size);
+  DRAKE_DEMAND(context.num_continuous_states() == state_size);
 
-  DRAKE_DEMAND(context.get_num_input_ports() == 1);
-  DRAKE_DEMAND(system.get_num_total_inputs() == input_size);
+  DRAKE_DEMAND(context.num_input_ports() == 1);
+  DRAKE_DEMAND(system.num_total_inputs() == input_size);
 
   DRAKE_DEMAND(timestep > 0.);
 
@@ -180,10 +180,10 @@ Eigen::VectorXd LinearProgrammingApproximateDynamicProgramming(
 
   // TODO(russt): handle discrete state.
   DRAKE_DEMAND(context.has_only_continuous_state());
-  DRAKE_DEMAND(context.get_continuous_state().size() == state_size);
+  DRAKE_DEMAND(context.num_continuous_states() == state_size);
 
-  DRAKE_DEMAND(context.get_num_input_ports() == 1);
-  DRAKE_DEMAND(system.get_num_total_inputs() == input_size);
+  DRAKE_DEMAND(context.num_input_ports() == 1);
+  DRAKE_DEMAND(system.num_total_inputs() == input_size);
 
   DRAKE_DEMAND(timestep > 0.);
 

--- a/systems/controllers/linear_model_predictive_controller.cc
+++ b/systems/controllers/linear_model_predictive_controller.cc
@@ -42,11 +42,11 @@ LinearModelPredictiveController<T>::LinearModelPredictiveController(
   // Check that the model is SISO and has discrete states belonging to a single
   // group.
   const auto model_context = model_->CreateDefaultContext();
-  DRAKE_DEMAND(model_context->get_num_discrete_state_groups() == 1);
-  DRAKE_DEMAND(model_context->get_continuous_state().size() == 0);
-  DRAKE_DEMAND(model_context->get_num_abstract_states() == 0);
-  DRAKE_DEMAND(model_->get_num_input_ports() == 1);
-  DRAKE_DEMAND(model_->get_num_output_ports() == 1);
+  DRAKE_DEMAND(model_context->num_discrete_state_groups() == 1);
+  DRAKE_DEMAND(model_context->num_continuous_states() == 0);
+  DRAKE_DEMAND(model_context->num_abstract_states() == 0);
+  DRAKE_DEMAND(model_->num_input_ports() == 1);
+  DRAKE_DEMAND(model_->num_output_ports() == 1);
 
   // Check that the provided  x0, u0, Q, R are consistent with the model.
   DRAKE_DEMAND(num_states_ > 0 && num_inputs_ > 0);

--- a/systems/controllers/linear_quadratic_regulator.cc
+++ b/systems/controllers/linear_quadratic_regulator.cc
@@ -101,7 +101,7 @@ std::unique_ptr<systems::AffineSystem<double>> LinearQuadraticRegulator(
   // but note that it will be a full quadratic form (x'S2x + s1'x + s0).
 
   const int num_inputs = system.get_input_port(input_port_index).size();
-  const int num_states = context.get_num_total_states();
+  const int num_states = context.num_total_states();
   DRAKE_DEMAND(num_states > 0);
   // The Linearize method call below will verify that the system has either
   // continuous-time OR (only simple) discrete-time dyanmics.

--- a/systems/controllers/pid_controlled_system.cc
+++ b/systems/controllers/pid_controlled_system.cc
@@ -63,8 +63,8 @@ void PidControlledSystem<T>::Initialize(
 
   DiagramBuilder<T> builder;
   plant_ = builder.template AddSystem(std::move(plant));
-  DRAKE_ASSERT(plant_->get_num_input_ports() >= 1);
-  DRAKE_ASSERT(plant_->get_num_output_ports() >= 1);
+  DRAKE_ASSERT(plant_->num_input_ports() >= 1);
+  DRAKE_ASSERT(plant_->num_output_ports() >= 1);
   // state_output_port_index_ will be checked by the get_output_port call below.
 
   auto input_ports =
@@ -75,7 +75,7 @@ void PidControlledSystem<T>::Initialize(
   builder.ExportInput(input_ports.control_input_port);
   builder.ExportInput(input_ports.state_input_port);
 
-  for (int i=0; i < plant_->get_num_output_ports(); i++) {
+  for (int i=0; i < plant_->num_output_ports(); i++) {
     builder.ExportOutput(plant_->get_output_port(i));
   }
   builder.BuildInto(this);

--- a/systems/controllers/test/inverse_dynamics_test.cc
+++ b/systems/controllers/test/inverse_dynamics_test.cc
@@ -46,20 +46,20 @@ class InverseDynamicsTest : public ::testing::Test {
     // Checks that the number of input ports in the Gravity Compensator system
     // and the Context are consistent.
     if (mode == InverseDynamics<double>::kGravityCompensation) {
-      EXPECT_EQ(inverse_dynamics_->get_num_input_ports(), 1);
-      EXPECT_EQ(inverse_dynamics_context_->get_num_input_ports(), 1);
+      EXPECT_EQ(inverse_dynamics_->num_input_ports(), 1);
+      EXPECT_EQ(inverse_dynamics_context_->num_input_ports(), 1);
     } else {
-      EXPECT_EQ(inverse_dynamics_->get_num_input_ports(), 2);
-      EXPECT_EQ(inverse_dynamics_context_->get_num_input_ports(), 2);
+      EXPECT_EQ(inverse_dynamics_->num_input_ports(), 2);
+      EXPECT_EQ(inverse_dynamics_context_->num_input_ports(), 2);
     }
 
     // Checks that no state variables are allocated in the context.
-    EXPECT_EQ(inverse_dynamics_context_->get_continuous_state().size(), 0);
+    EXPECT_EQ(inverse_dynamics_context_->num_continuous_states(), 0);
 
     // Checks that the number of output ports in the Gravity Compensator system
     // and the SystemOutput are consistent.
-    EXPECT_EQ(output_->get_num_ports(), 1);
-    EXPECT_EQ(inverse_dynamics_->get_num_output_ports(), 1);
+    EXPECT_EQ(output_->num_ports(), 1);
+    EXPECT_EQ(inverse_dynamics_->num_output_ports(), 1);
   }
 
   void CheckGravityTorque(const Eigen::VectorXd& position) {

--- a/systems/controllers/test/pid_controlled_system_test.cc
+++ b/systems/controllers/test/pid_controlled_system_test.cc
@@ -236,7 +236,7 @@ TEST_F(PidControlledSystemTest, PlantWithMoreOutputPorts) {
   PidControlledSystem<double> system(std::move(plant), Kp_, Ki_, Kd_,
                                      state_output_port_index);
 
-  EXPECT_EQ(system.get_num_output_ports(), 2);
+  EXPECT_EQ(system.num_output_ports(), 2);
   EXPECT_EQ(system.get_output_port(0).size(), 3);
   EXPECT_EQ(system.get_output_port(1).size(), 2);
 

--- a/systems/controllers/test/pid_controller_test.cc
+++ b/systems/controllers/test/pid_controller_test.cc
@@ -112,7 +112,7 @@ TEST_F(PidControllerTest, CalcOutput) {
 
   // Evaluates the output.
   controller_.CalcOutput(*context_, output_.get());
-  ASSERT_EQ(1, output_->get_num_ports());
+  ASSERT_EQ(1, output_->num_ports());
   const BasicVector<double>* output_vector = output_->get_vector_data(0);
   EXPECT_EQ(3, output_vector->size());
   EXPECT_EQ((kp_.array() * error_signal_.array() +

--- a/systems/estimators/kalman_filter.cc
+++ b/systems/estimators/kalman_filter.cc
@@ -40,7 +40,7 @@ std::unique_ptr<LuenbergerObserver<double>> SteadyStateKalmanFilter(
     const Eigen::Ref<const Eigen::MatrixXd>& V) {
   DRAKE_DEMAND(context->get_continuous_state_vector().size() >
                0);  // Otherwise, I don't need an estimator.
-  DRAKE_DEMAND(system->get_num_output_ports() ==
+  DRAKE_DEMAND(system->num_output_ports() ==
                1);  // Need measurements to estimate state.
 
   // TODO(russt): Demand time-invariant once we can.

--- a/systems/estimators/luenberger_observer.cc
+++ b/systems/estimators/luenberger_observer.cc
@@ -23,8 +23,8 @@ LuenbergerObserver<T>::LuenbergerObserver(
   DRAKE_DEMAND(observed_system_ != nullptr);
 
   // Note: Could potentially extend this to MIMO systems.
-  DRAKE_DEMAND(observed_system_->get_num_input_ports() <= 1);
-  DRAKE_DEMAND(observed_system_->get_num_output_ports() == 1);
+  DRAKE_DEMAND(observed_system_->num_input_ports() <= 1);
+  DRAKE_DEMAND(observed_system_->num_output_ports() == 1);
 
   DRAKE_DEMAND(observed_system_context_->has_only_continuous_state());
   // Otherwise there is nothing to estimate.
@@ -57,7 +57,7 @@ LuenbergerObserver<T>::LuenbergerObserver(
                observed_system_->get_output_port(0).size());
 
   // Second input port is the input to the observed system (if it exists).
-  if (observed_system_->get_num_input_ports() > 0) {
+  if (observed_system_->num_input_ports() > 0) {
     auto input_vec = observed_system_->AllocateInputVector(
         observed_system_->get_input_port(0));
     this->DeclareVectorInputPort(*input_vec);
@@ -79,7 +79,7 @@ void LuenbergerObserver<T>::DoCalcTimeDerivatives(
   // hidden undeclared state).
 
   // Set observed system input.
-  if (observed_system_->get_num_input_ports() > 0) {
+  if (observed_system_->num_input_ports() > 0) {
     // TODO(russt): Avoid this dynamic allocation by fixing the input port once
     // and updating it here.
     observed_system_->get_input_port(0).FixValue(

--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -207,11 +207,13 @@ class Context : public ContextBase {
   }
 
 #ifndef DRAKE_DOXYGEN_CXX
-  // These are to-be-deprecated. Use methods without the initial get_.
+  DRAKE_DEPRECATED("2019-07-01", "Use num_discrete_state_groups() instead.")
   int get_num_discrete_state_groups() const {
     return num_discrete_state_groups();
   }
+  DRAKE_DEPRECATED("2019-07-01", "Use num_abstract_states() instead.")
   int get_num_abstract_states() const { return num_abstract_states(); }
+  DRAKE_DEPRECATED("2019-07-01", "Use num_total_states() instead.")
   int get_num_total_states() const { return num_total_states(); }
 #endif
   //@}

--- a/systems/framework/context_base.h
+++ b/systems/framework/context_base.h
@@ -238,8 +238,9 @@ class ContextBase : public internal::ContextMessageInterface {
   }
 
 #ifndef DRAKE_DOXYGEN_CXX
-  // These are to-be-deprecated. Use methods without the initial get_.
+  DRAKE_DEPRECATED("2019-07-01", "Use num_input_ports() instead.")
   int get_num_input_ports() const { return num_input_ports(); }
+  DRAKE_DEPRECATED("2019-07-01", "Use num_output_ports() instead.")
   int get_num_output_ports() const { return num_output_ports(); }
 #endif
 

--- a/systems/framework/leaf_context.h
+++ b/systems/framework/leaf_context.h
@@ -134,8 +134,8 @@ class LeafContext : public Context<T> {
           os << "       " << this->get_discrete_state(i) << "\n";
         }
       }
-      if (this->get_num_abstract_states()) {
-        os << "  " << this->get_num_abstract_states() << " abstract states\n";
+      if (this->num_abstract_states()) {
+        os << "  " << this->num_abstract_states() << " abstract states\n";
       }
       os << "\n";
     }

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -1603,9 +1603,11 @@ class System : public SystemBase {
   // Don't promote output_port_ticket() since it is for internal use only.
 
 #ifndef DRAKE_DOXYGEN_CXX
-  // These are to-be-deprecated. Use methods without the initial get_.
+  DRAKE_DEPRECATED("2019-07-01", "Use num_continuous_states() instead.")
   int get_num_continuous_states() const { return num_continuous_states(); }
+  DRAKE_DEPRECATED("2019-07-01", "Use num_constraints() instead.")
   int get_num_constraints() const { return num_constraints(); }
+  DRAKE_DEPRECATED("2019-07-01", "Use num_constraint_equations() instead.")
   int get_num_constraint_equations(const Context<T>& context) const {
     return num_constraint_equations(context);
   }

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -757,16 +757,19 @@ class SystemBase : public internal::SystemMessageInterface {
   //@}
 
 #ifndef DRAKE_DOXYGEN_CXX
-  // These are to-be-deprecated. Use methods without the initial get_.
+  DRAKE_DEPRECATED("2019-07-01", "Use num_total_inputs() instead.")
   int get_num_total_inputs() const {
     return num_total_inputs();
   }
+  DRAKE_DEPRECATED("2019-07-01", "Use num_total_outputs() instead.")
   int get_num_total_outputs() const {
     return num_total_outputs();
   }
+  DRAKE_DEPRECATED("2019-07-01", "Use num_input_ports() instead.")
   int get_num_input_ports() const {
     return num_input_ports();
   }
+  DRAKE_DEPRECATED("2019-07-01", "Use num_output_ports() instead.")
   int get_num_output_ports() const {
     return num_output_ports();
   }

--- a/systems/framework/system_output.h
+++ b/systems/framework/system_output.h
@@ -78,7 +78,7 @@ class SystemOutput {
   }
 
 #ifndef DRAKE_DOXYGEN_CXX
-  // This is to-be-deprecated. Use num_ports() instead.
+  DRAKE_DEPRECATED("2019-07-01", "Use num_ports() instead.")
   int get_num_ports() const { return num_ports(); }
 #endif
 

--- a/systems/lcm/lcm_publisher_system.h
+++ b/systems/lcm/lcm_publisher_system.h
@@ -269,7 +269,7 @@ class LcmPublisherSystem : public LeafSystem<double> {
    * Returns the sole input port.
    */
   const InputPort<double>& get_input_port() const {
-    DRAKE_THROW_UNLESS(this->get_num_input_ports() == 1);
+    DRAKE_THROW_UNLESS(this->num_input_ports() == 1);
     return LeafSystem<double>::get_input_port(0);
   }
 

--- a/systems/lcm/lcm_subscriber_system.h
+++ b/systems/lcm/lcm_subscriber_system.h
@@ -129,7 +129,7 @@ class LcmSubscriberSystem : public LeafSystem<double> {
 
   /// Returns the sole output port.
   const OutputPort<double>& get_output_port() const {
-    DRAKE_THROW_UNLESS(this->get_num_output_ports() == 1);
+    DRAKE_THROW_UNLESS(this->num_output_ports() == 1);
     return LeafSystem<double>::get_output_port(0);
   }
 

--- a/systems/lcm/test/lcm_publisher_system_test.cc
+++ b/systems/lcm/test/lcm_publisher_system_test.cc
@@ -42,7 +42,7 @@ void TestPublisher(const std::string& channel_name, lcm::DrakeMockLcm* lcm,
   unique_ptr<SystemOutput<double>> output = dut->AllocateOutput();
 
   // Verifies that the context has one input port.
-  EXPECT_EQ(context->get_num_input_ports(), 1);
+  EXPECT_EQ(context->num_input_ports(), 1);
 
   // Instantiates a BasicVector with known state. This is the basic vector that
   // we want the LcmPublisherSystem to publish as a drake::lcmt_drake_signal

--- a/systems/optimization/system_constraint_adapter.cc
+++ b/systems/optimization/system_constraint_adapter.cc
@@ -208,7 +208,7 @@ SystemConstraintAdapter::MaybeCreateGenericConstraintSymbolically(
     }
   }
   // Discrete state.
-  for (int i = 0; i < context.get_num_discrete_state_groups(); ++i) {
+  for (int i = 0; i < context.num_discrete_state_groups(); ++i) {
     for (int j = 0; j < context.get_discrete_state(i).size(); ++j) {
       success = ParseSymbolicVariableOrConstant(
           context.get_discrete_state(i).GetAtIndex(j), &map_var_to_index,
@@ -249,7 +249,7 @@ SystemConstraintAdapter::MaybeCreateGenericConstraintSymbolically(
   // input ports
   // TODO(hongkai.dai): parse fixed values in the input ports, when we can copy
   // the fixed input port value from Context<double> to Context<AutoDiffXd>.
-  for (int i = 0; i < context.get_num_input_ports(); ++i) {
+  for (int i = 0; i < context.num_input_ports(); ++i) {
     if (context.MaybeGetFixedInputPortValue(i) != nullptr) {
       throw std::runtime_error(
           "SystemConstraintAdapter doesn't support system with fixed input "
@@ -258,7 +258,7 @@ SystemConstraintAdapter::MaybeCreateGenericConstraintSymbolically(
   }
 
   // abstract state
-  if (context.get_num_abstract_states() != 0) {
+  if (context.num_abstract_states() != 0) {
     throw std::invalid_argument(
         "SystemConstraintAdapter: cannot handle system with abstract state "
         "using symbolic Context, try SystemConstraintAdapter::Create() "

--- a/systems/optimization/system_constraint_wrapper.cc
+++ b/systems/optimization/system_constraint_wrapper.cc
@@ -27,7 +27,7 @@ SystemConstraintWrapper::SystemConstraintWrapper(
       updater_double_(std::move(updater_double)),
       updater_autodiff_(std::move(updater_autodiff)) {
   context_autodiff_->SetTimeStateAndParametersFrom(*context_double_);
-  for (int i = 0; i < context_double_->get_num_input_ports(); ++i) {
+  for (int i = 0; i < context_double_->num_input_ports(); ++i) {
     if (context_double_->MaybeGetFixedInputPortValue(i) != nullptr) {
       // TODO(hongkai.dai): support system with fixed values in the input ports,
       // when we can copy the fixed input port value from Context<double> to

--- a/systems/plants/spring_mass_system/spring_mass_system.h
+++ b/systems/plants/spring_mass_system/spring_mass_system.h
@@ -122,7 +122,7 @@ class SpringMassSystem : public LeafSystem<T> {
   /// @returns the external driving force to the system.
   T get_input_force(const Context<T>& context) const {
     T external_force = 0;
-    DRAKE_ASSERT(system_is_forced_ == (context.get_num_input_ports() == 1));
+    DRAKE_ASSERT(system_is_forced_ == (context.num_input_ports() == 1));
     if (system_is_forced_) {
       external_force = get_force_port().Eval(context)[0];
     }

--- a/systems/plants/spring_mass_system/test/spring_mass_system_test.cc
+++ b/systems/plants/spring_mass_system/test/spring_mass_system_test.cc
@@ -71,7 +71,7 @@ class SpringMassSystemTest : public ::testing::Test {
 
 TEST_F(SpringMassSystemTest, Construction) {
   // Asserts zero inputs for this case.
-  EXPECT_EQ(0, context_->get_num_input_ports());
+  EXPECT_EQ(0, context_->num_input_ports());
   EXPECT_EQ("test_system", system_->get_name());
   EXPECT_EQ(kSpring, system_->get_spring_constant());
   EXPECT_EQ(kMass, system_->get_mass());
@@ -111,7 +111,7 @@ TEST_F(SpringMassSystemTest, Output) {
   // Displacement 100cm, vel 250cm/s (.25 is exact in binary).
   InitializeState(0.1, 0.25);
   system_->CalcOutput(*context_, system_output_.get());
-  ASSERT_EQ(1, system_output_->get_num_ports());
+  ASSERT_EQ(1, system_output_->num_ports());
 
   // Check the output through the application-specific interface.
   EXPECT_NEAR(0.1, output_->get_position(), 1e-14);
@@ -185,7 +185,7 @@ TEST_F(SpringMassSystemTest, DynamicsWithExternalForce) {
   EXPECT_FALSE(system_->HasAnyDirectFeedthrough());
 
   // Asserts exactly one input for this case expecting an external force.
-  ASSERT_EQ(1, context_->get_num_input_ports());
+  ASSERT_EQ(1, context_->num_input_ports());
 
   // Creates a vector holding the data entry to the supplied input force.
   auto force_vector = make_unique<BasicVector<double>>(1 /* size */);

--- a/systems/primitives/adder.cc
+++ b/systems/primitives/adder.cc
@@ -20,7 +20,7 @@ Adder<T>::Adder(int num_inputs, int size)
 template <typename T>
 template <typename U>
 Adder<T>::Adder(const Adder<U>& other)
-    : Adder<T>(other.get_num_input_ports(), other.get_input_port(0).size()) {}
+    : Adder<T>(other.num_input_ports(), other.get_input_port(0).size()) {}
 
 template <typename T>
 void Adder<T>::CalcSum(const Context<T>& context,
@@ -31,7 +31,7 @@ void Adder<T>::CalcSum(const Context<T>& context,
   sum_vector.setZero();
 
   // Sum each input port into the output.
-  for (int i = 0; i < context.get_num_input_ports(); i++) {
+  for (int i = 0; i < context.num_input_ports(); i++) {
     sum_vector += this->get_input_port(i).Eval(context);
   }
 }

--- a/systems/primitives/linear_system.cc
+++ b/systems/primitives/linear_system.cc
@@ -95,7 +95,7 @@ std::unique_ptr<AffineSystem<double>> DoFirstOrderTaylorApproximation(
 
   const bool has_only_discrete_states_contained_in_one_group =
       context.has_only_discrete_state() &&
-      context.get_num_discrete_state_groups() == 1;
+      context.num_discrete_state_groups() == 1;
   DRAKE_DEMAND(context.is_stateless() || context.has_only_continuous_state() ||
                has_only_discrete_states_contained_in_one_group);
 

--- a/systems/primitives/multiplexer.cc
+++ b/systems/primitives/multiplexer.cc
@@ -55,7 +55,7 @@ void Multiplexer<T>::CombineInputsToOutput(const Context<T>& context,
                                            BasicVector<T>* output) const {
   auto output_vector = output->get_mutable_value();
   int output_vector_index{0};
-  for (int i = 0; i < this->get_num_input_ports(); ++i) {
+  for (int i = 0; i < this->num_input_ports(); ++i) {
     const int input_size = input_sizes_[i];
     output_vector.segment(output_vector_index, input_size) =
         this->get_input_port(i).Eval(context);

--- a/systems/primitives/random_source.cc
+++ b/systems/primitives/random_source.cc
@@ -23,7 +23,7 @@ int AddRandomInputs(double sampling_interval_sec,
   // Note: the mutable assignment to const below looks odd, but
   // there is (currently) no builder->GetSystems() method.
   for (const auto* system : builder->GetMutableSystems()) {
-    for (int i = 0; i < system->get_num_input_ports(); i++) {
+    for (int i = 0; i < system->num_input_ports(); i++) {
       const systems::InputPort<double>& port =
           system->get_input_port(i);
       // Check for the random label.

--- a/systems/primitives/symbolic_vector_system.h
+++ b/systems/primitives/symbolic_vector_system.h
@@ -88,13 +88,13 @@ class SymbolicVectorSystem final : public LeafSystem<T> {
 
   /// Returns the sole input port.
   const InputPort<T>& get_input_port() const {
-    DRAKE_DEMAND(this->get_num_input_ports() == 1);
+    DRAKE_DEMAND(this->num_input_ports() == 1);
     return LeafSystem<T>::get_input_port(0);
   }
 
   /// Returns the sole output port.
   const OutputPort<T>& get_output_port() const {
-    DRAKE_DEMAND(this->get_num_output_ports() == 1);
+    DRAKE_DEMAND(this->num_output_ports() == 1);
     return LeafSystem<T>::get_output_port(0);
   }
 

--- a/systems/primitives/test/adder_test.cc
+++ b/systems/primitives/test/adder_test.cc
@@ -33,14 +33,14 @@ class AdderTest : public ::testing::Test {
 
 // Tests that the system exports the correct topology.
 TEST_F(AdderTest, Topology) {
-  ASSERT_EQ(2, adder_->get_num_input_ports());
+  ASSERT_EQ(2, adder_->num_input_ports());
   for (int i = 0; i < 2; ++i) {
     const InputPort<double>& input_port = adder_->get_input_port(i);
     EXPECT_EQ(kVectorValued, input_port.get_data_type());
     EXPECT_EQ(3, input_port.size());
   }
 
-  ASSERT_EQ(1, adder_->get_num_output_ports());
+  ASSERT_EQ(1, adder_->num_output_ports());
   const OutputPort<double>& output_port =
       static_cast<LeafSystem<double>*>(adder_.get())->get_output_port(0);
   EXPECT_EQ(&output_port, &adder_->get_output_port());
@@ -51,7 +51,7 @@ TEST_F(AdderTest, Topology) {
 // Tests that the system computes the correct sum.
 TEST_F(AdderTest, AddTwoVectors) {
   // Hook up two inputs of the expected size.
-  ASSERT_EQ(2, context_->get_num_input_ports());
+  ASSERT_EQ(2, context_->num_input_ports());
   input0_->get_mutable_value() << 1, 2, 3;
   input1_->get_mutable_value() << 4, 5, 6;
   context_->FixInputPort(0, std::move(input0_));
@@ -63,13 +63,13 @@ TEST_F(AdderTest, AddTwoVectors) {
 
 // Tests that Adder allocates no state variables in the context_.
 TEST_F(AdderTest, AdderIsStateless) {
-  EXPECT_EQ(0, context_->get_continuous_state().size());
+  EXPECT_EQ(0, context_->num_continuous_states());
 }
 
 // Asserts that adders have direct-feedthrough from all inputs to the output.
 TEST_F(AdderTest, AdderIsDirectFeedthrough) {
   EXPECT_TRUE(adder_->HasAnyDirectFeedthrough());
-  for (int i = 0; i < adder_->get_num_input_ports(); ++i) {
+  for (int i = 0; i < adder_->num_input_ports(); ++i) {
     EXPECT_TRUE(adder_->HasDirectFeedthrough(i, 0));
   }
 }

--- a/systems/primitives/test/affine_system_test.cc
+++ b/systems/primitives/test/affine_system_test.cc
@@ -34,7 +34,7 @@ class AffineSystemTest : public AffineLinearSystemTest {
 
 // Tests that the affine system is correctly setup.
 TEST_F(AffineSystemTest, Construction) {
-  EXPECT_EQ(1, context_->get_num_input_ports());
+  EXPECT_EQ(1, context_->num_input_ports());
   EXPECT_EQ("test_affine_system", dut_->get_name());
   EXPECT_EQ(dut_->A(), A_);
   EXPECT_EQ(dut_->B(), B_);
@@ -42,8 +42,8 @@ TEST_F(AffineSystemTest, Construction) {
   EXPECT_EQ(dut_->D(), D_);
   EXPECT_EQ(dut_->f0(), f0_);
   EXPECT_EQ(dut_->y0(), y0_);
-  EXPECT_EQ(dut_->get_num_output_ports(), 1);
-  EXPECT_EQ(dut_->get_num_input_ports(), 1);
+  EXPECT_EQ(dut_->num_output_ports(), 1);
+  EXPECT_EQ(dut_->num_input_ports(), 1);
 
   // Test TimeVaryingAffineSystem accessor methods.
   const double t = 3.5;

--- a/systems/primitives/test/constant_value_source_test.cc
+++ b/systems/primitives/test/constant_value_source_test.cc
@@ -31,7 +31,7 @@ class ConstantValueSourceTest : public ::testing::Test {
 };
 
 TEST_F(ConstantValueSourceTest, Output) {
-  ASSERT_EQ(source_->get_num_input_ports(), context_->get_num_input_ports());
+  ASSERT_EQ(source_->num_input_ports(), context_->num_input_ports());
 
   // Check Eval() method.
   auto& cached_value = source_->get_output_port(0).Eval<std::string>(*context_);
@@ -40,7 +40,7 @@ TEST_F(ConstantValueSourceTest, Output) {
 
 // Tests that ConstantValueSource allocates no state variables in the context_.
 TEST_F(ConstantValueSourceTest, ConstantValueSourceIsStateless) {
-  EXPECT_EQ(0, context_->get_continuous_state().size());
+  EXPECT_EQ(0, context_->num_continuous_states());
 }
 
 // Tests conversion to different scalar types.

--- a/systems/primitives/test/constant_vector_source_test.cc
+++ b/systems/primitives/test/constant_vector_source_test.cc
@@ -41,8 +41,8 @@ class ConstantVectorSourceTest : public ::testing::Test {
 // model of double.
 TEST_F(ConstantVectorSourceTest, EigenModel) {
   SetUpEigenModel();
-  ASSERT_EQ(source_->get_num_input_ports(), 0);
-  ASSERT_EQ(source_->get_num_output_ports(), 1);
+  ASSERT_EQ(source_->num_input_ports(), 0);
+  ASSERT_EQ(source_->num_output_ports(), 1);
 
   EXPECT_TRUE(kConstantVectorSource.isApprox(
       source_->get_output_port().Eval(*context_),
@@ -63,8 +63,8 @@ TEST_F(ConstantVectorSourceTest, EigenModel) {
 // BasicVector<double> model.
 TEST_F(ConstantVectorSourceTest, BasicVectorModel) {
   SetUpBasicVectorModel();
-  ASSERT_EQ(source_->get_num_input_ports(), 0);
-  ASSERT_EQ(source_->get_num_output_ports(), 1);
+  ASSERT_EQ(source_->num_input_ports(), 0);
+  ASSERT_EQ(source_->num_output_ports(), 1);
 
   EXPECT_EQ(43.0, source_->get_output_port().Eval<MyVector3d>(*context_)[1]);
 
@@ -87,8 +87,8 @@ TEST_F(ConstantVectorSourceTest, ConstantVectorSourceIsStateless) {
 TEST_F(ConstantVectorSourceTest, ToAutoDiffPass) {
   SetUpEigenModel();
   EXPECT_TRUE(is_autodiffxd_convertible(*source_, [&](const auto& converted) {
-    EXPECT_EQ(0, converted.get_num_input_ports());
-    EXPECT_EQ(1, converted.get_num_output_ports());
+    EXPECT_EQ(0, converted.num_input_ports());
+    EXPECT_EQ(1, converted.num_output_ports());
     EXPECT_EQ(2, converted.get_output_port().size());
 
     auto new_context = converted.CreateDefaultContext();

--- a/systems/primitives/test/demultiplexer_test.cc
+++ b/systems/primitives/test/demultiplexer_test.cc
@@ -36,8 +36,8 @@ class DemultiplexerTest : public ::testing::Test {
 TEST_F(DemultiplexerTest, DemultiplexVector) {
   /// Checks that the number of input ports in the system and in the context
   // are consistent.
-  ASSERT_EQ(1, context_->get_num_input_ports());
-  ASSERT_EQ(1, demux_->get_num_input_ports());
+  ASSERT_EQ(1, context_->num_input_ports());
+  ASSERT_EQ(1, demux_->num_input_ports());
   Eigen::Vector3d input_vector(1.0, 3.14, 2.18);
   input_->get_mutable_value() << input_vector;
 
@@ -45,7 +45,7 @@ TEST_F(DemultiplexerTest, DemultiplexVector) {
   context_->FixInputPort(0, std::move(input_));
 
   // The number of output ports must match the size of the input vector.
-  ASSERT_EQ(input_vector.size(), demux_->get_num_output_ports());
+  ASSERT_EQ(input_vector.size(), demux_->num_output_ports());
 
   for (int i=0; i < input_vector.size(); ++i) {
     const auto& output_vector = demux_->get_output_port(i).Eval(*context_);
@@ -70,8 +70,8 @@ GTEST_TEST(OutputSize, SizeDifferentFromOne) {
 
   // Checks that the number of input ports in the system and in the context
   // are consistent.
-  ASSERT_EQ(1, context->get_num_input_ports());
-  ASSERT_EQ(1, demux->get_num_input_ports());
+  ASSERT_EQ(1, context->num_input_ports());
+  ASSERT_EQ(1, demux->num_input_ports());
   Eigen::VectorXd input_vector = Eigen::VectorXd::Random(kInputSize);
   input->get_mutable_value() << input_vector;
 
@@ -81,7 +81,7 @@ GTEST_TEST(OutputSize, SizeDifferentFromOne) {
   // The number of output ports must equal the size of the input port divided
   // by the size of the output ports provided in the constructor, in this case
   // 10 / 2 = 5.
-  ASSERT_EQ(kNumOutputs, demux->get_num_output_ports());
+  ASSERT_EQ(kNumOutputs, demux->num_output_ports());
 
   for (int output_index = 0; output_index < kNumOutputs; ++output_index) {
     const auto& output_vector =
@@ -94,12 +94,12 @@ GTEST_TEST(OutputSize, SizeDifferentFromOne) {
 
 // Tests that Demultiplexer allocates no state variables in the context_.
 TEST_F(DemultiplexerTest, DemultiplexerIsStateless) {
-  EXPECT_EQ(0, context_->get_continuous_state().size());
+  EXPECT_EQ(0, context_->num_continuous_states());
 }
 
 TEST_F(DemultiplexerTest, DirectFeedthrough) {
   EXPECT_TRUE(demux_->HasAnyDirectFeedthrough());
-  for (int i = 0; i < demux_->get_num_output_ports(); ++i) {
+  for (int i = 0; i < demux_->num_output_ports(); ++i) {
     EXPECT_TRUE(demux_->HasDirectFeedthrough(0, i));
   }
 }
@@ -107,8 +107,8 @@ TEST_F(DemultiplexerTest, DirectFeedthrough) {
 // Tests converting to different scalar types.
 TEST_F(DemultiplexerTest, ToAutoDiff) {
   EXPECT_TRUE(is_autodiffxd_convertible(*demux_, [&](const auto& converted) {
-    EXPECT_EQ(1, converted.get_num_input_ports());
-    EXPECT_EQ(3, converted.get_num_output_ports());
+    EXPECT_EQ(1, converted.num_input_ports());
+    EXPECT_EQ(3, converted.num_output_ports());
 
     EXPECT_EQ(3, converted.get_input_port(0).size());
     EXPECT_EQ(1, converted.get_output_port(0).size());

--- a/systems/primitives/test/discrete_time_delay_test.cc
+++ b/systems/primitives/test/discrete_time_delay_test.cc
@@ -94,10 +94,10 @@ class DiscreteTimeDelayTest : public ::testing::TestWithParam<bool> {
 // Tests that the time delay has one input, one output and no direct
 // feedthrough.
 TEST_P(DiscreteTimeDelayTest, Topology) {
-  EXPECT_EQ(1, delay_->get_num_input_ports());
-  EXPECT_EQ(1, context_->get_num_input_ports());
+  EXPECT_EQ(1, delay_->num_input_ports());
+  EXPECT_EQ(1, context_->num_input_ports());
 
-  EXPECT_EQ(1, delay_->get_num_output_ports());
+  EXPECT_EQ(1, delay_->num_output_ports());
 
   EXPECT_FALSE(delay_->HasAnyDirectFeedthrough());
 }

--- a/systems/primitives/test/first_order_low_pass_filter_test.cc
+++ b/systems/primitives/test/first_order_low_pass_filter_test.cc
@@ -53,12 +53,12 @@ class FirstOrderLowPassFilterTest : public ::testing::Test {
 // Tests that the system exports the correct topology.
 TEST_F(FirstOrderLowPassFilterTest, Topology) {
   SetUpSingleTimeConstantFilter();
-  ASSERT_EQ(1, filter_->get_num_input_ports());
+  ASSERT_EQ(1, filter_->num_input_ports());
   const auto& input_input_port = filter_->get_input_port();
   EXPECT_EQ(kVectorValued, input_input_port.get_data_type());
   EXPECT_EQ(kSignalSize, input_input_port.size());
 
-  ASSERT_EQ(1, filter_->get_num_output_ports());
+  ASSERT_EQ(1, filter_->num_output_ports());
   const auto& output_port = filter_->get_output_port();
   EXPECT_EQ(kVectorValued, output_port.get_data_type());
   EXPECT_EQ(kSignalSize, output_port.size());
@@ -67,10 +67,10 @@ TEST_F(FirstOrderLowPassFilterTest, Topology) {
 // Tests that the output of a low pass filter is its state.
 TEST_F(FirstOrderLowPassFilterTest, Output) {
   SetUpSingleTimeConstantFilter();
-  ASSERT_EQ(1, context_->get_num_input_ports());
+  ASSERT_EQ(1, context_->num_input_ports());
   context_->FixInputPort(0, BasicVector<double>::Make({1.0, 2.0, 3.0}));
 
-  ASSERT_EQ(1, filter_->get_num_output_ports());
+  ASSERT_EQ(1, filter_->num_output_ports());
 
   Eigen::Vector3d expected = Eigen::Vector3d::Zero();
   EXPECT_EQ(expected, filter_->get_output_port().Eval(*context_));
@@ -83,7 +83,7 @@ TEST_F(FirstOrderLowPassFilterTest, Output) {
 // Verifies the correctness of the time derivatives implementation.
 TEST_F(FirstOrderLowPassFilterTest, Derivatives) {
   SetUpMultipleTimeConstantsFilter();
-  ASSERT_EQ(1, context_->get_num_input_ports());
+  ASSERT_EQ(1, context_->num_input_ports());
   Vector3<double> u({1.0, 2.0, 3.0});  // The input signal.
   context_->FixInputPort(0, u);
 

--- a/systems/primitives/test/gain_scalartype_test.cc
+++ b/systems/primitives/test/gain_scalartype_test.cc
@@ -96,8 +96,8 @@ class SymbolicGainTest : public ::testing::Test {
 TEST_F(SymbolicGainTest, VectorThroughGainSystem) {
   // Checks that the number of input ports in the Gain system and the Context
   // are consistent.
-  EXPECT_EQ(1, gain_->get_num_input_ports());
-  EXPECT_EQ(1, context_->get_num_input_ports());
+  EXPECT_EQ(1, gain_->num_input_ports());
+  EXPECT_EQ(1, context_->num_input_ports());
   Eigen::Matrix<symbolic::Expression, 3, 1> input_vector(
       drake::symbolic::Expression{1.0}, drake::symbolic::Expression{3.14},
       drake::symbolic::Expression{2.18});
@@ -108,7 +108,7 @@ TEST_F(SymbolicGainTest, VectorThroughGainSystem) {
 
   // Checks that the number of output ports in the Gain system and the
   // SystemOutput are consistent.
-  EXPECT_EQ(1, gain_->get_num_output_ports());
+  EXPECT_EQ(1, gain_->num_output_ports());
   Eigen::Matrix<symbolic::Expression, 3, 1> expected{kGain_ * input_vector};
   EXPECT_EQ(expected, gain_->get_output_port(0).Eval(*context_));
   EXPECT_EQ(expected(0).Evaluate(), kGain_ * 1.0);

--- a/systems/primitives/test/gain_test.cc
+++ b/systems/primitives/test/gain_test.cc
@@ -24,14 +24,14 @@ void TestGainSystem(const Gain<T>& gain_system,
   auto context = gain_system.CreateDefaultContext();
 
   // Verifies that Gain allocates no state variables in the context.
-  EXPECT_EQ(0, context->get_continuous_state().size());
+  EXPECT_EQ(0, context->num_continuous_states());
   auto input =
       make_unique<BasicVector<double>>(gain_system.get_gain_vector().size());
 
   // Checks that the number of input ports in the Gain system and the Context
   // are consistent.
-  ASSERT_EQ(1, gain_system.get_num_input_ports());
-  ASSERT_EQ(1, context->get_num_input_ports());
+  ASSERT_EQ(1, gain_system.num_input_ports());
+  ASSERT_EQ(1, context->num_input_ports());
 
   input->get_mutable_value() << input_vector;
 
@@ -39,7 +39,7 @@ void TestGainSystem(const Gain<T>& gain_system,
   context->FixInputPort(0, std::move(input));
 
   // Checks the output.
-  ASSERT_EQ(1, gain_system.get_num_output_ports());
+  ASSERT_EQ(1, gain_system.num_output_ports());
   EXPECT_EQ(expected_output, gain_system.get_output_port().Eval(*context));
 }
 
@@ -96,8 +96,8 @@ GTEST_TEST(GainDeathTest, GainAccessorTest) {
 GTEST_TEST(GainTest, ToAutoDiff) {
   const Gain<double> gain(2.0, 3);
   EXPECT_TRUE(is_autodiffxd_convertible(gain, [&](const auto& converted) {
-    EXPECT_EQ(1, converted.get_num_input_ports());
-    EXPECT_EQ(1, converted.get_num_output_ports());
+    EXPECT_EQ(1, converted.num_input_ports());
+    EXPECT_EQ(1, converted.num_output_ports());
     EXPECT_EQ(Vector3d::Constant(2.0), converted.get_gain_vector());
   }));
 }

--- a/systems/primitives/test/integrator_test.cc
+++ b/systems/primitives/test/integrator_test.cc
@@ -42,12 +42,12 @@ class IntegratorTest : public ::testing::Test {
 
 // Tests that the system exports the correct topology.
 TEST_F(IntegratorTest, Topology) {
-  ASSERT_EQ(1, integrator_->get_num_input_ports());
+  ASSERT_EQ(1, integrator_->num_input_ports());
   const auto& input_port = integrator_->get_input_port(0);
   EXPECT_EQ(kVectorValued, input_port.get_data_type());
   EXPECT_EQ(kLength, input_port.size());
 
-  ASSERT_EQ(1, integrator_->get_num_output_ports());
+  ASSERT_EQ(1, integrator_->num_output_ports());
   const auto& output_port = integrator_->get_output_port(0);
   EXPECT_EQ(kVectorValued, output_port.get_data_type());
   EXPECT_EQ(kLength, output_port.size());
@@ -55,7 +55,7 @@ TEST_F(IntegratorTest, Topology) {
 
 // Tests that the output of an integrator is its state.
 TEST_F(IntegratorTest, Output) {
-  ASSERT_EQ(1, context_->get_num_input_ports());
+  ASSERT_EQ(1, context_->num_input_ports());
   integrator_->get_input_port(0).FixValue(context_.get(),
       Eigen::Vector3d{1.0, 2.0, 3.0});
 
@@ -69,7 +69,7 @@ TEST_F(IntegratorTest, Output) {
 
 // Tests that the derivatives of an integrator's state are its input.
 TEST_F(IntegratorTest, Derivatives) {
-  ASSERT_EQ(1, context_->get_num_input_ports());
+  ASSERT_EQ(1, context_->num_input_ports());
   integrator_->get_input_port(0).FixValue(context_.get(),
                                           Eigen::Vector3d{1.0, 2.0, 3.0});
 
@@ -91,7 +91,7 @@ class SymbolicIntegratorTest : public IntegratorTest {
     symbolic_context_ = symbolic_integrator_->CreateDefaultContext();
     symbolic_derivatives_ = symbolic_integrator_->AllocateTimeDerivatives();
 
-    ASSERT_EQ(1, symbolic_context_->get_num_input_ports());
+    ASSERT_EQ(1, symbolic_context_->num_input_ports());
     symbolic_integrator_->get_input_port(0).FixValue(symbolic_context_.get(),
         Vector3<symbolic::Expression>{symbolic::Variable("u0"),
                                       symbolic::Variable("u1"),

--- a/systems/primitives/test/linear_system_test.cc
+++ b/systems/primitives/test/linear_system_test.cc
@@ -82,7 +82,7 @@ class LinearSystemTest : public AffineLinearSystemTest {
 
 // Tests that the linear system is correctly setup.
 TEST_F(LinearSystemTest, Construction) {
-  EXPECT_EQ(1, context_->get_num_input_ports());
+  EXPECT_EQ(1, context_->num_input_ports());
   EXPECT_EQ("test_linear_system", dut_->get_name());
   EXPECT_EQ(dut_->A(), A_);
   EXPECT_EQ(dut_->B(), B_);
@@ -90,8 +90,8 @@ TEST_F(LinearSystemTest, Construction) {
   EXPECT_EQ(dut_->C(), C_);
   EXPECT_EQ(dut_->D(), D_);
   EXPECT_EQ(dut_->y0(), y0_);
-  EXPECT_EQ(1, dut_->get_num_output_ports());
-  EXPECT_EQ(1, dut_->get_num_input_ports());
+  EXPECT_EQ(1, dut_->num_output_ports());
+  EXPECT_EQ(1, dut_->num_input_ports());
 }
 
 // Tests that the derivatives are correctly computed.
@@ -177,8 +177,8 @@ class SimpleTimeVaryingLinearSystem final
 GTEST_TEST(SimpleTimeVaryingLinearSystemTest, ConstructorTest) {
   SimpleTimeVaryingLinearSystem sys;
 
-  EXPECT_EQ(sys.get_num_output_ports(), 1);
-  EXPECT_EQ(sys.get_num_input_ports(), 1);
+  EXPECT_EQ(sys.num_output_ports(), 1);
+  EXPECT_EQ(sys.num_input_ports(), 1);
   EXPECT_TRUE(CompareMatrices(sys.A(0.), Eigen::Matrix2d::Identity()));
   EXPECT_TRUE(CompareMatrices(sys.B(0.), Eigen::Matrix<double, 2, 1>::Ones()));
   EXPECT_TRUE(CompareMatrices(sys.C(0.), Eigen::Matrix2d::Identity()));

--- a/systems/primitives/test/matrix_gain_test.cc
+++ b/systems/primitives/test/matrix_gain_test.cc
@@ -33,7 +33,7 @@ class MatrixGainTest : public AffineLinearSystemTest {
 
 // Tests that the MatrixGain system is correctly setup.
 TEST_F(MatrixGainTest, Construction) {
-  EXPECT_EQ(context_->get_num_input_ports(), 1);
+  EXPECT_EQ(context_->num_input_ports(), 1);
   EXPECT_EQ(dut_->get_name(), "test_matrix_gain_system");
   EXPECT_EQ(dut_->A(), MatrixX<double>::Zero(kNumStates, kNumStates));
   EXPECT_EQ(dut_->B(), MatrixX<double>::Zero(kNumStates, D_.cols()));
@@ -41,8 +41,8 @@ TEST_F(MatrixGainTest, Construction) {
   EXPECT_EQ(dut_->C(), MatrixX<double>::Zero(D_.rows(), kNumStates));
   EXPECT_EQ(dut_->D(), D_);
   EXPECT_EQ(dut_->y0(), Eigen::VectorXd::Zero(2));
-  EXPECT_EQ(dut_->get_num_output_ports(), 1);
-  EXPECT_EQ(dut_->get_num_input_ports(), 1);
+  EXPECT_EQ(dut_->num_output_ports(), 1);
+  EXPECT_EQ(dut_->num_input_ports(), 1);
 }
 
 // Tests that the derivatives are correctly computed.

--- a/systems/primitives/test/multiplexer_test.cc
+++ b/systems/primitives/test/multiplexer_test.cc
@@ -38,12 +38,12 @@ TEST_F(MultiplexerTest, Basic) {
   InitializeFromSizes({2, 1, 3});
 
   // Confirm the shape.
-  ASSERT_EQ(3, mux_->get_num_input_ports());
+  ASSERT_EQ(3, mux_->num_input_ports());
   ASSERT_EQ(2, mux_->get_input_port(0).size());
   ASSERT_EQ(1, mux_->get_input_port(1).size());
   ASSERT_EQ(3, mux_->get_input_port(2).size());
-  ASSERT_EQ(3, context_->get_num_input_ports());
-  ASSERT_EQ(1, mux_->get_num_output_ports());
+  ASSERT_EQ(3, context_->num_input_ports());
+  ASSERT_EQ(1, mux_->num_output_ports());
   ASSERT_EQ(6, mux_->get_output_port(0).size());
 
   // Provide input data.
@@ -67,13 +67,13 @@ TEST_F(MultiplexerTest, ScalarConstructor) {
   context_ = mux_->CreateDefaultContext();
 
   // Confirm the shape.
-  ASSERT_EQ(4, mux_->get_num_input_ports());
+  ASSERT_EQ(4, mux_->num_input_ports());
   ASSERT_EQ(1, mux_->get_input_port(0).size());
   ASSERT_EQ(1, mux_->get_input_port(1).size());
   ASSERT_EQ(1, mux_->get_input_port(2).size());
   ASSERT_EQ(1, mux_->get_input_port(3).size());
-  ASSERT_EQ(4, context_->get_num_input_ports());
-  ASSERT_EQ(1, mux_->get_num_output_ports());
+  ASSERT_EQ(4, context_->num_input_ports());
+  ASSERT_EQ(1, mux_->num_output_ports());
   ASSERT_EQ(4, mux_->get_output_port(0).size());
 }
 
@@ -81,11 +81,11 @@ TEST_F(MultiplexerTest, ModelVectorConstructor) {
   InitializeFromMyVector();
 
   // Confirm the shape.
-  ASSERT_EQ(2, mux_->get_num_input_ports());
+  ASSERT_EQ(2, mux_->num_input_ports());
   ASSERT_EQ(1, mux_->get_input_port(0).size());
   ASSERT_EQ(1, mux_->get_input_port(1).size());
-  ASSERT_EQ(2, context_->get_num_input_ports());
-  ASSERT_EQ(1, mux_->get_num_output_ports());
+  ASSERT_EQ(2, context_->num_input_ports());
+  ASSERT_EQ(1, mux_->num_output_ports());
   ASSERT_EQ(2, mux_->get_output_port(0).size());
 
   // Confirm that the vector is truly MyVector2d.
@@ -96,14 +96,14 @@ TEST_F(MultiplexerTest, ModelVectorConstructor) {
 
 TEST_F(MultiplexerTest, IsStateless) {
   InitializeFromSizes({1});
-  EXPECT_EQ(0, context_->get_continuous_state().size());
+  EXPECT_EQ(0, context_->num_continuous_states());
 }
 
 TEST_F(MultiplexerTest, ToAutoDiffPass) {
   InitializeFromSizes({1, 1, 1});
   EXPECT_TRUE(is_autodiffxd_convertible(*mux_, [&](const auto& converted) {
-    EXPECT_EQ(3, converted.get_num_input_ports());
-    EXPECT_EQ(1, converted.get_num_output_ports());
+    EXPECT_EQ(3, converted.num_input_ports());
+    EXPECT_EQ(1, converted.num_output_ports());
 
     EXPECT_EQ(1, converted.get_input_port(0).size());
     EXPECT_EQ(1, converted.get_input_port(1).size());
@@ -123,8 +123,8 @@ TEST_F(MultiplexerTest, ToAutoDiffFail) {
 TEST_F(MultiplexerTest, ToSymbolic) {
   InitializeFromSizes({1, 1, 1});
   EXPECT_TRUE(is_symbolic_convertible(*mux_, [&](const auto& converted) {
-    EXPECT_EQ(3, converted.get_num_input_ports());
-    EXPECT_EQ(1, converted.get_num_output_ports());
+    EXPECT_EQ(3, converted.num_input_ports());
+    EXPECT_EQ(1, converted.num_output_ports());
 
     EXPECT_EQ(1, converted.get_input_port(0).size());
     EXPECT_EQ(1, converted.get_input_port(1).size());

--- a/systems/primitives/test/pass_through_test.cc
+++ b/systems/primitives/test/pass_through_test.cc
@@ -61,8 +61,8 @@ class PassThroughTest : public ::testing::TestWithParam<bool> {
 TEST_P(PassThroughTest, VectorThroughPassThroughSystem) {
   /// Checks that the number of input ports in the system and in the context
   // are consistent.
-  ASSERT_EQ(1, context_->get_num_input_ports());
-  ASSERT_EQ(1, pass_through_->get_num_input_ports());
+  ASSERT_EQ(1, context_->num_input_ports());
+  ASSERT_EQ(1, pass_through_->num_input_ports());
 
   // Hook input of the expected size.
   if (!is_abstract_) {
@@ -75,7 +75,7 @@ TEST_P(PassThroughTest, VectorThroughPassThroughSystem) {
 
   // Checks that the number of output ports in the system and in the
   // output are consistent.
-  ASSERT_EQ(1, pass_through_->get_num_output_ports());
+  ASSERT_EQ(1, pass_through_->num_output_ports());
 
   Eigen::VectorXd output;
   if (!is_abstract_) {
@@ -89,9 +89,9 @@ TEST_P(PassThroughTest, VectorThroughPassThroughSystem) {
 
 // Tests that PassThrough allocates no state variables in the context_.
 TEST_P(PassThroughTest, PassThroughIsStateless) {
-  EXPECT_EQ(0, context_->get_continuous_state().size());
-  EXPECT_EQ(0, context_->get_abstract_state().size());
-  EXPECT_EQ(0, context_->get_discrete_state().num_groups());
+  EXPECT_EQ(0, context_->num_continuous_states());
+  EXPECT_EQ(0, context_->num_abstract_states());
+  EXPECT_EQ(0, context_->num_discrete_state_groups());
 }
 
 // Tests that PassThrough is direct feedthrough.

--- a/systems/primitives/test/piecewise_polynomial_affine_system_test.cc
+++ b/systems/primitives/test/piecewise_polynomial_affine_system_test.cc
@@ -60,7 +60,7 @@ class PiecewisePolynomialAffineSystemTest
 };
 
 TEST_P(PiecewisePolynomialAffineSystemTest, Constructor) {
-  EXPECT_EQ(1, context_->get_num_input_ports());
+  EXPECT_EQ(1, context_->num_input_ports());
   EXPECT_EQ(dut_->A(0.), ltv_data_.A.value(0.));
   EXPECT_EQ(dut_->B(0.), ltv_data_.B.value(0.));
   EXPECT_EQ(dut_->C(0.), ltv_data_.C.value(0.));
@@ -68,8 +68,8 @@ TEST_P(PiecewisePolynomialAffineSystemTest, Constructor) {
   EXPECT_EQ(dut_->f0(0.), ltv_data_.f0.value(0.));
   EXPECT_EQ(dut_->y0(0.), ltv_data_.y0.value(0.));
   EXPECT_EQ(dut_->time_period(), time_period_);
-  EXPECT_EQ(1, dut_->get_num_output_ports());
-  EXPECT_EQ(1, dut_->get_num_input_ports());
+  EXPECT_EQ(1, dut_->num_output_ports());
+  EXPECT_EQ(1, dut_->num_input_ports());
 }
 
 TEST_P(PiecewisePolynomialAffineSystemTest, KnotPointConsistency) {

--- a/systems/primitives/test/piecewise_polynomial_linear_system_test.cc
+++ b/systems/primitives/test/piecewise_polynomial_linear_system_test.cc
@@ -60,14 +60,14 @@ class PiecewisePolynomialLinearSystemTest
 };
 
 TEST_P(PiecewisePolynomialLinearSystemTest, Constructor) {
-  EXPECT_EQ(1, context_->get_num_input_ports());
+  EXPECT_EQ(1, context_->num_input_ports());
   EXPECT_EQ(dut_->A(0.), ltv_data_.A.value(0.));
   EXPECT_EQ(dut_->B(0.), ltv_data_.B.value(0.));
   EXPECT_EQ(dut_->C(0.), ltv_data_.C.value(0.));
   EXPECT_EQ(dut_->D(0.), ltv_data_.D.value(0.));
   EXPECT_EQ(dut_->time_period(), time_period_);
-  EXPECT_EQ(1, dut_->get_num_output_ports());
-  EXPECT_EQ(1, dut_->get_num_input_ports());
+  EXPECT_EQ(1, dut_->num_output_ports());
+  EXPECT_EQ(1, dut_->num_input_ports());
 }
 
 TEST_P(PiecewisePolynomialLinearSystemTest, KnotPointConsistency) {

--- a/systems/primitives/test/random_source_test.cc
+++ b/systems/primitives/test/random_source_test.cc
@@ -186,7 +186,7 @@ GTEST_TEST(RandomSourceTest, AddToDiagramBuilderTest) {
       diagram->GetSubsystemContext(*sys2, *context)));
 
   // Check that the exported input remained exported.
-  EXPECT_EQ(diagram->get_num_input_ports(), 1);
+  EXPECT_EQ(diagram->num_input_ports(), 1);
   EXPECT_EQ(diagram->get_input_port(0).size(), 2);
 
   // Check that the previously connected input remained connected.

--- a/systems/primitives/test/saturation_test.cc
+++ b/systems/primitives/test/saturation_test.cc
@@ -18,14 +18,14 @@ void TestInputAndOutput(const Saturation<T>& saturation_system,
                         const VectorX<T>& input_vector,
                         const VectorX<T>& expected_output) {
   // Verifies that Saturation allocates no state variables in the context.
-  EXPECT_EQ(context->get_continuous_state().size(), 0);
+  EXPECT_EQ(context->num_continuous_states(), 0);
 
   // Hook input of the expected size.
   saturation_system.get_input_port().FixValue(context.get(), input_vector);
 
   // Checks that the number of output ports in the Saturation system and the
   // SystemOutput are consistent.
-  ASSERT_EQ(saturation_system.get_num_output_ports(), 1);
+  ASSERT_EQ(saturation_system.num_output_ports(), 1);
   EXPECT_EQ(saturation_system.get_output_port().Eval(*context),
             expected_output);
 }
@@ -38,8 +38,8 @@ void TestConstantSaturation(const Saturation<T>& saturation_system,
 
   // Checks that the number of input ports in the Saturation system and the
   // Context are consistent.
-  ASSERT_EQ(saturation_system.get_num_input_ports(), 1);
-  ASSERT_EQ(context->get_num_input_ports(), 1);
+  ASSERT_EQ(saturation_system.num_input_ports(), 1);
+  ASSERT_EQ(context->num_input_ports(), 1);
 
   TestInputAndOutput<T>(saturation_system, std::move(context), input_vector,
                         expected_output);
@@ -55,8 +55,8 @@ void TestVariableSaturation(const Saturation<T>& saturation_system,
 
   // Checks that the number of input ports in the Saturation system and the
   // Context are consistent.
-  ASSERT_EQ(saturation_system.get_num_input_ports(), 3);
-  ASSERT_EQ(context->get_num_input_ports(), 3);
+  ASSERT_EQ(saturation_system.num_input_ports(), 3);
+  ASSERT_EQ(context->num_input_ports(), 3);
 
   // Applies the min and max values as inputs to the context.
   if (min_value_vector.size() > 0) {

--- a/systems/primitives/test/sine_test.cc
+++ b/systems/primitives/test/sine_test.cc
@@ -32,22 +32,22 @@ void TestSineSystem(const Sine<T>& sine_system,
   T ktest_tolerance = 1e-4;
 
   // Verifies that Sine allocates no state variables in the context.
-  EXPECT_EQ(0, context->get_continuous_state().size());
+  EXPECT_EQ(0, context->num_continuous_states());
 
   if (sine_system.is_time_based()) {
     // If the system is time based, the input_vectors Matrix should only contain
     // a row vector of time instances to test against. In this case, the system
     // has zero inputs ports.
     ASSERT_EQ(input_vectors.rows(), 1);
-    ASSERT_EQ(0, sine_system.get_num_input_ports());
-    ASSERT_EQ(0, context->get_num_input_ports());
+    ASSERT_EQ(0, sine_system.num_input_ports());
+    ASSERT_EQ(0, context->num_input_ports());
 
     for (int i = 0; i < input_vectors.cols(); i++) {
       // Initialize the time in seconds to be used by the Sine system.
       context->SetTime(input_vectors(0, i));
 
       // Check the Sine output.
-      ASSERT_EQ(3, sine_system.get_num_output_ports());
+      ASSERT_EQ(3, sine_system.num_output_ports());
       EXPECT_TRUE(CompareMatrices(
           sine_system.get_output_port(0).Eval(*context),
           expected_outputs.col(i), ktest_tolerance));
@@ -65,8 +65,8 @@ void TestSineSystem(const Sine<T>& sine_system,
       auto input =
           make_unique<BasicVector<double>>(
               sine_system.amplitude_vector().size());
-      ASSERT_EQ(1, sine_system.get_num_input_ports());
-      ASSERT_EQ(1, context->get_num_input_ports());
+      ASSERT_EQ(1, sine_system.num_input_ports());
+      ASSERT_EQ(1, context->num_input_ports());
 
       // Confirm the the size of the input port matches the size of the sample
       // inputs (i.e., each column in the input_vectors matrix represents a
@@ -79,7 +79,7 @@ void TestSineSystem(const Sine<T>& sine_system,
       context->FixInputPort(0, std::move(input));
 
       // Check the Sine output.
-      ASSERT_EQ(3, sine_system.get_num_output_ports());
+      ASSERT_EQ(3, sine_system.num_output_ports());
       EXPECT_TRUE(CompareMatrices(
           sine_system.get_output_port(0).Eval(*context),
           expected_outputs.col(i), ktest_tolerance));
@@ -256,8 +256,8 @@ GTEST_TEST(SineTest, ToAutoDiff) {
   const Sine<double> sine_system(kAmp, kFreq, kPhase, true);
   EXPECT_TRUE(
       is_autodiffxd_convertible(sine_system, [&](const auto& converted) {
-    EXPECT_EQ(0, converted.get_num_input_ports());
-    EXPECT_EQ(3, converted.get_num_output_ports());
+    EXPECT_EQ(0, converted.num_input_ports());
+    EXPECT_EQ(3, converted.num_output_ports());
     EXPECT_EQ(kAmp, converted.amplitude_vector());
   }));
 }

--- a/systems/primitives/test/symbolic_vector_system_test.cc
+++ b/systems/primitives/test/symbolic_vector_system_test.cc
@@ -84,9 +84,9 @@ GTEST_TEST(SymbolicVectorSystemTest, CubicPolyViaBuilder) {
 
   auto context = system->CreateDefaultContext();
   EXPECT_TRUE(context->has_only_continuous_state());
-  EXPECT_EQ(context->get_num_total_states(), 1);
-  EXPECT_EQ(system->get_num_input_ports(), 0);
-  EXPECT_EQ(system->get_num_output_ports(), 1);
+  EXPECT_EQ(context->num_total_states(), 1);
+  EXPECT_EQ(system->num_input_ports(), 0);
+  EXPECT_EQ(system->num_output_ports(), 1);
 
   double xval = 0.45;
   context->SetContinuousState(Vector1d{xval});
@@ -144,7 +144,7 @@ GTEST_TEST(SymbolicVectorSystemTest, OutputScaledTime) {
 
   auto context = system.CreateDefaultContext();
   EXPECT_TRUE(context->is_stateless());
-  EXPECT_EQ(system.get_num_input_ports(), 0);
+  EXPECT_EQ(system.num_input_ports(), 0);
   EXPECT_EQ(system.get_output_port().size(), 1);
 
   context->SetTime(2.0);
@@ -163,9 +163,9 @@ GTEST_TEST(SymbolicVectorSystemTest, ContinuousStateOnly) {
 
   auto context = system.CreateDefaultContext();
   EXPECT_TRUE(context->has_only_continuous_state());
-  EXPECT_EQ(context->get_num_total_states(), 1);
-  EXPECT_EQ(system.get_num_input_ports(), 0);
-  EXPECT_EQ(system.get_num_output_ports(), 0);
+  EXPECT_EQ(context->num_total_states(), 1);
+  EXPECT_EQ(system.num_input_ports(), 0);
+  EXPECT_EQ(system.num_output_ports(), 0);
 
   double xval = 0.45;
   context->SetContinuousState(Vector1d{xval});
@@ -183,9 +183,9 @@ GTEST_TEST(SymbolicVectorSystemTest, DiscreteStateOnly) {
 
   auto context = system.CreateDefaultContext();
   EXPECT_TRUE(context->has_only_discrete_state());
-  EXPECT_EQ(context->get_num_total_states(), 1);
-  EXPECT_EQ(system.get_num_input_ports(), 0);
-  EXPECT_EQ(system.get_num_output_ports(), 0);
+  EXPECT_EQ(context->num_total_states(), 1);
+  EXPECT_EQ(system.num_input_ports(), 0);
+  EXPECT_EQ(system.num_output_ports(), 0);
 
   double xval = 0.45;
   context->get_mutable_discrete_state_vector()[0] = xval;

--- a/systems/primitives/test/trajectory_source_test.cc
+++ b/systems/primitives/test/trajectory_source_test.cc
@@ -45,7 +45,7 @@ TEST_F(TrajectorySourceTest, OutputTest) {
   const std::vector<Polynomiald> p_vec {yyyy};
   Reset(PiecewisePolynomial<double>(p_vec, {0.0, 3}));
 
-  ASSERT_EQ(0, context_->get_num_input_ports());
+  ASSERT_EQ(0, context_->num_input_ports());
 
   const double kTestTime = 1.75;
   context_->SetTime(kTestTime);
@@ -70,7 +70,7 @@ TEST_F(TrajectorySourceTest, OutputTest) {
 // Tests that ConstantVectorSource allocates no state variables in the context_.
 TEST_F(TrajectorySourceTest, ConstantVectorSourceIsStateless) {
   Reset(PiecewisePolynomial<double>(MatrixXd::Constant(2, 1, 1.5)));
-  EXPECT_EQ(0, context_->get_continuous_state().size());
+  EXPECT_EQ(0, context_->num_continuous_states());
 }
 
 }  // namespace

--- a/systems/primitives/test/wrap_to_system_test.cc
+++ b/systems/primitives/test/wrap_to_system_test.cc
@@ -32,8 +32,8 @@ void SecondElementOnlyTest() {
 
   EXPECT_EQ(dut.get_size(), 2);
 
-  EXPECT_EQ(dut.get_num_input_ports(), 1);
-  EXPECT_EQ(dut.get_num_output_ports(), 1);
+  EXPECT_EQ(dut.num_input_ports(), 1);
+  EXPECT_EQ(dut.num_output_ports(), 1);
 
   CheckOutput<T>(dut, Vector2<T>{.1, .5}, Vector2<T>{.1, 2.5});
   CheckOutput<T>(dut, Vector2<T>{.3, -.2}, Vector2<T>{.3, 2.8});

--- a/systems/primitives/test/zero_order_hold_test.cc
+++ b/systems/primitives/test/zero_order_hold_test.cc
@@ -102,10 +102,10 @@ class ZeroOrderHoldTest : public ::testing::TestWithParam<bool> {
 
 // Tests that the zero-order hold has one input and one output.
 TEST_P(ZeroOrderHoldTest, Topology) {
-  EXPECT_EQ(1, hold_->get_num_input_ports());
-  EXPECT_EQ(1, context_->get_num_input_ports());
+  EXPECT_EQ(1, hold_->num_input_ports());
+  EXPECT_EQ(1, context_->num_input_ports());
 
-  EXPECT_EQ(1, hold_->get_num_output_ports());
+  EXPECT_EQ(1, hold_->num_output_ports());
 
   EXPECT_FALSE(hold_->HasAnyDirectFeedthrough());
 }

--- a/systems/rendering/pose_aggregator.cc
+++ b/systems/rendering/pose_aggregator.cc
@@ -65,7 +65,7 @@ void PoseAggregator<T>::CalcPoseBundle(const Context<T>& context,
   PoseBundle<T>& bundle = *output;
   int pose_index = 0;
 
-  const int num_ports = this->get_num_input_ports();
+  const int num_ports = this->num_input_ports();
   for (int port_index = 0; port_index < num_ports; ++port_index) {
     const auto& port = this->get_input_port(port_index);
     const InputRecord& record = input_records_[port_index];

--- a/systems/rendering/test/render_pose_to_geometry_pose_test.cc
+++ b/systems/rendering/test/render_pose_to_geometry_pose_test.cc
@@ -42,16 +42,16 @@ GTEST_TEST(RenderPoseToGeometryPoseTest, DirectFeedthrough) {
 GTEST_TEST(RenderPoseToGeometryPoseTest, ToAutoDiff) {
   const RenderPoseToGeometryPose<double> dut({}, {});
   EXPECT_TRUE(is_autodiffxd_convertible(dut, [&](const auto& converted) {
-    EXPECT_EQ(1, converted.get_num_input_ports());
-    EXPECT_EQ(1, converted.get_num_output_ports());
+    EXPECT_EQ(1, converted.num_input_ports());
+    EXPECT_EQ(1, converted.num_output_ports());
   }));
 }
 
 GTEST_TEST(RenderPoseToGeometryPoseTest, ToSymbolic) {
   const RenderPoseToGeometryPose<double> dut({}, {});
   EXPECT_TRUE(is_symbolic_convertible(dut, [&](const auto& converted) {
-    EXPECT_EQ(1, converted.get_num_input_ports());
-    EXPECT_EQ(1, converted.get_num_output_ports());
+    EXPECT_EQ(1, converted.num_input_ports());
+    EXPECT_EQ(1, converted.num_output_ports());
   }));
 }
 

--- a/systems/sensors/image_to_lcm_image_array_t.cc
+++ b/systems/sensors/image_to_lcm_image_array_t.cc
@@ -186,7 +186,7 @@ void ImageToLcmImageArrayT::CalcImageArray(
   msg->num_images = 0;
   msg->images.clear();
 
-  for (int i = 0; i < get_num_input_ports(); i++) {
+  for (int i = 0; i < num_input_ports(); i++) {
     const auto& image_value = this->get_input_port(i).
         template Eval<AbstractValue>(context);
 

--- a/systems/sensors/image_writer.h
+++ b/systems/sensors/image_writer.h
@@ -244,7 +244,7 @@ class ImageWriter : public LeafSystem<double> {
   };
 
   // For each input port, this stores the corresponding image data. It is an
-  // invariant that port_info_.size() == get_num_input_ports().
+  // invariant that port_info_.size() == num_input_ports().
   std::vector<ImagePortInfo> port_info_;
 
   std::unordered_map<PixelType, std::string> labels_;

--- a/systems/sensors/test/beam_model_test.cc
+++ b/systems/sensors/test/beam_model_test.cc
@@ -78,7 +78,7 @@ GTEST_TEST(BeamModelTest, TestProbabilityDensity) {
   systems::Simulator<double> simulator(*diagram);
 
   // Zero all initial state.
-  for (int i = 0; i < simulator.get_context().get_num_discrete_state_groups();
+  for (int i = 0; i < simulator.get_context().num_discrete_state_groups();
        i++) {
     BasicVector<double>& state =
         simulator.get_mutable_context().get_mutable_discrete_state(0);

--- a/systems/trajectory_optimization/direct_collocation.cc
+++ b/systems/trajectory_optimization/direct_collocation.cc
@@ -23,7 +23,7 @@ DirectCollocationConstraint::DirectCollocationConstraint(
     variant<InputPortSelection, InputPortIndex> input_port_index,
     bool assume_non_continuous_states_are_fixed)
     : DirectCollocationConstraint(
-          system, context, context.get_continuous_state().size(),
+          system, context, context.num_continuous_states(),
           system.get_input_port_selection(input_port_index)
               ? system.get_input_port_selection(input_port_index)->size()
               : 0,
@@ -157,7 +157,7 @@ DirectCollocation::DirectCollocation(
           system->get_input_port_selection(input_port_index)
               ? system->get_input_port_selection(input_port_index)->size()
               : 0,
-          context.get_continuous_state().size(), num_time_samples,
+          context.num_continuous_states(), num_time_samples,
           minimum_timestep, maximum_timestep),
       system_(system),
       context_(context.Clone()),

--- a/systems/trajectory_optimization/direct_transcription.cc
+++ b/systems/trajectory_optimization/direct_transcription.cc
@@ -46,7 +46,7 @@ class DiscreteTimeSystemConstraint : public solvers::Constraint {
     DRAKE_DEMAND(context_->has_only_discrete_state());
     DRAKE_DEMAND(context_ != nullptr);
     DRAKE_DEMAND(discrete_state_ != nullptr);
-    DRAKE_DEMAND(context_->get_num_input_ports() == 0 ||
+    DRAKE_DEMAND(context_->num_input_ports() == 0 ||
                  input_port_value_ != nullptr);
 
     // Makes sure the autodiff vector is properly initialized.
@@ -76,7 +76,7 @@ class DiscreteTimeSystemConstraint : public solvers::Constraint {
     const auto next_state = x.tail(num_states_);
 
     context_->SetTime(evaluation_time_);
-    if (context_->get_num_input_ports() > 0) {
+    if (context_->num_input_ports() > 0) {
       input_port_value_->GetMutableVectorData<AutoDiffXd>()->SetFromVector(
           input);
     }
@@ -117,7 +117,7 @@ DirectTranscription::DirectTranscription(const System<double>* system,
                                          const Context<double>& context,
                                          int num_time_samples)
     : MultipleShooting(
-          system->get_num_total_inputs(), context.get_num_total_states(),
+          system->num_total_inputs(), context.num_total_states(),
           num_time_samples, get_period(system)),
       discrete_time_system_(true) {
   // Note: this constructor is for discrete-time systems.  For continuous-time
@@ -135,8 +135,8 @@ DirectTranscription::DirectTranscription(
     const LinearSystem<double>* linear_system,
     const Context<double>& context,
     int num_time_samples)
-    : MultipleShooting(linear_system->get_num_total_inputs(),
-                       context.get_num_total_states(), num_time_samples,
+    : MultipleShooting(linear_system->num_total_inputs(),
+                       context.num_total_states(), num_time_samples,
                        std::max(linear_system->time_period(),
                                 std::numeric_limits<double>::epsilon())
                        /* N.B. Ensures that MultipleShooting is well-formed */),
@@ -157,8 +157,8 @@ DirectTranscription::DirectTranscription(
 DirectTranscription::DirectTranscription(
     const TimeVaryingLinearSystem<double>* system,
     const Context<double>& context, int num_time_samples)
-    : MultipleShooting(system->get_num_total_inputs(),
-                       context.get_num_total_states(), num_time_samples,
+    : MultipleShooting(system->num_total_inputs(),
+                       context.num_total_states(), num_time_samples,
                        std::max(system->time_period(),
                                 std::numeric_limits<double>::epsilon())
                        /* N.B. Ensures that MultipleShooting is well-formed */),
@@ -299,7 +299,7 @@ void DirectTranscription::AddAutodiffDynamicConstraints(
 
   context_->SetTimeStateAndParametersFrom(context);
 
-  if (context_->get_num_input_ports() > 0) {
+  if (context_->num_input_ports() > 0) {
     // Allocate the input port and keep an alias around.
     input_port_value_ = &context_->FixInputPort(
         0, system_->AllocateInputVector(system_->get_input_port(0)));
@@ -327,10 +327,10 @@ void DirectTranscription::ConstrainEqualInputAtFinalTwoTimesteps() {
 void DirectTranscription::ValidateSystem(const System<double>& system,
                                          const Context<double>& context) {
   DRAKE_DEMAND(context.has_only_discrete_state());
-  DRAKE_DEMAND(context.get_num_discrete_state_groups() == 1);
+  DRAKE_DEMAND(context.num_discrete_state_groups() == 1);
   DRAKE_DEMAND(num_states() == context.get_discrete_state(0).size());
-  DRAKE_DEMAND(system.get_num_input_ports() <= 1);
-  DRAKE_DEMAND(num_inputs() == (context.get_num_input_ports() > 0
+  DRAKE_DEMAND(system.num_input_ports() <= 1);
+  DRAKE_DEMAND(num_inputs() == (context.num_input_ports() > 0
                                 ? system.get_input_port(0).size()
                                 : 0));
 }


### PR DESCRIPTION
In PR #10995, "count" methods like `get_num_abstract_states()` were replaced with just `num_abstract_states()` for consistency. The old names were left in place, marked "to be deprecated", and most usages were unchanged. This PR removes all use of the old names from Drake and deprecates the old methods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11078)
<!-- Reviewable:end -->
