### PR TITLE
pydrake: Add `numpy_compare` decorators for testing multiple scalar types

### DIFF
--- a/bindings/pydrake/common/eigen_geometry_py.cc
+++ b/bindings/pydrake/common/eigen_geometry_py.cc
@@ -4,17 +4,7 @@
 #include "pybind11/pybind11.h"
 
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
-#ifndef __clang__
-// N.B. Without this, GCC 7.4.0 on Ubuntu complains about
-// `AutoDiffScalar(const AutoDiffScalar& other)` having uninitialized values.
-// TODO(eric.cousineau): Figure out why?
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
-#pragma GCC diagnostic pop
-#else
-#include "drake/bindings/pydrake/common/default_scalars_pybind.h"
-#endif  // __clang__
 #include "drake/bindings/pydrake/common/eigen_geometry_pybind.h"
 #include "drake/bindings/pydrake/common/type_pack.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/common/test/eigen_geometry_test.py
+++ b/bindings/pydrake/common/test/eigen_geometry_test.py
@@ -17,23 +17,14 @@ def normalize(x):
 
 
 class TestEigenGeometry(unittest.TestCase):
-    def check_types(self, check_func):
-        check_func(float)
-        check_func(AutoDiffXd)
-        check_func(Expression)
-
-    def test_argument_deduction(self):
-        self.check_types(self.check_argument_deduction)
-
-    def check_argument_deduction(self, T):
+    @numpy_compare.check_all_types
+    def test_argument_deduction(self, T):
         # Brief check for argument deduction (#11667).
         q = mut.Quaternion_(w=T(1), x=T(0), y=T(0), z=T(0))
         self.assertIsInstance(q, mut.Quaternion_[T])
 
-    def test_quaternion(self):
-        self.check_types(self.check_quaternion)
-
-    def check_quaternion(self, T):
+    @numpy_compare.check_all_types
+    def test_quaternion(self, T):
         # Simple API.
         Quaternion = mut.Quaternion_[T]
         cast = np.vectorize(T)
@@ -116,10 +107,8 @@ class TestEigenGeometry(unittest.TestCase):
             self.assertTrue(isinstance(value, mut.Quaternion))
             test_util.check_quaternion(value)
 
-    def test_isometry3(self):
-        self.check_types(self.check_isometry3)
-
-    def check_isometry3(self, T):
+    @numpy_compare.check_all_types
+    def test_isometry3(self, T):
         Isometry3 = mut.Isometry3_[T]
         # - Default constructor
         transform = Isometry3()
@@ -189,10 +178,8 @@ class TestEigenGeometry(unittest.TestCase):
         self.assertEqual(value.shape, (3,))
         test_util.check_translation(value)
 
-    def test_angle_axis(self):
-        self.check_types(self.check_angle_axis)
-
-    def check_angle_axis(self, T):
+    @numpy_compare.check_all_types
+    def test_angle_axis(self, T):
         AngleAxis = mut.AngleAxis_[T]
         value_identity = AngleAxis.Identity()
         self.assertEqual(numpy_compare.resolve_type(value_identity.angle()), T)

--- a/bindings/pydrake/common/test/numpy_compare_test.py
+++ b/bindings/pydrake/common/test/numpy_compare_test.py
@@ -145,3 +145,23 @@ class TestNumpyCompareSimple(unittest.TestCase):
         numpy_compare.assert_equal(Formula.True_(), True)
         numpy_compare.assert_equal(Formula.False_(), False)
         numpy_compare.assert_not_equal(Formula.True_(), False)
+
+    def test_decorators(self):
+        T_list_all = []
+        T_list_nonsymbolic = []
+
+        @numpy_compare.check_all_types
+        def decorated_all(arg, T):
+            self.assertEqual(arg, 1)
+            T_list_all.append(T)
+
+        @numpy_compare.check_nonsymbolic_types
+        def decorated_nonsymbolic(arg, T):
+            self.assertEqual(arg, 2)
+            T_list_nonsymbolic.append(T)
+
+        decorated_all(1)
+        self.assertEqual(T_list_all, [float, AutoDiffXd, Expression])
+
+        decorated_nonsymbolic(2)
+        self.assertEqual(T_list_nonsymbolic, [float, AutoDiffXd])

--- a/bindings/pydrake/common/test_utilities/BUILD.bazel
+++ b/bindings/pydrake/common/test_utilities/BUILD.bazel
@@ -52,6 +52,7 @@ drake_py_library(
     deps = [
         ":deprecation_py",
         ":module_py",
+        ":numpy_compare_py",
     ],
 )
 

