### PR TITLE
py math: Add workaround for logical ops for np.ndarray[Expression]

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -178,6 +178,7 @@ drake_pybind_library(
         ":module_py",
         "//bindings/pydrake/common:eigen_geometry_py",
     ],
+    py_srcs = ["_math_extra.py"],
 )
 
 drake_pybind_library(

--- a/bindings/pydrake/_math_extra.py
+++ b/bindings/pydrake/_math_extra.py
@@ -1,0 +1,16 @@
+import operator
+
+import numpy as np
+
+# Add generic logical operators as ufuncs so that we may do comparisons on
+# arrays of any scalar type, without restriction on the output type.
+# These are added solely to work around #8315, where arrays of Expression can't
+# use direct logical operators (e.g. `<=`) since the output type is not bool.
+# N.B. Defined in order listed in Python documentation:
+# https://docs.python.org/3.6/library/operator.html
+lt = np.vectorize(operator.lt)
+le = np.vectorize(operator.le)
+eq = np.vectorize(operator.eq)
+ne = np.vectorize(operator.ne)
+ge = np.vectorize(operator.ge)
+gt = np.vectorize(operator.gt)

--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -286,6 +286,8 @@ PYBIND11_MODULE(math, m) {
     mtest.def(
         "TakeRigidTransform", [](const RigidTransform<T>&) { return true; });
   }
+
+  ExecuteExtraPythonCode(m);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -473,6 +473,14 @@ PYBIND11_MODULE(mathematicalprogram, m) {
           static_cast<Binding<LinearConstraint> (MathematicalProgram::*)(
               const Formula&)>(&MathematicalProgram::AddLinearConstraint),
           py::arg("f"), doc.MathematicalProgram.AddLinearConstraint.doc_1args_f)
+      .def("AddLinearConstraint",
+          [](MathematicalProgram* self,
+              const Eigen::Ref<const VectorX<Formula>>& formulas) {
+            return self->AddLinearConstraint(formulas.array());
+          },
+          py::arg("formulas"),
+          doc.MathematicalProgram.AddLinearConstraint
+              .doc_1args_constEigenArrayBase)
       .def("AddLinearEqualityConstraint",
           static_cast<Binding<LinearEqualityConstraint> (
               MathematicalProgram::*)(const Eigen::Ref<const Eigen::MatrixXd>&,

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -18,6 +18,7 @@ import pydrake
 from pydrake.autodiffutils import AutoDiffXd
 from pydrake.common.test_utilities.deprecation import catch_drake_warnings
 from pydrake.forwarddiff import jacobian
+from pydrake.math import ge
 import pydrake.symbolic as sym
 
 SNOPT_NO_GUROBI = SnoptSolver().available() and not GurobiSolver().available()
@@ -132,8 +133,9 @@ class TestMathematicalProgram(unittest.TestCase):
     def test_qp(self):
         prog = mp.MathematicalProgram()
         x = prog.NewContinuousVariables(2, "x")
-        prog.AddLinearConstraint(x[0] >= 1)
-        prog.AddLinearConstraint(x[1] >= 1)
+        # N.B. Scalar-wise logical ops work for Expression, but array ops need
+        # the workaround overloads from `pydrake.math`.
+        prog.AddLinearConstraint(ge(x, 1))
         prog.AddQuadraticCost(np.eye(2), np.zeros(2), x)
         # Redundant cost just to check the spelling.
         prog.AddQuadraticErrorCost(vars=x, Q=np.eye(2),

--- a/bindings/pydrake/test/algebra_test_util.py
+++ b/bindings/pydrake/test/algebra_test_util.py
@@ -2,7 +2,10 @@
 Provides utilities to test different algebra.
 """
 
+import operator
+
 import numpy as np
+
 import pydrake.math as drake_math
 
 
@@ -70,6 +73,13 @@ class ScalarAlgebra(BaseAlgebra):
         self.max = drake_math.max
         self.ceil = drake_math.ceil
         self.floor = drake_math.floor
+        # Comparison. Defined in same order as in `_math_extra.py`.
+        self.lt = operator.lt
+        self.le = operator.le
+        self.eq = operator.eq
+        self.ne = operator.ne
+        self.ge = operator.ge
+        self.gt = operator.gt
 
     def to_algebra(self, scalar):
         return scalar
@@ -101,6 +111,13 @@ class VectorizedAlgebra(BaseAlgebra):
         self.max = np.fmax
         self.ceil = np.ceil
         self.floor = np.floor
+        # Comparison. Defined in same order as in `_math_extra.py`.
+        self.lt = drake_math.lt
+        self.le = drake_math.le
+        self.eq = drake_math.eq
+        self.ne = drake_math.ne
+        self.ge = drake_math.ge
+        self.gt = drake_math.gt
 
     def to_algebra(self, scalar):
         return np.array([scalar, scalar])

--- a/bindings/pydrake/test/autodiffutils_test.py
+++ b/bindings/pydrake/test/autodiffutils_test.py
@@ -125,11 +125,17 @@ class TestAutoDiffXd(unittest.TestCase):
         algebra.check_value(2 / a, AD(2, [-2, 0]))
         # Logical
         algebra.check_logical(lambda x, y: x == y, a, a, True)
+        algebra.check_logical(algebra.eq, a, a, True)
         algebra.check_logical(lambda x, y: x != y, a, a, False)
+        algebra.check_logical(algebra.ne, a, a, False)
         algebra.check_logical(lambda x, y: x < y, a, b, True)
+        algebra.check_logical(algebra.lt, a, b, True)
         algebra.check_logical(lambda x, y: x <= y, a, b, True)
+        algebra.check_logical(algebra.le, a, b, True)
         algebra.check_logical(lambda x, y: x > y, a, b, False)
+        algebra.check_logical(algebra.gt, a, b, False)
         algebra.check_logical(lambda x, y: x >= y, a, b, False)
+        algebra.check_logical(algebra.ge, a, b, False)
         # Additional math
         # - See `math_overloads_test` for scalar overloads.
         algebra.check_value(a**2, AD(1, [2., 0]))

--- a/bindings/pydrake/test/symbolic_test.py
+++ b/bindings/pydrake/test/symbolic_test.py
@@ -316,7 +316,7 @@ class TestSymbolicExpression(SymbolicTestCase):
         install_numpy_warning_filters(force=True)
 
     def _check_scalar(self, actual, expected):
-        self.assertIsInstance(actual, sym.Expression)
+        self.assertIsInstance(actual, (sym.Expression, sym.Formula))
         # Chain conversion to ensure equivalent treatment.
         if isinstance(expected, float) or isinstance(expected, int):
             expected = sym.Expression(expected)
@@ -408,6 +408,18 @@ class TestSymbolicExpression(SymbolicTestCase):
         # Unary
         algebra.check_value((+e_xv), "x")
         algebra.check_value((-e_xv), "(-1 * x)")
+
+        # Comparison. For `VectorizedAlgebra`, uses `np.vectorize` workaround
+        # for #8315.
+        # TODO(eric.cousineau): `BaseAlgebra.check_logical` is designed for
+        # AutoDiffXd (float-convertible), not for symbolic (not always
+        # float-convertible).
+        algebra.check_value(algebra.lt(e_xv, e_yv), "(x < y)")
+        algebra.check_value(algebra.le(e_xv, e_yv), "(x <= y)")
+        algebra.check_value(algebra.eq(e_xv, e_yv), "(x == y)")
+        algebra.check_value(algebra.ne(e_xv, e_yv), "(x != y)")
+        algebra.check_value(algebra.ge(e_xv, e_yv), "(x >= y)")
+        algebra.check_value(algebra.gt(e_xv, e_yv), "(x > y)")
 
         # Math functions.
         algebra.check_value((algebra.abs(e_xv)), "abs(x)")
@@ -509,7 +521,8 @@ class TestSymbolicExpression(SymbolicTestCase):
         self.assertEqual(str(1 != e_y), "(y != 1)")
 
     def test_relational_operators_nonzero(self):
-        # For issues #8135 and #8491.
+        # For issues #8135 and #8491. See `pydrake.math` for operator overloads
+        # that work around this, which are tested in `_check_algebra`.
         # Ensure that we throw on `__nonzero__`.
         with self.assertRaises(RuntimeError) as cm:
             value = bool(e_x == e_x)


### PR DESCRIPTION
Workaround for #8315 

\cc @RussTedrake

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11171)
<!-- Reviewable:end -->
