### PR TITLE
pydrake: Add missing py_reference_internal to SignalLogger.data().

### DIFF
--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -189,7 +189,8 @@ PYBIND11_MODULE(primitives, m) {
             doc.SignalLogger.set_forced_publish_only.doc)
         .def("sample_times", &SignalLogger<T>::sample_times,
             doc.SignalLogger.sample_times.doc)
-        .def("data", &SignalLogger<T>::data, doc.SignalLogger.data.doc)
+        .def("data", &SignalLogger<T>::data, py_reference_internal,
+            doc.SignalLogger.data.doc)
         .def("reset", &SignalLogger<T>::reset, doc.SignalLogger.reset.doc);
 
     DefineTemplateClassWithDefault<SymbolicVectorSystem<T>, LeafSystem<T>>(m,

--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -188,7 +188,7 @@ PYBIND11_MODULE(primitives, m) {
             &SignalLogger<T>::set_forced_publish_only,
             doc.SignalLogger.set_forced_publish_only.doc)
         .def("sample_times", &SignalLogger<T>::sample_times,
-            doc.SignalLogger.sample_times.doc)
+            py_reference_internal, doc.SignalLogger.sample_times.doc)
         .def("data", &SignalLogger<T>::data, py_reference_internal,
             doc.SignalLogger.data.doc)
         .def("reset", &SignalLogger<T>::reset, doc.SignalLogger.reset.doc);

--- a/bindings/pydrake/systems/test/primitives_test.py
+++ b/bindings/pydrake/systems/test/primitives_test.py
@@ -138,14 +138,14 @@ class TestGeneral(unittest.TestCase):
         # Verify that t and x retain their values after systems are deleted.
         t_copy = t.copy()
         x_copy = x.copy()
-        del(builder)
-        del(integrator)
-        del(logger_periodic)
-        del(logger_per_step)
-        del(logger_per_step_2)
-        del(diagram)
-        del(simulator)
-        del(source)
+        del builder
+        del integrator
+        del logger_periodic
+        del logger_per_step
+        del logger_per_step_2
+        del diagram
+        del simulator
+        del source
         gc.collect()
         self.assertTrue((t == t_copy).all())
         self.assertTrue((x == x_copy).all())

--- a/bindings/pydrake/systems/test/primitives_test.py
+++ b/bindings/pydrake/systems/test/primitives_test.py
@@ -1,3 +1,4 @@
+import gc
 import unittest
 import numpy as np
 
@@ -133,6 +134,21 @@ class TestGeneral(unittest.TestCase):
         self.assertTrue(t.shape[0] == np.floor(kTime / kPeriod) + 1.)
 
         logger_per_step.reset()
+
+        # Verify that t and x retain their values after systems are deleted.
+        t_copy = t.copy()
+        x_copy = x.copy()
+        del(builder)
+        del(integrator)
+        del(logger_periodic)
+        del(logger_per_step)
+        del(logger_per_step_2)
+        del(diagram)
+        del(simulator)
+        del(source)
+        gc.collect()
+        self.assertTrue((t == t_copy).all())
+        self.assertTrue((x == x_copy).all())
 
     def test_linear_affine_system(self):
         # Just make sure linear system is spelled correctly.


### PR DESCRIPTION
The checks added to `test_signal_logger` by this PR fail on the `self.assertTrue((x == x_copy).all())` line without the change to `primitives_py.cc`. For reasons unknown to me, an analogous modification of the binding for `sample_times()` was not needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11810)
<!-- Reviewable:end -->
