### PR TITLE
[Py]Bind external force inputs for MBP

### DIFF
--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -214,6 +214,7 @@ drake_py_unittest(
         "//manipulation/models/iiwa_description:models",
         "//manipulation/models/wsg_50_description:models",
         "//multibody/benchmarks/acrobot:models",
+        "//multibody/benchmarks/free_body:models",
     ],
     deps = [
         ":benchmarks_py",
@@ -221,6 +222,7 @@ drake_py_unittest(
         ":plant_py",
         ":tree_py",
         "//bindings/pydrake/common/test_utilities",
+        "//bindings/pydrake/systems:analysis_py",
     ],
 )
 


### PR DESCRIPTION
Binds `ExternallyAppliedSpatialForce` and `std::vector<ExternallyAppliedSpatialForce>`, as well as the accessors for the external force input ports for the MBP. (The `std::vector` binding proved necessary as simple Python lists of `ExternallyAppliedSpatialForce` objects show up as generic Python objects once they enter C++-land, which aren't the right type to be accepted by the corresponding MBP input port. I'd love for this to be cleaner, though.)

Aside, but this is sufficient to build interactive interfaces like [this one](https://youtu.be/v_5k-lZv76U) from Python. (Heavily WIP, but that example maps relative motion 6DOF motion controller to a PD controller that uses ExternallyAppliedSpatialForces to drive object to desired configurations.)

@EricCousineau-TRI, mind taking a look?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11591)
<!-- Reviewable:end -->
