### PR TITLE
Addition of proximity infrastructure for ComputeContactSurface

### DIFF
--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -384,7 +384,7 @@ class GeometryState {
   /** See QueryObject::ComputeContactSurfaces() for documentation.  */
   std::vector<ContactSurface<T>> ComputeContactSurfaces() const {
     return geometry_engine_->ComputeContactSurfaces(
-        geometry_index_to_id_map_);
+        geometry_index_to_id_map_, X_WG_);
   }
 
   //@}

--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -17,6 +17,7 @@ drake_cc_package_library(
         ":distance_to_point",
         ":distance_to_point_with_gradient",
         ":distance_to_shape",
+        ":hydroelastic_callback",
         ":mesh_field",
         ":proximity_utilities",
         ":volume_mesh",
@@ -30,6 +31,19 @@ drake_cc_library(
         ":proximity_utilities",
         "//common:essential",
         "//common:sorted_vectors_have_intersection",
+    ],
+)
+
+drake_cc_library(
+    name = "distance_to_point",
+    hdrs = ["distance_to_point.h"],
+    deps = [
+        ":proximity_utilities",
+        "//common:essential",
+        "//geometry:geometry_ids",
+        "//geometry/query_results:signed_distance_to_point",
+        "//math:geometric_transform",
+        "@fcl",
     ],
 )
 
