### PR TITLE
Exponential cone constraint

### DIFF
--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -29,6 +29,7 @@ using solvers::BoundingBoxConstraint;
 using solvers::Constraint;
 using solvers::Cost;
 using solvers::EvaluatorBase;
+using solvers::ExponentialConeConstraint;
 using solvers::LinearComplementarityConstraint;
 using solvers::LinearConstraint;
 using solvers::LinearCost;
@@ -515,6 +516,12 @@ PYBIND11_MODULE(mathematicalprogram, m) {
           },
           doc.MathematicalProgram.AddPositiveSemidefiniteConstraint
               .doc_1args_constEigenMatrixBase)
+      .def("AddExponentialConeConstraint",
+          [](MathematicalProgram* self,
+              const Eigen::Ref<const Vector3<symbolic::Expression>>& z) {
+            return self->AddExponentialConeConstraint(z);
+          },
+          doc.MathematicalProgram.AddExponentialConeConstraint.doc_1args)
       .def("AddCost",
           [](MathematicalProgram* self, py::function func,
               const Eigen::Ref<const VectorXDecisionVariable>& vars,
@@ -948,6 +955,10 @@ PYBIND11_MODULE(mathematicalprogram, m) {
       "LinearComplementarityConstraint",
       doc.LinearComplementarityConstraint.doc);
 
+  py::class_<ExponentialConeConstraint, Constraint,
+      std::shared_ptr<ExponentialConeConstraint>>(
+      m, "ExponentialConeConstraint", doc.ExponentialConeConstraint.doc);
+
   RegisterBinding<Constraint>(&m, "Constraint");
   RegisterBinding<LinearConstraint>(&m, "LinearConstraint");
   RegisterBinding<LorentzConeConstraint>(&m, "LorentzConeConstraint");
@@ -957,6 +968,7 @@ PYBIND11_MODULE(mathematicalprogram, m) {
       &m, "PositiveSemidefiniteConstraint");
   RegisterBinding<LinearComplementarityConstraint>(
       &m, "LinearComplementarityConstraint");
+  RegisterBinding<ExponentialConeConstraint>(&m, "ExponentialConeConstraint");
 
   // Mirror procedure for costs
   py::class_<Cost, EvaluatorBase, std::shared_ptr<Cost>> cost(

--- a/solvers/constraint.cc
+++ b/solvers/constraint.cc
@@ -386,5 +386,41 @@ void ExpressionConstraint::DoEval(
   }
 }
 
+ExponentialConeConstraint::ExponentialConeConstraint(
+    const Eigen::Ref<const Eigen::SparseMatrix<double>>& A,
+    const Eigen::Ref<const Eigen::Vector3d>& b)
+    : Constraint(
+          2, A.cols(), Eigen::Vector2d::Zero(),
+          Eigen::Vector2d::Constant(std::numeric_limits<double>::infinity())),
+      A_{A},
+      b_{b} {
+  DRAKE_DEMAND(A.rows() == 3);
+}
+
+template <typename DerivedX, typename ScalarY>
+void ExponentialConeConstraint::DoEvalGeneric(
+    const Eigen::MatrixBase<DerivedX>& x, VectorX<ScalarY>* y) const {
+  y->resize(num_constraints());
+  Vector3<ScalarY> z = A_ * x.template cast<ScalarY>() + b_;
+  using std::exp;
+  (*y)(0) = z(0) - z(1) * exp(z(2) / z(1));
+  (*y)(1) = z(1);
+}
+
+void ExponentialConeConstraint::DoEval(
+    const Eigen::Ref<const Eigen::VectorXd>& x, Eigen::VectorXd* y) const {
+  DoEvalGeneric(x, y);
+}
+
+void ExponentialConeConstraint::DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
+                                       AutoDiffVecXd* y) const {
+  DoEvalGeneric(x, y);
+}
+
+void ExponentialConeConstraint::DoEval(
+    const Eigen::Ref<const VectorX<symbolic::Variable>>& x,
+    VectorX<symbolic::Expression>* y) const {
+  DoEvalGeneric(x, y);
+}
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/constraint.h
+++ b/solvers/constraint.h
@@ -907,7 +907,7 @@ class ExpressionConstraint : public Constraint {
 
 /**
  * An exponential cone constraint is a special type of convex cone constraint.
- * We constraint A * x + b to be in the exponential cone.
+ * We constrain A * x + b to be in the exponential cone.
  * A vector z in ℝ³ is in the exponential cone, if
  * {z₀, z₁, z₂ | z₀ ≥ z₁ * exp(z₂ / z₁), z₁ > 0}.
  * Equivalently, this constraint can be refomulated with logarithm function
@@ -919,9 +919,9 @@ class ExpressionConstraint : public Constraint {
  * where z = A * x + b.
  * It is not recommended to solve an exponential cone constraint through
  * generic nonlinear optimization. It is possible that the nonlinear solver
- * can accidentally set z₁ = 0, where the constraint is not well. Instead, the
- * user should consider to solve the program through conic solvers that can
- * exploit exponential cone, such as Mosek and SCS.
+ * can accidentally set z₁ = 0, where the constraint is not well defined.
+ * Instead, the user should consider to solve the program through conic solvers
+ * that can exploit exponential cone, such as Mosek and SCS.
  */
 class ExponentialConeConstraint : public Constraint {
  public:
@@ -929,7 +929,7 @@ class ExponentialConeConstraint : public Constraint {
 
   /**
    * Constructor for exponential cone.
-   * Constrains that A * x + b is in the exponential cone.
+   * Constrains A * x + b to be in the exponential cone.
    */
   ExponentialConeConstraint(
       const Eigen::Ref<const Eigen::SparseMatrix<double>>& A,

--- a/solvers/constraint.h
+++ b/solvers/constraint.h
@@ -907,7 +907,8 @@ class ExpressionConstraint : public Constraint {
 
 /**
  * An exponential cone constraint is a special type of convex cone constraint.
- * We constrain A * x + b to be in the exponential cone.
+ * We constrain A * x + b to be in the exponential cone, where A has 3 rows, and
+ * b is in ℝ³, x is the decision variable.
  * A vector z in ℝ³ is in the exponential cone, if
  * {z₀, z₁, z₂ | z₀ ≥ z₁ * exp(z₂ / z₁), z₁ > 0}.
  * Equivalently, this constraint can be refomulated with logarithm function
@@ -930,6 +931,7 @@ class ExponentialConeConstraint : public Constraint {
   /**
    * Constructor for exponential cone.
    * Constrains A * x + b to be in the exponential cone.
+   * @pre A has 3 rows.
    */
   ExponentialConeConstraint(
       const Eigen::Ref<const Eigen::SparseMatrix<double>>& A,

--- a/solvers/constraint.h
+++ b/solvers/constraint.h
@@ -905,5 +905,19 @@ class ExpressionConstraint : public Constraint {
   mutable symbolic::Environment environment_;
 };
 
+/**
+ * An exponential cone constraint is a special type of convex cone constraint.
+ * The constraint is that
+ * {x₀, x₁, x₂ | x₀ ≥ x₁ * exp(x₂ / x₁), x₀ > 0, x₁ > 0}.
+ * Equivalently, this constraint can be refomulated with logarithm function
+ * {x₀, x₁, x₂ | x₂ ≤ x₁ * log(x₀ / x₁), x₀ > 0, x₁ > 0}
+ */
+class ExponentialConeConstraint : public Constraint {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ExponentialConeConstraint)
+
+  
+};
+
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/constraint.h
+++ b/solvers/constraint.h
@@ -907,16 +907,59 @@ class ExpressionConstraint : public Constraint {
 
 /**
  * An exponential cone constraint is a special type of convex cone constraint.
- * The constraint is that
- * {x₀, x₁, x₂ | x₀ ≥ x₁ * exp(x₂ / x₁), x₀ > 0, x₁ > 0}.
+ * We constraint A * x + b to be in the exponential cone.
+ * A vector z in ℝ³ is in the exponential cone, if
+ * {z₀, z₁, z₂ | z₀ ≥ z₁ * exp(z₂ / z₁), z₁ > 0}.
  * Equivalently, this constraint can be refomulated with logarithm function
- * {x₀, x₁, x₂ | x₂ ≤ x₁ * log(x₀ / x₁), x₀ > 0, x₁ > 0}
+ * {z₀, z₁, z₂ | z₂ ≤ z₁ * log(z₀ / z₁), z₀ > 0, z₁ > 0}
+ *
+ * The Eval function implemented in this class is
+ * z₀ - z₁ * exp(z₂ / z₁) >= 0,
+ * z₁ > 0
+ * where z = A * x + b.
+ * It is not recommended to solve an exponential cone constraint through
+ * generic nonlinear optimization. It is possible that the nonlinear solver
+ * can accidentally set z₁ = 0, where the constraint is not well. Instead, the
+ * user should consider to solve the program through conic solvers that can
+ * exploit exponential cone, such as Mosek and SCS.
  */
 class ExponentialConeConstraint : public Constraint {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ExponentialConeConstraint)
 
-  
+  /**
+   * Constructor for exponential cone.
+   * Constrains that A * x + b is in the exponential cone.
+   */
+  ExponentialConeConstraint(
+      const Eigen::Ref<const Eigen::SparseMatrix<double>>& A,
+      const Eigen::Ref<const Eigen::Vector3d>& b);
+
+  ~ExponentialConeConstraint() override{};
+
+  /** Getter for matrix A. */
+  const Eigen::SparseMatrix<double>& A() const { return A_; }
+
+  /** Getter for vector b. */
+  const Eigen::Vector3d& b() const { return b_; }
+
+ protected:
+  template <typename DerivedX, typename ScalarY>
+  void DoEvalGeneric(const Eigen::MatrixBase<DerivedX>& x,
+                     VectorX<ScalarY>* y) const;
+
+  void DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
+              Eigen::VectorXd* y) const override;
+
+  void DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
+              AutoDiffVecXd* y) const override;
+
+  void DoEval(const Eigen::Ref<const VectorX<symbolic::Variable>>& x,
+              VectorX<symbolic::Expression>* y) const override;
+
+ private:
+  Eigen::SparseMatrix<double> A_;
+  Eigen::Vector3d b_;
 };
 
 }  // namespace solvers

--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -89,6 +89,7 @@ std::unique_ptr<MathematicalProgram> MathematicalProgram::Clone() const {
       positive_semidefinite_constraint_;
   new_prog->linear_matrix_inequality_constraint_ =
       linear_matrix_inequality_constraint_;
+  new_prog->exponential_cone_constraints_ = exponential_cone_constraints_;
   new_prog->linear_complementarity_constraints_ =
       linear_complementarity_constraints_;
 
@@ -880,6 +881,32 @@ MathematicalProgram::AddScaledDiagonallyDominantMatrixConstraint(
   return M;
 }
 
+Binding<ExponentialConeConstraint> MathematicalProgram::AddConstraint(
+    const Binding<ExponentialConeConstraint>& binding) {
+  CheckBinding(binding);
+  required_capabilities_.insert(ProgramAttribute::kExponentialConeConstraint);
+  exponential_cone_constraints_.push_back(binding);
+  return exponential_cone_constraints_.back();
+}
+
+Binding<ExponentialConeConstraint>
+MathematicalProgram::AddExponentialConeConstraint(
+    const Eigen::Ref<const Eigen::SparseMatrix<double>>& A,
+    const Eigen::Ref<const Eigen::Vector3d>& b,
+    const Eigen::Ref<const VectorXDecisionVariable>& vars) {
+  auto constraint = std::make_shared<ExponentialConeConstraint>(A, b);
+  return AddConstraint(constraint, vars);
+}
+
+Binding<ExponentialConeConstraint>
+MathematicalProgram::AddExponentialConeConstraint(
+    const Eigen::Ref<const Vector3<symbolic::Expression>>& z) {
+  Eigen::MatrixXd A{};
+  Eigen::VectorXd b(3);
+  VectorXDecisionVariable vars{};
+  internal::DecomposeLinearExpression(z, &A, &b, &vars);
+  return AddExponentialConeConstraint(A.sparseView(), Eigen::Vector3d(b), vars);
+}
 
 int MathematicalProgram::FindDecisionVariableIndex(const Variable& var) const {
   auto it = decision_variable_index_.find(var.get_id());

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -2146,11 +2146,36 @@ class MathematicalProgram {
   std::pair<MatrixXDecisionVariable, VectorX<symbolic::Monomial>>
   AddSosConstraint(const symbolic::Expression& e);
 
-  // template <typename FunctionType>
-  // void AddCost(std::function..);
-  // void AddLinearCost(const Eigen::MatrixBase<Derived>& c, const vector<const
-  // DecisionVariable&>& vars)
-  // void addQuadraticCost ...
+  /**
+   * Adds the exponential cone constraint, that z = binding.evaluator()->A() *
+   * binding.variables()+ binding.evaluator()->b() should be in the exponential
+   * cone. Namely {z₀, z₁, z₂ | z₀ ≥ z₁ * exp(z₂ / z₁), z₁ > 0}.
+   * @param binding The binding of ExponentialConeConstraint, and its bound
+   * variables.
+   */
+  Binding<ExponentialConeConstraint> AddConstraint(
+      const Binding<ExponentialConeConstraint>& binding);
+
+  /**
+   * Adds an exponential cone constraint, that z = A * vars + b should be in
+   * the exponential cone. Namely {z₀, z₁, z₂ | z₀ ≥ z₁ * exp(z₂ / z₁), z₁ >
+   * 0}.
+   * @param A The A matrix in the documentation above. A must have 3 rows.
+   * @param b The b vector in the documentation above.
+   * @param vars The variables bound with this constraint.
+   */
+  Binding<ExponentialConeConstraint> AddExponentialConeConstraint(
+      const Eigen::Ref<const Eigen::SparseMatrix<double>>& A,
+      const Eigen::Ref<const Eigen::Vector3d>& b,
+      const Eigen::Ref<const VectorXDecisionVariable>& vars);
+
+  /**
+   * Add the constraint that z is in the exponetial cone. 
+   * @param z The expression in the exponential cone. 
+   * @pre each entry in `z` is a linear expression of the decision variables.
+   */
+  Binding<ExponentialConeConstraint> AddExponentialConeConstraint(
+      const Eigen::Ref<const Vector3<symbolic::Expression>>& z);
 
   /**
    * Gets the initial guess for a single variable.
@@ -2384,28 +2409,34 @@ class MathematicalProgram {
     return linear_constraints_;
   }
 
-  /** Getter for Lorentz cone constraint */
+  /** Getter for Lorentz cone constraints */
   const std::vector<Binding<LorentzConeConstraint>>& lorentz_cone_constraints()
       const {
     return lorentz_cone_constraint_;
   }
 
-  /** Getter for rotated Lorentz cone constraint */
+  /** Getter for rotated Lorentz cone constraints */
   const std::vector<Binding<RotatedLorentzConeConstraint>>&
   rotated_lorentz_cone_constraints() const {
     return rotated_lorentz_cone_constraint_;
   }
 
-  /** Getter for positive semidefinite constraint */
+  /** Getter for positive semidefinite constraints */
   const std::vector<Binding<PositiveSemidefiniteConstraint>>&
   positive_semidefinite_constraints() const {
     return positive_semidefinite_constraint_;
   }
 
-  /** Getter for linear matrix inequality constraint */
+  /** Getter for linear matrix inequality constraints */
   const std::vector<Binding<LinearMatrixInequalityConstraint>>&
   linear_matrix_inequality_constraints() const {
     return linear_matrix_inequality_constraint_;
+  }
+
+  /** Getter for exponential cone constraints. */
+  const std::vector<Binding<ExponentialConeConstraint>>&
+  exponential_cone_constraints() const {
+    return exponential_cone_constraints_;
   }
 
   /**
@@ -2774,6 +2805,7 @@ class MathematicalProgram {
       positive_semidefinite_constraint_;
   std::vector<Binding<LinearMatrixInequalityConstraint>>
       linear_matrix_inequality_constraint_;
+  std::vector<Binding<ExponentialConeConstraint>> exponential_cone_constraints_;
 
   // Invariant:  The bindings in this list must be non-overlapping, when calling
   // Linear Complementarity solver like Moby. If this constraint is solved

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -2147,9 +2147,11 @@ class MathematicalProgram {
   AddSosConstraint(const symbolic::Expression& e);
 
   /**
-   * Adds the exponential cone constraint that z = binding.evaluator()->A() *
-   * binding.variables()+ binding.evaluator()->b() should be in the exponential
-   * cone. Namely {z₀, z₁, z₂ | z₀ ≥ z₁ * exp(z₂ / z₁), z₁ > 0}.
+   * Adds the exponential cone constraint that
+   * z = binding.evaluator()->A() * binding.variables() + 
+   *     binding.evaluator()->b()
+   * should be in the exponential cone. Namely
+   * {(z₀, z₁, z₂) | z₀ ≥ z₁ * exp(z₂ / z₁), z₁ > 0}.
    * @param binding The binding of ExponentialConeConstraint and its bound
    * variables.
    *
@@ -2411,25 +2413,25 @@ class MathematicalProgram {
     return linear_constraints_;
   }
 
-  /** Getter for Lorentz cone constraints */
+  /** Getter for Lorentz cone constraints. */
   const std::vector<Binding<LorentzConeConstraint>>& lorentz_cone_constraints()
       const {
     return lorentz_cone_constraint_;
   }
 
-  /** Getter for rotated Lorentz cone constraints */
+  /** Getter for rotated Lorentz cone constraints. */
   const std::vector<Binding<RotatedLorentzConeConstraint>>&
   rotated_lorentz_cone_constraints() const {
     return rotated_lorentz_cone_constraint_;
   }
 
-  /** Getter for positive semidefinite constraints */
+  /** Getter for positive semidefinite constraints. */
   const std::vector<Binding<PositiveSemidefiniteConstraint>>&
   positive_semidefinite_constraints() const {
     return positive_semidefinite_constraint_;
   }
 
-  /** Getter for linear matrix inequality constraints */
+  /** Getter for linear matrix inequality constraints. */
   const std::vector<Binding<LinearMatrixInequalityConstraint>>&
   linear_matrix_inequality_constraints() const {
     return linear_matrix_inequality_constraint_;

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -2148,7 +2148,7 @@ class MathematicalProgram {
 
   /**
    * Adds the exponential cone constraint that
-   * z = binding.evaluator()->A() * binding.variables() + 
+   * z = binding.evaluator()->A() * binding.variables() +
    *     binding.evaluator()->b()
    * should be in the exponential cone. Namely
    * {(z₀, z₁, z₂) | z₀ ≥ z₁ * exp(z₂ / z₁), z₁ > 0}.

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -2147,11 +2147,13 @@ class MathematicalProgram {
   AddSosConstraint(const symbolic::Expression& e);
 
   /**
-   * Adds the exponential cone constraint, that z = binding.evaluator()->A() *
+   * Adds the exponential cone constraint that z = binding.evaluator()->A() *
    * binding.variables()+ binding.evaluator()->b() should be in the exponential
    * cone. Namely {z₀, z₁, z₂ | z₀ ≥ z₁ * exp(z₂ / z₁), z₁ > 0}.
-   * @param binding The binding of ExponentialConeConstraint, and its bound
+   * @param binding The binding of ExponentialConeConstraint and its bound
    * variables.
+   *
+   * @exclude_from_pydrake_mkdoc{Not bound in pydrake.}
    */
   Binding<ExponentialConeConstraint> AddConstraint(
       const Binding<ExponentialConeConstraint>& binding);
@@ -2170,8 +2172,8 @@ class MathematicalProgram {
       const Eigen::Ref<const VectorXDecisionVariable>& vars);
 
   /**
-   * Add the constraint that z is in the exponetial cone. 
-   * @param z The expression in the exponential cone. 
+   * Add the constraint that z is in the exponential cone.
+   * @param z The expression in the exponential cone.
    * @pre each entry in `z` is a linear expression of the decision variables.
    */
   Binding<ExponentialConeConstraint> AddExponentialConeConstraint(

--- a/solvers/program_attribute.cc
+++ b/solvers/program_attribute.cc
@@ -44,6 +44,8 @@ std::string to_string(const ProgramAttribute& attr) {
       return "RotatedLorentzConeConstraint";
     case ProgramAttribute::kPositiveSemidefiniteConstraint:
       return "PositiveSemidefiniteConstraint";
+    case ProgramAttribute::kExponentialConeConstraint:
+      return "ExponentialConeConstraint";
     case ProgramAttribute::kBinaryVariable:
       return "BinaryVariable";
     case ProgramAttribute::kCallback:

--- a/solvers/program_attribute.h
+++ b/solvers/program_attribute.h
@@ -29,6 +29,8 @@ enum class ProgramAttribute {
 
   kPositiveSemidefiniteConstraint,  /// A positive semidefinite constraint.
 
+  kExponentialConeConstraint,  /// An exponential cone constraint.
+
   kBinaryVariable,  /// variable taking binary value {0, 1}.
 
   kCallback,  /// support callback during solving the problem.

--- a/solvers/test/constraint_test.cc
+++ b/solvers/test/constraint_test.cc
@@ -491,6 +491,26 @@ GTEST_TEST(testConstraint, testEvaluatorConstraint) {
       -1 <= y_sym[0] && y_sym[0] <= 1 && -1 <= y_sym[1] && y_sym[1] <= 1);
 }
 
+GTEST_TEST(testConstraint, testExponentialConeConstraint) {
+  Eigen::SparseMatrix<double> A(3, 2);
+  A.coeffRef(0, 0) = 2;
+  A.coeffRef(1, 1) = 3;
+  A.coeffRef(2, 0) = 1;
+  Eigen::Vector3d b(1, 2, 3);
+  ExponentialConeConstraint constraint(A, b);
+
+  Eigen::Vector2d x(3, 4);
+  Eigen::VectorXd y;
+  constraint.Eval(x, &y);
+  // Now evaluate z manually.
+  const Eigen::Vector3d z = A * x + b;
+  Eigen::Vector2d y_expected;
+  y_expected(0) = z(0) - z(1) * std::exp(z(2) / z(1));
+  y_expected(1) = z(1);
+  const double tol = 5 * std::numeric_limits<double>::epsilon();
+  EXPECT_TRUE(CompareMatrices(y, y_expected, tol));
+}
+
 }  // namespace
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -187,7 +187,7 @@ void CheckAddedIndeterminates(const MathematicalProgram& prog,
   }
 }
 
-GTEST_TEST(testMathematicalProgram, testConstructor) {
+GTEST_TEST(TestMathematicalProgram, TestConstructor) {
   MathematicalProgram prog;
   EXPECT_EQ(prog.initial_guess().rows(), 0);
   EXPECT_EQ(prog.num_vars(), 0);
@@ -197,7 +197,7 @@ GTEST_TEST(testMathematicalProgram, testConstructor) {
 #pragma GCC diagnostic pop
 }
 
-GTEST_TEST(testAddVariable, testAddContinuousVariables1) {
+GTEST_TEST(TestAddVariable, TestAddContinuousVariables1) {
   // Adds a dynamic-sized matrix of continuous variables.
   MathematicalProgram prog;
   auto X = prog.NewContinuousVariables(2, 3, "X");
@@ -206,7 +206,7 @@ GTEST_TEST(testAddVariable, testAddContinuousVariables1) {
       MathematicalProgram::VarType::CONTINUOUS);
 }
 
-GTEST_TEST(testAddVariable, testAddContinuousVariable2) {
+GTEST_TEST(TestAddVariable, TestAddContinuousVariable2) {
   // Adds a static-sized matrix of continuous variables.
   MathematicalProgram prog;
   auto X = prog.NewContinuousVariables<2, 3>("X");
@@ -215,7 +215,7 @@ GTEST_TEST(testAddVariable, testAddContinuousVariable2) {
       MathematicalProgram::VarType::CONTINUOUS);
 }
 
-GTEST_TEST(testAddVariable, testAddContinuousVariable3) {
+GTEST_TEST(TestAddVariable, TestAddContinuousVariable3) {
   // Adds a dynamic-sized vector of continuous variables.
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables(4, "x");
@@ -224,7 +224,7 @@ GTEST_TEST(testAddVariable, testAddContinuousVariable3) {
       MathematicalProgram::VarType::CONTINUOUS);
 }
 
-GTEST_TEST(testAddVariable, testAddContinuousVariable4) {
+GTEST_TEST(TestAddVariable, TestAddContinuousVariable4) {
   // Adds a static-sized vector of continuous variables.
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<4>("y");
@@ -233,7 +233,7 @@ GTEST_TEST(testAddVariable, testAddContinuousVariable4) {
       MathematicalProgram::VarType::CONTINUOUS);
 }
 
-GTEST_TEST(testAddVariable, testAddContinuousVariable5) {
+GTEST_TEST(TestAddVariable, TestAddContinuousVariable5) {
   // Adds a static-sized matrix of continuous variables.
   MathematicalProgram prog;
   auto X = prog.NewContinuousVariables<2, 3>(2, 3, "Y");
@@ -242,7 +242,7 @@ GTEST_TEST(testAddVariable, testAddContinuousVariable5) {
       MathematicalProgram::VarType::CONTINUOUS);
 }
 
-GTEST_TEST(testAddVariable, testAddContinuousVariables6) {
+GTEST_TEST(TestAddVariable, TestAddContinuousVariables6) {
   // Adds a dynamic-sized matrix of continuous variables.
   MathematicalProgram prog;
   auto X =
@@ -252,7 +252,7 @@ GTEST_TEST(testAddVariable, testAddContinuousVariables6) {
       MathematicalProgram::VarType::CONTINUOUS);
 }
 
-GTEST_TEST(testAddVariable, testAddContinuousVariables7) {
+GTEST_TEST(TestAddVariable, TestAddContinuousVariables7) {
   // Adds a dynamic-sized matrix of continuous variables.
   MathematicalProgram prog;
   auto X = prog.NewContinuousVariables<2, Eigen::Dynamic>(2, 3, "Y");
@@ -261,7 +261,7 @@ GTEST_TEST(testAddVariable, testAddContinuousVariables7) {
       MathematicalProgram::VarType::CONTINUOUS);
 }
 
-GTEST_TEST(testAddVariable, testAddContinuousVariables8) {
+GTEST_TEST(TestAddVariable, TestAddContinuousVariables8) {
   // Adds a dynamic-sized matrix of continuous variables.
   MathematicalProgram prog;
   auto X = prog.NewContinuousVariables<Eigen::Dynamic, 3>(2, 3, "Y");
@@ -270,7 +270,7 @@ GTEST_TEST(testAddVariable, testAddContinuousVariables8) {
       MathematicalProgram::VarType::CONTINUOUS);
 }
 
-GTEST_TEST(testAddVariable, testAddContinuousVariables9) {
+GTEST_TEST(TestAddVariable, TestAddContinuousVariables9) {
   // Adds continuous variables with default variable name.
   const std::string X_names = "X(0,0) X(0,1) X(0,2)\nX(1,0) X(1,1) X(1,2)\n";
   MathematicalProgram prog1;
@@ -292,7 +292,7 @@ GTEST_TEST(testAddVariable, testAddContinuousVariables9) {
       MathematicalProgram::VarType::CONTINUOUS);
 }
 
-GTEST_TEST(testAddVariable, testAddSymmetricVariable1) {
+GTEST_TEST(TestAddVariable, TestAddSymmetricVariable1) {
   // Adds a static-sized symmetric matrix of continuous variables.
   MathematicalProgram prog;
   auto X = prog.NewSymmetricContinuousVariables<3>("X");
@@ -302,7 +302,7 @@ GTEST_TEST(testAddVariable, testAddSymmetricVariable1) {
       true, MathematicalProgram::VarType::CONTINUOUS);
 }
 
-GTEST_TEST(testAddVariable, testAddSymmetricVariable2) {
+GTEST_TEST(TestAddVariable, TestAddSymmetricVariable2) {
   // Adds a dynamic-sized symmetric matrix of continuous variables.
   MathematicalProgram prog;
   auto X = prog.NewSymmetricContinuousVariables(3, "X");
@@ -312,7 +312,7 @@ GTEST_TEST(testAddVariable, testAddSymmetricVariable2) {
       true, MathematicalProgram::VarType::CONTINUOUS);
 }
 
-GTEST_TEST(testAddVariable, testAddBinaryVariable1) {
+GTEST_TEST(TestAddVariable, TestAddBinaryVariable1) {
   // Adds a dynamic-sized matrix of binary variables.
   MathematicalProgram prog;
   auto X = prog.NewBinaryVariables(2, 3, "B");
@@ -321,7 +321,7 @@ GTEST_TEST(testAddVariable, testAddBinaryVariable1) {
       MathematicalProgram::VarType::BINARY);
 }
 
-GTEST_TEST(testAddVariable, testAddBinaryVariable2) {
+GTEST_TEST(TestAddVariable, TestAddBinaryVariable2) {
   // Adds a dynamic-sized matrix of binary variables.
   MathematicalProgram prog;
   auto X = prog.NewBinaryVariables<Eigen::Dynamic, Eigen::Dynamic>(2, 3, "B");
@@ -330,7 +330,7 @@ GTEST_TEST(testAddVariable, testAddBinaryVariable2) {
       MathematicalProgram::VarType::BINARY);
 }
 
-GTEST_TEST(testAddVariable, testAddBinaryVariable3) {
+GTEST_TEST(TestAddVariable, TestAddBinaryVariable3) {
   // Adds dynamic-sized vector of binary variables.
   MathematicalProgram prog;
   auto X = prog.NewBinaryVariables(4, "B");
@@ -339,7 +339,7 @@ GTEST_TEST(testAddVariable, testAddBinaryVariable3) {
       MathematicalProgram::VarType::BINARY);
 }
 
-GTEST_TEST(testAddVariable, testAddBinaryVariable4) {
+GTEST_TEST(TestAddVariable, TestAddBinaryVariable4) {
   // Adds static-sized vector of binary variables.
   MathematicalProgram prog;
   auto X = prog.NewBinaryVariables<4>("B");
@@ -348,7 +348,7 @@ GTEST_TEST(testAddVariable, testAddBinaryVariable4) {
       MathematicalProgram::VarType::BINARY);
 }
 
-GTEST_TEST(testAddVariable, testAddBinaryVariable5) {
+GTEST_TEST(TestAddVariable, TestAddBinaryVariable5) {
   // Adds a static-sized matrix of binary variables.
   MathematicalProgram prog;
   auto X = prog.NewBinaryVariables<2, 3>("B");
@@ -357,7 +357,7 @@ GTEST_TEST(testAddVariable, testAddBinaryVariable5) {
       MathematicalProgram::VarType::BINARY);
 }
 
-GTEST_TEST(testAddVariable, testAddBinaryVariable6) {
+GTEST_TEST(TestAddVariable, TestAddBinaryVariable6) {
   // Adds a static-sized matrix of binary variables.
   MathematicalProgram prog;
   auto X = prog.NewBinaryVariables<2, 3>(2, 3, "B");
@@ -366,7 +366,7 @@ GTEST_TEST(testAddVariable, testAddBinaryVariable6) {
       MathematicalProgram::VarType::BINARY);
 }
 
-GTEST_TEST(testAddVariable, testAddBinaryVariable7) {
+GTEST_TEST(TestAddVariable, TestAddBinaryVariable7) {
   // Adds a dynamic-sized matrix of binary variables.
   MathematicalProgram prog;
   auto X = prog.NewBinaryVariables<2, Eigen::Dynamic>(2, 3, "B");
@@ -375,7 +375,7 @@ GTEST_TEST(testAddVariable, testAddBinaryVariable7) {
       MathematicalProgram::VarType::BINARY);
 }
 
-GTEST_TEST(testAddVariable, testAddBinaryVariable8) {
+GTEST_TEST(TestAddVariable, TestAddBinaryVariable8) {
   // Adds a dynamic-sized matrix of binary variables.
   MathematicalProgram prog;
   auto X = prog.NewBinaryVariables<Eigen::Dynamic, 3>(2, 3, "B");
@@ -384,7 +384,7 @@ GTEST_TEST(testAddVariable, testAddBinaryVariable8) {
       MathematicalProgram::VarType::BINARY);
 }
 
-GTEST_TEST(testAddDecisionVariables, AddDecisionVariables1) {
+GTEST_TEST(TestAddDecisionVariables, AddDecisionVariables1) {
   // Call AddVariable on an empty program.
   MathematicalProgram prog;
   const Variable x0("x0", Variable::Type::CONTINUOUS);
@@ -410,7 +410,7 @@ GTEST_TEST(testAddDecisionVariables, AddDecisionVariables1) {
 #pragma GCC diagnostic pop
 }
 
-GTEST_TEST(testAddDecisionVariables, AddVariable2) {
+GTEST_TEST(TestAddDecisionVariables, AddVariable2) {
   // Call AddDecisionVariables on a program that has some existing variables.
   MathematicalProgram prog;
   auto y = prog.NewContinuousVariables<3>("y");
@@ -437,7 +437,7 @@ GTEST_TEST(testAddDecisionVariables, AddVariable2) {
 #pragma GCC diagnostic pop
 }
 
-GTEST_TEST(testAddDecisionVariables, AddVariable3) {
+GTEST_TEST(TestAddDecisionVariables, AddVariable3) {
   // Test the error inputs.
   MathematicalProgram prog;
   auto y = prog.NewContinuousVariables<3>("y");
@@ -466,7 +466,7 @@ GTEST_TEST(testAddDecisionVariables, AddVariable3) {
                std::runtime_error);
 }
 
-GTEST_TEST(testAddIndeterminates, testAddIndeterminates1) {
+GTEST_TEST(TestAddIndeterminates, TestAddIndeterminates1) {
   // Adds a dynamic-sized matrix of Indeterminates.
   MathematicalProgram prog;
   auto X = prog.NewIndeterminates(2, 3, "X");
@@ -478,7 +478,7 @@ GTEST_TEST(testAddIndeterminates, testAddIndeterminates1) {
                            "X(0,0) X(0,1) X(0,2)\nX(1,0) X(1,1) X(1,2)\n");
 }
 
-GTEST_TEST(testAddIndeterminates, testAddIndeterminates2) {
+GTEST_TEST(TestAddIndeterminates, TestAddIndeterminates2) {
   // Adds a static-sized matrix of Indeterminates.
   MathematicalProgram prog;
   auto X = prog.NewIndeterminates<2, 3>("X");
@@ -488,7 +488,7 @@ GTEST_TEST(testAddIndeterminates, testAddIndeterminates2) {
                            "X(0,0) X(0,1) X(0,2)\nX(1,0) X(1,1) X(1,2)\n");
 }
 
-GTEST_TEST(testAddIndeterminates, testAddIndeterminates3) {
+GTEST_TEST(TestAddIndeterminates, TestAddIndeterminates3) {
   // Adds a dynamic-sized vector of Indeterminates.
   MathematicalProgram prog;
   auto x = prog.NewIndeterminates(4, "x");
@@ -498,7 +498,7 @@ GTEST_TEST(testAddIndeterminates, testAddIndeterminates3) {
   CheckAddedIndeterminates(prog, x, "x(0)\nx(1)\nx(2)\nx(3)\n");
 }
 
-GTEST_TEST(testAddIndeterminates, testAddIndeterminates4) {
+GTEST_TEST(TestAddIndeterminates, TestAddIndeterminates4) {
   // Adds a static-sized vector of Indeterminate variables.
   MathematicalProgram prog;
   auto x = prog.NewIndeterminates<4>("x");
@@ -531,7 +531,7 @@ CheckGetSolution(const MathematicalProgram& prog,
 }
 #pragma GCC diagnostic pop
 
-GTEST_TEST(testAddIndeterminates, AddIndeterminates1) {
+GTEST_TEST(TestAddIndeterminates, AddIndeterminates1) {
   // Call AddIndeterminates on an empty program.
   MathematicalProgram prog;
   const Variable x0("x0", Variable::Type::CONTINUOUS);
@@ -546,7 +546,7 @@ GTEST_TEST(testAddIndeterminates, AddIndeterminates1) {
   }
 }
 
-GTEST_TEST(testAddIndeterminates, AddIndeterminates2) {
+GTEST_TEST(TestAddIndeterminates, AddIndeterminates2) {
   // Call AddIndeterminates on a program with some indeterminates.
   MathematicalProgram prog;
   auto y = prog.NewIndeterminates<2>("y");
@@ -563,7 +563,7 @@ GTEST_TEST(testAddIndeterminates, AddIndeterminates2) {
   }
 }
 
-GTEST_TEST(testAddIndeterminates, AddIndeterminates3) {
+GTEST_TEST(TestAddIndeterminates, AddIndeterminates3) {
   // Call with erroneous inputs.
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<2>("x");
@@ -589,7 +589,7 @@ GTEST_TEST(testAddIndeterminates, AddIndeterminates3) {
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-GTEST_TEST(testGetSolution, testGetSolution1) {
+GTEST_TEST(TestGetSolution, TestGetSolution1) {
   // Tests setting and getting solution for
   // 1. A static-sized  matrix of decision variables.
   // 2. A dynamic-sized matrix of decision variables.
@@ -648,7 +648,7 @@ GTEST_TEST(testGetSolution, testGetSolution1) {
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-GTEST_TEST(testGetSolution, testGetSolution2) {
+GTEST_TEST(TestGetSolution, TestGetSolution2) {
   // GetSolution of a symbolic expression/polynomial
   MathematicalProgram prog;
   const auto x = prog.NewIndeterminates<2>();
@@ -714,7 +714,7 @@ void ExpectBadVar(MathematicalProgram* prog, int num_var, Args&&... args) {
 
 }  // namespace
 
-GTEST_TEST(testMathematicalProgram, testBadBindingVariable) {
+GTEST_TEST(TestMathematicalProgram, TestBadBindingVariable) {
   // Attempt to add a binding that does not have a valid decision variable.
   MathematicalProgram prog;
 
@@ -751,7 +751,7 @@ GTEST_TEST(testMathematicalProgram, testBadBindingVariable) {
   ExpectBadVar<EvaluatorCost<>>(&prog, 1, func);
 }
 
-GTEST_TEST(testMathematicalProgram, testAddFunction) {
+GTEST_TEST(TestMathematicalProgram, TestAddFunction) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<1>();
 
@@ -768,7 +768,7 @@ GTEST_TEST(testMathematicalProgram, testAddFunction) {
   prog.AddCost(unique_ptr<Unique>(new Unique), x);
 }
 
-GTEST_TEST(testMathematicalProgram, BoundingBoxTest2) {
+GTEST_TEST(TestMathematicalProgram, BoundingBoxTest2) {
   // Test the scalar version of the bounding box constraint methods.
 
   MathematicalProgram prog;
@@ -862,7 +862,7 @@ void VerifyAddedCost2(const MathematicalProgram& prog,
   EXPECT_TRUE(CompareMatrices(y, y_returned));
 }
 
-GTEST_TEST(testMathematicalProgram, AddCostTest) {
+GTEST_TEST(TestMathematicalProgram, AddCostTest) {
   // Test if the costs are added correctly.
 
   // There are ways to add a generic cost
@@ -953,7 +953,7 @@ void CheckAddedSymbolicLinearCost(MathematicalProgram* prog,
   CheckAddedSymbolicLinearCostUserFun(*prog, e, binding2, ++num_linear_costs);
 }
 
-GTEST_TEST(testMathematicalProgram, AddLinearCostSymbolic) {
+GTEST_TEST(TestMathematicalProgram, AddLinearCostSymbolic) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<2>();
   // Add linear cost 2 * x(0) + 3 * x(1)
@@ -976,7 +976,7 @@ GTEST_TEST(testMathematicalProgram, AddLinearCostSymbolic) {
   CheckAddedSymbolicLinearCost(&prog, x(1) * x(1) + x(0) - x(1) * x(1));
 }
 
-GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic1) {
+GTEST_TEST(TestMathematicalProgram, AddLinearConstraintSymbolic1) {
   // Add linear constraint: -10 <= 3 - 5*x0 + 10*x2 - 7*y1 <= 10
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables(3, "x");
@@ -997,7 +997,7 @@ GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic1) {
   EXPECT_TRUE((e - ub).EqualTo(Ax - ub_in_ctr));
 }
 
-GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic2) {
+GTEST_TEST(TestMathematicalProgram, AddLinearConstraintSymbolic2) {
   // Add linear constraint: -10 <= x0 <= 10
   // Note that this constraint is a bounding-box constraint which is a sub-class
   // of linear-constraint.
@@ -1021,7 +1021,7 @@ GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic2) {
   EXPECT_TRUE((e - 10).EqualTo(Ax - ub_in_ctr));
 }
 
-GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic3) {
+GTEST_TEST(TestMathematicalProgram, AddLinearConstraintSymbolic3) {
   // Add linear constraints
   //     3 <=  3 - 5*x0 +      + 10*x2        - 7*y1        <= 9
   //   -10 <=                       x2                      <= 10
@@ -1078,7 +1078,7 @@ GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic3) {
   }
 }
 
-GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic4) {
+GTEST_TEST(TestMathematicalProgram, AddLinearConstraintSymbolic4) {
   // Check the linear constraint 2  <= 2 * x <= 4.
   // Note: this is a bounding box constraint
   MathematicalProgram prog;
@@ -1099,7 +1099,7 @@ GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic4) {
       CompareMatrices(binding.evaluator()->upper_bound(), Vector1d(2)));
 }
 
-GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic5) {
+GTEST_TEST(TestMathematicalProgram, AddLinearConstraintSymbolic5) {
   // Check the linear constraint 2  <= -2 * x <= 4.
   // Note: this is a bounding box constraint
   MathematicalProgram prog;
@@ -1120,7 +1120,7 @@ GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic5) {
       CompareMatrices(binding.evaluator()->upper_bound(), Vector1d(-1)));
 }
 
-GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic6) {
+GTEST_TEST(TestMathematicalProgram, AddLinearConstraintSymbolic6) {
   // Checks the linear constraint 1 <= -x <= 3.
   // Note: this is a bounding box constraint.
   MathematicalProgram prog;
@@ -1140,7 +1140,7 @@ GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic6) {
       CompareMatrices(binding.evaluator()->upper_bound(), Vector1d(-1)));
 }
 
-GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic7) {
+GTEST_TEST(TestMathematicalProgram, AddLinearConstraintSymbolic7) {
   // Checks the linear constraints
   // 1 <= -2 * x0 <= 3
   // 3 <= 4 * x0 + 2<= 5
@@ -1172,7 +1172,7 @@ GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic7) {
                               Vector4d(-0.5, 0.75, 0.5, 0)));
 }
 
-GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic8) {
+GTEST_TEST(TestMathematicalProgram, AddLinearConstraintSymbolic8) {
   // Test the failure cases for adding linear constraint.
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<2>();
@@ -1187,7 +1187,7 @@ GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic8) {
   EXPECT_THROW(prog.AddLinearConstraint(x(0) - x(0), 1, 2), runtime_error);
 }
 
-GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic9) {
+GTEST_TEST(TestMathematicalProgram, AddLinearConstraintSymbolic9) {
   // Test trivial constraint with no variables, such as 1 <= 2 <= 3
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<2>();
@@ -1211,7 +1211,7 @@ GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolic9) {
                               Eigen::Vector2d(1, 4)));
 }
 
-GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolicFormula1) {
+GTEST_TEST(TestMathematicalProgram, AddLinearConstraintSymbolicFormula1) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<3>();
 
@@ -1240,7 +1240,7 @@ GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolicFormula1) {
   }
 }
 
-GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolicFormula2) {
+GTEST_TEST(TestMathematicalProgram, AddLinearConstraintSymbolicFormula2) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<3>();
 
@@ -1269,7 +1269,7 @@ GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolicFormula2) {
   }
 }
 
-GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolicFormula3) {
+GTEST_TEST(TestMathematicalProgram, AddLinearConstraintSymbolicFormula3) {
   // x(0) + x(2) == 1
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<3>();
@@ -1296,7 +1296,7 @@ GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolicFormula3) {
   }
 }
 
-GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolicFormula4) {
+GTEST_TEST(TestMathematicalProgram, AddLinearConstraintSymbolicFormula4) {
   // x(0) + 2 * x(2) <= 1
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<3>();
@@ -1333,7 +1333,7 @@ GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolicFormula4) {
   }
 }
 
-GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolicFormula5) {
+GTEST_TEST(TestMathematicalProgram, AddLinearConstraintSymbolicFormula5) {
   MathematicalProgram prog;
   const auto x = prog.NewContinuousVariables<1>();
   const double inf = std::numeric_limits<double>::infinity();
@@ -1359,7 +1359,7 @@ GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolicFormula5) {
   }
 }
 
-GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolicFormula6) {
+GTEST_TEST(TestMathematicalProgram, AddLinearConstraintSymbolicFormula6) {
   MathematicalProgram prog;
   const auto x = prog.NewContinuousVariables<2>();
   const double inf = std::numeric_limits<double>::infinity();
@@ -1381,7 +1381,7 @@ GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolicFormula6) {
   }
 }
 
-GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolicFormula7) {
+GTEST_TEST(TestMathematicalProgram, AddLinearConstraintSymbolicFormula7) {
   MathematicalProgram prog;
   const auto x = prog.NewContinuousVariables<2>();
   const double inf = std::numeric_limits<double>::infinity();
@@ -1403,7 +1403,7 @@ GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolicFormula7) {
   }
 }
 
-GTEST_TEST(testMathematicalProgram,
+GTEST_TEST(TestMathematicalProgram,
            AddLinearConstraintSymbolicFormulaException1) {
   MathematicalProgram prog;
   const auto x = prog.NewContinuousVariables<2>();
@@ -1414,7 +1414,7 @@ GTEST_TEST(testMathematicalProgram,
   EXPECT_THROW(prog.AddLinearConstraint(x(0) <= x(1) - inf), runtime_error);
 }
 
-GTEST_TEST(testMathematicalProgram,
+GTEST_TEST(TestMathematicalProgram,
            AddLinearConstraintSymbolicFormulaException2) {
   MathematicalProgram prog;
   const auto x = prog.NewContinuousVariables<2>();
@@ -1444,7 +1444,7 @@ GTEST_TEST(testMathematicalProgram,
                runtime_error);
 }
 
-GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolicFormulaAnd1) {
+GTEST_TEST(TestMathematicalProgram, AddLinearConstraintSymbolicFormulaAnd1) {
   // Add linear constraints
   //
   //   (A*x == b) = |1 2| * |x0| == |5|
@@ -1485,7 +1485,7 @@ GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolicFormulaAnd1) {
   EXPECT_EQ(constraint_set.count(Ax(1) - ub_in_ctr(1)), 1);
 }
 
-GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolicFormulaAnd2) {
+GTEST_TEST(TestMathematicalProgram, AddLinearConstraintSymbolicFormulaAnd2) {
   // Add linear constraints f1 && f2 && f3 where
   //   f1 := (x0 + 2*x1 >= 3)
   //   f2 := (3*x0 + 4*x1 <= 5)
@@ -1532,7 +1532,7 @@ GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolicFormulaAnd2) {
   }
 }
 
-GTEST_TEST(testMathematicalProgram,
+GTEST_TEST(TestMathematicalProgram,
            AddLinearConstraintSymbolicFormulaAndException) {
   // Add linear constraints:
   //   (x0 + 2*x1 > 3)
@@ -1556,7 +1556,7 @@ GTEST_TEST(testMathematicalProgram,
 }
 
 // Checks AddLinearConstraint function which takes an Eigen::Array<Formula>.
-GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolicArrayFormula1) {
+GTEST_TEST(TestMathematicalProgram, AddLinearConstraintSymbolicArrayFormula1) {
   // Add linear constraints
   //    3 - 5*x0 +      + 10*x2        - 7*y1         >= 3
   //                         x2                       >= -10
@@ -1610,7 +1610,7 @@ GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolicArrayFormula1) {
 // Checks AddLinearConstraint function which takes an Eigen::Array<Formula>.
 // This test uses operator>= provided for Eigen::Array<Expression> and
 // Eigen::Array<double>.
-GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolicArrayFormula2) {
+GTEST_TEST(TestMathematicalProgram, AddLinearConstraintSymbolicArrayFormula2) {
   // Add linear constraints
   //
   //     M_f = |f1 f2|
@@ -1652,7 +1652,7 @@ GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolicArrayFormula2) {
 }
 
 // Checks AddLinearConstraint function which takes an Eigen::Array<Formula>.
-GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolicArrayFormula3) {
+GTEST_TEST(TestMathematicalProgram, AddLinearConstraintSymbolicArrayFormula3) {
   // Add linear constraints
   //
   //   (A*x >= b) = |1 2| * |x0| >= |5|
@@ -1686,7 +1686,7 @@ GTEST_TEST(testMathematicalProgram, AddLinearConstraintSymbolicArrayFormula3) {
 }
 
 // Checks AddLinearConstraint function which takes an Eigen::Array<Formula>.
-GTEST_TEST(testMathematicalProgram,
+GTEST_TEST(TestMathematicalProgram,
            AddLinearConstraintSymbolicArrayFormulaException) {
   // Add linear constraints
   //    3 - 5*x0 + 10*x2 - 7*y1 >  3
@@ -1771,7 +1771,7 @@ void CheckAddedNonSymmetricSymbolicLinearEqualityConstraint(
 }
 }  // namespace
 
-GTEST_TEST(testMathematicalProgram, AddSymbolicLinearEqualityConstraint1) {
+GTEST_TEST(TestMathematicalProgram, AddSymbolicLinearEqualityConstraint1) {
   // Checks the single row linear equality constraint one by one:
 
   MathematicalProgram prog;
@@ -1823,7 +1823,7 @@ GTEST_TEST(testMathematicalProgram, AddSymbolicLinearEqualityConstraint1) {
       &prog, x(0) + 2 * (x(0) + x(2)) + 3 * (x(0) - x(1)), 3);
 }
 
-GTEST_TEST(testMathematicalProgram, AddSymbolicLinearEqualityConstraint2) {
+GTEST_TEST(TestMathematicalProgram, AddSymbolicLinearEqualityConstraint2) {
   // Checks adding multiple rows of linear equality constraints.
 
   MathematicalProgram prog;
@@ -1849,7 +1849,7 @@ GTEST_TEST(testMathematicalProgram, AddSymbolicLinearEqualityConstraint2) {
       &prog, Vector3<Expression>(+x(0), 1, -x(1)), Eigen::Vector3d(4, 1, 2));
 }
 
-GTEST_TEST(testMathematicalProgram, AddSymbolicLinearEqualityConstraint3) {
+GTEST_TEST(TestMathematicalProgram, AddSymbolicLinearEqualityConstraint3) {
   // Checks adding a matrix of linear equality constraints. This matrix is not
   // symmetric.
   MathematicalProgram prog;
@@ -1876,7 +1876,7 @@ GTEST_TEST(testMathematicalProgram, AddSymbolicLinearEqualityConstraint3) {
                                                          B_dynamic);
 }
 
-GTEST_TEST(testMathematicalProgram, AddSymbolicLinearEqualityConstraint4) {
+GTEST_TEST(TestMathematicalProgram, AddSymbolicLinearEqualityConstraint4) {
   // Checks adding a symmetric matrix of linear equality constraints.
   MathematicalProgram prog;
   auto X = prog.NewSymmetricContinuousVariables<2>("X");
@@ -1914,7 +1914,7 @@ GTEST_TEST(testMathematicalProgram, AddSymbolicLinearEqualityConstraint4) {
 // Tests `AddLinearEqualityConstraint(const symbolic::Formula& f)` method with a
 // case where `f` is a linear-equality formula (instead of a conjunction of
 // them).
-GTEST_TEST(testMathematicalProgram, AddSymbolicLinearEqualityConstraint5) {
+GTEST_TEST(TestMathematicalProgram, AddSymbolicLinearEqualityConstraint5) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<3>("x");
   // f = (3x₀ + 2x₁ + 3 == 5).
@@ -1937,7 +1937,7 @@ GTEST_TEST(testMathematicalProgram, AddSymbolicLinearEqualityConstraint5) {
 
 // Tests `AddLinearEqualityConstraint(const symbolic::Formula& f)` method with a
 // case where `f` is a conjunction of linear-equality formulas .
-GTEST_TEST(testMathematicalProgram, AddSymbolicLinearEqualityConstraint6) {
+GTEST_TEST(TestMathematicalProgram, AddSymbolicLinearEqualityConstraint6) {
   // Test problem: Ax = b where
   //
   // A = |-3.0  0.0  2.0|  x = |x0|  b = | 9.0|
@@ -1976,7 +1976,7 @@ GTEST_TEST(testMathematicalProgram, AddSymbolicLinearEqualityConstraint6) {
 
 // Checks if `AddLinearEqualityConstraint(f)` throws std::runtime_error if `f`
 // is a non-linear equality formula.
-GTEST_TEST(testMathematicalProgram,
+GTEST_TEST(TestMathematicalProgram,
            AddSymbolicLinearEqualityConstraintException1) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<2>("x");
@@ -1987,7 +1987,7 @@ GTEST_TEST(testMathematicalProgram,
 
 // Checks if `AddLinearEqualityConstraint(f)` throws std::runtime_error if a
 // conjunctive formula `f` includes a relational formula other than equality.
-GTEST_TEST(testMathematicalProgram,
+GTEST_TEST(TestMathematicalProgram,
            AddSymbolicLinearEqualityConstraintException2) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<2>("x");
@@ -1998,7 +1998,7 @@ GTEST_TEST(testMathematicalProgram,
 
 // Checks if `AddLinearEqualityConstraint(f)` throws std::runtime_error if `f`
 // is neither a linear-equality formula nor a conjunctive formula.
-GTEST_TEST(testMathematicalProgram,
+GTEST_TEST(TestMathematicalProgram,
            AddSymbolicLinearEqualityConstraintException3) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<2>("x");
@@ -2224,7 +2224,7 @@ TEST_F(SymbolicLorentzConeTest, TestError) {
                runtime_error);
 }
 
-GTEST_TEST(testMathematicalProgram, AddSymbolicRotatedLorentzConeConstraint1) {
+GTEST_TEST(TestMathematicalProgram, AddSymbolicRotatedLorentzConeConstraint1) {
   // Add rotated Lorentz cone constraint:
   // x is in the rotated Lorentz cone constraint.
   MathematicalProgram prog;
@@ -2234,7 +2234,7 @@ GTEST_TEST(testMathematicalProgram, AddSymbolicRotatedLorentzConeConstraint1) {
   CheckParsedSymbolicRotatedLorentzConeConstraint(&prog, e);
 }
 
-GTEST_TEST(testMathematicalProgram, AddSymbolicRotatedLorentzConeConstraint2) {
+GTEST_TEST(TestMathematicalProgram, AddSymbolicRotatedLorentzConeConstraint2) {
   // Add rotated Lorentz cone constraint:
   // [x(0) + 2 * x(2)]
   // [x(0)           ] is in the rotated Lorentz cone
@@ -2246,7 +2246,7 @@ GTEST_TEST(testMathematicalProgram, AddSymbolicRotatedLorentzConeConstraint2) {
   CheckParsedSymbolicRotatedLorentzConeConstraint(&prog, e);
 }
 
-GTEST_TEST(testMathematicalProgram, AddSymbolicRotatedLorentzConeConstraint3) {
+GTEST_TEST(TestMathematicalProgram, AddSymbolicRotatedLorentzConeConstraint3) {
   // Add rotated Lorentz cone constraint:
   // [x(0) + 1]
   // [x(1) + 2] is in the rotated Lorentz cone
@@ -2260,7 +2260,7 @@ GTEST_TEST(testMathematicalProgram, AddSymbolicRotatedLorentzConeConstraint3) {
   CheckParsedSymbolicRotatedLorentzConeConstraint(&prog, e);
 }
 
-GTEST_TEST(testMathematicalProgram, AddSymbolicRotatedLorentzConeConstraint4) {
+GTEST_TEST(TestMathematicalProgram, AddSymbolicRotatedLorentzConeConstraint4) {
   // Add rotated Lorentz cone constraint:
   // [2 * x(0) + 3 * x(2) + 3]
   // [    x(0) - 4 * x(2)    ] is in the rotated Lorentz cone
@@ -2274,7 +2274,7 @@ GTEST_TEST(testMathematicalProgram, AddSymbolicRotatedLorentzConeConstraint4) {
   CheckParsedSymbolicRotatedLorentzConeConstraint(&prog, e);
 }
 
-GTEST_TEST(testMathematicalProgram, AddSymbolicRotatedLorentzConeConstraint5) {
+GTEST_TEST(TestMathematicalProgram, AddSymbolicRotatedLorentzConeConstraint5) {
   // Add rotated Lorentz cone constraint, using quadratic expression.
   MathematicalProgram prog;
   const auto x = prog.NewContinuousVariables<4>("x");
@@ -2337,7 +2337,7 @@ CheckAddedSymbolicPositiveSemidefiniteConstraint(
 }
 }  // namespace
 
-GTEST_TEST(testMathematicalProgram, AddPositiveSemidefiniteConstraint) {
+GTEST_TEST(TestMathematicalProgram, AddPositiveSemidefiniteConstraint) {
   MathematicalProgram prog;
   auto X = prog.NewSymmetricContinuousVariables<4>("X");
 
@@ -2381,7 +2381,7 @@ GTEST_TEST(testMathematicalProgram, AddPositiveSemidefiniteConstraint) {
   CheckAddedSymbolicPositiveSemidefiniteConstraint(&prog, Y);
 }
 
-GTEST_TEST(testMathematicalProgram, testExponentialConeConstraint) {
+GTEST_TEST(TestMathematicalProgram, TestExponentialConeConstraint) {
   MathematicalProgram prog;
   EXPECT_EQ(prog.required_capabilities().count(
                 ProgramAttribute::kExponentialConeConstraint), 0);
@@ -2414,7 +2414,7 @@ void CheckAddedQuadraticCost(MathematicalProgram* prog,
   EXPECT_EQ(cnstr->b(), b);
 }
 
-GTEST_TEST(testMathematicalProgram, AddQuadraticCost) {
+GTEST_TEST(TestMathematicalProgram, AddQuadraticCost) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<3>();
 
@@ -2450,7 +2450,7 @@ void CheckAddedSymbolicQuadraticCost(MathematicalProgram* prog,
                                          ++num_quadratic_cost);
 }
 
-GTEST_TEST(testMathematicalProgram, AddSymbolicQuadraticCost) {
+GTEST_TEST(TestMathematicalProgram, AddSymbolicQuadraticCost) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<3>();
 
@@ -2488,7 +2488,7 @@ GTEST_TEST(testMathematicalProgram, AddSymbolicQuadraticCost) {
   EXPECT_THROW(prog.AddQuadraticCost(e8), runtime_error);
 }
 
-GTEST_TEST(testMathematicalProgram, TestL2NormCost) {
+GTEST_TEST(TestMathematicalProgram, TestL2NormCost) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<2>();
 
@@ -2624,7 +2624,7 @@ void CheckAddedPolynomialCost(MathematicalProgram* prog, const Expression& e) {
   EXPECT_TRUE(ArePolynomialIsomorphic(poly, poly_expected, var_id_to_var));
 }
 
-GTEST_TEST(testMathematicalProgram, testAddPolynomialCost) {
+GTEST_TEST(TestMathematicalProgram, TestAddPolynomialCost) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<2>();
   // Add a cubic cost
@@ -2638,7 +2638,7 @@ GTEST_TEST(testMathematicalProgram, testAddPolynomialCost) {
       &prog, x(0) * x(0) * x(1) * x(1) + pow(x(0), 3) * x(1) + 2 * x(1));
 }
 
-GTEST_TEST(testMathematicalProgram, testAddCostThrowError) {
+GTEST_TEST(TestMathematicalProgram, TestAddCostThrowError) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<2>();
 
@@ -2651,7 +2651,7 @@ GTEST_TEST(testMathematicalProgram, testAddCostThrowError) {
   EXPECT_THROW(prog.AddCost(x(0) * x(0) + y), runtime_error);
 }
 
-GTEST_TEST(testMathematicalProgram, testAddGenericCost) {
+GTEST_TEST(TestMathematicalProgram, TestAddGenericCost) {
   using GenericPtr = shared_ptr<Cost>;
   using Matrix1d = Vector1d;
 
@@ -2667,7 +2667,7 @@ GTEST_TEST(testMathematicalProgram, testAddGenericCost) {
   EXPECT_EQ(prog.quadratic_costs().size(), 1);
 }
 
-GTEST_TEST(testMathematicalProgram, testClone) {
+GTEST_TEST(TestMathematicalProgram, TestClone) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<3>("x");
   auto y = prog.NewIndeterminates<2>("y");
@@ -2790,7 +2790,7 @@ GTEST_TEST(testMathematicalProgram, testClone) {
 #pragma GCC diagnostic pop
 }
 
-GTEST_TEST(testMathematicalProgram, testEvalBinding) {
+GTEST_TEST(TestMathematicalProgram, TestEvalBinding) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<3>();
 
@@ -2836,7 +2836,7 @@ GTEST_TEST(testMathematicalProgram, testEvalBinding) {
   EXPECT_THROW(prog.EvalBinding(quadratic_cost_y, x_val), std::runtime_error);
 }
 
-GTEST_TEST(testMathematicalProgram, testSetAndGetInitialGuess) {
+GTEST_TEST(TestMathematicalProgram, TestSetAndGetInitialGuess) {
   MathematicalProgram prog;
   const auto x = prog.NewContinuousVariables<3>();
 
@@ -2869,7 +2869,7 @@ GTEST_TEST(testMathematicalProgram, testSetAndGetInitialGuess) {
       std::exception);
 }
 
-GTEST_TEST(testMathematicalProgram, testNonlinearExpressionConstraints) {
+GTEST_TEST(TestMathematicalProgram, TestNonlinearExpressionConstraints) {
   // min ∑ x , subject to x'x = 1.
   MathematicalProgram prog;
   const auto x = prog.NewContinuousVariables<2>();
@@ -2896,7 +2896,7 @@ GTEST_TEST(testMathematicalProgram, testNonlinearExpressionConstraints) {
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-GTEST_TEST(testMathematicalProgram, testSetSolverResult) {
+GTEST_TEST(TestMathematicalProgram, TestSetSolverResult) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<2>();
 
@@ -2939,7 +2939,7 @@ GTEST_TEST(testMathematicalProgram, testSetSolverResult) {
 }
 #pragma GCC diagnostic pop
 
-GTEST_TEST(testMathematicalProgram, testAddVisualizationCallback) {
+GTEST_TEST(TestMathematicalProgram, TestAddVisualizationCallback) {
   MathematicalProgram prog;
 
   auto x = prog.NewContinuousVariables<2>();
@@ -2982,7 +2982,7 @@ GTEST_TEST(testMathematicalProgram, testAddVisualizationCallback) {
   EXPECT_TRUE(was_called);
 }
 
-GTEST_TEST(testMathematicalProgram, TestSolverOptions) {
+GTEST_TEST(TestMathematicalProgram, TestSolverOptions) {
   MathematicalProgram prog;
   const SolverId solver_id("solver_id");
   const SolverId wrong_solver_id("wrong_solver_id");
@@ -3002,7 +3002,7 @@ GTEST_TEST(testMathematicalProgram, TestSolverOptions) {
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-GTEST_TEST(testMathematicalProgram, TestGetSolution) {
+GTEST_TEST(TestMathematicalProgram, TestGetSolution) {
   // Test GetSolution(var, result)
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<2>();
@@ -3054,7 +3054,7 @@ void CheckNewNonnegativePolynomial(
   EXPECT_TRUE(p.EqualTo(p_expected));
 }
 
-GTEST_TEST(testMathematicalProgram, NewNonnegativePolynomial) {
+GTEST_TEST(TestMathematicalProgram, NewNonnegativePolynomial) {
   CheckNewNonnegativePolynomial(
       MathematicalProgram::NonnegativePolynomial::kSos);
   CheckNewNonnegativePolynomial(


### PR DESCRIPTION
As mentioned in #11101 , we will need to support exponential cone (this is requested by @pangtao22 ). This is the first step to add exponential cone into MathematicalProgram.

Currently none of our `SolverInterface` class (like `MosekSolver` or `ScsSolver`) parses the exponential cone constraint. There will be follow-on PRs to support the constraint for Mosek and SCS solver.

cc @pangtao22

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11147)
<!-- Reviewable:end -->