--- a/bindings/pydrake/multibody/test/math_test.py
+++ b/bindings/pydrake/multibody/test/math_test.py
@@ -41,9 +41,9 @@ class TestMultibodyTreeMath(unittest.TestCase):
         numpy_compare.assert_float_equal(
                 cls(**coeffs_args).get_coeffs(), coeffs_expected)
 
-    def test_spatial_vector_types(self):
-        for T in [float, AutoDiffXd, Expression]:
-            self.check_spatial_vector(SpatialVelocity_[T], "V", "w", "v")
-            self.check_spatial_vector(
-                    SpatialAcceleration_[T], "A", "alpha", "a")
-            self.check_spatial_vector(SpatialForce_[T], "F", "tau", "f")
+    @numpy_compare.check_all_types
+    def test_spatial_vector_types(self, T):
+        self.check_spatial_vector(SpatialVelocity_[T], "V", "w", "v")
+        self.check_spatial_vector(
+                SpatialAcceleration_[T], "A", "alpha", "a")
+        self.check_spatial_vector(SpatialForce_[T], "F", "tau", "f")

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -126,21 +126,9 @@ class TestPlant(unittest.TestCase):
         if nonzero:
             numpy_compare.assert_float_not_equal(x, 0.)
 
-    def check_all_types(self, check_func):
-        check_func(float)
-        check_func(AutoDiffXd)
-        check_func(Expression)
-
-    def check_nonsymbolic_types(self, check_func):
-        check_func(float)
-        check_func(AutoDiffXd)
-
-    def test_multibody_plant_construction_api(self):
+    @numpy_compare.check_nonsymbolic_types
+    def test_multibody_plant_construction_api(self, T):
         # SceneGraph does not support `Expression` type.
-        self.check_nonsymbolic_types(
-            self.check_multibody_plant_construction_api)
-
-    def check_multibody_plant_construction_api(self, T):
         DiagramBuilder = DiagramBuilder_[T]
         SpatialInertia = SpatialInertia_[float]
         RigidTransform = RigidTransform_[T]
@@ -175,10 +163,8 @@ class TestPlant(unittest.TestCase):
         with catch_drake_warnings(expected_count=1):
             plant.Finalize(scene_graph)
 
-    def test_multibody_plant_api_via_parsing(self):
-        self.check_all_types(self.check_multibody_plant_api_via_parsing)
-
-    def check_multibody_plant_api_via_parsing(self, T):
+    @numpy_compare.check_all_types
+    def test_multibody_plant_api_via_parsing(self, T):
         MultibodyPlant = MultibodyPlant_[T]
         Joint = Joint_[T]
         Body = Body_[T]
@@ -321,10 +307,8 @@ class TestPlant(unittest.TestCase):
         # Just to make it obvious when this is being tested.
         self.assertIsNot(value, None)
 
-    def test_inertia_api(self):
-        self.check_all_types(self.check_inertia_api)
-
-    def check_inertia_api(self, T):
+    @numpy_compare.check_all_types
+    def test_inertia_api(self, T):
         UnitInertia = UnitInertia_[T]
         SpatialInertia = SpatialInertia_[T]
         UnitInertia()
@@ -333,17 +317,13 @@ class TestPlant(unittest.TestCase):
         SpatialInertia(mass=2.5, p_PScm_E=[0.1, -0.2, 0.3],
                        G_SP_E=unit_inertia)
 
-    def test_friction_api(self):
-        self.check_all_types(self.check_friction_api)
-
-    def check_friction_api(self, T):
+    @numpy_compare.check_all_types
+    def test_friction_api(self, T):
         CoulombFriction = CoulombFriction_[T]
         CoulombFriction(static_friction=0.7, dynamic_friction=0.6)
 
-    def test_multibody_gravity_default(self):
-        self.check_all_types(self.check_multibody_gravity_default)
-
-    def check_multibody_gravity_default(self, T):
+    @numpy_compare.check_all_types
+    def test_multibody_gravity_default(self, T):
         MultibodyPlant = MultibodyPlant_[T]
         UniformGravityFieldElement = UniformGravityFieldElement_[T]
         plant = MultibodyPlant()
@@ -352,10 +332,8 @@ class TestPlant(unittest.TestCase):
             plant.AddForceElement(UniformGravityFieldElement())
         plant.Finalize()
 
