### PR TITLE
Add System methods for selective state updates after an event

### DIFF
--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -842,10 +842,9 @@ void Simulator<T>::HandleUnrestrictedUpdate(
     // First, compute the unrestricted updates into a temporary buffer.
     system_.CalcUnrestrictedUpdate(*context_, events,
         unrestricted_updates_.get());
-    // TODO(edrumwri): simply swap the states for additional speed.
     // Now write the update back into the context.
-    State<T>& x = context_->get_mutable_state();
-    x.SetFrom(*unrestricted_updates_);
+    system_.ApplyUnrestrictedUpdate(events, unrestricted_updates_.get(),
+        context_.get());
     ++num_unrestricted_updates_;
 
     // Mark the witness function vector as needing to be redetermined.
@@ -862,8 +861,8 @@ void Simulator<T>::HandleDiscreteUpdate(
     system_.CalcDiscreteVariableUpdates(*context_, events,
         discrete_updates_.get());
     // Then, write them back into the context.
-    DiscreteValues<T>& xd = context_->get_mutable_discrete_state();
-    xd.SetFrom(*discrete_updates_);
+    system_.ApplyDiscreteVariableUpdate(events, discrete_updates_.get(),
+        context_.get());
     ++num_discrete_updates_;
   }
 }

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -1178,6 +1178,32 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
     }
   }
 
+  void DoApplyDiscreteVariableUpdate(
+      const EventCollection<DiscreteUpdateEvent<T>>& events,
+      DiscreteValues<T>* discrete_state, Context<T>* context) const final {
+    // If this method is called, these are all Diagram objects.
+    const auto& diagram_events =
+        dynamic_cast<const DiagramEventCollection<DiscreteUpdateEvent<T>>&>(
+            events);
+    auto& diagram_discrete =
+        dynamic_cast<DiagramDiscreteValues<T>&>(*discrete_state);
+    auto& diagram_context = dynamic_cast<DiagramContext<T>&>(*context);
+
+    for (SubsystemIndex i(0); i < num_subsystems(); ++i) {
+      const EventCollection<DiscreteUpdateEvent<T>>& subevents =
+          diagram_events.get_subevent_collection(i);
+
+      if (subevents.HasEvents()) {
+        DiscreteValues<T>& subdiscrete =
+            diagram_discrete.get_mutable_subdiscrete(i);
+        Context<T>& subcontext = diagram_context.GetMutableSubsystemContext(i);
+
+        registered_systems_[i]->ApplyDiscreteVariableUpdate(
+            subevents, &subdiscrete, &subcontext);
+      }
+    }
+  }
+
   // For each subsystem, if there is an unrestricted update event in its
   // corresponding subevent collection, calls its CalcUnrestrictedUpdate
   // method with the appropriate subcontext, subevent collection and substate.
@@ -1207,6 +1233,30 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
 
         registered_systems_[i]->CalcUnrestrictedUpdate(subcontext, subinfo,
             &substate);
+      }
+    }
+  }
+
+  void DoApplyUnrestrictedUpdate(
+      const EventCollection<UnrestrictedUpdateEvent<T>>& events,
+      State<T>* state, Context<T>* context) const final {
+    // If this method is called, these are all Diagram objects.
+    const auto& diagram_events =
+        dynamic_cast<const DiagramEventCollection<UnrestrictedUpdateEvent<T>>&>(
+            events);
+    auto& diagram_state = dynamic_cast<DiagramState<T>&>(*state);
+    auto& diagram_context = dynamic_cast<DiagramContext<T>&>(*context);
+
+    for (SubsystemIndex i(0); i < num_subsystems(); ++i) {
+      const EventCollection<UnrestrictedUpdateEvent<T>>& subevents =
+          diagram_events.get_subevent_collection(i);
+
+      if (subevents.HasEvents()) {
+        State<T>& substate = diagram_state.get_mutable_substate(i);
+        Context<T>& subcontext = diagram_context.GetMutableSubsystemContext(i);
+
+        registered_systems_[i]->ApplyUnrestrictedUpdate(subevents, &substate,
+                                                        &subcontext);
       }
     }
   }

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -2352,6 +2352,20 @@ class LeafSystem : public System<T> {
         discrete_state);
   }
 
