### PR TITLE
primitives: Add get/set seed support to RandomSource 

### DIFF
--- a/systems/primitives/random_source.h
+++ b/systems/primitives/random_source.h
@@ -3,6 +3,7 @@
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_optional.h"
 #include "drake/common/random.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/framework/leaf_system.h"
@@ -17,6 +18,38 @@ namespace systems {
 /// Ts is the sampling interval.
 ///
 /// @system{RandomSource,,@output_port{output}}
+///
+/// This system exposes a parameter named `seed` for the pseudo-random number
+/// generator that determines the noise output.  The `seed` parameter behaves
+/// as follows:
+///
+/// 1. Each newly-created RandomSource chooses a new `per_instance_seed` member
+/// field value for itself.  The value will be unique within the current
+/// executable process.
+///
+/// 2. By default, `source.CreateDefaultContext()` will set the returned
+/// context's `seed` parameter to `per_instance_seed`.  Therefore, for a given
+/// instance of this system, the parameters, state, and outputs will be
+/// identical for all simulations that start from a default context.
+///
+/// 3. By default, `source.SetRandomContext()` will choose a new, arbitrary
+/// value for the context's `seed` parameter, which means that the system's
+/// parameters, state, and outputs will (almost certainly) differ from their
+/// defaults.
+///
+/// 4. The user may call `source.set_fixed_seed(new_seed)` on this system.
+/// When a `new_seed` value is provided, it is used by both
+/// `CreateDefaultContext` and `SetRandomContext`.  Therefore, the system's
+/// parameters, state, and outputs will be identical to any other instances
+/// that share the same `new_seed` value for their `seed` context parameter.
+/// Note that `set_fixed_seed` affects subsequently-created contexts; any
+/// pre-existing contexts are unaffected.  The user may call
+/// `source.set_fixed_seed(nullopt)` to revert to the default the behaviors
+/// described in #2 and #3 again.
+///
+/// 5. The context returned by `source.AllocateContext()` does not contain a
+/// valid `seed` parameter; that context should not be used until its values
+/// are populated via another Context.
 ///
 /// @note This system is only defined for the double scalar type.
 ///
@@ -48,6 +81,20 @@ class RandomSource : public LeafSystem<double> {
 
   ~RandomSource() override;
 
+  /// Returns the `distribution` given at construction.
+  RandomDistribution get_distribution() const { return distribution_; }
+
+  /// Returns the value of the `seed` parameter in the given context.
+  Seed get_seed(const Context<double>& context) const;
+
+  /// Gets this system's fixed random seed (or else nullopt when the seed is
+  /// not fixed).  Refer to the class overview documentation for details.
+  optional<Seed> get_fixed_seed() const { return fixed_seed_; }
+
+  /// Sets (or clears) this system's fixed random seed.  Refer to the class
+  /// overview documentation for details.
+  void set_fixed_seed(const optional<Seed>& seed) { fixed_seed_ = seed; }
+
  private:
   void SetDefaultState(const Context<double>&, State<double>*) const final;
   void SetRandomState(const Context<double>&, State<double>*,
@@ -56,7 +103,8 @@ class RandomSource : public LeafSystem<double> {
   void UpdateSamples(const Context<double>&, State<double>*) const;
 
   const RandomDistribution distribution_;
-  const Seed seed_;
+  const Seed instance_seed_;
+  optional<Seed> fixed_seed_;
 };
 
 /// For each subsystem input port in @p builder that is (a) not yet connected


### PR DESCRIPTION
This is required for more reliably reproducing monte-carlo based simulations.

Builds atop #11670.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11676)
<!-- Reviewable:end -->
