### PR TITLE
geometry: Stop overriding DoHasDirectFeedthrough

### DIFF
--- a/geometry/dev/scene_graph.h
+++ b/geometry/dev/scene_graph.h
@@ -535,14 +535,6 @@ class SceneGraph final : public systems::LeafSystem<T> {
   // evaluate inputs on the context.
   friend class QueryObject<T>;
 
-  // The two output ports (bundle and query object) depend on all input
-  // kinematics (more or less). This makes those relationships concrete and
-  // official even if/when this class is made symbolic-compatible (or the
-  // default non-symbolic-compatible behavior were to change).
-  optional<bool> DoHasDirectFeedthrough(int, int) const override {
-    return true;
-  }
-
   // Helper class to register input ports for a source id.
   void MakeSourcePorts(SourceId source_id);
 

--- a/geometry/dev/test/scene_graph_test.cc
+++ b/geometry/dev/test/scene_graph_test.cc
@@ -60,13 +60,6 @@ class SceneGraphTester {
   SceneGraphTester() = delete;
 
   template <typename T>
-  static bool HasDirectFeedthrough(const SceneGraph<T>& scene_graph,
-                                   int input_port, int output_port) {
-    return scene_graph.DoHasDirectFeedthrough(input_port, output_port)
-        .value_or(true);
-  }
-
-  template <typename T>
   static void FullPoseUpdate(const SceneGraph<T>& scene_graph,
                              const GeometryContext<T>& context) {
     scene_graph.FullPoseUpdate(context);
@@ -258,16 +251,10 @@ TEST_F(SceneGraphTest, TopologyAfterAllocation) {
 // Confirms that the direct feedthrough logic is correct -- there is total
 // direct feedthrough.
 TEST_F(SceneGraphTest, DirectFeedThrough) {
-  SourceId id = scene_graph_.RegisterSource();
-  std::vector<int> input_ports{
-      scene_graph_.get_source_pose_port(id).get_index()};
-  for (int input_port_id : input_ports) {
-    EXPECT_TRUE(SceneGraphTester::HasDirectFeedthrough(
-        scene_graph_, input_port_id,
-        scene_graph_.get_query_output_port().get_index()));
-  }
-  // TODO(SeanCurtis-TRI): Update when the pose bundle output is added; it has
-  // direct feedthrough as well.
+  scene_graph_.RegisterSource();
+  EXPECT_EQ(scene_graph_.GetDirectFeedthroughs().size(),
+            scene_graph_.num_input_ports() *
+                scene_graph_.num_output_ports());
 }
 
 // Test the functionality that accumulates the values from the input ports.

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -599,14 +599,6 @@ class SceneGraph final : public systems::LeafSystem<T> {
   // evaluate inputs on the context.
   friend class QueryObject<T>;
 
-  // The two output ports (bundle and query object) depend on all input
-  // kinematics (more or less). This makes those relationships concrete and
-  // official even if/when this class is made symbolic-compatible (or the
-  // default non-symbolic-compatible behavior were to change).
-  optional<bool> DoHasDirectFeedthrough(int, int) const override {
-    return true;
-  }
-
   // Helper class to register input ports for a source id.
   void MakeSourcePorts(SourceId source_id);
 

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -58,13 +58,6 @@ class SceneGraphTester {
   SceneGraphTester() = delete;
 
   template <typename T>
-  static bool HasDirectFeedthrough(const SceneGraph<T>& scene_graph,
-                                   int input_port, int output_port) {
-    return scene_graph.DoHasDirectFeedthrough(input_port, output_port)
-        .value_or(true);
-  }
-
-  template <typename T>
   static void FullPoseUpdate(const SceneGraph<T>& scene_graph,
                              const GeometryContext<T>& context) {
     scene_graph.FullPoseUpdate(context);
@@ -267,16 +260,10 @@ TEST_F(SceneGraphTest, TopologyAfterAllocation) {
 // Confirms that the direct feedthrough logic is correct -- there is total
 // direct feedthrough.
 TEST_F(SceneGraphTest, DirectFeedThrough) {
-  SourceId id = scene_graph_.RegisterSource();
-  std::vector<int> input_ports{
-      scene_graph_.get_source_pose_port(id).get_index()};
-  for (int input_port_id : input_ports) {
-    EXPECT_TRUE(SceneGraphTester::HasDirectFeedthrough(
-        scene_graph_, input_port_id,
-        scene_graph_.get_query_output_port().get_index()));
-  }
-  // TODO(SeanCurtis-TRI): Update when the pose bundle output is added; it has
-  // direct feedthrough as well.
+  scene_graph_.RegisterSource();
+  EXPECT_EQ(scene_graph_.GetDirectFeedthroughs().size(),
+            scene_graph_.num_input_ports() *
+                scene_graph_.num_output_ports());
 }
 
 // Test the functionality that accumulates the values from the input ports.

--- a/systems/rendering/multibody_position_to_geometry_pose.h
+++ b/systems/rendering/multibody_position_to_geometry_pose.h
@@ -60,8 +60,6 @@ class MultibodyPositionToGeometryPose final : public LeafSystem<T> {
   }
 
  private:
-  optional<bool> DoHasDirectFeedthrough(int, int) const final { return true; }
-
   void CalcGeometryPose(const Context<T>& context, AbstractValue* poses) const;
 
   const multibody::MultibodyPlant<T>& plant_;

--- a/systems/rendering/render_pose_to_geometry_pose.h
+++ b/systems/rendering/render_pose_to_geometry_pose.h
@@ -38,10 +38,6 @@ class RenderPoseToGeometryPose final : public LeafSystem<T> {
   // Allow different specializations to access each other's private data.
   template <typename> friend class RenderPoseToGeometryPose;
 
-  optional<bool> DoHasDirectFeedthrough(int, int) const final {
-    return true;
-  }
-
   const geometry::SourceId source_id_;
   const geometry::FrameId frame_id_;
 };

--- a/systems/rendering/test/render_pose_to_geometry_pose_test.cc
+++ b/systems/rendering/test/render_pose_to_geometry_pose_test.cc
@@ -32,10 +32,7 @@ GTEST_TEST(RenderPoseToGeometryPoseTest, InputOutput) {
   EXPECT_TRUE(CompareMatrices(
       output.value(frame_id).matrix(),
       input.get_isometry().matrix()));
-}
 
-GTEST_TEST(RenderPoseToGeometryPoseTest, DirectFeedthrough) {
-  const RenderPoseToGeometryPose<double> dut({}, {});
   EXPECT_TRUE(dut.HasAnyDirectFeedthrough());
 }
 


### PR DESCRIPTION
`DoHasDirectFeedthrough` will be deprecated; using `Calc` declaration prereqs is the new preferred mechanism.  Since SceneGraph (etc.) were just returning `true` all the time for no apparent reason, we can just purge all of the overrides, instead.  The default is `true` already.

This is a prerequisite for #11298.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11305)
<!-- Reviewable:end -->
