### PR TITLE
find_resource: Enable resource finding for bazel-external projects

### DIFF
--- a/common/find_resource.cc
+++ b/common/find_resource.cc
@@ -10,6 +10,7 @@
 #include "drake/common/drake_throw.h"
 #include "drake/common/find_loaded_library.h"
 #include "drake/common/never_destroyed.h"
+#include "drake/common/text_logging.h"
 
 using std::string;
 
@@ -278,6 +279,7 @@ void AddResourceSearchPath(string search_path) {
 }
 
 Result FindResource(string resource_path) {
+  drake::log()->trace("FindResource: '{}'", resource_path);
   // Check if resource_path is well-formed: a relative path that starts with
   // "drake" as its first directory name.  A valid example would look like:
   // "drake/common/test/find_resource_test_data.txt".  Requiring strings passed
@@ -339,6 +341,8 @@ Result FindResource(string resource_path) {
 
   // See which (if any) candidate contains the requested resource.
   for (const auto& candidate_dir : candidate_dirs) {
+    drake::log()->trace("FindResource: candidate_dir = '{}'",
+        candidate_dir ? *candidate_dir : "nullopt");
     if (auto absolute_path = FileExists(candidate_dir, resource_path_substr)) {
       return Result::make_success(
           std::move(resource_path), std::move(*absolute_path));


### PR DESCRIPTION
@mpetersen94 ran into this in this Slack discussion:
https://drakedevelopers.slack.com/archives/C2CK4CWE7/p1554137399001800

I forgot that we had this same problem in Anzu, and workaround it with dirty environment variables.
This is one way to fix this behavior. (Couldn't find an issue; filed PR without it for now. Can file issue if this takes longer.)

EDIT: More elegant solution is the Bazel runfiles shindig, but this seems simple enough.

Downstream example:
https://github.com/RobotLocomotion/drake-external-examples/pull/138

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11111)
<!-- Reviewable:end -->
