### PR TITLE
Killing indices - removing GeometryIndex, RenderIndex, ProximityIndex

### DIFF
--- a/geometry/geometry_ids.h
+++ b/geometry/geometry_ids.h
@@ -1,9 +1,14 @@
 #pragma once
 
+#include "drake/common/drake_copyable.h"
 #include "drake/geometry/identifier.h"
 
 namespace drake {
 namespace geometry {
+
+namespace internal {
+class EncodedData;
+}  // namespace internal
 
 /** Type used to identify geometry sources in SceneGraph. */
 using SourceId = Identifier<class SourceTag>;
@@ -12,7 +17,39 @@ using SourceId = Identifier<class SourceTag>;
 using FrameId = Identifier<class FrameTag>;
 
 /** Type used to identify geometry instances in SceneGraph. */
-using GeometryId = Identifier<class GeometryTag>;
+class GeometryId : public Identifier<class GeometryTag> {
+  using Base = Identifier<class GeometryTag>;
+ public:
+  GeometryId() = default;
+
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(GeometryId);
+
+  static GeometryId get_new_id() {
+    auto base_id = Base::get_new_id();
+    return GeometryId(base_id.get_value());
+  }
+
+ private:
+  explicit GeometryId(int64_t value) : Base(value) {}
+
+  // EncodedData needs to be able to create GeometryId from FCL-encoded data.
+  // This gives it access to the otherwise inaccessible constructor.
+  friend class internal::EncodedData;
+};
 
 }  // namespace geometry
 }  // namespace drake
+
+namespace std {
+
+/** Enables use of the identifier to serve as a key in STL containers.
+ @relates GeometryId
+ */
+template <>
+struct hash<drake::geometry::GeometryId> {
+  size_t operator()(const drake::geometry::GeometryId& id) const {
+    return std::hash<int64_t>()(id.get_value());
+  }
+};
+
+}  // namespace std

--- a/geometry/geometry_index.h
+++ b/geometry/geometry_index.h
@@ -5,18 +5,7 @@
 namespace drake {
 namespace geometry {
 
-/** Type used to locate any geometry in the render engine. */
-using RenderIndex = TypeSafeIndex<class RenderTag>;
-
-/** Index used to identify a geometry in the proximity engine. The same index
- type applies to both anchored and dynamic geometries. They are distinguished
- by which method they are passed to.  */
-using ProximityIndex = TypeSafeIndex<class ProximityTag>;
-
-/** Index into the ordered vector of all registered geometries (regardless of
- parent frame, role, etc.)   */
-using GeometryIndex = TypeSafeIndex<class GeometryTag>;
-
+// TODO(SeanCurtis-TRI): Remove FrameIndex.
 /** Index into the ordered vector of all registered frames -- by convention,
  the world frame's index is always zero.  */
 using FrameIndex = TypeSafeIndex<class GeometryTag>;

--- a/geometry/geometry_roles.h
+++ b/geometry/geometry_roles.h
@@ -151,8 +151,6 @@ class ProximityProperties final : public GeometryProperties {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ProximityProperties);
   // TODO(SeanCurtis-TRI): Should this have the physical properties built in?
-
-  // TODO(SeanCurtis-TRI): Consider adding ProximityIndex to this.
   ProximityProperties() = default;
 };
 
@@ -165,8 +163,6 @@ class PerceptionProperties final : public GeometryProperties{
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PerceptionProperties);
   // TODO(SeanCurtis-TRI): Should this have a render label built in?
-
-  // TODO(SeanCurtis-TRI): Consider adding PerceptionIndex to this.
   PerceptionProperties() = default;
 };
 

--- a/geometry/identifier.h
+++ b/geometry/identifier.h
@@ -189,10 +189,11 @@ class Identifier {
     return Identifier(next_index.access()++);
   }
 
- private:
+ protected:
   // Instantiates an identifier from the underlying representation type.
   explicit Identifier(int64_t val) : value_(val) {}
 
+ private:
   // The underlying value.
   int64_t value_{};
 };

--- a/geometry/internal_geometry.cc
+++ b/geometry/internal_geometry.cc
@@ -12,12 +12,10 @@ using std::move;
 
 InternalGeometry::InternalGeometry(
     SourceId source_id, std::unique_ptr<Shape> shape, FrameId frame_id,
-    GeometryId geometry_id, std::string name, const Isometry3<double>& X_FG,
-    GeometryIndex index)
+    GeometryId geometry_id, std::string name, const Isometry3<double>& X_FG)
     : shape_spec_(std::move(shape)),
       id_(geometry_id),
       name_(std::move(name)),
-      index_(index),
       source_id_(source_id),
       frame_id_(frame_id),
       X_PG_(X_FG),
@@ -39,18 +37,10 @@ bool InternalGeometry::has_role(Role role) const {
   DRAKE_UNREACHABLE();
 }
 
-optional<RenderIndex> InternalGeometry::render_index(
-    const std::string& renderer_name) const {
-  auto iter = render_indices_.find(renderer_name);
-  if (iter != render_indices_.end()) return iter->second;
-  return {};
-}
-
-void InternalGeometry::set_render_index(std::string renderer_name,
-                                        RenderIndex index) {
-  auto result = render_indices_.emplace(move(renderer_name), index);
-  // As an internal class, setting a duplicate render index is a programming
-  // error in SceneGraph's internals.
+void InternalGeometry::set_renderer(std::string renderer_name) {
+  auto result = renderers_.emplace(move(renderer_name));
+  // As an internal class, setting a duplicate renderer is a programming error
+  // in SceneGraph's internals.
   DRAKE_ASSERT(result.second);
 }
 

--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -262,4 +262,9 @@ drake_cc_googletest(
     ],
 )
 
+drake_cc_googletest(
+    name = "proximity_utilities_test",
+    deps = [":proximity_utilities"],
+)
+
 add_lint_tests()

