### PR TITLE
py math: Add workaround to support AutoDiffXd and Expression `inv()`

### DIFF
--- a/bindings/pydrake/autodiffutils_py.cc
+++ b/bindings/pydrake/autodiffutils_py.cc
@@ -103,7 +103,11 @@ PYBIND11_MODULE(autodiffutils, m) {
       .def("max",
           [](const AutoDiffXd& x, const AutoDiffXd& y) { return max(x, y); })
       .def("ceil", [](const AutoDiffXd& x) { return ceil(x); })
-      .def("floor", [](const AutoDiffXd& x) { return floor(x); });
+      .def("floor", [](const AutoDiffXd& x) { return floor(x); })
+      // Matrix
+      .def("inv", [](const MatrixX<AutoDiffXd>& X) -> MatrixX<AutoDiffXd> {
+        return X.inverse();
+      });
   // Mirror for numpy.
   autodiff.attr("arcsin") = autodiff.attr("asin");
   autodiff.attr("arccos") = autodiff.attr("acos");

--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -245,7 +245,7 @@ PYBIND11_MODULE(math, m) {
       .def("RealDiscreteLyapunovEquation", &RealDiscreteLyapunovEquation,
           py::arg("A"), py::arg("Q"), doc.RealDiscreteLyapunovEquation.doc);
 
-  // General math overloads.
+  // General scalar math overloads.
   // N.B. Additional overloads will be added for autodiff, symbolic, etc, by
   // those respective modules.
   // TODO(eric.cousineau): If possible, delegate these to NumPy UFuncs,
@@ -277,6 +277,12 @@ PYBIND11_MODULE(math, m) {
       .def("max", [](double x, double y) { return fmax(x, y); })
       .def("ceil", [](double x) { return ceil(x); })
       .def("floor", [](double x) { return floor(x); });
+
+  // General vectorized / matrix overloads.
+  m  // BR
+      .def("inv", [](const Eigen::MatrixXd& X) -> Eigen::MatrixXd {
+        return X.inverse();
+      });
 
   // Add testing module.
   {

--- a/bindings/pydrake/symbolic_py.cc
+++ b/bindings/pydrake/symbolic_py.cc
@@ -347,7 +347,8 @@ PYBIND11_MODULE(symbolic, m) {
       .def("floor", &symbolic::floor, doc.floor.doc);
   DefCopyAndDeepCopy(&expr_cls);
 
-  // TODO(eric.cousineau): Consider deprecating these methods?
+  // TODO(eric.cousineau): Deprecate these methods if/when we support proper
+  // NumPy UFuncs.
   // TODO(m-chaturvedi) Add Pybind11 documentation.
   auto math = py::module::import("pydrake.math");
   MirrorDef<py::module, py::module>(&math, &m)
@@ -370,7 +371,11 @@ PYBIND11_MODULE(symbolic, m) {
       .def("min", &symbolic::min)
       .def("max", &symbolic::max)
       .def("ceil", &symbolic::ceil)
-      .def("floor", &symbolic::floor);
+      .def("floor", &symbolic::floor)
+      // Matrix overloads.
+      .def("inv", [](const MatrixX<Expression>& X) -> MatrixX<Expression> {
+        return X.inverse();
+      });
 
   m.def("if_then_else", &symbolic::if_then_else);
 

--- a/bindings/pydrake/test/autodiffutils_test.py
+++ b/bindings/pydrake/test/autodiffutils_test.py
@@ -207,3 +207,10 @@ class TestAutoDiffXd(unittest.TestCase):
         # to do so. See #8116 for alternative.
         with self.assertRaises(TypeError):
             Y = np.linalg.inv(X)
+
+        to_value = np.vectorize(AutoDiffXd.value)
+        # Use workaround for inverse. For now, just check values.
+        X_float = to_value(X)
+        Xinv_float = np.linalg.inv(X_float)
+        Xinv = drake_math.inv(X)
+        np.testing.assert_equal(to_value(Xinv), Xinv_float)

--- a/bindings/pydrake/test/math_overloads_test_utilities.py
+++ b/bindings/pydrake/test/math_overloads_test_utilities.py
@@ -16,6 +16,8 @@ import subprocess
 import sys
 import unittest
 
+import numpy as np
+
 # Change this to inspect output.
 VERBOSE = False
 
@@ -78,6 +80,7 @@ class AutoDiffOverloads(Overloads):
             "log",
             "tan", "asin", "acos", "atan2",
             "sinh", "cosh", "tanh",
+            "inv",
         ]
         if func.__name__ in backwards_compat:
             # Check backwards compatibility.
@@ -105,6 +108,7 @@ class SymbolicOverloads(Overloads):
             "sin", "cos", "tan", "asin", "acos", "atan",
             "sinh", "cosh", "tanh", "ceil", "floor",
             "min", "max", "pow", "atan2",
+            "inv",
         ]
         supported = backwards_compat
         if func.__name__ in backwards_compat:
@@ -194,3 +198,18 @@ class MathOverloadsBase(unittest.TestCase):
         check_eval(unary, 1)
         debug_print("Binary:")
         check_eval(binary, 2)
+
+        # Check specialized linear / array algebra.
+        if overload.supports(drake_math.inv):
+            f_drake, f_builtin = drake_math.inv, np.linalg.inv
+            X_float = np.eye(2)
+            Y_builtin = f_builtin(X_float)
+            Y_float = f_drake(X_float)
+            self.assertIsInstance(Y_float[0, 0].item(), float)
+            np.testing.assert_equal(Y_builtin, Y_float)
+            to_type_array = np.vectorize(overload.to_type)
+            to_float_array = np.vectorize(overload.to_float)
+            X_T = to_type_array(X_float)
+            Y_T = drake_math.inv(X_T)
+            self.assertIsInstance(Y_T[0, 0], overload.T)
+            np.testing.assert_equal(to_float_array(Y_T), Y_float)


### PR DESCRIPTION
Resolves #11164

\cc @RussTedrake 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11173)
<!-- Reviewable:end -->