-    def test_multibody_tree_kinematics(self):
-        self.check_all_types(self.check_multibody_tree_kinematics)
-
-    def check_multibody_tree_kinematics(self, T):
+    @numpy_compare.check_all_types
+    def test_multibody_tree_kinematics(self, T):
         RigidTransform = RigidTransform_[T]
         SpatialVelocity = SpatialVelocity_[T]
         plant_f = MultibodyPlant_[float]()
@@ -428,10 +406,8 @@ class TestPlant(unittest.TestCase):
             context=context, known_vdot=vdot)
         self.assertEqual(len(A_WB_array), plant.num_bodies())
 
-    def test_multibody_state_access(self):
-        self.check_all_types(self.check_multibody_state_access)
-
-    def check_multibody_state_access(self, T):
+    @numpy_compare.check_all_types
+    def test_multibody_state_access(self, T):
         MultibodyPlant = MultibodyPlant_[T]
 
         plant_f = MultibodyPlant_[float]()
@@ -513,10 +489,8 @@ class TestPlant(unittest.TestCase):
         self.assertEqual(plant.GetAccelerationLowerLimits().shape, (nv,))
         self.assertEqual(plant.GetAccelerationUpperLimits().shape, (nv,))
 
-    def test_model_instance_port_access(self):
-        self.check_all_types(self. check_model_instance_port_access)
-
-    def check_model_instance_port_access(self, T):
+    @numpy_compare.check_all_types
+    def test_model_instance_port_access(self, T):
         MultibodyPlant = MultibodyPlant_[T]
         InputPort = InputPort_[T]
         OutputPort = OutputPort_[T]
@@ -638,10 +612,8 @@ class TestPlant(unittest.TestCase):
         simulator = Simulator(diagram)
         simulator.StepTo(0.01)
 
-    def test_model_instance_state_access(self):
-        self.check_all_types(self.check_model_instance_state_access)
-
-    def check_model_instance_state_access(self, T):
+    @numpy_compare.check_all_types
+    def test_model_instance_state_access(self, T):
         # N.B. Please check warning above in `check_multibody_state_access`.
         # Create a MultibodyPlant with a kuka arm and a schunk gripper.
         # the arm is welded to the world, the gripper is welded to the
@@ -787,10 +759,8 @@ class TestPlant(unittest.TestCase):
         numpy_compare.assert_float_equal(plant.GetPositionsAndVelocities(
             context, iiwa_model), np.zeros(nq_iiwa + nv_iiwa))
 
-    def test_model_instance_state_access_by_array(self):
-        self.check_all_types(self.check_model_instance_state_access_by_array)
-
-    def check_model_instance_state_access_by_array(self, T):
+    @numpy_compare.check_all_types
+    def test_model_instance_state_access_by_array(self, T):
         # N.B. Please check warning above in `check_multibody_state_access`.
         MultibodyPlant = MultibodyPlant_[T]
         # Create a MultibodyPlant with a kuka arm and a schunk gripper.
@@ -906,10 +876,8 @@ class TestPlant(unittest.TestCase):
                 model_instance=iiwa_model, u_instance=u_iiwa, u=u)
             numpy_compare.assert_float_equal(u_iiwa, u[:7])
 
-    def test_map_qdot_to_v_and_back(self):
-        self.check_all_types(self.check_map_qdot_to_v_and_back)
-
-    def check_map_qdot_to_v_and_back(self, T):
+    @numpy_compare.check_all_types
+    def test_map_qdot_to_v_and_back(self, T):
         MultibodyPlant = MultibodyPlant_[T]
         RigidTransform = RigidTransform_[T]
         RollPitchYaw = RollPitchYaw_[T]
@@ -940,10 +908,8 @@ class TestPlant(unittest.TestCase):
         v_remap = plant.MapQDotToVelocity(context, qdot)
         numpy_compare.assert_float_allclose(v_remap, v_expected)
 
-    def test_multibody_add_joint(self):
-        self.check_all_types(self.check_multibody_add_joint)
-
-    def check_multibody_add_joint(self, T):
+    @numpy_compare.check_all_types
+    def test_multibody_add_joint(self, T):
         """
         Tests joint constructors and `AddJoint`.
         """
@@ -998,10 +964,8 @@ class TestPlant(unittest.TestCase):
             joint = plant.get_joint(joint_index=joint_f.index())
             self._test_joint_api(T, joint)
 
