### PR TITLE
[render] Add RenderEngine and PerceptionRole to GeometryState

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -155,6 +155,7 @@ drake_cc_library(
         ":internal_geometry",
         ":proximity_engine",
         ":utilities",
+        "//geometry/render:render_engine",
     ],
 )
 
@@ -329,6 +330,15 @@ drake_cc_googletest(
     deps = [
         ":geometry_state",
         "//common/test_utilities",
+        "//geometry/test_utilities:dummy_render_engine",
+    ],
+)
+
+drake_cc_googletest(
+    name = "internal_geometry_test",
+    deps = [
+        ":internal_geometry",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -19,6 +19,7 @@
 #include "drake/geometry/internal_frame.h"
 #include "drake/geometry/internal_geometry.h"
 #include "drake/geometry/proximity_engine.h"
+#include "drake/geometry/render/render_engine.h"
 #include "drake/geometry/utilities.h"
 
 namespace drake {
@@ -68,7 +69,6 @@ class GeometryState {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(GeometryState)
 
- public:
   /** An object that represents the range of FrameId values in the state. It
    is used in range-based for loops to iterate through registered frames.  */
   using FrameIdRange = internal::MapKeyRange<FrameId, internal::InternalFrame>;
@@ -196,12 +196,11 @@ class GeometryState {
    SceneGraphInspector::GetOwningSourceName(GeometryId) const.  */
   const std::string& GetOwningSourceName(GeometryId id) const;
 
-
   /** Implementation of SceneGraphInspector::GetFrameId().  */
   FrameId GetFrameId(GeometryId geometry_id) const;
 
   /** Implementation of SceneGraphInspector::GetName(GeometryId) const.  */
-  const std::string& get_name(GeometryId geometry_id) const;
+  const std::string& GetName(GeometryId geometry_id) const;
 
   /** Support for SceneGraphInspector::Reify().  */
   const Shape& GetShape(GeometryId id) const;
@@ -213,11 +212,13 @@ class GeometryState {
   const Isometry3<double>& GetPoseInParent(GeometryId geometry_id) const;
 
   /** Implementation of SceneGraphInspector::GetProximityProperties().  */
-  const ProximityProperties* get_proximity_properties(GeometryId id) const;
+  const ProximityProperties* GetProximityProperties(GeometryId id) const;
 
   /** Implementation of SceneGraphInspector::GetIllustrationProperties().  */
-  const IllustrationProperties* get_illustration_properties(
-      GeometryId id) const;
+  const IllustrationProperties* GetIllustrationProperties(GeometryId id) const;
+
+  /** Implementation of SceneGraphInspector::GetPerceptionProperties().  */
+  const PerceptionProperties* GetPerceptionProperties(GeometryId id) const;
 
   /** Implementation of SceneGraphInspector::CollisionFiltered().  */
   bool CollisionFiltered(GeometryId id1, GeometryId id2) const;
@@ -328,37 +329,21 @@ class GeometryState {
   bool IsValidGeometryName(FrameId frame_id, Role role,
                            const std::string& candidate_name) const;
 
-  /** Assigns the given geometry id the proximity role by assigning it the given
-   set of proximity properties. At this time, the geometry's name is tested for
-   uniqueness in among geometries with the proximity role.
-
-   @param source_id     The id of the geometry source that owns the geometry.
-   @param geometry_id   The geometry to assign a role.
-   @param properties    The proximity properties for this geometry.
-   @throws std::logic_error if 1. source id is invalid,
-                               2. geometry id is invalid,
-                               3. geometry id is not owned by the source id,
-                               4. geometry has already had a proximity role
-                                  assigned,
-                               5. the geometry's name is *not* unique in this
-                                  role.  */
+  /** Implementation of
+   @ref SceneGraph::AssignRole(SourceId,GeometryId, ProximityProperties)
+   "SceneGraph::AssignRole()".  */
   void AssignRole(SourceId source_id, GeometryId geometry_id,
                   ProximityProperties properties);
 
-  /** Assigns the given geometry id the illustration role by assigning it the
-   given set of proximity properties. At this time, the geometry's name is
-   tested for uniqueness in among geometries with the illustration role.
+  /** Implementation of
+   @ref SceneGraph::AssignRole(SourceId,GeometryId, PerceptionProperties)
+   "SceneGraph::AssignRole()".  */
+  void AssignRole(SourceId source_id, GeometryId geometry_id,
+                  PerceptionProperties properties);
 
-   @param source_id     The id of the geometry source that owns the geometry.
-   @param geometry_id   The geometry to assign a role.
-   @param properties    The illustration properties for this geometry.
-   @throws std::logic_error if 1. source id is invalid,
-                               2. geometry id is invalid,
-                               3. geometry id is not owned by the source id,
-                               4. geometry has already had a illustration role
-                                  assigned,
-                               5. the geometry's name is *not* unique in this
-                                  role.    */
+  /** Implementation of
+   @ref SceneGraph::AssignRole(SourceId,GeometryId, IllustrationProperties)
+   "SceneGraph::AssignRole()".  */
   void AssignRole(SourceId source_id, GeometryId geometry_id,
                   IllustrationProperties properties);
 
@@ -438,7 +423,11 @@ class GeometryState {
 
   //@}
 
-  /** @name Scalar conversion  */
+  /** Implementation support for SceneGraph::AddRenderer().  */
+  void AddRenderer(std::string name,
+                   std::unique_ptr<render::RenderEngine> renderer);
+
+  /** @name Scalar conversion */
   //@{
 
   /** Returns a deep copy of this state using the AutoDiffXd scalar with all
@@ -472,7 +461,8 @@ class GeometryState {
         frame_index_to_id_map_(source.frame_index_to_id_map_),
         dynamic_proximity_index_to_internal_map_(
             source.dynamic_proximity_index_to_internal_map_),
-        geometry_engine_(std::move(source.geometry_engine_->ToAutoDiffXd())) {
+        geometry_engine_(std::move(source.geometry_engine_->ToAutoDiffXd())),
+        render_engines_(source.render_engines_) {
     // NOTE: Can't assign Isometry3<double> to Isometry3<AutoDiff>. But we _can_
     // assign Matrix<double> to Matrix<AutoDiff>, so that's what we're doing.
     auto convert = [](const std::vector<Isometry3<U>>& s,
@@ -608,6 +598,10 @@ class GeometryState {
   void AssignRoleInternal(SourceId source_id, GeometryId geometry_id,
                           PropertyType properties, Role role);
 
+  // Retrieves the requested renderer (if supported), throwing otherwise.
+  const render::RenderEngine& GetRenderEngineOrThrow(
+      const std::string& renderer_name) const;
+
   // NOTE: If adding a member it is important that it be _explicitly_ copied
   // in the converting copy constructor and likewise tested in the unit test
   // for that constructor.
@@ -721,6 +715,10 @@ class GeometryState {
   // rely on temporal coherency to speed up the calculations. Thus we persist
   // and copy it.
   copyable_unique_ptr<internal::ProximityEngine<T>> geometry_engine_;
+
+  // The collection of all registered renderers.
+  std::unordered_map<std::string, copyable_unique_ptr<render::RenderEngine>>
+      render_engines_;
 };
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -293,7 +293,7 @@ class SceneGraphInspector {
    @throws std::logic_error if `id` does not map to a registered geometry.  */
   const std::string& GetName(GeometryId id) const {
     DRAKE_DEMAND(state_ != nullptr);
-    return state_->get_name(id);
+    return state_->GetName(id);
   }
 
   /** Returns the shape specified for the geometry with the given `id`. In order
@@ -332,7 +332,7 @@ class SceneGraphInspector {
   const ProximityProperties* GetProximityProperties(
       GeometryId id) const {
     DRAKE_DEMAND(state_ != nullptr);
-    return state_->get_proximity_properties(id);
+    return state_->GetProximityProperties(id);
   }
 
   /** Returns a pointer to the const illustration properties of the geometry
@@ -344,7 +344,19 @@ class SceneGraphInspector {
   const IllustrationProperties* GetIllustrationProperties(
       GeometryId id) const {
     DRAKE_DEMAND(state_ != nullptr);
-    return state_->get_illustration_properties(id);
+    return state_->GetIllustrationProperties(id);
+  }
+
+  /** Returns a pointer to the const perception properties of the geometry
+   with the given `id`.
+   @param id   The identifier for the queried geometry.
+   @return A pointer to the properties (or nullptr if there are no such
+           properties).
+   @throws std::logic_error if `id` does not map to a registered geometry.  */
+  const PerceptionProperties* GetPerceptionProperties(
+      GeometryId id) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->GetPerceptionProperties(id);
   }
 
   /** Reports true if the two geometries with given ids `id1` and `id2`, define

--- a/geometry/test/internal_geometry_test.cc
+++ b/geometry/test/internal_geometry_test.cc
@@ -1,0 +1,56 @@
+#include "drake/geometry/internal_geometry.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace {
+
+GTEST_TEST(InternalGeometryTest, RenderIndexAccess) {
+  InternalGeometry geometry;
+
+  const std::string renderer_name{"valid"};
+  EXPECT_FALSE(geometry.render_index(renderer_name));
+  RenderIndex index(2);
+  EXPECT_NO_THROW(geometry.set_render_index(renderer_name, index));
+  ASSERT_TRUE(geometry.render_index(renderer_name));
+  EXPECT_EQ(geometry.render_index(renderer_name), index);
+}
+
+// Confirms that redundantly setting properties causes an exception to be
+// thrown.
+GTEST_TEST(InternalGeometryTest, RedundantPropertyAssignment) {
+  InternalGeometry geometry;
+
+  EXPECT_FALSE(geometry.has_proximity_role());
+  EXPECT_NO_THROW(geometry.SetRole(ProximityProperties()));
+  EXPECT_TRUE(geometry.has_proximity_role());
+  DRAKE_EXPECT_THROWS_MESSAGE(geometry.SetRole(ProximityProperties()),
+                              std::logic_error,
+                              "Geometry already has proximity role assigned");
+  EXPECT_TRUE(geometry.has_proximity_role());
+
+  EXPECT_FALSE(geometry.has_illustration_role());
+  EXPECT_NO_THROW(geometry.SetRole(IllustrationProperties()));
+  EXPECT_TRUE(geometry.has_illustration_role());
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      geometry.SetRole(IllustrationProperties()), std::logic_error,
+      "Geometry already has illustration role assigned");
+  EXPECT_TRUE(geometry.has_illustration_role());
+
+  EXPECT_FALSE(geometry.has_perception_role());
+  EXPECT_NO_THROW(geometry.SetRole(PerceptionProperties()));
+  EXPECT_TRUE(geometry.has_perception_role());
+  DRAKE_EXPECT_THROWS_MESSAGE(geometry.SetRole(PerceptionProperties()),
+                              std::logic_error,
+                              "Geometry already has perception role assigned");
+  EXPECT_TRUE(geometry.has_perception_role());
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/test/scene_graph_inspector_test.cc
+++ b/geometry/test/scene_graph_inspector_test.cc
@@ -87,6 +87,7 @@ GTEST_TEST(SceneGraphInspector, ExerciseEverything) {
   inspector.X_FG(geometry_id);
   inspector.GetProximityProperties(geometry_id);
   inspector.GetIllustrationProperties(geometry_id);
+  inspector.GetPerceptionProperties(geometry_id);
   // Register an *additional* geometry and assign proximity properties to both
   // to prevent an exception being thrown.
   const GeometryId geometry_id2 =

--- a/geometry/test_utilities/dummy_render_engine.h
+++ b/geometry/test_utilities/dummy_render_engine.h
@@ -74,6 +74,13 @@ class DummyRenderEngine final : public render::RenderEngine {
     return PerceptionProperties();
   }
 
+  /** Resets all state to the initially constructed state.  */
+  void reset() {
+    updated_indices_.clear();
+    moved_index_ = nullopt;
+    register_count_ = 0;
+  }
+
   /** Reports the number of geometries that have been _accepted_ in
    registration.  */
   int num_registered() const { return register_count_; }


### PR DESCRIPTION
This is step 1 of 3 to integrate RenderEngines with the SceneGraph API.

1. Provides the *internal* interface (via GeometryState) for:
    a. adding a render engine instance
    b. assigning perception properties to geometry instances
2. Extend SceneGraphInspector to query assigned perception properties.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11553)
<!-- Reviewable:end -->
