### PR TITLE
Introduce RgbdSensor

### DIFF
--- a/attic/systems/sensors/rgbd_camera.h
+++ b/attic/systems/sensors/rgbd_camera.h
@@ -24,6 +24,10 @@ namespace sensors {
 /// An RGB-D camera system that provides RGB, depth and label images using
 /// visual elements of RigidBodyTree.
 ///
+/// @warning This is an old interface, with potentially ambiguous and outdated
+/// terms. Please see `RgbdSensor` and `CameraInfo` for more modern
+/// terminology.
+///
 /// Let `W` be the world coordinate system. In addition to `W`, there are three
 /// more coordinate systems that are associated with an RgbdCamera. They are
 /// defined as follows:

--- a/geometry/render/camera_properties.h
+++ b/geometry/render/camera_properties.h
@@ -10,6 +10,10 @@ namespace render {
 
 // TODO(SeanCurtis-TRI): Allow for configuring the intrinsic matrix directly
 // with a projection matrix.
+// TODO(eric.cousineau): Make this have `CameraInfo` as a member, move that
+// class outside of `drake::systems`, and possibly rename this class, in order
+// to decouple generic pinhole parameters from Drake-specific render engine
+// information.
 /** The intrinsic properties for a render camera. The render system
  uses a reduced set of intrinsic parameters by making some simplifying
  assumptions:

--- a/geometry/test_utilities/dummy_render_engine.h
+++ b/geometry/test_utilities/dummy_render_engine.h
@@ -29,7 +29,9 @@ namespace internal {
     PerceptionProperties (see accepting_properties() and
     rejecting_properties()).
  4. Records which poses have been updated via UpdatePoses() to validate which
-    RenderIndex values are updated and which aren't (and with what pose).  */
+    RenderIndex values are updated and which aren't (and with what pose).
+ 5. Records the camera pose provided to UpdateViewpoint() and report it with
+    last_updated_X_WC().  */
 class DummyRenderEngine final : public render::RenderEngine {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DummyRenderEngine);
@@ -42,7 +44,9 @@ class DummyRenderEngine final : public render::RenderEngine {
 
   /** @group No-op implementation of RenderEngine interface.  */
   //@{
-  void UpdateViewpoint(const math::RigidTransformd&) final {}
+  void UpdateViewpoint(const math::RigidTransformd& X_WC) final {
+    X_WC_ = X_WC;
+  }
   void RenderColorImage(const render::CameraProperties&, bool,
                         systems::sensors::ImageRgba8U*) const final {}
   void RenderDepthImage(const render::DepthCameraProperties&,
@@ -98,6 +102,8 @@ class DummyRenderEngine final : public render::RenderEngine {
     moved_index_ = index;
   }
 
+  const math::RigidTransformd& last_updated_X_WC() const { return X_WC_; }
+
   // Promote these to be public to facilitate testing.
   using RenderEngine::LabelFromColor;
   using RenderEngine::GetColorDFromLabel;
@@ -150,6 +156,9 @@ class DummyRenderEngine final : public render::RenderEngine {
 
   // The RenderIndex value to return on invocation of DoRemoveGeometry().
   optional<RenderIndex> moved_index_{};
+
+  // The last updated camera pose (defaults to identity).
+  math::RigidTransformd X_WC_;
 };
 
 }  // namespace internal

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -598,6 +598,20 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
     return it->second;
   }
 
+  /// Reports if the indicated `output` is connected to the `input` port.
+  /// @pre the ports belong to systems that are direct children of this diagram.
+  bool AreConnected(const OutputPort<T>& output,
+                    const InputPort<T>& input) const {
+    InputPortLocator in{&input.get_system(), input.get_index()};
+    OutputPortLocator out{&output.get_system(), output.get_index()};
+
+    const auto range = connection_map_.equal_range(in);
+    for (auto iter = range.first; iter != range.second; ++iter) {
+      if (iter->second == out) return true;
+    }
+    return false;
+  }
+
  protected:
   /// Constructs an uninitialized Diagram. Subclasses that use this constructor
   /// are obligated to call DiagramBuilder::BuildInto(this).  Provides scalar-

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -596,6 +596,30 @@ TEST_F(DiagramTest, Topology) {
   }
 }
 
+// Confirms that the Diagram::AreConnected() query reports the correct results.
+TEST_F(DiagramTest, AreConnected) {
+  // Several verifiably connected ports.
+  EXPECT_TRUE(diagram_->AreConnected(diagram_->adder0()->get_output_port(),
+                                     diagram_->adder1()->get_input_port(0)));
+  EXPECT_TRUE(diagram_->AreConnected(diagram_->adder1()->get_output_port(),
+                                     diagram_->adder2()->get_input_port(1)));
+  EXPECT_TRUE(diagram_->AreConnected(diagram_->adder0()->get_output_port(),
+                                     diagram_->adder2()->get_input_port(0)));
+
+  // A couple unconnected ports -- but they all belong to the diagram.
+  EXPECT_FALSE(diagram_->AreConnected(diagram_->adder0()->get_output_port(),
+                                      diagram_->adder1()->get_input_port(1)));
+  EXPECT_FALSE(diagram_->AreConnected(diagram_->adder1()->get_output_port(),
+                                      diagram_->adder2()->get_input_port(0)));
+
+  // Test against a port that does *not* belong to the diagram.
+  Adder<double> temp_adder(2, kSize);
+  EXPECT_FALSE(diagram_->AreConnected(temp_adder.get_output_port(),
+                                      diagram_->adder1()->get_input_port(1)));
+  EXPECT_FALSE(diagram_->AreConnected(diagram_->adder1()->get_output_port(),
+                                      temp_adder.get_input_port(1)));
+}
+
 // Tests that dependency wiring is set up correctly between
 //  1. input ports and their source output ports,
 //  2. diagram output ports and their source leaf output ports,

--- a/systems/primitives/zero_order_hold.h
+++ b/systems/primitives/zero_order_hold.h
@@ -78,6 +78,9 @@ class ZeroOrderHold final : public LeafSystem<T> {
     return LeafSystem<T>::get_output_port(0);
   }
 
+  /// Reports the period of this hold (in seconds).
+  double period() const { return period_sec_; }
+
   /// (Advanced) Manually sample the input port and copy ("latch") the value
   /// into the state. This emulates an update event and is mostly useful for
   /// testing.

--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -33,6 +33,7 @@ drake_cc_package_library(
         ":lcm_image_array_to_images",
         ":lcm_image_traits",
         ":optitrack_sender",
+        ":rgbd_sensor",
         ":rotary_encoders",
         ":vtk_util",
     ],
@@ -178,6 +179,22 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "rgbd_sensor",
+    srcs = ["rgbd_sensor.cc"],
+    hdrs = ["rgbd_sensor.h"],
+    deps = [
+        ":camera_info",
+        ":image",
+        "//geometry:geometry_ids",
+        "//geometry:scene_graph",
+        "//geometry/render:render_engine",
+        "//systems/framework:leaf_system",
+        "//systems/primitives:zero_order_hold",
+        "//systems/rendering:pose_vector",
+    ],
+)
+
+drake_cc_library(
     name = "rotary_encoders",
     srcs = ["rotary_encoders.cc"],
     hdrs = ["rotary_encoders.h"],
@@ -267,6 +284,16 @@ drake_cc_googletest(
         "//common/test_utilities",
         "@spruce",
         "@vtk//:vtkIOImage",
+    ],
+)
+
+drake_cc_googletest(
+    name = "rgbd_sensor_test",
+    tags = vtk_test_tags(),
+    deps = [
+        ":rgbd_sensor",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//geometry/test_utilities:dummy_render_engine",
     ],
 )
 

