### PR TITLE
To allow the output sizes of the demultiplexer specified by a vector

### DIFF
--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -98,7 +98,9 @@ PYBIND11_MODULE(primitives, m) {
     DefineTemplateClassWithDefault<Demultiplexer<T>, LeafSystem<T>>(
         m, "Demultiplexer", GetPyParam<T>(), doc.Demultiplexer.doc)
         .def(py::init<int, int>(), py::arg("size"),
-            py::arg("output_ports_sizes") = 1, doc.Demultiplexer.ctor.doc);
+            py::arg("output_ports_size") = 1, doc.Demultiplexer.ctor.doc_2args)
+        .def(py::init<const std::vector<int>&>(), py::arg("output_ports_sizes"),
+            doc.Demultiplexer.ctor.doc_1args);
 
     DefineTemplateClassWithDefault<                  // BR
         FirstOrderLowPassFilter<T>, LeafSystem<T>>(  //

--- a/bindings/pydrake/systems/test/primitives_test.py
+++ b/bindings/pydrake/systems/test/primitives_test.py
@@ -322,7 +322,7 @@ class TestGeneral(unittest.TestCase):
                             input_vec[i]))
 
         # Test demultiplexer with vector outputs.
-        demux = Demultiplexer(size=4, output_ports_sizes=2)
+        demux = Demultiplexer(size=4, output_ports_size=2)
         context = demux.CreateDefaultContext()
         self.assertEqual(demux.num_input_ports(), 1)
         self.assertEqual(demux.num_output_ports(), 2)
@@ -335,6 +335,28 @@ class TestGeneral(unittest.TestCase):
             self.assertTrue(
                 np.allclose(output.get_vector_data(i).get_value(),
                             input_vec[2*i:2*i+2]))
+
+        # Test demultiplexer with different output port sizes.
+        output_ports_sizes = np.array([1, 2, 1])
+        num_output_ports = output_ports_sizes.size
+        input_vec = np.array([1., 2., 3., 4.])
+        demux = Demultiplexer(output_ports_sizes=output_ports_sizes)
+        context = demux.CreateDefaultContext()
+        self.assertEqual(demux.num_input_ports(), 1)
+        self.assertEqual(demux.num_output_ports(), num_output_ports)
+
+        context.FixInputPort(0, BasicVector(input_vec))
+        output = demux.AllocateOutput()
+        demux.CalcOutput(context, output)
+
+        output_port_start = 0
+        for i in range(num_output_ports):
+            output_port_size = output.get_vector_data(i).size()
+            self.assertTrue(
+                np.allclose(output.get_vector_data(i).get_value(),
+                            input_vec[output_port_start:
+                                      output_port_start+output_port_size]))
+            output_port_start += output_port_size
 
     def test_multiplexer(self):
         my_vector = MyVector2(data=[1., 2.])

