### PR TITLE
Mass matrix computation ignores velocity terms.

### DIFF
--- a/examples/multibody/cart_pole/BUILD.bazel
+++ b/examples/multibody/cart_pole/BUILD.bazel
@@ -49,6 +49,7 @@ drake_cc_googletest(
         ":cart_pole_params",
         "//common:find_resource",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:limit_malloc",
         "//multibody/parsing",
         "//multibody/plant",
     ],

--- a/examples/multibody/cart_pole/test/cart_pole_test.cc
+++ b/examples/multibody/cart_pole/test/cart_pole_test.cc
@@ -6,6 +6,7 @@
 #include "drake/common/eigen_types.h"
 #include "drake/common/find_resource.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/limit_malloc.h"
 #include "drake/examples/multibody/cart_pole/gen/cart_pole_params.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/multibody/plant/multibody_plant.h"
@@ -127,6 +128,12 @@ TEST_F(CartPoleTest, MassMatrix) {
   const double kTolerance = 10 * std::numeric_limits<double>::epsilon();
   EXPECT_TRUE(CompareMatrices(M, M_expected,
                   kTolerance, MatrixCompareType::relative));
+
+  {  // Repeat the computation to confirm the heap behavior.  We allow the
+     // method to heap-allocate 4 temporaries.
+    drake::test::LimitMalloc guard({.max_num_allocations = 4});
+    cart_pole_.CalcMassMatrixViaInverseDynamics(*context_, &M);
+  }
 }
 
 // Tests that the hand-derived dynamics matches that computed with a

