### PR TITLE
[render] Implementation of VTK-based RenderEngine (take 2)

### DIFF
--- a/geometry/render/BUILD.bazel
+++ b/geometry/render/BUILD.bazel
@@ -14,6 +14,7 @@ drake_cc_package_library(
     name = "render",
     deps = [
         ":render_engine",
+        ":render_engine_vtk",
         ":render_label",
         ":render_label_class",
         ":render_label_manager",
@@ -38,6 +39,39 @@ drake_cc_library(
         "//math:geometric_transform",
         "//systems/sensors:color_palette",
         "//systems/sensors:image",
+    ],
+)
+
+# The VTK-OpenGL-based render engine implementation.
+drake_cc_library(
+    name = "render_engine_vtk",
+    srcs = [
+        "render_engine_vtk.cc",
+        "render_engine_vtk_factory.cc",
+    ],
+    hdrs = [
+        "render_engine_vtk.h",
+        "render_engine_vtk_factory.h",
+    ],
+    # render_engine_vtk.h directly pulls in VTK headers; leave it out of the
+    # install.
+    install_hdrs_exclude = ["render_engine_vtk.h"],
+    deps = [
+        ":render_engine",
+        "//common",
+        "//geometry/render/shaders:depth_shaders",
+        "//systems/sensors:color_palette",
+        "//systems/sensors:vtk_util",
+        "@eigen",
+        "@vtk//:vtkCommonCore",
+        "@vtk//:vtkCommonDataModel",
+        "@vtk//:vtkCommonTransforms",
+        "@vtk//:vtkFiltersGeneral",
+        "@vtk//:vtkFiltersSources",
+        "@vtk//:vtkIOGeometry",
+        "@vtk//:vtkIOImage",
+        "@vtk//:vtkRenderingCore",
+        "@vtk//:vtkRenderingOpenGL2",
     ],
 )
 

--- a/geometry/render/render_engine_vtk.cc
+++ b/geometry/render/render_engine_vtk.cc
@@ -1,0 +1,552 @@
+#include "drake/geometry/render/render_engine_vtk.h"
+
+#include <limits>
+#include <utility>
+
+#include <vtkCamera.h>
+#include <vtkCubeSource.h>
+#include <vtkCylinderSource.h>
+#include <vtkOBJReader.h>
+#include <vtkOpenGLPolyDataMapper.h>
+#include <vtkOpenGLTexture.h>
+#include <vtkPNGReader.h>
+#include <vtkPlaneSource.h>
+#include <vtkProperty.h>
+#include <vtkSphereSource.h>
+#include <vtkTransform.h>
+#include <vtkTransformPolyDataFilter.h>
+
+#include "drake/geometry/render/shaders/depth_shaders.h"
+#include "drake/systems/sensors/color_palette.h"
+#include "drake/systems/sensors/vtk_util.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+
+using Eigen::Vector4d;
+using std::make_unique;
+using math::RigidTransformd;
+using systems::sensors::ColorD;
+using systems::sensors::ColorI;
+using systems::sensors::ImageDepth32F;
+using systems::sensors::ImageLabel16I;
+using systems::sensors::ImageRgba8U;
+using systems::sensors::InvalidDepth;
+using systems::sensors::vtk_util::ConvertToVtkTransform;
+using systems::sensors::vtk_util::CreateSquarePlane;
+using systems::sensors::vtk_util::MakeVtkPointerArray;
+
+namespace {
+
+// A note on OpenGL clipping planes and DepthCameraProperties near and far.
+// The z near and far planes reported in DepthCameraProperties are properties of
+// the modeled sensor. They cannot produce reliable depths closer than z_near
+// or farther than z_far.
+// We *could* set the OpenGl clipping planes to [z_near, z_far], however, that
+// will lead to undesirable artifacts. Any geometry that lies at a distance
+// in the range [0, z_near) would be clipped away with *no* occluding effects.
+// So, instead, we render the depth image in the range [epsilon, z_far] and
+// then detect the occluding pixels that lie closer than the camera's supported
+// range and mark them as too close. Clipping all geometry beyond z_far is not
+// a problem because they can unambiguously be marked as too far.
+const double kClippingPlaneNear = 0.01;
+const double kTerrainSize = 100.;
+
+void SetModelTransformMatrixToVtkCamera(
+    vtkCamera* camera, const vtkSmartPointer<vtkTransform>& X_WC) {
+  // vtkCamera contains a transformation as the internal state and
+  // ApplyTransform multiplies a given transformation on top of the internal
+  // transformation. Thus, resetting 'Set{Position, FocalPoint, ViewUp}' is
+  // needed here.
+  camera->SetPosition(0., 0., 0.);
+  camera->SetFocalPoint(0., 0., 1.);  // Sets z-forward.
+  camera->SetViewUp(0., -1, 0.);  // Sets y-down. For the detail, please refer
+  // to CameraInfo's document.
+  camera->ApplyTransform(X_WC);
+}
+
+float CheckRangeAndConvertToMeters(float z_buffer_value, double z_near,
+                                   double z_far) {
+  const double kA = z_far - kClippingPlaneNear;
+  // Initialize with the assumption that the buffer value is outside the range
+  // [kClippingPlaneNear, z_far]. If the buffer value is *not* 1,
+  // then it lies inside the range.
+  float z = std::numeric_limits<float>::quiet_NaN();
+  if (z_buffer_value != 1.f) {
+    z = static_cast<float>(z_buffer_value * kA + kClippingPlaneNear);
+    // TODO(SeanCurtis-TRI): This is now slightly strange; the OpenGL clipping
+    //  plane is being set to the camera's z_far; we should never get a value
+    //  greater than that. Clean this up. Ideally, do more in the shader.
+    if (z > z_far) {
+      z = InvalidDepth::kTooFar;
+    } else if (z < z_near) {
+      z = InvalidDepth::kTooClose;
+    }
+  }
+  return z;
+}
+
+enum ImageType {
+  kColor = 0,
+  kLabel = 1,
+  kDepth = 2,
+};
+
+// TODO(SeanCurtis-TRI): Add X_PG pose to this data.
+// A package of data required to register a visual geometry.
+struct RegistrationData {
+  const PerceptionProperties& properties;
+  const RigidTransformd& X_FG;
+};
+
+}  // namespace
+
+namespace internal {
+
+ShaderCallback::ShaderCallback() :
+    z_near_(kClippingPlaneNear),
+    // This value will be overwritten by the camera's z_far value.
+    z_far_(100.0) {}
+
+}  // namespace internal
+
+vtkNew<internal::ShaderCallback> RenderEngineVtk::uniform_setting_callback_;
+
+RenderEngineVtk::RenderEngineVtk(const RenderEngineVtkParams& parameters)
+    : RenderEngine(parameters.default_label ? *parameters.default_label
+                                            : RenderLabel::kUnspecified),
+      pipelines_{{make_unique<RenderingPipeline>(),
+                  make_unique<RenderingPipeline>(),
+                  make_unique<RenderingPipeline>()}} {
+  if (parameters.default_diffuse) {
+    default_diffuse_ = *parameters.default_diffuse;
+  }
+
+  InitializePipelines();
+}
+
+void RenderEngineVtk::UpdateViewpoint(const RigidTransformd& X_WC) const {
+  vtkSmartPointer<vtkTransform> vtk_X_WC = ConvertToVtkTransform(X_WC);
+
+  for (const auto& pipeline : pipelines_) {
+    auto camera = pipeline->renderer->GetActiveCamera();
+    SetModelTransformMatrixToVtkCamera(camera, vtk_X_WC);
+  }
+}
+
+void RenderEngineVtk::RenderColorImage(const CameraProperties& camera,
+                                       bool show_window,
+                                       ImageRgba8U* color_image_out) const {
+  UpdateWindow(camera, show_window, pipelines_[ImageType::kColor].get(),
+               "Color Image");
+  PerformVtkUpdate(*pipelines_[ImageType::kColor]);
+
+  // TODO(SeanCurtis-TRI): Determine if this copies memory (and find some way
+  // around copying).
+  pipelines_[ImageType::kColor]->exporter->Export(color_image_out->at(0, 0));
+}
+
+void RenderEngineVtk::RenderDepthImage(const DepthCameraProperties& camera,
+                                       ImageDepth32F* depth_image_out) const {
+  UpdateWindow(camera, pipelines_[ImageType::kDepth].get());
+  PerformVtkUpdate(*pipelines_[ImageType::kDepth]);
+
+  // TODO(SeanCurtis-TRI): This copies the image and *that's* a tragedy. It
+  // would be much better to process the pixels directly. The solution is to
+  // simply call exporter->GetPointerToData() and process the pixels myself.
+  // See the implementation in vtkImageExport::Export() for details.
+  ImageRgba8U image(camera.width, camera.height);
+  pipelines_[ImageType::kDepth]->exporter->Export(image.at(0, 0));
+
+  for (int v = 0; v < camera.height; ++v) {
+    for (int u = 0; u < camera.width; ++u) {
+      if (image.at(u, v)[0] == 255u &&
+          image.at(u, v)[1] == 255u &&
+          image.at(u, v)[2] == 255u) {
+        depth_image_out->at(u, v)[0] = InvalidDepth::kTooFar;
+      } else {
+        // Decoding three channel color values to a float value. For the detail,
+        // see depth_shaders.h.
+        float shader_value = image.at(u, v)[0] + image.at(u, v)[1] / 255. +
+                             image.at(u, v)[2] / (255. * 255.);
+
+        // Dividing by 255 so that the range gets to be [0, 1].
+        shader_value /= 255.f;
+        // TODO(kunimatsu-tri) Calculate this in a vertex shader.
+        depth_image_out->at(u, v)[0] =
+            CheckRangeAndConvertToMeters(shader_value, camera.z_near,
+                                         camera.z_far);
+      }
+    }
+  }
+}
+
+void RenderEngineVtk::RenderLabelImage(const CameraProperties& camera,
+                                       bool show_window,
+                                       ImageLabel16I* label_image_out) const {
+  UpdateWindow(camera, show_window, pipelines_[ImageType::kLabel].get(),
+               "Label Image");
+  PerformVtkUpdate(*pipelines_[ImageType::kLabel]);
+
+  // TODO(SeanCurtis-TRI): This copies the image and *that's* a tragedy. It
+  // would be much better to process the pixels directly. The solution is to
+  // simply call exporter->GetPointerToData() and process the pixels myself.
+  // See the implementation in vtkImageExport::Export() for details.
+  ImageRgba8U image(camera.width, camera.height);
+  pipelines_[ImageType::kLabel]->exporter->Export(image.at(0, 0));
+
+  ColorI color;
+  for (int v = 0; v < camera.height; ++v) {
+    for (int u = 0; u < camera.width; ++u) {
+      color.r = image.at(u, v)[0];
+      color.g = image.at(u, v)[1];
+      color.b = image.at(u, v)[2];
+      label_image_out->at(u, v)[0] = RenderEngine::LabelFromColor(color);
+    }
+  }
+}
+
+void RenderEngineVtk::ImplementGeometry(const Sphere& sphere, void* user_data) {
+  vtkNew<vtkSphereSource> vtk_sphere;
+  vtk_sphere->SetRadius(sphere.get_radius());
+  // TODO(SeanCurtis-TRI): Provide control for smoothness/tessellation.
+  vtk_sphere->SetThetaResolution(50);
+  vtk_sphere->SetPhiResolution(50);
+  ImplementGeometry(vtk_sphere.GetPointer(), user_data);
+}
+
+void RenderEngineVtk::ImplementGeometry(const Cylinder& cylinder,
+                                        void* user_data) {
+  vtkNew<vtkCylinderSource> vtk_cylinder;
+  vtk_cylinder->SetHeight(cylinder.get_length());
+  vtk_cylinder->SetRadius(cylinder.get_radius());
+  // TODO(SeanCurtis-TRI): Provide control for smoothness/tessellation.
+  vtk_cylinder->SetResolution(50);
+
+  // Since the cylinder in vtkCylinderSource is y-axis aligned, we need
+  // to rotate it to be z-axis aligned because that is what Drake uses.
+  vtkNew<vtkTransform> transform;
+  transform->RotateX(90);
+  vtkNew<vtkTransformPolyDataFilter> transform_filter;
+  transform_filter->SetInputConnection(vtk_cylinder->GetOutputPort());
+  transform_filter->SetTransform(transform.GetPointer());
+  transform_filter->Update();
+
+  ImplementGeometry(transform_filter.GetPointer(), user_data);
+}
+
+void RenderEngineVtk::ImplementGeometry(const HalfSpace&,
+                                        void* user_data) {
+  vtkSmartPointer<vtkPlaneSource> vtk_plane = CreateSquarePlane(kTerrainSize);
+
+  ImplementGeometry(vtk_plane.GetPointer(), user_data);
+}
+
+void RenderEngineVtk::ImplementGeometry(const Box& box, void* user_data) {
+  vtkNew<vtkCubeSource> cube;
+  cube->SetXLength(box.width());
+  cube->SetYLength(box.depth());
+  cube->SetZLength(box.height());
+  ImplementGeometry(cube.GetPointer(), user_data);
+}
+
+void RenderEngineVtk::ImplementGeometry(const Mesh& mesh, void* user_data) {
+  ImplementObj(mesh.filename(), mesh.scale(), user_data);
+}
+
+void RenderEngineVtk::ImplementGeometry(const Convex& convex, void* user_data) {
+  ImplementObj(convex.filename(), convex.scale(), user_data);
+}
+
+optional<RenderIndex> RenderEngineVtk::DoRegisterVisual(
+    const Shape& shape, const PerceptionProperties& properties,
+    const RigidTransformd& X_FG) {
+  // Note: the user_data interface on reification requires a non-const pointer.
+  RegistrationData data{properties, X_FG};
+  shape.Reify(this, &data);
+  return RenderIndex(static_cast<int>(actors_.size()) - 1);
+}
+
+void RenderEngineVtk::DoUpdateVisualPose(RenderIndex index,
+                                         const RigidTransformd& X_WG) {
+  vtkSmartPointer<vtkTransform> vtk_X_WG = ConvertToVtkTransform(X_WG);
+  // TODO(SeanCurtis-TRI): Provide the ability to specify specific actors; i.e.
+  // only update the visual actor or only the label actor, etc.
+  for (const auto& actor : actors_.at(index)) {
+    actor->SetUserTransform(vtk_X_WG);
+  }
+}
+
+optional<RenderIndex> RenderEngineVtk::DoRemoveGeometry(RenderIndex index) {
+  DRAKE_DEMAND(index >= 0 && index < actors_.size());
+  for (int i = 0; i < kNumPipelines; ++i) {
+    // If the label actor hasn't been added to its renderer, this is a no-op.
+    pipelines_[i]->renderer->RemoveActor(actors_[index][i]);
+  }
+  optional<RenderIndex> moved_index{};
+  RenderIndex last_index{static_cast<int>(actors_.size()) - 1};
+  if (index < last_index) {
+    moved_index = last_index;
+    std::swap(actors_[index], actors_[last_index]);
+    actors_.pop_back();
+  }
+  return moved_index;
+}
+
+std::unique_ptr<RenderEngine> RenderEngineVtk::DoClone() const {
+  return std::unique_ptr<RenderEngineVtk>(new RenderEngineVtk(*this));
+}
+
+RenderEngineVtk::RenderEngineVtk(const RenderEngineVtk& other)
+    : RenderEngine(other),
+      pipelines_{{make_unique<RenderingPipeline>(),
+                  make_unique<RenderingPipeline>(),
+                  make_unique<RenderingPipeline>()}} {
+  InitializePipelines();
+
+  // Utility function for creating a cloned actor which *shares* the same
+  // underlying polygonal data.
+  auto clone_actor_array = [this](
+      const std::array<vtkSmartPointer<vtkActor>, kNumPipelines>& source_actors,
+      std::array<vtkSmartPointer<vtkActor>, kNumPipelines>* clone_actors_ptr) {
+    DRAKE_DEMAND(clone_actors_ptr != nullptr);
+    std::array<vtkSmartPointer<vtkActor>, kNumPipelines>& clone_actors =
+        *clone_actors_ptr;
+    for (int i = 0; i < kNumPipelines; ++i) {
+      // NOTE: source *should* be const; but none of the getters on the source
+      // are const-compatible.
+      DRAKE_DEMAND(source_actors[i]);
+      DRAKE_DEMAND(clone_actors[i]);
+      vtkActor& source = *source_actors[i];
+      vtkActor& clone = *clone_actors[i];
+
+      // Label actors only conditionally get tied into the pipeline (i.e., they
+      // can be tagged with the kDoNotRender label). This condition can be
+      // detected because the source actor has no mapper. Therefore, no
+      // configuration actions are required and it should _not_ be added to
+      // the pipeline's renderer.
+      if (source.GetMapper()) {
+        clone.GetProperty()->SetColor(source.GetProperty()->GetColor());
+
+        // NOTE: The clone renderer and original renderer *share* polygon data.
+        // If the meshes were *deformable* this would be invalid. Furthermore,
+        // even if dynamic adding/removing of geometry were valid, VTK's
+        // reference counting preserves the underlying geometry in the
+        // copy that still references it.
+        clone.SetMapper(source.GetMapper());
+        clone.SetUserTransform(source.GetUserTransform());
+        // This is necessary because *terrain* has its lighting turned off. To
+        // blindly handle arbitrary actors being flagged as terrain, we need to
+        // treat all actors this way.
+        clone.GetProperty()->SetLighting(source.GetProperty()->GetLighting());
+
+        pipelines_.at(i)->renderer.Get()->AddActor(&clone);
+      }
+    }
+  };
+
+  for (size_t a = 0; a < other.actors_.size(); ++a) {
+    std::array<vtkSmartPointer<vtkActor>, kNumPipelines> actors{
+        vtkSmartPointer<vtkActor>::New(), vtkSmartPointer<vtkActor>::New(),
+        vtkSmartPointer<vtkActor>::New()};
+    clone_actor_array(other.actors_.at(a), &actors);
+    actors_.emplace_back(actors);
+  }
+
+  // Copy camera properties
+  auto copy_cameras = [](auto src_renderer, auto dst_renderer) {
+    dst_renderer->GetActiveCamera()->DeepCopy(
+        src_renderer->GetActiveCamera());
+  };
+  for (int p = 0; p < kNumPipelines; ++p) {
+    copy_cameras(other.pipelines_.at(p)->renderer.Get(),
+                 pipelines_.at(p)->renderer.Get());
+  }
+}
+
+void RenderEngineVtk::InitializePipelines() {
+  const ColorD sky_color =
+      RenderEngine::GetColorDFromLabel(RenderLabel::kEmpty);
+  const vtkSmartPointer<vtkTransform> vtk_identity =
+      ConvertToVtkTransform(RigidTransformd::Identity());
+
+  // Generic configuration of pipelines.
+  for (auto& pipeline : pipelines_) {
+    // Multisampling disabled by design for label and depth. It's turned off for
+    // color because of a bug which affects on-screen rendering with NVidia
+    // drivers on Ubuntu 16.04. In certain very specific
+    // cases (camera position, scene, triangle drawing order, normal
+    // orientation), a plane surface has partial background pixels
+    // bleeding through it, which changes the color of the center pixel.
+    // TODO(fbudin69500) If lack of anti-aliasing in production code is
+    // problematic, change this to only disable anti-aliasing in unit
+    // tests. Alternatively, find other way to resolve the driver bug.
+    pipeline->window->SetMultiSamples(0);
+
+    pipeline->renderer->SetBackground(sky_color.r, sky_color.g, sky_color.b);
+    auto camera = pipeline->renderer->GetActiveCamera();
+    camera->SetViewAngle(90.0);  // Default to an arbitrary 90° field of view.
+    // Initialize far plane to arbitrary value. In the case of depth it will be
+    // overwritten by the depth camera's z-far value.
+    // TODO(SeanCurtis-TRI): Provide mechanism where user can set this value.
+    //  It's important to expose this as it will affect the efficacy of the
+    //  z-buffer.
+    camera->SetClippingRange(kClippingPlaneNear, 100.0);
+    SetModelTransformMatrixToVtkCamera(camera, vtk_identity);
+
+    pipeline->window->AddRenderer(pipeline->renderer.GetPointer());
+    pipeline->filter->SetInput(pipeline->window.GetPointer());
+    pipeline->filter->SetScale(1);
+    pipeline->filter->ReadFrontBufferOff();
+    pipeline->filter->SetInputBufferTypeToRGBA();
+    pipeline->exporter->SetInputData(pipeline->filter->GetOutput());
+    pipeline->exporter->ImageLowerLeftOff();
+  }
+
+  // Pipeline-specific tweaks.
+
+  // Depth image background color is white -- the representation of the maximum
+  // distance (e.g., infinity).
+  pipelines_[ImageType::kDepth]->renderer->SetBackground(1., 1., 1.);
+
+  pipelines_[ImageType::kColor]->renderer->SetUseDepthPeeling(1);
+  pipelines_[ImageType::kColor]->renderer->UseFXAAOn();
+}
+
+void RenderEngineVtk::ImplementObj(const std::string& file_name, double scale,
+                                   void* user_data) {
+  vtkNew<vtkOBJReader> mesh_reader;
+  mesh_reader->SetFileName(file_name.c_str());
+  mesh_reader->Update();
+
+  vtkNew<vtkTransform> transform;
+  // TODO(SeanCurtis-TRI): Should I be allowing only isotropic scale.
+  // TODO(SeanCurtis-TRI): Only add the transform filter if scale is not all 1.
+  transform->Scale(scale, scale, scale);
+  vtkNew<vtkTransformPolyDataFilter> transform_filter;
+  transform_filter->SetInputConnection(mesh_reader->GetOutputPort());
+  transform_filter->SetTransform(transform.GetPointer());
+  transform_filter->Update();
+
+  ImplementGeometry(transform_filter.GetPointer(), user_data);
+}
+
+void RenderEngineVtk::ImplementGeometry(vtkPolyDataAlgorithm* source,
+                                        void* user_data) {
+  DRAKE_DEMAND(user_data != nullptr);
+
+  std::array<vtkSmartPointer<vtkActor>, kNumPipelines> actors{
+      vtkSmartPointer<vtkActor>::New(), vtkSmartPointer<vtkActor>::New(),
+      vtkSmartPointer<vtkActor>::New()};
+  // Note: the mappers ultimately get referenced by the actors, so they do _not_
+  // get destroyed when this array goes out of scope.
+  std::array<vtkNew<vtkOpenGLPolyDataMapper>, kNumPipelines> mappers;
+
+  // Sets vertex and fragment shaders only to the depth mapper.
+  mappers[ImageType::kDepth]->SetVertexShaderCode(shaders::kDepthVS);
+  mappers[ImageType::kDepth]->SetFragmentShaderCode(shaders::kDepthFS);
+  mappers[ImageType::kDepth]->AddObserver(
+      vtkCommand::UpdateShaderEvent, uniform_setting_callback_.Get());
+
+  for (auto& mapper : mappers) {
+    mapper->SetInputConnection(source->GetOutputPort());
+  }
+
+  const RegistrationData& data =
+      *reinterpret_cast<RegistrationData*>(user_data);
+
+  // If the geometry is anchored, X_FG = X_WG so I'm setting the pose for
+  // anchored geometry -- for all other values of F, it is dynamic and will be
+  // re-written in the first pose update.
+  vtkSmartPointer<vtkTransform> vtk_X_PG = ConvertToVtkTransform(data.X_FG);
+
+  // Adds the actor into the specified pipeline.
+  auto connect_actor = [this, &actors, &mappers,
+                        &vtk_X_PG](ImageType image_type) {
+    actors[image_type]->SetMapper(mappers[image_type].Get());
+    actors[image_type]->SetUserTransform(vtk_X_PG);
+    pipelines_[image_type]->renderer->AddActor(actors[image_type].Get());
+  };
+
+  // Label actor.
+  const RenderLabel label = GetRenderLabelOrThrow(data.properties);
+  if (label != RenderLabel::kDoNotRender) {
+    // NOTE: We only configure the label actor if it doesn't have to "do not
+    // render" label applied. We *have* created an actor and connected it to
+    // a mapper; but otherwise, we leave it disconnected.
+    auto& label_actor = actors[ImageType::kLabel];
+    // This is to disable shadows and to get an object painted with a single
+    // color.
+    label_actor->GetProperty()->LightingOff();
+    const auto color = RenderEngine::GetColorDFromLabel(label);
+    label_actor->GetProperty()->SetColor(color.r, color.g, color.b);
+    connect_actor(ImageType::kLabel);
+  }
+
+  // Color actor.
+  auto& color_actor = actors[ImageType::kColor];
+  const std::string& diffuse_map_name =
+      data.properties.GetPropertyOrDefault<std::string>("phong", "diffuse_map",
+                                                        "");
+  std::ifstream file_exist(diffuse_map_name);
+  if (file_exist) {
+    vtkNew<vtkPNGReader> texture_reader;
+    texture_reader->SetFileName(diffuse_map_name.c_str());
+    texture_reader->Update();
+    vtkNew<vtkOpenGLTexture> texture;
+    texture->SetInputConnection(texture_reader->GetOutputPort());
+    texture->InterpolateOn();
+
+    color_actor->SetTexture(texture.Get());
+  } else {
+    const Vector4d& diffuse =
+        data.properties.GetPropertyOrDefault("phong", "diffuse",
+                                             default_diffuse_);
+    color_actor->GetProperty()->SetColor(diffuse(0), diffuse(1), diffuse(2));
+    // TODO(SeanCurtis-TRI): Make use of alpha.
+  }
+  connect_actor(ImageType::kColor);
+
+  // Depth actor; always gets wired in with no additional work.
+  connect_actor(ImageType::kDepth);
+
+  // Take ownership of the actors.
+  actors_.emplace_back(std::move(actors));
+}
+
+void RenderEngineVtk::PerformVtkUpdate(const RenderingPipeline& p) {
+  p.window->Render();
+  p.filter->Modified();
+  p.filter->Update();
+}
+
+void RenderEngineVtk::UpdateWindow(const CameraProperties& camera,
+                                   bool show_window,
+                                   const RenderingPipeline* p,
+                                   const char* name) const {
+  // NOTE: This is a horrible hack for modifying what otherwise looks like
+  // const entities.
+  p->window->SetSize(camera.width, camera.height);
+  p->window->SetOffScreenRendering(!show_window);
+  if (show_window) p->window->SetWindowName(name);
+  p->renderer->GetActiveCamera()->SetViewAngle(camera.fov_y * 180 / M_PI);
+}
+
+void RenderEngineVtk::UpdateWindow(const DepthCameraProperties& camera,
+                                   const RenderingPipeline* p) const {
+  p->renderer->GetActiveCamera()->SetClippingRange(kClippingPlaneNear,
+                                                   camera.z_far);
+
+  // See notes at the definition of kClippingPlaneNear (above) for the
+  // explanation of this value.
+  uniform_setting_callback_->set_z_near(kClippingPlaneNear);
+  uniform_setting_callback_->set_z_far(static_cast<float>(camera.z_far));
+  // Never show window for depth camera; it is a meaningless operation as the
+  // raw depth rasterization is not human consummable.
+  UpdateWindow(camera, false, p, "Depth Image");
+}
+
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/render_engine_vtk.h
+++ b/geometry/render/render_engine_vtk.h
@@ -1,0 +1,230 @@
+#pragma once
+
+#include <array>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <vtkActor.h>
+#include <vtkAutoInit.h>
+#include <vtkCommand.h>
+#include <vtkImageExport.h>
+#include <vtkNew.h>
+#include <vtkPolyDataAlgorithm.h>
+#include <vtkRenderWindow.h>
+#include <vtkRenderer.h>
+#include <vtkShaderProgram.h>
+#include <vtkSmartPointer.h>
+#include <vtkWindowToImageFilter.h>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/geometry/render/render_engine.h"
+#include "drake/geometry/render/render_engine_vtk_factory.h"
+#include "drake/geometry/render/render_label.h"
+
+#ifndef DRAKE_DOXYGEN_CXX
+// This, and the ModuleInitVtkRenderingOpenGL2, provide the basis for enabling
+// VTK's OpenGL2 infrastructure.
+VTK_AUTOINIT_DECLARE(vtkRenderingOpenGL2)
+#endif
+
+namespace drake {
+namespace geometry {
+namespace render {
+
+#ifndef DRAKE_DOXYGEN_CXX
+namespace internal {
+struct ModuleInitVtkRenderingOpenGL2 {
+  ModuleInitVtkRenderingOpenGL2(){
+    VTK_AUTOINIT_CONSTRUCT(vtkRenderingOpenGL2)
+  }
+};
+
+// A callback class for setting uniform variables used in shader programs,
+// namely z_near and z_far, when vtkCommand::UpdateShaderEvent is caught.
+// See also shaders::kDepthFS, this is where the variables are used.
+// For the detail of VTK's callback mechanism, please refer to:
+// https://www.vtk.org/doc/nightly/html/classvtkCommand.html#details
+class ShaderCallback : public vtkCommand {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ShaderCallback);
+
+  ShaderCallback();
+
+  static ShaderCallback* New() { return new ShaderCallback; }
+
+  // NOLINTNEXTLINE(runtime/int): To match pre-existing APIs.
+  void Execute(vtkObject*, unsigned long, void* callback_object) VTK_OVERRIDE {
+    vtkShaderProgram* program =
+        reinterpret_cast<vtkShaderProgram*>(callback_object);
+    program->SetUniformf("z_near", z_near_);
+    program->SetUniformf("z_far", z_far_);
+  }
+
+  void set_z_near(float z_near) {
+    z_near_ = z_near;
+  }
+
+  void set_z_far(float z_far) {
+    z_far_ = z_far;
+  }
+
+ private:
+  float z_near_{0.f};
+  float z_far_{0.f};
+};
+
+}  // namespace internal
+
+#endif  // !DRAKE_DOXYGEN_CXX
+
+/** See documentation of MakeRenderEngineVtk().  */
+class RenderEngineVtk final : public RenderEngine,
+                              private internal::ModuleInitVtkRenderingOpenGL2 {
+ public:
+  /** \name Does not allow copy, move, or assignment  */
+  //@{
+#ifdef DRAKE_DOXYGEN_CXX
+  // Note: the copy assignment operator is actually private to serve as the
+  // basis for implementing the DoClone() method.
+  RenderEngineVtk(const RenderEngineVtk&) = delete;
+#endif
+  RenderEngineVtk& operator=(const RenderEngineVtk&) = delete;
+  RenderEngineVtk(RenderEngineVtk&&) = delete;
+  RenderEngineVtk& operator=(RenderEngineVtk&&) = delete;
+  //@}}
+
+  /** Constructs the render engine from the given `parameters`.
+
+   When one of the optional parameters is omitted, the constructed value will be
+   as documented elsewhere in @ref render_engine_vtk_properties "this class".
+  */
+  RenderEngineVtk(
+      const RenderEngineVtkParams& parameters = RenderEngineVtkParams());
+
+  /** @see RenderEngine::UpdateViewpoint().  */
+  void UpdateViewpoint(const math::RigidTransformd& X_WR) const final;
+
+  /** @see RenderEngine::RenderColorImage().  */
+  void RenderColorImage(
+      const CameraProperties& camera, bool show_window,
+      systems::sensors::ImageRgba8U* color_image_out) const final;
+
+  /** @see RenderEngine::RenderDepthImage().  */
+  void RenderDepthImage(
+      const DepthCameraProperties& camera,
+      systems::sensors::ImageDepth32F* depth_image_out) const final;
+
+  /** @see RenderEngine::RenderLabelImage().  */
+  void RenderLabelImage(
+      const CameraProperties& camera, bool show_window,
+      systems::sensors::ImageLabel16I* label_image_out) const final;
+
+  /** @name    Shape reification  */
+  //@{
+  void ImplementGeometry(const Sphere& sphere, void* user_data) final;
+  void ImplementGeometry(const Cylinder& cylinder, void* user_data) final;
+  void ImplementGeometry(const HalfSpace& half_space, void* user_data) final;
+  void ImplementGeometry(const Box& box, void* user_data) final;
+  void ImplementGeometry(const Mesh& mesh, void* user_data) final;
+  void ImplementGeometry(const Convex& convex, void* user_data) final;
+  //@}
+
+  /** @name    Access the default properties
+
+   Provides access to the default values this instance of the render engine is
+   using. These values must be set at construction.  */
+  //@{
+
+  const Eigen::Vector4d& default_diffuse() const { return default_diffuse_; }
+
+  using RenderEngine::default_render_label;
+
+  // TODO(SeanCurtis-TRI): Provide a means to set the default clear color.
+
+  //@}
+
+ private:
+  // @see RenderEngine::DoRegisterVisual().
+  optional<RenderIndex> DoRegisterVisual(
+      const Shape& shape, const PerceptionProperties& properties,
+      const math::RigidTransformd& X_WG) final;
+
+  // @see RenderEngine::DoUpdateVisualPose().
+  void DoUpdateVisualPose(RenderIndex index,
+                          const math::RigidTransformd& X_WG) final;
+
+  // @see RenderEngine::DoRemoveGeometry().
+  optional<RenderIndex> DoRemoveGeometry(RenderIndex index) final;
+
+  // @see RenderEngine::DoClone().
+  std::unique_ptr<RenderEngine> DoClone() const final;
+
+  // Copy constructor for the purpose of cloning.
+  RenderEngineVtk(const RenderEngineVtk& other);
+
+  // Initializes the VTK pipelines.
+  void InitializePipelines();
+
+  // Common interface for loading an obj file -- used for both mesh and convex
+  // shapes.
+  void ImplementObj(const std::string& file_name, double scale,
+                    void* user_data);
+
+  // Performs the common setup for all shape types.
+  void ImplementGeometry(vtkPolyDataAlgorithm* source, void* user_data);
+
+  // The rendering pipeline for a single image type (color, depth, or label).
+  struct RenderingPipeline {
+    vtkNew<vtkRenderer> renderer;
+    vtkNew<vtkRenderWindow> window;
+    vtkNew<vtkWindowToImageFilter> filter;
+    vtkNew<vtkImageExport> exporter;
+  };
+
+  // Updates VTK rendering related objects including vtkRenderWindow,
+  // vtkWindowToImageFilter and vtkImageExporter, so that VTK reflects
+  // vtkActors' pose update for rendering.
+  static void PerformVtkUpdate(const RenderingPipeline& p);
+
+  // This actually modifies internal state; the pointer to a const pipeline
+  // allows mutation via the contained vtkNew pointers.
+  void UpdateWindow(const CameraProperties& camera, bool show_window,
+                    const RenderingPipeline* p, const char* name) const;
+
+  // Modifies the camera for the special case of the depth camera.
+  void UpdateWindow(const DepthCameraProperties& camera,
+                    const RenderingPipeline* p) const;
+
+  // Three pipelines: rgb, depth, and label.
+  static constexpr int kNumPipelines = 3;
+
+  std::array<std::unique_ptr<RenderingPipeline>, kNumPipelines> pipelines_;
+
+  // By design, all of the geometry is shared across clones of the render
+  // engine. This is predicated upon the idea that the geometry is *not*
+  // deformable and does *not* depend on the system's pose information.
+  // (If there is deformable geometry, it will have to be handled differently.)
+  // Having "shared geometry" means having shared vtkPolyDataAlgorithm and
+  // vtkOpenGLPolyDataMapper instances. The shader callback gets registered to
+  // the *mapper* instances, so they all, implicitly, share the same callback.
+  // Making this member static facilitates that but it does preclude the
+  // possibility of simultaneous renderings with different uniform parameters.
+  // Currently, this doesn't happen because drake isn't particularly thread safe
+  // (or executed in such a context). However, this renderer will need some
+  // formal thread safe mechanism so that it doesn't rely on that in the future.
+  // TODO(SeanCurtis-TRI): This is not threadsafe; investigate mechanisms to
+  // prevent undesirable behaviors if used in multi-threaded application.
+  static vtkNew<internal::ShaderCallback> uniform_setting_callback_;
+
+  // The collection of per-geometry actors (one actor per pipeline (color,
+  // depth, and label) indexed by the geometry's RenderIndex.
+  std::vector<std::array<vtkSmartPointer<vtkActor>, 3>> actors_;
+
+  // Obnoxious bright orange.
+  Eigen::Vector4d default_diffuse_{0.9, 0.45, 0.1, 1.0};
+};
+
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/render_engine_vtk_factory.cc
+++ b/geometry/render/render_engine_vtk_factory.cc
@@ -1,0 +1,16 @@
+#include "drake/geometry/render/render_engine_vtk_factory.h"
+
+#include "drake/geometry/render/render_engine_vtk.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+
+std::unique_ptr<RenderEngine> MakeRenderEngineVtk(
+    const RenderEngineVtkParams& params) {
+  return std::make_unique<RenderEngineVtk>(params);
+}
+
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/render_engine_vtk_factory.h
+++ b/geometry/render/render_engine_vtk_factory.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <memory>
+
+#include "drake/geometry/render/render_engine.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+
+/** Construction parameters for the RenderEngineVtk.  */
+struct RenderEngineVtkParams  {
+  /** The (optional) label to apply when none is otherwise specified.  */
+  optional<RenderLabel> default_label{};
+
+  /** The (optional) rgba color to apply to the (phong, diffuse) property when
+    none is otherwise specified. Note: currently the alpha channel is unused
+    by RenderEngineVtk.  */
+  optional<Eigen::Vector4d> default_diffuse{};
+};
+
+/** Constructs a RenderEngine implementation which uses a VTK-based OpenGL
+ renderer.
+
+ @anchor render_engine_vtk_properties
+ <h2>Geometry perception properties</h2>
+
+ This RenderEngine implementation looks for the following properties when
+ registering visual geometry, categorized by rendered image type.
+
+ <h3>RGB images</h3>
+
+ | Group name | Property Name | Required |  Property Type  | Property Description |
+ | :--------: | :-----------: | :------: | :-------------: | :------------------- |
+ |    phong   | diffuse       | no¹      | Eigen::Vector4d | The rgba² value of the object surface. |
+ |    phong   | diffuse_map   | no³      | std::string     | The path to a texture to apply to the geometry. |
+
+ ¹ If no diffuse value is given, a default rgba value will be applied. The
+   default color is a bright orange. This default value can be changed to a
+   different value at construction. <br>
+ ² WARNING: The alpha channel is currently ignored. <br>
+ ³ If no path is specified, or the file cannot be read, the diffuse rgba value
+   is used (or its default).
+
+ <h3>Depth images</h3>
+
+ No specific properties required.
+
+ <h3>Label images</h3>
+
+ | Group name | Property Name |   Required    |  Property Type  | Property Description |
+ | :--------: | :-----------: | :-----------: | :-------------: | :------------------- |
+ |   label    | id            | configurable⁴ |  RenderLabel    | The label to render into the image. |
+
+ ⁴ %RenderEngineVtk has a default render label value that is applied to any
+ geometry that doesn't have a (label, id) property at registration. If a value
+ is not explicitly specified, %RenderEngineVtk uses RenderLabel::kUnspecified
+ as this default value. It can be explicitly set upon construction. The possible
+ values for this default label and the ramifications of that choice are
+ documented @ref render_engine_default_label "here".
+
+ <h3>Geometries accepted by %RenderEngineVtk</h3>
+
+ As documented in RenderEngine::RegisterVisual(), a RenderEngine implementation
+ can use the properties found in the PerceptionProperties to determine whether
+ it _accepts_ a shape provided for registration. %RenderEngineVtk makes use of
+ defaults to accept _all_ geometries (assuming the properties pass validation,
+ e.g., render label validation).
+ <!-- TODO(SeanCurtis-TRI): Change this policy to be more selective when other
+      renderers with different properties are introduced. -->
+ */
+std::unique_ptr<RenderEngine> MakeRenderEngineVtk(
+    const RenderEngineVtkParams& params);
+
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/shaders/BUILD.bazel
+++ b/geometry/render/shaders/BUILD.bazel
@@ -1,0 +1,24 @@
+# -*- python -*-
+
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_library",
+    "drake_cc_package_library",
+)
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+package(default_visibility = ["//visibility:public"])
+
+drake_cc_package_library(
+    name = "shaders",
+    deps = [
+        ":depth_shaders",
+    ],
+)
+
+drake_cc_library(
+    name = "depth_shaders",
+    hdrs = ["depth_shaders.h"],
+)
+
+add_lint_tests()

--- a/geometry/render/shaders/depth_shaders.h
+++ b/geometry/render/shaders/depth_shaders.h
@@ -1,0 +1,108 @@
+#pragma once
+
+namespace drake {
+namespace systems {
+namespace sensors {
+namespace shaders {
+
+/// A vertex shader program for rendering depth images, which computes vertices
+/// and normals for the fragment shader program coming after.
+constexpr char kDepthVS[] =
+    "//VTK::System::Dec\n"  // Always start with this line.
+    "attribute vec4 vertexMC;\n"
+    "attribute vec3 normalMC;\n"
+    "uniform mat3 normalMatrix;\n"
+    "uniform mat4 MCDCMatrix;\n"
+    "uniform mat4 MCVCMatrix;\n"
+    "varying vec3 normalVCVSOutput;\n"
+    "varying vec4 vertexVCVSOutput;\n"
+    "attribute vec2 tcoordMC;\n"
+    "varying vec2 tcoordVCVSOutput;\n"
+    "void main () {\n"
+    "  normalVCVSOutput = normalMatrix * normalMC;\n"
+    "  tcoordVCVSOutput = tcoordMC;\n"
+    "  vertexVCVSOutput = MCVCMatrix * vertexMC;\n"
+    "  gl_Position = MCDCMatrix * vertexMC;\n"
+    "}\n";
+
+/// A fragment shader program for rendering depth images, which computes depth
+/// values for each pixel in depth images, converts them to be in range [0, 1]
+/// and packs those values to three color channels. In other words, we encode
+/// a depth image into a color image and output the color image. For the detail
+/// of packing algorithm, please refer to:
+/// https://aras-p.info/blog/2009/07/30/encoding-floats-to-rgba-the-final/
+/// Note that we are only using three channels instead of four channels to
+/// express a float value. This differs from the example code in the link above.
+/// The reason is that we need to set one to alpha channel so that the rendered
+/// "image" will be opaque. Otherwise, we will have different colors from what
+/// we output here, thus expect, in the end.
+constexpr char kDepthFS[] =
+    "//VTK::System::Dec\n"  // Always start with this line.
+    "//VTK::Output::Dec\n"  // Always have this line in your FS.
+    "varying vec3 normalVCVSOutput;\n"
+    "varying vec4 vertexVCVSOutput;\n"
+    "varying vec2 tcoordVCVSOutput;\n"
+    "out vec4 color_out;\n"
+    "uniform float z_near;\n"
+    "uniform float z_far;\n"
+    "\n"
+    "// This function splits a float value, whose range is [0, 1], to three\n"
+    "// float values, whose ranges are also [0, 1] but will eventually be\n"
+    "// converted to be [0, 255] of unsigned char. Each of the split float\n"
+    "// values holds specific decimal portion of the original float value\n"
+    "// using a bit shift operation, an integer part truncation and a bit\n"
+    "// mask operation. The maximum amount of information that each of the\n"
+    "// float value can hold is up to 8 bits which is the size of unsigned\n"
+    "// char and that is why we use a magic number 255 a lot in this\n"
+    "// function.\n"
+    "// Here we give you an example with concrete numbers using the base\n"
+    "// number 100 instead of 255 just to help you understand better:\n"
+    "// \n"
+    "// `value` = 0.123456\n"
+    "// `bit_shift` = `[1., 100., 10000.]`\n"
+    "// `bit_mask` = `[0.01, 0.01, 0]`\n"
+    "// \n"
+    "// `res` = `fract(value * bit_shift)`\n"
+    "//       = `fract(0.123456 * [1., 100., 10000.])`\n"
+    "//       = `fract([0.123456, 12.3456, 1234.56]`\n"
+    "//       = `[0.123456, 0.3456, 0.56]`\n"
+    "// \n"
+    "// `res.yzz` * `bit_mask` = `[0.3456, 0.56, 0.56]` * `[0.01, 0.01, 0]`\n"
+    "//                        = `[0.003456, 0.0056, 0]`\n"
+    "// \n"
+    "// `return` = `res` - `res.yzz` * `bit_mask`\n"
+    "//          = `[0.123456, 0.3456, 0.56]` - `[0.003456, 0.0056, 0]`\n"
+    "//          = `[0.12, 0.34, 0.56]`.\n"
+    "// \n"
+    "// To decode this value, you will simply need to calculate the reverse:\n"
+    "// \n"
+    "// i.e. `decoded = 0.12 + 0.34 * 0.01 + 0.56 * 0.0001`\n"
+    "//      `        = 0.12 + 0.0034 + 0.000056`\n"
+    "//      `        = 0.123456`.\n"
+    "vec3 PackFloatToVec3i(float value) {\n"
+    "  const vec3 bit_shift = vec3(1., 255., 255. * 255.);\n"
+    "  const float tmp = 1. / 255.;\n"
+    "  const vec3 bit_mask = vec3(tmp, tmp, 0.);\n"
+    "  vec3 res = fract(value * bit_shift);\n"
+    "  return res - (res.yzz * bit_mask);\n"
+    "}\n"
+    "\n"
+    "void main () {\n"
+    "  float z = -vertexVCVSOutput.z;  // In meters.\n"
+    "  // Converting meters to [0, 1].\n"
+    "  float z_norm = (z - z_near) / (z_far - z_near);\n"
+    "  vec3 res;\n"
+    "  if (z >= z_far) {\n"
+    "    res = vec3(1, 1, 1);\n"
+    "  } else if (z <= z_near) {\n"
+    "    res = vec3(0, 0, 0);\n"
+    "  } else {\n"
+    "    res = PackFloatToVec3i(z_norm);\n"
+    "  }\n"
+    "  color_out = vec4(res,  1.);"
+    "}\n";
+
+}  // namespace shaders
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/geometry/render/shaders/depth_shaders.h
+++ b/geometry/render/shaders/depth_shaders.h
@@ -12,9 +12,9 @@ namespace shaders {
 // much of a structured IR pattern is fed back to the camera. For example,
 // a surface with a normal perpendicular to the view direction wouldn't reflect
 // anything back and a surface with varying reflectance properties would be
-// captured as a texture. There are certain conventions in using shaders in
-// VTK. To simplify the inclusion of this data when we're ready, the requisite
-// shader code has been _commented out_ below for future reference.
+// captured as a texture. To simplify the inclusion of this data when we're
+// ready, the requisite shader code has been _commented out_ below for future
+// reference.
 // TODO(SeanCurtis-TRI): Re-enable providing normals and texture coordinates
 //  to the fragment shader when these quantities are used.
 

--- a/geometry/render/shaders/depth_shaders.h
+++ b/geometry/render/shaders/depth_shaders.h
@@ -7,23 +7,24 @@ namespace shaders {
 
 /// A vertex shader program for rendering depth images, which computes vertices
 /// and normals for the fragment shader program coming after.
-constexpr char kDepthVS[] =
-    "//VTK::System::Dec\n"  // Always start with this line.
-    "attribute vec4 vertexMC;\n"
-    "attribute vec3 normalMC;\n"
-    "uniform mat3 normalMatrix;\n"
-    "uniform mat4 MCDCMatrix;\n"
-    "uniform mat4 MCVCMatrix;\n"
-    "varying vec3 normalVCVSOutput;\n"
-    "varying vec4 vertexVCVSOutput;\n"
-    "attribute vec2 tcoordMC;\n"
-    "varying vec2 tcoordVCVSOutput;\n"
-    "void main () {\n"
-    "  normalVCVSOutput = normalMatrix * normalMC;\n"
-    "  tcoordVCVSOutput = tcoordMC;\n"
-    "  vertexVCVSOutput = MCVCMatrix * vertexMC;\n"
-    "  gl_Position = MCDCMatrix * vertexMC;\n"
-    "}\n";
+constexpr char kDepthVS[] = R"__(
+    //VTK::System::Dec
+    attribute vec4 vertexMC;
+    attribute vec3 normalMC;
+    uniform mat3 normalMatrix;
+    uniform mat4 MCDCMatrix;
+    uniform mat4 MCVCMatrix;
+    varying vec3 normalVCVSOutput;
+    varying vec4 vertexVCVSOutput;
+    attribute vec2 tcoordMC;
+    varying vec2 tcoordVCVSOutput;
+    void main () {
+      normalVCVSOutput = normalMatrix * normalMC;
+      tcoordVCVSOutput = tcoordMC;
+      vertexVCVSOutput = MCVCMatrix * vertexMC;
+      gl_Position = MCDCMatrix * vertexMC;
+    }
+)__";
 
 /// A fragment shader program for rendering depth images, which computes depth
 /// values for each pixel in depth images, converts them to be in range [0, 1]
@@ -36,71 +37,75 @@ constexpr char kDepthVS[] =
 /// The reason is that we need to set one to alpha channel so that the rendered
 /// "image" will be opaque. Otherwise, we will have different colors from what
 /// we output here, thus expect, in the end.
-constexpr char kDepthFS[] =
-    "//VTK::System::Dec\n"  // Always start with this line.
-    "//VTK::Output::Dec\n"  // Always have this line in your FS.
-    "varying vec3 normalVCVSOutput;\n"
-    "varying vec4 vertexVCVSOutput;\n"
-    "varying vec2 tcoordVCVSOutput;\n"
-    "out vec4 color_out;\n"
-    "uniform float z_near;\n"
-    "uniform float z_far;\n"
-    "\n"
-    "// This function splits a float value, whose range is [0, 1], to three\n"
-    "// float values, whose ranges are also [0, 1] but will eventually be\n"
-    "// converted to be [0, 255] of unsigned char. Each of the split float\n"
-    "// values holds specific decimal portion of the original float value\n"
-    "// using a bit shift operation, an integer part truncation and a bit\n"
-    "// mask operation. The maximum amount of information that each of the\n"
-    "// float value can hold is up to 8 bits which is the size of unsigned\n"
-    "// char and that is why we use a magic number 255 a lot in this\n"
-    "// function.\n"
-    "// Here we give you an example with concrete numbers using the base\n"
-    "// number 100 instead of 255 just to help you understand better:\n"
-    "// \n"
-    "// `value` = 0.123456\n"
-    "// `bit_shift` = `[1., 100., 10000.]`\n"
-    "// `bit_mask` = `[0.01, 0.01, 0]`\n"
-    "// \n"
-    "// `res` = `fract(value * bit_shift)`\n"
-    "//       = `fract(0.123456 * [1., 100., 10000.])`\n"
-    "//       = `fract([0.123456, 12.3456, 1234.56]`\n"
-    "//       = `[0.123456, 0.3456, 0.56]`\n"
-    "// \n"
-    "// `res.yzz` * `bit_mask` = `[0.3456, 0.56, 0.56]` * `[0.01, 0.01, 0]`\n"
-    "//                        = `[0.003456, 0.0056, 0]`\n"
-    "// \n"
-    "// `return` = `res` - `res.yzz` * `bit_mask`\n"
-    "//          = `[0.123456, 0.3456, 0.56]` - `[0.003456, 0.0056, 0]`\n"
-    "//          = `[0.12, 0.34, 0.56]`.\n"
-    "// \n"
-    "// To decode this value, you will simply need to calculate the reverse:\n"
-    "// \n"
-    "// i.e. `decoded = 0.12 + 0.34 * 0.01 + 0.56 * 0.0001`\n"
-    "//      `        = 0.12 + 0.0034 + 0.000056`\n"
-    "//      `        = 0.123456`.\n"
-    "vec3 PackFloatToVec3i(float value) {\n"
-    "  const vec3 bit_shift = vec3(1., 255., 255. * 255.);\n"
-    "  const float tmp = 1. / 255.;\n"
-    "  const vec3 bit_mask = vec3(tmp, tmp, 0.);\n"
-    "  vec3 res = fract(value * bit_shift);\n"
-    "  return res - (res.yzz * bit_mask);\n"
-    "}\n"
-    "\n"
-    "void main () {\n"
-    "  float z = -vertexVCVSOutput.z;  // In meters.\n"
-    "  // Converting meters to [0, 1].\n"
-    "  float z_norm = (z - z_near) / (z_far - z_near);\n"
-    "  vec3 res;\n"
-    "  if (z >= z_far) {\n"
-    "    res = vec3(1, 1, 1);\n"
-    "  } else if (z <= z_near) {\n"
-    "    res = vec3(0, 0, 0);\n"
-    "  } else {\n"
-    "    res = PackFloatToVec3i(z_norm);\n"
-    "  }\n"
-    "  color_out = vec4(res,  1.);"
-    "}\n";
+constexpr char kDepthFS[] = R"__(
+    //VTK::System::Dec
+    //VTK::Output::Dec
+    varying vec3 normalVCVSOutput;
+    varying vec4 vertexVCVSOutput;
+    varying vec2 tcoordVCVSOutput;
+    out vec4 color_out;
+    uniform float z_near;
+    uniform float z_far;
+
+    // This function splits a float value, whose range is [0, 1], to three
+    // float values, whose ranges are also [0, 1] but will eventually be
+    // converted to be [0, 255] of unsigned char. Each of the split float
+    // values holds specific decimal portion of the original float value
+    // using a bit shift operation, an integer part truncation and a bit
+    // mask operation. The maximum amount of information that each of the
+    // float value can hold is up to 8 bits which is the size of unsigned
+    // char and that is why we use a magic number 255 a lot in this
+    // function.
+    // Here we give you an example with concrete numbers using the base
+    // number 100 instead of 255 just to help you understand better:
+    //
+    // `value` = 0.123456
+    // `bit_shift` = `[1., 100., 10000.]`
+    // `bit_mask` = `[0.01, 0.01, 0]`
+    //
+    // `res` = `fract(value * bit_shift)`
+    //       = `fract(0.123456 * [1., 100., 10000.])`
+    //       = `fract([0.123456, 12.3456, 1234.56]`
+    //       = `[0.123456, 0.3456, 0.56]`
+    //
+    // `res.yzz` * `bit_mask` = `[0.3456, 0.56, 0.56]` * `[0.01, 0.01, 0]`
+    //                        = `[0.003456, 0.0056, 0]`
+    //
+    // `return` = `res` - `res.yzz` * `bit_mask`
+    //          = `[0.123456, 0.3456, 0.56]` - `[0.003456, 0.0056, 0]`
+    //          = `[0.12, 0.34, 0.56]`.
+    //
+    // To decode this value, you will simply need to calculate the reverse:
+    //
+    // i.e. `decoded = 0.12 + 0.34 * 0.01 + 0.56 * 0.0001`
+    //      `        = 0.12 + 0.0034 + 0.000056`
+    //      `        = 0.123456`.
+    vec3 PackFloatToVec3i(float value) {
+      const vec3 bit_shift = vec3(1., 255., 255. * 255.);
+      const float tmp = 1. / 255.;
+      const vec3 bit_mask = vec3(tmp, tmp, 0.);
+      vec3 res = fract(value * bit_shift);
+      return res - (res.yzz * bit_mask);
+    }
+
+    void main () {
+      // NOTE: This isn't the distance to the camera, but the distance to the
+      // plane that is parallel with the camera's image plane on which the
+      // corresponding point lies.
+      float z = -vertexVCVSOutput.z;  // In meters.
+      // Converting meters to [0, 1].
+      float z_norm = (z - z_near) / (z_far - z_near);
+      vec3 res;
+      if (z >= z_far) {
+        res = vec3(1, 1, 1);
+      } else if (z <= z_near) {
+        res = vec3(0, 0, 0);
+      } else {
+        res = PackFloatToVec3i(z_norm);
+      }
+      color_out = vec4(res, 1.);
+    }
+)__";
 
 }  // namespace shaders
 }  // namespace sensors

--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -163,6 +163,7 @@ drake_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//common:essential",
+        "//math:geometric_transform",
         "@eigen",
         "@vtk//:vtkCommonCore",
         "@vtk//:vtkCommonTransforms",

--- a/systems/sensors/vtk_util.cc
+++ b/systems/sensors/vtk_util.cc
@@ -6,6 +6,8 @@
 #include <vtkSmartPointer.h>
 #include <vtkTransform.h>
 
+#include "drake/math/rotation_matrix.h"
+
 namespace drake {
 namespace systems {
 namespace sensors {
@@ -32,6 +34,28 @@ vtkSmartPointer<vtkTransform> ConvertToVtkTransform(
       vtk_mat->SetElement(i, j, transform.matrix()(i, j));
     }
   }
+
+  vtkSmartPointer<vtkTransform> vtk_transform =
+      vtkSmartPointer<vtkTransform>::New();
+  vtk_transform->SetMatrix(vtk_mat.GetPointer());
+
+  return vtk_transform;
+}
+
+vtkSmartPointer<vtkTransform> ConvertToVtkTransform(
+    const math::RigidTransformd& transform) {
+  vtkNew<vtkMatrix4x4> vtk_mat;
+  for (int i = 0; i < 3; ++i) {
+    const auto& row = transform.rotation().row(i);
+    for (int j = 0; j < 3; ++j) {
+      vtk_mat->SetElement(i, j, row(j));
+    }
+    vtk_mat->SetElement(i, 3, transform.translation()(i));
+  }
+  for (int j = 0; j < 3; ++j) {
+    vtk_mat->SetElement(3, j, 0.0);
+  }
+  vtk_mat->SetElement(3, 3, 1.0);
 
   vtkSmartPointer<vtkTransform> vtk_transform =
       vtkSmartPointer<vtkTransform>::New();

--- a/systems/sensors/vtk_util.h
+++ b/systems/sensors/vtk_util.h
@@ -9,6 +9,7 @@
 #include <vtkTransform.h>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/math/rigid_transform.h"
 
 namespace drake {
 namespace systems {
@@ -35,6 +36,10 @@ vtkSmartPointer<vtkPlaneSource> CreateSquarePlane(double size);
 /// @param transform The transform to convert into a `vtkTransform`.
 vtkSmartPointer<vtkTransform> ConvertToVtkTransform(
     const Eigen::Isometry3d& transform);
+
+/// Converts the provided `transform` to a vtkTransform.
+vtkSmartPointer<vtkTransform> ConvertToVtkTransform(
+    const math::RigidTransformd& transform);
 
 /// Makes vtkPointerArray from one or multiple pointer(s) for VTK objects
 /// wrapped by vtkNew.


### PR DESCRIPTION
Implementation of the `RenderEngine` interface using VTK in a simple phong-shaded OpenGL rendering. This initial pass is as direct a port as possible of the original `RgbdRendererVtk` class. How VTK is exercised is the same. However, the difference between having an embedded RBT vs being SG-compatible has masked a great deal of the direct transformation.

This does not include the unit tests (due to PR size issues).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11477)
<!-- Reviewable:end -->
