### PR TITLE
Add --build_test_only to entries in dynamic analysis bazel.rc

### DIFF
--- a/tools/dynamic_analysis/bazel.rc
+++ b/tools/dynamic_analysis/bazel.rc
@@ -99,44 +99,6 @@ build:lsan_everything --test_env=LSAN_OPTIONS
 build:lsan_everything --test_env=LSAN_SYMBOLIZER_PATH
 build:lsan_everything --test_lang_filters=-sh,-py
 
-### MSan build. ###
-build:msan --build_tests_only
-build:msan --copt -g
-build:msan --copt -fsanitize=memory
-build:msan --copt -fsanitize-memory-track-origins
-build:msan --copt -O1
-build:msan --copt -fno-omit-frame-pointer
-build:msan --linkopt -fsanitize=memory
-build:msan --run_under=//tools/dynamic_analysis:msan
-build:msan --test_tag_filters=-gurobi,-mosek,-snopt,-no_msan
-build:msan --test_lang_filters=-sh,-py
-build:msan --test_env=MSAN_OPTIONS
-build:msan --test_env=MSAN_SYMBOLIZER_PATH
-# Typical slowdown introduced by MemorySanitizer is 3x.
-# See https://clang.llvm.org/docs/MemorySanitizer.html
-build:msan --test_timeout=180,900,2700,10800
-
-### MSan everything build. ###
-build:msan_everything --build_tests_only
-build:msan_everything --define=WITH_GUROBI=ON
-build:msan_everything --define=WITH_MOSEK=ON
-build:msan_everything --define=WITH_SNOPT=ON
-build:msan_everything --copt -g
-build:msan_everything --copt -fsanitize=memory
-build:msan_everything --copt -fsanitize-memory-track-origins
-build:msan_everything --copt -O1
-build:msan_everything --copt -fno-omit-frame-pointer
-build:msan_everything --linkopt -fsanitize=memory
-
-build:msan_everything --test_tag_filters=-no_msan
-build:msan_everything --run_under=//tools/dynamic_analysis:msan
-build:msan_everything --test_lang_filters=-sh,-py
-build:msan_everything --test_env=MSAN_OPTIONS
-build:msan_everything --test_env=MSAN_SYMBOLIZER_PATH
-# Typical slowdown introduced by MemorySanitizer is 3x.
-# See https://clang.llvm.org/docs/MemorySanitizer.html
-build:msan_everything --test_timeout=180,900,2700,10800
-
 ### TSan build. ###
 build:tsan --build_tests_only
 build:tsan --copt -g

--- a/tools/dynamic_analysis/bazel.rc
+++ b/tools/dynamic_analysis/bazel.rc
@@ -4,16 +4,16 @@
 ### Kcov coverage build. ###
 build:kcov --copt -g
 build:kcov --copt -O0
-test:kcov --spawn_strategy=standalone
-test:kcov --run_under //tools/dynamic_analysis:kcov
-test:kcov --local_test_jobs=1
-test:kcov --test_tag_filters=-lint,-gurobi,-mosek,-snopt,-no_kcov
-test:kcov --nocache_test_results
+build:kcov --spawn_strategy=standalone
+build:kcov --run_under //tools/dynamic_analysis:kcov
+build:kcov --local_test_jobs=1
+build:kcov --test_tag_filters=-lint,-gurobi,-mosek,-snopt,-no_kcov
+build:kcov --nocache_test_results
 # These increased timeouts were set through experimentation. Because kcov runs
 # in a separate process from the main program, the OS has to context-switch
 # between the processes every time a line is hit, slowing down execution
 # significantly. Timeouts are 3.5x default values.
-test:kcov --test_timeout=210,1050,3150,12600
+build:kcov --test_timeout=210,1050,3150,12600
 
 ### Kcov everything build. ###
 build:kcov_everything --define=WITH_GUROBI=ON
@@ -21,14 +21,13 @@ build:kcov_everything --define=WITH_MOSEK=ON
 build:kcov_everything --define=WITH_SNOPT=ON
 build:kcov_everything --copt -g
 build:kcov_everything --copt -O0
-
-test:kcov_everything --spawn_strategy=standalone
-test:kcov_everything --run_under=//tools/dynamic_analysis:kcov
-test:kcov_everything --local_test_jobs=1
-test:kcov_everything --test_tag_filters=-lint,-no_kcov
-test:kcov_everything --nocache_test_results
+build:kcov_everything --spawn_strategy=standalone
+build:kcov_everything --run_under=//tools/dynamic_analysis:kcov
+build:kcov_everything --local_test_jobs=1
+build:kcov_everything --test_tag_filters=-lint,-no_kcov
+build:kcov_everything --nocache_test_results
 # See timeout note above. Timeouts are 5x default values.
