### PR TITLE
Replaces stub mechanism to support symbolic::Expression in MBP.

### DIFF
--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -5,6 +5,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "drake/common/default_scalars.h"
 #include "drake/geometry/geometry_set.h"
 #include "drake/geometry/geometry_state.h"
 #include "drake/geometry/query_object.h"
@@ -822,6 +823,39 @@ class SceneGraph final : public systems::LeafSystem<T> {
   // The cache index for the pose update cache entry.
   systems::CacheIndex pose_update_index_{};
 };
+
+#ifndef DRAKE_DOXYGEN_CXX
+// Specialization to allow compilation of user code with symbolic::Expression.
+// This specialization only provides stub methods that throw an exception at
+// runtime.
+template <>
+class SceneGraph<symbolic::Expression> {
+ public:
+  static FrameId world_frame_id() {
+    return SceneGraph<double>::world_frame_id();
+  }
+
+#define DRAKE_STUB(Ret, Name)                   \
+  template <typename... Args>                   \
+  Ret Name(Args...) const { Throw(#Name); return Ret(); }
+
+  DRAKE_STUB(void, AssignRole)
+  DRAKE_STUB(void, ExcludeCollisionsBetween)
+  DRAKE_STUB(void, ExcludeCollisionsWithin)
+  DRAKE_STUB(FrameId, RegisterFrame)
+  DRAKE_STUB(GeometryId, RegisterGeometry)
+  DRAKE_STUB(SourceId, RegisterSource)
+  DRAKE_STUB(SceneGraphInspector<symbolic::Expression>, model_inspector)
+
+ private:
+  static void Throw(const char* operation_name) {
+    throw std::logic_error(fmt::format(
+        "Cannot {} on a SceneGraph<symbolic::Expression>", operation_name));
+  }
+
+#undef DRAKE_STUB
+};
+#endif  // DRAKE_DOXYGEN_CXX
 
 }  // namespace geometry
 

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -6,6 +6,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/default_scalars.h"
 #include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/geometry_state.h"
 #include "drake/geometry/shape_specification.h"
@@ -400,6 +401,23 @@ class SceneGraphInspector {
 
   const GeometryState<T>* state_{nullptr};
 };
+
+// Specialization to allow compilation of user code with symbolic::Expression.
+// This specialization only provides stub methods that throw an exception at
+// runtime.
+#ifndef DRAKE_DOXYGEN_CXX
+template <>
+class SceneGraphInspector<symbolic::Expression> {
+ public:
+  const geometry::ProximityProperties* GetProximityProperties(
+      GeometryId) const {
+    throw std::logic_error(
+        "Cannot GetProximityProperties on a "
+        "SceneGraphInspector<symbolic::Expression>");
+    return nullptr;
+  }
+};
+#endif
 
 }  // namespace geometry
 }  // namespace drake

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -695,55 +695,9 @@ MatrixX<T> MultibodyPlant<T>::MakeActuationMatrix() const {
 }
 
 template <typename T>
-struct MultibodyPlant<T>::SceneGraphStub {
-  struct StubSceneGraphInspector {
-    const geometry::ProximityProperties* GetProximityProperties(
-        GeometryId) const {
-      return nullptr;
-    }
-  };
-
-  static void Throw(const char* operation_name) {
-    throw std::logic_error(fmt::format(
-        "Cannot {} on a SceneGraph<symbolic::Expression>", operation_name));
-  }
-
-  static FrameId world_frame_id() {
-    return SceneGraph<double>::world_frame_id();
-  }
-
-#define DRAKE_STUB(Ret, Name)                   \
-  template <typename... Args>                   \
-  Ret Name(Args...) const { Throw(#Name); return Ret(); }
-
-  DRAKE_STUB(void, AssignRole)
-  DRAKE_STUB(void, ExcludeCollisionsBetween)
-  DRAKE_STUB(void, ExcludeCollisionsWithin)
-  DRAKE_STUB(FrameId, RegisterFrame)
-  DRAKE_STUB(GeometryId, RegisterGeometry)
-  DRAKE_STUB(SourceId, RegisterSource)
-  const StubSceneGraphInspector model_inspector() const {
-    Throw("model_inspector");
-    return StubSceneGraphInspector();
-  }
-
-#undef DRAKE_STUB
-};
-
-template <typename T>
-typename MultibodyPlant<T>::MemberSceneGraph&
-MultibodyPlant<T>::member_scene_graph() {
+SceneGraph<T>& MultibodyPlant<T>::member_scene_graph() {
   DRAKE_THROW_UNLESS(scene_graph_ != nullptr);
   return *scene_graph_;
-}
-
-// Specialize this function so that we can use our Stub class; we cannot call
-// methods on SceneGraph<Expression> because they do not exist.
-template <>
-typename MultibodyPlant<symbolic::Expression>::MemberSceneGraph&
-MultibodyPlant<symbolic::Expression>::member_scene_graph() {
-  static never_destroyed<SceneGraphStub> stub_;
-  return stub_.access();
 }
 
 template <typename T>

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3288,18 +3288,12 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // MultibodyTree::Finalize() was called.
   void FinalizePlantOnly();
 
-  // MemberSceneGraph is an alias for SceneGraph<T>, except when T = Expression.
-  struct SceneGraphStub;
-  using MemberSceneGraph = typename std::conditional<
-      std::is_same<T, symbolic::Expression>::value,
-      SceneGraphStub, geometry::SceneGraph<T>>::type;
-
   // Returns the SceneGraph that pre-Finalize geometry operations should
   // interact with.  In most cases, that will be whatever the user has passed
   // into RegisterAsSourceForSceneGraph.  However, when T = Expression, the
   // result will be a stub type instead.  (We can get rid of the stub once
   // SceneGraph supports symbolic::Expression.)
-  MemberSceneGraph& member_scene_graph();
+  geometry::SceneGraph<T>& member_scene_graph();
 
   // Helper to check when a deprecated user-provided `scene_graph` pointer is
   // passed in via public API (aside form `RegisterAsSourceForSceneGraph`).
@@ -3930,9 +3924,6 @@ struct AddMultibodyPlantSceneGraphResult final {
 #ifndef DRAKE_DOXYGEN_CXX
 // Forward-declare specializations, prior to DRAKE_DECLARE... below.
 // See the .cc file for an explanation why we specialize these methods.
-template <>
-typename MultibodyPlant<symbolic::Expression>::SceneGraphStub&
-MultibodyPlant<symbolic::Expression>::member_scene_graph();
 template <>
 std::vector<geometry::PenetrationAsPointPair<double>>
 MultibodyPlant<double>::CalcPointPairPenetrations(


### PR DESCRIPTION
As we add hydroelastics into MBP after #11713, another query not supporting symbolic, we need more stubs/hacs/template magic in order to let the code compile but somehow throw a meaningful exception at runtime.
Currently we do this for SceneGraph using a series of stubs, dummy classes that mimic SG APIs for when `T = symbolic::Expression`. This gets quite cumbersome (I couldn't even figure it out) when I start adding the `HydroelasticEngine` given that now more objects require stubs (`QueryObject`, `GeometryInspector`, to mention a few).

I found it way easier for each class not supporting symbolic to define a specialization for `T = symbolic::Expression` locally, in their own header. This had the nice side effect of:
- Reducing the number of classes for which I had to do this by hand.
- Not having to add more template magic into the MBP implementation.
- Hopefully other clients of SG can also benefit from this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11805)
<!-- Reviewable:end -->
