### PR TITLE
Replaces pointer versions of get_integrator() and get_mutable_integrator()...

### DIFF
--- a/attic/manipulation/dev/quasistatic_iiwa_pick_and_place_demo.cc
+++ b/attic/manipulation/dev/quasistatic_iiwa_pick_and_place_demo.cc
@@ -285,7 +285,7 @@ int do_main() {
   x0.SetAtIndex(15, 0.055);            // right gripper
 
   simulator.set_target_realtime_rate(0);
-  simulator.get_mutable_integrator()->set_maximum_step_size(h);
+  simulator.get_mutable_integrator().set_maximum_step_size(h);
   simulator.Initialize();
   simulator.AdvanceTo(kTimes.back());
 

--- a/attic/manipulation/dev/test/rod2d_time_stepping.cc
+++ b/attic/manipulation/dev/test/rod2d_time_stepping.cc
@@ -202,7 +202,7 @@ VectorXd RunSimulation(const bool is_analytic) {
 
   simulator.set_target_realtime_rate(0);
   const double h = rod2d->get_period_sec();
-  simulator.get_mutable_integrator()->set_maximum_step_size(h);
+  simulator.get_mutable_integrator().set_maximum_step_size(h);
   simulator.Initialize();
   simulator.AdvanceTo(7.5);
 

--- a/attic/manipulation/scene_generation/simulate_plant_to_rest.cc
+++ b/attic/manipulation/scene_generation/simulate_plant_to_rest.cc
@@ -90,8 +90,8 @@ VectorX<double> SimulatePlantToRest::Run(const VectorX<double>& q_ik,
 
     simulator.reset_integrator<systems::RungeKutta2Integrator<double>>(
         *diagram_, 0.0001, &simulator.get_mutable_context());
-    simulator.get_mutable_integrator()->set_maximum_step_size(max_step_size);
-    simulator.get_mutable_integrator()->set_fixed_step_mode(true);
+    simulator.get_mutable_integrator().set_maximum_step_size(max_step_size);
+    simulator.get_mutable_integrator().set_fixed_step_mode(true);
     step_time = 1.0;
     step_delta = 0.1;
     do {

--- a/attic/systems/sensors/test/accelerometer_test/accelerometer_test.cc
+++ b/attic/systems/sensors/test/accelerometer_test/accelerometer_test.cc
@@ -148,7 +148,7 @@ GTEST_TEST(TestAccelerometer, TestSensorAttachedToSwingingPendulum) {
   Simulator<double> simulator(diagram, std::move(context));
   // Decrease the step size to get x_dot(0) to be closer to x(1).
   const double stepSize = 1e-4;
-  simulator.get_mutable_integrator()->set_maximum_step_size(stepSize);
+  simulator.get_mutable_integrator().set_maximum_step_size(stepSize);
   simulator.Initialize();
 
   const AccelerometerTestLogger& logger = diagram.get_logger();

--- a/automotive/automotive_simulator.cc
+++ b/automotive/automotive_simulator.cc
@@ -730,7 +730,7 @@ void AutomotiveSimulator<T>::Start(
   const double max_step_size = 0.01;
   simulator_->template reset_integrator<RungeKutta2Integrator<T>>(
       *diagram_, max_step_size, &simulator_->get_mutable_context());
-  simulator_->get_mutable_integrator()->set_fixed_step_mode(true);
+  simulator_->get_mutable_integrator().set_fixed_step_mode(true);
   simulator_->Initialize();
 }
 

--- a/automotive/maliput/multilane/road_curve.cc
+++ b/automotive/maliput/multilane/road_curve.cc
@@ -133,11 +133,11 @@ RoadCurve::RoadCurve(double linear_tolerance, double scale_length,
   // accuracy balance). However, for the time being, the following
   // constants (considering 0.0 <= p <= 1.0) work well as a heuristic
   // approximation to appropriate step sizes.
-  systems::IntegratorBase<double>* s_from_p_integrator =
+  systems::IntegratorBase<double>& s_from_p_integrator =
       s_from_p_func_->get_mutable_integrator();
-  s_from_p_integrator->request_initial_step_size_target(0.1);
-  s_from_p_integrator->set_maximum_step_size(1.0);
-  s_from_p_integrator->set_target_accuracy(relative_tolerance_);
+  s_from_p_integrator.request_initial_step_size_target(0.1);
+  s_from_p_integrator.set_maximum_step_size(1.0);
+  s_from_p_integrator.set_target_accuracy(relative_tolerance_);
 
   // Sets `p_from_s`'s integration accuracy and step sizes. Said steps
   // should not be too large, because that could make accuracy control
@@ -146,11 +146,11 @@ RoadCurve::RoadCurve(double linear_tolerance, double scale_length,
   // optimal step sizes (in terms of their efficiency vs. accuracy balance).
   // However, for the time being, the following proportions of the scale
   // length work well as a heuristic approximation to appropriate step sizes.
-  systems::IntegratorBase<double>* p_from_s_integrator =
+  systems::IntegratorBase<double>& p_from_s_integrator =
       p_from_s_ivp_->get_mutable_integrator();
-  p_from_s_integrator->request_initial_step_size_target(0.1 * scale_length);
-  p_from_s_integrator->set_maximum_step_size(scale_length);
-  p_from_s_integrator->set_target_accuracy(relative_tolerance_);
+  p_from_s_integrator.request_initial_step_size_target(0.1 * scale_length);
+  p_from_s_integrator.set_maximum_step_size(scale_length);
+  p_from_s_integrator.set_target_accuracy(relative_tolerance_);
 }
 
 bool RoadCurve::AreFastComputationsAccurate(double r) const {

--- a/examples/acrobot/run_lqr_w_estimator.cc
+++ b/examples/acrobot/run_lqr_w_estimator.cc
@@ -134,8 +134,8 @@ int do_main() {
 
   // Simulate.
   simulator.set_target_realtime_rate(FLAGS_realtime_factor);
-  simulator.get_mutable_integrator()->set_maximum_step_size(0.01);
-  simulator.get_mutable_integrator()->set_fixed_step_mode(true);
+  simulator.get_mutable_integrator().set_maximum_step_size(0.01);
+  simulator.get_mutable_integrator().set_fixed_step_mode(true);
   simulator.Initialize();
   simulator.AdvanceTo(FLAGS_simulation_sec);
 

--- a/examples/bouncing_ball/test/bouncing_ball_test.cc
+++ b/examples/bouncing_ball/test/bouncing_ball_test.cc
@@ -166,8 +166,8 @@ TEST_F(BouncingBallTest, Simulate) {
   simulator.reset_integrator<systems::RungeKutta3Integrator<double>>(*dut_,
       &simulator.get_mutable_context());
   simulator.get_mutable_context().SetAccuracy(accuracy);
-  simulator.get_mutable_integrator()->request_initial_step_size_target(1e-3);
-  simulator.get_mutable_integrator()->set_target_accuracy(accuracy);
+  simulator.get_mutable_integrator().request_initial_step_size_target(1e-3);
+  simulator.get_mutable_integrator().set_target_accuracy(accuracy);
   simulator.Initialize();
 
   // Set the initial state for the bouncing ball.

--- a/examples/contact_model/rigid_gripper.cc
+++ b/examples/contact_model/rigid_gripper.cc
@@ -146,8 +146,8 @@ int main() {
   systems::Context<double>& context = simulator.get_mutable_context();
 
   simulator.reset_integrator<RungeKutta3Integrator<double>>(*model, &context);
-  simulator.get_mutable_integrator()->request_initial_step_size_target(1e-4);
-  simulator.get_mutable_integrator()->set_target_accuracy(FLAGS_accuracy);
+  simulator.get_mutable_integrator().request_initial_step_size_target(1e-4);
+  simulator.get_mutable_integrator().set_target_accuracy(FLAGS_accuracy);
   std::cout << "Variable-step integrator accuracy: " << FLAGS_accuracy << "\n";
 
   simulator.Initialize();

--- a/examples/kuka_iiwa_arm/controlled_kuka/controlled_kuka_multibody_demo.cc
+++ b/examples/kuka_iiwa_arm/controlled_kuka/controlled_kuka_multibody_demo.cc
@@ -101,7 +101,7 @@ int DoMain() {
   systems::Simulator<double> simulator(*diagram);
   simulator.Initialize();
   simulator.set_target_realtime_rate(1.0);
-  simulator.get_mutable_integrator()->set_target_accuracy(1e-3);
+  simulator.get_mutable_integrator().set_target_accuracy(1e-3);
 
   simulator.AdvanceTo(FLAGS_simulation_sec);
   return 0;

--- a/examples/manipulation_station/differential_ik.py
+++ b/examples/manipulation_station/differential_ik.py
@@ -39,15 +39,15 @@ class DifferentialIK(LeafSystem):
             self.robot_context)[-robot.num_velocities():].any()
 
         # Store the robot positions as state.
-        self._DeclareDiscreteState(robot.num_positions())
-        self._DeclarePeriodicDiscreteUpdate(time_step)
+        self.DeclareDiscreteState(robot.num_positions())
+        self.DeclarePeriodicDiscreteUpdate(time_step)
 
         # Desired pose of frame E in world frame.
-        self._DeclareInputPort("rpy_xyz_desired",
-                               PortDataType.kVectorValued, 6)
+        self.DeclareInputPort("rpy_xyz_desired",
+                              PortDataType.kVectorValued, 6)
 
         # Provide the output as desired positions.
-        self._DeclareVectorOutputPort("joint_position_desired", BasicVector(
+        self.DeclareVectorOutputPort("joint_position_desired", BasicVector(
             robot.num_positions()), self.CopyPositionOut)
 
     def SetPositions(self, context, q):

--- a/examples/manipulation_station/end_effector_teleop_mouse.py
+++ b/examples/manipulation_station/end_effector_teleop_mouse.py
@@ -123,16 +123,16 @@ class TeleopMouseKeyboardManager():
 class MouseKeyboardTeleop(LeafSystem):
     def __init__(self, grab_focus=True):
         LeafSystem.__init__(self)
-        self._DeclareVectorOutputPort("rpy_xyz", BasicVector(6),
-                                      self._DoCalcOutput)
-        self._DeclareVectorOutputPort("position", BasicVector(1),
-                                      self.CalcPositionOutput)
-        self._DeclareVectorOutputPort("force_limit", BasicVector(1),
-                                      self.CalcForceLimitOutput)
+        self.DeclareVectorOutputPort("rpy_xyz", BasicVector(6),
+                                     self._DoCalcOutput)
+        self.DeclareVectorOutputPort("position", BasicVector(1),
+                                     self.CalcPositionOutput)
+        self.DeclareVectorOutputPort("force_limit", BasicVector(1),
+                                     self.CalcForceLimitOutput)
 
         # Note: This timing affects the keyboard teleop performance. A larger
         #       time step causes more lag in the response.
-        self._DeclarePeriodicPublish(0.01, 0.0)
+        self.DeclarePeriodicPublish(0.01, 0.0)
 
         self.teleop_manager = TeleopMouseKeyboardManager(grab_focus=grab_focus)
         self.roll = self.pitch = self.yaw = 0

--- a/examples/multibody/inclined_plane_with_body/inclined_plane_with_body.cc
+++ b/examples/multibody/inclined_plane_with_body/inclined_plane_with_body.cc
@@ -162,12 +162,12 @@ int do_main() {
   plant.SetFreeBodyPoseInWorldFrame(&plant_context, bodyB, X_WB);
 
   systems::Simulator<double> simulator(*diagram, std::move(diagram_context));
-  systems::IntegratorBase<double>* integrator =
+  systems::IntegratorBase<double>& integrator =
       simulator.get_mutable_integrator();
 
   // Set the integration accuracy when the plant is integrated with a variable-
   // step integrator. This value is not used if time_step > 0 (fixed-time step).
-  integrator->set_target_accuracy(FLAGS_integration_accuracy);
+  integrator.set_target_accuracy(FLAGS_integration_accuracy);
 
   simulator.set_publish_every_time_step(false);
   simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);

--- a/examples/quadrotor/run_quadrotor_lqr.cc
+++ b/examples/quadrotor/run_quadrotor_lqr.cc
@@ -77,7 +77,7 @@ int do_main() {
 
     // The following accuracy is necessary for the example to satisfy its
     // ending state tolerances.
-    simulator.get_mutable_integrator()->set_target_accuracy(5e-5);
+    simulator.get_mutable_integrator().set_target_accuracy(5e-5);
     simulator.AdvanceTo(FLAGS_trial_duration);
 
     // Goal state verification.

--- a/examples/rod2d/rod2d_sim.cc
+++ b/examples/rod2d/rod2d_sim.cc
@@ -136,8 +136,8 @@ int main(int argc, char* argv[]) {
     simulator.reset_integrator<RungeKutta3Integrator<double>>(*diagram,
                                                               &mut_context);
   }
-  simulator.get_mutable_integrator()->set_target_accuracy(FLAGS_accuracy);
-  simulator.get_mutable_integrator()->set_maximum_step_size(FLAGS_dt);
+  simulator.get_mutable_integrator().set_target_accuracy(FLAGS_accuracy);
+  simulator.get_mutable_integrator().set_maximum_step_size(FLAGS_dt);
 
   // Start simulating.
   simulator.set_target_realtime_rate(1.0);

--- a/examples/scene_graph/bouncing_ball_run_dynamics.cc
+++ b/examples/scene_graph/bouncing_ball_run_dynamics.cc
@@ -89,7 +89,7 @@ int do_main() {
   init_ball(bouncing_ball1, 0.3, 0.);
   init_ball(bouncing_ball2, 0.3, 0.3);
 
-  simulator.get_mutable_integrator()->set_maximum_step_size(0.002);
+  simulator.get_mutable_integrator().set_maximum_step_size(0.002);
   simulator.set_target_realtime_rate(1.f);
   simulator.Initialize();
   simulator.AdvanceTo(FLAGS_simulation_time);

--- a/examples/scene_graph/dev/bouncing_ball_run_dynamics.cc
+++ b/examples/scene_graph/dev/bouncing_ball_run_dynamics.cc
@@ -176,7 +176,7 @@ int do_main() {
   init_ball(bouncing_ball1, 0.3, 0.);
   init_ball(bouncing_ball2, 0.3, 0.3);
 
-  simulator.get_mutable_integrator()->set_maximum_step_size(0.002);
+  simulator.get_mutable_integrator().set_maximum_step_size(0.002);
   simulator.Initialize();
   simulator.set_publish_every_time_step(false);
   simulator.set_publish_at_initialization(false);

--- a/examples/scene_graph/dev/solar_system_run_dynamics.cc
+++ b/examples/scene_graph/dev/solar_system_run_dynamics.cc
@@ -37,7 +37,7 @@ int do_main() {
 
   systems::Simulator<double> simulator(*diagram);
 
-  simulator.get_mutable_integrator()->set_maximum_step_size(0.002);
+  simulator.get_mutable_integrator().set_maximum_step_size(0.002);
   simulator.set_publish_every_time_step(false);
   simulator.set_target_realtime_rate(1);
   simulator.Initialize();

--- a/examples/scene_graph/solar_system_run_dynamics.cc
+++ b/examples/scene_graph/solar_system_run_dynamics.cc
@@ -36,7 +36,7 @@ int do_main() {
 
   systems::Simulator<double> simulator(*diagram);
 
-  simulator.get_mutable_integrator()->set_maximum_step_size(0.002);
+  simulator.get_mutable_integrator().set_maximum_step_size(0.002);
   simulator.set_publish_every_time_step(false);
   simulator.set_target_realtime_rate(1);
   simulator.Initialize();

--- a/multibody/plant/test/inclined_plane_test.cc
+++ b/multibody/plant/test/inclined_plane_test.cc
@@ -135,8 +135,8 @@ TEST_P(InclinedPlaneTest, RollingSphereTest) {
   plant.SetFreeBodyPoseInWorldFrame(&plant_context, ball, X_WB_initial);
 
   Simulator<double> simulator(*diagram, std::move(diagram_context));
-  IntegratorBase<double>* integrator = simulator.get_mutable_integrator();
-  integrator->set_target_accuracy(target_accuracy);
+  IntegratorBase<double>& integrator = simulator.get_mutable_integrator();
+  integrator.set_target_accuracy(target_accuracy);
   simulator.set_publish_every_time_step(true);
   simulator.Initialize();
   simulator.AdvanceTo(simulation_time);

--- a/multibody/plant/test/spring_mass_system_test.cc
+++ b/multibody/plant/test/spring_mass_system_test.cc
@@ -141,7 +141,7 @@ TEST_F(SpringMassSystemTest, UnDampedCase) {
   slider_->set_translation(&context, free_length_ + amplitude);
   slider_->set_translation_rate(&context, 0.0);
   simulator.Initialize();
-  simulator.get_mutable_integrator()->set_target_accuracy(integration_accuracy);
+  simulator.get_mutable_integrator().set_target_accuracy(integration_accuracy);
   simulator.AdvanceTo(simulation_time);
 
   const double x_analytic = CalcAnalyticSolution(
@@ -172,7 +172,7 @@ TEST_F(SpringMassSystemTest, UnderDampedCase) {
   slider_->set_translation(&context, free_length_ + amplitude);
   slider_->set_translation_rate(&context, 0.0);
   simulator.Initialize();
-  simulator.get_mutable_integrator()->set_target_accuracy(integration_accuracy);
+  simulator.get_mutable_integrator().set_target_accuracy(integration_accuracy);
   simulator.AdvanceTo(simulation_time);
 
   const double x_analytic = CalcAnalyticSolution(
@@ -203,7 +203,7 @@ TEST_F(SpringMassSystemTest, OverDampedCase) {
   slider_->set_translation(&context, free_length_ + amplitude);
   slider_->set_translation_rate(&context, 0.0);
   simulator.Initialize();
-  simulator.get_mutable_integrator()->set_target_accuracy(integration_accuracy);
+  simulator.get_mutable_integrator().set_target_accuracy(integration_accuracy);
   simulator.AdvanceTo(simulation_time);
 
   const double x_analytic = CalcAnalyticSolution(

--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -255,6 +255,7 @@ drake_cc_googletest(
         ":implicit_euler_integrator",
         ":runge_kutta3_integrator",
         ":simulator",
+        "//common/test_utilities:expect_throws_message",
         "//common/test_utilities:is_dynamic_castable",
         "//systems/analysis/test_utilities",
         "//systems/primitives",

--- a/systems/analysis/antiderivative_function.h
+++ b/systems/analysis/antiderivative_function.h
@@ -196,13 +196,13 @@ class AntiderivativeFunction {
         std::forward<Args>(args)...);
   }
 
-  /// Gets a pointer to the internal integrator instance.
-  const IntegratorBase<T>* get_integrator() const {
+  /// Gets a reference to the internal integrator instance.
+  const IntegratorBase<T>& get_integrator() const {
     return scalar_ivp_->get_integrator();
   }
 
-  /// Gets a pointer to the internal mutable integrator instance.
-  IntegratorBase<T>* get_mutable_integrator() {
+  /// Gets a mutable reference to the internal integrator instance.
+  IntegratorBase<T>& get_mutable_integrator() {
     return scalar_ivp_->get_mutable_integrator();
   }
 

--- a/systems/analysis/initial_value_problem.h
+++ b/systems/analysis/initial_value_problem.h
@@ -200,14 +200,14 @@ class InitialValueProblem {
     return static_cast<Integrator*>(integrator_.get());
   }
 
-  /// Gets a pointer to the internal integrator instance.
-  const IntegratorBase<T>* get_integrator() const {
-    return integrator_.get();
+  /// Gets a reference to the internal integrator instance.
+  const IntegratorBase<T>& get_integrator() const {
+    return *integrator_.get();
   }
 
-  /// Gets a pointer to the internal mutable integrator instance.
-  IntegratorBase<T>* get_mutable_integrator() {
-    return integrator_.get();
+  /// Gets a mutable reference to the internal integrator instance.
+  IntegratorBase<T>& get_mutable_integrator() {
+    return *integrator_.get();
   }
 
  private:

--- a/systems/analysis/initial_value_problem.h
+++ b/systems/analysis/initial_value_problem.h
@@ -202,11 +202,13 @@ class InitialValueProblem {
 
   /// Gets a reference to the internal integrator instance.
   const IntegratorBase<T>& get_integrator() const {
+    DRAKE_DEMAND(integrator_.get());
     return *integrator_.get();
   }
 
   /// Gets a mutable reference to the internal integrator instance.
   IntegratorBase<T>& get_mutable_integrator() {
+    DRAKE_DEMAND(integrator_.get());
     return *integrator_.get();
   }
 

--- a/systems/analysis/scalar_initial_value_problem.h
+++ b/systems/analysis/scalar_initial_value_problem.h
@@ -194,13 +194,13 @@ class ScalarInitialValueProblem {
         std::forward<Args>(args)...);
   }
 
-  /// Gets a pointer to the internal integrator instance.
-  const IntegratorBase<T>* get_integrator() const {
+  /// Gets a reference to the internal integrator instance.
+  const IntegratorBase<T>& get_integrator() const {
     return vector_ivp_->get_integrator();
   }
 
-  /// Gets a pointer to the internal mutable integrator instance.
-  IntegratorBase<T>* get_mutable_integrator() {
+  /// Gets a mutable reference to the internal integrator instance.
+  IntegratorBase<T>& get_mutable_integrator() {
     return vector_ivp_->get_mutable_integrator();
   }
 

--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -464,13 +464,13 @@ class Simulator {
   int64_t get_num_unrestricted_updates() const {
     return num_unrestricted_updates_; }
 
-  /// Gets a pointer to the integrator used to advance the continuous aspects
+  /// Gets a reference to the integrator used to advance the continuous aspects
   /// of the system.
-  const IntegratorBase<T>* get_integrator() const { return integrator_.get(); }
+  const IntegratorBase<T>& get_integrator() const { return *integrator_.get(); }
 
-  /// Gets a pointer to the mutable integrator used to advance the continuous
-  /// aspects of the system.
-  IntegratorBase<T>* get_mutable_integrator() { return integrator_.get(); }
+  /// Gets a reference to the mutable integrator used to advance the continuous
+  /// state of the system.
+  IntegratorBase<T>& get_mutable_integrator() { return *integrator_.get(); }
 
   /// Resets the integrator with a new one. An example usage is:
   /// @code
@@ -480,8 +480,11 @@ class Simulator {
   /// ensure the integrator is properly initialized. You can do that explicitly
   /// with the Initialize() method or it will be done implicitly at the first
   /// time step.
+  /// @throws std::logic_error if `integrator` is nullptr.
   template <class U>
   U* reset_integrator(std::unique_ptr<U> integrator) {
+    if (!integrator)
+      throw std::logic_error("Integrator cannot be null.");
     initialization_done_ = false;
     integrator_ = std::move(integrator);
     return static_cast<U*>(integrator_.get());

--- a/systems/analysis/test/antiderivative_function_test.cc
+++ b/systems/analysis/test/antiderivative_function_test.cc
@@ -44,13 +44,13 @@ GTEST_TEST(AntiderivativeFunctionTest, UsingMultipleIntegrators) {
 
   // Replaces default integrator.
   const double kMaximumStep = 0.1;
-  const IntegratorBase<double>* default_integrator =
+  const IntegratorBase<double>& default_integrator =
       antiderivative_function.get_integrator();
   using RK2 = RungeKutta2Integrator<double>;
   IntegratorBase<double>* configured_integrator =
       antiderivative_function.reset_integrator<RK2>(kMaximumStep);
-  EXPECT_NE(configured_integrator, default_integrator);
-  EXPECT_EQ(configured_integrator, antiderivative_function.get_integrator());
+  EXPECT_NE(configured_integrator, &default_integrator);
+  EXPECT_EQ(configured_integrator, &antiderivative_function.get_integrator());
 
   // Specifies a different parameter vector, but leaves the default
   // integration lower bound.
@@ -171,9 +171,9 @@ TEST_P(AntiderivativeFunctionAccuracyTest, NthPowerMonomialTestCase) {
         return std::pow(x, n);
       }, kDefaultValues);
 
-  IntegratorBase<double>* inner_integrator =
+  IntegratorBase<double>& inner_integrator =
       antiderivative_function.get_mutable_integrator();
-  inner_integrator->set_target_accuracy(integration_accuracy_);
+  inner_integrator.set_target_accuracy(integration_accuracy_);
 
   const int kLowestOrder = 0;
   const int kHighestOrder = 3;
@@ -228,9 +228,9 @@ TEST_P(AntiderivativeFunctionAccuracyTest, HyperbolicTangentTestCase) {
         return std::tanh(a * x);
       }, kDefaultValues);
 
-  IntegratorBase<double>* inner_integrator =
+  IntegratorBase<double>& inner_integrator =
       antiderivative_function.get_mutable_integrator();
-  inner_integrator->set_target_accuracy(integration_accuracy_);
+  inner_integrator.set_target_accuracy(integration_accuracy_);
 
   const double kParamIntervalLBound = -4.5;
   const double kParamIntervalUBound = 4.5;
@@ -288,9 +288,9 @@ TEST_P(AntiderivativeFunctionAccuracyTest,
         return 1. / ((x + a) * (x + b));
       }, kDefaultValues);
 
-  IntegratorBase<double>* inner_integrator =
+  IntegratorBase<double>& inner_integrator =
       antiderivative_function.get_mutable_integrator();
-  inner_integrator->set_target_accuracy(GetParam());
+  inner_integrator.set_target_accuracy(GetParam());
 
   const double k1stPoleIntervalLBound = 20.0;
   const double k1stPoleIntervalUBound = 25.0;
@@ -355,9 +355,9 @@ TEST_P(AntiderivativeFunctionAccuracyTest, ExponentialFunctionTestCase) {
         return x * std::exp(n * x);
       }, kDefaultValues);
 
-  IntegratorBase<double>* inner_integrator =
+  IntegratorBase<double>& inner_integrator =
       antiderivative_function.get_mutable_integrator();
-  inner_integrator->set_target_accuracy(integration_accuracy_);
+  inner_integrator.set_target_accuracy(integration_accuracy_);
 
   const double kParamIntervalLBound = -4.5;
   const double kParamIntervalUBound = 4.5;
@@ -415,9 +415,9 @@ TEST_P(AntiderivativeFunctionAccuracyTest, TrigonometricFunctionTestCase) {
         return x * std::sin(a * x);
       }, kDefaultValues);
 
-  IntegratorBase<double>* inner_integrator =
+  IntegratorBase<double>& inner_integrator =
       antiderivative_function.get_mutable_integrator();
-  inner_integrator->set_target_accuracy(integration_accuracy_);
+  inner_integrator.set_target_accuracy(integration_accuracy_);
 
   const double kParamIntervalLBound = -4.5;
   const double kParamIntervalUBound = 4.5;

--- a/systems/analysis/test/initial_value_problem_test.cc
+++ b/systems/analysis/test/initial_value_problem_test.cc
@@ -55,11 +55,11 @@ GTEST_TEST(InitialValueProblemTest, SolutionUsingMultipleIntegrators) {
 
   // Replaces default integrator.
   const double kMaximumStep = 0.1;
-  const IntegratorBase<double>* default_integrator = ivp.get_integrator();
+  const IntegratorBase<double>& default_integrator = ivp.get_integrator();
   IntegratorBase<double>* configured_integrator =
       ivp.reset_integrator<RungeKutta2Integrator<double>>(kMaximumStep);
-  EXPECT_NE(configured_integrator, default_integrator);
-  EXPECT_EQ(configured_integrator, ivp.get_integrator());
+  EXPECT_NE(configured_integrator, &default_integrator);
+  EXPECT_EQ(configured_integrator, &ivp.get_integrator());
 
   // Specifies a different parameter vector, but leaves both
   // initial time and state as defaults.
@@ -271,9 +271,9 @@ TEST_P(InitialValueProblemAccuracyTest, ParticleInAGasMomentum) {
         return -mu * p / m;
       }, kDefaultValues);
 
-  IntegratorBase<double>* inner_integrator =
+  IntegratorBase<double>& inner_integrator =
       particle_momentum_ivp.get_mutable_integrator();
-  inner_integrator->set_target_accuracy(integration_accuracy_);
+  inner_integrator.set_target_accuracy(integration_accuracy_);
 
   const double kLowestGasViscosity = 1.0;
   const double kHighestGasViscosity = 10.0;
@@ -356,9 +356,9 @@ TEST_P(InitialValueProblemAccuracyTest, ParticleInAGasForcedVelocity) {
         return (F - mu * v) / m;
       }, kDefaultValues);
 
-  IntegratorBase<double>* inner_integrator =
+  IntegratorBase<double>& inner_integrator =
       particle_velocity_ivp.get_mutable_integrator();
-  inner_integrator->set_target_accuracy(integration_accuracy_);
+  inner_integrator.set_target_accuracy(integration_accuracy_);
 
   const double kLowestGasViscosity = 1.0;
   const double kHighestGasViscosity = 10.0;

--- a/systems/analysis/test/scalar_initial_value_problem_test.cc
+++ b/systems/analysis/test/scalar_initial_value_problem_test.cc
@@ -51,11 +51,11 @@ GTEST_TEST(ScalarInitialValueProblemTest, UsingMultipleIntegrators) {
 
   // Replaces default integrator.
   const double kMaximumStep = 0.1;
-  const IntegratorBase<double>* default_integrator = ivp.get_integrator();
+  const IntegratorBase<double>& default_integrator = ivp.get_integrator();
   IntegratorBase<double>* configured_integrator =
       ivp.reset_integrator<RungeKutta2Integrator<double>>(kMaximumStep);
-  EXPECT_NE(configured_integrator, default_integrator);
-  EXPECT_EQ(configured_integrator, ivp.get_integrator());
+  EXPECT_NE(configured_integrator, &default_integrator);
+  EXPECT_EQ(configured_integrator, &ivp.get_integrator());
 
   // Specifies a different parameter vector, but leaves both
   // initial time and state as defaults.
@@ -226,9 +226,9 @@ TEST_P(ScalarInitialValueProblemAccuracyTest, StoredCharge) {
         return (std::sin(t) - q / Cs) / Rs;
       }, kDefaultValues);
 
-  IntegratorBase<double>* inner_integrator =
+  IntegratorBase<double>& inner_integrator =
       stored_charge_ivp.get_mutable_integrator();
-  inner_integrator->set_target_accuracy(integration_accuracy_);
+  inner_integrator.set_target_accuracy(integration_accuracy_);
 
   const double kLowestResistance = 1.0;
   const double kHighestResistance = 10.0;
@@ -310,9 +310,9 @@ TEST_P(ScalarInitialValueProblemAccuracyTest, PopulationGrowth) {
         return r * n;
       }, kDefaultValues);
 
-  IntegratorBase<double>* inner_integrator =
+  IntegratorBase<double>& inner_integrator =
       population_growth_ivp.get_mutable_integrator();
-  inner_integrator->set_target_accuracy(integration_accuracy_);
+  inner_integrator.set_target_accuracy(integration_accuracy_);
 
   const double kLowestMalthusParam = 0.1;
   const double kHighestMalthusParam = 1.0;

--- a/systems/analysis/test/simulator_test.cc
+++ b/systems/analysis/test/simulator_test.cc
@@ -10,6 +10,7 @@
 #include "drake/common/autodiff.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/common/test_utilities/is_dynamic_castable.h"
 #include "drake/common/text_logging.h"
 #include "drake/systems/analysis/explicit_euler_integrator.h"
@@ -116,6 +117,17 @@ class ExampleDiagram : public Diagram<double> {
  private:
   StatelessDiagram* stateless_diag_ = nullptr;
 };
+
+// Tests that resetting the integrator with a null pointer throws.
+GTEST_TEST(SimulatorTest, ResetWithNullIntegratorThrows) {
+  // We need an arbitrary system to instantiate the Simulator.
+  StatelessSystemPlusDerivs system;
+  Simulator<double> simulator(system);
+  std::unique_ptr<IntegratorBase<double>> null_unique;
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      simulator.reset_integrator(std::move(null_unique)),
+      std::logic_error, "Integrator cannot be null.");
+}
 
 // Tests that DoCalcTimeDerivatives() is not called when the system has no
 // continuous state.

--- a/systems/analysis/test/simulator_test.cc
+++ b/systems/analysis/test/simulator_test.cc
@@ -309,8 +309,8 @@ void InitFixedStepIntegratorForWitnessTesting(Simulator<double>* s, double dt) {
   const System<double>& system = s->get_system();
   Context<double>& context = s->get_mutable_context();
   s->reset_integrator<RungeKutta2Integrator<double>>(system, dt, &context);
-  s->get_mutable_integrator()->set_fixed_step_mode(true);
-  s->get_mutable_integrator()->set_maximum_step_size(dt);
+  s->get_mutable_integrator().set_fixed_step_mode(true);
+  s->get_mutable_integrator().set_maximum_step_size(dt);
   DisableDefaultPublishing(s);
 }
 
@@ -484,8 +484,8 @@ GTEST_TEST(SimulatorTest, MultipleWitnesses) {
   DisableDefaultPublishing(&simulator);
   simulator.reset_integrator<ImplicitEulerIntegrator<double>>(system,
                                               &simulator.get_mutable_context());
-  simulator.get_mutable_integrator()->set_maximum_step_size(dt);
-  simulator.get_mutable_integrator()->set_target_accuracy(0.1);
+  simulator.get_mutable_integrator().set_maximum_step_size(dt);
+  simulator.get_mutable_integrator().set_target_accuracy(0.1);
 
   // Set initial time and state.
   Context<double>& context = simulator.get_mutable_context();
@@ -542,7 +542,7 @@ GTEST_TEST(SimulatorTest, MultipleWitnessesIdentical) {
   const double dt = 2;
   simulator = std::make_unique<Simulator<double>>(system);
   DisableDefaultPublishing(simulator.get());
-  simulator->get_mutable_integrator()->set_maximum_step_size(dt);
+  simulator->get_mutable_integrator().set_maximum_step_size(dt);
 
   // Isolate witness functions to high accuracy.
   const double tol = 1e-12;
@@ -581,7 +581,7 @@ GTEST_TEST(SimulatorTest, MultipleWitnessesStaggered) {
   const double dt = 3;
   Simulator<double> simulator(system);
   DisableDefaultPublishing(&simulator);
-  simulator.get_mutable_integrator()->set_maximum_step_size(dt);
+  simulator.get_mutable_integrator().set_maximum_step_size(dt);
 
   // Isolate witness functions to high accuracy.
   const double tol = 1e-12;
@@ -891,7 +891,7 @@ GTEST_TEST(SimulatorTest, RealtimeRate) {
   Simulator<double> simulator(spring_mass);  // Use default Context.
 
   simulator.set_target_realtime_rate(1.);  // No faster than 1X real time.
-  simulator.get_mutable_integrator()->set_maximum_step_size(0.001);
+  simulator.get_mutable_integrator().set_maximum_step_size(0.001);
   simulator.get_mutable_context().SetTime(0.);
   simulator.Initialize();
   simulator.AdvanceTo(1.);  // Simulate for 1 simulated second.
@@ -1449,8 +1449,8 @@ GTEST_TEST(SimulatorTest, ControlledSpringMass) {
 
   // Forces simulator to use fixed-step integration at 1ms (to keep assumptions
   // below accurate).
-  simulator.get_mutable_integrator()->set_fixed_step_mode(true);
-  simulator.get_mutable_integrator()->set_maximum_step_size(0.001);
+  simulator.get_mutable_integrator().set_fixed_step_mode(true);
+  simulator.get_mutable_integrator().set_maximum_step_size(0.001);
 
   // Sets initial condition using the Simulator's internal Context.
   spring_mass.set_position(&simulator.get_mutable_context(), x0);
@@ -1821,9 +1821,9 @@ GTEST_TEST(SimulatorTest, ArtificalLimitingStep) {
   // Initialize the error controlled integrator and the simulator.
   simulator.reset_integrator<RungeKutta3Integrator<double>>(
       spring_mass, &simulator.get_mutable_context());
-  IntegratorBase<double>* integrator = simulator.get_mutable_integrator();
-  integrator->request_initial_step_size_target(req_initial_step_size);
-  integrator->set_target_accuracy(accuracy);
+  IntegratorBase<double>& integrator = simulator.get_mutable_integrator();
+  integrator.request_initial_step_size_target(req_initial_step_size);
+  integrator.set_target_accuracy(accuracy);
   simulator.Initialize();
 
   // Mark the event time.
@@ -1831,15 +1831,15 @@ GTEST_TEST(SimulatorTest, ArtificalLimitingStep) {
 
   // Take a single step with the integrator.
   const double inf = std::numeric_limits<double>::infinity();
-  const Context<double>& context = integrator->get_context();
-  integrator->IntegrateNoFurtherThanTime(inf,
+  const Context<double>& context = integrator.get_context();
+  integrator.IntegrateNoFurtherThanTime(inf,
       context.get_time() + 1.0, context.get_time() + 1.0);
 
   // Verify that the integrator has stepped before the event time.
   EXPECT_LT(context.get_time(), event_time);
 
   // Get the ideal next step size and verify that it is not NaN.
-  const double ideal_next_step_size = integrator->get_ideal_next_step_size();
+  const double ideal_next_step_size = integrator.get_ideal_next_step_size();
 
   // Set the time to right before an event, which should trigger artificial
   // limiting.
@@ -1847,14 +1847,14 @@ GTEST_TEST(SimulatorTest, ArtificalLimitingStep) {
   simulator.get_mutable_context().SetTime(event_time - desired_dt);
 
   // Step to the event time.
-  integrator->IntegrateNoFurtherThanTime(
+  integrator.IntegrateNoFurtherThanTime(
     inf, context.get_time() + desired_dt, inf);
 
   // Verify that the context is at the event time.
   EXPECT_EQ(context.get_time(), event_time);
 
   // Verify that artificial limiting did not change the ideal next step size.
-  EXPECT_EQ(integrator->get_ideal_next_step_size(), ideal_next_step_size);
+  EXPECT_EQ(integrator.get_ideal_next_step_size(), ideal_next_step_size);
 }
 
 // Verifies that an error controlled integrator will stretch its integration
@@ -1883,10 +1883,10 @@ GTEST_TEST(SimulatorTest, StretchedStepPerfectStorm) {
   // Initialize the error controlled integrator and the simulator.
   simulator.reset_integrator<RungeKutta3Integrator<double>>(spring_mass,
       &simulator.get_mutable_context());
-  IntegratorBase<double>* integrator = simulator.get_mutable_integrator();
-  integrator->set_requested_minimum_step_size(req_min_step_size);
-  integrator->request_initial_step_size_target(directed_t_final);
-  integrator->set_target_accuracy(accuracy);
+  IntegratorBase<double>& integrator = simulator.get_mutable_integrator();
+  integrator.set_requested_minimum_step_size(req_min_step_size);
+  integrator.request_initial_step_size_target(directed_t_final);
+  integrator.set_target_accuracy(accuracy);
 
   // Set initial condition using the Simulator's internal Context.
   simulator.get_mutable_context().SetTime(0);
@@ -1895,7 +1895,7 @@ GTEST_TEST(SimulatorTest, StretchedStepPerfectStorm) {
 
   // Activate exceptions on violating the minimum step size to verify that
   // error control is a limiting factor.
-  integrator->set_throw_on_minimum_step_size_violation(true);
+  integrator.set_throw_on_minimum_step_size_violation(true);
   EXPECT_THROW(simulator.AdvanceTo(expected_t_final), std::runtime_error);
 
   // Now disable exceptions on violating the minimum step size and step again.
@@ -1904,7 +1904,7 @@ GTEST_TEST(SimulatorTest, StretchedStepPerfectStorm) {
   simulator.get_mutable_context().SetTime(0);
   spring_mass.set_position(&simulator.get_mutable_context(), 0.1);
   spring_mass.set_velocity(&simulator.get_mutable_context(), 0);
-  integrator->set_throw_on_minimum_step_size_violation(false);
+  integrator.set_throw_on_minimum_step_size_violation(false);
   simulator.Initialize();
   simulator.AdvanceTo(expected_t_final);
 
@@ -2010,8 +2010,8 @@ GTEST_TEST(SimulatorTest, PerStepAction) {
   Simulator<double> sim(sys);
 
   // Forces simulator to use fixed-step integration.
-  sim.get_mutable_integrator()->set_fixed_step_mode(true);
-  sim.get_mutable_integrator()->set_maximum_step_size(0.001);
+  sim.get_mutable_integrator().set_fixed_step_mode(true);
+  sim.get_mutable_integrator().set_maximum_step_size(0.001);
 
   // Disables all simulator induced publish events, so that all publish calls
   // are initiated by sys.
@@ -2020,7 +2020,7 @@ GTEST_TEST(SimulatorTest, PerStepAction) {
   sim.Initialize();
   sim.AdvanceTo(0.1);
 
-  const double dt = sim.get_integrator()->get_maximum_step_size();
+  const double dt = sim.get_integrator().get_maximum_step_size();
   const int N = static_cast<int>(0.1 / dt);
   // Step size was set to 1ms above; make sure we don't have roundoff trouble.
   EXPECT_EQ(N, 100);
@@ -2176,13 +2176,13 @@ GTEST_TEST(SimulatorTest, EvalDerivativesCounter) {
   context.DisableCaching();
   simulator.reset_integrator<WastefulIntegrator>(spring_mass, 0.125, &context);
   simulator.AdvanceTo(1.);  // 8 steps, but 16 evaluations since no caching.
-  EXPECT_EQ(simulator.get_integrator()->get_num_steps_taken(), 8);
-  EXPECT_EQ(simulator.get_integrator()->get_num_derivative_evaluations(), 16);
+  EXPECT_EQ(simulator.get_integrator().get_num_steps_taken(), 8);
+  EXPECT_EQ(simulator.get_integrator().get_num_derivative_evaluations(), 16);
 
   context.EnableCaching();
   simulator.AdvanceTo(2.);  // 8 more steps, but only 8 more evaluations.
-  EXPECT_EQ(simulator.get_integrator()->get_num_steps_taken(), 16);
-  EXPECT_EQ(simulator.get_integrator()->get_num_derivative_evaluations(), 24);
+  EXPECT_EQ(simulator.get_integrator().get_num_steps_taken(), 16);
+  EXPECT_EQ(simulator.get_integrator().get_num_derivative_evaluations(), 24);
 }
 
 }  // namespace

--- a/systems/primitives/test/signal_logger_test.cc
+++ b/systems/primitives/test/signal_logger_test.cc
@@ -45,7 +45,7 @@ GTEST_TEST(TestSignalLogger, LinearSystemTest) {
   context.get_mutable_continuous_state_vector().SetAtIndex(0, 1.0);
 
   // Make the integrator tolerance sufficiently tight for the test to pass.
-  simulator.get_mutable_integrator()->set_target_accuracy(1e-4);
+  simulator.get_mutable_integrator().set_target_accuracy(1e-4);
 
   simulator.Initialize();
   // The Simulator schedules SignalLogger's default per-step event, which


### PR DESCRIPTION
...in Simulator to make the interface consistent with the rest of the API. This has been bugging me.

Needs a unit test but comments are welcome.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11197)
<!-- Reviewable:end -->
