### PR TITLE
Parsers accept a "convex" tag to load meshes as geometry::Convex

### DIFF
--- a/multibody/parsing/detail_scene_graph.cc
+++ b/multibody/parsing/detail_scene_graph.cc
@@ -152,8 +152,13 @@ std::unique_ptr<geometry::Shape> MakeShapeFromSdfGeometry(
         }
         scale = scale_vector.X();
       }
+
       // TODO(amcastro-tri): Fix the given path to be an absolute path.
-      return make_unique<geometry::Mesh>(file_name, scale);
+      if (mesh_element->HasElement("drake:declare_convex")) {
+        return make_unique<geometry::Convex>(file_name, scale);
+      } else {
+        return make_unique<geometry::Mesh>(file_name, scale);
+      }
     }
   }
 

--- a/multibody/parsing/detail_urdf_geometry.cc
+++ b/multibody/parsing/detail_urdf_geometry.cc
@@ -196,7 +196,12 @@ std::unique_ptr<geometry::Shape> ParseMesh(
     }
     scale = scale_vector(0);
   }
-  return std::make_unique<geometry::Mesh>(resolved_filename, scale);
+
+  if (shape_node->FirstChildElement("drake:declare_convex")) {
+    return std::make_unique<geometry::Convex>(resolved_filename, scale);
+  } else {
+    return std::make_unique<geometry::Mesh>(resolved_filename, scale);
+  }
 }
 
 std::unique_ptr<geometry::Shape> ParseGeometry(

--- a/multibody/parsing/test/detail_scene_graph_test.cc
+++ b/multibody/parsing/test/detail_scene_graph_test.cc
@@ -23,6 +23,7 @@ namespace {
 using Eigen::Matrix3d;
 using Eigen::Vector3d;
 using geometry::Box;
+using geometry::Convex;
 using geometry::Cylinder;
 using geometry::GeometryInstance;
 using geometry::HalfSpace;
@@ -223,6 +224,22 @@ GTEST_TEST(SceneGraphParserDetail, MakeMeshFromSdfGeometry) {
   ASSERT_NE(mesh, nullptr);
   EXPECT_EQ(mesh->filename(), absolute_file_path);
   EXPECT_EQ(mesh->scale(), 3);
+}
+
+// Verify MakeShapeFromSdfGeometry can make a convex mesh from an sdf::Geometry.
+GTEST_TEST(SceneGraphParserDetail, MakeConvexFromSdfGeometry) {
+  const std::string absolute_file_path = "path/to/some/mesh.obj";
+  unique_ptr<sdf::Geometry> sdf_geometry = MakeSdfGeometryFromString(
+      "<mesh xmlns:drake='drake.mit.edu'>"
+      "  <drake:declare_convex/>"
+      "  <uri>" + absolute_file_path + "</uri>"
+      "  <scale> 3 3 3 </scale>"
+      "</mesh>");
+  unique_ptr<Shape> shape = MakeShapeFromSdfGeometry(*sdf_geometry);
+  const Convex* convex = dynamic_cast<const Convex*>(shape.get());
+  ASSERT_NE(convex, nullptr);
+  EXPECT_EQ(convex->filename(), absolute_file_path);
+  EXPECT_EQ(convex->scale(), 3);
 }
 
 // Verify MakeGeometryInstanceFromSdfVisual can make a GeometryInstance from an

--- a/multibody/parsing/test/detail_urdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_urdf_geometry_test.cc
@@ -253,6 +253,31 @@ TEST_F(UrdfGeometryTests, TestWrongElementType) {
       "In link fake_name expected collision element, got material");
 }
 
+TEST_F(UrdfGeometryTests, TestParseConvexMesh) {
+  const std::string resource_dir{
+      "drake/multibody/parsing/test/urdf_parser_test/"};
+  const std::string convex_and_nonconvex_test =
+      FindResourceOrThrow(resource_dir + "convex_and_nonconvex_test.urdf");
+
+  EXPECT_NO_THROW(ParseUrdfGeometry(convex_and_nonconvex_test));
+
+  ASSERT_EQ(collision_instances_.size(), 2);
+
+  {
+    const auto& instance = collision_instances_[0];
+    const geometry::Convex* convex =
+        dynamic_cast<const geometry::Convex*>(&instance.shape());
+    ASSERT_TRUE(convex);
+  }
+
+  {
+    const auto& instance = collision_instances_[1];
+    const geometry::Mesh* mesh =
+        dynamic_cast<const geometry::Mesh*>(&instance.shape());
+    ASSERT_TRUE(mesh);
+  }
+}
+
 }  // namespace
 }  // namespace detail
 }  // namespace multibody

--- a/multibody/parsing/test/urdf_parser_test/convex_and_nonconvex_test.urdf
+++ b/multibody/parsing/test/urdf_parser_test/convex_and_nonconvex_test.urdf
@@ -1,0 +1,25 @@
+<?xml version="1.0" ?>
+
+<!--
+This URDF contains a single link with, in order:
+1) A convex-declared mesh, which should parse into geometry::Convex.
+2) A mesh that is not declared to be either, which should parse into
+  geometry::Mesh.
+-->
+<robot name="non_conflicting_materials_2" xmlns:drake="drake.mit.edu">
+  <link name="base_link">
+   <collision>
+      <geometry>
+        <mesh filename="../tri_cube.obj">
+          <drake:declare_convex/>
+        </mesh>
+      </geometry>
+    </collision>
+
+   <collision>
+      <geometry>
+        <mesh filename="../tri_cube.obj"/>
+      </geometry>
+    </collision>
+  </link>
+</robot>


### PR DESCRIPTION
This enables simulation of convex geometry, including [convex-decomposed geometry](https://www.youtube.com/watch?v=xrF1pIUwbvk&t=15s).

I feel like the precise spec update for URDF/SDF should be documented somewhere, but I'm not sure where... any ideas?

@sammy-tri @SeanCurtis-TRI Any chance I could get a review?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11598)
<!-- Reviewable:end -->
