### PR TITLE
Adds Bulb::GetDefaultState and Bulb::IsValidState

### DIFF
--- a/automotive/maliput/api/rules/traffic_lights.cc
+++ b/automotive/maliput/api/rules/traffic_lights.cc
@@ -1,7 +1,9 @@
 #include "drake/automotive/maliput/api/rules/traffic_lights.h"
 
+#include <algorithm>
 #include <utility>
 
+#include "drake/common/drake_assert.h"
 #include "drake/common/drake_throw.h"
 
 namespace drake {
@@ -49,11 +51,25 @@ Bulb::Bulb(const Bulb::Id& id, const GeoPosition& position_bulb_group,
   if (type_ != BulbType::kArrow) {
     DRAKE_THROW_UNLESS(arrow_orientation_rad_ == nullopt);
   }
-  if (states == nullopt) {
+  if (states == nullopt || states->size() == 0) {
     states_ = {BulbState::kOff, BulbState::kOn};
   } else {
     states_ = *states;
   }
+}
+
+BulbState Bulb::GetDefaultState() const {
+  for (const auto& bulb_state :
+       {BulbState::kOff, BulbState::kBlinking, BulbState::kOn}) {
+    if (IsValidState(bulb_state)) {
+      return bulb_state;
+    }
+  }
+  DRAKE_UNREACHABLE();
+}
+
+bool Bulb::IsValidState(const BulbState& bulb_state) const {
+  return std::find(states_.begin(), states_.end(), bulb_state) != states_.end();
 }
 
 BulbGroup::BulbGroup(const BulbGroup::Id& id,

--- a/automotive/maliput/api/rules/traffic_lights.h
+++ b/automotive/maliput/api/rules/traffic_lights.h
@@ -104,8 +104,8 @@ class Bulb final {
   /// will be thrown. An exception will also be thrown if this parameter is
   /// defined for non-arrow BulbType values.
   ///
-  /// @param states The possible states of this bulb. If this is nullopt, this
-  /// bulb has states {BulbState::kOff, BulbState::kOn}.
+  /// @param states The possible states of this bulb. If this is nullopt or an
+  /// empty vector, this bulb has states {BulbState::kOff, BulbState::kOn}.
   ///
   /// @param bounding_box The bounding box of the bulb. See BoundingBox for
   /// details about the default value.
@@ -145,6 +145,18 @@ class Bulb final {
 
   /// Returns the possible states of this bulb.
   const std::vector<BulbState>& states() const { return states_; }
+
+  /// Returns the default state of the bulb. The priority order is
+  /// BulbState::kOff, BulbState::kBlinking, then BulbState::kOn. For example,
+  /// if a bulb can be in states {BulbState::kOff, BulbState::kOn}, its default
+  /// state will be BulbState::kOff. Likewise, if a bulb can be in states
+  /// {BulbState::kOn, BulbState::kBlinking}, its default state will be
+  /// BulbState::kBlinking. The only case where the default state is
+  /// BulbState::kOn is when this is the bulb's only possible state.
+  BulbState GetDefaultState() const;
+
+  /// Returns true if @p bulb_state is one of this bulb's possible states.
+  bool IsValidState(const BulbState& bulb_state) const;
 
   /// Returns the bounding box of the bulb.
   const BoundingBox& bounding_box() const { return bounding_box_; }


### PR DESCRIPTION
These methods will enable the PhaseRingBookLoader to more efficiently load
the bulb states.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11205)
<!-- Reviewable:end -->
