### PR TITLE
Add MultipleShooting::NewSequentialContinuousVariable().

### DIFF
--- a/systems/trajectory_optimization/BUILD.bazel
+++ b/systems/trajectory_optimization/BUILD.bazel
@@ -16,6 +16,19 @@ drake_cc_package_library(
         ":direct_collocation",
         ":direct_transcription",
         ":multiple_shooting",
+        ":sequential_expression_manager",
+    ],
+)
+
+drake_cc_library(
+    name = "sequential_expression_manager",
+    srcs = ["sequential_expression_manager.cc"],
+    hdrs = [
+        "sequential_expression_manager.h",
+    ],
+    deps = [
+        "//common:essential",
+        "//common:symbolic",
     ],
 )
 
@@ -24,10 +37,10 @@ drake_cc_library(
     srcs = ["multiple_shooting.cc"],
     hdrs = ["multiple_shooting.h"],
     deps = [
+        ":sequential_expression_manager",
         "//common:essential",
         "//common/trajectories:piecewise_polynomial",
         "//solvers:mathematical_program",
-        "//systems/framework",
     ],
 )
 
@@ -43,6 +56,7 @@ drake_cc_library(
         ":multiple_shooting",
         "//math:autodiff",
         "//math:gradient",
+        "//systems/framework",
     ],
 )
 
@@ -58,6 +72,7 @@ drake_cc_library(
         ":multiple_shooting",
         "//math:autodiff",
         "//math:gradient",
+        "//systems/framework",
         "//systems/primitives:linear_system",
         "//systems/primitives:piecewise_polynomial_linear_system",
     ],
@@ -93,6 +108,14 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//solvers:solve",
         "//systems/primitives:piecewise_polynomial_linear_system",
+    ],
+)
+
+drake_cc_googletest(
+    name = "sequential_expression_manager_test",
+    deps = [
+        ":sequential_expression_manager",
+        "@fmt",
     ],
 )
 

--- a/systems/trajectory_optimization/multiple_shooting.h
+++ b/systems/trajectory_optimization/multiple_shooting.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -12,8 +13,7 @@
 #include "drake/common/symbolic.h"
 #include "drake/common/trajectories/piecewise_polynomial.h"
 #include "drake/solvers/mathematical_program.h"
