### PR TITLE
Improve visualization of contact forces (and simple gripper example) by desaturating the colors

### DIFF
--- a/examples/simple_gripper/simple_gripper.cc
+++ b/examples/simple_gripper/simple_gripper.cc
@@ -153,7 +153,7 @@ void AddGripperPads(MultibodyPlant<double>* plant,
     plant->RegisterCollisionGeometry(finger, X_FS, Sphere(kPadMinorRadius),
                                      "collision" + std::to_string(i), friction);
 
-    const Vector4<double> red(1.0, 0.0, 0.0, 1.0);
+    const Vector4<double> red(0.8, 0.2, 0.2, 1.0);
     plant->RegisterVisualGeometry(finger, X_FS, Sphere(kPadMinorRadius),
                                   "visual" + std::to_string(i), red);
   }

--- a/tools/workspace/drake_visualizer/plugin/show_contact.py
+++ b/tools/workspace/drake_visualizer/plugin/show_contact.py
@@ -95,8 +95,8 @@ class ContactVisualizer(object):
                            tubeRadius=0.005,
                            headRadius=0.01)
 
-            vis.showPolyData(
-                d.getPolyData(), str(key), parent=folder, color=[0, 1, 0])
+            vis.showPolyData(d.getPolyData(), str(key), parent=folder,
+                             color=[0.2, 0.8, 0.2])
 
 
 @scoped_singleton_func


### PR DESCRIPTION
This PR makes three changes:
1. It makes the green contact force arrows in drake_visualizer less saturated by changing the color to (0.2, 0.8, 0.4). This makes the simple_gripper example much easier to visualize with the contact forces. This is a general change to the drake visualizer
2. It makes the red contact spheres in the simple_gripper example less saturated.
3. It flips the direction of the green contact force arrows in drake_visualizer. In the simple_gripper example, for example, the arrows now proceed toward the gripper fingers. This is another general change to the drake visualizer, and I think it doesn't hurt in general because ConnectContactResultsToDrakeVisualizer() does not provide capabilities to select the body being visualized. (It's a question of whether we want to visualize the force applied on a body by another body vs the force applied by a body on another body, and we don't have to answer that here.) It strictly helps in visualizing the simple_gripper example here because the arrows don't cross the mug.

This is the new appearance with these changes:
![image](https://user-images.githubusercontent.com/52013372/60470878-271bb000-9c30-11e9-832f-c81f4b0068dd.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11764)
<!-- Reviewable:end -->
