### PR TITLE
pydrake: Restore the attic forwarding shims

### DIFF
--- a/bindings/pydrake/attic/BUILD.bazel
+++ b/bindings/pydrake/attic/BUILD.bazel
@@ -60,4 +60,16 @@ install(
     deps = get_drake_py_installs(PY_LIBRARIES_WITH_INSTALL),
 )
 
+drake_py_unittest(
+    name = "attic_forwarding_test",
+    deps = [
+        "//bindings/pydrake/attic/multibody",
+        "//bindings/pydrake/attic/solvers",
+        "//bindings/pydrake/attic/systems",
+        "//bindings/pydrake/multibody",
+        "//bindings/pydrake/solvers",
+        "//bindings/pydrake/systems",
+    ],
+)
+
 add_lint_tests_pydrake()

--- a/bindings/pydrake/attic/test/attic_forwarding_test.py
+++ b/bindings/pydrake/attic/test/attic_forwarding_test.py
@@ -1,0 +1,56 @@
+"""
+Tests existence of all relevant attic forwarding symbols.
+"""
+
+from contextlib import contextmanager
+import unittest
+import warnings
+
+from pydrake.common.deprecation import DrakeDeprecationWarning
+
+
+class TestAtticForwarding(unittest.TestCase):
+    @contextmanager
+    def expect_deprecation(self):
+        with warnings.catch_warnings():
+            with self.assertRaises(DrakeDeprecationWarning):
+                warnings.simplefilter("error", DrakeDeprecationWarning)
+                yield
+
+    def test_multibody_modules(self):
+        with self.expect_deprecation():
+            import pydrake.multibody.collision
+        with self.expect_deprecation():
+            import pydrake.multibody.joints
+        with self.expect_deprecation():
+            import pydrake.multibody.parsers
+        with self.expect_deprecation():
+            import pydrake.multibody.rigid_body_plant
+        with self.expect_deprecation():
+            import pydrake.multibody.rigid_body
+        with self.expect_deprecation():
+            import pydrake.multibody.rigid_body_tree
+        with self.expect_deprecation():
+            import pydrake.multibody.shapes
+
+    def test_solvers_modules(self):
+        with self.expect_deprecation():
+            import pydrake.solvers.ik
+
+    def test_systems_symbols(self):
+        from pydrake.systems.controllers import (
+            RbtInverseDynamics, RbtInverseDynamicsController,
+        )
+        from pydrake.systems.sensors import RgbdCamera, RgbdCameraDiscrete
+        callable_list = [
+            RbtInverseDynamics,
+            RbtInverseDynamicsController,
+            RgbdCamera,
+            RgbdCameraDiscrete,
+        ]
+        for c in callable_list:
+            with self.expect_deprecation():
+                # N.B. This will emit a deprecation warning before it tries to
+                # call the original constructor, so we need not worry about the
+                # specific arguments.
+                c()

--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -12,6 +12,10 @@ load(
     "drake_py_library",
     "drake_py_unittest",
 )
