### PR TITLE
primitives: Remove templates from RandomSource APIs

### DIFF
--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -112,6 +112,7 @@ drake_pybind_library(
         ":framework_py",
         ":module_py",
     ],
+    py_srcs = ["_primitives_extra.py"],
 )
 
 drake_pybind_library(
@@ -456,6 +457,7 @@ drake_py_unittest(
         ":primitives_py",
         ":test_util_py",
         "//bindings/pydrake:trajectories_py",
+        "//bindings/pydrake/common/test_utilities:deprecation_py",
     ],
 )
 

--- a/bindings/pydrake/systems/_primitives_extra.py
+++ b/bindings/pydrake/systems/_primitives_extra.py
@@ -1,0 +1,54 @@
+# See `ExecuteExtraPythonCode` in `pydrake_pybind.h` for usage details and
+# rationale.
+
+import warnings
+
+
+_DEPRECATION_MESSAGE = (
+    "Use primitives.RandomSource(RandomDistribution.kFoo, ...) instead of " +
+    "primitives.FooRandomSource. This class will be removed on 2019-10-01.")
+
+
+def UniformRandomSource(num_outputs, sampling_interval_sec):
+    """Deprecated constructor that desugars to
+    primitives.RandomSource(RandomDistribution.kUniform, **args, **kwargs).
+    This constructor will be removed on 2019-10-01."""
+    from pydrake.common import RandomDistribution
+    from pydrake.common.deprecation import DrakeDeprecationWarning
+    from pydrake.systems.primitives import RandomSource
+    warnings.warn(_DEPRECATION_MESSAGE, category=DrakeDeprecationWarning,
+                  stacklevel=2)
+    return RandomSource(
+            distribution=RandomDistribution.kUniform,
+            num_outputs=num_outputs,
+            sampling_interval_sec=sampling_interval_sec)
+
+
+def GaussianRandomSource(num_outputs, sampling_interval_sec):
+    """Deprecated constructor that desugars to
+    primitives.RandomSource(RandomDistribution.kGaussian, **args, **kwargs).
+    This constructor will be removed on 2019-10-01."""
+    from pydrake.common import RandomDistribution
+    from pydrake.common.deprecation import DrakeDeprecationWarning
+    from pydrake.systems.primitives import RandomSource
+    warnings.warn(_DEPRECATION_MESSAGE, category=DrakeDeprecationWarning,
+                  stacklevel=2)
+    return RandomSource(
+            distribution=RandomDistribution.kGaussian,
+            num_outputs=num_outputs,
+            sampling_interval_sec=sampling_interval_sec)
+
+
+def ExponentialRandomSource(num_outputs, sampling_interval_sec):
+    """Deprecated constructor that desugars to
+    primitives.RandomSource(RandomDistribution.kExponential, **args, **kwargs).
+    This constructor will be removed on 2019-10-01."""
+    from pydrake.common import RandomDistribution
+    from pydrake.common.deprecation import DrakeDeprecationWarning
+    from pydrake.systems.primitives import RandomSource
+    warnings.warn(_DEPRECATION_MESSAGE, category=DrakeDeprecationWarning,
+                  stacklevel=2)
+    return RandomSource(
+            distribution=RandomDistribution.kExponential,
+            num_outputs=num_outputs,
+            sampling_interval_sec=sampling_interval_sec)

--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -228,22 +228,11 @@ PYBIND11_MODULE(primitives, m) {
           &BarycentricMeshSystem<double>::get_output_values,
           doc.BarycentricMeshSystem.get_output_values.doc);
 
-  // Docs for typedef not being parsed.
-  py::class_<UniformRandomSource, LeafSystem<double>>(m, "UniformRandomSource")
-      .def(py::init<int, double>(), py::arg("num_outputs"),
-          py::arg("sampling_interval_sec"));
-
-  // Docs for typedef not being parsed.
-  py::class_<GaussianRandomSource, LeafSystem<double>>(
-      m, "GaussianRandomSource")
-      .def(py::init<int, double>(), py::arg("num_outputs"),
-          py::arg("sampling_interval_sec"));
-
-  // Docs for typedef not being parsed.
-  py::class_<ExponentialRandomSource, LeafSystem<double>>(
-      m, "ExponentialRandomSource")
-      .def(py::init<int, double>(), py::arg("num_outputs"),
-          py::arg("sampling_interval_sec"));
+  py::class_<RandomSource, LeafSystem<double>>(
+      m, "RandomSource", doc.RandomSource.doc)
+      .def(py::init<RandomDistribution, int, double>(), py::arg("distribution"),
+          py::arg("num_outputs"), py::arg("sampling_interval_sec"),
+          doc.RandomSource.ctor.doc);
 
   py::class_<TrajectorySource<double>, LeafSystem<double>>(
       m, "TrajectorySource", doc.TrajectorySource.doc)
