### PR TITLE
Linearize should allow Abstract inputs.

### DIFF
--- a/systems/primitives/linear_system.cc
+++ b/systems/primitives/linear_system.cc
@@ -115,6 +115,7 @@ std::unique_ptr<AffineSystem<double>> DoFirstOrderTaylorApproximation(
   std::unique_ptr<Context<AutoDiffXd>> autodiff_context =
       autodiff_system->CreateDefaultContext();
   autodiff_context->SetTimeStateAndParametersFrom(context);
+  autodiff_system->FixInputPortsFrom(system, context, autodiff_context.get());
 
   const InputPort<AutoDiffXd>* input_port =
       autodiff_system->get_input_port_selection(input_port_index);
@@ -139,36 +140,6 @@ std::unique_ptr<AffineSystem<double>> DoFirstOrderTaylorApproximation(
                  ? context.get_continuous_state_vector().CopyToVector()
                  : context.get_discrete_state(0).get_value());
   const int num_states = x0.size();
-
-  // Fix autodiff'd versions of the inputs to the autodiff'd Context.
-  for (int i = 0; i < system.get_num_input_ports(); ++i) {
-    const InputPort<double>& input_port_i =
-        system.get_input_port(InputPortIndex(i));
-
-    // Look for abstract valued port.
-    if (input_port_i.get_data_type() == PortDataType::kAbstractValued) {
-      if (input_port_i.HasValue(context)) {
-        throw std::logic_error(fmt::format(
-            "Unable to linearize system with connected abstract port ({}) - "
-            "connected abstract ports not yet supported.",
-            input_port_i.get_name()));
-      }
-      continue;
-    }
-
-    // Must be a vector valued port. First look to see whether it's connected
-    // or zero-dimensional.
-    if (input_port_i.size() > 0) {
-      if (!input_port_i.HasValue(context)) {
-        throw std::logic_error(fmt::format(
-            "Vector-valued input port {} must be either fixed or connected to "
-            "the output of another system.", input_port_i.get_name()));
-      }
-
-      Eigen::VectorBlock<const VectorX<double>> u = input_port_i.Eval(context);
-      autodiff_context->FixInputPort(i, u.cast<AutoDiffXd>());
-    }
-  }
 
   Eigen::VectorXd u0 = Eigen::VectorXd::Zero(num_inputs);
   if (input_port) {

--- a/systems/primitives/linear_system.h
+++ b/systems/primitives/linear_system.h
@@ -164,7 +164,8 @@ class TimeVaryingLinearSystem : public TimeVaryingAffineSystem<T> {
 /// @param context Defines the nominal operating point about which the system
 /// should be linearized.  See note below.
 /// @param input_port_index A valid input port index for @p system or
-/// InputPortSelection @default kUseFirstInputIfItExists.
+/// InputPortSelection.  All other inputs are assumed to be fixed to the
+/// value described by the @p context. @default kUseFirstInputIfItExists.
 /// @param output_port_index A valid output port index for @p system or
 /// an OutputPortSelection. @default kUseFirstOutputIfItExists.
 /// @param equilibrium_check_tolerance Specifies the tolerance on ensuring that

--- a/systems/primitives/test/linear_system_test.cc
+++ b/systems/primitives/test/linear_system_test.cc
@@ -411,27 +411,23 @@ GTEST_TEST(TestLinearize, LinearizingOnAbstractPortThrows) {
       "abstract ports is not supported.");
 }
 
-// Test that linearizing a system with mixed (vector and abstract) inputs does
-// not throw an exception when the abstract input port is unconnected and
-// does throw an exception when the abstract input port is connected.
+// Test linearizing a system with mixed (vector and abstract) inputs.
 GTEST_TEST(TestLinearize, LinearizingWithMixedInputs) {
   EmptyStateSystemWithMixedInputs<double> system;
   auto context = system.CreateDefaultContext();
 
   // First check without the vector-valued input port connected.
   DRAKE_EXPECT_THROWS_MESSAGE(Linearize(system, *context), std::logic_error,
-      "Vector-valued input port.*must be either fixed or connected to "
-          "the output of another system.");
+      "InputPort.*is not connected");
 
-  // Now check with the vector-valued input port connect but without the
-  // abstract input port connected.
+  // Now check with the vector-valued input port connected but the abstract
+  // input port not yet connected.
   context->FixInputPort(0, Vector1<double>(0.0));
   EXPECT_NO_THROW(Linearize(system, *context));
 
   // Now check with the abstract input port connected.
   context->FixInputPort(1, Value<std::vector<double>>());
-  DRAKE_EXPECT_THROWS_MESSAGE(Linearize(system, *context), std::logic_error,
-      "Unable to linearize system with connected abstract port.*");
+  EXPECT_NO_THROW(Linearize(system, *context));
 }
 
 // Test that Linearize throws when called on a discrete but non-periodic system.


### PR DESCRIPTION
In reviewing the implementation of additional inputs, I realized that abstract input ports were being handled inconsistently.  If it's ok to have a connected vector input port which gets frozen/cloned, then it should also be ok to have an additional connected abstract input port that behaves the same way.  

Also, the implementation in `FixInputPortsFrom` in `System` is slightly better than the one that was here (by handling derived types of BasicVector).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11079)
<!-- Reviewable:end -->
