### PR TITLE
framework: Move feedthrough query to SystemBase

### DIFF
--- a/systems/framework/diagram_builder.cc
+++ b/systems/framework/diagram_builder.cc
@@ -1,4 +1,139 @@
 #include "drake/systems/framework/diagram_builder.h"
 
+namespace drake {
+namespace systems {
+namespace internal {
+namespace {
+
+// This generic port identifier is used only for cycle detection below
+// because the algorithm treats both input & output ports as nodes.
+using PortIdentifier = std::pair<const SystemBase*, int>;
+
+// Helper to do the algebraic loop test. It recursively performs the
+// depth-first search on the graph to find cycles.
+bool HasCycleRecurse(
+    const PortIdentifier& n,
+    const std::map<PortIdentifier, std::set<PortIdentifier>>& edges,
+    std::set<PortIdentifier>* visited,
+    std::vector<PortIdentifier>* stack) {
+  DRAKE_ASSERT(visited->count(n) == 0);
+  visited->insert(n);
+
+  auto edge_iter = edges.find(n);
+  if (edge_iter != edges.end()) {
+    DRAKE_ASSERT(std::find(stack->begin(), stack->end(), n) == stack->end());
+    stack->push_back(n);
+    for (const auto& target : edge_iter->second) {
+      if (visited->count(target) == 0 &&
+          HasCycleRecurse(target, edges, visited, stack)) {
+        return true;
+      } else if (std::find(stack->begin(), stack->end(), target) !=
+                 stack->end()) {
+        return true;
+      }
+    }
+    stack->pop_back();
+  }
+  return false;
+}
+
+}  // namespace
+
+void DiagramBuilderImpl::ThrowIfAlgebraicLoopsExist(
+    const std::unordered_set<const SystemBase*>& systems,
+    const std::map<
+        std::pair<const SystemBase*, InputPortIndex>,
+        std::pair<const SystemBase*, OutputPortIndex>>& connection_map) {
+  // Each port in the diagram is a node in a graph.
+  // An edge exists from node u to node v if:
+  //  1. output u is connected to input v (via Connect(u, v) method), or
+  //  2. a direct feedthrough from input u to output v is reported.
+  // A depth-first search of the graph should produce a forest of valid trees
+  // if there are no algebraic loops. Otherwise, at least one link moving
+  // *up* the tree will exist.
+
+  // Build the graph.
+  // Generally, the nodes of the graph would be the set of all defined ports
+  // (input and output) of each subsystem. However, we only need to
+  // consider the input/output ports that have a diagram level output-to-input
+  // connection (ports that are not connected in this manner cannot contribute
+  // to an algebraic loop).
+
+  // Track *all* of the nodes involved in a diagram-level connection as
+  // described above.
+  std::set<PortIdentifier> nodes;
+  // A map from node u, to the set of edges { (u, v_i) }. In normal cases,
+  // not every node in `nodes` will serve as a key in `edges` (as that is a
+  // necessary condition for there to be no algebraic loop).
+  std::map<PortIdentifier, std::set<PortIdentifier>> edges;
+
+  // In order to store PortIdentifiers for both input and output ports in the
+  // same set, I need to encode the ports. The identifier for the first input
+  // port and output port look identical (same system pointer, same port
+  // id 0). So, to distinguish them, I'll modify the output ports to use the
+  // negative half of the int space. The function below provides a utility for
+  // encoding an output port id.
+  auto output_to_key = [](int port_id) { return -(port_id + 1); };
+
+  // Populate the node set from the connections (and define the edges implied
+  // by those connections).
+  for (const auto& connection : connection_map) {
+    // Dependency graph is a mapping from the destination of the connection
+    // to what it *depends on* (the source).
+    const PortIdentifier& src = connection.second;
+    const PortIdentifier& dest = connection.first;
+    PortIdentifier encoded_src{src.first, output_to_key(src.second)};
+    nodes.insert(encoded_src);
+    nodes.insert(dest);
+    edges[encoded_src].insert(dest);
+  }
+
+  // Populate more edges based on direct feedthrough.
+  for (const auto& system : systems) {
+    for (const auto& pair : system->GetDirectFeedthroughs()) {
+      PortIdentifier src_port{system, pair.first};
+      PortIdentifier dest_port{system, output_to_key(pair.second)};
+      if (nodes.count(src_port) > 0 && nodes.count(dest_port) > 0) {
+        // Track direct feedthrough only on port pairs where *both* ports are
+        // connected to other ports at the diagram level.
+        edges[src_port].insert(dest_port);
+      }
+    }
+  }
+
+  // Evaluate the graph for cycles.
+  std::set<PortIdentifier> visited;
+  std::vector<PortIdentifier> stack;
+  for (const auto& node : nodes) {
+    if (visited.count(node) == 0) {
+      if (HasCycleRecurse(node, edges, &visited, &stack)) {
+        std::stringstream ss;
+
+        auto port_to_stream = [&ss](const auto& id) {
+          ss << "  " << id.first->get_name() << ":";
+          if (id.second < 0)
+            ss << "Out(";
+          else
+            ss << "In(";
+          ss << (id.second >= 0 ? id.second : -id.second - 1) << ")";
+        };
+
+        ss << "Algebraic loop detected in DiagramBuilder:\n";
+        for (size_t i = 0; i < stack.size() - 1; ++i) {
+          port_to_stream(stack[i]);
+          ss << " depends on\n";
+        }
+        port_to_stream(stack.back());
+
+        throw std::runtime_error(ss.str());
+      }
+    }
+  }
+}
+
+}  // namespace internal
+}  // namespace systems
+}  // namespace drake
+
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::systems::DiagramBuilder)

