### PR TITLE
Revise note about python executable to use with macOS Python 2 bindings

### DIFF
--- a/doc/python_bindings.rst
+++ b/doc/python_bindings.rst
@@ -146,20 +146,9 @@ After following the above install steps, check to ensure you can import
 
 .. note::
 
-    If you are using macOS, you must ensure that you are using the ``python2``
-    executable to run these scripts. As an example for Homebrew:
-
-    .. code-block:: shell
-
-        export PATH=/usr/local/opt/python/libexec/bin:${PATH}
-
-    If you would like to use ``jupyter``, then be sure to install it via
-    ``pip2 install jupyter`` (*not* ``brew install jupyter``) to ensure that it
-    uses the correct ``PYTHONPATH``.
-
-    ..
-        Developers: Ensure this is synchronized with the steps in
-        ``install_prereqs_user_environment.sh``.
+    If you are using macOS and the Python 2 bindings, you must ensure that you
+    are using the ``python2`` executable (typically located at
+    ``/usr/local/bin/python2``) to run these scripts.
 
 .. note::
 


### PR DESCRIPTION
Also remove note about `jupyter`. Either works as well as the other (the Homebrew one was fixed a while ago).

Relates https://github.com/RobotLocomotion/drake/issues/11655#issuecomment-502733785.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11688)
<!-- Reviewable:end -->
