### PR TITLE
Adding threshold to pairwise signed distance

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -90,6 +90,7 @@ PYBIND11_MODULE(geometry, m) {
           doc.QueryObject.inspector.doc)
       .def("ComputeSignedDistancePairwiseClosestPoints",
           &QueryObject<T>::ComputeSignedDistancePairwiseClosestPoints,
+          py::arg("max_distance") = std::numeric_limits<double>::infinity(),
           doc.QueryObject.ComputeSignedDistancePairwiseClosestPoints.doc)
       .def("ComputePointPairPenetration",
           &QueryObject<T>::ComputePointPairPenetration,

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -425,30 +425,20 @@ class GeometryState {
   //---------------------------------------------------------------------------
   /** @name                Signed Distance Queries
 
-  Refer to @ref signed_distance_query "Signed Distance Queries" for more details.
-  */
+   Refer to @ref signed_distance_query "Signed Distance Queries" for more
+   details.  */
 
   //@{
 
-  /**
-   * Computes the signed distance together with the witness points across all
-   * pairs of geometries in the world. Reports both the separating geometries
-   * and penetrating geometries.
-   * @retval witness_pairs A vector of reporting the signed distance
-   * characterized as witness point pairs. Notice that this is an O(N²)
-   * operation, where N is the number of geometries in the world. We report the
-   * distance between dynamic objects, or between a dynamic object and an
-   * anchored object. We DO NOT report the distance between two anchored
-   * objects.
-   */
+  /** Supporting function for
+   QueryObject::ComputeSignedDistancePairwiseClosestPoints().  */
   std::vector<SignedDistancePair<T>>
-  ComputeSignedDistancePairwiseClosestPoints() const {
+  ComputeSignedDistancePairwiseClosestPoints(const double max_distance) const {
     return geometry_engine_->ComputeSignedDistancePairwiseClosestPoints(
-        geometry_index_to_id_map_, X_WG_);
+        geometry_index_to_id_map_, X_WG_, max_distance);
   }
 
-  /** Performs work in support of QueryObject::ComputeSignedDistanceToPoint().
-   */
+  /** Supporting function for QueryObject::ComputeSignedDistanceToPoint().  */
   std::vector<SignedDistanceToPoint<T>>
   ComputeSignedDistanceToPoint(
       const Vector3<T> &p_WQ,

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -551,11 +551,11 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
 
   std::vector<SignedDistancePair<T>> ComputeSignedDistancePairwiseClosestPoints(
       const std::vector<GeometryId>& geometry_map,
-      const std::vector<Isometry3<T>>& X_WGs) const {
+      const std::vector<Isometry3<T>>& X_WGs, const double max_distance) const {
     std::vector<SignedDistancePair<T>> witness_pairs;
     // All these quantities are aliased in the callback data.
     shape_distance::CallbackData<T> data{&geometry_map, &collision_filter_,
-                                         &X_WGs, &witness_pairs};
+                                         &X_WGs, max_distance, &witness_pairs};
     data.request.enable_nearest_points = true;
     data.request.enable_signed_distance = true;
     data.request.gjk_solver_type = fcl::GJKSolverType::GST_LIBCCD;
@@ -978,8 +978,10 @@ template <typename T>
 std::vector<SignedDistancePair<T>>
 ProximityEngine<T>::ComputeSignedDistancePairwiseClosestPoints(
     const std::vector<GeometryId>& geometry_map,
-    const std::vector<Isometry3<T>>& X_WGs) const {
-  return impl_->ComputeSignedDistancePairwiseClosestPoints(geometry_map, X_WGs);
+    const std::vector<Isometry3<T>>& X_WGs,
+    const double max_distance) const {
+  return impl_->ComputeSignedDistancePairwiseClosestPoints(geometry_map, X_WGs,
+                                                           max_distance);
 }
 
 template <typename T>

--- a/geometry/proximity_engine.h
+++ b/geometry/proximity_engine.h
@@ -170,19 +170,20 @@ class ProximityEngine {
                               global geometry identifier.
    @param[in] X_WGs           The pose of all geometries in world, indexed by
                               each geometry's GeometryIndex.
-   @retval signed_distances   A vector populated with per-object-pair signed
-                              distance values (and supporting data).
-                              Note: For a geometry pair (A, B), the supporting
-                              data will always be reported in a fixed order
-                              (e.g., always (A, B) and never (B, A)). The
-                              _basis_ for the ordering is arbitrary (and
-                              therefore undocumented), but guaranteed to be
-                              fixed and repeatable.
+   @param[in] max_distance    The maximum distance between objects such that
+                              they will be included in the results.
+   @returns  A vector populated with per-object-pair signed distance values (and
+             supporting data). All reported pairs will have a distance <=
+             `max_distance`. Note: For a geometry pair (A, B), the supporting
+             data will always be reported in a fixed order (e.g., always (A, B)
+             and never (B, A)). The _basis_ for the ordering is arbitrary (and
+             therefore undocumented), but guaranteed to be fixed and repeatable.
    */
   std::vector<SignedDistancePair<T>>
   ComputeSignedDistancePairwiseClosestPoints(
       const std::vector<GeometryId>& geometry_map,
-      const std::vector<Isometry3<T>>& X_WGs) const;
+      const std::vector<Isometry3<T>>& X_WGs,
+      const double max_distance) const;
 
   /** Performs work in support of GeometryState::ComputeSignedDistanceToPoint().
    @param[in] p_WQ            Position of a query point Q in world frame W.

--- a/geometry/query_object.cc
+++ b/geometry/query_object.cc
@@ -42,13 +42,14 @@ QueryObject<T>::ComputePointPairPenetration() const {
 
 template <typename T>
 std::vector<SignedDistancePair<T>>
-QueryObject<T>::ComputeSignedDistancePairwiseClosestPoints() const {
+QueryObject<T>::ComputeSignedDistancePairwiseClosestPoints(
+    const double max_distance) const {
   ThrowIfDefault();
 
   // TODO(SeanCurtis-TRI): Modify this when the cache system is in place.
   scene_graph_->FullPoseUpdate(*context_);
   const GeometryState<T>& state = geometry_state();
-  return state.ComputeSignedDistancePairwiseClosestPoints();
+  return state.ComputeSignedDistancePairwiseClosestPoints(max_distance);
 }
 
 template <typename T>

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -223,13 +223,13 @@ class QueryObject {
    <!-- TODO(SeanCurtis-TRI): Support queries of halfspace-A, where A is _not_ a
    halfspace. See https://github.com/RobotLocomotion/drake/issues/10905 -->
 
-   @retval near_pairs The signed distance for all unfiltered geometry pairs.
-  */
-  // TODO(hongkai.dai): add a distance bound as an optional input, such that the
-  // function doesn't return the pairs whose signed distance is larger than the
-  // distance bound.
-  std::vector<SignedDistancePair<T>>
-  ComputeSignedDistancePairwiseClosestPoints() const;
+   @param max_distance  The maximum distance at which distance data is reported.
+
+   @returns The signed distance for all unfiltered geometry pairs whose distance
+            is less than or equal to `max_distance`.  */
+  std::vector<SignedDistancePair<T>> ComputeSignedDistancePairwiseClosestPoints(
+      const double max_distance =
+          std::numeric_limits<double>::infinity()) const;
 
   // TODO(DamrongGuoy): Improve and refactor documentation of
   // ComputeSignedDistanceToPoint(). Move the common sections into Signed


### PR DESCRIPTION
1. The QueryObject::ComputeSignedDistancePairwiseClosestPoints now takes an optional final argument for specifying a maximum distance.
2. Propagate the parameter downward.
3. Update unit tests to use new parameter and add new unit tests to confirm the effect of the parameter.

resolves #8631

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11429)
<!-- Reviewable:end -->
