### PR TITLE
Introduces API for modifying role properties for registered geometry

### DIFF
--- a/geometry/geometry_roles.h
+++ b/geometry/geometry_roles.h
@@ -191,6 +191,16 @@ enum class Role {
   kPerception = 0x4
 };
 
+// NOTE: Currently this only includes new and replace; but someday it could also
+// include other operations: merge, subtract, etc.
+/** The operations that can be performed on the given properties when assigning
+ roles to geometry.  */
+enum class RoleAssign {
+  kNew,      ///< Assign the properties to a geometry that doesn't already have
+             ///< the role.
+  kReplace   ///< Replace the existing role properties completely.
+};
+
 /** @name  Geometry role to string conversions
 
  These are simply convenience functions for converting the Role enumeration into

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -338,19 +338,22 @@ class GeometryState {
    @ref SceneGraph::AssignRole(SourceId, GeometryId, ProximityProperties)
    "SceneGraph::AssignRole()".  */
   void AssignRole(SourceId source_id, GeometryId geometry_id,
-                  ProximityProperties properties);
+                  ProximityProperties properties,
+                  RoleAssign assign = RoleAssign::kNew);
 
   /** Implementation of
    @ref SceneGraph::AssignRole(SourceId, GeometryId, PerceptionProperties)
    "SceneGraph::AssignRole()".  */
   void AssignRole(SourceId source_id, GeometryId geometry_id,
-                  PerceptionProperties properties);
+                  PerceptionProperties properties,
+                  RoleAssign assign = RoleAssign::kNew);
 
   /** Implementation of
    @ref SceneGraph::AssignRole(SourceId, GeometryId, IllustrationProperties)
    "SceneGraph::AssignRole()".  */
   void AssignRole(SourceId source_id, GeometryId geometry_id,
-                  IllustrationProperties properties);
+                  IllustrationProperties properties,
+                  RoleAssign assign = RoleAssign::kNew);
 
   /** Implementation of
    @ref SceneGraph::RemoveRole(SourceId, FrameId, Role)
@@ -685,9 +688,11 @@ class GeometryState {
   void ThrowIfNameExistsInRole(FrameId id, Role role,
                                const std::string& name) const;
 
-  template <typename PropertyType>
-  void AssignRoleInternal(SourceId source_id, GeometryId geometry_id,
-                          PropertyType properties, Role role);
+  // Confirms that the given role assignment is valid and return the geometry
+  // if valid. Throws if not.
+  internal::InternalGeometry& ValidateRoleAssign(SourceId source_id,
+                                                 GeometryId geometry_id,
+                                                 Role role, RoleAssign assign);
 
   // Attempts to remove the indicated `role` from the indicated geometry.
   // Returns true if removed (false doesn't imply "failure", just nothing to

--- a/geometry/internal_geometry.h
+++ b/geometry/internal_geometry.h
@@ -179,12 +179,8 @@ class InternalGeometry {
    engine's understanding as well.  */
   //@{
 
-  /** Assigns a proximity role to this geometry. Fails if it has already been
-   assigned.  */
+  /** Assigns a proximity role to this geometry.  */
   void SetRole(ProximityProperties properties) {
-    if (proximity_props_) {
-      throw std::logic_error("Geometry already has proximity role assigned");
-    }
     proximity_props_ = std::move(properties);
   }
 

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -225,48 +225,54 @@ vector<std::string> SceneGraph<T>::RegisteredRendererNames() const {
 }
 
 template <typename T>
