### PR TITLE
pydrake doc: Add example of using scoped aliases for abbreviation

### DIFF
--- a/bindings/pydrake/attic/multibody/rigid_body_plant_py.cc
+++ b/bindings/pydrake/attic/multibody/rigid_body_plant_py.cc
@@ -30,8 +30,8 @@ PYBIND11_MODULE(rigid_body_plant, m) {
 
   {
     using Class = CompliantContactModelParameters;
-    py::class_<Class> cls(m, "CompliantContactModelParameters",
-        doc.CompliantContactModelParameters.doc);
+    constexpr auto& cls_doc = doc.CompliantContactModelParameters;
+    py::class_<Class> cls(m, "CompliantContactModelParameters", cls_doc.doc);
     cls  // BR
         .def(
             // Implicit constructor does not have documentation.
@@ -43,9 +43,9 @@ PYBIND11_MODULE(rigid_body_plant, m) {
             py::arg("characteristic_radius") =
                 Class::kDefaultCharacteristicRadius)
         .def_readwrite("v_stiction_tolerance", &Class::v_stiction_tolerance,
-            doc.CompliantContactModelParameters.v_stiction_tolerance.doc)
+            cls_doc.v_stiction_tolerance.doc)
         .def_readwrite("characteristic_radius", &Class::characteristic_radius,
-            doc.CompliantContactModelParameters.characteristic_radius.doc);
+            cls_doc.characteristic_radius.doc);
     cls.attr("kDefaultVStictionTolerance") = Class::kDefaultVStictionTolerance;
     cls.attr("kDefaultCharacteristicRadius") =
         Class::kDefaultCharacteristicRadius;
@@ -53,110 +53,111 @@ PYBIND11_MODULE(rigid_body_plant, m) {
 
   {
     using Class = ContactInfo<T>;
-    py::class_<Class> cls(m, "ContactInfo", doc.ContactInfo.doc);
+    constexpr auto& cls_doc = doc.ContactInfo;
+    py::class_<Class> cls(m, "ContactInfo", cls_doc.doc);
     cls  // BR
         .def("get_element_id_1", &Class::get_element_id_1,
-            doc.ContactInfo.get_element_id_1.doc)
+            cls_doc.get_element_id_1.doc)
         .def("get_element_id_2", &Class::get_element_id_2,
-            doc.ContactInfo.get_element_id_2.doc)
+            cls_doc.get_element_id_2.doc)
         .def("get_resultant_force", &Class::get_resultant_force,
-            py_reference_internal, doc.ContactInfo.get_resultant_force.doc);
+            py_reference_internal, cls_doc.get_resultant_force.doc);
   }
 
   {
     using Class = ContactForce<T>;
-    py::class_<Class> cls(m, "ContactForce", doc.ContactForce.doc);
+    constexpr auto& cls_doc = doc.ContactForce;
+    py::class_<Class> cls(m, "ContactForce", cls_doc.doc);
     cls  // BR
         .def(py::init<const Vector3<T>&, const Vector3<T>&, const Vector3<T>&,
                  const Vector3<T>&>(),
             py::arg("application_point"), py::arg("normal"), py::arg("force"),
-            py::arg("torque") = Vector3<T>::Zero(),
-            doc.ContactForce.ctor.doc_4args)
+            py::arg("torque") = Vector3<T>::Zero(), cls_doc.ctor.doc_4args)
         .def("get_reaction_force", &Class::get_reaction_force,
-            doc.ContactForce.get_reaction_force.doc)
+            cls_doc.get_reaction_force.doc)
         .def("get_application_point", &Class::get_application_point,
-            doc.ContactForce.get_application_point.doc)
-        .def("get_force", &Class::get_force, doc.ContactForce.get_force.doc)
+            cls_doc.get_application_point.doc)
+        .def("get_force", &Class::get_force, cls_doc.get_force.doc)
         .def("get_normal_force", &Class::get_normal_force,
-            doc.ContactForce.get_normal_force.doc)
+            cls_doc.get_normal_force.doc)
         .def("get_tangent_force", &Class::get_tangent_force,
-            doc.ContactForce.get_tangent_force.doc)
-        .def("get_torque", &Class::get_torque, doc.ContactForce.get_torque.doc)
-        .def("get_normal", &Class::get_normal, doc.ContactForce.get_normal.doc);
+            cls_doc.get_tangent_force.doc)
+        .def("get_torque", &Class::get_torque, cls_doc.get_torque.doc)
+        .def("get_normal", &Class::get_normal, cls_doc.get_normal.doc);
   }
 
   {
     using Class = ContactResults<T>;
-    py::class_<Class> cls(m, "ContactResults", doc.ContactResults.doc);
+    constexpr auto& cls_doc = doc.ContactResults;
+    py::class_<Class> cls(m, "ContactResults", cls_doc.doc);
     cls  // BR
-        .def(py::init<>(), doc.ContactResults.ctor.doc)
+        .def(py::init<>(), cls_doc.ctor.doc)
         .def("get_num_contacts", &Class::get_num_contacts,
-            doc.ContactResults.get_num_contacts.doc)
+            cls_doc.get_num_contacts.doc)
         .def("get_contact_info", &Class::get_contact_info,
-            py_reference_internal, doc.ContactResults.get_contact_info.doc)
+            py_reference_internal, cls_doc.get_contact_info.doc)
         .def("set_generalized_contact_force",
             [](Class* self, const Eigen::VectorXd& f) {
               self->set_generalized_contact_force(f);
             },
-            doc.ContactResults.set_generalized_contact_force.doc)
+            cls_doc.set_generalized_contact_force.doc)
         .def("get_generalized_contact_force",
             &Class::get_generalized_contact_force, py_reference_internal,
-            doc.ContactResults.get_generalized_contact_force.doc)
+            cls_doc.get_generalized_contact_force.doc)
         .def("AddContact", &Class::AddContact, py_reference_internal,
-            py::arg("element_a"), py::arg("element_b"),
-            doc.ContactResults.AddContact.doc)
-        .def("Clear", &Class::Clear, doc.ContactResults.Clear.doc);
+            py::arg("element_a"), py::arg("element_b"), cls_doc.AddContact.doc)
+        .def("Clear", &Class::Clear, cls_doc.Clear.doc);
     pysystems::AddValueInstantiation<Class>(m);
   }
 
   {
     using Class = CompliantMaterial;
-    py::class_<Class> cls(m, "CompliantMaterial", doc.CompliantMaterial.doc);
+    constexpr auto& cls_doc = doc.CompliantMaterial;
+    py::class_<Class> cls(m, "CompliantMaterial", cls_doc.doc);
     cls  // BR
-        .def(py::init<>(), doc.CompliantMaterial.ctor.doc_0args)
+        .def(py::init<>(), cls_doc.ctor.doc_0args)
         .def(py::init<double, double, double, double>(),
             py::arg("youngs_modulus"), py::arg("dissipation"),
             py::arg("static_friction"), py::arg("dynamic_friction"),
-            doc.CompliantMaterial.ctor.doc_4args)
+            cls_doc.ctor.doc_4args)
         // youngs_modulus
         .def("set_youngs_modulus", &Class::set_youngs_modulus, py_reference,
-            doc.CompliantMaterial.set_youngs_modulus.doc)
+            cls_doc.set_youngs_modulus.doc)
         .def("youngs_modulus", &Class::youngs_modulus,
             py::arg("default_value") = Class::kDefaultYoungsModulus,
-            doc.CompliantMaterial.youngs_modulus.doc)
+            cls_doc.youngs_modulus.doc)
         .def("youngs_modulus_is_default", &Class::youngs_modulus_is_default,
-            doc.CompliantMaterial.youngs_modulus_is_default.doc)
+            cls_doc.youngs_modulus_is_default.doc)
         .def("set_youngs_modulus_to_default",
             &Class::set_youngs_modulus_to_default,
-            doc.CompliantMaterial.set_youngs_modulus_to_default.doc)
+            cls_doc.set_youngs_modulus_to_default.doc)
         // dissipation
         .def("set_dissipation", &Class::set_dissipation, py_reference,
-            doc.CompliantMaterial.set_dissipation.doc)
+            cls_doc.set_dissipation.doc)
         .def("dissipation", &Class::dissipation,
             py::arg("default_value") = Class::kDefaultDissipation,
-            doc.CompliantMaterial.dissipation.doc)
+            cls_doc.dissipation.doc)
         .def("dissipation_is_default", &Class::dissipation_is_default,
-            doc.CompliantMaterial.dissipation_is_default.doc)
+            cls_doc.dissipation_is_default.doc)
         .def("set_dissipation_to_default", &Class::set_dissipation_to_default,
-            doc.CompliantMaterial.set_dissipation_to_default.doc)
+            cls_doc.set_dissipation_to_default.doc)
         // friction
         .def("set_friction", py::overload_cast<double>(&Class::set_friction),
-            py::arg("value"), py_reference,
-            doc.CompliantMaterial.set_friction.doc_1args)
+            py::arg("value"), py_reference, cls_doc.set_friction.doc_1args)
         .def("set_friction",
             py::overload_cast<double, double>(&Class::set_friction),
             py::arg("static_friction"), py::arg("dynamic_friction"),
-            py_reference, doc.CompliantMaterial.set_friction.doc_2args)
+            py_reference, cls_doc.set_friction.doc_2args)
         .def("static_friction", &Class::static_friction,
             py::arg("default_value") = Class::kDefaultStaticFriction,
-            doc.CompliantMaterial.static_friction.doc)
+            cls_doc.static_friction.doc)
         .def("dynamic_friction", &Class::dynamic_friction,
             py::arg("default_value") = Class::kDefaultDynamicFriction,
-            doc.CompliantMaterial.dynamic_friction.doc)
+            cls_doc.dynamic_friction.doc)
         .def("friction_is_default", &Class::friction_is_default,
-            doc.CompliantMaterial.friction_is_default.doc)
+            cls_doc.friction_is_default.doc)
         .def("set_friction_to_default", &Class::set_friction_to_default,
-            doc.CompliantMaterial.set_friction_to_default.doc);
+            cls_doc.set_friction_to_default.doc);
     cls.attr("kDefaultYoungsModulus") = Class::kDefaultYoungsModulus;
     cls.attr("kDefaultDissipation") = Class::kDefaultDissipation;
     cls.attr("kDefaultStaticFriction") = Class::kDefaultStaticFriction;
