### PR TITLE
Remove deprecated brew tap-pin from install_prereqs.sh

### DIFF
--- a/setup/mac/source_distribution/install_prereqs.sh
+++ b/setup/mac/source_distribution/install_prereqs.sh
@@ -14,7 +14,6 @@ fi
 
 /usr/local/bin/brew update
 /usr/local/bin/brew bundle --file="${BASH_SOURCE%/*}/Brewfile"
-/usr/local/bin/brew tap-pin bazelbuild/tap
 
 /usr/local/bin/pip2 install --upgrade --requirement "${BASH_SOURCE%/*}/requirements.txt"
 /usr/local/bin/pip3 install --upgrade --requirement "${BASH_SOURCE%/*}/requirements.txt"


### PR DESCRIPTION
Relates https://github.com/Homebrew/brew/pull/5925. We already use the fully-qualified name for `bazelbuild/tap/bazel` https://github.com/RobotLocomotion/drake/blob/47adc392bc86353d49110ac06076b487b4811de5/setup/mac/source_distribution/Brewfile#L9 so the pin was not really necessary anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11417)
<!-- Reviewable:end -->
