### PR TITLE
pydrake: Remove catching of deprecation errors in `.all` modules

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -309,7 +309,10 @@ drake_py_unittest(
     name = "all_test",
     timeout = "moderate",
     data = ["//examples/pendulum:models"],
-    deps = [":all_py"],
+    deps = [
+        ":all_py",
+        "//bindings/pydrake/common/test_utilities:deprecation_py",
+    ],
 )
 
 drake_py_library(

--- a/bindings/pydrake/all.py
+++ b/bindings/pydrake/all.py
@@ -3,14 +3,19 @@
 Things to note:
 
 * The `.all` modules in `pydrake` are intended as convenient end-user shortcut
-  for interactive or tutorial use.
+  for interactive or tutorial use. Please only use it for prototyping, but do
+  not use it in production code.
 * Code within pydrake itself should not use the all shortcut, but rather
   import only exactly what is needed.
-* The downside of importing an `.all` module is (a) pulling in additional
+* The downsides of importing an `.all` module are (a) pulling in additional
   dependencies, (b) the potential to lose a symbol if there is a conflict
   (e.g. something like `pydrake.multibody.shapes.Element` vs
   `pydrake.multibody.collision.Element` (which does not exist yet)), and
   (c) deprecated symbols could get removed without warning from `all` modules.
+* Deprecated modules will *not* be incorporated in `all` modules, because
+  otherwise, `all` would emit noisy deprecation warnings, or if they are
+  suppressed, subseqeuent imports of those deprecated modules will not trigger
+  warnings.
 
 Note:
     Import order matters! If there is a name conflict, the last one imported

--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -162,7 +162,7 @@ PY_LIBRARIES_ATTIC_ALIASES = [
 drake_py_library_aliases(
     actual_subdir = "bindings/pydrake/attic/multibody",
     add_deprecation_warning = 1,
-    deprecation_removal_date = "2019-06-01",
+    deprecation_removal_date = "2019-10-01",
     relative_labels = PY_LIBRARIES_ATTIC_ALIASES,
 )
 

--- a/bindings/pydrake/multibody/all.py
+++ b/bindings/pydrake/multibody/all.py
@@ -1,19 +1,5 @@
 import warnings
 
-# Deprecated symbols.
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore", DeprecationWarning)
-    # - Attic (#9314)
-    from .collision import *
-    from .joints import *
-    from .parsers import *
-    from .rigid_body_plant import *
-    from .rigid_body_tree import *
-    from .rigid_body import *
-    from .shapes import *
-    # - Shuffle (#9314. #9366)
-    from .multibody_tree.all import *  # noqa
-
 # Normal symbols.
 from .inverse_kinematics import *  # noqa
 from .math import *  # noqa

--- a/bindings/pydrake/solvers/BUILD.bazel
+++ b/bindings/pydrake/solvers/BUILD.bazel
@@ -180,7 +180,7 @@ PY_LIBRARIES_ATTIC_ALIASES = [
 drake_py_library_aliases(
     actual_subdir = "bindings/pydrake/attic/solvers",
     add_deprecation_warning = 1,
-    deprecation_removal_date = "2019-06-01",
+    deprecation_removal_date = "2019-10-01",
     relative_labels = PY_LIBRARIES_ATTIC_ALIASES,
 )
 

--- a/bindings/pydrake/solvers/all.py
+++ b/bindings/pydrake/solvers/all.py
@@ -1,11 +1,6 @@
 from __future__ import absolute_import
 import warnings
 
-# Deprecated symbols.
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore", DeprecationWarning)
-    from .ik import *
-
 from .mathematicalprogram import *  # noqa
 # TODO(eric.cousineau): Merge these into `mathematicalprogram`.
 from .gurobi import *  # noqa

--- a/bindings/pydrake/test/all_test.py
+++ b/bindings/pydrake/test/all_test.py
@@ -4,6 +4,8 @@ import sys
 import unittest
 import warnings
 
+from pydrake.common.test_utilities.deprecation import catch_drake_warnings
+
 
 class TestAll(unittest.TestCase):
     # N.B. Synchronize code snippests with `doc/python_bindings.rst`.
@@ -20,10 +22,17 @@ class TestAll(unittest.TestCase):
             # avoid issues on different machines, but still catch meaningful
             # warnings.
             warnings.simplefilter("always", Warning)
+            warnings.filterwarnings(
+                "ignore", message="Matplotlib is building the font cache",
+                category=UserWarning)
             import pydrake.all
             if w:
                 sys.stderr.write("Encountered import warnings:\n{}\n".format(
                     "\n".join(map(str, w)) + "\n"))
+            self.assertEqual(len(w), 0)
+        # Show that deprecated modules are not incorporated in `.all` (#11363).
+        with catch_drake_warnings(expected_count=1):
+            import pydrake.multibody.rigid_body_tree
 
     def test_usage_no_all(self):
         from pydrake.common import FindResourceOrThrow

--- a/tools/skylark/alias.bzl
+++ b/tools/skylark/alias.bzl
@@ -141,7 +141,8 @@ from {module} import *
 
 _warn_deprecated(
     "This module is deprecated and will be removed on or around "
-    "{deprecation_removal_date}. Please use '{module}' instead.")
+    "{deprecation_removal_date}. Please use '{module}' instead.",
+    stacklevel=3)
 '''
 
 def _strip_py_suffix(label):


### PR DESCRIPTION
Resolves #11363

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11645)
<!-- Reviewable:end -->
