### PR TITLE
Selectively copy only the state for event-handling leaf subsystems

### DIFF
--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -2333,9 +2333,9 @@ class LeafSystem : public System<T> {
   }
 
   // Calls DoCalcDiscreteVariableUpdates.
-  // Assumes @param events is an instance of LeafEventCollection, throws
+  // Assumes @p events is an instance of LeafEventCollection, throws
   // std::bad_cast otherwise.
-  // Assumes @param events is not empty. Aborts otherwise.
+  // Assumes @p events is not empty. Aborts otherwise.
   void DispatchDiscreteVariableUpdateHandler(
       const Context<T>& context,
       const EventCollection<DiscreteUpdateEvent<T>>& events,
@@ -2343,13 +2343,13 @@ class LeafSystem : public System<T> {
     const LeafEventCollection<DiscreteUpdateEvent<T>>& leaf_events =
         dynamic_cast<const LeafEventCollection<DiscreteUpdateEvent<T>>&>(
             events);
-    // TODO(siyuan): should have a API level SetFrom for DiscreteValues.
-    discrete_state->SetFrom(context.get_discrete_state());
-    // Only call DoCalcDiscreteVariableUpdates if there are discrete update
-    // events.
     DRAKE_DEMAND(leaf_events.HasEvents());
+
+    // Must initialize the output argument with the current contents of the
+    // discrete state.
+    discrete_state->SetFrom(context.get_discrete_state());
     this->DoCalcDiscreteVariableUpdates(context, leaf_events.get_events(),
-        discrete_state);
+        discrete_state);  // in/out
   }
 
   // To get here:
@@ -2367,9 +2367,9 @@ class LeafSystem : public System<T> {
   }
 
   // Calls DoCalcUnrestrictedUpdate.
-  // Assumes @param events is an instance of LeafEventCollection, throws
+  // Assumes @p events is an instance of LeafEventCollection, throws
   // std::bad_cast otherwise.
-  // Assumes @param events is not empty. Aborts otherwise.
+  // Assumes @p events is not empty. Aborts otherwise.
   void DispatchUnrestrictedUpdateHandler(
       const Context<T>& context,
       const EventCollection<UnrestrictedUpdateEvent<T>>& events,
@@ -2377,10 +2377,13 @@ class LeafSystem : public System<T> {
     const LeafEventCollection<UnrestrictedUpdateEvent<T>>& leaf_events =
         dynamic_cast<const LeafEventCollection<UnrestrictedUpdateEvent<T>>&>(
             events);
-    // Only call DoCalcUnrestrictedUpdate if there are unrestricted update
-    // events.
     DRAKE_DEMAND(leaf_events.HasEvents());
-    this->DoCalcUnrestrictedUpdate(context, leaf_events.get_events(), state);
+
+    // Must initialize the output argument with the current contents of the
+    // state.
+    state->SetFrom(context.get_state());
+    this->DoCalcUnrestrictedUpdate(context, leaf_events.get_events(),
+        state);  // in/out
   }
 
   // To get here:

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -771,10 +771,6 @@ class System : public SystemBase {
     const int discrete_state_dim = state->get_discrete_state().num_groups();
     const int abstract_state_dim = state->get_abstract_state().size();
 
-    // Copy current state to the passed-in state, as specified in the
-    // documentation for DoCalcUnrestrictedUpdate().
-    state->SetFrom(context.get_state());
-
     DispatchUnrestrictedUpdateHandler(context, events, state);
 
     if (continuous_state_dim != state->get_continuous_state().size() ||


### PR DESCRIPTION
Currently `System::CalcDiscreteVariableUpdates()` and `CalcUnrestrictedUpdate()`, when invoked on a Diagram, copy the entire Diagram discrete state or (worse) entire state (resp.) when _any_ event occurs _anywhere_ in a subsystem contained in that Diagram.

This PR delays copying until we recurse down to a leaf subsystem that is actually known to have at least one event that needs handling. Then the full discrete state, or full state (resp.) for that leaf subsystem is copied prior to invoking the handlers. This avoids copying non-participating subsystem's state, and also avoids copying the tree structure of the state. However it may still perform significant unnecessary copying if a leaf subsystem has a large amount of state that is actually not updated by the current events.

Combined with #11113, this should resolve the worst of the problems with UnrestrictedUpdate, which we currently believe are mostly due to copying of non-participating subsystem state, in particular SceneGraph's. 

This PR depends on #11113.

Resolves #10149

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11125)
<!-- Reviewable:end -->