-void SceneGraph<T>::AssignRole(SourceId source_id,
-                               GeometryId geometry_id,
-                               ProximityProperties properties) {
-  initial_state_->AssignRole(source_id, geometry_id, std::move(properties));
+void SceneGraph<T>::AssignRole(SourceId source_id, GeometryId geometry_id,
+                               ProximityProperties properties,
+                               RoleAssign assign) {
+  initial_state_->AssignRole(source_id, geometry_id, std::move(properties),
+                             assign);
 }
 
 template <typename T>
 void SceneGraph<T>::AssignRole(Context<T>* context, SourceId source_id,
                                GeometryId geometry_id,
-                               ProximityProperties properties) const {
+                               ProximityProperties properties,
+                               RoleAssign assign) const {
   auto& g_state = mutable_geometry_state(context);
-  g_state.AssignRole(source_id, geometry_id, std::move(properties));
+  g_state.AssignRole(source_id, geometry_id, std::move(properties), assign);
 }
 
 template <typename T>
-void SceneGraph<T>::AssignRole(SourceId source_id,
-                               GeometryId geometry_id,
-                               PerceptionProperties properties) {
-  initial_state_->AssignRole(source_id, geometry_id, std::move(properties));
+void SceneGraph<T>::AssignRole(SourceId source_id, GeometryId geometry_id,
+                               PerceptionProperties properties,
+                               RoleAssign assign) {
+  initial_state_->AssignRole(source_id, geometry_id, std::move(properties),
+                             assign);
 }
 
 template <typename T>
 void SceneGraph<T>::AssignRole(Context<T>* context, SourceId source_id,
                                GeometryId geometry_id,
-                               PerceptionProperties properties) const {
+                               PerceptionProperties properties,
+                               RoleAssign assign) const {
   auto& g_state = mutable_geometry_state(context);
-  g_state.AssignRole(source_id, geometry_id, std::move(properties));
+  g_state.AssignRole(source_id, geometry_id, std::move(properties), assign);
 }
 
 template <typename T>
-void SceneGraph<T>::AssignRole(SourceId source_id,
-                               GeometryId geometry_id,
-                               IllustrationProperties properties) {
-  initial_state_->AssignRole(source_id, geometry_id, std::move(properties));
+void SceneGraph<T>::AssignRole(SourceId source_id, GeometryId geometry_id,
+                               IllustrationProperties properties,
+                               RoleAssign assign) {
+  initial_state_->AssignRole(source_id, geometry_id, std::move(properties),
+                             assign);
 }
 
 template <typename T>
 void SceneGraph<T>::AssignRole(Context<T>* context, SourceId source_id,
                                GeometryId geometry_id,
-                               IllustrationProperties properties) const {
+                               IllustrationProperties properties,
+                               RoleAssign assign) const {
   auto& g_state = mutable_geometry_state(context);
-  g_state.AssignRole(source_id, geometry_id, std::move(properties));
+  g_state.AssignRole(source_id, geometry_id, std::move(properties), assign);
 }
 
 template <typename T>

--- a/geometry/test/internal_geometry_test.cc
+++ b/geometry/test/internal_geometry_test.cc
@@ -20,17 +20,12 @@ GTEST_TEST(InternalGeometryTest, RenderIndexAccess) {
   EXPECT_EQ(geometry.render_index(renderer_name), index);
 }
 
-// Confirms that redundantly setting properties causes an exception to be
-// thrown.
-GTEST_TEST(InternalGeometryTest, RedundantPropertyAssignment) {
+// Confirms that properties get set properly.
+GTEST_TEST(InternalGeometryTest, PropertyAssignment) {
   InternalGeometry geometry;
 
   EXPECT_FALSE(geometry.has_proximity_role());
   EXPECT_NO_THROW(geometry.SetRole(ProximityProperties()));
-  EXPECT_TRUE(geometry.has_proximity_role());
-  DRAKE_EXPECT_THROWS_MESSAGE(geometry.SetRole(ProximityProperties()),
-                              std::logic_error,
-                              "Geometry already has proximity role assigned");
   EXPECT_TRUE(geometry.has_proximity_role());
 
   EXPECT_FALSE(geometry.has_illustration_role());


### PR DESCRIPTION
This provides the API on SceneGraph (with appropriate documentation). It only implements it for proximity roles (for now) as a simple expedient. Those will come in a follow up PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11796)
<!-- Reviewable:end -->
