### PR TITLE
Implement and consolidate for CalcBiasForJacobianSpatialVelocity()

### DIFF
--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1562,61 +1562,61 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       const systems::Context<T>& context,
       const Frame<T>& frame_F,
       const Eigen::Ref<const MatrixX<T>>& p_FP_list) const {
-    return internal_tree().CalcBiasForJacobianTranslationalVelocity(
+    return CalcBiasForJacobianTranslationalVelocity(
         context, JacobianWrtVariable::kV, frame_F, p_FP_list,
         world_frame(), world_frame());
   }
 
   /// For a point Fp that is regarded as a point of (fixed/welded to) a frame F,
-  /// computes the bias term `b_AFp` associated with `a_AFp` (Fp's translational
-  /// acceleration in a frame A) with respect to "speeds" 𝑠, where 𝑠 is either
+  /// computes bias term `abias_DFp` associated with `a_DFp` (Fp's translational
+  /// acceleration in a frame D) with respect to "speeds" 𝑠, where 𝑠 is either
   /// q̇ ≜ [q̇₁ ... q̇ⱼ]ᵀ (time-derivatives of generalized positions) or
   /// v ≜ [v₁ ... vₖ]ᵀ (generalized velocities).
-  /// That is, the translational acceleration of point `Fp` can be computed as:
+  /// That is, point Fp's translational acceleration in frame D can be written
   /// <pre>
-  ///   a_AFp = Js_v_AFp(q)⋅ṡ + b_AFp(q, v)
+  ///   a_DFp = Js_v_DFp(q)⋅ṡ + abias_DFp(q, v)
   /// </pre>
-  /// where `b_AFp = J̇s_v_AFp(q, s)⋅s`.
+  /// where `abias_DFp = J̇s_v_DFp(q, s)⋅s`.
   ///
-  /// This method computes `b_AFp` for each such point Fp in the `p_FP_list`.
+  /// This method computes `abias_DFp` for each point Fp in the `p_FP_list`.
   /// The `p_FP_list` is a list of position vectors from Fo (Frame F's origin)
-  /// to Fp, expressed in frame F.
+  /// to each such point Fp, expressed in frame F.
   ///
-  /// @see CalcJacobianTranslationalVelocity() to compute `Js_v_AFp`, the
-  /// Jacobian with respect to s of Fp's velocity in A.
+  /// @see CalcJacobianTranslationalVelocity() to compute `Js_v_DFp`, point Fp's
+  /// translational velocity Jacobian in frame D with respect to s.
   ///
   /// @param[in] context The state of the multibody system, which includes the
   /// generalized positions q and generalized velocities v.
   /// @param[in] with_respect_to Enum equal to JacobianWrtVariable::kQDot or
-  /// JacobianWrtVariable::kV, indicating whether the Jacobian `Js_v_ABp` is
+  /// JacobianWrtVariable::kV, indicating whether the Jacobian `Js_v_DFp` is
   /// partial derivatives with respect to 𝑠 = q̇ (time-derivatives of generalized
   /// positions) or with respect to 𝑠 = v (generalized velocities).
   /// @param[in] frame_F The frame on which point Fp is fixed/welded.
   /// @param[in] p_FP_list `3 x n` matrix of position vectors `p_FoFp_F` from
   /// Fo (frame F's origin) to each such point Fp, expressed in frame F.
-  /// @param[in] frame_A The frame that measures `v_AFp` (Fp's velocity in A).
-  /// Currently, an exception is thrown if frame_A is not the World frame.
-  /// @param[in] frame_E The frame in which `v_AFp` is expressed on input and
-  /// the frame in which the bias term `b_AFp` is expressed on output.
+  /// @param[in] frame_D The frame that measures `abias_DFp`.
+  /// Currently, an exception is thrown if frame_D is not the World frame.
+  /// @param[in] frame_E The frame in which `abias_DFp` is expressed on output.
   /// Currently, an exception is thrown if frame_E is not the World frame.
-  /// @returns b_AFp `3 x n` matrix of bias terms for each of the associated n
-  /// points Fp, expressed in frame_E.  These bias terms are functions of the
-  /// generalized positions q and the generalized velocities v and depend on
-  /// whether `with_respect_to` is kQDot or kV.
+  /// @returns abias_DFp `3 x n` matrix of translational acceleration bias terms
+  /// in frame D and expressed in frame E for each of the `n` points associated
+  /// with p_FP_list.  These bias terms are functions of the generalized
+  /// positions q and the generalized velocities v and depend on whether
+  /// `with_respect_to` is kQDot or kV.
   /// @throws std::exception if `p_FP_list` does not have 3 rows.
   /// @throws std::exception if `with_respect_to` is not JacobianWrtVariable::kV
-  /// @throws std::exception if frame_A or frame_E are not the world frame.
+  /// @throws std::exception if frame_D or frame_E are not the world frame.
   // TODO(Mitiguy) Allow `with_respect_to` to be JacobianWrtVariable::kQDot
-  // and/or allow frame_A and frame_E to be non-world frames.
+  // and/or allow frame_D and frame_E to be non-world frames.
   VectorX<T> CalcBiasForJacobianTranslationalVelocity(
       const systems::Context<T>& context,
       JacobianWrtVariable with_respect_to,
       const Frame<T>& frame_F,
       const Eigen::Ref<const MatrixX<T>>& p_FP_list,
-      const Frame<T>& frame_A,
+      const Frame<T>& frame_D,
       const Frame<T>& frame_E) const {
     return internal_tree().CalcBiasForJacobianTranslationalVelocity(
-        context, with_respect_to, frame_F, p_FP_list, frame_A, frame_E);
+        context, with_respect_to, frame_F, p_FP_list, frame_D, frame_E);
   }
 
   // TODO(eric.cousineau): Reduce duplicate text between overloads.
@@ -1870,11 +1870,62 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   ///   related to the bias in translational acceleration.
   /// @note SpatialAcceleration(Ab_WFp) defines a valid SpatialAcceleration.
   // TODO(amcastro-tri): Rework this method as per issue #10155.