-test:kcov_everything --test_timeout=300,1500,4500,18000
+build:kcov_everything --test_timeout=300,1500,4500,18000
 
 ### ASan build. ###
 build:asan --copt -g
@@ -36,16 +35,16 @@ build:asan --copt -fsanitize=address
 build:asan --copt -O1
 build:asan --copt -fno-omit-frame-pointer
 build:asan --linkopt -fsanitize=address
-test:asan --run_under=//tools/dynamic_analysis:asan
-test:asan --test_env=ASAN_OPTIONS
-test:asan --test_env=LSAN_OPTIONS
-test:asan --test_env=ASAN_SYMBOLIZER_PATH
+build:asan --run_under=//tools/dynamic_analysis:asan
+build:asan --test_env=ASAN_OPTIONS
+build:asan --test_env=LSAN_OPTIONS
+build:asan --test_env=ASAN_SYMBOLIZER_PATH
 # LSan is run with ASan by default
-test:asan --test_tag_filters=-gurobi,-mosek,-snopt,-no_asan,-no_lsan
-test:asan --test_lang_filters=-sh,-py
+build:asan --test_tag_filters=-gurobi,-mosek,-snopt,-no_asan,-no_lsan
+build:asan --test_lang_filters=-sh,-py
 # Typical slowdown introduced by AddressSanitizer is 2x.
 # See https://clang.llvm.org/docs/AddressSanitizer.html
-test:asan --test_timeout=150,750,2250,9000  # 2.5x
+build:asan --test_timeout=150,750,2250,9000  # 2.5x
 
 ### ASan everything build. ###
 build:asan_everything --define=WITH_GUROBI=ON
@@ -56,17 +55,16 @@ build:asan_everything --copt -fsanitize=address
 build:asan_everything --copt -O1
 build:asan_everything --copt -fno-omit-frame-pointer
 build:asan_everything --linkopt -fsanitize=address
-
 # LSan is run with ASan by default
-test:asan_everything --test_tag_filters=-no_asan,-no_lsan
-test:asan_everything --run_under=//tools/dynamic_analysis:asan
-test:asan_everything --test_env=ASAN_OPTIONS
-test:asan_everything --test_env=LSAN_OPTIONS
-test:asan_everything --test_env=ASAN_SYMBOLIZER_PATH
-test:asan_everything --test_lang_filters=-sh,-py
+build:asan_everything --test_tag_filters=-no_asan,-no_lsan
+build:asan_everything --run_under=//tools/dynamic_analysis:asan
+build:asan_everything --test_env=ASAN_OPTIONS
+build:asan_everything --test_env=LSAN_OPTIONS
+build:asan_everything --test_env=ASAN_SYMBOLIZER_PATH
+build:asan_everything --test_lang_filters=-sh,-py
 # Typical slowdown introduced by AddressSanitizer is 2x.
 # See https://clang.llvm.org/docs/AddressSanitizer.html
-test:asan_everything --test_timeout=150,750,2250,9000  # 2.5x
+build:asan_everything --test_timeout=150,750,2250,9000  # 2.5x
 
 ### LSan build. ###
 build:lsan --copt -g
@@ -74,11 +72,11 @@ build:lsan --copt -fsanitize=leak
 build:lsan --copt -O1
 build:lsan --copt -fno-omit-frame-pointer
 build:lsan --linkopt -fsanitize=leak
-test:lsan --run_under=//tools/dynamic_analysis:lsan
-test:lsan --test_env=LSAN_OPTIONS
-test:lsan --test_env=LSAN_SYMBOLIZER_PATH
-test:lsan --test_tag_filters=-gurobi,-mosek,-snopt,-no_lsan
-test:lsan --test_lang_filters=-sh,-py
+build:lsan --run_under=//tools/dynamic_analysis:lsan
+build:lsan --test_env=LSAN_OPTIONS
+build:lsan --test_env=LSAN_SYMBOLIZER_PATH
+build:lsan --test_tag_filters=-gurobi,-mosek,-snopt,-no_lsan
+build:lsan --test_lang_filters=-sh,-py
 
 ### LSan everything build. ###
 build:lsan_everything --define=WITH_GUROBI=ON
