### PR TITLE
Removing pose from GeometryFrame

### DIFF
--- a/attic/multibody/rigid_body_plant/rigid_body_plant_bridge.cc
+++ b/attic/multibody/rigid_body_plant/rigid_body_plant_bridge.cc
@@ -142,8 +142,7 @@ void RigidBodyPlantBridge<T>::RegisterTree(SceneGraph<T>* scene_graph) {
       // All other bodies register a frame and (possibly) get a unique label.
       body_id = scene_graph->RegisterFrame(
           source_id_,
-          GeometryFrame(body.get_name(), Isometry3<double>::Identity(),
-                        body.get_model_instance_id()));
+          GeometryFrame(body.get_name(), body.get_model_instance_id()));
     }
     body_ids_.push_back(body_id);
 

--- a/automotive/automotive_simulator.cc
+++ b/automotive/automotive_simulator.cc
@@ -178,7 +178,7 @@ void AutomotiveSimulator<T>::ConnectCarOutputsAndPriusVis(
       "car_" + std::to_string(id));
   const geometry::FrameId frame_id = scene_graph_->RegisterFrame(
       source_id,
-      geometry::GeometryFrame("car_origin", Isometry3d::Identity()));
+      geometry::GeometryFrame("car_origin"));
 
   // Defines the distance between the SDF model's origin and the middle of the
   // rear axle.  This offset is necessary because the pose_output frame's

--- a/examples/pendulum/pendulum_plant.cc
+++ b/examples/pendulum/pendulum_plant.cc
@@ -137,7 +137,7 @@ void PendulumPlant<T>::RegisterGeometry(
       source_id_, id, MakeDrakeVisualizerProperties(Vector4d(.3, .6, .4, 1)));
 
   frame_id_ = scene_graph->RegisterFrame(
-      source_id_, GeometryFrame("arm", Isometry3d::Identity()));
+      source_id_, GeometryFrame("arm"));
 
   // The arm.
   id = scene_graph->RegisterGeometry(

--- a/examples/scene_graph/bouncing_ball_plant.cc
+++ b/examples/scene_graph/bouncing_ball_plant.cc
@@ -48,7 +48,7 @@ BouncingBallPlant<T>::BouncingBallPlant(SourceId source_id,
   static_assert(BouncingBallVectorIndices::kNumCoordinates == 1 + 1, "");
 
   ball_frame_id_ = scene_graph->RegisterFrame(
-      source_id, GeometryFrame("ball_frame", Isometry3<double>::Identity()));
+      source_id, GeometryFrame("ball_frame"));
   ball_id_ = scene_graph->RegisterGeometry(
       source_id, ball_frame_id_,
       make_unique<GeometryInstance>(Isometry3<double>::Identity(), /*X_FG*/

--- a/examples/scene_graph/dev/bouncing_ball_plant.cc
+++ b/examples/scene_graph/dev/bouncing_ball_plant.cc
@@ -48,7 +48,7 @@ BouncingBallPlant<T>::BouncingBallPlant(SourceId source_id,
   static_assert(BouncingBallVectorIndices::kNumCoordinates == 1 + 1, "");
 
   ball_frame_id_ = scene_graph->RegisterFrame(
-      source_id, GeometryFrame("ball_frame", Isometry3<double>::Identity()));
+      source_id, GeometryFrame("ball_frame"));
   ball_id_ = scene_graph->RegisterGeometry(
       source_id, ball_frame_id_,
       make_unique<GeometryInstance>(Isometry3<double>::Identity(), /*X_FG*/

--- a/examples/scene_graph/dev/solar_system.cc
+++ b/examples/scene_graph/dev/solar_system.cc
@@ -168,7 +168,7 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
   const double kEarthBottom = orrery_bottom + 0.25;
   Isometry3<double> X_SE{Translation3<double>{0, 0, kEarthBottom}};
   FrameId planet_id =
-      scene_graph->RegisterFrame(source_id_, GeometryFrame("Earth", X_SE));
+      scene_graph->RegisterFrame(source_id_, GeometryFrame("Earth"));
   body_ids_.push_back(planet_id);
   body_offset_.push_back(X_SE);
   axes_.push_back(Vector3<double>::UnitZ());
@@ -187,7 +187,7 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
   // Luna's frame L is at the center of Earth's geometry (Ge). So, X_EL = X_EGe.
   const Isometry3<double>& X_EL = X_EGe;
   FrameId luna_id = scene_graph->RegisterFrame(source_id_, planet_id,
-                                               GeometryFrame("Luna", X_EL));
+                                               GeometryFrame("Luna"));
   body_ids_.push_back(luna_id);
   body_offset_.push_back(X_EL);
   Vector3<double> plane_normal{1, 1, 1};
@@ -209,7 +209,7 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
   // arm).
   Isometry3<double> X_SM{Translation3<double>{0, 0, orrery_bottom}};
   planet_id =
-      scene_graph->RegisterFrame(source_id_, GeometryFrame("Mars", X_SM));
+      scene_graph->RegisterFrame(source_id_, GeometryFrame("Mars"));
   body_ids_.push_back(planet_id);
   body_offset_.push_back(X_SM);
   plane_normal << 0, 0.1, 1;
@@ -242,7 +242,7 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
   // opposite direction.
   const Isometry3<double>& X_MP = X_MGm;
   FrameId phobos_id = scene_graph->RegisterFrame(source_id_, planet_id,
-                                                 GeometryFrame("phobos", X_MP));
+                                                 GeometryFrame("phobos"));
   body_ids_.push_back(phobos_id);
   body_offset_.push_back(X_MP);
   plane_normal << 0, 0, -1;

--- a/examples/scene_graph/solar_system.cc
+++ b/examples/scene_graph/solar_system.cc
@@ -172,7 +172,7 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
   const double kEarthBottom = orrery_bottom + 0.25;
   Isometry3<double> X_SOe{Translation3<double>{0, 0, kEarthBottom}};
   FrameId planet_id = scene_graph->RegisterFrame(
-      source_id_, GeometryFrame("EarthOrbit", X_SOe));
+      source_id_, GeometryFrame("EarthOrbit"));
   body_ids_.push_back(planet_id);
   body_offset_.push_back(X_SOe);
   axes_.push_back(Vector3<double>::UnitZ());
@@ -196,7 +196,7 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
   // So, X_OeOl = X_OeE.
   const Isometry3<double>& X_OeOl = X_OeE;
   FrameId luna_id = scene_graph->RegisterFrame(
-      source_id_, planet_id, GeometryFrame("LunaOrbit", X_OeOl));
+      source_id_, planet_id, GeometryFrame("LunaOrbit"));
   body_ids_.push_back(luna_id);
   body_offset_.push_back(X_OeOl);
   const Vector3<double> luna_axis_Oe{1, 1, 1};
@@ -221,7 +221,7 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
   // Convex satellite orbits Earth in the same revolution as Luna but with
   // different initial position. See SetDefaultState().
   FrameId convexsat_id = scene_graph->RegisterFrame(source_id_, planet_id,
-                                          GeometryFrame("Convexsat", X_OeOl));
+                                          GeometryFrame("Convexsat"));
   body_ids_.push_back(convexsat_id);
   body_offset_.push_back(X_OeOl);
   axes_.push_back(luna_axis_Oe.normalized());
