### PR TITLE
For Issue#11064: Deprecate use of Isometry3 in WeldFrames(), SetFreeBodyPoseInWorldFrame(), SetFreeBodyPoseInAnchoredFrame()

### DIFF
--- a/bindings/pydrake/examples/test/manipulation_station_test.py
+++ b/bindings/pydrake/examples/test/manipulation_station_test.py
@@ -64,7 +64,7 @@ class TestManipulationStation(unittest.TestCase):
         X_WI = RigidTransform.Identity()
         plant.WeldFrames(plant.world_frame(),
                          plant.GetFrameByName("iiwa_link_0", iiwa),
-                         X_WI.GetAsIsometry3())
+                         X_WI)
 
         wsg_model_file = FindResourceOrThrow(
             "drake/manipulation/models/wsg_50_description/sdf/"
@@ -74,7 +74,7 @@ class TestManipulationStation(unittest.TestCase):
         plant.WeldFrames(
             plant.GetFrameByName("iiwa_link_7", iiwa),
             plant.GetFrameByName("body", wsg),
-            X_7G.GetAsIsometry3())
+            X_7G)
 
         # Register models for the controller.
         station.RegisterIiwaControllerModel(

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -127,7 +127,7 @@ PYBIND11_MODULE(plant, m) {
               WarnDeprecated(doc_iso3_deprecation);
               return self->WeldFrames(A, B, RigidTransform<double>(X_BG));
             },
-            py::arg("A"), py::arg("B"), py::arg("X_BG"), py_reference_internal,
+            py::arg("A"), py::arg("B"), py::arg("X_AB"), py_reference_internal,
             doc_iso3_deprecation)
         // N.B. This overload of `AddForceElement` is required to precede
         // the generic overload below so we can use our internal specialization

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -127,8 +127,8 @@ PYBIND11_MODULE(plant, m) {
               WarnDeprecated(doc_iso3_deprecation);
               return self->WeldFrames(A, B, RigidTransform<double>(X_BG));
             },
-            py::arg("A"), py::arg("B"), py::arg("X_BG"),
-            py_reference_internal, doc_iso3_deprecation)
+            py::arg("A"), py::arg("B"), py::arg("X_BG"), py_reference_internal,
+            doc_iso3_deprecation)
         // N.B. This overload of `AddForceElement` is required to precede
         // the generic overload below so we can use our internal specialization
         // to label this as our unique gravity field, mimicking the C++ API.

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -116,15 +116,18 @@ PYBIND11_MODULE(plant, m) {
             doc.MultibodyPlant.AddRigidBody.doc_2args)
         .def("WeldFrames",
             py::overload_cast<const Frame<T>&, const Frame<T>&,
-                const Isometry3<double>&>(&Class::WeldFrames),
-            py::arg("A"), py::arg("B"), py::arg("X_AB"), py_reference_internal,
-            doc_iso3_deprecation)
-        .def("WeldFrames",
-            py::overload_cast<const Frame<T>&, const Frame<T>&,
                 const RigidTransform<double>&>(&Class::WeldFrames),
             py::arg("A"), py::arg("B"),
             py::arg("X_AB") = RigidTransform<double>::Identity(),
             py_reference_internal, doc.MultibodyPlant.WeldFrames.doc)
+        .def("WeldFrames",
+            [doc_iso3_deprecation](Class* self, const Frame<T>& A,
+                const Frame<T>& B,
+                const Isometry3<double>& X_BG) -> const WeldJoint<T>& {
+              WarnDeprecated(doc_iso3_deprecation);
+              return self->WeldFrames(A, B, RigidTransform<double>(X_BG));
+            },
+            py_reference_internal, doc_iso3_deprecation)
         // N.B. This overload of `AddForceElement` is required to precede
         // the generic overload below so we can use our internal specialization
         // to label this as our unique gravity field, mimicking the C++ API.

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -127,6 +127,7 @@ PYBIND11_MODULE(plant, m) {
               WarnDeprecated(doc_iso3_deprecation);
               return self->WeldFrames(A, B, RigidTransform<double>(X_BG));
             },
