### PR TITLE
Patch octomap to fix C++17 builds using libc++

### DIFF
--- a/setup/ubuntu/source_distribution/packages-bionic.txt
+++ b/setup/ubuntu/source_distribution/packages-bionic.txt
@@ -42,6 +42,7 @@ libyaml-cpp-dev
 lldb
 locales
 openssh-client
+patch
 patchelf
 patchutils
 pkg-config

--- a/setup/ubuntu/source_distribution/packages-xenial.txt
+++ b/setup/ubuntu/source_distribution/packages-xenial.txt
@@ -42,6 +42,7 @@ libyaml-cpp-dev
 lldb-6.0
 locales
 openssh-client
+patch
 patchelf
 patchutils
 pkg-config

--- a/tools/workspace/octomap/BUILD.bazel
+++ b/tools/workspace/octomap/BUILD.bazel
@@ -2,4 +2,11 @@
 
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
+# Patch to allow OctoMap to be compiled with -std=c++17 against libc++.
+# Submitted upstream at https://github.com/OctoMap/octomap/pull/233.
+exports_files(
+    ["do_not_use_random_shuffle.patch"],
+    licenses = ["notice"],  # BSD-3-Clause
+)
+
 add_lint_tests()

--- a/tools/workspace/octomap/do_not_use_random_shuffle.patch
+++ b/tools/workspace/octomap/do_not_use_random_shuffle.patch
@@ -1,0 +1,38 @@
+From 7811ac619f0d88e466e7706583a471e6acaa72de Mon Sep 17 00:00:00 2001
+From: Jamie Snape <jamie.snape@kitware.com>
+Date: Thu, 30 May 2019 12:18:45 -0400
+Subject: [PATCH] Do not use std::random_shuffle with C++11 or above
+
+---
+ octomap/src/Pointcloud.cpp | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git octomap/src/Pointcloud.cpp octomap/src/Pointcloud.cpp
+index 09349db04c1255e1ba69f6b7bd141708e257de76..741273993ab71516e598a0b6cf077872c5aa1269 100644
+--- octomap/src/Pointcloud.cpp
++++ octomap/src/Pointcloud.cpp
+@@ -38,6 +38,9 @@
+ 
+ #if defined(_MSC_VER) || defined(_LIBCPP_VERSION)
+   #include <algorithm>
++  #if __cplusplus >= 201103L
++    #include <random>
++  #endif
+ #else
+   #include <ext/algorithm>
+ #endif
+@@ -210,7 +213,13 @@ namespace octomap {
+   #if defined(_MSC_VER) || defined(_LIBCPP_VERSION)
+     samples.reserve(this->size());
+     samples.insert(samples.end(), this->begin(), this->end());
+-    std::random_shuffle(samples.begin(), samples.end());
++    #if __cplusplus > 199711L
++      std::random_device r;
++      std::mt19937 urbg(r());
++      std::shuffle(samples.begin(), samples.end(), urbg);
++    #else
++      std::random_shuffle(samples.begin(), samples.end());
++    #endif
+     samples.resize(num_samples);
+   #else
+     random_sample_n(begin(), end(), std::back_insert_iterator<point3d_collection>(samples), num_samples);

--- a/tools/workspace/octomap/repository.bzl
+++ b/tools/workspace/octomap/repository.bzl
@@ -12,4 +12,7 @@ def octomap_repository(
         sha256 = "5f81c9a8cbc9526b2e725251cd3a829e5222a28201b394314002146d8b9214dd",  # noqa
         build_file = "@drake//tools/workspace/octomap:package.BUILD.bazel",
         mirrors = mirrors,
+        patches = [
+            "@drake//tools/workspace/octomap:do_not_use_random_shuffle.patch",
+        ],
     )


### PR DESCRIPTION
Applies https://github.com/OctoMap/octomap/pull/233 for C++17 compatibility.

<!-- Reviewable:start -->
----
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11627)
<!-- Reviewable:end -->
