### PR TITLE
Kinematic constraint autodiff2

### DIFF
--- a/multibody/inverse_kinematics/distance_constraint.cc
+++ b/multibody/inverse_kinematics/distance_constraint.cc
@@ -26,8 +26,7 @@ DistanceConstraint::DistanceConstraint(
       plant_context_double_{plant_context},
       geometry_pair_{std::move(geometry_pair)},
       plant_autodiff_{nullptr},
-      plant_context_autodiff_{nullptr},
-      use_autodiff_{false} {
+      plant_context_autodiff_{nullptr} {
   CheckPlantIsConnectedToSceneGraph(*plant_double_, *plant_context_double_);
 }
 
@@ -42,16 +41,15 @@ DistanceConstraint::DistanceConstraint(
       plant_context_double_{nullptr},
       geometry_pair_{std::move(geometry_pair)},
       plant_autodiff_{plant},
-      plant_context_autodiff_{plant_context},
-      use_autodiff_{true} {
+      plant_context_autodiff_{plant_context} {
   CheckPlantIsConnectedToSceneGraph(*plant_autodiff_, *plant_context_autodiff_);
 }
 
 template <typename T, typename S>
-void EvalGeneric(const MultibodyPlant<T>& plant,
-                 const SortedPair<geometry::GeometryId>& geometry_pair,
-                 systems::Context<T>* context,
-                 const Eigen::Ref<const VectorX<S>>& x, VectorX<S>* y) {
+void EvalDistance(const MultibodyPlant<T>& plant,
+                  const SortedPair<geometry::GeometryId>& geometry_pair,
+                  systems::Context<T>* context,
+                  const Eigen::Ref<const VectorX<S>>& x, VectorX<S>* y) {
   y->resize(1);
   internal::UpdateContextConfiguration(context, plant, x);
   const auto& query_port = plant.get_geometry_query_input_port();
@@ -98,12 +96,12 @@ void EvalGeneric(const MultibodyPlant<T>& plant,
 template <typename T>
 void DistanceConstraint::DoEvalGeneric(const Eigen::Ref<const VectorX<T>>& x,
                                        VectorX<T>* y) const {
-  if (use_autodiff_) {
-    EvalGeneric<AutoDiffXd, T>(*plant_autodiff_, geometry_pair_,
-                               plant_context_autodiff_, x, y);
+  if (use_autodiff()) {
+    EvalDistance<AutoDiffXd, T>(*plant_autodiff_, geometry_pair_,
+                                plant_context_autodiff_, x, y);
   } else {
-    EvalGeneric<double, T>(*plant_double_, geometry_pair_,
-                           plant_context_double_, x, y);
+    EvalDistance<double, T>(*plant_double_, geometry_pair_,
+                            plant_context_double_, x, y);
   }
 }
 

--- a/multibody/inverse_kinematics/distance_constraint.cc
+++ b/multibody/inverse_kinematics/distance_constraint.cc
@@ -22,43 +22,63 @@ DistanceConstraint::DistanceConstraint(
     double distance_upper)
     : solvers::Constraint(1, RefFromPtrOrThrow(plant).num_positions(),
                           Vector1d(distance_lower), Vector1d(distance_upper)),
-      plant_{RefFromPtrOrThrow(plant)},
-      plant_context_{plant_context},
-      geometry_pair_{std::move(geometry_pair)} {
-  CheckPlantIsConnectedToSceneGraph(plant_, *plant_context_);
+      plant_double_{plant},
+      plant_context_double_{plant_context},
+      geometry_pair_{std::move(geometry_pair)},
+      plant_autodiff_{nullptr},
+      plant_context_autodiff_{nullptr},
+      use_autodiff_{false} {
+  CheckPlantIsConnectedToSceneGraph(*plant_double_, *plant_context_double_);
 }
 
-template <typename T>
-void DistanceConstraint::DoEvalGeneric(const Eigen::Ref<const VectorX<T>>& x,
-                                       VectorX<T>* y) const {
-  y->resize(num_constraints());
-  internal::UpdateContextConfiguration(plant_context_, plant_, x);
-  const auto& query_port = plant_.get_geometry_query_input_port();
+DistanceConstraint::DistanceConstraint(
+    const multibody::MultibodyPlant<AutoDiffXd>* const plant,
+    SortedPair<geometry::GeometryId> geometry_pair,
+    systems::Context<AutoDiffXd>* plant_context, double distance_lower,
+    double distance_upper)
+    : solvers::Constraint(1, RefFromPtrOrThrow(plant).num_positions(),
+                          Vector1d(distance_lower), Vector1d(distance_upper)),
+      plant_double_{nullptr},
+      plant_context_double_{nullptr},
+      geometry_pair_{std::move(geometry_pair)},
+      plant_autodiff_{plant},
+      plant_context_autodiff_{plant_context},
+      use_autodiff_{true} {
+  CheckPlantIsConnectedToSceneGraph(*plant_autodiff_, *plant_context_autodiff_);
+}
+
+template <typename T, typename S>
+void EvalGeneric(const MultibodyPlant<T>& plant,
+                 const SortedPair<geometry::GeometryId>& geometry_pair,
+                 systems::Context<T>* context,
+                 const Eigen::Ref<const VectorX<S>>& x, VectorX<S>* y) {
+  y->resize(1);
+  internal::UpdateContextConfiguration(context, plant, x);
+  const auto& query_port = plant.get_geometry_query_input_port();
   const auto& query_object =
-      query_port.Eval<geometry::QueryObject<double>>(*plant_context_);
+      query_port.template Eval<geometry::QueryObject<T>>(*context);
   // TODO(hongkai.dai): call the distance for the single pair instead for all
   // pairs when SceneGraph provides the API.
-  const std::vector<geometry::SignedDistancePair<double>>
-      signed_distance_pairs =
-          query_object.ComputeSignedDistancePairwiseClosestPoints(kInf);
+  const std::vector<geometry::SignedDistancePair<T>> signed_distance_pairs =
+      query_object.ComputeSignedDistancePairwiseClosestPoints(kInf);
   bool found_pair = false;
   for (const auto& signed_distance_pair : signed_distance_pairs) {
     if (SortedPair<geometry::GeometryId>(signed_distance_pair.id_A,
                                          signed_distance_pair.id_B) ==
-        geometry_pair_) {
+        geometry_pair) {
       found_pair = true;
-      const geometry::SceneGraphInspector<double>& inspector =
+      const geometry::SceneGraphInspector<T>& inspector =
           query_object.inspector();
       const geometry::FrameId frame_A_id =
           inspector.GetFrameId(signed_distance_pair.id_A);
       const geometry::FrameId frame_B_id =
           inspector.GetFrameId(signed_distance_pair.id_B);
-      const Frame<double>& frameA =
-          plant_.GetBodyFromFrameId(frame_A_id)->body_frame();
-      const Frame<double>& frameB =
-          plant_.GetBodyFromFrameId(frame_B_id)->body_frame();
+      const Frame<T>& frameA =
+          plant.GetBodyFromFrameId(frame_A_id)->body_frame();
+      const Frame<T>& frameB =
+          plant.GetBodyFromFrameId(frame_B_id)->body_frame();
       internal::CalcDistanceDerivatives(
-          plant_, *plant_context_, frameA, frameB,
+          plant, *context, frameA, frameB,
           inspector.X_FG(signed_distance_pair.id_A) *
               signed_distance_pair.p_ACa,
           signed_distance_pair.distance, signed_distance_pair.nhat_BA_W, x,
@@ -70,14 +90,26 @@ void DistanceConstraint::DoEvalGeneric(const Eigen::Ref<const VectorX<T>>& x,
     throw std::runtime_error(
         "DistanceConstraint::DoEvalGeneric(): SceneGraph did not report the "
         "distance between the pair of geometry (" +
-        std::to_string(geometry_pair_.first().get_value()) + ", " +
-        std::to_string(geometry_pair_.second().get_value()) + ")");
+        std::to_string(geometry_pair.first().get_value()) + ", " +
+        std::to_string(geometry_pair.second().get_value()) + ")");
+  }
+}
+
+template <typename T>
+void DistanceConstraint::DoEvalGeneric(const Eigen::Ref<const VectorX<T>>& x,
+                                       VectorX<T>* y) const {
+  if (use_autodiff_) {
+    EvalGeneric<AutoDiffXd, T>(*plant_autodiff_, geometry_pair_,
+                               plant_context_autodiff_, x, y);
+  } else {
+    EvalGeneric<double, T>(*plant_double_, geometry_pair_,
+                           plant_context_double_, x, y);
   }
 }
 
 void DistanceConstraint::DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
                                 Eigen::VectorXd* y) const {
-  DoEvalGeneric<double>(x, y);
+  DoEvalGeneric(x, y);
 }
 
 void DistanceConstraint::DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,

--- a/multibody/inverse_kinematics/distance_constraint.h
+++ b/multibody/inverse_kinematics/distance_constraint.h
@@ -34,6 +34,15 @@ class DistanceConstraint : public solvers::Constraint {
                      systems::Context<double>* plant_context,
                      double distance_lower, double distance_upper);
 
+  /**
+   * Overloaded constructor. Constructs the constraint with
+   * MultibodyPlant<AutoDiffXd>.
+   */
+  DistanceConstraint(const multibody::MultibodyPlant<AutoDiffXd>* const plant,
+                     SortedPair<geometry::GeometryId> geometry_pair,
+                     systems::Context<AutoDiffXd>* plant_context,
+                     double distance_lower, double distance_upper);
+
   ~DistanceConstraint() override {}
 
  private:
@@ -53,9 +62,13 @@ class DistanceConstraint : public solvers::Constraint {
   void DoEvalGeneric(const Eigen::Ref<const VectorX<T>>& x,
                      VectorX<T>* y) const;
 
-  const multibody::MultibodyPlant<double>& plant_;
-  systems::Context<double>* const plant_context_;
+  const MultibodyPlant<double>* plant_double_;
+  systems::Context<double>* const plant_context_double_;
   SortedPair<geometry::GeometryId> geometry_pair_;
+
+  const MultibodyPlant<AutoDiffXd>* const plant_autodiff_;
+  systems::Context<AutoDiffXd>* plant_context_autodiff_;
+  const bool use_autodiff_;
 };
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/distance_constraint.h
+++ b/multibody/inverse_kinematics/distance_constraint.h
@@ -62,13 +62,14 @@ class DistanceConstraint : public solvers::Constraint {
   void DoEvalGeneric(const Eigen::Ref<const VectorX<T>>& x,
                      VectorX<T>* y) const;
 
+  bool use_autodiff() const { return plant_autodiff_; }
+
   const MultibodyPlant<double>* plant_double_;
   systems::Context<double>* const plant_context_double_;
   SortedPair<geometry::GeometryId> geometry_pair_;
 
   const MultibodyPlant<AutoDiffXd>* const plant_autodiff_;
   systems::Context<AutoDiffXd>* plant_context_autodiff_;
-  const bool use_autodiff_;
 };
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/distance_constraint_utilities.cc
+++ b/multibody/inverse_kinematics/distance_constraint_utilities.cc
@@ -5,16 +5,6 @@
 namespace drake {
 namespace multibody {
 namespace internal {
-void CalcDistanceDerivatives(const MultibodyPlant<double>&,
-                             const systems::Context<double>&,
-                             const Frame<double>&, const Frame<double>&,
-                             const Eigen::Vector3d&, double distance,
-                             const Eigen::Vector3d&,
-                             const Eigen::Ref<const AutoDiffVecXd>&,
-                             double* distance_double) {
-  *distance_double = distance;
-}
-
 void CalcDistanceDerivatives(const MultibodyPlant<double>& plant,
                              const systems::Context<double>& context,
                              const Frame<double>& frameA,
@@ -52,26 +42,25 @@ void CalcDistanceDerivatives(const MultibodyPlant<double>& plant,
       ddistance_dq * math::autoDiffToGradientMatrix(q);
 }
 
-void CheckPlantIsConnectedToSceneGraph(
-    const MultibodyPlant<double>& plant,
-    const systems::Context<double>& plant_context) {
-  if (!plant.geometry_source_is_registered()) {
-    throw std::invalid_argument(
-        "Kinematic constraint: MultibodyPlant has not registered "
-        "with a SceneGraph yet. Please refer to "
-        "AddMultibodyPlantSceneGraph on how to connect MultibodyPlant to "
-        "SceneGraph.");
-  }
-  const auto& query_port = plant.get_geometry_query_input_port();
-  if (!query_port.HasValue(plant_context)) {
-    throw std::invalid_argument(
-        "Kinematic constraint: Cannot get a valid "
-        "geometry::QueryObject. Either the plant's geometry query input port "
-        "is not properly connected to the SceneGraph's geometry query output "
-        "port, or the plant_context_ is incorrect. Please refer to "
-        "AddMultibodyPlantSceneGraph on connecting MultibodyPlant to "
-        "SceneGraph.");
-  }
+void CalcDistanceDerivatives(const MultibodyPlant<AutoDiffXd>&,
+                             const systems::Context<AutoDiffXd>&,
+                             const Frame<AutoDiffXd>&, const Frame<AutoDiffXd>&,
+                             const Vector3<AutoDiffXd>&,
+                             const AutoDiffXd& distance_autodiff,
+                             const Vector3<AutoDiffXd>&,
+                             const Eigen::Ref<const Eigen::VectorXd>&,
+                             double* distance) {
+  *distance = distance_autodiff.value();
+}
+
+void CalcDistanceDerivatives(const MultibodyPlant<double>&,
+                             const systems::Context<double>&,
+                             const Frame<double>&, const Frame<double>&,
+                             const Eigen::Vector3d&, double distance_in,
+                             const Eigen::Vector3d&,
+                             const Eigen::Ref<const VectorX<double>>&,
+                             double* distance_out) {
+  *distance_out = distance_in;
 }
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/inverse_kinematics/distance_constraint_utilities.h
+++ b/multibody/inverse_kinematics/distance_constraint_utilities.h
@@ -19,7 +19,7 @@ namespace internal {
  * signed distance field to geometry B, expressed in the world frame.
  * @param q The generalized position of the plant, it also stores the gradient
  * dq / dz, where z is some other variables.
- * @param[out] diatance_autodiff Containing the gradient of @p distance w.r.t
+ * @param[out] distance_autodiff Containing the gradient of @p distance w.r.t
  * z (the same variable as shown up in the gradient of q).
  */
 void CalcDistanceDerivatives(const MultibodyPlant<double>& plant,

--- a/multibody/inverse_kinematics/distance_constraint_utilities.h
+++ b/multibody/inverse_kinematics/distance_constraint_utilities.h
@@ -32,23 +32,57 @@ void CalcDistanceDerivatives(const MultibodyPlant<double>& plant,
                              AutoDiffXd* distance_autodiff);
 
 /**
- * This is the overloaded version of Distance for the input q of double scalar
- * type, it just copies @p distance to @p distance_double.
+ * This is the overloaded version of CalcDistanceDerivatives for plant being
+ * MultibodyPlant<AutoDiffXd> instead of MultibodyPlant<double>.
  */
-void CalcDistanceDerivatives(const MultibodyPlant<double>&,
-                             const systems::Context<double>&,
-                             const Frame<double>&, const Frame<double>&,
-                             const Eigen::Vector3d&, double distance,
-                             const Eigen::Vector3d&,
-                             const Eigen::Ref<const AutoDiffVecXd>&,
-                             double* distance_double);
+void CalcDistanceDerivatives(const MultibodyPlant<AutoDiffXd>& plant,
+                             const systems::Context<AutoDiffXd>& context,
+                             const Frame<AutoDiffXd>& frameA,
+                             const Frame<AutoDiffXd>& frameB,
+                             const Vector3<AutoDiffXd>& p_ACa,
+                             const AutoDiffXd& distance_autodiff,
+                             const Vector3<AutoDiffXd>& nhat_BA_W,
+                             const Eigen::Ref<const Eigen::VectorXd>& q,
+                             double* distance);
+
+/**
+ * This is the overloaded version of CalcDistanceDerivatives for the input q of
+ * double scalar type, it just copies @p distance_in to @p distance_out.
+ */
+template <typename T>
+void CalcDistanceDerivatives(const MultibodyPlant<T>&,
+                             const systems::Context<T>&, const Frame<T>&,
+                             const Frame<T>&, const Vector3<T>&, T distance_in,
+                             const Vector3<T>&,
+                             const Eigen::Ref<const VectorX<T>>&,
+                             T* distance_out) {
+  *distance_out = distance_in;
+}
 
 /**
  * Check if the plant has registered its geometry with the SceneGraph.
  */
+template <typename T>
 void CheckPlantIsConnectedToSceneGraph(
-    const MultibodyPlant<double>& plant,
-    const systems::Context<double>& plant_context);
+    const MultibodyPlant<T>& plant, const systems::Context<T>& plant_context) {
+  if (!plant.geometry_source_is_registered()) {
+    throw std::invalid_argument(
+        "Kinematic constraint: MultibodyPlant has not registered "
+        "with a SceneGraph yet. Please refer to "
+        "AddMultibodyPlantSceneGraph on how to connect MultibodyPlant to "
+        "SceneGraph.");
+  }
+  const auto& query_port = plant.get_geometry_query_input_port();
+  if (!query_port.HasValue(plant_context)) {
+    throw std::invalid_argument(
+        "Kinematic constraint: Cannot get a valid "
+        "geometry::QueryObject. Either the plant's geometry query input port "
+        "is not properly connected to the SceneGraph's geometry query output "
+        "port, or the plant_context_ is incorrect. Please refer to "
+        "AddMultibodyPlantSceneGraph on connecting MultibodyPlant to "
+        "SceneGraph.");
+  }
+}
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/minimum_distance_constraint.cc
+++ b/multibody/inverse_kinematics/minimum_distance_constraint.cc
@@ -110,8 +110,7 @@ MinimumDistanceConstraint::MinimumDistanceConstraint(
       plant_double_{plant},
       plant_context_double_{plant_context},
       plant_autodiff_{nullptr},
-      plant_context_autodiff_{nullptr},
-      use_autodiff_{false} {
+      plant_context_autodiff_{nullptr} {
   Initialize(*plant_double_, plant_context_double_, minimum_distance,
              influence_distance_offset, penalty_function);
 }
@@ -126,8 +125,7 @@ MinimumDistanceConstraint::MinimumDistanceConstraint(
       plant_double_{nullptr},
       plant_context_double_{nullptr},
       plant_autodiff_{plant},
-      plant_context_autodiff_{plant_context},
-      use_autodiff_{true} {
+      plant_context_autodiff_{plant_context} {
   Initialize(*plant_autodiff_, plant_context_autodiff_, minimum_distance,
              influence_distance_offset, penalty_function);
 }

--- a/multibody/inverse_kinematics/minimum_distance_constraint.cc
+++ b/multibody/inverse_kinematics/minimum_distance_constraint.cc
@@ -12,16 +12,59 @@ namespace drake {
 namespace multibody {
 using internal::RefFromPtrOrThrow;
 
-MinimumDistanceConstraint::MinimumDistanceConstraint(
-    const multibody::MultibodyPlant<double>* const plant,
-    double minimum_distance, systems::Context<double>* plant_context,
-    MinimumDistancePenaltyFunction penalty_function,
-    double influence_distance_offset)
-    : solvers::Constraint(1, RefFromPtrOrThrow(plant).num_positions(),
-                          Vector1d(0), Vector1d(0)),
-      plant_{RefFromPtrOrThrow(plant)},
-      plant_context_{plant_context} {
-  CheckPlantIsConnectedToSceneGraph(plant_, *plant_context_);
+template <typename T, typename S>
+VectorX<S> Distances(const MultibodyPlant<T>& plant,
+                     systems::Context<T>* context,
+                     const Eigen::Ref<const VectorX<S>>& q,
+                     double influence_distance) {
+  internal::UpdateContextConfiguration(context, plant, q);
+  const auto& query_port = plant.get_geometry_query_input_port();
+  if (!query_port.HasValue(*context)) {
+    throw std::invalid_argument(
+        "MinimumDistanceConstraint: Cannot get a valid geometry::QueryObject. "
+        "Either the plant geometry_query_input_port() is not properly "
+        "connected to the SceneGraph's output port, or the plant_context_ is "
+        "incorrect. Please refer to AddMultibodyPlantSceneGraph on connecting "
+        "MultibodyPlant to SceneGraph.");
+  }
+  const auto& query_object =
+      query_port.template Eval<geometry::QueryObject<T>>(*context);
+
+  const std::vector<geometry::SignedDistancePair<T>> signed_distance_pairs =
+      query_object.ComputeSignedDistancePairwiseClosestPoints(
+          influence_distance);
+  VectorX<S> distances(signed_distance_pairs.size());
+  int distance_count{0};
+  for (const auto& signed_distance_pair : signed_distance_pairs) {
+    if (signed_distance_pair.distance < influence_distance) {
+      const geometry::SceneGraphInspector<T>& inspector =
+          query_object.inspector();
+      const geometry::FrameId frame_A_id =
+          inspector.GetFrameId(signed_distance_pair.id_A);
+      const geometry::FrameId frame_B_id =
+          inspector.GetFrameId(signed_distance_pair.id_B);
+      const Frame<T>& frameA =
+          plant.GetBodyFromFrameId(frame_A_id)->body_frame();
+      const Frame<T>& frameB =
+          plant.GetBodyFromFrameId(frame_B_id)->body_frame();
+      internal::CalcDistanceDerivatives(
+          plant, *context, frameA, frameB,
+          inspector.X_FG(signed_distance_pair.id_A) *
+              signed_distance_pair.p_ACa,
+          signed_distance_pair.distance, signed_distance_pair.nhat_BA_W, q,
+          &distances(distance_count++));
+    }
+  }
+  distances.resize(distance_count);
+  return distances;
+}
+
+template <typename T>
+void MinimumDistanceConstraint::Initialize(
+    const MultibodyPlant<T>& plant, systems::Context<T>* plant_context,
+    double minimum_distance, double influence_distance_offset,
+    MinimumDistancePenaltyFunction penalty_function) {
+  CheckPlantIsConnectedToSceneGraph(plant, *plant_context);
   if (!std::isfinite(influence_distance_offset)) {
     throw std::invalid_argument(
         "MinimumDistanceConstraint: influence_distance_offset must be finite.");
@@ -31,22 +74,24 @@ MinimumDistanceConstraint::MinimumDistanceConstraint(
         "MinimumDistanceConstraint: influence_distance_offset must be "
         "positive.");
   }
-  const auto& query_port = plant_.get_geometry_query_input_port();
+  const auto& query_port = plant.get_geometry_query_input_port();
   // Maximum number of SignedDistancePairs returned by calls to
   // ComputeSignedDistancePairwiseClosestPoints().
   const int num_collision_candidates =
-      query_port.Eval<geometry::QueryObject<double>>(*plant_context_)
+      query_port.template Eval<geometry::QueryObject<T>>(*plant_context)
           .inspector()
           .GetCollisionCandidates()
           .size();
   minimum_value_constraint_ = std::make_unique<solvers::MinimumValueConstraint>(
       this->num_vars(), minimum_distance, influence_distance_offset,
       num_collision_candidates,
-      [this](const auto& x, double influence_distance) {
-        return this->Distances<AutoDiffXd>(x, influence_distance);
+      [&plant, plant_context](const auto& x, double influence_distance) {
+        return Distances<T, AutoDiffXd>(plant, plant_context, x,
+                                        influence_distance);
       },
-      [this](const auto& x, double influence_distance) {
-        return this->Distances<double>(x, influence_distance);
+      [&plant, plant_context](const auto& x, double influence_distance) {
+        return Distances<T, double>(plant, plant_context, x,
+                                    influence_distance);
       });
   this->set_bounds(minimum_value_constraint_->lower_bound(),
                    minimum_value_constraint_->upper_bound());
@@ -55,50 +100,36 @@ MinimumDistanceConstraint::MinimumDistanceConstraint(
   }
 }
 
-template <typename T>
-VectorX<T> MinimumDistanceConstraint::Distances(
-    const Eigen::Ref<const VectorX<T>>& q, double influence_distance) const {
-  internal::UpdateContextConfiguration(plant_context_, plant_, q);
-  const auto& query_port = plant_.get_geometry_query_input_port();
-  if (!query_port.HasValue(*plant_context_)) {
-    throw std::invalid_argument(
-        "MinimumDistanceConstraint: Cannot get a valid geometry::QueryObject. "
-        "Either the plant geometry_query_input_port() is not properly "
-        "connected to the SceneGraph's output port, or the plant_context_ is "
-        "incorrect. Please refer to AddMultibodyPlantSceneGraph on connecting "
-        "MultibodyPlant to SceneGraph.");
-  }
-  const auto& query_object =
-      query_port.Eval<geometry::QueryObject<double>>(*plant_context_);
+MinimumDistanceConstraint::MinimumDistanceConstraint(
+    const multibody::MultibodyPlant<double>* const plant,
+    double minimum_distance, systems::Context<double>* plant_context,
+    MinimumDistancePenaltyFunction penalty_function,
+    double influence_distance_offset)
+    : solvers::Constraint(1, RefFromPtrOrThrow(plant).num_positions(),
+                          Vector1d(0), Vector1d(0)),
+      plant_double_{plant},
+      plant_context_double_{plant_context},
+      plant_autodiff_{nullptr},
+      plant_context_autodiff_{nullptr},
+      use_autodiff_{false} {
+  Initialize(*plant_double_, plant_context_double_, minimum_distance,
+             influence_distance_offset, penalty_function);
+}
 
-  const std::vector<geometry::SignedDistancePair<double>>
-      signed_distance_pairs =
-          query_object.ComputeSignedDistancePairwiseClosestPoints(
-              influence_distance);
-  VectorX<T> distances(signed_distance_pairs.size());
-  int distance_count{0};
-  for (const auto& signed_distance_pair : signed_distance_pairs) {
-    if (signed_distance_pair.distance < influence_distance) {
-      const geometry::SceneGraphInspector<double>& inspector =
-          query_object.inspector();
-      const geometry::FrameId frame_A_id =
-          inspector.GetFrameId(signed_distance_pair.id_A);
-      const geometry::FrameId frame_B_id =
-          inspector.GetFrameId(signed_distance_pair.id_B);
-      const Frame<double>& frameA =
-          plant_.GetBodyFromFrameId(frame_A_id)->body_frame();
-      const Frame<double>& frameB =
-          plant_.GetBodyFromFrameId(frame_B_id)->body_frame();
-      internal::CalcDistanceDerivatives(
-          plant_, *plant_context_, frameA, frameB,
-          inspector.X_FG(signed_distance_pair.id_A) *
-              signed_distance_pair.p_ACa,
-          signed_distance_pair.distance, signed_distance_pair.nhat_BA_W, q,
-          &distances(distance_count++));
-    }
-  }
-  distances.resize(distance_count);
-  return distances;
+MinimumDistanceConstraint::MinimumDistanceConstraint(
+    const multibody::MultibodyPlant<AutoDiffXd>* const plant,
+    double minimum_distance, systems::Context<AutoDiffXd>* plant_context,
+    MinimumDistancePenaltyFunction penalty_function,
+    double influence_distance_offset)
+    : solvers::Constraint(1, RefFromPtrOrThrow(plant).num_positions(),
+                          Vector1d(0), Vector1d(0)),
+      plant_double_{nullptr},
+      plant_context_double_{nullptr},
+      plant_autodiff_{plant},
+      plant_context_autodiff_{plant_context},
+      use_autodiff_{true} {
+  Initialize(*plant_autodiff_, plant_context_autodiff_, minimum_distance,
+             influence_distance_offset, penalty_function);
 }
 
 template <typename T>

--- a/multibody/inverse_kinematics/minimum_distance_constraint.h
+++ b/multibody/inverse_kinematics/minimum_distance_constraint.h
@@ -142,7 +142,6 @@ class MinimumDistanceConstraint final : public solvers::Constraint {
   std::unique_ptr<solvers::MinimumValueConstraint> minimum_value_constraint_;
   const multibody::MultibodyPlant<AutoDiffXd>* const plant_autodiff_;
   systems::Context<AutoDiffXd>* const plant_context_autodiff_;
-  const bool use_autodiff_;
 };
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/minimum_distance_constraint.h
+++ b/multibody/inverse_kinematics/minimum_distance_constraint.h
@@ -92,8 +92,8 @@ class MinimumDistanceConstraint final : public solvers::Constraint {
       double influence_distance_offset = 1);
 
   /**
-   * Overloaded constructor.
-   * Constructs the constraint using MultibodyPlant<AutoDiffXd>.
+   Overloaded constructor.
+   Constructs the constraint using MultibodyPlant<AutoDiffXd>.
    */
   MinimumDistanceConstraint(
       const multibody::MultibodyPlant<AutoDiffXd>* const plant,

--- a/multibody/inverse_kinematics/minimum_distance_constraint.h
+++ b/multibody/inverse_kinematics/minimum_distance_constraint.h
@@ -91,6 +91,16 @@ class MinimumDistanceConstraint final : public solvers::Constraint {
       MinimumDistancePenaltyFunction penalty_function = {},
       double influence_distance_offset = 1);
 
+  /**
+   * Overloaded constructor.
+   * Constructs the constraint using MultibodyPlant<AutoDiffXd>.
+   */
+  MinimumDistanceConstraint(
+      const multibody::MultibodyPlant<AutoDiffXd>* const plant,
+      double minimum_distance, systems::Context<AutoDiffXd>* plant_context,
+      MinimumDistancePenaltyFunction penalty_function = {},
+      double influence_distance_offset = 1);
+
   ~MinimumDistanceConstraint() override {}
 
   /** Getter for the minimum distance. */
@@ -122,12 +132,17 @@ class MinimumDistanceConstraint final : public solvers::Constraint {
                      VectorX<T>* y) const;
 
   template <typename T>
-  VectorX<T> Distances(const Eigen::Ref<const VectorX<T>>& x,
-                       double influence_distance) const;
+  void Initialize(const MultibodyPlant<T>& plant,
+                  systems::Context<T>* plant_context, double minimum_distance,
+                  double influence_distance_offset,
+                  MinimumDistancePenaltyFunction penalty_function);
 
-  const multibody::MultibodyPlant<double>& plant_;
-  systems::Context<double>* const plant_context_;
+  const multibody::MultibodyPlant<double>* const plant_double_;
+  systems::Context<double>* const plant_context_double_;
   std::unique_ptr<solvers::MinimumValueConstraint> minimum_value_constraint_;
+  const multibody::MultibodyPlant<AutoDiffXd>* const plant_autodiff_;
+  systems::Context<AutoDiffXd>* const plant_context_autodiff_;
+  const bool use_autodiff_;
 };
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/orientation_constraint.cc
+++ b/multibody/inverse_kinematics/orientation_constraint.cc
@@ -9,18 +9,21 @@ using drake::multibody::internal::UpdateContextConfiguration;
 namespace drake {
 namespace multibody {
 OrientationConstraint::OrientationConstraint(
-    const MultibodyPlant<double>* const plant,
-    const Frame<double>& frameAbar, const math::RotationMatrix<double>& R_AbarA,
-    const Frame<double>& frameBbar, const math::RotationMatrix<double>& R_BbarB,
-    double theta_bound, systems::Context<double>* context)
+    const MultibodyPlant<double>* const plant, const Frame<double>& frameAbar,
+    const math::RotationMatrix<double>& R_AbarA, const Frame<double>& frameBbar,
+    const math::RotationMatrix<double>& R_BbarB, double theta_bound,
+    systems::Context<double>* context)
     : solvers::Constraint(1, RefFromPtrOrThrow(plant).num_positions(),
                           Vector1d(2 * std::cos(theta_bound) + 1), Vector1d(3)),
-      plant_{RefFromPtrOrThrow(plant)},
+      plant_double_{plant},
       frameAbar_index_{frameAbar.index()},
       frameBbar_index_{frameBbar.index()},
       R_AbarA_{R_AbarA},
       R_BbarB_{R_BbarB},
-      context_(context) {
+      context_double_(context),
+      plant_autodiff_{nullptr},
+      context_autodiff_{nullptr},
+      use_autodiff_{false} {
   if (context == nullptr) throw std::invalid_argument("context is nullptr.");
   if (theta_bound < 0) {
     throw std::invalid_argument(
@@ -28,16 +31,48 @@ OrientationConstraint::OrientationConstraint(
   }
 }
 
-void OrientationConstraint::DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
-                                   Eigen::VectorXd* y) const {
-  // TODO(avalenzu): Re-work to avoid round-trip through AutoDiffXd (#10205).
-  AutoDiffVecXd y_t;
-  Eval(math::initializeAutoDiff(x), &y_t);
-  *y = math::autoDiffToValueMatrix(y_t);
+OrientationConstraint::OrientationConstraint(
+    const MultibodyPlant<AutoDiffXd>* const plant,
+    const Frame<AutoDiffXd>& frameAbar,
+    const math::RotationMatrix<double>& R_AbarA,
+    const Frame<AutoDiffXd>& frameBbar,
+    const math::RotationMatrix<double>& R_BbarB, double theta_bound,
+    systems::Context<AutoDiffXd>* context)
+    : solvers::Constraint(1, RefFromPtrOrThrow(plant).num_positions(),
+                          Vector1d(2 * std::cos(theta_bound) + 1), Vector1d(3)),
+      plant_double_{nullptr},
+      frameAbar_index_{frameAbar.index()},
+      frameBbar_index_{frameBbar.index()},
+      R_AbarA_{R_AbarA},
+      R_BbarB_{R_BbarB},
+      context_double_(nullptr),
+      plant_autodiff_{plant},
+      context_autodiff_{context},
+      use_autodiff_{true} {
+  if (context == nullptr) throw std::invalid_argument("context is nullptr.");
+  if (theta_bound < 0) {
+    throw std::invalid_argument(
+        "OrientationConstraint: theta_bound should be non-negative.\n");
+  }
+}
+template <typename T, typename S>
+void EvalConstraintGradient(const MultibodyPlant<T>&,
+                            const systems::Context<T>&, const Frame<T>&,
+                            const Frame<T>&,
+                            const math::RotationMatrix<double>&,
+                            const Matrix3<T>& R_AB, const Vector3<T>&,
+                            const Eigen::Ref<const VectorX<S>>&,
+                            VectorX<S>* y) {
+  (*y)(0) = R_AB.trace();
 }
 
-void OrientationConstraint::DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
-                                   AutoDiffVecXd* y) const {
+template <>
+void EvalConstraintGradient<double, AutoDiffXd>(
+    const MultibodyPlant<double>& plant,
+    const systems::Context<double>& context, const Frame<double>& frameAbar,
+    const Frame<double>& frameBbar, const math::RotationMatrix<double>& R_AbarA,
+    const Matrix3<double>& R_AB, const Vector3<double>& r_AB,
+    const Eigen::Ref<const AutoDiffVecXd>& x, AutoDiffVecXd* y) {
   // The constraint function is
   //  g(q) = tr(R_AB(q)).
   // To derive the Jacobian of g, ∂g/∂q, we first differentiate
@@ -61,28 +96,61 @@ void OrientationConstraint::DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
   // By the chain rule, ġ = ∂g/∂q q̇. Comparing this with the previous equation,
   // we see that
   //   ∂g/∂q = r_ABᵀ Jq_w_AB.
-  y->resize(1);
-  UpdateContextConfiguration(context_, plant_, math::autoDiffToValueMatrix(x));
-  const Frame<double>& frameAbar = plant_.get_frame(frameAbar_index_);
-  const Frame<double>& frameBbar = plant_.get_frame(frameBbar_index_);
-  //
-  const Matrix3<double> R_AbarBbar =
-      plant_.CalcRelativeTransform(*context_, frameAbar, frameBbar).linear();
-  const Matrix3<double> R_AB =
-      R_AbarA_.inverse().matrix() * R_AbarBbar * R_BbarB_.matrix();
-  Eigen::MatrixXd Jq_V_AbarBbar(6, plant_.num_positions());
-  plant_.CalcJacobianSpatialVelocity(
-      *context_, JacobianWrtVariable::kQDot, frameBbar,
+  Eigen::MatrixXd Jq_V_AbarBbar(6, plant.num_positions());
+  plant.CalcJacobianSpatialVelocity(
+      context, JacobianWrtVariable::kQDot, frameBbar,
       Eigen::Vector3d::Zero() /* p_BQ */, frameAbar, frameAbar, &Jq_V_AbarBbar);
   // Since we're only concerned with the rotational portion,
   // Jq_w_AB = Jq_w_AbarBbar_A.
   const Eigen::MatrixXd Jq_w_AB =
-      R_AbarA_.inverse().matrix() * Jq_V_AbarBbar.topRows<3>();
-  const Vector3<double> r_AB{R_AB(1, 2) - R_AB(2, 1), R_AB(2, 0) - R_AB(0, 2),
-                             R_AB(0, 1) - R_AB(1, 0)};
+      R_AbarA.inverse().matrix() * Jq_V_AbarBbar.topRows<3>();
   *y = math::initializeAutoDiffGivenGradientMatrix(
       Vector1d(R_AB.trace()),
       r_AB.transpose() * Jq_w_AB * math::autoDiffToGradientMatrix(x));
+}
+
+template <typename T, typename S>
+void DoEvalGeneric(const MultibodyPlant<T>& plant, systems::Context<T>* context,
+                   FrameIndex frameAbar_index, FrameIndex frameBbar_index,
+                   const math::RotationMatrix<double>& R_AbarA,
+                   const math::RotationMatrix<double>& R_BbarB,
+                   const Eigen::Ref<const VectorX<S>>& x, VectorX<S>* y) {
+  y->resize(1);
+  UpdateContextConfiguration(context, plant, x);
+  const Frame<T>& frameAbar = plant.get_frame(frameAbar_index);
+  const Frame<T>& frameBbar = plant.get_frame(frameBbar_index);
+
+  const Matrix3<T> R_AbarBbar =
+      plant.CalcRelativeTransform(*context, frameAbar, frameBbar).linear();
+  const Matrix3<T> R_AB =
+      R_AbarA.inverse().matrix() * R_AbarBbar * R_BbarB.matrix();
+  const Vector3<T> r_AB{R_AB(1, 2) - R_AB(2, 1), R_AB(2, 0) - R_AB(0, 2),
+                        R_AB(0, 1) - R_AB(1, 0)};
+  EvalConstraintGradient(plant, *context, frameAbar, frameBbar, R_AbarA, R_AB,
+                         r_AB, x, y);
+}
+
+void OrientationConstraint::DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
+                                   Eigen::VectorXd* y) const {
+  if (use_autodiff_) {
+    AutoDiffVecXd y_t;
+    Eval(math::initializeAutoDiff(x), &y_t);
+    *y = math::autoDiffToValueMatrix(y_t);
+  } else {
+    DoEvalGeneric(*plant_double_, context_double_, frameAbar_index_,
+                  frameBbar_index_, R_AbarA_, R_BbarB_, x, y);
+  }
+}
+
+void OrientationConstraint::DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
+                                   AutoDiffVecXd* y) const {
+  if (use_autodiff_) {
+    DoEvalGeneric(*plant_autodiff_, context_autodiff_, frameAbar_index_,
+                  frameBbar_index_, R_AbarA_, R_BbarB_, x, y);
+  } else {
+    DoEvalGeneric(*plant_double_, context_double_, frameAbar_index_,
+                  frameBbar_index_, R_AbarA_, R_BbarB_, x, y);
+  }
 }
 
 }  // namespace multibody

--- a/multibody/inverse_kinematics/orientation_constraint.h
+++ b/multibody/inverse_kinematics/orientation_constraint.h
@@ -64,6 +64,18 @@ class OrientationConstraint : public solvers::Constraint {
       const math::RotationMatrix<double>& R_BbarB, double theta_bound,
       systems::Context<double>* context);
 
+  /**
+   * Overloaded constructor.
+   * Constructs the constraint using MultibodyPlant<AutoDiffXd>
+   */
+  OrientationConstraint(const MultibodyPlant<AutoDiffXd>* const plant,
+                        const Frame<AutoDiffXd>& frameAbar,
+                        const math::RotationMatrix<double>& R_AbarA,
+                        const Frame<AutoDiffXd>& frameBbar,
+                        const math::RotationMatrix<double>& R_BbarB,
+                        double theta_bound,
+                        systems::Context<AutoDiffXd>* context);
+
   ~OrientationConstraint() override {}
 
  private:
@@ -80,12 +92,16 @@ class OrientationConstraint : public solvers::Constraint {
         "variables.");
   }
 
-  const MultibodyPlant<double>& plant_;
+  const MultibodyPlant<double>* const plant_double_;
   const FrameIndex frameAbar_index_;
   const FrameIndex frameBbar_index_;
   const math::RotationMatrix<double> R_AbarA_;
   const math::RotationMatrix<double> R_BbarB_;
-  systems::Context<double>* const context_;
+  systems::Context<double>* const context_double_;
+
+  const MultibodyPlant<AutoDiffXd>* const plant_autodiff_;
+  systems::Context<AutoDiffXd>* context_autodiff_;
+  bool use_autodiff_;
 };
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/orientation_constraint.h
+++ b/multibody/inverse_kinematics/orientation_constraint.h
@@ -92,6 +92,8 @@ class OrientationConstraint : public solvers::Constraint {
         "variables.");
   }
 
+  bool use_autodiff() const { return plant_autodiff_; }
+
   const MultibodyPlant<double>* const plant_double_;
   const FrameIndex frameAbar_index_;
   const FrameIndex frameBbar_index_;
@@ -101,7 +103,6 @@ class OrientationConstraint : public solvers::Constraint {
 
   const MultibodyPlant<AutoDiffXd>* const plant_autodiff_;
   systems::Context<AutoDiffXd>* context_autodiff_;
-  bool use_autodiff_;
 };
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/test/distance_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/distance_constraint_test.cc
@@ -66,8 +66,11 @@ TEST_F(TwoFreeSpheresTest, TestEval) {
     dq(i, 0) = std::sin(i + 1);
     dq(i, 1) = 2 * i - 1;
   }
+  /* tolerance for checking numerical gradient vs analytical gradient. The
+   * numerical gradient is only accurate up to 5E-6 */
+  const double gradient_tol = 5E-6;
   TestKinematicConstraintEval(constraint, constraint_from_autodiff, q, dq,
-                              5E-6);
+                              gradient_tol);
 }
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/test/distance_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/distance_constraint_test.cc
@@ -9,21 +9,23 @@ namespace multibody {
 using solvers::test::CheckConstraintEvalNonsymbolic;
 
 TEST_F(TwoFreeSpheresTest, Constructor) {
-  const SortedPair<geometry::GeometryId> geometry_pair(sphere1_geometry_id_,
-                                                       sphere2_geometry_id_);
-  const DistanceConstraint dut(plant_double_, geometry_pair,
-                               plant_context_double_, 0.1, 2);
+  const SortedPair<geometry::GeometryId> geometry_pair_double(
+      GetSphereGeometryId(*plant_double_, sphere1_index_),
+      GetSphereGeometryId(*plant_double_, sphere2_index_));
+  const DistanceConstraint constraint(plant_double_, geometry_pair_double,
+                                      plant_context_double_, 0.1, 2);
 
-  EXPECT_EQ(dut.num_vars(), plant_double_->num_positions());
-  EXPECT_TRUE(CompareMatrices(dut.lower_bound(), Vector1d(0.1)));
-  EXPECT_TRUE(CompareMatrices(dut.upper_bound(), Vector1d(2)));
+  EXPECT_EQ(constraint.num_vars(), plant_double_->num_positions());
+  EXPECT_TRUE(CompareMatrices(constraint.lower_bound(), Vector1d(0.1)));
+  EXPECT_TRUE(CompareMatrices(constraint.upper_bound(), Vector1d(2)));
 }
 
 TEST_F(TwoFreeSpheresTest, TestEval) {
-  const SortedPair<geometry::GeometryId> geometry_pair(sphere1_geometry_id_,
-                                                       sphere2_geometry_id_);
-  const DistanceConstraint dut(plant_double_, geometry_pair,
-                               plant_context_double_, 0.1, 2);
+  const SortedPair<geometry::GeometryId> geometry_pair_double(
+      GetSphereGeometryId(*plant_double_, sphere1_index_),
+      GetSphereGeometryId(*plant_double_, sphere2_index_));
+  const DistanceConstraint constraint(plant_double_, geometry_pair_double,
+                                      plant_context_double_, 0.1, 2);
 
   Eigen::Matrix<double, 14, 1> q;
   // Set q to arbitrary value.
@@ -31,7 +33,7 @@ TEST_F(TwoFreeSpheresTest, TestEval) {
       0.5;
 
   Eigen::VectorXd y;
-  dut.Eval(q, &y);
+  constraint.Eval(q, &y);
 
   plant_double_->SetPositions(plant_context_double_, q);
   const math::RigidTransformd X_WB1 = plant_double_->CalcRelativeTransform(
@@ -49,7 +51,23 @@ TEST_F(TwoFreeSpheresTest, TestEval) {
                       1E-12 /* tolerance is chosen as about 1E4 * eps*/));
 
   Eigen::Matrix<AutoDiffXd, 14, 1> q_autodiff = math::initializeAutoDiff(q);
-  CheckConstraintEvalNonsymbolic(dut, q_autodiff, 1E-12);
+  CheckConstraintEvalNonsymbolic(constraint, q_autodiff, 1E-12);
+
+  // Now check if constraint constructed from MBP<ADS> gives the same result
+  // as that from MBP<double>
+  const SortedPair<geometry::GeometryId> geometry_pair_autodiff(
+      GetSphereGeometryId(*plant_autodiff_, sphere1_index_),
+      GetSphereGeometryId(*plant_autodiff_, sphere2_index_));
+  const DistanceConstraint constraint_from_autodiff(
+      plant_autodiff_, geometry_pair_autodiff, plant_context_autodiff_, 0.1, 2);
+  // Set dq to arbitrary values.
+  Eigen::Matrix<double, 14, 2> dq;
+  for (int i = 0; i < 14; ++i) {
+    dq(i, 0) = std::sin(i + 1);
+    dq(i, 1) = 2 * i - 1;
+  }
+  TestKinematicConstraintEval(constraint, constraint_from_autodiff, q, dq,
+                              5E-6);
 }
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.cc
+++ b/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.cc
@@ -131,11 +131,6 @@ TwoFreeSpheresTest::TwoFreeSpheresTest() {
   diagram_context_autodiff_ = diagram_autodiff_->CreateDefaultContext();
   plant_context_autodiff_ = &(diagram_autodiff_->GetMutableSubsystemContext(
       *plant_autodiff_, diagram_context_autodiff_.get()));
-
-  sphere1_geometry_id_ = plant_double_->GetCollisionGeometriesForBody(
-      plant_double_->get_frame(sphere1_index_).body())[0];
-  sphere2_geometry_id_ = plant_double_->GetCollisionGeometriesForBody(
-      plant_double_->get_frame(sphere2_index_).body())[0];
 }
 
 template <typename T>

--- a/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h
+++ b/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h
@@ -104,6 +104,13 @@ class TwoFreeSpheresTest : public ::testing::Test {
  public:
   TwoFreeSpheresTest();
 
+  template <typename T>
+  geometry::GeometryId GetSphereGeometryId(const MultibodyPlant<T>& plant,
+                                           FrameIndex sphere_index) const {
+    return plant.GetCollisionGeometriesForBody(
+        plant.get_frame(sphere_index).body())[0];
+  }
+
  protected:
   double radius1_{0.1};
   double radius2_{0.2};
@@ -116,9 +123,6 @@ class TwoFreeSpheresTest : public ::testing::Test {
 
   FrameIndex sphere1_index_;
   FrameIndex sphere2_index_;
-
-  geometry::GeometryId sphere1_geometry_id_;
-  geometry::GeometryId sphere2_geometry_id_;
 
   // The pose of sphere 1's collision geometry in sphere 1's body frame.
   math::RigidTransformd X_B1S1_;

--- a/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
@@ -305,8 +305,11 @@ TEST_F(BoxSphereTest, Test) {
       dq(i, 0) = std::sin(i + 1);
       dq(i, 1) = 2 * i - 1;
     }
+    /* tolerance for checking numerical gradient vs analytical gradient. The
+     * numerical gradient is only accurate up to 5E-6 */
+    const double gradient_tol = 5E-6;
     TestKinematicConstraintEval(constraint, constraint_from_autodiff, q, dq,
-                                5E-6);
+                                gradient_tol);
   }
 }
 }  // namespace multibody

--- a/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
@@ -293,6 +293,20 @@ TEST_F(BoxSphereTest, Test) {
         Eigen::MatrixXd::Identity(kNumPositionsForTwoFreeBodies,
                                   kNumPositionsForTwoFreeBodies),
         1E-12, box_size_, radius_);
+
+    // Now check if constraint constructed from MBP<ADS> gives the same result
+    // as that from MBP<double>
+    const MinimumDistanceConstraint constraint_from_autodiff(
+        plant_autodiff_, minimum_distance, plant_context_autodiff_,
+        penalty_function);
+    // Set dq to arbitrary values.
+    Eigen::Matrix<double, 14, 2> dq;
+    for (int i = 0; i < 14; ++i) {
+      dq(i, 0) = std::sin(i + 1);
+      dq(i, 1) = 2 * i - 1;
+    }
+    TestKinematicConstraintEval(constraint, constraint_from_autodiff, q, dq,
+                                5E-6);
   }
 }
 }  // namespace multibody

--- a/multibody/inverse_kinematics/test/orientation_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/orientation_constraint_test.cc
@@ -91,8 +91,11 @@ TEST_F(IiwaKinematicConstraintTest, OrientationConstraint) {
     dq(i, 0) = i * 2 + 1;
     dq(i, 1) = std::sin(i + 0.2);
   }
+  /* tolerance for checking numerical gradient vs analytical gradient. The
+   * numerical gradient is only accurate up to 2E-6 */
+  const double gradient_tol = 2E-6;
   TestKinematicConstraintEval(*constraint, constraint_from_autodiff, q, dq,
-                              2E-6);
+                              gradient_tol);
 }
 
 TEST_F(TwoFreeBodiesConstraintTest, OrientationConstraint) {

--- a/multibody/inverse_kinematics/test/orientation_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/orientation_constraint_test.cc
@@ -27,8 +27,10 @@ AutoDiffVecXd EvalOrientationConstraintAutoDiff(
 
 TEST_F(IiwaKinematicConstraintTest, OrientationConstraint) {
   const double angle_bound{0.1 * M_PI};
-  const Frame<double>& frameAbar = plant_->GetFrameByName("iiwa_link_7");
-  const Frame<double>& frameBbar = plant_->GetFrameByName("iiwa_link_3");
+  const auto frameAbar_index = plant_->GetFrameByName("iiwa_link_7").index();
+  const auto frameBbar_index = plant_->GetFrameByName("iiwa_link_3").index();
+  const Frame<double>& frameAbar = plant_->get_frame(frameAbar_index);
+  const Frame<double>& frameBbar = plant_->get_frame(frameBbar_index);
   const math::RotationMatrix<double> R_AbarA(Eigen::AngleAxisd(
       0.2 * M_PI, Eigen::Vector3d(0.2, 0.4, -0.5).normalized()));
   const math::RotationMatrix<double> R_BbarB(Eigen::AngleAxisd(
@@ -76,6 +78,21 @@ TEST_F(IiwaKinematicConstraintTest, OrientationConstraint) {
       plant_autodiff_->GetFrameByName(frameAbar.name()), R_AbarA,
       plant_autodiff_->GetFrameByName(frameBbar.name()), R_BbarB);
   CompareAutoDiffVectors(y_autodiff, y_autodiff_expected, 1E-12);
+
+  // Checks if the constraint constructed from MBP<ADS> gives the same result
+  // as from MBP<double>.
+  const OrientationConstraint constraint_from_autodiff(
+      plant_autodiff_.get(), plant_autodiff_->get_frame(frameAbar_index),
+      R_AbarA, plant_autodiff_->get_frame(frameBbar_index), R_BbarB,
+      angle_bound, plant_context_autodiff_.get());
+  // Set dq to arbitrary value.
+  Eigen::Matrix<double, 7, 2> dq;
+  for (int i = 0; i < 7; ++i) {
+    dq(i, 0) = i * 2 + 1;
+    dq(i, 1) = std::sin(i + 0.2);
+  }
+  TestKinematicConstraintEval(*constraint, constraint_from_autodiff, q, dq,
+                              2E-6);
 }
 
 TEST_F(TwoFreeBodiesConstraintTest, OrientationConstraint) {


### PR DESCRIPTION
A follow-up on PR #11669 , now OrientationConstraint, DistanceConstraint and MinimumDistanceConstraint can be constructed from MBP<ADS>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11709)
<!-- Reviewable:end -->
