### PR TITLE
Add methods for sequential variables to  MultipleShooting

### DIFF
--- a/bindings/pydrake/systems/test/trajectory_optimization_test.py
+++ b/bindings/pydrake/systems/test/trajectory_optimization_test.py
@@ -78,6 +78,7 @@ class TestTrajectoryOptimization(unittest.TestCase):
         times = dircol.GetSampleTimes(result)
         inputs = dircol.GetInputSamples(result)
         states = dircol.GetStateSamples(result)
+        variables = dircol.GetSequentialVariableSamples(result, "test")
         input_traj = dircol.ReconstructInputTrajectory(result)
         state_traj = dircol.ReconstructStateTrajectory(result)
 

--- a/bindings/pydrake/systems/test/trajectory_optimization_test.py
+++ b/bindings/pydrake/systems/test/trajectory_optimization_test.py
@@ -59,6 +59,8 @@ class TestTrajectoryOptimization(unittest.TestCase):
         input_was_called = False
         global state_was_called
         state_was_called = False
+        global complete_was_called
+        complete_was_called = False
 
         def input_callback(t, u):
             global input_was_called
@@ -68,12 +70,18 @@ class TestTrajectoryOptimization(unittest.TestCase):
             global state_was_called
             state_was_called = True
 
+        def complete_callback(t, x, u, v):
+            global complete_was_called
+            complete_was_called = True
+
         dircol.AddInputTrajectoryCallback(input_callback)
         dircol.AddStateTrajectoryCallback(state_callback)
+        dircol.AddCompleteTrajectoryCallback(complete_callback, ["test"])
 
         result = mp.Solve(dircol)
         self.assertTrue(input_was_called)
         self.assertTrue(state_was_called)
+        self.assertTrue(complete_was_called)
 
         times = dircol.GetSampleTimes(result)
         inputs = dircol.GetInputSamples(result)

--- a/bindings/pydrake/systems/test/trajectory_optimization_test.py
+++ b/bindings/pydrake/systems/test/trajectory_optimization_test.py
@@ -40,6 +40,8 @@ class TestTrajectoryOptimization(unittest.TestCase):
         xf = dircol.final_state()
         u = dircol.input()
         u2 = dircol.input(2)
+        v = dircol.NewSequentialVariable(1, "test")
+        v2 = dircol.GetSequentialVariableAtIndex("test", 2)
 
         dircol.AddRunningCost(x.dot(x))
         dircol.AddConstraintToAllKnotPoints(u[0] == 0)

--- a/bindings/pydrake/systems/test/trajectory_optimization_test.py
+++ b/bindings/pydrake/systems/test/trajectory_optimization_test.py
@@ -40,8 +40,8 @@ class TestTrajectoryOptimization(unittest.TestCase):
         xf = dircol.final_state()
         u = dircol.input()
         u2 = dircol.input(2)
-        v = dircol.NewSequentialVariable(1, "test")
-        v2 = dircol.GetSequentialVariableAtIndex("test", 2)
+        v = dircol.NewSequentialVariable(rows=1, name="test")
+        v2 = dircol.GetSequentialVariableAtIndex(name="test", index=2)
 
         dircol.AddRunningCost(x.dot(x))
         dircol.AddConstraintToAllKnotPoints(u[0] == 0)
@@ -76,7 +76,8 @@ class TestTrajectoryOptimization(unittest.TestCase):
 
         dircol.AddInputTrajectoryCallback(input_callback)
         dircol.AddStateTrajectoryCallback(state_callback)
-        dircol.AddCompleteTrajectoryCallback(complete_callback, ["test"])
+        dircol.AddCompleteTrajectoryCallback(callback=complete_callback,
+                                             names=["test"])
 
         result = mp.Solve(dircol)
         self.assertTrue(input_was_called)
@@ -86,7 +87,8 @@ class TestTrajectoryOptimization(unittest.TestCase):
         times = dircol.GetSampleTimes(result)
         inputs = dircol.GetInputSamples(result)
         states = dircol.GetStateSamples(result)
-        variables = dircol.GetSequentialVariableSamples(result, "test")
+        variables = dircol.GetSequentialVariableSamples(result=result,
+                                                        name="test")
         input_traj = dircol.ReconstructInputTrajectory(result)
         state_traj = dircol.ReconstructStateTrajectory(result)
 