-    def test_multibody_add_frame(self):
-        self.check_all_types(self.check_multibody_add_frame)
-
-    def check_multibody_add_frame(self, T):
+    @numpy_compare.check_all_types
+    def test_multibody_add_frame(self, T):
         MultibodyPlant = MultibodyPlant_[T]
         FixedOffsetFrame = FixedOffsetFrame_[T]
 
@@ -1016,10 +980,8 @@ class TestPlant(unittest.TestCase):
             frame.GetFixedPoseInBodyFrame().GetAsMatrix4(),
             np.eye(4))
 
-    def test_multibody_dynamics(self):
-        self.check_all_types(self.check_multibody_dynamics)
-
-    def check_multibody_dynamics(self, T):
+    @numpy_compare.check_all_types
+    def test_multibody_dynamics(self, T):
         MultibodyPlant = MultibodyPlant_[T]
         MultibodyForces = MultibodyForces_[T]
         SpatialForce = SpatialForce_[T]
@@ -1098,11 +1060,9 @@ class TestPlant(unittest.TestCase):
             link2.GetForceInWorld(context, forces).get_coeffs()),
             2 * F_expected)
 
-    def test_contact(self):
+    @numpy_compare.check_nonsymbolic_types
+    def test_contact(self, T):
         # PenetrationAsPointPair has been bound for non-symbolic types only.
-        self.check_nonsymbolic_types(self.check_contact)
-
-    def check_contact(self, T):
         PenetrationAsPointPair = PenetrationAsPointPair_[T]
         PointPairContactInfo = PointPairContactInfo_[T]
         ContactResults = ContactResults_[T]
@@ -1168,11 +1128,9 @@ class TestPlant(unittest.TestCase):
         publisher = ConnectContactResultsToDrakeVisualizer(builder, plant)
         self.assertIsInstance(publisher, LcmPublisherSystem)
 
-    def test_scene_graph_queries(self):
+    @numpy_compare.check_nonsymbolic_types
+    def test_scene_graph_queries(self, T):
         # SceneGraph does not support `Expression` type.
-        self.check_nonsymbolic_types(self.check_scene_graph_queries)
-
-    def check_scene_graph_queries(self, T):
         PenetrationAsPointPair = PenetrationAsPointPair_[T]
 
         builder_f = DiagramBuilder_[float]()

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -7,6 +7,7 @@ from pydrake.autodiffutils import AutoDiffXd
 from pydrake.common import FindResourceOrThrow
 from pydrake.common.eigen_geometry import Isometry3_
 from pydrake.common.test_utilities.deprecation import catch_drake_warnings
+from pydrake.common.test_utilities import numpy_compare
 from pydrake.lcm import DrakeMockLcm
 from pydrake.symbolic import Expression
 from pydrake.systems.framework import DiagramBuilder_, InputPort_, OutputPort_
@@ -17,14 +18,8 @@ class TestGeometry(unittest.TestCase):
     def setUp(self):
         warnings.simplefilter('error', DrakeDeprecationWarning)
 
-    def check_types(self, check_func):
-        check_func(float)
-        check_func(AutoDiffXd)
-
-    def test_scene_graph_api(self):
-        self.check_types(self.check_scene_graph_api)
-
-    def check_scene_graph_api(self, T):
+    @numpy_compare.check_nonsymbolic_types
+    def test_scene_graph_api(self, T):
         SceneGraph = mut.SceneGraph_[T]
         InputPort = InputPort_[T]
         OutputPort = OutputPort_[T]
@@ -61,10 +56,8 @@ class TestGeometry(unittest.TestCase):
             mut.DispatchLoadMessage(
                 scene_graph=scene_graph, lcm=lcm)
 
-    def test_frame_pose_vector_api(self):
-        self.check_types(self.check_frame_pose_vector_api)
-
-    def check_frame_pose_vector_api(self, T):
+    @numpy_compare.check_nonsymbolic_types
+    def test_frame_pose_vector_api(self, T):
         FramePoseVector = mut.FramePoseVector_[T]
         Isometry3 = Isometry3_[T]
         obj = FramePoseVector()
@@ -107,10 +100,8 @@ class TestGeometry(unittest.TestCase):
             # N.B. Creation order does not imply value.
             self.assertTrue(a < b or b > a)
 
