### PR TITLE
Build with -O0 for AddressSanitizer and LeakSanitizer

### DIFF
--- a/tools/dynamic_analysis/bazel.rc
+++ b/tools/dynamic_analysis/bazel.rc
@@ -31,17 +31,21 @@ build:kcov_everything --nocache_test_results
 # See timeout note above. Timeouts are 5x default values.
 build:kcov_everything --test_timeout=300,1500,4500,18000
 
-### ASan build. ###
+### ASan build. Clang only. ###
 build:asan --build_tests_only
-build:asan --copt -g
-build:asan --copt -fsanitize=address
-build:asan --copt -O1
-build:asan --copt -fno-omit-frame-pointer
-build:asan --linkopt -fsanitize=address
+build:asan --copt=-g
+# https://github.com/google/sanitizers/wiki/AddressSanitizer#faq
+build:asan --copt=-fno-common
+build:asan --copt=-fsanitize=address
+build:asan --copt=-fstandalone-debug
+build:asan --copt=-O0
+build:asan --copt=-fno-omit-frame-pointer
+build:asan --linkopt=-fsanitize=address
 build:asan --run_under=//tools/dynamic_analysis:asan
 build:asan --test_env=ASAN_OPTIONS
 build:asan --test_env=LSAN_OPTIONS
 build:asan --test_env=ASAN_SYMBOLIZER_PATH
+build:asan --test_env=LSAN_SYMBOLIZER_PATH
 # LSan is run with ASan by default
 build:asan --test_tag_filters=-gurobi,-mosek,-snopt,-no_asan,-no_lsan
 build:asan --test_lang_filters=-sh,-py
@@ -49,50 +53,58 @@ build:asan --test_lang_filters=-sh,-py
 # See https://clang.llvm.org/docs/AddressSanitizer.html
 build:asan --test_timeout=150,750,2250,9000  # 2.5x
 
-### ASan everything build. ###
+### ASan everything build. Clang only. ###
 build:asan_everything --build_tests_only
 build:asan_everything --define=WITH_GUROBI=ON
 build:asan_everything --define=WITH_MOSEK=ON
 build:asan_everything --define=WITH_SNOPT=ON
-build:asan_everything --copt -g
-build:asan_everything --copt -fsanitize=address
-build:asan_everything --copt -O1
-build:asan_everything --copt -fno-omit-frame-pointer
-build:asan_everything --linkopt -fsanitize=address
+build:asan_everything --copt=-g
+# https://github.com/google/sanitizers/wiki/AddressSanitizer#faq
+build:asan_everything --copt=-fno-common
+build:asan_everything --copt=-fsanitize=address
+build:asan_everything --copt=-fstandalone-debug
+build:asan_everything --copt=-O0
+build:asan_everything --copt=-fno-omit-frame-pointer
+build:asan_everything --linkopt=-fsanitize=address
 # LSan is run with ASan by default
 build:asan_everything --test_tag_filters=-no_asan,-no_lsan
 build:asan_everything --run_under=//tools/dynamic_analysis:asan
 build:asan_everything --test_env=ASAN_OPTIONS
 build:asan_everything --test_env=LSAN_OPTIONS
 build:asan_everything --test_env=ASAN_SYMBOLIZER_PATH
+build:asan_everything --test_env=LSAN_SYMBOLIZER_PATH
 build:asan_everything --test_lang_filters=-sh,-py
 # Typical slowdown introduced by AddressSanitizer is 2x.
 # See https://clang.llvm.org/docs/AddressSanitizer.html
 build:asan_everything --test_timeout=150,750,2250,9000  # 2.5x
 
-### LSan build. ###
+### LSan build. Clang only. ###
 build:lsan --build_tests_only
-build:lsan --copt -g
-build:lsan --copt -fsanitize=leak
-build:lsan --copt -O1
-build:lsan --copt -fno-omit-frame-pointer
-build:lsan --linkopt -fsanitize=leak
+build:lsan --copt=-g
+build:lsan --copt=-fno-common
+build:lsan --copt=-fsanitize=leak
+build:lsan --copt=-fstandalone-debug
+build:lsan --copt=-O0
+build:lsan --copt=-fno-omit-frame-pointer
+build:lsan --linkopt=-fsanitize=leak
 build:lsan --run_under=//tools/dynamic_analysis:lsan
 build:lsan --test_env=LSAN_OPTIONS
 build:lsan --test_env=LSAN_SYMBOLIZER_PATH
 build:lsan --test_tag_filters=-gurobi,-mosek,-snopt,-no_lsan
 build:lsan --test_lang_filters=-sh,-py
 
-### LSan everything build. ###
+### LSan everything build. Clang only. ###
 build:lsan_everything --build_tests_only
 build:lsan_everything --define=WITH_GUROBI=ON
 build:lsan_everything --define=WITH_MOSEK=ON
 build:lsan_everything --define=WITH_SNOPT=ON
-build:lsan_everything --copt -g
-build:lsan_everything --copt -fsanitize=leak
-build:lsan_everything --copt -O1
-build:lsan_everything --copt -fno-omit-frame-pointer
-build:lsan_everything --linkopt -fsanitize=leak
+build:lsan_everything --copt=-g
+build:lsan_everything --copt=-fno-common
+build:lsan_everything --copt=-fsanitize=leak
+build:lsan_everything --copt=-fstandalone-debug
+build:lsan_everything --copt=-O0
+build:lsan_everything --copt=-fno-omit-frame-pointer
+build:lsan_everything --linkopt=-fsanitize=leak
 build:lsan_everything --test_tag_filters=-no_lsan
 build:lsan_everything --run_under=//tools/dynamic_analysis:lsan
 build:lsan_everything --test_env=LSAN_OPTIONS


### PR DESCRIPTION
The background here is to force the same optimization flags on both Mac and Linux as well as get better console traces for debugging. Relates #11391.

<!-- Reviewable:start -->
----
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11491)
<!-- Reviewable:end -->
