### PR TITLE
Shallow clone snopt git repo when branch or tag is specified

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ endif()
 
 # The version passed to find_package(Bazel) should match the
 # minimum_bazel_version value in the call to versions.check() in WORKSPACE.
-set(MINIMUM_BAZEL_VERSION 0.25)
+set(MINIMUM_BAZEL_VERSION 0.28)
 find_package(Bazel ${MINIMUM_BAZEL_VERSION} MODULE REQUIRED)
 
 get_filename_component(C_COMPILER_REALPATH "${CMAKE_C_COMPILER}" REALPATH)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,4 +25,4 @@ load("@bazel_skylib//:lib.bzl", "versions")
 # This needs to be in WORKSPACE or a repository rule for native.bazel_version
 # to actually be defined. The minimum_bazel_version value should match the
 # version passed to the find_package(Bazel) call in the root CMakeLists.txt.
-versions.check(minimum_bazel_version = "0.25")
+versions.check(minimum_bazel_version = "0.28")

--- a/tools/workspace/snopt/repository.bzl
+++ b/tools/workspace/snopt/repository.bzl
@@ -1,5 +1,41 @@
 # -*- python -*-
 
+"""
+Either extracts an gzipped tar archive containing SNOPT source code located at
+SNOPT_PATH or if SNOPT_PATH is "git", clones a remote git repository
+containing SNOPT source code, checks out the specified branch, commit, or tag
+and makes the targets available for binding.
+
+If either branch or tag are provided, then the rule will determine and return
+a dict containing the values of commit and shallow_since that may be
+substituted to provide a reproducible version of this rule.
+
+Arguments:
+    name: A unique name for this rule.
+    remote: Location of the remote git repository.
+    commit: Commit in the remote git repository to be checked out. At most one
+        of branch, commit, or tag must be provided.
+    shallow_since: Optional date, not after the specified commit. Not allowed
+        if a branch or tag is specified. Provide a unix timestamp
+        corresponding to the date of commit to avoid generating a debug
+        message.
+    tag: Tag in the remote git repository to be checked out. At most one of
+        branch, commit, or tag must be provided.
+    branch: Branch in the remote git repository to be checked out. At most one
+        of branch, commit, or tag must be provided.
+    use_drake_build_rules: When obtaining SNOPT via git, controls whether or
+        not Drake's BUILD file should supplant the file(s) in git.
+"""
+
+load(
+    "@bazel_tools//tools/build_defs/repo:utils.bzl",
+    "patch",
+    "update_attrs",
+)
+load(
+    "@bazel_tools//tools/build_defs/repo:git_worker.bzl",
+    "git_repo",
+)
 load(
     "@drake//tools/workspace:os.bzl",
     "determine_os",
@@ -10,43 +46,40 @@ load(
     "execute_or_fail",
 )
 
-def _execute(repo_ctx, mnemonic, *command):
-    # Run the command, with fail() a non-zero returncode.
-    result = repo_ctx.execute(*command)
-    if result.return_code:
-        fail("Repository rule @{} error {} during {} operation: {}".format(
-            repo_ctx.name,
-            result.return_code,
-            mnemonic,
-            repr(result.stdout + result.stderr),
-        ))
+def snopt_repository(
+        name,
+        remote = "git@github.com:RobotLocomotion/snopt.git",
+        commit = None,
+        shallow_since = None,
+        tag = None,
+        branch = None,
+        use_drake_build_rules = True):
+    if not branch and not commit and not tag:
+        commit = "0254e961cb8c60193b0862a0428fd6a42bfb5243"
+        shallow_since = "1546539374 -0500"
 
-def _run_git(repo_ctx, *args):
-    # Runs the git operation named in *args.  We use "--git-dir" to prevent git
-    # from looking in parent directories to find the repository.  We only ever
-    # want it to look where we've told it.
-    _execute(repo_ctx, "git", ["git", "--git-dir=.git"] + list(args))
+    _snopt_repository(
+        name = name,
+        remote = remote,
+        commit = commit,
+        shallow_since = shallow_since,
+        tag = tag,
+        branch = branch,
+        use_drake_build_rules = use_drake_build_rules,
+    )
 
-def _git_clone(
-        repo_ctx,
-        remote = None,
-        commit = None):
-    # Clones a git repository named by the given remote and reset it to the
-    # given commit.
-    #
-    # The clone is placed into "." (which is the workspace being populated by
-    # whatever repository_rule calls this function).  This function assumes
-    # that "." is empty, which that's already been established by Bazel before
-    # it invokes the repository_rule.
-    #
-    # On any error, terminates via fail() and does not return.
-    #
-    # We would prefer to load `@bazel_tools//tools/build_defs/repo:git.bzl` and
-    # use its `git_repository` rule, but there is no flavor of that rule that
-    # allows us to pass in the repo_ctx from our own repository_rule.
-    (commit and remote) or fail("Missing commit or remote")
-    _run_git(repo_ctx, "clone", remote, ".")
-    _run_git(repo_ctx, "reset", "--hard", commit)
+def _delete_bazel_files(repo_ctx):
+    # Delete any existing BUILD, BUILD.bazel, or WORKSPACE files from the
+    # archive or cloned repository.
+    bash = repo_ctx.os.environ.get("BAZEL_SH", "bash")
+    execute_or_fail(repo_ctx, [bash, "-c", """
+        set -euxo pipefail
+        find . \
+            -name BUILD -print0 -o \
+            -name BUILD.bazel -print0 -o \
+            -name WORKSPACE -print0 |
+            xargs -t -n1 -0 -I{} mv {} {}.upstream-ignored
+        """])
 
 def _setup_git(repo_ctx):
     # Download the snopt sources from an access-controlled git repository.
@@ -58,34 +91,47 @@ def _setup_git(repo_ctx):
     # the protocol without changing the attributes of the repository_rule.
     # For example:
     # git config --global url.https://github.com/.insteadOf git@github.com:
-    _git_clone(
-        repo_ctx,
-        remote = repo_ctx.attr.remote,
-        commit = repo_ctx.attr.commit,
-    )
-    patchfile = repo_ctx.path(
-        Label("@drake//tools/workspace/snopt:snopt-openmp.patch"),
-    ).realpath
-    execute_or_fail(repo_ctx, [
-        "patch",
-        "-p0",
-        "interfaces/src/snopt_wrapper.f90",
-        patchfile,
-    ])
-    if repo_ctx.attr.use_drake_build_rules:
-        # Disable any files that came from the upstream snopt source.
-        _execute(repo_ctx, "find-and-mv", ["bash", "-c", """
-            set -euxo pipefail
-            find . -name BUILD -print0 -o -name BUILD.bazel -print0 |
-                xargs -t -n1 -0 -I{} \
-                mv {} {}.upstream-ignored
-        """])
+    #
+    # Based on https://github.com/bazelbuild/bazel/blob/0.28.0/tools/build_defs/repo/git.bzl#L24-L55. # noqa
+    if (not repo_ctx.attr.branch and not repo_ctx.attr.commit and not repo_ctx.attr.tag) or (repo_ctx.attr.commit and repo_ctx.attr.tag) or (repo_ctx.attr.branch and repo_ctx.attr.tag) or (repo_ctx.attr.branch and repo_ctx.attr.commit):  # noqa
+        fail("Exactly one of branch, commit, or tag must be provided")
 
-        # Link Drake's BUILD file into the snopt workspace.
-        repo_ctx.symlink(
-            Label("@drake//tools/workspace/snopt:package.BUILD.bazel"),
-            "BUILD",
-        )
+    git_repo_info = git_repo(repo_ctx, str(repo_ctx.path(".")))
+
+    if repo_ctx.attr.use_drake_build_rules:
+        _delete_bazel_files(repo_ctx)
+        repo_ctx.symlink(repo_ctx.attr.build_file, "BUILD.bazel")
+
+    patch(repo_ctx)
+    repo_ctx.delete(repo_ctx.path(".git"))
+
+    # Note that in Bazel 0.28, you cannot specify *by commit* a commit that
+    # exists not on a branch, but only as tag, therefore we silence the debug
+    # message in the case of tags. Note also that specifying a shallow_since
+    # value in a format other than a unix timestamp will generate a debug
+    # message even if it is equivalent to the unix timestamp of the given
+    # commit.
+    if repo_ctx.attr.tag:
+        return None
+
+    attrs_to_update = {
+        "commit": git_repo_info.commit,
+        "shallow_since": git_repo_info.shallow_since,
+    }
+
+    updated_attrs = update_attrs(
+        repo_ctx.attr,
+        _attrs.keys(),
+        attrs_to_update,
+    )
+
+    # If we found the actual commit, remove all other means of specifying
+    # it.
+    if "commit" in updated_attrs:
+        updated_attrs.pop("tag", None)
+        updated_attrs.pop("branch", None)
+
+    return updated_attrs
 
 def _extract_local_archive(repo_ctx, snopt_path):
     # TODO(jwnimmer-tri) Perhaps in the future we should allow SNOPT_PATH
@@ -95,6 +141,9 @@ def _extract_local_archive(repo_ctx, snopt_path):
         return "SNOPT_PATH of '{}' is malformed".format(snopt_path)
     if not repo_ctx.path(snopt_path).exists:
         return "SNOPT_PATH of '{}' does not exist".format(snopt_path)
+
+    repo_ctx.report_progress("Extracting archive")
+
     result = execute_and_return(repo_ctx, [
         "tar",
         "--gunzip",
@@ -105,16 +154,9 @@ def _extract_local_archive(repo_ctx, snopt_path):
     ])
     if result.error:
         return result.error
-    patchfile = repo_ctx.path(
-        Label("@drake//tools/workspace/snopt:snopt-openmp.patch"),
-    ).realpath
-    result = execute_and_return(repo_ctx, [
-        "patch",
-        "-p0",
-        "interfaces/src/snopt_wrapper.f90",
-        patchfile,
-    ])
-    return result.error
+
+    patch(repo_ctx)
+    return None
 
 def _setup_deferred_failure(repo_ctx, error_message):
     # Produce a repository with a valid BUILD.bazel file, but where all of the
@@ -126,18 +168,17 @@ def _setup_deferred_failure(repo_ctx, error_message):
             error_message,
         ),
     )
