### PR TITLE
Improves ManualPhaseProvider::SetPhase() Error Message

### DIFF
--- a/automotive/maliput/base/intersection_book_loader.cc
+++ b/automotive/maliput/base/intersection_book_loader.cc
@@ -51,6 +51,7 @@ std::unique_ptr<api::Intersection> BuildIntersection(
   optional<PhaseRing> ring = phase_ring_book.GetPhaseRing(ring_id);
   DRAKE_THROW_UNLESS(ring.has_value());
   DRAKE_THROW_UNLESS(ring->phases().size() > 0);
+  DRAKE_THROW_UNLESS(ring->phases().find(phase_id) != ring->phases().end());
   optional<api::rules::Phase::Id> next_phase_id = nullopt;
   optional<double> duration_until = nullopt;
   std::vector<PhaseRing::NextPhase> next_phases =

--- a/automotive/maliput/base/manual_phase_provider.cc
+++ b/automotive/maliput/base/manual_phase_provider.cc
@@ -45,6 +45,7 @@ class ManualPhaseProvider::Impl {
       throw std::logic_error(
           "Duration-until specified when next phase is unspecified.");
     }
+    DRAKE_THROW_UNLESS(phases_.find(id) != phases_.end());
     phases_.at(id) =
         PhaseProvider::Result{phase, ComputeNext(next_phase, duration_until)};
   }

--- a/automotive/maliput/base/test/manual_phase_provider_test.cc
+++ b/automotive/maliput/base/test/manual_phase_provider_test.cc
@@ -35,7 +35,7 @@ struct ManualPhaseProviderTest : public ::testing::Test {
 
 TEST_F(ManualPhaseProviderTest, EmptyProvider) {
   EXPECT_EQ(dut.GetPhase(phase_ring_id), nullopt);
-  EXPECT_THROW(dut.SetPhase(phase_ring_id, phase_id_1), std::out_of_range);
+  EXPECT_THROW(dut.SetPhase(phase_ring_id, phase_id_1), std::exception);
 }
 
 // Tests that an exception is thrown if duration-until is specified but the next


### PR DESCRIPTION
With this patch, the file name and line number are now included as part
of the thrown exception.

With this patch, the exception error message is:

  C++ exception with description
  "Failure at automotive/maliput/base/manual_phase_provider.cc:50 in
  SetPhase(): condition 'phases_.find(id) != phases_.end()' failed."
  thrown in the test body.

Prior to this patch, we get a relatively unhelpful exception:

  C++ exception with description "_Map_base::at" thrown in the test body.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11432)
<!-- Reviewable:end -->