@@ -165,98 +166,93 @@ PYBIND11_MODULE(rigid_body_plant, m) {
 
   {
     using Class = RigidBodyPlant<T>;
+    constexpr auto& cls_doc = doc.RigidBodyPlant;
     // Defined in order of declaration in `rigid_body_plant.h`.
-    py::class_<Class, LeafSystem<T>>(
-        m, "RigidBodyPlant", doc.RigidBodyPlant.doc)
+    py::class_<Class, LeafSystem<T>>(m, "RigidBodyPlant", cls_doc.doc)
         .def(py::init<unique_ptr<const RigidBodyTree<T>>, double>(),
-            py::arg("tree"), py::arg("timestep") = 0.0,
-            doc.RigidBodyPlant.ctor.doc)
+            py::arg("tree"), py::arg("timestep") = 0.0, cls_doc.ctor.doc)
         .def("set_contact_model_parameters",
             &Class::set_contact_model_parameters,
-            doc.RigidBodyPlant.set_contact_model_parameters.doc)
+            cls_doc.set_contact_model_parameters.doc)
         .def("set_default_compliant_material",
             &Class::set_default_compliant_material,
-            doc.RigidBodyPlant.set_default_compliant_material.doc)
+            cls_doc.set_default_compliant_material.doc)
         .def("get_rigid_body_tree", &Class::get_rigid_body_tree,
-            py_reference_internal, doc.RigidBodyPlant.get_rigid_body_tree.doc)
+            py_reference_internal, cls_doc.get_rigid_body_tree.doc)
         .def("get_num_bodies", &Class::get_num_bodies,
-            doc.RigidBodyPlant.get_num_bodies.doc)
+            cls_doc.get_num_bodies.doc)
         .def("get_num_positions",
             overload_cast_explicit<int>(&Class::get_num_positions),
-            doc.RigidBodyPlant.get_num_positions.doc_0args)
+            cls_doc.get_num_positions.doc_0args)
         .def("get_num_positions",
             overload_cast_explicit<int, int>(&Class::get_num_positions),
-            doc.RigidBodyPlant.get_num_positions.doc_1args)
+            cls_doc.get_num_positions.doc_1args)
         .def("get_num_velocities",
             overload_cast_explicit<int>(&Class::get_num_velocities),
-            doc.RigidBodyPlant.get_num_velocities.doc_0args)
+            cls_doc.get_num_velocities.doc_0args)
         .def("get_num_velocities",
             overload_cast_explicit<int, int>(&Class::get_num_velocities),
-            doc.RigidBodyPlant.get_num_velocities.doc_1args)
+            cls_doc.get_num_velocities.doc_1args)
         .def("get_num_states",
             overload_cast_explicit<int>(&Class::get_num_states),
-            doc.RigidBodyPlant.get_num_states.doc_0args)
+            cls_doc.get_num_states.doc_0args)
         .def("get_num_states",
             overload_cast_explicit<int, int>(&Class::get_num_states),
-            doc.RigidBodyPlant.get_num_states.doc_1args)
+            cls_doc.get_num_states.doc_1args)
         .def("get_num_actuators",
             overload_cast_explicit<int>(&Class::get_num_actuators),
-            doc.RigidBodyPlant.get_num_actuators.doc_0args)
+            cls_doc.get_num_actuators.doc_0args)
         .def("get_num_actuators",
             overload_cast_explicit<int, int>(&Class::get_num_actuators),
-            doc.RigidBodyPlant.get_num_actuators.doc_1args)
+            cls_doc.get_num_actuators.doc_1args)
         .def("get_num_model_instances", &Class::get_num_model_instances,
-            doc.RigidBodyPlant.get_num_model_instances.doc)
+            cls_doc.get_num_model_instances.doc)
         .def("get_input_size", &Class::get_input_size,
-            doc.RigidBodyPlant.get_input_size.doc)
+            cls_doc.get_input_size.doc)
         .def("get_output_size", &Class::get_output_size,
-            doc.RigidBodyPlant.get_output_size.doc)
-        .def("set_position", &Class::set_position,
-            doc.RigidBodyPlant.set_position.doc)
-        .def("set_velocity", &Class::set_velocity,
-            doc.RigidBodyPlant.set_velocity.doc)
+            cls_doc.get_output_size.doc)
+        .def("set_position", &Class::set_position, cls_doc.set_position.doc)
+        .def("set_velocity", &Class::set_velocity, cls_doc.set_velocity.doc)
         .def("set_state_vector",
             overload_cast_explicit<void, Context<T>*,
                 const Eigen::Ref<const VectorX<T>>>(&Class::set_state_vector),
-            doc.RigidBodyPlant.set_state_vector.doc)
+            cls_doc.set_state_vector.doc)
         .def("set_state_vector",
             overload_cast_explicit<void, State<T>*,
                 const Eigen::Ref<const VectorX<T>>>(&Class::set_state_vector),
-            doc.RigidBodyPlant.set_state_vector.doc)
+            cls_doc.set_state_vector.doc)
         .def("SetDefaultState", &Class::SetDefaultState,
-            doc.RigidBodyPlant.SetDefaultState.doc)
+            cls_doc.SetDefaultState.doc)
         .def("FindInstancePositionIndexFromWorldIndex",
             &Class::FindInstancePositionIndexFromWorldIndex,
-            doc.RigidBodyPlant.FindInstancePositionIndexFromWorldIndex.doc)
+            cls_doc.FindInstancePositionIndexFromWorldIndex.doc)
         .def("actuator_command_input_port", &Class::actuator_command_input_port,
-            py_reference_internal,
-            doc.RigidBodyPlant.actuator_command_input_port.doc)
+            py_reference_internal, cls_doc.actuator_command_input_port.doc)
         .def("model_instance_has_actuators",
             &Class::model_instance_has_actuators,
-            doc.RigidBodyPlant.model_instance_has_actuators.doc)
+            cls_doc.model_instance_has_actuators.doc)
         .def("model_instance_actuator_command_input_port",
             &Class::model_instance_actuator_command_input_port,
             py_reference_internal,
-            doc.RigidBodyPlant.model_instance_actuator_command_input_port.doc)
+            cls_doc.model_instance_actuator_command_input_port.doc)
         .def("state_output_port", &Class::state_output_port,
-            py_reference_internal, doc.RigidBodyPlant.state_output_port.doc)
+            py_reference_internal, cls_doc.state_output_port.doc)
         .def("state_derivative_output_port",
             &Class::state_derivative_output_port, py_reference_internal,
-            doc.RigidBodyPlant.state_derivative_output_port.doc)
+            cls_doc.state_derivative_output_port.doc)
         .def("model_instance_state_output_port",
             &Class::model_instance_state_output_port, py_reference_internal,
-            doc.RigidBodyPlant.model_instance_state_output_port.doc)
+            cls_doc.model_instance_state_output_port.doc)
         .def("torque_output_port", &Class::torque_output_port,
-            py_reference_internal, doc.RigidBodyPlant.torque_output_port.doc)
+            py_reference_internal, cls_doc.torque_output_port.doc)
         .def("model_instance_torque_output_port",
             &Class::model_instance_torque_output_port, py_reference_internal,
-            doc.RigidBodyPlant.model_instance_torque_output_port.doc)
+            cls_doc.model_instance_torque_output_port.doc)
         .def("kinematics_results_output_port",
             &Class::kinematics_results_output_port, py_reference_internal,
-            doc.RigidBodyPlant.kinematics_results_output_port.doc)
+            cls_doc.kinematics_results_output_port.doc)
         .def("contact_results_output_port", &Class::contact_results_output_port,
-            py_reference_internal,
-            doc.RigidBodyPlant.contact_results_output_port.doc)
+            py_reference_internal, cls_doc.contact_results_output_port.doc)
         .def("GetStateVector",
             [](const Class* self,
                 const Context<T>& context) -> Eigen::Ref<const VectorX<T>> {
@@ -264,29 +260,28 @@ PYBIND11_MODULE(rigid_body_plant, m) {
             },
             py_reference,
             // Keep alive, ownership: `return` keeps `Context` alive.
-            py::keep_alive<0, 2>(), doc.RigidBodyPlant.GetStateVector.doc)
+            py::keep_alive<0, 2>(), cls_doc.GetStateVector.doc)
         .def("is_state_discrete", &Class::is_state_discrete,
-            doc.RigidBodyPlant.is_state_discrete.doc)
-        .def("get_time_step", &Class::get_time_step,
-            doc.RigidBodyPlant.get_time_step.doc);
+            cls_doc.is_state_discrete.doc)
+        .def("get_time_step", &Class::get_time_step, cls_doc.get_time_step.doc);
   }
 
   {
     using Class = DrakeVisualizer;
-    py::class_<Class, LeafSystem<T>>(
-        m, "DrakeVisualizer", doc.DrakeVisualizer.doc)
+    constexpr auto& cls_doc = doc.DrakeVisualizer;
+    py::class_<Class, LeafSystem<T>>(m, "DrakeVisualizer", cls_doc.doc)
         .def(py::init<const RigidBodyTree<T>&, DrakeLcmInterface*, bool>(),
             py::arg("tree"), py::arg("lcm"), py::arg("enable_playback") = false,
             // Keep alive, reference: `this` keeps `tree` alive.
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `this` keeps `lcm` alive.
-            py::keep_alive<1, 3>(), doc.DrakeVisualizer.ctor.doc)
+            py::keep_alive<1, 3>(), cls_doc.ctor.doc)
         .def("set_publish_period", &Class::set_publish_period,
-            py::arg("period"), doc.DrakeVisualizer.set_publish_period.doc)
+            py::arg("period"), cls_doc.set_publish_period.doc)
         .def("ReplayCachedSimulation", &Class::ReplayCachedSimulation,
-            doc.DrakeVisualizer.ReplayCachedSimulation.doc)
+            cls_doc.ReplayCachedSimulation.doc)
         .def("PublishLoadRobot", &Class::PublishLoadRobot,
-            doc.DrakeVisualizer.PublishLoadRobot.doc);
+            cls_doc.PublishLoadRobot.doc);
     // TODO(eric.cousineau): Bind `PlaybackTrajectory` when
     // `PiecewisePolynomial` has bindings.
   }

