### PR TITLE
doc python: Make debugging tip easier to copy and paste

### DIFF
--- a/doc/python_bindings.rst
+++ b/doc/python_bindings.rst
@@ -330,19 +330,16 @@ trace. As an example:
         insert_awesome_code_here()
 
     if __name__ == "__main__":
-        # main()  # This is what you would have, but the following is useful:
+        # main()  # Normal invocation; commented out, because we will trace it.
 
-        # These are temporary, for debugging, so meh for programming style.
+        # The following (a) imports minimum dependencies, (b) ensures that
+        # output is immediately flushed (e.g. for segfaults), and (c) traces
+        # execution of your function, but filtering out any Python code outside
+        # of the system prefix.
         import sys, trace
-
-        # If there are segfaults, it's a good idea to always use stderr as it
-        # always prints to the screen, so you should get as much output as
-        # possible.
         sys.stdout = sys.stderr
-
-        # Now trace execution:
         tracer = trace.Trace(trace=1, count=0, ignoredirs=["/usr", sys.prefix])
-        tracer.run('main()')
+        tracer.runfunc(main)
 
 .. note::
 


### PR DESCRIPTION
Been meaning to do this for a while; I tend to use this frequently, but I've always disliked the copy+paste-ability of the existing code snippets. This makes it a little more compact, and uses `trace.runfunc(func, *args, **kwargs)`, which is better than `trace.run(str_to_eval)`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11732)
<!-- Reviewable:end -->
