### PR TITLE
Implicit Euler Integrator refactor

### DIFF
--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -18,6 +18,7 @@ drake_cc_package_library(
         ":explicit_euler_integrator",
         ":hermitian_dense_output",
         ":implicit_euler_integrator",
+        ":implicit_integrator",
         ":initial_value_problem",
         ":integrator_base",
         ":lyapunov",
@@ -143,6 +144,18 @@ drake_cc_library(
     hdrs = [
         "implicit_euler_integrator.h",
         "implicit_euler_integrator-inl.h",
+    ],
+    deps = [
+        ":implicit_integrator",
+        "//math:gradient",
+    ],
+)
+
+drake_cc_library(
+    name = "implicit_integrator",
+    srcs = ["implicit_integrator.cc"],
+    hdrs = [
+        "implicit_integrator.h",
     ],
     deps = [
         ":integrator_base",

--- a/systems/analysis/implicit_euler_integrator-inl.h
+++ b/systems/analysis/implicit_euler_integrator-inl.h
@@ -22,13 +22,14 @@ namespace drake {
 namespace systems {
 
 template <class T>
-void ImplicitEulerIntegrator<T>::DoResetStatistics() {
-  num_nr_iterations_ = num_err_est_nr_iterations_ = 0;
+void ImplicitEulerIntegrator<T>::DoResetImplicitIntegratorStatistics() {
+  num_iter_factorizations_ = 0;
+  num_nr_iterations_ = 0;
+  num_err_est_nr_iterations_ = 0;
   num_err_est_function_evaluations_ = 0;
-  num_jacobian_function_evaluations_ =
-    num_err_est_jacobian_function_evaluations_ = 0;
-  num_jacobian_evaluations_ = num_err_est_jacobian_reforms_ = 0;
-  num_iter_factorizations_ = num_err_est_iter_factorizations_ = 0;
+  num_err_est_jacobian_function_evaluations_ = 0;
+  num_err_est_jacobian_reforms_ = 0;
+  num_err_est_iter_factorizations_ = 0;
 }
 
 template <class T>
@@ -65,284 +66,22 @@ void ImplicitEulerIntegrator<T>::DoInitialize() {
   this->set_accuracy_in_use(working_accuracy);
 
   // Reset the Jacobian matrix (so that recomputation is forced).
-  J_.resize(0, 0);
+  this->get_mutable_jacobian().resize(0, 0);
 }
 
-// Computes the Jacobian of the ordinary differential equations taken with
-// respect to the continuous state (at a point specified by @p state) using
-// automatic differentiation.
-template <>
-MatrixX<AutoDiffXd> ImplicitEulerIntegrator<AutoDiffXd>::
-    ComputeAutoDiffJacobian(const System<AutoDiffXd>&,
-                            const Context<AutoDiffXd>&) {
-        throw std::runtime_error("AutoDiff'd Jacobian not supported from "
-                                     "AutoDiff'd ImplicitEulerIntegrator");
-}
-
-// Computes the Jacobian of the ordinary differential equations taken with
-// respect to the continuous state (at a point specified by @p state) using
-// automatic differentiation.
-// @param system The dynamical system.
-// @param context The context at which to compute the time derivatives.
-// @param state The continuous state at which to compute the time derivatives.
-//              The function can modify this continuous state during the
-//              Jacobian computation.
-// @post The continuous state will be indeterminate on return.
-template <class T>
-MatrixX<T> ImplicitEulerIntegrator<T>::ComputeAutoDiffJacobian(
-    const System<T>& system, const Context<T>& context) {
-  SPDLOG_DEBUG(drake::log(), "  IE Compute Autodiff Jacobian t={}",
-               context.get_time());
-  // Create AutoDiff versions of the state vector.
-  VectorX<AutoDiffXd> a_xtplus = context.get_continuous_state().CopyToVector();
-
-  // Set the size of the derivatives and prepare for Jacobian calculation.
-  const int n_state_dim = a_xtplus.size();
-  for (int i = 0; i < n_state_dim; ++i)
-    a_xtplus[i].derivatives() = VectorX<T>::Unit(n_state_dim, i);
-
-  // Get the system and the context in AutoDiffable format. Inputs must also
-  // be copied to the context used by the AutoDiff'd system (which is
-  // accomplished using FixInputPortsFrom()).
-  // TODO(edrumwri): Investigate means for moving as many of the operations
-  //                 below offline (or with lower frequency than once-per-
-  //                 Jacobian calculation) as is possible. These operations
-  //                 are likely to be expensive.
-  const auto adiff_system = system.ToAutoDiffXd();
-  std::unique_ptr<Context<AutoDiffXd>> adiff_context = adiff_system->
-      AllocateContext();
-  adiff_context->SetTimeStateAndParametersFrom(context);
-  adiff_system->FixInputPortsFrom(system, context, adiff_context.get());
-
-  // Set the continuous state in the context.
-  adiff_context->get_mutable_continuous_state().get_mutable_vector().
-      SetFromVector(a_xtplus);
-
-  // Evaluate the derivatives at that state.
-  const VectorX<AutoDiffXd> result =
-      this->EvalTimeDerivatives(*adiff_system, *adiff_context).CopyToVector();
-
-  return math::autoDiffToGradientMatrix(result);
-}
-
-// Evaluates the ordinary differential equations at the time and state in
-// the system's context (stored by the integrator).
-template <class T>
-VectorX<T> ImplicitEulerIntegrator<T>::EvalTimeDerivativesUsingContext() {
-    return this->EvalTimeDerivatives(this->get_context()).CopyToVector();
-}
-
-// Computes the Jacobian of the ordinary differential equations taken with
-// respect to the continuous state (at a point specified by @p state) using
-// a first-order forward difference (i.e., numerical differentiation).
-// @param system The dynamical system.
-// @param context Mutable context for in-place computation of time derivatives.
-// @param state The continuous state at which to compute the time derivatives.
-//              The function can modify this continuous state during the
-//              Jacobian computation.
-// @post The continuous state will be indeterminate on return.
-template <class T>
-MatrixX<T> ImplicitEulerIntegrator<T>::ComputeForwardDiffJacobian(
-    const System<T>&, Context<T>* context) {
-  using std::abs;
-
-  // Set epsilon to the square root of machine precision.
-  const double eps = std::sqrt(std::numeric_limits<double>::epsilon());
-
-  // Get the number of continuous state variables xc.
-  const int n = context->num_continuous_states();
-
-  // Get the current continuous state.
-  const VectorX<T> xtplus = context->get_continuous_state().CopyToVector();
-
-  SPDLOG_DEBUG(drake::log(), "  IE Compute Forwarddiff {}-Jacobian t={}",
-               n, context->get_time());
-  SPDLOG_DEBUG(drake::log(), "  computing from state {}", xtplus.transpose());
-
-  // Prevent compiler warnings for context.
-  unused(context);
-
-  // Initialize the Jacobian.
-  MatrixX<T> J(n, n);
-
-  // Evaluate f(t+h,xtplus) for the current state (current xtplus).
-  const VectorX<T> f = EvalTimeDerivativesUsingContext();
-
-  // Compute the Jacobian.
-  VectorX<T> xtplus_prime = xtplus;
-  for (int i = 0; i < n; ++i) {
-    // Compute a good increment to the dimension using approximately 1/eps
-    // digits of precision. Note that if |xtplus| is large, the increment will
-    // be large as well. If |xtplus| is small, the increment will be no smaller
-    // than eps.
-    const T abs_xi = abs(xtplus(i));
-    T dxi(abs_xi);
-    if (dxi <= 1) {
-      // When |xtplus[i]| is small, increment will be eps.
-      dxi = eps;
-    } else {
-      // |xtplus[i]| not small; make increment a fraction of |xtplus[i]|.
-      dxi = eps * abs_xi;
-    }
-
-    // Update xtplus', minimizing the effect of roundoff error by ensuring that
-    // x and dx differ by an exactly representable number. See p. 192 of
-    // Press, W., Teukolsky, S., Vetterling, W., and Flannery, P. Numerical
-    //   Recipes in C++, 2nd Ed., Cambridge University Press, 2002.
-    xtplus_prime(i) = xtplus(i) + dxi;
-    dxi = xtplus_prime(i) - xtplus(i);
-
-    // TODO(sherm1) This is invalidating q, v, and z but we only changed one.
-    //              Switch to a method that invalides just the relevant
-    //              partition, and ideally modify only the one changed element.
-    // Compute f' and set the relevant column of the Jacobian matrix.
-    context->SetContinuousState(xtplus_prime);
-    J.col(i) = (EvalTimeDerivativesUsingContext() - f) / dxi;
-
-    // Reset xtplus' to xtplus.
-    xtplus_prime(i) = xtplus(i);
-  }
-
-  return J;
-}
-
-// Computes the Jacobian of the ordinary differential equations taken with
-// respect to the continuous state (at a point specified by @p state) using
-// a second-order central difference (i.e., numerical differentiation).
-// @param system The dynamical system.
-// @param context Mutable context for in-place computation of time derivatives.
-// @post The continuous state will be indeterminate on return.
-template <class T>
-MatrixX<T> ImplicitEulerIntegrator<T>::ComputeCentralDiffJacobian(
-    const System<T>&, Context<T>* context) {
-  using std::abs;
-
-  // Cube root of machine precision (indicated by theory) seems a bit coarse.
-  // Pick power of eps halfway between 6/12 (i.e., 1/2) and 4/12 (i.e., 1/3).
-  const double eps = std::pow(std::numeric_limits<double>::epsilon(), 5.0/12);
-
-  // Get the number of continuous state variables xc.
-  const int n = context->num_continuous_states();
-
-  SPDLOG_DEBUG(drake::log(), "  IE Compute Centraldiff {}-Jacobian t={}",
-               n, context->get_time());
-
-  // Prevent compiler warnings for context.
-  unused(context);
-
-  // Initialize the Jacobian.
-  MatrixX<T> J(n, n);
-
-  // Get the current continuous state.
-  const VectorX<T> xtplus = context->get_continuous_state().CopyToVector();
-
-  // Compute the Jacobian.
-  VectorX<T> xtplus_prime = xtplus;
-  for (int i = 0; i < n; ++i) {
-    // Compute a good increment to the dimension using approximately 1/eps
-    // digits of precision. Note that if |xtplus| is large, the increment will
-    // be large as well. If |xtplus| is small, the increment will be no smaller
-    // than eps.
-    const T abs_xi = abs(xtplus(i));
-    T dxi(abs_xi);
-    if (dxi <= 1) {
-      // When |xtplus[i]| is small, increment will be eps.
-      dxi = eps;
-    } else {
-      // |xtplus[i]| not small; make increment a fraction of |xtplus[i]|.
-      dxi = eps * abs_xi;
-    }
-
-    // Update xtplus', minimizing the effect of roundoff error, by ensuring that
-    // x and dx differ by an exactly representable number. See p. 192 of
-    // Press, W., Teukolsky, S., Vetterling, W., and Flannery, P. Numerical
-    //   Recipes in C++, 2nd Ed., Cambridge University Press, 2002.
-    xtplus_prime(i) = xtplus(i) + dxi;
-    const T dxi_plus = xtplus_prime(i) - xtplus(i);
-
-    // TODO(sherm1) This is invalidating q, v, and z but we only changed one.
-    //              Switch to a method that invalides just the relevant
-    //              partition, and ideally modify only the one changed element.
-    // Compute f(x+dx).
-    context->SetContinuousState(xtplus_prime);
-    VectorX<T> fprime_plus = EvalTimeDerivativesUsingContext();
-
-    // Update xtplus' again, minimizing the effect of roundoff error.
-    xtplus_prime(i) = xtplus(i) - dxi;
-    const T dxi_minus = xtplus(i) - xtplus_prime(i);
-
-    // Compute f(x-dx).
-    context->SetContinuousState(xtplus_prime);
-    VectorX<T> fprime_minus = EvalTimeDerivativesUsingContext();
-
-    // Set the Jacobian column.
-    J.col(i) = (fprime_plus - fprime_minus) / (dxi_plus + dxi_minus);
-
-    // Reset xtplus' to xtplus.
-    xtplus_prime(i) = xtplus(i);
-  }
-
-  return J;
-}
-
-// Factors a dense matrix (the negated iteration matrix) using LU factorization,
-// which should be faster than the QR factorization used in the specialized
-// template method immediately below.
-template <class T>
-void ImplicitEulerIntegrator<T>::Factor(const MatrixX<T>& A) {
-  num_iter_factorizations_++;
-  LU_.compute(A);
-}
-
-// Factors a dense matrix (the negated iteration matrix). This
-// AutoDiff-specialized method is necessary because Eigen's LU factorization,
-// which should be faster than the QR factorization used here, is not currently
-// AutoDiff-able (while the QR factorization *is* AutoDiff-able).
-template <>
-void ImplicitEulerIntegrator<AutoDiffXd>::Factor(
-    const MatrixX<AutoDiffXd>& A) {
-  num_iter_factorizations_++;
-  QR_.compute(A);
-}
-
-// Solves a linear system Ax = b for x using a negated iteration matrix (A)
-// factored using LU decomposition.
-// @sa Factor()
-template <class T>
-VectorX<T> ImplicitEulerIntegrator<T>::Solve(const VectorX<T>& b) const {
-  return LU_.solve(b);
-}
-
-// Solves the linear system Ax = b for x using a negated iteration matrix (A)
-// factored using QR decomposition.
-// @sa Factor()
-template <>
-VectorX<AutoDiffXd> ImplicitEulerIntegrator<AutoDiffXd>::Solve(
-    const VectorX<AutoDiffXd>& b) const {
-  return QR_.solve(b);
-}
-
-// Checks to see whether a Jacobian matrix has "become bad" and needs to be
-// refactorized.
-template <class T>
-bool ImplicitEulerIntegrator<T>::IsBadJacobian(const MatrixX<T>& J) const {
-  return !J.allFinite();
-}
-
-// Computes any necessary matrices for the Newton-Raphson iteration in
-// StepAbstract(). Parameters are identical to those for StepAbstract;
-// @see StepAbstract() for their documentation.
+// Computes any necessary matrices (Jacobian, iteration matrix, or both)
+// for the Newton-Raphson iteration in StepAbstract() around time/state `(t,xt)`
+// and using the same `scale` parameter as in StepAbstract().
 // @returns `false` if the calling StepAbstract method should indicate failure;
 //          `true` otherwise.
 template <class T>
-bool ImplicitEulerIntegrator<T>::CalcMatrices(const T& tf, const T& dt,
-                                              int scale,
-                                              const VectorX<T>& xtplus,
-                                              int trial) {
+bool ImplicitEulerIntegrator<T>::CalcMatrices(const T& t, const T& h,
+    const VectorX<T>& xt, int scale, int trial) {
   // Compute the initial Jacobian and negated iteration matrices (see
   // rationale for the negation below) and factor them, if necessary.
-  if (!reuse_ || J_.rows() == 0 || IsBadJacobian(J_)) {
-    // Note that the Jacobian can become bad through a divergent Newton-Raphson
+  MatrixX<T>& J = this->get_mutable_jacobian();
+  if (!this->get_reuse() || J.rows() == 0 || this->IsBadJacobian(J)) {
+    // The Jacobian can become bad through a divergent Newton-Raphson
     // iteration, which causes the state to overflow, which then causes the
     // Jacobian to overflow. If the state overflows, recomputing the Jacobian
     // using this bad state will result in another bad Jacobian, eventually
@@ -350,10 +89,8 @@ bool ImplicitEulerIntegrator<T>::CalcMatrices(const T& tf, const T& dt,
     // the continuous state to its previous, good value). DoStep() will then
     // be called again with a smaller step size and the good state; the
     // bad Jacobian will then be corrected.
-    J_ = CalcJacobian(tf, xtplus);
-    const int n = xtplus.size();
-    neg_iteration_matrix_ = J_ * (dt / scale) - MatrixX<T>::Identity(n, n);
-    Factor(neg_iteration_matrix_);
+    J = this->CalcJacobian(t, xt);
+    ComputeAndFactorIterationMatrix(J, h, scale);
     return true;
   }
 
@@ -364,9 +101,7 @@ bool ImplicitEulerIntegrator<T>::CalcMatrices(const T& tf, const T& dt,
 
     case 2: {
       // For the second trial, re-construct and factor the iteration matrix.
-      const int n = xtplus.size();
-      neg_iteration_matrix_ = J_ * (dt / scale) - MatrixX<T>::Identity(n, n);
-      Factor(neg_iteration_matrix_);
+      ComputeAndFactorIterationMatrix(J, h, scale);
       return true;
     }
 
@@ -375,18 +110,12 @@ bool ImplicitEulerIntegrator<T>::CalcMatrices(const T& tf, const T& dt,
       // the Jacobian matrix is fresh and the iteration matrix has been newly
       // formed and factored (on Trial #2), so there is nothing more to be
       // done.
-      if (last_call_failed_) {
+      if (!this->last_call_succeeded()) {
         return false;
       } else {
-        // Reform the Jacobian matrix and refactor the negation of
-        // the iteration matrix. The idea of using the negation of this matrix
-        // is that an O(n^2) subtraction is not necessary as would
-        // be the case with MatrixX<T>::Identity(n, n) - J * (dt / scale).
-        J_ = CalcJacobian(tf, xtplus);
-        const int n = xtplus.size();
-        neg_iteration_matrix_ = J_ * (dt / scale) -
-            MatrixX<T>::Identity(n, n);
-        Factor(neg_iteration_matrix_);
+        // Reform the Jacobian matrix and refactor the iteration matrix.
+        J = this->CalcJacobian(t, xt);
+        ComputeAndFactorIterationMatrix(J, h, scale);
       }
       return true;
 
@@ -401,30 +130,41 @@ bool ImplicitEulerIntegrator<T>::CalcMatrices(const T& tf, const T& dt,
   }
 }
 
+template <class T>
+void ImplicitEulerIntegrator<T>::ComputeAndFactorIterationMatrix(
+  const MatrixX<T>& J, const T& h, int scale) {
+    ++num_iter_factorizations_;
+    const int n = J.rows();
+    // TODO(edrumwri) Investigate using a move-type operation below.
+    // We form the iteration matrix in this particular way to avoid an O(n^2)
+    // subtraction as would be the case with:
+    // MatrixX<T>::Identity(n, n) - J * (h / scale).
+    iteration_matrix_.SetAndFactorIterationMatrix(
+        J * (-h / static_cast<double>(scale)) + MatrixX<T>::Identity(n, n));
+}
+
 // Performs the bulk of the stepping computation for both implicit Euler and
 // implicit trapezoid method; all those methods need to do is provide a
-// residual function (@p g) and a scale factor (@p scale) specific to the
+// residual function (`g`) and a scale factor (`scale`) specific to the
 // particular integrator scheme and this method does the rest.
-// @param dt the integration step size to attempt.
-// @param g the particular implicit function to zero.
+// @param t0 the time at the left end of the integration interval.
+// @param h the integration step size (> 0) to attempt.
+// @param xt0 the continuous state at t0.
+// @param g the particular implicit function to compute the root of.
 // @param scale a scale factor- either 1 or 2- that allows this method to be
 //        used by both implicit Euler and implicit trapezoid methods.
-// @param [in,out] the starting guess for x(t+dt); the value for x(t+h) on
-//        return (assuming that h > 0)
+// @param [in, out] the starting guess for x(t0+h); the value for x(t0+h) on
+//        return.
 // @param trial the attempt for this approach (1-4). StepAbstract() uses more
 //        computationally expensive methods as the trial numbers increase.
 // @returns `true` if the method was successfully able to take an integration
-//           step of size @p dt (or `false` otherwise).
-// @pre The time and state of the system's context (stored by the integrator)
-//      are t0 and x(t0) on entry.
-// @post The time and state of the system's context (stored by the integrator)
-//       will be set to t0+dt and x(t0+dt) on successful exit (indicated by
-//       this function returning `true`) and will be indeterminate on
-//       unsuccessful exit (indicated by this function returning `false`).
+//           step of size h (or `false` otherwise).
+// @note The time and continuous state in the context are indeterminate upon
+//       exit.
 template <class T>
-bool ImplicitEulerIntegrator<T>::StepAbstract(const T& dt,
-                          const std::function<VectorX<T>()>& g,
-                          int scale, VectorX<T>* xtplus, int trial) {
+bool ImplicitEulerIntegrator<T>::StepAbstract(const T& t0, const T& h,
+    const VectorX<T>& xt0, const std::function<VectorX<T>()>& g,
+    int scale, VectorX<T>* xtplus, int trial) {
   using std::max;
   using std::min;
 
@@ -435,29 +175,28 @@ bool ImplicitEulerIntegrator<T>::StepAbstract(const T& dt,
   DRAKE_ASSERT(scale == 1 || scale == 2);
 
   // Verify xtplus
-  Context<T>* context = this->get_mutable_context();
-  DRAKE_ASSERT(xtplus &&
-               xtplus->size() == context->get_continuous_state_vector().size());
+  DRAKE_ASSERT(xtplus && xtplus->size() == xt0.size());
 
   SPDLOG_DEBUG(drake::log(), "StepAbstract() entered for t={}, h={}, trial={}",
-               context->get_time(), dt, trial);
+      t0, h, trial);
 
-  // Advance the context time; this means that all derivatives will be computed
-  // at t+dt.
-  const T tf = context->get_time() + dt;
+  // Advance the context time and state to compute derivatives at t0 + h.
+  const T tf = t0 + h;
+  Context<T>* context = this->get_mutable_context();
   context->SetTimeAndContinuousState(tf, *xtplus);
 
-  // Evaluate the residual error using the current x(t+h) as x⁰(t+h):
-  // g(x⁰(t+h)) = x⁰(t+h) - x(t) - h f(t+h,x⁰(t+h)), where h = dt;
+  // Evaluate the residual error using:
+  // g(x(t0+h)) = x(t0+h) - x(t0) - h f(t0+h,x(t0+h)).
   VectorX<T> goutput = g();
 
   // Initialize the "last" state update norm; this will be used to detect
   // convergence.
   T last_dx_norm = std::numeric_limits<double>::infinity();
 
-  // Calculate Jacobian and iteration matrices (and factorizations), as needed.
-  if (!CalcMatrices(tf, dt, scale, *xtplus, trial)) {
-    last_call_failed_ = true;
+  // Calculate Jacobian and iteration matrices (and factorizations), as needed,
+  // around (tf, xtplus).
+  if (!CalcMatrices(tf, h, *xtplus, scale, trial)) {
+    this->set_last_call_succeeded(false);
     return false;
   }
 
@@ -476,10 +215,9 @@ bool ImplicitEulerIntegrator<T>::StepAbstract(const T& dt,
     num_nr_iterations_++;
 
     // Compute the state update using the equation A*x = -g(), where A is the
-    // iteration matrix. Using nA as the negation of the iteration matrix, we
-    // instead solve nA*x = g().
+    // iteration matrix.
     // TODO(edrumwri): Allow caller to provide their own solver.
-    VectorX<T> dx = Solve(goutput);
+    VectorX<T> dx = iteration_matrix_.Solve(-goutput);
 
     // Get the infinity norm of the weighted update vector.
     dx_state_->get_mutable_vector().SetFromVector(dx);
@@ -487,6 +225,7 @@ bool ImplicitEulerIntegrator<T>::StepAbstract(const T& dt,
 
     // Update the state vector.
     *xtplus += dx;
+    context->SetTimeAndContinuousState(tf, *xtplus);
 
     // The check below looks for convergence using machine epsilon. Without
     // this check, the convergence criteria can be applied when
@@ -495,8 +234,7 @@ bool ImplicitEulerIntegrator<T>::StepAbstract(const T& dt,
     // equivalent to last_dx_norm, making theta = 1, and eta = infinity. Thus,
     // convergence would never be identified.
     if (dx_norm < 10 * std::numeric_limits<double>::epsilon()) {
-      context->SetContinuousState(*xtplus);
-      last_call_failed_ = false;
+      this->set_last_call_succeeded(true);
       return true;
     }
 
@@ -512,21 +250,20 @@ bool ImplicitEulerIntegrator<T>::StepAbstract(const T& dt,
       // Look for divergence.
       if (theta > 1) {
         SPDLOG_DEBUG(drake::log(), "Newton-Raphson divergence detected for "
-            "h={}", dt);
+            "h={}", h);
         break;
       }
 
       // Look for convergence using Equation 8.10 from [Hairer, 1996].
       // [Hairer, 1996] determined values of kappa in [0.01, 0.1] work most
-      // efficiently on a number of test problems with *RADAU5* (a fifth order
+      // efficiently on a number of test problems with Radau5 (a fifth order
       // implicit integrator), p. 121. We select a value halfway in-between.
       const double kappa = 0.05;
       const double k_dot_tol = kappa * this->get_accuracy_in_use();
       if (eta * dx_norm < k_dot_tol) {
         SPDLOG_DEBUG(drake::log(), "Newton-Raphson converged; η = {}, h = {}",
-                     eta, dt);
-        context->SetContinuousState(*xtplus);
-        last_call_failed_ = false;
+                     eta, h);
+        this->set_last_call_succeeded(true);
         return true;
       }
     }
@@ -535,7 +272,6 @@ bool ImplicitEulerIntegrator<T>::StepAbstract(const T& dt,
     last_dx_norm = dx_norm;
 
     // Update the state in the context and compute g(xⁱ⁺¹).
-    context->SetContinuousState(*xtplus);
     goutput = g();
   }
 
@@ -543,231 +279,165 @@ bool ImplicitEulerIntegrator<T>::StepAbstract(const T& dt,
 
   // If Jacobian and iteration matrix factorizations are not reused, there
   // is nothing else we can try.
-  if (!reuse_) {
-    last_call_failed_ = true;
+  if (!this->get_reuse()) {
+    this->set_last_call_succeeded(false);
     return false;
   }
 
   // Try StepAbstract again, freshening Jacobians and iteration matrix
   // factorizations as helpful.
-  return StepAbstract(dt, g, scale, xtplus, trial+1);
+  return StepAbstract(t0, h, xt0, g, scale, xtplus, trial+1);
 }
 
-// Steps the system forward by a single step of at most dt using the implicit
+// Steps the system forward by a single step of at most h using the implicit
 // Euler method.
-// @param dt the maximum time increment to step forward.
-// @returns the amount actually stepped forward by a single step.
+// @param t0 the time at the left end of the integration interval.
+// @param h the maximum time increment to step forward.
+// @param xt0 the continuous state at t0.
+// @param [in,out] xtplus a guess for the continuous state at the right end of
+//                 the integration interval (i.e., `x(t0+h)`), on entry, and
+//                 the computed value for `x(t0+h)` on successful return.
+// @returns `true` if the step of size `h` was successful, `false` otherwise.
+// @note The time and continuous state in the context are indeterminate upon
+//       exit.
 template <class T>
-bool ImplicitEulerIntegrator<T>::StepImplicitEuler(const T& h) {
+bool ImplicitEulerIntegrator<T>::StepImplicitEuler(const T& t0, const T& h,
+    const VectorX<T>& xt0, VectorX<T>* xtplus) {
   using std::abs;
 
-  // Get the current continuous state.
-  Context<T>* context = this->get_mutable_context();
-  const VectorX<T> xt0 = context->get_continuous_state_vector().CopyToVector();
-
-  SPDLOG_DEBUG(drake::log(), "StepImplicitEuler(h={}) t={}",
-               h, context->get_time());
+  SPDLOG_DEBUG(drake::log(), "StepImplicitEuler(h={}) t={}", h, t0);
 
   // Set g for the implicit Euler method.
+  Context<T>* context = this->get_mutable_context();
   std::function<VectorX<T>()> g =
       [&xt0, h, context, this]() {
         return (context->get_continuous_state().CopyToVector() - xt0 -
-            h * EvalTimeDerivativesUsingContext()).eval();
+            h * this->EvalTimeDerivativesUsingContext()).eval();
       };
 
   // Use the current state as the candidate value for the next state.
   // [Hairer 1996] validates this choice (p. 120).
-  VectorX<T> xtplus = xt0;
+  *xtplus = xt0;
 
   // Attempt the step.
-  return StepAbstract(h, g, 1, &xtplus);
+  return StepAbstract(t0, h, xt0, g, 1, &*xtplus);
 }
 
-// Steps forward by a single step of @p dt using the implicit trapezoid
+// Steps forward by a single step of `h` using the implicit trapezoid
 // method, if possible.
-// @param dt the maximum time increment to step forward.
-// @param dx0 the time derivatives computed at the beginning of the integration
-//        step.
-// @param xtplus the state computed by the implicit Euler method.
+// @param t0 the time at the left end of the integration interval.
+// @param h the maximum time increment to step forward.
+// @param dx0 the time derivatives computed at time and state (t0, xt0).
+// @param [in,out] xtplus the continuous state at the right end of the
+//                 integration (i.e., x(t0+h)) computed by implicit Euler
+//                 on entry; x(t0+h) computed by the implicit trapezoid method
+//                 on successful return.
 // @returns `true` if the step was successful and `false` otherwise.
-// @pre The time and state in the system's context (stored within the
-//      integrator) are set to those at t0 (the beginning of the integration
-//      step).
-// @post The time and state in the system's context (stored within the
-//       integrator) are set to those at t0+dt on successful return (i.e., when
-//       the function returns `true`). State will be indeterminate on `false`
-//       return.
+// @note The time and continuous state in the context are indeterminate upon
+//       exit.
 template <class T>
-bool ImplicitEulerIntegrator<T>::StepImplicitTrapezoid(const T& h,
-                                                       const VectorX<T>& dx0,
-                                                       VectorX<T>* xtplus) {
+bool ImplicitEulerIntegrator<T>::StepImplicitTrapezoid(const T& t0, const T& h,
+    const VectorX<T>& xt0, const VectorX<T>& dx0, VectorX<T>* xtplus) {
   using std::abs;
 
-  // Get the current continuous state.
-  Context<T>* context = this->get_mutable_context();
-  const VectorX<T> xt0 = context->get_continuous_state_vector().CopyToVector();
-
-  SPDLOG_DEBUG(drake::log(), "StepImplicitTrapezoid(h={}) t={}",
-               h, context->get_time());
+  SPDLOG_DEBUG(drake::log(), "StepImplicitTrapezoid(h={}) t={}", h, t0);
 
   // Set g for the implicit trapezoid method.
-  // Define g(x(t+h)) ≡ x(t+h) - x(t) - h/2 (f(t,x(t)) + f(t+h,x(t+h)) and
+  // Define g(x(t+h)) ≡ x(t0+h) - x(t0) - h/2 (f(t0,x(t0)) + f(t0+h,x(t0+h)) and
   // evaluate it at the current x(t+h).
+  Context<T>* context = this->get_mutable_context();
   std::function<VectorX<T>()> g =
       [&xt0, h, &dx0, context, this]() {
-        return (context->get_continuous_state().CopyToVector() - xt0 -
-            h/2 * (dx0 + EvalTimeDerivativesUsingContext().eval())).eval();
+        return (context->get_continuous_state().CopyToVector() - xt0 - h/2 *
+            (dx0 + this->EvalTimeDerivativesUsingContext().eval())).eval();
       };
 
   // Store statistics before calling StepAbstract(). The difference between
   // the modified statistics and the stored statistics will be used to compute
   // the trapezoid method-specific statistics.
-  int stored_num_jacobian_evaluations = num_jacobian_evaluations_;
-  int stored_num_iter_factorizations = num_iter_factorizations_;
+  int stored_num_jacobian_evaluations = this->get_num_jacobian_evaluations();
+  int stored_num_iter_factorizations =
+      this->get_num_iteration_matrix_factorizations();
   int64_t stored_num_function_evaluations =
       this->get_num_derivative_evaluations();
   int64_t stored_num_jacobian_function_evaluations =
-      num_jacobian_function_evaluations_;
-  int stored_num_nr_iterations = num_nr_iterations_;
+      this->get_num_derivative_evaluations_for_jacobian();
+  int stored_num_nr_iterations = this->get_num_newton_raphson_iterations();
 
-  // Step.
-  bool success = StepAbstract(h, g, 2, xtplus);
+  // Attempt to step.
+  bool success = StepAbstract(t0, h, xt0, g, 2, xtplus);
 
   // Move statistics to implicit trapezoid-specific.
   num_err_est_jacobian_reforms_ +=
-      num_jacobian_evaluations_ - stored_num_jacobian_evaluations;
-  num_err_est_iter_factorizations_ += num_iter_factorizations_ -
+      this->get_num_jacobian_evaluations() - stored_num_jacobian_evaluations;
+  num_err_est_iter_factorizations_ +=
+      this->get_num_iteration_matrix_factorizations() -
       stored_num_iter_factorizations;
   num_err_est_function_evaluations_ +=
       this->get_num_derivative_evaluations() - stored_num_function_evaluations;
   num_err_est_jacobian_function_evaluations_ +=
-      num_jacobian_function_evaluations_ -
-          stored_num_jacobian_function_evaluations;
-  num_err_est_nr_iterations_ += num_nr_iterations_ - stored_num_nr_iterations;
+      this->get_num_derivative_evaluations_for_jacobian() -
+      stored_num_jacobian_function_evaluations;
+  num_err_est_nr_iterations_ += this->get_num_newton_raphson_iterations() -
+      stored_num_nr_iterations;
 
   return success;
 }
 
-// Compute the partial derivative of the ordinary differential equations with
-// respect to the state variables for a given x(t).
-// @post the context's time and continuous state will be temporarily set during
-//       this call (and then reset to their original values) on return.
+// Steps both implicit Euler and implicit trapezoid forward by h, if possible.
+// @param t0 the time at the left end of the integration interval.
+// @param h the integration step size to attempt.
+// @param [out] xtplus_ie contains the Euler integrator solution (i.e.,
+//              `x(t0+h)`) on return.
+// @param [out] xtplus_itr contains the implicit trapezoid solution (i.e.,
+//              `x(t0+h)`) on return.
+// @returns `true` if the step of size `h` was successful, `false` otherwise.
 template <class T>
-MatrixX<T> ImplicitEulerIntegrator<T>::CalcJacobian(const T& t,
-                                                    const VectorX<T>& x) {
-  // We change the context but will change it back.
-  Context<T>* context = this->get_mutable_context();
-
-  // Get the current time and state.
-  T t_current = context->get_time();
-  const VectorX<T> x_current = context->get_continuous_state_vector().
-      CopyToVector();
-
-  // Update the time and state.
-  context->SetTimeAndContinuousState(t, x);
-  num_jacobian_evaluations_++;
-
-  // Get the current number of ODE evaluations.
-  int64_t current_ODE_evals = this->get_num_derivative_evaluations();
-
-  // Get a the system.
-  const System<T>& system = this->get_system();
-
-  // TODO(edrumwri): Give the caller the option to provide their own Jacobian.
-  const MatrixX<T> J = [&]() {
-    switch (jacobian_scheme_) {
-      case JacobianComputationScheme::kForwardDifference:
-        return ComputeForwardDiffJacobian(system, &*context);
-
-      case JacobianComputationScheme::kCentralDifference:
-        return ComputeCentralDiffJacobian(system, &*context);
-
-      case JacobianComputationScheme::kAutomatic:
-        return ComputeAutoDiffJacobian(system, *context);
-    }
-    DRAKE_UNREACHABLE();
-  }();
-
-  // Use the new number of ODE evaluations to determine the number of Jacobian
-  // evaluations.
-  num_jacobian_function_evaluations_ += this->get_num_derivative_evaluations()
-      - current_ODE_evals;
-
-  // Reset the time and state.
-  context->SetTimeAndContinuousState(t_current, x_current);
-
-  return J;
-}
-
-// Steps both implicit Euler and implicit trapezoid forward by dt, if possible.
-// @param dt the integration step size to attempt.
-// @param [out] xtplus_ie contains the Euler integrator solution on return
-// @param [out] xtplus_itr contains the implicit trapezoid solution on return
-// @returns `true` if the integration was successful at the requested step size
-//          and `false` otherwise.
-// @pre The time and state in the system's context (stored by the integrator)
-//      are set to {t0,x0} on entry (those at the beginning of the interval.
-// @post The time and state of the system's context (stored by the integrator)
-//       will be set to t0+dt and @p xtplus_ie on successful exit (indicated by
-//       this function returning `true`) and will be indeterminate on
-//       unsuccessful exit (indicated by this function returning `false`).
-template <class T>
-bool ImplicitEulerIntegrator<T>::AttemptStepPaired(const T& dt,
-                                                   VectorX<T>* xtplus_ie,
-                                                   VectorX<T>* xtplus_itr) {
+bool ImplicitEulerIntegrator<T>::AttemptStepPaired(const T& t0, const T& h,
+    const VectorX<T>& xt0, VectorX<T>* xtplus_ie, VectorX<T>* xtplus_itr) {
   using std::abs;
   DRAKE_ASSERT(xtplus_ie);
   DRAKE_ASSERT(xtplus_itr);
 
-  // Save the time and state at the beginning of this interval.
-  Context<T>* context = this->get_mutable_context();
-  T t0 = context->get_time();
-  const VectorX<T> xt0 = context->get_continuous_state_vector().CopyToVector();
-
-  // Compute the derivative at xt0. NOTE: the derivative is calculated at this
-  // point (early on in the integration process) in order to reuse the
-  // derivative evaluation, via the cache, from the last integration step (if
-  // possible).
-  const VectorX<T> dx0 = EvalTimeDerivativesUsingContext();
+  // Compute the derivative at time and state (t0, x(t0)). NOTE: the derivative
+  // is calculated at this point (early on in the integration process) in order
+  // to reuse the derivative evaluation, via the cache, from the last
+  // integration step (if possible).
+  const VectorX<T> dx0 = this->EvalTimeDerivativesUsingContext();
 
   // Do the Euler step.
-  if (!StepImplicitEuler(dt)) {
+  if (!StepImplicitEuler(t0, h, xt0, xtplus_ie)) {
     SPDLOG_DEBUG(drake::log(), "Implicit Euler approach did not converge for "
-        "step size {}", dt);
+        "step size {}", h);
     return false;
   }
 
-  // Get the new state.
-  *xtplus_ie = context->get_continuous_state_vector().CopyToVector();
-
-  // Reset the state.
-  context->SetTimeAndContinuousState(t0, xt0);
-
   // The error estimation process uses the implicit trapezoid method, which
   // is defined as:
-  // x(t+h) = x(t) + h/2 (f(t, x(t) + f(t+h, x(t+h))
-  // x(t+h) from the implicit Euler method is presumably a good starting point.
+  // x(t0+h) = x(t0) + h/2 (f(t0, x(t0) + f(t0+h, x(t0+h))
+  // x(t0+h) from the implicit Euler method is presumably a good starting point.
 
   // The error estimate is derived as follows (thanks to Michael Sherman):
-  // x*(t+h) = xᵢₑ(t+h) + O(h²)      [implicit Euler]
-  //         = xₜᵣ(t+h) + O(h³)      [implicit trapezoid]
-  // where x*(t+h) is the true (generally unknown) answer that we seek.
+  // x*(t0+h) = xᵢₑ(t0+h) + O(h²)      [implicit Euler]
+  //          = xₜᵣ(t0+h) + O(h³)      [implicit trapezoid]
+  // where x*(t0+h) is the true (generally unknown) answer that we seek.
   // This implies:
-  // xᵢₑ(t+h) + O(h²) = xₜᵣ(t+h) + O(h³)
+  // xᵢₑ(t0+h) + O(h²) = xₜᵣ(t0+h) + O(h³)
   // Given that the second order term subsumes the third order one:
-  // xᵢₑ(t+h) - xₜᵣ(t+h) = O(h²)
+  // xᵢₑ(t0+h) - xₜᵣ(t0+h) = O(h²)
   // Therefore the difference between the implicit trapezoid solution and the
   // implicit Euler solution gives a second-order error estimate for the
   // implicit Euler result xᵢₑ.
 
   // Attempt to compute the implicit trapezoid solution.
   *xtplus_itr = *xtplus_ie;
-  if (StepImplicitTrapezoid(dt, dx0, xtplus_itr)) {
+  if (StepImplicitTrapezoid(t0, h, xt0, dx0, xtplus_itr)) {
     // Reset the state to that computed by implicit Euler.
     // TODO(edrumwri): Explore using the implicit trapezoid method solution
     //                 instead as *the* solution, rather than the implicit
     //                 Euler. Refer to [Lambert, 1991], Ch 6.
-    context->SetTimeAndContinuousState(t0 + dt, *xtplus_ie);
+    Context<T>* context = this->get_mutable_context();
+    context->SetTimeAndContinuousState(t0 + h, *xtplus_ie);
     return true;
   } else {
     SPDLOG_DEBUG(drake::log(), "Implicit trapezoid approach FAILED with a step"
@@ -777,14 +447,14 @@ bool ImplicitEulerIntegrator<T>::AttemptStepPaired(const T& dt,
 }
 
 /// Takes a given step of the requested size, if possible.
-/// @returns `true` if successful and `false` otherwise.
-/// @post the time and continuous state will be advanced only if `true` is
-///       returned.
+/// @returns `true` if successful and `false` otherwise; on `true`, the time
+///          and continuous state will be advanced in the context (e.g., from
+///          t0 to t0 + h). On `false` return, the time and continuous state in
+///          the context will be restored to its original value (at t0).
 template <class T>
 bool ImplicitEulerIntegrator<T>::DoStep(const T& h) {
-  Context<T>* context = this->get_mutable_context();
-
   // Save the current time and state.
+  Context<T>* context = this->get_mutable_context();
   const T t0 = context->get_time();
   SPDLOG_DEBUG(drake::log(), "IE DoStep(h={}) t={}", h, t0);
 
@@ -811,18 +481,18 @@ bool ImplicitEulerIntegrator<T>::DoStep(const T& h) {
     // The error estimation process for explicit Euler uses two half-steps
     // of explicit Euler (for a total of two derivative evaluations). The error
     // estimation process is derived as follows:
-    // (1) x*(t+h) = xₑ(t+h) + h²/2 df/dt + ...                [full step]
-    // (2) x*(t+h) = ̅xₑ(t+h) + h²/8 (df/dt + df₊/dt) + ...    [two 1/2-steps]
+    // (1) x*(t0+h) = xₑ(t0+h) + h²/2 df/h + ...                [full step]
+    // (2) x*(t0+h) = ̅xₑ(t0+h) + h²/8 (df/h + df₊/h) + ...      [two 1/2-steps]
     //
-    // where x*(t+h) is the true (generally unknown) answer that we seek,
-    // f() is the ordinary differential equation evaluated at x(t), and
-    // f₊() is the derivative evaluated at x(t + h/2). Subtracting (1) from
+    // where x*(t0+h) is the true (generally unknown) answer that we seek,
+    // f() is the ordinary differential equation evaluated at x(t0), and
+    // f₊() is the derivative evaluated at x(t0 + h/2). Subtracting (1) from
     // (2), the above equations are rewritten as:
-    // 0 = x̅ₑ(t+h) - xₑ(t+h) + h²/8 (-3df/dt + df₊/dt) + ...
+    // 0 = x̅ₑ(t0+h) - xₑ(t0+h) + h²/8 (-3df/h + df₊/h) + ...
     // The sum of all but the first two terms on the right hand side
     // of the above equation is less in magnitude than ch², for some
     // sufficiently large c. Or, written using Big-Oh notation:
-    // x̅ₑ(t+h) - xₑ(t+h) = O(h²)
+    // x̅ₑ(t0+h) - xₑ(t0+h) = O(h²)
     // Thus, subtracting the two solutions yields a second order error estimate
     // (we compute norms on the error estimate, so the apparent sign error
     // in the algebra when arriving at the final equation is inconsequential).
@@ -834,21 +504,21 @@ bool ImplicitEulerIntegrator<T>::DoStep(const T& h) {
 
     // Do one half step.
     // TODO(sherm1) Heap allocation here; consider mutable temporary instead.
-    const VectorX<T> xtpoint5 = xt0 + h/2 * xdot;
-    context->SetTimeAndContinuousState(t0 + h/2, xtpoint5);
+    const VectorX<T> xtpoint5 = xt0 + h / 2.0 * xdot;
+    context->SetTimeAndContinuousState(t0 + h / 2.0, xtpoint5);
 
     // Do another half step, then set the "trapezoid" state to be the result of
     // taking two explicit Euler half steps. The code below the if/then/else
     // block simply subtracts the two results to obtain the error estimate.
     xdot = this->EvalTimeDerivatives(*context).CopyToVector();  // xdot(t + h/2)
-    xtplus_itr = xtpoint5 + h/2 * xdot;
+    xtplus_itr = xtpoint5 + h / 2.0 * xdot;
     context->SetTimeAndContinuousState(t0 + h, xtplus_itr);
 
     // Update the error estimation ODE counts.
     num_err_est_function_evaluations_ += 2;
   } else {
     // Try taking the requested step.
-    bool success = AttemptStepPaired(h, &xtplus_ie, &xtplus_itr);
+    bool success = AttemptStepPaired(t0, h, xt0, &xtplus_ie, &xtplus_itr);
 
     // If the step was not successful, reset the time and state.
     if (!success) {

--- a/systems/analysis/implicit_euler_integrator.h
+++ b/systems/analysis/implicit_euler_integrator.h
@@ -8,7 +8,7 @@
 
 #include "drake/common/drake_copyable.h"
 #include "drake/math/autodiff_gradient.h"
-#include "drake/systems/analysis/integrator_base.h"
+#include "drake/systems/analysis/implicit_integrator.h"
 
 namespace drake {
 namespace systems {
@@ -52,23 +52,6 @@ namespace systems {
  * [Lambert, 1991], Ch. 6 for an approachable discussion on stiff differential
  * equations and L- and A-Stability.
  *
- * The time complexity of this method is often dominated by the time to form
- * the Jacobian matrix consisting of the partial derivatives of the nonlinear
- * system (of `n` dimensions, where `n` is the number of state variables) taken
- * with respect to the partial derivatives of the state variables at `x(t+h)`.
- * For typical numerical differentiation, `f` will be evaluated `n` times during
- * the Jacobian formation; if we liberally assume that the derivative function
- * evaluation code runs in `O(n)` time (e.g., as it would for multi-rigid
- * body dynamics without kinematic loops), the asymptotic complexity to form
- * the Jacobian will be `O(n²)`. This Jacobian matrix needs to be formed
- * repeatedly- as often as every time the state variables are updated-
- * during the solution process. Using automatic differentiation replaces the
- * `n` derivative evaluations with what is hopefully a much less expensive
- * process, though the complexity to form the Jacobian matrix is still `O(n²)`.
- * For large `n`, the time complexity may be dominated by the `O(n³)` time
- * required to (repeatedly) solve linear systems problems as part of the
- * nonlinear system solution process.
- *
  * This implementation uses Newton-Raphson (NR) and relies upon the obvious
  * convergence to a solution for `g = 0` where
  * `g(x(t+h)) ≡ x(t+h) - x(t) - h f(t+h,x(t+h))` as `h` becomes sufficiently
@@ -81,9 +64,12 @@ namespace systems {
  *                    Springer, 1996.
  * - [Lambert, 1991]  J. D. Lambert. Numerical Methods for Ordinary Differential
  *                    Equations. John Wiley & Sons, 1991.
+ * 
+ * @see ImplicitIntegrator class documentation for information about implicit
+ *      integration methods in general.
  */
 template <class T>
-class ImplicitEulerIntegrator final : public IntegratorBase<T> {
+class ImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ImplicitEulerIntegrator)
 
@@ -91,237 +77,80 @@ class ImplicitEulerIntegrator final : public IntegratorBase<T> {
 
   explicit ImplicitEulerIntegrator(const System<T>& system,
                                    Context<T>* context = nullptr)
-      : IntegratorBase<T>(system, context) {}
-
-  /// Selecting the wrong such Jacobian determination scheme will slow (possibly
-  /// critically) the implicit integration process. Automatic differentiation is
-  /// recommended if the System supports it for reasons of both higher
-  /// accuracy and increased speed. Forward differencing (i.e., numerical
-  /// differentiation) exhibits error in the approximation close to √ε, where
-  /// ε is machine epsilon, from n forward dynamics calls (where n is the number
-  /// of state variables). Central differencing yields the most accurate
-  /// numerically differentiated Jacobian matrix, but expends double the
-  /// computational effort for approximately three digits greater accuracy: the
-  /// total error in the central-difference approximation is close to ε^(2/3),
-  /// from 2n forward dynamics calls. See [Nocedal 2004, pp. 167-169].
-  ///
-  /// - [Nocedal 2004] J. Nocedal and S. Wright. Numerical Optimization.
-  ///                  Springer, 2004.
-  enum class JacobianComputationScheme {
-    /// O(h) Forward differencing.
-    kForwardDifference,
-
-    /// O(h²) Central differencing.
-    kCentralDifference,
-
-    /// Automatic differentiation.
-    kAutomatic
-  };
-
-  /// @name Methods for getting and setting the Jacobian scheme.
-  ///
-  /// Methods for getting and setting the scheme used to determine the
-  /// Jacobian matrix necessary for solving the requisite nonlinear system
-  /// if equations.
-  /// @see JacobianComputationScheme
-  /// @{
-
-  /// Sets whether the integrator attempts to reuse Jacobian matrices and
-  /// iteration matrix factorizations (default is `true`). Forming Jacobian
-  /// matrices and factorizing iteration matrices are generally the two most
-  /// expensive operations performed by this integrator. For small systems
-  /// (those with on the order of ten state variables), the additional accuracy
-  /// that using fresh Jacobians and factorizations buys- which can permit
-  /// increased step sizes but should have no effect on solution accuracy- can
-  /// outweigh the small factorization cost.
-  /// @sa get_reuse
-  void set_reuse(bool reuse) { reuse_ = reuse; }
-
-  /// Gets whether the integrator attempts to reuse Jacobian matrices and
-  /// iteration matrix factorizations.
-  /// @sa set_reuse()
-  bool get_reuse() const { return reuse_; }
-
-  /// Sets the Jacobian computation scheme. This function can be safely called
-  /// at any time (i.e., the integrator need not be re-initialized afterward).
-  /// @note Discards any already-computed Jacobian matrices if the scheme
-  ///       changes.
-  void set_jacobian_computation_scheme(JacobianComputationScheme scheme) {
-    if (jacobian_scheme_ != scheme)
-      J_.resize(0, 0);
-    jacobian_scheme_ = scheme;
-  }
-
-  JacobianComputationScheme get_jacobian_computation_scheme() const {
-    return jacobian_scheme_;
-  }
-  /// @}
+      : ImplicitIntegrator<T>(system, context) {}
 
   /// The integrator supports error estimation.
-  bool supports_error_estimation() const override { return true; }
+  bool supports_error_estimation() const final { return true; }
 
   /// This integrator provides second order error estimates.
-  int get_error_estimate_order() const override { return 2; }
+  int get_error_estimate_order() const final { return 2; }
 
-  /// @name Cumulative statistics functions.
-  /// The functions return statistics specific to the implicit integration
-  /// process.
-  /// @{
-
-  /// Gets the number of ODE function evaluations
-  /// (calls to CalcTimeDerivatives()) *used only for the error estimation
-  /// process* since the last call to ResetStatistics(). This count
-  /// includes *all* such calls including (1) those necessary to compute
-  /// Jacobian matrices; and (2) calls that exhibit little
-  /// cost (due to results being cached).
-  int64_t get_num_error_estimator_derivative_evaluations() const {
-    return num_err_est_function_evaluations_;
-  }
-
-  /// Gets the number of ODE function evaluations
-  /// (calls to CalcTimeDerivatives()) *used only for computing
-  /// the Jacobian matrices* since the last call to ResetStatistics(). This
-  /// count includes those derivative calculations necessary for computing
-  /// Jacobian matrices during the error estimation process.
-  int64_t get_num_derivative_evaluations_for_jacobian() const {
-    return num_jacobian_function_evaluations_;
-  }
-
-  /// Gets the number of iterations used in the Newton-Raphson nonlinear systems
-  /// of equation solving process since the last call to ResetStatistics(). This
-  /// count includes those Newton-Raphson iterations used during the error
-  /// estimation process.
-  int64_t get_num_newton_raphson_iterations() const {
+ private:
+  int64_t do_get_num_newton_raphson_iterations() const final {
     return num_nr_iterations_;
   }
 
-  /// Gets the number of Jacobian evaluations (i.e., the number of times
-  /// that the Jacobian matrix was reformed) since the last call to
-  /// ResetStatistics(). This count includes those evaluations necessary
-  /// during the error estimation process.
-  int64_t get_num_jacobian_evaluations() const { return
-        num_jacobian_evaluations_;
-  }
-
-  /// Gets the number of factorizations of the iteration matrix since the last
-  /// call to ResetStatistics(). This count includes those refactorizations
-  /// necessary during the error estimation process.
-  int64_t get_num_iteration_matrix_factorizations() const {
+  int64_t do_get_num_iteration_matrix_factorizations() const final {
     return num_iter_factorizations_;
   }
 
-  /// @}
+  int64_t do_get_num_error_estimator_derivative_evaluations() const final {
+    return num_err_est_function_evaluations_;
+  }
 
-  /// @name Error-estimation statistics functions.
-  /// The functions return statistics specific to the error estimation
-  /// process.
-  /// @{
-  /// Gets the number of ODE function evaluations (calls to
-  /// CalcTimeDerivatives()) *used only for computing the Jacobian matrices
-  /// needed by the error estimation process* since the last call to
-  /// ResetStatistics().
-  int64_t get_num_error_estimator_derivative_evaluations_for_jacobian() const {
+  int64_t do_get_num_error_estimator_derivative_evaluations_for_jacobian()
+      const final {
     return num_err_est_jacobian_function_evaluations_;
   }
 
-  /// Gets the number of iterations *used in the Newton-Raphson nonlinear
-  /// systems of equation solving process for the error estimation process*
-  /// since the last call to ResetStatistics().
-  int64_t get_num_error_estimator_newton_raphson_iterations() const { return
-        num_err_est_nr_iterations_;
+  int64_t do_get_num_error_estimator_newton_raphson_iterations()
+      const final {
+    return num_err_est_nr_iterations_;
   }
 
-  /// Gets the number of Jacobian matrix evaluations *used only during
-  /// the error estimation process* since the last call to ResetStatistics().
-  int64_t get_num_error_estimator_jacobian_evaluations() const {
+  int64_t do_get_num_error_estimator_jacobian_evaluations() const final {
     return num_err_est_jacobian_reforms_;
   }
 
-  /// Gets the number of factorizations of the iteration matrix *used only
-  /// during the error estimation process* since the last call to
-  /// ResetStatistics().
-  int64_t get_num_error_estimator_iteration_matrix_factorizations() const {
+  int64_t do_get_num_error_estimator_iteration_matrix_factorizations()
+      const final {
     return num_err_est_iter_factorizations_;
   }
 
-  /// @}
-
- private:
-  bool IsBadJacobian(const MatrixX<T>& J) const;
-  void DoInitialize() override;
-  void DoResetStatistics() override;
-  void Factor(const MatrixX<T>& A);
-  VectorX<T> Solve(const VectorX<T>& rhs) const;
-  bool AttemptStepPaired(const T& dt, VectorX<T>* xtplus_euler,
-                         VectorX<T>* xtplus_trap);
-  bool StepAbstract(const T& dt, const std::function<VectorX<T>()>& g,
-                    int scale, VectorX<T>* xtplus, int trial = 1);
-  bool CalcMatrices(const T& tf, const T& dt, int scale,
-                    const VectorX<T>& xtplus, int trial);
-  MatrixX<T> CalcJacobian(const T& tf, const VectorX<T>& xtplus);
-  bool DoStep(const T& dt) override;
-  bool StepImplicitEuler(const T& h);
-  bool StepImplicitTrapezoid(const T& h, const VectorX<T>& dx0,
-                             VectorX<T>* xtplus);
+  void DoResetImplicitIntegratorStatistics() final;
+  void ComputeAndFactorIterationMatrix(
+      const MatrixX<T>& J, const T& dt, int scale);
+  void DoInitialize() final;
+  bool AttemptStepPaired(const T& t0, const T& h, const VectorX<T>& xt0,
+      VectorX<T>* xtplus_euler, VectorX<T>* xtplus_trap);
+  bool StepAbstract(const T& t0, const T& h, const VectorX<T>& xt0,
+      const std::function<VectorX<T>()>& g, int scale,
+      VectorX<T>* xtplus, int trial = 1);
+  bool CalcMatrices(const T& t, const T& h, const VectorX<T>& xt, int scale,
+      int trial);
+  bool DoStep(const T& h) final;
+  bool StepImplicitEuler(const T& t0, const T& h, const VectorX<T>& xt0,
+      VectorX<T>* xtplus);
+  bool StepImplicitTrapezoid(const T& t0, const T& h, const VectorX<T>& xt0,
+      const VectorX<T>& dx0, VectorX<T>* xtplus);
   MatrixX<T> ComputeForwardDiffJacobian(const System<T>&, Context<T>*);
   MatrixX<T> ComputeCentralDiffJacobian(const System<T>&, Context<T>*);
   MatrixX<T> ComputeAutoDiffJacobian(const System<T>& system,
                                      const Context<T>& context);
-  VectorX<T> EvalTimeDerivativesUsingContext();
 
-  // A simple LU factorization is all that is needed; robustness in the solve
-  // comes naturally as dt << 1. Keeping this data in the class definition
-  // serves to minimize heap allocations and deallocations.
-  Eigen::PartialPivLU<MatrixX<double>> LU_;
-
-  // A QR factorization is necessary for automatic differentiation (current
-  // Eigen requirement).
-  Eigen::HouseholderQR<MatrixX<AutoDiffXd>> QR_;
+  // The last computed iteration matrix and factorization, used for both the
+  // integrator and the error estimator.
+  typename ImplicitIntegrator<T>::IterationMatrix iteration_matrix_;
 
   // Vector used in error estimate calculations.
   VectorX<T> err_est_vec_;
 
-  // The pseudo-inverse of the matrix that converts time derivatives of
-  // generalized coordinates to generalized velocities, multiplied by the
-  // change in the generalized coordinates (used in update check tolerance
-  // calculations).
-  std::unique_ptr<VectorBase<T>> pinvN_ddq_;
-
-  // Vectors used in update check tolerance calculations.
-  VectorX<T> unweighted_delta_;
-  std::unique_ptr<VectorBase<T>> weighted_dq_;
-
   // The continuous state update vector used during Newton-Raphson.
   std::unique_ptr<ContinuousState<T>> dx_state_;
 
-  // The scheme to be used for computing the Jacobian matrix during the
-  // nonlinear system solve process.
-  JacobianComputationScheme jacobian_scheme_{
-      JacobianComputationScheme::kForwardDifference};
-
-  // The last computed Jacobian matrix. Keeping this data in the class
-  // definitions serves to minimize heap allocations and deallocations.
-  MatrixX<T> J_;
-
-  // The last computed *negation* of the "iteration matrix", equivalent to
-  // J_ * (dt / scale) - 1, where scale is either 1.0 or 2.0, depending on
-  // whether the implicit Euler or implicit trapezoid method was used. Keeping
-  // this data in the class definition serves to minimize heap allocations
-  // and deallocations.
-  MatrixX<T> neg_iteration_matrix_;
-
-  // Whether the last call to StepAbstract() was a failure.
-  bool last_call_failed_{false};
-
-  // If set to `false`, Jacobian matrices and iteration matrix factorizations
-  // will not be reused.
-  bool reuse_{true};
-
-  // Various combined statistics.
-  int64_t num_jacobian_evaluations_{0};
-  int64_t num_iter_factorizations_{0};
-  int64_t num_jacobian_function_evaluations_{0};
+  // Various statistics.
   int64_t num_nr_iterations_{0};
+  int64_t num_iter_factorizations_{0};
 
   // Implicit trapezoid specific statistics.
   int64_t num_err_est_jacobian_reforms_{0};

--- a/systems/analysis/implicit_integrator.cc
+++ b/systems/analysis/implicit_integrator.cc
@@ -1,0 +1,7 @@
+#include "drake/systems/analysis/implicit_integrator.h"
+
+#include "drake/common/autodiff.h"
+#include "drake/common/default_scalars.h"
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::systems::ImplicitIntegrator)

--- a/systems/analysis/implicit_integrator.h
+++ b/systems/analysis/implicit_integrator.h
@@ -1,0 +1,598 @@
+#pragma once
+
+#include <limits>
+#include <memory>
+#include <utility>
+
+#include <Eigen/LU>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/math/autodiff_gradient.h"
+#include "drake/systems/analysis/integrator_base.h"
+
+namespace drake {
+namespace systems {
+
+/**
+ * A class providing methods shared by implicit integrators.
+ * @tparam T The vector element type, which must be a valid Eigen scalar.
+ *
+ * This class uses Drake's `-inl.h` pattern.  When seeing linker errors from
+ * this class, please refer to https://drake.mit.edu/cxx_inl.html.
+ *
+ * @tparam T The scalar type. Must be a valid Eigen scalar.
+ */
+template <class T>
+class ImplicitIntegrator : public IntegratorBase<T> {
+ public:
+  virtual ~ImplicitIntegrator() {}
+
+  explicit ImplicitIntegrator(const System<T>& system,
+                                   Context<T>* context = nullptr)
+      : IntegratorBase<T>(system, context) {}
+
+  enum class JacobianComputationScheme {
+    /// Forward differencing.
+    kForwardDifference,
+
+    /// Central differencing.
+    kCentralDifference,
+
+    /// Automatic differentiation.
+    kAutomatic
+  };
+
+  /// @name Methods for getting and setting the Jacobian scheme.
+  ///
+  /// Methods for getting and setting the scheme used to determine the
+  /// Jacobian matrix necessary for solving the requisite nonlinear system
+  /// if equations.
+  ///
+  /// Selecting the wrong Jacobian determination scheme will slow (possibly
+  /// critically) the implicit integration process. Automatic differentiation is
+  /// recommended if the System supports it for reasons of both higher
+  /// accuracy and increased speed. Forward differencing (i.e., numerical
+  /// differentiation) exhibits error in the approximation close to √ε, where
+  /// ε is machine epsilon, from n forward dynamics calls (where n is the number
+  /// of state variables). Central differencing yields the most accurate
+  /// numerically differentiated Jacobian matrix, but expends double the
+  /// computational effort for approximately three digits greater accuracy: the
+  /// total error in the central-difference approximation is close to ε^(2/3),
+  /// from 2n forward dynamics calls. See [Nocedal 2004, pp. 167-169].
+  ///
+  /// - [Nocedal 2004] J. Nocedal and S. Wright. Numerical Optimization.
+  ///                  Springer, 2004.
+  /// @{
+
+  /// Sets whether the integrator attempts to reuse Jacobian matrices and
+  /// iteration matrix factorizations (default is `true`). Forming Jacobian
+  /// matrices and factorizing iteration matrices are generally the two most
+  /// expensive operations performed by this integrator. For small systems
+  /// (those with on the order of ten state variables), the additional accuracy
+  /// that using fresh Jacobians and factorizations buys- which can permit
+  /// increased step sizes but should have no effect on solution accuracy- can
+  /// outweigh the small factorization cost.
+  /// @sa get_reuse
+  void set_reuse(bool reuse) { reuse_ = reuse; }
+
+  /// Gets whether the integrator attempts to reuse Jacobian matrices and
+  /// iteration matrix factorizations.
+  /// @sa set_reuse()
+  bool get_reuse() const { return reuse_; }
+
+  /// Sets the Jacobian computation scheme. This function can be safely called
+  /// at any time (i.e., the integrator need not be re-initialized afterward).
+  /// @note Discards any already-computed Jacobian matrices if the scheme
+  ///       changes.
+  void set_jacobian_computation_scheme(JacobianComputationScheme scheme) {
+    if (jacobian_scheme_ != scheme)
+      J_.resize(0, 0);
+    jacobian_scheme_ = scheme;
+  }
+
+  JacobianComputationScheme get_jacobian_computation_scheme() const {
+    return jacobian_scheme_;
+  }
+  /// @}
+
+  /// @name Cumulative statistics functions.
+  /// The functions return statistics specific to the implicit integration
+  /// process.
+  /// @{
+
+  /// Gets the number of ODE function evaluations
+  /// (calls to EvalTimeDerivatives()) *used only for computing
+  /// the Jacobian matrices* since the last call to ResetStatistics(). This
+  /// count includes those derivative calculations necessary for computing
+  /// Jacobian matrices during error estimation processes.
+  int64_t get_num_derivative_evaluations_for_jacobian() const {
+    return num_jacobian_function_evaluations_;
+  }
+
+  /// Gets the number of Jacobian computations (i.e., the number of times
+  /// that the Jacobian matrix was reformed) since the last call to
+  /// ResetStatistics(). This count includes those evaluations necessary
+  /// during error estimation processes.
+  int64_t get_num_jacobian_evaluations() const { return
+        num_jacobian_evaluations_;
+  }
+
+  /// @name Cumulative statistics functions.
+  /// The functions return statistics specific to the implicit integration
+  /// process.
+  /// @{
+
+  /// Gets the number of iterations used in the Newton-Raphson nonlinear systems
+  /// of equation solving process since the last call to ResetStatistics(). This
+  /// count includes those Newton-Raphson iterations used during error
+  /// estimation processes.
+  int64_t get_num_newton_raphson_iterations() const {
+    return do_get_num_newton_raphson_iterations();
+  }
+
+  /// Gets the number of factorizations of the iteration matrix since the last
+  /// call to ResetStatistics(). This count includes those refactorizations
+  /// necessary during error estimation processes.
+  int64_t get_num_iteration_matrix_factorizations() const {
+    return do_get_num_iteration_matrix_factorizations();
+  }
+
+  /// Gets the number of ODE function evaluations
+  /// (calls to EvalTimeDerivatives()) *used only for the error estimation
+  /// process* since the last call to ResetStatistics(). This count
+  /// includes those needed to compute Jacobian matrices.
+  int64_t get_num_error_estimator_derivative_evaluations() const {
+    return do_get_num_error_estimator_derivative_evaluations();
+  }
+  /// @}
+
+  /// @name Error-estimation statistics functions.
+  /// The functions return statistics specific to the error estimation
+  /// process.
+  /// @{
+  /// Gets the number of ODE function evaluations (calls to
+  /// CalcTimeDerivatives()) *used only for computing the Jacobian matrices
+  /// needed by the error estimation process* since the last call to
+  /// ResetStatistics().
+  int64_t get_num_error_estimator_derivative_evaluations_for_jacobian() const {
+    return do_get_num_error_estimator_derivative_evaluations_for_jacobian();
+  }
+
+  /// Gets the number of iterations *used in the Newton-Raphson nonlinear
+  /// systems of equation solving process for the error estimation process*
+  /// since the last call to ResetStatistics().
+  int64_t get_num_error_estimator_newton_raphson_iterations() const { return
+        do_get_num_error_estimator_newton_raphson_iterations();
+  }
+
+  /// Gets the number of Jacobian matrix computations *used only during
+  /// the error estimation process* since the last call to ResetStatistics().
+  int64_t get_num_error_estimator_jacobian_evaluations() const {
+    return do_get_num_error_estimator_jacobian_evaluations();
+  }
+
+  /// Gets the number of factorizations of the iteration matrix *used only
+  /// during the error estimation process* since the last call to
+  /// ResetStatistics().
+  int64_t get_num_error_estimator_iteration_matrix_factorizations() const {
+    return do_get_num_error_estimator_iteration_matrix_factorizations();
+  }
+  /// @}
+
+ protected:
+  /// A class for storing the factorization of an iteration matrix and using it
+  /// to solve linear systems of equations. This class exists simply because
+  /// Eigen AutoDiff puts limitations on what kinds of factorizations can be
+  /// used; encapsulating the iteration matrix factorizations like this frees
+  /// the implementer of these kinds of details.
+  class IterationMatrix {
+   public:
+    void SetAndFactorIterationMatrix(const MatrixX<T>& iteration_matrix);
+    VectorX<T> Solve(const VectorX<T>& b) const;
+
+    /// Returns whether the iteration matrix has been set and factored.
+    bool matrix_factored() const { return matrix_factored_; }
+
+   private:
+    bool matrix_factored_{false};
+
+    // A simple LU factorization is all that is needed for ImplicitIntegrator
+    // templated on scalar type `double`; robustness in the solve
+    // comes naturally as dt << 1. Keeping this data in the class definition
+    // serves to minimize heap allocations and deallocations.
+    Eigen::PartialPivLU<MatrixX<double>> LU_;
+
+    // The only factorization supported by automatic differentiation in Eigen is
+    // currently QR. When ImplicitIntegrator is templated on type AutoDiffXd,
+    // this will be the factorization that is used.
+    Eigen::HouseholderQR<MatrixX<AutoDiffXd>> QR_;
+  };
+
+  /**
+   * Resets any statistics particular to a specific implicit integrator. The
+   * default implementation of this function does nothing. If your integrator
+   * collects its own statistics, you should re-implement this method and
+   * reset them there.
+   */
+  virtual void DoResetImplicitIntegratorStatistics() {}
+
+  // TODO(edrumwri) Document the functions below (or move documentation from
+  // the -inl file to here).
+  virtual int64_t do_get_num_newton_raphson_iterations() const = 0;
+  virtual int64_t do_get_num_iteration_matrix_factorizations() const = 0;
+  virtual int64_t do_get_num_error_estimator_derivative_evaluations() const = 0;
+  virtual int64_t
+      do_get_num_error_estimator_derivative_evaluations_for_jacobian()
+      const = 0;
+  virtual int64_t do_get_num_error_estimator_newton_raphson_iterations()
+      const = 0;
+  virtual int64_t do_get_num_error_estimator_jacobian_evaluations() const = 0;
+  virtual int64_t do_get_num_error_estimator_iteration_matrix_factorizations()
+      const = 0;
+  MatrixX<T>& get_mutable_jacobian() { return J_; }
+  void set_last_call_succeeded(bool success) { last_call_succeeded_ = success; }
+  bool last_call_succeeded() const { return last_call_succeeded_; }
+  bool IsBadJacobian(const MatrixX<T>& J) const;
+  void DoResetStatistics() override;
+  const MatrixX<T>& CalcJacobian(const T& tf, const VectorX<T>& xtplus);
+  void ComputeForwardDiffJacobian(const System<T>&, const T& t,
+      const VectorX<T>& xc, Context<T>*, MatrixX<T>* J);
+  void ComputeCentralDiffJacobian(const System<T>&, const T& t,
+      const VectorX<T>& xc, Context<T>*, MatrixX<T>* J);
+  void ComputeAutoDiffJacobian(const System<T>& system, const T& t,
+      const VectorX<T>& xc, const Context<T>& context, MatrixX<T>* J);
+  VectorX<T> EvalTimeDerivativesUsingContext();
+
+ private:
+  // The scheme to be used for computing the Jacobian matrix during the
+  // nonlinear system solve process.
+  JacobianComputationScheme jacobian_scheme_{
+      JacobianComputationScheme::kForwardDifference};
+
+  // The last computed Jacobian matrix.
+  MatrixX<T> J_;
+
+  // Whether the last stepping call was successful.
+  bool last_call_succeeded_{true};
+
+  // If set to `false`, Jacobian matrices and iteration matrix factorizations
+  // will not be reused.
+  bool reuse_{true};
+
+  // Various combined statistics.
+  int64_t num_jacobian_evaluations_{0};
+  int64_t num_jacobian_function_evaluations_{0};
+};
+
+template <class T>
+void ImplicitIntegrator<T>::DoResetStatistics() {
+  num_jacobian_function_evaluations_ = 0;
+  num_jacobian_evaluations_ = 0;
+}
+
+// We do not support computing the Jacobian matrix using automatic
+// differentiation when the scalar is already an AutoDiff type.
+// Note: must be declared inline because it's specialized and located in the
+// header file (to avoid multiple definition errors).
+template <>
+inline void ImplicitIntegrator<AutoDiffXd>::
+    ComputeAutoDiffJacobian(const System<AutoDiffXd>&,
+      const AutoDiffXd&, const VectorX<AutoDiffXd>&,
+      const Context<AutoDiffXd>&, MatrixX<AutoDiffXd>*) {
+        throw std::runtime_error("AutoDiff'd Jacobian not supported from "
+                                     "AutoDiff'd ImplicitIntegrator");
+}
+
+// Computes the Jacobian of the ordinary differential equations around time
+// and continuous state `(t, xt)` using automatic differentiation.
+// @param system The dynamical system.
+// @param t the time around which to compute the Jacobian matrix.
+// @param xt the continuous state around which to compute the Jacobian matrix.
+// @param context the Context of the system, at time and continuous state
+//        unknown.
+// @param [out] the Jacobian matrix around time and state `(t, xt)`.
+// @note The continuous state will be indeterminate on return.
+template <class T>
+void ImplicitIntegrator<T>::ComputeAutoDiffJacobian(
+    const System<T>& system, const T& t, const VectorX<T>& xt,
+    const Context<T>& context, MatrixX<T>* J) {
+  SPDLOG_DEBUG(drake::log(), "  ImplicitIntegrator Compute Autodiff Jacobian "
+               "t={}", t);
+  // Create AutoDiff versions of the state vector.
+  VectorX<AutoDiffXd> a_xt = xt;
+
+  // Set the size of the derivatives and prepare for Jacobian calculation.
+  const int n_state_dim = a_xt.size();
+  for (int i = 0; i < n_state_dim; ++i)
+    a_xt[i].derivatives() = VectorX<T>::Unit(n_state_dim, i);
+
+  // Get the system and the context in AutoDiffable format. Inputs must also
+  // be copied to the context used by the AutoDiff'd system (which is
+  // accomplished using FixInputPortsFrom()).
+  // TODO(edrumwri): Investigate means for moving as many of the operations
+  //                 below offline (or with lower frequency than once-per-
+  //                 Jacobian calculation) as is possible. These operations
+  //                 are likely to be expensive.
+  const auto adiff_system = system.ToAutoDiffXd();
+  std::unique_ptr<Context<AutoDiffXd>> adiff_context = adiff_system->
+      AllocateContext();
+  adiff_context->SetTimeStateAndParametersFrom(context);
+  adiff_system->FixInputPortsFrom(system, context, adiff_context.get());
+  adiff_context->SetTime(t);
+
+  // Set the continuous state in the context.
+  adiff_context->SetContinuousState(a_xt);
+
+  // Evaluate the derivatives at that state.
+  const VectorX<AutoDiffXd> result =
+      this->EvalTimeDerivatives(*adiff_system, *adiff_context).CopyToVector();
+
+  *J = math::autoDiffToGradientMatrix(result);
+}
+
+// Evaluates the ordinary differential equations at the time and state in
+// the system's context (stored by the integrator).
+template <class T>
+VectorX<T> ImplicitIntegrator<T>::EvalTimeDerivativesUsingContext() {
+    return this->EvalTimeDerivatives(this->get_context()).CopyToVector();
+}
+
+// Computes the Jacobian of the ordinary differential equations around time
+// and continuous state `(t, xt)` using a first-order forward difference (i.e.,
+// numerical differentiation).
+// @param system The dynamical system.
+// @param t the time around which to compute the Jacobian matrix.
+// @param xt the continuous state around which to compute the Jacobian matrix.
+// @param context the Context of the system, at time and continuous state
+//        unknown.
+// @param [out] the Jacobian matrix around time and state `(t, xt)`.
+// @note The continuous state will be indeterminate on return.
+template <class T>
+void ImplicitIntegrator<T>::ComputeForwardDiffJacobian(
+    const System<T>&, const T& t, const VectorX<T>& xt, Context<T>* context,
+    MatrixX<T>* J) {
+  using std::abs;
+
+  // Set epsilon to the square root of machine precision.
+  const double eps = std::sqrt(std::numeric_limits<double>::epsilon());
+
+  // Get the number of continuous state variables xt.
+  const int n = context->num_continuous_states();
+
+  SPDLOG_DEBUG(drake::log(), "  ImplicitIntegrator Compute Forwarddiff "
+               "{}-Jacobian t={}", n, t);
+  SPDLOG_DEBUG(drake::log(), "  computing from state {}", xt.transpose());
+
+  // Initialize the Jacobian.
+  J->resize(n, n);
+
+  // Evaluate f(t,xt).
+  context->SetTimeAndContinuousState(t, xt);
+  const VectorX<T> f = EvalTimeDerivativesUsingContext();
+
+  // Compute the Jacobian.
+  VectorX<T> xt_prime = xt;
+  for (int i = 0; i < n; ++i) {
+    // Compute a good increment to the dimension using approximately 1/eps
+    // digits of precision. Note that if |xt| is large, the increment will
+    // be large as well. If |xt| is small, the increment will be no smaller
+    // than eps.
+    const T abs_xi = abs(xt(i));
+    T dxi(abs_xi);
+    if (dxi <= 1) {
+      // When |xt[i]| is small, increment will be eps.
+      dxi = eps;
+    } else {
+      // |xt[i]| not small; make increment a fraction of |xt[i]|.
+      dxi = eps * abs_xi;
+    }
+
+    // Update xt', minimizing the effect of roundoff error by ensuring that
+    // x and dx differ by an exactly representable number. See p. 192 of
+    // Press, W., Teukolsky, S., Vetterling, W., and Flannery, P. Numerical
+    //   Recipes in C++, 2nd Ed., Cambridge University Press, 2002.
+    xt_prime(i) = xt(i) + dxi;
+    dxi = xt_prime(i) - xt(i);
+
+    // TODO(sherm1) This is invalidating q, v, and z but we only changed one.
+    //              Switch to a method that invalides just the relevant
+    //              partition, and ideally modify only the one changed element.
+    // Compute f' and set the relevant column of the Jacobian matrix.
+    context->SetTimeAndContinuousState(t, xt_prime);
+    J->col(i) = (EvalTimeDerivativesUsingContext() - f) / dxi;
+
+    // Reset xt' to xt.
+    xt_prime(i) = xt(i);
+  }
+}
+
+// Computes the Jacobian of the ordinary differential equations around time
+// and continuous state `(t, xt)` using a second-order central difference (i.e.,
+// numerical differentiation).
+// @param system The dynamical system.
+// @param t the time around which to compute the Jacobian matrix.
+// @param xt the continuous state around which to compute the Jacobian matrix.
+// @param context the Context of the system, at time and continuous state
+//        unknown.
+// @param [out] the Jacobian matrix around time and state `(t, xt)`.
+// @note The continuous state will be indeterminate on return.
+template <class T>
+void ImplicitIntegrator<T>::ComputeCentralDiffJacobian(
+    const System<T>&, const T& t, const VectorX<T>& xt, Context<T>* context,
+    MatrixX<T>* J) {
+  using std::abs;
+
+  // Cube root of machine precision (indicated by theory) seems a bit coarse.
+  // Pick power of eps halfway between 6/12 (i.e., 1/2) and 4/12 (i.e., 1/3).
+  const double eps = std::pow(std::numeric_limits<double>::epsilon(), 5.0/12);
+
+  // Get the number of continuous state variables xt.
+  const int n = context->num_continuous_states();
+
+  SPDLOG_DEBUG(drake::log(), "  ImplicitIntegrator Compute ",
+               "Centraldiff {}-Jacobian t={}", n, t);
+
+  // Initialize the Jacobian.
+  J->resize(n, n);
+
+  // Evaluate f(t,xt).
+  context->SetTimeAndContinuousState(t, xt);
+  const VectorX<T> f = EvalTimeDerivativesUsingContext();
+
+  // Compute the Jacobian.
+  VectorX<T> xt_prime = xt;
+  for (int i = 0; i < n; ++i) {
+    // Compute a good increment to the dimension using approximately 1/eps
+    // digits of precision. Note that if |xt| is large, the increment will
+    // be large as well. If |xt| is small, the increment will be no smaller
+    // than eps.
+    const T abs_xi = abs(xt(i));
+    T dxi(abs_xi);
+    if (dxi <= 1) {
+      // When |xt[i]| is small, increment will be eps.
+      dxi = eps;
+    } else {
+      // |xt[i]| not small; make increment a fraction of |xt[i]|.
+      dxi = eps * abs_xi;
+    }
+
+    // Update xt', minimizing the effect of roundoff error, by ensuring that
+    // x and dx differ by an exactly representable number. See p. 192 of
+    // Press, W., Teukolsky, S., Vetterling, W., and Flannery, P. Numerical
+    //   Recipes in C++, 2nd Ed., Cambridge University Press, 2002.
+    xt_prime(i) = xt(i) + dxi;
+    const T dxi_plus = xt_prime(i) - xt(i);
+
+    // TODO(sherm1) This is invalidating q, v, and z but we only changed one.
+    //              Switch to a method that invalides just the relevant
+    //              partition, and ideally modify only the one changed element.
+    // Compute f(x+dx).
+    context->SetContinuousState(xt_prime);
+    VectorX<T> fprime_plus = EvalTimeDerivativesUsingContext();
+
+    // Update xt' again, minimizing the effect of roundoff error.
+    xt_prime(i) = xt(i) - dxi;
+    const T dxi_minus = xt(i) - xt_prime(i);
+
+    // Compute f(x-dx).
+    context->SetContinuousState(xt_prime);
+    VectorX<T> fprime_minus = EvalTimeDerivativesUsingContext();
+
+    // Set the Jacobian column.
+    J->col(i) = (fprime_plus - fprime_minus) / (dxi_plus + dxi_minus);
+
+    // Reset xt' to xt.
+    xt_prime(i) = xt(i);
+  }
+}
+
+// Factors a dense matrix (the iteration matrix) using LU factorization,
+// which should be faster than the QR factorization used in the specialized
+// template method immediately below.
+template <class T>
+void ImplicitIntegrator<T>::IterationMatrix::SetAndFactorIterationMatrix(
+    const MatrixX<T>& iteration_matrix) {
+  LU_.compute(iteration_matrix);
+  matrix_factored_ = true;
+}
+
+// Factors a dense matrix (the iteration matrix). This
+// AutoDiff-specialized method is necessary because Eigen's LU factorization,
+// which should be faster than the QR factorization used here, is not currently
+// AutoDiff-able (while the QR factorization *is* AutoDiff-able).
+// Note: must be declared inline because it's specialized and located in the
+// header file (to avoid multiple definition errors).
+template <>
+inline void ImplicitIntegrator<AutoDiffXd>::IterationMatrix::
+    SetAndFactorIterationMatrix(const MatrixX<AutoDiffXd>& iteration_matrix) {
+  QR_.compute(iteration_matrix);
+  matrix_factored_ = true;
+}
+
+// Solves a linear system Ax = b for x using the iteration matrix (A)
+// factored using LU decomposition.
+// @sa Factor()
+template <class T>
+VectorX<T> ImplicitIntegrator<T>::IterationMatrix::Solve(
+    const VectorX<T>& b) const {
+  return LU_.solve(b);
+}
+
+// Solves the linear system Ax = b for x using the iteration matrix (A)
+// factored using QR decomposition.
+// @sa Factor()
+// Note: must be declared inline because it's specialized and located in the
+// header file (to avoid multiple definition errors).
+template <>
+inline VectorX<AutoDiffXd>
+ImplicitIntegrator<AutoDiffXd>::IterationMatrix::Solve(
+    const VectorX<AutoDiffXd>& b) const {
+  return QR_.solve(b);
+}
+
+// Checks to see whether a Jacobian matrix has "become bad" and needs to be
+// recomputed.
+template <class T>
+bool ImplicitIntegrator<T>::IsBadJacobian(const MatrixX<T>& J) const {
+  return !J.allFinite();
+}
+
+// Compute the partial derivative of the ordinary differential equations with
+// respect to the state variables for a given x(t).
+// @post the context's time and continuous state will be temporarily set during
+//       this call (and then reset to their original values) on return.
+template <class T>
+const MatrixX<T>& ImplicitIntegrator<T>::CalcJacobian(const T& t,
+    const VectorX<T>& x) {
+  // We change the context but will change it back.
+  Context<T>* context = this->get_mutable_context();
+
+  // Get the current time and state.
+  const T t_current = context->get_time();
+  const VectorX<T> x_current = context->get_continuous_state_vector().
+      CopyToVector();
+
+  // Update the time and state.
+  context->SetTimeAndContinuousState(t, x);
+  num_jacobian_evaluations_++;
+
+  // Get the current number of ODE evaluations.
+  int64_t current_ODE_evals = this->get_num_derivative_evaluations();
+
+  // Get a the system.
+  const System<T>& system = this->get_system();
+
+  // TODO(edrumwri): Give the caller the option to provide their own Jacobian.
+  [this, context, &system, &t, &x]() {
+    switch (jacobian_scheme_) {
+      case JacobianComputationScheme::kForwardDifference:
+        ComputeForwardDiffJacobian(system, t, x, &*context, &J_);
+        break;
+
+      case JacobianComputationScheme::kCentralDifference:
+        ComputeCentralDiffJacobian(system, t, x, &*context, &J_);
+        break;
+
+      case JacobianComputationScheme::kAutomatic:
+        ComputeAutoDiffJacobian(system, t, x, *context, &J_);
+        break;
+    }
+  }();
+
+  // Use the new number of ODE evaluations to determine the number of Jacobian
+  // evaluations.
+  num_jacobian_function_evaluations_ += this->get_num_derivative_evaluations()
+      - current_ODE_evals;
+
+  // Reset the time and state.
+  context->SetTimeAndContinuousState(t_current, x_current);
+
+  return J_;
+}
+
+}  // namespace systems
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::systems::ImplicitIntegrator)

--- a/systems/analysis/implicit_integrator.h
+++ b/systems/analysis/implicit_integrator.h
@@ -18,9 +18,6 @@ namespace systems {
  * A class providing methods shared by implicit integrators.
  * @tparam T The vector element type, which must be a valid Eigen scalar.
  *
- * This class uses Drake's `-inl.h` pattern.  When seeing linker errors from
- * this class, please refer to https://drake.mit.edu/cxx_inl.html.
- *
  * @tparam T The scalar type. Must be a valid Eigen scalar.
  */
 template <class T>
@@ -217,8 +214,7 @@ class ImplicitIntegrator : public IntegratorBase<T> {
    */
   virtual void DoResetImplicitIntegratorStatistics() {}
 
-  // TODO(edrumwri) Document the functions below (or move documentation from
-  // the -inl file to here).
+  // TODO(edrumwri) Document the functions below.
   virtual int64_t do_get_num_newton_raphson_iterations() const = 0;
   virtual int64_t do_get_num_iteration_matrix_factorizations() const = 0;
   virtual int64_t do_get_num_error_estimator_derivative_evaluations() const = 0;


### PR DESCRIPTION
Refactor of the Implicit Euler integrator to support building the upcoming Radau3 integrator off of a shared codebase. This also cleans up the code and documentation a little. There is very little new code in this PR. Summary of modifications to the code that don't include moves:

1. The iteration matrix and factorization has been moved to an internal class. This will allow us to maintain two of these structures for Radau3.
2. The stepping methods, Jacobian matrix computation, and iteration matrix computation no longer pass around hidden state using the Context. The time and continuous state variables are now passed around explicitly.

(Do not review yet, just making sure CI is happy)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11182)
<!-- Reviewable:end -->
