### PR TITLE
Welded bodies

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -59,6 +59,7 @@ drake_cc_library(
         "//geometry:scene_graph",
         "//math:geometric_transform",
         "//math:orthonormal_basis",
+        "//multibody/topology:multibody_graph",
         "//multibody/tree",
         "//systems/framework:diagram_builder",
         "//systems/framework:leaf_system",

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3672,7 +3672,6 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   std::vector<systems::OutputPortIndex>
       instance_generalized_contact_forces_output_ports_;
 
-  // A graph storing the topological information of the model.
   // A graph representing the body/joint topology of the multibody plant (Not
   // to be confused with the spanning-tree model we will build for analysis.)
   internal::MultibodyGraph multibody_graph_;

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -21,6 +21,7 @@
 #include "drake/multibody/plant/coulomb_friction.h"
 #include "drake/multibody/plant/implicit_stribeck_solver.h"
 #include "drake/multibody/plant/implicit_stribeck_solver_results.h"
+#include "drake/multibody/topology/multibody_graph.h"
 #include "drake/multibody/tree/force_element.h"
 #include "drake/multibody/tree/multibody_tree-inl.h"
 #include "drake/multibody/tree/multibody_tree_system.h"
@@ -708,6 +709,9 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       const std::string& name, ModelInstanceIndex model_instance,
       const SpatialInertia<double>& M_BBo_B) {
     DRAKE_MBP_THROW_IF_FINALIZED();
+    // Make note in the graph.
+    multibody_graph_.AddBody(name, model_instance);
+    // Add the actual rigid body to the model.
     const RigidBody<T>& body = this->mutable_tree().AddRigidBody(
         name, model_instance, M_BBo_B);
     // Each entry of visual_geometries_, ordered by body index, contains a
@@ -778,6 +782,17 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   const JointType<T>& AddJoint(std::unique_ptr<JointType<T>> joint) {
     static_assert(std::is_convertible<JointType<T>*, Joint<T>*>::value,
                   "JointType must be a sub-class of Joint<T>.");
+
+    const std::string type_name = joint->type_name();
+    if (!multibody_graph_.IsJointTypeRegistered(type_name)) {
+      multibody_graph_.RegisterJointType(type_name);
+    }
+
+    // Note changes in the graph.
+    multibody_graph_.AddJoint(joint->name(), joint->model_instance(), type_name,
+                              joint->parent_body().index(),
+                              joint->child_body().index());
+
     return this->mutable_tree().AddJoint(std::move(joint));
   }
 
@@ -859,8 +874,20 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       const optional<math::RigidTransform<double>>& X_PF, const Body<T>& child,
       const optional<math::RigidTransform<double>>& X_BM, Args&&... args) {
     DRAKE_MBP_THROW_IF_FINALIZED();
-    return this->mutable_tree().template AddJoint<JointType>(
-        name, parent, X_PF, child, X_BM, std::forward<Args>(args)...);
+    const JointType<T>& joint =
+        this->mutable_tree().template AddJoint<JointType>(
+            name, parent, X_PF, child, X_BM, std::forward<Args>(args)...);
+
+    const std::string type_name = joint.type_name();
+    if (!multibody_graph_.IsJointTypeRegistered(type_name)) {
+      multibody_graph_.RegisterJointType(type_name);
+    }
+
+    // Note changes in the graph.
+    multibody_graph_.AddJoint(joint.name(), joint.model_instance(), type_name,
+                              parent.index(), child.index());
+
+    return joint;
   }
 
   /// Adds a new force element model of type `ForceElementType` to `this`
@@ -2438,6 +2465,9 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// presence of a weld joint, not by other constructs that prevent mobility
   /// (e.g. constraints).
   ///
+  /// This method can be called at any time during the lifetime of `this` plant,
+  /// either pre- or post-finalize, see Finalize().
+  ///
   /// Meant to be used with `CollectRegisteredGeometries`.
   ///
   /// The following example demonstrates filtering collisions between all
@@ -2456,7 +2486,6 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   ///
   /// @returns all bodies rigidly fixed to `body`. This does not return the
   /// bodies in any prescribed order.
-  /// @throws std::exception if called pre-finalize.
   /// @throws std::exception if `body` is not part of this plant.
   std::vector<const Body<T>*> GetBodiesWeldedTo(const Body<T>& body) const;
 
@@ -2534,10 +2563,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   /// If the body with `body_index` has geometry registered with it, it returns
   /// the geometry::FrameId associated with it. Otherwise, it returns nullopt.
