### PR TITLE
Added some topology info to SurfaceMesh.

### DIFF
--- a/geometry/proximity/surface_mesh.h
+++ b/geometry/proximity/surface_mesh.h
@@ -154,7 +154,7 @@ class SurfaceMesh {
   /**
    Gets the set of triangles that refer to the specified vertex.
    */
-  const std::set<SurfaceFaceIndex> referring_triangles(VertexIndex v) const {
+  const std::set<SurfaceFaceIndex>& referring_triangles(VertexIndex v) const {
     return referring_triangles_[v];
   }
 
@@ -205,19 +205,6 @@ class SurfaceMesh {
    */
   const Vector3<T>& centroid() const { return p_MSc_; }
 
-  /**
-   Determines the triangular faces that refer to each vertex.
-   */
-  void SetReferringTriangles() {
-    referring_triangles_.resize(num_vertices());
-
-    for (SurfaceFaceIndex i(0); i < num_faces(); ++i) {
-      const int num_vertices_per_face = 3;
-      for (int j = 0; j < num_vertices_per_face; ++j)
-        referring_triangles_[element(i).vertex(j)].insert(i);
-    }
-  }
-
   /** 
    Maps the barycentric coordinates `Q_barycentric` of a point Q in
    `element_index` to its position vector p_MQ.
@@ -242,6 +229,19 @@ class SurfaceMesh {
   // Calculates the areas of each triangle, the total area, and the centorid of
   // the surface.
   void CalcAreasAndCentroid();
+
+  /**
+   Determines the triangular faces that refer to each vertex.
+   */
+  void SetReferringTriangles() {
+    referring_triangles_.resize(num_vertices());
+
+    for (SurfaceFaceIndex i(0); i < num_faces(); ++i) {
+      const int kNumVerticesPerFace = 3;
+      for (int j = 0; j < kNumVerticesPerFace; ++j)
+        referring_triangles_[element(i).vertex(j)].insert(i);
+    }
+  }
 
   // The triangles that comprise the surface.
   std::vector<SurfaceFace> faces_;

--- a/geometry/proximity/surface_mesh.h
+++ b/geometry/proximity/surface_mesh.h
@@ -226,13 +226,11 @@ class SurfaceMesh {
   }
 
  private:
-  // Calculates the areas of each triangle, the total area, and the centorid of
+  // Calculates the areas of each triangle, the total area, and the centroid of
   // the surface.
   void CalcAreasAndCentroid();
 
-  /**
-   Determines the triangular faces that refer to each vertex.
-   */
+  // Determines the triangular faces that refer to each vertex.
   void SetReferringTriangles() {
     referring_triangles_.resize(num_vertices());
 

--- a/geometry/proximity/surface_mesh.h
+++ b/geometry/proximity/surface_mesh.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <array>
-#include <utility>
 #include <set>
+#include <utility>
 #include <vector>
 
 #include "drake/common/drake_assert.h"
@@ -214,8 +214,8 @@ class SurfaceMesh {
     for (SurfaceFaceIndex i(0); i < num_faces(); ++i) {
       const int num_vertices_per_face = 3;
       for (int j = 0; j < num_vertices_per_face; ++j)
-        referring_triangles_[element(i).vertex(j)].insert(i);        
-    }    
+        referring_triangles_[element(i).vertex(j)].insert(i);
+    }
   }
 
   /** 

--- a/geometry/proximity/test/surface_mesh_test.cc
+++ b/geometry/proximity/test/surface_mesh_test.cc
@@ -116,10 +116,10 @@ GTEST_TEST(SurfaceMeshTest, ReferringTriangles) {
   ASSERT_EQ(tris_referring_to_3.size(), 1);
 
   // Check the referring triangles.
-  EXPECT_EQ(first(tris_referring_to_0), 0); 
+  EXPECT_EQ(first(tris_referring_to_0), 0);
   EXPECT_EQ(second(tris_referring_to_0), 1);
-  EXPECT_EQ(first(tris_referring_to_1), 0); 
-  EXPECT_EQ(first(tris_referring_to_2), 0); 
+  EXPECT_EQ(first(tris_referring_to_1), 0);
+  EXPECT_EQ(first(tris_referring_to_2), 0);
   EXPECT_EQ(second(tris_referring_to_2), 1);
   EXPECT_EQ(first(tris_referring_to_3), 1);
 }

--- a/geometry/proximity/test/surface_mesh_test.cc
+++ b/geometry/proximity/test/surface_mesh_test.cc
@@ -87,18 +87,6 @@ GTEST_TEST(SurfaceMeshTest, ReferringTriangles) {
   auto surface_mesh = GenerateTwoTriangleMesh<double>();
   ASSERT_EQ(surface_mesh->num_vertices(), 4);
 
-  // Gets the first element from a set of SurfaceFaceIndex.
-  auto first = [](const std::set<SurfaceFaceIndex>& s) -> SurfaceFaceIndex {
-    return *s.begin();
-  };
-
-  // Gets the second element from a set of SurfaceFaceIndex.
-  auto second = [](const std::set<SurfaceFaceIndex>& s) -> SurfaceFaceIndex {
-    auto iterator = s.begin();
-    ++iterator;
-    return *iterator;
-  };
-
   // Get the four sets.
   const std::set<SurfaceFaceIndex>& tris_referring_to_0 =
       surface_mesh->referring_triangles(SurfaceVertexIndex(0));
@@ -109,19 +97,19 @@ GTEST_TEST(SurfaceMeshTest, ReferringTriangles) {
   const std::set<SurfaceFaceIndex>& tris_referring_to_3 =
       surface_mesh->referring_triangles(SurfaceVertexIndex(3));
 
-  // Verify that they are the correct size.
-  ASSERT_EQ(tris_referring_to_0.size(), 2);
-  ASSERT_EQ(tris_referring_to_1.size(), 1);
-  ASSERT_EQ(tris_referring_to_2.size(), 2);
-  ASSERT_EQ(tris_referring_to_3.size(), 1);
+  // Construct the expected sets.
+  std::set<SurfaceFaceIndex> expected_tris_referring_to_0{
+      SurfaceFaceIndex(0), SurfaceFaceIndex(1) };
+  std::set<SurfaceFaceIndex> expected_tris_referring_to_1{SurfaceFaceIndex(0)};
+  std::set<SurfaceFaceIndex> expected_tris_referring_to_2{
+      SurfaceFaceIndex(0), SurfaceFaceIndex(1) };
+  std::set<SurfaceFaceIndex> expected_tris_referring_to_3{SurfaceFaceIndex(1)};
 
-  // Check the referring triangles.
-  EXPECT_EQ(first(tris_referring_to_0), 0);
-  EXPECT_EQ(second(tris_referring_to_0), 1);
-  EXPECT_EQ(first(tris_referring_to_1), 0);
-  EXPECT_EQ(first(tris_referring_to_2), 0);
-  EXPECT_EQ(second(tris_referring_to_2), 1);
-  EXPECT_EQ(first(tris_referring_to_3), 1);
+  // Check the results.
+  EXPECT_EQ(expected_tris_referring_to_0, tris_referring_to_0);
+  EXPECT_EQ(expected_tris_referring_to_1, tris_referring_to_1);
+  EXPECT_EQ(expected_tris_referring_to_2, tris_referring_to_2);
+  EXPECT_EQ(expected_tris_referring_to_3, tris_referring_to_3);
 }
 
 // Checks the area calculations.

--- a/geometry/proximity/test/surface_mesh_test.cc
+++ b/geometry/proximity/test/surface_mesh_test.cc
@@ -81,6 +81,49 @@ GTEST_TEST(SurfaceMeshTest, GenerateTwoTriangleMeshAutoDiffXd) {
   EXPECT_EQ(surface_mesh->num_faces(), 2);
 }
 
+// Tests that referring_triangles() produces the correct sets of referring
+// triangles.
+GTEST_TEST(SurfaceMeshTest, ReferringTriangles) {
+  auto surface_mesh = GenerateTwoTriangleMesh<double>();
+  ASSERT_EQ(surface_mesh->num_vertices(), 4);
+
+  // Gets the first element from a set of SurfaceFaceIndex.
+  auto first = [](const std::set<SurfaceFaceIndex>& s) -> SurfaceFaceIndex {
+    return *s.begin();
+  };
+
+  // Gets the second element from a set of SurfaceFaceIndex.
+  auto second = [](const std::set<SurfaceFaceIndex>& s) -> SurfaceFaceIndex {
+    auto iterator = s.begin();
+    ++iterator;
+    return *iterator;
+  };
+
+  // Get the four sets.
+  const std::set<SurfaceFaceIndex>& tris_referring_to_0 =
+      surface_mesh->referring_triangles(SurfaceVertexIndex(0));
+  const std::set<SurfaceFaceIndex>& tris_referring_to_1 =
+      surface_mesh->referring_triangles(SurfaceVertexIndex(1));
+  const std::set<SurfaceFaceIndex>& tris_referring_to_2 =
+      surface_mesh->referring_triangles(SurfaceVertexIndex(2));
+  const std::set<SurfaceFaceIndex>& tris_referring_to_3 =
+      surface_mesh->referring_triangles(SurfaceVertexIndex(3));
+
+  // Verify that they are the correct size.
+  ASSERT_EQ(tris_referring_to_0.size(), 2);
+  ASSERT_EQ(tris_referring_to_1.size(), 1);
+  ASSERT_EQ(tris_referring_to_2.size(), 2);
+  ASSERT_EQ(tris_referring_to_3.size(), 1);
+
+  // Check the referring triangles.
+  EXPECT_EQ(first(tris_referring_to_0), 0); 
+  EXPECT_EQ(second(tris_referring_to_0), 1);
+  EXPECT_EQ(first(tris_referring_to_1), 0); 
+  EXPECT_EQ(first(tris_referring_to_2), 0); 
+  EXPECT_EQ(second(tris_referring_to_2), 1);
+  EXPECT_EQ(first(tris_referring_to_3), 1);
+}
+
 // Checks the area calculations.
 GTEST_TEST(SurfaceMeshTest, TestArea) {
   const double tol = 10 * std::numeric_limits<double>::epsilon();


### PR DESCRIPTION
Adds the ability to get the set of triangles that refer to a vertex in a SurfaceMesh.

(I found myself coding this functionality into my PRs twice, and thought I should go ahead and add this feature to master).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11777)
<!-- Reviewable:end -->