+  DRAKE_DEPRECATED("2019-09-01",
+                   "Use CalcBiasForJacobianSpatialVelocity().")
   Vector6<T> CalcBiasForFrameGeometricJacobianExpressedInWorld(
       const systems::Context<T>& context,
       const Frame<T>& frame_F, const Eigen::Ref<const Vector3<T>>& p_FP) const {
-    return internal_tree().CalcBiasForFrameGeometricJacobianExpressedInWorld(
-        context, frame_F, p_FP);
+    return CalcBiasForJacobianSpatialVelocity(context, JacobianWrtVariable::kV,
+        frame_F, p_FP, world_frame(), world_frame());
+  }
+
+  /// For a point Fp that is regarded as a point of (fixed/welded to) a frame F,
+  /// computes the bias term `Abias_DFp` associated with `A_DFp` (Fp's spatial
+  /// acceleration in a frame D) with respect to "speeds" 𝑠, where 𝑠 is either
+  /// q̇ ≜ [q̇₁ ... q̇ⱼ]ᵀ (time-derivatives of generalized positions) or
+  /// v ≜ [v₁ ... vₖ]ᵀ (generalized velocities).
+  /// That is, point Fp's spatial acceleration in frame D can be written
+  /// <pre>
+  ///   A_DFp = Js_V_DFp(q)⋅ṡ + Abias_DFp(q, v)
+  /// </pre>
+  /// where `Abias_DFp = J̇s_V_DFp(q, s)⋅s`.
+  ///
+  /// @see CalcJacobianSpatialVelocity() to compute `Js_V_DFp`, point Fp's
+  /// spatial velocity Jacobian in frame D with respect to s.
+  ///
+  /// @param[in] context The state of the multibody system, which includes the
+  /// generalized positions q and generalized velocities v.
+  /// @param[in] with_respect_to Enum equal to JacobianWrtVariable::kQDot or
+  /// JacobianWrtVariable::kV, indicating whether the Jacobian `Js_v_DFp` is
+  /// partial derivatives with respect to 𝑠 = q̇ (time-derivatives of generalized
+  /// positions) or with respect to 𝑠 = v (generalized velocities).
+  /// @param[in] frame_F The frame on which point Fp is fixed/welded.
+  /// @param[in] p_FoFp_F position vector from Fo (frame F's origin) to
+  /// point Fp, expressed in frame F.
+  /// @param[in] frame_D The frame that measures `Abias_DFp`.
+  /// Currently, an exception is thrown if frame_D is not the World frame.
+  /// @param[in] frame_E The frame in which `Abias_DFp` is expressed on output.
+  /// Currently, an exception is thrown if frame_E is not the World frame.
+  /// @returns Abias_DFp Fp's spatial acceleration bias in frame D is returned
+  /// in a `6 x 1` matrix whose first three elements are frame F's angular
+  /// acceleration bias in frame D (expressed in frame E) and whose last three
+  /// elements are point Fp's translational acceleration bias in frame D
+  /// (expressed in frame E).  These bias terms are functions of the generalized
+  /// positions q and the generalized velocities v and depend on whether
+  /// `with_respect_to` is kQDot or kV.
+  /// @throws std::exception if `with_respect_to` is not JacobianWrtVariable::kV
+  /// @throws std::exception if frame_D or frame_E are not the world frame.
+  // TODO(Mitiguy) Allow `with_respect_to` to be JacobianWrtVariable::kQDot
+  // and/or allow frame_D and frame_E to be non-world frames.
+  Vector6<T> CalcBiasForJacobianSpatialVelocity(
+      const systems::Context<T>& context,
+      JacobianWrtVariable with_respect_to,
+      const Frame<T>& frame_F,
+      const Eigen::Ref<const Vector3<T>>& p_FoFp_F,
+      const Frame<T>& frame_D,
+      const Frame<T>& frame_E) const {
+    return internal_tree().CalcBiasForJacobianSpatialVelocity(
+        context, with_respect_to, frame_F, p_FoFp_F, frame_D, frame_E);
   }
 
   /// Computes the Jacobian of spatial velocity for a frame instantaneously

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1597,7 +1597,6 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @param[in] frame_D The frame that measures `abias_DFp`.
   /// Currently, an exception is thrown if frame_D is not the World frame.
   /// @param[in] frame_E The frame in which `abias_DFp` is expressed on output.
-  /// Currently, an exception is thrown if frame_E is not the World frame.
   /// @returns abias_DFp `3 x n` matrix of translational acceleration bias terms
   /// in frame D and expressed in frame E for each of the `n` points associated
   /// with p_FP_list.  These bias terms are functions of the generalized
@@ -1605,9 +1604,9 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// `with_respect_to` is kQDot or kV.
   /// @throws std::exception if `p_FP_list` does not have 3 rows.
   /// @throws std::exception if `with_respect_to` is not JacobianWrtVariable::kV
-  /// @throws std::exception if frame_D or frame_E are not the world frame.
+  /// @throws std::exception if frame_D is not the world frame.
   // TODO(Mitiguy) Allow `with_respect_to` to be JacobianWrtVariable::kQDot
