### PR TITLE
Make ComputeSignedDistanceToPoint autodiffable

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -50,7 +50,7 @@ drake_cc_library(
         ":utilities",
         "//common",
         "//common:default_scalars",
-        "//geometry/proximity:distance_to_point_with_gradient",
+        "//geometry/proximity",
         "//geometry/query_results",
         "//math",
         "@fcl",

--- a/geometry/dev/render/render_engine.h
+++ b/geometry/dev/render/render_engine.h
@@ -94,8 +94,9 @@ class RenderEngine : public ShapeReifier {
     for (auto pair : update_indices_) {
       RenderIndex render_index = pair.first;
       InternalIndex global_index = pair.second;
-      DoUpdateVisualPose(geometry::internal::convert(X_WG[global_index]),
-                         render_index);
+      DoUpdateVisualPose(
+          geometry::internal::convert_to_double(X_WG[global_index]),
+          render_index);
     }
   }
 

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -443,13 +443,14 @@ class GeometryState {
 
   /** Performs work in support of QueryObject::ComputeSignedDistanceToPoint().
    */
-  std::vector<SignedDistanceToPoint<double>>
+  std::vector<SignedDistanceToPoint<T>>
   ComputeSignedDistanceToPoint(
-      const Vector3<double> &p_WQ,
+      const Vector3<T> &p_WQ,
       const double threshold) const {
     return geometry_engine_->ComputeSignedDistanceToPoint(
-        p_WQ, geometry_index_to_id_map_, threshold);
+        p_WQ, geometry_index_to_id_map_, X_WG_, threshold);
   }
+
   //@}
 
   /** @name Scalar conversion  */

--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -13,7 +13,9 @@ package(default_visibility = ["//visibility:public"])
 drake_cc_package_library(
     name = "proximity",
     deps = [
+        ":distance_to_point",
         ":distance_to_point_with_gradient",
+        ":proximity_utilities",
     ],
 )
 
@@ -22,10 +24,46 @@ drake_cc_library(
     srcs = ["distance_to_point_with_gradient.cc"],
     hdrs = ["distance_to_point_with_gradient.h"],
     deps = [
+        ":distance_to_point",
+        ":proximity_utilities",
         "//geometry:geometry_ids",
         "//geometry/query_results:signed_distance_to_point_with_gradient",
         "//math",
         "@fcl",
+    ],
+)
+
+drake_cc_library(
+    name = "distance_to_point",
+    hdrs = ["distance_to_point.h"],
+    deps = [
+        ":proximity_utilities",
+        "//common:essential",
+        "//geometry:geometry_ids",
+        "//geometry/query_results:signed_distance_to_point",
+        "//math:geometric_transform",
+        "@fcl",
+    ],
+)
+
+drake_cc_library(
+    name = "proximity_utilities",
+    hdrs = ["proximity_utilities.h"],
+    deps = [
+        "//geometry:geometry_ids",
+        "//geometry:geometry_index",
+        "@fcl",
+        "@fmt",
+    ],
+)
+
+drake_cc_googletest(
+    name = "distance_to_point_test",
+    deps = [
+        ":distance_to_point",
+        "//common/test_utilities",
+        "//geometry:utilities",
+        "//math",
     ],
 )
 

--- a/geometry/proximity/distance_to_point.h
+++ b/geometry/proximity/distance_to_point.h
@@ -1,0 +1,552 @@
+#pragma once
+
+// Exclude internal classes from doxygen.
+#if !defined(DRAKE_DOXYGEN_CXX)
+
+#include <limits>
+#include <tuple>
+#include <vector>
+
+#include <fcl/fcl.h>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/eigen_types.h"
+#include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/proximity/proximity_utilities.h"
+#include "drake/geometry/query_results/signed_distance_to_point.h"
+#include "drake/math/rigid_transform.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace point_distance {
+
+/** Supporting data for the distance-to-point callback (see Callback below).
+ It includes:
+    - The query point Q, measured and expressed in the world frame, `p_WQ_W`.
+    - The fcl collision object representing the query point, Q.
+    - A map from GeometryIndex to GeometryId (to facilitate reporting GeometryId
+      values in the results).
+    - A distance threshold beyond which distances will not be reported.
+    - The pose of the geometry being queried against.
+    - The T-valued poses of _all_ geometries in the corresponding SceneGraph
+      indexable by their GeometryIndex.
+    - A vector of distance results -- one instance of SignedDistanceToPoint for
+      every supported geometry which lies with the threshold.
+ */
+template <typename T>
+struct CallbackData {
+  /** Constructs the fully-specified callback data. The values are as described
+   above. _Some_ of the parameters are aliased in the data and require the
+   aliased parameters to remain valid at least as long as the CallbackData
+   instance.
+
+   @param query_in            The object representing the query point. Aliased.
+   @param geometry_map_in     The index -> id map. Aliased.
+   @param threshold_in        The query threshold.
+   @param p_WQ_W_in           The T-valued position of the query point.
+   @param X_WGs_in             The T-valued poses. Aliased.
+   @param distances_in[out]   The output results. Aliased.
+   */
+  CallbackData(
+      fcl::CollisionObjectd* query_in,
+      const std::vector<GeometryId>* geometry_map_in,
+      const double threshold_in,
+      const Vector3<T>& p_WQ_W_in,
+      const std::vector<Isometry3<T>>* X_WGs_in,
+      std::vector<SignedDistanceToPoint<T>>* distances_in)
+      : query_point(*query_in),
+        geometry_map(*geometry_map_in),
+        threshold(threshold_in),
+        p_WQ_W(p_WQ_W_in),
+        X_WGs(*X_WGs_in),
+        distances(*distances_in) {
+    DRAKE_DEMAND(query_in);
+    DRAKE_DEMAND(geometry_map_in);
+    DRAKE_DEMAND(X_WGs_in);
+    DRAKE_DEMAND(distances_in);
+  }
+
+  /** The query fcl object.  */
+  const fcl::CollisionObjectd& query_point;
+
+  /** The index --> id map.  */
+  const std::vector<GeometryId>& geometry_map;
+
+  /** The query threshold.  */
+  const double threshold;
+
+  /** The T-valued query point Q.  */
+  const Vector3<T> p_WQ_W;
+
+  /** The T-valued pose of every geometry.  */
+  const std::vector<Isometry3<T>>& X_WGs;
+
+  /** The accumulator for results.  */
+  std::vector<SignedDistanceToPoint<T>>& distances;
+};
+
+
+/** @name Functions for computing distance from point to primitives
+ This family of functions compute the distance from a point Q to a primitive
+ shape.  Refer to QueryObject::ComputeSignedDistanceToPoint() for more details.
+
+ @param X_WG            The pose of the primitive geometry G in the world frame.
+ @param p_WQ            The position of the point Q in the world frame.
+ @param p_GN[out]       The position of the witness point N on the primitive,
+                        expressed in the primitive geometry frame G.
+ @param distance[out]   The signed distance from the point Q to the primitive.
+ @param grad_W[out]     The gradient of the distance function w.r.t p_GQ (the
+                        position of the point Q in the primitive's frame). This
+                        gradient vector has unit-length and is expressed in the
+                        world frame. Where grad_W is not well-defined, then
+                        an arbitrary value is assigned (as documented in
+                        QueryObject::ComputeSignedDistanceToPoint().  */
+//@{
+
+/** Overload of ComputeDistanceToPrimitive() for sphere primitive. */
+template <typename T>
+void ComputeDistanceToPrimitive(const fcl::Sphered& sphere,
+                                const math::RigidTransform<T>& X_WG,
+                                const Vector3<T>& p_WQ, Vector3<T>* p_GN,
+                                T* distance, Vector3<T>* grad_W) {
+  const double radius = sphere.radius;
+  const Vector3<T> p_GQ_G = X_WG.inverse() * p_WQ;
+  const T dist_GQ = p_GQ_G.norm();
+
+  // The gradient is always in the direction from the center of the sphere to
+  // the query point Q, regardless of whether the point Q is outside or inside
+  // the sphere G.  The gradient is undefined if the query point Q is at the
+  // center of the sphere G.
+  //
+  // If the query point Q is near the center of the sphere G within a
+  // tolerance, we arbitrarily set the gradient vector as documented in
+  // query_object.h (QueryObject::ComputeSignedDistanceToPoint).
+  const double tolerance = DistanceToPointRelativeTolerance(radius);
+  // Unit vector in x-direction of G's frame.
+  const Vector3<T> Gx = Vector3<T>::UnitX();
+  // Gradient vector expressed in G's frame.
+  const Vector3<T> grad_G = (dist_GQ > tolerance) ? p_GQ_G / dist_GQ : Gx;
+
+  // Do not compute distance as ∥p_GQ∥₂, because the gradient of ∥p_GQ∥₂ w.r.t.
+  // p_GQ is p_GQᵀ/∥p_GQ∥₂ which is not well defined at p_GQ = 0. Instead,
+  // compute the distance as p_GQ.dot(grad_G).
+  *distance = p_GQ_G.dot(grad_G) - T(radius);
+
+  // Position vector of the nearest point N on G's surface from the query
+  // point Q, expressed in G's frame.
+  *p_GN = radius * grad_G;
+  // Gradient vector expressed in World frame.
+  *grad_W = X_WG.rotation() * grad_G;
+}
+
+/** Overload of ComputeDistanceToPrimitive() for halfspace primitive. */
+template <typename T>
+void ComputeDistanceToPrimitive(const fcl::Halfspaced& halfspace,
+                                const math::RigidTransform<T>& X_WG,
+                                const Vector3<T>& p_WQ, Vector3<T>* p_GN,
+                                T* distance, Vector3<T>* grad_W) {
+  // FCL stores the halfspace as {x | nᵀ * x <= d}, with n being a unit length
+  // normal vector. Both n and x are expressed in the halfspace frame.
+  const Vector3<T> n_G = halfspace.n.cast<T>();
+  const Vector3<T> p_GQ = X_WG.inverse() * p_WQ;
+  *distance = n_G.dot(p_GQ) - T(halfspace.d);
+  *p_GN = p_GQ - *distance * n_G;
+  *grad_W = X_WG.rotation() * n_G;
+}
+
+// TODO(DamrongGuoy): Add overloads for all supported geometries.
+
+//@}
+
+/** A functor to compute signed distance between a point and a geometry. By
+ design, one instance should be created for each unique pairing of query point Q
+ with geometry G. The functor is constructed with all the parameters _except_
+ the actual shape. It relies on overloading the () operator and ADL to handle
+ specific shape types.  */
+template <typename T>
+class DistanceToPoint {
+ public:
+  /** Constructs the functor DistanceToPoint.
+   @param id    The id of the geometry G,
+   @param X_WG  The pose of the G in world frame,
+   @param p_WQ  The position of the query point Q in world frame.  */
+  DistanceToPoint(const GeometryId id,
+                  const math::RigidTransform<T>& X_WG,
+                  const Vector3<T>& p_WQ) :
+      geometry_id_(id), X_WG_(X_WG), p_WQ_(p_WQ) {}
+
+  // TODO(DamrongGuoy): Revisit computation over operator() overloads as per
+  //  issue: https://github.com/RobotLocomotion/drake/issues/11227
+
+  /** Overload to compute distance to a sphere.  */
+  SignedDistanceToPoint<T> operator()(const fcl::Sphered& sphere) {
+    T distance{};
+    Vector3<T> p_GN_G, grad_W;
+    ComputeDistanceToPrimitive(sphere, X_WG_, p_WQ_, &p_GN_G, &distance,
+                               &grad_W);
+
+    return SignedDistanceToPoint<T>{geometry_id_, p_GN_G, distance, grad_W};
+  }
+
+  /** Overload to compute distance to a box.  */
+  SignedDistanceToPoint<T> operator()(const fcl::Boxd& box) {
+    // Express the given query point Q in the frame of the box geometry G.
+    const Vector3<T> p_GQ_G = X_WG_.inverse() * p_WQ_;
+    // The box G is an axis-aligned box [-h(0),h(0)]x[-h(1),h(1)]x[-h(2),h(2)]
+    // centered at the origin, where h(i) is half the size of the box in the
+    // i-th coordinate.
+    const Eigen::Vector3d h = box.side / 2.0;
+    Vector3<T> p_GN_G, grad_G;
+    std::tie(p_GN_G, grad_G) = ComputeDistanceToBox(h, p_GQ_G);
+    const Vector3<T> grad_W = X_WG_.rotation() * grad_G;
+    const Vector3<T> p_WN = X_WG_ * p_GN_G;
+    T distance = grad_W.dot(p_WQ_ - p_WN);
+    return SignedDistanceToPoint<T>{geometry_id_, p_GN_G, distance, grad_W};
+  }
+
+  /** Overload to compute distance to a cylinder.  */
+  SignedDistanceToPoint<T> operator()(const fcl::Cylinderd& cylinder) {
+    using std::sqrt;
+    // TODO(SeanCurtis-TRI): This is not a good algorithm for differentiation.
+    //  Replace it with one that is.
+
+    // Overview. First, we map the problem from the 3D cylinder G (in frame G)
+    // to the 2D box B (in frame B) of G's cross section through the plane
+    // containing the query point Q and the center line of G. Then, we call the
+    // function ComputeDistanceToBox() to get the signed distance, the nearest
+    // point N, and the gradient vector expressed in B's frame. Finally, we map
+    // the answers back into G's frame.
+    // Express the query point Q in the cylinder geometry G's frame.
+    const Vector3<T> p_GQ = X_WG_.inverse() * p_WQ_;
+    // The 2D cross section B is the box [-h(0),h(0)]x[-h(1),h(1)], where
+    // h(0) and h(1) are the radius and the half length of the cylinder.
+    const Eigen::Vector2d h(cylinder.radius, cylinder.lz / 2.0);
+    // Transform coordinates between (x,y,z) in G's frame and (r,z) in B's
+    // frame. The basis vector `Bz` is aligned with `Gz`, and `r` is the
+    // distance to the z-axis (i.e., √(x² + y²)), and z transfers unchanged. The
+    // coordinate r is in the radial direction of G in the plane through Q and
+    // z-axis of G.
+    //
+    //  3D cylinder G (x,y,z)     2D box B (r,z)          .
+    //       z                         z                  .
+    //       |      y                  |                  .
+    //       |     /                   |                  .
+    //     o | o  /                    |                  .
+    //   o   |   o                     |                  .
+    //   o   |  /o                  +--|--+               .
+    //   | o o o |          <==>    |  |  |               .
+    //   |   |/  |                  |  |  |               .
+    //   |   +-----------x          |  +------Q-------r   .
+    //   |    \  |                  |     |               .
+    //   o     \ o                  +-----+               .
+    //     o o o\                                         .
+    //           \                                        .
+    //            Q                                       .
+    //             \                                      .
+    //              \                                     .
+    //               r                                    .
+    //
+    // Mathematically the (r,z)-to-(x,y,z) transformation is not defined if Q
+    // is on the z-axis of G because the cross section is not unique.  In that
+    // case, we will treat Q as if it lies on x-axis of G.
+    //
+    auto xyz_to_rz = [](Vector3<T> xyz) -> Vector2<T> {
+      // TODO(hongkai.dai): Why doesn't this cause bad derivatives? See test
+      // distance_to_point_test.cc, (DistanceToPoint, Cylinder), Case 1.
+      const T r = sqrt(xyz(0) * xyz(0) + xyz(1) * xyz(1));
+      return Vector2<T>(r, xyz(2));
+    };
+    // We compute the the basis vector Br in G's frame. Although a 3D vector, it
+    // is stored implicitly in a 2D vector, because v_GBr(2) must be zero. If
+    // Q is within a tolerance from the center line, v_GBr = <1, 0, 0> by
+    // convention.
+    const T r_Q = sqrt(p_GQ(0) * p_GQ(0) + p_GQ(1) * p_GQ(1));
+    const bool near_center_line =
+        (r_Q < DistanceToPointRelativeTolerance(cylinder.radius));
+    const Vector2<T> v_GBr = near_center_line
+                                 ? Vector2<T>(1., 0.)
+                                 : Vector2<T>(p_GQ(0), p_GQ(1)) / r_Q;
+    auto rz_to_xyz = [&v_GBr](Vector2<T> rz) -> Vector3<T> {
+      const T r = rz(0);
+      const T z = rz(1);
+      return Vector3<T>(r * v_GBr(0), r * v_GBr(1), z);
+    };
+
+    // Transform Q from 3D cylinder G to 2D box B.
+    const Vector2<T> p_BQ = xyz_to_rz(p_GQ);
+
+    // The position of the nearest point N expressed in 2D box B's frame in
+    // coordinates (r,z).
+    Vector2<T> p_BN;
+    // The gradient vector expressed in B's frame in coordinates (r,z).
+    Vector2<T> grad_B;
+    std::tie(p_BN, grad_B) = ComputeDistanceToBox(h, p_BQ);
+
+    // Transform coordinates from (r,z) in B's frame to (x,y,z) in G's frame.
+    const Vector3<T> p_GN = rz_to_xyz(p_BN);
+    const Vector3<T> grad_G = rz_to_xyz(grad_B);
+
+    // Use R_WG for vectors. Use X_WG for points.
+    const auto& R_WG = X_WG_.rotation();
+    const Vector3<T> grad_W = R_WG * grad_G;
+    const Vector3<T> p_WN = X_WG_ * p_GN;
+    T distance = grad_W.dot(p_WQ_ - p_WN);
+    return SignedDistanceToPoint<T>{geometry_id_, p_GN, distance, grad_W};
+  }
+
+  /** Reports the "sign" of x with a small modification; Sign(0) --> 1.
+   @tparam U  Templated to allow DistanceToPoint<AutoDiffXd> to still compute
+              Sign<double> or Sign<AutoDiffXd> as needed.  */
+  template <typename U = T>
+  static U Sign(const U& x) { return (x < U(0.0)) ? U(-1.0) : U(1.0); }
+
+  /** Picks the axis i whose coordinate p(i) is closest to the boundary value
+   ±bounds(i). If there are ties, we prioritize according to an arbitrary
+   ordering: +x,-x,+y,-y,+z,-z.
+
+   Note: the two vector types can be different scalars, they must be extractable
+   to double.
+
+   @tparam dim The number of rows in the column vector.
+   @tparam U   The scalar type of the point `p`; defaults to T.  */
+  template <int dim, typename U = T>
+  static int ExtremalAxis(const Vector<U, dim>& p,
+                          const Vector<double, dim>& bounds) {
+    double min_dist = std::numeric_limits<double>::infinity();
+    int axis = -1;
+    for (int i = 0; i < dim; ++i) {
+      for (const auto bound : {bounds(i), -bounds(i)}) {
+        const double dist = std::abs(bound - ExtractDoubleOrThrow(p(i)));
+        if (dist < min_dist) {
+          min_dist = dist;
+          axis = i;
+        }
+      }
+    }
+    return axis;
+  }
+
+  /** Calculates the signed distance from a query point Q to a box, G. The box
+   can be either two-dimensional or three-dimensional. It is defined centered
+   on its frame G and aligned with G's axes. We use the 3D version directly
+   for the signed distance from Box and use the 2D version indirectly for the
+   signed distance from Cylinder.
+   @param h        The vector from the center of the box to the positive
+                   corner of the box measured in frame G (the "half" size of
+                   the box).
+                   Mathematically the box is the Cartesian product
+                   [-h(0),h(0)]x[-h(1),h(1)] in 2D or
+                   [-h(0),h(0)]x[-h(1),h(1)]x[-h(2),h(2)] in 3D.
+   @param p_GQ_G   The position of the query point Q in G's frame.
+   @retval {p_GN_G, grad_G}   The tuple of the position of
+                   the nearest point N in G's frame and the gradient vector in
+                   the same frame G.
+   @tparam dim     The dimension, must be 2 or 3.  */
+  template <int dim>
+  std::tuple<Vector<T, dim>, Vector<T, dim>> ComputeDistanceToBox(
+      const Vector<double, dim>& h, const Vector<T, dim>& p_GQ_G) {
+    using std::abs;
+
+    // TODO(DamrongGuoy): Revisit this implementation based on a recommendation
+    // made in PR 11208:
+    // https://reviewable.io/reviews/robotlocomotion/drake/11208#-Lc6yion1LIgZrj5yohz:-Lc6yion1LIgZrj5yoi-:b-1qyfoi
+
+    // We need to classify Q as inside, outside, or on the boundary of G,
+    // where 'on the boundary' means within a tolerance of the boundary.
+    // This helper function takes the i-th coordinate `coord` of p_GQ_G.
+    // It returns the clamped value of `coord` within ±h(i). It also returns
+    // an enum to indicate whether the i-th coordinate is inside the interval
+    // (-h(i),+h(i)), or within a tolerance of the bounded value ±h(i), or
+    // outside the interval.
+    enum class Location {kInside, kBoundary, kOutside};
+    auto clamp = [&h](const int i, const T& coord,
+                      Location* location) -> T {
+      const double tolerance = DistanceToPointRelativeTolerance(h(i));
+      if (abs(coord) > h(i) + tolerance) {
+        *location = Location::kOutside;
+        return Sign(coord) * h(i);
+      } else if (abs(coord) >= h(i) - tolerance) {
+        *location = Location::kBoundary;
+        return Sign(coord) * h(i);
+      } else {
+        *location = Location::kInside;
+        return coord;
+      }
+    };
+
+    // Declare a type of vector of Location parallel to the vector of
+    // coordinates of the position p_GQ_G of Q.
+    typedef Vector<Location, dim> VectorLoc;
+
+    // The clamp point C has coordinates of Q clamped onto the box.
+    // Note that:
+    // 1. C is the nearest point to Q on ∂B if Q is classified as outside B.
+    // 2. C is at the same position as Q if Q is classified as inside B.
+    // 3. C is exactly on ∂B if Q is within a tolerance from ∂B.
+
+    Vector<T, dim> p_GC_G;
+    VectorLoc location;
+    for (int i = 0; i < p_GC_G.size(); ++i) {
+      p_GC_G(i) = clamp(i, ExtractDoubleOrThrow(p_GQ_G(i)), &location(i));
+    }
+
+    // Initialize the position of the nearest point N on ∂B as that of C.
+    // Note: if Q is outside or on the boundary of B, then C is N. In the
+    // case where Q is inside, this value will be changed.
+    Vector<T, dim> p_GN_G = p_GC_G;
+    T distance;
+    Vector<T, dim> grad_G = Vector<T, dim>::Zero();
+
+    if ((location.array() == Location::kOutside).any()) {
+      // Q is outside the box.
+      Vector<T, dim> p_NQ_G = p_GQ_G - p_GN_G;
+      distance = p_NQ_G.norm();
+      DRAKE_DEMAND(distance != 0.);
+      grad_G = p_NQ_G / distance;
+    } else if ((location.array() == Location::kBoundary).any()) {
+      for (int i = 0; i < dim; ++i) {
+        if (location(i) == Location::kBoundary) {
+          grad_G(i) = Sign(ExtractDoubleOrThrow(p_GC_G(i)));
+        }
+      }
+      grad_G.normalize();
+    } else {
+      // Q is inside the box.
+      // In 2D (3D), the nearest point N is the axis-aligned projection of Q
+      // onto one of the edge (faces) of the box.  The gradient vector is along
+      // that direction.
+      int axis = this->ExtremalAxis(p_GQ_G, h);
+      // NOTE: This will do funny things to the derivatives; this functionally
+      // treats it as constant w.r.t. all derivatives. However, as the point
+      // rolls from one Voronoi region to another, it goes funny.
+      double sign = Sign(ExtractDoubleOrThrow(p_GQ_G(axis)));
+      p_GN_G(axis) = sign * h(axis);
+      grad_G(axis) = sign;
+    }
+
+    return std::make_tuple(p_GN_G, grad_G);
+  }
+
+ private:
+  // The id of the geometry G.
+  const GeometryId geometry_id_;
+  // The pose of the geometry G in World frame.
+  const math::RigidTransform<T> X_WG_;
+  // The position of the query point Q in World frame.
+  const Vector3<T> p_WQ_;
+};
+
+// TODO(SeanCurtis-TRI): Replace this clunky mechanism with a new mechanism
+// which does this implicitly via ADL and templates.
+/** @name   Mechanism for reporting on which scalars and for which shapes
+            point-to-shape queries can be made.
+
+ By default, nothing is supported. For each supported scalar type, a class
+ specialization is provided which whitelists the supported shape types.
+
+ @tparam T      The computational scalar type.  */
+//@{
+
+template <typename T>
+struct ScalarSupport {
+  static bool is_supported(fcl::NODE_TYPE node_type) { return false; }
+};
+
+/** Primitive support for double-valued query.  */
+template <>
+struct ScalarSupport<double> {
+  static bool is_supported(fcl::NODE_TYPE node_type) {
+    switch (node_type) {
+      case fcl::GEOM_SPHERE:
+      case fcl::GEOM_BOX:
+      case fcl::GEOM_CYLINDER:
+        return true;
+      default:
+        return false;
+    }
+  }
+};
+
+/** Primitive support for AutoDiff-valued query.  */
+template <typename DerType>
+struct ScalarSupport<Eigen::AutoDiffScalar<DerType>> {
+  static bool is_supported(fcl::NODE_TYPE node_type) {
+    switch (node_type) {
+      case fcl::GEOM_SPHERE:
+      case fcl::GEOM_BOX:
+        return true;
+      default:
+        return false;
+    }
+  }
+};
+
+//@}
+
+/** The callback function for computing the signed distance between a point and
+ a supported shape. Intended to be invoked as a result of broadphase culling
+ of candidate geometry pairs for the pair (`object_A_ptr`, `object_B_ptr`).
+
+ @pre The `callback_data` is an instance of point_distance::CallbackData.
+ @pre One of the two fcl objects matches the CallbackData.query_point object.
+ */
+template <typename T>
+bool Callback(fcl::CollisionObjectd* object_A_ptr,
+              fcl::CollisionObjectd* object_B_ptr,
+              // NOLINTNEXTLINE
+              void* callback_data, double& threshold) {
+  auto& data = *static_cast<CallbackData<T>*>(callback_data);
+
+  // We intentionally pass the same number back to FCL in every callback.
+  // It instructs FCL to skip any objects proven to be beyond this threshold
+  // distance (for example, by checking bounding boxes).
+  threshold = data.threshold;
+
+  // We use `const` to prevent modification of the collision objects.
+  const fcl::CollisionObjectd* geometry_object =
+      (&data.query_point == object_A_ptr) ? object_B_ptr : object_A_ptr;
+
+  const std::vector<GeometryId>& geometry_map = data.geometry_map;
+  const EncodedData encoding(*geometry_object);
+  GeometryId geometry_id = encoding.id(geometry_map);
+
+  const fcl::CollisionGeometryd* collision_geometry =
+      geometry_object->collisionGeometry().get();
+  if (ScalarSupport<T>::is_supported(collision_geometry->getNodeType())) {
+    const math::RigidTransform<T> typed_X_WG(data.X_WGs[encoding.index()]);
+    DistanceToPoint<T> distance_to_point(geometry_id, typed_X_WG, data.p_WQ_W);
+
+    SignedDistanceToPoint<T> distance;
+    switch (collision_geometry->getNodeType()) {
+      case fcl::GEOM_SPHERE:
+        distance = distance_to_point(
+            *static_cast<const fcl::Sphered*>(collision_geometry));
+        break;
+      case fcl::GEOM_BOX:
+        distance = distance_to_point(
+            *static_cast<const fcl::Boxd*>(collision_geometry));
+        break;
+      case fcl::GEOM_CYLINDER:
+        distance = distance_to_point(
+            *static_cast<const fcl::Cylinderd*>(collision_geometry));
+        break;
+      default:
+        // Returning false tells fcl to continue to other objects.
+        return false;
+    }
+
+    if (distance.distance <= data.threshold) {
+      data.distances.emplace_back(distance);
+    }
+  }
+
+  return false;  // Returning false tells fcl to continue to other objects.
+}
+
+}  // namespace point_distance
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake
+
+#endif  // !defined(DRAKE_DOXYGEN_CXX)