--- a/systems/framework/diagram_builder.h
+++ b/systems/framework/diagram_builder.h
@@ -287,10 +287,6 @@ class DiagramBuilder {
   using InputPortLocator = typename Diagram<T>::InputPortLocator;
   using OutputPortLocator = typename Diagram<T>::OutputPortLocator;
 
-  // This generic port identifier is used only for cycle detection below
-  // because the algorithm treats both input & output ports as nodes.
-  using PortIdentifier = std::pair<const System<T>*, int>;
-
   // Throws if the given input port (belonging to a child subsystem) has
   // already been connected to an output port, or exported to be an input
   // port of the whole diagram.
@@ -311,125 +307,8 @@ class DiagramBuilder {
     }
   }
 
-  // Helper method to do the algebraic loop test. It recursively performs the
-  // depth-first search on the graph to find cycles.
-  static bool HasCycleRecurse(
-      const PortIdentifier& n,
-      const std::map<PortIdentifier, std::set<PortIdentifier>>& edges,
-      std::set<PortIdentifier>* visited,
-      std::vector<PortIdentifier>* stack) {
-    DRAKE_ASSERT(visited->count(n) == 0);
-    visited->insert(n);
-
-    auto edge_iter = edges.find(n);
-    if (edge_iter != edges.end()) {
-      DRAKE_ASSERT(std::find(stack->begin(), stack->end(), n) == stack->end());
-      stack->push_back(n);
-      for (const auto& target : edge_iter->second) {
-        if (visited->count(target) == 0 &&
-            HasCycleRecurse(target, edges, visited, stack)) {
-          return true;
-        } else if (std::find(stack->begin(), stack->end(), target) !=
-                   stack->end()) {
-          return true;
-        }
-      }
-      stack->pop_back();
-    }
-    return false;
-  }
-
-  // Evaluates the graph of port dependencies -- including *connections* between
-  // output ports and input ports and direct feedthrough connections between
-  // input ports and output ports. If an algebraic loop is detected, throws
-  // a std::logic_error.
-  void ThrowIfAlgebraicLoopsExist() const {
-    // Each port in the diagram is a node in a graph.
-    // An edge exists from node u to node v if:
-    //  1. output u is connected to input v (via Connect(u, v) method), or
-    //  2. a direct feedthrough from input u to output v is reported.
-    // A depth-first search of the graph should produce a forest of valid trees
-    // if there are no algebraic loops. Otherwise, at least one link moving
-    // *up* the tree will exist.
-
-    // Build the graph.
-    // Generally, the nodes of the graph would be the set of all defined ports
-    // (input and output) of each subsystem. However, we only need to
-    // consider the input/output ports that have a diagram level output-to-input
-    // connection (ports that are not connected in this manner cannot contribute
-    // to an algebraic loop).
-
-    // Track *all* of the nodes involved in a diagram-level connection as
-    // described above.
-    std::set<PortIdentifier> nodes;
-    // A map from node u, to the set of edges { (u, v_i) }. In normal cases,
-    // not every node in `nodes` will serve as a key in `edges` (as that is a
-    // necessary condition for there to be no algebraic loop).
-    std::map<PortIdentifier, std::set<PortIdentifier>> edges;
-
-    // In order to store PortIdentifiers for both input and output ports in the
-    // same set, I need to encode the ports. The identifier for the first input
-    // port and output port look identical (same system pointer, same port
-    // id 0). So, to distinguish them, I'll modify the output ports to use the
-    // negative half of the int space. The function below provides a utility for
-    // encoding an output port id.
-    auto output_to_key = [](int port_id) { return -(port_id + 1); };
-
-    // Populate the node set from the connections (and define the edges implied
-    // by those connections).
-    for (const auto& connection : connection_map_) {
-      // Dependency graph is a mapping from the destination of the connection
-      // to what it *depends on* (the source).
-      const PortIdentifier& src = connection.second;
-      const PortIdentifier& dest = connection.first;
-      PortIdentifier encoded_src{src.first, output_to_key(src.second)};
-      nodes.insert(encoded_src);
-      nodes.insert(dest);
-      edges[encoded_src].insert(dest);
-    }
-
-    // Populate more edges based on direct feedthrough.
-    for (const auto& system : registered_systems_) {
-      for (const auto& pair : system->GetDirectFeedthroughs()) {
-        PortIdentifier src_port{system.get(), pair.first};
-        PortIdentifier dest_port{system.get(), output_to_key(pair.second)};
-        if (nodes.count(src_port) > 0 && nodes.count(dest_port) > 0) {
-          // Track direct feedthrough only on port pairs where *both* ports are
-          // connected to other ports at the diagram level.
-          edges[src_port].insert(dest_port);
-        }
-      }
-    }
-
-    // Evaluate the graph for cycles.
-    std::set<PortIdentifier> visited;
-    std::vector<PortIdentifier> stack;
-    for (const auto& node : nodes) {
-      if (visited.count(node) == 0) {
-        if (HasCycleRecurse(node, edges, &visited, &stack)) {
-          std::stringstream ss;
-
-          auto port_to_stream = [&ss](const auto& id) {
-            ss << "  " << id.first->get_name() << ":";
-            if (id.second < 0)
-              ss << "Out(";
-            else
-              ss << "In(";
-            ss << (id.second >= 0 ? id.second : -id.second - 1) << ")";
-          };
-
-          ss << "Algebraic loop detected in DiagramBuilder:\n";
-          for (size_t i = 0; i < stack.size() - 1; ++i) {
-            port_to_stream(stack[i]);
-            ss << " depends on\n";
-          }
-          port_to_stream(stack.back());
-
-          throw std::runtime_error(ss.str());
-        }
-      }
-    }
-  }
+  // (Defined lower down in this file.)
+  void ThrowIfAlgebraicLoopsExist() const;
 
   // TODO(russt): Implement AddRandomSources method to wire up all dangling
   // random input ports with a compatible RandomSource system.