+    _delete_bazel_files(repo_ctx)
     repo_ctx.symlink(
         Label("@drake//tools/workspace/snopt:package-error.BUILD.bazel"),
-        "BUILD",
+        "BUILD.bazel",
     )
 
 def _setup_local_archive(repo_ctx, snopt_path):
     error = _extract_local_archive(repo_ctx, snopt_path)
     if error == None:
-        repo_ctx.symlink(
-            Label("@drake//tools/workspace/snopt:package.BUILD.bazel"),
-            "BUILD",
-        )
+        _delete_bazel_files(repo_ctx)
+        repo_ctx.symlink(repo_ctx.attr.build_file, "BUILD.bazel")
     else:
         _setup_deferred_failure(repo_ctx, error)
 
@@ -146,7 +187,9 @@ def _impl(repo_ctx):
     if os_result.error != None:
         fail(os_result.error)
 
+    updated_attrs = None
     snopt_path = repo_ctx.os.environ.get("SNOPT_PATH", "")
+
     if len(snopt_path) == 0:
         # When SNOPT is enabled (e.g., with `--config snopt`), then SNOPT_PATH
         # must be set.  If it's not set, we'll defer the error messages to the
@@ -168,7 +211,7 @@ def _impl(repo_ctx):
         # This case does not use deferred error handling.  If you set
         # SNOPT_PATH=git, then we'll assume you know what you're doing,
         # and that the git operations should always succeed.