--- a/geometry/proximity/distance_to_point_with_gradient.cc
+++ b/geometry/proximity/distance_to_point_with_gradient.cc
@@ -2,13 +2,11 @@
 
 #include <algorithm>
 
+#include "drake/geometry/proximity/distance_to_point.h"
+
 namespace drake {
 namespace geometry {
 namespace internal {
-
-double DistanceToPointRelativeTolerance(double size) {
-  return 1e-14 * std::max(1., size);
-}
 
 template <typename PrimitiveType>
 SignedDistanceToPointWithGradient DistanceToPointWithGradient::ComputeDistance(
@@ -26,9 +24,9 @@ SignedDistanceToPointWithGradient DistanceToPointWithGradient::ComputeDistance(
   X_WG_autodiff.set_translation(X_WG_.translation().cast<AutoDiffd<3>>());
   Vector3<AutoDiffd<3>> p_GN_autodiff, grad_W_autodiff;
   AutoDiffd<3> distance_autodiff;
-  ComputeDistanceToPrimitive(primitive, X_WG_autodiff, p_WQ_autodiff,
-                             &p_GN_autodiff, &distance_autodiff,
-                             &grad_W_autodiff);
+  point_distance::ComputeDistanceToPrimitive(
+      primitive, X_WG_autodiff, p_WQ_autodiff, &p_GN_autodiff,
+      &distance_autodiff, &grad_W_autodiff);
   return SignedDistanceToPointWithGradient(
       geometry_id_, math::autoDiffToValueMatrix(p_GN_autodiff),
       math::autoDiffToGradientMatrix(p_GN_autodiff), distance_autodiff.value(),

--- a/geometry/proximity/distance_to_point_with_gradient.h
+++ b/geometry/proximity/distance_to_point_with_gradient.h
@@ -6,6 +6,7 @@
 #include <fcl/geometry/shape/sphere.h>
 
 #include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/proximity/proximity_utilities.h"
 #include "drake/geometry/query_results/signed_distance_to_point_with_gradient.h"
 #include "drake/math/autodiff.h"
 #include "drake/math/autodiff_gradient.h"
@@ -14,80 +15,6 @@
 namespace drake {
 namespace geometry {
 namespace internal {
-/**
- * Calculates an absolute tolerance value conditioned to a problem's
- * characteristic `size`. The tolerance is sufficient to account for round-off
- * error which arises due to transformations.
- */
-double DistanceToPointRelativeTolerance(double size);
-
-/**
- * @name ComputeDistanceToPrimitive
- * Computes the signed distance from a point Q to a primitive.
- * Refer to QueryObject::ComputeSignedDistanceToPoint for more details.
- * @param X_WG The pose of the primitive geometry G in the world frame.
- * @param p_WQ The position of the point Q in the world frame.
- * @param p_GN[out] The position of the witness point N on the primitive,
- * expressed in the primitive geometry frame G.
- * @param distance[out] The signed distance from the point Q to the primitive.
- * @param grad_W[out] The gradient of the distance function w.r.t p_GQ (the
- * position of the point Q in the primitiveframe). This gradient vector is
- * expressed in the world frame.
- * @{
- */
-
-/** Overload of ComputeDistanceToPrimitive() for sphere primitive. */
-template <typename T>
-void ComputeDistanceToPrimitive(const fcl::Sphered& sphere,
-                                const math::RigidTransform<T>& X_WG,
-                                const Vector3<T>& p_WQ, Vector3<T>* p_GN,
-                                T* distance, Vector3<T>* grad_W) {
-  // TODO(DamrongGuoy): Move most code of this function into FCL.
-  const double radius = sphere.radius;
-  const Vector3<T> p_GQ_G = X_WG.inverse() * p_WQ;
-  const T dist_GQ = p_GQ_G.norm();
-
-  // The gradient is always in the direction from the center of the sphere to
-  // the query point Q, regardless of whether the point Q is outside or inside
-  // the sphere G.  The gradient is undefined if the query point Q is at the
-  // center of the sphere G.
-  //
-  // If the query point Q is near the center of the sphere G within a
-  // tolerance, we arbitrarily set the gradient vector as documented in
-  // query_object.h (QueryObject::ComputeSignedDistanceToPoint).
-  const double tolerance = DistanceToPointRelativeTolerance(radius);
-  // Unit vector in x-direction of G's frame.
-  const Vector3<T> Gx = Vector3<T>::UnitX();
-  // Gradient vector expressed in G's frame.
-  const Vector3<T> grad_G = (dist_GQ > tolerance) ? p_GQ_G / dist_GQ : Gx;
-
-  // Do not compute distance as |p_GQ|, as the gradient of |p_GQ| w.r.t p_GQ is
-  // p_GQᵀ/|p_GQ|, not well defined at p_GQ = 0. Instead, compute the distance
-  // as p_GQ.dot(grad_G).
-  *distance = p_GQ_G.dot(grad_G) - T(radius);
-
-  // Position vector of the nearest point N on G's surface from the query
-  // point Q, expressed in G's frame.
-  *p_GN = radius * grad_G;
-  // Gradient vector expressed in World frame.
-  *grad_W = X_WG.rotation() * grad_G;
-}
-
-/** Overload of ComputeDistanceToPrimitive() for halfspace primitive. */
-template <typename T>
-void ComputeDistanceToPrimitive(const fcl::Halfspaced& halfspace,
-                                const math::RigidTransform<T>& X_WG,
-                                const Vector3<T>& p_WQ, Vector3<T>* p_GN,
-                                T* distance, Vector3<T>* grad_W) {
-  // FCL stores the halfspace as {x | nᵀ * x <= d}, with n being a unit length
-  // normal vector. Both n and x are expressed in the halfspace frame.
-  const Vector3<T> n_G = halfspace.n.cast<T>();
-  const Vector3<T> p_GQ = X_WG.inverse() * p_WQ;
-  *distance = n_G.dot(p_GQ) - T(halfspace.d);
-  *p_GN = p_GQ - *distance * n_G;
-  *grad_W = X_WG.rotation() * n_G;
-}
-//@}
 
 /**
  * An internal functor to support the call back function in proximity_engine.cc.

--- a/geometry/proximity/proximity_utilities.h
+++ b/geometry/proximity/proximity_utilities.h
@@ -1,0 +1,116 @@
+#pragma once
+
+// Exclude internal classes from doxygen.
+#if !defined(DRAKE_DOXYGEN_CXX)
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+#include <fcl/fcl.h>
+#include <fmt/format.h>
+
+#include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/geometry_index.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+// TODO(SeanCurtis-TRI): Snake case this name.
+/** Calculates an absolute tolerance value conditioned to a problem's
+ characteristic, positive-valued `size`. The tolerance is sufficient to account
+ for round-off error which arises due to transformations.
+ @pre size > 0.  */
+constexpr double DistanceToPointRelativeTolerance(double size) {
+  return 1e-14 * std::max(1.0, size);
+}
+
+/** Class for coordinating the collision objects stored in the proximity engine
+ with the geometries stored in SceneGraph. The two are related in that the
+ collision object stores the GeometryIndex of the corresponding SceneGraph
+ geometry as well as a bit to mark whether it is anchored or dynamic.
+
+ It stores this data by compactly "encoding" them. The encoding packs a geometry
+ index value with a bit indicating if the index refers to dynamic or anchored
+ geometry (proximity engine segregates them). The highest-order bit indicates
+ dynamic (1) or anchored (0). The remaining lower bits store the index. The data
+ is stored in a pointer-sized integer. This integer is, in turn, stored directly
+ into fcl::CollisionObject's void* user data member.  */
+class EncodedData {
+ public:
+  /** Constructs encoded data directly from the index and the known
+   anchored/dynamic characterization.  */
+  EncodedData(GeometryIndex index, bool is_dynamic)
+      : data_(static_cast<uintptr_t>(index)) {
+    if (is_dynamic) set_dynamic();
+    // NOTE: data is encoded as anchored by default. So, an action only needs to
+    // be taken in the dynamic case.
+  }
+
+  /** Constructs encoded data by extracting it from the given collision object.
+   */
+  explicit EncodedData(const fcl::CollisionObject<double>& fcl_object)
+      : data_(reinterpret_cast<uintptr_t>(fcl_object.getUserData())) {}
+
+  /** Constucts encoded data for the given index identified as dynamic.  */
+  static EncodedData encode_dynamic(GeometryIndex index) {
+    return EncodedData(index, true);
+  }
+
+  /** Constucts encoded data for the given index identified as anchored.  */
+  static EncodedData encode_anchored(GeometryIndex index) {
+    return EncodedData(index, false);
+  }
+
+  /** Sets the encoded data to be dynamic.  */
+  void set_dynamic() { data_ |= kIsDynamicMask; }
+
+  /** Sets the encoded data to be anchored.  */
+  void set_anchored() { data_ &= ~kIsDynamicMask; }
+
+  /** Writes the encoded data into the collision object's user data.  */
+  void write_to(fcl::CollisionObject<double>* object) {
+    object->setUserData(reinterpret_cast<void*>(data_));
+  }
+
+  /** Reports true if the encoded data is marked as dynamic. False if anchored.
+   */
+  bool is_dynamic() const { return (data_ & kIsDynamicMask) != 0; }
+
+  /** Reports the stored index.  */
+  GeometryIndex index() const {
+    return static_cast<GeometryIndex>(data_ & ~kIsDynamicMask);
+  }
+
+  /** Given a map from GeometryIndex to ids of the SceneGraph geometries,
+   reports the geometry id for the encoded data.  */
+  GeometryId id(const std::vector<GeometryId>& geometry_map) const {
+    return geometry_map[index()];
+  }
+
+  /** Reports the encoded data.  */
+  uintptr_t encoded_data() const { return data_; }
+
+ private:
+  // Note: This sets a mask to be 1000...0 based on the size of a pointer.
+  // C++ guarantees that uintptr_t can hold a pointer and cast to a pointer,
+  // but it doesn't guarantee it's the *same size* as a pointer. So, we set
+  // the mask value based on pointer size. This is important because we're
+  // storing it in the void* of the collision object.
+  static const uintptr_t kIsDynamicMask = uintptr_t{1}
+      << (sizeof(void*) * 8 - 1);
+
+  // The encoded data - index and mobility type.
+  // We're using an unsigned value here because:
+  //   - Bitmasking games are typically more intuitive with unsigned values
+  //     (think of bit shifting as an example here).
+  //   - This unsigned integer doesn't bleed out into the API at all.
+  uintptr_t data_{};
+};
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake
+
+#endif  // !defined(DRAKE_DOXYGEN_CXX)

--- a/geometry/proximity/test/distance_to_point_test.cc
+++ b/geometry/proximity/test/distance_to_point_test.cc
@@ -1,0 +1,476 @@
+#include "drake/geometry/proximity/distance_to_point.h"
+
+#include <fcl/fcl.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/proximity/proximity_utilities.h"
+#include "drake/geometry/utilities.h"
+#include "drake/math/autodiff_gradient.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/math/rotation_matrix.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace point_distance {
+namespace {
+
+// TODO(SeanCurtis-TRI): Run through proximity_engine_test and pull the tests
+// from there that better belong here.
+
+using Eigen::Isometry3d;
+using Eigen::Vector3d;
+using math::RigidTransform;
+using math::RigidTransformd;
+using math::RotationMatrix;
+using Eigen::Translation3d;
+using std::make_shared;
+
+// Performs a point-to-shape signed-distance query and tests the result. This
+// particularly focuses on the AutoDiff-valued version of these methods. It
+// does a limited smoke-test on the results.
+//
+// It computes ∂distance / ∂p_WQ and compares it with the reported grad_W value
+// with the assumption that they should be the same.
+//
+// The caller provides the nearest point p_GN_G (in the geometry frame G) and
+// the offset from the nearest point to the query point Q (p_NQ_G) also in the
+// geometry frame G. The query point is inferred from these two values. It
+// performs the query and examines the results. It generally assumes
+// non-negative signed distance. If the point is inside (i.e., negative signed
+// distance), then the additional boolean `is_inside` should be set to true.
+// To test robustness, the frame G can have an arbitrary pose in the world
+// frame (defined by X_WG). Finally, an absolute tolerance is provided to
+// define the scope of correctness.
+//
+// Note: this is *not* the complete test; we should also confirm that the
+// derivatives of grad_W and the witness points are likewise correct.
+// TODO(hongkai.dai): Extend these tests to test the AutoDiff derivatives of
+// the reported gradient and witness points w.r.t. arbitrary basis as well.
+template <typename Shape>
+class PointShapeAutoDiffSignedDistanceTester {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PointShapeAutoDiffSignedDistanceTester)
+
+  // Constructs a tester for a given shape G, pose in world X_WG, and tolerance.
+  // The shape must be non-null and must persist beyond the life of the tester
+  // as a reference to the shape will be stored.
+  PointShapeAutoDiffSignedDistanceTester(const Shape* shape,
+                                         const RigidTransformd& X_WG,
+                                         double tolerance)
+      : shape_(*shape), X_WG_(X_WG), tolerance_(tolerance) {}
+
+  // Perform the test with the particular N and Q.
+  ::testing::AssertionResult Test(
+      const Vector3d& p_GN_G, const Vector3d& p_NQ_G, bool is_inside = false) {
+    const double sign = is_inside ? -1 : 1;
+    const double expected_distance = sign * p_NQ_G.norm();
+    const Vector3d p_GQ = p_GN_G + p_NQ_G;
+    const Vector3d p_WQ = X_WG_ * p_GQ;
+
+    ::testing::AssertionResult failure = ::testing::AssertionFailure();
+    bool error = false;
+
+    Vector3<AutoDiffXd> p_WQ_ad = math::initializeAutoDiff(p_WQ);
+    DistanceToPoint<AutoDiffXd> distance_to_point(
+        GeometryId::get_new_id(), X_WG_.cast<AutoDiffXd>(), p_WQ_ad);
+
+    SignedDistanceToPoint<AutoDiffXd> result = distance_to_point(shape_);
+    if (std::abs(result.distance.value() - expected_distance) > tolerance_) {
+      error = true;
+      failure << "The difference between expected distance and tested distance "
+                 "is greater than the given tolerance_:\n"
+              << "  Expected distance: " << expected_distance << "\n"
+              << "  Tested distance: " << result.distance.value() << "\n"
+              << "  tolerance: " << tolerance_ << "\n"
+              << "  difference: "
+              << (std::abs(result.distance.value() - expected_distance));
+    }
+    // The hand-computed `grad_W` value should match the autodiff-computed
+    // gradient.
+    if (result.distance.derivatives().size() != 3) {
+      if (error) failure << "\n";
+      error = true;
+      failure << "Test distance has no derivatives";
+    }
+    const Vector3d ddistance_dp_WQ = result.distance.derivatives();
+    const Vector3d grad_W = math::autoDiffToValueMatrix(result.grad_W);
+    if (grad_W.array().isNaN().any()) {
+      if (error) failure << "\n";
+      error = true;
+      failure << "Analytical gradient contains NaN: " << grad_W.transpose();
+    }
+    auto gradient_compare =
+        CompareMatrices(ddistance_dp_WQ, grad_W, tolerance_);
+    if (!gradient_compare) {
+      if (error) failure << "\n";
+      error = true;
+      failure << gradient_compare.message();
+    }
+    if (!error) return ::testing::AssertionSuccess();
+    return failure;
+}
+
+ private:
+  const Shape& shape_;
+  const RigidTransformd X_WG_;
+  const double tolerance_{std::numeric_limits<double>::epsilon()};
+};
+
+// Simple smoke test for signed distance to Sphere. It does the following:
+//   Perform test of three different points w.r.t. a sphere: outside, on
+//     surface, and inside.
+//   Do it with AutoDiff relative to the query point's position.
+//   Confirm the *values* of the reported quantity.
+//   Confirm that the derivative of distance (extracted from AutoDiff) matches
+//     the derivative computed by hand (grad_W).
+GTEST_TEST(DistanceToPoint, Sphere) {
+  const double kEps = 4 * std::numeric_limits<double>::epsilon();
+
+  // Provide some arbitary pose of the sphere in the world.
+  const RotationMatrix<double> R_WG(
+      AngleAxis<double>(M_PI / 5, Vector3d{1, 2, 3}.normalized()));
+  const Vector3d p_WG{0.5, 1.25, -2};
+  const RigidTransform<double> X_WG(R_WG, p_WG);
+  const fcl::Sphered sphere(0.7);
+  PointShapeAutoDiffSignedDistanceTester<fcl::Sphered> tester(&sphere, X_WG,
+                                                              kEps);
+
+  // An arbitrary direction away from the origin that *isn't* aligned with the
+  // frame basis.
+  const Vector3d vhat_NQ = Vector3d{2, -3, 6}.normalized();
+  const Vector3d p_NQ_G = 1.5 * vhat_NQ;
+  const Vector3d p_GN_G = sphere.radius * vhat_NQ;
+
+  // Case: point lies *outside* the sphere.
+  EXPECT_TRUE(tester.Test(p_GN_G, p_NQ_G));
+
+  // Case: point lies *on* the sphere.
+  EXPECT_TRUE(tester.Test(p_GN_G, Vector3d::Zero()));
+
+  // Case: point lies *in* the sphere.
+  EXPECT_TRUE(tester.Test(p_GN_G, -0.1 * p_NQ_G, true /* is inside */));
+
+  // Case: point lies at origin of the sphere.
+  EXPECT_TRUE(
+      tester.Test(p_GN_G, -sphere.radius * vhat_NQ, true /* is inside */));
+}
+
+// Simple smoke test for signed distance to Box. It does the following:
+//   Perform test of three different points w.r.t. a box: outside, on
+//     surface, and inside.
+//   Do it with AutoDiff relative to the query point's position.
+//   Confirm the *values* of the reported quantity.
+//   Confirm that the derivative of distance (extracted from AutoDiff) matches
+//     the derivative computed by hand (grad_W).
+GTEST_TEST(DistanceToPoint, Box) {
+  const double kEps = 4 * std::numeric_limits<double>::epsilon();
+
+  // Provide some arbitrary pose of the box in the world.
+  const RotationMatrix<double> R_WG(
+      AngleAxis<double>(M_PI / 5, Vector3d{1, 2, 3}.normalized()));
+  const Vector3d p_WG{0.5, 1.25, -2};
+  const RigidTransformd X_WG(R_WG, p_WG);
+  const fcl::Boxd box(1.0, 2.0, 3.0);
+  PointShapeAutoDiffSignedDistanceTester<fcl::Boxd> tester(&box, X_WG, kEps);
+
+  // Case: Nearest point is a vertex.
+  {
+    for (double x : {-1, 1}) {
+      for (double y : {-1, 1}) {
+        for (double z : {-1, 1}) {
+          const Vector3d p_NQ_G{x, y, z};
+          const Vector3d p_GN_G = p_NQ_G.cwiseProduct(box.side / 2);
+          // The query point lies outside the box.
+          EXPECT_TRUE(tester.Test(p_GN_G, p_NQ_G));
+          // The query point lies on the vertex of the box.
+          EXPECT_TRUE(tester.Test(p_GN_G, Vector3d::Zero()));
+        }
+      }
+    }
+    // A query point *inside* the box would not be nearest the vertex.
+  }
+
+  // Case: Nearest point lies on an edge.
+  for (int coord1 = 0; coord1 < 3; ++coord1) {
+    // p_NQ_G(coord1) = 0
+    int coord2 = (coord1 + 1) % 3;
+    int coord3 = (coord1 + 2) % 3;
+    for (double coord2_val : {-1, 1}) {
+      for (double coord3_val : {-1, 1}) {
+        Vector3d p_NQ_G;
+        p_NQ_G(coord1) = 0;
+        p_NQ_G(coord2) = coord2_val;
+        p_NQ_G(coord3) = coord3_val;
+        const Vector3d p_GN_G = p_NQ_G.cwiseProduct(box.side / 2);
+        // The query point lies outside the box.
+        EXPECT_TRUE(tester.Test(p_GN_G, p_NQ_G));
+        // The query point lies on the edge of the box.
+        EXPECT_TRUE(tester.Test(p_GN_G, Vector3d::Zero()));
+
+        // A query point *inside* the box would not be nearest the edge.
+      }
+    }
+  }
+
+  // Case point lies *outside* the box, nearest a face.
+  {
+    for (double sign : {-1, 1}) {
+      for (int axis : {0, 1, 2}) {
+        Vector3d vhat_NG = Vector3d::Zero();
+        vhat_NG(axis) = sign;
+        Vector3d p_NQ_G = 1.5 * vhat_NG;
+        const Vector3d p_GN_G = vhat_NG.cwiseProduct(box.side / 2);
+
+        // The query point lies outside the box.
+        EXPECT_TRUE(tester.Test(p_GN_G, p_NQ_G));
+
+        // The query point lies on the face of the box.
+        EXPECT_TRUE(tester.Test(p_GN_G, Vector3d::Zero()));
+
+        // The query point lies inside the box.
+        EXPECT_TRUE(tester.Test(p_GN_G, -0.1 * vhat_NG, true /* is inside */));
+      }
+    }
+  }
+}
+
+// TODO(SeanCurtis-TRI): Point-to-cylinder with AutoDiff has been "disabled".
+//  However, this has been done at the callback level and these tests are
+//  structured to exercise DistanceToPoint directly. This is a short-term
+//  issue and will be addressed with a reformulation of the point-cylinder
+//  calculation. When fixed, these tests will become meaningful, so we're
+//  leaving it in to prevent losing the effort.
+#if 0
+// Simple smoke test for signed distance to Cylinder. It does the following:
+//   Perform test of three different points w.r.t. a cylinder: outside, on
+//     surface, and inside.
+//   Do it with AutoDiff relative to the query point's position.
+//   Confirm the *values* of the reported quantity.
+//   Confirm that the derivative of distance (extracted from AutoDiff) matches
+//     the derivative computed by hand (grad_W).
+GTEST_TEST(DistanceToPoint, Cylinder) {
+  const double kEps = 4 * std::numeric_limits<double>::epsilon();
+
+  // Provide some arbitary pose of the cylinder in the world.
+  const RotationMatrix<double> R_WG(
+      AngleAxis<double>(M_PI / 5, Vector3d{1, 2, 3}.normalized()));
+  const Vector3d p_WG{0.5, 1.25, -2};
+  const RigidTransform<double> X_WG(R_WG, p_WG);
+  const fcl::Cylinderd cylinder(0.75, 2.5);
+  PointShapeAutoDiffSignedDistanceTester<fcl::Cylinderd> tester(&cylinder, X_WG,
+                                                                kEps);
+
+  // Case: Nearest point is on the cap.
+  {
+    // Test top and bottom caps.
+    for (double sign : {-1, 1}) {
+      // The nearest point N is the cap of the cylinder -- slightly perturbed to
+      // be away from the cap center.
+      const Vector3d p_GN_G{cylinder.radius * 0.25, cylinder.radius * 0.25,
+                            sign * cylinder.lz / 2};
+
+      // The query point lies outside the cylinder
+      EXPECT_TRUE(tester.Test(p_GN_G, Vector3d{0, 0, sign * 0.75}));
+
+      // The query point lies on the cap of the cylinder.
+      EXPECT_TRUE(tester.Test(p_GN_G, Vector3d{0, 0, 0}));
+
+      // The query point lies just inside the cap of the cylinder.
+      EXPECT_TRUE(tester.Test(p_GN_G, Vector3d{0, 0, -0.1 * sign},
+                              true /* is inside */));
+
+      // The query point lies outside, but *on* the central axis.
+      EXPECT_TRUE(
+          tester.Test(Vector3d{0, 0, cylinder.lz / 2}, Vector3d{0, 0, 1.5}));
+      EXPECT_TRUE(
+          tester.Test(Vector3d{0, 0, cylinder.lz / 2}, Vector3d{0, 0, 0}));
+      EXPECT_TRUE(tester.Test(Vector3d{0, 0, cylinder.lz / 2},
+                              Vector3d{0, 0, -0.1}, true /* is inside */));
+    }
+  }
+
+  // Case: Nearest point is on circular rim.
+  {
+    // The dimensions of the boundary of the cylinder. Used to find the
+    // "support" point on the cylinder rim in an arbitrary direction.
+    const Vector3d dim{cylinder.radius, cylinder.radius, cylinder.lz / 2};
+
+    // Test top and bottom rims.
+    for (double sign : {-1, 1}) {
+      // Put the nearest point on the rim at some arbitrary, non-trivial angle.
+      const double theta = M_PI / 7;
+      const Vector3d p_NQ_G{std::cos(theta), std::sin(theta), sign};
+      const Vector3d p_GN_G = p_NQ_G.cwiseProduct(dim);
+
+      // The query point lies outside the cylinder.
+      EXPECT_TRUE(tester.Test(p_GN_G, p_NQ_G));
+
+      // The query point lies on the cap of the cylinder.
+      EXPECT_TRUE(tester.Test(p_GN_G, Vector3d::Zero()));
+
+      // A query point *inside* the cylinder would not be nearest the rim.
+    }
+  }
+
+  // Case: Nearest point is on the barrel.
+  {
+    // The dimensions of the cylinder -- note it's shorter to make sure that the
+    // query points are well within the region of the barrel.
+    const Vector3d dim{cylinder.radius, cylinder.radius, cylinder.lz / 4};
+
+    // Test upper- and lower-halves of the barrel.
+    for (double sign : {-1, 1}) {
+      // Put the nearest point on the rim at some arbitrary, non-trivial angle.
+      const double theta = M_PI / 7;
+      const double cos_theta = std::cos(theta);
+      const double sin_theta = std::sin(theta);
+      const Vector3d p_NQ_G{cos_theta, sin_theta, 0};
+      const Vector3d p_GN_G =
+          dim.cwiseProduct(Vector3d{cos_theta, sin_theta, sign});
+
+      // The query point lies outside the cylinder.
+      EXPECT_TRUE(tester.Test(p_GN_G, p_NQ_G));
+
+      // The query point lies on the barrel of the cylinder.
+      EXPECT_TRUE(tester.Test(p_GN_G, Vector3d::Zero()));
+
+      // The query point lies inside the cylinder.
+      EXPECT_TRUE(tester.Test(p_GN_G, -0.1 * p_NQ_G, true /* is inside */));
+    }
+  }
+}
+#endif
+
+// TODO(SeanCurtis-TRI): Refactor these tests to reduce duplication.
+
+// This test simply confirms which scalar-shape combinations produce answers
+// and which don't. That culling takes place at the Callback level so that is
+// what is exercised here. Lack of support is signaled by no distance data
+// being returned.
+GTEST_TEST(DistanceToPoint, ScalarShapeSupportDouble) {
+  // Configure the basic query.
+  Vector3d p_WQ{10, 10, 10};
+  Isometry3d X_WQ{Translation3d{p_WQ}};
+  auto point_geometry = make_shared<fcl::Sphered>(0);
+  fcl::CollisionObjectd query_point(point_geometry);
+  query_point.setTranslation(p_WQ);
+  EncodedData encoding(GeometryIndex(0), true);
+  encoding.write_to(&query_point);
+  std::vector<SignedDistanceToPoint<double>> distances;
+  std::vector<GeometryId> geometry_map{GeometryId::get_new_id()};
+  double threshold = std::numeric_limits<double>::max();
+  std::vector<Isometry3d> X_WGs{X_WQ, Isometry3d::Identity()};
+  CallbackData<double> data{&query_point, &geometry_map, threshold,
+                            p_WQ,         &X_WGs,        &distances};
+
+
+  // The Drake-supported geometries (minus Mesh which isn't supported by
+  // ProximityEngine yet).
+
+  auto run_callback = [&query_point, &threshold, &distances, &data](
+                          auto geometry_shared_ptr) {
+    threshold = std::numeric_limits<double>::max();
+    distances.clear();
+    fcl::CollisionObjectd object(geometry_shared_ptr);
+    EncodedData object_encoding(GeometryIndex(1), true);
+    object_encoding.write_to(&object);
+    Callback<double>(&query_point, &object, &data, threshold);
+  };
+
+  // Sphere
+  {
+    run_callback(make_shared<fcl::Sphered>(1.0));
+    EXPECT_EQ(distances.size(), 1);
+  }
+
+  // Cylinder
+  {
+    run_callback(make_shared<fcl::Cylinderd>(1.0, 2.0));
+    EXPECT_EQ(distances.size(), 1);
+  }
+
+  // HalfSpace
+  {
+    run_callback(make_shared<fcl::Halfspaced>(0, 0, 1, 0));
+    EXPECT_EQ(distances.size(), 0);  // Query not supported.
+  }
+
+  // Box
+  {
+    run_callback(make_shared<fcl::Boxd>(1.0, 2.0, 3.5));
+    EXPECT_EQ(distances.size(), 1);
+  }
+
+  // Convex
+  // TODO(SeanCurtis-TRI): Add convex that is *not* supported; create a small
+  // utility test to generate a tetrahedron.
+}
+
+// The autodiff version of DistanceToPoint.ScalarShapeSupportDouble.
+GTEST_TEST(DistanceToPoint, ScalarShapeSupportAutoDiff) {
+  // Configure the basic query.
+  Vector3<AutoDiffXd> p_WQ{10, 10, 10};
+  Isometry3<AutoDiffXd> X_WQ{Translation3<AutoDiffXd>{p_WQ}};
+  auto point_geometry = make_shared<fcl::Sphered>(0);
+  fcl::CollisionObjectd query_point(point_geometry);
+  query_point.setTranslation(convert_to_double(p_WQ));
+  EncodedData encoding(GeometryIndex(0), true);
+  encoding.write_to(&query_point);
+  std::vector<SignedDistanceToPoint<AutoDiffXd>> distances;
+  std::vector<GeometryId> geometry_map{GeometryId::get_new_id()};
+  double threshold = std::numeric_limits<double>::max();
+  std::vector<Isometry3<AutoDiffXd>> X_WGs{X_WQ,
+                                           Isometry3<AutoDiffXd>::Identity()};
+  CallbackData<AutoDiffXd> data{&query_point, &geometry_map, threshold,
+                                p_WQ,         &X_WGs,        &distances};
+
+  // The Drake-supported geometries (minus Mesh which isn't supported by
+  // ProximityEngine yet).
+
+  auto run_callback = [&query_point, &threshold, &distances,
+                       &data](auto geometry_shared_ptr) {
+    threshold = std::numeric_limits<double>::max();
+    distances.clear();
+    fcl::CollisionObjectd object(geometry_shared_ptr);
+    EncodedData object_encoding(GeometryIndex(1), true);
+    object_encoding.write_to(&object);
+    Callback<AutoDiffXd>(&query_point, &object, &data, threshold);
+  };
+
+  // Sphere
+  {
+    run_callback(make_shared<fcl::Sphered>(1.0));
+    EXPECT_EQ(distances.size(), 1);
+  }
+
+  // Cylinder
+  {
+    run_callback(make_shared<fcl::Cylinderd>(1.0, 2.0));
+    EXPECT_EQ(distances.size(), 0);  // Query not supported.
+  }
+
+  // HalfSpace
+  {
+    run_callback(make_shared<fcl::Halfspaced>(0, 0, 1, 0));
+    EXPECT_EQ(distances.size(), 0);  // Query not supported.
+  }
+
+  // Box
+  {
+    run_callback(make_shared<fcl::Boxd>(1.0, 2.0, 3.5));
+    EXPECT_EQ(distances.size(), 1);
+  }
+
+  // Convex
+  // TODO(SeanCurtis-TRI): Add convex that is *not* supported; create a small
+  // utility test to generate a tetrahedron.
+}
+
+}  // namespace
+}  // namespace point_distance
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -7,7 +7,6 @@
 #include <iterator>
 #include <stdexcept>
 #include <string>
-#include <tuple>
 #include <unordered_map>
 #include <utility>
 
@@ -24,6 +23,7 @@
 #include "drake/common/drake_variant.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/sorted_vectors_have_intersection.h"
+#include "drake/geometry/proximity/distance_to_point.h"
 #include "drake/geometry/proximity/distance_to_point_with_gradient.h"
 #include "drake/geometry/utilities.h"
 #include "drake/math/rigid_transform.h"
@@ -33,7 +33,6 @@ namespace drake {
 namespace geometry {
 namespace internal {
 
-template <int Rows> using Vectord = Vector<double, Rows>;
 using Eigen::Vector2d;
 using Eigen::Vector3d;
 using Eigen::Isometry3d;
@@ -42,105 +41,15 @@ using std::make_unique;
 using std::move;
 using std::shared_ptr;
 using std::unique_ptr;
+using math::RigidTransform;
 using math::RigidTransformd;
 using math::RotationMatrixd;
+using point_distance::DistanceToPoint;
 
 namespace {
 
 // TODO(SeanCurtis-TRI): Swap all Isometry3 for RigidTransforms.
 
-// Utilities/functions for working with the encoding of collision object index
-// and mobility type in the fcl::CollisionObject user data field. The encoded
-// data produces a value that is guaranteed to be unique across all geometries.
-// The guarantee arises from the fact that it's an engine index combined with
-// a bit reporting anchored vs dynamic geometry; every geometry is uniquely
-// identified by its engine index and its dynamic/anchored state.
-//
-// The encoding packs a geometry index value with a bit indicating if the index
-// refers to dynamic or anchored geometry (they are stored in separate vectors
-// which means indices can be repeated). The highest-order bit indicates
-// dynamic (1) or anchored (0). The remaining lower bits store the index. The
-// data is stored in a pointer-sized integer. This integer is, in turn, stored
-// directly into fcl::CollisionObject's void* user data member.
-class EncodedData {
- public:
-  // Constructor which defines its encoded data by combining a geometry's index
-  // and its dynamic/anchored characterization.
-  EncodedData(int index, bool is_dynamic)
-      : data_(static_cast<uintptr_t>(index)) {
-    if (is_dynamic) set_dynamic();
-    // NOTE: data is encoded as anchored by default. So, an action only needs to
-    // be taken in the dynamic case.
-  }
-
-  // Constructor which defines its encoded data value by extracting it from the
-  // given Fcl collision object.
-  explicit EncodedData(const fcl::CollisionObject<double>& fcl_object)
-      : data_(reinterpret_cast<uintptr_t>(fcl_object.getUserData())) {}
-
-  // Factory method for creating EncodedData from the given `index` for a
-  // dynamic geometry.
-  static EncodedData encode_dynamic(GeometryIndex index) {
-    return EncodedData(index, true);
-  }
-
-  // Factory method for creating EncodedData from the given `index` for an
-  // anchored geometry.
-  static EncodedData encode_anchored(GeometryIndex index) {
-    return EncodedData(index, false);
-  }
-
-  // Sets the encoded data to be dynamic.
-  void set_dynamic() { data_ |= kIsDynamicMask; }
-
-  // Sets the encoded data to be anchored.
-  void set_anchored() { data_ &= ~kIsDynamicMask; }
-
-  // Stores the encoded data in the collision object's user data.
-  void store_in(fcl::CollisionObject<double>* object) {
-    object->setUserData(reinterpret_cast<void*>(data_));
-  }
-
-  // Reports true if the given fcl_object's user data is encoded as dynamic.
-  // False if anchored.
-  bool is_dynamic() const { return (data_ & kIsDynamicMask) != 0; }
-
-  // Reports the stored index.
-  GeometryIndex index() const {
-    return static_cast<GeometryIndex>(data_ & ~kIsDynamicMask);
-  }
-
-  // Given an fcl object and maps from index to id of both dynamic and anchored
-  // geometry, returns the geometry id for the given fcl object.
-  GeometryId id(const std::vector<GeometryId>& geometry_map) const {
-    return geometry_map[index()];
-  }
-
-  // Reports the encoded data.
-  uintptr_t encoded_data() const { return data_; }
-
-  // Fcl Collision objects allow for user data. We're storing *two* pieces of
-  // information: the engine index of the corresponding geometry and the
-  // _mobility_ type (i.e., dynamic vs anchored). We do this by mangling bits.
-  // Because user data is a void*, we can read it like a uintptr_t. The highest
-  // bit will represent dynamic (1) or anchored (0).The remaining lower order
-  // bits store the index.
-
-  // Note: This sets a mask to be 1000...0 based on the size of a pointer.
-  // C++ guarantees that uintptr_t can hold a pointer and cast to a pointer,
-  // but it doesn't guarantee it's the *same size* as a pointer. So, we set
-  // the mask value based on pointer size.
-  static const uintptr_t kIsDynamicMask = uintptr_t{1}
-                                          << (sizeof(void*) * 8 - 1);
-
- private:
-  // The encoded data - index and mobility type.
-  // We're using an unsigned value here because:
-  //   - Bitmasking games are typically more intuitive with unsigned values
-  //     (think of bit shifting as an example here).
-  //   - This unsigned integer doesn't bleed out into the API at all.
-  uintptr_t data_{};
-};
 
 // A simple class for providing collision filtering functionality similar to
 // that found in RigidBodyTree but made compatible with fcl. The majority of
@@ -234,31 +143,6 @@ struct DistanceData {
   std::vector<SignedDistancePair<double>>* nearest_pairs{};
 };
 
-// Struct for use in DistanceFromPointCallback(). Contains the distance request
-// and accumulates result in a vector of drake::geometry::SignedDistanceToPoint.
-struct DistanceFromPointCallbackData {
-  DistanceFromPointCallbackData(
-      fcl::CollisionObjectd* query_in,
-      const std::vector<GeometryId>* geometry_map_in,
-      const double threshold_in,
-      std::vector<SignedDistanceToPoint<double>>* distances_in)
-      : query_point(query_in),
-        geometry_map(*geometry_map_in),
-        threshold(threshold_in),
-        distances(distances_in) {}
-
-  // The query point is represented as a zero-radius sphere.
-  fcl::CollisionObjectd* query_point;
-
-  // Maps so the distance call back can map from geometry index to geometry id.
-  const std::vector<GeometryId>& geometry_map;
-
-  // We ignore any object beyond this distance.
-  const double threshold;
-
-  std::vector<SignedDistanceToPoint<double>>* distances;
-};
-
 // Struct for use in SingleCollisionCallback(). Contains the collision request
 // and accumulates results in a drake::multibody::collision::PointPair vector.
 struct CollisionData {
@@ -275,89 +159,6 @@ struct CollisionData {
 
   // Vector of distance results
   std::vector<PenetrationAsPointPair<double>>* contacts{};
-};
-
-// An internal functor to support DistanceFromPointCallback() and
-// ComputeNarrowPhaseDistance(). It computes the signed distance to a query
-// point from a supported geometry. Each overload to the call operator
-// reports the signed distance (encoded as SignedDistanceToPoint) between the
-// functor's stored query point and the given geometry argument.
-class DistanceToPoint {
- public:
-  // Constructs the functor DistanceToPoint.
-  // @param id    the id of the geometry G,
-  // @param X_WG  pose of the geometry G in World frame,
-  // @param p_WQ  position of the query point Q in World frame.
-  // @note Some parts of the geometry (id, pose) are initialized in this
-  // constructor, and the remaining part of the geometry (shape) is a parameter
-  // to the call operator() below.
-  DistanceToPoint(const GeometryId id,
-                  const RigidTransformd& X_WG,
-                  const Vector3d& p_WQ) :
-      geometry_id_(id), X_WG_(X_WG), p_WQ_(p_WQ) {}
-
-  // Overload for Sphere.
-  SignedDistanceToPoint<double> operator()(const fcl::Sphered& sphere);
-
-  // Overload for Box.
-  SignedDistanceToPoint<double> operator()(const fcl::Boxd& box);
-
-  // Overload for Cylinder.
-  SignedDistanceToPoint<double> operator()(const fcl::Cylinderd& cylinder);
-
- private:
-  static double RelativeTolerance(double size) {
-    return DistanceToPointRelativeTolerance(size);
-  }
-  // This version of Sign(x) returns +1.0 for zero.
-  static double Sign(double x) { return (x < 0.0) ? -1. : 1.; }
-  // Picks the axis i whose coordinate p(i) is closest to the boundary value
-  // ±bounds(i). If there are ties, we prioritize according to an arbitrary
-  // ordering: +x,-x,+y,-y,+z,-z.
-  // @tparam V The vector type: Vector2d or Vector3d.
-  template <typename V>
-  static int ExtremalAxis(const V& p, const V& bounds) {
-    DRAKE_DEMAND(V::SizeAtCompileTime == 2 ||
-                 V::SizeAtCompileTime == 3);
-    double min_dist = std::numeric_limits<double>::infinity();
-    int axis = -1;
-    for (int i = 0; i < V::SizeAtCompileTime; ++i) {
-      for (const auto bound : {bounds(i), -bounds(i)}) {
-        const double dist = std::abs(bound - p(i));
-        if (dist < min_dist) {
-          min_dist = dist;
-          axis = i;
-        }
-      }
-    }
-    return axis;
-  }
-  // Calculates the signed distance from a query point Q to a box, G. The box
-  // can be either two-dimensional or three-dimensional.  We use the 3D
-  // version directly for the signed distance from Box and use the 2D version
-  // indirectly for the signed distance from Cylinder.
-  // @tparam dim     The dimension, usually 2 or 3.
-  // @param h        The vector from the center of the box to the positive
-  //                 corner of the box.  In 2D, it consists of half the width
-  //                 and half the length of G. In 3D, it consists of half the
-  //                 width, half the depth, and half the height of G.
-  //                 Mathematically the box is the Cartesian product
-  //                 [-h(0),h(0)]x[-h(1),h(1)] in 2D and
-  //                 [-h(0),h(0)]x[-h(1),h(1)]x[-h(2),h(2)] in 3D.
-  // @param p_GQ_G   The position of the query point Q in G's frame.
-  // @retval {p_GN_G, distance, grad_G}   The tuple of the position of
-  //                 the nearest point N in G's frame, the signed distance,
-  //                 and the gradient vector in G's frame.
-  template <int dim>
-  std::tuple<Vectord<dim>, double, Vectord<dim>>
-  BoxDistanceXd(const Vectord<dim>& h, const Vectord<dim>& p_GQ_G);
-
-  // The id of the geometry G.
-  const GeometryId geometry_id_;
-  // The pose of the geometry G in World frame.
-  const RigidTransformd X_WG_;
-  // The position of the query point Q in World frame.
-  const Vector3d p_WQ_;
 };
 
 // An internal functor to support ComputeNarrowPhaseDistance(). It computes
@@ -443,7 +244,7 @@ template <typename FclShape>
 void DistancePairGeometry::SphereShapeDistance(const fcl::Sphered* sphere_A,
                                                const FclShape* shape_B) {
   const SignedDistanceToPoint<double> shape_B_to_point_Ao =
-      DistanceToPoint(id_B_, X_WB_, X_WA_.translation())(*shape_B);
+      DistanceToPoint<double>(id_B_, X_WB_, X_WA_.translation())(*shape_B);
   const double distance = shape_B_to_point_Ao.distance - sphere_A->radius;
   // Nb is the witness point on ∂B.
   const Vector3d& p_BNb = shape_B_to_point_Ao.p_GN;
@@ -624,255 +425,6 @@ bool DistanceCallback(fcl::CollisionObjectd* fcl_object_A_ptr,
   // we want to find all the signed distance present in the model's current
   // configuration, we return false.
   return false;
-}
-
-// Overload for Sphere.
-SignedDistanceToPoint<double> DistanceToPoint::operator()(
-    const fcl::Sphered& sphere) {
-  double distance{};
-  Vector3d p_GN_G, grad_W;
-  ComputeDistanceToPrimitive(sphere, X_WG_, p_WQ_, &p_GN_G, &distance, &grad_W);
-
-  return SignedDistanceToPoint<double>{geometry_id_, p_GN_G, distance,
-                                       grad_W};
-}
-
-template <int dim>
-std::tuple<Vectord<dim>, double, Vectord<dim>>
-DistanceToPoint::BoxDistanceXd(
-    const Vectord<dim>& h, const Vectord<dim>& p_GQ_G) {
-  // TODO(DamrongGuoy): Move into FCL.
-  // We need to classify Q as inside, outside, or on the boundary of B,
-  // where 'on the boundary' means within a tolerance of the boundary.
-  // This helper function takes the i-th coordinate `coord` of p_GQ_G.
-  // It returns the clamped value of `coord` within ±h(i). It also returns
-  // an enum to indicate whether the i-th coordinate is inside the interval
-  // (-h(i),+h(i)), or within a tolerance of the bounded value ±h(i), or
-  // outside the interval.
-  enum class Location {kInside, kBoundary, kOutside};
-  auto clamp = [&h](const int i, const double coord,
-                    Location* location) -> double {
-    const double tolerance = RelativeTolerance(h(i));
-    if (std::abs(coord) > h(i) + tolerance) {
-      *location = Location::kOutside;
-      return Sign(coord) * h(i);
-    } else if (std::abs(coord) >= h(i) - tolerance) {
-      *location = Location::kBoundary;
-      return Sign(coord) * h(i);
-    } else {
-      *location = Location::kInside;
-      return coord;
-    }
-  };
-
-  // Declare a type of vector of Location parallel to the vector of
-  // coordinates of the position p_GQ_G of Q.
-  typedef Vector<Location, dim> VectorLoc;
-
-  // The clamp point C has coordinates of Q clamped onto the box.
-  // Note that:
-  // 1. C is the nearest point to Q on ∂B if Q is classified as outside B.
-  // 2. C is at the same position as Q if Q is classified as inside B.
-  // 3. C is exactly on ∂B if Q is within a tolerance from ∂B.
-  Vectord<dim> p_GC_G;
-  VectorLoc location;
-  for (int i = 0; i < p_GC_G.size(); ++i)
-    p_GC_G(i) = clamp(i, p_GQ_G(i), &location(i));
-
-  // Initialize the position of the nearest point N on ∂B as that of C.
-  Vectord<dim> p_GN_G = p_GC_G;
-  double distance;
-  Vectord<dim> grad_G = Vectord<dim>::Zero();
-
-  if ((location.array() == Location::kOutside).any()) {
-    // Q is outside the box.
-    Vectord<dim> p_NQ_G = p_GQ_G - p_GN_G;
-    distance = p_NQ_G.norm();
-    DRAKE_DEMAND(distance != 0.);
-    grad_G = p_NQ_G / distance;
-  } else if ((location.array() == Location::kBoundary).any()) {
-    // Q is on the boundary of the box.
-    distance = 0.0;
-    // In any number of dimension, a point on the boundary of a box must have
-    // location(i) == kBoundary for one or more values of i. The gradient is
-    // defined as the average outward normal direction for each axis where
-    // location(axis) == kBoundary. This provides a unique value even when
-    // no such value exists (e.g., at a box corner).
-    for (int i = 0; i < dim; ++i) {
-      if (location(i) == Location::kBoundary)
-        grad_G(i) = Sign(p_GC_G(i));
-    }
-    grad_G.normalize();
-  } else {
-    // Q is inside the box.
-    // In 2D (3D), the nearest point N is the axis-aligned projection of Q
-    // onto one of the edge (faces) of the box.  The gradient vector is along
-    // that direction.
-    int axis = ExtremalAxis(p_GQ_G, h);
-    double sign = Sign(p_GQ_G(axis));
-    p_GN_G(axis) = sign * h(axis);
-    grad_G(axis) = sign;
-    distance = std::abs(p_GQ_G(axis)) - h(axis);
-  }
-  return std::make_tuple(p_GN_G, distance, grad_G);
-}
-
-// Overload for Box.
-SignedDistanceToPoint<double> DistanceToPoint::operator()(
-    const fcl::Boxd& box) {
-  // TODO(DamrongGuoy): Move most code of this function into FCL.
-  // Express the given query point Q in the frame of the box geometry G.
-  const Vector3d p_GQ_G = X_WG_.inverse() * p_WQ_;
-  // The box G is an axis-aligned box [-h(0),h(0)]x[-h(1),h(1)]x[-h(2),h(2)]
-  // centered at the origin, where h(i) is half the size of the box in the
-  // i-th coordinate.
-  const Vector3d h = box.side / 2.0;
-  Vector3d p_GN_G;
-  double distance;
-  Vector3d grad_G;
-  std::tie(p_GN_G, distance, grad_G) = BoxDistanceXd(h, p_GQ_G);
-  // Use R_WG for vectors. Use X_WG for points.
-  const auto& R_WG = X_WG_.rotation();
-  Vector3d grad_W = R_WG * grad_G;
-  return SignedDistanceToPoint<double>{geometry_id_, p_GN_G, distance, grad_W};
-}
-
-// Overload for Cylinder.
-SignedDistanceToPoint<double> DistanceToPoint::operator()(
-    const fcl::Cylinderd& cylinder) {
-  // Overview. First, we map the problem from the 3D cylinder G (in frame G) to
-  // the 2D box B (in frame B) of G's cross section through the plane
-  // containing the query point Q and the center line of G. Then, we call the
-  // function BoxDistanceXd() to get the signed distance, the nearest point N,
-  // and the gradient vector expressed in B's frame. Finally, we map the
-  // answers back into G's frame.
-  // TODO(DamrongGuoy): Move into FCL.
-  // Express the query point Q in the cylinder geometry G's frame.
-  const Vector3d p_GQ = X_WG_.inverse() * p_WQ_;
-  // The 2D cross section B is the box [-h(0),h(0)]x[-h(1),h(1)], where
-  // h(0) and h(1) are the radius and the half length of the cylinder.
-  const Vector2d h(cylinder.radius, cylinder.lz / 2.0);
-  // Transform coordinates between (x,y,z) in G's frame and (r,z) in B's frame.
-  // The basis vector `Bz` is aligned with `Gz`, and `r` is the distance to
-  // the z-axis (i.e., √(x² + y²)), and z transfers unchanged.
-  // The coordinate r is in the radial direction of G in the plane through Q
-  // and z-axis of G.
-  //
-  //  3D cylinder G (x,y,z)     2D box B (r,z)          .
-  //       z                         z                  .
-  //       |      y                  |                  .
-  //       |     /                   |                  .
-  //     o | o  /                    |                  .
-  //   o   |   o                     |                  .
-  //   o   |  /o                  +--|--+               .
-  //   | o o o |          <==>    |  |  |               .
-  //   |   |/  |                  |  |  |               .
-  //   |   +-----------x          |  +------Q-------r   .
-  //   |    \  |                  |     |               .
-  //   o     \ o                  +-----+               .
-  //     o o o\                                         .
-  //           \                                        .
-  //            Q                                       .
-  //             \                                      .
-  //              \                                     .
-  //               r                                    .
-  //
-  // Mathematically the (r,z)-to-(x,y,z) transformation is not defined if Q
-  // is on the z-axis of G because the cross section is not unique.  In that
-  // case, we will treat Q as if it lies on x-axis of G.
-  //
-  auto xyz_to_rz = [](Vector3d xyz) -> Vector2d {
-    const double r = sqrt(xyz(0) * xyz(0) + xyz(1) * xyz(1));
-    return Vector2d(r, xyz(2));
-  };
-  // We compute the the basis vector Br in G's frame. Although a 3D vector, it
-  // is stored implicitly in a 2D vector, because v_GBr(2) must be zero. If
-  // Q is within a tolerance from the center line, v_GBr = <1, 0, 0> by
-  // convention.
-  const double r_Q = std::sqrt(p_GQ(0) * p_GQ(0) + p_GQ(1) * p_GQ(1));
-  const bool near_center_line = (r_Q < RelativeTolerance(cylinder.radius));
-  const Vector2d v_GBr = near_center_line ? Vector2d(1., 0.)
-                                          : Vector2d(p_GQ(0), p_GQ(1)) / r_Q;
-  auto rz_to_xyz = [&v_GBr](Vector2d rz) -> Vector3d {
-    const double r = rz(0);
-    const double z = rz(1);
-    return Vector3d (r * v_GBr(0), r * v_GBr(1), z);
-  };
-
-  // Transform Q from 3D cylinder G to 2D box B.
-  const Vector2d p_BQ = xyz_to_rz(p_GQ);
-
-  // The position of the nearest point N expressed in 2D box B's frame in
-  // coordinates (r,z).
-  Vector2d p_BN;
-  double distance;
-  // The gradient vector expressed in B's frame in coordinates (r,z).
-  Vector2d grad_B;
-  std::tie(p_BN, distance, grad_B) = BoxDistanceXd(h, p_BQ);
-
-  // Transform coordinates from (r,z) in B's frame to (x,y,z) in G's frame.
-  const Vector3d p_GN = rz_to_xyz(p_BN);
-  const Vector3d grad_G = rz_to_xyz(grad_B);
-
-  // Use R_WG for vectors. Use X_WG for points.
-  const auto& R_WG = X_WG_.rotation();
-  const Vector3d grad_W = R_WG * grad_G;
-  return SignedDistanceToPoint<double>{geometry_id_, p_GN, distance, grad_W};
-}
-
-// Callback function from fcl::distance to help ComputeSignedDistanceToPoint.
-bool DistanceFromPointCallback(fcl::CollisionObjectd* fcl_object_A_ptr,
-                               fcl::CollisionObjectd* fcl_object_B_ptr,
-                               // NOLINTNEXTLINE
-                               void* callback_data, double& threshold) {
-  auto& data = *static_cast<DistanceFromPointCallbackData*>(callback_data);
-
-  // We intentionally pass the same number back to FCL in every callback.
-  // It instructs FCL to skip any objects proven to be beyond this threshold
-  // distance (for example, by checking bounding boxes).
-  threshold = data.threshold;
-
-  // We use `const` to prevent modification of the collision objects.
-  const fcl::CollisionObjectd* point_object = data.query_point;
-  const fcl::CollisionObjectd* geometry_object =
-      (data.query_point == fcl_object_A_ptr) ?
-      fcl_object_B_ptr : fcl_object_A_ptr;
-
-  const std::vector<GeometryId>& geometry_map = data.geometry_map;
-  GeometryId geometry_id = EncodedData(*geometry_object).id(geometry_map);
-
-  const fcl::CollisionGeometryd* collision_geometry =
-      geometry_object->collisionGeometry().get();
-
-  // TODO(DamrongGuoy): Replace this custom code when FCL does this for us with
-  // the required accuracy and performance.
-  //
-  DistanceToPoint distance_to_point(geometry_id,
-      RigidTransformd(geometry_object->getTransform()),
-      point_object->getTranslation());
-
-  SignedDistanceToPoint<double> distance;
-  switch (collision_geometry->getNodeType()) {
-    case fcl::GEOM_SPHERE:
-      distance = distance_to_point(
-          *static_cast<const fcl::Sphered*>(collision_geometry));
-      break;
-    case fcl::GEOM_BOX:
-      distance = distance_to_point(
-          *static_cast<const fcl::Boxd*>(collision_geometry));
-      break;
-    case fcl::GEOM_CYLINDER:
-      distance = distance_to_point(
-          *static_cast<const fcl::Cylinderd*>(collision_geometry));
-      break;
-    default:
-      return false;  // Returning false tells fcl to continue to other objects.
-  }
-
-  if (distance.distance <= data.threshold)
-    data.distances->emplace_back(distance);
-
-  return false;  // Returning false tells fcl to continue to other objects.
 }
 
 // Callback function for FCL's collide() function for retrieving a *single*
@@ -1133,9 +685,11 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     // Encode the *global* pose index so that the geometry id can be looked up
     // in the event of a collision.
     EncodedData encoding(index, true /* is dynamic */);
-    encoding.store_in(fcl_object.get());
+    encoding.write_to(fcl_object.get());
     dynamic_objects_.emplace_back(std::move(fcl_object));
+
     collision_filter_.AddGeometry(encoding.encoded_data());
+
     return proximity_index;
   }
 
@@ -1152,8 +706,9 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     anchored_tree_.update();
     ProximityIndex proximity_index(static_cast<int>(anchored_objects_.size()));
     EncodedData encoding(index, false /* is dynamic */);
-    encoding.store_in(fcl_object.get());
+    encoding.write_to(fcl_object.get());
     anchored_objects_.emplace_back(std::move(fcl_object));
+
     collision_filter_.AddGeometry(encoding.encoded_data());
 
     return proximity_index;
@@ -1163,10 +718,10 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
                            GeometryIndex geometry_index) {
     if (is_dynamic) {
       EncodedData::encode_dynamic(geometry_index)
-          .store_in(dynamic_objects_[proximity_index].get());
+          .write_to(dynamic_objects_[proximity_index].get());
     } else {
       EncodedData::encode_anchored(geometry_index)
-          .store_in(anchored_objects_[proximity_index].get());
+          .write_to(anchored_objects_[proximity_index].get());
     }
   }
 
@@ -1201,7 +756,9 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
                         const std::vector<GeometryIndex>& indices) {
     DRAKE_DEMAND(indices.size() == dynamic_objects_.size());
     for (size_t i = 0; i < indices.size(); ++i) {
-      dynamic_objects_[i]->setTransform(convert(X_WG[indices[i]]));
+      // The FCL broadphase requires double-valued poses; so we use ADL to
+      // efficiently get double-valued poses out of arbitrary T-valued poses.
+      dynamic_objects_[i]->setTransform(convert_to_double(X_WG[indices[i]]));
       dynamic_objects_[i]->computeAABB();
     }
     dynamic_tree_.update();
@@ -1389,28 +946,30 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     return witness_pairs;
   }
 
-  std::vector<SignedDistanceToPoint<double>> ComputeSignedDistanceToPoint(
-      const Vector3d& p_WQ,
+  std::vector<SignedDistanceToPoint<T>> ComputeSignedDistanceToPoint(
+      const Vector3<T>& p_WQ,
       const std::vector<GeometryId>& geometry_map,
+      const std::vector<Isometry3<T>>& X_WGs,
       const double threshold) const {
     // We create a sphere of zero radius centered at the query point and put
     // it into a fcl::CollisionObject.
     auto fcl_sphere = make_shared<fcl::Sphered>(0.0);  // sphere of zero radius
     fcl::CollisionObjectd query_point(fcl_sphere);
-    query_point.setTranslation(p_WQ);
+    // The FCL broadphase requires double-valued poses; so we use ADL to
+    // efficiently get double-valued poses out of arbitrary T-valued poses.
+    query_point.setTranslation(convert_to_double(p_WQ));
     query_point.computeAABB();
 
-    std::vector<SignedDistanceToPoint<double>> distances;
+    std::vector<SignedDistanceToPoint<T>> distances;
 
-    DistanceFromPointCallbackData data{&query_point, &geometry_map,
-                                       threshold, &distances};
+    point_distance::CallbackData<T> data{
+        &query_point, &geometry_map, threshold, p_WQ, &X_WGs, &distances};
 
-    anchored_tree_.distance(&query_point, &data, DistanceFromPointCallback);
-    dynamic_tree_.distance(&query_point, &data, DistanceFromPointCallback);
+    anchored_tree_.distance(&query_point, &data, point_distance::Callback<T>);
+    dynamic_tree_.distance(&query_point, &data, point_distance::Callback<T>);
 
     return distances;
   }
-
 
   std::vector<PenetrationAsPointPair<double>> ComputePointPairPenetration(
       const std::vector<GeometryId>& geometry_map) const {
@@ -1800,14 +1359,13 @@ ProximityEngine<T>::ComputeSignedDistancePairwiseClosestPoints(
 }
 
 template <typename T>
-std::vector<SignedDistanceToPoint<double>>
+std::vector<SignedDistanceToPoint<T>>
 ProximityEngine<T>::ComputeSignedDistanceToPoint(
-    const Vector3<double>& query,
-    const std::vector<GeometryId>& geometry_map,
-    const double threshold) const {
-  return impl_->ComputeSignedDistanceToPoint(query, geometry_map, threshold);
+    const Vector3<T>& query, const std::vector<GeometryId>& geometry_map,
+    const std::vector<Isometry3<T>>& X_WGs, const double threshold) const {
+  return impl_->ComputeSignedDistanceToPoint(query, geometry_map, X_WGs,
+                                             threshold);
 }
-
 
 template <typename T>
 std::vector<PenetrationAsPointPair<double>>

--- a/geometry/proximity_engine.h
+++ b/geometry/proximity_engine.h
@@ -184,15 +184,18 @@ class ProximityEngine {
    @param[in] p_WQ            Position of a query point Q in world frame W.
    @param[in] geometry_map    A map from geometry _index_ to the corresponding
                               global geometry identifier.
+   @param[in] X_WGs           The pose of all geometries in world, indexed by
+                              each geometry's GeometryIndex.
    @param[in] threshold       Ignore any object beyond this distance.
    @retval signed_distances   A vector populated with per-object signed
                               distance and gradient vector.
-                              See SignedDistanceFieldValue for details.
+                              See SignedDistanceToPoint for details.
    */
-  std::vector<SignedDistanceToPoint<double>>
+  std::vector<SignedDistanceToPoint<T>>
   ComputeSignedDistanceToPoint(
-      const Vector3<double>& p_WQ,
+      const Vector3<T>& p_WQ,
       const std::vector<GeometryId>& geometry_map,
+      const std::vector<Isometry3<T>>& X_WGs,
       const double threshold = std::numeric_limits<double>::infinity()) const;
   //@}
 

--- a/geometry/query_object.cc
+++ b/geometry/query_object.cc
@@ -41,9 +41,9 @@ QueryObject<T>::ComputeSignedDistancePairwiseClosestPoints() const {
 }
 
 template <typename T>
-std::vector<SignedDistanceToPoint<double>>
+std::vector<SignedDistanceToPoint<T>>
 QueryObject<T>::ComputeSignedDistanceToPoint(
-    const Vector3<double>& p_WQ,
+    const Vector3<T>& p_WQ,
     const double threshold) const {
   ThrowIfDefault();
 

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -11,6 +11,7 @@
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/shape_specification.h"
+#include "drake/math/autodiff_gradient.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/math/rotation_matrix.h"
 
@@ -61,6 +62,7 @@ class ProximityEngineTester {
 
 namespace {
 
+using math::RigidTransform;
 using math::RigidTransformd;
 using math::RollPitchYawd;
 using math::RotationMatrixd;
@@ -355,12 +357,14 @@ using std::shared_ptr;
 GTEST_TEST(SignedDistanceToPointBroadphaseTest, MultipleThreshold) {
   ProximityEngine<double> engine;
   std::vector<GeometryId> geometry_map;
+  std::vector<Isometry3d> X_WGs;
   const double radius = 0.1;
   const Vector3d center1(1., 1., 1.);
   const Vector3d center2(-1, -1, -1.);
   int index = 0;
   for (const Vector3d p_WG : {center1, center2}) {
     const RigidTransformd X_WG(p_WG);
+    X_WGs.push_back(X_WG.GetAsIsometry3());
     engine.AddAnchoredGeometry(Sphere(radius), X_WG.GetAsIsometry3(),
                                GeometryIndex(index++));
     geometry_map.push_back(GeometryId::get_new_id());
@@ -368,38 +372,44 @@ GTEST_TEST(SignedDistanceToPointBroadphaseTest, MultipleThreshold) {
   const Vector3d p_WQ(3., 3., 3.);
   // This small threshold allows no sphere.
   double threshold = 0.001;
-  auto results = engine.ComputeSignedDistanceToPoint(p_WQ, geometry_map,
+  auto results = engine.ComputeSignedDistanceToPoint(p_WQ, geometry_map, X_WGs,
                                                      threshold);
   EXPECT_EQ(0, results.size());
   // This threshold touches the corner of the bounding box of the first sphere.
   // It is still too small to yield any result.
   threshold = (p_WQ - (center1 + Vector3d(radius, radius, radius))).norm();
-  results = engine.ComputeSignedDistanceToPoint(p_WQ, geometry_map, threshold);
+  results =
+      engine.ComputeSignedDistanceToPoint(p_WQ, geometry_map, X_WGs, threshold);
   EXPECT_EQ(0, results.size());
   // This threshold barely touches outside the first sphere, so it still gives
   // no result.
   threshold = (p_WQ - center1).norm() - radius - 1e-10;
-  results = engine.ComputeSignedDistanceToPoint(p_WQ, geometry_map, threshold);
+  results =
+      engine.ComputeSignedDistanceToPoint(p_WQ, geometry_map, X_WGs, threshold);
   EXPECT_EQ(0, results.size());
   // This threshold barely touches inside the first sphere, so it gives
   // one result.
   threshold = (p_WQ - center1).norm() - radius + 1e-10;
-  results = engine.ComputeSignedDistanceToPoint(p_WQ, geometry_map, threshold);
+  results =
+      engine.ComputeSignedDistanceToPoint(p_WQ, geometry_map, X_WGs, threshold);
   EXPECT_EQ(1, results.size());
   // This threshold touches the corner of the bounding box of the second
   // sphere, so it is still too small to allow the second sphere.
   threshold = (p_WQ - (center2 + Vector3d(radius, radius, radius))).norm();
-  results = engine.ComputeSignedDistanceToPoint(p_WQ, geometry_map, threshold);
+  results =
+      engine.ComputeSignedDistanceToPoint(p_WQ, geometry_map, X_WGs, threshold);
   EXPECT_EQ(1, results.size());
   // This threshold barely touches the outside the second sphere, so it still
   // gives one result.
   threshold = (p_WQ - center2).norm() - radius - 1e-10;
-  results = engine.ComputeSignedDistanceToPoint(p_WQ, geometry_map, threshold);
+  results =
+      engine.ComputeSignedDistanceToPoint(p_WQ, geometry_map, X_WGs, threshold);
   EXPECT_EQ(1, results.size());
   // This threshold barely touches inside the second sphere, so it starts to
   // give two results.
   threshold = (p_WQ - center2).norm() - radius + 1e-10;
-  results = engine.ComputeSignedDistanceToPoint(p_WQ, geometry_map, threshold);
+  results =
+      engine.ComputeSignedDistanceToPoint(p_WQ, geometry_map, X_WGs, threshold);
   EXPECT_EQ(2, results.size());
 }
 
@@ -1006,6 +1016,7 @@ struct SignedDistanceToPointTest
     : public testing::TestWithParam<SignedDistanceToPointTestData> {
   ProximityEngine<double> engine;
   std::vector<GeometryId> geometry_map;
+  std::vector<Isometry3d> X_WGs;
 
   // The tolerance value for determining equivalency between expected and
   // tested results. The underlying algorithms have an empirically-determined,
@@ -1017,6 +1028,7 @@ struct SignedDistanceToPointTest
     auto data = GetParam();
     engine.AddAnchoredGeometry(*(data.geometry), data.X_WG.GetAsIsometry3(),
                                GeometryIndex(0));
+    X_WGs.push_back(data.X_WG.GetAsIsometry3());
     geometry_map.push_back(data.expected_result.id_G);
   }
 };
@@ -1024,7 +1036,8 @@ struct SignedDistanceToPointTest
 TEST_P(SignedDistanceToPointTest, SingleQueryPoint) {
   auto data = GetParam();
 
-  auto results = engine.ComputeSignedDistanceToPoint(data.p_WQ, geometry_map);
+  auto results =
+      engine.ComputeSignedDistanceToPoint(data.p_WQ, geometry_map, X_WGs);
   EXPECT_EQ(results.size(), 1);
   EXPECT_EQ(results[0].id_G, data.expected_result.id_G);
   EXPECT_TRUE(
@@ -1042,14 +1055,14 @@ TEST_P(SignedDistanceToPointTest, SingleQueryPointWithThreshold) {
 
   const double large_threshold = data.expected_result.distance + 0.01;
   auto results =
-      engine.ComputeSignedDistanceToPoint(data.p_WQ, geometry_map,
+      engine.ComputeSignedDistanceToPoint(data.p_WQ, geometry_map, X_WGs,
                                           large_threshold);
   // The large threshold allows one object in the results.
   EXPECT_EQ(results.size(), 1);
 
   const double small_threshold = data.expected_result.distance - 0.01;
   results =
-      engine.ComputeSignedDistanceToPoint(data.p_WQ, geometry_map,
+      engine.ComputeSignedDistanceToPoint(data.p_WQ, geometry_map, X_WGs,
                                           small_threshold);
   // The small threshold skips all objects.
   EXPECT_EQ(results.size(), 0);
@@ -3200,6 +3213,119 @@ GTEST_TEST(ProximityEngineTests, AnchoredBroadPhaseInitialization) {
   engine_copy.UpdateWorldPoses({X_WD}, {index_D});
   auto pairs_copy = engine_copy.ComputePointPairPenetration(geometry_map);
   EXPECT_EQ(pairs_copy.size(), 1);
+}
+
+// Basic smoke test for the autodiffibility of the signed distance computation.
+// Tests against the anchored geometry. Specifically, it confirms that while
+// poses are set with double, the calculation is done with AutoDiff and
+// derivatives come through.
+GTEST_TEST(ProximityEngineTests, ComputeSignedDistanceAutoDiffAnchored) {
+  ProximityEngine<AutoDiffXd> engine;
+
+  const double kEps = std::numeric_limits<double>::epsilon();
+
+  // Given a sphere with radius 0.7, centered on p_WSo, the point p_SQ = (2,3,6)
+  // is outside G at the positive distance 6.3.
+  const double expected_distance = 6.3;
+  const Vector3d p_SQ_W{2.0, 3.0, 6.0};
+  const Vector3d p_WS_W{0.5, 1.25, -2};
+  const Vector3d p_WQ{p_SQ_W + p_WS_W};
+  Vector3<AutoDiffXd> p_WQ_ad = math::initializeAutoDiff(p_WQ);
+
+  // An empty world inherently produces no results.
+  {
+    std::vector<GeometryId> geometry_map;
+    std::vector<Isometry3<AutoDiffXd>> X_WGs;
+    const auto results = engine.ComputeSignedDistanceToPoint(
+        p_WQ_ad, geometry_map, X_WGs);
+    EXPECT_EQ(results.size(), 0);
+  }
+
+  // Against an anchored sphere.
+  {
+    const RigidTransformd X_WS = RigidTransformd(p_WS_W);
+    engine.AddAnchoredGeometry(Sphere(0.7), X_WS, GeometryIndex(0));
+    std::vector<GeometryId> geometry_map{GeometryId::get_new_id()};
+    const RigidTransform<AutoDiffXd> X_WS_ad = X_WS.cast<AutoDiffXd>();
+    std::vector<Isometry3<AutoDiffXd>> X_WGs{X_WS_ad};
+
+    // Distance is just beyond the threshold.
+    {
+      std::vector<SignedDistanceToPoint<AutoDiffXd>> results =
+          engine.ComputeSignedDistanceToPoint(p_WQ_ad, geometry_map, X_WGs,
+                                              expected_distance - 1e-14);
+      EXPECT_EQ(results.size(), 0);
+    }
+
+    // Distance is just within the threshold
+    {
+      std::vector<SignedDistanceToPoint<AutoDiffXd>> results =
+          engine.ComputeSignedDistanceToPoint(p_WQ_ad, geometry_map, X_WGs,
+                                              expected_distance + 1e-14);
+      EXPECT_EQ(results.size(), 1);
+      const SignedDistanceToPoint<AutoDiffXd>& distance_data = results[0];
+      // The autodiff seems to lose a couple of bits relative to the known
+      // answer.
+      EXPECT_NEAR(distance_data.distance.value(), expected_distance, 4 * kEps);
+      // The analytical `grad_W` value should match the autodiff-computed
+      // gradient.
+      const Vector3d ddistance_dp_WQ = distance_data.distance.derivatives();
+      const Vector3d grad_W = math::autoDiffToValueMatrix(distance_data.grad_W);
+      EXPECT_TRUE(CompareMatrices(ddistance_dp_WQ, grad_W, kEps));
+    }
+  }
+}
+
+// Basic smoke test for the autodiffibility of the signed distance computation.
+// Tests against the dynamic geometry. Specifically, it confirms that while
+// poses are set with double, the calculation is done with AutoDiff and
+// derivatives come through.
+GTEST_TEST(ProximityEngineTests, ComputeSignedDistanceAutoDiffDynamic) {
+  ProximityEngine<AutoDiffXd> engine;
+
+  const double kEps = std::numeric_limits<double>::epsilon();
+
+  // Given a sphere with radius 0.7, centered on p_WSo, the point p_SQ = (2,3,6)
+  // is outside G at the positive distance 6.3.
+  const double expected_distance = 6.3;
+  const Vector3d p_SQ{2.0, 3.0, 6.0};
+  const Vector3d p_WS{0.5, 1.25, -2};
+  const Vector3d p_WQ{p_SQ + p_WS};
+  Vector3<AutoDiffXd> p_WQ_ad = math::initializeAutoDiff(p_WQ);
+
+  // Against a dynamic sphere.
+  GeometryIndex index(0);
+  engine.AddDynamicGeometry(Sphere(0.7), index);
+  std::vector<GeometryId> geometry_map{GeometryId::get_new_id()};
+  const auto X_WS_ad =
+      RigidTransformd(p_WS).cast<AutoDiffXd>().GetAsIsometry3();
+  std::vector<Isometry3<AutoDiffXd>> X_WGs{X_WS_ad};
+  engine.UpdateWorldPoses(X_WGs, {index});
+
+  // Distance is just beyond the threshold.
+  {
+    std::vector<SignedDistanceToPoint<AutoDiffXd>> results =
+        engine.ComputeSignedDistanceToPoint(p_WQ_ad, geometry_map, X_WGs,
+                                            expected_distance - 1e-14);
+    EXPECT_EQ(results.size(), 0);
+  }
+
+  // Distance is just within the threshold
+  {
+    std::vector<SignedDistanceToPoint<AutoDiffXd>> results =
+        engine.ComputeSignedDistanceToPoint(p_WQ_ad, geometry_map, X_WGs,
+                                            expected_distance + 1e-14);
+    EXPECT_EQ(results.size(), 1);
+    const SignedDistanceToPoint<AutoDiffXd>& distance_data = results[0];
+    // The autodiff seems to lose a couple of bits relative to the known
+    // answer.
+    EXPECT_NEAR(distance_data.distance.value(), expected_distance, 4 * kEps);
+    // The analytical `grad_W` value should match the autodiff-computed
+    // gradient.
+    const Vector3d ddistance_dp_WQ = distance_data.distance.derivatives();
+    const Vector3d grad_W = math::autoDiffToValueMatrix(distance_data.grad_W);
+    EXPECT_TRUE(CompareMatrices(ddistance_dp_WQ, grad_W, kEps));
+  }
 }
 
 

--- a/geometry/test/utilities_test.cc
+++ b/geometry/test/utilities_test.cc
@@ -61,12 +61,30 @@ GTEST_TEST(GeometryUtilities, IsometryConversion) {
   X_AB.linear() << 10, 20, 30, 40, 50, 60, 70, 80, 90;
   X_AB.makeAffine();
 
-  Isometry3<double> X_AB_converted = convert(X_AB);
+  Isometry3<double> X_AB_converted = convert_to_double(X_AB);
   EXPECT_TRUE(CompareMatrices(X_AB.matrix(), X_AB_converted.matrix()));
+  // Double to double conversion is just a pass through without copying.
+  const Isometry3<double>& X_AB_converted_ref = convert_to_double(X_AB);
+  EXPECT_EQ(&X_AB, &X_AB_converted_ref);
 
   Isometry3<AutoDiffXd> X_AB_ad(X_AB);
-  Isometry3<double> X_AB_ad_converted = convert(X_AB_ad);
+  Isometry3<double> X_AB_ad_converted = convert_to_double(X_AB_ad);
   EXPECT_TRUE(CompareMatrices(X_AB.matrix(), X_AB_ad_converted.matrix()));
+}
+
+GTEST_TEST(GeometryUtilities, Vector3Conversion) {
+  Vector3<double> p_AB{1, 2, 3};
+
+  Vector3<double> p_AB_converted = convert_to_double(p_AB);
+  EXPECT_TRUE(CompareMatrices(p_AB.matrix(), p_AB_converted.matrix()));
+  // Double to double conversion is just a pass through without copying, so
+  // we'll compare addresses.
+  const Vector3<double>& p_AB_converted_ref = convert_to_double(p_AB);
+  EXPECT_EQ(&p_AB, &p_AB_converted_ref);
+
+  Vector3<AutoDiffXd> p_AB_ad(p_AB);
+  Vector3<double> X_AB_ad_converted = convert_to_double(p_AB_ad);
+  EXPECT_TRUE(CompareMatrices(p_AB.matrix(), X_AB_ad_converted.matrix()));
 }
 
 }  // namespace

--- a/geometry/utilities.h
+++ b/geometry/utilities.h
@@ -58,20 +58,36 @@ class MapKeyRange {
 /** @name Isometry scalar conversion
 
  Some of SceneGraph's inner-workings are _not_ templated on scalar type and
- always require Isometry3<double>. These functions work in an ADL-compatible
- manner to allow SceneGraph to mindlessly convert templated Isometry3 to
- double-valued transforms.  */
+ always require double values. These functions work in an ADL-compatible
+ manner to allow SceneGraph to mindlessly convert Quantity<T> to
+ Quantity<double> efficiently. There is *particular* emphasis on making the
+ Quantity<double> -> Quantity<double> as cheap as possible.  */
 //@{
+
+inline const Vector3<double>& convert_to_double(const Vector3<double>& vec) {
+  return vec;
+}
+
+template <class VectorType>
+Vector3<double> convert_to_double(
+    const Vector3<Eigen::AutoDiffScalar<VectorType>>& vec) {
+  Vector3<double> result;
+  for (int r = 0; r < 3; ++r) {
+    result(r) = ExtractDoubleOrThrow(vec(r));
+  }
+  return result;
+}
 
 // TODO(SeanCurtis-TRI): Get rid of these when I finally swap for
 // RigidTransforms.
 
-inline const Isometry3<double>& convert(const Isometry3<double>& transform) {
+inline const Isometry3<double>& convert_to_double(
+    const Isometry3<double>& transform) {
   return transform;
 }
 
 template <class VectorType>
-Isometry3<double> convert(
+Isometry3<double> convert_to_double(
     const Isometry3<Eigen::AutoDiffScalar<VectorType>>& transform) {
   Isometry3<double> result;
   for (int r = 0; r < 4; ++r) {


### PR DESCRIPTION
This entailed several pieces of work. Relates to #11120 

1. Refactoring:
   -  Extract code from proximity_engine.cc into its own file (proximity/distance_to_point.h) and make it appropriately templated.
   - Steal functionality out of the soon-to-be-defunct distance_to_point_with_gradient.* to put into proximity_utilities.h
2. proximity_engine.h/cc:
   - Reformulate queries in proximity_engine.cc to make use of the refactored code in proximity_utilites.h and distance_to_point.h
   - Reformulate queries to separate broadphase in double with narrowphase in T.
   - Change signature of function is question to be tempalted on T instead of double.
3. Extend the conversion utilities in geometry/utilities.h to include convenience casting for Vector3<T> -> Vector3<double>
4. Push proximity engine changes through GeometryState and QueryObject.
5. Testing
   - New (limited) unit tests on distance_to_point.h. Specifically, spot checking of autodiff compatibility.
   - smoke test on ProximityEngine to confirm broadphase vs narrowphase funcionality.
6. Update documentation in QueryObject to pave the road for partial AutoDiff support.

Apologies in advance for the size of this PR. If absolutely necessary, I can chop it in two parts. One of the most frustrating parts of this review will be modifications to moved *portions* of files. Sorry 'bout that.

```
Category            added  modified  removed  
----------------------------------------------
code                584    37        250      
comments            379    7         224      
blank               144    0         51       
----------------------------------------------
TOTAL               1107   44        525 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11208)
<!-- Reviewable:end -->
