### PR TITLE
Add new method CalcRelativeRotationMatrix() for efficiency and ease-of use.

### DIFF
--- a/math/rotation_matrix.h
+++ b/math/rotation_matrix.h
@@ -139,7 +139,7 @@ class RotationMatrix {
   /// Note: B and A are no longer aligned.
   explicit RotationMatrix(const RollPitchYaw<T>& rpy) {
     // TODO(@mitiguy) Add publically viewable documentation on how Sherm and
-    // Goldstein's like to visualize/conceptualize rotation sequences.
+    // Goldstein like to visualize/conceptualize rotation sequences.
     const T& r = rpy.roll_angle();
     const T& p = rpy.pitch_angle();
     const T& y = rpy.yaw_angle();

--- a/math/rotation_matrix.h
+++ b/math/rotation_matrix.h
@@ -138,7 +138,8 @@ class RotationMatrix {
   /// rotate relative to frame A by a roll angle `y` about `Bz = Az`.
   /// Note: B and A are no longer aligned.
   explicit RotationMatrix(const RollPitchYaw<T>& rpy) {
-    // TODO(@mitiguy) Add Sherm/Goldstein's way to visualize rotation sequences.
+    // TODO(@mitiguy) Add publically viewable documentation on how Sherm and
+    // Goldstein's like to visualize/conceptualize rotation sequences.
     const T& r = rpy.roll_angle();
     const T& p = rpy.pitch_angle();
     const T& y = rpy.yaw_angle();
@@ -291,6 +292,17 @@ class RotationMatrix {
   /// currently allows cast from type double to AutoDiffXd, but not vice-versa.
   template <typename U>
   RotationMatrix<U> cast() const {
+    // TODO(Mitiguy) Make the RotationMatrix::cast() method more robust.  It is
+    // currently limited by Eigen's cast() for the matrix underlying this class.
+    // Consider the following logic to improve casts (and address issue #11785).
+    // 1. If relevant, use Eigen's underlying cast method.
+    // 2. Strip derivative data when casting from `<AutoDiffXd>` to `<double>`.
+    // 3. Call ExtractDoubleOrThrow() when casting from `<symbolic::Expression>`
+    //    to `<double>`.
+    // 4. The current RotationMatrix::cast() method incurs overhead due to its
+    //    underlying call to a RotationMatrix constructor. Perhaps create
+    //    specialized code to return a reference if casting to the same type,
+    //    e.g., casting from `<double>` to `<double>' should be inexpensive.
     const Matrix3<U> m = R_AB_.template cast<U>();
     return RotationMatrix<U>(m, true);
   }

--- a/multibody/inverse_kinematics/angle_between_vectors_constraint.cc
+++ b/multibody/inverse_kinematics/angle_between_vectors_constraint.cc
@@ -117,7 +117,7 @@ void DoEvalGeneric(const MultibodyPlant<T>& plant, systems::Context<T>* context,
   UpdateContextConfiguration(context, plant, x);
   const Frame<T>& frameA = plant.get_frame(frameA_index);
   const Frame<T>& frameB = plant.get_frame(frameB_index);
-  const RotationMatrix<T> R_AB =
+  const math::RotationMatrix<T> R_AB =
       plant.CalcRelativeRotationMatrix(*context, frameA, frameB);
   const Vector3<T> b_unit_A = R_AB * b_unit_B;
   *y = a_unit_A.transpose() * b_unit_A;

--- a/multibody/inverse_kinematics/angle_between_vectors_constraint.cc
+++ b/multibody/inverse_kinematics/angle_between_vectors_constraint.cc
@@ -120,13 +120,8 @@ void DoEvalGeneric(const MultibodyPlant<T>& plant, systems::Context<T>* context,
   const math::RotationMatrix<T> R_AB =
       plant.CalcRelativeRotationMatrix(*context, frameA, frameB);
 
-  // Note: The code below casts the Vector3 of type `<double>` to type `<T>`
-  // which allows RotationMatrix::operator* to multiply the RotationMatrix of
-  // type `<T>` by a Vector3 of type `<T>`.
-  // Alternately, use Eigen's underlying overloaded operator*, e.g., as
-  // const Vector3<T> b_unit_A = R_AB.matrix() * b_unit_B;
-  // Either way, the explicit cast() helps communicate the intent of this code
-  // which is to preserve the derivative information in R_AB.
+  // Note: The cast() below of Vector3 from type `<double>` to type `<T>`
+  // helps preserve derivative information in R_AB (if it exists).
   const Vector3<T> b_unit_A = R_AB * b_unit_B.cast<T>();
   *y = a_unit_A.transpose() * b_unit_A;
   EvalConstraintGradient(*context, plant, frameA, frameB, a_unit_A, b_unit_B,

--- a/multibody/inverse_kinematics/angle_between_vectors_constraint.cc
+++ b/multibody/inverse_kinematics/angle_between_vectors_constraint.cc
@@ -117,12 +117,12 @@ void DoEvalGeneric(const MultibodyPlant<T>& plant, systems::Context<T>* context,
   UpdateContextConfiguration(context, plant, x);
   const Frame<T>& frameA = plant.get_frame(frameA_index);
   const Frame<T>& frameB = plant.get_frame(frameB_index);
-  const Matrix3<T> R_AB =
-      plant.CalcRelativeTransform(*context, frameA, frameB).linear();
+  const RotationMatrix<T> R_AB =
+      plant.CalcRelativeRotationMatrix(*context, frameA, frameB);
   const Vector3<T> b_unit_A = R_AB * b_unit_B;
   *y = a_unit_A.transpose() * b_unit_A;
   EvalConstraintGradient(*context, plant, frameA, frameB, a_unit_A, b_unit_B,
-                         R_AB, x, y);
+                         R_AB.matrix(), x, y);
 }
 
 void AngleBetweenVectorsConstraint::DoEval(

--- a/multibody/inverse_kinematics/angle_between_vectors_constraint.cc
+++ b/multibody/inverse_kinematics/angle_between_vectors_constraint.cc
@@ -119,7 +119,15 @@ void DoEvalGeneric(const MultibodyPlant<T>& plant, systems::Context<T>* context,
   const Frame<T>& frameB = plant.get_frame(frameB_index);
   const math::RotationMatrix<T> R_AB =
       plant.CalcRelativeRotationMatrix(*context, frameA, frameB);
-  const Vector3<T> b_unit_A = R_AB.matrix() * b_unit_B;
+  // TODO(Mitiguy) Improve RotationMatrix operator* to allow multiplication of
+  // R * S where R is a RotationMatrix of one type and S is a Vector3 of a
+  // different type (e.g., R is type `<double>` and S is type `<AutoDiffXd>`).
+  // Background: The code below cannot use RotationMatrix operator* without a
+  // cast or RotationMatrix::matrix() [which uses Eigen's functionality].
+  // Why? R_AB is of type `<T>` whereas b_unit_B is of type `<double>`, yet
+  // RotationMatrix operator* only works for R_AB * b_unit_B if the type of
+  // R_AB is identical to the type of b_unit_B.  See issue #11779.
+  const Vector3<T> b_unit_A = R_AB * b_unit_B.cast<T>();
   *y = a_unit_A.transpose() * b_unit_A;
   EvalConstraintGradient(*context, plant, frameA, frameB, a_unit_A, b_unit_B,
                          R_AB.matrix(), x, y);

--- a/multibody/inverse_kinematics/angle_between_vectors_constraint.cc
+++ b/multibody/inverse_kinematics/angle_between_vectors_constraint.cc
@@ -119,7 +119,7 @@ void DoEvalGeneric(const MultibodyPlant<T>& plant, systems::Context<T>* context,
   const Frame<T>& frameB = plant.get_frame(frameB_index);
   const math::RotationMatrix<T> R_AB =
       plant.CalcRelativeRotationMatrix(*context, frameA, frameB);
-  const Vector3<T> b_unit_A = R_AB * b_unit_B;
+  const Vector3<T> b_unit_A = R_AB.matrix() * b_unit_B;
   *y = a_unit_A.transpose() * b_unit_A;
   EvalConstraintGradient(*context, plant, frameA, frameB, a_unit_A, b_unit_B,
                          R_AB.matrix(), x, y);

--- a/multibody/inverse_kinematics/angle_between_vectors_constraint.cc
+++ b/multibody/inverse_kinematics/angle_between_vectors_constraint.cc
@@ -120,8 +120,9 @@ void DoEvalGeneric(const MultibodyPlant<T>& plant, systems::Context<T>* context,
   const math::RotationMatrix<T> R_AB =
       plant.CalcRelativeRotationMatrix(*context, frameA, frameB);
 
-  // Note: The cast() below of Vector3 from type `<double>` to type `<T>`
-  // helps preserve derivative information in R_AB (if it exists).
+  // Note: The expression below has quantities with different scalar types.
+  // The cast from `double` to `T` preserves derivative or symbolic information
+  // in R_AB (if it exists).
   const Vector3<T> b_unit_A = R_AB * b_unit_B.cast<T>();
   *y = a_unit_A.transpose() * b_unit_A;
   EvalConstraintGradient(*context, plant, frameA, frameB, a_unit_A, b_unit_B,

--- a/multibody/inverse_kinematics/orientation_constraint.cc
+++ b/multibody/inverse_kinematics/orientation_constraint.cc
@@ -121,8 +121,9 @@ void DoEvalGeneric(const MultibodyPlant<T>& plant, systems::Context<T>* context,
   const math::RotationMatrix<T> R_AbarBbar =
       plant.CalcRelativeRotationMatrix(*context, frameAbar, frameBbar);
 
-  // Note: The casts below of RotationMatrix from type `<double>` to type `<T>`
-  // helps preserve derivative information in R_AbarBbar (if it exists).
+  // Note: The expression below has quantities with different scalar types.
+  // The casts from `double` to `T` preserves derivative or symbolic information
+  // in R_AbarBbar (if it exists).
   const math::RotationMatrix<T> R_AB = R_AbarA.cast<T>().inverse() * R_AbarBbar
                                      * R_BbarB.cast<T>();
   const Matrix3<T>& m = R_AB.matrix();

--- a/multibody/inverse_kinematics/orientation_constraint.cc
+++ b/multibody/inverse_kinematics/orientation_constraint.cc
@@ -121,15 +121,8 @@ void DoEvalGeneric(const MultibodyPlant<T>& plant, systems::Context<T>* context,
   const math::RotationMatrix<T> R_AbarBbar =
       plant.CalcRelativeRotationMatrix(*context, frameAbar, frameBbar);
 
-  // The code below casts a RotationMatrix of type `<double>` to type `<T>`
-  // which allows the RotationMatrix::operator* to multiply a RotationMatrix of
-  // type `<T>` by another RotationMatrix also of type `<T>`.
-  // Alternately, use Eigen's underlying overloaded operator*, e.g., as
-  // const Matrix3<T> m = R_AbarA.matrix().inverse() * R_AbarBbar.matrix()
-  //                    * R_BbarB.matrix();
-  // const math::RotationMatrix<T> R_AB(m);
-  // Either way, the explicit cast() helps communicate the intent of this code
-  // which is to preserve the derivative information in R_AbarBbar.
+  // Note: The casts below of RotationMatrix from type `<double>` to type `<T>`
+  // helps preserve derivative information in R_AbarBbar (if it exists).
   const math::RotationMatrix<T> R_AB = R_AbarA.cast<T>().inverse() * R_AbarBbar
                                      * R_BbarB.cast<T>();
   const Matrix3<T>& m = R_AB.matrix();

--- a/multibody/inverse_kinematics/orientation_constraint.cc
+++ b/multibody/inverse_kinematics/orientation_constraint.cc
@@ -118,10 +118,9 @@ void DoEvalGeneric(const MultibodyPlant<T>& plant, systems::Context<T>* context,
   const Frame<T>& frameAbar = plant.get_frame(frameAbar_index);
   const Frame<T>& frameBbar = plant.get_frame(frameBbar_index);
 
-  const Matrix3<T> R_AbarBbar =
-      plant.CalcRelativeTransform(*context, frameAbar, frameBbar).linear();
-  const Matrix3<T> R_AB =
-      R_AbarA.inverse().matrix() * R_AbarBbar * R_BbarB.matrix();
+  const math::RotationMatrix<T> R_AbarBbar =
+      plant.CalcRelativeRotationMatrix(*context, frameAbar, frameBbar);
+  const Matrix3<T> R_AB = (R_AbarA.inverse() * R_AbarBbar * R_BbarB()).matrix();
   const Vector3<T> r_AB{R_AB(1, 2) - R_AB(2, 1), R_AB(2, 0) - R_AB(0, 2),
                         R_AB(0, 1) - R_AB(1, 0)};
   EvalConstraintGradient(*context, plant, frameAbar, frameBbar, R_AbarA, R_AB,

--- a/multibody/inverse_kinematics/orientation_constraint.cc
+++ b/multibody/inverse_kinematics/orientation_constraint.cc
@@ -122,8 +122,8 @@ void DoEvalGeneric(const MultibodyPlant<T>& plant, systems::Context<T>* context,
       plant.CalcRelativeRotationMatrix(*context, frameAbar, frameBbar);
 
   // TODO(Mitiguy) Improve RotationMatrix operator* to allow multiplication of
-  // R * S where R is a RotationMatrix of one type and S is a RotationMatrix of
-  // a different type (e.g., R is type `<double>` and S is type `<AutoDiffXd>~).
+  // R1 * R2 where R1 is a RotationMatrix of one type and R2 is a RotationMatrix
+  // of a different type (e.g., R1 is `<double>` and R2 is `<AutoDiffXd>`).
   // Background: The code below cannot use RotationMatrix operator* without a
   // cast or RotationMatrix::matrix() [which uses Eigen's functionality].
   // Why? R_AB is of type `<T>` whereas R_BC is of type `<double>`, yet

--- a/multibody/inverse_kinematics/orientation_constraint.cc
+++ b/multibody/inverse_kinematics/orientation_constraint.cc
@@ -120,7 +120,8 @@ void DoEvalGeneric(const MultibodyPlant<T>& plant, systems::Context<T>* context,
 
   const math::RotationMatrix<T> R_AbarBbar =
       plant.CalcRelativeRotationMatrix(*context, frameAbar, frameBbar);
-  const Matrix3<T> R_AB = (R_AbarA.inverse() * R_AbarBbar * R_BbarB).matrix();
+  const Matrix3<T> R_AB =
+      R_AbarA.inverse().matrix() * R_AbarBbar.matrix() * R_BbarB.matrix();
   const Vector3<T> r_AB{R_AB(1, 2) - R_AB(2, 1), R_AB(2, 0) - R_AB(0, 2),
                         R_AB(0, 1) - R_AB(1, 0)};
   EvalConstraintGradient(*context, plant, frameAbar, frameBbar, R_AbarA, R_AB,

--- a/multibody/inverse_kinematics/orientation_constraint.cc
+++ b/multibody/inverse_kinematics/orientation_constraint.cc
@@ -120,7 +120,7 @@ void DoEvalGeneric(const MultibodyPlant<T>& plant, systems::Context<T>* context,
 
   const math::RotationMatrix<T> R_AbarBbar =
       plant.CalcRelativeRotationMatrix(*context, frameAbar, frameBbar);
-  const Matrix3<T> R_AB = (R_AbarA.inverse() * R_AbarBbar * R_BbarB()).matrix();
+  const Matrix3<T> R_AB = (R_AbarA.inverse() * R_AbarBbar * R_BbarB).matrix();
   const Vector3<T> r_AB{R_AB(1, 2) - R_AB(2, 1), R_AB(2, 0) - R_AB(0, 2),
                         R_AB(0, 1) - R_AB(1, 0)};
   EvalConstraintGradient(*context, plant, frameAbar, frameBbar, R_AbarA, R_AB,

--- a/multibody/inverse_kinematics/test/angle_between_vectors_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/angle_between_vectors_constraint_test.cc
@@ -13,9 +13,9 @@ AutoDiffVecXd EvalAngleBetweenVectorsConstraint(
     const Frame<AutoDiffXd>& frameA, const Vector3<double>& n_A,
     const Frame<AutoDiffXd>& frameB, const Vector3<double>& n_B) {
   Vector1<AutoDiffXd> y_autodiff;
-  y_autodiff(0) = n_A.normalized().dot(
-      plant.CalcRelativeRotationMatrix(context, frameA, frameB) *
-      n_B.normalized());
+  const math::RotationMatrix<AutoDiffXd> R_AB =
+      plant.CalcRelativeRotationMatrix(context, frameA, frameB);
+  y_autodiff(0) = n_A.normalized().dot(R_AB.matrix() * n_B.normalized());
   return y_autodiff;
 }
 

--- a/multibody/inverse_kinematics/test/angle_between_vectors_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/angle_between_vectors_constraint_test.cc
@@ -14,7 +14,7 @@ AutoDiffVecXd EvalAngleBetweenVectorsConstraint(
     const Frame<AutoDiffXd>& frameB, const Vector3<double>& n_B) {
   Vector1<AutoDiffXd> y_autodiff;
   y_autodiff(0) = n_A.normalized().dot(
-      plant.CalcRelativeTransform(context, frameA, frameB).linear() *
+      plant.CalcRelativeRotationMatrix(context, frameA, frameB) *
       n_B.normalized());
   return y_autodiff;
 }

--- a/multibody/inverse_kinematics/test/orientation_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/orientation_constraint_test.cc
@@ -16,10 +16,10 @@ AutoDiffVecXd EvalOrientationConstraintAutoDiff(
     const Frame<AutoDiffXd>& frameAbar, const RotationMatrixd& R_AbarA,
     const Frame<AutoDiffXd>& frameBbar, const RotationMatrixd& R_BbarB) {
   Vector1<AutoDiffXd> y_autodiff(1);
-  const Matrix3<AutoDiffXd> R_AbarBbar =
-      plant.CalcRelativeTransform(context, frameAbar, frameBbar).linear();
+  const RotationMatrix<AutoDiffXd> R_AbarBbar =
+      plant.CalcRelativeRotationMatrix(context, frameAbar, frameBbar);
   const Matrix3<AutoDiffXd> R_AB =
-      R_AbarA.matrix().cast<AutoDiffXd>().transpose() * R_AbarBbar *
+      R_AbarA.matrix().cast<AutoDiffXd>().transpose() * R_AbarBbar.matrix() *
       R_BbarB.matrix().cast<AutoDiffXd>();
   y_autodiff(0) = R_AB.trace();
   return y_autodiff;

--- a/multibody/inverse_kinematics/test/orientation_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/orientation_constraint_test.cc
@@ -16,12 +16,12 @@ AutoDiffVecXd EvalOrientationConstraintAutoDiff(
     const Frame<AutoDiffXd>& frameAbar, const RotationMatrixd& R_AbarA,
     const Frame<AutoDiffXd>& frameBbar, const RotationMatrixd& R_BbarB) {
   Vector1<AutoDiffXd> y_autodiff(1);
-  const RotationMatrix<AutoDiffXd> R_AbarBbar =
+  const math::RotationMatrix<AutoDiffXd> R_AbarBbar =
       plant.CalcRelativeRotationMatrix(context, frameAbar, frameBbar);
-  const Matrix3<AutoDiffXd> R_AB =
-      R_AbarA.matrix().cast<AutoDiffXd>().transpose() * R_AbarBbar.matrix() *
-      R_BbarB.matrix().cast<AutoDiffXd>();
-  y_autodiff(0) = R_AB.trace();
+  const math::RotationMatrix<AutoDiffXd> R_AB =
+      R_AbarA.cast<AutoDiffXd>().transpose() * R_AbarBbar *
+      R_BbarB.cast<AutoDiffXd>();
+  y_autodiff(0) = R_AB.matrix().trace();
   return y_autodiff;
 }
 

--- a/multibody/inverse_kinematics/test/orientation_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/orientation_constraint_test.cc
@@ -91,8 +91,8 @@ TEST_F(IiwaKinematicConstraintTest, OrientationConstraint) {
     dq(i, 0) = i * 2 + 1;
     dq(i, 1) = std::sin(i + 0.2);
   }
-  /* tolerance for checking numerical gradient vs analytical gradient. The
-   * numerical gradient is only accurate up to 2E-6 */
+  // tolerance for checking numerical gradient vs analytical gradient.
+  // The numerical gradient is only accurate up to 2E-6.
   const double gradient_tol = 2E-6;
   TestKinematicConstraintEval(*constraint, constraint_from_autodiff, q, dq,
                               gradient_tol);

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1382,8 +1382,6 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       const math::RigidTransform<T>& X_FB) const;
 
   /// Calculates the rigid transform (pose) `X_FG` relating frame F and frame G.
-  /// `X_FG` stores the rotation matrix `R_FG` and the position vector
-  /// `p_FoGo_F` from Fo (F's origin) to Go (G's origin), expressed in frame F.
   /// @param[in] context
   ///    The state of the multibody system, which includes the system's
   ///    generalized positions q.  Note: `X_FG` is a function of q.

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1381,26 +1381,38 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       const Frame<T>& frame_F, const Body<T>& body,
       const math::RigidTransform<T>& X_FB) const;
 
-  /// Computes the relative transform `X_AB(q)` from a frame B to a frame A, as
-  /// a function of the generalized positions q of the model.
-  /// That is, the position `p_AQ` of a point Q measured and expressed in
-  /// frame A can be computed from the position `p_BQ` of this point measured
-  /// and expressed in frame B using the transformation `p_AQ = X_AB⋅p_BQ`.
-  ///
-  /// @param[in] context
-  ///   The context containing the state of the model. It stores the
-  ///   generalized positions q of the model.
-  /// @param[in] frame_A
-  ///   The target frame A in the computed relative transform `X_AB`.
-  /// @param[in] frame_B
-  ///   The source frame B in the computed relative transform `X_AB`.
-  /// @retval X_AB
-  ///   The relative transform from frame B to frame A, such that
-  ///   `p_AQ = X_AB⋅p_BQ`.
+  /// Calculates the rigid transform `X_AB` that stores the pose (orientation
+  /// and position) of a frame B relative to a frame A.  `X_AB` stores the
+  /// rotation matrix `R_AB` that relates two sets of right-handed orthogonal
+  /// unit vectors, namely Ax, Ay, Az fixed in A to Bx, By, Bz fixed in B.
+  /// It also stores the position vector `p_AoBo_A`  from Ao (A's origin) to
+  /// Bo (B's origin), expressed in frame A (in terms of Ax, Ay, Az).
+  /// @param[in] context The state of the multibody system, which includes the
+  /// system's generalized positions q.  Note: `X_AB` is a function of q.
+  /// @param[in] frame_A The frame A designated in the rigid transform `X_AB`.
+  /// @param[in] frame_B The frame B designated in the rigid transform `X_AB`.
+  /// @retval X_AB  The RigidTransform relating frame A and frame B.
   math::RigidTransform<T> CalcRelativeTransform(
-      const systems::Context<T>& context, const Frame<T>& frame_A,
+      const systems::Context<T>& context,
+      const Frame<T>& frame_A,
       const Frame<T>& frame_B) const {
     return internal_tree().CalcRelativeTransform(context, frame_A, frame_B);
+  }
+
+  /// Calculates the rotation matrix R_AB that stores the orientation of a frame
+  /// B relative to a frame A.  R_AB relates two sets of right-handed orthogonal
+  /// unit vectors, namely Ax, Ay, Az fixed in A to Bx, By, Bz fixed in B.
+  /// @param[in] context The state of the multibody system, which includes the
+  /// system's generalized positions q.  Note: R_AB is a function of q.
+  /// @param[in] frame_A The frame A designated in the RotationMatrix `R_AB`.
+  /// @param[in] frame_B The frame B designated in the RotationMatrix `R_AB`.
+  /// @retval R_AB  The RotationMatrix relating frame A and frame B.
+  math::RigidTransform<T> CalcRelativeRotationMatrix(
+      const systems::Context<T>& context,
+      const Frame<T>& frame_A,
+      const Frame<T>& frame_B) const {
+    return internal_tree().CalcRelativeRotationMatrix(context,
+                                                      frame_A, frame_B);
   }
 
   /// Given the positions `p_BQi` for a set of points `Qi` measured and

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1407,7 +1407,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @param[in] frame_A The frame A designated in the RotationMatrix `R_AB`.
   /// @param[in] frame_B The frame B designated in the RotationMatrix `R_AB`.
   /// @retval R_AB  The RotationMatrix relating frame A and frame B.
-  math::RigidTransform<T> CalcRelativeRotationMatrix(
+  math::RotationMatrix<T> CalcRelativeRotationMatrix(
       const systems::Context<T>& context,
       const Frame<T>& frame_A,
       const Frame<T>& frame_B) const {

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1381,38 +1381,41 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       const Frame<T>& frame_F, const Body<T>& body,
       const math::RigidTransform<T>& X_FB) const;
 
-  /// Calculates the rigid transform `X_AB` that stores the pose (orientation
-  /// and position) of a frame B relative to a frame A.  `X_AB` stores the
-  /// rotation matrix `R_AB` that relates two sets of right-handed orthogonal
-  /// unit vectors, namely Ax, Ay, Az fixed in A to Bx, By, Bz fixed in B.
-  /// It also stores the position vector `p_AoBo_A`  from Ao (A's origin) to
-  /// Bo (B's origin), expressed in frame A (in terms of Ax, Ay, Az).
-  /// @param[in] context The state of the multibody system, which includes the
-  /// system's generalized positions q.  Note: `X_AB` is a function of q.
-  /// @param[in] frame_A The frame A designated in the rigid transform `X_AB`.
-  /// @param[in] frame_B The frame B designated in the rigid transform `X_AB`.
-  /// @retval X_AB  The RigidTransform relating frame A and frame B.
+  /// Calculates the rigid transform (pose) `X_FG` relating frame F and frame G.
+  /// `X_FG` stores the rotation matrix `R_FG` and the position vector
+  /// `p_FoGo_F` from Fo (F's origin) to Go (G's origin), expressed in frame F.
+  /// @param[in] context
+  ///    The state of the multibody system, which includes the system's
+  ///    generalized positions q.  Note: `X_FG` is a function of q.
+  /// @param[in] frame_F
+  ///    The frame F designated in the rigid transform `X_FG`.
+  /// @param[in] frame_G
+  ///    The frame G designated in the rigid transform `X_FG`.
+  /// @retval X_FG
+  ///    The RigidTransform relating frame F and frame G.
   math::RigidTransform<T> CalcRelativeTransform(
       const systems::Context<T>& context,
-      const Frame<T>& frame_A,
-      const Frame<T>& frame_B) const {
-    return internal_tree().CalcRelativeTransform(context, frame_A, frame_B);
+      const Frame<T>& frame_F,
+      const Frame<T>& frame_G) const {
+    return internal_tree().CalcRelativeTransform(context, frame_F, frame_G);
   }
 
-  /// Calculates the rotation matrix R_AB that stores the orientation of a frame
-  /// B relative to a frame A.  R_AB relates two sets of right-handed orthogonal
-  /// unit vectors, namely Ax, Ay, Az fixed in A to Bx, By, Bz fixed in B.
-  /// @param[in] context The state of the multibody system, which includes the
-  /// system's generalized positions q.  Note: R_AB is a function of q.
-  /// @param[in] frame_A The frame A designated in the RotationMatrix `R_AB`.
-  /// @param[in] frame_B The frame B designated in the RotationMatrix `R_AB`.
-  /// @retval R_AB  The RotationMatrix relating frame A and frame B.
+  /// Calculates the rotation matrix `R_FG` relating frame F and frame G.
+  /// @param[in] context
+  ///    The state of the multibody system, which includes the system's
+  ///    generalized positions q.  Note: `R_FG` is a function of q.
+  /// @param[in] frame_F
+  ///    The frame F designated in the rigid transform `R_FG`.
+  /// @param[in] frame_G
+  ///    The frame G designated in the rigid transform `R_FG`.
+  /// @retval R_FG
+  ///    The RigidTransform relating frame F and frame G.
   math::RotationMatrix<T> CalcRelativeRotationMatrix(
       const systems::Context<T>& context,
-      const Frame<T>& frame_A,
-      const Frame<T>& frame_B) const {
+      const Frame<T>& frame_F,
+      const Frame<T>& frame_G) const {
     return internal_tree().CalcRelativeRotationMatrix(context,
-                                                      frame_A, frame_B);
+                                                      frame_F, frame_G);
   }
 
   /// Given the positions `p_BQi` for a set of points `Qi` measured and

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -917,33 +917,33 @@ VectorX<T> MultibodyTree<T>::CalcGravityGeneralizedForces(
 template <typename T>
 RigidTransform<T> MultibodyTree<T>::CalcRelativeTransform(
     const systems::Context<T>& context,
-    const Frame<T>& frame_E,
-    const Frame<T>& frame_F) const {
+    const Frame<T>& frame_F,
+    const Frame<T>& frame_G) const {
   const PositionKinematicsCache<T>& pc = EvalPositionKinematics(context);
-  const Body<T>& A = frame_E.body();
-  const Body<T>& B = frame_F.body();
+  const Body<T>& A = frame_F.body();
+  const Body<T>& B = frame_G.body();
   const RigidTransform<T>& X_WA = pc.get_X_WB(A.node_index());
   const RigidTransform<T>& X_WB = pc.get_X_WB(B.node_index());
-  const RigidTransform<T> X_WE = X_WA * frame_E.CalcPoseInBodyFrame(context);
-  const RigidTransform<T> X_WF = X_WB * frame_F.CalcPoseInBodyFrame(context);
-  return X_WE.inverse() * X_WF;  // X_EF = X_EW * X_WF;
+  const RigidTransform<T> X_WF = X_WA * frame_F.CalcPoseInBodyFrame(context);
+  const RigidTransform<T> X_WG = X_WB * frame_G.CalcPoseInBodyFrame(context);
+  return X_WF.inverse() * X_WG;  // X_FG = X_FW * X_WG;
 }
 
 template <typename T>
 RotationMatrix<T> MultibodyTree<T>::CalcRelativeRotationMatrix(
     const systems::Context<T>& context,
-    const Frame<T>& frame_E,
-    const Frame<T>& frame_F) const {
+    const Frame<T>& frame_F,
+    const Frame<T>& frame_G) const {
   const PositionKinematicsCache<T>& pc = EvalPositionKinematics(context);
-  const Body<T>& A = frame_E.body();
-  const Body<T>& B = frame_F.body();
+  const Body<T>& A = frame_F.body();
+  const Body<T>& B = frame_G.body();
   const RotationMatrix<T>& R_WA = pc.get_X_WB(A.node_index()).rotation();
   const RotationMatrix<T>& R_WB = pc.get_X_WB(B.node_index()).rotation();
-  const RotationMatrix<T> R_WE =
-      R_WA * frame_E.CalcPoseInBodyFrame(context).rotation();
   const RotationMatrix<T> R_WF =
-      R_WB * frame_F.CalcPoseInBodyFrame(context).rotation();
-  return R_WE.inverse() * R_WF;  // R_EF = R_EW * R_WF;
+      R_WA * frame_F.CalcPoseInBodyFrame(context).rotation();
+  const RotationMatrix<T> R_WG =
+      R_WB * frame_G.CalcPoseInBodyFrame(context).rotation();
+  return R_WF.inverse() * R_WG;  // R_FG = R_FW * R_WG;
 }
 
 template <typename T>

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -1392,7 +1392,7 @@ void MultibodyTree<T>::CalcJacobianTranslationalVelocity(
   // Js_v_ABi_E = R_EW * (Js_v_WBi_W - Js_v_WAi_W).
   if (&frame_E != &frame_W) {
     const RotationMatrix<T> R_EW =
-        CalcRelativeTransform(context, frame_E, frame_W).rotation();
+        CalcRelativeRotationMatrix(context, frame_E, frame_W);
     // Extract the 3 x num_columns block that starts at row = 3 * i, column = 0.
     for (int i = 0;  i < num_points; ++i) {
       Js_v_ABi_E->template block<3, Eigen::Dynamic>(3 * i, 0, 3, num_columns) =

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -1215,7 +1215,14 @@ class MultibodyTree {
   /// See MultibodyPlant method.
   math::RigidTransform<T> CalcRelativeTransform(
       const systems::Context<T>& context,
-      const Frame<T>& frame_A, const Frame<T>& frame_B) const;
+      const Frame<T>& frame_A,
+      const Frame<T>& frame_B) const;
+
+  /// See MultibodyPlant method.
+  math::RotationMatrix<T> CalcRelativeRotationMatrix(
+      const systems::Context<T>& context,
+      const Frame<T>& frame_A,
+      const Frame<T>& frame_B) const;
 
   /// See MultibodyPlant method.
   void CalcPointsPositions(

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -1215,14 +1215,14 @@ class MultibodyTree {
   /// See MultibodyPlant method.
   math::RigidTransform<T> CalcRelativeTransform(
       const systems::Context<T>& context,
-      const Frame<T>& frame_A,
-      const Frame<T>& frame_B) const;
+      const Frame<T>& frame_F,
+      const Frame<T>& frame_G) const;
 
   /// See MultibodyPlant method.
   math::RotationMatrix<T> CalcRelativeRotationMatrix(
       const systems::Context<T>& context,
-      const Frame<T>& frame_A,
-      const Frame<T>& frame_B) const;
+      const Frame<T>& frame_F,
+      const Frame<T>& frame_G) const;
 
   /// See MultibodyPlant method.
   void CalcPointsPositions(

--- a/multibody/tree/test/tree_from_mobilizers_test.cc
+++ b/multibody/tree/test/tree_from_mobilizers_test.cc
@@ -1343,7 +1343,7 @@ TEST_F(PendulumKinematicTests, PointsPositionsAndRelativeTransform) {
   const RigidTransformd X_UL(tree().CalcRelativeTransform(
       *context_, upper_link_->body_frame(), lower_link_->body_frame()));
   const Vector3d p_UL = X_UL.translation();
-  const RotationMatrixd R_UL = X_UL.rotation();
+  const RotationMatrixd& R_UL = X_UL.rotation();
 
   const Vector3d p_UL_expected(0.0, -0.5, 0.0);
   const Matrix3d R_UL_expected(Eigen::AngleAxisd(M_PI_4, Vector3d::UnitZ()));
@@ -1352,6 +1352,13 @@ TEST_F(PendulumKinematicTests, PointsPositionsAndRelativeTransform) {
       p_UL, p_UL_expected, kTolerance, MatrixCompareType::relative));
   EXPECT_TRUE(CompareMatrices(
       R_UL.matrix(), R_UL_expected, kTolerance, MatrixCompareType::relative));
+
+  // Now test CalcRelativeRotationMatrix()
+  const math::RotationMatrix<double> RR_UL =
+      tree().CalcRelativeRotationMatrix(*context_, upper_link_->body_frame(),
+                                        lower_link_->body_frame());
+  EXPECT_TRUE(CompareMatrices(
+      RR_UL.matrix(), R_UL_expected, kTolerance, MatrixCompareType::relative));
 }
 
 TEST_F(PendulumKinematicTests, PointsHaveTheWrongSize) {

--- a/multibody/tree/test/tree_from_mobilizers_test.cc
+++ b/multibody/tree/test/tree_from_mobilizers_test.cc
@@ -1340,25 +1340,22 @@ TEST_F(PendulumKinematicTests, PointsPositionsAndRelativeTransform) {
   EXPECT_TRUE(CompareMatrices(
       p_WPi_set, p_WPi_set_expected, kTolerance, MatrixCompareType::relative));
 
-  const RigidTransformd X_UL(tree().CalcRelativeTransform(
-      *context_, upper_link_->body_frame(), lower_link_->body_frame()));
-  const Vector3d p_UL = X_UL.translation();
-  const RotationMatrixd& R_UL = X_UL.rotation();
-
   const Vector3d p_UL_expected(0.0, -0.5, 0.0);
   const Matrix3d R_UL_expected(Eigen::AngleAxisd(M_PI_4, Vector3d::UnitZ()));
 
-  EXPECT_TRUE(CompareMatrices(
-      p_UL, p_UL_expected, kTolerance, MatrixCompareType::relative));
-  EXPECT_TRUE(CompareMatrices(
-      R_UL.matrix(), R_UL_expected, kTolerance, MatrixCompareType::relative));
+  // Verify the RotationMatrix and position returned by CalcRelativeTransform().
+  const RigidTransformd X_UL(tree().CalcRelativeTransform(
+      *context_, upper_link_->body_frame(), lower_link_->body_frame()));
+  EXPECT_TRUE(CompareMatrices(X_UL.rotation().matrix(), R_UL_expected,
+                              kTolerance, MatrixCompareType::relative));
+  EXPECT_TRUE(CompareMatrices(X_UL.translation(), p_UL_expected,
+                              kTolerance, MatrixCompareType::relative));
 
-  // Now test CalcRelativeRotationMatrix()
-  const math::RotationMatrix<double> RR_UL =
-      tree().CalcRelativeRotationMatrix(*context_, upper_link_->body_frame(),
-                                        lower_link_->body_frame());
-  EXPECT_TRUE(CompareMatrices(
-      RR_UL.matrix(), R_UL_expected, kTolerance, MatrixCompareType::relative));
+  // Verify the RotationMatrix returned by CalcRelativeRotationMatrix().
+  const RotationMatrixd R_UL = tree().CalcRelativeRotationMatrix(
+      *context_, upper_link_->body_frame(), lower_link_->body_frame());
+  EXPECT_TRUE(CompareMatrices(R_UL.matrix(), R_UL_expected,
+                              kTolerance, MatrixCompareType::relative));
 }
 
 TEST_F(PendulumKinematicTests, PointsHaveTheWrongSize) {


### PR DESCRIPTION
Add new method CalcRelativeRotationMatrix() which helps with efficiency, ease-of-use, and for removal of deprecated .linear() from Isometry.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11752)
<!-- Reviewable:end -->