--- a/geometry/proximity/collision_filter_legacy.h
+++ b/geometry/proximity/collision_filter_legacy.h
@@ -99,29 +99,6 @@ class CollisionFilterLegacy {
    next_clique_id().  */
   int peek_next_clique() const { return next_available_clique_; }
 
-  /** A geometry that was previously registered under the `old_encoding` will
-   now be recognized under the `new_encoding`. The `old_encoding` will no longer
-   be valid.
-   @pre `old_encoding` must exist in the map of filters and `new_encoding` must
-         *not*.  */
-  void UpdateEncoding(uintptr_t old_encoding, uintptr_t new_encoding) {
-    // NOTE: The keys in the cliques is a function of a geometry's GeometryIndex
-    // and dynamic property (dynamic or anchored). When GeometryState *moves* a
-    // geometry in its compact vector, that geometry's index changes. That means
-    // we need remap the collision cliques from its old encoding to its new.
-    //
-    // Generally, this movement is to make the array of geometries compact; so
-    // a geometry is moved into a slot of a geometry that is being removed.
-    // Therefore, we require that the slot being moved into must *not* be
-    // occupied; i.e., the removed geometry has been removed.
-    auto old_iter = collision_cliques_.find(old_encoding);
-    DRAKE_DEMAND(old_iter != collision_cliques_.end());
-    auto new_iter = collision_cliques_.find(new_encoding);
-    DRAKE_DEMAND(new_iter == collision_cliques_.end());
-    collision_cliques_.emplace(new_encoding, std::move(old_iter->second));
-    collision_cliques_.erase(old_encoding);
-  }
-
  private:
   // A map between the EncodedData::encoding() value for a geometry and
   // its set of cliques.

--- a/geometry/proximity/distance_to_point_with_gradient.h
+++ b/geometry/proximity/distance_to_point_with_gradient.h
@@ -32,7 +32,7 @@ class DistanceToPointWithGradient {
   SignedDistanceToPointWithGradient operator()(
       const fcl::Sphered& sphere) const;
 
-  /** Overload for halfspace object */
+  /** Overload for half space object */
   SignedDistanceToPointWithGradient operator()(
       const fcl::Halfspaced& halfspace) const;
 

--- a/geometry/proximity/find_collision_candidates.cc
+++ b/geometry/proximity/find_collision_candidates.cc
@@ -5,13 +5,10 @@ namespace geometry {
 namespace internal {
 namespace find_collision_candidates {
 
-CallbackData::CallbackData(const std::vector<GeometryId>* geometry_map_in,
-                           const CollisionFilterLegacy* collision_filter_in,
+CallbackData::CallbackData(const CollisionFilterLegacy* collision_filter_in,
                            std::vector<SortedPair<GeometryId>>* pairs_in)
-    : geometry_map(*geometry_map_in),
-      collision_filter(*collision_filter_in),
+    : collision_filter(*collision_filter_in),
       pairs(*pairs_in) {
-  DRAKE_DEMAND(geometry_map_in);
   DRAKE_DEMAND(collision_filter_in);
   DRAKE_DEMAND(pairs_in);
 }
@@ -28,9 +25,7 @@ bool Callback(fcl::CollisionObjectd* object_A_ptr,
   const bool can_collide = data.collision_filter.CanCollideWith(
       encoding_a.encoding(), encoding_b.encoding());
   if (can_collide) {
-    const GeometryId id_a = encoding_a.id(data.geometry_map);
-    const GeometryId id_b = encoding_b.id(data.geometry_map);
-    data.pairs.emplace_back(id_a, id_b);
+    data.pairs.emplace_back(encoding_a.id(), encoding_b.id());
   }
   // Tell the broadphase to keep searching.
   return false;

--- a/geometry/proximity/find_collision_candidates.h
+++ b/geometry/proximity/find_collision_candidates.h
@@ -20,8 +20,6 @@ namespace find_collision_candidates {
 /** Supporting data for the collision candidates callback (see Callback below).
    It includes:
 
-    - A map from GeometryIndex to GeometryId (to facilitate reporting GeometryId
-      values in the results).
     - A collision filter instance.
     - A vector of geometry pairs -- each pair of geometries are possibly in
       contact.
@@ -31,15 +29,10 @@ struct CallbackData {
    in the class documentation. The parameters are all aliased in the data and
    must remain valid at least as long as the %CallbackData instance.
 
-   @param geometry_map_in         The index -> id map. Aliased.
    @param collision_filter_in     The collision filter system. Aliased.
    @param pairs_in                The output results. Aliased.  */
-  CallbackData(const std::vector<GeometryId>* geometry_map_in,
-               const CollisionFilterLegacy* collision_filter_in,
+  CallbackData(const CollisionFilterLegacy* collision_filter_in,
                std::vector<SortedPair<GeometryId>>* pairs_in);
-
-  /** The map from GeometryIndex to GeometryId.  */
-  const std::vector<GeometryId>& geometry_map;
 
   /** The collision filter system.  */
   const CollisionFilterLegacy& collision_filter;

--- a/geometry/proximity/test/find_collision_candidates_test.cc
+++ b/geometry/proximity/test/find_collision_candidates_test.cc
@@ -20,12 +20,12 @@ using std::vector;
 // Confirms that the callback properly returns a sorted pair for the
 // corresponding geometry ids.
 GTEST_TEST(Callback, PairsProperlyFormed) {
-  std::vector<GeometryId> geometry_map{GeometryId::get_new_id(),
-                                       GeometryId::get_new_id()};
+  const GeometryId id_A = GeometryId::get_new_id();
+  const GeometryId id_B = GeometryId::get_new_id();
   CollisionFilterLegacy collision_filter;
 
-  EncodedData data_A(GeometryIndex{0}, true);
-  EncodedData data_B(GeometryIndex{1}, true);
+  EncodedData data_A(id_A, true);
+  EncodedData data_B(id_B, true);
   collision_filter.AddGeometry(data_A.encoding());
   collision_filter.AddGeometry(data_B.encoding());
 
@@ -35,10 +35,10 @@ GTEST_TEST(Callback, PairsProperlyFormed) {
   data_B.write_to(&box_B);
 
   vector<SortedPair<GeometryId>> pairs;
-  CallbackData data(&geometry_map, &collision_filter, &pairs);
+  CallbackData data(&collision_filter, &pairs);
   Callback(&box_A, &box_B, &data);
   ASSERT_EQ(pairs.size(), 1u);
-  const SortedPair<GeometryId> expected_pair{geometry_map[0], geometry_map[1]};
+  const SortedPair<GeometryId> expected_pair{id_A, id_B};
   EXPECT_EQ(pairs[0], expected_pair);
 
   // We verify that the order the callback receives it doesn't affect the
@@ -51,12 +51,10 @@ GTEST_TEST(Callback, PairsProperlyFormed) {
 
 // This test verifies that the broad-phase callback respects filtering.
 GTEST_TEST(Callback, RespectsCollisionFilter) {
-  std::vector<GeometryId> geometry_map{GeometryId::get_new_id(),
-                                       GeometryId::get_new_id()};
   CollisionFilterLegacy collision_filter;
 
-  EncodedData data_A(GeometryIndex{0}, true);
-  EncodedData data_B(GeometryIndex{1}, true);
+  EncodedData data_A(GeometryId::get_new_id(), true);
+  EncodedData data_B(GeometryId::get_new_id(), true);
   collision_filter.AddGeometry(data_A.encoding());
   collision_filter.AddGeometry(data_B.encoding());
   // Filter the pair (A, B) by adding them to the same clique.
@@ -69,7 +67,7 @@ GTEST_TEST(Callback, RespectsCollisionFilter) {
   data_B.write_to(&box_B);
 
   vector<SortedPair<GeometryId>> pairs;
-  CallbackData data(&geometry_map, &collision_filter, &pairs);
+  CallbackData data(&collision_filter, &pairs);
   Callback(&box_A, &box_B, &data);
   EXPECT_EQ(pairs.size(), 0u);
 }

--- a/geometry/proximity/test/proximity_utilities_test.cc
+++ b/geometry/proximity/test/proximity_utilities_test.cc
@@ -1,0 +1,64 @@
+#include "drake/geometry/proximity/proximity_utilities.h"
+
+#include <memory>
+
+#include <fcl/fcl.h>
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+using fcl::CollisionGeometryd;
+using fcl::CollisionObjectd;
+
+// Construct a couple of encodings and test their properties.
+GTEST_TEST(EncodedData, ConstructorAndProperties) {
+  GeometryId id_A = GeometryId::get_new_id();
+  EncodedData data_A(id_A, true);
+  EXPECT_EQ(data_A.id(), id_A);
+  EXPECT_TRUE(data_A.is_dynamic());
+
+  GeometryId id_B = GeometryId::get_new_id();
+  EncodedData data_B(id_B, false);
+  EXPECT_EQ(data_B.id(), id_B);
+  EXPECT_FALSE(data_B.is_dynamic());
+}
+
+GTEST_TEST(EncodedData, FactoryConstruction) {
+  GeometryId id_A = GeometryId::get_new_id();
+
+  EncodedData dynamic = EncodedData::encode_dynamic(id_A);
+  EXPECT_EQ(dynamic.id(), id_A);
+  EXPECT_TRUE(dynamic.is_dynamic());
+
+  EncodedData anchored = EncodedData::encode_anchored(id_A);
+  EXPECT_EQ(anchored.id(), id_A);
+  EXPECT_FALSE(anchored.is_dynamic());
+}
+
+// This tests writing to and extracting from an fcl object,
+GTEST_TEST(EncodedData, ConstructionFromFclObject) {
+  GeometryId id_A = GeometryId::get_new_id();
+  EncodedData data_A(id_A, true);
+  CollisionObjectd object(std::shared_ptr<CollisionGeometryd>(nullptr));
+
+  data_A.write_to(&object);
+  {
+    EncodedData data_read(object);
+    EXPECT_TRUE(data_read.is_dynamic());
+    EXPECT_EQ(data_read.id(), data_A.id());
+  }
+
+  data_A.set_anchored();
+  data_A.write_to(&object);
+  {
+    EncodedData data_read(object);
+    EXPECT_FALSE(data_read.is_dynamic());
+    EXPECT_EQ(data_read.id(), data_A.id());
+  }
+}
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -26,11 +26,13 @@ namespace geometry {
 namespace internal {
 
 using Eigen::Vector3d;
+using fcl::CollisionObjectd;
 using std::make_shared;
 using std::make_unique;
 using std::move;
 using std::shared_ptr;
 using std::unique_ptr;
+using std::unordered_map;
 
 namespace {
 
@@ -39,12 +41,9 @@ namespace {
 // Struct for use in SingleCollisionCallback(). Contains the collision request
 // and accumulates results in a drake::multibody::collision::PointPair vector.
 struct CollisionData {
-  CollisionData(const std::vector<GeometryId>* geometry_map_in,
-                const CollisionFilterLegacy* collision_filter_in)
-      : geometry_map(*geometry_map_in),
-        collision_filter(*collision_filter_in) {}
-  // Maps so the penetration call back can map from engine index to geometry id.
-  const std::vector<GeometryId>& geometry_map;
+  explicit CollisionData(const CollisionFilterLegacy* collision_filter_in)
+      : collision_filter(*collision_filter_in) {}
+  // Collision filter used to exclude filtered pairs.
   const CollisionFilterLegacy& collision_filter;
 
   // Collision request
@@ -56,15 +55,15 @@ struct CollisionData {
 
 // Callback function for FCL's collide() function for retrieving a *single*
 // contact.
-bool SingleCollisionCallback(fcl::CollisionObjectd* fcl_object_A_ptr,
-                             fcl::CollisionObjectd* fcl_object_B_ptr,
+bool SingleCollisionCallback(CollisionObjectd* fcl_object_A_ptr,
+                             CollisionObjectd* fcl_object_B_ptr,
                              void* callback_data) {
   // NOTE: Although this function *takes* non-const pointers to satisfy the
   // fcl api, it should not exploit the non-constness to modify the collision
   // objects. We insure this by immediately assigning to a const version and
   // not directly using the provided parameters.
-  const fcl::CollisionObjectd& fcl_object_A = *fcl_object_A_ptr;
-  const fcl::CollisionObjectd& fcl_object_B = *fcl_object_B_ptr;
+  const CollisionObjectd& fcl_object_A = *fcl_object_A_ptr;
+  const CollisionObjectd& fcl_object_B = *fcl_object_B_ptr;
 
   auto& collision_data = *static_cast<CollisionData*>(callback_data);
 
@@ -126,11 +125,8 @@ bool SingleCollisionCallback(fcl::CollisionObjectd* fcl_object_A_ptr,
 
   PenetrationAsPointPair<double> penetration;
   penetration.depth = depth;
-  // The engine doesn't know geometry ids; it returns engine indices. The
-  // caller must map engine indices to geometry ids.
-  const std::vector<GeometryId>& geometry_map = collision_data.geometry_map;
-  penetration.id_A = encoding_A.id(geometry_map);
-  penetration.id_B = encoding_B.id(geometry_map);
+  penetration.id_A = encoding_A.id();
+  penetration.id_B = encoding_B.id();
   penetration.p_WCa = p_WAc;
   penetration.p_WCb = p_WBc;
   penetration.nhat_BA_W = drake_normal;
@@ -195,11 +191,11 @@ shared_ptr<fcl::ShapeBased> CopyShapeOrThrow(
 }
 
 // Helper function that creates a *deep* copy of the given collision object.
-unique_ptr<fcl::CollisionObjectd> CopyFclObjectOrThrow(
-    const fcl::CollisionObjectd& object) {
+unique_ptr<CollisionObjectd> CopyFclObjectOrThrow(
+    const CollisionObjectd& object) {
   shared_ptr<fcl::ShapeBased> geometry_copy =
       CopyShapeOrThrow(*object.collisionGeometry());
-  auto copy = make_unique<fcl::CollisionObjectd>(geometry_copy);
+  auto copy = make_unique<CollisionObjectd>(geometry_copy);
   copy->setUserData(object.getUserData());
   copy->setTransform(object.getTransform());
   copy->computeAABB();
@@ -212,16 +208,16 @@ unique_ptr<fcl::CollisionObjectd> CopyFclObjectOrThrow(
 // to facilitate copying broadphase culling data structures (see
 // ProximityEngine::operator=()).
 void CopyFclObjectsOrThrow(
-    const std::vector<unique_ptr<fcl::CollisionObjectd>>& source_objects,
-    std::vector<unique_ptr<fcl::CollisionObjectd>>* target_objects,
-    std::unordered_map<const fcl::CollisionObjectd*, fcl::CollisionObjectd*>*
-        copy_map) {
+    const unordered_map<GeometryId, unique_ptr<CollisionObjectd>>&
+        source_objects,
+    unordered_map<GeometryId, unique_ptr<CollisionObjectd>>* target_objects,
+    std::unordered_map<const CollisionObjectd*, CollisionObjectd*>* copy_map) {
   DRAKE_ASSERT(target_objects->size() == 0);
-  target_objects->reserve(source_objects.size());
-  for (const unique_ptr<fcl::CollisionObjectd>& source_object :
-       source_objects) {
-    target_objects->emplace_back(CopyFclObjectOrThrow(*source_object));
-    copy_map->insert({source_object.get(), target_objects->back().get()});
+  for (const auto& source_id_object_pair : source_objects) {
+    const GeometryId source_id = source_id_object_pair.first;
+    const CollisionObjectd& source_object = *source_id_object_pair.second;
+    (*target_objects)[source_id] = CopyFclObjectOrThrow(source_object);
+    copy_map->insert({&source_object, (*target_objects)[source_id].get()});
   }
 }
 
@@ -230,10 +226,10 @@ void CopyFclObjectsOrThrow(
 // collision objects (the map populated by CopyFclObjectsOrThrow()).
 void BuildTreeFromReference(
     const fcl::DynamicAABBTreeCollisionManager<double>& other,
-    const std::unordered_map<const fcl::CollisionObjectd*,
-                             fcl::CollisionObjectd*>& copy_map,
+    const std::unordered_map<const CollisionObjectd*,
+                             CollisionObjectd*>& copy_map,
     fcl::DynamicAABBTreeCollisionManager<double>* target) {
-  std::vector<fcl::CollisionObjectd*> other_objects;
+  std::vector<CollisionObjectd*> other_objects;
   other.getObjects(other_objects);
   for (auto* other_object : other_objects) {
     target->registerObject(copy_map.at(other_object));
@@ -257,9 +253,8 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     anchored_tree_.clear();
     anchored_objects_.clear();
 
-    // Copy all of the geometry to ensure that the engine index values stay
-    // aligned.
-    std::unordered_map<const fcl::CollisionObjectd*, fcl::CollisionObjectd*>
+    // Copy all of the geometry.
+    std::unordered_map<const CollisionObjectd*, CollisionObjectd*>
         object_map;
     CopyFclObjectsOrThrow(other.anchored_objects_, &anchored_objects_,
                           &object_map);
@@ -284,9 +279,8 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     // TODO(SeanCurtis-TRI): When AutoDiff is fully supported in the internal
     // types, modify this map to the appropriate scalar and modify consuming
     // functions accordingly.
-    // Copy all of the geometry to ensure that the engine index values stay
-    // aligned.
-    std::unordered_map<const fcl::CollisionObjectd*, fcl::CollisionObjectd*>
+    // Copy all of the geometry.
+    std::unordered_map<const CollisionObjectd*, CollisionObjectd*>
         object_map;
     CopyFclObjectsOrThrow(anchored_objects_, &engine->anchored_objects_,
                           &object_map);
@@ -301,64 +295,41 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     return engine;
   }
 
-  ProximityIndex AddDynamicGeometry(const Shape& shape,
-                                    GeometryIndex index) {
+  void AddDynamicGeometry(const Shape& shape, GeometryId id) {
     // The collision object gets instantiated in the reification process and
     // placed in this unique pointer.
-    std::unique_ptr<fcl::CollisionObject<double>> fcl_object;
+    std::unique_ptr<CollisionObjectd> fcl_object;
     shape.Reify(this, &fcl_object);
     dynamic_tree_.registerObject(fcl_object.get());
-    ProximityIndex proximity_index(static_cast<int>(dynamic_objects_.size()));
-    // Encode the *global* pose index so that the geometry id can be looked up
-    // in the event of a collision.
-    EncodedData encoding(index, true /* is dynamic */);
+    EncodedData encoding(id, true /* is dynamic */);
     encoding.write_to(fcl_object.get());
-    dynamic_objects_.emplace_back(std::move(fcl_object));
+    dynamic_objects_[id] = std::move(fcl_object);
 
     collision_filter_.AddGeometry(encoding.encoding());
-
-    return proximity_index;
   }
 
-  ProximityIndex AddAnchoredGeometry(const Shape& shape,
-                                     const Isometry3<double>& X_WG,
-                                     GeometryIndex index) {
+  void AddAnchoredGeometry(const Shape& shape, const Isometry3<double>& X_WG,
+                           GeometryId id) {
     // The collision object gets instantiated in the reification process and
     // placed in this unique pointer.
-    std::unique_ptr<fcl::CollisionObject<double>> fcl_object;
+    std::unique_ptr<CollisionObjectd> fcl_object;
     shape.Reify(this, &fcl_object);
     fcl_object->setTransform(X_WG);
     fcl_object->computeAABB();
     anchored_tree_.registerObject(fcl_object.get());
     anchored_tree_.update();
-    ProximityIndex proximity_index(static_cast<int>(anchored_objects_.size()));
-    EncodedData encoding(index, false /* is dynamic */);
+    EncodedData encoding(id, false /* is dynamic */);
     encoding.write_to(fcl_object.get());
-    anchored_objects_.emplace_back(std::move(fcl_object));
+    anchored_objects_[id] = std::move(fcl_object);
 
     collision_filter_.AddGeometry(encoding.encoding());
-
-    return proximity_index;
   }
 
-  void UpdateGeometryIndex(ProximityIndex proximity_index, bool is_dynamic,
-                           GeometryIndex geometry_index) {
-    fcl::CollisionObject<double>& object = is_dynamic ?
-        *dynamic_objects_[proximity_index] :
-        *anchored_objects_[proximity_index];
-    EncodedData old_data(object);
-
-    EncodedData new_data(geometry_index, is_dynamic);
-    new_data.write_to(&object);
-    collision_filter_.UpdateEncoding(old_data.encoding(), new_data.encoding());
-  }
-
-  optional<GeometryIndex> RemoveGeometry(ProximityIndex index,
-                                         bool is_dynamic) {
+  void RemoveGeometry(GeometryId id, bool is_dynamic) {
     if (is_dynamic) {
-      return RemoveGeometry(index, &dynamic_tree_, &dynamic_objects_);
+      RemoveGeometry(id, &dynamic_tree_, &dynamic_objects_);
     } else {
-      return RemoveGeometry(index, &anchored_tree_, &anchored_objects_);
+      RemoveGeometry(id, &anchored_tree_, &anchored_objects_);
     }
   }
 
@@ -380,14 +351,15 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
   //  1. I could make this move semantics (or swap semantics).
   //  2. I could simply have a method that returns a mutable reference to such
   //    a vector and the caller sets values there directly.
-  void UpdateWorldPoses(const std::vector<Isometry3<T>>& X_WG,
-                        const std::vector<GeometryIndex>& indices) {
-    DRAKE_DEMAND(indices.size() == dynamic_objects_.size());
-    for (size_t i = 0; i < indices.size(); ++i) {
+  void UpdateWorldPoses(
+      const std::unordered_map<GeometryId, Isometry3<T>>& X_WGs) {
+    for (const auto& id_object_pair : dynamic_objects_) {
+      const GeometryId id = id_object_pair.first;
+      const Isometry3<T>& X_WG = X_WGs.at(id);
       // The FCL broadphase requires double-valued poses; so we use ADL to
       // efficiently get double-valued poses out of arbitrary T-valued poses.
-      dynamic_objects_[i]->setTransform(convert_to_double(X_WG[indices[i]]));
-      dynamic_objects_[i]->computeAABB();
+      dynamic_objects_[id]->setTransform(convert_to_double(X_WG));
+      dynamic_objects_[id]->computeAABB();
     }
     dynamic_tree_.update();
   }
@@ -556,12 +528,12 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
   }
 
   std::vector<SignedDistancePair<T>> ComputeSignedDistancePairwiseClosestPoints(
-      const std::vector<GeometryId>& geometry_map,
-      const std::vector<Isometry3<T>>& X_WGs, const double max_distance) const {
+      const std::unordered_map<GeometryId, Isometry3<T>>& X_WGs,
+      const double max_distance) const {
     std::vector<SignedDistancePair<T>> witness_pairs;
     // All these quantities are aliased in the callback data.
-    shape_distance::CallbackData<T> data{&geometry_map, &collision_filter_,
-                                         &X_WGs, max_distance, &witness_pairs};
+    shape_distance::CallbackData<T> data{&collision_filter_, &X_WGs,
+                                         max_distance, &witness_pairs};
     data.request.enable_nearest_points = true;
     data.request.enable_signed_distance = true;
     data.request.gjk_solver_type = fcl::GJKSolverType::GST_LIBCCD;
@@ -577,13 +549,12 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
 
   std::vector<SignedDistanceToPoint<T>> ComputeSignedDistanceToPoint(
       const Vector3<T>& p_WQ,
-      const std::vector<GeometryId>& geometry_map,
-      const std::vector<Isometry3<T>>& X_WGs,
+      const std::unordered_map<GeometryId, Isometry3<T>>& X_WGs,
       const double threshold) const {
     // We create a sphere of zero radius centered at the query point and put
-    // it into a fcl::CollisionObject.
+    // it into a CollisionObject.
     auto fcl_sphere = make_shared<fcl::Sphered>(0.0);  // sphere of zero radius
-    fcl::CollisionObjectd query_point(fcl_sphere);
+    CollisionObjectd query_point(fcl_sphere);
     // The FCL broadphase requires double-valued poses; so we use ADL to
     // efficiently get double-valued poses out of arbitrary T-valued poses.
     query_point.setTranslation(convert_to_double(p_WQ));
@@ -592,7 +563,7 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     std::vector<SignedDistanceToPoint<T>> distances;
 
     point_distance::CallbackData<T> data{
-        &query_point, &geometry_map, threshold, p_WQ, &X_WGs, &distances};
+        &query_point, threshold, p_WQ, &X_WGs, &distances};
 
     anchored_tree_.distance(&query_point, &data, point_distance::Callback<T>);
     dynamic_tree_.distance(&query_point, &data, point_distance::Callback<T>);
@@ -600,11 +571,11 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     return distances;
   }
 
-  std::vector<PenetrationAsPointPair<double>> ComputePointPairPenetration(
-      const std::vector<GeometryId>& geometry_map) const {
+  std::vector<PenetrationAsPointPair<double>> ComputePointPairPenetration()
+      const {
     std::vector<PenetrationAsPointPair<double>> contacts;
     // CollisionData stores references to the provided data structures.
-    CollisionData collision_data{&geometry_map, &collision_filter_};
+    CollisionData collision_data{&collision_filter_};
     collision_data.contacts = &contacts;
     collision_data.request.num_max_contacts = 1;
     collision_data.request.enable_contact = true;
@@ -631,12 +602,10 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     return contacts;
   }
 
-  std::vector<SortedPair<GeometryId>> FindCollisionCandidates(
-      const std::vector<GeometryId>& geometry_map) const {
+  std::vector<SortedPair<GeometryId>> FindCollisionCandidates() const {
     std::vector<SortedPair<GeometryId>> pairs;
     // All these quantities are aliased in the callback data.
-    find_collision_candidates::CallbackData data{&geometry_map,
-                                                 &collision_filter_, &pairs};
+    find_collision_candidates::CallbackData data{&collision_filter_, &pairs};
     dynamic_tree_.collide(&data, find_collision_candidates::Callback);
     dynamic_tree_.collide(
         const_cast<fcl::DynamicAABBTreeCollisionManager<double>*>(
@@ -647,8 +616,8 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
 
   // TODO(SeanCurtis-TRI): Update this with the new collision filter method.
   void ExcludeCollisionsWithin(
-      const std::unordered_set<GeometryIndex>& dynamic,
-      const std::unordered_set<GeometryIndex>& anchored) {
+      const std::unordered_set<GeometryId>& dynamic,
+      const std::unordered_set<GeometryId>& anchored) {
     // Preventing collision between members in a single set is simple: assign
     // every geometry to the same clique.
 
@@ -665,22 +634,22 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
 
     if (dynamic.size() > 1 || (dynamic.size() > 0 && anchored.size() > 0)) {
       int clique = collision_filter_.next_clique_id();
-      for (auto index : dynamic) {
-        EncodedData encoding(index, true /* is dynamic */);
+      for (auto id : dynamic) {
+        EncodedData encoding(id, true /* is dynamic */);
         collision_filter_.AddToCollisionClique(encoding.encoding(), clique);
       }
-      for (auto index : anchored) {
-        EncodedData encoding(index, false /* is dynamic */);
+      for (auto id : anchored) {
+        EncodedData encoding(id, false /* is dynamic */);
         collision_filter_.AddToCollisionClique(encoding.encoding(), clique);
       }
     }
   }
 
   void ExcludeCollisionsBetween(
-      const std::unordered_set<GeometryIndex>& dynamic1,
-      const std::unordered_set<GeometryIndex>& anchored1,
-      const std::unordered_set<GeometryIndex>& dynamic2,
-      const std::unordered_set<GeometryIndex>& anchored2) {
+      const std::unordered_set<GeometryId>& dynamic1,
+      const std::unordered_set<GeometryId>& anchored1,
+      const std::unordered_set<GeometryId>& dynamic2,
+      const std::unordered_set<GeometryId>& anchored2) {
     // TODO(SeanCurtis-TRI): Update this with the new collision filter method.
 
     // NOTE: This is a brute-force implementation. It does not claim to be
@@ -731,20 +700,20 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     }
   }
 
-  bool CollisionFiltered(GeometryIndex index1, bool is_dynamic_1,
-                         GeometryIndex index2, bool is_dynamic_2) const {
+  bool CollisionFiltered(GeometryId id1, bool is_dynamic_1,
+                         GeometryId id2, bool is_dynamic_2) const {
     // Collisions between anchored geometries are implicitly filtered.
     if (!is_dynamic_1 && !is_dynamic_2) return true;
-    EncodedData encoding1(index1, is_dynamic_1);
-    EncodedData encoding2(index2, is_dynamic_2);
+    EncodedData encoding1(id1, is_dynamic_1);
+    EncodedData encoding2(id2, is_dynamic_2);
     return !collision_filter_.CanCollideWith(encoding1.encoding(),
                                              encoding2.encoding());
   }
 
   int get_next_clique() { return collision_filter_.next_clique_id(); }
 
-  void set_clique(GeometryIndex index, int clique) {
-    EncodedData encoding(index, true /* is dynamic */);
+  void set_clique(GeometryId id, int clique) {
+    EncodedData encoding(id, true /* is dynamic */);
     collision_filter_.AddToCollisionClique(encoding.encoding(), clique);
   }
 
@@ -756,8 +725,8 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
       // "identical" data. The test isn't exhaustive (for example, the
       // parameters of the particular geometric shape are not compared--instead,
       // we compare the AABBs).
-      auto ValidateObject = [](const fcl::CollisionObject<double>& test,
-                               const fcl::CollisionObject<double>& ref) {
+      auto ValidateObject = [](const CollisionObjectd& test,
+                               const CollisionObjectd& ref) {
         return test.getUserData() == ref.getUserData() && &test != &ref &&
                test.getNodeType() == ref.getNodeType() &&
                test.getObjectType() == ref.getObjectType() &&
@@ -773,18 +742,18 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
           is_copy &&
           this->anchored_objects_.size() == other.anchored_objects_.size();
       if (is_copy) {
-        for (size_t i = 0; i < this->dynamic_objects_.size(); ++i) {
-          const fcl::CollisionObject<double>& test_object =
-              *this->dynamic_objects_.at(i);
-          const fcl::CollisionObject<double>& ref_object =
-              *other.dynamic_objects_.at(i);
+        for (const auto& id_object_pair : this->dynamic_objects_) {
+          const GeometryId test_id = id_object_pair.first;
+          const CollisionObjectd& test_object = *id_object_pair.second;
+          const CollisionObjectd& ref_object =
+              *other.dynamic_objects_.at(test_id);
           is_copy = is_copy && ValidateObject(test_object, ref_object);
         }
-        for (size_t i = 0; i < this->anchored_objects_.size(); ++i) {
-          const fcl::CollisionObject<double>& test_object =
-              *this->anchored_objects_.at(i);
-          const fcl::CollisionObject<double>& ref_object =
-              *other.anchored_objects_.at(i);
+        for (const auto& id_object_pair : this->anchored_objects_) {
+          const GeometryId test_id = id_object_pair.first;
+          const CollisionObjectd& test_object = *id_object_pair.second;
+          const CollisionObjectd& ref_object =
+              *other.anchored_objects_.at(test_id);
           is_copy = is_copy && ValidateObject(test_object, ref_object);
         }
       }
@@ -796,20 +765,12 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
 
   int peek_next_clique() const { return collision_filter_.peek_next_clique(); }
 
-  const Isometry3<double>& GetX_WG(ProximityIndex index,
+  const Isometry3<double>& GetX_WG(GeometryId id,
                                    bool is_dynamic) const {
     if (is_dynamic) {
-      return dynamic_objects_[index]->getTransform();
+      return dynamic_objects_.at(id)->getTransform();
     } else {
-      return anchored_objects_[index]->getTransform();
-    }
-  }
-
-  GeometryIndex GetGeometryIndex(ProximityIndex index, bool is_dynamic) const {
-    if (is_dynamic) {
-      return EncodedData(*dynamic_objects_[index]).index();
-    } else {
-      return EncodedData(*anchored_objects_[index]).index();
+      return anchored_objects_.at(id)->getTransform();
     }
   }
 
@@ -819,35 +780,21 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
   template <typename>
   friend class ProximityEngine;
 
-  // Removes the geometry with the given proximity index from the given tree. It
-  // potentially moves another object to take its slot in the vector of objects
-  // to maintain a contiguous memory block.
-  optional<GeometryIndex> RemoveGeometry(
-      ProximityIndex index, fcl::DynamicAABBTreeCollisionManager<double>* tree,
-      std::vector<std::unique_ptr<fcl::CollisionObject<double>>>* geometries) {
-    std::vector<unique_ptr<fcl::CollisionObject<double>>>& typed_geometries =
+  // Removes the geometry with the given id from the given tree.
+  void RemoveGeometry(
+      GeometryId id, fcl::DynamicAABBTreeCollisionManager<double>* tree,
+      unordered_map<GeometryId, unique_ptr<CollisionObjectd>>* geometries) {
+    unordered_map<GeometryId, unique_ptr<CollisionObjectd>>& typed_geometries =
         *geometries;
-    fcl::CollisionObjectd* fcl_object = typed_geometries[index].get();
+    CollisionObjectd* fcl_object = typed_geometries.at(id).get();
     const size_t old_size = tree->size();
     tree->unregisterObject(fcl_object);
     EncodedData filter_key(*fcl_object);
     collision_filter_.RemoveGeometry(filter_key.encoding());
+    typed_geometries.erase(id);
     // NOTE: The FCL API provides no other mechanism for confirming the
     // unregistration was successful.
     DRAKE_DEMAND(old_size == tree->size() + 1);
-    optional<GeometryIndex> moved{};
-    DRAKE_DEMAND(typed_geometries.size() > 0);
-    const size_t last = typed_geometries.size() - 1;
-    if (index < last) {
-      // Removed geometry that *isn't* the last in the geometries. Swap last
-      // into empty slot.
-      const fcl::CollisionObjectd* move_object = typed_geometries[last].get();
-      EncodedData encoding(*move_object);
-      moved = encoding.index();
-      typed_geometries[index].swap(typed_geometries.back());
-    }
-    typed_geometries.pop_back();
-    return moved;
   }
 
   // TODO(SeanCurtis-TRI): Convert these to scalar type T when I know how to
@@ -861,27 +808,23 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
   void TakeShapeOwnership(const std::shared_ptr<fcl::ShapeBased>& shape,
                           void* data) {
     DRAKE_ASSERT(data != nullptr);
-    std::unique_ptr<fcl::CollisionObject<double>>& fcl_object_ptr =
-        *reinterpret_cast<std::unique_ptr<fcl::CollisionObject<double>>*>(data);
-    fcl_object_ptr = make_unique<fcl::CollisionObject<double>>(shape);
+    std::unique_ptr<CollisionObjectd>& fcl_object_ptr =
+        *reinterpret_cast<std::unique_ptr<CollisionObjectd>*>(data);
+    fcl_object_ptr = make_unique<CollisionObjectd>(shape);
   }
 
   // The BVH of all dynamic geometries; this depends on *all* inputs.
   // TODO(SeanCurtis-TRI): Ultimately, this should probably be a cache entry.
   fcl::DynamicAABBTreeCollisionManager<double> dynamic_tree_;
 
-  // All of the *dynamic* collision elements (spanning all sources). Their
-  // GeometryIndex maps to their position in *this* vector.
-  // TODO(SeanCurtis-TRI): Cluster the geometries on source such that each
-  // source owns a _contiguous_ block of engine indices.
-  std::vector<std::unique_ptr<fcl::CollisionObject<double>>> dynamic_objects_;
+  // All of the *dynamic* collision elements (spanning all sources).
+  unordered_map<GeometryId, unique_ptr<CollisionObjectd>> dynamic_objects_;
 
   // The tree containing all of the anchored geometry.
   fcl::DynamicAABBTreeCollisionManager<double> anchored_tree_;
 
-  // All of the *anchored* collision elements (spanning *all* sources). Their
-  // AnchoredGeometryIndex maps to their position in *this* vector.
-  std::vector<std::unique_ptr<fcl::CollisionObject<double>>> anchored_objects_;
+  // All of the *anchored* collision elements (spanning *all* sources).
+  unordered_map<GeometryId, unique_ptr<CollisionObjectd>> anchored_objects_;
 
   // The mechanism for dictating collision filtering.
   CollisionFilterLegacy collision_filter_;
@@ -933,28 +876,20 @@ ProximityEngine<T>& ProximityEngine<T>::operator=(
 }
 
 template <typename T>
-ProximityIndex ProximityEngine<T>::AddDynamicGeometry(
-    const Shape& shape, GeometryIndex index) {
-  return impl_->AddDynamicGeometry(shape, index);
+void ProximityEngine<T>::AddDynamicGeometry(
+    const Shape& shape, GeometryId id) {
+  impl_->AddDynamicGeometry(shape, id);
 }
 
 template <typename T>
-ProximityIndex ProximityEngine<T>::AddAnchoredGeometry(
-    const Shape& shape, const Isometry3<double>& X_WG, GeometryIndex index) {
-  return impl_->AddAnchoredGeometry(shape, X_WG, index);
+void ProximityEngine<T>::AddAnchoredGeometry(
+    const Shape& shape, const Isometry3<double>& X_WG, GeometryId id) {
+  impl_->AddAnchoredGeometry(shape, X_WG, id);
 }
 
 template <typename T>
-void ProximityEngine<T>::UpdateGeometryIndex(ProximityIndex proximity_index,
-                                             bool is_dynamic,
-                                             GeometryIndex geometry_index) {
-  impl_->UpdateGeometryIndex(proximity_index, is_dynamic, geometry_index);
-}
-
-template <typename T>
-optional<GeometryIndex> ProximityEngine<T>::RemoveGeometry(
-    ProximityIndex index, bool is_dynamic) {
-  return impl_->RemoveGeometry(index, is_dynamic);
+void ProximityEngine<T>::RemoveGeometry(GeometryId id, bool is_dynamic) {
+  impl_->RemoveGeometry(id, is_dynamic);
 }
 
 template <typename T>
@@ -991,71 +926,67 @@ std::unique_ptr<ProximityEngine<AutoDiffXd>> ProximityEngine<T>::ToAutoDiffXd()
 
 template <typename T>
 void ProximityEngine<T>::UpdateWorldPoses(
-    const std::vector<Isometry3<T>>& X_WG,
-    const std::vector<GeometryIndex>& indices) {
-  impl_->UpdateWorldPoses(X_WG, indices);
+    const unordered_map<GeometryId, Isometry3<T>>& X_WGs) {
+  impl_->UpdateWorldPoses(X_WGs);
 }
 
 template <typename T>
 std::vector<SignedDistancePair<T>>
 ProximityEngine<T>::ComputeSignedDistancePairwiseClosestPoints(
-    const std::vector<GeometryId>& geometry_map,
-    const std::vector<Isometry3<T>>& X_WGs,
+    const std::unordered_map<GeometryId, Isometry3<T>>& X_WGs,
     const double max_distance) const {
-  return impl_->ComputeSignedDistancePairwiseClosestPoints(geometry_map, X_WGs,
-                                                           max_distance);
+  return impl_->ComputeSignedDistancePairwiseClosestPoints(X_WGs, max_distance);
 }
 
 template <typename T>
 std::vector<SignedDistanceToPoint<T>>
 ProximityEngine<T>::ComputeSignedDistanceToPoint(
-    const Vector3<T>& query, const std::vector<GeometryId>& geometry_map,
-    const std::vector<Isometry3<T>>& X_WGs, const double threshold) const {
-  return impl_->ComputeSignedDistanceToPoint(query, geometry_map, X_WGs,
-                                             threshold);
+    const Vector3<T>& query,
+    const std::unordered_map<GeometryId, Isometry3<T>>& X_WGs,
+    const double threshold) const {
+  return impl_->ComputeSignedDistanceToPoint(query, X_WGs, threshold);
 }
 
 template <typename T>
 std::vector<PenetrationAsPointPair<double>>
-ProximityEngine<T>::ComputePointPairPenetration(
-    const std::vector<GeometryId>& geometry_map) const {
-  return impl_->ComputePointPairPenetration(geometry_map);
+ProximityEngine<T>::ComputePointPairPenetration() const {
+  return impl_->ComputePointPairPenetration();
 }
 
 template <typename T>
-std::vector<ContactSurface<T>> ProximityEngine<T>::ComputeContactSurfaces(
-    const std::vector<GeometryId>& /* geometry_map */) const {
+std::vector<ContactSurface<T>> ProximityEngine<T>::ComputeContactSurfaces()
+    const {
   throw std::runtime_error("ComputeContactSurfaces() is not implemented yet.");
   // TODO(DamrongGuoy): Compute contact surfaces and remove the above throw.
 }
 
 template <typename T>
-std::vector<SortedPair<GeometryId>> ProximityEngine<T>::FindCollisionCandidates(
-    const std::vector<GeometryId>& geometry_map) const {
-  return impl_->FindCollisionCandidates(geometry_map);
+std::vector<SortedPair<GeometryId>>
+ProximityEngine<T>::FindCollisionCandidates() const {
+  return impl_->FindCollisionCandidates();
 }
 
 template <typename T>
 void ProximityEngine<T>::ExcludeCollisionsWithin(
-    const std::unordered_set<GeometryIndex>& dynamic,
-    const std::unordered_set<GeometryIndex>& anchored) {
+    const std::unordered_set<GeometryId>& dynamic,
+    const std::unordered_set<GeometryId>& anchored) {
   impl_->ExcludeCollisionsWithin(dynamic, anchored);
 }
 
 template <typename T>
 void ProximityEngine<T>::ExcludeCollisionsBetween(
-    const std::unordered_set<GeometryIndex>& dynamic1,
-    const std::unordered_set<GeometryIndex>& anchored1,
-    const std::unordered_set<GeometryIndex>& dynamic2,
-    const std::unordered_set<GeometryIndex>& anchored2) {
+    const std::unordered_set<GeometryId>& dynamic1,
+    const std::unordered_set<GeometryId>& anchored1,
+    const std::unordered_set<GeometryId>& dynamic2,
+    const std::unordered_set<GeometryId>& anchored2) {
   impl_->ExcludeCollisionsBetween(dynamic1, anchored1, dynamic2, anchored2);
 }
 
 template <typename T>
 bool ProximityEngine<T>::CollisionFiltered(
-    GeometryIndex index1, bool is_dynamic_1,
-    GeometryIndex index2, bool is_dynamic_2) const {
-  return impl_->CollisionFiltered(index1, is_dynamic_1, index2, is_dynamic_2);
+    GeometryId id1, bool is_dynamic_1,
+    GeometryId id2, bool is_dynamic_2) const {
+  return impl_->CollisionFiltered(id1, is_dynamic_1, id2, is_dynamic_2);
 }
 
 // Client-attorney interface for GeometryState to manipulate collision filters.
@@ -1066,8 +997,8 @@ int ProximityEngine<T>::get_next_clique() {
 }
 
 template <typename T>
-void ProximityEngine<T>::set_clique(GeometryIndex index, int clique) {
-  impl_->set_clique(index, clique);
+void ProximityEngine<T>::set_clique(GeometryId id, int clique) {
+  impl_->set_clique(id, clique);
 }
 
 // Testing utilities
@@ -1083,15 +1014,9 @@ int ProximityEngine<T>::peek_next_clique() const {
 }
 
 template <typename T>
-const Isometry3<double>& ProximityEngine<T>::GetX_WG(ProximityIndex index,
+const Isometry3<double>& ProximityEngine<T>::GetX_WG(GeometryId id,
                                                      bool is_dynamic) const {
-  return impl_->GetX_WG(index, is_dynamic);
-}
-
-template <typename T>
-GeometryIndex ProximityEngine<T>::GetGeometryIndex(ProximityIndex index,
-                                                   bool is_dynamic) const {
-  return impl_->GetGeometryIndex(index, is_dynamic);
+  return impl_->GetX_WG(id, is_dynamic);
 }
 
 }  // namespace internal

--- a/geometry/proximity_engine.h
+++ b/geometry/proximity_engine.h
@@ -2,6 +2,7 @@
 
 #include <limits>
 #include <memory>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -9,7 +10,6 @@
 #include "drake/common/drake_optional.h"
 #include "drake/common/sorted_pair.h"
 #include "drake/geometry/geometry_ids.h"
-#include "drake/geometry/geometry_index.h"
 #include "drake/geometry/query_results/contact_surface.h"
 #include "drake/geometry/query_results/penetration_as_point_pair.h"
 #include "drake/geometry/query_results/signed_distance_pair.h"
@@ -82,39 +82,26 @@ class ProximityEngine {
 
   /** Adds the given `shape` to the engine's _dynamic_ geometry.
    @param shape   The shape to add.
-   @param index   The index of the geometry in SceneGraph to which this shape
-                  belongs.
-   @returns the index of the added shape in the proximity engine.  */
-  ProximityIndex AddDynamicGeometry(const Shape& shape, GeometryIndex index);
+   @param id      The id of the geometry in SceneGraph to which this shape
+                  belongs.  */
+  void AddDynamicGeometry(const Shape& shape, GeometryId id);
 
   /** Adds the given `shape` to the engine's _anchored_ geometry.
    @param shape   The shape to add.
    @param X_WG    The pose of the shape in the world frame.
-   @param index   The index of the geometry in SceneGraph to which this shape
-                  belongs.
-   @returns the index of the added shape in the proximity engine.  */
-  ProximityIndex AddAnchoredGeometry(const Shape& shape,
-                                     const Isometry3<double>& X_WG,
-                                     GeometryIndex index);
+   @param id      The id of the geometry in SceneGraph to which this shape
+                  belongs.  */
+  void AddAnchoredGeometry(const Shape& shape, const Isometry3<double>& X_WG,
+                           GeometryId id);
 
-  /** Informs the proximity engine that the geometry at `proximity_index` has
-   moved in the GeometryState storage (i.e., it's GeometryIndex has changed).
-   @param proximity_index   The index of the geometry.
-   @param is_dynamic        True if the geometry is dynamic (false if anchored).
-   @param geometry_index    The new _GeometryIndex_ for the geometry.  */
-  void UpdateGeometryIndex(ProximityIndex proximity_index, bool is_dynamic,
-                           GeometryIndex geometry_index);
-
-  /** Removes the given geometry indicated by `index` from the engine. Returns
-   the index of the geometry that was moved into this newly cleared index
-   position to maintain contiguous indices.
-   @param index       The proximity index of the geometry to be removed.
+  // TODO(SeanCurtis-TRI): Decide if knowing whether something is dynamic or not
+  //  is *actually* sufficiently helpful to justify this act.
+  /** Removes the given geometry indicated by `id` from the engine.
+   @param id          The id of the geometry to be removed.
    @param is_dynamic  True if the geometry is dynamic, false if anchored.
-   @returns The GeometryIndex of the geometry that was moved into this index
-            or nullopt if no geometry was moved.
-   @pre the index is valid value.
+   @throws std::logic_error if `id` does not refer to a geometry in this engine.
   */
-  optional<GeometryIndex> RemoveGeometry(ProximityIndex index, bool is_dynamic);
+  void RemoveGeometry(GeometryId id, bool is_dynamic);
 
   /** Reports the _total_ number of geometries in the engine -- dynamic and
    anchored (spanning all sources).  */
@@ -137,61 +124,55 @@ class ProximityEngine {
 
   //@}
 
-  /** Updates the poses for all of the dynamic geometries in the engine. It
-   is an invariant that _every_ registered dynamic geometry, across _all_
-   geometry sources, with a proximity role has a _unique_ index that lies in the
-   range [0, num_dynamic() - 1]. `indices.size()` should be equal to
-   num_dynamic() and any other length will cause program failure.
-   @param X_WG      The poses of each geometry `G` measured and expressed in the
+  /** Updates the poses for all of the _dynamic_ geometries in the engine.
+   @param X_WGs     The poses of each geometry `G` measured and expressed in the
                     world frame `W` (including geometries which may *not* be
-                    registered with the proximity engine).
-   @param indices   Indices into `X_WG` mapping engine index to geometry index.
+                    registered with the proximity engine or may not be
+                    dynamic).
   */
   // TODO(SeanCurtis-TRI): I could do things here differently a number of ways:
   //  1. I could make this move semantics (or swap semantics).
   //  2. I could simply have a method that returns a mutable reference to such
   //    a vector and the caller sets values there directly.
-  void UpdateWorldPoses(const std::vector<Isometry3<T>>& X_WG,
-                        const std::vector<GeometryIndex>& indices);
+  void UpdateWorldPoses(
+      const std::unordered_map<GeometryId, Isometry3<T>>& X_WGs);
 
   // ----------------------------------------------------------------------
   /**@name              Signed Distance Queries
   See @ref signed_distance_query "Signed Distance Query" for more details.  */
 
   //@{
+  // TODO(SeanCurtis-TRI): Remove this documentation in favor of a link to the
+  // public API.
   // NOTE: This maps to Model::ClosestPointsAllToAll().
-  /** Determines all the closest points between any pair of bodies/elements.
-   This function returns the _signed_ distance between all _valid_ pairs of
-   geometries. A valid pair consists of either two dynamic geometries or a
-   dynamic geometry and an anchored geometry. It _never_ includes two anchored
-   geometries. The order and size of the returned vector are invariant
-   when the poses of the objects are changed.
+  /** Determines the closest points between "all" pairs of bodies/elements. In
+   this case, for a signed distance to be reported for geometry pair (A, B):
 
-   @param[in] geometry_map    A map from geometry _index_ to the corresponding
-                              global geometry identifier.
-   @param[in] X_WGs           The pose of all geometries in world, indexed by
-                              each geometry's GeometryIndex.
+     - A and B cannot both be anchored.
+     - The pair (A, B) cannot be marked as filtered.
+     - The distance between A and B must be less than `max_distance`.
+
+   For a geometry pair (A, B), the returned results will always be reported in
+   a fixed order (e.g., always (A, B) and never (B, A)). The _basis_ for the
+   ordering is arbitrary (and therefore undocumented), but guaranteed to be
+   fixed and repeatable.
+
+   @param[in] X_WGs           The pose of all geometries in World, keyed on
+                              each geometry's GeometryId.
    @param[in] max_distance    The maximum distance between objects such that
                               they will be included in the results.
    @returns  A vector populated with per-object-pair signed distance values (and
-             supporting data). All reported pairs will have a distance <=
-             `max_distance`. Note: For a geometry pair (A, B), the supporting
-             data will always be reported in a fixed order (e.g., always (A, B)
-             and never (B, A)). The _basis_ for the ordering is arbitrary (and
-             therefore undocumented), but guaranteed to be fixed and repeatable.
+             supporting data).
    */
   std::vector<SignedDistancePair<T>>
   ComputeSignedDistancePairwiseClosestPoints(
-      const std::vector<GeometryId>& geometry_map,
-      const std::vector<Isometry3<T>>& X_WGs,
+      const std::unordered_map<GeometryId, Isometry3<T>>& X_WGs,
       const double max_distance) const;
 
   /** Performs work in support of GeometryState::ComputeSignedDistanceToPoint().
    @param[in] p_WQ            Position of a query point Q in world frame W.
-   @param[in] geometry_map    A map from geometry _index_ to the corresponding
-                              global geometry identifier.
-   @param[in] X_WGs           The pose of all geometries in world, indexed by
-                              each geometry's GeometryIndex.
+   @param[in] X_WGs           The pose of all geometries in world, keyed by
+                              each geometry's GeometryId.
    @param[in] threshold       Ignore any object beyond this distance.
    @retval signed_distances   A vector populated with per-object signed
                               distance and gradient vector.
@@ -200,8 +181,7 @@ class ProximityEngine {
   std::vector<SignedDistanceToPoint<T>>
   ComputeSignedDistanceToPoint(
       const Vector3<T>& p_WQ,
-      const std::vector<GeometryId>& geometry_map,
-      const std::vector<Isometry3<T>>& X_WGs,
+      const std::unordered_map<GeometryId, Isometry3<T>>& X_WGs,
       const double threshold = std::numeric_limits<double>::infinity()) const;
   //@}
 
@@ -244,12 +224,10 @@ class ProximityEngine {
    For two penetrating geometries g_A and g_B, it is guaranteed that they will
    map to `id_A` and `id_B` in a fixed, repeatable manner.
 
-   @param[in]   geometry_map  A map from geometry _index_ to the corresponding
-                              global geometry identifier.
    @returns A vector populated with all detected penetrations characterized as
             point pairs.  */
-  std::vector<PenetrationAsPointPair<double>> ComputePointPairPenetration(
-      const std::vector<GeometryId>& geometry_map) const;
+  std::vector<PenetrationAsPointPair<double>> ComputePointPairPenetration()
+      const;
 
   /**
    Computes the intersections across all pairs of geometries in the world with
@@ -259,12 +237,9 @@ class ProximityEngine {
    map to `id_A` and `id_B` in a fixed, repeatable manner, where `id_A` and
    `id_B` are GeometryId's of geometries g_A and g_B respectively.
 
-   @param[in] geometry_map    A map from geometry _index_ to the corresponding
-                              global geometry identifier.
    @returns A vector populated with all detected intersections characterized as
             contact surfaces.  */
-  std::vector<ContactSurface<T>> ComputeContactSurfaces(
-      const std::vector<GeometryId>& /* geometry_map */) const;
+  std::vector<ContactSurface<T>> ComputeContactSurfaces() const;
 
   //@}
 
@@ -273,8 +248,7 @@ class ProximityEngine {
    candidates. A pair in the returned set is not necessarily in contact, and
    further analysis must be done to confirm contact. A pair of geometries not
    present in the result is guaranteed not to be in contact.  */
-  std::vector<SortedPair<GeometryId>> FindCollisionCandidates(
-      const std::vector<GeometryId>& geometry_map) const;
+  std::vector<SortedPair<GeometryId>> FindCollisionCandidates() const;
 
   /** @name               Collision filters
 
@@ -289,14 +263,14 @@ class ProximityEngine {
   /** Excludes geometry pairs from collision evaluation by updating the
    candidate pair set `C = C - P`, where `P = {(gᵢ, gⱼ)}, ∀ gᵢ, gⱼ ∈ G` and
    `G = dynamic ⋃ anchored = {g₀, g₁, ..., gₙ}`.
-   @param[in]   dynamic     The set of geometry indices for _dynamic_ geometries
+   @param[in]   dynamic     The set of geometry ids for _dynamic_ geometries
                             for which no collisions can be reported.
-   @param[in]   anchored    The set of geometry indices for _anchored_
+   @param[in]   anchored    The set of geometry ids for _anchored_
                             geometries for which no collisions can be reported.
   */
   void ExcludeCollisionsWithin(
-      const std::unordered_set<GeometryIndex>& dynamic,
-      const std::unordered_set<GeometryIndex>& anchored);
+      const std::unordered_set<GeometryId>& dynamic,
+      const std::unordered_set<GeometryId>& anchored);
 
   /** Excludes geometry pairs from collision evaluation by updating the
    candidate pair set `C = C - P`, where `P = {(a, b)}, ∀ a ∈ A, b ∈ B` and
@@ -304,15 +278,15 @@ class ProximityEngine {
    `B = dynamic2 ⋃ anchored2 = {b₀, b₁, ..., bₙ}`. This does _not_
    preclude collisions between members of the _same_ set.   */
   void ExcludeCollisionsBetween(
-      const std::unordered_set<GeometryIndex>& dynamic1,
-      const std::unordered_set<GeometryIndex>& anchored1,
-      const std::unordered_set<GeometryIndex>& dynamic2,
-      const std::unordered_set<GeometryIndex>& anchored2);
+      const std::unordered_set<GeometryId>& dynamic1,
+      const std::unordered_set<GeometryId>& anchored1,
+      const std::unordered_set<GeometryId>& dynamic2,
+      const std::unordered_set<GeometryId>& anchored2);
 
-  /** Reports true if the geometry pair (index1, index2) has been filtered from
+  /** Reports true if the geometry pair (id1, id2) has been filtered from
    collision.  */
-  bool CollisionFiltered(GeometryIndex index1, bool is_dynamic_1,
-                         GeometryIndex index2, bool is_dynamic_2) const;
+  bool CollisionFiltered(GeometryId id1, bool is_dynamic_1,
+                         GeometryId id2, bool is_dynamic_2) const;
   //@}
 
  private:
@@ -322,10 +296,10 @@ class ProximityEngine {
   // Retrieves the next available clique.
   int get_next_clique();
 
-  // Assigns the given clique to the dynamic geometry indicated by `index`.
+  // Assigns the given clique to the geometry indicated by `id`.
   // This is exposed via the GeometryStateCollisionFilterAttorney to allow
   // GeometryState to set up cliques between sibling geometries.
-  void set_clique(GeometryIndex index, int clique);
+  void set_clique(GeometryId id, int clique);
 
   ////////////////////////////////////////////////////////////////////////////
 
@@ -340,11 +314,8 @@ class ProximityEngine {
   // Reveals what the next generated clique will be (without changing it).
   int peek_next_clique() const;
 
-  // Reports the pose (X_WG) of the geometry at the given index.
-  const Isometry3<double>& GetX_WG(ProximityIndex index, bool is_dynamic) const;
-
-  // Reports the GeometryIndex for the geometry at the given index.
-  GeometryIndex GetGeometryIndex(ProximityIndex index, bool is_dynamic) const;
+  // Reports the pose (X_WG) of the geometry with the given id.
+  const Isometry3<double>& GetX_WG(GeometryId id, bool is_dynamic) const;
 
   ////////////////////////////////////////////////////////////////////////////
 
@@ -399,12 +370,12 @@ class GeometryStateCollisionFilterAttorney {
   }
 
   // Assigns the given clique to the *dynamic* geometry indicated by the given
-  // index. This function exists for one reason, and one reason only. To allow
+  // id. This function exists for one reason, and one reason only. To allow
   // GeometryState to automatically exclude pair (gᵢ, gⱼ) from collision if gᵢ
   // and gⱼ are affixed to the same frame.
   template <typename T>
   static void set_dynamic_geometry_clique(ProximityEngine<T>* engine,
-                                          GeometryIndex geometry_index,
+                                          GeometryId geometry_index,
                                           int clique) {
     engine->set_clique(geometry_index, clique);
   }

--- a/geometry/render/BUILD.bazel
+++ b/geometry/render/BUILD.bazel
@@ -32,7 +32,7 @@ drake_cc_library(
     ],
     deps = [
         ":render_label",
-        "//geometry:geometry_index",
+        "//geometry:geometry_ids",
         "//geometry:geometry_roles",
         "//geometry:shape_specification",
         "//geometry:utilities",

--- a/geometry/render/render_engine.cc
+++ b/geometry/render/render_engine.cc
@@ -10,78 +10,33 @@ std::unique_ptr<RenderEngine> RenderEngine::Clone() const {
   return std::unique_ptr<RenderEngine>(DoClone());
 }
 
-optional<RenderIndex> RenderEngine::RegisterVisual(
-    GeometryIndex index, const drake::geometry::Shape& shape,
+bool RenderEngine::RegisterVisual(
+    GeometryId id, const drake::geometry::Shape& shape,
     const PerceptionProperties& properties,
     const RigidTransformd& X_WG, bool needs_updates) {
-  optional<RenderIndex> render_index =
-      DoRegisterVisual(shape, properties, X_WG);
-  if (render_index) {
+  // TODO(SeanCurtis-TRI): Test that the id hasn't already been used.
+  const bool accepted = DoRegisterVisual(id, shape, properties, X_WG);
+  if (accepted) {
     if (needs_updates) {
-      update_indices_.insert({*render_index, index});
+      update_ids_.insert(id);
     } else {
-      anchored_indices_.insert({*render_index, index});
+      anchored_ids_.insert(id);
     }
   }
-  return render_index;
+  return accepted;
 }
 
-optional<GeometryIndex> RenderEngine::RemoveGeometry(RenderIndex index) {
-  // The underlying engine doesn't know if the geometry to remove or the
-  // geometry that gets moved requires updates or not. As such, the removed
-  // index and the moved index can arbitrarily come from either mapping.
-  // Possible scenarios:
-  // Remove index in map A
-  //   Case 1: nothing moved
-  //     1. Remove the (remove index, remove GeometryIndex) pair from A.
-  //     2. return nullopt.
-  //   Case 2: moved geometry in A (i.e., _same_ map)
-  //     1. Remove the (moved index, moved GeometryIndex) pair from A.
-  //     2. Add the (removed index, moved GeometryIndex) pair into A.
-  //     3. Return moved GeometryIndex.
-  //   Case 3: moved geometry in B (i.e., _different_ map)
-  //     1. Remove the (removed index, removed GI) pair from A.
-  //     2. Remove the (moved index, moved GI) pair from B.
-  //     3. Add the (removed index, moved GI) pair to B.
-  //     4. Return moved GeometryIndex.
-
-  // Given an index, return a pointer to the anchored/update index map in which
-  // this index belongs.
-  auto get_index_map = [this](const RenderIndex r_index) {
-    auto iter = update_indices_.find(r_index);
-    if (iter != update_indices_.end()) return &update_indices_;
-    iter = anchored_indices_.find(r_index);
-    if (iter != anchored_indices_.end()) return &anchored_indices_;
-    throw std::logic_error(fmt::format(
-        "Error finding RenderIndex ({}) as either dynamic or anchored",
-        r_index));
-  };
-
-  // Determine map A.
-  std::unordered_map<RenderIndex, GeometryIndex>* map_A = get_index_map(index);
-
-  GeometryIndex moved_internal_index;
-  optional<RenderIndex> moved_index = DoRemoveGeometry(index);
-
-  // Determine map B.
-  std::unordered_map<RenderIndex, GeometryIndex>* map_B = nullptr;
-  if (moved_index) {
-    map_B = get_index_map(*moved_index);
-    moved_internal_index = (*map_B)[*moved_index];
+bool RenderEngine::RemoveGeometry(GeometryId id) {
+  const bool removed = DoRemoveGeometry(id);
+  // The derived sub-class should report geometry removal if and only if the
+  // base class is tracking the id.
+  if (removed) {
+    DRAKE_DEMAND(update_ids_.erase(id) > 0 || anchored_ids_.erase(id) > 0);
+  } else {
+    DRAKE_DEMAND(update_ids_.count(id) == 0 || anchored_ids_.count(id) == 0);
   }
 
-  // Examine cases:
-  map_A->erase(index);
-  if (map_B == nullptr) {                        // Case 1.
-    return nullopt;
-  } else if (map_A == map_B) {                   // Case 2.
-    map_A->erase(*moved_index);
-    (*map_A)[index] = moved_internal_index;
-  } else {                                       // Case 3.
-    map_B->erase(*moved_index);
-    (*map_B)[index] = moved_internal_index;
-  }
-  return moved_internal_index;
+  return removed;
 }
 
 RenderLabel RenderEngine::GetRenderLabelOrThrow(

--- a/geometry/render/render_engine_vtk.h
+++ b/geometry/render/render_engine_vtk.h
@@ -3,6 +3,7 @@
 #include <array>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <vtkActor.h>
@@ -144,16 +145,16 @@ class RenderEngineVtk final : public RenderEngine,
 
  private:
   // @see RenderEngine::DoRegisterVisual().
-  optional<RenderIndex> DoRegisterVisual(
-      const Shape& shape, const PerceptionProperties& properties,
+  bool DoRegisterVisual(
+      GeometryId id, const Shape& shape, const PerceptionProperties& properties,
       const math::RigidTransformd& X_WG) final;
 
   // @see RenderEngine::DoUpdateVisualPose().
-  void DoUpdateVisualPose(RenderIndex index,
+  void DoUpdateVisualPose(GeometryId id,
                           const math::RigidTransformd& X_WG) final;
 
   // @see RenderEngine::DoRemoveGeometry().
-  optional<RenderIndex> DoRemoveGeometry(RenderIndex index) final;
+  bool DoRemoveGeometry(GeometryId id) final;
 
   // @see RenderEngine::DoClone().
   std::unique_ptr<RenderEngine> DoClone() const final;
@@ -222,8 +223,9 @@ class RenderEngineVtk final : public RenderEngine,
   systems::sensors::ColorD default_clear_color_;
 
   // The collection of per-geometry actors (one actor per pipeline (color,
-  // depth, and label) indexed by the geometry's RenderIndex.
-  std::vector<std::array<vtkSmartPointer<vtkActor>, 3>> actors_;
+  // depth, and label) keyed by the geometry's GeometryId.
+  std::unordered_map<GeometryId, std::array<vtkSmartPointer<vtkActor>, 3>>
+      actors_;
 };
 
 }  // namespace render

--- a/geometry/render/test/render_engine_vtk_test.cc
+++ b/geometry/render/test/render_engine_vtk_test.cc
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <tuple>
+#include <unordered_map>
 #include <vector>
 
 #include <Eigen/Dense>
@@ -32,6 +33,7 @@ using math::RigidTransformd;
 using math::RotationMatrixd;
 using std::make_unique;
 using std::unique_ptr;
+using std::unordered_map;
 using std::vector;
 using systems::sensors::Color;
 using systems::sensors::ColorI;
@@ -148,7 +150,8 @@ class RenderEngineVtkTest : public ::testing::Test {
         // Looking straight down from kDefaultDistance meters above the ground.
         X_WC_(RotationMatrixd{AngleAxisd(M_PI, Vector3d::UnitY()) *
                               AngleAxisd(-M_PI_2, Vector3d::UnitZ())},
-              {0, 0, kDefaultDistance}) {}
+              {0, 0, kDefaultDistance}),
+        geometry_id_(GeometryId::get_new_id()) {}
 
  protected:
   // Method to allow the normal case (render with the built-in renderer against
@@ -303,7 +306,7 @@ class RenderEngineVtkTest : public ::testing::Test {
       material.AddProperty(
           "phong", "diffuse",
           Vector4d{terrain_color.r, terrain_color.g, terrain_color.b, 1.0});
-      engine->RegisterVisual(GeometryIndex(0), HalfSpace(), material,
+      engine->RegisterVisual(GeometryId::get_new_id(), HalfSpace(), material,
                              RigidTransformd::Identity(),
                              false /** needs update */);
     }
@@ -336,13 +339,13 @@ class RenderEngineVtkTest : public ::testing::Test {
   void PopulateSphereTest(RenderEngineVtk* renderer) {
     Sphere sphere{0.5};
     expected_label_ = RenderLabel(12345);  // an arbitrary value.
-    renderer->RegisterVisual(GeometryIndex(0), sphere, simple_material(),
+    renderer->RegisterVisual(geometry_id_, sphere, simple_material(),
                              RigidTransformd::Identity(),
                              true /* needs update */);
     RigidTransformd X_WV{Vector3d{0, 0, 0.5}};
-    renderer->UpdatePoses(vector<RigidTransformd>{X_WV});
     X_WV_.clear();
-    X_WV_.push_back(X_WV);
+    X_WV_.insert({geometry_id_, X_WV});
+    renderer->UpdatePoses(X_WV_);
   }
 
   // Performs the work to test the rendering with a shape centered in the
@@ -402,9 +405,10 @@ class RenderEngineVtkTest : public ::testing::Test {
   ImageDepth32F depth_;
   ImageLabel16I label_;
   RigidTransformd X_WC_;
+  GeometryId geometry_id_;
 
   // The pose of the sphere created in PopulateSphereTest().
-  std::vector<RigidTransformd> X_WV_;
+  unordered_map<GeometryId, RigidTransformd> X_WV_;
 
   unique_ptr<RenderEngineVtk> renderer_;
 };
@@ -521,12 +525,14 @@ TEST_F(RenderEngineVtkTest, BoxTest) {
   // Sets up a box.
   Box box(1, 1, 1);
   expected_label_ = RenderLabel(1);
-  renderer_->RegisterVisual(GeometryIndex(0), box, simple_material(),
+  const GeometryId id = GeometryId::get_new_id();
+  renderer_->RegisterVisual(id, box, simple_material(),
                             RigidTransformd::Identity(),
                             true /* needs update */);
   RigidTransformd X_WV{RotationMatrixd{AngleAxisd(M_PI, Vector3d::UnitX())},
                        Vector3d{0, 0, 0.5}};
-  renderer_->UpdatePoses(vector<RigidTransformd>{X_WV});
+  renderer_->UpdatePoses(
+      unordered_map<GeometryId, RigidTransformd>{{id, X_WV}});
 
   PerformCenterShapeTest(renderer_.get(), "Box test");
 }
@@ -547,12 +553,14 @@ TEST_F(RenderEngineVtkTest, CylinderTest) {
   // Sets up a cylinder.
   Cylinder cylinder(0.2, 1.2);
   expected_label_ = RenderLabel(2);
-  renderer_->RegisterVisual(GeometryIndex(0), cylinder, simple_material(),
+  const GeometryId id = GeometryId::get_new_id();
+  renderer_->RegisterVisual(id, cylinder, simple_material(),
                             RigidTransformd::Identity(),
                             true /* needs update */);
   // Position the top of the cylinder to be 1 m above the terrain.
   RigidTransformd X_WV{Vector3d{0, 0, 0.4}};
-  renderer_->UpdatePoses(vector<RigidTransformd>{X_WV});
+  renderer_->UpdatePoses(
+      unordered_map<GeometryId, RigidTransformd>{{id, X_WV}});
 
   PerformCenterShapeTest(renderer_.get(), "Cylinder test");
 }
@@ -570,11 +578,11 @@ TEST_F(RenderEngineVtkTest, MeshTest) {
   expected_label_ = RenderLabel(3);
   PerceptionProperties material = simple_material();
   material.AddProperty("phong", "diffuse_map", "bad_path");
-  renderer_->RegisterVisual(GeometryIndex(0), mesh, material,
-                            RigidTransformd::Identity(),
+  const GeometryId id = GeometryId::get_new_id();
+  renderer_->RegisterVisual(id, mesh, material, RigidTransformd::Identity(),
                             true /* needs update */);
-  renderer_->UpdatePoses(
-      std::vector<RigidTransformd>{RigidTransformd::Identity()});
+  renderer_->UpdatePoses(unordered_map<GeometryId, RigidTransformd>{
+      {id, RigidTransformd::Identity()}});
 
   PerformCenterShapeTest(renderer_.get(), "Mesh test");
 }
@@ -592,11 +600,11 @@ TEST_F(RenderEngineVtkTest, TextureMeshTest) {
   material.AddProperty(
       "phong", "diffuse_map",
       FindResourceOrThrow("drake/systems/sensors/test/models/meshes/box.png"));
-  renderer_->RegisterVisual(GeometryIndex(0), mesh, material,
-                            RigidTransformd::Identity(),
+  const GeometryId id = GeometryId::get_new_id();
+  renderer_->RegisterVisual(id, mesh, material, RigidTransformd::Identity(),
                             true /* needs update */);
-  renderer_->UpdatePoses(
-      std::vector<RigidTransformd>{RigidTransformd::Identity()});
+  renderer_->UpdatePoses(unordered_map<GeometryId, RigidTransformd>{
+      {id, RigidTransformd::Identity()}});
 
   // box.png contains a single pixel with the color (4, 241, 33). If the image
   // changes, the expected color would likewise have to change.
@@ -622,11 +630,11 @@ TEST_F(RenderEngineVtkTest, ImpliedTextureMeshTest) {
   Mesh mesh(filename);
   expected_label_ = RenderLabel(4);
   PerceptionProperties material = simple_material();
-  renderer_->RegisterVisual(GeometryIndex(0), mesh, material,
-                            RigidTransformd::Identity(),
+  const GeometryId id = GeometryId::get_new_id();
+  renderer_->RegisterVisual(id, mesh, material, RigidTransformd::Identity(),
                             true /* needs update */);
-  renderer_->UpdatePoses(
-      std::vector<RigidTransformd>{RigidTransformd::Identity()});
+  renderer_->UpdatePoses(unordered_map<GeometryId, RigidTransformd>{
+      {id, RigidTransformd::Identity()}});
 
   // box.png contains a single pixel with the color (4, 241, 33). If the image
   // changes, the expected color would likewise have to change.
@@ -681,7 +689,7 @@ TEST_F(RenderEngineVtkTest, RemoveVisual) {
 
   // Positions a sphere centered at <0, 0, z> with the given color.
   auto add_sphere = [this](const RgbaColor& diffuse, double z,
-                           GeometryIndex geometry_index) {
+                           GeometryId geometry_id) {
     const double kRadius = 0.5;
     Sphere sphere{kRadius};
     const float depth = kDefaultDistance - kRadius - z;
@@ -693,12 +701,12 @@ TEST_F(RenderEngineVtkTest, RemoveVisual) {
     material.AddProperty("label", "id", label);
     // This will accept all registered geometries and therefore, (bool)index
     // should always be true.
-    optional<RenderIndex> index = renderer_->RegisterVisual(
-        geometry_index, sphere, material, RigidTransformd::Identity());
+    renderer_->RegisterVisual(geometry_id, sphere, material,
+                              RigidTransformd::Identity());
     RigidTransformd X_WV{Vector3d{0, 0, z}};
-    X_WV_.push_back(X_WV);
+    X_WV_.insert({geometry_id, X_WV});
     renderer_->UpdatePoses(X_WV_);
-    return std::make_tuple(*index, label, depth);
+    return std::make_tuple(label, depth);
   };
 
   // Sets the expected values prior to calling PerformCenterShapeTest().
@@ -713,8 +721,8 @@ TEST_F(RenderEngineVtkTest, RemoveVisual) {
   const RgbaColor color1(Color<int>{128, 128, 255}, 255);
   float depth1{};
   RenderLabel label1{};
-  RenderIndex index1{};
-  std::tie(index1, label1, depth1) = add_sphere(color1, 0.75, GeometryIndex(1));
+  const GeometryId id1 = GeometryId::get_new_id();
+  std::tie(label1, depth1) = add_sphere(color1, 0.75, id1);
   set_expectations(color1, depth1, label1);
   PerformCenterShapeTest(renderer_.get(), "First sphere added in remove test");
 
@@ -722,26 +730,21 @@ TEST_F(RenderEngineVtkTest, RemoveVisual) {
   const RgbaColor color2(Color<int>{128, 255, 128}, 255);
   float depth2{};
   RenderLabel label2{};
-  RenderIndex index2{};
-  std::tie(index2, label2, depth2) = add_sphere(color2, 1.0, GeometryIndex(2));
+  const GeometryId id2 = GeometryId::get_new_id();
+  std::tie(label2, depth2) = add_sphere(color2, 1.0, id2);
   set_expectations(color2, depth2, label2);
   PerformCenterShapeTest(renderer_.get(), "Second sphere added in remove test");
 
-  // Remove the first sphere added:
-  //  1. index2 should be returned as the index of the shape that got moved.
-  //  2. The test should pass without changing expectations.
-  optional<GeometryIndex> moved = renderer_->RemoveGeometry(index1);
-  EXPECT_TRUE(moved);
-  EXPECT_EQ(*moved, GeometryIndex(2));
+  // Remove the first sphere added; should report "true" and the render test
+  // should pass without changing expectations.
+  bool removed = renderer_->RemoveGeometry(id1);
+  EXPECT_TRUE(removed);
   PerformCenterShapeTest(renderer_.get(), "First added sphere removed");
 
-  // Remove the second added sphere (now indexed by index1):
-  //  1. There should be no returned index.
-  //  2. The rendering should match the default sphere test results.
-  // Confirm restoration to original image.
-  moved = nullopt;
-  moved = renderer_->RemoveGeometry(index1);
-  EXPECT_FALSE(moved);
+  // Remove the second added sphere; should report true and rendering should
+  // return to its default configuration.
+  removed = renderer_->RemoveGeometry(id2);
+  EXPECT_TRUE(removed);
   set_expectations(default_color, default_depth, default_label);
   PerformCenterShapeTest(renderer_.get(),
                          "Default image restored by removing extra geometries");
@@ -787,7 +790,8 @@ TEST_F(RenderEngineVtkTest, CloneIndependence) {
   // Move the terrain *up* 10 units in the z.
   RigidTransformd X_WT_new{Vector3d{0, 0, 10}};
   // This assumes that the terrain is zero-indexed.
-  renderer_->UpdatePoses(std::vector<RigidTransformd>{X_WT_new});
+  renderer_->UpdatePoses(
+      unordered_map<GeometryId, RigidTransformd>{{geometry_id_, X_WT_new}});
   PerformCenterShapeTest(static_cast<RenderEngineVtk*>(clone.get()),
                          "Clone independence");
 }
@@ -859,11 +863,12 @@ TEST_F(RenderEngineVtkTest, DefaultProperties_RenderLabel) {
   // The result should be compatible with the running the sphere test.
   auto populate_default_sphere = [](auto* engine) {
     Sphere sphere{0.5};
-    engine->RegisterVisual(GeometryIndex(0), sphere, PerceptionProperties(),
+    const GeometryId id = GeometryId::get_new_id();
+    engine->RegisterVisual(id, sphere, PerceptionProperties(),
                            RigidTransformd::Identity(),
                            true /* needs update */);
     RigidTransformd X_WV{Vector3d{0, 0, 0.5}};
-    engine->UpdatePoses(vector<RigidTransformd>{X_WV});
+    engine->UpdatePoses(unordered_map<GeometryId, RigidTransformd>{{id, X_WV}});
   };
 
   // Case: No change to render engine's default must throw.

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -103,11 +103,21 @@ class SceneGraphInspector {
 
   /** Returns the set of all ids for registered geometries. The order is _not_
    guaranteed to have any particular meaning. But the order is
+   guaranteed to remain fixed until a topological change is made (e.g., removal
+   or addition of geometry/frames).  */
+  const std::vector<GeometryId> GetAllGeometryIds() const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->GetAllGeometryIds();
+  }
+
+  /** Returns the set of all ids for registered geometries. The order is _not_
+   guaranteed to have any particular meaning. But the order is
    guaranteed to remain fixed between topological changes (e.g., removal or
    addition of geometry/frames).  */
-  const std::vector<GeometryId>& all_geometry_ids() const {
+  DRAKE_DEPRECATED("2019-11-01", "Please use GetAllGeometryIds() instead")
+  const std::vector<GeometryId> all_geometry_ids() const {
     DRAKE_DEMAND(state_ != nullptr);
-    return state_->get_geometry_ids();
+    return state_->GetAllGeometryIds();
   }
 
   /** Reports the _total_ number of geometries in the scene graph with the

--- a/geometry/shape_to_string.h
+++ b/geometry/shape_to_string.h
@@ -14,7 +14,7 @@ namespace geometry {
  ```c++
  ShapeToString reifier;
  SceneGraphInspector inspector = ...;  // Get the inspector from somewhere.
- for (GeometryId id : inspector.all_geometry_ids()) {
+ for (GeometryId id : inspector.GetAllGeometryIds()) {
    inspector.Reify(id, reifier);
    std::cout << reifier.string() << "\n";
  }

--- a/geometry/test/internal_geometry_test.cc
+++ b/geometry/test/internal_geometry_test.cc
@@ -9,17 +9,6 @@ namespace geometry {
 namespace internal {
 namespace {
 
-GTEST_TEST(InternalGeometryTest, RenderIndexAccess) {
-  InternalGeometry geometry;
-
-  const std::string renderer_name{"valid"};
-  EXPECT_FALSE(geometry.render_index(renderer_name));
-  RenderIndex index(2);
-  EXPECT_NO_THROW(geometry.set_render_index(renderer_name, index));
-  ASSERT_TRUE(geometry.render_index(renderer_name));
-  EXPECT_EQ(geometry.render_index(renderer_name), index);
-}
-
 // Confirms that properties get set properly.
 GTEST_TEST(InternalGeometryTest, PropertyAssignment) {
   InternalGeometry geometry;
@@ -85,43 +74,45 @@ GTEST_TEST(InternalGeometryTest, RemovePerceptionRole) {
   // Configure a geometry with all roles; we assume from previous unit tests
   // that the geometry's state is correct.
   InternalGeometry geometry;
-  const RenderIndex index1(10);
-  const RenderIndex index2(20);
-  geometry.set_render_index(renderer1, index1);
-  geometry.set_render_index(renderer2, index2);
+  geometry.set_renderer(renderer1);
+  geometry.set_renderer(renderer2);
   geometry.SetRole(PerceptionProperties());
-
-  // Case: Remove render index for a non-existent render engine; old index is
-  // still valid and there are still perception properties.
-  EXPECT_NO_THROW(geometry.ClearRenderIndex("invalid"));
-  EXPECT_EQ(geometry.render_index(renderer1), index1);
-  EXPECT_EQ(geometry.render_index(renderer2), index2);
+  EXPECT_TRUE(geometry.in_renderer(renderer1));
+  EXPECT_TRUE(geometry.in_renderer(renderer2));
   EXPECT_TRUE(geometry.has_role(Role::kPerception));
 
-  // Case: Remove render index for valid render engine; no index exists and it
-  // still has perception properties.
-  EXPECT_NO_THROW(geometry.ClearRenderIndex(renderer1));
-  EXPECT_EQ(geometry.render_index(renderer1), nullopt);
-  EXPECT_EQ(geometry.render_index(renderer2), index2);
+  // Case: Remove from a non-existent render engine; its perception role
+  // configuration should remain unchanged.
+  EXPECT_NO_THROW(geometry.ClearRenderer("invalid"));
+  EXPECT_TRUE(geometry.in_renderer(renderer1));
+  EXPECT_TRUE(geometry.in_renderer(renderer2));
+  EXPECT_TRUE(geometry.has_role(Role::kPerception));
+
+  // Case: Remove from a valid render engine; otherwise unchanged perception
+  // role configuration.
+  EXPECT_NO_THROW(geometry.ClearRenderer(renderer1));
+  EXPECT_FALSE(geometry.in_renderer(renderer1));
+  EXPECT_TRUE(geometry.in_renderer(renderer2));
   EXPECT_TRUE(geometry.has_role(Role::kPerception));
 
   // Case: Remove perception properties while there is still a valid render
-  // index. All render indices are cleared.
+  // engine. The remaining valid render engines are cleared.
   EXPECT_NO_THROW(geometry.RemovePerceptionRole());
-  EXPECT_EQ(geometry.render_index(renderer1), nullopt);
-  EXPECT_EQ(geometry.render_index(renderer2), nullopt);
+  EXPECT_FALSE(geometry.in_renderer(renderer1));
+  EXPECT_FALSE(geometry.in_renderer(renderer2));
   EXPECT_FALSE(geometry.has_role(Role::kPerception));
 
-  // Case: Removing render index leaves the geometry with *no* render indices,
-  // but it *still* has perception properties.
-  geometry.set_render_index(renderer1, index1);
+  // Case: Removing from last render engine leaves the geometry with perception
+  // properties.
+  // In preparation, we reassign perception role and render engine.
+  geometry.set_renderer(renderer1);
   geometry.SetRole(PerceptionProperties());
   // Confirm it's wired up for renderer1.
-  EXPECT_EQ(geometry.render_index(renderer1), index1);
+  EXPECT_TRUE(geometry.in_renderer(renderer1));
   EXPECT_TRUE(geometry.has_role(Role::kPerception));
 
-  EXPECT_NO_THROW(geometry.ClearRenderIndex(renderer1));
-  EXPECT_EQ(geometry.render_index(renderer1), nullopt);
+  EXPECT_NO_THROW(geometry.ClearRenderer(renderer1));
+  EXPECT_FALSE(geometry.in_renderer(renderer1));
   EXPECT_TRUE(geometry.has_role(Role::kPerception));
 }
 

--- a/geometry/test/scene_graph_inspector_test.cc
+++ b/geometry/test/scene_graph_inspector_test.cc
@@ -45,7 +45,11 @@ GTEST_TEST(SceneGraphInspector, ExerciseEverything) {
   inspector.num_frames();
   inspector.all_frame_ids();
   inspector.num_geometries();
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   inspector.all_geometry_ids();
+#pragma GCC diagnostic pop
+  inspector.GetAllGeometryIds();
   inspector.NumGeometriesWithRole(Role::kUnassigned);
   inspector.GetNumDynamicGeometries();
   inspector.GetNumAnchoredGeometries();

--- a/geometry/test_utilities/dummy_render_engine.h
+++ b/geometry/test_utilities/dummy_render_engine.h
@@ -3,6 +3,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <unordered_set>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_optional.h"
@@ -21,21 +22,19 @@ namespace internal {
 
  1. It makes the RenderLabel-Color conversion methods of the RenderEngine
     public to this renderer (so test infrastructure can invoke the conversion).
- 2. It facilitates testing RemoveGeometry() logic by allowing the test to
-    explicitly set what RenderIndex this dummy engine returns in
-    DoRemoveGeometry().
- 3. It facilitates testing the RegisterGeometry() method by making the
-    registration of a geometry dependent on particular contents in the
-    PerceptionProperties (see accepting_properties() and
-    rejecting_properties()). Also provides an override so that every geometry
-    is accepted (set_force_accept()).
+ 2. It conditionally registers geometry based on an "accepting" set of
+    properties and remembers the ids of geometries successfully registered.
+ 3. By remembering successful registration, it can test geometry removal (in
+    that this implementation will only report removal of a geometry id that it
+    knows to be registered).
  4. Records which poses have been updated via UpdatePoses() to validate which
-    RenderIndex values are updated and which aren't (and with what pose).
+    ids values are updated and which aren't (and with what pose).
  5. Records the camera pose provided to UpdateViewpoint() and report it with
     last_updated_X_WC().  */
 class DummyRenderEngine final : public render::RenderEngine {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DummyRenderEngine);
+
   /** Constructor to exercise the default constructor of RenderEngine.  */
   DummyRenderEngine() = default;
 
@@ -79,11 +78,10 @@ class DummyRenderEngine final : public render::RenderEngine {
     return PerceptionProperties();
   }
 
-  /** Resets all state to the initially constructed state.  */
-  void reset() {
-    updated_indices_.clear();
-    moved_index_ = nullopt;
-    register_count_ = 0;
+  /** Initializes the set data to the freshly-constructed values. This
+   leaves the registered data intact.  */
+  void init_test_data() {
+    updated_ids_.clear();
   }
 
   /** If true, this render engine will accept all registered geometry.  */
@@ -93,19 +91,14 @@ class DummyRenderEngine final : public render::RenderEngine {
 
   /** Reports the number of geometries that have been _accepted_ in
    registration.  */
-  int num_registered() const { return register_count_; }
-
-  /** Returns the indices that have been updated via a call to UpdatePoses() and
-   the poses that were set.  */
-  const std::map<RenderIndex, math::RigidTransformd>& updated_indices() const {
-    return updated_indices_;
+  int num_registered() const {
+    return static_cast<int>(registered_geometries_.size());
   }
 
-  /** Sets the RenderIndex that DoRemoveGeometry() returns. Set to `nullopt`
-   to have RemoveGeometry() do no additional work. Otherwise, set it to some
-   valid index to cause index re-ordering.  */
-  void set_moved_index(optional<RenderIndex> index) {
-    moved_index_ = index;
+  /** Returns the ids that have been updated via a call to UpdatePoses() and
+   the poses that were set.  */
+  const std::map<GeometryId, math::RigidTransformd>& updated_ids() const {
+    return updated_ids_;
   }
 
   const math::RigidTransformd& last_updated_X_WC() const { return X_WC_; }
@@ -118,30 +111,30 @@ class DummyRenderEngine final : public render::RenderEngine {
  protected:
   /** Dummy implementation that registers the given `shape` if the `properties`
    contains the "in_test" group or the render engine has been forced to accept
-   all geometires (via set_force_accept()). (Also counts the number of
+   all geometries (via set_force_accept()). (Also counts the number of
    successfully registered shape over the lifespan of `this` instance.)  */
-  optional<RenderIndex> DoRegisterVisual(const Shape&,
-                                         const PerceptionProperties& properties,
-                                         const math::RigidTransformd&) final {
+  bool DoRegisterVisual(GeometryId id, const Shape&,
+                        const PerceptionProperties& properties,
+                        const math::RigidTransformd&) final {
     GetRenderLabelOrThrow(properties);
     if (force_accept_ || properties.HasGroup(include_group_name_)) {
-      return RenderIndex(register_count_++);
+      registered_geometries_.insert(id);
+      return true;
     }
-    return nullopt;
+    return false;
   }
 
-  /** Updates the pose X_WG for the geometry with the given `index`. Also tracks
-   which indices have been updated and the poses set (over the _lifespan_ of
-   `this` instance).  */
-  void DoUpdateVisualPose(RenderIndex index,
+  /** Updates the pose X_WG for the geometry with the given `id`. Also tracks
+   which ids have been updated and the poses set (over the _lifespan_ of
+   `this` instance). This can be reset with a call to init_test_data().  */
+  void DoUpdateVisualPose(GeometryId id,
                           const math::RigidTransformd& X_WG) final {
-    updated_indices_[index] = X_WG;
+    updated_ids_[id] = X_WG;
   }
 
-  /** Simulates removing a geometry and returns the index defined by
-   set_moved_index().  */
-  optional<RenderIndex> DoRemoveGeometry(RenderIndex index) final {
-    return moved_index_;
+  /** Removes the given geometry id (if it is registered).  */
+  bool DoRemoveGeometry(GeometryId id) final {
+    return registered_geometries_.erase(id) > 0;
   }
 
   /** Implementation of RenderEngine::DoClone().  */
@@ -153,19 +146,14 @@ class DummyRenderEngine final : public render::RenderEngine {
   // If true, the engine will accept all geometries.
   bool force_accept_{};
 
-  // Number of registered geometries.
-  int register_count_{};
+  std::unordered_set<GeometryId> registered_geometries_;
 
-  // Track each index and what it has been updated to (allows us to confirm
-  // RenderIndex and GeometryIndex association.
-  std::map<RenderIndex, math::RigidTransformd> updated_indices_;
+  // Track each id that gets updated and what it has been updated to.
+  std::map<GeometryId, math::RigidTransformd> updated_ids_;
 
   // The group name whose presence will lead to a shape being added to the
   // engine.
   std::string include_group_name_{"in_test"};
-
-  // The RenderIndex value to return on invocation of DoRemoveGeometry().
-  optional<RenderIndex> moved_index_{};
 
   // The last updated camera pose (defaults to identity).
   math::RigidTransformd X_WC_;

--- a/multibody/hydroelastics/hydroelastic_engine.cc
+++ b/multibody/hydroelastics/hydroelastic_engine.cc
@@ -45,7 +45,7 @@ template <typename T>
 void HydroelasticEngine<T>::MakeModels(
     const geometry::SceneGraphInspector<T>& inspector) {
   // Only reify geometries with proximity roles.
-  for (const geometry::GeometryId geometry_id : inspector.all_geometry_ids()) {
+  for (const geometry::GeometryId geometry_id : inspector.GetAllGeometryIds()) {
     if (const geometry::ProximityProperties* properties =
             inspector.GetProximityProperties(geometry_id)) {
       const Shape& shape = inspector.GetShape(geometry_id);


### PR DESCRIPTION
Rather than having all of the doman-specific indices which require
remapping and coordination among indices, we're going to make the globally
unique GeometryId is the universal identifier (replacing vectors<Foo> with
maps<GeometryId, Foo>.

This turns into a lot of work:

 - EncodedData
   - Enocde the GeometryId instead of GeometryIndex
   - However, the GeometryId needs to be specialized such that an
     EncodedData can make a GeometryId from the void*.
  - ProximityEngine uses GeometryIds.
    - this includes all of the distance_to_* support functionality.
  - RenderEngine uses GeometryId
    - Some of the public API and NVI API changes.
    - update the RenderEngineVtk
    - update the DummyRenderEngine.
  - GeometryState
    - remove indices from InternalGeometry.
    - the method that returned all the GeometryIds no longer returns a
      *reference* to a pre-existing vector. Now it creates it by copying
      all keys. Although far more expensive, it is assumed that this is in
      no way called during simulation and the add'l cost of the copy will

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11814)
<!-- Reviewable:end -->
