### PR TITLE
 Deprecate CalcPointsAnalyticalJacobianExpressedInWorld() due to CalcJacobianTranslationalVelocity().

### DIFF
--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1734,10 +1734,13 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // TODO(amcastro-tri): provide the Jacobian-times-vector operation, since for
   // most applications it is all we need and it is more efficient to compute.
   // TODO(amcastro-tri): Rework this method as per issue #10155.
+  DRAKE_DEPRECATED("2019-10-01", "Use CalcJacobianTranslationalVelocity().")
   void CalcPointsAnalyticalJacobianExpressedInWorld(
       const systems::Context<T>& context,
-      const Frame<T>& frame_F, const Eigen::Ref<const MatrixX<T>>& p_FP_list,
-      EigenPtr<MatrixX<T>> p_WP_list, EigenPtr<MatrixX<T>> Jq_WFp) const {
+      const Frame<T>& frame_F,
+      const Eigen::Ref<const MatrixX<T>>& p_FP_list,
+      EigenPtr<MatrixX<T>> p_WP_list,
+      EigenPtr<MatrixX<T>> Jq_WFp) const {
     internal_tree().CalcPointsAnalyticalJacobianExpressedInWorld(
         context, frame_F, p_FP_list, p_WP_list, Jq_WFp);
   }

