### PR TITLE
Move MakeDrakeVisualizerProperties

### DIFF
--- a/attic/multibody/rigid_body_plant/BUILD.bazel
+++ b/attic/multibody/rigid_body_plant/BUILD.bazel
@@ -88,7 +88,7 @@ drake_cc_library(
     deps = [
         "//attic/multibody:rigid_body_tree",
         "//geometry:geometry_ids",
-        "//geometry:geometry_visualization",
+        "//geometry:geometry_roles",
         "//geometry:scene_graph",
     ],
 )

--- a/attic/multibody/rigid_body_plant/rigid_body_plant_bridge.cc
+++ b/attic/multibody/rigid_body_plant/rigid_body_plant_bridge.cc
@@ -9,7 +9,6 @@
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/geometry_roles.h"
-#include "drake/geometry/geometry_visualization.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/framework_common.h"
 
@@ -24,7 +23,7 @@ using geometry::GeometryFrame;
 using geometry::GeometryId;
 using geometry::GeometryInstance;
 using geometry::IllustrationProperties;
-using geometry::MakeDrakeVisualizerProperties;
+using geometry::MakePhongIllustrationProperties;
 using geometry::Mesh;
 using geometry::ProximityProperties;
 using geometry::SceneGraph;
@@ -160,7 +159,7 @@ void RigidBodyPlantBridge<T>::RegisterTree(SceneGraph<T>* scene_graph) {
         // Illustration properties -- simply pass the diffuse along.
         const Vector4<double>& diffuse = visual_element.getMaterial();
         scene_graph->AssignRole(source_id_, id,
-                                MakeDrakeVisualizerProperties(diffuse));
+                                MakePhongIllustrationProperties(diffuse));
       }
     }
     int collision_count = 0;

