### PR TITLE
Polishes docstring of maliput/base/intersection.h

### DIFF
--- a/automotive/maliput/base/intersection.h
+++ b/automotive/maliput/base/intersection.h
@@ -13,10 +13,7 @@
 namespace drake {
 namespace maliput {
 
-/// A convenience data structure for aggregating information about an
-/// intersection. Its primary purpose is to serve as a single source of this
-/// information and to remove the need to query numerous disparate data
-/// structures and state providers.
+/// A concrete implementation of the api::Intersection abstract interface.
 class Intersection : public api::Intersection {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Intersection)


### PR DESCRIPTION
Removes redundancy with the abstract base class's docstring.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11309)
<!-- Reviewable:end -->
