### PR TITLE
quadrotor: Split QuadrotorGeometry from QuadrotorPlant

### DIFF
--- a/bindings/pydrake/examples/quadrotor_py.cc
+++ b/bindings/pydrake/examples/quadrotor_py.cc
@@ -3,7 +3,9 @@
 
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/examples/quadrotor/quadrotor_geometry.h"
 #include "drake/examples/quadrotor/quadrotor_plant.h"
+#include "drake/systems/primitives/affine_system.h"
 
 namespace drake {
 namespace pydrake {
@@ -32,15 +34,14 @@ PYBIND11_MODULE(quadrotor, m) {
           py::arg("m_arg"), py::arg("L_arg"), py::arg("I_arg"),
           py::arg("kF_arg"), py::arg("kM_arg"), doc.QuadrotorPlant.ctor.doc)
       .def("m", &QuadrotorPlant<T>::m, doc.QuadrotorPlant.m.doc)
-      .def("g", &QuadrotorPlant<T>::g, doc.QuadrotorPlant.g.doc)
-      .def("RegisterGeometry", &QuadrotorPlant<T>::RegisterGeometry,
-          py::arg("scene_graph"), doc.QuadrotorPlant.RegisterGeometry.doc)
-      .def("get_geometry_pose_output_port",
-          &QuadrotorPlant<T>::get_geometry_pose_output_port,
-          py_reference_internal,
-          doc.QuadrotorPlant.get_geometry_pose_output_port.doc)
-      .def("source_id", &QuadrotorPlant<T>::source_id,
-          doc.QuadrotorPlant.source_id.doc);
+      .def("g", &QuadrotorPlant<T>::g, doc.QuadrotorPlant.g.doc);
+
+  py::class_<QuadrotorGeometry, LeafSystem<double>>(
+      m, "QuadrotorGeometry", doc.QuadrotorGeometry.doc)
+      .def_static("AddToBuilder", &QuadrotorGeometry::AddToBuilder,
+          py::arg("builder"), py::arg("quadrotor_state_port"),
+          py::arg("scene_graph"), py::return_value_policy::reference,
+          py::keep_alive<0, 1>(), doc.QuadrotorGeometry.AddToBuilder.doc);
 
   m.def("StabilizingLQRController", &StabilizingLQRController,
       py::arg("quadrotor_plant"), py::arg("nominal_position"),

--- a/bindings/pydrake/examples/test/quadrotor_test.py
+++ b/bindings/pydrake/examples/test/quadrotor_test.py
@@ -4,7 +4,9 @@ import unittest
 import numpy as np
 
 from pydrake.geometry import SceneGraph
-from pydrake.examples.quadrotor import QuadrotorPlant, StabilizingLQRController
+from pydrake.examples.quadrotor import (
+    QuadrotorPlant, QuadrotorGeometry, StabilizingLQRController)
+from pydrake.systems.framework import DiagramBuilder
 
 
 class TestQuadrotor(unittest.TestCase):
@@ -18,10 +20,11 @@ class TestQuadrotor(unittest.TestCase):
         self.assertEqual(quadrotor.m(), 1)
         self.assertEqual(quadrotor.g(), 9.81)
 
-        scene_graph = SceneGraph()
-        quadrotor.RegisterGeometry(scene_graph)
-
-        self.assertTrue(quadrotor.source_id().is_valid())
-        quadrotor.get_geometry_pose_output_port()
-
         StabilizingLQRController(quadrotor, np.zeros(3))
+
+    def test_geometry(self):
+        builder = DiagramBuilder()
+        quadrotor = builder.AddSystem(QuadrotorPlant())
+        scene_graph = builder.AddSystem(SceneGraph())
+        state_port = quadrotor.get_output_port(0)
+        QuadrotorGeometry.AddToBuilder(builder, state_port, scene_graph)

--- a/examples/pendulum/BUILD.bazel
+++ b/examples/pendulum/BUILD.bazel
@@ -170,6 +170,7 @@ drake_cc_googletest(
     name = "pendulum_geometry_test",
     deps = [
         ":pendulum_geometry",
+        ":pendulum_plant",
         "//common/test_utilities:eigen_matrix_compare",
         "//math:geometric_transform",
     ],

--- a/examples/pendulum/pendulum_geometry.cc
+++ b/examples/pendulum/pendulum_geometry.cc
@@ -30,7 +30,7 @@ using std::make_unique;
 
 const PendulumGeometry* PendulumGeometry::AddToBuilder(
     systems::DiagramBuilder<double>* builder,
-    const systems::OutputPort<double>& pendulum_state,
+    const systems::OutputPort<double>& pendulum_state_port,
     geometry::SceneGraph<double>* scene_graph) {
   DRAKE_THROW_UNLESS(builder != nullptr);
   DRAKE_THROW_UNLESS(scene_graph != nullptr);
@@ -39,7 +39,7 @@ const PendulumGeometry* PendulumGeometry::AddToBuilder(
       std::unique_ptr<PendulumGeometry>(
           new PendulumGeometry(scene_graph)));
   builder->Connect(
-      pendulum_state,
+      pendulum_state_port,
       pendulum_geometry->get_input_port(0));
   builder->Connect(
       pendulum_geometry->get_output_port(0),
@@ -91,6 +91,8 @@ PendulumGeometry::PendulumGeometry(geometry::SceneGraph<double>* scene_graph) {
   scene_graph->AssignRole(
       source_id_, id, MakeDrakeVisualizerProperties(Vector4d(0, 0, 1, 1)));
 }
+
+PendulumGeometry::~PendulumGeometry() = default;
 
 void PendulumGeometry::OutputGeometryPose(
     const systems::Context<double>& context,

--- a/examples/pendulum/pendulum_geometry.h
+++ b/examples/pendulum/pendulum_geometry.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "drake/examples/pendulum/pendulum_plant.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/framework/leaf_system.h"
@@ -21,6 +20,7 @@ namespace pendulum {
 class PendulumGeometry final : public systems::LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PendulumGeometry);
+  ~PendulumGeometry() final;
 
   /// Creates, adds, and connects a PendulumGeometry system into the given
   /// `builder`.  Both the `pendulum_state.get_system()` and `scene_graph`
@@ -31,7 +31,7 @@ class PendulumGeometry final : public systems::LeafSystem<double> {
   /// that is owned by the `builder`.
   static const PendulumGeometry* AddToBuilder(
       systems::DiagramBuilder<double>* builder,
-      const systems::OutputPort<double>& pendulum_state,
+      const systems::OutputPort<double>& pendulum_state_port,
       geometry::SceneGraph<double>* scene_graph);
 
  private:

--- a/examples/quadrotor/BUILD.bazel
+++ b/examples/quadrotor/BUILD.bazel
@@ -19,17 +19,28 @@ drake_cc_library(
     name = "quadrotor_plant",
     srcs = ["quadrotor_plant.cc"],
     hdrs = ["quadrotor_plant.h"],
-    data = [":models"],
     deps = [
-        "//attic/util",
         "//common:default_scalars",
-        "//geometry:scene_graph",
         "//math:geometric_transform",
-        "//math:gradient",
-        "//multibody/parsing",
         "//systems/controllers:linear_quadratic_regulator",
         "//systems/framework:leaf_system",
         "//systems/primitives:affine_system",
+    ],
+)
+
+drake_cc_library(
+    name = "quadrotor_geometry",
+    srcs = ["quadrotor_geometry.cc"],
+    hdrs = ["quadrotor_geometry.h"],
+    data = [":models"],
+    deps = [
+        "//common:find_resource",
+        "//geometry:scene_graph",
+        "//math:geometric_transform",
+        "//multibody/parsing",
+        "//multibody/plant",
+        "//systems/framework:diagram_builder",
+        "//systems/framework:leaf_system",
     ],
 )
 
@@ -37,6 +48,7 @@ drake_cc_binary(
     name = "run_quadrotor_dynamics",
     srcs = ["run_quadrotor_dynamics.cc"],
     add_test_rule = 1,
+    data = [":models"],
     test_rule_args = [
         "--duration=0.1",
         "--initial_height=0.051",
@@ -66,6 +78,7 @@ drake_cc_binary(
         "-simulation_real_time_rate=0.0",
     ],
     deps = [
+        ":quadrotor_geometry",
         ":quadrotor_plant",
         "//common:find_resource",
         "//common:is_approx_equal_abstol",
@@ -91,6 +104,14 @@ drake_cc_googletest(
         "//systems/framework:diagram",
         "//systems/framework/test_utilities",
         "//systems/primitives:constant_vector_source",
+    ],
+)
+
+drake_cc_googletest(
+    name = "quadrotor_geometry_test",
+    deps = [
+        ":quadrotor_geometry",
+        ":quadrotor_plant",
     ],
 )
 

--- a/examples/quadrotor/quadrotor_geometry.cc
+++ b/examples/quadrotor/quadrotor_geometry.cc
@@ -1,0 +1,77 @@
+#include "drake/examples/quadrotor/quadrotor_geometry.h"
+
+#include <memory>
+
+#include "drake/common/find_resource.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/math/roll_pitch_yaw.h"
+#include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/plant/multibody_plant.h"
+
+using Eigen::Matrix3d;
+
+namespace drake {
+namespace examples {
+namespace quadrotor {
+
+const QuadrotorGeometry* QuadrotorGeometry::AddToBuilder(
+      systems::DiagramBuilder<double>* builder,
+      const systems::OutputPort<double>& quadrotor_state_port,
+      geometry::SceneGraph<double>* scene_graph) {
+  DRAKE_THROW_UNLESS(builder != nullptr);
+  DRAKE_THROW_UNLESS(scene_graph != nullptr);
+
+  auto quadrotor_geometry = builder->AddSystem(
+      std::unique_ptr<QuadrotorGeometry>(
+          new QuadrotorGeometry(scene_graph)));
+  builder->Connect(
+      quadrotor_state_port,
+      quadrotor_geometry->get_input_port(0));
+  builder->Connect(
+      quadrotor_geometry->get_output_port(0),
+      scene_graph->get_source_pose_port(quadrotor_geometry->source_id_));
+
+  return quadrotor_geometry;
+}
+
+QuadrotorGeometry::QuadrotorGeometry(
+    geometry::SceneGraph<double>* scene_graph) {
+  DRAKE_THROW_UNLESS(scene_graph != nullptr);
+
+  // Use (temporary) MultibodyPlant to parse the urdf and setup the
+  // scene_graph.
+  // TODO(SeanCurtis-TRI): Update this on resolution of #10775.
+  multibody::MultibodyPlant<double> mbp;
+  multibody::Parser parser(&mbp, scene_graph);
+
+  auto model_id = parser.AddModelFromFile(
+      FindResourceOrThrow("drake/examples/quadrotor/quadrotor.urdf"),
+      "quadrotor");
+  mbp.Finalize();
+
+  source_id_ = *mbp.get_source_id();
+  frame_id_ = mbp.GetBodyFrameIdOrThrow(mbp.GetBodyIndices(model_id)[0]);
+
+  this->DeclareVectorInputPort("state", systems::BasicVector<double>(12));
+  this->DeclareAbstractOutputPort(
+      "geometry_pose", &QuadrotorGeometry::OutputGeometryPose);
+}
+
+QuadrotorGeometry::~QuadrotorGeometry() = default;
+
+void QuadrotorGeometry::OutputGeometryPose(
+    const systems::Context<double>& context,
+    geometry::FramePoseVector<double>* poses) const {
+  DRAKE_DEMAND(frame_id_.is_valid());
+
+  const auto& state = get_input_port(0).Eval(context);
+  math::RigidTransformd pose(
+      math::RollPitchYawd(state.segment<3>(3)),
+      state.head<3>());
+
+  *poses = {{frame_id_, pose.GetAsIsometry3()}};
+}
+
+}  // namespace quadrotor
+}  // namespace examples
+}  // namespace drake

--- a/examples/quadrotor/quadrotor_geometry.h
+++ b/examples/quadrotor/quadrotor_geometry.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "drake/geometry/scene_graph.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace examples {
+namespace quadrotor {
+
+/// Expresses a QuadrotorPlant's geometry to a SceneGraph.
+///
+/// @system{QuadrotorGeometry,
+///    @input_port{state},
+///    @output_port{geometry_pose}
+/// }
+///
+/// This class has no public constructor; instead use the AddToBuilder() static
+/// method to create and add it to a DiagramBuilder directly.
+class QuadrotorGeometry final : public systems::LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(QuadrotorGeometry);
+  ~QuadrotorGeometry() final;
+
+  /// Creates, adds, and connects a QuadrotorGeometry system into the given
+  /// `builder`.  Both the `quadrotor_state.get_system()` and `scene_graph`
+  /// systems must have been added to the given `builder` already.
+  ///
+  /// The `scene_graph` pointer is not retained by the %QuadrotorGeometry
+  /// system.  The return value pointer is an alias of the new
+  /// %QuadrotorGeometry system that is owned by the `builder`.
+  static const QuadrotorGeometry* AddToBuilder(
+      systems::DiagramBuilder<double>* builder,
+      const systems::OutputPort<double>& quadrotor_state_port,
+      geometry::SceneGraph<double>* scene_graph);
+
+ private:
+  explicit QuadrotorGeometry(geometry::SceneGraph<double>*);
+  void OutputGeometryPose(const systems::Context<double>&,
+                          geometry::FramePoseVector<double>*) const;
+
+  // Geometry source identifier for this system to interact with SceneGraph.
+  geometry::SourceId source_id_{};
+  // The id for the quadrotor body.
+  geometry::FrameId frame_id_{};
+};
+
+}  // namespace quadrotor
+}  // namespace examples
+}  // namespace drake

--- a/examples/quadrotor/quadrotor_plant.cc
+++ b/examples/quadrotor/quadrotor_plant.cc
@@ -1,16 +1,8 @@
 #include "drake/examples/quadrotor/quadrotor_plant.h"
 
-#include <memory>
-
 #include "drake/common/default_scalars.h"
-#include "drake/common/find_resource.h"
-#include "drake/math/gradient.h"
-#include "drake/math/rigid_transform.h"
 #include "drake/math/rotation_matrix.h"
-#include "drake/multibody/parsing/parser.h"
-#include "drake/multibody/plant/multibody_plant.h"
 #include "drake/systems/controllers/linear_quadratic_regulator.h"
-#include "drake/util/drakeGeometryUtil.h"
 
 using Eigen::Matrix3d;
 
@@ -47,24 +39,15 @@ QuadrotorPlant<T>::QuadrotorPlant(double m_arg, double L_arg,
   this->DeclareInputPort("propellor_force", systems::kVectorValued, 4);
   // State is x ,y , z, roll, pitch, yaw + velocities.
   this->DeclareContinuousState(12);
-  state_port_ =
-      this->DeclareVectorOutputPort("state", systems::BasicVector<T>(12),
-                                    &QuadrotorPlant::CopyStateOut,
-                                    {this->all_state_ticket()})
-          .get_index();
+  this->DeclareVectorOutputPort("state", systems::BasicVector<T>(12),
+                                &QuadrotorPlant::CopyStateOut,
+                                {this->all_state_ticket()});
 }
 
 template <typename T>
 template <typename U>
 QuadrotorPlant<T>:: QuadrotorPlant(const QuadrotorPlant<U>& other)
-    : QuadrotorPlant<T>(other.m_, other.L_, other.I_, other.kF_, other.kM_) {
-  source_id_ = other.source_id();
-  frame_id_ = other.frame_id_;
-
-  if (source_id_.is_valid()) {
-    geometry_pose_port_ = AllocateGeometryPoseOutputPort();
-  }
-}
+    : QuadrotorPlant<T>(other.m_, other.L_, other.I_, other.kF_, other.kM_) {}
 
 template <typename T>
 QuadrotorPlant<T>::~QuadrotorPlant() {}
@@ -144,49 +127,6 @@ void QuadrotorPlant<T>::DoCalcTimeDerivatives(
   VectorX<T> xDt(12);
   xDt << state.template tail<6>(), xyzDDt, rpyDDt;
   derivatives->SetFromVector(xDt);
-}
-
-template <typename T>
-systems::OutputPortIndex QuadrotorPlant<T>::AllocateGeometryPoseOutputPort() {
-  DRAKE_DEMAND(source_id_.is_valid() && frame_id_.is_valid());
-  return this
-      ->DeclareAbstractOutputPort(
-          "geometry_pose", &QuadrotorPlant<T>::CopyPoseOut)
-      .get_index();
-}
-
-template <typename T>
-void QuadrotorPlant<T>::RegisterGeometry(
-    geometry::SceneGraph<double>* scene_graph) {
-  DRAKE_DEMAND(!source_id_.is_valid());
-  DRAKE_DEMAND(scene_graph);
-
-  // Use (temporary) MultibodyPlant to parse the urdf and setup the
-  // scene_graph.
-  // TODO(SeanCurtis-TRI): Update this on resolution of #10775.
-  multibody::MultibodyPlant<double> mbp;
-  multibody::Parser parser(&mbp, scene_graph);
-
-  auto model_id = parser.AddModelFromFile(
-      FindResourceOrThrow("drake/examples/quadrotor/quadrotor.urdf"),
-      "quadrotor");
-  mbp.Finalize();
-
-  source_id_ = *mbp.get_source_id();
-  frame_id_ = mbp.GetBodyFrameIdOrThrow(mbp.GetBodyIndices(model_id)[0]);
-
-  // Now allocate the output port.
-  geometry_pose_port_ = AllocateGeometryPoseOutputPort();
-}
-
-template <typename T>
-void QuadrotorPlant<T>::CopyPoseOut(const systems::Context<T>& context,
-                                   geometry::FramePoseVector<T>* poses) const {
-  VectorX<T> state = context.get_continuous_state_vector().CopyToVector();
-  math::RigidTransform<T> pose(
-      math::RollPitchYaw<T>(state.template segment<3>(3)),
-      state.template head<3>());
-  *poses = {{frame_id_, pose.GetAsIsometry3()}};
 }
 
 std::unique_ptr<systems::AffineSystem<double>> StabilizingLQRController(

--- a/examples/quadrotor/quadrotor_plant.h
+++ b/examples/quadrotor/quadrotor_plant.h
@@ -4,7 +4,6 @@
 
 #include <Eigen/Core>
 
-#include "drake/geometry/scene_graph.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/leaf_system.h"
 #include "drake/systems/primitives/affine_system.h"
@@ -19,7 +18,7 @@ namespace quadrotor {
 ///
 /// @system{QuadrotorPlant,
 ///    @input_port{propellor_force},
-///    @output_port{state} @output_port{geometry_pose}
+///    @output_port{state}
 /// }
 template <typename T>
 class QuadrotorPlant final : public systems::LeafSystem<T> {
@@ -37,22 +36,6 @@ class QuadrotorPlant final : public systems::LeafSystem<T> {
   double m() const { return m_; }
   double g() const { return g_; }
 
-  /// Registers this system as a source for the SceneGraph, adds the
-  /// quadrotor geometry, and creates the geometry_pose_output_port for this
-  /// system.  This must be called before the a SceneGraph's Context is
-  /// allocated.  It can only be called once.
-  // TODO(russt): this call only accepts doubles (not T) until SceneGraph
-  // supports symbolic.
-  void RegisterGeometry(geometry::SceneGraph<double>* scene_graph);
-
-  /// Returns the port to output the pose to SceneGraph.  Users must call
-  /// RegisterGeometry() first to enable this port.
-  const systems::OutputPort<T>& get_geometry_pose_output_port() const {
-    return systems::System<T>::get_output_port(geometry_pose_port_);
-  }
-
-  geometry::SourceId source_id() const { return source_id_; }
-
  private:
   void DoCalcTimeDerivatives(
       const systems::Context<T>& context,
@@ -60,12 +43,6 @@ class QuadrotorPlant final : public systems::LeafSystem<T> {
 
   void CopyStateOut(const systems::Context<T>& context,
                     systems::BasicVector<T>* output) const;
-
-  systems::OutputPortIndex AllocateGeometryPoseOutputPort();
-
-  // Calculator method for the pose output port.
-  void CopyPoseOut(const systems::Context<T>& context,
-                   geometry::FramePoseVector<T>* poses) const;
 
   // Allow different specializations to access each other's private data.
   template <typename> friend class QuadrotorPlant;
@@ -77,15 +54,6 @@ class QuadrotorPlant final : public systems::LeafSystem<T> {
   const double kF_;          // Force input constant.
   const double kM_;          // Moment input constant.
   const Eigen::Matrix3d I_;  // Moment of Inertia about the Center of Mass
-
-  // Port handles.
-  int state_port_{-1};
-  int geometry_pose_port_{-1};
-
-  // Geometry source identifier for this system to interact with SceneGraph.
-  geometry::SourceId source_id_{};
-  // The id for the quadrotor body.
-  geometry::FrameId frame_id_{};
 };
 
 /// Generates an LQR controller to move to @p nominal_position. Internally

--- a/examples/quadrotor/run_quadrotor_lqr.cc
+++ b/examples/quadrotor/run_quadrotor_lqr.cc
@@ -9,6 +9,7 @@
 
 #include "drake/common/find_resource.h"
 #include "drake/common/is_approx_equal_abstol.h"
+#include "drake/examples/quadrotor/quadrotor_geometry.h"
 #include "drake/examples/quadrotor/quadrotor_plant.h"
 #include "drake/geometry/geometry_visualization.h"
 #include "drake/lcm/drake_lcm.h"
@@ -50,9 +51,8 @@ int do_main() {
 
   // Set up visualization
   auto scene_graph = builder.AddSystem<geometry::SceneGraph>();
-  quadrotor->RegisterGeometry(scene_graph);
-  builder.Connect(quadrotor->get_geometry_pose_output_port(),
-      scene_graph->get_source_pose_port(quadrotor->source_id()));
+  QuadrotorGeometry::AddToBuilder(
+      &builder, quadrotor->get_output_port(0), scene_graph);
   geometry::ConnectDrakeVisualizer(&builder, *scene_graph);
 
   auto diagram = builder.Build();

--- a/examples/quadrotor/test/quadrotor_geometry_test.cc
+++ b/examples/quadrotor/test/quadrotor_geometry_test.cc
@@ -1,0 +1,28 @@
+#include "drake/examples/quadrotor/quadrotor_geometry.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/examples/quadrotor/quadrotor_plant.h"
+#include "drake/geometry/scene_graph.h"
+#include "drake/systems/framework/diagram_builder.h"
+
+namespace drake {
+namespace examples {
+namespace quadrotor {
+namespace {
+
+GTEST_TEST(QuadrotorGeometryTest, AcceptanceTest) {
+  // Just make sure nothing faults out.
+  systems::DiagramBuilder<double> builder;
+  auto plant = builder.AddSystem<QuadrotorPlant>();
+  auto scene_graph = builder.AddSystem<geometry::SceneGraph>();
+  auto geom = QuadrotorGeometry::AddToBuilder(
+      &builder, plant->get_output_port(0), scene_graph);
+  auto diagram = builder.Build();
+  ASSERT_NE(geom, nullptr);
+}
+
+}  // namespace
+}  // namespace quadrotor
+}  // namespace examples
+}  // namespace drake

--- a/tools/install/libdrake/build_components.bzl
+++ b/tools/install/libdrake/build_components.bzl
@@ -61,8 +61,10 @@ LIBDRAKE_COMPONENTS = [
     "//examples/compass_gait:compass_gait_vector_types",  # unpackaged
     "//examples/manipulation_station:manipulation_station",  # unpackaged
     "//examples/manipulation_station:manipulation_station_hardware_interface",  # unpackaged  # noqa
+    "//examples/pendulum:pendulum_geometry",  # unpackaged
     "//examples/pendulum:pendulum_plant",  # unpackaged
     "//examples/pendulum:pendulum_vector_types",  # unpackaged
+    "//examples/quadrotor:quadrotor_geometry",  # unpackaged
     "//examples/quadrotor:quadrotor_plant",  # unpackaged
     "//examples/rimless_wheel:rimless_wheel",  # unpackaged
     "//examples/rimless_wheel:rimless_wheel_vector_types",  # unpackaged


### PR DESCRIPTION
Also tidy up some analogous PendulumGeometry nits.

Towards #11179, repeating the #11244 rework to stay consistent within examples.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11327)
<!-- Reviewable:end -->
