### PR TITLE
Python bindings for mainstream geometry render artifacts

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -144,6 +144,7 @@ drake_pybind_library(
         "//bindings/pydrake/common:cpp_template_pybind",
         "//bindings/pydrake/common:default_scalars_pybind",
         "//bindings/pydrake/common:deprecation_pybind",
+        "//bindings/pydrake/common:drake_optional_pybind",
         "//bindings/pydrake/common:type_pack",
         "//bindings/pydrake/common:value_pybind",
         "//lcmtypes:viewer",
@@ -416,6 +417,7 @@ drake_py_unittest(
     deps = [
         ":geometry_py",
         "//bindings/pydrake/common/test_utilities",
+        "//bindings/pydrake/systems:sensors_py",
     ],
 )
 

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -485,7 +485,10 @@ drake_py_unittest(
         "//systems/sensors:test_models",
     ],
     tags = vtk_test_tags(),
-    deps = [":sensors_py"],
+    deps = [
+        ":sensors_py",
+        "//bindings/pydrake:geometry_py",
+    ],
 )
 
 drake_py_unittest(

--- a/bindings/pydrake/systems/test/sensors_test.py
+++ b/bindings/pydrake/systems/test/sensors_test.py
@@ -7,6 +7,12 @@ import unittest
 import numpy as np
 
 from pydrake.common import FindResourceOrThrow
+from pydrake.geometry import FrameId
+from pydrake.geometry.render import DepthCameraProperties
+from pydrake.math import (
+    RigidTransform,
+    RollPitchYaw,
+    )
 from pydrake.systems.framework import (
     AbstractValue,
     InputPort,
@@ -226,3 +232,61 @@ class TestSensors(unittest.TestCase):
         # N.B. This Value[] is a C++ LCM object. See
         # `lcm_py_bind_cpp_serializers.h` for more information.
         self.assertIsInstance(output.get_data(0), AbstractValue)
+
+    def test_rgbd_sensor(self):
+        def check_ports(system):
+            self.assertIsInstance(system.query_object_input_port(), InputPort)
+            self.assertIsInstance(system.color_image_output_port(), OutputPort)
+            self.assertIsInstance(system.depth_image_32F_output_port(),
+                                  OutputPort)
+            self.assertIsInstance(system.depth_image_16U_output_port(),
+                                  OutputPort)
+            self.assertIsInstance(system.label_image_output_port(), OutputPort)
+
+        # Use HDTV size.
+        width = 1280
+        height = 720
+
+        properties = DepthCameraProperties(width=width, height=height,
+                                           fov_y=np.pi/6,
+                                           renderer_name="renderer",
+                                           z_near=0.1, z_far=5.5)
+
+        # Put it at the origin.
+        X_WB = RigidTransform()
+        # This id would fail if we tried to render; no such id exists.
+        parent_id = FrameId.get_new_id()
+        camera_poses = mut.RgbdSensor.CameraPoses()
+        sensor = mut.RgbdSensor(parent_id=parent_id, X_PB=X_WB,
+                                properties=properties,
+                                camera_poses=camera_poses)
+
+        def check_info(camera_info):
+            self.assertIsInstance(camera_info, mut.CameraInfo)
+            self.assertEqual(camera_info.width(), width)
+            self.assertEqual(camera_info.height(), height)
+
+        check_info(sensor.color_camera_info())
+        check_info(sensor.depth_camera_info())
+        self.assertIsInstance(sensor.X_BC(),
+                              RigidTransform)
+        self.assertIsInstance(sensor.X_BD(),
+                              RigidTransform)
+        self.assertEqual(sensor.parent_frame_id(), parent_id)
+        check_ports(sensor)
+
+        # Test discrete camera.
+        period = mut.RgbdSensorDiscrete.kDefaultPeriod
+        discrete = mut.RgbdSensorDiscrete(
+            sensor=sensor, period=period, render_label_image=True)
+        self.assertTrue(discrete.sensor() is sensor)
+        self.assertEqual(discrete.period(), period)
+        check_ports(discrete)
+
+        # That we can access the state as images.
+        context = discrete.CreateDefaultContext()
+        values = context.get_abstract_state()
+        self.assertIsInstance(values.get_value(0), Value[mut.ImageRgba8U])
+        self.assertIsInstance(values.get_value(1), Value[mut.ImageDepth32F])
+        self.assertIsInstance(values.get_value(2), Value[mut.ImageDepth16U])
+        self.assertIsInstance(values.get_value(3), Value[mut.ImageLabel16I])

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -2,6 +2,9 @@ import pydrake.geometry as mut
 
 import unittest
 import warnings
+from math import pi
+
+import numpy as np
 
 from pydrake.autodiffutils import AutoDiffXd
 from pydrake.common import FindResourceOrThrow
@@ -9,8 +12,14 @@ from pydrake.common.eigen_geometry import Isometry3_
 from pydrake.common.test_utilities.deprecation import catch_drake_warnings
 from pydrake.common.test_utilities import numpy_compare
 from pydrake.lcm import DrakeMockLcm
+from pydrake.math import RigidTransform
 from pydrake.symbolic import Expression
 from pydrake.systems.framework import DiagramBuilder_, InputPort_, OutputPort_
+from pydrake.systems.sensors import (
+    ImageRgba8U,
+    ImageDepth32F,
+    ImageLabel16I
+    )
 from pydrake.common.deprecation import DrakeDeprecationWarning
 
 
@@ -32,6 +41,11 @@ class TestGeometry(unittest.TestCase):
             scene_graph.get_pose_bundle_output_port(), OutputPort)
         self.assertIsInstance(
             scene_graph.get_query_output_port(), OutputPort)
+
+        # Test limited rendering API.
+        scene_graph.AddRenderer("test_renderer",
+                                mut.render.MakeRenderEngineVtk(
+                                    mut.render.RenderEngineVtkParams()))
 
     def test_connect_drake_visualizer(self):
         # Test visualization API.
@@ -143,3 +157,88 @@ class TestGeometry(unittest.TestCase):
         ]
         for shape in shapes:
             self.assertIsInstance(shape, mut.Shape)
