### PR TITLE
py deprecation: Add `WrapDeprecated` and `py_init_deprecated`

### DIFF
--- a/bindings/pydrake/common/BUILD.bazel
+++ b/bindings/pydrake/common/BUILD.bazel
@@ -10,6 +10,7 @@ load(
     "@drake//tools/skylark:pybind.bzl",
     "drake_pybind_cc_googletest",
     "drake_pybind_library",
+    "generate_pybind_documentation_header",
     "get_drake_py_installs",
     "get_pybind_package_info",
 )
@@ -102,7 +103,10 @@ drake_cc_library(
     hdrs = ["deprecation_pybind.h"],
     declare_installed_headers = 0,
     visibility = ["//visibility:public"],
-    deps = ["//bindings/pydrake:pydrake_pybind"],
+    deps = [
+        ":wrap_function",
+        "//bindings/pydrake:pydrake_pybind",
+    ],
 )
 
 drake_cc_library(
@@ -339,13 +343,42 @@ drake_cc_googletest(
     ],
 )
 
+drake_cc_library(
+    name = "deprecation_example_class",
+    testonly = 1,
+    hdrs = ["test/deprecation_example/example_class.h"],
+    deps = [
+        "//:drake_shared_library",
+    ],
+)
+
+generate_pybind_documentation_header(
+    name = "generate_deprecation_example_class_documentation",
+    testonly = 1,
+    out = "test/deprecation_example/example_class_documentation.h",
+    targets = [":deprecation_example_class"],
+)
+
+drake_cc_library(
+    name = "deprecation_example_class_documentation",
+    testonly = 1,
+    hdrs = ["test/deprecation_example/example_class_documentation.h"],
+    tags = ["nolint"],
+)
+
 drake_pybind_library(
     name = "deprecation_example_cc_module_py",
     testonly = 1,
     add_install = False,
-    cc_deps = [":deprecation_pybind"],
+    cc_deps = [
+        ":deprecation_example_class",
+        ":deprecation_example_class_documentation",
+        ":deprecation_pybind",
+    ],
     cc_so_name = "test/deprecation_example/cc_module",
-    cc_srcs = ["test/deprecation_example/cc_module_py.cc"],
+    cc_srcs = [
+        "test/deprecation_example/cc_module_py.cc",
+    ],
     package_info = PACKAGE_INFO,
     visibility = ["//visibility:private"],
 )

--- a/bindings/pydrake/common/deprecation_pybind.h
+++ b/bindings/pydrake/common/deprecation_pybind.h
@@ -4,8 +4,12 @@
 /// Provides access to Python deprecation utilities from C++.
 /// For example usages, please see `deprecation_example/cc_module_py.cc`.
 
+#include <memory>
+#include <utility>
+
 #include "pybind11/pybind11.h"
 
+#include "drake/bindings/pydrake/common/wrap_function.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 
 namespace drake {
@@ -30,6 +34,57 @@ inline void WarnDeprecated(py::str message) {
   py::object warn_deprecated =
       py::module::import("pydrake.common.deprecation").attr("_warn_deprecated");
   warn_deprecated(message);
+}
+
+namespace detail {
+
+template <typename Func, typename Return, typename... Args>
+auto WrapDeprecatedImpl(py::str message,
+    function_info<Func, Return, Args...>&& info,
+    std::enable_if_t<std::is_same<Return, void>::value, void*> = {}) {
+  return [info = std::move(info), message](Args... args) {
+    WarnDeprecated(message);
+    info.func(std::forward<Args>(args)...);
+  };
+}
+
+template <typename Func, typename Return, typename... Args>
+auto WrapDeprecatedImpl(py::str message,
+    function_info<Func, Return, Args...>&& info,
+    std::enable_if_t<!std::is_same<Return, void>::value, void*> = {}) {
+  return [info = std::move(info), message](Args... args) -> Return {
+    WarnDeprecated(message);
+    return info.func(std::forward<Args>(args)...);
+  };
+}
+
+}  // namespace detail
+
+/// Wraps any callable (function pointer, method pointer, lambda, etc.) to emit
+/// a deprecation message.
+template <typename Func>
+auto WrapDeprecated(py::str message, Func&& func) {
+  return detail::WrapDeprecatedImpl(
+      message, detail::infer_function_info(std::forward<Func>(func)));
+}
+
+/// Deprecated wrapping of `py::init<>`.
+/// @note Only for `unique_ptr` holders. If using `shared_ptr`, talk to Eric.
+template <typename Class, typename... Args>
+auto py_init_deprecated(py::str message) {
+  // N.B. For simplicity, require that Class be passed up front, rather than
+  // trying to figure out how to pipe code into / mock `py::detail::initimpl`
+  // classes.
+  return py::init([message](Args... args) {
+    WarnDeprecated(message);
+    return std::make_unique<Class>(std::forward<Args>(args)...);
+  });
+}
+
+/// Deprecated wrapping of `py::init(factory)`.
+template <typename Func>
+auto py_init_deprecated(py::str message, Func&& func) {
+  return py::init(WrapDeprecated(message, std::forward<Func>(func)));
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/common/test/deprecation_example/example_class.h
+++ b/bindings/pydrake/common/test/deprecation_example/example_class.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "drake/common/drake_deprecated.h"
+
+namespace drake {
+namespace example_class {
+
+/// Example class.
+class ExampleCppClass {
+ public:
+  /// Good constructor.
+  ExampleCppClass() {}
+
+  // N.B. This spacer is to ensure that the class's documentation does not pick
+  // up the following deprecation below.
+
+  DRAKE_DEPRECATED("2038-01-19", "Do not use ExampleCppClass(int).")
+  explicit ExampleCppClass(int) {}
+
+  DRAKE_DEPRECATED("2038-01-19", "Do not use ExampleCppClass(double).")
+  explicit ExampleCppClass(double) {}
+
+  DRAKE_DEPRECATED("2038-01-19", "Do not use DeprecatedMethod().")
+  void DeprecatedMethod() {}
+
+  /// Good property.
+  int prop{};
+
+  /// Good overload.
+  void overload() {}
+
+  DRAKE_DEPRECATED("2038-01-19", "Do not use overload(int).")
+  void overload(int) {}
+};
+
+}  // namespace example_class
+}  // namespace drake


### PR DESCRIPTION
Here's a quick pass at addressing the request in #10605.

Gonna add in something like `deprecated_init`...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11701)
<!-- Reviewable:end -->
