### PR TITLE
multibody: Use Calc prereqs, not DoHasDirectFeedthrough

### DIFF
--- a/attic/multibody/rigid_body_plant/rigid_body_plant.h
+++ b/attic/multibody/rigid_body_plant/rigid_body_plant.h
@@ -427,8 +427,6 @@ class RigidBodyPlant : public LeafSystem<T> {
     DoCalcDiscreteVariableUpdatesImpl(context, events, updates);
   }
 
-  optional<bool> DoHasDirectFeedthrough(int, int) const override;
-
   // TODO(amcastro-tri): provide proper implementations for these methods to
   // track energy conservation.
   // TODO(amcastro-tri): provide a method to track applied actuator power.

--- a/attic/multibody/rigid_body_plant/rigid_body_plant_bridge.h
+++ b/attic/multibody/rigid_body_plant/rigid_body_plant_bridge.h
@@ -125,11 +125,6 @@ class RigidBodyPlantBridge : public systems::LeafSystem<T> {
   // geometry system.
   void RegisterTree(geometry::SceneGraph<T>* scene_graph);
 
-  // This is nothing _but_ direct-feedthrough.
-  optional<bool> DoHasDirectFeedthrough(int, int) const override {
-    return true;
-  }
-
   // Calculate the frame pose set output port value.
   void CalcFramePoseOutput(const MyContext& context,
                            geometry::FramePoseVector<T>* poses) const;

--- a/attic/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
+++ b/attic/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
@@ -53,6 +53,8 @@ GTEST_TEST(RigidBodyPlantTest, TestLoadUrdf) {
   EXPECT_EQ(plant.get_input_size(), 0);
   EXPECT_EQ(plant.get_output_size(), 0);
 
+  EXPECT_FALSE(plant.HasAnyDirectFeedthrough());
+
   // Obtains a const reference to the underlying RigidBodyTree within the
   // RigidBodyPlant.
   const RigidBodyTree<double>& tree = plant.get_rigid_body_tree();
@@ -116,6 +118,8 @@ GTEST_TEST(RigidBodyPlantTest, MapVelocityToConfigurationDerivativesAndBack) {
   EXPECT_EQ(plant.get_num_velocities(), kNumVelocities);
   EXPECT_EQ(plant.get_input_size(), 0);  // There are no actuators.
   EXPECT_EQ(plant.get_output_size(), kNumStates);
+
+  EXPECT_FALSE(plant.HasAnyDirectFeedthrough());
 
   const Vector3d v0(1, 2, 3);    // Linear velocity in body's frame.
   const Vector3d w0(-4, 5, -6);  // Angular velocity in body's frame.
@@ -532,6 +536,8 @@ GTEST_TEST(RigidBodyPlantTest, InstancePortTest) {
   EXPECT_EQ(plant.get_num_positions(1), 4);
   EXPECT_EQ(plant.get_num_velocities(1), 4);
   EXPECT_EQ(plant.get_num_states(1), 8);
+
+  EXPECT_TRUE(plant.HasAnyDirectFeedthrough());
 
   // TODO(liang.fok) The following has a bug, see #4697.
   const RigidBodyTree<double>& tree = plant.get_rigid_body_tree();

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3193,12 +3193,6 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // TODO(SeanCurtis-TRI): Remove this when geometry roles are introduced.
   void ExcludeCollisionsWithVisualGeometry();
 
-  // No inputs implies no feedthrough; this makes it explicit.
-  // TODO(amcastro-tri): add input ports for actuators.
-  optional<bool> DoHasDirectFeedthrough(int, int) const override {
-    return false;
-  }
-
   // Helper method to declare state, cache entries, and ports after Finalize().
   void DeclareStateCacheAndPorts();
 
@@ -3330,8 +3324,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // Calc method to output per model instance vector of generalized contact
   // forces.
   void CopyGeneralizedContactForcesOut(
-      ModelInstanceIndex model_instance, const systems::Context<T>& context,
-      systems::BasicVector<T>* tau_vector) const;
+      const internal::ImplicitStribeckSolverResults<T>&,
+      ModelInstanceIndex, systems::BasicVector<T>* tau_vector) const;
 
   // Helper method to declare output ports used by this plant to communicate
   // with a SceneGraph.

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -1143,6 +1143,10 @@ GTEST_TEST(MultibodyPlantTest, CollisionGeometryRegistration) {
   // We are done defining the model.
   plant.Finalize();
 
+  // There is no direct feedthrough of any kind, even with the new ports
+  // related to SceneGraph interaction.
+  EXPECT_FALSE(plant.HasAnyDirectFeedthrough());
+
   EXPECT_EQ(plant.num_visual_geometries(), 0);
   EXPECT_EQ(plant.num_collision_geometries(), 3);
   EXPECT_TRUE(plant.geometry_source_is_registered());
@@ -1968,6 +1972,10 @@ class KukaArmTest : public ::testing::TestWithParam<double> {
         plant_->WeldFrames(plant_->world_frame(),
                            plant_->GetFrameByName("iiwa_link_0"));
     plant_->Finalize();
+
+    // There is no direct feedthrough of any kind, for either continuous or
+    // discrete plants.
+    EXPECT_FALSE(plant_->HasAnyDirectFeedthrough());
 
     EXPECT_EQ(plant_->num_positions(), 7);
     EXPECT_EQ(plant_->num_velocities(), 7);


### PR DESCRIPTION
`DoHasDirectFeedthrough` will be deprecated, and this is the new preferred mechanism.  It may also have the side-effect of reducing invalidations.

It also newly marks some `RigidBodyPlant` outputs as `feedthrough==true`; they were lying about being non-feedthrough previously.

This is a prerequisite for #11298.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11299)
<!-- Reviewable:end -->
