### PR TITLE
move detailed description to top of doxygen pages

### DIFF
--- a/doc/DoxygenLayout.xml
+++ b/doc/DoxygenLayout.xml
@@ -24,7 +24,8 @@
 
   <!-- Layout definition for a class page -->
   <class>
-    <briefdescription visible="yes"/>
+    <briefdescription visible="no"/>
+    <detaileddescription title=""/>
     <includes visible="$SHOW_INCLUDE_FILES"/>
     <inheritancegraph visible="$CLASS_GRAPH"/>
     <collaborationgraph visible="$COLLABORATION_GRAPH"/>
@@ -62,7 +63,6 @@
       <related title="" subtitle=""/>
       <membergroups visible="yes"/>
     </memberdecl>
-    <detaileddescription title=""/>
     <memberdef>
       <inlineclasses title=""/>
       <typedefs title=""/>
@@ -83,7 +83,8 @@
 
   <!-- Layout definition for a namespace page -->
   <namespace>
-    <briefdescription visible="yes"/>
+    <briefdescription visible="no"/>
+    <detaileddescription title=""/>
     <memberdecl>
       <nestednamespaces visible="yes" title=""/>
       <constantgroups visible="yes" title=""/>
@@ -94,7 +95,6 @@
       <variables title=""/>
       <membergroups visible="yes"/>
     </memberdecl>
-    <detaileddescription title=""/>
     <memberdef>
       <inlineclasses title=""/>
       <typedefs title=""/>
@@ -107,7 +107,8 @@
 
   <!-- Layout definition for a file page -->
   <file>
-    <briefdescription visible="yes"/>
+    <briefdescription visible="no"/>
+    <detaileddescription title=""/>
     <includes visible="$SHOW_INCLUDE_FILES"/>
     <includegraph visible="$INCLUDE_GRAPH"/>
     <includedbygraph visible="$INCLUDED_BY_GRAPH"/>
@@ -123,7 +124,6 @@
       <variables title=""/>
       <membergroups visible="yes"/>
     </memberdecl>
-    <detaileddescription title=""/>
     <memberdef>
       <inlineclasses title=""/>
       <defines title=""/>
@@ -138,6 +138,7 @@
   <!-- Layout definition for a group page -->
   <group>
     <briefdescription visible="no"/>
+    <detaileddescription title=""/>
     <groupgraph visible="$GROUP_GRAPHS"/>
     <memberdecl>
       <nestedgroups visible="yes" title=""/>
@@ -160,7 +161,6 @@
       <friends title=""/>
       <membergroups visible="yes"/>
     </memberdecl>
-    <detaileddescription title=""/>
     <memberdef>
       <pagedocs/>
       <inlineclasses title=""/>
@@ -183,7 +183,7 @@
 
   <!-- Layout definition for a directory page -->
   <directory>
-    <briefdescription visible="yes"/>
+    <briefdescription visible="no"/>
     <directorygraph visible="yes"/>
     <memberdecl>
       <dirs visible="yes"/>


### PR DESCRIPTION
I'd been searching for a way to get the system diagrams to the top of the page, and finally found this solution -- which appears to be way better in every case.

before:
![image](https://user-images.githubusercontent.com/6442292/59097133-c7f5a480-88ea-11e9-9a74-519ba880b259.png)
after:
![image](https://user-images.githubusercontent.com/6442292/59097154-d2b03980-88ea-11e9-9ff5-69365cc45d2f.png)


before:
![image](https://user-images.githubusercontent.com/6442292/59097183-e5c30980-88ea-11e9-9dae-a29a04b5b006.png)
after:
![image](https://user-images.githubusercontent.com/6442292/59097204-f07d9e80-88ea-11e9-82a3-903f36620720.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11592)
<!-- Reviewable:end -->
