### PR TITLE
bazelrc: Require `gen/` artifacts

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,9 +2,7 @@
 import %workspace%/tools/bazel.rc
 
 # Import environment-specific configuration.
-# TODO(eric.cousineau): Make this required once CI is configured to always run
-# `install_prereqs_user_environment`.
-try-import %workspace%/gen/environment.bazelrc
+import %workspace%/gen/environment.bazelrc
 
 # Try to import user-specific configuration local to workspace.
 try-import %workspace%/user.bazelrc


### PR DESCRIPTION
Follow-up to #10257

Slack convo: https://drakedevelopers.slack.com/archives/C0KDGF4V9/p1554337575008300

> Would anyone object to me hoisting the `gen/*.bazelrc` bits to be required, rather than optional?
I've found myself invalidating my cache because sometimes I build with / without it there (esp. when switching between Python 2 / 3) 

Didn't realize I had actually put a TODO to this effect... D'oh!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11149)
<!-- Reviewable:end -->
