### PR TITLE
Add the abstract RenderEngine

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -257,7 +257,10 @@ drake_cc_library(
     name = "utilities",
     srcs = ["utilities.cc"],
     hdrs = ["utilities.h"],
-    deps = ["//common"],
+    deps = [
+        "//common",
+        "//math:geometric_transform",
+    ],
 )
 
 # -----------------------------------------------------

--- a/geometry/render/BUILD.bazel
+++ b/geometry/render/BUILD.bazel
@@ -13,9 +13,29 @@ package(default_visibility = ["//visibility:public"])
 drake_cc_package_library(
     name = "render",
     deps = [
+        ":render_engine",
         ":render_label",
         ":render_label_class",
         ":render_label_manager",
+    ],
+)
+
+# A build target for code that wants to interact with the *idea* of a render
+# engine but doesn't want any build dependencies on the implementation details.
+drake_cc_library(
+    name = "render_engine",
+    srcs = ["render_engine.cc"],
+    hdrs = [
+        "camera_properties.h",
+        "render_engine.h",
+    ],
+    deps = [
+        "//geometry:geometry_index",
+        "//geometry:geometry_roles",
+        "//geometry:shape_specification",
+        "//geometry:utilities",
+        "//math:geometric_transform",
+        "//systems/sensors:image",
     ],
 )
 
@@ -53,6 +73,15 @@ drake_cc_library(
 )
 
 # === test/ ===
