### PR TITLE
MinimumDistanceConstraint: Non-zero gradients at minimum distance.

### DIFF
--- a/bindings/pydrake/multibody/inverse_kinematics_py.cc
+++ b/bindings/pydrake/multibody/inverse_kinematics_py.cc
@@ -53,7 +53,8 @@ PYBIND11_MODULE(inverse_kinematics, m) {
             py::arg("angle_lower"), py::arg("angle_upper"),
             cls_doc.AddAngleBetweenVectorsConstraint.doc)
         .def("AddMinimumDistanceConstraint",
-            &Class::AddMinimumDistanceConstraint, py::arg("minimal_distance"),
+            &Class::AddMinimumDistanceConstraint, py::arg("minimum_distance"),
+            py::arg("threshold_distance") = 1.0,
             cls_doc.AddMinimumDistanceConstraint.doc)
         .def("q", &Class::q, cls_doc.q.doc)
         .def("prog", &Class::prog, py_reference_internal, cls_doc.prog.doc)

--- a/bindings/pydrake/multibody/test/inverse_kinematics_test.py
+++ b/bindings/pydrake/multibody/test/inverse_kinematics_test.py
@@ -240,7 +240,7 @@ class TestInverseKinematics(unittest.TestCase):
         radius1 = 0.1
         radius2 = 0.2
 
-        ik.AddMinimumDistanceConstraint(minimal_distance=min_distance)
+        ik.AddMinimumDistanceConstraint(minimum_distance=min_distance)
         context = self.plant.CreateDefaultContext()
         self.plant.SetFreeBodyPose(
             context, B1.body(), RigidTransform([0, 0, 0.01]))

--- a/multibody/inverse_kinematics/inverse_kinematics.cc
+++ b/multibody/inverse_kinematics/inverse_kinematics.cc
@@ -81,9 +81,11 @@ InverseKinematics::AddAngleBetweenVectorsConstraint(
 }
 
 solvers::Binding<solvers::Constraint>
-InverseKinematics::AddMinimumDistanceConstraint(double minimal_distance) {
+InverseKinematics::AddMinimumDistanceConstraint(double minimum_distance,
+                                                double threshold_distance) {
   auto constraint = std::make_shared<MinimumDistanceConstraint>(
-      &plant_, minimal_distance, get_mutable_context());
+      &plant_, minimum_distance, get_mutable_context(),
+      &QuadraticallySmoothedHingeLoss, threshold_distance);
   return prog_->AddConstraint(constraint, q_);
 }
 }  // namespace multibody

--- a/multibody/inverse_kinematics/inverse_kinematics.h
+++ b/multibody/inverse_kinematics/inverse_kinematics.h
@@ -195,7 +195,7 @@ class InverseKinematics {
    * with a SceneGraph.
    */
   solvers::Binding<solvers::Constraint> AddMinimumDistanceConstraint(
-      double minimal_distance);
+      double minimum_distance, double threshold_distance = 1);
 
   /** Getter for q. q is the decision variable for the generalized positions of
    * the robot. */

