### PR TITLE
systems/lcm: Re-enable lcm_interface_system_test 

### DIFF
--- a/systems/lcm/BUILD.bazel
+++ b/systems/lcm/BUILD.bazel
@@ -200,8 +200,6 @@ drake_cc_library(
 
 drake_cc_googletest(
     name = "lcm_interface_system_test",
-    # TODO(jwnimmer-tri) Re-enable this after fixing the race condition.
-    tags = ["manual"],
     deps = [
         ":lcm_interface_system",
         ":lcm_subscriber_system",

--- a/systems/lcm/BUILD.bazel
+++ b/systems/lcm/BUILD.bazel
@@ -221,7 +221,7 @@ drake_cc_googletest(
         "//common/test_utilities:is_dynamic_castable",
         "//lcm:lcmt_drake_signal_utils",
         "//lcm:mock",
-        "//systems/analysis",
+        "//systems/analysis:simulator",
     ],
 )
 
@@ -231,7 +231,8 @@ drake_cc_googletest(
         ":lcm_log_playback_system",
         ":lcm_pubsub_system",
         "//lcmtypes:drake_signal",
-        "//systems/analysis",
+        "//systems/analysis:simulator",
+        "//systems/framework:diagram_builder",
     ],
 )
 

--- a/systems/lcm/test/lcm_interface_system_test.cc
+++ b/systems/lcm/test/lcm_interface_system_test.cc
@@ -103,6 +103,11 @@ TEST_P(LcmInterfaceSystemTest, AcceptanceTest) {
     // still publish and service subscriptions.  The LcmSubscriberSystem's
     // subscriptions should NOT be called anymore.
     simulator.reset();
+    // Empty the queue of anything that was published subsequent to the final
+    // simulator.AdvanceTo call, but prior to the simulator.reset call.
+    drake_lcm->HandleSubscriptions(0);
+    // Even though the transmit thread is still publishing, nothing else should
+    // appear at the handlers because there are no more active subscriptions.
     int total = 0;
     for (int i = 0; i < 100; ++i) {
       total += drake_lcm->HandleSubscriptions(1);


### PR DESCRIPTION
The test conditions have been relaxed to account for a (purposeful) race condition with the transmitter thread.

Testing with `--runs_per_test=50` reliably trips the failure on master, and does not trip the failure after this fix.

Follow-up from #11121.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11122)
<!-- Reviewable:end -->
