### PR TITLE
Make QueryObject legitimately copyable

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -349,7 +349,7 @@ drake_cc_googletest(
         ":geometry_frame",
         ":geometry_instance",
         ":scene_graph",
-        "//common/test_utilities:expect_throws_message",
+        "//common/test_utilities",
     ],
 )
 

--- a/geometry/query_object.cc
+++ b/geometry/query_object.cc
@@ -8,23 +8,41 @@ namespace drake {
 namespace geometry {
 
 template <typename T>
-QueryObject<T>::QueryObject(const QueryObject&)
-    : context_{nullptr}, scene_graph_{nullptr} {}
+QueryObject<T>::QueryObject(const QueryObject& query_object) {
+  *this = query_object;
+}
 
 template <typename T>
-QueryObject<T>& QueryObject<T>::operator=(const QueryObject<T>&) {
+QueryObject<T>& QueryObject<T>::operator=(const QueryObject<T>& query_object) {
+  if (this == &query_object) return *this;
+
+  DRAKE_DEMAND(query_object.is_copyable());
+
   context_ = nullptr;
   scene_graph_ = nullptr;
+  state_.reset();
+
+  if (query_object.state_) {
+    // Share the underlying baked state.
+    state_ = query_object.state_;
+  } else if (query_object.context_ && query_object.scene_graph_) {
+    // Create a new baked state; make sure the source is fully updated.
+    query_object.FullPoseUpdate();
+    state_ = std::make_shared<GeometryState<T>>(query_object.geometry_state());
+  }
+  inspector_.set(state_.get());
+  // If `query_object` is default, then this will likewise be default.
+
   return *this;
 }
 
 template <typename T>
 std::vector<ContactSurface<T>>
 QueryObject<T>::ComputeContactSurfaces() const {
-  ThrowIfDefault();
+  ThrowIfNotCallable();
 
   // TODO(DamrongGuoy): Modify this when the cache system is in place.
-  scene_graph_->FullPoseUpdate(*context_);
+  FullPoseUpdate();
   const GeometryState<T>& state = geometry_state();
   return state.ComputeContactSurfaces();
 }
@@ -32,10 +50,10 @@ QueryObject<T>::ComputeContactSurfaces() const {
 template <typename T>
 std::vector<PenetrationAsPointPair<double>>
 QueryObject<T>::ComputePointPairPenetration() const {
-  ThrowIfDefault();
+  ThrowIfNotCallable();
 
   // TODO(SeanCurtis-TRI): Modify this when the cache system is in place.
-  scene_graph_->FullPoseUpdate(*context_);
+  FullPoseUpdate();
   const GeometryState<T>& state = geometry_state();
   return state.ComputePointPairPenetration();
 }
@@ -44,10 +62,10 @@ template <typename T>
 std::vector<SignedDistancePair<T>>
 QueryObject<T>::ComputeSignedDistancePairwiseClosestPoints(
     const double max_distance) const {
-  ThrowIfDefault();
+  ThrowIfNotCallable();
 
   // TODO(SeanCurtis-TRI): Modify this when the cache system is in place.
-  scene_graph_->FullPoseUpdate(*context_);
+  FullPoseUpdate();
   const GeometryState<T>& state = geometry_state();
   return state.ComputeSignedDistancePairwiseClosestPoints(max_distance);
 }
@@ -57,19 +75,22 @@ std::vector<SignedDistanceToPoint<T>>
 QueryObject<T>::ComputeSignedDistanceToPoint(
     const Vector3<T>& p_WQ,
     const double threshold) const {
-  ThrowIfDefault();
+  ThrowIfNotCallable();
 
-  scene_graph_->FullPoseUpdate(*context_);
+  FullPoseUpdate();
   const GeometryState<T>& state = geometry_state();
   return state.ComputeSignedDistanceToPoint(p_WQ, threshold);
 }
 
 template <typename T>
 const GeometryState<T>& QueryObject<T>::geometry_state() const {
-  // TODO(SeanCurtis-TRI): Handle the "baked" query object case.
-  DRAKE_DEMAND(scene_graph_ != nullptr);
-  DRAKE_DEMAND(context_ != nullptr);
-  return scene_graph_->geometry_state(*context_);
+  // Some extra insurance in case some query *hadn't* called this.
+  DRAKE_ASSERT_VOID(ThrowIfNotCallable());
+  if (context_) {
+    return scene_graph_->geometry_state(*context_);
+  } else {
+    return *state_;
+  }
 }
 
 }  // namespace geometry

--- a/geometry/test/query_object_test.cc
+++ b/geometry/test/query_object_test.cc
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/geometry_frame.h"
 #include "drake/geometry/geometry_instance.h"
@@ -19,7 +20,7 @@ class QueryObjectTester {
 
   template <typename T>
   static std::unique_ptr<QueryObject<T>> MakeQueryObject() {
-    return std::unique_ptr<QueryObject<T>>(new QueryObject<T>());
+    return std::make_unique<QueryObject<T>>();
   }
 
   template <typename T>
@@ -31,20 +32,74 @@ class QueryObjectTester {
   }
 
   template <typename T>
-  static void expect_default(const QueryObject<T>& object) {
-    EXPECT_EQ(object.scene_graph_, nullptr);
-    EXPECT_EQ(object.context_, nullptr);
+  static ::testing::AssertionResult is_default(const QueryObject<T>& object) {
+    if (object.scene_graph_ != nullptr || object.context_ != nullptr ||
+        object.state_ != nullptr) {
+      return ::testing::AssertionFailure()
+             << "A default query object should have all null fields. Has "
+                "scene_graph: "
+             << object.scene_graph_ << ", context: " << object.context_
+             << ", state: " << object.state_.get();
+    }
+    return ::testing::AssertionSuccess();
   }
 
   template <typename T>
-  static void expect_live(const QueryObject<T>& object) {
-    EXPECT_NE(object.scene_graph_, nullptr);
-    EXPECT_NE(object.context_, nullptr);
+  static ::testing::AssertionResult is_live(const QueryObject<T>& object) {
+    if (object.scene_graph_ == nullptr || object.context_ == nullptr ||
+        object.state_ != nullptr) {
+      return ::testing::AssertionFailure()
+             << "A live query object should have non-null scene graph and "
+                "context and null state. Has scene_graph: "
+             << object.scene_graph_ << ", context: " << object.context_
+             << ", state: " << object.state_.get();
+    }
+    return ::testing::AssertionSuccess();
   }
 
   template <typename T>
-  static void ThrowIfDefault(const QueryObject<T>& object) {
-    object.ThrowIfDefault();
+  static ::testing::AssertionResult is_baked(const QueryObject<T>& object) {
+    if (object.scene_graph_ != nullptr || object.context_ != nullptr ||
+        object.state_ == nullptr) {
+      return ::testing::AssertionFailure()
+          << "A baked query object should have all null scene graph and "
+             "context and non-null state. Has scene_graph: "
+          << object.scene_graph_ << ", context: " << object.context_
+          << ", state: " << object.state_.get();
+    }
+    return ::testing::AssertionSuccess();
+  }
+
+  template <typename T>
+  static ::testing::AssertionResult shared_baked(const QueryObject<T>& o1,
+                                                 const QueryObject<T>& o2) {
+    auto result = is_baked(o1);
+    if (result) {
+      result = is_baked(o2);
+      if (result) {
+        if (o1.state_ != o2.state_) {
+          result = ::testing::AssertionFailure()
+                   << "The two objects are baked but have different states";
+        }
+      }
+    }
+    return result;
+  }
+
+  template <typename T>
+  static void set(const systems::Context<T>* context,
+                  const SceneGraph<T>* scene_graph, QueryObject<T>* object) {
+    object->set(context, scene_graph);
+  }
+
+  template <typename T>
+  static const GeometryState<T>& state(const QueryObject<T>& object) {
+    return object.geometry_state();
+  }
+
+  template <typename T>
+  static void ThrowIfNotCallable(const QueryObject<T>& object) {
+    object.ThrowIfNotCallable();
   }
 };
 
@@ -62,7 +117,7 @@ class QueryObjectTest : public ::testing::Test {
     context_ = scene_graph_.AllocateContext();
     query_object_ = QOT::MakeQueryObject(context_.get(), &scene_graph_);
 
-    QueryObjectTester::expect_live(*query_object_);
+    EXPECT_TRUE(QueryObjectTester::is_live(*query_object_));
   }
 
   SceneGraph<double> scene_graph_;
@@ -75,13 +130,21 @@ TEST_F(QueryObjectTest, CopySemantics) {
   // Default query object *can* be copied and assigned.
   unique_ptr<QueryObject<double>> default_object =
       QOT::MakeQueryObject<double>();
-  QOT::expect_default(*default_object);
+  EXPECT_TRUE(QOT::is_default(*default_object));
 
   QueryObject<double> from_default{*default_object};
-  QOT::expect_default(from_default);
+  EXPECT_TRUE(QOT::is_default(*default_object));
 
   QueryObject<double> from_live{*query_object_};
-  QOT::expect_default(from_live);
+  EXPECT_TRUE(QOT::is_baked(from_live));
+
+  QueryObject<double> from_baked{from_live};
+  // Simultaneously test from_baked *is* baked and shares state with from_live.
+  EXPECT_TRUE(QOT::shared_baked(from_live, from_baked));
+
+  // Confirm a baked object can be reset to be a live object.
+  QOT::set(context_.get(), &scene_graph_, &from_baked);
+  EXPECT_TRUE(QOT::is_live(from_baked));
 }
 
 // NOTE: This doesn't test the specific queries; GeometryQuery simply wraps
@@ -92,13 +155,13 @@ TEST_F(QueryObjectTest, CopySemantics) {
 TEST_F(QueryObjectTest, DefaultQueryThrows) {
   unique_ptr<QueryObject<double>> default_object =
       QOT::MakeQueryObject<double>();
-  QOT::expect_default(*default_object);
+  EXPECT_TRUE(QOT::is_default(*default_object));
 
 #define EXPECT_DEFAULT_ERROR(expression) \
   DRAKE_EXPECT_THROWS_MESSAGE(expression, std::runtime_error, \
       "Attempting to perform query on invalid QueryObject.+");
 
-  EXPECT_DEFAULT_ERROR(QOT::ThrowIfDefault(*default_object));
+  EXPECT_DEFAULT_ERROR(QOT::ThrowIfNotCallable(*default_object));
 
   // Enumerate *all* queries to confirm they throw the proper exception.
   EXPECT_DEFAULT_ERROR(default_object->ComputePointPairPenetration());
@@ -132,6 +195,41 @@ GTEST_TEST(QueryObjectInspectTest, CreateValidInspector) {
   // state uniquely populated above (guaranteed via the uniqueness of frame and
   // geometry identifiers).
   EXPECT_EQ(inspector.GetFrameId(geometry_id), frame_id);
+}
+
+// This test confirms that the copied (aka baked) query object has its pose
+// data properly baked. This is confirmed by a great deal of convoluted
+// trickery.
+GTEST_TEST(QueryObjectBakeTest, BakedCopyHasFullUpdate) {
+  using QOT = QueryObjectTester;
+
+  SceneGraph<double> scene_graph;
+  SourceId s_id = scene_graph.RegisterSource("BakeTest");
+  FrameId frame_id = scene_graph.RegisterFrame(s_id, GeometryFrame("frame"));
+  unique_ptr<Context<double>> context = scene_graph.AllocateContext();
+  Isometry3<double> X_WF{Translation3<double>{1, 2, 3}};
+  FramePoseVector<double> poses{{frame_id, X_WF}};
+  scene_graph.get_source_pose_port(s_id).FixValue(context.get(), poses);
+  const auto& query_object =
+      scene_graph.get_query_output_port().Eval<QueryObject<double>>(*context);
+  EXPECT_TRUE(QOT::is_live(query_object));
+
+  // Here's the convoluted trickery. We examine the state that's embedded in
+  // the context of the live query object. It *hasn't* updated poses at all.
+  // So, if we ask for the world pose of frame_id, it will *not* be at X_WF.
+  // However, when we copy the query_object, the same query on its state
+  // *will* return that value (showing that the copy has the updated poses).
+
+  const GeometryState<double>& state = QOT::state(query_object);
+  const auto& stale_pose = state.get_pose_in_world(frame_id);
+  // Confirm the live state hasn't been updated yet.
+  EXPECT_FALSE(CompareMatrices(stale_pose.matrix(), X_WF.matrix()));
+
+  const QueryObject<double> baked(query_object);
+
+  const GeometryState<double>& baked_state = QOT::state(query_object);
+  const auto& baked_pose = baked_state.get_pose_in_world(frame_id);
+  EXPECT_TRUE(CompareMatrices(baked_pose.matrix(), X_WF.matrix()));
 }
 
 }  // namespace


### PR DESCRIPTION
This finishes the "live" vs "baked" state of the QueryObject. This
implements the "baked" state -- such that it has an embedded GeometryState
that can support queries but is no longer tied to a changing Context.

NOTE: This doesn't touch dev/query_object.h. The expectation is that it
won't cause problems before it gets deleted.

resolves #11482

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11484)
<!-- Reviewable:end -->
