### PR TITLE
Add basic maliput::api::RoadNetwork class binding to pydrake.

### DIFF
--- a/bindings/pydrake/maliput/api_py.cc
+++ b/bindings/pydrake/maliput/api_py.cc
@@ -5,6 +5,7 @@
 #include "drake/automotive/maliput/api/lane.h"
 #include "drake/automotive/maliput/api/lane_data.h"
 #include "drake/automotive/maliput/api/road_geometry.h"
+#include "drake/automotive/maliput/api/road_network.h"
 #include "drake/automotive/maliput/api/segment.h"
 #include "drake/bindings/pydrake/common/wrap_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
@@ -57,6 +58,10 @@ PYBIND11_MODULE(api, m) {
       .def(
           "quat", &Rotation::quat, py_reference_internal, doc.Rotation.quat.doc)
       .def("rpy", &Rotation::rpy, doc.Rotation.rpy.doc);
+
+  py::class_<RoadNetwork>(m, "RoadNetwork", doc.RoadNetwork.doc)
+      .def("road_geometry", &RoadNetwork::road_geometry,
+          doc.RoadNetwork.road_geometry.doc);
 
   py::class_<RoadGeometry>(m, "RoadGeometry", doc.RoadGeometry.doc)
       .def("num_junctions", &RoadGeometry::num_junctions,


### PR DESCRIPTION
This pull request adds a basic binding in `pydrake` for the recently introduced `maliput::api::RoadNetwork` class. See https://github.com/RobotLocomotion/drake/pull/10881 for further reference.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11084)
<!-- Reviewable:end -->
