### PR TITLE
Implements CalcZeroLevelSetInMeshDomain().

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -14,6 +14,7 @@ drake_cc_package_library(
     name = "proximity",
     deps = [
         ":collision_filter_legacy",
+        ":contact_surface_calculator",
         ":distance_to_point",
         ":distance_to_point_with_gradient",
         ":distance_to_shape",
@@ -127,6 +128,20 @@ drake_cc_library(
     ],
 )
 
+drake_cc_library(
+    name = "contact_surface_calculator",
+    hdrs = [
+        "contact_surface_calculator.h",
+    ],
+    deps = [
+        "//common:autodiff",
+        "//common:essential",
+        "//geometry/proximity:volume_mesh",
+        "//geometry/query_results:contact_surface",
+        "//math:geometric_transform",
+    ],
+)
+
 drake_cc_googletest(
     name = "distance_to_point_test",
     deps = [
@@ -160,6 +175,17 @@ drake_cc_googletest(
     deps = [
         "//geometry:geometry_ids",
         "//geometry/query_results:contact_surface",
+    ],
+)
+
+drake_cc_googletest(
+    name = "contact_surface_calculator_test",
+    deps = [
+        ":contact_surface_calculator",
+        ":make_unit_sphere_mesh",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+        "//math",
     ],
 )
 

--- a/geometry/proximity/contact_surface_calculator.h
+++ b/geometry/proximity/contact_surface_calculator.h
@@ -1,0 +1,243 @@
+#pragma once
+
+#include <array>
+#include <limits>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/type_safe_index.h"
+#include "drake/geometry/proximity/surface_mesh.h"
+#include "drake/geometry/proximity/volume_mesh.h"
+#include "drake/geometry/query_results/contact_surface.h"
+#include "drake/math/rigid_transform.h"
+
+namespace drake {
+namespace geometry {
+#ifndef DRAKE_DOXYGEN_CXX
+namespace internal {
+// This table essentially assigns an index to each edge in the tetrahedra. Each
+// edge is represented by its pair of vertex indexes.
+using Edge = std::pair<int, int>;
+const std::array<Edge, 6> kEdges = {
+    Edge{0, 1}, Edge{1, 2}, Edge{2, 0},   // base formed by vertices 0, 1, 2.
+    Edge{0, 3}, Edge{1, 3}, Edge{2, 3}};  // pyramid with top at node 3.
+
+// Marching tetrahedra table. Each entry in this table has an index assigned by
+// encoding the sign of each vertex in binary. Therefore, with four vertices and
+// two possible signs, we have a total of 16 entries.
+// We encode the table indexes in binary so that a "1" corresponds to a
+// positive value at that vertex and conversely "0" corresponds to a
+// negative value. The least significan bit, bit 0, maps to vertex 0 while the
+// most significant bit, bit 3, maps to vertex 3.
+// Each entry stores a vector of edges. Based on the sign of the level set,
+// these edges are the ones with a zero level set crossing. Edges are numbered
+// according to table kEdges.
+// See Figure 3 in [Bloomenthal, 1994] cited in the documentation for
+// CalcZeroLevelSetInMeshDomain() for details on the entries in this table.
+// We changed the order of the edges here so that they always form a closed
+// boundary oriented according to the right-hand rule around a vector from the
+// negative side to the positive side. The accompanying unit tests verify this.
+using EdgeIndex = int;
+const std::array<std::vector<EdgeIndex>, 16> kMarchingTetsTable = {
+        {{},           /* 0000 */
+         {0, 2, 3},    /* 0001 */
+         {0, 4, 1},    /* 0010 */
+         {1, 2, 3, 4}, /* 0011 */
+         {1, 5, 2},    /* 0100 */
+         {1, 5, 3, 0}, /* 0101 */
+         {4, 5, 2, 0}, /* 0110 */
+         {3, 4, 5},    /* 0111 */
+         {3, 5, 4},    /* 1000 */
+         {0, 2, 5, 4}, /* 1001 */
+         {0, 3, 5, 1}, /* 1010 */
+         {1, 2, 5},    /* 1011 */
+         {4, 3, 2, 1}, /* 1100 */
+         {0, 1, 4},    /* 1101 */
+         {0, 3, 2},    /* 1110 */
+         {}            /* 1111 */}};
+
+// Given a tetrahedron defined by the four vertices in `tet_vertices_N` and
+// a corresponding set of level set values at each vertex in `phi_N`, this
+// method computes a triangulation of the zero level set surface within the
+// domain of the tetrahedra.
+// On return this method adds the new vertices and faces of the triangulation
+// into `vertices` and `faces` respectively and returns the number of vertices
+// added.
+// The first three "vertices" define the first face of the tetrahedra, with
+// its right-handed normal pointing towards the outside.
+// The last vertex is on the "negative side" of the first face.
+//
+// @param[in] tet_vertices_N Vertices defining the tetrahedron. The first
+// three vertices define the first face of the tetrahedra, with its
+// right-handed normal pointing towards the outside. The last vertex is on the
+// "negative side" of the first face.
+// @param[in] phi_N The level set function evaluated at each of the four
+// vertices in `tet_vertices_N`, in the same order.
+// @param[out] vertices Adds the new vertices into `vertices`.
+// @param[out] faces Adds the new faces into `faces`.
+// @return The number of vertices added.
+// @note   The convention used by this private method is different from the
+// one used in VolumeMesh.
+// TODO(amcastro-tri): fix the case for when the zero level set is right in the
+// middle between two adjacent faces, which might lead to double counting.
+template <typename T>
+int IntersectTetWithLevelSet(const std::array<Vector3<T>, 4>& tet_vertices_N,
+                             const Vector4<T>& phi_N,
+                             std::vector<SurfaceVertex<T>>* vertices,
+                             std::vector<SurfaceFace>* faces) {
+  DRAKE_ASSERT(vertices != nullptr);
+  DRAKE_ASSERT(faces != nullptr);
+
+  const double kZeroTolerance = 20 * std::numeric_limits<double>::epsilon();
+  using std::abs;
+  int num_zeros = 0;
+  for (int i = 0; i < 4; ++i)
+    if (abs(phi_N[i]) < kZeroTolerance) num_zeros++;
+  if (num_zeros >= 3) {
+    throw std::logic_error(
+        "One or more faces of this tetrahedron are close to being a zero "
+        "crossing level set, within machine precision. This situation could "
+        "lead to double counting an interface between two neighboring "
+        "tetrahedra. Often changing your initial conditions will mitigate this "
+        "problem.");
+  }
+
+  // The current number of vertices before new are added.
+  const int num_vertices = vertices->size();
+
+  // Find out the marching tetrahedra case. We encode the case number in binary.
+  // If a vertex is positive, we assign a "1", otherwise "0". We then form the
+  // four bits number "binary_code" which in decimal leads to the index entry in
+  // the marching tetrahedra table (from 0 to 15).
+  using Array4i = Eigen::Array<int, 4, 1>;
+  const Array4i binary_code = (phi_N.array() > 0.0).template cast<int>();
+  const Array4i powers_of_two = Vector4<int>(1, 2, 4, 8).array();
+  const int case_index = (binary_code * powers_of_two).sum();
+
+  const std::vector<int>& intersected_edges = kMarchingTetsTable[case_index];
+  const int num_intersections = intersected_edges.size();
+
+  if (num_intersections == 0) return num_intersections;  // no new triangles.
+
+  // Compute intersections vertices by linear interpolation of the level-set
+  // to the zero-crossing.
+  Vector3<T> pc_N = Vector3<T>::Zero();  // Geometric center.
+  for (int edge_index : intersected_edges) {
+    const Edge& edge = kEdges[edge_index];
+    const Vector3<T>& p1_N = tet_vertices_N[edge.first];
+    const Vector3<T>& p2_N = tet_vertices_N[edge.second];
+    const T& phi1 = phi_N[edge.first];
+    const T& phi2 = phi_N[edge.second];
+    const T w2 = abs(phi1) / (abs(phi1) + abs(phi2));
+    const T w1 = 1.0 - w2;
+    const Vector3<T> pz_N = w1 * p1_N + w2 * p2_N;
+    vertices->emplace_back(pz_N);
+    // The geometric center is only needed for Case II.
+    if (num_intersections == 4) pc_N += pz_N;
+  }
+
+  // Case I: A single vertex has different sign from the other three. A single
+  // triangle is formed. We form a triangle so that its right handed normal
+  // points in the direction of the positive side of the volume.
+  using V = SurfaceVertexIndex;
+  if (num_intersections == 3) {
+    faces->emplace_back(V(num_vertices), V(num_vertices + 1),
+                        V(num_vertices + 2));
+    return num_intersections;
+  }
+
+  // Case II: Two pairs of vertices with the same sign. We form four new
+  // triangles by placing an additional vertex in the geometry center of the
+  // intersected vertices. The new triangles are oriented such that their
+  // normals point towards the positive side, in accordance to our convention.
+  if (num_intersections == 4) {
+    // Add the geometric center.
+    pc_N /= 4.0;
+    vertices->emplace_back(pc_N);
+
+    // Make four triangles sharing the geometric center. All oriented such
+    // that their right-handed normal points towards the positive side.
+    faces->emplace_back(V(0 + num_vertices), V(1 + num_vertices),
+                        V(4 + num_vertices));
+    faces->emplace_back(V(1 + num_vertices), V(2 + num_vertices),
+                        V(4 + num_vertices));
+    faces->emplace_back(V(2 + num_vertices), V(3 + num_vertices),
+                        V(4 + num_vertices));
+    faces->emplace_back(V(3 + num_vertices), V(0 + num_vertices),
+                        V(4 + num_vertices));
+
+    // Five vertices from intersecting four edges plus one additional vertex at
+    // the geometric center.
+    return 5;
+  }
+
+  throw std::logic_error("This line should never be reached.");
+}
+
+/// Given a level set function `φ(V)` and a volume defined by `mesh_M`, this
+/// method computes a triangulation of the zero level set `φ(V)` in the volume
+/// defined by the `mesh_M`.
+/// @param mesh_M
+///   Defines the volume M within which the zero level of `φ(V)` is found.
+/// @param level_set_N
+///   The level set function `φ(V)` represented as a `std::function`
+///   level_set_N, which takes the position of point V expressed in a frame N.
+///   That is, in code, φ(V) ≡ level_set_N(p_NV).
+/// @param X_NM
+///   The pose of M in N.
+///
+/// @note The resolution of the zero level set triangulation depends on the
+/// resolution of the initial volume mesh. That is, if we denote with h the
+/// typical length scale of a tetrahedral element, then the surface
+/// triangulation will also have triangular elements of size in the order of
+/// h. Thus, features in the level set function with a length scale smaller
+/// than h will not be properly captured by the triangulation.
+///
+/// @note This implementation uses the marching tetrahedra algorithm as
+/// described in [Bloomenthal, 1994].
+///
+/// @returns A triangulation of the zero level set of `φ(V)` in the volume
+/// defined by the `mesh_M`.  The triangulation is expressed in frame N.
+///
+/// @note  The SurfaceMesh may have duplicated vertices.
+///
+/// Bloomenthal, J., 1994. An Implicit Surface Polygonizer. Graphics Gems IV,
+/// pp. 324-349.
+template <typename T>
+SurfaceMesh<T> CalcZeroLevelSetInMeshDomain(
+    const VolumeMesh<T>& mesh_M,
+    std::function<T(const Vector3<T>&)> level_set_N,
+    const math::RigidTransform<T>& X_NM) {
+  std::vector<SurfaceVertex<T>> vertices;
+  std::vector<SurfaceFace> faces;
+
+  // We scan each tetrahedron in the mesh and compute the zero level set with
+  // IntersectTetWithLevelSet().
+  std::array<Vector3<T>, 4> tet_vertices_N;
+  Vector4<T> phi_N;
+  for (const auto& tet_indexes : mesh_M.tetrahedra()) {
+    // Collect data for each vertex of the tetrahedron.
+    for (int i = 0; i < 4; ++i) {
+      const auto& p_MV = mesh_M.vertex(tet_indexes.vertex(i)).r_MV();
+      tet_vertices_N[i] = X_NM * p_MV;
+      phi_N[i] = level_set_N(tet_vertices_N[i]);
+    }
+    // IntersectTetWithLevelSet() uses a different convention than VolumeMesh
+    // to index the vertices of a tetrahedra and therefore we swap vertexes 1
+    // and 2.
+    // TODO(amcastro-tri): If this becomes a performance issue, re-write
+    // IntersectTetWithLevelSet() to use the convention in VolumeMesh.
+    std::swap(tet_vertices_N[1], tet_vertices_N[2]);
+    std::swap(phi_N[1], phi_N[2]);
+    IntersectTetWithLevelSet(tet_vertices_N, phi_N, &vertices, &faces);
+  }
+
+  return SurfaceMesh<T>(std::move(faces), std::move(vertices));
+}
+
+}  // namespace internal
+#endif
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/test/contact_surface_calculator_test.cc
+++ b/geometry/proximity/test/contact_surface_calculator_test.cc
@@ -1,0 +1,402 @@
+#include "drake/geometry/proximity/contact_surface_calculator.h"
+
+#include <fstream>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/proximity/make_unit_sphere_mesh.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/math/roll_pitch_yaw.h"
+
+using drake::math::RigidTransformd;
+using drake::math::RollPitchYawd;
+using Eigen::Vector3d;
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+namespace {
+
+// Fixture to test the internals of ContactSurfaceCalculator.
+// We will test the intersection of a level set with a single regular
+// tetrahedron. All cases in the marching tetrahedra algorithm are tested.
+class TetrahedronIntersectionTest : public ::testing::Test {
+ protected:
+  void SetUp() { unit_tet_ = MakeRegularTetrahedron(); }
+
+  // Helper to make a tetrahedron with unit length edges.
+  static std::array<Vector3<double>, 4> MakeRegularTetrahedron() {
+    const double face_height = sqrt(3.0) / 2.0;
+    const double tet_height = sqrt(6.0) / 3.0;
+    std::array<Vector3<double>, 4> vertices;
+    vertices[0] = {2. / 3. * face_height, 0.0, 0.0};
+    vertices[1] = {-1. / 3. * face_height, -0.5, 0.0};
+    vertices[2] = {-1. / 3. * face_height, 0.5, 0.0};
+    vertices[3] = {0.0, 0.0, tet_height};
+    return vertices;
+  }
+
+  // This method computes the right handed normal defined by the three vertices
+  // of a triangle in the input argument v.
+  static Vector3<double> CalcTriangleNormal(
+      const std::vector<SurfaceVertex<double>>& v) {
+    return ((v[1].r_MV() - v[0].r_MV()).cross(v[2].r_MV() - v[0].r_MV()))
+        .normalized();
+  }
+
+  std::array<Vector3<double>, 4> unit_tet_;
+};
+
+// Verifies we get an empty intersection when all vertices have the same sign.
+TEST_F(TetrahedronIntersectionTest, EmptyIntersection) {
+  std::vector<SurfaceVertex<double>> vertices;
+  std::vector<SurfaceFace> faces;
+
+  // All positive vertices.
+  Vector4<double> phi_N = Vector4<double>::Ones();
+  EXPECT_EQ(IntersectTetWithLevelSet(unit_tet_, phi_N, &vertices, &faces), 0);
+
+  // All negative vertices.
+  phi_N = -Vector4<double>::Ones();
+  EXPECT_EQ(IntersectTetWithLevelSet(unit_tet_, phi_N, &vertices, &faces), 0);
+}
+
+// Case I of marching tetrahedra: only one of the vertices has a sign different
+// from all the other three.
+TEST_F(TetrahedronIntersectionTest, CaseI) {
+  std::vector<SurfaceVertex<double>> vertices;
+  std::vector<SurfaceFace> faces;
+  const double kTolerance = 5.0 * std::numeric_limits<double>::epsilon();
+
+  const int expected_num_intersections = 3;
+
+  // Computes a unit vector in the direction of vertex "top" from the centroid
+  // of the face opposite to "top".
+  auto calc_unit_vector_from_base_to_top = [&unit_tet =
+                                            this->unit_tet_](int top) {
+    const Vector3<double>& to = unit_tet[top];
+    // Index to the other three vertices.
+    const Vector3<double>& v1 = unit_tet[++top % 4];
+    const Vector3<double>& v2 = unit_tet[++top % 4];
+    const Vector3<double>& v3 = unit_tet[++top % 4];
+    const Vector3<double> from = (v1 + v2 + v3) / 3.0;
+    return (to - from).normalized();
+  };
+
+  // All vertices are positive but the i-th vertex.
+  for (int i = 0; i < 4; ++i) {
+    vertices.clear();
+    faces.clear();
+    Vector4<double> phi_N = Vector4<double>::Ones();
+    phi_N[i] = -1.0;
+    ASSERT_EQ(IntersectTetWithLevelSet(unit_tet_, phi_N, &vertices, &faces),
+        expected_num_intersections);
+
+    ASSERT_EQ(faces.size(), 1);
+    const Vector3<int> expected_face(0, 1, 2);
+    const Vector3<int> face(faces[0].vertex(0), faces[0].vertex(1),
+                            faces[0].vertex(2));
+    EXPECT_EQ(face, expected_face);
+
+    ASSERT_EQ(vertices.size(), 3);
+
+    // The negative sign is due to the fact that the i-th vertex is negative.
+    const Vector3<double> expected_normal =
+        -calc_unit_vector_from_base_to_top(i);
+    const Vector3<double> normal = CalcTriangleNormal(vertices);
+    EXPECT_TRUE(CompareMatrices(normal, expected_normal, kTolerance));
+  }
+
+  // All vertices are negative but the i-th vertex.
+  for (int i = 0; i < 4; ++i) {
+    vertices.clear();
+    faces.clear();
+    Vector4<double> phi_N = -Vector4<double>::Ones();
+    phi_N[i] = 1.0;
+    ASSERT_EQ(IntersectTetWithLevelSet(unit_tet_, phi_N, &vertices, &faces),
+        expected_num_intersections);
+
+    ASSERT_EQ(faces.size(), 1);
+    const Vector3<int> expected_face(0, 1, 2);
+    const Vector3<int> face(faces[0].vertex(0), faces[0].vertex(1),
+                            faces[0].vertex(2));
+    EXPECT_EQ(face, expected_face);
+
+    ASSERT_EQ(vertices.size(), 3);
+
+    // The expected normal points in the direction of the i-th vertex.
+    const Vector3<double> expected_normal =
+        calc_unit_vector_from_base_to_top(i);
+    const Vector3<double> normal = CalcTriangleNormal(vertices);
+    EXPECT_TRUE(CompareMatrices(normal, expected_normal, kTolerance));
+  }
+}
+
+// Case II of marching tetrahedra: two pairs of vertices with the same sign.
+TEST_F(TetrahedronIntersectionTest, CaseII) {
+  // This method assumes that two of vertices are positive (thus defining a
+  // positive edge) and two vertices are negative (thus defining a negative
+  // edge).
+  auto calc_unit_vector_from_negative_edge_to_positive_edge =
+      [& unit_tet = this->unit_tet_](const Vector4<double>& phi) {
+        Vector3<double> from = Vector3<double>::Zero();
+        Vector3<double> to = Vector3<double>::Zero();
+        for (int i = 0; i < 4; ++i) {
+          (phi[i] > 0.0 ? to : from) += unit_tet[i];
+        }
+        to /= 2.0;
+        from /= 2.0;
+        return (to - from).normalized();
+      };
+
+  auto verify_case2 = [&](const Vector4<double>& phi_N) {
+    const double kTolerance = 5.0 * std::numeric_limits<double>::epsilon();
+    const int expected_num_vertices = 5;
+
+    std::vector<SurfaceVertex<double>> vertices;
+    std::vector<SurfaceFace> faces;
+    ASSERT_EQ(IntersectTetWithLevelSet(unit_tet_, phi_N, &vertices, &faces),
+        expected_num_vertices);
+
+    ASSERT_EQ(faces.size(), 4);
+    ASSERT_EQ(vertices.size(), 5);
+
+    // To verify the computation of the normals we make use of the symmetry of
+    // the problem, for which we have a regular tetrahedron and we set all
+    // vertices to have the same absolute value of phi_N. With this setup, all
+    // triangles lie on the same plane, thus with the same normal.
+    const Vector3<double> expected_normal =
+        calc_unit_vector_from_negative_edge_to_positive_edge(phi_N);
+
+    for (int i = 0; i < 4; ++i) {
+      const SurfaceFace& t = faces[i];
+      std::vector<SurfaceVertex<double>> triangle_vertices = {
+          vertices[t.vertex(0)], vertices[t.vertex(1)], vertices[t.vertex(2)]};
+      const Vector3<double> normal = CalcTriangleNormal(triangle_vertices);
+      // This check has the nice side effect of checking triangles are properly
+      // oriented with the right-handed normal pointing towards the positive
+      // half of the tetrahedron.
+      EXPECT_TRUE(CompareMatrices(normal, expected_normal, kTolerance));
+    }
+  };
+
+  // Verify case II for the six different cases.
+  verify_case2(Vector4<double>(1.0, 1.0, -1.0, -1.0));
+  verify_case2(Vector4<double>(-1.0, -1.0, 1.0, 1.0));
+  verify_case2(Vector4<double>(-1.0, 1.0, -1.0, 1.0));
+  verify_case2(Vector4<double>(1.0, -1.0, 1.0, -1.0));
+  verify_case2(Vector4<double>(1.0, -1.0, -1.0, 1.0));
+  verify_case2(Vector4<double>(-1.0, 1.0, 1.0, -1.0));
+}
+
+// Fixture to test the intersection of a level set with a unit box.
+class BoxPlaneIntersectionTest : public ::testing::Test {
+ protected:
+  void SetUp() {
+    // Generate a partition of the unit cube into 6 tetrahedra.
+    std::vector<VolumeVertex<double>> vertices = {
+        {0.0, 0.0, 0.0}, {1.0, 0.0, 0.0}, {1.0, 1.0, 0.0}, {0.0, 1.0, 0.0},
+        {0.0, 0.0, 1.0}, {1.0, 0.0, 1.0}, {1.0, 1.0, 1.0}, {0.0, 1.0, 1.0}};
+    // translate origin to the geometric center of the box.
+    std::transform(
+        vertices.begin(), vertices.end(), vertices.begin(),
+        [](const VolumeVertex<double>& v) {
+          return VolumeVertex<double>(v.r_MV() - 0.5 * Vector3<double>::Ones());
+        });
+
+    const int e0[] = {0, 1, 3, 7};
+    const int e1[] = {1, 0, 4, 7};
+    const int e2[] = {1, 2, 3, 7};
+    const int e3[] = {2, 1, 5, 7};
+    const int e4[] = {1, 4, 5, 7};
+    const int e5[] = {2, 5, 6, 7};
+    using VE = VolumeElement;
+    std::vector<VolumeElement> elements = {VE(e0), VE(e1), VE(e2),
+                                           VE(e3), VE(e4), VE(e5)};
+    box_B_ = std::make_unique<VolumeMesh<double>>(std::move(elements),
+                                                  std::move(vertices));
+    half_space_H_ = [](const Vector3<double>& p_HQ) { return p_HQ[2]; };
+  }
+
+  double CalcSurfaceArea(const SurfaceMesh<double>& mesh) {
+    double area = 0;
+    for (SurfaceFaceIndex f(0); f < mesh.num_faces(); ++f) {
+      area += mesh.area(f);
+    }
+    return area;
+  }
+
+  // Mesh modeling a box, with its vertex positions expressed in the frame of
+  // the box B.
+  std::unique_ptr<VolumeMesh<double>> box_B_;
+
+  // A level set function, chosen to be the distance function, for a half space.
+  // It is defined as a function φ: ℝ³ → ℝ with the input position vector
+  // expressed in the frame H of the half space. Frame H is defined such that Hz
+  // normal to the half space points into the positive direction (outwards).
+  std::function<double(const Vector3<double>&)> half_space_H_;
+};
+
+// The bottom face of the box is machine epsilon from being flat on the
+// half-space, making contact. Currently, this might lead to double counting the
+// contact interface between neighboring tetrahedra. However, we can still
+// detect this situation and throw an exception with an appropriate message. We
+// verify this.
+TEST_F(BoxPlaneIntersectionTest, ImminentContact) {
+  const double kEpsilon = std::numeric_limits<double>::epsilon();
+
+  // The box overlaps the plane by kEpsilon. Expect intersection.
+  {
+    const math::RigidTransformd X_HB =
+        Translation3<double>(0.0, 0.0, 0.5 - 5 * kEpsilon);
+    DRAKE_EXPECT_THROWS_MESSAGE(CalcZeroLevelSetInMeshDomain(
+            *box_B_, half_space_H_, X_HB),
+        std::logic_error,
+        "One or more faces of this tetrahedron are close to being a zero "
+        "crossing.*");
+  }
+
+  // The box is on top of the plane by kEpsilon. Expect no intersection.
+  {
+    const math::RigidTransformd X_HB =
+        Translation3<double>(0.0, 0.0, 0.5 + 5 * kEpsilon);
+    DRAKE_EXPECT_THROWS_MESSAGE(CalcZeroLevelSetInMeshDomain(
+            *box_B_, half_space_H_, X_HB),
+        std::logic_error,
+        "One or more faces of this tetrahedron are close to being a zero "
+        "crossing.*");
+  }
+}
+
+// When one of the axes of the box is aligned with the plane normal the contact
+// surface simply is a unit square. The contact area however gets discretized
+// by a complex mesh of triangles given the non-homogenous tessellation of the
+// original box. Therefore verifying that the contact surface has unit area is a
+// very good measure of the success of the algorithm.
+// We do this for several orientations.
+TEST_F(BoxPlaneIntersectionTest, VerifyContactArea) {
+  const double kEpsilon = std::numeric_limits<double>::epsilon();
+  const double kTolerance = 5.0 * kEpsilon;
+
+  const auto Rx_pi_2 = RollPitchYawd(M_PI_2, 0.0, 0.0);
+  const auto Ry_pi_2 = RollPitchYawd(0.0, M_PI_2, 0.0);
+  const auto Rx_pi = RollPitchYawd(M_PI, 0.0, 0.0);
+  const auto Ry_pi = RollPitchYawd(0.0, M_PI, 0.0);
+  const Vector3<double> lowest(0.0, 0.0, -0.4);
+  const Vector3<double> middle(0.0, 0.0, 0.0);
+  const Vector3<double> highest(0.0, 0.0, 0.4);
+  // We choose a number of arbitrary poses but such that the plane is
+  // perpendicular to one of the main axes of the box. Therefore we know that
+  // the intersected surface is a 1x1 square.
+  std::vector<math::RigidTransformd> poses = {
+      Translation3<double>(lowest),
+      Translation3<double>(middle),
+      Translation3<double>(highest),
+      RigidTransformd(Rx_pi_2, lowest),
+      RigidTransformd(Rx_pi_2, middle),
+      RigidTransformd(Rx_pi_2, highest),
+      RigidTransformd(Ry_pi_2, lowest),
+      RigidTransformd(Ry_pi_2, middle),
+      RigidTransformd(Ry_pi_2, highest),
+      RigidTransformd(Rx_pi, lowest),
+      RigidTransformd(Rx_pi, middle),
+      RigidTransformd(Rx_pi, highest),
+      RigidTransformd(Ry_pi, lowest),
+      RigidTransformd(Ry_pi, middle),
+      RigidTransformd(Ry_pi, highest)};
+
+  for (const auto& X_HB : poses) {
+    const SurfaceMesh<double> contact_surface = CalcZeroLevelSetInMeshDomain(
+            *box_B_, half_space_H_, X_HB);
+    EXPECT_NEAR(CalcSurfaceArea(contact_surface), 1.0, kTolerance);
+  }
+}
+
+// Verify the algorithm returns no intersections when the box is over the plane.
+TEST_F(BoxPlaneIntersectionTest, NoIntersection) {
+  const double kEpsilon = std::numeric_limits<double>::epsilon();
+  const double kTolerance = 5.0 * kEpsilon;
+
+  const auto Rx_pi_2 = RollPitchYawd(M_PI_2, 0.0, 0.0);
+  const auto Ry_pi_2 = RollPitchYawd(0.0, M_PI_2, 0.0);
+  const auto Rx_pi = RollPitchYawd(M_PI, 0.0, 0.0);
+  const auto Ry_pi = RollPitchYawd(0.0, M_PI, 0.0);
+  // We choose a an arbitrary number of poses but such that the box is entirely
+  // above the plane.
+  const Vector3<double> lowest(0.0, 0.0, 0.6);
+  const Vector3<double> middle(0.0, 0.0, 0.8);
+  const Vector3<double> highest(0.0, 0.0, 1.0);
+  std::vector<math::RigidTransformd> poses = {
+      Translation3<double>(lowest),
+      Translation3<double>(middle),
+      Translation3<double>(highest),
+      RigidTransformd(Rx_pi_2, lowest),
+      RigidTransformd(Rx_pi_2, middle),
+      RigidTransformd(Rx_pi_2, highest),
+      RigidTransformd(Ry_pi_2, lowest),
+      RigidTransformd(Ry_pi_2, middle),
+      RigidTransformd(Ry_pi_2, highest),
+      RigidTransformd(Rx_pi, lowest),
+      RigidTransformd(Rx_pi, middle),
+      RigidTransformd(Rx_pi, highest),
+      RigidTransformd(Ry_pi, lowest),
+      RigidTransformd(Ry_pi, middle),
+      RigidTransformd(Ry_pi, highest)};
+
+  for (const auto& X_HB : poses) {
+    const SurfaceMesh<double> contact_surface = CalcZeroLevelSetInMeshDomain(
+            *box_B_, half_space_H_, X_HB);
+    EXPECT_NEAR(CalcSurfaceArea(contact_surface), 0.0, kTolerance);
+  }
+}
+
+// This test verifies the computation of the contact surface between a
+// tessellated sphere and a half-space represented by a level set function.
+// In particular, we verify that the vertices on the contact surface are
+// properly interpolated to lie on the plane within a circle of the expected
+// radius.
+GTEST_TEST(SpherePlaneIntersectionTest, VerticesProperlyInterpolated) {
+  const double kTolerance = 5.0 * std::numeric_limits<double>::epsilon();
+
+  // A tessellation of a unit sphere. Vertices are in the mesh frame M.
+  // This creates a volume mesh with over 32K tetrahedra.
+  const VolumeMesh<double> sphere_M = MakeUnitSphereMesh<double>(4);
+  // A level set for a half-space, as a function of the position vector p_WQ for
+  // points Q in the world frame W.
+  std::function<double(const Vector3<double>&)> half_space_W =
+      [](const Vector3<double>& p_WQ) { return p_WQ[2]; };
+
+  // We place the sphere above the half-space but overlapping, such that the
+  // deepest penetration point is at a distance equal to 0.3 (the sphere radius
+  // is 1.0, dimensionless for the purposes of this test).
+  const double height = 0.7;
+  const RigidTransformd X_WM = Translation3<double>(0.0, 0.0, height);
+
+  // The contact surface is expressed in the frame of the level set, in this
+  // case the world frame W.
+  const SurfaceMesh<double> contact_surface_W =
+      CalcZeroLevelSetInMeshDomain(sphere_M, half_space_W, X_WM);
+  // Assert non-empty intersection.
+  ASSERT_GT(contact_surface_W.num_faces(), 0);
+
+  for (SurfaceVertexIndex v(0); v < contact_surface_W.num_vertices(); ++v) {
+    const Vector3<double>& p_WV = contact_surface_W.vertex(v).r_MV();
+    // We verify that the postions were correctly interpolated to lie on the
+    // plane.
+    EXPECT_NEAR(p_WV[2], 0.0, kTolerance);
+
+    // Verify surface vertices lie within a circle of the expected radius.
+    const double surface_radius = std::sqrt(1.0 - height * height);
+    const double radius = p_WV.norm();  // since z component is zero.
+    EXPECT_LE(radius, surface_radius);
+  }
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
First part of #11519 that computes the `SurfaceMesh`. The computation of `ContactSurface`, including the normal traction field, will build from this PR.

The figure bellow shows the intersection of a box (tessellated by tetrahedra) with a plane (represented by a level set). The intersection, shown in orange, is translated down for clarity.

![box_vs_half_space](https://user-images.githubusercontent.com/17601461/58667588-69d22b80-8304-11e9-9fd6-0ce513d3013d.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11558)
<!-- Reviewable:end -->
