### PR TITLE
Implements HydroelasticEngine

### DIFF
--- a/multibody/hydroelastics/BUILD.bazel
+++ b/multibody/hydroelastics/BUILD.bazel
@@ -14,6 +14,9 @@ drake_cc_package_library(
     name = "hydroelastics",
     deps = [
         ":contact_surface_from_level_set",
+        ":hydroelastic_engine",
+        ":hydroelastic_field",
+        ":hydroelastic_field_sphere",
         ":level_set_field",
     ],
 )
@@ -33,6 +36,53 @@ drake_cc_library(
     ],
 )
 
+drake_cc_library(
+    name = "hydroelastic_engine",
+    srcs = [
+        "hydroelastic_engine.cc",
+    ],
+    hdrs = [
+        "hydroelastic_engine.h",
+    ],
+    deps = [
+        ":contact_surface_from_level_set",
+        ":hydroelastic_field",
+        ":hydroelastic_field_sphere",
+        ":level_set_field",
+        "//common:essential",
+        "//geometry:scene_graph",
+    ],
+)
+
+drake_cc_library(
+    name = "hydroelastic_field",
+    hdrs = [
+        "hydroelastic_field.h",
+    ],
+    deps = [
+        "//common:essential",
+        "//geometry/proximity:mesh_field",
+    ],
+)
+
+drake_cc_library(
+    name = "hydroelastic_field_sphere",
+    hdrs = [
+        "hydroelastic_field_sphere.h",
+    ],
+    deps = [
+        ":hydroelastic_field",
+        "//common:essential",
+        "//geometry/proximity:make_unit_sphere_mesh",
+    ],
+)
+
+drake_cc_library(
+    name = "level_set_field",
+    hdrs = ["level_set_field.h"],
+    deps = ["//common:essential"],
+)
+
 drake_cc_googletest(
     name = "contact_surface_from_level_set_test",
     deps = [
@@ -44,10 +94,20 @@ drake_cc_googletest(
     ],
 )
 
-drake_cc_library(
-    name = "level_set_field",
-    hdrs = ["level_set_field.h"],
-    deps = ["//common"],
+drake_cc_googletest(
+    name = "hydroelastic_engine_test",
+    data = [
+        "test/sphere_vs_plane.sdf",
+    ],
+    deps = [
+        ":hydroelastic_engine",
+        "//common:find_resource",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+        "//math:geometric_transform",
+        "//multibody/parsing",
+        "//multibody/plant",
+    ],
 )
 
 add_lint_tests()

--- a/multibody/hydroelastics/hydroelastic_engine.cc
+++ b/multibody/hydroelastics/hydroelastic_engine.cc
@@ -1,0 +1,251 @@
+#include "drake/multibody/hydroelastics/hydroelastic_engine.h"
+
+#include <limits>
+#include <memory>
+#include <utility>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_assert.h"
+#include "drake/common/text_logging.h"
+#include "drake/geometry/shape_specification.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/multibody/hydroelastics/contact_surface_from_level_set.h"
+#include "drake/multibody/hydroelastics/hydroelastic_field_sphere.h"
+
+using drake::geometry::Box;
+using drake::geometry::ContactSurface;
+using drake::geometry::Convex;
+using drake::geometry::Cylinder;
+using drake::geometry::GeometryId;
+using drake::geometry::HalfSpace;
+using drake::geometry::Mesh;
+using drake::geometry::QueryObject;
+using drake::geometry::Shape;
+using drake::geometry::Sphere;
+using drake::geometry::SurfaceMesh;
+using drake::math::RigidTransform;
+
+namespace drake {
+namespace multibody {
+namespace hydroelastics {
+namespace internal {
+
+template <typename T>
+HydroelasticGeometry<T>::HydroelasticGeometry(
+    std::unique_ptr<HydroelasticField<T>> mesh_field)
+    : mesh_field_(std::move(mesh_field)) {}
+
+template <typename T>
+HydroelasticGeometry<T>::HydroelasticGeometry(
+    std::unique_ptr<LevelSetField<T>> level_set)
+    : level_set_(std::move(level_set)) {}
+
+template <typename T>
+void HydroelasticEngine<T>::MakeModels(
+    const geometry::SceneGraphInspector<T>& inspector) {
+  // Only reify geometries with proximity roles.
+  for (const geometry::GeometryId geometry_id : inspector.all_geometry_ids()) {
+    if (const geometry::ProximityProperties* properties =
+            inspector.GetProximityProperties(geometry_id)) {
+      const Shape& shape = inspector.GetShape(geometry_id);
+      const double elastic_modulus =
+          properties->template GetPropertyOrDefault<double>(
+              "hydroelastics", "elastic modulus",
+              std::numeric_limits<double>::infinity());
+      GeometryImplementationData specs{geometry_id, elastic_modulus};
+      shape.Reify(this, &specs);
+    }
+  }
+
+  // Mark the model data as initialized so that we don't perform this step on
+  // the next call to ComputeContactSurfaces().
+  model_data_.models_are_initialized_ = true;
+}
+
+template <typename T>
+int HydroelasticEngine<T>::num_models() const {
+  return static_cast<int>(model_data_.geometry_id_to_model_.size());
+}
+
+template <typename T>
+const HydroelasticGeometry<T>* HydroelasticEngine<T>::get_model(
+    geometry::GeometryId id) const {
+  auto it = model_data_.geometry_id_to_model_.find(id);
+  if (it != model_data_.geometry_id_to_model_.end()) return it->second.get();
+  return nullptr;
+}
+
+template <typename T>
+std::vector<ContactSurface<T>> HydroelasticEngine<T>::ComputeContactSurfaces(
+    const geometry::QueryObject<T>& query_object) const {
+  const std::vector<SortedPair<GeometryId>>& geometry_pairs =
+      query_object.FindCollisionCandidates();
+
+  std::vector<ContactSurface<T>> all_contact_surfaces;
+  for (const auto& pair : geometry_pairs) {
+    GeometryId id_M = pair.first();
+    GeometryId id_N = pair.second();
+    const HydroelasticGeometry<T>* model_M = get_model(id_M);
+    const HydroelasticGeometry<T>* model_N = get_model(id_N);
+
+    // Skip contact surface computation if these ids do not have a hydrostatic
+    // model.
+    if (!model_M || !model_N) {
+      throw std::runtime_error(
+          "HydroelasticEngine. Unsupported geometries possibly in contact. "
+          "You can remove the unsupported geometries, replace them with "
+          "supported geometry, or filter collisions on them.");
+    }
+
+    // Thus far we only support rigid vs. soft.
+    if (model_M->is_soft() == model_N->is_soft()) {
+      throw std::runtime_error(
+          "HydroelasticEngine. The current implementation of the "
+          "hydroelastic model only supports soft vs. rigid contact.");
+    }
+    const RigidTransform<T>& X_WM = query_object.X_WG(id_M);
+    const RigidTransform<T>& X_WN = query_object.X_WG(id_N);
+
+    // Pose of the soft model frame S in the rigid model frame R.
+    // N.B. For a given state, SceneGraph broadphase reports are guaranteed to
+    // always be in the same order that is, id_M < id_N.
+    // Therefore, even if we swap the id's below so that id_S (id_R) always
+    // corresponds to the soft (rigid) geometry, the order still is guaranteed
+    // to be the same on successive calls.
+    const RigidTransform<T> X_NM = X_WN.inverse() * X_WM;
+    const RigidTransform<T> X_RS = model_M->is_soft() ? X_NM : X_NM.inverse();
+    const GeometryId id_S = model_M->is_soft() ? id_M : id_N;
+    const GeometryId id_R = model_M->is_soft() ? id_N : id_M;
+    const HydroelasticGeometry<T>& model_S =
+        model_M->is_soft() ? *model_M : *model_N;
+    const HydroelasticGeometry<T>& model_R =
+        model_M->is_soft() ? *model_N : *model_M;
+
+    optional<ContactSurface<T>> surface =
+        CalcContactSurface(id_S, model_S, id_R, model_R, X_RS);
+    if (surface) all_contact_surfaces.emplace_back(std::move(*surface));
+  }
+
+  return all_contact_surfaces;
+}
+
+template <typename T>
+optional<ContactSurface<T>> HydroelasticEngine<T>::CalcContactSurface(
+    GeometryId id_S, const HydroelasticGeometry<T>& soft_model_S,
+    GeometryId id_R, const HydroelasticGeometry<T>& rigid_model_R,
+    const RigidTransform<T>& X_RS) const {
+  DRAKE_DEMAND(soft_model_S.is_soft());
+  DRAKE_DEMAND(!rigid_model_R.is_soft());
+  const HydroelasticField<T>& soft_field_S = soft_model_S.hydroelastic_field();
+  std::vector<T> e_s_surface;
+  std::vector<Vector3<T>> grad_level_set_R_surface;
+  std::unique_ptr<SurfaceMesh<T>> surface_R = CalcZeroLevelSetInMeshDomain(
+      soft_field_S.volume_mesh(), rigid_model_R.level_set(), X_RS,
+      soft_field_S.scalar_field().values(), &e_s_surface,
+      &grad_level_set_R_surface);
+  if (surface_R->num_vertices() == 0) return nullopt;
+  // Compute pressure field.
+  for (T& e_s : e_s_surface) e_s *= soft_model_S.elastic_modulus();
+
+  auto e_s = std::make_unique<geometry::SurfaceMeshFieldLinear<T, T>>(
+      "e_MN", std::move(e_s_surface), surface_R.get());
+  auto grad_level_set_R =
+      std::make_unique<geometry::SurfaceMeshFieldLinear<Vector3<T>, T>>(
+          "grad_h_MN_M", std::move(grad_level_set_R_surface), surface_R.get());
+  // Surface and gradients are measured and expressed in the rigid frame R.
+  // In consistency with ContactSurface's contract, the first id must belong
+  // to the geometry associated with the frame in which quantities are
+  // expressed, in this case id_R.
+  ContactSurface<T> contact_surface(id_R, id_S, std::move(surface_R),
+                                    std::move(e_s),
+                                    std::move(grad_level_set_R));
+  // ContactSurface's contract is that id_M < id_N. We make sure this is the
+  // case by swapping if needed.
+  // TODO(amcastro-tri): Update to pass X_SR to ContactSurface's constructor
+  // once ContactSurface takes care of the swapping at construction.
+  if (id_S < id_R) {
+    contact_surface.SwapMAndN(X_RS.inverse());
+  }
+  return contact_surface;
+}
+
+template <typename T>
+void HydroelasticEngine<T>::ImplementGeometry(const Sphere& sphere,
+                                              void* user_data) {
+  const GeometryImplementationData& specs =
+      *reinterpret_cast<GeometryImplementationData*>(user_data);
+  const double elastic_modulus = specs.elastic_modulus;
+  if (elastic_modulus == std::numeric_limits<double>::infinity()) {
+    drake::log()->warn(
+        "HydroelasticEngine. The current hydroelastic model implementation "
+        "does not support rigid spheres. Geometry ignored.");
+  }
+  // We arbitrarily choose the refinement level so that we have 512
+  // tetrahedron in the tessellation of the sphere. This provides a reasonable
+  // tessellation of the sphere with a coarse mesh.
+  // TODO(amcastro-tri): Make this a user setable parameter.
+  const int refinement_level = 2;
+  auto sphere_field =
+      MakeSphereHydroelasticField<T>(refinement_level, sphere.get_radius());
+  auto model =
+      std::make_unique<HydroelasticGeometry<T>>(std::move(sphere_field));
+  model->set_elastic_modulus(elastic_modulus);
+
+  model_data_.geometry_id_to_model_[specs.id] = std::move(model);
+}
+
+template <typename T>
+void HydroelasticEngine<T>::ImplementGeometry(const HalfSpace&,
+                                              void* user_data) {
+  const GeometryImplementationData& specs =
+      *reinterpret_cast<GeometryImplementationData*>(user_data);
+  const double elastic_modulus = specs.elastic_modulus;
+  if (elastic_modulus != std::numeric_limits<double>::infinity()) {
+    drake::log()->warn(
+        "HydroelasticEngine. The current hydroelastic model implementation "
+        "does not support soft half-spaces. Geometry ignored.");
+  }
+  auto level_set = std::make_unique<LevelSetField<T>>(
+      [](const Vector3<T>& p) { return p[2]; },
+      [](const Vector3<T>&) { return Vector3<double>::UnitZ(); });
+  model_data_.geometry_id_to_model_[specs.id] =
+      std::make_unique<HydroelasticGeometry<T>>(std::move(level_set));
+}
+
+// The following overrides are no-ops given that currently HydroelasticEngine
+// does not support these geometries.
+template <typename T>
+void HydroelasticEngine<T>::ImplementGeometry(const Cylinder&, void*) {
+  drake::log()->warn(
+      "HydroelasticEngine. The current hydroelastic model implementation "
+      "does not support cylinder geometries. Geometry ignored.");
+}
+
+template <typename T>
+void HydroelasticEngine<T>::ImplementGeometry(const Box&, void*) {
+  drake::log()->warn(
+      "HydroelasticEngine. The current hydroelastic model implementation "
+      "does not support box geometries. Geometry ignored.");
+}
+
+template <typename T>
+void HydroelasticEngine<T>::ImplementGeometry(const Mesh&, void*) {
+  drake::log()->warn(
+      "HydroelasticEngine. The current hydroelastic model implementation "
+      "does not support mesh geometries. Geometry ignored.");
+}
+
+template <typename T>
+void HydroelasticEngine<T>::ImplementGeometry(const Convex&, void*) {
+  drake::log()->warn(
+      "HydroelasticEngine. The current hydroelastic model implementation "
+      "does not support convex geometries. Geometry ignored.");
+}
+
+}  // namespace internal
+}  // namespace hydroelastics
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::hydroelastics::internal::HydroelasticEngine)

--- a/multibody/hydroelastics/hydroelastic_engine.h
+++ b/multibody/hydroelastics/hydroelastic_engine.h
@@ -1,0 +1,186 @@
+#pragma once
+
+#include <limits>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include "drake/common/drake_optional.h"
+#include "drake/common/eigen_types.h"
+#include "drake/geometry/proximity/volume_mesh.h"
+#include "drake/geometry/query_object.h"
+#include "drake/geometry/query_results/contact_surface.h"
+#include "drake/multibody/hydroelastics/hydroelastic_field.h"
+#include "drake/multibody/hydroelastics/level_set_field.h"
+
+namespace drake {
+namespace multibody {
+namespace hydroelastics {
+namespace internal {
+
+/// This class provides the underlying computational representation for each
+/// geometry in the model.
+template <typename T>
+class HydroelasticGeometry {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(HydroelasticGeometry)
+
+  /// Creates a soft model from a given %HydroelasticField object.
+  explicit HydroelasticGeometry(
+      std::unique_ptr<HydroelasticField<T>> mesh_field);
+
+  /// Constructor for a rigid model with its geometry represented by the
+  /// zero-level of a level set function.
+  explicit HydroelasticGeometry(std::unique_ptr<LevelSetField<T>> level_set);
+
+  /// Returns `true` iff the underlying model represents a soft object.
+  bool is_soft() const {
+    // There must be only one representation.
+    DRAKE_ASSERT((mesh_field_ != nullptr) != (level_set_ != nullptr));
+    return mesh_field_ != nullptr;
+  }
+
+  /// Returns a reference to the underlying HydroelasticField object.
+  /// It aborts if the model is not soft.
+  const HydroelasticField<T>& hydroelastic_field() const {
+    DRAKE_DEMAND(is_soft());
+    return *mesh_field_;
+  }
+
+  /// Returns the underlying LevelSetField object.
+  /// It aborts if the model is not rigid.
+  const LevelSetField<T>& level_set() const {
+    DRAKE_DEMAND(!is_soft());
+    return *level_set_;
+  }
+
+  /// Returns the modulus of elasticity for `this` model.
+  /// Iff infinity, the model is considered to be rigid.
+  double elastic_modulus() const { return elastic_modulus_; }
+
+  /// Sets the modulus of elasticity for `this` model.
+  /// If infinity, the model is considered to be rigid.
+  /// @throws std::exception if the geometry is rigid.
+  /// @throws std::exception if `elastic_modulus` is not strictly positive.
+  /// @throws std::exception if `elastic_modulus` is infinity.
+  void set_elastic_modulus(double elastic_modulus) {
+    DRAKE_THROW_UNLESS(is_soft());
+    DRAKE_THROW_UNLESS(elastic_modulus > 0);
+    DRAKE_THROW_UNLESS(elastic_modulus !=
+                       std::numeric_limits<double>::infinity());
+    elastic_modulus_ = elastic_modulus;
+  }
+
+ private:
+  // Model is rigid by default.
+  double elastic_modulus_{std::numeric_limits<double>::infinity()};
+  std::unique_ptr<HydroelasticField<T>> mesh_field_;
+  std::unique_ptr<LevelSetField<T>> level_set_;
+};
+
+/// The underlying engine to perform the geometric computations needed by the
+/// hydroelastic model described in:
+/// [Elandt, 2019]  R. Elandt, E. Drumwright, M. Sherman, and A. Ruina.
+/// A pressure field model for fast, robust approximation of net contact force
+/// and moment between nominally rigid objects. Proc. IEEE/RSJ Intl. Conf. on
+/// Intelligent Robots and Systems (IROS), 2019.
+///
+/// This engine:
+///  - Creates the internal representation of the geometric models as
+///    HydroelasticGeometry instances. This creation takes place on the first
+///    context-based query.
+///  - Owns the HydroelasticGeometry instances.
+///  - Provides API to perform hydroelastic contact specific queries.
+///
+/// @warning
+/// Currently %HydroelasticEngine only provides support for hydroelastic contact
+/// specific queries between soft spheres and rigid half spaces. The engine will
+/// throw an exception if two unsupported geometries are detected to possibly be
+/// in contact during the broadphase.
+///
+/// Instantiated templates for the following kinds of T's are provided:
+///
+/// - double
+/// - AutoDiffXd
+///
+/// They are already available to link against in the containing library.
+/// No other values for T are currently supported.
+template <typename T>
+class HydroelasticEngine final : public geometry::ShapeReifier {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(HydroelasticEngine)
+
+  HydroelasticEngine() = default;
+
+  ~HydroelasticEngine() = default;
+
+  /// This method builds the underlying computational representation as needed
+  /// for the hydroelastic model for each geometry specified in `inspector`.
+  /// As outlined in the class's documentation, %HydroelasticEngine ignores
+  /// geometries that are not supported. Therefore, models for unsupported
+  /// geometries are not instantiated and num_models() might differ from the
+  /// number of collision geometries in `inspector`.
+  /// Physical properties will be obtained from the
+  /// `geometry::ProximityProperties` for each geometry. Hydroelastic model
+  /// relevant properties are expected to be within a group named
+  /// "hydroelastics". The value of the "elastic modulus" is assumed to be
+  /// infinity, rigid object, if not provided.
+  void MakeModels(const geometry::SceneGraphInspector<T>& inspector);
+
+  /// Returns the number of underlying HydroelasticGeometry models created on
+  /// the call to MakeModels().
+  int num_models() const;
+
+  /// Returns the underlying HydroelasticGeometry for the given geometry
+  /// identified by its `id` or `nullptr` if the engine did not create a
+  /// hydroelastic model for this geometry.
+  const HydroelasticGeometry<T>* get_model(geometry::GeometryId id) const;
+
+  /// For a given state of `query_object`, this method computes the contact
+  /// surfaces for all geometries in contact.
+  /// @warning Unsupported geometries are ignored unless the broadphase pass
+  /// detects that they are possibly in contact. In this case an exception is
+  /// thrown.
+  std::vector<geometry::ContactSurface<T>> ComputeContactSurfaces(
+      const geometry::QueryObject<T>& query_object) const;
+
+ private:
+  // This struct stores additional data passed to ImplementGeometry() during
+  // the reification process.
+  struct GeometryImplementationData {
+    geometry::GeometryId id;
+    double elastic_modulus;
+  };
+
+  // This struct holds the engines's data, created by the call to MakeModels().
+  struct ModelData {
+    bool models_are_initialized_{false};
+    std::unordered_map<geometry::GeometryId,
+                       std::unique_ptr<HydroelasticGeometry<T>>>
+        geometry_id_to_model_;
+  };
+
+  // Helper method to compute the contact surface betwen a soft model S and a
+  // rigid model R with a relative pose X_RS.
+  // Returns nullopt if soft_model_S and rigid_model_R do not intersect.
+  optional<geometry::ContactSurface<T>> CalcContactSurface(
+      geometry::GeometryId id_S, const HydroelasticGeometry<T>& soft_model_S,
+      geometry::GeometryId id_R, const HydroelasticGeometry<T>& rigid_model_R,
+      const math::RigidTransform<T>& X_RS) const;
+
+  // Implementation of ShapeReifier interface
+  void ImplementGeometry(const geometry::Sphere& sphere,
+                         void* user_data) override;
+  void ImplementGeometry(const geometry::HalfSpace&, void* user_data) override;
+  void ImplementGeometry(const geometry::Cylinder&, void*) override;
+  void ImplementGeometry(const geometry::Box&, void*) override;
+  void ImplementGeometry(const geometry::Mesh&, void*) override;
+  void ImplementGeometry(const geometry::Convex&, void*) override;
+
+  ModelData model_data_;
+};
+
+}  // namespace internal
+}  // namespace hydroelastics
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/hydroelastics/hydroelastic_field.h
+++ b/multibody/hydroelastics/hydroelastic_field.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/geometry/proximity/volume_mesh.h"
+#include "drake/geometry/proximity/volume_mesh_field.h"
+
+namespace drake {
+namespace multibody {
+namespace hydroelastics {
+namespace internal {
+
+/// This class stores the tetrahedral mesh, scalar, and vector fields for the
+/// hydroelastic model.
+template <typename T>
+class HydroelasticField {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(HydroelasticField)
+
+  /// Constructor of a HydroelasticField.
+  /// @param[in] mesh_M
+  ///   The tetrahedral mesh representation of the geometry, with position
+  ///   vectors measured and expressed in the frame M of the model.
+  /// @param[in] e_m
+  ///   The volumetric scalar field of the hydroelastic model.
+  /// @param[in] grad_e_m_M
+  ///   The gradient of the scalar field e_m, expressed in the frame M of the
+  ///   mesh.
+  HydroelasticField(
+      std::unique_ptr<geometry::VolumeMesh<T>> mesh_M,
+      std::unique_ptr<geometry::VolumeMeshFieldLinear<T, T>> e_m,
+      std::unique_ptr<geometry::VolumeMeshFieldLinear<Vector3<T>, T>>
+          grad_e_m_M)
+      : mesh_M_(std::move(mesh_M)),
+        e_m_(std::move(e_m)),
+        grad_e_m_M_(std::move(grad_e_m_M)) {}
+
+  const geometry::VolumeMesh<T>& volume_mesh() const { return *mesh_M_; }
+
+  const geometry::VolumeMeshFieldLinear<T, T>& scalar_field() const {
+    return *e_m_;
+  }
+
+  // TODO(amcastro-tri): when needed, add accessor:
+  // const VolumeMeshFieldLinear<Vector3<T>, T>& gradient_field() const;
+
+ private:
+  /** The volume mesh of M. */
+  std::unique_ptr<geometry::VolumeMesh<T>> mesh_M_;
+  /** Represents the scalar field eₘ on the surface mesh. */
+  std::unique_ptr<geometry::VolumeMeshFieldLinear<T, T>> e_m_;
+  /** Represents the vector field ∇eₘ on the surface mesh, expressed in M's
+    frame */
+  std::unique_ptr<geometry::VolumeMeshFieldLinear<Vector3<T>, T>> grad_e_m_M_;
+};
+
+}  // namespace internal
+}  // namespace hydroelastics
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/hydroelastics/hydroelastic_field_sphere.h
+++ b/multibody/hydroelastics/hydroelastic_field_sphere.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "drake/geometry/proximity/make_unit_sphere_mesh.h"
+#include "drake/multibody/hydroelastics/hydroelastic_field.h"
+
+namespace drake {
+namespace multibody {
+namespace hydroelastics {
+namespace internal {
+
+/// Creates a HydroelasticField for a sphere of a given radius.
+/// The input parameter `refinement_level`, ℓ ∈ ℕ₀, controls the resolution of
+/// the mesh generated. The resulting number of tetrahedra nₜ can
+/// be predicted according to: nₜ = 8ˡ⁺¹. A characteristic tetrahedron length
+/// can be estimated with `h  = R / (ℓ + 1)`, with R the sphere radius.
+/// Even though the dimensionless hydroelastic strain field is arbitrary, we
+/// construct it to satisfy a number of properties:
+///  1. The field ε is zero at the boundary and increases towards the interior.
+///  2. The field ε and its gradient ∇ε are continuous in the domain of the
+///     sphere.
+///  3. The radial gradient at the boundary of the sphere is
+///     dε/dr(r = R) = -1 / R, with R the radius of the sphere, so that if the
+///     field was linear, then the maximum strain ε = 1 would occur at the
+///     center of the sphere.
+///
+/// We then choose the simplest functional form that can satisfy these
+/// requirements; a quadratic function of the radius, ε(r) = 0.5 [1 - (r / R)²].
+template <typename T>
+std::unique_ptr<HydroelasticField<T>> MakeSphereHydroelasticField(
+    int refinement_level, double sphere_radius) {
+  geometry::VolumeMesh<T> unit_sphere_mesh =
+      geometry::internal::MakeUnitSphereMesh<T>(refinement_level);
+
+  // Scale the unit sphere to have the desired radius.
+  std::vector<geometry::VolumeElement> tetrahedra =
+      unit_sphere_mesh.tetrahedra();
+  std::vector<geometry::VolumeVertex<T>> vertices;
+  vertices.reserve(unit_sphere_mesh.num_vertices());
+  for (const auto& v : unit_sphere_mesh.vertices()) {
+    const Vector3<T> scaled_v = sphere_radius * v.r_MV();
+    vertices.emplace_back(scaled_v);
+  }
+  auto mesh = std::make_unique<geometry::VolumeMesh<T>>(std::move(tetrahedra),
+                                                        std::move(vertices));
+
+  // Analytic pressure field and gradient.
+  std::vector<T> e_m_values(mesh->vertices().size());
+  std::vector<Vector3<T>> grad_e_m_values(mesh->vertices().size());
+  const double sphere_radius_squared = sphere_radius * sphere_radius;
+  for (geometry::VolumeVertexIndex v(0); v < mesh->num_vertices(); ++v) {
+    const Vector3<T>& p_MV = mesh->vertex(v).r_MV();
+    const T radius_squared = p_MV.squaredNorm();
+    // x is the dimensionless radius squared.
+    const T x = radius_squared / sphere_radius_squared;
+    // The dimensionless strain field ε.
+    e_m_values[v] = 0.5 * (1.0 - x);
+
+    // with r(v⃗) = ‖v⃗‖₂:
+    //   ε(v⃗) = 0.5[1-(r(v⃗)/R)²]
+    //   ∇ε(v⃗) = dε/dr⋅v̂ = -v / R²
+    grad_e_m_values[v] = -p_MV / sphere_radius_squared;
+  }
+  auto e_m = std::make_unique<geometry::VolumeMeshFieldLinear<T, T>>(
+      "Sphere Pressure Field", std::move(e_m_values), mesh.get());
+  auto grad_e_m =
+      std::make_unique<geometry::VolumeMeshFieldLinear<Vector3<T>, T>>(
+          "Sphere Pressure Gradient Field", std::move(grad_e_m_values),
+          mesh.get());
+  return std::make_unique<HydroelasticField<T>>(
+      std::move(mesh), std::move(e_m), std::move(grad_e_m));
+}
+
+}  // namespace internal
+}  // namespace hydroelastics
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/hydroelastics/level_set_field.h
+++ b/multibody/hydroelastics/level_set_field.h
@@ -2,11 +2,12 @@
 
 #include <functional>
 
-#include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 
 namespace drake {
-namespace geometry {
+namespace multibody {
+namespace hydroelastics {
+namespace internal {
 
 // TODO(amcastro-tri): consider making this an abstract class so that we can
 // inherit multiple implementations (analytical, structured grids, etc.)
@@ -15,6 +16,8 @@ namespace geometry {
 /// F.
 template <typename T>
 struct LevelSetField {
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LevelSetField)
+
   /// Constructs a level set field from user-defined functions for a level set
   /// and its gradient.
   /// These functions implicitly defines a frame F for the level set
@@ -26,12 +29,11 @@ struct LevelSetField {
                 std::function<Vector3<T>(const Vector3<T>&)> grad_level_set_F)
       : value(level_set_F), gradient(grad_level_set_F) {}
 
-  LevelSetField(LevelSetField&&) = default;
-  LevelSetField& operator=(LevelSetField&&) = default;
-
   std::function<T(const Vector3<T>&)> value;
   std::function<Vector3<T>(const Vector3<T>&)> gradient;
 };
 
-}  // namespace geometry
+}  // namespace internal
+}  // namespace hydroelastics
+}  // namespace multibody
 }  // namespace drake

--- a/multibody/hydroelastics/test/contact_surface_from_level_set_test.cc
+++ b/multibody/hydroelastics/test/contact_surface_from_level_set_test.cc
@@ -15,9 +15,21 @@ using drake::math::RigidTransformd;
 using drake::math::RollPitchYawd;
 
 namespace drake {
-namespace geometry {
+namespace multibody {
+namespace hydroelastics {
 namespace internal {
 namespace {
+
+using drake::geometry::internal::MakeUnitSphereMesh;
+using drake::geometry::SurfaceFace;
+using drake::geometry::SurfaceFaceIndex;
+using drake::geometry::SurfaceMesh;
+using drake::geometry::SurfaceVertex;
+using drake::geometry::SurfaceVertexIndex;
+using drake::geometry::VolumeElement;
+using drake::geometry::VolumeMesh;
+using drake::geometry::VolumeVertex;
+using drake::geometry::VolumeVertexIndex;
 
 // This method computes the right handed normal defined by the three vertices
 // of a triangle in the input argument v.
@@ -360,10 +372,10 @@ TEST_F(BoxPlaneIntersectionTest, VerifyContactArea) {
   std::vector<double> e_b_surface;
   std::vector<Vector3<double>> level_set_gradient_H;
   for (const auto& X_HB : poses) {
-    const SurfaceMesh<double> contact_surface_H =
+    std::unique_ptr<SurfaceMesh<double>> contact_surface_H =
         CalcZeroLevelSetInMeshDomain(*box_B_, *half_space_H_, X_HB, e_b_,
                                      &e_b_surface, &level_set_gradient_H);
-    EXPECT_NEAR(CalcSurfaceArea(contact_surface_H), 1.0, kTolerance);
+    EXPECT_NEAR(CalcSurfaceArea(*contact_surface_H), 1.0, kTolerance);
   }
 }
 
@@ -379,15 +391,15 @@ TEST_F(BoxPlaneIntersectionTest, VerifySurfaceFieldsInterpolations) {
   std::vector<Vector3<double>> level_set_gradient_H;
   for (const auto& h : heights) {
     const RigidTransformd X_HB = Translation3<double>(0.0, 0.0, h);
-    const SurfaceMesh<double> contact_surface_H =
+    std::unique_ptr<SurfaceMesh<double>> contact_surface_H =
         CalcZeroLevelSetInMeshDomain(*box_B_, *half_space_H_, X_HB, e_b_,
                                      &e_b_surface, &level_set_gradient_H);
 
     const double eb_expected = 0.5 - h;
-    for (SurfaceVertexIndex v(0); v < contact_surface_H.num_vertices(); ++v) {
+    for (SurfaceVertexIndex v(0); v < contact_surface_H->num_vertices(); ++v) {
       const double eb = e_b_surface[v];
       const Vector3<double>& grad_level_set_H = level_set_gradient_H[v];
-      const Vector3<double>& p_HV = contact_surface_H.vertex(v).r_MV();
+      const Vector3<double>& p_HV = contact_surface_H->vertex(v).r_MV();
       const Vector3<double> level_set_gradient_H_expected =
           half_space_H_->gradient(p_HV);
       EXPECT_NEAR(eb, eb_expected, kTolerance);
@@ -431,10 +443,10 @@ TEST_F(BoxPlaneIntersectionTest, NoIntersection) {
   for (const auto& X_HB : poses) {
     std::vector<double> e_b_surface;
     std::vector<Vector3<double>> level_set_gradient_H;
-    const SurfaceMesh<double> contact_surface =
+    std::unique_ptr<SurfaceMesh<double>> contact_surface =
         CalcZeroLevelSetInMeshDomain(*box_B_, *half_space_H_, X_HB, e_b_,
                                      &e_b_surface, &level_set_gradient_H);
-    EXPECT_NEAR(CalcSurfaceArea(contact_surface), 0.0, kTolerance);
+    EXPECT_NEAR(CalcSurfaceArea(*contact_surface), 0.0, kTolerance);
   }
 }
 
@@ -486,16 +498,16 @@ GTEST_TEST(SpherePlaneIntersectionTest, VerifyInterpolations) {
   // case the world frame W.
   std::vector<double> e_m_surface;
   std::vector<Vector3<double>> level_set_gradient_W;
-  const SurfaceMesh<double> contact_surface_W =
+  std::unique_ptr<SurfaceMesh<double>> contact_surface_W =
       CalcZeroLevelSetInMeshDomain(sphere_M, half_space_W, X_WM, em_volume,
                                    &e_m_surface, &level_set_gradient_W);
   // Assert non-empty intersection.
-  ASSERT_GT(contact_surface_W.num_faces(), 0);
+  ASSERT_GT(contact_surface_W->num_faces(), 0);
 
-  ASSERT_EQ(e_m_surface.size(), contact_surface_W.num_vertices());
+  ASSERT_EQ(e_m_surface.size(), contact_surface_W->num_vertices());
 
-  for (SurfaceVertexIndex v(0); v < contact_surface_W.num_vertices(); ++v) {
-    const Vector3<double>& p_WV = contact_surface_W.vertex(v).r_MV();
+  for (SurfaceVertexIndex v(0); v < contact_surface_W->num_vertices(); ++v) {
+    const Vector3<double>& p_WV = contact_surface_W->vertex(v).r_MV();
     // We verify that the positions were correctly interpolated to lie on the
     // plane.
     EXPECT_NEAR(p_WV[2], 0.0, kTolerance);
@@ -520,12 +532,12 @@ GTEST_TEST(SpherePlaneIntersectionTest, VerifyInterpolations) {
   }
 
   // Verify all normals point towards the positive side of the plane.
-  for (SurfaceFaceIndex f(0); f < contact_surface_W.num_faces(); ++f) {
-    const SurfaceFace& face = contact_surface_W.element(f);
+  for (SurfaceFaceIndex f(0); f < contact_surface_W->num_faces(); ++f) {
+    const SurfaceFace& face = contact_surface_W->element(f);
     std::vector<SurfaceVertex<double>> vertices_W = {
-        contact_surface_W.vertex(face.vertex(0)),
-        contact_surface_W.vertex(face.vertex(1)),
-        contact_surface_W.vertex(face.vertex(2))};
+        contact_surface_W->vertex(face.vertex(0)),
+        contact_surface_W->vertex(face.vertex(1)),
+        contact_surface_W->vertex(face.vertex(2))};
     const Vector3<double> normal_W = CalcTriangleNormal(vertices_W);
     // We expect the normals to point in the same direction as the halfsapce's
     // outward facing normal, according to the convention used by
@@ -544,5 +556,6 @@ GTEST_TEST(SpherePlaneIntersectionTest, VerifyInterpolations) {
 
 }  // namespace
 }  // namespace internal
-}  // namespace geometry
+}  // namespace hydroelastics
+}  // namespace multibody
 }  // namespace drake

--- a/multibody/hydroelastics/test/hydroelastic_engine_test.cc
+++ b/multibody/hydroelastics/test/hydroelastic_engine_test.cc
@@ -1,0 +1,188 @@
+#include "drake/multibody/hydroelastics/hydroelastic_engine.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+#include "drake/common/find_resource.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/scene_graph.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/multibody/parsing/parser.h"
+#include "drake/systems/framework/context.h"
+#include "drake/systems/framework/diagram_builder.h"
+
+namespace drake {
+namespace multibody {
+namespace hydroelastics {
+namespace internal {
+namespace {
+
+using drake::geometry::ContactSurface;
+using drake::geometry::SurfaceMesh;
+using drake::math::RigidTransformd;
+using Eigen::Vector3d;
+
+class SphereVsPlaneTest : public ::testing::Test {
+ public:
+  void SetUp() override {
+    systems::DiagramBuilder<double> builder;
+    const std::string full_name = FindResourceOrThrow(
+        "drake/multibody/hydroelastics/test/sphere_vs_plane.sdf");
+    std::tie(plant_, scene_graph_) = AddMultibodyPlantSceneGraph(&builder);
+    Parser(plant_).AddModelFromFile(full_name);
+
+    // Retrieve bodies and geometry ids.
+    sphere_ = &plant_->GetBodyByName("sphere");
+    ground_ = &plant_->GetBodyByName("ground");
+    ASSERT_EQ(plant_->GetCollisionGeometriesForBody(*sphere_).size(), 1u);
+    sphere_geometry_id_ = plant_->GetCollisionGeometriesForBody(*sphere_)[0];
+    ASSERT_EQ(plant_->GetCollisionGeometriesForBody(*ground_).size(), 1u);
+    ground_geometry_id_ = plant_->GetCollisionGeometriesForBody(*ground_)[0];
+
+    // Set elastic properties pre-finalize.
+    const double elastic_modulus = 10.0;
+    plant_->set_elastic_modulus(sphere_geometry_id_, elastic_modulus);
+
+    plant_->Finalize();
+    diagram_ = builder.Build();
+    // Sanity check on the availability of the optional source id before using
+    // it.
+    DRAKE_DEMAND(plant_->get_source_id() != nullopt);
+
+    MakeNewContext();
+
+    engine_ = std::make_unique<HydroelasticEngine<double>>();
+    engine_->MakeModels(scene_graph_->model_inspector());
+
+    SetInContactConfiguration();
+  }
+
+  // Sets a configuration for which there is contact between the sphere and the
+  // ground. The 5 cm sphere is placed with its center 4 cm above the ground and
+  // thefore its lowest point is 1 cm below the ground.
+  void SetInContactConfiguration() {
+    const RigidTransformd X_WS = Eigen::Translation3d(0.0, 0.0, height_);
+    plant_->SetFreeBodyPoseInWorldFrame(plant_context_, *sphere_, X_WS);
+  }
+
+  // Sets the sphere pose in a configuration such that it is clearly overlapping
+  // with the anchored box in the model. Since box-sphere is currently not
+  // supported by HydroelasticEngine, we expect a contact query to throw an
+  // exception.
+  void SetInUnsupportedConfiguration() {
+    const RigidTransformd X_WS = Eigen::Translation3d(0.0, 0.1, height_);
+    plant_->SetFreeBodyPoseInWorldFrame(plant_context_, *sphere_, X_WS);
+  }
+
+  void MakeNewContext() {
+    context_ = diagram_->CreateDefaultContext();
+    plant_context_ =
+        &diagram_->GetMutableSubsystemContext(*plant_, context_.get());
+
+    const auto& query_port = plant_->get_geometry_query_input_port();
+    query_object_ = &query_port.template Eval<geometry::QueryObject<double>>(
+        *plant_context_);
+  }
+
+ protected:
+  MultibodyPlant<double>* plant_{nullptr};
+  geometry::SceneGraph<double>* scene_graph_{nullptr};
+  // The diagram owning the plant and scene graph.
+  std::unique_ptr<systems::Diagram<double>> diagram_;
+  const Body<double>* sphere_{nullptr};
+  const Body<double>* ground_{nullptr};
+  geometry::GeometryId sphere_geometry_id_, ground_geometry_id_;
+  std::unique_ptr<systems::Context<double>> context_;
+  systems::Context<double>* plant_context_{nullptr};
+  const geometry::QueryObject<double>* query_object_{nullptr};
+  std::unique_ptr<HydroelasticEngine<double>> engine_;
+  // Numerical parameters of the problem.
+  double height_{0.04};
+  double radius_{0.05};  // consistent with the *.sdf file.
+};
+
+// HydroelasticEngine relies on QueryObject::FindCollisionCandidates() for
+// collision filtering. This is just a smoke test to detect if the upstream ever
+// changes behavior.
+TEST_F(SphereVsPlaneTest, RespectsCollisionFilter) {
+  // Before filtering is applied the engine should report contact.
+  EXPECT_EQ(engine_->ComputeContactSurfaces(*query_object_).size(), 1u);
+
+  // Add filter to exclude collisions between the ground and the sphere.
+  optional<geometry::FrameId> ground_id =
+      plant_->GetBodyFrameIdIfExists(ground_->index());
+  ASSERT_TRUE(ground_id.has_value());
+  optional<geometry::FrameId> sphere_id =
+      plant_->GetBodyFrameIdIfExists(sphere_->index());
+  ASSERT_TRUE(sphere_id.has_value());
+  scene_graph_->ExcludeCollisionsBetween(context_.get(),
+                                         geometry::GeometrySet(*ground_id),
+                                         geometry::GeometrySet(*sphere_id));
+  EXPECT_EQ(engine_->ComputeContactSurfaces(*query_object_).size(), 0u);
+}
+
+TEST_F(SphereVsPlaneTest, VerifyModelSizeAndResults) {
+  EXPECT_EQ(plant_->num_bodies(), 4);  // Including the "world" body.
+
+  // We expect three collision geomtries from the SDF: a plane for the ground, a
+  // box attached to the ground, and a sphere.
+  EXPECT_EQ(scene_graph_->model_inspector().num_geometries(), 3);
+
+  // Expect a model for the sphere and for the half-space. Currently, the box is
+  // ignored.
+  EXPECT_EQ(engine_->num_models(), 2);
+
+  const std::vector<ContactSurface<double>> all_surfaces =
+      engine_->ComputeContactSurfaces(*query_object_);
+
+  ASSERT_EQ(all_surfaces.size(), 1u);
+  const ContactSurface<double>& surface = all_surfaces[0];
+
+  // Verify the invariant id_M < id_N.
+  EXPECT_LT(surface.id_M(), surface.id_N());
+
+  // Verify that the sphere is soft and the ground is rigid.
+  EXPECT_TRUE(engine_->get_model(sphere_geometry_id_)->is_soft());
+  EXPECT_FALSE(engine_->get_model(ground_geometry_id_)->is_soft());
+
+  // This is merely a sanity check on the returned results. The contact
+  // surface calculation implemented in CalcZeroLevelSetInMeshDomain(), already
+  // has thorough unit tests.
+  // Since id_M corresponds to the ground geometry, the mesh is expressed in
+  // frame G of the ground.
+  const SurfaceMesh<double>& mesh_G = surface.mesh();
+  EXPECT_GT(mesh_G.num_vertices(), 0);
+  const double kTolerance = 5.0 * std::numeric_limits<double>::epsilon();
+  for (geometry::SurfaceVertexIndex v(0); v < mesh_G.num_vertices(); ++v) {
+    // Position of a vertex V in the frame S of the soft sphere.
+    const Vector3d p_SV = mesh_G.vertex(v).r_MV();
+
+    // We verify that the positions were correctly interpolated to lie on the
+    // plane.
+    EXPECT_NEAR(p_SV[2], 0.0, kTolerance);
+
+    // Verify surface vertices lie within a circle of the expected radius.
+    const double surface_radius =
+        std::sqrt(radius_ * radius_ - height_ * height_);
+    const double radius = p_SV.norm();  // since z component is zero.
+    EXPECT_LE(radius, surface_radius);
+  }
+
+  // The number of models should not change on further queries.
+  engine_->ComputeContactSurfaces(*query_object_);
+  EXPECT_EQ(engine_->num_models(), 2);
+}
+
+TEST_F(SphereVsPlaneTest, ThrowsIfUnspportedGeometriesAreInContact) {
+  SetInUnsupportedConfiguration();
+  EXPECT_THROW(engine_->ComputeContactSurfaces(*query_object_),
+               std::runtime_error);
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace hydroelastics
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/hydroelastics/test/sphere_vs_plane.sdf
+++ b/multibody/hydroelastics/test/sphere_vs_plane.sdf
@@ -1,0 +1,117 @@
+<?xml version='1.0'?>
+<sdf version='1.6'>
+  <!-- Note: This is the accompaning SDF file for the unit test
+  hydroelastic_engine_test.cc and therefore these two files must be kept in
+  sync.
+
+  This model defines a link with "sphere" geometry and a link with "plane"
+  geometry in order to test hydroelastic specific queries involving these
+  gometry types. This model also includes un-supported geometry to test the
+  engine properly throws an exception when un-supported geometry is detected to
+  possibly be in contact by the broadphase. -->
+  <model name='box_vs_plane'>
+    <!-- A link to model the ground. Inertia values are not particularly
+         important since the ground does not move. -->
+    <link name='ground'>
+      <inertial>
+        <mass>1.0</mass>
+        <inertia>
+          <ixx>1.0</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>1.0</iyy>
+          <iyz>0</iyz>
+          <izz>1.0</izz>
+        </inertia>
+      </inertial>
+
+      <collision name='plane'>
+        <geometry>
+          <plane>
+            <normal>0.0 0.0 1.0</normal>
+          </plane>
+        </geometry>
+
+        <surface>
+          <friction>
+            <ode>
+              <mu>1.0</mu>
+              <mu2>1.0</mu2>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+    </link>
+
+    <!-- For unit testing purposes, we add a link with box collision geometry to
+    demonstrate that unsupported geometries are ignored by HydroelasticEngine.
+    This link and its collision should be removed/updated once boxes are
+    supported. -->
+    <link name='anchored_link'>
+      <pose>0 0.1 0.005 0 0 0</pose>
+      <inertial>
+        <mass>1.0</mass>
+        <inertia>
+          <ixx>1.0</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>1.0</iyy>
+          <iyz>0</iyz>
+          <izz>1.0</izz>
+        </inertia>
+      </inertial>
+      <collision name='box'>
+        <geometry>
+          <box>
+            <size>0.01 0.01 0.01</size>
+          </box>
+        </geometry>
+      </collision>
+    </link>
+
+    <joint name='weld_ground' type='fixed'>
+      <parent>world</parent>
+      <child>ground</child>
+    </joint>
+
+    <joint name='weld_anchored_geometry' type='fixed'>
+      <parent>world</parent>
+      <child>anchored_link</child>
+    </joint>
+
+    <!-- The model for a solid sphere of uniform density 10 cm in diameter. -->
+    <link name='sphere'>
+      <pose>0 0 0.05 0 0 0</pose>
+      <inertial>
+        <mass>0.1</mass>
+        <inertia>
+          <!-- Ixx = Iyy = Izz = 2/5 * m * R^2 -->
+          <ixx>1.0e-4</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>1.0e-4</iyy>
+          <iyz>0</iyz>
+          <izz>1.0e-4</izz>
+        </inertia>
+      </inertial>
+
+      <collision name='collision'>
+        <geometry>
+          <sphere>
+            <radius>0.05</radius>
+          </sphere>
+        </geometry>
+
+        <surface>
+          <friction>
+            <ode>
+              <mu>1.0</mu>
+              <mu2>1.0</mu2>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+    </link>
+
+  </model>
+</sdf>

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -696,6 +696,13 @@ MatrixX<T> MultibodyPlant<T>::MakeActuationMatrix() const {
 
 template <typename T>
 struct MultibodyPlant<T>::SceneGraphStub {
+  struct StubSceneGraphInspector {
+    const geometry::ProximityProperties* GetProximityProperties(
+        GeometryId) const {
+      return nullptr;
+    }
+  };
+
   static void Throw(const char* operation_name) {
     throw std::logic_error(fmt::format(
         "Cannot {} on a SceneGraph<symbolic::Expression>", operation_name));
@@ -715,6 +722,10 @@ struct MultibodyPlant<T>::SceneGraphStub {
   DRAKE_STUB(FrameId, RegisterFrame)
   DRAKE_STUB(GeometryId, RegisterGeometry)
   DRAKE_STUB(SourceId, RegisterSource)
+  const StubSceneGraphInspector model_inspector() const {
+    Throw("model_inspector");
+    return StubSceneGraphInspector();
+  }
 
 #undef DRAKE_STUB
 };

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -2710,6 +2710,24 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     return default_coulomb_friction_[collision_index];
   }
 
+  /// Specifies the `elastic_modulus` for a geometry identified by its `id`.
+  /// @throws std::exception if `id` does not correspond to a collision
+  /// geometry previously registered with this model.
+  /// @throws std::exception if called post-finalize.
+  void set_elastic_modulus(geometry::GeometryId id, double elastic_modulus) {
+    // It must not be finalized so that member_scene_graph() is valid.
+    DRAKE_MBP_THROW_IF_FINALIZED();
+    DRAKE_THROW_UNLESS(is_collision_geometry(id));
+
+    const geometry::ProximityProperties* old_props =
+        member_scene_graph().model_inspector().GetProximityProperties(id);
+    DRAKE_DEMAND(old_props);
+    geometry::ProximityProperties new_props(*old_props);
+    new_props.AddProperty("hydroelastics", "elastic modulus", elastic_modulus);
+    member_scene_graph().AssignRole(*get_source_id(), id, new_props,
+                                    geometry::RoleAssign::kReplace);
+  }
+
   /// @name Retrieving ports for communication with a SceneGraph.
   /// @{
 


### PR DESCRIPTION
This PR introduces in `multibody/hydroelastic/hydroelastic_engine.h` `internal::HydroelasticEngine`, which is responsible for the geometric model and queries for the hydroelastic model.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11713)
<!-- Reviewable:end -->