+load(
+    "@drake//tools/skylark:alias.bzl",
+    "drake_py_library_aliases",
+)
 load("//bindings/pydrake:pydrake.bzl", "add_lint_tests_pydrake")
 
 package(default_visibility = [
@@ -132,6 +136,23 @@ drake_pybind_library(
     ],
 )
 
+PY_LIBRARIES_ATTIC_ALIASES = [
+    ":collision_py",
+    ":joints_py",
+    ":parsers_py",
+    ":rigid_body_plant_py",
+    ":rigid_body_py",
+    ":rigid_body_tree_py",
+    ":shapes_py",
+]
+
+drake_py_library_aliases(
+    actual_subdir = "bindings/pydrake/attic/multibody",
+    add_deprecation_warning = 1,
+    deprecation_removal_date = "2019-06-01",
+    relative_labels = PY_LIBRARIES_ATTIC_ALIASES,
+)
+
 PY_LIBRARIES_WITH_INSTALL = [
     ":benchmarks_py",
     ":inverse_kinematics_py",
@@ -142,7 +163,7 @@ PY_LIBRARIES_WITH_INSTALL = [
     ":tree_py",
 ]
 
-PY_LIBRARIES = [
+PY_LIBRARIES = PY_LIBRARIES_ATTIC_ALIASES + [
     ":module_py",
 ]
 

--- a/bindings/pydrake/multibody/all.py
+++ b/bindings/pydrake/multibody/all.py
@@ -3,6 +3,14 @@ import warnings
 # Deprecated symbols.
 with warnings.catch_warnings():
     warnings.simplefilter("ignore", DeprecationWarning)
+    # - Attic (#9314)
+    from .collision import *
+    from .joints import *
+    from .parsers import *
+    from .rigid_body_plant import *
+    from .rigid_body_tree import *
+    from .rigid_body import *
+    from .shapes import *
     # - Shuffle (#9314. #9366)
     from .multibody_tree.all import *  # noqa
 

--- a/bindings/pydrake/solvers/BUILD.bazel
+++ b/bindings/pydrake/solvers/BUILD.bazel
@@ -22,6 +22,10 @@ load(
     "drake_py_test",
     "drake_py_unittest",
 )
+load(
+    "@drake//tools/skylark:alias.bzl",
+    "drake_py_library_aliases",
+)
 load("//bindings/pydrake:pydrake.bzl", "add_lint_tests_pydrake")
 
 package(default_visibility = [
@@ -123,6 +127,17 @@ drake_pybind_library(
     py_deps = [":mathematicalprogram_py"],
 )
 
+PY_LIBRARIES_ATTIC_ALIASES = [
+    ":ik_py",
+]
+
+drake_py_library_aliases(
+    actual_subdir = "bindings/pydrake/attic/solvers",
+    add_deprecation_warning = 1,
+    deprecation_removal_date = "2019-06-01",
+    relative_labels = PY_LIBRARIES_ATTIC_ALIASES,
+)
+
 PY_LIBRARIES_WITH_INSTALL = [
     ":gurobi_py",
     ":ipopt_py",
@@ -132,7 +147,7 @@ PY_LIBRARIES_WITH_INSTALL = [
     ":snopt_py",
 ]
 
-PY_LIBRARIES = [
+PY_LIBRARIES = PY_LIBRARIES_ATTIC_ALIASES + [
     ":module_py",
 ]
 

--- a/bindings/pydrake/solvers/all.py
+++ b/bindings/pydrake/solvers/all.py
@@ -1,4 +1,10 @@
 from __future__ import absolute_import
+import warnings
+
+# Deprecated symbols.
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
+    from .ik import *
 
 from .mathematicalprogram import *  # noqa
 # TODO(eric.cousineau): Merge these into `mathematicalprogram`.

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -141,6 +141,7 @@ drake_pybind_library(
         "//bindings/pydrake:symbolic_py",
         "//bindings/pydrake/multibody:multibody_tree_py",
     ],
+    py_srcs = ["_controllers_extra.py"],
 )
 
 drake_pybind_library(
@@ -177,6 +178,7 @@ drake_pybind_library(
         "//bindings/pydrake/common:cpp_template_py",
         "//bindings/pydrake/common:eigen_geometry_py",
     ],
+    py_srcs = ["_sensors_extra.py"],
 )
 
 drake_pybind_library(

--- a/bindings/pydrake/systems/_controllers_extra.py
+++ b/bindings/pydrake/systems/_controllers_extra.py
@@ -1,0 +1,8 @@
+from pydrake.common.deprecation import _forward_callables_as_deprecated
+
+# Only try to import attic symbols if they're available.
+try:
+    from pydrake.attic.systems import controllers as _attic
+    _forward_callables_as_deprecated(locals(), _attic, "2019-06-01")
+except ImportError:
+    pass

--- a/bindings/pydrake/systems/_sensors_extra.py
+++ b/bindings/pydrake/systems/_sensors_extra.py
@@ -1,0 +1,8 @@
+from pydrake.common.deprecation import _forward_callables_as_deprecated
+
+# Only try to import attic symbols if they're available.
+try:
+    from pydrake.attic.systems import sensors as _attic
+    _forward_callables_as_deprecated(locals(), _attic, "2019-06-01")
+except ImportError:
+    pass

--- a/bindings/pydrake/systems/controllers_py.cc
+++ b/bindings/pydrake/systems/controllers_py.cc
@@ -153,6 +153,8 @@ PYBIND11_MODULE(controllers, m) {
       py::arg("system"), py::arg("context"), py::arg("Q"), py::arg("R"),
       py::arg("N") = Eigen::Matrix<double, 0, 0>::Zero(),
       py::arg("input_port_index") = 0, doc.LinearQuadraticRegulator.doc_6args);
+
+  ExecuteExtraPythonCode(m);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/systems/sensors_py.cc
+++ b/bindings/pydrake/systems/sensors_py.cc
@@ -215,6 +215,8 @@ PYBIND11_MODULE(sensors, m) {
     };
     type_visit(def_image_input_port, PixelTypeList{});
   }
+
+  ExecuteExtraPythonCode(m);
 }
 
 }  // namespace pydrake


### PR DESCRIPTION
Extend the removal date to 2019-06-01.

The deprecation warnings forewarning about removal did not trigger in all circumstances.

This partially reverts commit 68567cb2c5c5a3bee237655fb95c4dd39530fdb8 (#11358).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11361)
<!-- Reviewable:end -->