+            py::arg("A"), py::arg("B"), py::arg("X_BG"),
             py_reference_internal, doc_iso3_deprecation)
         // N.B. This overload of `AddForceElement` is required to precede
         // the generic overload below so we can use our internal specialization

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -123,9 +123,9 @@ PYBIND11_MODULE(plant, m) {
         .def("WeldFrames",
             [doc_iso3_deprecation](Class* self, const Frame<T>& A,
                 const Frame<T>& B,
-                const Isometry3<double>& X_BG) -> const WeldJoint<T>& {
+                const Isometry3<double>& X_AB) -> const WeldJoint<T>& {
               WarnDeprecated(doc_iso3_deprecation);
-              return self->WeldFrames(A, B, RigidTransform<double>(X_BG));
+              return self->WeldFrames(A, B, RigidTransform<double>(X_AB));
             },
             py::arg("A"), py::arg("B"), py::arg("X_AB"), py_reference_internal,
             doc_iso3_deprecation)

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -419,10 +419,8 @@ class TestPlant(unittest.TestCase):
             file_name=wsg50_sdf_path, model_name='gripper')
 
         # Weld the base of arm and gripper to reduce the number of states.
-        X_EeGripper = Isometry3.Identity()
-        X_EeGripper.set_translation([0, 0, 0.081])
-        X_EeGripper.set_rotation(
-            RollPitchYaw(np.pi / 2, 0, np.pi / 2).ToRotationMatrix().matrix())
+        X_EeGripper = RigidTransform(
+            RollPitchYaw(np.pi / 2, 0, np.pi / 2), [0, 0, 0.081])
         plant.WeldFrames(A=plant.world_frame(),
                          B=plant.GetFrameByName("iiwa_link_0", iiwa_model))
         plant.WeldFrames(

--- a/examples/manipulation_station/manipulation_station.cc
+++ b/examples/manipulation_station/manipulation_station.cc
@@ -398,7 +398,7 @@ void ManipulationStation<T>::MakeIiwaControllerModel() {
       owned_controller_plant_->world_frame(),
       owned_controller_plant_->GetFrameByName(iiwa_model_.child_frame->name(),
                                               controller_iiwa_model),
-      iiwa_model_.X_PC.GetAsIsometry3());
+      iiwa_model_.X_PC);
   // Add a single body to represent the IIWA pendant's calibration of the
   // gripper.  The body of the WSG accounts for >90% of the total mass
   // (according to the sdf)... and we don't believe our inertia calibration
@@ -415,7 +415,7 @@ void ManipulationStation<T>::MakeIiwaControllerModel() {
   owned_controller_plant_->WeldFrames(
       owned_controller_plant_->GetFrameByName(wsg_model_.parent_frame->name(),
                                               controller_iiwa_model),
-      wsg_equivalent.body_frame(), wsg_model_.X_PC.GetAsIsometry3());
+      wsg_equivalent.body_frame(), wsg_model_.X_PC);
 
   owned_controller_plant_
       ->template AddForceElement<multibody::UniformGravityFieldElement>();

--- a/examples/manipulation_station/manipulation_station_hardware_interface.cc
+++ b/examples/manipulation_station/manipulation_station_hardware_interface.cc
@@ -139,7 +139,7 @@ ManipulationStationHardwareInterface::ManipulationStationHardwareInterface(
   owned_controller_plant_->WeldFrames(owned_controller_plant_->world_frame(),
                                       owned_controller_plant_->GetFrameByName(
                                           "iiwa_link_0", controller_iiwa_model),
-                                      Isometry3d::Identity());
+                                      math::RigidTransformd::Identity());
   owned_controller_plant_
       ->template AddForceElement<multibody::UniformGravityFieldElement>();
   owned_controller_plant_->Finalize();

--- a/manipulation/schunk_wsg/test/schunk_wsg_position_controller_test.cc
+++ b/manipulation/schunk_wsg/test/schunk_wsg_position_controller_test.cc
@@ -67,7 +67,7 @@ GTEST_TEST(SchunkWsgPositionControllerTest, SimTest) {
       "wsg_50_description/sdf/schunk_wsg_50.sdf");
   const auto wsg_model = Parser(wsg).AddModelFromFile(wsg_sdf_path, "gripper");
   wsg->WeldFrames(wsg->world_frame(), wsg->GetFrameByName("body", wsg_model),
-                  Eigen::Isometry3d::Identity());
+                  math::RigidTransformd ::Identity());
   wsg->Finalize();
 
   const auto controller = builder.AddSystem<SchunkWsgPositionController>();