-  // and/or allow frame_D and frame_E to be non-world frames.
+  // and/or allow frame_D to be a non-world frame.
   VectorX<T> CalcBiasForJacobianTranslationalVelocity(
       const systems::Context<T>& context,
       JacobianWrtVariable with_respect_to,
@@ -1905,7 +1904,6 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @param[in] frame_D The frame that measures `Abias_DFp`.
   /// Currently, an exception is thrown if frame_D is not the World frame.
   /// @param[in] frame_E The frame in which `Abias_DFp` is expressed on output.
-  /// Currently, an exception is thrown if frame_E is not the World frame.
   /// @returns Abias_DFp Fp's spatial acceleration bias in frame D is returned
   /// in a `6 x 1` matrix whose first three elements are frame F's angular
   /// acceleration bias in frame D (expressed in frame E) and whose last three
@@ -1914,9 +1912,9 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// positions q and the generalized velocities v and depend on whether
   /// `with_respect_to` is kQDot or kV.
   /// @throws std::exception if `with_respect_to` is not JacobianWrtVariable::kV
-  /// @throws std::exception if frame_D or frame_E are not the world frame.
+  /// @throws std::exception if frame_D is not the world frame.
   // TODO(Mitiguy) Allow `with_respect_to` to be JacobianWrtVariable::kQDot
-  // and/or allow frame_D and frame_E to be non-world frames.
+  // and/or allow frame_D to be a non-world frame.
   Vector6<T> CalcBiasForJacobianSpatialVelocity(
       const systems::Context<T>& context,
       JacobianWrtVariable with_respect_to,

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1597,7 +1597,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @param[in] frame_A The frame that measures `abias_AFp`.
   /// Currently, an exception is thrown if frame_A is not the World frame.
   /// @param[in] frame_E The frame in which `abias_AFp` is expressed on output.
-  /// @returns abias_AFp_E 3 x n matrix of translational acceleration bias terms
+  /// @returns abias_AFp_E matrix of translational acceleration bias terms
   /// in frame_A and expressed in frame_E for each of the `n` points associated
   /// with p_FP_list.  These bias terms are functions of the generalized
   /// positions q and the generalized velocities v and depend on whether
@@ -1910,7 +1910,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// elements are point Fp's translational acceleration bias in frame_A
   /// (expressed in frame_E).  These bias terms are functions of the generalized
   /// positions q and the generalized velocities v and depend on whether
-  /// `with_respect_to` is kQDot or kV.
+  /// `with_respect_to` is kQDot or kV.  Note: Although the return quantity is a
+  /// Vector6, it is actually a SpatialAcceleration (having units of that type).
   /// @throws std::exception if `with_respect_to` is not JacobianWrtVariable::kV
   /// @throws std::exception if frame_A is not the world frame.
   Vector6<T> CalcBiasForJacobianSpatialVelocity(

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1568,54 +1568,54 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   }
 
   /// For a point Fp that is regarded as a point of (fixed/welded to) a frame F,
-  /// computes bias term `abias_DFp` associated with `a_DFp` (Fp's translational
-  /// acceleration in a frame D) with respect to "speeds" 𝑠, where 𝑠 is either
+  /// computes bias term `abias_AFp` associated with `a_AFp` (Fp's translational
+  /// acceleration in a frame A) with respect to "speeds" 𝑠, where 𝑠 is either
   /// q̇ ≜ [q̇₁ ... q̇ⱼ]ᵀ (time-derivatives of generalized positions) or
   /// v ≜ [v₁ ... vₖ]ᵀ (generalized velocities).
-  /// That is, point Fp's translational acceleration in frame D can be written
+  /// That is, point Fp's translational acceleration in frame A can be written
   /// <pre>
-  ///   a_DFp = Js_v_DFp(q)⋅ṡ + abias_DFp(q, v)
+  ///   a_AFp = Js_v_AFp(q)⋅ṡ + abias_AFp(q, v)
   /// </pre>
-  /// where `abias_DFp = J̇s_v_DFp(q, s)⋅s`.
+  /// where `abias_AFp = J̇s_v_AFp(q, s)⋅s`.
   ///
-  /// This method computes `abias_DFp` for each point Fp in the `p_FP_list`.
+  /// This method computes `abias_AFp` for each point Fp in the `p_FP_list`.
   /// The `p_FP_list` is a list of position vectors from Fo (Frame F's origin)
   /// to each such point Fp, expressed in frame F.
   ///
-  /// @see CalcJacobianTranslationalVelocity() to compute `Js_v_DFp`, point Fp's
-  /// translational velocity Jacobian in frame D with respect to s.
+  /// @see CalcJacobianTranslationalVelocity() to compute `Js_v_AFp`, point Fp's
+  /// translational velocity Jacobian in frame A with respect to s.
   ///
   /// @param[in] context The state of the multibody system, which includes the
   /// generalized positions q and generalized velocities v.
   /// @param[in] with_respect_to Enum equal to JacobianWrtVariable::kQDot or
-  /// JacobianWrtVariable::kV, indicating whether the Jacobian `Js_v_DFp` is
+  /// JacobianWrtVariable::kV, indicating whether the Jacobian `Js_v_AFp` is
   /// partial derivatives with respect to 𝑠 = q̇ (time-derivatives of generalized
   /// positions) or with respect to 𝑠 = v (generalized velocities).
   /// @param[in] frame_F The frame on which point Fp is fixed/welded.
   /// @param[in] p_FP_list `3 x n` matrix of position vectors `p_FoFp_F` from
   /// Fo (frame F's origin) to each such point Fp, expressed in frame F.
-  /// @param[in] frame_D The frame that measures `abias_DFp`.
-  /// Currently, an exception is thrown if frame_D is not the World frame.
-  /// @param[in] frame_E The frame in which `abias_DFp` is expressed on output.
-  /// @returns abias_DFp `3 x n` matrix of translational acceleration bias terms
-  /// in frame D and expressed in frame E for each of the `n` points associated
+  /// @param[in] frame_A The frame that measures `abias_AFp`.
+  /// Currently, an exception is thrown if frame_A is not the World frame.
+  /// @param[in] frame_E The frame in which `abias_AFp` is expressed on output.
+  /// @returns abias_AFp_E 3 x n matrix of translational acceleration bias terms
+  /// in frame_A and expressed in frame_E for each of the `n` points associated
   /// with p_FP_list.  These bias terms are functions of the generalized
   /// positions q and the generalized velocities v and depend on whether
   /// `with_respect_to` is kQDot or kV.
   /// @throws std::exception if `p_FP_list` does not have 3 rows.
   /// @throws std::exception if `with_respect_to` is not JacobianWrtVariable::kV
-  /// @throws std::exception if frame_D is not the world frame.
-  // TODO(Mitiguy) Allow `with_respect_to` to be JacobianWrtVariable::kQDot
-  // and/or allow frame_D to be a non-world frame.
+  /// @throws std::exception if frame_A is not the world frame.
   VectorX<T> CalcBiasForJacobianTranslationalVelocity(
       const systems::Context<T>& context,
       JacobianWrtVariable with_respect_to,
       const Frame<T>& frame_F,
       const Eigen::Ref<const MatrixX<T>>& p_FP_list,
-      const Frame<T>& frame_D,
+      const Frame<T>& frame_A,
       const Frame<T>& frame_E) const {
+    // TODO(Mitiguy) Allow `with_respect_to` to be JacobianWrtVariable::kQDot
+    // and/or allow frame_A to be a non-world frame.
     return internal_tree().CalcBiasForJacobianTranslationalVelocity(
-        context, with_respect_to, frame_F, p_FP_list, frame_D, frame_E);
+        context, with_respect_to, frame_F, p_FP_list, frame_A, frame_E);
   }
 
   // TODO(eric.cousineau): Reduce duplicate text between overloads.
@@ -1879,51 +1879,51 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   }
 
   /// For a point Fp that is regarded as a point of (fixed/welded to) a frame F,
-  /// computes the bias term `Abias_DFp` associated with `A_DFp` (Fp's spatial
-  /// acceleration in a frame D) with respect to "speeds" 𝑠, where 𝑠 is either
+  /// computes the bias term `Abias_AFp` associated with `A_AFp` (Fp's spatial
+  /// acceleration in a frame A) with respect to "speeds" 𝑠, where 𝑠 is either
   /// q̇ ≜ [q̇₁ ... q̇ⱼ]ᵀ (time-derivatives of generalized positions) or
   /// v ≜ [v₁ ... vₖ]ᵀ (generalized velocities).
-  /// That is, point Fp's spatial acceleration in frame D can be written
+  /// That is, point Fp's spatial acceleration in frame A can be written
   /// <pre>
-  ///   A_DFp = Js_V_DFp(q)⋅ṡ + Abias_DFp(q, v)
+  ///   A_AFp = Js_V_AFp(q)⋅ṡ + Abias_AFp(q, v)
   /// </pre>
-  /// where `Abias_DFp = J̇s_V_DFp(q, s)⋅s`.
+  /// where `Abias_AFp = J̇s_V_AFp(q, s)⋅s`.
   ///
-  /// @see CalcJacobianSpatialVelocity() to compute `Js_V_DFp`, point Fp's
-  /// spatial velocity Jacobian in frame D with respect to s.
+  /// @see CalcJacobianSpatialVelocity() to compute `Js_V_AFp`, point Fp's
+  /// spatial velocity Jacobian in frame A with respect to s.
   ///
   /// @param[in] context The state of the multibody system, which includes the
   /// generalized positions q and generalized velocities v.
   /// @param[in] with_respect_to Enum equal to JacobianWrtVariable::kQDot or
