### PR TITLE
workspace: Add missing snopt toolchain dependency

### DIFF
--- a/tools/workspace/snopt/fortran-ubuntu.bzl
+++ b/tools/workspace/snopt/fortran-ubuntu.bzl
@@ -38,6 +38,7 @@ def fortran_library(
         srcs = objs,
         outs = [libname],
         cmd = "$(AR) q $@ $(SRCS)",
+        toolchains = ["@bazel_tools//tools/cpp:current_cc_toolchain"],
         visibility = ["//visibility:private"],
     )
 


### PR DESCRIPTION
This shows up as an error in Bazel >= 0.25.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11434)
<!-- Reviewable:end -->