@@ -89,12 +87,11 @@ build:lsan_everything --copt -fsanitize=leak
 build:lsan_everything --copt -O1
 build:lsan_everything --copt -fno-omit-frame-pointer
 build:lsan_everything --linkopt -fsanitize=leak
-
-test:lsan_everything --test_tag_filters=-no_lsan
-test:lsan_everything --run_under=//tools/dynamic_analysis:lsan
-test:lsan_everything --test_env=LSAN_OPTIONS
-test:lsan_everything --test_env=LSAN_SYMBOLIZER_PATH
-test:lsan_everything --test_lang_filters=-sh,-py
+build:lsan_everything --test_tag_filters=-no_lsan
+build:lsan_everything --run_under=//tools/dynamic_analysis:lsan
+build:lsan_everything --test_env=LSAN_OPTIONS
+build:lsan_everything --test_env=LSAN_SYMBOLIZER_PATH
+build:lsan_everything --test_lang_filters=-sh,-py
 
 ### MSan build. ###
 build:msan --copt -g
@@ -103,14 +100,14 @@ build:msan --copt -fsanitize-memory-track-origins
 build:msan --copt -O1
 build:msan --copt -fno-omit-frame-pointer
 build:msan --linkopt -fsanitize=memory
-test:msan --run_under=//tools/dynamic_analysis:msan
-test:msan --test_tag_filters=-gurobi,-mosek,-snopt,-no_msan
-test:msan --test_lang_filters=-sh,-py
-test:msan --test_env=MSAN_OPTIONS
-test:msan --test_env=MSAN_SYMBOLIZER_PATH
+build:msan --run_under=//tools/dynamic_analysis:msan
+build:msan --test_tag_filters=-gurobi,-mosek,-snopt,-no_msan
+build:msan --test_lang_filters=-sh,-py
+build:msan --test_env=MSAN_OPTIONS
+build:msan --test_env=MSAN_SYMBOLIZER_PATH
 # Typical slowdown introduced by MemorySanitizer is 3x.
 # See https://clang.llvm.org/docs/MemorySanitizer.html
-test:msan --test_timeout=180,900,2700,10800
+build:msan --test_timeout=180,900,2700,10800
 
 ### MSan everything build. ###
 build:msan_everything --define=WITH_GUROBI=ON
@@ -123,14 +120,14 @@ build:msan_everything --copt -O1
 build:msan_everything --copt -fno-omit-frame-pointer
 build:msan_everything --linkopt -fsanitize=memory
 
-test:msan_everything --test_tag_filters=-no_msan
-test:msan_everything --run_under=//tools/dynamic_analysis:msan
-test:msan_everything --test_lang_filters=-sh,-py
-test:msan_everything --test_env=MSAN_OPTIONS
-test:msan_everything --test_env=MSAN_SYMBOLIZER_PATH
+build:msan_everything --test_tag_filters=-no_msan
+build:msan_everything --run_under=//tools/dynamic_analysis:msan
+build:msan_everything --test_lang_filters=-sh,-py
+build:msan_everything --test_env=MSAN_OPTIONS
+build:msan_everything --test_env=MSAN_SYMBOLIZER_PATH
 # Typical slowdown introduced by MemorySanitizer is 3x.
 # See https://clang.llvm.org/docs/MemorySanitizer.html
-test:msan_everything --test_timeout=180,900,2700,10800
+build:msan_everything --test_timeout=180,900,2700,10800
 
 ### TSan build. ###
 build:tsan --copt -g
@@ -144,13 +141,12 @@ build:tsan --copt -fno-omit-frame-pointer
 # Bug in GCC: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67308
 build:tsan --noforce_pic
 build:tsan --linkopt -fsanitize=thread
-test:tsan --run_under=//tools/dynamic_analysis:tsan
-test:tsan --test_env=TSAN_OPTIONS
-test:tsan --test_tag_filters=-gurobi,-mosek,-snopt,-no_tsan
-test:tsan --test_lang_filters=-sh,-py
+build:tsan --run_under=//tools/dynamic_analysis:tsan
+build:tsan --test_env=TSAN_OPTIONS
+build:tsan --test_tag_filters=-gurobi,-mosek,-snopt,-no_tsan
 # Typical slowdown introduced by ThreadSanitizer is about 5x-15x
 # See https://clang.llvm.org/docs/ThreadSanitizer.html
