### PR TITLE
Revert "add missing bindings for State<T> abstract values. "

### DIFF
--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -100,11 +100,10 @@ void DefineFrameworkPySemantics(py::module m) {
       .def(py::init<>(), doc.AbstractValues.ctor.doc_0args)
       .def(py::init<AbstractValuePtrList>(), doc.AbstractValues.ctor.doc_1args)
       .def("size", &AbstractValues::size, doc.AbstractValues.size.doc)
-      .def("get_value", &AbstractValues::get_value, py::arg("index"),
-          py_reference_internal, doc.AbstractValues.get_value.doc)
+      .def("get_value", &AbstractValues::get_value, py_reference_internal,
+          doc.AbstractValues.get_value.doc)
       .def("get_mutable_value", &AbstractValues::get_mutable_value,
-          py::arg("index"), py_reference_internal,
-          doc.AbstractValues.get_mutable_value.doc)
+          py_reference_internal, doc.AbstractValues.get_mutable_value.doc)
       .def("CopyFrom",
           [](AbstractValues* self, const AbstractValues& other) {
             WarnDeprecated(
@@ -310,8 +309,7 @@ void DefineFrameworkPySemantics(py::module m) {
             [](const Context<T>* self, int index) -> auto& {
               return self->get_abstract_state().get_value(index);
             },
-            py::arg("index"), py_reference_internal,
-            doc.Context.get_abstract_state.doc_1args)
+            py_reference_internal, doc.Context.get_abstract_state.doc_1args)
         .def("get_mutable_abstract_state",
             [](Context<T>* self) -> AbstractValues& {
               return self->get_mutable_abstract_state();
@@ -323,7 +321,7 @@ void DefineFrameworkPySemantics(py::module m) {
               return self->get_mutable_abstract_state().get_mutable_value(
                   index);
             },
-            py::arg("index"), py_reference_internal,
+            py_reference_internal,
             doc.Context.get_mutable_abstract_state.doc_1args)
         .def("SetAbstractState",
             [](py::object self, int index, py::object value) {
@@ -636,39 +634,7 @@ void DefineFrameworkPySemantics(py::module m) {
         .def("get_mutable_discrete_state",
             overload_cast_explicit<DiscreteValues<T>&>(
                 &State<T>::get_mutable_discrete_state),
-            py_reference_internal, doc.State.get_mutable_discrete_state.doc)
-        .def("get_discrete_state",
-            overload_cast_explicit<const BasicVector<T>&, int>(
-                &State<T>::get_discrete_state),
-            py::arg("index"), py_reference_internal,
-            doc.State.get_discrete_state.doc)
-        .def("get_mutable_discrete_state",
-            overload_cast_explicit<BasicVector<T>&, int>(
-                &State<T>::get_mutable_discrete_state),
-            py::arg("index"), py_reference_internal,
-            doc.State.get_mutable_discrete_state.doc)
-        .def("get_abstract_state",
-            static_cast<const AbstractValues& (State<T>::*)() const>(
-                &State<T>::get_abstract_state),
-            py_reference_internal, doc.State.get_abstract_state.doc)
-        .def("get_mutable_abstract_state",
-            [](State<T>* self) -> AbstractValues& {
-              return self->get_mutable_abstract_state();
-            },
-            py_reference_internal, doc.State.get_mutable_abstract_state.doc)
-        .def("get_abstract_state",
-            [](const State<T>* self, int index) -> auto& {
-              return self->get_abstract_state().get_value(index);
-            },
-            py::arg("index"), py_reference_internal,
-            doc.State.get_abstract_state.doc)
-        .def("get_mutable_abstract_state",
-            [](State<T>* self, int index) -> AbstractValue& {
-              return self->get_mutable_abstract_state().get_mutable_value(
-                  index);
-            },
-            py::arg("index"), py_reference_internal,
-            doc.State.get_mutable_abstract_state.doc);
+            py_reference_internal, doc.State.get_mutable_discrete_state.doc);
 
     // - Constituents.
     DefineTemplateClassWithDefault<ContinuousState<T>>(

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -164,28 +164,12 @@ class TestGeneral(unittest.TestCase):
         np.testing.assert_equal(
             context.get_discrete_state_vector().CopyToVector(), 3 * x)
 
-        def check_abstract_value_zero(context, expected_value):
-            # Check through Context, State, and AbstractValues APIs.
-            self.assertEqual(context.get_abstract_state(index=0).get_value(),
-                             expected_value)
-            self.assertEqual(context.get_abstract_state().get_value(
-                index=0).get_value(), expected_value)
-            self.assertEqual(context.get_state().get_abstract_state(
-                index=0).get_value(), expected_value)
-            self.assertEqual(context.get_state().get_abstract_state()
-                             .get_value(index=0).get_value(), expected_value)
-
         context.SetAbstractState(index=0, value=True)
-        check_abstract_value_zero(context, True)
+        value = context.get_abstract_state(0)
+        self.assertTrue(value.get_value())
         context.SetAbstractState(index=0, value=False)
-        check_abstract_value_zero(context, False)
-        value = context.get_mutable_state().get_mutable_abstract_state(index=0)
-        value.set_value(True)
-        check_abstract_value_zero(context, True)
-        value = context.get_mutable_state().get_mutable_abstract_state()\
-            .get_mutable_value(index=0)
-        value.set_value(False)
-        check_abstract_value_zero(context, False)
+        value = context.get_abstract_state(0)
+        self.assertFalse(value.get_value())
 
     def test_event_api(self):
         # TriggerType - existence check.


### PR DESCRIPTION
Dear Russ,

The on-call build cop, $BUILD_COP, believes that your PR #11416 may have
broken one or more of Drake's continuous integration builds [1]. It is
possible to break a build even if your PR passed continuous integration
pre-merge because additional platforms are tested post-merge.

The specific build failures under investigation are:
https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-xenial-gcc-bazel-continuous-debug/901/

Therefore, the build cop has created this revert PR and started a complete
post-merge build to determine whether your PR was in fact the cause of the
problem. If that build passes, this revert PR will be merged 60 minutes from
now. You can then fix the problem at your leisure, and send a new PR to
reinstate your change.

If you believe your original PR did not actually break the build, please
explain on this thread.

If you believe you can fix the break promptly in lieu of a revert, please
explain on this thread, and send a PR to the build cop for review ASAP.

If you believe your original PR definitely did break the build and should be
reverted, please review and LGTM this PR. This allows the build cop to merge
without waiting for CI results.

For advice on how to handle a build cop revert, see [2].

Thanks!
Your Friendly On-call Build Cop

[1] CI Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Production/
[2] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11420)
<!-- Reviewable:end -->