--- a/automotive/automotive_simulator.cc
+++ b/automotive/automotive_simulator.cc
@@ -205,7 +205,7 @@ void AutomotiveSimulator<T>::ConnectCarOutputsAndPriusVis(
   scene_graph_->AssignRole(source_id, geometry_id,
                            geometry::IllustrationProperties());
   const geometry::IllustrationProperties grey =
-      geometry::MakeDrakeVisualizerProperties(
+      geometry::MakePhongIllustrationProperties(
           Eigen::Vector4d(0.2, 0.2, 0.2, 1.0));
   geometry_id = scene_graph_->RegisterGeometry(
       source_id, frame_id,

--- a/examples/pendulum/BUILD.bazel
+++ b/examples/pendulum/BUILD.bazel
@@ -44,7 +44,7 @@ drake_cc_library(
     deps = [
         ":pendulum_plant",
         ":pendulum_vector_types",
-        "//geometry:geometry_visualization",
+        "//geometry:geometry_roles",
         "//geometry:scene_graph",
         "//math:geometric_transform",
         "//systems/framework:diagram_builder",

--- a/examples/pendulum/pendulum_geometry.cc
+++ b/examples/pendulum/pendulum_geometry.cc
@@ -8,7 +8,7 @@
 #include "drake/geometry/geometry_frame.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/geometry_instance.h"
-#include "drake/geometry/geometry_visualization.h"
+#include "drake/geometry/geometry_roles.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/math/rotation_matrix.h"
 
@@ -24,7 +24,7 @@ using geometry::Cylinder;
 using geometry::GeometryFrame;
 using geometry::GeometryId;
 using geometry::GeometryInstance;
-using geometry::MakeDrakeVisualizerProperties;
+using geometry::MakePhongIllustrationProperties;
 using geometry::Sphere;
 using std::make_unique;
 
@@ -71,7 +71,7 @@ PendulumGeometry::PendulumGeometry(geometry::SceneGraph<double>* scene_graph) {
       make_unique<GeometryInstance>(Isometry3d(Translation3d(0., 0., .025)),
                                     make_unique<Box>(.05, 0.05, 0.05), "base"));
   scene_graph->AssignRole(
-      source_id_, id, MakeDrakeVisualizerProperties(Vector4d(.3, .6, .4, 1)));
+      source_id_, id, MakePhongIllustrationProperties(Vector4d(.3, .6, .4, 1)));
 
   // The arm.
   id = scene_graph->RegisterGeometry(
@@ -80,7 +80,7 @@ PendulumGeometry::PendulumGeometry(geometry::SceneGraph<double>* scene_graph) {
           Isometry3d(Translation3d(0, 0, -length / 2.)),
           make_unique<Cylinder>(0.01, length), "arm"));
   scene_graph->AssignRole(
-      source_id_, id, MakeDrakeVisualizerProperties(Vector4d(.9, .1, 0, 1)));
+      source_id_, id, MakePhongIllustrationProperties(Vector4d(.9, .1, 0, 1)));
 
   // The mass at the end of the arm.
   id = scene_graph->RegisterGeometry(
@@ -89,7 +89,7 @@ PendulumGeometry::PendulumGeometry(geometry::SceneGraph<double>* scene_graph) {
           Isometry3d(Translation3d(0, 0, -length)),
           make_unique<Sphere>(mass / 40.), "arm point mass"));
   scene_graph->AssignRole(
-      source_id_, id, MakeDrakeVisualizerProperties(Vector4d(0, 0, 1, 1)));
+      source_id_, id, MakePhongIllustrationProperties(Vector4d(0, 0, 1, 1)));
 }
 
 PendulumGeometry::~PendulumGeometry() = default;

--- a/examples/scene_graph/BUILD.bazel
+++ b/examples/scene_graph/BUILD.bazel
@@ -67,7 +67,7 @@ drake_cc_library(
     deps = [
         "//common",
         "//geometry:geometry_ids",
-        "//geometry:geometry_visualization",
+        "//geometry:geometry_roles",
         "//geometry:scene_graph",
         "//math:geometric_transform",
         "//systems/framework:leaf_system",

--- a/examples/scene_graph/solar_system.cc
+++ b/examples/scene_graph/solar_system.cc
@@ -9,7 +9,6 @@
 #include "drake/geometry/geometry_frame.h"
 #include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/geometry_roles.h"
-#include "drake/geometry/geometry_visualization.h"
 #include "drake/systems/framework/continuous_state.h"
 #include "drake/systems/framework/discrete_values.h"
 
@@ -27,7 +26,7 @@ using geometry::GeometryFrame;
 using geometry::GeometryId;
 using geometry::GeometryInstance;
 using geometry::IllustrationProperties;
-using geometry::MakeDrakeVisualizerProperties;
+using geometry::MakePhongIllustrationProperties;
 using geometry::SceneGraph;
 using geometry::Mesh;
 using geometry::SourceId;
@@ -137,7 +136,7 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
   axes_.reserve(kBodyCount);
 
   IllustrationProperties post_material =
-      MakeDrakeVisualizerProperties(Vector4d(0.3, 0.15, 0.05, 1));
+      MakePhongIllustrationProperties(Vector4d(0.3, 0.15, 0.05, 1));
   const double orrery_bottom = -1.5;
   const double pipe_radius = 0.05;
 
@@ -148,8 +147,8 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
       source_id_, make_unique<GeometryInstance>(
                       Isometry3<double>::Identity(), make_unique<Sphere>(1.f),
                       "sun"));
-  scene_graph->AssignRole(source_id_, id,
-                          MakeDrakeVisualizerProperties(Vector4d(1, 1, 0, 1)));
+  scene_graph->AssignRole(
+      source_id_, id, MakePhongIllustrationProperties(Vector4d(1, 1, 0, 1)));
 
   // The fixed post on which Sun sits and around which all planets rotate.
   const double post_height = 1;
@@ -186,8 +185,8 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
       source_id_, planet_id,
       make_unique<GeometryInstance>(X_OeE, make_unique<Sphere>(0.25f),
                                     "Earth"));
-  scene_graph->AssignRole(source_id_, id,
-                          MakeDrakeVisualizerProperties(Vector4d(0, 0, 1, 1)));
+  scene_graph->AssignRole(
+      source_id_, id, MakePhongIllustrationProperties(Vector4d(0, 0, 1, 1)));
   // Earth's orrery arm.
   MakeArm(source_id_, planet_id, kEarthOrbitRadius, -kEarthBottom, pipe_radius,
           post_material, scene_graph);
@@ -216,7 +215,7 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
           X_OlL, make_unique<Sphere>(0.075f), "Luna"));
   scene_graph->AssignRole(
       source_id_, id,
-      MakeDrakeVisualizerProperties(Vector4d(0.5, 0.5, 0.35, 1)));
+      MakePhongIllustrationProperties(Vector4d(0.5, 0.5, 0.35, 1)));
 
   // Convex satellite orbits Earth in the same revolution as Luna but with
   // different initial position. See SetDefaultState().
