### PR TITLE
Use the event handlers for the receivers

### DIFF
--- a/examples/kinova_jaco_arm/jaco_lcm.h
+++ b/examples/kinova_jaco_arm/jaco_lcm.h
@@ -15,6 +15,7 @@
 #include "drake/common/eigen_types.h"
 #include "drake/lcmt_jaco_command.hpp"
 #include "drake/lcmt_jaco_status.hpp"
+#include "drake/systems/framework/event_status.h"
 #include "drake/systems/framework/leaf_system.h"
 
 namespace drake {
@@ -65,12 +66,11 @@ class JacoCommandReceiver : public systems::LeafSystem<double> {
   void OutputCommand(const systems::Context<double>& context,
                      systems::BasicVector<double>* output) const;
 
-  void DoCalcDiscreteVariableUpdates(
+  /// Event handler of the periodic discrete state update.
+  systems::EventStatus UpdateDiscreteState(
       const systems::Context<double>& context,
-      const std::vector<const systems::DiscreteUpdateEvent<double>*>&,
-      systems::DiscreteValues<double>* discrete_state) const override;
+      systems::DiscreteValues<double>* discrete_state) const;
 
- private:
   const int num_joints_;
   const int num_fingers_;
 };
@@ -133,10 +133,10 @@ class JacoStatusReceiver : public systems::LeafSystem<double> {
   void OutputStatus(const systems::Context<double>& context,
                     systems::BasicVector<double>* output) const;
 
-  void DoCalcDiscreteVariableUpdates(
+  /// Event handler of the periodic discrete state update.
+  systems::EventStatus UpdateDiscreteState(
       const systems::Context<double>& context,
-      const std::vector<const systems::DiscreteUpdateEvent<double>*>&,
-      systems::DiscreteValues<double>* discrete_state) const override;
+      systems::DiscreteValues<double>* discrete_state) const;
 
   const int num_joints_;
   const int num_fingers_;


### PR DESCRIPTION
This example overloads the dispatcher functions to handle periodic
discrete update, which is not recommended for general use cases. This PR
switches to use the customized event handlers instead. A forced update
event has been added to guarantee that the updated code is functionally
similar to the original event dispatcher implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11735)
<!-- Reviewable:end -->