--- a/manipulation/schunk_wsg/test/schunk_wsg_position_controller_test.cc
+++ b/manipulation/schunk_wsg/test/schunk_wsg_position_controller_test.cc
@@ -67,7 +67,7 @@ GTEST_TEST(SchunkWsgPositionControllerTest, SimTest) {
       "wsg_50_description/sdf/schunk_wsg_50.sdf");
   const auto wsg_model = Parser(wsg).AddModelFromFile(wsg_sdf_path, "gripper");
   wsg->WeldFrames(wsg->world_frame(), wsg->GetFrameByName("body", wsg_model),
-                  math::RigidTransformd ::Identity());
+                  math::RigidTransformd::Identity());
   wsg->Finalize();
 
   const auto controller = builder.AddSystem<SchunkWsgPositionController>();

--- a/multibody/optimization/test/optimization_with_contact_utilities.cc
+++ b/multibody/optimization/test/optimization_with_contact_utilities.cc
@@ -50,8 +50,7 @@ FreeSpheresAndBoxes<T>::FreeSpheresAndBoxes(
       ground, math::RigidTransformd::Identity(),
       geometry::Box(ground_box_size(0), ground_box_size(1), ground_box_size(2)),
       "ground", ground_friction_, scene_graph_);
-  math::RigidTransformd X_WG = math::RigidTransformd::Identity();
-  X_WG.set_translation(Eigen::Vector3d(0, 0, -ground_box_size(2) / 2));
+  math::RigidTransformd X_WG(Eigen::Vector3d(0, 0, -ground_box_size(2) / 2));
   plant_->WeldFrames(plant_->world_frame(), ground.body_frame(), X_WG);
 
   // Add gravity.

--- a/multibody/optimization/test/optimization_with_contact_utilities.cc
+++ b/multibody/optimization/test/optimization_with_contact_utilities.cc
@@ -50,7 +50,8 @@ FreeSpheresAndBoxes<T>::FreeSpheresAndBoxes(
       ground, math::RigidTransformd::Identity(),
       geometry::Box(ground_box_size(0), ground_box_size(1), ground_box_size(2)),
       "ground", ground_friction_, scene_graph_);
-  math::RigidTransformd X_WG(Eigen::Vector3d(0, 0, -ground_box_size(2) / 2));
+  math::RigidTransformd X_WG = math::RigidTransformd::Identity();
+  X_WG.set_translation(Eigen::Vector3d(0, 0, -ground_box_size(2) / 2));
   plant_->WeldFrames(plant_->world_frame(), ground.body_frame(), X_WG);
 
   // Add gravity.

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3006,7 +3006,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   }
 
   DRAKE_DEPRECATED(
-      "2019-06-15",
+      "2019-07-01",
       "This Isometry3 overload will be removed pending the resolution of "
       "#9865. Use the RigidTransform overload instead.")
   const WeldJoint<T>& WeldFrames(
@@ -3016,7 +3016,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   }
 
   DRAKE_DEPRECATED(
-      "2019-06-15",
+      "2019-07-01",
       "This Isometry3 overload will be removed pending the resolution of "
       "#9865. Use the RigidTransform overload instead.")
   void SetFreeBodyPoseInWorldFrame(systems::Context<T>* context,
@@ -3026,7 +3026,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   }
 
   DRAKE_DEPRECATED(
-      "2019-06-15",
+      "2019-07-01",
       "This Isometry3 overload will be removed pending the resolution of "
       "#9865. Use the RigidTransform overload instead.")
   void SetFreeBodyPoseInAnchoredFrame(systems::Context<T>* context,

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3005,18 +3005,30 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
         name, parent, X_PF_rt, child, X_BM_rt, std::forward<Args>(args)...);
   }
 
+  DRAKE_DEPRECATED(
+      "2019-06-15",
+      "This Isometry3 overload will be removed pending the resolution of "
+      "#9865. Use the RigidTransform overload instead.")
   const WeldJoint<T>& WeldFrames(
       const Frame<T>& A, const Frame<T>& B,
       const Isometry3<double>& X_AB) {
-    return WeldFrames(A, B, math::RigidTransformd(X_AB));
+    return WeldFrames(A, B, math::RigidTransform<double>(X_AB));
   }
 
