### PR TITLE
Remove Isometry3 uses from inverse kinematics tests.

### DIFF
--- a/bindings/pydrake/multibody/test/inverse_kinematics_test.py
+++ b/bindings/pydrake/multibody/test/inverse_kinematics_test.py
@@ -9,7 +9,7 @@ import numpy as np
 from numpy.linalg import norm
 
 from pydrake.common import FindResourceOrThrow
-from pydrake.common.eigen_geometry import Quaternion, AngleAxis, Isometry3
+from pydrake.common.eigen_geometry import Quaternion
 from pydrake.common.test_utilities.deprecation import catch_drake_warnings
 from pydrake.math import RigidTransform, RotationMatrix
 from pydrake.multibody.plant import (

--- a/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.cc
+++ b/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.cc
@@ -93,8 +93,8 @@ Eigen::Vector4d QuaternionToVectorWxyz(const Eigen::Quaterniond& q) {
 namespace {
 template <typename T>
 std::unique_ptr<systems::Diagram<T>> BuildTwoFreeSpheresDiagram(
-    double radius1, double radius2, const Eigen::Isometry3d& X_B1S1,
-    const Eigen::Isometry3d& X_B2S2, MultibodyPlant<T>** plant,
+    double radius1, double radius2, const RigidTransformd& X_B1S1,
+    const RigidTransformd& X_B2S2, MultibodyPlant<T>** plant,
     geometry::SceneGraph<T>** scene_graph, FrameIndex* sphere1_index,
     FrameIndex* sphere2_index) {
   systems::DiagramBuilder<T> builder;
@@ -117,10 +117,8 @@ std::unique_ptr<systems::Diagram<T>> BuildTwoFreeSpheresDiagram(
 }  // namespace
 
 TwoFreeSpheresTest::TwoFreeSpheresTest() {
-  X_B1S1_.setIdentity();
-  X_B1S1_.translation() << 0.01, 0.02, 0.03;
-  X_B2S2_.setIdentity();
-  X_B2S2_.translation() << 0.02, -0.01, -0.02;
+  X_B1S1_.set_translation({0.01, 0.02, 0.03});
+  X_B2S2_.set_translation({0.02, -0.01, -0.02});
   diagram_double_ = BuildTwoFreeSpheresDiagram(
       radius1_, radius2_, X_B1S1_, X_B2S2_, &plant_double_,
       &scene_graph_double_, &sphere1_index_, &sphere2_index_);

--- a/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h
+++ b/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h
@@ -8,6 +8,7 @@
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/math/autodiff_gradient.h"
+#include "drake/math/rigid_transform.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/multibody/tree/multibody_tree.h"
 #include "drake/systems/framework/diagram.h"
@@ -109,9 +110,9 @@ class TwoFreeSpheresTest : public ::testing::Test {
   FrameIndex sphere2_index_;
 
   // The pose of sphere 1's collision geometry in sphere 1's body frame.
-  Eigen::Isometry3d X_B1S1_;
+  math::RigidTransformd X_B1S1_;
   // The pose of sphere 2's collision geometry in sphere 2's body frame.
-  Eigen::Isometry3d X_B2S2_;
+  math::RigidTransformd X_B2S2_;
 
   std::unique_ptr<systems::Context<double>> diagram_context_double_;
   std::unique_ptr<systems::Context<AutoDiffXd>> diagram_context_autodiff_;

--- a/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
@@ -3,6 +3,7 @@
 #include <limits>
 
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/math/rigid_transform.h"
 #include "drake/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h"
 
 namespace drake {
@@ -132,12 +133,10 @@ void CheckMinimumDistanceConstraintEval(
 }
 
 template <typename T>
-Vector3<T> ComputeCollisionSphereCenterPosition(const Vector3<T>& p_WB,
-                                                const Quaternion<T>& quat_WB,
-                                                const Eigen::Isometry3d& X_BS) {
-  Isometry3<T> X_WB;
-  X_WB.linear() = quat_WB.toRotationMatrix();
-  X_WB.translation() = p_WB;
+Vector3<T> ComputeCollisionSphereCenterPosition(
+    const Vector3<T>& p_WB, const Quaternion<T>& quat_WB,
+    const math::RigidTransformd& X_BS) {
+  math::RigidTransform<T> X_WB{quat_WB, p_WB};
   return X_WB * (X_BS.translation().cast<T>());
 }
 


### PR DESCRIPTION
Part of #11193.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11215)
<!-- Reviewable:end -->
