### PR TITLE
Extend SceneGraph introspection: poses in world and shape data

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -30,6 +30,7 @@ drake_cc_package_library(
         ":scene_graph",
         ":scene_graph_inspector",
         ":shape_specification",
+        ":shape_to_string",
         ":utilities",
     ],
 )
@@ -243,6 +244,16 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "shape_to_string",
+    srcs = ["shape_to_string.cc"],
+    hdrs = ["shape_to_string.h"],
+    deps = [
+        ":shape_specification",
+        "@fmt",
+    ],
+)
+
+drake_cc_library(
     name = "utilities",
     srcs = ["utilities.cc"],
     hdrs = ["utilities.h"],
@@ -366,6 +377,13 @@ drake_cc_googletest(
     deps = [
         ":shape_specification",
         "//common/test_utilities",
+    ],
+)
+
+drake_cc_googletest(
+    name = "shape_to_string_test",
+    deps = [
+        ":shape_to_string",
     ],
 )
 

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -203,7 +203,7 @@ class GeometryState {
   /** Implementation of SceneGraphInspector::GetName(GeometryId) const.  */
   const std::string& get_name(GeometryId geometry_id) const;
 
-  /** Implementation of SceneGraphInspector::GetShape().  */
+  /** Support for SceneGraphInspector::Reify().  */
   const Shape& GetShape(GeometryId id) const;
 
   /** Implementation of SceneGraphInspector::X_FG().  */
@@ -230,24 +230,13 @@ class GeometryState {
    registered frames.  */
   //@{
 
-  /** Reports the pose of the frame with the given id.
-   @param frame_id  The identifier of the queried frame.
-   @returns The pose in the world (X_WF) of the identified frame.
-   @throws std::logic_error if the frame id is not valid.  */
+  /** Implementation of QueryObject::X_WF().  */
   const Isometry3<T>& get_pose_in_world(FrameId frame_id) const;
 
-  /** Reports the pose of the geometry with the given id.
-   @param geometry_id  The identifier of the queried geometry.
-   @returns The pose in the world (X_WG) of the identified geometry.
-   @throws std::logic_error if the geometry id is not valid.  */
+  /** Implementation of QueryObject::X_WG().  */
   const Isometry3<T>& get_pose_in_world(GeometryId geometry_id) const;
 
-  /** Reports the pose of the frame with the given id relative to its parent
-   frame. If the frame's parent is the world, the value should be the same as
-   a call to get_pose_in_world().
-   @param frame_id  The identifier of the queried frame.
-   @returns The pose in the _parent_ frame (X_PF) of the identified frame.
-   @throws std::logic_error if the frame id is not valid.  */
+  /** Implementation of QueryObject::X_PF().  */
   const Isometry3<T>& get_pose_in_parent(FrameId frame_id) const;
 
   //@}

--- a/geometry/query_object.cc
+++ b/geometry/query_object.cc
@@ -7,6 +7,8 @@
 namespace drake {
 namespace geometry {
 
+using math::RigidTransform;
+
 template <typename T>
 QueryObject<T>::QueryObject(const QueryObject& query_object) {
   *this = query_object;
@@ -34,6 +36,33 @@ QueryObject<T>& QueryObject<T>::operator=(const QueryObject<T>& query_object) {
   // If `query_object` is default, then this will likewise be default.
 
   return *this;
+}
+
+template <typename T>
+RigidTransform<T> QueryObject<T>::X_WF(FrameId id) const {
+  ThrowIfNotCallable();
+
+  FullPoseUpdate();
+  const GeometryState<T>& state = geometry_state();
+  return RigidTransform<T>(state.get_pose_in_world(id));
+}
+
+template <typename T>
+RigidTransform<T> QueryObject<T>::X_PF(FrameId id) const {
+  ThrowIfNotCallable();
+
+  FullPoseUpdate();
+  const GeometryState<T>& state = geometry_state();
+  return RigidTransform<T>(state.get_pose_in_parent(id));
+}
+
+template <typename T>
+RigidTransform<T> QueryObject<T>::X_WG(GeometryId id) const {
+  ThrowIfNotCallable();
+
+  FullPoseUpdate();
+  const GeometryState<T>& state = geometry_state();
+  return RigidTransform<T>(state.get_pose_in_world(id));
 }
 
 template <typename T>

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -100,7 +100,36 @@ class QueryObject {
     return inspector_;
   }
 
-  //----------------------------------------------------------------------------
+  /** @name                Pose-dependent Introspection
+
+   These methods provide access to introspect geometry and frame quantities that
+   directly depend on the poses of the frames.  For geometry and frame
+   quantities that do not depend on the poses of frames, such as  X_FG, use
+   inspector() to access the SceneGraphInspector.  */
+  //@{
+
+  // TODO(SeanCurtis-TRI): When I have RigidTransform internally, make these
+  // const references.
+  /** Reports the position of the frame indicated by `id` relative to the world
+   frame.
+   @throws std::logic_error if the frame `id` is not valid.  */
+  math::RigidTransform<T> X_WF(FrameId id) const;
+
+  /** Reports the position of the frame indicated by `id` relative to its parent
+   frame. If the frame was registered with the world frame as its parent frame,
+   this value will be identical to that returned by X_WF().
+   @note This is analogous to but distinct from SceneGraphInspector::X_PG().
+   In this case, the pose will *always* be relative to another frame.
+   @throws std::logic_error if the frame `id` is not valid.  */
+  math::RigidTransform<T> X_PF(FrameId id) const;
+
+  /** Reports the position of the geometry indicated by `id` relative to the
+   world frame.
+   @throws std::logic_error if the geometry `id` is not valid.  */
+  math::RigidTransform<T> X_WG(GeometryId id) const;
+
+  //@}
+
   /** @name                Collision Queries
 
    These queries detect _collisions_ between geometry. Two geometries collide

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -8,6 +8,7 @@
 
 #include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/geometry_state.h"
+#include "drake/geometry/shape_specification.h"
 
 namespace drake {
 namespace geometry {
@@ -354,6 +355,16 @@ class SceneGraphInspector {
   bool CollisionFiltered(GeometryId id1, GeometryId id2) const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->CollisionFiltered(id1, id2);
+  }
+
+  /** Introspects the geometry indicated by the given `id`. The geometry will
+   be passed into the provided `reifier`. This is the mechanism by which
+   external code can discover and respond to the different types of geometries
+   stored in SceneGraph. See ShapeToString as an example.
+   @throws std::logic_error if the `id` does not refer to a valid geometry.  */
+  void Reify(GeometryId id, ShapeReifier* reifier) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    state_->GetShape(id).Reify(reifier);
   }
 
   //@}

--- a/geometry/shape_to_string.cc
+++ b/geometry/shape_to_string.cc
@@ -1,0 +1,36 @@
+#include "drake/geometry/shape_to_string.h"
+
+#include <fmt/format.h>
+
+namespace drake {
+namespace geometry {
+
+void ShapeToString::ImplementGeometry(const Sphere& sphere, void*) {
+  string_ = fmt::format("Sphere(r: {})", sphere.get_radius());
+}
+
+void ShapeToString::ImplementGeometry(const Cylinder& cylinder, void*) {
+  string_ = fmt::format("Cylinder(r: {}, l: {})", cylinder.get_radius(),
+                        cylinder.get_length());
+}
+
+void ShapeToString::ImplementGeometry(const HalfSpace&, void*) {
+  string_ = "Halfspace";
+}
+
+void ShapeToString::ImplementGeometry(const Box& box, void*) {
+  string_ = fmt::format("Box(w: {}, d: {}, h: {})", box.width(), box.depth(),
+                        box.height());
+}
+
+void ShapeToString::ImplementGeometry(const Mesh& mesh, void*) {
+  string_ = fmt::format("Mesh(s: {}, path: {})", mesh.scale(), mesh.filename());
+}
+
+void ShapeToString::ImplementGeometry(const Convex& convex, void*) {
+  string_ =
+      fmt::format("Convex(s: {}, path: {})", convex.scale(), convex.filename());
+}
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/shape_to_string.h
+++ b/geometry/shape_to_string.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <string>
+
+#include "drake/geometry/shape_specification.h"
+
+namespace drake {
+namespace geometry {
+
+/** Class that turns a Shape into a std::string representation. This reifier has
+ a string() member that gets updated for each shape reified. The expected
+ workflow would be:
+
+ ```c++
+ ShapeToString reifier;
+ SceneGraphInspector inspector = ...;  // Get the inspector from somewhere.
+ for (GeometryId id : inspector.all_geometry_ids()) {
+   inspector.Reify(id, reifier);
+   std::cout << reifier.string() << "\n";
+ }
+ ```
+
+ This will write out a string representation of every geometry registered to
+ SceneGraph.  */
+class ShapeToString final : public ShapeReifier {
+ public:
+  /** @name  Implementation of ShapeReifier interface  */
+  //@{
+
+  void ImplementGeometry(const Sphere& sphere, void* user_data) final;
+  void ImplementGeometry(const Cylinder& cylinder, void* user_data) final;
+  void ImplementGeometry(const HalfSpace& half_space, void* user_data) final;
+  void ImplementGeometry(const Box& box, void* user_data) final;
+  void ImplementGeometry(const Mesh& mesh, void* user_data) final;
+  void ImplementGeometry(const Convex& convex, void* user_data) final;
+
+  //@}
+  const std::string& string() const { return string_; }
+
+ private:
+  std::string string_;
+};
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/test/query_object_test.cc
+++ b/geometry/test/query_object_test.cc
@@ -171,6 +171,12 @@ TEST_F(QueryObjectTest, DefaultQueryThrows) {
       default_object->ComputeSignedDistanceToPoint(Vector3<double>::Zero()));
   EXPECT_DEFAULT_ERROR(
       default_object->ComputeContactSurfaces());
+  EXPECT_DEFAULT_ERROR(
+      default_object->X_WF(FrameId::get_new_id()));
+  EXPECT_DEFAULT_ERROR(
+      default_object->X_PF(FrameId::get_new_id()));
+  EXPECT_DEFAULT_ERROR(
+      default_object->X_WG(GeometryId::get_new_id()));
 #undef EXPECT_DEFAULT_ERROR
 }
 

--- a/geometry/test/shape_to_string_test.cc
+++ b/geometry/test/shape_to_string_test.cc
@@ -1,0 +1,52 @@
+#include "drake/geometry/shape_to_string.h"
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace geometry {
+namespace {
+
+GTEST_TEST(ShapeToStringTest, Sphere) {
+  ShapeToString reifier;
+  Sphere s(1.25);
+  s.Reify(&reifier);
+  EXPECT_EQ(reifier.string(), "Sphere(r: 1.25)");
+}
+
+GTEST_TEST(ShapeToStringTest, Cylinder) {
+  ShapeToString reifier;
+  Cylinder c(1.25, 2.5);
+  c.Reify(&reifier);
+  EXPECT_EQ(reifier.string(), "Cylinder(r: 1.25, l: 2.5)");}
+
+GTEST_TEST(ShapeToStringTest, Halfspace) {
+  ShapeToString reifier;
+  HalfSpace h;
+  h.Reify(&reifier);
+  EXPECT_EQ(reifier.string(), "Halfspace");
+}
+
+GTEST_TEST(ShapeToStringTest, Box) {
+  ShapeToString reifier;
+  Box b(1.5, 2.5, 3.5);
+  b.Reify(&reifier);
+  EXPECT_EQ(reifier.string(), "Box(w: 1.5, d: 2.5, h: 3.5)");
+}
+
+GTEST_TEST(ShapeToStringTest, Mesh) {
+  ShapeToString reifier;
+  Mesh m("path/to/file", 1.5);
+  m.Reify(&reifier);
+  EXPECT_EQ(reifier.string(), "Mesh(s: 1.5, path: path/to/file)");
+}
+
+GTEST_TEST(ShapeToStringTest, Convex) {
+  ShapeToString reifier;
+  Convex m("path/to/file", 1.5);
+  m.Reify(&reifier);
+  EXPECT_EQ(reifier.string(), "Convex(s: 1.5, path: path/to/file)");
+}
+
+}  // namespace
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
1. QueryObject can report the pose-dependent quantities of: X_WF, X_PF, and X_WG (poses of frames and geometries).
2. SceneGraphInspector provides a mechanism to introspect shapes.
3. Provide ShapeStringReifier - a means to translate a `GeometryId` to a `string`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11488)
<!-- Reviewable:end -->
