### PR TITLE
common: Add find_runfiles

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -32,6 +32,7 @@ drake_cc_package_library(
         ":essential",
         ":extract_double",
         ":find_resource",
+        ":find_runfiles",
         ":hash",
         ":is_approx_equal_abstol",
         ":is_cloneable",
@@ -301,6 +302,16 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "find_runfiles",
+    srcs = ["find_runfiles.cc"],
+    hdrs = ["find_runfiles.h"],
+    deps = [
+        ":essential",
+        "@bazel_tools//tools/cpp/runfiles",
+    ],
+)
+
+drake_cc_library(
     name = "find_resource",
     srcs = [
         "find_loaded_library.cc",
@@ -321,6 +332,7 @@ drake_cc_library(
     deps = [
         ":drake_marker_shared_library",
         ":essential",
+        ":find_runfiles",
         "@spruce",
     ],
 )
@@ -847,6 +859,32 @@ drake_cc_googletest(
     ],
     deps = [
         ":find_resource",
+    ],
+)
+
+drake_cc_googletest(
+    name = "find_runfiles_test",
+    data = [
+        "test/find_resource_test_data.txt",
+    ],
+    deps = [
+        ":find_runfiles",
+        ":temp_directory",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
+    name = "find_runfiles_fail_test",
+    deps = [
+        ":find_runfiles",
+    ],
+)
+
+drake_py_unittest(
+    name = "find_runfiles_subprocess_test",
+    data = [
+        ":find_runfiles_test",
     ],
 )
 

--- a/common/find_loaded_library.cc
+++ b/common/find_loaded_library.cc
@@ -1,6 +1,7 @@
 #include "drake/common/find_loaded_library.h"
 
 #include "drake/common/drake_throw.h"
+#include "drake/common/find_runfiles.h"
 
 #ifdef __APPLE__
 #include <dlfcn.h>
@@ -101,11 +102,8 @@ optional<string> LoadedLibraryPath(const std::string& library_name) {
     if (pos_slash && !strcmp(pos_slash + 1, library_name.c_str())) {
       // Check if path is relative. If so, make it absolute.
       if (map->l_name[0] != '/') {
-        char buf[PATH_MAX];
-        ssize_t readlink_res = readlink("/proc/self/exe", buf, sizeof(buf));
-        DRAKE_THROW_UNLESS(readlink_res >= 0 && readlink_res < PATH_MAX);
-        buf[readlink_res] = '\0';
-        return string(dirname(buf)) + "/" +
+        std::string argv0 = internal::Readlink("/proc/self/exe");
+        return string(dirname(&argv0[0])) + "/" +
               string(map->l_name, pos_slash - map->l_name);
       } else {
         return string(map->l_name, pos_slash - map->l_name);

--- a/common/find_runfiles.cc
+++ b/common/find_runfiles.cc
@@ -1,0 +1,228 @@
+#include "drake/common/find_runfiles.h"
+
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <cstdlib>
+#include <fstream>
+#include <memory>
+
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#endif
+
+#include "fmt/format.h"
+#include "tools/cpp/runfiles/runfiles.h"
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/never_destroyed.h"
+#include "drake/common/text_logging.h"
+
+using bazel::tools::cpp::runfiles::Runfiles;
+
+namespace drake {
+namespace internal {
+namespace {
+
+// Replace `nullptr` with `"nullptr",` or else just return `arg` unchanged.
+const char* nullable_to_string(const char* arg) {
+  return arg ? arg : "nullptr";
+}
+
+// Either a bazel_tools Runfiles object xor an error string.
+struct RunfilesSingleton {
+  std::unique_ptr<Runfiles> runfiles;
+  std::string runfiles_dir;
+  std::string error;
+};
+
+// Create a bazel_tools Runfiles object xor an error string.  This is memoized
+// by GetSingletonRunfiles (i.e., this is only called once per process).
+RunfilesSingleton Create() {
+  const char* mechanism{};
+  RunfilesSingleton result;
+  std::string bazel_error;
+
+  // Chose a mechanism based on environment variables.
+  if (std::getenv("TEST_SRCDIR")) {
+    // When running under bazel test, use the test heuristics.
+    mechanism = "TEST_SRCDIR";
+    result.runfiles.reset(Runfiles::CreateForTest(&bazel_error));
+  } else if ((std::getenv("RUNFILES_MANIFEST_FILE") != nullptr) ||
+             (std::getenv("RUNFILES_DIR") != nullptr)) {
+    // When running with some RUNFILES_* env already set, just use that.
+    mechanism = "RUNFILES_{MANIFEST_FILE,DIR}";
+    result.runfiles.reset(Runfiles::Create({}, &bazel_error));
+  } else {
+    // When running from the user's command line, use argv0.
+    mechanism = "argv0";
+#ifdef __APPLE__
+    std::string argv0;
+    argv0.resize(4096);
+    uint32_t buf_size = argv0.size();
+    int error = _NSGetExecutablePath(&argv0.front(), &buf_size);
+    if (error) {
+      throw std::runtime_error("Error from _NSGetExecutablePath");
+    }
+    argv0.resize(buf_size);
+    drake::log()->debug("_NSGetExecutablePath = {}", argv0);
+#else
+    const std::string& argv0 = Readlink("/proc/self/exe");
+    drake::log()->debug("readlink(/proc/self/exe) = {}", argv0);
+#endif
+    result.runfiles.reset(Runfiles::Create(argv0, &bazel_error));
+  }
+  drake::log()->debug("FindRunfile mechanism = {}", mechanism);
+
+  // If there were runfiles, identify the RUNFILES_DIR.
+  if (result.runfiles) {
+    for (const auto& key_value : result.runfiles->EnvVars()) {
+      if (key_value.first == "RUNFILES_DIR") {
+        result.runfiles_dir = key_value.second;
+        break;
+      }
+    }
+    // If we didn't find it, something was very wrong.
+    if (result.runfiles_dir.empty()) {
+      bazel_error = "RUNFILES_DIR was not provided by the Runfiles object";
+      result.runfiles.reset();
+    } else if (!IsDir(result.runfiles_dir)) {
+      bazel_error = fmt::format(
+          "RUNFILES_DIR '{}' does not exist", result.runfiles_dir);
+      result.runfiles.reset();
+    }
+  }
+
+  // Report any error.
+  if (!result.runfiles) {
+    result.runfiles_dir.clear();
+    result.error = fmt::format(
+        "{} (created using {} with TEST_SRCDIR={} and "
+            "RUNFILES_MANIFEST_FILE={} and RUNFILES_DIR={})",
+        bazel_error, mechanism,
+        nullable_to_string(std::getenv("TEST_SRCDIR")),
+        nullable_to_string(std::getenv("RUNFILES_MANIFEST_FILE")),
+        nullable_to_string(std::getenv("RUNFILES_DIR")));
+  }
+
+  // Sanity check our return value.
+  if (result.runfiles.get() == nullptr) {
+    DRAKE_DEMAND(result.runfiles_dir.empty());
+    DRAKE_DEMAND(result.error.length() > 0);
+  } else {
+    DRAKE_DEMAND(result.runfiles_dir.length() > 0);
+    DRAKE_DEMAND(result.error.empty());
+  }
+
+  return result;
+}
+
+// Returns the RunfilesSingleton for the current process, latch-initializing it
+// first if necessary.
+const RunfilesSingleton& GetRunfilesSingleton() {
+  static const never_destroyed<RunfilesSingleton> result{Create()};
+  return result.access();
+}
+
+}  // namespace
+
+bool HasRunfiles() {
+  return GetRunfilesSingleton().runfiles.get() != nullptr;
+}
+
+RlocationOrError FindRunfile(const std::string& resource_path) {
+  const auto& singleton = GetRunfilesSingleton();
+
+  // Check for HasRunfiles.
+  RlocationOrError result;
+  if (!singleton.runfiles) {
+    DRAKE_DEMAND(!singleton.error.empty());
+    result.error = singleton.error;
+    return result;
+  }
+
+  // Check the user input.
+  if (resource_path.empty()) {
+    result.error = "Resource path must not be empty";
+    return result;
+  }
+  if (resource_path[0] == '/') {
+    result.error = fmt::format(
+        "Resource path '{}' must not be an absolute path", resource_path);
+    return result;
+  }
+
+  // Locate the file on the manifest and in the directory.
+  const std::string by_man = singleton.runfiles->Rlocation(resource_path);
+  const std::string by_dir = singleton.runfiles_dir + "/" + resource_path;
+  const bool by_man_ok = IsFile(by_man);
+  const bool by_dir_ok = IsFile(by_dir);
+  drake::log()->debug(
+      "FindRunfile found by-manifest '{}' ({}) and by-directory '{}' ({})",
+      by_man, by_man_ok ? "good" : "bad", by_dir, by_dir_ok ? "good" : "bad");
+
+  if (by_man_ok && by_dir_ok) {
+    // We must always return the directory-based result (not the manifest
+    // result) because the result itself may be a file that contains embedded
+    // relative pathnames.  The manifest result might actually be in the source
+    // tree, not the runfiles directory, and in that case relative paths may
+    // not work (e.g., when the relative path refers to a genfile).
+    result.abspath = by_dir;
+    return result;
+  }
+
+  // Report an error.
+  const char* detail{};
+  if (!by_man_ok && !by_dir_ok) {
+    detail =
+        "but the file does not exist at that location "
+        "nor is it on the manifest";
+  } else if (!by_man_ok && by_dir_ok) {
+    detail =
+        "and the file exists at that location "
+        "but it is not on the manifest";
+  } else {
+    DRAKE_DEMAND(by_man_ok && !by_dir_ok);
+    detail =
+        "and it is on the manifest"
+        "but the file does not exist at that location";
+  }
+  result.error = fmt::format(
+      "Sought '{}' in runfiles directory '{}' {}; "
+      "perhaps a 'data = []' dependency is missing.",
+      resource_path, singleton.runfiles_dir, detail);
+  return result;
+}
+
+bool IsFile(const std::string& filesystem_path) {
+  struct stat attributes{};
+  int error = stat(filesystem_path.c_str(), &attributes);
+  if (error) { return false; }
+  return S_ISREG(attributes.st_mode);
+}
+
+bool IsDir(const std::string& filesystem_path) {
+  struct stat attributes{};
+  int error = stat(filesystem_path.c_str(), &attributes);
+  if (error) { return false; }
+  return S_ISDIR(attributes.st_mode);
+}
+
+std::string Readlink(const std::string& pathname) {
+  std::string result;
+  result.resize(4096);
+  ssize_t length = ::readlink(pathname.c_str(), &result.front(), result.size());
+  if (length < 0) {
+    throw std::runtime_error(fmt::format(
+        "Could not open {}", pathname));
+  }
+  if (length >= static_cast<ssize_t>(result.size())) {
+    throw std::runtime_error(
+        fmt::format("Could not readlink {} (too long)", pathname));
+  }
+  result.resize(length);
+  return result;
+}
+
+}  // namespace internal
+}  // namespace drake

--- a/common/find_runfiles.h
+++ b/common/find_runfiles.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <string>
+
+namespace drake {
+namespace internal {
+
+/** Returns true iff this process has Bazel runfiles available.  For both C++
+and Python programs, and no matter what workspace a program resides in (`@drake`
+or otherwise), this will be true when running `bazel-bin/pkg/program` or `bazel
+test //pkg:program` or `bazel run //pkg:program`. */
+bool HasRunfiles();
+
+/** The return type of FindRunfile(). Exactly one of the two strings is
+non-empty. */
+struct RlocationOrError {
+  /** The absolute path to the resource_path runfile. */
+  std::string abspath;
+  /** The error message. */
+  std::string error;
+};
+
+/** Returns the absolute path to the given resource_path from Bazel runfiles,
+or else an error message when not found.  When HasRunfiles() is false, returns
+an error. */
+RlocationOrError FindRunfile(const std::string& resource_path);
+
+/** Returns true iff the given path is a file. */
+bool IsFile(const std::string& filesystem_path);
+
+/** Returns true iff the given path is a directory. */
+bool IsDir(const std::string& filesystem_path);
+
+/** A C++ wrapper for C's readlink(2). */
+std::string Readlink(const std::string& pathname);
+
+}  // namespace internal
+}  // namespace drake

--- a/common/test/find_runfiles_fail_test.cc
+++ b/common/test/find_runfiles_fail_test.cc
@@ -1,0 +1,34 @@
+#include <stdlib.h>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/find_runfiles.h"
+#include "drake/common/text_logging.h"
+
+namespace drake {
+namespace internal {
+namespace {
+
+// Test error message codepaths.  We purposefully lobotomize the environment
+// variables before latch-initializing the runfiles singleton.  Because we
+// can't reinitialize it, we can only write a single unit test in this file and
+// we need to keep this case separate from the find_runfiles_test.cc cases.
+GTEST_TEST(FindRunfilesFailTest, ErrorMessageTest) {
+  drake::logging::set_log_level("trace");
+  ASSERT_EQ(::setenv("TEST_SRCDIR", "/no_such_srcdir", 1), 0);
+  ASSERT_EQ(::unsetenv("RUNFILES_DIR"), 0);
+  ASSERT_EQ(::unsetenv("RUNFILES_MANIFEST_FILE"), 0);
+
+  EXPECT_FALSE(HasRunfiles());
+  const auto result = FindRunfile("drake/nothing");
+  EXPECT_EQ(result.abspath, "");
+  EXPECT_THAT(result.error, testing::MatchesRegex(
+      "ERROR: .* cannot find runfiles .*"
+      "created using TEST_SRCDIR with TEST_SRCDIR=/no_such_srcdir "
+      "and RUNFILES_MANIFEST_FILE=nullptr and RUNFILES_DIR=nullptr."));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace drake

--- a/common/test/find_runfiles_subprocess_test.py
+++ b/common/test/find_runfiles_subprocess_test.py
@@ -1,0 +1,59 @@
+import os
+import subprocess
+import unittest
+
+
+class TestFindRunfilesSubprocess(unittest.TestCase):
+
+    def _check_output(self, env=os.environ):
+        try:
+            output = subprocess.check_output([
+                "common/find_runfiles_test", "-spdlog_level=trace",
+                "--gtest_filter=FindRunfilesTest.AcceptanceTest",
+            ], stderr=subprocess.STDOUT, env=env)
+            return output.decode("utf-8")
+        except subprocess.CalledProcessError as e:
+            print(e.output)
+            raise
+
+    def test_basic_child_process(self):
+        # Check that a C++ program that uses FindRunfiles succeeds when called
+        # from a python binary.
+        output = self._check_output()
+        # Check that the C++ program used the resource paths we wanted it to:
+        # - It used the special-case TEST_SRCDIR mechanism.
+        self.assertIn("FindRunfile mechanism = TEST_SRCDIR", output)
+        # - It used find_runfiles_subprocess_test not find_runfiles_test, i.e.,
+        # the runfiles of the parent process were imbued to the subprocess.
+        self.assertIn("find_runfiles_subprocess_test.runfile", output)
+        self.assertNotIn("find_runfiles_test.runfile", output)
+
+    def test_sans_test_srcdir(self):
+        # Repeat test_basic_child_subprocess but with TEST_SRCDIR unset.
+        # from a python binary.
+        new_env = dict(os.environ)
+        del new_env["TEST_SRCDIR"]
+        output = self._check_output(env=new_env)
+        self.assertIn("FindRunfile mechanism = RUNFILES_{MANIFEST", output)
+        self.assertIn("find_runfiles_subprocess_test.runfile", output)
+        self.assertNotIn("find_runfiles_test.runfile", output)
+
+    def test_sans_all_env(self):
+        # Repeat test_basic_child_subprocess but with an empty environment.
+        # This covers the "argv0 mechanism" codepaths.
+        try:
+            output = self._check_output(env={})
+            status = 0
+        except subprocess.CalledProcessError as e:
+            output = e.output
+            status = e.returncode
+        # If the user-facing binary bazel-bin/common/find_runfiles_test happens
+        # to already exist then the subprocess's AcceptanceTest case passes.
+        #
+        # If instead only bazel-out/k8-opt/bin/common/find_runfiles_test exists
+        # (and it will always exist, because it is a data dependency of this
+        # python test), then the the subprocess's AcceptanceTest case fails.
+        #
+        # Either way, should report that its using argv0 and not segfault.
+        self.assertIn("FindRunfile mechanism = argv0", output)
+        self.assertIn(status, (0, 1))

--- a/common/test/find_runfiles_test.cc
+++ b/common/test/find_runfiles_test.cc
@@ -1,0 +1,89 @@
+#include "drake/common/find_runfiles.h"
+
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <fstream>
+#include <string>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/temp_directory.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+namespace drake {
+namespace internal {
+namespace {
+
+GTEST_TEST(FindRunfilesTest, ExistTest) {
+  EXPECT_FALSE(IsFile("."));
+  EXPECT_FALSE(IsFile("common"));
+  EXPECT_TRUE(IsFile("common/find_runfiles_test"));
+  EXPECT_FALSE(IsFile("/no/such/path"));
+
+  EXPECT_TRUE(IsDir("."));
+  EXPECT_TRUE(IsDir("common"));
+  EXPECT_FALSE(IsDir("common/find_runfiles_test"));
+  EXPECT_FALSE(IsDir("/no/such/path"));
+}
+
+GTEST_TEST(FindRunfilesTest, ReadlinkTest) {
+  std::string tmp = temp_directory();
+  std::string rel_file = tmp + "/rel_file";
+  std::string rel_dir = tmp + "/rel_dir";
+  ASSERT_EQ(::symlink("a_file", rel_file.c_str()), 0);
+  ASSERT_EQ(::symlink("a_dir", rel_dir.c_str()), 0);
+  EXPECT_EQ(Readlink(rel_file), "a_file");
+  EXPECT_EQ(Readlink(rel_dir), "a_dir");
+
+  EXPECT_FALSE(IsFile(rel_file));
+  EXPECT_FALSE(IsDir(rel_dir));
+  EXPECT_FALSE(IsFile(rel_dir));
+  EXPECT_FALSE(IsDir(rel_file));
+
+  ASSERT_EQ(::mkdir((tmp + "/a_dir").c_str(), S_IRWXU), 0);
+  std::ofstream(tmp + "/a_file", std::ios::out).close();
+
+  EXPECT_TRUE(IsFile(rel_file));
+  EXPECT_TRUE(IsDir(rel_dir));
+  EXPECT_FALSE(IsFile(rel_dir));
+  EXPECT_FALSE(IsDir(rel_file));
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      Readlink("/no_such_readlink"), std::exception,
+      "Could not open /no_such_readlink");
+}
+
+GTEST_TEST(FindRunfilesTest, AcceptanceTest) {
+  EXPECT_TRUE(HasRunfiles());
+  const auto result = FindRunfile(
+      "drake/common/test/find_resource_test_data.txt");
+  EXPECT_GT(result.abspath.size(), 0);
+  EXPECT_TRUE(IsFile(result.abspath));
+  EXPECT_EQ(result.error, "");
+}
+
+GTEST_TEST(FindRunfilesTest, NotDeclaredTest) {
+  const auto result = FindRunfile("foo");
+  EXPECT_THAT(result.error, testing::MatchesRegex(
+      "Sought 'foo' in runfiles directory '.*' but "
+      "the file does not exist at that location nor is it on the "
+      "manifest; perhaps a 'data = ..' dependency is missing."));
+};
+
+GTEST_TEST(FindRunfilesTest, AbsolutePathTest) {
+  const auto result = FindRunfile("/dev/null");
+  EXPECT_THAT(result.error, testing::MatchesRegex(
+      ".*must not be an absolute path.*"));
+};
+
+GTEST_TEST(FindRunfilesTest, EmptyPathTest) {
+  const auto result = FindRunfile("");
+  EXPECT_THAT(result.error, testing::MatchesRegex(
+      ".*must not be empty.*"));
+};
+
+}  // namespace
+}  // namespace internal
+}  // namespace drake


### PR DESCRIPTION
This adds a for-now-internal utility to robustly lookup bazel runfiles, with nice error messages and tracing.

This feature is used by #11261.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11262)
<!-- Reviewable:end -->
