### PR TITLE
rigid_transform: Use `VectorOrInitList` 

### DIFF
--- a/common/eigen_types.h
+++ b/common/eigen_types.h
@@ -461,8 +461,8 @@ class EigenPtr {
 template <typename T, int N = Eigen::Dynamic>
 class VectorOrInitList {
  public:
-  // NOLINTNEXTLINE(runtime/explicit) This conversion is desirable.
   template <typename Derived>
+  // NOLINTNEXTLINE(runtime/explicit) This conversion is desirable.
   VectorOrInitList(const Eigen::MatrixBase<Derived>& value) : value_(value) {}
 
   // NOLINTNEXTLINE(runtime/explicit) This conversion is desirable.

--- a/common/eigen_types.h
+++ b/common/eigen_types.h
@@ -455,4 +455,31 @@ class EigenPtr {
   }
 };
 
+/// Permits specifying values via a Vector<> or an initializer list. Useful for
+/// function arguments.
+/// N.B. This may cause a performance impact.
+template <typename T, int N = Eigen::Dynamic>
+class VectorOrInitList {
+ public:
+  // NOLINTNEXTLINE(runtime/explicit) This conversion is desirable.
+  template <typename Derived>
+  VectorOrInitList(const Eigen::MatrixBase<Derived>& value) : value_(value) {}
+
+  // NOLINTNEXTLINE(runtime/explicit) This conversion is desirable.
+  VectorOrInitList(const std::initializer_list<T>& list) {
+    DRAKE_DEMAND(N == Eigen::Dynamic || static_cast<int>(list.size()) == N);
+    auto iter = list.begin();
+    value_.resize(list.size());
+    for (size_t i = 0; i < list.size(); ++i) {
+      value_[i] = *iter;
+      ++iter;
+    }
+    DRAKE_DEMAND(iter == list.end());
+  }
+
+  const Vector<T, N>& value() const { return value_; }
+ private:
+  Vector<T, N> value_{};
+};
+
 }  // namespace drake

--- a/common/test/eigen_types_test.cc
+++ b/common/test/eigen_types_test.cc
@@ -219,5 +219,32 @@ GTEST_TEST(EigenTypesTest, FixedSizeVector) {
   EXPECT_EQ(row.cols(), 2);
 }
 
+// Check implicit casts.
+template <int N>
+void CheckValue(
+    const VectorOrInitList<double, N>& actual,
+    const Vector<double, N>& expected) {
+  EXPECT_TRUE((actual.value().array() == expected.array()).all());
+}
+
+GTEST_TEST(EigenTypesTest, VectorOrInitList) {
+  // Test dynamic vectors.
+  static_assert(
+      std::is_same<
+          VectorOrInitList<double>, VectorOrInitList<double, -1>>::value,
+      "Bad aliasing?");
+
+  VectorXd expected(5);
+  expected << 1, 2, 3, 4, 5;
+  CheckValue<Eigen::Dynamic>(expected, expected);
+  CheckValue<Eigen::Dynamic>({1, 2, 3, 4, 5}, expected);
+  CheckValue<5>({1, 2, 3, 4, 5}, expected);
+
+  Vector<double, 5> expected5;
+  expected5 << 1, 2, 3, 4, 5;
+  CheckValue<5>(expected, expected5);
+  CheckValue<5>(expected5, expected);
+}
+
 }  // namespace
 }  // namespace drake

--- a/examples/manipulation_station/manipulation_station.cc
+++ b/examples/manipulation_station/manipulation_station.cc
@@ -256,8 +256,8 @@ void ManipulationStation<T>::SetupDefaultStation(
         "amazon_table_simplified.sdf");
 
     const Isometry3<double> X_WT =
-        RigidTransform<double>(Vector3d(dx_table_center_to_robot_base, 0,
-                                        -dz_table_top_robot_base))
+        RigidTransform<double>({dx_table_center_to_robot_base, 0,
+                                -dz_table_top_robot_base})
             .GetAsIsometry3();
     internal::AddAndWeldModelFrom(sdf_path, "table", plant_->world_frame(),
                                   "amazon_table", X_WT, plant_);

