### PR TITLE
Small updates to the implicit Euler integrator

### DIFF
--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -158,6 +158,7 @@ drake_cc_library(
     ],
     deps = [
         ":implicit_integrator",
+        ":runge_kutta2_integrator",
         "//math:gradient",
     ],
 )

--- a/systems/analysis/implicit_euler_integrator-inl.h
+++ b/systems/analysis/implicit_euler_integrator-inl.h
@@ -66,6 +66,14 @@ void ImplicitEulerIntegrator<T>::DoInitialize() {
 
   // Reset the Jacobian matrix (so that recomputation is forced).
   this->get_mutable_jacobian().resize(0, 0);
+
+  // Initialize the embedded second order Runge-Kutta integrator. The maximum
+  // step size will be set to infinity because we will explicitly request the
+  // step sizes to be taken. 
+  rk2_ = std::make_unique<RungeKutta2Integrator<T>>(
+      this->get_system(),
+      std::numeric_limits<double>::infinity() /* maximum step size */,
+      this->get_mutable_context());
 }
 
 template <class T>
@@ -374,12 +382,9 @@ bool ImplicitEulerIntegrator<T>::AttemptStepPaired(const T& t0, const T& h,
   //          = xₜᵣ(t0+h) + O(h³)      [implicit trapezoid]
   // where x*(t0+h) is the true (generally unknown) answer that we seek.
   // This implies:
-  // xᵢₑ(t0+h) + O(h²) = xₜᵣ(t0+h) + O(h³)
-  // Given that the second order term subsumes the third order one:
-  // xᵢₑ(t0+h) - xₜᵣ(t0+h) = O(h²)
-  // Therefore the difference between the implicit trapezoid solution and the
-  // implicit Euler solution gives a second-order error estimate for the
-  // implicit Euler result xᵢₑ.
+  // xᵢₑ(t0+h) + O(h²) = xₜᵣ(t0+h) + O(h³).
+  // Given that the second order term subsumes the third order one, we have:
+  // xᵢₑ(t0+h) - xₜᵣ(t0+h) = O(h²).
 
   // Attempt to compute the implicit trapezoid solution.
   *xtplus_itr = *xtplus_ie;
@@ -410,16 +415,12 @@ bool ImplicitEulerIntegrator<T>::DoImplicitIntegratorStep(const T& h) {
   const T t0 = context->get_time();
   SPDLOG_DEBUG(drake::log(), "IE DoStep(h={}) t={}", h, t0);
 
-  // TODO(sherm1) Heap allocation here; consider mutable temporaries instead.
-  const VectorX<T> xt0 = context->get_continuous_state().CopyToVector();
-  VectorX<T> xtplus_ie(xt0.size()), xtplus_itr(xt0.size());
+  xt0_ = context->get_continuous_state().CopyToVector();
+  xtplus_ie_.resize(xt0_.size());
+  xtplus_tr_.resize(xt0_.size());
 
   // If the requested h is less than the minimum step size, we'll advance time
-  // using two explicit Euler steps of size h/2. For error estimation, we also
-  // take a single step of size h. We can estimate the error in the larger
-  // step that way, but note that we propagate the two half-steps on the
-  // assumption the result will be better despite not having an error estimate
-  // for them (that's called "local extrapolation").
+  // using an explicit Euler step.
   if (h < this->get_working_minimum_step_size()) {
     SPDLOG_DEBUG(drake::log(), "-- requested step too small, taking explicit "
         "step instead");
@@ -430,57 +431,39 @@ bool ImplicitEulerIntegrator<T>::DoImplicitIntegratorStep(const T& h) {
     //                 test of, e.g., a square wave function, should quantify
     //                 the improvement (if any).
 
-    // The error estimation process for explicit Euler uses two half-steps
-    // of explicit Euler (for a total of two derivative evaluations). The error
-    // estimation process is derived as follows:
-    // (1) x*(t0+h) = xₑ(t0+h) + h²/2 df/h + ...                [full step]
-    // (2) x*(t0+h) = ̅xₑ(t0+h) + h²/8 (df/h + df₊/h) + ...      [two 1/2-steps]
-    //
-    // where x*(t0+h) is the true (generally unknown) answer that we seek,
-    // f() is the ordinary differential equation evaluated at x(t0), and
-    // f₊() is the derivative evaluated at x(t0 + h/2). Subtracting (1) from
-    // (2), the above equations are rewritten as:
-    // 0 = x̅ₑ(t0+h) - xₑ(t0+h) + h²/8 (-3df/h + df₊/h) + ...
-    // The sum of all but the first two terms on the right hand side
-    // of the above equation is less in magnitude than ch², for some
-    // sufficiently large c. Or, written using Big-Oh notation:
-    // x̅ₑ(t0+h) - xₑ(t0+h) = O(h²)
-    // Thus, subtracting the two solutions yields a second order error estimate
-    // (we compute norms on the error estimate, so the apparent sign error
-    // in the algebra when arriving at the final equation is inconsequential).
+    // The error estimation process for explicit Euler uses an explicit second
+    // order Runge-Kutta method so that the order of the asymptotic term
+    // matches that used for estimating the error of the implicit Euler
+    // integrator. 
 
     // Compute the Euler step.
-    // TODO(sherm1) Heap allocation here; consider mutable temporary instead.
-    VectorX<T> xdot = this->EvalTimeDerivatives(*context).CopyToVector();
-    xtplus_ie = xt0 + h * xdot;
+    xdot_ = this->EvalTimeDerivatives(*context).CopyToVector();
+    xtplus_ie_ = xt0_ + h * xdot_;
 
-    // Do one half step.
-    // TODO(sherm1) Heap allocation here; consider mutable temporary instead.
-    const VectorX<T> xtpoint5 = xt0 + h / 2.0 * xdot;
-    context->SetTimeAndContinuousState(t0 + h / 2.0, xtpoint5);
-
-    // Do another half step, then set the "trapezoid" state to be the result of
-    // taking two explicit Euler half steps. The code below the if/then/else
-    // block simply subtracts the two results to obtain the error estimate.
-    xdot = this->EvalTimeDerivatives(*context).CopyToVector();  // xdot(t + h/2)
-    xtplus_itr = xtpoint5 + h / 2.0 * xdot;
-    context->SetTimeAndContinuousState(t0 + h, xtplus_itr);
+    // Compute the RK2 step.
+    const int evals_before_rk2 = rk2_->get_num_derivative_evaluations();
+    DRAKE_DEMAND(rk2_->IntegrateWithSingleFixedStepToTime(t0 + h));
+    const int evals_after_rk2 = rk2_->get_num_derivative_evaluations();
+    xtplus_tr_ = context->get_continuous_state().CopyToVector();
 
     // Update the error estimation ODE counts.
-    num_err_est_function_evaluations_ += 2;
+    num_err_est_function_evaluations_ += (evals_after_rk2 - evals_before_rk2);
+
+    // Revert the state to that computed by explicit Euler.
+    context->SetTimeAndContinuousState(t0, xtplus_ie_);
   } else {
     // Try taking the requested step.
-    bool success = AttemptStepPaired(t0, h, xt0, &xtplus_ie, &xtplus_itr);
+    bool success = AttemptStepPaired(t0, h, xt0_, &xtplus_ie_, &xtplus_tr_);
 
     // If the step was not successful, reset the time and state.
     if (!success) {
-      context->SetTimeAndContinuousState(t0, xt0);
+      context->SetTimeAndContinuousState(t0, xt0_);
       return false;
     }
   }
 
   // Compute and update the error estimate.
-  err_est_vec_ = xtplus_ie - xtplus_itr;
+  err_est_vec_ = xtplus_ie_ - xtplus_tr_;
 
   // Update the caller-accessible error estimate.
   this->get_mutable_error_estimate()->get_mutable_vector().

--- a/systems/analysis/implicit_euler_integrator-inl.h
+++ b/systems/analysis/implicit_euler_integrator-inl.h
@@ -450,7 +450,7 @@ bool ImplicitEulerIntegrator<T>::DoImplicitIntegratorStep(const T& h) {
     num_err_est_function_evaluations_ += (evals_after_rk2 - evals_before_rk2);
 
     // Revert the state to that computed by explicit Euler.
-    context->SetTimeAndContinuousState(t0, xtplus_ie_);
+    context->SetTimeAndContinuousState(t0 + h, xtplus_ie_);
   } else {
     // Try taking the requested step.
     bool success = AttemptStepPaired(t0, h, xt0_, &xtplus_ie_, &xtplus_tr_);

--- a/systems/analysis/implicit_euler_integrator-inl.h
+++ b/systems/analysis/implicit_euler_integrator-inl.h
@@ -442,7 +442,11 @@ bool ImplicitEulerIntegrator<T>::DoImplicitIntegratorStep(const T& h) {
 
     // Compute the RK2 step.
     const int evals_before_rk2 = rk2_->get_num_derivative_evaluations();
-    DRAKE_DEMAND(rk2_->IntegrateWithSingleFixedStepToTime(t0 + h));
+    if (!rk2_->IntegrateWithSingleFixedStepToTime(t0 + h)) {
+      throw std::runtime_error("Embedded RK2 integrator failed to take a single"
+          "fixed step to the requested time.");
+    }
+
     const int evals_after_rk2 = rk2_->get_num_derivative_evaluations();
     xtplus_tr_ = context->get_continuous_state().CopyToVector();
 

--- a/systems/analysis/implicit_euler_integrator-inl.h
+++ b/systems/analysis/implicit_euler_integrator-inl.h
@@ -69,7 +69,7 @@ void ImplicitEulerIntegrator<T>::DoInitialize() {
 
   // Initialize the embedded second order Runge-Kutta integrator. The maximum
   // step size will be set to infinity because we will explicitly request the
-  // step sizes to be taken. 
+  // step sizes to be taken.
   rk2_ = std::make_unique<RungeKutta2Integrator<T>>(
       this->get_system(),
       std::numeric_limits<double>::infinity() /* maximum step size */,
@@ -434,7 +434,7 @@ bool ImplicitEulerIntegrator<T>::DoImplicitIntegratorStep(const T& h) {
     // The error estimation process for explicit Euler uses an explicit second
     // order Runge-Kutta method so that the order of the asymptotic term
     // matches that used for estimating the error of the implicit Euler
-    // integrator. 
+    // integrator.
 
     // Compute the Euler step.
     xdot_ = this->EvalTimeDerivatives(*context).CopyToVector();

--- a/systems/analysis/implicit_euler_integrator.h
+++ b/systems/analysis/implicit_euler_integrator.h
@@ -89,7 +89,7 @@ class ImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   /// This first-order integrator uses embedded second order methods to compute
   /// estimates of the local truncation error. The order of the asymptotic
   /// difference between these two methods (from which the error estimate is
-  /// computed) is O(h²). 
+  /// computed) is O(h²).
   int get_error_estimate_order() const final { return 2; }
 
  private:
@@ -162,7 +162,7 @@ class ImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   // Various statistics.
   int64_t num_nr_iterations_{0};
 
-  // Second order Runge-Kutta method for estimating the integration error when 
+  // Second order Runge-Kutta method for estimating the integration error when
   // the requested step size lies below the working step size.
   std::unique_ptr<RungeKutta2Integrator<T>> rk2_;
 

--- a/systems/analysis/implicit_euler_integrator.h
+++ b/systems/analysis/implicit_euler_integrator.h
@@ -162,7 +162,7 @@ class ImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   // Various statistics.
   int64_t num_nr_iterations_{0};
 
-  // Second order Runge-Kutta method for estimating the integration error for
+  // Second order Runge-Kutta method for estimating the integration error when 
   // the requested step size lies below the working step size.
   std::unique_ptr<RungeKutta2Integrator<T>> rk2_;
 

--- a/systems/analysis/implicit_euler_integrator.h
+++ b/systems/analysis/implicit_euler_integrator.h
@@ -9,6 +9,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/math/autodiff_gradient.h"
 #include "drake/systems/analysis/implicit_integrator.h"
+#include "drake/systems/analysis/runge_kutta2_integrator.h"
 
 namespace drake {
 namespace systems {
@@ -154,6 +155,10 @@ class ImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
 
   // Various statistics.
   int64_t num_nr_iterations_{0};
+
+  // Second order Runge-Kutta method for estimating the integration error for
+  // the requested step size lies below the working step size.
+  std::unique_ptr<RungeKutta2Integrator<T>> rk2_;
 
   // Implicit trapezoid specific statistics.
   int64_t num_err_est_jacobian_reforms_{0};

--- a/systems/analysis/implicit_euler_integrator.h
+++ b/systems/analysis/implicit_euler_integrator.h
@@ -156,7 +156,7 @@ class ImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   // The continuous state update vector used during Newton-Raphson.
   std::unique_ptr<ContinuousState<T>> dx_state_;
 
-  // Mutable variables to avoid heap allocations.
+  // Variables to avoid heap allocations.
   VectorX<T> xt0_, xdot_, xtplus_ie_, xtplus_tr_;
 
   // Various statistics.

--- a/systems/analysis/implicit_euler_integrator.h
+++ b/systems/analysis/implicit_euler_integrator.h
@@ -86,7 +86,10 @@ class ImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   /// The integrator supports error estimation.
   bool supports_error_estimation() const final { return true; }
 
-  /// This integrator provides second order error estimates.
+  /// This first-order integrator uses embedded second order methods to compute
+  /// estimates of the local truncation error. The order of the asymptotic
+  /// difference between these two methods (from which the error estimate is
+  /// computed) is O(h²). 
   int get_error_estimate_order() const final { return 2; }
 
  private:
@@ -152,6 +155,9 @@ class ImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
 
   // The continuous state update vector used during Newton-Raphson.
   std::unique_ptr<ContinuousState<T>> dx_state_;
+
+  // Mutable variables to avoid heap allocations.
+  VectorX<T> xt0_, xdot_, xtplus_ie_, xtplus_tr_;
 
   // Various statistics.
   int64_t num_nr_iterations_{0};

--- a/systems/analysis/integrator_base.h
+++ b/systems/analysis/integrator_base.h
@@ -686,7 +686,7 @@ class IntegratorBase {
     // that time be non-negative.
     DRAKE_DEMAND(context_->get_time() >= 0);
     const double tol = 10 * std::numeric_limits<double>::epsilon() *
-        ExtractDoubleOrThrow(max(t_target, context_->get_time()));
+        ExtractDoubleOrThrow(max(1.0, max(t_target, context_->get_time())));
     DRAKE_DEMAND(abs(context_->get_time() - t_target) < tol);
     context_->SetTime(t_target);
 

--- a/systems/analysis/test/implicit_euler_integrator_test.cc
+++ b/systems/analysis/test/implicit_euler_integrator_test.cc
@@ -322,8 +322,7 @@ GTEST_TEST(ImplicitIntegratorErrorEstimatorTest, LinearTest) {
   ie.Initialize();
   ASSERT_TRUE(ie.IntegrateWithSingleFixedStepToTime(t_final));
 
-  const double err_est =
-      ie.get_error_estimate()->get_vector().GetAtIndex(0);
+  const double err_est = ie.get_error_estimate()->get_vector()[0];
 
   // Note the very tight tolerance used, which will likely not hold for
   // arbitrary values of C, t_final, or polynomial coefficients.
@@ -345,8 +344,7 @@ GTEST_TEST(ImplicitIntegratorErrorEstimatorTest, LinearTest) {
   ie2.Initialize();
   ASSERT_TRUE(ie2.IntegrateWithSingleFixedStepToTime(updated_t_final));
 
-  const double updated_err_est =
-      ie2.get_error_estimate()->get_vector().GetAtIndex(0);
+  const double updated_err_est = ie2.get_error_estimate()->get_vector()[0];
 
   // Note the very tight tolerance used, which will likely not hold for
   // arbitrary values of C, t_final, or polynomial coefficients.

--- a/systems/analysis/test/implicit_euler_integrator_test.cc
+++ b/systems/analysis/test/implicit_euler_integrator_test.cc
@@ -299,13 +299,14 @@ TEST_F(ImplicitIntegratorTest, AccuracyEstAndErrorControl) {
   EXPECT_NO_THROW(integrator.request_initial_step_size_target(dt_));
 }
 
-// Tests accuracy for integrating the linear system (with the state at time t
-// corresponding to f(t) ≡ 4t + C, where C is the initial state) over
-// t ∈ [0, 1]. The error estimator from ImplicitEulerIntegrator is
-// second order, meaning that it uses the Taylor Series expansion:
-// f(t+h) ≈ f(t) + hf'(t) + O(h²)
+// Tests accuracy for integrating linear systems (with the state at time t
+// corresponding to f(t) ≡ St + C, where S is a scalar and C is the initial
+// state) over t ∈ [0, 1]. The asymptotic term in ImplicitEulerIntegrator's
+// error estimate is second order, meaning that it uses the Taylor Series
+// expansion:
+// f(t+h) ≈ f(t) + hf'(t) + O(h²).
 // This formula indicates that the approximation error will be zero if
-// f''(t) = 0, which is true for the linear equation. We check that the
+// f''(t) = 0, which is true for linear systems. We check that the
 // error estimator gives a perfect error estimate for this function.
 GTEST_TEST(ImplicitIntegratorErrorEstimatorTest, LinearTest) {
   LinearScalarSystem linear;
@@ -330,7 +331,7 @@ GTEST_TEST(ImplicitIntegratorErrorEstimatorTest, LinearTest) {
 
   // Repeat this test, but using a final time that is below the working minimum
   // step size (thereby triggering the implicit integrator's alternate, explicit
-  // mode). To retain our existing tolerances, we change the scale factor
+  // mode). To retain our existing tolerances, we change the scale factor (S)
   // for the linear system.
   ie.get_mutable_context()->SetTime(0);
   const double working_min = ie.get_working_minimum_step_size();

--- a/systems/analysis/test_utilities/linear_scalar_system.h
+++ b/systems/analysis/test_utilities/linear_scalar_system.h
@@ -8,14 +8,16 @@ namespace systems {
 namespace analysis_test {
 
 /// System where the state at (scalar) time t corresponds to the linear equation
-/// 4t + 3.
+/// St + 3, where S is 4 by default.
 class LinearScalarSystem : public LeafSystem<double> {
  public:
-  LinearScalarSystem() { this->DeclareContinuousState(1); }
+  LinearScalarSystem(double S = 4.0) : S_(S) {
+      this->DeclareContinuousState(1);
+  }
 
   // Evaluates the system at time t.
   double Evaluate(double t) const {
-    return 3 + 4 * t;
+    return 3 + S_ * t;
   }
 
  private:
@@ -29,8 +31,11 @@ class LinearScalarSystem : public LeafSystem<double> {
   void DoCalcTimeDerivatives(
       const Context<double>&,
       ContinuousState<double>* deriv) const override {
-    (*deriv)[0] = 4;
+    (*deriv)[0] = S_;
   }
+
+  // The linear scalar.
+  double S_;
 };
 
 }  // namespace analysis_test

--- a/systems/analysis/test_utilities/linear_scalar_system.h
+++ b/systems/analysis/test_utilities/linear_scalar_system.h
@@ -34,7 +34,6 @@ class LinearScalarSystem : public LeafSystem<double> {
     (*deriv)[0] = S_;
   }
 
-  // The linear scalar.
   double S_;
 };
 

--- a/systems/analysis/test_utilities/linear_scalar_system.h
+++ b/systems/analysis/test_utilities/linear_scalar_system.h
@@ -11,7 +11,7 @@ namespace analysis_test {
 /// St + 3, where S is 4 by default.
 class LinearScalarSystem : public LeafSystem<double> {
  public:
-  LinearScalarSystem(double S = 4.0) : S_(S) {
+  explicit LinearScalarSystem(double S = 4.0) : S_(S) {
       this->DeclareContinuousState(1);
   }
 

--- a/systems/analysis/test_utilities/linear_scalar_system.h
+++ b/systems/analysis/test_utilities/linear_scalar_system.h
@@ -34,7 +34,7 @@ class LinearScalarSystem : public LeafSystem<double> {
     (*deriv)[0] = S_;
   }
 
-  double S_;
+  double S_{};
 };
 
 }  // namespace analysis_test


### PR DESCRIPTION
This PR:

1. Replaces the embedded local extrapolation method (activated when the step size becomes very small) for error estimation with a much simpler call to the RK2 integrator.
2. Updates the documentation for the integrator, massaging text (for consistency with the existing integrators) about the order of the error estimation process.
3. Adds a test for the order of the error estimation process.
4. Replaces local variables with mutable class members to minimize the possibility of heap allocations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11727)
<!-- Reviewable:end -->
