### PR TITLE
Deprecating Isometry3-flavored from MBP::Register[]Geometry API

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -423,14 +423,6 @@ PYBIND11_MODULE(plant, m) {
             &Class::RegisterAsSourceForSceneGraph, py::arg("scene_graph"),
             doc.MultibodyPlant.RegisterAsSourceForSceneGraph.doc)
         .def("RegisterVisualGeometry",
-            py::overload_cast<const Body<T>&, const Isometry3<double>&,
-                const geometry::Shape&, const std::string&,
-                const Vector4<double>&, geometry::SceneGraph<T>*>(
-                &Class::RegisterVisualGeometry),
-            py::arg("body"), py::arg("X_BG"), py::arg("shape"), py::arg("name"),
-            py::arg("diffuse_color"), py::arg("scene_graph") = nullptr,
-            doc_iso3_deprecation)
-        .def("RegisterVisualGeometry",
             py::overload_cast<const Body<T>&, const RigidTransform<double>&,
                 const geometry::Shape&, const std::string&,
                 const Vector4<double>&, geometry::SceneGraph<T>*>(
@@ -439,13 +431,18 @@ PYBIND11_MODULE(plant, m) {
             py::arg("diffuse_color"), py::arg("scene_graph") = nullptr,
             doc.MultibodyPlant.RegisterVisualGeometry
                 .doc_6args_body_X_BG_shape_name_diffuse_color_scene_graph)
-        .def("RegisterCollisionGeometry",
-            py::overload_cast<const Body<T>&, const Isometry3<double>&,
-                const geometry::Shape&, const std::string&,
-                const CoulombFriction<double>&, geometry::SceneGraph<T>*>(
-                &Class::RegisterCollisionGeometry),
+        .def("RegisterVisualGeometry",
+            [doc_iso3_deprecation](Class* self, const Body<T>& body,
+                const Isometry3<double>& X_BG, const geometry::Shape& shape,
+                const std::string& name, const Vector4<double>& diffuse_color,
+                geometry::SceneGraph<T>* scene_graph) {
+              WarnDeprecated(doc_iso3_deprecation);
+              return self->RegisterVisualGeometry(body,
+                  RigidTransform<double>(X_BG), shape, name, diffuse_color,
+                  scene_graph);
+            },
             py::arg("body"), py::arg("X_BG"), py::arg("shape"), py::arg("name"),
-            py::arg("coulomb_friction"), py::arg("scene_graph") = nullptr,
+            py::arg("diffuse_color"), py::arg("scene_graph") = nullptr,
             doc_iso3_deprecation)
         .def("RegisterCollisionGeometry",
             py::overload_cast<const Body<T>&, const RigidTransform<double>&,
@@ -455,6 +452,20 @@ PYBIND11_MODULE(plant, m) {
             py::arg("body"), py::arg("X_BG"), py::arg("shape"), py::arg("name"),
             py::arg("coulomb_friction"), py::arg("scene_graph") = nullptr,
             doc.MultibodyPlant.RegisterCollisionGeometry.doc)
+        .def("RegisterCollisionGeometry",
+            [doc_iso3_deprecation](Class* self, const Body<T>& body,
+                const Isometry3<double>& X_BG, const geometry::Shape& shape,
+                const std::string& name,
+                const CoulombFriction<double>& coulomb_friction,
+                geometry::SceneGraph<T>* scene_graph) {
+              WarnDeprecated(doc_iso3_deprecation);
+              return self->RegisterCollisionGeometry(body,
+                  RigidTransform<double>(X_BG), shape, name, coulomb_friction,
+                  scene_graph);
+            },
+            py::arg("body"), py::arg("X_BG"), py::arg("shape"), py::arg("name"),
+            py::arg("coulomb_friction"), py::arg("scene_graph") = nullptr,
+            doc_iso3_deprecation)
         .def("get_source_id", &Class::get_source_id,
             doc.MultibodyPlant.get_source_id.doc)
         .def("get_geometry_query_input_port",

--- a/examples/simple_gripper/simple_gripper.cc
+++ b/examples/simple_gripper/simple_gripper.cc
@@ -32,25 +32,25 @@ namespace simple_gripper {
 namespace {
 
 using Eigen::Isometry3d;
-using Eigen::Translation3d;
 using Eigen::Vector3d;
-using drake::geometry::SceneGraph;
-using drake::geometry::Sphere;
-using drake::lcm::DrakeLcm;
-using drake::math::RollPitchYaw;
-using drake::math::RotationMatrix;
-using drake::multibody::Body;
-using drake::multibody::CoulombFriction;
-using drake::multibody::ConnectContactResultsToDrakeVisualizer;
-using drake::multibody::MultibodyPlant;
-using drake::multibody::Parser;
-using drake::multibody::PrismaticJoint;
-using drake::multibody::UniformGravityFieldElement;
-using drake::systems::ImplicitEulerIntegrator;
-using drake::systems::RungeKutta2Integrator;
-using drake::systems::RungeKutta3Integrator;
-using drake::systems::SemiExplicitEulerIntegrator;
-using drake::systems::Sine;
+using geometry::SceneGraph;
+using geometry::Sphere;
+using lcm::DrakeLcm;
+using math::RigidTransformd;
+using math::RollPitchYaw;
+using math::RotationMatrix;
+using multibody::Body;
+using multibody::CoulombFriction;
+using multibody::ConnectContactResultsToDrakeVisualizer;
+using multibody::MultibodyPlant;
+using multibody::Parser;
+using multibody::PrismaticJoint;
+using multibody::UniformGravityFieldElement;
+using systems::ImplicitEulerIntegrator;
+using systems::RungeKutta2Integrator;
+using systems::RungeKutta3Integrator;
+using systems::SemiExplicitEulerIntegrator;
+using systems::Sine;
 
 // TODO(amcastro-tri): Consider moving this large set of parameters to a
 // configuration file (e.g. YAML).
@@ -149,7 +149,7 @@ void AddGripperPads(MultibodyPlant<double>* plant,
     p_FSo(2) = std::sin(d_theta * i + sample_rotation) * kPadMajorRadius;
 
     // Pose of the sphere frame S in the finger frame F.
-    const Isometry3d X_FS = Isometry3d(Translation3d(p_FSo));
+    const RigidTransformd X_FS(p_FSo);
 
     CoulombFriction<double> friction(
         FLAGS_ring_static_friction, FLAGS_ring_static_friction);

--- a/multibody/benchmarks/acrobot/make_acrobot_plant.cc
+++ b/multibody/benchmarks/acrobot/make_acrobot_plant.cc
@@ -9,7 +9,6 @@ namespace multibody {
 namespace benchmarks {
 namespace acrobot {
 
-using Eigen::Translation3d;
 using Eigen::Vector3d;
 
 using geometry::Cylinder;
@@ -53,18 +52,18 @@ MakeAcrobotPlant(const AcrobotParameters& params, bool finalize,
 
     // Pose of the geometry for link 1 in the link's frame.
     const RigidTransformd X_L1G1(-params.l1() / 2.0 * Vector3d::UnitZ());
-    plant->RegisterVisualGeometry(link1, X_L1G1.GetAsIsometry3(),
+    plant->RegisterVisualGeometry(link1, X_L1G1,
                                   Cylinder(params.r1(), params.l1()), "visual");
 
     // Pose of the geometry for link 2 in the link's frame.
     const RigidTransformd X_L2G2(-params.l2() / 2.0 * Vector3d::UnitZ());
-    plant->RegisterVisualGeometry(link2, X_L2G2.GetAsIsometry3(),
+    plant->RegisterVisualGeometry(link2, X_L2G2,
                                   Cylinder(params.r2(), params.l2()), "visual");
 
     // Register some (anchored) geometry to the world.
     const RigidTransformd X_WG;  // Default is identity transform.
     plant->RegisterVisualGeometry(
-        plant->world_body(), X_WG.GetAsIsometry3(),
+        plant->world_body(), X_WG,
         Sphere(params.l1() / 8.0), /* Arbitrary radius to decorate the model. */
         "visual");
   }

--- a/multibody/benchmarks/inclined_plane/make_inclined_plane_plant.cc
+++ b/multibody/benchmarks/inclined_plane/make_inclined_plane_plant.cc
@@ -11,7 +11,10 @@ namespace inclined_plane {
 using geometry::HalfSpace;
 using geometry::SceneGraph;
 using geometry::Sphere;
+using math::RigidTransformd;
 using Eigen::AngleAxisd;
+using Eigen::Matrix3d;
+using Eigen::Vector3d;
 
 void AddInclinedPlaneToPlant(
     double radius, double mass, double slope,
@@ -20,69 +23,60 @@ void AddInclinedPlaneToPlant(
   DRAKE_THROW_UNLESS(plant != nullptr);
 
   UnitInertia<double> G_Bcm = UnitInertia<double>::SolidSphere(radius);
-  SpatialInertia<double> M_Bcm(mass, Vector3<double>::Zero(), G_Bcm);
+  SpatialInertia<double> M_Bcm(mass, Vector3d::Zero(), G_Bcm);
 
   const RigidBody<double>& ball = plant->AddRigidBody("Ball", M_Bcm);
 
   // Orientation of a plane frame P with its z axis normal to the plane and its
   // x axis pointing down the plane.
-  const Matrix3<double> R_WP(AngleAxisd(slope, Vector3<double>::UnitY()));
+  const Matrix3d R_WP(AngleAxisd(slope, Vector3d::UnitY()));
 
-  const Vector3<double> normal_W = R_WP.col(2);
+  const Vector3d normal_W = R_WP.col(2);
   // Offset the plane so that with the rolling object's center at x = (0, 0, 0)
   // (the default initial condition) there is a contact point at point_W.
-  const Vector3<double> point_W = -normal_W * radius;
+  const Vector3d point_W = -normal_W * radius;
 
   // A half-space for the inclined plane geometry.
-  plant->RegisterCollisionGeometry(
-      plant->world_body(), HalfSpace::MakePose(normal_W, point_W), HalfSpace(),
-      "collision", surface_friction);
+  const RigidTransformd X_WG(HalfSpace::MakePose(normal_W, point_W));
+  plant->RegisterCollisionGeometry(plant->world_body(), X_WG, HalfSpace(),
+                                   "collision", surface_friction);
 
   // Visual for the ground.
-  plant->RegisterVisualGeometry(plant->world_body(),
-                                HalfSpace::MakePose(normal_W, point_W),
-                                HalfSpace(), "visual");
+  plant->RegisterVisualGeometry(plant->world_body(), X_WG, HalfSpace(),
+                                "visual");
 
   // Add sphere geometry for the ball.
   // Pose X_BG of geometry frame G in the ball frame B is an identity transform.
-  const math::RigidTransformd X_BG;   // Identity transform.
-  plant->RegisterCollisionGeometry(
-      ball,
-      X_BG.GetAsIsometry3(), Sphere(radius), "collision",
-      surface_friction);
+  const RigidTransformd X_BG;  // Identity transform.
+  plant->RegisterCollisionGeometry(ball, X_BG, Sphere(radius), "collision",
+                                   surface_friction);
 
   // Visual for the ball.
   const Vector4<double> orange(1.0, 0.55, 0.0, 1.0);
-  plant->RegisterVisualGeometry(
-      ball,
-      X_BG.GetAsIsometry3(), Sphere(radius), "visual1", orange);
+  plant->RegisterVisualGeometry(ball, X_BG, Sphere(radius), "visual1", orange);
 
   // Adds little spherical spokes to highlight the sphere's rotation.
   const Vector4<double> red(1.0, 0.0, 0.0, 1.0);
-  plant->RegisterVisualGeometry(
-      ball,
-      // Pose of 1st spoke frame in the ball frame B.
-      math::RigidTransformd(Vector3<double>(0, 0, radius)).GetAsIsometry3(),
-      Sphere(radius / 5), "visual2", red);
-  plant->RegisterVisualGeometry(
-      ball,
-      // Pose of 2nd spoke frame in the ball frame B.
-      math::RigidTransformd(Vector3<double>(0, 0, -radius)).GetAsIsometry3(),
-      Sphere(radius / 5), "visual3", red);
-  plant->RegisterVisualGeometry(
-      ball,
-      // Pose of 3rd spoke frame in the ball frame B.
-      math::RigidTransformd(Vector3<double>(radius, 0, 0)).GetAsIsometry3(),
-      Sphere(radius / 5), "visual4", red);
-  plant->RegisterVisualGeometry(
-      ball,
-      // Pose of 4th spoke frame in the ball frame B.
-      math::RigidTransformd(Vector3<double>(-radius, 0, 0)).GetAsIsometry3(),
-      Sphere(radius / 5), "visual5", red);
+  plant->RegisterVisualGeometry(ball,
+                                // Pose of 1st spoke frame in the ball frame B.
+                                RigidTransformd(Vector3d(0, 0, radius)),
+                                Sphere(radius / 5), "visual2", red);
+  plant->RegisterVisualGeometry(ball,
+                                // Pose of 2nd spoke frame in the ball frame B.
+                                RigidTransformd(Vector3d(0, 0, -radius)),
+                                Sphere(radius / 5), "visual3", red);
+  plant->RegisterVisualGeometry(ball,
+                                // Pose of 3rd spoke frame in the ball frame B.
+                                RigidTransformd(Vector3d(radius, 0, 0)),
+                                Sphere(radius / 5), "visual4", red);
+  plant->RegisterVisualGeometry(ball,
+                                // Pose of 4th spoke frame in the ball frame B.
+                                RigidTransformd(Vector3d(-radius, 0, 0)),
+                                Sphere(radius / 5), "visual5", red);
 
   // Gravity acting in the -z direction.
-  plant->AddForceElement<UniformGravityFieldElement>(
-      -gravity * Vector3<double>::UnitZ());
+  plant->AddForceElement<UniformGravityFieldElement>(-gravity *
+                                                     Vector3d::UnitZ());
 }
 
 }  // namespace inclined_plane

--- a/multibody/benchmarks/pendulum/make_pendulum_plant.cc
+++ b/multibody/benchmarks/pendulum/make_pendulum_plant.cc
@@ -43,13 +43,13 @@ MakePendulumPlant(const PendulumParameters& params,
     plant->RegisterAsSourceForSceneGraph(scene_graph);
     // Pose of the sphere used to visualize the point mass in the body frame B.
     const math::RigidTransformd X_BGs(-params.l() * Vector3d::UnitZ());
-    plant->RegisterVisualGeometry(point_mass, X_BGs.GetAsIsometry3(),
+    plant->RegisterVisualGeometry(point_mass, X_BGs,
                                   Sphere(params.point_mass_radius()),
                                   params.body_name());
 
     // Pose of the cylinder used to visualize the massless rod in frame B.
     const math::RigidTransformd X_BGc(-params.l() / 2.0 * Vector3d::UnitZ());
-    plant->RegisterVisualGeometry(point_mass, X_BGc.GetAsIsometry3(),
+    plant->RegisterVisualGeometry(point_mass, X_BGc,
         Cylinder(params.massless_rod_radius(), params.l()), "arm");
   }
 

--- a/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.cc
+++ b/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.cc
@@ -15,6 +15,8 @@ using drake::geometry::SceneGraph;
 namespace drake {
 namespace multibody {
 
+using math::RigidTransformd;
+
 IiwaKinematicConstraintTest::IiwaKinematicConstraintTest() {
   const std::string iiwa_path = FindResourceOrThrow(
       "drake/manipulation/models/iiwa_description/sdf/"
@@ -101,11 +103,11 @@ std::unique_ptr<systems::Diagram<T>> BuildTwoFreeSpheresDiagram(
   const auto& sphere1 = (*plant)->GetBodyByName("body1");
   const auto& sphere2 = (*plant)->GetBodyByName("body2");
   (*plant)->RegisterCollisionGeometry(
-      sphere1, X_B1S1, geometry::Sphere(radius1), "sphere1_collision",
-      multibody::CoulombFriction<double>(), *scene_graph);
+      sphere1, RigidTransformd(X_B1S1), geometry::Sphere(radius1),
+      "sphere1_collision", multibody::CoulombFriction<double>(), *scene_graph);
   (*plant)->RegisterCollisionGeometry(
-      sphere2, X_B2S2, geometry::Sphere(radius2), "sphere2_collision",
-      multibody::CoulombFriction<double>(), *scene_graph);
+      sphere2, RigidTransformd(X_B2S2), geometry::Sphere(radius2),
+      "sphere2_collision", multibody::CoulombFriction<double>(), *scene_graph);
   *sphere1_index = sphere1.body_frame().index();
   *sphere2_index = sphere2.body_frame().index();
   (*plant)->Finalize(*scene_graph);
@@ -145,7 +147,7 @@ std::unique_ptr<systems::Diagram<T>> ConstructBoxSphereDiagram(
       "box", SpatialInertia<double>(1, Eigen::Vector3d(0, 0, 0),
                                     UnitInertia<double>(1, 1, 1)));
   (*plant)->RegisterCollisionGeometry(
-      box, Isometry3<double>::Identity(),
+      box, RigidTransformd::Identity(),
       geometry::Box(box_size(0), box_size(1), box_size(2)), "box",
       CoulombFriction<double>(0.9, 0.8), *scene_graph);
 
@@ -153,7 +155,7 @@ std::unique_ptr<systems::Diagram<T>> ConstructBoxSphereDiagram(
       "sphere", SpatialInertia<double>(1, Eigen::Vector3d::Zero(),
                                        UnitInertia<double>(1, 1, 1)));
   (*plant)->RegisterCollisionGeometry(
-      sphere, Isometry3<double>::Identity(), geometry::Sphere(radius), "sphere",
+      sphere, RigidTransformd::Identity(), geometry::Sphere(radius), "sphere",
       CoulombFriction<double>(0.9, 0.8), *scene_graph);
 
   (*plant)->Finalize();

--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -29,6 +29,7 @@ using Eigen::Translation3d;
 using Eigen::Vector3d;
 using geometry::GeometryInstance;
 using geometry::SceneGraph;
+using math::RigidTransformd;
 using std::unique_ptr;
 
 // Unnamed namespace for free functions local to this file.
@@ -435,8 +436,8 @@ void AddLinksFromSpecification(
               geometry_instance->illustration_properties() != nullptr);
 
           plant->RegisterVisualGeometry(
-              body, geometry_instance->pose(), geometry_instance->shape(),
-              geometry_instance->name(),
+              body, RigidTransformd(geometry_instance->pose()),
+              geometry_instance->shape(), geometry_instance->name(),
               *geometry_instance->illustration_properties());
         }
       }
@@ -448,8 +449,8 @@ void AddLinksFromSpecification(
         const sdf::Geometry& sdf_geometry = *sdf_collision.Geom();
         ThrowIfPoseFrameSpecified(sdf_collision.Element());
         if (sdf_geometry.Type() != sdf::GeometryType::EMPTY) {
-          const Isometry3d X_LG =
-              MakeGeometryPoseFromSdfCollision(sdf_collision);
+          const RigidTransformd X_LG(
+              MakeGeometryPoseFromSdfCollision(sdf_collision));
           std::unique_ptr<geometry::Shape> shape =
               MakeShapeFromSdfGeometry(sdf_geometry);
           const CoulombFriction<double> coulomb_friction =

--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -25,6 +25,7 @@ using Eigen::Isometry3d;
 using Eigen::Matrix3d;
 using Eigen::Vector3d;
 using Eigen::Vector4d;
+using math::RigidTransformd;
 using tinyxml2::XMLDocument;
 using tinyxml2::XMLElement;
 
@@ -125,11 +126,10 @@ void ParseBody(const multibody::PackageMap& package_map,
           ParseVisual(body_name, package_map, root_dir, visual_node, materials);
       // The parsing should *always* produce an IllustrationProperties
       // instance, even if it is empty.
-      DRAKE_DEMAND(
-          geometry_instance.illustration_properties() != nullptr);
+      DRAKE_DEMAND(geometry_instance.illustration_properties() != nullptr);
       plant->RegisterVisualGeometry(
-          body, geometry_instance.pose(), geometry_instance.shape(),
-          geometry_instance.name(),
+          body, RigidTransformd(geometry_instance.pose()),
+          geometry_instance.shape(), geometry_instance.name(),
           *geometry_instance.illustration_properties(), scene_graph);
     }
 
@@ -141,8 +141,9 @@ void ParseBody(const multibody::PackageMap& package_map,
           ParseCollision(body_name, package_map, root_dir, collision_node,
                          &friction);
       plant->RegisterCollisionGeometry(
-          body, geometry_instance.pose(), geometry_instance.shape(),
-          geometry_instance.name(), friction, scene_graph);
+          body, RigidTransformd(geometry_instance.pose()),
+          geometry_instance.shape(), geometry_instance.name(), friction,
+          scene_graph);
     }
   }
 }

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3006,6 +3006,10 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
                                    math::RigidTransform<T>(X_FB));
   }
 
+  DRAKE_DEPRECATED(
+      "2019-06-15",
+      "This Isometry3 overload will be removed pending the resolution of "
+      "#9865. Use the RigidTransform overload instead.")
   geometry::GeometryId RegisterVisualGeometry(
       const Body<T>& body, const Isometry3<double>& X_BG,
       const geometry::Shape& shape, const std::string& name,
@@ -3015,6 +3019,10 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
                                   shape, name, properties, scene_graph);
   }
 
+  DRAKE_DEPRECATED(
+      "2019-06-15",
+      "This Isometry3 overload will be removed pending the resolution of "
+      "#9865. Use the RigidTransform overload instead.")
   geometry::GeometryId RegisterVisualGeometry(
       const Body<T>& body, const Isometry3<double>& X_BG,
       const geometry::Shape& shape, const std::string& name,
@@ -3024,6 +3032,10 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
                                   shape, name, diffuse_color, scene_graph);
   }
 
+  DRAKE_DEPRECATED(
+      "2019-06-15",
+      "This Isometry3 overload will be removed pending the resolution of "
+      "#9865. Use the RigidTransform overload instead.")
   geometry::GeometryId RegisterVisualGeometry(
       const Body<T>& body, const Isometry3<double>& X_BG,
       const geometry::Shape& shape, const std::string& name,
@@ -3032,6 +3044,10 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
                                   shape, name, scene_graph);
   }
 
+  DRAKE_DEPRECATED(
+      "2019-06-15",
+      "This Isometry3 overload will be removed pending the resolution of "
+      "#9865. Use the RigidTransform overload instead.")
   geometry::GeometryId RegisterCollisionGeometry(
       const Body<T>& body, const Isometry3<double>& X_BG,
       const geometry::Shape& shape, const std::string& name,

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -851,7 +851,8 @@ class SphereChainScenario {
     ground_id_ = plant_->RegisterCollisionGeometry(
         plant_->world_body(),
         // A half-space passing through the origin in the x-z plane.
-        geometry::HalfSpace::MakePose(Vector3d::UnitY(), Vector3d::Zero()),
+        RigidTransformd(
+            geometry::HalfSpace::MakePose(Vector3d::UnitY(), Vector3d::Zero())),
         geometry::HalfSpace(), "ground", CoulombFriction<double>());
 
     auto make_sphere = [this](int i) {
@@ -859,11 +860,11 @@ class SphereChainScenario {
       const RigidBody<double>& sphere = plant_->AddRigidBody(
           "Sphere" + to_string(i), SpatialInertia<double>());
       GeometryId sphere_id = plant_->RegisterCollisionGeometry(
-          sphere, Isometry3d::Identity(), geometry::Sphere(radius), "collision",
-          CoulombFriction<double>());
+          sphere, RigidTransformd::Identity(), geometry::Sphere(radius),
+          "collision", CoulombFriction<double>());
       // We add visual geometry to implicitly test that they are *not* included
       // in the collision results. We don't even save the ids for them.
-      plant_->RegisterVisualGeometry(sphere, Isometry3d::Identity(),
+      plant_->RegisterVisualGeometry(sphere, RigidTransformd::Identity(),
                                      geometry::Sphere(radius), "visual");
       return std::make_tuple(&sphere, sphere_id);
     };
@@ -1111,7 +1112,8 @@ GTEST_TEST(MultibodyPlantTest, CollisionGeometryRegistration) {
   GeometryId ground_id = plant.RegisterCollisionGeometry(
       plant.world_body(),
       // A half-space passing through the origin in the x-z plane.
-      geometry::HalfSpace::MakePose(Vector3d::UnitY(), Vector3d::Zero()),
+      RigidTransformd(
+          geometry::HalfSpace::MakePose(Vector3d::UnitY(), Vector3d::Zero())),
       geometry::HalfSpace(), "ground", ground_friction);
 
   // Add two spherical bodies.
@@ -1119,13 +1121,13 @@ GTEST_TEST(MultibodyPlantTest, CollisionGeometryRegistration) {
       plant.AddRigidBody("Sphere1", SpatialInertia<double>());
   CoulombFriction<double> sphere1_friction(0.8, 0.5);
   GeometryId sphere1_id = plant.RegisterCollisionGeometry(
-      sphere1, Isometry3d::Identity(), geometry::Sphere(radius),
+      sphere1, RigidTransformd::Identity(), geometry::Sphere(radius),
       "collision", sphere1_friction);
   const RigidBody<double>& sphere2 =
       plant.AddRigidBody("Sphere2", SpatialInertia<double>());
   CoulombFriction<double> sphere2_friction(0.7, 0.6);
   GeometryId sphere2_id = plant.RegisterCollisionGeometry(
-      sphere2, Isometry3d::Identity(), geometry::Sphere(radius),
+      sphere2, RigidTransformd::Identity(), geometry::Sphere(radius),
       "collision", sphere2_friction);
 
   // We are done defining the model.
@@ -1195,7 +1197,8 @@ GTEST_TEST(MultibodyPlantTest, VisualGeometryRegistration) {
   GeometryId ground_id = plant.RegisterVisualGeometry(
       plant.world_body(),
       // A half-space passing through the origin in the x-z plane.
-      geometry::HalfSpace::MakePose(Vector3d::UnitY(), Vector3d::Zero()),
+      RigidTransformd(
+          geometry::HalfSpace::MakePose(Vector3d::UnitY(), Vector3d::Zero())),
       geometry::HalfSpace(), "ground");
 
   // Add two spherical bodies.
@@ -1203,13 +1206,13 @@ GTEST_TEST(MultibodyPlantTest, VisualGeometryRegistration) {
       plant.AddRigidBody("Sphere1", SpatialInertia<double>());
   Vector4<double> sphere1_diffuse{0.9, 0.1, 0.1, 0.5};
   GeometryId sphere1_id = plant.RegisterVisualGeometry(
-      sphere1, Isometry3d::Identity(), geometry::Sphere(radius),
+      sphere1, RigidTransformd::Identity(), geometry::Sphere(radius),
       "visual", sphere1_diffuse);
   const RigidBody<double>& sphere2 =
       plant.AddRigidBody("Sphere2", SpatialInertia<double>());
   Vector4<double> sphere2_diffuse{0.1, 0.9, 0.1, 0.5};
   GeometryId sphere2_id = plant.RegisterVisualGeometry(
-      sphere2, Isometry3d::Identity(), geometry::Sphere(radius),
+      sphere2, RigidTransformd::Identity(), geometry::Sphere(radius),
       "visual", sphere2_diffuse);
 
   // We are done defining the model.
@@ -1538,14 +1541,14 @@ class MultibodyPlantContactJacobianTests : public ::testing::Test {
     const RigidBody<double>& large_box =
         plant_.AddRigidBody("LargeBox", SpatialInertia<double>());
     large_box_id_ = plant_.RegisterCollisionGeometry(
-        large_box, Isometry3d::Identity(),
+        large_box, RigidTransformd::Identity(),
         geometry::Box(large_box_size_, large_box_size_, large_box_size_),
         "collision", CoulombFriction<double>());
 
     const RigidBody<double>& small_box =
         plant_.AddRigidBody("SmallBox", SpatialInertia<double>());
     small_box_id_ = plant_.RegisterCollisionGeometry(
-        small_box, Isometry3d::Identity(),
+        small_box, RigidTransformd::Identity(),
         geometry::Box(small_box_size_, small_box_size_, small_box_size_),
         "collision", CoulombFriction<double>());
 


### PR DESCRIPTION
This marks the MBP API's that depend on Isometery3 as deprecated and updates all internal call sites to use the new API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11091)
<!-- Reviewable:end -->
