### PR TITLE
Adds to-left and to-right information to GenerateString

### DIFF
--- a/automotive/maliput/utility/generate_string.cc
+++ b/automotive/maliput/utility/generate_string.cc
@@ -92,6 +92,14 @@ std::string GenerateString(const api::RoadGeometry& road_geometry,
                    << lane->ToGeoPosition(
                           api::LanePosition(lane->length(), 0, 0))
                    << "\n";
+            const api::Lane* left = lane->to_left();
+            const api::Lane* right = lane->to_right();
+            result << lane_prefix
+                   << "  to left: " << (left ? left->id().string() : "")
+                   << "\n";
+            result << lane_prefix
+                   << "  to right: " << (right ? right->id().string() : "")
+                   << "\n";
           }
         }
       }

--- a/automotive/maliput/utility/test/generate_string_test.cc
+++ b/automotive/maliput/utility/test/generate_string_test.cc
@@ -34,6 +34,10 @@ class GenerateStringTest : public ::testing::Test {
                 options_.include_lane_ids);
     EXPECT_TRUE((s.find("geo position") != std::string::npos) ==
                 options_.include_lane_details);
+    EXPECT_TRUE((s.find("to left") != std::string::npos) ==
+                options_.include_lane_details);
+    EXPECT_TRUE((s.find("to right") != std::string::npos) ==
+                options_.include_lane_details);
     if (options_.include_road_geometry_id || options_.include_junction_ids ||
         options_.include_segment_ids || options_.include_lane_ids) {
       const bool has_type_label = (s.find("geometry: ") != std::string::npos ||


### PR DESCRIPTION
This is useful for knowing the left-right ordering of the lanes within a
Segment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11445)
<!-- Reviewable:end -->