--- a/bindings/pydrake/lcm_py.cc
+++ b/bindings/pydrake/lcm_py.cc
@@ -26,8 +26,8 @@ PYBIND11_MODULE(lcm, m) {
 
   {
     using Class = DrakeLcmInterface;
-
-    py::class_<Class>(m, "DrakeLcmInterface", doc.DrakeLcmInterface.doc)
+    constexpr auto& cls_doc = doc.DrakeLcmInterface;
+    py::class_<Class>(m, "DrakeLcmInterface", cls_doc.doc)
         // N.B. We do not bind `Subscribe` as multi-threading from C++ may
         // wreak havoc on the Python GIL with a callback.
         .def("Publish",
@@ -39,18 +39,18 @@ PYBIND11_MODULE(lcm, m) {
               self->Publish(channel, str.data(), str.size(), time_sec);
             },
             py::arg("channel"), py::arg("buffer"),
-            py::arg("time_sec") = py::none(), doc.DrakeLcmInterface.Publish.doc)
+            py::arg("time_sec") = py::none(), cls_doc.Publish.doc)
         .def("HandleSubscriptions", &DrakeLcmInterface::HandleSubscriptions,
-            py::arg("timeout_millis"),
-            doc.DrakeLcmInterface.HandleSubscriptions.doc);
+            py::arg("timeout_millis"), cls_doc.HandleSubscriptions.doc);
   }
 
   {
     using Class = DrakeLcm;
-    py::class_<Class, DrakeLcmInterface>(m, "DrakeLcm", doc.DrakeLcm.doc)
-        .def(py::init<>(), doc.DrakeLcm.ctor.doc_0args)
-        .def(py::init<std::string>(), py::arg("lcm_url"),
-            doc.DrakeLcm.ctor.doc_1args)
+    constexpr auto& cls_doc = doc.DrakeLcm;
+    py::class_<Class, DrakeLcmInterface>(m, "DrakeLcm", cls_doc.doc)
+        .def(py::init<>(), cls_doc.ctor.doc_0args)
+        .def(
+            py::init<std::string>(), py::arg("lcm_url"), cls_doc.ctor.doc_1args)
         .def("StartReceiveThread",
             [](DrakeLcm* self) {
               WarnDeprecated(
@@ -60,7 +60,7 @@ PYBIND11_MODULE(lcm, m) {
               self->StartReceiveThread();
 #pragma GCC diagnostic pop
             },
-            doc.DrakeLcm.StartReceiveThread.doc_deprecated)
+            cls_doc.StartReceiveThread.doc_deprecated)
         .def("StopReceiveThread",
             [](DrakeLcm* self) {
               WarnDeprecated(
@@ -70,15 +70,15 @@ PYBIND11_MODULE(lcm, m) {
               self->StopReceiveThread();
 #pragma GCC diagnostic pop
             },
-            doc.DrakeLcm.StopReceiveThread.doc_deprecated);
+            cls_doc.StopReceiveThread.doc_deprecated);
     // TODO(eric.cousineau): Add remaining methods.
   }
 
   {
     using Class = DrakeMockLcm;
-    py::class_<Class, DrakeLcmInterface>(
-        m, "DrakeMockLcm", doc.DrakeMockLcm.doc)
-        .def(py::init<>(), doc.DrakeMockLcm.ctor.doc)
+    constexpr auto& cls_doc = doc.DrakeMockLcm;
+    py::class_<Class, DrakeLcmInterface>(m, "DrakeMockLcm", cls_doc.doc)
+        .def(py::init<>(), cls_doc.ctor.doc)
         .def("Subscribe",
             [](Class* self, const std::string& channel,
                 PyHandlerFunction handler) {
@@ -89,8 +89,7 @@ PYBIND11_MODULE(lcm, m) {
               // Unsubscribe is not supported by the mock.
               DRAKE_DEMAND(subscription == nullptr);
             },
-            py::arg("channel"), py::arg("handler"),
-            doc.DrakeMockLcm.Subscribe.doc)
+            py::arg("channel"), py::arg("handler"), cls_doc.Subscribe.doc)
         .def("InduceSubscriberCallback",
             [](Class* self, const std::string& channel, py::bytes buffer) {
               WarnDeprecated("Use Publish + HandleSubscriptions instead.");
@@ -101,7 +100,7 @@ PYBIND11_MODULE(lcm, m) {
 #pragma GCC diagnostic pop
             },
             py::arg("channel"), py::arg("buffer"),
-            doc.DrakeMockLcm.InduceSubscriberCallback.doc_deprecated)
+            cls_doc.InduceSubscriberCallback.doc_deprecated)
         .def("get_last_published_message",
             [](const Class* self, const std::string& channel) {
               WarnDeprecated("Use pydrake.lcm.Subscriber instead.");
@@ -114,7 +113,7 @@ PYBIND11_MODULE(lcm, m) {
 #pragma GCC diagnostic pop
             },
             py::arg("channel"),
-            doc.DrakeMockLcm.get_last_published_message.doc_deprecated);
+            cls_doc.get_last_published_message.doc_deprecated);
   }
 
   ExecuteExtraPythonCode(m);

--- a/bindings/pydrake/manipulation/planner_py.cc
+++ b/bindings/pydrake/manipulation/planner_py.cc
@@ -28,7 +28,7 @@ PYBIND11_MODULE(planner, m) {
 
   {
     using Class = manipulation::planner::DifferentialInverseKinematicsResult;
-    constexpr auto& class_doc = doc.DifferentialInverseKinematicsResult;
+    constexpr auto& cls_doc = doc.DifferentialInverseKinematicsResult;
     py::class_<Class> cls(m, "DifferentialInverseKinematicsResult",
         doc.DifferentialInverseKinematicsResult.doc);
 
@@ -39,13 +39,13 @@ PYBIND11_MODULE(planner, m) {
        }),
            py::arg("joint_velocities"), py::arg("status"))
         .def_readwrite("joint_velocities", &Class::joint_velocities,
-            class_doc.joint_velocities.doc)
-        .def_readwrite("status", &Class::status, class_doc.status.doc);
+            cls_doc.joint_velocities.doc)
+        .def_readwrite("status", &Class::status, cls_doc.status.doc);
   }
   {
     using Class =
         manipulation::planner::DifferentialInverseKinematicsParameters;
-    constexpr auto& class_doc = doc.DifferentialInverseKinematicsParameters;
+    constexpr auto& cls_doc = doc.DifferentialInverseKinematicsParameters;
 
     py::class_<Class> cls(m, "DifferentialInverseKinematicsParameters",
         doc.DifferentialInverseKinematicsParameters.doc);
@@ -54,43 +54,43 @@ PYBIND11_MODULE(planner, m) {
          return Class{num_positions, num_velocities};
        }),
            py::arg("num_positions") = 0, py::arg("num_velocities") = 0,
-           class_doc.ctor.doc)
-        .def("get_timestep", &Class::get_timestep, class_doc.get_timestep.doc)
-        .def("set_timestep", &Class::set_timestep, class_doc.set_timestep.doc)
+           cls_doc.ctor.doc)
+        .def("get_timestep", &Class::get_timestep, cls_doc.get_timestep.doc)
+        .def("set_timestep", &Class::set_timestep, cls_doc.set_timestep.doc)
         .def("get_num_positions", &Class::get_num_positions,
-            class_doc.get_num_positions.doc)
+            cls_doc.get_num_positions.doc)
         .def("get_num_velocities", &Class::get_num_velocities,
-            class_doc.get_num_velocities.doc)
+            cls_doc.get_num_velocities.doc)
         .def("get_nominal_joint_position", &Class::get_nominal_joint_position,
-            class_doc.get_nominal_joint_position.doc)
+            cls_doc.get_nominal_joint_position.doc)
         .def("set_nominal_joint_position", &Class::set_nominal_joint_position,
-            class_doc.set_nominal_joint_position.doc)
+            cls_doc.set_nominal_joint_position.doc)
         .def("get_end_effector_velocity_gain",
             &Class::get_end_effector_velocity_gain,
-            class_doc.get_end_effector_velocity_gain.doc)
+            cls_doc.get_end_effector_velocity_gain.doc)
         .def("set_end_effector_velocity_gain",
             &Class::set_end_effector_velocity_gain,
-            class_doc.set_end_effector_velocity_gain.doc)
+            cls_doc.set_end_effector_velocity_gain.doc)
         .def("get_unconstrained_degrees_of_freedom_velocity_limit",
             &Class::get_unconstrained_degrees_of_freedom_velocity_limit,
-            class_doc.get_unconstrained_degrees_of_freedom_velocity_limit.doc)
+            cls_doc.get_unconstrained_degrees_of_freedom_velocity_limit.doc)
         .def("set_unconstrained_degrees_of_freedom_velocity_limit",
             &Class::set_unconstrained_degrees_of_freedom_velocity_limit,
-            class_doc.set_unconstrained_degrees_of_freedom_velocity_limit.doc)
+            cls_doc.set_unconstrained_degrees_of_freedom_velocity_limit.doc)
         .def("get_joint_position_limits", &Class::get_joint_position_limits,
-            class_doc.get_joint_position_limits.doc)
+            cls_doc.get_joint_position_limits.doc)
         .def("set_joint_position_limits", &Class::set_joint_position_limits,
-            class_doc.set_joint_position_limits.doc)
+            cls_doc.set_joint_position_limits.doc)
         .def("get_joint_velocity_limits", &Class::get_joint_velocity_limits,
-            class_doc.get_joint_velocity_limits.doc)
+            cls_doc.get_joint_velocity_limits.doc)
         .def("set_joint_velocity_limits", &Class::set_joint_velocity_limits,
-            class_doc.set_joint_velocity_limits.doc)
+            cls_doc.set_joint_velocity_limits.doc)
         .def("get_joint_acceleration_limits",
             &Class::get_joint_acceleration_limits,
-            class_doc.get_joint_acceleration_limits.doc)
+            cls_doc.get_joint_acceleration_limits.doc)
         .def("set_joint_acceleration_limits",
             &Class::set_joint_acceleration_limits,
-            class_doc.set_joint_acceleration_limits.doc);
+            cls_doc.set_joint_acceleration_limits.doc);
   }
 
   m.def("DoDifferentialInverseKinematics",

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -61,65 +61,60 @@ PYBIND11_MODULE(plant, m) {
 
   {
     using Class = MultibodyPlant<T>;
+    constexpr auto& cls_doc = doc.MultibodyPlant;
     py::class_<Class, systems::LeafSystem<T>> cls(
-        m, "MultibodyPlant", doc.MultibodyPlant.doc);
+        m, "MultibodyPlant", cls_doc.doc);
     // N.B. These are defined as they appear in the class declaration.
     // Forwarded methods from `MultibodyTree`.
     cls  // BR
         .def(py::init<double>(), py::arg("time_step") = 0.)
-        .def(
-            "num_bodies", &Class::num_bodies, doc.MultibodyPlant.num_bodies.doc)
-        .def(
-            "num_joints", &Class::num_joints, doc.MultibodyPlant.num_joints.doc)
-        .def("num_actuators", &Class::num_actuators,
-            doc.MultibodyPlant.num_actuators.doc)
+        .def("num_bodies", &Class::num_bodies, cls_doc.num_bodies.doc)
+        .def("num_joints", &Class::num_joints, cls_doc.num_joints.doc)
+        .def("num_actuators", &Class::num_actuators, cls_doc.num_actuators.doc)
         .def("num_model_instances", &Class::num_model_instances,
-            doc.MultibodyPlant.num_model_instances.doc)
+            cls_doc.num_model_instances.doc)
         .def("num_positions",
             overload_cast_explicit<int>(&Class::num_positions),
-            doc.MultibodyPlant.num_positions.doc_0args)
+            cls_doc.num_positions.doc_0args)
         .def("num_positions",
             overload_cast_explicit<int, ModelInstanceIndex>(
                 &Class::num_positions),
-            py::arg("model_instance"),
-            doc.MultibodyPlant.num_positions.doc_1args)
+            py::arg("model_instance"), cls_doc.num_positions.doc_1args)
         .def("num_velocities",
             overload_cast_explicit<int>(&Class::num_velocities),
-            doc.MultibodyPlant.num_velocities.doc_0args)
+            cls_doc.num_velocities.doc_0args)
         .def("num_velocities",
             overload_cast_explicit<int, ModelInstanceIndex>(
                 &Class::num_velocities),
-            doc.MultibodyPlant.num_velocities.doc_1args)
+            cls_doc.num_velocities.doc_1args)
         .def("num_multibody_states", &Class::num_multibody_states,
-            doc.MultibodyPlant.num_multibody_states.doc)
+            cls_doc.num_multibody_states.doc)
         .def("num_actuated_dofs",
             overload_cast_explicit<int>(&Class::num_actuated_dofs),
-            doc.MultibodyPlant.num_actuated_dofs.doc_0args);
+            cls_doc.num_actuated_dofs.doc_0args);
     // Construction.
     cls  // BR
         .def("AddJoint",
             [](Class * self, std::unique_ptr<Joint<T>> joint) -> auto& {
               return self->AddJoint(std::move(joint));
             },
-            py::arg("joint"), py_reference_internal,
-            doc.MultibodyPlant.AddJoint.doc_1args)
+            py::arg("joint"), py_reference_internal, cls_doc.AddJoint.doc_1args)
         .def("AddFrame",
             [](Class * self, std::unique_ptr<Frame<double>> frame) -> auto& {
               return self->AddFrame(std::move(frame));
             },
-            py_reference_internal, py::arg("frame"),
-            doc.MultibodyPlant.AddFrame.doc)
+            py_reference_internal, py::arg("frame"), cls_doc.AddFrame.doc)
         .def("AddRigidBody",
             py::overload_cast<const std::string&,
                 const SpatialInertia<double>&>(&Class::AddRigidBody),
             py::arg("name"), py::arg("M_BBo_B"), py_reference_internal,
-            doc.MultibodyPlant.AddRigidBody.doc_2args)
+            cls_doc.AddRigidBody.doc_2args)
         .def("WeldFrames",
             py::overload_cast<const Frame<T>&, const Frame<T>&,
                 const RigidTransform<double>&>(&Class::WeldFrames),
             py::arg("A"), py::arg("B"),
             py::arg("X_AB") = RigidTransform<double>::Identity(),
-            py_reference_internal, doc.MultibodyPlant.WeldFrames.doc)
+            py_reference_internal, cls_doc.WeldFrames.doc)
         .def("WeldFrames",
             [](Class* self, const Frame<T>& A, const Frame<T>& B,
                 const Isometry3<double>& X_AB) -> const WeldJoint<T>& {
@@ -142,7 +137,7 @@ PYBIND11_MODULE(plant, m) {
                   force_element->gravity_vector());
             },
             py::arg("force_element"), py_reference_internal,
-            doc.MultibodyPlant.AddForceElement.doc)
+            cls_doc.AddForceElement.doc)
         .def("AddForceElement",
             [](Class * self,
                 std::unique_ptr<ForceElement<T>> force_element) -> auto& {
@@ -150,7 +145,7 @@ PYBIND11_MODULE(plant, m) {
                   std::move(force_element));
             },
             py::arg("force_element"), py_reference_internal,
-            doc.MultibodyPlant.AddForceElement.doc);
+            cls_doc.AddForceElement.doc);
     // Mathy bits
     cls  // BR
         .def("CalcPointsPositions",
@@ -164,7 +159,7 @@ PYBIND11_MODULE(plant, m) {
               return p_AQi;
             },
             py::arg("context"), py::arg("frame_B"), py::arg("p_BQi"),
-            py::arg("frame_A"), doc.MultibodyPlant.CalcPointsPositions.doc)
+            py::arg("frame_A"), cls_doc.CalcPointsPositions.doc)
         .def("CalcFrameGeometricJacobianExpressedInWorld",
             [](const Class* self, const Context<T>& context,
                 const Frame<T>& frame_B, const Vector3<T>& p_BoFo_B) {
@@ -175,7 +170,7 @@ PYBIND11_MODULE(plant, m) {
             },
             py::arg("context"), py::arg("frame_B"),
             py::arg("p_BoFo_B") = Vector3<T>::Zero().eval(),
-            doc.MultibodyPlant.CalcFrameGeometricJacobianExpressedInWorld.doc)
+            cls_doc.CalcFrameGeometricJacobianExpressedInWorld.doc)
         // TODO(eric.cousineau): Include `CalcInverseDynamics` once there is an
         // overload that (a) services MBP directly and (b) uses body
         // association that is less awkward than implicit BodyNodeIndex.