+  // To get here:
+  // - The EventCollection must be a LeafEventCollection, and
+  // - There must be at least one Event belonging to this leaf subsystem.
+  void DoApplyDiscreteVariableUpdate(
+      const EventCollection<DiscreteUpdateEvent<T>>& events,
+      DiscreteValues<T>* discrete_state, Context<T>* context) const final {
+    DRAKE_ASSERT(
+        dynamic_cast<const LeafEventCollection<DiscreteUpdateEvent<T>>*>(
+            &events) != nullptr);
+    DRAKE_DEMAND(events.HasEvents());
+    // TODO(sherm1) Should swap rather than copy.
+    context->get_mutable_discrete_state().SetFrom(*discrete_state);
+  }
+
   // Calls DoCalcUnrestrictedUpdate.
   // Assumes @param events is an instance of LeafEventCollection, throws
   // std::bad_cast otherwise.
@@ -2367,6 +2381,20 @@ class LeafSystem : public System<T> {
     // events.
     DRAKE_DEMAND(leaf_events.HasEvents());
     this->DoCalcUnrestrictedUpdate(context, leaf_events.get_events(), state);
+  }
+
+  // To get here:
+  // - The EventCollection must be a LeafEventCollection, and
+  // - There must be at least one Event belonging to this leaf subsystem.
+  void DoApplyUnrestrictedUpdate(
+      const EventCollection<UnrestrictedUpdateEvent<T>>& events,
+      State<T>* state, Context<T>* context) const final {
+    DRAKE_ASSERT(
+        dynamic_cast<const LeafEventCollection<UnrestrictedUpdateEvent<T>>*>(
+            &events) != nullptr);
+    DRAKE_DEMAND(events.HasEvents());
+    // TODO(sherm1) Should swap rather than copy.
+    context->get_mutable_state().SetFrom(*state);
   }
 
   void DoGetPerStepEvents(

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -720,6 +720,29 @@ class System : public SystemBase {
     DispatchDiscreteVariableUpdateHandler(context, events, discrete_state);
   }
 
+  /// Given the @p discrete_state results of a previous call to
+  /// CalcDiscreteVariableUpdates() that processed the given collection of
+  /// events, modifies the @p context to reflect the updated @p discrete_state.
+  /// @param[in] events
+  ///     The Event collection that resulted in the given @p discrete_state.
+  /// @param[in,out] discrete_state
+  ///     The updated discrete state from a CalcDiscreteVariableUpdates()
+  ///     call. This is mutable to permit its contents to be swapped with the
+  ///     corresponding @p context contents (rather than copied).
+  /// @param[in,out] context
+  ///     The Context whose discrete state is modified to match
+  ///     @p discrete_state. Note that swapping contents with @p discrete_state
+  ///     may cause addresses of individual discrete state group vectors in
+  ///     @p context to be different on return than they were on entry.
+  /// @pre @p discrete_state is the result of a previous
+  ///      CalcDiscreteVariableUpdates() call that processed this @p events
+  ///      collection.
+  void ApplyDiscreteVariableUpdate(
+      const EventCollection<DiscreteUpdateEvent<T>>& events,
+      DiscreteValues<T>* discrete_state, Context<T>* context) const {
+    DoApplyDiscreteVariableUpdate(events, discrete_state, context);
+  }
+
   /// This method forces a discrete update on the system given a @p context,
   /// and the updated discrete state is stored in @p discrete_state. The
   /// discrete update event will have a trigger type of kForced, with no
@@ -760,6 +783,28 @@ class System : public SystemBase {
       throw std::logic_error(
           "State variable dimensions cannot be changed "
           "in CalcUnrestrictedUpdate().");
+  }
+
+  /// Given the @p state results of a previous call to CalcUnrestrictedUpdate()
+  /// that processed the given collection of events, modifies the @p context to
+  /// reflect the updated @p state.
+  /// @param[in] events
+  ///     The Event collection that resulted in the given @p state.
+  /// @param[in,out] state
+  ///     The updated State from a CalcUnrestrictedUpdate() call. This is
+  ///     mutable to permit its contents to be swapped with the corresponding
+  ///     @p context contents (rather than copied).
+  /// @param[in,out] context
+  ///     The Context whose State is modified to match @p state. Note that
+  ///     swapping contents with the @p state may cause addresses of
+  ///     continuous, discrete, and abstract state containers in @p context
+  ///     to be different on return than they were on entry.
+  /// @pre @p state is the result of a previous CalcUnrestrictedUpdate() call
+  ///      that processed this @p events collection.
+  void ApplyUnrestrictedUpdate(
+      const EventCollection<UnrestrictedUpdateEvent<T>>& events,
+      State<T>* state, Context<T>* context) const {
+    DoApplyUnrestrictedUpdate(events, state, context);
   }
 
   /// This method forces an unrestricted update on the system given a
@@ -1675,12 +1720,20 @@ class System : public SystemBase {
       const EventCollection<DiscreteUpdateEvent<T>>& events,
       DiscreteValues<T>* discrete_state) const = 0;
 
+  virtual void DoApplyDiscreteVariableUpdate(
+      const EventCollection<DiscreteUpdateEvent<T>>& events,
+      DiscreteValues<T>* discrete_state, Context<T>* context) const = 0;
+
   /// This function dispatches all unrestricted update events to the appropriate
   /// handlers. @p state cannot be null.
   virtual void DispatchUnrestrictedUpdateHandler(
       const Context<T>& context,
       const EventCollection<UnrestrictedUpdateEvent<T>>& events,
       State<T>* state) const = 0;
+
+  virtual void DoApplyUnrestrictedUpdate(
+      const EventCollection<UnrestrictedUpdateEvent<T>>& events,
+      State<T>* state, Context<T>* context) const = 0;
   //@}
 
   //----------------------------------------------------------------------------

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -1768,8 +1768,8 @@ TEST_F(DiscreteStateTest, UpdateDiscreteVariables) {
       diagram_
           .GetSubsystemDiscreteValues(*diagram_.hold2(), *updates);
 
-      // Set the time to 8.5, so only hold2 updates.
-      context_->SetTime(8.5);
+  // Set the time to 8.5, so only hold2 updates.
+  context_->SetTime(8.5);
 
   // Request the next update time.
   auto events = diagram_.AllocateCompositeEventCollection();
@@ -1803,6 +1803,68 @@ TEST_F(DiscreteStateTest, UpdateDiscreteVariables) {
       *context_, events->get_discrete_update_events(), updates.get());
   EXPECT_EQ(17.0, updates1[0]);
   EXPECT_EQ(23.0, updates2[0]);
+}
+
+// Tests that in a Diagram where multiple subsystems have discrete variables,
+// an update in one subsystem doesn't cause invalidation in the other. Note
+// that although we use the caching system to observe what gets invalidated,
+// we are testing for proper Diagram behavior here; we're not testing the
+// caching system (which is well-tested elsewhere).
+TEST_F(DiscreteStateTest, DiscreteUpdateNotificationsAreLocalized) {
+  // Initialize the zero-order holds to different values than their input ports.
+  Context<double>& ctx1 =
+      diagram_.GetMutableSubsystemContext(*diagram_.hold1(), context_.get());
+  ctx1.get_mutable_discrete_state(0)[0] = 1001.0;
+  Context<double>& ctx2 =
+      diagram_.GetMutableSubsystemContext(*diagram_.hold2(), context_.get());
+  ctx2.get_mutable_discrete_state(0)[0] = 1002.0;
+
+  // Allocate space to hold the updated discrete variables.
+  std::unique_ptr<DiscreteValues<double>> updates =
+      diagram_.AllocateDiscreteVariables();
+
+  // Hold1 is due for an update at 2s, so only it should be included in the
+  // next update time event collection.
+  context_->SetTime(1.5);
+
+  // Request the next update time.
+  auto events = diagram_.AllocateCompositeEventCollection();
+  double time = diagram_.CalcNextUpdateTime(*context_, events.get());
+  EXPECT_EQ(2.0, time);
+  EXPECT_TRUE(events->HasDiscreteUpdateEvents());
+  const auto& discrete_events = events->get_discrete_update_events();
+
+  auto num_notifications = [](const Context<double>& context) {
+    return context.get_tracker(SystemBase::xd_ticket())
+        .num_notifications_received();
+  };
+
+  const int64_t notifications_1 = num_notifications(ctx1);
+  const int64_t notifications_2 = num_notifications(ctx2);
+
+  // Fast forward to 2.0 sec and collect the update.
+  context_->SetTime(2.0);
+  diagram_.CalcDiscreteVariableUpdates(
+      *context_, discrete_events, updates.get());
+
+  // Of course nothing should have been notified since nothing's changed yet.
+  EXPECT_EQ(num_notifications(ctx1), notifications_1);
+  EXPECT_EQ(num_notifications(ctx2), notifications_2);
+
+  // Selectively apply the update; only hold1 should get notified.
+  diagram_.ApplyDiscreteVariableUpdate(discrete_events, updates.get(),
+                                       context_.get());
+  // Sanity check that the update did occur!
+  EXPECT_EQ(17.0, ctx1.get_discrete_state(0)[0]);
+  EXPECT_EQ(1002.0, ctx2.get_discrete_state(0)[0]);
+
+  EXPECT_EQ(num_notifications(ctx1), notifications_1 + 1);
+  EXPECT_EQ(num_notifications(ctx2), notifications_2);
+
+  // Now apply the updates the dumb way. Everyone gets notified.
+  context_->get_mutable_discrete_state().SetFrom(*updates);
+  EXPECT_EQ(num_notifications(ctx1), notifications_1 + 2);
+  EXPECT_EQ(num_notifications(ctx2), notifications_2 + 1);
 }
 
 // Tests that a publish action is taken at 19 sec.
@@ -1976,6 +2038,73 @@ TEST_F(AbstractStateDiagramTest, CalcUnrestrictedUpdate) {
   context_->get_mutable_state().SetFrom(*x_buf);
   EXPECT_EQ(get_sys0_abstract_data_as_double(), (time + 0));
   EXPECT_EQ(get_sys1_abstract_data_as_double(), (time + 1));
+}
+
+// Tests that in a Diagram where multiple subsystems have abstract variables,
+// an unrestricted update in one subsystem doesn't invalidate the other.
+// Note that although we use the caching system to observe what gets
+// invalidated, we are testing for proper Diagram behavior here; we're not
+// testing the caching system.
+TEST_F(AbstractStateDiagramTest, UnrestrictedUpdateNotificationsAreLocalized) {
+  Context<double>& ctx0 =
+      diagram_.GetMutableSubsystemContext(diagram_.get_sys(0), context_.get());
+  Context<double>& ctx1 =
+      diagram_.GetMutableSubsystemContext(diagram_.get_sys(1), context_.get());
+
+  // Allocate space to hold the updated state
+  std::unique_ptr<State<double>> updates = context_->CloneState();
+
+  // sys0 is due for an update at 2s, so only it should be included in the
+  // next update time event collection.
+  context_->SetTime(1.5);
+
+  // Request the next update time.
+  auto events = diagram_.AllocateCompositeEventCollection();
+  const double next_time = diagram_.CalcNextUpdateTime(*context_, events.get());
+  EXPECT_EQ(2.0, next_time);
+  EXPECT_TRUE(events->HasUnrestrictedUpdateEvents());
+  const auto& unrestricted_events = events->get_unrestricted_update_events();
+
+  // Unrestricted update will notify xc, xd, xa and composite x. We'll count
+  // xa notifications as representative. (We're not trying to prove here that
+  // notifications are sent correctly, just that notifications are *not* sent
+  // to uninvolved subsystems.)
+  auto num_notifications = [](const Context<double>& context) {
+    return context.get_tracker(SystemBase::xa_ticket())
+        .num_notifications_received();
+  };
+
+  const int64_t notifications_0 = num_notifications(ctx0);
+  const int64_t notifications_1 = num_notifications(ctx1);
+
+  // The abstract data should be initialized to their ids.
+  EXPECT_EQ(get_sys0_abstract_data_as_double(), 0);
+  EXPECT_EQ(get_sys1_abstract_data_as_double(), 1);
+
+  // Fast forward to 2.0 sec and collect the update.
+  context_->SetTime(next_time);
+  diagram_.CalcUnrestrictedUpdate(
+      *context_, unrestricted_events, updates.get());
+
+  // Of course nothing should have been notified since nothing's changed yet.
+  EXPECT_EQ(num_notifications(ctx0), notifications_0);
+  EXPECT_EQ(num_notifications(ctx1), notifications_1);
+
+  // Selectively apply the update; only hold1 should get notified.
+  diagram_.ApplyUnrestrictedUpdate(unrestricted_events, updates.get(),
+                                       context_.get());
+  // Sanity check that the update actually occured -- should have added time
+  // to sys0's abstract id.
+  EXPECT_EQ(get_sys0_abstract_data_as_double(), 0 + next_time);
+  EXPECT_EQ(get_sys1_abstract_data_as_double(), 1);
+
+  EXPECT_EQ(num_notifications(ctx0), notifications_0 + 1);
+  EXPECT_EQ(num_notifications(ctx1), notifications_1);
+
+  // Now apply the updates the dumb way. Everyone gets notified.
+  context_->get_mutable_state().SetFrom(*updates);
+  EXPECT_EQ(num_notifications(ctx0), notifications_0 + 2);
+  EXPECT_EQ(num_notifications(ctx1), notifications_1 + 1);
 }
 
 // Test diagram. Top level diagram (big_diagram) has 3 components:

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -164,10 +164,23 @@ class TestSystem : public System<double> {
     }
   }
 
