### PR TITLE
Extend Maliput pydrake bindings for id based lookups

### DIFF
--- a/bindings/pydrake/maliput/api_py.cc
+++ b/bindings/pydrake/maliput/api_py.cc
@@ -68,16 +68,17 @@ PYBIND11_MODULE(api, m) {
           doc.RoadGeometry.num_junctions.doc)
       .def("junction", &RoadGeometry::junction, py_reference_internal,
           doc.RoadGeometry.junction.doc)
-      .def("by_id", [](const RoadGeometry* self) { return &self->ById(); },
-          py_reference_internal, doc.RoadGeometry.ById.doc);
+      .def("ById", &RoadGeometry::ById, py_reference_internal,
+          doc.RoadGeometry.ById.doc);
 
   py::class_<RoadGeometry::IdIndex>(
       m, "RoadGeometry.IdIndex", doc.RoadGeometry.IdIndex.doc)
-      .def("get_lane",
+      .def("GetLane",
           [](const RoadGeometry::IdIndex* self, const std::string& id) {
             return self->GetLane(LaneId(id));
           },
-          py_reference_internal, doc.RoadGeometry.IdIndex.GetLane.doc);
+          py::arg("id"), py_reference_internal,
+          doc.RoadGeometry.IdIndex.GetLane.doc);
 
   py::class_<Junction>(m, "Junction", doc.Junction.doc)
       .def("num_segments", &Junction::num_segments,

--- a/bindings/pydrake/maliput/api_py.cc
+++ b/bindings/pydrake/maliput/api_py.cc
@@ -67,7 +67,17 @@ PYBIND11_MODULE(api, m) {
       .def("num_junctions", &RoadGeometry::num_junctions,
           doc.RoadGeometry.num_junctions.doc)
       .def("junction", &RoadGeometry::junction, py_reference_internal,
-          doc.RoadGeometry.junction.doc);
+          doc.RoadGeometry.junction.doc)
+      .def("by_id", [](const RoadGeometry* self) { return &self->ById(); },
+          py_reference_internal, doc.RoadGeometry.ById.doc);
+
+  py::class_<RoadGeometry::IdIndex>(
+      m, "RoadGeometry.IdIndex", doc.RoadGeometry.IdIndex.doc)
+      .def("get_lane",
+          [](const RoadGeometry::IdIndex* self, const std::string& id) {
+            return self->GetLane(LaneId(id));
+          },
+          py_reference_internal, doc.RoadGeometry.IdIndex.GetLane.doc);
 
   py::class_<Junction>(m, "Junction", doc.Junction.doc)
       .def("num_segments", &Junction::num_segments,


### PR DESCRIPTION
This pull request adds pydrake bindings for:

- `maliput::api::RoadGeometry::ById()` method
- `maliput::api::RoadGeometry::IdIndex` class
- `maliput::api::RoadGeometry::IdIndex::GetLane` method

while it avoids to bind type specific identifiers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11233)
<!-- Reviewable:end -->
