### PR TITLE
find_runfiles_test: Handle python3 str vs bytes

### DIFF
--- a/common/test/find_runfiles_subprocess_test.py
+++ b/common/test/find_runfiles_subprocess_test.py
@@ -13,6 +13,7 @@ class TestFindRunfilesSubprocess(unittest.TestCase):
             ], stderr=subprocess.STDOUT, env=env)
             return output.decode("utf-8")
         except subprocess.CalledProcessError as e:
+            e.output = e.output.decode("utf-8")
             print(e.output)
             raise
 


### PR DESCRIPTION
The test case has two control flow paths, and which one is selected is non-deterministic based on how far bazel build has progressed before the test begins running.

To repro the failure on master locally:
```console
$ bazel clean && bazel test --config python3 //common:py/find_runfiles_subprocess_test --nocache_test_results
```
It will not repro if `bazel test //common:find_resource_test` has already passed.

Closes #11276.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11278)
<!-- Reviewable:end -->