@@ -183,7 +178,7 @@ PYBIND11_MODULE(plant, m) {
             overload_cast_explicit<void, Context<T>*, const Body<T>&,
                 const RigidTransform<T>&>(&Class::SetFreeBodyPose),
             py::arg("context"), py::arg("body"), py::arg("X_WB"),
-            doc.MultibodyPlant.SetFreeBodyPose.doc_3args)
+            cls_doc.SetFreeBodyPose.doc_3args)
         .def("SetFreeBodyPose",
             [](const Class* self, Context<T>* context, const Body<T>& body,
                 const Isometry3<T>& X_WB) {
@@ -200,10 +195,10 @@ PYBIND11_MODULE(plant, m) {
               self->SetActuationInArray(model_instance, u_instance, &u);
             },
             py::arg("model_instance"), py::arg("u_instance"), py::arg("u"),
-            doc.MultibodyPlant.SetActuationInArray.doc)
+            cls_doc.SetActuationInArray.doc)
         .def("GetPositionsFromArray", &Class::GetPositionsFromArray,
             py::arg("model_instance"), py::arg("q"),
-            doc.MultibodyPlant.GetPositionsFromArray.doc)
+            cls_doc.GetPositionsFromArray.doc)
         .def("SetPositionsInArray",
             [](const Class* self, multibody::ModelInstanceIndex model_instance,
                 const Eigen::Ref<const VectorX<T>> q_instance,
@@ -211,10 +206,10 @@ PYBIND11_MODULE(plant, m) {
               self->SetPositionsInArray(model_instance, q_instance, &q);
             },
             py::arg("model_instance"), py::arg("q_instance"), py::arg("q"),
-            doc.MultibodyPlant.SetPositionsInArray.doc)
+            cls_doc.SetPositionsInArray.doc)
         .def("GetVelocitiesFromArray", &Class::GetVelocitiesFromArray,
             py::arg("model_instance"), py::arg("v"),
-            doc.MultibodyPlant.GetVelocitiesFromArray.doc)
+            cls_doc.GetVelocitiesFromArray.doc)
         .def("SetVelocitiesInArray",
             [](const Class* self, multibody::ModelInstanceIndex model_instance,
                 const Eigen::Ref<const VectorX<T>> v_instance,
@@ -222,7 +217,7 @@ PYBIND11_MODULE(plant, m) {
               self->SetVelocitiesInArray(model_instance, v_instance, &v);
             },
             py::arg("model_instance"), py::arg("v_instance"), py::arg("v"),
-            doc.MultibodyPlant.SetVelocitiesInArray.doc)
+            cls_doc.SetVelocitiesInArray.doc)
         // TODO(eric.cousineau): Ensure all of these return either references,
         // or copies, consistently. At present, `GetX(context)` returns a
         // reference, while `GetX(context, model_instance)` returns a copy.
@@ -233,7 +228,7 @@ PYBIND11_MODULE(plant, m) {
             },
             py::arg("context"), py_reference_internal,
             // Keep alive, ownership: `return` keeps `context` alive.
