### PR TITLE
find_resource: Deprecate AddResourceSearchPath

### DIFF
--- a/bindings/pydrake/common/BUILD.bazel
+++ b/bindings/pydrake/common/BUILD.bazel
@@ -39,7 +39,10 @@ PACKAGE_INFO = get_pybind_package_info("//bindings")
 # `libdrake.so`.
 drake_pybind_library(
     name = "_init_py",
-    cc_deps = ["//bindings/pydrake:documentation_pybind"],
+    cc_deps = [
+        "//bindings/pydrake:documentation_pybind",
+        "//bindings/pydrake/common:deprecation_pybind",
+    ],
     cc_so_name = "_module_py",
     cc_srcs = ["module_py.cc"],
     package_info = PACKAGE_INFO,

--- a/bindings/pydrake/common/module_py.cc
+++ b/bindings/pydrake/common/module_py.cc
@@ -2,6 +2,7 @@
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 
+#include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/common/drake_assert.h"
@@ -70,15 +71,25 @@ PYBIND11_MODULE(_module_py, m) {
     }
   });
   // Convenient wrapper to add a resource search path.
-  m.def("AddResourceSearchPath", &AddResourceSearchPath,
-      "Adds a path in which to search for resource files. "
-      "The path refers to the relative path within the Drake repository, ",
-      py::arg("search_path"), doc.AddResourceSearchPath.doc);
+  m.def("AddResourceSearchPath",
+      [](const std::string& x) {
+        WarnDeprecated("See API docs for deprecation notice.");
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+        AddResourceSearchPath(x);
+#pragma GCC diagnostic pop
+      },
+      py::arg("search_path"), doc.AddResourceSearchPath.doc_deprecated);
   // Convenient wrapper to get the list of resource search paths.
-  m.def("GetResourceSearchPaths", &GetResourceSearchPaths,
-      "Gets a copy of the list of paths set programmatically in which "
-      "resource files are searched.",
-      doc.GetResourceSearchPaths.doc);
+  m.def("GetResourceSearchPaths",
+      []() {
+        WarnDeprecated("See API docs for deprecation notice.");
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+        return GetResourceSearchPaths();
+#pragma GCC diagnostic pop
+      },
+      doc.GetResourceSearchPaths.doc_deprecated);
   // Convenient wrapper for querying FindResource(resource_path).
   m.def("FindResourceOrThrow", &FindResourceOrThrow,
       "Attempts to locate a Drake resource named by the given path string. "

--- a/common/find_resource.h
+++ b/common/find_resource.h
@@ -5,6 +5,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/drake_optional.h"
 
 namespace drake {
@@ -72,15 +73,18 @@ class FindResourceResult {
   optional<std::string> error_message_;
 };
 
-/// Adds a path in which resources are searched in a persistent variable. Paths
-/// are accumulated each time this function is called. It is searched after the
-/// path given by the environment variable but before the path that can be
-/// found with the sentinel `.drake-resource-sentinel`. This can be used to
-/// find data in installed distributions of drake (or in `pydrake`).
+/// (Deprecated.)  Sets the kDrakeResourceRootEnvironmentVariableName
+/// environment variable to @p root_directory.
+/// @throws std::runtime_error if the environment variable is already set.
 /// @throws std::runtime_error if the given path is not absolute.
+DRAKE_DEPRECATED("2019-08-01",
+    "Call setenv(kDrakeResourceRootEnvironmentVariableName) instead.")
 void AddResourceSearchPath(std::string root_directory);
 
-/// Gets current root directory value from a persistent variable.
+/// Returns a single-element vector containing the last root_directory passed
+/// to AddResourceSearchPath() if any; otherwise, returns an empty vector.
+DRAKE_DEPRECATED("2019-08-01",
+    "Call getenv(kDrakeResourceRootEnvironmentVariableName) instead.")
 std::vector<std::string> GetResourceSearchPaths();
 
 /// Attempts to locate a Drake resource named by the given @p resource_path.
@@ -93,9 +97,9 @@ std::vector<std::string> GetResourceSearchPaths();
 /// The search scans for the resource in the following places and in
 /// the following order:
 ///
-/// 1. In the DRAKE_RESOURCE_ROOT environment variable
-/// 2. In the directories specified by `AddResourceSearchPath()` and
-/// 3. In the drake source workspace.
+/// 1. In the DRAKE_RESOURCE_ROOT environment variable.
+/// 2. In the drake source workspace.
+/// 3. In the drake installed workspace.
 ///
 /// If all of these are unavailable, or do not have the resource, then it will
 /// return a failed result.

--- a/common/resource_tool.cc
+++ b/common/resource_tool.cc
@@ -52,9 +52,14 @@ int main(int argc, char* argv[]) {
     return 0;
   }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   if (!FLAGS_add_resource_search_path.empty()) {
+    std::cerr << "resource_tool: WARNING: "
+              << "--add_resource_search_path is deprecated.\n";
     AddResourceSearchPath(FLAGS_add_resource_search_path);
   }
+#pragma GCC diagnostic pop
 
   const FindResourceResult& result = FindResource(FLAGS_print_resource_path);
   if (result.get_absolute_path()) {

--- a/common/test/find_resource_test.cc
+++ b/common/test/find_resource_test.cc
@@ -92,6 +92,8 @@ GTEST_TEST(FindResourceTest, FoundDeclaredData) {
   EXPECT_EQ(FindResourceOrThrow(relpath), absolute_path);
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 // Check that adding a relative resource path fails on purpose.
 GTEST_TEST(FindResourceTest, RelativeResourcePathShouldFail) {
   // Test `AddResourceSearchPath()` with a relative path. It is expected to
@@ -99,6 +101,7 @@ GTEST_TEST(FindResourceTest, RelativeResourcePathShouldFail) {
   const std::string test_directory = "find_resource_test_scratch";
   EXPECT_THROW(AddResourceSearchPath(test_directory), std::runtime_error);
 }
+#pragma GCC diagnostic pop
 
 optional<std::string> GetEnv(const std::string& name) {
   const char* result = ::getenv(name.c_str());
@@ -179,6 +182,8 @@ void Touch(const std::string& filename) {
   std::ofstream(filename.c_str(), std::ios::out).close();
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 // NOTE: This test modifies the result of calls to GetDrakePath() and variants.
 // However, it does *not* clean up the modifications. As such, it must run
 // *last*. Relying on execution order being alphabetical, we make sure it is
@@ -199,6 +204,7 @@ GTEST_TEST(ZZZ_FindResourceTest, ZZZ_AlternativeDirectory) {
   EXPECT_EQ(GetResourceSearchPaths()[0], test_directory);
   EXPECT_NO_THROW(drake::FindResourceOrThrow(candidate_filename));
 }
+#pragma GCC diagnostic pop
 
 }  // namespace
 }  // namespace drake


### PR DESCRIPTION
This feature was added to make pydrake paths work, before we had the other linker-based mechanisms in place to find resources.  (Drake used to have internal calls to this function.)  Now that we no longer use this in pydrake, we should remove it for simplicity, and in anticipation of runfiles cleanups.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11259)
<!-- Reviewable:end -->
