### PR TITLE
Prefer "internal" namespace (not "detail")

### DIFF
--- a/attic/manipulation/planner/rbt_differential_inverse_kinematics.cc
+++ b/attic/manipulation/planner/rbt_differential_inverse_kinematics.cc
@@ -28,8 +28,9 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
   MatrixX<double> J_WE =
       robot.CalcFrameSpatialVelocityJacobianInWorldFrame(cache, frame_E);
   // Call the (non-attic) helper function.
-  return drake::manipulation::planner::detail::DoDifferentialInverseKinematics(
-      cache.getQ(), cache.getV(), X_WE, J_WE, V_WE_desired, parameters);
+  return drake::manipulation::planner::internal::
+      DoDifferentialInverseKinematics(
+          cache.getQ(), cache.getV(), X_WE, J_WE, V_WE_desired, parameters);
 }
 
 }  // namespace rbt

--- a/attic/multibody/parsers/sdf_parser.cc
+++ b/attic/multibody/parsers/sdf_parser.cc
@@ -50,8 +50,8 @@ using tinyxml2::XMLDocument;
 
 using math::RigidTransformd;
 using math::RollPitchYawd;
-using multibody::detail::GetFullPath;
-using multibody::detail::ResolveUri;
+using multibody::internal::GetFullPath;
+using multibody::internal::ResolveUri;
 using multibody::joints::FloatingBaseType;
 
 void ParseSdfInertial(

--- a/attic/multibody/parsers/urdf_parser.cc
+++ b/attic/multibody/parsers/urdf_parser.cc
@@ -44,8 +44,8 @@ using tinyxml2::XMLDocument;
 using tinyxml2::XMLElement;
 
 using drake::parsers::ModelInstanceIdTable;
-using drake::multibody::detail::GetFullPath;
-using drake::multibody::detail::ResolveUri;
+using drake::multibody::internal::GetFullPath;
+using drake::multibody::internal::ResolveUri;
 using drake::multibody::joints::FloatingBaseType;
 using drake::multibody::joints::kRollPitchYaw;
 

--- a/bindings/pydrake/common/deprecation_pybind.h
+++ b/bindings/pydrake/common/deprecation_pybind.h
@@ -36,7 +36,7 @@ inline void WarnDeprecated(py::str message) {
   warn_deprecated(message);
 }
 
-namespace detail {
+namespace internal {
 
 template <typename Func, typename Return, typename... Args>
 auto WrapDeprecatedImpl(py::str message,
@@ -58,14 +58,14 @@ auto WrapDeprecatedImpl(py::str message,
   };
 }
 
-}  // namespace detail
+}  // namespace internal
 
 /// Wraps any callable (function pointer, method pointer, lambda, etc.) to emit
 /// a deprecation message.
 template <typename Func>
 auto WrapDeprecated(py::str message, Func&& func) {
-  return detail::WrapDeprecatedImpl(
-      message, detail::infer_function_info(std::forward<Func>(func)));
+  return internal::WrapDeprecatedImpl(
+      message, internal::infer_function_info(std::forward<Func>(func)));
 }
 
 /// Deprecated wrapping of `py::init<>`.

--- a/bindings/pydrake/common/eigen_geometry_pybind.h
+++ b/bindings/pydrake/common/eigen_geometry_pybind.h
@@ -18,7 +18,7 @@
 
 namespace drake {
 namespace pydrake {
-namespace detail {
+namespace internal {
 
 // Implements a `type_caster<>` specialization used to convert types using a
 // specific wrapping policy.
@@ -97,7 +97,7 @@ struct wrapper_eigen_translation {
 // N.B. Since `Isometry3<>` and `Eigen::Quaternion<>` have more
 // complicated structures, they are registered as types in `eigen_geometry_py`.
 
-}  // namespace detail
+}  // namespace internal
 }  // namespace pydrake
 }  // namespace drake
 
@@ -106,8 +106,8 @@ namespace detail {
 
 template <typename T, int Dim>
 struct type_caster<Eigen::Translation<T, Dim>>
-    : public drake::pydrake::detail::type_caster_wrapped<
-          drake::pydrake::detail::wrapper_eigen_translation<T, Dim>> {};
+    : public drake::pydrake::internal::type_caster_wrapped<
+          drake::pydrake::internal::wrapper_eigen_translation<T, Dim>> {};
 
 }  // namespace detail
 }  // namespace pybind11

--- a/bindings/pydrake/common/module_py.cc
+++ b/bindings/pydrake/common/module_py.cc
@@ -66,7 +66,7 @@ PYBIND11_MODULE(_module_py, m) {
       if (p) {
         std::rethrow_exception(p);
       }
-    } catch (const drake::detail::assertion_error& e) {
+    } catch (const drake::internal::assertion_error& e) {
       PyErr_SetString(PyExc_SystemExit, e.what());
     }
   });

--- a/bindings/pydrake/common/test/wrap_function_test.cc
+++ b/bindings/pydrake/common/test/wrap_function_test.cc
@@ -171,7 +171,7 @@ template <typename T, typename = void>
 struct wrap_change : public wrap_arg_default<T> {};
 
 template <typename T>
-using wrap_change_t = detail::wrap_function_impl<wrap_change>::wrap_type_t<T>;
+using wrap_change_t = internal::wrap_function_impl<wrap_change>::wrap_type_t<T>;
 
 // Wraps any `const T*` with `const_ptr`, except for `int`.
 // SFINAE. Could be achieved with specialization, but using to uphold SFINAE
