### PR TITLE
Revert "check if the constraint lower bound is no larger than the upper bound"

### DIFF
--- a/multibody/inverse_kinematics/test/angle_between_vectors_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/angle_between_vectors_constraint_test.cc
@@ -118,12 +118,10 @@ TEST_F(IiwaKinematicConstraintTest,
                    Eigen::Vector3d::Ones(), -0.1, 0.2, plant_context_),
                std::invalid_argument);
   // angle_upper < angle_lower
-  if (!kDrakeAssertIsArmed) {
-    EXPECT_THROW(AngleBetweenVectorsConstraint(
-                     plant_, frameA, Eigen::Vector3d::Ones(), frameB,
-                     Eigen::Vector3d::Zero(), 0.1, 0.09, plant_context_),
-                 std::invalid_argument);
-  }
+  EXPECT_THROW(AngleBetweenVectorsConstraint(
+                   plant_, frameA, Eigen::Vector3d::Ones(), frameB,
+                   Eigen::Vector3d::Zero(), 0.1, 0.09, plant_context_),
+               std::invalid_argument);
   // angle_upper > pi
   EXPECT_THROW(AngleBetweenVectorsConstraint(
                    plant_, frameA, Eigen::Vector3d::Ones(), frameB,

--- a/solvers/constraint.h
+++ b/solvers/constraint.h
@@ -174,7 +174,6 @@ class Constraint : public EvaluatorBase {
                  "Size of lower bound must match number of constraints.");
     DRAKE_ASSERT(upper_bound_.size() == num_constraints &&
                  "Size of upper bound must match number of constraints.");
-    DRAKE_ASSERT((lower_bound_.array() <= upper_bound_.array()).all());
   }
 
   Eigen::VectorXd lower_bound_;

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -1053,7 +1053,7 @@ GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic3) {
       -7,
        2,
       1;
-  M_ub << 9,
+  M_ub << -7,
       10,
       12,
       3,


### PR DESCRIPTION
Reverts #11129.

----
Dear @hongkai-dai,

The on-call build cop, @jamiesnape, believes that your PR #11129 may have
broken one or more of Drake's continuous integration builds [1]. It is
possible to break a build even if your PR passed continuous integration
pre-merge because additional platforms are tested post-merge.

The specific build failures under investigation are:
* https://drake-jenkins.csail.mit.edu/job/linux-bionic-clang-bazel-continuous-everything-debug/709/
* https://drake-jenkins.csail.mit.edu/job/linux-bionic-clang-bazel-continuous-everything-python3-debug/503/
* https://drake-jenkins.csail.mit.edu/job/linux-xenial-clang-bazel-continuous-everything-debug/708/

Therefore, the build cop has created this revert PR and started a complete
post-merge build to determine whether your PR was in fact the cause of the
problem. If that build passes, this revert PR will be merged 60 minutes from
now. You can then fix the problem at your leisure, and send a new PR to
reinstate your change.

If you believe your original PR did not actually break the build, please
explain on this thread.

If you believe you can fix the break promptly in lieu of a revert, please
explain on this thread, and send a PR to the build cop for review ASAP.

If you believe your original PR definitely did break the build and should be
reverted, please review and LGTM this PR. This allows the build cop to merge
without waiting for CI results.

For advice on how to handle a build cop revert, see [2].

Thanks!
Your Friendly On-call Build Cop

[1] CI Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Production/
[2] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11135)
<!-- Reviewable:end -->
