### PR TITLE
RenderEngineVtk has configurable clear color

### DIFF
--- a/geometry/render/render_engine_vtk.h
+++ b/geometry/render/render_engine_vtk.h
@@ -140,8 +140,6 @@ class RenderEngineVtk final : public RenderEngine,
 
   using RenderEngine::default_render_label;
 
-  // TODO(SeanCurtis-TRI): Provide a means to set the default clear color.
-
   //@}
 
  private:
@@ -217,12 +215,15 @@ class RenderEngineVtk final : public RenderEngine,
   // prevent undesirable behaviors if used in multi-threaded application.
   static vtkNew<internal::ShaderCallback> uniform_setting_callback_;
 
+  // Obnoxious bright orange.
+  Eigen::Vector4d default_diffuse_{0.9, 0.45, 0.1, 1.0};
+
+  // The color to clear the color buffer to.
+  systems::sensors::ColorD default_clear_color_;
+
   // The collection of per-geometry actors (one actor per pipeline (color,
   // depth, and label) indexed by the geometry's RenderIndex.
   std::vector<std::array<vtkSmartPointer<vtkActor>, 3>> actors_;
-
-  // Obnoxious bright orange.
-  Eigen::Vector4d default_diffuse_{0.9, 0.45, 0.1, 1.0};
 };
 
 }  // namespace render

--- a/geometry/render/render_engine_vtk_factory.h
+++ b/geometry/render/render_engine_vtk_factory.h
@@ -17,6 +17,11 @@ struct RenderEngineVtkParams  {
     none is otherwise specified. Note: currently the alpha channel is unused
     by RenderEngineVtk.  */
   optional<Eigen::Vector4d> default_diffuse{};
+
+  /** The rgb color to which the color buffer is cleared (each
+   channel in the range [0, 1]). The default value (in byte values) would be
+   [204, 229, 255].  */
+  Eigen::Vector3d default_clear_color{204 / 255., 229 / 255., 255 / 255.};
 };
 
 /** Constructs a RenderEngine implementation which uses a VTK-based OpenGL


### PR DESCRIPTION
This gives RenderEngineVtk the ability to configure the color to which the
color buffer gets cleared. Furthermore, it changes the default clear color
to match the legacy color used in RgbdRenderer and geometry/dev-based
applications.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11823)
<!-- Reviewable:end -->