--- a/examples/manipulation_station/test/manipulation_station_test.cc
+++ b/examples/manipulation_station/test/manipulation_station_test.cc
@@ -351,15 +351,15 @@ GTEST_TEST(ManipulationStationTest, RegisterRgbdCameraTest) {
     geometry::dev::render::DepthCameraProperties camera_properties(
         640, 480, M_PI_4, dut.default_renderer_name(), 0.1, 2.0);
 
-    math::RigidTransform<double> X_WF0(Eigen::Vector3d(0, 0, 0.2));
-    math::RigidTransform<double> X_F0C0(Eigen::Vector3d(0.3, 0.2, 0.0));
+    math::RigidTransform<double> X_WF0({0, 0, 0.2});
+    math::RigidTransform<double> X_F0C0({0.3, 0.2, 0.0});
     const auto& frame0 =
         plant.AddFrame(std::make_unique<multibody::FixedOffsetFrame<double>>(
             "frame0", plant.world_frame(), X_WF0.GetAsIsometry3()));
     dut.RegisterRgbdCamera("camera0", frame0, X_F0C0, camera_properties);
 
-    math::RigidTransform<double> X_F0F1(Eigen::Vector3d(0, -0.1, 0.2));
-    math::RigidTransform<double> X_F1C1(Eigen::Vector3d(-0.2, 0.2, 0.33));
+    math::RigidTransform<double> X_F0F1({0, -0.1, 0.2});
+    math::RigidTransform<double> X_F1C1({-0.2, 0.2, 0.33});
     const auto& frame1 =
         plant.AddFrame(std::make_unique<multibody::FixedOffsetFrame<double>>(
             "frame1", frame0, X_F0F1.GetAsIsometry3()));

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -710,7 +710,7 @@ std::vector<SignedDistanceToPointTestData> GenDistanceTestDataTranslateBox() {
       // The position of the query point p_WQ(23,20,30) is closest to G at
       // (20,20,30) in World frame, which is p_GN=(10,0,0) in G's frame.
       // The gradient vector is expressed in both frames as (1,0,0).
-      {box, RigidTransformd(Vector3d(10., 20., 30.)), Vector3d{23., 20., 30.},
+      {box, RigidTransformd({10., 20., 30.}), Vector3d{23., 20., 30.},
        SignedDistanceToPoint<double>(GeometryId::get_new_id(),
                                      Vector3d(10., 0., 0.), 3.,
                                      Vector3d(1., 0., 0.))}};
@@ -2530,8 +2530,8 @@ GenDistPairRepeatabilityTestData() {
       make_shared<const Convex>(
           drake::FindResourceOrThrow("drake/geometry/test/quad_cube.obj"),
           1.1)};
-  const RigidTransformd X_WA = RigidTransformd(Vector3d(0.1, 0.2, 0.3));
-  const RigidTransformd X_WB = RigidTransformd(Vector3d(0.11, 0.21, 0.31));
+  const RigidTransformd X_WA = RigidTransformd({0.1, 0.2, 0.3});
+  const RigidTransformd X_WB = RigidTransformd({0.11, 0.21, 0.31});
   std::vector<SignedDistancePairRepeatTestData> test_data;
   for (shared_ptr<const Shape>& a : shapes_A)
     for (shared_ptr<const Shape>& b : shapes_B)
@@ -2910,7 +2910,7 @@ class BoxPenetrationTest : public ::testing::Test {
     // a. Orient the box so that the corner p_BoC_B = (-0.5, -0.5, -0.5) lies in
     //    the most -z extent. With only rotation, p_BoC_B != p_WC.
     const math::RotationMatrixd R_WB(AngleAxisd(std::atan(M_SQRT2),
-                                     Vector3d(M_SQRT1_2, -M_SQRT1_2, 0)));
+                                     {M_SQRT1_2, -M_SQRT1_2, 0}));
 
     // b. Translate it so that the rotated corner p_BoC_W lies at
     //    (0, 0, -d).

--- a/math/rigid_transform.h
+++ b/math/rigid_transform.h
@@ -63,6 +63,7 @@ class RigidTransform {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(RigidTransform)
 
+
   /// Constructs the %RigidTransform that corresponds to aligning the two frames
   /// so unit vectors Ax = Bx, Ay = By, Az = Bz and point Ao is coincident with
   /// Bo.  Hence, the constructed %RigidTransform contains an identity
@@ -76,7 +77,9 @@ class RigidTransform {
   /// @param[in] R rotation matrix relating frames A and B (e.g., `R_AB`).
   /// @param[in] p position vector from frame A's origin to frame B's origin,
   /// expressed in frame A.  In monogram notation p is denoted `p_AoBo_A`.
-  RigidTransform(const RotationMatrix<T>& R, const Vector3<T>& p) { set(R, p); }
+  RigidTransform(
+      const RotationMatrix<T>& R,
+      const VectorOrInitList<T, 3>& p) { set(R, p.value()); }
 
   /// Constructs a %RigidTransform from a RollPitchYaw and a position vector.
   /// @param[in] rpy a %RollPitchYaw which is a Space-fixed (extrinsic) X-Y-Z
@@ -85,7 +88,7 @@ class RigidTransform {
   /// @see RotationMatrix::RotationMatrix(const RollPitchYaw<T>&)
   /// @param[in] p position vector from frame A's origin to frame B's origin,
   /// expressed in frame A.  In monogram notation p is denoted `p_AoBo_A`.
-  RigidTransform(const RollPitchYaw<T>& rpy, const Vector3<T>& p)
+  RigidTransform(const RollPitchYaw<T>& rpy, const VectorOrInitList<T, 3>& p)
       : RigidTransform(RotationMatrix<T>(rpy), p) {}
 
   /// Constructs a %RigidTransform from a Quaternion and a position vector.
@@ -96,7 +99,8 @@ class RigidTransform {
   /// @throws std::logic_error in debug builds if the rotation matrix
   /// that is built from `quaternion` is invalid.
   /// @see RotationMatrix::RotationMatrix(const Eigen::Quaternion<T>&)
-  RigidTransform(const Eigen::Quaternion<T>& quaternion, const Vector3<T>& p)
+  RigidTransform(
+      const Eigen::Quaternion<T>& quaternion, const VectorOrInitList<T, 3>& p)
       : RigidTransform(RotationMatrix<T>(quaternion), p) {}
 
   /// Constructs a %RigidTransform from a AngleAxis and a position vector.
@@ -108,7 +112,8 @@ class RigidTransform {
   /// @throws std::logic_error in debug builds if the rotation matrix
   /// that is built from `theta_lambda` is invalid.
   /// @see RotationMatrix::RotationMatrix(const Eigen::AngleAxis<T>&)
-  RigidTransform(const Eigen::AngleAxis<T>& theta_lambda, const Vector3<T>& p)
+  RigidTransform(
+      const Eigen::AngleAxis<T>& theta_lambda, const VectorOrInitList<T, 3>& p)
       : RigidTransform(RotationMatrix<T>(theta_lambda), p) {}
 
   /// Constructs a %RigidTransform with a given RotationMatrix and a zero
@@ -122,7 +127,8 @@ class RigidTransform {
   /// position vector 'p'.
   /// @param[in] p position vector from frame A's origin to frame B's origin,
   /// expressed in frame A.  In monogram notation p is denoted `p_AoBo_A`.
-  explicit RigidTransform(const Vector3<T>& p) { set_translation(p); }
+  explicit RigidTransform(const VectorOrInitList<T, 3>& p) {
+      set_translation(p.value()); }
 
   /// Constructs a %RigidTransform from an Eigen Isometry3.
   /// @param[in] pose Isometry3 that contains an allegedly valid rotation matrix
@@ -138,9 +144,9 @@ class RigidTransform {
   /// @param[in] R rotation matrix relating frames A and B (e.g., `R_AB`).
   /// @param[in] p position vector from frame A's origin to frame B's origin,
   /// expressed in frame A.  In monogram notation p is denoted `p_AoBo_A`.
-  void set(const RotationMatrix<T>& R, const Vector3<T>& p) {
+  void set(const RotationMatrix<T>& R, const VectorOrInitList<T, 3>& p) {
     set_rotation(R);
-    set_translation(p);
+    set_translation(p.value());
   }
 
   /// Sets `this` %RigidTransform from an Eigen Isometry3.

--- a/math/test/rigid_transform_test.cc
+++ b/math/test/rigid_transform_test.cc
@@ -176,6 +176,8 @@ GTEST_TEST(RigidTransform, ConstructorQuaternionPositionVector) {
   const RotationMatrix<double> R(quaternion);
   EXPECT_TRUE(X.rotation().IsExactlyEqualTo(R));
   EXPECT_TRUE(X.translation() == position);
+  const RigidTransform<double> X2(quaternion, {4, 5, 6});
+  EXPECT_TRUE(X2.translation() == position);
 }
 
 // Tests constructing a RigidTransform from an AngleAxis and a position vector.

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -1139,7 +1139,7 @@ GTEST_TEST(MultibodyPlantTest, CollisionGeometryRegistration) {
   unique_ptr<Context<double>> context = plant.CreateDefaultContext();
 
   // Test the API taking a RigidTransform.
-  auto X_WS1 = RigidTransformd(Vector3d(-x_offset, radius, 0.0));
+  auto X_WS1 = RigidTransformd({-x_offset, radius, 0.0});
 
   // Place sphere 1 on top of the ground, with offset x = -x_offset.
   plant.SetFreeBodyPose(
@@ -2383,7 +2383,7 @@ GTEST_TEST(StateSelection, FloatingBodies) {
       0.057 / 2;
   plant.WeldFrames(
       plant.world_frame(), plant.GetFrameByName("iiwa_link_0", arm_model),
-      RigidTransform<double>(Vector3d(0, 0, table_top_z_in_world))
+      RigidTransform<double>({0, 0, table_top_z_in_world})
           .GetAsIsometry3());
 
   // Load a second table for objects.

--- a/multibody/tree/test/frames_test.cc
+++ b/multibody/tree/test/frames_test.cc
@@ -61,7 +61,7 @@ class FrameTests : public ::testing::Test {
     // Some arbitrary pose of frame P in the body frame B.
     X_BP_ = RigidTransformd(AngleAxisd(M_PI / 6.0, Vector3d::UnitZ()) *
                             AngleAxisd(M_PI / 5.0, Vector3d::UnitX()) *
-                            Translation3d(0.0, -1.0, 0.0));
+                            {0.0, -1.0, 0.0});
     // Frame P is rigidly attached to B with pose X_BP.
     frameP_ =
         &model->AddFrame<FixedOffsetFrame>(bodyB_->body_frame(), X_BP_);
@@ -69,7 +69,7 @@ class FrameTests : public ::testing::Test {
     // Some arbitrary pose of frame Q in frame P.
     X_PQ_ = RigidTransformd(AngleAxisd(-M_PI / 3.0, Vector3d::UnitZ()) *
                             AngleAxisd(M_PI / 7.0, Vector3d::UnitX()) *
-                            Translation3d(0.5, 1.0, -2.0));
+                            {0.5, 1.0, -2.0});
     // Frame Q is rigidly attached to P with pose X_PQ.
     frameQ_ =
         &model->AddFrame<FixedOffsetFrame>(*frameP_, X_PQ_);
@@ -97,7 +97,7 @@ class FrameTests : public ::testing::Test {
     X_FG_ = RigidTransformd(AngleAxisd(M_PI / 6.0, Vector3d::UnitY()) *
                             AngleAxisd(M_PI / 8.0, Vector3d::UnitZ()) *
                             AngleAxisd(M_PI / 5.0, Vector3d::UnitX()) *
-                            Translation3d(2.0, -1.0, 0.5));
+                            {2.0, -1.0, 0.5});
 
     // An arbitrary pose of an arbitrary frame F in an arbitrary frame Q.
     X_QF_ = X_FG_;

--- a/multibody/tree/test/multibody_tree_test.cc
+++ b/multibody/tree/test/multibody_tree_test.cc
@@ -1208,8 +1208,8 @@ class WeldMobilizerTest : public ::testing::Test {
                                     Eigen::Translation3d(0.5, 0.0, 0.0)};
   math::RigidTransformd X_WB1_{X_WB1};
   math::RigidTransformd X_FM_{math::RotationMatrixd::MakeZRotation(-M_PI_2)};
-  math::RigidTransformd X_B1F_{Vector3d(0.5, 0.0, 0.0)};
-  math::RigidTransformd X_B2M_{Vector3d(-0.5, 0.0, 0.0)};
+  math::RigidTransformd X_B1F_{{0.5, 0.0, 0.0}};
+  math::RigidTransformd X_B2M_{{-0.5, 0.0, 0.0}};
   math::RigidTransformd X_WB2_;
 };
 

--- a/multibody/tree/test/tree_from_joints_test.cc
+++ b/multibody/tree/test/tree_from_joints_test.cc
@@ -136,7 +136,7 @@ class DoublePendulumModel {
     // L1's origin is located at the com of link 1.
     // X_L1So defines the pose of the shoulder outboard frame So in link 1's
     // frame.
-    const math::RigidTransformd X_L1So{Vector3d(0.0, half_length1_, 0.0)};
+    const math::RigidTransformd X_L1So{{0.0, half_length1_, 0.0}};
 
     shoulder_ = &model->template AddJoint<RevoluteJoint>(
         "ShoulderJoint",
@@ -154,7 +154,7 @@ class DoublePendulumModel {
     // The elbow's outboard frame Eo is taken to be coincident with link 2's
     // frame L2 (i.e. L2o != L2cm).
     // X_L1Ei defines the pose of the elbow inboard frame Ei link 1's frame L1.
-    const math::RigidTransformd X_L1Ei{Vector3d(0.0, -half_length1_, 0.0)};
+    const math::RigidTransformd X_L1Ei{{0.0, -half_length1_, 0.0}};
 
     elbow_ = &model->template AddJoint<RevoluteJoint>(
         "ElbowJoint",

--- a/multibody/tree/test/tree_from_mobilizers_test.cc
+++ b/multibody/tree/test/tree_from_mobilizers_test.cc
@@ -311,13 +311,13 @@ class PendulumTests : public ::testing::Test {
   const double acceleration_of_gravity_ = 9.81;
   // Poses:
   // Desired pose of the lower link frame L in the world frame W.
-  const RigidTransformd X_WL_{Vector3d(0.0, -half_link1_length_, 0.0)};
+  const RigidTransformd X_WL_{{0.0, -half_link1_length_, 0.0}};
   // Pose of the shoulder outboard frame So in the upper link frame U.
-  const RigidTransformd X_USo_{Vector3d(0.0, half_link1_length_, 0.0)};
+  const RigidTransformd X_USo_{{0.0, half_link1_length_, 0.0}};
   // Pose of the elbow inboard frame Ei in the upper link frame U.
-  const RigidTransformd X_UEi_{Vector3d(0.0, -half_link1_length_, 0.0)};
+  const RigidTransformd X_UEi_{{0.0, -half_link1_length_, 0.0}};
   // Pose of the elbow outboard frame Eo in the lower link frame L.
-  const RigidTransformd X_LEo_{Vector3d(0.0, half_link2_length_, 0.0)};
+  const RigidTransformd X_LEo_{{0.0, half_link2_length_, 0.0}};
 };
 
 TEST_F(PendulumTests, CreateModelBasics) {

--- a/multibody/tree/test/weld_joint_test.cc
+++ b/multibody/tree/test/weld_joint_test.cc
@@ -53,7 +53,7 @@ class WeldJointTest : public ::testing::Test {
 
   const RigidBody<double>* body_{nullptr};
   const WeldJoint<double>* joint_{nullptr};
-  const math::RigidTransformd X_FM_{Vector3d(0, 0.5, 0)};
+  const math::RigidTransformd X_FM_{{0, 0.5, 0}};
 };
 
 // Verify the expected number of dofs.

--- a/perception/test/depth_image_to_point_cloud_test.cc
+++ b/perception/test/depth_image_to_point_cloud_test.cc
@@ -214,8 +214,8 @@ class DepthImageToPointCloudTest : public ::testing::Test {
 
   const CameraInfo single_pixel_camera_{1, 1, 1.0, 1.0, 0.5, 0.5};
   const RigidTransformd random_transform_{RollPitchYawd(0.1, -0.2, 0.3),
-                                          Vector3d(1.1, -1.2, 1.3)};
-  const RigidTransformd z_translation_{Vector3d(0.0, 0.0, 1.3)};
+                                          {1.1, -1.2, 1.3}};
+  const RigidTransformd z_translation_{{0.0, 0.0, 1.3}};
 };
 TYPED_TEST_CASE(DepthImageToPointCloudTest, AllConfigs);
 


### PR DESCRIPTION
Prototype that could: Resolve #11033

Not sure if it will make performance suck, though.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11083)
<!-- Reviewable:end -->
