### PR TITLE
NLopt/IPOPT/SNOPT all handle cost/constraint with zero-size gradient.

### DIFF
--- a/solvers/ipopt_solver.cc
+++ b/solvers/ipopt_solver.cc
@@ -123,8 +123,14 @@ size_t EvaluateConstraint(const MathematicalProgram& prog,
   size_t grad_idx = 0;
 
   for (int i = 0; i < c.num_constraints(); i++) {
-    for (int j = 0; j < variables.rows(); j++) {
-      grad[grad_idx++] = ty(i).derivatives()(j);
+    if (ty(i).derivatives().size() > 0) {
+      for (int j = 0; j < variables.rows(); j++) {
+        grad[grad_idx++] = ty(i).derivatives()(j);
+      }
+    } else {
+      for (int j = 0; j < variables.rows(); j++) {
+        grad[grad_idx++] = 0;
+      }
     }
   }
 
@@ -466,10 +472,12 @@ class IpoptSolver_NLP : public Ipopt::TNLP {
 
       cost_cache_->result[0] += ty(0).value();
 
-      for (int j = 0; j < num_v_variables; ++j) {
-        const size_t vj_index =
-            problem_->FindDecisionVariableIndex(binding.variables()(j));
-        cost_cache_->grad[vj_index] += ty(0).derivatives()(j);
+      if (ty(0).derivatives().size() > 0) {
+        for (int j = 0; j < num_v_variables; ++j) {
+          const size_t vj_index =
+              problem_->FindDecisionVariableIndex(binding.variables()(j));
+          cost_cache_->grad[vj_index] += ty(0).derivatives()(j);
+        }
       }
     }
   }

--- a/solvers/ipopt_solver.cc
+++ b/solvers/ipopt_solver.cc
@@ -122,7 +122,8 @@ size_t EvaluateConstraint(const MathematicalProgram& prog,
   // gradient array.
   size_t grad_idx = 0;
 
-  for (int i = 0; i < c.num_constraints(); i++) {
+  DRAKE_ASSERT(ty.rows() == c.num_constraints());
+  for (int i = 0; i < ty.rows(); i++) {
     if (ty(i).derivatives().size() > 0) {
       for (int j = 0; j < variables.rows(); j++) {
         grad[grad_idx++] = ty(i).derivatives()(j);
@@ -479,6 +480,8 @@ class IpoptSolver_NLP : public Ipopt::TNLP {
           cost_cache_->grad[vj_index] += ty(0).derivatives()(j);
         }
       }
+      // We do not need to add code for ty(0).derivatives().size() == 0, since
+      // cost_cache_->grad would be unchanged if the derivative has zero size.
     }
   }
 

--- a/solvers/nlopt_solver.cc
+++ b/solvers/nlopt_solver.cc
@@ -79,10 +79,12 @@ double EvaluateCosts(const std::vector<double>& x, std::vector<double>& grad,
 
     cost += ty(0).value();
     if (!grad.empty()) {
-      for (int j = 0; j < num_vars; ++j) {
-        size_t vj_index =
-            prog->FindDecisionVariableIndex(binding.variables()(j));
-        grad[vj_index] += ty(0).derivatives()(vj_index);
+      if (ty(0).derivatives().size() > 0) {
+        for (int j = 0; j < num_vars; ++j) {
+          const size_t vj_index =
+              prog->FindDecisionVariableIndex(binding.variables()(j));
+          grad[vj_index] += ty(0).derivatives()(vj_index);
+        }
       }
     }
   }
@@ -224,9 +226,11 @@ void EvaluateVectorConstraint(unsigned m, double* result, unsigned n,
         grad_sign = -1;
       }
       DRAKE_ASSERT(wrapped->vars->cols() == 1);
-      for (int j = 0; j < wrapped->vars->rows(); ++j) {
-        grad[(result_idx * n) + v_index[j]] =
-            ty(i).derivatives()(v_index[j]) * grad_sign;
+      if (ty(i).derivatives().size() > 0) {
+        for (int j = 0; j < wrapped->vars->rows(); ++j) {
+          grad[(result_idx * n) + v_index[j]] =
+              ty(i).derivatives()(v_index[j]) * grad_sign;
+        }
       }
       result_idx++;
       DRAKE_ASSERT(result_idx <= m);

--- a/solvers/snopt_solver_f2c.cc
+++ b/solvers/snopt_solver_f2c.cc
@@ -318,14 +318,22 @@ void EvaluateNonlinearConstraints(
     if (gradient_sparsity_pattern.has_value()) {
       for (const auto& nonzero_entry : gradient_sparsity_pattern.value()) {
         G[(*grad_index)++] = static_cast<snopt::doublereal>(
-            ty(nonzero_entry.first).derivatives()(nonzero_entry.second));
+            ty(nonzero_entry.first).derivatives().size() > 0
+                ? ty(nonzero_entry.first).derivatives()(nonzero_entry.second)
+                : 0.0);
       }
     } else {
       for (snopt::integer i = 0;
            i < static_cast<snopt::integer>(num_constraints); i++) {
-        for (int j = 0; j < num_v_variables; ++j) {
-          G[(*grad_index)++] =
-              static_cast<snopt::doublereal>(ty(i).derivatives()(j));
+        if (ty(i).derivatives().size() > 0) {
+          for (int j = 0; j < num_v_variables; ++j) {
+            G[(*grad_index)++] =
+                static_cast<snopt::doublereal>(ty(i).derivatives()(j));
+          }
+        } else {
+          for (int j = 0; j < num_v_variables; ++j) {
+            G[(*grad_index)++] = static_cast<snopt::doublereal>(0.0);
+          }
         }
       }
     }
@@ -371,10 +379,13 @@ void EvaluateAllCosts(const MathematicalProgram& prog,
 
     F[0] += static_cast<snopt::doublereal>(ty(0).value());
 
-    for (int j = 0; j < num_v_variables; ++j) {
-      size_t vj_index = prog.FindDecisionVariableIndex(binding.variables()(j));
-      cost_gradient[vj_index] +=
-          static_cast<snopt::doublereal>(ty(0).derivatives()(j));
+    if (ty(0).derivatives().size() > 0) {
+      for (int j = 0; j < num_v_variables; ++j) {
+        size_t vj_index =
+            prog.FindDecisionVariableIndex(binding.variables()(j));
+        cost_gradient[vj_index] +=
+            static_cast<snopt::doublereal>(ty(0).derivatives()(j));
+      }
     }
   }
   for (const auto cost_gradient_index : cost_gradient_indices) {

--- a/solvers/snopt_solver_f2c.cc
+++ b/solvers/snopt_solver_f2c.cc
@@ -332,7 +332,7 @@ void EvaluateNonlinearConstraints(
           }
         } else {
           for (int j = 0; j < num_v_variables; ++j) {
-            G[(*grad_index)++] = static_cast<snopt::doublereal>(0.0);
+            G[(*grad_index)++] = snopt::doublereal(0.0);
           }
         }
       }

--- a/solvers/test/nonlinear_program_test.cc
+++ b/solvers/test/nonlinear_program_test.cc
@@ -485,6 +485,15 @@ GTEST_TEST(testNonlinearProgram, HeatExchangerDesignProblem) {
                       &result);
 }
 
+GTEST_TEST(testNonlinearProgram, EmptyGradientProblem) {
+  EmptyGradientProblem prob;
+  MathematicalProgramResult result;
+  Eigen::VectorXd x_init = Eigen::Vector2d(0, 0);
+  RunNonlinearProgram(prob.prog(), x_init,
+                      [&prob, &result]() { prob.CheckSolution(result); },
+                      &result);
+}
+
 GTEST_TEST(testNonlinearProgram, CallbackTest) {
   MathematicalProgram prog;
   const auto x = prog.NewContinuousVariables<3>();

--- a/solvers/test/optimization_examples.cc
+++ b/solvers/test/optimization_examples.cc
@@ -769,6 +769,22 @@ void HeatExchangerDesignProblem::CheckSolution(
   EXPECT_TRUE(CompareMatrices(x_val, x_expected, tol));
   EXPECT_NEAR(result.get_optimal_cost(), 7049.330923, tol);
 }
+
+EmptyGradientProblem::EmptyGradientProblem()
+    : prog_{new MathematicalProgram()}, x_{prog_->NewContinuousVariables<2>()} {
+  prog_->AddCost(std::make_shared<EmptyGradientProblem::EmptyGradientCost>(),
+                 x_);
+  prog_->AddConstraint(
+      std::make_shared<EmptyGradientProblem::EmptyGradientConstraint>(), x_);
+}
+
+void EmptyGradientProblem::CheckSolution(
+    const MathematicalProgramResult& result) const {
+  EXPECT_TRUE(result.is_success());
+}
+
+EmptyGradientProblem::EmptyGradientConstraint::EmptyGradientConstraint()
+    : Constraint(1, 2, Vector1d(-kInf), Vector1d(0)) {}
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/optimization_examples.h
+++ b/solvers/test/optimization_examples.h
@@ -846,17 +846,20 @@ class HeatExchangerDesignProblem {
   Eigen::Matrix<symbolic::Variable, 8, 1> x_;
 };
 
-/// In Eigen's autodiff, when the derivatives() has empty size, it is
+/// In Eigen's autodiff, when the derivatives() vector has empty size, it is
 /// interpreted as 0 gradient (i.e., the gradient has value 0, with the size of
 /// the gradient matrix being arbitrary). On the other hand, many solvers
 /// interpret empty size gradient in a different way, that the variable to be
 /// taken derivative with has 0 size. This test guarantees that when Eigen
 /// autodiff returns an empty size gradient, we can manually set the gradient
-/// size to be the right size. A trivial problem
+/// size to be the right size. This class represents the following trivial
+/// problem
+/// <pre>
 /// min f(x)
 /// s.t g(x) <= 0
+/// </pre>
 /// where f(x) = 1 and g(x) = 0. x.rows() == 2.
-/// When evaluating f(x) and g(x), autodiff returns empty gradient. But the
+/// When evaluating f(x) and g(x), autodiff returns an empty gradient. But the
 /// solvers expect to see gradient ∂f/∂x = [0 0] and ∂g/∂x = [0 0], namely
 /// matrices of size 1 x 2, not empty size matrix. This test shows that we can
 /// automatically set the gradient to the right size, although Eigen's autodiff

--- a/solvers/test/optimization_examples.h
+++ b/solvers/test/optimization_examples.h
@@ -846,17 +846,21 @@ class HeatExchangerDesignProblem {
   Eigen::Matrix<symbolic::Variable, 8, 1> x_;
 };
 
-/**
- * In Eigen's autodiff, when the derivative has empty size, it is interpreted
- * as 0 gradient (i.e., the gradient has value 0, with the size of the gradient
- * matrix being arbitrary). Many solvers interpret empty size gradient in a
- * different way, that the variable to be taken derivative with has 0 size. This
- * test guarantees that when Eigen autodiff returns an empty size gradient, we
- * can manually set the gradient size to be the right size.
- * A trivial problem
- * min 1
- * s.t 0 <= 0
- */
+/// In Eigen's autodiff, when the derivatives() has empty size, it is
+/// interpreted as 0 gradient (i.e., the gradient has value 0, with the size of
+/// the gradient matrix being arbitrary). On the other hand, many solvers
+/// interpret empty size gradient in a different way, that the variable to be
+/// taken derivative with has 0 size. This test guarantees that when Eigen
+/// autodiff returns an empty size gradient, we can manually set the gradient
+/// size to be the right size. A trivial problem
+/// min f(x)
+/// s.t g(x) <= 0
+/// where f(x) = 1 and g(x) = 0. x.rows() == 2.
+/// When evaluating f(x) and g(x), autodiff returns empty gradient. But the
+/// solvers expect to see gradient ∂f/∂x = [0 0] and ∂g/∂x = [0 0], namely
+/// matrices of size 1 x 2, not empty size matrix. This test shows that we can
+/// automatically set the gradient to the right size, although Eigen's autodiff
+/// returns an empty size gradient.
 class EmptyGradientProblem {
  public:
   EmptyGradientProblem();


### PR DESCRIPTION
I realized that we don't handle this problem, when working with Sean on autodiff scene graph, that Eigen's AutoDiffXd regards empty `derivatives()` as gradient with value `0`. This would cause our code to segfault, since in `nlopt/ipopt/snopt_solver.cc`, we always assume that `math::autoDiffToGradientMatrix` returns the gradient matrix with the same number of columns as the number of decision variables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11411)
<!-- Reviewable:end -->