+
+drake_cc_googletest(
+    name = "render_engine_test",
+    deps = [
+        ":render_engine",
+        "//common/test_utilities",
+        "//geometry:geometry_ids",
+    ],
+)
 
 drake_cc_googletest(
     name = "render_label_test",

--- a/geometry/render/render_engine.cc
+++ b/geometry/render/render_engine.cc
@@ -1,0 +1,89 @@
+#include "drake/geometry/render/render_engine.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+
+using math::RigidTransformd;
+
+std::unique_ptr<RenderEngine> RenderEngine::Clone() const {
+  return std::unique_ptr<RenderEngine>(DoClone());
+}
+
+optional<RenderIndex> RenderEngine::RegisterVisual(
+    GeometryIndex index, const drake::geometry::Shape& shape,
+    const PerceptionProperties& properties,
+    const RigidTransformd& X_WG, bool needs_updates) {
+  optional<RenderIndex> render_index =
+      DoRegisterVisual(shape, properties, X_WG);
+  if (render_index) {
+    if (needs_updates) {
+      update_indices_.insert({*render_index, index});
+    } else {
+      anchored_indices_.insert({*render_index, index});
+    }
+  }
+  return render_index;
+}
+
+optional<GeometryIndex> RenderEngine::RemoveGeometry(RenderIndex index) {
+  // The underlying engine doesn't know if the geometry to remove or the
+  // geometry that gets moved requires updates or not. As such, the removed
+  // index and the moved index can arbitrarily come from either mapping.
+  // Possible scenarios:
+  // Remove index in map A
+  //   Case 1: nothing moved
+  //     1. Remove the (remove index, remove GeometryIndex) pair from A.
+  //     2. return nullopt.
+  //   Case 2: moved geometry in A (i.e., _same_ map)
+  //     1. Remove the (moved index, moved GeometryIndex) pair from A.
+  //     2. Add the (removed index, moved GeometryIndex) pair into A.
+  //     3. Return moved GeometryIndex.
+  //   Case 3: moved geometry in B (i.e., _different_ map)
+  //     1. Remove the (removed index, removed GI) pair from A.
+  //     2. Remove the (moved index, moved GI) pair from B.
+  //     3. Add the (removed index, moved GI) pair to B.
+  //     4. Return moved GeometryIndex.
+
+  // Given an index, return a pointer to the anchored/update index map in which
+  // this index belongs.
+  auto get_index_map = [this](const RenderIndex r_index) {
+    auto iter = update_indices_.find(r_index);
+    if (iter != update_indices_.end()) return &update_indices_;
+    iter = anchored_indices_.find(r_index);
+    if (iter != anchored_indices_.end()) return &anchored_indices_;
+    throw std::logic_error(fmt::format(
+        "Error finding RenderIndex ({}) as either dynamic or anchored",
+        r_index));
+  };
+
+  // Determine map A.
+  std::unordered_map<RenderIndex, GeometryIndex>* map_A = get_index_map(index);
+
+  GeometryIndex moved_internal_index;
+  optional<RenderIndex> moved_index = DoRemoveGeometry(index);
+
+  // Determine map B.
+  std::unordered_map<RenderIndex, GeometryIndex>* map_B = nullptr;
+  if (moved_index) {
+    map_B = get_index_map(*moved_index);
+    moved_internal_index = (*map_B)[*moved_index];
+  }
+
+  // Examine cases:
+  map_A->erase(index);
+  if (map_B == nullptr) {                        // Case 1.
+    return nullopt;
+  } else if (map_A == map_B) {                   // Case 2.
+    map_A->erase(*moved_index);
+    (*map_A)[index] = moved_internal_index;
+  } else {                                       // Case 3.
+    map_B->erase(*moved_index);
+    (*map_B)[index] = moved_internal_index;
+  }
+  return moved_internal_index;
+}
+
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/render_engine.h
+++ b/geometry/render/render_engine.h
@@ -1,0 +1,184 @@
+
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include <Eigen/Dense>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/drake_optional.h"
+#include "drake/geometry/geometry_index.h"
+#include "drake/geometry/geometry_roles.h"
+#include "drake/geometry/render/camera_properties.h"
+#include "drake/geometry/shape_specification.h"
+#include "drake/geometry/utilities.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/systems/sensors/image.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+
+/** The engine for performing rasterization operations on geometry. This
+ includes rgb images and depth images. The coordinate system of
+ %RenderEngine's viewpoint `R` is `X-right`, `Y-down` and `Z-forward`
+ with respect to the rendered images.
+
+ Output image format:
+   - RGB (ImageRgba8U) : the RGB image has four channels in the following
+     order: red, green, blue, and alpha. Each channel is represented by
+     a uint8_t.
+
+   - Depth (ImageDepth32F) : the depth image has a depth channel represented
+     by a float. For a point in space `P`, the value stored in the depth
+     channel holds *the Z-component of the position vector `p_RP`.*
+     Note that this is different from the range data used by laser
+     range finders (like that provided by DepthSensor) in which the depth
+     value represents the distance from the sensor origin to the object's
+     surface.  */
+class RenderEngine : public ShapeReifier {
+ public:
+  RenderEngine() = default;
+
+  virtual ~RenderEngine() = default;
+
+  /** Clones the render engine -- making the RenderEngine compatible with
+   copyable_unique_ptr.  */
+  std::unique_ptr<RenderEngine> Clone() const;
+
+  /** Registers a shape specification and returns the optional index of the
+   corresponding render geometry. The geometry can be uniquely referenced in
+   this engine (and copies of this engine) by its geometry index. The renderer
+   is allowed to examine the given `properties` and choose to _not_ register
+   the geometry.
+
+   @param index          The geometry index of the shape to register.
+   @param shape          The shape specification to add to the render engine.
+   @param properties     The perception properties provided for this geometry.
+   @param X_WG           The pose of the geometry relative to the world frame W.
+   @param needs_updates  If true, the geometry's pose will be updated via
+                         UpdatePoses().
+   @returns A unique index for the resultant render geometry (nullopt if not
+            registered).
+   @throws std::runtime_error if the shape is an unsupported type.  */
+  optional<RenderIndex> RegisterVisual(
+      GeometryIndex index,
+      const Shape& shape, const PerceptionProperties& properties,
+      const math::RigidTransformd& X_WG, bool needs_updates = true);
+
+  /** Removes the geometry indicated by the given `index` from the engine.
+   It may move another geometry into that index value to maintain a contiguous
+   block of indices. If it does so, it returns the internal geometry index of
+   the geometry that got moved into the `index` position.
+   @param index  The _render_ index of the geometry to remove.
+   @returns The _geometry_ index of the geometry that _now_ maps to the _render_
+            `index` if the `index` was recycled.
+   @throws std::logic_error if the index is invalid.  */
+  optional<GeometryIndex> RemoveGeometry(RenderIndex index);
+
+  /** Updates the poses of all geometries marked as "needing update" (see
+ RegisterVisual()).
+
+ @param  X_WGs   The poses of *all* geometries in SceneGraph (measured and
+                 expressed in the world frame). The pose for a geometry is
+                 accessed by that geometry's GeometryIndex.  */
+  template <typename T>
+  void UpdatePoses(const std::vector<math::RigidTransform<T>>& X_WGs) {
+    for (auto pair : update_indices_) {
+      RenderIndex render_index = pair.first;
+      GeometryIndex geometry_index = pair.second;
+      DoUpdateVisualPose(render_index,
+                         geometry::internal::convert(X_WGs[geometry_index]));
+    }
+  }
+
+  /** Updates the renderer's viewpoint with given pose X_WR.
+
+   @param X_WR  The pose of renderer's viewpoint in the world coordinate
+                system.  */
+  virtual void UpdateViewpoint(const math::RigidTransformd& X_WR) const = 0;
+
+  /** Renders the registered geometry into the given color (rgb) image.
+
+   @param camera                The intrinsic properties of the camera.
+   @param show_window           If true, the render window will be displayed.
+   @param[out] color_image_out  The rendered color image.  */
+  virtual void RenderColorImage(
+      const CameraProperties& camera, bool show_window,
+      systems::sensors::ImageRgba8U* color_image_out) const = 0;
+
+  /** Renders the registered geometry into the given depth image. In contrast to
+   the other rendering operations, depth images don't have an option to display
+   the window; generally, basic depth images are not readily communicative to
+   humans.
+
+   @param camera                The intrinsic properties of the camera.
+   @param[out] depth_image_out  The rendered depth image.  */
+  virtual void RenderDepthImage(
+      const DepthCameraProperties& camera,
+      systems::sensors::ImageDepth32F* depth_image_out) const = 0;
+
+ protected:
+  // Allow derived classes to implement Cloning via copy-construction.
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(RenderEngine)
+
+  /** The NVI-function for sub-classes to implement actual geometry
+   registration. If the derived class chooses not to register this particular
+   shape, it should return nullopt.
+
+   A derived render engine can choose not to register geometry because, e.g., it
+   doesn't have default properties. This is the primary mechanism which enables
+   different renderers to use different geometries for the same frame.
+   For example, a low-fidelity renderer may use simple geometry whereas a
+   high-fidelity renderer would require a very detailed geometry. Both
+   geometries would have PerceptionProperties, but, based on the provided
+   property groups and values, one would be accepted and registered with one
+   render engine implementation and the other geometry with another render
+   engine.  */
+  virtual optional<RenderIndex> DoRegisterVisual(
+      const Shape& shape, const PerceptionProperties& properties,
+      const math::RigidTransformd& X_WG) = 0;
+
+  /** The NVI-function for updating the pose of a render geometry (identified
+   by index) to the given pose X_WG.
+
+   @param index    The index of the render geometry whose pose is being set.
+   @param X_WG     The pose of the render geometry in the world frame.  */
+  virtual void DoUpdateVisualPose(RenderIndex index,
+                                  const math::RigidTransformd& X_WG) = 0;
+
+  /** The NVI-function for removing the geometry at the given `index`. If the
+   implementation _moves_ another geometry into this slot, the pre-move index
+   for the moved geometry is returned.
+   @param index  The index of the geometry to remove.
+   @return  The original index of the geometry that got moved to `index`. It
+            must be the case that the return value is either nullopt _or_ it
+            must not be equal to `index`.  */
+  virtual optional<RenderIndex> DoRemoveGeometry(RenderIndex index) = 0;
+
+  /** The NVI-function for cloning this render engine.  */
+  virtual std::unique_ptr<RenderEngine> DoClone() const = 0;
+
+  friend class RenderEngineTester;
+
+ private:
+  // The following two maps store all registered render index values to the
+  // corresponding geometry's internal index. It should be the case that the
+  // keys of the two maps are disjoint and span all of the valid render index
+  // values (i.e., [0, number of actors - 1]).
+  // The mapping is generally necessary to facilitate updates and geometry
+  // removal.
+
+  // The mapping from render index to internal index for those geometries whose
+  // poses must be updated in UpdateVisualPose.
+  std::unordered_map<RenderIndex, GeometryIndex> update_indices_;
+
+  // The mapping from render index to internal index of all other geometries.
+  std::unordered_map<RenderIndex, GeometryIndex> anchored_indices_;
+};
+
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/test/render_engine_test.cc
+++ b/geometry/render/test/render_engine_test.cc
@@ -1,0 +1,330 @@
+#include "drake/geometry/render/render_engine.h"
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/drake_optional.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+
+using math::RigidTransformd;
+
+class RenderEngineTester {
+ public:
+  explicit RenderEngineTester(const RenderEngine* engine) : engine_(*engine) {}
+
+  const std::unordered_map<RenderIndex, GeometryIndex>& update_map() const {
+    return engine_.update_indices_;
+  }
+
+  const std::unordered_map<RenderIndex, GeometryIndex>& anchored_map() const {
+    return engine_.anchored_indices_;
+  }
+
+ private:
+  const RenderEngine& engine_;
+};
+
+namespace {
+
+// Dummy implementation of the RenderEngine interface to facilitate testing
+// the specific RenderEngine functionality.
+class DummyRenderEngine final : public RenderEngine {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DummyRenderEngine);
+  DummyRenderEngine() = default;
+  void UpdateViewpoint(const RigidTransformd&) const final {}
+  void RenderColorImage(const render::CameraProperties&, bool,
+                        systems::sensors::ImageRgba8U*) const final {}
+  void RenderDepthImage(const render::DepthCameraProperties&,
+                        systems::sensors::ImageDepth32F*) const final {}
+  void ImplementGeometry(const Sphere& sphere, void* user_data) final {}
+  void ImplementGeometry(const Cylinder& cylinder, void* user_data) final {}
+  void ImplementGeometry(const HalfSpace& half_space, void* user_data) final {}
+  void ImplementGeometry(const Box& box, void* user_data) final {}
+  void ImplementGeometry(const Mesh& mesh, void* user_data) final {}
+  void ImplementGeometry(const Convex& convex, void* user_data) final {}
+
+  // Test harness.
+
+  // Provide access to the group name that implies full registration.
+  const std::string& include_group_name() const { return include_group_name_; }
+
+  // Return the indices that have been updated via a call to UpdatePoses().
+  const std::map<RenderIndex, RigidTransformd>& updated_indices() const {
+    return updated_indices_;
+  }
+
+  // Utility to set what value DoRemoveGeometry() returns to facilitate testing.
+  void set_moved_index(optional<RenderIndex> index) {
+    moved_index_ = index;
+  }
+
+ protected:
+  // Conditionally register the visual based on the properties having an
+  // "in_test" group.
+  optional<RenderIndex> DoRegisterVisual(const Shape&,
+                                         const PerceptionProperties& properties,
+                                         const RigidTransformd&) final {
+    if (properties.HasGroup(include_group_name_)) {
+      return RenderIndex(register_count_++);
+    }
+    return nullopt;
+  }
+
+  // Track all of the indices provided an update pose for.
+  void DoUpdateVisualPose(RenderIndex index,
+                          const RigidTransformd& X_WG) final {
+    updated_indices_[index] = X_WG;
+  }
+
+  optional<RenderIndex> DoRemoveGeometry(RenderIndex index) final {
+    return moved_index_;
+  }
+
+  std::unique_ptr<render::RenderEngine> DoClone() const final {
+    return std::make_unique<DummyRenderEngine>(*this);
+  }
+
+ private:
+  int register_count_{};
+  // Track each index and what it has been updated to (allows us to confirm
+  // RenderIndex and GeometryIndex association.
+  std::map<RenderIndex, RigidTransformd> updated_indices_;
+  // The group name whose presence will lead to a shape being added to the
+  // engine.
+  std::string include_group_name_{"in_test"};
+  // The RenderIndex value to return on invocation of DoRemoveGeometry().
+  optional<RenderIndex> moved_index_;
+};
+
+// Tests the RenderEngine-specific functionality for managing registration of
+// geometry and its corresponding update behavior. The former should configure
+// each geometry correctly on whether it gets updated or not, and the latter
+// will confirm that the right geometries get updated.
+GTEST_TEST(RenderEngine, RegistrationAndUpdate) {
+  DummyRenderEngine engine;
+
+  // Configure parameters for registering visuals.
+  PerceptionProperties skip_properties;
+  PerceptionProperties add_properties;
+  add_properties.AddProperty(engine.include_group_name(), "ignored", 0);
+  Sphere sphere(1.0);
+  RigidTransformd X_WG = RigidTransformd::Identity();
+  // A collection of poses to provide to calls to UpdatePoses(). Configured
+  // to all identity transforms because the values generally don't matter. In
+  // the single case where it does matter, a value is explicitly set (see
+  // below).
+  std::vector<RigidTransformd> X_WG_all{3, X_WG};
+
+  // These test cases are accumulative; re-ordering them will require
+  // refactoring.
+
+  // Case: the shape is configured to be ignored by the render engine. Returns
+  // nullopt (and other arguments do not matter).
+  optional<RenderIndex> optional_index = engine.RegisterVisual(
+      GeometryIndex(0), sphere, skip_properties, X_WG, false);
+  EXPECT_FALSE(optional_index);
+  optional_index = engine.RegisterVisual(GeometryIndex(0), sphere,
+                                         skip_properties, X_WG, true);
+  EXPECT_FALSE(optional_index);
+  // Confirm nothing is updated - because nothing is registered.
+  engine.UpdatePoses(X_WG_all);
+  EXPECT_EQ(engine.updated_indices().size(), 0);
+
+  // Case: the shape is configured for registration, but does *not* require
+  // updating. We get a valid render index, but it is _not_ included in
+  // UpdatePoses().
+  optional_index = engine.RegisterVisual(GeometryIndex(1), sphere,
+                                         add_properties, X_WG, false);
+  EXPECT_TRUE(optional_index);
+  engine.UpdatePoses(X_WG_all);
+  EXPECT_EQ(engine.updated_indices().size(), 0);
+
+  // Case: the shape is configured for registration *and* requires updating. We
+  // get a valid render index and it _is_ included in UpdatePoses().
+  GeometryIndex update_index{2};
+  // Configure the pose for index 2 to *not* be the identity so we can confirm
+  // that the registered GeometryIndex is properly associated with the resulting
+  // RenderIndex.
+  const Vector3<double> p_WG(1, 2, 3);
+  X_WG_all[update_index].set_translation(p_WG);
+  optional_index =
+      engine.RegisterVisual(update_index, sphere, add_properties, X_WG, true);
+  EXPECT_TRUE(optional_index);
+  engine.UpdatePoses(X_WG_all);
+  EXPECT_EQ(engine.updated_indices().size(), 1);
+  ASSERT_EQ(engine.updated_indices().count(*optional_index), 1);
+  EXPECT_TRUE(CompareMatrices(
+      engine.updated_indices().at(*optional_index).translation(), p_WG));
+}
+
+// Tests the removal of geometry from the renderer -- confirms that the
+// RenderEngine is
+//   a) Reporting the correct geometry index for the removed geometry and
+//   b) Updating the remaining RenderIndex -> GeometryIndex pairs correctly.
+GTEST_TEST(RenderEngine, RemoveGeometry) {
+  const int need_update_count = 3;
+  const int anchored_count = 2;
+  std::vector<GeometryIndex> render_index_to_geometry_index;
+  // Configure a clean render engine so each test is independent. Specifically,
+  // It creates three dynamic geometries and two anchored. The initial render
+  // index and geometry index matches for each geometry. Conceptually, we'll
+  // have two maps:
+  //  dynamic map: {{0, 0}, {1, 1}, {2, 2}}
+  //  anchored map: {{3, 3}, {4, 4}}
+  // Ultimately, we'll examine the the maps after removing geometry to confirm
+  // the state of the mappings as a perturbation from this initial condition.
+  auto make_engine = [&render_index_to_geometry_index]() -> DummyRenderEngine {
+    render_index_to_geometry_index.clear();
+    DummyRenderEngine engine;
+    // A set of properties that will cause a shape to be properly registered.
+    PerceptionProperties add_properties;
+    add_properties.AddProperty(engine.include_group_name(), "ignored", 0);
+    RigidTransformd X_WG = RigidTransformd::Identity();
+    Sphere sphere(1.0);
+
+    for (int i = 0; i < need_update_count + anchored_count; ++i) {
+      const GeometryIndex geometry_index = GeometryIndex(i);
+      optional<RenderIndex> render_index = engine.RegisterVisual(
+          geometry_index, sphere, add_properties, X_WG, i < need_update_count);
+      if (!render_index || *render_index != i) {
+        throw std::logic_error("Unexpected render indices");
+      }
+      render_index_to_geometry_index.push_back(geometry_index);
+    }
+    return engine;
+  };
+
+  // Function for performing the removal and testing the results.
+  auto expect_removal =
+      [make_engine](RenderIndex remove_index, optional<RenderIndex> move_index,
+         optional<GeometryIndex> expected_moved,
+         std::initializer_list<std::pair<int, int>> dynamic_map,
+         std::initializer_list<std::pair<int, int>> anchored_map,
+         const char* case_description) {
+        DummyRenderEngine engine = make_engine();
+        engine.set_moved_index(move_index);
+        optional<GeometryIndex> moved_index =
+            engine.RemoveGeometry(remove_index);
+        EXPECT_EQ(moved_index, expected_moved) << case_description;
+        RenderEngineTester tester(&engine);
+        EXPECT_EQ(tester.update_map().size(), dynamic_map.size())
+            << case_description;
+        for (const auto& pair : dynamic_map) {
+          EXPECT_EQ(tester.update_map().at(RenderIndex(pair.first)),
+                    GeometryIndex(pair.second))
+              << case_description;
+        }
+        EXPECT_EQ(tester.anchored_map().size(), anchored_map.size())
+            << case_description;
+        for (const auto& pair : anchored_map) {
+          EXPECT_EQ(tester.anchored_map().at(RenderIndex(pair.first)),
+                    GeometryIndex(pair.second))
+              << case_description;
+        }
+      };
+
+  using IndexMap = std::initializer_list<std::pair<int, int>>;
+
+  // Case 1: remove dynamic geometry where nothing gets moved. Specifically,
+  // remove the geometry (2, 2) with nothing else changing.
+  {
+    const RenderIndex remove_index(need_update_count - 1);
+    optional<RenderIndex> moved_render_index = nullopt;
+    optional<GeometryIndex> moved_geometry_index = nullopt;
+    // Note: loss of need_update_count - 1 (i.e., 2) from the dynamic map.
+    IndexMap expected_dynamic_map = {{0, 0}, {1, 1}};
+    IndexMap expected_anchored_map = {{3, 3}, {4, 4}};
+    expect_removal(remove_index, moved_render_index, moved_geometry_index,
+                   expected_dynamic_map, expected_anchored_map, "case 1");
+  }
+
+  // Case 2: remove dynamic geometry where dynamic geometry gets moved.
+  // Specifically, we have three dynamic geometries (0, 1, 2). We remove
+  // geometry 1 and 2 gets moved into its slot.
+  {
+    const RenderIndex remove_index(1);
+    const int move_value = 2;
+    optional<RenderIndex> moved_render_index = RenderIndex(move_value);
+    optional<GeometryIndex> moved_geometry_index = GeometryIndex(move_value);
+    // Note: loss (1, 1) and (2, 2) gets moved to (1, 2) in the dynamic map.
+    IndexMap expected_dynamic_map = {{0, 0}, {1, 2}};
+    IndexMap expected_anchored_map = {{3, 3}, {4, 4}};
+    expect_removal(remove_index, moved_render_index, moved_geometry_index,
+                   expected_dynamic_map, expected_anchored_map, "case 2");
+  }
+
+  // Case 3: remove dynamic geometry where anchored geometry gets moved.
+  // Specifically, remove the last dynamic geometry (2, 2), and move the last
+  // anchored geometry (4, 4) into its slot.
+  {
+    const RenderIndex remove_index(2);
+    const int move_value = 4;
+    optional<RenderIndex> moved_render_index = RenderIndex(move_value);
+    optional<GeometryIndex> moved_geometry_index = GeometryIndex(move_value);
+    // Note: loss of (2, 2) from the dynamic map.
+    IndexMap expected_dynamic_map = {{0, 0}, {1, 1}};
+    // Note: (4, 4) gets moved to use the removed render index (2). So,
+    // (4, 4) becomes (2, 4).
+    IndexMap expected_anchored_map = {{3, 3}, {2, 4}};
+    expect_removal(remove_index, moved_render_index, moved_geometry_index,
+                   expected_dynamic_map, expected_anchored_map, "case 3");
+  }
+
+  // Case 4: remove anchored geometry where nothing gets moved.
+  {
+    const RenderIndex remove_index(4);
+    optional<RenderIndex> moved_render_index = nullopt;
+    optional<GeometryIndex> moved_geometry_index = nullopt;
+    // Dynamic map untouched.
+    IndexMap expected_dynamic_map = {{0, 0}, {1, 1}, {2, 2}};
+    // Geometry (4, 4) has been removed.
+    IndexMap expected_anchored_map = {{3, 3}};
+    expect_removal(remove_index, moved_render_index, moved_geometry_index,
+                   expected_dynamic_map, expected_anchored_map, "case 4");
+  }
+
+  // Case 5: remove anchored geometry where dynamic geometry gets moved.
+  // Specifically, remove the _last_ anchored geometry (4, 4) and move the
+  // last dynamic geometry (2, 2) into that slot to become (2, 4).
+  {
+    const RenderIndex remove_index(4);
+    const int move_value = 2;
+    optional<RenderIndex> moved_render_index = RenderIndex(move_value);
+    optional<GeometryIndex> moved_geometry_index = GeometryIndex(move_value);
+    // Note: (2, 2) has been moved into the remove index (4, 2).
+    IndexMap expected_dynamic_map = {{0, 0}, {1, 1}, {4, 2}};
+    // Note: (4, 4) has been removed
+    IndexMap expected_anchored_map = {{3, 3}};
+    expect_removal(remove_index, moved_render_index, moved_geometry_index,
+                   expected_dynamic_map, expected_anchored_map, "case 5");
+  }
+
+  // Case 6: remove anchored geometry where anchored geometry gets moved.
+  // We have two anchored geometries: (3, 3) and (4, 4). Remove (3, 3) and move
+  // (4, 4) into its place (3, 4).
+  {
+    const RenderIndex remove_index(3);
+    const int move_value = 4;
+    optional<RenderIndex> moved_render_index = RenderIndex(move_value);
+    optional<GeometryIndex> moved_geometry_index = GeometryIndex(move_value);
+    // Note: Dynamic is untouched.
+    IndexMap expected_dynamic_map = {{0, 0}, {1, 1}, {2, 2}};
+    // Note: Remove (3, 3) and move (4, 4) into position 3: (3, 4).
+    IndexMap expected_anchored_map = {{3, 4}};
+    expect_removal(remove_index, moved_render_index, moved_geometry_index,
+                   expected_dynamic_map, expected_anchored_map, "case 6");
+  }
+}
+
+}  // namespace
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/utilities.h
+++ b/geometry/utilities.h
@@ -7,6 +7,7 @@
 #include "drake/common/autodiff_overloads.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
