### PR TITLE
multibody: Deprecate Isometry3 usages in element constructors

### DIFF
--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -705,7 +705,7 @@ class TestPlant(unittest.TestCase):
                     distal_frame, instances[0]).body_frame(),
                 child_frame_C=plant.GetBodyByName(
                     proximal_frame, instances[1]).body_frame(),
-                X_PC=Isometry3.Identity()),
+                X_PC=RigidTransform.Identity()),
         ]
         for joint in joints:
             joint_out = plant.AddJoint(joint)
@@ -720,8 +720,8 @@ class TestPlant(unittest.TestCase):
     def test_multibody_add_frame(self):
         plant = MultibodyPlant()
         frame = plant.AddFrame(frame=FixedOffsetFrame(
-            name="frame", P=plant.world_frame(), X_PF=Isometry3.Identity(),
-            model_instance=None))
+            name="frame", P=plant.world_frame(),
+            X_PF=RigidTransform.Identity(), model_instance=None))
         self.assertIsInstance(frame, Frame)
         np.testing.assert_equal(
             np.eye(4), frame.GetFixedPoseInBodyFrame().GetAsMatrix4())

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -29,6 +29,8 @@ using T = double;
 
 using std::string;
 
+using math::RigidTransform;
+
 // Binds `MultibodyTreeElement` methods.
 // N.B. We do this rather than inheritance because this template is more of a
 // mixin than it is a parent class (since it is not used for its dynamic
@@ -71,6 +73,11 @@ PYBIND11_MODULE(tree, m) {
       m, "ModelInstanceIndex", doc.ModelInstanceIndex.doc);
   m.def("world_index", &world_index, doc.world_index.doc);
 
+  constexpr char doc_iso3_deprecation[] =
+      "This API using Isometry3 is / will be deprecated soon with the "
+      "resolution of #9865. We only offer it for backwards compatibility. DO "
+      "NOT USE!.";
+
   // Frames.
   {
     using Class = Frame<T>;
@@ -93,10 +100,19 @@ PYBIND11_MODULE(tree, m) {
     using Class = FixedOffsetFrame<T>;
     constexpr auto& cls_doc = doc.FixedOffsetFrame;
     py::class_<Class, Frame<T>>(m, "FixedOffsetFrame", cls_doc.doc)
-        .def(py::init<const std::string&, const Frame<double>&,
-                 const Isometry3<double>&, optional<ModelInstanceIndex>>(),
+        .def(py::init<const std::string&, const Frame<T>&,
+                 const RigidTransform<T>&, optional<ModelInstanceIndex>>(),
             py::arg("name"), py::arg("P"), py::arg("X_PF"),
-            py::arg("model_instance") = nullopt, cls_doc.ctor.doc_4args);
+            py::arg("model_instance") = nullopt, cls_doc.ctor.doc_4args)
+        .def(py::init([doc_iso3_deprecation](const std::string& name,
+                          const Frame<T>& P, const Isometry3<T>& X_PF,
+                          optional<ModelInstanceIndex> model_instance) {
+          WarnDeprecated(doc_iso3_deprecation);
+          return std::make_unique<Class>(
+              name, P, RigidTransform<T>(X_PF), model_instance);
+        }),
+            py::arg("name"), py::arg("P"), py::arg("X_PF"),
+            py::arg("model_instance") = nullopt, doc_iso3_deprecation);
   }
 
   // Bodies.
@@ -197,9 +213,19 @@ PYBIND11_MODULE(tree, m) {
     py::class_<Class, Joint<T>> cls(m, "WeldJoint", doc.WeldJoint.doc);
     cls  // BR
         .def(py::init<const string&, const Frame<T>&, const Frame<T>&,
-                 const Isometry3<double>&>(),
+                 const RigidTransform<T>&>(),
             py::arg("name"), py::arg("parent_frame_P"),
-            py::arg("child_frame_C"), py::arg("X_PC"), doc.WeldJoint.ctor.doc);
+            py::arg("child_frame_C"), py::arg("X_PC"), doc.WeldJoint.ctor.doc)
+        .def(py::init(
+                 [doc_iso3_deprecation](const std::string& name,
+                     const Frame<T>& parent_frame_P,
+                     const Frame<T>& child_frame_C, const Isometry3<T>& X_PC) {
+                   WarnDeprecated(doc_iso3_deprecation);
+                   return std::make_unique<Class>(name, parent_frame_P,
+                       child_frame_C, RigidTransform<T>(X_PC));
+                 }),
+            py::arg("name"), py::arg("parent_frame_P"),
+            py::arg("child_frame_C"), py::arg("X_PC"), doc_iso3_deprecation);
   }
 
   // Actuators.

