### PR TITLE
CalcJacobianTranslationalVelocity() helps deprecate CalcPointsGeometricJacobianExpressedInWorld()

### DIFF
--- a/math/rigid_transform.h
+++ b/math/rigid_transform.h
@@ -401,7 +401,7 @@ class RigidTransform {
     const Eigen::Matrix<typename Derived::Scalar, 3, Derived::ColsAtCompileTime>
         p_BoQ_A = R_AB.matrix() * p_BoQ_B;
 
-    // Reserve space (on stack on heap) to store the result.
+    // Reserve space (on stack or heap) to store the result.
     const int number_of_position_vectors = p_BoQ_B.cols();
     Eigen::Matrix<typename Derived::Scalar, 3, Derived::ColsAtCompileTime>
         p_AoQ_A(3, number_of_position_vectors);

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -791,7 +791,7 @@ void MultibodyPlant<T>::CalcNormalAndTangentContactJacobians(
   // sized.
   if (num_contacts == 0) return;
 
-  const Frame<T>& world_frame = world_frame();
+  const Frame<T>& world_frame = internal_tree().world_frame();
   for (int icontact = 0; icontact < num_contacts; ++icontact) {
     const auto& point_pair = point_pairs_set[icontact];
 

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -816,7 +816,7 @@ void MultibodyPlant<T>::CalcNormalAndTangentContactJacobians(
     // Geometric Jacobian for the velocity of the contact point C as moving with
     // body A, s.t.: v_WAc = Jv_WAc * v
     // where v is the vector of generalized velocities.
-    MatrixX<T> Jv_WAc(3, this->num_velocities());
+    Matrix3X<T> Jv_WAc(3, this->num_velocities());
     internal_tree().CalcJacobianTranslationalVelocity(context,
                                                       JacobianWrtVariable::kV,
                                                       bodyA.body_frame(),
@@ -828,7 +828,7 @@ void MultibodyPlant<T>::CalcNormalAndTangentContactJacobians(
 
     // Geometric Jacobian for the velocity of the contact point C as moving with
     // body B, s.t.: v_WBc = Jv_WBc * v.
-    MatrixX<T> Jv_WBc(3, this->num_velocities());
+    Matrix3X<T> Jv_WBc(3, this->num_velocities());
     internal_tree().CalcJacobianTranslationalVelocity(context,
                                                       JacobianWrtVariable::kV,
                                                       bodyB.body_frame(),

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -791,6 +791,7 @@ void MultibodyPlant<T>::CalcNormalAndTangentContactJacobians(
   // sized.
   if (num_contacts == 0) return;
 
+  const Frame<T>& world_frame = world_frame();
   for (int icontact = 0; icontact < num_contacts; ++icontact) {
     const auto& point_pair = point_pairs_set[icontact];
 
@@ -816,14 +817,26 @@ void MultibodyPlant<T>::CalcNormalAndTangentContactJacobians(
     // body A, s.t.: v_WAc = Jv_WAc * v
     // where v is the vector of generalized velocities.
     MatrixX<T> Jv_WAc(3, this->num_velocities());
-    internal_tree().CalcPointsGeometricJacobianExpressedInWorld(
-        context, bodyA.body_frame(), p_WCa, &Jv_WAc);
+    internal_tree().CalcJacobianTranslationalVelocity(context,
+                                                      JacobianWrtVariable::kV,
+                                                      bodyA.body_frame(),
+                                                      world_frame,
+                                                      p_WCa,
+                                                      world_frame,
+                                                      world_frame,
+                                                      &Jv_WAc);
 
     // Geometric Jacobian for the velocity of the contact point C as moving with
     // body B, s.t.: v_WBc = Jv_WBc * v.
     MatrixX<T> Jv_WBc(3, this->num_velocities());
-    internal_tree().CalcPointsGeometricJacobianExpressedInWorld(
-        context, bodyB.body_frame(), p_WCb, &Jv_WBc);
+    internal_tree().CalcJacobianTranslationalVelocity(context,
+                                                      JacobianWrtVariable::kV,
+                                                      bodyB.body_frame(),
+                                                      world_frame,
+                                                      p_WCb,
+                                                      world_frame,
+                                                      world_frame,
+                                                      &Jv_WBc);
 
     // Computation of the normal separation velocities Jacobian Jn:
     //

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -791,7 +791,7 @@ void MultibodyPlant<T>::CalcNormalAndTangentContactJacobians(
   // sized.
   if (num_contacts == 0) return;
 
-  const Frame<T>& world_frame = internal_tree().world_frame();
+  const Frame<T>& frame_W = internal_tree().world_frame();
   for (int icontact = 0; icontact < num_contacts; ++icontact) {
     const auto& point_pair = point_pairs_set[icontact];
 
@@ -820,10 +820,10 @@ void MultibodyPlant<T>::CalcNormalAndTangentContactJacobians(
     internal_tree().CalcJacobianTranslationalVelocity(context,
                                                       JacobianWrtVariable::kV,
                                                       bodyA.body_frame(),
-                                                      world_frame,
+                                                      frame_W,
                                                       p_WCa,
-                                                      world_frame,
-                                                      world_frame,
+                                                      frame_W,
+                                                      frame_W,
                                                       &Jv_WAc);
 
     // Geometric Jacobian for the velocity of the contact point C as moving with
@@ -832,10 +832,10 @@ void MultibodyPlant<T>::CalcNormalAndTangentContactJacobians(
     internal_tree().CalcJacobianTranslationalVelocity(context,
                                                       JacobianWrtVariable::kV,
                                                       bodyB.body_frame(),
-                                                      world_frame,
+                                                      frame_W,
                                                       p_WCb,
-                                                      world_frame,
-                                                      world_frame,
+                                                      frame_W,
+                                                      frame_W,
                                                       &Jv_WBc);
 
     // Computation of the normal separation velocities Jacobian Jn:

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -2066,7 +2066,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       const systems::Context<T>& context,
       JacobianWrtVariable with_respect_to,
       const Frame<T>& frame_B,
-      const Eigen::Ref<const MatrixX<T>>& p_BoBi_B,
+      const Eigen::Ref<const Matrix3X<T>>& p_BoBi_B,
       const Frame<T>& frame_A,
       const Frame<T>& frame_E,
       EigenPtr<MatrixX<T>> Js_v_ABi_E) const {

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1514,7 +1514,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // TODO(amcastro-tri): provide the Jacobian-times-vector operation, since for
   // most applications it is all we need and it is more efficient to compute.
   // TODO(amcastro-tri): Rework this method as per issue #10155.
-  DRAKE_DEPRECATED("2019-09-01", "Use CalcJacobianTranslationalVelocity().")
+  DRAKE_DEPRECATED("2019-10-01", "Use CalcJacobianTranslationalVelocity().")
   void CalcPointsGeometricJacobianExpressedInWorld(
       const systems::Context<T>& context,
       const Frame<T>& frame_F,
@@ -1663,7 +1663,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // TODO(amcastro-tri): provide the Jacobian-times-vector operation, since for
   // most applications it is all we need and it is more efficient to compute.
   // TODO(amcastro-tri): Rework this method as per issue #10155.
-  DRAKE_DEPRECATED("2019-09-01", "Use CalcJacobianTranslationalVelocity().")
+  DRAKE_DEPRECATED("2019-10-01", "Use CalcJacobianTranslationalVelocity().")
   void CalcPointsGeometricJacobianExpressedInWorld(
       const systems::Context<T>& context,
       const Frame<T>& frame_F,

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1514,10 +1514,13 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // TODO(amcastro-tri): provide the Jacobian-times-vector operation, since for
   // most applications it is all we need and it is more efficient to compute.
   // TODO(amcastro-tri): Rework this method as per issue #10155.
+  DRAKE_DEPRECATED("2019-09-01", "Use CalcJacobianTranslationalVelocity().")
   void CalcPointsGeometricJacobianExpressedInWorld(
       const systems::Context<T>& context,
-      const Frame<T>& frame_F, const Eigen::Ref<const MatrixX<T>>& p_FP_list,
-      EigenPtr<MatrixX<T>> p_WP_list, EigenPtr<MatrixX<T>> Jv_WFp) const {
+      const Frame<T>& frame_F,
+      const Eigen::Ref<const MatrixX<T>>& p_FP_list,
+      EigenPtr<MatrixX<T>> p_WP_list,
+      EigenPtr<MatrixX<T>> Jv_WFp) const {
     return internal_tree().CalcPointsGeometricJacobianExpressedInWorld(
         context, frame_F, p_FP_list, p_WP_list, Jv_WFp);
   }
@@ -1660,9 +1663,11 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // TODO(amcastro-tri): provide the Jacobian-times-vector operation, since for
   // most applications it is all we need and it is more efficient to compute.
   // TODO(amcastro-tri): Rework this method as per issue #10155.
+  DRAKE_DEPRECATED("2019-09-01", "Use CalcJacobianTranslationalVelocity().")
   void CalcPointsGeometricJacobianExpressedInWorld(
       const systems::Context<T>& context,
-      const Frame<T>& frame_F, const Eigen::Ref<const MatrixX<T>>& p_WP_list,
+      const Frame<T>& frame_F,
+      const Eigen::Ref<const MatrixX<T>>& p_WP_list,
       EigenPtr<MatrixX<T>> Jv_WFp) const {
     return internal_tree().CalcPointsGeometricJacobianExpressedInWorld(
         context, frame_F, p_WP_list, Jv_WFp);
@@ -2029,41 +2034,44 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   /// Return a point's translational velocity Jacobian in a frame A with respect
   /// to "speeds" 𝑠, where 𝑠 is either q̇ ≜ [q̇₁ ... q̇ⱼ]ᵀ (time-derivatives of
-  /// generalized positions) or v ≜ [v₁ ... vₖ]ᵀ (generalized velocities).
-  /// For a point Bp of (fixed/welded to) a frame B whose translational velocity
-  /// `v_ABp` in a frame A is characterized by speeds 𝑠, Bp's velocity Jacobian
+  /// j generalized positions) or v ≜ [v₁ ... vₖ]ᵀ (k generalized velocities).
+  /// For each point Bi of (fixed to) a frame B whose translational velocity
+  /// `v_ABi` in a frame A is characterized by speeds 𝑠, Bi's velocity Jacobian
   /// in A with respect to 𝑠 is defined as
   /// <pre>
-  ///      Js_v_ABp = [ ∂(v_ABp)/∂𝑠₁,  ...  ∂(v_ABp)/∂𝑠ₙ ]    (n is j or k)
+  ///      Js_v_ABi = [ ∂(v_ABi)/∂𝑠₁,  ...  ∂(v_ABi)/∂𝑠ₙ ]    (n is j or k)
   /// </pre>
-  /// Point Bp's velocity in A is linear in 𝑠₁, ... 𝑠ₙ and can be written
-  /// `v_ABp = Js_v_ABp ⋅ 𝑠`  where 𝑠 is [𝑠₁ ... 𝑠ₙ]ᵀ.
+  /// Point Bi's velocity in A is linear in 𝑠₁, ... 𝑠ₙ and can be written
+  /// `v_ABi = Js_v_ABi ⋅ 𝑠`  where 𝑠 is [𝑠₁ ... 𝑠ₙ]ᵀ.
   ///
   /// @param[in] context The state of the multibody system.
   /// @param[in] with_respect_to Enum equal to JacobianWrtVariable::kQDot or
-  /// JacobianWrtVariable::kV, indicating whether the Jacobian `Js_v_ABp` is
+  /// JacobianWrtVariable::kV, indicating whether the Jacobian `Js_v_ABi` is
   /// partial derivatives with respect to 𝑠 = q̇ (time-derivatives of generalized
   /// positions) or with respect to 𝑠 = v (generalized velocities).
-  /// @param[in] frame_B The frame on which point Bp is fixed/welded.
-  /// @param[in] p_BoBp_B The position vector from Bo (frame_B's origin) to
-  ///   point Bp (which is regarded as fixed to B), expressed in frame B.
-  /// @param[in] frame_A The frame that measures `v_ABp` (Bp's velocity in A).
-  /// @param[in] frame_E The frame in which `v_ABp` is expressed on input and
-  /// the frame in which the Jacobian `Js_v_ABp` is expressed on output.
-  /// @param[out] Js_v_ABp_E Point Bp's velocity Jacobian in frame A with
+  /// @param[in] frame_B The frame on which point Bi is fixed (e.g., welded).
+  /// @param[in] p_BoBi_B A position vector or list of position vectors from
+  /// Bo (frame_B's origin) to points Bi (regarded as fixed to B), where each
+  /// position vector is expressed in frame_B.
+  /// @param[in] frame_A The frame that measures `v_ABi` (Bi's velocity in A).
+  /// @param[in] frame_E The frame in which `v_ABi` is expressed on input and
+  /// the frame in which the Jacobian `Js_v_ABi` is expressed on output.
+  /// @param[out] Js_v_ABi_E Point Bi's velocity Jacobian in frame A with
   /// respect to speeds 𝑠 (which is either q̇ or v), expressed in frame E.
+  /// `Js_v_ABi_E` is a `3 x n` matrix, where n is the number of elements in 𝑠.
   /// The Jacobian is a function of only generalized positions q (which are
-  /// pulled from the context).  The previous definition shows `Js_v_ABp_E` is
-  /// a matrix of size `3 x n`, where n is the number of elements in 𝑠.
-  /// @throws std::exception if `Js_v_ABp_E` is nullptr or not of size `3 x n`.
+  /// pulled from the context).
+  /// @throws std::exception if `Js_v_ABi_E` is nullptr or not of size `3 x n`.
   void CalcJacobianTranslationalVelocity(
-      const systems::Context<T>& context, JacobianWrtVariable with_respect_to,
-      const Frame<T>& frame_B, const Eigen::Ref<const Vector3<T>>& p_BoBp_B,
-      const Frame<T>& frame_A, const Frame<T>& frame_E,
-      EigenPtr<MatrixX<T>> Js_v_ABp_E) const {
-    return internal_tree().CalcJacobianTranslationalVelocity(
-        context, with_respect_to, frame_B, p_BoBp_B, frame_A, frame_E,
-        Js_v_ABp_E);
+      const systems::Context<T>& context,
+      JacobianWrtVariable with_respect_to,
+      const Frame<T>& frame_B,
+      const Eigen::Ref<const MatrixX<T>>& p_BoBi_B,
+      const Frame<T>& frame_A,
+      const Frame<T>& frame_E,
+      EigenPtr<MatrixX<T>> Js_v_ABi_E) const {
+    internal_tree().CalcJacobianTranslationalVelocity(context, with_respect_to,
+        frame_B, frame_B, p_BoBi_B, frame_A, frame_E, Js_v_ABi_E);
   }
 
   /// Given the state of this model in `context` and a known vector

--- a/multibody/plant/test/multibody_plant_jacobians_test.cc
+++ b/multibody/plant/test/multibody_plant_jacobians_test.cc
@@ -240,13 +240,18 @@ TEST_F(KukaIiwaModelTests, CalcJacobianSpatialVelocity) {
   EXPECT_TRUE(CompareMatrices(Jq_w_WE, top_three_rows, kTolerance,
                               MatrixCompareType::relative));
 
-  // Test CalcJacobianTranslationalVelocity by calculating the 3xn matrix for
+  // Test CalcJacobianTranslationalVelocity() by calculating the 3xn matrix for
   // point Ep's translational velocity Jacobian in W (world) and ensuring this
   // is the last 3 rows of the spatial velocity Jacobian Jq_V_WEp.
   MatrixX<double> Jq_v_WEp(3, num_generalized_positions);
-  plant_->CalcJacobianTranslationalVelocity(
-      *context_, JacobianWrtVariable::kQDot, end_effector_frame, p_EoEp_E,
-      world_frame, world_frame, &Jq_v_WEp);
+  plant_->CalcJacobianTranslationalVelocity(*context_,
+                                            JacobianWrtVariable::kQDot,
+                                            end_effector_frame,
+                                            end_effector_frame,
+                                            p_EoEp_E,
+                                            world_frame,
+                                            world_frame,
+                                            &Jq_v_WEp);
   MatrixX<double> bottom_three_rows(3, num_generalized_positions);
   bottom_three_rows = Jq_V_WEp.template bottomRows<3>();
   EXPECT_TRUE(CompareMatrices(Jq_v_WEp, bottom_three_rows, kTolerance,

--- a/multibody/plant/test/multibody_plant_jacobians_test.cc
+++ b/multibody/plant/test/multibody_plant_jacobians_test.cc
@@ -243,10 +243,9 @@ TEST_F(KukaIiwaModelTests, CalcJacobianSpatialVelocity) {
   // Test CalcJacobianTranslationalVelocity() by calculating the 3xn matrix for
   // point Ep's translational velocity Jacobian in W (world) and ensuring this
   // is the last 3 rows of the spatial velocity Jacobian Jq_V_WEp.
-  MatrixX<double> Jq_v_WEp(3, num_generalized_positions);
+  Matrix3X<double> Jq_v_WEp(3, num_generalized_positions);
   plant_->CalcJacobianTranslationalVelocity(*context_,
                                             JacobianWrtVariable::kQDot,
-                                            end_effector_frame,
                                             end_effector_frame,
                                             p_EoEp_E,
                                             world_frame,

--- a/multibody/plant/test/multibody_plant_jacobians_test.cc
+++ b/multibody/plant/test/multibody_plant_jacobians_test.cc
@@ -251,7 +251,7 @@ TEST_F(KukaIiwaModelTests, CalcJacobianSpatialVelocity) {
                                             world_frame,
                                             world_frame,
                                             &Jq_v_WEp);
-  MatrixX<double> bottom_three_rows(3, num_generalized_positions);
+  Matrix3X<double> bottom_three_rows(3, num_generalized_positions);
   bottom_three_rows = Jq_V_WEp.template bottomRows<3>();
   EXPECT_TRUE(CompareMatrices(Jq_v_WEp, bottom_three_rows, kTolerance,
                               MatrixCompareType::relative));

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -993,8 +993,9 @@ void MultibodyTree<T>::CalcPointsGeometricJacobianExpressedInWorld(
     const Frame<T>& frame_F,
     const Eigen::Ref<const MatrixX<T>>& p_FP_list,
     EigenPtr<MatrixX<T>> p_WP_list,
-    EigenPtr<MatrixX<T>> Jv_v_WFp_W) const {
+    EigenPtr<MatrixX<T>> Jv_WFp) const {
   // TODO(Mitiguy) Delete this method as per issue #10155.
+  // DRAKE_DEPRECATED("2019-10-01", "Use CalcJacobianTranslationalVelocity().")
   const int num_points = p_FP_list.cols();
   DRAKE_THROW_UNLESS(p_WP_list != nullptr);
   DRAKE_THROW_UNLESS(p_WP_list->cols() == num_points);
@@ -1009,7 +1010,7 @@ void MultibodyTree<T>::CalcPointsGeometricJacobianExpressedInWorld(
                                     *p_WP_list,
                                     frame_W,
                                     frame_W,
-                                    Jv_v_WFp_W);
+                                    Jv_WFp);
 }
 
 template <typename T>
@@ -1126,8 +1127,9 @@ void MultibodyTree<T>::CalcPointsGeometricJacobianExpressedInWorld(
     const systems::Context<T>& context,
     const Frame<T>& frame_F,
     const Eigen::Ref<const MatrixX<T>>& p_WP_list,
-    EigenPtr<MatrixX<T>> Jv_v_WFp_W) const {
+    EigenPtr<MatrixX<T>> Jv_WFp) const {
   // TODO(Mitiguy) Delete this method as per issue #10155.
+  // DRAKE_DEPRECATED("2019-10-01", "Use CalcJacobianTranslationalVelocity().")
   const Frame<T>& frame_W = world_frame();
   CalcJacobianTranslationalVelocity(context,
                                     JacobianWrtVariable::kV,
@@ -1136,7 +1138,7 @@ void MultibodyTree<T>::CalcPointsGeometricJacobianExpressedInWorld(
                                     p_WP_list,
                                     frame_W,
                                     frame_W,
-                                    Jv_v_WFp_W);
+                                    Jv_WFp);
 }
 
 template <typename T>
@@ -1347,7 +1349,6 @@ void MultibodyTree<T>::CalcJacobianTranslationalVelocity(
   } else {
     // If frame_F != frame_W, then for each point Bi, determine Bi's position
     // from Wo (World origin), expressed in world W and call helper method.
-    DRAKE_THROW_UNLESS(&frame_F == &frame_B);
     Matrix3X<T> p_WoBi_W(3, num_points);
     CalcPointsPositions(context, frame_F, p_FoBi_F,  /* From frame F */
                         world_frame(), &p_WoBi_W);   /* To world frame W */
@@ -1357,7 +1358,7 @@ void MultibodyTree<T>::CalcJacobianTranslationalVelocity(
 
   // If frame_E is not the world frame, re-express Js_v_ABi_W in frame_E as
   // Js_v_ABi_E = R_EW * (Js_v_WBi_W - Js_v_WAi_W).
-  if (frame_E.index() != frame_W.index()) {
+  if (&frame_E != &frame_W) {
     const RotationMatrix<T> R_EW =
         CalcRelativeTransform(context, frame_E, frame_W).rotation();
     // Extract the 3 x num_columns block that starts at row = 3 * i, column = 0.

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -940,11 +940,7 @@ void MultibodyTree<T>::CalcPointsPositions(
   DRAKE_THROW_UNLESS(p_AQi->cols() == p_BQi.cols());
   const RigidTransform<T> X_AB =
       CalcRelativeTransform(context, frame_A, frame_B);
-  // We demanded above that these matrices have three rows. Therefore we tell
-  // Eigen so. We also convert to Isometry3 to take advantage of the operator*()
-  // for a column vector of Vector3 without using heap allocation. See #10986.
-  p_AQi->template topRows<3>() =
-      X_AB.GetAsIsometry3() * p_BQi.template topRows<3>();
+  p_AQi->template topRows<3>() = X_AB * p_BQi.template topRows<3>();
 }
 
 template <typename T>
@@ -989,28 +985,6 @@ void MultibodyTree<T>::CalcAcrossNodeGeometricJacobianExpressedInWorld(
     node.CalcAcrossNodeGeometricJacobianExpressedInWorld(
         context, pc, &H_PB_W);
   }
-}
-
-template <typename T>
-void MultibodyTree<T>::CalcPointsGeometricJacobianExpressedInWorld(
-    const systems::Context<T>& context,
-    const Frame<T>& frame_F, const Eigen::Ref<const MatrixX<T>>& p_FP_list,
-    EigenPtr<MatrixX<T>> p_WP_list, EigenPtr<MatrixX<T>> Jv_WFp) const {
-  DRAKE_THROW_UNLESS(p_FP_list.rows() == 3);
-  const int num_points = p_FP_list.cols();
-  DRAKE_THROW_UNLESS(p_WP_list != nullptr);
-  DRAKE_THROW_UNLESS(p_WP_list->cols() == num_points);
-  DRAKE_THROW_UNLESS(Jv_WFp != nullptr);
-  DRAKE_THROW_UNLESS(Jv_WFp->rows() == 3 * num_points);
-  DRAKE_THROW_UNLESS(Jv_WFp->cols() == num_velocities());
-
-  // Compute p_WFp for each point Pi in the set P_BPi_list.
-  CalcPointsPositions(context,
-                      frame_F, p_FP_list,        /* From frame B */
-                      world_frame(), p_WP_list); /* To world frame W */
-
-  CalcPointsGeometricJacobianExpressedInWorld(
-      context, frame_F, *p_WP_list, Jv_WFp);
 }
 
 template <typename T>
@@ -1120,20 +1094,6 @@ VectorX<T> MultibodyTree<T>::CalcBiasForJacobianTranslationalVelocity(
   }
 
   return Abias_WFp_array;
-}
-
-template <typename T>
-void MultibodyTree<T>::CalcPointsGeometricJacobianExpressedInWorld(
-    const systems::Context<T>& context,
-    const Frame<T>& frame_F, const Eigen::Ref<const MatrixX<T>>& p_WP_list,
-    EigenPtr<MatrixX<T>> Jv_WFp) const {
-  DRAKE_THROW_UNLESS(p_WP_list.rows() == 3);
-  const int num_points = p_WP_list.cols();
-  DRAKE_THROW_UNLESS(Jv_WFp != nullptr);
-  DRAKE_THROW_UNLESS(Jv_WFp->rows() == 3 * num_points);
-  DRAKE_THROW_UNLESS(Jv_WFp->cols() == num_velocities());
-  CalcFrameJacobianExpressedInWorld(context, frame_F, p_WP_list,
-      JacobianWrtVariable::kV, nullptr /* angular not needed */, Jv_WFp);
 }
 
 template <typename T>
@@ -1260,7 +1220,7 @@ void MultibodyTree<T>::CalcJacobianAngularVelocity(
   CalcFrameJacobianExpressedInWorld(context, frame_B, empty_position_list,
                                     with_respect_to, &Js_w_WB_W, nullptr);
 
-  const BodyFrame<T>& frame_W = world_frame();
+  const Frame<T>& frame_W = world_frame();
   if (frame_E.index() == frame_W.index()) {
     // Calculate B's angular velocity Jacobian in A, expressed in W.
     *Js_w_AB_E = Js_w_WB_W - Js_w_WA_W;  // This calculates Js_w_AB_W.
@@ -1275,54 +1235,138 @@ void MultibodyTree<T>::CalcJacobianAngularVelocity(
 }
 
 template <typename T>
-void MultibodyTree<T>::CalcJacobianTranslationalVelocity(
+void MultibodyTree<T>::CalcJacobianTranslationalVelocityHelper(
     const systems::Context<T>& context,
-    const JacobianWrtVariable with_respect_to, const Frame<T>& frame_B,
-    const Eigen::Ref<const Vector3<T>>& p_BoBp_B, const Frame<T>& frame_A,
-    const Frame<T>& frame_E, EigenPtr<MatrixX<T>> Js_v_ABp_E) const {
-  DRAKE_THROW_UNLESS(Js_v_ABp_E != nullptr);
-  DRAKE_THROW_UNLESS(Js_v_ABp_E->rows() == 3);
+    const JacobianWrtVariable with_respect_to,
+    const Frame<T>& frame_B,
+    const Eigen::Ref<const MatrixX<T>>& p_WoBi_W,
+    const Frame<T>& frame_A,
+    EigenPtr<MatrixX<T>> Js_v_ABi_E) const {
   const int num_columns = (with_respect_to == JacobianWrtVariable::kQDot) ?
                           num_positions() : num_velocities();
-  DRAKE_THROW_UNLESS(Js_v_ABp_E->cols() == num_columns);
+  const int num_points = p_WoBi_W.cols();
+  DRAKE_THROW_UNLESS(num_points > 0);
+  DRAKE_THROW_UNLESS(Js_v_ABi_E != nullptr);
+  DRAKE_THROW_UNLESS(Js_v_ABi_E->rows() == 3 * num_points);
+  DRAKE_THROW_UNLESS(Js_v_ABi_E->cols() == num_columns);
 
-  // Bp's velocity in W can be calculated v_WBp = v_WAp + v_ABp, where
-  // v_WBp is point Bp's translational velocity in world W,
-  // v_WAp is point Ap's translational velocity in world W
-  //         (where Ap is the point of A coincident with Bp),
-  // v_ABp is point Bp's translational velocity in frame A.
-  // Rearrange to calculate Bp's velocity in A as v_ABp = v_WBp - v_WAp.
-  // So Bp's translational velocity Jacobian in A, expressed in frame E is
-  // Js_v_ABp_E = R_EW * (Js_v_WBp_W - Js_v_WAp_W).
+  // Bi's velocity in W can be calculated v_WBi = v_WAi + v_ABi, where
+  // v_WBi is point Bi's translational velocity in world W,
+  // v_WAi is point Ai's translational velocity in world W
+  //         (where Ai is the point of A coincident with Bi),
+  // v_ABi is point Bi's translational velocity in frame A.
+  // Rearrange to calculate Bi's velocity in A as v_ABi = v_WBi - v_WAi.
 
   // TODO(Mitiguy): When performance becomes an issue, optimize this method by
   // only using the kinematics path from A to B.
 
-  // Determine Bp's position from Wo (World origin), expressed in World W.
-  Vector3<T> p_WoBp_W;
-  CalcPointsPositions(context, frame_B, p_BoBp_B, /* From frame B */
-                      world_frame(), &p_WoBp_W);  /* To world frame W */
+  // Calculate each point Ai's translational velocity Jacobian in world W.
+  MatrixX<T> Js_v_WAi_W(3 * num_points, num_columns);
+  CalcFrameJacobianExpressedInWorld(context, frame_A, p_WoBi_W,
+                                    with_respect_to, nullptr, &Js_v_WAi_W);
 
-  MatrixX<T> Js_v_WAp_W(3, num_columns);
-  CalcFrameJacobianExpressedInWorld(context, frame_A, p_WoBp_W,
-                                    with_respect_to, nullptr, &Js_v_WAp_W);
+  // Calculate each point Bi's translational velocity Jacobian in world W.
+  MatrixX<T> Js_v_WBi_W(3 * num_points, num_columns);
+  CalcFrameJacobianExpressedInWorld(context, frame_B, p_WoBi_W,
+                                    with_respect_to, nullptr, &Js_v_WBi_W);
 
-  MatrixX<T> Js_v_WBp_W(3, num_columns);
-  CalcFrameJacobianExpressedInWorld(context, frame_B, p_WoBp_W,
-                                    with_respect_to, nullptr, &Js_v_WBp_W);
+  // Calculate each point Bi's translational velocity Jacobian in frame A,
+  // expressed in world W.
+  *Js_v_ABi_E = Js_v_WBi_W - Js_v_WAi_W;  // This calculates Js_v_ABi_W.
+}
 
-  const BodyFrame<T>& frame_W = world_frame();
-  if (frame_E.index() == frame_W.index()) {
-    // Calculate Bp's translational velocity Jacobian in A, expressed in W.
-    *Js_v_ABp_E = Js_v_WBp_W - Js_v_WAp_W;  // This calculates Js_v_ABp_W.
+template <typename T>
+void MultibodyTree<T>::CalcJacobianTranslationalVelocity(
+    const systems::Context<T>& context,
+    const JacobianWrtVariable with_respect_to,
+    const Frame<T>& frame_B,
+    const Frame<T>& frame_F,
+    const Eigen::Ref<const MatrixX<T>>& p_FoBi_F,
+    const Frame<T>& frame_A,
+    const Frame<T>& frame_E,
+    EigenPtr<MatrixX<T>> Js_v_ABi_E) const {
+  const int num_columns = (with_respect_to == JacobianWrtVariable::kQDot) ?
+                          num_positions() : num_velocities();
+  const int num_points = p_FoBi_F.cols();
+  DRAKE_THROW_UNLESS(num_points > 0);
+  DRAKE_THROW_UNLESS(p_FoBi_F.rows() == 3);
+  DRAKE_THROW_UNLESS(Js_v_ABi_E != nullptr);
+  DRAKE_THROW_UNLESS(Js_v_ABi_E->rows() == 3 * num_points);
+  DRAKE_THROW_UNLESS(Js_v_ABi_E->cols() == num_columns);
+
+  // If frame_F == frame_W (World), then just call helper method.
+  // The helper method returns each point Bi's translational velocity Jacobian
+  // in frame A, expressed in world W, i.e., helper method returns Js_v_ABi_W.
+  const Frame<T>& frame_W = world_frame();
+  if (&frame_F == &frame_W) {
+    CalcJacobianTranslationalVelocityHelper(context, with_respect_to, frame_B,
+                                            p_FoBi_F, frame_A, Js_v_ABi_E);
   } else {
-    // When frame E is not the world frame:
-    // 1. Calculate Bp's translational velocity Jacobian in A, expressed in W.
-    // 2. Re-express that Jacobian in frame_E (rather than frame_W).
-    const RotationMatrix<T> R_EW(
-        CalcRelativeTransform(context, frame_E, frame_W).linear());
-    *Js_v_ABp_E = R_EW.matrix() * (Js_v_WBp_W - Js_v_WAp_W);
+    // If frame_F != frame_W, then for each point Bi, determine Bi's position
+    // from Wo (World origin), expressed in world W and call helper method.
+    DRAKE_THROW_UNLESS(&frame_F == &frame_B);
+    MatrixX<T> p_WoBi_W(3, num_points);
+    CalcPointsPositions(context, frame_F, p_FoBi_F,  /* From frame F */
+                        world_frame(), &p_WoBi_W);   /* To world frame W */
+    CalcJacobianTranslationalVelocityHelper(context, with_respect_to, frame_B,
+                                            p_WoBi_W, frame_A, Js_v_ABi_E);
   }
+
+  // If frame_E is not the world frame, re-express Js_v_ABi_W in frame_E as
+  // Js_v_ABi_E = R_EW * (Js_v_WBi_W - Js_v_WAi_W).
+  if (frame_E.index() != frame_W.index()) {
+    const RotationMatrix<T> R_EW =
+        CalcRelativeTransform(context, frame_E, frame_W).rotation();
+    // Extract the 3 x num_columns block that starts at row = 3 * i, column = 0.
+    for (int i = 0;  i < num_points; ++i) {
+      Js_v_ABi_E->template block<3, Eigen::Dynamic>(3 * i, 0, 3, num_columns) =
+      R_EW.matrix() *
+      Js_v_ABi_E->template block<3, Eigen::Dynamic>(3 * i, 0, 3, num_columns);
+    }
+  }
+}
+
+template <typename T>
+void MultibodyTree<T>::CalcPointsGeometricJacobianExpressedInWorld(
+    const systems::Context<T>& context,
+    const Frame<T>& frame_F,
+    const Eigen::Ref<const MatrixX<T>>& p_FP_list,
+    EigenPtr<MatrixX<T>> p_WP_list,
+    EigenPtr<MatrixX<T>> Jv_v_WFp_W) const {
+  // TODO(Mitiguy) Delete this method as per issue #10155.
+  const int num_points = p_FP_list.cols();
+  DRAKE_THROW_UNLESS(p_WP_list != nullptr);
+  DRAKE_THROW_UNLESS(p_WP_list->cols() == num_points);
+
+  const Frame<T>& frame_W = world_frame();
+  CalcPointsPositions(context, frame_F, p_FP_list,  /* From frame F */
+                      frame_W, p_WP_list);          /* To world frame W */
+  CalcJacobianTranslationalVelocity(context,
+                                    JacobianWrtVariable::kV,
+                                    frame_F,
+                                    frame_W,
+                                    *p_WP_list,
+                                    frame_W,
+                                    frame_W,
+                                    Jv_v_WFp_W);
+}
+
+template <typename T>
+void MultibodyTree<T>::CalcPointsGeometricJacobianExpressedInWorld(
+    const systems::Context<T>& context,
+    const Frame<T>& frame_F,
+    const Eigen::Ref<const MatrixX<T>>& p_WP_list,
+    EigenPtr<MatrixX<T>> Jv_v_WFp_W) const {
+  // TODO(Mitiguy) Delete this method as per issue #10155.
+  const Frame<T>& frame_W = world_frame();
+  CalcJacobianTranslationalVelocity(context,
+                                    JacobianWrtVariable::kV,
+                                    frame_F,
+                                    frame_W,
+                                    p_WP_list,
+                                    frame_W,
+                                    frame_W,
+                                    Jv_v_WFp_W);
 }
 
 template <typename T>

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -2285,17 +2285,14 @@ class MultibodyTree {
   // partial derivatives with respect to 𝑠 = q̇ (time-derivatives of generalized
   // positions) or with respect to 𝑠 = v (generalized velocities).
   // @param[in] frame_B The frame on which point Bi is fixed (e.g., welded).
-  // @param[in] frame_F The frame associated with `p_FoBi_F` (next argument),
-  // which must be either frame_B or the world frame W.
-  // @param[in] p_FoBi_F A position vector or list of position vectors from
-  // Fo (frame_F's origin) to points Bi (regarded as fixed to B), where each
-  // position vector is expressed in frame F.
+  // @param[in] p_WoBi_W A position vector or list of position vectors from
+  // Wo (world frame W's origin) to points Bi (regarded as fixed to B),
+  // where each position vector is expressed in frame W.
   // @param[in] frame_A The frame that measures `v_ABi` (Bi's velocity in A).
   // @param[out] Js_v_ABi_W Point Bi's velocity Jacobian in frame A with
   // respect to speeds 𝑠 (which is either q̇ or v), expressed in world frame W.
   // `Js_v_ABi_E` is a `3 x n` matrix, where n is the number of elements in 𝑠.
   // @throws std::exception if `Js_v_ABi_W` is nullptr or not of size `3 x n`.
-  // @throws std::exception if frame_F is not frame_B or not the world frame W.
   void CalcJacobianTranslationalVelocityHelper(
       const systems::Context<T>& context,
       JacobianWrtVariable with_respect_to,

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -1342,7 +1342,7 @@ class MultibodyTree {
       JacobianWrtVariable with_respect_to,
       const Frame<T>& frame_B,
       const Frame<T>& frame_F,
-      const Eigen::Ref<const MatrixX<T>>& p_FoBi_F,
+      const Eigen::Ref<const Matrix3X<T>>& p_FoBi_F,
       const Frame<T>& frame_A,
       const Frame<T>& frame_E,
       EigenPtr<MatrixX<T>> Js_v_ABp_E) const;
@@ -2297,7 +2297,7 @@ class MultibodyTree {
       const systems::Context<T>& context,
       JacobianWrtVariable with_respect_to,
       const Frame<T>& frame_B,
-      const Eigen::Ref<const MatrixX<T>>& p_WoBi_W,
+      const Eigen::Ref<const Matrix3X<T>>& p_WoBi_W,
       const Frame<T>& frame_A,
       EigenPtr<MatrixX<T>> Js_v_ABi_E) const;
 

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -1247,14 +1247,14 @@ class MultibodyTree {
       const Frame<T>& frame_F,
       const Eigen::Ref<const MatrixX<T>>& p_FP_list,
       EigenPtr<MatrixX<T>> p_WP_list,
-      EigenPtr<MatrixX<T>> Jv_v_WFp_W) const;
+      EigenPtr<MatrixX<T>> Jv_WFp) const;
 
   /// See MultibodyPlant method.
   void CalcPointsGeometricJacobianExpressedInWorld(
       const systems::Context<T>& context,
       const Frame<T>& frame_F,
       const Eigen::Ref<const MatrixX<T>>& p_WP_list,
-      EigenPtr<MatrixX<T>> Jv_v_WFp_W) const;
+      EigenPtr<MatrixX<T>> Jv_WFp) const;
 
   /// See MultibodyPlant method.
   VectorX<T> CalcBiasForJacobianTranslationalVelocity(
@@ -1302,9 +1302,6 @@ class MultibodyTree {
                                    const Frame<T>& frame_E,
                                    EigenPtr<MatrixX<T>> Js_w_AB_E) const;
 
-  /// Note: This method is more general than the corresponding MultibodyPlant
-  /// method as it also contains the argument `frame_F`.
-  ///
   /// Return a point's translational velocity Jacobian in a frame A with respect
   /// to "speeds" 𝑠, where 𝑠 is either q̇ ≜ [q̇₁ ... q̇ⱼ]ᵀ (time-derivatives of
   /// j generalized positions) or v ≜ [v₁ ... vₖ]ᵀ (k generalized velocities).
@@ -1337,6 +1334,9 @@ class MultibodyTree {
   /// The Jacobian is a function of only generalized positions q (which are
   /// pulled from the context).
   /// @throws std::exception if `Js_v_ABi_E` is nullptr or not of size `3 x n`.
+  ///
+  /// Note: This method is more general than the corresponding MultibodyPlant
+  /// method as it also contains the argument `frame_F`.
   void CalcJacobianTranslationalVelocity(
       const systems::Context<T>& context,
       JacobianWrtVariable with_respect_to,
@@ -1345,7 +1345,7 @@ class MultibodyTree {
       const Eigen::Ref<const Matrix3X<T>>& p_FoBi_F,
       const Frame<T>& frame_A,
       const Frame<T>& frame_E,
-      EigenPtr<MatrixX<T>> Js_v_ABp_E) const;
+      EigenPtr<MatrixX<T>> Js_v_ABi_E) const;
 
   /// @}
   // End of multibody Jacobian methods section.

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -1244,14 +1244,17 @@ class MultibodyTree {
   /// See MultibodyPlant method.
   void CalcPointsGeometricJacobianExpressedInWorld(
       const systems::Context<T>& context,
-      const Frame<T>& frame_F, const Eigen::Ref<const MatrixX<T>>& p_FP_list,
-      EigenPtr<MatrixX<T>> p_WP_list, EigenPtr<MatrixX<T>> Jv_WFp) const;
+      const Frame<T>& frame_F,
+      const Eigen::Ref<const MatrixX<T>>& p_FP_list,
+      EigenPtr<MatrixX<T>> p_WP_list,
+      EigenPtr<MatrixX<T>> Jv_v_WFp_W) const;
 
   /// See MultibodyPlant method.
   void CalcPointsGeometricJacobianExpressedInWorld(
       const systems::Context<T>& context,
-      const Frame<T>& frame_F, const Eigen::Ref<const MatrixX<T>>& p_WP_list,
-      EigenPtr<MatrixX<T>> Jv_WFp) const;
+      const Frame<T>& frame_F,
+      const Eigen::Ref<const MatrixX<T>>& p_WP_list,
+      EigenPtr<MatrixX<T>> Jv_v_WFp_W) const;
 
   /// See MultibodyPlant method.
   VectorX<T> CalcBiasForJacobianTranslationalVelocity(
@@ -1299,12 +1302,50 @@ class MultibodyTree {
                                    const Frame<T>& frame_E,
                                    EigenPtr<MatrixX<T>> Js_w_AB_E) const;
 
-  /// See MultibodyPlant method.
+  /// Note: This method is more general than the corresponding MultibodyPlant
+  /// method as it also contains the argument `frame_F`.
+  ///
+  /// Return a point's translational velocity Jacobian in a frame A with respect
+  /// to "speeds" 𝑠, where 𝑠 is either q̇ ≜ [q̇₁ ... q̇ⱼ]ᵀ (time-derivatives of
+  /// j generalized positions) or v ≜ [v₁ ... vₖ]ᵀ (k generalized velocities).
+  /// For each point Bi of (fixed to) a frame B whose translational velocity
+  /// `v_ABi` in a frame A is characterized by speeds 𝑠, Bi's velocity Jacobian
+  /// in A with respect to 𝑠 is defined as
+  /// <pre>
+  ///      Js_v_ABi = [ ∂(v_ABi)/∂𝑠₁,  ...  ∂(v_ABi)/∂𝑠ₙ ]    (n is j or k)
+  /// </pre>
+  /// Point Bi's velocity in A is linear in 𝑠₁, ... 𝑠ₙ and can be written
+  /// `v_ABi = Js_v_ABi ⋅ 𝑠`  where 𝑠 is [𝑠₁ ... 𝑠ₙ]ᵀ.
+  ///
+  /// @param[in] context The state of the multibody system.
+  /// @param[in] with_respect_to Enum equal to JacobianWrtVariable::kQDot or
+  /// JacobianWrtVariable::kV, indicating whether the Jacobian `Js_v_ABi` is
+  /// partial derivatives with respect to 𝑠 = q̇ (time-derivatives of generalized
+  /// positions) or with respect to 𝑠 = v (generalized velocities).
+  /// @param[in] frame_B The frame on which point Bi is fixed (e.g., welded).
+  /// @param[in] frame_F The frame associated with `p_FoBi_F` (next argument),
+  /// which is usually (but is not necessarily) frame_B or the world frame W.
+  /// @param[in] p_FoBi_F A position vector or list of position vectors from
+  /// Fo (frame_F's origin) to points Bi (regarded as fixed to B), where each
+  /// position vector is expressed in frame F.
+  /// @param[in] frame_A The frame that measures `v_ABi` (Bi's velocity in A).
+  /// @param[in] frame_E The frame in which `v_ABi` is expressed on input and
+  /// the frame in which the Jacobian `Js_v_ABi` is expressed on output.
+  /// @param[out] Js_v_ABi_E Point Bi's velocity Jacobian in frame A with
+  /// respect to speeds 𝑠 (which is either q̇ or v), expressed in frame E.
+  /// `Js_v_ABi_E` is a `3 x n` matrix, where n is the number of elements in 𝑠.
+  /// The Jacobian is a function of only generalized positions q (which are
+  /// pulled from the context).
+  /// @throws std::exception if `Js_v_ABi_E` is nullptr or not of size `3 x n`.
   void CalcJacobianTranslationalVelocity(
       const systems::Context<T>& context,
-      JacobianWrtVariable with_respect_to, const Frame<T>& frame_B,
-      const Eigen::Ref<const Vector3<T>>& p_BoBp_B, const Frame<T>& frame_A,
-      const Frame<T>& frame_E, EigenPtr<MatrixX<T>> Js_v_ABp_E) const;
+      JacobianWrtVariable with_respect_to,
+      const Frame<T>& frame_B,
+      const Frame<T>& frame_F,
+      const Eigen::Ref<const MatrixX<T>>& p_FoBi_F,
+      const Frame<T>& frame_A,
+      const Frame<T>& frame_E,
+      EigenPtr<MatrixX<T>> Js_v_ABp_E) const;
 
   /// @}
   // End of multibody Jacobian methods section.
@@ -2234,7 +2275,34 @@ class MultibodyTree {
       const Frame<T>& frame_F,
       const Eigen::Ref<const MatrixX<T>>& p_WQ_list,
       JacobianWrtVariable with_respect_to,
-      EigenPtr<MatrixX<T>> Jr_WFq, EigenPtr<MatrixX<T>> Jt_WFq) const;
+      EigenPtr<MatrixX<T>> Jr_WFq,
+      EigenPtr<MatrixX<T>> Jt_WFq) const;
+
+  // Helper method for CalcJacobianTranslationalVelocity().
+  // @param[in] context The state of the multibody system.
+  // @param[in] with_respect_to Enum equal to JacobianWrtVariable::kQDot or
+  // JacobianWrtVariable::kV, indicating whether the Jacobian `Js_v_ABi` is
+  // partial derivatives with respect to 𝑠 = q̇ (time-derivatives of generalized
+  // positions) or with respect to 𝑠 = v (generalized velocities).
+  // @param[in] frame_B The frame on which point Bi is fixed (e.g., welded).
+  // @param[in] frame_F The frame associated with `p_FoBi_F` (next argument),
+  // which must be either frame_B or the world frame W.
+  // @param[in] p_FoBi_F A position vector or list of position vectors from
+  // Fo (frame_F's origin) to points Bi (regarded as fixed to B), where each
+  // position vector is expressed in frame F.
+  // @param[in] frame_A The frame that measures `v_ABi` (Bi's velocity in A).
+  // @param[out] Js_v_ABi_W Point Bi's velocity Jacobian in frame A with
+  // respect to speeds 𝑠 (which is either q̇ or v), expressed in world frame W.
+  // `Js_v_ABi_E` is a `3 x n` matrix, where n is the number of elements in 𝑠.
+  // @throws std::exception if `Js_v_ABi_W` is nullptr or not of size `3 x n`.
+  // @throws std::exception if frame_F is not frame_B or not the world frame W.
+  void CalcJacobianTranslationalVelocityHelper(
+      const systems::Context<T>& context,
+      JacobianWrtVariable with_respect_to,
+      const Frame<T>& frame_B,
+      const Eigen::Ref<const MatrixX<T>>& p_WoBi_W,
+      const Frame<T>& frame_A,
+      EigenPtr<MatrixX<T>> Js_v_ABi_E) const;
 
   // Helper method to apply forces due to damping at the joints.
   // MultibodyTree treats damping forces separately from other ForceElement


### PR DESCRIPTION
Merge two instances of methods CalcPointsGeometricJacobianExpressedInWorld() into one general  instance of CalcJacobianTranslationalVelocity().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11623)
<!-- Reviewable:end -->
