### PR TITLE
pydrake doc: Add explicit guideline for use of `py::arg`

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -40,6 +40,11 @@ int GetVariableSize(const multibody::MultibodyPlant<T>& plant,
   DRAKE_UNREACHABLE();
 }
 
+constexpr char doc_iso3_deprecation[] = R"""(
+This API using Isometry3 is / will be deprecated soon with the resolution of
+#9865. We only offer it for backwards compatibility. DO NOT USE!.
+)""";
+
 PYBIND11_MODULE(plant, m) {
   PYDRAKE_PREVENT_PYTHON3_MODULE_REIMPORT(m);
 
@@ -53,11 +58,6 @@ PYBIND11_MODULE(plant, m) {
   py::module::import("pydrake.multibody.math");
   py::module::import("pydrake.multibody.tree");
   py::module::import("pydrake.systems.framework");
-
-  constexpr char doc_iso3_deprecation[] =
-      "This API using Isometry3 is / will be deprecated soon with the "
-      "resolution of #9865. We only offer it for backwards compatibility. DO "
-      "NOT USE!.";
 
   {
     using Class = MultibodyPlant<T>;
@@ -121,8 +121,7 @@ PYBIND11_MODULE(plant, m) {
             py::arg("X_AB") = RigidTransform<double>::Identity(),
             py_reference_internal, doc.MultibodyPlant.WeldFrames.doc)
         .def("WeldFrames",
-            [doc_iso3_deprecation](Class* self, const Frame<T>& A,
-                const Frame<T>& B,
+            [](Class* self, const Frame<T>& A, const Frame<T>& B,
                 const Isometry3<double>& X_AB) -> const WeldJoint<T>& {
               WarnDeprecated(doc_iso3_deprecation);
               return self->WeldFrames(A, B, RigidTransform<double>(X_AB));
@@ -186,8 +185,8 @@ PYBIND11_MODULE(plant, m) {
             py::arg("context"), py::arg("body"), py::arg("X_WB"),
             doc.MultibodyPlant.SetFreeBodyPose.doc_3args)
         .def("SetFreeBodyPose",
-            [doc_iso3_deprecation](const Class* self, Context<T>* context,
-                const Body<T>& body, const Isometry3<T>& X_WB) {
+            [](const Class* self, Context<T>* context, const Body<T>& body,
+                const Isometry3<T>& X_WB) {
               WarnDeprecated(doc_iso3_deprecation);
               return self->SetFreeBodyPose(
                   context, body, RigidTransform<T>(X_WB));
@@ -456,9 +455,9 @@ PYBIND11_MODULE(plant, m) {
             doc.MultibodyPlant.RegisterVisualGeometry
                 .doc_6args_body_X_BG_shape_name_diffuse_color_scene_graph)
         .def("RegisterVisualGeometry",
-            [doc_iso3_deprecation](Class* self, const Body<T>& body,
-                const Isometry3<double>& X_BG, const geometry::Shape& shape,
-                const std::string& name, const Vector4<double>& diffuse_color,
+            [](Class* self, const Body<T>& body, const Isometry3<double>& X_BG,
+                const geometry::Shape& shape, const std::string& name,
+                const Vector4<double>& diffuse_color,
                 geometry::SceneGraph<T>* scene_graph) {
               WarnDeprecated(doc_iso3_deprecation);
               return self->RegisterVisualGeometry(body,
@@ -477,9 +476,8 @@ PYBIND11_MODULE(plant, m) {
             py::arg("coulomb_friction"), py::arg("scene_graph") = nullptr,
             doc.MultibodyPlant.RegisterCollisionGeometry.doc)
         .def("RegisterCollisionGeometry",
-            [doc_iso3_deprecation](Class* self, const Body<T>& body,
-                const Isometry3<double>& X_BG, const geometry::Shape& shape,
-                const std::string& name,
+            [](Class* self, const Body<T>& body, const Isometry3<double>& X_BG,
+                const geometry::Shape& shape, const std::string& name,
                 const CoulombFriction<double>& coulomb_friction,
                 geometry::SceneGraph<T>* scene_graph) {
               WarnDeprecated(doc_iso3_deprecation);

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -50,6 +50,11 @@ void BindMultibodyTreeElementMixin(PyClass* pcls) {
       cls, "get_parent_tree", "`get_parent_tree()` will soon be internal.");
 }
 
+constexpr char doc_iso3_deprecation[] = R"""(
+This API using Isometry3 is / will be deprecated soon with the resolution of
+#9865. We only offer it for backwards compatibility. DO NOT USE!.
+)""";
+
 PYBIND11_MODULE(tree, m) {
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
   using namespace drake::multibody;
@@ -72,11 +77,6 @@ PYBIND11_MODULE(tree, m) {
   BindTypeSafeIndex<ModelInstanceIndex>(
       m, "ModelInstanceIndex", doc.ModelInstanceIndex.doc);
   m.def("world_index", &world_index, doc.world_index.doc);
-
-  constexpr char doc_iso3_deprecation[] =
-      "This API using Isometry3 is / will be deprecated soon with the "
-      "resolution of #9865. We only offer it for backwards compatibility. DO "
-      "NOT USE!.";
 
   // Frames.
   {
@@ -104,8 +104,8 @@ PYBIND11_MODULE(tree, m) {
                  const RigidTransform<T>&, optional<ModelInstanceIndex>>(),
             py::arg("name"), py::arg("P"), py::arg("X_PF"),
             py::arg("model_instance") = nullopt, cls_doc.ctor.doc_4args)
-        .def(py::init([doc_iso3_deprecation](const std::string& name,
-                          const Frame<T>& P, const Isometry3<T>& X_PF,
+        .def(py::init([](const std::string& name, const Frame<T>& P,
+                          const Isometry3<T>& X_PF,
                           optional<ModelInstanceIndex> model_instance) {
           WarnDeprecated(doc_iso3_deprecation);
           return std::make_unique<Class>(
@@ -217,8 +217,7 @@ PYBIND11_MODULE(tree, m) {
             py::arg("name"), py::arg("parent_frame_P"),
             py::arg("child_frame_C"), py::arg("X_PC"), doc.WeldJoint.ctor.doc)
         .def(py::init(
-                 [doc_iso3_deprecation](const std::string& name,
-                     const Frame<T>& parent_frame_P,
+                 [](const std::string& name, const Frame<T>& parent_frame_P,
                      const Frame<T>& child_frame_C, const Isometry3<T>& X_PC) {
                    WarnDeprecated(doc_iso3_deprecation);
                    return std::make_unique<Class>(name, parent_frame_P,

--- a/bindings/pydrake/pydrake_doxygen.h
+++ b/bindings/pydrake/pydrake_doxygen.h
@@ -62,13 +62,22 @@ derived class, you should use
 
 # Conventions
 
-## API Names
+## API
 
 Any Python bindings of C++ code will maintain C++ naming conventions, as well
 as Python code that is directly related to C++ symbols (e.g. shims, wrappers,
 or extensions on existing bound classes).
 
 All other Python code be Pythonic and use PEP 8 naming conventions.
+
+For binding functions or methods, argument names should be provided that
+correspond exactly to the C++ signatures using `py::arg("arg_name")`. This
+permits the C++ documentation to be relevant to the Sphinx-generated
+@ref PydrakeDoc "documentation", and allows for the keyword-arguments to be
+used in Python.
+
+For binding functions, methods, properties, and classes, docstrings should be
+provided. These should be provided as described @ref PydrakeDoc "here".
 
 ## Target Conventions
 
@@ -132,8 +141,14 @@ Drake uses a modified version of `mkdoc.py` from `pybind11`, where `libclang`
 Python bindings are used to generate C++ docstrings accessible to the C++
 binding code.
 
-An example of incorporating docstrings:
+These docstrings are avaialable within `constexpr struct ... pydrake_doc`
+as `const char*` values . When these are not available or not suitable for
+Python documentation, provide custom strings. If this custom string is long,
+consider placing them in a heredoc string.
 
+An example of incorporating docstrings from `pydrake_doc`:
+
+~~~{.cc}
     #include "drake/bindings/pydrake/documentation_pybind.h"
 
     PYBIND11_MODULE(math, m) {
@@ -141,10 +156,10 @@ An example of incorporating docstrings:
       constexpr auto& doc = pydrake_doc.drake.math;
       using T = double;
       py::class_<RigidTransform<T>>(m, "RigidTransform", doc.RigidTransform.doc)
-          .def(py::init(), doc.ExampleClass.ctor.doc_0args)
+          .def(py::init(), doc.RigidTransform.ctor.doc_0args)
           ...
           .def(py::init<const RotationMatrix<T>&>(), py::arg("R"),
-              doc.RigidTransform.ctor.doc_1args)
+              doc.RigidTransform.ctor.doc_1args_R)
           .def(py::init<const Eigen::Quaternion<T>&, const Vector3<T>&>(),
               py::arg("quaternion"), py::arg("p"),
               doc.RigidTransform.ctor.doc_2args_quaternion_p)
@@ -153,6 +168,21 @@ An example of incorporating docstrings:
               doc.RigidTransform.set_rotation.doc)
       ...
     }
+~~~
+
+An example of supplying custom strings:
+
+~~~{.cc}
+    constexpr char another_helper_doc[] = R"""(
+    Another helper docstring. This is really long.
+    And has multiple lines.
+    )""";
+
+    PYBIND11_MODULE(example, m) {
+      m.def("helper", []() { return 42; }, "My helper method");
+      m.def("another_helper", []() { return 10; }, another_helper_doc);
+    }
+~~~
 
 To view the documentation rendered in Sphinx:
 


### PR DESCRIPTION
Fix staleness in example

This might be able to address proposal 1 in #11234.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11238)
<!-- Reviewable:end -->
