### PR TITLE
pydrake math: Add bindings for missing RotationMatrix methods

### DIFF
--- a/bindings/pydrake/common/test/numpy_compare_test.py
+++ b/bindings/pydrake/common/test/numpy_compare_test.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from pydrake.autodiffutils import AutoDiffXd
 from pydrake.common.test_utilities import numpy_compare
-from pydrake.symbolic import Expression, Variable
+from pydrake.symbolic import Expression, Formula, Variable
 
 
 class Custom(object):
@@ -142,3 +142,6 @@ class TestNumpyCompareSimple(unittest.TestCase):
         numpy_compare.assert_equal(e, "(x + y)")
         numpy_compare.assert_not_equal(e, x - y)
         numpy_compare.assert_not_equal(e, "(x - y)")
+        numpy_compare.assert_equal(Formula.True_(), True)
+        numpy_compare.assert_equal(Formula.False_(), False)
+        numpy_compare.assert_not_equal(Formula.True_(), False)

--- a/bindings/pydrake/common/test_utilities/numpy_compare.py
+++ b/bindings/pydrake/common/test_utilities/numpy_compare.py
@@ -187,8 +187,26 @@ def _register_symbolic():
     def sym_struct_ne(a, b):
         assert not a.EqualTo(b), (a, b)
 
+    def from_bool(x):
+        assert isinstance(x, (bool, np.bool_)), type(x)
+        if x:
+            return Formula.True_()
+        else:
+            return Formula.False_()
+
+    def formula_bool_eq(a, b):
+        return sym_struct_eq(a, from_bool(b))
+
+    def formula_bool_ne(a, b):
+        return sym_struct_ne(a, from_bool(b))
+
     _registry.register_to_float(Expression, Expression.Evaluate)
     _registry.register_comparator(Formula, str, _str_eq, _str_ne)
+    # Ensure that we can do simple boolean comparison, e.g. in lieu of
+    # `unittest.TestCase.assertTrue`, use
+    # `numpy_compare.assert_equal(f, True)`.
+    _registry.register_comparator(
+        Formula, bool, formula_bool_eq, formula_bool_ne)
     lhs_types = [Variable, Expression, Polynomial, Monomial]
     rhs_types = lhs_types + [float]
     for lhs_type in lhs_types:

