### PR TITLE
Autodiff support for the pairwise signed distance query

### DIFF
--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -435,10 +435,10 @@ class GeometryState {
    * anchored object. We DO NOT report the distance between two anchored
    * objects.
    */
-  std::vector<SignedDistancePair<double>>
+  std::vector<SignedDistancePair<T>>
   ComputeSignedDistancePairwiseClosestPoints() const {
     return geometry_engine_->ComputeSignedDistancePairwiseClosestPoints(
-        geometry_index_to_id_map_);
+        geometry_index_to_id_map_, X_WG_);
   }
 
   /** Performs work in support of QueryObject::ComputeSignedDistanceToPoint().

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -715,6 +715,7 @@ class GeometryState {
   // frame Fₖ, and the world frame W is the parent of frame Fₙ.
   // In other words, it is the full evaluation of the kinematic chain from the
   // geometry to the world frame.
+  // TODO(SeanCurtis-TRI): Rename this to X_WGs_ to reflect multiplicity.
   std::vector<Isometry3<T>> X_WG_;
 
   // The pose of each frame relative to the _world_ frame.

--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -71,6 +71,7 @@ drake_cc_library(
 
 drake_cc_library(
     name = "proximity_utilities",
+    srcs = ["proximity_utilities.cc"],
     hdrs = ["proximity_utilities.h"],
     deps = [
         "//geometry:geometry_ids",
@@ -87,6 +88,16 @@ drake_cc_googletest(
         "//common/test_utilities",
         "//geometry:utilities",
         "//math",
+    ],
+)
+
+drake_cc_googletest(
+    name = "distance_sphere_to_shape_test",
+    deps = [
+        ":distance_to_shape",
+        "//common/test_utilities",
+        "//geometry:utilities",
+        "//math:gradient",
     ],
 )
 

--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -13,9 +13,21 @@ package(default_visibility = ["//visibility:public"])
 drake_cc_package_library(
     name = "proximity",
     deps = [
+        ":collision_filter_legacy",
         ":distance_to_point",
         ":distance_to_point_with_gradient",
+        ":distance_to_shape",
         ":proximity_utilities",
+    ],
+)
+
+drake_cc_library(
+    name = "collision_filter_legacy",
+    hdrs = ["collision_filter_legacy.h"],
+    deps = [
+        ":proximity_utilities",
+        "//common:essential",
+        "//common:sorted_vectors_have_intersection",
     ],
 )
 
@@ -43,6 +55,17 @@ drake_cc_library(
         "//geometry/query_results:signed_distance_to_point",
         "//math:geometric_transform",
         "@fcl",
+    ],
+)
+
+drake_cc_library(
+    name = "distance_to_shape",
+    hdrs = ["distance_to_shape.h"],
+    deps = [
+        ":collision_filter_legacy",
+        ":distance_to_point",
+        ":proximity_utilities",
+        "//geometry/query_results:signed_distance_pair",
     ],
 )
 

--- a/geometry/proximity/collision_filter_legacy.h
+++ b/geometry/proximity/collision_filter_legacy.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/sorted_vectors_have_intersection.h"
+#include "drake/geometry/proximity/proximity_utilities.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+// TODO(SeanCurtis-TRI): Replace this "legacy" mechanism with the
+// new-and-improved alternative when it is ready.
+/** A simple class for providing collision filtering functionality similar to
+ that found in RigidBodyTree but made compatible with fcl. The majority of
+ this code is lifted verbatim from drake/multibody/collision/element.{h, cc}.
+
+ The basic principle is that we create "cliques". If geometries A and B belong
+ to the same clique, then the pair (A, B) is filtered. It is possible for A and
+ B to redundantly belong to multiple cliques.
+
+ Geometries are identified by their encoded ids (see EncodedData). Before a
+ geometry can be added to a clique (AddToCollisionClique()) it must be added
+ to this filter system (AddGeometry()).  */
+class CollisionFilterLegacy {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CollisionFilterLegacy)
+
+  CollisionFilterLegacy() = default;
+
+  /** Adds a geometry to the filter system as represented by its encoded `id`
+   (see EncodedData). When added, it will not be part of any filtered pairs.  */
+  void AddGeometry(uintptr_t id) {
+    collision_cliques_.insert({id, std::vector<int>()});
+  }
+
+  /** Reports true if the geometry pair (`id_A`, `id_B`) has been explicitly
+   added to the set of filtered pairs.  */
+  bool CanCollideWith(uintptr_t id_A, uintptr_t id_B) const {
+    // These ids should all be registered with the filter machinery.
+    DRAKE_ASSERT(collision_cliques_.count(id_A) == 1);
+    DRAKE_ASSERT(collision_cliques_.count(id_B) == 1);
+
+    bool excluded = id_A == id_B ||
+                    SortedVectorsHaveIntersection(collision_cliques_.at(id_A),
+                                                  collision_cliques_.at(id_B));
+
+    return !excluded;
+  }
+
+  /** Adds the previously registered geometry indicated by its encoded id
+   `geometry_id` to the clique with the given `clique_id`.  */
+  void AddToCollisionClique(uintptr_t geometry_id, int clique_id) {
+    DRAKE_ASSERT(collision_cliques_.count(geometry_id) == 1);
+
+    std::vector<int>& cliques = collision_cliques_[geometry_id];
+    // Order(N) insertion.
+    // `cliques` is a sorted vector so that checking if two collision elements
+    // belong to a common group can be performed efficiently in order N.
+    // See Element::CanCollideWith() and Element::collision_cliques_ for
+    // explanation.
+    auto it = std::lower_bound(cliques.begin(), cliques.end(), clique_id);
+
+    // This test prevents duplicate clique ids from being added.
+    if (it == cliques.end() || clique_id < *it) cliques.insert(it, clique_id);
+  }
+
+  int num_cliques(uintptr_t geometry_id) const {
+    DRAKE_ASSERT(collision_cliques_.count(geometry_id) == 1);
+    return static_cast<int>(collision_cliques_.at(geometry_id).size());
+  }
+
+  /** Allocates a new clique and returns its id (to use with
+   AddToCollisionClique()). Allocation is _not_ threadsafe.
+   @throws std::logic_error if all cliques have been allocated.  */
+  int next_clique_id() {
+    int clique = next_available_clique_++;
+    if (clique < 0) {
+      throw std::logic_error(
+          "SceneGraph has run out of cliques (more than two billion served)");
+    }
+    return clique;
+  }
+
+  // TODO(SeanCurtis-TRI): Eliminate this method; I'm sure I can reframe the
+  // tests without this.
+  /** (Test support) reports what the next value that would be returned by
+   next_clique_id().  */
+  int peek_next_clique() const { return next_available_clique_; }
+
+ private:
+  // A map between the EncodedData::encoding() value for a geometry and
+  // its set of cliques.
+  std::unordered_map<uintptr_t, std::vector<int>> collision_cliques_;
+
+  int next_available_clique_{0};
+};
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/distance_to_shape.h
+++ b/geometry/proximity/distance_to_shape.h
@@ -9,79 +9,138 @@
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/proximity/collision_filter_legacy.h"
+#include "drake/geometry/proximity/distance_to_point.h"
 #include "drake/geometry/proximity/proximity_utilities.h"
