### PR TITLE
manipulation_station: Initialize q0 from robot in teleop --hardware

### DIFF
--- a/examples/manipulation_station/end_effector_teleop_mouse.py
+++ b/examples/manipulation_station/end_effector_teleop_mouse.py
@@ -331,12 +331,16 @@ builder.Connect(teleop.GetOutputPort("force_limit"),
 diagram = builder.Build()
 simulator = Simulator(diagram)
 
+# This is important to avoid duplicate publishes to the hardware interface:
+simulator.set_publish_every_time_step(False)
+
 station_context = diagram.GetMutableSubsystemContext(
     station, simulator.get_mutable_context())
 
 station_context.FixInputPort(station.GetInputPort(
     "iiwa_feedforward_torque").get_index(), np.zeros(7))
 
+simulator.AdvanceTo(1e-6)
 q0 = station.GetOutputPort("iiwa_position_measured").Eval(station_context)
 differential_ik.parameters.set_nominal_joint_position(q0)
 
@@ -348,9 +352,6 @@ filter.set_initial_output_value(
         teleop, simulator.get_mutable_context())))
 differential_ik.SetPositions(diagram.GetMutableSubsystemContext(
     differential_ik, simulator.get_mutable_context()), q0)
-
-# This is important to avoid duplicate publishes to the hardware interface:
-simulator.set_publish_every_time_step(False)
 
 simulator.set_target_realtime_rate(args.target_realtime_rate)
 


### PR DESCRIPTION
Closes #11159.

The manipulation_station teleop controllers (slider, mouse, joystick, etc.) assume that if they Eval the `iiwa_position` output port prior to the simulation, they will be told the current q, which they then use to initialize their starting q for control.  Under `--hardware`, this is wrong!  LCM messages should not appear on an output port until the Diagram's events are processed!

This oversight was masked previously because we had a bug #10464 where the output ports _did_ initialize the first time a Context was created, i.e., when the Simulator was created.  In #10476 (in January), I fixed that and probably broke `--hardware`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11162)
<!-- Reviewable:end -->