@@ -289,6 +278,8 @@ PYBIND11_MODULE(primitives, m) {
       py_reference, doc.LogOutput.doc);
 
   // TODO(eric.cousineau): Add more systems as needed.
+
+  ExecuteExtraPythonCode(m);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/systems/test/primitives_test.py
+++ b/bindings/pydrake/systems/test/primitives_test.py
@@ -2,6 +2,8 @@ import unittest
 import numpy as np
 
 from pydrake.autodiffutils import AutoDiffXd
+from pydrake.common import RandomDistribution
+from pydrake.common.test_utilities.deprecation import catch_drake_warnings
 from pydrake.symbolic import Expression, Variable
 from pydrake.systems.analysis import Simulator
 from pydrake.systems.framework import (
@@ -36,6 +38,7 @@ from pydrake.systems.primitives import (
     Multiplexer, Multiplexer_,
     ObservabilityMatrix,
     PassThrough, PassThrough_,
+    RandomSource,
     Saturation, Saturation_,
     SignalLogger, SignalLogger_,
     Sine, Sine_,
@@ -362,23 +365,23 @@ class TestGeneral(unittest.TestCase):
                 value = output.get_vector_data(0)
                 self.assertTrue(isinstance(value, MyVector2))
 
-    def test_random_sources(self):
-        uniform_source = UniformRandomSource(num_outputs=2,
-                                             sampling_interval_sec=0.01)
-        self.assertEqual(uniform_source.get_output_port(0).size(), 2)
-
-        gaussian_source = GaussianRandomSource(num_outputs=3,
-                                               sampling_interval_sec=0.01)
-        self.assertEqual(gaussian_source.get_output_port(0).size(), 3)
-
-        exponential_source = ExponentialRandomSource(num_outputs=4,
-                                                     sampling_interval_sec=0.1)
-        self.assertEqual(exponential_source.get_output_port(0).size(), 4)
+    def test_random_source(self):
+        source = RandomSource(distribution=RandomDistribution.kUniform,
+                              num_outputs=2, sampling_interval_sec=0.01)
+        self.assertEqual(source.get_output_port(0).size(), 2)
 
         builder = DiagramBuilder()
         # Note: There are no random inputs to add to the empty diagram, but it
         # confirms the API works.
         AddRandomInputs(sampling_interval_sec=0.01, builder=builder)
+
+    def test_random_sources_deprecated(self):
+        with catch_drake_warnings(expected_count=1):
+            UniformRandomSource(num_outputs=2, sampling_interval_sec=0.01)
+        with catch_drake_warnings(expected_count=1):
+            GaussianRandomSource(num_outputs=3, sampling_interval_sec=0.01)
+        with catch_drake_warnings(expected_count=1):
+            ExponentialRandomSource(num_outputs=4, sampling_interval_sec=0.1)
 
     def test_ctor_api(self):
         """Tests construction of systems for systems whose executions semantics

--- a/systems/analysis/test/monte_carlo_test.cc
+++ b/systems/analysis/test/monte_carlo_test.cc
@@ -126,8 +126,8 @@ GTEST_TEST(RandomSimulationTest, WithRandomInputs) {
     DiagramBuilder<double> builder;
     const int kNumOutputs = 1;
     const double sampling_interval = 0.1;
-    auto random_source =
-        builder.AddSystem<UniformRandomSource>(kNumOutputs, sampling_interval);
+    auto random_source = builder.AddSystem<RandomSource>(
+        RandomDistribution::kUniform, kNumOutputs, sampling_interval);
     auto pass_through = builder.template AddSystem<PassThrough>(kNumOutputs);
     builder.Connect(random_source->get_output_port(0),
                     pass_through->get_input_port());

--- a/systems/primitives/random_source.cc
+++ b/systems/primitives/random_source.cc
@@ -1,21 +1,122 @@
 #include "drake/systems/primitives/random_source.h"
 
+#include <atomic>
+#include <random>
+
 #include "drake/common/never_destroyed.h"
 
 namespace drake {
 namespace systems {
+namespace {
 
-namespace internal {
-template<typename Generator>
-typename Generator::result_type generate_unique_seed() {
-  static never_destroyed<typename Generator::result_type> seed(
-      Generator::default_seed);
+using Seed = RandomSource::Seed;
+
+// Stores exactly one of the three supported distribution objects.  Note that
+// the distribution objects hold computational state; they are not just pure
+// mathematical functions.
+using DistributionVariant = variant<
+    std::uniform_real_distribution<double>,
+    std::normal_distribution<double>,
+    std::exponential_distribution<double>>;
+
+// Creates a distribution object from the distribution enumeration.
+DistributionVariant MakeDistributionVariant(RandomDistribution which) {
+  switch (which) {
+    case RandomDistribution::kUniform:
+      return std::uniform_real_distribution<double>();
+    case RandomDistribution::kGaussian:
+      return std::normal_distribution<double>();
+    case RandomDistribution::kExponential:
+      return std::exponential_distribution<double>();
+  }
+  DRAKE_UNREACHABLE();
+}
+
+// Generates real-valued (i.e., `double`) samples from some distribution.  This
+// serves as the abstract state of a RandomSource, which encompasses all of the
+// source's state *except* for the currently-sampled output values which are
+// stored as discrete state.
+class SampleGenerator {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SampleGenerator)
+
+  SampleGenerator() = default;
+  SampleGenerator(Seed seed, RandomDistribution which)
+      : generator_(seed), distribution_(MakeDistributionVariant(which)) {}
+
+  double GenerateNext() {
+    switch (distribution_.index()) {
+      case 0: return get<0>(distribution_)(generator_);
+      case 1: return get<1>(distribution_)(generator_);
+      case 2: return get<2>(distribution_)(generator_);
+    }
+    DRAKE_UNREACHABLE();
+  }
+
+ private:
+  RandomGenerator generator_;
+  DistributionVariant distribution_;
+};
+
+// Returns a monotonically increasing integer on each call.
+Seed get_next_seed() {
+  static never_destroyed<std::atomic<Seed>> seed(
+      RandomGenerator::default_seed);
   return seed.access()++;
 }
 
-template RandomGenerator::result_type generate_unique_seed<RandomGenerator>();
+}  // namespace
 
-}  // namespace internal
+RandomSource::RandomSource(
+    RandomDistribution distribution, int num_outputs,
+    double sampling_interval_sec)
+    : distribution_(distribution), seed_(get_next_seed()) {
+  this->DeclareDiscreteState(num_outputs);
+  this->DeclareAbstractState(Value<SampleGenerator>().Clone());
+  this->DeclarePeriodicUnrestrictedUpdateEvent(
+      sampling_interval_sec, 0., &RandomSource::UpdateSamples);
+  this->DeclareVectorOutputPort(
+      "output", BasicVector<double>(num_outputs),
+      [](const Context<double>& context, BasicVector<double>* output) {
+        const auto& values = context.get_discrete_state(0);
+        output->SetFrom(values);
+      });
+}
+
+RandomSource::~RandomSource() {}
+
+void RandomSource::SetDefaultState(
+    const Context<double>& context, State<double>* state) const {
+  SetSeed(seed_, context, state);
+}
+
+void RandomSource::SetRandomState(
+    const Context<double>& context, State<double>* state,
+    RandomGenerator* seed_generator) const {
+  const Seed fresh_seed = (*seed_generator)();
+  SetSeed(fresh_seed, context, state);
+}
+
+// Writes the given seed into abstract state (replacing the existing
+// SampleGenerator) and then does `UpdateSamples`.
+void RandomSource::SetSeed(
+    Seed seed, const Context<double>& context, State<double>* state) const {
+  state->template get_mutable_abstract_state<SampleGenerator>(0) =
+      SampleGenerator(seed, distribution_);
+  UpdateSamples(context, state);
+}
+
+// Samples random values into the discrete state, using the SampleGenerator
+// from the abstract state.  (Note that the generator's abstract state is also
+// mutated as a side effect of this method.)
+void RandomSource::UpdateSamples(
+    const Context<double>&, State<double>* state) const {
+  auto& source = state->template get_mutable_abstract_state<SampleGenerator>(0);
+  auto& samples = state->get_mutable_discrete_state(0);
+  for (int i = 0; i < samples.size(); ++i) {
+    samples[i] = source.GenerateNext();
+  }
+}
 
 int AddRandomInputs(double sampling_interval_sec,
                     DiagramBuilder<double>* builder) {
@@ -24,14 +125,13 @@ int AddRandomInputs(double sampling_interval_sec,
   // there is (currently) no builder->GetSystems() method.
   for (const auto* system : builder->GetMutableSystems()) {
     for (int i = 0; i < system->num_input_ports(); i++) {
-      const systems::InputPort<double>& port =
-          system->get_input_port(i);
+      const systems::InputPort<double>& port = system->get_input_port(i);
       // Check for the random label.
       if (!port.is_random()) {
         continue;
       }
 
-      typedef typename Diagram<double>::InputPortLocator InputPortLocator;
+      using InputPortLocator = Diagram<double>::InputPortLocator;
       // Check if the input is already wired up.
       InputPortLocator id{&port.get_system(), port.get_index()};
       if (builder->connection_map_.count(id) > 0 ||
@@ -39,28 +139,10 @@ int AddRandomInputs(double sampling_interval_sec,
         continue;
       }
 
-      count++;
-      switch (port.get_random_type().value()) {
-        case RandomDistribution::kUniform: {
-          const auto* uniform = builder->AddSystem<UniformRandomSource>(
-              port.size(), sampling_interval_sec);
-          builder->Connect(uniform->get_output_port(0), port);
-          continue;
-        }
-        case RandomDistribution::kGaussian: {
-          const auto* gaussian = builder->AddSystem<GaussianRandomSource>(
-              port.size(), sampling_interval_sec);
-          builder->Connect(gaussian->get_output_port(0), port);
-          continue;
-        }
-        case RandomDistribution::kExponential: {
-          const auto* exponential = builder->AddSystem<ExponentialRandomSource>(
-              port.size(), sampling_interval_sec);
-          builder->Connect(exponential->get_output_port(0), port);
-          continue;
-        }
-      }
-      DRAKE_UNREACHABLE();
+      const auto* const source = builder->AddSystem<RandomSource>(
+          port.get_random_type().value(), port.size(), sampling_interval_sec);
+      builder->Connect(source->get_output_port(0), port);
+      ++count;
     }
   }
   return count;
@@ -68,4 +150,3 @@ int AddRandomInputs(double sampling_interval_sec,
 
 }  // namespace systems
 }  // namespace drake
-

--- a/systems/primitives/random_source.h
+++ b/systems/primitives/random_source.h
@@ -1,42 +1,14 @@
 #pragma once
 
-#include <memory>
-#include <random>
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/random.h"
-#include "drake/common/unused.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/framework/leaf_system.h"
 
 namespace drake {
 namespace systems {
-
-namespace internal {
-
-template <typename Generator = RandomGenerator>
-typename Generator::result_type generate_unique_seed();
-
-/// State for a given random distribution and generator. This owns both the
-/// distribution and the generator.
-template <typename Distribution, typename Generator = RandomGenerator>
-class RandomState {
- public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(RandomState)
-
-  typedef typename Generator::result_type Seed;
-
-  explicit RandomState(Seed seed) : generator_(seed) {}
-
-  /// Generate the next random value with the given distribution.
-  double GetNextValue() { return distribution_(generator_); }
-
- private:
-  // TODO(russt): Obtain consistent results across multiple platforms (#4361).
-  Generator generator_;
-  Distribution distribution_;
-};
 
 /// A source block which generates random numbers at a fixed sampling interval,
 /// with a zero-order hold between samples.  For continuous-time systems, this
@@ -44,121 +16,48 @@ class RandomState {
 /// (with a power-spectral density of the form Ts * sinc^2( omega * Ts ), where
 /// Ts is the sampling interval.
 ///
-/// @tparam Distribution A class modeling the c++ RandomNumberDistribution
-/// concept.
-///   http://en.cppreference.com/w/cpp/concept/RandomNumberDistribution
-///
-/// @note User code should not instantiate this class directly, but
-/// should use systems::UniformRandomSource, systems::GaussianRandomSource, and
-/// systems::ExponentialRandomSource systems instead.
+/// @system{RandomSource,,@output_port{output}}
 ///
 /// @note This system is only defined for the double scalar type.
+///
+/// @note The exact distribution results may vary across multiple platforms or
+/// revisions of Drake, but will be consistent for all compilations on a given
+/// platform and Drake revision.
 ///
 /// @note The hard-coding of (default) distribution parameters is imposed
 /// intentionally to simplify analysis (by forcing systems taking noise inputs
 /// to implement the shifting/scaling, the system itself contains all of the
 /// necessary information for stochastic analysis).
 ///
-/// @see @ref stochastic_systems, UniformRandomSource, GaussianRandomSource,
-/// ExponentialRandomSource.
+/// @see @ref stochastic_systems
 ///
 /// @ingroup primitive_systems
-template <typename Distribution, typename Generator = RandomGenerator>
-class RandomSource final : public LeafSystem<double> {
+class RandomSource : public LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RandomSource)
 
-  typedef internal::RandomState<Distribution, Generator> RandomState;
-  typedef typename RandomState::Seed Seed;
+  /// An integer type for a random seed.
+  using Seed = RandomGenerator::result_type;
 
   /// Constructs the RandomSource system.
+  /// @param distribution The RandomDistribution used for each of the outputs.
   /// @param num_outputs The dimension of the (single) vector output port.
   /// @param sampling_interval_sec The sampling interval in seconds.
-  RandomSource(int num_outputs, double sampling_interval_sec)
-      : seed_(generate_unique_seed()) {
-    this->DeclarePeriodicUnrestrictedUpdate(sampling_interval_sec, 0.);
-    this->DeclareVectorOutputPort(BasicVector<double>(num_outputs),
-                                  &RandomSource::CopyStateToOutput);
-    this->DeclareDiscreteState(num_outputs);
-    this->DeclareAbstractState(AbstractValue::Make(RandomState(seed_)));
-  }
+  RandomSource(RandomDistribution distribution, int num_outputs,
+               double sampling_interval_sec);
+
+  ~RandomSource() override;
 
  private:
-  // Computes a random number and stores it in the discrete state.
-  void DoCalcUnrestrictedUpdate(
-      const Context<double>&,
-      const std::vector<const UnrestrictedUpdateEvent<double>*>&,
-      State<double>* state) const final {
-    auto& random_state =
-        state->template get_mutable_abstract_state<RandomState>(0);
-    auto& updates = state->get_mutable_discrete_state();
-    for (int i = 0; i < updates.size(); i++) {
-      updates[i] = random_state.GetNextValue();
-    }
-  }
+  void SetDefaultState(const Context<double>&, State<double>*) const final;
+  void SetRandomState(const Context<double>&, State<double>*,
+                      RandomGenerator*) const final;
+  void SetSeed(Seed, const Context<double>&, State<double>*) const;
+  void UpdateSamples(const Context<double>&, State<double>*) const;
 
-  std::unique_ptr<AbstractValues> AllocateAbstractState() const final {
-    return std::make_unique<AbstractValues>(
-        AbstractValue::Make(RandomState(seed_)));
-  }
-
-  void SetDefaultState(const Context<double>& context,
-                       State<double>* state) const final {
-    unused(context);
-    auto& random_state =
-        state->template get_mutable_abstract_state<RandomState>(0);
-    random_state = RandomState(seed_);
-    auto& values = state->get_mutable_discrete_state();
-    for (int i = 0; i < values.size(); i++) {
-      values[i] = random_state.GetNextValue();
-    }
-  }
-
-  void SetRandomState(const Context<double>& context, State<double>* state,
-                      RandomGenerator* generator) const final {
-    unused(context);
-    auto& random_state =
-        state->template get_mutable_abstract_state<RandomState>(0);
-    random_state = RandomState((*generator)());
-    auto& values = state->get_mutable_discrete_state();
-    for (int i = 0; i < values.size(); i++) {
-      values[i] = random_state.GetNextValue();
-    }
-  }
-
-  // Output is the zero-order hold of the discrete state.
-  void CopyStateToOutput(const Context<double>& context,
-                         BasicVector<double>* output) const {
-    output->SetFromVector(context.get_discrete_state(0).CopyToVector());
-  }
-
+  const RandomDistribution distribution_;
   const Seed seed_;
 };
-
-}  // namespace internal
-
-/// Generates uniformly distributed random numbers in the interval [0.0, 1.0).
-///
-/// @see internal::RandomSource
-/// @ingroup primitive_systems
-typedef internal::RandomSource<std::uniform_real_distribution<double>>
-    UniformRandomSource;
-
-/// Generates normally distributed random numbers with mean zero and unit
-/// covariance.
-///
-/// @see internal::RandomSource
-/// @ingroup primitive_systems
-typedef internal::RandomSource<std::normal_distribution<double>>
-    GaussianRandomSource;
-
-/// Generates exponentially distributed random numbers with mean, standard
-/// deviation, and scale parameter (aka 1/λ) set to one.
-///
-/// @see internal::RandomSource
-/// @ingroup primitive_systems
-typedef internal::RandomSource<std::exponential_distribution<double>>
-    ExponentialRandomSource;
 
 /// For each subsystem input port in @p builder that is (a) not yet connected
 /// and (b) labeled as random in the InputPort, this method will add a
@@ -171,6 +70,45 @@ typedef internal::RandomSource<std::exponential_distribution<double>>
 /// @see @ref stochastic_systems
 int AddRandomInputs(double sampling_interval_sec,
                     DiagramBuilder<double>* builder);
+
+namespace internal {
+// TODO(jwnimmer-tri) Once this class disappears, update RandomSource to be
+// declared final.
+/// (Deprecated.) A RandomSource with a compile-time RandomDistribution.
+template <RandomDistribution distribution>
+class RandomSourceWithDistribution final : public RandomSource {
+ public:
+  RandomSourceWithDistribution(int num_outputs, double sampling_interval_sec)
+      : RandomSource(distribution, num_outputs, sampling_interval_sec) {}
+};
+}  // namespace internal
+
+/// (Deprecated.) Generates uniformly distributed random numbers in the
+/// interval [0.0, 1.0).
+/// @see RandomSource
+using UniformRandomSource
+    DRAKE_DEPRECATED("2019-10-01",
+        "Use primitives::RandomSource(kUniform, ...) instead of "
+        "primitives::UniformRandomSource.")
+    = internal::RandomSourceWithDistribution<RandomDistribution::kUniform>;
+
+/// (Deprecated.) Generates normally distributed random numbers with mean zero
+/// and unit covariance.
+/// @see RandomSource
+using GaussianRandomSource
+    DRAKE_DEPRECATED("2019-10-01",
+        "Use primitives::RandomSource(kGaussian, ...) instead of "
+        "primitives::GaussianRandomSource.")
+    = internal::RandomSourceWithDistribution<RandomDistribution::kGaussian>;
+
+/// (Deprecated.) Generates exponentially distributed random numbers with mean,
+/// standard deviation, and scale parameter (aka 1/λ) set to one.
+/// @see RandomSource
+using ExponentialRandomSource
+    DRAKE_DEPRECATED("2019-10-01",
+        "Use primitives::RandomSource(kExponential, ...) instead of "
+        "primitives::ExponentialRandomSource.")
+    = internal::RandomSourceWithDistribution<RandomDistribution::kExponential>;
 
 }  // namespace systems
 }  // namespace drake

--- a/systems/sensors/test/beam_model_test.cc
+++ b/systems/sensors/test/beam_model_test.cc
@@ -55,19 +55,23 @@ GTEST_TEST(BeamModelTest, TestProbabilityDensity) {
   builder.Connect(constant_depth->get_output_port(),
                   beam_model->get_depth_input_port());
 
-  auto w_event = builder.AddSystem<UniformRandomSource>(1, 0.0025);
+  auto w_event = builder.AddSystem<RandomSource>(
+      RandomDistribution::kUniform, 1, 0.0025);
   builder.Connect(w_event->get_output_port(0),
                   beam_model->get_event_random_input_port());
 
-  auto w_hit = builder.AddSystem<GaussianRandomSource>(1, 0.0025);
+  auto w_hit = builder.AddSystem<RandomSource>(
+      RandomDistribution::kGaussian, 1, 0.0025);
   builder.Connect(w_hit->get_output_port(0),
                   beam_model->get_hit_random_input_port());
 
-  auto w_short = builder.AddSystem<ExponentialRandomSource>(1, 0.0025);
+  auto w_short = builder.AddSystem<RandomSource>(
+      RandomDistribution::kExponential, 1, 0.0025);
   builder.Connect(w_short->get_output_port(0),
                   beam_model->get_short_random_input_port());
 
-  auto w_uniform = builder.AddSystem<UniformRandomSource>(1, 0.0025);
+  auto w_uniform = builder.AddSystem<RandomSource>(
+      RandomDistribution::kUniform, 1, 0.0025);
   builder.Connect(w_uniform->get_output_port(0),
                   beam_model->get_uniform_random_input_port());
 


### PR DESCRIPTION
Templates are stupid and make compilation times long and error messages bad.

This also might make it easier to extract the state of a RandomSource (#11676).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11670)
<!-- Reviewable:end -->
