### PR TITLE
Remove reference to original MATLAB from documentation

### DIFF
--- a/doc/developers.rst
+++ b/doc/developers.rst
@@ -83,7 +83,7 @@ supported for CMake builds using the "Unix Makefiles" generator.
 | Ubuntu 16.04 LTS (Xenial Xerus)  | 0.28  | 3.5   | | Clang 6.0         | OpenJDK 8  | R2017a            | 2.7    |
 |                                  |       |       | | GCC 5.4           |            |                   |        |
 +----------------------------------+       +-------+---------------------+------------+-------------------+--------+
-| Ubuntu 18.04 LTS (Bionic Beaver) |       | 3.10  | | Clang 6.0         | OpenJDK 11 | R2018b            | | 2.7  |
+| Ubuntu 18.04 LTS (Bionic Beaver) |       | 3.10  | | Clang 6.0         | OpenJDK 11 | Not Supported     | | 2.7  |
 |                                  |       |       | | GCC 7.3           |            |                   | | 3.6  |
 +----------------------------------+       +-------+---------------------+------------+                   +--------+
 | macOS High Sierra (10.13)        |       | 3.14  | | Apple LLVM 10.0.0 | Oracle 12  |                   | | 2.7  |
@@ -96,10 +96,6 @@ supported for CMake builds using the "Unix Makefiles" generator.
 CPython is the only Python implementation supported. On all platforms, Python 2.7
 is the default version. On Ubuntu, amd64 (i.e., x86_64) is the only supported
 architecture.
-
-The following configurations are presently untested in continuous integration:
-
--   macOS, Ubuntu Bionic: MATLAB
 
 Please review the following issues for current support roadmaps:
 

--- a/doc/matlab_bindings.rst
+++ b/doc/matlab_bindings.rst
@@ -4,9 +4,8 @@
 Using Drake from MATLAB
 ***********************
 
-MATLAB code/bindings available in Drake are unit tested on MATLAB R2017a.
-Other MATLAB versions may work (namely R2016a or above) but are not officially
-supported.
+MATLAB code/bindings available in Drake are unit tested on MATLAB R2017a on
+Ubuntu 16.04 (Xenial Xerus).
 
 We are currently experimenting with a few solutions for implementing the
 MATLAB bindings for Drake's new C++ libraries.  You will find minimal
@@ -45,13 +44,3 @@ If so, modify your MATLAB installation as follows:
     sudo ln -s /usr/lib/x86_64-linux-gnu/libgfortran.so.3 libgfortran.so.3
     sudo ln -s /usr/lib/x86_64-linux-gnu/libstdc++.so.6 libstdc++.so.6
     sudo ln -s /usr/lib/x86_64-linux-gnu/libquadmath.so.0 libquadmath.so.0
-
-Original MATLAB
-===============
-
-Prior to 2016, Drake was built around a substantial base of MATLAB software.
-Most of that was removed from the head of git master during 2017.
-
-To view or use the original MATLAB implementation, you may use this tag:
-
-https://github.com/RobotLocomotion/drake/tree/last_sha_with_original_matlab


### PR DESCRIPTION
Relates #11753.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11768)
<!-- Reviewable:end -->
