### PR TITLE
Correct usage of MatrixBase::head and ::tail

### DIFF
--- a/multibody/optimization/contact_wrench_evaluator.h
+++ b/multibody/optimization/contact_wrench_evaluator.h
@@ -58,8 +58,8 @@ class ContactWrenchEvaluator : public solvers::EvaluatorBase {
     DRAKE_ASSERT(lambda_value.rows() == num_lambda_ &&
                  lambda_value.cols() == 1);
     VectorX<typename DerivedQ::Scalar> x(num_vars());
-    x.template head(plant_->num_positions()) = q_value;
-    x.template tail(num_lambda_) = lambda_value;
+    x.head(plant_->num_positions()) = q_value;
+    x.tail(num_lambda_) = lambda_value;
     return x;
   }
   //@}


### PR DESCRIPTION
It was invoked with the template keyword, but the runtime overload was used instead of the compile time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11451)
<!-- Reviewable:end -->
