### PR TITLE
Fix ASan problems in pose_aggregator_test.cc and normalize_vector.h

### DIFF
--- a/math/normalize_vector.h
+++ b/math/normalize_vector.h
@@ -40,10 +40,10 @@ void NormalizeVector(
 
     if (ddx_norm) {
       auto dx_norm_transpose = transposeGrad(*dx_norm, x.rows());
-      auto ddx_norm_times_norm = -matGradMultMat(
+      auto minus_ddx_norm_times_norm = matGradMultMat(
           x_norm, x_norm.transpose(), (*dx_norm), dx_norm_transpose);
       auto dnorm_inv = -x.transpose() / (xdotx * norm_x);
-      (*ddx_norm) = ddx_norm_times_norm / norm_x;
+      (*ddx_norm) = -minus_ddx_norm_times_norm / norm_x;
       auto temp = (*dx_norm) * norm_x;
       typename Derived::Index n = x.rows();
       for (int col = 0; col < n; col++) {

--- a/systems/rendering/test/pose_aggregator_test.cc
+++ b/systems/rendering/test/pose_aggregator_test.cc
@@ -208,9 +208,10 @@ TEST_F(PoseAggregatorTest, AddSinglePoseAndVelocityPorts) {
 // Tests that PoseBundle supports Symbolic form.
 GTEST_TEST(PoseBundleTest, Symbolic) {
   PoseBundle<symbolic::Expression> dut{1};
-
+  multibody::SpatialVelocity<symbolic::Expression> msv =
+    dut.get_velocity(0).get_velocity();
   // Just sanity check that some element got zero-initialized.
-  const symbolic::Expression& x = dut.get_velocity(0).get_velocity()[0];
+  const symbolic::Expression& x = msv[0];
   EXPECT_TRUE(x.EqualTo(0.0));
 }
 


### PR DESCRIPTION
To reproduce: 

- `bazel test --config=asan --copt -O0 //systems/rendering:pose_aggregator_test`
   [Error](https://gist.github.com/m-chaturvedi/abd860710c7f5a4671dd986c10e9dbd6)

- `bazel test --config=asan --copt -O0  //math:normalize_vector_test`
   [Error with line numbers (via @jamiesnape) ](https://gist.github.com/m-chaturvedi/76eb5d2fa09233c75bd885d2e759a4da)
   [Reference](https://eigen.tuxfamily.org/dox/TopicPitfalls.html)

Closes #11391

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11395)
<!-- Reviewable:end -->