@@ -239,12 +239,13 @@ template <typename RetExpected, typename... ArgsExpected>
 struct check_signature {
   template <typename FuncActual>
   static void run(const FuncActual& func) {
-    run_impl(detail::infer_function_info(func));
+    run_impl(internal::infer_function_info(func));
   }
 
   template <typename RetActual, typename... ArgsActual, typename FuncActual>
   static void run_impl(
-      const detail::function_info<FuncActual, RetActual, ArgsActual...>& info) {
+      const internal::function_info<FuncActual, RetActual, ArgsActual...>&
+          info) {
     check_type<RetActual, RetExpected>();
     using Dummy = int[];
     (void)Dummy{(check_type<ArgsActual, ArgsExpected>(), 0)...};

--- a/bindings/pydrake/common/type_pack.h
+++ b/bindings/pydrake/common/type_pack.h
@@ -15,7 +15,7 @@ namespace drake {
 template <typename... Ts>
 struct type_pack;
 
-namespace detail {
+namespace internal {
 
 // Provides type at given index.
 template <size_t N, size_t K, typename T, typename... Ts>
@@ -67,13 +67,13 @@ struct assert_default_constructible {
       std::is_default_constructible<T>::value, "Must be default constructible");
 };
 
-}  // namespace detail
+}  // namespace internal
 
 /// Extracts the Ith type from a sequence of types.
 template <size_t I, typename... Ts>
 struct type_at {
   static_assert(I >= 0 && I < sizeof...(Ts), "Invalid type index");
-  using type = typename detail::type_at_impl<I, 0, Ts...>::type;
+  using type = typename internal::type_at_impl<I, 0, Ts...>::type;
 };
 
 /// Provides a tag to pass a type for ease of inference.
@@ -118,7 +118,7 @@ Tpl<Ts...> type_bind(type_pack<Ts...>);
 /// Extracts the inner template arguments (typename only) for a typename which
 /// is a template instantiation.
 template <typename T>
-using type_pack_extract = typename detail::type_pack_extract_impl<T>::type;
+using type_pack_extract = typename internal::type_pack_extract_impl<T>::type;
 
 /// Visit a type by constructing its default value.
 /// Useful for iterating over `type_tag`, `type_pack`, `std::integral_constant`,
@@ -128,7 +128,7 @@ struct type_visit_with_default {
   inline static void run(Visitor&& visitor) {
     // TODO(eric.cousineau): Figure out how to make this the only error, without
     // wasting more function calls.
-    (void)detail::assert_default_constructible<T>{};
+    (void)internal::assert_default_constructible<T>{};
     visitor(T{});
   }
 };
@@ -170,8 +170,8 @@ template <class VisitWith = type_visit_with_default,
 void type_visit(Visitor&& visitor, type_pack<Ts...> = {},
     template_single_tag<Predicate> = {}) {
   // clang-format off
-  (void)detail::DummyList{(
-      detail::type_visit_impl<VisitWith, Visitor>::
+  (void)internal::DummyList{(
+      internal::type_visit_impl<VisitWith, Visitor>::
           template runner<Ts, Predicate<Ts>::value>::
               run(std::forward<Visitor>(visitor)),
       true)...};

--- a/bindings/pydrake/common/wrap_function.h
+++ b/bindings/pydrake/common/wrap_function.h
@@ -6,7 +6,7 @@
 
 namespace drake {
 namespace pydrake {
-namespace detail {
+namespace internal {
 
 // Collects both a functor object and its signature for ease of inference.
 template <typename Func, typename Return, typename... Args>
@@ -81,7 +81,7 @@ struct functor_helpers {
 };
 
 // Infers `function_info<>` from a generic functor.
-template <typename Func, typename = detail::enable_if_lambda_t<Func>>
+template <typename Func, typename = internal::enable_if_lambda_t<Func>>
 auto infer_function_info(Func&& func) {
   return make_function_info(std::forward<Func>(func),
       functor_helpers::infer_function_ptr<std::decay_t<Func>>());
@@ -199,7 +199,7 @@ struct wrap_function_impl {
   }
 };
 
-}  // namespace detail
+}  // namespace internal
 
 /// Wraps the types used in a function signature to produce a new function with
 /// wrapped arguments and return value (if non-void). The wrapping is based on
@@ -232,8 +232,8 @@ template <template <typename...> class wrap_arg_policy,
 auto WrapFunction(Func&& func) {
   // TODO(eric.cousineau): Create an overload with `type_pack<Args...>` to
   // handle overloads, to disambiguate when necessary.
-  return detail::wrap_function_impl<wrap_arg_policy, use_functions>::run(
-      detail::infer_function_info(std::forward<Func>(func)));
+  return internal::wrap_function_impl<wrap_arg_policy, use_functions>::run(
+      internal::infer_function_info(std::forward<Func>(func)));
 }
 
 /// Default case for argument wrapping, with pure pass-through. Consider
@@ -252,7 +252,7 @@ struct wrap_arg_default {
 
 /// Policy for explicitly wrapping functions for a given policy.
 template <template <typename...> class wrap_arg_policy, typename Signature>
-using wrap_arg_function = typename detail::wrap_function_impl<
+using wrap_arg_function = typename internal::wrap_function_impl<
     wrap_arg_policy>::template wrap_arg<std::function<Signature>>;
 
 }  // namespace pydrake

--- a/bindings/pydrake/common/wrap_pybind.h
+++ b/bindings/pydrake/common/wrap_pybind.h
@@ -15,7 +15,7 @@
 namespace drake {
 namespace pydrake {
 
-namespace detail {
+namespace internal {
 
 template <typename T, typename = void>
 struct wrap_ref_ptr : public wrap_arg_default<T> {};
@@ -42,7 +42,7 @@ template <typename Signature>
 struct wrap_callback<std::function<Signature>>
     : public wrap_callback<const std::function<Signature>&> {};
 
-}  // namespace detail
+}  // namespace internal
 
 /// Ensures that any `std::function<>` arguments are wrapped such that any `T&`
 /// (which can infer for `T = const U`) is wrapped as `U*` (and conversely
@@ -55,7 +55,7 @@ struct wrap_callback<std::function<Signature>>
 /// For more information, see: https://github.com/pybind/pybind11/issues/1241
 template <typename Func>
 auto WrapCallbacks(Func&& func) {
-  return WrapFunction<detail::wrap_callback, false>(std::forward<Func>(func));
+  return WrapFunction<internal::wrap_callback, false>(std::forward<Func>(func));
 }
 
 /// Idempotent to pybind11's `def_readwrite()`, with the exception that the

--- a/common/drake_assert.h
+++ b/common/drake_assert.h
@@ -81,7 +81,7 @@
 #endif
 
 namespace drake {
-namespace detail {
+namespace internal {
 // Abort the program with an error message.
 __attribute__((noreturn)) /* gcc is ok with [[noreturn]]; clang is not. */
 void Abort(const char* condition, const char* func, const char* file, int line);
@@ -89,7 +89,7 @@ void Abort(const char* condition, const char* func, const char* file, int line);
 __attribute__((noreturn)) /* gcc is ok with [[noreturn]]; clang is not. */
 void AssertionFailed(
     const char* condition, const char* func, const char* file, int line);
-}  // namespace detail
+}  // namespace internal
 namespace assert {
 // Allows for specialization of how to bool-convert Conditions used in
 // assertions, in case they are not intrinsically convertible.  See
@@ -107,7 +107,7 @@ struct ConditionTraits {
 }  // namespace drake
 
 #define DRAKE_UNREACHABLE()                                             \
-  ::drake::detail::Abort(                                               \
+  ::drake::internal::Abort(                                             \
       "Unreachable code was reached?!", __func__, __FILE__, __LINE__)
 
 #define DRAKE_DEMAND(condition)                                              \
@@ -116,7 +116,7 @@ struct ConditionTraits {
         typename std::remove_cv<decltype(condition)>::type> Trait;           \
     static_assert(Trait::is_valid, "Condition should be bool-convertible."); \
     if (!Trait::Evaluate(condition)) {                                       \
-      ::drake::detail::AssertionFailed(                                      \
+      ::drake::internal::AssertionFailed(                                    \
            #condition, __func__, __FILE__, __LINE__);                        \
     }                                                                        \
   } while (0)

--- a/common/drake_assert_and_throw.cc
+++ b/common/drake_assert_and_throw.cc
@@ -15,7 +15,7 @@
 #include "drake/common/never_destroyed.h"
 
 namespace drake {
-namespace detail {
+namespace internal {
 namespace {
 
 // Singleton to manage assertion configuration.
@@ -67,7 +67,7 @@ void AssertionFailed(const char* condition, const char* func, const char* file,
   }
 }
 
-}  // namespace detail
+}  // namespace internal
 }  // namespace drake
 
 // Configures the DRAKE_ASSERT and DRAKE_DEMAND assertion failure handling
@@ -82,6 +82,6 @@ void AssertionFailed(const char* condition, const char* func, const char* file,
 // This method is intended ONLY for use by pydrake bindings, and thus is not
 // declared in any header file, to discourage anyone from using it.
 extern "C" void drake_set_assertion_failure_to_throw_exception() {
-  drake::detail::AssertionConfig::singleton().
+  drake::internal::AssertionConfig::singleton().
       assertion_failures_are_exceptions = true;
 }

--- a/common/drake_assertion_error.h
+++ b/common/drake_assertion_error.h
@@ -4,7 +4,7 @@
 #include <string>
 
 namespace drake {
-namespace detail {
+namespace internal {
 
 /// This is what DRAKE_ASSERT and DRAKE_DEMAND throw when our assertions are
 /// configured to throw.
@@ -14,5 +14,5 @@ class assertion_error : public std::runtime_error {
       : std::runtime_error(what_arg) {}
 };
 
-}  // namespace detail
+}  // namespace internal
 }  // namespace drake

--- a/common/drake_throw.h
+++ b/common/drake_throw.h
@@ -10,11 +10,11 @@
 /// ::abort(), and cannot be disabled.
 
 namespace drake {
-namespace detail {
+namespace internal {
 // Throw an error message.
 __attribute__((noreturn)) /* gcc is ok with [[noreturn]]; clang is not. */
 void Throw(const char* condition, const char* func, const char* file, int line);
-}  // namespace detail
+}  // namespace internal
 }  // namespace drake
 
 /// Evaluates @p condition and iff the value is false will throw an exception
@@ -26,6 +26,6 @@ void Throw(const char* condition, const char* func, const char* file, int line);
         typename std::remove_cv<decltype(condition)>::type> Trait;           \
     static_assert(Trait::is_valid, "Condition should be bool-convertible."); \
     if (!Trait::Evaluate(condition)) {                                       \
-      ::drake::detail::Throw(#condition, __func__, __FILE__, __LINE__);      \
+      ::drake::internal::Throw(#condition, __func__, __FILE__, __LINE__);    \
     }                                                                        \
   } while (0)

--- a/common/is_cloneable.h
+++ b/common/is_cloneable.h
@@ -7,7 +7,7 @@ namespace drake {
 
 /** @cond */
 
-namespace is_cloneable_detail {
+namespace is_cloneable_internal {
 
 // Default case; assumes that a class is *not* cloneable.
 template <typename T, class>
@@ -24,7 +24,7 @@ struct is_cloneable_helper<
         typename std::remove_const<T>::type*>::value>::type>
     : std::true_type {};
 
-}  // namespace is_cloneable_detail
+}  // namespace is_cloneable_internal
 
 /** @endcond */
 
@@ -80,6 +80,6 @@ struct is_cloneable_helper<
  */
 template <typename T>
 using is_cloneable =
-    is_cloneable_detail::is_cloneable_helper<T, void>;
+    is_cloneable_internal::is_cloneable_helper<T, void>;
 
 }  // namespace drake

--- a/common/is_less_than_comparable.h
+++ b/common/is_less_than_comparable.h
@@ -8,7 +8,7 @@ namespace drake {
 
 #ifndef DRAKE_DOXYGEN_CXX
 
-namespace is_less_than_comparable_detail {
+namespace is_less_than_comparable_internal {
 
 // Default case; assumes that a class is *not* less-than comparable.
 template <typename T, typename = void>
@@ -22,7 +22,7 @@ struct is_less_than_comparable_helper<T, typename std::enable_if<true,
     decltype(unused(std::declval<T&>() < std::declval<T&>()),
     (void)0)>::type> : std::true_type {};
 
-}  // namespace is_less_than_comparable_detail
+}  // namespace is_less_than_comparable_internal
 
 /** @endcond */
 
@@ -67,7 +67,7 @@ struct is_less_than_comparable_helper<T, typename std::enable_if<true,
  */
 template <typename T>
 using is_less_than_comparable =
-    is_less_than_comparable_detail::is_less_than_comparable_helper<T, void>;
+    is_less_than_comparable_internal::is_less_than_comparable_helper<T, void>;
 
 }  // namespace drake
 

--- a/common/symbolic_formula.h
+++ b/common/symbolic_formula.h
@@ -492,7 +492,7 @@ const Formula& get_quantified_formula(const Formula& f);
 const MatrixX<Expression>& get_matrix_in_positive_semidefinite(
     const Formula& f);
 
-namespace detail {
+namespace internal {
 /// Provides a return type of relational operations (=, ≠, ≤, <, ≥, >) between
 /// `Eigen::Array`s.
 ///
@@ -530,7 +530,7 @@ inline Formula logic_and(const Formula& f1, const Formula& f2) {
 inline Formula logic_or(const Formula& f1, const Formula& f2) {
   return f1 || f2;
 }
-}  // namespace detail
+}  // namespace internal
 
 /// Returns an Eigen array of symbolic formulas where each element includes
 /// element-wise symbolic-equality of two arrays @p m1 and @p m2.
@@ -559,7 +559,7 @@ typename std::enable_if<
         std::is_same<decltype(typename DerivedA::Scalar() ==
                               typename DerivedB::Scalar()),
                      Formula>::value,
-    typename detail::RelationalOpTraits<DerivedA, DerivedB>::ReturnType>::type
+    typename internal::RelationalOpTraits<DerivedA, DerivedB>::ReturnType>::type
 operator==(const DerivedA& a1, const DerivedB& a2) {
   EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(DerivedA, DerivedB);
   DRAKE_DEMAND(a1.rows() == a2.rows() && a1.cols() == a2.cols());
@@ -632,7 +632,7 @@ typename std::enable_if<
         std::is_same<decltype(typename DerivedA::Scalar() <=
                               typename DerivedB::Scalar()),
                      Formula>::value,
-    typename detail::RelationalOpTraits<DerivedA, DerivedB>::ReturnType>::type
+    typename internal::RelationalOpTraits<DerivedA, DerivedB>::ReturnType>::type
 operator<=(const DerivedA& a1, const DerivedB& a2) {
   EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(DerivedA, DerivedB);
   DRAKE_DEMAND(a1.rows() == a2.rows() && a1.cols() == a2.cols());
@@ -685,7 +685,7 @@ typename std::enable_if<
         std::is_same<decltype(typename DerivedA::Scalar() <
                               typename DerivedB::Scalar()),
                      Formula>::value,
-    typename detail::RelationalOpTraits<DerivedA, DerivedB>::ReturnType>::type
+    typename internal::RelationalOpTraits<DerivedA, DerivedB>::ReturnType>::type
 operator<(const DerivedA& a1, const DerivedB& a2) {
   EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(DerivedA, DerivedB);
   DRAKE_DEMAND(a1.rows() == a2.rows() && a1.cols() == a2.cols());
@@ -736,7 +736,7 @@ typename std::enable_if<
         std::is_same<decltype(typename DerivedA::Scalar() >=
                               typename DerivedB::Scalar()),
                      Formula>::value,
-    typename detail::RelationalOpTraits<DerivedA, DerivedB>::ReturnType>::type
+    typename internal::RelationalOpTraits<DerivedA, DerivedB>::ReturnType>::type
 operator>=(const DerivedA& a1, const DerivedB& a2) {
   EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(DerivedA, DerivedB);
   DRAKE_DEMAND(a1.rows() == a2.rows() && a1.cols() == a2.cols());
@@ -795,7 +795,7 @@ typename std::enable_if<
         std::is_same<decltype(typename DerivedA::Scalar() >
                               typename DerivedB::Scalar()),
                      Formula>::value,
-    typename detail::RelationalOpTraits<DerivedA, DerivedB>::ReturnType>::type
+    typename internal::RelationalOpTraits<DerivedA, DerivedB>::ReturnType>::type
 operator>(const DerivedA& a1, const DerivedB& a2) {
   EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(DerivedA, DerivedB);
   DRAKE_DEMAND(a1.rows() == a2.rows() && a1.cols() == a2.cols());
@@ -853,7 +853,7 @@ typename std::enable_if<
         std::is_same<decltype(typename DerivedA::Scalar() !=
                               typename DerivedB::Scalar()),
                      Formula>::value,
-    typename detail::RelationalOpTraits<DerivedA, DerivedB>::ReturnType>::type
+    typename internal::RelationalOpTraits<DerivedA, DerivedB>::ReturnType>::type
 operator!=(const DerivedA& a1, const DerivedB& a2) {
   EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(DerivedA, DerivedB);
   DRAKE_DEMAND(a1.rows() == a2.rows() && a1.cols() == a2.cols());
@@ -949,7 +949,7 @@ typename std::enable_if<
 operator==(const DerivedA& m1, const DerivedB& m2) {
   EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(DerivedA, DerivedB);
   DRAKE_DEMAND(m1.rows() == m2.rows() && m1.cols() == m2.cols());
-  return m1.binaryExpr(m2, std::equal_to<void>()).redux(detail::logic_and);
+  return m1.binaryExpr(m2, std::equal_to<void>()).redux(internal::logic_and);
 }
 
 /// Returns a symbolic formula representing the condition whether @p m1 and @p
@@ -982,7 +982,7 @@ typename std::enable_if<
 operator!=(const DerivedA& m1, const DerivedB& m2) {
   EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(DerivedA, DerivedB);
   DRAKE_DEMAND(m1.rows() == m2.rows() && m1.cols() == m2.cols());
-  return m1.binaryExpr(m2, std::not_equal_to<void>()).redux(detail::logic_or);
+  return m1.binaryExpr(m2, std::not_equal_to<void>()).redux(internal::logic_or);
 }
 
 /// Returns a symbolic formula representing element-wise comparison between two
@@ -1010,7 +1010,7 @@ typename std::enable_if<
 operator<(const DerivedA& m1, const DerivedB& m2) {
   EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(DerivedA, DerivedB);
   DRAKE_DEMAND(m1.rows() == m2.rows() && m1.cols() == m2.cols());
-  return m1.binaryExpr(m2, std::less<void>()).redux(detail::logic_and);
+  return m1.binaryExpr(m2, std::less<void>()).redux(internal::logic_and);
 }
 
 /// Returns a symbolic formula representing element-wise comparison between two
@@ -1038,7 +1038,7 @@ typename std::enable_if<
 operator<=(const DerivedA& m1, const DerivedB& m2) {
   EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(DerivedA, DerivedB);
   DRAKE_DEMAND(m1.rows() == m2.rows() && m1.cols() == m2.cols());
-  return m1.binaryExpr(m2, std::less_equal<void>()).redux(detail::logic_and);
+  return m1.binaryExpr(m2, std::less_equal<void>()).redux(internal::logic_and);
 }
 
 /// Returns a symbolic formula representing element-wise comparison between two
@@ -1066,7 +1066,7 @@ typename std::enable_if<
 operator>(const DerivedA& m1, const DerivedB& m2) {
   EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(DerivedA, DerivedB);
   DRAKE_DEMAND(m1.rows() == m2.rows() && m1.cols() == m2.cols());
-  return m1.binaryExpr(m2, std::greater<void>()).redux(detail::logic_and);
+  return m1.binaryExpr(m2, std::greater<void>()).redux(internal::logic_and);
 }
 
 /// Returns a symbolic formula representing element-wise comparison between two
@@ -1094,7 +1094,8 @@ typename std::enable_if<
 operator>=(const DerivedA& m1, const DerivedB& m2) {
   EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(DerivedA, DerivedB);
   DRAKE_DEMAND(m1.rows() == m2.rows() && m1.cols() == m2.cols());
-  return m1.binaryExpr(m2, std::greater_equal<void>()).redux(detail::logic_and);
+  return m1.binaryExpr(m2, std::greater_equal<void>()).redux(
+      internal::logic_and);
 }
 
 }  // namespace symbolic

--- a/common/test/symbolic_expression_matrix_test.cc
+++ b/common/test/symbolic_expression_matrix_test.cc
@@ -178,7 +178,7 @@ TEST_F(SymbolicExpressionMatrixTest, CheckStructuralEquality) {
 bool CheckMatrixOperatorEq(const MatrixX<Expression>& m1,
                            const MatrixX<Expression>& m2) {
   const Formula f1{m1 == m2};
-  const Formula f2{(m1.array() == m2.array()).redux(detail::logic_and)};
+  const Formula f2{(m1.array() == m2.array()).redux(internal::logic_and)};
   return f1.EqualTo(f2);
 }
 
@@ -188,7 +188,7 @@ bool CheckMatrixOperatorEq(const MatrixX<Expression>& m1,
 bool CheckMatrixOperatorNeq(const MatrixX<Expression>& m1,
                             const MatrixX<Expression>& m2) {
   const Formula f1{m1 != m2};
-  const Formula f2{(m1.array() != m2.array()).redux(detail::logic_or)};
+  const Formula f2{(m1.array() != m2.array()).redux(internal::logic_or)};
   return f1.EqualTo(f2);
 }
 
@@ -198,7 +198,7 @@ bool CheckMatrixOperatorNeq(const MatrixX<Expression>& m1,
 bool CheckMatrixOperatorLt(const MatrixX<Expression>& m1,
                            const MatrixX<Expression>& m2) {
   const Formula f1{m1 < m2};
-  const Formula f2{(m1.array() < m2.array()).redux(detail::logic_and)};
+  const Formula f2{(m1.array() < m2.array()).redux(internal::logic_and)};
   return f1.EqualTo(f2);
 }
 
@@ -208,7 +208,7 @@ bool CheckMatrixOperatorLt(const MatrixX<Expression>& m1,
 bool CheckMatrixOperatorLte(const MatrixX<Expression>& m1,
                             const MatrixX<Expression>& m2) {
   const Formula f1{m1 <= m2};
-  const Formula f2{(m1.array() <= m2.array()).redux(detail::logic_and)};
+  const Formula f2{(m1.array() <= m2.array()).redux(internal::logic_and)};
   return f1.EqualTo(f2);
 }
 
@@ -218,7 +218,7 @@ bool CheckMatrixOperatorLte(const MatrixX<Expression>& m1,
 bool CheckMatrixOperatorGt(const MatrixX<Expression>& m1,
                            const MatrixX<Expression>& m2) {
   const Formula f1{m1 > m2};
-  const Formula f2{(m1.array() > m2.array()).redux(detail::logic_and)};
+  const Formula f2{(m1.array() > m2.array()).redux(internal::logic_and)};
   return f1.EqualTo(f2);
 }
 
@@ -228,7 +228,7 @@ bool CheckMatrixOperatorGt(const MatrixX<Expression>& m1,
 bool CheckMatrixOperatorGte(const MatrixX<Expression>& m1,
                             const MatrixX<Expression>& m2) {
   const Formula f1{m1 >= m2};
-  const Formula f2{(m1.array() >= m2.array()).redux(detail::logic_and)};
+  const Formula f2{(m1.array() >= m2.array()).redux(internal::logic_and)};
   return f1.EqualTo(f2);
 }
 

--- a/geometry/dev/render/render_engine_vtk.cc
+++ b/geometry/dev/render/render_engine_vtk.cc
@@ -107,15 +107,15 @@ std::string RemoveFileExtension(const std::string& filepath) {
 
 }  // namespace
 
-namespace detail {
+namespace internal {
 
 ShaderCallback::ShaderCallback() :
     z_near_(kClippingPlaneNear),
     z_far_(kClippingPlaneFar) {}
 
-}  // namespace detail
+}  // namespace internal
 
-vtkNew<detail::ShaderCallback> RenderEngineVtk::uniform_setting_callback_;
+vtkNew<internal::ShaderCallback> RenderEngineVtk::uniform_setting_callback_;
 
 RenderEngineVtk::RenderEngineVtk()
     : color_palette_(kNumMaxLabel, RenderLabel::terrain_label(),

--- a/geometry/dev/render/render_engine_vtk.h
+++ b/geometry/dev/render/render_engine_vtk.h
@@ -34,7 +34,7 @@ namespace dev {
 namespace render {
 
 #ifndef DRAKE_DOXYGEN_CXX
-namespace detail {
+namespace internal {
 struct ModuleInitVtkRenderingOpenGL2 {
   ModuleInitVtkRenderingOpenGL2(){
     VTK_AUTOINIT_CONSTRUCT(vtkRenderingOpenGL2)
@@ -75,7 +75,7 @@ class ShaderCallback : public vtkCommand {
   float z_far_{0.f};
 };
 
-}  // namespace detail
+}  // namespace internal
 
 #endif
 
@@ -110,7 +110,7 @@ class ShaderCallback : public vtkCommand {
  If no label is provided, it uses the terrain label.
  */
 class RenderEngineVtk final : public RenderEngine,
-                              private detail::ModuleInitVtkRenderingOpenGL2 {
+                              private internal::ModuleInitVtkRenderingOpenGL2 {
  public:
   /** \name Does not allow copy, move, or assignment  */
   //@{
@@ -234,7 +234,7 @@ class RenderEngineVtk final : public RenderEngine,
   // formal thread safe mechanism so that it doesn't rely on that in the future.
   // TODO(SeanCurtis-TRI): Add thread safety mechanisms to the renderings to
   // preclude collisions if this code is executed in a multi-thread context.
-  static vtkNew<detail::ShaderCallback> uniform_setting_callback_;
+  static vtkNew<internal::ShaderCallback> uniform_setting_callback_;
 
   // The collection of per-geometry actors (one actor per pipeline (color,
   // depth, and label) indexed by the geometry's RenderIndex.

--- a/manipulation/planner/differential_inverse_kinematics.cc
+++ b/manipulation/planner/differential_inverse_kinematics.cc
@@ -12,7 +12,7 @@ namespace drake {
 namespace manipulation {
 namespace planner {
 
-namespace detail {
+namespace internal {
 DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
     const Eigen::Ref<const VectorX<double>>& q_current,
     const Eigen::Ref<const VectorX<double>>& v_current,
@@ -44,7 +44,7 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
       q_current, v_current, V_WE_E_scaled.head(num_cart_constraints),
       J_WE_E_scaled.topRows(num_cart_constraints), parameters);
 }
-}  // namespace detail
+}  // namespace internal
 
 std::ostream& operator<<(std::ostream& os,
                          const DifferentialInverseKinematicsStatus value) {
@@ -246,7 +246,7 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
   plant.CalcFrameGeometricJacobianExpressedInWorld(
       context, frame_E, Vector3<double>::Zero(), &J_WE);
 
-  return detail::DoDifferentialInverseKinematics(
+  return internal::DoDifferentialInverseKinematics(
       plant.GetPositions(context), plant.GetVelocities(context),
       X_WE, J_WE, V_WE_desired, parameters);
 }

--- a/manipulation/planner/differential_inverse_kinematics.h
+++ b/manipulation/planner/differential_inverse_kinematics.h
@@ -331,7 +331,7 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
     const DifferentialInverseKinematicsParameters& parameters);
 
 #ifndef DRAKE_DOXYGEN_CXX
-namespace detail {
+namespace internal {
 DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
     const Eigen::Ref<const VectorX<double>>&,
     const Eigen::Ref<const VectorX<double>>&,
@@ -339,7 +339,7 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
     const Eigen::Ref<const MatrixX<double>>&,
     const Vector6<double>&,
     const DifferentialInverseKinematicsParameters&);
-}  // namespace detail
+}  // namespace internal
 #endif
 
 }  // namespace planner

--- a/multibody/parsing/detail_common.h
+++ b/multibody/parsing/detail_common.h
@@ -4,7 +4,7 @@
 
 namespace drake {
 namespace multibody {
-namespace detail {
+namespace internal {
 
 // Note:
 //   static global variables are strongly discouraged by the C++ style guide:
@@ -17,6 +17,6 @@ inline CoulombFriction<double> default_friction() {
   return CoulombFriction<double>(1.0, 1.0);
 }
 
-}  // namespace detail
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/detail_ignition.cc
+++ b/multibody/parsing/detail_ignition.cc
@@ -2,7 +2,7 @@
 
 namespace drake {
 namespace multibody {
-namespace detail {
+namespace internal {
 
 using Eigen::Vector3d;
 using math::RigidTransformd;
@@ -17,6 +17,6 @@ RigidTransformd ToRigidTransform(const ignition::math::Pose3d& pose) {
   return RigidTransformd(rotation, ToVector3(pose.Pos()));;
 }
 
-}  // namespace detail
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/detail_ignition.h
+++ b/multibody/parsing/detail_ignition.h
@@ -7,7 +7,7 @@
 
 namespace drake {
 namespace multibody {
-namespace detail {
+namespace internal {
 
 /// Helper function to express an ignition::math::Vector3d instance as
 /// a Vector3d instance.
@@ -17,6 +17,6 @@ Eigen::Vector3d ToVector3(const ignition::math::Vector3d& vector);
 /// a RigidTransform instance.
 math::RigidTransformd ToRigidTransform(const ignition::math::Pose3d& pose);
 
-}  // namespace detail
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/detail_path_utils.cc
+++ b/multibody/parsing/detail_path_utils.cc
@@ -13,7 +13,7 @@
 
 namespace drake {
 namespace multibody {
-namespace detail {
+namespace internal {
 
 using std::string;
 
@@ -122,6 +122,6 @@ string ResolveUri(const string& uri, const PackageMap& package_map,
   return result.getStr();
 }
 
-}  // namespace detail
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/detail_path_utils.h
+++ b/multibody/parsing/detail_path_utils.h
@@ -6,7 +6,7 @@
 
 namespace drake {
 namespace multibody {
-namespace detail {
+namespace internal {
 
 /// Obtains the full path of @file_name. If @p file_name is already a
 /// full path (i.e., it starts with a "/"), the path is not modified.
@@ -39,6 +39,6 @@ std::string ResolveUri(const std::string& uri,
                        const PackageMap& package_map,
                        const std::string& root_dir);
 
-}  // namespace detail
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/detail_scene_graph.cc
+++ b/multibody/parsing/detail_scene_graph.cc
@@ -15,7 +15,7 @@
 
 namespace drake {
 namespace multibody {
-namespace detail {
+namespace internal {
 
 using Eigen::Vector3d;
 using std::make_unique;
@@ -389,6 +389,6 @@ sdf::Visual ResolveVisualUri(const sdf::Visual& original,
   return visual;
 }
 
-}  // namespace detail
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/detail_scene_graph.h
+++ b/multibody/parsing/detail_scene_graph.h
@@ -12,7 +12,7 @@
 
 namespace drake {
 namespace multibody {
-namespace detail {
+namespace internal {
 
 /** Given an sdf::Geometry object representing a <geometry> element from an SDF
  file, this method makes a new drake::geometry::Shape object from this
@@ -123,6 +123,6 @@ sdf::Visual ResolveVisualUri(const sdf::Visual& original,
                              const multibody::PackageMap& package_map,
                              const std::string& root_dir);
 
-}  // namespace detail
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -22,7 +22,7 @@
 
 namespace drake {
 namespace multibody {
-namespace detail {
+namespace internal {
 
 using Eigen::Matrix3d;
 using Eigen::Translation3d;
@@ -657,6 +657,6 @@ std::vector<ModelInstanceIndex> AddModelsFromSdfFile(
   return model_instances;
 }
 
-}  // namespace detail
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/detail_sdf_parser.h
+++ b/multibody/parsing/detail_sdf_parser.h
@@ -10,7 +10,7 @@
 
 namespace drake {
 namespace multibody {
-namespace detail {
+namespace internal {
 
 /// Parses a `<model>` element from the SDF file specified by `file_name` and
 /// adds it to `plant`. The SDF file can only contain a single `<model>`
@@ -74,6 +74,6 @@ std::vector<ModelInstanceIndex> AddModelsFromSdfFile(
     const PackageMap& package_map,
     MultibodyPlant<double>* plant,
     geometry::SceneGraph<double>* scene_graph = nullptr);
-}  // namespace detail
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/detail_tinyxml.cc
+++ b/multibody/parsing/detail_tinyxml.cc
@@ -10,7 +10,7 @@
 
 namespace drake {
 namespace multibody {
-namespace detail {
+namespace internal {
 
 namespace {
 std::vector<double> ConvertToDoubles(const std::string& str) {
@@ -129,6 +129,6 @@ bool ParseThreeVectorAttribute(const tinyxml2::XMLElement* node,
   return true;
 }
 
-}  // namespace detail
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/detail_tinyxml.h
+++ b/multibody/parsing/detail_tinyxml.h
@@ -9,7 +9,7 @@
 
 namespace drake {
 namespace multibody {
-namespace detail {
+namespace internal {
 
 /// Parses a string attribute of @p node named @p attribute_name into @p val.
 /// If the attribute is not present, @p val will be cleared.
@@ -79,6 +79,6 @@ bool ParseThreeVectorAttribute(const tinyxml2::XMLElement* node,
                                const char* attribute_name,
                                Eigen::Vector3d* val);
 
-}  // namespace detail
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/detail_urdf_geometry.cc
+++ b/multibody/parsing/detail_urdf_geometry.cc
@@ -15,7 +15,7 @@
 
 namespace drake {
 namespace multibody {
-namespace detail {
+namespace internal {
 
 using Eigen::Vector3d;
 using Eigen::Vector4d;
@@ -464,6 +464,6 @@ geometry::GeometryInstance ParseCollision(
                                     geometry_name);
 }
 
-}  // namespace detail
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/detail_urdf_geometry.h
+++ b/multibody/parsing/detail_urdf_geometry.h
@@ -14,7 +14,7 @@
 
 namespace drake {
 namespace multibody {
-namespace detail {
+namespace internal {
 
 /// A map from the name of a material to its color. The color is specified in
 /// RGBA (Red, Green, Blue, Alpha) format.
@@ -54,6 +54,6 @@ geometry::GeometryInstance ParseCollision(
     const std::string& root_dir, const tinyxml2::XMLElement* node,
     CoulombFriction<double>* friction);
 
-}  /// namespace detail
+}  /// namespace internal
 }  /// namespace multibody
 }  /// namespace drake

--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -19,7 +19,7 @@
 
 namespace drake {
 namespace multibody {
-namespace detail {
+namespace internal {
 
 using Eigen::Matrix3d;
 using Eigen::Vector3d;
@@ -535,6 +535,6 @@ ModelInstanceIndex AddModelFromUrdfFile(
                    &xml_doc, plant);
 }
 
-}  // namespace detail
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/detail_urdf_parser.h
+++ b/multibody/parsing/detail_urdf_parser.h
@@ -9,7 +9,7 @@
 
 namespace drake {
 namespace multibody {
-namespace detail {
+namespace internal {
 
 /// Parses a `<robot>` element from the URDF file specified by @p file_name and
 /// adds it to @p plant.  A new model instance will be added to @p plant.
@@ -36,6 +36,7 @@ ModelInstanceIndex AddModelFromUrdfFile(
     const PackageMap& package_map,
     MultibodyPlant<double>* plant,
     geometry::SceneGraph<double>* scene_graph = nullptr);
-}  // namespace detail
+
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/parser.cc
+++ b/multibody/parsing/parser.cc
@@ -8,9 +8,9 @@
 namespace drake {
 namespace multibody {
 
-using detail::AddModelFromSdfFile;
-using detail::AddModelFromUrdfFile;
-using detail::AddModelsFromSdfFile;
+using internal::AddModelFromSdfFile;
+using internal::AddModelFromUrdfFile;
+using internal::AddModelsFromSdfFile;
 
 Parser::Parser(
     MultibodyPlant<double>* plant,

--- a/multibody/parsing/test/common_parser_test.cc
+++ b/multibody/parsing/test/common_parser_test.cc
@@ -17,7 +17,7 @@
 
 namespace drake {
 namespace multibody {
-namespace detail {
+namespace internal {
 namespace {
 
 using geometry::GeometryId;
@@ -155,6 +155,6 @@ INSTANTIATE_TEST_CASE_P(UrdfMultibodyPlantLinkTests,
                         ::testing::Values(test::LoadFromUrdf));
 
 }  // namespace
-}  // namespace detail
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/test/detail_path_utils_test.cc
+++ b/multibody/parsing/test/detail_path_utils_test.cc
@@ -12,7 +12,7 @@ using std::string;
 
 namespace drake {
 namespace multibody {
-namespace detail {
+namespace internal {
 namespace {
 
 // Verifies that GetFullPath() promotes a relative path to an absolute path,
@@ -139,6 +139,6 @@ GTEST_TEST(ResolveUriTest, TestUnsupported) {
 }
 
 }  // namespace
-}  // namespace detail
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/test/detail_scene_graph_test.cc
+++ b/multibody/parsing/test/detail_scene_graph_test.cc
@@ -17,7 +17,7 @@
 
 namespace drake {
 namespace multibody {
-namespace detail {
+namespace internal {
 namespace {
 
 using Eigen::Matrix3d;
@@ -35,11 +35,11 @@ using geometry::Sphere;
 using math::RigidTransformd;
 using math::RollPitchYaw;
 using math::RotationMatrix;
-using multibody::detail::MakeCoulombFrictionFromSdfCollisionOde;
-using multibody::detail::MakeGeometryInstanceFromSdfVisual;
-using multibody::detail::MakeGeometryPoseFromSdfCollision;
-using multibody::detail::MakeShapeFromSdfGeometry;
-using multibody::detail::MakeVisualPropertiesFromSdfVisual;
+using multibody::internal::MakeCoulombFrictionFromSdfCollisionOde;
+using multibody::internal::MakeGeometryInstanceFromSdfVisual;
+using multibody::internal::MakeGeometryPoseFromSdfCollision;
+using multibody::internal::MakeShapeFromSdfGeometry;
+using multibody::internal::MakeVisualPropertiesFromSdfVisual;
 using std::make_unique;
 using std::unique_ptr;
 using systems::Context;
@@ -913,7 +913,7 @@ GTEST_TEST(SceneGraphParserDetail,
 }
 
 }  // namespace
-}  // namespace detail
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -20,7 +20,7 @@
 
 namespace drake {
 namespace multibody {
-namespace detail {
+namespace internal {
 namespace {
 
 using Eigen::Vector3d;
@@ -414,6 +414,6 @@ GTEST_TEST(SdfParser, TestUnsupportedFrames) {
 
 
 }  // namespace
-}  // namespace detail
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/test/detail_tinyxml_test.cc
+++ b/multibody/parsing/test/detail_tinyxml_test.cc
@@ -17,7 +17,7 @@ using tinyxml2::XMLElement;
 
 namespace drake {
 namespace multibody {
-namespace detail {
+namespace internal {
 namespace {
 
 GTEST_TEST(TinyxmlUtilTest, ParseAttributeTest) {
@@ -75,7 +75,7 @@ GTEST_TEST(TinyxmlUtilTest, OriginAttributesTest) {
   XMLElement* element = xml_doc.FirstChildElement("element");
   ASSERT_TRUE(element != nullptr);
 
-  const RigidTransformd actual = detail::OriginAttributesToTransform(element);
+  const RigidTransformd actual = internal::OriginAttributesToTransform(element);
   const RigidTransformd expected(RollPitchYawd(1, 2, 3), Vector3d(4, 5, 6));
 
   EXPECT_TRUE(CompareMatrices(actual.matrix(), expected.matrix()));
@@ -90,7 +90,7 @@ GTEST_TEST(TinyxmlUtilTest, MalformedRpyOriginAttributesTest) {
   XMLElement* element = xml_doc.FirstChildElement("element");
   ASSERT_TRUE(element != nullptr);
 
-  EXPECT_THROW(detail::OriginAttributesToTransform(element),
+  EXPECT_THROW(internal::OriginAttributesToTransform(element),
                std::invalid_argument);
 }
 
@@ -104,13 +104,13 @@ GTEST_TEST(TinyxmlUtilTest, ThreeVectorAttributeTest) {
   ASSERT_TRUE(element != nullptr);
 
   Vector3d out = Vector3d::Zero();
-  EXPECT_TRUE(detail::ParseThreeVectorAttribute(element, "one", &out));
+  EXPECT_TRUE(internal::ParseThreeVectorAttribute(element, "one", &out));
   EXPECT_TRUE(CompareMatrices(out, Vector3d(1, 1, 1)));
 
-  EXPECT_TRUE(detail::ParseThreeVectorAttribute(element, "three", &out));
+  EXPECT_TRUE(internal::ParseThreeVectorAttribute(element, "three", &out));
   EXPECT_TRUE(CompareMatrices(out, Vector3d(4, 5, 6)));
 
-  EXPECT_FALSE(detail::ParseThreeVectorAttribute(element, "meh", &out));
+  EXPECT_FALSE(internal::ParseThreeVectorAttribute(element, "meh", &out));
 }
 
 GTEST_TEST(TinyxmlUtilTest, LocaleAttributeTest) {
@@ -133,7 +133,7 @@ GTEST_TEST(TinyxmlUtilTest, LocaleAttributeTest) {
   ASSERT_TRUE(element != nullptr);
 
   double scalar = 0.0;
-  EXPECT_TRUE(detail::ParseScalarAttribute(element, "oneAndHalf", &scalar));
+  EXPECT_TRUE(internal::ParseScalarAttribute(element, "oneAndHalf", &scalar));
   EXPECT_EQ(scalar, 1.5);
 
   // Restore the original global locale
@@ -141,6 +141,6 @@ GTEST_TEST(TinyxmlUtilTest, LocaleAttributeTest) {
 }
 
 }  // namespace
-}  // namespace detail
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/test/detail_urdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_urdf_geometry_test.cc
@@ -14,7 +14,7 @@
 
 namespace drake {
 namespace multibody {
-namespace detail {
+namespace internal {
 namespace {
 
 using tinyxml2::XMLDocument;
@@ -63,8 +63,8 @@ class UrdfGeometryTests : public testing::Test {
            visual_node;
            visual_node = visual_node->NextSiblingElement("visual")) {
         geometry::GeometryInstance geometry_instance =
-            detail::ParseVisual(body_name, package_map_, root_dir_,
-                                visual_node, &materials_);
+            internal::ParseVisual(body_name, package_map_, root_dir_,
+                                  visual_node, &materials_);
         visual_instances_.push_back(geometry_instance);
       }
 
@@ -74,8 +74,8 @@ class UrdfGeometryTests : public testing::Test {
            collision_node = collision_node->NextSiblingElement("collision")) {
         CoulombFriction<double> friction;
         geometry::GeometryInstance geometry_instance =
-            detail::ParseCollision(body_name, package_map_, root_dir_,
-                                   collision_node, &friction);
+            internal::ParseCollision(body_name, package_map_, root_dir_,
+                                     collision_node, &friction);
         collision_instances_.push_back(geometry_instance);
       }
     }
@@ -235,21 +235,21 @@ TEST_F(UrdfGeometryTests, TestWrongElementType) {
   ASSERT_TRUE(node);
 
   DRAKE_EXPECT_THROWS_MESSAGE(
-      detail::ParseMaterial(node, &materials_), std::runtime_error,
+      internal::ParseMaterial(node, &materials_), std::runtime_error,
       "Expected material element, got robot");
 
   const XMLElement* material_node = node->FirstChildElement("material");
   ASSERT_TRUE(material_node);
 
   DRAKE_EXPECT_THROWS_MESSAGE(
-      detail::ParseVisual("fake_name", package_map_, root_dir_, material_node,
-                          &materials_), std::runtime_error,
+      internal::ParseVisual("fake_name", package_map_, root_dir_, material_node,
+                            &materials_), std::runtime_error,
       "In link fake_name expected visual element, got material");
 
   CoulombFriction<double> friction;
   DRAKE_EXPECT_THROWS_MESSAGE(
-      detail::ParseCollision("fake_name", package_map_, root_dir_,
-                             material_node, &friction), std::runtime_error,
+      internal::ParseCollision("fake_name", package_map_, root_dir_,
+                               material_node, &friction), std::runtime_error,
       "In link fake_name expected collision element, got material");
 }
 
@@ -279,6 +279,6 @@ TEST_F(UrdfGeometryTests, TestParseConvexMesh) {
 }
 
 }  // namespace
-}  // namespace detail
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/test/detail_urdf_parser_test.cc
+++ b/multibody/parsing/test/detail_urdf_parser_test.cc
@@ -12,7 +12,7 @@
 
 namespace drake {
 namespace multibody {
-namespace detail {
+namespace internal {
 namespace {
 
 using Eigen::Vector3d;
@@ -188,6 +188,6 @@ GTEST_TEST(MultibodyPlantUrdfParserTest, JointParsingTest) {
 }
 
 }  // namespace
-}  // namespace detail
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/solvers/cost.h
+++ b/solvers/cost.h
@@ -251,7 +251,6 @@ class PolynomialCost : public EvaluatorCost<PolynomialEvaluator> {
  * @tparam FF The forwarded function type (e.g., `const F&, `F&&`, ...).
  * The class `F` should have functions numInputs(), numOutputs(), and
  * eval(x, y).
- * @see detail::FunctionTraits.
  */
 template <typename FF>
 std::shared_ptr<Cost> MakeFunctionCost(FF&& f) {

--- a/solvers/create_cost.h
+++ b/solvers/create_cost.h
@@ -33,11 +33,8 @@ Binding<PolynomialCost> ParsePolynomialCost(const symbolic::Expression& e);
  */
 Binding<Cost> ParseCost(const symbolic::Expression& e);
 
-}  // namespace internal
-
 // TODO(eric.cousineau): Remove this when functor cost is no longer exposed
 // externally, and must be explicitly called.
-namespace detail {
 
 // From Drake git sha 24452c1:
 // drake/solvers/mathematical_program.h:739
@@ -79,7 +76,6 @@ struct is_cost_functor_candidate
                                        (!is_convertible_workaround<
                                            F, symbolic::Expression>::value)> {};
 
-}  // namespace detail
-
+}  // namespace internal
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/evaluator_base.h
+++ b/solvers/evaluator_base.h
@@ -211,7 +211,6 @@ class PolynomialEvaluator : public EvaluatorBase {
  * An evaluator that may be specified using a callable object. Consider
  * constructing these instances using MakeFunctionEvaluator(...).
  * @tparam F The function / functor's type.
- * @see detail::FunctionTraits.
  */
 template <typename F>
 class FunctionEvaluator : public EvaluatorBase {
@@ -227,30 +226,30 @@ class FunctionEvaluator : public EvaluatorBase {
    */
   template <typename FF, typename... Args>
   FunctionEvaluator(FF&& f, Args&&... args)
-      : EvaluatorBase(detail::FunctionTraits<F>::numOutputs(f),
-                      detail::FunctionTraits<F>::numInputs(f),
+      : EvaluatorBase(internal::FunctionTraits<F>::numOutputs(f),
+                      internal::FunctionTraits<F>::numInputs(f),
                       std::forward<Args>(args)...),
         f_(std::forward<FF>(f)) {}
 
  private:
   void DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
               Eigen::VectorXd* y) const override {
-    y->resize(detail::FunctionTraits<F>::numOutputs(f_));
+    y->resize(internal::FunctionTraits<F>::numOutputs(f_));
     DRAKE_ASSERT(static_cast<size_t>(x.rows()) ==
-                 detail::FunctionTraits<F>::numInputs(f_));
+                 internal::FunctionTraits<F>::numInputs(f_));
     DRAKE_ASSERT(static_cast<size_t>(y->rows()) ==
-                 detail::FunctionTraits<F>::numOutputs(f_));
-    detail::FunctionTraits<F>::eval(f_, x, y);
+                 internal::FunctionTraits<F>::numOutputs(f_));
+    internal::FunctionTraits<F>::eval(f_, x, y);
   }
 
   void DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
               AutoDiffVecXd* y) const override {
-    y->resize(detail::FunctionTraits<F>::numOutputs(f_));
+    y->resize(internal::FunctionTraits<F>::numOutputs(f_));
     DRAKE_ASSERT(static_cast<size_t>(x.rows()) ==
-                 detail::FunctionTraits<F>::numInputs(f_));
+                 internal::FunctionTraits<F>::numInputs(f_));
     DRAKE_ASSERT(static_cast<size_t>(y->rows()) ==
-                 detail::FunctionTraits<F>::numOutputs(f_));
-    detail::FunctionTraits<F>::eval(f_, x, y);
+                 internal::FunctionTraits<F>::numOutputs(f_));
+    internal::FunctionTraits<F>::eval(f_, x, y);
   }
 
   void DoEval(const Eigen::Ref<const VectorX<symbolic::Variable>>&,
@@ -267,7 +266,6 @@ class FunctionEvaluator : public EvaluatorBase {
  * @tparam FF Perfect-forwarding type of `F` (e.g., `const F&`, `F&&`).
  * @param f Callable function object.
  * @return An implementation of EvaluatorBase using the callable object.
- * @see detail::FunctionTraits.
  * @relates FunctionEvaluator
  */
 template <typename FF>

--- a/solvers/function.h
+++ b/solvers/function.h
@@ -8,7 +8,7 @@
 
 namespace drake {
 namespace solvers {
-namespace detail {
+namespace internal {
 
 template <typename ScalarType>
 using VecIn = Eigen::Ref<const VectorX<ScalarType>>;
@@ -81,6 +81,6 @@ struct FunctionTraits<std::unique_ptr<F>> {
 // void eval(x1,..., xn,  y1,..., ym), and
 // InputOutputRelation getInputOutputRelation(input_index, output_index)
 
-}  // namespace detail
+}  // namespace internal
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -110,9 +110,7 @@ void SetVariableNames(const std::string& name, int rows, int cols,
     }
   }
 }
-}  // namespace internal
 
-namespace detail {
 /**
  * Template condition to only catch when Constraints are inadvertently passed
  * as an argument. If the class is binding-compatible with a Constraint, then
@@ -130,7 +128,7 @@ struct assert_if_is_constraint {
       "You cannot pass a Constraint to create a Cost object from a function. "
       "Please ensure you are passing a Cost.");
 };
-}  // namespace detail
+}  // namespace internal
 
 /**
  * MathematicalProgram stores the decision variables, the constraints and costs
@@ -751,7 +749,6 @@ class MathematicalProgram {
    * Convert an input of type @p F to a FunctionCost object.
    * @tparam F This class should have functions numInputs(), numOutputs and
    * eval(x, y).
-   * @see drake::solvers::detail::FunctionTraits.
    */
   template <typename F>
   static std::shared_ptr<Cost> MakeCost(F&& f) {
@@ -761,10 +758,9 @@ class MathematicalProgram {
   /**
    * Adds a cost to the optimization program on a list of variables.
    * @tparam F it should define functions numInputs, numOutputs and eval. Check
-   * drake::solvers::detail::FunctionTraits for more detail.
    */
   template <typename F>
-  typename std::enable_if<detail::is_cost_functor_candidate<F>::value,
+  typename std::enable_if<internal::is_cost_functor_candidate<F>::value,
                           Binding<Cost>>::type
   AddCost(F&& f, const VariableRefList& vars) {
     return AddCost(f, ConcatenateVariableRefList(vars));
@@ -774,10 +770,9 @@ class MathematicalProgram {
    * Adds a cost to the optimization program on an Eigen::Vector containing
    * decision variables.
    * @tparam F Type that defines functions numInputs, numOutputs and eval.
-   * @see drake::solvers::detail::FunctionTraits.
    */
   template <typename F>
-  typename std::enable_if<detail::is_cost_functor_candidate<F>::value,
+  typename std::enable_if<internal::is_cost_functor_candidate<F>::value,
                           Binding<Cost>>::type
   AddCost(F&& f, const Eigen::Ref<const VectorXDecisionVariable>& vars) {
     auto c = MakeFunctionCost(std::forward<F>(f));
@@ -790,7 +785,7 @@ class MathematicalProgram {
    * @tparam F The type to check.
    */
   template <typename F, typename Vars>
-  typename std::enable_if<detail::assert_if_is_constraint<F>::value,
+  typename std::enable_if<internal::assert_if_is_constraint<F>::value,
                           Binding<Cost>>::type
   AddCost(F&&, Vars&&) {
     throw std::runtime_error("This will assert at compile-time.");

--- a/solvers/test/cost_test.cc
+++ b/solvers/test/cost_test.cc
@@ -31,7 +31,7 @@ using Eigen::Ref;
 using drake::Vector1d;
 using Eigen::Vector2d;
 using Eigen::VectorXd;
-using drake::solvers::detail::is_convertible_workaround;
+using drake::solvers::internal::is_convertible_workaround;
 using drake::solvers::test::GenericTrivialCost2;
 
 namespace drake {

--- a/solvers/test/evaluator_base_test.cc
+++ b/solvers/test/evaluator_base_test.cc
@@ -59,7 +59,7 @@ struct GenericTrivialFunctor {
   int numOutputs() const { return 3; }
 
   template <typename T>
-  void eval(const detail::VecIn<T>& x, detail::VecOut<T>* y) const {
+  void eval(const internal::VecIn<T>& x, internal::VecOut<T>* y) const {
     Eigen::Vector3d c(1, 2, 3);
     *y = c * x.transpose() * c;
   }
@@ -133,7 +133,7 @@ class FunctionWrapper {
   int numOutputs() const { return num_outputs_; }
 
   template <typename T>
-  void eval(const detail::VecIn<T>& x, detail::VecOut<T>* y) const {
+  void eval(const internal::VecIn<T>& x, internal::VecOut<T>* y) const {
     callable_(x, y);
   }
 

--- a/solvers/test/generic_trivial_costs.h
+++ b/solvers/test/generic_trivial_costs.h
@@ -66,8 +66,8 @@ class GenericTrivialCost2 {
   static size_t numOutputs() { return 1; }
 
   template <typename ScalarType>
-  void eval(detail::VecIn<ScalarType> const& x,
-            detail::VecOut<ScalarType>* y) const {
+  void eval(internal::VecIn<ScalarType> const& x,
+            internal::VecOut<ScalarType>* y) const {
     DRAKE_ASSERT(static_cast<size_t>(x.rows()) == numInputs());
     DRAKE_ASSERT(static_cast<size_t>(y->rows()) == numOutputs());
     (*y)(0) = x(0) * x(0) - x(1) * x(1) + 2;

--- a/solvers/test/ipopt_solver_test.cc
+++ b/solvers/test/ipopt_solver_test.cc
@@ -82,7 +82,7 @@ class NoisyQuadraticCost {
   int numInputs() const { return 1; }
   int numOutputs() const { return 1; }
   template <typename T>
-  void eval(detail::VecIn<T> const& x, detail::VecOut<T>* y) const {
+  void eval(internal::VecIn<T> const& x, internal::VecOut<T>* y) const {
     // Parabola with minimum at (-1, 1) with some deterministic noise applied to
     // the input so derivatives will be correctish but not easily followable to
     // the minimum.

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -45,8 +45,8 @@ using Eigen::Vector4d;
 using Eigen::VectorXd;
 
 using drake::Vector1d;
-using drake::solvers::detail::VecIn;
-using drake::solvers::detail::VecOut;
+using drake::solvers::internal::VecIn;
+using drake::solvers::internal::VecOut;
 using drake::symbolic::Expression;
 using drake::symbolic::Formula;
 using drake::symbolic::Variable;

--- a/solvers/test/nonlinear_program_test.cc
+++ b/solvers/test/nonlinear_program_test.cc
@@ -32,8 +32,8 @@ using Eigen::Vector3d;
 using Eigen::Vector4d;
 using Eigen::VectorXd;
 
-using drake::solvers::detail::VecIn;
-using drake::solvers::detail::VecOut;
+using drake::solvers::internal::VecIn;
+using drake::solvers::internal::VecOut;
 
 using std::numeric_limits;
 

--- a/solvers/test/optimization_examples.h
+++ b/solvers/test/optimization_examples.h
@@ -200,8 +200,8 @@ class NonConvexQPproblem1 {
     static size_t numOutputs() { return 1; }
 
     template <typename ScalarType>
-    void eval(detail::VecIn<ScalarType> const& x,
-              detail::VecOut<ScalarType>* y) const {
+    void eval(internal::VecIn<ScalarType> const& x,
+              internal::VecOut<ScalarType>* y) const {
       DRAKE_ASSERT(static_cast<size_t>(x.rows()) == numInputs());
       DRAKE_ASSERT(static_cast<size_t>(y->rows()) == numOutputs());
       (*y)(0) = (-50.0 * x(0) * x(0)) + (42 * x(0)) - (50.0 * x(1) * x(1)) +
@@ -260,8 +260,8 @@ class NonConvexQPproblem2 {
     static size_t numOutputs() { return 1; }
 
     template <typename ScalarType>
-    void eval(detail::VecIn<ScalarType> const& x,
-              detail::VecOut<ScalarType>* y) const {
+    void eval(internal::VecIn<ScalarType> const& x,
+              internal::VecOut<ScalarType>* y) const {
       DRAKE_ASSERT(static_cast<size_t>(x.rows()) == numInputs());
       DRAKE_ASSERT(static_cast<size_t>(y->rows()) == numOutputs());
       (*y)(0) = (-50.0 * x(0) * x(0)) + (-10.5 * x(0)) - (50.0 * x(1) * x(1)) +
@@ -317,8 +317,8 @@ class LowerBoundedProblem {
     static size_t numOutputs() { return 1; }
 
     template <typename ScalarType>
-    void eval(detail::VecIn<ScalarType> const& x,
-              detail::VecOut<ScalarType>* y) const {
+    void eval(internal::VecIn<ScalarType> const& x,
+              internal::VecOut<ScalarType>* y) const {
       DRAKE_ASSERT(static_cast<size_t>(x.rows()) == numInputs());
       DRAKE_ASSERT(static_cast<size_t>(y->rows()) == numOutputs());
       (*y)(0) = -25 * (x(0) - 2) * (x(0) - 2) + (x(1) - 2) * (x(1) - 2) -
@@ -425,8 +425,8 @@ class GloptiPolyConstrainedMinimizationProblem {
     static size_t numOutputs() { return 1; }
 
     template <typename ScalarType>
-    void eval(detail::VecIn<ScalarType> const& x,
-              detail::VecOut<ScalarType>* y) const {
+    void eval(internal::VecIn<ScalarType> const& x,
+              internal::VecOut<ScalarType>* y) const {
       DRAKE_ASSERT(static_cast<size_t>(x.rows()) == numInputs());
       DRAKE_ASSERT(static_cast<size_t>(y->rows()) == numOutputs());
       (*y)(0) = -2 * x(0) + x(1) - x(2);

--- a/systems/analysis/hermitian_dense_output.h
+++ b/systems/analysis/hermitian_dense_output.h
@@ -20,7 +20,7 @@
 namespace drake {
 namespace systems {
 
-namespace detail {
+namespace internal {
 
 /// Converts a matrix with scalar type `S` elements to a matrix with double
 /// type elements, failing at runtime if the type cannot be converted.
@@ -68,7 +68,7 @@ ExtractDoublesOrThrow(const std::vector<MatrixX<S>>& input_vector) {
   return output_vector;
 }
 
-}  // namespace detail
+}  // namespace internal
 
 /// A StepwiseDenseOutput class implementation using Hermitian interpolators,
 /// and therefore a _continuous extension_ of the solution 𝐱(t) (see
@@ -274,9 +274,9 @@ class HermitianDenseOutput final : public StepwiseDenseOutput<T> {
     for (const IntegrationStep& step : raw_steps_) {
       continuous_trajectory_.ConcatenateInTime(
           trajectories::PiecewisePolynomial<double>::Cubic(
-              detail::ExtractDoublesOrThrow(step.get_times()),
-              detail::ExtractDoublesOrThrow(step.get_states()),
-              detail::ExtractDoublesOrThrow(step.get_state_derivatives())));
+              internal::ExtractDoublesOrThrow(step.get_times()),
+              internal::ExtractDoublesOrThrow(step.get_states()),
+              internal::ExtractDoublesOrThrow(step.get_state_derivatives())));
     }
     start_time_ = continuous_trajectory_.start_time();
     end_time_ = continuous_trajectory_.end_time();

--- a/systems/analysis/initial_value_problem-inl.h
+++ b/systems/analysis/initial_value_problem-inl.h
@@ -16,7 +16,7 @@
 namespace drake {
 namespace systems {
 
-namespace detail {
+namespace internal {
 
 /// A LeafSystem subclass used to describe parameterized ODE systems
 /// i.e. d𝐱/dt = f(t, 𝐱; 𝐤) where f : t ⨯ 𝐱 →  ℝⁿ, t ∈ ℝ , 𝐱 ∈ ℝⁿ, 𝐤 ∈ ℝᵐ.
@@ -96,7 +96,7 @@ void ODESystem<T>::DoCalcTimeDerivatives(
       parameter_vector.get_value()));
 }
 
-}  // namespace detail
+}  // namespace internal
 
 template<typename T>
 const double InitialValueProblem<T>::kDefaultAccuracy = 1e-4;
@@ -124,7 +124,7 @@ InitialValueProblem<T>::InitialValueProblem(
     throw std::logic_error("No default parameters vector k was given.");
   }
   // Instantiates the system using the given defaults as models.
-  system_ = std::make_unique<detail::ODESystem<T>>(
+  system_ = std::make_unique<internal::ODESystem<T>>(
       ode_function, default_values_.x0.value(), default_values_.k.value());
 
   // Allocates a new default integration context with the

--- a/systems/framework/context_base.cc
+++ b/systems/framework/context_base.cc
@@ -34,7 +34,7 @@ std::string ContextBase::GetSystemPathname() const {
 FixedInputPortValue& ContextBase::FixInputPort(
     int index, std::unique_ptr<AbstractValue> value) {
   std::unique_ptr<FixedInputPortValue> fixed =
-      detail::ContextBaseFixedInputAttorney::CreateFixedInputPortValue(
+      internal::ContextBaseFixedInputAttorney::CreateFixedInputPortValue(
           std::move(value));
   FixedInputPortValue& fixed_ref = *fixed;
   SetFixedInputPortValue(InputPortIndex(index), std::move(fixed));
@@ -110,9 +110,9 @@ void ContextBase::SetFixedInputPortValue(
   }
 
   // Fill in the FixedInputPortValue object and install it.
-  detail::ContextBaseFixedInputAttorney::set_ticket(port_value.get(),
-                                                    ticket_to_use);
-  detail::ContextBaseFixedInputAttorney::set_owning_subcontext(
+  internal::ContextBaseFixedInputAttorney::set_ticket(port_value.get(),
+                                                      ticket_to_use);
+  internal::ContextBaseFixedInputAttorney::set_owning_subcontext(
       port_value.get(), this);
   input_port_values_[index] = std::move(port_value);
 
@@ -300,7 +300,7 @@ void ContextBase::FixContextPointers(
   clone->cache_.RepairCachePointers(clone);
   for (auto& fixed_input : clone->input_port_values_) {
     if (fixed_input != nullptr) {
-      detail::ContextBaseFixedInputAttorney::set_owning_subcontext(
+      internal::ContextBaseFixedInputAttorney::set_owning_subcontext(
           fixed_input.get_mutable(), clone);
     }
   }

--- a/systems/framework/context_base.h
+++ b/systems/framework/context_base.h
@@ -19,10 +19,10 @@ namespace drake {
 namespace systems {
 
 #ifndef DRAKE_DOXYGEN_CXX
-namespace detail {
+namespace internal {
 // This provides SystemBase limited "friend" access to ContextBase.
 class SystemBaseContextBaseAttorney;
-}  // namespace detail
+}  // namespace internal
 #endif
 
 /** Provides non-templatized Context functionality shared by the templatized
@@ -581,7 +581,7 @@ class ContextBase : public internal::ContextMessageInterface {
   }
 
  private:
-  friend class detail::SystemBaseContextBaseAttorney;
+  friend class internal::SystemBaseContextBaseAttorney;
 
   // Returns the parent Context or `nullptr` if this is the root Context.
   const ContextBase* get_parent_base() const { return parent_; }
@@ -661,7 +661,7 @@ class ContextBase : public internal::ContextMessageInterface {
 
 #ifndef DRAKE_DOXYGEN_CXX
 class SystemBase;
-namespace detail {
+namespace internal {
 
 // This is an attorney-client pattern class providing SystemBase with access to
 // certain specific ContextBase private methods, and nothing else.
@@ -735,7 +735,7 @@ class SystemBaseContextBaseAttorney {
   }
 };
 
-}  // namespace detail
+}  // namespace internal
 #endif
 
 }  // namespace systems

--- a/systems/framework/fixed_input_port_value.h
+++ b/systems/framework/fixed_input_port_value.h
@@ -20,10 +20,10 @@ namespace systems {
 class ContextBase;
 
 #ifndef DRAKE_DOXYGEN_CXX
-namespace detail {
+namespace internal {
 // This provides ContextBase limited "friend" access to FixedInputPortValue.
 class ContextBaseFixedInputAttorney;
-}  // namespace detail
+}  // namespace internal
 #endif
 
 /** A %FixedInputPortValue encapsulates a vector or abstract value for
@@ -105,7 +105,7 @@ class FixedInputPortValue {
   }
 
  private:
-  friend class detail::ContextBaseFixedInputAttorney;
+  friend class internal::ContextBaseFixedInputAttorney;
 
   // Allow this adapter access to our private copy constructor. This is intended
   // only for use by ContextBase.
@@ -157,7 +157,7 @@ class FixedInputPortValue {
 };
 
 #ifndef DRAKE_DOXYGEN_CXX
-namespace detail {
+namespace internal {
 
 class ContextBaseFixedInputAttorney {
  public:
@@ -191,7 +191,7 @@ class ContextBaseFixedInputAttorney {
   }
 };
 
-}  // namespace detail
+}  // namespace internal
 #endif
 
 }  // namespace systems

--- a/systems/framework/leaf_system.cc
+++ b/systems/framework/leaf_system.cc
@@ -4,7 +4,7 @@
 
 namespace drake {
 namespace systems {
-namespace leaf_system_detail {
+namespace leaf_system_internal {
 
 // C++'s deprecation attribute only triggers a diagnostic for callers, not for
 // overriders.  So our "DoHasDirectFeedthroughDeprecated" deprecation would
@@ -18,7 +18,7 @@ void MaybeWarnDoHasDirectFeedthroughDeprecated() {
       "deprecated; please consult its API documentation for alternatives.");
 }
 
-}  // namespace leaf_system_detail
+}  // namespace leaf_system_internal
 }  // namespace systems
 }  // namespace drake
 

--- a/systems/framework/model_values.cc
+++ b/systems/framework/model_values.cc
@@ -5,7 +5,7 @@
 
 namespace drake {
 namespace systems {
-namespace detail {
+namespace internal {
 
 int ModelValues::size() const {
   return static_cast<int>(values_.size());
@@ -32,6 +32,6 @@ std::unique_ptr<AbstractValue> ModelValues::CloneModel(int index) const {
 }
 
 
-}  // namespace detail
+}  // namespace internal
 }  // namespace systems
 }  // namespace drake

--- a/systems/framework/model_values.h
+++ b/systems/framework/model_values.h
@@ -11,7 +11,7 @@
 
 namespace drake {
 namespace systems {
-namespace detail {
+namespace internal {
 
 /// Represents models for a sequence of AbstractValues (usually a sequence of
 /// either input or output ports).  The models are the "prototype" design
@@ -92,6 +92,6 @@ ModelValues::CloneVectorModel(int index) const {
   return basic_vector.Clone();
 }
 
-}  // namespace detail
+}  // namespace internal
 }  // namespace systems
 }  // namespace drake

--- a/systems/framework/system_base.cc
+++ b/systems/framework/system_base.cc
@@ -58,10 +58,11 @@ void SystemBase::InitializeContextBase(ContextBase* context_ptr) const {
 
   // Initialization should happen only once per Context.
   DRAKE_DEMAND(
-      !detail::SystemBaseContextBaseAttorney::is_context_base_initialized(
+      !internal::SystemBaseContextBaseAttorney::is_context_base_initialized(
           context));
 
-  detail::SystemBaseContextBaseAttorney::set_system_name(&context, get_name());
+  internal::SystemBaseContextBaseAttorney::set_system_name(
+      &context, get_name());
 
   // Add the independent-source trackers and wire them up appropriately. That
   // includes input ports since their dependencies are external.
@@ -91,12 +92,12 @@ void SystemBase::InitializeContextBase(ContextBase* context_ptr) const {
   // an exported output port in the parent Diagram. The associated cache entries
   // were just created above. Any intra-system prerequisites are set up now.
   for (const auto& oport : output_ports_) {
-    detail::SystemBaseContextBaseAttorney::AddOutputPort(
+    internal::SystemBaseContextBaseAttorney::AddOutputPort(
         &context, oport->get_index(), oport->ticket(),
         oport->GetPrerequisite());
   }
 
-  detail::SystemBaseContextBaseAttorney::mark_context_base_initialized(
+  internal::SystemBaseContextBaseAttorney::mark_context_base_initialized(
       &context);
 }
 
@@ -130,27 +131,27 @@ void SystemBase::CreateSourceTrackers(ContextBase* context_ptr) const {
   // the "all discrete variables" tracker xd to those.
   make_trackers(
       xd_ticket(), discrete_state_tickets_,
-      &detail::SystemBaseContextBaseAttorney::AddDiscreteStateTicket);
+      &internal::SystemBaseContextBaseAttorney::AddDiscreteStateTicket);
 
   // Allocate trackers for each abstract state variable xaᵢ, and subscribe
   // the "all abstract variables" tracker xa to those.
   make_trackers(
       xa_ticket(), abstract_state_tickets_,
-      &detail::SystemBaseContextBaseAttorney::AddAbstractStateTicket);
+      &internal::SystemBaseContextBaseAttorney::AddAbstractStateTicket);
 
   // Allocate trackers for each numeric parameter pnᵢ and each abstract
   // parameter paᵢ, and subscribe the pn and pa trackers to them.
   make_trackers(
       pn_ticket(), numeric_parameter_tickets_,
-      &detail::SystemBaseContextBaseAttorney::AddNumericParameterTicket);
+      &internal::SystemBaseContextBaseAttorney::AddNumericParameterTicket);
   make_trackers(
       pa_ticket(), abstract_parameter_tickets_,
-      &detail::SystemBaseContextBaseAttorney::AddAbstractParameterTicket);
+      &internal::SystemBaseContextBaseAttorney::AddAbstractParameterTicket);
 
   // Allocate trackers for each input port uᵢ, and subscribe the "all input
   // ports" tracker u to them. Doesn't use TrackerInfo so can't use the lambda.
   for (const auto& iport : input_ports_) {
-    detail::SystemBaseContextBaseAttorney::AddInputPort(
+    internal::SystemBaseContextBaseAttorney::AddInputPort(
         &context, iport->get_index(), iport->ticket(),
         MakeFixInputPortTypeChecker(iport->get_index()));
   }
@@ -180,7 +181,7 @@ const AbstractValue* SystemBase::EvalAbstractInputImpl(
   // This is not the root System, and the port isn't fixed, so ask our parent to
   // evaluate it.
   return get_parent_service()->EvalConnectedSubsystemInputPort(
-      *detail::SystemBaseContextBaseAttorney::get_parent_base(context),
+      *internal::SystemBaseContextBaseAttorney::get_parent_base(context),
       get_input_port_base(port_index));
 }
 

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -92,7 +92,7 @@ class SystemBase : public internal::SystemMessageInterface {
     // We depend on derived classes to call our InitializeContextBase() method
     // after allocating the appropriate concrete Context.
     DRAKE_DEMAND(
-        detail::SystemBaseContextBaseAttorney::is_context_base_initialized(
+        internal::SystemBaseContextBaseAttorney::is_context_base_initialized(
             *context));
 
     return context;

--- a/systems/framework/system_scalar_converter.h
+++ b/systems/framework/system_scalar_converter.h
@@ -220,7 +220,7 @@ std::unique_ptr<System<T>> SystemScalarConverter::Convert(
   return std::unique_ptr<System<T>>(result);
 }
 
-namespace system_scalar_converter_detail {
+namespace system_scalar_converter_internal {
 // When Traits says that conversion is supported.
 template <template <typename> class S, typename T, typename U>
 static std::unique_ptr<System<T>> Make(
@@ -250,9 +250,9 @@ static std::unique_ptr<System<T>> Make(
     bool, const System<U>&, std::false_type) {
   // AddIfSupported is guaranteed not to call us, but we *will* be compiled,
   // so we have to have some kind of function body.
-  throw std::logic_error("system_scalar_converter_detail");
+  throw std::logic_error("system_scalar_converter_internal");
 }
-}  // namespace system_scalar_converter_detail
+}  // namespace system_scalar_converter_internal
 
 template <template <typename> class S, typename T, typename U>
 void SystemScalarConverter::AddIfSupported(
@@ -265,7 +265,7 @@ void SystemScalarConverter::AddIfSupported(
       // Dispatch to an overload based on whether S<U> ==> S<T> is supported.
       // (At runtime, this block is only executed for supported conversions,
       // but at compile time, Make will be instantiated unconditionally.)
-      return system_scalar_converter_detail::Make<S, T, U>(
+      return system_scalar_converter_internal::Make<S, T, U>(
           (subtype_preservation == GuaranteedSubtypePreservation::kEnabled),
           other, supported{});
     };

--- a/systems/framework/test/model_values_test.cc
+++ b/systems/framework/test/model_values_test.cc
@@ -10,7 +10,7 @@
 
 namespace drake {
 namespace systems {
-namespace detail {
+namespace internal {
 namespace {
 
 using symbolic::Expression;
@@ -131,6 +131,6 @@ GTEST_TEST(ModelValuesTest, NullTest) {
 }
 
 }  // namespace
-}  // namespace detail
+}  // namespace internal
 }  // namespace systems
 }  // namespace drake

--- a/systems/framework/test/system_base_test.cc
+++ b/systems/framework/test/system_base_test.cc
@@ -17,7 +17,7 @@ namespace systems {
 // Don't want anonymous here because the type name test would then depend on
 // exactly how anonymous namespaces are rendered by NiceTypeName, which is
 // a "don't care" here.
-namespace system_base_test_detail {
+namespace system_base_test_internal {
 
 // A minimal concrete ContextBase object suitable for some simple tests.
 class MyContextBase final : public ContextBase {
@@ -80,7 +80,7 @@ GTEST_TEST(SystemBaseTest, NameAndMessageSupport) {
   EXPECT_EQ(system.GetSystemPathname(), "::any_name_will_do");
 
   EXPECT_EQ(system.GetSystemType(),
-            "drake::systems::system_base_test_detail::MySystemBase");
+            "drake::systems::system_base_test_internal::MySystemBase");
 
   auto context = system.AllocateContext();
   EXPECT_NO_THROW(system.ThrowIfContextNotCompatible(*context));
@@ -91,6 +91,6 @@ GTEST_TEST(SystemBaseTest, NameAndMessageSupport) {
                               ".*Context.*unacceptable.*");
 }
 
-}  // namespace system_base_test_detail
+}  // namespace system_base_test_internal
 }  // namespace systems
 }  // namespace drake

--- a/systems/framework/test/value_checker_test.cc
+++ b/systems/framework/test/value_checker_test.cc
@@ -51,7 +51,7 @@ class NotQuiteGoodVector : public GoodVector {
 
 // A convenience wrapper for the "device under test".
 void CheckVector(const BasicVector<double>* basic_vector) {
-  drake::systems::detail::CheckBasicVectorInvariants(basic_vector);
+  drake::systems::internal::CheckBasicVectorInvariants(basic_vector);
 }
 
 GTEST_TEST(ValueCheckerTest, CheckBasicVectorInvariantsTest) {
@@ -71,7 +71,7 @@ GTEST_TEST(ValueCheckerTest, CheckBasicVectorInvariantsTest) {
 
 // A convenience wrapper for the "device under test".
 void CheckValue(const AbstractValue* abstract_value) {
-  drake::systems::detail::CheckVectorValueInvariants<double>(abstract_value);
+  drake::systems::internal::CheckVectorValueInvariants<double>(abstract_value);
 }
 
 GTEST_TEST(ValueCheckerTest, CheckVectorValueInvariantsTest) {

--- a/systems/framework/value_checker.h
+++ b/systems/framework/value_checker.h
@@ -11,7 +11,7 @@
 
 namespace drake {
 namespace systems {
-namespace detail {
+namespace internal {
 
 /// Checks some BasicVector invariants on @p basic_vector.
 ///
@@ -67,6 +67,6 @@ void CheckVectorValueInvariants(const AbstractValue* abstract_value) {
   }
 }
 
-}  // namespace detail
+}  // namespace internal
 }  // namespace systems
 }  // namespace drake

--- a/systems/rendering/pose_aggregator.h
+++ b/systems/rendering/pose_aggregator.h
@@ -13,7 +13,7 @@ namespace drake {
 namespace systems {
 namespace rendering {
 
-namespace pose_aggregator_detail { struct InputRecord; }
+namespace pose_aggregator_internal { struct InputRecord; }
 
 /// A container with references to the input port for the pose input, and a
 /// reference to the input port for the velocity input.
@@ -126,7 +126,7 @@ class PoseAggregator : public LeafSystem<T> {
   // This is the method used by the allocator for the output port.
   PoseBundle<T> MakePoseBundle() const;
 
-  using InputRecord = pose_aggregator_detail::InputRecord;
+  using InputRecord = pose_aggregator_internal::InputRecord;
 
   // Returns an InputRecord for a generic single pose input.
   static InputRecord MakeSinglePoseInputRecord(const std::string& name,
@@ -151,7 +151,7 @@ class PoseAggregator : public LeafSystem<T> {
 };
 
 /** @cond */
-namespace pose_aggregator_detail {
+namespace pose_aggregator_internal {
 
 // A private data structure of PoseAggregator.  It is not nested within
 // PoseAggregator because it does not (and should not) depend on the type
@@ -171,7 +171,7 @@ struct InputRecord {
   int model_instance_id{-1};
 };
 
-}  // namespace pose_aggregator_detail
+}  // namespace pose_aggregator_internal
 /** @endcond */
 
 }  // namespace rendering


### PR DESCRIPTION
Per Drake GSG we should always use "internal" (see https://github.com/RobotLocomotion/styleguide/pull/18).  This brings all existing code up to par, which benefits both consistency and also better dissuades downstream users from thinking that "detail" items are okay to use.

(I have confirmed locally that in Anzu we aren't using any `detail` symbols accidentally; this commit compiles fine over there.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11765)
<!-- Reviewable:end -->
