### PR TITLE
Make RigidTransform easy to use with Eigen::Translation3 in C++ (not Python).

### DIFF
--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -105,8 +105,6 @@ PYBIND11_MODULE(math, m) {
             cls_doc.ctor.doc_1args_R)
         .def(py::init<const Vector3<T>&>(), py::arg("p"),
             cls_doc.ctor.doc_1args_p)
-        .def(py::init<const Eigen::Translation<T, 3>&>(), py::arg("position"),
-            cls_doc.ctor.doc_1args_position)
         .def(py::init<const Isometry3<T>&>(), py::arg("pose"),
             cls_doc.ctor.doc_1args_pose)
         .def("set", &Class::set, py::arg("R"), py::arg("p"), cls_doc.set.doc)
@@ -132,11 +130,6 @@ PYBIND11_MODULE(math, m) {
         .def("multiply",
             [](const Class* self, const Class& other) { return *self * other; },
             py::arg("other"), cls_doc.operator_mul.doc_1args_other)
-        .def("multiply",
-            [](const Class* self, const Eigen::Translation<T, 3>& X_BC) {
-              return *self * X_BC;
-            },
-            py::arg("X_BC"), cls_doc.operator_mul.doc_1args_X_BC)
         .def("multiply",
             [](const Class* self, const Vector3<T>& p_BoQ_B) {
               return *self * p_BoQ_B;

--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -105,8 +105,8 @@ PYBIND11_MODULE(math, m) {
             cls_doc.ctor.doc_1args_R)
         .def(py::init<const Vector3<T>&>(), py::arg("p"),
             cls_doc.ctor.doc_1args_p)
-        .def(py::init<const Eigen::Translation<T, 3>&>(), py::arg("X_AB"),
-            cls_doc.ctor.doc_1args_X_AB)
+        .def(py::init<const Eigen::Translation<T, 3>&>(), py::arg("position"),
+            cls_doc.ctor.doc_1args_position)
         .def(py::init<const Isometry3<T>&>(), py::arg("pose"),
             cls_doc.ctor.doc_1args_pose)
         .def("set", &Class::set, py::arg("R"), py::arg("p"), cls_doc.set.doc)

--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -105,6 +105,8 @@ PYBIND11_MODULE(math, m) {
             cls_doc.ctor.doc_1args_R)
         .def(py::init<const Vector3<T>&>(), py::arg("p"),
             cls_doc.ctor.doc_1args_p)
+        .def(py::init<const Eigen::Translation<T, 3>&>(), py::arg("X_AB"),
+            cls_doc.ctor.doc_1args_X_AB)
         .def(py::init<const Isometry3<T>&>(), py::arg("pose"),
             cls_doc.ctor.doc_1args_pose)
         .def("set", &Class::set, py::arg("R"), py::arg("p"), cls_doc.set.doc)
@@ -130,6 +132,11 @@ PYBIND11_MODULE(math, m) {
         .def("multiply",
             [](const Class* self, const Class& other) { return *self * other; },
             py::arg("other"), cls_doc.operator_mul.doc_1args_other)
+        .def("multiply",
+            [](const Class* self, const Eigen::Translation<T, 3>& X_BC) {
+              return *self * X_BC;
+            },
+            py::arg("X_BC"), cls_doc.operator_mul.doc_1args_X_BC)
         .def("multiply",
             [](const Class* self, const Vector3<T>& p_BoQ_B) {
               return *self * p_BoQ_B;

--- a/examples/manipulation_station/test/manipulation_station_test.cc
+++ b/examples/manipulation_station/test/manipulation_station_test.cc
@@ -351,18 +351,18 @@ GTEST_TEST(ManipulationStationTest, RegisterRgbdCameraTest) {
     geometry::dev::render::DepthCameraProperties camera_properties(
         640, 480, M_PI_4, dut.default_renderer_name(), 0.1, 2.0);
 
-    math::RigidTransform<double> X_WF0(Eigen::Vector3d(0, 0, 0.2));
-    math::RigidTransform<double> X_F0C0(Eigen::Vector3d(0.3, 0.2, 0.0));
+    const Eigen::Translation3d X_WF0(0, 0, 0.2);
+    const Eigen::Translation3d X_F0C0(0.3, 0.2, 0.0);
     const auto& frame0 =
         plant.AddFrame(std::make_unique<multibody::FixedOffsetFrame<double>>(
-            "frame0", plant.world_frame(), X_WF0.GetAsIsometry3()));
+            "frame0", plant.world_frame(), X_WF0));
     dut.RegisterRgbdCamera("camera0", frame0, X_F0C0, camera_properties);
 
-    math::RigidTransform<double> X_F0F1(Eigen::Vector3d(0, -0.1, 0.2));
-    math::RigidTransform<double> X_F1C1(Eigen::Vector3d(-0.2, 0.2, 0.33));
+    const Eigen::Translation3d X_F0F1(0, -0.1, 0.2);
+    const Eigen::Translation3d X_F1C1(-0.2, 0.2, 0.33);
     const auto& frame1 =
         plant.AddFrame(std::make_unique<multibody::FixedOffsetFrame<double>>(
-            "frame1", frame0, X_F0F1.GetAsIsometry3()));
+            "frame1", frame0, X_F0F1));
     dut.RegisterRgbdCamera("camera1", frame1, X_F1C1, camera_properties);
 
     std::map<std::string, math::RigidTransform<double>> camera_poses =

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -710,7 +710,7 @@ std::vector<SignedDistanceToPointTestData> GenDistanceTestDataTranslateBox() {
       // The position of the query point p_WQ(23,20,30) is closest to G at
       // (20,20,30) in World frame, which is p_GN=(10,0,0) in G's frame.
       // The gradient vector is expressed in both frames as (1,0,0).
-      {box, RigidTransformd(Vector3d(10., 20., 30.)), Vector3d{23., 20., 30.},
+      {box, Translation3d(10., 20., 30.), Vector3d{23., 20., 30.},
        SignedDistanceToPoint<double>(GeometryId::get_new_id(),
                                      Vector3d(10., 0., 0.), 3.,
                                      Vector3d(1., 0., 0.))}};
@@ -2530,8 +2530,8 @@ GenDistPairRepeatabilityTestData() {
       make_shared<const Convex>(
           drake::FindResourceOrThrow("drake/geometry/test/quad_cube.obj"),
           1.1)};
-  const RigidTransformd X_WA = RigidTransformd(Vector3d(0.1, 0.2, 0.3));
-  const RigidTransformd X_WB = RigidTransformd(Vector3d(0.11, 0.21, 0.31));
+  const Translation3d X_WA(0.1, 0.2, 0.3);
+  const Translation3d X_WB(0.11, 0.21, 0.31);
   std::vector<SignedDistancePairRepeatTestData> test_data;
   for (shared_ptr<const Shape>& a : shapes_A)
     for (shared_ptr<const Shape>& b : shapes_B)

--- a/math/rigid_transform.h
+++ b/math/rigid_transform.h
@@ -128,11 +128,11 @@ class RigidTransform {
   /// frames A and B.  Hence, the constructed %RigidTransform contains an
   /// identity RotationMatrix and the position vector underlying the given
   /// Eigen Translation3 transform.
-  /// @param[in] position Translation3 that stores `p_AoBo_A`, the position
+  /// @param[in] translation Translation3 that stores `p_AoBo_A`, the position
   /// vector from frame A's origin to frame B's origin, expressed in frame A.
   RigidTransform(  // NOLINT(runtime/explicit)
-      const Eigen::Translation<T, 3>& position) {
-    set_translation(position.translation());
+      const Eigen::Translation<T, 3>& translation) {
+    set_translation(translation.translation());
   }
 
   /// Constructs a %RigidTransform from an Eigen Isometry3.
@@ -336,14 +336,14 @@ class RigidTransform {
     return RigidTransform<T>(rotation() * other.rotation(), p_AoCo_A);
   }
 
-  /// Multiplies `this` %RigidTransform `X_AB` by the Eigen Translation3
-  /// transform `X_BC` and returns %RigidTransform `X_AC = X_AB * X_BC`.
+  /// Multiplies `this` %RigidTransform `X_AB` by the translation transform
+  /// `X_BC` and returns %RigidTransform `X_AC = X_AB * X_BC`.
   RigidTransform<T> operator*(const Eigen::Translation<T, 3>& X_BC) const {
     const Vector3<T> p_AoCo_A = *this * X_BC.translation();
     return RigidTransform<T>(rotation(), p_AoCo_A);
   }
 
-  /// Multiplies the Eigen Translation3 transform `X_AB` by the %RigidTransform
+  /// Multiplies the translation transform `X_AB` by the %RigidTransform
   /// `X_BC` and returns %RigidTransform `X_AC = X_AB * X_BC`.
   friend RigidTransform<T> operator*(const Eigen::Translation<T, 3>& X_AB,
       const RigidTransform<T>& X_BC) {

--- a/math/rigid_transform.h
+++ b/math/rigid_transform.h
@@ -124,13 +124,15 @@ class RigidTransform {
   /// expressed in frame A.  In monogram notation p is denoted `p_AoBo_A`.
   explicit RigidTransform(const Vector3<T>& p) { set_translation(p); }
 
-  /// Constructs a %RigidTransform with an identity RotationMatrix and a
-  /// position vector from a given Eigen Translation3 transform `p`.
-  /// @param[in] p Translation3 that contains `p_AoBo_A`, the position vector
+  /// Constructs a %RigidTransform that represents a translation between two
+  /// frames A and B.  Hence, the constructed %RigidTransform contains an
+  /// identity RotationMatrix and the position vector underlying the given
+  /// Eigen Translation3 transform `X_AB`.
+  /// @param[in] X_AB Translation3 that stores `p_AoBo_A`, the position vector
   /// from frame A's origin to frame B's origin, expressed in frame A.
   RigidTransform(  // NOLINT(runtime/explicit)
-      const Eigen::Translation<T, 3>& p) {
-    set_translation(p.translation());
+      const Eigen::Translation<T, 3>& X_AB) {
+    set_translation(X_AB.translation());
   }
 
   /// Constructs a %RigidTransform from an Eigen Isometry3.
@@ -139,7 +141,7 @@ class RigidTransform {
   /// origin to frame B's origin.  `p_AoBo_A` must be expressed in frame A.
   /// @throws std::logic_error in debug builds if R_AB is not a proper
   /// orthonormal 3x3 rotation matrix.
-  /// @note no attempt is made to orthogonalize the 3x3 rotation matrix part of
+  /// @note No attempt is made to orthogonalize the 3x3 rotation matrix part of
   /// `pose`.  As needed, use RotationMatrix::ProjectToRotationMatrix().
   explicit RigidTransform(const Isometry3<T>& pose) { SetFromIsometry3(pose); }
 
@@ -158,7 +160,7 @@ class RigidTransform {
   /// origin to frame B's origin.  `p_AoBo_A` must be expressed in frame A.
   /// @throws std::logic_error in debug builds if R_AB is not a proper
   /// orthonormal 3x3 rotation matrix.
-  /// @note no attempt is made to orthogonalize the 3x3 rotation matrix part of
+  /// @note No attempt is made to orthogonalize the 3x3 rotation matrix part of
   /// `pose`.  As needed, use RotationMatrix::ProjectToRotationMatrix().
   void SetFromIsometry3(const Isometry3<T>& pose) {
     set(RotationMatrix<T>(pose.linear()), pose.translation());
@@ -336,16 +338,16 @@ class RigidTransform {
     return RigidTransform<T>(rotation() * other.rotation(), p_AoCo_A);
   }
 
-  /// Efficiently calculates `this` %RigidTransform `X_AB` multiplied by `other`
-  /// Eigen Translation3 transform `X_BC`.
-  /// @param[in] other Translation3 that post-multiplies `this`.
+  /// Calculates `this` %RigidTransform `X_AB` multiplied by the Eigen
+  /// Translation3 transform `X_BC`.
+  /// @param[in] X_BC Translation3 that post-multiplies `this`.
   /// @retval X_AC = X_AB * X_BC
-  RigidTransform<T> operator*(const Eigen::Translation<T, 3>& other) const {
-    const Vector3<T> p_AoCo_A = *this * other.translation();
+  RigidTransform<T> operator*(const Eigen::Translation<T, 3>& X_BC) const {
+    const Vector3<T> p_AoCo_A = *this * X_BC.translation();
     return RigidTransform<T>(rotation(), p_AoCo_A);
   }
 
-  /// Efficiently calculates an Eigen Translation3 transform `X_AB` multiplied
+  /// Calculates an Eigen Translation3 transform `X_AB` multiplied
   /// by a %RigidTransform `X_BC`.
   /// @retval X_AC = X_AB * X_BC
   friend RigidTransform<T> operator*(const Eigen::Translation<T, 3>& X_AB,

--- a/math/rigid_transform.h
+++ b/math/rigid_transform.h
@@ -127,12 +127,12 @@ class RigidTransform {
   /// Constructs a %RigidTransform that represents a translation between two
   /// frames A and B.  Hence, the constructed %RigidTransform contains an
   /// identity RotationMatrix and the position vector underlying the given
-  /// Eigen Translation3 transform `X_AB`.
-  /// @param[in] X_AB Translation3 that stores `p_AoBo_A`, the position vector
-  /// from frame A's origin to frame B's origin, expressed in frame A.
+  /// Eigen Translation3 transform.
+  /// @param[in] position Translation3 that stores `p_AoBo_A`, the position
+  /// vector from frame A's origin to frame B's origin, expressed in frame A.
   RigidTransform(  // NOLINT(runtime/explicit)
-      const Eigen::Translation<T, 3>& X_AB) {
-    set_translation(X_AB.translation());
+      const Eigen::Translation<T, 3>& position) {
+    set_translation(position.translation());
   }
 
   /// Constructs a %RigidTransform from an Eigen Isometry3.
@@ -329,27 +329,22 @@ class RigidTransform {
     return *this;
   }
 
-  /// Calculates `this` %RigidTransform `X_AB` multiplied by `other`
-  /// %RigidTransform `X_BC`.
-  /// @param[in] other %RigidTransform that post-multiplies `this`.
-  /// @retval X_AC = X_AB * X_BC
+  /// Multiplies `this` %RigidTransform `X_AB` by the `other` %RigidTransform
+  /// `X_BC` and returns %RigidTransform `X_AC = X_AB * X_BC`.
   RigidTransform<T> operator*(const RigidTransform<T>& other) const {
     const Vector3<T> p_AoCo_A = *this * other.translation();
     return RigidTransform<T>(rotation() * other.rotation(), p_AoCo_A);
   }
 
-  /// Calculates `this` %RigidTransform `X_AB` multiplied by the Eigen
-  /// Translation3 transform `X_BC`.
-  /// @param[in] X_BC Translation3 that post-multiplies `this`.
-  /// @retval X_AC = X_AB * X_BC
+  /// Multiplies `this` %RigidTransform `X_AB` by the Eigen Translation3
+  /// transform `X_BC` and returns %RigidTransform `X_AC = X_AB * X_BC`.
   RigidTransform<T> operator*(const Eigen::Translation<T, 3>& X_BC) const {
     const Vector3<T> p_AoCo_A = *this * X_BC.translation();
     return RigidTransform<T>(rotation(), p_AoCo_A);
   }
 
-  /// Calculates an Eigen Translation3 transform `X_AB` multiplied
-  /// by a %RigidTransform `X_BC`.
-  /// @retval X_AC = X_AB * X_BC
+  /// Multiplies the Eigen Translation3 transform `X_AB` by the %RigidTransform
+  /// `X_BC` and returns %RigidTransform `X_AC = X_AB * X_BC`.
   friend RigidTransform<T> operator*(const Eigen::Translation<T, 3>& X_AB,
       const RigidTransform<T>& X_BC) {
     const RotationMatrix<T>& R_AC = X_BC.rotation();

--- a/math/test/rigid_transform_test.cc
+++ b/math/test/rigid_transform_test.cc
@@ -485,6 +485,58 @@ GTEST_TEST(RigidTransform, SymbolicRigidTransformThrowsExceptions) {
   EXPECT_THROW(test_Bool.Evaluate(), std::runtime_error);
 }
 
+// Test constructing a RigidTransform constructor from an Eigen::Translation3.
+GTEST_TEST(RigidTransform, ConstructRigidTransformFromTranslation3) {
+  const Vector3d p_AoBo_A(1.0, 2.0, 3.0);
+  const Eigen::Translation3d translation3(p_AoBo_A);
+  const RigidTransformd X_AB(translation3);
+  EXPECT_EQ(X_AB.translation(), p_AoBo_A);
+  EXPECT_TRUE(X_AB.rotation().IsExactlyIdentity());
+}
+
+// Test multiplying a RigidTransform by an Eigen::Translation3 and vice-versa.
+GTEST_TEST(RigidTransform, MultiplyByTranslation3AndViceVersa) {
+  const Vector3d p_AoBo_A(1.0, 2.0, 3.0);
+  const RotationMatrixd R_AB(RollPitchYawd(0.3, 0.2, 0.7));
+  const RigidTransformd X_AB(R_AB, p_AoBo_A);
+
+  const Vector3d p_BoCo_B(4.0, 5.0, 9.0);
+  const Eigen::Translation3d X_BC(p_BoCo_B);
+
+  // Multiply a RigidTransform by a Translation3.
+  const RigidTransformd X_AC = X_AB * X_BC;
+
+  // Verify the rotation portion of the previous multiply.
+  const RotationMatrixd& R_AC = X_AC.rotation();
+  EXPECT_TRUE(R_AC.IsExactlyEqualTo(X_AB.rotation()));
+
+  // Verify the translation portion of the previous multiply.
+  const Vector3d p_BoCo_A = R_AB * p_BoCo_B;
+  const Vector3d p_AoCo_A = p_AoBo_A + p_BoCo_A;
+  EXPECT_TRUE(X_AC.translation().isApprox(p_AoCo_A, 32 * kEpsilon));
+
+  // Test multiplying a Translation3 by a RigidTransform.
+  const Eigen::Translation3d X_CB = X_BC.inverse();
+  const RigidTransformd X_BA = X_AB.inverse();
+  const RigidTransformd X_CA = X_CB * X_BA;
+
+  // Verify the rotation portion of the previous multiply.
+  const RotationMatrixd& R_CA = X_CA.rotation();
+  const RotationMatrixd& R_BA = X_BA.rotation();
+  EXPECT_TRUE(R_CA.IsExactlyEqualTo(R_BA));
+  const RotationMatrixd  R_CB = RotationMatrixd::Identity();
+
+  // Verify the translation portion of the previous multiply.
+  const Vector3d p_CoBo_C = X_CB.translation();
+  const Vector3d p_BoAo_B = X_BA.translation();
+  const Vector3d p_BoAo_C = R_CB * p_BoAo_B;
+  const Vector3d p_CoAo_C = p_CoBo_C + p_BoAo_C;
+  EXPECT_TRUE(X_CA.translation().isApprox(p_CoAo_C, 32 * kEpsilon));
+
+  // Verify X_AC is the inverse of X_CA.
+  EXPECT_TRUE(X_AC.IsNearlyEqualTo(X_CA.inverse(), 32 * kEpsilon));
+}
+
 }  // namespace
 }  // namespace math
 }  // namespace drake

--- a/math/test/rigid_transform_test.cc
+++ b/math/test/rigid_transform_test.cc
@@ -527,8 +527,8 @@ GTEST_TEST(RigidTransform, MultiplyByTranslation3AndViceVersa) {
   const RotationMatrixd  R_CB = RotationMatrixd::Identity();
 
   // Verify the translation portion of the previous multiply.
-  const Vector3d p_CoBo_C = X_CB.translation();
-  const Vector3d p_BoAo_B = X_BA.translation();
+  const Vector3d& p_CoBo_C = X_CB.translation();
+  const Vector3d& p_BoAo_B = X_BA.translation();
   const Vector3d p_BoAo_C = R_CB * p_BoAo_B;
   const Vector3d p_CoAo_C = p_CoBo_C + p_BoAo_C;
   EXPECT_TRUE(X_CA.translation().isApprox(p_CoAo_C, 32 * kEpsilon));

--- a/math/test/rigid_transform_test.cc
+++ b/math/test/rigid_transform_test.cc
@@ -489,9 +489,11 @@ GTEST_TEST(RigidTransform, SymbolicRigidTransformThrowsExceptions) {
 GTEST_TEST(RigidTransform, ConstructRigidTransformFromTranslation3) {
   const Vector3d p_AoBo_A(1.0, 2.0, 3.0);
   const Eigen::Translation3d translation3(p_AoBo_A);
-  const RigidTransformd X_AB(translation3);
+  const RigidTransformd X_AB(translation3);            // Explicit construction
+  const RigidTransformd X_AB_implicit = translation3;  // Implicit construction
   EXPECT_EQ(X_AB.translation(), p_AoBo_A);
   EXPECT_TRUE(X_AB.rotation().IsExactlyIdentity());
+  EXPECT_TRUE(X_AB.IsExactlyEqualTo(X_AB_implicit));
 }
 
 // Test multiplying a RigidTransform by an Eigen::Translation3 and vice-versa.

--- a/multibody/tree/test/weld_joint_test.cc
+++ b/multibody/tree/test/weld_joint_test.cc
@@ -53,7 +53,7 @@ class WeldJointTest : public ::testing::Test {
 
   const RigidBody<double>* body_{nullptr};
   const WeldJoint<double>* joint_{nullptr};
-  const math::RigidTransformd X_FM_{Vector3d(0, 0.5, 0)};
+  const Translation3d X_FM_{0, 0.5, 0};
 };
 
 // Verify the expected number of dofs.


### PR DESCRIPTION
This is a new PR that implements PR #11090.
The differences are in documentation, improved efficiency, more comprehensive tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11198)
<!-- Reviewable:end -->
