### PR TITLE
Disable "Query welded bodies pre-finalization"

### DIFF
--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -2465,9 +2465,6 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// presence of a weld joint, not by other constructs that prevent mobility
   /// (e.g. constraints).
   ///
-  /// This method can be called at any time during the lifetime of `this` plant,
-  /// either pre- or post-finalize, see Finalize().
-  ///
   /// Meant to be used with `CollectRegisteredGeometries`.
   ///
   /// The following example demonstrates filtering collisions between all
@@ -2486,6 +2483,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   ///
   /// @returns all bodies rigidly fixed to `body`. This does not return the
   /// bodies in any prescribed order.
+  /// @throws std::exception if called pre-finalize.
   /// @throws std::exception if `body` is not part of this plant.
   std::vector<const Body<T>*> GetBodiesWeldedTo(const Body<T>& body) const;
 

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -1096,11 +1096,18 @@ GTEST_TEST(MultibodyPlantTest, GetBodiesWeldedTo) {
   const Body<double>& upper = plant.GetBodyByName("upper_section");
   const Body<double>& lower = plant.GetBodyByName("lower_section");
 
+  // TODO(jwnimmer-tri) The block of code inside the "#if 0" is the tests that
+  // we *want* to pass, but don't yet.
+#if 0
   // Verify we can call GetBodiesWeldedTo() pre-finalize.
   EXPECT_THAT(plant.GetBodiesWeldedTo(plant.world_body()),
               UnorderedElementsAreArray({&plant.world_body()}));
   EXPECT_THAT(plant.GetBodiesWeldedTo(lower),
               UnorderedElementsAreArray({&upper, &lower}));
+#else
+  EXPECT_THROW(plant.GetBodiesWeldedTo(plant.world_body()), std::exception);
+  EXPECT_THROW(plant.GetBodiesWeldedTo(lower), std::exception);
+#endif
 
   // And post-finalize.
   plant.Finalize();


### PR DESCRIPTION
After #1127 merged, the `GetBodiesWeldedTo` method started lying.

This partially reverts f44d069a998f847b67de18f04d232080bbfa3e5e (#11257) by not asking the `internal::MultibodyGraph` questions anymore.

If we can't find a real fix soon, we can use this as a band-aid for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11343)
<!-- Reviewable:end -->
