### PR TITLE
Re-order context python bindings to match context.h

### DIFF
--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -122,6 +122,10 @@ class TestGeneral(unittest.TestCase):
             context.get_continuous_state_vector(), VectorBase)
         self.assertIsInstance(
             context.get_mutable_continuous_state_vector(), VectorBase)
+        self.assertTrue(context.is_stateless())
+        self.assertFalse(context.has_only_continuous_state())
+        self.assertFalse(context.has_only_discrete_state())
+        self.assertEqual(context.num_total_states(), 0)
         # TODO(eric.cousineau): Consolidate main API tests for `Context` here.
 
         # Test methods with two scalar types.


### PR DESCRIPTION
Also adds TODOs for remaining missing methods.  (I'm tired of running into them one at a time!)

Implements the three trivial missing bindings: is_stateless, has_only_continuous_state, has_only_discrete_state.
Apart from these three additions, there are no other functional changes in this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11499)
<!-- Reviewable:end -->