--- a/bindings/pydrake/systems/trajectory_optimization_py.cc
+++ b/bindings/pydrake/systems/trajectory_optimization_py.cc
@@ -112,6 +112,9 @@ PYBIND11_MODULE(trajectory_optimization, m) {
       .def("AddStateTrajectoryCallback",
           &MultipleShooting::AddStateTrajectoryCallback,
           doc.MultipleShooting.AddStateTrajectoryCallback.doc)
+      .def("AddCompleteTrajectoryCallback",
+          &MultipleShooting::AddCompleteTrajectoryCallback,
+          doc.MultipleShooting.AddCompleteTrajectoryCallback.doc)
       .def("SetInitialTrajectory", &MultipleShooting::SetInitialTrajectory,
           doc.MultipleShooting.SetInitialTrajectory.doc)
       .def("GetSampleTimes",

--- a/bindings/pydrake/systems/trajectory_optimization_py.cc
+++ b/bindings/pydrake/systems/trajectory_optimization_py.cc
@@ -69,12 +69,14 @@ PYBIND11_MODULE(trajectory_optimization, m) {
               const std::string& name) -> VectorXDecisionVariable {
             return self.NewSequentialVariable(rows, name);
           },
+          py::arg("rows"), py::arg("name"),
           doc.MultipleShooting.NewSequentialVariable.doc)
       .def("GetSequentialVariableAtIndex",
           [](const MultipleShooting& self, const std::string& name,
               int index) -> VectorXDecisionVariable {
             return self.GetSequentialVariableAtIndex(name, index);
           },
+          py::arg("name"), py::arg("index"),
           doc.MultipleShooting.GetSequentialVariableAtIndex.doc)
       .def("AddRunningCost",
           [](MultipleShooting& prog, const symbolic::Expression& g) {
@@ -113,7 +115,8 @@ PYBIND11_MODULE(trajectory_optimization, m) {
           &MultipleShooting::AddStateTrajectoryCallback,
           doc.MultipleShooting.AddStateTrajectoryCallback.doc)
       .def("AddCompleteTrajectoryCallback",
-          &MultipleShooting::AddCompleteTrajectoryCallback,
+          &MultipleShooting::AddCompleteTrajectoryCallback, py::arg("callback"),
+          py::arg("names"),
           doc.MultipleShooting.AddCompleteTrajectoryCallback.doc)
       .def("SetInitialTrajectory", &MultipleShooting::SetInitialTrajectory,
           doc.MultipleShooting.SetInitialTrajectory.doc)
@@ -136,6 +139,7 @@ PYBIND11_MODULE(trajectory_optimization, m) {
           overload_cast_explicit<Eigen::MatrixXd,
               const solvers::MathematicalProgramResult&, const std::string&>(
               &MultipleShooting::GetSequentialVariableSamples),
+          py::arg("result"), py::arg("name"),
           doc.MultipleShooting.GetSequentialVariableSamples.doc)
       .def("ReconstructInputTrajectory",
           overload_cast_explicit<trajectories::PiecewisePolynomial<double>,

--- a/bindings/pydrake/systems/trajectory_optimization_py.cc
+++ b/bindings/pydrake/systems/trajectory_optimization_py.cc
@@ -129,6 +129,11 @@ PYBIND11_MODULE(trajectory_optimization, m) {
               const solvers::MathematicalProgramResult&>(
               &MultipleShooting::GetStateSamples),
           doc.MultipleShooting.GetStateSamples.doc)
+      .def("GetSequentialVariableSamples",
+          overload_cast_explicit<Eigen::MatrixXd,
+              const solvers::MathematicalProgramResult&, const std::string&>(
+              &MultipleShooting::GetSequentialVariableSamples),
+          doc.MultipleShooting.GetSequentialVariableSamples.doc)
       .def("ReconstructInputTrajectory",
           overload_cast_explicit<trajectories::PiecewisePolynomial<double>,
               const solvers::MathematicalProgramResult&>(

--- a/bindings/pydrake/systems/trajectory_optimization_py.cc
+++ b/bindings/pydrake/systems/trajectory_optimization_py.cc
@@ -64,6 +64,18 @@ PYBIND11_MODULE(trajectory_optimization, m) {
           [](const MultipleShooting& self, int index)
               -> VectorXDecisionVariable { return self.input(index); },
           doc.MultipleShooting.input.doc_1args)
+      .def("NewSequentialVariable",
+          [](MultipleShooting& self, int rows,
+              const std::string& name) -> VectorXDecisionVariable {
+            return self.NewSequentialVariable(rows, name);
+          },
+          doc.MultipleShooting.NewSequentialVariable.doc)
+      .def("GetSequentialVariableAtIndex",
+          [](const MultipleShooting& self, const std::string& name,
+              int index) -> VectorXDecisionVariable {
+            return self.GetSequentialVariableAtIndex(name, index);
+          },
+          doc.MultipleShooting.GetSequentialVariableAtIndex.doc)
       .def("AddRunningCost",
           [](MultipleShooting& prog, const symbolic::Expression& g) {
             prog.AddRunningCost(g);

--- a/systems/trajectory_optimization/multiple_shooting.cc
+++ b/systems/trajectory_optimization/multiple_shooting.cc
@@ -241,6 +241,18 @@ Eigen::MatrixXd MultipleShooting::GetStateSamples(
   return states;
 }
 
+Eigen::MatrixXd MultipleShooting::GetSequentialVariableSamples(
+    const solvers::MathematicalProgramResult& result,
+    const std::string& name) const {
+  int num_sequential_variables = sequential_expression_manager_.num_rows(name);
+  Eigen::MatrixXd sequential_variables(num_sequential_variables, N_);
+  for (int i = 0; i < N_; i++) {
+    sequential_variables.col(i) =
+        result.GetSolution(GetSequentialVariableAtIndex(name, i));
+  }
+  return sequential_variables;
+}
+
 symbolic::Substitution
 MultipleShooting::ConstructPlaceholderVariableSubstitution(
     int interval_index) const {

--- a/systems/trajectory_optimization/multiple_shooting.cc
+++ b/systems/trajectory_optimization/multiple_shooting.cc
@@ -157,6 +157,46 @@ MultipleShooting::AddStateTrajectoryCallback(
       {h_vars_, x_vars_});
 }
 
+solvers::Binding<solvers::VisualizationCallback>
+MultipleShooting::AddCompleteTrajectoryCallback(
+    const MultipleShooting::CompleteTrajectoryCallback& callback,
+    const std::vector<std::string>& names) {
+  int num_extra_vars = 0;
+  std::vector<int> size_extra_vars;
+  for (size_t ii = 0; ii < names.size(); ii++) {
+    int num_rows = sequential_expression_manager_.num_rows(names[ii]);
+    num_extra_vars += num_rows;
+    size_extra_vars.push_back(num_rows);
+  }
+  solvers::VectorXDecisionVariable extra_vars(num_extra_vars * N_);
+  int row_offset = 0;
+  for (size_t ii = 0; ii < names.size(); ii++) {
+    extra_vars.middleRows(row_offset, size_extra_vars[ii] * N_) =
+        GetSequentialVariable(names[ii]);
+    row_offset += size_extra_vars[ii] * N_;
+  }
+
+  return AddVisualizationCallback(
+      [this, callback,
+       size_extra_vars](const Eigen::Ref<const Eigen::VectorXd>& x) {
+        const Eigen::VectorXd times = GetSampleTimes(x.head(h_vars_.size()));
+        const Eigen::Map<const Eigen::MatrixXd> states(
+            x.data() + h_vars_.size(), num_states_, N_);
+        const Eigen::Map<const Eigen::MatrixXd> inputs(
+            x.data() + h_vars_.size() + x_vars_.size(), num_inputs_, N_);
+        int data_offset = h_vars_.size() + u_vars_.size() + x_vars_.size();
+        std::vector<Eigen::Ref<const Eigen::MatrixXd>> extras_vec;
+        for (size_t ii = 0; ii < size_extra_vars.size(); ii++) {
+          const Eigen::Map<const Eigen::MatrixXd> extras(
+              x.data() + data_offset, size_extra_vars[ii], N_);
+          data_offset += size_extra_vars[ii] * N_;
+          extras_vec.push_back(extras);
+        }
+        callback(times, states, inputs, extras_vec);
+      },
+      {h_vars_, x_vars_, u_vars_, extra_vars});
+}
+
 void MultipleShooting::SetInitialTrajectory(
     const PiecewisePolynomial<double>& traj_init_u,
     const PiecewisePolynomial<double>& traj_init_x) {
@@ -263,6 +303,17 @@ MultipleShooting::ConstructPlaceholderVariableSubstitution(
 symbolic::Expression MultipleShooting::SubstitutePlaceholderVariables(
     const symbolic::Expression& e, int interval_index) const {
   return e.Substitute(ConstructPlaceholderVariableSubstitution(interval_index));
+}
+
+const solvers::VectorXDecisionVariable MultipleShooting::GetSequentialVariable(
+    const std::string& name) const {
+  int rows = sequential_expression_manager_.num_rows(name);
+  VectorX<symbolic::Expression> sequential_variable(rows * N_);
+  for (int i = 0; i < N_; i++) {
+    sequential_variable.segment(i * rows, rows) =
+        sequential_expression_manager_.GetSequentialExpressionsByName(name, i);
+  }
+  return symbolic::GetVariableVector(sequential_variable);
 }
 
 symbolic::Formula MultipleShooting::SubstitutePlaceholderVariables(

--- a/systems/trajectory_optimization/multiple_shooting.h
+++ b/systems/trajectory_optimization/multiple_shooting.h
@@ -215,8 +215,8 @@ class MultipleShooting : public solvers::MathematicalProgram {
       CompleteTrajectoryCallback;
 
   /**
-   * Adds a callback method to visualize intermediate results of the
-   * trajectory optimization.  The callback should be of the form
+   * Adds a callback method to visualize intermediate results of input variables
+   * used in the trajectory optimization.  The callback should be of the form
    *   MyVisualization(sample_times, values),
    * where breaks is a N-by-1 VectorXd of sample times, and values is a
    * num_inputs-by-N MatrixXd representing the current (intermediate) value of
@@ -232,8 +232,8 @@ class MultipleShooting : public solvers::MathematicalProgram {
   AddInputTrajectoryCallback(const TrajectoryCallback& callback);
 
   /**
-   * Adds a callback method to visualize intermediate results of the
-   * trajectory optimization.  The callback should be of the form
+   * Adds a callback method to visualize intermediate results of state variables
+   * used in the trajectory optimization.  The callback should be of the form
    *   MyVisualization(sample_times, values),
    * where sample_times is a N-by-1 VectorXd of sample times, and values is a
    * num_states-by-N MatrixXd representing the current (intermediate) value of
@@ -249,15 +249,15 @@ class MultipleShooting : public solvers::MathematicalProgram {
   AddStateTrajectoryCallback(const TrajectoryCallback& callback);
 
   /**
-   * Adds a callback method to visualize intermediate results of the
-   * trajectory optimization.  The callback should be of the form
+   * Adds a callback method to visualize intermediate results of all variables
+   * used in the trajectory optimization.  The callback should be of the form
    *   MyVisualization(sample_times, states, inputs, values),
    * where sample_times is an N-by-1 VectorXd of sample times, states is a
    * num_states-by-N MatrixXd of the current (intermediate) state trajectory at
    * the break points, inputs is a num_inputs-by-N MatrixXd of the current
    * (intermediate) input trajectory at the break points and values is a
    * vector of num_rows-by-N MatrixXds of the current (intermediate) extra
-   * sequenctial variables specified by @p names at the break points.
+   * sequential variables specified by @p names at the break points.
    *
    * @note Just like other costs/constraints, not all solvers support callbacks.
    * Adding a callback here will force MathematicalProgram::Solve to select a

--- a/systems/trajectory_optimization/multiple_shooting.h
+++ b/systems/trajectory_optimization/multiple_shooting.h
@@ -287,6 +287,12 @@ class MultipleShooting : public solvers::MathematicalProgram {
   Eigen::MatrixXd GetStateSamples(
       const solvers::MathematicalProgramResult& result) const;
 
+  /// Returns a matrix containing the sequential variable values (arranged in
+  /// columns) at each knot point at the solution.
+  Eigen::MatrixXd GetSequentialVariableSamples(
+      const solvers::MathematicalProgramResult& result,
+      const std::string& name) const;
+
   /// Get the input trajectory at the solution as a PiecewisePolynomial.  The
   /// order of the trajectory will be determined by the integrator used in
   /// the dynamic constraints.  Requires that the system has at least one input

--- a/systems/trajectory_optimization/multiple_shooting.h
+++ b/systems/trajectory_optimization/multiple_shooting.h
@@ -252,14 +252,14 @@ class MultipleShooting : public solvers::MathematicalProgram {
    * Adds a callback method to visualize intermediate results of the
    * trajectory optimization.  The callback should be of the form
    *   MyVisualization(sample_times, states, inputs, values),
-   * where sample_times is a N-by-1 VectorXd of sample times, states is a
+   * where sample_times is an N-by-1 VectorXd of sample times, states is a
    * num_states-by-N MatrixXd of the current (intermediate) state trajectory at
    * the break points, inputs is a num_inputs-by-N MatrixXd of the current
    * (intermediate) input trajectory at the break points and values is a
-   * num_extra-by-N MatrixXd of the current (intermediate) extra variable
-   * trajectory at the break points.
+   * vector of num_rows-by-N MatrixXds of the current (intermediate) extra
+   * sequenctial variables specified by @p names at the break points.
    *
-   * Note: Just like other costs/constraints, not all solvers support callbacks.
+   * @note Just like other costs/constraints, not all solvers support callbacks.
    * Adding a callback here will force MathematicalProgram::Solve to select a
    * solver that support callbacks.  For instance, adding a visualization
    * callback to a quadratic programming problem may result in using a nonlinear
@@ -316,6 +316,9 @@ class MultipleShooting : public solvers::MathematicalProgram {
 
   /// Returns a matrix containing the sequential variable values (arranged in
   /// columns) at each knot point at the solution.
+  ///
+  /// @param name The name of sequential variable to get the results for.  Must
+  /// correspond to an already added sequential variable.
   Eigen::MatrixXd GetSequentialVariableSamples(
       const solvers::MathematicalProgramResult& result,
       const std::string& name) const;

--- a/systems/trajectory_optimization/sequential_expression_manager.cc
+++ b/systems/trajectory_optimization/sequential_expression_manager.cc
@@ -61,6 +61,13 @@ SequentialExpressionManager::GetSequentialExpressionsByName(
   return sequential_expressions.col(index);
 }
 
+int SequentialExpressionManager::num_rows(const std::string& name) const {
+  const auto it = name_to_placeholders_and_sequential_expressions_.find(name);
+  DRAKE_THROW_UNLESS(it !=
+                     name_to_placeholders_and_sequential_expressions_.end());
+  return it->second.first.size();
+}
+
 }  // namespace internal
 }  // namespace trajectory_optimization
 }  // namespace systems

--- a/systems/trajectory_optimization/sequential_expression_manager.h
+++ b/systems/trajectory_optimization/sequential_expression_manager.h
@@ -73,6 +73,12 @@ class SequentialExpressionManager {
    */
   int num_samples() const { return num_samples_; }
 
+  /**
+   * Returns the number of rows for the sequential expression vector `name`.
+   * @pre `name` is associated with a registered sequential expression vector.
+   */
+  int num_rows(const std::string& name) const;
+
  private:
   int num_samples_{};
   std::unordered_map<std::string, std::pair<VectorX<symbolic::Variable>,

--- a/systems/trajectory_optimization/test/sequential_expression_manager_test.cc
+++ b/systems/trajectory_optimization/test/sequential_expression_manager_test.cc
@@ -45,6 +45,7 @@ TEST_F(SequentialExpressionManagerTests, RegisterAndSubstituteExpressionTest) {
   x_sequential.cwiseSqrt();
   VectorX<Variable> x_placeholder =
       dut_.RegisterSequentialExpressions(x_sequential.cast<Expression>(), "x");
+  EXPECT_EQ(dut_.num_rows("x"), num_variables_);
   MatrixX<Expression> placeholder_expression =
       x_placeholder * x_placeholder.transpose();
   for (int j = 0; j < num_samples_; ++j) {


### PR DESCRIPTION
Add methods for sequential variables to  MultipleShooting
Commits are organized as follows:
- Adds bindings for already existing sequential variable methods
- Adds method for extracting the sequential variable values from results
- Enables adding a callback method that takes in time, state, input and sequential variables

These commits are arranged by how much discussion I believe each piece requires before being merged or not (from least to most).  I'm happy to drop any components from this PR that don't seem useful and keep them for my own purposes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11835)
<!-- Reviewable:end -->
