### PR TITLE
Constrain docutils dependency of Sphinx to < 0.15 with python 2.x

### DIFF
--- a/setup/mac/source_distribution/requirements.txt
+++ b/setup/mac/source_distribution/requirements.txt
@@ -1,4 +1,5 @@
 boto3; python_version >= "3.3"
+docutils < 0.15; python_version < "3.0"
 pygame
 # Constrain Sphinx due to hack customizations for templates in
 # `pydrake_sphinx_extension`.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11819)
<!-- Reviewable:end -->
