### PR TITLE
systems/lcm: Deprecate CopyLatestMessageInto

### DIFF
--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -245,6 +245,7 @@ drake_pybind_library(
 drake_py_unittest(
     name = "lcm_test",
     deps = [
+        ":analysis_py",
         ":lcm_py",
         ":primitives_py",
     ],

--- a/bindings/pydrake/systems/lcm_py.cc
+++ b/bindings/pydrake/systems/lcm_py.cc
@@ -171,7 +171,15 @@ PYBIND11_MODULE(lcm, m) {
             py::keep_alive<1, 3>(),
             // Keep alive: `self` keeps `DrakeLcmInterface` alive.
             py::keep_alive<1, 4>(), doc.LcmSubscriberSystem.ctor.doc)
-        .def("CopyLatestMessageInto", &Class::CopyLatestMessageInto,
+        .def("CopyLatestMessageInto",
+            [](Class* self, State<double>* state) {
+              WarnDeprecated(
+                  "This unit-test-only method is being made non-public.");
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+              self->CopyLatestMessageInto(state);
+#pragma GCC diagnostic pop
+            },
             py::arg("state"), cls_doc.CopyLatestMessageInto.doc)
         .def("WaitForMessage", &Class::WaitForMessage,
             py::arg("old_message_count"), py::arg("message") = nullptr,

--- a/systems/lcm/lcm_subscriber_system.h
+++ b/systems/lcm/lcm_subscriber_system.h
@@ -162,6 +162,8 @@ class LcmSubscriberSystem : public LeafSystem<double> {
    * into @p state.  If no messages have been received, only the message count
    * is updated.  This is primarily useful for unit testing.
    */
+  DRAKE_DEPRECATED("2019-06-01",
+      "This unit-test-only method is being made non-public.")
   void CopyLatestMessageInto(State<double>* state) const;
 
   /**

--- a/systems/lcm/test/lcm_subscriber_system_test.cc
+++ b/systems/lcm/test/lcm_subscriber_system_test.cc
@@ -73,6 +73,8 @@ void TestSubscriber(drake::lcm::DrakeMockLcm* lcm,
     EXPECT_EQ(value[i], i);
   }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   // Confirm that the unit test sugar used by pydrake is another equally-valid
   // way to read messages.
   auto new_context = dut->CreateDefaultContext();
@@ -81,6 +83,7 @@ void TestSubscriber(drake::lcm::DrakeMockLcm* lcm,
   for (int i = 0; i < kDim; ++i) {
     EXPECT_EQ(new_y[i], i);
   }
+#pragma GCC diagnostic pop
 }
 
 #pragma GCC diagnostic push


### PR DESCRIPTION
Relates #10981.

This is a follow-up from #10476 where this method was created to backfill implicit updates from CreateDefaultContext that a pydrake unit test relied on.  To prune the public API, we should just call the event handler, instead of manually write into the state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11127)
<!-- Reviewable:end -->
