### PR TITLE
py systems: Demote `_{NAME}` deprecation to trigger on function call

### DIFF
--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -57,14 +57,15 @@ void AddDeprecatedProtectedAliases(
         DeprecatedProtectedAliasMessage(name, "call");
     py::handle cls_handle = *cls;
     cls->def(alias.c_str(),
-        [cls_handle, name](py::object self, py::args args, py::kwargs kwargs) {
+        [cls_handle, name, deprecation](
+            py::object self, py::args args, py::kwargs kwargs) {
           // N.B. Trying to capture a `py::handle` for `original` does not work
           // and causes segfaults.
           py::object original = cls_handle.attr(name.c_str());
+          WarnDeprecated(deprecation);
           return original(self, *args, **kwargs);
         },
         deprecation.c_str());
-    DeprecateAttribute(*cls, alias, deprecation);
   }
 }
 

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -330,8 +330,7 @@ class TestCustom(unittest.TestCase):
         self.assertTrue(system.called_publish)
 
         # Ensure documentation doesn't duplicate stuff.
-        with catch_drake_warnings(expected_count=1):
-            self.assertIn("deprecated", LeafSystem._DoPublish.__doc__)
+        self.assertIn("deprecated", LeafSystem._DoPublish.__doc__)
         # This will warn both on (a) calling the method and (b) on the
         # invocation of the override.
         with catch_drake_warnings(expected_count=2):


### PR DESCRIPTION
If used as a property deprecation, it can triggered by `py::get_overload`.
This was missed because of some bug in either
(a) `pybind11` (our fork or the real thing) or (b) CPython.

Resolves #11138

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11150)
<!-- Reviewable:end -->
