### PR TITLE
Set G_DEBUG and G_SLICE environment variables when running valgrind

### DIFF
--- a/tools/dynamic_analysis/valgrind.sh
+++ b/tools/dynamic_analysis/valgrind.sh
@@ -2,6 +2,15 @@
 me=$(python -c 'import os; print(os.path.realpath("'"$0"'"))')
 mydir=$(dirname "$me")
 
+# Ensure that newly allocated memory that is not directly initialized by GLib
+# and memory being freed by GLib are reset to zero.
+export G_DEBUG=gc-friendly
+
+# Ensure that all GLib memory slices that are allocated through g_slice_alloc()
+# and released by g_slice_free1() are actually allocated via direct calls to
+# g_malloc() and g_free().
+export G_SLICE=always-malloc
+
 # Disable GTest death test use of clone() because it confuses valgrind.
 export GTEST_DEATH_TEST_USE_FORK=1
 

--- a/tools/dynamic_analysis/valgrind.supp
+++ b/tools/dynamic_analysis/valgrind.supp
@@ -1,17 +1,5 @@
 # This is the valgrind.supp used by `bazel test --config memcheck`.
 
-# LCM (via glib) leaks a few hundred bytes in some global handler allocation.
-{
-   lcm_glib_leak
-   Memcheck:Leak
-   match-leak-kinds: definite
-   ...
-   fun:g_slice_alloc
-   ...
-   fun:g_static_rec_mutex_lock
-   fun:lcm_handle
-}
-
 {
     <mosek-1>
     Memcheck:Addr4


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11679)
<!-- Reviewable:end -->
