### PR TITLE
simulator doxygen: Centralize nuanced semantics of CalcNextUpdateTime

### DIFF
--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -417,19 +417,15 @@ class LeafSystem : public System<T> {
     event->AddToComposite(events);
   }
 
-  /// Computes the next update time based on the configured periodic events, for
-  /// scalar types that are arithmetic, or aborts for scalar types that are not
-  /// arithmetic. Subclasses that require aperiodic events should override, but
-  /// be sure to invoke the parent class implementation at the start of the
-  /// override if you want periodic events to continue to be handled.
+  /// Computes the next update time based on the configured timed events as
+  /// detailed in @ref ComputingUpdateTimes. Subclasses that require aperiodic
+  /// events should override, but be sure to invoke the parent class
+  /// implementation at the start of the override if you want periodic events
+  /// to continue to be handled.
   ///
+  /// @pre T is arithemtic. Aborts at runtime otherwise.
   /// @post `time` is set to a value greater than or equal to
   ///       `context.get_time()` on return.
-  /// @warning If you override this method, think carefully before setting
-  ///          `time` to `context.get_time()` on return, which can inadvertently
-  ///          cause simulations of systems derived from %LeafSystem to loop
-  ///          interminably. Such a loop will occur if, for example, the
-  ///          event(s) does not modify the state.
   void DoCalcNextUpdateTime(const Context<T>& context,
                             CompositeEventCollection<T>* events,
                             T* time) const override {

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -809,7 +809,8 @@ class System : public SystemBase {
   }
 
   /// This method is called by a Simulator during its calculation of the size of
-  /// the next continuous step to attempt. The System returns the next time at
+  /// the next continuous step to attempt, as detailed in @ref
+  /// ComputingUpdateTimes. The System returns the next time at
   /// which some discrete action must be taken, and records what those actions
   /// ought to be in @p events. Upon reaching that time, the simulator will
   /// merge @p events with the other CompositeEventCollection instances


### PR DESCRIPTION
Per discussions with @pangtao22 on [Slack](https://drakedevelopers.slack.com/archives/C2CHRT98E/p1556481975055900) and discussion f2f, here's an initial suggested doc update to consolidate the CalcNextUpdateTime semantics.

For now, I've placed the consolidation in `simulator.h` as the overarching discussion in its class documentation seemed uber relevant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11402)
<!-- Reviewable:end -->
