### PR TITLE
Do not exclude all sh tests when running under Valgrind Memcheck

### DIFF
--- a/automotive/BUILD.bazel
+++ b/automotive/BUILD.bazel
@@ -942,6 +942,8 @@ sh_test(
         "--dry-run",
     ],
     data = [":demo"],
+    # Valgrind Memcheck reports numerous leaks in the python executable.
+    tags = ["no_memcheck"],
 )
 
 add_lint_tests()

--- a/bindings/pydrake/attic/systems/BUILD.bazel
+++ b/bindings/pydrake/attic/systems/BUILD.bazel
@@ -14,6 +14,7 @@ load(
     "drake_py_unittest",
 )
 load("//bindings/pydrake:pydrake.bzl", "add_lint_tests_pydrake")
+load("//tools/skylark:test_tags.bzl", "vtk_test_tags")
 
 package(default_visibility = [
     "//bindings/pydrake:__subpackages__",
@@ -102,6 +103,7 @@ drake_py_unittest(
     data = [
         "//systems/sensors:test_models",
     ],
+    tags = vtk_test_tags(),
     deps = [
         ":sensors_py",
         "//bindings/pydrake/systems:sensors_py",

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -18,6 +18,7 @@ load(
     "drake_py_unittest",
 )
 load("//bindings/pydrake:pydrake.bzl", "add_lint_tests_pydrake")
+load("//tools/skylark:test_tags.bzl", "vtk_test_tags")
 
 package(default_visibility = [
     "//bindings/pydrake:__subpackages__",
@@ -483,6 +484,7 @@ drake_py_unittest(
     data = [
         "//systems/sensors:test_models",
     ],
+    tags = vtk_test_tags(),
     deps = [":sensors_py"],
 )
 

--- a/common/test/drake_assert_test_compile_variants.sh
+++ b/common/test/drake_assert_test_compile_variants.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # This test should only be invoked via Bazel.
 set -ex
 

--- a/common/test_utilities/BUILD.bazel
+++ b/common/test_utilities/BUILD.bazel
@@ -150,8 +150,8 @@ drake_cc_googletest(
     ],
 )
 
-# N.B. All sh_tests are excluded from dynamic_analysis (sanitizer and memcheck)
-# build by default; these death tests are skipped under those configurations.
+# N.B. All sh_tests are excluded from sanitizer builds by default; these death
+# tests are therefore skipped under those configurations.
 sh_test(
     name = "limit_malloc_death_test",
     srcs = [":limit_malloc_test"],
@@ -168,6 +168,8 @@ sh_test(
     data = [
         ":limit_malloc_test",
     ],
+    # Fails to terminate when run under Valgrind Memcheck.
+    tags = ["no_memcheck"],
 )
 
 drake_cc_googletest(

--- a/examples/schunk_wsg/BUILD.bazel
+++ b/examples/schunk_wsg/BUILD.bazel
@@ -57,8 +57,11 @@ drake_cc_googletest(
     # This test is prohibitively slow with --compilation_mode=dbg.
     disable_in_compilation_mode_dbg = True,
     # TODO(betsymcphail): Re-enable this test when it no longer
-    # causes timeouts in kcov.
-    tags = ["no_kcov"],
+    # causes timeouts in kcov and Valgrind Memcheck.
+    tags = [
+        "no_kcov",
+        "no_memcheck",
+    ],
     deps = [
         "//attic/multibody:rigid_body_tree",
         "//attic/multibody:rigid_body_tree_construction",

--- a/geometry/dev/render/BUILD.bazel
+++ b/geometry/dev/render/BUILD.bazel
@@ -7,6 +7,7 @@ load(
     "drake_cc_package_library",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
+load("//tools/skylark:test_tags.bzl", "vtk_test_tags")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -89,15 +90,7 @@ drake_cc_googletest(
     data = [
         "//systems/sensors:test_models",
     ],
-    # Mitigates driver-related issues when running under `bazel test`. For more
-    # information, see #7004.
-    local = 1,
-    # Disable under LeakSanitizer and Valgrind Memcheck due to driver-related
-    # leaks. For more information, see #7520.
-    tags = [
-        "no_lsan",
-        "no_memcheck",
-    ],
+    tags = vtk_test_tags(),
     deps = [
         ":render_engine_vtk",
         "//common:find_resource",

--- a/geometry/render/BUILD.bazel
+++ b/geometry/render/BUILD.bazel
@@ -7,6 +7,7 @@ load(
     "drake_cc_package_library",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
+load("//tools/skylark:test_tags.bzl", "vtk_test_tags")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -113,18 +114,7 @@ drake_cc_googletest(
     data = [
         "//systems/sensors:test_models",
     ],
-    # Mitigates driver-related issues when running under `bazel test`. For more
-    # information, see #7004.
-    local = 1,
-    tags = [
-        # Disable under LeakSanitizer and Valgrind Memcheck due to
-        # driver-related leaks. For more information, see #7520.
-        "no_lsan",
-        "no_memcheck",
-        # Mitigates driver-related issues when running under `bazel test`. For
-        # more information, see #7004.
-        "no-sandbox",
-    ],
+    tags = vtk_test_tags(),
     deps = [
         ":render_engine_vtk",
         "//common:find_resource",

--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -193,13 +193,6 @@ drake_cc_googletest(
         ":test_models",
         "//multibody/benchmarks/acrobot:models",
     ],
-    # TODO(sam.creasey) Write a printer function (or another
-    # workaround) for ModelLoadFunction so that gtest won't trigger
-    # memcheck.  Related to
-    # https://github.com/google/googletest/issues/1610
-    tags = [
-        "no_memcheck",
-    ],
     deps = [
         ":test_loaders",
         "//common/test_utilities",
@@ -212,13 +205,6 @@ drake_cc_googletest(
     name = "common_parser_test",
     data = [
         ":test_models",
-    ],
-    # TODO(sam.creasey) Write a printer function (or another
-    # workaround) for ModelLoadFunction so that gtest won't trigger
-    # memcheck.  Related to
-    # https://github.com/google/googletest/issues/1610
-    tags = [
-        "no_memcheck",
     ],
     deps = [
         ":test_loaders",

--- a/setup/ubuntu/source_distribution/packages-bionic.txt
+++ b/setup/ubuntu/source_distribution/packages-bionic.txt
@@ -63,5 +63,6 @@ python3-sphinx-rtd-theme
 ruby
 unzip
 valgrind
+valgrind-dbg
 zip
 zlib1g-dev

--- a/setup/ubuntu/source_distribution/packages-xenial.txt
+++ b/setup/ubuntu/source_distribution/packages-xenial.txt
@@ -56,5 +56,6 @@ python-sphinx-rtd-theme
 ruby
 unzip
 valgrind
+valgrind-dbg
 zip
 zlib1g-dev

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -1429,8 +1429,6 @@ drake_cc_googletest(
     tags = gurobi_test_tags() + mosek_test_tags() + [
         # Excluding asan because it is unreasonably slow (> 30 minutes).
         "no_asan",
-        # Takes too long to run with Valgrind.
-        "no_memcheck",
         # Excluding tsan because an assertion fails in LLVM code. Issue #6179.
         "no_tsan",
     ],

--- a/systems/lcm/BUILD.bazel
+++ b/systems/lcm/BUILD.bazel
@@ -167,7 +167,6 @@ drake_cc_googletest(
     flaky = 1,
     tags = [
         "no_asan",
-        "no_memcheck",
         "no_tsan",
         "requires-network",
     ],

--- a/systems/sensors/dev/BUILD.bazel
+++ b/systems/sensors/dev/BUILD.bazel
@@ -15,16 +15,6 @@ load("//tools/lint:lint.bzl", "add_lint_tests")
 
 package(default_visibility = ["//visibility:public"])
 
-vtk_test_tags = [
-    # Disable under LeakSanitizer and Valgrind Memcheck due to
-    # driver-related leaks. For more information, see #7520.
-    "no_lsan",
-    "no_memcheck",
-    # Mitigates driver-related issues when running under `bazel test`. For
-    # more information, see #7004.
-    "no-sandbox",
-]
-
 drake_cc_package_library(
     name = "dev",
     deps = [

--- a/tools/dynamic_analysis/bazel.rc
+++ b/tools/dynamic_analysis/bazel.rc
@@ -208,11 +208,12 @@ build:memcheck --copt -g
 # https://sourceforge.net/p/valgrind/mailman/valgrind-developers/?viewmonth=201806&viewday=11&style=flat
 build:memcheck --copt -O2
 build:memcheck --run_under=//tools/dynamic_analysis:valgrind
-build:memcheck --test_tag_filters=-gurobi,-mosek,-snopt,-no_memcheck
-build:memcheck --test_lang_filters=-sh,-py
+build:memcheck --test_lang_filters=-py
+build:memcheck --test_tag_filters=-gurobi,-mosek,-snopt,-lint,-no_memcheck
 # Slowdown factor can range from 5-100.
 # See http://valgrind.org/info/about.html
 build:memcheck --test_timeout=1500,7500,22500,90000  # 25x
+test:memcheck --test_env=VALGRIND_OPTS
 
 ### Memcheck everything build. ###
 build:memcheck_everything --build_tests_only

--- a/tools/dynamic_analysis/valgrind.sh
+++ b/tools/dynamic_analysis/valgrind.sh
@@ -15,10 +15,15 @@ export G_SLICE=always-malloc
 export GTEST_DEATH_TEST_USE_FORK=1
 
 valgrind \
+    --tool=memcheck \
+    --gen-suppressions=all \
     --leak-check=full \
     --suppressions="$mydir/valgrind.supp" \
+    --suppressions=/usr/lib/valgrind/debian.supp \
+    --suppressions=/usr/lib/valgrind/python.supp \
     --error-exitcode=1 \
     --trace-children=yes \
+    --trace-children-skip=/bin/cat,/bin/cp,/bin/mkdir,/bin/sed,/usr/bin/clang,/usr/bin/clang-6.0,/usr/bin/clang-format-6.0,/usr/bin/find,/usr/bin/gcc \
     --track-origins=yes \
     --show-leak-kinds=definite,possible \
     --num-callers=16 \

--- a/tools/dynamic_analysis/valgrind.supp
+++ b/tools/dynamic_analysis/valgrind.supp
@@ -399,3 +399,148 @@
    fun:dmumps_c
    fun:_ZN5Ipopt20MumpsSolverInterfaceC1Ev
 }
+
+{
+   bash: definite leak in set_default_locale
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:xmalloc
+   fun:set_default_locale
+   fun:main
+}
+
+{
+   bash: definite leak in reader_loop
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:xmalloc
+   ...
+   fun:reader_loop
+   fun:main
+}
+
+# TODO(sam.creasey) Write a printer function (or another workaround) for
+# drake::multibody::test::ModelLoadFunction so that gtest won't trigger
+# memcheck. Related to https://github.com/google/googletest/issues/1610.
+{
+   googletest: conditional jump or move depends on uninitialised value in PrintValue
+   Memcheck:Cond
+   ...
+   fun:vfprintf
+   fun:vsnprintf
+   fun:snprintf
+   fun:*PrintByteSegmentInObjectTo*
+   fun:PrintBytesInObjectToImpl
+   fun:*PrintBytesInObjectTo*
+   fun:PrintValue
+}
+
+{
+   googletest: use of uninitialized value of size 8 in PrintValue
+   Memcheck:Value8
+   ...
+   fun:vfprintf
+   fun:vsnprintf
+   fun:snprintf
+   fun:*PrintByteSegmentInObjectTo*
+   fun:PrintBytesInObjectToImpl
+   fun:*PrintBytesInObjectTo*
+   fun:PrintValue
+}
+
+{
+   nvidia-glcore: conditional jump or move depends on uninitialized value
+   Memcheck:Cond
+   ...
+   obj:/usr/lib/x86_64-linux-gnu/libnvidia-glcore.so.*
+}
+
+{
+   python: invalid read of size 4 in PyObject_Free
+   Memcheck:Addr4
+   ...
+   fun:PyObject_Free
+}
+
+{
+   python: invalid read of size 4 in PyObject_Free
+   Memcheck:Value4
+   ...
+   fun:PyObject_Free
+}
+
+{
+   python: use of uninitialized value of size 8 in PyObject_Free
+   Memcheck:Addr8
+   ...
+   fun:PyObject_Free
+}
+
+{
+   python: use of uninitialized value of size 8 in PyObject_Free
+   Memcheck:Value8
+   ...
+   fun:PyObject_Free
+}
+
+{
+   python: conditional jump or move depends on uninitialized value in PyObject_Free
+   Memcheck:Cond
+   ...
+   fun:PyObject_Free
+}
+
+{
+   python: invalid read of size 4 in PyObject_Realloc
+   Memcheck:Addr4
+   ...
+   fun:PyObject_Realloc
+}
+
+{
+   python: invalid read of size 4 in PyObject_Realloc
+   Memcheck:Value4
+   ...
+   fun:PyObject_Realloc
+}
+
+{
+   python: use of uninitialized value of size 8 in PyObject_Realloc
+   Memcheck:Addr8
+   ...
+   fun:PyObject_Realloc
+}
+
+{
+   python: use of uninitialized value of size 8 in PyObject_Realloc
+   Memcheck:Value8
+   ...
+   fun:PyObject_Realloc
+}
+
+{
+   python: conditional jump or move depends on uninitialized value in PyObject_Realloc
+   Memcheck:Cond
+   ...
+   fun:PyObject_Realloc
+}
+
+{
+   swrast: conditional jump or move depends on uninitialized value in clone
+   Memcheck:Cond
+   ...
+   obj:/usr/lib/x86_64-linux-gnu/dri/swrast_dri.so
+   fun:start_thread
+   fun:clone
+}
+
+{
+   swrast: use of uninitialized value of size 8 in clone
+   Memcheck:Value8
+   ...
+   obj:/usr/lib/x86_64-linux-gnu/dri/swrast_dri.so
+   fun:start_thread
+   fun:clone
+}

--- a/tools/lint/BUILD.bazel
+++ b/tools/lint/BUILD.bazel
@@ -137,6 +137,8 @@ sh_test(
     data = [
         ":clang-format-includes",
     ],
+    # Valgrind Memcheck reports numerous leaks in the python executable.
+    tags = ["no_memcheck"],
 )
 
 # Exercise `ignore` for `python_lint`.

--- a/tools/lint/test/clang_format_includes_test.sh
+++ b/tools/lint/test/clang_format_includes_test.sh
@@ -1,8 +1,13 @@
+#!/bin/bash
+
 # A basic _acceptance_ test for clang-format-includes.
 # More specific _unit_ testing is in formatter_test.py.
 # This test should only be run via Bazel, never directly on the command line.
 
 set -ex
+
+# Fail if not run under Bazel.
+[[ -n "${TEST_TMPDIR}" ]]
 
 # Dump some debugging output.
 find .

--- a/tools/vector_gen/test/lcm_vector_gen_test.sh
+++ b/tools/vector_gen/test/lcm_vector_gen_test.sh
@@ -1,9 +1,11 @@
+#!/bin/bash
+
 # This test should only be run via Bazel, never directly on the command line.
 # Unit test for lcm_vector_gen.py.
 
 set -ex
 
-[[ -f ./tools/vector_gen/lcm_vector_gen_test ]]  # Fail-fast when not under Bazel.
+[[ -n "${TEST_TMPDIR}" ]]  # Fail-fast when not under Bazel.
 
 # Dump some debugging output.
 find .


### PR DESCRIPTION
Also remove some outdated/superfluous `no_memcheck` tags (e.g., related to Xenial, Mac, and/or when we compiled with `-O1` instead of `-O2`). We did have defects in some of the tests excluded by tags or language filters (which were fixed after being revealed by early drafts of these PR).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11716)
<!-- Reviewable:end -->
