### PR TITLE
Use versioned formula clp@1.17 on macs

### DIFF
--- a/tools/workspace/dreal/repository.bzl
+++ b/tools/workspace/dreal/repository.bzl
@@ -85,8 +85,10 @@ dreal_repository = repository_rule(
         # in the pkg_config_repository rule.
         "pkg_config_paths": attr.string_list(
             default = [
+                # TODO(soonho-tri): Remove the following two lines.
                 "/usr/local/opt/clp/lib/pkgconfig",
                 "/usr/local/opt/coinutils/lib/pkgconfig",
+                "/usr/local/opt/clp@1.17/lib/pkgconfig",
                 "/usr/local/opt/dreal/lib/pkgconfig",
                 "/usr/local/opt/ibex@{}/share/pkgconfig".format(IBEX_VERSION),
                 "/usr/local/opt/nlopt/lib/pkgconfig",


### PR DESCRIPTION
Following @jamiesnape's suggestion, dReal is using the versioned formula `clp@1.17` and we need to add its pkg-config-path in Drake. When https://github.com/Homebrew/homebrew-core/pull/40725 is merged, I'll revisit this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11634)
<!-- Reviewable:end -->
