### PR TITLE
Fix C++17 optional and variant vs stx

### DIFF
--- a/bindings/pydrake/common/drake_variant_pybind.h
+++ b/bindings/pydrake/common/drake_variant_pybind.h
@@ -10,9 +10,11 @@ namespace detail {
 // Ensure that we expose a type_caster for `stx::variant`.
 // @see pybind11/stl.h, `variant_caster`.
 
+#ifdef STX_NO_STD_VARIANT
 template <typename... Types>
 struct type_caster<stx::variant<Types...>>
     : public variant_caster<stx::variant<Types...>> {};
+#endif
 
 }  // namespace detail
 }  // namespace pybind11

--- a/common/drake_variant.h
+++ b/common/drake_variant.h
@@ -1,26 +1,26 @@
 #pragma once
 
+/// @file
+/// Provides drake::variant as an alias for the appropriate implementation of
+/// std::variant or stx::variant for the C++ toolchain being used.
+
 // For now, #include <stx/variant.hpp> via drake_optional.h; there is a lot of
 // ceremony to include it correctly, which we only want to repeat once.
 #include "drake/common/drake_optional.h"
 
-/// @file
-/// Provides drake::variant as an alias for the appropriate implementation of
-/// std::variant or or stx::variant for the C++ toolchain being used.
-
 namespace drake {
 
+#ifdef STX_NO_STD_VARIANT
 template <typename... Types>
 using variant = stx::variant<Types...>;
-
-#ifdef STX_HAVE_STD_VARIANT
-// The stx::get alias is missing, so we have to do this instead.
-using std::get;
-#else
 using stx::get;
-#endif
-
 using stx::holds_alternative;
+#else
+template <typename... Types>
+using variant = std::variant<Types...>;
+using std::get;
+using std::holds_alternative;
+#endif
 
 // N.B. We don't alias stx::get_if, because it's signature (reference argument)
 // differs from what was standardized (pointer argument).

--- a/common/test/drake_variant_test.cc
+++ b/common/test/drake_variant_test.cc
@@ -50,7 +50,7 @@ GTEST_TEST(VariantTest, BasicTest) {
 
   // Bad access.
   dut = 0;
-  EXPECT_THROW(get<double>(dut), std::logic_error);
+  EXPECT_THROW(get<double>(dut), std::exception);
 }
 
 }  // namespace

--- a/common/yaml/test/yaml_read_archive_test.cc
+++ b/common/yaml/test/yaml_read_archive_test.cc
@@ -512,7 +512,7 @@ TEST_F(YamlReadArchiveTest, VisitVariantFoundUnknownTag) {
       "YAML node of type Map \\(with size 1 and keys \\{value\\}\\) "
       "has unsupported type tag !UnknownTag "
       "while selecting a variant<> entry for "
-      "stx::variant<std::string,double,\\(anonymous\\)::DoubleStruct> value.");
+      "st.::variant<std::string,double,\\(anonymous\\)::DoubleStruct> value.");
 }
 
 // This finds nothing when an Eigen::Vector or Eigen::Matrix was wanted.

--- a/systems/controllers/linear_quadratic_regulator.cc
+++ b/systems/controllers/linear_quadratic_regulator.cc
@@ -111,7 +111,8 @@ std::unique_ptr<systems::AffineSystem<double>> LinearQuadraticRegulator(
   // Use specified input and no outputs (the output dynamics are irrelevant for
   // LQR design).
   auto linear_system = Linearize(
-    system, context, input_port_index, OutputPortSelection::kNoOutput);
+      system, context, InputPortIndex{input_port_index},
+      OutputPortSelection::kNoOutput);
 
   // DiscreteTimeLinearQuadraticRegulator does not support N yet.
   DRAKE_DEMAND(linear_system->time_period() == 0.0 || N.rows() == 0);

