### PR TITLE
Make MemcpyMovable move-constructible

### DIFF
--- a/common/test_utilities/test/is_memcpy_movable_test.cc
+++ b/common/test_utilities/test/is_memcpy_movable_test.cc
@@ -32,7 +32,7 @@ class MemcpyMovable {
   };
 
  private:
-  const unique_ptr<string> name_;
+  unique_ptr<string> name_;
 };
 
 // An example class that is not memcpy-movable.


### PR DESCRIPTION
`clang-8` generates the following warning:

```
INFO: From Compiling common/test_utilities/test/is_memcpy_movable_test.cc:
common/test_utilities/test/is_memcpy_movable_test.cc:24:3: warning: explicitly defaulted move constructor is implicitly deleted [-Wdefaulted-function-deleted]
  MemcpyMovable(MemcpyMovable&& m) = default;
  ^
common/test_utilities/test/is_memcpy_movable_test.cc:35:28: note: move constructor of 'MemcpyMovable' is implicitly deleted because field 'name_' has a deleted move constructor
  const unique_ptr<string> name_;
                           ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/unique_ptr.h:394:7: note: 'unique_ptr' has been explicitly marked deleted here
      unique_ptr(const unique_ptr&) = delete;
      ^
1 warning generated.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11174)
<!-- Reviewable:end -->
