### PR TITLE
common: Use find_runfiles in find_resource

### DIFF
--- a/attic/multibody/parsers/BUILD.bazel
+++ b/attic/multibody/parsers/BUILD.bazel
@@ -84,6 +84,7 @@ drake_cc_googletest(
     deps = [
         ":parsers",
         "//common:find_resource",
+        "@spruce",
     ],
 )
 

--- a/attic/multibody/parsers/test/urdf_parser_test.cc
+++ b/attic/multibody/parsers/test/urdf_parser_test.cc
@@ -6,6 +6,7 @@
 #include <string>
 
 #include <gtest/gtest.h>
+#include <spruce.hh>
 
 #include "drake/common/find_resource.h"
 #include "drake/multibody/joints/floating_base_types.h"
@@ -195,8 +196,10 @@ GTEST_TEST(URDFParserTest,
   const string model_file = FindResourceOrThrow(
       "drake/examples/atlas/urdf/atlas_minimal_contact.urdf");
 
+  const string atlas_xml = FindResourceOrThrow(
+      "drake/examples/atlas/package.xml");
   PackageMap package_map;
-  package_map.Add("Atlas", FindResourceOrThrow("drake/examples/atlas"));
+  package_map.Add("Atlas", spruce::path(atlas_xml).root());
 
   auto tree = make_unique<RigidBodyTree<double>>();
   ASSERT_NO_THROW(AddModelInstanceFromUrdfFileSearchingInRosPackages(

--- a/bindings/pydrake/test/common_install_test.py
+++ b/bindings/pydrake/test/common_install_test.py
@@ -21,8 +21,7 @@ class TestCommonInstall(unittest.TestCase):
              ],
             env=tool_env,
             ).strip()
-        found_install_path = (data_folder in output_path)
-        self.assertTrue(found_install_path)
+        self.assertIn(data_folder, output_path)
 
 
 if __name__ == '__main__':

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -316,6 +316,7 @@ drake_cc_library(
     srcs = [
         "find_loaded_library.cc",
         "find_resource.cc",
+        "find_resource_deprecated.cc",
     ],
     hdrs = [
         "find_loaded_library.h",
@@ -333,7 +334,6 @@ drake_cc_library(
         ":drake_marker_shared_library",
         ":essential",
         ":find_runfiles",
-        "@spruce",
     ],
 )
 

--- a/common/find_resource.cc
+++ b/common/find_resource.cc
@@ -5,13 +5,15 @@
 #include <vector>
 
 #include <fmt/format.h>
-#include <spruce.hh>
 
 #include "drake/common/drake_marker.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/find_loaded_library.h"
+#include "drake/common/find_runfiles.h"
 #include "drake/common/never_destroyed.h"
+#include "drake/common/text_logging.h"
 
+using std::getenv;
 using std::string;
 
 namespace drake {
@@ -101,129 +103,53 @@ void Result::CheckInvariants() {
 
 namespace {
 
-optional<std::string> getenv_optional(const char* const name) {
-  const char* const value = std::getenv(name);
-  if (value) {
-    return string(value);
-  }
-  return nullopt;
+bool StartsWith(const string& str, const string& prefix) {
+  return str.compare(0, prefix.size(), prefix) == 0;
 }
 
-// If we are linked against libdrake_marker.so, return a candidate directory
-// based on libdrake_marker.so's path; otherwise, return nullopt.  The
-// resulting string will already end with "drake"; that is, the directory will
-// contain files named like "common/foo.txt", not "drake/common/foo.txt".
-optional<std::string>  GetCandidateDirFromLibDrakeMarker() {
-  // Ensure that we have the library loaded.
-  DRAKE_DEMAND(drake::internal::drake_marker_lib_check() == 1234);
-  optional<std::string> libdrake_dir = LoadedLibraryPath("libdrake_marker.so");
-  if (libdrake_dir) {
-    libdrake_dir = libdrake_dir.value() + "/../share/drake";
-  }
-  return libdrake_dir;
-}
-
-// Returns true iff the path is relative (not absolute).
+// Returns true iff the path is relative (not absolute nor empty).
 bool IsRelativePath(const string& path) {
-  // TODO(jwnimmer-tri) Prevent .. escape?
   return !path.empty() && (path[0] != '/');
 }
 
-// Returns the absolute_path iff the `$dirpath/$relpath` exists, else nullopt.
-// As a convenience to callers, if `dirpath` is nullopt, the result is nullopt.
-// (To inquire about an empty `dirpath`, pass the empty string, not nullopt.)
-optional<string> FileExists(
-    const optional<string>& dirpath, const string& relpath) {
-  DRAKE_ASSERT(IsRelativePath(relpath));
-  if (!dirpath) { return nullopt; }
-  const spruce::path dir_query(*dirpath);
-  if (!dir_query.isDir()) { return nullopt; }
-  const spruce::path file_query(dir_query.getStr() + '/' + relpath);
-  if (!file_query.exists()) { return nullopt; }
-  return file_query.getStr();
-}
+// Taking `root` to be Drake's resource root, confirm that the sentinel file
+// exists and return the found resource_path (or an error if either the
+// sentinel or resource_path was missing).
+Result CheckAndMakeResult(
+    const string& root_description, const string& root,
+    const string& resource_path) {
+  DRAKE_DEMAND(!root.empty());
+  DRAKE_DEMAND(!resource_path.empty());
+  DRAKE_DEMAND(internal::IsDir(root));
+  DRAKE_DEMAND(IsRelativePath(resource_path));
 
-// Given a path like /foo/bar, returns the path /foo/bar/drake.
-// Iff the path is nullopt, then the result is nullopt.
-optional<string> AppendDrakeTo(const optional<string>& path) {
-  if (path) {
-    spruce::path result = *path;
-    result.append("drake");
-    return result.getStr();
+  // Check for the sentinel.
+  const char* const sentinel_relpath = "drake/.drake-find_resource-sentinel";
+  if (!internal::IsFile(root + "/" + sentinel_relpath)) {
+    return Result::make_error(resource_path, fmt::format(
+        "Could not find Drake resource_path '{}' because {} specified a "
+        "resource root of '{}' but that root did not contain the expected "
+        "sentinel file '{}'.",
+        resource_path, root_description, root, sentinel_relpath));
   }
-  return nullopt;
-}
 
-// Returns candidate_dir iff it exists and contains our sentinel file.
-// Candidate paths will already end with "drake" as their final path element,
-// or possibly a related name like "drake2"; that is, they will contain files
-// named like "common/foo.txt", not "drake/common/foo.txt".
-optional<string> CheckCandidateDir(const spruce::path& candidate_dir) {
-  // If we found the sentinel, we win.
-  spruce::path candidate_file = candidate_dir;
-  candidate_file.append(".drake-find_resource-sentinel");
-  if (candidate_file.isFile()) {
-    return candidate_dir.getStr();
+  // Check for the resource_path.
+  const string abspath = root + '/' + resource_path;
+  if (!internal::IsFile(abspath)) {
+    return Result::make_error(resource_path, fmt::format(
+        "Could not find Drake resource_path '{}' because {} specified a "
+        "resource root of '{}' but that root did not contain the expected "
+        "file '{}'.",
+        resource_path, root_description, root, abspath));
   }
-  return nullopt;
-}
 
-// Returns a sentinel directory appropriate when running under `bazel test`.
-optional<string> GetTestRunfilesDir() {
-  // These environment variables are documented at:
-  // https://docs.bazel.build/versions/master/test-encyclopedia.html#initial-conditions
-  // We check TEST_TMPDIR as a sanity check that we're being called by Bazel.
-  // Other than TEST_SRCDIR below, its the only other non-standard environment
-  // variable that Bazel is required to set when running a test.
-  if (::getenv("TEST_TMPDIR") == nullptr) {
-    // Not running under `bazel test`.
-    return nullopt;
-  }
-  char* test_srcdir = ::getenv("TEST_SRCDIR");
-  if (test_srcdir == nullptr) {
-    // Apparently running under `bazel test`, but no runfiles tree is set?
-    // Maybe TEST_TMPDIR was something other than Bazel; ignore it.
-    return nullopt;
-  }
-  return CheckCandidateDir(*AppendDrakeTo(string(test_srcdir)));
-}
-
-// Returns the directory that contains our sentinel file, searching from the
-// current directory and working up through all transitive parent directories
-// up to "/".  Candidate paths will already end with "drake" as their final
-// path element, or possibly a related name like "drake2"; that is, they will
-// contain files named like "common/foo.txt", not "drake/common/foo.txt".
-optional<string> FindSentinelDir() {
-  spruce::path candidate_dir = spruce::dir::getcwd();
-  int num_attempts = 0;
-  while (true) {
-    DRAKE_THROW_UNLESS(num_attempts < 1000);  // Insanity fail-fast.
-    ++num_attempts;
-
-    // If we fall off the end of the world somehow, stop.
-    if (!candidate_dir.isDir()) {
-      return nullopt;
-    }
-
-    // If we found the sentinel, we win.
-    optional<string> result = CheckCandidateDir(candidate_dir);
-    if (result) {
-      return result;
-    }
-
-    // Move up one directory; with spruce, "root" means "parent".
-    candidate_dir = candidate_dir.root();
-  }
-}
-
-bool StartsWith(const string& str, const string& prefix) {
-  return str.compare(0, prefix.size(), prefix) == 0;
+  return Result::make_success(resource_path, abspath);
 }
 
 // Opportunistically searches inside the attic for multibody resource paths.
 // This function is not unit tested -- only acceptance-tested by the fact that
 // none of the tests in the attic fail.
-Result MaybeFindResourceInAttic(const string& resource_path) {
+optional<string> MaybeFindResourceInAttic(const string& resource_path) {
   const string prefix("drake/");
   DRAKE_DEMAND(StartsWith(resource_path, prefix));
   const string substr = resource_path.substr(prefix.size());
@@ -238,14 +164,34 @@ Result MaybeFindResourceInAttic(const string& resource_path) {
            "systems/controllers/qp_inverse_dynamics/test"
        }) {
     if (StartsWith(substr, directory)) {
-      const Result attic_result =
-          FindResource(prefix + string("attic/") + substr);
-      if (attic_result.get_absolute_path() != nullopt) {
-        return attic_result;
+      const auto rlocation_or_error =
+          internal::FindRunfile(prefix + string("attic/") + substr);
+      if (rlocation_or_error.error.empty()) {
+        return rlocation_or_error.abspath;
       }
     }
   }
-  return Result::make_error(resource_path, "Not an attic path");
+  return nullopt;
+}
+
+// If we are linked against libdrake_marker.so, and the install-tree-relative
+// path resolves correctly, return it as the resource root, else return nullopt.
+optional<string> MaybeGetInstallResourceRoot() {
+  // Ensure that we have the library loaded.
+  DRAKE_DEMAND(drake::internal::drake_marker_lib_check() == 1234);
+  optional<string> libdrake_dir = LoadedLibraryPath("libdrake_marker.so");
+  if (libdrake_dir) {
+    const string root = *libdrake_dir + "/../share";
+    if (internal::IsDir(root)) {
+      return root;
+    } else {
+      log()->debug("FindResource ignoring CMake install candidate '{}' "
+                   "because it does not exist", root);
+    }
+  } else {
+    log()->debug("FindResource has no CMake install candidate");
+  }
+  return nullopt;
 }
 
 }  // namespace
@@ -253,41 +199,7 @@ Result MaybeFindResourceInAttic(const string& resource_path) {
 const char* const kDrakeResourceRootEnvironmentVariableName =
     "DRAKE_RESOURCE_ROOT";
 
-// Saves search directories path in a persistent variable.
-// This function is only accessible from this file and should not
-// be used outside of `GetResourceSearchPaths()` and
-// `AddResourceSearchPath()`.
-namespace {
-std::vector<string>& GetMutableResourceSearchPaths() {
-  static never_destroyed<std::vector<string>> search_paths;
-  return search_paths.access();
-}
-}  // namespace
-
-std::vector<string> GetResourceSearchPaths() {
-  return GetMutableResourceSearchPaths();
-}
-
-void AddResourceSearchPath(string search_path) {
-  // Throw an error if path is relative.
-  DRAKE_THROW_UNLESS(!IsRelativePath(search_path));
-
-  // When the environment variable is aready in play, this function has no
-  // effect.
-  if (getenv_optional(kDrakeResourceRootEnvironmentVariableName)) {
-    throw std::runtime_error(fmt::format(
-        "Cannot AddResourceSearchPath when {} is already set.",
-        kDrakeResourceRootEnvironmentVariableName));
-  }
-
-  // Set the environment variable so that `search_path` will be considered.
-  ::setenv(kDrakeResourceRootEnvironmentVariableName, search_path.c_str(), 1);
-
-  // Add it to the collection so that GetResourceSearchPaths still works.
-  GetMutableResourceSearchPaths().push_back(std::move(search_path));
-}
-
-Result FindResource(string resource_path) {
+Result FindResource(const string& resource_path) {
   // Check if resource_path is well-formed: a relative path that starts with
   // "drake" as its first directory name.  A valid example would look like:
   // "drake/common/test/find_resource_test_data.txt".  Requiring strings passed
@@ -295,75 +207,69 @@ Result FindResource(string resource_path) {
   // compatibility with the original semantics of this function; if we want to
   // offer a function that takes paths without "drake", we can use a new name.
   if (!IsRelativePath(resource_path)) {
-    return Result::make_error(
-        std::move(resource_path),
-        "resource_path is not a relative path");
+    return Result::make_error(resource_path, fmt::format(
+        "Drake resource_path '{}' is not a relative path.",
+        resource_path));
   }
-  const std::string prefix("drake/");
+  const string prefix("drake/");
   if (!StartsWith(resource_path, prefix)) {
-    return Result::make_error(
-        std::move(resource_path),
-        "resource_path does not start with " + prefix);
+    return Result::make_error(resource_path, fmt::format(
+        "Drake resource_path '{}' does not start with {}.",
+        resource_path, prefix));
   }
-  const std::string resource_path_substr = resource_path.substr(prefix.size());
 
-  // Collect a list of (priority-ordered) directories to check.  Candidate
-  // paths will already end with "drake" as their final path element, or
-  // possibly a related name like "drake2"; that is, they will contain files
-  // named like "common/foo.txt", not "drake/common/foo.txt".
-  std::vector<optional<string>> candidate_dirs;
+  // We will check each potential resource root one by one.  The first root
+  // that is present will be chosen, even if does not contain the particular
+  // resource_path.  We expect that all sources offer all files.
 
-  // (1) Search the environment variable first; if it works, it should always
-  // win.  TODO(jwnimmer-tri) Should we split on colons, making this a PATH?
-  candidate_dirs.emplace_back(AppendDrakeTo(getenv_optional(
-      kDrakeResourceRootEnvironmentVariableName)));
-
-  // (3) Find where `libdrake_marker.so` is, and add search path that
-  // corresponds to resource folder in install tree based on
-  // `libdrake_marker.so` location.
-  candidate_dirs.emplace_back(GetCandidateDirFromLibDrakeMarker());
-
-  // (4) Find resources during `bazel test` execution.
-  candidate_dirs.emplace_back(GetTestRunfilesDir());
-
-  // (5) Search in cwd (and its parent, grandparent, etc.) to find Drake's
-  // resource-root sentinel file.
-  candidate_dirs.emplace_back(FindSentinelDir());
-
-  // Make sure that candidate_dirs are not relative paths. This could cause
-  // bugs, but in theory it should never happen as the code above should
-  // guard against it.
-  for (const auto& candidate_dir : candidate_dirs) {
-    if (candidate_dir && IsRelativePath(candidate_dir.value())) {
-        string error_message = "path is not absolute: " + candidate_dir.value();
-        return Result::make_error(std::move(resource_path), error_message);
-      }
+  // (1) Check the environment variable.
+  if (char* guess = getenv(kDrakeResourceRootEnvironmentVariableName)) {
+    const char* const env_name = kDrakeResourceRootEnvironmentVariableName;
+    if (internal::IsDir(guess)) {
+      return CheckAndMakeResult(
+          fmt::format("{} environment variable ", env_name),
+          guess, resource_path);
+    } else {
+      log()->debug("FindResource ignoring {}='{}' because it does not exist",
+                   env_name, guess);
     }
+  }
 
-  // See which (if any) candidate contains the requested resource.
-  for (const auto& candidate_dir : candidate_dirs) {
-    if (auto absolute_path = FileExists(candidate_dir, resource_path_substr)) {
+  // (2) Check the Runfiles.
+  if (internal::HasRunfiles()) {
+    auto rlocation_or_error = internal::FindRunfile(resource_path);
+    if (rlocation_or_error.error.empty()) {
       return Result::make_success(
-          std::move(resource_path), std::move(*absolute_path));
+          resource_path, rlocation_or_error.abspath);
     }
+    // As a compatibility shim, for resource paths that have been moved into the
+    // attic, we opportunistically try a fallback search path for them.  This
+    // heuristic is only helpful for source trees -- any install data files from
+    // the attic should be installed without the "attic/" portion of their path.
+    if (auto attic_abspath = MaybeFindResourceInAttic(resource_path)) {
+      return Result::make_success(resource_path, *attic_abspath);
+    }
+    return Result::make_error(resource_path, rlocation_or_error.error);
   }
 
-  // As a compatibility shim, for resource paths that have been moved into the
-  // attic, we opportunistically try a fallback search path for them.  This
-  // heuristic is only helpful for source trees -- any install data files from
-  // the attic should be installed without the "attic/" portion of their path.
-  const Result attic_result = MaybeFindResourceInAttic(resource_path);
-  if (attic_result.get_absolute_path() != nullopt) {
-    return attic_result;
+  // (3) Check the `libdrake_marker.so` location in the install tree.
+  if (auto guess = MaybeGetInstallResourceRoot()) {
+    return CheckAndMakeResult(
+        "Drake CMake install marker",
+        *guess, resource_path);
   }
 
-  // Nothing found.
-  string error_message = "could not find resource: " + resource_path;
-  return Result::make_error(std::move(resource_path), error_message);
+  // No resource roots were found.
+  return Result::make_error(resource_path, fmt::format(
+      "Could not find Drake resource_path '{}' because no resource roots of "
+      "any kind could be found: {} is unset, a {} could not be created, and "
+      "there is no Drake CMake install marker.",
+      resource_path, kDrakeResourceRootEnvironmentVariableName,
+      "bazel::tools::cpp::runfiles::Runfiles"));
 }
 
-std::string FindResourceOrThrow(std::string resource_path) {
-  return FindResource(std::move(resource_path)).get_absolute_path_or_throw();
+string FindResourceOrThrow(const string& resource_path) {
+  return FindResource(resource_path).get_absolute_path_or_throw();
 }
 
 }  // namespace drake

--- a/common/find_resource.h
+++ b/common/find_resource.h
@@ -79,7 +79,7 @@ class FindResourceResult {
 /// @throws std::runtime_error if the given path is not absolute.
 DRAKE_DEPRECATED("2019-08-01",
     "Call setenv(kDrakeResourceRootEnvironmentVariableName) instead.")
-void AddResourceSearchPath(std::string root_directory);
+void AddResourceSearchPath(const std::string& root_directory);
 
 /// Returns a single-element vector containing the last root_directory passed
 /// to AddResourceSearchPath() if any; otherwise, returns an empty vector.
@@ -92,22 +92,26 @@ std::vector<std::string> GetResourceSearchPaths();
 /// repository, prepended with `drake/`.  For example, to find the source
 /// file `examples/pendulum/Pendulum.urdf`, the @p resource_path would be
 /// `drake/examples/pendulum/Pendulum.urdf`.  Paths that do not start with
-/// `drake/` will return a failed result.
+/// `drake/` will return an error result.  The @p resource_path must refer
+/// to a file (not a directory).
 ///
-/// The search scans for the resource in the following places and in
+/// The search scans for the resource in the following resource roots and in
 /// the following order:
 ///
 /// 1. In the DRAKE_RESOURCE_ROOT environment variable.
-/// 2. In the drake source workspace.
-/// 3. In the drake installed workspace.
+/// 2. In the Bazel runfiles for a bazel-bin/pkg/program.
+/// 3. In the Drake CMake install directory.
 ///
-/// If all of these are unavailable, or do not have the resource, then it will
-/// return a failed result.
-FindResourceResult FindResource(std::string resource_path);
+/// The first resource root from the list that exists is used to find any and
+/// all Drake resources.  If the resource root does not contain the resource,
+/// the result is an error even (if a resource root lower on the list happens
+/// to have the resource).  If all three roots are unavailable, then returns an
+/// error result.
+FindResourceResult FindResource(const std::string& resource_path);
 
 /// Convenient wrapper for querying FindResource(resource_path) followed by
 /// FindResourceResult::get_absolute_path_or_throw().
-std::string FindResourceOrThrow(std::string resource_path);
+std::string FindResourceOrThrow(const std::string& resource_path);
 
 /// The name of the environment variable that provides the first place where
 /// FindResource attempts to look.  The environment variable is allowed to be

--- a/common/find_resource_deprecated.cc
+++ b/common/find_resource_deprecated.cc
@@ -1,0 +1,43 @@
+#include <cstdlib>
+#include <stdexcept>
+
+#include <fmt/format.h>
+
+#include "drake/common/drake_throw.h"
+#include "drake/common/find_resource.h"
+#include "drake/common/never_destroyed.h"
+
+// This file contains the implementations of find_resource.h functions that are
+// deprecated, in order to de-clutter find_resource.cc.
+
+namespace drake {
+namespace {
+std::vector<std::string>& GetMutableResourceSearchPaths() {
+  static never_destroyed<std::vector<std::string>> search_paths;
+  return search_paths.access();
+}
+}  // namespace
+
+std::vector<std::string> GetResourceSearchPaths() {
+  return GetMutableResourceSearchPaths();
+}
+
+void AddResourceSearchPath(const std::string& search_path) {
+  DRAKE_THROW_UNLESS((search_path.length() > 0) && (search_path[0] == '/'));
+
+  // When the environment variable is aready in play, this function has no
+  // effect.
+  if (::getenv(kDrakeResourceRootEnvironmentVariableName)) {
+    throw std::runtime_error(fmt::format(
+        "Cannot AddResourceSearchPath when {} is already set.",
+        kDrakeResourceRootEnvironmentVariableName));
+  }
+
+  // Set the environment variable so that `search_path` will be considered.
+  ::setenv(kDrakeResourceRootEnvironmentVariableName, search_path.c_str(), 1);
+
+  // Add it to the collection so that GetResourceSearchPaths still works.
+  GetMutableResourceSearchPaths().push_back(std::move(search_path));
+}
+
+}  // namespace drake

--- a/common/test/find_resource_test.cc
+++ b/common/test/find_resource_test.cc
@@ -8,6 +8,7 @@
 #include <stdexcept>
 #include <string>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <spruce.hh>
 
@@ -42,7 +43,8 @@ GTEST_TEST(FindResourceTest, NonRelativeRequest) {
   // We get an error back.
   const optional<string> error_message = result.get_error_message();
   ASSERT_TRUE(error_message);
-  EXPECT_EQ(*error_message, "resource_path is not a relative path");
+  EXPECT_EQ(*error_message,
+            "Drake resource_path '/dev/null' is not a relative path.");
 }
 
 GTEST_TEST(FindResourceTest, NotFound) {
@@ -57,7 +59,8 @@ GTEST_TEST(FindResourceTest, NotFound) {
   // We get an error back.
   const optional<string> error_message = result.get_error_message();
   ASSERT_TRUE(error_message);
-  EXPECT_EQ(*error_message, "could not find resource: " + relpath);
+  EXPECT_THAT(*error_message, testing::ContainsRegex(
+      "Sought '" + relpath + "' in runfiles.*not exist.*on the manifest"));
 
   // Sugar works the same way.
   EXPECT_THROW(FindResourceOrThrow(relpath), std::runtime_error);
@@ -102,64 +105,6 @@ GTEST_TEST(FindResourceTest, RelativeResourcePathShouldFail) {
   EXPECT_THROW(AddResourceSearchPath(test_directory), std::runtime_error);
 }
 #pragma GCC diagnostic pop
-
-optional<std::string> GetEnv(const std::string& name) {
-  const char* result = ::getenv(name.c_str());
-  if (!result) { return nullopt; }
-  return std::string(result);
-}
-
-void SetEnv(const std::string& name, const optional<std::string>& value) {
-  if (value) {
-    const int result = ::setenv(name.c_str(), value->c_str(), 1);
-    DRAKE_THROW_UNLESS(result == 0);
-  } else {
-    const int result = ::unsetenv(name.c_str());
-    DRAKE_THROW_UNLESS(result == 0);
-  }
-}
-
-// Make a scope exit guard -- an object that when destroyed runs `func`.
-auto MakeGuard(std::function<void()> func) {
-  // The shared_ptr deleter func is always invoked, even for nullptrs.
-  // http://en.cppreference.com/w/cpp/memory/shared_ptr/%7Eshared_ptr
-  return std::shared_ptr<void>(nullptr, [=](void*) { func(); });
-}
-
-GTEST_TEST(FindResourceTest, FindUsingTestSrcdir) {
-  // Confirm that the resource is found normally.
-  const string relpath = "drake/common/test/find_resource_test_data.txt";
-  EXPECT_TRUE(FindResource(relpath).get_absolute_path());
-
-  // If we defeat both (1) the "look in current working directory" heuristic
-  // and (2) the "look in TEST_SRCDIR" heuristic, then we should no longer be
-  // able to find the resource.
-
-  // Change cwd to be "/", but put it back when this test case ends.
-  const spruce::path original_cwd = spruce::dir::getcwd();
-  auto restore_cwd_guard = MakeGuard([original_cwd]() {
-      const bool restore_ok = spruce::dir::chdir(original_cwd);
-      DRAKE_DEMAND(restore_ok);
-    });
-  const bool chdir_ok = spruce::dir::chdir(spruce::path("/"));
-  ASSERT_TRUE(chdir_ok);
-
-  // Unset TEST_SRCDIR for a moment, and confirm that FindResource now fails.
-  const std::string original_test_srcdir = GetEnv("TEST_SRCDIR").value_or("");
-  ASSERT_FALSE(original_test_srcdir.empty());
-  {
-    auto restore_test_srcdir_guard = MakeGuard([original_test_srcdir]() {
-        SetEnv("TEST_SRCDIR", original_test_srcdir);
-      });
-    SetEnv("TEST_SRCDIR", nullopt);
-
-    // Can't find the resource anymore.
-    EXPECT_TRUE(FindResource(relpath).get_error_message());
-  }
-
-  // Having TEST_SRCDIR back again is enough to get us working.
-  EXPECT_TRUE(FindResource(relpath).get_absolute_path());
-}
 
 GTEST_TEST(GetDrakePathTest, BasicTest) {
   // Just test that we find a path, without any exceptions.

--- a/common/test/resource_tool_test.py
+++ b/common/test/resource_tool_test.py
@@ -75,7 +75,8 @@ class TestResourceTool(unittest.TestCase):
             "--print_resource_path",
             "drake/no_such_file",
             ], expected_returncode=1)
-        self.assertTrue("could not find resource" in output)
+        self.assertIn("Sought 'drake/no_such_file' in runfiles", output)
+        self.assertIn("file does not exist", output)
 
     def test_help_example_is_correct(self):
         # Look at the usage message, and snarf its Pendulum example paths.

--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -250,6 +250,7 @@ drake_cc_googletest(
         ":detail_sdf_parser",
         "//common:find_resource",
         "//common/test_utilities",
+        "@spruce",
     ],
 )
 
@@ -267,6 +268,7 @@ drake_cc_googletest(
         "//common/test_utilities",
         "//multibody/benchmarks/acrobot",
         "//multibody/benchmarks/acrobot:make_acrobot_plant",
+        "@spruce",
     ],
 )
 

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 #include <sdf/sdf.hh>
+#include <spruce.hh>
 
 #include "drake/common/find_resource.h"
 #include "drake/common/temp_directory.h"
@@ -43,12 +44,13 @@ GTEST_TEST(MultibodyPlantSdfParserTest, PackageMapSpecified) {
 
   const std::string full_sdf_filename = FindResourceOrThrow(
       "drake/multibody/parsing/test/box_package/sdfs/box.sdf");
-  const std::string package_path = FindResourceOrThrow(
-      "drake/multibody/parsing/test/box_package");
+  spruce::path package_path = full_sdf_filename;
+  package_path = package_path.root();
+  package_path = package_path.root();
 
   // Construct the PackageMap.
   PackageMap package_map;
-  package_map.PopulateFromFolder(package_path);
+  package_map.PopulateFromFolder(package_path.getStr());
 
   // Read in the SDF file.
   AddModelFromSdfFile(full_sdf_filename, "", package_map, &plant, &scene_graph);
@@ -220,9 +222,10 @@ GTEST_TEST(SdfParserThrowsWhen, JointDampingIsNegative) {
 }
 
 GTEST_TEST(SdfParser, IncludeTags) {
-  const std::string sdf_file_path =
-      "drake/multibody/parsing/test/sdf_parser_test";
-  sdf::addURIPath("model://", FindResourceOrThrow(sdf_file_path));
+  const std::string full_name = FindResourceOrThrow(
+      "drake/multibody/parsing/test/sdf_parser_test/"
+      "include_models.sdf");
+  sdf::addURIPath("model://", spruce::path(full_name).root());
   MultibodyPlant<double> plant;
 
   // We start with the world and default model instances.
@@ -231,8 +234,6 @@ GTEST_TEST(SdfParser, IncludeTags) {
   ASSERT_EQ(plant.num_joints(), 0);
 
   PackageMap package_map;
-  const std::string full_name = FindResourceOrThrow(
-      sdf_file_path + "/include_models.sdf");
   package_map.PopulateUpstreamToDrake(full_name);
   AddModelsFromSdfFile(full_name, package_map, &plant);
   plant.Finalize();

--- a/multibody/parsing/test/detail_urdf_parser_test.cc
+++ b/multibody/parsing/test/detail_urdf_parser_test.cc
@@ -3,6 +3,7 @@
 #include <limits>
 
 #include <gtest/gtest.h>
+#include <spruce.hh>
 
 #include "drake/common/eigen_types.h"
 #include "drake/common/find_resource.h"
@@ -28,12 +29,13 @@ GTEST_TEST(MultibodyPlantUrdfParserTest, PackageMapSpecified) {
 
   const std::string full_urdf_filename = FindResourceOrThrow(
       "drake/multibody/parsing/test/box_package/urdfs/box.urdf");
-  const std::string package_path = FindResourceOrThrow(
-      "drake/multibody/parsing/test/box_package");
+  spruce::path package_path = full_urdf_filename;
+  package_path = package_path.root();
+  package_path = package_path.root();
 
   // Construct the PackageMap.
   PackageMap package_map;
-  package_map.PopulateFromFolder(package_path);
+  package_map.PopulateFromFolder(package_path.getStr());
 
   // Read in the URDF file.
   AddModelFromUrdfFile(full_urdf_filename, "", package_map, &plant,

--- a/tools/install/install_test.py
+++ b/tools/install/install_test.py
@@ -22,11 +22,20 @@ class TestInstall(unittest.TestCase):
         content = set(os.listdir(installation_folder))
         self.assertSetEqual(set(['bin', 'include', 'lib', 'share']), content)
 
+        # Our launched processes should be independent, not inherit their
+        # runfiles from the install_test.py runner.
+        cmd_env = dict(os.environ)
+        for key in ["RUNFILES_MANIFEST_FILE", "RUNFILES_DIR", "TEST_SRCDIR"]:
+            if key in cmd_env:
+                del cmd_env[key]
+
         # Execute the install actions.
         for cmd in lines:
             cmd = cmd.strip()
             print("+ {}".format(cmd))
-            install_test_helper.check_call([os.path.join(os.getcwd(), cmd)])
+            install_test_helper.check_call(
+                [os.path.join(os.getcwd(), cmd)],
+                env=cmd_env)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This simplifies FindResourceOrThrow to just the three essential modes: user override, or runfiles, or CMake install.

Besides reducing the maintenance burden, this also makes workflows like [drake_bazel_external](https://github.com/RobotLocomotion/drake-external-examples/tree/master/drake_bazel_external) able to call Drake library code that requires resources without having to set `DRAKE_RESOURCE_ROOT` in the environment first.

Closes #11111.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11261)
<!-- Reviewable:end -->
