### PR TITLE
[geometry] Add CloneAndSetMesh() to MeshField and use it to copy ContactSurface.

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -142,4 +142,18 @@ drake_cc_googletest(
     ],
 )
 
+drake_cc_googletest(
+    name = "mesh_field_test",
+    deps = [
+        "//geometry/query_results:mesh_field",
+    ],
+)
+
+drake_cc_googletest(
+    name = "mesh_field_linear_test",
+    deps = [
+        "//geometry/query_results:mesh_field",
+    ],
+)
+
 add_lint_tests()

--- a/geometry/proximity/test/mesh_field_linear_test.cc
+++ b/geometry/proximity/test/mesh_field_linear_test.cc
@@ -1,0 +1,70 @@
+#include "drake/geometry/query_results/mesh_field_linear.h"
+
+#include <memory>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+#include "drake/geometry/query_results/surface_mesh.h"
+
+namespace drake {
+namespace geometry {
+namespace {
+
+template <typename T>
+std::unique_ptr<SurfaceMesh<T>> GenerateMesh() {
+// A simple surface mesh consists of two right triangles that make a square.
+//
+//   y
+//   |
+//   |
+//   |
+//   v3(0,1,0)  v2(1,1,0)
+//   +-----------+
+//   |         . |
+//   |  f1  . .  |
+//   |    . .    |
+//   | . .   f0  |
+//   |.          |
+//   +-----------+---------- x
+//   v0(0,0,0)  v1(1,0,0)
+//
+  const int face_data[2][3] = {{0, 1, 2}, {2, 3, 0}};
+  std::vector<SurfaceFace> faces;
+  for (int f = 0; f < 2; ++f) faces.emplace_back(face_data[f]);
+  const Vector3<T> vertex_data[4] = {
+      {0., 0., 0.}, {1., 0., 0.}, {1., 1., 0.}, {0., 1., 0.}};
+  std::vector<SurfaceVertex<T>> vertices;
+  for (int v = 0; v < 4; ++v) vertices.emplace_back(vertex_data[v]);
+  auto surface_mesh =
+      std::make_unique<SurfaceMesh<T>>(move(faces), std::move(vertices));
+  return surface_mesh;
+}
+
+// Tests CloneAndSetMesh(). We use `double` and SurfaceMesh<double> as
+// representative arguments for type parameters.
+GTEST_TEST(MeshFieldLinearTest, TestDoCloneWithMesh) {
+  using FieldValue = double;
+  using MeshType = SurfaceMesh<double>;
+  using MeshFieldLineard = MeshFieldLinear<FieldValue, MeshType>;
+
+  auto mesh1 = GenerateMesh<double>();
+  std::vector<FieldValue> e_values = {0., 1., 2., 3.};
+  auto original =
+      std::make_unique<MeshFieldLineard>("e", std::move(e_values), mesh1.get());
+
+  MeshType mesh2 = *mesh1;
+  auto clone_base = original->CloneAndSetMesh(&mesh2);
+  auto clone = dynamic_cast<MeshFieldLineard*>(clone_base.get());
+
+  // Check uniqueness.
+  EXPECT_NE(original.get(), clone);
+
+  // Check equivalence.
+  EXPECT_EQ(original->name(), clone->name());
+  EXPECT_EQ(original->values(), clone->values());
+}
+
+}  // namespace
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/test/mesh_field_test.cc
+++ b/geometry/proximity/test/mesh_field_test.cc
@@ -1,0 +1,75 @@
+#include "drake/geometry/query_results/mesh_field.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/geometry/query_results/surface_mesh.h"
+
+namespace drake {
+namespace geometry {
+namespace {
+
+template <typename T>
+std::unique_ptr<SurfaceMesh<T>> GenerateMesh() {
+// A simple surface mesh consists of two right triangles that make a square.
+//
+//   y
+//   |
+//   |
+//   |
+//   v3(0,1,0)  v2(1,1,0)
+//   +-----------+
+//   |         . |
+//   |  f1  . .  |
+//   |    . .    |
+//   | . .   f0  |
+//   |.          |
+//   +-----------+---------- x
+//   v0(0,0,0)  v1(1,0,0)
+//
+  const int face_data[2][3] = {{0, 1, 2}, {2, 3, 0}};
+  std::vector<SurfaceFace> faces;
+  for (int f = 0; f < 2; ++f) faces.emplace_back(face_data[f]);
+  const Vector3<T> vertex_data[4] = {
+      {0., 0., 0.}, {1., 0., 0.}, {1., 1., 0.}, {0., 1., 0.}};
+  std::vector<SurfaceVertex<T>> vertices;
+  for (int v = 0; v < 4; ++v) vertices.emplace_back(vertex_data[v]);
+  auto surface_mesh =
+      std::make_unique<SurfaceMesh<T>>(move(faces), std::move(vertices));
+  return surface_mesh;
+}
+
+// Tests CloneAndSetMesh(). We use `double` and SurfaceMesh<double>
+// to represent the type parameters FieldValue and MeshType respectively.
+GTEST_TEST(MeshFieldTest, TestClone) {
+  using FieldValue = double;
+  using MeshType = SurfaceMesh<double>;
+  using MeshFieldBase = MeshField<FieldValue, MeshType>;
+
+  class MeshFieldSubclass : public MeshFieldBase {
+   public:
+    explicit MeshFieldSubclass(MeshType* mesh): MeshFieldBase(mesh) {}
+
+    FieldValue Evaluate(const MeshType::ElementIndex,
+                        const MeshType::Barycentric&) const final {
+      return FieldValue(0);
+    }
+   private:
+    DRAKE_NODISCARD std::unique_ptr<MeshFieldBase> DoCloneWithNullMesh() const
+    final {
+      return std::make_unique<MeshFieldSubclass>(*this);
+    }
+  };
+  auto mesh1 = GenerateMesh<double>();
+  MeshFieldSubclass original(mesh1.get());
+  MeshType mesh2 = *mesh1;
+
+  std::unique_ptr<MeshFieldBase> clone = original.CloneAndSetMesh(&mesh2);
+  EXPECT_EQ(&mesh2, &clone->mesh());
+  EXPECT_NE(nullptr, dynamic_cast<MeshFieldSubclass*>(clone.get()));
+}
+
+}  // namespace
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/query_results/contact_surface.h
+++ b/geometry/query_results/contact_surface.h
@@ -133,18 +133,13 @@ class ContactSurface {
 
     id_M_ = surface.id_M_;
     id_N_ = surface.id_N_;
+    mesh_ = std::make_unique<SurfaceMesh<T>>(*surface.mesh_.get());
 
     // We can't simply copy the mesh fields; the copies must contain pointers
-    // to a unique mesh. So, we reconstruct new fields on the newly created
-    // mesh.
-    mesh_ = std::make_unique<SurfaceMesh<T>>(*surface.mesh_.get());
-    std::vector<T> e_MN_values = surface.e_MN_->values();
-    e_MN_ = std::make_unique<SurfaceMeshFieldLinear<T, T>>(
-        surface.e_MN_->name(), std::move(e_MN_values), mesh_.get());
-    std::vector<Vector3<T>> grad_h_MN_M_values = surface.grad_h_MN_M_->values();
-    grad_h_MN_M_ = std::make_unique<SurfaceMeshFieldLinear<Vector3<T>, T>>(
-        surface.grad_h_MN_M_->name(), std::move(grad_h_MN_M_values),
-        mesh_.get());
+    // to the new mesh. So, we use CloneAndSetMesh() instead.
+    e_MN_ = surface.e_MN_->CloneAndSetMesh(mesh_.get());
+    grad_h_MN_M_ = surface.grad_h_MN_M_->CloneAndSetMesh(mesh_.get());
+
     return *this;
   }
 
@@ -217,12 +212,11 @@ class ContactSurface {
   GeometryId id_N_;
   /** The surface mesh of the contact surface 𝕊ₘₙ between M and N. */
   std::unique_ptr<SurfaceMesh<T>> mesh_;
-  // TODO(DamrongGuoy): Change to SurfaceMeshField when we have it.
-  /** Represents the common scalar field eₘₙ on the surface mesh. */
-  std::unique_ptr<SurfaceMeshFieldLinear<T, T>> e_MN_;
+  /** Represents the scalar field eₘₙ on the surface mesh. */
+  std::unique_ptr<SurfaceMeshField<T, T>> e_MN_;
   /** Represents the vector field ∇hₘₙ on the surface mesh, expressed in M's
-      frame */
-  std::unique_ptr<SurfaceMeshFieldLinear<Vector3<T>, T>> grad_h_MN_M_;
+    frame */
+  std::unique_ptr<SurfaceMeshField<Vector3<T>, T>> grad_h_MN_M_;
   friend class ContactSurfaceTester;
 };
 

--- a/geometry/query_results/mesh_field.h
+++ b/geometry/query_results/mesh_field.h
@@ -1,6 +1,11 @@
 #pragma once
 
+#include <memory>
+
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_nodiscard.h"
+#include "drake/common/reset_on_copy.h"
+#include "drake/geometry/query_results/surface_mesh.h"
 
 namespace drake {
 namespace geometry {
@@ -18,20 +23,61 @@ template <class FieldValue, class MeshType>
 //  a scalar type explicit here for some additional error checking.
 class MeshField {
  public:
+  virtual ~MeshField() = default;
   /** Evaluates the field value at a location on an element.
-    @param e The index of the element.
-    @param b The barycentric coordinates.
+   @param e The index of the element.
+   @param b The barycentric coordinates.
    */
   virtual FieldValue Evaluate(
       const typename MeshType::ElementIndex e,
       const typename MeshType::Barycentric& b) const = 0;
 
+  /** Copy to a new %MeshField and set the new %MeshField to use a new
+   compatible mesh. %MeshField needs a mesh to operate; however, %MeshField
+   does not own the mesh. In fact, several %MeshField objects can use the same
+   mesh.
+   */
+  DRAKE_NODISCARD std::unique_ptr<MeshField> CloneAndSetMesh(
+      MeshType* new_mesh) const {
+    DRAKE_DEMAND(new_mesh != nullptr);
+    DRAKE_DEMAND(new_mesh->num_vertices() == mesh_->num_vertices());
+    // TODO(DamrongGuoy): Check that the `new_mesh` is equivalent to the
+    //  current `mesh_`.
+    std::unique_ptr<MeshField> new_mesh_field = CloneWithNullMesh();
+    new_mesh_field->mesh_ = new_mesh;
+    return new_mesh_field;
+  }
+
+  const MeshType& mesh() const { return *mesh_; }
+
  protected:
+  DRAKE_NODISCARD std::unique_ptr<MeshField> CloneWithNullMesh() const {
+    return DoCloneWithNullMesh();
+  }
+  /** Derived classes must implement this method to clone themselves given
+   that the pointer to the mesh is null.
+   */
+  DRAKE_NODISCARD virtual std::unique_ptr<MeshField> DoCloneWithNullMesh()
+      const = 0;
+
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(MeshField)
-  MeshField() = default;
-  virtual ~MeshField() = default;
+  explicit MeshField(MeshType* mesh): mesh_(mesh) {
+    DRAKE_DEMAND(mesh_ != nullptr);
+  }
+
+ private:
+  // We use `reset_on_copy` so that the default copy constructor resets
+  // the pointer to null when a MeshField is copied.
+  reset_on_copy<MeshType*> mesh_;
 };
 
+/**
+ @tparam FieldValue  a valid Eigen scalar or vector of valid Eigen scalars for
+                     the field value.
+ @tparam T  a valid Eigen scalar for coordinates.
+ */
+template <typename FieldValue, typename T>
+using SurfaceMeshField = MeshField<FieldValue, SurfaceMesh<T>>;
 
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/query_results/surface_mesh.h
+++ b/geometry/query_results/surface_mesh.h
@@ -148,6 +148,10 @@ class SurfaceMesh {
     return vertices_[v];
   }
 
+  /** Returns the number of vertices in the mesh.
+   */
+  int num_vertices() const { return vertices_.size(); }
+
   //@}
 
   /** Constructs a SurfaceMesh from faces and vertices.
@@ -165,10 +169,6 @@ class SurfaceMesh {
   /** Returns the number of triangular elements in the mesh.
    */
   int num_faces() const { return faces_.size(); }
-
-  /** Returns the number of vertices in the mesh.
-   */
-  int num_vertices() const { return vertices_.size(); }
 
   /** Returns area of a triangular element.
    */


### PR DESCRIPTION
Change the copy constructor of ContactSurface to use the MeshField::CloneAndSetMesh().  ContactSurface owns both MeshField and Mesh. MeshField uses Mesh; however, it does not own Mesh.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11494)
<!-- Reviewable:end -->