-#include "drake/systems/framework/context.h"
-#include "drake/systems/framework/system.h"
+#include "drake/systems/trajectory_optimization/sequential_expression_manager.h"
 
 namespace drake {
 namespace systems {
@@ -39,7 +39,7 @@ class MultipleShooting : public solvers::MathematicalProgram {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MultipleShooting)
 
-  ~MultipleShooting() override {}
+  virtual ~MultipleShooting() {}
 
   /// Returns the decision variable associated with the timestep, h, at time
   /// index @p index.
@@ -112,11 +112,28 @@ class MultipleShooting : public solvers::MathematicalProgram {
     return u_vars_.segment(index * num_inputs_, num_inputs_);
   }
 
+  /// Adds a sequential variable (a variable that has associated decision
+  /// variables for each time index) to the optimization problem and returns a
+  /// placeholder variable (not actually declared as a decision variable in the
+  /// MathematicalProgram).  This variable will be substituted for real decision
+  /// variables at particular times in methods like AddRunningCost().  Passing
+  /// this variable directly into objectives/constraints for the parent classes
+  /// will result in an error.
+  solvers::VectorXDecisionVariable NewSequentialVariable(
+      int rows, const std::string& name);
+
+  /// Returns the decision variables associated with the sequential variable
+  /// `name` at time index `index`.
+  /// @see NewSequentialVariable().
+  solvers::VectorXDecisionVariable GetSequentialVariableAtIndex(
+      const std::string& name, int index) const;
+
   /// Adds an integrated cost to all time steps, of the form
   ///    @f[ cost = \int_0^T g(t,x,u) dt, @f]
   /// where any instances of time(), state(), and/or input() placeholder
-  /// variables are substituted with the relevant variables for each current
-  /// time index.  The particular integration scheme is determined by the
+  /// variables, as well as placeholder variables returned by calls to
+  /// NewSequentialVariable(), are substituted with the relevant variables for
+  /// each time index.  The particular integration scheme is determined by the
   /// derived class implementation.
   void AddRunningCost(const symbolic::Expression& g) { DoAddRunningCost(g); }
 
@@ -129,8 +146,9 @@ class MultipleShooting : public solvers::MathematicalProgram {
   }
 
   /// Adds a constraint to all knot points, where any instances of time(),
-  /// state(), and/or input() placeholder variables are substituted with the
-  /// relevant variables for each current time index.
+  /// state(), and/or input() placeholder variables, as well as placeholder
+  /// variables returned by calls to NewSequentialVariable(), are substituted
+  /// with the relevant variables for each time index.
   void AddConstraintToAllKnotPoints(const symbolic::Formula& f) {
     for (int i = 0; i < N_; i++) {
       // TODO(russt): update this to AddConstraint once MathematicalProgram
@@ -168,8 +186,9 @@ class MultipleShooting : public solvers::MathematicalProgram {
   /// Adds a cost to the final time, of the form
   ///    @f[ cost = e(t,x,u), @f]
   /// where any instances of time(), state(), and/or input() placeholder
-  /// variables are substituted with the relevant variables for each current
-  /// time index.
+  /// variables, as well as placeholder variables returned by calls to
+  /// NewSequentialVariable(), are substituted with the relevant variables for
+  /// the final time index.
   void AddFinalCost(const symbolic::Expression& e) {
     AddCost(SubstitutePlaceholderVariables(e, N_ - 1));
   }
@@ -389,6 +408,10 @@ class MultipleShooting : public solvers::MathematicalProgram {
   const solvers::VectorXDecisionVariable& x_vars() const { return x_vars_; }
 
  private:
+  MultipleShooting(int num_inputs, int num_states, int num_time_samples,
+                   bool timesteps_are_decision_variables,
+                   double minimum_timestep, double maximum_timestep);
+
   virtual void DoAddRunningCost(const symbolic::Expression& g) = 0;
 
   // Helper method that performs the work for SubstitutePlaceHolderVariables
@@ -404,14 +427,16 @@ class MultipleShooting : public solvers::MathematicalProgram {
   solvers::VectorXDecisionVariable h_vars_;  // Time deltas between each
                                              // input/state sample or the empty
                                              // vector (if timesteps are fixed).
-  const solvers::VectorXDecisionVariable x_vars_;
-  const solvers::VectorXDecisionVariable u_vars_;
+  solvers::VectorXDecisionVariable x_vars_;
+  solvers::VectorXDecisionVariable u_vars_;
 
   // See description of the public time(), state(), and input() accessor methods
   // for details about the placeholder variables.
-  const solvers::VectorDecisionVariable<1> placeholder_t_var_;
-  const solvers::VectorXDecisionVariable placeholder_x_vars_;
-  const solvers::VectorXDecisionVariable placeholder_u_vars_;
+  solvers::VectorDecisionVariable<1> placeholder_t_var_;
+  solvers::VectorXDecisionVariable placeholder_x_vars_;
+  solvers::VectorXDecisionVariable placeholder_u_vars_;
+
+  internal::SequentialExpressionManager sequential_expression_manager_;
 };
 
 }  // namespace trajectory_optimization

--- a/systems/trajectory_optimization/sequential_expression_manager.cc
+++ b/systems/trajectory_optimization/sequential_expression_manager.cc
@@ -1,0 +1,67 @@
+#include "drake/systems/trajectory_optimization/sequential_expression_manager.h"
+
+#include <fmt/format.h>
+
+namespace drake {
+namespace systems {
+namespace trajectory_optimization {
+namespace internal {
+
+using symbolic::Substitution;
+using symbolic::Expression;
+using symbolic::Variable;
+using symbolic::Variables;
+
+SequentialExpressionManager::SequentialExpressionManager(int num_samples)
+    : num_samples_(num_samples) {
+  DRAKE_THROW_UNLESS(num_samples_ > 0);
+}
+
+VectorX<Variable> SequentialExpressionManager::RegisterSequentialExpressions(
+    const Eigen::Ref<const MatrixX<Expression>>& sequential_expressions,
+    const std::string& name) {
+  const int rows = sequential_expressions.rows();
+  DRAKE_THROW_UNLESS(sequential_expressions.cols() == num_samples_);
+  VectorX<Variable> placeholders{rows};
+  for (int i = 0; i < rows; ++i) {
+    placeholders(i) = Variable(fmt::format("{}{}", name, i));
+  }
+  const auto pair = name_to_placeholders_and_sequential_expressions_.insert(
+      {name, {placeholders, sequential_expressions}});
+  DRAKE_THROW_UNLESS(pair.second);
+  return placeholders;
+}
+
+Substitution
+SequentialExpressionManager::ConstructPlaceholderVariableSubstitution(
+    int index) const {
+  DRAKE_THROW_UNLESS(0 <= index && index < num_samples_);
+  Substitution substitution;
+  for (const auto& pair : name_to_placeholders_and_sequential_expressions_) {
+    // pair.first is the name, which we don't need here.
+    const VectorX<Variable>& placeholders = pair.second.first;
+    const MatrixX<Expression>& sequential_expressions = pair.second.second;
+    const int rows = placeholders.rows();
+    for (int row = 0; row < rows; ++row) {
+      substitution.emplace(placeholders(row),
+                           sequential_expressions(row, index));
+    }
+  }
+  return substitution;
+}
+
+VectorX<Expression>
+SequentialExpressionManager::GetSequentialExpressionsByName(
+    const std::string& name, int index) const {
+  DRAKE_THROW_UNLESS(0 <= index && index < num_samples_);
+  const auto it = name_to_placeholders_and_sequential_expressions_.find(name);
+  DRAKE_THROW_UNLESS(it !=
+                     name_to_placeholders_and_sequential_expressions_.end());
+  const MatrixX<Expression>& sequential_expressions = it->second.second;
+  return sequential_expressions.col(index);
+}
+
+}  // namespace internal
+}  // namespace trajectory_optimization
+}  // namespace systems
+}  // namespace drake

--- a/systems/trajectory_optimization/sequential_expression_manager.h
+++ b/systems/trajectory_optimization/sequential_expression_manager.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/common/symbolic.h"
+
+namespace drake {
+namespace systems {
+namespace trajectory_optimization {
+namespace internal {
+/**
+ * Represents a collection of sequential expression vectors (expression vectors
+ * that take on different values for each index in {0, ..., `num_samples` - 1}).
+ * Each sequential expression vector is identified by a name and has an
+ * associated vector of placeholder variables. These placeholder variables can
+ * be replaced with the corresponding expressions for a given index by means of
+ * the symbolic::Substitution that ConstructPlaceholderVariableSubstitution()
+ * returns.
+ */
+class SequentialExpressionManager {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SequentialExpressionManager);
+
+  /**
+   * @pre `num_samples` > 0
+   */
+  explicit SequentialExpressionManager(int num_samples);
+
+  ~SequentialExpressionManager() = default;
+
+  /**
+   * Registers a sequential expression vector and returns a vector of
+   * placeholder variables.
+   * @param sequential_expressions [num_expressions x num_samples] matrix of
+   * symbolic expressions. sequential_expressions(i, j) is the value of the i-th
+   * expression at the j-th index.
+   * @param name Name for the newly registered sequential expression vector. The
+   * i-th element of the placeholder variable vector will be named name_i.
+   * @pre `sequential_expressions` has num_samples() columns.
+   * @pre `name` must not duplicate the name of any previously registered
+   * sequential expression vector.
+   * @returns placeholder variable vector for use with
+   * ConstructPlaceholderVariableSubstitution().
+   */
+  VectorX<symbolic::Variable> RegisterSequentialExpressions(
+      const Eigen::Ref<const MatrixX<symbolic::Expression>>&
+          sequential_expressions,
+      const std::string& name);
+
+  /**
+   * Returns a symbolic::Substitution for replacing all placeholder variables
+   * with their respective `index`-th expression.
+   * @pre 0 <= index < num_samples()
+   */
+  symbolic::Substitution ConstructPlaceholderVariableSubstitution(
+      int index) const;
+
+  /**
+   * Returns the `index`-th vector of expressions for `name`.
+   * @pre `name` is associated with a registered sequential expression vector.
+   * @pre 0 <= index < num_samples()
+   **/
+  VectorX<symbolic::Expression> GetSequentialExpressionsByName(
+      const std::string& name, int index) const;
+
+  /**
+   * Returns the number of samples for the sequential expressions managed by
+   * `this`.
+   */
+  int num_samples() const { return num_samples_; }
+
+ private:
+  int num_samples_{};
+  std::unordered_map<std::string, std::pair<VectorX<symbolic::Variable>,
+                                            MatrixX<symbolic::Expression>>>
+      name_to_placeholders_and_sequential_expressions_;
+};
+}  // namespace internal
+}  // namespace trajectory_optimization
+}  // namespace systems
+}  // namespace drake

--- a/systems/trajectory_optimization/test/sequential_expression_manager_test.cc
+++ b/systems/trajectory_optimization/test/sequential_expression_manager_test.cc
@@ -1,0 +1,114 @@
+#include "drake/systems/trajectory_optimization/sequential_expression_manager.h"
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+#include "drake/common/symbolic.h"
+
+namespace drake {
+namespace systems {
+namespace trajectory_optimization {
+namespace internal {
+
+using symbolic::Expression;
+using symbolic::Substitution;
+using symbolic::Variable;
+
+class SequentialExpressionManagerTests : public testing::Test {
+ public:
+  static MatrixX<Variable> MakeVariableMatrix(int rows, int cols) {
+    MatrixX<Variable> variable{rows, cols};
+    for (int i = 0; i < rows; ++i) {
+      for (int j = 0; j < cols; ++j) {
+        variable(i, j) = Variable(fmt::format("x_{}_{}", i, j));
+      }
+    }
+    return variable;
+  }
+
+ protected:
+  const int num_variables_{3};
+  const int num_samples_{5};
+  SequentialExpressionManager dut_{num_samples_};
+};
+
+// Verify that num_samples() works as expected.
+TEST_F(SequentialExpressionManagerTests, NumSamplesTest) {
+  EXPECT_EQ(dut_.num_samples(), num_samples_);
+}
+
+// Test with a matrix of Expressions.
+TEST_F(SequentialExpressionManagerTests, RegisterAndSubstituteExpressionTest) {
+  MatrixX<Expression> x_sequential =
+      MakeVariableMatrix(num_variables_, num_samples_);
+  x_sequential.cwiseSqrt();
+  VectorX<Variable> x_placeholder =
+      dut_.RegisterSequentialExpressions(x_sequential.cast<Expression>(), "x");
+  MatrixX<Expression> placeholder_expression =
+      x_placeholder * x_placeholder.transpose();
+  for (int j = 0; j < num_samples_; ++j) {
+    MatrixX<Expression> expected_expression =
+        x_sequential.col(j) * x_sequential.col(j).transpose();
+    Substitution subs = dut_.ConstructPlaceholderVariableSubstitution(j);
+    EXPECT_EQ(symbolic::Substitute(placeholder_expression, subs),
+              expected_expression);
+  }
+}
+
+// Test with an Eigen::Map applied to a vector of Expressions.
+TEST_F(SequentialExpressionManagerTests, RegisterAndSubstituteMapTest) {
+  VectorX<Expression> x_sequential =
+      MakeVariableMatrix(num_variables_ * num_samples_, 1);
+  VectorX<Variable> x_placeholder = dut_.RegisterSequentialExpressions(
+      Eigen::Map<MatrixX<Expression>>(x_sequential.data(), num_variables_,
+                                      num_samples_),
+      "x");
+  MatrixX<Expression> placeholder_expression =
+      x_placeholder * x_placeholder.transpose();
+  for (int j = 0; j < num_samples_; ++j) {
+    MatrixX<Expression> expected_expression =
+        x_sequential.segment(j * num_variables_, num_variables_) *
+        x_sequential.segment(j * num_variables_, num_variables_).transpose();
+    Substitution subs = dut_.ConstructPlaceholderVariableSubstitution(j);
+    EXPECT_EQ(symbolic::Substitute(placeholder_expression, subs),
+              expected_expression);
+  }
+}
+
+// Test with an Eigen::Map and cast() applied to a vector of Variables.
+TEST_F(SequentialExpressionManagerTests, RegisterAndSubstituteMapCastTest) {
+  VectorX<Variable> x_sequential =
+      MakeVariableMatrix(num_variables_ * num_samples_, 1);
+  VectorX<Variable> x_placeholder = dut_.RegisterSequentialExpressions(
+      Eigen::Map<MatrixX<Variable>>(x_sequential.data(), num_variables_,
+                                    num_samples_)
+          .cast<Expression>(),
+      "x");
+  MatrixX<Expression> placeholder_expression =
+      x_placeholder * x_placeholder.transpose();
+  for (int j = 0; j < num_samples_; ++j) {
+    MatrixX<Expression> expected_expression =
+        x_sequential.segment(j * num_variables_, num_variables_) *
+        x_sequential.segment(j * num_variables_, num_variables_).transpose();
+    Substitution subs = dut_.ConstructPlaceholderVariableSubstitution(j);
+    EXPECT_EQ(symbolic::Substitute(placeholder_expression, subs),
+              expected_expression);
+  }
+}
+
+// Verify that GetSequentialExpressionsByName behaves as expected.
+TEST_F(SequentialExpressionManagerTests, GetSequentialExpressionsByNameTest) {
+  MatrixX<Expression> x_sequential =
+      MakeVariableMatrix(num_variables_, num_samples_);
+  x_sequential.cwiseSqrt();
+  dut_.RegisterSequentialExpressions(x_sequential.cast<Expression>(), "x");
+  for (int j = 0; j < num_samples_; ++j) {
+    VectorX<Expression> expected_expression = x_sequential.col(j);
+    EXPECT_EQ(dut_.GetSequentialExpressionsByName("x", j), expected_expression);
+  }
+}
+}  // namespace internal
+}  // namespace trajectory_optimization
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
This method returns a vector of placeholder variables that can be used with the
newly public `ConstructPlaceholderVariableSubstitution()`. The actual decision
variables for a particular time index can be retrieved with
`GetSequentialVariablesByName()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11207)
<!-- Reviewable:end -->
