### PR TITLE
py mbp: Bind minimal but relevant spatial force API

### DIFF
--- a/bindings/pydrake/multibody/math_py.cc
+++ b/bindings/pydrake/multibody/math_py.cc
@@ -4,6 +4,7 @@
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/multibody/math/spatial_acceleration.h"
+#include "drake/multibody/math/spatial_force.h"
 #include "drake/multibody/math/spatial_velocity.h"
 
 namespace drake {
@@ -29,7 +30,11 @@ void BindSpatialVectorMixin(PyClass* pcls) {
             return self->translational();
           },
           py_reference_internal,
-          doc.SpatialVector.translational.doc_0args_const);
+          doc.SpatialVector.translational.doc_0args_const)
+      .def("SetZero", &Class::SetZero, doc.SpatialVector.SetZero.doc)
+      .def("get_coeffs", [](const Class& self) { return self.get_coeffs(); },
+          doc.SpatialVector.get_coeffs.doc_0args_const)
+      .def_static("Zero", &Class::Zero, doc.SpatialVector.Zero.doc);
 }
 
 PYBIND11_MODULE(math, m) {
@@ -48,7 +53,9 @@ PYBIND11_MODULE(math, m) {
         .def(py::init(), cls_doc.ctor.doc_0args)
         .def(py::init<const Eigen::Ref<const Vector3<T>>&,
                  const Eigen::Ref<const Vector3<T>>&>(),
-            py::arg("w"), py::arg("v"), cls_doc.ctor.doc_2args);
+            py::arg("w"), py::arg("v"), cls_doc.ctor.doc_2args)
+        .def(py::init<const Vector6<T>&>(), py::arg("V"),
+            cls_doc.ctor.doc_1args);
   }
   {
     using Class = SpatialAcceleration<T>;
@@ -59,7 +66,22 @@ PYBIND11_MODULE(math, m) {
         .def(py::init(), cls_doc.ctor.doc_0args)
         .def(py::init<const Eigen::Ref<const Vector3<T>>&,
                  const Eigen::Ref<const Vector3<T>>&>(),
-            py::arg("alpha"), py::arg("a"), cls_doc.ctor.doc_2args);
+            py::arg("alpha"), py::arg("a"), cls_doc.ctor.doc_2args)
+        .def(py::init<const Vector6<T>&>(), py::arg("A"),
+            cls_doc.ctor.doc_1args);
+  }
+  {
+    using Class = multibody::SpatialForce<T>;
+    constexpr auto& cls_doc = doc.SpatialForce;
+    py::class_<Class> cls(m, "SpatialForce", cls_doc.doc);
+    BindSpatialVectorMixin(&cls);
+    cls  // BR
+        .def(py::init(), cls_doc.ctor.doc_0args)
+        .def(py::init<const Eigen::Ref<const Vector3<T>>&,
+                 const Eigen::Ref<const Vector3<T>>&>(),
+            py::arg("tau"), py::arg("f"), cls_doc.ctor.doc_2args)
+        .def(py::init<const Vector6<T>&>(), py::arg("F"),
+            cls_doc.ctor.doc_1args);
   }
 }
 

--- a/bindings/pydrake/multibody/test/math_test.py
+++ b/bindings/pydrake/multibody/test/math_test.py
@@ -4,12 +4,14 @@ import numpy as np
 
 from pydrake.multibody.math import (
     SpatialAcceleration,
+    SpatialForce,
     SpatialVelocity,
 )
 
 
 class TestMultibodyTreeMath(unittest.TestCase):
-    def check_spatial_vector(self, cls, rotation_name, translation_name):
+    def check_spatial_vector(
+            self, cls, coeffs_name, rotation_name, translation_name):
         vec = cls()
         # - Accessors.
         self.assertTrue(isinstance(vec.rotational(), np.ndarray))
@@ -19,15 +21,24 @@ class TestMultibodyTreeMath(unittest.TestCase):
         # - Fully-parameterized constructor.
         rotation_expected = [0.1, 0.3, 0.5]
         translation_expected = [0., 1., 2.]
