### PR TITLE
Implements a tetrahedral mesh generator for the unit sphere.

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -17,6 +17,7 @@ drake_cc_package_library(
         ":distance_to_point",
         ":distance_to_point_with_gradient",
         ":distance_to_shape",
+        ":make_unit_sphere_mesh",
         ":mesh_field",
         ":proximity_utilities",
         ":volume_mesh",
@@ -101,6 +102,15 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "make_unit_sphere_mesh",
+    hdrs = ["make_unit_sphere_mesh.h"],
+    deps = [
+        "//common:essential",
+        "//geometry/proximity:volume_mesh",
+    ],
+)
+
+drake_cc_library(
     name = "volume_mesh",
     srcs = [
         "volume_mesh.cc",
@@ -171,6 +181,13 @@ drake_cc_googletest(
     name = "mesh_field_linear_test",
     deps = [
         "//geometry/proximity:mesh_field",
+    ],
+)
+
+drake_cc_googletest(
+    name = "make_unit_sphere_mesh_test",
+    deps = [
+        ":make_unit_sphere_mesh",
     ],
 )
 

--- a/geometry/proximity/make_unit_sphere_mesh.h
+++ b/geometry/proximity/make_unit_sphere_mesh.h
@@ -1,0 +1,248 @@
+#pragma once
+
+#include <algorithm>
+#include <utility>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/geometry/proximity/volume_mesh.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+// Helper methods for MakeUnitSphereMesh().
+#ifndef DRAKE_DOXYGEN_CXX
+// Refines a tetrahedron defined by vertices A, B, C, and D
+// into 8 new tetrahedra. Vector is_boundary stores `true` at entries 0, 1, 2,
+// and 3 (corresponding to A, B, C, and D, respectively) for those vertices
+// that lie on the surface of the unit sphere. If an edge is formed by two
+// vertices that lie on the sphere, the new vertex created by splitting this
+// edge in half is projected so that it lies on the surface of the sphere as
+// well.
+// The return is a pair with: 1) a VolumeMesh including the original and
+// new vertices, and 2) a vector of booleans that, similar to is_boundary,
+// stores `true` iff the corresponding vertex on the new mesh lies on the
+// surface of the sphere.
+template <typename T>
+std::pair<VolumeMesh<T>, std::vector<bool>> RefineTetrahdron(
+    const Vector3<T>& A, const Vector3<T>& B, const Vector3<T>& C,
+    const Vector3<T>& D, const std::vector<bool>& is_boundary) {
+  // Aliases to the indexes, just to ease writing the code.
+  // That is, index a corresponds to vertex A, index b to vertex B, etc.
+  const VolumeVertexIndex a(0), b(1), c(2), d(3), e(4), f(5), g(6), h(7), i(8),
+      j(9);
+
+  // Each tetrahedra is split into 8 sub-tetrahedra.
+  std::vector<VolumeElement> tetrahedra;
+  std::vector<VolumeVertex<T>> vertices;  // Original 4 plus 6, one per edge.
+  Vector3<T> E = (A + B) / 2.0;
+  Vector3<T> F = (A + C) / 2.0;
+  Vector3<T> G = (A + D) / 2.0;
+  Vector3<T> H = (B + C) / 2.0;
+  Vector3<T> I = (B + D) / 2.0;
+  Vector3<T> J = (C + D) / 2.0;
+
+  // Mark which vertices belong to the boundary.
+  std::vector<bool> split_vertex_is_boundary(10);
+  split_vertex_is_boundary[a] = is_boundary[a];
+  split_vertex_is_boundary[b] = is_boundary[b];
+  split_vertex_is_boundary[c] = is_boundary[c];
+  split_vertex_is_boundary[d] = is_boundary[d];
+  split_vertex_is_boundary[e] = is_boundary[a] && is_boundary[b];
+  split_vertex_is_boundary[f] = is_boundary[a] && is_boundary[c];
+  split_vertex_is_boundary[g] = is_boundary[a] && is_boundary[d];
+  split_vertex_is_boundary[h] = is_boundary[b] && is_boundary[c];
+  split_vertex_is_boundary[i] = is_boundary[b] && is_boundary[d];
+  split_vertex_is_boundary[j] = is_boundary[c] && is_boundary[d];
+
+  //  Project boundary vertices onto the surface of the sphere.
+  if (split_vertex_is_boundary[e]) E.normalize();
+  if (split_vertex_is_boundary[f]) F.normalize();
+  if (split_vertex_is_boundary[g]) G.normalize();
+  if (split_vertex_is_boundary[h]) H.normalize();
+  if (split_vertex_is_boundary[i]) I.normalize();
+  if (split_vertex_is_boundary[j]) J.normalize();
+
+  // Place the new vertices in the vector of vertices.
+  vertices.emplace_back(A);
+  vertices.emplace_back(B);
+  vertices.emplace_back(C);
+  vertices.emplace_back(D);
+  vertices.emplace_back(E);
+  vertices.emplace_back(F);
+  vertices.emplace_back(G);
+  vertices.emplace_back(H);
+  vertices.emplace_back(I);
+  vertices.emplace_back(J);
+
+  // The four tetrahedra at the corners.
+  tetrahedra.emplace_back(a, e, f, g);
+  tetrahedra.emplace_back(b, h, e, i);
+  tetrahedra.emplace_back(f, h, c, j);
+  tetrahedra.emplace_back(j, g, i, d);
+
+  // TODO(amcastro-tri): Split along EJ, FI and GH and choose the partition with
+  // best quality factor as described in [Everett, 1997], see the class's
+  // documentation.
+  // Currently we arbitrarily choose to partition along the GH edge.
+  auto split_along_gh = [&]() {
+    std::vector<VolumeElement> inner_tets;
+    inner_tets.emplace_back(g, h, i, e);
+    inner_tets.emplace_back(g, f, h, e);
+    inner_tets.emplace_back(g, i, h, j);
+    inner_tets.emplace_back(g, h, f, j);
+    return inner_tets;
+  };
+
+  // Split the internal octahedron EFGHIJ into four sub-tetrahedra.
+  auto inner_tets = split_along_gh();
+  std::copy(inner_tets.begin(), inner_tets.end(), back_inserter(tetrahedra));
+
+  return std::make_pair(
+      VolumeMesh<T>(std::move(tetrahedra), std::move(vertices)),
+      split_vertex_is_boundary);
+}
+
+// Makes the initial mesh for refinement_level = 0.
+// It creates an octahedron by placing its six vertices on the surface of the
+// unit sphere and an additional vertex at the origin. The volume is then
+// tessellated into eight tetrahedra.
+// The additional vector of booleans indicates `true` if the corresponding
+// vertex lies on the surface of the sphere.
+template <typename T>
+std::pair<VolumeMesh<T>, std::vector<bool>> MakeSphereMeshLevel0() {
+  std::vector<VolumeElement> tetrahedra;
+  std::vector<VolumeVertex<T>> vertices;
+
+  // Level "0" consists of the octahedron with vertices on the surface of the
+  // a sphere of unit radius.
+  vertices.emplace_back(0.0, 0.0, 0.0);
+  vertices.emplace_back(1.0, 0.0, 0.0);
+  vertices.emplace_back(0.0, 1.0, 0.0);
+  vertices.emplace_back(-1.0, 0.0, 0.0);
+  vertices.emplace_back(0.0, -1.0, 0.0);
+  vertices.emplace_back(0.0, 0.0, 1.0);
+  vertices.emplace_back(0.0, 0.0, -1.0);
+
+  // Create tetrahedra. The convention is that the first three vertices define
+  // the "base" of the tetrahedron with its right-handed normal vector
+  // pointing towards the outside. The fourth vertex is on the "negative" side
+  // of the plane defined by this normal.
+
+  using V = VolumeVertexIndex;
+
+  // Top tetrahedra.
+  tetrahedra.emplace_back(V(0), V(2), V(1), V(5));
+  tetrahedra.emplace_back(V(0), V(3), V(2), V(5));
+  tetrahedra.emplace_back(V(0), V(4), V(3), V(5));
+  tetrahedra.emplace_back(V(0), V(1), V(4), V(5));
+
+  // Bottom tetrahedra.
+  tetrahedra.emplace_back(V(0), V(1), V(2), V(6));
+  tetrahedra.emplace_back(V(0), V(2), V(3), V(6));
+  tetrahedra.emplace_back(V(0), V(3), V(4), V(6));
+  tetrahedra.emplace_back(V(0), V(4), V(1), V(6));
+
+  // Indicate what vertices are on the surface of the sphere.
+  // All vertices are boundaries but the first one at (0, 0, 0).
+  std::vector<bool> is_boundary(7, true);
+  is_boundary[0] = false;
+
+  return std::make_pair(
+      VolumeMesh<T>(std::move(tetrahedra), std::move(vertices)), is_boundary);
+}
+
+// Splits a mesh by calling RefineTetrahdron() on each tetrahedron of `mesh`.
+// `is_boundary` is a vector with as many entries as vertices in the mesh
+// indicating if the vertex at the same index lies on the boundary of the
+// sphere.
+template <typename T>
+std::pair<VolumeMesh<T>, std::vector<bool>> RefineMesh(
+    const VolumeMesh<T>& mesh, const std::vector<bool>& is_boundary) {
+  std::vector<VolumeElement> split_mesh_tetrahedra;
+  std::vector<VolumeVertex<T>> split_mesh_vertices;
+  std::vector<bool> split_is_boundary;
+  for (const auto& t : mesh.tetrahedra()) {
+    const auto& A = mesh.vertex(t.vertex(0)).r_MV();
+    const auto& B = mesh.vertex(t.vertex(1)).r_MV();
+    const auto& C = mesh.vertex(t.vertex(2)).r_MV();
+    const auto& D = mesh.vertex(t.vertex(3)).r_MV();
+
+    // Vector that flags A, B, C and D as boundary vertices or not.
+    std::vector<bool> tet_is_boundary;
+    tet_is_boundary.push_back(is_boundary[t.vertex(0)]);
+    tet_is_boundary.push_back(is_boundary[t.vertex(1)]);
+    tet_is_boundary.push_back(is_boundary[t.vertex(2)]);
+    tet_is_boundary.push_back(is_boundary[t.vertex(3)]);
+
+    const std::pair<VolumeMesh<T>, std::vector<bool>> split_pair =
+        RefineTetrahdron<T>(A, B, C, D, tet_is_boundary);
+    const VolumeMesh<T>& split_tet = split_pair.first;
+    const std::vector<bool>& split_tet_is_boundary = split_pair.second;
+    const int num_vertices = static_cast<int>(split_mesh_vertices.size());
+
+    std::copy(split_tet.vertices().begin(), split_tet.vertices().end(),
+              back_inserter(split_mesh_vertices));
+    std::copy(split_tet_is_boundary.begin(), split_tet_is_boundary.end(),
+              back_inserter(split_is_boundary));
+
+    // Add the new tets. Offset the vertex indexes to account for the indexing
+    // within the full mesh.
+    std::transform(split_tet.tetrahedra().begin(), split_tet.tetrahedra().end(),
+                   back_inserter(split_mesh_tetrahedra),
+                   [num_vertices](const VolumeElement& tet) {
+                     using V = VolumeVertexIndex;
+                     return VolumeElement(V(tet.vertex(0) + num_vertices),
+                                          V(tet.vertex(1) + num_vertices),
+                                          V(tet.vertex(2) + num_vertices),
+                                          V(tet.vertex(3) + num_vertices));
+                   });
+  }
+
+  return std::make_pair(VolumeMesh<T>(std::move(split_mesh_tetrahedra),
+                                      std::move(split_mesh_vertices)),
+                        split_is_boundary);
+}
+#endif
+
+/// This method implements a variant of the generator described in
+/// [Everett, 1997]. It is based on a recursive refinement of an initial
+/// (refinement_level = 0) coarse mesh representation of the unit sphere. The
+/// initial mesh discretizes an octahedron with its six vertices on the
+/// surface of the unit sphere and a seventh vertex at the origin to form a
+/// volume tessellation consisting of eight tetrahedra. At each refinement
+/// level each tetrahedron is split into eight new tetrahedra by splitting
+/// each edge in half. When splitting an edge formed by vertices on the
+/// surface of the sphere, the newly created vertex is projected back onto the
+/// surface of the sphere.
+/// See [Jakub Velímský, 2010] for additional implementation details and a
+/// series of very useful schematics.
+///
+/// @throws std::exception if refinement_level is negative.
+///
+/// [Everett, 1997]  Everett, M.E., 1997. A three-dimensional spherical mesh
+/// generator. Geophysical Journal International, 130(1), pp.193-200.
+/// [Jakub Velímský, 2010] GESTIKULATOR Generator of a tetrahedral mesh on a
+/// sphere. Department of Geophysics, Charles University in Prague.
+template <typename T>
+VolumeMesh<T> MakeUnitSphereMesh(int refinement_level) {
+  DRAKE_THROW_UNLESS(refinement_level >= 0);
+  std::pair<VolumeMesh<T>, std::vector<bool>> pair = MakeSphereMeshLevel0<T>();
+  VolumeMesh<T>& mesh = pair.first;
+  std::vector<bool>& is_boundary = pair.second;
+
+  for (int level = 1; level <= refinement_level; ++level) {
+    auto split_pair = RefineMesh<T>(mesh, is_boundary);
+    mesh = split_pair.first;
+    is_boundary = split_pair.second;
+    DRAKE_DEMAND(mesh.vertices().size() == is_boundary.size());
+  }
+
+  return std::move(mesh);
+}
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/test/make_unit_sphere_mesh_test.cc
+++ b/geometry/proximity/test/make_unit_sphere_mesh_test.cc
@@ -1,0 +1,96 @@
+#include "drake/geometry/proximity/make_unit_sphere_mesh.h"
+
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace {
+
+// TODO(amcastro-tri): The unit tests below were designed with the idea in mind
+// that if a typical bug is present (for instance wrong tetrahedron sign
+// convention, missing tetrahedra or faulty vertices computation) they would
+// fail. However, from a purist point of view on unit testing, a variety of
+// tests are missing. To mention a few:
+//   1. Level 0 tessellation should have all of its properties confirmed:
+//      tetrahedra sign convention, positive volume, sphere coverage.
+//   2. Is level 0 correct in that there are no overlappong tetrahedra?
+//   3. The refinement process preserves the tetrahedron sign convention.
+//   4. Confirm that the k-level refinement of a tet spans the same volume of
+//      the k-1-level (if there are no boundary vertices).
+//
+// N.B. All of these were confirmed during the development however they did not
+// make it into a clean unit test.
+
+// Computes the volume of a tetrahedron given the four vertices that define it.
+// The convention is that the first three vertices a, b, c define a triangle
+// with its right-handed normal pointing towards the outside of the tetrahedra.
+// The fourth vertex, d, is on the negative side of the plane defined by a, b,
+// c. With this convention, the computed volume will be positive, otherwise
+// negative.
+double CalcTetrahedronVolume(const Vector3<double>& a, const Vector3<double>& b,
+                             const Vector3<double>& c,
+                             const Vector3<double>& d) {
+  return (a - d).dot((b - d).cross(c - d)) / 6.0;
+}
+
+// Computes the total volume of a VolumeMesh by summing up the contribution
+// of each tetrahedron.
+double CalcTetrahedronMeshVolume(const VolumeMesh<double>& mesh) {
+  const std::vector<VolumeVertex<double>>& vertices = mesh.vertices();
+  const std::vector<VolumeElement>& tetrahedra = mesh.tetrahedra();
+  double volume = 0.0;
+  for (const auto& t : tetrahedra) {
+    volume += CalcTetrahedronVolume(
+        vertices[t.vertex(0)].r_MV(), vertices[t.vertex(1)].r_MV(),
+        vertices[t.vertex(2)].r_MV(), vertices[t.vertex(3)].r_MV());
+  }
+  return volume;
+}
+
+// This test verifies that the volume of the tessellated sphere converges to the
+// exact value as the tessellation is refined.
+GTEST_TEST(MakeSphereMesh, VolumeConvergence) {
+  const double kTolerance = 5.0 * std::numeric_limits<double>::epsilon();
+
+  auto mesh0 = MakeUnitSphereMesh<double>(0);
+  const double volume0 = CalcTetrahedronMeshVolume(mesh0);
+  const double sphere_volume = 4.0 / 3.0 * M_PI;
+  // Initial error in the computation of the volume.
+  double prev_error = sphere_volume - volume0;
+
+  // The volume of a pyramid with base of size l x w and height h is V = lwh/3.
+  // For our level zero octahedron we have two pyramids with sizes
+  // l = w = sqrt(2) and height = 1.0. Thus its volume is 4/3.
+  const double expected_volume = 4.0 / 3.0;
+
+  EXPECT_NEAR(volume0, expected_volume, kTolerance);
+
+  for (int level = 1; level < 6; ++level) {
+    auto mesh = MakeUnitSphereMesh<double>(level);
+
+    // Verify correct size.
+    const size_t num_tetrahedra = std::pow(8, level + 1);
+    EXPECT_EQ(mesh.tetrahedra().size(), num_tetrahedra);
+
+    // Verify that the volume monotonically converges towards the exact volume
+    // of the unit radius sphere.
+    const double volume = CalcTetrahedronMeshVolume(mesh);
+    const double error = sphere_volume - volume;
+
+    EXPECT_GT(error, 0.0);
+    EXPECT_LT(error, prev_error);
+
+    // Always compare against last computed error to show monotonic convergence.
+    prev_error = error;
+  }
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/volume_mesh.h
+++ b/geometry/proximity/volume_mesh.h
@@ -39,6 +39,12 @@ class VolumeVertex {
   explicit VolumeVertex(const Vector3<T>& r_MV)
       : r_MV_(r_MV) {}
 
+  /** Constructs VolumeVertex from the xyz components of a point V in a frame
+   M.
+   */
+  VolumeVertex(const T& Vx_M, const T& Vy_M, const T& Vz_M)
+      : r_MV_(Vx_M, Vy_M, Vz_M) {}
+
   /** Returns the displacement vector from the origin of M's frame to this
     vertex, expressed in M's frame.
    */
@@ -97,7 +103,7 @@ class VolumeElement {
 template <class T>
 class VolumeMesh {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(VolumeMesh)
+  DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN(VolumeMesh)
 
   /**
    @name Mesh type traits
@@ -126,6 +132,12 @@ class VolumeMesh {
   */
   using Barycentric = Vector<T, kDim + 1>;
 
+  //@}
+
+  VolumeMesh(std::vector<VolumeElement>&& elements,
+             std::vector<VolumeVertex<T>>&& vertices)
+      : elements_(std::move(elements)), vertices_(std::move(vertices)) {}
+
   const VolumeElement& element(ElementIndex e) const {
     DRAKE_DEMAND(0 <= e && num_elements());
     return elements_[e];
@@ -140,11 +152,9 @@ class VolumeMesh {
     return vertices_[v];
   }
 
-  //@}
+  const std::vector<VolumeVertex<T>>& vertices() const { return vertices_; }
 
-  VolumeMesh(std::vector<VolumeElement>&& elements,
-             std::vector<VolumeVertex<T>>&& vertices)
-      : elements_(std::move(elements)), vertices_(std::move(vertices)) {}
+  const std::vector<VolumeElement>& tetrahedra() const { return elements_; }
 
   /** Returns the number of tetrahedral elements in the mesh.
    */
@@ -160,6 +170,7 @@ class VolumeMesh {
   // The vertices that are shared between the tetrahedral elements.
   std::vector<VolumeVertex<T>> vertices_;
 };
+DRAKE_DEFINE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN_T(VolumeMesh)
 
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
     class VolumeMesh)


### PR DESCRIPTION
Resolves #11520. Towards #11523

The figure below shows a slice of the generated mesh using four levels of refinement. The histogram on the right shows the quality of the mesh measured as the ratio of the longest to shortest edge for each tetrahedron. 

![sphere_level4](https://user-images.githubusercontent.com/17601461/58594959-206ad900-823d-11e9-8eba-5453e5596a4b.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11555)
<!-- Reviewable:end -->