@@ -477,6 +356,36 @@ class DiagramBuilder {
 
   friend int AddRandomInputs(double, systems::DiagramBuilder<double>*);
 };
+
+#ifndef DRAKE_DOXYGEN_CXX
+namespace internal {
+// A non-templated helper class so that we can isolate code in our *.cc file.
+class DiagramBuilderImpl {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DiagramBuilderImpl)
+  DiagramBuilderImpl() = delete;
+
+  // Examines the graph of port dependencies (including connections between
+  // output ports and input ports and direct feedthrough connections between
+  // input ports and output ports) and if an algebraic loop is detected throws
+  // a std::logic_error.
+  static void ThrowIfAlgebraicLoopsExist(
+      const std::unordered_set<const SystemBase*>& systems,
+      const std::map<
+        std::pair<const SystemBase*, InputPortIndex>,
+        std::pair<const SystemBase*, OutputPortIndex>>& connection_map);
+};
+
+}  // namespace internal
+#endif  // DRAKE_DOXYGEN_CXX
+
+template <typename T>
+void DiagramBuilder<T>::ThrowIfAlgebraicLoopsExist() const {
+  // Delegate to our Impl after upcasting the pointers to SystemBase.
+  internal::DiagramBuilderImpl::ThrowIfAlgebraicLoopsExist(
+      {systems_.begin(), systems_.end()},
+      {connection_map_.begin(), connection_map_.end()});
+}
 
 }  // namespace systems
 }  // namespace drake

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -265,17 +265,6 @@ class System : public SystemBase {
     }
   }
 