-        _setup_git(repo_ctx)
+        updated_attrs = _setup_git(repo_ctx)
     else:
         # This case uses deferred error handling, since doing so is easy.
         _setup_local_archive(repo_ctx, snopt_path)
@@ -181,17 +224,35 @@ def _impl(repo_ctx):
         "fortran.bzl",
     )
 
-snopt_repository = repository_rule(
-    attrs = {
-        "remote": attr.string(default = "git@github.com:RobotLocomotion/snopt.git"),  # noqa
-        "commit": attr.string(default = "0254e961cb8c60193b0862a0428fd6a42bfb5243"),  # noqa
-        "use_drake_build_rules": attr.bool(
-            default = True,
-            doc = ("When obtaining SNOPT via git, controls whether or not " +
-                   "Drake's BUILD file should supplant the file(s) in git"),
-        ),
-    },
-    environ = ["SNOPT_PATH"],
+    return updated_attrs
+
+_attrs = {
+    "remote": attr.string(),
+    "commit": attr.string(),
+    "shallow_since": attr.string(),
+    "tag": attr.string(),
+    "branch": attr.string(),
+    "init_submodules": attr.bool(),
+    "verbose": attr.bool(),
+    "patches": attr.label_list(
+        default = ["@drake//tools/workspace/snopt:snopt-openmp.patch"],
+    ),
+    "patch_cmds": attr.string_list(),
+    "patch_tool": attr.string(default = "patch"),
+    "patch_args": attr.string_list(default = ["-p0"]),
+    "build_file": attr.label(
+        allow_single_file = True,
+        default = "@drake//tools/workspace/snopt:package.BUILD.bazel",
+    ),
+    "use_drake_build_rules": attr.bool(default = True),
+}
+
+_snopt_repository = repository_rule(
+    attrs = _attrs,
+    environ = [
+        "BAZEL_SH",
+        "SNOPT_PATH",
+    ],
     local = False,
     implementation = _impl,
 )


### PR DESCRIPTION
Note that commits that exist not on a branch and only as a tag and must now use the tag argument rather than the commit argument.

<!-- Reviewable:start -->
----
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11791)
<!-- Reviewable:end -->