### PR TITLE
Add the constructor for SdpaFreeFormat

### DIFF
--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -56,6 +56,7 @@ drake_cc_package_library(
         ":program_attribute",
         ":rotation_constraint",
         ":scs_solver",
+        ":sdpa_free_format",
         ":snopt_solver",
         ":solution_result",
         ":solve",
@@ -106,6 +107,7 @@ drake_cc_library(
     srcs = ["choose_best_solver.cc"],
     hdrs = ["choose_best_solver.h"],
     deps = [
+        ":csdp_solver",
         ":equality_constrained_qp_solver",
         ":gurobi_solver",
         ":ipopt_solver",
@@ -277,6 +279,7 @@ drake_cc_library(
     srcs = ["solver_type_converter.cc"],
     hdrs = ["solver_type_converter.h"],
     deps = [
+        ":csdp_solver",
         ":dreal_solver",
         ":equality_constrained_qp_solver",
         ":gurobi_solver",
@@ -974,6 +977,16 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "sdpa_free_format",
+    srcs = ["sdpa_free_format.cc"],
+    hdrs = ["sdpa_free_format.h"],
+    deps = [
+        ":mathematical_program_lite",
+        "//common:type_safe_index",
+    ],
+)
+
+drake_cc_library(
     name = "csdp_solver",
     srcs = select({
         "//conditions:default": [
@@ -999,8 +1012,7 @@ drake_cc_library(
         "//conditions:default": [
             ":mathematical_program_private",
             ":solver_base",
-            "//common:type_safe_index",
-            "//math:eigen_sparse_triplet",
+            ":sdpa_free_format",
             "@csdp",
         ],
         "//tools:no_csdp": [
@@ -1145,6 +1157,28 @@ drake_cc_googletest(
         ":create_constraint",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:symbolic_test_util",
+    ],
+)
+
+drake_cc_library(
+    name = "csdp_test_examples",
+    testonly = 1,
+    srcs = ["test/csdp_test_examples.cc"],
+    hdrs = ["test/csdp_test_examples.h"],
+    deps = [
+        ":mathematical_program",
+        "@gtest//:without_main",
+    ],
+)
+
+drake_cc_googletest(
+    name = "sdpa_free_format_test",
+    deps = [
+        ":csdp_test_examples",
+        ":sdpa_free_format",
+        "//common:temp_directory",
+        "//common/test_utilities:eigen_matrix_compare",
+        "@spruce",
     ],
 )
 

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -107,7 +107,6 @@ drake_cc_library(
     srcs = ["choose_best_solver.cc"],
     hdrs = ["choose_best_solver.h"],
     deps = [
-        ":csdp_solver",
         ":equality_constrained_qp_solver",
         ":gurobi_solver",
         ":ipopt_solver",
@@ -1176,9 +1175,7 @@ drake_cc_googletest(
     deps = [
         ":csdp_test_examples",
         ":sdpa_free_format",
-        "//common:temp_directory",
         "//common/test_utilities:eigen_matrix_compare",
-        "@spruce",
     ],
 )
 

--- a/solvers/constraint.h
+++ b/solvers/constraint.h
@@ -337,6 +337,9 @@ class LorentzConeConstraint : public Constraint {
   /** Getter for A. */
   const Eigen::SparseMatrix<double>& A() const { return A_; }
 
+  /** Getter for dense version of A. */
+  const Eigen::MatrixXd& A_dense() const { return A_dense_; }
+
   /** Getter for b. */
   const Eigen::VectorXd& b() const { return b_; }
 
@@ -397,6 +400,9 @@ class RotatedLorentzConeConstraint : public Constraint {
 
   /** Getter for A. */
   const Eigen::SparseMatrix<double>& A() const { return A_; }
+
+  /** Getter for dense version of A. */
+  const Eigen::MatrixXd& A_dense() const { return A_dense_; }
 
   /** Getter for b. */
   const Eigen::VectorXd& b() const { return b_; }

--- a/solvers/sdpa_free_format.cc
+++ b/solvers/sdpa_free_format.cc
@@ -1,0 +1,477 @@
+#include "drake/solvers/sdpa_free_format.h"
+
+#include <algorithm>
+#include <fstream>
+#include <iomanip>
+#include <limits>
+#include <stdexcept>
+#include <unordered_map>
+#include <vector>
+
+#include <Eigen/Core>
+#include <Eigen/Sparse>
+#include <Eigen/SparseQR>
+
+namespace drake {
+namespace solvers {
+namespace internal {
+
+const double kInf = std::numeric_limits<double>::infinity();
+
+SdpaFreeFormat::~SdpaFreeFormat() {}
+
+void SdpaFreeFormat::DeclareXforPositiveSemidefiniteConstraints(
+    const MathematicalProgram& prog,
+    std::unordered_map<symbolic::Variable::Id, std::vector<EntryInX>>*
+        entries_in_X_for_same_decision_variable) {
+  int num_blocks = 0;
+  for (const auto& binding : prog.positive_semidefinite_constraints()) {
+    // The bound variables are the column-stacked vector of the psd matrix. We
+    // only record the upper-diagonal entries in the psd matrix.
+    int psd_matrix_variable_index = 0;
+    const int matrix_rows = binding.evaluator()->matrix_rows();
+    X_blocks_.emplace_back(BlockType::kMatrix, matrix_rows);
+    for (int j = 0; j < matrix_rows; ++j) {
+      for (int i = 0; i <= j; ++i) {
+        const symbolic::Variable& psd_ij_var =
+            binding.variables()(psd_matrix_variable_index++);
+        const int psd_ij_var_index = prog.FindDecisionVariableIndex(psd_ij_var);
+        const bool has_var_registered = !(holds_alternative<std::nullptr_t>(
+            prog_var_in_sdpa_[psd_ij_var_index]));
+        const EntryInX psd_ij_entry_in_X(num_blocks, i, j, num_X_rows_);
+        if (!has_var_registered) {
+          // This variable has not been registered into X. Now register this
+          // variable, by adding it to map_prog_var_index_to_entry_in_X_.
+          prog_var_in_sdpa_[psd_ij_var_index].emplace<DecisionVariableInSdpaX>(
+              Sign::kPositive, 0, psd_ij_entry_in_X);
+        } else {
+          // This variable has been registered into X. We need to add the
+          // equality constraint between all X entries corresponding to this
+          // variable.
+
+          // First find if there exists equality constraint on this variable
+          // already.
+          const auto it2 = entries_in_X_for_same_decision_variable->find(
+              psd_ij_var.get_id());
+          if (it2 == entries_in_X_for_same_decision_variable->end()) {
+            // There does not exist equality constraint on this variable yet.
+            entries_in_X_for_same_decision_variable->emplace_hint(
+                it2, psd_ij_var.get_id(),
+                std::vector<EntryInX>({get<DecisionVariableInSdpaX>(
+                                           prog_var_in_sdpa_[psd_ij_var_index])
+                                           .entry_in_X,
+                                       psd_ij_entry_in_X}));
+          } else {
+            // We found equality constraint on this variable, append the vector
+            // containing all X entries that correspond to this variable.
+            it2->second.push_back(psd_ij_entry_in_X);
+          }
+        }
+      }
+      psd_matrix_variable_index += matrix_rows - j - 1;
+    }
+    num_blocks++;
+    num_X_rows_ += matrix_rows;
+  }
+}
+
+void AddTermToTriplets(const EntryInX& entry_in_X, double coeff,
+                       std::vector<Eigen::Triplet<double>>* triplets) {
+  if (entry_in_X.row_index_in_block == entry_in_X.column_index_in_block) {
+    triplets->emplace_back(
+        entry_in_X.X_start_row + entry_in_X.row_index_in_block,
+        entry_in_X.X_start_row + entry_in_X.column_index_in_block, coeff);
+  } else {
+    triplets->emplace_back(
+        entry_in_X.X_start_row + entry_in_X.row_index_in_block,
+        entry_in_X.X_start_row + entry_in_X.column_index_in_block, coeff / 2);
+    triplets->emplace_back(
+        entry_in_X.X_start_row + entry_in_X.column_index_in_block,
+        entry_in_X.X_start_row + entry_in_X.row_index_in_block, coeff / 2);
+  }
+}
+
+void SdpaFreeFormat::AddLinearEqualityConstraint(
+    const std::vector<double>& a, const std::vector<int>& prog_vars_indices,
+    const std::vector<double>& b, const std::vector<EntryInX>& X_entries,
+    const std::vector<double>& c,
+    const std::vector<FreeVariableIndex>& s_indices, double rhs) {
+  DRAKE_ASSERT(a.size() == prog_vars_indices.size());
+  DRAKE_ASSERT(b.size() == X_entries.size());
+  DRAKE_ASSERT(c.size() == s_indices.size());
+  const int constraint_index = static_cast<int>(A_triplets_.size());
+  std::vector<Eigen::Triplet<double>> Ai_triplets;
+  // If the entries are off-diagonal entries of X, then it needs two
+  // coefficients in Ai, for both the upper and lower diagonal part.
+  Ai_triplets.reserve(static_cast<int>(a.size() + b.size()) * 2);
+  g_.conservativeResize(g_.rows() + 1);
+  g_(constraint_index) = rhs;
+  for (int i = 0; i < static_cast<int>(a.size()); ++i) {
+    if (a[i] != 0) {
+      const int prog_var_index = prog_vars_indices[i];
+      if (holds_alternative<DecisionVariableInSdpaX>(
+              prog_var_in_sdpa_[prog_var_index])) {
+        // This variable is an entry in X.
+        const auto& decision_var_in_X =
+            get<DecisionVariableInSdpaX>(prog_var_in_sdpa_[prog_var_index]);
+        g_(constraint_index) -= a[i] * decision_var_in_X.offset;
+        const double coeff =
+            decision_var_in_X.coeff_sign == Sign::kPositive ? a[i] : -a[i];
+        AddTermToTriplets(decision_var_in_X.entry_in_X, coeff, &Ai_triplets);
+      } else if (holds_alternative<double>(prog_var_in_sdpa_[prog_var_index])) {
+        // This variable has a constant value.
+        const double var_value = get<double>(prog_var_in_sdpa_[prog_var_index]);
+        g_(constraint_index) -= a[i] * var_value;
+      } else if (holds_alternative<FreeVariableIndex>(
+                     prog_var_in_sdpa_[prog_var_index])) {
+        B_triplets_.emplace_back(
+            constraint_index,
+            get<FreeVariableIndex>(prog_var_in_sdpa_[prog_var_index]), a[i]);
+      } else {
+        throw std::runtime_error(
+            "SdpaFreeFormat::AddLinearEqualityConstraint() : this decision "
+            "variable is not an entry in X or s, and is not a constant.");
+      }
+    }
+  }
+  for (int i = 0; i < static_cast<int>(b.size()); ++i) {
+    if (b[i] != 0) {
+      AddTermToTriplets(X_entries[i], b[i], &Ai_triplets);
+    }
+  }
+  A_triplets_.push_back(Ai_triplets);
+  if (!b.empty()) {
+    for (int i = 0; i < static_cast<int>(c.size()); ++i) {
+      B_triplets_.emplace_back(constraint_index, s_indices[i], c[i]);
+    }
+  }
+}
+
+void SdpaFreeFormat::AddEqualityConstraintOnXentriesForSameDecisionVariable(
+    const std::unordered_map<symbolic::Variable::Id, std::vector<EntryInX>>&
+        entries_in_X_for_same_decision_variable) {
+  for (const auto& item : entries_in_X_for_same_decision_variable) {
+    const auto& Xentries = item.second;
+    DRAKE_ASSERT(Xentries.size() >= 2);
+    const std::vector<double> a{{1, -1}};
+    for (int i = 1; i < static_cast<int>(Xentries.size()); ++i) {
+      AddLinearEqualityConstraint({}, {}, a, {Xentries[0], Xentries[i]}, {}, {},
+                                  0.0);
+    }
+  }
+}
+
+void SdpaFreeFormat::RegisterMathematicalProgramDecisionVariable(
+    const MathematicalProgram& prog) {
+  // Go through all the decision variables in @p prog. If the decision variable
+  // has not been registered in SDPA, then register it now. Refer to @ref
+  // map_decision_variable_to_sdpa for different types.
+  Eigen::VectorXd lower_bound =
+      Eigen::VectorXd::Constant(prog.num_vars(), -kInf);
+  Eigen::VectorXd upper_bound =
+      Eigen::VectorXd::Constant(prog.num_vars(), kInf);
+  for (const auto& bounding_box : prog.bounding_box_constraints()) {
+    for (int i = 0; i < bounding_box.variables().rows(); ++i) {
+      const int variable_index =
+          prog.FindDecisionVariableIndex(bounding_box.variables()(i));
+      lower_bound(variable_index) =
+          std::max(lower_bound(variable_index),
+                   bounding_box.evaluator()->lower_bound()(i));
+      upper_bound(variable_index) =
+          std::min(upper_bound(variable_index),
+                   bounding_box.evaluator()->upper_bound()(i));
+    }
+  }
+
+  // Now go through each of the decision variables in prog.
+
+  const int block_index = static_cast<int>(X_blocks_.size());
+  int new_X_var_count = 0;
+  for (int i = 0; i < prog.num_vars(); ++i) {
+    // The variable might have been registered when we go through the positive
+    // semidefinite constraint.
+    bool has_var_registered =
+        !holds_alternative<std::nullptr_t>(prog_var_in_sdpa_[i]);
+    // First check if this variable has either finite lower or upper bound. If
+    // not, then the variable is a free variable in SDPA.
+    if (!has_var_registered) {
+      if (std::isinf(lower_bound(i)) && std::isinf(upper_bound(i))) {
+        // This is a free variable.
+        prog_var_in_sdpa_[i].emplace<FreeVariableIndex>(num_free_variables_);
+        num_free_variables_++;
+      } else {
+        if (!std::isinf(lower_bound(i)) && std::isinf(upper_bound(i))) {
+          // lower <= x.
+          prog_var_in_sdpa_[i].emplace<DecisionVariableInSdpaX>(
+              Sign::kPositive, lower_bound(i), block_index, new_X_var_count,
+              new_X_var_count, num_X_rows_);
+          new_X_var_count++;
+        } else if (std::isinf(lower_bound(i)) && !std::isinf(upper_bound(i))) {
+          // x <= upper.
+          prog_var_in_sdpa_[i].emplace<DecisionVariableInSdpaX>(
+              Sign::kNegative, upper_bound(i), block_index, new_X_var_count,
+              new_X_var_count, num_X_rows_);
+          new_X_var_count++;
+        } else if (lower_bound(i) == upper_bound(i)) {
+          // x == bound
+          prog_var_in_sdpa_[i].emplace<double>(lower_bound(i));
+        } else {
+          // lower <= x <= upper
+          // x will be replaced as y + lower, where y is an entry in X.
+          prog_var_in_sdpa_[i].emplace<DecisionVariableInSdpaX>(
+              Sign::kPositive, lower_bound(i), block_index, new_X_var_count,
+              new_X_var_count, num_X_rows_);
+          // Add another slack variables z, with the constraint x + z = upper
+          AddLinearEqualityConstraint(
+              {1}, {i}, {1.0},
+              {EntryInX(block_index, new_X_var_count + 1, new_X_var_count + 1,
+                        num_X_rows_)},
+              {}, {}, upper_bound(i));
+          new_X_var_count += 2;
+        }
+      }
+    } else {
+      // This variable has been registered as a variable in SDPA. It should have
+      // been registered as an entry in X.
+      if (holds_alternative<DecisionVariableInSdpaX>(prog_var_in_sdpa_[i])) {
+        if (std::isinf(lower_bound(i)) && std::isinf(upper_bound(i))) {
+          // no finite bounds.
+          continue;
+        } else if (!std::isinf(lower_bound(i)) && std::isinf(upper_bound(i))) {
+          // lower <= x
+          // Adds a slack variable y as a diagonal entry in X, with the
+          // constraint x - y = lower
+          AddLinearEqualityConstraint({1}, {i}, {-1.0},
+                                      {EntryInX(block_index, new_X_var_count,
+                                                new_X_var_count, num_X_rows_)},
+                                      {}, {}, lower_bound(i));
+          new_X_var_count++;
+        } else if (std::isinf(lower_bound(i)) && !std::isinf(upper_bound(i))) {
+          // x <= upper
+          // Adds a slack variable y as a diagonal entry in X, with the
+          // constraint x + y = upper
+          AddLinearEqualityConstraint({1.0}, {i}, {1.0},
+                                      {EntryInX(block_index, new_X_var_count,
+                                                new_X_var_count, num_X_rows_)},
+                                      {}, {}, upper_bound(i));
+          new_X_var_count++;
+        } else if (lower_bound(i) == upper_bound(i)) {
+          // Add the constraint x == bound.
+          AddLinearEqualityConstraint({1.0}, {i}, {}, {}, {}, {},
+                                      lower_bound(i));
+        } else {
+          // lower <= x <= upper
+          // Adds two slack variables y1, y2 in X, with the linear equality
+          // constraint x - y1 = lower and x + y2 <= upper
+          AddLinearEqualityConstraint({1.0}, {i}, {-1.0},
+                                      {EntryInX(block_index, new_X_var_count,
+                                                new_X_var_count, num_X_rows_)},
+                                      {}, {}, lower_bound(i));
+          AddLinearEqualityConstraint(
+              {1.0}, {i}, {1.0},
+              {EntryInX(block_index, new_X_var_count + 1, new_X_var_count + 1,
+                        num_X_rows_)},
+              {}, {}, upper_bound(i));
+          new_X_var_count += 2;
+        }
+      } else {
+        throw std::runtime_error(
+            "SdpaFreeFormat::RegisterMathematicalProgramDecisionVariable(): "
+            "the registed variable should be an entry in X");
+      }
+    }
+  }
+  if (new_X_var_count > 0) {
+    X_blocks_.emplace_back(BlockType::kDiagonal, new_X_var_count);
+    num_X_rows_ += new_X_var_count;
+  }
+}
+
+void SdpaFreeFormat::AddLinearCosts(const MathematicalProgram& prog) {
+  for (const auto& linear_cost : prog.linear_costs()) {
+    for (int i = 0; i < linear_cost.variables().rows(); ++i) {
+      // The negation sign is because in CSDP format, the objective is to
+      // maximize the cost, while in MathematicalProgram, the objective is to
+      // minimize the cost.
+      double coeff = -linear_cost.evaluator()->a()(i);
+      if (coeff != 0) {
+        // Only adds the cost if the cost coefficient is non-zero.
+        const int var_index =
+            prog.FindDecisionVariableIndex(linear_cost.variables()(i));
+        if (holds_alternative<DecisionVariableInSdpaX>(
+                prog_var_in_sdpa_[var_index])) {
+          const auto& decision_var_in_X =
+              get<DecisionVariableInSdpaX>(prog_var_in_sdpa_[var_index]);
+          coeff =
+              decision_var_in_X.coeff_sign == Sign::kPositive ? coeff : -coeff;
+          constant_min_cost_term_ +=
+              linear_cost.evaluator()->a()(i) * decision_var_in_X.offset;
+          AddTermToTriplets(decision_var_in_X.entry_in_X, coeff, &C_triplets_);
+        } else if (holds_alternative<double>(prog_var_in_sdpa_[var_index])) {
+          const double val = get<double>(prog_var_in_sdpa_[var_index]);
+          constant_min_cost_term_ += linear_cost.evaluator()->a()(i) * val;
+        } else if (holds_alternative<FreeVariableIndex>(
+                       prog_var_in_sdpa_[var_index])) {
+          const FreeVariableIndex& s_index =
+              get<FreeVariableIndex>(prog_var_in_sdpa_[var_index]);
+          d_triplets_.emplace_back(s_index, 0, coeff);
+        } else {
+          throw std::runtime_error(
+              "SdpaFreeFormat::AddLinearCost() only supports "
+              "DecisionVariableInSdpaX, double or FreeVariableIndex.");
+        }
+      }
+    }
+    constant_min_cost_term_ += linear_cost.evaluator()->b();
+  }
+}
+
+template <typename Constraint>
+void SdpaFreeFormat::AddLinearConstraintsHelper(
+    const MathematicalProgram& prog,
+    const Binding<Constraint>& linear_constraint, bool is_equality_constraint,
+    int* linear_constraint_slack_entry_in_X_count) {
+  const std::vector<int> var_indices =
+      prog.FindDecisionVariableIndices(linear_constraint.variables());
+  // Go through each row of the constraint.
+  for (int i = 0; i < linear_constraint.evaluator()->num_constraints(); ++i) {
+    const bool does_lower_equal_upper_in_this_row =
+        is_equality_constraint ||
+        linear_constraint.evaluator()->lower_bound()(i) ==
+            linear_constraint.evaluator()->upper_bound()(i);
+    std::vector<double> a, b;
+    // If this row's lower and upper bound are the same, then we only need to
+    // append one row to SDPA format, namely tr(Ai * X) + bi' * s = rhs,
+    // Otherwise, we need to append two rows to SDPA format
+    // tr(Ai_lower * X_lower) + bi' * s = lower_bound
+    // tr(Ai_upper * X_upper) + bi' * s = upper_bound
+    // and append two diagonal entries into X as slack variables.
+    a.reserve(var_indices.size());
+    b.reserve(1);
+    std::vector<int> decision_var_indices_in_X;
+    decision_var_indices_in_X.reserve(var_indices.size());
+    std::vector<EntryInX> X_entries;
+    X_entries.reserve(1);
+    std::vector<int> s_indices;
+    for (int j = 0; j < linear_constraint.variables().rows(); ++j) {
+      if (linear_constraint.evaluator()->A()(i, j) != 0) {
+        a.push_back(linear_constraint.evaluator()->A()(i, j));
+        decision_var_indices_in_X.push_back(var_indices[j]);
+      }
+    }
+    if (does_lower_equal_upper_in_this_row) {
+      // Add the equality constraint.
+      AddLinearEqualityConstraint(
+          a, decision_var_indices_in_X, {}, {}, {}, {},
+          linear_constraint.evaluator()->lower_bound()(i));
+    } else {
+      // First add the constraint and slack variable for the lower bound.
+      if (!std::isinf(linear_constraint.evaluator()->lower_bound()(i))) {
+        AddLinearEqualityConstraint(
+            a, decision_var_indices_in_X, {-1},
+            {EntryInX(static_cast<int>(X_blocks_.size()),
+                      *linear_constraint_slack_entry_in_X_count,
+                      *linear_constraint_slack_entry_in_X_count, num_X_rows_)},
+            {}, {}, linear_constraint.evaluator()->lower_bound()(i));
+        (*linear_constraint_slack_entry_in_X_count)++;
+      }
+      // Now add the constraint and slack variable for the upper bound.
+      if (!std::isinf(linear_constraint.evaluator()->upper_bound()(i))) {
+        AddLinearEqualityConstraint(
+            a, decision_var_indices_in_X, {1},
+            {EntryInX(static_cast<int>(X_blocks_.size()),
+                      *linear_constraint_slack_entry_in_X_count,
+                      *linear_constraint_slack_entry_in_X_count, num_X_rows_)},
+            {}, {}, linear_constraint.evaluator()->upper_bound()(i));
+        (*linear_constraint_slack_entry_in_X_count)++;
+      }
+    }
+  }
+}
+
+void SdpaFreeFormat::AddLinearConstraints(const MathematicalProgram& prog) {
+  int linear_constraint_slack_entry_in_X_count = 0;
+  for (const auto& linear_eq_constraint : prog.linear_equality_constraints()) {
+    AddLinearConstraintsHelper(prog, linear_eq_constraint, true,
+                               &linear_constraint_slack_entry_in_X_count);
+  }
+  for (const auto& linear_constraint : prog.linear_constraints()) {
+    AddLinearConstraintsHelper(prog, linear_constraint, false,
+                               &linear_constraint_slack_entry_in_X_count);
+  }
+  if (linear_constraint_slack_entry_in_X_count > 0) {
+    num_X_rows_ += linear_constraint_slack_entry_in_X_count;
+    X_blocks_.emplace_back(BlockType::kDiagonal,
+                           linear_constraint_slack_entry_in_X_count);
+  }
+}
+
+void SdpaFreeFormat::AddLinearMatrixInequalityConstraints(
+    const MathematicalProgram& prog) {
+  for (const auto& lmi_constraint :
+       prog.linear_matrix_inequality_constraints()) {
+    const std::vector<int> var_indices =
+        prog.FindDecisionVariableIndices(lmi_constraint.variables());
+    // Add the constraint that F1 * x1 + ... + Fn * xn - X_slack = -F0 and
+    // X_slack is psd.
+    const std::vector<Eigen::MatrixXd>& F = lmi_constraint.evaluator()->F();
+    for (int j = 0; j < lmi_constraint.evaluator()->matrix_rows(); ++j) {
+      for (int i = 0; i <= j; ++i) {
+        std::vector<double> a;
+        a.reserve(static_cast<int>(F.size()) - 1);
+        for (int k = 1; k < static_cast<int>(F.size()); ++k) {
+          a.push_back(F[k](i, j));
+        }
+        AddLinearEqualityConstraint(
+            a, var_indices, {-1},
+            {EntryInX(static_cast<int>(X_blocks_.size()), i, j, num_X_rows_)},
+            {}, {}, -F[0](i, j));
+      }
+    }
+
+    X_blocks_.emplace_back(BlockType::kMatrix,
+                           lmi_constraint.evaluator()->matrix_rows());
+    num_X_rows_ += lmi_constraint.evaluator()->matrix_rows();
+  }
+}
+
+void SdpaFreeFormat::Finalize() {
+  A_.reserve(A_triplets_.size());
+  for (int i = 0; i < static_cast<int>(A_triplets_.size()); ++i) {
+    A_.emplace_back(num_X_rows_, num_X_rows_);
+    A_.back().setFromTriplets(A_triplets_[i].begin(), A_triplets_[i].end());
+  }
+  B_.resize(static_cast<int>(A_triplets_.size()), num_free_variables_);
+  B_.setFromTriplets(B_triplets_.begin(), B_triplets_.end());
+  C_.resize(num_X_rows_, num_X_rows_);
+  C_.setFromTriplets(C_triplets_.begin(), C_triplets_.end());
+  d_.resize(num_free_variables_, 1);
+  d_.setFromTriplets(d_triplets_.begin(), d_triplets_.end());
+}
+
+SdpaFreeFormat::SdpaFreeFormat(const MathematicalProgram& prog) {
+  prog_var_in_sdpa_.reserve(prog.num_vars());
+  for (int i = 0; i < prog.num_vars(); ++i) {
+    prog_var_in_sdpa_.emplace_back(nullptr);
+  }
+  std::unordered_map<symbolic::Variable::Id, std::vector<EntryInX>>
+      entries_in_X_for_same_decision_variable;
+  DeclareXforPositiveSemidefiniteConstraints(
+      prog, &entries_in_X_for_same_decision_variable);
+
+  AddEqualityConstraintOnXentriesForSameDecisionVariable(
+      entries_in_X_for_same_decision_variable);
+
+  RegisterMathematicalProgramDecisionVariable(prog);
+
+  AddLinearCosts(prog);
+
+  AddLinearConstraints(prog);
+
+  AddLinearMatrixInequalityConstraints(prog);
+
+  Finalize();
+}
+}  // namespace internal
+}  // namespace solvers
+}  // namespace drake

--- a/solvers/sdpa_free_format.cc
+++ b/solvers/sdpa_free_format.cc
@@ -1,8 +1,6 @@
 #include "drake/solvers/sdpa_free_format.h"
 
 #include <algorithm>
-#include <fstream>
-#include <iomanip>
 #include <limits>
 #include <stdexcept>
 #include <unordered_map>

--- a/solvers/sdpa_free_format.h
+++ b/solvers/sdpa_free_format.h
@@ -1,0 +1,261 @@
+#pragma once
+
+#include <unordered_map>
+#include <vector>
+
+#include <Eigen/Core>
+#include <Eigen/Sparse>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/drake_variant.h"
+#include "drake/common/type_safe_index.h"
+#include "drake/solvers/mathematical_program.h"
+
+namespace drake {
+namespace solvers {
+namespace internal {
+/**
+ * X is a block diagonal matrix in SDPA format. EntryInX stores the information
+ * of one entry in this block-diagonal matrix X.
+ */
+struct EntryInX {
+  EntryInX(int block_index_in, int row_index_in_block_in,
+           int column_index_in_block_in, int X_start_row_in)
+      : block_index{block_index_in},
+        row_index_in_block(row_index_in_block_in),
+        column_index_in_block(column_index_in_block_in),
+        X_start_row(X_start_row_in) {}
+
+  // block_index is 0-indexed.
+  int block_index;
+  // The row and column indices of the entry in this block. Both row/column
+  // indices are 0-indexed.
+  int row_index_in_block;
+  int column_index_in_block;
+  // The starting row index of this block in X. This is 0-indexed.
+  int X_start_row;
+};
+
+enum class BlockType {
+  kMatrix,
+  kDiagonal,
+};
+
+struct BlockInX {
+  BlockInX(BlockType blocktype_in, int num_rows_in)
+      : blocktype{blocktype_in}, num_rows{num_rows_in} {}
+  BlockType blocktype;
+  int num_rows;
+};
+
+/**
+ * @anchor map_decision_variable_to_sdpa
+ * Each of the variable x in MathematicalProgram might be mapped to a variable
+ * in the SDPA free format, depending on the following conditions.
+ * 1. If the variable x has no lower nor upper bound, it is mapped to a free
+ *    variable in SDPA free format.
+ * 2. If the variable x only has a finite lower bound, and an infinite upper
+ *    bound, then we will replace x by lower + y, where y is a diagonal entry
+ *    in X in SDPA free format.
+ * 3. If the variable x only has a finite upper bound, and an infinite lower
+ *    bound, then we will replace x by upper - y, where y is a diagonal entry
+ *    in X in SDPA free format.
+ * 4. If the variable x has both finite upper and lower bounds, and these bounds
+ *    are not equal, then we replace x by lower + y1, and introduce another
+ *    constraint y1 + y2 = upper - lower, where both y1 and y2 are diagonal
+ *    entries in X in SDPA free format.
+ * 5. If the variable x has equal lower and upper bound, then we replace x with
+ *    the double value of lower bound.
+ */
+//@{
+/**
+ * Refer to @ref map_decision_variable_to_sdpa
+ * When the decision variable either (or both) finite lower or upper bound (with
+ * the two bounds not equal), we need to record the sign of the coefficient
+ * before y.
+ */
+enum class Sign {
+  kPositive,
+  kNegative,
+};
+
+/**
+ * Refer to @ref map_decision_variable_to_sdpa
+ * A MathematicalProgram decision variable can be replaced by coeff_sign * y +
+ * offset, where y is a diagonal entry in SDPA X matrix. (See case 2, 3, 4 in
+ * @ref map_decision_variable_to_sdpa).
+ */
+struct DecisionVariableInSdpaX {
+  DecisionVariableInSdpaX(Sign coeff_sign_m, double offset_m,
+                          EntryInX entry_in_X_m)
+      : coeff_sign{coeff_sign_m}, offset{offset_m}, entry_in_X{entry_in_X_m} {}
+
+  DecisionVariableInSdpaX(Sign coeff_sign_m, double offset_m, int block_index,
+                          int row_index_in_block, int col_index_in_block,
+                          int block_start_row)
+      : coeff_sign(coeff_sign_m),
+        offset(offset_m),
+        entry_in_X(block_index, row_index_in_block, col_index_in_block,
+                   block_start_row) {}
+  Sign coeff_sign;
+  double offset;
+  EntryInX entry_in_X;
+};
+//@}
+
+/**
+ * SDPA format with free variables.
+ * max tr(C * X) + dᵀs
+ * s.t tr(Aᵢ*X) + bᵢᵀs = gᵢ
+ *     X ≽ 0
+ *     s is free.
+ */
+class SdpaFreeFormat {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SdpaFreeFormat)
+
+  explicit SdpaFreeFormat(const MathematicalProgram& prog);
+
+  ~SdpaFreeFormat();
+
+  const std::vector<BlockInX>& X_blocks() const { return X_blocks_; }
+
+  using FreeVariableIndex = TypeSafeIndex<class FreeVariableTag>;
+
+  const std::vector<variant<DecisionVariableInSdpaX, FreeVariableIndex, double,
+                            std::nullptr_t>>&
+  prog_var_in_sdpa() const {
+    return prog_var_in_sdpa_;
+  }
+
+  const std::vector<std::vector<Eigen::Triplet<double>>>& A_triplets() const {
+    return A_triplets_;
+  }
+
+  const std::vector<Eigen::Triplet<double>>& B_triplets() const {
+    return B_triplets_;
+  }
+
+  const Eigen::VectorXd& g() const { return g_; }
+
+  int num_X_rows() const { return num_X_rows_; }
+
+  int num_free_variables() const { return num_free_variables_; }
+
+  const std::vector<Eigen::Triplet<double>>& C_triplets() const {
+    return C_triplets_;
+  }
+
+  const std::vector<Eigen::Triplet<double>>& d_triplets() const {
+    return d_triplets_;
+  }
+
+  const std::vector<Eigen::SparseMatrix<double>>& A() const { return A_; }
+
+  const Eigen::SparseMatrix<double>& B() const { return B_; }
+
+  const Eigen::SparseMatrix<double>& C() const { return C_; }
+
+  const Eigen::SparseMatrix<double>& d() const { return d_; }
+
+  double constant_min_cost_term() const { return constant_min_cost_term_; }
+
+ private:
+  // Go through all the positive semidefinite constraint in @p prog, and
+  // register the corresponding blocks in matrix X for the bound variables of
+  // each PositiveSemidefiniteConstraint. It is possible for two
+  // PositiveSemidefiniteConstraint bindings to have overlapping decision
+  // variables, or for a single PositiveSemidefiniteConstraint to have duplicate
+  // decision variables. We need to impose equality constraints on these entries
+  // in X. We use entries_in_X_for_same_decision_variable to record these
+  // entries in X, so that we can impose the equality constraints later.
+  void DeclareXforPositiveSemidefiniteConstraints(
+      const MathematicalProgram& prog,
+      std::unordered_map<symbolic::Variable::Id, std::vector<EntryInX>>*
+          entries_in_X_for_same_decision_variable);
+
+  // Some entries in X correspond to the same decision variables. We need to add
+  // the equality constraint on these entries.
+  void AddEqualityConstraintOnXentriesForSameDecisionVariable(
+      const std::unordered_map<symbolic::Variable::Id, std::vector<EntryInX>>&
+          entries_in_X_for_same_decision_variable);
+
+  /**
+   * Adds a linear equality constraint
+   * @param a The coefficients for program decision variables that appear in X.
+   * @param prog_vars_indices  The vectors of the MathematicalProgram decision
+   * variables indices in X that show up in this constraint.
+   * @param b The coefficients for X entries.
+   * @param X_entries The entries in X that show up in the linear equality
+   * constraint, X_entries and prog_vars_inindices should not overlap.
+   * @param c The coefficients of free variables.
+   * @param s_indices The indices of the free variables show up in this
+   * constraint, these free variables are not the decision variables in the
+   * MathematicalProgram.
+   * @param rhs The right-hand side of the linear equality constraint.
+   */
+  void AddLinearEqualityConstraint(
+      const std::vector<double>& a, const std::vector<int>& prog_vars_indices,
+      const std::vector<double>& b, const std::vector<EntryInX>& X_entries,
+      const std::vector<double>& c,
+      const std::vector<FreeVariableIndex>& s_indices, double rhs);
+
+  void RegisterMathematicalProgramDecisionVariable(
+      const MathematicalProgram& prog);
+
+  /** Sum up all the linear costs in prog, store the result in SDPA free format.
+   */
+  void AddLinearCosts(const MathematicalProgram& prog);
+
+  /** Add both the linear constraints lower <= a'x <= upper and the linear
+   * equality constraints a'x = rhs to SDPA free format. */
+  void AddLinearConstraints(const MathematicalProgram& prog);
+
+  template <typename Constraint>
+  void AddLinearConstraintsHelper(
+      const MathematicalProgram& prog,
+      const Binding<Constraint>& linear_constraint, bool is_equality_constraint,
+      int* linear_constraint_slack_entry_in_X_count);
+
+  void AddLinearMatrixInequalityConstraints(const MathematicalProgram& prog);
+
+  void Finalize();
+
+  // X_blocks_ just stores the size and category of each block in the
+  // block-diagonal matrix X.
+  std::vector<BlockInX> X_blocks_;
+
+  std::vector<Eigen::Triplet<double>> C_triplets_;
+  std::vector<Eigen::Triplet<double>> d_triplets_;
+  // gᵢ is the i-th entry of g.
+  Eigen::VectorXd g_;
+  // A_triplets_[i] is the nonzero entries in Aᵢ
+  std::vector<std::vector<Eigen::Triplet<double>>> A_triplets_;
+  // bᵢ is the i-th column of B. B_triplets records the nonzero entries in B.
+  std::vector<Eigen::Triplet<double>> B_triplets_;
+
+  /**
+   * Depending on the bounds and whether the variable appears in a PSD cone, a
+   * MathematicalProgram decision variable can be either an entry in X, a free
+   * variable, or a double constant in SDPA free format.
+   * We use std::nullptr_t to indicate that this variable hasn't been registered
+   * into SDPA free format yet.
+   */
+  std::vector<variant<DecisionVariableInSdpaX, FreeVariableIndex, double,
+                      std::nullptr_t>>
+      prog_var_in_sdpa_;
+
+  int num_X_rows_{0};
+  int num_free_variables_{0};
+  // The SDPA format doesn't include the constant term in the cost, but
+  // MathematicalProgram does. We store the constant cost term here.
+  double constant_min_cost_term_{0.0};
+
+  std::vector<Eigen::SparseMatrix<double>> A_;
+  Eigen::SparseMatrix<double> C_;
+  Eigen::SparseMatrix<double> B_;
+  Eigen::SparseMatrix<double> d_;
+};
+}  // namespace internal
+}  // namespace solvers
+}  // namespace drake

--- a/solvers/sdpa_free_format.h
+++ b/solvers/sdpa_free_format.h
@@ -42,9 +42,9 @@ enum class BlockType {
 };
 
 struct BlockInX {
-  BlockInX(BlockType blocktype_in, int num_rows_in)
-      : blocktype{blocktype_in}, num_rows{num_rows_in} {}
-  BlockType blocktype;
+  BlockInX(BlockType block_type_in, int num_rows_in)
+      : block_type{block_type_in}, num_rows{num_rows_in} {}
+  BlockType block_type;
   int num_rows;
 };
 
@@ -80,7 +80,7 @@ enum class Sign {
 };
 
 /**
- * Refer to @ref map_decision_variable_to_sdpa
+ * Refer to @ref map_decision_variable_to_sdpa.
  * A MathematicalProgram decision variable can be replaced by coeff_sign * y +
  * offset, where y is a diagonal entry in SDPA X matrix. (See case 2, 3, 4 in
  * @ref map_decision_variable_to_sdpa).
@@ -180,20 +180,18 @@ class SdpaFreeFormat {
       const std::unordered_map<symbolic::Variable::Id, std::vector<EntryInX>>&
           entries_in_X_for_same_decision_variable);
 
-  /**
-   * Adds a linear equality constraint
-   * @param a The coefficients for program decision variables that appear in X.
-   * @param prog_vars_indices  The vectors of the MathematicalProgram decision
-   * variables indices in X that show up in this constraint.
-   * @param b The coefficients for X entries.
-   * @param X_entries The entries in X that show up in the linear equality
-   * constraint, X_entries and prog_vars_inindices should not overlap.
-   * @param c The coefficients of free variables.
-   * @param s_indices The indices of the free variables show up in this
-   * constraint, these free variables are not the decision variables in the
-   * MathematicalProgram.
-   * @param rhs The right-hand side of the linear equality constraint.
-   */
+  // Adds a linear equality constraint.
+  // @param a The coefficients for program decision variables that appear in X.
+  // @param prog_vars_indices  The vectors of the MathematicalProgram decision
+  // variables indices in X that show up in this constraint.
+  // @param b The coefficients for @p X_entries.
+  // @param X_entries The entries in X that show up in the linear equality
+  // constraint, X_entries and prog_vars_indices should not overlap.
+  // @param c The coefficients of free variables.
+  // @param s_indices The indices of the free variables show up in this
+  // constraint, these free variables are not the decision variables in the
+  // MathematicalProgram.
+  // @param rhs The right-hand side of the linear equality constraint.
   void AddLinearEqualityConstraint(
       const std::vector<double>& a, const std::vector<int>& prog_vars_indices,
       const std::vector<double>& b, const std::vector<EntryInX>& X_entries,
@@ -203,13 +201,12 @@ class SdpaFreeFormat {
   void RegisterMathematicalProgramDecisionVariable(
       const MathematicalProgram& prog);
 
-  /** Sum up all the linear costs in prog, store the result in SDPA free format.
-   */
-  void AddLinearCosts(const MathematicalProgram& prog);
+  // Sum up all the linear costs in prog, store the result in SDPA free format.
+  void AddLinearCostsFromProgram(const MathematicalProgram& prog);
 
-  /** Add both the linear constraints lower <= a'x <= upper and the linear
-   * equality constraints a'x = rhs to SDPA free format. */
-  void AddLinearConstraints(const MathematicalProgram& prog);
+  // Add both the linear constraints lower <= a'x <= upper and the linear
+  // equality constraints a'x = rhs to SDPA free format. */
+  void AddLinearConstraintsFromProgram(const MathematicalProgram& prog);
 
   template <typename Constraint>
   void AddLinearConstraintsHelper(
@@ -219,6 +216,7 @@ class SdpaFreeFormat {
 
   void AddLinearMatrixInequalityConstraints(const MathematicalProgram& prog);
 
+  // Called at the end of the constructor.
   void Finalize();
 
   // X_blocks_ just stores the size and category of each block in the
@@ -229,7 +227,7 @@ class SdpaFreeFormat {
   std::vector<Eigen::Triplet<double>> d_triplets_;
   // gᵢ is the i-th entry of g.
   Eigen::VectorXd g_;
-  // A_triplets_[i] is the nonzero entries in Aᵢ
+  // A_triplets_[i] describes the nonzero entries in Aᵢ
   std::vector<std::vector<Eigen::Triplet<double>>> A_triplets_;
   // bᵢ is the i-th column of B. B_triplets records the nonzero entries in B.
   std::vector<Eigen::Triplet<double>> B_triplets_;

--- a/solvers/test/csdp_test_examples.cc
+++ b/solvers/test/csdp_test_examples.cc
@@ -34,7 +34,7 @@ CsdpDocExample::CsdpDocExample()
       3 * X2_(0, 0) + 4 * X2_(1, 1) + 2 * X2_(0, 2) + 5 * X2_(2, 2) + y_(1), 2);
 }
 
-LinearProgram1::LinearProgram1()
+LinearProgramBoundingBox1::LinearProgramBoundingBox1()
     : prog_{new MathematicalProgram()}, x_{prog_->NewContinuousVariables<8>()} {
   Eigen::Matrix<double, 8, 1> lower, upper;
   lower << 0, 0, -1, -kInf, -2, 0, 1, -kInf;
@@ -43,7 +43,7 @@ LinearProgram1::LinearProgram1()
   prog_->AddLinearCost(-(-x_(0) + x_(1) - 2 * x_(2) + 3 * x_(3) + x_(4) + 1));
 }
 
-LinearProgram2::LinearProgram2()
+CsdpLinearProgram2::CsdpLinearProgram2()
     : prog_{new MathematicalProgram()}, x_{prog_->NewContinuousVariables<3>()} {
   prog_->AddLinearEqualityConstraint(2 * x_(0) + 3 * x_(1) + x_(2), 1);
   Eigen::Matrix<double, 4, 3> A;
@@ -59,7 +59,7 @@ LinearProgram2::LinearProgram2()
   prog_->AddLinearCost(x_(0) + 2 * x_(1) + 3 * x_(2));
 }
 
-LinearProgram3::LinearProgram3()
+CsdpLinearProgram3::CsdpLinearProgram3()
     : prog_{new MathematicalProgram()}, x_{prog_->NewContinuousVariables<3>()} {
   prog_->AddBoundingBoxConstraint(Eigen::Vector2d(-1, -kInf),
                                   Eigen::Vector2d(10, 8), x_.head<2>());

--- a/solvers/test/csdp_test_examples.cc
+++ b/solvers/test/csdp_test_examples.cc
@@ -1,0 +1,105 @@
+#include "drake/solvers/test/csdp_test_examples.h"
+
+#include <limits>
+#include <vector>
+
+namespace drake {
+namespace solvers {
+const double kInf = std::numeric_limits<double>::infinity();
+SDPwithOverlappingVariables::SDPwithOverlappingVariables()
+    : prog_{new MathematicalProgram()}, x_{prog_->NewContinuousVariables<3>()} {
+  prog_->AddLinearCost(2 * x_(0) + x_(2));
+  prog_->AddBoundingBoxConstraint(1, 1, x_(1));
+  prog_->AddPositiveSemidefiniteConstraint(
+      (Matrix2<symbolic::Variable>() << x_(0), x_(1), x_(1), x_(0)).finished());
+  prog_->AddPositiveSemidefiniteConstraint(
+      (Matrix2<symbolic::Variable>() << x_(0), x_(2), x_(2), x_(0)).finished());
+}
+
+CsdpDocExample::CsdpDocExample()
+    : prog_{new MathematicalProgram()},
+      X1_{prog_->NewSymmetricContinuousVariables<2>()},
+      X2_{prog_->NewSymmetricContinuousVariables<3>()},
+      y_{prog_->NewContinuousVariables<2>()} {
+  prog_->AddPositiveSemidefiniteConstraint(X1_);
+  prog_->AddPositiveSemidefiniteConstraint(X2_);
+  prog_->AddBoundingBoxConstraint(Eigen::Vector2d(0, 0),
+                                  Eigen::Vector2d(kInf, kInf), y_);
+  prog_->AddLinearCost(-(2 * X1_(0, 0) + 2 * X1_(0, 1) + 2 * X1_(1, 1) +
+                         3 * X2_(0, 0) + 2 * X2_(1, 1) + 2 * X2_(0, 2) +
+                         3 * X2_(2, 2)));
+  prog_->AddLinearEqualityConstraint(
+      3 * X1_(0, 0) + 2 * X1_(0, 1) + 3 * X1_(1, 1) + y_(0), 1);
+  prog_->AddLinearEqualityConstraint(
+      3 * X2_(0, 0) + 4 * X2_(1, 1) + 2 * X2_(0, 2) + 5 * X2_(2, 2) + y_(1), 2);
+}
+
+LinearProgram1::LinearProgram1()
+    : prog_{new MathematicalProgram()}, x_{prog_->NewContinuousVariables<8>()} {
+  Eigen::Matrix<double, 8, 1> lower, upper;
+  lower << 0, 0, -1, -kInf, -2, 0, 1, -kInf;
+  upper << kInf, 5, kInf, 10, 5, 0, 1, kInf;
+  prog_->AddBoundingBoxConstraint(lower, upper, x_);
+  prog_->AddLinearCost(-(-x_(0) + x_(1) - 2 * x_(2) + 3 * x_(3) + x_(4) + 1));
+}
+
+LinearProgram2::LinearProgram2()
+    : prog_{new MathematicalProgram()}, x_{prog_->NewContinuousVariables<3>()} {
+  prog_->AddLinearEqualityConstraint(2 * x_(0) + 3 * x_(1) + x_(2), 1);
+  Eigen::Matrix<double, 4, 3> A;
+  // clang-format off
+    A << 1, 0, -2,
+         1, 2, 0,
+         -1, 0, 3,
+         1, 1, 4;
+  // clang-format on
+  Eigen::Vector4d lower(-kInf, -2, -2, 3);
+  Eigen::Vector4d upper(-1, kInf, 3, 3);
+  prog_->AddLinearConstraint(A, lower, upper, x_);
+  prog_->AddLinearCost(x_(0) + 2 * x_(1) + 3 * x_(2));
+}
+
+LinearProgram3::LinearProgram3()
+    : prog_{new MathematicalProgram()}, x_{prog_->NewContinuousVariables<3>()} {
+  prog_->AddBoundingBoxConstraint(Eigen::Vector2d(-1, -kInf),
+                                  Eigen::Vector2d(10, 8), x_.head<2>());
+  Eigen::Matrix<double, 4, 3> A;
+  // clang-format off
+  A << 1, 2, 3,
+       2, 0, -1,
+       0, 1, -3,
+       1, 0, 1;
+  // clang-format on
+  prog_->AddLinearConstraint(A, Eigen::Vector4d(3, -1, -kInf, -4),
+                             Eigen::Vector4d(3, kInf, 5, 9), x_);
+  prog_->AddLinearCost(-(2 * x_(0) + 3 * x_(1) + 4 * x_(2) + 3));
+}
+
+TrivialSDP1::TrivialSDP1()
+    : prog_{new MathematicalProgram()},
+      X1_{prog_->NewSymmetricContinuousVariables<3>()} {
+  prog_->AddPositiveSemidefiniteConstraint(X1_);
+  prog_->AddLinearEqualityConstraint(X1_(0, 0) + X1_(1, 1) + X1_(2, 2), 1);
+  prog_->AddLinearConstraint(X1_(0, 1) + X1_(1, 2) - 2 * X1_(0, 2), -kInf, 0);
+  prog_->AddLinearCost(-(X1_(0, 1) + X1_(1, 2)));
+}
+
+TrivialSDP2::TrivialSDP2()
+    : prog_{new MathematicalProgram()},
+      X1_{prog_->NewSymmetricContinuousVariables<2>()},
+      y_{prog_->NewContinuousVariables<1>()(0)} {
+  prog_->AddPositiveSemidefiniteConstraint(X1_);
+  Eigen::Matrix2d F0 = Eigen::Matrix2d::Identity();
+  Eigen::Matrix2d F1;
+  F1 << 1, 2, 2, 3;
+  Eigen::Matrix2d F2;
+  F2 << 2, 0, 0, 4;
+  prog_->AddConstraint(
+      std::make_shared<LinearMatrixInequalityConstraint>(
+          std::vector<Eigen::Ref<const Eigen::MatrixXd>>{F0, F1, F2}),
+      Vector2<symbolic::Variable>(y_, X1_(0, 0)));
+  prog_->AddLinearEqualityConstraint(X1_(0, 0) + 2 * X1_(1, 1) + 3 * y_, 1);
+  prog_->AddLinearCost(-y_);
+}
+}  // namespace solvers
+}  // namespace drake

--- a/solvers/test/csdp_test_examples.h
+++ b/solvers/test/csdp_test_examples.h
@@ -68,9 +68,9 @@ class CsdpDocExample : public ::testing::Test {
  *  1 <= x(6) <= 1
  * -inf<=x(7) <= inf
  */
-class LinearProgram1 : public ::testing::Test {
+class LinearProgramBoundingBox1 : public ::testing::Test {
  public:
-  LinearProgram1();
+  LinearProgramBoundingBox1();
 
  protected:
   std::unique_ptr<MathematicalProgram> prog_;
@@ -88,9 +88,9 @@ class LinearProgram1 : public ::testing::Test {
  * The optimal solution is x = (5 / 13, -2 / 13, 9 / 13). The optimal cost is
  * (28 / 13).
  */
-class LinearProgram2 : public ::testing::Test {
+class CsdpLinearProgram2 : public ::testing::Test {
  public:
-  LinearProgram2();
+  CsdpLinearProgram2();
 
  protected:
   std::unique_ptr<MathematicalProgram> prog_;
@@ -109,9 +109,9 @@ class LinearProgram2 : public ::testing::Test {
  *     x(1) <= 8
  * The optimal solution is (10, -2/3, -17/9), the optimal cost is 121 / 9
  */
-class LinearProgram3 : public ::testing::Test {
+class CsdpLinearProgram3 : public ::testing::Test {
  public:
-  LinearProgram3();
+  CsdpLinearProgram3();
 
  protected:
   std::unique_ptr<MathematicalProgram> prog_;

--- a/solvers/test/csdp_test_examples.h
+++ b/solvers/test/csdp_test_examples.h
@@ -1,0 +1,155 @@
+#pragma once
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/solvers/mathematical_program.h"
+
+namespace drake {
+namespace solvers {
+/**
+ * min 2 * x0 + x2
+ * s.t [x0 x1] is psd
+ *     [x1 x0]
+
+ *     [x0 x2] is psd
+ *     [x2 x0]
+ *     x1 == 1
+ * the optimal solution is x = (1, 1, -1).
+ */
+class SDPwithOverlappingVariables : public ::testing::Test {
+ public:
+  SDPwithOverlappingVariables();
+
+ protected:
+  std::unique_ptr<MathematicalProgram> prog_;
+  Vector3<symbolic::Variable> x_;
+};
+
+/**
+ * This is the example in CSDP 6.2.0 User's Guide
+ * max tr(C1 * X1) + tr(C2 * X2)
+ * s.t tr(A1 * X1) + y(0) = 1
+ *     tr(A2 * X2) + y(1) = 2
+ *     X1, X2 are psd.
+ *     y(0), y(1) >= 0
+ * where C1 = [2 1]
+ *            [1 2]
+ *       C2 = [3 0 1]
+ *            [0 2 0]
+ *            [1 0 3]
+ *       A1 = [3 1]
+ *            [1 3]
+ *       A2 = [3 0 1]
+ *            [0 4 0]
+ *            [1 0 5]
+ */
+class CsdpDocExample : public ::testing::Test {
+ public:
+  CsdpDocExample();
+
+ protected:
+  std::unique_ptr<MathematicalProgram> prog_;
+  Matrix2<symbolic::Variable> X1_;
+  Matrix3<symbolic::Variable> X2_;
+  Vector2<symbolic::Variable> y_;
+};
+
+/**
+ * A simple linear program withou only bounding box constraint.
+ * max -x(0) + x(1) - 2 *x(2) + 3 * x(3) + x(4) + 1
+ * 0 <= x(0)
+ * 0 <= x(1) <= 5;
+ * -1 <= x(2)
+ *       x(3) <= 10
+ * -2 <= x(4) <= 5
+ *  0 <= x(5) <= 0
+ *  1 <= x(6) <= 1
+ * -inf<=x(7) <= inf
+ */
+class LinearProgram1 : public ::testing::Test {
+ public:
+  LinearProgram1();
+
+ protected:
+  std::unique_ptr<MathematicalProgram> prog_;
+  Eigen::Matrix<symbolic::Variable, 8, 1> x_;
+};
+
+/**
+ * A simple linear program.
+ * min x(0) + 2 * x(1) +  3 * x(2)
+ * s.t 2 * x(0) + 3 * x(1) + x(2) = 1
+ *     -2 * x(2) + x(0) <= -1
+ *     2 * x(1) + x(0) >= -2
+ *     -2 <= -x(0) + 3 * x(2) <= 3
+ *     x(0) + x(1) + 4 * x(2) = 3
+ * The optimal solution is x = (5 / 13, -2 / 13, 9 / 13). The optimal cost is
+ * (28 / 13).
+ */
+class LinearProgram2 : public ::testing::Test {
+ public:
+  LinearProgram2();
+
+ protected:
+  std::unique_ptr<MathematicalProgram> prog_;
+  Vector3<symbolic::Variable> x_;
+};
+
+/**
+ * A linear program with both linear (in)equality constraints and bounding box
+ * constraint.
+ * max 2x(0) + 3x(1) + 4x(2) + 3
+ * s.t x(0) + 2x(1) + 3x(2) = 3
+ *     2x(0) - x(2) >= -1
+ *     x(1) - 3x(2) <= 5
+ *     -4 <= x(0) + x(2) <= 9
+ *     -1 <= x(0) <= 10
+ *     x(1) <= 8
+ * The optimal solution is (10, -2/3, -17/9), the optimal cost is 121 / 9
+ */
+class LinearProgram3 : public ::testing::Test {
+ public:
+  LinearProgram3();
+
+ protected:
+  std::unique_ptr<MathematicalProgram> prog_;
+  Vector3<symbolic::Variable> x_;
+};
+
+/**
+ * A trivial SDP
+ * max X1(0, 1) + X1(1, 2)
+ * s.t X1 ∈ ℝ³ˣ³ is psd
+ *     X1(0, 0) + X1(1, 1) + X1(2, 2) = 1
+ *     X1(0, 1) + X1(1, 2) - 2 * X1(0, 2) <= 0
+ */
+class TrivialSDP1 : public ::testing::Test {
+ public:
+  TrivialSDP1();
+
+ protected:
+  std::unique_ptr<MathematicalProgram> prog_;
+  Matrix3<symbolic::Variable> X1_;
+};
+
+/**
+ * max y
+ * X1 ∈ ℝ²ˣ² is psd
+ * I + F1 * y + F2 * X1(0, 0) is psd.
+ * X1(0, 0) + 2 * X1(1, 1) + 3 * y = 1
+ * where F1 = [1 2; 2 3], F2 = [2 0; 0 4]
+ * The optimal solution is X1 = [0 0; 0 0], y = 1 / 3, The optimal cost is 1/3.
+ */
+class TrivialSDP2 : public ::testing::Test {
+ public:
+  TrivialSDP2();
+
+ protected:
+  std::unique_ptr<MathematicalProgram> prog_;
+  Matrix2<symbolic::Variable> X1_;
+  symbolic::Variable y_;
+};
+}  // namespace solvers
+}  // namespace drake

--- a/solvers/test/csdp_test_examples.h
+++ b/solvers/test/csdp_test_examples.h
@@ -9,14 +9,13 @@
 namespace drake {
 namespace solvers {
 /**
- * min 2 * x0 + x2
- * s.t [x0 x1] is psd
- *     [x1 x0]
-
- *     [x0 x2] is psd
- *     [x2 x0]
- *     x1 == 1
- * the optimal solution is x = (1, 1, -1).
+ * min 2x0 + x2
+ * s.t ⎡x0 x1⎤ is psd,
+ *     ⎣x1 x0⎦
+ *     ⎡x0 x2⎤ is psd, and
+ *     ⎣x2 x0⎦
+ *     x1 == 1.
+ * The optimal solution is x = (1, 1, -1).
  */
 class SDPwithOverlappingVariables : public ::testing::Test {
  public:
@@ -33,17 +32,17 @@ class SDPwithOverlappingVariables : public ::testing::Test {
  * s.t tr(A1 * X1) + y(0) = 1
  *     tr(A2 * X2) + y(1) = 2
  *     X1, X2 are psd.
- *     y(0), y(1) >= 0
- * where C1 = [2 1]
- *            [1 2]
- *       C2 = [3 0 1]
- *            [0 2 0]
- *            [1 0 3]
- *       A1 = [3 1]
- *            [1 3]
- *       A2 = [3 0 1]
- *            [0 4 0]
- *            [1 0 5]
+ *     y(0), y(1) ≥ 0
+ * where C1 = ⎡2 1⎤
+ *            ⎣1 2⎦
+ *       C2 = ⎡3 0 1⎤
+ *            ⎢0 2 0⎥
+ *            ⎣1 0 3⎦
+ *       A1 = ⎡3 1⎤
+ *            ⎣1 3⎦
+ *       A2 = ⎡3 0 1⎤
+ *            ⎢0 4 0⎥
+ *            ⎣1 0 5⎦
  */
 class CsdpDocExample : public ::testing::Test {
  public:
@@ -59,14 +58,14 @@ class CsdpDocExample : public ::testing::Test {
 /**
  * A simple linear program withou only bounding box constraint.
  * max -x(0) + x(1) - 2 *x(2) + 3 * x(3) + x(4) + 1
- * 0 <= x(0)
- * 0 <= x(1) <= 5;
- * -1 <= x(2)
- *       x(3) <= 10
- * -2 <= x(4) <= 5
- *  0 <= x(5) <= 0
- *  1 <= x(6) <= 1
- * -inf<=x(7) <= inf
+ * 0 ≤ x(0)
+ * 0 ≤ x(1) ≤ 5;
+ * -1 ≤ x(2)
+ *       x(3) ≤ 10
+ * -2 ≤ x(4) ≤ 5
+ *  0 ≤ x(5) ≤ 0
+ *  1 ≤ x(6) ≤ 1
+ * -inf≤x(7) ≤ inf
  */
 class LinearProgramBoundingBox1 : public ::testing::Test {
  public:
@@ -79,12 +78,12 @@ class LinearProgramBoundingBox1 : public ::testing::Test {
 
 /**
  * A simple linear program.
- * min x(0) + 2 * x(1) +  3 * x(2)
- * s.t 2 * x(0) + 3 * x(1) + x(2) = 1
- *     -2 * x(2) + x(0) <= -1
- *     2 * x(1) + x(0) >= -2
- *     -2 <= -x(0) + 3 * x(2) <= 3
- *     x(0) + x(1) + 4 * x(2) = 3
+ * min x(0) + 2x(1) +  3x(2)
+ * s.t 2x(0) + 3x(1) + x(2) = 1
+ *     -2x(2) + x(0) ≤ -1
+ *     2x(1) + x(0) ≥ -2
+ *     -2 ≤ -x(0) + 3x(2) ≤ 3
+ *     x(0) + x(1) + 4x(2) = 3
  * The optimal solution is x = (5 / 13, -2 / 13, 9 / 13). The optimal cost is
  * (28 / 13).
  */
@@ -102,11 +101,11 @@ class CsdpLinearProgram2 : public ::testing::Test {
  * constraint.
  * max 2x(0) + 3x(1) + 4x(2) + 3
  * s.t x(0) + 2x(1) + 3x(2) = 3
- *     2x(0) - x(2) >= -1
- *     x(1) - 3x(2) <= 5
- *     -4 <= x(0) + x(2) <= 9
- *     -1 <= x(0) <= 10
- *     x(1) <= 8
+ *     2x(0) - x(2) ≥ -1
+ *     x(1) - 3x(2) ≤ 5
+ *     -4 ≤ x(0) + x(2) ≤ 9
+ *     -1 ≤ x(0) ≤ 10
+ *     x(1) ≤ 8
  * The optimal solution is (10, -2/3, -17/9), the optimal cost is 121 / 9
  */
 class CsdpLinearProgram3 : public ::testing::Test {
@@ -123,7 +122,7 @@ class CsdpLinearProgram3 : public ::testing::Test {
  * max X1(0, 1) + X1(1, 2)
  * s.t X1 ∈ ℝ³ˣ³ is psd
  *     X1(0, 0) + X1(1, 1) + X1(2, 2) = 1
- *     X1(0, 1) + X1(1, 2) - 2 * X1(0, 2) <= 0
+ *     X1(0, 1) + X1(1, 2) - 2 * X1(0, 2) ≤ 0
  */
 class TrivialSDP1 : public ::testing::Test {
  public:

--- a/solvers/test/sdpa_free_format_test.cc
+++ b/solvers/test/sdpa_free_format_test.cc
@@ -1,13 +1,10 @@
 #include "drake/solvers/sdpa_free_format.h"
 
-#include <fstream>
 #include <limits>
 #include <utility>
 
 #include <gtest/gtest.h>
-#include <spruce.hh>
 
-#include "drake/common/temp_directory.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/solvers/test/csdp_test_examples.h"
 

--- a/solvers/test/sdpa_free_format_test.cc
+++ b/solvers/test/sdpa_free_format_test.cc
@@ -1,0 +1,497 @@
+#include "drake/solvers/sdpa_free_format.h"
+
+#include <fstream>
+#include <limits>
+#include <utility>
+
+#include <gtest/gtest.h>
+#include <spruce.hh>
+
+#include "drake/common/temp_directory.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/solvers/test/csdp_test_examples.h"
+
+namespace drake {
+namespace solvers {
+const double kInf = std::numeric_limits<double>::infinity();
+namespace internal {
+
+void CompareProgVarInSdpa(const SdpaFreeFormat& sdpa_free_format,
+                          int variable_index, double val_expected) {
+  const double val =
+      get<double>(sdpa_free_format.prog_var_in_sdpa()[variable_index]);
+  EXPECT_EQ(val, val_expected);
+}
+
+void CompareProgVarInSdpa(const SdpaFreeFormat& sdpa_free_format,
+                          int variable_index,
+                          SdpaFreeFormat::FreeVariableIndex s_index_expected) {
+  const SdpaFreeFormat::FreeVariableIndex s_index =
+      get<SdpaFreeFormat::FreeVariableIndex>(
+          sdpa_free_format.prog_var_in_sdpa()[variable_index]);
+  EXPECT_EQ(s_index, s_index_expected);
+}
+
+void CompareProgVarInSdpa(const SdpaFreeFormat& sdpa_free_format,
+                          int variable_index,
+                          const DecisionVariableInSdpaX& val_expected) {
+  const auto val = get<DecisionVariableInSdpaX>(
+      sdpa_free_format.prog_var_in_sdpa()[variable_index]);
+  EXPECT_EQ(val.coeff_sign, val_expected.coeff_sign);
+  EXPECT_EQ(val.offset, val_expected.offset);
+  EXPECT_EQ(val.entry_in_X.block_index, val_expected.entry_in_X.block_index);
+  EXPECT_EQ(val.entry_in_X.row_index_in_block,
+            val_expected.entry_in_X.row_index_in_block);
+  EXPECT_EQ(val.entry_in_X.column_index_in_block,
+            val_expected.entry_in_X.column_index_in_block);
+  EXPECT_EQ(val.entry_in_X.X_start_row, val_expected.entry_in_X.X_start_row);
+}
+
+void CompareBlockInX(const BlockInX& block1, const BlockInX& block2) {
+  EXPECT_EQ(block1.blocktype, block2.blocktype);
+  EXPECT_EQ(block1.num_rows, block2.num_rows);
+}
+
+void CompareTriplets(const std::vector<Eigen::Triplet<double>>& triplets1,
+                     const std::vector<Eigen::Triplet<double>>& triplets2,
+                     int matrix_rows, int matrix_cols) {
+  EXPECT_EQ(triplets1.size(), triplets2.size());
+  Eigen::SparseMatrix<double> mat1(matrix_rows, matrix_cols);
+  mat1.setFromTriplets(triplets1.begin(), triplets1.end());
+  Eigen::SparseMatrix<double> mat2(matrix_rows, matrix_cols);
+  mat2.setFromTriplets(triplets2.begin(), triplets2.end());
+  EXPECT_TRUE(
+      CompareMatrices(Eigen::MatrixXd(mat1), Eigen::MatrixXd(mat2), 1E-12));
+}
+
+TEST_F(SDPwithOverlappingVariables, TestSdpaFreeFormatConstructor) {
+  const SdpaFreeFormat dut(*prog_);
+  EXPECT_EQ(dut.num_X_rows(), 4);
+  EXPECT_EQ(dut.num_free_variables(), 0);
+  EXPECT_EQ(dut.X_blocks().size(), 2);
+  CompareBlockInX(dut.X_blocks()[0], BlockInX(BlockType::kMatrix, 2));
+  CompareBlockInX(dut.X_blocks()[1], BlockInX(BlockType::kMatrix, 2));
+  EXPECT_EQ(dut.prog_var_in_sdpa().size(), 3);
+  CompareProgVarInSdpa(dut, prog_->FindDecisionVariableIndex(x_(0)),
+                       DecisionVariableInSdpaX(Sign::kPositive, 0, 0, 0, 0, 0));
+  CompareProgVarInSdpa(dut, prog_->FindDecisionVariableIndex(x_(1)),
+                       DecisionVariableInSdpaX(Sign::kPositive, 0, 0, 0, 1, 0));
+  CompareProgVarInSdpa(dut, prog_->FindDecisionVariableIndex(x_(2)),
+                       DecisionVariableInSdpaX(Sign::kPositive, 0, 1, 0, 1, 2));
+
+  // Check A_triplets.
+  EXPECT_EQ(dut.A_triplets().size(), 4);
+  CompareTriplets(
+      dut.A_triplets()[0],
+      {Eigen::Triplet<double>(0, 0, 1.0), Eigen::Triplet<double>(1, 1, -1.0)},
+      dut.num_X_rows(), dut.num_X_rows());
+  CompareTriplets(
+      dut.A_triplets()[1],
+      {Eigen::Triplet<double>(0, 0, 1.0), Eigen::Triplet<double>(2, 2, -1.0)},
+      dut.num_X_rows(), dut.num_X_rows());
+  CompareTriplets(
+      dut.A_triplets()[2],
+      {Eigen::Triplet<double>(0, 0, 1.0), Eigen::Triplet<double>(3, 3, -1.0)},
+      dut.num_X_rows(), dut.num_X_rows());
+  // The constraint that x1 = 1
+  CompareTriplets(
+      dut.A_triplets()[3],
+      {Eigen::Triplet<double>(0, 1, 0.5), Eigen::Triplet<double>(1, 0, 0.5)},
+      dut.num_X_rows(), dut.num_X_rows());
+
+  EXPECT_TRUE(CompareMatrices(dut.g(), Eigen::Vector4d(0, 0, 0, 1)));
+  EXPECT_EQ(dut.B_triplets().size(), 0);
+
+  // Now check the cost.
+  CompareTriplets(
+      dut.C_triplets(),
+      {Eigen::Triplet<double>(0, 0, -2), Eigen::Triplet<double>(2, 3, -0.5),
+       Eigen::Triplet<double>(3, 2, -0.5)},
+      dut.num_X_rows(), dut.num_X_rows());
+  EXPECT_EQ(dut.d_triplets().size(), 0);
+  EXPECT_EQ(dut.constant_min_cost_term(), 0);
+}
+
+TEST_F(CsdpDocExample, TestSdpaFreeFormatConstructor) {
+  SdpaFreeFormat dut(*prog_);
+  EXPECT_EQ(dut.num_X_rows(), 7);
+  EXPECT_EQ(dut.num_free_variables(), 0);
+  EXPECT_EQ(dut.X_blocks().size(), 3);
+  CompareBlockInX(dut.X_blocks()[0], BlockInX(BlockType::kMatrix, 2));
+  CompareBlockInX(dut.X_blocks()[1], BlockInX(BlockType::kMatrix, 3));
+  CompareBlockInX(dut.X_blocks()[2], BlockInX(BlockType::kDiagonal, 2));
+  EXPECT_EQ(dut.prog_var_in_sdpa().size(), prog_->num_vars());
+  CompareProgVarInSdpa(dut, prog_->FindDecisionVariableIndex(X1_(0, 0)),
+                       DecisionVariableInSdpaX(Sign::kPositive, 0, 0, 0, 0, 0));
+  CompareProgVarInSdpa(dut, prog_->FindDecisionVariableIndex(X1_(1, 0)),
+                       DecisionVariableInSdpaX(Sign::kPositive, 0, 0, 0, 1, 0));
+  CompareProgVarInSdpa(dut, prog_->FindDecisionVariableIndex(X1_(1, 1)),
+                       DecisionVariableInSdpaX(Sign::kPositive, 0, 0, 1, 1, 0));
+  for (int j = 0; j < 3; ++j) {
+    for (int i = 0; i <= j; ++i) {
+      CompareProgVarInSdpa(
+          dut, prog_->FindDecisionVariableIndex(X2_(i, j)),
+          DecisionVariableInSdpaX(Sign::kPositive, 0, 1, i, j, 2));
+    }
+  }
+  for (int i = 0; i < 2; ++i) {
+    CompareProgVarInSdpa(
+        dut, prog_->FindDecisionVariableIndex(y_(i)),
+        DecisionVariableInSdpaX(Sign::kPositive, 0, 2, i, i, 5));
+  }
+
+  // Check the cost.
+  CompareTriplets(
+      dut.C_triplets(),
+      {Eigen::Triplet<double>(0, 0, 2), Eigen::Triplet<double>(0, 1, 1),
+       Eigen::Triplet<double>(1, 0, 1), Eigen::Triplet<double>(1, 1, 2),
+       Eigen::Triplet<double>(2, 2, 3), Eigen::Triplet<double>(3, 3, 2),
+       Eigen::Triplet<double>(2, 4, 1), Eigen::Triplet<double>(4, 2, 1),
+       Eigen::Triplet<double>(4, 4, 3)},
+      dut.num_X_rows(), dut.num_X_rows());
+  EXPECT_EQ(dut.d_triplets().size(), 0);
+  EXPECT_EQ(dut.constant_min_cost_term(), 0);
+
+  // Check the constraints.
+  EXPECT_EQ(dut.A_triplets().size(), 2);
+  CompareTriplets(
+      dut.A_triplets()[0],
+      {Eigen::Triplet<double>(0, 0, 3), Eigen::Triplet<double>(0, 1, 1),
+       Eigen::Triplet<double>(1, 0, 1), Eigen::Triplet<double>(1, 1, 3),
+       Eigen::Triplet<double>(5, 5, 1)},
+      dut.num_X_rows(), dut.num_X_rows());
+  CompareTriplets(
+      dut.A_triplets()[1],
+      {Eigen::Triplet<double>(2, 2, 3), Eigen::Triplet<double>(3, 3, 4),
+       Eigen::Triplet<double>(2, 4, 1), Eigen::Triplet<double>(4, 2, 1),
+       Eigen::Triplet<double>(4, 4, 5), Eigen::Triplet<double>(6, 6, 1)},
+      dut.num_X_rows(), dut.num_X_rows());
+  EXPECT_EQ(dut.B_triplets().size(), 0);
+  EXPECT_TRUE(CompareMatrices(dut.g(), Eigen::Vector2d(1, 2)));
+}
+
+TEST_F(LinearProgram1, TestSdpaFreeFormatConstructor) {
+  // Test if we can correctly register decision variables with bounding box
+  // constraints.
+  SdpaFreeFormat dut(*prog_);
+  EXPECT_EQ(dut.num_X_rows(), 7);
+  EXPECT_EQ(dut.num_free_variables(), 1);
+
+  EXPECT_EQ(dut.X_blocks().size(), 1);
+  CompareBlockInX(dut.X_blocks()[0], BlockInX(BlockType::kDiagonal, 7));
+  EXPECT_EQ(dut.prog_var_in_sdpa().size(), prog_->num_vars());
+  CompareProgVarInSdpa(dut, 0,
+                       DecisionVariableInSdpaX(Sign::kPositive, 0, 0, 0, 0, 0));
+  CompareProgVarInSdpa(dut, 1,
+                       DecisionVariableInSdpaX(Sign::kPositive, 0, 0, 1, 1, 0));
+  CompareProgVarInSdpa(
+      dut, 2, DecisionVariableInSdpaX(Sign::kPositive, -1, 0, 3, 3, 0));
+  CompareProgVarInSdpa(
+      dut, 3, DecisionVariableInSdpaX(Sign::kNegative, 10, 0, 4, 4, 0));
+  CompareProgVarInSdpa(
+      dut, 4, DecisionVariableInSdpaX(Sign::kPositive, -2, 0, 5, 5, 0));
+  CompareProgVarInSdpa(dut, 5, 0.0);
+  CompareProgVarInSdpa(dut, 6, 1.0);
+  CompareProgVarInSdpa(dut, 7, SdpaFreeFormat::FreeVariableIndex(0));
+
+  // Constraining 0 <= x(1) <= 5
+  Eigen::Vector2d g_expected;
+  CompareTriplets(
+      dut.A_triplets()[0],
+      {Eigen::Triplet<double>(1, 1, 1), Eigen::Triplet<double>(2, 2, 1)},
+      dut.num_X_rows(), dut.num_X_rows());
+  g_expected(0) = 5;
+  // Constraining -2 <= x(4) <= 5
+  CompareTriplets(
+      dut.A_triplets()[1],
+      {Eigen::Triplet<double>(5, 5, 1), Eigen::Triplet<double>(6, 6, 1)},
+      dut.num_X_rows(), dut.num_X_rows());
+  g_expected(1) = 7;
+  EXPECT_EQ(dut.B_triplets().size(), 0);
+  EXPECT_TRUE(CompareMatrices(dut.g(), g_expected));
+
+  // Check the cost max -x(0) + x(1) - 2 * x(2) + 3 * x(3) +  x(4) + 1
+  CompareTriplets(
+      dut.C_triplets(),
+      {Eigen::Triplet<double>(0, 0, -1), Eigen::Triplet<double>(1, 1, 1),
+       Eigen::Triplet<double>(3, 3, -2), Eigen::Triplet<double>(4, 4, -3),
+       Eigen::Triplet<double>(5, 5, 1)},
+      dut.num_X_rows(), dut.num_X_rows());
+  EXPECT_EQ(dut.constant_min_cost_term(), -31);
+}
+
+TEST_F(LinearProgram2, TestSdpaFreeFormatConstructor) {
+  // This tests adding linear constraint.
+  const SdpaFreeFormat dut(*prog_);
+  EXPECT_EQ(dut.num_X_rows(), 4);
+  EXPECT_EQ(dut.num_free_variables(), 3);
+  EXPECT_EQ(dut.prog_var_in_sdpa().size(), 3);
+  for (int i = 0; i < 3; ++i) {
+    CompareProgVarInSdpa(dut, i, SdpaFreeFormat::FreeVariableIndex(i));
+  }
+
+  EXPECT_EQ(dut.X_blocks().size(), 1);
+  CompareBlockInX(dut.X_blocks()[0], BlockInX(BlockType::kDiagonal, 4));
+
+  // Check the linear constraints.
+  EXPECT_EQ(dut.A_triplets().size(), 6);
+  std::vector<Eigen::Triplet<double>> B_triplets_expected;
+  Vector6<double> g_expected;
+  // 2 * x(0) + 3 * x(1) + x(2) = 1
+  B_triplets_expected.emplace_back(0, 0, 2);
+  B_triplets_expected.emplace_back(0, 1, 3);
+  B_triplets_expected.emplace_back(0, 2, 1);
+  g_expected(0) = 1;
+  // -2 * x(2) + x(0) <= -1
+  EXPECT_EQ(dut.A_triplets()[0].size(), 0);
+  std::vector<Eigen::Triplet<double>> A1_triplets_expected;
+  A1_triplets_expected.emplace_back(0, 0, 1);
+  CompareTriplets(dut.A_triplets()[1], A1_triplets_expected, dut.num_X_rows(),
+                  dut.num_X_rows());
+  B_triplets_expected.emplace_back(1, 0, 1);
+  B_triplets_expected.emplace_back(1, 2, -2);
+  g_expected(1) = -1;
+  // 2 * x(1) + x(0) >= -2
+  std::vector<Eigen::Triplet<double>> A2_triplets_expected;
+  A2_triplets_expected.emplace_back(1, 1, -1);
+  CompareTriplets(dut.A_triplets()[2], A2_triplets_expected, dut.num_X_rows(),
+                  dut.num_X_rows());
+  B_triplets_expected.emplace_back(2, 0, 1);
+  B_triplets_expected.emplace_back(2, 1, 2);
+  g_expected(2) = -2;
+  // -2 <= -x(0) + 3 * x(2) <= 3
+  std::vector<Eigen::Triplet<double>> A3_triplets_expected;
+  A3_triplets_expected.emplace_back(2, 2, -1);
+  CompareTriplets(dut.A_triplets()[3], A3_triplets_expected, dut.num_X_rows(),
+                  dut.num_X_rows());
+  B_triplets_expected.emplace_back(3, 0, -1);
+  B_triplets_expected.emplace_back(3, 2, 3);
+  g_expected(3) = -2;
+  std::vector<Eigen::Triplet<double>> A4_triplets_expected;
+  A4_triplets_expected.emplace_back(3, 3, 1);
+  CompareTriplets(dut.A_triplets()[4], A4_triplets_expected, dut.num_X_rows(),
+                  dut.num_X_rows());
+  B_triplets_expected.emplace_back(4, 0, -1);
+  B_triplets_expected.emplace_back(4, 2, 3);
+  g_expected(4) = 3;
+  // x(0) + x(1) + 4 * x(2) = 3
+  EXPECT_EQ(dut.A_triplets()[5].size(), 0);
+  B_triplets_expected.emplace_back(5, 0, 1);
+  B_triplets_expected.emplace_back(5, 1, 1);
+  B_triplets_expected.emplace_back(5, 2, 4);
+  g_expected(5) = 3;
+
+  CompareTriplets(dut.B_triplets(), B_triplets_expected, 6,
+                  dut.num_free_variables());
+  EXPECT_TRUE(CompareMatrices(dut.g(), g_expected));
+
+  // Check the cost min x(0) + 2 * x(1) +  3 * x(2)
+  EXPECT_EQ(dut.C_triplets().size(), 0);
+  std::vector<Eigen::Triplet<double>> d_triplets_expected;
+  d_triplets_expected.emplace_back(0, 0, -1);
+  d_triplets_expected.emplace_back(1, 0, -2);
+  d_triplets_expected.emplace_back(2, 0, -3);
+  CompareTriplets(dut.d_triplets(), d_triplets_expected, 3, 1);
+}
+
+TEST_F(LinearProgram3, TestSdpaFreeFormatConstructor) {
+  const SdpaFreeFormat dut(*prog_);
+  EXPECT_EQ(dut.num_X_rows(), 7);
+  EXPECT_EQ(dut.num_free_variables(), 1);
+  EXPECT_EQ(dut.prog_var_in_sdpa().size(), 3);
+  CompareProgVarInSdpa(
+      dut, 0, DecisionVariableInSdpaX(Sign::kPositive, -1, 0, 0, 0, 0));
+  CompareProgVarInSdpa(dut, 1,
+                       DecisionVariableInSdpaX(Sign::kNegative, 8, 0, 2, 2, 0));
+  CompareProgVarInSdpa(dut, 2, SdpaFreeFormat::FreeVariableIndex(0));
+
+  EXPECT_EQ(dut.X_blocks().size(), 2);
+
+  CompareBlockInX(dut.X_blocks()[0], BlockInX(BlockType::kDiagonal, 3));
+  CompareBlockInX(dut.X_blocks()[1], BlockInX(BlockType::kDiagonal, 4));
+
+  // Check the cost 2x(0) + 3x(1) + 4x(2) + 3
+  CompareTriplets(
+      dut.C_triplets(),
+      {Eigen::Triplet<double>(0, 0, 2), Eigen::Triplet<double>(2, 2, -3)},
+      dut.num_X_rows(), dut.num_X_rows());
+  CompareTriplets(dut.d_triplets(), {Eigen::Triplet<double>(0, 0, 4)}, 1, 1);
+  EXPECT_EQ(dut.constant_min_cost_term(), -25);
+  EXPECT_EQ(dut.A_triplets().size(), 6);
+  Vector6<double> g_expected;
+  std::vector<Eigen::Triplet<double>> B_triplets_expected;
+  // Check the constraint x(0) <= 10
+  CompareTriplets(
+      dut.A_triplets()[0],
+      {Eigen::Triplet<double>(0, 0, 1), Eigen::Triplet<double>(1, 1, 1)},
+      dut.num_X_rows(), dut.num_X_rows());
+  g_expected(0) = 11;
+
+  // Check the constraint x(0) + 2x(1) + 3x(2) = 3
+  CompareTriplets(
+      dut.A_triplets()[1],
+      {Eigen::Triplet<double>(0, 0, 1), Eigen::Triplet<double>(2, 2, -2)},
+      dut.num_X_rows(), dut.num_X_rows());
+  B_triplets_expected.emplace_back(1, 0, 3);
+  g_expected(1) = -12;
+
+  // Check the constraint 2x(0) - x(2)>= -1
+  CompareTriplets(
+      dut.A_triplets()[2],
+      {Eigen::Triplet<double>(0, 0, 2), Eigen::Triplet<double>(3, 3, -1)},
+      dut.num_X_rows(), dut.num_X_rows());
+  B_triplets_expected.emplace_back(2, 0, -1);
+  g_expected(2) = 1;
+
+  // Check the constraint x(1) - 3x(2) <= 5
+  CompareTriplets(
+      dut.A_triplets()[3],
+      {Eigen::Triplet<double>(2, 2, -1), Eigen::Triplet<double>(4, 4, 1)},
+      dut.num_X_rows(), dut.num_X_rows());
+  B_triplets_expected.emplace_back(3, 0, -3);
+  g_expected(3) = -3;
+
+  // Check the constraint -4 <= x(0) + x(2) <= 9
+  CompareTriplets(
+      dut.A_triplets()[4],
+      {Eigen::Triplet<double>(0, 0, 1), Eigen::Triplet<double>(5, 5, -1)},
+      dut.num_X_rows(), dut.num_X_rows());
+  B_triplets_expected.emplace_back(4, 0, 1);
+  g_expected(4) = -3;
+
+  CompareTriplets(
+      dut.A_triplets()[5],
+      {Eigen::Triplet<double>(0, 0, 1), Eigen::Triplet<double>(6, 6, 1)},
+      dut.num_X_rows(), dut.num_X_rows());
+  B_triplets_expected.emplace_back(5, 0, 1);
+  g_expected(5) = 10;
+  CompareTriplets(dut.B_triplets(), B_triplets_expected, dut.g().rows(),
+                  dut.num_free_variables());
+  EXPECT_TRUE(CompareMatrices(dut.g(), g_expected));
+}
+
+TEST_F(TrivialSDP1, TestSdpaFreeFormatConstructor) {
+  // Test SdpaFreeFormat constructor with both PSD constraint and linear
+  // constraint.
+  const SdpaFreeFormat dut(*prog_);
+  EXPECT_EQ(dut.num_X_rows(), 4);
+  EXPECT_EQ(dut.num_free_variables(), 0);
+
+  EXPECT_EQ(dut.X_blocks().size(), 2);
+  CompareBlockInX(dut.X_blocks()[0], BlockInX(BlockType::kMatrix, 3));
+  CompareBlockInX(dut.X_blocks()[1], BlockInX(BlockType::kDiagonal, 1));
+  for (int j = 0; j < 3; ++j) {
+    for (int i = 0; i <= j; ++i) {
+      CompareProgVarInSdpa(
+          dut, prog_->FindDecisionVariableIndex(X1_(i, j)),
+          DecisionVariableInSdpaX(Sign::kPositive, 0, 0, i, j, 0));
+    }
+  }
+
+  EXPECT_EQ(dut.A_triplets().size(), 2);
+  Eigen::Vector2d g_expected(1, 0);
+  // X1(0, 0) + X1(1, 1) + X1(2, 2) = 1
+  std::vector<Eigen::Triplet<double>> A0_triplets_expected;
+  A0_triplets_expected.emplace_back(0, 0, 1);
+  A0_triplets_expected.emplace_back(1, 1, 1);
+  A0_triplets_expected.emplace_back(2, 2, 1);
+  CompareTriplets(dut.A_triplets()[0], A0_triplets_expected, dut.num_X_rows(),
+                  dut.num_X_rows());
+
+  // X1(0, 1) + X1(1, 2) - 2 * X1(0, 2) <= 0
+  std::vector<Eigen::Triplet<double>> A1_triplets_expected;
+  A1_triplets_expected.emplace_back(0, 1, 0.5);
+  A1_triplets_expected.emplace_back(1, 0, 0.5);
+  A1_triplets_expected.emplace_back(1, 2, 0.5);
+  A1_triplets_expected.emplace_back(2, 1, 0.5);
+  A1_triplets_expected.emplace_back(0, 2, -1);
+  A1_triplets_expected.emplace_back(2, 0, -1);
+  A1_triplets_expected.emplace_back(3, 3, 1);
+  CompareTriplets(dut.A_triplets()[1], A1_triplets_expected, dut.num_X_rows(),
+                  dut.num_X_rows());
+  EXPECT_TRUE(CompareMatrices(dut.g(), g_expected));
+  EXPECT_EQ(dut.B_triplets().size(), 0);
+
+  // Cost max X1(0, 1) + X1(1, 2)
+  std::vector<Eigen::Triplet<double>> C_triplets_expected;
+  C_triplets_expected.emplace_back(0, 1, 0.5);
+  C_triplets_expected.emplace_back(1, 0, 0.5);
+  C_triplets_expected.emplace_back(1, 2, 0.5);
+  C_triplets_expected.emplace_back(2, 1, 0.5);
+  CompareTriplets(dut.C_triplets(), C_triplets_expected, dut.num_X_rows(),
+                  dut.num_X_rows());
+  EXPECT_EQ(dut.d_triplets().size(), 0);
+}
+
+TEST_F(TrivialSDP2, TestSdpaFreeFormatConstructor) {
+  // Test constructor with linear matrix inequality constraint.
+  const SdpaFreeFormat dut(*prog_);
+  EXPECT_EQ(dut.num_X_rows(), 4);
+  EXPECT_EQ(dut.num_free_variables(), 1);
+
+  EXPECT_EQ(dut.X_blocks().size(), 2);
+  CompareBlockInX(dut.X_blocks()[0], BlockInX(BlockType::kMatrix, 2));
+  CompareBlockInX(dut.X_blocks()[1], BlockInX(BlockType::kMatrix, 2));
+  for (int j = 0; j < 2; ++j) {
+    for (int i = 0; i <= j; ++i) {
+      CompareProgVarInSdpa(
+          dut, prog_->FindDecisionVariableIndex(X1_(i, j)),
+          DecisionVariableInSdpaX(Sign::kPositive, 0, 0, i, j, 0));
+    }
+  }
+  CompareProgVarInSdpa(dut, prog_->FindDecisionVariableIndex(y_),
+                       SdpaFreeFormat::FreeVariableIndex(0));
+
+  // Check linear constraint
+  EXPECT_EQ(dut.A_triplets().size(), 4);
+  std::vector<Eigen::Triplet<double>> B_triplets_expected;
+  Eigen::Vector4d g_expected;
+  // X1(0, 0) + 2 * X1(1, 1) + 3 * y = 1
+  std::vector<Eigen::Triplet<double>> A0_triplets_expected;
+  A0_triplets_expected.emplace_back(0, 0, 1);
+  A0_triplets_expected.emplace_back(1, 1, 2);
+  CompareTriplets(dut.A_triplets()[0], A0_triplets_expected, dut.num_X_rows(),
+                  dut.num_X_rows());
+  B_triplets_expected.emplace_back(0, 0, 3);
+  g_expected(0) = 1;
+
+  // I + F1 * y + F2 * X1(0, 0) is psd.
+  // where F1 = [1 2; 2 3], F2 = [2 0; 0 4]
+  // 1 + y + 2 * X1(0, 0) = X_slack(0, 0)
+  std::vector<Eigen::Triplet<double>> A1_triplets_expected;
+  A1_triplets_expected.emplace_back(0, 0, 2);
+  A1_triplets_expected.emplace_back(2, 2, -1);
+  CompareTriplets(dut.A_triplets()[1], A1_triplets_expected, dut.num_X_rows(),
+                  dut.num_X_rows());
+  B_triplets_expected.emplace_back(1, 0, 1);
+  g_expected(1) = -1;
+
+  // 2*y = X_slack(0, 1)
+  std::vector<Eigen::Triplet<double>> A2_triplets_expected;
+  A2_triplets_expected.emplace_back(2, 3, -0.5);
+  A2_triplets_expected.emplace_back(3, 2, -0.5);
+  CompareTriplets(dut.A_triplets()[2], A2_triplets_expected, dut.num_X_rows(),
+                  dut.num_X_rows());
+  B_triplets_expected.emplace_back(2, 0, 2);
+  g_expected(2) = 0;
+
+  // 1 + 3*y + 4*X1_(0, 0) = X_slack(1, 1)
+  std::vector<Eigen::Triplet<double>> A3_triplets_expected;
+  A3_triplets_expected.emplace_back(0, 0, 4);
+  A3_triplets_expected.emplace_back(3, 3, -1);
+  CompareTriplets(dut.A_triplets()[3], A3_triplets_expected, dut.num_X_rows(),
+                  dut.num_X_rows());
+  B_triplets_expected.emplace_back(3, 0, 3);
+  g_expected(3) = -1;
+  CompareTriplets(dut.B_triplets(), B_triplets_expected, 4, 1);
+  EXPECT_TRUE(CompareMatrices(dut.g(), g_expected));
+
+  // Check the cost max y
+  EXPECT_EQ(dut.C_triplets().size(), 0);
+  std::vector<Eigen::Triplet<double>> d_triplets_expected;
+  d_triplets_expected.emplace_back(0, 0, 1);
+  CompareTriplets(dut.d_triplets(), d_triplets_expected, 1, 1);
+}
+}  // namespace internal
+}  // namespace solvers
+}  // namespace drake

--- a/solvers/test/sdpa_free_format_test.cc
+++ b/solvers/test/sdpa_free_format_test.cc
@@ -62,12 +62,12 @@ void CompareTriplets(const std::vector<Eigen::Triplet<double>>& triplets1,
 
 TEST_F(SDPwithOverlappingVariables, TestSdpaFreeFormatConstructor) {
   const SdpaFreeFormat dut(*prog_);
-  EXPECT_EQ(dut.num_X_rows(), 4);
-  EXPECT_EQ(dut.num_free_variables(), 0);
-  EXPECT_EQ(dut.X_blocks().size(), 2);
+  ASSERT_EQ(dut.num_X_rows(), 4);
+  ASSERT_EQ(dut.num_free_variables(), 0);
+  ASSERT_EQ(dut.X_blocks().size(), 2);
   CompareBlockInX(dut.X_blocks()[0], BlockInX(BlockType::kMatrix, 2));
   CompareBlockInX(dut.X_blocks()[1], BlockInX(BlockType::kMatrix, 2));
-  EXPECT_EQ(dut.prog_var_in_sdpa().size(), 3);
+  ASSERT_EQ(dut.prog_var_in_sdpa().size(), 3);
   CompareProgVarInSdpa(dut, prog_->FindDecisionVariableIndex(x_(0)),
                        DecisionVariableInSdpaX(Sign::kPositive, 0, 0, 0, 0, 0));
   CompareProgVarInSdpa(dut, prog_->FindDecisionVariableIndex(x_(1)),
@@ -76,7 +76,7 @@ TEST_F(SDPwithOverlappingVariables, TestSdpaFreeFormatConstructor) {
                        DecisionVariableInSdpaX(Sign::kPositive, 0, 1, 0, 1, 2));
 
   // Check A_triplets.
-  EXPECT_EQ(dut.A_triplets().size(), 4);
+  ASSERT_EQ(dut.A_triplets().size(), 4);
   CompareTriplets(
       dut.A_triplets()[0],
       {Eigen::Triplet<double>(0, 0, 1.0), Eigen::Triplet<double>(1, 1, -1.0)},
@@ -166,7 +166,7 @@ TEST_F(CsdpDocExample, TestSdpaFreeFormatConstructor) {
   EXPECT_TRUE(CompareMatrices(dut.g(), Eigen::Vector2d(1, 2)));
 }
 
-TEST_F(LinearProgram1, TestSdpaFreeFormatConstructor) {
+TEST_F(LinearProgramBoundingBox1, TestSdpaFreeFormatConstructor) {
   // Test if we can correctly register decision variables with bounding box
   // constraints.
   SdpaFreeFormat dut(*prog_);
@@ -216,7 +216,7 @@ TEST_F(LinearProgram1, TestSdpaFreeFormatConstructor) {
   EXPECT_EQ(dut.constant_min_cost_term(), -31);
 }
 
-TEST_F(LinearProgram2, TestSdpaFreeFormatConstructor) {
+TEST_F(CsdpLinearProgram2, TestSdpaFreeFormatConstructor) {
   // This tests adding linear constraint.
   const SdpaFreeFormat dut(*prog_);
   EXPECT_EQ(dut.num_X_rows(), 4);
@@ -290,7 +290,7 @@ TEST_F(LinearProgram2, TestSdpaFreeFormatConstructor) {
   CompareTriplets(dut.d_triplets(), d_triplets_expected, 3, 1);
 }
 
-TEST_F(LinearProgram3, TestSdpaFreeFormatConstructor) {
+TEST_F(CsdpLinearProgram3, TestSdpaFreeFormatConstructor) {
   const SdpaFreeFormat dut(*prog_);
   EXPECT_EQ(dut.num_X_rows(), 7);
   EXPECT_EQ(dut.num_free_variables(), 1);

--- a/solvers/test/sdpa_free_format_test.cc
+++ b/solvers/test/sdpa_free_format_test.cc
@@ -13,7 +13,6 @@
 
 namespace drake {
 namespace solvers {
-const double kInf = std::numeric_limits<double>::infinity();
 namespace internal {
 
 void CompareProgVarInSdpa(const SdpaFreeFormat& sdpa_free_format,
@@ -48,7 +47,7 @@ void CompareProgVarInSdpa(const SdpaFreeFormat& sdpa_free_format,
 }
 
 void CompareBlockInX(const BlockInX& block1, const BlockInX& block2) {
-  EXPECT_EQ(block1.blocktype, block2.blocktype);
+  EXPECT_EQ(block1.block_type, block2.block_type);
   EXPECT_EQ(block1.num_rows, block2.num_rows);
 }
 


### PR DESCRIPTION
This is the second step to integrate CSDP into Drake as an SDP solver.

We convert the data in MathematicalProgram to another format, called `SDPA` format with free variables. This format is almost usable by CSDP, except it contains free variables. In the following PRs, I will remove the free variables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11540)
<!-- Reviewable:end -->
