### PR TITLE
Allow adding render engine after registering geometry

### DIFF
--- a/geometry/internal_geometry.cc
+++ b/geometry/internal_geometry.cc
@@ -37,13 +37,6 @@ bool InternalGeometry::has_role(Role role) const {
   DRAKE_UNREACHABLE();
 }
 
-void InternalGeometry::add_renderer(std::string renderer_name) {
-  auto result = renderers_.emplace(move(renderer_name));
-  // As an internal class, setting a duplicate renderer is a programming error
-  // in SceneGraph's internals.
-  DRAKE_ASSERT(result.second);
-}
-
 }  // namespace internal
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/internal_geometry.cc
+++ b/geometry/internal_geometry.cc
@@ -37,7 +37,7 @@ bool InternalGeometry::has_role(Role role) const {
   DRAKE_UNREACHABLE();
 }
 
-void InternalGeometry::set_renderer(std::string renderer_name) {
+void InternalGeometry::add_renderer(std::string renderer_name) {
   auto result = renderers_.emplace(move(renderer_name));
   // As an internal class, setting a duplicate renderer is a programming error
   // in SceneGraph's internals.

--- a/geometry/internal_geometry.h
+++ b/geometry/internal_geometry.h
@@ -226,11 +226,15 @@ class InternalGeometry {
     return nullptr;
   }
 
+  // TODO(SeanCurtis-TRI): Investigate removing this pair of methods and
+  //  completely rely on the render engine to report whether a geometry has
+  //  been registered with it.
   /** Informs this geometry that it is registered to the given named render
-   engine.
+   engine. Subsequent to this call, `in_renderer(renderer_name)` should return
+   true.
    @pre This geometry doesn't already have this renderer name.
    @pre The `renderer_name` is a name for a valid renderer.  */
-  void set_renderer(std::string renderer_name);
+  void add_renderer(std::string renderer_name);
 
   /** Reports true if this geometry knows that it is registered with a render
    engine with the given name.  */

--- a/geometry/internal_geometry.h
+++ b/geometry/internal_geometry.h
@@ -226,32 +226,6 @@ class InternalGeometry {
     return nullptr;
   }
 
-  // TODO(SeanCurtis-TRI): Investigate removing this pair of methods and
-  //  completely rely on the render engine to report whether a geometry has
-  //  been registered with it.
-  /** Informs this geometry that it is registered to the given named render
-   engine. Subsequent to this call, `in_renderer(renderer_name)` should return
-   true.
-   @pre This geometry doesn't already have this renderer name.
-   @pre The `renderer_name` is a name for a valid renderer.  */
-  void add_renderer(std::string renderer_name);
-
-  /** Reports true if this geometry knows that it is registered with a render
-   engine with the given name.  */
-  bool in_renderer(const std::string& renderer_name) const {
-    return renderers_.count(renderer_name) > 0;
-  }
-
-  /** Clears this geometry's knowledge that it has been registered with the
-   named render engine. If the geometry doesn't know about the given name,
-   nothing happens.
-   @note This leaves the properties intact; it makes no effort to divine which
-   properties caused this geometry to be accepted by that renderer or its
-   uniqueness (both would be required for removing those properties).  */
-  void ClearRenderer(const std::string& renderer_name) {
-    renderers_.erase(renderer_name);
-  }
-
   /** Removes the proximity role assigned to this geometry -- if there was
    no proximity role previously, this has no effect.  */
   void RemoveProximityRole() {
@@ -268,7 +242,6 @@ class InternalGeometry {
    no perception role previously, this has no effect.  */
   void RemovePerceptionRole() {
     perception_props_ = nullopt;
-    renderers_.clear();
   }
 
   //@}
@@ -311,9 +284,6 @@ class InternalGeometry {
   optional<ProximityProperties> proximity_props_{};
   optional<IllustrationProperties> illustration_props_{};
   optional<PerceptionProperties> perception_props_{};
-
-  // The renderers in which this geometry is registered.
-  std::unordered_set<std::string> renderers_;
 };
 
 }  // namespace internal

--- a/geometry/render/render_engine.cc
+++ b/geometry/render/render_engine.cc
@@ -35,8 +35,11 @@ bool RenderEngine::RemoveGeometry(GeometryId id) {
   } else {
     DRAKE_DEMAND(update_ids_.count(id) == 0 || anchored_ids_.count(id) == 0);
   }
-
   return removed;
+}
+
+bool RenderEngine::has_geometry(GeometryId id) const {
+  return update_ids_.count(id) > 0 || anchored_ids_.count(id) > 0;
 }
 
 RenderLabel RenderEngine::GetRenderLabelOrThrow(

--- a/geometry/render/render_engine.h
+++ b/geometry/render/render_engine.h
@@ -141,6 +141,10 @@ class RenderEngine : public ShapeReifier {
             registered with this engine).  */
   bool RemoveGeometry(GeometryId id);
 
+  /** Reports true if a geometry with the given `id` has been registered with
+   `this` engine.  */
+  bool has_geometry(GeometryId id) const;
+
   /** Updates the poses of all geometries marked as "needing update" (see
  RegisterVisual()).
 

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -474,14 +474,28 @@ class SceneGraph final : public systems::LeafSystem<T> {
   //@{
 
   /** Adds a new render engine to this %SceneGraph. The %SceneGraph owns the
-   render engine. All render engines must be assigned prior to any geometry
-   registration. The render engine's name should be referenced in the
+   render engine. The render engine's name should be referenced in the
    @ref render::CameraProperties "CameraProperties" provided in the render
    queries (see QueryObject::RenderColorImage() as an example).
+
+   There is no restriction on when a renderer is added relative to geometry
+   registration and role assignment. Given a representative sequence of
+   registration and perception role assignment, the addition of the renderer
+   can be introduced anywhere in the sequence and the end result would be
+   the same.
+
+   ```
+   GeometryId id1 = scene_graph.RegisterGeometry(source_id, ...);
+   scene_graph.AssignRole(source_id, id1, PerceptionProperties());
+   GeometryId id2 = scene_graph.RegisterGeometry(source_id, ...);
+   scene_graph.AssignRole(source_id, id2, PerceptionProperties());
+   GeometryId id3 = scene_graph.RegisterGeometry(source_id, ...);
+   scene_graph.AssignRole(source_id, id3, PerceptionProperties());
+   ```
+
    @param name      The unique name of the renderer.
    @param renderer  The `renderer` to add.
-   @throws std::logic_error if the name is not unique, or geometry has already
-                            been registered.  */
+   @throws std::logic_error if the name is not unique.  */
   void AddRenderer(std::string name,
                    std::unique_ptr<render::RenderEngine> renderer);
 

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -907,7 +907,6 @@ TEST_F(GeometryStateTest, ValidateSingleSourceTree) {
       EXPECT_EQ(geometry.child_geometry_ids().size(), 0);
       EXPECT_FALSE(geometry.parent_id());
       EXPECT_EQ(geometry.name(), geometry_names_[i]);
-      EXPECT_FALSE(geometry.in_renderer(kDummyRenderName));
       EXPECT_EQ(geometry.child_geometry_ids().size(), 0);
 
       // Note: There are no geometries parented to other geometries. The results
@@ -2851,8 +2850,9 @@ TEST_F(GeometryStateTest, RemoveUnassignedRole) {
 TEST_F(GeometryStateTest, RemoveGeometryFromRenderer) {
   // Add an additional renderer *before* populating the world (as required).
   const string other_renderer_name = "alt_renderer";
-  geometry_state_.AddRenderer(other_renderer_name,
-                              make_unique<DummyRenderEngine>());
+  auto temp_engine = make_unique<DummyRenderEngine>();
+  const DummyRenderEngine& other_engine = *temp_engine;
+  geometry_state_.AddRenderer(other_renderer_name, move(temp_engine));
 
   SetUpSingleSourceTree(Assign::kPerception);
 
@@ -2864,15 +2864,15 @@ TEST_F(GeometryStateTest, RemoveGeometryFromRenderer) {
   // addition,
   //   a) report itself in the "other" render engine, xor
   //   b) be present in the `removed_from_renderer` set.
-  auto confirm_renderers = [=](set<GeometryId> removed_from_renderer) {
+  auto confirm_renderers = [=, &other_engine](
+                               set<GeometryId> removed_from_renderer) {
     set<GeometryId> ids(geometries_.begin(), geometries_.end());
     ids.insert(anchored_geometry_);
     for (GeometryId id : ids) {
       // All should report in the dummy renderer.
-      EXPECT_TRUE(gs_tester_.GetGeometry(id)->in_renderer(kDummyRenderName));
+      EXPECT_TRUE(render_engine_->has_geometry(id));
       // Should report in the renderer if it is *not* in the removed set.
-      EXPECT_EQ(gs_tester_.GetGeometry(id)
-                    ->in_renderer(other_renderer_name),
+      EXPECT_EQ(other_engine.has_geometry(id),
                 removed_from_renderer.count(id) == 0);
     }
   };
@@ -2927,8 +2927,9 @@ TEST_F(GeometryStateTest, RemoveFrameFromRenderer) {
   // TODO(SeanCurtis-TRI): Consider refactoring this set-up code between _this_
   // test and the RemoveGeometryFromRenderer test.
   const string other_renderer_name = "alt_renderer";
-  geometry_state_.AddRenderer(other_renderer_name,
-                              make_unique<DummyRenderEngine>());
+  auto temp_engine = make_unique<DummyRenderEngine>();
+  const DummyRenderEngine& other_engine = *temp_engine;
+  geometry_state_.AddRenderer(other_renderer_name, move(temp_engine));
 
   SetUpSingleSourceTree(Assign::kPerception);
 
@@ -2940,16 +2941,15 @@ TEST_F(GeometryStateTest, RemoveFrameFromRenderer) {
   // addition,
   //   a) report itself in the "other" render engine, xor
   //   b) be present in the `removed_from_renderer` set.
-  auto confirm_renderers = [=](set<GeometryId> removed_from_renderer) {
+  auto confirm_renderers = [=, &other_engine](
+                               set<GeometryId> removed_from_renderer) {
     set<GeometryId> ids(geometries_.begin(), geometries_.end());
     ids.insert(anchored_geometry_);
     for (GeometryId id : ids) {
       // All should report in the dummy renderer.
-      EXPECT_TRUE(gs_tester_.GetGeometry(id)
-                      ->in_renderer(kDummyRenderName));
+      EXPECT_TRUE(render_engine_->has_geometry(id));
       // Should report in the renderer if it is *not* in the removed set.
-      EXPECT_EQ(gs_tester_.GetGeometry(id)
-                    ->in_renderer(other_renderer_name),
+      EXPECT_EQ(other_engine.has_geometry(id),
                 removed_from_renderer.count(id) == 0);
     }
   };
@@ -3046,11 +3046,10 @@ TEST_F(GeometryStateTest, AddRendererAfterGeometry) {
   EXPECT_EQ(other_renderer->num_registered(),
             single_tree_total_geometry_count());
 
-  EXPECT_FALSE(
-      gs_tester_.GetGeometry(id_no_perception)->in_renderer(other_name));
+  EXPECT_FALSE(other_renderer->has_geometry(id_no_perception));
 
   for (const GeometryId id : geometries_) {
-    EXPECT_TRUE(gs_tester_.GetGeometry(id)->in_renderer(other_name));
+    EXPECT_TRUE(other_renderer->has_geometry(id));
   }
 }
 
@@ -3092,8 +3091,8 @@ TEST_F(GeometryStateTest, RendererPoseUpdate) {
   // Reality check -- all geometries report as part of both engines.
   for (int i = 0; i < single_tree_dynamic_geometry_count(); ++i) {
     const InternalGeometry* geometry = gs_tester_.GetGeometry(geometries_[i]);
-    EXPECT_TRUE(geometry->in_renderer(kDummyRenderName));
-    EXPECT_TRUE(geometry->in_renderer(second_engine_name));
+    EXPECT_TRUE(render_engine_->has_geometry(geometry->id()));
+    EXPECT_TRUE(second_engine->has_geometry(geometry->id()));
   }
 
   EXPECT_EQ(second_engine->updated_ids().size(), 0u);

--- a/geometry/test/internal_geometry_test.cc
+++ b/geometry/test/internal_geometry_test.cc
@@ -34,86 +34,59 @@ GTEST_TEST(InternalGeometryTest, PropertyAssignment) {
   EXPECT_TRUE(geometry.has_perception_role());
 }
 
-// Tests the removal of proximity and illustration roles -- the removal is
-// identical for both. Perception requires special treatment (see below).
-GTEST_TEST(InternalGeometryTest, RemoveRole_NonPerception) {
+// Tests the removal of all roles.
+GTEST_TEST(InternalGeometryTest, RemoveRole) {
   // Configure a geometry with all roles; we assume from previous unit tests
   // that the geometry's state is correct.
   InternalGeometry geometry;
   geometry.SetRole(ProximityProperties());
   geometry.SetRole(IllustrationProperties());
-
-  // Case: Remove proximity, illustration persists.
-  EXPECT_NO_THROW(geometry.RemoveProximityRole());
-  EXPECT_FALSE(geometry.has_role(Role::kProximity));
-  EXPECT_TRUE(geometry.has_role(Role::kIllustration));
-
-  // Case: Redundant removal of role is a no-op.
-  EXPECT_NO_THROW(geometry.RemoveProximityRole());
-  EXPECT_FALSE(geometry.has_role(Role::kProximity));
-  EXPECT_TRUE(geometry.has_role(Role::kIllustration));
-
-  // Case: Remove illustration, no roles exist.
-  EXPECT_NO_THROW(geometry.RemoveIllustrationRole());
-  EXPECT_FALSE(geometry.has_role(Role::kProximity));
-  EXPECT_FALSE(geometry.has_role(Role::kIllustration));
-
-  // Case: Redundant removal of role is a no-op.
-  EXPECT_NO_THROW(geometry.RemoveIllustrationRole());
-  EXPECT_FALSE(geometry.has_role(Role::kProximity));
-  EXPECT_FALSE(geometry.has_role(Role::kIllustration));
-}
-
-// Test the perception role removal. This is its own unique test because it has
-// special, per-renderer logic that doesn't apply to either proximity or
-// illustration.
-GTEST_TEST(InternalGeometryTest, RemovePerceptionRole) {
-  const std::string renderer1("renderer1");
-  const std::string renderer2("renderer2");
-
-  // Configure a geometry with all roles; we assume from previous unit tests
-  // that the geometry's state is correct.
-  InternalGeometry geometry;
-  geometry.add_renderer(renderer1);
-  geometry.add_renderer(renderer2);
   geometry.SetRole(PerceptionProperties());
-  EXPECT_TRUE(geometry.in_renderer(renderer1));
-  EXPECT_TRUE(geometry.in_renderer(renderer2));
+
+  // Two notes on the structure of this test:
+  //  1. As currently formulated, the correctness of the test depends on the
+  //     order of these actions. Changing the order can lead to meaningless
+  //     test failure.
+  //  2. This test doesn't exhaustively test all permutations of removing a
+  //     role. (There are 8 unique configurations and 24 total possible removal
+  //     invocations.) We assume that the *suggestion* of independence suggested
+  //     here is actually true.
+
+  // Case: Remove proximity, other roles persist.
+  EXPECT_NO_THROW(geometry.RemoveProximityRole());
+  EXPECT_FALSE(geometry.has_role(Role::kProximity));
+  EXPECT_TRUE(geometry.has_role(Role::kIllustration));
   EXPECT_TRUE(geometry.has_role(Role::kPerception));
 
-  // Case: Remove from a non-existent render engine; its perception role
-  // configuration should remain unchanged.
-  EXPECT_NO_THROW(geometry.ClearRenderer("invalid"));
-  EXPECT_TRUE(geometry.in_renderer(renderer1));
-  EXPECT_TRUE(geometry.in_renderer(renderer2));
+  // Case: Redundant removal of role is a no-op.
+  EXPECT_NO_THROW(geometry.RemoveProximityRole());
+  EXPECT_FALSE(geometry.has_role(Role::kProximity));
+  EXPECT_TRUE(geometry.has_role(Role::kIllustration));
   EXPECT_TRUE(geometry.has_role(Role::kPerception));
 
-  // Case: Remove from a valid render engine; otherwise unchanged perception
-  // role configuration.
-  EXPECT_NO_THROW(geometry.ClearRenderer(renderer1));
-  EXPECT_FALSE(geometry.in_renderer(renderer1));
-  EXPECT_TRUE(geometry.in_renderer(renderer2));
+  // Case: Remove illustration, only perception remains.
+  EXPECT_NO_THROW(geometry.RemoveIllustrationRole());
+  EXPECT_FALSE(geometry.has_role(Role::kProximity));
+  EXPECT_FALSE(geometry.has_role(Role::kIllustration));
   EXPECT_TRUE(geometry.has_role(Role::kPerception));
 
-  // Case: Remove perception properties while there is still a valid render
-  // engine. The remaining valid render engines are cleared.
+  // Case: Redundant removal of role is a no-op.
+  EXPECT_NO_THROW(geometry.RemoveIllustrationRole());
+  EXPECT_FALSE(geometry.has_role(Role::kProximity));
+  EXPECT_FALSE(geometry.has_role(Role::kIllustration));
+  EXPECT_TRUE(geometry.has_role(Role::kPerception));
+
+  // Case: Remove perception, no roles exist.
   EXPECT_NO_THROW(geometry.RemovePerceptionRole());
-  EXPECT_FALSE(geometry.in_renderer(renderer1));
-  EXPECT_FALSE(geometry.in_renderer(renderer2));
+  EXPECT_FALSE(geometry.has_role(Role::kProximity));
+  EXPECT_FALSE(geometry.has_role(Role::kIllustration));
   EXPECT_FALSE(geometry.has_role(Role::kPerception));
 
-  // Case: Removing from last render engine leaves the geometry with perception
-  // properties.
-  // In preparation, we reassign perception role and render engine.
-  geometry.add_renderer(renderer1);
-  geometry.SetRole(PerceptionProperties());
-  // Confirm it's wired up for renderer1.
-  EXPECT_TRUE(geometry.in_renderer(renderer1));
-  EXPECT_TRUE(geometry.has_role(Role::kPerception));
-
-  EXPECT_NO_THROW(geometry.ClearRenderer(renderer1));
-  EXPECT_FALSE(geometry.in_renderer(renderer1));
-  EXPECT_TRUE(geometry.has_role(Role::kPerception));
+  // Case: Redundant removal of role is a no-op.
+  EXPECT_NO_THROW(geometry.RemoveIllustrationRole());
+  EXPECT_FALSE(geometry.has_role(Role::kProximity));
+  EXPECT_FALSE(geometry.has_role(Role::kIllustration));
+  EXPECT_FALSE(geometry.has_role(Role::kPerception));
 }
 
 }  // namespace

--- a/geometry/test/internal_geometry_test.cc
+++ b/geometry/test/internal_geometry_test.cc
@@ -74,8 +74,8 @@ GTEST_TEST(InternalGeometryTest, RemovePerceptionRole) {
   // Configure a geometry with all roles; we assume from previous unit tests
   // that the geometry's state is correct.
   InternalGeometry geometry;
-  geometry.set_renderer(renderer1);
-  geometry.set_renderer(renderer2);
+  geometry.add_renderer(renderer1);
+  geometry.add_renderer(renderer2);
   geometry.SetRole(PerceptionProperties());
   EXPECT_TRUE(geometry.in_renderer(renderer1));
   EXPECT_TRUE(geometry.in_renderer(renderer2));
@@ -105,7 +105,7 @@ GTEST_TEST(InternalGeometryTest, RemovePerceptionRole) {
   // Case: Removing from last render engine leaves the geometry with perception
   // properties.
   // In preparation, we reassign perception role and render engine.
-  geometry.set_renderer(renderer1);
+  geometry.add_renderer(renderer1);
   geometry.SetRole(PerceptionProperties());
   // Confirm it's wired up for renderer1.
   EXPECT_TRUE(geometry.in_renderer(renderer1));

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -776,16 +776,17 @@ GTEST_TEST(SceneGraphRenderTest, AddRenderer) {
       scene_graph.AddRenderer("unique", make_unique<DummyRenderEngine>()),
       std::logic_error);
 
-  // Adding a renderer _after_ geometry registration.
+  // Adding a renderer _after_ geometry registration. We rely on geometry state
+  // tests to confirm that the right thing happens; this just confirms that it's
+  // not an error in the SceneGraph API.
   SourceId s_id = scene_graph.RegisterSource("dummy");
   scene_graph.RegisterGeometry(
       s_id, scene_graph.world_frame_id(),
       make_unique<GeometryInstance>(Isometry3<double>::Identity(),
                                     make_unique<Sphere>(1.0), "sphere"));
 
-  EXPECT_THROW(
-      scene_graph.AddRenderer("different", make_unique<DummyRenderEngine>()),
-      std::logic_error);
+  EXPECT_NO_THROW(
+      scene_graph.AddRenderer("different", make_unique<DummyRenderEngine>()));
 }
 
 }  // namespace


### PR DESCRIPTION
This removes the old requirement that all renderers needed to be added before any geometry. Now, geometry that has been registered and has had the perception property assigned will automatically be added to any subsequent render engine that gets added.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11820)
<!-- Reviewable:end -->
