### PR TITLE
Adds label images to the RenderEngine

### DIFF
--- a/geometry/render/BUILD.bazel
+++ b/geometry/render/BUILD.bazel
@@ -30,11 +30,13 @@ drake_cc_library(
         "render_engine.h",
     ],
     deps = [
+        ":render_label",
         "//geometry:geometry_index",
         "//geometry:geometry_roles",
         "//geometry:shape_specification",
         "//geometry:utilities",
         "//math:geometric_transform",
+        "//systems/sensors:color_palette",
         "//systems/sensors:image",
     ],
 )

--- a/geometry/render/BUILD.bazel
+++ b/geometry/render/BUILD.bazel
@@ -82,6 +82,7 @@ drake_cc_googletest(
         ":render_engine",
         "//common/test_utilities",
         "//geometry:geometry_ids",
+        "//geometry/test_utilities:dummy_render_engine",
     ],
 )
 

--- a/geometry/render/render_engine.cc
+++ b/geometry/render/render_engine.cc
@@ -14,8 +14,6 @@ optional<RenderIndex> RenderEngine::RegisterVisual(
     GeometryIndex index, const drake::geometry::Shape& shape,
     const PerceptionProperties& properties,
     const RigidTransformd& X_WG, bool needs_updates) {
-  RenderLabelIsValidOrThrow(properties);
-
   optional<RenderIndex> render_index =
       DoRegisterVisual(shape, properties, X_WG);
   if (render_index) {
@@ -86,7 +84,7 @@ optional<GeometryIndex> RenderEngine::RemoveGeometry(RenderIndex index) {
   return moved_internal_index;
 }
 
-void RenderEngine::RenderLabelIsValidOrThrow(
+RenderLabel RenderEngine::GetRenderLabelOrThrow(
     const PerceptionProperties& properties) const {
   RenderLabel label =
       properties.GetPropertyOrDefault("label", "id", default_render_label_);
@@ -97,6 +95,7 @@ void RenderEngine::RenderLabelIsValidOrThrow(
         "RenderLabel or the RenderEngine may have provided it as a default for "
         "missing render labels in the properties.");
   }
+  return label;
 }
 
 }  // namespace render

--- a/geometry/render/render_engine.cc
+++ b/geometry/render/render_engine.cc
@@ -14,8 +14,6 @@ optional<RenderIndex> RenderEngine::RegisterVisual(
     GeometryIndex index, const drake::geometry::Shape& shape,
     const PerceptionProperties& properties,
     const RigidTransformd& X_WG, bool needs_updates) {
-  default_label_state_ = DefaultValueState::kGeometryRegistered;
-
   RenderLabelIsValidOrThrow(properties);
 
   optional<RenderIndex> render_index =
@@ -86,21 +84,6 @@ optional<GeometryIndex> RenderEngine::RemoveGeometry(RenderIndex index) {
     (*map_B)[index] = moved_internal_index;
   }
   return moved_internal_index;
-}
-
-void RenderEngine::set_default_render_label(const RenderLabel& label) {
-  if (default_label_state_ != DefaultValueState::kUnset) {
-    if (default_label_state_ == DefaultValueState::kSet) {
-      throw std::logic_error(
-          "The RenderEngine's default render label can only be set once");
-    } else {
-      throw std::logic_error(
-          "The RenderEngine's default render label cannot be set after "
-          "registering geometry");
-    }
-  }
-  default_label_state_ = DefaultValueState::kSet;
-  default_render_label_ = label;
 }
 
 void RenderEngine::RenderLabelIsValidOrThrow(

--- a/geometry/render/render_engine.h
+++ b/geometry/render/render_engine.h
@@ -23,16 +23,6 @@ namespace drake {
 namespace geometry {
 namespace render {
 
-/** Parameters for constructing RenderEngine.  */
-struct RenderEngineParams {
-  /** The render label to apply to geometries that have not otherwise specified
-   a (label, id) property. The value _must_ be either RenderLabel::kUnspecified
-   or RenderLabel::kDontCare. (See
-   @ref render_engine_default_label "this section" for more details.) Defaults
-   to RenderLabel::kUnspecified.  */
-  RenderLabel default_render_label{RenderLabel::kUnspecified};
-};
-
 /** The engine for performing rasterization operations on geometry. This
  includes rgb images and depth images. The coordinate system of
  %RenderEngine's viewpoint `R` is `X-right`, `Y-down` and `Z-forward`
@@ -90,11 +80,17 @@ struct RenderEngineParams {
  GetRenderLabelOrThrow().  */
 class RenderEngine : public ShapeReifier {
  public:
-  /** Constructs a %RenderEngine with the given `parameters`.
+  /** Constructs a %RenderEngine with the given default render label. The
+   default render label is applied to geometries that have not otherwise
+   specified a (label, id) property. The value _must_ be either
+   RenderLabel::kUnspecified or RenderLabel::kDontCare. (See
+   @ref render_engine_default_label "this section" for more details.)
+
    @throws std::logic_error if the default render label is not one of the two
                             allowed labels.  */
-  explicit RenderEngine(const RenderEngineParams& parameters)
-      : default_render_label_(parameters.default_render_label) {
+  explicit RenderEngine(
+      const RenderLabel& default_label = RenderLabel::kUnspecified)
+      : default_render_label_(default_label) {
     if (default_render_label_ != RenderLabel::kUnspecified &&
         default_render_label_ != RenderLabel::kDontCare) {
       throw std::logic_error(
@@ -317,7 +313,7 @@ class RenderEngine : public ShapeReifier {
   // The default render label to apply to geometries that don't otherwise
   // provide one. Default constructor is RenderLabel::kUnspecified via the
   // RenderLabel default constructor.
-  RenderLabel  default_render_label_{};
+  RenderLabel default_render_label_{};
 };
 
 }  // namespace render

--- a/geometry/render/render_label.h
+++ b/geometry/render/render_label.h
@@ -152,6 +152,10 @@ class RenderLabel {
   friend std::string to_string(const RenderLabel& label);
 
  private:
+  // RenderEngine needs access to encode labels as raster colors and to convert
+  // rasterized colors back into labels.
+  friend class RenderEngine;
+
   // Private constructor precludes general construction except by the approved
   // factories (see above).
   RenderLabel(int value, bool needs_testing)

--- a/geometry/render/render_label.h
+++ b/geometry/render/render_label.h
@@ -34,9 +34,7 @@ namespace render {
  applications. They are:
 
  - `empty`: a pixel with the `empty` %RenderLabel value indicates that _no_
-   geometry rendered to that pixel. There is no good reason to assign this
-   label to a geometry; attempting to do will produce an error during
-   registration.
+   geometry rendered to that pixel.
  - `do_not_render`: any geometry assigned the `do_not_render` tag will _not_ be
    rendered into a label image. This is a clear declaration that a geometry
    should be omitted. Useful for marking, e.g., glass windows so that the
@@ -46,8 +44,10 @@ namespace render {
    but whose class is irrelevant (e.g., the walls of a room a robot is working
    in or the background terrain in driving simulation).
  - `unspecified`: a default-constructed %RenderLabel has an `unspecified` value.
-   Attempting to apply an unspecified label to a geometry produce an error
-   during registration.
+
+ Generally, there is no good reason to assign `empty` or `unspecified` labels
+ to a geometry. A RenderEngine implementation is entitled to throw an exception
+ if you attempt to do so.
 
  <h2>Usage</h2>
 

--- a/geometry/render/render_label.h
+++ b/geometry/render/render_label.h
@@ -34,16 +34,19 @@ namespace render {
  applications. They are:
 
  - `empty`: a pixel with the `empty` %RenderLabel value indicates that _no_
-   geometry rendered to that pixel.
- - `do_not_render`: any geometry assigned the `do_not_render` tag will _not_ be
+   geometry rendered to that pixel. Implemented as RenderLabel::kEmpty.
+ - `do not render`: any geometry assigned the `do not render` tag will _not_ be
    rendered into a label image. This is a clear declaration that a geometry
    should be omitted. Useful for marking, e.g., glass windows so that the
    visible geometry behind the glass is what is included in the label image.
- - `dont_care`: the `dont_care` label is intended as a convenient dumping
+   Implemented as RenderLabel::kDoNotRender.
+ - `don't care`: the `don't care` label is intended as a convenient dumping
    ground. This would be for geometry that _should_ render into the label image,
    but whose class is irrelevant (e.g., the walls of a room a robot is working
-   in or the background terrain in driving simulation).
+   in or the background terrain in driving simulation). Implemented as
+   RenderLabel::kDontCare.
  - `unspecified`: a default-constructed %RenderLabel has an `unspecified` value.
+   Implemented as RenderLabel::kUnspecified.
 
  Generally, there is no good reason to assign `empty` or `unspecified` labels
  to a geometry. A RenderEngine implementation is entitled to throw an exception

--- a/geometry/render/render_label.h
+++ b/geometry/render/render_label.h
@@ -34,8 +34,8 @@ namespace render {
  applications. They are:
 
  - `empty`: a pixel with the `empty` %RenderLabel value indicates that _no_
-   geometry rendered to that pixel. Assigning this label to geometry is _highly_
-   inadvisable and will typically lead to undesirable results.
+   geometry rendered to that pixel. There is no good reason to assign this
+   label to a geometry; attempting to do so is considered defective.
  - `do_not_render`: any geometry assigned the `do_not_render` tag will _not_ be
    rendered into a label image. This is a clear declaration that a geometry
    should be omitted. Useful for marking, e.g., glass windows so that the
@@ -44,11 +44,13 @@ namespace render {
    ground. This would be for geometry that _should_ render into the label image,
    but whose class is irrelevant (e.g., the walls of a room a robot is working
    in or the background terrain in driving simulation).
- - `unspecified`: in the absence of an explicitly assigned render label, a
-   geometry receives the `unspecified` label. RenderEngine implementations will
-   throw an exception if they are given a geometry with an `unspecified`
-   %RenderLabel, because it is considered to be a likely a defect for an
-   application not to explicitly assign a label to every rendered geometry.
+ - `unspecified`: a default-constructed %RenderLabel has an `unspecified` value.
+   Attempting to apply an unspecified label to a geometry is considered
+   defective.
+
+ Attempts to register a visual geometry with the `empty` or `unspecified` label
+ will cause an exception to be thrown (in support of the designation of that
+ action as "defective").
 
  <h2>Usage</h2>
 
@@ -129,9 +131,16 @@ class RenderLabel {
    @ref reserved_render_label "reserved labels" for details.  */
   //@{
 
+  /** See @ref reserved_render_label "Reserved labels"  */
   static const RenderLabel kEmpty;
+
+  /** See @ref reserved_render_label "Reserved labels"  */
   static const RenderLabel kDoNotRender;
+
+  /** See @ref reserved_render_label "Reserved labels"  */
   static const RenderLabel kDontCare;
+
+  /** See @ref reserved_render_label "Reserved labels"  */
   static const RenderLabel kUnspecified;
 
   /** The largest value that a %RenderLabel can be instantiated on. */

--- a/geometry/render/render_label.h
+++ b/geometry/render/render_label.h
@@ -35,7 +35,8 @@ namespace render {
 
  - `empty`: a pixel with the `empty` %RenderLabel value indicates that _no_
    geometry rendered to that pixel. There is no good reason to assign this
-   label to a geometry; attempting to do so is considered defective.
+   label to a geometry; attempting to do will produce an error during
+   registration.
  - `do_not_render`: any geometry assigned the `do_not_render` tag will _not_ be
    rendered into a label image. This is a clear declaration that a geometry
    should be omitted. Useful for marking, e.g., glass windows so that the
@@ -45,12 +46,8 @@ namespace render {
    but whose class is irrelevant (e.g., the walls of a room a robot is working
    in or the background terrain in driving simulation).
  - `unspecified`: a default-constructed %RenderLabel has an `unspecified` value.
-   Attempting to apply an unspecified label to a geometry is considered
-   defective.
-
- Attempts to register a visual geometry with the `empty` or `unspecified` label
- will cause an exception to be thrown (in support of the designation of that
- action as "defective").
+   Attempting to apply an unspecified label to a geometry produce an error
+   during registration.
 
  <h2>Usage</h2>
 

--- a/geometry/render/test/render_engine_test.cc
+++ b/geometry/render/test/render_engine_test.cc
@@ -334,13 +334,13 @@ GTEST_TEST(RenderEngine, ColorLabelConversion) {
 GTEST_TEST(RenderEngine, DefaultRenderLabel) {
   // Case: Confirm RenderEngine default is kUnspecified.
   {
-    DummyRenderEngine engine(RenderEngineParams{});
+    DummyRenderEngine engine;
     EXPECT_EQ(engine.default_render_label(), RenderLabel::kUnspecified);
   }
 
   // Case: Confirm kDontCare is valid.
   {
-    DummyRenderEngine engine(RenderEngineParams{RenderLabel::kDontCare});
+    DummyRenderEngine engine(RenderLabel::kDontCare);
     EXPECT_EQ(engine.default_render_label(), RenderLabel::kDontCare);
   }
 
@@ -348,7 +348,7 @@ GTEST_TEST(RenderEngine, DefaultRenderLabel) {
   {
     for (auto label :
          {RenderLabel::kDoNotRender, RenderLabel::kEmpty, RenderLabel{10}}) {
-      DRAKE_EXPECT_THROWS_MESSAGE(DummyRenderEngine({label}), std::logic_error,
+      DRAKE_EXPECT_THROWS_MESSAGE(DummyRenderEngine{label}, std::logic_error,
                                   ".* default render label must be either "
                                   "'kUnspecified' or 'kDontCare'");
     }

--- a/geometry/render/test/render_engine_test.cc
+++ b/geometry/render/test/render_engine_test.cc
@@ -350,7 +350,7 @@ GTEST_TEST(RenderEngine, DefaultRenderLabel) {
          {RenderLabel::kDoNotRender, RenderLabel::kEmpty, RenderLabel{10}}) {
       DRAKE_EXPECT_THROWS_MESSAGE(DummyRenderEngine({label}), std::logic_error,
                                   ".* default render label must be either "
-                                  "'unspecified' or 'don't care'");
+                                  "'kUnspecified' or 'kDontCare'");
     }
   }
 }

--- a/geometry/render/test/render_label_test.cc
+++ b/geometry/render/test/render_label_test.cc
@@ -91,6 +91,11 @@ TEST_F(RenderLabelTests, AssignmentAndComparison) {
   EXPECT_TRUE(labels_[0] < RenderLabel::kEmpty);
   EXPECT_TRUE(labels_[0] < RenderLabel::kDoNotRender);
   EXPECT_TRUE(labels_[0] < RenderLabel::kUnspecified);
+
+  // Comparison of RenderLabel with values of underlying type.
+  for (RenderLabel::ValueType i(0); i < kLabelCount; ++i) {
+    EXPECT_TRUE(labels_[i] == i);
+  }
 }
 
 // Confirms that RenderLabels can be used as hashable entries in STL containers

--- a/geometry/render/test/render_label_test.cc
+++ b/geometry/render/test/render_label_test.cc
@@ -11,7 +11,6 @@
 namespace drake {
 namespace geometry {
 namespace render {
-
 namespace  {
 
 class RenderLabelTests : public ::testing::Test {

--- a/geometry/test_utilities/BUILD.bazel
+++ b/geometry/test_utilities/BUILD.bazel
@@ -5,10 +5,19 @@ load(
     "@drake//tools/skylark:drake_cc.bzl",
     "drake_cc_googletest",
     "drake_cc_library",
+    "drake_cc_package_library",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 package(default_visibility = ["//visibility:public"])
+
+drake_cc_package_library(
+    name = "test_utilities",
+    deps = [
+        ":dummy_render_engine",
+        ":geometry_set_tester",
+    ],
+)
 
 drake_cc_library(
     name = "geometry_set_tester",
@@ -17,6 +26,15 @@ drake_cc_library(
     srcs = [],
     hdrs = ["geometry_set_tester.h"],
     deps = ["//geometry:geometry_set"],
+)
+
+drake_cc_library(
+    name = "dummy_render_engine",
+    # TODO(SeanCurtis-TRI): Make this `testonly = 1` once dev/GeometryState is
+    # removed; then all of these become testonly (as does the package).
+    srcs = [],
+    hdrs = ["dummy_render_engine.h"],
+    deps = ["//geometry/render:render_engine"],
 )
 
 add_lint_tests()

--- a/geometry/test_utilities/dummy_render_engine.h
+++ b/geometry/test_utilities/dummy_render_engine.h
@@ -101,6 +101,7 @@ class DummyRenderEngine final : public render::RenderEngine {
   optional<RenderIndex> DoRegisterVisual(const Shape&,
                                          const PerceptionProperties& properties,
                                          const math::RigidTransformd&) final {
+    GetRenderLabelOrThrow(properties);
     if (properties.HasGroup(include_group_name_)) {
       return RenderIndex(register_count_++);
     }

--- a/geometry/test_utilities/dummy_render_engine.h
+++ b/geometry/test_utilities/dummy_render_engine.h
@@ -33,12 +33,10 @@ namespace internal {
 class DummyRenderEngine final : public render::RenderEngine {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DummyRenderEngine);
-  /** Constructor that exercises the RenderEngine's default constructor.  */
-  DummyRenderEngine() = default;
 
-  /** Constructor that allows configuring RenderLabel upon construction.  */
-  explicit DummyRenderEngine(const render::RenderLabel& label)
-      : render::RenderEngine(label) {}
+  /** Constructor for configuring the underlying RenderEngine.  */
+  explicit DummyRenderEngine(const render::RenderEngineParams& parameters)
+      : render::RenderEngine(parameters) {}
 
   /** @group No-op implementation of RenderEngine interface.  */
   //@{
@@ -56,10 +54,6 @@ class DummyRenderEngine final : public render::RenderEngine {
   void ImplementGeometry(const Mesh& mesh, void* user_data) final {}
   void ImplementGeometry(const Convex& convex, void* user_data) final {}
   //@}
-
-  // Make the default render label publicly available for testing.
-  using render::RenderEngine::set_default_render_label;
-  using render::RenderEngine::default_render_label;
 
   /** @name  Functions for supporting tests.  */
   //@{

--- a/geometry/test_utilities/dummy_render_engine.h
+++ b/geometry/test_utilities/dummy_render_engine.h
@@ -1,0 +1,153 @@
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/drake_optional.h"
+#include "drake/geometry/render/render_engine.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/systems/sensors/color_palette.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+/** A dummy implementation of the RenderEngine to facilitate testing. Its
+ purpose is to facilitate testing at the RenderEngine interface and _not_ the
+ details of any particular implementation. To that end, it has the following
+ features:
+
+ 1. It makes the RenderLabel-Color conversion methods of the RenderEngine
+    public to this renderer (so test infrastructure can invoke the conversion).
+ 2. It facilitates testing RemoveGeometry() logic by allowing the test to
+    explicitly set what RenderIndex this dummy engine returns in
+    DoRemoveGeometry().
+ 3. It facilitates testing the RegisterGeometry() method by making the
+    registration of a geometry dependent on particular contents in the
+    PerceptionProperties (see accepting_properties() and
+    rejecting_properties()).
+ 4. Records which poses have been updated via UpdatePoses() to validate which
+    RenderIndex values are updated and which aren't (and with what pose).  */
+class DummyRenderEngine final : public render::RenderEngine {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DummyRenderEngine);
+  /** Constructor that exercises the RenderEngine's default constructor.  */
+  DummyRenderEngine() = default;
+
+  /** Constructor that allows configuring RenderLabel upon construction.  */
+  explicit DummyRenderEngine(const render::RenderLabel& label)
+      : render::RenderEngine(label) {}
+
+  /** @group No-op implementation of RenderEngine interface.  */
+  //@{
+  void UpdateViewpoint(const math::RigidTransformd&) const final {}
+  void RenderColorImage(const render::CameraProperties&, bool,
+                        systems::sensors::ImageRgba8U*) const final {}
+  void RenderDepthImage(const render::DepthCameraProperties&,
+                        systems::sensors::ImageDepth32F*) const final {}
+  void RenderLabelImage(const render::CameraProperties&, bool,
+                        systems::sensors::ImageLabel16I*) const final {}
+  void ImplementGeometry(const Sphere& sphere, void* user_data) final {}
+  void ImplementGeometry(const Cylinder& cylinder, void* user_data) final {}
+  void ImplementGeometry(const HalfSpace& half_space, void* user_data) final {}
+  void ImplementGeometry(const Box& box, void* user_data) final {}
+  void ImplementGeometry(const Mesh& mesh, void* user_data) final {}
+  void ImplementGeometry(const Convex& convex, void* user_data) final {}
+  //@}
+
+  // Make the default render label publicly available for testing.
+  using render::RenderEngine::set_default_render_label;
+  using render::RenderEngine::default_render_label;
+
+  /** @name  Functions for supporting tests.  */
+  //@{
+
+  /** Creates a set of perception properties that will cause this render engine
+   to _accept_ geometry during registration.  */
+  PerceptionProperties accepting_properties() const {
+    PerceptionProperties properties;
+    properties.AddProperty(include_group_name_, "ignored", 0);
+    return properties;
+  }
+
+  /** Creates a set of perception properties that will cause this render engine
+   to _reject_ geometry during registration.  */
+  PerceptionProperties rejecting_properties() const {
+    return PerceptionProperties();
+  }
+
+  /** Reports the number of geometries that have been _accepted_ in
+   registration.  */
+  int num_registered() const { return register_count_; }
+
+  /** Returns the indices that have been updated via a call to UpdatePoses() and
+   the poses that were set.  */
+  const std::map<RenderIndex, math::RigidTransformd>& updated_indices() const {
+    return updated_indices_;
+  }
+
+  /** Sets the RenderIndex that DoRemoveGeometry() returns. Set to `nullopt`
+   to have RemoveGeometry() do no additional work. Otherwise, set it to some
+   valid index to cause index re-ordering.  */
+  void set_moved_index(optional<RenderIndex> index) {
+    moved_index_ = index;
+  }
+
+  // Promote these to be public to facilitate testing.
+  using RenderEngine::LabelFromColor;
+  using RenderEngine::GetColorDFromLabel;
+  using RenderEngine::GetColorIFromLabel;
+
+ protected:
+  /** Dummy implementation that registers the given `shape` iff the `properties`
+   contains the "in_test" group. (Also counts the number of successfully
+   registered shape over the lifespan of `this` instance.)  */
+  optional<RenderIndex> DoRegisterVisual(const Shape&,
+                                         const PerceptionProperties& properties,
+                                         const math::RigidTransformd&) final {
+    if (properties.HasGroup(include_group_name_)) {
+      return RenderIndex(register_count_++);
+    }
+    return nullopt;
+  }
+
+  /** Updates the pose X_WG for the geometry with the given `index`. Also tracks
+   which indices have been updated and the poses set (over the _lifespan_ of
+   `this` instance).  */
+  void DoUpdateVisualPose(RenderIndex index,
+                          const math::RigidTransformd& X_WG) final {
+    updated_indices_[index] = X_WG;
+  }
+
+  /** Simulates removing a geometry and returns the index defined by
+   set_moved_index().  */
+  optional<RenderIndex> DoRemoveGeometry(RenderIndex index) final {
+    return moved_index_;
+  }
+
+  /** Implementation of RenderEngine::DoClone().  */
+  std::unique_ptr<render::RenderEngine> DoClone() const final {
+    return std::make_unique<DummyRenderEngine>(*this);
+  }
+
+ private:
+  // Number of registered geometries.
+  int register_count_{};
+
+  // Track each index and what it has been updated to (allows us to confirm
+  // RenderIndex and GeometryIndex association.
+  std::map<RenderIndex, math::RigidTransformd> updated_indices_;
+
+  // The group name whose presence will lead to a shape being added to the
+  // engine.
+  std::string include_group_name_{"in_test"};
+
+  // The RenderIndex value to return on invocation of DoRemoveGeometry().
+  optional<RenderIndex> moved_index_{};
+};
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/test_utilities/dummy_render_engine.h
+++ b/geometry/test_utilities/dummy_render_engine.h
@@ -33,10 +33,12 @@ namespace internal {
 class DummyRenderEngine final : public render::RenderEngine {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DummyRenderEngine);
+  /** Constructor to exercise the default constructor of RenderEngine.  */
+  DummyRenderEngine() = default;
 
   /** Constructor for configuring the underlying RenderEngine.  */
-  explicit DummyRenderEngine(const render::RenderEngineParams& parameters)
-      : render::RenderEngine(parameters) {}
+  explicit DummyRenderEngine(const render::RenderLabel& label)
+      : render::RenderEngine(label) {}
 
   /** @group No-op implementation of RenderEngine interface.  */
   //@{


### PR DESCRIPTION
- Adds the virtual interface to RenderEngine for label images
- Adds the facility to convert between RenderLabel and colors to use in the rasterization pipeline.
- Appropriate tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11331)
<!-- Reviewable:end -->