-    def test_penetration_as_point_pair_api(self):
-        self.check_types(self.check_penetration_as_point_pair_api)
-
-    def check_penetration_as_point_pair_api(self, T):
+    @numpy_compare.check_nonsymbolic_types
+    def test_penetration_as_point_pair_api(self, T):
         obj = mut.PenetrationAsPointPair_[T]()
         self.assertIsInstance(obj.id_A, mut.GeometryId)
         self.assertIsInstance(obj.id_B, mut.GeometryId)
@@ -118,10 +109,8 @@ class TestGeometry(unittest.TestCase):
         self.assertTupleEqual(obj.p_WCb.shape, (3,))
         self.assertEqual(obj.depth, -1.)
 
-    def test_signed_distance_api(self):
-        self.check_types(self.check_signed_distance_api)
-
-    def check_signed_distance_api(self, T):
+    @numpy_compare.check_nonsymbolic_types
+    def test_signed_distance_api(self, T):
         obj = mut.SignedDistancePair_[T]()
         self.assertIsInstance(obj.id_A, mut.GeometryId)
         self.assertIsInstance(obj.id_B, mut.GeometryId)
@@ -130,10 +119,8 @@ class TestGeometry(unittest.TestCase):
         self.assertIsInstance(obj.distance, T)
         self.assertTupleEqual(obj.nhat_BA_W.shape, (3,))
 
-    def test_signed_distance_to_point_api(self):
-        self.check_types(self.check_signed_distance_to_point_api)
-
-    def check_signed_distance_to_point_api(self, T):
+    @numpy_compare.check_nonsymbolic_types
+    def test_signed_distance_to_point_api(self, T):
         obj = mut.SignedDistanceToPoint_[T]()
         self.assertIsInstance(obj.id_G, mut.GeometryId)
         self.assertTupleEqual(obj.p_GN.shape, (3,))

--- a/bindings/pydrake/test/math_test.py
+++ b/bindings/pydrake/test/math_test.py
@@ -96,15 +96,8 @@ class TestMath(unittest.TestCase):
         for f_core, f_cpp in binary:
             self.assertEqual(f_core(a, b), f_cpp(a, b))
 
-    def check_types(self, check_func):
-        check_func(float)
-        check_func(AutoDiffXd)
-        check_func(Expression)
-
-    def test_rigid_transform(self):
-        self.check_types(self.check_rigid_transform)
-
-    def check_rigid_transform(self, T):
+    @numpy_compare.check_all_types
+    def test_rigid_transform(self, T):
         RigidTransform = mut.RigidTransform_[T]
         RotationMatrix = mut.RotationMatrix_[T]
         RollPitchYaw = mut.RollPitchYaw_[T]
@@ -158,20 +151,16 @@ class TestMath(unittest.TestCase):
                 eval("X @ RigidTransform()"), RigidTransform)
             self.assertIsInstance(eval("X @ [0, 0, 0]"), np.ndarray)
 
-    def test_isometry_implicit(self):
-        self.check_types(self.check_isometry_implicit)
-
-    def check_isometry_implicit(self, T):
+    @numpy_compare.check_all_types
+    def test_isometry_implicit(self, T):
         Isometry3 = Isometry3_[T]
         # Explicitly disabled, to mirror C++ API.
         with self.assertRaises(TypeError):
             self.assertTrue(mtest.TakeRigidTransform(Isometry3()))
         self.assertTrue(mtest.TakeIsometry3(mut.RigidTransform()))
 
-    def test_rotation_matrix(self):
-        self.check_types(self.check_rotation_matrix)
-
-    def check_rotation_matrix(self, T):
+    @numpy_compare.check_all_types
+    def test_rotation_matrix(self, T):
         # - Constructors.
         RotationMatrix = mut.RotationMatrix_[T]
         AngleAxis = AngleAxis_[T]
@@ -228,10 +217,8 @@ class TestMath(unittest.TestCase):
             numpy_compare.assert_float_equal(
                     eval("R.inverse() @ R").matrix(), np.eye(3))
 
-    def test_roll_pitch_yaw(self):
-        self.check_types(self.check_roll_pitch_yaw)
-
-    def check_roll_pitch_yaw(self, T):
+    @numpy_compare.check_all_types
+    def test_roll_pitch_yaw(self, T):
         # - Constructors.
         RollPitchYaw = mut.RollPitchYaw_[T]
         RotationMatrix = mut.RotationMatrix_[T]


### PR DESCRIPTION
Resolves #11647

\cc @m-chaturvedi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11703)
<!-- Reviewable:end -->
