### PR TITLE
py math: Document logical comparison for symbolic scalar types

### DIFF
--- a/bindings/pydrake/_math_extra.py
+++ b/bindings/pydrake/_math_extra.py
@@ -1,11 +1,35 @@
+"""
+Bindings for ``math``, including overloads for scalar types and basic SE(3)
+representations.
+
+Note that arrays of symbolic scalar types, such as ``Variable`` and
+``Expression``, are exposed using ``ndarray[object]``, and as such logical
+operations are constrained to return boolean values given NumPy's
+implementation; this is not desirable, as one should really get a ``Formula``
+object. As a workaround, this module provides the following vectorized
+operators, following suit with the ``operator`` builtin module:
+``lt``, ``le``, ``eq``, ``ne``, ``ge``, and ``gt``.
+
+As an example::
+
+    >>> x = np.array([Variable("x0"), Variable("x1")])
+    >>> y = np.array([Variable("y0"), Variable("y1")])
+    >>> x >= y
+    # This should throw a RuntimeError
+    >>> ge(x, y)
+    array([<Formula "(x0 >= y0)">, <Formula "(x1 >= y1)">], dtype=object)
+
+"""
+
 import operator
 
 import numpy as np
 
-# Add generic logical operators as ufuncs so that we may do comparisons on
-# arrays of any scalar type, without restriction on the output type.
-# These are added solely to work around #8315, where arrays of Expression can't
-# use direct logical operators (e.g. `<=`) since the output type is not bool.
+# As mentioned in top-level, add generic logical operators as ufuncs so that we
+# may do comparisons on arrays of any scalar type, without restriction on the
+# output type. These are added solely to work around #8315, where arrays of
+# Expression can't use direct logical operators (e.g. `<=`) since the output
+# type is not bool.
 # N.B. Defined in order listed in Python documentation:
 # https://docs.python.org/3.6/library/operator.html
 lt = np.vectorize(operator.lt)

--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -350,13 +350,11 @@ void DoScalarIndependentDefinitions(py::module m) {
   // See TODO in corresponding header file - these should be removed soon!
   pydrake::internal::BindAutoDiffMathOverloads(&m);
   pydrake::internal::BindSymbolicMathOverloads(&m);
-
-  ExecuteExtraPythonCode(m);
 }
 }  // namespace
 
 PYBIND11_MODULE(math, m) {
-  m.doc() = "Bindings for //math.";
+  // N.B. Docstring contained in `_math_extra.py`.
 
   py::module::import("pydrake.autodiffutils");
   py::module::import("pydrake.symbolic");
@@ -364,6 +362,8 @@ PYBIND11_MODULE(math, m) {
   type_visit([m](auto dummy) { DoScalarDependentDefinitions(m, dummy); },
       CommonScalarPack{});
   DoScalarIndependentDefinitions(m);
+
+  ExecuteExtraPythonCode(m);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -165,7 +165,12 @@ class PyFunctionConstraint : public Constraint {
 }  // namespace
 
 PYBIND11_MODULE(mathematicalprogram, m) {
-  m.doc() = "Drake MathematicalProgram Bindings";
+  m.doc() = R"""(
+Bindings for MathematicalProgram
+
+If you are formulating constraints using symbolic formulas, please review the
+top-level documentation for :py:mod:`pydrake.math`.
+)""";
   constexpr auto& doc = pydrake_doc.drake.solvers;
 
   py::module::import("pydrake.autodiffutils");


### PR DESCRIPTION
Per Slack convo:
https://drakedevelopers.slack.com/archives/C3YB3EV5W/p1561585127031200

\cc @RussTedrake

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11734)
<!-- Reviewable:end -->