--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -160,8 +160,6 @@ void DoDefinitions(py::module m, T) {
         .def("IsIdentityToInternalTolerance",
             &Class::IsIdentityToInternalTolerance,
             cls_doc.IsIdentityToInternalTolerance.doc)
-        // .def("IsNearlyEqualTo", ...)
-        // .def("IsExactlyEqualTo", ...)
         // Does not return the quality_factor
         .def_static("ProjectToRotationMatrix",
             [](const Matrix3<T>& M) {

--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -134,7 +134,7 @@ void DoDefinitions(py::module m, T) {
         .def(py::init<Eigen::Quaternion<T>>(), py::arg("quaternion"),
             cls_doc.ctor.doc_1args_quaternion)
         .def(py::init<const Eigen::AngleAxis<T>&>(), py::arg("theta_lambda"),
-            cls_doc.ctor.doc_1args_rpy)  // This is wrong doc string
+            cls_doc.ctor.doc_1args_theta_lambda)
         .def(py::init<const RollPitchYaw<T>&>(), py::arg("rpy"),
             cls_doc.ctor.doc_1args_rpy)
         .def_static("MakeXRotation", &Class::MakeXRotation, py::arg("theta"),

--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -133,17 +133,44 @@ void DoDefinitions(py::module m, T) {
             cls_doc.ctor.doc_1args_R)
         .def(py::init<Eigen::Quaternion<T>>(), py::arg("quaternion"),
             cls_doc.ctor.doc_1args_quaternion)
+        .def(py::init<const Eigen::AngleAxis<T>&>(), py::arg("theta_lambda"),
+            cls_doc.ctor.doc_1args_rpy)  // This is wrong doc string
         .def(py::init<const RollPitchYaw<T>&>(), py::arg("rpy"),
             cls_doc.ctor.doc_1args_rpy)
+        .def_static("MakeXRotation", &Class::MakeXRotation, py::arg("theta"),
+            cls_doc.MakeXRotation.doc)
+        .def_static("MakeYRotation", &Class::MakeYRotation, py::arg("theta"),
+            cls_doc.MakeYRotation.doc)
+        .def_static("MakeZRotation", &Class::MakeZRotation, py::arg("theta"),
+            cls_doc.MakeZRotation.doc)
+        .def_static("Identity", &Class::Identity, cls_doc.Identity.doc)
+        .def("set", &Class::set, py::arg("R"), cls_doc.set.doc)
+        .def("inverse", &Class::inverse, cls_doc.inverse.doc)
+        .def("transpose", &Class::transpose, cls_doc.transpose.doc)
         .def("matrix", &Class::matrix, cls_doc.matrix.doc)
+        .def("row", &Class::row, py::arg("index"), cls_doc.row.doc)
+        .def("col", &Class::col, py::arg("index"), cls_doc.col.doc)
         .def("multiply",
             [](const Class& self, const Class& other) { return self * other; },
             cls_doc.operator_mul.doc_1args_other)
-        .def("inverse", &Class::inverse, cls_doc.inverse.doc)
+        .def("IsValid", overload_cast_explicit<boolean<T>>(&Class::IsValid),
+            cls_doc.IsValid.doc_0args)
+        .def("IsExactlyIdentity", &Class::IsExactlyIdentity,
+            cls_doc.IsExactlyIdentity.doc)
+        .def("IsIdentityToInternalTolerance",
+            &Class::IsIdentityToInternalTolerance,
+            cls_doc.IsIdentityToInternalTolerance.doc)
+        // .def("IsNearlyEqualTo", ...)
+        // .def("IsExactlyEqualTo", ...)
+        // Does not return the quality_factor
+        .def_static("ProjectToRotationMatrix",
+            [](const Matrix3<T>& M) {
+              return RotationMatrix<T>::ProjectToRotationMatrix(M);
+            },
+            py::arg("M"), cls_doc.ProjectToRotationMatrix.doc)
         .def("ToQuaternion",
             overload_cast_explicit<Eigen::Quaternion<T>>(&Class::ToQuaternion),
-            cls_doc.ToQuaternion.doc_0args)
-        .def_static("Identity", &Class::Identity, cls_doc.Identity.doc);
+            cls_doc.ToQuaternion.doc_0args);
     cls.attr("__matmul__") = cls.attr("multiply");
     DefCopyAndDeepCopy(&cls);
   }

--- a/bindings/pydrake/test/math_test.py
+++ b/bindings/pydrake/test/math_test.py
@@ -174,6 +174,7 @@ class TestMath(unittest.TestCase):
     def check_rotation_matrix(self, T):
         # - Constructors.
         RotationMatrix = mut.RotationMatrix_[T]
+        AngleAxis = AngleAxis_[T]
         Quaternion = Quaternion_[T]
         RollPitchYaw = mut.RollPitchYaw_[T]
 
@@ -188,7 +189,22 @@ class TestMath(unittest.TestCase):
         numpy_compare.assert_float_equal(R.matrix(), np.eye(3))
         R = RotationMatrix(quaternion=Quaternion.Identity())
         numpy_compare.assert_float_equal(R.matrix(), np.eye(3))
+        R = RotationMatrix(theta_lambda=AngleAxis(angle=0, axis=[0, 0, 1]))
+        numpy_compare.assert_float_equal(R.matrix(), np.eye(3))
         R = RotationMatrix(rpy=RollPitchYaw(rpy=[0, 0, 0]))
+        numpy_compare.assert_float_equal(R.matrix(), np.eye(3))
+        # One axis RotationMatrices
+        R = RotationMatrix.MakeXRotation(theta=0)
+        numpy_compare.assert_float_equal(R.matrix(), np.eye(3))
+        R = RotationMatrix.MakeYRotation(theta=0)
+        numpy_compare.assert_float_equal(R.matrix(), np.eye(3))
+        R = RotationMatrix.MakeZRotation(theta=0)
+        numpy_compare.assert_float_equal(R.matrix(), np.eye(3))
+        # TODO(eric.cousineau): #11575, remove the conditional.
+        if T == float:
+            numpy_compare.assert_float_equal(R.row(index=0), [1., 0., 0.])
+            numpy_compare.assert_float_equal(R.col(index=0), [1., 0., 0.])
+        R.set(R=np.eye(3))
         numpy_compare.assert_float_equal(R.matrix(), np.eye(3))
         # - Nontrivial quaternion.
         q = Quaternion(wxyz=[0.5, 0.5, 0.5, 0.5])
@@ -196,9 +212,19 @@ class TestMath(unittest.TestCase):
         q_R = R.ToQuaternion()
         numpy_compare.assert_float_equal(
                 q.wxyz(), numpy_compare.to_float(q_R.wxyz()))
-        # - Inverse.
+        # - Inverse, transpose, projection
         R_I = R.inverse().multiply(R)
         numpy_compare.assert_float_equal(R_I.matrix(), np.eye(3))
+        R_T = R.transpose().multiply(R)
+        numpy_compare.assert_float_equal(R_T.matrix(), np.eye(3))
+        R_P = RotationMatrix.ProjectToRotationMatrix(M=2*np.eye(3))
+        numpy_compare.assert_float_equal(R_P.matrix(), np.eye(3))
+        # Matrix checks
+        if T == float or T == AutoDiffXd:
+            self.assertTrue(R.IsValid())
+            R = RotationMatrix()
+            self.assertTrue(R.IsExactlyIdentity())
+            self.assertTrue(R.IsIdentityToInternalTolerance())
         if six.PY3:
             numpy_compare.assert_float_equal(
                     eval("R.inverse() @ R").matrix(), np.eye(3))

--- a/bindings/pydrake/test/math_test.py
+++ b/bindings/pydrake/test/math_test.py
@@ -211,7 +211,7 @@ class TestMath(unittest.TestCase):
         R = RotationMatrix(quaternion=q)
         q_R = R.ToQuaternion()
         numpy_compare.assert_float_equal(
-                q.wxyz(), numpy_compare.to_float(q_R.wxyz()))
+            q.wxyz(), numpy_compare.to_float(q_R.wxyz()))
         # - Inverse, transpose, projection
         R_I = R.inverse().multiply(R)
         numpy_compare.assert_float_equal(R_I.matrix(), np.eye(3))
@@ -220,11 +220,10 @@ class TestMath(unittest.TestCase):
         R_P = RotationMatrix.ProjectToRotationMatrix(M=2*np.eye(3))
         numpy_compare.assert_float_equal(R_P.matrix(), np.eye(3))
         # Matrix checks
-        if T == float or T == AutoDiffXd:
-            self.assertTrue(R.IsValid())
-            R = RotationMatrix()
-            self.assertTrue(R.IsExactlyIdentity())
-            self.assertTrue(R.IsIdentityToInternalTolerance())
+        numpy_compare.assert_equal(R.IsValid(), True)
+        R = RotationMatrix()
+        numpy_compare.assert_equal(R.IsExactlyIdentity(), True)
+        numpy_compare.assert_equal(R.IsIdentityToInternalTolerance(), True)
         if six.PY3:
             numpy_compare.assert_float_equal(
                     eval("R.inverse() @ R").matrix(), np.eye(3))

--- a/math/rotation_matrix.h
+++ b/math/rotation_matrix.h
@@ -65,6 +65,9 @@ class RotationMatrix {
   /// @throws std::logic_error in debug builds if R fails IsValid(R).
   explicit RotationMatrix(const Matrix3<T>& R) { set(R); }
 
+  // TODO(mitiguy) Although this method is fairly efficient, consider adding an
+  // optional second argument if `quaternion` is known to be normalized apriori
+  // or for some reason the calling site does not want `quaternion` normalized.
   /// Constructs a %RotationMatrix from an Eigen::Quaternion.
   /// @param[in] quaternion a non-zero, finite quaternion which may or may not
   /// have unit length [i.e., `quaternion.norm()` does not have to be 1].
@@ -73,9 +76,6 @@ class RotationMatrix {
   /// exception is thrown if `quaternion` is zero or contains a NaN or infinity.
   /// @note This method has the effect of normalizing its `quaternion` argument,
   /// without the inefficiency of the square-root associated with normalization.
-  // TODO(mitiguy) Although this method is fairly efficient, consider adding an
-  // optional second argument if `quaternion` is known to be normalized apriori
-  // or for some reason the calling site does not want `quaternion` normalized.
   explicit RotationMatrix(const Eigen::Quaternion<T>& quaternion) {
     // Cost for various way to create a rotation matrix from a quaternion.
     // Eigen quaternion.toRotationMatrix() = 12 multiplies, 12 adds.
@@ -86,6 +86,12 @@ class RotationMatrix {
     set(QuaternionToRotationMatrix(quaternion, two_over_norm_squared));
   }
 
+  // @internal In general, the %RotationMatrix constructed by passing a non-unit
+  // `lambda` to this method is different than the %RotationMatrix produced by
+  // converting `lambda` to an un-normalized quaternion and calling the
+  // %RotationMatrix constructor (above) with that un-normalized quaternion.
+  // TODO(mitiguy) Consider adding an optional second argument if `lambda` is
+  // known to be normalized apriori or calling site does not want normalization.
   /// Constructs a %RotationMatrix from an Eigen::AngleAxis.
   /// @param[in] theta_lambda an Eigen::AngleAxis whose associated axis (vector
   /// direction herein called `lambda`) is non-zero and finite, but which may or
@@ -93,12 +99,6 @@ class RotationMatrix {
   /// @throws std::logic_error in debug builds if the rotation matrix
   /// R that is built from `theta_lambda` fails IsValid(R).  For example, an
   /// exception is thrown if `lambda` is zero or contains a NaN or infinity.
-  // @internal In general, the %RotationMatrix constructed by passing a non-unit
-  // `lambda` to this method is different than the %RotationMatrix produced by
-  // converting `lambda` to an un-normalized quaternion and calling the
-  // %RotationMatrix constructor (above) with that un-normalized quaternion.
-  // TODO(mitiguy) Consider adding an optional second argument if `lambda` is
-  // known to be normalized apriori or calling site does not want normalization.
   explicit RotationMatrix(const Eigen::AngleAxis<T>& theta_lambda) {
     const Vector3<T>& lambda = theta_lambda.axis();
     const T norm = lambda.norm();

--- a/math/rotation_matrix.h
+++ b/math/rotation_matrix.h
@@ -65,9 +65,6 @@ class RotationMatrix {
   /// @throws std::logic_error in debug builds if R fails IsValid(R).
   explicit RotationMatrix(const Matrix3<T>& R) { set(R); }
 
-  // TODO(mitiguy) Although this method is fairly efficient, consider adding an
-  // optional second argument if `quaternion` is known to be normalized apriori
-  // or for some reason the calling site does not want `quaternion` normalized.
   /// Constructs a %RotationMatrix from an Eigen::Quaternion.
   /// @param[in] quaternion a non-zero, finite quaternion which may or may not
   /// have unit length [i.e., `quaternion.norm()` does not have to be 1].
@@ -77,6 +74,10 @@ class RotationMatrix {
   /// @note This method has the effect of normalizing its `quaternion` argument,
   /// without the inefficiency of the square-root associated with normalization.
   explicit RotationMatrix(const Eigen::Quaternion<T>& quaternion) {
+    // TODO(mitiguy) Although this method is fairly efficient, consider adding
+    // an optional second argument if `quaternion` is known to be normalized
+    // apriori or for some reason the calling site does not want `quaternion`
+    // normalized.
     // Cost for various way to create a rotation matrix from a quaternion.
     // Eigen quaternion.toRotationMatrix() = 12 multiplies, 12 adds.
     // Drake  QuaternionToRotationMatrix() = 12 multiplies, 12 adds.
@@ -90,8 +91,6 @@ class RotationMatrix {
   // `lambda` to this method is different than the %RotationMatrix produced by
   // converting `lambda` to an un-normalized quaternion and calling the
   // %RotationMatrix constructor (above) with that un-normalized quaternion.
-  // TODO(mitiguy) Consider adding an optional second argument if `lambda` is
-  // known to be normalized apriori or calling site does not want normalization.
   /// Constructs a %RotationMatrix from an Eigen::AngleAxis.
   /// @param[in] theta_lambda an Eigen::AngleAxis whose associated axis (vector
   /// direction herein called `lambda`) is non-zero and finite, but which may or
@@ -100,13 +99,15 @@ class RotationMatrix {
   /// R that is built from `theta_lambda` fails IsValid(R).  For example, an
   /// exception is thrown if `lambda` is zero or contains a NaN or infinity.
   explicit RotationMatrix(const Eigen::AngleAxis<T>& theta_lambda) {
+    // TODO(mitiguy) Consider adding an optional second argument if `lambda` is
+    // known to be normalized apriori or calling site does not want
+    // normalization.
     const Vector3<T>& lambda = theta_lambda.axis();
     const T norm = lambda.norm();
     const T& theta = theta_lambda.angle();
     set(Eigen::AngleAxis<T>(theta, lambda / norm).toRotationMatrix());
   }
 
-  // TODO(@mitiguy) Add Sherm/Goldstein's way to visualize rotation sequences.
   /// Constructs a %RotationMatrix from an %RollPitchYaw.  In other words,
   /// makes the %RotationMatrix for a Space-fixed (extrinsic) X-Y-Z rotation by
   /// "roll-pitch-yaw" angles `[r, p, y]`, which is equivalent to a Body-fixed
@@ -137,6 +138,7 @@ class RotationMatrix {
   /// rotate relative to frame A by a roll angle `y` about `Bz = Az`.
   /// Note: B and A are no longer aligned.
   explicit RotationMatrix(const RollPitchYaw<T>& rpy) {
+    // TODO(@mitiguy) Add Sherm/Goldstein's way to visualize rotation sequences.
     const T& r = rpy.roll_angle();
     const T& p = rpy.pitch_angle();
     const T& y = rpy.yaw_angle();


### PR DESCRIPTION
Also reordered some of the RotationMatrix bindings to match the C++ ordering.

Closes #11585 
/cc @kunimatsu-tri

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11604)
<!-- Reviewable:end -->
