### PR TITLE
Add a function to declare forced unrestricted event

### DIFF
--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -2213,6 +2213,12 @@ class System : public SystemBase {
     return *forced_discrete_update_events_;
   }
 
+  EventCollection<UnrestrictedUpdateEvent<T>>&
+  get_mutable_forced_unrestricted_update_events() {
+    DRAKE_DEMAND(forced_unrestricted_update_events_.get());
+    return *forced_unrestricted_update_events_;
+  }
+
   const EventCollection<PublishEvent<T>>&
   get_forced_publish_events() const {
     DRAKE_DEMAND(forced_publish_events_.get());


### PR DESCRIPTION
Current leaf_system misses an API to declare forced unrestricted event. This PR adds this function and the corresponding unit test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11739)
<!-- Reviewable:end -->
