### PR TITLE
bugfix - Signed distance queries with a zero threshold lose results

### DIFF
--- a/geometry/proximity/distance_to_point.h
+++ b/geometry/proximity/distance_to_point.h
@@ -3,6 +3,7 @@
 // Exclude internal classes from doxygen.
 #if !defined(DRAKE_DOXYGEN_CXX)
 
+#include <algorithm>
 #include <limits>
 #include <tuple>
 #include <vector>
@@ -544,10 +545,21 @@ bool Callback(fcl::CollisionObjectd* object_A_ptr,
               void* callback_data, double& threshold) {
   auto& data = *static_cast<CallbackData<T>*>(callback_data);
 
-  // We intentionally pass the same number back to FCL in every callback.
-  // It instructs FCL to skip any objects proven to be beyond this threshold
-  // distance (for example, by checking bounding boxes).
-  threshold = data.threshold;
+  // Three things:
+  //   1. We repeatedly set max_distance in each call to the callback because we
+  //   can't initialize it. The cost is negligible but maximizes any culling
+  //   benefit.
+  //   2. Due to how FCL is implemented, passing a value <= 0 will cause results
+  //   to be omitted because the bounding box test only considers *separating*
+  //   distance and doesn't do any work if the distance between bounding boxes
+  //   is zero.
+  //   3. We pass in a number smaller than the typical epsilon because typically
+  //   computation tolerances are greater than or equal to epsilon() and we
+  //   don't want this value to trip those tolerances. This is safe because the
+  //   bounding box test in which this is used doesn't produce a code via
+  //   calculation; it is a perfect, hard-coded zero.
+  const double kEps = std::numeric_limits<double>::epsilon() / 10;
+  threshold = std::max(data.threshold, kEps);
 
   // We use `const` to prevent modification of the collision objects.
   const fcl::CollisionObjectd* geometry_object =


### PR DESCRIPTION
FCL is fundamentally incompatible with a zero-valued threshold. The
broadphase has a *special* function for traversing for distance. This
function assumes that it is only reporting *separating* distance. As such,
it only computes box *separating* distance and doesn't even take action if
the boxes are intersecting.

So, in order to avoid falling into that beartrap, we make sure that we
always pass in a positive tolerance and rely on Drake-side culling to
eliminate any distance results that don't satisfy the threshold.

resolves #10934 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11508)
<!-- Reviewable:end -->
