### PR TITLE
Cloning a context detects violations of DoCloneWithoutPointers law

### DIFF
--- a/systems/framework/context_base.cc
+++ b/systems/framework/context_base.cc
@@ -10,19 +10,14 @@ namespace systems {
 
 std::unique_ptr<ContextBase> ContextBase::Clone() const {
   std::unique_ptr<ContextBase> clone_ptr(CloneWithoutPointers(*this));
-
-  // Verify that the most-derived Context didn't forget to override
-  // DoCloneWithoutPointers().
-  const ContextBase& source = *this;  // Deref here to avoid typeid warning.
   ContextBase& clone = *clone_ptr;
-  DRAKE_DEMAND(typeid(source) == typeid(clone));
 
   // Create a complete mapping of tracker pointers.
   DependencyTracker::PointerMap tracker_map;
   BuildTrackerPointerMap(*this, clone, &tracker_map);
 
   // Then do a pointer fixup pass.
-  FixContextPointers(source, tracker_map, &clone);
+  FixContextPointers(*this, tracker_map, &clone);
   return clone_ptr;
 }
 

--- a/systems/framework/context_base.h
+++ b/systems/framework/context_base.h
@@ -465,7 +465,14 @@ class ContextBase : public internal::ContextMessageInterface {
   // protected function on its children.
   static std::unique_ptr<ContextBase> CloneWithoutPointers(
       const ContextBase& source) {
-    return source.DoCloneWithoutPointers();
+    std::unique_ptr<ContextBase> result = source.DoCloneWithoutPointers();
+
+    // Verify that the most-derived Context didn't forget to override
+    // DoCloneWithoutPointers().
+    ContextBase& clone = *result;
+    DRAKE_THROW_UNLESS(typeid(source) == typeid(clone));
+
+    return result;
   }
 
   /** (Internal use only) Given a new context `clone` containing an
@@ -541,7 +548,7 @@ class ContextBase : public internal::ContextMessageInterface {
   up base class pointers. To do that, implement a protected copy constructor
   that inherits from the base class copy constructor (which doesn't repair the
   pointers), then implement DoCloneWithoutPointers() as
-  `return unique_ptr<ContextBase>(new DerivedType(*this));`. */
+  `return std::unique_ptr<ContextBase>(new DerivedType(*this));`. */
   virtual std::unique_ptr<ContextBase> DoCloneWithoutPointers() const = 0;
 
   /** DiagramContext must implement this to invoke BuildTrackerPointerMap() on

--- a/systems/framework/test/leaf_context_test.cc
+++ b/systems/framework/test/leaf_context_test.cc
@@ -554,6 +554,19 @@ TEST_F(LeafContextTest, Clone) {
   EXPECT_EQ(1.0, context_.get_numeric_parameter(0)[0]);
 }
 
+// Violates the Context `DoCloneWithoutPointers` law.
+class InvalidContext : public LeafContext<double> {
+ public:
+  InvalidContext() : LeafContext<double>() {}
+};
+
+TEST_F(LeafContextTest, BadClone) {
+  InvalidContext bad_context;
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      bad_context.Clone(), std::runtime_error,
+      ".*typeid.source. == typeid.clone.*");
+}
+
 // Tests that a LeafContext can provide a clone of its State.
 TEST_F(LeafContextTest, CloneState) {
   std::unique_ptr<State<double>> clone = context_.CloneState();


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11419)
<!-- Reviewable:end -->
