### PR TITLE
py autodiff: Ensure pow() takes double exponents

### DIFF
--- a/bindings/pydrake/autodiffutils_py.cc
+++ b/bindings/pydrake/autodiffutils_py.cc
@@ -70,7 +70,7 @@ PYBIND11_MODULE(autodiffutils, m) {
       .def(py::self >= double())
       // Additional math
       .def("__pow__",
-          [](const AutoDiffXd& base, int exponent) {
+          [](const AutoDiffXd& base, double exponent) {
             return pow(base, exponent);
           },
           py::is_operator())
@@ -87,7 +87,7 @@ PYBIND11_MODULE(autodiffutils, m) {
       .def("abs", [](const AutoDiffXd& x) { return abs(x); })
       .def("exp", [](const AutoDiffXd& x) { return exp(x); })
       .def("sqrt", [](const AutoDiffXd& x) { return sqrt(x); })
-      .def("pow", [](const AutoDiffXd& x, int y) { return pow(x, y); })
+      .def("pow", [](const AutoDiffXd& x, double y) { return pow(x, y); })
       .def("sin", [](const AutoDiffXd& x) { return sin(x); })
       .def("cos", [](const AutoDiffXd& x) { return cos(x); })
       .def("tan", [](const AutoDiffXd& x) { return tan(x); })

--- a/bindings/pydrake/test/autodiffutils_test.py
+++ b/bindings/pydrake/test/autodiffutils_test.py
@@ -144,6 +144,7 @@ class TestAutoDiffXd(unittest.TestCase):
         algebra.check_value(algebra.exp(a), AD(np.e, [np.e, 0]))
         algebra.check_value(algebra.sqrt(a), AD(1, [0.5, 0]))
         algebra.check_value(algebra.pow(a, 2), AD(1, [2., 0]))
+        algebra.check_value(algebra.pow(a, 0.5), AD(1, [0.5, 0]))
         algebra.check_value(algebra.sin(c), AD(0, [1, 0]))
         algebra.check_value(algebra.cos(c), AD(1, [0, 0]))
         algebra.check_value(algebra.tan(c), AD(0, [1, 0]))


### PR DESCRIPTION
Regarding Slack convo: https://drakedevelopers.slack.com/archives/C3YB3EV5W/p1556036552008300
\cc @mpetersen94

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11313)
<!-- Reviewable:end -->