-  /// @throws std::exception if called pre-finalize.
   optional<geometry::FrameId> GetBodyFrameIdIfExists(
       BodyIndex body_index) const {
-    DRAKE_MBP_THROW_IF_NOT_FINALIZED();
     const auto it = body_index_to_frame_id_.find(body_index);
     if (it == body_index_to_frame_id_.end()) {
       return {};
@@ -2550,9 +2577,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// an exception.
   /// @throws std::exception if no geometry has been registered with the body
   /// indicated by `body_index`.
-  /// @throws std::exception if called pre-finalize.
   geometry::FrameId GetBodyFrameIdOrThrow(BodyIndex body_index) const {
-    DRAKE_MBP_THROW_IF_NOT_FINALIZED();
     const auto it = body_index_to_frame_id_.find(body_index);
     if (it == body_index_to_frame_id_.end()) {
       throw std::logic_error(
@@ -3646,6 +3671,11 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // velocities and thus no generalized forces.
   std::vector<systems::OutputPortIndex>
       instance_generalized_contact_forces_output_ports_;
+
+  // A graph storing the topological information of the model.
+  // A graph representing the body/joint topology of the multibody plant (Not
+  // to be confused with the spanning-tree model we will build for analysis.)
+  internal::MultibodyGraph multibody_graph_;
 
   // If the plant is modeled as a discrete system with periodic updates,
   // time_step_ corresponds to the period of those updates. Otherwise, if the

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -382,14 +382,21 @@ class AcrobotPlantTests : public ::testing::Test {
         "Pre-finalize calls to '.*' are not allowed; "
         "you must call Finalize\\(\\) first.");
 
+    link1_ = &plant_->GetBodyByName(parameters_.link1_name());
+    link2_ = &plant_->GetBodyByName(parameters_.link2_name());
+
+    // Test we can call these methods pre-finalize.
+    const FrameId link1_frame_id =
+        plant_->GetBodyFrameIdOrThrow(link1_->index());
+    EXPECT_EQ(link1_frame_id, *plant_->GetBodyFrameIdIfExists(link1_->index()));
+    EXPECT_EQ(plant_->GetBodyFromFrameId(link1_frame_id), link1_);
+
     // Finalize() the plant.
     plant_->Finalize();
 
     // And build the Diagram:
     diagram_ = builder.Build();
 
-    link1_ = &plant_->GetBodyByName(parameters_.link1_name());
-    link2_ = &plant_->GetBodyByName(parameters_.link2_name());
     shoulder_ = &plant_->GetMutableJointByName<RevoluteJoint>(
         parameters_.shoulder_joint_name());
     elbow_ = &plant_->GetMutableJointByName<RevoluteJoint>(

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -1073,23 +1073,25 @@ GTEST_TEST(MultibodyPlantTest, GetBodiesWeldedTo) {
   using ::testing::UnorderedElementsAreArray;
   // This test expects that the following model has a world body and a pair of
   // welded-together bodies.
-  const std::string sdf_file = FindResourceOrThrow(
-      "drake/multibody/plant/test/split_pendulum.sdf");
+  const std::string sdf_file =
+      FindResourceOrThrow("drake/multibody/plant/test/split_pendulum.sdf");
   MultibodyPlant<double> plant;
   Parser(&plant).AddModelFromFile(sdf_file);
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      plant.GetBodiesWeldedTo(plant.world_body()), std::logic_error,
-      "Pre-finalize calls to 'GetBodiesWeldedTo\\(\\)' are not "
-      "allowed; you must call Finalize\\(\\) first.");
-  plant.Finalize();
   const Body<double>& upper = plant.GetBodyByName("upper_section");
   const Body<double>& lower = plant.GetBodyByName("lower_section");
-  EXPECT_THAT(
-      plant.GetBodiesWeldedTo(plant.world_body()),
-      UnorderedElementsAreArray({&plant.world_body()}));
-  EXPECT_THAT(
-      plant.GetBodiesWeldedTo(lower),
-      UnorderedElementsAreArray({&upper, &lower}));
+
+  // Verify we can call GetBodiesWeldedTo() pre-finalize.
+  EXPECT_THAT(plant.GetBodiesWeldedTo(plant.world_body()),
+              UnorderedElementsAreArray({&plant.world_body()}));
+  EXPECT_THAT(plant.GetBodiesWeldedTo(lower),
+              UnorderedElementsAreArray({&upper, &lower}));
+
+  // And post-finalize.
+  plant.Finalize();
+  EXPECT_THAT(plant.GetBodiesWeldedTo(plant.world_body()),
+              UnorderedElementsAreArray({&plant.world_body()}));
+  EXPECT_THAT(plant.GetBodiesWeldedTo(lower),
+              UnorderedElementsAreArray({&upper, &lower}));
 }
 
 // Verifies the process of collision geometry registration with a

--- a/multibody/topology/BUILD.bazel
+++ b/multibody/topology/BUILD.bazel
@@ -1,0 +1,37 @@
+# -*- python -*-
+# This file contains rules for Bazel; see drake/doc/bazel.rst.
+
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_googletest",
+    "drake_cc_library",
+    "drake_cc_package_library",
+)
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+drake_cc_library(
+    name = "multibody_graph",
+    srcs = [
+        "multibody_graph.cc",
+    ],
+    hdrs = [
+        "multibody_graph.h",
+    ],
+    deps = [
+        "//multibody/tree:multibody_tree_indexes",
+    ],
+)
+
+drake_cc_googletest(
+    name = "multibody_graph_test",
+    deps = [
+        ":multibody_graph",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+add_lint_tests()

--- a/multibody/topology/multibody_graph.cc
+++ b/multibody/topology/multibody_graph.cc
@@ -1,0 +1,262 @@
+#include "drake/multibody/topology/multibody_graph.h"
+
+#include <fmt/format.h>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_throw.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+MultibodyGraph::MultibodyGraph() {
+  RegisterJointType(weld_type_name());
+  // Verify invariant promised to users in the documentation.
+  DRAKE_DEMAND(joint_type_name_to_index_[weld_type_name()] ==
+               JointTypeIndex(0));
+}
+
+BodyIndex MultibodyGraph::AddBody(const std::string& body_name,
+                                  ModelInstanceIndex model_instance) {
+  DRAKE_DEMAND(model_instance.is_valid());
+
+  // Reject the usage of the "world" model instance for any other bodies but the
+  // world.
+  if (num_bodies() > 0 && model_instance == world_model_instance()) {
+    const std::string msg = fmt::format(
+        "AddBody(): Model instance index = {} is reserved for the world body. "
+        " body_index = 0, named '{}'",
+        world_model_instance(), world_body_name());
+    throw std::runtime_error(msg);
+  }
+
+  // Reject duplicate body name.
+  if (HasBodyNamed(body_name, model_instance)) {
+    throw std::runtime_error("AddBody(): Duplicate body name '" + body_name +
+                             "'");
+  }
+  // next available
+  const BodyIndex body_index(num_bodies());
+  // provide fast name lookup
+  body_name_to_index_.insert({body_name, body_index});
+
+  // Can't use emplace_back below because the constructor is private.
+  bodies_.push_back(Body(body_index, body_name, model_instance));
+
+  return body_index;
+}
+
+bool MultibodyGraph::HasBodyNamed(const std::string& name,
+                                  ModelInstanceIndex model_instance) const {
+  DRAKE_DEMAND(model_instance.is_valid());
+
+  // Search linearly on the assumption that we won't often have lots of
+  // bodies with the same name in different model instances.  If this turns
+  // out to be incorrect we can switch to a different data structure.
+  const auto range = body_name_to_index_.equal_range(name);
+  for (auto it = range.first; it != range.second; ++it) {
+    if (get_body(it->second).model_instance() == model_instance) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool MultibodyGraph::HasJointNamed(const std::string& name,
+                                   ModelInstanceIndex model_instance) const {
+  DRAKE_DEMAND(model_instance.is_valid());
+
+  // Search linearly on the assumption that we won't often have lots of
+  // joints with the same name in different model instances.  If this turns
+  // out to be incorrect we can switch to a different data structure.
+  const auto range = joint_name_to_index_.equal_range(name);
+  for (auto it = range.first; it != range.second; ++it) {
+    if (get_joint(it->second).model_instance() == model_instance) {
+      return true;
+    }
+  }
+  return false;
+}
+
+const std::string& MultibodyGraph::world_body_name() const {
+  if (bodies_.empty())
+    throw std::runtime_error(
+        "get_world_body_name(): you can't call this until you have called "
+        "AddBody() at least once -- the first body is World.");
+  return bodies_[0].name();
+}
+
+const MultibodyGraph::Body& MultibodyGraph::world_body() const {
+  if (bodies_.empty())
+    throw std::runtime_error(
+        "world_body(): you can't call this until you have called "
+        "AddBody() at least once -- the first body is 'world'.");
+  return bodies_[0];
+}
+
+JointIndex MultibodyGraph::AddJoint(const std::string& name,
+                                    ModelInstanceIndex model_instance,
+                                    const std::string& type,
+                                    BodyIndex parent_body_index,
+                                    BodyIndex child_body_index) {
+  DRAKE_DEMAND(model_instance.is_valid());
+
+  // Reject duplicate joint name.
+  if (HasJointNamed(name, model_instance)) {
+    throw std::runtime_error("AddJoint(): Duplicate joint name '" + name +
+                             "'.");
+  }
+
+  const JointTypeIndex type_index = GetJointTypeIndex(type);
+  if (!type_index.is_valid()) {
+    throw std::runtime_error("AddJoint(): Unrecognized type '" + type +
+                             "' for joint '" + name + "'.");
+  }
+
+  // Verify we are connecting bodies within the graph.
+  if (!(parent_body_index.is_valid() && parent_body_index < num_bodies())) {
+    throw std::runtime_error("AddJoint(): parent body index for joint '" +
+                             name + "' is invalid.");
+  }
+  if (!(child_body_index.is_valid() && child_body_index < num_bodies())) {
+    throw std::runtime_error("AddJoint(): child body index for joint '" + name +
+                             "' is invalid.");
+  }
+
+  // next available index.
+  const JointIndex joint_index(num_joints());
+  // provide fast name lookup.
+  joint_name_to_index_.insert({name, joint_index});
+
+  // Can't use emplace_back below because the constructor is private.
+  joints_.push_back(Joint(name, model_instance, type_index, parent_body_index,
+                          child_body_index));
+
+  // Connect the graph.
+  get_mutable_body(parent_body_index).add_joint(joint_index);
+  get_mutable_body(child_body_index).add_joint(joint_index);
+
+  return joint_index;
+}
+
+int MultibodyGraph::num_joint_types() const {
+  return static_cast<int>(joint_type_name_to_index_.size());
+}
+
+JointTypeIndex MultibodyGraph::RegisterJointType(
+    const std::string& joint_type_name) {
+  // Reject duplicate type name.
+  const auto it = joint_type_name_to_index_.find(joint_type_name);
+  if (it != joint_type_name_to_index_.end())
+    throw std::runtime_error(fmt::format(
+        "RegisterJointType(): Duplicate joint type: '{}'.", joint_type_name));
+  const JointTypeIndex joint_type_index(num_joint_types());
+  joint_type_name_to_index_[joint_type_name] = joint_type_index;
+  return joint_type_index;
+}
+
+bool MultibodyGraph::IsJointTypeRegistered(
+    const std::string& joint_type_name) const {
+  const auto it = joint_type_name_to_index_.find(joint_type_name);
+  return it != joint_type_name_to_index_.end();
+}
+
+JointTypeIndex MultibodyGraph::GetJointTypeIndex(
+    const std::string& joint_type_name) const {
+  const auto it = joint_type_name_to_index_.find(joint_type_name);
+  return it == joint_type_name_to_index_.end() ? JointTypeIndex() : it->second;
+}
+
+std::vector<std::set<BodyIndex>> MultibodyGraph::FindIslandsOfWeldedBodies()
+    const {
+  std::vector<bool> visited(num_bodies(), false);
+  std::vector<std::set<BodyIndex>> islands;
+
+  // Reserve the maximum possible number of islands (that is, when each body
+  // forms its own island) in advance in order to avoid reallocation in the
+  // std::vector "islands" which would cause the invalidation of references as
+  // we recursively fill it in.
+  islands.reserve(num_bodies());
+
+  // The first body visited is the "world" (body_index = 0), and therefore
+  // islands[0] corresponds to the islands of all bodies welded to the world.
+  for (const auto& body : bodies_) {
+    if (!visited[body.index()]) {
+      // If `body` was not visited yet, we create an island for it.
+      islands.push_back(std::set<BodyIndex>{body.index()});
+
+      // We build the island to which `body` belongs by recursively traversing
+      // the sub-graph it belongs to.
+      std::set<BodyIndex>& body_island = islands.back();
+
+      // Thus far `body` forms its own island. Find if other bodies belong to
+      // this island by recursively traversing the sub-graph of welded joints
+      // connected to `body`.
+      FindIslandsOfWeldedBodiesRecurse(body, &body_island, &islands, &visited);
+    }
+  }
+  return islands;
+}
+
+void MultibodyGraph::FindIslandsOfWeldedBodiesRecurse(
+    const Body& parent_body, std::set<BodyIndex>* parent_island,
+    std::vector<std::set<BodyIndex>>* islands,
+    std::vector<bool>* visited) const {
+  // Mark parent_body as visited in order to detect loops.
+  visited->at(parent_body.index()) = true;
+
+  // Scan each sibling body.
+  for (JointIndex joint_index : parent_body.joints()) {
+    const Joint& joint = get_joint(joint_index);
+    const BodyIndex sibling_index = joint.parent_body() == parent_body.index()
+                                        ? joint.child_body()
+                                        : joint.parent_body();
+
+    // If already visited continue with the next joint.
+    if (visited->at(sibling_index)) continue;
+
+    const Body& sibling = get_body(sibling_index);
+    if (joint.type_index() == weld_type_index()) {
+      // Welded to parent_body, add it to parent_island.
+      parent_island->insert(sibling_index);
+      FindIslandsOfWeldedBodiesRecurse(sibling, parent_island, islands,
+                                       visited);
+    } else {
+      // Disconnected (non-welded) from parent_island. Create its own new island
+      // and continue the recursion from "sibling" with its new island
+      // "sibling_island".
+      islands->push_back(std::set<BodyIndex>{sibling_index});
+      std::set<BodyIndex>& sibling_island = islands->back();
+      FindIslandsOfWeldedBodiesRecurse(sibling, &sibling_island, islands,
+                                       visited);
+    }
+  }
+}
+
+std::set<BodyIndex> MultibodyGraph::FindBodiesWeldedTo(
+    BodyIndex body_index) const {
+  DRAKE_THROW_UNLESS(body_index.is_valid() && body_index < num_bodies());
+
+  // TODO(amcastro-tri): Notice that "islands" will get compute with every call
+  // to FindBodiesWeldedTo(). Consider storing this for subsequent calls if it
+  // becomes a performance bottleneck.
+  const std::vector<std::set<BodyIndex>> islands = FindIslandsOfWeldedBodies();
+
+  // Find subgraph that contains this body_index.
+  // TODO(amcastro-tri): Consider storing within Body the island it belongs to
+  // if performance becomes an issue.
+  auto predicate = [body_index](auto& island) {
+    return island.count(body_index) > 0;
+  };
+  auto island_iter = std::find_if(islands.begin(), islands.end(), predicate);
+
+  // If body_index is a valid index to a body in this graph, then it MUST belong
+  // to one of the islands. We verify this explicitly.
+  DRAKE_DEMAND(island_iter != islands.end());
+
+  return *island_iter;
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/topology/multibody_graph.h
+++ b/multibody/topology/multibody_graph.h
@@ -147,22 +147,22 @@ class MultibodyGraph {
   bool HasJointNamed(const std::string& name,
                      ModelInstanceIndex model_instance) const;
 
-  /** This method partitions the %MultibodyGraph into islands such that (a)
-  every body is in one and only one island, and (b) two bodies are in the same
-  island iff there is a path between them which includes only weld joints (see
-  weld_type_name()). Each island of welded bodies is represented as a set of
-  body indices. By definition, these islands will be disconnected by any
-  non-weld joint between two bodies. The first island will have all of the
-  bodies welded to the world, including the world body itself; all subsequent
-  islands will be in no particular order. A few more notes:
+  /** This method partitions the %MultibodyGraph into sub-graphs such that (a)
+  every body is in one and only one sub-graph, and (b) two bodies are in the
+  same sub-graph iff there is a path between them which includes only weld
+  joints (see weld_type_name()). Each sub-graph of welded bodies is represented
+  as a set of body indices. By definition, these sub-graphs will be disconnected
+  by any non-weld joint between two bodies. The first sub-graph will have all of
+  the bodies welded to the world, including the world body itself; all
+  subsequent sub-graphs will be in no particular order. A few more notes:
     - Each body in the %MultibodyGraph is included in one set and one set only.
-    - The maximum number of returned islands equals the number of bodies in the
-      graph (num_bodies()). This corresponds to a graph with no weld joints.
+    - The maximum number of returned sub-graphs equals the number of bodies in
+      the graph (num_bodies()). This corresponds to a graph with no weld joints.
     - The world body is also included in a set of welded bodies, and this set is
       element zero in the returned vector.
-    - The minimum number of islands is one. This corresponds to a graph with
+    - The minimum number of sub-graphs is one. This corresponds to a graph with
       all bodies welded to the world. */
-  std::vector<std::set<BodyIndex>> FindIslandsOfWeldedBodies() const;
+  std::vector<std::set<BodyIndex>> FindSubgraphsOfWeldedBodies() const;
 
   /** Returns all bodies that are transitively welded, or rigidly affixed, to
   `body_index`, per these two definitions:
@@ -183,21 +183,21 @@ class MultibodyGraph {
 
   Body& get_mutable_body(BodyIndex body_index) { return bodies_[body_index]; }
 
-  // Recursive helper method for FindIslandsOfWeldedBodies().
+  // Recursive helper method for FindSubgraphsOfWeldedBodies().
   // The first thing this helper does is to mark `parent_body` as "visited" in
   // the output array `visited`.
   // Next, it scans the sibling bodies connected to `parent_index` by a joint.
   // If the sibling was already visited, it moves on to the next sibling, if
   // any. For a sibling visited for the first time there are two options:
-  //   1) if it is connected by a weld joint, it gets added to parent_island.
+  //   1) if it is connected by a weld joint, it gets added to parent_subgraph.
   //      Recursion continues starting with parent_index = sibling and the
-  //      parent island. Otherwise,
-  //   2) a new island is created for the sibling and gets added to the
-  //      list of all `islands`. Recursion continues starting with parent_index
-  //      = sibling and the new island for this sibling.
-  void FindIslandsOfWeldedBodiesRecurse(
-      const Body& parent_body, std::set<BodyIndex>* parent_island,
-      std::vector<std::set<BodyIndex>>* islands,
+  //      parent sub-graph. Otherwise,
+  //   2) a new sub-graph is created for the sibling and gets added to the
+  //      list of all `subgraphs`. Recursion continues starting with
+  //      parent_index = sibling and the new sub-graph for this sibling.
+  void FindSubgraphsOfWeldedBodiesRecurse(
+      const Body& parent_body, std::set<BodyIndex>* parent_subgraph,
+      std::vector<std::set<BodyIndex>>* subgraphs,
       std::vector<bool>* visited) const;
 
   // bodies_ includes the world body at world_index() with name

--- a/multibody/topology/multibody_graph.h
+++ b/multibody/topology/multibody_graph.h
@@ -1,0 +1,295 @@
+#pragma once
+
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/multibody/tree/multibody_tree_indexes.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+/** Type used to identify joint types. */
+using JointTypeIndex = TypeSafeIndex<class JointTypeTag>;
+
+/** Defines a multibody graph consisting of bodies interconnected by joints.
+The graph is defined by a sequence of calls to AddBody() and AddJoint(). Anytime
+during the lifetime of the graph, a user can ask graph specific questions such
+as how bodies are connected, by which joints or even perform more complex
+queries such as what set of bodies are welded together. */
+// TODO(amcastro-tri): consider moving outside internal:: and available to users
+// of MBP.
+class MultibodyGraph {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(MultibodyGraph)
+
+  // Local classes.
+  class Body;
+  class Joint;
+
+  MultibodyGraph();
+
+  /** Add a new Body to the graph.
+  @param[in] name
+    The unique name of the new body in the particular `model_instance`. Several
+    bodies can have the same name within a %MultibodyGraph however, their name
+    within their model instance must be unique.
+  @param[in] model_instance
+    The model instance to which this body belongs, see @ref model_instance.
+  @note The first call to AddBody() defines the "world" body's `name`. For this
+  first call `model_instance` must be world_model_instance().
+  @returns The unique BodyIndex for the added joint in the graph. */
+  BodyIndex AddBody(const std::string& name, ModelInstanceIndex model_instance);
+
+  /** Add a new Joint to the graph.
+  @param[in] name
+    The unique name of the new Joint in the particular `model_instance`. Several
+    joints can have the same name within a %MultibodyGraph however, their name
+    within their model instance must be unique.
+  @param[in] model_instance
+    The model instance to which this joint belongs, see @ref model_instance.
+  @param[in] type
+    A string designating the type of this joint, such as "revolute" or
+    "ball". This must be chosen from the set of joint types previously
+    registered with calls to RegisterJointType().
+  @param[in] parent_body_index
+    This must be the index of a body previously obtained with a call to
+    AddBody(), or it must be the designated index for the world body
+    (world_index()).
+  @param[in] child_body_index
+    This must be the index of a body previously obtained with a call to
+    AddBody(), or it must be the designated index for the world body
+    (world_index()).
+  @returns The unique JointIndex for the added joint in the graph.
+  @throws std::runtime_error iff `name` is duplicated within `model_instance`.
+  @throws std::runtime_error iff `type` has not been registered with
+  RegisterJointType().
+  @throws std::runtime_error iff `parent_body_index` or `child_body_index` are
+  not valide body indexes for `this` graph. */
+  JointIndex AddJoint(const std::string& name,
+                      ModelInstanceIndex model_instance,
+                      const std::string& type, BodyIndex parent_body_index,
+                      BodyIndex child_body_index);
+
+  /** Returns the body that corresponds to the world. This body added via the
+  first call to AddBody().
+  @throws std::runtime_error iff AddBody() was not called even once yet. */
+  const Body& world_body() const;
+
+  /** Returns the name we recognize as the World (or Ground) body. This is
+  the name that was provided in the first AddBody() call.
+  In Drake, MultibodyPlant names it the "WorldBody".
+  @throws std::runtime_error iff AddBody() was not called even once yet. */
+  const std::string& world_body_name() const;
+
+  /** Returns the unique index that identifies the "weld" joint type (always
+  zero).
+  @note SDF calls this type a "fixed" joint. */
+  static JointTypeIndex weld_type_index() { return JointTypeIndex(0); }
+
+  /** Returns the unique name reserved to identify weld joints (always "weld").
+   */
+  static std::string weld_type_name() { return "weld"; }
+
+  /** Register a joint type by name.
+  MultibodyGraph() registers "weld" at construction as Drake reserves this name
+  to identify weld joints. "weld" joint type has index `weld_type_index()`.
+  @param[in] joint_type_name
+    A unique string identifying a joint type, such as "pin" or "prismatic".
+  @throws std::runtime_error if `joint_type_name` already identifies a
+  previously registered joint type.
+  @retval JointTypeIndex Index uniquely identifying the new joint type. */
+  JointTypeIndex RegisterJointType(const std::string& joint_type_name);
+
+  /** @returns `true` iff the given `joint_type_name` was previously registered
+  via a call to RegisterJointType(), or iff it equals weld_type_name(). */
+  bool IsJointTypeRegistered(const std::string& joint_type_name) const;
+
+  /** Returns the number of registered joint types. */
+  int num_joint_types() const;
+
+  /** Returns the number of bodies, including all added bodies, and the world
+  body.
+  @see AddBody(), world_index(), world_body_name(). */
+  int num_bodies() const { return static_cast<int>(bodies_.size()); }
+
+  /** Returns the number joints added with AddJoint(). */
+  int num_joints() const { return static_cast<int>(joints_.size()); }
+
+  /** Gets a Body by index. The world body has index world_index().
+  @throws std::exception iff `index` does not correspond to a body in this
+  graph. */
+  const Body& get_body(BodyIndex index) const {
+    DRAKE_THROW_UNLESS(index < num_bodies());
+    return bodies_[index];
+  }
+
+  /** Gets a Joint by index.
+  @throws std::exception iff `index` does not correspond to a joint in this
+  graph. */
+  const Joint& get_joint(JointIndex index) const {
+    DRAKE_THROW_UNLESS(index < num_joints());
+    return joints_[index];
+  }
+
+  /** @returns `true` if a body named `name` was added to `model_instance`.
+  @see AddBody().
+  @throws std::exception if `model_instance` is not a valid index. */
+  bool HasBodyNamed(const std::string& name,
+                    ModelInstanceIndex model_instance) const;
+
+  /** @returns `true` if a joint named `name` was added to `model_instance`.
+  @see AddBody().
+  @throws std::exception if `model_instance` is not a valid index. */
+  bool HasJointNamed(const std::string& name,
+                     ModelInstanceIndex model_instance) const;
+
+  /** This method partitions the %MultibodyGraph into islands such that (a)
+  every body is in one and only one island, and (b) two bodies are in the same
+  island iff there is a path between them which includes only weld joints (see
+  weld_type_name()). Each island of welded bodies is represented as a set of
+  body indices. By definition, these islands will be disconnected by any
+  non-weld joint between two bodies. The first island will have all of the
+  bodies welded to the world, including the world body itself; all subsequent
+  islands will be in no particular order. A few more notes:
+    - Each body in the %MultibodyGraph is included in one set and one set only.
+    - The maximum number of returned islands equals the number of bodies in the
+      graph (num_bodies()). This corresponds to a graph with no weld joints.
+    - The world body is also included in a set of welded bodies, and this set is
+      element zero in the returned vector.
+    - The minimum number of islands is one. This corresponds to a graph with
+      all bodies welded to the world. */
+  std::vector<std::set<BodyIndex>> FindIslandsOfWeldedBodies() const;
+
+  /** Returns all bodies that are transitively welded, or rigidly affixed, to
+  `body_index`, per these two definitions:
+    1. A body is always considered welded to itself.
+    2. Two unique bodies are considered welded together exclusively by the
+       presence of a weld joint, not by other constructs such as constraints.
+  Therefore, if `body_index` is a valid index to a Body in this graph, then the
+  return vector will always contain at least one entry storing `body_index`.
+  @throws std::exception iff `body_index` does not correspond to a body in this
+  graph. */
+  std::set<BodyIndex> FindBodiesWeldedTo(BodyIndex body_index) const;
+
+ private:
+  // Finds the assigned index for a joint type from the type name. Returns an
+  // invalid index if `joint_type_name` was not previously registered with a
+  // call to RegisterJointType().
+  JointTypeIndex GetJointTypeIndex(const std::string& joint_type_name) const;
+
+  Body& get_mutable_body(BodyIndex body_index) { return bodies_[body_index]; }
+
+  // Recursive helper method for FindIslandsOfWeldedBodies().
+  // The first thing this helper does is to mark `parent_body` as "visited" in
+  // the output array `visited`.
+  // Next, it scans the sibling bodies connected to `parent_index` by a joint.
+  // If the sibling was already visited, it moves on to the next sibling, if
+  // any. For a sibling visited for the first time there are two options:
+  //   1) if it is connected by a weld joint, it gets added to parent_island.
+  //      Recursion continues starting with parent_index = sibling and the
+  //      parent island. Otherwise,
+  //   2) a new island is created for the sibling and gets added to the
+  //      list of all `islands`. Recursion continues starting with parent_index
+  //      = sibling and the new island for this sibling.
+  void FindIslandsOfWeldedBodiesRecurse(
+      const Body& parent_body, std::set<BodyIndex>* parent_island,
+      std::vector<std::set<BodyIndex>>* islands,
+      std::vector<bool>* visited) const;
+
+  // bodies_ includes the world body at world_index() with name
+  // world_body_name().
+  std::vector<Body> bodies_;
+  std::vector<Joint> joints_;
+
+  std::unordered_map<std::string, JointTypeIndex> joint_type_name_to_index_;
+
+  // The xxx_name_to_index_ structures are multimaps because
+  // bodies/joints/actuators/etc may appear with the same name in different
+  // model instances. The index values are still unique across the graph.
+  std::unordered_multimap<std::string, BodyIndex> body_name_to_index_;
+  std::unordered_multimap<std::string, JointIndex> joint_name_to_index_;
+};
+
+class MultibodyGraph::Body {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Body)
+
+  /** @returns its unique index in the graph. */
+  BodyIndex index() const { return index_; }
+
+  /** @returns its model instance. */
+  ModelInstanceIndex model_instance() const { return model_instance_; }
+
+  /** @returns its name, unique within model_instance(). */
+  const std::string& name() const { return name_; }
+
+  /** Returns the total number of joints that have `this` body as either the
+  parent or child body in a Joint. */
+  int num_joints() const;
+
+  /** @returns all the joints that connect to `this` body. */
+  const std::vector<JointIndex>& joints() const { return joints_; }
+
+ private:
+  // Restrict construction and modification to only MultibodyGraph.
+  friend class MultibodyGraph;
+
+  Body(BodyIndex index, const std::string& name,
+       ModelInstanceIndex model_instance)
+      : index_(index), name_(name), model_instance_(model_instance) {}
+
+  // Notes that this body is connected by `joint`.
+  void add_joint(JointIndex joint) { joints_.push_back(joint); }
+
+  BodyIndex index_;
+  std::string name_;
+  ModelInstanceIndex model_instance_;
+
+  // How this body appears in joints (input and added).
+  std::vector<JointIndex> joints_as_child_;   // where this body is the child
+  std::vector<JointIndex> joints_as_parent_;  // where this body is the parent
+  // All joints connecting this body. The union (in no particular order) of
+  // joints_as_parent_ and joints_as_child_.
+  std::vector<JointIndex> joints_;
+};
+
+class MultibodyGraph::Joint {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Joint)
+
+  ModelInstanceIndex model_instance() const { return model_instance_; }
+
+  const std::string& name() const { return name_; }
+
+  BodyIndex parent_body() const { return parent_body_index_; }
+  BodyIndex child_body() const { return child_body_index_; }
+
+  JointTypeIndex type_index() const { return type_index_; }
+
+ private:
+  // Restrict construction and modification to only MultibodyGraph.
+  friend class MultibodyGraph;
+
+  Joint(const std::string& name, ModelInstanceIndex model_instance,
+        JointTypeIndex joint_type_index, BodyIndex parent_body_index,
+        BodyIndex child_body_index)
+      : name_(name),
+        model_instance_(model_instance),
+        type_index_(joint_type_index),
+        parent_body_index_(parent_body_index),
+        child_body_index_(child_body_index) {}
+
+  std::string name_;
+  ModelInstanceIndex model_instance_;
+  JointTypeIndex type_index_;
+  BodyIndex parent_body_index_;
+  BodyIndex child_body_index_;
+};
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/topology/multibody_graph.h
+++ b/multibody/topology/multibody_graph.h
@@ -21,7 +21,7 @@ during the lifetime of the graph, a user can ask graph specific questions such
 as how bodies are connected, by which joints or even perform more complex
 queries such as what set of bodies are welded together. */
 // TODO(amcastro-tri): consider moving outside internal:: and available to users
-// of MBP.
+// of MBP, towards #11307.
 class MultibodyGraph {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(MultibodyGraph)
@@ -87,7 +87,7 @@ class MultibodyGraph {
 
   /** Returns the unique index that identifies the "weld" joint type (always
   zero).
-  @note SDF calls this type a "fixed" joint. */
+  @note The SDF format calls this type a "fixed" joint. */
   static JointTypeIndex weld_type_index() { return JointTypeIndex(0); }
 
   /** Returns the unique name reserved to identify weld joints (always "weld").
@@ -249,9 +249,6 @@ class MultibodyGraph::Body {
   std::string name_;
   ModelInstanceIndex model_instance_;
 
-  // How this body appears in joints (input and added).
-  std::vector<JointIndex> joints_as_child_;   // where this body is the child
-  std::vector<JointIndex> joints_as_parent_;  // where this body is the parent
   // All joints connecting this body. The union (in no particular order) of
   // joints_as_parent_ and joints_as_child_.
   std::vector<JointIndex> joints_;

--- a/multibody/topology/test/multibody_graph_test.cc
+++ b/multibody/topology/test/multibody_graph_test.cc
@@ -1,0 +1,255 @@
+#include "drake/multibody/topology/multibody_graph.h"
+
+#include <string>
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+const char kRevoluteType[] = "revolute";
+const char kPrismaticType[] = "prismatic";
+
+// Arbitrary world name for testing.
+const char kWorldBodyName[] = "DefaultWorldBodyName";
+
+// Test a straightforward serial chain of bodies connected by
+// revolute joints: world->body1->body2->body3->body4->body5.
+// We perform a number of sanity checks on the provided API.
+GTEST_TEST(MultibodyGraph, SerialChain) {
+  MultibodyGraph graph;
+  EXPECT_EQ(graph.num_joint_types(), 1);  // "weld" joint thus far.
+  graph.RegisterJointType(kRevoluteType);
+  EXPECT_EQ(graph.num_joint_types(), 2);  // "weld" and "revolute".
+
+  // Verify what joint types were registered.
+  EXPECT_TRUE(graph.IsJointTypeRegistered(kRevoluteType));
+  EXPECT_FALSE(graph.IsJointTypeRegistered(kPrismaticType));
+
+  // The first body added defines the world's name and model instance.
+  // We'll verify their values below.
+  graph.AddBody(kWorldBodyName, world_model_instance());
+
+  // We'll add the chain to this model.
+  const ModelInstanceIndex model_instance(5);
+
+  // We cannot register to the world model instance, unless it's the first call
+  // to AddBody().
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      graph.AddBody("InvalidBody", world_model_instance()), std::runtime_error,
+      fmt::format("AddBody\\(\\): Model instance index = {}.*",
+                  world_model_instance()));
+
+  BodyIndex parent = graph.AddBody("body1", model_instance);
+  graph.AddJoint("pin1", model_instance, kRevoluteType, world_index(), parent);
+  for (int i = 2; i <= 5; ++i) {
+    BodyIndex child = graph.AddBody("body" + std::to_string(i), model_instance);
+    graph.AddJoint("pin" + std::to_string(i), model_instance, kRevoluteType,
+                   parent, child);
+    parent = child;
+  }
+
+  // We cannot duplicate the name of a body or joint.
+  DRAKE_EXPECT_THROWS_MESSAGE(graph.AddBody("body3", model_instance),
+                              std::runtime_error,
+                              "AddBody\\(\\): Duplicate body name.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      graph.AddJoint("pin3", model_instance, kRevoluteType, BodyIndex(1),
+                     BodyIndex(2)),
+      std::runtime_error, "AddJoint\\(\\): Duplicate joint name.*");
+
+  // We cannot add an unregistered joint type.
+  DRAKE_EXPECT_THROWS_MESSAGE(graph.AddJoint("screw1", model_instance, "screw",
+                                             BodyIndex(1), BodyIndex(2)),
+                              std::runtime_error,
+                              "AddJoint\\(\\): Unrecognized type.*");
+
+  // Invalid parent/child body throws.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      graph.AddJoint("another_pin", model_instance, kRevoluteType, BodyIndex(1),
+                     BodyIndex(9)),
+      std::runtime_error,
+      "AddJoint\\(\\): child body index for joint '.*' is invalid.");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      graph.AddJoint("another_pin", model_instance, kRevoluteType, BodyIndex(9),
+                     BodyIndex(1)),
+      std::runtime_error,
+      "AddJoint\\(\\): parent body index for joint '.*' is invalid.");
+
+  // Verify the world's name and model instance are registered correctly.
+  EXPECT_EQ(graph.world_body_name(), kWorldBodyName);
+  EXPECT_EQ(graph.world_body().model_instance(), world_model_instance());
+  // Body "0" is always the world.
+  EXPECT_EQ(graph.get_body(BodyIndex(0)).name(), kWorldBodyName);
+  EXPECT_EQ(graph.get_body(BodyIndex(0)).model_instance(),
+            world_model_instance());
+
+  // Sanity check sizes.
+  EXPECT_EQ(graph.num_bodies(), 6);  // this includes the world body.
+  EXPECT_EQ(graph.num_joints(), 5);
+
+  // Verify we can get bodies/joints.
+  EXPECT_EQ(graph.get_body(BodyIndex(3)).name(), "body3");
+  EXPECT_EQ(graph.get_joint(JointIndex(3)).name(), "pin4");
+  DRAKE_EXPECT_THROWS_MESSAGE(graph.get_body(BodyIndex(9)), std::exception,
+                              ".*index < num_bodies\\(\\).*");
+  DRAKE_EXPECT_THROWS_MESSAGE(graph.get_joint(JointIndex(9)), std::exception,
+                              ".*index < num_joints\\(\\).*");
+
+  // Verify we can query if a body/joint is in the graph.
+  const ModelInstanceIndex kInvalidModelInstance(666);
+  EXPECT_TRUE(graph.HasBodyNamed("body3", model_instance));
+  EXPECT_FALSE(graph.HasBodyNamed("body3", kInvalidModelInstance));
+  EXPECT_FALSE(graph.HasBodyNamed("invalid_body_name", model_instance));
+  EXPECT_TRUE(graph.HasJointNamed("pin3", model_instance));
+  EXPECT_FALSE(graph.HasJointNamed("pin3", kInvalidModelInstance));
+  EXPECT_FALSE(graph.HasJointNamed("invalid_joint_name", model_instance));
+}
+
+// We build a model containing a number of kinematic loops and islands of welded
+// bodies.
+//
+// Island A (forms closed loop):
+//  - WeldJoint(1, 13)
+//  - WeldJoint(1, 4)
+//  - WeldJoint(4, 13)
+//
+// Island B (forms closed loop):
+//  - WeldJoint(6, 10)
+//  - WeldJoint(6, 8)
+//  - WeldJoint(8, 10)
+//
+// Island C (the "world" island):
+//  - WeldJoint(5, 7)
+//  - WeldJoint(5, 12)
+//
+// Non-weld joints kinematic loop:
+//  - PrimaticJoint(2, 11)
+//  - PrimaticJoint(2, 7)
+//  - RevoluteJoint(7, 11)
+//
+// Additionally we have the following non-weld joints:
+//  - RevoluteJoint(3, 13): connects body 3 to island A.
+//  - PrimaticJoint(1, 10): connects island A and B.
+//
+// Therefore we expect the following islands, in no particular oder, but with
+// the "world" island first:
+//   {0, 5, 7, 12}, {1, 4, 13}, {6, 8, 10}, {3}, {9}, {2}, {11}.
+GTEST_TEST(MultibodyGraph, WeldedIslands) {
+  MultibodyGraph graph;
+  graph.RegisterJointType(kRevoluteType);
+  graph.RegisterJointType(kPrismaticType);
+  EXPECT_EQ(graph.num_joint_types(), 3);  // weld, revolute and prismatic.
+
+  // The first body added defines the world's name and model instance.
+  graph.AddBody(kWorldBodyName, world_model_instance());
+
+  // We'll add bodies and joints to this model instance.
+  const ModelInstanceIndex model_instance(5);
+
+  // Define the model.
+  for (int i = 1; i <= 13; ++i) {
+    graph.AddBody("body" + std::to_string(i), model_instance);
+  }
+
+  // Add joints.
+  int j = 0;
+
+  // Island A: formed by bodies 1, 4, 13.
+  graph.AddJoint("joint" + std::to_string(j++), model_instance,
+                 graph.weld_type_name(), BodyIndex(1), BodyIndex(13));
+  graph.AddJoint("joint" + std::to_string(j++), model_instance,
+                 graph.weld_type_name(), BodyIndex(4), BodyIndex(1));
+  graph.AddJoint("joint" + std::to_string(j++), model_instance,
+                 graph.weld_type_name(), BodyIndex(13), BodyIndex(4));
+
+  // Body 3 connects to island A via a revolute joint.
+  graph.AddJoint("joint" + std::to_string(j++), model_instance, kRevoluteType,
+                 BodyIndex(3), BodyIndex(13));
+
+  // Island B: formed by bodies 8, 6, 10.
+  graph.AddJoint("joint" + std::to_string(j++), model_instance,
+                 graph.weld_type_name(), BodyIndex(10), BodyIndex(6));
+  graph.AddJoint("joint" + std::to_string(j++), model_instance,
+                 graph.weld_type_name(), BodyIndex(10), BodyIndex(8));
+  graph.AddJoint("joint" + std::to_string(j++), model_instance,
+                 graph.weld_type_name(), BodyIndex(6), BodyIndex(8));
+
+  // Body 1 (in island A) and body 10 (in island B) connect through a prismatic
+  // joint.
+  graph.AddJoint("joint" + std::to_string(j++), model_instance, kPrismaticType,
+                 BodyIndex(1), BodyIndex(10));
+
+  // Closed kinematic loop of non-weld joints.
+  graph.AddJoint("joint" + std::to_string(j++), model_instance, kPrismaticType,
+                 BodyIndex(2), BodyIndex(11));
+  graph.AddJoint("joint" + std::to_string(j++), model_instance, kPrismaticType,
+                 BodyIndex(7), BodyIndex(2));
+  graph.AddJoint("joint" + std::to_string(j++), model_instance, kRevoluteType,
+                 BodyIndex(7), BodyIndex(11));
+
+  // Island C: formed by bodies 5, 7, 12.
+  graph.AddJoint("joint" + std::to_string(j++), model_instance,
+                 graph.weld_type_name(), BodyIndex(5), BodyIndex(7));
+  graph.AddJoint("joint" + std::to_string(j++), model_instance,
+                 graph.weld_type_name(), BodyIndex(5), world_index());
+  graph.AddJoint("joint" + std::to_string(j++), model_instance,
+                 graph.weld_type_name(), BodyIndex(12), BodyIndex(5));
+
+  EXPECT_EQ(graph.num_bodies(), 14);  // this includes the world body.
+
+  const std::vector<std::set<BodyIndex>> welded_islands =
+      graph.FindIslandsOfWeldedBodies();
+
+  // Verify number of expected islands.
+  EXPECT_EQ(welded_islands.size(), 7);
+
+  // The first island must contain the world.
+  const std::set<BodyIndex> world_island = welded_islands[0];
+  EXPECT_EQ(world_island.count(world_index()), 1);
+
+  // Build the expected set of islands.
+  std::set<std::set<BodyIndex>> expected_islands;
+  //   {0, 5, 7, 12}, {1, 4, 13}, {6, 8, 10}, {3}, {9}, {2}, {11}.
+  const std::set<BodyIndex>& expected_world_island =
+      *expected_islands
+           .insert({BodyIndex(0), BodyIndex(5), BodyIndex(7), BodyIndex(12)})
+           .first;
+  const std::set<BodyIndex>& expected_islandA =
+      *expected_islands.insert({BodyIndex(1), BodyIndex(4), BodyIndex(13)})
+           .first;
+  const std::set<BodyIndex>& expected_islandB =
+      *expected_islands.insert({BodyIndex(6), BodyIndex(8), BodyIndex(10)})
+           .first;
+  expected_islands.insert({BodyIndex(3)});
+  expected_islands.insert({BodyIndex(9)});
+  expected_islands.insert({BodyIndex(2)});
+  expected_islands.insert({BodyIndex(11)});
+
+  // We do expect the first island to correspond to the set of bodies welded to
+  // the world.
+  EXPECT_EQ(world_island, expected_world_island);
+
+  // In order to compare the computed list of welded bodies against the expected
+  // list, irrespective of the ordering in the computed list, we first convert
+  // the computed islands to a set.
+  const std::set<std::set<BodyIndex>> welded_islands_set(welded_islands.begin(),
+                                                         welded_islands.end());
+  EXPECT_EQ(welded_islands_set, expected_islands);
+
+  // Verify we can query the list of bodies welded to a particular body.
+  EXPECT_EQ(graph.FindBodiesWeldedTo(BodyIndex(9)).size(), 1);
+  EXPECT_EQ(graph.FindBodiesWeldedTo(BodyIndex(11)).size(), 1);
+  EXPECT_EQ(graph.FindBodiesWeldedTo(BodyIndex(4)), expected_islandA);
+  EXPECT_EQ(graph.FindBodiesWeldedTo(BodyIndex(13)), expected_islandA);
+  EXPECT_EQ(graph.FindBodiesWeldedTo(BodyIndex(10)), expected_islandB);
+  EXPECT_EQ(graph.FindBodiesWeldedTo(BodyIndex(6)), expected_islandB);
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/tree/joint.h
+++ b/multibody/tree/joint.h
@@ -164,6 +164,10 @@ class Joint : public MultibodyTreeElement<Joint<T>, JointIndex>  {
     return frame_on_child_;
   }
 
+  /// Returns a string identifying the type of `this` joint, such as "revolute"
+  /// or "prismatic".
+  virtual std::string type_name() const = 0;
+
   /// Returns the index to the first generalized velocity for this joint
   /// within the vector v of generalized velocities for the full multibody
   /// system.

--- a/multibody/tree/joint.h
+++ b/multibody/tree/joint.h
@@ -166,7 +166,7 @@ class Joint : public MultibodyTreeElement<Joint<T>, JointIndex>  {
 
   /// Returns a string identifying the type of `this` joint, such as "revolute"
   /// or "prismatic".
-  virtual std::string type_name() const = 0;
+  virtual const std::string& type_name() const = 0;
 
   /// Returns the index to the first generalized velocity for this joint
   /// within the vector v of generalized velocities for the full multibody

--- a/multibody/tree/prismatic_joint.h
+++ b/multibody/tree/prismatic_joint.h
@@ -95,6 +95,8 @@ class PrismaticJoint final : public Joint<T> {
     damping_ = damping;
   }
 
+  std::string type_name() const override { return "prismatic"; }
+
   /// Returns the axis of translation for `this` joint as a unit vector.
   /// Since the measures of this axis in either frame F or M are the same (see
   /// this class's documentation for frames's definitions) then,

--- a/multibody/tree/prismatic_joint.h
+++ b/multibody/tree/prismatic_joint.h
@@ -42,6 +42,8 @@ class PrismaticJoint final : public Joint<T> {
   template<typename Scalar>
   using Context = systems::Context<Scalar>;
 
+  static const char kTypeName[];
+
   /// Constructor to create a prismatic joint between two bodies so that
   /// frame F attached to the parent body P and frame M attached to the child
   /// body B, translate relatively to one another along a common axis. See this
@@ -95,7 +97,10 @@ class PrismaticJoint final : public Joint<T> {
     damping_ = damping;
   }
 
-  std::string type_name() const override { return "prismatic"; }
+  const std::string& type_name() const override {
+    static const never_destroyed<std::string> name{kTypeName};
+    return name.access();
+  }
 
   /// Returns the axis of translation for `this` joint as a unit vector.
   /// Since the measures of this axis in either frame F or M are the same (see
@@ -334,6 +339,8 @@ class PrismaticJoint final : public Joint<T> {
   /// This joint's damping constant in N⋅s/m.
   double damping_{0};
 };
+
+template <typename T> const char PrismaticJoint<T>::kTypeName[] = "prismatic";
 
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/revolute_joint.h
+++ b/multibody/tree/revolute_joint.h
@@ -128,6 +128,8 @@ class RevoluteJoint final : public Joint<T> {
     damping_ = damping;
   }
 
+  std::string type_name() const override { return "revolute"; }
+
   /// Returns the axis of revolution of `this` joint as a unit vector.
   /// Since the measures of this axis in either frame F or M are the same (see
   /// this class's documentation for frames's definitions) then,

--- a/multibody/tree/revolute_joint.h
+++ b/multibody/tree/revolute_joint.h
@@ -43,6 +43,8 @@ class RevoluteJoint final : public Joint<T> {
   template<typename Scalar>
   using Context = systems::Context<Scalar>;
 
+  static const char kTypeName[];
+
   /// Constructor to create a revolute joint between two bodies so that
   /// frame F attached to the parent body P and frame M attached to the child
   /// body B, rotate relatively to one another about a common axis. See this
@@ -128,7 +130,10 @@ class RevoluteJoint final : public Joint<T> {
     damping_ = damping;
   }
 
-  std::string type_name() const override { return "revolute"; }
+  const std::string& type_name() const override {
+    static const never_destroyed<std::string> name{kTypeName};
+    return name.access();
+  }
 
   /// Returns the axis of revolution of `this` joint as a unit vector.
   /// Since the measures of this axis in either frame F or M are the same (see
@@ -363,6 +368,8 @@ class RevoluteJoint final : public Joint<T> {
   // This joint's damping constant in N⋅m⋅s.
   double damping_{0};
 };
+
+template <typename T> const char RevoluteJoint<T>::kTypeName[] = "revolute";
 
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/test/prismatic_joint_test.cc
+++ b/multibody/tree/test/prismatic_joint_test.cc
@@ -73,6 +73,11 @@ class PrismaticJointTest : public ::testing::Test {
   PrismaticJoint<double>* mutable_joint1_{nullptr};
 };
 
+TEST_F(PrismaticJointTest, Type) {
+  const Joint<double>& base = *joint1_;
+  EXPECT_EQ(base.type_name(), PrismaticJoint<double>::kTypeName);
+}
+
 // Verify the expected number of dofs.
 TEST_F(PrismaticJointTest, NumDOFs) {
   EXPECT_EQ(tree().num_positions(), 1);

--- a/multibody/tree/test/revolute_joint_test.cc
+++ b/multibody/tree/test/revolute_joint_test.cc
@@ -75,6 +75,11 @@ class RevoluteJointTest : public ::testing::Test {
   RevoluteJoint<double>* mutable_joint1_{nullptr};
 };
 
+TEST_F(RevoluteJointTest, Type) {
+  const Joint<double>& base = *joint1_;
+  EXPECT_EQ(base.type_name(), RevoluteJoint<double>::kTypeName);
+}
+
 // Verify the expected number of dofs.
 TEST_F(RevoluteJointTest, NumDOFs) {
   EXPECT_EQ(tree().num_positions(), 1);

--- a/multibody/tree/test/weld_joint_test.cc
+++ b/multibody/tree/test/weld_joint_test.cc
@@ -56,6 +56,11 @@ class WeldJointTest : public ::testing::Test {
   const math::RigidTransformd X_FM_{Vector3d(0, 0.5, 0)};
 };
 
+TEST_F(WeldJointTest, Type) {
+  const Joint<double>& base = *joint_;
+  EXPECT_EQ(base.type_name(), WeldJoint<double>::kTypeName);
+}
+
 // Verify the expected number of dofs.
 TEST_F(WeldJointTest, NumDOFs) {
   EXPECT_EQ(tree().num_positions(), 0);

--- a/multibody/tree/weld_joint.h
+++ b/multibody/tree/weld_joint.h
@@ -35,6 +35,8 @@ class WeldJoint final : public Joint<T> {
   template<typename Scalar>
   using Context = systems::Context<Scalar>;
 
+  static const char kTypeName[];
+
   /// Constructor for a %WeldJoint between a `parent_frame_P` and a
   /// `child_frame_C` so that their relative pose `X_PC` is fixed as if they
   /// were "welded" together.
@@ -50,7 +52,10 @@ class WeldJoint final : public Joint<T> {
                  VectorX<double>() /* no acc upper limits */),
         X_PC_(X_PC) {}
 
-  std::string type_name() const override { return "weld"; }
+  const std::string& type_name() const override {
+    static const never_destroyed<std::string> name{kTypeName};
+    return name.access();
+  }
 
 #ifndef DRAKE_DOXYGEN_CXX
   DRAKE_DEPRECATED(
@@ -153,6 +158,8 @@ class WeldJoint final : public Joint<T> {
   // The pose of frame C in P.
   const math::RigidTransform<double> X_PC_;
 };
+
+template <typename T> const char WeldJoint<T>::kTypeName[] = "weld";
 
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/weld_joint.h
+++ b/multibody/tree/weld_joint.h
@@ -50,6 +50,8 @@ class WeldJoint final : public Joint<T> {
                  VectorX<double>() /* no acc upper limits */),
         X_PC_(X_PC) {}
 
+  std::string type_name() const override { return "weld"; }
+
 #ifndef DRAKE_DOXYGEN_CXX
   DRAKE_DEPRECATED(
       "2019-06-15",


### PR DESCRIPTION
Resolves #9754.
MBP now creates a graph of bodies/joints during pre-finalization, which allows users to answer physically meaningful topological questions. In this PR we answer to the question from #9754; what bodies are welded to this one particular body? so that users can create collision filters as they build their model, pre-finalize.

cc'ing @EricCousineau-TRI

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11257)
<!-- Reviewable:end -->
