### PR TITLE
Obtain Python runtime from a toolchain rather than a flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,13 +217,17 @@ else()
   string(REPLACE "." ";" WITH_PYTHON_VERSION_LIST "${WITH_PYTHON_VERSION}")
   list(GET WITH_PYTHON_VERSION_LIST 0 WITH_PYTHON_VERSION_MAJOR)
 
-  if(APPLE AND WITH_PYTHON_VERSION_MAJOR EQUAL 2)
-    # Ensure that the python2 executable or link is used in preference to the
-    # python and python2.7 executables or links, which correspond to the
-    # system version of Python installed on macOS. There is no system python3
-    # as of macOS Mojave 10.14.
-    find_program(PYTHON_EXECUTABLE NAMES python2)
+  if(APPLE)
+    set(FIND_PYTHON_EXECUTABLE_PATHS /usr/local/bin)
+  else()
+    set(FIND_PYTHON_EXECUTABLE_PATHS /usr/bin)
   endif()
+
+  find_program(PYTHON_EXECUTABLE
+    NAMES python${WITH_PYTHON_VERSION_MAJOR}
+    PATHS "${FIND_PYTHON_EXECUTABLE_PATHS}"
+    NO_DEFAULT_PATH
+  )
 
   find_package(PythonInterp ${WITH_PYTHON_VERSION} EXACT MODULE REQUIRED)
 endif()
@@ -237,6 +241,8 @@ if(NOT PYTHON_VERSION_MAJOR_MINOR IN_LIST SUPPORTED_PYTHON_VERSIONS)
     "Python ${PYTHON_VERSION_MAJOR_MINOR} is NOT supported. Python code in project drake_cxx_python may fail at runtime."
   )
 endif()
+
+set(BAZEL_PYTHON_VERSION PY${PYTHON_VERSION_MAJOR})
 
 if(CMAKE_COLOR_MAKEFILE)
   set(BAZEL_COLOR yes)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,6 +5,11 @@
 
 workspace(name = "drake")
 
+register_toolchains(
+    "//tools/py_toolchain:linux_python_toolchain",
+    "//tools/py_toolchain:macos_python_toolchain",
+)
+
 load("//tools/workspace:default.bzl", "add_default_repositories")
 
 add_default_repositories()

--- a/cmake/bazel.rc.in
+++ b/cmake/bazel.rc.in
@@ -12,7 +12,8 @@
 
 build --action_env=DRAKE_PYTHON_BIN_PATH=@PYTHON_EXECUTABLE@
 build --color=@BAZEL_COLOR@
-build --python_path=@PYTHON_EXECUTABLE@
+build --host_force_python=@BAZEL_PYTHON_VERSION@
+build --python_version=@BAZEL_PYTHON_VERSION@
 build --subcommands=@BAZEL_SUBCOMMANDS@
 build --symlink_prefix=/
 

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -1,5 +1,6 @@
 # Import some helper configurations.
 import %workspace%/tools/cc_toolchain/bazel.rc
+import %workspace%/tools/py_toolchain/bazel.rc
 import %workspace%/tools/dynamic_analysis/bazel.rc
 import %workspace%/tools/lint/bazel.rc
 

--- a/tools/install/install_test_helper.py
+++ b/tools/install/install_test_helper.py
@@ -69,16 +69,8 @@ def create_temporary_dir(name='tmp'):
 
 
 def get_python_executable():
-    """Use appropriate Python executable
-
-    Call python2/3 on MacOS to force using python brew install. Calling python
-    system would result in a crash since pydrake was built against brew python.
-    On other systems, it will just fall-back to the current Python executable.
-    """
-    if sys.platform == "darwin":
-        return "python{}".format(sys.version_info.major)
-    else:
-        return sys.executable
+    """Use appropriate Python executable."""
+    return os.environ['DRAKE_PYTHON_BIN_PATH']
 
 
 def run_and_kill(cmd, timeout=2.0, from_install_dir=True):

--- a/tools/macos.bazelrc
+++ b/tools/macos.bazelrc
@@ -1,11 +1,9 @@
 # N.B. Ensure we only use Homebrew's Python in `/usr/local`.
 
 # Use Python 2 by default.
-build --python_path=/usr/local/bin/python2
 build --action_env=DRAKE_PYTHON_BIN_PATH=/usr/local/bin/python2
 
 # Explicit configuration for Python 3.