-test:tsan --test_timeout=300,1500,5400,18000
+build:tsan --test_timeout=300,1500,5400,18000
 
 ### TSan everything build. ###
 build:tsan_everything --define=WITH_GUROBI=ON
@@ -167,14 +163,13 @@ build:tsan_everything --copt -fno-omit-frame-pointer
 # Bug in GCC: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67308
 build:tsan_everything --noforce_pic
 build:tsan_everything --linkopt -fsanitize=thread
-
-test:tsan_everything --test_tag_filters=-no_tsan
-test:tsan_everything --run_under=//tools/dynamic_analysis:tsan
-test:tsan_everything --test_env=TSAN_OPTIONS
-test:tsan_everything --test_lang_filters=-sh,-py
+build:tsan_everything --test_tag_filters=-no_tsan
+build:tsan_everything --run_under=//tools/dynamic_analysis:tsan
+build:tsan_everything --test_env=TSAN_OPTIONS
+build:tsan_everything --test_lang_filters=-sh,-py
 # Typical slowdown introduced by ThreadSanitizer is about 5x-15x
 # See https://clang.llvm.org/docs/ThreadSanitizer.html
-test:tsan_everything --test_timeout=300,1500,5400,18000
+build:tsan_everything --test_timeout=300,1500,5400,18000
 
 ### UBSan build. ###
 build:ubsan --copt -g
@@ -188,13 +183,13 @@ build:ubsan --copt -fno-omit-frame-pointer
 # autogenerated toolchain.
 # build:ubsan --copt -fsanitize-blacklist=tools/dynamic_analysis/ubsan.blacklist
 build:ubsan --linkopt -fsanitize=undefined
-test:ubsan --run_under=//tools/dynamic_analysis:ubsan
-test:ubsan --test_env=UBSAN_OPTIONS
-test:ubsan --test_tag_filters=-gurobi,-mosek,-snopt,-no_ubsan
-test:ubsan --test_lang_filters=-sh,-py
+build:ubsan --run_under=//tools/dynamic_analysis:ubsan
+build:ubsan --test_env=UBSAN_OPTIONS
+build:ubsan --test_tag_filters=-gurobi,-mosek,-snopt,-no_ubsan
+build:ubsan --test_lang_filters=-sh,-py
 # Typical slowdown introduced by UBSan is 1.2x, increasing timeouts to 2x.
 # See https://developer.apple.com/documentation/code_diagnostics/undefined_behavior_sanitizer
-test:ubsan --test_timeout=120,600,1800,7200
+build:ubsan --test_timeout=120,600,1800,7200
 
 ### UBSan everything build. ###
 build:ubsan_everything --define=WITH_GUROBI=ON
@@ -212,24 +207,24 @@ build:ubsan_everything --copt -fno-omit-frame-pointer
 # autogenerated toolchain.
 # build:ubsan_everything --copt -fsanitize-blacklist=tools/dynamic_analysis/ubsan.blacklist
 build:ubsan_everything --linkopt -fsanitize=undefined
-test:ubsan_everything --test_tag_filters=-no_ubsan
-test:ubsan_everything --run_under=//tools/dynamic_analysis:ubsan
-test:ubsan_everything --test_env=UBSAN_OPTIONS
-test:ubsan_everything --test_lang_filters=-sh,-py
+build:ubsan_everything --test_tag_filters=-no_ubsan
+build:ubsan_everything --run_under=//tools/dynamic_analysis:ubsan
+build:ubsan_everything --test_env=UBSAN_OPTIONS
+build:ubsan_everything --test_lang_filters=-sh,-py
 # Typical slowdown introduced by UBSan is 1.2x, increasing timeouts to 2x.
 # See https://developer.apple.com/documentation/code_diagnostics/undefined_behavior_sanitizer
-test:ubsan_everything --test_timeout=120,600,1800,7200
+build:ubsan_everything --test_timeout=120,600,1800,7200
 
 ### Memcheck build. ###
 build:memcheck --copt -g
 # https://sourceforge.net/p/valgrind/mailman/valgrind-developers/?viewmonth=201806&viewday=11&style=flat
 build:memcheck --copt -O2
-test:memcheck --run_under=//tools/dynamic_analysis:valgrind
-test:memcheck --test_tag_filters=-gurobi,-mosek,-snopt,-no_memcheck
-test:memcheck --test_lang_filters=-sh,-py
+build:memcheck --run_under=//tools/dynamic_analysis:valgrind
+build:memcheck --test_tag_filters=-gurobi,-mosek,-snopt,-no_memcheck
+build:memcheck --test_lang_filters=-sh,-py
 # Slowdown factor can range from 5-100.
 # See http://valgrind.org/info/about.html
