### PR TITLE
framework: Improve error message for algebraic loops

### DIFF
--- a/systems/framework/diagram_builder.cc
+++ b/systems/framework/diagram_builder.cc
@@ -1,13 +1,26 @@
 #include "drake/systems/framework/diagram_builder.h"
 
+#include "drake/common/drake_variant.h"
+
 namespace drake {
 namespace systems {
 namespace internal {
 namespace {
 
-// This generic port identifier is used only for cycle detection below
-// because the algorithm treats both input & output ports as nodes.
-using PortIdentifier = std::pair<const SystemBase*, int>;
+using EitherPortIndex = variant<InputPortIndex, OutputPortIndex>;
+using PortIdentifier = std::pair<const SystemBase*, EitherPortIndex>;
+
+bool is_input_port_index(const EitherPortIndex& either) {
+  return either.index() == 0;
+}
+
+std::string to_string(const PortIdentifier& port_id) {
+  const SystemBase& system = *port_id.first;
+  const EitherPortIndex& index = port_id.second;
+  return is_input_port_index(index) ?
+      system.get_input_port_base(drake::get<0>(index)).GetFullDescription() :
+      system.get_output_port_base(drake::get<1>(index)).GetFullDescription();
+}
 
 // Helper to do the algebraic loop test. It recursively performs the
 // depth-first search on the graph to find cycles.
@@ -44,89 +57,71 @@ void DiagramBuilderImpl::ThrowIfAlgebraicLoopsExist(
     const std::map<
         std::pair<const SystemBase*, InputPortIndex>,
         std::pair<const SystemBase*, OutputPortIndex>>& connection_map) {
-  // Each port in the diagram is a node in a graph.
-  // An edge exists from node u to node v if:
-  //  1. output u is connected to input v (via Connect(u, v) method), or
-  //  2. a direct feedthrough from input u to output v is reported.
-  // A depth-first search of the graph should produce a forest of valid trees
-  // if there are no algebraic loops. Otherwise, at least one link moving
-  // *up* the tree will exist.
+  // To discover loops, we will construct a digraph and check it for cycles.
 
-  // Build the graph.
-  // Generally, the nodes of the graph would be the set of all defined ports
-  // (input and output) of each subsystem. However, we only need to
-  // consider the input/output ports that have a diagram level output-to-input
-  // connection (ports that are not connected in this manner cannot contribute
-  // to an algebraic loop).
-
-  // Track *all* of the nodes involved in a diagram-level connection as
-  // described above.
+  // The nodes in the digraph are the input and output ports mentioned by the
+  // diagram's internal connections.  Ports that are not internally connected
+  // cannot participate in a cycle, so we don't include them in the nodes set.
   std::set<PortIdentifier> nodes;
-  // A map from node u, to the set of edges { (u, v_i) }. In normal cases,
-  // not every node in `nodes` will serve as a key in `edges` (as that is a
-  // necessary condition for there to be no algebraic loop).
+
+  // The edges in the digraph are a directed "influences" relation: for each
+  // `value` in `edges[key]`, the `key` influences `value`.  (This is the
+  // opposite of the "depends-on" relation.)
   std::map<PortIdentifier, std::set<PortIdentifier>> edges;
 
-  // In order to store PortIdentifiers for both input and output ports in the
-  // same set, I need to encode the ports. The identifier for the first input
-  // port and output port look identical (same system pointer, same port
-  // id 0). So, to distinguish them, I'll modify the output ports to use the
-  // negative half of the int space. The function below provides a utility for
-  // encoding an output port id.
-  auto output_to_key = [](int port_id) { return -(port_id + 1); };
-
-  // Populate the node set from the connections (and define the edges implied
-  // by those connections).
-  for (const auto& connection : connection_map) {
-    // Dependency graph is a mapping from the destination of the connection
-    // to what it *depends on* (the source).
-    const PortIdentifier& src = connection.second;
-    const PortIdentifier& dest = connection.first;
-    PortIdentifier encoded_src{src.first, output_to_key(src.second)};
-    nodes.insert(encoded_src);
-    nodes.insert(dest);
-    edges[encoded_src].insert(dest);
+  // Add the diagram's internal connections to the digraph nodes *and* edges.
+  // The output port influences the input port.
+  for (const auto& item : connection_map) {
+    const PortIdentifier input{item.first};
+    const PortIdentifier output{item.second};
+    nodes.insert(input);
+    nodes.insert(output);
+    edges[output].insert(input);
   }
 
-  // Populate more edges based on direct feedthrough.
+  // Add more edges (*not* nodes) based on each System's direct feedthrough.
+  // An input port influences an output port iff there is direct feedthrough
+  // from that input to that output.  If a feedthrough edge refers to a port
+  // not in `nodes`, we omit it because ports that are not connected inside the
+  // diagram cannot participate in a cycle.
   for (const auto& system : systems) {
-    for (const auto& pair : system->GetDirectFeedthroughs()) {
-      PortIdentifier src_port{system, pair.first};
-      PortIdentifier dest_port{system, output_to_key(pair.second)};
-      if (nodes.count(src_port) > 0 && nodes.count(dest_port) > 0) {
-        // Track direct feedthrough only on port pairs where *both* ports are
-        // connected to other ports at the diagram level.
-        edges[src_port].insert(dest_port);
+    for (const auto& item : system->GetDirectFeedthroughs()) {
+      const PortIdentifier input{system, InputPortIndex{item.first}};
+      const PortIdentifier output{system, OutputPortIndex{item.second}};
+      if (nodes.count(input) > 0 && nodes.count(output) > 0) {
+        edges[input].insert(output);
       }
     }
   }
+
+  static constexpr char kAdvice[] =
+      "A System may have conservatively reported that one of its output ports "
+      "depends on an input port, making one of the 'is direct-feedthrough to' "
+      "lines above spurious.  If that is the case, remove the spurious "
+      "dependency as shown in the API documentation for "
+      "LeafSystem::DoHasDirectFeedthrough.";
 
   // Evaluate the graph for cycles.
   std::set<PortIdentifier> visited;
   std::vector<PortIdentifier> stack;
   for (const auto& node : nodes) {
-    if (visited.count(node) == 0) {
-      if (HasCycleRecurse(node, edges, &visited, &stack)) {
-        std::stringstream ss;
-
-        auto port_to_stream = [&ss](const auto& id) {
-          ss << "  " << id.first->get_name() << ":";
-          if (id.second < 0)
-            ss << "Out(";
-          else
-            ss << "In(";
-          ss << (id.second >= 0 ? id.second : -id.second - 1) << ")";
-        };
-
-        ss << "Algebraic loop detected in DiagramBuilder:\n";
-        for (size_t i = 0; i < stack.size() - 1; ++i) {
-          port_to_stream(stack[i]);
-          ss << " depends on\n";
+    if (visited.count(node) > 0) {
+      continue;
+    }
+    if (HasCycleRecurse(node, edges, &visited, &stack)) {
+      std::stringstream message;
+      message << "Reported algebraic loop detected in DiagramBuilder:\n";
+      for (const auto& item : stack) {
+        message << "  " << to_string(item);
+        if (is_input_port_index(item.second)) {
+          message << " is direct-feedthrough to\n";
+        } else {
+          message << " is connected to\n";
         }
-        port_to_stream(stack.back());
-
-        throw std::runtime_error(ss.str());
       }
+      message << "  " << to_string(stack.front()) << "\n";
+      message << kAdvice;
+      throw std::runtime_error(message.str());
     }
   }
 }


### PR DESCRIPTION
Stop saying "depends on"; it was actually "influences", which is the opposite.  Distinguish "output is connected to input" from "input is direct-feedthrough from output".  Mention the first/last node twice in the message (to close the loop, so to speak).

Relates #11179.  Future work towards that issue may involve explaining to the user why the direct-feedthrough condition exists, and/or improving the Doxygen instructions for resolving it.  For now, this just wordsmiths the reporting of the connections / feedthroughs loop while making the graph-search code simpler in the first place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11212)
<!-- Reviewable:end -->