+#include "drake/geometry/query_results/signed_distance_pair.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/math/rotation_matrix.h"
+
+/** @file Provides the structures and logic to support signed distance queries
+ between shapes.  */
 
 namespace drake {
 namespace geometry {
 namespace internal {
 namespace shape_distance {
 
-// Struct for use in DistanceCallback(). Contains the distance request
-// and accumulates result in a drake::geometry::SignedDistancePair vector.
+/** Supporting data for the shape-to-shape signed distance callback (see
+ Callback below). It includes:
+
+    - A map from GeometryIndex to GeometryId (to facilitate reporting GeometryId
+      values in the results).
+    - A collision filter instance.
+    - The T-valued poses of _all_ geometries in the corresponding SceneGraph,
+      each indexed by its corresponding geometry's GeometryIndex.
+    - A vector of distance results -- one instance of SignedDistancePair for
+      every supported geometry which lies with the threshold.
+
+ @tparam T The computation scalar.  */
+template <typename T>
 struct CallbackData {
+  /** Constructs the mostly-specified callback data. The fcl distance request is
+   left in its default constructed state for subsequent configuration. The
+   values are as described above. _Some_ of the parameters are aliased in the
+   data and require the aliased parameters to remain valid at least as long as
+   the CallbackData instance.
+
+   @param geometry_map_in         The index -> id map. Aliased.
+   @param collision_filter_in     The collision filter system. Aliased.
+   @param X_WGs_in                The T-valued poses. Aliased.
+   @param nearest_pairs_in[out]   The output results. Aliased.
+   */
   CallbackData(const std::vector<GeometryId>* geometry_map_in,
-               const CollisionFilterLegacy* collision_filter_in)
+               const CollisionFilterLegacy* collision_filter_in,
+               const std::vector<Isometry3<T>>* X_WGs_in,
+               std::vector<SignedDistancePair<T>>* nearest_pairs_in)
       : geometry_map(*geometry_map_in),
-        collision_filter(*collision_filter_in) {}
-  // Maps so the distance call back can map from engine index to geometry id.
+        collision_filter(*collision_filter_in),
+        X_WGs(*X_WGs_in),
+        nearest_pairs(*nearest_pairs_in) {
+    DRAKE_DEMAND(geometry_map_in);
+    DRAKE_DEMAND(collision_filter_in);
+    DRAKE_DEMAND(X_WGs_in);
+    DRAKE_DEMAND(nearest_pairs_in);
+  }
+
+  /** That map from GeometryIndex to GeometryId.  */
   const std::vector<GeometryId>& geometry_map;
+
+  /** The collision filter system.  */
   const CollisionFilterLegacy& collision_filter;
 
-  // Distance request
+  /** The T-valued poses of all geometries.  */
+  const std::vector<Isometry3<T>>& X_WGs;
+
+  /** The distance query parameters.  */
   fcl::DistanceRequestd request;
 
-  // Vectors of distance results
-  std::vector<SignedDistancePair<double>>* nearest_pairs{};
+  /** The results of the distance query.  */
+  std::vector<SignedDistancePair<T>>& nearest_pairs{};
 };
 
-// An internal functor to support ComputeNarrowPhaseDistance(). It computes
-// the signed distance between a supported pair of geometries.  Each overload
-// to the call operator reports the signed distance (encoded in
-// fcl::DistanceResultd) between the two given geometry arguments using the
-// functor's stored poses.
+/** A functor to support ComputeNarrowPhaseDistance(). It computes the signed
+ distance between a supported pair of geometries. Each overload to the call
+ operator reports the signed distance (encoded in SignedDistancePair<T>)
+ between the two given geometry arguments using the functor's stored poses.
+
+ @tparam T  Computation scalar type.  */
+template <typename T>
 class DistancePairGeometry {
  public:
-  // @param result   We report the signed distance and the witness points in
-  //                 the struct fcl::DistanceResultd pointed by `result`.
-  // @note Those aspects of the query geometry that do not depend on the
-  // shape type are provided to the constructor. The overloaded call operator
-  // takes the actual shape types.
-  DistancePairGeometry(const GeometryId& id_A, const GeometryId& id_B,
-                       const math::RigidTransformd& X_WA,
-                       const math::RigidTransformd& X_WB,
-                       fcl::DistanceResultd* result)
-      : id_A_(id_A), id_B_(id_B), X_WA_(X_WA), X_WB_(X_WB), result_(result) {}
+  /** Constructs the functor caching all parameters that do _not_ depend on
+   the shape type.
 
-  // Given a sphere A centered at Ao with radius r and another geometry B,
-  // we want to compute
-  // 1. φ_A,B = the signed distance between the two objects, which is positive
-  //    for non-overlapping objects and equals the negative penetration depth
-  //    for overlapping objects.
-  // 2. Na, Nb = a pair of witness points, Na ∈ ∂A, Nb ∈ ∂B (not necessarily
-  //    unique), |Na-Nb| = |φ_A,B|.
-  //
-  // Define these functions: (available from SignedDistanceToPoint)
-  //   φ_B:ℝ³→ℝ, φ_B(p)  = signed distance to point p from B.
-  //   η_B:ℝ³→ℝ³, η_B(p) = a nearest point to p on the boundary ∂B (not
-  //                       necessarily unique).
-  //   ∇φ_B:ℝ³→ℝ³, ∇φ_B(p) = gradient vector of φ_B with respect to p.
-  //                         It has unit length by construction.
-  // Algorithm:
-  // 1. φ_A,B = φ_B(Ao) - r
-  // 2. Nb = η_B(Ao)
-  // 3. Na = Ao - r * ∇φ_B(Ao)
+   @param id_A         Identifier of the first geometry passed to operator().
+   @param id_B         Identifier of the second geometry passed to operator().
+   @param X_WA         Pose of geometry A in world space, stored in the query
+                       scalar T.
+   @param X_WB         Pose of geometry B in world space, stored in the query
+                       scalar T.
+   @param[out] result  The signed distance values are stored here.  */
+  DistancePairGeometry(const GeometryId& id_A, const GeometryId& id_B,
+                       const math::RigidTransform<T>& X_WA,
+                       const math::RigidTransform<T>& X_WB,
+                       SignedDistancePair<T>* result)
+      : id_A_(id_A), id_B_(id_B), X_WA_(X_WA), X_WB_(X_WB), result_(result) {
+    DRAKE_ASSERT(result);
+  }
+
+  /** @name  Overloads in support of sphere-shape computation
+
+   Given a sphere A centered at Ao with radius r and another geometry B,
+   we want to compute
+   1. φ_A,B = the signed distance between the two objects, which is positive
+      for non-overlapping objects and equals the negative penetration depth
+      for overlapping objects.
+   2. Na, Nb = a pair of witness points, Na ∈ ∂A, Nb ∈ ∂B (not necessarily
+      unique), |Na-Nb| = |φ_A,B|.
+
+   Define these functions: (available from SignedDistanceToPoint)
+     φ_B:ℝ³→ℝ, φ_B(p)  = signed distance to point p from B.
+     η_B:ℝ³→ℝ³, η_B(p) = a nearest point to p on the boundary ∂B (not
+                         necessarily unique).
+     ∇φ_B:ℝ³→ℝ³, ∇φ_B(p) = gradient vector of φ_B with respect to p.
+                           It has unit length by construction.
+   Algorithm:
+   1. φ_A,B = φ_B(Ao) - r
+   2. Nb = η_B(Ao)
+   3. Na = Ao - r * ∇φ_B(Ao)  */
+  //@{
+
   void operator()(const fcl::Sphered& sphere_A, const fcl::Sphered& sphere_B) {
     SphereShapeDistance(sphere_A, sphere_B);
   }
+
   void operator()(const fcl::Sphered& sphere_A, const fcl::Boxd& box_B) {
     SphereShapeDistance(sphere_A, box_B);
   }
+
   void operator()(const fcl::Sphered& sphere_A,
                   const fcl::Cylinderd& cylinder_B) {
     SphereShapeDistance(sphere_A, cylinder_B);
   }
+
+  //@}
 
  private:
   // Distance computation between a sphere A and a generic shape B. We use
@@ -90,56 +149,117 @@ class DistancePairGeometry {
   template <typename FclShape>
   void SphereShapeDistance(const fcl::Sphered& sphere_A,
                            const FclShape& shape_B) {
-    const SignedDistanceToPoint<double> shape_B_to_point_Ao =
-        point_distance::DistanceToPoint<double>(id_B_, X_WB_,
-                                                X_WA_.translation())(shape_B);
-    const double distance = shape_B_to_point_Ao.distance - sphere_A.radius;
+    const SignedDistanceToPoint<T> shape_B_to_point_Ao =
+        point_distance::DistanceToPoint<T>(id_B_, X_WB_,
+                                           X_WA_.translation())(shape_B);
+    result_->id_A = id_A_;
+    result_->id_B = id_B_;
+    result_->distance = shape_B_to_point_Ao.distance - sphere_A.radius;
     // Nb is the witness point on ∂B.
-    const Eigen::Vector3d& p_BNb = shape_B_to_point_Ao.p_GN;
-    const Eigen::Vector3d p_WNb = X_WB_ * p_BNb;
-    const Eigen::Vector3d& gradB_W = shape_B_to_point_Ao.grad_W;
+    result_->p_BCb = shape_B_to_point_Ao.p_GN;
+    result_->nhat_BA_W = shape_B_to_point_Ao.grad_W;
     // Na is the witness point on ∂A.
-    const Eigen::Vector3d p_WNa =
-        WitnessPointOnSphere(sphere_A.radius, X_WA_, gradB_W);
-    // fcl::DistanceResult expects -1 for primitive shapes.
-    result_->update(distance, &sphere_A, &shape_B, -1, -1, p_WNa, p_WNb);
-  }
-  // Performs step 3. Na = Ao - r * ∇φ_B(Ao).
-  // @param radius_A the radius of the sphere A.
-  // @param X_WA the pose of the sphere A.
-  // @param gradB_W the gradient vector ∇φ_B(Ao).
-  // @retval p_WNa the witness point Na ∈ ∂A expressed in World frame.
-  Eigen::Vector3d WitnessPointOnSphere(
-      const double radius_A, const math::RigidTransformd& X_WA,
-      const Eigen::Vector3d& gradB_W) const {
-    // Notation:
-    // gradB_W = ∇φ_B(Ao) expressed in World frame.
-    // gradB_A = ∇φ_B(Ao) expressed in A's frame.
-    const math::RotationMatrixd& R_WA = X_WA.rotation();
-    const math::RotationMatrixd R_AW = R_WA.transpose();
-    const Eigen::Vector3d gradB_A = R_AW * gradB_W;
-    // By construction gradB_A has unit length.
-    const Eigen::Vector3d p_ANa = -radius_A * gradB_A;
-    const Eigen::Vector3d p_WNa = X_WA * p_ANa;
-    return p_WNa;
+    result_->p_ACa = -sphere_A.radius * (X_WA_.rotation().transpose() *
+        shape_B_to_point_Ao.grad_W);
   }
 
   GeometryId id_A_;
   GeometryId id_B_;
-  math::RigidTransformd X_WA_;
-  math::RigidTransformd X_WB_;
-  fcl::DistanceResultd* result_;
+  math::RigidTransform<T> X_WA_;
+  math::RigidTransform<T> X_WB_;
+  SignedDistancePair<T>* result_;
 };
 
-// Helps DistanceCallback(). Do it in closed forms for sphere-sphere,
-// sphere-box, or sphere-cylinder. Otherwise, use FCL GJK/EPA.
-void ComputeNarrowPhaseDistance(const fcl::CollisionObjectd* a,
-                                const fcl::CollisionObjectd* b,
+/** @name  Definition of fallback for missing primitive-primitive tests
+
+ Generally, we favor hand-crafted functions for determining the signed distance
+ between two shapes. However, just because we have no such function for a
+ particular geometry pair does not mean we have no recourse for computing
+ signed distance. Instead, we have the "fallback" function.
+
+ The fallback function is a simple interface that takes two fcl collision
+ objects (called `a` and `b`), fcl distance request parameters, and a pointer
+ to the SignedDistancePair which will be populated with the results of the
+ query.
+
+ Currently, our ability to fallback depends on the scalar type. This family
+ of functions defines the fallback logic for the various scalar types. It
+ applies a _whitelist_-based approach in that we assume there is no fallback
+ for a scalar type unless one is explicitly provided.  */
+//@{
+
+/** For all non-whitelisted scalar types T, throws an exception declaring the
+ unsupported combination of geometry types and scalar type.  */
+template <typename T>
+void CalcDistanceFallback(const fcl::CollisionObjectd& a,
+                          const fcl::CollisionObjectd& b,
+                          const fcl::DistanceRequestd& /* request */,
+                          SignedDistancePair<T>* /* pair_data */) {
+  // By default, there is no fallback. For every scalar type for which one
+  // actually exists, it should be specialized below.
+  throw std::logic_error(fmt::format(
+      "Signed distance queries between shapes '{}' and '{}' "
+      "are not supported for scalar type {}",
+      GetGeometryName(a), GetGeometryName(b), NiceTypeName::Get<T>()));
+}
+
+/** For the double scalar, computes the signed distance between the two objects.
+ */
+template <>
+void CalcDistanceFallback<double>(const fcl::CollisionObjectd& a,
+                                  const fcl::CollisionObjectd& b,
+                                  const fcl::DistanceRequestd& request,
+                                  SignedDistancePair<double>* pair_data) {
+  fcl::DistanceResultd result;
+  fcl::distance(&a, &b, request, result);
+
+  pair_data->distance = result.min_distance;
+
+  // Setting the witness points.
+  const Eigen::Vector3d& p_WCa = result.nearest_points[0];
+  pair_data->p_ACa = a.getTransform().inverse() * p_WCa;
+  const Eigen::Vector3d& p_WCb = result.nearest_points[1];
+  pair_data->p_BCb = b.getTransform().inverse() * p_WCb;
+
+  // Setting the normal.
+  const double kEps = std::numeric_limits<double>::epsilon();
+  const double kNan = std::numeric_limits<double>::quiet_NaN();
+
+  // TODO(DamrongGuoy): For sphere-{sphere,box,cylinder} we will start
+  //  working on the right nhat when min_distance is 0 or almost 0 after
+  //  PR #10813 lands to avoid conflicts with this PR #10823. For now,
+  //  we simply return NaN in nhat when min_distance is 0 or almost 0.
+  pair_data->nhat_BA_W = std::abs(result.min_distance) < kEps
+                         ? Eigen::Vector3d(kNan, kNan, kNan)
+                         : (p_WCa - p_WCb) / result.min_distance;
+}
+
+//@}
+
+/** Dispatches the narrowphase shape-shape query for the object pair (`a, `b`)
+ to the appropriate primitive-primitive function (optionally defaulting to the
+ type- and shape-dependent fallback function).
+
+ @param a               The first object in the pair.
+ @param X_WA            The pose of object `a` expressed in the world frame
+                        stored in the computation scalar type.
+ @param b               The second object in the pair.
+ @param X_WB            The pose of object `b` expressed in the world frame
+                        stored in the computation scalar type.
+ @param geometry_map    A map from GeometryIndex to GeometryId.
+ @param request         The distance request parameters.
+ @param result          The structure to capture the computation results in.
+ @tparam T Computation scalar type.  */
+template <typename T>
+void ComputeNarrowPhaseDistance(const fcl::CollisionObjectd& a,
+                                const Isometry3<T>& X_WA,
+                                const fcl::CollisionObjectd& b,
+                                const Isometry3<T>& X_WB,
                                 const std::vector<GeometryId>& geometry_map,
                                 const fcl::DistanceRequestd& request,
-                                fcl::DistanceResultd* result) {
-  const fcl::CollisionGeometryd* a_geometry = a->collisionGeometry().get();
-  const fcl::CollisionGeometryd* b_geometry = b->collisionGeometry().get();
+                                SignedDistancePair<T>* result) {
+  const fcl::CollisionGeometryd* a_geometry = a.collisionGeometry().get();
+  const fcl::CollisionGeometryd* b_geometry = b.collisionGeometry().get();
 
   // We use FCL's GJK/EPA fallback in those geometries we haven't explicitly
   // supported. However, FCL doesn't support: half spaces, planes, triangles, or
@@ -148,9 +268,12 @@ void ComputeNarrowPhaseDistance(const fcl::CollisionObjectd* a,
   // NOTE: Currently this only tests for halfspace (because it is an otherwise
   // supported geometry type in SceneGraph. When meshes, planes, and/or octrees
   // are supported, this error would have to be modified.
-  // TODO(SeanCurtis-TRI): Remove this test when FCL supports signed distance
-  // queries for halfspaces (see issue #10905). Also see FCL issue
+  // TODO(SeanCurtis-TRI): Remove this test when FCL/Drake supports signed
+  // distance queries for halfspaces (see issue #10905). Also see FCL issue
   // https://github.com/flexible-collision-library/fcl/issues/383.
+  // TODO(SeanCurtis-TRI): Convert this to a drakeassert/drake demand. It should
+  // be the case that this isn't called *except* by the Callback, and the
+  // Callback should already have handled the question of unsupported geometry.
   if (a_geometry->getNodeType() == fcl::GEOM_HALFSPACE ||
       b_geometry->getNodeType() == fcl::GEOM_HALFSPACE) {
     throw std::logic_error(
@@ -158,13 +281,11 @@ void ComputeNarrowPhaseDistance(const fcl::CollisionObjectd* a,
         "Try using a large box instead.");
   }
 
-  const bool a_is_sphere =
-      a->collisionGeometry().get()->getNodeType() == fcl::GEOM_SPHERE;
-  const bool b_is_sphere =
-      b->collisionGeometry().get()->getNodeType() == fcl::GEOM_SPHERE;
-  const bool no_sphere = ((!a_is_sphere) && (!b_is_sphere));
+  const bool a_is_sphere = a_geometry->getNodeType() == fcl::GEOM_SPHERE;
+  const bool b_is_sphere = b_geometry->getNodeType() == fcl::GEOM_SPHERE;
+  const bool no_sphere = !(a_is_sphere || b_is_sphere);
   if (no_sphere) {
-    fcl::distance(a, b, request, *result);
+    CalcDistanceFallback<T>(a, b, request, result);
     return;
   }
   DRAKE_ASSERT(a_is_sphere || b_is_sphere);
@@ -174,15 +295,15 @@ void ComputeNarrowPhaseDistance(const fcl::CollisionObjectd* a,
   // that takes (sphere, other) but not (other, sphere).  This scheme helps us
   // keep the code compact; however, we might have to re-order the result
   // afterwards.
-  const fcl::CollisionObjectd* s = a_is_sphere ? a : b;
-  const fcl::CollisionObjectd* o = a_is_sphere ? b : a;
-  const fcl::CollisionGeometryd* s_geometry = s->collisionGeometry().get();
-  const fcl::CollisionGeometryd* o_geometry = o->collisionGeometry().get();
-  const math::RigidTransformd X_WS(s->getTransform());
-  const math::RigidTransformd X_WO(o->getTransform());
-  const auto id_S = EncodedData(*s).id(geometry_map);
-  const auto id_O = EncodedData(*o).id(geometry_map);
-  DistancePairGeometry distance_pair(id_S, id_O, X_WS, X_WO, result);
+  const fcl::CollisionObjectd& s = a_is_sphere ? a : b;
+  const fcl::CollisionObjectd& o = a_is_sphere ? b : a;
+  const fcl::CollisionGeometryd* s_geometry = s.collisionGeometry().get();
+  const fcl::CollisionGeometryd* o_geometry = o.collisionGeometry().get();
+  const math::RigidTransform<T> X_WS(a_is_sphere ? X_WA : X_WB);
+  const math::RigidTransform<T> X_WO(a_is_sphere ? X_WB : X_WA);
+  const auto id_S = EncodedData(s).id(geometry_map);
+  const auto id_O = EncodedData(o).id(geometry_map);
+  DistancePairGeometry<T> distance_pair(id_S, id_O, X_WS, X_WO, result);
   const auto& sphere_S = *static_cast<const fcl::Sphered*>(s_geometry);
   switch (o_geometry->getNodeType()) {
     case fcl::GEOM_SPHERE: {
@@ -203,81 +324,145 @@ void ComputeNarrowPhaseDistance(const fcl::CollisionObjectd* a,
     default: {
       // We don't have a closed form solution for the other geometry, so we
       // call FCL GJK/EPA.
-      fcl::distance(s, o, request, *result);
+      CalcDistanceFallback<T>(a, b, request, result);
       break;
     }
   }
   // If needed, re-order the result for (s,o) back to the result for (a,b).
   if (!a_is_sphere) {
-    std::swap(result->o1, result->o2);
-    std::swap(result->nearest_points[0], result->nearest_points[1]);
+    result->SwapAAndB();
   }
 }
 
-// The callback function in fcl::distance request. The final unnamed parameter
-// is `dist`, which is used in fcl::distance, that if the distance between two
-// geometries is proved to be greater than `dist` (for example, the smallest
-// distance between the bounding boxes containing object A and object B is
-// greater than `dist`), then fcl::distance will skip this callback. In our
-// case, as we want to compute the distance between any pair of geometries, we
-// leave `dist` unchanged as its default value (max_double). So the last
-// parameter is merely a placeholder, and not being used or updated in the
-// callback.
-bool Callback(fcl::CollisionObjectd* fcl_object_A_ptr,
-              fcl::CollisionObjectd* fcl_object_B_ptr,
-              // NOLINTNEXTLINE
-              void* callback_data, double&) {
-  auto& distance_data = *static_cast<CallbackData*>(callback_data);
-  const std::vector<GeometryId>& geometry_map = distance_data.geometry_map;
-  // We want to pass object_A and object_B to the narrowphase distance in a
-  // specific order. This way the broadphase distance is free to give us
-  // either (A,B) or (B,A), and the narrowphase distance will always give the
-  // same result.
-  const GeometryId orig_id_A = EncodedData(*fcl_object_A_ptr).id(geometry_map);
-  const GeometryId orig_id_B = EncodedData(*fcl_object_B_ptr).id(geometry_map);
-  const bool swap_AB = (orig_id_B < orig_id_A);
-  const GeometryId id_A = swap_AB ? orig_id_B : orig_id_A;
-  const GeometryId id_B = swap_AB ? orig_id_A : orig_id_B;
-  // NOTE: Although this function *takes* pointers to non-const objects to
-  // satisfy the fcl api, it should not exploit the non-constness to modify
-  // the collision objects. We ensure this by a reference to a const version
-  // and not directly use the provided pointers afterwards.
-  const fcl::CollisionObjectd& fcl_object_A =
-      *(swap_AB ? fcl_object_B_ptr : fcl_object_A_ptr);
-  const fcl::CollisionObjectd& fcl_object_B =
-      *(swap_AB ? fcl_object_A_ptr : fcl_object_B_ptr);
+// TODO(SeanCurtis-TRI): Replace this clunky mechanism with a new mechanism
+// which does this implicitly via ADL and templates.
+/** @name   Mechanism for reporting on which scalars and for which shape-pairs
+            shape-to-shape queries can be made.
 
-  // Extract the collision filter keys from the fcl collision objects. These
-  // keys will also be used to map the fcl collision object back to the Drake
-  // GeometryId for colliding geometries.
-  const EncodedData encoding_A(fcl_object_A);
-  const EncodedData encoding_B(fcl_object_B);
+ By default, nothing is supported. For each supported scalar type, a class
+ specialization is provided which whitelists the supported shape types.
 
-  const bool can_collide = distance_data.collision_filter.CanCollideWith(
-      encoding_A.encoded_data(), encoding_B.encoded_data());
+ @tparam T      The computational scalar type.  */
+//@{
 
-  if (can_collide) {
-    fcl::DistanceResultd result;
-    ComputeNarrowPhaseDistance(&fcl_object_A, &fcl_object_B, geometry_map,
-                               distance_data.request, &result);
-    const Eigen::Vector3d& p_WCa = result.nearest_points[0];
-    const Eigen::Vector3d& p_WCb = result.nearest_points[1];
-    const Eigen::Vector3d p_ACa = fcl_object_A.getTransform().inverse() * p_WCa;
-    const Eigen::Vector3d p_BCb = fcl_object_B.getTransform().inverse() * p_WCb;
-    // TODO(DamrongGuoy): For sphere-{sphere,box,cylinder} we will start
-    //  working on the right nhat when min_distance is 0 or almost 0 after
-    //  PR #10813 lands to avoid conflicts with this PR #10823. For now,
-    //  we simply return NaN in nhat when min_distance is 0 or almost 0.
-    const Eigen::Vector3d nhat_BA_W =
-        (std::abs(result.min_distance) < std::numeric_limits<double>::epsilon())
-        ? Eigen::Vector3d(std::numeric_limits<double>::quiet_NaN(),
-                   std::numeric_limits<double>::quiet_NaN(),
-                   std::numeric_limits<double>::quiet_NaN())
-        : (p_WCa - p_WCb) / result.min_distance;
-    distance_data.nearest_pairs->emplace_back(id_A, id_B, p_ACa, p_BCb,
-                                              result.min_distance, nhat_BA_W);
+void throw_if_halfspace(fcl::NODE_TYPE node1, fcl::NODE_TYPE node2) {
+  // Stupid, historical special case where halfspace-halfspace throws.
+  if (node1 == fcl::GEOM_HALFSPACE || node2 == fcl::GEOM_HALFSPACE) {
+    throw std::logic_error(
+        "Signed distance queries on halfspaces are not currently supported. "
+        "Try using a large box instead.");
   }
+}
 
+template <typename T>
+struct ScalarSupport {
+  static bool is_supported(fcl::NODE_TYPE node1, fcl::NODE_TYPE node2) {
+    return false;
+  }
+};
+
+/** Primitive support for double-valued query.  */
+template <>
+struct ScalarSupport<double> {
+  static bool is_supported(fcl::NODE_TYPE node1, fcl::NODE_TYPE node2) {
+    throw_if_halfspace(node1, node2);
+
+    // For doubles, we can produce values for all pairs *except* if it includes
+    // a halfspace (caught above). This will change to only *pairs* of half
+    // spaces in the future.
+    return true;
+  }
+};
+
+/** Primitive support for AutoDiff-valued query.  */
+template <typename DerType>
+struct ScalarSupport<Eigen::AutoDiffScalar<DerType>> {
+  static bool is_supported(fcl::NODE_TYPE node1, fcl::NODE_TYPE node2) {
+    throw_if_halfspace(node1, node2);
+
+    // This is a clunky way of saying: one of these is a sphere and the other is
+    // either a box or sphere. This will be replaced in the near
+    // future with something that is less obfuscated.
+    return (node1 == fcl::GEOM_SPHERE &&
+        (node2 == fcl::GEOM_SPHERE || node2 == fcl::GEOM_BOX)) ||
+        (node2 == fcl::GEOM_SPHERE &&
+            (node1 == fcl::GEOM_SPHERE || node1 == fcl::GEOM_BOX));
+  }
+};
+
+//@}
+
+/** The callback function for computing signed distance between two arbitrary
+ shapes.
+
+ This callback is used in the context where we're going to report the distance
+ between all O(N²) objects, regardless of the results. The final parameter
+ in the callback serves as a threshold to the FCL broadphase -- any objects
+ that are known to be farther than the `dist` value will not be dispatched to
+ this narrow phase callback. This query does not *reduce* the distance so
+ it does not set it.
+
+ @tparam T  The scalar type for the query.
+  @param object_A_ptr   Pointer to the first object in the pair (the order has
+                        no significance).
+ @param object_B_ptr    Pointer to the second object in the pair (the order has
+                        no significance).
+ @param callback_data   Supporting data to compute distance. This includes the
+                        results of this narrowphase computation.
+ @returns False; the broadphase should *not* terminate its process.  */
+template <typename T>
+bool Callback(fcl::CollisionObjectd* object_A_ptr,
+              fcl::CollisionObjectd* object_B_ptr,
+              // NOLINTNEXTLINE
+              void* callback_data, double& /* dist */) {
+  auto& data = *static_cast<CallbackData<T>*>(callback_data);
+  // Throw if the geometry-pair isn't supported.
+  if (ScalarSupport<T>::is_supported(
+          object_A_ptr->collisionGeometry()->getNodeType(),
+          object_B_ptr->collisionGeometry()->getNodeType())) {
+    const EncodedData encoding_a(*object_A_ptr);
+    const EncodedData encoding_b(*object_B_ptr);
+
+    const bool can_collide = data.collision_filter.CanCollideWith(
+        encoding_a.encoding(), encoding_b.encoding());
+
+    if (can_collide) {
+      const std::vector<GeometryId>& geometry_map = data.geometry_map;
+      // We want to pass object_A and object_B to the narrowphase distance in a
+      // specific order. This way the broadphase distance is free to give us
+      // either (A,B) or (B,A), but the narrowphase distance will always receive
+      // the result in a consistent order.
+      const GeometryId orig_id_A = encoding_a.id(geometry_map);
+      const GeometryId orig_id_B = encoding_b.id(geometry_map);
+      const bool swap_AB = (orig_id_B < orig_id_A);
+
+      // NOTE: Although this function *takes* pointers to non-const objects to
+      // satisfy the fcl api, it should not exploit the non-constness to modify
+      // the collision objects. We ensure this by a reference to a const version
+      // and not directly use the provided pointers afterwards.
+      const fcl::CollisionObjectd& fcl_object_A =
+          *(swap_AB ? object_B_ptr : object_A_ptr);
+      const fcl::CollisionObjectd& fcl_object_B =
+          *(swap_AB ? object_A_ptr : object_B_ptr);
+
+      const GeometryIndex index_A =
+          swap_AB ? encoding_b.index() : encoding_a.index();
+      const GeometryIndex index_B =
+          swap_AB ? encoding_a.index() : encoding_b.index();
+
+      SignedDistancePair<T> signed_pair;
+      ComputeNarrowPhaseDistance(fcl_object_A, data.X_WGs[index_A],
+                                 fcl_object_B, data.X_WGs[index_B],
+                                 geometry_map, data.request, &signed_pair);
+      data.nearest_pairs.emplace_back(std::move(signed_pair));
+    }
+  } else {
+    throw std::logic_error(fmt::format(
+        "Signed distance queries between shapes '{}' and '{}' "
+        "are not supported for scalar type {}",
+        GetGeometryName(*object_A_ptr), GetGeometryName(*object_B_ptr),
+        NiceTypeName::Get<T>()));
+  }
   // Returning true would tell the broadphase manager to terminate early. Since
   // we want to find all the signed distance present in the model's current
   // configuration, we return false.

--- a/geometry/proximity/distance_to_shape.h
+++ b/geometry/proximity/distance_to_shape.h
@@ -1,0 +1,290 @@
+#pragma once
+
+#include <limits>
+#include <utility>
+#include <vector>
+
+#include <fcl/fcl.h>
+
+#include "drake/common/eigen_types.h"
+#include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/proximity/collision_filter_legacy.h"
+#include "drake/geometry/proximity/proximity_utilities.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/math/rotation_matrix.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace shape_distance {
+
+// Struct for use in DistanceCallback(). Contains the distance request
+// and accumulates result in a drake::geometry::SignedDistancePair vector.
+struct CallbackData {
+  CallbackData(const std::vector<GeometryId>* geometry_map_in,
+               const CollisionFilterLegacy* collision_filter_in)
+      : geometry_map(*geometry_map_in),
+        collision_filter(*collision_filter_in) {}
+  // Maps so the distance call back can map from engine index to geometry id.
+  const std::vector<GeometryId>& geometry_map;
+  const CollisionFilterLegacy& collision_filter;
+
+  // Distance request
+  fcl::DistanceRequestd request;
+
+  // Vectors of distance results
+  std::vector<SignedDistancePair<double>>* nearest_pairs{};
+};
+
+// An internal functor to support ComputeNarrowPhaseDistance(). It computes
+// the signed distance between a supported pair of geometries.  Each overload
+// to the call operator reports the signed distance (encoded in
+// fcl::DistanceResultd) between the two given geometry arguments using the
+// functor's stored poses.
+class DistancePairGeometry {
+ public:
+  // @param result   We report the signed distance and the witness points in
+  //                 the struct fcl::DistanceResultd pointed by `result`.
+  // @note Those aspects of the query geometry that do not depend on the
+  // shape type are provided to the constructor. The overloaded call operator
+  // takes the actual shape types.
+  DistancePairGeometry(const GeometryId& id_A, const GeometryId& id_B,
+                       const math::RigidTransformd& X_WA,
+                       const math::RigidTransformd& X_WB,
+                       fcl::DistanceResultd* result)
+      : id_A_(id_A), id_B_(id_B), X_WA_(X_WA), X_WB_(X_WB), result_(result) {}
+
+  // Given a sphere A centered at Ao with radius r and another geometry B,
+  // we want to compute
+  // 1. φ_A,B = the signed distance between the two objects, which is positive
+  //    for non-overlapping objects and equals the negative penetration depth
+  //    for overlapping objects.
+  // 2. Na, Nb = a pair of witness points, Na ∈ ∂A, Nb ∈ ∂B (not necessarily
+  //    unique), |Na-Nb| = |φ_A,B|.
+  //
+  // Define these functions: (available from SignedDistanceToPoint)
+  //   φ_B:ℝ³→ℝ, φ_B(p)  = signed distance to point p from B.
+  //   η_B:ℝ³→ℝ³, η_B(p) = a nearest point to p on the boundary ∂B (not
+  //                       necessarily unique).
+  //   ∇φ_B:ℝ³→ℝ³, ∇φ_B(p) = gradient vector of φ_B with respect to p.
+  //                         It has unit length by construction.
+  // Algorithm:
+  // 1. φ_A,B = φ_B(Ao) - r
+  // 2. Nb = η_B(Ao)
+  // 3. Na = Ao - r * ∇φ_B(Ao)
+  void operator()(const fcl::Sphered& sphere_A, const fcl::Sphered& sphere_B) {
+    SphereShapeDistance(sphere_A, sphere_B);
+  }
+  void operator()(const fcl::Sphered& sphere_A, const fcl::Boxd& box_B) {
+    SphereShapeDistance(sphere_A, box_B);
+  }
+  void operator()(const fcl::Sphered& sphere_A,
+                  const fcl::Cylinderd& cylinder_B) {
+    SphereShapeDistance(sphere_A, cylinder_B);
+  }
+
+ private:
+  // Distance computation between a sphere A and a generic shape B. We use
+  // the overloaded call operators above to limit the kinds of queries, and
+  // they all call this private template function to minimize code duplication.
+  template <typename FclShape>
+  void SphereShapeDistance(const fcl::Sphered& sphere_A,
+                           const FclShape& shape_B) {
+    const SignedDistanceToPoint<double> shape_B_to_point_Ao =
+        point_distance::DistanceToPoint<double>(id_B_, X_WB_,
+                                                X_WA_.translation())(shape_B);
+    const double distance = shape_B_to_point_Ao.distance - sphere_A.radius;
+    // Nb is the witness point on ∂B.
+    const Eigen::Vector3d& p_BNb = shape_B_to_point_Ao.p_GN;
+    const Eigen::Vector3d p_WNb = X_WB_ * p_BNb;
+    const Eigen::Vector3d& gradB_W = shape_B_to_point_Ao.grad_W;
+    // Na is the witness point on ∂A.
+    const Eigen::Vector3d p_WNa =
+        WitnessPointOnSphere(sphere_A.radius, X_WA_, gradB_W);
+    // fcl::DistanceResult expects -1 for primitive shapes.
+    result_->update(distance, &sphere_A, &shape_B, -1, -1, p_WNa, p_WNb);
+  }
+  // Performs step 3. Na = Ao - r * ∇φ_B(Ao).
+  // @param radius_A the radius of the sphere A.
+  // @param X_WA the pose of the sphere A.
+  // @param gradB_W the gradient vector ∇φ_B(Ao).
+  // @retval p_WNa the witness point Na ∈ ∂A expressed in World frame.
+  Eigen::Vector3d WitnessPointOnSphere(
+      const double radius_A, const math::RigidTransformd& X_WA,
+      const Eigen::Vector3d& gradB_W) const {
+    // Notation:
+    // gradB_W = ∇φ_B(Ao) expressed in World frame.
+    // gradB_A = ∇φ_B(Ao) expressed in A's frame.
+    const math::RotationMatrixd& R_WA = X_WA.rotation();
+    const math::RotationMatrixd R_AW = R_WA.transpose();
+    const Eigen::Vector3d gradB_A = R_AW * gradB_W;
+    // By construction gradB_A has unit length.
+    const Eigen::Vector3d p_ANa = -radius_A * gradB_A;
+    const Eigen::Vector3d p_WNa = X_WA * p_ANa;
+    return p_WNa;
+  }
+
+  GeometryId id_A_;
+  GeometryId id_B_;
+  math::RigidTransformd X_WA_;
+  math::RigidTransformd X_WB_;
+  fcl::DistanceResultd* result_;
+};
+
+// Helps DistanceCallback(). Do it in closed forms for sphere-sphere,
+// sphere-box, or sphere-cylinder. Otherwise, use FCL GJK/EPA.
+void ComputeNarrowPhaseDistance(const fcl::CollisionObjectd* a,
+                                const fcl::CollisionObjectd* b,
+                                const std::vector<GeometryId>& geometry_map,
+                                const fcl::DistanceRequestd& request,
+                                fcl::DistanceResultd* result) {
+  const fcl::CollisionGeometryd* a_geometry = a->collisionGeometry().get();
+  const fcl::CollisionGeometryd* b_geometry = b->collisionGeometry().get();
+
+  // We use FCL's GJK/EPA fallback in those geometries we haven't explicitly
+  // supported. However, FCL doesn't support: half spaces, planes, triangles, or
+  // octtrees in that workflow. We need to give intelligent feedback rather than
+  // the segfault otherwise produced.
+  // NOTE: Currently this only tests for halfspace (because it is an otherwise
+  // supported geometry type in SceneGraph. When meshes, planes, and/or octrees
+  // are supported, this error would have to be modified.
+  // TODO(SeanCurtis-TRI): Remove this test when FCL supports signed distance
+  // queries for halfspaces (see issue #10905). Also see FCL issue
+  // https://github.com/flexible-collision-library/fcl/issues/383.
+  if (a_geometry->getNodeType() == fcl::GEOM_HALFSPACE ||
+      b_geometry->getNodeType() == fcl::GEOM_HALFSPACE) {
+    throw std::logic_error(
+        "Signed distance queries on halfspaces are not currently supported. "
+        "Try using a large box instead.");
+  }
+
+  const bool a_is_sphere =
+      a->collisionGeometry().get()->getNodeType() == fcl::GEOM_SPHERE;
+  const bool b_is_sphere =
+      b->collisionGeometry().get()->getNodeType() == fcl::GEOM_SPHERE;
+  const bool no_sphere = ((!a_is_sphere) && (!b_is_sphere));
+  if (no_sphere) {
+    fcl::distance(a, b, request, *result);
+    return;
+  }
+  DRAKE_ASSERT(a_is_sphere || b_is_sphere);
+  // We write `s` for the sphere object and `o` for the other object. We
+  // assign either (a,b) or (b,a) to (s,o) depending on whether `a` is a
+  // sphere or not. Therefore, we only need the helper DistancePairGeometry
+  // that takes (sphere, other) but not (other, sphere).  This scheme helps us
+  // keep the code compact; however, we might have to re-order the result
+  // afterwards.
+  const fcl::CollisionObjectd* s = a_is_sphere ? a : b;
+  const fcl::CollisionObjectd* o = a_is_sphere ? b : a;
+  const fcl::CollisionGeometryd* s_geometry = s->collisionGeometry().get();
+  const fcl::CollisionGeometryd* o_geometry = o->collisionGeometry().get();
+  const math::RigidTransformd X_WS(s->getTransform());
+  const math::RigidTransformd X_WO(o->getTransform());
+  const auto id_S = EncodedData(*s).id(geometry_map);
+  const auto id_O = EncodedData(*o).id(geometry_map);
+  DistancePairGeometry distance_pair(id_S, id_O, X_WS, X_WO, result);
+  const auto& sphere_S = *static_cast<const fcl::Sphered*>(s_geometry);
+  switch (o_geometry->getNodeType()) {
+    case fcl::GEOM_SPHERE: {
+      const auto& sphere_O = *static_cast<const fcl::Sphered*>(o_geometry);
+      distance_pair(sphere_S, sphere_O);
+      break;
+    }
+    case fcl::GEOM_BOX: {
+      const auto& box_O = *static_cast<const fcl::Boxd*>(o_geometry);
+      distance_pair(sphere_S, box_O);
+      break;
+    }
+    case fcl::GEOM_CYLINDER: {
+      const auto& cylinder_O = *static_cast<const fcl::Cylinderd*>(o_geometry);
+      distance_pair(sphere_S, cylinder_O);
+      break;
+    }
+    default: {
+      // We don't have a closed form solution for the other geometry, so we
+      // call FCL GJK/EPA.
+      fcl::distance(s, o, request, *result);
+      break;
+    }
+  }
+  // If needed, re-order the result for (s,o) back to the result for (a,b).
+  if (!a_is_sphere) {
+    std::swap(result->o1, result->o2);
+    std::swap(result->nearest_points[0], result->nearest_points[1]);
+  }
+}
+
+// The callback function in fcl::distance request. The final unnamed parameter
+// is `dist`, which is used in fcl::distance, that if the distance between two
+// geometries is proved to be greater than `dist` (for example, the smallest
+// distance between the bounding boxes containing object A and object B is
+// greater than `dist`), then fcl::distance will skip this callback. In our
+// case, as we want to compute the distance between any pair of geometries, we
+// leave `dist` unchanged as its default value (max_double). So the last
+// parameter is merely a placeholder, and not being used or updated in the
+// callback.
+bool Callback(fcl::CollisionObjectd* fcl_object_A_ptr,
+              fcl::CollisionObjectd* fcl_object_B_ptr,
+              // NOLINTNEXTLINE
+              void* callback_data, double&) {
+  auto& distance_data = *static_cast<CallbackData*>(callback_data);
+  const std::vector<GeometryId>& geometry_map = distance_data.geometry_map;
+  // We want to pass object_A and object_B to the narrowphase distance in a
+  // specific order. This way the broadphase distance is free to give us
+  // either (A,B) or (B,A), and the narrowphase distance will always give the
+  // same result.
+  const GeometryId orig_id_A = EncodedData(*fcl_object_A_ptr).id(geometry_map);
+  const GeometryId orig_id_B = EncodedData(*fcl_object_B_ptr).id(geometry_map);
+  const bool swap_AB = (orig_id_B < orig_id_A);
+  const GeometryId id_A = swap_AB ? orig_id_B : orig_id_A;
+  const GeometryId id_B = swap_AB ? orig_id_A : orig_id_B;
+  // NOTE: Although this function *takes* pointers to non-const objects to
+  // satisfy the fcl api, it should not exploit the non-constness to modify
+  // the collision objects. We ensure this by a reference to a const version
+  // and not directly use the provided pointers afterwards.
+  const fcl::CollisionObjectd& fcl_object_A =
+      *(swap_AB ? fcl_object_B_ptr : fcl_object_A_ptr);
+  const fcl::CollisionObjectd& fcl_object_B =
+      *(swap_AB ? fcl_object_A_ptr : fcl_object_B_ptr);
+
+  // Extract the collision filter keys from the fcl collision objects. These
+  // keys will also be used to map the fcl collision object back to the Drake
+  // GeometryId for colliding geometries.
+  const EncodedData encoding_A(fcl_object_A);
+  const EncodedData encoding_B(fcl_object_B);
+
+  const bool can_collide = distance_data.collision_filter.CanCollideWith(
+      encoding_A.encoded_data(), encoding_B.encoded_data());
+
+  if (can_collide) {
+    fcl::DistanceResultd result;
+    ComputeNarrowPhaseDistance(&fcl_object_A, &fcl_object_B, geometry_map,
+                               distance_data.request, &result);
+    const Eigen::Vector3d& p_WCa = result.nearest_points[0];
+    const Eigen::Vector3d& p_WCb = result.nearest_points[1];
+    const Eigen::Vector3d p_ACa = fcl_object_A.getTransform().inverse() * p_WCa;
+    const Eigen::Vector3d p_BCb = fcl_object_B.getTransform().inverse() * p_WCb;
+    // TODO(DamrongGuoy): For sphere-{sphere,box,cylinder} we will start
+    //  working on the right nhat when min_distance is 0 or almost 0 after
+    //  PR #10813 lands to avoid conflicts with this PR #10823. For now,
+    //  we simply return NaN in nhat when min_distance is 0 or almost 0.
+    const Eigen::Vector3d nhat_BA_W =
+        (std::abs(result.min_distance) < std::numeric_limits<double>::epsilon())
+        ? Eigen::Vector3d(std::numeric_limits<double>::quiet_NaN(),
+                   std::numeric_limits<double>::quiet_NaN(),
+                   std::numeric_limits<double>::quiet_NaN())
+        : (p_WCa - p_WCb) / result.min_distance;
+    distance_data.nearest_pairs->emplace_back(id_A, id_B, p_ACa, p_BCb,
+                                              result.min_distance, nhat_BA_W);
+  }
+
+  // Returning true would tell the broadphase manager to terminate early. Since
+  // we want to find all the signed distance present in the model's current
+  // configuration, we return false.
+  return false;
+}
+
+}  // namespace shape_distance
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/proximity_utilities.cc
+++ b/geometry/proximity/proximity_utilities.cc
@@ -1,0 +1,49 @@
+#include "drake/geometry/proximity/proximity_utilities.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+std::string GetGeometryName(const fcl::CollisionObjectd& object) {
+  switch (object.collisionGeometry()->getNodeType()) {
+    case fcl::BV_UNKNOWN:
+    case fcl::BV_AABB:
+    case fcl::BV_OBB:
+    case fcl::BV_RSS:
+    case fcl::BV_kIOS:
+    case fcl::BV_OBBRSS:
+    case fcl::BV_KDOP16:
+    case fcl::BV_KDOP18:
+    case fcl::BV_KDOP24:
+      return "Unsupported";
+    case fcl::GEOM_BOX:
+      return "Box";
+    case fcl::GEOM_SPHERE:
+      return "Sphere";
+    case fcl::GEOM_ELLIPSOID:
+      return "Ellipsoid";
+    case fcl::GEOM_CAPSULE:
+      return "Capsule";
+    case fcl::GEOM_CONE:
+      return "Cone";
+    case fcl::GEOM_CYLINDER:
+      return "Cylinder";
+    case fcl::GEOM_CONVEX:
+      return "Convex";
+    case fcl::GEOM_PLANE:
+      return "Plane";
+    case fcl::GEOM_HALFSPACE:
+      return "Halfspace";
+    case fcl::GEOM_TRIANGLE:
+      return "Mesh";
+    case fcl::GEOM_OCTREE:
+      return "Octtree";
+    case fcl::NODE_COUNT:
+      return "Unsupported";
+  }
+  DRAKE_UNREACHABLE();
+}
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/proximity_utilities.h
+++ b/geometry/proximity/proximity_utilities.h
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <string>
 #include <vector>
 
 #include <fcl/fcl.h>
@@ -90,7 +91,7 @@ class EncodedData {
   }
 
   /** Reports the encoded data.  */
-  uintptr_t encoded_data() const { return data_; }
+  uintptr_t encoding() const { return data_; }
 
  private:
   // Note: This sets a mask to be 1000...0 based on the size of a pointer.
@@ -108,6 +109,10 @@ class EncodedData {
   //   - This unsigned integer doesn't bleed out into the API at all.
   uintptr_t data_{};
 };
+
+/** Prints the name of the geometry associated with the given collision
+ `object`.  */
+std::string GetGeometryName(const fcl::CollisionObjectd& object);
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/proximity_utilities.h
+++ b/geometry/proximity/proximity_utilities.h
@@ -110,7 +110,7 @@ class EncodedData {
   uintptr_t data_{};
 };
 
-/** Prints the name of the geometry associated with the given collision
+/** Returns the name of the geometry associated with the given collision
  `object`.  */
 std::string GetGeometryName(const fcl::CollisionObjectd& object);
 

--- a/geometry/proximity/test/distance_sphere_to_shape_test.cc
+++ b/geometry/proximity/test/distance_sphere_to_shape_test.cc
@@ -1,0 +1,702 @@
+#include <limits>
+#include <regex>
+#include <utility>
+#include <vector>
+
+#include <fcl/fcl.h>
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/proximity/distance_to_shape.h"
+#include "drake/geometry/proximity/proximity_utilities.h"
+#include "drake/geometry/utilities.h"
+#include "drake/math/autodiff_gradient.h"
+#include "drake/math/rigid_transform.h"
+
+// TODO(SeanCurtis-TRI): Figure out the right decomposition of code for
+// primitive tests.
+
+/** @file
+ This tests only the code in distance_to_shape.h that supports (sphere-shape)
+ signed distance queries. Ultimately, we'll have unit tests for all
+ shapeA-shapeB primitive functions.  */
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace shape_distance {
+
+// Specialization of the shape-shape distance fallback function. We use float
+// as an otherwise unsupported scalar to confirm when the fallback is called
+// and when it is not. If invoked, it throws an exception, otherwise nothing.
+template <>
+void CalcDistanceFallback<float>(const fcl::CollisionObjectd&,
+                                 const fcl::CollisionObjectd&,
+                                 const fcl::DistanceRequestd&,
+                                 SignedDistancePair<float>*) {
+  throw std::logic_error("Float fallback called!");
+}
+
+// Specializations of the DistancePairGeometry::operator() method on float so
+// that they don't actually do any *work* with floats. This goes with the
+// float specialization of CalcDistanceFallback -- in the case the fallback
+// doesn't get invoked, we don't want to actually *do* anything.
+template <>
+void DistancePairGeometry<float>::operator()(const fcl::Sphered&,
+                                             const fcl::Sphered&) {}
+
+template <>
+void DistancePairGeometry<float>::operator()(const fcl::Sphered&,
+                                             const fcl::Boxd&) {}
+
+template <>
+void DistancePairGeometry<float>::operator()(const fcl::Sphered&,
+                                             const fcl::Cylinderd&) {}
+
+namespace {
+
+using Eigen::Isometry3d;
+using Eigen::Translation3d;
+using Eigen::Vector3d;
+using fcl::Boxd;
+using fcl::CollisionObjectd;
+using fcl::Cylinderd;
+using fcl::Halfspaced;
+using fcl::Sphered;
+using math::RigidTransform;
+using math::RigidTransformd;
+using math::RotationMatrix;
+using math::RotationMatrixd;
+using std::make_shared;
+
+// TODO(SeanCurtis-TRI): Troll through proximity_engine_test and pull/remove all
+// tests there that more rightly belong here.
+
+// This tests the expected fallback support based on scalar type (i.e., we have
+// a fallback for double, but not for AutoDiff). We merely confirm the throw/no
+// throw nature of the test. Other tests evaluate the correctness of the
+// numerical values.
+GTEST_TEST(SphereShapeDistance, FallbackSupport) {
+  // NOTE: The shape type or pose are unimportant to this test.
+  auto sphere = make_shared<Sphered>(0);
+  CollisionObjectd obj_a(sphere);
+  CollisionObjectd obj_b(sphere);
+  fcl::DistanceRequestd request{};
+
+  SignedDistancePair<double> distance_pair_d{};
+  EXPECT_NO_THROW(
+      CalcDistanceFallback<double>(obj_a, obj_b, request, &distance_pair_d));
+
+  SignedDistancePair<AutoDiffXd> distance_pair_ad{};
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      CalcDistanceFallback<AutoDiffXd>(obj_a, obj_b, request,
+                                       &distance_pair_ad),
+      std::logic_error,
+      "Signed distance queries between shapes .+ and .+ are not supported for "
+      "scalar type .*AutoDiffXd");
+}
+
+// This relies on the knowledge that sphere-shape distance is a slight
+// modification of point-shape distance. Essentially, I should get the same
+// answers with the caveat that the distance is reduced by the sphere radius.
+// So, we perform *both* tests and compare the answers. However, we rely on the
+// tests for distance-to-point for general correctness of the underlying code.
+//
+// In the AutoDiff tests, it repeats the pattern in distance_to_point_test.
+// Looks at the derivatives w.r.t. the query sphere's position.
+class DistancePairGeometryTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    R_WSphere_ = RotationMatrixd::Identity();
+    p_WSphere_ = Vector3d{2, 3, 5};
+    X_WShape_.set(RotationMatrixd(AngleAxis<double>(
+                      M_PI / 5, Vector3d{2, 4, 7}.normalized())),
+                  Vector3d::Zero());
+  }
+
+  template <typename T, typename Shape>
+  ::testing::AssertionResult ResultsMatch(const Shape& test_shape) {
+    SignedDistancePair<T> shape_result;
+    const GeometryId sphere_id = GeometryId::get_new_id();
+    const GeometryId shape_id = GeometryId::get_new_id();
+    RigidTransform<T> X_WSphere(R_WSphere_.cast<T>(), p_WSphere<T>());
+    DistancePairGeometry<T> distance_functor(
+        sphere_id, shape_id, X_WSphere, X_WShape_.cast<T>(), &shape_result);
+
+    // Computes sphere-shape results.
+    distance_functor(query_sphere_, test_shape);
+    point_distance::DistanceToPoint<T> distance_to_point(
+        shape_id, X_WShape_.cast<T>(), p_WSphere<T>());
+    // Computes point-shape results.
+    SignedDistanceToPoint<T> point_result = distance_to_point(test_shape);
+
+    // Compares the results.
+    const double kEps = std::numeric_limits<double>::epsilon();
+    using std::abs;
+    if (abs(shape_result.distance - (point_result.distance - kRadius)) > kEps) {
+      return ::testing::AssertionFailure() << fmt::format(
+                 "Distances didn't match. Distance to shapes was {}, expected "
+                 "{}",
+                 shape_result.distance, point_result.distance - kRadius);
+    }
+
+    ::testing::AssertionResult result = ::testing::AssertionSuccess();
+
+    result = CompareMatrices(shape_result.nhat_BA_W, point_result.grad_W);
+    if (!result) return result;
+
+    // Note this comparison can be performed directly because B = G and N = C.
+    // So, it is ostensibly the same point expressed in the same frame.
+    result = CompareMatrices(shape_result.p_BCb, point_result.p_GN);
+    if (!result) return result;
+
+    // TODO(SeanCurtis-TRI): Make this work with autodiff.
+    // Distance to point provides no explicit value to compare with p_ACa.
+    // However, it is simply the point that is radius units away from the
+    // sphere's origin in the direction of the gradient. In this case, we put
+    // them both in A's frame.
+    result = CompareMatrices(
+        shape_result.p_ACa,
+        R_WSphere_.inverse().cast<T>() * (-kRadius * point_result.grad_W));
+
+    if (!shape_result.id_A.is_valid()) {
+      return ::testing::AssertionFailure() << "id_A is not valid";
+    }
+
+    if (shape_result.id_A != sphere_id) {
+      return ::testing::AssertionFailure() << fmt::format(
+                 "Sphere-shape distance misreported sphere id. Expected {} got "
+                 "{}",
+                 sphere_id, shape_result.id_A);
+    }
+
+    if (!shape_result.id_B.is_valid()) {
+      return ::testing::AssertionFailure() << "id_A is not valid";
+    }
+
+    if (shape_result.id_B != point_result.id_G) {
+      return ::testing::AssertionFailure() << fmt::format(
+                 "Sphere-shape distance misreported shape id. Expected {} got "
+                 "{}",
+                 point_result.id_G, shape_result.id_B);
+    }
+    if (!result) return result;
+
+    result = TestDerivatives(shape_result, point_result);
+    if (!result) return result;
+
+    return result;
+  }
+
+  template <typename T>
+  Vector3<T> p_WSphere() {
+    return p_WSphere_;
+  }
+
+  ::testing::AssertionResult TestDerivatives(
+      const SignedDistancePair<double>&, const SignedDistanceToPoint<double>&) {
+    return ::testing::AssertionSuccess();
+  }
+
+  ::testing::AssertionResult TestDerivatives(
+      const SignedDistancePair<AutoDiffXd>& shape_result,
+      const SignedDistanceToPoint<AutoDiffXd>& point_result) {
+    // These tests assume a very specific basis of differentiation: p_WAₒ. For
+    // notational convenience we'll use Aₒ to mean p_WAₒ. So, for every quantity
+    // Q, we're going to determine that δ(Q)/δAₒ is as expected. In most cases,
+    // we can match the derivatives in one result directly to the other. The
+    // exception is p_ACa (see below).
+
+    ::testing::AssertionResult result = ::testing::AssertionSuccess();
+
+    // Derivatives of distance.
+    const Vector3d dd_dAo_shape = shape_result.distance.derivatives();
+    const Vector3d dd_dAo_point = point_result.distance.derivatives();
+    result = CompareMatrices(dd_dAo_shape, dd_dAo_point);
+    if (!result) {
+      return ::testing::AssertionFailure()
+             << "Distance derivatives don't match; "
+             << "expected: <" << dd_dAo_point << ">, got: <" << dd_dAo_shape
+             << ">";
+    }
+
+    // Derivatives of gradient.
+    const auto dgrad_dAo_shape =
+        math::autoDiffToGradientMatrix(shape_result.nhat_BA_W);
+    const auto dgrad_dAo_point =
+        math::autoDiffToGradientMatrix(point_result.grad_W);
+    result = CompareMatrices(dgrad_dAo_shape, dgrad_dAo_point);
+    if (!result) {
+      return ::testing::AssertionFailure() << "Normal derivatives don't match; "
+                                           << "expected:\n"
+                                           << dgrad_dAo_point << "\ngot:\n"
+                                           << dgrad_dAo_shape;
+    }
+
+    // Derivatives of p_BCb.
+    auto dCb_dAo = math::autoDiffToGradientMatrix(shape_result.p_BCb);
+    const auto dN_dAo = math::autoDiffToGradientMatrix(point_result.p_GN);
+    result = CompareMatrices(dCb_dAo, dN_dAo);
+    if (!result) {
+      return ::testing::AssertionFailure() << "p_BCb derivatives don't match; "
+                                           << "expected:\n"
+                                           << dN_dAo << "\ngot:\n"
+                                           << dCb_dAo;
+    }
+
+    // Derivatives of p_ACa.
+    // We have no pre-computed value to compare against. Given the assumptions
+    // of this problem, we _can_ express δ(p_ACa)/δAₒ in terms of givens.
+    //
+    // p_ACa = X_AW⋅p_WCa
+    //       = R_AW⋅p_WCa + p_WAₒ
+    // δ(p_ACa)/δAₒ = δ(R_AW⋅p_WCa - p_WAₒ)/δAₒ
+    //              = δ(R_AW)/δAₒ⋅p_WCa + R_AW⋅δ(p_WCa)/δAₒ + (p_WAₒ)/δAₒ
+    //              =         0         + R_AW⋅δ(p_WCa)/δAₒ -     I
+    //
+    // δ(p_ACa)/δAₒ = R_AW⋅δ(p_WCa)/δAₒ - I   (Eq 1)
+    //
+    // We have R_AW, and need δ(p_WCa)/δAₒ.
+    // p_WCa = p_WCb + d⋅∇φ_B_W
+    // p_WCa = X_WB⋅p_BCb + d⋅∇φ_B_W
+    // δ(p_WCa)/δAₒ = δ(X_WB⋅p_BCb + d⋅∇φ_B_W)/δAₒ
+    // δ(p_WCa)/δAₒ = δ(R_WB⋅p_BCb + p_WB + d⋅∇φ_B_W)/δAₒ
+    // δ(p_WCa)/δAₒ = δ(R_WB)/δAₒ⋅p_BCb + R_WB⋅δ(p_BCb)/δAₒ + δ(p_WB)/δAₒ
+    //                ∇φ_B_W⋅δ(d)/δAₒᵀ + d⋅δ(∇φ_B_W)/δAₒ
+    //              =           0       + R_WB⋅δ(p_BCb)/δAₒ +     0
+    //                ∇φ_B_W⋅δ(d)/δAₒᵀ + d⋅δ(∇φ_B_W)/δAₒ
+    //
+    // δ(p_WCa)/δAₒ = R_WB⋅δ(p_BCb)/δAₒ + ∇φ_B_W⋅δ(d)/δAₒᵀ + d⋅δ(∇φ_B_W)/δAₒ
+    //                                                                    (Eq 2)
+    //
+    // We have all of the quantities on the right-hand side. So, we can rewrite
+    // Eq 1 by substituting Eq 2 into it:
+    //
+    // δ(p_ACa)/δAₒ =
+    //   R_AW⋅[R_WB⋅δ(p_BCb)/δAₒ + δ(d)/δAₒ⋅∇φ_B_W + d⋅δ(∇φ_B_W)/δAₒ] - I (Eq 3)
+    const double kEps = std::numeric_limits<double>::epsilon();
+    const Matrix3<double> R_AW = R_WSphere_.matrix().transpose();
+    const Matrix3<double> R_WB = X_WShape_.rotation().matrix();
+    const Vector3<double> grad_W = convert_to_double(point_result.grad_W);
+
+    // Note: for some geometries, the derivatives of some of the quantities are
+    // zero (e.g., the derivative of the gradient when the point is nearest a
+    // face -- any infinitesimal movement of the point will *not* change the
+    // normal). This is reported as having an *empty* derivatives vector. Here
+    // we explicitly set it to the zero vector so Eigen sizes match up.
+    if (dCb_dAo.size() == 0) dCb_dAo = Matrix3<double>::Zero();
+
+    const Matrix3<double> dp_WCa_dAo =
+        R_WB * dCb_dAo + grad_W * dd_dAo_shape.transpose() +
+        shape_result.distance.value() * dgrad_dAo_shape;
+    Matrix3<double> dCa_dAo_expected =
+        R_AW * dp_WCa_dAo - Matrix3<double>::Identity();
+    const auto dCa_dAo = math::autoDiffToGradientMatrix(shape_result.p_ACa);
+    result = CompareMatrices(dCa_dAo, dCa_dAo_expected, 4 * kEps);
+    if (!result) {
+      return ::testing::AssertionFailure() << "p_ACa derivatives don't match; "
+                                           << "expected:\n"
+                                           << dCa_dAo_expected << "\ngot:\n"
+                                           << dCa_dAo;
+    }
+
+    return result;
+  }
+
+  RotationMatrixd R_WSphere_;
+  Vector3d p_WSphere_;
+  RigidTransformd X_WShape_;
+  static const double kRadius;
+  Sphered query_sphere_{kRadius};
+};
+
+const double DistancePairGeometryTest::kRadius = 0.75;
+
+template <>
+Vector3<AutoDiffXd> DistancePairGeometryTest::p_WSphere<AutoDiffXd>() {
+  return math::initializeAutoDiff(p_WSphere_);
+}
+
+TEST_F(DistancePairGeometryTest, SphereSphereDouble) {
+  EXPECT_TRUE((ResultsMatch<double, Sphered>(Sphered(1.3))));
+}
+
+TEST_F(DistancePairGeometryTest, SphereBoxDouble) {
+  EXPECT_TRUE((ResultsMatch<double, Boxd>(Boxd{1.3, 2.3, 0.7})));
+}
+
+TEST_F(DistancePairGeometryTest, SphereCylinderDouble) {
+  EXPECT_TRUE((ResultsMatch<double, Cylinderd>(Cylinderd{1.3, 2.3})));
+}
+
+TEST_F(DistancePairGeometryTest, SphereSphereAutoDiff) {
+  EXPECT_TRUE((ResultsMatch<AutoDiffXd, Sphered>(Sphered(1.3))));
+}
+
+TEST_F(DistancePairGeometryTest, SphereBoxAutoDiffXd) {
+  EXPECT_TRUE((ResultsMatch<AutoDiffXd, Boxd>(Boxd{1.3, 2.3, 0.7})));
+}
+
+TEST_F(DistancePairGeometryTest, SphereCylinderAutoDiffXd) {
+  EXPECT_TRUE((ResultsMatch<AutoDiffXd, Cylinderd>(Cylinderd{1.3, 2.3})));
+}
+
+// Test infrastructure for confirming that signed distance to halfspaces throws
+// an exception with an intelligible message.
+using ScalarTypes = ::testing::Types<double, AutoDiffXd>;
+template <typename T>
+class ComputeNarrowHalfspaceTest : public ::testing::Test {};
+TYPED_TEST_CASE(ComputeNarrowHalfspaceTest, ScalarTypes);
+
+TYPED_TEST(ComputeNarrowHalfspaceTest, HalfspaceThrows) {
+  // Values that are always double, regardless of T.
+  auto half_space_geo = make_shared<Halfspaced>(Vector3d{0, 0, 1}, 0);
+  auto sphere_geo = make_shared<Sphered>(0.25);
+  CollisionObjectd half_space(half_space_geo);
+  CollisionObjectd sphere(sphere_geo);
+  std::vector<GeometryId> geometry_map;
+  fcl::DistanceRequestd request{};
+
+  // T-valued parameters.
+  const Isometry3<TypeParam> X_WA = Isometry3<TypeParam>::Identity();
+  const Isometry3<TypeParam> X_WB = Isometry3<TypeParam>::Identity();
+  SignedDistancePair<TypeParam> result;
+
+  const char* message =
+      "Signed distance queries on halfspaces are not currently supported.*";
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      ComputeNarrowPhaseDistance<TypeParam>(half_space, X_WA, sphere, X_WB,
+                                            geometry_map, request, &result),
+      std::logic_error, message);
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      ComputeNarrowPhaseDistance<TypeParam>(sphere, X_WA, half_space, X_WB,
+                                            geometry_map, request, &result),
+      std::logic_error, message);
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      ComputeNarrowPhaseDistance<TypeParam>(half_space, X_WA, half_space, X_WB,
+                                            geometry_map, request, &result),
+      std::logic_error, message);
+}
+
+// Confirms that the distance fallback is *not* invoked for (sphere-X) pairs
+// where X is in {Sphere, Box, Cylinder}. Note the use of the `float` scalar.
+// This is a specialization of the fallback function only available to this
+// test. Invoking this fallback throws a particular exception -- this is how we
+// detect whether the fallback is called or not.
+GTEST_TEST(ComputeNarrowPhaseDistance, NoFallbackInvocation) {
+  // Parameters that don't depend on T.
+  CollisionObjectd sphere(make_shared<Sphered>(1));
+  EncodedData(GeometryIndex(0), true).write_to(&sphere);
+  std::vector<GeometryId> geometry_map{GeometryId::get_new_id(),
+                                       GeometryId::get_new_id()};
+  fcl::DistanceRequestd request{};
+
+  // T-valued parameters.
+  using T = float;
+  const Isometry3<T> X_WA = Isometry3<T>::Identity();
+  const Isometry3<T> X_WB = Isometry3<T>::Identity();
+  SignedDistancePair<T> result;
+
+  // These scenarios should *not* invoke the fallback; they will be exercised
+  // by primitives.
+
+  EXPECT_NO_THROW(ComputeNarrowPhaseDistance<T>(
+      sphere, X_WA, sphere, X_WB, geometry_map, request, &result));
+
+  std::vector<std::shared_ptr<fcl::CollisionGeometry<double>>> supported{
+      make_shared<Boxd>(1, 1, 1), make_shared<Cylinderd>(1, 1)};
+  for (auto other_geo : supported) {
+    CollisionObjectd other(other_geo);
+    EncodedData(GeometryIndex(1), true).write_to(&other);
+
+    EXPECT_NO_THROW(ComputeNarrowPhaseDistance<T>(
+        other, X_WA, sphere, X_WB, geometry_map, request, &result));
+    EXPECT_NO_THROW(ComputeNarrowPhaseDistance<T>(
+        sphere, X_WA, other, X_WB, geometry_map, request, &result));
+  }
+}
+
+// Confirms that the fallback *is* invoked for other geometry pairs.
+GTEST_TEST(ComputeNarrowPhaseDistance, FallbackInvocation) {
+  // Parameters that don't depend on T.
+  std::vector<GeometryId> geometry_map{GeometryId::get_new_id(),
+                                       GeometryId::get_new_id()};
+  fcl::DistanceRequestd request{};
+
+  // T-valued parameters.
+  using T = float;
+  const Isometry3<T> X_WA = Isometry3<T>::Identity();
+  const Isometry3<T> X_WB = Isometry3<T>::Identity();
+  SignedDistancePair<T> result;
+
+  // TODO(SeanCurtis-TRI): Add convex-* pairs to this list.
+  // clang-format off
+  std::vector<std::pair<std::shared_ptr<fcl::CollisionGeometry<double>>,
+                        std::shared_ptr<fcl::CollisionGeometry<double>>>>
+      unsupported_pairs{
+          {make_shared<Boxd>(1, 1, 1),   make_shared<Boxd>(1, 1, 1)},
+          {make_shared<Cylinderd>(1, 1), make_shared<Cylinderd>(1, 1)},
+          {make_shared<Boxd>(1, 1, 1),   make_shared<Cylinderd>(1, 1)}};
+  // clang-format on
+  for (const auto& pair : unsupported_pairs) {
+    CollisionObjectd A(pair.first);
+    EncodedData{GeometryIndex(0), true}.write_to(&A);
+    CollisionObjectd B(pair.second);
+    EncodedData{GeometryIndex(1), true}.write_to(&A);
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        ComputeNarrowPhaseDistance<T>(A, X_WA, B, X_WB, geometry_map, request,
+                                      &result),
+        std::logic_error, "Float fallback called!");
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        ComputeNarrowPhaseDistance<T>(B, X_WB, A, X_WA, geometry_map, request,
+                                      &result),
+        std::logic_error, "Float fallback called!");
+  }
+}
+
+// This confirms that I get the same answer, regardless of the order of the
+// two geometries using Sphere-Box as a representative sample.
+GTEST_TEST(ComputeNarrowPhaseDistance, OrderInvariance) {
+  // Sphere
+  CollisionObjectd sphere(make_shared<Sphered>(1));
+  EncodedData(GeometryIndex(0), true).write_to(&sphere);
+
+  // Box
+  CollisionObjectd box(make_shared<Boxd>(1, 1, 1));
+  EncodedData(GeometryIndex(1), true).write_to(&box);
+
+  std::vector<GeometryId> geometry_map{GeometryId::get_new_id(),
+                                       GeometryId::get_new_id()};
+  fcl::DistanceRequestd request{};
+  const Isometry3<double> X_WS(Translation3d{2, 2, 2});
+  const Isometry3<double> X_WB = Isometry3<double>::Identity();
+  SignedDistancePair<double> result_BS;
+  SignedDistancePair<double> result_SB;
+
+  ComputeNarrowPhaseDistance<double>(sphere, X_WS, box, X_WB, geometry_map,
+                                     request, &result_SB);
+
+  ComputeNarrowPhaseDistance<double>(box, X_WB, sphere, X_WS, geometry_map,
+                                     request, &result_BS);
+
+  EXPECT_EQ(result_SB.id_A, result_BS.id_B);
+  EXPECT_EQ(result_SB.id_B, result_BS.id_A);
+  EXPECT_EQ(result_SB.distance, result_BS.distance);
+  EXPECT_TRUE(CompareMatrices(result_SB.p_BCb, result_BS.p_ACa));
+  EXPECT_TRUE(CompareMatrices(result_SB.p_ACa, result_BS.p_BCb));
+  EXPECT_TRUE(CompareMatrices(result_SB.nhat_BA_W, -result_BS.nhat_BA_W));
+}
+
+template <typename T>
+class CallbackScalarSupport : public ::testing::Test {
+ public:
+  CallbackScalarSupport()
+      : geometry_map_(), collision_filter_(), X_WGs_(), results_(),
+        data_(&geometry_map_, &collision_filter_, &X_WGs_, &results_),
+        spheres_() {}
+
+ protected:
+  void SetUp() override {
+    // Populate the callback data structures.
+    geometry_map_.push_back(GeometryId::get_new_id());
+    geometry_map_.push_back(GeometryId::get_new_id());
+    EncodedData data_A(GeometryIndex{0}, true);
+    EncodedData data_B(GeometryIndex{1}, true);
+    collision_filter_.AddGeometry(data_A.encoding());
+    collision_filter_.AddGeometry(data_B.encoding());
+    X_WGs_.emplace_back(Translation3<T>{10, 11, 12});
+    X_WGs_.push_back(Isometry3<T>::Identity());
+
+    auto apply_data = [&data_A, &data_B](auto& shapes) {
+      data_A.write_to(&shapes[0]);
+      data_B.write_to(&shapes[1]);
+    };
+
+    spheres_.emplace_back(make_shared<Sphered>(0.25));
+    spheres_.emplace_back(make_shared<Sphered>(0.75));
+    apply_data(spheres_);
+
+    boxes_.emplace_back(make_shared<Boxd>(0.25, 0.3, 0.4));
+    boxes_.emplace_back(make_shared<Boxd>(0.4, 0.3, 0.2));
+    apply_data(boxes_);
+
+    cylinders_.emplace_back(make_shared<Cylinderd>(0.3, 0.4));
+    cylinders_.emplace_back(make_shared<Cylinderd>(0.3, 0.2));
+    apply_data(cylinders_);
+
+    halfspaces_.emplace_back(make_shared<Halfspaced>(Vector3d{0, 0, 1}, 0.3));
+    halfspaces_.emplace_back(make_shared<Halfspaced>(Vector3d{1, 0, 0}, -0.3));
+    apply_data(halfspaces_);
+  }
+
+  std::vector<std::pair<CollisionObjectd&, CollisionObjectd&>>
+  supported_pairs() {
+    throw std::logic_error(
+        "No supported pairs implemented -- check scalar type");
+  }
+
+  std::vector<std::pair<CollisionObjectd&, CollisionObjectd&>>
+  unsupported_pairs() {
+    throw std::logic_error(
+        "No unsupported pairs implemented -- check scalar type");
+  }
+
+ protected:
+  std::vector<GeometryId> geometry_map_;
+  CollisionFilterLegacy collision_filter_;
+  std::vector<Isometry3<T>> X_WGs_;
+  std::vector<SignedDistancePair<T>> results_;
+  CallbackData<T> data_;
+  std::vector<CollisionObjectd> spheres_;
+  std::vector<CollisionObjectd> boxes_;
+  std::vector<CollisionObjectd> cylinders_;
+  std::vector<CollisionObjectd> halfspaces_;
+};
+
+template <>
+std::vector<std::pair<CollisionObjectd&, CollisionObjectd&>>
+CallbackScalarSupport<double>::supported_pairs() {
+  // Given the shared indices, it is important that the indices in each pair
+  // include 0 and 1.
+  return {{spheres_[0], spheres_[1]},   {spheres_[0], boxes_[1]},
+          {spheres_[0], cylinders_[1]}, {boxes_[0], boxes_[1]},
+          {boxes_[0], cylinders_[1]},   {cylinders_[0], cylinders_[1]}};
+}
+
+template <>
+std::vector<std::pair<CollisionObjectd&, CollisionObjectd&>>
+CallbackScalarSupport<double>::unsupported_pairs() {
+  return {
+      {spheres_[0], halfspaces_[1]},
+      {boxes_[0], halfspaces_[1]},
+      {cylinders_[0], halfspaces_[1]},
+      {halfspaces_[0], halfspaces_[1]},
+  };
+}
+
+template <>
+std::vector<std::pair<CollisionObjectd&, CollisionObjectd&>>
+CallbackScalarSupport<AutoDiffXd>::supported_pairs() {
+  return {{spheres_[0], spheres_[1]},
+          {spheres_[0], boxes_[1]}};
+}
+
+template <>
+std::vector<std::pair<CollisionObjectd&, CollisionObjectd&>>
+CallbackScalarSupport<AutoDiffXd>::unsupported_pairs() {
+  return {
+      {spheres_[0], cylinders_[1]},    {spheres_[0], halfspaces_[1]},
+      {boxes_[0], boxes_[1]},          {boxes_[0], cylinders_[1]},
+      {boxes_[0], halfspaces_[1]},     {cylinders_[0], cylinders_[1]},
+      {cylinders_[0], halfspaces_[1]}, {halfspaces_[0], halfspaces_[1]},
+  };
+}
+
+TYPED_TEST_CASE(CallbackScalarSupport, ScalarTypes);
+
+// Tests that the pairs that are reported supported, run normally. The pairs
+// that are marked *unsupported* throw.
+TYPED_TEST(CallbackScalarSupport, SupportedPairClassification) {
+  auto run_callback = [this](auto& object_A, auto& object_B) {
+    double threshold = std::numeric_limits<double>::max();
+    this->results_.clear();
+    Callback<TypeParam>(&object_A, &object_B, &this->data_, threshold);
+  };
+
+  // Supported pairs will produce a result.
+  for (auto& pair : this->supported_pairs()) {
+    run_callback(pair.first, pair.second);
+    EXPECT_EQ(this->results_.size(), 1);
+    run_callback(pair.second, pair.first);
+    EXPECT_EQ(this->results_.size(), 1);
+  }
+  // Unsupported pairs will *not* produce a result.
+  for (auto& pair : this->unsupported_pairs()) {
+    EXPECT_THROW(run_callback(pair.first, pair.second), std::logic_error);
+    EXPECT_THROW(run_callback(pair.second, pair.first), std::logic_error);
+  }
+}
+
+GTEST_TEST(Callback, RespectCollisionFiltering) {
+  CollisionObjectd sphere_A(make_shared<Sphered>(0.25));
+  CollisionObjectd sphere_B(make_shared<Sphered>(0.25));
+  EncodedData data_A(GeometryIndex{0}, true);
+  EncodedData data_B(GeometryIndex{1}, true);
+  data_A.write_to(&sphere_A);
+  data_B.write_to(&sphere_B);
+  std::vector<Isometry3d> X_WGs{Isometry3d{Translation3d{10, 11, 12}},
+                                Isometry3d::Identity()};
+  std::vector<GeometryId> geometry_map{GeometryId::get_new_id(),
+                                       GeometryId::get_new_id()};
+  std::vector<SignedDistancePair<double>> results;
+  CollisionFilterLegacy collision_filter;
+  collision_filter.AddGeometry(data_A.encoding());
+  collision_filter.AddGeometry(data_B.encoding());
+
+  CallbackData<double> data{&geometry_map, &collision_filter, &X_WGs, &results};
+
+  // Case: No collision filters added should produce a single result.
+  double threshold = std::numeric_limits<double>::max();
+  Callback<double>(&sphere_A, &sphere_B, &data, threshold);
+  EXPECT_EQ(results.size(), 1u);
+
+  // Case: filtered collisions.
+  collision_filter.AddToCollisionClique(data_A.encoding(), 3);
+  collision_filter.AddToCollisionClique(data_B.encoding(), 3);
+  results.clear();
+  threshold = std::numeric_limits<double>::max();
+  Callback<double>(&sphere_A, &sphere_B, &data, threshold);
+  EXPECT_EQ(results.size(), 0u);
+}
+
+// Confirms that regardless of the order of the two objects, the result always
+// has the same (A, B) ordering such that id_A < id_B.
+GTEST_TEST(Callback, ABOrdering) {
+  CollisionObjectd sphere_A(make_shared<Sphered>(0.25));
+  CollisionObjectd sphere_B(make_shared<Sphered>(0.25));
+  EncodedData data_A(GeometryIndex{0}, true);
+  EncodedData data_B(GeometryIndex{1}, true);
+  data_A.write_to(&sphere_A);
+  data_B.write_to(&sphere_B);
+  std::vector<Isometry3d> X_WGs{Isometry3d{Translation3d{10, 11, 12}},
+                                Isometry3d::Identity()};
+  std::vector<GeometryId> geometry_map{GeometryId::get_new_id(),
+                                       GeometryId::get_new_id()};
+  CollisionFilterLegacy collision_filter;
+  collision_filter.AddGeometry(data_A.encoding());
+  collision_filter.AddGeometry(data_B.encoding());
+  double threshold = std::numeric_limits<double>::max();
+
+  // Pass in the two geometries in order (A, B).
+  std::vector<SignedDistancePair<double>> results1;
+  CallbackData<double> data1{&geometry_map, &collision_filter, &X_WGs,
+                             &results1};
+  Callback<double>(&sphere_A, &sphere_B, &data1, threshold);
+  ASSERT_EQ(results1.size(), 1u);
+  EXPECT_TRUE(results1[0].id_A < results1[0].id_B);
+
+  // Pass in the two geometries in order (B, A).
+  std::vector<SignedDistancePair<double>> results2;
+  CallbackData<double> data2{&geometry_map, &collision_filter, &X_WGs,
+                             &results2};
+  Callback<double>(&sphere_B, &sphere_A, &data2, threshold);
+  ASSERT_EQ(results2.size(), 1u);
+  EXPECT_TRUE(results2[0].id_A < results2[0].id_B);
+
+  // The numerical values match.
+  EXPECT_EQ(results1[0].distance, results2[0].distance);
+  EXPECT_TRUE(CompareMatrices(results1[0].p_BCb, results2[0].p_BCb));
+  EXPECT_TRUE(CompareMatrices(results1[0].p_ACa, results2[0].p_ACa));
+  EXPECT_TRUE(CompareMatrices(results1[0].nhat_BA_W, results2[0].nhat_BA_W));
+}
+
+}  // namespace
+}  // namespace shape_distance
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -1,39 +1,25 @@
 #include "drake/geometry/proximity_engine.h"
 
 #include <algorithm>
-#include <cctype>
-#include <cmath>
-#include <cstdint>
-#include <iterator>
-#include <stdexcept>
 #include <string>
 #include <unordered_map>
 #include <utility>
 
-#include <fcl/common/types.h>
 #include <fcl/fcl.h>
-#include <fcl/geometry/shape/box.h>
-#include <fcl/geometry/shape/convex.h>
-#include <fcl/narrowphase/collision_request.h>
-#include <fcl/narrowphase/distance_request.h>
-#include <spruce.hh>
 #include <tiny_obj_loader.h>
 
 #include "drake/common/default_scalars.h"
-#include "drake/common/drake_variant.h"
 #include "drake/common/eigen_types.h"
-#include "drake/common/sorted_vectors_have_intersection.h"
+#include "drake/geometry/proximity/collision_filter_legacy.h"
 #include "drake/geometry/proximity/distance_to_point.h"
 #include "drake/geometry/proximity/distance_to_point_with_gradient.h"
+#include "drake/geometry/proximity/distance_to_shape.h"
 #include "drake/geometry/utilities.h"
-#include "drake/math/rigid_transform.h"
-#include "drake/math/rotation_matrix.h"
 
 namespace drake {
 namespace geometry {
 namespace internal {
 
-using Eigen::Vector2d;
 using Eigen::Vector3d;
 using Eigen::Isometry3d;
 using std::make_shared;
@@ -41,107 +27,11 @@ using std::make_unique;
 using std::move;
 using std::shared_ptr;
 using std::unique_ptr;
-using math::RigidTransform;
-using math::RigidTransformd;
-using math::RotationMatrixd;
 using point_distance::DistanceToPoint;
 
 namespace {
 
 // TODO(SeanCurtis-TRI): Swap all Isometry3 for RigidTransforms.
-
-
-// A simple class for providing collision filtering functionality similar to
-// that found in RigidBodyTree but made compatible with fcl. The majority of
-// this code is lifted verbatim from drake/multibody/collision/element.{h, cc}.
-//
-// Note: I'm using uintptr_t instead of EncodedData directly to avoid having
-// to hash EncodedData.
-// TODO(SeanCurtis-TRI): Replace this "legacy" mechanism with the
-// new-and-improved alternative when it is ready.
-class CollisionFilterLegacy {
- public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CollisionFilterLegacy)
-
-  CollisionFilterLegacy() = default;
-
-  void AddGeometry(uintptr_t id) {
-    collision_cliques_.insert({id, std::vector<int>()});
-  }
-
-  // NOTE: This assumes that `id_A` and `id_B` will *never* both be anchored
-  // geometries. The structure of the collision query logic precludes that
-  // possibility; dynamic is collided against dynamic and dynamic is collided
-  // against anchored, but anchored is never collided against anchored.
-  bool CanCollideWith(uintptr_t id_A, uintptr_t id_B) const {
-    // These ids should all be registered with the filter machinery.
-    DRAKE_ASSERT(collision_cliques_.count(id_A) == 1);
-    DRAKE_ASSERT(collision_cliques_.count(id_B) == 1);
-
-    bool excluded = id_A == id_B ||
-                    SortedVectorsHaveIntersection(collision_cliques_.at(id_A),
-                                                  collision_cliques_.at(id_B));
-
-    return !excluded;
-  }
-
-  void AddToCollisionClique(uintptr_t geometry_id, int clique_id) {
-    DRAKE_ASSERT(collision_cliques_.count(geometry_id) == 1);
-
-    std::vector<int>& cliques = collision_cliques_[geometry_id];
-    // Order(N) insertion.
-    // `cliques` is a sorted vector so that checking if two collision elements
-    // belong to a common group can be performed efficiently in order N.
-    // See Element::CanCollideWith() and Element::collision_cliques_ for
-    // explanation.
-    auto it = std::lower_bound(cliques.begin(), cliques.end(), clique_id);
-
-    // This test prevents duplicate clique ids from being added.
-    if (it == cliques.end() || clique_id < *it) cliques.insert(it, clique_id);
-  }
-
-  int num_cliques(uintptr_t geometry_id) const {
-    DRAKE_ASSERT(collision_cliques_.count(geometry_id) == 1);
-    return static_cast<int>(collision_cliques_.at(geometry_id).size());
-  }
-
-  // This method is not thread safe.
-  int next_clique_id() {
-    int clique = next_available_clique_++;
-    if (clique < 0) {
-      throw std::logic_error(
-          "SceneGraph has run out of cliques (more than two billion served)");
-    }
-    return clique;
-  }
-
-  // Test support; to detect when cliques are generated.
-  int peek_next_clique() const { return next_available_clique_; }
-
- private:
-  // A map between the EncodedData::encoded_data() value for a geometry and
-  // its set of cliques.
-  std::unordered_map<uintptr_t, std::vector<int>> collision_cliques_;
-  int next_available_clique_{0};
-};
-
-// Struct for use in DistanceCallback(). Contains the distance request
-// and accumulates result in a drake::geometry::SignedDistancePair vector.
-struct DistanceData {
-  DistanceData(const std::vector<GeometryId>* geometry_map_in,
-               const CollisionFilterLegacy* collision_filter_in)
-      : geometry_map(*geometry_map_in),
-        collision_filter(*collision_filter_in) {}
-  // Maps so the distance call back can map from engine index to geometry id.
-  const std::vector<GeometryId>& geometry_map;
-  const CollisionFilterLegacy& collision_filter;
-
-  // Distance request
-  fcl::DistanceRequestd request;
-
-  // Vectors of distance results
-  std::vector<SignedDistancePair<double>>* nearest_pairs{};
-};
 
 // Struct for use in SingleCollisionCallback(). Contains the collision request
 // and accumulates results in a drake::multibody::collision::PointPair vector.
@@ -160,272 +50,6 @@ struct CollisionData {
   // Vector of distance results
   std::vector<PenetrationAsPointPair<double>>* contacts{};
 };
-
-// An internal functor to support ComputeNarrowPhaseDistance(). It computes
-// the signed distance between a supported pair of geometries.  Each overload
-// to the call operator reports the signed distance (encoded in
-// fcl::DistanceResultd) between the two given geometry arguments using the
-// functor's stored poses.
-class DistancePairGeometry {
- public:
-  // @param result   We report the signed distance and the witness points in
-  //                 the struct fcl::DistanceResultd pointed by `result`.
-  // @note Those aspects of the query geometry that do not depend on the
-  // shape type are provided to the constructor. The overloaded call operator
-  // takes the actual shape types.
-  DistancePairGeometry(const GeometryId& id_A, const GeometryId& id_B,
-                       const RigidTransformd& X_WA, const RigidTransformd& X_WB,
-                       fcl::DistanceResultd* result)
-      : id_A_(id_A), id_B_(id_B), X_WA_(X_WA), X_WB_(X_WB), result_(result) {}
-
-  // Given a sphere A centered at Ao with radius r and another geometry B,
-  // we want to compute
-  // 1. φ_A,B = the signed distance between the two objects, which is positive
-  //    for non-overlapping objects and equals the negative penetration depth
-  //    for overlapping objects.
-  // 2. Na, Nb = a pair of witness points, Na ∈ ∂A, Nb ∈ ∂B (not necessarily
-  //    unique), |Na-Nb| = |φ_A,B|.
-  //
-  // Define these functions: (available from SignedDistanceToPoint)
-  //   φ_B:ℝ³→ℝ, φ_B(p)  = signed distance to point p from B.
-  //   η_B:ℝ³→ℝ³, η_B(p) = a nearest point to p on the boundary ∂B (not
-  //                       necessarily unique).
-  //   ∇φ_B:ℝ³→ℝ³, ∇φ_B(p) = gradient vector of φ_B with respect to p.
-  //                         It has unit length by construction.
-  // Algorithm:
-  // 1. φ_A,B = φ_B(Ao) - r
-  // 2. Nb = η_B(Ao)
-  // 3. Na = Ao - r * ∇φ_B(Ao)
-  void operator()(const fcl::Sphered* sphere_A, const fcl::Sphered* sphere_B);
-  void operator()(const fcl::Sphered* sphere_A, const fcl::Boxd* box_B);
-  void operator()(const fcl::Sphered* sphere_A,
-                  const fcl::Cylinderd* cylinder_B);
-
- private:
-  // Distance computation between a sphere A and a generic shape B. We use
-  // the overloaded call operators above to limit the kinds of queries, and
-  // they all call this private template function to minimize code duplication.
-  template <typename FclShape>
-  void SphereShapeDistance(const fcl::Sphered* sphere_A,
-                           const FclShape* shape_B);
-  // Performs step 3. Na = Ao - r * ∇φ_B(Ao).
-  // @param radius_A the radius of the sphere A.
-  // @param X_WA the pose of the sphere A.
-  // @param gradB_W the gradient vector ∇φ_B(Ao).
-  // @retval p_WNa the witness point Na ∈ ∂A expressed in World frame.
-  Vector3d WitnessPointOnSphere(
-      const double radius_A, const RigidTransformd& X_WA,
-      const Vector3d& gradB_W) const;
-
-  GeometryId id_A_;
-  GeometryId id_B_;
-  RigidTransformd X_WA_;
-  RigidTransformd X_WB_;
-  fcl::DistanceResultd* result_;
-};
-
-Vector3d DistancePairGeometry::WitnessPointOnSphere(
-    const double radius_A, const RigidTransformd& X_WA,
-    const Vector3d& gradB_W) const {
-  // Notation:
-  // gradB_W = ∇φ_B(Ao) expressed in World frame.
-  // gradB_A = ∇φ_B(Ao) expressed in A's frame.
-  const RotationMatrixd& R_WA = X_WA.rotation();
-  const RotationMatrixd R_AW = R_WA.transpose();
-  const Vector3d gradB_A = R_AW * gradB_W;
-  // By construction gradB_A has unit length.
-  const Vector3d p_ANa = -radius_A * gradB_A;
-  const Vector3d p_WNa = X_WA * p_ANa;
-  return p_WNa;
-}
-
-// Signed distance between a sphere and another shape.
-template <typename FclShape>
-void DistancePairGeometry::SphereShapeDistance(const fcl::Sphered* sphere_A,
-                                               const FclShape* shape_B) {
-  const SignedDistanceToPoint<double> shape_B_to_point_Ao =
-      DistanceToPoint<double>(id_B_, X_WB_, X_WA_.translation())(*shape_B);
-  const double distance = shape_B_to_point_Ao.distance - sphere_A->radius;
-  // Nb is the witness point on ∂B.
-  const Vector3d& p_BNb = shape_B_to_point_Ao.p_GN;
-  const Vector3d p_WNb = X_WB_ * p_BNb;
-  const Vector3d& gradB_W = shape_B_to_point_Ao.grad_W;
-  // Na is the witness point on ∂A.
-  const Vector3d p_WNa = WitnessPointOnSphere(sphere_A->radius, X_WA_, gradB_W);
-  // fcl::DistanceResult expects -1 for primitive shapes.
-  result_->update(distance, sphere_A, shape_B, -1, -1, p_WNa, p_WNb);
-}
-
-// Signed distance between two spheres.
-void DistancePairGeometry::operator()(const fcl::Sphered* sphere_A,
-                                      const fcl::Sphered* sphere_B) {
-  SphereShapeDistance(sphere_A, sphere_B);
-}
-
-// Signed distance between a sphere and a box.
-void DistancePairGeometry::operator()(const fcl::Sphered* sphere_A,
-                                      const fcl::Boxd* box_B) {
-  SphereShapeDistance(sphere_A, box_B);
-}
-
-// Signed distance between a sphere and a cylinder.
-void DistancePairGeometry::operator()(const fcl::Sphered* sphere_A,
-                                      const fcl::Cylinderd* cylinder_B) {
-  SphereShapeDistance(sphere_A, cylinder_B);
-}
-
-// Helps DistanceCallback(). Do it in closed forms for sphere-sphere,
-// sphere-box, or sphere-cylinder. Otherwise, use FCL GJK/EPA.
-void ComputeNarrowPhaseDistance(const fcl::CollisionObjectd* a,
-                                const fcl::CollisionObjectd* b,
-                                const std::vector<GeometryId>& geometry_map,
-                                const fcl::DistanceRequestd& request,
-                                fcl::DistanceResultd* result) {
-  const fcl::CollisionGeometryd* a_geometry = a->collisionGeometry().get();
-  const fcl::CollisionGeometryd* b_geometry = b->collisionGeometry().get();
-
-  // We use FCL's GJK/EPA fallback in those geometries we haven't explicitly
-  // supported. However, FCL doesn't support: half spaces, planes, triangles, or
-  // octtrees in that workflow. We need to give intelligent feedback rather than
-  // the segfault otherwise produced.
-  // NOTE: Currently this only tests for halfspace (because it is an otherwise
-  // supported geometry type in SceneGraph. When meshes, planes, and/or octrees
-  // are supported, this error would have to be modified.
-  // TODO(SeanCurtis-TRI): Remove this test when FCL supports signed distance
-  // queries for halfspaces (see issue #10905). Also see FCL issue
-  // https://github.com/flexible-collision-library/fcl/issues/383.
-  if (a_geometry->getNodeType() == fcl::GEOM_HALFSPACE ||
-      b_geometry->getNodeType() == fcl::GEOM_HALFSPACE) {
-    throw std::logic_error(
-        "Signed distance queries on halfspaces are not currently supported. "
-        "Try using a large box instead.");
-  }
-
-  const bool a_is_sphere =
-      a->collisionGeometry().get()->getNodeType() == fcl::GEOM_SPHERE;
-  const bool b_is_sphere =
-      b->collisionGeometry().get()->getNodeType() == fcl::GEOM_SPHERE;
-  const bool no_sphere = ((!a_is_sphere) && (!b_is_sphere));
-  if (no_sphere) {
-    fcl::distance(a, b, request, *result);
-    return;
-  }
-  DRAKE_ASSERT(a_is_sphere || b_is_sphere);
-  // We write `s` for the sphere object and `o` for the other object. We
-  // assign either (a,b) or (b,a) to (s,o) depending on whether `a` is a
-  // sphere or not. Therefore, we only need the helper DistancePairGeometry
-  // that takes (sphere, other) but not (other, sphere).  This scheme helps us
-  // keep the code compact; however, we might have to re-order the result
-  // afterwards.
-  const fcl::CollisionObjectd* s = a_is_sphere ? a : b;
-  const fcl::CollisionObjectd* o = a_is_sphere ? b : a;
-  const fcl::CollisionGeometryd* s_geometry = s->collisionGeometry().get();
-  const fcl::CollisionGeometryd* o_geometry = o->collisionGeometry().get();
-  const RigidTransformd X_WS(s->getTransform());
-  const RigidTransformd X_WO(o->getTransform());
-  const auto id_S = EncodedData(*s).id(geometry_map);
-  const auto id_O = EncodedData(*o).id(geometry_map);
-  DistancePairGeometry distance_pair(id_S, id_O, X_WS, X_WO, result);
-  auto sphere_S = static_cast<const fcl::Sphered*>(s_geometry);
-  switch (o_geometry->getNodeType()) {
-    case fcl::GEOM_SPHERE: {
-      auto sphere_O = static_cast<const fcl::Sphered*>(o_geometry);
-      distance_pair(sphere_S, sphere_O);
-      break;
-    }
-    case fcl::GEOM_BOX: {
-      auto box_O = static_cast<const fcl::Boxd*>(o_geometry);
-      distance_pair(sphere_S, box_O);
-      break;
-    }
-    case fcl::GEOM_CYLINDER: {
-      auto cylinder_O = static_cast<const fcl::Cylinderd*>(o_geometry);
-      distance_pair(sphere_S, cylinder_O);
-      break;
-    }
-    default: {
-      // We don't have a closed form solution for the other geometry, so we
-      // call FCL GJK/EPA.
-      fcl::distance(s, o, request, *result);
-      break;
-    }
-  }
-  // If needed, re-order the result for (s,o) back to the result for (a,b).
-  if (!a_is_sphere) {
-    std::swap(result->o1, result->o2);
-    std::swap(result->nearest_points[0], result->nearest_points[1]);
-  }
-}
-
-// The callback function in fcl::distance request. The final unnamed parameter
-// is `dist`, which is used in fcl::distance, that if the distance between two
-// geometries is proved to be greater than `dist` (for example, the smallest
-// distance between the bounding boxes containing object A and object B is
-// greater than `dist`), then fcl::distance will skip this callback. In our
-// case, as we want to compute the distance between any pair of geometries, we
-// leave `dist` unchanged as its default value (max_double). So the last
-// parameter is merely a placeholder, and not being used or updated in the
-// callback.
-bool DistanceCallback(fcl::CollisionObjectd* fcl_object_A_ptr,
-                      fcl::CollisionObjectd* fcl_object_B_ptr,
-                      // NOLINTNEXTLINE
-                      void* callback_data, double&) {
-  auto& distance_data = *static_cast<DistanceData*>(callback_data);
-  const std::vector<GeometryId>& geometry_map = distance_data.geometry_map;
-  // We want to pass object_A and object_B to the narrowphase distance in a
-  // specific order. This way the broadphase distance is free to give us
-  // either (A,B) or (B,A), and the narrowphase distance will always give the
-  // same result.
-  const GeometryId orig_id_A = EncodedData(*fcl_object_A_ptr).id(geometry_map);
-  const GeometryId orig_id_B = EncodedData(*fcl_object_B_ptr).id(geometry_map);
-  const bool swap_AB = (orig_id_B < orig_id_A);
-  const GeometryId id_A = swap_AB ? orig_id_B : orig_id_A;
-  const GeometryId id_B = swap_AB ? orig_id_A : orig_id_B;
-  // NOTE: Although this function *takes* pointers to non-const objects to
-  // satisfy the fcl api, it should not exploit the non-constness to modify
-  // the collision objects. We ensure this by a reference to a const version
-  // and not directly use the provided pointers afterwards.
-  const fcl::CollisionObjectd& fcl_object_A =
-      *(swap_AB ? fcl_object_B_ptr : fcl_object_A_ptr);
-  const fcl::CollisionObjectd& fcl_object_B =
-      *(swap_AB ? fcl_object_A_ptr : fcl_object_B_ptr);
-
-  // Extract the collision filter keys from the fcl collision objects. These
-  // keys will also be used to map the fcl collision object back to the Drake
-  // GeometryId for colliding geometries.
-  const EncodedData encoding_A(fcl_object_A);
-  const EncodedData encoding_B(fcl_object_B);
-
-  const bool can_collide = distance_data.collision_filter.CanCollideWith(
-      encoding_A.encoded_data(), encoding_B.encoded_data());
-
-  if (can_collide) {
-    fcl::DistanceResultd result;
-    ComputeNarrowPhaseDistance(&fcl_object_A, &fcl_object_B, geometry_map,
-                               distance_data.request, &result);
-    const Vector3d& p_WCa = result.nearest_points[0];
-    const Vector3d& p_WCb = result.nearest_points[1];
-    const Vector3d p_ACa = fcl_object_A.getTransform().inverse() * p_WCa;
-    const Vector3d p_BCb = fcl_object_B.getTransform().inverse() * p_WCb;
-    // TODO(DamrongGuoy): For sphere-{sphere,box,cylinder} we will start
-    //  working on the right nhat when min_distance is 0 or almost 0 after
-    //  PR #10813 lands to avoid conflicts with this PR #10823. For now,
-    //  we simply return NaN in nhat when min_distance is 0 or almost 0.
-    const Vector3d nhat_BA_W =
-        (std::abs(result.min_distance) < std::numeric_limits<double>::epsilon())
-            ? Vector3d(std::numeric_limits<double>::quiet_NaN(),
-                       std::numeric_limits<double>::quiet_NaN(),
-                       std::numeric_limits<double>::quiet_NaN())
-            : (p_WCa - p_WCb) / result.min_distance;
-    distance_data.nearest_pairs->emplace_back(id_A, id_B, p_ACa, p_BCb,
-                                              result.min_distance, nhat_BA_W);
-  }
-
-  // Returning true would tell the broadphase manager to terminate early. Since
-  // we want to find all the signed distance present in the model's current
-  // configuration, we return false.
-  return false;
-}
 
 // Callback function for FCL's collide() function for retrieving a *single*
 // contact.
@@ -931,18 +555,19 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
   ComputeSignedDistancePairwiseClosestPoints(
       const std::vector<GeometryId>& geometry_map) const {
     std::vector<SignedDistancePair<double>> witness_pairs;
-    DistanceData distance_data{&geometry_map, &collision_filter_};
+    shape_distance::CallbackData distance_data{&geometry_map,
+                                               &collision_filter_};
     distance_data.nearest_pairs = &witness_pairs;
     distance_data.request.enable_nearest_points = true;
     distance_data.request.enable_signed_distance = true;
     distance_data.request.gjk_solver_type = fcl::GJKSolverType::GST_LIBCCD;
     distance_data.request.distance_tolerance = distance_tolerance_;
 
-    dynamic_tree_.distance(&distance_data, DistanceCallback);
+    dynamic_tree_.distance(&distance_data, shape_distance::Callback);
     dynamic_tree_.distance(
         const_cast<fcl::DynamicAABBTreeCollisionManager<double>*>(
             &anchored_tree_),
-        &distance_data, DistanceCallback);
+        &distance_data, shape_distance::Callback);
     return witness_pairs;
   }
 

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -978,8 +978,8 @@ template <typename T>
 std::vector<SignedDistancePair<T>>
 ProximityEngine<T>::ComputeSignedDistancePairwiseClosestPoints(
     const std::vector<GeometryId>& geometry_map,
-    const std::vector<Isometry3<T>>& X_WG) const {
-  return impl_->ComputeSignedDistancePairwiseClosestPoints(geometry_map, X_WG);
+    const std::vector<Isometry3<T>>& X_WGs) const {
+  return impl_->ComputeSignedDistancePairwiseClosestPoints(geometry_map, X_WGs);
 }
 
 template <typename T>

--- a/geometry/proximity_engine.h
+++ b/geometry/proximity_engine.h
@@ -165,20 +165,23 @@ class ProximityEngine {
    geometries. The order and size of the returned vector are invariant
    when the poses of the objects are changed.
 
-   @param[in] geometry_map      A map from geometry _index_ to the corresponding
-                                global geometry identifier.
-   @retval signed_distances     A vector populated with per-object-pair signed
-                                distance values (and supporting data).
-                                Note: For a geometry pair (A, B), the supporting
-                                data will always be reported in a fixed order
-                                (e.g., always (A, B) and never (B, A)). The
-                                _basis_ for the ordering is arbitrary (and
-                                therefore undocumented), but guaranteed to be
-                                fixed and repeatable.
+   @param[in] geometry_map    A map from geometry _index_ to the corresponding
+                              global geometry identifier.
+   @param[in] X_WG            The pose of all geometries in world, indexed by
+                              each geometry's GeometryIndex.
+   @retval signed_distances   A vector populated with per-object-pair signed
+                              distance values (and supporting data).
+                              Note: For a geometry pair (A, B), the supporting
+                              data will always be reported in a fixed order
+                              (e.g., always (A, B) and never (B, A)). The
+                              _basis_ for the ordering is arbitrary (and
+                              therefore undocumented), but guaranteed to be
+                              fixed and repeatable.
    */
-  std::vector<SignedDistancePair<double>>
+  std::vector<SignedDistancePair<T>>
   ComputeSignedDistancePairwiseClosestPoints(
-      const std::vector<GeometryId>& geometry_map) const;
+      const std::vector<GeometryId>& geometry_map,
+      const std::vector<Isometry3<T>>& X_WG) const;
 
   /** Performs work in support of GeometryState::ComputeSignedDistanceToPoint().
    @param[in] p_WQ            Position of a query point Q in world frame W.

--- a/geometry/proximity_engine.h
+++ b/geometry/proximity_engine.h
@@ -167,7 +167,7 @@ class ProximityEngine {
 
    @param[in] geometry_map    A map from geometry _index_ to the corresponding
                               global geometry identifier.
-   @param[in] X_WG            The pose of all geometries in world, indexed by
+   @param[in] X_WGs           The pose of all geometries in world, indexed by
                               each geometry's GeometryIndex.
    @retval signed_distances   A vector populated with per-object-pair signed
                               distance values (and supporting data).
@@ -181,7 +181,7 @@ class ProximityEngine {
   std::vector<SignedDistancePair<T>>
   ComputeSignedDistancePairwiseClosestPoints(
       const std::vector<GeometryId>& geometry_map,
-      const std::vector<Isometry3<T>>& X_WG) const;
+      const std::vector<Isometry3<T>>& X_WGs) const;
 
   /** Performs work in support of GeometryState::ComputeSignedDistanceToPoint().
    @param[in] p_WQ            Position of a query point Q in world frame W.

--- a/geometry/query_object.cc
+++ b/geometry/query_object.cc
@@ -30,7 +30,7 @@ QueryObject<T>::ComputePointPairPenetration() const {
 }
 
 template <typename T>
-std::vector<SignedDistancePair<double>>
+std::vector<SignedDistancePair<T>>
 QueryObject<T>::ComputeSignedDistancePairwiseClosestPoints() const {
   ThrowIfDefault();
 

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -195,12 +195,27 @@ class QueryObject {
    filter. We report the distance between dynamic objects, and between dynamic
    and anchored objects. We DO NOT report the distance between two anchored
    objects.
+
+   <h3>Scalar support</h3>
+   This function does not support halfspaces. If an unfiltered pair contains
+   a halfspace, an exception will be thrown for all scalar types. Otherwise,
+   this query supports all other pairs of Drake geometry types for `double`.
+   For `AutoDiffXd`, it only supports distance between sphere-box and
+   sphere-sphere. If there are any unfiltered geometry pairs that include other
+   geometries, the AutoDiff throws an exception.
+
+   <!-- TODO(SeanCurtis-TRI): Document expected precision of answer based on
+   members of shape pair. See
+   https://github.com/RobotLocomotion/drake/issues/10907 -->
+   <!-- TODO(SeanCurtis-TRI): Support queries of halfspace-A, where A is _not_ a
+   halfspace. See https://github.com/RobotLocomotion/drake/issues/10905 -->
+
    @retval near_pairs The signed distance for all unfiltered geometry pairs.
   */
   // TODO(hongkai.dai): add a distance bound as an optional input, such that the
   // function doesn't return the pairs whose signed distance is larger than the
   // distance bound.
-  std::vector<SignedDistancePair<double>>
+  std::vector<SignedDistancePair<T>>
   ComputeSignedDistancePairwiseClosestPoints() const;
 
   // TODO(DamrongGuoy): Improve and refactor documentation of

--- a/geometry/query_results/signed_distance_pair.h
+++ b/geometry/query_results/signed_distance_pair.h
@@ -107,8 +107,9 @@ struct SignedDistancePair{
         distance(dist),
         nhat_BA_W(Vector3<T>::Zero()) {}
 
-  // Swaps the values for a and b.
+  /** Swaps the interpretation of geometries A and B. */
   void SwapAAndB() {
+    // Leave distance alone; swapping A and B doesn't change the distance.
     std::swap(id_A, id_B);
     std::swap(p_ACa, p_BCb);
     nhat_BA_W = -nhat_BA_W;

--- a/geometry/query_results/signed_distance_pair.h
+++ b/geometry/query_results/signed_distance_pair.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/geometry_ids.h"
@@ -104,6 +106,13 @@ struct SignedDistancePair{
         p_BCb(p_BCb_in),
         distance(dist),
         nhat_BA_W(Vector3<T>::Zero()) {}
+
+  // Swaps the values for a and b.
+  void SwapAAndB() {
+    std::swap(id_A, id_B);
+    std::swap(p_ACa, p_BCb);
+    nhat_BA_W = -nhat_BA_W;
+  }
 
   /** The id of the first geometry in the pair. */
   GeometryId id_A;

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -20,10 +20,12 @@ namespace geometry {
 namespace internal {
 // Compare witness pair. Note that we can switch body A with body B in one pair,
 // and the comparison result would be the same.
-void CompareSignedDistancePair(const SignedDistancePair<double>& pair,
-                               const SignedDistancePair<double>& pair_expected,
+template <typename T>
+void CompareSignedDistancePair(const SignedDistancePair<T>& pair,
+                               const SignedDistancePair<T>& pair_expected,
                                double tol) {
-  EXPECT_NEAR(pair.distance, pair_expected.distance, tol);
+  using std::abs;
+  EXPECT_TRUE(abs(pair.distance - pair_expected.distance) < tol);
   ASSERT_LT(pair.id_A, pair_expected.id_B);
   EXPECT_EQ(pair.id_B, pair_expected.id_B);
   EXPECT_TRUE(CompareMatrices(pair.p_ACa, pair_expected.p_ACa, tol,
@@ -287,9 +289,10 @@ GTEST_TEST(ProximityEngineTests, MoveSemantics) {
 GTEST_TEST(ProximityEngineTests, SignedDistanceClosestPointsOnEmptyScene) {
   ProximityEngine<double> engine;
   std::vector<GeometryId> empty_map;
+  std::vector<Isometry3d> X_WGs;
 
   const auto results =
-      engine.ComputeSignedDistancePairwiseClosestPoints(empty_map);
+      engine.ComputeSignedDistancePairwiseClosestPoints(empty_map, X_WGs);
   EXPECT_EQ(results.size(), 0);
 }
 
@@ -297,15 +300,17 @@ GTEST_TEST(ProximityEngineTests, SignedDistanceClosestPointsOnEmptyScene) {
 GTEST_TEST(ProximityEngineTests, SignedDistanceClosestPointsSingleAnchored) {
   ProximityEngine<double> engine;
   std::vector<GeometryId> geometry_map;
+  std::vector<Isometry3d> X_WGs;
 
   Sphere sphere{0.5};
   Isometry3<double> pose = Isometry3<double>::Identity();
+  X_WGs.push_back(pose);
   ProximityIndex index = engine.AddAnchoredGeometry(sphere, pose,
                                                     GeometryIndex(0));
   geometry_map.push_back(GeometryId::get_new_id());
   EXPECT_EQ(index, 0);
   const auto results = engine.ComputeSignedDistancePairwiseClosestPoints(
-      geometry_map);
+      geometry_map, X_WGs);
   EXPECT_EQ(results.size(), 0);
 }
 
@@ -313,21 +318,24 @@ GTEST_TEST(ProximityEngineTests, SignedDistanceClosestPointsSingleAnchored) {
 GTEST_TEST(ProximityEngineTests, SignedDistanceClosestPointsMultipleAnchored) {
   ProximityEngine<double> engine;
   std::vector<GeometryId> geometry_map;
+  std::vector<Isometry3d> X_WGs;
 
   const double radius = 0.5;
   Sphere sphere{radius};
   Isometry3<double> pose = Isometry3<double>::Identity();
+  X_WGs.push_back(pose);
   ProximityIndex index1 = engine.AddAnchoredGeometry(sphere, pose,
                                                      GeometryIndex(0));
   geometry_map.push_back(GeometryId::get_new_id());
   EXPECT_EQ(index1, 0);
   pose.translation() << 1.8 * radius, 0, 0;
+  X_WGs.push_back(pose);
   ProximityIndex index2 = engine.AddAnchoredGeometry(sphere, pose,
                                                      GeometryIndex(1));
   geometry_map.push_back(GeometryId::get_new_id());
   EXPECT_EQ(index2, 1);
   const auto results = engine.ComputeSignedDistancePairwiseClosestPoints(
-      geometry_map);
+      geometry_map, X_WGs);
   EXPECT_EQ(results.size(), 0);
 }
 
@@ -1231,16 +1239,32 @@ class SimplePenetrationTest : public ::testing::Test {
   //   *    │ o  *      o
   //    *   │  o*      o
   //       *│*    o o
-  void MoveDynamicSphere(int index, bool is_colliding,
+
+  // Updates a pose in X_WG_ to be colliding or non-colliding. Then udpates the
+  // position of all dynamic geometries (as given by index).
+  void MoveDynamicSphere(GeometryIndex index, bool is_colliding,
+      const std::vector<GeometryIndex>& dynamic_indices,
                          ProximityEngine<double>* engine = nullptr) {
     engine = engine == nullptr ? &engine_ : engine;
-    std::vector<Isometry3<double>> poses(engine->num_dynamic(),
-                                         Isometry3<double>::Identity());
+
+    DRAKE_DEMAND(engine->num_geometries() == static_cast<int>(X_WGs_.size()));
+
     const double x_pos = is_colliding ? colliding_x_ : free_x_;
-    poses[index] = Isometry3<double>(Translation3d{x_pos, 0, 0});
-    std::vector<GeometryIndex> indices(poses.size());
-    std::iota(indices.begin(), indices.end(), GeometryIndex(0));
-    engine->UpdateWorldPoses(poses, indices);
+    X_WGs_[index] = Isometry3<double>(Translation3d{x_pos, 0, 0});
+
+    engine->UpdateWorldPoses(X_WGs_, dynamic_indices);
+  }
+
+  // Poses have been defined as doubles; get them in the required scalar type.
+  template <typename T>
+  std::vector<Isometry3<T>> GetTypedPoses() const {
+    std::vector<Isometry3<T>> typed_X_WG;
+    for (const auto& X_WG : X_WGs_) {
+      Isometry3<T> X_WG_t;
+      X_WG_t.matrix() = X_WG.matrix();
+      typed_X_WG.push_back(X_WG_t);
+    }
+    return typed_X_WG;
   }
 
   // Compute penetration and confirm that a single penetration with the expected
@@ -1254,10 +1278,11 @@ class SimplePenetrationTest : public ::testing::Test {
     ASSERT_EQ(penetration_results.size(), 1);
     const PenetrationAsPointPair<double>& penetration = penetration_results[0];
 
-    std::vector<SignedDistancePair<double>> distance_results =
-        engine->ComputeSignedDistancePairwiseClosestPoints(geometry_map_);
+    std::vector<SignedDistancePair<T>> distance_results =
+        engine->ComputeSignedDistancePairwiseClosestPoints(geometry_map_,
+                                                           GetTypedPoses<T>());
     ASSERT_EQ(distance_results.size(), 1);
-    const SignedDistancePair<double>& distance = distance_results[0];
+    const SignedDistancePair<T>& distance = distance_results[0];
 
     // There are no guarantees as to the ordering of which element is A and
     // which is B. This test enforces an order for validation.
@@ -1301,7 +1326,7 @@ class SimplePenetrationTest : public ::testing::Test {
                                 1e-13, MatrixCompareType::absolute));
 
     // Should return the penetration depth here.
-    SignedDistancePair<double> expected_distance;
+    SignedDistancePair<T> expected_distance;
     expected_distance.distance = -expected.depth;
     expected_distance.id_A = origin_sphere;
     expected_distance.id_B = colliding_sphere;
@@ -1326,8 +1351,9 @@ class SimplePenetrationTest : public ::testing::Test {
         engine->ComputePointPairPenetration(geometry_map_);
     EXPECT_EQ(penetration_results.size(), 0);
 
-    std::vector<SignedDistancePair<double>> distance_results =
-        engine->ComputeSignedDistancePairwiseClosestPoints(geometry_map_);
+    std::vector<SignedDistancePair<T>> distance_results =
+        engine->ComputeSignedDistancePairwiseClosestPoints(geometry_map_,
+                                                           GetTypedPoses<T>());
     ASSERT_EQ(distance_results.size(), 0);
   }
 
@@ -1341,7 +1367,8 @@ class SimplePenetrationTest : public ::testing::Test {
     EXPECT_EQ(penetration_results.size(), 0);
 
     std::vector<SignedDistancePair<double>> distance_results =
-        engine->ComputeSignedDistancePairwiseClosestPoints(geometry_map_);
+        engine->ComputeSignedDistancePairwiseClosestPoints(geometry_map_,
+                                                           X_WGs_);
     ASSERT_EQ(distance_results.size(), 1);
     SignedDistancePair<double> distance = distance_results[0];
 
@@ -1369,6 +1396,7 @@ class SimplePenetrationTest : public ::testing::Test {
 
   ProximityEngine<double> engine_;
   std::vector<GeometryId> geometry_map_;
+  std::vector<Isometry3d> X_WGs_;
   const double radius_{0.5};
   const Sphere sphere_{radius_};
   const double free_x_{2.5 * radius_};
@@ -1378,28 +1406,34 @@ class SimplePenetrationTest : public ::testing::Test {
 // Tests collision between dynamic and anchored sphere. One case colliding, one
 // case *not* colliding.
 TEST_F(SimplePenetrationTest, PenetrationDynamicAndAnchored) {
+  std::vector<GeometryIndex> dynamic_indices;
   // Set up anchored geometry
   Isometry3<double> pose = Isometry3<double>::Identity();
-  ProximityIndex anchored_index =
+  ProximityIndex anchored_pindex =
       engine_.AddAnchoredGeometry(sphere_, pose, GeometryIndex(0));
-  EXPECT_EQ(anchored_index, 0);
+  EXPECT_EQ(anchored_pindex, 0);
   GeometryId origin_id = GeometryId::get_new_id();
   geometry_map_.push_back(origin_id);
 
   // Set up dynamic geometry
-  ProximityIndex dynamic_index =
-      engine_.AddDynamicGeometry(sphere_, GeometryIndex(1));
-  EXPECT_EQ(dynamic_index, 0);
+  GeometryIndex dynamic_index(1);
+  dynamic_indices.push_back(dynamic_index);
+  ProximityIndex dynamic_pindex =
+      engine_.AddDynamicGeometry(sphere_, dynamic_index);
+  EXPECT_EQ(dynamic_pindex, 0);
   GeometryId dynamic_id = GeometryId::get_new_id();
   geometry_map_.push_back(dynamic_id);
   EXPECT_EQ(engine_.num_geometries(), 2);
 
+  X_WGs_.push_back(pose);
+  X_WGs_.push_back(Isometry3d::Identity());
+
   // Non-colliding case
-  MoveDynamicSphere(dynamic_index, false /* not colliding */);
+  MoveDynamicSphere(dynamic_index, false /* not colliding */, dynamic_indices);
   ExpectNoPenetration(origin_id, dynamic_id, &engine_);
 
   // Colliding case
-  MoveDynamicSphere(dynamic_index, true /* colliding */);
+  MoveDynamicSphere(dynamic_index, true /* colliding */, dynamic_indices);
   ExpectPenetration(origin_id, dynamic_id, &engine_);
 
   // Test colliding case on copy.
@@ -1415,29 +1449,32 @@ TEST_F(SimplePenetrationTest, PenetrationDynamicAndAnchored) {
 // Performs the same collision test between two dynamic spheres which belong to
 // the same source
 TEST_F(SimplePenetrationTest, PenetrationDynamicAndDynamicSingleSource) {
-  ProximityIndex origin_index =
-      engine_.AddDynamicGeometry(sphere_, GeometryIndex(0));
+  std::vector<GeometryIndex> dynamic_indices;
+  dynamic_indices.emplace_back(0);
+  ProximityIndex origin_pindex =
+      engine_.AddDynamicGeometry(sphere_, dynamic_indices.back());
   GeometryId origin_id = GeometryId::get_new_id();
   geometry_map_.push_back(origin_id);
-  EXPECT_EQ(origin_index, 0);
-  std::vector<Isometry3<double>> poses{Isometry3<double>::Identity()};
-  std::vector<GeometryIndex> indices(poses.size());
-  std::iota(indices.begin(), indices.end(), GeometryIndex(0));
-  engine_.UpdateWorldPoses(poses, indices);
+  EXPECT_EQ(origin_pindex, 0);
 
-  ProximityIndex collide_index =
-      engine_.AddDynamicGeometry(sphere_, GeometryIndex(1));
+  GeometryIndex collide_index(1);
+  dynamic_indices.push_back(collide_index);
+  ProximityIndex collide_pindex =
+      engine_.AddDynamicGeometry(sphere_, dynamic_indices.back());
   GeometryId collide_id = GeometryId::get_new_id();
   geometry_map_.push_back(collide_id);
-  EXPECT_EQ(collide_index, 1);
+  EXPECT_EQ(collide_pindex, 1);
   EXPECT_EQ(engine_.num_geometries(), 2);
 
+  X_WGs_.push_back(Isometry3d::Identity());
+  X_WGs_.push_back(Isometry3d::Identity());
+
   // Non-colliding case
-  MoveDynamicSphere(collide_index, false /* not colliding */);
+  MoveDynamicSphere(collide_index, false /* not colliding */, dynamic_indices);
   ExpectNoPenetration(origin_id, collide_id, &engine_);
 
   // Colliding case
-  MoveDynamicSphere(collide_index, true /* colliding */);
+  MoveDynamicSphere(collide_index, true /* colliding */, dynamic_indices);
   ExpectPenetration(origin_id, collide_id, &engine_);
 
   // Test colliding case on copy.
@@ -1460,9 +1497,9 @@ TEST_F(SimplePenetrationTest, ExcludeCollisionsWithinCliqueGeneration) {
   engine_.AddDynamicGeometry(sphere_, dynamic2);
 
   Isometry3<double> pose{Isometry3<double>::Identity()};
-  GeometryIndex anchored1(0);
+  GeometryIndex anchored1(2);
   engine_.AddAnchoredGeometry(sphere_, pose, anchored1);
-  GeometryIndex anchored2(1);
+  GeometryIndex anchored2(3);
   engine_.AddAnchoredGeometry(sphere_, pose, anchored2);
 
   int expected_clique = PET::peek_next_clique(engine_);
@@ -1508,21 +1545,22 @@ TEST_F(SimplePenetrationTest, ExcludeCollisionsWithinCliqueGeneration) {
 
 // Performs the same collision test where the geometries have been filtered.
 TEST_F(SimplePenetrationTest, ExcludeCollisionsWithin) {
+  std::vector<GeometryIndex> dynamic_indices;
   GeometryIndex origin_index(0);
+  dynamic_indices.push_back(origin_index);
   engine_.AddDynamicGeometry(sphere_, origin_index);
   GeometryId origin_id = GeometryId::get_new_id();
   geometry_map_.push_back(origin_id);
 
-  std::vector<Isometry3<double>> poses{Isometry3<double>::Identity()};
-  std::vector<GeometryIndex> indices(poses.size());
-  std::iota(indices.begin(), indices.end(), GeometryIndex(0));
-  engine_.UpdateWorldPoses(poses, indices);
-
   GeometryIndex collide_index(1);
   engine_.AddDynamicGeometry(sphere_, collide_index);
+  dynamic_indices.push_back(collide_index);
   GeometryId collide_id = GeometryId::get_new_id();
   geometry_map_.push_back(collide_id);
   EXPECT_EQ(engine_.num_geometries(), 2);
+
+  X_WGs_.push_back(Isometry3d::Identity());
+  X_WGs_.push_back(Isometry3d::Identity());
 
   EXPECT_FALSE(engine_.CollisionFiltered(origin_index, true,
                                          collide_index, true));
@@ -1531,11 +1569,11 @@ TEST_F(SimplePenetrationTest, ExcludeCollisionsWithin) {
                                         collide_index, true));
 
   // Non-colliding case
-  MoveDynamicSphere(collide_index, false /* not colliding */);
+  MoveDynamicSphere(collide_index, false /* not colliding */, dynamic_indices);
   ExpectIgnoredPenetration(origin_id, collide_id, &engine_);
 
   // Colliding case
-  MoveDynamicSphere(collide_index, true /* colliding */);
+  MoveDynamicSphere(collide_index, true /* colliding */, dynamic_indices);
   ExpectIgnoredPenetration(origin_id, collide_id, &engine_);
 
   // Test colliding case on copy.
@@ -1610,18 +1648,16 @@ TEST_F(SimplePenetrationTest, ExcludeCollisionsBetweenCliqueGeneration) {
 }
 
 TEST_F(SimplePenetrationTest, ExcludeCollisionsBetween) {
+  std::vector<GeometryIndex> dynamic_indices;
   GeometryIndex origin_index(0);
+  dynamic_indices.push_back(origin_index);
   engine_.AddDynamicGeometry(sphere_, origin_index);
   GeometryId origin_id = GeometryId::get_new_id();
   geometry_map_.push_back(origin_id);
 
-  std::vector<Isometry3<double>> poses{Isometry3<double>::Identity()};
-  std::vector<GeometryIndex> indices(poses.size());
-  std::iota(indices.begin(), indices.end(), GeometryIndex(0));
-  engine_.UpdateWorldPoses(poses, indices);
-
   GeometryIndex collide_index(1);
   engine_.AddDynamicGeometry(sphere_, collide_index);
+  dynamic_indices.push_back(collide_index);
   GeometryId collide_id = GeometryId::get_new_id();
   geometry_map_.push_back(collide_id);
   EXPECT_EQ(engine_.num_geometries(), 2);
@@ -1632,12 +1668,15 @@ TEST_F(SimplePenetrationTest, ExcludeCollisionsBetween) {
   EXPECT_TRUE(engine_.CollisionFiltered(origin_index, true,
                                         collide_index, true));
 
+  X_WGs_.push_back(Isometry3d::Identity());
+  X_WGs_.push_back(Isometry3d::Identity());
+
   // Non-colliding case
-  MoveDynamicSphere(collide_index, false /* not colliding */);
+  MoveDynamicSphere(collide_index, false /* not colliding */, dynamic_indices);
   ExpectIgnoredPenetration(origin_id, collide_id, &engine_);
 
   // Colliding case
-  MoveDynamicSphere(collide_index, true /* colliding */);
+  MoveDynamicSphere(collide_index, true /* colliding */, dynamic_indices);
   ExpectIgnoredPenetration(origin_id, collide_id, &engine_);
 
   // Test colliding case on copy.
@@ -2235,14 +2274,20 @@ class SignedDistancePairTest
     engine_.AddAnchoredGeometry(*(data.a_), data.X_WA_.GetAsIsometry3(),
                                 GeometryIndex(0));
     geometry_map_.push_back(data.expected_result_.id_A);
-    engine_.AddDynamicGeometry(*(data.b_), GeometryIndex(1));
+
+    std::vector<GeometryIndex> dynamic_indices{GeometryIndex(1)};
+    engine_.AddDynamicGeometry(*(data.b_), dynamic_indices.back());
     geometry_map_.push_back(data.expected_result_.id_B);
-    engine_.UpdateWorldPoses({data.X_WB_.GetAsIsometry3()}, {GeometryIndex(0)});
+
+    X_WGs_.push_back(data.X_WA_.GetAsIsometry3());
+    X_WGs_.push_back(data.X_WB_.GetAsIsometry3());
+    engine_.UpdateWorldPoses(X_WGs_, dynamic_indices);
   }
 
  protected:
   ProximityEngine<double> engine_;
   std::vector<GeometryId> geometry_map_;
+  std::vector<Isometry3d> X_WGs_;
 
  public:
   // The tolerance value for determining equivalency between expected and
@@ -2255,7 +2300,7 @@ class SignedDistancePairTest
 TEST_P(SignedDistancePairTest, SinglePair) {
   const auto& data = GetParam();
   const auto results =
-      engine_.ComputeSignedDistancePairwiseClosestPoints(geometry_map_);
+      engine_.ComputeSignedDistancePairwiseClosestPoints(geometry_map_, X_WGs_);
   ASSERT_EQ(results.size(), 1);
   const auto& result = results[0];
 
@@ -2334,6 +2379,9 @@ GTEST_TEST(SignedDistancePairError, HalfspaceException) {
   // so that the behavior (and this test) can be removed.
   ProximityEngine<double> engine;
   std::vector<GeometryId> geometry_map;
+  // NOTE: It's not necessary to put any poses into X_WGs; they never get
+  // evaluated due to the error condition.
+  std::vector<Isometry3d> X_WGs;
 
   Sphere sphere{0.5};
   engine.AddDynamicGeometry(sphere, GeometryIndex(0));
@@ -2345,7 +2393,7 @@ GTEST_TEST(SignedDistancePairError, HalfspaceException) {
   geometry_map.push_back(GeometryId::get_new_id());
 
   DRAKE_EXPECT_THROWS_MESSAGE(
-      engine.ComputeSignedDistancePairwiseClosestPoints(geometry_map),
+      engine.ComputeSignedDistancePairwiseClosestPoints(geometry_map, X_WGs),
       std::logic_error,
       "Signed distance .* halfspaces .* not .* supported.* Try .* box .*");
 }
@@ -2359,7 +2407,7 @@ class SignedDistancePairConcentricTest : public SignedDistancePairTest {};
 TEST_P(SignedDistancePairConcentricTest, DistanceInvariance) {
   const auto& data = GetParam();
   const auto results =
-      engine_.ComputeSignedDistancePairwiseClosestPoints(geometry_map_);
+      engine_.ComputeSignedDistancePairwiseClosestPoints(geometry_map_, X_WGs_);
   ASSERT_EQ(results.size(), 1);
   const auto& result = results[0];
 
@@ -2513,119 +2561,6 @@ INSTANTIATE_TEST_CASE_P(SphereBoxConcentric,
 INSTANTIATE_TEST_CASE_P(SphereBoxConcentricTransform,
     SignedDistancePairConcentricTest,
     testing::ValuesIn(GenDistPairTestSphereBoxConcentricTransform()));
-
-//
-// Tests the repeatability of the call to compute the signed distance between
-// closest pairs of dynamic objects when the objects keep the same poses.
-// Related to https://github.com/RobotLocomotion/drake/issues/10286
-//
-// TODO(DamrongGuoy): Remove this test after FCL guarantees consistency in
-// the result of broadphase distance. See this FCL issue:
-// https://github.com/flexible-collision-library/fcl/issues/368
-//
-// We use value-parameterized tests to generate data on many kinds of
-// pairs of shapes. We separate the code to generate test data from the test
-// fixture and the test procedure for modularity.
-//
-// The test is organized in the following way:
-// 1. Define test data SignedDistancePairRepeatTestData.
-// 2. Define test fixture SignedDistancePairRepeatabilityTest that takes a
-//    parameter of type SignedDistancePairRepeatTestData.
-// 3. Define test procedure TEST_P() of the test fixture.
-// 4. Instantiate the tests from the test data and the test fixture.
-//
-
-// Test data.
-struct SignedDistancePairRepeatTestData {
-  SignedDistancePairRepeatTestData(const shared_ptr<const Shape>& a,
-                                   const shared_ptr<const Shape>& b,
-                                   const RigidTransformd& X_WA_in,
-                                   const RigidTransformd& X_WB_in)
-      : shape_A(a), shape_B(b), X_WA(X_WA_in), X_WB(X_WB_in) {}
-
-  shared_ptr<const Shape> shape_A;
-  shared_ptr<const Shape> shape_B;
-  RigidTransformd X_WA;
-  RigidTransformd X_WB;
-};
-
-std::vector<SignedDistancePairRepeatTestData>
-GenDistPairRepeatabilityTestData() {
-  std::vector<shared_ptr<const Shape>> shapes_A{
-      make_shared<const Sphere>(0.1),
-      make_shared<const Box>(0.1, 0.2, 0.3),
-      make_shared<const Cylinder>(0.1, 3.1),
-      make_shared<const Convex>(
-          drake::FindResourceOrThrow("drake/geometry/test/quad_cube.obj"),
-          1.0)};
-  std::vector<shared_ptr<const Shape>> shapes_B{
-      make_shared<const Sphere>(0.2),
-      make_shared<const Box>(0.11, 0.21, 0.31),
-      make_shared<const Cylinder>(0.2, 3.2),
-      make_shared<const Convex>(
-          drake::FindResourceOrThrow("drake/geometry/test/quad_cube.obj"),
-          1.1)};
-  const Translation3d X_WA(0.1, 0.2, 0.3);
-  const Translation3d X_WB(0.11, 0.21, 0.31);
-  std::vector<SignedDistancePairRepeatTestData> test_data;
-  for (shared_ptr<const Shape>& a : shapes_A)
-    for (shared_ptr<const Shape>& b : shapes_B)
-      test_data.emplace_back(a, b, X_WA, X_WB);
-  return test_data;
-}
-
-// Test fixture.
-class SignedDistancePairRepeatabilityTest
-    : public testing::TestWithParam<SignedDistancePairRepeatTestData> {
- public:
-  SignedDistancePairRepeatabilityTest() {
-    auto data = GetParam();
-    engine_.AddDynamicGeometry(*(data.shape_A), GeometryIndex(0));
-    engine_.AddDynamicGeometry(*(data.shape_B), GeometryIndex(1));
-    geometry_map_.push_back(GeometryId::get_new_id());
-    geometry_map_.push_back(GeometryId::get_new_id());
-    X_WG_.push_back(data.X_WA.GetAsIsometry3());
-    X_WG_.push_back(data.X_WB.GetAsIsometry3());
-    geometry_indices_.push_back(GeometryIndex(0));
-    geometry_indices_.push_back(GeometryIndex(1));
-  }
-
- protected:
-  ProximityEngine<double> engine_;
-  std::vector<GeometryId> geometry_map_;
-  std::vector<Isometry3d> X_WG_;
-  std::vector<GeometryIndex> geometry_indices_;
-};
-
-// Test procedure.
-// TODO(DamrongGuoy): Use a more direct way to test that the function
-// drake::geometry::internal::<unnamed>::DistanceCallback() always passes two
-// objects A and B in a consistent order by their geometry id.
-TEST_P(SignedDistancePairRepeatabilityTest, SinglePair) {
-  engine_.UpdateWorldPoses(X_WG_, geometry_indices_);
-  const auto results =
-      engine_.ComputeSignedDistancePairwiseClosestPoints(geometry_map_);
-  ASSERT_EQ(results.size(), 1);
-  const double signed_distance_first_call = results[0].distance;
-
-  // Repeat the computation many times and make sure we always get exactly
-  // the same signed distance as the first one above. No tolerance.
-  const int kRepeat = 7;
-  for (int count = 1; count <= kRepeat; ++count) {
-    engine_.UpdateWorldPoses(X_WG_, geometry_indices_);
-    const auto repeat_results =
-        engine_.ComputeSignedDistancePairwiseClosestPoints(geometry_map_);
-    ASSERT_EQ(repeat_results.size(), 1);
-    // Compare using all the bits of `double`.
-    ASSERT_EQ(signed_distance_first_call, repeat_results[0].distance)
-        << "Repeated call did not give exactly the same signed distance.";
-  }
-}
-
-// Instantiate the tests.
-INSTANTIATE_TEST_CASE_P(RepeatabilityTest, SignedDistancePairRepeatabilityTest,
-                        testing::ValuesIn(GenDistPairRepeatabilityTestData()));
-
 
 // Given a sphere S and box B. The box's height and depth are large (much larger
 // than the diameter of the sphere), but the box's *width* is *less* than the
@@ -3241,7 +3176,7 @@ GTEST_TEST(ProximityEngineTests, AnchoredBroadPhaseInitialization) {
 // Tests against the anchored geometry. Specifically, it confirms that while
 // poses are set with double, the calculation is done with AutoDiff and
 // derivatives come through.
-GTEST_TEST(ProximityEngineTests, ComputeSignedDistanceAutoDiffAnchored) {
+GTEST_TEST(ProximityEngineTests, ComputePointSignedDistanceAutoDiffAnchored) {
   ProximityEngine<AutoDiffXd> engine;
 
   const double kEps = std::numeric_limits<double>::epsilon();
@@ -3302,7 +3237,7 @@ GTEST_TEST(ProximityEngineTests, ComputeSignedDistanceAutoDiffAnchored) {
 // Tests against the dynamic geometry. Specifically, it confirms that while
 // poses are set with double, the calculation is done with AutoDiff and
 // derivatives come through.
-GTEST_TEST(ProximityEngineTests, ComputeSignedDistanceAutoDiffDynamic) {
+GTEST_TEST(ProximityEngineTests, ComputePointSignedDistanceAutoDiffDynamic) {
   ProximityEngine<AutoDiffXd> engine;
 
   const double kEps = std::numeric_limits<double>::epsilon();
@@ -3350,6 +3285,72 @@ GTEST_TEST(ProximityEngineTests, ComputeSignedDistanceAutoDiffDynamic) {
   }
 }
 
+GTEST_TEST(ProximityEngineTests, ComputePairwiseSignedDistanceAutoDiff) {
+  ProximityEngine<AutoDiffXd> engine;
+
+  const double kEps = std::numeric_limits<double>::epsilon();
+
+  const double radius = 0.7;
+
+  // Two spheres with radius 0.7 whose centers are 7 m apart. The literal
+  // values just keep it from being trivial zero-able.
+  const double expected_distance = 7.0 - radius - radius;
+  const Vector3d p_SQ{2.0, 3.0, 6.0};
+  const Vector3d p_WS{0.5, 1.25, -2};
+  const Vector3d p_WQ{p_SQ + p_WS};
+  Vector3<AutoDiffXd> p_WQ_ad = math::initializeAutoDiff(p_WQ);
+
+  // Add a pair of dynamic spheres. We'll differentiate w.r.t. the pose of the
+  // first sphere.
+  GeometryIndex index2(0);
+  engine.AddDynamicGeometry(Sphere(radius), index2);
+  const RigidTransform<AutoDiffXd> X_WS1_ad(p_WQ_ad);
+
+  GeometryIndex index1(1);
+  engine.AddDynamicGeometry(Sphere(radius), index1);
+  std::vector<GeometryId> geometry_map{GeometryId::get_new_id(),
+                                       GeometryId::get_new_id()};
+  const auto X_WS2_ad =
+      RigidTransformd(p_WS).cast<AutoDiffXd>().GetAsIsometry3();
+
+  std::vector<Isometry3<AutoDiffXd>> X_WGs{X_WS1_ad, X_WS2_ad};
+  engine.UpdateWorldPoses(X_WGs, {index1, index2});
+
+  std::vector<SignedDistancePair<AutoDiffXd>> results =
+      engine.ComputeSignedDistancePairwiseClosestPoints(geometry_map, X_WGs);
+  ASSERT_EQ(results.size(), 1);
+
+  const SignedDistancePair<AutoDiffXd>& distance_data = results[0];
+  // The autodiff seems to lose a couple of bits relative to the known
+  // answer.
+  EXPECT_NEAR(distance_data.distance.value(), expected_distance, 4 * kEps);
+  // The hand-computed `grad_W` value should match the autodiff-computed
+  // gradient.
+  const Vector3d ddistance_dp_WQ = distance_data.distance.derivatives();
+  const Vector3d grad_w = math::autoDiffToValueMatrix(distance_data.nhat_BA_W);
+  EXPECT_TRUE(CompareMatrices(ddistance_dp_WQ, grad_w, kEps));
+}
+
+// Tests that an unsupported geometry causes the engine to throw.
+GTEST_TEST(ProximityEngineTests,
+    ComputePairwiseSignedDistanceAutoDiffUnsupported) {
+  ProximityEngine<AutoDiffXd> engine;
+
+  // Add two geometries that can't be queried.
+  engine.AddDynamicGeometry(Box(1, 2, 3), GeometryIndex(0));
+  engine.AddDynamicGeometry(Box(2, 4, 6), GeometryIndex(1));
+
+  Eigen::Isometry3d a;
+  std::vector<GeometryId> geometry_map{GeometryId::get_new_id(),
+                                       GeometryId::get_new_id()};
+  std::vector<Isometry3<AutoDiffXd>> X_WGs{Isometry3<AutoDiffXd>::Identity(),
+                                           Isometry3<AutoDiffXd>::Identity()};
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      engine.ComputeSignedDistancePairwiseClosestPoints(geometry_map, X_WGs),
+      std::logic_error,
+      "Signed distance queries between shapes 'Box' and 'Box' are not "
+      "supported for scalar type drake::AutoDiffXd");
+}
 
 }  // namespace
 }  // namespace internal

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -1240,7 +1240,7 @@ class SimplePenetrationTest : public ::testing::Test {
   //    *   │  o*      o
   //       *│*    o o
 
-  // Updates a pose in X_WG_ to be colliding or non-colliding. Then udpates the
+  // Updates a pose in X_WGs_ to be colliding or non-colliding. Then udpates the
   // position of all dynamic geometries (as given by index).
   void MoveDynamicSphere(GeometryIndex index, bool is_colliding,
       const std::vector<GeometryIndex>& dynamic_indices,
@@ -1451,6 +1451,7 @@ TEST_F(SimplePenetrationTest, PenetrationDynamicAndAnchored) {
 TEST_F(SimplePenetrationTest, PenetrationDynamicAndDynamicSingleSource) {
   std::vector<GeometryIndex> dynamic_indices;
   dynamic_indices.emplace_back(0);
+  // ProximityIndex --> pindex (in contrast with GeometryIndex --> index).
   ProximityIndex origin_pindex =
       engine_.AddDynamicGeometry(sphere_, dynamic_indices.back());
   GeometryId origin_id = GeometryId::get_new_id();

--- a/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
@@ -70,12 +70,12 @@ AutoDiffVecXd EvalMinimumDistanceConstraintAutoDiff(
       plant.get_geometry_query_input_port()
           .Eval<geometry::QueryObject<AutoDiffXd>>(context);
 
-  const std::vector<geometry::SignedDistancePair<double>>
+  const std::vector<geometry::SignedDistancePair<AutoDiffXd>>
       signed_distance_pairs =
           query_object.ComputeSignedDistancePairwiseClosestPoints();
 
   for (const auto& signed_distance_pair : signed_distance_pairs) {
-    const double distance = signed_distance_pair.distance;
+    const double distance = signed_distance_pair.distance.value();
     if (distance < minimum_distance) {
       const double sign = distance > 0 ? 1 : -1;
 
@@ -223,7 +223,7 @@ class TwoFreeSpheresMinimumDistanceTest : public TwoFreeSpheresTest {
     // The exponential penalty function -x * e^{1/x} can introduce relatively
     // large numerical error, when the distance is close to minimum_distance (
     // namely when x is close to 0).
-    const double gradient_tol = 3E-12;
+    const double gradient_tol = 6E-12;
     EXPECT_TRUE(CompareMatrices(y_autodiff(0).derivatives(),
                                 penalty_autodiff.derivatives(), gradient_tol));
     // Now evaluate the constraint using autodiff from start.

--- a/multibody/optimization/static_equilibrium_constraint.cc
+++ b/multibody/optimization/static_equilibrium_constraint.cc
@@ -60,7 +60,7 @@ void StaticEquilibriumConstraint::DoEval(
   }
   const auto& query_object =
       query_port.Eval<geometry::QueryObject<AutoDiffXd>>(*context_);
-  const std::vector<geometry::SignedDistancePair<double>>
+  const std::vector<geometry::SignedDistancePair<AutoDiffXd>>
       signed_distance_pairs =
           query_object.ComputeSignedDistancePairwiseClosestPoints();
   const geometry::SceneGraphInspector<AutoDiffXd>& inspector =
@@ -82,12 +82,12 @@ void StaticEquilibriumConstraint::DoEval(
     // and the witness point on geometry Ga is Ca.
     const auto& X_AGa = inspector.X_FG(signed_distance_pair.id_A);
     const auto& p_GaCa = signed_distance_pair.p_ACa;
-    const Vector3<double> p_ACa = X_AGa * p_GaCa;
+    const Vector3<AutoDiffXd> p_ACa = X_AGa.cast<AutoDiffXd>() * p_GaCa;
     // Define Body B's frame as B, the geometry attached to body B has frame Gb,
     // and the witness point on geometry Ga is Cb.
     const auto& X_BGb = inspector.X_FG(signed_distance_pair.id_B);
     const auto& p_GbCb = signed_distance_pair.p_BCb;
-    const Vector3<double> p_BCb = X_BGb * p_GbCb;
+    const Vector3<AutoDiffXd> p_BCb = X_BGb.cast<AutoDiffXd>() * p_GbCb;
     Eigen::Matrix<AutoDiffXd, 6, Eigen::Dynamic> Jv_V_WCa(
         6, plant_->num_velocities());
     Eigen::Matrix<AutoDiffXd, 6, Eigen::Dynamic> Jv_V_WCb(

--- a/multibody/optimization/test/static_equilibrium_constraint_test.cc
+++ b/multibody/optimization/test/static_equilibrium_constraint_test.cc
@@ -66,7 +66,7 @@ class TwoFreeSpheresTest : public ::testing::Test {
     const auto& query_object =
         query_port.Eval<geometry::QueryObject<AutoDiffXd>>(
             spheres_->plant_context());
-    const std::vector<geometry::SignedDistancePair<double>>
+    const std::vector<geometry::SignedDistancePair<AutoDiffXd>>
         signed_distance_pairs =
             query_object.ComputeSignedDistancePairwiseClosestPoints();
     EXPECT_EQ(signed_distance_pairs.size(), 3);
@@ -85,14 +85,12 @@ class TwoFreeSpheresTest : public ::testing::Test {
       Eigen::Matrix<AutoDiffXd, 6, Eigen::Dynamic> Jv_V_WCb(6, 12);
       spheres_->plant().CalcJacobianSpatialVelocity(
           spheres_->plant_context(), JacobianWrtVariable::kV, frameA,
-          signed_distance_pair.p_ACa.cast<AutoDiffXd>(),
-          spheres_->plant().world_frame(), spheres_->plant().world_frame(),
-          &Jv_V_WCa);
+          signed_distance_pair.p_ACa, spheres_->plant().world_frame(),
+          spheres_->plant().world_frame(), &Jv_V_WCa);
       spheres_->plant().CalcJacobianSpatialVelocity(
           spheres_->plant_context(), JacobianWrtVariable::kV, frameB,
-          signed_distance_pair.p_BCb.cast<AutoDiffXd>(),
-          spheres_->plant().world_frame(), spheres_->plant().world_frame(),
-          &Jv_V_WCb);
+          signed_distance_pair.p_BCb, spheres_->plant().world_frame(),
+          spheres_->plant().world_frame(), &Jv_V_WCb);
 
       AutoDiffVecXd F_AB_W(6);
 
@@ -220,15 +218,24 @@ TEST_F(TwoFreeSpheresTest, Eval) {
       Eigen::Vector3d(std::sqrt(4 * spheres_->spheres()[0].radius *
                                 spheres_->spheres()[1].radius),
                       0, spheres_->spheres()[1].radius));
+  q_val.head<4>() << 1, 0, 0, 0;
   q_val.segment<3>(4) = X_WS0.translation();
+  q_val.segment<4>(7) << 1, 0, 0, 0;
   q_val.tail<3>() = X_WS1.translation();
 
-  prog_.AddBoundingBoxConstraint(q_val, q_val, q_vars_);
   prog_.AddConstraint(static_equilibrium_binding);
 
   Eigen::VectorXd x_init(prog_.num_vars());
   x_init.setZero();
   prog_.SetDecisionVariableValueInVector(q_vars_, q_val, &x_init);
+  prog_.SetDecisionVariableValueInVector(
+      contact_wrench_evaluators_and_lambda_[1].second,
+      Eigen::Vector3d(0, 0, -spheres_->spheres()[0].inertia.get_mass() * 9.81),
+      &x_init);
+  prog_.SetDecisionVariableValueInVector(
+      contact_wrench_evaluators_and_lambda_[2].second,
+      Eigen::Vector3d(0, 0, -spheres_->spheres()[1].inertia.get_mass() * 9.81),
+      &x_init);
 
   auto result = solvers::Solve(prog_, x_init);
   EXPECT_TRUE(result.is_success());


### PR DESCRIPTION
This makes the QueryObject::ComputeSignedDistancePairwiseClosestPoints() method autodiffable (to a limited degree). For double scalar, it supports most primitives (except halfspace for historical reasons). However, AutoDiff has more limited support. This feature is now supported and documented.

To achieve this:

- Code got pulled out of proximity_engine.cc and into distance_to_shape.h and collision_filter_legacy.h.
- The pulled code got modified/augmented to support AutoDiff.
- ProximityEngine interface got augmented (similarly to the distance_to_point.h.
- The extracted code can now be unit tested; those tests have been provided.
- The core functionality has been exposed all the way through QueryObject.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11379)
<!-- Reviewable:end -->
