### PR TITLE
Add strip_path_prefix and other sanitizer options

### DIFF
--- a/tools/dynamic_analysis/asan.sh
+++ b/tools/dynamic_analysis/asan.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 me=$(python -c 'import os; print(os.path.realpath("'"$0"'"))')
 mydir=$(dirname "$me")
-export ASAN_OPTIONS="$ASAN_OPTIONS:check_initialization_order=1:detect_stack_use_after_return=1:suppressions=$mydir/asan.supp"
+export ASAN_OPTIONS="$ASAN_OPTIONS:check_initialization_order=1:detect_invalid_pointer_pairs=1:detect_stack_use_after_return=1:strict_init_order=1:strict_string_checks=1:strip_path_prefix=/proc/self/cwd/:suppressions=$mydir/asan.supp"
 # LSan is run with ASan by default, ASAN_OPTIONS can't be used to suppress LSan
 # errors
-export LSAN_OPTIONS="$LSAN_OPTIONS:suppressions=$mydir/lsan.supp"
+export LSAN_OPTIONS="$LSAN_OPTIONS:strip_path_prefix=/proc/self/cwd/:suppressions=$mydir/lsan.supp"
 # Ensure executable named llvm-symbolizer is on the PATH.
 export PATH="$PATH:/usr/lib/llvm-6.0/bin:/usr/local/opt/llvm/bin"
 "$@"

--- a/tools/dynamic_analysis/bazel.rc
+++ b/tools/dynamic_analysis/bazel.rc
@@ -37,10 +37,12 @@ build:asan --copt=-g
 # https://github.com/google/sanitizers/wiki/AddressSanitizer#faq
 build:asan --copt=-fno-common
 build:asan --copt=-fsanitize=address
+build:asan --copt=-fsanitize-address-use-after-scope
 build:asan --copt=-fstandalone-debug
 build:asan --copt=-O0
 build:asan --copt=-fno-omit-frame-pointer
 build:asan --linkopt=-fsanitize=address
+build:asan --linkopt=-fsanitize-address-use-after-scope
 build:asan --run_under=//tools/dynamic_analysis:asan
 build:asan --test_env=ASAN_OPTIONS
 build:asan --test_env=LSAN_OPTIONS
@@ -62,10 +64,12 @@ build:asan_everything --copt=-g
 # https://github.com/google/sanitizers/wiki/AddressSanitizer#faq
 build:asan_everything --copt=-fno-common
 build:asan_everything --copt=-fsanitize=address
+build:asan_everything --copt=-fsanitize-address-use-after-scope
 build:asan_everything --copt=-fstandalone-debug
 build:asan_everything --copt=-O0
 build:asan_everything --copt=-fno-omit-frame-pointer
 build:asan_everything --linkopt=-fsanitize=address
+build:asan_everything --linkopt=-fsanitize-address-use-after-scope
 # LSan is run with ASan by default
 build:asan_everything --test_tag_filters=-no_asan,-no_lsan
 build:asan_everything --run_under=//tools/dynamic_analysis:asan

--- a/tools/dynamic_analysis/lsan.sh
+++ b/tools/dynamic_analysis/lsan.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 me=$(python -c 'import os; print(os.path.realpath("'"$0"'"))')
 mydir=$(dirname "$me")
-export LSAN_OPTIONS="$LSAN_OPTIONS:suppressions=$mydir/lsan.supp"
+export LSAN_OPTIONS="$LSAN_OPTIONS:strip_path_prefix=/proc/self/cwd/:suppressions=$mydir/lsan.supp"
 # Ensure executable named llvm-symbolizer is on the PATH.
 export PATH="$PATH:/usr/lib/llvm-6.0/bin:/usr/local/opt/llvm/bin"
 "$@"

--- a/tools/dynamic_analysis/msan.sh
+++ b/tools/dynamic_analysis/msan.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 me=$(python -c 'import os; print(os.path.realpath("'"$0"'"))')
 mydir=$(dirname "$me")
-export MSAN_OPTIONS="$MSAN_OPTIONS:suppressions=$mydir/msan.supp"
+export MSAN_OPTIONS="$MSAN_OPTIONS:strip_path_prefix=/proc/self/cwd/:suppressions=$mydir/msan.supp"
 "$@"

--- a/tools/dynamic_analysis/tsan.sh
+++ b/tools/dynamic_analysis/tsan.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 me=$(python -c 'import os; print(os.path.realpath("'"$0"'"))')
 mydir=$(dirname "$me")
-export TSAN_OPTIONS="$TSAN_OPTIONS:detect_deadlocks=1:second_deadlock_stack=1:suppressions=$mydir/tsan.supp"
+export TSAN_OPTIONS="$TSAN_OPTIONS:detect_deadlocks=1:second_deadlock_stack=1:strip_path_prefix=/proc/self/cwd/:suppressions=$mydir/tsan.supp"
 # Ensure executable named llvm-symbolizer is on the PATH.
 export PATH="$PATH:/usr/lib/llvm-6.0/bin:/usr/local/opt/llvm/bin"
 "$@"

--- a/tools/dynamic_analysis/ubsan.sh
+++ b/tools/dynamic_analysis/ubsan.sh
@@ -4,7 +4,7 @@ mydir=$(dirname "$me")
 # halt_on_error exits the program when the *first* error is detected by UBSan.
 # We're adding this because `exitcode` set in `UBSAN_OPTIONS` is not heeded by
 # clang without this option.
-export UBSAN_OPTIONS="$UBSAN_OPTIONS:halt_on_error=1:suppressions=$mydir/ubsan.supp"
+export UBSAN_OPTIONS="$UBSAN_OPTIONS:halt_on_error=1:strip_path_prefix=/proc/self/cwd/:suppressions=$mydir/ubsan.supp"
 # Ensure executable named llvm-symbolizer is on the PATH.
 export PATH="$PATH:/usr/lib/llvm-6.0/bin:/usr/local/opt/llvm/bin"
 "$@"


### PR DESCRIPTION
Note that before we had `detect_stack_use_after_return=1` without `-fsanitize-address-use-after-scope` which was a no-op on the older versions of sanitizers that we use (`-fsanitize-address-use-after-scope` is the default in the latest versions).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11750)
<!-- Reviewable:end -->
