### PR TITLE
mkdoc: Parse DRAKE_DEPRECATED into the pydrake doc

### DIFF
--- a/bindings/pydrake/attic/multibody/rigid_body_tree_py.cc
+++ b/bindings/pydrake/attic/multibody/rigid_body_tree_py.cc
@@ -160,11 +160,11 @@ PYBIND11_MODULE(rigid_body_tree, m) {
       .def("getBodyOrFrameName", &RigidBodyTree<double>::getBodyOrFrameName,
           py::arg("body_or_frame_id"), doc.RigidBodyTree.getBodyOrFrameName.doc)
       .def("number_of_positions", &RigidBodyTree<double>::get_num_positions,
-          doc.RigidBodyTree.number_of_positions.doc)
+          doc.RigidBodyTree.number_of_positions.doc_deprecated)
       .def("get_num_positions", &RigidBodyTree<double>::get_num_positions,
           doc.RigidBodyTree.get_num_positions.doc)
       .def("number_of_velocities", &RigidBodyTree<double>::get_num_velocities,
-          doc.RigidBodyTree.number_of_velocities.doc)
+          doc.RigidBodyTree.number_of_velocities.doc_deprecated)
       .def("get_num_velocities", &RigidBodyTree<double>::get_num_velocities,
           doc.RigidBodyTree.get_num_velocities.doc)
       .def("get_body", &RigidBodyTree<double>::get_body,

--- a/bindings/pydrake/common/module_py.cc
+++ b/bindings/pydrake/common/module_py.cc
@@ -96,7 +96,8 @@ PYBIND11_MODULE(_module_py, m) {
 // Returns the fully-qualified path to the root of the `drake` source tree.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  m.def("GetDrakePath", &GetDrakePath, "Get Drake path", doc.GetDrakePath.doc);
+  m.def("GetDrakePath", &GetDrakePath, "Get Drake path",
+      doc.GetDrakePath.doc_deprecated);
 #pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
   // These are meant to be called internally by pydrake; not by users.
   m.def("set_assertion_failure_to_throw_exception",

--- a/bindings/pydrake/pydrake_doxygen.h
+++ b/bindings/pydrake/pydrake_doxygen.h
@@ -193,6 +193,8 @@ count.
 `@exclude_from_pydrake_mkdoc{Explanatory text.}` to the API comment text.
 (This is useful to help dismiss unbound overloads, so that mkdoc's choice of
 `_something` name suffix is simpler for the remaining overloads.)
+- The docstring for a method that is marked as deprecated in C++ Doxygen will
+be named `.doc_deprecated...` instead of just `.doc...`.
 
 @anchor PydrakeKeepAlive
 ## Keep Alive Behavior

--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -90,7 +90,8 @@ auto RegisterBinding(py::handle* scope, const string& name) {
     py::implicitly_convertible<B, Binding<EvaluatorBase>>();
   }
   // Add deprecated `constraint`.
-  binding_cls.def("constraint", &B::evaluator, cls_doc.constraint.doc);
+  binding_cls.def(
+      "constraint", &B::evaluator, cls_doc.constraint.doc_deprecated);
   DeprecateAttribute(binding_cls, "constraint",
       "`constraint` is deprecated; please use `evaluator` instead.");
   return binding_cls;

--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -115,7 +115,7 @@ void DefineFrameworkPySemantics(py::module m) {
             self->CopyFrom(other);
 #pragma GCC diagnostic pop
           },
-          doc.AbstractValues.CopyFrom.doc)
+          doc.AbstractValues.CopyFrom.doc_deprecated)
       .def("SetFrom", &AbstractValues::SetFrom, doc.AbstractValues.SetFrom.doc);
 
   {
@@ -150,7 +150,7 @@ void DefineFrameworkPySemantics(py::module m) {
               self->get_num_input_ports();
 #pragma GCC diagnostic pop
             },
-            "Use num_input_ports() instead.")
+            doc.ContextBase.get_num_input_ports.doc_deprecated)
         .def("num_output_ports", &Context<T>::num_output_ports,
             doc.ContextBase.num_output_ports.doc)
         .def("FixInputPort",
@@ -182,7 +182,7 @@ void DefineFrameworkPySemantics(py::module m) {
               self->set_time(time);
 #pragma GCC diagnostic pop
             },
-            "Use SetTime() instead.")
+            doc.Context.set_time.doc_deprecated)
         .def("SetAccuracy", &Context<T>::SetAccuracy, py::arg("accuracy"),
             doc.Context.SetAccuracy.doc)
         .def("set_accuracy",
@@ -195,7 +195,7 @@ void DefineFrameworkPySemantics(py::module m) {
               self->set_accuracy(accuracy);
 #pragma GCC diagnostic pop
             },
-            "Use SetAccuracy() instead.")
+            doc.Context.set_accuracy.doc_deprecated)
         .def("get_accuracy", &Context<T>::get_accuracy,
             doc.Context.get_accuracy.doc)
         .def("Clone", &Context<T>::Clone, doc.Context.Clone.doc)