-            py::keep_alive<0, 2>(), doc.MultibodyPlant.GetPositions.doc_1args)
+            py::keep_alive<0, 2>(), cls_doc.GetPositions.doc_1args)
         .def("GetPositions",
             [](const Class* self, const Context<T>& context,
                 ModelInstanceIndex model_instance) {
@@ -241,7 +236,7 @@ PYBIND11_MODULE(plant, m) {
               return self->GetPositions(context, model_instance);
             },
             py::arg("context"), py::arg("model_instance"),
-            doc.MultibodyPlant.GetPositions.doc_2args)
+            cls_doc.GetPositions.doc_2args)
         .def("GetVelocities",
             [](const Class* self, const Context<T>& context) {
               // Reference.
@@ -249,7 +244,7 @@ PYBIND11_MODULE(plant, m) {
             },
             py::arg("context"), py_reference_internal,
             // Keep alive, ownership: `return` keeps `context` alive.
-            py::keep_alive<0, 2>(), doc.MultibodyPlant.GetVelocities.doc_1args)
+            py::keep_alive<0, 2>(), cls_doc.GetVelocities.doc_1args)
         .def("GetVelocities",
             [](const Class* self, const Context<T>& context,
                 ModelInstanceIndex model_instance) {
@@ -257,28 +252,28 @@ PYBIND11_MODULE(plant, m) {
               return self->GetVelocities(context, model_instance);
             },
             py::arg("context"), py::arg("model_instance"),
-            doc.MultibodyPlant.GetVelocities.doc_2args)
+            cls_doc.GetVelocities.doc_2args)
         .def("SetFreeBodySpatialVelocity",
             [](const Class* self, const Body<T>& body,
                 const SpatialVelocity<T>& V_WB, Context<T>* context) {
               self->SetFreeBodySpatialVelocity(context, body, V_WB);
             },
             py::arg("body"), py::arg("V_WB"), py::arg("context"),
-            doc.MultibodyPlant.SetFreeBodySpatialVelocity.doc_3args)
+            cls_doc.SetFreeBodySpatialVelocity.doc_3args)
         .def("EvalBodyPoseInWorld",
             [](const Class* self, const Context<T>& context,
                 const Body<T>& body_B) {
               return self->EvalBodyPoseInWorld(context, body_B);
             },
             py::arg("context"), py::arg("body"),
-            doc.MultibodyPlant.EvalBodyPoseInWorld.doc)
+            cls_doc.EvalBodyPoseInWorld.doc)
         .def("EvalBodySpatialVelocityInWorld",
             [](const Class* self, const Context<T>& context,
                 const Body<T>& body_B) {
               return self->EvalBodySpatialVelocityInWorld(context, body_B);
             },
             py::arg("context"), py::arg("body"),
-            doc.MultibodyPlant.EvalBodySpatialVelocityInWorld.doc)
+            cls_doc.EvalBodySpatialVelocityInWorld.doc)
         .def("CalcJacobianSpatialVelocity",
             [](const Class* self, const systems::Context<T>& context,
                 JacobianWrtVariable with_respect_to, const Frame<T>& frame_B,
@@ -291,7 +286,7 @@ PYBIND11_MODULE(plant, m) {
             },
             py::arg("context"), py::arg("with_respect_to"), py::arg("frame_B"),
             py::arg("p_BP"), py::arg("frame_A"), py::arg("frame_E"),
-            doc.MultibodyPlant.CalcJacobianSpatialVelocity.doc)
+            cls_doc.CalcJacobianSpatialVelocity.doc)
         .def("CalcSpatialAccelerationsFromVdot",
             [](const Class* self, const Context<T>& context,
                 const VectorX<T>& known_vdot) {
@@ -302,31 +297,29 @@ PYBIND11_MODULE(plant, m) {
               return A_WB_array;
             },
             py::arg("context"), py::arg("known_vdot"),
-            doc.MultibodyPlant.CalcSpatialAccelerationsFromVdot.doc)
+            cls_doc.CalcSpatialAccelerationsFromVdot.doc)
         .def("CalcInverseDynamics", &Class::CalcInverseDynamics,
             py::arg("context"), py::arg("known_vdot"),
-            py::arg("external_forces"),
-            doc.MultibodyPlant.CalcInverseDynamics.doc)
+            py::arg("external_forces"), cls_doc.CalcInverseDynamics.doc)
         .def("CalcForceElementsContribution",
             &Class::CalcForceElementsContribution, py::arg("context"),
-            py::arg("forces"),
-            doc.MultibodyPlant.CalcForceElementsContribution.doc)
+            py::arg("forces"), cls_doc.CalcForceElementsContribution.doc)
         .def("CalcPotentialEnergy", &Class::CalcPotentialEnergy,
-            py::arg("context"), doc.MultibodyPlant.CalcPotentialEnergy.doc)
+            py::arg("context"), cls_doc.CalcPotentialEnergy.doc)
         .def("CalcConservativePower", &Class::CalcConservativePower,
-            py::arg("context"), doc.MultibodyPlant.CalcConservativePower.doc)
+            py::arg("context"), cls_doc.CalcConservativePower.doc)
         .def("GetPositionLowerLimits", &Class::GetPositionLowerLimits,
-            doc.MultibodyPlant.GetPositionLowerLimits.doc)
+            cls_doc.GetPositionLowerLimits.doc)
         .def("GetPositionUpperLimits", &Class::GetPositionUpperLimits,
-            doc.MultibodyPlant.GetPositionUpperLimits.doc)
+            cls_doc.GetPositionUpperLimits.doc)
         .def("GetVelocityLowerLimits", &Class::GetVelocityLowerLimits,
-            doc.MultibodyPlant.GetVelocityLowerLimits.doc)
+            cls_doc.GetVelocityLowerLimits.doc)
         .def("GetVelocityUpperLimits", &Class::GetVelocityUpperLimits,
-            doc.MultibodyPlant.GetVelocityUpperLimits.doc)
+            cls_doc.GetVelocityUpperLimits.doc)
         .def("GetAccelerationLowerLimits", &Class::GetAccelerationLowerLimits,
-            doc.MultibodyPlant.GetAccelerationLowerLimits.doc)
+            cls_doc.GetAccelerationLowerLimits.doc)
         .def("GetAccelerationUpperLimits", &Class::GetAccelerationUpperLimits,
-            doc.MultibodyPlant.GetAccelerationUpperLimits.doc)
+            cls_doc.GetAccelerationUpperLimits.doc)
         .def("CalcMassMatrixViaInverseDynamics",
             [](const Class* self, const Context<T>& context) {
               MatrixX<T> H;
@@ -342,10 +335,10 @@ PYBIND11_MODULE(plant, m) {
               self->CalcBiasTerm(context, &Cv);
               return Cv;
             },
-            py::arg("context"), doc.MultibodyPlant.CalcBiasTerm.doc)
+            py::arg("context"), cls_doc.CalcBiasTerm.doc)
         .def("CalcGravityGeneralizedForces",
             &Class::CalcGravityGeneralizedForces, py::arg("context"),
-            doc.MultibodyPlant.CalcGravityGeneralizedForces.doc)
+            cls_doc.CalcGravityGeneralizedForces.doc)
         .def("MapVelocityToQDot",
             [](const Class* self, const Context<T>& context,
                 const Eigen::Ref<const VectorX<T>>& v) {
@@ -353,8 +346,7 @@ PYBIND11_MODULE(plant, m) {
               self->MapVelocityToQDot(context, v, &qdot);
               return qdot;
             },
-            py::arg("context"), py::arg("v"),
-            doc.MultibodyPlant.MapVelocityToQDot.doc)
+            py::arg("context"), py::arg("v"), cls_doc.MapVelocityToQDot.doc)
         .def("MapQDotToVelocity",
             [](const Class* self, const Context<T>& context,
                 const Eigen::Ref<const VectorX<T>>& qdot) {
@@ -362,89 +354,87 @@ PYBIND11_MODULE(plant, m) {
               self->MapQDotToVelocity(context, qdot, &v);
               return v;
             },
-            py::arg("context"), py::arg("qdot"),
-            doc.MultibodyPlant.MapQDotToVelocity.doc)
+            py::arg("context"), py::arg("qdot"), cls_doc.MapQDotToVelocity.doc)
         .def("CalcRelativeTransform", &Class::CalcRelativeTransform,
             py::arg("context"), py::arg("frame_A"), py::arg("frame_B"),
-            doc.MultibodyPlant.CalcRelativeTransform.doc);
+            cls_doc.CalcRelativeTransform.doc);
     // Topology queries.
     cls  // BR
