### PR TITLE
pydrake: Add bindings for Output prerequisites_of_calc

### DIFF
--- a/bindings/pydrake/systems/framework_py.cc
+++ b/bindings/pydrake/systems/framework_py.cc
@@ -16,9 +16,9 @@ PYBIND11_MODULE(framework, m) {
   py::module::import("pydrake.symbolic");
 
   // Incorporate definitions as pieces (to speed up compilation).
-  DefineFrameworkPySystems(m);
-  DefineFrameworkPySemantics(m);
   DefineFrameworkPyValues(m);
+  DefineFrameworkPySemantics(m);
+  DefineFrameworkPySystems(m);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -540,12 +540,17 @@ Note: The above is for the C++ documentation. For Python, use
             py::arg("model_vector"), doc.LeafSystem.DeclareNumericParameter.doc)
         .def("DeclareAbstractOutputPort",
             WrapCallbacks([](PyLeafSystem* self, const std::string& name,
-                              AllocCallback arg1,
-                              CalcCallback arg2) -> const OutputPort<T>& {
-              return self->DeclareAbstractOutputPort(name, arg1, arg2);
+                              AllocCallback arg1, CalcCallback arg2,
+                              const std::set<DependencyTicket>& arg3)
+                              -> const OutputPort<T>& {
+              return self->DeclareAbstractOutputPort(name, arg1, arg2, arg3);
             }),
             py_reference_internal, py::arg("name"), py::arg("alloc"),
-            py::arg("calc"))
+            py::arg("calc"),
+            py::arg("prerequisites_of_calc") =
+                std::set<DependencyTicket>{SystemBase::all_sources_ticket()},
+            doc.LeafSystem.DeclareAbstractOutputPort
+                .doc_4args_name_alloc_function_calc_function_prerequisites_of_calc)
         .def("DeclareAbstractOutputPort",
             WrapCallbacks([](PyLeafSystem* self, AllocCallback arg1,
                               CalcCallback arg2) -> const OutputPort<T>& {
@@ -566,13 +571,19 @@ Note: The above is for the C++ documentation. For Python, use
             py::arg("random_type") = nullopt,
             doc.LeafSystem.DeclareVectorInputPort.doc_3args)
         .def("DeclareVectorOutputPort",
-            WrapCallbacks([](PyLeafSystem* self, const std::string& name,
-                              const BasicVector<T>& arg1,
-                              CalcVectorCallback arg2) -> const OutputPort<T>& {
-              return self->DeclareVectorOutputPort(name, arg1, arg2);
-            }),
+            WrapCallbacks(
+                [](PyLeafSystem* self, const std::string& name,
+                    const BasicVector<T>& arg1, CalcVectorCallback arg2,
+                    const std::set<DependencyTicket>& arg3)
+                    -> const OutputPort<T>& {
+                  return self->DeclareVectorOutputPort(name, arg1, arg2, arg3);
+                }),
             py_reference_internal, py::arg("name"), py::arg("model_value"),
-            py::arg("calc"))
+            py::arg("calc"),
+            py::arg("prerequisites_of_calc") =
+                std::set<DependencyTicket>{SystemBase::all_sources_ticket()},
+            doc.LeafSystem.DeclareVectorOutputPort
+                .doc_4args_name_model_vector_vector_calc_function_prerequisites_of_calc)
         .def("DeclareVectorOutputPort",
             WrapCallbacks([](PyLeafSystem* self, const BasicVector<T>& arg1,
                               CalcVectorCallback arg2) -> const OutputPort<T>& {

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -272,7 +272,9 @@ class TestCustom(unittest.TestCase):
                 self.DeclareVectorInputPort(
                     name="test_input", model_vector=BasicVector(1),
                     random_type=None)
-                self.DeclareVectorOutputPort(BasicVector(1), noop)
+                self.DeclareVectorOutputPort(
+                    "noop", BasicVector(1), noop,
+                    prerequisites_of_calc=set([self.nothing_ticket()]))
                 self.witness = self.MakeWitnessFunction(
                     "witness", WitnessFunctionDirection.kCrossesZero,
                     self._witness)
@@ -642,7 +644,9 @@ class TestCustom(unittest.TestCase):
                     self.output_port = self.DeclareAbstractOutputPort(
                         "out",
                         lambda: AbstractValue.Make(default_value),
-                        self.DoCalcAbstractOutput)
+                        self.DoCalcAbstractOutput,
+                        prerequisites_of_calc=set([
+                            self.input_port.ticket()]))
 
                 def DoCalcAbstractOutput(self, context, y_data):
                     input_value = self.EvalAbstractInput(


### PR DESCRIPTION
Follow-up from #11426, towards #11423.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11430)
<!-- Reviewable:end -->
