### PR TITLE
[render] Mainstream RenderEngineVtk missing default texture behavior

### DIFF
--- a/geometry/render/render_engine_vtk_factory.h
+++ b/geometry/render/render_engine_vtk_factory.h
@@ -33,7 +33,7 @@ struct RenderEngineVtkParams  {
  | Group name | Property Name | Required |  Property Type  | Property Description |
  | :--------: | :-----------: | :------: | :-------------: | :------------------- |
  |    phong   | diffuse       | no¹      | Eigen::Vector4d | The rgba² value of the object surface. |
- |    phong   | diffuse_map   | no³      | std::string     | The path to a texture to apply to the geometry. |
+ |    phong   | diffuse_map   | no³      | std::string     | The path to a texture to apply to the geometry.⁴ |
 
  ¹ If no diffuse value is given, a default rgba value will be applied. The
    default color is a bright orange. This default value can be changed to a
@@ -41,6 +41,12 @@ struct RenderEngineVtkParams  {
  ² WARNING: The alpha channel is currently ignored. <br>
  ³ If no path is specified, or the file cannot be read, the diffuse rgba value
    is used (or its default).
+ ⁴ %RenderEngineVtk implements a legacy feature for associating textures with
+   _meshes_. If _no_ `(phong, diffuse_map)` property is provided (or it refers
+   to a file that doesn't exist), for a mesh named `/path/to/mesh.obj`,
+   %RenderEngineVtk will search for a file `/path/to/mesh.png` (replacing "obj"
+   with "png"). If that image exists, it will be used as a texture on the mesh
+   object.
 
  <h3>Depth images</h3>
 
@@ -50,9 +56,9 @@ struct RenderEngineVtkParams  {
 
  | Group name | Property Name |   Required    |  Property Type  | Property Description |
  | :--------: | :-----------: | :-----------: | :-------------: | :------------------- |
- |   label    | id            | configurable⁴ |  RenderLabel    | The label to render into the image. |
+ |   label    | id            | configurable⁵ |  RenderLabel    | The label to render into the image. |
 
- ⁴ %RenderEngineVtk has a default render label value that is applied to any
+ ⁵ %RenderEngineVtk has a default render label value that is applied to any
  geometry that doesn't have a (label, id) property at registration. If a value
  is not explicitly specified, %RenderEngineVtk uses RenderLabel::kUnspecified
  as this default value. It can be explicitly set upon construction. The possible

--- a/geometry/render/test/render_engine_vtk_test.cc
+++ b/geometry/render/test/render_engine_vtk_test.cc
@@ -585,6 +585,36 @@ TEST_F(RenderEngineVtkTest, TextureMeshTest) {
   // changes, the expected color would likewise have to change.
   expected_color_ = RgbaColor(ColorI{4, 241, 33}, 255);
   PerformCenterShapeTest(renderer_.get(), "Textured mesh test");
+
+  // Now confirm that the texture survives cloning.
+  unique_ptr<RenderEngine> clone = renderer_->Clone();
+  EXPECT_NE(dynamic_cast<RenderEngineVtk*>(clone.get()), nullptr);
+  PerformCenterShapeTest(dynamic_cast<RenderEngineVtk*>(clone.get()),
+                         "Cloned mesh test");
+}
+
+// Repeat the texture test but with an *implied* texture map. In other words,
+// registering a mesh "foo.obj" will look for a "foo.png" in the same folder as
+// a fall back and use it if found. But *only* as a back up. This is a
+// SHORT TERM hack to get textures in.
+TEST_F(RenderEngineVtkTest, ImpliedTextureMeshTest) {
+  Init(X_WC_, true);
+
+  auto filename =
+      FindResourceOrThrow("drake/systems/sensors/test/models/meshes/box.obj");
+  Mesh mesh(filename);
+  expected_label_ = RenderLabel(4);
+  PerceptionProperties material = simple_material();
+  renderer_->RegisterVisual(GeometryIndex(0), mesh, material,
+                            RigidTransformd::Identity(),
+                            true /* needs update */);
+  renderer_->UpdatePoses(
+      std::vector<RigidTransformd>{RigidTransformd::Identity()});
+
+  // box.png contains a single pixel with the color (4, 241, 33). If the image
+  // changes, the expected color would likewise have to change.
+  expected_color_ = RgbaColor(ColorI{4, 241, 33}, 255);
+  PerformCenterShapeTest(renderer_.get(), "Implied textured mesh test");
 }
 
 // This confirms that geometries are correctly removed from the render engine.


### PR DESCRIPTION
A feature that was added to the dev version of RenderEngineVtk hadn't made it back into the main PR. This brings it back in. Specifically, this re-introduces the behavior where obj files automatically look for a texture and apply it if it exists.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11545)
<!-- Reviewable:end -->