+  void DoApplyDiscreteVariableUpdate(
+      const EventCollection<DiscreteUpdateEvent<double>>& events,
+      DiscreteValues<double>* discrete_state,
+      Context<double>* context) const final {
+    ADD_FAILURE() << "Implementation is required, but unused here.";
+  }
+
   void DispatchUnrestrictedUpdateHandler(
       const Context<double>&,
       const EventCollection<UnrestrictedUpdateEvent<double>>&,
       State<double>*) const final {
+    ADD_FAILURE() << "Implementation is required, but unused here.";
+  }
+
+  void DoApplyUnrestrictedUpdate(
+      const EventCollection<UnrestrictedUpdateEvent<double>>& events,
+      State<double>* state, Context<double>* context) const final {
     ADD_FAILURE() << "Implementation is required, but unused here.";
   }
 
@@ -621,10 +634,23 @@ class ValueIOTestSystem : public System<T> {
     ADD_FAILURE() << "Implementation is required, but unused here.";
   }
 
+  void DoApplyDiscreteVariableUpdate(
+      const EventCollection<DiscreteUpdateEvent<T>>& events,
+      DiscreteValues<T>* discrete_state,
+      Context<T>* context) const final {
+    ADD_FAILURE() << "Implementation is required, but unused here.";
+  }
+
   void DispatchUnrestrictedUpdateHandler(
       const Context<T>& context,
       const EventCollection<UnrestrictedUpdateEvent<T>>& event_info,
       State<T>* state) const final {
+    ADD_FAILURE() << "Implementation is required, but unused here.";
+  }
+
+  void DoApplyUnrestrictedUpdate(
+      const EventCollection<UnrestrictedUpdateEvent<T>>& events,
+      State<T>* state, Context<T>* context) const final {
     ADD_FAILURE() << "Implementation is required, but unused here.";
   }
 
