### PR TITLE
Ensure sanitizer defect reports include line numbers

### DIFF
--- a/tools/dynamic_analysis/asan.sh
+++ b/tools/dynamic_analysis/asan.sh
@@ -5,4 +5,6 @@ export ASAN_OPTIONS="$ASAN_OPTIONS:check_initialization_order=1:detect_stack_use
 # LSan is run with ASan by default, ASAN_OPTIONS can't be used to suppress LSan
 # errors
 export LSAN_OPTIONS="$LSAN_OPTIONS:suppressions=$mydir/lsan.supp"
+# Ensure executable named llvm-symbolizer is on the PATH.
+export PATH="$PATH:/usr/lib/llvm-6.0/bin:/usr/local/opt/llvm/bin"
 "$@"

--- a/tools/dynamic_analysis/lsan.sh
+++ b/tools/dynamic_analysis/lsan.sh
@@ -2,4 +2,6 @@
 me=$(python -c 'import os; print(os.path.realpath("'"$0"'"))')
 mydir=$(dirname "$me")
 export LSAN_OPTIONS="$LSAN_OPTIONS:suppressions=$mydir/lsan.supp"
+# Ensure executable named llvm-symbolizer is on the PATH.
+export PATH="$PATH:/usr/lib/llvm-6.0/bin:/usr/local/opt/llvm/bin"
 "$@"

--- a/tools/dynamic_analysis/tsan.sh
+++ b/tools/dynamic_analysis/tsan.sh
@@ -2,4 +2,6 @@
 me=$(python -c 'import os; print(os.path.realpath("'"$0"'"))')
 mydir=$(dirname "$me")
 export TSAN_OPTIONS="$TSAN_OPTIONS:detect_deadlocks=1:second_deadlock_stack=1:suppressions=$mydir/tsan.supp"
+# Ensure executable named llvm-symbolizer is on the PATH.
+export PATH="$PATH:/usr/lib/llvm-6.0/bin:/usr/local/opt/llvm/bin"
 "$@"

--- a/tools/dynamic_analysis/ubsan.sh
+++ b/tools/dynamic_analysis/ubsan.sh
@@ -4,7 +4,7 @@ mydir=$(dirname "$me")
 # halt_on_error exits the program when the *first* error is detected by UBSan.
 # We're adding this because `exitcode` set in `UBSAN_OPTIONS` is not heeded by
 # clang without this option.
-export UBSAN_OPTIONS="$UBSAN_OPTIONS:
-suppressions=$mydir/ubsan.supp:
-halt_on_error=1"
+export UBSAN_OPTIONS="$UBSAN_OPTIONS:halt_on_error=1:suppressions=$mydir/ubsan.supp"
+# Ensure executable named llvm-symbolizer is on the PATH.
+export PATH="$PATH:/usr/lib/llvm-6.0/bin:/usr/local/opt/llvm/bin"
 "$@"


### PR DESCRIPTION
This was puzzling for a while, but seems likely we probably lost line numbers when we switched to clang-6.0 and the symbolizer in the `PATH` was no longer named `llvm-symbolizer`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11730)
<!-- Reviewable:end -->