-test:memcheck --test_timeout=1500,7500,22500,90000  # 25x
+build:memcheck --test_timeout=1500,7500,22500,90000  # 25x
 
 ### Memcheck everything build. ###
 build:memcheck_everything --define=WITH_GUROBI=ON
@@ -238,13 +233,12 @@ build:memcheck_everything --define=WITH_SNOPT=ON
 build:memcheck_everything --copt -g
 # https://sourceforge.net/p/valgrind/mailman/valgrind-developers/?viewmonth=201806&viewday=11&style=flat
 build:memcheck_everything --copt -O2
-
-test:memcheck_everything --test_tag_filters=-no_memcheck
-test:memcheck_everything --run_under=//tools/dynamic_analysis:valgrind
-test:memcheck_everything --test_lang_filters=-sh,-py
+build:memcheck_everything --test_tag_filters=-no_memcheck
+build:memcheck_everything --run_under=//tools/dynamic_analysis:valgrind
+build:memcheck_everything --test_lang_filters=-sh,-py
 # Slowdown factor can range from 5-100.
 # See http://valgrind.org/info/about.html
-test:memcheck_everything --test_timeout=1500,7500,22500,90000  # 25x
+build:memcheck_everything --test_timeout=1500,7500,22500,90000  # 25x
 
 # Fast memcheck.
 #
@@ -255,8 +249,8 @@ test:memcheck_everything --test_timeout=1500,7500,22500,90000  # 25x
 # when errors are found, try `-c dbg --config fastmemcheck` or `--config
 # memcheck` to recompile with line numbers and lower optimization levels.
 #
-test:fastmemcheck --run_under=//tools/dynamic_analysis:valgrind
-test:fastmemcheck --test_lang_filters=-sh,-py
+build:fastmemcheck --run_under=//tools/dynamic_analysis:valgrind
+build:fastmemcheck --test_lang_filters=-sh,-py
 # Slowdown factor can range from 5-100.
 # See http://valgrind.org/info/about.html
-test:fastmemcheck --test_timeout=1500,7500,22500,90000  # 25x
+build:fastmemcheck --test_timeout=1500,7500,22500,90000  # 25x

--- a/tools/dynamic_analysis/bazel.rc
+++ b/tools/dynamic_analysis/bazel.rc
@@ -2,6 +2,7 @@
 # This filed is included by //tools:bazel.rc.
 
 ### Kcov coverage build. ###
+build:kcov --build_tests_only
 build:kcov --copt -g
 build:kcov --copt -O0
 build:kcov --spawn_strategy=standalone
@@ -16,6 +17,7 @@ build:kcov --nocache_test_results
 build:kcov --test_timeout=210,1050,3150,12600
 
 ### Kcov everything build. ###
+build:kcov_everything --build_tests_only
 build:kcov_everything --define=WITH_GUROBI=ON
 build:kcov_everything --define=WITH_MOSEK=ON
 build:kcov_everything --define=WITH_SNOPT=ON
@@ -30,6 +32,7 @@ build:kcov_everything --nocache_test_results
 build:kcov_everything --test_timeout=300,1500,4500,18000
 
 ### ASan build. ###
+build:asan --build_tests_only
 build:asan --copt -g
 build:asan --copt -fsanitize=address
 build:asan --copt -O1
@@ -47,6 +50,7 @@ build:asan --test_lang_filters=-sh,-py
 build:asan --test_timeout=150,750,2250,9000  # 2.5x
 
 ### ASan everything build. ###
+build:asan_everything --build_tests_only
 build:asan_everything --define=WITH_GUROBI=ON
 build:asan_everything --define=WITH_MOSEK=ON
 build:asan_everything --define=WITH_SNOPT=ON
@@ -67,6 +71,7 @@ build:asan_everything --test_lang_filters=-sh,-py
 build:asan_everything --test_timeout=150,750,2250,9000  # 2.5x
 
 ### LSan build. ###
+build:lsan --build_tests_only
 build:lsan --copt -g
 build:lsan --copt -fsanitize=leak
 build:lsan --copt -O1
@@ -79,6 +84,7 @@ build:lsan --test_tag_filters=-gurobi,-mosek,-snopt,-no_lsan
 build:lsan --test_lang_filters=-sh,-py
 
 ### LSan everything build. ###