-        kwargs = {
+        vec_args = {
             rotation_name: rotation_expected,
             translation_name: translation_expected,
         }
-        vec1 = cls(**kwargs)
+        vec1 = cls(**vec_args)
         self.assertTrue(np.allclose(vec1.rotational(), rotation_expected))
         self.assertTrue(
             np.allclose(vec1.translational(), translation_expected))
+        vec_zero = cls()
+        vec_zero.SetZero()
+        self.assertTrue(
+            np.allclose(cls.Zero().get_coeffs(), vec_zero.get_coeffs()))
+        coeffs_expected = np.hstack((rotation_expected, translation_expected))
+        coeffs_args = {coeffs_name: coeffs_expected}
+        self.assertTrue(
+            np.allclose(cls(**coeffs_args).get_coeffs(), coeffs_expected))
 
     def test_spatial_vector_types(self):
-        self.check_spatial_vector(SpatialVelocity, 'w', 'v')
-        self.check_spatial_vector(SpatialAcceleration, 'alpha', 'a')
+        self.check_spatial_vector(SpatialVelocity, "V", "w", "v")
+        self.check_spatial_vector(SpatialAcceleration, "A", "alpha", "a")
+        self.check_spatial_vector(SpatialForce, "F", "tau", "f")

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -127,7 +127,14 @@ PYBIND11_MODULE(tree, m) {
     cls  // BR
         .def("name", &Class::name, cls_doc.name.doc)
         .def("body_frame", &Class::body_frame, py_reference_internal,
-            cls_doc.body_frame.doc);
+            cls_doc.body_frame.doc)
+        .def("GetForceInWorld", &Class::GetForceInWorld, py::arg("context"),
+            py::arg("forces"), cls_doc.GetForceInWorld.doc)
+        .def("AddInForceInWorld", &Class::AddInForceInWorld, py::arg("context"),
+            py::arg("F_Bo_W"), py::arg("forces"), cls_doc.AddInForceInWorld.doc)
+        .def("AddInForce", &Class::AddInForce, py::arg("context"),
+            py::arg("p_BP_E"), py::arg("F_Bp_E"), py::arg("frame_E"),
+            py::arg("forces"), cls_doc.AddInForce.doc);
   }
 
   {
@@ -273,10 +280,20 @@ PYBIND11_MODULE(tree, m) {
     // N.B. This depends on `plant_py.cc`, but this codepath will only be
     // activated if this module is present, and thus should not create a runtime
     // error.
-    cls.def(py::init([](const MultibodyPlant<T>& plant) {
-      return std::make_unique<MultibodyForces<T>>(plant);
-    }),
-        py::arg("plant"), cls_doc.ctor.doc_1args_plant);
+    cls  // BR
+        .def(py::init([](const MultibodyPlant<T>& plant) {
+          return std::make_unique<Class>(plant);
+        }),
+            py::arg("plant"), cls_doc.ctor.doc_1args_plant)
+        .def("SetZero", &Class::SetZero, cls_doc.SetZero.doc)
+        .def("generalized_forces", &Class::generalized_forces,
+            cls_doc.generalized_forces.doc)
+        .def("mutable_generalized_forces", &Class::mutable_generalized_forces,
+            py_reference_internal, cls_doc.mutable_generalized_forces.doc)
+        // WARNING: Do not bind `body_forces` or `mutable_body_forces` because
+        // they use `internal::BodyNodeIndex`. Instead, use force API in Body.
+        .def("AddInForces", &Class::AddInForces, py::arg("addend"),
+            cls_doc.AddInForces.doc);
   }
 
   {

--- a/multibody/math/spatial_force.h
+++ b/multibody/math/spatial_force.h
@@ -60,11 +60,11 @@ class SpatialForce : public SpatialVector<SpatialForce, T> {
 
   /// SpatialForce constructor from an Eigen expression that represents a
   /// six-dimensional vector.
-  /// This constructor will assert the size of V is six (6) at compile-time
+  /// This constructor will assert the size of F is six (6) at compile-time
   /// for fixed sized Eigen expressions and at run-time for dynamic sized Eigen
   /// expressions.
   template <typename Derived>
-  explicit SpatialForce(const Eigen::MatrixBase<Derived>& V) : Base(V) {}
+  explicit SpatialForce(const Eigen::MatrixBase<Derived>& F) : Base(F) {}
 
   /// In-place shift of a %SpatialForce from one application point to another.
   /// `this` spatial force `F_Bp_E`, which applies its translational force

--- a/multibody/plant/test/external_forces_test.cc
+++ b/multibody/plant/test/external_forces_test.cc
@@ -21,7 +21,6 @@ namespace {
 
 TEST_F(KukaIiwaModelTests, ExternalBodyForces) {
   SetArbitraryConfiguration();
-  context_->EnableCaching();
 
   // An arbitrary point on the end effector frame E.
   Vector3<double> p_EP(0.1, -0.05, 0.3);
@@ -75,6 +74,25 @@ TEST_F(KukaIiwaModelTests, ExternalBodyForces) {
   EXPECT_TRUE(CompareMatrices(
       tau_id, tau_id_expected,
       kTolerance, MatrixCompareType::relative));
+}
+
+TEST_F(KukaIiwaModelTests, BodyForceApi) {
+  SetArbitraryConfiguration();
+  MultibodyForces<double> forces(*plant_);
+  Vector6<double> F_expected;
+  F_expected << 1, 2, 3, 4, 5, 6;
+  SpatialForce<double> F_Bo_W(F_expected);
+  end_effector_link_->AddInForceInWorld(*context_, F_Bo_W, &forces);
+  EXPECT_TRUE(CompareMatrices(
+      end_effector_link_->GetForceInWorld(*context_, forces).get_coeffs(),
+      F_expected));
+  // Test frame-specfic, and ensure we accumulate.
+  end_effector_link_->AddInForce(
+      *context_, Vector3<double>::Zero(), F_Bo_W, plant_->world_frame(),
+      &forces);
+  EXPECT_TRUE(CompareMatrices(
+      end_effector_link_->GetForceInWorld(*context_, forces).get_coeffs(),
+      2 * F_expected));
 }
 
 }  // namespace

--- a/multibody/tree/body.h
+++ b/multibody/tree/body.h
@@ -231,15 +231,24 @@ class Body : public MultibodyTreeElement<Body<T>, BodyIndex> {
         context, *this);
   }
 
+  /// Gets the sptatial force on `this` body B from `forces` as F_BBo_W:
+  /// applied at body B's origin Bo and expressed in world world frame W.
+  const SpatialForce<T>& GetForceInWorld(
+      const systems::Context<T>&, const MultibodyForces<T>& forces) const {
+    DRAKE_THROW_UNLESS(
+        forces.CheckHasRightSizeForModel(this->get_parent_tree()));
+    return forces.body_forces()[node_index()];
+  }
+
   /// Adds the spatial force on `this` body B, applied at body B's origin Bo and
   /// expressed in the world frame W into `forces`.
-  void AddInForceInWorld(const systems::Context<T>& context,
+  void AddInForceInWorld(const systems::Context<T>&,
                          const SpatialForce<T>& F_Bo_W,
                          MultibodyForces<T>* forces) const {
     DRAKE_THROW_UNLESS(forces != nullptr);
     DRAKE_THROW_UNLESS(
         forces->CheckHasRightSizeForModel(this->get_parent_tree()));
-    forces->mutable_body_forces()[node_index()] = F_Bo_W;
+    forces->mutable_body_forces()[node_index()] += F_Bo_W;
   }
 
   /// Adds the spatial force on `this` body B, applied at point P and


### PR DESCRIPTION
For @TobiaMarcucci: https://drakedevelopers.slack.com/archives/C2CK4CWE7/p1555511460002500?thread_ts=1555024805.009600&cid=C2CK4CWE7

May file follow-up issue to strip `BodyNodeIndex` junk out of `MultibodyForces`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11265)
<!-- Reviewable:end -->