--- a/multibody/inverse_kinematics/inverse_kinematics.h
+++ b/multibody/inverse_kinematics/inverse_kinematics.h
@@ -184,15 +184,20 @@ class InverseKinematics {
   // TODO(hongkai.dai): remove this documentation.
   /**
    * Adds the constraint that the pairwise distance between objects should be no
-   * smaller than a positive threshold. We consider the distance between pairs
+   * smaller than `minimum_distance`. We consider the distance between pairs
    * of
    * 1. Anchored (static) object and a dynamic object.
    * 2. A dynamic object and another dynamic object, if one is not the parent
    * link of the other.
+   * @param minimum_distance Minimum allowable distance between any candidate
+   * pair of collision geometries.
+   * @param threshold_distance The distance below which a collision pair is
+   * assigned a non-zero penalty value.
    * @see MinimumDistanceConstraint for more details on the constraint
    * formulation.
    * @throws invalid_argument if the plant does not register its geometry
    * with a SceneGraph.
+   * @throws invalid_argument if threshold_distance ≤ minimum_distance.
    */
   solvers::Binding<solvers::Constraint> AddMinimumDistanceConstraint(
       double minimum_distance, double threshold_distance = 1);

--- a/multibody/inverse_kinematics/inverse_kinematics.h
+++ b/multibody/inverse_kinematics/inverse_kinematics.h
@@ -189,15 +189,19 @@ class InverseKinematics {
    * 1. Anchored (static) object and a dynamic object.
    * 2. A dynamic object and another dynamic object, if one is not the parent
    * link of the other.
-   * @param minimum_distance Minimum allowable distance between any candidate
-   * pair of collision geometries.
-   * @param threshold_distance The distance below which a collision pair is
-   * assigned a non-zero penalty value.
-   * @see MinimumDistanceConstraint for more details on the constraint
+   * @param minimum_distance The minimum allowed value, dₘᵢₙ, of the signed
+   * distance between any candidate pair of geometries.
+   * @param influence_distance_offset The difference (in meters) between the
+   * influence distance, d_influence, and the minimum distance, dₘᵢₙ. This value
+   * must be finite and strictly positive, as it is used to scale the signed
+   * distances between pairs of geometries. Smaller values may improve
+   * performance, as fewer pairs of geometries need to be considered in each
+   * constraint evaluation. @default 1 meter
+   * @see MinimumDistanceConstraint for more details on the %constraint
    * formulation.
-   * @throws invalid_argument if the plant does not register its geometry
-   * with a SceneGraph.
-   * @throws invalid_argument if threshold_distance ≤ minimum_distance.
+   * @pre The MultibodyPlant passed to the constructor of `this` has registered
+   * its geometry with a SceneGraph.
+   * @pre 0 < `influence_distance_offset` < ∞
    */
   solvers::Binding<solvers::Constraint> AddMinimumDistanceConstraint(
       double minimum_distance, double threshold_distance = 1);

--- a/multibody/inverse_kinematics/minimum_distance_constraint.cc
+++ b/multibody/inverse_kinematics/minimum_distance_constraint.cc
@@ -3,11 +3,48 @@
 #include <limits>
 #include <vector>
 
+#include <Eigen/Dense>
+
 #include "drake/multibody/inverse_kinematics/kinematic_constraint_utilities.h"
 
 namespace drake {
 namespace multibody {
 using internal::RefFromPtrOrThrow;
+
+namespace {
+/** Computes log(∑exp(xᵢ)). Exploits the shift invariance of log-sum-exp to
+avoid overflow. */
+template <typename T>
+T LogSumExp(const std::vector<T>& x) {
+  using std::exp;
+  using std::log;
+  const T x_max = *std::max_element(x.begin(), x.end());
+  T sum_exp{0.0};
+  for (const T& xi : x) {
+    sum_exp += exp(xi - x_max);
+  }
+  return x_max + log(sum_exp);
+}
+
+/** Computes a smooth approximation of max(x). */
+template <typename T>
+T SmoothMax(const std::vector<T>& x) {
+  double alpha{100};
+  std::vector<T> x_scaled{x};
+  for (T& xi_scaled : x_scaled) {
+    xi_scaled *= alpha;
+  }
+  return LogSumExp(x_scaled) / alpha;
+}
+
+template <typename T>
+T ScaleDistance(T distance, double minimum_distance,
+                double threshold_distance) {
+  return (distance - threshold_distance) /
+         (threshold_distance - minimum_distance);
+}
+
+}  // namespace
 
 void ExponentiallySmoothedHingeLoss(double x, double* penalty,
                                     double* dpenalty_dx) {
@@ -50,11 +87,21 @@ void QuadraticallySmoothedHingeLoss(double x, double* penalty,
 MinimumDistanceConstraint::MinimumDistanceConstraint(
     const multibody::MultibodyPlant<double>* const plant,
     double minimum_distance, systems::Context<double>* plant_context,
-    MinimumDistancePenaltyFunction penalty_function)
+    MinimumDistancePenaltyFunction penalty_function, double threshold_distance)
     : solvers::Constraint(1, RefFromPtrOrThrow(plant).num_positions(),
-                          Vector1d(0), Vector1d(0)),
+                          Vector1d(0), Vector1d(1)),
       plant_{RefFromPtrOrThrow(plant)},
       minimum_distance_{minimum_distance},
+      threshold_distance_{threshold_distance},
+      penalty_output_scaling_{
+          1.0 /
+          [&penalty_function](double x) {
+            double upper_bound{};
+            double dummy{};
+            penalty_function(x, &upper_bound, &dummy);
+            return upper_bound;
+          }(ScaleDistance(minimum_distance, minimum_distance,
+                          threshold_distance))},
       plant_context_{plant_context},
       penalty_function_{penalty_function} {
   if (!plant_.geometry_source_is_registered()) {
@@ -64,63 +111,93 @@ MinimumDistanceConstraint::MinimumDistanceConstraint(
         "AddMultibodyPlantSceneGraph on how to connect MultibodyPlant to "
         "SceneGraph.");
   }
-  if (minimum_distance_ <= 0) {
+  if (minimum_distance_ < 0) {
     throw std::invalid_argument(
-        "MinimumDistanceConstraint: minimum_distance should be positive.");
+        "MinimumDistanceConstraint: minimum_distance should be non-negative.");
   }
+  if (threshold_distance_ <= minimum_distance) {
+    throw std::invalid_argument(
+        "MinimumDistanceConstraint: threshold_distance should be greater than "
+        "minimum_distance.");
+  }
+  const auto& query_port = plant_.get_geometry_query_input_port();
+  if (!query_port.HasValue(*plant_context_)) {
+    throw std::invalid_argument(
+        "MinimumDistanceConstraint: Cannot get a valid geometry::QueryObject. "
+        "Either the plant geometry_query_input_port() is not properly "
+        "connected to the SceneGraph's output port, or the plant_context_ is "
+        "incorrect. Please refer to AddMultibodyPlantSceneGraph on connecting "
+        "MultibodyPlant to SceneGraph.");
+  }
+  // Maximum number of SignedDistancePairs returned by calls to
+  // ComputeSignedDistancePairwiseClosestPoints().
+  num_collision_candidates_ =
+      query_port.Eval<geometry::QueryObject<double>>(*plant_context_)
+          .inspector()
+          .GetCollisionCandidates()
+          .size();
 }
 
 namespace {
-void InitializeY(const Eigen::Ref<const Eigen::VectorXd>&, Eigen::VectorXd* y) {
-  (*y)(0) = 0;
+void InitializeY(const Eigen::Ref<const Eigen::VectorXd>&, Eigen::VectorXd* y,
+                 double y_value) {
+  (*y)(0) = y_value;
 }
 
-void InitializeY(const Eigen::Ref<const AutoDiffVecXd>& x, AutoDiffVecXd* y) {
+void InitializeY(const Eigen::Ref<const AutoDiffVecXd>& x, AutoDiffVecXd* y,
+                 double y_value) {
   (*y) = math::initializeAutoDiffGivenGradientMatrix(
-      Vector1d(0), Eigen::RowVectorXd::Zero(x(0).derivatives().size()));
-}
-void AddPenalty(const MultibodyPlant<double>&, const systems::Context<double>&,
-                const Frame<double>&, const Frame<double>&,
-                const Eigen::Vector3d&, double distance,
-                double minimum_distance,
-                MinimumDistancePenaltyFunction penalty_function,
-                const Eigen::Vector3d&, const Eigen::Vector3d&,
-                const Eigen::Ref<const Eigen::VectorXd>&, Eigen::VectorXd* y) {
-  double penalty;
-  const double x = distance / minimum_distance - 1;
-  penalty_function(x, &penalty, nullptr);
-  (*y)(0) += penalty;
+      Vector1d(y_value), Eigen::RowVectorXd::Zero(x(0).derivatives().size()));
 }
 
-void AddPenalty(const MultibodyPlant<double>& plant,
-                const systems::Context<double>& context,
-                const Frame<double>& frameA, const Frame<double>& frameB,
-                const Eigen::Vector3d& p_ACa, double distance,
-                double minimum_distance,
-                MinimumDistancePenaltyFunction penalty_function,
-                const Eigen::Vector3d& p_WCa, const Eigen::Vector3d& p_WCb,
-                const Eigen::Ref<const AutoDiffVecXd>& x, AutoDiffVecXd* y) {
+void Penalty(const MultibodyPlant<double>&, const systems::Context<double>&,
+             const Frame<double>&, const Frame<double>&, const Eigen::Vector3d&,
+             double distance, double minimum_distance,
+             double threshold_distance,
+             MinimumDistancePenaltyFunction penalty_function,
+             const Eigen::Vector3d&, const Eigen::Vector3d&,
+             const Eigen::Ref<const Eigen::VectorXd>&, double* y) {
+  double penalty;
+  const double x =
+      ScaleDistance(distance, minimum_distance, threshold_distance);
+  penalty_function(x, &penalty, nullptr);
+  *y = penalty;
+}
+
+void Penalty(const MultibodyPlant<double>& plant,
+             const systems::Context<double>& context,
+             const Frame<double>& frameA, const Frame<double>& frameB,
+             const Eigen::Vector3d& p_ACa, double distance,
+             double minimum_distance, double threshold_distance,
+             MinimumDistancePenaltyFunction penalty_function,
+             const Eigen::Vector3d& p_WCa, const Eigen::Vector3d& p_WCb,
+             const Eigen::Ref<const AutoDiffVecXd>& q, AutoDiffXd* y) {
   // The distance is d = sign * |p_CbCa_B|, where the
   // closest points are Ca on object A, and Cb on object B.
   // So the gradient ∂d/∂q = p_CbCa_W * ∂p_BCa_B/∂q / d
   // where p_CbCa_W = p_WCa - p_WCb = p_WA + R_WA * p_ACa - (p_WB + R_WB *
   // p_BCb)
-  double penalty, dpenalty_dx;
-  const double penalty_x = distance / minimum_distance - 1;
-  penalty_function(penalty_x, &penalty, &dpenalty_dx);
-  const double dpenalty_ddistance = dpenalty_dx / minimum_distance;
-
   Eigen::Matrix<double, 6, Eigen::Dynamic> Jq_V_BCa_W(6, plant.num_positions());
   plant.CalcJacobianSpatialVelocity(context, JacobianWrtVariable::kQDot, frameA,
                                     p_ACa, frameB, plant.world_frame(),
                                     &Jq_V_BCa_W);
   const Eigen::RowVectorXd ddistance_dq =
       (p_WCa - p_WCb).transpose() * Jq_V_BCa_W.bottomRows<3>() / distance;
+  AutoDiffXd distance_autodiff{
+      distance, ddistance_dq * math::autoDiffToGradientMatrix(q)};
+  const AutoDiffXd scaled_distance_autodiff =
+      ScaleDistance(distance_autodiff, minimum_distance, threshold_distance);
+  double penalty, dpenalty_dscaled_distance;
+  penalty_function(scaled_distance_autodiff.value(), &penalty,
+                   &dpenalty_dscaled_distance);
+
   const Vector1<AutoDiffXd> penalty_autodiff =
       math::initializeAutoDiffGivenGradientMatrix(
-          Vector1d(penalty), dpenalty_ddistance * ddistance_dq *
-                                 math::autoDiffToGradientMatrix(x));
-  *y += penalty_autodiff;
+          Vector1d(penalty),
+          dpenalty_dscaled_distance *
+              math::autoDiffToGradientMatrix(
+                  Vector1<AutoDiffXd>{scaled_distance_autodiff}));
+  *y = penalty_autodiff(0);
 }
 }  // namespace
 
@@ -144,13 +221,17 @@ void MinimumDistanceConstraint::DoEvalGeneric(
 
   const std::vector<geometry::SignedDistancePair<double>>
       signed_distance_pairs =
-          query_object.ComputeSignedDistancePairwiseClosestPoints();
+          query_object.ComputeSignedDistancePairwiseClosestPoints(
+              threshold_distance_);
 
-  InitializeY(x, y);
+  // Initialize y to SmoothMax([0, 0, ..., 0]).
+  InitializeY(x, y,
+              SmoothMax(std::vector<double>(num_collision_candidates_, 0.0)));
 
+  std::vector<T> penalties;
   for (const auto& signed_distance_pair : signed_distance_pairs) {
     const double distance = signed_distance_pair.distance;
-    if (distance < minimum_distance_) {
+    if (distance < threshold_distance_) {
       Vector3<double> p_WCa, p_WCb;
       const geometry::SceneGraphInspector<double>& inspector =
           query_object.inspector();
@@ -170,12 +251,20 @@ void MinimumDistanceConstraint::DoEvalGeneric(
                                  inspector.X_FG(signed_distance_pair.id_B) *
                                      signed_distance_pair.p_BCb,
                                  plant_.world_frame(), &p_WCb);
-      AddPenalty(plant_, *plant_context_, frameA, frameB,
-                 inspector.X_FG(signed_distance_pair.id_A) *
-                     signed_distance_pair.p_ACa,
-                 distance, minimum_distance_, penalty_function_, p_WCa, p_WCb,
-                 x, y);
+      penalties.emplace_back();
+      Penalty(plant_, *plant_context_, frameA, frameB,
+              inspector.X_FG(signed_distance_pair.id_A) *
+                  signed_distance_pair.p_ACa,
+              distance, minimum_distance_, threshold_distance_,
+              penalty_function_, p_WCa, p_WCb, x, &penalties.back());
+      penalties.back() *= penalty_output_scaling_;
     }
+  }
+  if (!penalties.empty()) {
+    // Pad penalties up to num_collision_candidates_ so that the constraint
+    // function is actually smooth.
+    penalties.resize(num_collision_candidates_, T{0.0});
+    (*y)(0) = SmoothMax(penalties);
   }
 }
 

--- a/multibody/inverse_kinematics/minimum_distance_constraint.cc
+++ b/multibody/inverse_kinematics/minimum_distance_constraint.cc
@@ -33,7 +33,7 @@ T SmoothMax(const std::vector<T>& x) {
   // This soft-max approaches max(x) as α increases. We choose α = 100, as that
   // gives a qualitatively good fit for xᵢ ∈ [0, 1], which is the range of
   // potential penalty values when the MinimumDistanceConstraint is feasible.
-  double alpha{100};
+  const double alpha{100};
   std::vector<T> x_scaled{x};
   for (T& xi_scaled : x_scaled) {
     xi_scaled *= alpha;

--- a/multibody/inverse_kinematics/minimum_distance_constraint.cc
+++ b/multibody/inverse_kinematics/minimum_distance_constraint.cc
@@ -188,7 +188,7 @@ void Penalty(const MultibodyPlant<double>& plant,
   // nhat_BA_W whenever d ≠ 0, we use ∂d/∂q = nhat_BA_W′ * ∂p_BCa_B/∂q. This
   // allows us to compute a gradient at d = 0 in certain cases (See
   // geometry::SignedDistancePair for details).
-  Eigen::Matrix<double, 3, Eigen::Dynamic> Jq_v_BCa_W(6, plant.num_positions());
+  Eigen::Matrix<double, 3, Eigen::Dynamic> Jq_v_BCa_W(3, plant.num_positions());
   plant.CalcJacobianTranslationalVelocity(context, JacobianWrtVariable::kQDot,
                                           frameA, p_ACa, frameB,
                                           plant.world_frame(), &Jq_v_BCa_W);

--- a/multibody/inverse_kinematics/minimum_distance_constraint.cc
+++ b/multibody/inverse_kinematics/minimum_distance_constraint.cc
@@ -30,7 +30,7 @@ T LogSumExp(const std::vector<T>& x) {
 template <typename T>
 T SmoothMax(const std::vector<T>& x) {
   // We compute the soft-max of x as softmax(x) = log(∑ᵢ exp(αxᵢ)) / α.
-  // This soft-max aproaches max(x) as α increases. We choose α = 100, as that
+  // This soft-max approaches max(x) as α increases. We choose α = 100, as that
   // gives a qualitatively good fit for xᵢ ∈ [0, 1], which is the range of
   // potential penalty values when the MinimumDistanceConstraint is feasible.
   double alpha{100};

--- a/multibody/inverse_kinematics/minimum_distance_constraint.cc
+++ b/multibody/inverse_kinematics/minimum_distance_constraint.cc
@@ -44,6 +44,7 @@ T SmoothMax(const std::vector<T>& x) {
 template <typename T>
 T ScaleDistance(T distance, double minimum_distance,
                 double influence_distance) {
+  DRAKE_ASSERT(influence_distance > minimum_distance);
   return (distance - influence_distance) /
          (influence_distance - minimum_distance);
 }

--- a/multibody/inverse_kinematics/minimum_distance_constraint.cc
+++ b/multibody/inverse_kinematics/minimum_distance_constraint.cc
@@ -118,9 +118,9 @@ MinimumDistanceConstraint::MinimumDistanceConstraint(
         "AddMultibodyPlantSceneGraph on how to connect MultibodyPlant to "
         "SceneGraph.");
   }
-  if (minimum_distance_ < 0) {
+  if (std::isinf(threshold_distance_)) {
     throw std::invalid_argument(
-        "MinimumDistanceConstraint: minimum_distance should be non-negative.");
+        "MinimumDistanceConstraint: threshold_distance must be finite.");
   }
   if (threshold_distance_ <= minimum_distance) {
     throw std::invalid_argument(

--- a/multibody/inverse_kinematics/minimum_distance_constraint.cc
+++ b/multibody/inverse_kinematics/minimum_distance_constraint.cc
@@ -29,8 +29,10 @@ T LogSumExp(const std::vector<T>& x) {
 /** Computes a smooth approximation of max(x). */
 template <typename T>
 T SmoothMax(const std::vector<T>& x) {
-  // This scaling factor was chosen to give a qualitatively good fit for
-  // 0 ≤ xᵢ ≤ 1.
+  // We compute the soft-max of x as softmax(x) = log(∑ᵢ exp(αxᵢ)) / α.
+  // This soft-max aproaches max(x) as α increases. We choose α = 100, as that
+  // gives a qualitatively good fit for xᵢ ∈ [0, 1], which is the range of
+  // potential penalty values when the MinimumDistanceConstraint is feasible.
   double alpha{100};
   std::vector<T> x_scaled{x};
   for (T& xi_scaled : x_scaled) {

--- a/multibody/inverse_kinematics/minimum_distance_constraint.cc
+++ b/multibody/inverse_kinematics/minimum_distance_constraint.cc
@@ -44,7 +44,6 @@ T SmoothMax(const std::vector<T>& x) {
 template <typename T>
 T ScaleDistance(T distance, double minimum_distance,
                 double influence_distance) {
-  DRAKE_ASSERT(influence_distance > minimum_distance);
   return (distance - influence_distance) /
          (influence_distance - minimum_distance);
 }

--- a/multibody/inverse_kinematics/minimum_distance_constraint.h
+++ b/multibody/inverse_kinematics/minimum_distance_constraint.h
@@ -75,12 +75,19 @@ class MinimumDistanceConstraint : public solvers::Constraint {
   @param minimum_distance The minimum value of the signed distance between
   any admissible pairs of objects.
   @param penalty_type The penalty function formulation.
-  @param threshold_distance The distance below which a collision pair is
-  assigned a non-zero penalty value.
+  @param threshold_distance The  signed distance beyond which a pair of
+  geometries is ignored. Must be greater than minimum_distance. NOTE: This
+  parameter is also used in scaling the signed distances between bodies and
+  therefore MUST be finite. This is in contrast to the similarly named arguments
+  to geometry::QueryObject methods, which are purely performance optimizations.
+  @default 1
   @pre The MultibodyPlant passed in the constructor of InverseKinematics has
   registered its geometry with a SceneGraph object already.
-  @pre minimum_distance > 0.
-  @throw invalid_argument if the geometry hasn't been registered. */
+  @pre minimum_distance < threshold_distance
+  @throws std::invalid_argument if the geometry hasn't been registered.
+  @throws std::invalid_argument if threshold_distance = ∞.
+  @throws std::invalid_argument if threshold_distance <= minimum_distance.
+  */
   MinimumDistanceConstraint(
       const multibody::MultibodyPlant<double>* const plant,
       double minimum_distance, systems::Context<double>* plant_context,

--- a/multibody/inverse_kinematics/minimum_distance_constraint.h
+++ b/multibody/inverse_kinematics/minimum_distance_constraint.h
@@ -53,16 +53,16 @@ no smaller than a specified minimum distance.
 
 The formulation of the constraint is
 
-0 ≤ SmoothMax( γ((dᵢ - d*)/(d* - dₘᵢₙ)) / γ(-1) ) ≤ 1
+0 ≤ SmoothMax( γ((dᵢ - d_influence)/(d_influence - dₘᵢₙ)) / γ(-1) ) ≤ 1
 
 where dᵢ is the signed distance of the i-th pair, dₘᵢₙ is the minimum allowable
-distance, d* is the "influence distance" (the distance below which a pair of
-geometries influences the constraint), γ is a
+distance, d_influence is the "influence distance" (the distance below which a
+pair of geometries influences the constraint), γ is a
 multibody::MinimumDistancePenaltyFunction, and SmoothMax(d) is smooth
-approximation of max(d). We require that dₘᵢₙ < d*. The input scaling
-(dᵢ - d*)/(d* - dₘᵢₙ) ensures that at the boundary of the feasible set (when
-dᵢ == dₘᵢₙ), we evaluate the penalty function at -1, where it is required to
-have a non-zero gradient.
+approximation of max(d). We require that dₘᵢₙ < d_influence. The input scaling
+(dᵢ - d_influence)/(d_influence - dₘᵢₙ) ensures that at the boundary of the
+feasible set (when dᵢ == dₘᵢₙ), we evaluate the penalty function at -1, where it
+is required to have a non-zero gradient.
 */
 class MinimumDistanceConstraint : public solvers::Constraint {
  public:
@@ -75,15 +75,15 @@ class MinimumDistanceConstraint : public solvers::Constraint {
   @param penalty_function The penalty function formulation.
   @default QuadraticallySmoothedHinge
   @param influence_distance_offset The difference (in meters) between the
-  influence distance, d*, and the minimum distance, dₘᵢₙ (see class
+  influence distance, d_influence, and the minimum distance, dₘᵢₙ (see class
   documentation). This value must be finite and strictly positive, as it is used
   to scale the signed distances between pairs of geometries. Smaller values may
   improve performance, as fewer pairs of geometries need to be considered in
-  each constraint evaluation. @default 1
+  each constraint evaluation. @default 1 meter
   @throws std::invalid_argument if `plant` has not registered its geometry with
   a SceneGraph object.
-  @throws std::invalid_argument if influence_distance_offset == ∞.
-  @throws std::invalid_argument if influence_distance_offset <= 0.
+  @throws std::invalid_argument if influence_distance_offset = ∞.
+  @throws std::invalid_argument if influence_distance_offset ≤ 0.
   */
   MinimumDistanceConstraint(
       const multibody::MultibodyPlant<double>* const plant,
@@ -121,9 +121,9 @@ class MinimumDistanceConstraint : public solvers::Constraint {
   const multibody::MultibodyPlant<double>& plant_;
   const double minimum_distance_;
   const double influence_distance_;
-  /** Stores the value of 1 / γ((dₘᵢₙ - d*)/(d* - dₘᵢₙ)) = 1 / γ(-1).
-  This is used to scale the output of the penalty function to be 1 when
-  d == dₘᵢₙ. */
+  /** Stores the value of
+  1 / γ((dₘᵢₙ - d_influence)/(d_influence - dₘᵢₙ)) = 1 / γ(-1). This is used to
+  scale the output of the penalty function to be 1 when d == dₘᵢₙ. */
   const double penalty_output_scaling_;
   int num_collision_candidates_{};
   systems::Context<double>* const plant_context_;

--- a/multibody/inverse_kinematics/minimum_distance_constraint.h
+++ b/multibody/inverse_kinematics/minimum_distance_constraint.h
@@ -13,7 +13,8 @@ penalty functions must meet the following criteria:
 
 1.     γ(x) ≥ 0 ∀ x ∈ ℝ.
 2. dγ(x)/dx ≤ 0 ∀ x ∈ ℝ.
-3.     γ(x) = 0 ∀ x ≥ 0. */
+3.     γ(x) = 0 ∀ x ≥ 0.
+4. dγ(x)/dx < 0 ∀ x < 0. */
 using MinimumDistancePenaltyFunction =
     std::function<void(double x, double* penalty, double* dpenalty_dx)>;
 
@@ -57,7 +58,10 @@ The formulation of the constraint is
 where dᵢ is the signed distance of the i-th pair, dₘᵢₙ is the minimum allowable
 distance, dₜₕᵣₑₛₕ is the distance beyond which pairs of geometries are ignored,
 γ is a MinimumDistancePenaltyFunction, and SmoothMax(d) is smooth approximation
-of max(d). We require that 0 ≤ dₘᵢₙ < dₜₕᵣₑₛₕ.
+of max(d). We require that dₘᵢₙ < dₜₕᵣₑₛₕ. The input scaling
+(dᵢ - dₜₕᵣₑₛₕ)/(dₜₕᵣₑₛₕ - dₘᵢₙ) ensures that at the boundary of the feasible set
+(when dᵢ == dₘᵢₙ), we evaluate the penalty function at -1, where it is required
+to have a non-zero gradient.
 */
 class MinimumDistanceConstraint : public solvers::Constraint {
  public:
@@ -112,6 +116,9 @@ class MinimumDistanceConstraint : public solvers::Constraint {
   const multibody::MultibodyPlant<double>& plant_;
   const double minimum_distance_;
   const double threshold_distance_;
+  /** Stores the value of 1 / γ((dₘᵢₙ - dₜₕᵣₑₛₕ)/(dₜₕᵣₑₛₕ - dₘᵢₙ)) = 1 / γ(-1).
+  This is used to scale the output of the penalty function to be 1 when
+  d == dₘᵢₙ. */
   const double penalty_output_scaling_;
   int num_collision_candidates_{};
   systems::Context<double>* const plant_context_;

--- a/multibody/inverse_kinematics/minimum_distance_constraint.h
+++ b/multibody/inverse_kinematics/minimum_distance_constraint.h
@@ -75,7 +75,8 @@ class MinimumDistanceConstraint : public solvers::Constraint {
   @param minimum_distance The minimum value of the signed distance between
   any admissible pairs of objects.
   @param penalty_type The penalty function formulation.
-  @param threshold_distance The penalty function formulation.
+  @param threshold_distance The distance below which a collision pair is
+  assigned a non-zero penalty value.
   @pre The MultibodyPlant passed in the constructor of InverseKinematics has
   registered its geometry with a SceneGraph object already.
   @pre minimum_distance > 0.

--- a/multibody/inverse_kinematics/test/inverse_kinematics_test.cc
+++ b/multibody/inverse_kinematics/test/inverse_kinematics_test.cc
@@ -210,7 +210,7 @@ TEST_F(TwoFreeBodiesTest, AngleBetweenVectorsConstraint) {
   EXPECT_NEAR(angle, angle_lower, 1E-6);
 }
 
-TEST_F(TwoFreeSpheresTest, MinimalDistanceConstraintTest) {
+TEST_F(TwoFreeSpheresTest, MinimumDistanceConstraintTest) {
   const double min_distance = 0.1;
 
   InverseKinematics ik(*plant_double_, plant_context_double_);
@@ -244,7 +244,7 @@ TEST_F(TwoFreeSpheresTest, MinimalDistanceConstraintTest) {
     const Eigen::Vector3d p_WS2 =
         p_WB2 + quat_WB2.toRotationMatrix() * X_B2S2_.translation();
     // This large error is due to the derivative of the penalty function(i.e.,
-    // the gradient ∂penalty/∂distance) being small near minimal_distance. Hence
+    // the gradient ∂penalty/∂distance) being small near minimum_distance. Hence
     // a small violation on the penalty leads to a large violation on the
     // minimum_distance.
     const double tol = 2e-4;

--- a/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
@@ -57,7 +57,7 @@ class TwoFreeSpheresMinimumDistanceTest : public TwoFreeSpheresTest {
   void CheckConstraintEvalLargerThanThresholdDistance(
       const MinimumDistanceConstraint& constraint, const Eigen::Vector3d& p_WB1,
       const Eigen::Vector3d p_WB2) const {
-    // distance larger than minimum_distance;
+    // Distance larger than threshold_distance;
     // The penalty should be 0, so is the gradient.
     const Eigen::Quaterniond sphere1_quaternion(1, 0, 0, 0);
     const Eigen::Quaterniond sphere2_quaternion(1, 0, 0, 0);

--- a/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
@@ -3,133 +3,38 @@
 #include <limits>
 
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/math/compute_numerical_gradient.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h"
 
 namespace drake {
 namespace multibody {
-const double kEps = std::numeric_limits<double>::epsilon();
 
-namespace {
-enum class PenaltyType {
-  kExponential,
-  kQuadratic,
-};
-
-template <typename T>
-T QuadraticallySmoothedPenalty(const T& distance, double minimum_distance) {
-  if (distance >= minimum_distance) {
-    // use 0 * distance to set the right size of the derivatives.
-    return T(0) * distance;
-  }
-  const T x = distance / minimum_distance - 1;
-  if (x > -1) {
-    return x * x / 2;
-  } else {
-    return -0.5 - x;
-  }
-}
-
-template <typename T>
-T ExponentiallySmoothedPenalty(const T& distance, double minimum_distance) {
-  if (distance >= minimum_distance) {
-    // use 0 * distance to set the right size of the derivatives.
-    return T(0) * distance;
-  }
-  const T x = distance / minimum_distance - 1;
-  using std::exp;
-  const T penalty = -x * exp(1.0 / x);
-  return penalty;
-}
-
-template <typename T>
-T Penalty(const T& distance, double minimum_distance,
-          PenaltyType penalty_type) {
-  switch (penalty_type) {
-    case PenaltyType::kQuadratic: {
-      return QuadraticallySmoothedPenalty(distance, minimum_distance);
-    }
-    case PenaltyType::kExponential: {
-      return ExponentiallySmoothedPenalty(distance, minimum_distance);
-    }
-    default: { throw std::runtime_error("Should not reach here."); }
-  }
-}
-}  // namespace
-
-AutoDiffVecXd EvalMinimumDistanceConstraintAutoDiff(
-    const systems::Context<AutoDiffXd>& context,
-    const MultibodyPlant<AutoDiffXd>& plant, double minimum_distance,
-    PenaltyType penalty_type) {
-  AutoDiffVecXd y(1);
-  y(0).value() = 0;
-  y(0).derivatives().resize(
-      math::autoDiffToGradientMatrix(plant.GetPositions(context)).cols());
-  y(0).derivatives().setZero();
-  const auto& query_object =
-      plant.get_geometry_query_input_port()
-          .Eval<geometry::QueryObject<AutoDiffXd>>(context);
-
-  const std::vector<geometry::SignedDistancePair<AutoDiffXd>>
-      signed_distance_pairs =
-          query_object.ComputeSignedDistancePairwiseClosestPoints();
-
-  for (const auto& signed_distance_pair : signed_distance_pairs) {
-    const double distance = signed_distance_pair.distance.value();
-    if (distance < minimum_distance) {
-      const double sign = distance > 0 ? 1 : -1;
-
-      Vector3<AutoDiffXd> p_WCa, p_WCb;
-      const geometry::SceneGraphInspector<AutoDiffXd>& inspector =
-          query_object.inspector();
-      const geometry::FrameId frame_A_id =
-          inspector.GetFrameId(signed_distance_pair.id_A);
-      const geometry::FrameId frame_B_id =
-          inspector.GetFrameId(signed_distance_pair.id_B);
-      plant.CalcPointsPositions(
-          context, plant.GetBodyFromFrameId(frame_A_id)->body_frame(),
-          (inspector.X_FG(signed_distance_pair.id_A) *
-           signed_distance_pair.p_ACa)
-              .cast<AutoDiffXd>(),
-          plant.world_frame(), &p_WCa);
-      plant.CalcPointsPositions(
-          context, plant.GetBodyFromFrameId(frame_B_id)->body_frame(),
-          (inspector.X_FG(signed_distance_pair.id_B) *
-           signed_distance_pair.p_BCb)
-              .cast<AutoDiffXd>(),
-          plant.world_frame(), &p_WCb);
-
-      const AutoDiffXd distance_autodiff = sign * (p_WCa - p_WCb).norm();
-
-      const Vector1<AutoDiffXd> penalty_autodiff = Vector1<AutoDiffXd>(
-          Penalty(distance_autodiff, minimum_distance, penalty_type));
-
-      y += penalty_autodiff;
-    }
-  }
-  return y;
-}
 // Compare the result between Eval<double> and Eval<AutoDiffXd>. Also compare
-// the gradient in Eval<AutoDiffXd> with the result in
-// EvalMinimumDistanceConstraintAutoDiff.
+// the gradient in Eval<AutoDiffXd> with a numerical approximation.
 void CheckMinimumDistanceConstraintEval(
     const MinimumDistanceConstraint& constraint,
     const Eigen::Ref<const AutoDiffVecXd>& x_autodiff,
     const MultibodyPlant<AutoDiffXd>& plant_autodiff,
-    systems::Context<AutoDiffXd>* context_autodiff, double tol,
-    PenaltyType penalty_type) {
+    systems::Context<AutoDiffXd>* context_autodiff, double tol) {
+  const Eigen::VectorXd x_double{math::autoDiffToValueMatrix(x_autodiff)};
   Eigen::VectorXd y_double;
-  constraint.Eval(math::autoDiffToValueMatrix(x_autodiff), &y_double);
+  constraint.Eval(x_double, &y_double);
   AutoDiffVecXd y_autodiff;
   constraint.Eval(x_autodiff, &y_autodiff);
   EXPECT_TRUE(
       CompareMatrices(y_double, math::autoDiffToValueMatrix(y_autodiff), tol));
-  plant_autodiff.SetPositions(context_autodiff, x_autodiff);
-  const AutoDiffVecXd y_autodiff_expected =
-      EvalMinimumDistanceConstraintAutoDiff(*context_autodiff, plant_autodiff,
-                                            constraint.minimum_distance(),
-                                            penalty_type);
-  CompareAutoDiffVectors(y_autodiff, y_autodiff_expected, tol);
+  std::function<void(const Eigen::Ref<const Eigen::VectorXd>&,
+                     Eigen::VectorXd*)>
+      constraint_eval =
+          [&constraint](const Eigen::Ref<const Eigen::VectorXd>& x,
+                        Eigen::VectorXd* y) { return constraint.Eval(x, y); };
+  const auto J = math::ComputeNumericalGradient(
+      constraint_eval, x_double,
+      math::NumericalGradientOption{math::NumericalGradientMethod::kCentral});
+  EXPECT_TRUE(CompareMatrices(J * math::autoDiffToGradientMatrix(x_autodiff),
+                              math::autoDiffToGradientMatrix(y_autodiff),
+                              std::sqrt(tol)));
 }
 
 template <typename T>
@@ -146,12 +51,12 @@ class TwoFreeSpheresMinimumDistanceTest : public TwoFreeSpheresTest {
       const MinimumDistanceConstraint& constraint) const {
     EXPECT_EQ(constraint.num_constraints(), 1);
     EXPECT_TRUE(CompareMatrices(constraint.lower_bound(), Vector1d(0)));
-    EXPECT_TRUE(CompareMatrices(constraint.upper_bound(), Vector1d(0)));
+    EXPECT_TRUE(CompareMatrices(constraint.upper_bound(), Vector1d(1)));
   }
 
-  void CheckConstraintEvalLargerThanMinimumDistance(
+  void CheckConstraintEvalLargerThanThresholdDistance(
       const MinimumDistanceConstraint& constraint, const Eigen::Vector3d& p_WB1,
-      const Eigen::Vector3d p_WB2, PenaltyType penalty_type) const {
+      const Eigen::Vector3d p_WB2) const {
     // distance larger than minimum_distance;
     // The penalty should be 0, so is the gradient.
     const Eigen::Quaterniond sphere1_quaternion(1, 0, 0, 0);
@@ -165,86 +70,79 @@ class TwoFreeSpheresMinimumDistanceTest : public TwoFreeSpheresTest {
     AutoDiffVecXd y_autodiff(1);
     constraint.Eval(q_autodiff, &y_autodiff);
 
+    EXPECT_TRUE(constraint.CheckSatisfied(q));
+    EXPECT_TRUE(constraint.CheckSatisfied(q_autodiff));
     EXPECT_EQ(y_double(0), 0);
     EXPECT_TRUE(CompareMatrices(y_autodiff(0).derivatives(),
                                 Eigen::Matrix<double, 14, 1>::Zero()));
     CheckMinimumDistanceConstraintEval(constraint, q_autodiff, *plant_autodiff_,
-                                       plant_context_autodiff_, 1E-12,
-                                       penalty_type);
+                                       plant_context_autodiff_, 1E-12);
   }
 
-  void CheckConstraintEvalSmallerThanMinimumDistance(
+  void CheckConstraintEvalBetweenMinimumAndThresholdDistance(
       const MinimumDistanceConstraint& constraint, const Eigen::Vector3d& p_WB1,
-      const Eigen::Vector3d& p_WB2, PenaltyType penalty_type) const {
-    // distance smaller than the minimum_distance, we can compute the penalty
-    // and the gradient by hand.
+      const Eigen::Vector3d p_WB2) const {
     const Eigen::Quaterniond sphere1_quaternion(1, 0, 0, 0);
     const Eigen::Quaterniond sphere2_quaternion(1, 0, 0, 0);
     Eigen::Matrix<double, 14, 1> q;
     q << QuaternionToVectorWxyz(sphere1_quaternion), p_WB1,
         QuaternionToVectorWxyz(sphere2_quaternion), p_WB2;
-    const Eigen::Vector3d p_WS1 = ComputeCollisionSphereCenterPosition(
-        p_WB1, sphere1_quaternion, X_B1S1_);
-    const Eigen::Vector3d p_WS2 = ComputeCollisionSphereCenterPosition(
-        p_WB2, sphere2_quaternion, X_B2S2_);
-    const double distance_expected =
-        (p_WS1 - p_WS2).norm() - radius1_ - radius2_;
     Eigen::VectorXd y_double(1);
     constraint.Eval(q, &y_double);
-    const double penalty_expected =
-        Penalty(distance_expected, constraint.minimum_distance(), penalty_type);
-    const double tol{5 * kEps};
-    EXPECT_NEAR(y_double(0), penalty_expected, tol);
-    // Test with a non-ideneity gradient.
-    Eigen::Matrix<double, 14, Eigen::Dynamic> dqdz(14, 2);
-    for (int i = 0; i < 14; ++i) {
-      dqdz(i, 0) = i;
-      dqdz(i, 1) = i + 1;
-    }
-    Eigen::Matrix<AutoDiffXd, 14, 1> q_autodiff =
-        math::initializeAutoDiffGivenGradientMatrix(q, dqdz);
-    Vector3<AutoDiffXd> p_WB1_autodiff = q_autodiff.segment<3>(4);
-    Vector3<AutoDiffXd> p_WB2_autodiff = q_autodiff.segment<3>(11);
-    Quaternion<AutoDiffXd> quat_WB1_autodiff(q_autodiff(0), q_autodiff(1),
-                                             q_autodiff(2), q_autodiff(3));
-    Quaternion<AutoDiffXd> quat_WB2_autodiff(q_autodiff(7), q_autodiff(8),
-                                             q_autodiff(9), q_autodiff(10));
-    Vector3<AutoDiffXd> p_WS1_autodiff = ComputeCollisionSphereCenterPosition(
-        p_WB1_autodiff, quat_WB1_autodiff, X_B1S1_);
-    Vector3<AutoDiffXd> p_WS2_autodiff = ComputeCollisionSphereCenterPosition(
-        p_WB2_autodiff, quat_WB2_autodiff, X_B2S2_);
-    const AutoDiffXd distance_autodiff =
-        (p_WS1_autodiff - p_WS2_autodiff).norm() - AutoDiffXd(radius1_) -
-        AutoDiffXd(radius2_);
-    const AutoDiffXd penalty_autodiff =
-        Penalty(distance_autodiff, constraint.minimum_distance(), penalty_type);
-    AutoDiffVecXd y_autodiff;
+    Eigen::Matrix<AutoDiffXd, 14, 1> q_autodiff = math::initializeAutoDiff(q);
+    AutoDiffVecXd y_autodiff(1);
     constraint.Eval(q_autodiff, &y_autodiff);
-    // The exponential penalty function -x * e^{1/x} can introduce relatively
-    // large numerical error, when the distance is close to minimum_distance (
-    // namely when x is close to 0).
-    const double gradient_tol = 6E-12;
-    EXPECT_TRUE(CompareMatrices(y_autodiff(0).derivatives(),
-                                penalty_autodiff.derivatives(), gradient_tol));
-    // Now evaluate the constraint using autodiff from start.
+
+    EXPECT_TRUE(constraint.CheckSatisfied(q));
+    EXPECT_TRUE(constraint.CheckSatisfied(q_autodiff));
+    // Check that the value is strictly greater than 0.
+    EXPECT_GT(y_double(0), 0);
     CheckMinimumDistanceConstraintEval(constraint, q_autodiff, *plant_autodiff_,
-                                       plant_context_autodiff_, gradient_tol,
-                                       penalty_type);
+                                       plant_context_autodiff_, 1E-12);
   }
 
-  void CheckConstraintEval(const MinimumDistanceConstraint& constraint,
-                           PenaltyType penalty_type) {
-    // Distance between the spheres are larger than minimum_distance
+  void CheckConstraintEvalSmallerThanMinimumDistance(
+      const MinimumDistanceConstraint& constraint, const Eigen::Vector3d& p_WB1,
+      const Eigen::Vector3d p_WB2) const {
+    const Eigen::Quaterniond sphere1_quaternion(1, 0, 0, 0);
+    const Eigen::Quaterniond sphere2_quaternion(1, 0, 0, 0);
+    Eigen::Matrix<double, 14, 1> q;
+    q << QuaternionToVectorWxyz(sphere1_quaternion), p_WB1,
+        QuaternionToVectorWxyz(sphere2_quaternion), p_WB2;
+    Eigen::VectorXd y_double(1);
+    constraint.Eval(q, &y_double);
+    Eigen::Matrix<AutoDiffXd, 14, 1> q_autodiff = math::initializeAutoDiff(q);
+    AutoDiffVecXd y_autodiff(1);
+    constraint.Eval(q_autodiff, &y_autodiff);
+
+    EXPECT_FALSE(constraint.CheckSatisfied(q));
+    EXPECT_FALSE(constraint.CheckSatisfied(q_autodiff));
+    // Check that the value is strictly greater than 1.
+    EXPECT_GT(y_double(0), 1);
+    CheckMinimumDistanceConstraintEval(constraint, q_autodiff, *plant_autodiff_,
+                                       plant_context_autodiff_, 1E-12);
+  }
+
+  void CheckConstraintEval(const MinimumDistanceConstraint& constraint) {
+    // Distance between the spheres is larger than threshold_distance
     Eigen::Vector3d p_WB1(0.2, 1.2, 0.3);
     Eigen::Vector3d p_WB2(1.2, -0.4, 2.3);
-    CheckConstraintEvalLargerThanMinimumDistance(constraint, p_WB1, p_WB2,
-                                                 penalty_type);
+    CheckConstraintEvalLargerThanThresholdDistance(constraint, p_WB1, p_WB2);
+
+    // Distance between the spheres is larger than minimum_distance but less
+    // than threshold_distance
+    p_WB1 << 0.1, 0.2, 0.3;
+    p_WB2 = p_WB1 + Eigen::Vector3d(1.0 / 3, 2.0 / 3, 2.0 / 3) *
+                        (radius1_ + radius2_ +
+                         0.5 * (constraint.threshold_distance() +
+                                constraint.minimum_distance()));
+    CheckConstraintEvalBetweenMinimumAndThresholdDistance(constraint, p_WB1,
+                                                          p_WB2);
 
     // Two spheres are colliding.
     p_WB1 << 0.1, 0.2, 0.3;
     p_WB2 << 0.11, 0.21, 0.31;
-    CheckConstraintEvalSmallerThanMinimumDistance(constraint, p_WB1, p_WB2,
-                                                  penalty_type);
+    CheckConstraintEvalSmallerThanMinimumDistance(constraint, p_WB1, p_WB2);
 
     // Two spheres are separated, but their distance is smaller than
     // minimum_distance.
@@ -253,8 +151,7 @@ class TwoFreeSpheresMinimumDistanceTest : public TwoFreeSpheresTest {
             Eigen::Vector3d(1.0 / 3, 2.0 / 3, 2.0 / 3) *
                 (radius1_ + radius2_ + 0.5 * constraint.minimum_distance());
 
-    CheckConstraintEvalSmallerThanMinimumDistance(constraint, p_WB1, p_WB2,
-                                                  penalty_type);
+    CheckConstraintEvalSmallerThanMinimumDistance(constraint, p_WB1, p_WB2);
   }
 };
 
@@ -265,7 +162,7 @@ TEST_F(TwoFreeSpheresMinimumDistanceTest, ExponentialPenalty) {
                                              ExponentiallySmoothedHingeLoss);
   CheckConstraintBounds(constraint);
 
-  CheckConstraintEval(constraint, PenaltyType::kExponential);
+  CheckConstraintEval(constraint);
 }
 
 TEST_F(TwoFreeSpheresMinimumDistanceTest, QuadraticallySmoothedHingePenalty) {
@@ -276,7 +173,7 @@ TEST_F(TwoFreeSpheresMinimumDistanceTest, QuadraticallySmoothedHingePenalty) {
 
   CheckConstraintBounds(constraint);
 
-  CheckConstraintEval(constraint, PenaltyType::kQuadratic);
+  CheckConstraintEval(constraint);
 }
 
 GTEST_TEST(MinimumDistanceConstraintTest,
@@ -292,15 +189,28 @@ GTEST_TEST(MinimumDistanceConstraintTest,
       "SceneGraph.");
 }
 
-TEST_F(TwoFreeSpheresTest, NonpositiveMinimalDistance) {
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      MinimumDistanceConstraint(plant_double_, 0, plant_context_double_),
-      std::invalid_argument,
-      "MinimumDistanceConstraint: minimum_distance should be positive.");
+TEST_F(TwoFreeSpheresTest, NegativeMinimumDistance) {
+  EXPECT_NO_THROW(
+      MinimumDistanceConstraint(plant_double_, 0, plant_context_double_));
   DRAKE_EXPECT_THROWS_MESSAGE(
       MinimumDistanceConstraint(plant_double_, -0.1, plant_context_double_),
       std::invalid_argument,
-      "MinimumDistanceConstraint: minimum_distance should be positive.");
+      "MinimumDistanceConstraint: minimum_distance should be non-negative.");
+}
+
+TEST_F(TwoFreeSpheresTest, ThresholdDistanceNotGreaterThanMinimumDistance) {
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      MinimumDistanceConstraint(plant_double_, 0.1, plant_context_double_,
+                                QuadraticallySmoothedHingeLoss, 0.1),
+      std::invalid_argument,
+      "MinimumDistanceConstraint: threshold_distance should be greater than "
+      "minimum_distance.");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      MinimumDistanceConstraint(plant_double_, 0.1, plant_context_double_,
+                                QuadraticallySmoothedHingeLoss, 0.05),
+      std::invalid_argument,
+      "MinimumDistanceConstraint: threshold_distance should be greater than "
+      "minimum_distance.");
 }
 
 template <typename T>
@@ -317,31 +227,24 @@ T BoxSphereSignedDistance(const Eigen::Vector3d& box_size, double radius,
 
 TEST_F(BoxSphereTest, Test) {
   const double minimum_distance = 0.01;
-  for (PenaltyType penalty_type :
-       {PenaltyType::kQuadratic, PenaltyType::kExponential}) {
-    MinimumDistancePenaltyFunction penalty_function =
-        penalty_type == PenaltyType::kQuadratic
-            ? QuadraticallySmoothedHingeLoss
-            : ExponentiallySmoothedHingeLoss;
+  for (MinimumDistancePenaltyFunction penalty_function :
+       {QuadraticallySmoothedHingeLoss, ExponentiallySmoothedHingeLoss}) {
     MinimumDistanceConstraint constraint(plant_double_, minimum_distance,
                                          plant_context_double_,
                                          penalty_function);
 
-    auto check_eval_autodiff = [&minimum_distance, &constraint, penalty_type](
-        const Eigen::VectorXd& q_val, const Eigen::MatrixXd& q_gradient,
-        double tol, const Eigen::Vector3d& box_size, double radius) {
-      AutoDiffVecXd x_autodiff =
-          math::initializeAutoDiffGivenGradientMatrix(q_val, q_gradient);
+    auto check_eval_autodiff =
+        [&constraint, this](const Eigen::VectorXd& q_val,
+                            const Eigen::MatrixXd& q_gradient, double tol,
+                            const Eigen::Vector3d& box_size, double radius) {
+          AutoDiffVecXd x_autodiff =
+              math::initializeAutoDiffGivenGradientMatrix(q_val, q_gradient);
 
-      AutoDiffVecXd y_autodiff;
-      constraint.Eval(x_autodiff, &y_autodiff);
+          CheckMinimumDistanceConstraintEval(constraint, x_autodiff,
+                                             *plant_autodiff_,
+                                             plant_context_autodiff_, tol);
+        };
 
-      auto distance = BoxSphereSignedDistance(box_size, radius, x_autodiff);
-      CompareAutoDiffVectors(y_autodiff,
-                             Vector1<AutoDiffXd>(Penalty(
-                                 distance, minimum_distance, penalty_type)),
-                             tol);
-    };
     Eigen::VectorXd q(14);
     // First check q with normalized quaternion.
     q.head<4>() = Eigen::Vector4d(1, 0, 0, 0);


### PR DESCRIPTION
This makes the constraint play more nicely with solvers. The reformulation also
adds a separate threshold_distance to control when collision pairs are ignored,
and allows the user to specify minimum_distance <= 0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11461)
<!-- Reviewable:end -->