@@ -967,12 +993,27 @@ class ComputationTestSystem final : public System<double> {
       DiscreteValues<double>* discrete_state) const final {
     ADD_FAILURE() << "Implementation is required, but unused here.";
   }
+
+  void DoApplyDiscreteVariableUpdate(
+      const EventCollection<DiscreteUpdateEvent<double>>& events,
+      DiscreteValues<double>* discrete_state,
+      Context<double>* context) const final {
+    ADD_FAILURE() << "Implementation is required, but unused here.";
+  }
+
   void DispatchUnrestrictedUpdateHandler(
       const Context<double>&,
       const EventCollection<UnrestrictedUpdateEvent<double>>&,
       State<double>*) const final {
     ADD_FAILURE() << "Implementation is required, but unused here.";
   }
+
+  void DoApplyUnrestrictedUpdate(
+      const EventCollection<UnrestrictedUpdateEvent<double>>& events,
+      State<double>* state, Context<double>* context) const final {
+    ADD_FAILURE() << "Implementation is required, but unused here.";
+  }
+
   std::map<PeriodicEventData, std::vector<const Event<double>*>,
            PeriodicEventDataComparator>
   DoGetPeriodicEvents() const final { return {}; }


### PR DESCRIPTION
Provides `System::ApplyDiscreteVariableUpdate()` and `ApplyUnrestrictedUpdate()` methods guided by the Event collection that was used by the Simulator in `CalcDiscreteVariableUpdates()` or `CalcUnrestrictedUpdate()` to do a minimal amount of state updating.

Resolves #11059
Relates #10149

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11113)
<!-- Reviewable:end -->