--- a/systems/sensors/camera_info.cc
+++ b/systems/sensors/camera_info.cc
@@ -25,6 +25,13 @@ CameraInfo::CameraInfo(int width, int height, double vertical_fov_rad)
                  height * 0.5 / std::tan(0.5 * vertical_fov_rad),
                  height * 0.5 / std::tan(0.5 * vertical_fov_rad),
                  width * 0.5 - 0.5, height * 0.5 - 0.5) {}
+// TODO(SeanCurtis-TRI): The shift of the principal point by (-0.5, -0.5) is
+//  overly opaque. The primary explanation comes from pixel addressing
+//  conventions used in various APIs (see
+//  https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_fragment_coord_conventions.txt
+//  However, we don't want to look like this class is coupled with OpenGL. How
+//  do we articulate this math in a way that *doesn't* depend on OpenGL?
+//  See https://github.com/SeanCurtis-TRI/drake/pull/5#pullrequestreview-264447958.
 
 }  // namespace sensors
 }  // namespace systems

--- a/systems/sensors/camera_info.h
+++ b/systems/sensors/camera_info.h
@@ -8,111 +8,183 @@ namespace drake {
 namespace systems {
 namespace sensors {
 
-/// Simple data structure for camera information that includes the image size
-/// and camera intrinsic parameters.
-///
-/// To clarify the terminology used to describe 2D and/or 3D spaces throughout
-/// the class, we use "coordinate system" rather than "frame".  This is because
-/// the term "frame" has two different meanings in the computer vision field: a
-/// synonym of coordinate system, and a snapshot out of consecutively captured
-/// images.  To ensure the reader will not be confused, we clearly differentiate
-/// the use of the terms "coordinate system" and "frame" by using "coordinate
-/// system" to denote 2D/3D spaces and "frame" to denote a captured image.
-///
-/// There are three types of the coordinate systems that are relevant to this
-/// class:
-///
-///   - the camera coordinate system
-///   - the image coordinate system
-///   - the pixel coordinate system.
-///
-/// The camera coordinate system expresses a camera's 6D pose relative to the
-/// world coordinate system.  The camera coordinate system is defined to be
-/// `X-right`, `Y-down` and `Z-forward`.  The `Z` axis is also called the
-/// "optical axis".  Note that each axis in the camera coordinate system is
-/// expressed in the upper case, like `(X, Y, Z)` to distinguish from those of
-/// the image coordinate system which we explain next.
-///
-/// The image coordinate system is the 2D coordinate system made by projecting
-/// the camera coordinate system onto the 2D image plane which is perpendicular
-/// to the "optical axis".  Therefore, the direction of the each axis is
-/// `x-right` and `y-down`, and the origin of the image coordinate system is
-/// located at the crossing point between the 2D image plane and the "optical
-/// axis".  This origin is called the "image center" or "principal point".  Note
-/// that each axis in the image coordinate system is expressed in the lower case
-/// , like `(x, y)`.
-///
-/// The pixel coordinate system is also a 2D coordinate system.  The main
-/// differences between the pixel coordinate system and the image coordinate
-/// system are the location of the origin and the direction of the axes.  The
-/// origin of the pixel coordinate system is at the left-upper corner of the
-/// image and the direction of the each axis is the same as those of the image
-/// coordinate system.  The axes of the pixel coordinate system are expressed
-/// using `u` and `v`, therefore the axes directions are `u-right` and `v-down`.
-///
-/// For more detail including an explanation of the focal lengths, refer to:
-/// http://docs.opencv.org/2.4/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.html
-/// and https://en.wikipedia.org/wiki/Pinhole_camera_model.
-///
 // TODO(kunimatsu-tri) Add camera distortion parameters and other parameters as
 // needed.
+/**
+ Simple struct for characterizing the Drake camera model. The camera model is
+ based on the
+ [pinhole _model_](http://docs.opencv.org/2.4/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.html)
+ , which is related to but distinct from an actual
+ [pinhole _camera_](https://en.wikipedia.org/wiki/Pinhole_camera). The former
+ is a mathematical model for producing images, the latter is a physical object.
+
+ The camera info members are directly tied to the underlying model's
+ mathematical parameters. In order to understand the model parameters, we will
+ provide a discussion of how cameras are treated in Drake with some common
+ terminology (liberally borrowed from computer vision).
+
+ <h3>Pinhole camera model</h3>
+
+ (To get an exact definition of the terms used here, please refer to the
+ glossary below.)
+
+ Intuitively, a camera produces images of an observed environment. The pinhole
+ model serves as a camera for a virtually modeled environment. Its parameters
+ are those required to determine where in the resultant image a virtual object
+ appears. In essence, the parameters of the camera model define a mapping from
+ points in 3D space to a point on the image (2D space).
+
+ The full discussion of this mapping can be found in the
+ [OpenCV documentation](https://docs.opencv.org/2.4/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.html).
+ Here, we'll highlight one or two points as it relates to this struct.
+
+ The mapping from 3D to 2D is decomposed into two sets of properties: extrinsic
+ and intrinsic. The extrinsic properties define the pose of the camera in the
+ environment -- specifically, given the camera frame `C`, it defines `X_WC`.
+ Once a point `Q` is measured and expressed in the camera's frame (i.e.,
+ `p_CQ_C`), the intrinsic matrix projects it into the 2D image. %CameraInfo does
+ _not_ concern itself with the extrinsic properties (other classes are
+ responsible for that -- see RgbdSensor).
+
+ %CameraInfo defines the parameters of the intrinsic projection. The projection
+ can be captured by the camera or intrinsic matrix which essentially maps points
+ in the camera frame C to the image plane (the matrix is called `A` in the
+ OpenCV documentation, but typically called `K` in computer vision literature):
+
+         │ f_x  0    c_x │
+     K = │ 0    f_y  c_y │, i.e.,
+         │ 0    0    1   │
+
+ - This matrix maps a point in the camera frame C to the projective space of the
+   image (via homogeneous coordinates). The resulting image coordinate `(u, v)`
+   is extracted by dividing out the homogeneous scale factor.
+ - (c_x, c_y) defines the principal point.
+ - (f_x, f_y) defines the model focal length.
+
+ In other words, for point Q in the world frame, its texture coordinates
+ `(u_Q, v_Q)` are calculated as:
+
+      │ u_Q │
+     s│ v_Q │ = K ⋅ X_CW ⋅ p_WQ
+      │  1  │
+
+ Note: The expression on the right will generally produce a homogeneous
+ coordinate vector of the form `(s * u_Q, s * v_Q, s)`. The texture coordinate
+ is defined as the first two measures when the *third* measure is 1. The magic
+ of homogeneous coordinates allows us to simply factor out `s`.
+
+ <h3>Glossary</h3>
+
+ These terms are important to the discussion. Some refer to real world concepts
+ and some to the model. The application domain of the term will be indicated
+ and, where necessary, ambiguities will be resolved. The terms are ordered
+ alphabetically for ease of reference.
+
+ - __aperture__: the opening in a camera through which light passes. The origin
+   of the camera frame `Co` is located at the aperture's center.
+   - in a physical camera it may contain a lens and the size of the camera
+     affects optical artifacts such as depth of field.
+   - in the pinhole model, there is no lens and the aperture is a single point.
+ - __focal length__: a camera property that determines the field of view angle
+   and the scale of objects in the image (large focal length --> small field of
+   view angle).
+   - In a physical camera, it is the distance (in meters) between the center of
+     the lens and the plane at which all incoming, parallel light rays converge
+     (assuming a radially symmetric lens).
+   - in the pinhole model, `(f_x, f_y)` is described as "focal length", but the
+     units are in pixels and the interpretation is different. The relationship
+     between `(f_x, f_y)` and the physical focal length `F` is `f_i = F * s_i`,
+     where `(s_x, s_y)` are the number of pixels per meter in the x- and
+     y-directions (of the image). Both values described as "focal length" have
+     analogous effects on field of view and scale of objects in the image.
+ - __frame__: (Also "pose") an origin point and a space-spanning basis in 2D/3D,
+   as in @ref multibody_frames_and_bodies.
+   - Incidentally, the word "frame" is also used in conjunction with a single
+   image in a video (such as a "video frame"). Drake doesn't use this sense in
+   discussing cameras (unless explicitly noted).
+ - __image__: an array of measurements such that the measured values have
+   spatial relationships based on where they are in the array.
+ - __image frame__: the 2D frame embedded in 3D space spanning the image plane.
+   The image frame's x- and y-axes are parallel with `Cx` and `Cy`,
+   respectively. Coordinates are expressed as the pair `(u, v)` and the camera's
+   image lies on the plane spanned by the frame's basis. The _center_ of the
+   pixel in the first row and first column is at `(u=0, v=0)`.
+ - __image plane__: a plane in 3D which is perpendicular to the camera's viewing
+   direction. Conceptually, the image lies on this plane.
+     - In a physical pinhole camera, the aperture is between the image plane and
+     the environment being imaged.
+     - In the pinhole model, the image plane lies between the environment and
+     aperture (i.e., in the positive Cz direction from Co).
+ - __imager__: a sensor whose measurements are reported in images.
+ - __principal point__: The projection of the camera origin, `Co`, on the image
+   plane. Its value is measured from the image's origin in pixels.
+ - __sensor__: a measurement device.
+ - __viewing direction__: the direction the camera is facing. Defined as being
+   parallel with Cz.
+
+ When looking at the resulting image and reasoning about the camera that
+ produced it, one can say that Cz points into the image, Cx is parallel with the
+ image rows, pointing to the right, and Cy is parallel with the image columns,
+ pointing down leading to language such as: "X-right", "Y-down", and "Z-forward".
+*/
 class CameraInfo final {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CameraInfo)
 
-  /// Constructor that directly sets the image size, center, and focal lengths.
-  ///
-  /// @param width The image width in pixels, must be greater than zero.
-  /// @param height The image height in pixels, must be greater than zero.
-  /// @param focal_x The focal length x in pixels.
-  /// @param focal_y The focal length y in pixels.
-  /// @param center_x The x coordinate of the image center in the pixel
-  /// coordinate system in pixels.
-  /// @param center_y The y coordinate of the image center in the pixel
-  /// coordinate system in pixels.
+  /**
+   Constructor that directly sets the image size, principal point, and focal
+   lengths.
+
+   @param width    The image width in pixels, must be greater than zero.
+   @param height   The image height in pixels, must be greater than zero.
+   @param focal_x  The _model_ "focal length" x in pixels (as documented above).
+   @param focal_y  The _model_ "focal length" y in pixels (as documented above).
+   @param center_x The x coordinate of the principal point in pixels (as
+                   documented above).
+   @param center_y The y coordinate of the principal point in pixels (as
+                   documented above).
+  */
   CameraInfo(int width, int height, double focal_x, double focal_y,
              double center_x, double center_y);
 
-  /// Constructor that sets the image size and vertical field of view `fov_y`.
-  /// We assume there is no image offset, so the image center `(center_x,`
-  /// `center_y)` is equal to `(width / 2, height / 2)`.  We also assume the
-  /// focal lengths `focal_x` and `focal_y` are identical.  The horizontal
-  /// field of view `fov_x` is calculated using the aspect ratio of the image
-  /// width and height together with the vertical field of view:
-  /// <pre>
-  ///   fov_x = 2 * atan(width / height * tan(fov_y / 2)).
-  /// </pre>
-  /// This can be derived from the equations of the focal lengths:
-  /// <pre>
-  ///   focal_x = width / 2 / tan(fov_x / 2)
-  ///   focal_y = height / 2 / tan(fov_y / 2)
-  /// </pre>
-  /// where `focal_x / focal_y = 1`.
-  ///
-  /// @param width The image width in pixels, must be greater than zero.
-  /// @param height The image height in pixels, must be greater than zero.
-  /// @param fov_y The vertical field of view.
+  /**
+   Constructs this instance from image size and vertical field of view. We
+   assume the principal point is in the center of the image;
+   `(center x, center_y)` is equal to `(width / 2.0 - 0.5, height / 2.0 - 0.5)`.
+   We also assume the focal lengths `focal_x` and `focal_y` are identical
+   (modeling a radially symmetric lens). The value is derived from field of
+   view and image size as:
+
+        focal_x = focal_y = height * 0.5 / tan(0.5 * fov_y)
+
+   @param width The image width in pixels, must be greater than zero.
+   @param height The image height in pixels, must be greater than zero.
+   @param fov_y The vertical field of view in radians.
+  */
   CameraInfo(int width, int height, double fov_y);
 
-  /// Returns the width of the image in pixels.
+  /** Returns the width of the image in pixels. */
   int width() const { return width_; }
 
-  /// Returns the height of the image in pixels.
+  /** Returns the height of the image in pixels. */
   int height() const { return height_; }
 
-  /// Returns the focal length x in pixels.
+  /** Returns the focal length x in pixels. */
   double focal_x() const { return intrinsic_matrix_(0, 0); }
 
-  /// Returns the focal length y in pixels.
+  /** Returns the focal length y in pixels. */
   double focal_y() const { return intrinsic_matrix_(1, 1); }
 
-  /// Returns the image center x value in pixels.
+  // TODO(eric.cousineau): Deprecate "center_{x,y}" and use
+  // "principal_point_{x,y}" or "pp{x,y}".
+
+  /** Returns the principal point's x coordinate in pixels. */
   double center_x() const { return intrinsic_matrix_(0, 2); }
 
-  /// Returns the image center y value in pixels.
+  /** Returns the principal point's y coordinate in pixels. */
   double center_y() const { return intrinsic_matrix_(1, 2); }
 
-  /// Returns the camera intrinsic matrix.
+  /** Returns the camera intrinsic matrix, K. */
   const Eigen::Matrix3d& intrinsic_matrix() const {
     return intrinsic_matrix_;
   }

--- a/systems/sensors/dev/rgbd_camera.h
+++ b/systems/sensors/dev/rgbd_camera.h
@@ -25,6 +25,10 @@ namespace dev {
 /** An RGB-D camera system that provides RGB, depth, and label images using
  the geometry in the geometry::dev::SceneGraph.
 
+ @warning This is an old interface, with potentially ambiguous and outdated
+ terms. Please see `RgbdSensor` and `CameraInfo` for more modern
+ terminology.
+
  @system{RgbdCamera,
     @input_port{geometry_query},
     @output_port{color_image}

--- a/systems/sensors/rgbd_sensor.cc
+++ b/systems/sensors/rgbd_sensor.cc
@@ -1,0 +1,236 @@
+#include "drake/systems/sensors/rgbd_sensor.h"
+
+#include <algorithm>
+#include <limits>
+#include <string>
+#include <utility>
+
+#include <Eigen/Dense>
+
+#include "drake/geometry/render/camera_properties.h"
+#include "drake/geometry/scene_graph.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/math/rotation_matrix.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/primitives/zero_order_hold.h"
+#include "drake/systems/rendering/pose_vector.h"
+#include "drake/systems/sensors/camera_info.h"
+#include "drake/systems/sensors/image.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+
+using Eigen::Translation3d;
+using geometry::FrameId;
+using geometry::QueryObject;
+using geometry::render::DepthCameraProperties;
+using geometry::SceneGraph;
+using math::RigidTransformd;
+using std::move;
+
+RgbdSensor::RgbdSensor(FrameId parent_id,
+                       const RigidTransformd& X_PB,
+                       const DepthCameraProperties& properties,
+                       const CameraPoses& camera_poses,
+                       bool show_window)
+    : parent_frame_id_(parent_id),
+      show_window_(show_window),
+      color_camera_info_(properties.width, properties.height, properties.fov_y),
+      depth_camera_info_(properties.width, properties.height, properties.fov_y),
+      properties_(properties),
+      X_PB_(X_PB),
+      X_BC_(camera_poses.X_BC),
+      X_BD_(camera_poses.X_BD) {
+  query_object_input_port_ = &this->DeclareAbstractInputPort(
+      "geometry_query", Value<geometry::QueryObject<double>>{});
+
+  ImageRgba8U color_image(color_camera_info_.width(),
+                          color_camera_info_.height());
+  color_image_port_ = &this->DeclareAbstractOutputPort(
+      "color_image", color_image, &RgbdSensor::CalcColorImage);
+
+  ImageDepth32F depth32(depth_camera_info_.width(),
+                        depth_camera_info_.height());
+  depth_image_32F_port_ = &this->DeclareAbstractOutputPort(
+      "depth_image_32f", depth32, &RgbdSensor::CalcDepthImage32F);
+
+  ImageDepth16U depth16(depth_camera_info_.width(),
+                        depth_camera_info_.height());
+  depth_image_16U_port_ = &this->DeclareAbstractOutputPort(
+      "depth_image_16u", depth16, &RgbdSensor::CalcDepthImage16U);
+
+  ImageLabel16I label_image(color_camera_info_.width(),
+                            color_camera_info_.height());
+  label_image_port_ = &this->DeclareAbstractOutputPort(
+      "label_image", label_image, &RgbdSensor::CalcLabelImage);
+
+  X_WB_pose_port_ = &this->DeclareVectorOutputPort(
+      "X_WB", rendering::PoseVector<double>(), &RgbdSensor::CalcX_WB);
+
+  const float kMaxValidDepth16UInMM =
+      (std::numeric_limits<uint16_t>::max() - 1) / 1000.;
+  if (properties.z_far > kMaxValidDepth16UInMM) {
+    drake::log()->warn(
+        "Specified max depth is {} > max valid depth for 16 bits {}. "
+        "depth_image_16u might not be able to capture the full depth range.",
+        properties.z_far, kMaxValidDepth16UInMM);
+  }
+}
+
+const InputPort<double>& RgbdSensor::query_object_input_port() const {
+  return *query_object_input_port_;
+}
+
+const OutputPort<double>& RgbdSensor::color_image_output_port() const {
+  return *color_image_port_;
+}
+
+const OutputPort<double>& RgbdSensor::depth_image_32F_output_port() const {
+  return *depth_image_32F_port_;
+}
+
+const OutputPort<double>& RgbdSensor::depth_image_16U_output_port() const {
+  return *depth_image_16U_port_;
+}
+
+const OutputPort<double>& RgbdSensor::label_image_output_port() const {
+  return *label_image_port_;
+}
+
+const OutputPort<double>& RgbdSensor::X_WB_output_port() const {
+  return *X_WB_pose_port_;
+}
+
+void RgbdSensor::CalcColorImage(const Context<double>& context,
+                                ImageRgba8U* color_image) const {
+  const QueryObject<double>& query_object = get_query_object(context);
+  query_object.RenderColorImage(properties_, parent_frame_id_, X_PB_ * X_BC_,
+                                show_window_, color_image);
+}
+
+void RgbdSensor::CalcDepthImage32F(const Context<double>& context,
+                                   ImageDepth32F* depth_image) const {
+  const QueryObject<double>& query_object = get_query_object(context);
+  query_object.RenderDepthImage(properties_, parent_frame_id_, X_PB_ * X_BD_,
+                                depth_image);
+}
+
+void RgbdSensor::CalcDepthImage16U(const Context<double>& context,
+                                   ImageDepth16U* depth_image) const {
+  ImageDepth32F depth32(depth_image->width(), depth_image->height());
+  CalcDepthImage32F(context, &depth32);
+  ConvertDepth32FTo16U(depth32, depth_image);
+}
+
+void RgbdSensor::CalcLabelImage(const Context<double>& context,
+                                ImageLabel16I* label_image) const {
+  const QueryObject<double>& query_object = get_query_object(context);
+  query_object.RenderLabelImage(properties_, parent_frame_id_, X_PB_ * X_BC_,
+                                show_window_, label_image);
+}
+
+void RgbdSensor::CalcX_WB(
+    const Context<double>& context,
+    rendering::PoseVector<double>* pose_vector) const {
+  // Calculates X_WB.
+  RigidTransformd X_WB;
+  if (parent_frame_id_ == SceneGraph<double>::world_frame_id()) {
+    X_WB = X_PB_;
+  } else {
+    const QueryObject<double>& query_object = get_query_object(context);
+    X_WB = query_object.X_WF(parent_frame_id_) * X_PB_;
+  }
+
+  Translation3d trans{X_WB.translation()};
+  pose_vector->set_translation(trans);
+
+  pose_vector->set_rotation(X_WB.rotation().ToQuaternion());
+}
+
+void RgbdSensor::ConvertDepth32FTo16U(const ImageDepth32F& d32,
+                                      ImageDepth16U* d16) {
+  // Convert to mm and 16bits.
+  const float kDepth16UOverflowDistance =
+      std::numeric_limits<uint16_t>::max() / 1000.;
+  for (int w = 0; w < d16->width(); w++) {
+    for (int h = 0; h < d16->height(); h++) {
+      const double dist = std::min(d32.at(w, h)[0], kDepth16UOverflowDistance);
+      d16->at(w, h)[0] = static_cast<uint16_t>(dist * 1000);
+    }
+  }
+}
+
+// Note: Ideally, this would be inlined. However, inlining this caused GCC
+// to do something weird with GeometryState such that the rgbd_sensor_test.cc
+// was unable to instantiate an GeometryStateTester that GCC recognized as a
+// friend to GeometryState.
+const geometry::QueryObject<double>& RgbdSensor::get_query_object(
+    const Context<double>& context) const {
+  return query_object_input_port().
+      Eval<geometry::QueryObject<double>>(context);
+}
+
+RgbdSensorDiscrete::RgbdSensorDiscrete(std::unique_ptr<RgbdSensor> camera,
+                                       double period, bool render_label_image)
+    : camera_(camera.get()), period_(period) {
+  const auto& color_camera_info = camera->color_camera_info();
+  const auto& depth_camera_info = camera->depth_camera_info();
+
+  DiagramBuilder<double> builder;
+  builder.AddSystem(std::move(camera));
+  query_object_port_ =
+      builder.ExportInput(camera_->query_object_input_port(), "geometry_query");
+
+  // Color image.
+  const Value<ImageRgba8U> image_color(color_camera_info.width(),
+                                       color_camera_info.height());
+  const auto* const zoh_color =
+      builder.AddSystem<ZeroOrderHold>(period_, image_color);
+  builder.Connect(camera_->color_image_output_port(),
+                  zoh_color->get_input_port());
+  output_port_color_image_ =
+      builder.ExportOutput(zoh_color->get_output_port(), "color_image");
+
+  // Depth images.
+  const Value<ImageDepth32F> image_depth_32F(depth_camera_info.width(),
+                                             depth_camera_info.height());
+  const auto* const zoh_depth_32F =
+      builder.AddSystem<ZeroOrderHold>(period_, image_depth_32F);
+  builder.Connect(camera_->depth_image_32F_output_port(),
+                  zoh_depth_32F->get_input_port());
+  output_port_depth_image_32F_ =
+      builder.ExportOutput(zoh_depth_32F->get_output_port(), "depth_image_32f");
+
+  // Depth images.
+  const Value<ImageDepth16U> image_depth_16U(depth_camera_info.width(),
+                                             depth_camera_info.height());
+  const auto* const zoh_depth_16U =
+      builder.AddSystem<ZeroOrderHold>(period_, image_depth_16U);
+  builder.Connect(camera_->depth_image_16U_output_port(),
+                  zoh_depth_16U->get_input_port());
+  output_port_depth_image_16U_ =
+      builder.ExportOutput(zoh_depth_16U->get_output_port(), "depth_image_16u");
+
+  // Label image.
+  if (render_label_image) {
+    const Value<ImageLabel16I> image_label(color_camera_info.width(),
+                                           color_camera_info.height());
+    const auto* const zoh_label =
+        builder.AddSystem<ZeroOrderHold>(period_, image_label);
+    builder.Connect(camera_->label_image_output_port(),
+                    zoh_label->get_input_port());
+    output_port_label_image_ =
+        builder.ExportOutput(zoh_label->get_output_port(), "label_image");
+  }
+
+  // No need to place a ZOH on pose output.
+  X_WB_output_port_ =
+      builder.ExportOutput(camera_->X_WB_output_port(), "X_WB");
+
+  builder.BuildInto(this);
+}
+
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/systems/sensors/rgbd_sensor.h
+++ b/systems/sensors/rgbd_sensor.h
@@ -1,0 +1,305 @@
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <Eigen/Dense>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/query_object.h"
+#include "drake/geometry/render/camera_properties.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/math/roll_pitch_yaw.h"
+#include "drake/systems/framework/diagram.h"
+#include "drake/systems/framework/leaf_system.h"
+#include "drake/systems/rendering/pose_vector.h"
+#include "drake/systems/sensors/camera_info.h"
+#include "drake/systems/sensors/image.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+
+/** A meta-sensor that houses RGB, depth, and label cameras, producing their
+ corresponding images based on the contents of the geometry::SceneGraph.
+
+ @system{RgbdSensor,
+    @input_port{geometry_query},
+    @output_port{color_image}
+    @output_port{depth_image_32f}
+    @output_port{depth_image_16u}
+    @output_port{label_image}
+    @output_port{X_WB}
+ }
+
+ The following text uses terminology and conventions from CameraInfo. Please
+ review its documentation.
+
+ This class uses the following frames:
+
+   - W - world frame
+   - C - color camera frame, used for both color and label cameras to guarantee
+     perfect registration between color and label images.
+   - D - depth camera frame
+   - B - sensor body frame. Approximately, the frame of the "physical" sensor
+     that contains the color, depth, and label cameras. The contained cameras
+     are rigidly fixed to B and X_WB is what is used to pose the sensor in the
+     world (or, alternatively, X_PB where P is some parent frame for which X_WP
+     is known).
+
+ By default, frames B, C, and D are coincident and aligned. These can be
+ changed using the `camera_poses` constructor parameter. Frames C and D are
+ always rigidly affixed to the sensor body frame B.
+
+ <!-- TODO(SeanCurtis-TRI): Relax these assumptions into more general sensors.
+ -->
+ In terms of the camera intrinsics outlined in CameraInfo, this sensor assumes
+ that each camera's principal point is in the center of the image and that the
+ focal lengths in both the x- and y-directions are equal.
+
+ Output port image formats:
+
+   - color_image: Four channels, each channel uint8_t, in the following order:
+     red, green, blue, and alpha.
+
+   - depth_image_32f: One channel, float, representing the Z value in
+     `D` in *meters*. The values 0 and infinity are reserved for out-of-range
+     depth returns (too close or too far, respectively, as defined by
+     @ref geometry::render::DepthCameraProperties "DepthCameraProperties").
+
+   - depth_image_16u: One channel, uint16_t, representing the Z value in
+     `D` in *millimeters*. The values 0 and 65535 are reserved for out-of-range
+     depth returns (too close or too far, respectively, as defined by
+     @ref geometry::render::DepthCameraProperties "DepthCameraProperties").
+     Additionally, 65535 will also be returned if the
+     depth measurement exceeds the representation range of uint16_t. Thus, the
+     maximum valid depth return is 65534mm.
+
+   - label_image: One channel, int16_t, whose value is a unique
+     @ref geometry::render::RenderLabel "RenderLabel" value aligned with the
+     color camera frame. See @ref geometry::render::RenderLabel "RenderLabel"
+     for discussion of interpreting rendered labels.
+
+ @note These depth sensor measurements differ from those of range data used by
+ laser range finders (like DepthSensor), where the depth value represents the
+ distance from the sensor origin to the object's surface.
+
+ @ingroup sensor_systems  */
+class RgbdSensor final : public LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RgbdSensor)
+
+  /** Specifies poses of cameras with respect ot the sensor base `B`.  */
+  struct CameraPoses {
+    /** Pose of color camera `C` with respect to sensor base `B`. Defaults to
+     the identity matrix.  */
+    math::RigidTransformd X_BC;
+
+    /** Pose of depth camera `D` with respect to sensor base `B`. Defaults to
+     the identity matrix.  */
+    math::RigidTransformd X_BD;
+  };
+
+  /** Constructs an %RgbdSensor whose frame `B` is rigidly affixed to the frame
+   P, indicated by `parent_id`, and with the given camera properties. The camera
+   will move as frame P moves. For a stationary camera, use the frame id from
+   SceneGraph::world_frame_id().
+
+   @param parent_id      The identifier of a parent frame `P` in
+                         geometry::SceneGraph to which this camera is rigidly
+                         affixed with pose `X_PB`.
+   @param X_PB           The pose of the camera `B` frame relative to the parent
+                         frame `P`.
+   @param properties     The properties which define this camera's intrinsics.
+                         Please note that this assumes that the color and depth
+                         cameras share the same intrinsics.
+   @param camera_poses   The poses of the color (C) and depth camera (D) frames
+                         with respect to the sensor base (B). If omitted, all
+                         three frames will be aligned and coincident.
+   @param show_window    A flag for showing a visible window. If this is false,
+                         off-screen rendering is executed. The default is false.
+   */
+  RgbdSensor(geometry::FrameId parent_id,
+             const math::RigidTransformd& X_PB,
+             const geometry::render::DepthCameraProperties& properties,
+             const CameraPoses& camera_poses = {},
+             bool show_window = false);
+
+  ~RgbdSensor() = default;
+
+  /** Returns the color sensor's info.  */
+  const CameraInfo& color_camera_info() const { return color_camera_info_; }
+
+  /** Returns the depth sensor's info.  */
+  const CameraInfo& depth_camera_info() const { return depth_camera_info_; }
+
+  /** Returns `X_BC`.  */
+  const math::RigidTransformd& X_BC() const {
+    return X_BC_;
+  }
+
+  /** Returns `X_BD`.  */
+  const math::RigidTransformd& X_BD() const {
+    return X_BD_;
+  }
+
+  /** Returns the id of the frame to which the base is affixed.  */
+  geometry::FrameId parent_frame_id() const { return parent_frame_id_; }
+
+  /** Returns the geometry::QueryObject<double>-valued input port.  */
+  const InputPort<double>& query_object_input_port() const;
+
+  /** Returns the abstract-valued output port that contains an ImageRgba8U.  */
+  const OutputPort<double>& color_image_output_port() const;
+
+  /** Returns the abstract-valued output port that contains an ImageDepth32F.
+   */
+  const OutputPort<double>& depth_image_32F_output_port() const;
+
+  /** Returns the abstract-valued output port that contains an ImageDepth16U.
+   */
+  const OutputPort<double>& depth_image_16U_output_port() const;
+
+  /** Returns the abstract-valued output port that contains an ImageLabel16I.
+   */
+  const OutputPort<double>& label_image_output_port() const;
+
+  /** Returns the abstract-valued output port that contains a RigidTransform
+    for `X_WB`.
+   */
+  const OutputPort<double>& X_WB_output_port() const;
+
+ private:
+  friend class RgbdSensorTester;
+
+  // The calculator methods for the four output ports.
+  void CalcColorImage(const Context<double>& context,
+                      ImageRgba8U* color_image) const;
+  void CalcDepthImage32F(const Context<double>& context,
+                         ImageDepth32F* depth_image) const;
+  void CalcDepthImage16U(const Context<double>& context,
+                         ImageDepth16U* depth_image) const;
+  void CalcLabelImage(const Context<double>& context,
+                      ImageLabel16I* label_image) const;
+  void CalcX_WB(const Context<double>& context,
+                rendering::PoseVector<double>* pose_vector) const;
+
+  // Convert a single channel, float depth image (with depths in meters) to a
+  // single channel, unsigned uint16_t depth image (with depths in millimeters).
+  static void ConvertDepth32FTo16U(const ImageDepth32F& d32,
+                                   ImageDepth16U* d16);
+
+  // Extract the query object from the given context (via the appropriate input
+  // port.
+  const geometry::QueryObject<double>& get_query_object(
+      const Context<double>& context) const;
+
+  const InputPort<double>* query_object_input_port_{};
+  const OutputPort<double>* color_image_port_{};
+  const OutputPort<double>* depth_image_32F_port_{};
+  const OutputPort<double>* depth_image_16U_port_{};
+  const OutputPort<double>* label_image_port_{};
+  const OutputPort<double>* X_WB_pose_port_{};
+
+  // The identifier for the parent frame `P`.
+  const geometry::FrameId parent_frame_id_;
+
+  // If true, a window will be shown for the camera.
+  const bool show_window_;
+  const CameraInfo color_camera_info_;
+  const CameraInfo depth_camera_info_;
+  const geometry::render::DepthCameraProperties properties_;
+  // The position of the camera's B frame relative to its parent frame P.
+  const math::RigidTransformd X_PB_;
+  // Camera poses.
+  const math::RigidTransformd X_BC_;
+  const math::RigidTransformd X_BD_;
+};
+
+/**
+ Wraps a continuous %RgbdSensor with a zero-order hold to create a discrete
+ sensor.
+
+ @system{%RgbdSensorDiscrete,
+    @input_port{geometry_query},
+    @output_port{color_image}
+    @output_port{depth_image_32f}
+    @output_port{depth_image_16u}
+    @output_port{label_image}
+    @output_port{X_WB}
+ }
+ */
+class RgbdSensorDiscrete final : public systems::Diagram<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RgbdSensorDiscrete);
+
+  static constexpr double kDefaultPeriod = 1. / 30;
+
+  /** Constructs a diagram containing a (non-registered) RgbdSensor that will
+   update at a given rate.
+   @param sensor               The continuous sensor used to generate periodic
+                               images.
+   @param period               Update period (sec).
+   @param render_label_image   If true, renders label image (which requires
+                               additional overhead). If false,
+                               `label_image_output_port` will raise an error if
+                               called.  */
+  RgbdSensorDiscrete(std::unique_ptr<RgbdSensor> sensor,
+                     double period = kDefaultPeriod,
+                     bool render_label_image = true);
+
+  /** Returns reference to RgbdSensor instance.  */
+  const RgbdSensor& sensor() const { return *camera_; }
+
+  /** Returns update period for discrete camera.  */
+  double period() const { return period_; }
+
+  /** @see RgbdSensor::query_object_input_port().  */
+  const InputPort<double>& query_object_input_port() const {
+    return get_input_port(query_object_port_);
+  }
+
+  /** @see RgbdSensor::color_image_output_port().  */
+  const systems::OutputPort<double>& color_image_output_port() const {
+    return get_output_port(output_port_color_image_);
+  }
+
+  /** @see RgbdSensor::depth_image_32F_output_port().  */
+  const systems::OutputPort<double>& depth_image_32F_output_port() const {
+    return get_output_port(output_port_depth_image_32F_);
+  }
+
+  /** @see RgbdSensor::depth_image_16U_output_port().  */
+  const systems::OutputPort<double>& depth_image_16U_output_port() const {
+    return get_output_port(output_port_depth_image_16U_);
+  }
+
+  /** @see RgbdSensor::label_image_output_port().  */
+  const systems::OutputPort<double>& label_image_output_port() const {
+    return get_output_port(output_port_label_image_);
+  }
+
+  /** @see RgbdSensor::base_pose_output_port().  */
+  const systems::OutputPort<double>& X_WB_output_port() const {
+    return get_output_port(X_WB_output_port_);
+  }
+
+ private:
+  RgbdSensor* const camera_{};
+  const double period_{};
+
+  int query_object_port_{-1};
+  int output_port_color_image_{-1};
+  int output_port_depth_image_32F_{-1};
+  int output_port_depth_image_16U_{-1};
+  int output_port_label_image_{-1};
+  int X_WB_output_port_{-1};
+};
+
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/systems/sensors/test/rgbd_sensor_test.cc
+++ b/systems/sensors/test/rgbd_sensor_test.cc
@@ -1,0 +1,383 @@
+#include "drake/systems/sensors/rgbd_sensor.h"
+
+#include <functional>
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/geometry/geometry_frame.h"
+#include "drake/geometry/geometry_state.h"
+#include "drake/geometry/render/camera_properties.h"
+#include "drake/geometry/scene_graph.h"
+#include "drake/geometry/test_utilities/dummy_render_engine.h"
+#include "drake/systems/framework/context.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/primitives/zero_order_hold.h"
+
+namespace drake {
+namespace geometry {
+
+// Friend class provides access to the render engine in the GeometryState. This
+// is important because we need access to the render engine in the *context*
+// which is a copy of the engine that was initially instantiated and registered
+// with SceneGraph.
+template <class T>
+class GeometryStateTester {
+ public:
+  // Extract a dummy render engine from the given `context` with the given
+  // `name`. Blindly assumes the context belongs to a SceneGraph and that
+  // the renderer with the given name *is* a DummyRenderEngine. (If no renderer
+  // with that name exists, it will simply throw.)
+  static const internal::DummyRenderEngine& GetDummyRenderEngine(
+      systems::Context<T>* context, const std::string& name) {
+    // Technically brittle, but relatively safe assumption that GeometryState
+    // is abstract state value 0.
+    auto& geo_state = context->get_mutable_state()
+        .template get_mutable_abstract_state<GeometryState<T>>(0);
+    const render::RenderEngine& engine = geo_state.GetRenderEngineOrThrow(name);
+    return dynamic_cast<const internal::DummyRenderEngine&>(engine);
+  }
+};
+
+}  // namespace geometry
+
+namespace systems {
+namespace sensors {
+
+std::ostream& operator<<(std::ostream& out, const CameraInfo& info) {
+  out << "CameraInfo:"
+      << "\n  width: " << info.width()
+      << "\n  height: " << info.height()
+      << "\n  focal_x: " << info.focal_x()
+      << "\n  focal_y: " << info.focal_y()
+      << "\n  center_x: " << info.center_x()
+      << "\n  center_y: " << info.center_y();
+  return out;
+}
+
+// Helper class for exercising private methods in RgbdSensor.
+class RgbdSensorTester {
+ public:
+  static void ConvertDepth32FTo16U(const ImageDepth32F& d32,
+                                   ImageDepth16U* d16) {
+    RgbdSensor::ConvertDepth32FTo16U(d32, d16);
+  }
+};
+
+namespace {
+
+using Eigen::AngleAxisd;
+using Eigen::Vector3d;
+using geometry::FrameId;
+using geometry::FramePoseVector;
+using geometry::GeometryFrame;
+using geometry::GeometryStateTester;
+using geometry::internal::DummyRenderEngine;
+using geometry::QueryObject;
+using geometry::render::CameraProperties;
+using geometry::render::DepthCameraProperties;
+using geometry::render::RenderEngine;
+using geometry::SceneGraph;
+using geometry::SourceId;
+using math::RigidTransformd;
+using math::RollPitchYawd;
+using std::make_unique;
+using std::move;
+using std::unique_ptr;
+using std::vector;
+using systems::Context;
+using systems::Diagram;
+using systems::DiagramBuilder;
+
+::testing::AssertionResult CompareCameraInfo(const CameraInfo& test,
+                                             const CameraInfo& expected) {
+  if (test.width() != expected.width() || test.height() != expected.height() ||
+      test.focal_x() != expected.focal_x() ||
+      test.focal_y() != expected.focal_y() ||
+      test.center_x() != expected.center_x() ||
+      test.center_y() != expected.center_y()) {
+    return ::testing::AssertionFailure()
+           << "Expected " << expected << "\n got: " << test;
+  }
+  return ::testing::AssertionSuccess();
+}
+
+class RgbdSensorTest : public ::testing::Test {
+ public:
+  RgbdSensorTest()
+      : ::testing::Test(),
+        properties_(640, 480, M_PI / 4, kRendererName, 0.1, 10) {}
+
+ protected:
+  // Creates a Diagram with a SceneGraph and RgbdSensor connected appropriately.
+  // Various components are stored in members for easy access. This should only
+  // be called once per test.
+  // make_sensor is a callback that will create the sensor. It is provided a
+  // pointer to the SceneGraph so it has the opportunity to modify the
+  // SceneGraph as it needs.
+  void MakeCameraDiagram(
+      std::function<unique_ptr<RgbdSensor>(SceneGraph<double>*)> make_sensor) {
+    ASSERT_EQ(scene_graph_, nullptr)
+        << "Only call MakeCameraDiagram() once per test";
+    DiagramBuilder<double> builder;
+    scene_graph_ = builder.AddSystem<SceneGraph<double>>();
+    scene_graph_->AddRenderer(kRendererName, make_unique<DummyRenderEngine>());
+    sensor_ = builder.AddSystem(make_sensor(scene_graph_));
+    builder.Connect(scene_graph_->get_query_output_port(),
+                    sensor_->query_object_input_port());
+    diagram_ = builder.Build();
+    context_ = diagram_->AllocateContext();
+    context_->DisableCaching();
+    scene_graph_context_ =
+        &diagram_->GetMutableSubsystemContext(*scene_graph_, context_.get());
+    sensor_context_ =
+        &diagram_->GetMutableSubsystemContext(*sensor_, context_.get());
+    // Must get the render engine instance from the context itself.
+    render_engine_ = &GeometryStateTester<double>::GetDummyRenderEngine(
+        scene_graph_context_, kRendererName);
+  }
+
+  // Confirms that the member sensor_ matches the expected properties.
+  ::testing::AssertionResult ValidateConstruction(
+      FrameId parent_id, const RigidTransformd& X_WC_expected,
+      std::function<void()> pre_render_callback = {}) const {
+    if (sensor_->parent_frame_id() != parent_id) {
+      return ::testing::AssertionFailure()
+             << "The sensor's parent id (" << sensor_->parent_frame_id()
+             << ") does not match the expected id (" << parent_id << ")";
+    }
+    ::testing::AssertionResult result = ::testing::AssertionSuccess();
+    CameraInfo expected_info(properties_.width, properties_.height,
+                             properties_.fov_y);
+    result = CompareCameraInfo(sensor_->color_camera_info(), expected_info);
+    if (!result) return result;
+    result = CompareCameraInfo(sensor_->depth_camera_info(), expected_info);
+    if (!result) return result;
+
+    // By default, frames B, C, and D are aligned and coincident.
+    EXPECT_TRUE(CompareMatrices(sensor_->X_BC().matrix(),
+                                RigidTransformd().matrix()));
+    EXPECT_TRUE(CompareMatrices(sensor_->X_BD().matrix(),
+                                RigidTransformd().matrix()));
+
+    // Confirm the pose used by the renderer is the expected X_WC pose. We do
+    // this by invoking a render (the dummy render engine will cache the last
+    // call to UpdateViewpoint()).
+    if (pre_render_callback) pre_render_callback();
+    sensor_->color_image_output_port().Eval<ImageRgba8U>(*sensor_context_);
+    EXPECT_TRUE(CompareMatrices(render_engine_->last_updated_X_WC().matrix(),
+                                X_WC_expected.matrix()));
+
+    return result;
+  }
+
+  DepthCameraProperties properties_;
+  unique_ptr<Diagram<double>> diagram_;
+  unique_ptr<Context<double>> context_;
+
+  // Convenient pointers into the diagram and context; the underlying systems
+  // are owned by the diagram and its context.
+  SceneGraph<double>* scene_graph_{};
+  RgbdSensor* sensor_{};
+  const DummyRenderEngine* render_engine_{};
+  Context<double>* sensor_context_{};
+  Context<double>* scene_graph_context_{};
+
+  static const char kRendererName[];
+};
+
+const char RgbdSensorTest::kRendererName[] = "renderer";
+
+// Confirms that port names are as documented in rgbd_sensor.h. This uses the
+// anchored constructor and assumes that the ports are the same for the
+// frame-fixed port.
+TEST_F(RgbdSensorTest, PortNames) {
+  RgbdSensor sensor(SceneGraph<double>::world_frame_id(),
+                    RigidTransformd::Identity(), properties_);
+  EXPECT_EQ(sensor.query_object_input_port().get_name(), "geometry_query");
+  EXPECT_EQ(sensor.color_image_output_port().get_name(), "color_image");
+  EXPECT_EQ(sensor.depth_image_32F_output_port().get_name(), "depth_image_32f");
+  EXPECT_EQ(sensor.depth_image_16U_output_port().get_name(), "depth_image_16u");
+  EXPECT_EQ(sensor.label_image_output_port().get_name(), "label_image");
+  EXPECT_EQ(sensor.X_WB_output_port().get_name(), "X_WB");
+}
+
+// Tests that the anchored camera reports the correct parent frame and has the
+// right pose passed to the renderer.
+TEST_F(RgbdSensorTest, ConstructAnchoredCamera) {
+  const Vector3d p_WB(1, 2, 3);
+  const RollPitchYawd rpy_WB(M_PI / 2, 0, 0);
+  const RigidTransformd X_WB(rpy_WB, p_WB);
+
+  auto make_sensor = [this, &X_WB](SceneGraph<double>*) {
+    return make_unique<RgbdSensor>(SceneGraph<double>::world_frame_id(), X_WB,
+                                   properties_);
+  };
+  MakeCameraDiagram(make_sensor);
+
+  const RigidTransformd& X_BC = sensor_->X_BC();
+  const RigidTransformd X_WC_expected = X_WB * X_BC;
+  EXPECT_TRUE(
+      ValidateConstruction(scene_graph_->world_frame_id(), X_WC_expected));
+}
+
+// Similar to the AnchoredCamera test -- but, in this case, the reported pose
+// of the camera X_WC depends on the value of the specified parent frame P.
+TEST_F(RgbdSensorTest, ConstructFrameFixedCamera) {
+  SourceId source_id;
+  const GeometryFrame frame("camera_frame");
+  const RigidTransformd X_PB(AngleAxisd(M_PI/6, Vector3d(1, 1, 1)),
+                             Vector3d(1, 2, 3));
+  const RigidTransformd X_WP(AngleAxisd(M_PI/7, Vector3d(-1, 0, 1)),
+                             Vector3d(-2, -1, -3));
+  const FramePoseVector<double> X_WPs{{frame.id(), X_WP}};
+
+  // The sensor requires a frame to be registered in order to attach to the
+  // frame.
+  auto make_sensor = [this, &source_id, &frame,
+                      &X_PB](SceneGraph<double>* graph) {
+    source_id = graph->RegisterSource("source");
+    graph->RegisterFrame(source_id, frame);
+    return make_unique<RgbdSensor>(frame.id(), X_PB, properties_);
+  };
+  MakeCameraDiagram(make_sensor);
+
+  const RigidTransformd& X_BC = sensor_->X_BC();
+  // NOTE: This *particular* factorization eliminates the need for a tolerance
+  // in the matrix comparison -- it is the factorization that is implicit in
+  // the code path for rendering.
+  const RigidTransformd X_WC_expected = X_WP * (X_PB * X_BC);
+  auto pre_render_callback = [this, &X_WPs, source_id]() {
+    scene_graph_->get_source_pose_port(source_id).FixValue(scene_graph_context_,
+                                                           X_WPs);
+  };
+  EXPECT_TRUE(
+      ValidateConstruction(frame.id(), X_WC_expected, pre_render_callback));
+}
+
+TEST_F(RgbdSensorTest, ConstructCameraWithNonTrivialOffsets) {
+  const RigidTransformd X_BC{
+        math::RotationMatrixd::MakeFromOrthonormalRows(
+            Eigen::Vector3d(0, 0, 1),
+            Eigen::Vector3d(-1, 0, 0),
+            Eigen::Vector3d(0, -1, 0)),
+        Eigen::Vector3d(0, 0.02, 0)};
+  // For uniqueness, simply invert X_BC.
+  const RigidTransformd X_BD{X_BC.inverse()};
+  const RigidTransformd X_WB;
+  const RgbdSensor sensor(
+      scene_graph_->world_frame_id(), X_WB, properties_,
+      RgbdSensor::CameraPoses{X_BC, X_BD});
+  EXPECT_TRUE(CompareMatrices(sensor.X_BC().matrix(), X_BC.matrix()));
+  EXPECT_TRUE(CompareMatrices(sensor.X_BD().matrix(), X_BD.matrix()));
+}
+
+// We don't explicitly test any of the image outputs. Most of the image outputs
+// simple wrap the corresponding QueryObject call; the only calculations they
+// do is to produce the X_PC matrix (which is implicitly tested in the
+// construction tests above). The *one* exception is the 16U depth image which
+// converts 32F to 16U. In this case, we test the conversion method directly.
+TEST_F(RgbdSensorTest, DepthImage32FTo16U) {
+  // The largest uint16_t value (unitless). Period.
+  const uint16_t kMax16 = std::numeric_limits<uint16_t>::max();
+  // The saturation depth (in mm) that will be reported.
+  const double kDepth16Saturation = kMax16 / 1000.0;
+
+  // Create a simple depth image with some representative values and their
+  // corresponding uint16 values.
+  std::array<uint16_t, 4> expected_depths;
+  ImageDepth32F depth32(1, 4);
+  // Too near.
+  *depth32.at(0, 0) = 0.0;
+  expected_depths[0] = 0;
+  // Valid and representable.
+  *depth32.at(0, 1) = kDepth16Saturation / 2;
+  expected_depths[1] = kMax16 / 2;
+  // Valid but not representable.
+  *depth32.at(0, 2) = kDepth16Saturation * 1.1;
+  expected_depths[2] = kMax16;
+  // Too far.
+  *depth32.at(0, 3) = std::numeric_limits<float>::infinity();
+  expected_depths[3] = kMax16;
+
+  // Perform conversion.
+  ImageDepth16U depth16(1, 4);
+  RgbdSensorTester::ConvertDepth32FTo16U(depth32, &depth16);
+
+  for (int c = 0; c < 4; ++c) {
+    EXPECT_EQ(*depth16.at(0, c), expected_depths[c]);
+  }
+}
+
+// Tests that the discrete sensor is properly constructed.
+GTEST_TEST(RgbdSensorDiscrete, Construction) {
+  DepthCameraProperties properties(640, 480, M_PI / 4, "render", 0.1, 10);
+  const double kPeriod = 0.1;
+
+  const bool include_render_port = true;
+  RgbdSensorDiscrete sensor(
+      make_unique<RgbdSensor>(SceneGraph<double>::world_frame_id(),
+                              RigidTransformd::Identity(), properties),
+      kPeriod, include_render_port);
+  EXPECT_EQ(sensor.query_object_input_port().get_name(), "geometry_query");
+  EXPECT_EQ(sensor.color_image_output_port().get_name(), "color_image");
+  EXPECT_EQ(sensor.depth_image_32F_output_port().get_name(), "depth_image_32f");
+  EXPECT_EQ(sensor.depth_image_16U_output_port().get_name(), "depth_image_16u");
+  EXPECT_EQ(sensor.label_image_output_port().get_name(), "label_image");
+  EXPECT_EQ(sensor.X_WB_output_port().get_name(), "X_WB");
+
+  // Confirm that the period was passed into the ZOH correctly. If the ZOH
+  // reports the expected period, we rely on it to do the right thing.
+  EXPECT_EQ(sensor.period(), kPeriod);
+}
+
+// Test that the diagram's internal architecture is correct and, likewise,
+// wired correctly.
+GTEST_TEST(RgbdSensorDiscrete, ImageHold) {
+  DepthCameraProperties properties(640, 480, M_PI / 4, "render", 0.1, 10);
+  auto sensor =
+      make_unique<RgbdSensor>(SceneGraph<double>::world_frame_id(),
+                              RigidTransformd::Identity(), properties);
+  RgbdSensor* sensor_raw = sensor.get();
+  const double kPeriod = 0.1;
+  const bool include_render_port = true;
+  RgbdSensorDiscrete discrete_sensor(move(sensor), kPeriod,
+                                     include_render_port);
+
+  // This tests very *explicit* knowledge of what the wiring should be. As such,
+  // it's a bit brittle, but this is the most efficient way to affect this test.
+  // We assume these systems are reported in the order they were added.
+  vector<const System<double>*> sub_systems = discrete_sensor.GetSystems();
+
+  // Five sub-systems: the sensor and one hold per image type.
+  ASSERT_EQ(sub_systems.size(), 5);
+  ASSERT_EQ(sub_systems[0], sensor_raw);
+
+  // For each image output port, we want to make sure it's connected to the
+  // expected ZOH and that the hold's period is kPeriod. This proves that
+  // RgbdSensorDiscrete has wired things up properly.
+  auto confirm_hold = [&sub_systems, &kPeriod, &discrete_sensor](
+                          int hold_index,
+                          const OutputPort<double>& image_port) {
+    const ZeroOrderHold<double>* zoh =
+        dynamic_cast<const ZeroOrderHold<double>*>(sub_systems[hold_index]);
+    ASSERT_NE(zoh, nullptr);
+    EXPECT_EQ(zoh->period(), kPeriod);
+    EXPECT_TRUE(
+        discrete_sensor.AreConnected(image_port, zoh->get_input_port()));
+  };
+
+  confirm_hold(1, sensor_raw->color_image_output_port());
+  confirm_hold(2, sensor_raw->depth_image_32F_output_port());
+  confirm_hold(3, sensor_raw->depth_image_16U_output_port());
+  confirm_hold(4, sensor_raw->label_image_output_port());
+
+  // TODO(SeanCurtis-TRI): Consider confirming that the exported ports map to
+  //  the expected sub-system ports.
+}
+
+}  // namespace
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
This is the modern version of the old `RgbdCamera`, made compatible with the `SceneGraph` architecture. This also includes the discrete version.

This includes modifications to the framework:

  - `Diagram`: can report if the output/input ports of two child systems are
    connected. (Used to directly unit test of `DiscreteRgbdSensor`.)
  - `ZeroOrderHold`: can report its period.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11704)
<!-- Reviewable:end -->
