### PR TITLE
Enhance RigidTransform class so operator* can multiply n position vectors

### DIFF
--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -476,6 +476,7 @@ drake_cc_googletest(
     name = "rigid_transform_test",
     deps = [
         ":geometric_transform",
+        "//common/test_utilities",
     ],
 )
 

--- a/math/rigid_transform.h
+++ b/math/rigid_transform.h
@@ -384,6 +384,10 @@ class RigidTransform {
   template <typename Derived>
   Eigen::Matrix<typename Derived::Scalar, 3, Derived::ColsAtCompileTime>
   operator*(const Eigen::MatrixBase<Derived>& p_BoQ_B) const {
+    if (p_BoQ_B.rows() != 3) {
+      throw std::logic_error(
+          "Error: Inner dimension for matrix multiplication is not 3.");
+    }
     const int number_of_position_vectors = p_BoQ_B.cols();
     Eigen::Matrix<typename Derived::Scalar, 3, Derived::ColsAtCompileTime>
         p_AoQ_A(3, number_of_position_vectors);

--- a/math/rigid_transform.h
+++ b/math/rigid_transform.h
@@ -381,6 +381,14 @@ class RigidTransform {
   /// @param[in] p_BoQ_B `3 x n` matrix with n position vectors `p_BoQi_B`.
   /// @retval p_AoQ_A `3 x n` matrix with n position vectors `p_AoQi_A`, i.e., n
   /// position vectors from Ao (frame A's origin) to Qi, expressed in frame A.
+  /// @code{.cc}
+  /// const RollPitchYaw<double> rpy(0.1, 0.2, 0.3);
+  /// const RigidTransform<double> X_AB(rpy, Vector3d(1, 2, 3));
+  /// Eigen::Matrix<double, 3, 2> p_BoQ_B;
+  /// p_BoQ_B.col(0) = Vector3d(4, 5, 6);
+  /// p_BoQ_B.col(1) = Vector3d(9, 8, 7);
+  /// const Eigen::Matrix<double, 3, 2> p_AoQ_A = X_AB * p_BoQ_B;
+  /// @endcode
   template <typename Derived>
   Eigen::Matrix<typename Derived::Scalar, 3, Derived::ColsAtCompileTime>
   operator*(const Eigen::MatrixBase<Derived>& p_BoQ_B) const {
@@ -388,13 +396,20 @@ class RigidTransform {
       throw std::logic_error(
           "Error: Inner dimension for matrix multiplication is not 3.");
     }
+    // Express position vectors in terms of frame A as p_BoQ_A = R_AB * p_BoQ_B.
+    const RotationMatrix<typename Derived::Scalar> &R_AB = rotation();
+    const Eigen::Matrix<typename Derived::Scalar, 3, Derived::ColsAtCompileTime>
+        p_BoQ_A = R_AB.matrix() * p_BoQ_B;
+
+    // Reserve space (on stack on heap) to store the result.
     const int number_of_position_vectors = p_BoQ_B.cols();
     Eigen::Matrix<typename Derived::Scalar, 3, Derived::ColsAtCompileTime>
         p_AoQ_A(3, number_of_position_vectors);
-    for (int i = 0;  i < number_of_position_vectors;  ++i) {
-      const Vector3<typename Derived::Scalar>& p_BoQi_B = p_BoQ_B.col(i);
-      p_AoQ_A.col(i) = *this * p_BoQi_B;
-    }
+
+    // Create each returned position vector as p_AoQi_A = p_AoBo_A + p_BoQi_A.
+    for (int i = 0;  i < number_of_position_vectors;  ++i)
+      p_AoQ_A.col(i) = translation() + p_BoQ_A.col(i);
+
     return p_AoQ_A;
   }
 

--- a/math/rigid_transform.h
+++ b/math/rigid_transform.h
@@ -122,7 +122,7 @@ class RigidTransform {
   }
 
   /// Constructs a %RigidTransform with an identity RotationMatrix and a given
-  /// position vector 'p'.
+  /// position vector `p`.
   /// @param[in] p position vector from frame A's origin to frame B's origin,
   /// expressed in frame A.  In monogram notation p is denoted `p_AoBo_A`.
   explicit RigidTransform(const Vector3<T>& p) { set_translation(p); }
@@ -368,7 +368,7 @@ class RigidTransform {
   }
 
   /// Multiplies `this` %RigidTransform `X_AB` by the position vector
-  /// 'p_BoQ_B` which is from Bo (B's origin) to an arbitrary point Q.
+  /// `p_BoQ_B` which is from Bo (B's origin) to an arbitrary point Q.
   /// @param[in] p_BoQ_B position vector from Bo to Q, expressed in frame B.
   /// @retval p_AoQ_A position vector from Ao to Q, expressed in frame A.
   Vector3<T> operator*(const Vector3<T>& p_BoQ_B) const {
@@ -376,7 +376,7 @@ class RigidTransform {
   }
 
   /// Multiplies `this` %RigidTransform `X_AB` by the n position vectors
-  /// 'p_BoQ1_B` ... `p_BoQn_B`, where `p_BoQi_B` is the iᵗʰ position vector
+  /// `p_BoQ1_B` ... `p_BoQn_B`, where `p_BoQi_B` is the iᵗʰ position vector
   /// from Bo (frame B's origin) to an arbitrary point Qi, expressed in frame B.
   /// @param[in] p_BoQ_B `3 x n` matrix with n position vectors `p_BoQi_B`.
   /// @retval p_AoQ_A `3 x n` matrix with n position vectors `p_AoQi_A`, i.e., n

--- a/math/rigid_transform.h
+++ b/math/rigid_transform.h
@@ -367,12 +367,31 @@ class RigidTransform {
     return RigidTransform<T>(R_AB, p_AB_A);
   }
 
-  /// Calculates `this` %RigidTransform `X_AB` multiplied by the position vector
+  /// Multiplies `this` %RigidTransform `X_AB` by the position vector
   /// 'p_BoQ_B` which is from Bo (B's origin) to an arbitrary point Q.
   /// @param[in] p_BoQ_B position vector from Bo to Q, expressed in frame B.
   /// @retval p_AoQ_A position vector from Ao to Q, expressed in frame A.
   Vector3<T> operator*(const Vector3<T>& p_BoQ_B) const {
     return p_AoBo_A_ + R_AB_ * p_BoQ_B;
+  }
+
+  /// Multiplies `this` %RigidTransform `X_AB` by the n position vectors
+  /// 'p_BoQ1_B` ... `p_BoQn_B`, where `p_BoQi_B` is the iᵗʰ position vector
+  /// from Bo (frame B's origin) to an arbitrary point Qi, expressed in frame B.
+  /// @param[in] p_BoQ_B `3 x n` matrix with n position vectors `p_BoQi_B`.
+  /// @retval p_AoQ_A `3 x n` matrix with n position vectors `p_AoQi_A`, i.e., n
+  /// position vectors from Ao (frame A's origin) to Qi, expressed in frame A.
+  template <typename Derived>
+  Eigen::Matrix<typename Derived::Scalar, 3, Derived::ColsAtCompileTime>
+  operator*(const Eigen::MatrixBase<Derived>& p_BoQ_B) const {
+    const int number_of_position_vectors = p_BoQ_B.cols();
+    Eigen::Matrix<typename Derived::Scalar, 3, Derived::ColsAtCompileTime>
+        p_AoQ_A(3, number_of_position_vectors);
+    for (int i = 0;  i < number_of_position_vectors;  ++i) {
+      const Vector3<typename Derived::Scalar>& p_BoQi_B = p_BoQ_B.col(i);
+      p_AoQ_A.col(i) = *this * p_BoQi_B;
+    }
+    return p_AoQ_A;
   }
 
   /// Compares each element of `this` to the corresponding element of `other`

--- a/math/test/rigid_transform_test.cc
+++ b/math/test/rigid_transform_test.cc
@@ -581,7 +581,7 @@ GTEST_TEST(RigidTransform, OperatorMultiplyByMatrix3X) {
   EXPECT_EQ(p_AoP_A.cols(), number_of_position_vectors);
   for (int i = 0; i < number_of_position_vectors; ++i) {
     const Vector3d p_AoPi_A = p_AoP_A.col(i);
-    const Vector3d p_AoPi_A_expected = p_AoP_A.col(i); // Previous calculation.
+    const Vector3d p_AoPi_A_expected = p_AoP_A.col(i);  // Previous result.
     EXPECT_TRUE(CompareMatrices(p_AoPi_A, p_AoPi_A_expected, kEpsilon));
   }
 

--- a/math/test/rigid_transform_test.cc
+++ b/math/test/rigid_transform_test.cc
@@ -561,8 +561,14 @@ GTEST_TEST(RigidTransform, OperatorMultiplyByMatrix3X) {
 
   // Multiply a generic RigidTransform X_AB by n position vectors.  Verifies
   // operator* for 3 x n matrix, where n is not known before compilation.
-  const int number_of_position_vectors = 5;
+  constexpr int number_of_position_vectors = 5;
   Eigen::Matrix3Xd p_BoP_B(3, number_of_position_vectors);
+  p_BoP_B.col(0) = p_BoQ1_B;
+  p_BoP_B.col(1) = p_BoQ2_B;
+  p_BoP_B.col(2) = p_BoQ3_B;
+  p_BoP_B.col(3) = p_BoQ1_B;
+  p_BoP_B.col(4) = p_BoQ2_B;
+
   Eigen::Matrix3Xd p_AoP_A = X_AB * p_BoP_B;
   EXPECT_EQ(p_AoP_A.rows(), 3);
   EXPECT_EQ(p_AoP_A.cols(), number_of_position_vectors);
@@ -571,6 +577,17 @@ GTEST_TEST(RigidTransform, OperatorMultiplyByMatrix3X) {
     const Vector3d& p_AoPi_A = p_AoP_A.col(i);
     const Vector3d p_AoQi_A_expected = X_AB * p_BoPi_B;
     EXPECT_TRUE(p_AoPi_A.isApprox(p_AoQi_A_expected, kEpsilon));
+    if (i < 3) {
+      EXPECT_TRUE(p_AoPi_A.isApprox(p_AoQ_A.col(i), kEpsilon));
+    }
+  }
+
+  // Test that operator* disallows weirdly-sized matrix multiplication.
+  if (kDrakeAssertIsArmed) {
+    Eigen::MatrixXd m_7x8(7, 8);
+    m_7x8 = Eigen::MatrixXd::Identity(7, 8);
+    Eigen::MatrixXd bad_matrix_multiply;
+    EXPECT_THROW(bad_matrix_multiply = X_AB * m_7x8, std::logic_error);
   }
 }
 

--- a/math/test/rigid_transform_test.cc
+++ b/math/test/rigid_transform_test.cc
@@ -2,6 +2,8 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+
 namespace drake {
 namespace math {
 namespace {
@@ -544,43 +546,62 @@ GTEST_TEST(RigidTransform, OperatorMultiplyByTranslation3AndViceVersa) {
 // Qi, expressed in B.  The result is tested to be a 3 x n matrix whose columns
 // are position vectors from Ao (frame A's origin) to Qi, expressed in A.
 GTEST_TEST(RigidTransform, OperatorMultiplyByMatrix3X) {
+  // Create a generic RigidTransform having a rotation matrix whose elements are
+  // all non-zero elements and a position vector having all non-zero elements.
   const RigidTransform<double> X_AB = GetRigidTransformA();
 
-  // Multiply a generic RigidTransform X_AB by 3 position vectors.  Verifies
-  // operator* for 3 x n matrix, where n = 3 is known before compilation.
+  // Multiply the RigidTransform X_AB by 3 position vectors to test operator*
+  // for a 3 x n matrix, where n = 3 is known before compilation.
   Eigen::Matrix3d p_BoQ_B;
   const Vector3d p_BoQ1_B(-12, -9, 7);   p_BoQ_B.col(0) = p_BoQ1_B;
   const Vector3d p_BoQ2_B(-11, -8, 10);  p_BoQ_B.col(1) = p_BoQ2_B;
   const Vector3d p_BoQ3_B(-10, -7, 12);  p_BoQ_B.col(2) = p_BoQ3_B;
-  const Eigen::Matrix3d p_AoQ_A = X_AB * p_BoQ_B;
-  EXPECT_EQ(p_AoQ_A.rows(), 3);
-  EXPECT_EQ(p_AoQ_A.cols(), 3);
-  EXPECT_TRUE(p_AoQ_A.col(0).isApprox(X_AB * p_BoQ1_B, kEpsilon));
-  EXPECT_TRUE(p_AoQ_A.col(1).isApprox(X_AB * p_BoQ2_B, kEpsilon));
-  EXPECT_TRUE(p_AoQ_A.col(2).isApprox(X_AB * p_BoQ3_B, kEpsilon));
+  const auto p_AoQ_A = X_AB * p_BoQ_B;
 
-  // Multiply a generic RigidTransform X_AB by n position vectors.  Verifies
-  // operator* for 3 x n matrix, where n is not known before compilation.
-  constexpr int number_of_position_vectors = 5;
+  // Ensure the compiler's declared type for p_AoQ_A has the proper number of
+  // rows and columns before compilation.  Then verify the results.
+  EXPECT_EQ(decltype(p_AoQ_A)::RowsAtCompileTime, 3);
+  EXPECT_EQ(decltype(p_AoQ_A)::ColsAtCompileTime, 3);
+  EXPECT_TRUE(CompareMatrices(p_AoQ_A.col(0), X_AB * p_BoQ1_B, kEpsilon));
+  EXPECT_TRUE(CompareMatrices(p_AoQ_A.col(1), X_AB * p_BoQ2_B, kEpsilon));
+  EXPECT_TRUE(CompareMatrices(p_AoQ_A.col(2), X_AB * p_BoQ3_B, kEpsilon));
+
+  // Multiply the RigidTransform X_AB by n position vectors to test operator*
+  // for a 3 x n matrix, where n is not known before compilation.
+  const int number_of_position_vectors = 2;
   Eigen::Matrix3Xd p_BoP_B(3, number_of_position_vectors);
   p_BoP_B.col(0) = p_BoQ1_B;
   p_BoP_B.col(1) = p_BoQ2_B;
-  p_BoP_B.col(2) = p_BoQ3_B;
-  p_BoP_B.col(3) = p_BoQ1_B;
-  p_BoP_B.col(4) = p_BoQ2_B;
+  const auto p_AoP_A = X_AB * p_BoP_B;
 
-  Eigen::Matrix3Xd p_AoP_A = X_AB * p_BoP_B;
-  EXPECT_EQ(p_AoP_A.rows(), 3);
+  // Ensure the compiler's declared type for p_AoP_A has the proper number of
+  // rows before compilation (dictated by the return type of operator*) and
+  // has the proper number of columns at run time.
+  EXPECT_EQ(decltype(p_AoP_A)::RowsAtCompileTime, 3);
   EXPECT_EQ(p_AoP_A.cols(), number_of_position_vectors);
-  for (int i = 0;  i < number_of_position_vectors;  ++i) {
-    const Vector3d& p_BoPi_B = p_BoP_B.col(i);
-    const Vector3d& p_AoPi_A = p_AoP_A.col(i);
-    const Vector3d p_AoQi_A_expected = X_AB * p_BoPi_B;
-    EXPECT_TRUE(p_AoPi_A.isApprox(p_AoQi_A_expected, kEpsilon));
-    if (i < 3) {
-      EXPECT_TRUE(p_AoPi_A.isApprox(p_AoQ_A.col(i), kEpsilon));
-    }
+  for (int i = 0; i < number_of_position_vectors; ++i) {
+    const Vector3d p_AoPi_A = p_AoP_A.col(i);
+    const Vector3d p_AoPi_A_expected = p_AoP_A.col(i); // Previous calculation.
+    EXPECT_TRUE(CompareMatrices(p_AoPi_A, p_AoPi_A_expected, kEpsilon));
   }
+
+  // Test RigidTransform operator* can multiply an Eigen expression, namely the
+  // Eigen expression arising from a 3x1 matrix multiplied by a 1x4 matrix.
+  const Eigen::MatrixXd p_AoR_A = X_AB * (Eigen::Vector3d(1, 2, 3) *
+                                          Eigen::RowVector4d(1, 2, 3, 4));
+  EXPECT_EQ(p_AoR_A.rows(), 3);
+  EXPECT_EQ(p_AoR_A.cols(), 4);
+
+  // Test RigidTransform operator* can multiply a different looking Eigen
+  // expression that produces the same result.
+  const auto p_AoR_A_expected = X_AB *
+       (Eigen::MatrixXd(3, 4) << Eigen::Vector3d(1, 2, 3),
+                                 Eigen::Vector3d(2, 4, 6),
+                                 Eigen::Vector3d(3, 6, 9),
+                                 Eigen::Vector3d(4, 8, 12)).finished();
+  EXPECT_EQ(decltype(p_AoR_A_expected)::RowsAtCompileTime, 3);
+  EXPECT_EQ(p_AoR_A_expected.cols(), 4);
+  EXPECT_TRUE(CompareMatrices(p_AoR_A, p_AoR_A_expected, kEpsilon));
 
   // Test that operator* disallows weirdly-sized matrix multiplication.
   if (kDrakeAssertIsArmed) {


### PR DESCRIPTION
This PR resolves Issue #10816.
It also conceals a bug in Eigen that would otherwise adversely affects RigidTransform.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11308)
<!-- Reviewable:end -->
