### PR TITLE
Implements interpolation of scalar/vector fields onto zero-level set surface.

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -139,6 +139,7 @@ drake_cc_library(
         "//geometry/proximity:volume_mesh",
         "//geometry/query_results:contact_surface",
         "//math:geometric_transform",
+        "//multibody/hydroelastics:level_set_field",
     ],
 )
 

--- a/geometry/proximity/contact_surface_calculator.h
+++ b/geometry/proximity/contact_surface_calculator.h
@@ -1,42 +1,50 @@
 #pragma once
 
+// TODO(amcastro-tri): rename to something less generic.
+
 #include <array>
 #include <limits>
 #include <memory>
 #include <utility>
 #include <vector>
 
+#include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/type_safe_index.h"
 #include "drake/geometry/proximity/surface_mesh.h"
 #include "drake/geometry/proximity/volume_mesh.h"
 #include "drake/geometry/query_results/contact_surface.h"
 #include "drake/math/rigid_transform.h"
+#include "drake/multibody/hydroelastics/level_set_field.h"
 
 namespace drake {
 namespace geometry {
 #ifndef DRAKE_DOXYGEN_CXX
 namespace internal {
-// This table essentially assigns an index to each edge in the tetrahedra. Each
+// This table essentially assigns an index to each edge in the tetrahedron. Each
 // edge is represented by its pair of vertex indexes.
 using Edge = std::pair<int, int>;
 const std::array<Edge, 6> kEdges = {
     Edge{0, 1}, Edge{1, 2}, Edge{2, 0},   // base formed by vertices 0, 1, 2.
     Edge{0, 3}, Edge{1, 3}, Edge{2, 3}};  // pyramid with top at node 3.
 
-// Marching tetrahedra table. Each entry in this table has an index assigned by
-// encoding the sign of each vertex in binary. Therefore, with four vertices and
-// two possible signs, we have a total of 16 entries.
-// We encode the table indexes in binary so that a "1" corresponds to a
-// positive value at that vertex and conversely "0" corresponds to a
-// negative value. The least significan bit, bit 0, maps to vertex 0 while the
-// most significant bit, bit 3, maps to vertex 3.
-// Each entry stores a vector of edges. Based on the sign of the level set,
-// these edges are the ones with a zero level set crossing. Edges are numbered
-// according to table kEdges.
-// See Figure 3 in [Bloomenthal, 1994] cited in the documentation for
-// CalcZeroLevelSetInMeshDomain() for details on the entries in this table.
-// We changed the order of the edges here so that they always form a closed
+// Marching tetrahedra table. Each entry in this table has an index value
+// based on a binary encoding of the signs of the a scalar function phi
+// evaluated at all tetrahedron vertices. Therefore, with four vertices and two
+// possible signs, we have a total of 16 entries. We encode the table indexes in
+// binary so that a "1" corresponds to a positive value at that vertex and
+// conversely "0" corresponds to a negative value. The least significant bit,
+// bit 0, maps to vertex 0 while the most significant bit, bit 3, maps to
+// vertex 3. Each entry stores a vector of edges. Based on the sign of the level
+// set, these edges are the ones with a zero level set crossing. Edges are
+// numbered according to table kEdges. The edges have been ordered such that a
+// polygon formed by the intersection vertices visited in the same order has a
+// right-handed normal pointing in the direction of increasing "phi", and it can
+// be shown (through a lot of algebra) that the polygon is always planar (even
+// for arbitrary level set functions and a polygon with four sides). See Figure
+// 3 in [Bloomenthal, 1994] cited in the documentation for
+// CalcZeroLevelSetInMeshDomain() for details on the entries in this table. We
+// changed the order of the edges here so that they always form a closed
 // boundary oriented according to the right-hand rule around a vector from the
 // negative side to the positive side. The accompanying unit tests verify this.
 using EdgeIndex = int;
@@ -59,60 +67,91 @@ const std::array<std::vector<EdgeIndex>, 16> kMarchingTetsTable = {
          {}            /* 1111 */}};
 
 // Given a tetrahedron defined by the four vertices in `tet_vertices_N` and
-// a corresponding set of level set values at each vertex in `phi_N`, this
-// method computes a triangulation of the zero level set surface within the
-// domain of the tetrahedra.
-// On return this method adds the new vertices and faces of the triangulation
-// into `vertices` and `faces` respectively and returns the number of vertices
-// added.
-// The first three "vertices" define the first face of the tetrahedra, with
-// its right-handed normal pointing towards the outside.
-// The last vertex is on the "negative side" of the first face.
+// a corresponding set of level set values at each vertex in `phi`, this
+// method computes a continuous triangulation of the zero level set surface
+// within the domain of the tetrahedron. With "continuous" we mean that small
+// perturbations to `phi` will not induce changes on the topology of the
+// triangulation. To be more precise, as the phi changes continuously the
+// topology remains fixed with the triangles themselves changing continuously.
+// When topoology changes (adding or removing triangles), the disappearing
+// triangle's area has first continuously gone to zero (and, conversely, the
+// newly added triangle's area has continuously increased from zero). The
+// positions of the input vertices `tet_vertices_N` are measured and expressed
+// in a frame N. On return this method adds the new vertices and faces of the
+// triangulation into `vertices_N` and `faces`, respectively and returns the
+// number of vertices added. The geometric interpretation of the tetrahedron is
+// described in the documentation for the parameter `tet_vertices_N`. Finally,
+// the input scalar field `e_m` evaluated at each vertex of the tetrahedron is
+// linearly interpolated for each new vertex in `vertices_N` and placed in
+// `e_m_surface`.
 //
-// @param[in] tet_vertices_N Vertices defining the tetrahedron. The first
-// three vertices define the first face of the tetrahedra, with its
-// right-handed normal pointing towards the outside. The last vertex is on the
-// "negative side" of the first face.
-// @param[in] phi_N The level set function evaluated at each of the four
-// vertices in `tet_vertices_N`, in the same order.
-// @param[out] vertices Adds the new vertices into `vertices`.
-// @param[out] faces Adds the new faces into `faces`.
-// @return The number of vertices added.
-// @note   The convention used by this private method is different from the
-// one used in VolumeMesh.
-// TODO(amcastro-tri): fix the case for when the zero level set is right in the
-// middle between two adjacent faces, which might lead to double counting.
+// @param[in] tet_vertices_N
+//   Vertices defining the tetrahedron. The first three vertices define the
+//   first face of the tetrahedra, with its right-handed normal pointing towards
+//   the outside. The last vertex is on the "negative side" of the first face.
+// @param[in] phi
+//   The level set function evaluated at each of the four vertices in
+//   `tet_vertices_N`, in the same order.
+// @param[in] e_m
+//   A discrete, linear representation of a scalar field, defined by the value
+//   of the field at the tetrahedron vertices.
+// @param[out] vertices_N
+//   Adds the new vertices into `vertices`.
+// @param[out] faces
+//   Adds the new faces into `faces`.
+// @param[out] e_m_surface
+//   The scalar field `e_m` linearly interpolated onto each new vertex in
+//   `vertices`, in the same order.
+// @returns The number of vertices added.
+// @note The convention used by this private method is different from the
+// one used in VolumeMesh. For this method, vertices are must be provided in
+// the order documented in the input parameter `tet_vertices_N`.
+// For VolumeMesh, the convention is documented in the class's constructor and
+// in the constructor for VolumeElement. Please refer to the documentation
+// for VolumeMesh and VolumeElement.
+// details.
 template <typename T>
 int IntersectTetWithLevelSet(const std::array<Vector3<T>, 4>& tet_vertices_N,
-                             const Vector4<T>& phi_N,
-                             std::vector<SurfaceVertex<T>>* vertices,
-                             std::vector<SurfaceFace>* faces) {
-  DRAKE_ASSERT(vertices != nullptr);
+                             const Vector4<T>& phi, const Vector4<T>& e_m,
+                             std::vector<SurfaceVertex<T>>* vertices_N,
+                             std::vector<SurfaceFace>* faces,
+                             std::vector<T>* e_m_surface) {
+  DRAKE_ASSERT(vertices_N != nullptr);
   DRAKE_ASSERT(faces != nullptr);
+  DRAKE_ASSERT(e_m_surface != nullptr);
 
+  // Since this implementation does not cover the corner case of a face being in
+  // the zero level set, we assert this condition does not happen within a given
+  // tolerance. This tolerance is chosen small enough so only states that are
+  // very close to this condition trigger the assertion however, large enough to
+  // cover a band of numerical noise due to finite floating point precision.
+  // This assertion will be removed as part of the fix to the TODO below.
+  // TODO(amcastro-tri): fix the case for when the zero level set is right in
+  // the middle between two adjacent faces, which might lead to double counting.
   const double kZeroTolerance = 20 * std::numeric_limits<double>::epsilon();
   using std::abs;
   int num_zeros = 0;
-  for (int i = 0; i < 4; ++i)
-    if (abs(phi_N[i]) < kZeroTolerance) num_zeros++;
+  for (int i = 0; i < 4; ++i) {
+    if (abs(phi[i]) < kZeroTolerance) num_zeros++;
+  }
   if (num_zeros >= 3) {
     throw std::logic_error(
-        "One or more faces of this tetrahedron are close to being a zero "
-        "crossing level set, within machine precision. This situation could "
+        "One or more faces of this tetrahedron are close to being in the zero "
+        "level set, within machine precision. This situation could "
         "lead to double counting an interface between two neighboring "
         "tetrahedra. Often changing your initial conditions will mitigate this "
         "problem.");
   }
 
   // The current number of vertices before new are added.
-  const int num_vertices = vertices->size();
+  const int num_vertices = vertices_N->size();
 
   // Find out the marching tetrahedra case. We encode the case number in binary.
   // If a vertex is positive, we assign a "1", otherwise "0". We then form the
   // four bits number "binary_code" which in decimal leads to the index entry in
   // the marching tetrahedra table (from 0 to 15).
   using Array4i = Eigen::Array<int, 4, 1>;
-  const Array4i binary_code = (phi_N.array() > 0.0).template cast<int>();
+  const Array4i binary_code = (phi.array() > 0.0).template cast<int>();
   const Array4i powers_of_two = Vector4<int>(1, 2, 4, 8).array();
   const int case_index = (binary_code * powers_of_two).sum();
 
@@ -126,16 +165,23 @@ int IntersectTetWithLevelSet(const std::array<Vector3<T>, 4>& tet_vertices_N,
   Vector3<T> pc_N = Vector3<T>::Zero();  // Geometric center.
   for (int edge_index : intersected_edges) {
     const Edge& edge = kEdges[edge_index];
-    const Vector3<T>& p1_N = tet_vertices_N[edge.first];
-    const Vector3<T>& p2_N = tet_vertices_N[edge.second];
-    const T& phi1 = phi_N[edge.first];
-    const T& phi2 = phi_N[edge.second];
+    const int v1 = edge.first;
+    const int v2 = edge.second;
+    const Vector3<T>& p1_N = tet_vertices_N[v1];
+    const Vector3<T>& p2_N = tet_vertices_N[v2];
+    const T& phi1 = phi[v1];
+    const T& phi2 = phi[v2];
     const T w2 = abs(phi1) / (abs(phi1) + abs(phi2));
     const T w1 = 1.0 - w2;
     const Vector3<T> pz_N = w1 * p1_N + w2 * p2_N;
-    vertices->emplace_back(pz_N);
+    vertices_N->emplace_back(pz_N);
+
     // The geometric center is only needed for Case II.
     if (num_intersections == 4) pc_N += pz_N;
+
+    // Interpolate the scalar field e_m at the zero crossing z.
+    const T e_m_at_z = w1 * e_m[v1] + w2 * e_m[v2];
+    e_m_surface->emplace_back(e_m_at_z);
   }
 
   // Case I: A single vertex has different sign from the other three. A single
@@ -155,7 +201,14 @@ int IntersectTetWithLevelSet(const std::array<Vector3<T>, 4>& tet_vertices_N,
   if (num_intersections == 4) {
     // Add the geometric center.
     pc_N /= 4.0;
-    vertices->emplace_back(pc_N);
+    vertices_N->emplace_back(pc_N);
+
+    // Interpolate scalar field e_m at pc_N as the average of the values at the
+    // zero crossings.
+    const T e_m_at_c =
+        std::accumulate(e_m_surface->end() - 4, e_m_surface->end(), T(0)) /
+        T(4.0);
+    e_m_surface->emplace_back(e_m_at_c);
 
     // Make four triangles sharing the geometric center. All oriented such
     // that their right-handed normal points towards the positive side.
@@ -173,71 +226,105 @@ int IntersectTetWithLevelSet(const std::array<Vector3<T>, 4>& tet_vertices_N,
     return 5;
   }
 
-  throw std::logic_error("This line should never be reached.");
+  DRAKE_UNREACHABLE();
 }
 
 /// Given a level set function `φ(V)` and a volume defined by `mesh_M`, this
-/// method computes a triangulation of the zero level set `φ(V)` in the volume
-/// defined by the `mesh_M`.
-/// @param mesh_M
-///   Defines the volume M within which the zero level of `φ(V)` is found.
-/// @param level_set_N
-///   The level set function `φ(V)` represented as a `std::function`
-///   level_set_N, which takes the position of point V expressed in a frame N.
-///   That is, in code, φ(V) ≡ level_set_N(p_NV).
-/// @param X_NM
-///   The pose of M in N.
+/// method computes a triangulation of the zero level set of `φ(V)` in the
+/// volume defined by `mesh_M`.
 ///
-/// @note The resolution of the zero level set triangulation depends on the
+/// This method produces a surface mesh that samples a scalar field defined on a
+/// volume mesh. The geometry of the surface mesh is implicitly defined by a
+/// function. The surface is the zero level set of the function within the
+/// domain of the volume mesh. The vertices of the surface lie on the zero level
+/// set and the normals at the vertices are the gradient of the level set at the
+/// vertex positions. Finally, each surface mesh vertex is associated with the
+/// value of the volume mesh field `e_m_volume` evaluated at the vertex
+/// position.
+///
+/// The resolution of the zero level set triangulation depends on the
 /// resolution of the initial volume mesh. That is, if we denote with h the
 /// typical length scale of a tetrahedral element, then the surface
 /// triangulation will also have triangular elements of size in the order of
 /// h. Thus, features in the level set function with a length scale smaller
 /// than h will not be properly captured by the triangulation.
 ///
+/// @param mesh_M
+///   Defines the volume M within which the zero level of `φ(V)` is found.
+/// @param[in] phi_N
+///   The representation of the function `φ(V)` expressed in the frame N. That
+///   is, it can be evaluated for a point V when measured and expressed in that
+///   same frame N. In code, φ(V) ≡ phi_N(p_NV).
+/// @param[in] X_NM
+///   The pose of M in N.
+/// @param[in] e_m_volume
+///   A discrete, linear representation of a scalar field, defined by the value
+///   of the field at the mesh vertices.
+/// @param[out] e_m_surface
+///   The scalar field e_m_volume sampled on the vertices of the zero-level set
+///   contact surface. Because `e_m_volume` is itself a discrete, linear
+///   representation of a continuous scalar field, the values on the contact
+///   surface will be an linear interpolation of those values.
+///   Any existing values in `e_m_surface` at input are cleared.
+/// @param[out] phi_gradient_N
+///   The gradient `[∇φ]_N`, expressed in frame N, of `phi_N` sampled at
+///   the surface vertices.
+///   Any existing values in `phi_gradient_N` at input are cleared.
+///
 /// @note This implementation uses the marching tetrahedra algorithm as
-/// described in [Bloomenthal, 1994].
+/// described in Bloomenthal, J., 1994. An Implicit Surface Polygonizer.
+/// Graphics Gems IV, pp. 324-349.
 ///
 /// @returns A triangulation of the zero level set of `φ(V)` in the volume
-/// defined by the `mesh_M`.  The triangulation is expressed in frame N. The
+/// defined by `mesh_M`.  The triangulation is expressed in frame N. The
 /// right handed normal of each triangle points towards the positive side of the
-/// level set function `φ(V)` or in other words, the normal is aligned with the
-/// gradient of `φ(V)`.
+/// level set function `φ(V)`.
 ///
-/// @note  The SurfaceMesh may have duplicated vertices.
-///
-/// Bloomenthal, J., 1994. An Implicit Surface Polygonizer. Graphics Gems IV,
-/// pp. 324-349.
+/// @note  The SurfaceMesh may have duplicate vertices.
 template <typename T>
 SurfaceMesh<T> CalcZeroLevelSetInMeshDomain(
-    const VolumeMesh<T>& mesh_M,
-    std::function<T(const Vector3<T>&)> level_set_N,
-    const math::RigidTransform<T>& X_NM) {
-  std::vector<SurfaceVertex<T>> vertices;
+    const VolumeMesh<T>& mesh_M, const LevelSetField<T>& phi_N,
+    const math::RigidTransform<T>& X_NM, const std::vector<T>& e_m_volume,
+    std::vector<T>* e_m_surface,
+    std::vector<Vector3<T>>* phi_gradient_N) {
+  DRAKE_DEMAND(e_m_surface != nullptr);
+  DRAKE_ASSERT(phi_gradient_N != nullptr);
+  std::vector<SurfaceVertex<T>> vertices_N;
   std::vector<SurfaceFace> faces;
+  e_m_surface->clear();
 
   // We scan each tetrahedron in the mesh and compute the zero level set with
   // IntersectTetWithLevelSet().
   std::array<Vector3<T>, 4> tet_vertices_N;
-  Vector4<T> phi_N;
-  for (const auto& tet_indexes : mesh_M.tetrahedra()) {
+  Vector4<T> phi;
+  Vector4<T> e_m;
+  for (const auto& tet : mesh_M.tetrahedra()) {
     // Collect data for each vertex of the tetrahedron.
     for (int i = 0; i < 4; ++i) {
-      const auto& p_MV = mesh_M.vertex(tet_indexes.vertex(i)).r_MV();
+      const auto& p_MV = mesh_M.vertex(tet.vertex(i)).r_MV();
       tet_vertices_N[i] = X_NM * p_MV;
-      phi_N[i] = level_set_N(tet_vertices_N[i]);
+      phi[i] = phi_N.value(tet_vertices_N[i]);
+      e_m[i] = e_m_volume[tet.vertex(i)];
     }
     // IntersectTetWithLevelSet() uses a different convention than VolumeMesh
     // to index the vertices of a tetrahedra and therefore we swap vertexes 1
     // and 2.
-    // TODO(amcastro-tri): If this becomes a performance issue, re-write
-    // IntersectTetWithLevelSet() to use the convention in VolumeMesh.
+    // TODO(amcastro-tri): re-write IntersectTetWithLevelSet() to use the
+    // convention in VolumeMesh.
     std::swap(tet_vertices_N[1], tet_vertices_N[2]);
-    std::swap(phi_N[1], phi_N[2]);
-    IntersectTetWithLevelSet(tet_vertices_N, phi_N, &vertices, &faces);
+    std::swap(phi[1], phi[2]);
+    std::swap(e_m[1], e_m[2]);
+    IntersectTetWithLevelSet(tet_vertices_N, phi, e_m, &vertices_N, &faces,
+                             e_m_surface);
   }
 
-  return SurfaceMesh<T>(std::move(faces), std::move(vertices));
+  phi_gradient_N->resize(vertices_N.size());
+  for (SurfaceVertexIndex v(0); v < vertices_N.size(); ++v) {
+    const Vector3<T>& p_NV = vertices_N[v].r_MV();
+    (*phi_gradient_N)[v] = phi_N.gradient(p_NV);
+  }
+
+  return SurfaceMesh<T>(std::move(faces), std::move(vertices_N));
 }
 
 }  // namespace internal

--- a/geometry/proximity/test/contact_surface_calculator_test.cc
+++ b/geometry/proximity/test/contact_surface_calculator_test.cc
@@ -13,7 +13,6 @@
 
 using drake::math::RigidTransformd;
 using drake::math::RollPitchYawd;
-using Eigen::Vector3d;
 
 namespace drake {
 namespace geometry {
@@ -54,14 +53,23 @@ class TetrahedronIntersectionTest : public ::testing::Test {
 TEST_F(TetrahedronIntersectionTest, EmptyIntersection) {
   std::vector<SurfaceVertex<double>> vertices;
   std::vector<SurfaceFace> faces;
+  std::vector<double> e_M_surface;
 
   // All positive vertices.
   Vector4<double> phi_N = Vector4<double>::Ones();
-  EXPECT_EQ(IntersectTetWithLevelSet(unit_tet_, phi_N, &vertices, &faces), 0);
+
+  // Arbitrary values of scalar and vector fields since they are not used in
+  // this test.
+  const Vector4<double> e_M = Vector4<double>::Zero();
+  EXPECT_EQ(IntersectTetWithLevelSet(unit_tet_, phi_N, e_M, &vertices, &faces,
+                                     &e_M_surface),
+            0);
 
   // All negative vertices.
   phi_N = -Vector4<double>::Ones();
-  EXPECT_EQ(IntersectTetWithLevelSet(unit_tet_, phi_N, &vertices, &faces), 0);
+  EXPECT_EQ(IntersectTetWithLevelSet(unit_tet_, phi_N, e_M, &vertices, &faces,
+                                     &e_M_surface),
+            0);
 }
 
 // Case I of marching tetrahedra: only one of the vertices has a sign different
@@ -69,6 +77,7 @@ TEST_F(TetrahedronIntersectionTest, EmptyIntersection) {
 TEST_F(TetrahedronIntersectionTest, CaseI) {
   std::vector<SurfaceVertex<double>> vertices;
   std::vector<SurfaceFace> faces;
+  std::vector<double> e_M_surface;
   const double kTolerance = 5.0 * std::numeric_limits<double>::epsilon();
 
   const int expected_num_intersections = 3;
@@ -86,14 +95,19 @@ TEST_F(TetrahedronIntersectionTest, CaseI) {
     return (to - from).normalized();
   };
 
+  // Arbitrary values of scalar and vector fields since they are not used in
+  // this test.
+  const Vector4<double> e_M = Vector4<double>::Zero();
+
   // All vertices are positive but the i-th vertex.
   for (int i = 0; i < 4; ++i) {
     vertices.clear();
     faces.clear();
     Vector4<double> phi_N = Vector4<double>::Ones();
     phi_N[i] = -1.0;
-    ASSERT_EQ(IntersectTetWithLevelSet(unit_tet_, phi_N, &vertices, &faces),
-        expected_num_intersections);
+    ASSERT_EQ(IntersectTetWithLevelSet(unit_tet_, phi_N, e_M, &vertices, &faces,
+                                       &e_M_surface),
+              expected_num_intersections);
 
     ASSERT_EQ(faces.size(), 1);
     const Vector3<int> expected_face(0, 1, 2);
@@ -116,8 +130,9 @@ TEST_F(TetrahedronIntersectionTest, CaseI) {
     faces.clear();
     Vector4<double> phi_N = -Vector4<double>::Ones();
     phi_N[i] = 1.0;
-    ASSERT_EQ(IntersectTetWithLevelSet(unit_tet_, phi_N, &vertices, &faces),
-        expected_num_intersections);
+    ASSERT_EQ(IntersectTetWithLevelSet(unit_tet_, phi_N, e_M, &vertices, &faces,
+                                       &e_M_surface),
+              expected_num_intersections);
 
     ASSERT_EQ(faces.size(), 1);
     const Vector3<int> expected_face(0, 1, 2);
@@ -158,8 +173,13 @@ TEST_F(TetrahedronIntersectionTest, CaseII) {
 
     std::vector<SurfaceVertex<double>> vertices;
     std::vector<SurfaceFace> faces;
-    ASSERT_EQ(IntersectTetWithLevelSet(unit_tet_, phi_N, &vertices, &faces),
-        expected_num_vertices);
+    std::vector<double> e_M_surface;
+    // Arbitrary values of scalar and vector fields since they are not used in
+    // this test.
+    const Vector4<double> e_M = Vector4<double>::Zero();
+    ASSERT_EQ(IntersectTetWithLevelSet(unit_tet_, phi_N, e_M, &vertices, &faces,
+                                       &e_M_surface),
+              expected_num_vertices);
 
     ASSERT_EQ(faces.size(), 4);
     ASSERT_EQ(vertices.size(), 5);
@@ -218,9 +238,31 @@ class BoxPlaneIntersectionTest : public ::testing::Test {
                                            VE(e3), VE(e4), VE(e5)};
     box_B_ = std::make_unique<VolumeMesh<double>>(std::move(elements),
                                                   std::move(vertices));
-    half_space_H_ = [](const Vector3<double>& p_HQ) { return p_HQ[2]; };
+    // Level set for a half-space.
+    // N.B. The "gradient" functor is not the true gradient of the level set
+    // function. We choose however a "more interesting" function for testing
+    // purposes. What we want to test is that a linear scalar field is
+    // interpolated exactly, whithin machine precision.
+    half_space_H_ = std::make_unique<LevelSetField<double>>(
+        [](const Vector3<double>& p_HQ) { return p_HQ[2]; },
+        [](const Vector3<double>& p_HQ) {
+          return p_HQ + 0.5 * Vector3<double>::Ones();
+        });
+
+    // For unit testing purposes, generate scalar and vector fields that are
+    // linear with the position coordinates.
+    // The scalar field is chosen to be a linear function of the z coordinate
+    // with zero value at the bottom face and a value of 1.0 at the top face.
+    // Since CalcZeroLevelSetInMeshDomain() uses linear interpolations, we
+    // expect to get exact values to machine precision.
+    for (VolumeVertexIndex v(0); v < box_B_->num_vertices(); ++v) {
+      const Vector3<double>& p_BV = box_B_->vertex(v).r_MV();
+      const double eb = p_BV[2] + 0.5;
+      e_b_.push_back(eb);
+    }
   }
 
+  // TODO(amcastro-tri): we'd like this to be a method of SurfaceMesh.
   double CalcSurfaceArea(const SurfaceMesh<double>& mesh) {
     double area = 0;
     for (SurfaceFaceIndex f(0); f < mesh.num_faces(); ++f) {
@@ -233,11 +275,14 @@ class BoxPlaneIntersectionTest : public ::testing::Test {
   // the box B.
   std::unique_ptr<VolumeMesh<double>> box_B_;
 
+  // Value of a scalar field e_b defined on the volume mesh box_B_.
+  std::vector<double> e_b_;
+
   // A level set function, chosen to be the distance function, for a half space.
   // It is defined as a function φ: ℝ³ → ℝ with the input position vector
   // expressed in the frame H of the half space. Frame H is defined such that Hz
   // normal to the half space points into the positive direction (outwards).
-  std::function<double(const Vector3<double>&)> half_space_H_;
+  std::unique_ptr<LevelSetField<double>> half_space_H_;
 };
 
 // The bottom face of the box is machine epsilon from being flat on the
@@ -247,27 +292,31 @@ class BoxPlaneIntersectionTest : public ::testing::Test {
 // verify this.
 TEST_F(BoxPlaneIntersectionTest, ImminentContact) {
   const double kEpsilon = std::numeric_limits<double>::epsilon();
+  std::vector<double> e_b_surface;
+  std::vector<Vector3<double>> level_set_gradient_H;
 
   // The box overlaps the plane by kEpsilon. Expect intersection.
   {
     const math::RigidTransformd X_HB =
         Translation3<double>(0.0, 0.0, 0.5 - 5 * kEpsilon);
-    DRAKE_EXPECT_THROWS_MESSAGE(CalcZeroLevelSetInMeshDomain(
-            *box_B_, half_space_H_, X_HB),
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        CalcZeroLevelSetInMeshDomain(*box_B_, *half_space_H_, X_HB, e_b_,
+                                     &e_b_surface, &level_set_gradient_H),
         std::logic_error,
-        "One or more faces of this tetrahedron are close to being a zero "
-        "crossing.*");
+        "One or more faces of this tetrahedron are close to being in the "
+        "zero.*");
   }
 
   // The box is on top of the plane by kEpsilon. Expect no intersection.
   {
     const math::RigidTransformd X_HB =
         Translation3<double>(0.0, 0.0, 0.5 + 5 * kEpsilon);
-    DRAKE_EXPECT_THROWS_MESSAGE(CalcZeroLevelSetInMeshDomain(
-            *box_B_, half_space_H_, X_HB),
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        CalcZeroLevelSetInMeshDomain(*box_B_, *half_space_H_, X_HB, e_b_,
+                                     &e_b_surface, &level_set_gradient_H),
         std::logic_error,
-        "One or more faces of this tetrahedron are close to being a zero "
-        "crossing.*");
+        "One or more faces of this tetrahedron are close to being in the "
+        "zero.*");
   }
 }
 
@@ -308,10 +357,43 @@ TEST_F(BoxPlaneIntersectionTest, VerifyContactArea) {
       RigidTransformd(Ry_pi, middle),
       RigidTransformd(Ry_pi, highest)};
 
+  std::vector<double> e_b_surface;
+  std::vector<Vector3<double>> level_set_gradient_H;
   for (const auto& X_HB : poses) {
-    const SurfaceMesh<double> contact_surface = CalcZeroLevelSetInMeshDomain(
-            *box_B_, half_space_H_, X_HB);
-    EXPECT_NEAR(CalcSurfaceArea(contact_surface), 1.0, kTolerance);
+    const SurfaceMesh<double> contact_surface_H =
+        CalcZeroLevelSetInMeshDomain(*box_B_, *half_space_H_, X_HB, e_b_,
+                                     &e_b_surface, &level_set_gradient_H);
+    EXPECT_NEAR(CalcSurfaceArea(contact_surface_H), 1.0, kTolerance);
+  }
+}
+
+// This unit test verifies that CalcZeroLevelSetInMeshDomain() properly
+// computes both the scalar and vector fields onto the zero-level set surface.
+TEST_F(BoxPlaneIntersectionTest, VerifySurfaceFieldsInterpolations) {
+  const double kEpsilon = std::numeric_limits<double>::epsilon();
+  const double kTolerance = 5.0 * kEpsilon;
+
+  const std::vector<double> heights = {-0.4, -0.2, 0.0, 0.2, 0.4};
+
+  std::vector<double> e_b_surface;
+  std::vector<Vector3<double>> level_set_gradient_H;
+  for (const auto& h : heights) {
+    const RigidTransformd X_HB = Translation3<double>(0.0, 0.0, h);
+    const SurfaceMesh<double> contact_surface_H =
+        CalcZeroLevelSetInMeshDomain(*box_B_, *half_space_H_, X_HB, e_b_,
+                                     &e_b_surface, &level_set_gradient_H);
+
+    const double eb_expected = 0.5 - h;
+    for (SurfaceVertexIndex v(0); v < contact_surface_H.num_vertices(); ++v) {
+      const double eb = e_b_surface[v];
+      const Vector3<double>& grad_level_set_H = level_set_gradient_H[v];
+      const Vector3<double>& p_HV = contact_surface_H.vertex(v).r_MV();
+      const Vector3<double> level_set_gradient_H_expected =
+          half_space_H_->gradient(p_HV);
+      EXPECT_NEAR(eb, eb_expected, kTolerance);
+      EXPECT_TRUE(CompareMatrices(grad_level_set_H,
+                                  level_set_gradient_H_expected, kTolerance));
+    }
   }
 }
 
@@ -347,8 +429,11 @@ TEST_F(BoxPlaneIntersectionTest, NoIntersection) {
       RigidTransformd(Ry_pi, highest)};
 
   for (const auto& X_HB : poses) {
-    const SurfaceMesh<double> contact_surface = CalcZeroLevelSetInMeshDomain(
-            *box_B_, half_space_H_, X_HB);
+    std::vector<double> e_b_surface;
+    std::vector<Vector3<double>> level_set_gradient_H;
+    const SurfaceMesh<double> contact_surface =
+        CalcZeroLevelSetInMeshDomain(*box_B_, *half_space_H_, X_HB, e_b_,
+                                     &e_b_surface, &level_set_gradient_H);
     EXPECT_NEAR(CalcSurfaceArea(contact_surface), 0.0, kTolerance);
   }
 }
@@ -358,16 +443,38 @@ TEST_F(BoxPlaneIntersectionTest, NoIntersection) {
 // In particular, we verify that the vertices on the contact surface are
 // properly interpolated to lie on the plane within a circle of the expected
 // radius, and normals point towards the positive side of the plane.
-GTEST_TEST(SpherePlaneIntersectionTest, VerticesProperlyInterpolated) {
+// We also verify that both scalar and vector fields are properly interpolated
+// onto the zero-level set surface.
+GTEST_TEST(SpherePlaneIntersectionTest, VerifyInterpolations) {
   const double kTolerance = 5.0 * std::numeric_limits<double>::epsilon();
 
   // A tessellation of a unit sphere. Vertices are in the mesh frame M.
   // This creates a volume mesh with over 32K tetrahedra.
   const VolumeMesh<double> sphere_M = MakeUnitSphereMesh<double>(4);
-  // A level set for a half-space, as a function of the position vector p_WQ for
-  // points Q in the world frame W.
-  std::function<double(const Vector3<double>&)> half_space_W =
-      [](const Vector3<double>& p_WQ) { return p_WQ[2]; };
+
+  // We generate scalar and vector fields linear in the position coordinates.
+  // Since CalcZeroLevelSetInMeshDomain() uses linear interpolations, we
+  // expect to get exact values to machine precision.
+  // A scalar field function of the y coordinate provides an interesting case
+  // for which the field changes values over the patch (vs a case with a scalar
+  // field function of the z coordinate which would lead to a constant value
+  // over the patch.)
+  std::vector<double> em_volume;
+  for (VolumeVertexIndex v(0); v < sphere_M.num_vertices(); ++v) {
+    const Vector3<double>& p_MV = sphere_M.vertex(v).r_MV();
+    const double em = (p_MV[1] + 1) / 2.0;
+    em_volume.push_back(em);
+  }
+
+  // A level set for a half-space, as a function of the position vector p_WQ
+  // for points Q in the world frame W.
+  // We choose a linear function of the position coordinates instead of the
+  // actual gradient for testing purposes.
+  const LevelSetField<double> half_space_W(
+      [](const Vector3<double>& p_WQ) { return p_WQ[2]; },
+      [](const Vector3<double>& p_WQ) {
+        return (p_WQ + Vector3<double>::Ones()) / 2.0;
+      });
 
   // We place the sphere above the half-space but overlapping, such that the
   // deepest penetration point is at a distance equal to 0.3 (the sphere radius
@@ -377,14 +484,19 @@ GTEST_TEST(SpherePlaneIntersectionTest, VerticesProperlyInterpolated) {
 
   // The contact surface is expressed in the frame of the level set, in this
   // case the world frame W.
+  std::vector<double> e_m_surface;
+  std::vector<Vector3<double>> level_set_gradient_W;
   const SurfaceMesh<double> contact_surface_W =
-      CalcZeroLevelSetInMeshDomain(sphere_M, half_space_W, X_WM);
+      CalcZeroLevelSetInMeshDomain(sphere_M, half_space_W, X_WM, em_volume,
+                                   &e_m_surface, &level_set_gradient_W);
   // Assert non-empty intersection.
   ASSERT_GT(contact_surface_W.num_faces(), 0);
 
+  ASSERT_EQ(e_m_surface.size(), contact_surface_W.num_vertices());
+
   for (SurfaceVertexIndex v(0); v < contact_surface_W.num_vertices(); ++v) {
     const Vector3<double>& p_WV = contact_surface_W.vertex(v).r_MV();
-    // We verify that the postions were correctly interpolated to lie on the
+    // We verify that the positions were correctly interpolated to lie on the
     // plane.
     EXPECT_NEAR(p_WV[2], 0.0, kTolerance);
 
@@ -392,6 +504,19 @@ GTEST_TEST(SpherePlaneIntersectionTest, VerticesProperlyInterpolated) {
     const double surface_radius = std::sqrt(1.0 - height * height);
     const double radius = p_WV.norm();  // since z component is zero.
     EXPECT_LE(radius, surface_radius);
+
+    // Since the scalar field is linear in y and CalcZeroLevelSetInMeshDomain()
+    // uses linear interpolations, we expect an exact match with the analytical
+    // expression (modulo machine precision).
+    const double em_expected = (1.0 + p_WV[1]) / 2.0;
+    EXPECT_NEAR(e_m_surface[v], em_expected, kTolerance);
+
+    // Similarly for the gradient.
+    const Vector3<double> level_set_gradient_W_expected =
+        half_space_W.gradient(p_WV);
+    EXPECT_TRUE(CompareMatrices(level_set_gradient_W[v],
+                                level_set_gradient_W_expected,
+                                40 * kTolerance));
   }
 
   // Verify all normals point towards the positive side of the plane.
@@ -410,7 +535,10 @@ GTEST_TEST(SpherePlaneIntersectionTest, VerticesProperlyInterpolated) {
     //   1) precision loss in the frame transformation between the sphere and
     //      the plane.
     //   2) Interpolation within the tetrahedra.
-    EXPECT_TRUE(CompareMatrices(normal_W, Vector3d::UnitZ(), 40 * kTolerance));
+    // We empirically determined the tolerance used for the tests below to
+    // be a representative number of the precission loss that we observed.
+    EXPECT_TRUE(
+        CompareMatrices(normal_W, Vector3<double>::UnitZ(), 40 * kTolerance));
   }
 }
 

--- a/geometry/proximity/volume_mesh.h
+++ b/geometry/proximity/volume_mesh.h
@@ -65,6 +65,11 @@ class VolumeElement {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(VolumeElement)
 
   /** Constructs VolumeElement.
+   We follow the convention that the first three vertices define a triangle with
+   its right-handed normal pointing inwards. The fourth vertex is then on the
+   positive side of this first triangle.
+   @warning This class does not enforce our convention for the ordering of the
+   vertices.
    @param v0 Index of the first vertex in VolumeMesh.
    @param v1 Index of the second vertex in VolumeMesh.
    @param v2 Index of the third vertex in VolumeMesh.
@@ -134,6 +139,10 @@ class VolumeMesh {
 
   //@}
 
+  /** Constructor from a vector of vertices and from a vector of elements.
+   Each element must be a valid VolumeElement following the vertex ordering
+   convention documented in the VolumeElement class. This class however does not
+   enforce this convention and it is thus the responsibility of the user.  */
   VolumeMesh(std::vector<VolumeElement>&& elements,
              std::vector<VolumeVertex<T>>&& vertices)
       : elements_(std::move(elements)), vertices_(std::move(vertices)) {}

--- a/multibody/hydroelastics/BUILD.bazel
+++ b/multibody/hydroelastics/BUILD.bazel
@@ -1,0 +1,26 @@
+# -*- python -*-
+
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_googletest",
+    "drake_cc_library",
+    "drake_cc_package_library",
+)
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+package(default_visibility = ["//visibility:public"])
+
+drake_cc_package_library(
+    name = "hydroelastics",
+    deps = [
+        ":level_set_field",
+    ],
+)
+
+drake_cc_library(
+    name = "level_set_field",
+    hdrs = ["level_set_field.h"],
+    deps = ["//common"],
+)
+
+add_lint_tests()

--- a/multibody/hydroelastics/level_set_field.h
+++ b/multibody/hydroelastics/level_set_field.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <functional>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace geometry {
+
+// TODO(amcastro-tri): consider making this an abstract class so that we can
+// inherit multiple implementations (analytical, structured grids, etc.)
+/// This class represents a level set function as the mapping
+/// `φ(p_FR): ℝ³ →  ℝ` with `p_FR` the position vector for a point R in a frame
+/// F.
+template <typename T>
+struct LevelSetField {
+  /// Constructs a level set field from user-defined functions for a level set
+  /// and its gradient.
+  /// These functions implicitly defines a frame F for the level set
+  /// field. `level_set_F` defines the level set value at a point R from its
+  /// position vector `p_FR` in F as `φ(R) ≡ level_set_F(p_FR)`.
+  /// Similarly, `grad_level_set_F` is a function taking the position of point R
+  /// in frame F, with the resulting gradient expressed in frame F.
+  LevelSetField(std::function<T(const Vector3<T>&)> level_set_F,
+                std::function<Vector3<T>(const Vector3<T>&)> grad_level_set_F)
+      : value(level_set_F), gradient(grad_level_set_F) {}
+
+  LevelSetField(LevelSetField&&) = default;
+  LevelSetField& operator=(LevelSetField&&) = default;
+
+  std::function<T(const Vector3<T>&)> value;
+  std::function<Vector3<T>(const Vector3<T>&)> gradient;
+};
+
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
This PR updates `CalcZeroLevelSetInMeshDomain()` so that scalar and vector fields are interpolated onto the zero-level set surface.

As a unit test, we verify the interpolation of linear scalar and vector fields for the intersection between a (tessellated) sphere and a (zero-level set) half-space. The figure below shows the interpolation of a scalar field (originally defined in the sphere volume) linear in the y coordinate onto the intersected surface:

![sphere_plane_interpolation](https://user-images.githubusercontent.com/17601461/59466423-4ecee380-8dfb-11e9-9dfd-5b2b0aa0733c.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11644)
<!-- Reviewable:end -->
