### PR TITLE
pydrake trajectory: Add more bindings for PiecewisePolynomial

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -258,11 +258,15 @@ drake_pybind_library(
 
 drake_pybind_library(
     name = "trajectories_py",
-    cc_deps = ["//bindings/pydrake:documentation_pybind"],
+    cc_deps = [
+        ":polynomial_types_pybind",
+        "//bindings/pydrake:documentation_pybind",
+    ],
     cc_srcs = ["trajectories_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
         ":module_py",
+        "//bindings/pydrake:polynomial_py",
     ],
 )
 

--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -211,6 +211,28 @@ drake_pybind_library(
 )
 
 drake_cc_library(
+    name = "polynomial_types_pybind",
+    hdrs = ["polynomial_types_pybind.h"],
+    declare_installed_headers = 0,
+    visibility = ["//visibility:public"],
+    deps = ["//:drake_shared_library"],
+)
+
+drake_pybind_library(
+    name = "polynomial_py",
+    cc_deps = [
+        ":polynomial_types_pybind",
+        "//bindings/pydrake:documentation_pybind",
+    ],
+    cc_srcs = ["polynomial_py.cc"],
+    package_info = PACKAGE_INFO,
+    py_deps = [
+        ":module_py",
+        "//bindings/pydrake/common:deprecation_py",
+    ],
+)
+
+drake_cc_library(
     name = "symbolic_types_pybind",
     hdrs = ["symbolic_types_pybind.h"],
     declare_installed_headers = 0,
@@ -251,6 +273,7 @@ PY_LIBRARIES_WITH_INSTALL = [
     ":lcm_py",
     ":math_py",
     ":perception_py",
+    ":polynomial_py",
     ":symbolic_py",
     ":trajectories_py",
     "//bindings/pydrake/attic",
@@ -423,6 +446,14 @@ drake_py_unittest(
     name = "perception_test",
     deps = [
         ":perception_py",
+    ],
+)
+
+drake_py_unittest(
+    name = "polynomial_test",
+    deps = [
+        ":polynomial_py",
+        "//bindings/pydrake/common/test_utilities:numpy_compare_py",
     ],
 )
 

--- a/bindings/pydrake/all.py
+++ b/bindings/pydrake/all.py
@@ -38,6 +38,7 @@ from .geometry import *
 from .lcm import *
 from .math import *
 from .perception import *
+from .polynomial import *
 from .symbolic import *
 from .trajectories import *
 

--- a/bindings/pydrake/common/test_utilities/BUILD.bazel
+++ b/bindings/pydrake/common/test_utilities/BUILD.bazel
@@ -41,6 +41,7 @@ drake_py_library(
     deps = [
         ":module_py",
         "//bindings/pydrake:autodiffutils_py",
+        "//bindings/pydrake:polynomial_py",
         "//bindings/pydrake:symbolic_py",
     ],
 )

--- a/bindings/pydrake/common/test_utilities/numpy_compare.py
+++ b/bindings/pydrake/common/test_utilities/numpy_compare.py
@@ -20,7 +20,7 @@ import numpy as np
 from pydrake.autodiffutils import AutoDiffXd
 from pydrake.symbolic import (
     Expression, Formula, Monomial, Polynomial, Variable)
-from pydrake.common.polynomial import Polynomial as RawPolynomial
+from pydrake.polynomial import Polynomial as RawPolynomial
 
 
 class _UnwantedEquality(AssertionError):

--- a/bindings/pydrake/polynomial_py.cc
+++ b/bindings/pydrake/polynomial_py.cc
@@ -13,9 +13,9 @@ namespace drake {
 namespace pydrake {
 
 PYBIND11_MODULE(polynomial, m) {
-  constexpr auto& doc = pydrake_doc;
+  // constexpr auto& doc = pydrake_doc;
 
-  using T = double;
+  // using T = double;
 
   {
     // TODO(eric.cousineau): Where to put this?

--- a/bindings/pydrake/polynomial_py.cc
+++ b/bindings/pydrake/polynomial_py.cc
@@ -4,21 +4,15 @@
 #include "pybind11/stl.h"
 
 #include "drake/bindings/pydrake/documentation_pybind.h"
+#include "drake/bindings/pydrake/polynomial_types_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/common/polynomial.h"
-
-PYBIND11_NUMPY_OBJECT_DTYPE(Polynomial<double>);
 
 namespace drake {
 namespace pydrake {
 
 PYBIND11_MODULE(polynomial, m) {
-  // constexpr auto& doc = pydrake_doc;
-
-  // using T = double;
-
   {
-    // TODO(eric.cousineau): Where to put this?
     using CoefficientType = double;
     using Class = Polynomial<CoefficientType>;
     constexpr auto& cls_doc = pydrake_doc.Polynomial;

--- a/bindings/pydrake/polynomial_types_pybind.h
+++ b/bindings/pydrake/polynomial_types_pybind.h
@@ -6,7 +6,7 @@
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/common/polynomial.h"
 
-// The macro `PYBIND11_NUMPY_OBJECT_DTYPE` place symbols into the namespace
+// The macro `PYBIND11_NUMPY_OBJECT_DTYPE` places symbols into the namespace
 // `pybind11::detail`, so we should not place these in `drake::pydrake`.
 
 PYBIND11_NUMPY_OBJECT_DTYPE(Polynomial<double>);

--- a/bindings/pydrake/test/polynomial_test.py
+++ b/bindings/pydrake/test/polynomial_test.py
@@ -1,0 +1,41 @@
+from __future__ import print_function
+
+import numpy as np
+import unittest
+
+from pydrake.common.test_utilities import numpy_compare
+from pydrake.polynomial import Polynomial
+
+
+class TestPolynomial(unittest.TestCase):
+    def test_constructors(self):
+        p1 = Polynomial()
+        p2 = Polynomial(5)
+        p3 = Polynomial([1, 2, 3])
+
+    def test_analysis_methods(self):
+        p = Polynomial([1, 2, 3])
+        self.assertEqual(p.GetNumberOfCoefficients(), 3)
+        self.assertEqual(p.GetDegree(), 2)
+        self.assertFalse(p.IsAffine())
+        np.testing.assert_equal(p.GetCoefficients(), np.array([1, 2, 3]))
+        p_d = p.Derivative(derivative_order=1)
+        self.assertEqual(p_d.GetDegree(), 1)
+        p_i = p.Integral(integration_constant=0)
+        self.assertEqual(p_i.GetDegree(), 3)
+        self.assertTrue(p.IsApprox(p, 1e-14))
+
+    def test_arithmetic(self):
+        p = Polynomial([0, 1])
+        np.testing.assert_equal((-p).GetCoefficients(), np.array([0, -1]))
+        np.testing.assert_equal((p+p).GetCoefficients(), np.array([0, 2]))
+        np.testing.assert_equal((p+5).GetCoefficients(), np.array([5, 1]))
+        np.testing.assert_equal((5+p).GetCoefficients(), np.array([5, 1]))
+        np.testing.assert_equal((p-p).GetCoefficients(), np.array([0]))
+        np.testing.assert_equal((p-5).GetCoefficients(), np.array([-5, 1]))
+        np.testing.assert_equal((5-p).GetCoefficients(), np.array([5, -1]))
+        np.testing.assert_equal((p*p).GetCoefficients(), np.array([0, 0, 1]))
+        np.testing.assert_equal((p*5).GetCoefficients(), np.array([0, 5]))
+        np.testing.assert_equal((5*p).GetCoefficients(), np.array([0, 5]))
+        np.testing.assert_equal((p/5).GetCoefficients(), np.array([0, 0.2]))
+        self.assertTrue(p == p)

--- a/bindings/pydrake/test/trajectories_test.py
+++ b/bindings/pydrake/test/trajectories_test.py
@@ -22,22 +22,28 @@ class TestTrajectories(unittest.TestCase):
     def test_zero_order_hold(self):
         x = np.array([[1., 2.], [3., 4.], [5., 6.]]).transpose()
         pp = PiecewisePolynomial.ZeroOrderHold([0., 1., 2.], x)
-        pp_d = pp.derivative(1)
+        pp_d = pp.derivative(derivative_order=1)
         np.testing.assert_equal(np.array([[1.], [2.]]), pp.value(.5))
         np.testing.assert_equal(pp_d.value(.5), np.array([[0.], [0.]]))
         self.assertEqual(pp.get_number_of_segments(), 2)
         self.assertEqual(pp.start_time(), 0.)
         self.assertEqual(pp.end_time(), 2.)
-        self.assertEqual(pp.start_time(0), 0.)
-        self.assertEqual(pp.end_time(0), 1.)
-        self.assertEqual(pp.duration(0), 1.)
-        self.assertEqual(pp.get_segment_index(1.5), 1)
+        self.assertEqual(pp.start_time(segment_index=0), 0.)
+        self.assertEqual(pp.end_time(segment_index=0), 1.)
+        self.assertEqual(pp.duration(segment_index=0), 1.)
+        self.assertTrue(pp.is_time_in_range(t=1.5))
+        self.assertEqual(pp.get_segment_index(t=1.5), 1)
         self.assertEqual(pp.get_segment_times(), [0., 1., 2.])
 
     def test_first_order_hold(self):
         x = np.array([[1., 2.], [3., 4.], [5., 6.]]).transpose()
         pp = PiecewisePolynomial.FirstOrderHold([0., 1., 2.], x)
         np.testing.assert_equal(np.array([[2.], [3.]]), pp.value(.5))
+
+    def test_pchip(self):
+        t = [0., 1., 2.]
+        x = np.array([[0, 1, 1]])
+        pp = PiecewisePolynomial.Pchip(t, x, zero_end_point_derivatives=False)
 
     def test_cubic(self):
         t = [0., 1., 2.]

--- a/bindings/pydrake/test/trajectories_test.py
+++ b/bindings/pydrake/test/trajectories_test.py
@@ -54,12 +54,20 @@ class TestTrajectories(unittest.TestCase):
         self.assertEqual(pp.cols(), 1)
         np.testing.assert_equal(x, pp.value(11.))
 
+    def test_piecewise_polynomial_vector_constructor(self):
+        p1 = Polynomial(1)
+        p2 = Polynomial(2)
+        pp = PiecewisePolynomial([p1, p2], [0, 1, 2])
+
     def test_zero_order_hold(self):
         x = np.array([[1., 2.], [3., 4.], [5., 6.]]).transpose()
         pp = PiecewisePolynomial.ZeroOrderHold([0., 1., 2.], x)
         pp_d = pp.derivative(derivative_order=1)
         np.testing.assert_equal(np.array([[1.], [2.]]), pp.value(.5))
         np.testing.assert_equal(pp_d.value(.5), np.array([[0.], [0.]]))
+        p = pp.getPolynomial(segment_index=0, row=1, col=0)
+        np.testing.assert_equal(p.GetCoefficients(), np.array([2]))
+        self.assertEqual(pp.getSegmentPolynomialDegree(segment_index=1), 0)
         self.assertEqual(pp.get_number_of_segments(), 2)
         self.assertEqual(pp.start_time(), 0.)
         self.assertEqual(pp.end_time(), 2.)
@@ -101,3 +109,11 @@ class TestTrajectories(unittest.TestCase):
         pp_sub.shiftRight(10.)
         self.assertEqual(pp_sub.start_time(), 11.)
         self.assertEqual(pp_sub.end_time(), 12.)
+
+    def test_compare_and_concatenate(self):
+        x = np.array([[10.], [20.], [30.]]).transpose()
+        pp1 = PiecewisePolynomial.FirstOrderHold([0., 1., 2.], x)
+        pp2 = PiecewisePolynomial.FirstOrderHold([2., 3., 4.], x)
+        self.assertTrue(pp1.isApprox(other=pp1, tol=1e-14))
+        pp1.ConcatenateInTime(other=pp2)
+        self.assertEqual(pp1.end_time(), 4.)

--- a/bindings/pydrake/test/trajectories_test.py
+++ b/bindings/pydrake/test/trajectories_test.py
@@ -10,40 +10,6 @@ from pydrake.trajectories import (
 )
 
 
-class TestPolynomial(unittest.TestCase):
-    def test_constructors(self):
-        p1 = Polynomial()
-        p2 = Polynomial(5)
-        p3 = Polynomial([1, 2, 3])
-
-    def test_analysis_methods(self):
-        p = Polynomial([1, 2, 3])
-        self.assertEqual(p.GetNumberOfCoefficients(), 3)
-        self.assertEqual(p.GetDegree(), 2)
-        self.assertFalse(p.IsAffine())
-        np.testing.assert_equal(p.GetCoefficients(), np.array([1, 2, 3]))
-        p_d = p.Derivative(derivative_order=1)
-        self.assertEqual(p_d.GetDegree(), 1)
-        p_i = p.Integral(integration_constant=0)
-        self.assertEqual(p_i.GetDegree(), 3)
-        self.assertTrue(p.IsApprox(p, 1e-14))
-
-    def test_arithmetic(self):
-        p = Polynomial([0, 1])
-        np.testing.assert_equal((-p).GetCoefficients(), np.array([0, -1]))
-        np.testing.assert_equal((p+p).GetCoefficients(), np.array([0, 2]))
-        np.testing.assert_equal((p+5).GetCoefficients(), np.array([5, 1]))
-        np.testing.assert_equal((5+p).GetCoefficients(), np.array([5, 1]))
-        np.testing.assert_equal((p-p).GetCoefficients(), np.array([0]))
-        np.testing.assert_equal((p-5).GetCoefficients(), np.array([-5, 1]))
-        np.testing.assert_equal((5-p).GetCoefficients(), np.array([5, -1]))
-        np.testing.assert_equal((p*p).GetCoefficients(), np.array([0, 0, 1]))
-        np.testing.assert_equal((p*5).GetCoefficients(), np.array([0, 5]))
-        np.testing.assert_equal((5*p).GetCoefficients(), np.array([0, 5]))
-        np.testing.assert_equal((p/5).GetCoefficients(), np.array([0, 0.2]))
-        self.assertTrue(p == p)
-
-
 class TestTrajectories(unittest.TestCase):
     def test_piecewise_polynomial_empty_constructor(self):
         pp = PiecewisePolynomial()

--- a/bindings/pydrake/test/trajectories_test.py
+++ b/bindings/pydrake/test/trajectories_test.py
@@ -4,8 +4,43 @@ import numpy as np
 import unittest
 
 from pydrake.trajectories import (
-    PiecewisePolynomial
+    PiecewisePolynomial,
+    Polynomial,
 )
+
+
+class TestPolynomial(unittest.TestCase):
+    def test_constructors(self):
+        p1 = Polynomial()
+        p2 = Polynomial(5)
+        p3 = Polynomial([1, 2, 3])
+
+    def test_analysis_methods(self):
+        p = Polynomial([1, 2, 3])
+        self.assertEqual(p.GetNumberOfCoefficients(), 3)
+        self.assertEqual(p.GetDegree(), 2)
+        self.assertFalse(p.IsAffine())
+        np.testing.assert_equal(p.GetCoefficients(), np.array([1, 2, 3]))
+        p_d = p.Derivative(derivative_order=1)
+        self.assertEqual(p_d.GetDegree(), 1)
+        p_i = p.Integral(integration_constant=0)
+        self.assertEqual(p_i.GetDegree(), 3)
+        self.assertTrue(p.IsApprox(p, 1e-14))
+
+    def test_arithmetic(self):
+        p = Polynomial([0, 1])
+        np.testing.assert_equal((-p).GetCoefficients(), np.array([0, -1]))
+        np.testing.assert_equal((p+p).GetCoefficients(), np.array([0, 2]))
+        np.testing.assert_equal((p+5).GetCoefficients(), np.array([5, 1]))
+        np.testing.assert_equal((5+p).GetCoefficients(), np.array([5, 1]))
+        np.testing.assert_equal((p-p).GetCoefficients(), np.array([0]))
+        np.testing.assert_equal((p-5).GetCoefficients(), np.array([-5, 1]))
+        np.testing.assert_equal((5-p).GetCoefficients(), np.array([5, -1]))
+        np.testing.assert_equal((p*p).GetCoefficients(), np.array([0, 0, 1]))
+        np.testing.assert_equal((p*5).GetCoefficients(), np.array([0, 5]))
+        np.testing.assert_equal((5*p).GetCoefficients(), np.array([0, 5]))
+        np.testing.assert_equal((p/5).GetCoefficients(), np.array([0, 0.2]))
+        self.assertTrue(p == p)
 
 
 class TestTrajectories(unittest.TestCase):

--- a/bindings/pydrake/test/trajectories_test.py
+++ b/bindings/pydrake/test/trajectories_test.py
@@ -25,7 +25,8 @@ class TestTrajectories(unittest.TestCase):
         pm1 = np.array([[Polynomial(1), Polynomial(2)]])
         pm2 = np.array([[Polynomial(2), Polynomial(0)]])
         pp = PiecewisePolynomial([pm1, pm2], [0, 1, 2])
-        np.testing.assert_equal(pp.getPolynomialMatrix(segment_index=0), pm1)
+        numpy_compare.assert_equal(pp.getPolynomialMatrix(segment_index=0),
+                                   pm1)
         pm3 = np.array([[Polynomial(5), Polynomial(10)]])
         pp.setPolynomialMatrixBlock(replacement=pm3, segment_index=1)
 

--- a/bindings/pydrake/test/trajectories_test.py
+++ b/bindings/pydrake/test/trajectories_test.py
@@ -21,6 +21,14 @@ class TestTrajectories(unittest.TestCase):
         self.assertEqual(pp.cols(), 1)
         np.testing.assert_equal(x, pp.value(11.))
 
+    def test_piecewise_polynomial_matrix_constructor(self):
+        pm1 = np.array([[Polynomial(1), Polynomial(2)]])
+        pm2 = np.array([[Polynomial(2), Polynomial(0)]])
+        pp = PiecewisePolynomial([pm1, pm2], [0, 1, 2])
+        np.testing.assert_equal(pp.getPolynomialMatrix(segment_index=0), pm1)
+        pm3 = np.array([[Polynomial(5), Polynomial(10)]])
+        pp.setPolynomialMatrixBlock(replacement=pm3, segment_index=1)
+
     def test_piecewise_polynomial_vector_constructor(self):
         p1 = Polynomial(1)
         p2 = Polynomial(2)
@@ -44,8 +52,6 @@ class TestTrajectories(unittest.TestCase):
         self.assertTrue(pp.is_time_in_range(t=1.5))
         self.assertEqual(pp.get_segment_index(t=1.5), 1)
         self.assertEqual(pp.get_segment_times(), [0., 1., 2.])
-        # tmp
-        print(pp.getPolynomialMatrix(0))
 
     def test_first_order_hold(self):
         x = np.array([[1., 2.], [3., 4.], [5., 6.]]).transpose()

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -1,9 +1,11 @@
 #include "pybind11/eigen.h"
+#include "pybind11/operators.h"
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/common/polynomial.h"
 #include "drake/common/trajectories/piecewise_polynomial.h"
 #include "drake/common/trajectories/trajectory.h"
 
@@ -11,6 +13,43 @@ namespace drake {
 namespace pydrake {
 
 PYBIND11_MODULE(trajectories, m) {
+  {
+    using CoefficientType = double;
+    using Class = Polynomial<CoefficientType>;
+    constexpr auto& cls_doc = pydrake_doc.Polynomial;
+    py::class_<Class>(m, "Polynomial", cls_doc.doc)
+        .def(py::init<>(), cls_doc.ctor.doc_0args)
+        .def(py::init<const CoefficientType&>(), cls_doc.ctor.doc_1args_scalar)
+        .def(py::init<const Eigen::Ref<const Eigen::VectorXd>&>(),
+            cls_doc.ctor.doc_1args_constEigenMatrixBase)
+        .def("GetNumberOfCoefficients", &Class::GetNumberOfCoefficients,
+            cls_doc.GetNumberOfCoefficients.doc)
+        .def("GetDegree", &Class::GetDegree, cls_doc.GetDegree.doc)
+        .def("IsAffine", &Class::IsAffine, cls_doc.IsAffine.doc)
+        .def("GetCoefficients", &Class::GetCoefficients,
+            cls_doc.GetCoefficients.doc)
+        .def("Derivative", &Class::Derivative, py::arg("derivative_order") = 1,
+            cls_doc.Derivative.doc)
+        .def("Integral", &Class::Integral,
+            py::arg("integration_constant") = 0.0, cls_doc.Integral.doc)
+        .def("IsApprox", &Class::IsApprox, py::arg("other"), py::arg("tol"),
+            cls_doc.IsApprox.doc)
+        // Arithmetic
+        .def(-py::self)
+        .def(py::self + py::self)
+        .def(py::self + double())
+        .def(double() + py::self)
+        .def(py::self - py::self)
+        .def(py::self - double())
+        .def(double() - py::self)
+        .def(py::self * py::self)
+        .def(py::self * double())
+        .def(double() * py::self)
+        .def(py::self / double())
+        // Logical comparison
+        .def(py::self == py::self);
+  }
+
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
   using namespace drake::trajectories;
   constexpr auto& doc = pydrake_doc.drake.trajectories;

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -21,44 +21,6 @@ PYBIND11_MODULE(trajectories, m) {
 
   using T = double;
 
-  {
-    // TODO(eric.cousineau): Where to put this?
-    using CoefficientType = double;
-    using Class = Polynomial<CoefficientType>;
-    constexpr auto& cls_doc = pydrake_doc.Polynomial;
-    py::class_<Class>(m, "Polynomial", cls_doc.doc)
-        .def(py::init<>(), cls_doc.ctor.doc_0args)
-        .def(py::init<const CoefficientType&>(), cls_doc.ctor.doc_1args_scalar)
-        .def(py::init<const Eigen::Ref<const Eigen::VectorXd>&>(),
-            cls_doc.ctor.doc_1args_constEigenMatrixBase)
-        .def("GetNumberOfCoefficients", &Class::GetNumberOfCoefficients,
-            cls_doc.GetNumberOfCoefficients.doc)
-        .def("GetDegree", &Class::GetDegree, cls_doc.GetDegree.doc)
-        .def("IsAffine", &Class::IsAffine, cls_doc.IsAffine.doc)
-        .def("GetCoefficients", &Class::GetCoefficients,
-            cls_doc.GetCoefficients.doc)
-        .def("Derivative", &Class::Derivative, py::arg("derivative_order") = 1,
-            cls_doc.Derivative.doc)
-        .def("Integral", &Class::Integral,
-            py::arg("integration_constant") = 0.0, cls_doc.Integral.doc)
-        .def("IsApprox", &Class::IsApprox, py::arg("other"), py::arg("tol"),
-            cls_doc.IsApprox.doc)
-        // Arithmetic
-        .def(-py::self)
-        .def(py::self + py::self)
-        .def(py::self + double())
-        .def(double() + py::self)
-        .def(py::self - py::self)
-        .def(py::self - double())
-        .def(double() - py::self)
-        .def(py::self * py::self)
-        .def(py::self * double())
-        .def(double() * py::self)
-        .def(py::self / double())
-        // Logical comparison
-        .def(py::self == py::self);
-  }
-
   py::class_<Trajectory<T>>(m, "Trajectory", doc.Trajectory.doc);
 
   py::class_<PiecewiseTrajectory<T>, Trajectory<T>>(
@@ -94,11 +56,11 @@ PYBIND11_MODULE(trajectories, m) {
       .def(py::init<>(), doc.PiecewisePolynomial.ctor.doc_0args)
       .def(py::init<const Eigen::Ref<const MatrixX<T>>&>(),
           doc.PiecewisePolynomial.ctor.doc_1args)
-      // .def(PiecewisePolynomial(std::vector<PolynomialMatrix> const& polynomials,
-      //                          std::vector<double> const& breaks))
-      // Documentation for this method is not building
+      // Documentation for these methods are not building
+      .def(py::init<std::vector<MatrixX<Polynomial<T>>> const&,
+          std::vector<double> const&>())
       .def(py::init<std::vector<Polynomial<T>> const&,
-              std::vector<double> const&>())
+          std::vector<double> const&>())
       .def_static("ZeroOrderHold",
           py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
               const Eigen::Ref<const MatrixX<T>>&>(

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -91,6 +91,11 @@ PYBIND11_MODULE(trajectories, m) {
       .def(py::init<>(), doc.PiecewisePolynomial.ctor.doc_0args)
       .def(py::init<const Eigen::Ref<const MatrixX<T>>&>(),
           doc.PiecewisePolynomial.ctor.doc_1args)
+      // .def(PiecewisePolynomial(std::vector<PolynomialMatrix> const& polynomials,
+      //                          std::vector<double> const& breaks))
+      // Documentation for this method is not building
+      .def(py::init<std::vector<Polynomial<T>> const&,
+              std::vector<double> const&>())
       .def_static("ZeroOrderHold",
           py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
               const Eigen::Ref<const MatrixX<T>>&>(
@@ -137,15 +142,34 @@ PYBIND11_MODULE(trajectories, m) {
       .def("derivative", &PiecewisePolynomial<T>::derivative,
           py::arg("derivative_order") = 1,
           doc.PiecewisePolynomial.derivative.doc)
+      // .def("getPolynomialMatrix", &PiecewisePolynomial<T>::getPolynomialMatrix,
+      //     py::arg("segment_index"),
+      //     doc.PiecewisePolynomial.getPolynomialMatrix.doc)
+      .def("getPolynomial", &PiecewisePolynomial<T>::getPolynomial,
+          py::arg("segment_index"), py::arg("row") = 0, py::arg("col") = 0,
+          doc.PiecewisePolynomial.getPolynomial.doc)
+      .def("getSegmentPolynomialDegree",
+          &PiecewisePolynomial<T>::getSegmentPolynomialDegree,
+          py::arg("segment_index"), py::arg("row") = 0, py::arg("col") = 0,
+          doc.PiecewisePolynomial.getSegmentPolynomialDegree.doc)
       .def("rows", &PiecewisePolynomial<T>::rows,
           doc.PiecewisePolynomial.rows.doc)
       .def("cols", &PiecewisePolynomial<T>::cols,
           doc.PiecewisePolynomial.cols.doc)
+      .def("isApprox", &PiecewisePolynomial<T>::isApprox, py::arg("other"),
+          py::arg("tol"), doc.PiecewisePolynomial.isApprox.doc)
+      .def("ConcatenateInTime", &PiecewisePolynomial<T>::ConcatenateInTime,
+          py::arg("other"), doc.PiecewisePolynomial.ConcatenateInTime.doc)
       .def("slice", &PiecewisePolynomial<T>::slice,
           py::arg("start_segment_index"), py::arg("num_segments"),
           doc.PiecewisePolynomial.slice.doc)
       .def("shiftRight", &PiecewisePolynomial<T>::shiftRight, py::arg("offset"),
           doc.PiecewisePolynomial.shiftRight.doc);
+      // .def("setPolynomialMatrixBlock",
+      //     &PiecewisePolynomial<T>::setPolynomialMatrixBlock,
+      //     py::arg("replacement"), py::arg("segment_index"),
+      //     py::arg("row_start") = 0, py::arg("col_start") = 0,
+      //     doc.PiecewisePolynomial.setPolynomialMatrixBlock.doc);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -27,21 +27,23 @@ PYBIND11_MODULE(trajectories, m) {
       .def("start_time",
           overload_cast_explicit<double, int>(
               &PiecewiseTrajectory<T>::start_time),
-          doc.PiecewiseTrajectory.start_time.doc)
+          py::arg("segment_index"), doc.PiecewiseTrajectory.start_time.doc)
       .def("end_time",
           overload_cast_explicit<double, int>(
               &PiecewiseTrajectory<T>::end_time),
-          doc.PiecewiseTrajectory.end_time.doc)
+          py::arg("segment_index"), doc.PiecewiseTrajectory.end_time.doc)
       .def("duration", &PiecewiseTrajectory<T>::duration,
-          doc.PiecewiseTrajectory.duration.doc)
+          py::arg("segment_index"), doc.PiecewiseTrajectory.duration.doc)
       .def("start_time",
           overload_cast_explicit<double>(&PiecewiseTrajectory<T>::start_time),
           doc.PiecewiseTrajectory.start_time.doc)
       .def("end_time",
           overload_cast_explicit<double>(&PiecewiseTrajectory<T>::end_time),
           doc.PiecewiseTrajectory.end_time.doc)
+      .def("is_time_in_range", &PiecewiseTrajectory<T>::is_time_in_range,
+          py::arg("t"), doc.PiecewiseTrajectory.is_time_in_range.doc)
       .def("get_segment_index", &PiecewiseTrajectory<T>::get_segment_index,
-          doc.PiecewiseTrajectory.get_segment_index.doc)
+          py::arg("t"), doc.PiecewiseTrajectory.get_segment_index.doc)
       .def("get_segment_times", &PiecewiseTrajectory<T>::get_segment_times,
           doc.PiecewiseTrajectory.get_segment_times.doc);
 
@@ -64,6 +66,8 @@ PYBIND11_MODULE(trajectories, m) {
           py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
               const Eigen::Ref<const MatrixX<T>>&, bool>(
               &PiecewisePolynomial<T>::Pchip),
+          py::arg("breaks"), py::arg("knots"),
+          py::arg("zero_end_point_derivatives") = false,
           doc.PiecewisePolynomial.Pchip.doc)
       .def_static("Cubic",
           py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
@@ -89,9 +93,10 @@ PYBIND11_MODULE(trajectories, m) {
           py::arg("breaks"), py::arg("knots"), py::arg("periodic_end"),
           doc.PiecewisePolynomial.Cubic
               .doc_3args_breaks_knots_periodic_end_condition)
-      .def("value", &PiecewisePolynomial<T>::value,
+      .def("value", &PiecewisePolynomial<T>::value, py::arg("t"),
           doc.PiecewisePolynomial.value.doc)
       .def("derivative", &PiecewisePolynomial<T>::derivative,
+          py::arg("derivative_order") = 1,
           doc.PiecewisePolynomial.derivative.doc)
       .def("rows", &PiecewisePolynomial<T>::rows,
           doc.PiecewisePolynomial.rows.doc)

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -4,12 +4,11 @@
 #include "pybind11/stl.h"
 
 #include "drake/bindings/pydrake/documentation_pybind.h"
+#include "drake/bindings/pydrake/polynomial_types_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/common/polynomial.h"
 #include "drake/common/trajectories/piecewise_polynomial.h"
 #include "drake/common/trajectories/trajectory.h"
-
-PYBIND11_NUMPY_OBJECT_DTYPE(Polynomial<double>);
 
 namespace drake {
 namespace pydrake {
@@ -18,6 +17,7 @@ PYBIND11_MODULE(trajectories, m) {
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
   using namespace drake::trajectories;
   constexpr auto& doc = pydrake_doc.drake.trajectories;
+  py::module::import("pydrake.polynomial");
 
   using T = double;
 
@@ -56,7 +56,7 @@ PYBIND11_MODULE(trajectories, m) {
       .def(py::init<>(), doc.PiecewisePolynomial.ctor.doc_0args)
       .def(py::init<const Eigen::Ref<const MatrixX<T>>&>(),
           doc.PiecewisePolynomial.ctor.doc_1args)
-      // Documentation for these methods are not building
+      // TODO(eric.cousineau): Add docstrings once #11800 is resolved.
       .def(py::init<std::vector<MatrixX<Polynomial<T>>> const&,
           std::vector<double> const&>())
       .def(py::init<std::vector<Polynomial<T>> const&,

--- a/doc/code_style_tools.rst
+++ b/doc/code_style_tools.rst
@@ -59,7 +59,7 @@ install Drake's required version of ``clang-format``, depending on the platform
 To run clang-format::
 
     # For development on macOS:
-    clang-format -i -style=file [file name]
+    /usr/local/opt/llvm@6/bin/clang-format -i -style=file [file name]
 
     # For development on Ubuntu:
     clang-format-6.0 -i -style=file [file name]


### PR DESCRIPTION
Also binds `drake::common::Polynomial` and cleans up previous bindings/tests for PiecewisePolynomial.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11783)
<!-- Reviewable:end -->
