### PR TITLE
common: Deprecate find_resource on a directory

### DIFF
--- a/common/test/find_resource_test.cc
+++ b/common/test/find_resource_test.cc
@@ -95,6 +95,30 @@ GTEST_TEST(FindResourceTest, FoundDeclaredData) {
   EXPECT_EQ(FindResourceOrThrow(relpath), absolute_path);
 }
 
+GTEST_TEST(FindResourceTest, DeprecatedFoundDirectory) {
+  const string relpath = "drake/common";
+  const auto& result = FindResource(relpath);
+
+  // We get a path back.
+  ASSERT_FALSE(result.get_error_message());
+  EXPECT_EQ(result.get_resource_path(), relpath);
+  string absolute_path;
+  EXPECT_NO_THROW(absolute_path = result.get_absolute_path_or_throw());
+
+  // The path is the correct answer.
+  ASSERT_FALSE(absolute_path.empty());
+  EXPECT_EQ(absolute_path[0], '/');
+  std::ifstream input(
+      absolute_path + "/test/find_resource_test_data.txt",
+      std::ios::binary);
+  ASSERT_TRUE(input);
+  std::stringstream buffer;
+  buffer << input.rdbuf();
+  EXPECT_EQ(
+      buffer.str(),
+      "Test data for drake/common/test/find_resource_test.cc.\n");
+}
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 // Check that adding a relative resource path fails on purpose.

--- a/common/test/resource_tool_installed_test.py
+++ b/common/test/resource_tool_installed_test.py
@@ -58,6 +58,18 @@ class TestResourceTool(unittest.TestCase):
         with open(absolute_path, 'r') as data:
             self.assertEqual(data.read(), resource_data)
 
+        # Use the installed resource_tool to find a directory.
+        # (This feature is deprecated and will eventually be removed.)
+        absolute_path = install_test_helper.check_output(
+            [resource_tool,
+             "--print_resource_path",
+             "drake/common/test",
+             ],
+            env=tool_env,
+            ).strip()
+        with open(absolute_path + '/tmp_resource', 'r') as data:
+            self.assertEqual(data.read(), resource_data)
+
         # Use --add_resource_search_path instead of environment variable
         # to find resources.
         absolute_path = install_test_helper.check_output(


### PR DESCRIPTION
Since this worked previously, we should try to shim it instead of immediately change to a hard-failure.  It turns out that finding directory names was common for ROS package paths.

Amends #11261.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11310)
<!-- Reviewable:end -->
