### PR TITLE
Applies PIMPL pattern to ManualPhaseProvider

### DIFF
--- a/automotive/maliput/base/manual_phase_provider.cc
+++ b/automotive/maliput/base/manual_phase_provider.cc
@@ -1,6 +1,8 @@
 #include "drake/automotive/maliput/base/manual_phase_provider.h"
 
+#include <stdexcept>
 #include <string>
+#include <unordered_map>
 
 #include "drake/common/drake_throw.h"
 
@@ -9,31 +11,61 @@ namespace maliput {
 
 using api::rules::PhaseProvider;
 
+class ManualPhaseProvider::Impl {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Impl)
+
+  Impl() {}
+  ~Impl() {}
+
+  void AddPhaseRing(const api::rules::PhaseRing::Id& id,
+                    const api::rules::Phase::Id& initial_phase) {
+    auto result = phases_.emplace(id, initial_phase);
+    if (!result.second) {
+      throw std::logic_error("Attempted to add multiple phase rings with id " +
+                             id.string());
+    }
+  }
+
+  void SetPhase(const api::rules::PhaseRing::Id& id,
+                const api::rules::Phase::Id& phase) {
+    phases_.at(id) = phase;
+  }
+
+  optional<PhaseProvider::Result> DoGetPhase(
+      const api::rules::PhaseRing::Id& id) const {
+    auto it = phases_.find(id);
+    if (it == phases_.end()) {
+      return nullopt;
+    }
+    // TODO(liang.fok) Add support for "next phase" and "duration until", #9993.
+    return PhaseProvider::Result{it->second, nullopt};
+  }
+
+ private:
+  std::unordered_map<maliput::api::rules::PhaseRing::Id,
+                     maliput::api::rules::Phase::Id>
+      phases_;
+};
+
+ManualPhaseProvider::ManualPhaseProvider() : impl_(std::make_unique<Impl>()) {}
+
+ManualPhaseProvider::~ManualPhaseProvider() = default;
+
 void ManualPhaseProvider::AddPhaseRing(
     const api::rules::PhaseRing::Id& id,
     const api::rules::Phase::Id& initial_phase) {
-  auto result = phases_.emplace(id, initial_phase);
-  if (!result.second) {
-     throw std::logic_error(
-        "Attempted to add multiple phase rings with id " + id.string());
-  }
+  impl_->AddPhaseRing(id, initial_phase);
 }
 
-
-void ManualPhaseProvider::SetPhase(
-    const api::rules::PhaseRing::Id& id,
-    const api::rules::Phase::Id& phase) {
-  phases_.at(id) = phase;
+void ManualPhaseProvider::SetPhase(const api::rules::PhaseRing::Id& id,
+                                   const api::rules::Phase::Id& phase) {
+  impl_->SetPhase(id, phase);
 }
 
 optional<PhaseProvider::Result> ManualPhaseProvider::DoGetPhase(
     const api::rules::PhaseRing::Id& id) const {
-  auto it = phases_.find(id);
-  if (it == phases_.end()) {
-    return nullopt;
-  }
-  // TODO(liang.fok) Add support for "next phase" and "duration until", #9993.
-  return Result{it->second, nullopt};
+  return impl_->DoGetPhase(id);
 }
 
 }  // namespace maliput

--- a/automotive/maliput/base/manual_phase_provider.h
+++ b/automotive/maliput/base/manual_phase_provider.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <unordered_map>
+#include <memory>
 
 #include "drake/automotive/maliput/api/rules/phase.h"
 #include "drake/automotive/maliput/api/rules/phase_provider.h"
@@ -17,9 +17,9 @@ class ManualPhaseProvider : public api::rules::PhaseProvider {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ManualPhaseProvider);
 
-  ManualPhaseProvider() {}
+  ManualPhaseProvider();
 
-  ~ManualPhaseProvider() override = default;
+  ~ManualPhaseProvider() override;
 
   /// Adds a phase ring to this provider.
   ///
@@ -39,8 +39,8 @@ class ManualPhaseProvider : public api::rules::PhaseProvider {
   optional<api::rules::PhaseProvider::Result> DoGetPhase(
       const api::rules::PhaseRing::Id& id) const override;
 
-  std::unordered_map<maliput::api::rules::PhaseRing::Id,
-                     maliput::api::rules::Phase::Id> phases_;
+  class Impl;
+  std::unique_ptr<Impl> impl_;
 };
 
 }  // namespace maliput


### PR DESCRIPTION
This is to be consistent with other Maliput providers and to make way
for next phase information.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11273)
<!-- Reviewable:end -->
