### PR TITLE
pydrake doxygen: Fix markup for `@exclude_from_pydrake_mkdoc`

### DIFF
--- a/bindings/pydrake/pydrake_doxygen.h
+++ b/bindings/pydrake/pydrake_doxygen.h
@@ -233,9 +233,11 @@ the pydrake binding's signature is consistent with the docstring argument
 count.
 - If two or more docstrings are the same, only one new symbol is introduced.
 - To suppress a Doxygen comment from mkdoc, add the custom Doxygen command
-`@exclude_from_pydrake_mkdoc{Explanatory text.}` to the API comment text.
-(This is useful to help dismiss unbound overloads, so that mkdoc's choice of
-`_something` name suffix is simpler for the remaining overloads.)
+\c \@exclude_from_pydrake_mkdoc{Explanation} to the API comment text.
+This is useful to help dismiss unbound overloads, so that mkdoc's choice of
+`_something` name suffix is simpler for the remaining overloads, especially if
+you see the symbol `.doc_was_unable_to_choose_unambiguous_names` in the
+generated documentation.
 - The docstring for a method that is marked as deprecated in C++ Doxygen will
 be named `.doc_deprecated...` instead of just `.doc...`.
 


### PR DESCRIPTION
Add explicit mention of `.doc_was_unable_to_choose_unambiguous_names`

Before:
> ![image](https://user-images.githubusercontent.com/26719449/56511285-4395c080-64fa-11e9-9f17-0afd110ecbbc.png)

After:
> ![image](https://user-images.githubusercontent.com/26719449/56511329-54decd00-64fa-11e9-87bc-74ca6b093ccc.png)

Clarifying this based on @rcory's question about this behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11300)
<!-- Reviewable:end -->
