### PR TITLE
Tag maliput::RoadNetwork::road_geometry() return reference as internal

### DIFF
--- a/bindings/pydrake/maliput/api_py.cc
+++ b/bindings/pydrake/maliput/api_py.cc
@@ -60,7 +60,7 @@ PYBIND11_MODULE(api, m) {
       .def("rpy", &Rotation::rpy, doc.Rotation.rpy.doc);
 
   py::class_<RoadNetwork>(m, "RoadNetwork", doc.RoadNetwork.doc)
-      .def("road_geometry", &RoadNetwork::road_geometry,
+      .def("road_geometry", &RoadNetwork::road_geometry, py_reference_internal,
           doc.RoadNetwork.road_geometry.doc);
 
   py::class_<RoadGeometry>(m, "RoadGeometry", doc.RoadGeometry.doc)


### PR DESCRIPTION
Follow up PR after #11084. Bound `::road_geometry()` method return value should've been tagged as an internal reference. If not, `pybind11` takes ownership, which results in a double free error later on.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11204)
<!-- Reviewable:end -->