@@ -233,8 +232,8 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
       make_unique<GeometryInstance>(
           X_OlL, make_unique<Convex>(convexsat_absolute_path, 0.075),
           "convexsat"));
-  scene_graph->AssignRole(source_id_, id,
-                          MakeDrakeVisualizerProperties(Vector4d(1, 1, 0, 1)));
+  scene_graph->AssignRole(
+      source_id_, id, MakePhongIllustrationProperties(Vector4d(1, 1, 0, 1)));
 
   // Box satellite orbits Earth in the same revolution as Luna but with
   // different initial position. See SetDefaultState().
@@ -248,8 +247,8 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
       source_id_, boxsat_id,
       make_unique<GeometryInstance>(
           X_OlL, make_unique<Box>(0.15, 0.15, 0.15), "boxsat"));
-  scene_graph->AssignRole(source_id_, id,
-                          MakeDrakeVisualizerProperties(Vector4d(1, 0, 1, 1)));
+  scene_graph->AssignRole(
+      source_id_, id, MakePhongIllustrationProperties(Vector4d(1, 0, 1, 1)));
 
   // Mars's orbital frame Om lies directly *below* the sun (to account for the
   // orrery arm).
@@ -273,7 +272,7 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
                                     "Mars"));
   scene_graph->AssignRole(
       source_id_, mars_geometry_id,
-      MakeDrakeVisualizerProperties(Vector4d(0.9, 0.1, 0, 1)));
+      MakePhongIllustrationProperties(Vector4d(0.9, 0.1, 0, 1)));
 
   std::string rings_absolute_path =
       FindResourceOrThrow("drake/examples/scene_graph/planet_rings.obj");
@@ -284,8 +283,8 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
       make_unique<GeometryInstance>(
           X_MR, make_unique<Mesh>(rings_absolute_path, kMarsSize),
           "MarsRings"));
-  scene_graph->AssignRole(
-      source_id_, id, MakeDrakeVisualizerProperties(Vector4d(0.45, 0.9, 0, 1)));
+  scene_graph->AssignRole(source_id_, id, MakePhongIllustrationProperties(
+                                              Vector4d(0.45, 0.9, 0, 1)));
 
   // Mars's orrery arm.
   MakeArm(source_id_, planet_id, kMarsOrbitRadius, -orrery_bottom, pipe_radius,
@@ -310,7 +309,7 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
                                  X_OpP, make_unique<Sphere>(0.06f), "Phobos"));
   scene_graph->AssignRole(
       source_id_, id,
-      MakeDrakeVisualizerProperties(Vector4d(0.65, 0.6, 0.8, 1)));
+      MakePhongIllustrationProperties(Vector4d(0.65, 0.6, 0.8, 1)));
 
   DRAKE_DEMAND(static_cast<int>(body_ids_.size()) == kBodyCount);
 }

--- a/geometry/dev/geometry_visualization.cc
+++ b/geometry/dev/geometry_visualization.cc
@@ -285,14 +285,6 @@ systems::lcm::LcmPublisherSystem* ConnectDrakeVisualizer(
   return publisher;
 }
 
-IllustrationProperties MakeDrakeVisualizerProperties(
-    const Vector4<double>& diffuse) {
-  IllustrationProperties props;
-  props.AddGroup("phong");
-  props.AddProperty("phong", "diffuse", diffuse);
-  return props;
-}
-
 }  // namespace dev
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/dev/geometry_visualization.h
+++ b/geometry/dev/geometry_visualization.h
@@ -51,10 +51,12 @@ class GeometryVisualizationImpl {
  @ref geometry_roles for details). Specifically, only geometries with
  the illustration role assigned will be included. The visualization function
  looks for the following properties in the IllustrationProperties instance.
+
  | Group name | Required | Property Name |  Property Type  | Property Description |
  | :--------: | :------: | :-----------: | :-------------: | :------------------- |
  |    phong   | no       | diffuse       | Eigen::Vector4d | The rgba value of the object surface |
- See MakeDrakeVisualizerProperties() to facilitate making a compliant set of
+
+ See MakePhongIllustrationProperties() to facilitate making a compliant set of
  illustration properties.
 
  You can then connect source output ports for visualization like this:
