### PR TITLE
drakelint: Report missing EOF more directly

### DIFF
--- a/tools/lint/drakelint.py
+++ b/tools/lint/drakelint.py
@@ -37,7 +37,11 @@ def _check_invalid_line_endings(filename):
 
 def _check_includes(filename):
     """Return 0 if clang-format-includes is a no-op, and 1 otherwise."""
-    tool = IncludeFormatter(filename)
+    try:
+        tool = IncludeFormatter(filename)
+    except Exception as e:
+        print("ERROR: " + filename + ":0: " + e.message)
+        return 1
     tool.format_includes()
     first_difference = tool.get_first_differing_original_index()
     if first_difference is not None:

--- a/tools/lint/formatter.py
+++ b/tools/lint/formatter.py
@@ -45,9 +45,11 @@ class FormatterBase(object):
         else:
             self._original_lines = [unicode(line) for line in readlines]
         self._working_lines = list(self._original_lines)
-        self._check_rep()
         if any(["\r" in line for line in self._working_lines]):
             raise Exception("DOS newlines are not supported")
+        if not self._working_lines[-1].endswith("\n"):
+            raise Exception("Missing newline character at end of file")
+        self._check_rep()
 
     def _check_rep(self):
         assert self._filename

--- a/tools/lint/test/formatter_test.py
+++ b/tools/lint/test/formatter_test.py
@@ -65,6 +65,13 @@ class TestFormatterBase(unittest.TestCase):
         with self.assertRaisesRegexp(Exception, "DOS newline"):
             FormatterBase("filename.cc", readlines=original_lines)
 
+    def test_missing_eof(self):
+        original_lines = [
+            '#include "line0"',
+        ]
+        with self.assertRaisesRegexp(Exception, "newline.*end of file"):
+            FormatterBase("filename.cc", readlines=original_lines)
+
 
 class TestIncludeFormatter(unittest.TestCase):
 


### PR DESCRIPTION
Closes #11231.

(This was actually hard to reproduce.  Literally no text editor installed on my system allows me to save a file with no EOF.  I had to break out a hex editor.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11235)
<!-- Reviewable:end -->
