### PR TITLE
systems/lcm: Deprecate MakeFixedSize

### DIFF
--- a/examples/kuka_iiwa_arm/iiwa_wsg_simulation.cc
+++ b/examples/kuka_iiwa_arm/iiwa_wsg_simulation.cc
@@ -161,8 +161,8 @@ int DoMain() {
 
   // Create the command subscriber and status publisher.
   auto iiwa_command_sub = builder.AddSystem(
-      MakeIiwaCommandLcmSubscriberSystem(
-          kIiwaArmNumJoints, "IIWA_COMMAND", lcm));
+      systems::lcm::LcmSubscriberSystem::Make<drake::lcmt_iiwa_command>(
+          "IIWA_COMMAND", lcm));
   iiwa_command_sub->set_name("iiwa_command_subscriber");
   auto iiwa_command_receiver = builder.AddSystem<IiwaCommandReceiver>();
   iiwa_command_receiver->set_name("iwwa_command_receiver");
@@ -219,8 +219,8 @@ int DoMain() {
                   iiwa_status_pub->get_input_port());
 
   auto wsg_command_sub = builder.AddSystem(
-      systems::lcm::LcmSubscriberSystem::MakeFixedSize(
-          lcmt_schunk_wsg_command{}, "SCHUNK_WSG_COMMAND", lcm));
+      systems::lcm::LcmSubscriberSystem::Make<lcmt_schunk_wsg_command>(
+          "SCHUNK_WSG_COMMAND", lcm));
   wsg_command_sub->set_name("wsg_command_subscriber");
   auto wsg_controller = builder.AddSystem<SchunkWsgController>();
 

--- a/examples/kuka_iiwa_arm/kuka_simulation.cc
+++ b/examples/kuka_iiwa_arm/kuka_simulation.cc
@@ -110,8 +110,8 @@ int DoMain() {
 
   // Create the command subscriber and status publisher.
   auto command_sub = base_builder->AddSystem(
-      MakeIiwaCommandLcmSubscriberSystem(
-          num_joints, "IIWA_COMMAND", lcm));
+      systems::lcm::LcmSubscriberSystem::Make<drake::lcmt_iiwa_command>(
+          "IIWA_COMMAND", lcm));
   command_sub->set_name("command_subscriber");
   auto command_receiver =
       base_builder->AddSystem<IiwaCommandReceiver>(num_joints);

--- a/examples/manipulation_station/mock_station_simulation.cc
+++ b/examples/manipulation_station/mock_station_simulation.cc
@@ -71,8 +71,8 @@ int do_main(int argc, char* argv[]) {
   auto lcm = builder.AddSystem<systems::lcm::LcmInterfaceSystem>();
 
   auto iiwa_command_subscriber = builder.AddSystem(
-      kuka_iiwa_arm::MakeIiwaCommandLcmSubscriberSystem(
-          kuka_iiwa_arm::kIiwaArmNumJoints, "IIWA_COMMAND", lcm));
+      systems::lcm::LcmSubscriberSystem::Make<drake::lcmt_iiwa_command>(
+          "IIWA_COMMAND", lcm));
   auto iiwa_command = builder.AddSystem<kuka_iiwa_arm::IiwaCommandReceiver>();
   builder.Connect(iiwa_command_subscriber->get_output_port(),
                   iiwa_command->GetInputPort("command_message"));