--- a/multibody/tree/fixed_offset_frame.h
+++ b/multibody/tree/fixed_offset_frame.h
@@ -78,23 +78,35 @@ class FixedOffsetFrame final : public Frame<T> {
       : FixedOffsetFrame("", bodyB, X_BF) {}
 
 #ifndef DRAKE_DOXYGEN_CXX
-  // TODO(amcastro-tri): These constructors are provided only for backwards
-  // compatibilty until #9865 is fully resolved. DO NOT USE THEM. They'll very
-  // soon go through a deprecation process.
-
+  DRAKE_DEPRECATED(
+      "2019-06-15",
+      "This Isometry3 overload will be removed pending the resolution of "
+      "#9865. Use the RigidTransform overload instead.")
   FixedOffsetFrame(const std::string& name, const Frame<T>& P,
                    const Isometry3<double>& X_PF,
                    optional<ModelInstanceIndex> model_instance = {})
       : FixedOffsetFrame(name, P, math::RigidTransformd(X_PF), model_instance) {
   }
 
+  DRAKE_DEPRECATED(
+      "2019-06-15",
+      "This Isometry3 overload will be removed pending the resolution of "
+      "#9865. Use the RigidTransform overload instead.")
   FixedOffsetFrame(const Frame<T>& P, const Isometry3<double>& X_PF)
       : FixedOffsetFrame(P, math::RigidTransformd(X_PF)) {}
 
+  DRAKE_DEPRECATED(
+      "2019-06-15",
+      "This Isometry3 overload will be removed pending the resolution of "
+      "#9865. Use the RigidTransform overload instead.")
   FixedOffsetFrame(const std::string& name, const Body<T>& bodyB,
                    const Isometry3<double>& X_BF)
       : FixedOffsetFrame(name, bodyB, math::RigidTransformd(X_BF)) {}
 
+  DRAKE_DEPRECATED(
+      "2019-06-15",
+      "This Isometry3 overload will be removed pending the resolution of "
+      "#9865. Use the RigidTransform overload instead.")
   FixedOffsetFrame(const Body<T>& bodyB, const Isometry3<double>& X_BF)
       : FixedOffsetFrame(bodyB, math::RigidTransformd(X_BF)) {}
 #endif

--- a/multibody/tree/weld_joint.h
+++ b/multibody/tree/weld_joint.h
@@ -51,10 +51,10 @@ class WeldJoint final : public Joint<T> {
         X_PC_(X_PC) {}
 
 #ifndef DRAKE_DOXYGEN_CXX
-  // TODO(amcastro-tri): This constructor is provided only for backwards
-  // compatibilty until #9865 is fully resolved. DO NOT USE IT. It'll very
-  // soon go through a deprecation process.
-
+  DRAKE_DEPRECATED(
+      "2019-06-15",
+      "This Isometry3 overload will be removed pending the resolution of "
+      "#9865. Use the RigidTransform overload instead.")
   WeldJoint(const std::string& name, const Frame<T>& parent_frame_P,
             const Frame<T>& child_frame_C, const Isometry3<double>& X_PC)
       : WeldJoint(name, parent_frame_P, child_frame_C,


### PR DESCRIPTION
Towards #11064

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11181)
<!-- Reviewable:end -->
