### PR TITLE
Fix MinimumDistanceConstraint in the num_collision_candidates_=0 case.

### DIFF
--- a/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h
+++ b/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h
@@ -23,6 +23,12 @@ template <typename T>
 std::unique_ptr<MultibodyPlant<T>> ConstructTwoFreeBodiesPlant();
 
 /**
+ * Constructs a MultibodyPlant consisting of two free bodies.
+ */
+template <typename T>
+void AddTwoFreeBodiesToPlant(MultibodyPlant<T>* model);
+
+/**
  * Constructs a MultibodyPlant consisting of an Iiwa robot.
  */
 std::unique_ptr<MultibodyPlant<double>> ConstructIiwaPlant(

--- a/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
@@ -189,6 +189,30 @@ GTEST_TEST(MinimumDistanceConstraintTest,
       "SceneGraph.");
 }
 
+GTEST_TEST(MinimumDistanceConstraintTest,
+           MultibodyPlantWithoutCollisionPairs) {
+  // Make sure MinimumDistanceConstraint evaluation works when
+  // no collisions are possible in an MBP with no collision geometry.
+
+  systems::DiagramBuilder<double> builder{};
+  MultibodyPlant<double>& plant = AddMultibodyPlantSceneGraph(&builder);
+  AddTwoFreeBodiesToPlant(&plant);
+  plant.Finalize();
+  auto diagram = builder.Build();
+  auto diagram_context = diagram->CreateDefaultContext();
+  auto plant_context = &diagram->GetMutableSubsystemContext(
+    plant, diagram_context.get());
+
+  const double minimum_distance(0.1);
+  const MinimumDistanceConstraint constraint(&plant, minimum_distance,
+                                             plant_context);
+
+  Eigen::Matrix<AutoDiffXd, 14, 1> q_autodiff = math::initializeAutoDiff(
+    Eigen::VectorXd::Zero(14));
+  AutoDiffVecXd y_autodiff(1);
+  constraint.Eval(q_autodiff, &y_autodiff);
+}
+
 TEST_F(TwoFreeSpheresTest, NonpositiveInfluenceDistanceOffset) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       MinimumDistanceConstraint(plant_double_, 0.1, plant_context_double_,


### PR DESCRIPTION
LogSumExp(), as used in MinimumDistanceConstraint, fails when x.size() == 0 (it winds up dereferencing x.end(), which is invalid if x is empty). This happens if the constraint is evaluated against a SG with no possible collision pairs, which leads to a nasty segfault. This patch short-circuits the constraint evaluation before this can happen.

@avalenzu, would you mind taking a look? Not sure this was this was the cleanest solution pathway but it cleared up the bug for me.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11537)
<!-- Reviewable:end -->