+build:lsan_everything --build_tests_only
 build:lsan_everything --define=WITH_GUROBI=ON
 build:lsan_everything --define=WITH_MOSEK=ON
 build:lsan_everything --define=WITH_SNOPT=ON
@@ -94,6 +100,7 @@ build:lsan_everything --test_env=LSAN_SYMBOLIZER_PATH
 build:lsan_everything --test_lang_filters=-sh,-py
 
 ### MSan build. ###
+build:msan --build_tests_only
 build:msan --copt -g
 build:msan --copt -fsanitize=memory
 build:msan --copt -fsanitize-memory-track-origins
@@ -110,6 +117,7 @@ build:msan --test_env=MSAN_SYMBOLIZER_PATH
 build:msan --test_timeout=180,900,2700,10800
 
 ### MSan everything build. ###
+build:msan_everything --build_tests_only
 build:msan_everything --define=WITH_GUROBI=ON
 build:msan_everything --define=WITH_MOSEK=ON
 build:msan_everything --define=WITH_SNOPT=ON
@@ -130,6 +138,7 @@ build:msan_everything --test_env=MSAN_SYMBOLIZER_PATH
 build:msan_everything --test_timeout=180,900,2700,10800
 
 ### TSan build. ###
+build:tsan --build_tests_only
 build:tsan --copt -g
 build:tsan --copt -fsanitize=thread
 build:tsan --copt -O1
@@ -144,11 +153,13 @@ build:tsan --linkopt -fsanitize=thread
 build:tsan --run_under=//tools/dynamic_analysis:tsan
 build:tsan --test_env=TSAN_OPTIONS
 build:tsan --test_tag_filters=-gurobi,-mosek,-snopt,-no_tsan
+build:tsan --test_lang_filters=-sh,-py
 # Typical slowdown introduced by ThreadSanitizer is about 5x-15x
 # See https://clang.llvm.org/docs/ThreadSanitizer.html
 build:tsan --test_timeout=300,1500,5400,18000
 
 ### TSan everything build. ###
+build:tsan_everything --build_tests_only
 build:tsan_everything --define=WITH_GUROBI=ON
 build:tsan_everything --define=WITH_MOSEK=ON
 build:tsan_everything --define=WITH_SNOPT=ON
@@ -172,6 +183,7 @@ build:tsan_everything --test_lang_filters=-sh,-py
 build:tsan_everything --test_timeout=300,1500,5400,18000
 
 ### UBSan build. ###
+build:ubsan --build_tests_only
 build:ubsan --copt -g
 build:ubsan --copt -fsanitize=undefined
 # Since Bazel uses clang instead of clang++, enabling -fsanitize=vptr would
@@ -192,6 +204,7 @@ build:ubsan --test_lang_filters=-sh,-py
 build:ubsan --test_timeout=120,600,1800,7200
 
 ### UBSan everything build. ###
+build:ubsan_everything --build_tests_only
 build:ubsan_everything --define=WITH_GUROBI=ON
 build:ubsan_everything --define=WITH_MOSEK=ON
 build:ubsan_everything --define=WITH_SNOPT=ON
@@ -216,6 +229,7 @@ build:ubsan_everything --test_lang_filters=-sh,-py
 build:ubsan_everything --test_timeout=120,600,1800,7200
 
 ### Memcheck build. ###
+build:memcheck --build_tests_only
 build:memcheck --copt -g
 # https://sourceforge.net/p/valgrind/mailman/valgrind-developers/?viewmonth=201806&viewday=11&style=flat
 build:memcheck --copt -O2
@@ -227,6 +241,7 @@ build:memcheck --test_lang_filters=-sh,-py
 build:memcheck --test_timeout=1500,7500,22500,90000  # 25x
 
 ### Memcheck everything build. ###
+build:memcheck_everything --build_tests_only
 build:memcheck_everything --define=WITH_GUROBI=ON
 build:memcheck_everything --define=WITH_MOSEK=ON
 build:memcheck_everything --define=WITH_SNOPT=ON


### PR DESCRIPTION
And other cleanup. The choice of `build:` and `test:` prefixes seems arbitrary; all those options in this file are valid for both commands and inherited by `test` when set as `build`. Also `msan` and `msan_everything` have never  been functional, and it seems unlikely that they even will be. https://github.com/RobotLocomotion/drake-ci/commit/7dfa5869a49c2b15028cc8256a888f56c11e5dfb should be reverted once this merges.

Closes #11027.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11178)
<!-- Reviewable:end -->
