### PR TITLE
Do not build Drake as root in Docker image, use a longer workspace path, exclude more untracked files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,6 @@
 .gitignore
 .idea
 bazel-*
+gen
+tools/bazel
+user.bazelrc

--- a/setup/ubuntu/docker/bionic/Dockerfile
+++ b/setup/ubuntu/docker/bionic/Dockerfile
@@ -2,11 +2,22 @@
 # vi: set ft=dockerfile :
 
 FROM ubuntu:bionic
-WORKDIR /drake
+WORKDIR /tmp
 COPY setup/ubuntu setup/ubuntu
-RUN set -eux \
-  && export DEBIAN_FRONTEND=noninteractive \
-  && yes | setup/ubuntu/install_prereqs.sh \
-  && rm -rf /var/lib/apt/lists/*
-COPY . .
+RUN export DEBIAN_FRONTEND=noninteractive \
+  && apt-get update --quiet \
+  && apt-get install --no-install-recommends --quiet --yes \
+       passwd \
+       sudo \
+  && yes | ./setup/ubuntu/binary_distribution/install_prereqs.sh \
+  && yes | ./setup/ubuntu/source_distribution/install_prereqs.sh \
+  && rm -rf setup /var/lib/apt/lists/* \
+  && useradd --create-home --groups sudo --shell /bin/bash ubuntu \
+  && echo "ubuntu ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/ubuntu \
+  && mkdir --parents /home/ubuntu/drake \
+  && chown --recursive ubuntu:ubuntu /home/ubuntu/drake
+USER ubuntu
+WORKDIR /home/ubuntu/drake
+COPY --chown=ubuntu:ubuntu . .
+RUN ./setup/ubuntu/source_distribution/install_prereqs_user_environment.sh
 ENTRYPOINT ["./setup/ubuntu/docker/entrypoint.sh"]

--- a/setup/ubuntu/docker/bionic/Dockerfile.nvidia-cuda-9.1-devel-ubuntu18.04
+++ b/setup/ubuntu/docker/bionic/Dockerfile.nvidia-cuda-9.1-devel-ubuntu18.04
@@ -2,19 +2,28 @@
 # vi: set ft=dockerfile :
 
 FROM ubuntu:bionic
-WORKDIR /drake
+WORKDIR /tmp
 COPY setup/ubuntu setup/ubuntu
-RUN set -eux \
-  && export DEBIAN_FRONTEND=noninteractive \
-  && apt-get update \
-  && apt-get install --no-install-recommends --yes \
+RUN export DEBIAN_FRONTEND=noninteractive \
+  && apt-get update --quiet \
+  && apt-get install --no-install-recommends --quiet --yes \
        libglvnd-dev \
        nvidia-cuda-gdb \
        nvidia-cuda-toolkit \
        nvidia-driver-390 \
-  && yes | setup/ubuntu/install_prereqs.sh \
-  && rm -rf /var/lib/apt/lists/*
-COPY . .
+       passwd \
+       sudo \
+  && yes | ./setup/ubuntu/binary_distribution/install_prereqs.sh \
+  && yes | ./setup/ubuntu/source_distribution/install_prereqs.sh \
+  && rm -rf setup /var/lib/apt/lists/* \
+  && useradd --create-home --groups sudo --shell /bin/bash ubuntu \
+  && echo "ubuntu ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/ubuntu \
+  && mkdir --parents /home/ubuntu/drake \
+  && chown --recursive ubuntu:ubuntu /home/ubuntu/drake
+USER ubuntu
+WORKDIR /home/ubuntu/drake
+COPY --chown=ubuntu:ubuntu . .
+RUN ./setup/ubuntu/source_distribution/install_prereqs_user_environment.sh
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 ENV NVIDIA_REQUIRE_CUDA "cuda>=9.1"

--- a/setup/ubuntu/docker/xenial/Dockerfile
+++ b/setup/ubuntu/docker/xenial/Dockerfile
@@ -2,11 +2,22 @@
 # vi: set ft=dockerfile :
 
 FROM ubuntu:xenial
-WORKDIR /drake
+WORKDIR /tmp
 COPY setup/ubuntu setup/ubuntu
-RUN set -eux \
-  && export DEBIAN_FRONTEND=noninteractive \
-  && yes | setup/ubuntu/install_prereqs.sh \
-  && rm -rf /var/lib/apt/lists/*
-COPY . .
+RUN export DEBIAN_FRONTEND=noninteractive \
+  && apt-get update --quiet \
+  && apt-get install --no-install-recommends --quiet --yes \
+       passwd \
+       sudo \
+  && yes | ./setup/ubuntu/binary_distribution/install_prereqs.sh \
+  && yes | ./setup/ubuntu/source_distribution/install_prereqs.sh \
+  && rm -rf setup /var/lib/apt/lists/* \
+  && useradd --create-home --groups sudo --shell /bin/bash ubuntu \
+  && echo "ubuntu ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/ubuntu \
+  && mkdir --parents /home/ubuntu/drake \
+  && chown --recursive ubuntu:ubuntu /home/ubuntu/drake
+USER ubuntu
+WORKDIR /home/ubuntu/drake
+COPY --chown=ubuntu:ubuntu . .
+RUN ./setup/ubuntu/source_distribution/install_prereqs_user_environment.sh
 ENTRYPOINT ["./setup/ubuntu/docker/entrypoint.sh"]

--- a/setup/ubuntu/docker/xenial/Dockerfile.nvidia-cuda-7.5-devel-ubuntu16.04
+++ b/setup/ubuntu/docker/xenial/Dockerfile.nvidia-cuda-7.5-devel-ubuntu16.04
@@ -2,18 +2,27 @@
 # vi: set ft=dockerfile :
 
 FROM ubuntu:xenial
-WORKDIR /drake
+WORKDIR /tmp
 COPY setup/ubuntu setup/ubuntu
-RUN set -eux \
-  && export DEBIAN_FRONTEND=noninteractive \
-  && apt-get update \
-  && apt-get install --no-install-recommends --yes \
+RUN export DEBIAN_FRONTEND=noninteractive \
+  && apt-get update --quiet \
+  && apt-get install --no-install-recommends --quiet --yes \
        nvidia-384 \
        nvidia-cuda-gdb \
        nvidia-cuda-toolkit \
-  && yes | setup/ubuntu/install_prereqs.sh \
-  && rm -rf /var/lib/apt/lists/*
-COPY . .
+       passwd \
+       sudo \
+  && yes | ./setup/ubuntu/binary_distribution/install_prereqs.sh \
+  && yes | ./setup/ubuntu/source_distribution/install_prereqs.sh \
+  && rm -rf setup /var/lib/apt/lists/* \
+  && useradd --create-home --groups sudo --shell /bin/bash ubuntu \
+  && echo "ubuntu ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/ubuntu \
+  && mkdir --parents /home/ubuntu/drake \
+  && chown --recursive ubuntu:ubuntu /home/ubuntu/drake
+USER ubuntu
+WORKDIR /home/ubuntu/drake
+COPY --chown=ubuntu:ubuntu . .
+RUN ./setup/ubuntu/source_distribution/install_prereqs_user_environment.sh
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 ENV NVIDIA_REQUIRE_CUDA "cuda>=7.5"


### PR DESCRIPTION
It shouldn't really be this complicated, but this seems to get all the tests passing (modulo being able to pass `DISPLAY` correctly to the container, which depends on the host OS).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11544)
<!-- Reviewable:end -->
