### PR TITLE
Fix C++17 constexpr storage deprecation warnings

### DIFF
--- a/attic/multibody/rigid_body_tree_alias_groups.cc
+++ b/attic/multibody/rigid_body_tree_alias_groups.cc
@@ -11,10 +11,12 @@
 // system how to omit it, specially since alias_groups.pb.h is not installed.
 #include "drake/attic/multibody/alias_groups.pb.h"
 
+#if  __cplusplus < 201703L
 template <typename T>
 constexpr char RigidBodyTreeAliasGroups<T>::kBodyGroupsKeyword[];
 template <typename T>
 constexpr char RigidBodyTreeAliasGroups<T>::kJointGroupsKeyword[];
+#endif
 
 namespace {
 // Inserts @p vec into @p mapping if @p key does not exist, or appends @p vec

--- a/automotive/maliput_railcar.cc
+++ b/automotive/maliput_railcar.cc
@@ -68,11 +68,12 @@ const LaneDirection& get_lane_direction(
 
 }  // namespace
 
-
+#if  __cplusplus < 201703L
 template <typename T> constexpr T MaliputRailcar<T>::kDefaultInitialS;
 template <typename T> constexpr T MaliputRailcar<T>::kDefaultInitialSpeed;
 template <typename T> constexpr double MaliputRailcar<T>::kLaneEndEpsilon;
 template <typename T> constexpr double MaliputRailcar<T>::kTimeEpsilon;
+#endif
 
 template <typename T>
 MaliputRailcar<T>::MaliputRailcar(const LaneDirection& initial_lane_direction)

--- a/common/hash.cc
+++ b/common/hash.cc
@@ -3,7 +3,9 @@
 namespace drake {
 namespace internal {
 
+#if  __cplusplus < 201703L
 constexpr size_t FNV1aHasher::kFnvPrime;
+#endif
 
 }  // namespace internal
 }  // namespace drake

--- a/common/random.cc
+++ b/common/random.cc
@@ -2,6 +2,8 @@
 
 namespace drake {
 
+#if  __cplusplus < 201703L
 constexpr RandomGenerator::result_type RandomGenerator::default_seed;
+#endif
 
 }  // namespace drake

--- a/common/value.h
+++ b/common/value.h
@@ -599,8 +599,10 @@ struct TypeHash {
   // (Such failures are expected to be rare.)
   static constexpr size_t value = calc();
 };
+#if  __cplusplus < 201703L
 template <typename T>
 constexpr size_t TypeHash<T>::value;
+#endif
 
 // This is called once per process per T whose type_hash is 0.  It logs a
 // TypeHash failure message to Drake's text log.

--- a/manipulation/planner/robot_plan_interpolator.cc
+++ b/manipulation/planner/robot_plan_interpolator.cc
@@ -34,7 +34,9 @@ constexpr int kAbsStateIdxInitFlag = 1;
 
 }  // namespace
 
+#if  __cplusplus < 201703L
 constexpr double RobotPlanInterpolator::kDefaultPlanUpdateInterval;
+#endif
 
 // TODO(sammy-tri) If we had version of Trajectory which supported
 // outputting the derivatives in value(), we could avoid keeping track