-  /// JacobianWrtVariable::kV, indicating whether the Jacobian `Js_v_DFp` is
+  /// JacobianWrtVariable::kV, indicating whether the Jacobian `Js_v_AFp` is
   /// partial derivatives with respect to 𝑠 = q̇ (time-derivatives of generalized
   /// positions) or with respect to 𝑠 = v (generalized velocities).
   /// @param[in] frame_F The frame on which point Fp is fixed/welded.
   /// @param[in] p_FoFp_F position vector from Fo (frame F's origin) to
   /// point Fp, expressed in frame F.
-  /// @param[in] frame_D The frame that measures `Abias_DFp`.
-  /// Currently, an exception is thrown if frame_D is not the World frame.
-  /// @param[in] frame_E The frame in which `Abias_DFp` is expressed on output.
-  /// @returns Abias_DFp Fp's spatial acceleration bias in frame D is returned
-  /// in a `6 x 1` matrix whose first three elements are frame F's angular
-  /// acceleration bias in frame D (expressed in frame E) and whose last three
-  /// elements are point Fp's translational acceleration bias in frame D
-  /// (expressed in frame E).  These bias terms are functions of the generalized
+  /// @param[in] frame_A The frame that measures `Abias_AFp`.
+  /// Currently, an exception is thrown if frame_A is not the World frame.
+  /// @param[in] frame_E The frame in which `Abias_AFp` is expressed on output.
+  /// @returns Abias_AFp_E Fp's spatial acceleration bias in frame_A is returned
+  /// in a `6 x 1` matrix whose first three elements are frame_F's angular
+  /// acceleration bias in frame_A (expressed in frame_E) and whose last three
+  /// elements are point Fp's translational acceleration bias in frame_A
+  /// (expressed in frame_E).  These bias terms are functions of the generalized
   /// positions q and the generalized velocities v and depend on whether
   /// `with_respect_to` is kQDot or kV.
   /// @throws std::exception if `with_respect_to` is not JacobianWrtVariable::kV