@@ -48,19 +62,6 @@ drake_cc_library(
 )
 
 drake_cc_library(
-    name = "distance_to_point",
-    hdrs = ["distance_to_point.h"],
-    deps = [
-        ":proximity_utilities",
-        "//common:essential",
-        "//geometry:geometry_ids",
-        "//geometry/query_results:signed_distance_to_point",
-        "//math:geometric_transform",
-        "@fcl",
-    ],
-)
-
-drake_cc_library(
     name = "distance_to_shape",
     hdrs = ["distance_to_shape.h"],
     deps = [
@@ -68,6 +69,22 @@ drake_cc_library(
         ":distance_to_point",
         ":proximity_utilities",
         "//geometry/query_results:signed_distance_pair",
+    ],
+)
+
+drake_cc_library(
+    name = "hydroelastic_callback",
+    hdrs = [
+        "hydroelastic_callback.h",
+        "hydroelastic_sphere_halfspace.h",
+    ],
+    deps = [
+        ":collision_filter_legacy",
+        ":proximity_utilities",
+        "//geometry/query_results:contact_surface",
+        "//math:geometric_transform",
+        "@fcl",
+        "@fmt",
     ],
 )
 
@@ -118,12 +135,28 @@ drake_cc_library(
 )
 
 drake_cc_googletest(
+    name = "contact_surface_test",
+    deps = [
+        "//geometry:geometry_ids",
+        "//geometry/query_results:contact_surface",
+    ],
+)
+
+drake_cc_googletest(
     name = "distance_to_point_test",
     deps = [
         ":distance_to_point",
         "//common/test_utilities",
         "//geometry:utilities",
         "//math",
+    ],
+)
+
+drake_cc_googletest(
+    name = "distance_to_point_with_gradient_test",
+    deps = [
+        ":distance_to_point_with_gradient",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -138,25 +171,11 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
-    name = "distance_to_point_with_gradient_test",
+    name = "hydroelastic_callback_test",
     deps = [
-        ":distance_to_point_with_gradient",
+        ":hydroelastic_callback",
         "//common/test_utilities:eigen_matrix_compare",
-    ],
-)
-
-drake_cc_googletest(
-    name = "contact_surface_test",
-    deps = [
-        "//geometry:geometry_ids",
-        "//geometry/query_results:contact_surface",
-    ],
-)
-
-drake_cc_googletest(
-    name = "volume_mesh_test",
-    deps = [
-        "//geometry/proximity:volume_mesh",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 
@@ -171,6 +190,13 @@ drake_cc_googletest(
     name = "mesh_field_linear_test",
     deps = [
         "//geometry/proximity:mesh_field",
+    ],
+)
+
+drake_cc_googletest(
+    name = "volume_mesh_test",
+    deps = [
+        "//geometry/proximity:volume_mesh",
     ],
 )
 

--- a/geometry/proximity/hydroelastic_callback.h
+++ b/geometry/proximity/hydroelastic_callback.h
@@ -1,0 +1,165 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include <fcl/fcl.h>
+#include <fmt/format.h>
+
+#include "drake/common/drake_optional.h"
+#include "drake/common/eigen_types.h"
+#include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/proximity/collision_filter_legacy.h"
+#include "drake/geometry/proximity/hydroelastic_sphere_halfspace.h"
+#include "drake/geometry/proximity/proximity_utilities.h"
+#include "drake/geometry/query_results/contact_surface.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/math/rotation_matrix.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace hydroelastic {
+
+/** Supporting data for the shape-to-shape hydroelastic contact callback (see
+ Callback below). It includes:
+
+    - A map from GeometryIndex to GeometryId (to facilitate reporting GeometryId
+      values in the results).
+    - A collision filter instance.
+    - The T-valued poses of _all_ geometries in the corresponding SceneGraph,
+      each indexed by its corresponding geometry's GeometryIndex.
+    - A vector of contact surfaces -- one instance of ContactSurface for
+      every supported, unfiltered penetrating pair.
+
+ @tparam T The computation scalar.  */
+template <typename T>
+struct CallbackData {
+  /** Constructs the fully-specified callback data. The values are as described
+   in the class documentation. The parameters are all aliased in the data and
+   must remain valid at least as long as the %CallbackData instance.
+
+   @param geometry_map_in         The index -> id map. Aliased.
+   @param collision_filter_in     The collision filter system. Aliased.
+   @param X_WGs_in                The T-valued poses. Aliased.
+   @param surfaces_in             The output results. Aliased.  */
+  CallbackData(const std::vector<GeometryId>* geometry_map_in,
+               const CollisionFilterLegacy* collision_filter_in,
+               const std::vector<Isometry3<T>>* X_WGs_in,
+               std::vector<ContactSurface<T>>* surfaces_in)
+      : geometry_map(*geometry_map_in),
+        collision_filter(*collision_filter_in),
+        X_WGs(*X_WGs_in),
+        surfaces(*surfaces_in) {
+    DRAKE_DEMAND(geometry_map_in);
+    DRAKE_DEMAND(collision_filter_in);
+    DRAKE_DEMAND(X_WGs_in);
+    DRAKE_DEMAND(surfaces_in);
+  }
+
+  /** The map from GeometryIndex to GeometryId.  */
+  const std::vector<GeometryId>& geometry_map;
+
+  /** The collision filter system.  */
+  const CollisionFilterLegacy& collision_filter;
+
+  /** The T-valued poses of all geometries.  */
+  const std::vector<Isometry3<T>>& X_WGs;
+
+  /** The results of the distance query.  */
+  std::vector<ContactSurface<T>>& surfaces{};
+};
+
+// TODO(SeanCurtis-TRI): Replace this clunky mechanism with a new mechanism
+// which does this implicitly via ADL and templates.
+/** @name   Mechanism for reporting on which scalars and for which shape-pairs
+            contact surface queries can be made.
+
+ By default, *only* sphere-halfspace is supported, but for all scalars.
+
+ @tparam T      The computational scalar type.  */
+//@{
+
+template <typename T>
+struct ScalarSupport {
+  static bool is_supported(fcl::NODE_TYPE node1, fcl::NODE_TYPE node2) {
+    // Current version only supports sphere-halfspace contact.
+    return (node1 == fcl::GEOM_HALFSPACE && node2 == fcl::GEOM_SPHERE) ||
+           (node2 == fcl::GEOM_HALFSPACE && node1 == fcl::GEOM_SPHERE);
+  }
+};
+
+//@}
+
+/** The callback function for computing a hydroelastic contact surface between
+ two arbitrary shapes.
+
+ @param object_A_ptr    Pointer to the first object in the pair (the order has
+                        no significance).
+ @param object_B_ptr    Pointer to the second object in the pair (the order has
+                        no significance).
+ @param callback_data   Supporting data to compute the contact surface.
+ @returns False; the broadphase should *not* terminate its process.
+ @tparam T  The scalar type for the query.  */
+template <typename T>
+bool Callback(fcl::CollisionObjectd* object_A_ptr,
+              fcl::CollisionObjectd* object_B_ptr,
+              // NOLINTNEXTLINE
+              void* callback_data) {
+  auto& data = *static_cast<CallbackData<T>*>(callback_data);
+
+  const EncodedData encoding_a(*object_A_ptr);
+  const EncodedData encoding_b(*object_B_ptr);
+
+  const bool can_collide = data.collision_filter.CanCollideWith(
+      encoding_a.encoding(), encoding_b.encoding());
+
+  if (can_collide) {
+    if (ScalarSupport<T>::is_supported(
+            object_A_ptr->collisionGeometry()->getNodeType(),
+            object_B_ptr->collisionGeometry()->getNodeType())) {
+      // NOTE: This A_is_sphere only works because right now, we only support
+      // sphere-halfspace. When we support a larger space, we'll have to be more
+      // clever about this.
+      bool A_is_sphere =
+          object_A_ptr->collisionGeometry()->getNodeType() == fcl::GEOM_SPHERE;
+      const GeometryId id_S = A_is_sphere ? encoding_a.id(data.geometry_map)
+                                          : encoding_b.id(data.geometry_map);
+      const GeometryId id_H = A_is_sphere ? encoding_b.id(data.geometry_map)
+                                          : encoding_a.id(data.geometry_map);
+      const GeometryIndex index_S =
+          A_is_sphere ? encoding_a.index() : encoding_b.index();
+      const GeometryIndex index_H =
+          A_is_sphere ? encoding_b.index() : encoding_a.index();
+      double radius = A_is_sphere ? static_cast<const fcl::Sphered*>(
+                                        object_A_ptr->collisionGeometry().get())
+                                        ->radius
+                                  : static_cast<const fcl::Sphered*>(
+                                        object_B_ptr->collisionGeometry().get())
+                                        ->radius;
+      const math::RigidTransform<T> X_WS(data.X_WGs[index_S]);
+      const math::RigidTransform<T> X_WH(data.X_WGs[index_H]);
+      optional<ContactSurface<T>> surface_maybe =
+          CalcHalfspaceSphereContact(radius, X_WS, id_S, X_WH, id_H);
+      //  Just because the broadphase says these two might be colliding, doesn't
+      //  mean they are colliding. We verify that.
+      if (surface_maybe) {
+        DRAKE_DEMAND(surface_maybe->id_M() < surface_maybe->id_N());
+        data.surfaces.emplace_back(std::move(*surface_maybe));
+      }
+    } else {
+      throw std::logic_error(
+          fmt::format("Contact surface queries between shapes '{}' and '{}' "
+                      "are not supported for scalar type {}",
+                      GetGeometryName(*object_A_ptr),
+                      GetGeometryName(*object_B_ptr), NiceTypeName::Get<T>()));
+    }
+  }
+  // Tell the broadphase to keep searching.
+  return false;
+}
+
+}  // namespace hydroelastic
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/hydroelastic_sphere_halfspace.h
+++ b/geometry/proximity/hydroelastic_sphere_halfspace.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "drake/common/drake_optional.h"
+#include "drake/common/unused.h"
+#include "drake/geometry/query_results/contact_surface.h"
+#include "drake/math/rigid_transform.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace hydroelastic {
+
+/** Computes the contact surface between a compliant sphere and rigid halfspace.
+ The halfspace is defined in frame H lying on H's Hx-Hy plane (with its normal
+ in the Hz direction). The sphere has the given `radius` and is centered at the
+ origin of frame S. The poses of the two geometries are given in the common
+ world frame W.
+
+ @note This function does not explicitly interpret the halfspace as volume M or
+ N. It depends on the relationship between the ids of the sphere and halfspace.
+ The halfspace is interpreted as volume M iff id_H < id_S, otherwise the sphere
+ is volume M (see documentation of ContactSurface for details).
+
+ @param radius      The radius of the sphere.
+ @param X_WS        The pose of the sphere in the world frame W.
+ @param id_S        The geometry id for the sphere.
+ @param X_WH        The pose of the halfspace in the world frame W.
+ @param id_H        The geometry id for the halfspace.
+ @returns The contact surface for the two shapes if the sphere intersects the
+ half space. Otherwise `nullopt`.
+ @tparam T  The scalar type for the query.  */
+template <typename T>
+optional<ContactSurface<T>> CalcHalfspaceSphereContact(
+    double radius, const math::RigidTransform<T>& X_WS, GeometryId id_S,
+    const math::RigidTransform<T>& X_WH, GeometryId id_H) {
+  // TODO(amcastro-tri): Write the actual implementation of this method once
+  // #11520 and #11519 are in master.
+  unused(radius);
+  unused(X_WS);
+  unused(X_WH);
+  // NOTE: Don't read anything into the interpretation of id_S as being id_M;
+  // it's just a place holder. See @note in for this method's documentation.
+  return ContactSurface<T>(id_S, id_H, nullptr, nullptr, nullptr);
+}
+
+}  // namespace hydroelastic
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/test/hydroelastic_callback_test.cc
+++ b/geometry/proximity/test/hydroelastic_callback_test.cc
@@ -1,0 +1,141 @@
+#include "drake/geometry/proximity/hydroelastic_callback.h"
+
+#include <utility>
+#include <vector>
+
+#include <fcl/fcl.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace hydroelastic {
+namespace {
+
+using Eigen::Vector3d;
+using fcl::Boxd;
+using fcl::CollisionObjectd;
+using fcl::Halfspaced;
+using fcl::Sphered;
+using std::make_shared;
+using std::vector;
+
+// Infrastructure to repeat tests on both double and AutoDiffXd.
+using ScalarTypes = ::testing::Types<double, AutoDiffXd>;
+
+template <typename T>
+class HydroelasticCallbackTyped : public ::testing::Test {};
+
+TYPED_TEST_CASE(HydroelasticCallbackTyped, ScalarTypes);
+
+// Confirms that sphere-halfspace is supported for double and autodiff, but only
+// for sphere and halfspace. If support fractures across scalar type, this will
+// need to be split.
+TYPED_TEST(HydroelasticCallbackTyped, ScalarSupport) {
+  using Support = ScalarSupport<TypeParam>;
+  EXPECT_TRUE(Support::is_supported(fcl::GEOM_SPHERE, fcl::GEOM_HALFSPACE));
+  EXPECT_TRUE(Support::is_supported(fcl::GEOM_HALFSPACE, fcl::GEOM_SPHERE));
+
+  // TODO(SeanCurtis-TRI): Add other supported fcl geometry types as they get
+  // introduced (here and below for autodiff support).
+  for (auto other : {fcl::GEOM_BOX, fcl::GEOM_CONVEX, fcl::GEOM_CYLINDER}) {
+    EXPECT_FALSE(Support::is_supported(fcl::GEOM_SPHERE, other));
+    EXPECT_FALSE(Support::is_supported(other, fcl::GEOM_SPHERE));
+    EXPECT_FALSE(Support::is_supported(other, fcl::GEOM_HALFSPACE));
+    EXPECT_FALSE(Support::is_supported(fcl::GEOM_HALFSPACE, other));
+  }
+}
+
+// TODO(SeanCurtis-TRI): Refactor the "set up CallbackData" boilerplate across
+//  these three (or more) tests.
+
+// Confirms that if geometry to be collided are not supported, that an exception
+// is thrown.
+TYPED_TEST(HydroelasticCallbackTyped, ThrowForUnsupported) {
+  using T = TypeParam;
+  std::vector<GeometryId> geometry_map{GeometryId::get_new_id(),
+                                       GeometryId::get_new_id()};
+  CollisionFilterLegacy collision_filter;
+
+  EncodedData data_A(GeometryIndex{0}, true);
+  EncodedData data_B(GeometryIndex{1}, true);
+  collision_filter.AddGeometry(data_A.encoding());
+  collision_filter.AddGeometry(data_B.encoding());
+  std::vector<Isometry3<T>> X_WGs{Isometry3<T>::Identity(),
+                                  Isometry3<T>::Identity()};
+
+  CollisionObjectd box_A(make_shared<Boxd>(0.25, 0.3, 0.4));
+  data_A.write_to(&box_A);
+  CollisionObjectd box_B(make_shared<Boxd>(0.4, 0.3, 0.2));
+  data_B.write_to(&box_B);
+
+  vector<ContactSurface<T>> surfaces;
+  CallbackData<T> data(&geometry_map, &collision_filter, &X_WGs, &surfaces);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      Callback<T>(&box_A, &box_B, &data), std::logic_error,
+      "Contact surface queries between .* and .* are not supported .*");
+}
+
+// Confirms that if the world contains unsupported geometry, as long as they are
+// filtered, they don't pose a problem.
+TYPED_TEST(HydroelasticCallbackTyped, RespectsCollisionFilter) {
+  using T = TypeParam;
+  std::vector<GeometryId> geometry_map{GeometryId::get_new_id(),
+                                       GeometryId::get_new_id()};
+  CollisionFilterLegacy collision_filter;
+
+  EncodedData data_A(GeometryIndex{0}, true);
+  EncodedData data_B(GeometryIndex{1}, true);
+  collision_filter.AddGeometry(data_A.encoding());
+  collision_filter.AddGeometry(data_B.encoding());
+  // Filter the pair (A, B) by adding them to the same clique.
+  collision_filter.AddToCollisionClique(data_A.encoding(), 1);
+  collision_filter.AddToCollisionClique(data_B.encoding(), 1);
+  std::vector<Isometry3<T>> X_WGs{Isometry3<T>::Identity(),
+                                  Isometry3<T>::Identity()};
+
+  CollisionObjectd box_A(make_shared<Boxd>(0.25, 0.3, 0.4));
+  data_A.write_to(&box_A);
+  CollisionObjectd box_B(make_shared<Boxd>(0.4, 0.3, 0.2));
+  data_B.write_to(&box_B);
+
+  vector<ContactSurface<T>> surfaces;
+  CallbackData<T> data(&geometry_map, &collision_filter, &X_WGs, &surfaces);
+  EXPECT_NO_THROW(Callback<T>(&box_A, &box_B, &data));
+  EXPECT_EQ(surfaces.size(), 0u);
+}
+
+// Confirms that a colliding sphere and halfspace produces a result. This
+// doesn't test the actual data -- it assumes the function responsible for
+// computing that result has been successfully tested.
+TYPED_TEST(HydroelasticCallbackTyped, SphereHalfspaceProducesResult) {
+  using T = TypeParam;
+  std::vector<GeometryId> geometry_map{GeometryId::get_new_id(),
+                                       GeometryId::get_new_id()};
+  CollisionFilterLegacy collision_filter;
+
+  EncodedData data_A(GeometryIndex{0}, true);
+  EncodedData data_B(GeometryIndex{1}, true);
+  collision_filter.AddGeometry(data_A.encoding());
+  collision_filter.AddGeometry(data_B.encoding());
+  std::vector<Isometry3<T>> X_WGs{Isometry3<T>::Identity(),
+                                  Isometry3<T>::Identity()};
+
+  CollisionObjectd sphere(make_shared<Sphered>(0.5));
+  data_A.write_to(&sphere);
+  CollisionObjectd halfspace(make_shared<Halfspaced>(Vector3d{0, 0, 1}, 0));
+  data_B.write_to(&halfspace);
+
+  vector<ContactSurface<T>> surfaces;
+  CallbackData<T> data(&geometry_map, &collision_filter, &X_WGs, &surfaces);
+  EXPECT_NO_THROW(Callback<T>(&sphere, &halfspace, &data));
+  EXPECT_EQ(surfaces.size(), 1u);
+}
+
+}  // namespace
+}  // namespace hydroelastic
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity_engine.h
+++ b/geometry/proximity_engine.h
@@ -258,12 +258,15 @@ class ProximityEngine {
    map to `id_A` and `id_B` in a fixed, repeatable manner, where `id_A` and
    `id_B` are GeometryId's of geometries g_A and g_B respectively.
 
-   @param[in]   geometry_map  A map from geometry _index_ to the corresponding
+   @param[in] geometry_map    A map from geometry _index_ to the corresponding
                               global geometry identifier.
+   @param[in] X_WGs           The pose of all geometries in world, indexed by
+                              each geometry's GeometryIndex.
    @returns A vector populated with all detected intersections characterized as
             contact surfaces.  */
   std::vector<ContactSurface<T>> ComputeContactSurfaces(
-      const std::vector<GeometryId>& /* geometry_map */) const;
+      const std::vector<GeometryId>& geometry_map,
+      const std::vector<Isometry3<T>>& X_WGs) const;
 
   //@}
 

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -178,6 +178,10 @@ class QueryObject {
    intersection as a ContactSurface. The computation is subject to collision
    filtering.
 
+   Currently, only contact between spheres and halfspaces is supported. Any
+   _unfiltered_ geometry pair comprised of other types will cause an exception
+   to be thrown.
+
    @returns A vector populated with contact surfaces of all detected
             intersecting pairs of geometries.
    @note  This function is not implemented yet. */


### PR DESCRIPTION
Towards resolving #11521. 
Kudos to @SeanCurtis-TRI who provided this branch! I only really made small modifications on docs and linting. Great way to make PRs! :-) 

This includes:
  1. the invocation of broadphase culling,
  2. Definition of callback (only accepts spheres-halfspaces, throws on
     all else).
  3. Calls stub function to compute sphere-halfspace contact surface.
  4. Initial unit tests.
  5. Modification of QueryObject documentation to indicate initial
     supported behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11562)
<!-- Reviewable:end -->
