### PR TITLE
Fix an ASan issue in cost_test.cc

### DIFF
--- a/solvers/test/cost_test.cc
+++ b/solvers/test/cost_test.cc
@@ -201,9 +201,9 @@ template <typename C, typename BoundType, typename... Args>
 void VerifyRelatedCost(const Ref<const VectorXd>& x_value, Args&&... args) {
   // Ensure that a constraint constructed in a particular fashion yields
   // equivalent results to its shim, and the related cost.
-  const auto inf = std::numeric_limits<double>::infinity();
-  auto lb = -BoundType(-inf);
-  auto ub = BoundType(inf);
+  const double inf = std::numeric_limits<double>::infinity();
+  BoundType lb = -BoundType(-inf);
+  BoundType ub = BoundType(inf);
   C constraint(std::forward<Args>(args)..., lb, ub);
   typename related_cost<C>::type cost(std::forward<Args>(args)...);
   VectorXd y_expected, y;


### PR DESCRIPTION
To reproduce: `bazel test --config=asan --copt -O0  //solvers:cost_test`

[Error](https://gist.github.com/m-chaturvedi/c2b0b6414c71569a590828784704665d)
[Reference](https://eigen.tuxfamily.org/dox/TopicPitfalls.html)
[Build failure](https://drake-jenkins.csail.mit.edu/view/Mac%20Mojave/job/mac-mojave-clang-bazel-experimental-address-sanitizer/2/)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11371)
<!-- Reviewable:end -->