--- a/systems/framework/system_constraint.cc
+++ b/systems/framework/system_constraint.cc
@@ -33,14 +33,14 @@ SystemConstraintBounds::SystemConstraintBounds(
 
 SystemConstraintBounds::SystemConstraintBounds(
     const Eigen::Ref<const Eigen::VectorXd>& lower,
-    stx::nullopt_t)
+    nullopt_t)
     : SystemConstraintBounds(
           lower,
           Eigen::VectorXd::Constant(
               lower.size(), std::numeric_limits<double>::infinity())) {}
 
 SystemConstraintBounds::SystemConstraintBounds(
-    stx::nullopt_t,
+    nullopt_t,
     const Eigen::Ref<const Eigen::VectorXd>& upper)
     : SystemConstraintBounds(
           Eigen::VectorXd::Constant(

--- a/systems/framework/system_constraint.h
+++ b/systems/framework/system_constraint.h
@@ -63,12 +63,12 @@ class SystemConstraintBounds final {
   /// The upper bounds are all positive infinity.
   SystemConstraintBounds(
       const Eigen::Ref<const Eigen::VectorXd>& lower,
-      stx::nullopt_t);
+      nullopt_t);
 
   /// Creates an inequality constraint with the given upper bounds for `f(x)`.
   /// The lower bounds are all negative infinity.
   SystemConstraintBounds(
-      stx::nullopt_t,
+      nullopt_t,
       const Eigen::Ref<const Eigen::VectorXd>& upper);
 
   int size() const { return size_; }

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -403,7 +403,8 @@ TEST_F(SystemTest, PortSelectionTest) {
                 InputPortSelection::kUseFirstInputIfItExists),
             &input_port);
 
-  EXPECT_EQ(system_.get_input_port_selection(0), &system_.get_input_port(0));
+  EXPECT_EQ(system_.get_input_port_selection(InputPortIndex{0}),
+            &system_.get_input_port(0));
 
   // Output ports.
   EXPECT_EQ(system_.get_output_port_selection(OutputPortSelection::kNoOutput),
@@ -417,7 +418,8 @@ TEST_F(SystemTest, PortSelectionTest) {
                 OutputPortSelection::kUseFirstOutputIfItExists),
             &output_port);
 
-  EXPECT_EQ(system_.get_output_port_selection(0), &system_.get_output_port(0));
+  EXPECT_EQ(system_.get_output_port_selection(OutputPortIndex{0}),
+            &system_.get_output_port(0));
 }
 
 // Tests the constraint list logic.

--- a/systems/primitives/test/linear_system_test.cc
+++ b/systems/primitives/test/linear_system_test.cc
@@ -769,25 +769,25 @@ void TestMimo(bool is_discrete) {
   const double tol = 1e-8;
 
   // First-input, first output.
-  auto sys00 = Linearize(sys, *context, 0, 0);
+  auto sys00 = Linearize(sys, *context, InputPortIndex{0}, OutputPortIndex{0});
   EXPECT_TRUE(CompareMatrices(sys00->A(), sys.A_, tol));
   EXPECT_TRUE(CompareMatrices(sys00->B(), sys.B0_, tol));
   EXPECT_TRUE(CompareMatrices(sys00->C(), sys.C0_, tol));
   EXPECT_TRUE(CompareMatrices(sys00->D(), sys.D00_, tol));
 
-  auto sys01 = Linearize(sys, *context, 0, 1);
+  auto sys01 = Linearize(sys, *context, InputPortIndex{0}, OutputPortIndex{1});
   EXPECT_TRUE(CompareMatrices(sys01->A(), sys.A_, tol));
   EXPECT_TRUE(CompareMatrices(sys01->B(), sys.B0_, tol));
   EXPECT_TRUE(CompareMatrices(sys01->C(), sys.C1_, tol));
   EXPECT_TRUE(CompareMatrices(sys01->D(), sys.D10_, tol));
 
-  auto sys10 = Linearize(sys, *context, 1, 0);
+  auto sys10 = Linearize(sys, *context, InputPortIndex{1}, OutputPortIndex{0});
   EXPECT_TRUE(CompareMatrices(sys10->A(), sys.A_, tol));
   EXPECT_TRUE(CompareMatrices(sys10->B(), sys.B1_, tol));
   EXPECT_TRUE(CompareMatrices(sys10->C(), sys.C0_, tol));
   EXPECT_TRUE(CompareMatrices(sys10->D(), sys.D01_, tol));
 
-  auto sys11 = Linearize(sys, *context, 1, 1);
+  auto sys11 = Linearize(sys, *context, InputPortIndex{1}, OutputPortIndex{1});
   EXPECT_TRUE(CompareMatrices(sys11->A(), sys.A_, tol));
   EXPECT_TRUE(CompareMatrices(sys11->B(), sys.B1_, tol));
   EXPECT_TRUE(CompareMatrices(sys11->C(), sys.C1_, tol));


### PR DESCRIPTION
When we have a working C++17 optional and variant, use it without even including anything stx-related; this allows for easily stubbing out stx.

Update call sites to with the std::variant constructor (apparently the stx constructor is more lax with "explicit" keywords).

Update pydrake type-caster to avoid redundantly declaring the std type-caster.

The full feature branch is tested in #11622.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11621)
<!-- Reviewable:end -->
