### PR TITLE
Remove template keywords within ContactWrenchEvaluator::ComposeVariableValues definition

### DIFF
--- a/multibody/optimization/contact_wrench_evaluator.h
+++ b/multibody/optimization/contact_wrench_evaluator.h
@@ -27,8 +27,8 @@ class ContactWrenchEvaluator : public solvers::EvaluatorBase {
   ComposeVariableValues(const systems::Context<T>& context,
                         const Derived& lambda_value) const {
     VectorX<T> x(num_vars());
-    x.template head(plant_->num_positions()) = plant_->GetPositions(context);
-    x.template tail(num_lambda_) = lambda_value;
+    x.head(plant_->num_positions()) = plant_->GetPositions(context);
+    x.tail(num_lambda_) = lambda_value;
     return x;
   }
 


### PR DESCRIPTION
Breaks compilation with Xcode 10.2.1.

<!-- Reviewable:start -->
----
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11330)
<!-- Reviewable:end -->
