### PR TITLE
Hot fix to address sanitizer failures

### DIFF
--- a/geometry/proximity/test/distance_to_point_test.cc
+++ b/geometry/proximity/test/distance_to_point_test.cc
@@ -360,7 +360,8 @@ GTEST_TEST(DistanceToPoint, ScalarShapeSupportDouble) {
   EncodedData encoding(GeometryIndex(0), true);
   encoding.write_to(&query_point);
   std::vector<SignedDistanceToPoint<double>> distances;
-  std::vector<GeometryId> geometry_map{GeometryId::get_new_id()};
+  std::vector<GeometryId> geometry_map{GeometryId::get_new_id(),
+                                       GeometryId::get_new_id()};
   double threshold = std::numeric_limits<double>::max();
   std::vector<Isometry3d> X_WGs{X_WQ, Isometry3d::Identity()};
   CallbackData<double> data{&query_point, &geometry_map, threshold,
@@ -420,7 +421,8 @@ GTEST_TEST(DistanceToPoint, ScalarShapeSupportAutoDiff) {
   EncodedData encoding(GeometryIndex(0), true);
   encoding.write_to(&query_point);
   std::vector<SignedDistanceToPoint<AutoDiffXd>> distances;
-  std::vector<GeometryId> geometry_map{GeometryId::get_new_id()};
+std::vector<GeometryId> geometry_map{GeometryId::get_new_id(),
+                                     GeometryId::get_new_id()};
   double threshold = std::numeric_limits<double>::max();
   std::vector<Isometry3<AutoDiffXd>> X_WGs{X_WQ,
                                            Isometry3<AutoDiffXd>::Identity()};


### PR DESCRIPTION
The simplified test was missing an entry in the map. The access was done in the test without any reliance on its result -- but it addressed where it shouldn't.

This makes sure the map is fully populated.

Replaces #11250

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11251)
<!-- Reviewable:end -->
