### PR TITLE
MBP "visual" geometry has both illustration and perception roles

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -281,7 +281,7 @@ drake_cc_googletest(
         "//common:find_resource",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
-        "//geometry/test_utilities:geometry_set_tester",
+        "//geometry/test_utilities",
         "//math:geometric_transform",
         "//math:gradient",
         "//multibody/benchmarks/acrobot",

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -2552,6 +2552,12 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// Registers geometry in a SceneGraph with a given geometry::Shape to be
   /// used for visualization of a given `body`.
   ///
+  /// @note Currently, the visual geometry will _also_ be assigned a perception
+  /// role. Its render label's value will be equal to the body's index and its
+  /// perception color will be the same as its illustration color (defaulting to
+  /// gray if no color is provided). This behavior will change in the near
+  /// future and code that directly relies on this behavior will break.
+  ///
   /// @param[in] body
   ///   The body for which geometry is being registered.
   /// @param[in] X_BG

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -19,6 +19,7 @@
 #include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/query_object.h"
 #include "drake/geometry/scene_graph.h"
+#include "drake/geometry/test_utilities/dummy_render_engine.h"
 #include "drake/geometry/test_utilities/geometry_set_tester.h"
 #include "drake/math/autodiff_gradient.h"
 #include "drake/math/rigid_transform.h"
@@ -50,6 +51,7 @@ using geometry::FrameId;
 using geometry::FramePoseVector;
 using geometry::GeometryId;
 using geometry::IllustrationProperties;
+using geometry::internal::DummyRenderEngine;
 using geometry::PenetrationAsPointPair;
 using geometry::QueryObject;
 using geometry::SceneGraph;
@@ -1253,8 +1255,21 @@ GTEST_TEST(MultibodyPlantTest, VisualGeometryRegistration) {
   const double radius = 0.5;
 
   SceneGraph<double> scene_graph;
+
+  // Add a render engine so we can confirm that the current default behavior of
+  // assigning perception roles to visual geometries is happening.
+  auto temp_engine = std::make_unique<DummyRenderEngine>();
+  // We want to confirm MBP is assigning perception roles; so we force the
+  // engine to accept all registered visuals so we don't have to worry about
+  // possible *conditions* of acceptance. To attempt a registration is to
+  // succeed. That way, we can simply look at the number of registered ids to
+  // determine role assignment has happened.
+  temp_engine->set_force_accept(true);
+  const DummyRenderEngine& render_engine = *temp_engine;
+  scene_graph.AddRenderer("dummy", move(temp_engine));
   MultibodyPlant<double> plant;
   plant.RegisterAsSourceForSceneGraph(&scene_graph);
+  EXPECT_EQ(render_engine.num_registered(), 0);
 
   // A half-space for the ground geometry -- uses default visual material
   GeometryId ground_id = plant.RegisterVisualGeometry(
@@ -1263,6 +1278,7 @@ GTEST_TEST(MultibodyPlantTest, VisualGeometryRegistration) {
       RigidTransformd(
           geometry::HalfSpace::MakePose(Vector3d::UnitY(), Vector3d::Zero())),
       geometry::HalfSpace(), "ground");
+  EXPECT_EQ(render_engine.num_registered(), 1);
 
   // Add two spherical bodies.
   const RigidBody<double>& sphere1 =
@@ -1271,12 +1287,14 @@ GTEST_TEST(MultibodyPlantTest, VisualGeometryRegistration) {
   GeometryId sphere1_id = plant.RegisterVisualGeometry(
       sphere1, RigidTransformd::Identity(), geometry::Sphere(radius),
       "visual", sphere1_diffuse);
+  EXPECT_EQ(render_engine.num_registered(), 2);
   const RigidBody<double>& sphere2 =
       plant.AddRigidBody("Sphere2", SpatialInertia<double>());
   Vector4<double> sphere2_diffuse{0.1, 0.9, 0.1, 0.5};
   GeometryId sphere2_id = plant.RegisterVisualGeometry(
       sphere2, RigidTransformd::Identity(), geometry::Sphere(radius),
       "visual", sphere2_diffuse);
+  EXPECT_EQ(render_engine.num_registered(), 3);
 
   // We are done defining the model.
   plant.Finalize();


### PR DESCRIPTION
In the absence of a robust pipeline for parsing data and assigning distinct
roles, registering a visual geometry through MBP will cause it to have both
illustration and perception roles.

This hack needs to be removed when it can be done in a more disciplined
way (particularly, when all knowledge of geometry is taken away from MBP).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11824)
<!-- Reviewable:end -->
