### PR TITLE
Set --incompatible_py3_is_default=false

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -3,6 +3,9 @@ import %workspace%/tools/cc_toolchain/bazel.rc
 import %workspace%/tools/dynamic_analysis/bazel.rc
 import %workspace%/tools/lint/bazel.rc
 
+# Continue to use Python 2 by default in Bazel 0.25 and above.
+build --incompatible_py3_is_default=false
+
 # Continue to obtain the python runtime from the --python_version flag rather
 # than a toolchain in Bazel 0.27 and above until #11660 is resolved.
 build --incompatible_use_python_toolchains=false


### PR DESCRIPTION
This was flipped in 0.25, but does not really cause any issues until 0.27. Ideally, we would just default to 3 in Drake too and resolve the death-match between Bazel and Drake that way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11665)
<!-- Reviewable:end -->