@@ -239,7 +239,7 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
   // Box satellite orbits Earth in the same revolution as Luna but with
   // different initial position. See SetDefaultState().
   FrameId boxsat_id = scene_graph->RegisterFrame(
-      source_id_, planet_id, GeometryFrame("Boxsat", X_OeOl));
+      source_id_, planet_id, GeometryFrame("Boxsat"));
   body_ids_.push_back(boxsat_id);
   body_offset_.push_back(X_OeOl);
   axes_.push_back(luna_axis_Oe.normalized());
@@ -255,7 +255,7 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
   // orrery arm).
   Isometry3<double> X_SOm{Translation3<double>{0, 0, orrery_bottom}};
   planet_id =
-      scene_graph->RegisterFrame(source_id_, GeometryFrame("MarsOrbit", X_SOm));
+      scene_graph->RegisterFrame(source_id_, GeometryFrame("MarsOrbit"));
   body_ids_.push_back(planet_id);
   body_offset_.push_back(X_SOm);
   Vector3<double>  mars_axis_S {0, 0.1, 1};
@@ -296,7 +296,7 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
   // opposite direction.
   const Isometry3<double>& X_OmOp = X_OmM;
   FrameId phobos_id = scene_graph->RegisterFrame(
-      source_id_, planet_id, GeometryFrame("PhobosOrbit", X_OmOp));
+      source_id_, planet_id, GeometryFrame("PhobosOrbit"));
   body_ids_.push_back(phobos_id);
   body_offset_.push_back(X_OmOp);
   mars_axis_S << 0, 0, -1;