-  /// @throws std::exception if frame_D is not the world frame.
-  // TODO(Mitiguy) Allow `with_respect_to` to be JacobianWrtVariable::kQDot
-  // and/or allow frame_D to be a non-world frame.
+  /// @throws std::exception if frame_A is not the world frame.
   Vector6<T> CalcBiasForJacobianSpatialVelocity(
       const systems::Context<T>& context,
       JacobianWrtVariable with_respect_to,
       const Frame<T>& frame_F,
       const Eigen::Ref<const Vector3<T>>& p_FoFp_F,
-      const Frame<T>& frame_D,
+      const Frame<T>& frame_A,
       const Frame<T>& frame_E) const {
+    // TODO(Mitiguy) Allow `with_respect_to` to be JacobianWrtVariable::kQDot
+    // and/or allow frame_A to be a non-world frame.
     return internal_tree().CalcBiasForJacobianSpatialVelocity(
-        context, with_respect_to, frame_F, p_FoFp_F, frame_D, frame_E);
+        context, with_respect_to, frame_F, p_FoFp_F, frame_A, frame_E);
   }
 
   /// Computes the Jacobian of spatial velocity for a frame instantaneously

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -1078,15 +1078,15 @@ VectorX<T> MultibodyTree<T>::CalcBiasForJacobianTranslationalVelocity(
     JacobianWrtVariable with_respect_to,
     const Frame<T>& frame_F,
     const Eigen::Ref<const MatrixX<T>>& p_FP_list,
-    const Frame<T>& frame_D,
+    const Frame<T>& frame_A,
     const Frame<T>& frame_E) const {
   DRAKE_THROW_UNLESS(p_FP_list.rows() == 3);
 
   // TODO(mitiguy) Allow with_respect_to be JacobianWrtVariable::kQDot.
   DRAKE_THROW_UNLESS(with_respect_to == JacobianWrtVariable::kV);
 
-  // TODO(mitiguy) Allow frame D to be something other than world W.
-  DRAKE_THROW_UNLESS(&frame_D == &world_frame());
+  // TODO(mitiguy) Allow frame_A to be something other than world frame W.
+  DRAKE_THROW_UNLESS(&frame_A == &world_frame());
 
   // This algorithm is explained in CalcBiasForJacobianSpatialVelocity().
   const PositionKinematicsCache<T>& pc = EvalPositionKinematics(context);
@@ -1331,36 +1331,36 @@ Vector6<T> MultibodyTree<T>::CalcBiasForJacobianSpatialVelocity(
     JacobianWrtVariable with_respect_to,
     const Frame<T>& frame_F,
     const Eigen::Ref<const Vector3<T>>& p_FoFp_F,
-    const Frame<T>& frame_D,
+    const Frame<T>& frame_A,
     const Frame<T>& frame_E) const {
   // TODO(mitiguy) Allow with_respect_to be JacobianWrtVariable::kQDot.
   DRAKE_THROW_UNLESS(with_respect_to == JacobianWrtVariable::kV);
 
-  // TODO(mitiguy) Allow frame D to be something other than world W.
-  DRAKE_THROW_UNLESS(&frame_D == &world_frame());
+  // TODO(mitiguy) Allow frame_A to be something other than world frame W.
+  DRAKE_THROW_UNLESS(&frame_A == &world_frame());
 
   // Consider a point Fp of (fixed/welded to) a frame F, where frame F is
   // regarded as fixed/welded to a body frame B.  Fp's spatial acceleration in
-  // an arbitrary frame D can be written as:
-  //   A_DFp = Js_V_DFp ⋅ ṡ + Abias_DFp,
-  // where Js_V_DFp is Fp's spatial velocity Jacobian in frame D with respect to
+  // an arbitrary frame A can be written as:
+  //   A_AFp = Js_V_AFp ⋅ ṡ + Abias_AFp,
+  // where Js_V_AFp is Fp's spatial velocity Jacobian in frame A with respect to
   // "speeds" 𝑠, where 𝑠 is either
   // q̇ ≜ [q̇₁ ... q̇ⱼ]ᵀ (time-derivatives of generalized positions) or
   // v ≜ [v₁ ... vₖ]ᵀ (generalized velocities), and
-  // Abias_DFp is the associated spatial acceleration bias term, equal to
-  //   Abias_DFp = J̇s_V_DFp ⋅ s
-  // Evident in this formula is Abias_DFp can contribute to A_DFp when s != 0
+  // Abias_AFp is the associated spatial acceleration bias term, equal to
+  //   Abias_AFp = J̇s_V_AFp ⋅ s
+  // Evident in this formula is Abias_AFp can contribute to A_AFp when s != 0
   // (e.g., there are centripetal, Coriolis, or gyroscopic terms).
   // One way to calculate this bias term is to observe that it is equal to the
   // spatial acceleration when ṡ = 0, that is:
-  //   Abias_DFp = A_DFp(q, s, ṡ = 0)
+  //   Abias_AFp = A_AFp(q, s, ṡ = 0)
   // After setting ṡ = 0, Fp's spatial acceleration bias can be calculated from
   // Bo's spatial acceleration bias with a shift operation as
-  //   Abias_DFp = Abias_DBo.Shift(p_BoFp_D, w_DB_D)
-  // where p_BoBp_D is the position from Bo (body frame B's origin) to point Fp
-  // and w_DB_D is frame B's angular velocity in frame D, expressed in frame D.
+  //   Abias_AFp = Abias_ABo.Shift(p_BoFp_A, w_AB_A)
+  // where p_BoBp_A is the position from Bo (body frame B's origin) to point Fp
+  // and w_AB_A is frame B's angular velocity in frame A, expressed in frame A.
   // See SpatialAcceleration::Shift() for details.
-  // TODO(amcastro-tri): Consider caching each body's bias term Abias_DBo(q, s).
+  // TODO(amcastro-tri): Consider caching each body's bias term Abias_ABo(q, s).
   const PositionKinematicsCache<T>& pc = EvalPositionKinematics(context);
   const VelocityKinematicsCache<T>& vc = EvalVelocityKinematics(context);
 

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -1061,7 +1061,7 @@ SpatialAcceleration<T> MultibodyTree<T>::CalcSpatialAccelerationBiasShift(
   SpatialAcceleration<T> Abias_WFp = Abias_WBo.Shift(p_BoFp_W, w_WB_W);
 
   // Express the resulting vectors in frame_E (rather than the world frame).
-  if (&frame_E != &world_frame() ) {
+  if (&frame_E != &world_frame()) {
     const RigidTransform<T> X_WE = frame_E.CalcPoseInWorld(context);
     const RotationMatrix<T> R_EW = X_WE.rotation().inverse();
 

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -1041,7 +1041,7 @@ SpatialAcceleration<T> MultibodyTree<T>::CalcSpatialAccelerationBiasShift(
     const Frame<T>& frame_F,
     const math::RigidTransform<T>& X_BF,
     const Vector3<T>& p_FoFp_F,
-    const SpatialAcceleration<T>& Abias_WBo,
+    const SpatialAcceleration<T>& Abias_WBo_W,
     const Frame<T>& frame_E) const {
 
   const PositionKinematicsCache<T>& pc = EvalPositionKinematics(context);
@@ -1058,7 +1058,7 @@ SpatialAcceleration<T> MultibodyTree<T>::CalcSpatialAccelerationBiasShift(
 
   // Shift spatial acceleration bias term from point Bo to point Fp.
   // See SpatialAcceleration::Shift() for details.
-  SpatialAcceleration<T> Abias_WFp = Abias_WBo.Shift(p_BoFp_W, w_WB_W);
+  SpatialAcceleration<T> Abias_WFp = Abias_WBo_W.Shift(p_BoFp_W, w_WB_W);
 
   // Express the resulting vectors in frame_E (rather than the world frame).
   if (&frame_E != &world_frame()) {

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -1036,85 +1036,99 @@ void MultibodyTree<T>::CalcPointsAnalyticalJacobianExpressedInWorld(
 }
 
 template <typename T>
+SpatialAcceleration<T> MultibodyTree<T>::CalcSpatialAccelerationBiasHelper(
+    JacobianWrtVariable with_respect_to,
+    const Frame<T>& frame_F,
+    const math::RigidTransform<T>& X_BF,
+    const Vector3<T>& p_FoFp_F,
+    const PositionKinematicsCache<T>& pc,
+    const VelocityKinematicsCache<T>& vc,
+    const SpatialAcceleration<T>& Abias_WBo) const {
+  // TODO(mitiguy) Allow with_respect_to be JacobianWrtVariable::kQDot.
+  DRAKE_THROW_UNLESS(with_respect_to == JacobianWrtVariable::kV);
+
+  // Consider a point Fp of (fixed/welded to) a frame F, where frame F is
+  // regarded as fixed/welded to a body frame B.  Fp's spatial acceleration in
+  // world W can be written as:
+  //   A_WFp = Js_V_WFp ⋅ ṡ + Abias_WFp,
+  // where Js_V_WFp is Fp's spatial velocity Jacobian in world W with respect to
+  // "speeds" 𝑠, where 𝑠 is either
+  // q̇ ≜ [q̇₁ ... q̇ⱼ]ᵀ (time-derivatives of generalized positions) or
+  // v ≜ [v₁ ... vₖ]ᵀ (generalized velocities), and
+  // Abias_WFp is the associated spatial acceleration bias term, equal to
+  //   Abias_WFp = J̇s_V_WFp ⋅ s
+  // This formula for Abias_WFp shows this bias term may contribute to A_WFp
+  // when s != 0 (e.g., there are centripetal, Coriolis, or gyroscopic terms).
+  // One way to calculate this bias term is to observe that it is equal to the
+  // spatial acceleration when ṡ = 0, that is:
+  //   Abias_WFp = A_WFp(q, v, ṡ = 0)
+  // After setting ṡ = 0, Fp's spatial acceleration bias can be calculated from
+  // Bo's spatial acceleration bias with a shift operation as
+  //   Abias_WFp = Abias_WBo.Shift(p_BoFp_W, w_WB)
+  // where p_BoBp_W is the position from Bo (body frame B's origin) to point Fp.
+  // See SpatialAcceleration::Shift() for details.
+  // TODO(amcastro-tri): Consider caching each body's bias term Abias_WBo(q, v).
+
+  // Get body B's rotation matrix in world W and angular velocity in world W.
+  const Body<T>& body_B = frame_F.body();
+  const RotationMatrix<T>& R_WB = pc.get_X_WB(body_B.node_index()).rotation();
+  const Vector3<T>& w_WB = vc.get_V_WB(body_B.node_index()).rotational();
+
+  // We need to compute p_BoFp_W, the position from Bo to Fp, expressed in W.
+  const Vector3<T> p_BoFp_B = X_BF * p_FoFp_F;
+  const Vector3<T> p_BoFp_W = R_WB * p_BoFp_B;
+
+  // Shift spatial acceleration bias term from point Bo to point Fp.
+  const SpatialAcceleration<T> Abias_WFp = Abias_WBo.Shift(p_BoFp_W, w_WB);
+  return Abias_WFp;
+}
+
+template <typename T>
 VectorX<T> MultibodyTree<T>::CalcBiasForJacobianTranslationalVelocity(
     const systems::Context<T>& context,
     JacobianWrtVariable with_respect_to,
     const Frame<T>& frame_F,
     const Eigen::Ref<const MatrixX<T>>& p_FP_list,
-    const Frame<T>& frame_A,
+    const Frame<T>& frame_D,
     const Frame<T>& frame_E) const {
   DRAKE_THROW_UNLESS(p_FP_list.rows() == 3);
 
-  // For now, this method requires with_respect_to to be kV.
-  DRAKE_THROW_UNLESS(with_respect_to == JacobianWrtVariable::kV);
-
-  // For now, this method requires frame_A and frame_E to be the world frame.
-  DRAKE_THROW_UNLESS(&frame_A == &world_frame());
+  // TODO(mitiguy) Allow frame D and frame E to be something other than world W.
+  DRAKE_THROW_UNLESS(&frame_D == &world_frame());
   DRAKE_THROW_UNLESS(&frame_E == &world_frame());
 
   const PositionKinematicsCache<T>& pc = EvalPositionKinematics(context);
   const VelocityKinematicsCache<T>& vc = EvalVelocityKinematics(context);
 
-  // For a frame F instantaneously moving with a body frame B, the spatial
-  // acceleration in world W of the frame F shifted to frame Fp with origin at
-  // point P fixed in frame F, can be computed as:
-  //   A_WFp = Jv_WFp⋅v̇ + Ab_WFp,
-  // where Jv_WFp is the Jacobian with respect to generalized velocities v of
-  // the spatial velocity of frame Fp in world W and Ab_WFp is the bias
-  // term for that Jacobian, defined as Ab_WFp = J̇v_WFp⋅v. The bias terms
-  // contains the Coriolis and centrifugal contributions to the total spatial
-  // acceleration due to non-zero velocities. Therefore, the bias term for
-  // Jv_WFp is the spatial acceleration of Fp when v̇ = 0, that is:
-  //   Ab_WFp = A_WFp(q, v, v̇ = 0)
-  // Given the position p_BP_W of point P on body frame B, we can compute the
-  // spatial acceleration Ab_WFp from the body spatial acceleration A_WB by
-  // simply performing a shift operation:
-  //   Ab_WFp = A_WB.Shift(p_BP_W, w_WB)
-  // where the shift operation also includes the angular velocity w_WB of B in
-  // W since rigid shifts on acceleration will usually include additional
-  // centrifugal and Coriolis terms, see SpatialAcceleration::Shift() for a
-  // detailed derivation of these terms.
+  // This algorithm is explained in CalcSpatialAccelerationBiasHelper().
+  // Set ṡ = 0 and calculate point Bo's spatial acceleration bias in world W.
+  std::vector<SpatialAcceleration<T>> Abias_WB_array(num_bodies());
+  const VectorX<T> sdot = VectorX<T>::Zero(num_velocities());
+  CalcSpatialAccelerationsFromVdot(context, pc, vc, sdot, &Abias_WB_array);
 
-  // TODO(amcastro-tri): Consider caching Ab_WB(q, v), the bias term for each
-  // body, and compute the bias as Ab_WBp = Ab_WB.Shift(p_BP_W, w_WB).
-  // Where the body bias terms is defined s.t. A_WB = J_WB⋅v̇ + Ab_WB or,
-  // Ab_WB = J̇_WB⋅v
-
-  std::vector<SpatialAcceleration<T>> A_WB_array(num_bodies());
-  const VectorX<T> vdot = VectorX<T>::Zero(num_velocities());
-  CalcSpatialAccelerationsFromVdot(context, pc, vc, vdot, &A_WB_array);
-
+  // Extract point Bo's spatial acceleration bias from the large array.
   const Body<T>& body_B = frame_F.body();
-  // Bias for body B spatial acceleration.
-  const SpatialAcceleration<T>& Ab_WB = A_WB_array[body_B.node_index()];
+  const SpatialAcceleration<T>& Abias_WBo = Abias_WB_array[body_B.node_index()];
 
+  // Get transform from body B to frame F.
+  const RigidTransform<T> X_BF = frame_F.GetFixedPoseInBodyFrame();
+
+  // Allocate the output vector.
   const int num_points = p_FP_list.cols();
-
-  // Allocate output vector.
-  VectorX<T> Ab_WB_array(3 * num_points);
+  VectorX<T> Abias_WFp_array(3 * num_points);
 
   for (int ipoint = 0; ipoint < num_points; ++ipoint) {
-    const Vector3<T> p_FPi_F = p_FP_list.col(ipoint);
+    const Vector3<T> p_FoPi_F = p_FP_list.col(ipoint);
 
-    // Body B's orientation in world W.
-    const RotationMatrix<T>& R_WB = pc.get_X_WB(body_B.node_index()).rotation();
-
-    // We need to compute p_BPi_W, the position from Bo to Pi, expressed in W.
-    const RigidTransform<T> X_BF = frame_F.GetFixedPoseInBodyFrame();
-    const Vector3<T> p_BPi_B = X_BF * p_FPi_F;
-    const Vector3<T> p_BPi_W = R_WB * p_BPi_B;
-
-    // Body B's velocity in the world frame W.
-    const Vector3<T>& w_WB = vc.get_V_WB(body_B.node_index()).rotational();
-
-    // Shift body B's bias term to point Pi.
-    const SpatialAcceleration<T> Ab_WBp = Ab_WB.Shift(p_BPi_W, w_WB);
+    // Shift spatial acceleration bias term from point Bo to point Fp.
+    const SpatialAcceleration<T> Abias_WFp = CalcSpatialAccelerationBiasHelper(
+        with_respect_to, frame_F, X_BF, p_FoPi_F, pc, vc, Abias_WBo);
 
     // Output translational component only.
-    Ab_WB_array.template segment<3>(3 * ipoint) = Ab_WBp.translational();
+    Abias_WFp_array.template segment<3>(3 * ipoint) = Abias_WFp.translational();
   }
 
-  return Ab_WB_array;
+  return Abias_WFp_array;
 }
 
 template <typename T>
@@ -1321,60 +1335,41 @@ void MultibodyTree<T>::CalcJacobianTranslationalVelocity(
 }
 
 template <typename T>
-Vector6<T> MultibodyTree<T>::CalcBiasForFrameGeometricJacobianExpressedInWorld(
+Vector6<T> MultibodyTree<T>::CalcBiasForJacobianSpatialVelocity(
     const systems::Context<T>& context,
-    const Frame<T>& frame_F, const Eigen::Ref<const Vector3<T>>& p_FP) const {
+    JacobianWrtVariable with_respect_to,
+    const Frame<T>& frame_F,
+    const Eigen::Ref<const Vector3<T>>& p_FoFp_F,
+    const Frame<T>& frame_D,
+    const Frame<T>& frame_E) const {
+  // TODO(mitiguy) Allow with_respect_to be JacobianWrtVariable::kQDot.
+  DRAKE_THROW_UNLESS(with_respect_to == JacobianWrtVariable::kV);
+
+  // TODO(mitiguy) Allow frame D and frame E to be something other than world W.
+  DRAKE_THROW_UNLESS(&frame_D == &world_frame());
+  DRAKE_THROW_UNLESS(&frame_E == &world_frame());
+
   const PositionKinematicsCache<T>& pc = EvalPositionKinematics(context);
   const VelocityKinematicsCache<T>& vc = EvalVelocityKinematics(context);
 
-  // For a frame F moving instantaneously with its body frame B, the spatial
-  // acceleration of the frame F shifted to frame Fp with origin at point P
-  // fixed in frame F, can be computed as:
-  //   A_WFp = Jv_WFp⋅v̇ + Ab_WFp,
-  // where Jv_WFp is the frame geometric Jacobian for frame Fp and Ab_WFp is the
-  // bias term for that Jacobian, defined as Ab_WFp = J̇v_WFp⋅v. The bias term
-  // contains the Coriolis and centrifugal contributions to the total spatial
-  // acceleration due to non-zero velocities. Therefore, the bias term for
-  // Jv_WFp is the spatial acceleration of Fp when v̇ = 0, that is:
-  //   Ab_WFp = A_WFp(q, v, v̇ = 0)
-  // Given the position p_BP_W of point P in body frame B, we can compute the
-  // spatial acceleration Ab_WFp from the body spatial acceleration A_WB by
-  // simply performing a shift operation:
-  //   Ab_WFp = A_WB.Shift(p_BP_W, w_WB)
-  // where the shift operation also includes the angular velocity w_WB of B in
-  // W since rigid shifts on acceleration will usually include additional
-  // centrifugal and Coriolis terms, see SpatialAcceleration::Shift() for a
-  // detailed derivation of these terms.
+  // This algorithm is explained in CalcSpatialAccelerationBiasHelper().
+  // Set ṡ = 0 and calculate point Bo's spatial acceleration bias in world W.
+  std::vector<SpatialAcceleration<T>> Abias_WB_array(num_bodies());
+  const VectorX<T> sdot = VectorX<T>::Zero(num_velocities());
+  CalcSpatialAccelerationsFromVdot(context, pc, vc, sdot, &Abias_WB_array);
 
-  // TODO(amcastro-tri): Consider caching Ab_WB(q, v), the bias term for each
-  // body, and compute the bias as Ab_WBp = Ab_WB.Shift(p_BP_W, w_WB).
-  // Where the body bias terms is defined s.t. A_WB = J_WB⋅v̇ + Ab_WB or,
-  // Ab_WB = J̇_WB⋅v
-
-  std::vector<SpatialAcceleration<T>> A_WB_array(num_bodies());
-  const VectorX<T> vdot = VectorX<T>::Zero(num_velocities());
-  CalcSpatialAccelerationsFromVdot(context, pc, vc, vdot, &A_WB_array);
-
+  // Extract point Bo's spatial acceleration bias from the large array.
   const Body<T>& body_B = frame_F.body();
-  // Bias for body B spatial acceleration.
-  const SpatialAcceleration<T>& Ab_WB = A_WB_array[body_B.node_index()];
+  const SpatialAcceleration<T>& Abias_WBo = Abias_WB_array[body_B.node_index()];
 
-  // Body B's orientation.
-  const Matrix3<T>& R_WB = pc.get_X_WB(body_B.node_index()).linear();
-
-  // We need to compute p_BoP_W, the position of P from B's origin Bo,
-  // expressed in W.
+  // Get transform from body B to frame F.
   const RigidTransform<T> X_BF = frame_F.GetFixedPoseInBodyFrame();
-  const Vector3<T> p_BP = X_BF * p_FP;
-  const Vector3<T> p_BP_W = R_WB * p_BP;
 
-  // Body B's velocity in the world frame W.
-  const Vector3<T>& w_WB = vc.get_V_WB(body_B.node_index()).rotational();
+  // Shift spatial acceleration bias term from point Bo to point Fp.
+  const SpatialAcceleration<T> Abias_WFp = CalcSpatialAccelerationBiasHelper(
+  with_respect_to, frame_F, X_BF, p_FoFp_F, pc, vc, Abias_WBo);
 
-  // Shift body B's bias term to frame P.
-  const SpatialAcceleration<T> Ab_WP = Ab_WB.Shift(p_BP_W, w_WB);
-
-  return Ab_WP.get_coeffs();
+  return Abias_WFp.get_coeffs();
 }
 
 template <typename T>

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -2064,14 +2064,13 @@ class MultibodyTree {
 
   // Helper method for CalcBiasForJacobianTranslationalVelocity() and
   // CalcBiasForJacobianSpatialVelocity().
-  SpatialAcceleration<T> CalcSpatialAccelerationBiasHelper(
-      JacobianWrtVariable with_respect_to,
+  SpatialAcceleration<T> CalcSpatialAccelerationBiasShift(
+      const systems::Context<T>& context,
       const Frame<T>& frame_F,
       const math::RigidTransform<T>& X_BF,
       const Vector3<T>& p_FoFp_F,
-      const PositionKinematicsCache<T>& pc,
-      const VelocityKinematicsCache<T>& vc,
-      const SpatialAcceleration<T>& Abias_WBo) const;
+      const SpatialAcceleration<T>& Abias_WBo,
+      const Frame<T>& frame_E) const;
 
   // Helper method to access the mobilizer of a free body.
   // If `body` is a free body in the model, this method will return the

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -2063,13 +2063,27 @@ class MultibodyTree {
   void AddQuaternionFreeMobilizerToAllBodiesWithNoMobilizer();
 
   // Helper method for CalcBiasForJacobianTranslationalVelocity() and
-  // CalcBiasForJacobianSpatialVelocity().
+  // CalcBiasForJacobianSpatialVelocity() which shifts the spatial acceleration
+  // bias term from point Fo (the origin of a frame F) to point Fp (fixed on F),
+  // where frame F is fixed to a body B.
+  // @param[in] context The state of the multibody system, which includes the
+  // generalized positions q and generalized velocities v.
+  // @param[in] frame_F The frame on which point Fp is fixed/welded.
+  // @param[in] X_BF rigid transform relating body B's frame to frame F.
+  // @param[in] p_FoFp_F position vector from Fo (frame F's origin) to Fp,
+  // expressed in frame F.
+  // @param[in] Abias_WBo_W spatial acceleration bias of Bo (body B's origin) in
+  // world W, expressed in W.
+  // expressed in frame F.
+  // @param[in] frame_E The frame in which `Abias_WFp` is expressed on output.
+  // @returns Abias_WFp_E  Fp's spatial acceleration bias in world frame W,
+  // expressed in frame_E.
   SpatialAcceleration<T> CalcSpatialAccelerationBiasShift(
       const systems::Context<T>& context,
       const Frame<T>& frame_F,
       const math::RigidTransform<T>& X_BF,
       const Vector3<T>& p_FoFp_F,
-      const SpatialAcceleration<T>& Abias_WBo,
+      const SpatialAcceleration<T>& Abias_WBo_W,
       const Frame<T>& frame_E) const;
 
   // Helper method to access the mobilizer of a free body.

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -1259,7 +1259,7 @@ class MultibodyTree {
       JacobianWrtVariable with_respect_to,
       const Frame<T>& frame_F,
       const Eigen::Ref<const MatrixX<T>>& p_FP_list,
-      const Frame<T>& frame_A,
+      const Frame<T>& frame_D,
       const Frame<T>& frame_E) const;
 
   /// See MultibodyPlant method.
@@ -1275,9 +1275,13 @@ class MultibodyTree {
       EigenPtr<MatrixX<T>> Jv_WFp) const;
 
   /// See MultibodyPlant method.
-  Vector6<T> CalcBiasForFrameGeometricJacobianExpressedInWorld(
+  Vector6<T> CalcBiasForJacobianSpatialVelocity(
       const systems::Context<T>& context,
-      const Frame<T>& frame_F, const Eigen::Ref<const Vector3<T>>& p_FP) const;
+      JacobianWrtVariable with_respect_to,
+      const Frame<T>& frame_F,
+      const Eigen::Ref<const Vector3<T>>& p_FoFp_F,
+      const Frame<T>& frame_D,
+      const Frame<T>& frame_E) const;
 
   /// See MultibodyPlant method.
   void CalcJacobianSpatialVelocity(
@@ -2057,6 +2061,17 @@ class MultibodyTree {
   // The world body is special in that it is the only body in the model with no
   // mobilizer, even after Finalize().
   void AddQuaternionFreeMobilizerToAllBodiesWithNoMobilizer();
+
+  // Helper method for CalcBiasForJacobianTranslationalVelocity() and
+  // CalcBiasForJacobianSpatialVelocity().
+  SpatialAcceleration<T> CalcSpatialAccelerationBiasHelper(
+      JacobianWrtVariable with_respect_to,
+      const Frame<T>& frame_F,
+      const math::RigidTransform<T>& X_BF,
+      const Vector3<T>& p_FoFp_F,
+      const PositionKinematicsCache<T>& pc,
+      const VelocityKinematicsCache<T>& vc,
+      const SpatialAcceleration<T>& Abias_WBo) const;
 
   // Helper method to access the mobilizer of a free body.
   // If `body` is a free body in the model, this method will return the

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -1259,7 +1259,7 @@ class MultibodyTree {
       JacobianWrtVariable with_respect_to,
       const Frame<T>& frame_F,
       const Eigen::Ref<const MatrixX<T>>& p_FP_list,
-      const Frame<T>& frame_D,
+      const Frame<T>& frame_A,
       const Frame<T>& frame_E) const;
 
   /// See MultibodyPlant method.
@@ -1280,7 +1280,7 @@ class MultibodyTree {
       JacobianWrtVariable with_respect_to,
       const Frame<T>& frame_F,
       const Eigen::Ref<const Vector3<T>>& p_FoFp_F,
-      const Frame<T>& frame_D,
+      const Frame<T>& frame_A,
       const Frame<T>& frame_E) const;
 
   /// See MultibodyPlant method.

--- a/multibody/tree/test/multibody_tree_test.cc
+++ b/multibody/tree/test/multibody_tree_test.cc
@@ -702,13 +702,13 @@ TEST_F(KukaIiwaModelTests, CalcBiasForJacobianTranslationalVelocity) {
   abias_WHp_H_expected.head(3) = R_HW * abias_WHp_W_expected.head(3);
   abias_WHp_H_expected.tail(3) = R_HW * abias_WHp_W_expected.tail(3);
 
-  // Directly calculate Abias_WHp_H.
+  // Directly calculate abias_WHp_H.
   const VectorX<double> abias_WHp_H =
       tree().CalcBiasForJacobianTranslationalVelocity(
           *context_, JacobianWrtVariable::kV, *frame_H_, p_HPi,
           world_frame, *frame_H_);
 
-  // Ensure Abias_WHp_H is nearly identical to Abias_WHp_H_expected.
+  // Ensure abias_WHp_H is nearly identical to abias_WHp_H_expected.
   EXPECT_TRUE(CompareMatrices(abias_WHp_H, abias_WHp_H_expected,
                               kTolerance, MatrixCompareType::relative));
 

--- a/multibody/tree/test/multibody_tree_test.cc
+++ b/multibody/tree/test/multibody_tree_test.cc
@@ -906,10 +906,9 @@ TEST_F(KukaIiwaModelTests, CalcFrameGeometricJacobianExpressedInWorld) {
   EXPECT_TRUE(Jv_WF_times_v.IsApprox(V_WEf, kTolerance));
 }
 
-// Unit tests MBT::CalcBiasForFrameGeometricJacobianExpressedInWorld() using
-// AutoDiffXd to compute time derivatives of the geometric Jacobian to obtain a
-// reference solution.
-TEST_F(KukaIiwaModelTests, CalcBiasForFrameGeometricJacobianExpressedInWorld) {
+// Unit tests MBT::CalcBiasForJacobianSpatialVelocity() use AutoDiffXd to time-
+// differentiate the spatial velocity Jacobian to form a reference solution.
+TEST_F(KukaIiwaModelTests, CalcBiasForJacobianSpatialVelocity) {
   // The number of generalized velocities in the Kuka iiwa robot arm model.
   const int kNumVelocities = tree().num_velocities();
 
@@ -976,16 +975,18 @@ TEST_F(KukaIiwaModelTests, CalcBiasForFrameGeometricJacobianExpressedInWorld) {
 
   // Compute the expected value of the bias terms using the time derivatives
   // computed with AutoDiffXd.
-  const VectorX<double> Ab_WHp_expected = Jv_WHp_derivs * v;
+  const VectorX<double> Abias_WHp_expected = Jv_WHp_derivs * v;
 
-  // Compute frame Hp geometric Jacobian bias.
-  const VectorX<double> Ab_WHp =
-      tree().CalcBiasForFrameGeometricJacobianExpressedInWorld(
-          *context_, *frame_H_, p_HPo);
+  // Compute point Hp's spatial velocity Jacobian bias in world W.
+  const Frame<double>& world_frame = tree().world_frame();
+  const VectorX<double> Abias_WHp =
+      tree().CalcBiasForJacobianSpatialVelocity(
+          *context_, JacobianWrtVariable::kV, *frame_H_, p_HPo,
+          world_frame, world_frame);
 
-  // Ab_WHp is of size 6 x num_velocities. CompareMatrices() below
+  // Abias_WHp is of size 6 x num_velocities. CompareMatrices() below
   // verifies this, in addition to the numerical values of each element.
-  EXPECT_TRUE(CompareMatrices(Ab_WHp, Ab_WHp_expected,
+  EXPECT_TRUE(CompareMatrices(Abias_WHp, Abias_WHp_expected,
                               kTolerance, MatrixCompareType::relative));
 }
 

--- a/multibody/tree/test/multibody_tree_test.cc
+++ b/multibody/tree/test/multibody_tree_test.cc
@@ -717,13 +717,6 @@ TEST_F(KukaIiwaModelTests, CalcBiasForJacobianTranslationalVelocity) {
                    *context_, JacobianWrtVariable::kV, *frame_H_, p_HPi,
                    *frame_H_, world_frame),
                std::exception);
-
-  // Verify CalcBiasForJacobianTranslationalVelocity() throws an exception if
-  // expressed-in-frame is not world frame W.
-  EXPECT_THROW(tree().CalcBiasForJacobianTranslationalVelocity(
-                   *context_, JacobianWrtVariable::kV, *frame_H_, p_HPi,
-                   world_frame, *frame_H_),
-               std::exception);
 }
 
 // Given a set of points Pi attached to the end effector frame G, this test


### PR DESCRIPTION
Deprecate CalcBiasForFrameGeometricJacobianExpressedInWorld() in favor of CalcBiasForJacobianSpatialVelocity() per issue #10144.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11539)
<!-- Reviewable:end -->
