### PR TITLE
geometry: Make FrameKinematicsVector less ceremonial

### DIFF
--- a/attic/manipulation/util/frame_pose_tracker.cc
+++ b/attic/manipulation/util/frame_pose_tracker.cc
@@ -100,7 +100,6 @@ void FramePoseTracker::Init() {
 
   pose_vector_output_port_index_ =
       this->DeclareAbstractOutputPort(
-          geometry::FramePoseVector<double>(source_id_, frame_ids),
           &FramePoseTracker::OutputStatus).get_index();
 }
 

--- a/attic/multibody/rigid_body_plant/rigid_body_plant_bridge.cc
+++ b/attic/multibody/rigid_body_plant/rigid_body_plant_bridge.cc
@@ -97,9 +97,7 @@ RigidBodyPlantBridge<T>::RigidBodyPlantBridge(const RigidBodyTree<T>* tree,
   // second body id.
   std::vector<FrameId> dynamic_frames(body_ids_.begin() + 1, body_ids_.end());
   geometry_pose_port_ = this->DeclareAbstractOutputPort(
-          FramePoseVector<T>(source_id_, dynamic_frames),
-          &RigidBodyPlantBridge::CalcFramePoseOutput)
-      .get_index();
+          &RigidBodyPlantBridge::CalcFramePoseOutput).get_index();
 }
 
 template <typename T>
