### PR TITLE
pydrake: Revert some bindings of State abstract values

### DIFF
--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -655,20 +655,7 @@ void DefineFrameworkPySemantics(py::module m) {
             [](State<T>* self) -> AbstractValues& {
               return self->get_mutable_abstract_state();
             },
-            py_reference_internal, doc.State.get_mutable_abstract_state.doc)
-        .def("get_abstract_state",
-            [](const State<T>* self, int index) -> auto& {
-              return self->get_abstract_state().get_value(index);
-            },
-            py::arg("index"), py_reference_internal,
-            doc.State.get_abstract_state.doc)
-        .def("get_mutable_abstract_state",
-            [](State<T>* self, int index) -> AbstractValue& {
-              return self->get_mutable_abstract_state().get_mutable_value(
-                  index);
-            },
-            py::arg("index"), py_reference_internal,
-            doc.State.get_mutable_abstract_state.doc);
+            py_reference_internal, doc.State.get_mutable_abstract_state.doc);
 
     // - Constituents.
     DefineTemplateClassWithDefault<ContinuousState<T>>(

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -170,8 +170,6 @@ class TestGeneral(unittest.TestCase):
                              expected_value)
             self.assertEqual(context.get_abstract_state().get_value(
                 index=0).get_value(), expected_value)
-            self.assertEqual(context.get_state().get_abstract_state(
-                index=0).get_value(), expected_value)
             self.assertEqual(context.get_state().get_abstract_state()
                              .get_value(index=0).get_value(), expected_value)
 
@@ -179,13 +177,10 @@ class TestGeneral(unittest.TestCase):
         check_abstract_value_zero(context, True)
         context.SetAbstractState(index=0, value=False)
         check_abstract_value_zero(context, False)
-        value = context.get_mutable_state().get_mutable_abstract_state(index=0)
-        value.set_value(True)
-        check_abstract_value_zero(context, True)
         value = context.get_mutable_state().get_mutable_abstract_state()\
             .get_mutable_value(index=0)
-        value.set_value(False)
-        check_abstract_value_zero(context, False)
+        value.set_value(True)
+        check_abstract_value_zero(context, True)
 
     def test_event_api(self):
         # TriggerType - existence check.


### PR DESCRIPTION
Under Xenial GCC 5.4 + Python 2 + `--compilation_mode=dbg` only, the `//bindings/pydrake/systems:py/custom_test` has about 75% failure rate when `pydrake.systems.State` has more than 8 methods bound.

We'll need to root cause this further, but for now this repairs CI, while stopping short of a full revert.

This reverts a portion of cabd2abd187ceae593510b93fade1ba8bb8ea654 from #11416.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11421)
<!-- Reviewable:end -->
