### PR TITLE
Cleanup some Python bindings' code

### DIFF
--- a/bindings/pydrake/common/eigen_geometry_py.cc
+++ b/bindings/pydrake/common/eigen_geometry_py.cc
@@ -97,7 +97,7 @@ void CheckAngleAxis(const Eigen::AngleAxis<Expression>&) {}
 }  // namespace
 
 template <typename T>
-void DoDefinitions(py::module m, T) {
+void DoScalarDependentDefinitions(py::module m, T) {
   // Do not return references to matrices (e.g. `Eigen::Ref<>`) so that we have
   // tighter control over validation.
 
@@ -361,7 +361,8 @@ PYBIND11_MODULE(eigen_geometry, m) {
 
   py::module::import("pydrake.autodiffutils");
   py::module::import("pydrake.symbolic");
-  type_visit([m](auto dummy) { DoDefinitions(m, dummy); }, CommonScalarPack{});
+  type_visit([m](auto dummy) { DoScalarDependentDefinitions(m, dummy); },
+      CommonScalarPack{});
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -32,7 +32,7 @@ using symbolic::Expression;
 
 namespace {
 template <typename T>
-void DoDefinitions(py::module m, T) {
+void DoScalarDependentDefinitions(py::module m, T) {
   py::tuple param = GetPyParam<T>();
 
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
@@ -227,22 +227,13 @@ void DoDefinitions(py::module m, T) {
   py::implicitly_convertible<RigidTransform<T>, Isometry3<T>>();
 }
 
-}  // namespace
-
-PYBIND11_MODULE(math, m) {
+void DoScalarIndependentDefinitions(py::module m) {
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
   using namespace drake::math;
-
-  m.doc() = "Bindings for //math.";
   constexpr auto& doc = pydrake_doc.drake.math;
-
-  py::module::import("pydrake.autodiffutils");
-  py::module::import("pydrake.symbolic");
 
   // TODO(eric.cousineau): Bind remaining classes for all available scalar
   // types.
-
-  type_visit([m](auto dummy) { DoDefinitions(m, dummy); }, CommonScalarPack{});
   using T = double;
   m.def("wrap_to", &wrap_to<T, T>, py::arg("value"), py::arg("low"),
       py::arg("high"), doc.wrap_to.doc);
@@ -361,6 +352,18 @@ PYBIND11_MODULE(math, m) {
   pydrake::internal::BindSymbolicMathOverloads(&m);
 
   ExecuteExtraPythonCode(m);
+}
+}  // namespace
+
+PYBIND11_MODULE(math, m) {
+  m.doc() = "Bindings for //math.";
+
+  py::module::import("pydrake.autodiffutils");
+  py::module::import("pydrake.symbolic");
+
+  type_visit([m](auto dummy) { DoScalarDependentDefinitions(m, dummy); },
+      CommonScalarPack{});
+  DoScalarIndependentDefinitions(m);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/multibody/math_py.cc
+++ b/bindings/pydrake/multibody/math_py.cc
@@ -38,7 +38,7 @@ void BindSpatialVectorMixin(PyClass* pcls) {
 
 namespace {
 template <typename T>
-void DoDefinitions(py::module m, T) {
+void DoScalarDependentDefinitions(py::module m, T) {
   py::tuple param = GetPyParam<T>();
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
   using namespace drake::multibody;
@@ -95,7 +95,8 @@ PYBIND11_MODULE(math, m) {
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
   using namespace drake::multibody;
   m.doc() = "Bindings for multibody math.";
-  type_visit([m](auto dummy) { DoDefinitions(m, dummy); }, CommonScalarPack{});
+  type_visit([m](auto dummy) { DoScalarDependentDefinitions(m, dummy); },
+      CommonScalarPack{});
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -338,7 +338,7 @@ struct Impl {
     }
   };
 
-  static void DoDefinitions(py::module m) {
+  static void DoScalarDependentDefinitions(py::module m) {
     // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
     using namespace drake::systems;
     constexpr auto& doc = pydrake_doc.drake.systems;
@@ -876,7 +876,7 @@ void DefineFrameworkPySystems(py::module m) {
   // Do templated instantiations of system types.
   auto bind_common_scalar_types = [m](auto dummy) {
     using T = decltype(dummy);
-    Impl<T>::DoDefinitions(m);
+    Impl<T>::DoScalarDependentDefinitions(m);
   };
   type_visit(bind_common_scalar_types, CommonScalarPack{});
 }


### PR DESCRIPTION
Addressing [this](https://reviewable.io/reviews/robotlocomotion/drake/11633#-Lh_UryF00NepB6YKYKj) and [that](https://reviewable.io/reviews/robotlocomotion/drake/11633#-Lh_SONjE_BgOVHmmGcR).

EDIT(eric): Inlining summary of comments: Ensuring that `DoX` names are meaningful, using `DoScalarIndependentDefinitions` and `DoScalarDependentDefinitions`.

Reference #11633

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11678)
<!-- Reviewable:end -->