-        .def(
-            "num_frames", &Class::num_frames, doc.MultibodyPlant.num_frames.doc)
+        .def("num_frames", &Class::num_frames, cls_doc.num_frames.doc)
         .def("get_body", &Class::get_body, py::arg("body_index"),
-            py_reference_internal, doc.MultibodyPlant.get_body.doc)
+            py_reference_internal, cls_doc.get_body.doc)
         .def("get_joint", &Class::get_joint, py::arg("joint_index"),
-            py_reference_internal, doc.MultibodyPlant.get_joint.doc)
+            py_reference_internal, cls_doc.get_joint.doc)
         .def("get_joint_actuator", &Class::get_joint_actuator,
             py::arg("actuator_index"), py_reference_internal,
-            doc.MultibodyPlant.get_joint_actuator.doc)
+            cls_doc.get_joint_actuator.doc)
         .def("get_frame", &Class::get_frame, py::arg("frame_index"),
-            py_reference_internal, doc.MultibodyPlant.get_frame.doc)
+            py_reference_internal, cls_doc.get_frame.doc)
         .def("GetModelInstanceName",
             overload_cast_explicit<const string&, ModelInstanceIndex>(
                 &Class::GetModelInstanceName),
             py::arg("model_instance"), py_reference_internal,
-            doc.MultibodyPlant.GetModelInstanceName.doc)
+            cls_doc.GetModelInstanceName.doc)
         .def("HasBodyNamed",
             overload_cast_explicit<bool, const string&>(&Class::HasBodyNamed),
-            py::arg("name"), doc.MultibodyPlant.HasBodyNamed.doc_1args)
+            py::arg("name"), cls_doc.HasBodyNamed.doc_1args)
         .def("HasBodyNamed",
             overload_cast_explicit<bool, const string&, ModelInstanceIndex>(
                 &Class::HasBodyNamed),
             py::arg("name"), py::arg("model_instance"),
-            doc.MultibodyPlant.HasBodyNamed.doc_2args)
+            cls_doc.HasBodyNamed.doc_2args)
         .def("HasJointNamed",
             overload_cast_explicit<bool, const string&>(&Class::HasJointNamed),
-            py::arg("name"), doc.MultibodyPlant.HasJointNamed.doc_1args)
+            py::arg("name"), cls_doc.HasJointNamed.doc_1args)
         .def("HasJointNamed",
             overload_cast_explicit<bool, const string&, ModelInstanceIndex>(
                 &Class::HasJointNamed),
             py::arg("name"), py::arg("model_instance"),
-            doc.MultibodyPlant.HasJointNamed.doc_2args)
+            cls_doc.HasJointNamed.doc_2args)
         .def("GetFrameByName",
             overload_cast_explicit<const Frame<T>&, const string&>(
                 &Class::GetFrameByName),
             py::arg("name"), py_reference_internal,
-            doc.MultibodyPlant.GetFrameByName.doc_1args)
+            cls_doc.GetFrameByName.doc_1args)
         .def("GetFrameByName",
             overload_cast_explicit<const Frame<T>&, const string&,
                 ModelInstanceIndex>(&Class::GetFrameByName),
             py::arg("name"), py::arg("model_instance"), py_reference_internal,
-            doc.MultibodyPlant.GetFrameByName.doc_2args)
+            cls_doc.GetFrameByName.doc_2args)
         .def("GetBodyByName",
             overload_cast_explicit<const Body<T>&, const string&>(
                 &Class::GetBodyByName),
             py::arg("name"), py_reference_internal,
-            doc.MultibodyPlant.GetBodyByName.doc_1args)
+            cls_doc.GetBodyByName.doc_1args)
         .def("GetBodyByName",
             overload_cast_explicit<const Body<T>&, const string&,
                 ModelInstanceIndex>(&Class::GetBodyByName),
             py::arg("name"), py::arg("model_instance"), py_reference_internal,
-            doc.MultibodyPlant.GetBodyByName.doc_2args)
+            cls_doc.GetBodyByName.doc_2args)
         .def("GetBodyIndices", &Class::GetBodyIndices,
-            py::arg("model_instance"), doc.MultibodyPlant.GetBodyIndices.doc)
+            py::arg("model_instance"), cls_doc.GetBodyIndices.doc)
         .def("GetJointByName",
             [](const Class* self, const string& name,
                 optional<ModelInstanceIndex> model_instance) -> auto& {
               return self->GetJointByName(name, model_instance);
             },
             py::arg("name"), py::arg("model_instance") = nullopt,
-            py_reference_internal, doc.MultibodyPlant.GetJointByName.doc)
+            py_reference_internal, cls_doc.GetJointByName.doc)
         .def("GetJointActuatorByName",
             overload_cast_explicit<const JointActuator<T>&, const string&>(
                 &Class::GetJointActuatorByName),
             py::arg("name"), py_reference_internal,
-            doc.MultibodyPlant.GetJointActuatorByName.doc_1args)
+            cls_doc.GetJointActuatorByName.doc_1args)
         .def("GetModelInstanceByName",
             overload_cast_explicit<ModelInstanceIndex, const string&>(
                 &Class::GetModelInstanceByName),
             py::arg("name"), py_reference_internal,
-            doc.MultibodyPlant.GetModelInstanceByName.doc);
+            cls_doc.GetModelInstanceByName.doc);
     // Geometry.
     cls  // BR
         .def("RegisterAsSourceForSceneGraph",
             &Class::RegisterAsSourceForSceneGraph, py::arg("scene_graph"),
-            doc.MultibodyPlant.RegisterAsSourceForSceneGraph.doc)
+            cls_doc.RegisterAsSourceForSceneGraph.doc)
         .def("RegisterVisualGeometry",
             py::overload_cast<const Body<T>&, const RigidTransform<double>&,
                 const geometry::Shape&, const std::string&,
@@ -452,7 +442,7 @@ PYBIND11_MODULE(plant, m) {
                 &Class::RegisterVisualGeometry),
             py::arg("body"), py::arg("X_BG"), py::arg("shape"), py::arg("name"),
             py::arg("diffuse_color"), py::arg("scene_graph") = nullptr,
-            doc.MultibodyPlant.RegisterVisualGeometry
+            cls_doc.RegisterVisualGeometry
                 .doc_6args_body_X_BG_shape_name_diffuse_color_scene_graph)
         .def("RegisterVisualGeometry",
             [](Class* self, const Body<T>& body, const Isometry3<double>& X_BG,
@@ -474,7 +464,7 @@ PYBIND11_MODULE(plant, m) {
                 &Class::RegisterCollisionGeometry),
             py::arg("body"), py::arg("X_BG"), py::arg("shape"), py::arg("name"),
             py::arg("coulomb_friction"), py::arg("scene_graph") = nullptr,
-            doc.MultibodyPlant.RegisterCollisionGeometry.doc)
+            cls_doc.RegisterCollisionGeometry.doc)
         .def("RegisterCollisionGeometry",
             [](Class* self, const Body<T>& body, const Isometry3<double>& X_BG,
                 const geometry::Shape& shape, const std::string& name,
@@ -488,67 +478,62 @@ PYBIND11_MODULE(plant, m) {
             py::arg("body"), py::arg("X_BG"), py::arg("shape"), py::arg("name"),
             py::arg("coulomb_friction"), py::arg("scene_graph") = nullptr,
             doc_iso3_deprecation)
-        .def("get_source_id", &Class::get_source_id,
-            doc.MultibodyPlant.get_source_id.doc)
+        .def("get_source_id", &Class::get_source_id, cls_doc.get_source_id.doc)
         .def("get_geometry_query_input_port",
             &Class::get_geometry_query_input_port, py_reference_internal,
-            doc.MultibodyPlant.get_geometry_query_input_port.doc)
+            cls_doc.get_geometry_query_input_port.doc)
         .def("get_geometry_poses_output_port",
             &Class::get_geometry_poses_output_port, py_reference_internal,
-            doc.MultibodyPlant.get_geometry_poses_output_port.doc)
+            cls_doc.get_geometry_poses_output_port.doc)
         .def("geometry_source_is_registered",
             &Class::geometry_source_is_registered,
-            doc.MultibodyPlant.geometry_source_is_registered.doc)
+            cls_doc.geometry_source_is_registered.doc)
         .def("GetBodyFromFrameId", &Class::GetBodyFromFrameId,
-            py_reference_internal, doc.MultibodyPlant.GetBodyFromFrameId.doc)
+            py_reference_internal, cls_doc.GetBodyFromFrameId.doc)
         .def("GetBodyFrameIdIfExists", &Class::GetBodyFrameIdIfExists,
             py::arg("body_index"), py_reference_internal,
-            doc.MultibodyPlant.GetBodyFrameIdIfExists.doc);
+            cls_doc.GetBodyFrameIdIfExists.doc);
     // Port accessors.
     cls  // BR
         .def("get_actuation_input_port",
             overload_cast_explicit<const systems::InputPort<T>&>(
                 &Class::get_actuation_input_port),
-            py_reference_internal,
-            doc.MultibodyPlant.get_actuation_input_port.doc_0args)
+            py_reference_internal, cls_doc.get_actuation_input_port.doc_0args)
         .def("get_actuation_input_port",
             overload_cast_explicit<const systems::InputPort<T>&,
                 multibody::ModelInstanceIndex>(
                 &Class::get_actuation_input_port),
-            py_reference_internal,
-            doc.MultibodyPlant.get_actuation_input_port.doc_1args)
+            py_reference_internal, cls_doc.get_actuation_input_port.doc_1args)
         .def("get_continuous_state_output_port",
             overload_cast_explicit<const systems::OutputPort<T>&>(
                 &Class::get_continuous_state_output_port),
             py_reference_internal,
-            doc.MultibodyPlant.get_continuous_state_output_port.doc_0args)
+            cls_doc.get_continuous_state_output_port.doc_0args)
         .def("get_continuous_state_output_port",
             overload_cast_explicit<const systems::OutputPort<T>&,
                 multibody::ModelInstanceIndex>(
                 &Class::get_continuous_state_output_port),
             py_reference_internal,
-            doc.MultibodyPlant.get_continuous_state_output_port.doc_1args)
+            cls_doc.get_continuous_state_output_port.doc_1args)
         .def("get_contact_results_output_port",
             overload_cast_explicit<const systems::OutputPort<T>&>(
                 &Class::get_contact_results_output_port),
-            py_reference_internal,
-            doc.MultibodyPlant.get_contact_results_output_port.doc)
+            py_reference_internal, cls_doc.get_contact_results_output_port.doc)
         .def("get_generalized_contact_forces_output_port",
             overload_cast_explicit<const systems::OutputPort<T>&,
                 multibody::ModelInstanceIndex>(
                 &Class::get_generalized_contact_forces_output_port),
             py_reference_internal, py::arg("model_instance"),
-            doc.MultibodyPlant.get_generalized_contact_forces_output_port.doc);
+            cls_doc.get_generalized_contact_forces_output_port.doc);
     // Property accessors.
     cls  // BR
         .def("world_body", &Class::world_body, py_reference_internal,
-            doc.MultibodyPlant.world_body.doc)
+            cls_doc.world_body.doc)
         .def("world_frame", &Class::world_frame, py_reference_internal,
-            doc.MultibodyPlant.world_frame.doc)
-        .def("is_finalized", &Class::is_finalized,
-            doc.MultibodyPlant.is_finalized.doc)
+            cls_doc.world_frame.doc)
+        .def("is_finalized", &Class::is_finalized, cls_doc.is_finalized.doc)
         .def("Finalize", py::overload_cast<SceneGraph<T>*>(&Class::Finalize),
-            py::arg("scene_graph") = nullptr, doc.MultibodyPlant.Finalize.doc);
+            py::arg("scene_graph") = nullptr, cls_doc.Finalize.doc);
     // Position and velocity accessors and mutators.
     cls  // BR
         .def("GetMutablePositionsAndVelocities",
@@ -559,7 +544,7 @@ PYBIND11_MODULE(plant, m) {
             py_reference,
             // Keep alive, ownership: `return` keeps `Context` alive.
             py::keep_alive<0, 2>(), py::arg("context"),
-            doc.MultibodyPlant.GetMutablePositionsAndVelocities.doc)
+            cls_doc.GetMutablePositionsAndVelocities.doc)
         .def("GetMutablePositions",
             [](const MultibodyPlant<T>* self,
                 Context<T>* context) -> Eigen::Ref<VectorX<T>> {
@@ -568,7 +553,7 @@ PYBIND11_MODULE(plant, m) {
             py_reference,
             // Keep alive, ownership: `return` keeps `Context` alive.
             py::keep_alive<0, 2>(), py::arg("context"),
-            doc.MultibodyPlant.GetMutablePositions.doc_1args)
+            cls_doc.GetMutablePositions.doc_1args)
         .def("GetMutableVelocities",
             [](const MultibodyPlant<T>* self,
                 Context<T>* context) -> Eigen::Ref<VectorX<T>> {
@@ -577,24 +562,23 @@ PYBIND11_MODULE(plant, m) {
             py_reference,
             // Keep alive, ownership: `return` keeps `Context` alive.
             py::keep_alive<0, 2>(), py::arg("context"),
-            doc.MultibodyPlant.GetMutableVelocities.doc_1args)
+            cls_doc.GetMutableVelocities.doc_1args)
         .def("GetPositions",
             [](const MultibodyPlant<T>* self, const Context<T>& context)
                 -> VectorX<T> { return self->GetPositions(context); },
-            py_reference, py::arg("context"),
-            doc.MultibodyPlant.GetPositions.doc_1args)
+            py_reference, py::arg("context"), cls_doc.GetPositions.doc_1args)
         .def("GetPositions",
             [](const MultibodyPlant<T>* self, const Context<T>& context,
                 multibody::ModelInstanceIndex model_instance) -> VectorX<T> {
               return self->GetPositions(context, model_instance);
             },
             py_reference, py::arg("context"), py::arg("model_instance"),
-            doc.MultibodyPlant.GetPositions.doc_2args)
+            cls_doc.GetPositions.doc_2args)
         .def("SetPositions",
             [](const MultibodyPlant<T>* self, Context<T>* context,
                 const VectorX<T>& q) { self->SetPositions(context, q); },
             py_reference, py::arg("context"), py::arg("q"),
-            doc.MultibodyPlant.SetPositions.doc_2args)
+            cls_doc.SetPositions.doc_2args)
         .def("SetPositions",
             [](const MultibodyPlant<T>* self, Context<T>* context,
                 multibody::ModelInstanceIndex model_instance,
@@ -602,52 +586,51 @@ PYBIND11_MODULE(plant, m) {
               self->SetPositions(context, model_instance, q);
             },
             py_reference, py::arg("context"), py::arg("model_instance"),
-            py::arg("q"), doc.MultibodyPlant.SetPositions.doc_2args)
+            py::arg("q"), cls_doc.SetPositions.doc_2args)
         .def("GetVelocities",
             [](const MultibodyPlant<T>* self, const Context<T>& context)
                 -> VectorX<T> { return self->GetVelocities(context); },
-            py_reference, py::arg("context"),
-            doc.MultibodyPlant.GetVelocities.doc_1args)
+            py_reference, py::arg("context"), cls_doc.GetVelocities.doc_1args)
         .def("GetVelocities",
             [](const MultibodyPlant<T>* self, const Context<T>& context,
                 multibody::ModelInstanceIndex model_instance) -> VectorX<T> {
               return self->GetVelocities(context, model_instance);
             },
             py_reference, py::arg("context"), py::arg("model_instance"),
-            doc.MultibodyPlant.GetVelocities.doc_2args)
+            cls_doc.GetVelocities.doc_2args)
         .def("SetVelocities",
             [](const MultibodyPlant<T>* self, Context<T>* context,
                 const VectorX<T>& v) { self->SetVelocities(context, v); },
             py_reference, py::arg("context"), py::arg("v"),
-            doc.MultibodyPlant.SetVelocities.doc_2args)
+            cls_doc.SetVelocities.doc_2args)
         .def("SetVelocities",
             [](const MultibodyPlant<T>* self, Context<T>* context,
                 ModelInstanceIndex model_instance, const VectorX<T>& v) {
               self->SetVelocities(context, model_instance, v);
             },
             py_reference, py::arg("context"), py::arg("model_instance"),
-            py::arg("v"), doc.MultibodyPlant.SetVelocities.doc_3args)
+            py::arg("v"), cls_doc.SetVelocities.doc_3args)
         .def("GetPositionsAndVelocities",
             [](const MultibodyPlant<T>* self,
                 const Context<T>& context) -> VectorX<T> {
               return self->GetPositionsAndVelocities(context);
             },
             py_reference, py::arg("context"),
-            doc.MultibodyPlant.GetPositionsAndVelocities.doc_1args)
+            cls_doc.GetPositionsAndVelocities.doc_1args)
         .def("GetPositionsAndVelocities",
             [](const MultibodyPlant<T>* self, const Context<T>& context,
                 multibody::ModelInstanceIndex model_instance) -> VectorX<T> {
               return self->GetPositionsAndVelocities(context, model_instance);
             },
             py_reference, py::arg("context"), py::arg("model_instance"),
-            doc.MultibodyPlant.GetPositionsAndVelocities.doc_2args)
+            cls_doc.GetPositionsAndVelocities.doc_2args)
         .def("SetPositionsAndVelocities",
             [](const MultibodyPlant<T>* self, Context<T>* context,
                 const VectorX<T>& q_v) {
               self->SetPositionsAndVelocities(context, q_v);
             },
             py_reference, py::arg("context"), py::arg("q_v"),
-            doc.MultibodyPlant.SetPositionsAndVelocities.doc_2args)
+            cls_doc.SetPositionsAndVelocities.doc_2args)
         .def("SetPositionsAndVelocities",
             [](const MultibodyPlant<T>* self, Context<T>* context,
                 multibody::ModelInstanceIndex model_instance,
@@ -655,66 +638,72 @@ PYBIND11_MODULE(plant, m) {
               self->SetPositionsAndVelocities(context, model_instance, q_v);
             },
             py_reference, py::arg("context"), py::arg("model_instance"),
-            py::arg("q_v"),
-            doc.MultibodyPlant.SetPositionsAndVelocities.doc_3args)
+            py::arg("q_v"), cls_doc.SetPositionsAndVelocities.doc_3args)
         .def("SetDefaultState",
             [](const Class* self, const Context<T>& context, State<T>* state) {
               self->SetDefaultState(context, state);
             },
-            py::arg("context"), py::arg("state"),
-            doc.MultibodyPlant.SetDefaultState.doc);
+            py::arg("context"), py::arg("state"), cls_doc.SetDefaultState.doc);
   }
 
   // PointPairContactInfo
   {
     using Class = PointPairContactInfo<T>;
-    py::class_<Class>(m, "PointPairContactInfo")
+    constexpr auto& cls_doc = doc.PointPairContactInfo;
+    py::class_<Class>(m, "PointPairContactInfo", cls_doc.doc)
         .def(py::init<BodyIndex, BodyIndex, const Vector3<T>, const Vector3<T>,
                  const T&, const T&,
                  const geometry::PenetrationAsPointPair<T>>(),
             py::arg("bodyA_index"), py::arg("bodyB_index"), py::arg("f_Bc_W"),
             py::arg("p_WC"), py::arg("separation_speed"), py::arg("slip_speed"),
-            py::arg("point_pair"))
-        .def("bodyA_index", &Class::bodyA_index)
-        .def("bodyB_index", &Class::bodyB_index)
-        .def("contact_force", &Class::contact_force)
-        .def("contact_point", &Class::contact_point)
-        .def("slip_speed", &Class::slip_speed)
-        .def("separation_speed", &Class::separation_speed)
-        .def("point_pair", &Class::point_pair);
+            py::arg("point_pair"), cls_doc.ctor.doc)
+        .def("bodyA_index", &Class::bodyA_index, cls_doc.bodyA_index.doc)
+        .def("bodyB_index", &Class::bodyB_index, cls_doc.bodyB_index.doc)
+        .def("contact_force", &Class::contact_force, cls_doc.contact_force.doc)
+        .def("contact_point", &Class::contact_point, cls_doc.contact_point.doc)
+        .def("slip_speed", &Class::slip_speed, cls_doc.slip_speed.doc)
+        .def("separation_speed", &Class::separation_speed,
+            cls_doc.separation_speed.doc)
+        .def("point_pair", &Class::point_pair, cls_doc.point_pair.doc);
   }
 
   // ContactResults
   {
     using Class = ContactResults<T>;
-    py::class_<Class>(m, "ContactResults")
-        .def(py::init<>())
-        .def("num_contacts", &Class::num_contacts)
+    constexpr auto& cls_doc = doc.ContactResults;
+    py::class_<Class>(m, "ContactResults", cls_doc.doc)
+        .def(py::init<>(), cls_doc.ctor.doc)
+        .def("num_contacts", &Class::num_contacts, cls_doc.num_contacts.doc)
         .def("AddContactInfo", &Class::AddContactInfo,
-            py::arg("point_pair_info"))
-        .def("contact_info", &Class::contact_info, py::arg("i"));
+            py::arg("point_pair_info"), cls_doc.AddContactInfo.doc)
+        .def("contact_info", &Class::contact_info, py::arg("i"),
+            cls_doc.contact_info.doc);
     pysystems::AddValueInstantiation<Class>(m);
   }
 
   // ContactResultsToLcmSystem
   {
     using Class = ContactResultsToLcmSystem<T>;
-    py::class_<Class, systems::LeafSystem<T>>(m, "ContactResultsToLcmSystem")
+    constexpr auto& cls_doc = doc.ContactResultsToLcmSystem;
+    py::class_<Class, systems::LeafSystem<T>>(
+        m, "ContactResultsToLcmSystem", cls_doc.doc)
         .def(py::init<const MultibodyPlant<double>&>(), py::arg("plant"),
             // Keep alive, reference: `self` keeps `plant` alive.
-            py::keep_alive<1, 2>())
+            py::keep_alive<1, 2>(), cls_doc.ctor.doc)
         .def("get_contact_result_input_port",
-            &Class::get_contact_result_input_port, py_reference_internal)
+            &Class::get_contact_result_input_port, py_reference_internal,
+            cls_doc.get_contact_result_input_port.doc)
         .def("get_lcm_message_output_port", &Class::get_lcm_message_output_port,
-            py_reference_internal);
+            py_reference_internal, cls_doc.get_lcm_message_output_port.doc);
   }
 
   // CoulombFriction
   {
     using Class = CoulombFriction<T>;
-    py::class_<Class>(m, "CoulombFriction")
+    constexpr auto& cls_doc = doc.CoulombFriction;
+    py::class_<Class>(m, "CoulombFriction", cls_doc.doc)
         .def(py::init<const T&, const T&>(), py::arg("static_friction"),
-            py::arg("dynamic_friction"), doc.CoulombFriction.ctor.doc_2args);
+            py::arg("dynamic_friction"), cls_doc.ctor.doc_2args);
   }
 
   m.def("AddMultibodyPlantSceneGraph",
@@ -748,7 +737,8 @@ PYBIND11_MODULE(plant, m) {
       py::keep_alive<2, 1>(),
       // Keep alive, reference transfer: `lcm` keeps `builder` alive.
       py::keep_alive<3, 1>(), py_reference, py::arg("builder"),
-      py::arg("plant"), py::arg("lcm") = nullptr);
+      py::arg("plant"), py::arg("lcm") = nullptr,
+      doc.ConnectContactResultsToDrakeVisualizer.doc_3args);
 }  // NOLINT(readability/fn_size)
 
 }  // namespace pydrake

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -40,6 +40,7 @@ using math::RigidTransform;
 template <typename PyClass>
 void BindMultibodyTreeElementMixin(PyClass* pcls) {
   using Class = typename PyClass::type;
+  // TODO(eric.cousineau): Fix docstring generation for `MultibodyTreeElement`.
   auto& cls = *pcls;
   cls  // BR
       .def("index", &Class::index)
@@ -81,18 +82,20 @@ PYBIND11_MODULE(tree, m) {
   // Frames.
   {
     using Class = Frame<T>;
-    py::class_<Class> cls(m, "Frame", doc.Frame.doc);
+    constexpr auto& cls_doc = doc.Frame;
+    py::class_<Class> cls(m, "Frame", cls_doc.doc);
     BindMultibodyTreeElementMixin(&cls);
     cls  // BR
-        .def("name", &Class::name, doc.Frame.name.doc)
-        .def("body", &Class::body, py_reference_internal, doc.Frame.body.doc)
+        .def("name", &Class::name, cls_doc.name.doc)
+        .def("body", &Class::body, py_reference_internal, cls_doc.body.doc)
         .def("GetFixedPoseInBodyFrame", &Frame<double>::GetFixedPoseInBodyFrame,
-            doc.Frame.GetFixedPoseInBodyFrame.doc);
+            cls_doc.GetFixedPoseInBodyFrame.doc);
   }
 
   {
     using Class = BodyFrame<T>;
-    py::class_<Class, Frame<T>> cls(m, "BodyFrame", doc.BodyFrame.doc);
+    constexpr auto& cls_doc = doc.BodyFrame;
+    py::class_<Class, Frame<T>> cls(m, "BodyFrame", cls_doc.doc);
     // No need to re-bind element mixins from `Frame`.
   }
 
@@ -118,60 +121,62 @@ PYBIND11_MODULE(tree, m) {
   // Bodies.
   {
     using Class = Body<T>;
-    py::class_<Class> cls(m, "Body", doc.Body.doc);
+    constexpr auto& cls_doc = doc.Body;
+    py::class_<Class> cls(m, "Body", cls_doc.doc);
     BindMultibodyTreeElementMixin(&cls);
     cls  // BR
-        .def("name", &Class::name, doc.Body.name.doc)
+        .def("name", &Class::name, cls_doc.name.doc)
         .def("body_frame", &Class::body_frame, py_reference_internal,
-            doc.Body.body_frame.doc);
+            cls_doc.body_frame.doc);
   }
 
   {
     using Class = RigidBody<T>;
-    py::class_<Class, Body<T>> cls(m, "RigidBody", doc.RigidBody.doc);
+    constexpr auto& cls_doc = doc.RigidBody;
+    py::class_<Class, Body<T>> cls(m, "RigidBody", cls_doc.doc);
   }
 
   // Joints.
   {
     using Class = Joint<T>;
-    py::class_<Class> cls(m, "Joint", doc.Joint.doc);
+    constexpr auto& cls_doc = doc.Joint;
+    py::class_<Class> cls(m, "Joint", cls_doc.doc);
     BindMultibodyTreeElementMixin(&cls);
     cls  // BR
-        .def("name", &Class::name, doc.Joint.name.doc)
+        .def("name", &Class::name, cls_doc.name.doc)
         .def("parent_body", &Class::parent_body, py_reference_internal,
-            doc.Joint.parent_body.doc)
+            cls_doc.parent_body.doc)
         .def("child_body", &Class::child_body, py_reference_internal,
-            doc.Joint.child_body.doc)
+            cls_doc.child_body.doc)
         .def("frame_on_parent", &Class::frame_on_parent, py_reference_internal,
-            doc.Joint.frame_on_parent.doc)
+            cls_doc.frame_on_parent.doc)
         .def("frame_on_child", &Class::frame_on_child, py_reference_internal,
-            doc.Joint.frame_on_child.doc)
+            cls_doc.frame_on_child.doc)
         .def("position_start", &Class::position_start,
-            doc.Joint.position_start.doc)
+            cls_doc.position_start.doc)
         .def("velocity_start", &Class::velocity_start,
-            doc.Joint.velocity_start.doc)
-        .def(
-            "num_positions", &Class::num_positions, doc.Joint.num_positions.doc)
+            cls_doc.velocity_start.doc)
+        .def("num_positions", &Class::num_positions, cls_doc.num_positions.doc)
         .def("num_velocities", &Class::num_velocities,
-            doc.Joint.num_velocities.doc)
+            cls_doc.num_velocities.doc)
         .def("position_lower_limits", &Class::position_lower_limits,
-            doc.Joint.position_lower_limits.doc)
+            cls_doc.position_lower_limits.doc)
         .def("position_upper_limits", &Class::position_upper_limits,
-            doc.Joint.position_upper_limits.doc)
+            cls_doc.position_upper_limits.doc)
         .def("velocity_lower_limits", &Class::velocity_lower_limits,
-            doc.Joint.velocity_lower_limits.doc)
+            cls_doc.velocity_lower_limits.doc)
         .def("velocity_upper_limits", &Class::velocity_upper_limits,
-            doc.Joint.velocity_upper_limits.doc)
+            cls_doc.velocity_upper_limits.doc)
         .def("acceleration_lower_limits", &Class::acceleration_lower_limits,
-            doc.Joint.acceleration_lower_limits.doc)
+            cls_doc.acceleration_lower_limits.doc)
         .def("acceleration_upper_limits", &Class::acceleration_upper_limits,
-            doc.Joint.acceleration_upper_limits.doc);
+            cls_doc.acceleration_upper_limits.doc);
   }
 
   {
     using Class = PrismaticJoint<T>;
-    py::class_<Class, Joint<T>> cls(
-        m, "PrismaticJoint", doc.PrismaticJoint.doc);
+    constexpr auto& cls_doc = doc.PrismaticJoint;
+    py::class_<Class, Joint<T>> cls(m, "PrismaticJoint", cls_doc.doc);
     cls  // BR
         .def(py::init<const string&, const Frame<T>&, const Frame<T>&,
                  const Vector3<T>&, double, double, double>(),
@@ -181,41 +186,43 @@ PYBIND11_MODULE(tree, m) {
                 -std::numeric_limits<double>::infinity(),
             py::arg("pos_upper_limit") =
                 std::numeric_limits<double>::infinity(),
-            py::arg("damping") = 0, doc.RevoluteJoint.ctor.doc_7args)
+            py::arg("damping") = 0, cls_doc.ctor.doc)
         .def("get_translation", &Class::get_translation, py::arg("context"),
-            doc.PrismaticJoint.get_translation.doc)
+            cls_doc.get_translation.doc)
         .def("set_translation", &Class::set_translation, py::arg("context"),
-            py::arg("translation"), doc.PrismaticJoint.set_translation.doc)
+            py::arg("translation"), cls_doc.set_translation.doc)
         .def("get_translation_rate", &Class::get_translation_rate,
-            py::arg("context"), doc.PrismaticJoint.get_translation_rate.doc)
+            py::arg("context"), cls_doc.get_translation_rate.doc)
         .def("set_translation_rate", &Class::set_translation_rate,
             py::arg("context"), py::arg("translation_dot"),
-            doc.PrismaticJoint.set_translation_rate.doc);
+            cls_doc.set_translation_rate.doc);
   }
 
   {
     using Class = RevoluteJoint<T>;
-    py::class_<Class, Joint<T>> cls(m, "RevoluteJoint", doc.RevoluteJoint.doc);
+    constexpr auto& cls_doc = doc.RevoluteJoint;
+    py::class_<Class, Joint<T>> cls(m, "RevoluteJoint", cls_doc.doc);
     cls  // BR
         .def(py::init<const string&, const Frame<T>&, const Frame<T>&,
                  const Vector3<T>&, double>(),
             py::arg("name"), py::arg("frame_on_parent"),
             py::arg("frame_on_child"), py::arg("axis"), py::arg("damping") = 0,
-            doc.RevoluteJoint.ctor.doc_5args)
+            cls_doc.ctor.doc_5args)
         .def("get_angle", &Class::get_angle, py::arg("context"),
-            doc.RevoluteJoint.get_angle.doc)
+            cls_doc.get_angle.doc)
         .def("set_angle", &Class::set_angle, py::arg("context"),
-            py::arg("angle"), doc.RevoluteJoint.set_angle.doc);
+            py::arg("angle"), cls_doc.set_angle.doc);
   }
 
   {
     using Class = WeldJoint<T>;
-    py::class_<Class, Joint<T>> cls(m, "WeldJoint", doc.WeldJoint.doc);
+    constexpr auto& cls_doc = doc.WeldJoint;
+    py::class_<Class, Joint<T>> cls(m, "WeldJoint", cls_doc.doc);
     cls  // BR
         .def(py::init<const string&, const Frame<T>&, const Frame<T>&,
                  const RigidTransform<T>&>(),
             py::arg("name"), py::arg("parent_frame_P"),
-            py::arg("child_frame_C"), py::arg("X_PC"), doc.WeldJoint.ctor.doc)
+            py::arg("child_frame_C"), py::arg("X_PC"), cls_doc.ctor.doc)
         .def(py::init(
                  [](const std::string& name, const Frame<T>& parent_frame_P,
                      const Frame<T>& child_frame_C, const Isometry3<T>& X_PC) {
@@ -230,34 +237,37 @@ PYBIND11_MODULE(tree, m) {
   // Actuators.
   {
     using Class = JointActuator<T>;
-    py::class_<Class> cls(m, "JointActuator", doc.JointActuator.doc);
+    constexpr auto& cls_doc = doc.JointActuator;
+    py::class_<Class> cls(m, "JointActuator", cls_doc.doc);
     BindMultibodyTreeElementMixin(&cls);
     cls  // BR
-        .def("name", &Class::name, doc.JointActuator.name.doc)
-        .def("joint", &Class::joint, py_reference_internal,
-            doc.JointActuator.joint.doc);
+        .def("name", &Class::name, cls_doc.name.doc)
+        .def("joint", &Class::joint, py_reference_internal, cls_doc.joint.doc);
   }
 
   // Force Elements.
   {
     using Class = ForceElement<T>;
-    py::class_<Class> cls(m, "ForceElement", doc.ForceElement.doc);
+    constexpr auto& cls_doc = doc.ForceElement;
+    py::class_<Class> cls(m, "ForceElement", cls_doc.doc);
     BindMultibodyTreeElementMixin(&cls);
   }
 
   {
     using Class = UniformGravityFieldElement<T>;
+    constexpr auto& cls_doc = doc.UniformGravityFieldElement;
     py::class_<Class, ForceElement<T>>(
-        m, "UniformGravityFieldElement", doc.UniformGravityFieldElement.doc)
-        .def(py::init<>(), doc.UniformGravityFieldElement.ctor.doc_0args)
+        m, "UniformGravityFieldElement", cls_doc.doc)
+        .def(py::init<>(), cls_doc.ctor.doc_0args)
         .def(py::init<Vector3<double>>(), py::arg("g_W"),
-            doc.UniformGravityFieldElement.ctor.doc_1args);
+            cls_doc.ctor.doc_1args);
   }
 
   // MultibodyForces
   {
     using Class = MultibodyForces<T>;
-    py::class_<Class> cls(m, "MultibodyForces", doc.MultibodyForces.doc);
+    constexpr auto& cls_doc = doc.MultibodyForces;
+    py::class_<Class> cls(m, "MultibodyForces", cls_doc.doc);
     // Custom constructor so that in Python we can take a MultibodyPlant
     // instead of a MultibodyTreeSystem.
     // N.B. This depends on `plant_py.cc`, but this codepath will only be
@@ -266,7 +276,7 @@ PYBIND11_MODULE(tree, m) {
     cls.def(py::init([](const MultibodyPlant<T>& plant) {
       return std::make_unique<MultibodyForces<T>>(plant);
     }),
-        py::arg("plant"), doc.MultibodyForces.ctor.doc_1args_plant);
+        py::arg("plant"), cls_doc.ctor.doc_1args_plant);
   }
 
   {

--- a/bindings/pydrake/pydrake_doxygen.h
+++ b/bindings/pydrake/pydrake_doxygen.h
@@ -184,6 +184,19 @@ An example of supplying custom strings:
     }
 ~~~
 
+@note Consider using scoped aliases to abbreviate both the usage of bound types
+and the docstring structures. Borrowing from above:
+
+~~~{.cc}
+    {
+      using Class = RigidTransform<T>;
+      constexpr auto& cls_doc = doc.RigidTransform;
+      py::class_<Class>(m, "RigidTransform", cls_doc.doc)
+          .def(py::init(), cls_doc.ctor.doc_0args)
+          ...
+    }
+~~~
+
 To view the documentation rendered in Sphinx:
 
     bazel run //bindings/pydrake/doc:serve_sphinx [-- --browser=false]

--- a/bindings/pydrake/systems/sensors_py.cc
+++ b/bindings/pydrake/systems/sensors_py.cc
@@ -181,8 +181,8 @@ PYBIND11_MODULE(sensors, m) {
           doc.CameraInfo.intrinsic_matrix.doc);
 
   {
-    constexpr auto& cls_doc = doc.ImageToLcmImageArrayT;
     using Class = ImageToLcmImageArrayT;
+    constexpr auto& cls_doc = doc.ImageToLcmImageArrayT;
     py::class_<Class, LeafSystem<T>> cls(
         m, "ImageToLcmImageArrayT", cls_doc.doc);
     cls  // BR


### PR DESCRIPTION
I've employed this, and like to use this when the class name is noisy (templated) or long. Same with docstrings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11237)
<!-- Reviewable:end -->