@@ -238,7 +238,7 @@ void DefineFrameworkPySemantics(py::module m) {
               self->get_num_discrete_state_groups();
 #pragma GCC diagnostic pop
             },
-            "Use num_discrete_state_groups() instead.")
+            doc.Context.get_num_discrete_state_groups.doc_deprecated)
         .def("get_discrete_state",
             overload_cast_explicit<const DiscreteValues<T>&>(
                 &Context<T>::get_discrete_state),
@@ -287,7 +287,7 @@ void DefineFrameworkPySemantics(py::module m) {
               self->get_num_abstract_states();
 #pragma GCC diagnostic pop
             },
-            "Use num_abstract_states() instead.")
+            doc.Context.get_num_abstract_states.doc_deprecated)
         .def("get_abstract_state",
             static_cast<const AbstractValues& (Context<T>::*)() const>(
                 &Context<T>::get_abstract_state),
@@ -434,7 +434,7 @@ void DefineFrameworkPySemantics(py::module m) {
               self->get_num_ports();
 #pragma GCC diagnostic pop
             },
-            "Use num_ports() instead.")
+            doc.SystemOutput.get_num_ports.doc_deprecated)
         .def("get_data", &SystemOutput<T>::get_data, py_reference_internal,
             doc.SystemOutput.get_data.doc)
         .def("get_vector_data", &SystemOutput<T>::get_vector_data,

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -336,7 +336,7 @@ struct Impl {
               self->get_num_input_ports();
 #pragma GCC diagnostic pop
             },
-            "Use num_input_ports() instead.")
+            doc.SystemBase.get_num_input_ports.doc_deprecated)
         .def("get_input_port", &System<T>::get_input_port,
             py_reference_internal, py::arg("port_index"),
             doc.System.get_input_port.doc)
@@ -354,7 +354,7 @@ struct Impl {
               self->get_num_output_ports();
 #pragma GCC diagnostic pop
             },
-            "Use num_output_ports() instead.")
+            doc.SystemBase.get_num_output_ports.doc_deprecated)
         .def("get_output_port", &System<T>::get_output_port,
             py_reference_internal, py::arg("port_index"),
             doc.System.get_output_port.doc)

--- a/bindings/pydrake/systems/lcm_py.cc
+++ b/bindings/pydrake/systems/lcm_py.cc
@@ -157,7 +157,7 @@ PYBIND11_MODULE(lcm, m) {
               self->set_publish_period(period);
 #pragma GCC diagnostic pop
             },
-            py::arg("period"), cls_doc.set_publish_period.doc);
+            py::arg("period"), cls_doc.set_publish_period.doc_deprecated);
   }
 
   {
@@ -180,7 +180,7 @@ PYBIND11_MODULE(lcm, m) {
               self->CopyLatestMessageInto(state);
 #pragma GCC diagnostic pop
             },
-            py::arg("state"), cls_doc.CopyLatestMessageInto.doc)
+            py::arg("state"), cls_doc.CopyLatestMessageInto.doc_deprecated)
         .def("WaitForMessage", &Class::WaitForMessage,
             py::arg("old_message_count"), py::arg("message") = nullptr,
             py::arg("timeout") = -1, cls_doc.WaitForMessage.doc);

--- a/bindings/pydrake/systems/trajectory_optimization_py.cc
+++ b/bindings/pydrake/systems/trajectory_optimization_py.cc
@@ -118,7 +118,7 @@ PYBIND11_MODULE(trajectory_optimization, m) {
             return prog.GetSampleTimes();
 #pragma GCC diagnostic pop
           },
