### PR TITLE
Adds PhaseRingBook::GetPhaseRings()

### DIFF
--- a/automotive/maliput/api/rules/phase_ring_book.h
+++ b/automotive/maliput/api/rules/phase_ring_book.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+
 #include "drake/automotive/maliput/api/rules/phase_ring.h"
 #include "drake/automotive/maliput/api/rules/right_of_way_rule.h"
 #include "drake/common/drake_copyable.h"
@@ -18,6 +20,11 @@ class PhaseRingBook {
 
   virtual ~PhaseRingBook() = default;
 
+  /// Gets a list of all PhaseRings within this book.
+  std::vector<PhaseRing::Id> GetPhaseRings() const {
+    return DoGetPhaseRings();
+  }
+
   /// Gets the specified PhaseRing. Returns nullopt if @p ring_id is
   /// unrecognized.
   optional<PhaseRing> GetPhaseRing(const PhaseRing::Id& ring_id) const {
@@ -34,6 +41,8 @@ class PhaseRingBook {
   PhaseRingBook() = default;
 
  private:
+  virtual std::vector<PhaseRing::Id> DoGetPhaseRings() const = 0;
+
   virtual optional<PhaseRing> DoGetPhaseRing(const PhaseRing::Id& ring_id)
       const = 0;
 

--- a/automotive/maliput/api/test/mock.cc
+++ b/automotive/maliput/api/test/mock.cc
@@ -113,6 +113,10 @@ class MockPhaseRingBook final : public rules::PhaseRingBook {
   MockPhaseRingBook() {}
 
  private:
+  std::vector<rules::PhaseRing::Id> DoGetPhaseRings() const override {
+    return std::vector<rules::PhaseRing::Id>();
+  }
+
   optional<rules::PhaseRing> DoGetPhaseRing(
       const rules::PhaseRing::Id&) const override {
     return nullopt;

--- a/automotive/maliput/base/manual_phase_ring_book.cc
+++ b/automotive/maliput/base/manual_phase_ring_book.cc
@@ -51,6 +51,15 @@ class ManualPhaseRingBook::Impl {
     }
   }
 
+  std::vector<PhaseRing::Id> DoGetPhaseRings() const {
+    std::vector<PhaseRing::Id> result;
+    result.reserve(ring_book_.size());
+    for (const auto& element : ring_book_) {
+      result.push_back(element.first);
+    }
+    return result;
+  }
+
   optional<PhaseRing> DoGetPhaseRing(const PhaseRing::Id& ring_id) const {
     auto it = ring_book_.find(ring_id);
     if (it == ring_book_.end()) {
@@ -83,6 +92,10 @@ void ManualPhaseRingBook::AddPhaseRing(const PhaseRing& ring) {
 
 void ManualPhaseRingBook::RemovePhaseRing(const PhaseRing::Id& ring_id) {
   impl_->RemovePhaseRing(ring_id);
+}
+
+std::vector<PhaseRing::Id> ManualPhaseRingBook::DoGetPhaseRings() const {
+  return impl_->DoGetPhaseRings();
 }
 
 optional<PhaseRing> ManualPhaseRingBook::DoGetPhaseRing(

--- a/automotive/maliput/base/manual_phase_ring_book.h
+++ b/automotive/maliput/base/manual_phase_ring_book.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include "drake/automotive/maliput/api/rules/phase_ring.h"
 #include "drake/automotive/maliput/api/rules/phase_ring_book.h"
@@ -37,6 +38,8 @@ class ManualPhaseRingBook : public api::rules::PhaseRingBook {
   void RemovePhaseRing(const api::rules::PhaseRing::Id& ring_id);
 
  private:
+  std::vector<api::rules::PhaseRing::Id> DoGetPhaseRings() const override;
+
   optional<api::rules::PhaseRing> DoGetPhaseRing(
       const api::rules::PhaseRing::Id& ring_id) const override;
 

--- a/automotive/maliput/base/test/manual_phase_ring_book_test.cc
+++ b/automotive/maliput/base/test/manual_phase_ring_book_test.cc
@@ -37,6 +37,8 @@ struct ManualPhaseRingBookTest : public ::testing::Test {
 TEST_F(ManualPhaseRingBookTest, BasicTest) {
   ManualPhaseRingBook dut;
   EXPECT_NO_THROW(dut.AddPhaseRing(ring));
+  EXPECT_EQ(dut.GetPhaseRings().size(), 1);
+  EXPECT_EQ(dut.GetPhaseRings()[0], ring.id());
   optional<PhaseRing> result = dut.GetPhaseRing(ring_id);
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result->id(), ring_id);


### PR DESCRIPTION
This is needed so users can populate a PhaseProvider.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11433)
<!-- Reviewable:end -->
