### PR TITLE
symbolic::Expression holds a shared pointer to a non-const ExpressionCell

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -1016,6 +1016,15 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "symbolic_expression_cell_test",
+    deps = [
+        ":essential",
+        ":symbolic",
+        "//common/test_utilities:symbolic_test_util",
+    ],
+)
+
+drake_cc_googletest(
     name = "symbolic_expression_differentiation_test",
     deps = [
         ":essential",

--- a/common/symbolic_expression.cc
+++ b/common/symbolic_expression.cc
@@ -43,16 +43,16 @@ bool operator<(ExpressionKind k1, ExpressionKind k2) {
 
 namespace {
 // This function is used in Expression(const double d) constructor. It turns out
-// a ternary expression "std::isnan(d) ? make_shared<const ExpressionNaN>() :
-// make_shared<const ExpressionConstant>()" does not work due to C++'s
+// a ternary expression "std::isnan(d) ? make_shared<ExpressionNaN>() :
+// make_shared<ExpressionConstant>()" does not work due to C++'s
 // type-system. It throws "Incompatible operand types when using ternary
 // conditional operator" error. Related S&O entry:
 // http://stackoverflow.com/questions/29842095/incompatible-operand-types-when-using-ternary-conditional-operator.
-shared_ptr<const ExpressionCell> make_cell(const double d) {
+shared_ptr<ExpressionCell> make_cell(const double d) {
   if (std::isnan(d)) {
-    return make_shared<const ExpressionNaN>();
+    return make_shared<ExpressionNaN>();
   }
-  return make_shared<const ExpressionConstant>(d);
+  return make_shared<ExpressionConstant>(d);
 }
 
 // Negates an addition expression.
@@ -71,9 +71,9 @@ Expression NegateMultiplication(const Expression& e) {
 }  // namespace
 
 Expression::Expression(const Variable& var)
-    : ptr_{make_shared<const ExpressionVar>(var)} {}
+    : ptr_{make_shared<ExpressionVar>(var)} {}
 Expression::Expression(const double d) : ptr_{make_cell(d)} {}
-Expression::Expression(std::shared_ptr<const ExpressionCell> ptr)
+Expression::Expression(std::shared_ptr<ExpressionCell> ptr)
     : ptr_{std::move(ptr)} {}
 
 ExpressionKind Expression::get_kind() const {
@@ -109,7 +109,7 @@ Expression Expression::E() {
 
 Expression Expression::NaN() {
   static const never_destroyed<Expression> nan{
-      Expression{make_shared<const ExpressionNaN>()}};
+      Expression{make_shared<ExpressionNaN>()}};
   return nan.access();
 }
 
@@ -520,7 +520,7 @@ Expression& operator/=(Expression& lhs, const Expression& rhs) {
     lhs = Expression::One();
     return lhs;
   }
-  lhs.ptr_ = make_shared<const ExpressionDiv>(lhs, rhs);
+  lhs.ptr_ = make_shared<ExpressionDiv>(lhs, rhs);
   return lhs;
 }
 
@@ -556,7 +556,7 @@ Expression log(const Expression& e) {
     ExpressionLog::check_domain(v);
     return Expression{std::log(v)};
   }
-  return Expression{make_shared<const ExpressionLog>(e)};
+  return Expression{make_shared<ExpressionLog>(e)};
 }
 
 Expression abs(const Expression& e) {
@@ -564,7 +564,7 @@ Expression abs(const Expression& e) {
   if (is_constant(e)) {
     return Expression{std::fabs(get_constant_value(e))};
   }
-  return Expression{make_shared<const ExpressionAbs>(e)};
+  return Expression{make_shared<ExpressionAbs>(e)};
 }
 
 Expression exp(const Expression& e) {
@@ -572,7 +572,7 @@ Expression exp(const Expression& e) {
   if (is_constant(e)) {
     return Expression{std::exp(get_constant_value(e))};
   }
-  return Expression{make_shared<const ExpressionExp>(e)};
+  return Expression{make_shared<ExpressionExp>(e)};
 }
 
 Expression sqrt(const Expression& e) {
@@ -588,7 +588,7 @@ Expression sqrt(const Expression& e) {
       return abs(get_first_argument(e));
     }
   }
-  return Expression{make_shared<const ExpressionSqrt>(e)};
+  return Expression{make_shared<ExpressionSqrt>(e)};
 }
 
 Expression pow(const Expression& e1, const Expression& e2) {
@@ -616,9 +616,9 @@ Expression pow(const Expression& e1, const Expression& e2) {
     // pow(base, exponent) ^ e2 => pow(base, exponent * e2)
     const Expression& base{get_first_argument(e1)};
     const Expression& exponent{get_second_argument(e1)};
-    return Expression{make_shared<const ExpressionPow>(base, exponent * e2)};
+    return Expression{make_shared<ExpressionPow>(base, exponent * e2)};
   }
-  return Expression{make_shared<const ExpressionPow>(e1, e2)};
+  return Expression{make_shared<ExpressionPow>(e1, e2)};
 }
 
 Expression sin(const Expression& e) {
@@ -626,7 +626,7 @@ Expression sin(const Expression& e) {
   if (is_constant(e)) {
     return Expression{std::sin(get_constant_value(e))};
   }
-  return Expression{make_shared<const ExpressionSin>(e)};
+  return Expression{make_shared<ExpressionSin>(e)};
 }
 
 Expression cos(const Expression& e) {
@@ -635,7 +635,7 @@ Expression cos(const Expression& e) {
     return Expression{std::cos(get_constant_value(e))};
   }
 
-  return Expression{make_shared<const ExpressionCos>(e)};
+  return Expression{make_shared<ExpressionCos>(e)};
 }
 
 Expression tan(const Expression& e) {
@@ -643,7 +643,7 @@ Expression tan(const Expression& e) {
   if (is_constant(e)) {
     return Expression{std::tan(get_constant_value(e))};
   }
-  return Expression{make_shared<const ExpressionTan>(e)};
+  return Expression{make_shared<ExpressionTan>(e)};
 }
 
 Expression asin(const Expression& e) {
@@ -653,7 +653,7 @@ Expression asin(const Expression& e) {
     ExpressionAsin::check_domain(v);
     return Expression{std::asin(v)};
   }
-  return Expression{make_shared<const ExpressionAsin>(e)};
+  return Expression{make_shared<ExpressionAsin>(e)};
 }
 
 Expression acos(const Expression& e) {
@@ -663,7 +663,7 @@ Expression acos(const Expression& e) {
     ExpressionAcos::check_domain(v);
     return Expression{std::acos(v)};
   }
-  return Expression{make_shared<const ExpressionAcos>(e)};
+  return Expression{make_shared<ExpressionAcos>(e)};
 }
 
 Expression atan(const Expression& e) {
@@ -671,7 +671,7 @@ Expression atan(const Expression& e) {
   if (is_constant(e)) {
     return Expression{std::atan(get_constant_value(e))};
   }
-  return Expression{make_shared<const ExpressionAtan>(e)};
+  return Expression{make_shared<ExpressionAtan>(e)};
 }
 
 Expression atan2(const Expression& e1, const Expression& e2) {
@@ -680,7 +680,7 @@ Expression atan2(const Expression& e1, const Expression& e2) {
     return Expression{
         std::atan2(get_constant_value(e1), get_constant_value(e2))};
   }
-  return Expression{make_shared<const ExpressionAtan2>(e1, e2)};
+  return Expression{make_shared<ExpressionAtan2>(e1, e2)};
 }
 
 Expression sinh(const Expression& e) {
@@ -688,7 +688,7 @@ Expression sinh(const Expression& e) {
   if (is_constant(e)) {
     return Expression{std::sinh(get_constant_value(e))};
   }
-  return Expression{make_shared<const ExpressionSinh>(e)};
+  return Expression{make_shared<ExpressionSinh>(e)};
 }
 
 Expression cosh(const Expression& e) {
@@ -696,7 +696,7 @@ Expression cosh(const Expression& e) {
   if (is_constant(e)) {
     return Expression{std::cosh(get_constant_value(e))};
   }
-  return Expression{make_shared<const ExpressionCosh>(e)};
+  return Expression{make_shared<ExpressionCosh>(e)};
 }
 
 Expression tanh(const Expression& e) {
@@ -704,7 +704,7 @@ Expression tanh(const Expression& e) {
   if (is_constant(e)) {
     return Expression{std::tanh(get_constant_value(e))};
   }
-  return Expression{make_shared<const ExpressionTanh>(e)};
+  return Expression{make_shared<ExpressionTanh>(e)};
 }
 
 Expression min(const Expression& e1, const Expression& e2) {
@@ -716,7 +716,7 @@ Expression min(const Expression& e1, const Expression& e2) {
   if (is_constant(e1) && is_constant(e2)) {
     return Expression{std::min(get_constant_value(e1), get_constant_value(e2))};
   }
-  return Expression{make_shared<const ExpressionMin>(e1, e2)};
+  return Expression{make_shared<ExpressionMin>(e1, e2)};
 }
 
 Expression max(const Expression& e1, const Expression& e2) {
@@ -728,7 +728,7 @@ Expression max(const Expression& e1, const Expression& e2) {
   if (is_constant(e1) && is_constant(e2)) {
     return Expression{std::max(get_constant_value(e1), get_constant_value(e2))};
   }
-  return Expression{make_shared<const ExpressionMax>(e1, e2)};
+  return Expression{make_shared<ExpressionMax>(e1, e2)};
 }
 
 Expression ceil(const Expression& e) {
@@ -736,7 +736,7 @@ Expression ceil(const Expression& e) {
   if (is_constant(e)) {
     return Expression{std::ceil(get_constant_value(e))};
   }
-  return Expression{make_shared<const ExpressionCeiling>(e)};
+  return Expression{make_shared<ExpressionCeiling>(e)};
 }
 
 Expression floor(const Expression& e) {
@@ -744,7 +744,7 @@ Expression floor(const Expression& e) {
   if (is_constant(e)) {
     return Expression{std::floor(get_constant_value(e))};
   }
-  return Expression{make_shared<const ExpressionFloor>(e)};
+  return Expression{make_shared<ExpressionFloor>(e)};
 }
 
 Expression if_then_else(const Formula& f_cond, const Expression& e_then,
@@ -757,12 +757,11 @@ Expression if_then_else(const Formula& f_cond, const Expression& e_then,
   if (f_cond.EqualTo(Formula::False())) {
     return e_else;
   }
-  return Expression{
-      make_shared<const ExpressionIfThenElse>(f_cond, e_then, e_else)};
+  return Expression{make_shared<ExpressionIfThenElse>(f_cond, e_then, e_else)};
 }
 
 Expression uninterpreted_function(string name, vector<Expression> arguments) {
-  return Expression{make_shared<const ExpressionUninterpretedFunction>(
+  return Expression{make_shared<ExpressionUninterpretedFunction>(
       std::move(name), std::move(arguments))};
 }
 

--- a/common/symbolic_expression.h
+++ b/common/symbolic_expression.h
@@ -492,17 +492,48 @@ class Expression {
   friend std::shared_ptr<const ExpressionUninterpretedFunction>
   to_uninterpreted_function(const Expression& e);
 
+  // Cast functions which takes a pointer to a non-const Expression.
+  friend std::shared_ptr<ExpressionConstant> to_constant(Expression* e);
+  friend std::shared_ptr<ExpressionVar> to_variable(Expression* e);
+  friend std::shared_ptr<UnaryExpressionCell> to_unary(Expression* e);
+  friend std::shared_ptr<BinaryExpressionCell> to_binary(Expression* e);
+  friend std::shared_ptr<ExpressionAdd> to_addition(Expression* e);
+  friend std::shared_ptr<ExpressionMul> to_multiplication(Expression* e);
+  friend std::shared_ptr<ExpressionDiv> to_division(Expression* e);
+  friend std::shared_ptr<ExpressionLog> to_log(Expression* e);
+  friend std::shared_ptr<ExpressionAbs> to_abs(Expression* e);
+  friend std::shared_ptr<ExpressionExp> to_exp(Expression* e);
+  friend std::shared_ptr<ExpressionSqrt> to_sqrt(Expression* e);
+  friend std::shared_ptr<ExpressionPow> to_pow(Expression* e);
+  friend std::shared_ptr<ExpressionSin> to_sin(Expression* e);
+  friend std::shared_ptr<ExpressionCos> to_cos(Expression* e);
+  friend std::shared_ptr<ExpressionTan> to_tan(Expression* e);
+  friend std::shared_ptr<ExpressionAsin> to_asin(Expression* e);
+  friend std::shared_ptr<ExpressionAcos> to_acos(Expression* e);
+  friend std::shared_ptr<ExpressionAtan> to_atan(Expression* e);
+  friend std::shared_ptr<ExpressionAtan2> to_atan2(Expression* e);
+  friend std::shared_ptr<ExpressionSinh> to_sinh(Expression* e);
+  friend std::shared_ptr<ExpressionCosh> to_cosh(Expression* e);
+  friend std::shared_ptr<ExpressionTanh> to_tanh(Expression* e);
+  friend std::shared_ptr<ExpressionMin> to_min(Expression* e);
+  friend std::shared_ptr<ExpressionMax> to_max(Expression* e);
+  friend std::shared_ptr<ExpressionCeiling> to_ceil(Expression* e);
+  friend std::shared_ptr<ExpressionFloor> to_floor(Expression* e);
+  friend std::shared_ptr<ExpressionIfThenElse> to_if_then_else(Expression* e);
+  friend std::shared_ptr<ExpressionUninterpretedFunction>
+  to_uninterpreted_function(Expression* e);
+
   friend class ExpressionAddFactory;
   friend class ExpressionMulFactory;
 
  private:
-  explicit Expression(std::shared_ptr<const ExpressionCell> ptr);
+  explicit Expression(std::shared_ptr<ExpressionCell> ptr);
   void HashAppend(DelegatingHasher* hasher) const;
 
-  // Note: We use "const" ExpressionCell type here because an ExpressionCell
-  // object can be shared by multiple expressions, an expression should _not_ be
-  // able to change the cell that it points to.
-  std::shared_ptr<const ExpressionCell> ptr_;
+  // Note: We use "non-const" ExpressionCell type. This allows us to perform
+  // destructive updates on the pointed cell if the cell is not shared with
+  // other Expressions (that is, ptr_.use_count() == 1).
+  std::shared_ptr<ExpressionCell> ptr_;
 };
 
 Expression operator+(Expression lhs, const Expression& rhs);

--- a/common/symbolic_expression_cell.cc
+++ b/common/symbolic_expression_cell.cc
@@ -651,8 +651,7 @@ Expression ExpressionAddFactory::GetExpression() const {
     const auto it(expr_to_coeff_map_.cbegin());
     return it->first * it->second;
   }
-  return Expression{
-      make_shared<const ExpressionAdd>(constant_, expr_to_coeff_map_)};
+  return Expression{make_shared<ExpressionAdd>(constant_, expr_to_coeff_map_)};
 }
 
 void ExpressionAddFactory::AddConstant(const double constant) {
@@ -958,7 +957,7 @@ Expression ExpressionMulFactory::GetExpression() const {
     return pow(it->first, it->second);
   }
   return Expression{
-      make_shared<const ExpressionMul>(constant_, base_to_exponent_map_)};
+      make_shared<ExpressionMul>(constant_, base_to_exponent_map_)};
 }
 
 void ExpressionMulFactory::AddConstant(const double constant) {
@@ -2096,261 +2095,387 @@ bool is_uninterpreted_function(const ExpressionCell& c) {
   return c.get_kind() == ExpressionKind::UninterpretedFunction;
 }
 
-shared_ptr<const ExpressionConstant> to_constant(
-    const shared_ptr<const ExpressionCell>& expr_ptr) {
+shared_ptr<ExpressionConstant> to_constant(
+    const shared_ptr<ExpressionCell>& expr_ptr) {
   DRAKE_ASSERT(is_constant(*expr_ptr));
-  return static_pointer_cast<const ExpressionConstant>(expr_ptr);
+  return static_pointer_cast<ExpressionConstant>(expr_ptr);
 }
+
 shared_ptr<const ExpressionConstant> to_constant(const Expression& e) {
   return to_constant(e.ptr_);
 }
 
-shared_ptr<const ExpressionVar> to_variable(
-    const shared_ptr<const ExpressionCell>& expr_ptr) {
-  DRAKE_ASSERT(is_variable(*expr_ptr));
-  return static_pointer_cast<const ExpressionVar>(expr_ptr);
+shared_ptr<ExpressionConstant> to_constant(Expression* const e) {
+  return to_constant(e->ptr_);
 }
+
+shared_ptr<ExpressionVar> to_variable(
+    const shared_ptr<ExpressionCell>& expr_ptr) {
+  DRAKE_ASSERT(is_variable(*expr_ptr));
+  return static_pointer_cast<ExpressionVar>(expr_ptr);
+}
+
 shared_ptr<const ExpressionVar> to_variable(const Expression& e) {
   return to_variable(e.ptr_);
 }
 
-shared_ptr<const UnaryExpressionCell> to_unary(
-    const shared_ptr<const ExpressionCell>& expr_ptr) {
+shared_ptr<ExpressionVar> to_variable(Expression* const e) {
+  return to_variable(e->ptr_);
+}
+
+shared_ptr<UnaryExpressionCell> to_unary(
+    const shared_ptr<ExpressionCell>& expr_ptr) {
   DRAKE_ASSERT(is_log(*expr_ptr) || is_abs(*expr_ptr) || is_exp(*expr_ptr) ||
                is_sqrt(*expr_ptr) || is_sin(*expr_ptr) || is_cos(*expr_ptr) ||
                is_tan(*expr_ptr) || is_asin(*expr_ptr) || is_acos(*expr_ptr) ||
                is_atan(*expr_ptr) || is_sinh(*expr_ptr) || is_cosh(*expr_ptr) ||
                is_tanh(*expr_ptr) || is_ceil(*expr_ptr) || is_floor(*expr_ptr));
-  return static_pointer_cast<const UnaryExpressionCell>(expr_ptr);
+  return static_pointer_cast<UnaryExpressionCell>(expr_ptr);
 }
+
 shared_ptr<const UnaryExpressionCell> to_unary(const Expression& e) {
   return to_unary(e.ptr_);
 }
 
-shared_ptr<const BinaryExpressionCell> to_binary(
-    const shared_ptr<const ExpressionCell>& expr_ptr) {
+shared_ptr<UnaryExpressionCell> to_unary(Expression* const e) {
+  return to_unary(e->ptr_);
+}
+
+shared_ptr<BinaryExpressionCell> to_binary(
+    const shared_ptr<ExpressionCell>& expr_ptr) {
   DRAKE_ASSERT(is_division(*expr_ptr) || is_pow(*expr_ptr) ||
                is_atan2(*expr_ptr) || is_min(*expr_ptr) || is_max(*expr_ptr));
-  return static_pointer_cast<const BinaryExpressionCell>(expr_ptr);
+  return static_pointer_cast<BinaryExpressionCell>(expr_ptr);
 }
+
 shared_ptr<const BinaryExpressionCell> to_binary(const Expression& e) {
   return to_binary(e.ptr_);
 }
 
-shared_ptr<const ExpressionAdd> to_addition(
-    const shared_ptr<const ExpressionCell>& expr_ptr) {
-  DRAKE_ASSERT(is_addition(*expr_ptr));
-  return static_pointer_cast<const ExpressionAdd>(expr_ptr);
+shared_ptr<BinaryExpressionCell> to_binary(Expression* const e) {
+  return to_binary(e->ptr_);
 }
+
+shared_ptr<ExpressionAdd> to_addition(
+    const shared_ptr<ExpressionCell>& expr_ptr) {
+  DRAKE_ASSERT(is_addition(*expr_ptr));
+  return static_pointer_cast<ExpressionAdd>(expr_ptr);
+}
+
 shared_ptr<const ExpressionAdd> to_addition(const Expression& e) {
   return to_addition(e.ptr_);
 }
 
-shared_ptr<const ExpressionMul> to_multiplication(
-    const shared_ptr<const ExpressionCell>& expr_ptr) {
-  DRAKE_ASSERT(is_multiplication(*expr_ptr));
-  return static_pointer_cast<const ExpressionMul>(expr_ptr);
+shared_ptr<ExpressionAdd> to_addition(Expression* const e) {
+  return to_addition(e->ptr_);
 }
+
+shared_ptr<ExpressionMul> to_multiplication(
+    const shared_ptr<ExpressionCell>& expr_ptr) {
+  DRAKE_ASSERT(is_multiplication(*expr_ptr));
+  return static_pointer_cast<ExpressionMul>(expr_ptr);
+}
+
 shared_ptr<const ExpressionMul> to_multiplication(const Expression& e) {
   return to_multiplication(e.ptr_);
 }
 
-shared_ptr<const ExpressionDiv> to_division(
-    const shared_ptr<const ExpressionCell>& expr_ptr) {
-  DRAKE_ASSERT(is_division(*expr_ptr));
-  return static_pointer_cast<const ExpressionDiv>(expr_ptr);
+shared_ptr<ExpressionMul> to_multiplication(Expression* const e) {
+  return to_multiplication(e->ptr_);
 }
+
+shared_ptr<ExpressionDiv> to_division(
+    const shared_ptr<ExpressionCell>& expr_ptr) {
+  DRAKE_ASSERT(is_division(*expr_ptr));
+  return static_pointer_cast<ExpressionDiv>(expr_ptr);
+}
+
 shared_ptr<const ExpressionDiv> to_division(const Expression& e) {
   return to_division(e.ptr_);
 }
 
-shared_ptr<const ExpressionLog> to_log(
-    const shared_ptr<const ExpressionCell>& expr_ptr) {
-  DRAKE_ASSERT(is_log(*expr_ptr));
-  return static_pointer_cast<const ExpressionLog>(expr_ptr);
+shared_ptr<ExpressionDiv> to_division(Expression* const e) {
+  return to_division(e->ptr_);
 }
+
+shared_ptr<ExpressionLog> to_log(const shared_ptr<ExpressionCell>& expr_ptr) {
+  DRAKE_ASSERT(is_log(*expr_ptr));
+  return static_pointer_cast<ExpressionLog>(expr_ptr);
+}
+
 shared_ptr<const ExpressionLog> to_log(const Expression& e) {
   return to_log(e.ptr_);
 }
 
-shared_ptr<const ExpressionAbs> to_abs(
-    const shared_ptr<const ExpressionCell>& expr_ptr) {
-  DRAKE_ASSERT(is_abs(*expr_ptr));
-  return static_pointer_cast<const ExpressionAbs>(expr_ptr);
+shared_ptr<ExpressionLog> to_log(Expression* const e) {
+  return to_log(e->ptr_);
 }
+
+shared_ptr<ExpressionAbs> to_abs(const shared_ptr<ExpressionCell>& expr_ptr) {
+  DRAKE_ASSERT(is_abs(*expr_ptr));
+  return static_pointer_cast<ExpressionAbs>(expr_ptr);
+}
+
 shared_ptr<const ExpressionAbs> to_abs(const Expression& e) {
   return to_abs(e.ptr_);
 }
 
-shared_ptr<const ExpressionExp> to_exp(
-    const shared_ptr<const ExpressionCell>& expr_ptr) {
-  DRAKE_ASSERT(is_exp(*expr_ptr));
-  return static_pointer_cast<const ExpressionExp>(expr_ptr);
+shared_ptr<ExpressionAbs> to_abs(Expression* const e) {
+  return to_abs(e->ptr_);
 }
+
+shared_ptr<ExpressionExp> to_exp(const shared_ptr<ExpressionCell>& expr_ptr) {
+  DRAKE_ASSERT(is_exp(*expr_ptr));
+  return static_pointer_cast<ExpressionExp>(expr_ptr);
+}
+
 shared_ptr<const ExpressionExp> to_exp(const Expression& e) {
   return to_exp(e.ptr_);
 }
 
-shared_ptr<const ExpressionSqrt> to_sqrt(
-    const shared_ptr<const ExpressionCell>& expr_ptr) {
-  DRAKE_ASSERT(is_sqrt(*expr_ptr));
-  return static_pointer_cast<const ExpressionSqrt>(expr_ptr);
+shared_ptr<ExpressionExp> to_exp(Expression* const e) {
+  return to_exp(e->ptr_);
 }
+
+shared_ptr<ExpressionSqrt> to_sqrt(const shared_ptr<ExpressionCell>& expr_ptr) {
+  DRAKE_ASSERT(is_sqrt(*expr_ptr));
+  return static_pointer_cast<ExpressionSqrt>(expr_ptr);
+}
+
 shared_ptr<const ExpressionSqrt> to_sqrt(const Expression& e) {
   return to_sqrt(e.ptr_);
 }
-shared_ptr<const ExpressionPow> to_pow(
-    const shared_ptr<const ExpressionCell>& expr_ptr) {
-  DRAKE_ASSERT(is_pow(*expr_ptr));
-  return static_pointer_cast<const ExpressionPow>(expr_ptr);
+
+shared_ptr<ExpressionSqrt> to_sqrt(Expression* const e) {
+  return to_sqrt(e->ptr_);
 }
+
+shared_ptr<ExpressionPow> to_pow(const shared_ptr<ExpressionCell>& expr_ptr) {
+  DRAKE_ASSERT(is_pow(*expr_ptr));
+  return static_pointer_cast<ExpressionPow>(expr_ptr);
+}
+
 shared_ptr<const ExpressionPow> to_pow(const Expression& e) {
   return to_pow(e.ptr_);
 }
 
-shared_ptr<const ExpressionSin> to_sin(
-    const shared_ptr<const ExpressionCell>& expr_ptr) {
-  DRAKE_ASSERT(is_sin(*expr_ptr));
-  return static_pointer_cast<const ExpressionSin>(expr_ptr);
+shared_ptr<ExpressionPow> to_pow(Expression* const e) {
+  return to_pow(e->ptr_);
 }
+
+shared_ptr<ExpressionSin> to_sin(const shared_ptr<ExpressionCell>& expr_ptr) {
+  DRAKE_ASSERT(is_sin(*expr_ptr));
+  return static_pointer_cast<ExpressionSin>(expr_ptr);
+}
+
 shared_ptr<const ExpressionSin> to_sin(const Expression& e) {
   return to_sin(e.ptr_);
 }
 
-shared_ptr<const ExpressionCos> to_cos(
-    const shared_ptr<const ExpressionCell>& expr_ptr) {
-  DRAKE_ASSERT(is_cos(*expr_ptr));
-  return static_pointer_cast<const ExpressionCos>(expr_ptr);
+shared_ptr<ExpressionSin> to_sin(Expression* const e) {
+  return to_sin(e->ptr_);
 }
+
+shared_ptr<ExpressionCos> to_cos(const shared_ptr<ExpressionCell>& expr_ptr) {
+  DRAKE_ASSERT(is_cos(*expr_ptr));
+  return static_pointer_cast<ExpressionCos>(expr_ptr);
+}
+
 shared_ptr<const ExpressionCos> to_cos(const Expression& e) {
   return to_cos(e.ptr_);
 }
 
-shared_ptr<const ExpressionTan> to_tan(
-    const shared_ptr<const ExpressionCell>& expr_ptr) {
-  DRAKE_ASSERT(is_tan(*expr_ptr));
-  return static_pointer_cast<const ExpressionTan>(expr_ptr);
+shared_ptr<ExpressionCos> to_cos(Expression* const e) {
+  return to_cos(e->ptr_);
 }
+
+shared_ptr<ExpressionTan> to_tan(const shared_ptr<ExpressionCell>& expr_ptr) {
+  DRAKE_ASSERT(is_tan(*expr_ptr));
+  return static_pointer_cast<ExpressionTan>(expr_ptr);
+}
+
 shared_ptr<const ExpressionTan> to_tan(const Expression& e) {
   return to_tan(e.ptr_);
 }
 
-shared_ptr<const ExpressionAsin> to_asin(
-    const shared_ptr<const ExpressionCell>& expr_ptr) {
-  DRAKE_ASSERT(is_asin(*expr_ptr));
-  return static_pointer_cast<const ExpressionAsin>(expr_ptr);
+shared_ptr<ExpressionTan> to_tan(Expression* const e) {
+  return to_tan(e->ptr_);
 }
+
+shared_ptr<ExpressionAsin> to_asin(const shared_ptr<ExpressionCell>& expr_ptr) {
+  DRAKE_ASSERT(is_asin(*expr_ptr));
+  return static_pointer_cast<ExpressionAsin>(expr_ptr);
+}
+
 shared_ptr<const ExpressionAsin> to_asin(const Expression& e) {
   return to_asin(e.ptr_);
 }
 
-shared_ptr<const ExpressionAcos> to_acos(
-    const shared_ptr<const ExpressionCell>& expr_ptr) {
-  DRAKE_ASSERT(is_acos(*expr_ptr));
-  return static_pointer_cast<const ExpressionAcos>(expr_ptr);
+shared_ptr<ExpressionAsin> to_asin(Expression* const e) {
+  return to_asin(e->ptr_);
 }
+
+shared_ptr<ExpressionAcos> to_acos(const shared_ptr<ExpressionCell>& expr_ptr) {
+  DRAKE_ASSERT(is_acos(*expr_ptr));
+  return static_pointer_cast<ExpressionAcos>(expr_ptr);
+}
+
 shared_ptr<const ExpressionAcos> to_acos(const Expression& e) {
   return to_acos(e.ptr_);
 }
 
-shared_ptr<const ExpressionAtan> to_atan(
-    const shared_ptr<const ExpressionCell>& expr_ptr) {
-  DRAKE_ASSERT(is_atan(*expr_ptr));
-  return static_pointer_cast<const ExpressionAtan>(expr_ptr);
+shared_ptr<ExpressionAcos> to_acos(Expression* const e) {
+  return to_acos(e->ptr_);
 }
+
+shared_ptr<ExpressionAtan> to_atan(const shared_ptr<ExpressionCell>& expr_ptr) {
+  DRAKE_ASSERT(is_atan(*expr_ptr));
+  return static_pointer_cast<ExpressionAtan>(expr_ptr);
+}
+
 shared_ptr<const ExpressionAtan> to_atan(const Expression& e) {
   return to_atan(e.ptr_);
 }
 
-shared_ptr<const ExpressionAtan2> to_atan2(
-    const shared_ptr<const ExpressionCell>& expr_ptr) {
-  DRAKE_ASSERT(is_atan2(*expr_ptr));
-  return static_pointer_cast<const ExpressionAtan2>(expr_ptr);
+shared_ptr<ExpressionAtan> to_atan(Expression* const e) {
+  return to_atan(e->ptr_);
 }
+
+shared_ptr<ExpressionAtan2> to_atan2(
+    const shared_ptr<ExpressionCell>& expr_ptr) {
+  DRAKE_ASSERT(is_atan2(*expr_ptr));
+  return static_pointer_cast<ExpressionAtan2>(expr_ptr);
+}
+
 shared_ptr<const ExpressionAtan2> to_atan2(const Expression& e) {
   return to_atan2(e.ptr_);
 }
 
-shared_ptr<const ExpressionSinh> to_sinh(
-    const shared_ptr<const ExpressionCell>& expr_ptr) {
-  DRAKE_ASSERT(is_sinh(*expr_ptr));
-  return static_pointer_cast<const ExpressionSinh>(expr_ptr);
+shared_ptr<ExpressionAtan2> to_atan2(Expression* const e) {
+  return to_atan2(e->ptr_);
 }
+
+shared_ptr<ExpressionSinh> to_sinh(const shared_ptr<ExpressionCell>& expr_ptr) {
+  DRAKE_ASSERT(is_sinh(*expr_ptr));
+  return static_pointer_cast<ExpressionSinh>(expr_ptr);
+}
+
 shared_ptr<const ExpressionSinh> to_sinh(const Expression& e) {
   return to_sinh(e.ptr_);
 }
 
-shared_ptr<const ExpressionCosh> to_cosh(
-    const shared_ptr<const ExpressionCell>& expr_ptr) {
-  DRAKE_ASSERT(is_cosh(*expr_ptr));
-  return static_pointer_cast<const ExpressionCosh>(expr_ptr);
+shared_ptr<ExpressionSinh> to_sinh(Expression* const e) {
+  return to_sinh(e->ptr_);
 }
+
+shared_ptr<ExpressionCosh> to_cosh(const shared_ptr<ExpressionCell>& expr_ptr) {
+  DRAKE_ASSERT(is_cosh(*expr_ptr));
+  return static_pointer_cast<ExpressionCosh>(expr_ptr);
+}
+
 shared_ptr<const ExpressionCosh> to_cosh(const Expression& e) {
   return to_cosh(e.ptr_);
 }
 
-shared_ptr<const ExpressionTanh> to_tanh(
-    const shared_ptr<const ExpressionCell>& expr_ptr) {
-  DRAKE_ASSERT(is_tanh(*expr_ptr));
-  return static_pointer_cast<const ExpressionTanh>(expr_ptr);
+shared_ptr<ExpressionCosh> to_cosh(Expression* const e) {
+  return to_cosh(e->ptr_);
 }
+
+shared_ptr<ExpressionTanh> to_tanh(const shared_ptr<ExpressionCell>& expr_ptr) {
+  DRAKE_ASSERT(is_tanh(*expr_ptr));
+  return static_pointer_cast<ExpressionTanh>(expr_ptr);
+}
+
 shared_ptr<const ExpressionTanh> to_tanh(const Expression& e) {
   return to_tanh(e.ptr_);
 }
 
-shared_ptr<const ExpressionMin> to_min(
-    const shared_ptr<const ExpressionCell>& expr_ptr) {
-  DRAKE_ASSERT(is_min(*expr_ptr));
-  return static_pointer_cast<const ExpressionMin>(expr_ptr);
+shared_ptr<ExpressionTanh> to_tanh(Expression* const e) {
+  return to_tanh(e->ptr_);
 }
+
+shared_ptr<ExpressionMin> to_min(const shared_ptr<ExpressionCell>& expr_ptr) {
+  DRAKE_ASSERT(is_min(*expr_ptr));
+  return static_pointer_cast<ExpressionMin>(expr_ptr);
+}
+
 shared_ptr<const ExpressionMin> to_min(const Expression& e) {
   return to_min(e.ptr_);
 }
 
-shared_ptr<const ExpressionMax> to_max(
-    const shared_ptr<const ExpressionCell>& expr_ptr) {
-  DRAKE_ASSERT(is_max(*expr_ptr));
-  return static_pointer_cast<const ExpressionMax>(expr_ptr);
+shared_ptr<ExpressionMin> to_min(Expression* const e) {
+  return to_min(e->ptr_);
 }
+
+shared_ptr<ExpressionMax> to_max(const shared_ptr<ExpressionCell>& expr_ptr) {
+  DRAKE_ASSERT(is_max(*expr_ptr));
+  return static_pointer_cast<ExpressionMax>(expr_ptr);
+}
+
 shared_ptr<const ExpressionMax> to_max(const Expression& e) {
   return to_max(e.ptr_);
 }
 
-shared_ptr<const ExpressionCeiling> to_ceil(
-    const shared_ptr<const ExpressionCell>& expr_ptr) {
-  DRAKE_ASSERT(is_ceil(*expr_ptr));
-  return static_pointer_cast<const ExpressionCeiling>(expr_ptr);
+shared_ptr<ExpressionMax> to_max(Expression* const e) {
+  return to_max(e->ptr_);
 }
+
+shared_ptr<ExpressionCeiling> to_ceil(
+    const shared_ptr<ExpressionCell>& expr_ptr) {
+  DRAKE_ASSERT(is_ceil(*expr_ptr));
+  return static_pointer_cast<ExpressionCeiling>(expr_ptr);
+}
+
 shared_ptr<const ExpressionCeiling> to_ceil(const Expression& e) {
   return to_ceil(e.ptr_);
 }
 
-shared_ptr<const ExpressionFloor> to_floor(
-    const shared_ptr<const ExpressionCell>& expr_ptr) {
-  DRAKE_ASSERT(is_floor(*expr_ptr));
-  return static_pointer_cast<const ExpressionFloor>(expr_ptr);
+shared_ptr<ExpressionCeiling> to_ceil(Expression* const e) {
+  return to_ceil(e->ptr_);
 }
+
+shared_ptr<ExpressionFloor> to_floor(
+    const shared_ptr<ExpressionCell>& expr_ptr) {
+  DRAKE_ASSERT(is_floor(*expr_ptr));
+  return static_pointer_cast<ExpressionFloor>(expr_ptr);
+}
+
 shared_ptr<const ExpressionFloor> to_floor(const Expression& e) {
   return to_floor(e.ptr_);
 }
 
-shared_ptr<const ExpressionIfThenElse> to_if_then_else(
-    const shared_ptr<const ExpressionCell>& expr_ptr) {
-  DRAKE_ASSERT(is_if_then_else(*expr_ptr));
-  return static_pointer_cast<const ExpressionIfThenElse>(expr_ptr);
+shared_ptr<ExpressionFloor> to_floor(Expression* const e) {
+  return to_floor(e->ptr_);
 }
+
+shared_ptr<ExpressionIfThenElse> to_if_then_else(
+    const shared_ptr<ExpressionCell>& expr_ptr) {
+  DRAKE_ASSERT(is_if_then_else(*expr_ptr));
+  return static_pointer_cast<ExpressionIfThenElse>(expr_ptr);
+}
+
 shared_ptr<const ExpressionIfThenElse> to_if_then_else(const Expression& e) {
   return to_if_then_else(e.ptr_);
 }
 
-shared_ptr<const ExpressionUninterpretedFunction> to_uninterpreted_function(
-    const shared_ptr<const ExpressionCell>& expr_ptr) {
-  DRAKE_ASSERT(is_uninterpreted_function(*expr_ptr));
-  return static_pointer_cast<const ExpressionUninterpretedFunction>(expr_ptr);
+shared_ptr<ExpressionIfThenElse> to_if_then_else(Expression* const e) {
+  return to_if_then_else(e->ptr_);
 }
+
+shared_ptr<ExpressionUninterpretedFunction> to_uninterpreted_function(
+    const shared_ptr<ExpressionCell>& expr_ptr) {
+  DRAKE_ASSERT(is_uninterpreted_function(*expr_ptr));
+  return static_pointer_cast<ExpressionUninterpretedFunction>(expr_ptr);
+}
+
 shared_ptr<const ExpressionUninterpretedFunction> to_uninterpreted_function(
     const Expression& e) {
   return to_uninterpreted_function(e.ptr_);
+}
+
+shared_ptr<ExpressionUninterpretedFunction> to_uninterpreted_function(
+    Expression* const e) {
+  return to_uninterpreted_function(e->ptr_);
 }
 
 }  // namespace symbolic

--- a/common/symbolic_expression_cell.h
+++ b/common/symbolic_expression_cell.h
@@ -876,298 +876,472 @@ bool is_if_then_else(const ExpressionCell& c);
 /** Checks if @p c is an uninterpreted-function expression. */
 bool is_uninterpreted_function(const ExpressionCell& c);
 
-/** Casts @p expr_ptr to @c shared_ptr<const ExpressionConstant>.
+/** Casts @p expr_ptr to @c shared_ptr<ExpressionConstant>.
  *  @pre @p *expr_ptr is of @c ExpressionConstant.
  */
-std::shared_ptr<const ExpressionConstant> to_constant(
-    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+std::shared_ptr<ExpressionConstant> to_constant(
+    const std::shared_ptr<ExpressionCell>& expr_ptr);
+
 /** Casts @p e to @c shared_ptr<const ExpressionConstant>.
  *  @pre @p *(e.ptr_) is of @c ExpressionConstant.
  */
 std::shared_ptr<const ExpressionConstant> to_constant(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<const ExpressionVar>.
+/** Casts @p e to @c shared_ptr<ExpressionConstant>.
+ *  @pre @p *(e->ptr_) is of @c ExpressionConstant.
+ */
+std::shared_ptr<ExpressionConstant> to_constant(Expression* e);
+
+/** Casts @p expr_ptr to @c shared_ptr<ExpressionVar>.
  *  @pre @p *expr_ptr is of @c ExpressionVar.
  */
-std::shared_ptr<const ExpressionVar> to_variable(
-    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+std::shared_ptr<ExpressionVar> to_variable(
+    const std::shared_ptr<ExpressionCell>& expr_ptr);
+
 /** Casts @p e to @c shared_ptr<const ExpressionVar>.
  *  @pre @p *(e.ptr_) is of @c ExpressionVar.
  */
 std::shared_ptr<const ExpressionVar> to_variable(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<const UnaryExpressionCell>.
+/** Casts @p e to @c shared_ptr<ExpressionVar>.
+ *  @pre @p *(e->ptr_) is of @c ExpressionVar.
+ */
+std::shared_ptr<ExpressionVar> to_variable(Expression* e);
+
+/** Casts @p expr_ptr to @c shared_ptr<UnaryExpressionCell>.
  *  @pre @c *expr_ptr is of @c UnaryExpressionCell.
  */
-std::shared_ptr<const UnaryExpressionCell> to_unary(
-    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+std::shared_ptr<UnaryExpressionCell> to_unary(
+    const std::shared_ptr<ExpressionCell>& expr_ptr);
+
 /** Casts @p e to @c shared_ptr<const UnaryExpressionCell>.
  *  @pre @c *(e.ptr_) is of @c UnaryExpressionCell.
  */
 std::shared_ptr<const UnaryExpressionCell> to_unary(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<const BinaryExpressionCell>.
+/** Casts @p e to @c shared_ptr<UnaryExpressionCell>.
+ *  @pre @c *(e->ptr_) is of @c UnaryExpressionCell.
+ */
+std::shared_ptr<UnaryExpressionCell> to_unary(Expression* e);
+
+/** Casts @p expr_ptr to @c shared_ptr<BinaryExpressionCell>.
  *  @pre @c *expr_ptr is of @c BinaryExpressionCell.
  */
-std::shared_ptr<const BinaryExpressionCell> to_binary(
-    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+std::shared_ptr<BinaryExpressionCell> to_binary(
+    const std::shared_ptr<ExpressionCell>& expr_ptr);
+
 /** Casts @p e to @c shared_ptr<const BinaryExpressionCell>.
  *  @pre @c *(e.ptr_) is of @c BinaryExpressionCell.
  */
 std::shared_ptr<const BinaryExpressionCell> to_binary(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<const ExpressionAdd>.
+/** Casts @p e to @c shared_ptr<BinaryExpressionCell>.
+ *  @pre @c *(e->ptr_) is of @c BinaryExpressionCell.
+ */
+std::shared_ptr<BinaryExpressionCell> to_binary(Expression* e);
+
+/** Casts @p expr_ptr to @c shared_ptr<ExpressionAdd>.
  *  @pre @c *expr_ptr is of @c ExpressionAdd.
  */
-std::shared_ptr<const ExpressionAdd> to_addition(
-    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+std::shared_ptr<ExpressionAdd> to_addition(
+    const std::shared_ptr<ExpressionCell>& expr_ptr);
+
 /** Casts @p e to @c shared_ptr<const ExpressionAdd>.
  *  @pre @c *(e.ptr_) is of @c ExpressionAdd.
  */
 std::shared_ptr<const ExpressionAdd> to_addition(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<const ExpressionMul>.
+/** Casts @p e to @c shared_ptr<ExpressionAdd>.
+ *  @pre @c *(e.ptr_) is of @c ExpressionAdd.
+ */
+std::shared_ptr<ExpressionAdd> to_addition(Expression* e);
+
+/** Casts @p expr_ptr to @c shared_ptr<ExpressionMul>.
  *  @pre @c *expr_ptr is of @c ExpressionMul.
  */
-std::shared_ptr<const ExpressionMul> to_multiplication(
-    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+std::shared_ptr<ExpressionMul> to_multiplication(
+    const std::shared_ptr<ExpressionCell>& expr_ptr);
+
 /** Casts @p e to @c shared_ptr<const ExpressionMul>.
  *  @pre @c *(e.ptr_) is of @c ExpressionMul.
  */
 std::shared_ptr<const ExpressionMul> to_multiplication(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<const ExpressionDiv>.
+/** Casts @p e to @c shared_ptr<ExpressionMul>.
+ *  @pre @c *(e.ptr_) is of @c ExpressionMul.
+ */
+std::shared_ptr<ExpressionMul> to_multiplication(Expression* e);
+
+/** Casts @p expr_ptr to @c shared_ptr<ExpressionDiv>.
  *  @pre @c *expr_ptr is of @c ExpressionDiv.
  */
-std::shared_ptr<const ExpressionDiv> to_division(
-    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+std::shared_ptr<ExpressionDiv> to_division(
+    const std::shared_ptr<ExpressionCell>& expr_ptr);
+
 /** Casts @p e to @c shared_ptr<const ExpressionDiv>.
  *  @pre @c *(e.ptr_) is of @c ExpressionDiv.
  */
 std::shared_ptr<const ExpressionDiv> to_division(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<const ExpressionLog>.
+/** Casts @p e to @c shared_ptr<ExpressionDiv>.
+ *  @pre @c *(e.ptr_) is of @c ExpressionDiv.
+ */
+std::shared_ptr<ExpressionDiv> to_division(Expression* e);
+
+/** Casts @p expr_ptr to @c shared_ptr<ExpressionLog>.
  *  @pre @c *expr_ptr is of @c ExpressionLog.
  */
-std::shared_ptr<const ExpressionLog> to_log(
-    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+std::shared_ptr<ExpressionLog> to_log(
+    const std::shared_ptr<ExpressionCell>& expr_ptr);
+
 /** Casts @p e to @c shared_ptr<const ExpressionLog>.
  *  @pre @c *(e.ptr_) is of @c ExpressionLog.
  */
 std::shared_ptr<const ExpressionLog> to_log(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<const ExpressionExp>.
+/** Casts @p e to @c shared_ptr<ExpressionLog>.
+ *  @pre @c *(e.ptr_) is of @c ExpressionLog.
+ */
+std::shared_ptr<ExpressionLog> to_log(Expression* e);
+
+/** Casts @p expr_ptr to @c shared_ptr<ExpressionExp>.
  *  @pre @c *expr_ptr is of @c ExpressionExp.
  */
-std::shared_ptr<const ExpressionExp> to_exp(
-    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+std::shared_ptr<ExpressionExp> to_exp(
+    const std::shared_ptr<ExpressionCell>& expr_ptr);
+
 /** Casts @p e to @c shared_ptr<const ExpressionExp>.
  *  @pre @c *(e.ptr_) is of @c ExpressionExp.
  */
 std::shared_ptr<const ExpressionExp> to_exp(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<const ExpressionAbs>.
+/** Casts @p e to @c shared_ptr<ExpressionExp>.
+ *  @pre @c *(e.ptr_) is of @c ExpressionExp.
+ */
+std::shared_ptr<ExpressionExp> to_exp(Expression* e);
+
+/** Casts @p expr_ptr to @c shared_ptr<ExpressionAbs>.
  *  @pre @c *expr_ptr is of @c ExpressionAbs.
  */
-std::shared_ptr<const ExpressionAbs> to_abs(
-    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+std::shared_ptr<ExpressionAbs> to_abs(
+    const std::shared_ptr<ExpressionCell>& expr_ptr);
+
 /** Casts @p e to @c shared_ptr<const ExpressionAbs>.
  *  @pre @c *(e.ptr_) is of @c ExpressionAbs.
  */
 std::shared_ptr<const ExpressionAbs> to_abs(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<const ExpressionExp>.
+/** Casts @p e to @c shared_ptr<ExpressionAbs>.
+ *  @pre @c *(e.ptr_) is of @c ExpressionAbs.
+ */
+std::shared_ptr<ExpressionAbs> to_abs(Expression* e);
+
+/** Casts @p expr_ptr to @c shared_ptr<ExpressionExp>.
  *  @pre @c *expr_ptr is of @c ExpressionExp.
  */
-std::shared_ptr<const ExpressionExp> to_exp(
-    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+std::shared_ptr<ExpressionExp> to_exp(
+    const std::shared_ptr<ExpressionCell>& expr_ptr);
+
 /** Casts @p e to @c shared_ptr<const ExpressionExp>.
  *  @pre @c *(e.ptr_) is of @c ExpressionExp.
  */
 std::shared_ptr<const ExpressionExp> to_exp(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<const ExpressionSqrt>.
+/** Casts @p e to @c shared_ptr<ExpressionExp>.
+ *  @pre @c *(e.ptr_) is of @c ExpressionExp.
+ */
+std::shared_ptr<ExpressionExp> to_exp(Expression* e);
+
+/** Casts @p expr_ptr to @c shared_ptr<ExpressionSqrt>.
  *  @pre @c *expr_ptr is of @c ExpressionSqrt.
  */
-std::shared_ptr<const ExpressionSqrt> to_sqrt(
-    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+std::shared_ptr<ExpressionSqrt> to_sqrt(
+    const std::shared_ptr<ExpressionCell>& expr_ptr);
+
 /** Casts @p e to @c shared_ptr<const ExpressionSqrt>.
  *  @pre @c *(e.ptr_) is of @c ExpressionSqrt.
  */
 std::shared_ptr<const ExpressionSqrt> to_sqrt(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<const ExpressionPow>.
+/** Casts @p e to @c shared_ptr<ExpressionSqrt>.
+ *  @pre @c *(e.ptr_) is of @c ExpressionSqrt.
+ */
+std::shared_ptr<ExpressionSqrt> to_sqrt(Expression* e);
+
+/** Casts @p expr_ptr to @c shared_ptr<ExpressionPow>.
  *  @pre @c *expr_ptr is of @c ExpressionPow.
  */
-std::shared_ptr<const ExpressionPow> to_pow(
-    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+std::shared_ptr<ExpressionPow> to_pow(
+    const std::shared_ptr<ExpressionCell>& expr_ptr);
+
 /** Casts @p e to @c shared_ptr<const ExpressionPow>.
  *  @pre @c *(e.ptr_) is of @c ExpressionPow.
  */
 std::shared_ptr<const ExpressionPow> to_pow(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<const ExpressionSin>.
+/** Casts @p e to @c shared_ptr<ExpressionPow>.
+ *  @pre @c *(e.ptr_) is of @c ExpressionPow.
+ */
+std::shared_ptr<ExpressionPow> to_pow(Expression* e);
+
+/** Casts @p expr_ptr to @c shared_ptr<ExpressionSin>.
  *  @pre @c *expr_ptr is of @c ExpressionSin.
  */
-std::shared_ptr<const ExpressionSin> to_sin(
-    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+std::shared_ptr<ExpressionSin> to_sin(
+    const std::shared_ptr<ExpressionCell>& expr_ptr);
+
 /** Casts @p e to @c shared_ptr<const ExpressionSin>.
  *  @pre @c *(e.ptr_) is of @c ExpressionSin.
  */
 std::shared_ptr<const ExpressionSin> to_sin(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<const ExpressionCos>.
+/** Casts @p e to @c shared_ptr<ExpressionSin>.
+ *  @pre @c *(e.ptr_) is of @c ExpressionSin.
+ */
+std::shared_ptr<ExpressionSin> to_sin(Expression* e);
+
+/** Casts @p expr_ptr to @c shared_ptr<ExpressionCos>.
  *  @pre @c *expr_ptr is of @c ExpressionCos.
  */
-std::shared_ptr<const ExpressionCos> to_cos(
-    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+std::shared_ptr<ExpressionCos> to_cos(
+    const std::shared_ptr<ExpressionCell>& expr_ptr);
+
 /** Casts @p e to @c shared_ptr<const ExpressionCos>.
  *  @pre @c *(e.ptr_) is of @c ExpressionCos.
  */
 std::shared_ptr<const ExpressionCos> to_cos(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<const ExpressionTan>.
+/** Casts @p e to @c shared_ptr<ExpressionCos>.
+ *  @pre @c *(e.ptr_) is of @c ExpressionCos.
+ */
+std::shared_ptr<ExpressionCos> to_cos(Expression* e);
+
+/** Casts @p expr_ptr to @c shared_ptr<ExpressionTan>.
  *  @pre @c *expr_ptr is of @c ExpressionTan.
  */
-std::shared_ptr<const ExpressionTan> to_tan(
-    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+std::shared_ptr<ExpressionTan> to_tan(
+    const std::shared_ptr<ExpressionCell>& expr_ptr);
+
 /** Casts @p e to @c shared_ptr<const ExpressionTan>.
  *  @pre @c *(e.ptr_) is of @c ExpressionTan.
  */
 std::shared_ptr<const ExpressionTan> to_tan(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<const ExpressionAsin>.
+/** Casts @p e to @c shared_ptr<ExpressionTan>.
+ *  @pre @c *(e.ptr_) is of @c ExpressionTan.
+ */
+std::shared_ptr<ExpressionTan> to_tan(Expression* e);
+
+/** Casts @p expr_ptr to @c shared_ptr<ExpressionAsin>.
  *  @pre @c *expr_ptr is of @c ExpressionAsin.
  */
-std::shared_ptr<const ExpressionAsin> to_asin(
-    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+std::shared_ptr<ExpressionAsin> to_asin(
+    const std::shared_ptr<ExpressionCell>& expr_ptr);
+
 /** Casts @p e to @c shared_ptr<const ExpressionAsin>.
  *  @pre @c *(e.ptr_) is of @c ExpressionAsin.
  */
 std::shared_ptr<const ExpressionAsin> to_asin(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<const ExpressionAcos>.
+/** Casts @p e to @c shared_ptr<ExpressionAsin>.
+ *  @pre @c *(e.ptr_) is of @c ExpressionAsin.
+ */
+std::shared_ptr<ExpressionAsin> to_asin(Expression* e);
+
+/** Casts @p expr_ptr to @c shared_ptr<ExpressionAcos>.
  *  @pre @c *expr_ptr is of @c ExpressionAcos.
  */
-std::shared_ptr<const ExpressionAcos> to_acos(
-    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+std::shared_ptr<ExpressionAcos> to_acos(
+    const std::shared_ptr<ExpressionCell>& expr_ptr);
+
 /** Casts @p e to @c shared_ptr<const ExpressionAcos>.
  *  @pre @c *(e.ptr_) is of @c ExpressionAcos.
  */
 std::shared_ptr<const ExpressionAcos> to_acos(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<const ExpressionAtan>.
+/** Casts @p e to @c shared_ptr<ExpressionAcos>.
+ *  @pre @c *(e.ptr_) is of @c ExpressionAcos.
+ */
+std::shared_ptr<ExpressionAcos> to_acos(Expression* e);
+
+/** Casts @p expr_ptr to @c shared_ptr<ExpressionAtan>.
  *  @pre @c *expr_ptr is of @c ExpressionAtan.
  */
-std::shared_ptr<const ExpressionAtan> to_atan(
-    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+std::shared_ptr<ExpressionAtan> to_atan(
+    const std::shared_ptr<ExpressionCell>& expr_ptr);
+
 /** Casts @p e to @c shared_ptr<const ExpressionAtan>.
  *  @pre @c *(e.ptr_) is of @c ExpressionAtan.
  */
 std::shared_ptr<const ExpressionAtan> to_atan(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<const ExpressionAtan2>.
+/** Casts @p e to @c shared_ptr<ExpressionAtan>.
+ *  @pre @c *(e.ptr_) is of @c ExpressionAtan.
+ */
+std::shared_ptr<ExpressionAtan> to_atan(Expression* e);
+
+/** Casts @p expr_ptr to @c shared_ptr<ExpressionAtan2>.
  *  @pre @c *expr_ptr is of @c ExpressionAtan2.
  */
-std::shared_ptr<const ExpressionAtan2> to_atan2(
-    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+std::shared_ptr<ExpressionAtan2> to_atan2(
+    const std::shared_ptr<ExpressionCell>& expr_ptr);
+
 /** Casts @p e to @c shared_ptr<const ExpressionAtan2>.
  *  @pre @c *(e.ptr_) is of @c ExpressionAtan2.
  */
 std::shared_ptr<const ExpressionAtan2> to_atan2(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<const ExpressionSinh>.
+/** Casts @p e to @c shared_ptr<ExpressionAtan2>.
+ *  @pre @c *(e.ptr_) is of @c ExpressionAtan2.
+ */
+std::shared_ptr<ExpressionAtan2> to_atan2(Expression* e);
+
+/** Casts @p expr_ptr to @c shared_ptr<ExpressionSinh>.
  *  @pre @c *expr_ptr is of @c ExpressionSinh.
  */
-std::shared_ptr<const ExpressionSinh> to_sinh(
-    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+std::shared_ptr<ExpressionSinh> to_sinh(
+    const std::shared_ptr<ExpressionCell>& expr_ptr);
+
 /** Casts @p e to @c shared_ptr<const ExpressionSinh>.
  *  @pre @c *(e.ptr_) is of @c ExpressionSinh.
  */
 std::shared_ptr<const ExpressionSinh> to_sinh(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<const ExpressionCosh>.
+/** Casts @p e to @c shared_ptr<ExpressionSinh>.
+ *  @pre @c *(e.ptr_) is of @c ExpressionSinh.
+ */
+std::shared_ptr<ExpressionSinh> to_sinh(Expression* e);
+
+/** Casts @p expr_ptr to @c shared_ptr<ExpressionCosh>.
  *  @pre @c *expr_ptr is of @c ExpressionCosh.
  */
-std::shared_ptr<const ExpressionCosh> to_cosh(
-    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+std::shared_ptr<ExpressionCosh> to_cosh(
+    const std::shared_ptr<ExpressionCell>& expr_ptr);
+
 /** Casts @p e to @c shared_ptr<const ExpressionCosh>.
  *  @pre @c *(e.ptr_) is of @c ExpressionCosh.
  */
 std::shared_ptr<const ExpressionCosh> to_cosh(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<const ExpressionTanh>.
+/** Casts @p e to @c shared_ptr<ExpressionCosh>.
+ *  @pre @c *(e.ptr_) is of @c ExpressionCosh.
+ */
+std::shared_ptr<ExpressionCosh> to_cosh(Expression* e);
+
+/** Casts @p expr_ptr to @c shared_ptr<ExpressionTanh>.
  *  @pre @c *expr_ptr is of @c ExpressionTanh.
  */
-std::shared_ptr<const ExpressionTanh> to_tanh(
-    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+std::shared_ptr<ExpressionTanh> to_tanh(
+    const std::shared_ptr<ExpressionCell>& expr_ptr);
+
 /** Casts @p e to @c shared_ptr<const ExpressionTanh>.
  *  @pre @c *(e.ptr_) is of @c ExpressionTanh.
  */
 std::shared_ptr<const ExpressionTanh> to_tanh(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<const ExpressionMin>.
+/** Casts @p e to @c shared_ptr<ExpressionTanh>.
+ *  @pre @c *(e.ptr_) is of @c ExpressionTanh.
+ */
+std::shared_ptr<ExpressionTanh> to_tanh(Expression* e);
+
+/** Casts @p expr_ptr to @c shared_ptr<ExpressionMin>.
  *  @pre @c *expr_ptr is of @c ExpressionMin.
  */
-std::shared_ptr<const ExpressionMin> to_min(
-    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+std::shared_ptr<ExpressionMin> to_min(
+    const std::shared_ptr<ExpressionCell>& expr_ptr);
+
 /** Casts @p e to @c shared_ptr<const ExpressionMin>.
  *  @pre @c *(e.ptr_) is of @c ExpressionMin.
  */
 std::shared_ptr<const ExpressionMin> to_min(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<const ExpressionMax>.
+/** Casts @p e to @c shared_ptr<ExpressionMin>.
+ *  @pre @c *(e.ptr_) is of @c ExpressionMin.
+ */
+std::shared_ptr<ExpressionMin> to_min(Expression* e);
+
+/** Casts @p expr_ptr to @c shared_ptr<ExpressionMax>.
  *  @pre @c *expr_ptr is of @c ExpressionMax.
  */
-std::shared_ptr<const ExpressionMax> to_max(
-    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+std::shared_ptr<ExpressionMax> to_max(
+    const std::shared_ptr<ExpressionCell>& expr_ptr);
+
 /** Casts @p e to @c shared_ptr<const ExpressionMax>.
  *  @pre @c *(e.ptr_) is of @c ExpressionMax.
  */
 std::shared_ptr<const ExpressionMax> to_max(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<const ExpressionCeiling>.
+/** Casts @p e to @c shared_ptr<ExpressionMax>.
+ *  @pre @c *(e.ptr_) is of @c ExpressionMax.
+ */
+std::shared_ptr<ExpressionMax> to_max(Expression* e);
+
+/** Casts @p expr_ptr to @c shared_ptr<ExpressionCeiling>.
  *  @pre @c *expr_ptr is of @c ExpressionCeiling.
  */
-std::shared_ptr<const ExpressionCeiling> to_ceil(
-    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+std::shared_ptr<ExpressionCeiling> to_ceil(
+    const std::shared_ptr<ExpressionCell>& expr_ptr);
+
 /** Casts @p e to @c shared_ptr<const ExpressionCeiling>.
  *  @pre @c *(e.ptr_) is of @c ExpressionCeiling.
  */
 std::shared_ptr<const ExpressionCeiling> to_ceil(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<const ExpressionFloor>.
+/** Casts @p e to @c shared_ptr<ExpressionCeiling>.
+ *  @pre @c *(e.ptr_) is of @c ExpressionCeiling.
+ */
+std::shared_ptr<ExpressionCeiling> to_ceil(Expression* e);
+
+/** Casts @p expr_ptr to @c shared_ptr<ExpressionFloor>.
  *  @pre @c *expr_ptr is of @c ExpressionFloor.
  */
-std::shared_ptr<const ExpressionFloor> to_floor(
-    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+std::shared_ptr<ExpressionFloor> to_floor(
+    const std::shared_ptr<ExpressionCell>& expr_ptr);
+
 /** Casts @p e to @c shared_ptr<const ExpressionFloor>.
  *  @pre @c *(e.ptr_) is of @c ExpressionFloor.
  */
 std::shared_ptr<const ExpressionFloor> to_floor(const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<const ExpressionIfThenElse>.
+/** Casts @p e to @c shared_ptr<ExpressionFloor>.
+ *  @pre @c *(e.ptr_) is of @c ExpressionFloor.
+ */
+std::shared_ptr<ExpressionFloor> to_floor(Expression* e);
+
+/** Casts @p expr_ptr to @c shared_ptr<ExpressionIfThenElse>.
  *  @pre @c *expr_ptr is of @c ExpressionIfThenElse.
  */
-std::shared_ptr<const ExpressionIfThenElse> to_if_then_else(
-    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+std::shared_ptr<ExpressionIfThenElse> to_if_then_else(
+    const std::shared_ptr<ExpressionCell>& expr_ptr);
+
 /** Casts @p e to @c shared_ptr<const ExpressionIfThenElse>.
  *  @pre @c *(e.ptr_) is of @c ExpressionIfThenElse.
  */
 std::shared_ptr<const ExpressionIfThenElse> to_if_then_else(
     const Expression& e);
 
-/** Casts @p expr_ptr to @c shared_ptr<const ExpressionUninterpretedFunction>.
+/** Casts @p e to @c shared_ptr<ExpressionIfThenElse>.
+ *  @pre @c *(e.ptr_) is of @c ExpressionIfThenElse.
+ */
+std::shared_ptr<ExpressionIfThenElse> to_if_then_else(Expression* e);
+
+/** Casts @p expr_ptr to @c shared_ptr<ExpressionUninterpretedFunction>.
  *  @pre @c *expr_ptr is of @c ExpressionUninterpretedFunction.
  */
-std::shared_ptr<const ExpressionUninterpretedFunction>
-to_uninterpreted_function(
-    const std::shared_ptr<const ExpressionCell>& expr_ptr);
+std::shared_ptr<ExpressionUninterpretedFunction> to_uninterpreted_function(
+    const std::shared_ptr<ExpressionCell>& expr_ptr);
+
 /** Casts @p e to @c shared_ptr<const ExpressionUninterpretedFunction>.
  *  @pre @c *(e.ptr_) is of @c ExpressionUninterpretedFunction.
  */
 std::shared_ptr<const ExpressionUninterpretedFunction>
 to_uninterpreted_function(const Expression& e);
+
+/** Casts @p e to @c shared_ptr<ExpressionUninterpretedFunction>.
+ *  @pre @c *(e.ptr_) is of @c ExpressionUninterpretedFunction.
+ */
+std::shared_ptr<ExpressionUninterpretedFunction> to_uninterpreted_function(
+    Expression* e);
 
 }  // namespace symbolic
 }  // namespace drake

--- a/common/test/symbolic_expression_cell_test.cc
+++ b/common/test/symbolic_expression_cell_test.cc
@@ -1,0 +1,224 @@
+#define DRAKE_COMMON_SYMBOLIC_DETAIL_HEADER
+#include "drake/common/symbolic_expression_cell.h"
+#undef DRAKE_COMMON_SYMBOLIC_DETAIL_HEADER
+
+#include <gtest/gtest.h>
+
+#include "drake/common/symbolic.h"
+#include "drake/common/test_utilities/symbolic_test_util.h"
+
+namespace drake {
+namespace symbolic {
+namespace {
+
+using test::ExprEqual;
+using test::FormulaEqual;
+
+// Provides common variables and expressions that are used by the following
+// tests.
+class SymbolicExpressionCellTest : public ::testing::Test {
+ protected:
+  const Variable var_x_{"x"};
+  const Variable var_y_{"y"};
+  const Variable var_z_{"z"};
+
+  const Expression x_{var_x_};
+  const Expression y_{var_y_};
+
+  const Expression e_constant_{1.0};
+  const Expression e_var_{var_x_};
+  const Expression e_add_{x_ + y_};
+  const Expression e_mul_{x_ * y_};
+  const Expression e_div_{x_ / y_};
+  const Expression e_log_{log(x_)};
+  const Expression e_abs_{abs(x_)};
+  const Expression e_exp_{exp(x_)};
+  const Expression e_sqrt_{sqrt(x_)};
+  const Expression e_pow_{pow(x_, y_)};
+  const Expression e_sin_{sin(x_)};
+  const Expression e_cos_{cos(x_)};
+  const Expression e_tan_{tan(x_)};
+  const Expression e_asin_{asin(x_)};
+  const Expression e_acos_{acos(x_)};
+  const Expression e_atan_{atan(x_)};
+  const Expression e_atan2_{atan2(x_, y_)};
+  const Expression e_sinh_{sinh(x_)};
+  const Expression e_cosh_{cosh(x_)};
+  const Expression e_tanh_{tanh(x_)};
+  const Expression e_min_{min(x_, y_)};
+  const Expression e_max_{max(x_, y_)};
+  const Expression e_ceil_{ceil(x_)};
+  const Expression e_floor_{floor(x_)};
+  const Expression e_ite_{if_then_else(x_ < y_, x_, y_)};
+  const Expression e_uf_{uninterpreted_function("uf", {var_x_, var_y_})};
+};
+
+TEST_F(SymbolicExpressionCellTest, CastFunctionsConst) {
+  EXPECT_EQ(to_constant(e_constant_)->get_value(),
+            get_constant_value(e_constant_));
+  EXPECT_EQ(to_variable(e_var_)->get_variable(), get_variable(e_var_));
+
+  EXPECT_EQ(to_addition(e_add_)->get_constant(),
+            get_constant_in_addition(e_add_));
+  EXPECT_EQ(to_addition(e_add_)->get_expr_to_coeff_map(),
+            get_expr_to_coeff_map_in_addition(e_add_));
+
+  EXPECT_EQ(to_multiplication(e_mul_)->get_constant(),
+            get_constant_in_multiplication(e_mul_));
+  EXPECT_EQ(to_multiplication(e_mul_)->get_base_to_exponent_map().size(),
+            get_base_to_exponent_map_in_multiplication(e_mul_).size());
+  EXPECT_EQ(to_multiplication(e_mul_)->get_base_to_exponent_map().size(), 2);
+  EXPECT_PRED2(ExprEqual,
+               to_multiplication(e_mul_)->get_base_to_exponent_map().at(var_x_),
+               get_base_to_exponent_map_in_multiplication(e_mul_).at(var_x_));
+  EXPECT_PRED2(ExprEqual,
+               to_multiplication(e_mul_)->get_base_to_exponent_map().at(var_y_),
+               get_base_to_exponent_map_in_multiplication(e_mul_).at(var_y_));
+
+  EXPECT_EQ(to_division(e_div_)->get_second_argument(),
+            get_second_argument(e_div_));
+  EXPECT_EQ(to_division(e_div_)->get_second_argument(),
+            get_second_argument(e_div_));
+
+  EXPECT_EQ(to_log(e_log_)->get_argument(), get_argument(e_log_));
+  EXPECT_EQ(to_abs(e_abs_)->get_argument(), get_argument(e_abs_));
+  EXPECT_EQ(to_exp(e_exp_)->get_argument(), get_argument(e_exp_));
+  EXPECT_EQ(to_sqrt(e_sqrt_)->get_argument(), get_argument(e_sqrt_));
+  EXPECT_EQ(to_pow(e_pow_)->get_first_argument(), get_first_argument(e_pow_));
+  EXPECT_EQ(to_pow(e_pow_)->get_second_argument(), get_second_argument(e_pow_));
+  EXPECT_EQ(to_sin(e_sin_)->get_argument(), get_argument(e_sin_));
+  EXPECT_EQ(to_cos(e_cos_)->get_argument(), get_argument(e_cos_));
+  EXPECT_EQ(to_tan(e_tan_)->get_argument(), get_argument(e_tan_));
+  EXPECT_EQ(to_asin(e_asin_)->get_argument(), get_argument(e_asin_));
+  EXPECT_EQ(to_acos(e_acos_)->get_argument(), get_argument(e_acos_));
+  EXPECT_EQ(to_atan(e_atan_)->get_argument(), get_argument(e_atan_));
+  EXPECT_EQ(to_atan2(e_atan2_)->get_first_argument(),
+            get_first_argument(e_atan2_));
+  EXPECT_EQ(to_atan2(e_atan2_)->get_second_argument(),
+            get_second_argument(e_atan2_));
+  EXPECT_EQ(to_sinh(e_sinh_)->get_argument(), get_argument(e_sinh_));
+  EXPECT_EQ(to_cosh(e_cosh_)->get_argument(), get_argument(e_cosh_));
+  EXPECT_EQ(to_tanh(e_tanh_)->get_argument(), get_argument(e_tanh_));
+  EXPECT_EQ(to_min(e_min_)->get_first_argument(), get_first_argument(e_min_));
+  EXPECT_EQ(to_min(e_min_)->get_second_argument(), get_second_argument(e_min_));
+  EXPECT_EQ(to_max(e_max_)->get_first_argument(), get_first_argument(e_max_));
+  EXPECT_EQ(to_max(e_max_)->get_second_argument(), get_second_argument(e_max_));
+  EXPECT_EQ(to_ceil(e_ceil_)->get_argument(), get_argument(e_ceil_));
+  EXPECT_EQ(to_floor(e_floor_)->get_argument(), get_argument(e_floor_));
+  EXPECT_PRED2(FormulaEqual, to_if_then_else(e_ite_)->get_conditional_formula(),
+               get_conditional_formula(e_ite_));
+  EXPECT_PRED2(ExprEqual, to_if_then_else(e_ite_)->get_then_expression(),
+               get_then_expression(e_ite_));
+  EXPECT_PRED2(ExprEqual, to_if_then_else(e_ite_)->get_else_expression(),
+               get_else_expression(e_ite_));
+  EXPECT_EQ(to_uninterpreted_function(e_uf_)->get_name(),
+            get_uninterpreted_function_name(e_uf_));
+  EXPECT_EQ(to_uninterpreted_function(e_uf_)->get_arguments().size(), 2);
+  EXPECT_EQ(to_uninterpreted_function(e_uf_)->get_arguments().size(),
+            get_uninterpreted_function_arguments(e_uf_).size());
+  EXPECT_EQ(to_uninterpreted_function(e_uf_)->get_arguments()[0],
+            get_uninterpreted_function_arguments(e_uf_)[0]);
+  EXPECT_EQ(to_uninterpreted_function(e_uf_)->get_arguments()[1],
+            get_uninterpreted_function_arguments(e_uf_)[1]);
+}
+
+TEST_F(SymbolicExpressionCellTest, CastFunctionsNonConst) {
+  EXPECT_EQ(to_constant(Expression{e_constant_})->get_value(),
+            get_constant_value(e_constant_));
+  EXPECT_EQ(to_variable(Expression{e_var_})->get_variable(),
+            get_variable(e_var_));
+
+  EXPECT_EQ(to_addition(Expression{e_add_})->get_constant(),
+            get_constant_in_addition(e_add_));
+  EXPECT_EQ(to_addition(Expression{e_add_})->get_expr_to_coeff_map(),
+            get_expr_to_coeff_map_in_addition(e_add_));
+
+  EXPECT_EQ(to_multiplication(Expression{e_mul_})->get_constant(),
+            get_constant_in_multiplication(e_mul_));
+  EXPECT_EQ(
+      to_multiplication(Expression{e_mul_})->get_base_to_exponent_map().size(),
+      get_base_to_exponent_map_in_multiplication(e_mul_).size());
+  EXPECT_EQ(
+      to_multiplication(Expression{e_mul_})->get_base_to_exponent_map().size(),
+      2);
+  EXPECT_PRED2(ExprEqual,
+               to_multiplication(Expression{e_mul_})
+                   ->get_base_to_exponent_map()
+                   .at(var_x_),
+               get_base_to_exponent_map_in_multiplication(e_mul_).at(var_x_));
+  EXPECT_PRED2(ExprEqual,
+               to_multiplication(Expression{e_mul_})
+                   ->get_base_to_exponent_map()
+                   .at(var_y_),
+               get_base_to_exponent_map_in_multiplication(e_mul_).at(var_y_));
+
+  EXPECT_EQ(to_division(Expression{e_div_})->get_second_argument(),
+            get_second_argument(e_div_));
+  EXPECT_EQ(to_division(Expression{e_div_})->get_second_argument(),
+            get_second_argument(e_div_));
+
+  EXPECT_EQ(to_log(Expression{e_log_})->get_argument(), get_argument(e_log_));
+  EXPECT_EQ(to_abs(Expression{e_abs_})->get_argument(), get_argument(e_abs_));
+  EXPECT_EQ(to_exp(Expression{e_exp_})->get_argument(), get_argument(e_exp_));
+  EXPECT_EQ(to_sqrt(Expression{e_sqrt_})->get_argument(),
+            get_argument(e_sqrt_));
+  EXPECT_EQ(to_pow(Expression{e_pow_})->get_first_argument(),
+            get_first_argument(e_pow_));
+  EXPECT_EQ(to_pow(Expression{e_pow_})->get_second_argument(),
+            get_second_argument(e_pow_));
+  EXPECT_EQ(to_sin(Expression{e_sin_})->get_argument(), get_argument(e_sin_));
+  EXPECT_EQ(to_cos(Expression{e_cos_})->get_argument(), get_argument(e_cos_));
+  EXPECT_EQ(to_tan(Expression{e_tan_})->get_argument(), get_argument(e_tan_));
+  EXPECT_EQ(to_asin(Expression{e_asin_})->get_argument(),
+            get_argument(e_asin_));
+  EXPECT_EQ(to_acos(Expression{e_acos_})->get_argument(),
+            get_argument(e_acos_));
+  EXPECT_EQ(to_atan(Expression{e_atan_})->get_argument(),
+            get_argument(e_atan_));
+  EXPECT_EQ(to_atan2(Expression{e_atan2_})->get_first_argument(),
+            get_first_argument(e_atan2_));
+  EXPECT_EQ(to_atan2(Expression{e_atan2_})->get_second_argument(),
+            get_second_argument(e_atan2_));
+  EXPECT_EQ(to_sinh(Expression{e_sinh_})->get_argument(),
+            get_argument(e_sinh_));
+  EXPECT_EQ(to_cosh(Expression{e_cosh_})->get_argument(),
+            get_argument(e_cosh_));
+  EXPECT_EQ(to_tanh(Expression{e_tanh_})->get_argument(),
+            get_argument(e_tanh_));
+  EXPECT_EQ(to_min(Expression{e_min_})->get_first_argument(),
+            get_first_argument(e_min_));
+  EXPECT_EQ(to_min(Expression{e_min_})->get_second_argument(),
+            get_second_argument(e_min_));
+  EXPECT_EQ(to_max(Expression{e_max_})->get_first_argument(),
+            get_first_argument(e_max_));
+  EXPECT_EQ(to_max(Expression{e_max_})->get_second_argument(),
+            get_second_argument(e_max_));
+  EXPECT_EQ(to_ceil(Expression{e_ceil_})->get_argument(),
+            get_argument(e_ceil_));
+  EXPECT_EQ(to_floor(Expression{e_floor_})->get_argument(),
+            get_argument(e_floor_));
+  EXPECT_PRED2(FormulaEqual,
+               to_if_then_else(Expression{e_ite_})->get_conditional_formula(),
+               get_conditional_formula(e_ite_));
+  EXPECT_PRED2(ExprEqual,
+               to_if_then_else(Expression{e_ite_})->get_then_expression(),
+               get_then_expression(e_ite_));
+  EXPECT_PRED2(ExprEqual,
+               to_if_then_else(Expression{e_ite_})->get_else_expression(),
+               get_else_expression(e_ite_));
+  EXPECT_EQ(to_uninterpreted_function(Expression{e_uf_})->get_name(),
+            get_uninterpreted_function_name(e_uf_));
+  EXPECT_EQ(
+      to_uninterpreted_function(Expression{e_uf_})->get_arguments().size(), 2);
+  EXPECT_EQ(
+      to_uninterpreted_function(Expression{e_uf_})->get_arguments().size(),
+      get_uninterpreted_function_arguments(e_uf_).size());
+  EXPECT_EQ(to_uninterpreted_function(Expression{e_uf_})->get_arguments()[0],
+            get_uninterpreted_function_arguments(e_uf_)[0]);
+  EXPECT_EQ(to_uninterpreted_function(Expression{e_uf_})->get_arguments()[1],
+            get_uninterpreted_function_arguments(e_uf_)[1]);
+}
+
+}  // namespace
+}  // namespace symbolic
+}  // namespace drake


### PR DESCRIPTION
Toward the solution proposed in https://github.com/RobotLocomotion/drake/issues/10900#issuecomment-472161681 .

/cc @hongkai-dai

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11756)
<!-- Reviewable:end -->
