### PR TITLE
systems/lcm: Deprecate lcm_driven_loop

### DIFF
--- a/bindings/pydrake/systems/test/lcm_test.py
+++ b/bindings/pydrake/systems/test/lcm_test.py
@@ -177,7 +177,8 @@ class TestSystemsLcm(unittest.TestCase):
     def test_utime_to_seconds(self):
         msg = header_t()
         msg.utime = int(1e6)
-        dut = mut.PyUtimeMessageToSeconds(header_t)
+        with catch_drake_warnings(expected_count=1):
+            dut = mut.PyUtimeMessageToSeconds(header_t)
         t_sec = dut.GetTimeInSeconds(AbstractValue.Make(msg))
         self.assertEqual(t_sec, 1)
 
@@ -216,7 +217,8 @@ class TestSystemsLcm(unittest.TestCase):
 
         # Construct diagram for LcmDrivenLoop.
         lcm = DrakeLcm(lcm_url)
-        utime = mut.PyUtimeMessageToSeconds(header_t)
+        with catch_drake_warnings(expected_count=1):
+            utime = mut.PyUtimeMessageToSeconds(header_t)
         sub = mut.LcmSubscriberSystem.Make("TEST_LOOP", header_t, lcm)
         builder = DiagramBuilder()
         builder.AddSystem(sub)
@@ -225,7 +227,8 @@ class TestSystemsLcm(unittest.TestCase):
         logger = LogOutput(dummy.get_output_port(0), builder)
         logger.set_forced_publish_only()
         diagram = builder.Build()
-        dut = mut.LcmDrivenLoop(diagram, sub, None, lcm, utime)
+        with catch_drake_warnings(expected_count=1):
+            dut = mut.LcmDrivenLoop(diagram, sub, None, lcm, utime)
         dut.set_publish_on_every_received_message(True)
 
         # N.B. Use `multiprocessing` instead of `threading` so that we may