--- a/systems/primitives/demultiplexer.cc
+++ b/systems/primitives/demultiplexer.cc
@@ -8,19 +8,24 @@ namespace drake {
 namespace systems {
 
 template <typename T>
-Demultiplexer<T>::Demultiplexer(int size, int output_ports_sizes)
-    : LeafSystem<T>(SystemTypeTag<systems::Demultiplexer>{}) {
-  // The size must be a multiple of output_ports_sizes.
-  DRAKE_DEMAND(size % output_ports_sizes == 0);
-  const int num_output_ports = size / output_ports_sizes;
+Demultiplexer<T>::Demultiplexer(const std::vector<int>& output_ports_sizes)
+    : LeafSystem<T>(SystemTypeTag<systems::Demultiplexer>{}),
+      output_ports_sizes_(output_ports_sizes),
+      output_ports_start_(CalcOutputPortsStart(output_ports_sizes)) {
+  const int size =
+      std::accumulate(output_ports_sizes.begin(), output_ports_sizes.end(), 0);
 
-  // TODO(amcastro-tri): remove the size parameter from the constructor once
-  // #3109 supporting automatic sizes is resolved.
   this->DeclareInputPort(kVectorValued, size);
+
   // TODO(david-german-tri): Provide a way to infer the type.
+  const int num_output_ports = output_ports_sizes.size();
+  DRAKE_THROW_UNLESS(num_output_ports >= 1);
   for (int i = 0; i < num_output_ports; ++i) {
+    const int output_port_size = output_ports_sizes[i];
+    // Require no zero size output port.
+    DRAKE_THROW_UNLESS(output_port_size >= 1);
     this->DeclareVectorOutputPort(
-        BasicVector<T>(output_ports_sizes),
+        BasicVector<T>(output_port_size),
         [this, i](const Context<T>& context, BasicVector<T>* vector) {
           this->CopyToOutput(context, OutputPortIndex(i), vector);
         });
@@ -28,23 +33,26 @@ Demultiplexer<T>::Demultiplexer(int size, int output_ports_sizes)
 }
 
 template <typename T>
+Demultiplexer<T>::Demultiplexer(int size, int output_ports_size)
+    : Demultiplexer(CalcOutputPortsSizes(size, output_ports_size)) {}
+
+template <typename T>
 template <typename U>
 Demultiplexer<T>::Demultiplexer(const Demultiplexer<U>& other)
-    : Demultiplexer<T>(other.get_input_port(0).size(),
-                       other.get_output_port(0).size()) {}
+    : Demultiplexer<T>(other.get_output_ports_sizes()) {}
 
 template <typename T>
 void Demultiplexer<T>::CopyToOutput(const Context<T>& context,
                                     OutputPortIndex port_index,
                                     BasicVector<T>* output) const {
-  // All output ports have the same size as defined in the constructor.
-  const int out_size = this->get_output_port(0).size();
+  const int out_size = this->get_output_port(port_index).size();
+  const int out_start_index = output_ports_start_[port_index];
 
   // TODO(amcastro-tri): the output should simply reference the input port's
   // value to avoid copy.
   auto in_vector = this->get_input_port(0).Eval(context);
   auto out_vector = output->get_mutable_value();
-  out_vector = in_vector.segment(port_index * out_size, out_size);
+  out_vector = in_vector.segment(out_start_index, out_size);
 }
 
 }  // namespace systems

--- a/systems/primitives/demultiplexer.h
+++ b/systems/primitives/demultiplexer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/leaf_system.h"
@@ -29,27 +30,78 @@ class Demultiplexer final : public LeafSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Demultiplexer)
 
-  /// Constructs %Demultiplexer with one vector valued input port of size
-  /// @p size and vector valued output ports of size @p output_ports_sizes.
+  /// Constructs %Demultiplexer with one vector valued output ports with sizes
+  /// specified as the vector @p output_ports_sizes. The number of output ports
+  /// is the length of this vector. The size of each output port is the value of
+  /// the corresponding element of the vector @p output_ports_sizes.
   ///
-  /// @p output_ports_sizes must exactly divide @p size. Otherwise this
-  /// constructor throws an exception. The number of output ports is therefore
-  /// `size / output_ports_sizes`.
+  /// @throws std::logic_error if @p output_ports_sizes is a zero length vector.
+  /// @throws std::logic_error if any element of the @p output_ports_sizes is
+  /// zero. Therefore, the Demultiplexer does not allow zero size output ports.
+  ///
+  /// @param output_ports_sizes Contains the sizes of each output port. The
+  /// number of output ports is determined by the length of @p
+  /// output_ports_sizes. The accumulative value of the all the values in @p
+  /// output_ports_sizes will be the size of the input port.
+  explicit Demultiplexer(const std::vector<int>& output_ports_sizes);
+
+  /// Constructs %Demultiplexer with one vector valued input port of size
+  /// @p size and vector valued output ports of size @p output_ports_size.
+  ///
+  /// @throws std::logic_error if output_ports_sizes can not exactly divide @p
+  /// size. The number of output ports is therefore `size / output_ports_size`.
   ///
   /// @param size is the size of the input signal to be demultiplexed into its
   /// individual components.
-  /// @param output_ports_sizes The size of the output ports. @p size must be
-  /// a multiple of @p output_ports_sizes.
-  explicit Demultiplexer(int size, int output_ports_sizes = 1);
+  /// @param output_ports_size The size of the output ports. @p size must be
+  /// a multiple of @p output_ports_size.
+  explicit Demultiplexer(int size, int output_ports_size = 1);
 
   /// Scalar-converting copy constructor. See @ref system_scalar_conversion.
   template <typename U>
   explicit Demultiplexer(const Demultiplexer<U>&);
 
+  const std::vector<int>& get_output_ports_sizes() const {
+    return output_ports_sizes_;
+  }
+
  private:
   // Sets the port_index-th output port value.
   void CopyToOutput(const Context<T>& context, OutputPortIndex port_index,
                     BasicVector<T>* output) const;
+
+  // Return a std vector with size of 'size / output_ports_size' and all values
+  // as @p output_ports_sizes.
+  static const std::vector<int> CalcOutputPortsSizes(int size,
+                                                     int output_ports_size) {
+    // The size must be a multiple of output_ports_size.
+    DRAKE_DEMAND(size % output_ports_size == 0);
+    const int num_output_ports = size / output_ports_size;
+    return std::vector<int>(num_output_ports, output_ports_size);
+  }
+
+  // Return a std vector with the same size as the input @p output_ports_sizes.
+  // The values are calculated as the start index of the output port inside the
+  // input port vector.
+  static const std::vector<int> CalcOutputPortsStart(
+      const std::vector<int>& output_ports_sizes) {
+    const int num_output_ports = output_ports_sizes.size();
+    // Require the number of output ports should be greater than 1.
+    DRAKE_DEMAND(num_output_ports >= 1);
+    std::vector<int> output_ports_start;
+    output_ports_start.resize(num_output_ports);
+
+    output_ports_start[0] = 0;
+    for (int i = 1; i < num_output_ports; i++) {
+      output_ports_start[i] =
+          output_ports_start[i - 1] + output_ports_sizes[i - 1];
+    }
+    return output_ports_start;
+  }
+
+  const std::vector<int> output_ports_sizes_;
+
+  const std::vector<int> output_ports_start_;
 };
 
 }  // namespace systems

