### PR TITLE
Remove dev Geometry from scene graph examples

### DIFF
--- a/examples/scene_graph/BUILD.bazel
+++ b/examples/scene_graph/BUILD.bazel
@@ -11,6 +11,7 @@ load(
     "drake_cc_vector_gen_library",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
+load("//tools/skylark:test_tags.bzl", "vtk_test_tags")
 
 drake_cc_vector_gen_library(
     name = "bouncing_ball_vector",
@@ -33,6 +34,7 @@ drake_cc_binary(
     name = "bouncing_ball_run_dynamics",
     srcs = ["bouncing_ball_run_dynamics.cc"],
     add_test_rule = 1,
+    tags = vtk_test_tags(),
     test_rule_args = [
         "--simulation_time=0.1",
     ],
@@ -40,10 +42,13 @@ drake_cc_binary(
         ":bouncing_ball_plant",
         "//geometry:geometry_visualization",
         "//geometry:scene_graph",
+        "//geometry/render:render_engine_vtk",
         "//systems/analysis:simulator",
         "//systems/framework:diagram",
+        "//systems/lcm:lcm_pubsub_system",
         "//systems/primitives:constant_vector_source",
-        "//systems/primitives:signal_logger",
+        "//systems/sensors:image_to_lcm_image_array_t",
+        "//systems/sensors:rgbd_sensor",
         "@gflags",
     ],
 )

--- a/examples/scene_graph/bouncing_ball_plant.cc
+++ b/examples/scene_graph/bouncing_ball_plant.cc
@@ -15,12 +15,15 @@ namespace examples {
 namespace scene_graph {
 namespace bouncing_ball {
 
+using Eigen::Vector4d;
 using geometry::FramePoseVector;
 using geometry::GeometryFrame;
 using geometry::GeometryInstance;
 using geometry::IllustrationProperties;
 using geometry::PenetrationAsPointPair;
+using geometry::PerceptionProperties;
 using geometry::ProximityProperties;
+using geometry::render::RenderLabel;
 using geometry::SceneGraph;
 using geometry::SourceId;
 using geometry::Sphere;
@@ -58,6 +61,12 @@ BouncingBallPlant<T>::BouncingBallPlant(SourceId source_id,
   // Use the default material.
   scene_graph->AssignRole(source_id, ball_id_, IllustrationProperties());
   scene_graph->AssignRole(source_id, ball_id_, ProximityProperties());
+  PerceptionProperties perception_properties;
+  perception_properties.AddProperty("phong", "diffuse",
+                                    Vector4d{0.8, 0.8, 0.8, 1.0});
+  perception_properties.AddProperty("label", "id",
+                                    RenderLabel(ball_id_.get_value()));
+  scene_graph->AssignRole(source_id, ball_id_, perception_properties);
 
   // Allocate the output port now that the frame has been registered.
   geometry_pose_port_ = this->DeclareAbstractOutputPort(
@@ -114,9 +123,8 @@ void BouncingBallPlant<T>::DoCalcTimeDerivatives(
   const BouncingBallVector<T>& state = get_state(context);
   BouncingBallVector<T>& derivative_vector = get_mutable_state(derivatives);
 
-  const geometry::QueryObject<T>& query_object =
-      get_geometry_query_input_port().
-          template Eval<geometry::QueryObject<T>>(context);
+  const auto& query_object = get_geometry_query_input_port().
+      template Eval<geometry::QueryObject<T>>(context);
 
   std::vector<PenetrationAsPointPair<T>> penetrations =
       query_object.ComputePointPairPenetration();

--- a/examples/scene_graph/bouncing_ball_run_dynamics.cc
+++ b/examples/scene_graph/bouncing_ball_run_dynamics.cc
@@ -6,15 +6,27 @@
 #include "drake/examples/scene_graph/bouncing_ball_plant.h"
 #include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/geometry_visualization.h"
+#include "drake/geometry/render/render_engine_vtk_factory.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/geometry/shape_specification.h"
 #include "drake/lcm/drake_lcm.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/math/rotation_matrix.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram.h"
 #include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/lcm/lcm_publisher_system.h"
+#include "drake/systems/sensors/image_to_lcm_image_array_t.h"
+#include "drake/systems/sensors/pixel_types.h"
+#include "drake/systems/sensors/rgbd_sensor.h"
 
 DEFINE_double(simulation_time, 10.0,
               "Desired duration of the simulation in seconds.");
+DEFINE_bool(render_on, true, "Sets rendering generally enabled (or not)");
+DEFINE_bool(color, true, "Sets the enabled camera to render color");
+DEFINE_bool(depth, true, "Sets the enabled camera to render depth");
+DEFINE_bool(label, true, "Sets the enabled camera to render label");
+DEFINE_double(render_fps, 10, "Frames per simulation second to render");
 
 namespace drake {
 namespace examples {
@@ -22,44 +34,59 @@ namespace scene_graph {
 namespace bouncing_ball {
 namespace {
 
+using Eigen::Vector3d;
+using Eigen::Vector4d;
+using geometry::ConnectDrakeVisualizer;
 using geometry::GeometryInstance;
 using geometry::SceneGraph;
 using geometry::GeometryId;
 using geometry::HalfSpace;
 using geometry::IllustrationProperties;
+using geometry::PerceptionProperties;
 using geometry::ProximityProperties;
+using geometry::render::DepthCameraProperties;
+using geometry::render::RenderEngineVtkParams;
+using geometry::render::RenderLabel;
+using geometry::SceneGraph;
 using geometry::SourceId;
 using lcm::DrakeLcm;
+using math::RigidTransformd;
+using math::RotationMatrixd;
 using systems::InputPort;
+using systems::sensors::PixelType;
+using systems::sensors::RgbdSensor;
 using std::make_unique;
 
 int do_main() {
   systems::DiagramBuilder<double> builder;
   auto scene_graph = builder.AddSystem<SceneGraph<double>>();
   scene_graph->set_name("scene_graph");
+  const std::string render_name("renderer");
+  scene_graph->AddRenderer(render_name,
+                           MakeRenderEngineVtk(RenderEngineVtkParams()));
 
   // Create two bouncing balls --> two plants. Put the balls at positions
   // mirrored over the origin (<0.25, 0.25> and <-0.25, -0.25>, respectively).
   // See below for setting the initial *height*.
-  SourceId ball_source_id1 = scene_graph->RegisterSource("ball1");
+  const SourceId ball_source_id1 = scene_graph->RegisterSource("ball1");
   auto bouncing_ball1 = builder.AddSystem<BouncingBallPlant>(
       ball_source_id1, scene_graph, Vector2<double>(0.25, 0.25));
   bouncing_ball1->set_name("BouncingBall1");
 
-  SourceId ball_source_id2 = scene_graph->RegisterSource("ball2");
+  const SourceId ball_source_id2 = scene_graph->RegisterSource("ball2");
   auto bouncing_ball2 = builder.AddSystem<BouncingBallPlant>(
       ball_source_id2, scene_graph, Vector2<double>(-0.25, -0.25));
   bouncing_ball2->set_name("BouncingBall2");
 
-  SourceId global_source = scene_graph->RegisterSource("anchored");
+  const SourceId global_source = scene_graph->RegisterSource("anchored");
   // Add a "ground" halfspace. Define the pose of the half space (H) in the
   // world from its normal (Hz_W) and a point on the plane (p_WH). In this case,
   // X_WH will be the identity.
   Vector3<double> Hz_W(0, 0, 1);
-  Vector3<double> p_WH(0, 0, 0);
-  GeometryId ground_id = scene_graph->RegisterAnchoredGeometry(
+  Vector3<double> p_WHo_W(0, 0, 0);
+  const GeometryId ground_id = scene_graph->RegisterAnchoredGeometry(
       global_source,
-      make_unique<GeometryInstance>(HalfSpace::MakePose(Hz_W, p_WH),
+      make_unique<GeometryInstance>(HalfSpace::MakePose(Hz_W, p_WHo_W),
                                     make_unique<HalfSpace>(), "ground"));
   scene_graph->AssignRole(global_source, ground_id, ProximityProperties());
   scene_graph->AssignRole(global_source, ground_id, IllustrationProperties());
@@ -74,7 +101,81 @@ int do_main() {
   builder.Connect(scene_graph->get_query_output_port(),
                   bouncing_ball2->get_geometry_query_input_port());
 
-  geometry::ConnectDrakeVisualizer(&builder, *scene_graph);
+  DrakeLcm lcm;
+  ConnectDrakeVisualizer(&builder, *scene_graph, &lcm);
+
+  if (FLAGS_render_on) {
+    PerceptionProperties properties;
+    properties.AddProperty("phong", "diffuse", Vector4d{0.8, 0.8, 0.8, 1.0});
+    properties.AddProperty("label", "id", RenderLabel(ground_id.get_value()));
+    scene_graph->AssignRole(global_source, ground_id, properties);
+
+    // Create the camera.
+    DepthCameraProperties camera_properties(640, 480, M_PI_4, render_name, 0.1,
+                                            2.0);
+    // We need to position and orient the camera. We have the camera body frame
+    // B (see rgbd_sensor.h) and the camera frame C (see camera_info.h).
+    // By default X_BC = I in the RgbdSensor. So, to aim the camera, Cz = Bz
+    // should point from the camera position to the origin. By points *down* the
+    // image, so we need to align it in the -Wz direction. So,  we compute the
+    // basis using camera Y-ish in the By ≈ -Wz direction to compute Bx, and
+    // then use Bx an and Bz to compute By.
+    const Vector3d p_WB(0.3, -1, 0.25);
+    // Set rotation looking at the origin.
+    const Vector3d Bz_W = -p_WB.normalized();
+    const Vector3d Bx_W = -Vector3d::UnitZ().cross(Bz_W).normalized();
+    const Vector3d By_W = Bz_W.cross(Bx_W).normalized();
+    const RotationMatrixd R_WB =
+        RotationMatrixd::MakeFromOrthonormalColumns(Bx_W, By_W, Bz_W);
+    const RigidTransformd X_WB(R_WB, p_WB);
+
+    auto camera = builder.AddSystem<RgbdSensor>(
+        scene_graph->world_frame_id(), X_WB, camera_properties);
+    builder.Connect(scene_graph->get_query_output_port(),
+                    camera->query_object_input_port());
+
+    // Broadcast the images.
+    // Publishing images to drake visualizer
+    auto image_to_lcm_image_array =
+        builder.template AddSystem<systems::sensors::ImageToLcmImageArrayT>();
+    image_to_lcm_image_array->set_name("converter");
+
+    systems::lcm::LcmPublisherSystem* image_array_lcm_publisher{nullptr};
+    if ((FLAGS_color || FLAGS_depth || FLAGS_label)) {
+      image_array_lcm_publisher =
+          builder.template AddSystem(systems::lcm::LcmPublisherSystem::Make<
+              robotlocomotion::image_array_t>(
+              "DRAKE_RGBD_CAMERA_IMAGES", &lcm,
+              1. / FLAGS_render_fps /* publish period */));
+      image_array_lcm_publisher->set_name("publisher");
+
+      builder.Connect(
+          image_to_lcm_image_array->image_array_t_msg_output_port(),
+          image_array_lcm_publisher->get_input_port());
+    }
+
+    if (FLAGS_color) {
+      const auto& port =
+          image_to_lcm_image_array->DeclareImageInputPort<PixelType::kRgba8U>(
+              "color");
+      builder.Connect(camera->color_image_output_port(), port);
+    }
+
+    if (FLAGS_depth) {
+      const auto& port =
+          image_to_lcm_image_array
+              ->DeclareImageInputPort<PixelType::kDepth32F>("depth");
+      builder.Connect(camera->depth_image_32F_output_port(), port);
+    }
+
+    if (FLAGS_label) {
+      const auto& port =
+          image_to_lcm_image_array
+              ->DeclareImageInputPort<PixelType::kLabel16I>("label");
+      builder.Connect(camera->label_image_output_port(), port);
+    }
+  }
+
   auto diagram = builder.Build();
 
   systems::Simulator<double> simulator(*diagram);


### PR DESCRIPTION
1. solar system -- there were various improvements made in
   dev/solar_system* that are being pulled into the mainstream.
   Specifically, making the instantiation of components more compact.
2. Bouncing ball -- the demo introduced cameras and broadcast images to
   the visualizer. This has all been moved into the mainstream.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11829)
<!-- Reviewable:end -->