-build:python3 --python_path=/usr/local/bin/python3
 build:python3 --action_env=DRAKE_PYTHON_BIN_PATH=/usr/local/bin/python3
 
 # Configure ${PATH} for actions.

--- a/tools/py_toolchain/BUILD.bazel
+++ b/tools/py_toolchain/BUILD.bazel
@@ -1,0 +1,72 @@
+# -*- python -*-
+
+load("@bazel_tools//tools/python:toolchain.bzl", "py_runtime_pair")
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+package(default_visibility = ["//visibility:public"])
+
+py_runtime(
+    name = "linux_py2_runtime",
+    interpreter_path = "/usr/bin/python2",
+    python_version = "PY2",
+)
+
+py_runtime(
+    name = "linux_py3_runtime",
+    interpreter_path = "/usr/bin/python3",
+    python_version = "PY3",
+)
+
+py_runtime_pair(
+    name = "linux_py_runtime_pair",
+    py2_runtime = ":linux_py2_runtime",
+    py3_runtime = ":linux_py3_runtime",
+)
+
+toolchain(
+    name = "linux_python_toolchain",
+    exec_compatible_with = [
+        "@bazel_tools//platforms:linux",
+        "@bazel_tools//platforms:x86_64",
+    ],
+    target_compatible_with = [
+        "@bazel_tools//platforms:linux",
+        "@bazel_tools//platforms:x86_64",
+    ],
+    toolchain = ":linux_py_runtime_pair",
+    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
+)
+
+py_runtime(
+    name = "macos_py2_runtime",
+    interpreter_path = "/usr/local/bin/python2",
+    python_version = "PY2",
+)
+
+py_runtime(
+    name = "macos_py3_runtime",
+    interpreter_path = "/usr/local/bin/python3",
+    python_version = "PY3",
+)
+
+py_runtime_pair(
+    name = "macos_py_runtime_pair",
+    py2_runtime = ":macos_py2_runtime",
+    py3_runtime = ":macos_py3_runtime",
+)
+
+toolchain(
+    name = "macos_python_toolchain",
+    exec_compatible_with = [
+        "@bazel_tools//platforms:osx",
+        "@bazel_tools//platforms:x86_64",
+    ],
+    target_compatible_with = [
+        "@bazel_tools//platforms:osx",
+        "@bazel_tools//platforms:x86_64",
+    ],
+    toolchain = ":macos_py_runtime_pair",
+    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
+)
+
+add_lint_tests()

--- a/tools/py_toolchain/bazel.rc
+++ b/tools/py_toolchain/bazel.rc
@@ -1,0 +1,4 @@
+build --host_force_python=PY2
+build --python_version=PY2
+build:python3 --host_force_python=PY3
+build:python3 --python_version=PY3

--- a/tools/ubuntu-bionic.bazelrc
+++ b/tools/ubuntu-bionic.bazelrc
@@ -1,9 +1,7 @@
 # Use Python 2 by default.
-build --python_path=/usr/bin/python2
 build --action_env=DRAKE_PYTHON_BIN_PATH=/usr/bin/python2
 
 # Explicit configuration for Python 3.
-build:python3 --python_path=/usr/bin/python3
 build:python3 --action_env=DRAKE_PYTHON_BIN_PATH=/usr/bin/python3
 
 # Configure ${PATH} for actions.

--- a/tools/ubuntu-xenial.bazelrc
+++ b/tools/ubuntu-xenial.bazelrc
@@ -1,9 +1,7 @@
 # Use Python 2 by default.
-build --python_path=/usr/bin/python2
 build --action_env=DRAKE_PYTHON_BIN_PATH=/usr/bin/python2
 
 # Explicit configuration for Python 3.
-build:python3 --python_path=/usr/bin/python3
 build:python3 --action_env=DRAKE_PYTHON_BIN_PATH=/usr/bin/python3
 
 # Configure ${PATH} for actions.


### PR DESCRIPTION
I think ultimately we can get rid of `DRAKE_PYTHON_BIN_PATH`, but since Drake is broken with Bazel 0.27, I can work on that later.

Downstream users are going to need to make some changes, of course, after this.

Closes #11380.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11660)
<!-- Reviewable:end -->