+#include "drake/math/rigid_transform.h"
 
 namespace drake {
 namespace geometry {
@@ -80,6 +81,25 @@ Isometry3<double> convert(
     }
   }
   return result;
+}
+
+// Don't needlessly copy transforms that are already scalar-valued.
+inline const math::RigidTransformd& convert(const math::RigidTransformd& X_AB) {
+  return X_AB;
+}
+
+template <class VectorType>
+math::RigidTransformd convert(
+    const math::RigidTransform<Eigen::AutoDiffScalar<VectorType>>& X_AB) {
+  Matrix3<double> R_converted;
+  Vector3<double> p_converted;
+  for (int r = 0; r < 3; ++r) {
+    p_converted(r) = ExtractDoubleOrThrow(X_AB.translation()(r));
+    for (int c = 0; c < 3; ++c) {
+      R_converted(r, c) = ExtractDoubleOrThrow(X_AB.rotation().matrix()(r, c));
+    }
+  }
+  return math::RigidTransformd(math::RotationMatrixd(R_converted), p_converted);
 }
 
 //@}


### PR DESCRIPTION
The RenderEngine is the common base-class for all perception-role renderers. It provides some core functionality for interacting with the GeometryState (supported by NVI methods).

The interface of the RenderEngine should largely mirror that of the older RgbdRenderer interface.

This commit excludes the *label* images so that it can be reviewed in parallel with the RenderLabel PR. Once both have landed, the label image will be included in the RenderEngine interface.

```
Category            added  modified  removed  
----------------------------------------------
code                356    0         0        
comments            188    0         0        
blank               80     0         0        
----------------------------------------------
TOTAL               624    0         0 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11216)
<!-- Reviewable:end -->