@@ -90,11 +92,6 @@ systems::lcm::LcmPublisherSystem* ConnectDrakeVisualizer(
     systems::DiagramBuilder<double>* builder,
     const SceneGraph<double>& scene_graph,
     lcm::DrakeLcmInterface* lcm = nullptr);
-
-/** Constructs an IllustrationProperties instance compatible with the
- ConnectDrakeVisualizer incorporating the given diffuse color. */
-IllustrationProperties MakeDrakeVisualizerProperties(
-    const Vector4<double>& diffuse);
 
 /** (Advanced) Explicitly dispatches an LCM load message based on the registered
  geometry. Normally this is done automatically at Simulator initialization. But

--- a/geometry/dev/test/geometry_visualization_test.cc
+++ b/geometry/dev/test/geometry_visualization_test.cc
@@ -49,7 +49,7 @@ GTEST_TEST(GeometryVisualization, SimpleScene) {
       Isometry3d::Identity(), make_unique<Sphere>(radius), "sphere");
   Vector4<double> color{r, g, b, a};
   instance->set_illustration_properties(
-      geometry::MakeDrakeVisualizerProperties(color));
+      geometry::MakePhongIllustrationProperties(color));
   scene_graph.RegisterGeometry(source_id, frame_id, std::move(instance));
 
   unique_ptr<Context<double>> context = scene_graph.AllocateContext();

--- a/geometry/geometry_roles.cc
+++ b/geometry/geometry_roles.cc
@@ -24,5 +24,12 @@ std::ostream& operator<<(std::ostream& out, const Role& role) {
   return out;
 }
 
+IllustrationProperties MakePhongIllustrationProperties(
+    const Vector4<double>& diffuse) {
+  IllustrationProperties props;
+  props.AddProperty("phong", "diffuse", diffuse);
+  return props;
+}
+
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/geometry_roles.h
+++ b/geometry/geometry_roles.h
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
 #include "drake/geometry/geometry_properties.h"
 
 namespace drake {
@@ -199,6 +200,18 @@ enum class Role {
 std::string to_string(const Role& role);
 
 std::ostream& operator<<(std::ostream& out, const Role& role);
+
+//@}
+
+/** @name  Convenience functions
+
+ A collection of functions to help facilitate working with properties.  */
+//@{
+
+/** Constructs an IllustrationProperties instance compatible with a simple
+ "phong" material using only the given `diffuse` color.  */
+IllustrationProperties MakePhongIllustrationProperties(
+    const Vector4<double>& diffuse);
 
 //@}
 

--- a/geometry/geometry_visualization.cc
+++ b/geometry/geometry_visualization.cc
@@ -292,9 +292,7 @@ systems::lcm::LcmPublisherSystem* ConnectDrakeVisualizer(
 
 IllustrationProperties MakeDrakeVisualizerProperties(
     const Vector4<double>& diffuse) {
-  IllustrationProperties props;
-  props.AddProperty("phong", "diffuse", diffuse);
-  return props;
+  return MakePhongIllustrationProperties(diffuse);
 }
 
 }  // namespace geometry

--- a/geometry/geometry_visualization.h
+++ b/geometry/geometry_visualization.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/geometry/geometry_state.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/lcm/drake_lcm_interface.h"
@@ -53,7 +54,8 @@ class GeometryVisualizationImpl {
  | Group name | Required | Property Name |  Property Type  | Property Description |
  | :--------: | :------: | :-----------: | :-------------: | :------------------- |
  |    phong   | no       | diffuse       | Eigen::Vector4d | The rgba value of the object surface |
- See MakeDrakeVisualizerProperties() to facilitate making a compliant set of
+
+ See MakePhongIllustrationProperties() to facilitate making a compliant set of
  illustration properties.
 
  You can then connect source output ports for visualization like this:
@@ -108,6 +110,8 @@ systems::lcm::LcmPublisherSystem* ConnectDrakeVisualizer(
 
 /** Constructs an IllustrationProperties instance compatible with the
  ConnectDrakeVisualizer incorporating the given diffuse color.  */
+DRAKE_DEPRECATED("2019-09-01",
+    "Please use MakePhongIllustrationProperties() instead")
 IllustrationProperties MakeDrakeVisualizerProperties(
     const Vector4<double>& diffuse);
 

--- a/geometry/test/geometry_visualization_test.cc
+++ b/geometry/test/geometry_visualization_test.cc
@@ -48,7 +48,7 @@ GTEST_TEST(GeometryVisualization, SimpleScene) {
                                     make_unique<Sphere>(radius), "sphere"));
   Vector4<double> color{r, g, b, a};
   scene_graph.AssignRole(source_id, sphere_id,
-                         MakeDrakeVisualizerProperties(color));
+                         MakePhongIllustrationProperties(color));
 
   // Add a second frame and geometry that only has proximity properties. It
   // should not impact the result.

