### PR TITLE
pydrake geometry: Add bindings for ComputeSignedDistanceToPoint

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -74,6 +74,14 @@ PYBIND11_MODULE(geometry, m) {
               &SceneGraph<T>::RegisterSource),
           py::arg("name") = "", doc.SceneGraph.RegisterSource.doc);
 
+  py::class_<FramePoseVector<T>>(
+      m, "FramePoseVector", doc.FrameKinematicsVector.doc)
+      .def(py::init<>(), doc.FrameKinematicsVector.ctor.doc_0args)
+      .def(py::init<SourceId, const std::vector<FrameId>&>(),
+          py::arg("source_id"), py::arg("ids"),
+          doc.FrameKinematicsVector.ctor.doc_2args);
+  pysystems::AddValueInstantiation<FramePoseVector<T>>(m);
+
   py::class_<QueryObject<T>>(m, "QueryObject", doc.QueryObject.doc)
       .def("inspector", &QueryObject<T>::inspector, py_reference_internal,
           doc.QueryObject.inspector.doc)
@@ -82,7 +90,11 @@ PYBIND11_MODULE(geometry, m) {
           doc.QueryObject.ComputeSignedDistancePairwiseClosestPoints.doc)
       .def("ComputePointPairPenetration",
           &QueryObject<T>::ComputePointPairPenetration,
-          doc.QueryObject.ComputePointPairPenetration.doc);
+          doc.QueryObject.ComputePointPairPenetration.doc)
+      .def("ComputeSignedDistanceToPoint",
+          &QueryObject<T>::ComputeSignedDistanceToPoint, py::arg("p_WQ"),
+          py::arg("threshold") = std::numeric_limits<double>::infinity(),
+          doc.QueryObject.ComputeSignedDistanceToPoint.doc);
   pysystems::AddValueInstantiation<QueryObject<T>>(m);
 
   py::module::import("pydrake.systems.lcm");
@@ -123,6 +135,18 @@ PYBIND11_MODULE(geometry, m) {
           doc.SignedDistancePair.distance.doc)
       .def_readwrite("nhat_BA_W", &SignedDistancePair<T>::nhat_BA_W,
           doc.SignedDistancePair.nhat_BA_W.doc);
+
+  // SignedDistanceToPoint
+  py::class_<SignedDistanceToPoint<T>>(m, "SignedDistanceToPoint")
+      .def(py::init<>(), doc.SignedDistanceToPoint.ctor.doc)
+      .def_readwrite("id_G", &SignedDistanceToPoint<T>::id_G,
+          doc.SignedDistanceToPoint.id_G.doc)
+      .def_readwrite("p_GN", &SignedDistanceToPoint<T>::p_GN,
+          doc.SignedDistanceToPoint.p_GN.doc)
+      .def_readwrite("distance", &SignedDistanceToPoint<T>::distance,
+          doc.SignedDistanceToPoint.distance.doc)
+      .def_readwrite("grad_W", &SignedDistanceToPoint<T>::grad_W,
+          doc.SignedDistanceToPoint.grad_W.doc);
 
   // PenetrationAsPointPair
   py::class_<PenetrationAsPointPair<T>>(m, "PenetrationAsPointPair")

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -44,6 +44,7 @@ from pydrake.geometry import (
     GeometryId,
     PenetrationAsPointPair,
     SignedDistancePair,
+    SignedDistanceToPoint,
     SceneGraph,
 )
 from pydrake.systems.framework import AbstractValue, DiagramBuilder
@@ -863,6 +864,13 @@ class TestPlant(unittest.TestCase):
         signed_distance_pair, = query_object.\
             ComputeSignedDistancePairwiseClosestPoints()
         self.assertIsInstance(signed_distance_pair, SignedDistancePair)
+        signed_distance_to_point = query_object.\
+            ComputeSignedDistanceToPoint(p_WQ=np.ones(3))
+        self.assertEqual(len(signed_distance_to_point), 2)
+        self.assertIsInstance(signed_distance_to_point[0],
+                              SignedDistanceToPoint)
+        self.assertIsInstance(signed_distance_to_point[1],
+                              SignedDistanceToPoint)
         inspector = query_object.inspector()
 
         def get_body_from_frame_id(frame_id):

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -39,6 +39,11 @@ class TestGeometry(unittest.TestCase):
             mut.DispatchLoadMessage(
                 scene_graph=scene_graph, lcm=lcm)
 
+    def test_frame_pose_vector_api(self):
+        mut.FramePoseVector()
+        mut.FramePoseVector(source_id=mut.SourceId.get_new_id(),
+                            ids=[mut.FrameId.get_new_id()])
+
     def test_query_object_api(self):
         # TODO(eric.cousineau): Create self-contained unittests (#9899).
         # Pending that, the relevant API is exercised via
@@ -78,6 +83,14 @@ class TestGeometry(unittest.TestCase):
         self.assertTupleEqual(obj.p_ACa.shape, (3,))
         self.assertTupleEqual(obj.p_BCb.shape, (3,))
         self.assertIsInstance(obj.distance, float)
+        self.assertTupleEqual(obj.nhat_BA_W.shape, (3,))
+
+    def test_signed_distance_to_point_api(self):
+        obj = mut.SignedDistanceToPoint()
+        self.assertIsInstance(obj.id_G, mut.GeometryId)
+        self.assertTupleEqual(obj.p_GN.shape, (3,))
+        self.assertIsInstance(obj.distance, float)
+        self.assertTupleEqual(obj.grad_W.shape, (3,))
 
     def test_shape_constructors(self):
         box_mesh_path = FindResourceOrThrow(


### PR DESCRIPTION
Also adds bindings for FramePoseVector.

@EricCousineau-TRI for feature review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11292)
<!-- Reviewable:end -->
