### PR TITLE
Adds "freeze cache" capability to Context

### DIFF
--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -681,6 +681,7 @@ drake_cc_googletest(
         ":cache_and_dependency_tracker",
         ":context_base",
         "//common:essential",
+        "//common/test_utilities:expect_throws_message",
         "//systems/framework/test_utilities",
     ],
 )

--- a/systems/framework/context_base.h
+++ b/systems/framework/context_base.h
@@ -90,6 +90,31 @@ class ContextBase : public internal::ContextMessageInterface {
     PropagateCachingChange(*this, &Cache::SetAllEntriesOutOfDate);
   }
 
+  /** (Advanced) Freezes the cache at its current contents, preventing any
+  further cache updates. When frozen, accessing an out-of-date cache entry
+  causes an exception to be throw. This is applied recursively to this
+  %Context and all its subcontexts, but _not_ to its parent or siblings so
+  it is most useful when called on the root %Context. If the cache was already
+  frozen this method does nothing but waste a little time. */
+  void FreezeCache() const {
+    PropagateCachingChange(*this, &Cache::freeze_cache);
+  }
+
+  /** (Advanced) Unfreezes the cache if it was previously frozen. This is
+  applied recursively to this %Context and all its subcontexts, but _not_
+  to its parent or siblings. If the cache was not frozen, this does nothing
+  but waste a little time. */
+  void UnfreezeCache() const {
+    PropagateCachingChange(*this, &Cache::unfreeze_cache);
+  }
+
+  /** (Advanced) Reports whether this %Context's cache is currently frozen.
+  This checks only locally; it is possible that parent, child, or sibling
+  subcontext caches are in a different state than this one. */
+  bool is_cache_frozen() const final {
+    return get_cache().is_cache_frozen();
+  }
+
   /** Returns the local name of the subsystem for which this is the Context.
   This is intended primarily for error messages and logging.
   @see SystemBase::GetSystemName() for details.

--- a/systems/framework/framework_common.h
+++ b/systems/framework/framework_common.h
@@ -207,6 +207,9 @@ class ContextMessageInterface {
   // and the path separator from SystemMessageInterface::path_separator().
   virtual std::string GetSystemPathname() const = 0;
 
+  // Returns true if the cache in this subcontext has been frozen.
+  virtual bool is_cache_frozen() const = 0;
+
  protected:
   ContextMessageInterface() = default;
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ContextMessageInterface);

--- a/systems/framework/test/cache_test.cc
+++ b/systems/framework/test/cache_test.cc
@@ -12,6 +12,7 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/systems/framework/context_base.h"
 #include "drake/systems/framework/test_utilities/my_vector.h"
 #include "drake/systems/framework/test_utilities/pack_value.h"
@@ -325,6 +326,71 @@ TEST_F(CacheTest, DisableCachingWorks) {
   EXPECT_TRUE(int_val.is_out_of_date());
   EXPECT_TRUE(str_val.is_out_of_date());
   EXPECT_TRUE(vec_val.is_out_of_date());
+}
+
+// Freezing the cache should prevent mutable access to any out-of-date value.
+// These are the mutable methods:
+//   SetValueOrThrow<T>()
+//   set_value<V>()
+//   GetMutableAbstractValueOrThrow()
+//   GetMutableValueOrThrow<V>()
+//   swap_value()
+TEST_F(CacheTest, FreezeUnfreezeWork) {
+  // Test that the flag gets set and reset.
+  EXPECT_FALSE(context_.is_cache_frozen());
+  context_.FreezeCache();
+  EXPECT_TRUE(context_.is_cache_frozen());
+  context_.UnfreezeCache();
+  EXPECT_FALSE(context_.is_cache_frozen());
+
+  CacheEntryValue& str_val = cache_value(string_index_);
+  EXPECT_FALSE(str_val.is_out_of_date());
+  // All mutable methods should be OK here as long as the entry is out of date.
+  str_val.mark_out_of_date();
+  EXPECT_NO_THROW(str_val.SetValueOrThrow<std::string>("one"));
+  str_val.mark_out_of_date();
+  EXPECT_NO_THROW(str_val.set_value<std::string>("two"));
+  str_val.mark_out_of_date();
+  // The next two leave the entry out of date.
+  EXPECT_NO_THROW(str_val.GetMutableAbstractValueOrThrow());
+  EXPECT_NO_THROW(str_val.GetMutableValueOrThrow<std::string>());
+
+  auto swapper = AbstractValue::Make<std::string>("for swapping");
+  EXPECT_NO_THROW(str_val.swap_value(&swapper));
+
+
+  // With cache frozen but up to date, check some const methods to make sure
+  // they still work.
+  str_val.mark_up_to_date();
+  context_.FreezeCache();
+  EXPECT_NO_THROW(str_val.GetAbstractValueOrThrow());
+  EXPECT_NO_THROW(str_val.GetValueOrThrow<std::string>());
+  EXPECT_NO_THROW(str_val.get_value<std::string>());
+
+  // Const methods still fail if entry is out of date (just check one).
+  str_val.mark_out_of_date();
+  DRAKE_EXPECT_THROWS_MESSAGE(str_val.GetValueOrThrow<std::string>(),
+                              std::logic_error,
+                              ".*string thing.*GetValueOrThrow.*out of date.*");
+
+  // But, all mutable methods should fail now. "Set" methods should leave the
+  // cache entry out of date.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      str_val.SetValueOrThrow<std::string>("three"), std::logic_error,
+      ".*string thing.*SetValueOrThrow.*cache is frozen.*");
+  // (Despite the snake_case name, this still checks for frozen cache.)
+  DRAKE_EXPECT_THROWS_MESSAGE(str_val.set_value<std::string>("four"),
+                              std::logic_error,
+                              ".*string thing.*set_value.*cache is frozen.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      str_val.GetMutableAbstractValueOrThrow(), std::logic_error,
+      ".*string thing.*GetMutableAbstractValueOrThrow.*cache is frozen.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      str_val.GetMutableValueOrThrow<std::string>(), std::logic_error,
+      ".*string thing.*GetMutableValueOrThrow.*cache is frozen.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      str_val.swap_value(&swapper), std::logic_error,
+      ".*string thing.*swap_value.*cache is frozen.*");
 }
 
 // Test that the vector-valued cache entry works and preserved the underlying


### PR DESCRIPTION
Adds `FreezeCache()` `UnfreezeCache()` `is_cache_frozen()` methods to ContextBase.

Resolves #10442
Relates #11148

cc @calderpg-tri

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11145)
<!-- Reviewable:end -->
