### PR TITLE
geometry: Remove unnecessary death tests

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -362,7 +362,11 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "identifier_test",
-    deps = [":identifier"],
+    deps = [
+        ":identifier",
+        "//common:unused",
+        "//common/test_utilities:expect_throws_message",
+    ],
 )
 
 drake_cc_googletest(

--- a/geometry/identifier.h
+++ b/geometry/identifier.h
@@ -5,8 +5,8 @@
 #include <functional>
 #include <string>
 
-#include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_throw.h"
 #include "drake/common/never_destroyed.h"
 
 namespace drake {
@@ -62,7 +62,7 @@ namespace geometry {
  facilitate use with STL containers that require default constructors. Using an
  invalid identifier in any operation is considered an error. In Debug build,
  attempts to compare, get the value of, hash, or write an invalid identifier to
- a stream will cause program failure.
+ a stream will throw an exception.
 
  Functions that query for identifiers should not return invalid identifiers. We
  prefer the practice of returning std::optional<Identifier> instead.
@@ -146,8 +146,11 @@ class Identifier {
    considered invalid for invalid ids and is strictly enforced in Debug builds.
    */
   int64_t get_value() const {
-    DRAKE_ASSERT(is_valid());
-    return value_; }
+    if (kDrakeAssertIsArmed) {
+      DRAKE_THROW_UNLESS(this->is_valid());
+    }
+    return value_;
+  }
 
   /** Reports if the id is valid. */
   bool is_valid() const { return value_ > 0; }
@@ -156,24 +159,21 @@ class Identifier {
    is considered invalid for invalid ids and is strictly enforced in Debug
    builds. */
   bool operator==(Identifier other) const {
-    DRAKE_ASSERT(is_valid() && other.is_valid());
-    return value_ == other.value_;
+    return this->get_value() == other.get_value();
   }
 
   /** Compares one identifier with another of the same type for inequality. This
    is considered invalid for invalid ids and is strictly enforced in Debug
    builds. */
   bool operator!=(Identifier other) const {
-    DRAKE_ASSERT(is_valid() && other.is_valid());
-    return value_ != other.value_ && is_valid() && other.is_valid();
+    return this->get_value() != other.get_value();
   }
 
   /** Compare two identifiers in order to define a total ordering among
    identifiers. This makes identifiers compatible with data structures which
    require total ordering (e.g., std::set).  */
   bool operator<(Identifier other) const {
-    DRAKE_ASSERT(is_valid() && other.is_valid());
-    return value_ < other.value_;
+    return this->get_value() < other.get_value();
   }
 
   /** Generates a new identifier for this id type. This new identifier will be
@@ -194,7 +194,7 @@ class Identifier {
   explicit Identifier(int64_t val) : value_(val) {}
 
   // The underlying value.
-  int64_t value_;
+  int64_t value_{};
 };
 
 /** Streaming output operator.   This is considered invalid for invalid ids and

--- a/geometry/proximity/mesh_intersection.h
+++ b/geometry/proximity/mesh_intersection.h
@@ -69,8 +69,8 @@ class HalfSpace {
     // evaluated magnitude is within epsilon of one. There may be some
     // unconsidered value that disproves this -- at that point, adapt the
     // tolerance here and add it to the unit test.
-    DRAKE_DEMAND(abs(nhat_F_.norm() - 1.0) <=
-                 std::numeric_limits<double>::epsilon());
+    DRAKE_THROW_UNLESS(abs(nhat_F_.norm() - 1.0) <=
+                       std::numeric_limits<double>::epsilon());
   }
 
   /** Computes the signed distance to the point Q (measured and expressed in

--- a/geometry/proximity/test/mesh_intersection_test.cc
+++ b/geometry/proximity/test/mesh_intersection_test.cc
@@ -47,10 +47,10 @@ GTEST_TEST(HalfSpace, Construction) {
 }
 
 // Confirms that a plane normal that is *insufficiently* unit length aborts.
-GTEST_TEST(HalfSpaceDeathTest, Unnormalized) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+GTEST_TEST(HalfSpaceTest, Unnormalized) {
   const double kDelta = 4 * std::sqrt(std::numeric_limits<double>::epsilon());
-  ASSERT_DEATH(HalfSpace<double>(Vector3d{1, kDelta, kDelta}, 0.25), "");
+  EXPECT_THROW(HalfSpace<double>(Vector3d{1, kDelta, kDelta}, 0.25),
+               std::exception);
 }
 
 // TODO(SeanCurtis-TRI): Robustly confirm that epsilon of 1e-14 is correct for

--- a/geometry/test/identifier_test.cc
+++ b/geometry/test/identifier_test.cc
@@ -8,10 +8,12 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/common/unused.h"
+
 namespace drake {
 namespace geometry {
 namespace {
-
 
 // Creates various dummy index types to test.
 using std::set;
@@ -192,67 +194,51 @@ TEST_F(IdentifierTests, Convertible) {
                 "Identifiers should not be convertible from ints");
 }
 
-// Suite of tests to catch the debug-build assertions.
-class IdentifierDeathTests : public IdentifierTests {};
-
 // Attempting to acquire the value is an error.
-TEST_F(IdentifierDeathTests, InvalidGetValueCall) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+TEST_F(IdentifierTests, InvalidGetValueCall) {
   if (kDrakeAssertIsDisarmed) { return; }
   AId invalid;
-  int64_t value = -1;
-  ASSERT_DEATH(
-      {value = invalid.get_value();},
-      "abort: .*identifier.h:.+ in get_value.+"
-          "'is_valid\\(\\)' failed");
-  // This lets gcc thinks the variable is used.
-  EXPECT_EQ(value, -1);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      unused(invalid.get_value()),
+      std::exception, ".*is_valid.*failed.*");
 }
 
 // Comparison of invalid ids is an error.
-TEST_F(IdentifierDeathTests, InvalidEqualityCompare) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+TEST_F(IdentifierTests, InvalidEqualityCompare) {
   if (kDrakeAssertIsDisarmed) { return; }
   AId invalid;
-  bool result = true;
-  EXPECT_DEATH(
-      {result = invalid == a1_;},
-      "abort: .*identifier.h:.+ in operator==.+"
-          "'is_valid\\(\\) && other.is_valid\\(\\)' failed");
-  // This lets gcc thinks the variable is used.
-  EXPECT_EQ(result, true);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      unused(invalid == a1_),
+      std::exception, ".*is_valid.*failed.*");
 }
 
 // Comparison of invalid ids is an error.
-TEST_F(IdentifierDeathTests, InvalidInequalityCompare) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+TEST_F(IdentifierTests, InvalidInequalityCompare) {
   if (kDrakeAssertIsDisarmed) { return; }
   AId invalid;
-  bool result = true;
-  EXPECT_DEATH(
-      {result = invalid != a1_;},
-      "abort:.*identifier.h:.+ in operator!=.+"
-          "'is_valid\\(\\) && other.is_valid\\(\\)' failed");
-  // This lets gcc thinks the variable is used.
-  EXPECT_EQ(result, true);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      unused(invalid != a1_),
+      std::exception, ".*is_valid.*failed.*");
 }
 
 // Hashing an invalid id is an error.
-TEST_F(IdentifierDeathTests, InvalidHash) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+TEST_F(IdentifierTests, InvalidHash) {
   if (kDrakeAssertIsDisarmed) { return; }
   std::unordered_set<AId> ids;
   AId invalid;
-  ASSERT_DEATH({ids.insert(invalid);}, "");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      unused(ids.insert(invalid)),
+      std::exception, ".*is_valid.*failed.*");
 }
 
 // Streaming an invalid id is an error.
-TEST_F(IdentifierDeathTests, InvalidStream) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+TEST_F(IdentifierTests, InvalidStream) {
   if (kDrakeAssertIsDisarmed) { return; }
   AId invalid;
   std::stringstream ss;
-  ASSERT_DEATH({ss << invalid;}, "");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      unused(ss << invalid),
+      std::exception, ".*is_valid.*failed.*");
 }
 
 }  // namespace


### PR DESCRIPTION
Testing assertions is complicated, and by convention we tend to prefer exceptions, instead.  These two tests are the sole remaining examples of places where death tests were used in application code. (Beyond these two, there are still two other death tests remaining on master -- for drake_assert and limit_malloc, which have no choice but to be death tests).

This also factors the check into a single place.  In my experience with this error, knowing whether `operator==` vs `operator!=` was used on an unset identifier is not helpful -- I always needs a few frames higher up the stack instead anyway, so we can rid ourselves of the operator-specific checks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11789)
<!-- Reviewable:end -->
