### PR TITLE
Adds accessors to TrafficLight and BulbGroup

### DIFF
--- a/automotive/maliput/api/rules/traffic_lights.cc
+++ b/automotive/maliput/api/rules/traffic_lights.cc
@@ -67,6 +67,15 @@ BulbGroup::BulbGroup(const BulbGroup::Id& id,
   DRAKE_THROW_UNLESS(bulbs_.size() > 0);
 }
 
+optional<Bulb> BulbGroup::GetBulb(const Bulb::Id& id) const {
+  for (const auto& bulb : bulbs_) {
+    if (bulb.id() == id) {
+      return bulb;
+    }
+  }
+  return nullopt;
+}
+
 TrafficLight::TrafficLight(const TrafficLight::Id& id,
                            const GeoPosition& position_road_network,
                            const Rotation& orientation_road_network,
@@ -75,6 +84,15 @@ TrafficLight::TrafficLight(const TrafficLight::Id& id,
       position_road_network_(position_road_network),
       orientation_road_network_(orientation_road_network),
       bulb_groups_(bulb_groups) {}
+
+optional<BulbGroup> TrafficLight::GetBulbGroup(const BulbGroup::Id& id) const {
+  for (const auto& bulb_group : bulb_groups_) {
+    if (bulb_group.id() == id) {
+      return bulb_group;
+    }
+  }
+  return nullopt;
+}
 
 }  // namespace rules
 }  // namespace api

--- a/automotive/maliput/api/rules/traffic_lights.h
+++ b/automotive/maliput/api/rules/traffic_lights.h
@@ -209,6 +209,9 @@ class BulbGroup final {
   /// Returns the bulbs contained within this bulb group.
   const std::vector<Bulb>& bulbs() const { return bulbs_; }
 
+  /// Gets the specified Bulb. Returns nullopt if @p id is unrecognized.
+  optional<Bulb> GetBulb(const Bulb::Id& id) const;
+
  private:
   Id id_;
   GeoPosition position_traffic_light_;
@@ -273,6 +276,9 @@ class TrafficLight final {
 
   /// Returns the bulb groups contained within this traffic light.
   const std::vector<BulbGroup>& bulb_groups() const { return bulb_groups_; }
+
+  /// Gets the specified BulbGroup. Returns nullopt if @p id is unrecognized.
+  optional<BulbGroup> GetBulbGroup(const BulbGroup::Id& id) const;
 
  private:
   Id id_;

--- a/automotive/maliput/api/test/traffic_lights_test.cc
+++ b/automotive/maliput/api/test/traffic_lights_test.cc
@@ -163,6 +163,8 @@ TEST_F(BulbGroupTest, Accessors) {
   EXPECT_EQ(bulb_group_.orientation_traffic_light().matrix(),
             Rotation::FromRpy(4, 5, 6).matrix());
   EXPECT_EQ(bulb_group_.bulbs().size(), 3);
+  EXPECT_EQ(bulb_group_.GetBulb(Bulb::Id("unknown_bulb")), nullopt);
+  EXPECT_NE(bulb_group_.GetBulb(Bulb::Id("red_bulb")), nullopt);
 }
 
 TEST_F(BulbGroupTest, Copying) {
@@ -233,6 +235,9 @@ TEST_F(TrafficLightTest, Accessors) {
   EXPECT_EQ(traffic_light_.orientation_road_network().matrix(),
             Rotation::FromRpy(0, 0, 0).matrix());
   EXPECT_EQ(traffic_light_.bulb_groups().size(), 4);
+  EXPECT_EQ(traffic_light_.GetBulbGroup(BulbGroup::Id("unknown_bulb_group")),
+            nullopt);
+  EXPECT_NE(traffic_light_.GetBulbGroup(BulbGroup::Id("north_group")), nullopt);
 }
 
 TEST_F(TrafficLightTest, Copying) {


### PR DESCRIPTION
These are convenience methods for quickly obtaining a BulbGroup or Bulb
based on their IDs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11202)
<!-- Reviewable:end -->
