### PR TITLE
Fix ASan issue in normalize_vector.h

### DIFF
--- a/math/normalize_vector.h
+++ b/math/normalize_vector.h
@@ -40,10 +40,10 @@ void NormalizeVector(
 
     if (ddx_norm) {
       auto dx_norm_transpose = transposeGrad(*dx_norm, x.rows());
-      auto ddx_norm_times_norm = -matGradMultMat(
+      auto ddx_norm_times_norm = matGradMultMat(
           x_norm, x_norm.transpose(), (*dx_norm), dx_norm_transpose);
       auto dnorm_inv = -x.transpose() / (xdotx * norm_x);
-      (*ddx_norm) = ddx_norm_times_norm / norm_x;
+      (*ddx_norm) = -ddx_norm_times_norm / norm_x;
       auto temp = (*dx_norm) * norm_x;
       typename Derived::Index n = x.rows();
       for (int col = 0; col < n; col++) {


### PR DESCRIPTION
`bazel test --config=asan --copt -O0  //math:normalize_vector_test`

[Error with line numbers (via @jamiesnape) ](https://gist.github.com/m-chaturvedi/76eb5d2fa09233c75bd885d2e759a4da)
[Reference](https://eigen.tuxfamily.org/dox/TopicPitfalls.html)

Towards #11391

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11396)
<!-- Reviewable:end -->
