### PR TITLE
pendulum: Split PendulumGeometry from PendulumPlant

### DIFF
--- a/examples/pendulum/BUILD.bazel
+++ b/examples/pendulum/BUILD.bazel
@@ -32,10 +32,23 @@ drake_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":pendulum_vector_types",
+        "//systems/framework:leaf_system",
+    ],
+)
+
+drake_cc_library(
+    name = "pendulum_geometry",
+    srcs = ["pendulum_geometry.cc"],
+    hdrs = ["pendulum_geometry.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":pendulum_plant",
+        ":pendulum_vector_types",
         "//geometry:geometry_visualization",
         "//geometry:scene_graph",
         "//math:geometric_transform",
-        "//systems/framework",
+        "//systems/framework:diagram_builder",
+        "//systems/framework:leaf_system",
     ],
 )
 
@@ -46,10 +59,9 @@ drake_cc_binary(
     data = [":models"],
     test_rule_args = ["--target_realtime_rate=0.0"],
     deps = [
+        ":pendulum_geometry",
         ":pendulum_plant",
-        "//common:find_resource",
         "//geometry:geometry_visualization",
-        "//lcm",
         "//systems/analysis:simulator",
         "//systems/framework:diagram",
         "//systems/primitives:constant_vector_source",
@@ -64,10 +76,9 @@ drake_cc_binary(
     data = [":models"],
     test_rule_args = ["--target_realtime_rate=0.0"],
     deps = [
+        ":pendulum_geometry",
         ":pendulum_plant",
-        "//common:find_resource",
         "//geometry:geometry_visualization",
-        "//lcm",
         "//systems/analysis:simulator",
         "//systems/framework:diagram",
         "//systems/framework:leaf_system",
@@ -82,11 +93,10 @@ drake_cc_binary(
     data = [":models"],
     test_rule_args = ["--target_realtime_rate=0.0"],
     deps = [
+        ":pendulum_geometry",
         ":pendulum_plant",
-        "//common:find_resource",
         "//common:is_approx_equal_abstol",
         "//geometry:geometry_visualization",
-        "//lcm",
         "//systems/analysis:simulator",
         "//systems/controllers:linear_quadratic_regulator",
         "//systems/framework:diagram",
@@ -104,15 +114,14 @@ drake_cc_binary(
     # Non-deterministic IPOPT-related failures on macOS, see #10276.
     test_rule_flaky = 1,
     deps = [
+        ":pendulum_geometry",
         ":pendulum_plant",
-        "//common:find_resource",
         "//common:is_approx_equal_abstol",
         "//geometry:geometry_visualization",
-        "//lcm",
         "//solvers:solve",
         "//systems/analysis:simulator",
         "//systems/controllers:pid_controlled_system",
-        "//systems/framework",
+        "//systems/framework:diagram",
         "//systems/primitives:trajectory_source",
         "//systems/trajectory_optimization:direct_collocation",
         "@gflags",
@@ -154,6 +163,15 @@ drake_cc_googletest(
         "//attic/multibody/rigid_body_plant",
         "//common:find_resource",
         "//common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "pendulum_geometry_test",
+    deps = [
+        ":pendulum_geometry",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//math:geometric_transform",
     ],
 )
 

--- a/examples/pendulum/energy_shaping_simulation.cc
+++ b/examples/pendulum/energy_shaping_simulation.cc
@@ -1,13 +1,11 @@
 #include <cmath>
-#include <memory>
 
 #include <gflags/gflags.h>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/find_resource.h"
+#include "drake/examples/pendulum/pendulum_geometry.h"
 #include "drake/examples/pendulum/pendulum_plant.h"
 #include "drake/geometry/geometry_visualization.h"
-#include "drake/lcm/drake_lcm.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram.h"
 #include "drake/systems/framework/diagram_builder.h"
@@ -70,16 +68,13 @@ int DoMain() {
   auto controller = builder.AddSystem<PendulumEnergyShapingController>(
       params);
   controller->set_name("controller");
-  builder.Connect(pendulum->get_state_output_port(), controller->get_input_port
-      (0));
+  builder.Connect(pendulum->get_state_output_port(),
+                  controller->get_input_port(0));
   builder.Connect(controller->get_output_port(0), pendulum->get_input_port());
-
   auto scene_graph = builder.AddSystem<geometry::SceneGraph>();
-  pendulum->RegisterGeometry(params, scene_graph);
-  builder.Connect(pendulum->get_geometry_pose_output_port(),
-                  scene_graph->get_source_pose_port(pendulum->source_id()));
-
-  geometry::ConnectDrakeVisualizer(&builder, *scene_graph);
+  PendulumGeometry::AddToBuilder(
+      &builder, pendulum->get_state_output_port(), scene_graph);
+  ConnectDrakeVisualizer(&builder, *scene_graph);
   auto diagram = builder.Build();
 
   systems::Simulator<double> simulator(*diagram);

--- a/examples/pendulum/lqr_simulation.cc
+++ b/examples/pendulum/lqr_simulation.cc
@@ -1,20 +1,14 @@
-#include <cmath>
-#include <memory>
-
 #include <gflags/gflags.h>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/find_resource.h"
 #include "drake/common/is_approx_equal_abstol.h"
+#include "drake/examples/pendulum/pendulum_geometry.h"
 #include "drake/examples/pendulum/pendulum_plant.h"
 #include "drake/geometry/geometry_visualization.h"
-#include "drake/lcm/drake_lcm.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/controllers/linear_quadratic_regulator.h"
-#include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/diagram.h"
 #include "drake/systems/framework/diagram_builder.h"
-#include "drake/systems/framework/fixed_input_port_value.h"
 #include "drake/systems/framework/leaf_system.h"
 
 namespace drake {
@@ -36,9 +30,8 @@ int DoMain() {
   auto& desired_state = pendulum->get_mutable_state(pendulum_context.get());
   desired_state.set_theta(M_PI);
   desired_state.set_thetadot(0);
-  auto input = std::make_unique<PendulumInput<double>>();
-  input->set_tau(0.0);
-  pendulum_context->FixInputPort(0, std::move(input));
+  pendulum->get_input_port().FixValue(
+      pendulum_context.get(), PendulumInput<double>{}.with_tau(0.0));
 
   // Set up cost function for LQR: integral of 10*theta^2 + thetadot^2 + tau^2.
   // The factor of 10 is heuristic, but roughly accounts for the unit conversion
@@ -58,12 +51,9 @@ int DoMain() {
   builder.Connect(controller->get_output_port(), pendulum->get_input_port());
 
   auto scene_graph = builder.AddSystem<geometry::SceneGraph>();
-  pendulum->RegisterGeometry(pendulum->get_parameters(*pendulum_context),
-                             scene_graph);
-  builder.Connect(pendulum->get_geometry_pose_output_port(),
-                  scene_graph->get_source_pose_port(pendulum->source_id()));
-
-  geometry::ConnectDrakeVisualizer(&builder, *scene_graph);
+  PendulumGeometry::AddToBuilder(
+      &builder, pendulum->get_state_output_port(), scene_graph);
+  ConnectDrakeVisualizer(&builder, *scene_graph);
   auto diagram = builder.Build();
 
   systems::Simulator<double> simulator(*diagram);

--- a/examples/pendulum/passive_simulation.cc
+++ b/examples/pendulum/passive_simulation.cc
@@ -1,11 +1,8 @@
-#include <memory>
-
 #include <gflags/gflags.h>
 
-#include "drake/common/find_resource.h"
+#include "drake/examples/pendulum/pendulum_geometry.h"
 #include "drake/examples/pendulum/pendulum_plant.h"
 #include "drake/geometry/geometry_visualization.h"
-#include "drake/lcm/drake_lcm.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram.h"
 #include "drake/systems/framework/diagram_builder.h"
@@ -21,24 +18,17 @@ DEFINE_double(target_realtime_rate, 1.0,
               "Simulator::set_target_realtime_rate() for details.");
 
 int DoMain() {
-  PendulumParams<double> params;
-
-  PendulumInput<double> input;
-  input.set_tau(0.0);
-
   systems::DiagramBuilder<double> builder;
-  auto source = builder.AddSystem<systems::ConstantVectorSource>(input);
-  source->set_name("tau");
+  auto source = builder.AddSystem<systems::ConstantVectorSource>(
+      PendulumInput<double>{}.with_tau(0.0));
+  source->set_name("source");
   auto pendulum = builder.AddSystem<PendulumPlant>();
   pendulum->set_name("pendulum");
-  builder.Connect(source->get_output_port(), pendulum->get_input_port());
-
+  builder.Connect(*source, *pendulum);
   auto scene_graph = builder.AddSystem<geometry::SceneGraph>();
-  pendulum->RegisterGeometry(params, scene_graph);
-  builder.Connect(pendulum->get_geometry_pose_output_port(),
-                  scene_graph->get_source_pose_port(pendulum->source_id()));
-
-  geometry::ConnectDrakeVisualizer(&builder, *scene_graph);
+  PendulumGeometry::AddToBuilder(
+      &builder, pendulum->get_state_output_port(), scene_graph);
+  ConnectDrakeVisualizer(&builder, *scene_graph);
   auto diagram = builder.Build();
 
   systems::Simulator<double> simulator(*diagram);

--- a/examples/pendulum/pendulum_geometry.cc
+++ b/examples/pendulum/pendulum_geometry.cc
@@ -1,0 +1,112 @@
+#include "drake/examples/pendulum/pendulum_geometry.h"
+
+#include <memory>
+#include <utility>
+
+#include "drake/examples/pendulum/gen/pendulum_params.h"
+#include "drake/examples/pendulum/gen/pendulum_state.h"
+#include "drake/geometry/geometry_frame.h"
+#include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/geometry_instance.h"
+#include "drake/geometry/geometry_visualization.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/math/rotation_matrix.h"
+
+namespace drake {
+namespace examples {
+namespace pendulum {
+
+using Eigen::Isometry3d;
+using Eigen::Translation3d;
+using Eigen::Vector4d;
+using geometry::Box;
+using geometry::Cylinder;
+using geometry::GeometryFrame;
+using geometry::GeometryId;
+using geometry::GeometryInstance;
+using geometry::MakeDrakeVisualizerProperties;
+using geometry::Sphere;
+using std::make_unique;
+
+const PendulumGeometry* PendulumGeometry::AddToBuilder(
+    systems::DiagramBuilder<double>* builder,
+    const systems::OutputPort<double>& pendulum_state,
+    geometry::SceneGraph<double>* scene_graph) {
+  DRAKE_THROW_UNLESS(builder != nullptr);
+  DRAKE_THROW_UNLESS(scene_graph != nullptr);
+
+  auto pendulum_geometry = builder->AddSystem(
+      std::unique_ptr<PendulumGeometry>(
+          new PendulumGeometry(scene_graph)));
+  builder->Connect(
+      pendulum_state,
+      pendulum_geometry->get_input_port(0));
+  builder->Connect(
+      pendulum_geometry->get_output_port(0),
+      scene_graph->get_source_pose_port(pendulum_geometry->source_id_));
+
+  return pendulum_geometry;
+}
+
+PendulumGeometry::PendulumGeometry(geometry::SceneGraph<double>* scene_graph) {
+  DRAKE_THROW_UNLESS(scene_graph != nullptr);
+  source_id_ = scene_graph->RegisterSource("pendulum");
+  frame_id_ = scene_graph->RegisterFrame(source_id_, GeometryFrame("arm"));
+
+  this->DeclareVectorInputPort("state", PendulumState<double>());
+  this->DeclareAbstractOutputPort(
+      "geometry_pose", &PendulumGeometry::OutputGeometryPose);
+
+  // TODO(jwnimmer-tri) This registration fails to reflect any non-default
+  // parameters.  Ideally, it should happen in an Initialize event that
+  // modifies the Context, or the output port should express the geometries
+  // themselves instead of just their poses, or etc.
+  const PendulumParams<double> params;
+  const double length = params.length();
+  const double mass = params.mass();
+
+  // The base.
+  GeometryId id = scene_graph->RegisterAnchoredGeometry(
+      source_id_,
+      make_unique<GeometryInstance>(Isometry3d(Translation3d(0., 0., .025)),
+                                    make_unique<Box>(.05, 0.05, 0.05), "base"));
+  scene_graph->AssignRole(
+      source_id_, id, MakeDrakeVisualizerProperties(Vector4d(.3, .6, .4, 1)));
+
+  // The arm.
+  id = scene_graph->RegisterGeometry(
+      source_id_, frame_id_,
+      make_unique<GeometryInstance>(
+          Isometry3d(Translation3d(0, 0, -length / 2.)),
+          make_unique<Cylinder>(0.01, length), "arm"));
+  scene_graph->AssignRole(
+      source_id_, id, MakeDrakeVisualizerProperties(Vector4d(.9, .1, 0, 1)));
+
+  // The mass at the end of the arm.
+  id = scene_graph->RegisterGeometry(
+      source_id_, frame_id_,
+      make_unique<GeometryInstance>(
+          Isometry3d(Translation3d(0, 0, -length)),
+          make_unique<Sphere>(mass / 40.), "arm point mass"));
+  scene_graph->AssignRole(
+      source_id_, id, MakeDrakeVisualizerProperties(Vector4d(0, 0, 1, 1)));
+}
+
+void PendulumGeometry::OutputGeometryPose(
+    const systems::Context<double>& context,
+    geometry::FramePoseVector<double>* poses) const {
+  DRAKE_DEMAND(source_id_.is_valid());
+  DRAKE_DEMAND(frame_id_.is_valid());
+
+  const auto& input = get_input_port(0).Eval<PendulumState<double>>(context);
+  const double theta = input.theta();
+  const math::RigidTransformd pose(math::RotationMatrixd::MakeYRotation(theta));
+
+  *poses = geometry::FramePoseVector<double>(source_id_, {frame_id_});
+  poses->clear();
+  poses->set_value(frame_id_, pose.GetAsIsometry3());
+}
+
+}  // namespace pendulum
+}  // namespace examples
+}  // namespace drake

--- a/examples/pendulum/pendulum_geometry.h
+++ b/examples/pendulum/pendulum_geometry.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "drake/examples/pendulum/pendulum_plant.h"
+#include "drake/geometry/scene_graph.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace examples {
+namespace pendulum {
+
+/// Expresses a PendulumPlants's geometry to a SceneGraph.
+///
+/// @system{PendulumGeometry,
+///    @input_port{state},
+///    @output_port{geometry_pose}
+/// }
+///
+/// This class has no public constructor; instead use the AddToBuilder() static
+/// method to create and add it to a DiagramBuilder directly.
+class PendulumGeometry final : public systems::LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PendulumGeometry);
+
+  /// Creates, adds, and connects a PendulumGeometry system into the given
+  /// `builder`.  Both the `pendulum_state.get_system()` and `scene_graph`
+  /// systems must have been added to the given `builder` already.
+  ///
+  /// The `scene_graph` pointer is not retained by the %PendulumGeometry system.
+  /// The return value pointer is an alias of the new %PendulumGeometry system
+  /// that is owned by the `builder`.
+  static const PendulumGeometry* AddToBuilder(
+      systems::DiagramBuilder<double>* builder,
+      const systems::OutputPort<double>& pendulum_state,
+      geometry::SceneGraph<double>* scene_graph);
+
+ private:
+  explicit PendulumGeometry(geometry::SceneGraph<double>*);
+  void OutputGeometryPose(const systems::Context<double>&,
+                          geometry::FramePoseVector<double>*) const;
+
+  // Geometry source identifier for this system to interact with SceneGraph.
+  geometry::SourceId source_id_;
+  // The id for the pendulum (arm + point mass) frame.
+  geometry::FrameId frame_id_;
+};
+
+}  // namespace pendulum
+}  // namespace examples
+}  // namespace drake

--- a/examples/pendulum/pendulum_plant.cc
+++ b/examples/pendulum/pendulum_plant.cc
@@ -3,36 +3,17 @@
 #include <cmath>
 
 #include "drake/common/default_scalars.h"
-#include "drake/geometry/geometry_frame.h"
-#include "drake/geometry/geometry_ids.h"
-#include "drake/geometry/geometry_instance.h"
-#include "drake/geometry/geometry_visualization.h"
-#include "drake/math/rotation_matrix.h"
 
 namespace drake {
 namespace examples {
 namespace pendulum {
 
-using Eigen::Isometry3d;
-using Eigen::Translation3d;
-using Eigen::Vector4d;
-using geometry::Box;
-using geometry::Cylinder;
-using geometry::GeometryFrame;
-using geometry::GeometryId;
-using geometry::GeometryInstance;
-using geometry::MakeDrakeVisualizerProperties;
-using geometry::Sphere;
-using std::make_unique;
-
 template <typename T>
 PendulumPlant<T>::PendulumPlant()
     : systems::LeafSystem<T>(
           systems::SystemTypeTag<pendulum::PendulumPlant>{}) {
-  this->DeclareVectorInputPort(PendulumInput<T>());
-  state_port_ = this->DeclareVectorOutputPort(PendulumState<T>(),
-                                              &PendulumPlant::CopyStateOut)
-                    .get_index();
+  this->DeclareVectorInputPort("tau", PendulumInput<T>());
+  this->DeclareVectorOutputPort("state", &PendulumPlant::CopyStateOut);
   this->DeclareContinuousState(PendulumState<T>(), 1 /* num_q */, 1 /* num_v */,
                                0 /* num_z */);
   this->DeclareNumericParameter(PendulumParams<T>());
@@ -40,52 +21,27 @@ PendulumPlant<T>::PendulumPlant()
 
 template <typename T>
 template <typename U>
-PendulumPlant<T>::PendulumPlant(const PendulumPlant<U>& p) : PendulumPlant() {
-  source_id_ = p.source_id();
-  frame_id_ = p.frame_id();
-
-  if (source_id_.is_valid()) {
-    geometry_pose_port_ = AllocateGeometryPoseOutputPort();
-  }
-}
+PendulumPlant<T>::PendulumPlant(const PendulumPlant<U>&) : PendulumPlant() {}
 
 template <typename T>
-PendulumPlant<T>::~PendulumPlant() {}
+PendulumPlant<T>::~PendulumPlant() = default;
 
 template <typename T>
 const systems::InputPort<T>& PendulumPlant<T>::get_input_port() const {
-  return systems::System<T>::get_input_port(0);
+  DRAKE_DEMAND(systems::LeafSystem<T>::num_input_ports() == 1);
+  return systems::LeafSystem<T>::get_input_port(0);
 }
 
 template <typename T>
 const systems::OutputPort<T>& PendulumPlant<T>::get_state_output_port() const {
-  return systems::System<T>::get_output_port(state_port_);
-}
-
-template <typename T>
-const systems::OutputPort<T>& PendulumPlant<T>::get_geometry_pose_output_port()
-    const {
-  return systems::System<T>::get_output_port(geometry_pose_port_);
+  DRAKE_DEMAND(systems::LeafSystem<T>::num_output_ports() == 1);
+  return systems::LeafSystem<T>::get_output_port(0);
 }
 
 template <typename T>
 void PendulumPlant<T>::CopyStateOut(const systems::Context<T>& context,
                                     PendulumState<T>* output) const {
-  output->set_value(get_state(context).get_value());
-}
-
-template <typename T>
-void PendulumPlant<T>::CopyPoseOut(const systems::Context<T>& context,
-                                   geometry::FramePoseVector<T>* poses) const {
-  DRAKE_DEMAND(poses->size() == 1);
-  DRAKE_DEMAND(poses->source_id() == source_id_);
-
-  const T theta = get_state(context).theta();
-
-  poses->clear();
-  Isometry3<T> pose = Isometry3<T>::Identity();
-  pose.linear() = math::RotationMatrix<T>::MakeYRotation(theta).matrix();
-  poses->set_value(frame_id_, pose);
+  *output = get_state(context);
 }
 
 template <typename T>
@@ -117,57 +73,6 @@ void PendulumPlant<T>::DoCalcTimeDerivatives(
        params.mass() * params.gravity() * params.length() * sin(state.theta()) -
        params.damping() * state.thetadot()) /
       (params.mass() * params.length() * params.length()));
-}
-
-template <typename T>
-void PendulumPlant<T>::RegisterGeometry(
-    const PendulumParams<double>& params,
-    geometry::SceneGraph<double>* scene_graph) {
-  DRAKE_DEMAND(!source_id_.is_valid());
-  DRAKE_DEMAND(scene_graph);
-
-  source_id_ = scene_graph->RegisterSource("pendulum");
-
-  // The base.
-  GeometryId id = scene_graph->RegisterAnchoredGeometry(
-      source_id_,
-      make_unique<GeometryInstance>(Isometry3d(Translation3d(0., 0., .025)),
-                                    make_unique<Box>(.05, 0.05, 0.05), "base"));
-  scene_graph->AssignRole(
-      source_id_, id, MakeDrakeVisualizerProperties(Vector4d(.3, .6, .4, 1)));
-
-  frame_id_ = scene_graph->RegisterFrame(
-      source_id_, GeometryFrame("arm"));
-
-  // The arm.
-  id = scene_graph->RegisterGeometry(
-      source_id_, frame_id_,
-      make_unique<GeometryInstance>(
-          Isometry3d(Translation3d(0, 0, -params.length() / 2.)),
-          make_unique<Cylinder>(0.01, params.length()), "arm"));
-  scene_graph->AssignRole(
-      source_id_, id, MakeDrakeVisualizerProperties(Vector4d(.9, .1, 0, 1)));
-
-  // The mass at the end of the arm.
-  id = scene_graph->RegisterGeometry(
-      source_id_, frame_id_,
-      make_unique<GeometryInstance>(
-          Isometry3d(Translation3d(0, 0, -params.length())),
-          make_unique<Sphere>(params.mass() / 40.), "arm point mass"));
-  scene_graph->AssignRole(
-      source_id_, id, MakeDrakeVisualizerProperties(Vector4d(0, 0, 1, 1)));
-
-  // Now allocate the output port.
-  geometry_pose_port_ = AllocateGeometryPoseOutputPort();
-}
-
-template <typename T>
-systems::OutputPortIndex PendulumPlant<T>::AllocateGeometryPoseOutputPort() {
-  DRAKE_DEMAND(source_id_.is_valid() && frame_id_.is_valid());
-  return this->DeclareAbstractOutputPort("geometry_pose",
-      geometry::FramePoseVector<T>(source_id_, {frame_id_}),
-                                  &PendulumPlant<T>::CopyPoseOut)
-      .get_index();
 }
 
 }  // namespace pendulum

--- a/examples/pendulum/pendulum_plant.h
+++ b/examples/pendulum/pendulum_plant.h
@@ -1,13 +1,8 @@
 #pragma once
 
-#include <memory>
-
-#include "drake/common/symbolic.h"
 #include "drake/examples/pendulum/gen/pendulum_input.h"
 #include "drake/examples/pendulum/gen/pendulum_params.h"
 #include "drake/examples/pendulum/gen/pendulum_state.h"
-#include "drake/geometry/scene_graph.h"
-#include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/leaf_system.h"
 
 namespace drake {
@@ -19,7 +14,7 @@ namespace pendulum {
 ///
 /// @system{PendulumPlant,
 ///    @input_port{tau},
-///    @output_port{state} @output_port{geometry_pose}
+///    @output_port{state}
 /// }
 ///
 /// @tparam T The vector element type, which must be a valid Eigen scalar.
@@ -34,36 +29,20 @@ class PendulumPlant final : public systems::LeafSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PendulumPlant);
 
-  /** Constructs a default plant. */
+  /// Constructs a default plant.
   PendulumPlant();
 
   /// Scalar-converting copy constructor.  See @ref system_scalar_conversion.
   template <typename U>
   explicit PendulumPlant(const PendulumPlant<U>&);
 
-  ~PendulumPlant() override;
+  ~PendulumPlant() final;
 
   /// Returns the input port to the externally applied force.
   const systems::InputPort<T>& get_input_port() const;
 
   /// Returns the port to output state.
   const systems::OutputPort<T>& get_state_output_port() const;
-
-  geometry::SourceId source_id() const { return source_id_; }
-  geometry::FrameId frame_id() const { return frame_id_; }
-
-  /// Registers this system as a source for the SceneGraph, adds the
-  /// pendulum geometry, and creates the geometry_pose_output_port for this
-  /// system.  This must be called before the a SceneGraph's Context is
-  /// allocated.  It can only be called once.
-  // TODO(russt): this call only accepts doubles (not T) until SceneGraph
-  // supports symbolic.
-  void RegisterGeometry(const PendulumParams<double>& params,
-                        geometry::SceneGraph<double>* scene_graph);
-
-  /// Returns the port to output the pose to SceneGraph.  Users must call
-  /// RegisterGeometry() first to enable this port.
-  const systems::OutputPort<T>& get_geometry_pose_output_port() const;
 
   /// Calculates the kinetic + potential energy.
   T CalcTotalEnergy(const systems::Context<T>& context) const;
@@ -92,7 +71,6 @@ class PendulumPlant final : public systems::LeafSystem<T> {
     return get_mutable_state(&context->get_mutable_continuous_state());
   }
 
-
   const PendulumParams<T>& get_parameters(
       const systems::Context<T>& context) const {
     return this->template GetNumericParameter<PendulumParams>(context, 0);
@@ -105,29 +83,12 @@ class PendulumPlant final : public systems::LeafSystem<T> {
   }
 
  private:
-  systems::OutputPortIndex AllocateGeometryPoseOutputPort();
-
-  // This is the calculator method for the state output port.
   void CopyStateOut(const systems::Context<T>& context,
                     PendulumState<T>* output) const;
 
-  // Calculator method for the pose output port.
-  void CopyPoseOut(const systems::Context<T>& context,
-                   geometry::FramePoseVector<T>* poses) const;
-
   void DoCalcTimeDerivatives(
       const systems::Context<T>& context,
-      systems::ContinuousState<T>* derivatives) const override;
-
-
-  // Port handles.
-  int state_port_{-1};
-  int geometry_pose_port_{-1};
-
-  // Geometry source identifier for this system to interact with SceneGraph.
-  geometry::SourceId source_id_{};
-  // The id for the pendulum (arm + point mass) frame.
-  geometry::FrameId frame_id_{};
+      systems::ContinuousState<T>* derivatives) const final;
 };
 
 }  // namespace pendulum

--- a/examples/pendulum/test/pendulum_geometry_test.cc
+++ b/examples/pendulum/test/pendulum_geometry_test.cc
@@ -1,0 +1,72 @@
+#include "drake/examples/pendulum/pendulum_geometry.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_throw.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/examples/pendulum/pendulum_plant.h"
+#include "drake/geometry/scene_graph.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/math/rotation_matrix.h"
+#include "drake/systems/framework/diagram_builder.h"
+
+namespace drake {
+namespace examples {
+namespace pendulum {
+namespace {
+
+using geometry::FramePoseVector;
+using math::RotationMatrixd;
+using math::RigidTransformd;
+
+math::RigidTransformd ExtractSinglePose(
+    const geometry::FramePoseVector<double>& pose_vector) {
+  DRAKE_THROW_UNLESS(pose_vector.size() == 1);
+  for (const auto& id : pose_vector.frame_ids()) {
+    RigidTransformd result;
+    result.SetFromIsometry3(pose_vector.value(id));
+    return result;
+  }
+  DRAKE_UNREACHABLE();
+}
+
+GTEST_TEST(PendulumGeometryTest, AcceptanceTest) {
+  // Specify the diagram.
+  systems::DiagramBuilder<double> builder;
+  auto plant = builder.AddSystem<PendulumPlant>();
+  auto scene_graph = builder.AddSystem<geometry::SceneGraph>();
+  auto geom = PendulumGeometry::AddToBuilder(
+      &builder, plant->get_state_output_port(), scene_graph);
+  ASSERT_NE(geom, nullptr);
+
+  // Finish the diagram and create a context.
+  auto diagram = builder.Build();
+  auto diagram_context = diagram->CreateDefaultContext();
+  auto& plant_context = diagram->GetMutableSubsystemContext(
+      *plant, diagram_context.get());
+  auto& geom_context = diagram->GetMutableSubsystemContext(
+      *geom, diagram_context.get());
+
+  // Zero the pendulum input, but set a non-zero initial state.
+  const double theta = 0.2;
+  plant->get_input_port().FixValue(&plant_context, PendulumInput<double>{});
+  plant->get_mutable_state(&plant_context).set_theta(theta);
+
+  // Check the frame pose.
+  const double tolerance = 1E-9;  // Arbitrary.
+  const auto& geom_output_value =
+      geom->get_output_port(0).Eval<FramePoseVector<double>>(geom_context);
+  EXPECT_TRUE(CompareMatrices(
+      ExtractSinglePose(geom_output_value).matrix(),
+      RigidTransformd(RotationMatrixd::MakeYRotation(theta)).matrix(),
+      tolerance));
+
+  // Check other stuff.
+  EXPECT_TRUE(geom->HasAnyDirectFeedthrough());
+}
+
+}  // namespace
+}  // namespace pendulum
+}  // namespace examples
+}  // namespace drake

--- a/examples/pendulum/trajectory_optimization_simulation.cc
+++ b/examples/pendulum/trajectory_optimization_simulation.cc
@@ -3,11 +3,10 @@
 
 #include <gflags/gflags.h>
 
-#include "drake/common/find_resource.h"
 #include "drake/common/is_approx_equal_abstol.h"
+#include "drake/examples/pendulum/pendulum_geometry.h"
 #include "drake/examples/pendulum/pendulum_plant.h"
 #include "drake/geometry/geometry_visualization.h"
-#include "drake/lcm/drake_lcm.h"
 #include "drake/solvers/solve.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/controllers/pid_controlled_system.h"
@@ -31,8 +30,6 @@ DEFINE_double(target_realtime_rate, 1.0,
               "Simulator::set_target_realtime_rate() for details.");
 
 int DoMain() {
-  systems::DiagramBuilder<double> builder;
-
   auto pendulum = std::make_unique<PendulumPlant<double>>();
   pendulum->set_name("pendulum");
 
@@ -78,6 +75,9 @@ int DoMain() {
     return 1;
   }
 
+  systems::DiagramBuilder<double> builder;
+  const auto* pendulum_ptr = builder.AddSystem(std::move(pendulum));
+
   const PiecewisePolynomial<double> pp_traj =
       dircol.ReconstructInputTrajectory(result);
   const PiecewisePolynomial<double> pp_xtraj =
@@ -88,33 +88,24 @@ int DoMain() {
       builder.AddSystem<systems::TrajectorySource>(pp_xtraj);
   state_trajectory->set_name("state trajectory");
 
-  auto scene_graph = builder.AddSystem<geometry::SceneGraph>();
-  pendulum->RegisterGeometry(pendulum->get_parameters(*context),
-                             scene_graph);
-  const geometry::SourceId source_id = pendulum->source_id();
-  const int state_port_index = pendulum->get_state_output_port().get_index();
-  const int geometry_port_index =
-      pendulum->get_geometry_pose_output_port().get_index();
-
   // The choices of PidController constants here are fairly arbitrary,
   // but seem to effectively swing up the pendulum and hold it.
-  const double Kp = 10;
-  const double Ki = 0;
-  const double Kd = 1;
-  auto pid_controlled_pendulum =
-      builder.AddSystem<systems::controllers::PidControlledSystem<double>>(
-          std::move(pendulum), Kp, Ki, Kd, state_port_index);
-  pid_controlled_pendulum->set_name("PID Controlled Pendulum");
-
+  const double Kp = 10.0;
+  const double Ki = 0.0;
+  const double Kd = 1.0;
+  auto connect_result =
+      systems::controllers::PidControlledSystem<double>::ConnectController(
+          pendulum_ptr->get_input_port(), pendulum_ptr->get_state_output_port(),
+          Vector1d{Kp}, Vector1d{Ki}, Vector1d{Kd}, &builder);
   builder.Connect(input_trajectory->get_output_port(),
-                  pid_controlled_pendulum->get_control_input_port());
+                  connect_result.control_input_port);
   builder.Connect(state_trajectory->get_output_port(),
-                  pid_controlled_pendulum->get_state_input_port());
+                  connect_result.state_input_port);
 
-  builder.Connect(pid_controlled_pendulum->get_output_port(geometry_port_index),
-                  scene_graph->get_source_pose_port(source_id));
-
-  geometry::ConnectDrakeVisualizer(&builder, *scene_graph);
+  auto scene_graph = builder.AddSystem<geometry::SceneGraph>();
+  PendulumGeometry::AddToBuilder(
+      &builder, pendulum_ptr->get_state_output_port(), scene_graph);
+  ConnectDrakeVisualizer(&builder, *scene_graph);
   auto diagram = builder.Build();
 
   systems::Simulator<double> simulator(*diagram);
@@ -124,7 +115,7 @@ int DoMain() {
 
   const auto& pendulum_state =
       PendulumPlant<double>::get_state(diagram->GetSubsystemContext(
-          *(pid_controlled_pendulum->plant()), simulator.get_context()));
+          *pendulum_ptr, simulator.get_context()));
 
   if (!is_approx_equal_abstol(pendulum_state.get_value(),
                               final_state.get_value(), 1e-3)) {


### PR DESCRIPTION
Conflating the two concerns makes unit testing and any reasoning about the plant much more difficult (e.g., the System changed shape, sparsity, etc. when visualization is added), and also bloats simple unit tests that only want the pendulum dynamics but had to depend on SceneGraph (which is an astonishingly huge set of object code).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11244)
<!-- Reviewable:end -->
