### PR TITLE
Ensure that all cache entries are marked out of date in a cloned Context.

### DIFF
--- a/systems/framework/context_base.cc
+++ b/systems/framework/context_base.cc
@@ -12,6 +12,11 @@ std::unique_ptr<ContextBase> ContextBase::Clone() const {
   std::unique_ptr<ContextBase> clone_ptr(CloneWithoutPointers(*this));
   ContextBase& clone = *clone_ptr;
 
+  // We don't trust that every user-written copy constructor will make
+  // a faithful copy of cached results. This way we'll be sure to recompute
+  // in the new Context.
+  clone.cache_.SetAllEntriesOutOfDate();
+
   // Create a complete mapping of tracker pointers.
   DependencyTracker::PointerMap tracker_map;
   BuildTrackerPointerMap(*this, clone, &tracker_map);

--- a/systems/framework/test/cache_entry_test.cc
+++ b/systems/framework/test/cache_entry_test.cc
@@ -677,7 +677,29 @@ TEST_F(CacheEntryTest, Copy) {
   MyContextBase& clone_context =
       dynamic_cast<MyContextBase&>(*clone_context_ptr);
 
-  // The copy should have the same values.
+  // Although every cache entry in the original was up to date (see
+  // CacheEntryTest::Setup()), all cache entries in the copy should be
+  // out of date.
+  EXPECT_TRUE(entry0().is_out_of_date(clone_context));
+  EXPECT_TRUE(entry1().is_out_of_date(clone_context));
+  EXPECT_TRUE(entry2().is_out_of_date(clone_context));
+  EXPECT_TRUE(entry3().is_out_of_date(clone_context));
+  EXPECT_TRUE(entry4().is_out_of_date(clone_context));
+  EXPECT_TRUE(entry5().is_out_of_date(clone_context));
+  EXPECT_TRUE(string_entry().is_out_of_date(clone_context));
+  EXPECT_TRUE(vector_entry().is_out_of_date(clone_context));
+
+  // But the copies should still have the same values if we mark them
+  // up to date (don't try this at home, kids).
+  entry0().get_mutable_cache_entry_value(clone_context).mark_up_to_date();
+  entry1().get_mutable_cache_entry_value(clone_context).mark_up_to_date();
+  entry2().get_mutable_cache_entry_value(clone_context).mark_up_to_date();
+  entry3().get_mutable_cache_entry_value(clone_context).mark_up_to_date();
+  entry4().get_mutable_cache_entry_value(clone_context).mark_up_to_date();
+  entry5().get_mutable_cache_entry_value(clone_context).mark_up_to_date();
+  string_entry().get_mutable_cache_entry_value(clone_context).mark_up_to_date();
+  vector_entry().get_mutable_cache_entry_value(clone_context).mark_up_to_date();
+
   EXPECT_EQ(entry0().GetKnownUpToDate<int>(context_),
             entry0().GetKnownUpToDate<int>(clone_context));
   EXPECT_EQ(entry1().GetKnownUpToDate<int>(context_),

--- a/systems/framework/test/cache_test.cc
+++ b/systems/framework/test/cache_test.cc
@@ -517,7 +517,23 @@ TEST_F(CacheTest, Clone) {
     EXPECT_EQ(clone_value_tracker.ticket(), value.ticket());
   }
 
-  // The clone_cache should have the same values.
+  // The original has all entries up to date; the copy should contain the
+  // same values but they should be marked out of date.
+  EXPECT_TRUE(cache_value(index0_, &clone_cache).is_out_of_date());
+  EXPECT_TRUE(cache_value(index1_, &clone_cache).is_out_of_date());
+  EXPECT_TRUE(cache_value(index2_, &clone_cache).is_out_of_date());
+  EXPECT_TRUE(cache_value(string_index_, &clone_cache).is_out_of_date());
+  EXPECT_TRUE(cache_value(vector_index_, &clone_cache).is_out_of_date());
+  EXPECT_TRUE(cache_value(last_index, &clone_cache).is_out_of_date());
+
+  // Mark the clone up to date for the remaining tests.
+  cache_value(index0_, &clone_cache).mark_up_to_date();
+  cache_value(index1_, &clone_cache).mark_up_to_date();
+  cache_value(index2_, &clone_cache).mark_up_to_date();
+  cache_value(string_index_, &clone_cache).mark_up_to_date();
+  cache_value(vector_index_, &clone_cache).mark_up_to_date();
+  cache_value(last_index, &clone_cache).mark_up_to_date();
+
   EXPECT_EQ(cache_value(index0_, &clone_cache).GetValueOrThrow<int>(),
             cache_value(index0_).GetValueOrThrow<int>());
   EXPECT_EQ(cache_value(index1_, &clone_cache).GetValueOrThrow<int>(),


### PR DESCRIPTION
Currently when a Context is cloned, cache entries are copied along with their "up to date" flag. That works as long as all copy constructors produce faithful copies (as they should). However we know of at least one case where that isn't happening (SceneGraph's QueryObject), although proper behavior is a (somewhat difficult) TODO. This blocked @ggould-tri who was trying to do some real work -- the stubbed QueryObject would have been replaced by a good one on the next recomputation, but the "up to date" flag prevented that.

Making cache entries up to date in the clone is an optimization for which there is no proven need, and is causing trouble at the moment. This PR conservatively marks everything out of date in the clone instead, which provides some immunity to incomplete copy constructors in user-defined types and will let @ggould-tri move ahead. Later if we decide we need this optimization we can reintroduce it, perhaps with some rigorous validation that copying actually works properly.

Resolves #11476

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11480)
<!-- Reviewable:end -->