--- a/multibody/plant/test/kuka_iiwa_model_tests.h
+++ b/multibody/plant/test/kuka_iiwa_model_tests.h
@@ -132,19 +132,31 @@ class KukaIiwaModelTests : public ::testing::Test {
   // the end effector frame E, given their (fixed) position p_EPi in the end
   // effector frame.
   // This templated helper method allows us to use automatic differentiation.
-  // See MultibodyTree::CalcPointsAnalyticalJacobianExpressedInWorld() for
-  // details.
+  // See MultibodyTree::CalcJacobianTranslationalVelocity() for details.
   // TODO(amcastro-tri): Rename this method as per issue #10155.
+  // TODO(Mitiguy): If this method is not used, delete it per issue #10155.
   template <typename T>
+  DRAKE_DEPRECATED("2019-10-01", "Use CalcJacobianSpatialVelocity().")
   void CalcPointsOnEndEffectorAnalyticJacobian(
       const MultibodyPlant<T>& plant_on_T,
       const Context<T>& context_on_T,
-      const MatrixX<T>& p_EPi,
-      MatrixX<T>* p_WPi, MatrixX<T>* Jq_WPi) const {
-    const Body<T>& linkG_on_T =
-        plant_on_T.get_body(end_effector_link_->index());
-    plant_on_T.CalcPointsAnalyticalJacobianExpressedInWorld(
-        context_on_T, linkG_on_T.body_frame(), p_EPi, p_WPi, Jq_WPi);
+      const MatrixX<T>& p_EoEi_E,
+      MatrixX<T>* p_WoEi_W,
+      MatrixX<T>* Jq_v_WEi_W) const {
+    const Frame<T>& frame_W = plant_on_T.world_frame();
+    const Frame<T>& frame_E =  /* End-effector frame E */
+        (plant_on_T.get_body(end_effector_link_->index())).body_frame();
+
+    plant_on_T.CalcJacobianTranslationalVelocity(context_on_T,
+                                                 JacobianWrtVariable::kQDot,
+                                                 frame_E,
+                                                 p_EoEi_E,
+                                                 frame_W,
+                                                 frame_W,
+                                                 Jq_v_WEi_W);
+    plant_on_T.CalcPointsPositions(context_on_T,
+                                   frame_E, p_EoEi_E,     /* From frame E */
+                                   frame_W, p_WoEi_W);   /* To world frame W */
   }
 
  protected:

--- a/multibody/plant/test/multibody_plant_jacobians_test.cc
+++ b/multibody/plant/test/multibody_plant_jacobians_test.cc
@@ -34,7 +34,10 @@ TEST_F(KukaIiwaModelTests, FixtureInvariants) {
   EXPECT_EQ(plant_->num_velocities(), kNumVelocities);
 }
 
-// TODO(amcastro-tri): Rename this test as per issue #10155.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+// TODO(Mitiguy) Delete this test per issue #10155.
+// DRAKE_DEPRECATED("2019-09-01", "Use CalcJacobianTranslationalVelocity().")
 TEST_F(KukaIiwaModelTests, CalcPointsAnalyticalJacobianExpressedInWorld) {
   // Numerical tolerance used to verify numerical results.
   const double kTolerance = 10 * std::numeric_limits<double>::epsilon();
@@ -50,8 +53,9 @@ TEST_F(KukaIiwaModelTests, CalcPointsAnalyticalJacobianExpressedInWorld) {
   MatrixX<double> p_WPi(3, kNumPoints);
   MatrixX<double> Jq_WPi(3 * kNumPoints, plant_->num_positions());
 
-  CalcPointsOnEndEffectorAnalyticJacobian(
-      *plant_, *context_, p_EPi, &p_WPi, &Jq_WPi);
+  const Frame<double>& frame_E = end_effector_link_->body_frame();
+  plant_->CalcPointsAnalyticalJacobianExpressedInWorld(
+    *context_, frame_E, p_EPi, &p_WPi, &Jq_WPi);
 
   // Alternatively, compute the analytic Jacobian by taking the gradient of
   // the positions p_WPi(q) with respect to the generalized positions. We do
@@ -66,11 +70,14 @@ TEST_F(KukaIiwaModelTests, CalcPointsAnalyticalJacobianExpressedInWorld) {
 
   const MatrixX<AutoDiffXd> p_EPi_autodiff = p_EPi;
   MatrixX<AutoDiffXd> p_WPi_autodiff(3, kNumPoints);
-  MatrixX<AutoDiffXd> Jq_WPi_autodiff(3 * kNumPoints, plant_->num_positions());
 
-  CalcPointsOnEndEffectorAnalyticJacobian(
-      *plant_autodiff_, *context_autodiff_,
-      p_EPi_autodiff, &p_WPi_autodiff, &Jq_WPi_autodiff);
+  // Get position of Pi from Wo (world origin), expressed in W (world).
+  const Frame<AutoDiffXd>& frame_W_autodiff = plant_autodiff_->world_frame();
+  const Frame<AutoDiffXd>& frame_E_autodiff =
+      (plant_autodiff_->get_body(end_effector_link_->index())).body_frame();
+  plant_autodiff_->CalcPointsPositions(*context_autodiff_,
+                   frame_E_autodiff, p_EPi_autodiff,      /* From frame E */
+                   frame_W_autodiff, &p_WPi_autodiff);  /* To world frame W */
 
   // Extract values and derivatives:
   const Matrix3X<double> p_WPi_value =
@@ -92,64 +99,68 @@ TEST_F(KukaIiwaModelTests, CalcPointsAnalyticalJacobianExpressedInWorld) {
   EXPECT_TRUE(CompareMatrices(Jq_WPi, p_WPi_derivs,
                               kTolerance, MatrixCompareType::relative));
 }
+#pragma GCC diagnostic pop
 
-// This unit test verifies the computation of a Jacobian with respect to qdot
-// when the context stores a non-unit quaternion.
-TEST_F(KukaIiwaModelTests, CalcPointsAnalyticalJacobianFromNonUnitQuaternion) {
-  // Numerical tolerance used to verify numerical results.
-  const double kTolerance = 10 * std::numeric_limits<double>::epsilon();
-
+// This unit test verifies the calculation of a set of points' translational
+// Jacobian with respect to q̇ when the context stores a non-unit quaternion.
+TEST_F(KukaIiwaModelTests, CalcJacobianTranslationalVelocityNonUnitQuaternion) {
   SetArbitraryConfiguration(false /* non-unit quaternion for floating base */);
 
-  // A set of points Pi fixed in the end effector frame E.
+  // A set of points Ei fixed in the end effector frame E.
   const int kNumPoints = 2;  // The set stores 2 points.
-  MatrixX<double> p_EPi(3, kNumPoints);
-  p_EPi.col(0) << 0.1, -0.05, 0.02;
-  p_EPi.col(1) << 0.2, 0.3, -0.15;
+  MatrixX<double> p_EoEi_E(3, kNumPoints);
+  p_EoEi_E.col(0) << 0.1, -0.05, 0.02;
+  p_EoEi_E.col(1) << 0.2, 0.3, -0.15;
 
-  MatrixX<double> p_WPi(3, kNumPoints);
-  MatrixX<double> Jq_WPi(3 * kNumPoints, plant_->num_positions());
+  const int num_positions = plant_->num_positions();
+  MatrixX<double> p_WoEi_W(3, kNumPoints);
+  MatrixX<double> Jq_v_WEi_W(3 * kNumPoints, num_positions);
 
-  CalcPointsOnEndEffectorAnalyticJacobian(
-      *plant_, *context_, p_EPi, &p_WPi, &Jq_WPi);
+  const Frame<double>& frame_W = plant_->world_frame();
+  const Frame<double>& frame_E = end_effector_link_->body_frame();
+  plant_->CalcJacobianTranslationalVelocity(*context_,
+                                            JacobianWrtVariable::kQDot,
+                                            frame_E,
+                                            p_EoEi_E,
+                                            frame_W,
+                                            frame_W,
+                                            &Jq_v_WEi_W);
 
   // Alternatively, compute the analytic Jacobian by taking the gradient of
-  // the positions p_WPi(q) with respect to the generalized positions. We do
+  // the positions p_WoEi_W(q) with respect to the generalized positions. We do
   // that with the steps below.
 
   // Initialize q to have values qvalue and so that it is the independent
   // variable of the problem.
-  VectorX<AutoDiffXd> q_autodiff(plant_->num_positions());
+  VectorX<AutoDiffXd> q_autodiff(num_positions);
   auto q_double = plant_->GetPositions(*context_);
   math::initializeAutoDiff(q_double, q_autodiff);
   plant_autodiff_->GetMutablePositions(context_autodiff_.get()) = q_autodiff;
 
-  const MatrixX<AutoDiffXd> p_EPi_autodiff = p_EPi;
-  MatrixX<AutoDiffXd> p_WPi_autodiff(3, kNumPoints);
-  MatrixX<AutoDiffXd> Jq_WPi_autodiff(3 * kNumPoints, plant_->num_positions());
+  const MatrixX<AutoDiffXd> p_EoEi_E_autodiff = p_EoEi_E;
+  MatrixX<AutoDiffXd> p_WoEi_W_autodiff(3, kNumPoints);
 
-  CalcPointsOnEndEffectorAnalyticJacobian(
-      *plant_autodiff_, *context_autodiff_,
-      p_EPi_autodiff, &p_WPi_autodiff, &Jq_WPi_autodiff);
+  // Get position of Pi from Wo (world origin), expressed in W (world).
+  const Frame<AutoDiffXd>& frame_W_autodiff = plant_autodiff_->world_frame();
+  const Frame<AutoDiffXd>& frame_E_autodiff =
+      (plant_autodiff_->get_body(end_effector_link_->index())).body_frame();
+  plant_autodiff_->CalcPointsPositions(*context_autodiff_,
+      frame_E_autodiff, p_EoEi_E_autodiff,       /* From frame E */
+      frame_W_autodiff, &p_WoEi_W_autodiff);  /* To world frame W */
 
   // Extract values and derivatives:
-  const Matrix3X<double> p_WPi_value =
-      math::autoDiffToValueMatrix(p_WPi_autodiff);
-  const MatrixX<double> p_WPi_derivs =
-      math::autoDiffToGradientMatrix(p_WPi_autodiff);
+  const Matrix3X<double> p_WoEi_W_value =
+      math::autoDiffToValueMatrix(p_WoEi_W_autodiff);
+  const MatrixX<double> p_WoEi_W_deriv_wrt_q =
+      math::autoDiffToGradientMatrix(p_WoEi_W_autodiff);
 
-  // Some sanity checks:
-  // Values obtained with <AutoDiffXd> should match those computed with
-  // <double>.
-  EXPECT_TRUE(CompareMatrices(p_WPi_value, p_WPi,
-                              kTolerance, MatrixCompareType::relative));
-  // Sizes of the derivatives.
-  EXPECT_EQ(p_WPi_derivs.rows(), 3 * kNumPoints);
-  EXPECT_EQ(p_WPi_derivs.cols(), plant_->num_positions());
+  // Ensure proper sizes for the matrix storing the partial derivatives.
+  EXPECT_EQ(p_WoEi_W_deriv_wrt_q.rows(), 3 * kNumPoints);
+  EXPECT_EQ(p_WoEi_W_deriv_wrt_q.cols(), num_positions);
 
-  // Verify the computed Jacobian Jq_WPi matches the one obtained using
-  // automatic differentiation.
-  EXPECT_TRUE(CompareMatrices(Jq_WPi, p_WPi_derivs,
+  // Verify the Jacobian Jq_v_WEi_W matches the one from auto-differentiation.
+  const double kTolerance = 8 * std::numeric_limits<double>::epsilon();
+  EXPECT_TRUE(CompareMatrices(Jq_v_WEi_W, p_WoEi_W_deriv_wrt_q,
                               kTolerance, MatrixCompareType::relative));
 }
 
@@ -255,6 +266,77 @@ TEST_F(KukaIiwaModelTests, CalcJacobianSpatialVelocity) {
   bottom_three_rows = Jq_V_WEp.template bottomRows<3>();
   EXPECT_TRUE(CompareMatrices(Jq_v_WEp, bottom_three_rows, kTolerance,
                               MatrixCompareType::relative));
+}
+
+TEST_F(KukaIiwaModelTests, CalcJacobianTranslationalVelocityB) {
+  // Form two position vectors, one for each point Ei (i = 1, 2).
+  // Each point is regarded as fixed/welded to the end effector frame E.
+  const int kNumPoints = 2;
+  Matrix3X<double> p_EoEi_E(3, kNumPoints);
+  p_EoEi_E.col(0) << 0.1, -0.05, 0.02;  // Position from Eo to first point.
+  p_EoEi_E.col(1) << 0.2, 0.3, -0.15;   // Position from Eo to second point.
+
+  // Make space for stacked Jacobians with respect to generalized coordinates.
+  // Jq_v_WEi_W stores points Ei's translational velocity Jacobian in W (world).
+  const int num_positions = plant_->num_positions();
+  MatrixX<double> Jq_v_WEi_W(3 * kNumPoints, num_positions);
+
+  // Set arbitrary joint angles.
+  SetArbitraryConfiguration();
+
+  // Calculate the 6xn matrix Jq_v_WEi_W that stores each of the two points Ei's
+  // translational velocity Jacobian in world W, with respect to q̇.
+  const Frame<double>& frame_E = end_effector_link_->body_frame();
+  const Frame<double>& frame_W = plant_->world_frame();
+  plant_->CalcJacobianTranslationalVelocity(*context_,
+                                            JacobianWrtVariable::kQDot,
+                                            frame_E,
+                                            p_EoEi_E,
+                                            frame_W,
+                                            frame_W,
+                                            &Jq_v_WEi_W);
+
+  // Since p_WoEi_W, Ei's position vector from Wo (world origin) expressed in
+  // W (world frame), is a function of generalized coordinates/positions q,
+  // an alternate calculation of Ei's translational velocity Jacobian in world W
+  // with respect to q̇ is by calculating the partial derivatives of p_WoEi_W
+  // with respect to q (generalized coordinates/positions).
+
+  // Initialize an array of variables q for subsequent partial differentiation
+  // and set q's values to match this system's generalized coordinate values.
+  VectorX<AutoDiffXd> q_autodiff(num_positions);
+  const VectorX<double> q_double = plant_->GetPositions(*context_);
+  math::initializeAutoDiff(q_double, q_autodiff);
+  plant_autodiff_->GetMutablePositions(context_autodiff_.get()) = q_autodiff;
+
+  // Reserve space and then for each point Ei, calculate Ei's position from
+  // Wo (World origin), expressed in world W.
+  const MatrixX<AutoDiffXd> p_EoEi_E_autodiff = p_EoEi_E;
+  Matrix3X<AutoDiffXd> p_WoEi_W_autodiff(3, kNumPoints);
+
+  // Create shortcuts to end-effector link frame E and world frame W.
+  const Body<AutoDiffXd>& end_effector_autodiff =
+      plant_autodiff_->get_body(end_effector_link_->index());
+  const Frame<AutoDiffXd>& frame_E_autodiff =
+      end_effector_autodiff.body_frame();
+  const Frame<AutoDiffXd>& frame_W_autodiff = plant_autodiff_->world_frame();
+  plant_autodiff_->CalcPointsPositions(*context_autodiff_,
+                     frame_E_autodiff, p_EoEi_E_autodiff,    /* From frame E */
+                     frame_W_autodiff, &p_WoEi_W_autodiff);    /* To frame W */
+
+  // Form the partial derivatives of p_WoEi_W with respect to q,
+  // evaluated at q's values.
+  const MatrixX<double> p_WoEi_W_deriv_wrt_q =
+      math::autoDiffToGradientMatrix(p_WoEi_W_autodiff);
+
+  // Ensure proper sizes for the matrix storing the partial derivatives.
+  EXPECT_EQ(p_WoEi_W_deriv_wrt_q.rows(), 3 * kNumPoints);
+  EXPECT_EQ(p_WoEi_W_deriv_wrt_q.cols(), num_positions);
+
+  // Verify the Jacobian Jq_v_WEi_W matches the one from auto-differentiation.
+  const double kTolerance = 8 * std::numeric_limits<double>::epsilon();
+  EXPECT_TRUE(CompareMatrices(Jq_v_WEi_W, p_WoEi_W_deriv_wrt_q,
+                              kTolerance, MatrixCompareType::relative));
 }
 
 }  // namespace

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -1268,8 +1268,10 @@ class MultibodyTree {
   /// See MultibodyPlant method.
   void CalcPointsAnalyticalJacobianExpressedInWorld(
       const systems::Context<T>& context,
-      const Frame<T>& frame_F, const Eigen::Ref<const MatrixX<T>>& p_FP_list,
-      EigenPtr<MatrixX<T>> p_WP_list, EigenPtr<MatrixX<T>> Jq_WFp) const;
+      const Frame<T>& frame_F,
+      const Eigen::Ref<const MatrixX<T>>& p_FP_list,
+      EigenPtr<MatrixX<T>> p_WP_list,
+      EigenPtr<MatrixX<T>> Jq_WFp) const;
 
   /// See MultibodyPlant method.
   void CalcFrameGeometricJacobianExpressedInWorld(


### PR DESCRIPTION
Deprecate CalcPointsAnalyticalJacobianExpressedInWorld() due to CalcJacobianTranslationalVelocity().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11671)
<!-- Reviewable:end -->