--- a/systems/primitives/test/demultiplexer_test.cc
+++ b/systems/primitives/test/demultiplexer_test.cc
@@ -47,7 +47,7 @@ TEST_F(DemultiplexerTest, DemultiplexVector) {
   // The number of output ports must match the size of the input vector.
   ASSERT_EQ(input_vector.size(), demux_->num_output_ports());
 
-  for (int i=0; i < input_vector.size(); ++i) {
+  for (int i = 0; i < input_vector.size(); ++i) {
     const auto& output_vector = demux_->get_output_port(i).Eval(*context_);
     ASSERT_EQ(1, output_vector.size());
     ASSERT_EQ(input_vector[i], output_vector[0]);
@@ -64,7 +64,7 @@ GTEST_TEST(OutputSize, SizeDifferentFromOne) {
   // Creates a demultiplexer with an input port of size ten and output ports of
   // size two. Therefore there are five output ports.
   auto demux = make_unique<Demultiplexer<double>>(
-      kInputSize /* size */, kOutputSize /* output_ports_sizes */);
+      kInputSize /* size */, kOutputSize /* output_ports_size */);
   auto context = demux->CreateDefaultContext();
   auto input = make_unique<BasicVector<double>>(kInputSize /* size */);
 
@@ -72,7 +72,8 @@ GTEST_TEST(OutputSize, SizeDifferentFromOne) {
   // are consistent.
   ASSERT_EQ(1, context->num_input_ports());
   ASSERT_EQ(1, demux->num_input_ports());
-  Eigen::VectorXd input_vector = Eigen::VectorXd::Random(kInputSize);
+  Eigen::VectorXd input_vector =
+      Eigen::VectorXd::LinSpaced(kInputSize, 1.0, 6.0);
   input->get_mutable_value() << input_vector;
 
   // Hook input of the expected size.
@@ -89,6 +90,52 @@ GTEST_TEST(OutputSize, SizeDifferentFromOne) {
     ASSERT_EQ(kOutputSize, output_vector.size());
     ASSERT_EQ(input_vector.segment<kOutputSize>(output_index * kOutputSize),
               output_vector);
+  }
+}
+
+// Tests that the input signal gets demultiplexed into its individual
+// components.
+GTEST_TEST(VectorizedOutputSize, SizeDifferentFromOne) {
+  const int kOutputPortOneSize = 1;
+  const int kOutputPortTwoSize = 2;
+  const int kOutputPortThreeSize = 3;
+  const int kInputSize =
+      kOutputPortOneSize + kOutputPortTwoSize + kOutputPortThreeSize;
+  const std::vector<int> kOutputPortsSizes{
+      kOutputPortOneSize, kOutputPortTwoSize, kOutputPortThreeSize};
+  // Creates a demultiplexer with an input port of size six and number of output
+  // ports of three. The size of each output port is specified inside the input
+  // vector.
+  auto demux = make_unique<Demultiplexer<double>>(
+      kOutputPortsSizes /* output_ports_sizes */);
+  auto context = demux->CreateDefaultContext();
+  auto input = make_unique<BasicVector<double>>(kInputSize /* size */);
+
+  // Checks that the number of input ports in the system and in the context
+  // are consistent.
+  ASSERT_EQ(1, context->num_input_ports());
+  ASSERT_EQ(1, demux->num_input_ports());
+  Eigen::VectorXd input_vector =
+      Eigen::VectorXd::LinSpaced(kInputSize, 1.0, 6.0);
+  input->get_mutable_value() << input_vector;
+
+  // Hook input of the expected size.
+  context->FixInputPort(0, std::move(input));
+
+  // The number of output ports must equal the length of the vector
+  // kOutputPortsSizes.
+  const int num_output_ports = kOutputPortsSizes.size();
+  ASSERT_EQ(num_output_ports, demux->num_output_ports());
+
+  int output_port_start = 0;
+  for (int output_index = 0; output_index < num_output_ports; ++output_index) {
+    const auto& output_vector =
+        demux->get_output_port(output_index).Eval(*context);
+    const int output_size = kOutputPortsSizes[output_index];
+    ASSERT_EQ(output_size, output_vector.size());
+    ASSERT_EQ(input_vector.segment(output_port_start, output_size),
+              output_vector);
+    output_port_start += output_size;
   }
 }
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11714)
<!-- Reviewable:end -->
