### PR TITLE
systems/lcm: Deprecate LcmAndVectorBaseTranslator

### DIFF
--- a/systems/lcm/BUILD.bazel
+++ b/systems/lcm/BUILD.bazel
@@ -36,8 +36,9 @@ drake_cc_library(
     ],
     deps = [
         ":lcm_publisher_system",
-        ":lcmt_drake_signal_translator",
+        "//lcmtypes:drake_signal",
         "//systems/framework:diagram_builder",
+        "//systems/framework:leaf_system",
     ],
 )
 
@@ -48,6 +49,9 @@ drake_cc_library(
     ],
     hdrs = [
         "lcm_and_vector_base_translator.h",
+    ],
+    copts = [
+        "-Wno-deprecated-declarations",
     ],
     deps = [
         "//common:essential",
@@ -140,6 +144,9 @@ drake_cc_library(
     name = "lcmt_drake_signal_translator",
     srcs = ["lcmt_drake_signal_translator.cc"],
     hdrs = ["lcmt_drake_signal_translator.h"],
+    copts = [
+        "-Wno-deprecated-declarations",
+    ],
     deps = [
         ":translator",
         "//lcmtypes:drake_signal",

--- a/systems/lcm/connect_lcm_scope.h
+++ b/systems/lcm/connect_lcm_scope.h
@@ -10,19 +10,12 @@ namespace systems {
 namespace lcm {
 
 /**
- Provides the ability to publish any VectorBase<double> output port to the LCM
+ Provides the ability to publish any vector-valued output port to the LCM
  @p channel, using the drake::lcmt_drake_signal LCM message type, by adding
  an appropriate LcmPublisherSystem to the @p builder.  If @p lcm is
  null, then an LCM instance will be created automatically (but this is
  expensive, and creating multiple LCM instances in a single process should be
  avoided).
-
- What it does is:
-
- - adds systems LcmtDrakeSignalTranslator and LcmPublisherSystem to
-   the Diagram and connects the translator output to the publisher input, and
- - connects the @p src output to the LcmtDrakeSignalTranslator
-   system.
 
  The intention is to enable logging and debugging in complex diagrams
  using external tools like `lcm-spy`.  Consider using

--- a/systems/lcm/lcm_and_vector_base_translator.h
+++ b/systems/lcm/lcm_and_vector_base_translator.h
@@ -5,18 +5,20 @@
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/systems/framework/basic_vector.h"
 
 namespace drake {
 namespace systems {
 namespace lcm {
 
-// TODO(jwnimmer-tri) We should deprecated and then remove this base class.
 /**
  * Defines an abstract parent class of all translators that convert between
  * LCM message bytes and `drake::systems::VectorBase` objects.
  */
-class LcmAndVectorBaseTranslator {
+class DRAKE_DEPRECATED("2019-08-01",
+    "LcmAndVectorBaseTranslator is deprecated, with no replacement.")
+LcmAndVectorBaseTranslator {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LcmAndVectorBaseTranslator)
 
@@ -25,6 +27,8 @@ class LcmAndVectorBaseTranslator {
    *
    * @param[in] size The size of the vector in the `VectorBase`.
    */
+  DRAKE_DEPRECATED("2019-08-01",
+      "LcmAndVectorBaseTranslator is deprecated, with no replacement.")
   explicit LcmAndVectorBaseTranslator(int size);
   virtual ~LcmAndVectorBaseTranslator();
 
@@ -32,6 +36,8 @@ class LcmAndVectorBaseTranslator {
    * Returns the size of the vector in the `drake::systems::VectorBase`
    * object.
    */
+  DRAKE_DEPRECATED("2019-08-01",
+      "LcmAndVectorBaseTranslator is deprecated, with no replacement.")
   int get_vector_size() const;
 
   /**
@@ -43,6 +49,8 @@ class LcmAndVectorBaseTranslator {
    * The default implementation in this class returns nullptr.  Subclasses that
    * require custom VectorBase subtypes should override it.
    */
+  DRAKE_DEPRECATED("2019-08-01",
+      "LcmAndVectorBaseTranslator is deprecated, with no replacement.")
   virtual std::unique_ptr<BasicVector<double>> AllocateOutputVector() const;
 
   /**
@@ -62,6 +70,8 @@ class LcmAndVectorBaseTranslator {
    * This often occurs when the size of the @p vector_base does not equal
    * or is incompatible with the size of the decoded LCM message.
    */
+  DRAKE_DEPRECATED("2019-08-01",
+      "LcmAndVectorBaseTranslator is deprecated, with no replacement.")
   virtual void Deserialize(
       const void* lcm_message_bytes, int lcm_message_length,
       VectorBase<double>* vector_base) const = 0;
@@ -77,6 +87,8 @@ class LcmAndVectorBaseTranslator {
    * @param[out] lcm_message_bytes The LCM message bytes.
    * This pointer must not be `nullptr`.
    */
+  DRAKE_DEPRECATED("2019-08-01",
+      "LcmAndVectorBaseTranslator is deprecated, with no replacement.")
   virtual void Serialize(double time,
       const VectorBase<double>& vector_base,
       std::vector<uint8_t>* lcm_message_bytes) const = 0;

--- a/systems/lcm/lcmt_drake_signal_translator.h
+++ b/systems/lcm/lcmt_drake_signal_translator.h
@@ -18,7 +18,9 @@ namespace lcm {
  * Assumes the number and order of values in the LCM message and the
  * drake::systems::VectorBase are identical.
  */
-class LcmtDrakeSignalTranslator : public LcmAndVectorBaseTranslator {
+class DRAKE_DEPRECATED("2019-08-01",
+    "LcmtDrakeSignalTranslator is deprecated, with no replacement.")
+LcmtDrakeSignalTranslator : public LcmAndVectorBaseTranslator {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LcmtDrakeSignalTranslator)
 
@@ -29,13 +31,19 @@ class LcmtDrakeSignalTranslator : public LcmAndVectorBaseTranslator {
    * @param[in] size The number of elements in both `VectorBase` and
    * `drake::lcmt_drake_signal`.
    */
+  DRAKE_DEPRECATED("2019-08-01",
+      "LcmtDrakeSignalTranslator is deprecated, with no replacement.")
   explicit LcmtDrakeSignalTranslator(int size)
       : LcmAndVectorBaseTranslator(size) {}
 
+  DRAKE_DEPRECATED("2019-08-01",
+      "LcmtDrakeSignalTranslator is deprecated, with no replacement.")
   void Deserialize(
       const void* lcm_message_bytes, int lcm_message_length,
       VectorBase<double>* vector_base) const override;
 
+  DRAKE_DEPRECATED("2019-08-01",
+      "LcmtDrakeSignalTranslator is deprecated, with no replacement.")
   void Serialize(double time,
       const VectorBase<double>& vector_base,
       std::vector<uint8_t>* lcm_message_bytes) const override;


### PR DESCRIPTION
Nothing in Drake uses this anymore, but in #10514 we failed to mark it as deprecated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11359)
<!-- Reviewable:end -->
