### PR TITLE
Fixes MultibodyPositionToGeometrtyPose doxygen error

### DIFF
--- a/systems/rendering/multibody_position_to_geometry_pose.h
+++ b/systems/rendering/multibody_position_to_geometry_pose.h
@@ -36,7 +36,7 @@ class MultibodyPositionToGeometryPose final : public LeafSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MultibodyPositionToGeometryPose)
 
-  /***
+  /**
    * The %MultibodyPositionToGeometryPose holds an internal, non-owned
    * reference to the MultibodyPlant object so you must ensure that @p plant
    * has a longer lifetime than `this` %MultibodyPositionToGeometryPose system.


### PR DESCRIPTION
The doxygen for the constructor was not being rendered because it started with `/***` instead of `/**`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11680)
<!-- Reviewable:end -->