--- a/manipulation/models/ycb/BUILD.bazel
+++ b/manipulation/models/ycb/BUILD.bazel
@@ -33,6 +33,7 @@ drake_cc_googletest(
     data = [":models"],
     deps = [
         "//common:find_resource",
+        "//geometry:geometry_visualization",
         "//multibody/parsing",
         "//multibody/plant",
         "//systems/analysis:simulator",

--- a/multibody/optimization/BUILD.bazel
+++ b/multibody/optimization/BUILD.bazel
@@ -92,6 +92,7 @@ drake_cc_library(
     hdrs = ["test/optimization_with_contact_utilities.h"],
     visibility = ["//visibility:private"],
     deps = [
+        "//geometry:geometry_visualization",
         "//geometry:scene_graph",
         "//multibody/plant",
         "//systems/analysis:simulator",

--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -104,7 +104,7 @@ drake_cc_library(
     deps = [
         ":detail_misc",
         ":package_map",
-        "//geometry:geometry_visualization",
+        "//geometry:geometry_roles",
         "//geometry:scene_graph",
         "//multibody/plant:coulomb_friction",
         "@sdformat",

--- a/multibody/parsing/detail_urdf_geometry.cc
+++ b/multibody/parsing/detail_urdf_geometry.cc
@@ -9,7 +9,6 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/text_logging.h"
 #include "drake/geometry/geometry_roles.h"
-#include "drake/geometry/geometry_visualization.h"
 #include "drake/multibody/parsing/detail_common.h"
 #include "drake/multibody/parsing/detail_path_utils.h"
 #include "drake/multibody/parsing/detail_tinyxml.h"
@@ -335,7 +334,7 @@ geometry::GeometryInstance ParseVisual(
     // node, use that color. It takes precedence over any material saved in
     // the material map.
     if (color_specified) {
-      properties = geometry::MakeDrakeVisualizerProperties(rgba);
+      properties = geometry::MakePhongIllustrationProperties(rgba);
     } else if (name_specified) {
       // No color specified. Checks if the material is already in the
       // materials map.
@@ -345,7 +344,7 @@ geometry::GeometryInstance ParseVisual(
         // The material is in the map. Sets the material of the visual
         // element based on the value in the map.
         properties =
-            geometry::MakeDrakeVisualizerProperties(material_iter->second);
+            geometry::MakePhongIllustrationProperties(material_iter->second);
       }
     }
   }

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -55,7 +55,7 @@ drake_cc_library(
         ":implicit_stribeck_solver_results",
         "//common:default_scalars",
         "//geometry:geometry_ids",
-        "//geometry:geometry_visualization",
+        "//geometry:geometry_roles",
         "//geometry:scene_graph",
         "//math:geometric_transform",
         "//math:orthonormal_basis",

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -11,7 +11,7 @@
 #include "drake/geometry/frame_kinematics_vector.h"
 #include "drake/geometry/geometry_frame.h"
 #include "drake/geometry/geometry_instance.h"
-#include "drake/geometry/geometry_visualization.h"
+#include "drake/geometry/geometry_roles.h"
 #include "drake/math/orthonormal_basis.h"
 #include "drake/math/random_rotation.h"
 #include "drake/math/rotation_matrix.h"
@@ -309,7 +309,7 @@ geometry::GeometryId MultibodyPlant<T>::RegisterVisualGeometry(
     SceneGraph<T>* scene_graph) {
   return RegisterVisualGeometry(
       body, X_BG, shape, name,
-      geometry::MakeDrakeVisualizerProperties(diffuse_color), scene_graph);
+      geometry::MakePhongIllustrationProperties(diffuse_color), scene_graph);
 }
 
 template <typename T>


### PR DESCRIPTION
This utility function was causing other code that used it to end up dependent on LCM. The solution is to move it out of geometry_visualization.

The movement led to a name change (since it's now presented as a more general utility.)  So, this changes all the call sites with the new, generic name.

Closes #11507.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11515)
<!-- Reviewable:end -->
