### PR TITLE
doc: Repair clang-format path for macOS

### DIFF
--- a/doc/code_style_tools.rst
+++ b/doc/code_style_tools.rst
@@ -59,7 +59,7 @@ install Drake's required version of ``clang-format``, depending on the platform
 To run clang-format::
 
     # For development on macOS:
-    clang-format -i -style=file [file name]
+    /usr/local/opt/llvm@6/bin/clang-format -i -style=file [file name]
 
     # For development on Ubuntu:
     clang-format-6.0 -i -style=file [file name]


### PR DESCRIPTION
To match https://github.com/RobotLocomotion/drake/blob/967aba6524fc4bb8b338876754c7d48b25bcde89/tools/lint/clang_format.py#L10

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11770)
<!-- Reviewable:end -->