+
+    def test_render_engine_vtk_params(self):
+        # Confirm default construction of params.
+        params = mut.render.RenderEngineVtkParams()
+        self.assertEqual(params.default_label, None)
+        self.assertEqual(params.default_diffuse, None)
+
+        label = mut.render.RenderLabel(10)
+        diffuse = np.array((1.0, 0.0, 0.0, 0.0))
+        params.default_label = label
+        params.default_diffuse = diffuse
+        self.assertEqual(params.default_label, label)
+        self.assertTrue((params.default_diffuse == diffuse).all())
+
+    def test_render_depth_camera_properties(self):
+        obj = mut.render.DepthCameraProperties(width=320, height=240,
+                                               fov_y=pi/6,
+                                               renderer_name="test_renderer",
+                                               z_near=0.1, z_far=5.0)
+        self.assertEqual(obj.width, 320)
+        self.assertEqual(obj.height, 240)
+        self.assertEqual(obj.fov_y, pi/6)
+        self.assertEqual(obj.renderer_name, "test_renderer")
+        self.assertEqual(obj.z_near, 0.1)
+        self.assertEqual(obj.z_far, 5.0)
+
+    def test_render_label(self):
+        RenderLabel = mut.render.RenderLabel
+        value = 10
+        obj = RenderLabel(value)
+
+        self.assertEqual(value, obj)
+        self.assertEqual(obj, value)
+
+        self.assertFalse(obj.is_reserved())
+        self.assertTrue(RenderLabel.kEmpty.is_reserved())
+        self.assertTrue(RenderLabel.kDoNotRender.is_reserved())
+        self.assertTrue(RenderLabel.kDontCare.is_reserved())
+        self.assertTrue(RenderLabel.kUnspecified.is_reserved())
+        self.assertEqual(RenderLabel(value), RenderLabel(value))
+        self.assertNotEqual(RenderLabel(value), RenderLabel.kEmpty)
+
+    @numpy_compare.check_nonsymbolic_types
+    def test_query_object(self, T):
+        SceneGraph = mut.SceneGraph_[T]
+        QueryObject = mut.QueryObject_[T]
+        SceneGraphInspector = mut.SceneGraphInspector_[T]
+
+        scene_graph = SceneGraph()
+        render_params = mut.render.RenderEngineVtkParams()
+        renderer_name = "test_renderer"
+        scene_graph.AddRenderer(renderer_name,
+                                mut.render.MakeRenderEngineVtk(render_params))
+
+        context = scene_graph.CreateDefaultContext()
+        query_object = scene_graph.get_query_output_port().Eval(context)
+
+        self.assertIsInstance(query_object.inspector(), SceneGraphInspector)
+
+        # Proximity queries -- all of these will produce empty results.
+        results = query_object.ComputeSignedDistancePairwiseClosestPoints()
+        self.assertEqual(len(results), 0)
+        results = query_object.ComputePointPairPenetration()
+        self.assertEqual(len(results), 0)
+        results = query_object.ComputeSignedDistanceToPoint(p_WQ=(1, 2, 3))
+        self.assertEqual(len(results), 0)
+        results = query_object.FindCollisionCandidates()
+        self.assertEqual(len(results), 0)
+
+        # Confirm rendering API returns images of appropriate type.
+        d_camera = mut.render.DepthCameraProperties(
+            width=320, height=240, fov_y=pi/6, renderer_name=renderer_name,
+            z_near=0.1, z_far=5.0)
+        image = query_object.RenderColorImage(
+            camera=d_camera, parent_frame=SceneGraph.world_frame_id(),
+            X_PC=RigidTransform())
+        self.assertIsInstance(image, ImageRgba8U)
+        image = query_object.RenderDepthImage(
+            camera=d_camera, parent_frame=SceneGraph.world_frame_id(),
+            X_PC=RigidTransform())
+        self.assertIsInstance(image, ImageDepth32F)
+        image = query_object.RenderLabelImage(
+            camera=d_camera, parent_frame=SceneGraph.world_frame_id(),
+            X_PC=RigidTransform())
+        self.assertIsInstance(image, ImageLabel16I)


### PR DESCRIPTION
This extends the python bindings to include:

  - pydrake.geometry.render with
    - CameraProperties,
    - DepthCameraPropeties
    - RenderEngine
    - RenderEngineVtkParams and MakeRenderEngineVtk
    - RenderLabel
  - SceneGraph
    - AddRender()
    - world_frame_id()
  - QueryObject
    - FindCollisionCandidates()
    - Render*Image()
  - pydrake.systems.sensors with
    - RgbdSensor, RgbdSensorDiscrete

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11825)
<!-- Reviewable:end -->
