### PR TITLE
Move generic code from MinDistConstraint to MinimumValueConstraint.

### DIFF
--- a/doc/doxygen_extra.css
+++ b/doc/doxygen_extra.css
@@ -92,3 +92,10 @@ div.toc h3 {
 #powerTip div {
   font-family: 'DejaVu Sans', sans-serif;
 }
+
+/* Custom CSS */
+
+pre.unicode-art {
+  font-family: 'DejaVu Sans Mono', monospace;
+  line-height: 1em;
+}

--- a/multibody/inverse_kinematics/BUILD.bazel
+++ b/multibody/inverse_kinematics/BUILD.bazel
@@ -129,6 +129,7 @@ drake_cc_googletest(
         ":inverse_kinematics_test_utilities",
         ":kinematic_constraint",
         "//common/test_utilities:expect_throws_message",
+        "//solvers/test_utilities",
     ],
 )
 

--- a/multibody/inverse_kinematics/BUILD.bazel
+++ b/multibody/inverse_kinematics/BUILD.bazel
@@ -48,6 +48,7 @@ drake_cc_library(
         "//math:gradient",
         "//multibody/plant",
         "//solvers:constraint",
+        "//solvers:minimum_value_constraint",
     ],
 )
 

--- a/multibody/inverse_kinematics/inverse_kinematics.cc
+++ b/multibody/inverse_kinematics/inverse_kinematics.cc
@@ -81,11 +81,12 @@ InverseKinematics::AddAngleBetweenVectorsConstraint(
 }
 
 solvers::Binding<solvers::Constraint>
-InverseKinematics::AddMinimumDistanceConstraint(double minimum_distance,
-                                                double threshold_distance) {
-  auto constraint = std::make_shared<MinimumDistanceConstraint>(
-      &plant_, minimum_distance, get_mutable_context(),
-      &QuadraticallySmoothedHingeLoss, threshold_distance);
+InverseKinematics::AddMinimumDistanceConstraint(
+    double minimum_distance, double influence_distance_offset) {
+  auto constraint =
+      std::shared_ptr<MinimumDistanceConstraint>(new MinimumDistanceConstraint(
+          &plant_, minimum_distance, get_mutable_context(), {},
+          influence_distance_offset));
   return prog_->AddConstraint(constraint, q_);
 }
 }  // namespace multibody

--- a/multibody/inverse_kinematics/inverse_kinematics.h
+++ b/multibody/inverse_kinematics/inverse_kinematics.h
@@ -204,7 +204,7 @@ class InverseKinematics {
    * @pre 0 < `influence_distance_offset` < ∞
    */
   solvers::Binding<solvers::Constraint> AddMinimumDistanceConstraint(
-      double minimum_distance, double threshold_distance = 1);
+      double minimum_distance, double influence_distance_offset = 1);
 
   /** Getter for q. q is the decision variable for the generalized positions of
    * the robot. */

