### PR TITLE
Add python3-scipy to setup script

### DIFF
--- a/setup/ubuntu/binary_distribution/packages-bionic.txt
+++ b/setup/ubuntu/binary_distribution/packages-bionic.txt
@@ -46,6 +46,7 @@ python3-lxml
 python3-matplotlib
 python3-numpy
 python3-pydot
+python3-scipy
 python3-six
 python3-tk
 python3-tornado


### PR DESCRIPTION
Historically this has not been in the script since only Director needed it, which is Python 2 only in Drake. However, we will soon switch the Python 3 for Director and it was confusing that was a package being installed for Python 2 only when all the others were installed for both Python 2 and 3.

Relates #10606.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11798)
<!-- Reviewable:end -->