@@ -188,9 +186,6 @@ void RigidBodyPlantBridge<T>::RegisterTree(SceneGraph<T>* scene_graph) {
 template <typename T>
 void RigidBodyPlantBridge<T>::CalcFramePoseOutput(
     const MyContext& context, FramePoseVector<T>* poses) const {
-  DRAKE_DEMAND(source_id_.is_valid());
-  DRAKE_DEMAND(poses->size() == static_cast<int>(body_ids_.size() - 1));
-
   const BasicVector<T>& input_vector = *this->EvalVectorInput(context, 0);
   // Obtains the generalized positions from vector_base.
   const VectorX<T> q = input_vector.CopyToVector().head(

--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -148,6 +148,7 @@ drake_pybind_library(
     package_info = PACKAGE_INFO,
     py_deps = [
         ":module_py",
+        "//bindings/pydrake/common/test_utilities",
         "//bindings/pydrake/systems:framework_py",
         "//bindings/pydrake/systems:lcm_py",
     ],

--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -77,9 +77,12 @@ PYBIND11_MODULE(geometry, m) {
   py::class_<FramePoseVector<T>>(
       m, "FramePoseVector", doc.FrameKinematicsVector.doc)
       .def(py::init<>(), doc.FrameKinematicsVector.ctor.doc_0args)
-      .def(py::init<SourceId, const std::vector<FrameId>&>(),
+      .def(py::init([](SourceId source_id, const std::vector<FrameId>& ids) {
+        WarnDeprecated("See API docs for deprecation notice.");
+        return std::make_unique<FramePoseVector<T>>(source_id, ids);
+      }),
           py::arg("source_id"), py::arg("ids"),
-          doc.FrameKinematicsVector.ctor.doc_2args);
+          doc.FrameKinematicsVector.ctor.doc_deprecated_2args);
   pysystems::AddValueInstantiation<FramePoseVector<T>>(m);
 
   py::class_<QueryObject<T>>(m, "QueryObject", doc.QueryObject.doc)

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -4,6 +4,7 @@ import unittest
 import warnings
 
 from pydrake.common import FindResourceOrThrow
+from pydrake.common.test_utilities.deprecation import catch_drake_warnings
 from pydrake.lcm import DrakeMockLcm
 from pydrake.systems.framework import DiagramBuilder, InputPort, OutputPort
 from pydrake.common.deprecation import DrakeDeprecationWarning
@@ -41,8 +42,9 @@ class TestGeometry(unittest.TestCase):
 
     def test_frame_pose_vector_api(self):
         mut.FramePoseVector()
-        mut.FramePoseVector(source_id=mut.SourceId.get_new_id(),
-                            ids=[mut.FrameId.get_new_id()])
+        with catch_drake_warnings(expected_count=1):
+            mut.FramePoseVector(source_id=mut.SourceId.get_new_id(),
+                                ids=[mut.FrameId.get_new_id()])
 
     def test_query_object_api(self):
         # TODO(eric.cousineau): Create self-contained unittests (#9899).

--- a/examples/pendulum/pendulum_geometry.cc
+++ b/examples/pendulum/pendulum_geometry.cc
@@ -95,16 +95,13 @@ PendulumGeometry::PendulumGeometry(geometry::SceneGraph<double>* scene_graph) {
 void PendulumGeometry::OutputGeometryPose(
     const systems::Context<double>& context,
     geometry::FramePoseVector<double>* poses) const {
-  DRAKE_DEMAND(source_id_.is_valid());
   DRAKE_DEMAND(frame_id_.is_valid());
 
   const auto& input = get_input_port(0).Eval<PendulumState<double>>(context);
   const double theta = input.theta();
   const math::RigidTransformd pose(math::RotationMatrixd::MakeYRotation(theta));
 
-  *poses = geometry::FramePoseVector<double>(source_id_, {frame_id_});
-  poses->clear();
-  poses->set_value(frame_id_, pose.GetAsIsometry3());
+  *poses = {{frame_id_, pose.GetAsIsometry3()}};
 }
 
 }  // namespace pendulum

--- a/examples/quadrotor/quadrotor_plant.cc
+++ b/examples/quadrotor/quadrotor_plant.cc
@@ -151,9 +151,7 @@ systems::OutputPortIndex QuadrotorPlant<T>::AllocateGeometryPoseOutputPort() {
   DRAKE_DEMAND(source_id_.is_valid() && frame_id_.is_valid());
   return this
       ->DeclareAbstractOutputPort(
-          "geometry_pose",
-          geometry::FramePoseVector<T>(source_id_, {frame_id_}),
-          &QuadrotorPlant<T>::CopyPoseOut)
+          "geometry_pose", &QuadrotorPlant<T>::CopyPoseOut)
       .get_index();
 }
 
@@ -184,16 +182,11 @@ void QuadrotorPlant<T>::RegisterGeometry(
 template <typename T>
 void QuadrotorPlant<T>::CopyPoseOut(const systems::Context<T>& context,
                                    geometry::FramePoseVector<T>* poses) const {
-  DRAKE_DEMAND(poses->size() == 1);
-  DRAKE_DEMAND(poses->source_id() == source_id_);
-
   VectorX<T> state = context.get_continuous_state_vector().CopyToVector();
-
-  poses->clear();
   math::RigidTransform<T> pose(
       math::RollPitchYaw<T>(state.template segment<3>(3)),
       state.template head<3>());
-  poses->set_value(frame_id_, pose.GetAsIsometry3());
+  *poses = {{frame_id_, pose.GetAsIsometry3()}};
 }
 
 std::unique_ptr<systems::AffineSystem<double>> StabilizingLQRController(

--- a/examples/scene_graph/bouncing_ball_plant.cc
+++ b/examples/scene_graph/bouncing_ball_plant.cc
@@ -31,9 +31,9 @@ template <typename T>
 BouncingBallPlant<T>::BouncingBallPlant(SourceId source_id,
                                         SceneGraph<T>* scene_graph,
                                         const Vector2<double>& p_WB)
-    : source_id_(source_id), p_WB_(p_WB) {
+    : p_WB_(p_WB) {
   DRAKE_DEMAND(scene_graph != nullptr);
-  DRAKE_DEMAND(source_id_.is_valid());
+  DRAKE_DEMAND(source_id.is_valid());
 
   geometry_query_port_ = this->DeclareAbstractInputPort(
       systems::kUseDefaultName, Value<geometry::QueryObject<T>>{})
@@ -61,7 +61,6 @@ BouncingBallPlant<T>::BouncingBallPlant(SourceId source_id,
 
   // Allocate the output port now that the frame has been registered.
   geometry_pose_port_ = this->DeclareAbstractOutputPort(
-          FramePoseVector<double>(source_id_, {ball_frame_id_}),
           &BouncingBallPlant::CalcFramePoseOutput,
           {this->configuration_ticket()})
       .get_index();
@@ -99,14 +98,10 @@ void BouncingBallPlant<T>::CopyStateToOutput(
 template <typename T>
 void BouncingBallPlant<T>::CalcFramePoseOutput(
     const Context<T>& context, FramePoseVector<T>* poses) const {
-  DRAKE_DEMAND(poses->source_id() == source_id_);
-  DRAKE_DEMAND(poses->size() == 1);
-
   Isometry3<T> pose = Isometry3<T>::Identity();
   const BouncingBallVector<T>& state = get_state(context);
   pose.translation() << p_WB_.x(), p_WB_.y(), state.z();
-  poses->clear();
-  poses->set_value(ball_frame_id_, pose);
+  *poses = {{ball_frame_id_, pose}};
 }
 
 // Compute the actual physics.

--- a/examples/scene_graph/bouncing_ball_plant.h
+++ b/examples/scene_graph/bouncing_ball_plant.h
@@ -106,8 +106,6 @@ class BouncingBallPlant : public systems::LeafSystem<T> {
     return get_mutable_state(&context->get_mutable_continuous_state());
   }
 
-  // This plant's source id in SceneGraph.
-  geometry::SourceId source_id_;
   // The projected position of the ball onto the ground plane. I.e., it's
   // "where the ball bounces".
   const Vector2<double> p_WB_;

--- a/examples/scene_graph/dev/bouncing_ball_plant.cc
+++ b/examples/scene_graph/dev/bouncing_ball_plant.cc
@@ -31,9 +31,9 @@ template <typename T>
 BouncingBallPlant<T>::BouncingBallPlant(SourceId source_id,
                                         SceneGraph<T>* scene_graph,
                                         const Vector2<double>& p_WB)
-    : source_id_(source_id), p_WB_(p_WB) {
+    : p_WB_(p_WB) {
   DRAKE_DEMAND(scene_graph != nullptr);
-  DRAKE_DEMAND(source_id_.is_valid());
+  DRAKE_DEMAND(source_id.is_valid());
 
   geometry_query_port_ = this->DeclareAbstractInputPort(
       systems::kUseDefaultName, Value<geometry::QueryObject<T>>{})
@@ -61,7 +61,6 @@ BouncingBallPlant<T>::BouncingBallPlant(SourceId source_id,
 
   // Allocate the output port now that the frame has been registered.
   geometry_pose_port_ = this->DeclareAbstractOutputPort(
-          FramePoseVector<double>(source_id_, {ball_frame_id_}),
           &BouncingBallPlant::CalcFramePoseOutput,
           {this->configuration_ticket()})
       .get_index();
@@ -99,14 +98,10 @@ void BouncingBallPlant<T>::CopyStateToOutput(
 template <typename T>
 void BouncingBallPlant<T>::CalcFramePoseOutput(
     const Context<T>& context, FramePoseVector<T>* poses) const {
-  DRAKE_DEMAND(poses->source_id() == source_id_);
-  DRAKE_DEMAND(poses->size() == 1);
-
   Isometry3<T> pose = Isometry3<T>::Identity();
   const BouncingBallVector<T>& state = get_state(context);
   pose.translation() << p_WB_.x(), p_WB_.y(), state.z();
-  poses->clear();
-  poses->set_value(ball_frame_id_, pose);
+  *poses = {{ball_frame_id_, pose}};
 }
 
 // Compute the actual physics.

--- a/examples/scene_graph/dev/bouncing_ball_plant.h
+++ b/examples/scene_graph/dev/bouncing_ball_plant.h
@@ -106,8 +106,6 @@ class BouncingBallPlant : public systems::LeafSystem<T> {
     return get_mutable_state(&context->get_mutable_continuous_state());
   }
 
-  // This plant's source id in SceneGraph.
-  geometry::SourceId source_id_;
   // The projected position of the ball onto the ground plane. I.e., it's
   // "where the ball bounces".
   const Vector2<double> p_WB_;

--- a/examples/scene_graph/dev/solar_system.cc
+++ b/examples/scene_graph/dev/solar_system.cc
@@ -61,7 +61,6 @@ SolarSystem<T>::SolarSystem(SceneGraph<T>* scene_graph) {
 
   // Now that frames have been registered, allocate the output port.
   geometry_pose_port_ = this->DeclareAbstractOutputPort(
-          FramePoseVector<T>(source_id_, body_ids_),
           &SolarSystem::CalcFramePoseOutput,
           {this->configuration_ticket()})
       .get_index();
@@ -262,11 +261,7 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
 template <typename T>
 void SolarSystem<T>::CalcFramePoseOutput(const Context<T>& context,
                                          FramePoseVector<T>* poses) const {
-  DRAKE_DEMAND(poses->size() == kBodyCount);
-  DRAKE_DEMAND(poses->source_id() == source_id_);
-
   const BasicVector<T>& state = get_state(context);
-
   poses->clear();
   for (int i = 0; i < kBodyCount; ++i) {
     Isometry3<T> pose = body_offset_[i];

--- a/examples/scene_graph/solar_system.cc
+++ b/examples/scene_graph/solar_system.cc
@@ -50,7 +50,6 @@ SolarSystem<T>::SolarSystem(SceneGraph<T>* scene_graph) {
 
   // Now that frames have been registered, allocate the output port.
   geometry_pose_port_ = this->DeclareAbstractOutputPort(
-          FramePoseVector<T>(source_id_, body_ids_),
           &SolarSystem::CalcFramePoseOutput,
           {this->configuration_ticket()})
       .get_index();
@@ -319,11 +318,7 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
 template <typename T>
 void SolarSystem<T>::CalcFramePoseOutput(const Context<T>& context,
                                          FramePoseVector<T>* poses) const {
-  DRAKE_DEMAND(poses->size() == kBodyCount);
-  DRAKE_DEMAND(poses->source_id() == source_id_);
-
   const BasicVector<T>& state = get_state(context);
-
   poses->clear();
   for (int i = 0; i < kBodyCount; ++i) {
     Isometry3<T> pose = body_offset_[i];

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -282,6 +282,7 @@ drake_cc_googletest(
     deps = [
         ":frame_kinematics",
         "//common/test_utilities",
+        "//math:geometric_transform",
     ],
 )
 

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -282,6 +282,7 @@ drake_cc_googletest(
     deps = [
         ":frame_kinematics",
         "//common/test_utilities",
+        "//common/test_utilities:limit_malloc",
         "//math:geometric_transform",
     ],
 )

--- a/geometry/dev/geometry_state.cc
+++ b/geometry/dev/geometry_state.cc
@@ -1025,12 +1025,13 @@ void GeometryState<T>::CollectIndices(
 }
 
 template <typename T>
-void GeometryState<T>::SetFramePoses(const FramePoseVector<T>& poses) {
+void GeometryState<T>::SetFramePoses(
+    const SourceId source_id, const FramePoseVector<T>& poses) {
   // TODO(SeanCurtis-TRI): Down the road, make this validation depend on
   // ASSERT_ARMED.
-  ValidateFrameIds(poses);
+  ValidateFrameIds(source_id, poses);
   const Isometry3<T> world_pose = Isometry3<T>::Identity();
-  for (auto frame_id : source_root_frame_map_[poses.source_id()]) {
+  for (auto frame_id : source_root_frame_map_[source_id]) {
     UpdatePosesRecursively(frames_[frame_id], world_pose, poses);
   }
 }
@@ -1038,8 +1039,8 @@ void GeometryState<T>::SetFramePoses(const FramePoseVector<T>& poses) {
 template <typename T>
 template <typename ValueType>
 void GeometryState<T>::ValidateFrameIds(
+    const SourceId source_id,
     const FrameKinematicsVector<ValueType>& kinematics_data) const {
-  SourceId source_id = kinematics_data.source_id();
   auto& frames = GetFramesForSource(source_id);
   const int ref_frame_count = static_cast<int>(frames.size());
   if (ref_frame_count != kinematics_data.size()) {

--- a/geometry/dev/geometry_state.h
+++ b/geometry/dev/geometry_state.h
@@ -782,14 +782,15 @@ class GeometryState {
   // @param poses The frame id and pose values.
   // @throws std::logic_error  If the ids are invalid as defined by
   // ValidateFrameIds().
-  void SetFramePoses(const FramePoseVector<T>& poses);
+  void SetFramePoses(SourceId source_id, const FramePoseVector<T>& poses);
 
   // Confirms that the set of ids provided include _all_ of the frames
   // registered to the set's source id and that no extra frames are included.
   // @param values The kinematics values (ids and values) to validate.
   // @throws std::runtime_error if the set is inconsistent with known topology.
   template <typename ValueType>
-  void ValidateFrameIds(const FrameKinematicsVector<ValueType>& values) const;
+  void ValidateFrameIds(SourceId source_id,
+                        const FrameKinematicsVector<ValueType>& values) const;
 
   // Method that performs any final book-keeping/updating on the state after
   // _all_ of the state's frames have had their poses updated.

--- a/geometry/dev/scene_graph.cc
+++ b/geometry/dev/scene_graph.cc
@@ -456,7 +456,7 @@ void SceneGraph<T>::CalcPoseUpdate(const GeometryContext<T>& context,
         }
         const auto& poses =
             pose_port.template Eval<FramePoseVector<T>>(context);
-        mutable_state.SetFramePoses(poses);
+        mutable_state.SetFramePoses(source_id, poses);
       }
     }
   }

--- a/geometry/dev/test/geometry_state_test.cc
+++ b/geometry/dev/test/geometry_state_test.cc
@@ -85,8 +85,8 @@ class GeometryStateTester {
     return state_->X_PF_;
   }
 
-  void SetFramePoses(const FramePoseVector<T>& poses) {
-    state_->SetFramePoses(poses);
+  void SetFramePoses(SourceId source_id, const FramePoseVector<T>& poses) {
+    state_->SetFramePoses(source_id, poses);
   }
 
   // Returns the internal index for the geometry with the given index; if there
@@ -119,8 +119,9 @@ class GeometryStateTester {
   }
 
   template <typename ValueType>
-  void ValidateFrameIds(const FrameKinematicsVector<ValueType>& data) const {
-    state_->ValidateFrameIds(data);
+  void ValidateFrameIds(SourceId source_id,
+                        const FrameKinematicsVector<ValueType>& data) const {
+    state_->ValidateFrameIds(source_id, data);
   }
 
   int peek_next_clique() const {
@@ -627,12 +628,11 @@ TEST_F(GeometryStateTest, ValidateSingleSourceTree) {
     }
 
     // Confirm posing positions the frames properly.
-    FramePoseVector<double> poses(source_id_, frames_);
-    poses.clear();
+    FramePoseVector<double> poses;
     for (int f = 0; f < static_cast<int>(frames_.size()); ++f) {
       poses.set_value(frames_[f], X_PF_[f]);
     }
-    gs_tester_.SetFramePoses(poses);
+    gs_tester_.SetFramePoses(source_id_, poses);
     gs_tester_.FinalizePoseUpdate();
 
     test_frame(0, gs_tester_.get_world_frame(), 0);
@@ -1122,33 +1122,30 @@ TEST_F(GeometryStateTest, GetFrameIdFromBadId) {
 // Tests the validation of the ids provided in a frame kinematics vector.
 TEST_F(GeometryStateTest, ValidateFrameIds) {
   SourceId s_id = SetUpSingleSourceTree();
-  FramePoseVector<double> frame_set(s_id, frames_);
-  frame_set.clear();
+  FramePoseVector<double> frame_set;
   for (auto frame_id : frames_) {
     frame_set.set_value(frame_id, Isometry3<double>::Identity());
   }
   // Case: frame ids are valid.
-  EXPECT_NO_THROW(gs_tester_.ValidateFrameIds(frame_set));
+  EXPECT_NO_THROW(gs_tester_.ValidateFrameIds(s_id, frame_set));
 
   // Case: Right number, wrong frames.
-  vector<FrameId> bad_frames;
+  FramePoseVector<double> frame_set_2;
   for (int i = 0; i < kFrameCount; ++i) {
-    bad_frames.push_back(FrameId::get_new_id());
+    frame_set_2.set_value(FrameId::get_new_id(), Isometry3d::Identity());
   }
-  FramePoseVector<double> frame_set_2(s_id, bad_frames);
   DRAKE_EXPECT_THROWS_MESSAGE(
-      gs_tester_.ValidateFrameIds(frame_set_2), std::runtime_error,
+      gs_tester_.ValidateFrameIds(s_id, frame_set_2), std::runtime_error,
       "Registered frame id \\(\\d+\\) belonging to source \\d+ was not found "
           "in the provided kinematics data.");
 
   // Case: Too few frames.
-  vector<FrameId> missing_frames;
+  FramePoseVector<double> frame_set_3;
   for (int i = 0; i < kFrameCount - 1; ++i) {
-    missing_frames.push_back(frames_[i]);
+    frame_set.set_value(frames_[i], Isometry3<double>::Identity());
   }
-  FramePoseVector<double> frame_set_3(s_id, missing_frames);
   DRAKE_EXPECT_THROWS_MESSAGE(
-      gs_tester_.ValidateFrameIds(frame_set_3), std::runtime_error,
+      gs_tester_.ValidateFrameIds(s_id, frame_set_3), std::runtime_error,
       "Disagreement in expected number of frames \\(\\d+\\)"
       " and the given number of frames \\(\\d+\\).");
 }
@@ -1169,10 +1166,9 @@ TEST_F(GeometryStateTest, SetFramePoses) {
   }
 
   auto make_pose_vector =
-      [&s_id, &frame_poses, this]() -> FramePoseVector<double> {
+      [&frame_poses, this]() -> FramePoseVector<double> {
     const int count = static_cast<int>(this->frames_.size());
-    FramePoseVector<double> poses(s_id, this->frames_);
-    poses.clear();
+    FramePoseVector<double> poses;
     for (int i = 0; i < count; ++i) {
       poses.set_value(this->frames_[i], frame_poses[i]);
     }
@@ -1185,7 +1181,7 @@ TEST_F(GeometryStateTest, SetFramePoses) {
   // Case 1: Set all frames to identity poses. The world pose of all the
   // geometry should be that of the geometry in its frame.
   FramePoseVector<double> poses1 = make_pose_vector();
-  gs_tester_.SetFramePoses(poses1);
+  gs_tester_.SetFramePoses(s_id, poses1);
   const auto& world_poses = gs_tester_.get_geometry_world_poses();
   for (int i = 0; i < kFrameCount * kGeometryCount; ++i) {
     EXPECT_TRUE(CompareMatrices(world_poses[i].matrix().block<3, 4>(0, 0),
@@ -1200,7 +1196,7 @@ TEST_F(GeometryStateTest, SetFramePoses) {
   frame_poses[0] = offset;
   frame_poses[1] = offset;
   FramePoseVector<double> poses2 = make_pose_vector();
-  gs_tester_.SetFramePoses(poses2);
+  gs_tester_.SetFramePoses(s_id, poses2);
   for (int i = 0; i < kFrameCount * kGeometryCount; ++i) {
     EXPECT_TRUE(
         CompareMatrices(world_poses[i].matrix().block<3, 4>(0, 0),
@@ -1211,7 +1207,7 @@ TEST_F(GeometryStateTest, SetFramePoses) {
   // 0, 1, 2, & 3 moved up 1, and geometries 4 & 5 moved up two.
   frame_poses[2] = offset;
   FramePoseVector<double> poses3 = make_pose_vector();
-  gs_tester_.SetFramePoses(poses3);
+  gs_tester_.SetFramePoses(s_id, poses3);
   for (int i = 0; i < (kFrameCount - 1) * kGeometryCount; ++i) {
     EXPECT_TRUE(
         CompareMatrices(world_poses[i].matrix().block<3, 4>(0, 0),
@@ -1245,10 +1241,9 @@ TEST_F(GeometryStateTest, QueryFrameProperties) {
       "No frame name available for invalid frame id: \\d+");
 
   // Set the frame poses to query geometry and frame poses.
-  FramePoseVector<double> poses(s_id, frames_);
-  poses.clear();
+  FramePoseVector<double> poses;
   for (int i = 0; i < kFrameCount; ++i) poses.set_value(frames_[i], X_PF_[i]);
-  gs_tester_.SetFramePoses(poses);
+  gs_tester_.SetFramePoses(s_id, poses);
 
   EXPECT_TRUE(
       CompareMatrices(geometry_state_.get_pose_in_world(frames_[0]).matrix(),
@@ -1286,12 +1281,11 @@ TEST_F(GeometryStateTest, ExcludeCollisionsWithin) {
   SetUpSingleSourceTree(true /* assign proximity roles */);
 
   // Pose all of the frames to the specified poses in their parent frame.
-  FramePoseVector<double> poses(source_id_, frames_);
-  poses.clear();
+  FramePoseVector<double> poses;
   for (int f = 0; f < static_cast<int>(frames_.size()); ++f) {
     poses.set_value(frames_[f], X_PF_[f]);
   }
-  gs_tester_.SetFramePoses(poses);
+  gs_tester_.SetFramePoses(source_id_, poses);
   gs_tester_.FinalizePoseUpdate();
 
   // This is *non* const; we'll decrement it as we filter more and more
@@ -1342,12 +1336,11 @@ TEST_F(GeometryStateTest, ExcludeCollisionsBetween) {
   SetUpSingleSourceTree(true  /* add proximity roles */);
 
   // Pose all of the frames to the specified poses in their parent frame.
-  FramePoseVector<double> poses(source_id_, frames_);
-  poses.clear();
+  FramePoseVector<double> poses;
   for (int f = 0; f < static_cast<int>(frames_.size()); ++f) {
     poses.set_value(frames_[f], X_PF_[f]);
   }
-  gs_tester_.SetFramePoses(poses);
+  gs_tester_.SetFramePoses(source_id_, poses);
   gs_tester_.FinalizePoseUpdate();
 
   // This is *non* const; we'll decrement it as we filter more and more
@@ -1383,12 +1376,11 @@ TEST_F(GeometryStateTest, NonProximityRoleInCollisionFilter) {
   SetUpSingleSourceTree(true  /* add proximity roles */);
 
   // Pose all of the frames to the specified poses in their parent frame.
-  FramePoseVector<double> poses(source_id_, frames_);
-  poses.clear();
+  FramePoseVector<double> poses;
   for (int f = 0; f < static_cast<int>(frames_.size()); ++f) {
     poses.set_value(frames_[f], X_PF_[f]);
   }
-  gs_tester_.SetFramePoses(poses);
+  gs_tester_.SetFramePoses(source_id_, poses);
   gs_tester_.FinalizePoseUpdate();
 
   // This is *non* const; we'll decrement it as we filter more and more

--- a/geometry/frame_kinematics_vector.cc
+++ b/geometry/frame_kinematics_vector.cc
@@ -29,40 +29,56 @@ template <typename KinematicsValue>
 FrameKinematicsVector<KinematicsValue>::FrameKinematicsVector(
     SourceId source_id, const std::vector<FrameId>& ids)
     : source_id_(source_id), values_(0) {
-  KinematicsValue default_value;
-  InitializeKinematicsValue(&default_value);
+  optional<KinematicsValue> default_value{KinematicsValue{}};
+  InitializeKinematicsValue(&default_value.value());
   for (FrameId id : ids) {
     bool is_unique = values_.emplace(id, default_value).second;
     if (!is_unique) {
       throw std::runtime_error(
           fmt::format("At least one frame id appears multiple times: {}", id));
     }
+    ++size_;
   }
+  DRAKE_ASSERT_VOID(CheckInvariants());
 }
 
 template <typename KinematicsValue>
 FrameKinematicsVector<KinematicsValue>::FrameKinematicsVector(
     std::initializer_list<std::pair<const FrameId, KinematicsValue>> init) {
-  values_ = init;
+  values_.insert(init.begin(), init.end());
+  size_ = init.size();
+  DRAKE_ASSERT_VOID(CheckInvariants());
 }
 
 template <typename KinematicsValue>
 FrameKinematicsVector<KinematicsValue>&
 FrameKinematicsVector<KinematicsValue>::operator=(
     std::initializer_list<std::pair<const FrameId, KinematicsValue>> init) {
-  values_ = init;
+  // N.B. We can't use unordered_map::insert in our operator= implementation
+  // because it does not overwrite pre-existing keys.  (Our clear() doesn't
+  // remove the keys, it only nulls the values.)
+  clear();
+  for (const auto& item : init) {
+    set_value(item.first, item.second);
+  }
+  DRAKE_ASSERT_VOID(CheckInvariants());
   return *this;
 }
 
 template <typename KinematicsValue>
 void FrameKinematicsVector<KinematicsValue>::clear() {
-  values_.clear();
+  for (auto& item : values_) {
+    item.second = nullopt;
+  }
+  size_ = 0;
 }
 
 template <typename KinematicsValue>
 void FrameKinematicsVector<KinematicsValue>::set_value(
     FrameId id, const KinematicsValue& value) {
-  values_[id] = value;
+  auto& map_value = values_[id];
+  if (!map_value.has_value()) { ++size_; }
+  map_value = value;
 }
 
 template <typename KinematicsValue>
@@ -70,10 +86,44 @@ const KinematicsValue& FrameKinematicsVector<KinematicsValue>::value(
     FrameId id) const {
   using std::to_string;
   auto iter = values_.find(id);
-  if (iter == values_.end()) {
-    throw std::runtime_error("No such FrameId " + to_string(id) + ".");
+  if (iter != values_.end()) {
+    const optional<KinematicsValue>& map_value = iter->second;
+    if (map_value.has_value()) {
+      return *map_value;
+    }
   }
-  return iter->second;
+  throw std::runtime_error("No such FrameId " + to_string(id) + ".");
+}
+
+template <typename KinematicsValue>
+bool FrameKinematicsVector<KinematicsValue>::has_id(FrameId id) const {
+  auto iter = values_.find(id);
+  return (iter != values_.end()) && iter->second.has_value();
+}
+
+template <typename KinematicsValue>
+std::vector<FrameId>
+FrameKinematicsVector<KinematicsValue>::frame_ids() const {
+  std::vector<FrameId> result;
+  result.reserve(size_);
+  for (const auto& item : values_) {
+    if (item.second.has_value()) {
+      result.emplace_back(item.first);
+    }
+  }
+  DRAKE_ASSERT(static_cast<int>(result.size()) == size_);
+  return result;
+}
+
+template <typename KinematicsValue>
+void FrameKinematicsVector<KinematicsValue>::CheckInvariants() const {
+  int num_nonnull = 0;
+  for (const auto& item : values_) {
+    if (item.second.has_value()) {
+      ++num_nonnull;
+    }
+  }
+  DRAKE_DEMAND(num_nonnull == size_);
 }
 
 // Explicitly instantiates on the most common scalar types.

--- a/geometry/frame_kinematics_vector.h
+++ b/geometry/frame_kinematics_vector.h
@@ -1,10 +1,12 @@
 #pragma once
 
+#include <initializer_list>
 #include <unordered_map>
 #include <utility>
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/utilities.h"
@@ -12,140 +14,57 @@
 namespace drake {
 namespace geometry {
 
-#ifndef DRAKE_DOXYGEN_CXX
-namespace detail {
-
-// A type-traits-style initializer for making sure that quantities in the frame
-// kinematics vector are initialized. This is because Eigen actively does *not*
-// initialize its data types and there is a code path by which uninitialized
-// values in the vector can be accessed.
-
-template <typename Value>
-struct KinematicsValueInitializer {
-  static void Initialize(Value* value) {
-    std::logic_error("Unsupported kinematics value");
-  }
-};
-
-template <typename S>
-struct KinematicsValueInitializer<Isometry3<S>> {
-  static void Initialize(Isometry3<S>* value) {
-    value->setIdentity();
-  }
-};
-
-// TODO(SeanCurtis-TRI): Add specializations for SpatialVelocity and
-// SpatialAcceleration (setting them to zero vectors) as those quantities are
-// added to SceneGraph.
-
-}  // namespace detail
-#endif  // DRAKE_DOXYGEN_CXX
-
 /** A %FrameKinematicsVector is used to report kinematics data for registered
  frames (identified by unique FrameId values) to SceneGraph.
  It serves as the basis of FramePoseVector, FrameVelocityVector, and
  FrameAccelerationVector.
-
- The %FrameKinematicsVector must be constructed with the source's SourceId and
- the ids of the frames *owned* by the source. Once constructed, it cannot be
- resized. Typically, this will be done in the allocation method of the
- LeafSystem which serves as a geometry source.
-
- Populating the vector with values is a two-step process: clear and set. Before
- writing any kinematics data the vector should be _cleared_ (see clear()). After
- clearing, each registered frame will have a kinematics value assigned to it
- by calling set_value().
-
- Only those frame ids provided in the constructor can be set. Attempting to
- set the value for any other frame id is considered an error.
- Attempting to write more frames than the vector was constructed for is
- considered an error and will throw an exception. Failing to set data for every
- registered frame will be considered an error when the %FrameKinematicsVector
- is consumed by SceneGraph.
 
  <!--
    TODO(SeanCurtis-TRI): The FrameVelocityVector and FrameAccelerationVector
    are still to come.
   -->
 
- The usage of this method would be in the allocation and calculation
- of a LeafSystem's output port. The nature of the allocation depends on whether
- the source id and number of frames are available at construction or not. The
- first example shows the case where source id and frame count are known. The
- second shows the alternate, deferred case.
-
  ```
  template <typename T>
- class AllocInConstructorSystem : public LeafSystem<T> {
+ class MySystem : public LeafSystem<T> {
   public:
-   explicit AllocInConstructorSystem(SourceId source_id)
-       : source_id_(source_id) {
+   MySystem() {
      ...
-     // Register frames, storing ids in frame_ids_
      this->DeclareAbstractOutputPort(
-         FramePoseVector<T>(source_id, frame_ids_),
          &AllocInConstructorSystem::CalcFramePoseOutput);
      ...
    }
 
   private:
-   void CalcFramePoseOutput(const MyContext& context,
+   void CalcFramePoseOutput(const Context<T>& context,
                             geometry::FramePoseVector<T>* poses) const {
-     DRAKE_DEMAND(poses->source_id() == source_id_);
-     DRAKE_DEMAND(poses->size() == static_cast<int>(frame_ids_.size()));
-
      poses->clear();
      for (int i = 0; i < static_cast<int>(frame_ids_.size()); ++i) {
        poses->set_value(frame_ids_[i], poses_[i]);
      }
    }
 
-   SourceId source_id_;
    std::vector<FrameId> frame_ids_;
    std::vector<Isometry3<T>> poses_;
  };
  ```
- __Example 1: Known source id and frame count in constructor.__
 
+ If a System only ever emits a single frame (or small-constant-number of
+ frames), then there's a shorter alternative way to write a Calc method, using
+ an initializer_list:
  ```
- /// Definition of FramePoseVector deferred to define number of frames. However,
- /// it must be defined prior to call to `AllocateContext()`.
- template <typename T>
- class DeferredAllocationSystem : public LeafSystem<T> {
-  public:
-   DeferredAllocationSystem() {
-     ...
-     this->DeclareAbstractOutputPort(
-         &DeferredAllocationSystem::AllocateFramePoseOutput,
-         &DeferredAllocationSystem::CalcFramePoseOutput);
-   }
-
-  private:
-   geometry::FramePoseVector<T> AllocateFramePoseOutput() const {
-     // Assume that source_id_ has been assigned and the frames have been
-     // registered.
-     DRAKE_DEMAND(source_id_.is_valid());
-
-     return geometry::FramePoseVector<T>(source_id_, frame_ids_);
-   }
-
-   void CalcFramePoseOutput(const MyContext& context,
+   void CalcFramePoseOutput(const Context<T>& context,
                             geometry::FramePoseVector<T>* poses) const {
-     DRAKE_DEMAND(poses->source_id() == source_id_);
-     DRAKE_DEMAND(poses->size() == static_cast<int>(frame_ids_.size()));
-
-     poses->clear();
-     for (int i = 0; i < static_cast<int>(frame_ids_.size()); ++i) {
-       poses->set_value(frame_ids_[i], poses_[i]);
-     }
+     const Isometry3<T>& pose = ...;
+     *poses = {{frame_id_, pose}};
    }
-
-   SourceId source_id_;
-   std::vector<FrameId> frame_ids_;
-   std::vector<Isometry3<T>> poses_;
- };
  ```
- __Example 2: Deferred pose vector allocation.__
+
+ N.B. When the systems framework calls the `Calc` method, the value pointed to
+ by `poses` is in an unspecified state.  The implementation of `Calc` must
+ always ensure that `poses` contains the correct value upon return, no matter
+ what value it started with.  The easy ways to do this are to call either
+ `poses->clear()` or the assignment operator `*poses = ...`.
 
  @tparam KinematicsValue  The underlying data type of for the order of
                           kinematics data (e.g., pose, velocity, or
@@ -170,51 +89,42 @@ struct KinematicsValueInitializer<Isometry3<S>> {
   */
 template <class KinematicsValue>
 class FrameKinematicsVector {
-  // Forward declaration.
-  struct FlaggedValue;
-
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(FrameKinematicsVector)
 
   /** An object that represents the range of FrameId values in this class. It
    is used in range-based for loops to iterate through registered frames.  */
-  using FrameIdRange = internal::MapKeyRange<FrameId, FlaggedValue>;
+  using FrameIdRange = internal::MapKeyRange<FrameId, KinematicsValue>;
 
-  // TODO(SeanCurtis-TRI) Find some API language that cautions users that this
-  // result is not terribly useful on its own, but instead it will usually be
-  // assigned into (using operator=) from another FrameKinematicsVector.
   /** Initializes the vector using an invalid SourceId with no frames .*/
   FrameKinematicsVector();
 
-  /** Initializes the vector on the owned ids.
-   @param source_id  The source id of the owning geometry source.
-   @param ids        The set of *all* frames owned by this geometry source. All
-                     of these ids must have values provided in the output port
-                     calculation and _only_ these ids. SceneGraph will
-                     validate the ids to confirm that they are all owned by
-                     the source with the given `source_id`. */
+  /** Initializes the vector to the given source ID and frame IDs, using a
+  default value for each frame. */
+  DRAKE_DEPRECATED("2019-08-01", "Simply use the default constructor.")
   FrameKinematicsVector(SourceId source_id, const std::vector<FrameId>& ids);
 
-  /** Initializes the vector to start setting kinematics values. */
+  /** Initializes the vector using an invalid SourceId and the given frames and
+  kinematics values. */
+  FrameKinematicsVector(
+      std::initializer_list<std::pair<const FrameId, KinematicsValue>> init);
+
+  /** Resets the vector to the given frames and kinematics values .*/
+  FrameKinematicsVector& operator=(
+      std::initializer_list<std::pair<const FrameId, KinematicsValue>> init);
+
+  /** Clears all values, resetting the size to zero. */
   void clear();
 
-  /** Sets the kinematics `value` for the frame indicated by the given `id`.
-   There are various error conditions which will lead to an exception being
-   thrown:
-
-   1. the id provided is not one of the frame ids provided in the constructor.
-   2. clear() hasn't been called.
-   3. the value for a particular id is set multiple times between clear()
-      invocations.
-
-   If this isn't invoked for _every_ frame id provided at construction, it will
-   lead to a subsequent exception when SceneGraph consumes the data. */
+  /** Sets the kinematics `value` for the frame indicated by the given `id`. */
   void set_value(FrameId id, const KinematicsValue& value);
 
+  DRAKE_DEPRECATED("2019-08-01",
+      "The source_id is being removed from FrameKinematicsVector; "
+      "the SceneGraph no longer requires that it be set.")
   SourceId source_id() const { return source_id_; }
 
-  /** Returns the constructed size of this vector -- the number of FrameId
-   values it was constructed with. */
+  /** Returns number of frame_ids(). */
   int size() const { return static_cast<int>(values_.size()); }
 
   /** Returns the value associated with the given `id`.
@@ -237,25 +147,13 @@ class FrameKinematicsVector {
   FrameIdRange frame_ids() const { return FrameIdRange(&values_); }
 
  private:
-  // Utility function to help catch misuse.
-  struct FlaggedValue {
-    FlaggedValue() {
-      detail::KinematicsValueInitializer<KinematicsValue>::Initialize(&value);
-    }
-    int64_t version{0};
-    KinematicsValue value;
-  };
-
-  // The source id for the geometry source reporting data in this vector
+  // TODO(jwnimmer-tri) This field is only here to support the deprecated
+  // source_id() method; when that method is removed, this field should be
+  // removed also.
   SourceId source_id_;
 
-  // Mapping from frame id to its current pose (with a flag indicating
-  // successful update).
-  std::unordered_map<FrameId, FlaggedValue> values_;
-
-  // The current version tag -- used to detect if values have been properly
-  // updated.
-  int64_t version_{0};
+  // Mapping from frame id to its current pose.
+  std::unordered_map<FrameId, KinematicsValue> values_;
 };
 
 /** Class for communicating _pose_ information to SceneGraph for registered
@@ -267,6 +165,7 @@ class FrameKinematicsVector {
 
  - double
  - AutoDiffXd
+ - Expression
 
  They are already available to link against in the containing library.
  No other values for T are currently supported.

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -830,12 +830,13 @@ void GeometryState<T>::CollectIndices(
 }
 
 template <typename T>
-void GeometryState<T>::SetFramePoses(const FramePoseVector<T>& poses) {
+void GeometryState<T>::SetFramePoses(
+    const SourceId source_id, const FramePoseVector<T>& poses) {
   // TODO(SeanCurtis-TRI): Down the road, make this validation depend on
   // ASSERT_ARMED.
-  ValidateFrameIds(poses);
+  ValidateFrameIds(source_id, poses);
   const Isometry3<T> world_pose = Isometry3<T>::Identity();
-  for (auto frame_id : source_root_frame_map_[poses.source_id()]) {
+  for (auto frame_id : source_root_frame_map_[source_id]) {
     UpdatePosesRecursively(frames_[frame_id], world_pose, poses);
   }
 }
@@ -843,8 +844,8 @@ void GeometryState<T>::SetFramePoses(const FramePoseVector<T>& poses) {
 template <typename T>
 template <typename ValueType>
 void GeometryState<T>::ValidateFrameIds(
+    const SourceId source_id,
     const FrameKinematicsVector<ValueType>& kinematics_data) const {
-  SourceId source_id = kinematics_data.source_id();
   auto& frames = GetFramesForSource(source_id);
   const int ref_frame_count = static_cast<int>(frames.size());
   if (ref_frame_count != kinematics_data.size()) {

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -543,16 +543,19 @@ class GeometryState {
 
   // Sets the kinematic poses for the frames indicated by the given ids.
   // @param poses The frame id and pose values.
+  // @pre source_id is a registered source.
   // @throws std::logic_error  If the ids are invalid as defined by
   // ValidateFrameIds().
-  void SetFramePoses(const FramePoseVector<T>& poses);
+  void SetFramePoses(SourceId source_id, const FramePoseVector<T>& poses);
 
   // Confirms that the set of ids provided include _all_ of the frames
   // registered to the set's source id and that no extra frames are included.
   // @param values The kinematics values (ids and values) to validate.
+  // @pre source_id is a registered source.
   // @throws std::runtime_error if the set is inconsistent with known topology.
   template <typename ValueType>
-  void ValidateFrameIds(const FrameKinematicsVector<ValueType>& values) const;
+  void ValidateFrameIds(SourceId source_id,
+                        const FrameKinematicsVector<ValueType>& values) const;
 
   // Method that performs any final book-keeping/updating on the state after
   // _all_ of the state's frames have had their poses updated.

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -384,7 +384,7 @@ void SceneGraph<T>::CalcPoseUpdate(const GeometryContext<T>& context,
         }
         const auto& poses =
             pose_port.template Eval<FramePoseVector<T>>(context);
-        mutable_state.SetFramePoses(poses);
+        mutable_state.SetFramePoses(source_id, poses);
       }
     }
   }

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -74,8 +74,8 @@ class QueryObject;
  FramePoseVector. For each registered frame, this "pose vector" maps the
  registered FrameId to a pose value. All registered frames must be accounted
  for and only frames registered by a source can be included in its output port.
- See the details in FrameKinematicsVector for details on how to allocate and
- calculate this port.
+ See the details in FrameKinematicsVector for details on how to provide values
+ for this port.
 
  @section geom_sys_outputs Outputs
 

--- a/geometry/test/frame_kinematics_vector_test.cc
+++ b/geometry/test/frame_kinematics_vector_test.cc
@@ -1,5 +1,6 @@
 #include "drake/geometry/frame_kinematics_vector.h"
 
+#include <algorithm>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -9,6 +10,7 @@
 #include "drake/common/symbolic.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/math/rigid_transform.h"
 
 namespace drake {
 namespace geometry {
@@ -22,10 +24,15 @@ namespace test {
 
 GTEST_TEST(FrameKinematicsVector, DefaultConstructor) {
   const FramePoseVector<double> dut;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   EXPECT_FALSE(dut.source_id().is_valid());
+#pragma GCC diagnostic pop
   EXPECT_EQ(dut.size(), 0);
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 GTEST_TEST(FrameKinematicsVector, Constructor) {
   SourceId source_id = SourceId::get_new_id();
 
@@ -54,22 +61,59 @@ GTEST_TEST(FrameKinematicsVector, Constructor) {
       FramePoseVector<double>(source_id, duplicate_ids), std::runtime_error,
       "At least one frame id appears multiple times: \\d+");
 }
+#pragma GCC diagnostic pop
+
+GTEST_TEST(FrameKinematicsVector, InitializerListCtor) {
+  const auto& id_0 = FrameId::get_new_id();
+  const Isometry3<double> pose_0 = Isometry3<double>::Identity();
+  const auto& id_1 = FrameId::get_new_id();
+  const Isometry3<double> pose_1 =
+      math::RigidTransformd{Eigen::Translation3d(0.1, 0.2, 0.3)}.
+          GetAsIsometry3();
+
+  const FramePoseVector<double> dut{{id_0, pose_0}, {id_1, pose_1}};
+  ASSERT_EQ(dut.size(), 2);
+  EXPECT_TRUE(dut.has_id(id_0));
+  EXPECT_TRUE(dut.has_id(id_1));
+  EXPECT_FALSE(dut.has_id(FrameId::get_new_id()));
+  EXPECT_TRUE(ExpectExactIdentity(dut.value(id_0)));
+  EXPECT_TRUE(CompareMatrices(
+      dut.value(id_1).matrix().block<3, 4>(0, 0),
+      pose_1.matrix().block<3, 4>(0, 0)));
+}
+
+GTEST_TEST(FrameKinematicsVector, InitializerListAssign) {
+  const auto& id_0 = FrameId::get_new_id();
+  const Isometry3<double> pose_0 = Isometry3<double>::Identity();
+  const auto& id_1 = FrameId::get_new_id();
+  const Isometry3<double> pose_1 =
+      math::RigidTransformd{Eigen::Translation3d(0.1, 0.2, 0.3)}.
+          GetAsIsometry3();
+
+  // Start with a non-empty dut, so we confirm that assignment replaces all of
+  // the existing values.  (An STL map insert defaults to a no-op when the key
+  // exists already; we don't want that!)
+  FramePoseVector<double> dut{{id_1, Isometry3<double>::Identity()}};
+  dut = {{id_0, pose_0}, {id_1, pose_1}};
+  ASSERT_EQ(dut.size(), 2);
+  EXPECT_TRUE(dut.has_id(id_0));
+  EXPECT_TRUE(dut.has_id(id_1));
+  EXPECT_FALSE(dut.has_id(FrameId::get_new_id()));
+  EXPECT_TRUE(ExpectExactIdentity(dut.value(id_0)));
+  EXPECT_TRUE(CompareMatrices(
+      dut.value(id_1).matrix().block<3, 4>(0, 0),
+      pose_1.matrix().block<3, 4>(0, 0)));
+
+  dut = {};
+  ASSERT_EQ(dut.size(), 0);
+}
 
 GTEST_TEST(FrameKinematicsVector, WorkingWithValues) {
-  SourceId source_id = SourceId::get_new_id();
   int kPoseCount = 3;
   std::vector<FrameId> ids;
   for (int i = 0; i < kPoseCount; ++i) ids.push_back(FrameId::get_new_id());
-  FramePoseVector<double> poses(source_id, ids);
+  FramePoseVector<double> poses;
 
-  // Forgot to call clear.
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      poses.set_value(ids[0], Isometry3<double>::Identity()),
-      std::runtime_error,
-      "Trying to set kinematics value for the same id .* multiple "
-          "times. Did you forget to call clear.*?");
-
-  poses.clear();
   std::vector<Isometry3<double>> recorded_poses;
   for (int i = 0; i < kPoseCount; ++i) {
     Isometry3<double> pose = Isometry3<double>::Identity();
@@ -78,22 +122,25 @@ GTEST_TEST(FrameKinematicsVector, WorkingWithValues) {
     EXPECT_NO_THROW(poses.set_value(ids[i], pose));
   }
 
-  // Set valid id multiple times.
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      poses.set_value(ids[0], Isometry3<double>::Identity()),
-      std::runtime_error,
-      "Trying to set kinematics value for the same id .* multiple "
-          "times. Did you forget to call clear.*?");
-
-  // Set invalid id.
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      poses.set_value(FrameId::get_new_id(), Isometry3<double>::Identity()),
-      std::runtime_error,
-      "Trying to set a kinematics value for a frame id that does not belong "
-          "to the kinematics vector: \\d+");
-
   // Confirm that poses get recorded properly.
   for (int i = 0; i < kPoseCount; ++i) {
+    EXPECT_TRUE(poses.has_id(ids[i]));
+    const Isometry3<double>& pose = poses.value(ids[i]);
+    EXPECT_TRUE(CompareMatrices(pose.matrix(), recorded_poses[i].matrix()));
+  }
+
+  // Confirm that poses get cleared properly.
+  poses.clear();
+  EXPECT_EQ(poses.size(), 0);
+  EXPECT_FALSE(poses.has_id(ids[0]));
+
+  // Confirm that poses get re-established properly.
+  std::reverse(recorded_poses.begin(), recorded_poses.end());
+  for (int i = 0; i < kPoseCount; ++i) {
+    EXPECT_NO_THROW(poses.set_value(ids[i], recorded_poses[i]));
+  }
+  for (int i = 0; i < kPoseCount; ++i) {
+    EXPECT_TRUE(poses.has_id(ids[i]));
     const Isometry3<double>& pose = poses.value(ids[i]);
     EXPECT_TRUE(CompareMatrices(pose.matrix(), recorded_poses[i].matrix()));
   }
@@ -101,35 +148,23 @@ GTEST_TEST(FrameKinematicsVector, WorkingWithValues) {
   // Ask for the pose of an id that does not belong to the set.
   DRAKE_EXPECT_THROWS_MESSAGE(poses.value(FrameId::get_new_id()),
                               std::runtime_error,
-                              "Can't acquire value for id \\d+. It is not part "
-                              "of the kinematics data id set.");
+                              "No such FrameId \\d+.");
 }
 
 GTEST_TEST(FrameKinematicsVector, AutoDiffInstantiation) {
-  SourceId source_id = SourceId::get_new_id();
-  std::vector<FrameId> ids{FrameId::get_new_id(), FrameId::get_new_id()};
-  const int kCount = static_cast<int>(ids.size());
-  FramePoseVector<AutoDiffXd> poses(source_id, ids);
-
-  EXPECT_EQ(poses.source_id(), source_id);
-  EXPECT_EQ(poses.size(), kCount);
+  FramePoseVector<AutoDiffXd> poses;
+  poses.set_value(FrameId::get_new_id(), Isometry3<AutoDiffXd>::Identity());
+  EXPECT_EQ(poses.size(), 1);
 }
 
 GTEST_TEST(FrameKinematicsVector, SymbolicInstantiation) {
   using symbolic::Expression;
   using symbolic::Variable;
 
-  SourceId source_id = SourceId::get_new_id();
   std::vector<FrameId> ids{FrameId::get_new_id(), FrameId::get_new_id()};
-  const int kCount = static_cast<int>(ids.size());
-  FramePoseVector<Expression> poses(source_id, ids);
-
-  EXPECT_EQ(poses.source_id(), source_id);
-  EXPECT_EQ(poses.size(), kCount);
+  FramePoseVector<Expression> poses;
 
   // Set and retrieve a simple symbolic::Expression.
-  poses.clear();
-
   poses.set_value(ids[0], Isometry3<Expression>::Identity());
 
   const Variable var_x_{"x"};
@@ -149,11 +184,12 @@ GTEST_TEST(FrameKinematicsVector, SymbolicInstantiation) {
 }
 
 GTEST_TEST(FrameKinematicsVector, FrameIdRange) {
-  SourceId source_id = SourceId::get_new_id();
-  int kPoseCount = 3;
+  FramePoseVector<double> poses;
   std::vector<FrameId> ids;
-  for (int i = 0; i < kPoseCount; ++i) ids.push_back(FrameId::get_new_id());
-  FramePoseVector<double> poses(source_id, ids);
+  for (int i = 0; i < 3; ++i) {
+    ids.push_back(FrameId::get_new_id());
+    poses.set_value(ids.back(), Isometry3<double>::Identity());
+  }
 
   std::set<FrameId> actual_ids;
   for (FrameId id : poses.frame_ids()) actual_ids.insert(id);

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -413,11 +413,7 @@ class GeometrySourceSystem : public systems::LeafSystem<double> {
     frame_ids_.push_back(f_id);
 
     // Set up output port now that the frame is registered.
-    std::vector<FrameId> all_ids{f_id};
-    all_ids.insert(all_ids.end(), extra_frame_ids_.begin(),
-                   extra_frame_ids_.end());
     this->DeclareAbstractOutputPort(
-        FramePoseVector<double>(source_id_, all_ids),
         &GeometrySourceSystem::CalcFramePoseOutput);
   }
   SourceId get_source_id() const { return source_id_; }
@@ -440,11 +436,6 @@ class GeometrySourceSystem : public systems::LeafSystem<double> {
   // Populate with the pose data.
   void CalcFramePoseOutput(const Context<double>& context,
                            FramePoseVector<double>* poses) const {
-    const int frame_count =
-        static_cast<int>(frame_ids_.size() + extra_frame_ids_.size());
-    DRAKE_DEMAND(poses->size() == frame_count);
-    DRAKE_DEMAND(poses->source_id() == source_id_);
-
     poses->clear();
 
     const int base_count = static_cast<int>(frame_ids_.size());
@@ -597,9 +588,9 @@ GTEST_TEST(SceneGraphVisualizationTest, NoWorldInPoseVector) {
     // bundle.
     EXPECT_EQ(0, poses.get_num_poses());
     auto context = scene_graph.AllocateContext();
-    FramePoseVector<double> pose_vector(s_id, {f_id});
-    context->FixInputPort(scene_graph.get_source_pose_port(s_id).get_index(),
-                          Value<FramePoseVector<double>>(pose_vector));
+    const FramePoseVector<double> pose_vector{{
+        f_id, Isometry3<double>::Identity()}};
+    scene_graph.get_source_pose_port(s_id).FixValue(context.get(), pose_vector);
     EXPECT_NO_THROW(
         SceneGraphTester::CalcPoseBundle(scene_graph, *context, &poses));
   }
@@ -623,9 +614,9 @@ GTEST_TEST(SceneGraphVisualizationTest, NoWorldInPoseVector) {
     // frame to be included in the bundle.
     EXPECT_EQ(0, poses.get_num_poses());
     auto context = scene_graph.AllocateContext();
-    FramePoseVector<double> pose_vector(s_id, {f_id});
-    context->FixInputPort(scene_graph.get_source_pose_port(s_id).get_index(),
-                          Value<FramePoseVector<double>>(pose_vector));
+    const FramePoseVector<double> pose_vector{{
+        f_id, Isometry3<double>::Identity()}};
+    scene_graph.get_source_pose_port(s_id).FixValue(context.get(), pose_vector);
     EXPECT_NO_THROW(SceneGraphTester::CalcPoseBundle(scene_graph, *context,
                                                      &poses));
   }

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -686,11 +686,10 @@ TEST_F(AcrobotPlantTests, VisualGeometryRegistration) {
   EXPECT_NO_THROW(poses_value->get_value<FramePoseVector<double>>());
   const FramePoseVector<double>& poses =
       poses_value->get_value<FramePoseVector<double>>();
-  EXPECT_EQ(poses.source_id(), plant_->get_source_id());
-  EXPECT_EQ(poses.size(), 2);  // Only two frames move.
 
   // Compute the poses for each geometry in the model.
   plant_->get_geometry_poses_output_port().Calc(*context, poses_value.get());
+  EXPECT_EQ(poses.size(), 2);  // Only two frames move.
 
   const FrameId world_frame_id =
       plant_->GetBodyFrameIdOrThrow(plant_->world_body().index());
@@ -1170,11 +1169,10 @@ GTEST_TEST(MultibodyPlantTest, CollisionGeometryRegistration) {
   EXPECT_NO_THROW(poses_value->get_value<FramePoseVector<double>>());
   const FramePoseVector<double>& pose_data =
       poses_value->get_value<FramePoseVector<double>>();
-  EXPECT_EQ(pose_data.source_id(), plant.get_source_id());
-  EXPECT_EQ(pose_data.size(), 2);  // Only two frames move.
 
   // Compute the poses for each geometry in the model.
   plant.get_geometry_poses_output_port().Calc(*context, poses_value.get());
+  EXPECT_EQ(pose_data.size(), 2);  // Only two frames move.
 
   const double kTolerance = 5 * std::numeric_limits<double>::epsilon();
   for (BodyIndex body_index(1);

--- a/systems/rendering/render_pose_to_geometry_pose.cc
+++ b/systems/rendering/render_pose_to_geometry_pose.cc
@@ -22,16 +22,13 @@ RenderPoseToGeometryPose<T>::RenderPoseToGeometryPose(
   using Output = geometry::FramePoseVector<T>;
   this->DeclareVectorInputPort(Input{});
   this->DeclareAbstractOutputPort(
-      [source_id, frame_id]() {
-        const std::vector<FrameId> frame_ids{frame_id};
-        const Output result(source_id, frame_ids);
-        return Value<Output>::Make(result);
+      []() {
+        return Value<Output>{}.Clone();
       },
       [this, frame_id](const Context<T>& context, AbstractValue* calculated) {
         const Input& input = get_input_port().template Eval<Input>(context);
-        Output& output = calculated->get_mutable_value<Output>();
-        output.clear();
-        output.set_value(frame_id, input.get_isometry());
+        calculated->get_mutable_value<Output>() =
+            {{frame_id, input.get_isometry()}};
       });
 }
 

--- a/systems/rendering/test/multibody_position_to_geometry_pose_test.cc
+++ b/systems/rendering/test/multibody_position_to_geometry_pose_test.cc
@@ -35,7 +35,6 @@ GTEST_TEST(MultibodyPositionToGeometryPoseTest, InputOutput) {
 
   const auto& output =
       dut.get_output_port().Eval<geometry::FramePoseVector<double>>(*context);
-  EXPECT_EQ(output.source_id(), mbp.get_source_id());
   for (multibody::BodyIndex i(0); i < mbp.num_bodies(); i++) {
     if (i == mbp.world_body().index()) {
       // The world geometry will not appear in the poses.

--- a/systems/rendering/test/render_pose_to_geometry_pose_test.cc
+++ b/systems/rendering/test/render_pose_to_geometry_pose_test.cc
@@ -26,7 +26,6 @@ GTEST_TEST(RenderPoseToGeometryPoseTest, InputOutput) {
   const auto& output =
       dut.get_output_port().Eval<geometry::FramePoseVector<double>>(
           *context);
-  EXPECT_EQ(output.source_id(), source_id);
   EXPECT_EQ(output.size(), 1);
   ASSERT_TRUE(output.has_id(frame_id));
   EXPECT_TRUE(CompareMatrices(

--- a/systems/sensors/test/optitrack_sender_test.cc
+++ b/systems/sensors/test/optitrack_sender_test.cc
@@ -18,7 +18,6 @@ using optitrack::optitrack_frame_t;
 // ensures that the TrackedBody input to the OptitrackLcmFrameSender system
 // matches the output `optitrack_frame_t` object.
 GTEST_TEST(OptitrackSenderTest, OptitrackLcmSenderTest) {
-  geometry::SourceId source_id = geometry::SourceId::get_new_id();
   geometry::FrameId frame_id = geometry::FrameId::get_new_id();
   std::vector<geometry::FrameId> frame_ids{frame_id};
   int optitrack_id = 11;
@@ -28,18 +27,16 @@ GTEST_TEST(OptitrackSenderTest, OptitrackLcmSenderTest) {
       "test_body", optitrack_id);
   OptitrackLcmFrameSender dut(frame_map);
 
-  geometry::FramePoseVector<double> pose_vector(source_id, frame_ids);
-  pose_vector.clear();
-
   constexpr double tx = 0.2;  // x-translation for the test object
   constexpr double ty = 0.4;  // y-translation for the test object
   constexpr double tz = 0.7;  // z-translation for the test object
 
   // Sets up a test body with an arbitrarily chosen pose.
   Eigen::Vector3d axis(1 / sqrt(3), 1 / sqrt(3), 1 / sqrt(3));
-  pose_vector.set_value(frame_id,
-                        Eigen::Isometry3d(Eigen::AngleAxis<double>(0.2, axis)).
-                        pretranslate(Eigen::Vector3d(tx, ty, tz)));
+  const geometry::FramePoseVector<double> pose_vector{{
+      frame_id,
+      Eigen::Isometry3d(Eigen::AngleAxis<double>(0.2, axis)).
+          pretranslate(Eigen::Vector3d(tx, ty, tz))}};
 
   EXPECT_EQ(pose_vector.value(frame_id).translation()[0], tx);
   EXPECT_EQ(pose_vector.value(frame_id).translation()[1], ty);


### PR DESCRIPTION
The required call pattern ceremony is difficult to get right when writing systems that produce frames:
1. The FlaggedValue (serial numbering) is awkward for output ports to provide, and unlikely to catch real bugs.
    - If we want to catch reuse-without-set bugs, then the framework should do that on its own -- in Debug builds, Eval could reset every Calc's output pointer to the default value prior to calling Calc.
2. The IDs can be checked by the SceneGraph based solely on the FrameId.  Requiring that callers copy the SourceId into the output port's value is useless and painful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11302)
<!-- Reviewable:end -->