@@ -104,8 +104,8 @@ int do_main(int argc, char* argv[]) {
 
   // Receive the WSG commands.
   auto wsg_command_subscriber = builder.AddSystem(
-      systems::lcm::LcmSubscriberSystem::MakeFixedSize(
-          drake::lcmt_schunk_wsg_command{}, "SCHUNK_WSG_COMMAND", lcm));
+      systems::lcm::LcmSubscriberSystem::Make<drake::lcmt_schunk_wsg_command>(
+          "SCHUNK_WSG_COMMAND", lcm));
   auto wsg_command =
       builder.AddSystem<manipulation::schunk_wsg::SchunkWsgCommandReceiver>();
   builder.Connect(wsg_command_subscriber->get_output_port(),

--- a/examples/schunk_wsg/schunk_wsg_simulation.cc
+++ b/examples/schunk_wsg/schunk_wsg_simulation.cc
@@ -56,8 +56,8 @@ int DoMain() {
       builder.AddSystem<DrakeVisualizer>(tree, lcm);
   visualizer->set_name("visualizer");
   auto command_sub = builder.AddSystem(
-      systems::lcm::LcmSubscriberSystem::MakeFixedSize(
-          lcmt_schunk_wsg_command{}, "SCHUNK_WSG_COMMAND", lcm));
+      systems::lcm::LcmSubscriberSystem::Make<lcmt_schunk_wsg_command>(
+          "SCHUNK_WSG_COMMAND", lcm));
   command_sub->set_name("command_subscriber");
 
   auto wsg_controller = builder.AddSystem<SchunkWsgController>();

--- a/manipulation/kuka_iiwa/iiwa_command_receiver.cc
+++ b/manipulation/kuka_iiwa/iiwa_command_receiver.cc
@@ -170,15 +170,10 @@ void IiwaCommandReceiver::CalcStateOutput(
 
 std::unique_ptr<systems::lcm::LcmSubscriberSystem>
 MakeIiwaCommandLcmSubscriberSystem(
-    int num_joints, const std::string& channel,
+    int, const std::string& channel,
     drake::lcm::DrakeLcmInterface* lcm) {
-  drake::lcmt_iiwa_command message_size_exemplar;
-  message_size_exemplar.num_joints = num_joints;
-  message_size_exemplar.joint_position.resize(num_joints);
-  message_size_exemplar.num_torques = num_joints;
-  message_size_exemplar.joint_torque.resize(num_joints);
-  return systems::lcm::LcmSubscriberSystem::MakeFixedSize(
-      message_size_exemplar, channel, lcm);
+  return systems::lcm::LcmSubscriberSystem::Make<drake::lcmt_iiwa_command>(
+      channel, lcm);
 }
 
 }  // namespace kuka_iiwa

--- a/manipulation/kuka_iiwa/iiwa_command_receiver.h
+++ b/manipulation/kuka_iiwa/iiwa_command_receiver.h
@@ -20,7 +20,7 @@ namespace kuka_iiwa {
 ///
 /// Note that this system does not actually subscribe to an LCM channel. To
 /// receive the message, the input of this system should be connected to a
-/// MakeIiwaCommandLcmSubscriberSystem().
+/// LcmSubscriberSystem::Make<drake::lcmt_iiwa_command>().
 ///
 /// It has one input port, "lcmt_iiwa_command".
 /// (As well as some deprecated input ports; see below.)
@@ -95,8 +95,9 @@ class IiwaCommandReceiver : public systems::LeafSystem<double> {
   const systems::CacheEntry* groomed_input_{};
 };
 
-/// Creates a LcmSubscriberSystem for lcmt_iiwa_command, using the fixed-size
-/// message optimization; see LcmSubscriberSystem::MakeFixedSize for details.
+/// Creates a LcmSubscriberSystem for lcmt_iiwa_command.
+DRAKE_DEPRECATED("2019-07-01",
+    "Call LcmSubscriberSystem::Make<drake::lcmt_iiwa_command> instead.")
 std::unique_ptr<systems::lcm::LcmSubscriberSystem>
 MakeIiwaCommandLcmSubscriberSystem(
     int num_joints, const std::string& channel,

--- a/systems/lcm/lcm_subscriber_system.h
+++ b/systems/lcm/lcm_subscriber_system.h
@@ -75,6 +75,7 @@ class LcmSubscriberSystem : public LeafSystem<double> {
    * System must be no larger than this encoded size.
    */
   template <typename LcmMessage>
+  DRAKE_DEPRECATED("2019-05-01", "Use Make<LcmMessage>() instead.")
   static std::unique_ptr<LcmSubscriberSystem> MakeFixedSize(
       const LcmMessage& exemplar, const std::string& channel,
       drake::lcm::DrakeLcmInterface* lcm) {

--- a/systems/lcm/test/lcm_subscriber_system_test.cc
+++ b/systems/lcm/test/lcm_subscriber_system_test.cc
@@ -177,6 +177,8 @@ GTEST_TEST(LcmSubscriberSystemTest, SerializerTest) {
   EXPECT_TRUE(CompareLcmtDrakeSignalMessages(value, sample_data.value));
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 // Tests LcmSubscriberSystem using a fixed-size Serializer.
 GTEST_TEST(LcmSubscriberSystemTest, FixedSizeSerializerTest) {
   drake::lcm::DrakeMockLcm lcm;
@@ -212,6 +214,7 @@ GTEST_TEST(LcmSubscriberSystemTest, FixedSizeSerializerTest) {
   auto small_value = small_abstract_value->get_value<lcmt_drake_signal>();
   EXPECT_TRUE(CompareLcmtDrakeSignalMessages(small_value, smaller_data.value));
 }
+#pragma GCC diagnostic pop
 
 GTEST_TEST(LcmSubscriberSystemTest, WaitTest) {
   // Ensure that `WaitForMessage` works as expected.


### PR DESCRIPTION
Given recent performance improvements within the framework (#11125), this subscriber-internal performance optimization is no longer necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11158)
<!-- Reviewable:end -->