--- a/examples/humanoid_controller/BUILD.bazel
+++ b/examples/humanoid_controller/BUILD.bazel
@@ -135,6 +135,7 @@ drake_cc_binary(
     srcs = [
         "valkyrie_balancing_demo.cc",
     ],
+    copts = ["-Wno-deprecated-declarations"],
     data = [
         ":config/valkyrie.alias_groups",
         ":config/valkyrie.id_controller_config",

--- a/examples/kinova_jaco_arm/BUILD.bazel
+++ b/examples/kinova_jaco_arm/BUILD.bazel
@@ -39,6 +39,10 @@ drake_cc_library(
 drake_cc_binary(
     name = "jaco_controller",
     srcs = ["jaco_controller.cc"],
+    copts = [
+        # TODO(sammy-tri) Remove this once ported away from lcm_driven_loop.
+        "-Wno-deprecated-declarations",
+    ],
     data = [
         "//manipulation/models/jaco_description:models",
     ],

--- a/systems/lcm/BUILD.bazel
+++ b/systems/lcm/BUILD.bazel
@@ -168,6 +168,11 @@ drake_cc_library(
 
 drake_cc_googletest(
     name = "lcm_driven_loop_test",
+    copts = [
+        # The entire class under test is deprecated; when the class is removed,
+        # remove this entire unit test as well.
+        "-Wno-deprecated-declarations",
+    ],
     # TODO(jamiesnape, siyuanfeng-tri): Remove flaky flag, see #5936.
     flaky = 1,
     tags = [

--- a/systems/lcm/lcm_driven_loop.cc
+++ b/systems/lcm/lcm_driven_loop.cc
@@ -4,6 +4,8 @@ namespace drake {
 namespace systems {
 namespace lcm {
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 LcmDrivenLoop::LcmDrivenLoop(
     const System<double>& system, const LcmSubscriberSystem& driving_subscriber,
     std::unique_ptr<Context<double>> context, drake::lcm::DrakeLcm* lcm,
@@ -31,11 +33,9 @@ LcmDrivenLoop::LcmDrivenLoop(
   stepper_->Initialize();
 
   // Starts the subscribing thread.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   lcm_->StartReceiveThread();
-#pragma GCC diagnostic pop
 }
+#pragma GCC diagnostic push
 
 const AbstractValue& LcmDrivenLoop::WaitForMessage() {
   driving_sub_.WaitForMessage(driving_sub_.GetMessageCount(*sub_context_));

--- a/systems/lcm/lcm_driven_loop.h
+++ b/systems/lcm/lcm_driven_loop.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <utility>
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/lcm/drake_lcm.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/lcm/lcm_subscriber_system.h"
@@ -16,9 +17,16 @@ namespace lcm {
  * A generic translator interface that extracts time in seconds from an
  * abstract type.
  */
-class LcmMessageToTimeInterface {
+class DRAKE_DEPRECATED("2019-08-01",
+    "LcmDrivenLoop is deprecated with no direct replacement; "
+    "see https://github.com/RobotLocomotion/drake/pull/11281 for suggestions.")
+LcmMessageToTimeInterface {
  public:
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LcmMessageToTimeInterface)
+#pragma GCC diagnostic pop
+
   virtual ~LcmMessageToTimeInterface() {}
 
   virtual double GetTimeInSeconds(
@@ -33,9 +41,16 @@ class LcmMessageToTimeInterface {
  * is in micro seconds.
  */
 template <typename MessageType>
-class UtimeMessageToSeconds : public LcmMessageToTimeInterface {
+class DRAKE_DEPRECATED("2019-08-01",
+    "LcmDrivenLoop is deprecated with no direct replacement; "
+    "see https://github.com/RobotLocomotion/drake/pull/11281 for suggestions.")
+UtimeMessageToSeconds : public LcmMessageToTimeInterface {
  public:
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(UtimeMessageToSeconds)
+#pragma GCC diagnostic pop
+
   UtimeMessageToSeconds() {}
   ~UtimeMessageToSeconds() {}
 
@@ -101,8 +116,13 @@ class UtimeMessageToSeconds : public LcmMessageToTimeInterface {
  * 3. The computation for the given system should be faster than the incoming
  *    message rate.
  */
-class LcmDrivenLoop {
+class DRAKE_DEPRECATED("2019-08-01",
+    "LcmDrivenLoop is deprecated with no direct replacement; "
+    "see https://github.com/RobotLocomotion/drake/pull/11281 for suggestions.")
+LcmDrivenLoop {
  public:
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LcmDrivenLoop)
 
   /**
@@ -122,11 +142,15 @@ class LcmDrivenLoop {
    * time stamp field that has consistent units. So extracting the time stamp
    * depends on the concrete message content.
    */
+  DRAKE_DEPRECATED("2019-08-01",
+    "LcmDrivenLoop is deprecated with no direct replacement; "
+    "see https://github.com/RobotLocomotion/drake/pull/11281 for suggestions.")
   LcmDrivenLoop(const System<double>& system,
                 const LcmSubscriberSystem& driving_subscriber,
                 std::unique_ptr<Context<double>> context,
                 drake::lcm::DrakeLcm* lcm,
                 std::unique_ptr<LcmMessageToTimeInterface> time_converter);
+#pragma GCC diagnostic pop
 
   /**
    * Blocks the caller until a driving Lcm message is received, then returns
@@ -165,12 +189,15 @@ class LcmDrivenLoop {
     return stepper_->get_mutable_context();
   }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   /**
    * Returns a const reference to the message to seconds converter.
    */
   const LcmMessageToTimeInterface& get_message_to_time_converter() const {
     return *time_converter_;
   }
+#pragma GCC diagnostic pop
 
  private:
   // The handler system.
@@ -182,8 +209,11 @@ class LcmDrivenLoop {
   // The lcm interface for publishing and subscribing.
   drake::lcm::DrakeLcm* lcm_;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   // Extracts time in seconds from received lcm messages.
   std::unique_ptr<LcmMessageToTimeInterface> time_converter_;
+#pragma GCC diagnostic pop
 
   // If true, explicitly calls system_.Publish() after every step in the loop.
   bool publish_on_every_received_message_{true};


### PR DESCRIPTION
Closes #5936.  Closes #10714.

---

**If you are a Drake user and would like to adjust your code to the new APIs, please read on for details.**

Drake has deprecated (and will eventually remove) the LcmDrivenLoop class, which organized the execution and message flow of an LCM-triggered control loop.

LcmDrivenLoop presents challenging problems with threading, mutexes, and condition variables because it assumes the LCM service in handled by a separate thread (no longer true as of #11166), and it is insufficiently general in the first place (#10714).

For a fully-worked example of adapting to this change, see PR #11274 where the `iiwa_controller` was ported to no longer use LcmDrivenLoop.

The new pattern should go like this:
1. Wait for the initial condition to obtain, e.g., wait for one or more types of messages.
2. Adjust the Diagram's initial Context as necessary.
3. In a loop:
  a. Wait for the "ready to advance" condition to obtain.
  b. Adjust the Diagram's current Context as necessary.
  c. Advance time as governed by received message(s).
  d. Transmit any outputs, e.g., by force-publishing an LcmPublisherSystem.

To implement the "wait for" steps (1) and (3a) while blocking on the LCM receiver, see `LcmHandleSubscriptionsUntil`.  (See [L118](https://github.com/RobotLocomotion/drake/pull/11274/commits/0ba2af165812e7d4b98593b480bdd6df42788724#diff-36526bc09f8876565e0ba1fad26165c4R118) and [L138](https://github.com/RobotLocomotion/drake/pull/11274/commits/0ba2af165812e7d4b98593b480bdd6df42788724#diff-36526bc09f8876565e0ba1fad26165c4R138) for an example.)  You supply your own custom "ready" predicate.  It could be as simple as a single message's receipt counter, or span multiple messages, or have extra conditions such as velocity==0 in the messages.

To implement the "adjust the Context" steps (2) and (3b) based on received messages, it is often more convenient to use the `InputPort.FixValue(&context)` method, instead of an `LcmSubscriberSystem`.  (See [L129](https://github.com/RobotLocomotion/drake/pull/11274/commits/0ba2af165812e7d4b98593b480bdd6df42788724#diff-36526bc09f8876565e0ba1fad26165c4R129) and [L141](https://github.com/RobotLocomotion/drake/pull/11274/commits/0ba2af165812e7d4b98593b480bdd6df42788724#diff-36526bc09f8876565e0ba1fad26165c4R141) for an example).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11281)
<!-- Reviewable:end -->
