### PR TITLE
Hydroelastic traction quadrature

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -190,6 +190,13 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "surface_mesh_test",
+    deps = [
+        "//geometry/proximity:mesh_field",
+    ],
+)
+
+drake_cc_googletest(
     name = "volume_mesh_test",
     deps = [
         "//geometry/proximity:volume_mesh",

--- a/geometry/proximity/surface_mesh.h
+++ b/geometry/proximity/surface_mesh.h
@@ -160,10 +160,17 @@ class SurfaceMesh {
    */
   SurfaceMesh(std::vector<SurfaceFace>&& faces,
               std::vector<SurfaceVertex<T>>&& vertices)
-      : faces_(std::move(faces)),
-        area_(faces_.size()),
-        vertices_(std::move(vertices)) {
-    init();
+      : faces_(std::move(faces)), vertices_(std::move(vertices)),
+        area_(faces_.size()),  // Pre-allocate here, not yet calculated.
+        total_area_(0.), p_MSc_(Vector3<T>::Zero()) {
+    // Calculate areas and accumulate area-weighted surface centroid Sc.
+    for (SurfaceFaceIndex f(0); f < faces_.size(); ++f) {
+      AccumulateAreaAndCentroidForFace(f);
+    }
+
+    // Finalize centroid.
+    if (total_area_ != T(0.))
+      p_MSc_ /= (3. * total_area_);
   }
 
   /** Returns the number of triangular elements in the mesh.
@@ -174,10 +181,26 @@ class SurfaceMesh {
    */
   const T& area(SurfaceFaceIndex f) const { return area_[f]; }
 
+  /** Returns the total area of all the faces of this surface mesh.
+   */
+  const T& total_area() const { return total_area_; }
+
+  /** Returns the area-weighted geometric centroid of this surface mesh. The
+   returned value is the position vector p_MSc from M's origin to the
+   centroid Sc, expressed in frame M. (M is the frame in which this mesh's
+   vertices are measured and expressed.) Note that the centroid is not
+   necessarily a point on the surface. If the total mesh area is exactly
+   zero, we define the centroid to be (0,0,0).
+
+   The centroid location is calculated _per face_ not _per vertex_ so is
+   insensitive to whether vertices are shared by faces.
+   */
+  const Vector3<T>& centroid() const { return p_MSc_; }
+
   /** 
    Maps the barycentric coordinates `Q_barycentric` of a point Q in
    `element_index` to its position vector p_MQ.
-  */
+   */
   Vector3<T> CalcCartesianFromBarycentric(
       ElementIndex element_index, const Vector3<T>& Q_barycentric) const {
     const SurfaceVertex<T> va = vertex(element(element_index).vertex(0));
@@ -195,33 +218,41 @@ class SurfaceMesh {
   }
 
  private:
-  // Initialization.
-  void init();
-  // Evaluate area of a triangular face.
-  T EvaluateFaceArea(SurfaceFaceIndex f);
+  // Evaluate area and centroid of a triangular face.
+  void AccumulateAreaAndCentroidForFace(SurfaceFaceIndex f);
+
   // The triangles that comprise the surface.
   std::vector<SurfaceFace> faces_;
-  // Area of the triangles. Computed in initialization.
-  std::vector<T> area_;
-  // The vertices that are shared between the triangles.
+  // The vertices that are shared among the triangles.
   std::vector<SurfaceVertex<T>> vertices_;
+
+  // Computed in initialization.
+
+  // Area of the triangles.
+  std::vector<T> area_;
+  T total_area_{};
+
+  // Area-weighted geometric centroid Sc of the surface mesh.
+  Vector3<T> p_MSc_;
 };
 
 template <class T>
-void SurfaceMesh<T>::init() {
-  for (SurfaceFaceIndex f(0); f < faces_.size(); ++f)
-    area_[f] = EvaluateFaceArea(f);
-}
-
-template <class T>
-T SurfaceMesh<T>::EvaluateFaceArea(SurfaceFaceIndex f) {
-  const auto& r_MA = vertices_[faces_[f].vertex(0)].r_MV();
-  const auto& r_MB = vertices_[faces_[f].vertex(1)].r_MV();
-  const auto& r_MC = vertices_[faces_[f].vertex(2)].r_MV();
+void SurfaceMesh<T>::AccumulateAreaAndCentroidForFace(SurfaceFaceIndex f) {
+  const SurfaceFace& face = faces_[f];
+  const Vector3<T>& r_MA = vertices_[face.vertex(0)].r_MV();
+  const Vector3<T>& r_MB = vertices_[face.vertex(1)].r_MV();
+  const Vector3<T>& r_MC = vertices_[face.vertex(2)].r_MV();
   const auto r_UV_M = r_MB - r_MA;
   const auto r_UW_M = r_MC - r_MA;
+
   const auto cross = r_UV_M.cross(r_UW_M);
-  return T(0.5)*cross.norm();
+  const T face_area = T(0.5) * cross.norm();
+  area_[f] = face_area;
+  total_area_ += face_area;
+
+  // Accumulate area-weighted surface centroid; must be divided by 3X the
+  // total area afterwards.
+  p_MSc_ += face_area * (r_MA + r_MB + r_MC);
 }
 
 }  // namespace geometry

--- a/geometry/proximity/surface_mesh.h
+++ b/geometry/proximity/surface_mesh.h
@@ -165,7 +165,7 @@ class SurfaceMesh {
         total_area_(0.), p_MSc_(Vector3<T>::Zero()) {
     // Calculate areas and accumulate area-weighted surface centroid Sc.
     for (SurfaceFaceIndex f(0); f < faces_.size(); ++f) {
-      AccumulateAreaAndCentroidForFace(f);
+      AccumulateAreaAndCentroidFromFace(f);
     }
 
     // Finalize centroid.
@@ -219,7 +219,7 @@ class SurfaceMesh {
 
  private:
   // Evaluate area and centroid of a triangular face.
-  void AccumulateAreaAndCentroidForFace(SurfaceFaceIndex f);
+  void AccumulateAreaAndCentroidFromFace(SurfaceFaceIndex f);
 
   // The triangles that comprise the surface.
   std::vector<SurfaceFace> faces_;
@@ -232,12 +232,13 @@ class SurfaceMesh {
   std::vector<T> area_;
   T total_area_{};
 
-  // Area-weighted geometric centroid Sc of the surface mesh.
+  // Area-weighted geometric centroid Sc of the surface mesh as an offset vector
+  // from the origin of Frame M to point Sc, expressed in Frame M.
   Vector3<T> p_MSc_;
 };
 
 template <class T>
-void SurfaceMesh<T>::AccumulateAreaAndCentroidForFace(SurfaceFaceIndex f) {
+void SurfaceMesh<T>::AccumulateAreaAndCentroidFromFace(SurfaceFaceIndex f) {
   const SurfaceFace& face = faces_[f];
   const Vector3<T>& r_MA = vertices_[face.vertex(0)].r_MV();
   const Vector3<T>& r_MB = vertices_[face.vertex(1)].r_MV();

--- a/geometry/proximity/surface_mesh.h
+++ b/geometry/proximity/surface_mesh.h
@@ -161,16 +161,8 @@ class SurfaceMesh {
   SurfaceMesh(std::vector<SurfaceFace>&& faces,
               std::vector<SurfaceVertex<T>>&& vertices)
       : faces_(std::move(faces)), vertices_(std::move(vertices)),
-        area_(faces_.size()),  // Pre-allocate here, not yet calculated.
-        total_area_(0.), p_MSc_(Vector3<T>::Zero()) {
-    // Calculate areas and accumulate area-weighted surface centroid Sc.
-    for (SurfaceFaceIndex f(0); f < faces_.size(); ++f) {
-      AccumulateAreaAndCentroidFromFace(f);
-    }
-
-    // Finalize centroid.
-    if (total_area_ != T(0.))
-      p_MSc_ /= (3. * total_area_);
+        area_(faces_.size()) {  // Pre-allocate here, not yet calculated.
+    CalcAreasAndCentroid();
   }
 
   /** Returns the number of triangular elements in the mesh.
@@ -218,8 +210,9 @@ class SurfaceMesh {
   }
 
  private:
-  // Evaluate area and centroid of a triangular face.
-  void AccumulateAreaAndCentroidFromFace(SurfaceFaceIndex f);
+  // Calculates the areas of each triangle, the total area, and the centorid of
+  // the surface.
+  void CalcAreasAndCentroid();
 
   // The triangles that comprise the surface.
   std::vector<SurfaceFace> faces_;
@@ -238,22 +231,31 @@ class SurfaceMesh {
 };
 
 template <class T>
-void SurfaceMesh<T>::AccumulateAreaAndCentroidFromFace(SurfaceFaceIndex f) {
-  const SurfaceFace& face = faces_[f];
-  const Vector3<T>& r_MA = vertices_[face.vertex(0)].r_MV();
-  const Vector3<T>& r_MB = vertices_[face.vertex(1)].r_MV();
-  const Vector3<T>& r_MC = vertices_[face.vertex(2)].r_MV();
-  const auto r_UV_M = r_MB - r_MA;
-  const auto r_UW_M = r_MC - r_MA;
+void SurfaceMesh<T>::CalcAreasAndCentroid() {
+  total_area_ = 0;
+  p_MSc_.setZero();
 
-  const auto cross = r_UV_M.cross(r_UW_M);
-  const T face_area = T(0.5) * cross.norm();
-  area_[f] = face_area;
-  total_area_ += face_area;
+  for (SurfaceFaceIndex f(0); f < faces_.size(); ++f) {
+    const SurfaceFace& face = faces_[f];
+    const Vector3<T>& r_MA = vertices_[face.vertex(0)].r_MV();
+    const Vector3<T>& r_MB = vertices_[face.vertex(1)].r_MV();
+    const Vector3<T>& r_MC = vertices_[face.vertex(2)].r_MV();
+    const auto r_UV_M = r_MB - r_MA;
+    const auto r_UW_M = r_MC - r_MA;
 
-  // Accumulate area-weighted surface centroid; must be divided by 3X the
-  // total area afterwards.
-  p_MSc_ += face_area * (r_MA + r_MB + r_MC);
+    const auto cross = r_UV_M.cross(r_UW_M);
+    const T face_area = T(0.5) * cross.norm();
+    area_[f] = face_area;
+    total_area_ += face_area;
+
+    // Accumulate area-weighted surface centroid; must be divided by 3X the
+    // total area afterwards.
+    p_MSc_ += face_area * (r_MA + r_MB + r_MC);
+  }
+
+  // Finalize centroid.
+  if (total_area_ != T(0.))
+    p_MSc_ /= (3. * total_area_);
 }
 
 }  // namespace geometry

--- a/geometry/proximity/test/surface_mesh_test.cc
+++ b/geometry/proximity/test/surface_mesh_test.cc
@@ -23,7 +23,7 @@ std::unique_ptr<SurfaceMesh<T>> GenerateTwoTriangleMesh() {
   vertices.emplace_back(Vector3<T>(0.5, 0.5, -0.5));
   vertices.emplace_back(Vector3<T>(-0.5, 0.5, -0.5));
   vertices.emplace_back(Vector3<T>(-0.5, -0.5, -0.5));
-  vertices.emplace_back(Vector3<T>(0.5, -0.5, -0.5));
+  vertices.emplace_back(Vector3<T>(1.0, -1.0, -0.5));
 
   // Create the two triangles.
   std::vector<SurfaceFace> faces;
@@ -84,8 +84,8 @@ GTEST_TEST(SurfaceMeshTest, TestArea) {
   const double eps = 10 * std::numeric_limits<double>::epsilon();
   auto surface_mesh = GenerateTwoTriangleMesh<double>();
   EXPECT_NEAR(surface_mesh->area(SurfaceFaceIndex(0)), 0.5, eps);
-  EXPECT_NEAR(surface_mesh->area(SurfaceFaceIndex(1)), 0.5, eps);
-  EXPECT_NEAR(surface_mesh->total_area(), 1.0, eps);
+  EXPECT_NEAR(surface_mesh->area(SurfaceFaceIndex(1)), 1.0, eps);
+  EXPECT_NEAR(surface_mesh->total_area(), 1.5, eps);
 
   // Verify that the empty mesh and the zero area mesh both give zero area.
   EXPECT_NEAR(GenerateEmptyMesh()->total_area(), 0.0, eps);
@@ -97,8 +97,8 @@ GTEST_TEST(SurfaceMeshTest, TestCentroid) {
   const double eps = 10 * std::numeric_limits<double>::epsilon();
   auto surface_mesh = GenerateTwoTriangleMesh<double>();
   const Vector3<double> centroid = surface_mesh->centroid();
-  EXPECT_NEAR(centroid[0], 0, eps);
-  EXPECT_NEAR(centroid[1], 0, eps);
+  EXPECT_NEAR(centroid[0], 1.0/6, eps);
+  EXPECT_NEAR(centroid[1], -1.0/6, eps);
   EXPECT_NEAR(centroid[2], -0.5, eps);
 
   // The documentation for the centroid method specifies particular behavior

--- a/geometry/proximity/test/surface_mesh_test.cc
+++ b/geometry/proximity/test/surface_mesh_test.cc
@@ -26,7 +26,8 @@ std::unique_ptr<SurfaceMesh<T>> GenerateTwoTriangleMesh() {
   vertices.emplace_back(Vector3<T>(-0.5, -0.5, -0.5));
   vertices.emplace_back(Vector3<T>(1.0, -1.0, -0.5));
 
-  // Create the two triangles.
+  // Create the two triangles. Note that SurfaceMesh does not specify (or use) a
+  // particular winding.
   std::vector<SurfaceFace> faces;
   faces.emplace_back(
       SurfaceVertexIndex(0), SurfaceVertexIndex(1), SurfaceVertexIndex(2));
@@ -82,30 +83,30 @@ GTEST_TEST(SurfaceMeshTest, GenerateTwoTriangleMeshAutoDiffXd) {
 
 // Checks the area calculations.
 GTEST_TEST(SurfaceMeshTest, TestArea) {
-  const double eps = 10 * std::numeric_limits<double>::epsilon();
+  const double tol = 10 * std::numeric_limits<double>::epsilon();
   auto surface_mesh = GenerateTwoTriangleMesh<double>();
-  EXPECT_NEAR(surface_mesh->area(SurfaceFaceIndex(0)), 0.5, eps);
-  EXPECT_NEAR(surface_mesh->area(SurfaceFaceIndex(1)), 1.0, eps);
-  EXPECT_NEAR(surface_mesh->total_area(), 1.5, eps);
+  EXPECT_NEAR(surface_mesh->area(SurfaceFaceIndex(0)), 0.5, tol);
+  EXPECT_NEAR(surface_mesh->area(SurfaceFaceIndex(1)), 1.0, tol);
+  EXPECT_NEAR(surface_mesh->total_area(), 1.5, tol);
 
   // Verify that the empty mesh and the zero area mesh both give zero area.
-  EXPECT_NEAR(GenerateEmptyMesh()->total_area(), 0.0, eps);
-  EXPECT_NEAR(GenerateZeroAreaMesh()->total_area(), 0.0, eps);
+  EXPECT_NEAR(GenerateEmptyMesh()->total_area(), 0.0, tol);
+  EXPECT_NEAR(GenerateZeroAreaMesh()->total_area(), 0.0, tol);
 }
 
 // Checks the centroid calculations.
 GTEST_TEST(SurfaceMeshTest, TestCentroid) {
-  const double eps = 10 * std::numeric_limits<double>::epsilon();
+  const double tol = 10 * std::numeric_limits<double>::epsilon();
   auto surface_mesh = GenerateTwoTriangleMesh<double>();
   const Vector3<double> centroid = surface_mesh->centroid();
-  EXPECT_NEAR(centroid[0], 1.0/6, eps);
-  EXPECT_NEAR(centroid[1], -1.0/6, eps);
-  EXPECT_NEAR(centroid[2], -0.5, eps);
+  EXPECT_NEAR(centroid[0], 1.0/6, tol);
+  EXPECT_NEAR(centroid[1], -1.0/6, tol);
+  EXPECT_NEAR(centroid[2], -0.5, tol);
 
   // The documentation for the centroid method specifies particular behavior
   // when the total area is zero. Test that.
-  EXPECT_NEAR(GenerateEmptyMesh()->centroid().norm(), 0.0, eps);
-  EXPECT_NEAR(GenerateZeroAreaMesh()->centroid().norm(), 0.0, eps);
+  EXPECT_NEAR(GenerateEmptyMesh()->centroid().norm(), 0.0, tol);
+  EXPECT_NEAR(GenerateZeroAreaMesh()->centroid().norm(), 0.0, tol);
 }
 
 }  // namespace

--- a/geometry/proximity/test/surface_mesh_test.cc
+++ b/geometry/proximity/test/surface_mesh_test.cc
@@ -1,0 +1,111 @@
+#include "drake/geometry/proximity/surface_mesh.h"
+
+#include <memory>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/autodiff.h"
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace geometry {
+
+// Used for testing instantiation of SurfaceMesh and inspecting its components.
+template <typename T>
+std::unique_ptr<SurfaceMesh<T>> GenerateTwoTriangleMesh() {
+  // The surface mesh will consist of four vertices and two faces and will
+  // be constructed such that area and geometric centroid are straightforward
+  // to check.
+
+  // Create the vertices.
+  std::vector<SurfaceVertex<T>> vertices;
+  vertices.emplace_back(Vector3<T>(0.5, 0.5, -0.5));
+  vertices.emplace_back(Vector3<T>(-0.5, 0.5, -0.5));
+  vertices.emplace_back(Vector3<T>(-0.5, -0.5, -0.5));
+  vertices.emplace_back(Vector3<T>(0.5, -0.5, -0.5));
+
+  // Create the two triangles.
+  std::vector<SurfaceFace> faces;
+  faces.emplace_back(
+      SurfaceVertexIndex(0), SurfaceVertexIndex(1), SurfaceVertexIndex(2));
+  faces.emplace_back(
+      SurfaceVertexIndex(2), SurfaceVertexIndex(3), SurfaceVertexIndex(0));
+
+  return std::make_unique<SurfaceMesh<T>>(
+      std::move(faces), std::move(vertices));
+}
+
+// Generates an empty mesh.
+std::unique_ptr<SurfaceMesh<double>> GenerateEmptyMesh() {
+  std::vector<SurfaceVertex<double>> vertices;
+  std::vector<SurfaceFace> faces;
+  return std::make_unique<SurfaceMesh<double>>(
+      std::move(faces), std::move(vertices));
+}
+
+// Generates a zero-area mesh.
+std::unique_ptr<SurfaceMesh<double>> GenerateZeroAreaMesh() {
+  // The surface mesh will consist of four vertices and two faces.
+
+  // Create the vertices.
+  std::vector<SurfaceVertex<double>> vertices;
+  for (int i = 0; i < 4; ++i)
+    vertices.emplace_back(Vector3<double>::Zero());
+
+  // Create the two triangles.
+  std::vector<SurfaceFace> faces;
+  faces.emplace_back(
+      SurfaceVertexIndex(0), SurfaceVertexIndex(1), SurfaceVertexIndex(2));
+  faces.emplace_back(
+      SurfaceVertexIndex(2), SurfaceVertexIndex(3), SurfaceVertexIndex(0));
+
+  return std::make_unique<SurfaceMesh<double>>(
+      std::move(faces), std::move(vertices));
+}
+
+// Test instantiation of SurfaceMesh using `double` as the underlying scalar
+// type.
+GTEST_TEST(SurfaceMeshTest, GenerateTwoTriangleMeshDouble) {
+  auto surface_mesh = GenerateTwoTriangleMesh<double>();
+  EXPECT_EQ(surface_mesh->num_faces(), 2);
+}
+
+// Smoke tests using `AutoDiffXd` as the underlying scalar type. The purpose
+// of this test is simply to check that it compiles. There is no test of
+// differentiation.
+GTEST_TEST(SurfaceMeshTest, GenerateTwoTriangleMeshAutoDiffXd) {
+  auto surface_mesh = GenerateTwoTriangleMesh<AutoDiffXd>();
+  EXPECT_EQ(surface_mesh->num_faces(), 2);
+}
+
+// Checks the area calculations.
+GTEST_TEST(SurfaceMeshTest, TestArea) {
+  const double eps = 10 * std::numeric_limits<double>::epsilon();
+  auto surface_mesh = GenerateTwoTriangleMesh<double>();
+  EXPECT_NEAR(surface_mesh->area(SurfaceFaceIndex(0)), 0.5, eps);
+  EXPECT_NEAR(surface_mesh->area(SurfaceFaceIndex(1)), 0.5, eps);
+  EXPECT_NEAR(surface_mesh->total_area(), 1.0, eps);
+
+  // Verify that the empty mesh and the zero area mesh both give zero area.
+  EXPECT_NEAR(GenerateEmptyMesh()->total_area(), 0.0, eps);
+  EXPECT_NEAR(GenerateZeroAreaMesh()->total_area(), 0.0, eps);
+}
+
+// Checks the centroid calculations.
+GTEST_TEST(SurfaceMeshTest, TestCentroid) {
+  const double eps = 10 * std::numeric_limits<double>::epsilon();
+  auto surface_mesh = GenerateTwoTriangleMesh<double>();
+  const Vector3<double> centroid = surface_mesh->centroid();
+  EXPECT_NEAR(centroid[0], 0, eps);
+  EXPECT_NEAR(centroid[1], 0, eps);
+  EXPECT_NEAR(centroid[2], -0.5, eps);
+
+  // The documentation for the centroid method specifies particular behavior
+  // when the total area is zero. Test that.
+  EXPECT_NEAR(GenerateEmptyMesh()->centroid().norm(), 0.0, eps);
+  EXPECT_NEAR(GenerateZeroAreaMesh()->centroid().norm(), 0.0, eps);
+}
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/test/surface_mesh_test.cc
+++ b/geometry/proximity/test/surface_mesh_test.cc
@@ -10,6 +10,7 @@
 
 namespace drake {
 namespace geometry {
+namespace {
 
 // Used for testing instantiation of SurfaceMesh and inspecting its components.
 template <typename T>
@@ -107,5 +108,6 @@ GTEST_TEST(SurfaceMeshTest, TestCentroid) {
   EXPECT_NEAR(GenerateZeroAreaMesh()->centroid().norm(), 0.0, eps);
 }
 
+}  // namespace
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/query_results/contact_surface.h
+++ b/geometry/query_results/contact_surface.h
@@ -77,15 +77,15 @@ namespace geometry {
   <!-- Note from PR discussion
     1. `∇hₘₙ` *is* a well-behaved vector (subject to some assumptions -- see
         below).
-    2. The contact surface "clips" intersecting goemetries M and N into disjoint
-       geometires M' and N'. `∇hₘₙ` points *out* of M' and *into* N'.
+    2. The contact surface "clips" intersecting geometries M and N into disjoint
+       geometries M' and N'. `∇hₘₙ` points *out* of M' and *into* N'.
     Assumptions:
-    - `∇e` is differntiable and "points outward"
+    - `∇e` is differentiable and "points outward"
 
    TODO(DamrongGuoy):
    1. Document the above listed properties of `∇hₘₙ`.
    2. Add a todo indicating M' and N' should be illustrated in the docs.
-   3. Explicitly add the assumptions on `e` that make this interpretatoin valid.
+   3. Explicitly add the assumptions on `e` that make this interpretation valid.
   -->
 
   Notice that the domain of eₘₙ is the two-dimensional surface 𝕊ₘₙ, while the
@@ -110,10 +110,10 @@ namespace geometry {
   contains Q. With vertices of the triangle labeled as v₀, v₁, v₂, we can
   map (b0, b1, b2) to r_MQ by:
 
-               r_MQ = b0 * r_MV₀ + b1 * r_MV₁ + b2 * r_MV₂,
+               r_MQ = b0 * r_Mv₀ + b1 * r_Mv₁ + b2 * r_Mv₂,
                b0 + b1 + b2 = 1, bᵢ ∈ [0,1],
 
-  where r_MVᵢ is the displacement vector of the vertex labeled as vᵢ from the
+  where r_Mvᵢ is the displacement vector of the vertex labeled as vᵢ from the
   origin of M's frame, expressed in M's frame.
 
   We use the barycentric coordinates to evaluate the field values.

--- a/multibody/plant/hydroelastic_traction_calculator.cc
+++ b/multibody/plant/hydroelastic_traction_calculator.cc
@@ -64,9 +64,14 @@ ComputeSpatialForcesAtBodyOriginsFromHydroelasticModel(
     SpatialForce<T>* F_Ao_W, SpatialForce<T>* F_Bo_W) const {
   DRAKE_DEMAND(F_Ao_W && F_Bo_W);
 
-  // Use a second-order Gaussian quadrature rule. This will be exact for linear
-  // and quadratic pressure fields. We don't expect anything higher order.
-  // TODO(sherm1) Consider 1st-order quadrature for linear pressure fields.
+  // Use a second-order Gaussian quadrature rule. For linear pressure fields,
+  // the second-order rule allows exact computation (to floating point error)
+  // of the moment on the bodies from the integral of the contact tractions.
+  // The moment r × f is a quadratic function of the surface location, since it
+  // is a linear operation (r × f) applied to a (typically) linear function
+  // (i.e., the traction, f). Higher-order pressure fields and nonlinear
+  // tractions (from, e.g., incorporating the Stribeck curve into the friction
+  // model) might see benefit from a higher-order quadrature.
   const GaussianTriangleQuadratureRule gaussian(2 /* order */);
 
   // Collect kinematic data once.

--- a/multibody/plant/hydroelastic_traction_calculator.cc
+++ b/multibody/plant/hydroelastic_traction_calculator.cc
@@ -28,10 +28,13 @@ HydroelasticTractionCalculator<T>::HydroelasticTractionCalculatorData::
     : surface_(*surface) {
   DRAKE_DEMAND(surface);
 
-  // Get the transformation of the geometry for M to the world frame.
+  // Get the transform of the geometry for M to the world frame.
   const auto& query_object = plant.get_geometry_query_input_port().
       template Eval<geometry::QueryObject<T>>(context);
   X_WM_ = query_object.X_WG(surface->id_M());
+
+  const Vector3<T>& p_MC = surface_.mesh().centroid();
+  p_WC_ = X_WM_ * p_MC;
 
   // Get the bodies that the two geometries are affixed to. We'll call these
   // A and B.
@@ -69,68 +72,75 @@ ComputeSpatialForcesAtBodyOriginsFromHydroelasticModel(
   // Collect kinematic data once.
   const HydroelasticTractionCalculatorData data(context, plant, &surface);
 
-  // We'll be accumulating force on body A triangle-by-triangle. Start at zero.
-  F_Ao_W->SetZero();
+  // We'll be accumulating force on body A at the surface centroid C,
+  // triangle-by-triangle.
+  SpatialForce<T> F_Ac_W;
+  F_Ac_W.SetZero();
 
   // Integrate the tractions over all triangles in the contact surface.
   for (geometry::SurfaceFaceIndex i(0); i < surface.mesh().num_faces(); ++i) {
     // Construct the function to be integrated over triangle i.
     // TODO(sherm1) Pull functor creation out of the loop (not a good idea to
     //              create a new functor for every i).
-    std::function<SpatialForce<T>(const Vector3<T>&)> traction =
+    std::function<SpatialForce<T>(const Vector3<T>&)> traction_Ac_W =
         [this, &data, i, dissipation,
          mu_coulomb](const Vector3<T>& Q_barycentric) {
           Vector3<T> p_WQ;
           const Vector3<T> traction_Aq_W = CalcTractionAtPoint(
               data, i, Q_barycentric, dissipation, mu_coulomb, &p_WQ);
-          return ComputeSpatialTractionAtAoFromTractionAtPoint(data, p_WQ,
-                                                               traction_Aq_W);
+          return ComputeSpatialTractionAtAcFromTractionAtAq(data, p_WQ,
+                                                            traction_Aq_W);
         };
 
     // Compute the integral over the triangle to get a force from the
-    // tractions (force/area) at the Gauss points.
-    const SpatialForce<T> Fi_Ao_W =  // Force from triangle i.
+    // tractions (force/area) at the Gauss points (shifted to C).
+    const SpatialForce<T> Fi_Ac_W =  // Force from triangle i.
         TriangleQuadrature<SpatialForce<T>, T>::Integrate(
-            traction, gaussian, surface.mesh().area(i));
+            traction_Ac_W, gaussian, surface.mesh().area(i));
 
     // Update the spatial force at body A's origin.
-    (*F_Ao_W) += Fi_Ao_W;
+    F_Ac_W += Fi_Ac_W;
   }
 
-  // The force on body B is equal and opposite to the force on body A, but we
-  // want it applied at B's origin so we need to shift it also.
+  // The spatial force on body A was accumulated at the surface centroid C. We
+  // need to shift it to A's origin Ao. The force on body B is equal and
+  // opposite to the force on body A, but we want it as if applied at Bo.
+  const Vector3<T>& p_WC = data.p_WC();
   const Vector3<T>& p_WAo = data.X_WA().translation();
   const Vector3<T>& p_WBo = data.X_WB().translation();
-  const Vector3<T> p_AoBo_W = p_WBo - p_WAo;
-  *F_Bo_W = -(F_Ao_W->Shift(p_AoBo_W));
+  const Vector3<T> p_CAo_W = p_WAo - p_WC;
+  const Vector3<T> p_CBo_W = p_WBo - p_WC;
+
+  *F_Ao_W = F_Ac_W.Shift(p_CAo_W);
+  *F_Bo_W = -(F_Ac_W.Shift(p_CBo_W));
 }
 
-// Computes the spatial force at the origin Ao of body A due to the traction at
-// the given contact point.
+// Computes the spatial force on body A acting at a point Ac coincident with
+// the surface centroid C, due to the traction on body A at the given contact
+// point Q.
 // @param data computed once for each pair of geometries.
 // @param p_WQ the position vector from the origin of the world frame to the
 //        contact point Q, expressed in the world frame.
 // @param traction_Aq_W the traction vector applied to Body A at Point Q,
 //        expressed in the world frame, where Body A is the body to which
 //        `surface.M_id()` is fixed.
-// @retval F_Ao_W on return, the spatial traction acting at the origin of
+// @retval Ft_Ac_W on return, the spatial traction acting at point Ac of
 //         Body A resulting from the given traction at Q. (Body A is the one
 //         to which `surface.M_id()` is fixed.)
 template <typename T>
 SpatialForce<T> HydroelasticTractionCalculator<T>::
-    ComputeSpatialTractionAtAoFromTractionAtPoint(
+    ComputeSpatialTractionAtAcFromTractionAtAq(
         const HydroelasticTractionCalculatorData& data, const Vector3<T>& p_WQ,
         const Vector3<T>& traction_Aq_W) const {
-  // Set the two vectors from the contact point to the two body frames, all
-  // expressed in the world frame.
-  const Vector3<T> p_QAo_W = data.X_WA().translation() - p_WQ;
+  // Find the vector from Q to C.
+  const Vector3<T> p_QC_W = data.p_WC() - p_WQ;
 
-  // Convert the traction to a momentless-spatial traction (i.e., without
+  // Convert the traction to a momentless spatial traction (i.e., without
   // changing the point of application), then shift to body A's origin which
-  // will add a moment.
-  const SpatialForce<T> F_Q_W(Vector3<T>(0, 0, 0), traction_Aq_W);
-  const SpatialForce<T> F_Ao_W = F_Q_W.Shift(p_QAo_W);
-  return F_Ao_W;  // Still a traction (force/area).
+  // will add a moment. (We're using "Ft" for spatial traction.)
+  const SpatialForce<T> Ft_Aq_W(Vector3<T>(0, 0, 0), traction_Aq_W);
+  const SpatialForce<T> Ft_Ac_W = Ft_Aq_W.Shift(p_QC_W);
+  return Ft_Ac_W;  // Still a traction (force/area).
 }
 
 template <typename T>
@@ -139,6 +149,7 @@ Vector3<T> HydroelasticTractionCalculator<T>::CalcTractionAtPoint(
     SurfaceFaceIndex face_index,
     const typename SurfaceMesh<T>::Barycentric& Q_barycentric,
     double dissipation, double mu_coulomb, Vector3<T>* p_WQ) const {
+  DRAKE_DEMAND(p_WQ != nullptr);
   // Compute the point of contact in the world frame.
   const Vector3<T> p_MQ = data.surface().mesh().CalcCartesianFromBarycentric(
       face_index, Q_barycentric);

--- a/multibody/plant/hydroelastic_traction_calculator.h
+++ b/multibody/plant/hydroelastic_traction_calculator.h
@@ -76,6 +76,9 @@ class HydroelasticTractionCalculator {
     // Gets the ContactSurface passed to the data structure on construction.
     const geometry::ContactSurface<T>& surface() const { return surface_; }
 
+    // Gets the surface centroid C, measured and expressed in World.
+    const Vector3<T>& p_WC() const { return p_WC_; }
+
     // Gets the pose from Body A (the body that Geometry `surface.M_id()` in the
     // contact surface is affixed to) relative to the world frame.
     const math::RigidTransform<T>& X_WA() const { return X_WA_; }
@@ -100,6 +103,7 @@ class HydroelasticTractionCalculator {
 
    private:
     const geometry::ContactSurface<T>& surface_;
+    Vector3<T> p_WC_;
     math::RigidTransform<T> X_WM_;
     math::RigidTransform<T> X_WA_;
     math::RigidTransform<T> X_WB_;
@@ -110,13 +114,11 @@ class HydroelasticTractionCalculator {
   Vector3<T> CalcTractionAtPoint(
       const HydroelasticTractionCalculatorData& data,
       geometry::SurfaceFaceIndex face_index,
-      const typename geometry::SurfaceMesh<T>::Barycentric&
-          Q_barycentric, double dissipation, double mu_coulomb,
-      Vector3<T>* p_WQ) const;
+      const typename geometry::SurfaceMesh<T>::Barycentric& Q_barycentric,
+      double dissipation, double mu_coulomb, Vector3<T>* p_WQ) const;
 
-  multibody::SpatialForce<T> ComputeSpatialTractionAtAoFromTractionAtPoint(
-      const HydroelasticTractionCalculatorData& data,
-      const Vector3<T>& p_WQ,
+  multibody::SpatialForce<T> ComputeSpatialTractionAtAcFromTractionAtAq(
+      const HydroelasticTractionCalculatorData& data, const Vector3<T>& p_WQ,
       const Vector3<T>& traction_Aq_W) const;
 
   // The parameter (in m/s) for regularizing the Coulomb friction model.

--- a/multibody/plant/hydroelastic_traction_calculator.h
+++ b/multibody/plant/hydroelastic_traction_calculator.h
@@ -114,12 +114,10 @@ class HydroelasticTractionCalculator {
           Q_barycentric, double dissipation, double mu_coulomb,
       Vector3<T>* p_WQ) const;
 
-  void ComputeSpatialForcesAtBodyOriginsFromTraction(
+  multibody::SpatialForce<T> ComputeSpatialTractionAtAoFromTractionAtPoint(
       const HydroelasticTractionCalculatorData& data,
       const Vector3<T>& p_WQ,
-      const Vector3<T>& traction_Aq_W,
-      multibody::SpatialForce<T>* F_Ao_W,
-      multibody::SpatialForce<T>* F_Bo_W) const;
+      const Vector3<T>& traction_Aq_W) const;
 
   // The parameter (in m/s) for regularizing the Coulomb friction model.
   double vslip_regularizer_{1e-6};

--- a/multibody/plant/hydroelastic_traction_calculator.h
+++ b/multibody/plant/hydroelastic_traction_calculator.h
@@ -27,8 +27,9 @@ namespace internal {
 template <typename T>
 class HydroelasticTractionCalculator {
  public:
-  HydroelasticTractionCalculator() {}
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(HydroelasticTractionCalculator)
+
+  HydroelasticTractionCalculator() {}
 
   /**
    Gets the regularization parameter used for friction (in m/s). The closer
@@ -36,6 +37,20 @@ class HydroelasticTractionCalculator {
    model will approximate Coulomb friction.
    */
   double regularization_scalar() const { return vslip_regularizer_; }
+
+  /**
+   Applies the hydroelastic model to two geometries defined in `surface`,
+   resulting in a pair of spatial forces at the origins of two body frames.
+   The body frames, A and B, are those to which `surface.M_id()` and
+   `surface.N_id()` are affixed, respectively.
+   */
+  void ComputeSpatialForcesAtBodyOriginsFromHydroelasticModel(
+       const systems::Context<T>& context,
+       const MultibodyPlant<T>& plant,
+       const geometry::ContactSurface<T>& surface,
+       double dissipation, double mu_coulomb,
+       multibody::SpatialForce<T>* F_Ao_W,
+       multibody::SpatialForce<T>* F_Bo_W) const;
 
  private:
   // To allow GTEST to test private functions.

--- a/multibody/plant/test/hydroelastic_traction_test.cc
+++ b/multibody/plant/test/hydroelastic_traction_test.cc
@@ -94,15 +94,18 @@ public ::testing::TestWithParam<RigidTransform<double>> {
     // Verify the point of contact.
     for (int i = 0; i < 3; ++i) ASSERT_NEAR(p_WQ[i], p_WQ_expected[i], eps());
 
-    *Ft_Ao_W =
-        traction_calculator().ComputeSpatialTractionAtAoFromTractionAtPoint(
+    const SpatialForce<double> Ft_Ac_W =
+        traction_calculator().ComputeSpatialTractionAtAcFromTractionAtAq(
             calculator_data, p_WQ, traction_Aq_W);
 
-    // Traction on body B is equal and opposite, but shift it to Bo.
+    // Shift to body origins. Traction on body B is equal and opposite.
+    const Vector3<double>& p_WC = calculator_data.p_WC();
     const Vector3<double>& p_WAo = calculator_data.X_WA().translation();
     const Vector3<double>& p_WBo = calculator_data.X_WB().translation();
-    const Vector3<double> p_AoBo_W = p_WBo - p_WAo;
-    *Ft_Bo_W = -(Ft_Ao_W->Shift(p_AoBo_W));
+    const Vector3<double> p_CAo_W = p_WAo - p_WC;
+    const Vector3<double> p_CBo_W = p_WBo - p_WC;
+    *Ft_Ao_W = Ft_Ac_W.Shift(p_CAo_W);
+    *Ft_Bo_W = -(Ft_Ac_W.Shift(p_CBo_W));
   }
 
   void SetBoxTranslationalVelocity(const Vector3<double>& v) {

--- a/multibody/triangle_quadrature/gaussian_triangle_quadrature_rule.h
+++ b/multibody/triangle_quadrature/gaussian_triangle_quadrature_rule.h
@@ -97,13 +97,13 @@ class GaussianTriangleQuadratureRule final : public TriangleQuadratureRule {
     }
   }
 
-  int do_order() const override { return order_; }
+  int do_order() const final { return order_; }
 
-  const std::vector<double>& do_weights() const override {
+  const std::vector<double>& do_weights() const final {
     return weights_;
   }
 
-  const std::vector<Vector2<double>>& do_quadrature_points() const override {
+  const std::vector<Vector2<double>>& do_quadrature_points() const final {
     return quadrature_points_;
   }
 

--- a/multibody/triangle_quadrature/triangle_quadrature.h
+++ b/multibody/triangle_quadrature/triangle_quadrature.h
@@ -80,6 +80,9 @@ NumericReturnType TriangleQuadrature<NumericReturnType, T>::Integrate(
     const std::function<NumericReturnType(const Vector3<T>&)>& f,
     const TriangleQuadratureRule& rule,
     const T& area) {
+  // TODO(edrumwri) These composite functions might be slowing computation.
+  //     Consider optimizing this.
+
   // Create a function fprime accepting a 2D barycentric representation but
   // using it to call the given 3D function f.
   std::function<NumericReturnType(const Vector2<T>&)> fprime = [&f](

--- a/multibody/triangle_quadrature/triangle_quadrature.h
+++ b/multibody/triangle_quadrature/triangle_quadrature.h
@@ -35,6 +35,18 @@ class TriangleQuadrature {
       const std::function<NumericReturnType(const Vector2<T>&)>& f,
       const TriangleQuadratureRule& rule,
       const T& area);
+
+  /// Alternative signature for Integrate() that uses three-dimensional
+  /// barycentric coordinates.
+  /// @param f(p) a function that returns a numerical value for point p in the
+  ///        domain of the triangle, specified in barycentric coordinates.
+  ///        The barycentric coordinates are given by
+  ///        (p[0], p[1], p[2]).
+  /// @param area the area of the triangle.
+  static NumericReturnType Integrate(
+      const std::function<NumericReturnType(const Vector3<T>&)>& f,
+      const TriangleQuadratureRule& rule,
+      const T& area);
 };
 
 template <typename NumericReturnType, typename T>
@@ -42,7 +54,6 @@ NumericReturnType TriangleQuadrature<NumericReturnType, T>::Integrate(
     const std::function<NumericReturnType(const Vector2<T>&)>& f,
     const TriangleQuadratureRule& rule,
     const T& area) {
-
   // Get the quadrature points and weights.
   const std::vector<Eigen::Vector2d>& barycentric_coordinates =
       rule.quadrature_points();
@@ -62,6 +73,24 @@ NumericReturnType TriangleQuadrature<NumericReturnType, T>::Integrate(
     integral += f(barycentric_coordinates[i]) * weights[i];
 
   return integral * area;
+}
+
+template <typename NumericReturnType, typename T>
+NumericReturnType TriangleQuadrature<NumericReturnType, T>::Integrate(
+    const std::function<NumericReturnType(const Vector3<T>&)>& f,
+    const TriangleQuadratureRule& rule,
+    const T& area) {
+  // Create a function fprime accepting a 2D barycentric representation but
+  // using it to call the given 3D function f.
+  std::function<NumericReturnType(const Vector2<T>&)> fprime = [&f](
+      const Vector2<T>& barycentric_2D) {
+    return f(Vector3<T>(
+        barycentric_2D[0],
+        barycentric_2D[1],
+        T(1.0) - barycentric_2D[0] - barycentric_2D[1]));
+  };
+
+  return Integrate(fprime, rule, area);
 }
 
 }  // namespace multibody

--- a/multibody/triangle_quadrature/triangle_quadrature_rule.h
+++ b/multibody/triangle_quadrature/triangle_quadrature_rule.h
@@ -22,12 +22,15 @@ class TriangleQuadratureRule {
     return rule_order;
   }
 
-  /// Returns the vector of quadrature points.
+  /// Returns the vector of quadrature points. These are returned as the first
+  /// two barycentric coordinates b0 b1; the third is just b2 = 1 - b0 - b1.
+  /// Each of these has a corresponding weight returned by weights().
   const std::vector<Vector2<double>>& quadrature_points() const {
     return do_quadrature_points();
   }
 
-  /// Returns the vector of weights.
+  /// Returns the vector of weights. These sum to 1 and there is one weight
+  /// for each point returned by quadrature_points().
   const std::vector<double>& weights() const {
     return do_weights();
   }


### PR DESCRIPTION
(Do not review yet)
This is a replacement for @edrumwri's in-progress PR #11596 since he's on vacation (I'll close that PR once the review comments are dealt with). The initial commit was cherry-picked from Evan's branch. The main changes to be made before this goes in are:
- Calculate the force only once and use Newton's 3rd law for the other body
- Ensure that surface tractions are accumulated locally to allow for cancellations, rather than shifting to body frame during accumulation.
- Add unit tests to confirm correctness for cases with & without friction and dissipation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11615)
<!-- Reviewable:end -->
