### PR TITLE
solvers: Improve test latency via shards

### DIFF
--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -1242,6 +1242,8 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "non_convex_optimization_util_test",
+    # This test is quite long, so split it into 4 processes for better latency.
+    shard_count = 4,
     tags = mosek_test_tags(),
     deps = [
         ":decision_variable",
@@ -1266,6 +1268,8 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "mixed_integer_rotation_constraint_test",
     timeout = "long",
+    # This test is quite long, so split it into 4 processes for better latency.
+    shard_count = 4,
     tags = gurobi_test_tags() + mosek_test_tags() + [
         # Excluding asan because it is unreasonably slow (> 30 minutes).
         "no_asan",
@@ -1290,6 +1294,8 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "mixed_integer_rotation_constraint_corner_test",
     timeout = "long",
+    # This test is quite long, so split it into 4 processes for better latency.
+    shard_count = 4,
     tags = gurobi_test_tags() + mosek_test_tags() + [
         # Excluding asan because it is unreasonably slow (> 30 minutes).
         "no_asan",
@@ -1310,6 +1316,8 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "rotation_constraint_test",
     timeout = "long",
+    # This test is quite long, so split it into 4 processes for better latency.
+    shard_count = 4,
     tags = gurobi_test_tags() + mosek_test_tags() + [
         # Excluding asan because it is unreasonably slow (> 30 minutes).
         "no_asan",

--- a/solvers/test/rotation_constraint_test.cc
+++ b/solvers/test/rotation_constraint_test.cc
@@ -8,7 +8,6 @@
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/math/random_rotation.h"
 #include "drake/math/rotation_matrix.h"
-#include "drake/solvers/gurobi_solver.h"
 #include "drake/solvers/mathematical_program.h"
 #include "drake/solvers/mosek_solver.h"
 #include "drake/solvers/solve.h"
@@ -43,8 +42,16 @@ void AddObjective(MathematicalProgram* prog,
 // evaluates a mesh of points within those limits.  This test confirms that
 // of the rotation matrices generated from rotations with those limits are
 // still feasible after the RPY limits constraints have been applied.
-GTEST_TEST(RotationTest, TestRPYLimits) {
-  for (int limits = (1 << 1); limits < (1 << 7); limits += 2) {
+class TestRpyLimitsFixture : public ::testing::TestWithParam<int> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(TestRpyLimitsFixture)
+  TestRpyLimitsFixture() = default;
+};
+
+TEST_P(TestRpyLimitsFixture, TestRpyLimits) {
+  const int limits = GetParam();
+  // Add brace scope to avoid reflowing all of this code.
+  {
     MathematicalProgram prog;
     auto Rvar = NewRotationMatrixVars(&prog);
     AddBoundingBoxConstraintsImpliedByRollPitchYawLimits(
@@ -88,6 +95,10 @@ GTEST_TEST(RotationTest, TestRPYLimits) {
     }
   }
 }
+
+INSTANTIATE_TEST_CASE_P(
+    RotationTest, TestRpyLimitsFixture,
+    ::testing::Range(1 << 1, 1 << 7, 2));
 
 // Sets up and solves an optimization:
 // <pre>


### PR DESCRIPTION
Anecdotally, the `-everything` pre-merge build often stalls its pipeline waiting for multi-minute-latency test processes to finish.  By parallelizing those tests, we can probably shave a minute or two off the build time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11428)
<!-- Reviewable:end -->
