### PR TITLE
changed SetupDefaultStation to SetupMITClassStation

### DIFF
--- a/bindings/pydrake/examples/manipulation_station_py.cc
+++ b/bindings/pydrake/examples/manipulation_station_py.cc
@@ -42,9 +42,9 @@ PYBIND11_MODULE(manipulation_station, m) {
   py::class_<ManipulationStation<T>, Diagram<T>>(m, "ManipulationStation")
       .def(py::init<double>(), py::arg("time_step") = 0.002,
           doc.ManipulationStation.ctor.doc)
-      .def("SetupDefaultStation", &ManipulationStation<T>::SetupDefaultStation,
+      .def("SetupMITClassStation", &ManipulationStation<T>::SetupMITClassStation,
           py::arg("collision_model") = IiwaCollisionModel::kNoCollision,
-          doc.ManipulationStation.SetupDefaultStation.doc)
+          doc.ManipulationStation.SetupMITClassStation.doc)
       .def("SetupClutterClearingStation",
           &ManipulationStation<T>::SetupClutterClearingStation,
           py::arg("X_WCameraBody") = nullopt,

--- a/bindings/pydrake/examples/manipulation_station_py.cc
+++ b/bindings/pydrake/examples/manipulation_station_py.cc
@@ -51,8 +51,9 @@ PYBIND11_MODULE(manipulation_station, m) {
               IiwaCollisionModel collision_model =
                   IiwaCollisionModel::kNoCollision) {
             WarnDeprecated(
-                "SetupDefaultStation is deprecated.  Please use "
-                "SetupManipulationClassStation instead.");
+                "SetupDefaultStation is deprecated and will be removed on or"
+                "around 2019-09-01.  Please use SetupManipulationClassStation "
+                "instead.");
             self->SetupManipulationClassStation(collision_model);
           })
       .def("SetupClutterClearingStation",

--- a/bindings/pydrake/examples/manipulation_station_py.cc
+++ b/bindings/pydrake/examples/manipulation_station_py.cc
@@ -42,10 +42,19 @@ PYBIND11_MODULE(manipulation_station, m) {
   py::class_<ManipulationStation<T>, Diagram<T>>(m, "ManipulationStation")
       .def(py::init<double>(), py::arg("time_step") = 0.002,
           doc.ManipulationStation.ctor.doc)
-      .def("SetupMITClassStation",
-          &ManipulationStation<T>::SetupMITClassStation,
+      .def("SetupManipulationClassStation",
+          &ManipulationStation<T>::SetupManipulationClassStation,
           py::arg("collision_model") = IiwaCollisionModel::kNoCollision,
-          doc.ManipulationStation.SetupMITClassStation.doc)
+          doc.ManipulationStation.SetupManipulationClassStation.doc)
+      .def("SetupDefaultStation",
+          [](ManipulationStation<T>* self,
+              IiwaCollisionModel collision_model =
+                  IiwaCollisionModel::kNoCollision) {
+            WarnDeprecated(
+                "SetupDefaultStation is deprecated.  Please use "
+                "SetupManipulationClassStation instead.");
+            self->SetupManipulationClassStation(collision_model);
+          })
       .def("SetupClutterClearingStation",
           &ManipulationStation<T>::SetupClutterClearingStation,
           py::arg("X_WCameraBody") = nullopt,

--- a/bindings/pydrake/examples/manipulation_station_py.cc
+++ b/bindings/pydrake/examples/manipulation_station_py.cc
@@ -42,7 +42,8 @@ PYBIND11_MODULE(manipulation_station, m) {
   py::class_<ManipulationStation<T>, Diagram<T>>(m, "ManipulationStation")
       .def(py::init<double>(), py::arg("time_step") = 0.002,
           doc.ManipulationStation.ctor.doc)
-      .def("SetupMITClassStation", &ManipulationStation<T>::SetupMITClassStation,
+      .def("SetupMITClassStation",
+          &ManipulationStation<T>::SetupMITClassStation,
           py::arg("collision_model") = IiwaCollisionModel::kNoCollision,
           doc.ManipulationStation.SetupMITClassStation.doc)
       .def("SetupClutterClearingStation",

--- a/bindings/pydrake/examples/test/manipulation_station_test.py
+++ b/bindings/pydrake/examples/test/manipulation_station_test.py
@@ -19,7 +19,7 @@ class TestManipulationStation(unittest.TestCase):
     def test_manipulation_station(self):
         # Just check the spelling.
         station = ManipulationStation(time_step=0.001)
-        station.SetupMITClassStation()
+        station.SetupManipulationClassStation()
         station.SetWsgGains(0.1, 0.1)
         station.SetIiwaPositionGains(np.ones(7))
         station.SetIiwaVelocityGains(np.ones(7))

--- a/bindings/pydrake/examples/test/manipulation_station_test.py
+++ b/bindings/pydrake/examples/test/manipulation_station_test.py
@@ -19,7 +19,7 @@ class TestManipulationStation(unittest.TestCase):
     def test_manipulation_station(self):
         # Just check the spelling.
         station = ManipulationStation(time_step=0.001)
-        station.SetupDefaultStation()
+        station.SetupMITClassStation()
         station.SetWsgGains(0.1, 0.1)
         station.SetIiwaPositionGains(np.ones(7))
         station.SetIiwaVelocityGains(np.ones(7))

--- a/examples/manipulation_station/end_effector_teleop_mouse.py
+++ b/examples/manipulation_station/end_effector_teleop_mouse.py
@@ -263,9 +263,9 @@ def main():
              "Note: The pre-defined velocity limits are specified by "
              "iiwa14_velocity_limits, found in this python file.")
     parser.add_argument(
-        '--setup', type=str, default='mit_class',
+        '--setup', type=str, default='manipulation_class',
         help="The manipulation station setup to simulate. ",
-        choices=['mit_class', 'clutter_clearing'])
+        choices=['manipulation_class', 'clutter_clearing'])
     MeshcatVisualizer.add_argparse_argument(parser)
     args = parser.parse_args()
 
@@ -286,8 +286,8 @@ def main():
         station = builder.AddSystem(ManipulationStation())
 
         # Initializes the chosen station type.
-        if args.setup == 'mit_class':
-            station.SetupMITClassStation()
+        if args.setup == 'manipulation_class':
+            station.SetupManipulationClassStation()
             station.AddManipulandFromFile(
                 ("drake/examples/manipulation_station/models/"
                  "061_foam_brick.sdf"),

--- a/examples/manipulation_station/end_effector_teleop_mouse.py
+++ b/examples/manipulation_station/end_effector_teleop_mouse.py
@@ -11,7 +11,7 @@ from pydrake.geometry import ConnectDrakeVisualizer
 from pydrake.multibody.plant import MultibodyPlant
 from pydrake.manipulation.planner import (
     DifferentialInverseKinematicsParameters)
-from pydrake.math import RigidTransform, RollPitchYaw
+from pydrake.math import RigidTransform, RollPitchYaw, RotationMatrix
 from pydrake.systems.analysis import Simulator
 from pydrake.systems.framework import (BasicVector, DiagramBuilder,
                                        LeafSystem)
@@ -263,9 +263,9 @@ def main():
              "Note: The pre-defined velocity limits are specified by "
              "iiwa14_velocity_limits, found in this python file.")
     parser.add_argument(
-        '--setup', type=str, default='default',
+        '--setup', type=str, default='mit_class',
         help="The manipulation station setup to simulate. ",
-        choices=['default', 'clutter_clearing'])
+        choices=['mit_class', 'clutter_clearing'])
     MeshcatVisualizer.add_argparse_argument(parser)
     args = parser.parse_args()
 
@@ -286,8 +286,12 @@ def main():
         station = builder.AddSystem(ManipulationStation())
 
         # Initializes the chosen station type.
-        if args.setup == 'default':
-            station.SetupDefaultStation()
+        if args.setup == 'mit_class':
+            station.SetupMITClassStation()
+            station.AddManipulandFromFile(
+                ("drake/examples/manipulation_station/models/"
+                 "061_foam_brick.sdf"),
+                RigidTransform(RotationMatrix.Identity(), [0.6, 0, 0]))
         elif args.setup == 'clutter_clearing':
             station.SetupClutterClearingStation()
             ycb_objects = CreateDefaultYcbObjectList()

--- a/examples/manipulation_station/end_effector_teleop_sliders.py
+++ b/examples/manipulation_station/end_effector_teleop_sliders.py
@@ -16,7 +16,7 @@ from pydrake.manipulation.simple_ui import SchunkWsgButtons
 from pydrake.manipulation.planner import (
     DifferentialInverseKinematicsParameters)
 from pydrake.multibody.parsing import Parser
-from pydrake.math import RigidTransform, RollPitchYaw
+from pydrake.math import RigidTransform, RollPitchYaw, RotationMatrix
 from pydrake.systems.analysis import Simulator
 from pydrake.systems.framework import (BasicVector, DiagramBuilder,
                                        LeafSystem)
@@ -174,9 +174,9 @@ parser.add_argument(
          "Note: The pre-defined velocity limits are specified by "
          "iiwa14_velocity_limits, found in this python file.")
 parser.add_argument(
-    '--setup', type=str, default='default',
+    '--setup', type=str, default='mit_class',
     help="The manipulation station setup to simulate. ",
-    choices=['default', 'clutter_clearing'])
+    choices=['mit_class', 'clutter_clearing'])
 
 MeshcatVisualizer.add_argparse_argument(parser)
 args = parser.parse_args()
@@ -190,8 +190,11 @@ else:
     station = builder.AddSystem(ManipulationStation())
 
     # Initializes the chosen station type.
-    if args.setup == 'default':
-        station.SetupDefaultStation()
+    if args.setup == 'mit_class':
+        station.SetupMITClassStation()
+        station.AddManipulandFromFile(
+            "drake/examples/manipulation_station/models/061_foam_brick.sdf",
+            RigidTransform(RotationMatrix.Identity(), [0.6, 0, 0]))
     elif args.setup == 'clutter_clearing':
         station.SetupClutterClearingStation()
         ycb_objects = CreateDefaultYcbObjectList()

--- a/examples/manipulation_station/end_effector_teleop_sliders.py
+++ b/examples/manipulation_station/end_effector_teleop_sliders.py
@@ -174,9 +174,9 @@ parser.add_argument(
          "Note: The pre-defined velocity limits are specified by "
          "iiwa14_velocity_limits, found in this python file.")
 parser.add_argument(
-    '--setup', type=str, default='mit_class',
+    '--setup', type=str, default='manipulation_class',
     help="The manipulation station setup to simulate. ",
-    choices=['mit_class', 'clutter_clearing'])
+    choices=['manipulation_class', 'clutter_clearing'])
 
 MeshcatVisualizer.add_argparse_argument(parser)
 args = parser.parse_args()
@@ -190,8 +190,8 @@ else:
     station = builder.AddSystem(ManipulationStation())
 
     # Initializes the chosen station type.
-    if args.setup == 'mit_class':
-        station.SetupMITClassStation()
+    if args.setup == 'manipulation_class':
+        station.SetupManipulationClassStation()
         station.AddManipulandFromFile(
             "drake/examples/manipulation_station/models/061_foam_brick.sdf",
             RigidTransform(RotationMatrix.Identity(), [0.6, 0, 0]))

--- a/examples/manipulation_station/joint_teleop.py
+++ b/examples/manipulation_station/joint_teleop.py
@@ -49,7 +49,7 @@ if args.hardware:
     station.Connect(wait_for_cameras=False)
 else:
     station = builder.AddSystem(ManipulationStation())
-    station.SetupMITClassStation()
+    station.SetupManipulationClassStation()
     station.AddManipulandFromFile(
         "drake/examples/manipulation_station/models/061_foam_brick.sdf",
         RigidTransform(RotationMatrix.Identity(), [0.6, 0, 0]))

--- a/examples/manipulation_station/joint_teleop.py
+++ b/examples/manipulation_station/joint_teleop.py
@@ -12,6 +12,7 @@ from pydrake.examples.manipulation_station import \
     (ManipulationStation, ManipulationStationHardwareInterface)
 from pydrake.geometry import ConnectDrakeVisualizer
 from pydrake.manipulation.simple_ui import JointSliders, SchunkWsgButtons
+from pydrake.math import RigidTransform, RotationMatrix
 from pydrake.multibody.parsing import Parser
 from pydrake.systems.framework import DiagramBuilder
 from pydrake.systems.analysis import Simulator
@@ -48,7 +49,10 @@ if args.hardware:
     station.Connect(wait_for_cameras=False)
 else:
     station = builder.AddSystem(ManipulationStation())
-    station.SetupDefaultStation()
+    station.SetupMITClassStation()
+    station.AddManipulandFromFile(
+        "drake/examples/manipulation_station/models/061_foam_brick.sdf",
+        RigidTransform(RotationMatrix.Identity(), [0.6, 0, 0]))
     station.Finalize()
 
     ConnectDrakeVisualizer(builder, station.get_scene_graph(),

--- a/examples/manipulation_station/manipulation_station.cc
+++ b/examples/manipulation_station/manipulation_station.cc
@@ -234,10 +234,10 @@ void ManipulationStation<T>::SetupClutterClearingStation(
 }
 
 template <typename T>
-void ManipulationStation<T>::SetupDefaultStation(
-    const IiwaCollisionModel collision_model) {
+void ManipulationStation<T>::SetupMITClassStation(
+    IiwaCollisionModel collision_model) {
   DRAKE_DEMAND(setup_ == Setup::kNone);
-  setup_ = Setup::kDefault;
+  setup_ = Setup::kMITClass;
 
   // Add the table and 80/20 workcell frame.
   {
@@ -272,21 +272,6 @@ void ManipulationStation<T>::SetupDefaultStation(
                     dz_table_top_robot_base));
     internal::AddAndWeldModelFrom(sdf_path, "cupboard", plant_->world_frame(),
                                   "cupboard_body", X_WC, plant_);
-  }
-
-  // Add the object.
-  {
-    multibody::Parser parser(plant_);
-    const auto model_index = parser.AddModelFromFile(FindResourceOrThrow(
-        "drake/examples/manipulation_station/models/061_foam_brick.sdf"));
-    const auto indices = plant_->GetBodyIndices(model_index);
-    DRAKE_DEMAND(indices.size() == 1);
-    object_ids_.push_back(indices[0]);
-
-    RigidTransform<T> X_WObject;
-    X_WObject.set_translation(Eigen::Vector3d(0.6, 0, 0));
-    X_WObject.set_rotation(RotationMatrix<T>::Identity());
-    object_poses_.push_back(X_WObject);
   }
 
   // Add the default iiwa/wsg models.
@@ -440,13 +425,22 @@ void ManipulationStation<T>::Finalize(
 
   switch (setup_) {
     case Setup::kNone:
-    case Setup::kDefault:
+    case Setup::kMITClass: {
       // Set the initial positions of the IIWA to a comfortable configuration
       // inside the workspace of the station.
       q0_iiwa << 0, 0.6, 0, -1.75, 0, 1.0, 0;
 
+      std::uniform_real_distribution<symbolic::Expression> x(0.4, 0.65),
+          y(-0.35, 0.35), z(0, 0.05);
+      const Vector3<symbolic::Expression> xyz{x(), y(), z()};
+      for (const auto body_index : object_ids_) {
+        const multibody::Body<T> &body = plant_->get_body(body_index);
+        plant_->SetFreeBodyRandomPositionDistribution(body, xyz);
+        plant_->SetFreeBodyRandomRotationDistributionToUniform(body);
+      }
       break;
-    case Setup::kClutterClearing:
+    }
+    case Setup::kClutterClearing: {
       // Set the initial positions of the IIWA to a configuration right above
       // the picking bin.
       q0_iiwa << -1.57, 0.1, 0, -1.2, 0, 1.6, 0;
@@ -455,11 +449,12 @@ void ManipulationStation<T>::Finalize(
           y(-0.8, -.55), z(0.3, 0.35);
       const Vector3<symbolic::Expression> xyz{x(), y(), z()};
       for (const auto body_index : object_ids_) {
-        const multibody::Body<T>& body = plant_->get_body(body_index);
+        const multibody::Body<T> &body = plant_->get_body(body_index);
         plant_->SetFreeBodyRandomPositionDistribution(body, xyz);
         plant_->SetFreeBodyRandomRotationDistributionToUniform(body);
       }
       break;
+    }
   }
 
   // Set the iiwa default configuration.

--- a/examples/manipulation_station/manipulation_station.cc
+++ b/examples/manipulation_station/manipulation_station.cc
@@ -234,10 +234,10 @@ void ManipulationStation<T>::SetupClutterClearingStation(
 }
 
 template <typename T>
-void ManipulationStation<T>::SetupMITClassStation(
+void ManipulationStation<T>::SetupManipulationClassStation(
     IiwaCollisionModel collision_model) {
   DRAKE_DEMAND(setup_ == Setup::kNone);
-  setup_ = Setup::kMITClass;
+  setup_ = Setup::kManipulationClass;
 
   // Add the table and 80/20 workcell frame.
   {
@@ -425,7 +425,7 @@ void ManipulationStation<T>::Finalize(
 
   switch (setup_) {
     case Setup::kNone:
-    case Setup::kMITClass: {
+    case Setup::kManipulationClass: {
       // Set the initial positions of the IIWA to a comfortable configuration
       // inside the workspace of the station.
       q0_iiwa << 0, 0.6, 0, -1.75, 0, 1.0, 0;

--- a/examples/manipulation_station/manipulation_station.h
+++ b/examples/manipulation_station/manipulation_station.h
@@ -23,7 +23,7 @@ namespace manipulation_station {
 enum class IiwaCollisionModel { kNoCollision, kBoxCollision };
 
 /// Determines which manipulation station is simulated.
-enum class Setup { kNone, kMITClass, kClutterClearing };
+enum class Setup { kNone, kManipulationClass, kClutterClearing };
 
 /// @defgroup manipulation_station_systems Manipulation Station
 /// @{
@@ -152,6 +152,12 @@ class ManipulationStation : public systems::Diagram<T> {
       const optional<const math::RigidTransformd>& X_WCameraBody = {},
       IiwaCollisionModel collision_model = IiwaCollisionModel::kNoCollision);
 
+  DRAKE_DEPRECATED("2019-09-01", "Prefer SetupManipulationClassStation.")
+  void SetupDefaultStation(
+      IiwaCollisionModel collision_model = IiwaCollisionModel::kNoCollision) {
+    SetupManipulationClassStation(collision_model);
+  }
+
   /// Adds a default iiwa, wsg, cupboard, and 80/20 frame for the MIT
   /// Intelligent Robot Manipulation class, then calls
   /// RegisterIiwaControllerModel() and RegisterWsgControllerModel() with
@@ -159,7 +165,7 @@ class ManipulationStation : public systems::Diagram<T> {
   /// @note Must be called before Finalize().
   /// @note Only one of the `Setup___()` methods should be called.
   /// @param collision_model Determines which sdf is loaded for the IIWA.
-  void SetupMITClassStation(
+  void SetupManipulationClassStation(
       IiwaCollisionModel collision_model = IiwaCollisionModel::kNoCollision);
 
   /// Sets the default State for the chosen setup.
@@ -512,8 +518,9 @@ class ManipulationStation : public systems::Diagram<T> {
   double wsg_kd_{5};
 
   // Represents the manipulation station to simulate. This gets set in the
-  // corresponding station setup function (e.g., SetupMITClassStation()), and
-  // informs how SetDefaultState() initializes the sim.
+  // corresponding station setup function (e.g.,
+  // SetupManipulationClassStation()), and informs how SetDefaultState()
+  // initializes the sim.
   Setup setup_{Setup::kNone};
 };
 

--- a/examples/manipulation_station/manipulation_station.h
+++ b/examples/manipulation_station/manipulation_station.h
@@ -23,7 +23,7 @@ namespace manipulation_station {
 enum class IiwaCollisionModel { kNoCollision, kBoxCollision };
 
 /// Determines which manipulation station is simulated.
-enum class Setup { kNone, kDefault, kClutterClearing };
+enum class Setup { kNone, kMITClass, kClutterClearing };
 
 /// @defgroup manipulation_station_systems Manipulation Station
 /// @{
@@ -153,14 +153,14 @@ class ManipulationStation : public systems::Diagram<T> {
       IiwaCollisionModel collision_model = IiwaCollisionModel::kNoCollision);
 
   // TODO(kmuhlrad): Rename SetupMITClassStation.
-  /// Adds a default iiwa, wsg, cupboard, and 8020 frame for the MIT
+  /// Adds a default iiwa, wsg, cupboard, and 80/20 frame for the MIT
   /// Intelligent Robot Manipulation class, then calls
   /// RegisterIiwaControllerModel() and RegisterWsgControllerModel() with
   /// the appropriate arguments.
   /// @note Must be called before Finalize().
   /// @note Only one of the `Setup___()` methods should be called.
   /// @param collision_model Determines which sdf is loaded for the IIWA.
-  void SetupDefaultStation(
+  void SetupMITClassStation(
       IiwaCollisionModel collision_model = IiwaCollisionModel::kNoCollision);
 
   /// Sets the default State for the chosen setup.
@@ -513,7 +513,7 @@ class ManipulationStation : public systems::Diagram<T> {
   double wsg_kd_{5};
 
   // Represents the manipulation station to simulate. This gets set in the
-  // corresponding station setup function (e.g., SetupDefaultStation()), and
+  // corresponding station setup function (e.g., SetupMITClassStation()), and
   // informs how SetDefaultState() initializes the sim.
   Setup setup_{Setup::kNone};
 };

--- a/examples/manipulation_station/manipulation_station.h
+++ b/examples/manipulation_station/manipulation_station.h
@@ -152,7 +152,6 @@ class ManipulationStation : public systems::Diagram<T> {
       const optional<const math::RigidTransformd>& X_WCameraBody = {},
       IiwaCollisionModel collision_model = IiwaCollisionModel::kNoCollision);
 
-  // TODO(kmuhlrad): Rename SetupMITClassStation.
   /// Adds a default iiwa, wsg, cupboard, and 80/20 frame for the MIT
   /// Intelligent Robot Manipulation class, then calls
   /// RegisterIiwaControllerModel() and RegisterWsgControllerModel() with

--- a/examples/manipulation_station/mock_station_simulation.cc
+++ b/examples/manipulation_station/mock_station_simulation.cc
@@ -65,7 +65,8 @@ int do_main(int argc, char* argv[]) {
                                      Eigen::Vector3d(-0.3, -0.55, 0.36)));
   } else {
     throw std::domain_error(
-        "Unrecognized station type. Options are {mit_class, clutter_clearing}.");
+        "Unrecognized station type. Options are "
+        "{mit_class, clutter_clearing}.");
   }
   // TODO(russt): Load sdf objects specified at the command line.  Requires
   // #9747.

--- a/examples/manipulation_station/mock_station_simulation.cc
+++ b/examples/manipulation_station/mock_station_simulation.cc
@@ -41,8 +41,9 @@ DEFINE_double(target_realtime_rate, 1.0,
               "Simulator::set_target_realtime_rate() for details.");
 DEFINE_double(duration, std::numeric_limits<double>::infinity(),
               "Simulation duration.");
-DEFINE_string(setup, "mit_class", "Manipulation station type to simulate. "
-                               "Can be {mit_class, clutter_clearing}");
+DEFINE_string(setup, "manipulation_class",
+              "Manipulation station type to simulate. "
+              "Can be {manipulation_class, clutter_clearing}");
 
 int do_main(int argc, char* argv[]) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
@@ -51,8 +52,8 @@ int do_main(int argc, char* argv[]) {
 
   // Create the "manipulation station".
   auto station = builder.AddSystem<ManipulationStation>();
-  if (FLAGS_setup == "mit_class") {
-    station->SetupMITClassStation();
+  if (FLAGS_setup == "manipulation_class") {
+    station->SetupManipulationClassStation();
     station->AddManipulandFromFile(
         "drake/examples/manipulation_station/models/061_foam_brick.sdf",
         math::RigidTransform<double>(math::RotationMatrix<double>::Identity(),
@@ -66,7 +67,7 @@ int do_main(int argc, char* argv[]) {
   } else {
     throw std::domain_error(
         "Unrecognized station type. Options are "
-        "{mit_class, clutter_clearing}.");
+        "{manipulation_class, clutter_clearing}.");
   }
   // TODO(russt): Load sdf objects specified at the command line.  Requires
   // #9747.

--- a/examples/manipulation_station/mock_station_simulation.cc
+++ b/examples/manipulation_station/mock_station_simulation.cc
@@ -13,6 +13,8 @@
 #include "drake/lcmt_schunk_wsg_command.hpp"
 #include "drake/lcmt_schunk_wsg_status.hpp"
 #include "drake/manipulation/schunk_wsg/schunk_wsg_lcm.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/math/rotation_matrix.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram.h"
@@ -39,8 +41,8 @@ DEFINE_double(target_realtime_rate, 1.0,
               "Simulator::set_target_realtime_rate() for details.");
 DEFINE_double(duration, std::numeric_limits<double>::infinity(),
               "Simulation duration.");
-DEFINE_string(setup, "default", "Manipulation station type to simulate. "
-                               "Can be {default, clutter_clearing}");
+DEFINE_string(setup, "mit_class", "Manipulation station type to simulate. "
+                               "Can be {mit_class, clutter_clearing}");
 
 int do_main(int argc, char* argv[]) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
@@ -49,17 +51,21 @@ int do_main(int argc, char* argv[]) {
 
   // Create the "manipulation station".
   auto station = builder.AddSystem<ManipulationStation>();
-  if (FLAGS_setup == "default") {
-    station->SetupDefaultStation();
+  if (FLAGS_setup == "mit_class") {
+    station->SetupMITClassStation();
+    station->AddManipulandFromFile(
+        "drake/examples/manipulation_station/models/061_foam_brick.sdf",
+        math::RigidTransform<double>(math::RotationMatrix<double>::Identity(),
+                                     Eigen::Vector3d(0.6, 0, 0)));
   } else if (FLAGS_setup == "clutter_clearing") {
     station->SetupClutterClearingStation();
     station->AddManipulandFromFile(
         "drake/manipulation/models/ycb/sdf/003_cracker_box.sdf",
         math::RigidTransform<double>(math::RollPitchYaw<double>(-1.57, 0, 3),
-                               Eigen::Vector3d(-0.3, -0.55, 0.36)));
+                                     Eigen::Vector3d(-0.3, -0.55, 0.36)));
   } else {
     throw std::domain_error(
-        "Unrecognized station type. Options are {default, clutter_clearing}.");
+        "Unrecognized station type. Options are {mit_class, clutter_clearing}.");
   }
   // TODO(russt): Load sdf objects specified at the command line.  Requires
   // #9747.

--- a/examples/manipulation_station/print_station_context.py
+++ b/examples/manipulation_station/print_station_context.py
@@ -6,7 +6,7 @@ contents of its (default) Context.
 from pydrake.examples.manipulation_station import ManipulationStation
 
 station = ManipulationStation()
-station.SetupMITClassStation()
+station.SetupManipulationClassStation()
 station.Finalize()
 
 context = station.CreateDefaultContext()

--- a/examples/manipulation_station/print_station_context.py
+++ b/examples/manipulation_station/print_station_context.py
@@ -6,7 +6,7 @@ contents of its (default) Context.
 from pydrake.examples.manipulation_station import ManipulationStation
 
 station = ManipulationStation()
-station.SetupDefaultStation()
+station.SetupMITClassStation()
 station.Finalize()
 
 context = station.CreateDefaultContext()

--- a/examples/manipulation_station/proof_of_life.cc
+++ b/examples/manipulation_station/proof_of_life.cc
@@ -55,7 +55,8 @@ int do_main(int argc, char* argv[]) {
                                Eigen::Vector3d(0.6, 0, 0)));
   } else {
     throw std::domain_error(
-        "Unrecognized setup option. Options are {mit_class, clutter_clearing}.");
+        "Unrecognized setup option. Options are "
+        "{mit_class, clutter_clearing}.");
   }
   station->Finalize();
 

--- a/examples/manipulation_station/proof_of_life.cc
+++ b/examples/manipulation_station/proof_of_life.cc
@@ -47,11 +47,15 @@ int do_main(int argc, char* argv[]) {
         "drake/manipulation/models/ycb/sdf/003_cracker_box.sdf",
         RigidTransform<double>(RollPitchYaw<double>(-1.57, 0, 3),
                                Eigen::Vector3d(-0.3, -0.55, 0.36)));
-  } else if (FLAGS_setup == "default") {
-    station->SetupDefaultStation();
+  } else if (FLAGS_setup == "mit_class") {
+    station->SetupMITClassStation();
+    station->AddManipulandFromFile(
+        "drake/examples/manipulation_station/models/061_foam_brick.sdf",
+        RigidTransform<double>(RotationMatrix<double>::Identity(),
+                               Eigen::Vector3d(0.6, 0, 0)));
   } else {
     throw std::domain_error(
-        "Unrecognized setup option. Options are {default, clutter_clearing}.");
+        "Unrecognized setup option. Options are {mit_class, clutter_clearing}.");
   }
   station->Finalize();
 

--- a/examples/manipulation_station/proof_of_life.cc
+++ b/examples/manipulation_station/proof_of_life.cc
@@ -47,8 +47,8 @@ int do_main(int argc, char* argv[]) {
         "drake/manipulation/models/ycb/sdf/003_cracker_box.sdf",
         RigidTransform<double>(RollPitchYaw<double>(-1.57, 0, 3),
                                Eigen::Vector3d(-0.3, -0.55, 0.36)));
-  } else if (FLAGS_setup == "mit_class") {
-    station->SetupMITClassStation();
+  } else if (FLAGS_setup == "manipulation_class") {
+    station->SetupManipulationClassStation();
     station->AddManipulandFromFile(
         "drake/examples/manipulation_station/models/061_foam_brick.sdf",
         RigidTransform<double>(RotationMatrix<double>::Identity(),
@@ -56,7 +56,7 @@ int do_main(int argc, char* argv[]) {
   } else {
     throw std::domain_error(
         "Unrecognized setup option. Options are "
-        "{mit_class, clutter_clearing}.");
+        "{manipulation_class, clutter_clearing}.");
   }
   station->Finalize();
 

--- a/examples/manipulation_station/test/manipulation_station_test.cc
+++ b/examples/manipulation_station/test/manipulation_station_test.cc
@@ -23,7 +23,7 @@ using systems::BasicVector;
 
 GTEST_TEST(ManipulationStationTest, CheckPlantBasics) {
   ManipulationStation<double> station(0.001);
-  station.SetupDefaultStation();
+  station.SetupMITClassStation();
   multibody::Parser parser(&station.get_mutable_multibody_plant(),
                            &station.get_mutable_scene_graph());
   parser.AddModelFromFile(
@@ -123,7 +123,7 @@ GTEST_TEST(ManipulationStationTest, CheckPlantBasics) {
 GTEST_TEST(ManipulationStationTest, CheckDynamics) {
   const double kTimeStep = 0.002;
   ManipulationStation<double> station(kTimeStep);
-  station.SetupDefaultStation();
+  station.SetupMITClassStation();
   station.Finalize();
 
   auto context = station.CreateDefaultContext();
@@ -192,7 +192,7 @@ GTEST_TEST(ManipulationStationTest, CheckDynamics) {
 
 GTEST_TEST(ManipulationStationTest, CheckWsg) {
   ManipulationStation<double> station(0.001);
-  station.SetupDefaultStation();
+  station.SetupMITClassStation();
   station.Finalize();
 
   auto context = station.CreateDefaultContext();
@@ -216,7 +216,7 @@ GTEST_TEST(ManipulationStationTest, CheckWsg) {
 
 GTEST_TEST(ManipulationStationTest, CheckRGBDOutputs) {
   ManipulationStation<double> station(0.001);
-  station.SetupDefaultStation();
+  station.SetupMITClassStation();
   station.Finalize();
 
   auto context = station.CreateDefaultContext();
@@ -240,7 +240,7 @@ GTEST_TEST(ManipulationStationTest, CheckRGBDOutputs) {
 
 GTEST_TEST(ManipulationStationTest, CheckCollisionVariants) {
   ManipulationStation<double> station1(0.002);
-  station1.SetupDefaultStation(IiwaCollisionModel::kNoCollision);
+  station1.SetupMITClassStation(IiwaCollisionModel::kNoCollision);
 
   // In this variant, there are collision geometries from the world and the
   // gripper, but not from the iiwa.
@@ -248,7 +248,7 @@ GTEST_TEST(ManipulationStationTest, CheckCollisionVariants) {
       station1.get_multibody_plant().num_collision_geometries();
 
   ManipulationStation<double> station2(0.002);
-  station2.SetupDefaultStation(IiwaCollisionModel::kBoxCollision);
+  station2.SetupMITClassStation(IiwaCollisionModel::kBoxCollision);
   // Check for additional collision elements (one for each link, which includes
   // the base).
   EXPECT_EQ(station2.get_multibody_plant().num_collision_geometries(),
@@ -299,7 +299,7 @@ GTEST_TEST(ManipulationStationTest, SetupClutterClearingStation) {
 GTEST_TEST(ManipulationStationTest, MultipleInstanceTest) {
   for (int i = 0; i < 20; ++i) {
     ManipulationStation<double> station;
-    station.SetupDefaultStation();
+    station.SetupMITClassStation();
     station.Finalize();
   }
 }
@@ -327,7 +327,7 @@ GTEST_TEST(ManipulationStationTest, RegisterRgbdCameraTest) {
     };
 
     ManipulationStation<double> dut;
-    dut.SetupDefaultStation();
+    dut.SetupMITClassStation();
 
     std::map<std::string, math::RigidTransform<double>> camera_poses =
         dut.GetStaticCameraPosesInWorld();
@@ -438,7 +438,7 @@ GTEST_TEST(ManipulationStationTest, ConfigureRenderer) {
   // Case: no user render engines specified; has renderer with default name.
   {
     ManipulationStation<double> dut;
-    dut.SetupDefaultStation();
+    dut.SetupMITClassStation();
     dut.Finalize();
     const auto& scene_graph = dut.get_render_scene_graph();
     EXPECT_EQ(1, scene_graph.RendererCount());
@@ -448,7 +448,7 @@ GTEST_TEST(ManipulationStationTest, ConfigureRenderer) {
   // Case: multiple user-specified render engines provided.
   {
     ManipulationStation<double> dut;
-    dut.SetupDefaultStation();
+    dut.SetupMITClassStation();
     std::map<std::string, std::unique_ptr<geometry::dev::render::RenderEngine>>
         engines;
     const std::string name1 = "engine1";

--- a/examples/manipulation_station/test/manipulation_station_test.cc
+++ b/examples/manipulation_station/test/manipulation_station_test.cc
@@ -23,7 +23,7 @@ using systems::BasicVector;
 
 GTEST_TEST(ManipulationStationTest, CheckPlantBasics) {
   ManipulationStation<double> station(0.001);
-  station.SetupMITClassStation();
+  station.SetupManipulationClassStation();
   multibody::Parser parser(&station.get_mutable_multibody_plant(),
                            &station.get_mutable_scene_graph());
   parser.AddModelFromFile(
@@ -123,7 +123,7 @@ GTEST_TEST(ManipulationStationTest, CheckPlantBasics) {
 GTEST_TEST(ManipulationStationTest, CheckDynamics) {
   const double kTimeStep = 0.002;
   ManipulationStation<double> station(kTimeStep);
-  station.SetupMITClassStation();
+  station.SetupManipulationClassStation();
   station.Finalize();
 
   auto context = station.CreateDefaultContext();
@@ -192,7 +192,7 @@ GTEST_TEST(ManipulationStationTest, CheckDynamics) {
 
 GTEST_TEST(ManipulationStationTest, CheckWsg) {
   ManipulationStation<double> station(0.001);
-  station.SetupMITClassStation();
+  station.SetupManipulationClassStation();
   station.Finalize();
 
   auto context = station.CreateDefaultContext();
@@ -216,7 +216,7 @@ GTEST_TEST(ManipulationStationTest, CheckWsg) {
 
 GTEST_TEST(ManipulationStationTest, CheckRGBDOutputs) {
   ManipulationStation<double> station(0.001);
-  station.SetupMITClassStation();
+  station.SetupManipulationClassStation();
   station.Finalize();
 
   auto context = station.CreateDefaultContext();
@@ -240,7 +240,7 @@ GTEST_TEST(ManipulationStationTest, CheckRGBDOutputs) {
 
 GTEST_TEST(ManipulationStationTest, CheckCollisionVariants) {
   ManipulationStation<double> station1(0.002);
-  station1.SetupMITClassStation(IiwaCollisionModel::kNoCollision);
+  station1.SetupManipulationClassStation(IiwaCollisionModel::kNoCollision);
 
   // In this variant, there are collision geometries from the world and the
   // gripper, but not from the iiwa.
@@ -248,7 +248,7 @@ GTEST_TEST(ManipulationStationTest, CheckCollisionVariants) {
       station1.get_multibody_plant().num_collision_geometries();
 
   ManipulationStation<double> station2(0.002);
-  station2.SetupMITClassStation(IiwaCollisionModel::kBoxCollision);
+  station2.SetupManipulationClassStation(IiwaCollisionModel::kBoxCollision);
   // Check for additional collision elements (one for each link, which includes
   // the base).
   EXPECT_EQ(station2.get_multibody_plant().num_collision_geometries(),
@@ -299,7 +299,7 @@ GTEST_TEST(ManipulationStationTest, SetupClutterClearingStation) {
 GTEST_TEST(ManipulationStationTest, MultipleInstanceTest) {
   for (int i = 0; i < 20; ++i) {
     ManipulationStation<double> station;
-    station.SetupMITClassStation();
+    station.SetupManipulationClassStation();
     station.Finalize();
   }
 }
@@ -327,7 +327,7 @@ GTEST_TEST(ManipulationStationTest, RegisterRgbdCameraTest) {
     };
 
     ManipulationStation<double> dut;
-    dut.SetupMITClassStation();
+    dut.SetupManipulationClassStation();
 
     std::map<std::string, math::RigidTransform<double>> camera_poses =
         dut.GetStaticCameraPosesInWorld();
@@ -438,7 +438,7 @@ GTEST_TEST(ManipulationStationTest, ConfigureRenderer) {
   // Case: no user render engines specified; has renderer with default name.
   {
     ManipulationStation<double> dut;
-    dut.SetupMITClassStation();
+    dut.SetupManipulationClassStation();
     dut.Finalize();
     const auto& scene_graph = dut.get_render_scene_graph();
     EXPECT_EQ(1, scene_graph.RendererCount());
@@ -448,7 +448,7 @@ GTEST_TEST(ManipulationStationTest, ConfigureRenderer) {
   // Case: multiple user-specified render engines provided.
   {
     ManipulationStation<double> dut;
-    dut.SetupMITClassStation();
+    dut.SetupManipulationClassStation();
     std::map<std::string, std::unique_ptr<geometry::dev::render::RenderEngine>>
         engines;
     const std::string name1 = "engine1";


### PR DESCRIPTION
Renames `ManipulationStation::SetupDefaultStation` to `ManipulationStation::SetupMITClassStation`.

Also removes the foam brick being automatically added to this setup so it or any other object can be added by `AddManipulandFromFile`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11541)
<!-- Reviewable:end -->
