### PR TITLE
method to add YCB objects to MIT class manipulation station

### DIFF
--- a/bindings/pydrake/examples/_manipulation_station_extra.py
+++ b/bindings/pydrake/examples/_manipulation_station_extra.py
@@ -1,45 +1,83 @@
 # See `ExecuteExtraPythonCode` in `pydrake_pybind.h` for usage details and
 # rationale.
+import numpy as np
+
 from pydrake.math import RigidTransform, RollPitchYaw
 
 
-def _xyz_rpy(xyz, rpy):
-    return RigidTransform(RollPitchYaw(rpy), xyz)
+def _xyz_rpy_deg(xyz, rpy_deg):
+    return RigidTransform(RollPitchYaw(np.asarray(rpy_deg) * np.pi / 180), xyz)
 
 
-def CreateDefaultYcbObjectList():
-    """Creates a list of (model_file, pose) pairs to add six YCB objects to a
-    ManipulationStation.
+def CreateManipulationClassYcbObjectList():
+    """Creates a list of (model_file, pose) pairs to add five YCB objects to a
+    ManipulationStation with the ManipulationClass setup.
     """
     ycb_object_pairs = []
 
-    X_WCracker = _xyz_rpy([-0.3, -0.55, 0.36], [-1.57, 0, 3])
+    # The cracker box pose
+    X_WCracker = _xyz_rpy_deg([0.35, 0.14, 0.09], [0, -90, 230])
     ycb_object_pairs.append(
         ("drake/manipulation/models/ycb/sdf/003_cracker_box.sdf", X_WCracker))
 
     # The sugar box pose.
-    X_WSugar = _xyz_rpy([-0.3, -0.7, 0.33], [1.57, 1.57, 0])
+    X_WSugar = _xyz_rpy_deg([0.28, -0.17, 0.03], [0, 90, 180])
     ycb_object_pairs.append(
         ("drake/manipulation/models/ycb/sdf/004_sugar_box.sdf", X_WSugar))
 
     # The tomato soup can pose.
-    X_WSoup = _xyz_rpy([-0.03, -0.57, 0.31], [-1.57, 0, 3.14])
+    X_WSoup = _xyz_rpy_deg([0.40, -0.07, 0.03], [-90, 0, 180])
     ycb_object_pairs.append(
         ("drake/manipulation/models/ycb/sdf/005_tomato_soup_can.sdf", X_WSoup))
 
     # The mustard bottle pose.
-    X_WMustard = _xyz_rpy([0.05, -0.66, 0.35], [-1.57, 0, 3.3])
+    X_WMustard = _xyz_rpy_deg([0.44, -0.16, 0.09], [-90, 0, 190])
+    ycb_object_pairs.append(
+        ("drake/manipulation/models/ycb/sdf/006_mustard_bottle.sdf",
+         X_WMustard))
+
+    # The potted meat can pose.
+    X_WMeat = _xyz_rpy_deg([0.35, -0.32, 0.03], [-90, 0, 145])
+    ycb_object_pairs.append(
+        ("drake/manipulation/models/ycb/sdf/010_potted_meat_can.sdf", X_WMeat))
+
+    return ycb_object_pairs
+
+
+def CreateClutterClearingYcbObjectList():
+    """Creates a list of (model_file, pose) pairs to add six YCB objects to a
+    ManipulationStation with the ClutterClearing setup.
+    """
+    ycb_object_pairs = []
+
+    # The cracker box pose.
+    X_WCracker = _xyz_rpy_deg([-0.3, -0.55, 0.36], [-90, 0, 170])
+    ycb_object_pairs.append(
+        ("drake/manipulation/models/ycb/sdf/003_cracker_box.sdf", X_WCracker))
+
+    # The sugar box pose.
+    X_WSugar = _xyz_rpy_deg([-0.3, -0.7, 0.33], [90, 90, 0])
+    ycb_object_pairs.append(
+        ("drake/manipulation/models/ycb/sdf/004_sugar_box.sdf", X_WSugar))
+
+    # The tomato soup can pose.
+    X_WSoup = _xyz_rpy_deg([-0.03, -0.57, 0.31], [-90, 0, 180])
+    ycb_object_pairs.append(
+        ("drake/manipulation/models/ycb/sdf/005_tomato_soup_can.sdf", X_WSoup))
+
+    # The mustard bottle pose.
+    X_WMustard = _xyz_rpy_deg([0.05, -0.66, 0.35], [-90, 0, 190])
     ycb_object_pairs.append(
         ("drake/manipulation/models/ycb/sdf/006_mustard_bottle.sdf",
          X_WMustard))
 
     # The gelatin box pose.
-    X_WGelatin = _xyz_rpy([-0.15, -0.62, 0.38], [-1.57, 0, 3.7])
+    X_WGelatin = _xyz_rpy_deg([-0.15, -0.62, 0.38], [-90, 0, 210])
     ycb_object_pairs.append(
         ("drake/manipulation/models/ycb/sdf/009_gelatin_box.sdf", X_WGelatin))
 
     # The potted meat can pose.
-    X_WMeat = _xyz_rpy([-0.15, -0.62, 0.3], [-1.57, 0, 2.5])
+    X_WMeat = _xyz_rpy_deg([-0.15, -0.62, 0.3], [-90, 0, 145])
     ycb_object_pairs.append(
         ("drake/manipulation/models/ycb/sdf/010_potted_meat_can.sdf", X_WMeat))
 

--- a/bindings/pydrake/examples/test/manipulation_station_test.py
+++ b/bindings/pydrake/examples/test/manipulation_station_test.py
@@ -4,7 +4,8 @@ import numpy as np
 
 from pydrake.common import FindResourceOrThrow
 from pydrake.examples.manipulation_station import (
-    CreateDefaultYcbObjectList,
+    CreateClutterClearingYcbObjectList,
+    CreateManipulationClassYcbObjectList,
     IiwaCollisionModel,
     ManipulationStation,
     ManipulationStationHardwareInterface
@@ -100,7 +101,7 @@ class TestManipulationStation(unittest.TestCase):
         num_station_bodies = (
             station.get_multibody_plant().num_model_instances())
 
-        ycb_objects = CreateDefaultYcbObjectList()
+        ycb_objects = CreateClutterClearingYcbObjectList()
         for model_file, X_WObject in ycb_objects:
             station.AddManipulandFromFile(model_file, X_WObject)
 
@@ -138,5 +139,8 @@ class TestManipulationStation(unittest.TestCase):
         self.assertEqual(len(station.get_camera_names()), 2)
 
     def test_ycb_object_creation(self):
-        ycb_objects = CreateDefaultYcbObjectList()
+        ycb_objects = CreateClutterClearingYcbObjectList()
         self.assertEqual(len(ycb_objects), 6)
+
+        ycb_objects = CreateManipulationClassYcbObjectList()
+        self.assertEqual(len(ycb_objects), 5)

--- a/examples/manipulation_station/end_effector_teleop_mouse.py
+++ b/examples/manipulation_station/end_effector_teleop_mouse.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from pydrake.examples.manipulation_station import (
     ManipulationStation, ManipulationStationHardwareInterface,
-    CreateDefaultYcbObjectList)
+    CreateClutterClearingYcbObjectList)
 from pydrake.geometry import ConnectDrakeVisualizer
 from pydrake.multibody.plant import MultibodyPlant
 from pydrake.manipulation.planner import (
@@ -294,7 +294,7 @@ def main():
                 RigidTransform(RotationMatrix.Identity(), [0.6, 0, 0]))
         elif args.setup == 'clutter_clearing':
             station.SetupClutterClearingStation()
-            ycb_objects = CreateDefaultYcbObjectList()
+            ycb_objects = CreateClutterClearingYcbObjectList()
             for model_file, X_WObject in ycb_objects:
                 station.AddManipulandFromFile(model_file, X_WObject)
 

--- a/examples/manipulation_station/end_effector_teleop_sliders.py
+++ b/examples/manipulation_station/end_effector_teleop_sliders.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from pydrake.examples.manipulation_station import (
     ManipulationStation, ManipulationStationHardwareInterface,
-    CreateDefaultYcbObjectList)
+    CreateClutterClearingYcbObjectList)
 from pydrake.geometry import ConnectDrakeVisualizer
 from pydrake.multibody.plant import MultibodyPlant
 from pydrake.manipulation.simple_ui import SchunkWsgButtons
@@ -197,7 +197,7 @@ else:
             RigidTransform(RotationMatrix.Identity(), [0.6, 0, 0]))
     elif args.setup == 'clutter_clearing':
         station.SetupClutterClearingStation()
-        ycb_objects = CreateDefaultYcbObjectList()
+        ycb_objects = CreateClutterClearingYcbObjectList()
         for model_file, X_WObject in ycb_objects:
             station.AddManipulandFromFile(model_file, X_WObject)
 


### PR DESCRIPTION
Adds a method for adding multiple YCB objects to a ManipulationStation with the cabinet setup for the MIT Class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11542)
<!-- Reviewable:end -->