-  /// Reports all direct feedthroughs from input ports to output ports. For
-  /// a system with m input ports: `I = i₀, i₁, ..., iₘ₋₁`, and n output ports,
-  /// `O = o₀, o₁, ..., oₙ₋₁`, the return map will contain pairs (u, v) such
-  /// that
-  ///
-  /// - 0 ≤ u < m,
-  /// - 0 ≤ v < n,
-  /// - and there _might_ be a direct feedthrough from input iᵤ to each
-  ///   output oᵥ.
-  virtual std::multimap<int, int> GetDirectFeedthroughs() const = 0;
-
   /// Returns `true` if any of the inputs to the system might be directly
   /// fed through to any of its outputs and `false` otherwise.
   bool HasAnyDirectFeedthrough() const {
@@ -302,6 +291,8 @@ class System : public SystemBase {
     }
     return false;
   }
+
+  using SystemBase::GetDirectFeedthroughs;
   //@}
 
   //----------------------------------------------------------------------------

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <map>
 #include <memory>
 #include <set>
 #include <string>
@@ -182,7 +183,6 @@ class SystemBase : public internal::SystemMessageInterface {
     return static_cast<int>(output_ports_.size());
   }
 
-
   /** Returns a reference to an InputPort given its `port_index`.
   @pre `port_index` selects an existing input port of this System. */
   const InputPortBase& get_input_port_base(InputPortIndex port_index) const {
@@ -210,6 +210,16 @@ class SystemBase : public internal::SystemMessageInterface {
     for (const auto& out : output_ports_) count += out->size();
     return count;
   }
+
+  /** Reports all direct feedthroughs from input ports to output ports. For
+  a system with m input ports: `I = i₀, i₁, ..., iₘ₋₁`, and n output ports,
+  `O = o₀, o₁, ..., oₙ₋₁`, the return map will contain pairs (u, v) such that
+
+  - 0 ≤ u < m,
+  - 0 ≤ v < n,
+  - and there _might_ be a direct feedthrough from input iᵤ to each output oᵥ.
+  */
+  virtual std::multimap<int, int> GetDirectFeedthroughs() const = 0;
 
   /** Returns the number nc of cache entries currently allocated in this System.
   These are indexed from 0 to nc-1. */

--- a/systems/framework/test/cache_entry_test.cc
+++ b/systems/framework/test/cache_entry_test.cc
@@ -165,6 +165,10 @@ class MySystemBase final : public SystemBase {
     return {};
   }
 
+  std::multimap<int, int> GetDirectFeedthroughs() const final {
+    throw std::logic_error("GetDirectFeedthroughs is not implemented");
+  }
+
   const CacheEntry& entry0_;
   const CacheEntry& entry1_;
   const CacheEntry& entry2_;

--- a/systems/framework/test/system_base_test.cc
+++ b/systems/framework/test/system_base_test.cc
@@ -59,6 +59,10 @@ class MySystemBase final : public SystemBase {
       InputPortIndex) const override {
     return {};
   }
+
+  std::multimap<int, int> GetDirectFeedthroughs() const final {
+    throw std::logic_error("GetDirectFeedthroughs is not implemented");
+  }
 };
 
 // Verify that system name methods work properly. Can't fully test the


### PR DESCRIPTION
The feedthrough signature does not depend on the scalar type, so it can live in `SystemBase` (along with the other input and output port interrogation methods).

By relocating it to `SystemBase`, we can move `DiagramBuilder`'s implementation of loop detection into it's cc file to save on recompilation time.

This is a prerequisite for #11189.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11190)
<!-- Reviewable:end -->
