### PR TITLE
Statically link osqp and qldl libraries and set visibility to hidden

### DIFF
--- a/tools/workspace/osqp/package.BUILD.bazel
+++ b/tools/workspace/osqp/package.BUILD.bazel
@@ -97,8 +97,10 @@ cc_library(
         "lin_sys/direct/qdldl/amd/include",
     ],
     copts = [
+        "-fvisibility=hidden",
         "-w",
     ],
+    linkstatic = 1,
     deps = [
         "@qdldl",
     ],

--- a/tools/workspace/qdldl/package.BUILD.bazel
+++ b/tools/workspace/qdldl/package.BUILD.bazel
@@ -39,9 +39,13 @@ cc_library(
     srcs = [
         "src/qdldl.c",
     ],
+    copts = [
+        "-fvisibility=hidden",
+    ],
     includes = [
         "include",
     ],
+    linkstatic = 1,
 )
 
 install(


### PR DESCRIPTION
Looks like this was missed in https://github.com/RobotLocomotion/drake/commit/9f8a3379c42e94890ce2cacda2e8d57c99aa5ca0.

<!-- Reviewable:start -->
----
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11516)
<!-- Reviewable:end -->
