### PR TITLE
Remove unused variable expected_forward_start_endpoint

### DIFF
--- a/automotive/maliput/multilane/test/multilane_builder_test.cc
+++ b/automotive/maliput/multilane/test/multilane_builder_test.cc
@@ -133,7 +133,6 @@ GTEST_TEST(EndReferenceSpecTest, Connection) {
 
   const EndReference::Spec forward_start_dut =
       EndReference().z_at(conn, Which::kStart, Direction::kForward);
-  const EndpointZ expected_forward_start_endpoint{kFlatZWithoutThetaDot};
   EXPECT_TRUE(test::IsEndpointZClose(forward_start_dut.endpoint_z(),
                                      kFlatZWithoutThetaDot,
                                      kEndpointLinearTolerance,


### PR DESCRIPTION
Only triggering an error on Mac in C++17 mode as far as I can tell.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11629)
<!-- Reviewable:end -->
