### PR TITLE
[Bugfix] Removing geometry preserves collision filter semantics

### DIFF
--- a/geometry/proximity/collision_filter_legacy.h
+++ b/geometry/proximity/collision_filter_legacy.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "drake/common/drake_assert.h"
@@ -36,6 +37,12 @@ class CollisionFilterLegacy {
    (see EncodedData). When added, it will not be part of any filtered pairs.  */
   void AddGeometry(uintptr_t id) {
     collision_cliques_.insert({id, std::vector<int>()});
+  }
+
+  /** Removes the geometry represented by its encoded `id` from the data. If
+   `id` has no collision filters; no action is taken.  */
+  void RemoveGeometry(uintptr_t id) {
+    collision_cliques_.erase(id);
   }
 
   /** Reports true if the geometry pair (`id_A`, `id_B`) has been explicitly
@@ -91,6 +98,29 @@ class CollisionFilterLegacy {
   /** (Test support) reports what the next value that would be returned by
    next_clique_id().  */
   int peek_next_clique() const { return next_available_clique_; }
+
+  /** A geometry that was previously registered under the `old_encoding` will
+   now be recognized under the `new_encoding`. The `old_encoding` will no longer
+   be valid.
+   @pre `old_encoding` must exist in the map of filters and `new_encoding` must
+         *not*.  */
+  void UpdateEncoding(uintptr_t old_encoding, uintptr_t new_encoding) {
+    // NOTE: The keys in the cliques is a function of a geometry's GeometryIndex
+    // and dynamic property (dynamic or anchored). When GeometryState *moves* a
+    // geometry in its compact vector, that geometry's index changes. That means
+    // we need remap the collision cliques from its old encoding to its new.
+    //
+    // Generally, this movement is to make the array of geometries compact; so
+    // a geometry is moved into a slot of a geometry that is being removed.
+    // Therefore, we require that the slot being moved into must *not* be
+    // occupied; i.e., the removed geometry has been removed.
+    auto old_iter = collision_cliques_.find(old_encoding);
+    DRAKE_DEMAND(old_iter != collision_cliques_.end());
+    auto new_iter = collision_cliques_.find(new_encoding);
+    DRAKE_DEMAND(new_iter == collision_cliques_.end());
+    collision_cliques_.emplace(new_encoding, std::move(old_iter->second));
+    collision_cliques_.erase(old_encoding);
+  }
 
  private:
   // A map between the EncodedData::encoding() value for a geometry and


### PR DESCRIPTION
Previously, when a geometry was removed, the resulting geometries didn't necessarily preserve their collision filter semantics. This happened particularly when a geometry was moved elsewhere in the `GeometryState` array. The collision filter mechanism depended on that location but wasn't given the chance to update itself after the change.

1. This introduces a test that fails without the bugfix.
2. `CollisionFilterLegacy` has direct support for geometry removal.
3. `ProximityEngine` explicitly exercises that support to keep the collision filters in sync.
4. `GeometryState` handles the re-ordering *after* it has allowed the engines to do a clean removal.

resolves: #11490 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11493)
<!-- Reviewable:end -->