+  DRAKE_DEPRECATED(
+      "2019-06-15",
+      "This Isometry3 overload will be removed pending the resolution of "
+      "#9865. Use the RigidTransform overload instead.")
   void SetFreeBodyPoseInWorldFrame(systems::Context<T>* context,
                                    const Body<T>& body,
                                    const Isometry3<T>& X_WB) const {
     SetFreeBodyPoseInWorldFrame(context, body, math::RigidTransform<T>(X_WB));
   }
 
+  DRAKE_DEPRECATED(
+      "2019-06-15",
+      "This Isometry3 overload will be removed pending the resolution of "
+      "#9865. Use the RigidTransform overload instead.")
   void SetFreeBodyPoseInAnchoredFrame(systems::Context<T>* context,
                                       const Frame<T>& frame_F,
                                       const Body<T>& body,

--- a/multibody/plant/test/kuka_iiwa_model_tests.h
+++ b/multibody/plant/test/kuka_iiwa_model_tests.h
@@ -81,8 +81,7 @@ class KukaIiwaModelTests : public ::testing::Test {
         RollPitchYaw<double>(M_PI / 3, -M_PI / 2, M_PI / 8),
         Vector3<double>(0.05, -0.2, 0.05));
     plant_->SetFreeBodyPoseInAnchoredFrame(
-        context_.get(), plant_->world_frame(), base_body,
-        X_WB.GetAsIsometry3());
+        context_.get(), plant_->world_frame(), base_body, X_WB);
     // Set an arbitrary non-zero spatial velocity of the floating base link.
     const Vector3<double> w_WB{-1, 1, -1};
     const Vector3<double> v_WB{1, -1, 1};

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -40,7 +40,6 @@
 namespace drake {
 
 using Eigen::AngleAxisd;
-using Eigen::Isometry3d;
 using Eigen::Matrix2d;
 using Eigen::Translation3d;
 using Eigen::Vector2d;
@@ -2402,10 +2401,10 @@ GTEST_TEST(StateSelection, FloatingBodies) {
       0.736 +
       // table's top width
       0.057 / 2;
-  const RigidTransformd X_W_Link0(Vector3d(0, 0, table_top_z_in_world));
+  const RigidTransformd X_WLink0(Vector3d(0, 0, table_top_z_in_world));
   plant.WeldFrames(
       plant.world_frame(), plant.GetFrameByName("iiwa_link_0", arm_model),
-      X_W_Link0);
+      X_WLink0);
 
   // Load a second table for objects.
   const ModelInstanceIndex objects_table_model =
@@ -2437,15 +2436,15 @@ GTEST_TEST(StateSelection, FloatingBodies) {
   auto context = plant.CreateDefaultContext();
 
   // Initialize the pose X_OM of the mug frame M in the objects table frame O.
-  const Vector3d p_Oo_Mo_O(0.05, 0.0, 0.05);
+  const Vector3d p_OoMo_O(0.05, 0.0, 0.05);
   const RigidTransformd X_OM(p_Oo_Mo_O);
   plant.SetFreeBodyPoseInAnchoredFrame(
       context.get(), objects_frame_O, mug, X_OM);
 
   // Retrieve the pose of the mug in the world.
-  const Isometry3d& X_WM = plant.EvalBodyPoseInWorld(*context, mug);
+  const RigidTransformd X_WM = plant.EvalBodyPoseInWorld(*context, mug);
 
-  const Isometry3d X_WM_expected = X_WT * X_TO * X_OM;
+  const RigidTransformd X_WM_expected = X_WT * X_TO * X_OM;
 
   const double kTolerance = 5 * std::numeric_limits<double>::epsilon();
   EXPECT_TRUE(CompareMatrices(X_WM.matrix(), X_WM_expected.matrix(),

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -2437,7 +2437,7 @@ GTEST_TEST(StateSelection, FloatingBodies) {
 
   // Initialize the pose X_OM of the mug frame M in the objects table frame O.
   const Vector3d p_OoMo_O(0.05, 0.0, 0.05);
-  const RigidTransformd X_OM(p_Oo_Mo_O);
+  const RigidTransformd X_OM(p_OoMo_O);
   plant.SetFreeBodyPoseInAnchoredFrame(
       context.get(), objects_frame_O, mug, X_OM);
 


### PR DESCRIPTION
Deprecate the following multibody methods that use an Isometry3 argument in favor of RigidTransform: WeldFrames(), SetFreeBodyPoseInWorldFrame(), and SetFreeBodyPoseInAnchoredFrame().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11183)
<!-- Reviewable:end -->