--- a/math/roll_pitch_yaw.cc
+++ b/math/roll_pitch_yaw.cc
@@ -10,8 +10,10 @@
 namespace drake {
 namespace math {
 
+#if  __cplusplus < 201703L
 template <class T>
 constexpr double RollPitchYaw<T>::kGimbalLockToleranceCosPitchAngle;
+#endif
 
 template <typename T>
 RotationMatrix<T> RollPitchYaw<T>::ToRotationMatrix() const {

--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -52,8 +52,10 @@ using internal::CreateBinding;
 using internal::DecomposeLinearExpression;
 using internal::SymbolicError;
 
+#if  __cplusplus < 201703L
 constexpr double MathematicalProgram::kGlobalInfeasibleCost;
 constexpr double MathematicalProgram::kUnboundedCost;
+#endif
 
 MathematicalProgram::MathematicalProgram()
     : x_initial_guess_(0),

--- a/systems/framework/test/vector_system_test.cc
+++ b/systems/framework/test/vector_system_test.cc
@@ -136,7 +136,9 @@ class TestVectorSystem : public VectorSystem<double> {
   mutable int time_derivatives_count_{0};
   mutable int discrete_variable_updates_count_{0};
 };
+#if  __cplusplus < 201703L
 constexpr int TestVectorSystem::kSize;
+#endif
 
 class VectorSystemTest : public ::testing::Test {
   // Not yet needed, but placeholder for future common code.

--- a/systems/rendering/frame_velocity.cc
+++ b/systems/rendering/frame_velocity.cc
@@ -6,8 +6,9 @@ namespace drake {
 namespace systems {
 namespace rendering {
 
-// Linkage for kSize.
+#if  __cplusplus < 201703L
 template <typename T> constexpr int FrameVelocity<T>::kSize;
+#endif
 
 template <typename T>
 FrameVelocity<T>::FrameVelocity()

--- a/systems/rendering/pose_vector.cc
+++ b/systems/rendering/pose_vector.cc
@@ -6,8 +6,9 @@ namespace drake {
 namespace systems {
 namespace rendering {
 
-// Linkage for kSize.
+#if  __cplusplus < 201703L
 template <typename T> constexpr int PoseVector<T>::kSize;
+#endif
 
 template <typename T>
 PoseVector<T>::PoseVector()

--- a/systems/sensors/image.cc
+++ b/systems/sensors/image.cc
@@ -4,11 +4,13 @@ namespace drake {
 namespace systems {
 namespace sensors {
 
+#if  __cplusplus < 201703L
 constexpr float InvalidDepth::kTooFar;
 constexpr float InvalidDepth::kTooClose;
 
 constexpr int16_t Label::kNoBody;
 constexpr int16_t Label::kFlatTerrain;
+#endif
 
 }  // namespace sensors
 }  // namespace systems

--- a/systems/sensors/image.h
+++ b/systems/sensors/image.h
@@ -184,6 +184,7 @@ class Label {
     std::numeric_limits<int16_t>::max() - 1};
 };
 
+#if  __cplusplus < 201703L
 template <PixelType kPixelType>
 constexpr int Image<kPixelType>::kNumChannels;
 
@@ -192,6 +193,7 @@ constexpr int Image<kPixelType>::kPixelSize;
 
 template <PixelType kPixelType>
 constexpr PixelFormat Image<kPixelType>::kPixelFormat;
+#endif
 
 }  // namespace sensors
 }  // namespace systems

--- a/systems/sensors/pixel_types.cc
+++ b/systems/sensors/pixel_types.cc
@@ -4,6 +4,7 @@ namespace drake {
 namespace systems {
 namespace sensors {
 
+#if  __cplusplus < 201703L
 constexpr int ImageTraits<PixelType::kRgb8U>::kNumChannels;
 constexpr PixelFormat ImageTraits<PixelType::kRgb8U>::kPixelFormat;
 
@@ -34,6 +35,7 @@ constexpr PixelFormat ImageTraits<PixelType::kGrey8U>::kPixelFormat;
 
 constexpr int ImageTraits<PixelType::kExpr>::kNumChannels;
 constexpr PixelFormat ImageTraits<PixelType::kExpr>::kPixelFormat;
+#endif  // __cplusplus
 
 }  // namespace sensors
 }  // namespace systems


### PR DESCRIPTION
_"If a ... constexpr static data member is odr-used, a definition at namespace scope is ... deprecated for constexpr data members since C++17."_ -- https://en.cppreference.com/w/cpp/language/static

To see the improvement, compare [build of master](https://drake-jenkins.csail.mit.edu/view/C++17/job/linux-bionic-gcc-bazel-experimental-cxx17-release/2/) vs [build of this PR](https://drake-jenkins.csail.mit.edu/view/C++17/job/linux-bionic-gcc-bazel-experimental-cxx17-release/3/).

The full feature branch is tested in #11622.

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11619)
<!-- Reviewable:end -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11619)
<!-- Reviewable:end -->
