### PR TITLE
py manipulation_station: Hotfix for deprecated `SetupDefaultStation`

### DIFF
--- a/bindings/pydrake/examples/manipulation_station_py.cc
+++ b/bindings/pydrake/examples/manipulation_station_py.cc
@@ -47,15 +47,15 @@ PYBIND11_MODULE(manipulation_station, m) {
           py::arg("collision_model") = IiwaCollisionModel::kNoCollision,
           doc.ManipulationStation.SetupManipulationClassStation.doc)
       .def("SetupDefaultStation",
-          [](ManipulationStation<T>* self,
-              IiwaCollisionModel collision_model =
-                  IiwaCollisionModel::kNoCollision) {
+          [](ManipulationStation<T>* self, IiwaCollisionModel collision_model) {
             WarnDeprecated(
                 "SetupDefaultStation is deprecated and will be removed on or"
                 "around 2019-09-01.  Please use SetupManipulationClassStation "
                 "instead.");
             self->SetupManipulationClassStation(collision_model);
-          })
+          },
+          py::arg("collision_model") = IiwaCollisionModel::kNoCollision,
+          doc.ManipulationStation.SetupDefaultStation.doc_deprecated)
       .def("SetupClutterClearingStation",
           &ManipulationStation<T>::SetupClutterClearingStation,
           py::arg("X_WCameraBody") = nullopt,


### PR DESCRIPTION
Hotfix for #11541 - I didn't fully review the deprecation, oops!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11607)
<!-- Reviewable:end -->