-          doc.MultipleShooting.GetSampleTimes.doc)
+          doc.MultipleShooting.GetSampleTimes.doc_deprecated)
       .def("GetSampleTimes",
           overload_cast_explicit<Eigen::VectorXd,
               const solvers::MathematicalProgramResult&>(
@@ -132,7 +132,7 @@ PYBIND11_MODULE(trajectory_optimization, m) {
             return prog.GetInputSamples();
 #pragma GCC diagnostic pop
           },
-          doc.MultipleShooting.GetInputSamples.doc)
+          doc.MultipleShooting.GetInputSamples.doc_deprecated)
       .def("GetInputSamples",
           overload_cast_explicit<Eigen::MatrixXd,
               const solvers::MathematicalProgramResult&>(
@@ -146,7 +146,7 @@ PYBIND11_MODULE(trajectory_optimization, m) {
             return prog.GetStateSamples();
 #pragma GCC diagnostic pop
           },
-          doc.MultipleShooting.GetStateSamples.doc)
+          doc.MultipleShooting.GetStateSamples.doc_deprecated)
       .def("GetStateSamples",
           overload_cast_explicit<Eigen::MatrixXd,
               const solvers::MathematicalProgramResult&>(
@@ -160,7 +160,7 @@ PYBIND11_MODULE(trajectory_optimization, m) {
             return prog.ReconstructInputTrajectory();
 #pragma GCC diagnostic pop
           },
-          doc.MultipleShooting.ReconstructInputTrajectory.doc)
+          doc.MultipleShooting.ReconstructInputTrajectory.doc_deprecated)
       .def("ReconstructInputTrajectory",
           overload_cast_explicit<trajectories::PiecewisePolynomial<double>,
               const solvers::MathematicalProgramResult&>(
@@ -174,7 +174,7 @@ PYBIND11_MODULE(trajectory_optimization, m) {
             return prog.ReconstructStateTrajectory();
 #pragma GCC diagnostic pop
           },
-          doc.MultipleShooting.ReconstructStateTrajectory.doc)
+          doc.MultipleShooting.ReconstructStateTrajectory.doc_deprecated)
       .def("ReconstructStateTrajectory",
           overload_cast_explicit<trajectories::PiecewisePolynomial<double>,
               const solvers::MathematicalProgramResult&>(

--- a/systems/trajectory_optimization/multiple_shooting.h
+++ b/systems/trajectory_optimization/multiple_shooting.h
@@ -295,10 +295,6 @@ class MultipleShooting : public solvers::MathematicalProgram {
   Eigen::MatrixXd GetStateSamples(
       const solvers::MathematicalProgramResult& result) const;
 
-  /// Get the input trajectory at the solution as a PiecewisePolynomial.  The
-  /// order of the trajectory will be determined by the integrator used in
-  /// the dynamic constraints.  Requires that the system has at least one input
-  /// port.
   DRAKE_DEPRECATED("2019-06-01",
       "MathematicalProgram methods that assume the solution is stored inside "
       "the program are deprecated; for details and porting advice, see "
@@ -306,6 +302,10 @@ class MultipleShooting : public solvers::MathematicalProgram {
   virtual trajectories::PiecewisePolynomial<double>
   ReconstructInputTrajectory() const = 0;
 
+  /// Get the input trajectory at the solution as a PiecewisePolynomial.  The
+  /// order of the trajectory will be determined by the integrator used in
+  /// the dynamic constraints.  Requires that the system has at least one input
+  /// port.
   virtual trajectories::PiecewisePolynomial<double> ReconstructInputTrajectory(
       const solvers::MathematicalProgramResult&) const {
     // TODO(hongkai.dai): make this function an abstract virtual function, when
@@ -316,9 +316,6 @@ class MultipleShooting : public solvers::MathematicalProgram {
         "The derived class has to override this function.");
   }
 
-  /// Get the state trajectory at the solution as a PiecewisePolynomial.  The
-  /// order of the trajectory will be determined by the integrator used in
-  /// the dynamic constraints.
   DRAKE_DEPRECATED("2019-06-01",
       "MathematicalProgram methods that assume the solution is stored inside "
       "the program are deprecated; for details and porting advice, see "
@@ -326,6 +323,9 @@ class MultipleShooting : public solvers::MathematicalProgram {
   virtual trajectories::PiecewisePolynomial<double>
   ReconstructStateTrajectory() const = 0;
 
+  /// Get the state trajectory at the solution as a PiecewisePolynomial.  The
+  /// order of the trajectory will be determined by the integrator used in
+  /// the dynamic constraints.
   virtual trajectories::PiecewisePolynomial<double> ReconstructStateTrajectory(
       const solvers::MathematicalProgramResult&) const {
     // TODO(hongkai.dai): make this function an abstract virtual function, when

--- a/third_party/com_github_pybind_pybind11/mkdoc.py
+++ b/third_party/com_github_pybind_pybind11/mkdoc.py
@@ -159,6 +159,70 @@ def sanitize_name(name):
     return name
 
 
+def extract_comment(cursor, deprecations):
+    # Returns the cursor's docstring INCLUDING any deprecation text.
+
+    # Start with the cursor's docstring.
+    result = ''
+    if cursor.raw_comment is not None:
+        result = utf8(cursor.raw_comment)
+
+    # Look for a DRAKE_DEPRECATED macro.
+    c = cursor  # The cursor whose deprecation macro we want to find.
+    found = None  # The DRAKE_DEPRECATED cursor associated with `c`.
+    possible_d = [
+        d for d in deprecations
+        if d.extent.start.file.name == c.extent.start.file.name
+    ]
+
+    # For a method declaration, the extent-begin-column for both will be
+    # identical and the MACRO_INSTATIATION will end immediately prior to
+    # the FUNCTION_DECL begin.
+    for d in possible_d:
+        if all([d.extent.start.column == c.extent.start.column,
+                (d.extent.end.line + 1) == c.extent.start.line]):
+            found = d
+            break
+
+    # For a class declaration, the MACRO_INSTATIATION extent will lie fully
+    # within the CLASS_DECL extent, near the top.  Allow up to 5 lines between
+    # the `class Foo` or `template <> class Foo` and the DRAKE_DEPRECATED macro
+    # so that we're sure NOT to match a deprecated inline method near the top
+    # of the class, but we DO allow various whitespace arrangements of template
+    # parameters, class decl, and macro.
+    for d in possible_d:
+        if all([d.extent.start.line >= c.extent.start.line,
+                d.extent.start.line <= (c.extent.start.line + 5),
+                d.extent.end.line <= c.extent.end.line]):
+            found = d
+            break
+
+    # If no deprecations matched, we are done.
+    if not found:
+        return result
+
+    # Extract the DRAKE_DEPRECATED macro arguments.
+    tokens = [x.spelling for x in found.get_tokens()]
+    assert len(tokens) >= 6, tokens
+    assert tokens[0] == b'DRAKE_DEPRECATED', tokens
+    assert tokens[1] == b'(', tokens
+    assert tokens[3] == b',', tokens
+    assert tokens[-1] == b')', tokens
+    removal_date = utf8(tokens[2])[1:-1]  # 1:-1 to strip quotes.
+    message = "".join([
+        utf8(x)[1:-1]
+        for x in tokens[4:-1]
+    ])
+
+    # Append the deprecation text.
+    result += (
+        " (Deprecated.) \deprecated {} " +
+        "This will be removed from Drake on or after {}.").format(
+            message, removal_date)
+
+    return result
+
+
 # TODO(jamiesnape): Refactor into multiple functions and unit test.
 def process_comment(comment):
     """
@@ -632,15 +696,22 @@ class SymbolTree(object):
             return self.children_map[piece]
 
 
-def extract(include_file_map, cursor, symbol_tree):
+def extract(include_file_map, cursor, symbol_tree, deprecations=None):
     """
     Extracts libclang cursors and add to a symbol tree.
     """
     if cursor.kind == CursorKind.TRANSLATION_UNIT:
+        deprecations = []
         for i in cursor.get_children():
-            extract(include_file_map, i, symbol_tree)
+            if i.kind == CursorKind.MACRO_DEFINITION:
+                continue
+            if i.kind == CursorKind.MACRO_INSTANTIATION:
+                if i.spelling == b'DRAKE_DEPRECATED':
+                    deprecations.append(i)
+                continue
+            extract(include_file_map, i, symbol_tree, deprecations)
         return
-    assert cursor.location.file is not None
+    assert cursor.location.file is not None, cursor.kind
     filename = utf8(cursor.location.file.name)
     include = include_file_map.get(filename)
     line = cursor.location.line
@@ -662,13 +733,12 @@ def extract(include_file_map, cursor, symbol_tree):
         if node is None:
             node = get_node()
         for i in cursor.get_children():
-            extract(include_file_map, i, symbol_tree)
+            extract(include_file_map, i, symbol_tree, deprecations)
     if cursor.kind in PRINT_LIST:
         if node is None:
             node = get_node()
         if len(cursor.spelling) > 0:
-            comment = utf8(
-                cursor.raw_comment) if cursor.raw_comment is not None else ''
+            comment = extract_comment(cursor, deprecations)
             comment = process_comment(comment)
             symbol = Symbol(cursor, name_chain, include, line, comment)
             node.doc_symbols.append(symbol)
@@ -758,6 +828,8 @@ def choose_doc_var_names(symbols):
                 # have a nice short name for these, that doesn't necessarily
                 # conflte with any *other* 1-argument constructor.
                 result[i] = "doc_copyconvert"
+            elif "\nDeprecated:" in symbols[i].comment:
+                result[i] = "doc_deprecated" + result[i][3:]
             else:
                 # If no special cases matched, leave the name alone.
                 continue
@@ -1022,7 +1094,9 @@ def main():
             eprint("Parse headers...")
         index = cindex.Index(
             cindex.conf.lib.clang_createIndex(False, True))
-        translation_unit = index.parse(glue_filename, parameters)
+        translation_unit = index.parse(
+            glue_filename, parameters,
+            options=cindex.TranslationUnit.PARSE_DETAILED_PROCESSING_RECORD)
     shutil.rmtree(tmpdir)
     # Extract symbols.
     if not quiet:

--- a/tools/workspace/pybind11/test/sample_header.h
+++ b/tools/workspace/pybind11/test/sample_header.h
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/unused.h"
 
 /// @def PREPROCESSOR_DEFINITION
@@ -365,6 +366,25 @@ enum {
   /// Anonymous enum's constant.
   AnonymousConstant,
 };
+
+/// I am measurably old.
+class DRAKE_DEPRECATED("2038-01-19", "Use MyNewClass instead.")
+DrakeDeprecatedClass {
+ public:
+  DRAKE_DEPRECATED("2038-01-19",
+    "f() is slow; use g() instead. "
+    "Also, I like hats.")
+  int f(int arg);
+
+  /// Ideally this overview would still appear, but it does not yet.
+  DRAKE_DEPRECATED("2038-01-19", "a() is slow; use b() instead.")
+  int a();
+};
+
+/// I am symbolically old.
+template <typename T>
+class DRAKE_DEPRECATED("2038-01-19", "Templates rule!")
+DrakeDeprecatedTemplateClass {};
 
 }  // namespace mkdoc_test
 }  // namespace drake

--- a/tools/workspace/pybind11/test/sample_header_documentation.expected.h
+++ b/tools/workspace/pybind11/test/sample_header_documentation.expected.h
@@ -15,7 +15,7 @@
 constexpr struct /* sample_header_doc */ {
   // Symbol: RootLevelSymbol
   struct /* RootLevelSymbol */ {
-    // Source: drake/tools/workspace/pybind11/test/sample_header.h:30
+    // Source: drake/tools/workspace/pybind11/test/sample_header.h:31
     const char* doc =
 R"""(Root-level symbol. Magna fermentum iaculis eu non diam phasellus
 vestibulum.)""";
@@ -24,7 +24,7 @@ vestibulum.)""";
   struct /* drake */ {
     // Symbol: drake::MidLevelSymbol
     struct /* MidLevelSymbol */ {
-      // Source: drake/tools/workspace/pybind11/test/sample_header.h:72
+      // Source: drake/tools/workspace/pybind11/test/sample_header.h:73
       const char* doc =
 R"""(Mid-level symbol. Ut enim ad minim veniam, quis nostrud exercitation
 ullamco laboris nisi ut aliquip ex ea commodo consequat.
@@ -65,12 +65,12 @@ Version:
     struct /* mkdoc_test */ {
       // Symbol: drake::mkdoc_test::AnonymousConstant
       struct /* AnonymousConstant */ {
-        // Source: drake/tools/workspace/pybind11/test/sample_header.h:366
+        // Source: drake/tools/workspace/pybind11/test/sample_header.h:367
         const char* doc = R"""(Anonymous enum's constant.)""";
       } AnonymousConstant;
       // Symbol: drake::mkdoc_test::Class
       struct /* Class */ {
-        // Source: drake/tools/workspace/pybind11/test/sample_header.h:127
+        // Source: drake/tools/workspace/pybind11/test/sample_header.h:128
         const char* doc =
 R"""(Class. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
 eiusmod tempor incididunt ut labore et dolore magna aliqua.
@@ -114,9 +114,9 @@ See also:
     Struct)""";
         // Symbol: drake::mkdoc_test::Class::Class
         struct /* ctor */ {
-          // Source: drake/tools/workspace/pybind11/test/sample_header.h:150
+          // Source: drake/tools/workspace/pybind11/test/sample_header.h:151
           const char* doc_0args = R"""(Custom constructor 1.)""";
-          // Source: drake/tools/workspace/pybind11/test/sample_header.h:163
+          // Source: drake/tools/workspace/pybind11/test/sample_header.h:164
           const char* doc_1args =
 R"""(Custom constructor 2. *Italics*. Ut tristique et egestas quis ipsum
 suspendisse ultrices gravida. ``Typewriter``. Suscipit tellus mauris a
@@ -133,7 +133,7 @@ Ut consequat semper viverra nam libero.
 
     Class class();
     class.PublicMethod();)""";
-          // Source: drake/tools/workspace/pybind11/test/sample_header.h:176
+          // Source: drake/tools/workspace/pybind11/test/sample_header.h:177
           const char* doc_2args =
 R"""(Custom constructor 3. *Italics*. Integer quis auctor elit sed
 vulputate mi sit.
@@ -148,7 +148,7 @@ Parameter ``param2``:
         } ctor;
         // Symbol: drake::mkdoc_test::Class::Nested
         struct /* Nested */ {
-          // Source: drake/tools/workspace/pybind11/test/sample_header.h:261
+          // Source: drake/tools/workspace/pybind11/test/sample_header.h:262
           const char* doc =
 R"""(Protected nested class. *Italics*. Sed turpis tincidunt id aliquet.
 Egestas sed sed risus pretium.
@@ -164,7 +164,7 @@ Test case:
         } Nested;
         // Symbol: drake::mkdoc_test::Class::ProtectedMethod
         struct /* ProtectedMethod */ {
-          // Source: drake/tools/workspace/pybind11/test/sample_header.h:250
+          // Source: drake/tools/workspace/pybind11/test/sample_header.h:251
           const char* doc =
 R"""(Protected method. **Bold**. Nibh sed pulvinar proin gravida hendrerit.
 Orci phasellus egestas tellus rutrum tellus pellentesque eu.
@@ -176,14 +176,14 @@ Returns:
         } ProtectedMethod;
         // Symbol: drake::mkdoc_test::Class::PublicMethod
         struct /* PublicMethod */ {
-          // Source: drake/tools/workspace/pybind11/test/sample_header.h:191
+          // Source: drake/tools/workspace/pybind11/test/sample_header.h:192
           const char* doc =
 R"""(Public method. :math:`A = \pi r^2`. Condimentum id venenatis a
 condimentum vitae sapien pellentesque habitant morbi.)""";
         } PublicMethod;
         // Symbol: drake::mkdoc_test::Class::PublicStatic
         struct /* PublicStatic */ {
-          // Source: drake/tools/workspace/pybind11/test/sample_header.h:214
+          // Source: drake/tools/workspace/pybind11/test/sample_header.h:215
           const char* doc =
 R"""(Static method. ``Typewriter``. Sed faucibus turpis in eu mi bibendum
 neque egestas.
@@ -206,7 +206,7 @@ Postcondition:
         } PublicStatic;
         // Symbol: drake::mkdoc_test::Class::PublicTemplateMethod
         struct /* PublicTemplateMethod */ {
-          // Source: drake/tools/workspace/pybind11/test/sample_header.h:201
+          // Source: drake/tools/workspace/pybind11/test/sample_header.h:202
           const char* doc =
 R"""(Public template method.
 
@@ -220,72 +220,112 @@ Template parameter ``T``:
         } PublicTemplateMethod;
         // Symbol: drake::mkdoc_test::Class::TypedefAlias
         struct /* TypedefAlias */ {
-          // Source: drake/tools/workspace/pybind11/test/sample_header.h:142
+          // Source: drake/tools/workspace/pybind11/test/sample_header.h:143
           const char* doc =
 R"""(Typedef alias. **Bold**. Risus nec feugiat in fermentum posuere urna
 nec tincidunt praesent.)""";
         } TypedefAlias;
         // Symbol: drake::mkdoc_test::Class::UsingAlias
         struct /* UsingAlias */ {
-          // Source: drake/tools/workspace/pybind11/test/sample_header.h:137
+          // Source: drake/tools/workspace/pybind11/test/sample_header.h:138
           const char* doc =
 R"""(Using alias. *Italics*. Sit amet nisl purus in mollis nunc sed id
 semper.)""";
         } UsingAlias;
         // Symbol: drake::mkdoc_test::Class::get_foo
         struct /* get_foo */ {
-          // Source: drake/tools/workspace/pybind11/test/sample_header.h:238
+          // Source: drake/tools/workspace/pybind11/test/sample_header.h:239
           const char* doc_0args_nonconst = R"""(Overloaded only by its const-ness.)""";
-          // Source: drake/tools/workspace/pybind11/test/sample_header.h:241
+          // Source: drake/tools/workspace/pybind11/test/sample_header.h:242
           const char* doc_0args_const = R"""(The const one.)""";
         } get_foo;
         // Symbol: drake::mkdoc_test::Class::overloaded_method
         struct /* overloaded_method */ {
-          // Source: drake/tools/workspace/pybind11/test/sample_header.h:217
+          // Source: drake/tools/workspace/pybind11/test/sample_header.h:218
           const char* doc_1args_alpha = R"""(This one takes an int.)""";
-          // Source: drake/tools/workspace/pybind11/test/sample_header.h:220
+          // Source: drake/tools/workspace/pybind11/test/sample_header.h:221
           const char* doc_1args_bravo = R"""(This one takes a double.)""";
-          // Source: drake/tools/workspace/pybind11/test/sample_header.h:223
+          // Source: drake/tools/workspace/pybind11/test/sample_header.h:224
           const char* doc_2args_charlie_delta = R"""(This one takes an int and a double.)""";
-          // Source: drake/tools/workspace/pybind11/test/sample_header.h:226
+          // Source: drake/tools/workspace/pybind11/test/sample_header.h:227
           const char* doc_2args_double_int = R"""(This one takes the road less traveled.)""";
-          // Source: drake/tools/workspace/pybind11/test/sample_header.h:229
+          // Source: drake/tools/workspace/pybind11/test/sample_header.h:230
           const char* doc_1args_conststdstring = R"""(This one takes a non-primitive type.)""";
         } overloaded_method;
         // Symbol: drake::mkdoc_test::Class::overloaded_with_same_doc
         struct /* overloaded_with_same_doc */ {
-          // Source: drake/tools/workspace/pybind11/test/sample_header.h:232
+          // Source: drake/tools/workspace/pybind11/test/sample_header.h:233
           const char* doc = R"""(Different overload with same doc.)""";
         } overloaded_with_same_doc;
         // Symbol: drake::mkdoc_test::Class::protected_member_
         struct /* protected_member_ */ {
-          // Source: drake/tools/workspace/pybind11/test/sample_header.h:267
+          // Source: drake/tools/workspace/pybind11/test/sample_header.h:268
           const char* doc =
 R"""(Protected member. ``Typewriter``. Porttitor eget dolor morbi non arcu
 risus quis varius quam.)""";
         } protected_member_;
       } Class;
+      // Symbol: drake::mkdoc_test::DrakeDeprecatedClass
+      struct /* DrakeDeprecatedClass */ {
+        // Source: drake/tools/workspace/pybind11/test/sample_header.h:372
+        const char* doc_deprecated =
+R"""(I am measurably old. (Deprecated.)
+
+Deprecated:
+    Use MyNewClass instead. This will be removed from Drake on or
+    after 2038-01-19.)""";
+        // Symbol: drake::mkdoc_test::DrakeDeprecatedClass::a
+        struct /* a */ {
+          // Source: drake/tools/workspace/pybind11/test/sample_header.h:381
+          const char* doc_deprecated =
+R"""((Deprecated.)
+
+Deprecated:
+    a() is slow; use b() instead. This will be removed from Drake on
+    or after 2038-01-19.)""";
+        } a;
+        // Symbol: drake::mkdoc_test::DrakeDeprecatedClass::f
+        struct /* f */ {
+          // Source: drake/tools/workspace/pybind11/test/sample_header.h:377
+          const char* doc_deprecated =
+R"""((Deprecated.)
+
+Deprecated:
+    f() is slow; use g() instead. Also, I like hats. This will be
+    removed from Drake on or after 2038-01-19.)""";
+        } f;
+      } DrakeDeprecatedClass;
+      // Symbol: drake::mkdoc_test::DrakeDeprecatedTemplateClass
+      struct /* DrakeDeprecatedTemplateClass */ {
+        // Source: drake/tools/workspace/pybind11/test/sample_header.h:387
+        const char* doc_deprecated =
+R"""(I am symbolically old. (Deprecated.)
+
+Deprecated:
+    Templates rule! This will be removed from Drake on or after
+    2038-01-19.)""";
+      } DrakeDeprecatedTemplateClass;
       // Symbol: drake::mkdoc_test::Enum
       struct /* Enum */ {
-        // Source: drake/tools/workspace/pybind11/test/sample_header.h:350
+        // Source: drake/tools/workspace/pybind11/test/sample_header.h:351
         const char* doc =
 R"""(Enumeration. Feugiat scelerisque varius morbi enim. Facilisis leo vel
 fringilla est ullamcorper eget nulla facilisi.)""";
         // Symbol: drake::mkdoc_test::Enum::EnumConstant
         struct /* EnumConstant */ {
-          // Source: drake/tools/workspace/pybind11/test/sample_header.h:352
+          // Source: drake/tools/workspace/pybind11/test/sample_header.h:353
           const char* doc = R"""(Enumeration constant.)""";
         } EnumConstant;
       } Enum;
       // Symbol: drake::mkdoc_test::EnumClass
       struct /* EnumClass */ {
-        // Source: drake/tools/workspace/pybind11/test/sample_header.h:357
+        // Source: drake/tools/workspace/pybind11/test/sample_header.h:358
         const char* doc =
 R"""(Enumeration class. Malesuada fames ac turpis egestas integer eget
 aliquet nibh praesent.)""";
         // Symbol: drake::mkdoc_test::EnumClass::EnumClassConstant
         struct /* EnumClassConstant */ {
-          // Source: drake/tools/workspace/pybind11/test/sample_header.h:360
+          // Source: drake/tools/workspace/pybind11/test/sample_header.h:361
           const char* doc =
 R"""(Enumeration class constant. Vestibulum mattis ullamcorper velit sed
 ullamcorper.)""";
@@ -293,8 +333,8 @@ ullamcorper.)""";
       } EnumClass;
       // Symbol: drake::mkdoc_test::Struct
       struct /* Struct */ {
-        // Source: drake/tools/workspace/pybind11/test/sample_header.h:286
-        const char* doc =
+        // Source: drake/tools/workspace/pybind11/test/sample_header.h:287
+        const char* doc_deprecated =
 R"""(Struct. Sed elementum tempus egestas sed sed risus pretium. Vel
 pharetra vel turpis nunc.
 
@@ -306,7 +346,7 @@ See also:
     Class)""";
         // Symbol: drake::mkdoc_test::Struct::field_1
         struct /* field_1 */ {
-          // Source: drake/tools/workspace/pybind11/test/sample_header.h:292
+          // Source: drake/tools/workspace/pybind11/test/sample_header.h:293
           const char* doc =
 R"""(Field 1. Sit amet cursus sit amet dictum sit amet. Id leo in vitae
 turpis massa sed elementum tempus.
@@ -317,7 +357,7 @@ Attention:
         } field_1;
         // Symbol: drake::mkdoc_test::Struct::field_2
         struct /* field_2 */ {
-          // Source: drake/tools/workspace/pybind11/test/sample_header.h:297
+          // Source: drake/tools/workspace/pybind11/test/sample_header.h:298
           const char* doc =
 R"""(Field 2. Consectetur libero id faucibus nisl tincidunt eget nullam non
 nisi.
@@ -329,7 +369,7 @@ Note:
       } Struct;
       // Symbol: drake::mkdoc_test::TemplateClass
       struct /* TemplateClass */ {
-        // Source: drake/tools/workspace/pybind11/test/sample_header.h:306
+        // Source: drake/tools/workspace/pybind11/test/sample_header.h:307
         const char* doc_was_unable_to_choose_unambiguous_names =
 R"""(Template class. Mauris pharetra et ultrices neque ornare aenean
 euismod elementum.
@@ -339,7 +379,7 @@ Template parameter ``T``:
     nunc faucibus a. End template parameter.)""";
         // Symbol: drake::mkdoc_test::TemplateClass::TemplateClass<T>
         struct /* ctor */ {
-          // Source: drake/tools/workspace/pybind11/test/sample_header.h:314
+          // Source: drake/tools/workspace/pybind11/test/sample_header.h:315
           const char* doc_0args =
 R"""(Default constructor. Condimentum mattis pellentesque id nibh tortor
 id. Nisl rhoncus mattis rhoncus urna neque.
@@ -347,18 +387,18 @@ id. Nisl rhoncus mattis rhoncus urna neque.
 Remark:
     Begin remarks. Ante metus dictum at tempor commodo. Nec feugiat in
     fermentum posuere urna nec. End remarks.)""";
-          // Source: drake/tools/workspace/pybind11/test/sample_header.h:317
+          // Source: drake/tools/workspace/pybind11/test/sample_header.h:318
           const char* doc_1args = R"""(Single argument int constructor.)""";
-          // Source: drake/tools/workspace/pybind11/test/sample_header.h:321
+          // Source: drake/tools/workspace/pybind11/test/sample_header.h:322
           const char* doc_copyconvert = R"""(Scalar-converting copy constructor.)""";
         } ctor;
       } TemplateClass;
       // Symbol: drake::mkdoc_test::func
       struct /* func */ {
-        // Source: drake/tools/workspace/pybind11/test/sample_header.h:80
+        // Source: drake/tools/workspace/pybind11/test/sample_header.h:81
         const char* doc_0args =
 R"""(Function. Mi sit amet mauris commodo quis.)""";
-        // Source: drake/tools/workspace/pybind11/test/sample_header.h:86
+        // Source: drake/tools/workspace/pybind11/test/sample_header.h:87
         const char* doc_1args_param =
 R"""(Function, overload 1. Velit ut tortor pretium viverra suspendisse
 potenti nullam ac tortor.
@@ -367,7 +407,7 @@ Raises:
     RuntimeError Begin raises. Morbi tincidunt augue interdum velit
     euismod. Justo nec ultrices dui sapien eget mi proin sed libero.
     End raises.)""";
-        // Source: drake/tools/workspace/pybind11/test/sample_header.h:92
+        // Source: drake/tools/workspace/pybind11/test/sample_header.h:93
         const char* doc_1args_T =
 R"""(Function, template overload. Pellentesque diam volutpat commodo sed
 egestas egestas fringilla phasellus faucibus.


### PR DESCRIPTION
Fixes one checkbox from #9599.

It's extremely aggravating how much copypasta in pydrake we need when we deprecate a C++ class or method.

This PR fixes the first half -- placing the rework suggestion and date into the documentation.

The second half (in another PR) will be a higher-order function that decorates the deprecated function pointer or lamba with a call to `WarnDeprecated`, so that we don't have to completely rewrite the binding from pointer to lambda every time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11131)
<!-- Reviewable:end -->