--- a/multibody/inverse_kinematics/minimum_distance_constraint.cc
+++ b/multibody/inverse_kinematics/minimum_distance_constraint.cc
@@ -11,83 +11,6 @@ namespace drake {
 namespace multibody {
 using internal::RefFromPtrOrThrow;
 
-namespace {
-/** Computes log(∑exp(xᵢ)). Exploits the shift invariance of log-sum-exp to
-avoid overflow. */
-template <typename T>
-T LogSumExp(const std::vector<T>& x) {
-  using std::exp;
-  using std::log;
-  const T x_max = *std::max_element(x.begin(), x.end());
-  T sum_exp{0.0};
-  for (const T& xi : x) {
-    sum_exp += exp(xi - x_max);
-  }
-  return x_max + log(sum_exp);
-}
-
-/** Computes a smooth approximation of max(x). */
-template <typename T>
-T SmoothMax(const std::vector<T>& x) {
-  // We compute the soft-max of x as softmax(x) = log(∑ᵢ exp(αxᵢ)) / α.
-  // This soft-max approaches max(x) as α increases. We choose α = 100, as that
-  // gives a qualitatively good fit for xᵢ ∈ [0, 1], which is the range of
-  // potential penalty values when the MinimumDistanceConstraint is feasible.
-  const double alpha{100};
-  std::vector<T> x_scaled{x};
-  for (T& xi_scaled : x_scaled) {
-    xi_scaled *= alpha;
-  }
-  return LogSumExp(x_scaled) / alpha;
-}
-
-template <typename T>
-T ScaleDistance(T distance, double minimum_distance,
-                double influence_distance) {
-  return (distance - influence_distance) /
-         (influence_distance - minimum_distance);
-}
-
-}  // namespace
-
-void ExponentiallySmoothedHingeLoss(double x, double* penalty,
-                                    double* dpenalty_dx) {
-  if (x >= 0) {
-    *penalty = 0;
-    if (dpenalty_dx) {
-      *dpenalty_dx = 0;
-    }
-  } else {
-    const double exp_one_over_x = std::exp(1.0 / x);
-    *penalty = -x * exp_one_over_x;
-    if (dpenalty_dx) {
-      *dpenalty_dx = -exp_one_over_x + exp_one_over_x / x;
-    }
-  }
-}
-
-void QuadraticallySmoothedHingeLoss(double x, double* penalty,
-                                    double* dpenalty_dx) {
-  if (x >= 0) {
-    *penalty = 0;
-    if (dpenalty_dx) {
-      *dpenalty_dx = 0;
-    }
-  } else {
-    if (x > -1) {
-      *penalty = x * x / 2;
-      if (dpenalty_dx) {
-        *dpenalty_dx = x;
-      }
-    } else {
-      *penalty = -0.5 - x;
-      if (dpenalty_dx) {
-        *dpenalty_dx = -1;
-      }
-    }
-  }
-}
-
 MinimumDistanceConstraint::MinimumDistanceConstraint(
     const multibody::MultibodyPlant<double>* const plant,
     double minimum_distance, systems::Context<double>* plant_context,
@@ -96,22 +19,7 @@ MinimumDistanceConstraint::MinimumDistanceConstraint(
     : solvers::Constraint(1, RefFromPtrOrThrow(plant).num_positions(),
                           Vector1d(0), Vector1d(1)),
       plant_{RefFromPtrOrThrow(plant)},
-      minimum_distance_{minimum_distance},
-      influence_distance_{minimum_distance + influence_distance_offset},
-      // Since penalty_function uses output parameters rather than a return
-      // value, we construct a lambda and then call it immediately to compute
-      // the output scaling factor.
-      penalty_output_scaling_{
-          1.0 /
-          [&penalty_function](double x) {
-            double upper_bound{};
-            double dummy{};
-            penalty_function(x, &upper_bound, &dummy);
-            return upper_bound;
-          }(ScaleDistance(minimum_distance, minimum_distance,
-                          minimum_distance + influence_distance_offset))},
-      plant_context_{plant_context},
-      penalty_function_{penalty_function} {
+      plant_context_{plant_context} {
   if (!plant_.geometry_source_is_registered()) {
     throw std::invalid_argument(
         "MinimumDistanceConstraint: MultibodyPlant has not registered its "
@@ -139,47 +47,38 @@ MinimumDistanceConstraint::MinimumDistanceConstraint(
   }
   // Maximum number of SignedDistancePairs returned by calls to
   // ComputeSignedDistancePairwiseClosestPoints().
-  num_collision_candidates_ =
+  const int num_collision_candidates =
       query_port.Eval<geometry::QueryObject<double>>(*plant_context_)
           .inspector()
           .GetCollisionCandidates()
           .size();
+  minimum_value_constraint_ = std::make_unique<solvers::MinimumValueConstraint>(
+      this->num_vars(), minimum_distance, influence_distance_offset,
+      num_collision_candidates,
+      std::bind(&MinimumDistanceConstraint::Distances<AutoDiffXd>, this,
+                std::placeholders::_1, std::placeholders::_2),
+      std::bind(&MinimumDistanceConstraint::Distances<double>, this,
+                std::placeholders::_1, std::placeholders::_2));
+  if (penalty_function) {
+    minimum_value_constraint_->set_penalty_function(penalty_function);
+  }
 }
 
 namespace {
-void InitializeY(const Eigen::Ref<const Eigen::VectorXd>&, Eigen::VectorXd* y,
-                 double y_value) {
-  (*y)(0) = y_value;
+void Distance(const MultibodyPlant<double>&, const systems::Context<double>&,
+              const Frame<double>&, const Frame<double>&,
+              const Eigen::Vector3d&, double distance, const Eigen::Vector3d&,
+              const Eigen::Ref<const AutoDiffVecXd>&, double* distance_double) {
+  *distance_double = distance;
 }
 
-void InitializeY(const Eigen::Ref<const AutoDiffVecXd>& x, AutoDiffVecXd* y,
-                 double y_value) {
-  (*y) = math::initializeAutoDiffGivenGradientMatrix(
-      Vector1d(y_value), Eigen::RowVectorXd::Zero(x(0).derivatives().size()));
-}
-
-void Penalty(const MultibodyPlant<double>&, const systems::Context<double>&,
-             const Frame<double>&, const Frame<double>&, const Eigen::Vector3d&,
-             double distance, double minimum_distance,
-             double influence_distance,
-             MinimumDistancePenaltyFunction penalty_function,
-             const Eigen::Vector3d&, const Eigen::Ref<const Eigen::VectorXd>&,
-             double* y) {
-  double penalty;
-  const double x =
-      ScaleDistance(distance, minimum_distance, influence_distance);
-  penalty_function(x, &penalty, nullptr);
-  *y = penalty;
-}
-
-void Penalty(const MultibodyPlant<double>& plant,
-             const systems::Context<double>& context,
-             const Frame<double>& frameA, const Frame<double>& frameB,
-             const Eigen::Vector3d& p_ACa, double distance,
-             double minimum_distance, double influence_distance,
-             MinimumDistancePenaltyFunction penalty_function,
-             const Eigen::Vector3d& nhat_BA_W,
-             const Eigen::Ref<const AutoDiffVecXd>& q, AutoDiffXd* y) {
+void Distance(const MultibodyPlant<double>& plant,
+              const systems::Context<double>& context,
+              const Frame<double>& frameA, const Frame<double>& frameB,
+              const Eigen::Vector3d& p_ACa, double distance,
+              const Eigen::Vector3d& nhat_BA_W,
+              const Eigen::Ref<const AutoDiffVecXd>& q,
+              AutoDiffXd* distance_autodiff) {
   // The distance is d = sign * |p_CbCa_B|, where the
   // closest points are Ca on object A, and Cb on object B.
   // So the gradient ∂d/∂q = p_CbCa_W * ∂p_BCa_B/∂q / d (Note that
@@ -194,30 +93,16 @@ void Penalty(const MultibodyPlant<double>& plant,
                                           frameA, p_ACa, frameB,
                                           plant.world_frame(), &Jq_v_BCa_W);
   const Eigen::RowVectorXd ddistance_dq = nhat_BA_W.transpose() * Jq_v_BCa_W;
-  AutoDiffXd distance_autodiff{
-      distance, ddistance_dq * math::autoDiffToGradientMatrix(q)};
-  const AutoDiffXd scaled_distance_autodiff =
-      ScaleDistance(distance_autodiff, minimum_distance, influence_distance);
-  double penalty, dpenalty_dscaled_distance;
-  penalty_function(scaled_distance_autodiff.value(), &penalty,
-                   &dpenalty_dscaled_distance);
-
-  const Vector1<AutoDiffXd> penalty_autodiff =
-      math::initializeAutoDiffGivenGradientMatrix(
-          Vector1d(penalty),
-          dpenalty_dscaled_distance *
-              math::autoDiffToGradientMatrix(
-                  Vector1<AutoDiffXd>{scaled_distance_autodiff}));
-  *y = penalty_autodiff(0);
+  distance_autodiff->value() = distance;
+  distance_autodiff->derivatives() =
+      ddistance_dq * math::autoDiffToGradientMatrix(q);
 }
 }  // namespace
 
 template <typename T>
-void MinimumDistanceConstraint::DoEvalGeneric(
-    const Eigen::Ref<const VectorX<T>>& x, VectorX<T>* y) const {
-  y->resize(1);
-
-  internal::UpdateContextConfiguration(plant_context_, plant_, x);
+VectorX<T> MinimumDistanceConstraint::Distances(
+    const Eigen::Ref<const VectorX<T>>& q, double influence_distance) const {
+  internal::UpdateContextConfiguration(plant_context_, plant_, q);
   const auto& query_port = plant_.get_geometry_query_input_port();
   if (!query_port.HasValue(*plant_context_)) {
     throw std::invalid_argument(
@@ -233,16 +118,11 @@ void MinimumDistanceConstraint::DoEvalGeneric(
   const std::vector<geometry::SignedDistancePair<double>>
       signed_distance_pairs =
           query_object.ComputeSignedDistancePairwiseClosestPoints(
-              influence_distance_);
-
-  // Initialize y to SmoothMax([0, 0, ..., 0]).
-  InitializeY(x, y,
-              SmoothMax(std::vector<double>(num_collision_candidates_, 0.0)));
-
-  std::vector<T> penalties;
+              influence_distance);
+  VectorX<T> distances(signed_distance_pairs.size());
+  int distance_count{0};
   for (const auto& signed_distance_pair : signed_distance_pairs) {
-    const double distance = signed_distance_pair.distance;
-    if (distance < influence_distance_) {
+    if (signed_distance_pair.distance < influence_distance) {
       const geometry::SceneGraphInspector<double>& inspector =
           query_object.inspector();
       const geometry::FrameId frame_A_id =
@@ -253,22 +133,21 @@ void MinimumDistanceConstraint::DoEvalGeneric(
           plant_.GetBodyFromFrameId(frame_A_id)->body_frame();
       const Frame<double>& frameB =
           plant_.GetBodyFromFrameId(frame_B_id)->body_frame();
-      penalties.emplace_back();
-      Penalty(plant_, *plant_context_, frameA, frameB,
-              inspector.X_FG(signed_distance_pair.id_A) *
-                  signed_distance_pair.p_ACa,
-              distance, minimum_distance_, influence_distance_,
-              penalty_function_, signed_distance_pair.nhat_BA_W, x,
-              &penalties.back());
-      penalties.back() *= penalty_output_scaling_;
+      Distance(plant_, *plant_context_, frameA, frameB,
+               inspector.X_FG(signed_distance_pair.id_A) *
+                   signed_distance_pair.p_ACa,
+               signed_distance_pair.distance, signed_distance_pair.nhat_BA_W, q,
+               &distances(distance_count++));
     }
   }
-  if (!penalties.empty()) {
-    // Pad penalties up to num_collision_candidates_ so that the constraint
-    // function is actually smooth.
-    penalties.resize(num_collision_candidates_, T{0.0});
-    (*y)(0) = SmoothMax(penalties);
-  }
+  distances.resize(distance_count);
+  return distances;
+}
+
+template <typename T>
+void MinimumDistanceConstraint::DoEvalGeneric(
+    const Eigen::Ref<const VectorX<T>>& x, VectorX<T>* y) const {
+  minimum_value_constraint_->Eval(x, y);
 }
 
 void MinimumDistanceConstraint::DoEval(

--- a/multibody/inverse_kinematics/minimum_distance_constraint.cc
+++ b/multibody/inverse_kinematics/minimum_distance_constraint.cc
@@ -55,10 +55,12 @@ MinimumDistanceConstraint::MinimumDistanceConstraint(
   minimum_value_constraint_ = std::make_unique<solvers::MinimumValueConstraint>(
       this->num_vars(), minimum_distance, influence_distance_offset,
       num_collision_candidates,
-      std::bind(&MinimumDistanceConstraint::Distances<AutoDiffXd>, this,
-                std::placeholders::_1, std::placeholders::_2),
-      std::bind(&MinimumDistanceConstraint::Distances<double>, this,
-                std::placeholders::_1, std::placeholders::_2));
+      [this](const auto& x, double influence_distance) {
+        return this->Distances<AutoDiffXd>(x, influence_distance);
+      },
+      [this](const auto& x, double influence_distance) {
+        return this->Distances<double>(x, influence_distance);
+      });
   this->set_bounds(minimum_value_constraint_->lower_bound(),
                    minimum_value_constraint_->upper_bound());
   if (penalty_function) {

--- a/multibody/inverse_kinematics/minimum_distance_constraint.cc
+++ b/multibody/inverse_kinematics/minimum_distance_constraint.cc
@@ -17,7 +17,7 @@ MinimumDistanceConstraint::MinimumDistanceConstraint(
     MinimumDistancePenaltyFunction penalty_function,
     double influence_distance_offset)
     : solvers::Constraint(1, RefFromPtrOrThrow(plant).num_positions(),
-                          Vector1d(0), Vector1d(1)),
+                          Vector1d(0), Vector1d(0)),
       plant_{RefFromPtrOrThrow(plant)},
       plant_context_{plant_context} {
   if (!plant_.geometry_source_is_registered()) {
@@ -59,6 +59,8 @@ MinimumDistanceConstraint::MinimumDistanceConstraint(
                 std::placeholders::_1, std::placeholders::_2),
       std::bind(&MinimumDistanceConstraint::Distances<double>, this,
                 std::placeholders::_1, std::placeholders::_2));
+  this->set_bounds(minimum_value_constraint_->lower_bound(),
+                   minimum_value_constraint_->upper_bound());
   if (penalty_function) {
     minimum_value_constraint_->set_penalty_function(penalty_function);
   }

--- a/multibody/inverse_kinematics/minimum_distance_constraint.h
+++ b/multibody/inverse_kinematics/minimum_distance_constraint.h
@@ -1,22 +1,26 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/solvers/constraint.h"
+#include "drake/solvers/minimum_value_constraint.h"
 #include "drake/systems/framework/context.h"
 
 namespace drake {
 namespace multibody {
-/** Computes the penalty function γ(x) and its derivatives dγ(x)/dx. Valid
+
+/** Computes the penalty function φ(x) and its derivatives dφ(x)/dx. Valid
 penalty functions must meet the following criteria:
 
-1.     γ(x) ≥ 0 ∀ x ∈ ℝ.
-2. dγ(x)/dx ≤ 0 ∀ x ∈ ℝ.
-3.     γ(x) = 0 ∀ x ≥ 0.
-4. dγ(x)/dx < 0 ∀ x < 0. */
-using MinimumDistancePenaltyFunction =
-    std::function<void(double x, double* penalty, double* dpenalty_dx)>;
+1.     φ(x) ≥ 0 ∀ x ∈ ℝ.
+2. dφ(x)/dx ≤ 0 ∀ x ∈ ℝ.
+3.     φ(x) = 0 ∀ x ≥ 0.
+4. dφ(x)/dx < 0 ∀ x < 0.
+
+If `dpenalty_dx` is nullptr, the function should only compute φ(x). */
+using MinimumDistancePenaltyFunction = solvers::MinimumValuePenaltyFunction;
 
 /** A hinge loss function smoothed by exponential function. This loss
 function is differentiable everywhere. The fomulation is described in
@@ -24,28 +28,26 @@ section II.C of [2].
 The penalty is
 <pre>
        ⎧ 0            if x ≥ 0
-γ(x) = ⎨
+φ(x) = ⎨
        ⎩  -x exp(1/x) if x < 0.
 </pre>
 [2] "Whole-body Motion Planning with Centroidal Dynamics and Full
 Kinematics" by Hongkai Dai, Andres Valenzuela and Russ Tedrake, IEEE-RAS
 International Conference on Humanoid Robots, 2014. */
-void ExponentiallySmoothedHingeLoss(double x, double* penalty,
-                                    double* dpenalty_dx);
+using solvers::ExponentiallySmoothedHingeLoss;
 
 /** A linear hinge loss, smoothed with a quadratic loss near the origin. The
 formulation is in equation (6) of [1].
 The penalty is
 <pre>
        ⎧  0        if x ≥ 0
-γ(x) = ⎨  x²/2     if -1 < x < 0
+φ(x) = ⎨  x²/2     if -1 < x < 0
        ⎩  -0.5 - x if x ≤ -1.
 </pre>
 [1] "Loss Functions for Preference Levels: Regression with Discrete Ordered
 Labels." by Jason Rennie and Nathan Srebro, Proceedings of IJCAI
 multidisciplinary workshop on Advances in preference handling. */
-void QuadraticallySmoothedHingeLoss(double x, double* penalty,
-                                    double* dpenalty_dx);
+using solvers::QuadraticallySmoothedHingeLoss;
 
 /** Constrain the signed distance between all candidate pairs of geometries
 (according to the logic of SceneGraphInspector::GetCollisionCandidates()) to be
@@ -53,18 +55,18 @@ no smaller than a specified minimum distance.
 
 The formulation of the constraint is
 
-0 ≤ SmoothMax( γ((dᵢ - d_influence)/(d_influence - dₘᵢₙ)) / γ(-1) ) ≤ 1
+0 ≤ SmoothMax( φ((dᵢ - d_influence)/(d_influence - dₘᵢₙ)) / φ(-1) ) ≤ 1
 
 where dᵢ is the signed distance of the i-th pair, dₘᵢₙ is the minimum allowable
 distance, d_influence is the "influence distance" (the distance below which a
-pair of geometries influences the constraint), γ is a
+pair of geometries influences the constraint), φ is a
 multibody::MinimumDistancePenaltyFunction, and SmoothMax(d) is smooth
 approximation of max(d). We require that dₘᵢₙ < d_influence. The input scaling
 (dᵢ - d_influence)/(d_influence - dₘᵢₙ) ensures that at the boundary of the
 feasible set (when dᵢ == dₘᵢₙ), we evaluate the penalty function at -1, where it
 is required to have a non-zero gradient.
 */
-class MinimumDistanceConstraint : public solvers::Constraint {
+class MinimumDistanceConstraint final : public solvers::Constraint {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MinimumDistanceConstraint)
 
@@ -88,17 +90,20 @@ class MinimumDistanceConstraint : public solvers::Constraint {
   MinimumDistanceConstraint(
       const multibody::MultibodyPlant<double>* const plant,
       double minimum_distance, systems::Context<double>* plant_context,
-      MinimumDistancePenaltyFunction penalty_function =
-          QuadraticallySmoothedHingeLoss,
+      MinimumDistancePenaltyFunction penalty_function = {},
       double influence_distance_offset = 1);
 
   ~MinimumDistanceConstraint() override {}
 
   /** Getter for the minimum distance. */
-  double minimum_distance() const { return minimum_distance_; }
+  double minimum_distance() const {
+    return minimum_value_constraint_->minimum_value();
+  }
 
   /** Getter for the influence distance. */
-  double influence_distance() const { return influence_distance_; }
+  double influence_distance() const {
+    return minimum_value_constraint_->influence_value();
+  }
 
  private:
   void DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
@@ -118,16 +123,13 @@ class MinimumDistanceConstraint : public solvers::Constraint {
   void DoEvalGeneric(const Eigen::Ref<const VectorX<T>>& x,
                      VectorX<T>* y) const;
 
+  template <typename T>
+  VectorX<T> Distances(const Eigen::Ref<const VectorX<T>>& x,
+                       double influence_distance) const;
+
   const multibody::MultibodyPlant<double>& plant_;
-  const double minimum_distance_;
-  const double influence_distance_;
-  /** Stores the value of
-  1 / γ((dₘᵢₙ - d_influence)/(d_influence - dₘᵢₙ)) = 1 / γ(-1). This is used to
-  scale the output of the penalty function to be 1 when d == dₘᵢₙ. */
-  const double penalty_output_scaling_;
-  int num_collision_candidates_{};
   systems::Context<double>* const plant_context_;
-  MinimumDistancePenaltyFunction penalty_function_;
+  std::unique_ptr<solvers::MinimumValueConstraint> minimum_value_constraint_;
 };
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/minimum_distance_constraint.h
+++ b/multibody/inverse_kinematics/minimum_distance_constraint.h
@@ -17,9 +17,7 @@ penalty functions must meet the following criteria:
 1.     φ(x) ≥ 0 ∀ x ∈ ℝ.
 2. dφ(x)/dx ≤ 0 ∀ x ∈ ℝ.
 3.     φ(x) = 0 ∀ x ≥ 0.
-4. dφ(x)/dx < 0 ∀ x < 0.
-
-If `dpenalty_dx` is nullptr, the function should only compute φ(x). */
+4. dφ(x)/dx < 0 ∀ x < 0. */
 using MinimumDistancePenaltyFunction = solvers::MinimumValuePenaltyFunction;
 
 /** A hinge loss function smoothed by exponential function. This loss

--- a/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h
+++ b/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h
@@ -17,6 +17,12 @@ namespace drake {
 namespace multibody {
 
 /**
+ * Adds two free bodies to a MultibodyPlant.
+ */
+template <typename T>
+void AddTwoFreeBodiesToPlant(MultibodyPlant<T>* model);
+
+/**
  * Constructs a MultibodyPlant consisting of two free bodies.
  */
 template <typename T>

--- a/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
@@ -157,9 +157,9 @@ class TwoFreeSpheresMinimumDistanceTest : public TwoFreeSpheresTest {
 
 TEST_F(TwoFreeSpheresMinimumDistanceTest, ExponentialPenalty) {
   const double minimum_distance(0.1);
-  const MinimumDistanceConstraint constraint(plant_double_, minimum_distance,
-                                             plant_context_double_,
-                                             ExponentiallySmoothedHingeLoss);
+  const MinimumDistanceConstraint constraint(
+      plant_double_, minimum_distance, plant_context_double_,
+      solvers::ExponentiallySmoothedHingeLoss);
   CheckConstraintBounds(constraint);
 
   CheckConstraintEval(constraint);
@@ -191,13 +191,13 @@ GTEST_TEST(MinimumDistanceConstraintTest,
 
 TEST_F(TwoFreeSpheresTest, NonpositiveInfluenceDistanceOffset) {
   DRAKE_EXPECT_THROWS_MESSAGE(
-      MinimumDistanceConstraint(plant_double_, 0.1, plant_context_double_,
-                                QuadraticallySmoothedHingeLoss, 0.0),
+      MinimumDistanceConstraint(plant_double_, 0.1, plant_context_double_, {},
+                                0.0),
       std::invalid_argument,
       "MinimumDistanceConstraint: influence_distance_offset must be positive.");
   DRAKE_EXPECT_THROWS_MESSAGE(
-      MinimumDistanceConstraint(plant_double_, 0.1, plant_context_double_,
-                                QuadraticallySmoothedHingeLoss, -0.1),
+      MinimumDistanceConstraint(plant_double_, 0.1, plant_context_double_, {},
+                                -0.1),
       std::invalid_argument,
       "MinimumDistanceConstraint: influence_distance_offset must be positive.");
 }
@@ -205,13 +205,13 @@ TEST_F(TwoFreeSpheresTest, NonpositiveInfluenceDistanceOffset) {
 TEST_F(TwoFreeSpheresTest, NonfiniteInfluenceDistanceOffset) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       MinimumDistanceConstraint(plant_double_, 0.1, plant_context_double_,
-                                QuadraticallySmoothedHingeLoss,
+                                {},
                                 std::numeric_limits<double>::infinity()),
       std::invalid_argument,
       "MinimumDistanceConstraint: influence_distance_offset must be finite.");
   DRAKE_EXPECT_THROWS_MESSAGE(
       MinimumDistanceConstraint(plant_double_, 0.1, plant_context_double_,
-                                QuadraticallySmoothedHingeLoss,
+                                {},
                                 std::numeric_limits<double>::quiet_NaN()),
       std::invalid_argument,
       "MinimumDistanceConstraint: influence_distance_offset must be finite.");

--- a/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
@@ -26,7 +26,9 @@ class TwoFreeSpheresMinimumDistanceTest : public TwoFreeSpheresTest {
   void CheckConstraintBounds(
       const MinimumDistanceConstraint& constraint) const {
     EXPECT_EQ(constraint.num_constraints(), 1);
-    EXPECT_TRUE(CompareMatrices(constraint.lower_bound(), Vector1d(0)));
+    EXPECT_TRUE(
+        CompareMatrices(constraint.lower_bound(),
+                        Vector1d(-std::numeric_limits<double>::infinity())));
     EXPECT_TRUE(CompareMatrices(constraint.upper_bound(), Vector1d(1)));
   }
 

--- a/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
@@ -209,7 +209,7 @@ TEST_F(BoxSphereTest, Test) {
                                          penalty_function);
 
     auto check_eval_autodiff =
-        [&constraint, this](const Eigen::VectorXd& q_val,
+        [&constraint](const Eigen::VectorXd& q_val,
                             const Eigen::MatrixXd& q_gradient, double tol,
                             const Eigen::Vector3d& box_size, double radius) {
           AutoDiffVecXd x_autodiff =

--- a/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
@@ -177,14 +177,12 @@ TEST_F(TwoFreeSpheresTest, NonpositiveInfluenceDistanceOffset) {
 
 TEST_F(TwoFreeSpheresTest, NonfiniteInfluenceDistanceOffset) {
   DRAKE_EXPECT_THROWS_MESSAGE(
-      MinimumDistanceConstraint(plant_double_, 0.1, plant_context_double_,
-                                {},
+      MinimumDistanceConstraint(plant_double_, 0.1, plant_context_double_, {},
                                 std::numeric_limits<double>::infinity()),
       std::invalid_argument,
       "MinimumDistanceConstraint: influence_distance_offset must be finite.");
   DRAKE_EXPECT_THROWS_MESSAGE(
-      MinimumDistanceConstraint(plant_double_, 0.1, plant_context_double_,
-                                {},
+      MinimumDistanceConstraint(plant_double_, 0.1, plant_context_double_, {},
                                 std::numeric_limits<double>::quiet_NaN()),
       std::invalid_argument,
       "MinimumDistanceConstraint: influence_distance_offset must be finite.");

--- a/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
@@ -164,6 +164,29 @@ GTEST_TEST(MinimumDistanceConstraintTest,
       "SceneGraph.");
 }
 
+GTEST_TEST(MinimumDistanceConstraintTest, MultibodyPlantWithoutCollisionPairs) {
+  // Make sure MinimumDistanceConstraint evaluation works when
+  // no collisions are possible in an MBP with no collision geometry.
+
+  systems::DiagramBuilder<double> builder{};
+  MultibodyPlant<double>& plant = AddMultibodyPlantSceneGraph(&builder);
+  AddTwoFreeBodiesToPlant(&plant);
+  plant.Finalize();
+  auto diagram = builder.Build();
+  auto diagram_context = diagram->CreateDefaultContext();
+  auto plant_context =
+      &diagram->GetMutableSubsystemContext(plant, diagram_context.get());
+
+  const double minimum_distance(0.1);
+  const MinimumDistanceConstraint constraint(&plant, minimum_distance,
+                                             plant_context);
+
+  Eigen::Matrix<AutoDiffXd, 14, 1> q_autodiff =
+      math::initializeAutoDiff(Eigen::VectorXd::Zero(14));
+  AutoDiffVecXd y_autodiff(1);
+  constraint.Eval(q_autodiff, &y_autodiff);
+}
+
 TEST_F(TwoFreeSpheresTest, NonpositiveInfluenceDistanceOffset) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       MinimumDistanceConstraint(plant_double_, 0.1, plant_context_double_, {},

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -1054,6 +1054,14 @@ drake_cc_googletest(
     ],
 )
 
+drake_cc_googletest(
+    name = "minimum_value_constraint_test",
+    deps = [
+        ":minimum_value_constraint",
+        "//solvers/test_utilities",
+    ]
+)
+
 # TODO(eric.cousineau): Remove dependence on create_cost
 drake_cc_googletest(
     name = "cost_test",

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -44,6 +44,7 @@ drake_cc_package_library(
         ":mathematical_program",
         ":mathematical_program_lite",
         ":mathematical_program_result",
+        ":minimum_value_constraint",
         ":mixed_integer_optimization_util",
         ":mixed_integer_rotation_constraint",
         ":moby_lcp_solver",
@@ -146,6 +147,16 @@ drake_cc_library(
         "//common:polynomial",
         "//common:symbolic",
         "//math:matrix_util",
+    ],
+)
+
+drake_cc_library(
+    name = "minimum_value_constraint",
+    srcs = ["minimum_value_constraint.cc"],
+    hdrs = ["minimum_value_constraint.h"],
+    deps = [
+        ":constraint",
+        "//math:gradient",
     ],
 )
 

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -1059,7 +1059,7 @@ drake_cc_googletest(
     deps = [
         ":minimum_value_constraint",
         "//solvers/test_utilities",
-    ]
+    ],
 )
 
 # TODO(eric.cousineau): Remove dependence on create_cost

--- a/solvers/minimum_value_constraint.cc
+++ b/solvers/minimum_value_constraint.cc
@@ -1,0 +1,203 @@
+#include "drake/solvers/minimum_value_constraint.h"
+
+#include <vector>
+
+#include "drake/math/autodiff_gradient.h"
+
+namespace drake {
+namespace solvers {
+
+namespace {
+/** Computes log(∑exp(xᵢ)). Exploits the shift invariance of log-sum-exp to
+avoid overflow. */
+template <typename T>
+T LogSumExp(const std::vector<T>& x) {
+  using std::exp;
+  using std::log;
+  const T x_max = *std::max_element(x.begin(), x.end());
+  T sum_exp{0.0};
+  for (const T& xi : x) {
+    sum_exp += exp(xi - x_max);
+  }
+  return x_max + log(sum_exp);
+}
+
+/** Computes a smooth approximation of max(x). */
+template <typename T>
+T SmoothMax(const std::vector<T>& x) {
+  // We compute the smooth max of x as smoothmax(x) = log(∑ᵢ exp(αxᵢ)) / α.
+  // This smooth max approaches max(x) as α increases. We choose α = 100, as
+  // that gives a qualitatively good fit for xᵢ ∈ [0, 1], which is the range of
+  // potential penalty values when the MinimumValueConstraint is feasible.
+  const double alpha{100};
+  std::vector<T> x_scaled{x};
+  for (T& xi_scaled : x_scaled) {
+    xi_scaled *= alpha;
+  }
+  return LogSumExp(x_scaled) / alpha;
+}
+
+template <typename T>
+T ScaleValue(T value, double minimum_value, double influence_value) {
+  return (value - influence_value) / (influence_value - minimum_value);
+}
+
+void InitializeY(const Eigen::Ref<const Eigen::VectorXd>&, Eigen::VectorXd* y,
+                 double y_value) {
+  (*y)(0) = y_value;
+}
+
+void InitializeY(const Eigen::Ref<const AutoDiffVecXd>& x, AutoDiffVecXd* y,
+                 double y_value) {
+  (*y) = math::initializeAutoDiffGivenGradientMatrix(
+      Vector1d(y_value), Eigen::RowVectorXd::Zero(x(0).derivatives().size()));
+}
+
+void Penalty(double value, double minimum_value, double influence_value,
+             MinimumValuePenaltyFunction penalty_function, double* y) {
+  double penalty;
+  const double x = ScaleValue(value, minimum_value, influence_value);
+  penalty_function(x, &penalty, nullptr);
+  *y = penalty;
+}
+
+void Penalty(AutoDiffXd value, double minimum_value, double influence_value,
+             MinimumValuePenaltyFunction penalty_function, AutoDiffXd* y) {
+  const AutoDiffXd scaled_value_autodiff =
+      ScaleValue(value, minimum_value, influence_value);
+  double penalty, dpenalty_dscaled_value;
+  penalty_function(scaled_value_autodiff.value(), &penalty,
+                   &dpenalty_dscaled_value);
+
+  const Vector1<AutoDiffXd> penalty_autodiff =
+      math::initializeAutoDiffGivenGradientMatrix(
+          Vector1d(penalty),
+          dpenalty_dscaled_value *
+              math::autoDiffToGradientMatrix(
+                  Vector1<AutoDiffXd>{scaled_value_autodiff}));
+  *y = penalty_autodiff(0);
+}
+
+}  // namespace
+
+void ExponentiallySmoothedHingeLoss(double x, double* penalty,
+                                    double* dpenalty_dx) {
+  if (x >= 0) {
+    *penalty = 0;
+    if (dpenalty_dx) {
+      *dpenalty_dx = 0;
+    }
+  } else {
+    const double exp_one_over_x = std::exp(1.0 / x);
+    *penalty = -x * exp_one_over_x;
+    if (dpenalty_dx) {
+      *dpenalty_dx = -exp_one_over_x + exp_one_over_x / x;
+    }
+  }
+}
+
+void QuadraticallySmoothedHingeLoss(double x, double* penalty,
+                                    double* dpenalty_dx) {
+  if (x >= 0) {
+    *penalty = 0;
+    if (dpenalty_dx) {
+      *dpenalty_dx = 0;
+    }
+  } else {
+    if (x > -1) {
+      *penalty = x * x / 2;
+      if (dpenalty_dx) {
+        *dpenalty_dx = x;
+      }
+    } else {
+      *penalty = -0.5 - x;
+      if (dpenalty_dx) {
+        *dpenalty_dx = -1;
+      }
+    }
+  }
+}
+
+MinimumValueConstraint::MinimumValueConstraint(
+    int num_vars, double minimum_value, double influence_value_offset,
+    int max_num_values,
+    std::function<AutoDiffVecXd(const Eigen::Ref<const AutoDiffVecXd>&, double)>
+        value_function,
+    std::function<VectorX<double>(const Eigen::Ref<const VectorX<double>>&,
+                                  double)>
+        value_function_double)
+    : solvers::Constraint(1, num_vars, Vector1d(0), Vector1d(1)),
+      value_function_{value_function},
+      value_function_double_{value_function_double},
+      minimum_value_{minimum_value},
+      influence_value_{minimum_value + influence_value_offset},
+      max_num_values_{max_num_values} {
+  set_penalty_function(QuadraticallySmoothedHingeLoss);
+}
+
+void MinimumValueConstraint::set_penalty_function(
+    MinimumValuePenaltyFunction new_penalty_function) {
+  penalty_function_ = new_penalty_function;
+  double unscaled_penalty_at_minimum_value{};
+  penalty_function_(
+      ScaleValue(minimum_value_, minimum_value_, influence_value_),
+      &unscaled_penalty_at_minimum_value, nullptr);
+  penalty_output_scaling_ = 1 / unscaled_penalty_at_minimum_value;
+}
+
+template <>
+VectorX<double> MinimumValueConstraint::Values(
+    const Eigen::Ref<const VectorX<double>>& x) const {
+  return value_function_double_
+             ? value_function_double_(x, influence_value_)
+             : math::autoDiffToValueMatrix(value_function_(
+                   math::initializeAutoDiff(x), influence_value_));
+}
+
+template <>
+AutoDiffVecXd MinimumValueConstraint::Values(
+    const Eigen::Ref<const AutoDiffVecXd>& x) const {
+  return value_function_(x, influence_value_);
+}
+
+template <typename T>
+void MinimumValueConstraint::DoEvalGeneric(
+    const Eigen::Ref<const VectorX<T>>& x, VectorX<T>* y) const {
+  y->resize(1);
+
+  // Initialize y to SmoothMax([0, 0, ..., 0]).
+  InitializeY(x, y, SmoothMax(std::vector<double>(max_num_values_, 0.0)));
+
+  VectorX<T> values = Values(x);
+  std::vector<T> penalties{};
+  const int num_values = static_cast<int>(values.size());
+  DRAKE_ASSERT(num_values <= max_num_values_);
+  penalties.reserve(max_num_values_);
+  for (int i = 0; i < num_values; ++i) {
+    const T& value = values(i);
+    if (value < influence_value_) {
+      penalties.emplace_back();
+      Penalty(value, minimum_value_, influence_value_, penalty_function_,
+              &penalties.back());
+      penalties.back() *= penalty_output_scaling_;
+    }
+  }
+  if (!penalties.empty()) {
+    // Pad penalties up to max_num_values_ so that the constraint
+    // function is actually smooth.
+    penalties.resize(max_num_values_, T{0.0});
+    (*y)(0) = SmoothMax(penalties);
+  }
+}
+
+void MinimumValueConstraint::DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
+                                    Eigen::VectorXd* y) const {
+  DoEvalGeneric(x, y);
+}
+
+void MinimumValueConstraint::DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
+                                    AutoDiffVecXd* y) const {
+  DoEvalGeneric(x, y);
+}
+}  // namespace solvers
+}  // namespace drake

--- a/solvers/minimum_value_constraint.cc
+++ b/solvers/minimum_value_constraint.cc
@@ -1,5 +1,6 @@
 #include "drake/solvers/minimum_value_constraint.h"
 
+#include <limits>
 #include <vector>
 
 #include "drake/math/autodiff_gradient.h"

--- a/solvers/minimum_value_constraint.cc
+++ b/solvers/minimum_value_constraint.cc
@@ -61,7 +61,8 @@ void Penalty(const double& value, double minimum_value, double influence_value,
   *y = penalty;
 }
 
-void Penalty(const AutoDiffXd& value, double minimum_value, double influence_value,
+void Penalty(const AutoDiffXd& value, double minimum_value,
+             double influence_value,
              MinimumValuePenaltyFunction penalty_function, AutoDiffXd* y) {
   const AutoDiffXd scaled_value_autodiff =
       ScaleValue(value, minimum_value, influence_value);

--- a/solvers/minimum_value_constraint.cc
+++ b/solvers/minimum_value_constraint.cc
@@ -53,7 +53,7 @@ void InitializeY(const Eigen::Ref<const AutoDiffVecXd>& x, AutoDiffVecXd* y,
       Vector1d(y_value), Eigen::RowVectorXd::Zero(x(0).derivatives().size()));
 }
 
-void Penalty(double value, double minimum_value, double influence_value,
+void Penalty(const double& value, double minimum_value, double influence_value,
              MinimumValuePenaltyFunction penalty_function, double* y) {
   double penalty;
   const double x = ScaleValue(value, minimum_value, influence_value);
@@ -61,7 +61,7 @@ void Penalty(double value, double minimum_value, double influence_value,
   *y = penalty;
 }
 
-void Penalty(AutoDiffXd value, double minimum_value, double influence_value,
+void Penalty(const AutoDiffXd& value, double minimum_value, double influence_value,
              MinimumValuePenaltyFunction penalty_function, AutoDiffXd* y) {
   const AutoDiffXd scaled_value_autodiff =
       ScaleValue(value, minimum_value, influence_value);
@@ -126,7 +126,9 @@ MinimumValueConstraint::MinimumValueConstraint(
     std::function<VectorX<double>(const Eigen::Ref<const VectorX<double>>&,
                                   double)>
         value_function_double)
-    : solvers::Constraint(1, num_vars, Vector1d(0), Vector1d(1)),
+    : solvers::Constraint(1, num_vars,
+                          Vector1d(-std::numeric_limits<double>::infinity()),
+                          Vector1d(1)),
       value_function_{value_function},
       value_function_double_{value_function_double},
       minimum_value_{minimum_value},

--- a/solvers/minimum_value_constraint.h
+++ b/solvers/minimum_value_constraint.h
@@ -1,0 +1,152 @@
+#pragma once
+
+#include <functional>
+
+#include "drake/solvers/constraint.h"
+
+namespace drake {
+namespace solvers {
+/** Computes the penalty function φ(x) and its derivatives dφ(x)/dx. Valid
+penalty functions must meet the following criteria:
+
+1.     φ(x) ≥ 0 ∀ x ∈ ℝ.
+2. dφ(x)/dx ≤ 0 ∀ x ∈ ℝ.
+3.     φ(x) = 0 ∀ x ≥ 0.
+4. dφ(x)/dx < 0 ∀ x < 0.
+
+If `dpenalty_dx` is nullptr, the function should only compute φ(x). */
+using MinimumValuePenaltyFunction =
+    std::function<void(double x, double* penalty, double* dpenalty_dx)>;
+
+/** A hinge loss function smoothed by exponential function. This loss
+function is differentiable everywhere. The fomulation is described in
+section II.C of [2].
+The penalty is
+<pre>
+       ⎧ 0            if x ≥ 0
+φ(x) = ⎨
+       ⎩  -x exp(1/x) if x < 0.
+</pre>
+[2] "Whole-body Motion Planning with Centroidal Dynamics and Full
+Kinematics" by Hongkai Dai, Andres Valenzuela and Russ Tedrake, IEEE-RAS
+International Conference on Humanoid Robots, 2014. */
+void ExponentiallySmoothedHingeLoss(double x, double* penalty,
+                                    double* dpenalty_dx);
+
+/** A linear hinge loss, smoothed with a quadratic loss near the origin. The
+formulation is in equation (6) of [1].
+The penalty is
+<pre>
+       ⎧  0        if x ≥ 0
+φ(x) = ⎨  x²/2     if -1 < x < 0
+       ⎩  -0.5 - x if x ≤ -1.
+</pre>
+[1] "Loss Functions for Preference Levels: Regression with Discrete Ordered
+Labels." by Jason Rennie and Nathan Srebro, Proceedings of IJCAI
+multidisciplinary workshop on Advances in preference handling. */
+void QuadraticallySmoothedHingeLoss(double x, double* penalty,
+                                    double* dpenalty_dx);
+
+/** Constrain all elements of the vector returned by the user-provided function
+to be no smaller than a specified minimum value.
+
+The formulation of the constraint is
+
+0 ≤ SmoothMax( φ((vᵢ - v_influence)/(v_influence - vₘᵢₙ)) / φ(-1) ) ≤ 1
+
+where vᵢ is the i-th value returned by the user-provided function, vₘᵢₙ is the
+minimum allowable value, v_influence is the "influence value" (the value below
+which an element constraint), φ is a solvers::MinimumValuePenaltyFunction, and
+SmoothMax(v) is smooth approximation of max(v). We require that vₘᵢₙ <
+v_influence. The input scaling (vᵢ - v_influence)/(v_influence - vₘᵢₙ) ensures
+that at the boundary of the feasible set (when vᵢ == vₘᵢₙ), we evaluate the
+penalty function at -1, where it is required to have a non-zero gradient. The
+user-provided function may return a vector with up to `max_num_values` elements.
+If it returns a vector with fewer than `max_num_values` elements, the remaining
+elements are assumed to be greater than the "influence value". */
+class MinimumValueConstraint final : public solvers::Constraint {
+ public:
+  /** Constructs a MinimumValueConstraint.
+  @param num_vars The number of inputs to `value_function`
+  @param minimum_value The minimum allowed value, vₘᵢₙ, for all elements of the
+  vector returned by `value_function`.
+  @param influence_value_offset The difference between the
+  influence value, v_influence, and the minimum value, vₘᵢₙ (see class
+  documentation). This value must be finite and strictly positive, as it is used
+  to scale the values returned by `value_function`. Smaller values may
+  improve performance if `value_function` is able to quickly determine that some
+  elements will be larger than the influence value and can therefore be
+  ignored. @default 1
+  @param value_function User-provided function that takes a `num_vars`-element
+  vector and the influence distance as inputs and returns a vector with up to
+  `max_num_values` elements. The function can omit from the return vector any
+  elements larger than the provided influence distance.
+  @param value_function_double Optional user-provide function that computes the
+  same values as `value_function` but for double rather than AutoDiffXd. If
+  ommited, `value_function` will be called (and the gradients discarded) when
+  this constraint is evaluated for doubles.
+  @pre `value_function_double(math::autoDiffToValueMatrix(x), v_influence) ==
+  math::autoDiffToValueMatrix(value_function(x, v_influence))` for all x.
+  @throws std::invalid_argument if influence_value_offset = ∞.
+  @throws std::invalid_argument if influence_value_offset ≤ 0.
+  */
+  MinimumValueConstraint(
+      int num_vars, double minimum_value, double influence_value_offset,
+      int max_num_values,
+      std::function<AutoDiffVecXd(const Eigen::Ref<const AutoDiffVecXd>&,
+                                  double)>
+          value_function,
+      std::function<VectorX<double>(const Eigen::Ref<const VectorX<double>>&,
+                                    double)>
+          value_function_double = {});
+
+  ~MinimumValueConstraint() override {}
+
+  /** Getter for the minimum value. */
+  double minimum_value() const { return minimum_value_; }
+
+  /** Getter for the influence value. */
+  double influence_value() const { return influence_value_; }
+
+  /** Getter for maximum number of values expected from value_function. */
+  double max_num_values() const { return max_num_values_; }
+
+  /** Setter for the penalty function. */
+  void set_penalty_function(MinimumValuePenaltyFunction new_penalty_function);
+
+ private:
+  template <typename T>
+  VectorX<T> Values(const Eigen::Ref<const VectorX<T>>& x) const;
+
+  template <typename T>
+  void DoEvalGeneric(const Eigen::Ref<const VectorX<T>>& x,
+                     VectorX<T>* y) const;
+
+  void DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
+              Eigen::VectorXd* y) const override;
+
+  void DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
+              AutoDiffVecXd* y) const override;
+
+  void DoEval(const Eigen::Ref<const VectorX<symbolic::Variable>>&,
+              VectorX<symbolic::Expression>*) const override {
+    throw std::logic_error(
+        "MinimumValueConstraint::DoEval() does not work for symbolic "
+        "variables.");
+  }
+
+  std::function<AutoDiffVecXd(const AutoDiffVecXd&, double)> value_function_;
+  std::function<VectorX<double>(const VectorX<double>&, double)>
+      value_function_double_;
+  const double minimum_value_;
+  const double influence_value_;
+  /** Stores the value of
+  1 / φ((vₘᵢₙ - v_influence)/(v_influence - vₘᵢₙ)) = 1 / φ(-1). This is
+  used to scale the output of the penalty function to be 1 when v == vₘᵢₙ. */
+  double penalty_output_scaling_;
+  int max_num_values_{};
+  MinimumValuePenaltyFunction penalty_function_{};
+};
+
+}  // namespace solvers
+}  // namespace drake

--- a/solvers/minimum_value_constraint.h
+++ b/solvers/minimum_value_constraint.h
@@ -22,10 +22,10 @@ using MinimumValuePenaltyFunction =
 function is differentiable everywhere. The fomulation is described in
 section II.C of [2].
 The penalty is
-<pre>
+<pre class="unicode-art">
        ⎧ 0            if x ≥ 0
 φ(x) = ⎨
-       ⎩  -x exp(1/x) if x < 0.
+       ⎩ -x exp(1/x)  if x < 0.
 </pre>
 [2] "Whole-body Motion Planning with Centroidal Dynamics and Full
 Kinematics" by Hongkai Dai, Andres Valenzuela and Russ Tedrake, IEEE-RAS
@@ -36,7 +36,7 @@ void ExponentiallySmoothedHingeLoss(double x, double* penalty,
 /** A linear hinge loss, smoothed with a quadratic loss near the origin. The
 formulation is in equation (6) of [1].
 The penalty is
-<pre>
+<pre class="unicode-art">
        ⎧  0        if x ≥ 0
 φ(x) = ⎨  x²/2     if -1 < x < 0
        ⎩  -0.5 - x if x ≤ -1.
@@ -80,6 +80,8 @@ class MinimumValueConstraint final : public solvers::Constraint {
   `value_function` can quickly determine that some elements will be
   larger than the influence value and skip the computation associated with those
   elements. @default 1
+  @param max_num_values The maximum number of elements in the vector returned by
+  `value_function`.
   @param value_function User-provided function that takes a `num_vars`-element
   vector and the influence distance as inputs and returns a vector with up to
   `max_num_values` elements. The function can omit from the return vector any
@@ -90,6 +92,7 @@ class MinimumValueConstraint final : public solvers::Constraint {
   this constraint is evaluated for doubles.
   @pre `value_function_double(math::autoDiffToValueMatrix(x), v_influence) ==
   math::autoDiffToValueMatrix(value_function(x, v_influence))` for all x.
+  @pre `value_function(x).size() <= max_num_values` for all x.
   @throws std::invalid_argument if influence_value_offset = ∞.
   @throws std::invalid_argument if influence_value_offset ≤ 0.
   */

--- a/solvers/minimum_value_constraint.h
+++ b/solvers/minimum_value_constraint.h
@@ -56,8 +56,9 @@ The formulation of the constraint is
 
 where vᵢ is the i-th value returned by the user-provided function, vₘᵢₙ is the
 minimum allowable value, v_influence is the "influence value" (the value below
-which an element constraint), φ is a solvers::MinimumValuePenaltyFunction, and
-SmoothMax(v) is smooth approximation of max(v). We require that vₘᵢₙ <
+which an element influences the constraint or conversely the value above which
+an element is ignored), φ is a solvers::MinimumValuePenaltyFunction, and
+SmoothMax(v) is a smooth approximation of max(v). We require that vₘᵢₙ <
 v_influence. The input scaling (vᵢ - v_influence)/(v_influence - vₘᵢₙ) ensures
 that at the boundary of the feasible set (when vᵢ == vₘᵢₙ), we evaluate the
 penalty function at -1, where it is required to have a non-zero gradient. The
@@ -74,9 +75,10 @@ class MinimumValueConstraint final : public solvers::Constraint {
   influence value, v_influence, and the minimum value, vₘᵢₙ (see class
   documentation). This value must be finite and strictly positive, as it is used
   to scale the values returned by `value_function`. Smaller values may
-  improve performance if `value_function` is able to quickly determine that some
-  elements will be larger than the influence value and can therefore be
-  ignored. @default 1
+  decrease the amount of computation required for each constraint evaluation if
+  `value_function` can quickly determine that some elements will be
+  larger than the influence value and skip the computation associated with those
+  elements. @default 1
   @param value_function User-provided function that takes a `num_vars`-element
   vector and the influence distance as inputs and returns a vector with up to
   `max_num_values` elements. The function can omit from the return vector any

--- a/solvers/minimum_value_constraint.h
+++ b/solvers/minimum_value_constraint.h
@@ -52,19 +52,20 @@ to be no smaller than a specified minimum value.
 
 The formulation of the constraint is
 
-0 ≤ SmoothMax( φ((vᵢ - v_influence)/(v_influence - vₘᵢₙ)) / φ(-1) ) ≤ 1
+SmoothMax( φ((vᵢ - v_influence)/(v_influence - vₘᵢₙ)) / φ(-1) ) ≤ 1
 
 where vᵢ is the i-th value returned by the user-provided function, vₘᵢₙ is the
 minimum allowable value, v_influence is the "influence value" (the value below
 which an element influences the constraint or, conversely, the value above which
 an element is ignored), φ is a solvers::MinimumValuePenaltyFunction, and
-SmoothMax(v) is a smooth approximation of max(v). We require that vₘᵢₙ <
-v_influence. The input scaling (vᵢ - v_influence)/(v_influence - vₘᵢₙ) ensures
-that at the boundary of the feasible set (when vᵢ == vₘᵢₙ), we evaluate the
-penalty function at -1, where it is required to have a non-zero gradient. The
-user-provided function may return a vector with up to `max_num_values` elements.
-If it returns a vector with fewer than `max_num_values` elements, the remaining
-elements are assumed to be greater than the "influence value". */
+SmoothMax(v) is a smooth, conservative approximation of max(v) (i.e.
+SmoothMax(v) >= max(v), for all v). We require that vₘᵢₙ < v_influence. The
+input scaling (vᵢ - v_influence)/(v_influence - vₘᵢₙ) ensures that at the
+boundary of the feasible set (when vᵢ == vₘᵢₙ), we evaluate the penalty function
+at -1, where it is required to have a non-zero gradient. The user-provided
+function may return a vector with up to `max_num_values` elements. If it returns
+a vector with fewer than `max_num_values` elements, the remaining elements are
+assumed to be greater than the "influence value". */
 class MinimumValueConstraint final : public solvers::Constraint {
  public:
   /** Constructs a MinimumValueConstraint.

--- a/solvers/minimum_value_constraint.h
+++ b/solvers/minimum_value_constraint.h
@@ -56,7 +56,7 @@ The formulation of the constraint is
 
 where vᵢ is the i-th value returned by the user-provided function, vₘᵢₙ is the
 minimum allowable value, v_influence is the "influence value" (the value below
-which an element influences the constraint or conversely the value above which
+which an element influences the constraint or, conversely, the value above which
 an element is ignored), φ is a solvers::MinimumValuePenaltyFunction, and
 SmoothMax(v) is a smooth approximation of max(v). We require that vₘᵢₙ <
 v_influence. The input scaling (vᵢ - v_influence)/(v_influence - vₘᵢₙ) ensures

--- a/solvers/test/minimum_value_constraint_test.cc
+++ b/solvers/test/minimum_value_constraint_test.cc
@@ -1,0 +1,124 @@
+#include "drake/solvers/minimum_value_constraint.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/symbolic.h"
+#include "drake/math/autodiff_gradient.h"
+#include "drake/solvers/test_utilities/check_constraint_eval_nonsymbolic.h"
+
+namespace drake {
+namespace solvers {
+namespace {
+
+double kEps{std::numeric_limits<double>::epsilon()};
+
+// Returns the element-wise square of it's input.
+template <typename T>
+VectorX<T> SquareAndReturnAll(const Eigen::Ref<const VectorX<T>>& x,
+                              double influence_value) {
+  int max_num_values = static_cast<int>(x.size());
+  VectorX<T> values(max_num_values);
+  for (int i = 0; i < max_num_values; ++i) {
+    values(i) = x(i) * x(i);
+  }
+  return values;
+}
+
+// Returns the elements of the element-wise square of its input
+// that are less than `influence_value`.
+template <typename T>
+VectorX<T> SquareAndReturnLessThanInfluenceValue(
+    const Eigen::Ref<const VectorX<T>>& x, double influence_value) {
+  int max_num_values = static_cast<int>(x.size());
+  VectorX<T> values(max_num_values);
+  int value_count{0};
+  double sqrt_influence_value = std::sqrt(influence_value);
+  for (int i = 0; i < max_num_values; ++i) {
+    if (x(i) < sqrt_influence_value) {
+      values(value_count++) = x(i) * x(i);
+    }
+  }
+  values.conservativeResize(value_count);
+  return values;
+}
+
+// Verify that the constructor works as expected.
+GTEST_TEST(MinimumValueConstraintTests, ConstructorTest) {
+  int expected_num_vars{5};
+  int expected_max_num_values{3};
+  double expected_minimum_value{0.1};
+  double expected_influence_value{0.2};
+  MinimumValueConstraint dut(expected_num_vars, expected_minimum_value,
+                             expected_influence_value - expected_minimum_value,
+                             expected_max_num_values,
+                             &SquareAndReturnAll<AutoDiffXd>);
+  EXPECT_EQ(dut.num_vars(), expected_num_vars);
+  EXPECT_EQ(dut.max_num_values(), expected_max_num_values);
+  EXPECT_EQ(dut.minimum_value(), expected_minimum_value);
+  EXPECT_EQ(dut.influence_value(), expected_influence_value);
+  EXPECT_EQ(dut.num_constraints(), 1);
+}
+
+// Verify that the non-symbolic versions of Eval() behave as expected.
+GTEST_TEST(MinimumValueConstraintTests, EvalNonsymbolicTest) {
+  int num_vars{5};
+  int max_num_values{5};
+  double minimum_value{0.1};
+  double influence_value{0.2};
+  MinimumValueConstraint dut_return_all(
+      num_vars, minimum_value, influence_value - minimum_value, max_num_values,
+      &SquareAndReturnAll<AutoDiffXd>);
+  MinimumValueConstraint dut_return_less_than_influence_value(
+      num_vars, minimum_value, influence_value - minimum_value, max_num_values,
+      &SquareAndReturnLessThanInfluenceValue<AutoDiffXd>);
+  double tol = kEps;
+  AutoDiffVecXd x_0 = AutoDiffVecXd::Zero(num_vars);
+  AutoDiffVecXd x_0_to_twice_sqrt_influence_value =
+      AutoDiffVecXd::LinSpaced(num_vars, 0, 2 * std::sqrt(influence_value));
+  AutoDiffVecXd x_sqrt_min_value_to_twice_sqrt_influence_value =
+      AutoDiffVecXd::LinSpaced(num_vars, std::sqrt(minimum_value),
+                               2 * std::sqrt(influence_value));
+  auto check_constraints = [&](std::vector<AutoDiffVecXd> inputs,
+                               bool should_constraints_be_satisfied) {
+    for (const AutoDiffVecXd& x : inputs) {
+      test::CheckConstraintEvalNonsymbolic(dut_return_all, x, tol);
+      test::CheckConstraintEvalNonsymbolic(dut_return_less_than_influence_value,
+                                           x, tol);
+      AutoDiffVecXd y_return_all, y_return_less_than_influence_value;
+      dut_return_all.Eval(x, &y_return_all);
+      dut_return_less_than_influence_value.Eval(
+          x, &y_return_less_than_influence_value);
+      ASSERT_EQ(y_return_all.size(), 1);
+      ASSERT_EQ(y_return_less_than_influence_value.size(), 1);
+      EXPECT_EQ(y_return_all(0), y_return_less_than_influence_value(0));
+      EXPECT_EQ(dut_return_all.CheckSatisfied(x, kEps),
+                should_constraints_be_satisfied);
+      EXPECT_EQ(dut_return_less_than_influence_value.CheckSatisfied(x, kEps),
+                should_constraints_be_satisfied);
+    }
+  };
+  // Check with inputs that should violate the constraints.
+  check_constraints({x_0, x_0_to_twice_sqrt_influence_value,
+                     x_sqrt_min_value_to_twice_sqrt_influence_value -
+                         AutoDiffVecXd::Constant(num_vars, kEps)},
+                    false);
+  // Check with inputs that should satisfy the constraints.
+  check_constraints({x_sqrt_min_value_to_twice_sqrt_influence_value}, true);
+}
+
+// Verify that Eval() throws for symbolic inputs.
+GTEST_TEST(MinimumValueConstraintTests, EvalSymbolicTest) {
+  int num_vars{5};
+  int max_num_values{5};
+  double minimum_value{0.1};
+  double influence_value{0.2};
+  MinimumValueConstraint dut(num_vars, minimum_value,
+                             influence_value - minimum_value, max_num_values,
+                             &SquareAndReturnAll<AutoDiffXd>);
+  VectorX<symbolic::Variable> x{num_vars};
+  VectorX<symbolic::Expression> y;
+  EXPECT_THROW(dut.Eval(x, &y), std::logic_error);
+}
+}  // namespace
+}  // namespace solvers
+}  // namespace drake

--- a/solvers/test/minimum_value_constraint_test.cc
+++ b/solvers/test/minimum_value_constraint_test.cc
@@ -42,6 +42,13 @@ VectorX<T> SquareAndReturnLessThanInfluenceValue(
   return values;
 }
 
+// Returns a zero-element vector.
+template <typename T>
+VectorX<T> ReturnNoValues(const Eigen::Ref<const VectorX<T>>& x,
+                          double influence_value) {
+  return VectorX<T>(0);
+}
+
 // Verify that the constructor works as expected.
 GTEST_TEST(MinimumValueConstraintTests, ConstructorTest) {
   int expected_num_vars{5};
@@ -67,7 +74,7 @@ GTEST_TEST(MinimumValueConstraintTests, EvalNonsymbolicTest) {
   double influence_value{0.2};
   MinimumValueConstraint dut_return_all(
       num_vars, minimum_value, influence_value - minimum_value, max_num_values,
-      &SquareAndReturnAll<AutoDiffXd>);
+      &SquareAndReturnAll<AutoDiffXd>, &SquareAndReturnAll<double>);
   MinimumValueConstraint dut_return_less_than_influence_value(
       num_vars, minimum_value, influence_value - minimum_value, max_num_values,
       &SquareAndReturnLessThanInfluenceValue<AutoDiffXd>);
@@ -104,6 +111,18 @@ GTEST_TEST(MinimumValueConstraintTests, EvalNonsymbolicTest) {
                     false);
   // Check with inputs that should satisfy the constraints.
   check_constraints({x_sqrt_min_value_to_twice_sqrt_influence_value}, true);
+}
+
+GTEST_TEST(MinimumValueConstraintTests, EvalNoValuesTest) {
+  int num_vars{5};
+  int max_num_values{0};
+  double minimum_value{0.1};
+  double influence_value{0.2};
+  MinimumValueConstraint dut_no_values(
+      num_vars, minimum_value, influence_value - minimum_value, max_num_values,
+      &ReturnNoValues<AutoDiffXd>);
+  test::CheckConstraintEvalNonsymbolic(dut_no_values,
+                                       AutoDiffVecXd::Zero(num_vars), kEps);
 }
 
 // Verify that Eval() throws for symbolic inputs.

--- a/solvers/test/minimum_value_constraint_test.cc
+++ b/solvers/test/minimum_value_constraint_test.cc
@@ -14,14 +14,8 @@ double kEps{std::numeric_limits<double>::epsilon()};
 
 // Returns the element-wise square of it's input.
 template <typename T>
-VectorX<T> SquareAndReturnAll(const Eigen::Ref<const VectorX<T>>& x,
-                              double influence_value) {
-  int max_num_values = static_cast<int>(x.size());
-  VectorX<T> values(max_num_values);
-  for (int i = 0; i < max_num_values; ++i) {
-    values(i) = x(i) * x(i);
-  }
-  return values;
+VectorX<T> SquareAndReturnAll(const Eigen::Ref<const VectorX<T>>& x, double) {
+  return x.array().square();
 }
 
 // Returns the elements of the element-wise square of its input
@@ -44,8 +38,7 @@ VectorX<T> SquareAndReturnLessThanInfluenceValue(
 
 // Returns a zero-element vector.
 template <typename T>
-VectorX<T> ReturnNoValues(const Eigen::Ref<const VectorX<T>>& x,
-                          double influence_value) {
+VectorX<T> ReturnNoValues(const Eigen::Ref<const VectorX<T>>&, double) {
   return VectorX<T>(0);
 }
 

--- a/solvers/test_utilities/BUILD.bazel
+++ b/solvers/test_utilities/BUILD.bazel
@@ -1,0 +1,35 @@
+# -*- python -*-
+
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_library",
+    "drake_cc_package_library",
+)
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+package(default_visibility = ["//visibility:public"])
+
+# This should encompass every cc_library in this package, except for items that
+# should only ever be linked into main() programs.
+drake_cc_package_library(
+    name = "test_utilities",
+    testonly = 1,
+    deps = [
+        ":check_constraint_eval_nonsymbolic",
+    ],
+)
+
+drake_cc_library(
+    name = "check_constraint_eval_nonsymbolic",
+    testonly = 1,
+    srcs = ["check_constraint_eval_nonsymbolic.cc"],
+    hdrs = ["check_constraint_eval_nonsymbolic.h"],
+    deps = [
+        "//common/test_utilities",
+        "//math:compute_numerical_gradient",
+        "//math:gradient",
+        "//solvers:constraint",
+    ],
+)
+
+add_lint_tests()

--- a/solvers/test_utilities/check_constraint_eval_nonsymbolic.cc
+++ b/solvers/test_utilities/check_constraint_eval_nonsymbolic.cc
@@ -1,0 +1,36 @@
+#include "drake/solvers/test_utilities/check_constraint_eval_nonsymbolic.h"
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/math/autodiff_gradient.h"
+#include "drake/math/compute_numerical_gradient.h"
+
+namespace drake {
+namespace solvers {
+namespace test {
+/** Compare the result between Eval<double> and Eval<AutoDiffXd>. Also compare
+    the gradient in Eval<AutoDiffXd> with a numerical approximation. */
+void CheckConstraintEvalNonsymbolic(const Constraint& constraint,
+                         const Eigen::Ref<const AutoDiffVecXd>& x_autodiff,
+                         double tol) {
+  const Eigen::VectorXd x_double{math::autoDiffToValueMatrix(x_autodiff)};
+  Eigen::VectorXd y_double;
+  constraint.Eval(x_double, &y_double);
+  AutoDiffVecXd y_autodiff;
+  constraint.Eval(x_autodiff, &y_autodiff);
+  EXPECT_TRUE(
+      CompareMatrices(y_double, math::autoDiffToValueMatrix(y_autodiff), tol));
+  std::function<void(const Eigen::Ref<const Eigen::VectorXd>&,
+                     Eigen::VectorXd*)>
+      constraint_eval =
+      [&constraint](const Eigen::Ref<const Eigen::VectorXd>& x,
+                    Eigen::VectorXd* y) { return constraint.Eval(x, y); };
+  const auto J = math::ComputeNumericalGradient(
+      constraint_eval, x_double,
+      math::NumericalGradientOption{math::NumericalGradientMethod::kCentral});
+  EXPECT_TRUE(CompareMatrices(J * math::autoDiffToGradientMatrix(x_autodiff),
+                              math::autoDiffToGradientMatrix(y_autodiff),
+                              std::sqrt(tol)));
+}
+}  // namespace test
+}  // namespace solvers
+}  // namespace drake

--- a/solvers/test_utilities/check_constraint_eval_nonsymbolic.cc
+++ b/solvers/test_utilities/check_constraint_eval_nonsymbolic.cc
@@ -9,9 +9,9 @@ namespace solvers {
 namespace test {
 /** Compare the result between Eval<double> and Eval<AutoDiffXd>. Also compare
     the gradient in Eval<AutoDiffXd> with a numerical approximation. */
-void CheckConstraintEvalNonsymbolic(const Constraint& constraint,
-                         const Eigen::Ref<const AutoDiffVecXd>& x_autodiff,
-                         double tol) {
+void CheckConstraintEvalNonsymbolic(
+    const Constraint& constraint,
+    const Eigen::Ref<const AutoDiffVecXd>& x_autodiff, double tol) {
   const Eigen::VectorXd x_double{math::autoDiffToValueMatrix(x_autodiff)};
   Eigen::VectorXd y_double;
   constraint.Eval(x_double, &y_double);
@@ -22,8 +22,8 @@ void CheckConstraintEvalNonsymbolic(const Constraint& constraint,
   std::function<void(const Eigen::Ref<const Eigen::VectorXd>&,
                      Eigen::VectorXd*)>
       constraint_eval =
-      [&constraint](const Eigen::Ref<const Eigen::VectorXd>& x,
-                    Eigen::VectorXd* y) { return constraint.Eval(x, y); };
+          [&constraint](const Eigen::Ref<const Eigen::VectorXd>& x,
+                        Eigen::VectorXd* y) { return constraint.Eval(x, y); };
   const auto J = math::ComputeNumericalGradient(
       constraint_eval, x_double,
       math::NumericalGradientOption{math::NumericalGradientMethod::kCentral});

--- a/solvers/test_utilities/check_constraint_eval_nonsymbolic.h
+++ b/solvers/test_utilities/check_constraint_eval_nonsymbolic.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <Eigen/Dense>
+
+#include "drake/common/autodiff.h"
+#include "drake/solvers/constraint.h"
+
+namespace drake {
+namespace solvers {
+namespace test {
+/** Compare the result between Eval<double> and Eval<AutoDiffXd>. Also compare
+the gradient in Eval<AutoDiffXd> with a numerical approximation. */
+void CheckConstraintEvalNonsymbolic(const Constraint& constraint,
+                         const Eigen::Ref<const AutoDiffVecXd>& x_autodiff,
+                         double tol);
+}  // namespace test
+}  // namespace solvers
+}  // namespace drake

--- a/solvers/test_utilities/check_constraint_eval_nonsymbolic.h
+++ b/solvers/test_utilities/check_constraint_eval_nonsymbolic.h
@@ -10,9 +10,9 @@ namespace solvers {
 namespace test {
 /** Compare the result between Eval<double> and Eval<AutoDiffXd>. Also compare
 the gradient in Eval<AutoDiffXd> with a numerical approximation. */
-void CheckConstraintEvalNonsymbolic(const Constraint& constraint,
-                         const Eigen::Ref<const AutoDiffVecXd>& x_autodiff,
-                         double tol);
+void CheckConstraintEvalNonsymbolic(
+    const Constraint& constraint,
+    const Eigen::Ref<const AutoDiffVecXd>& x_autodiff, double tol);
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test_utilities/check_constraint_eval_nonsymbolic.h
+++ b/solvers/test_utilities/check_constraint_eval_nonsymbolic.h
@@ -8,8 +8,15 @@
 namespace drake {
 namespace solvers {
 namespace test {
-/** Compare the result between Eval<double> and Eval<AutoDiffXd>. Also compare
-the gradient in Eval<AutoDiffXd> with a numerical approximation. */
+/** Compare the result between Eval<double>() and Eval<AutoDiffXd>(). Also compare
+the gradient in Eval<AutoDiffXd>() with a finite difference approximation.
+@param constraint The constraint object to test.
+@param x_autodiff The point at which the Eval() methods are tested.
+@param tol Tolerance on the comparison of the results from Eval<double>() and
+Eval<AutoDiffXd>(). The tolerance on the comparision between the autodiff
+gradient and the finite difference approximation is sqrt(tolerance) to account
+for approximation error.
+*/
 void CheckConstraintEvalNonsymbolic(
     const Constraint& constraint,
     const Eigen::Ref<const AutoDiffVecXd>& x_autodiff, double tol);


### PR DESCRIPTION
This adds solvers::MinimumValueConstaint, which ensures that the smallest element
in the vector returned by a user-provided function is above a specified minimum
value. The user-provided function should also take a second argument,
influence_value. Any elements of the return vector that would be greater than
influence_value may safely be ommited.

It also refactors multibody::MinimumDistanceConstraint to use
solvers::MinimumValueConstraint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11525)
<!-- Reviewable:end -->