--- a/multibody/benchmarks/kuka_iiwa_robot/drake_kuka_iiwa_robot.h
+++ b/multibody/benchmarks/kuka_iiwa_robot/drake_kuka_iiwa_robot.h
@@ -228,7 +228,7 @@ class DrakeKukaIIwaRobot {
         forces.mutable_generalized_forces();
 
     // Calculate inverse dynamics on this robot.
-    tree().CalcInverseDynamics(*context_, pc, vc, qDDt,
+    tree().CalcInverseDynamics(*context_, qDDt,
                 Fapplied_Bo_W_array, generalized_force_applied,
                 &A_WB_array, &F_BMo_W_array, &generalized_force_output);
 

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1355,7 +1355,7 @@ void MultibodyPlant<T>::DoCalcTimeDerivatives(
   }
 
   internal_tree().CalcInverseDynamics(
-      context, pc, vc, vdot,
+      context, vdot,
       F_BBo_W_array, tau_array,
       &A_WB_array,
       &F_BBo_W_array, /* Notice these arrays gets overwritten on output. */
@@ -1477,7 +1477,7 @@ void MultibodyPlant<T>::CalcImplicitStribeckResults(
   //   -tau = C(q, v)v - tau_app - ∑ J_WBᵀ(q) Fapp_Bo_W.
   VectorX<T>& minus_tau = forces0.mutable_generalized_forces();
   internal_tree().CalcInverseDynamics(
-      context0, pc0, vc0, vdot,
+      context0, vdot,
       F_BBo_W_array, minus_tau,
       &A_WB_array,
       &F_BBo_W_array, /* Note: these arrays get overwritten on output. */

--- a/multibody/tree/body_node.h
+++ b/multibody/tree/body_node.h
@@ -364,6 +364,8 @@ class BodyNode : public MultibodyTreeElement<BodyNode<T>, BodyNodeIndex> {
   ///   An already updated position kinematics cache in sync with `context`.
   /// @param[in] vc
   ///   An already updated velocity kinematics cache in sync with `context`.
+  ///   If vc is nullptr, velocities are assumed to be zero and velocity
+  ///   dependent terms are not computed.
   /// @param[in] mbt_vdot
   ///   The entire vector of generalized accelerations for the full
   ///   MultibodyTree model. It must have a size equal to the number of
@@ -398,7 +400,7 @@ class BodyNode : public MultibodyTreeElement<BodyNode<T>, BodyNodeIndex> {
   void CalcSpatialAcceleration_BaseToTip(
       const systems::Context<T>& context,
       const PositionKinematicsCache<T>& pc,
-      const VelocityKinematicsCache<T>& vc,
+      const VelocityKinematicsCache<T>* vc,
       const VectorX<T>& mbt_vdot,
       std::vector<SpatialAcceleration<T>>* A_WB_array_ptr) const {
     // This method must not be called for the "world" body node.
@@ -494,9 +496,6 @@ class BodyNode : public MultibodyTreeElement<BodyNode<T>, BodyNodeIndex> {
         /* p_MB_F = R_FM * p_MB_M */
         get_X_FM(pc).linear() * X_MB.translation();
 
-    // Across mobilizer velocity is available from the velocity kinematics.
-    const SpatialVelocity<T>& V_FM = get_V_FM(vc);
-
     // Generalized velocities' time derivatives local to this node's mobilizer.
     const auto& vmdot = this->get_mobilizer_velocities(mbt_vdot);
 
@@ -504,23 +503,12 @@ class BodyNode : public MultibodyTreeElement<BodyNode<T>, BodyNodeIndex> {
     SpatialAcceleration<T> A_FM =
         get_mobilizer().CalcAcrossMobilizerSpatialAcceleration(context, vmdot);
 
-    SpatialAcceleration<T> A_PB_W =
-        R_WF * A_FM.Shift(p_MB_F, V_FM.rotational());  // Eq. (4)
-
     // =========================================================================
     // Compose acceleration A_WP of P in W with acceleration A_PB of B in P,
     // Eq. (2)
 
-    // Since we are in a base-to-tip recursion the parent body P's spatial
-    // velocity is already available in the cache.
-    const SpatialVelocity<T>& V_WP = get_V_WP(vc);
-
     // Obtains a const reference to the parent acceleration from A_WB_array.
     const SpatialAcceleration<T>& A_WP = get_A_WP_from_array(A_WB_array);
-
-    // For body B, only the spatial velocity V_PB_W is already available in the
-    // cache. The acceleration A_PB_W was computed above.
-    const SpatialVelocity<T>& V_PB_W = get_V_PB_W(vc);
 
     // Shift vector between the parent body P and this node's body B,
     // expressed in the world frame W.
@@ -530,9 +518,32 @@ class BodyNode : public MultibodyTreeElement<BodyNode<T>, BodyNodeIndex> {
     /* p_PB_W = R_WP * p_PB */
     Vector3<T> p_PB_W = get_X_WP(pc).linear() * get_X_PB(pc).translation();
 
-    get_mutable_A_WB_from_array(&A_WB_array) =
-        A_WP.ComposeWithMovingFrameAcceleration(p_PB_W, V_WP.rotational(),
-                                                V_PB_W, A_PB_W);
+    if (vc != nullptr) {
+      // Since we are in a base-to-tip recursion the parent body P's spatial
+      // velocity is already available in the cache.
+      const SpatialVelocity<T>& V_WP = get_V_WP(*vc);
+
+      // For body B, only the spatial velocity V_PB_W is already available in
+      // the cache. The acceleration A_PB_W was computed above.
+      const SpatialVelocity<T>& V_PB_W = get_V_PB_W(*vc);
+
+      // Across mobilizer velocity is available from the velocity kinematics.
+      const SpatialVelocity<T>& V_FM = get_V_FM(*vc);
+
+      const SpatialAcceleration<T> A_PB_W =
+          R_WF * A_FM.Shift(p_MB_F, V_FM.rotational());  // Eq. (4)
+
+      // Velocities are non-zero.
+      get_mutable_A_WB_from_array(&A_WB_array) =
+          A_WP.ComposeWithMovingFrameAcceleration(p_PB_W, V_WP.rotational(),
+                                                  V_PB_W, A_PB_W);
+    } else {
+      const SpatialAcceleration<T> A_PB_W =
+          R_WF * A_FM.Shift(p_MB_F);  // Eq. (4), with w_FM = 0.
+      // Velocities are zero. No need to compute terms that become zero.
+      get_mutable_A_WB_from_array(&A_WB_array).get_coeffs() =
+          A_WP.Shift(p_PB_W).get_coeffs() + A_PB_W.get_coeffs();
+    }
   }
 
   /// Computes the generalized forces `tau` for a single BodyNode.
@@ -547,6 +558,8 @@ class BodyNode : public MultibodyTreeElement<BodyNode<T>, BodyNodeIndex> {
   ///   An already updated position kinematics cache in sync with `context`.
   /// @param[in] vc
   ///   An already updated velocity kinematics cache in sync with `context`.
+  ///   If vc is nullptr, velocities are assumed to be zero and velocity
+  ///   dependent terms are not computed.
   /// @param[in] A_WB_array
   ///   A vector of known spatial accelerations containing the spatial
   ///   acceleration `A_WB` for each body in the MultibodyTree model. It must be
@@ -601,7 +614,7 @@ class BodyNode : public MultibodyTreeElement<BodyNode<T>, BodyNodeIndex> {
   void CalcInverseDynamics_TipToBase(
       const systems::Context<T>& context,
       const PositionKinematicsCache<T>& pc,
-      const VelocityKinematicsCache<T>& vc,
+      const VelocityKinematicsCache<T>* vc,
       const std::vector<SpatialAcceleration<T>>& A_WB_array,
       const SpatialForce<T>& Fapplied_Bo_W,
       const Eigen::Ref<const VectorX<T>>& tau_applied,
@@ -1403,10 +1416,12 @@ class BodyNode : public MultibodyTreeElement<BodyNode<T>, BodyNodeIndex> {
   //   1. Ftot_BBo = b_Bo when A_WB = 0.
   //   2. b_Bo = 0 when w_WB = 0.
   //   3. b_Bo.translational() = 0 when Bo = Bcm (p_BoBcm = 0).
+  //      When vc is nullptr velocites are considered to be zero. Therefore,
+  //      from (2), the bias term is assumed to be zero and is not computed.
   void CalcBodySpatialForceGivenItsSpatialAcceleration(
       const systems::Context<T>& context,
       const PositionKinematicsCache<T>& pc,
-      const VelocityKinematicsCache<T>& vc,
+      const VelocityKinematicsCache<T>* vc,
       const SpatialAcceleration<T>& A_WB, SpatialForce<T>* Ftot_BBo_W_ptr)
   const {
     DRAKE_DEMAND(Ftot_BBo_W_ptr != nullptr);
@@ -1425,10 +1440,6 @@ class BodyNode : public MultibodyTreeElement<BodyNode<T>, BodyNodeIndex> {
     // Orientation of B in W.
     const math::RotationMatrix<T> R_WB(X_WB.linear());
 
-    // Body spatial velocity in W.
-    const SpatialVelocity<T>& V_WB = get_V_WB(vc);
-    const Vector3<T>& w_WB = V_WB.rotational();
-
     // Spatial inertia of body B about Bo and expressed in the body frame B.
     const SpatialInertia<T> M_B = body_B.CalcSpatialInertiaInBodyFrame(context);
 
@@ -1443,17 +1454,24 @@ class BodyNode : public MultibodyTreeElement<BodyNode<T>, BodyNodeIndex> {
     // B's unit rotational inertia about Bo, expressed in W.
     const UnitInertia<T>& G_B_W = M_B_W.get_unit_inertia();
 
-    // Gyroscopic spatial force on body B about Bo.
-    // Notice b_Bo_W(q, v) is a function of positions and velocities only.
-    // TODO(amcastro-tri): consider caching b_Bo_W in PositionDynamicsCache.
-    SpatialForce<T> b_Bo_W = mass *
-        SpatialForce<T>(w_WB.cross(G_B_W * w_WB),         /* rotational */
-                        w_WB.cross(w_WB.cross(p_BoBcm_W)) /* translational */);
-
     // Equations of motion for a rigid body written at a generic point Bo not
     // necessarily coincident with the body's center of mass. This corresponds
     // to Eq. 2.26 (p. 27) in A. Jain's book.
-    Ftot_BBo_W = M_B_W * A_WB + b_Bo_W;
+    Ftot_BBo_W = M_B_W * A_WB;
+
+    // Gyroscopic spatial force on body B about Bo. Zero if velocities are zero.
+    // Notice b_Bo_W(q, v) is a function of positions and velocities only.
+    // TODO(amcastro-tri): cache b_Bo_W.
+    if (vc != nullptr) {
+      // Body spatial velocity in W.
+      const SpatialVelocity<T>& V_WB = get_V_WB(*vc);
+      const Vector3<T>& w_WB = V_WB.rotational();
+      SpatialForce<T> b_Bo_W =
+          mass * SpatialForce<T>(
+                     w_WB.cross(G_B_W * w_WB), /* rotational */
+                     w_WB.cross(w_WB.cross(p_BoBcm_W)) /* translational */);
+      Ftot_BBo_W += b_Bo_W;
+    }
   }
 
   // Implementation for MultibodyTreeElement::DoSetTopology().

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -535,14 +535,29 @@ void MultibodyTree<T>::CalcVelocityKinematicsCache(
 template <typename T>
 void MultibodyTree<T>::CalcSpatialAccelerationsFromVdot(
     const systems::Context<T>& context,
-    const PositionKinematicsCache<T>& pc,
-    const VelocityKinematicsCache<T>& vc,
+    const PositionKinematicsCache<T>&,
+    const VelocityKinematicsCache<T>&,
     const VectorX<T>& known_vdot,
+    std::vector<SpatialAcceleration<T>>* A_WB_array) const {
+  const bool ignore_velocities = false;
+  CalcSpatialAccelerationsFromVdot(context, known_vdot, ignore_velocities,
+                                   A_WB_array);
+}
+
+template <typename T>
+void MultibodyTree<T>::CalcSpatialAccelerationsFromVdot(
+    const systems::Context<T>& context,
+    const VectorX<T>& known_vdot,
+    bool ignore_velocities,
     std::vector<SpatialAcceleration<T>>* A_WB_array) const {
   DRAKE_DEMAND(A_WB_array != nullptr);
   DRAKE_DEMAND(static_cast<int>(A_WB_array->size()) == num_bodies());
 
   DRAKE_DEMAND(known_vdot.size() == topology_.num_velocities());
+
+  const auto& pc = EvalPositionKinematics(context);
+  const VelocityKinematicsCache<T>* vc =
+      ignore_velocities ? nullptr : &EvalVelocityKinematics(context);
 
   // TODO(amcastro-tri): Loop over bodies to compute acceleration kinematics
   // updates corresponding to flexible bodies.
@@ -592,12 +607,9 @@ VectorX<T> MultibodyTree<T>::CalcInverseDynamics(
   // Temporary storage used in the computation of inverse dynamics.
   std::vector<SpatialAcceleration<T>> A_WB(num_bodies());
   std::vector<SpatialForce<T>> F_BMo_W(num_bodies());
-
-  const auto& pc = EvalPositionKinematics(context);
-  const auto& vc = EvalVelocityKinematics(context);
   VectorX<T> tau(num_velocities());
   CalcInverseDynamics(
-      context, pc, vc, known_vdot,
+      context, known_vdot,
       external_forces.body_forces(), external_forces.generalized_forces(),
       &A_WB, &F_BMo_W, &tau);
   return tau;
@@ -605,12 +617,25 @@ VectorX<T> MultibodyTree<T>::CalcInverseDynamics(
 
 template <typename T>
 void MultibodyTree<T>::CalcInverseDynamics(
+    const systems::Context<T>& context, const VectorX<T>& known_vdot,
+    const std::vector<SpatialForce<T>>& Fapplied_Bo_W_array,
+    const Eigen::Ref<const VectorX<T>>& tau_applied_array,
+    std::vector<SpatialAcceleration<T>>* A_WB_array,
+    std::vector<SpatialForce<T>>* F_BMo_W_array,
+    EigenPtr<VectorX<T>> tau_array) const {
+  const bool ignore_velocities = false;
+  CalcInverseDynamics(context, known_vdot, Fapplied_Bo_W_array,
+                      tau_applied_array, ignore_velocities, A_WB_array,
+                      F_BMo_W_array, tau_array);
+}
+
+template <typename T>
+void MultibodyTree<T>::CalcInverseDynamics(
     const systems::Context<T>& context,
-    const PositionKinematicsCache<T>& pc,
-    const VelocityKinematicsCache<T>& vc,
     const VectorX<T>& known_vdot,
     const std::vector<SpatialForce<T>>& Fapplied_Bo_W_array,
     const Eigen::Ref<const VectorX<T>>& tau_applied_array,
+    bool ignore_velocities,
     std::vector<SpatialAcceleration<T>>* A_WB_array,
     std::vector<SpatialForce<T>>* F_BMo_W_array,
     EigenPtr<VectorX<T>> tau_array) const {
@@ -631,7 +656,8 @@ void MultibodyTree<T>::CalcInverseDynamics(
 
   // Compute body spatial accelerations given the generalized accelerations are
   // known.
-  CalcSpatialAccelerationsFromVdot(context, pc, vc, known_vdot, A_WB_array);
+  CalcSpatialAccelerationsFromVdot(context, known_vdot, ignore_velocities,
+                                   A_WB_array);
 
   // Vector of generalized forces per mobilizer.
   // It has zero size if no forces are applied.
@@ -640,6 +666,11 @@ void MultibodyTree<T>::CalcInverseDynamics(
   // Spatial force applied on B at Bo.
   // It is left initialized to zero if no forces are applied.
   SpatialForce<T> Fapplied_Bo_W = SpatialForce<T>::Zero();
+
+  const PositionKinematicsCache<T>& pc = EvalPositionKinematics(context);
+  // Do not compute velocity kinematics if velocities are to be ignored.
+  const VelocityKinematicsCache<T>* vc =
+      ignore_velocities ? nullptr : &EvalVelocityKinematics(context);
 
   // Performs a tip-to-base recursion computing the total spatial force F_BMo_W
   // acting on body B, about point Mo, expressed in the world frame W.
@@ -753,19 +784,6 @@ void MultibodyTree<T>::CalcMassMatrixViaInverseDynamics(
   DRAKE_DEMAND(H != nullptr);
   DRAKE_DEMAND(H->rows() == num_velocities());
   DRAKE_DEMAND(H->cols() == num_velocities());
-  const PositionKinematicsCache<T>& pc = EvalPositionKinematics(context);
-  DoCalcMassMatrixViaInverseDynamics(context, pc, H);
-}
-
-template <typename T>
-void MultibodyTree<T>::DoCalcMassMatrixViaInverseDynamics(
-    const systems::Context<T>& context,
-    const PositionKinematicsCache<T>& pc,
-    EigenPtr<MatrixX<T>> H) const {
-  // TODO(amcastro-tri): Consider passing a boolean flag to tell
-  // CalcInverseDynamics() to ignore velocity dependent terms.
-  VelocityKinematicsCache<T> vc(get_topology());
-  vc.InitializeToZero();
 
   // Compute one column of the mass matrix via inverse dynamics at a time.
   const int nv = num_velocities();
@@ -775,10 +793,15 @@ void MultibodyTree<T>::DoCalcMassMatrixViaInverseDynamics(
   std::vector<SpatialAcceleration<T>> A_WB_array(num_bodies());
   std::vector<SpatialForce<T>> F_BMo_W_array(num_bodies());
 
+  // The mass matrix is only a function of configuration q. Therefore velocity
+  // terms are not considered.
+  const bool ignore_velocities = true;
   for (int j = 0; j < nv; ++j) {
+    // N.B. VectorX<T>::Unit() does not perform any heap allocation but rather
+    // returns a functor-like object that fills the entries in vdot.
     vdot = VectorX<T>::Unit(nv, j);
     tau.setZero();
-    CalcInverseDynamics(context, pc, vc, vdot, {}, VectorX<T>(),
+    CalcInverseDynamics(context, vdot, {}, VectorX<T>(), ignore_velocities,
                         &A_WB_array, &F_BMo_W_array, &tau);
     H->col(j) = tau;
   }
@@ -790,9 +813,14 @@ void MultibodyTree<T>::CalcBiasTerm(
   DRAKE_DEMAND(Cv != nullptr);
   DRAKE_DEMAND(Cv->rows() == num_velocities());
   DRAKE_DEMAND(Cv->cols() == 1);
-  const PositionKinematicsCache<T>& pc = EvalPositionKinematics(context);
-  const VelocityKinematicsCache<T>& vc = EvalVelocityKinematics(context);
-  DoCalcBiasTerm(context, pc, vc, Cv);
+  const int nv = num_velocities();
+  const VectorX<T> vdot = VectorX<T>::Zero(nv);
+  // Auxiliary arrays used by inverse dynamics.
+  std::vector<SpatialAcceleration<T>> A_WB_array(num_bodies());
+  std::vector<SpatialForce<T>> F_BMo_W_array(num_bodies());
+  // TODO(amcastro-tri): provide specific API for when vdot = 0.
+  CalcInverseDynamics(context, vdot, {}, VectorX<T>(),
+                      &A_WB_array, &F_BMo_W_array, Cv);
 }
 
 template <typename T>
@@ -803,24 +831,6 @@ VectorX<T> MultibodyTree<T>::CalcGravityGeneralizedForces(
     return gravity_field_.value()->CalcGravityGeneralizedForces(context);
   }
   return VectorX<T>::Zero(num_velocities());
-}
-
-template <typename T>
-void MultibodyTree<T>::DoCalcBiasTerm(
-    const systems::Context<T>& context,
-    const PositionKinematicsCache<T>& pc,
-    const VelocityKinematicsCache<T>& vc,
-    EigenPtr<VectorX<T>> Cv) const {
-  const int nv = num_velocities();
-  const VectorX<T> vdot = VectorX<T>::Zero(nv);
-
-  // Auxiliary arrays used by inverse dynamics.
-  std::vector<SpatialAcceleration<T>> A_WB_array(num_bodies());
-  std::vector<SpatialForce<T>> F_BMo_W_array(num_bodies());
-
-  // TODO(amcastro-tri): provide specific API for when vdot = 0.
-  CalcInverseDynamics(context, pc, vc, vdot, {}, VectorX<T>(),
-                      &A_WB_array, &F_BMo_W_array, Cv);
 }
 
 template <typename T>

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -1501,15 +1501,12 @@ class MultibodyTree {
   /// @pre The velocity kinematics `vc` must have been previously updated with a
   /// call to CalcVelocityKinematicsCache().
   void CalcInverseDynamics(
-      const systems::Context<T>& context,
-      const PositionKinematicsCache<T>& pc,
-      const VelocityKinematicsCache<T>& vc,
-      const VectorX<T>& known_vdot,
+      const systems::Context<T>& context, const VectorX<T>& known_vdot,
       const std::vector<SpatialForce<T>>& Fapplied_Bo_W_array,
-  const Eigen::Ref<const VectorX<T>>& tau_applied_array,
+      const Eigen::Ref<const VectorX<T>>& tau_applied_array,
       std::vector<SpatialAcceleration<T>>* A_WB_array,
-  std::vector<SpatialForce<T>>* F_BMo_W_array,
-  EigenPtr<VectorX<T>> tau_array) const;
+      std::vector<SpatialForce<T>>* F_BMo_W_array,
+      EigenPtr<VectorX<T>> tau_array) const;
 
   /// See MultibodyPlant method.
   void CalcForceElementsContribution(
@@ -2047,6 +2044,42 @@ class MultibodyTree {
   // that the error message can include that detail.
   void ThrowIfNotFinalized(const char* source_method) const;
 
+  // Given the state of this model in `context` and a known vector
+  // of generalized accelerations `known_vdot`, this method computes the
+  // spatial acceleration `A_WB` for each body as measured and expressed in the
+  // world frame W.
+  //
+  // Iff `ignore_velocities = true` velocity values stored in `context` are
+  // ignored and are assumed to be zero. Therefore, Velocity kinematics and
+  // velocity dependent terms that become zero (such as bias terms) are not
+  // computed to avoid unnecessary work.
+  void CalcSpatialAccelerationsFromVdot(
+      const systems::Context<T>& context, const VectorX<T>& known_vdot,
+      bool ignore_velocities,
+      std::vector<SpatialAcceleration<T>>* A_WB_array) const;
+
+  // Given the state stored in `context` and a
+  // known vector of generalized accelerations `vdot`, this method computes the
+  // set of generalized forces `tau_id` that would need to be applied at each
+  // Mobilizer in order to attain the specified generalized accelerations.
+  // Mathematically, this method computes: <pre>
+  //   tau_id = M(q)v̇ + C(q, v)v - tau_app - ∑ J_WBᵀ(q) Fapp_Bo_W
+  // </pre>
+  // where `M(q)` is the mass matrix, `C(q, v)v` is the bias
+  // term containing Coriolis and gyroscopic effects and `tau_app` consists
+  // of a vector applied generalized forces.
+  //
+  // iff `ignore_velocities = true` velocity values stored in `context` are
+  // ignored and are assumed to be zero. Therefore, C(q, v)v = 0 and it is not
+  // computed to avoid unnecessary work.
+  void CalcInverseDynamics(
+      const systems::Context<T>& context, const VectorX<T>& known_vdot,
+      const std::vector<SpatialForce<T>>& Fapplied_Bo_W_array,
+      const Eigen::Ref<const VectorX<T>>& tau_applied_array,
+      bool ignore_velocities, std::vector<SpatialAcceleration<T>>* A_WB_array,
+      std::vector<SpatialForce<T>>* F_BMo_W_array,
+      EigenPtr<VectorX<T>> tau_array) const;
+
   // Helper method to compute the rotational part of the frame Jacobian Jr_WFq
   // and the translational part of the frame Jacobian Jt_WFq for a list of
   // points Q which instantaneously move with frame F that is, the position
@@ -2117,31 +2150,6 @@ class MultibodyTree {
       const Eigen::Ref<const MatrixX<T>>& p_WQ_list,
       JacobianWrtVariable with_respect_to,
       EigenPtr<MatrixX<T>> Jr_WFq, EigenPtr<MatrixX<T>> Jt_WFq) const;
-
-  // Implementation for CalcMassMatrixViaInverseDynamics().
-  // It assumes:
-  //  - The position kinematics cache object is already updated to be in sync
-  //    with `context`.
-  //  - H is not nullptr.
-  //  - H has storage for a square matrix of size num_velocities().
-  void DoCalcMassMatrixViaInverseDynamics(
-      const systems::Context<T>& context,
-      const PositionKinematicsCache<T>& pc,
-      EigenPtr<MatrixX<T>> H) const;
-
-  // Implementation of CalcBiasTerm().
-  // It assumes:
-  //  - The position kinematics cache object is already updated to be in sync
-  //    with `context`.
-  //  - The velocity kinematics cache object is already updated to be in sync
-  //    with `context`.
-  //  - Cv is not nullptr.
-  //  - Cv has storage for a vector of size num_velocities().
-  void DoCalcBiasTerm(
-      const systems::Context<T>& context,
-      const PositionKinematicsCache<T>& pc,
-      const VelocityKinematicsCache<T>& vc,
-      EigenPtr<VectorX<T>> Cv) const;
 
   // Helper method to apply forces due to damping at the joints.
   // MultibodyTree treats damping forces separately from other ForceElement

--- a/multibody/tree/test/tree_from_joints_test.cc
+++ b/multibody/tree/test/tree_from_joints_test.cc
@@ -340,7 +340,7 @@ class PendulumTests : public ::testing::Test {
     // With vdot = 0, this computes:
     //   rhs = C(q, v)v - tau_app - ∑ J_WBᵀ(q) Fapp_Bo_W.
     tree().CalcInverseDynamics(
-        *context_, pc, vc, vdot,
+        *context_, vdot,
         F_BBo_W_array, tau_array,
         &A_WB_array,
         &F_BMo_W, &tau  /* Output forces */);

--- a/multibody/tree/test/tree_from_mobilizers_test.cc
+++ b/multibody/tree/test/tree_from_mobilizers_test.cc
@@ -694,7 +694,7 @@ class PendulumKinematicTests : public PendulumTests {
     tau.setConstant(std::numeric_limits<double>::quiet_NaN());
     tau_applied.setZero();
     tree().CalcInverseDynamics(
-        *context_, pc, vc, vdot, Fapplied_Bo_W_array, tau_applied,
+        *context_, vdot, Fapplied_Bo_W_array, tau_applied,
         &A_WB_array, &F_BMo_W_array, &tau);
     // The result from inverse dynamics must be tau = -tau_g(q).
     EXPECT_TRUE(tau.isApprox(-tau_g_expected, kTolerance));
@@ -703,7 +703,7 @@ class PendulumKinematicTests : public PendulumTests {
     // Fapplied_Bo_W_array will get overwritten through the output argument).
     tau_applied.setZero();  // This will now get overwritten.
     tree().CalcInverseDynamics(
-        *context_, pc, vc, vdot, Fapplied_Bo_W_array, tau_applied,
+        *context_, vdot, Fapplied_Bo_W_array, tau_applied,
         &A_WB_array, &Fapplied_Bo_W_array, &tau_applied);
     // The result from inverse dynamics must be tau = -tau_g(q).
     EXPECT_TRUE(tau.isApprox(-tau_g_expected, kTolerance));
@@ -801,7 +801,7 @@ class PendulumKinematicTests : public PendulumTests {
     VectorXd tau(tree().num_velocities());
     vector<SpatialAcceleration<double>> A_WB_array(tree().num_bodies());
     vector<SpatialForce<double>> F_BMo_W_array(tree().num_bodies());
-    tree().CalcInverseDynamics(*context_, pc, vc, vdot, {}, VectorXd(),
+    tree().CalcInverseDynamics(*context_, vdot, {}, VectorXd(),
                                 &A_WB_array, &F_BMo_W_array, &tau);
 
     // ======================================================================

--- a/multibody/tree/uniform_gravity_field_element.cc
+++ b/multibody/tree/uniform_gravity_field_element.cc
@@ -56,7 +56,7 @@ VectorX<T> UniformGravityFieldElement<T>::CalcGravityGeneralizedForces(
   // TODO(amcastro-tri): Replace this inverse dynamics implementation by a JᵀF
   // operator implementation, which would be more efficient.
   model.CalcInverseDynamics(
-      context, pc, vc, /* state */
+      context,
       VectorX<T>::Zero(model.num_velocities()), /* vdot = 0 */
       /* Applied forces. In this case only gravity. */
       forces.body_forces(), forces.generalized_forces(),


### PR DESCRIPTION
What the title says. No public APIs introduced. This code is verified by unit tests already in master telling us that inverse dynamics and mass matrix computations were not broken by this PR.
An initial clean up of my dev branch towards #10447, relates to #10322.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11334)
<!-- Reviewable:end -->
