### PR TITLE
install: Factor our libdrake_marker install rule

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -538,6 +538,11 @@ drake_py_binary(
 )
 
 install(
+    name = "install_drake_marker",
+    targets = [":libdrake_marker.so"],
+)
+
+install(
     name = "install",
     install_tests = [":test/resource_tool_installed_test.py"],
     targets = [
@@ -551,6 +556,9 @@ install(
     data_dest = "share/drake",
     guess_data = "WORKSPACE",
     allowed_externals = [DRAKE_RESOURCE_SENTINEL],
+    deps = [
+        ":install_drake_marker",
+    ],
 )
 
 # === test/ ===


### PR DESCRIPTION
This offers a public target that installs only the marker library, without resource_tool.  This is useful to install in bazel external environments that do not want to depend on gflags.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11609)
<!-- Reviewable:end -->