--- a/geometry/dev/geometry_state.cc
+++ b/geometry/dev/geometry_state.cc
@@ -264,7 +264,6 @@ GeometryState<T>& GeometryState<T>::operator=(
       const geometry::internal::InternalFrame& source_frame =
           tester.frames().at(frame_id);
       RegisterValidFrame(source_id, frame_id, source_frame.name(),
-                         Isometry3<double>::Identity(),
                          source_frame.frame_group(),
                          source_frame.parent_frame_id(), source_frame.clique(),
                          &frame_set);
@@ -587,8 +586,8 @@ FrameId GeometryState<T>::RegisterFrame(SourceId source_id, FrameId parent_id,
 
   int clique = GeometryStateCollisionFilterAttorney::get_next_clique(
       geometry_engine_.get_mutable());
-  RegisterValidFrame(source_id, frame_id, frame.name(), frame.pose(),
-                     frame.frame_group(), parent_id, clique, &f_set);
+  RegisterValidFrame(source_id, frame_id, frame.name(), frame.frame_group(),
+                     parent_id, clique, &f_set);
   return frame_id;
 }
 
@@ -1288,7 +1287,6 @@ void GeometryState<T>::RegisterValidSource(SourceId source_id,
 template <typename T>
 void GeometryState<T>::RegisterValidFrame(SourceId source_id, FrameId frame_id,
                                           const std::string& name,
-                                          const Isometry3<double>& X_PF,
                                           int frame_group, FrameId parent_id,
                                           int clique, FrameIdSet* frame_set) {
   if (parent_id != InternalFrame::world_frame_id()) {
@@ -1304,7 +1302,7 @@ void GeometryState<T>::RegisterValidFrame(SourceId source_id, FrameId frame_id,
 
   DRAKE_ASSERT(X_PF_.size() == frame_index_to_frame_map_.size());
   InternalIndex internal_index(X_PF_.size());
-  X_PF_.emplace_back(X_PF);
+  X_PF_.emplace_back(Isometry3<double>::Identity());
   X_WF_.emplace_back(Isometry3<double>::Identity());
   frame_index_to_frame_map_.push_back(frame_id);
   frame_set->insert(frame_id);

--- a/geometry/dev/geometry_state.h
+++ b/geometry/dev/geometry_state.h
@@ -861,8 +861,7 @@ class GeometryState {
   // version.
   void RegisterValidSource(SourceId source_id, const std::string& name);
   void RegisterValidFrame(SourceId source_id, FrameId frame_id,
-                          const std::string& name,
-                          const Isometry3<double>& X_PF, int frame_group,
+                          const std::string& name, int frame_group,
                           FrameId parent_id, int clique, FrameIdSet* frame_set);
   void RegisterValidGeometry(SourceId source_id, FrameId frame_id,
                              GeometryId geometry_id,

--- a/geometry/dev/test/geometry_visualization_test.cc
+++ b/geometry/dev/test/geometry_visualization_test.cc
@@ -37,7 +37,7 @@ GTEST_TEST(GeometryVisualization, SimpleScene) {
 
   const std::string frame_name("frame");
   FrameId frame_id = scene_graph.RegisterFrame(
-      source_id, GeometryFrame(frame_name, Isometry3d::Identity()));
+      source_id, GeometryFrame(frame_name));
 
   // Floats because the lcm messages store floats.
   const float radius = 1.25f;

--- a/geometry/dev/test/query_object_test.cc
+++ b/geometry/dev/test/query_object_test.cc
@@ -149,7 +149,7 @@ GTEST_TEST(QueryObjectInspectTest, CreateValidInspector) {
   SourceId source_id = scene_graph.RegisterSource("source");
   auto identity = Isometry3<double>::Identity();
   FrameId frame_id =
-      scene_graph.RegisterFrame(source_id, GeometryFrame("frame", identity));
+      scene_graph.RegisterFrame(source_id, GeometryFrame("frame"));
   GeometryId geometry_id = scene_graph.RegisterGeometry(
       source_id, frame_id, make_unique<GeometryInstance>(
                                identity, make_unique<Sphere>(1.0), "sphere"));

--- a/geometry/dev/test/scene_graph_test.cc
+++ b/geometry/dev/test/scene_graph_test.cc
@@ -218,17 +218,15 @@ TEST_F(SceneGraphTest, TopologyAfterAllocation) {
 
   // Attach frame to world.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      scene_graph_.RegisterFrame(
-          id, GeometryFrame("frame", Isometry3<double>::Identity())),
+      scene_graph_.RegisterFrame(id, GeometryFrame("frame")),
       std::logic_error,
       "The call to RegisterFrame is invalid; a context has already been "
       "allocated.");
 
   // Attach frame to another frame.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      scene_graph_.RegisterFrame(
-          id, FrameId::get_new_id(),
-          GeometryFrame("frame", Isometry3<double>::Identity())),
+      scene_graph_.RegisterFrame(id, FrameId::get_new_id(),
+          GeometryFrame("frame")),
       std::logic_error,
       "The call to RegisterFrame is invalid; a context has already been "
       "allocated.");
@@ -388,9 +386,9 @@ TEST_F(SceneGraphTest, ModelInspector) {
   ASSERT_TRUE(scene_graph_.SourceIsRegistered(source_id));
 
   FrameId frame_1 = scene_graph_.RegisterFrame(
-      source_id, GeometryFrame{"f1", Isometry3d::Identity()});
+      source_id, GeometryFrame{"f1"});
   FrameId frame_2 = scene_graph_.RegisterFrame(
-      source_id, GeometryFrame{"f2", Isometry3d::Identity()});
+      source_id, GeometryFrame{"f2"});
 
   // Note: all these geometries have the same *name* -- but because they are
   // affixed to different nodes, that should be alright.
@@ -426,7 +424,7 @@ class GeometrySourceSystem : public systems::LeafSystem<double> {
     // Register with SceneGraph.
     source_id_ = scene_graph->RegisterSource();
     FrameId f_id = scene_graph->RegisterFrame(
-        source_id_, GeometryFrame("frame", Isometry3<double>::Identity()));
+        source_id_, GeometryFrame("frame"));
     frame_ids_.push_back(f_id);
 
     // Set up output port now that the frame is registered.
@@ -446,7 +444,7 @@ class GeometrySourceSystem : public systems::LeafSystem<double> {
   // will *not* automatically get a pose.
   void add_extra_frame(bool add_to_output = true) {
     FrameId frame_id = scene_graph_->RegisterFrame(
-        source_id_, GeometryFrame("frame", Isometry3<double>::Identity()));
+        source_id_, GeometryFrame("frame"));
     if (add_to_output) extra_frame_ids_.push_back(frame_id);
   }
   // Method used to bring frame ids and poses out of sync. Adds a pose in
@@ -598,8 +596,6 @@ GTEST_TEST(SceneGraphVisualizationTest, NoWorldInPoseVector) {
                                                      &poses));
   }
 
-  const Isometry3<double> kIdentity = Isometry3<double>::Identity();
-
   // Case: Registered source with anchored geometry and frame but no dynamic
   // geometry --> empty pose vector; only frames with dynamic geometry with an
   // illustration role are included.
@@ -611,7 +607,7 @@ GTEST_TEST(SceneGraphVisualizationTest, NoWorldInPoseVector) {
         make_unique<GeometryInstance>(Isometry3<double>::Identity(),
                                       make_unique<Sphere>(1.0), "sphere"));
     FrameId f_id =
-        scene_graph.RegisterFrame(s_id, GeometryFrame("f", kIdentity));
+        scene_graph.RegisterFrame(s_id, GeometryFrame("f"));
     PoseBundle<double> poses = SceneGraphTester::MakePoseBundle(scene_graph);
     // The frame has no illustration geometry, so it is not part of the pose
     // bundle.

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -479,7 +479,7 @@ FrameId GeometryState<T>::RegisterFrame(SourceId source_id, FrameId parent_id,
 
   DRAKE_ASSERT(X_PF_.size() == frame_index_to_id_map_.size());
   FrameIndex index(X_PF_.size());
-  X_PF_.emplace_back(frame.pose());
+  X_PF_.emplace_back(Isometry3<double>::Identity());
   X_WF_.emplace_back(Isometry3<double>::Identity());
   frame_index_to_id_map_.push_back(frame_id);
   f_set.insert(frame_id);

--- a/geometry/test/geometry_frame_test.cc
+++ b/geometry/test/geometry_frame_test.cc
@@ -16,34 +16,32 @@ using std::move;
 
 GTEST_TEST(GeometryFrameTest, Constructor) {
   // Case: use default frame group.
-  const Isometry3<double> pose = Isometry3<double>::Identity();
   {
-    GeometryFrame frame("frame", pose);
+    GeometryFrame frame("frame");
     EXPECT_EQ(frame.frame_group(), 0);
   }
 
   // Case: user-specified, valid frame group.
   {
-    GeometryFrame frame("frame", pose, 17);
+    GeometryFrame frame("frame", 17);
     EXPECT_EQ(frame.frame_group(), 17);
   }
 
   // Case: user-specified, invalid frame group.
   {
     DRAKE_EXPECT_THROWS_MESSAGE(
-        GeometryFrame("name", pose, -1),
+        GeometryFrame("name", -1),
         std::logic_error,
         "GeometryFrame requires a non-negative frame group");
   }
 }
 
 GTEST_TEST(GeometryFrameTest, IdCopies) {
-  Isometry3<double> pose = Isometry3<double>::Identity();
-  GeometryFrame frame_a{"frame_a", pose};
+  GeometryFrame frame_a{"frame_a"};
   GeometryFrame frame_b{frame_a};
   EXPECT_EQ(frame_a.id(), frame_b.id());
 
-  GeometryFrame frame_c{"frame_c", pose};
+  GeometryFrame frame_c{"frame_c"};
   EXPECT_NE(frame_c.id(), frame_a.id());
   frame_c = frame_a;
   EXPECT_EQ(frame_c.id(), frame_a.id());

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -293,8 +293,7 @@ void ShapeMatcher<Convex>::TestShapeParameters(const Convex& test) {
 class GeometryStateTest : public ::testing::Test {
  protected:
   void SetUp() {
-    frame_ = make_unique<GeometryFrame>("ref_frame",
-                                        Isometry3<double>::Identity());
+    frame_ = make_unique<GeometryFrame>("ref_frame");
     instance_pose_.translation() << 10, 20, 30;
     instance_ = make_unique<GeometryInstance>(
         instance_pose_, make_unique<Sphere>(1.0), "instance");
@@ -357,7 +356,7 @@ class GeometryStateTest : public ::testing::Test {
     pose.translation() << 1, 2, 3;
     pose.linear() << 1, 0, 0, 0, 0, 1, 0, -1, 0;  // 90° around x-axis.
     frames_.push_back(geometry_state_.RegisterFrame(
-        source_id_, GeometryFrame("f0", pose)));
+        source_id_, GeometryFrame("f0")));
     X_WF_.push_back(pose);
     X_PF_.push_back(pose);
 
@@ -365,14 +364,14 @@ class GeometryStateTest : public ::testing::Test {
     pose.translation() << 10, 20, 30;
     pose.linear() << 0, 0, -1, 0, 1, 0, 1, 0, 0;  // 90° around y-axis.
     frames_.push_back(geometry_state_.RegisterFrame(
-        source_id_, GeometryFrame("f1", pose)));
+        source_id_, GeometryFrame("f1")));
     X_WF_.push_back(pose);
     X_PF_.push_back(pose);
 
     // Create f2.
     pose = pose.inverse();
     frames_.push_back(geometry_state_.RegisterFrame(
-        source_id_, frames_[1], GeometryFrame("f2", pose)));
+        source_id_, frames_[1], GeometryFrame("f2")));
     X_WF_.push_back(X_WF_[1] * pose);
     X_PF_.push_back(pose);
 
@@ -534,7 +533,7 @@ TEST_F(GeometryStateTest, Constructor) {
 TEST_F(GeometryStateTest, IntrospectShapes) {
   SourceId source_id = geometry_state_.RegisterNewSource("test_source");
   FrameId frame_id = geometry_state_.RegisterFrame(
-      source_id, GeometryFrame("frame", Isometry3d::Identity()));
+      source_id, GeometryFrame("frame"));
 
   // Test across all valid shapes.
   {
@@ -758,6 +757,7 @@ TEST_F(GeometryStateTest, ValidateSingleSourceTree) {
     const auto& internal_frames = gs_tester_.get_frames();
     // The world frame + the frames added by s_id.
     EXPECT_EQ(internal_frames.size(), kFrameCount + 1);
+
     auto test_frame = [internal_frames, this, s_id](
         FrameIndex i, FrameId parent_id, int num_child_frames) {
       const auto& frame = internal_frames.at(frames_[i]);
@@ -779,6 +779,24 @@ TEST_F(GeometryStateTest, ValidateSingleSourceTree) {
           CompareMatrices(frame_in_parent[frame.index()].matrix(),
                           X_PF_[i].matrix()));
     };
+
+    // When added, all frames' poses w.r.t. their parents are the identity.
+    const auto& frame_in_parent = gs_tester_.get_frame_parent_poses();
+    for (FrameId frame_id : frames_) {
+      const auto& frame = internal_frames.at(frame_id);
+      EXPECT_TRUE(CompareMatrices(frame_in_parent[frame.index()].matrix(),
+                                  Isometry3<double>::Identity().matrix()));
+    }
+
+    // Confirm posing positions the frames properly.
+    FramePoseVector<double> poses(source_id_, frames_);
+    poses.clear();
+    for (int f = 0; f < static_cast<int>(frames_.size()); ++f) {
+      poses.set_value(frames_[f], X_PF_[f]);
+    }
+    gs_tester_.SetFramePoses(poses);
+    gs_tester_.FinalizePoseUpdate();
+
     test_frame(FrameIndex(0), gs_tester_.get_world_frame(), 0);
     test_frame(FrameIndex(1), gs_tester_.get_world_frame(), 1);
     test_frame(FrameIndex(2), frames_[1], 0);
@@ -2304,7 +2322,7 @@ TEST_F(GeometryStateTest, AssignRolesToGeometry) {
 TEST_F(GeometryStateTest, InstanceRoleAssignment) {
   SourceId s_id = NewSource();
   FrameId f_id = geometry_state_.RegisterFrame(
-      s_id, GeometryFrame("frame", Isometry3<double>::Identity()));
+      s_id, GeometryFrame("frame"));
 
   auto make_instance = [this](const std::string& name) {
     return make_unique<GeometryInstance>(

--- a/geometry/test/geometry_visualization_test.cc
+++ b/geometry/test/geometry_visualization_test.cc
@@ -35,7 +35,7 @@ GTEST_TEST(GeometryVisualization, SimpleScene) {
 
   const std::string frame_name("frame");
   FrameId frame_id = scene_graph.RegisterFrame(
-      source_id, GeometryFrame(frame_name, Isometry3d::Identity()));
+      source_id, GeometryFrame(frame_name));
 
   // Floats because the lcm messages store floats.
   const float radius = 1.25f;
@@ -54,7 +54,7 @@ GTEST_TEST(GeometryVisualization, SimpleScene) {
   // Add a second frame and geometry that only has proximity properties. It
   // should not impact the result.
   FrameId collision_frame_id = scene_graph.RegisterFrame(
-      source_id, GeometryFrame("collision frame", Isometry3d::Identity()));
+      source_id, GeometryFrame("collision frame"));
   GeometryId collision_id = scene_graph.RegisterGeometry(
       source_id, collision_frame_id,
       make_unique<GeometryInstance>(Isometry3d::Identity(),

--- a/geometry/test/query_object_test.cc
+++ b/geometry/test/query_object_test.cc
@@ -121,7 +121,7 @@ GTEST_TEST(QueryObjectInspectTest, CreateValidInspector) {
   SourceId source_id = scene_graph.RegisterSource("source");
   auto identity = Isometry3<double>::Identity();
   FrameId frame_id =
-      scene_graph.RegisterFrame(source_id, GeometryFrame("frame", identity));
+      scene_graph.RegisterFrame(source_id, GeometryFrame("frame"));
   GeometryId geometry_id = scene_graph.RegisterGeometry(
       source_id, frame_id, make_unique<GeometryInstance>(
                                identity, make_unique<Sphere>(1.0), "sphere"));

--- a/geometry/test/scene_graph_inspector_test.cc
+++ b/geometry/test/scene_graph_inspector_test.cc
@@ -61,8 +61,8 @@ GTEST_TEST(SceneGraphInspector, ExerciseEverything) {
 
   // Frames and their properties.
   // Register a frame to prevent exceptions being thrown.
-  const FrameId frame_id = tester.mutable_state().RegisterFrame(
-      source_id, GeometryFrame("frame", Isometry3<double>::Identity()));
+  const FrameId frame_id =
+      tester.mutable_state().RegisterFrame(source_id, GeometryFrame("frame"));
   inspector.BelongsToSource(frame_id, source_id);
   inspector.GetOwningSourceName(frame_id);
   inspector.GetName(frame_id);

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -215,19 +215,18 @@ TEST_F(SceneGraphTest, AcquireInputPortsAfterAllocation) {
 // details are correct.
 TEST_F(SceneGraphTest, TopologyAfterAllocation) {
   SourceId id = scene_graph_.RegisterSource();
-  FrameId old_frame_id = scene_graph_.RegisterFrame(
-      id, GeometryFrame("old_frame", Isometry3<double>::Identity()));
+  FrameId old_frame_id =
+      scene_graph_.RegisterFrame(id, GeometryFrame("old_frame"));
   // This geometry will be removed after allocation.
   GeometryId old_geometry_id = scene_graph_.RegisterGeometry(id, old_frame_id,
       make_sphere_instance());
 
   AllocateContext();
 
-  FrameId parent_frame_id = scene_graph_.RegisterFrame(
-      id, GeometryFrame("frame", Isometry3<double>::Identity()));
-  FrameId child_frame_id = scene_graph_.RegisterFrame(
-      id, parent_frame_id,
-      GeometryFrame("frame", Isometry3<double>::Identity()));
+  FrameId parent_frame_id =
+      scene_graph_.RegisterFrame(id, GeometryFrame("frame"));
+  FrameId child_frame_id =
+      scene_graph_.RegisterFrame(id, parent_frame_id, GeometryFrame("frame"));
   GeometryId parent_geometry_id = scene_graph_.RegisterGeometry(
       id, parent_frame_id, make_sphere_instance());
   GeometryId child_geometry_id = scene_graph_.RegisterGeometry(
@@ -366,8 +365,8 @@ TEST_F(SceneGraphTest, TransmogrifyContext) {
 // allowed.
 TEST_F(SceneGraphTest, PostAllocationCollisionFiltering) {
   SourceId source_id = scene_graph_.RegisterSource("filter_after_allocation");
-  FrameId frame_id = scene_graph_.RegisterFrame(
-      source_id, GeometryFrame("dummy", Isometry3d::Identity()));
+  FrameId frame_id =
+      scene_graph_.RegisterFrame(source_id, GeometryFrame("dummy"));
   AllocateContext();
 
   GeometrySet geometry_set{frame_id};
@@ -386,10 +385,8 @@ TEST_F(SceneGraphTest, ModelInspector) {
   SourceId source_id = scene_graph_.RegisterSource();
   ASSERT_TRUE(scene_graph_.SourceIsRegistered(source_id));
 
-  FrameId frame_1 = scene_graph_.RegisterFrame(
-      source_id, GeometryFrame{"f1", Isometry3d::Identity()});
-  FrameId frame_2 = scene_graph_.RegisterFrame(
-      source_id, GeometryFrame{"f2", Isometry3d::Identity()});
+  FrameId frame_1 = scene_graph_.RegisterFrame(source_id, GeometryFrame{"f1"});
+  FrameId frame_2 = scene_graph_.RegisterFrame(source_id, GeometryFrame{"f2"});
 
   // Note: all these geometries have the same *name* -- but because they are
   // affixed to different nodes, that should be alright.
@@ -424,8 +421,8 @@ class GeometrySourceSystem : public systems::LeafSystem<double> {
       : systems::LeafSystem<double>(), scene_graph_(scene_graph) {
     // Register with SceneGraph.
     source_id_ = scene_graph->RegisterSource();
-    FrameId f_id = scene_graph->RegisterFrame(
-        source_id_, GeometryFrame("frame", Isometry3<double>::Identity()));
+    FrameId f_id =
+        scene_graph->RegisterFrame(source_id_, GeometryFrame("frame"));
     frame_ids_.push_back(f_id);
 
     // Set up output port now that the frame is registered.
@@ -444,8 +441,8 @@ class GeometrySourceSystem : public systems::LeafSystem<double> {
   // Method used to bring frame ids and poses out of sync. Adds a frame that
   // will *not* automatically get a pose.
   void add_extra_frame(bool add_to_output = true) {
-    FrameId frame_id = scene_graph_->RegisterFrame(
-        source_id_, GeometryFrame("frame", Isometry3<double>::Identity()));
+    FrameId frame_id =
+        scene_graph_->RegisterFrame(source_id_, GeometryFrame("frame"));
     if (add_to_output) extra_frame_ids_.push_back(frame_id);
   }
   // Method used to bring frame ids and poses out of sync. Adds a pose in
@@ -597,8 +594,6 @@ GTEST_TEST(SceneGraphVisualizationTest, NoWorldInPoseVector) {
                                                      &poses));
   }
 
-  const Isometry3<double> kIdentity = Isometry3<double>::Identity();
-
   // Case: Registered source with anchored geometry and frame but no dynamic
   // geometry --> empty pose vector; only frames with dynamic geometry with an
   // illustration role are included.
@@ -609,8 +604,7 @@ GTEST_TEST(SceneGraphVisualizationTest, NoWorldInPoseVector) {
         s_id, scene_graph.world_frame_id(),
         make_unique<GeometryInstance>(Isometry3<double>::Identity(),
                                       make_unique<Sphere>(1.0), "sphere"));
-    FrameId f_id =
-        scene_graph.RegisterFrame(s_id, GeometryFrame("f", kIdentity));
+    FrameId f_id = scene_graph.RegisterFrame(s_id, GeometryFrame("f"));
     PoseBundle<double> poses = SceneGraphTester::MakePoseBundle(scene_graph);
     // The frame has no illustration geometry, so it is not part of the pose
     // bundle.
@@ -632,8 +626,7 @@ GTEST_TEST(SceneGraphVisualizationTest, NoWorldInPoseVector) {
         s_id, scene_graph.world_frame_id(),
         make_unique<GeometryInstance>(Isometry3<double>::Identity(),
                                       make_unique<Sphere>(1.0), "sphere"));
-    FrameId f_id =
-        scene_graph.RegisterFrame(s_id, GeometryFrame("f", kIdentity));
+    FrameId f_id = scene_graph.RegisterFrame(s_id, GeometryFrame("f"));
     scene_graph.RegisterGeometry(
         s_id, f_id,
         make_unique<GeometryInstance>(Isometry3<double>::Identity(),
@@ -658,8 +651,8 @@ GTEST_TEST(SceneGraphContextModifier, RegisterGeometry) {
   // Initializes the scene graph and context.
   SceneGraph<double> scene_graph;
   SourceId source_id = scene_graph.RegisterSource("source");
-  FrameId frame_id = scene_graph.RegisterFrame(
-      source_id, GeometryFrame("frame", Isometry3d::Identity()));
+  FrameId frame_id =
+      scene_graph.RegisterFrame(source_id, GeometryFrame("frame"));
   auto context = scene_graph.AllocateContext();
 
   // Confirms the state. NOTE: All subsequent actions modify `context` in place.
@@ -700,12 +693,12 @@ GTEST_TEST(SceneGraphContextModifier, CollisionFilters) {
   // Simple scene with three frames, each with a sphere which, by default
   // collide.
   SourceId source_id = scene_graph.RegisterSource("source");
-  FrameId f_id1 = scene_graph.RegisterFrame(
-      source_id, GeometryFrame("frame_1", Isometry3d::Identity()));
-  FrameId f_id2 = scene_graph.RegisterFrame(
-      source_id, GeometryFrame("frame_2", Isometry3d::Identity()));
-  FrameId f_id3 = scene_graph.RegisterFrame(
-      source_id, GeometryFrame("frame_3", Isometry3d::Identity()));
+  FrameId f_id1 =
+      scene_graph.RegisterFrame(source_id, GeometryFrame("frame_1"));
+  FrameId f_id2 =
+      scene_graph.RegisterFrame(source_id, GeometryFrame("frame_2"));
+  FrameId f_id3 =
+      scene_graph.RegisterFrame(source_id, GeometryFrame("frame_3"));
   GeometryId g_id1 =
       scene_graph.RegisterGeometry(source_id, f_id1, make_sphere_instance());
   scene_graph.AssignRole(source_id, g_id1, ProximityProperties());

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -436,8 +436,6 @@ geometry::GeometryId MultibodyPlant<T>::RegisterGeometry(
         source_id_.value(),
         GeometryFrame(
             GetScopedName(*this, body.model_instance(), body.name()),
-            /* Initial pose: Not really used by GS. Will get removed. */
-            Isometry3<double>::Identity(),
             /* TODO(@SeanCurtis-TRI): Add test coverage for this
              * model-instance support as requested in #9390. */
             body.model_instance()));


### PR DESCRIPTION
The GeometryFrame represents a dynamic frame. Evaluating its value will *always* require connected input ports that will define the frame. Therefore, initialization is pointless -- the intial value will be stomped on. This is manifest in the sheer number of sites where the pose is simply the identity.

Adds a new, streamlined constructor and deprecates the old.

```
Category            added  modified  removed  
----------------------------------------------
code                38     75        21       
comments            11     0         2        
blank               7      0         3        
----------------------------------------------
TOTAL               56     75        26 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11092)
<!-- Reviewable:end -->
