### PR TITLE
systems: Stop overriding DoHasDirectFeedthrough

### DIFF
--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -246,7 +246,9 @@ struct Impl {
    public:
     using Base = VectorSystem<T>;
 
-    VectorSystemPublic(int inputs, int outputs) : Base(inputs, outputs) {}
+    VectorSystemPublic(
+        int input_size, int output_size, optional<bool> direct_feedthrough)
+        : Base(input_size, output_size, direct_feedthrough) {}
 
     using Base::EvalVectorInput;
     using Base::GetVectorState;
@@ -708,10 +710,14 @@ Note: The above is for the C++ documentation. For Python, use
     // we're already abusing Python and C++ enough.
     DefineTemplateClassWithDefault<VectorSystem<T>, PyVectorSystem,
         LeafSystem<T>>(m, "VectorSystem", GetPyParam<T>(), doc.VectorSystem.doc)
-        .def(py::init([](int inputs, int outputs) {
-          return new PyVectorSystem(inputs, outputs);
+        .def(py::init([](int input_size, int output_size,
+                          optional<bool> direct_feedthrough) {
+          return new PyVectorSystem(
+              input_size, output_size, direct_feedthrough);
         }),
-            doc.VectorSystem.ctor.doc_2args);
+            py::arg("input_size"), py::arg("output_size"),
+            py::arg("direct_feedthrough") = nullopt,
+            doc.VectorSystem.ctor.doc_3args);
     // TODO(eric.cousineau): Bind virtual methods once we provide a function
     // wrapper to convert `Map<Derived>*` arguments.
     // N.B. This could be mitigated by using `EigenPtr` in public interfaces in

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -104,7 +104,7 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
     std::multimap<int, int> pairs;
     for (InputPortIndex u(0); u < this->num_input_ports(); ++u) {
       for (OutputPortIndex v(0); v < this->num_output_ports(); ++v) {
-        if (DoHasDirectFeedthrough(u, v)) {
+        if (DiagramHasDirectFeedthrough(u, v)) {
           pairs.emplace(u, v);
         }
       }
@@ -1060,7 +1060,7 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
 
   // Returns true if there might be direct feedthrough from the given
   // @p input_port of the Diagram to the given @p output_port of the Diagram.
-  bool DoHasDirectFeedthrough(int input_port, int output_port) const {
+  bool DiagramHasDirectFeedthrough(int input_port, int output_port) const {
     DRAKE_ASSERT(input_port >= 0);
     DRAKE_ASSERT(input_port < this->num_input_ports());
     DRAKE_ASSERT(output_port >= 0);

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -1369,10 +1369,12 @@ TEST_F(DiagramTest, SubclassTransmogrificationTest) {
 class Reduce : public LeafSystem<double> {
  public:
   Reduce() {
-    feedthrough_input_ = this->DeclareInputPort(kVectorValued, 1).get_index();
+    const auto& input0 = this->DeclareInputPort(kVectorValued, 1);
+    feedthrough_input_ = input0.get_index();
     sink_input_ = this->DeclareInputPort(kVectorValued, 1).get_index();
     this->DeclareVectorOutputPort(BasicVector<double>(1),
-                                  &Reduce::CalcFeedthrough);
+                                  &Reduce::CalcFeedthrough,
+                                  {input0.ticket()});
   }
 
   const systems::InputPort<double>& get_sink_input() const {
@@ -1387,10 +1389,6 @@ class Reduce : public LeafSystem<double> {
                        BasicVector<double>* output) const {
     const auto& input = get_feedthrough_input().Eval(context);
     output->get_mutable_value() = input;
-  }
-
-  optional<bool> DoHasDirectFeedthrough(int input_port, int) const override {
-    return input_port == feedthrough_input_;
   }
 
  private:

--- a/systems/framework/test/vector_system_test.cc
+++ b/systems/framework/test/vector_system_test.cc
@@ -346,11 +346,9 @@ TEST_F(VectorSystemTest, DiscreteVariableUpdates) {
 
 class NoFeedthroughContinuousTimeSystem : public VectorSystem<double> {
  public:
-  NoFeedthroughContinuousTimeSystem() : VectorSystem<double>(1, 1) {
+  NoFeedthroughContinuousTimeSystem() : VectorSystem<double>(1, 1, false) {
     this->DeclareContinuousState(1);
   }
-
-  optional<bool> DoHasDirectFeedthrough(int, int) const final { return false; }
 
  private:
   void DoCalcVectorOutput(

--- a/systems/primitives/pass_through.h
+++ b/systems/primitives/pass_through.h
@@ -99,10 +99,6 @@ class PassThrough final : public LeafSystem<T> {
       const Context<T>& context,
       AbstractValue* output) const;
 
-  // Override feedthrough detection to avoid the need for `DoToSymbolic()`.
-  optional<bool> DoHasDirectFeedthrough(
-      int input_port, int output_port) const final;
-
   bool is_abstract() const { return abstract_model_value_ != nullptr; }
 
   const std::unique_ptr<const AbstractValue> abstract_model_value_;
@@ -166,16 +162,6 @@ void PassThrough<T>::DoCalcAbstractOutput(const Context<T>& context,
                                           AbstractValue* output) const {
   DRAKE_ASSERT(is_abstract());
   output->SetFrom(this->get_input_port().template Eval<AbstractValue>(context));
-}
-
-template <typename T>
-optional<bool> PassThrough<T>::DoHasDirectFeedthrough(
-    int input_port, int output_port) const {
-  DRAKE_DEMAND(input_port == 0);
-  DRAKE_DEMAND(output_port == 0);
-  // By definition, a pass-through will have direct feedthrough, as the
-  // output depends directly on the input.
-  return true;
 }
 
 }  // namespace systems

--- a/systems/primitives/symbolic_vector_system.cc
+++ b/systems/primitives/symbolic_vector_system.cc
@@ -82,19 +82,6 @@ SymbolicVectorSystem<T>::SymbolicVectorSystem(
 }
 
 template <typename T>
-optional<bool> SymbolicVectorSystem<T>::DoHasDirectFeedthrough(
-    int input_port, int output_port) const {
-  DRAKE_DEMAND(input_port == 0);
-  DRAKE_DEMAND(output_port == 0);
-  for (int i = 0; i <= output_.size(); i++) {
-    for (int j = 0; j <= input_vars_.size(); j++) {
-      if (output_[i].GetVariables().include(input_vars_[j])) return true;
-    }
-  }
-  return false;
-}
-
-template <typename T>
 template <typename Container>
 void SymbolicVectorSystem<T>::PopulateFromContext(const Context<T>& context,
                                                   Container* penv) const {

--- a/systems/primitives/symbolic_vector_system.h
+++ b/systems/primitives/symbolic_vector_system.h
@@ -99,10 +99,6 @@ class SymbolicVectorSystem final : public LeafSystem<T> {
   }
 
  private:
-  // Override feedthrough detection to avoid the need for `DoToSymbolic()`.
-  optional<bool> DoHasDirectFeedthrough(int input_port,
-                                        int output_port) const final;
-
   template <typename Container>
   void PopulateFromContext(const Context<T>& context, Container* penv) const;
 

--- a/systems/primitives/test/symbolic_vector_system_test.cc
+++ b/systems/primitives/test/symbolic_vector_system_test.cc
@@ -110,6 +110,7 @@ GTEST_TEST(SymbolicVectorSystemTest, ScalarPassThrough) {
   EXPECT_TRUE(context->is_stateless());
   EXPECT_EQ(system.get_input_port().size(), 1);
   EXPECT_EQ(system.get_output_port().size(), 1);
+  EXPECT_TRUE(system.HasDirectFeedthrough(0, 0));
 
   context->FixInputPort(0, Vector1d{0.12});
   EXPECT_TRUE(CompareMatrices(system.get_output_port()
@@ -193,6 +194,19 @@ GTEST_TEST(SymbolicVectorSystemTest, DiscreteStateOnly) {
   system.CalcDiscreteVariableUpdates(*context, discrete_variables.get());
   EXPECT_TRUE(CompareMatrices(discrete_variables->get_vector().get_value(),
                               Vector1d{-xval + xval * xval * xval}));
+}
+
+GTEST_TEST(SymbolicVectorSystemTest, IntegratorNoFeedthrough) {
+  Variable x{"x"};
+  Variable u{"u"};
+  auto system = SymbolicVectorSystemBuilder()
+                    .state(Vector1<Variable>{x})
+                    .input(Vector1<Variable>{u})
+                    .dynamics(Vector1<Expression>{u})
+                    .output(Vector1<Expression>{x})
+                    .Build<Expression>();
+
+  EXPECT_FALSE(system->HasDirectFeedthrough(0, 0));
 }
 
 GTEST_TEST(SymbolicVectorSystemTest, ContinuousTimeSymbolic) {


### PR DESCRIPTION
`DoHasDirectFeedthrough` will be deprecated; using `Calc` declaration prereqs is the new preferred mechanism.

This is ideally a prerequisite for #11298, though can be worked around if necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11306)
<!-- Reviewable:end -->
