### PR TITLE
math: Clarify RigidTransform method deprecation date

### DIFF
--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -37,13 +37,16 @@ void DoScalarDependentDefinitions(py::module m, T) {
 
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
   using namespace drake::math;
-  const char* doc_iso3_deprecation =
-      "DO NOT USE!. We only offer this API for backwards compatibility with "
-      "Isometry3 and it will be deprecated soon with the resolution of "
-      "#9865. This will be removed on or around 2019-08-01.";
-
   constexpr auto& doc = pydrake_doc.drake.math;
+
   {
+    // N.B. Keep the deprecation date here in sync with the deprecation comment
+    // inside drake/math/rigid_transform.h.
+    const char* doc_rigid_transform_linear_matrix_deprecation =
+        "DO NOT USE! We offer this API for backwards compatibility with "
+        "Isometry3, but it will be removed on or around 2019-12-01. "
+        "See drake issue #9865 for details.";
+
     using Class = RigidTransform<T>;
     constexpr auto& cls_doc = doc.RigidTransform;
     auto cls = DefineTemplateClassWithDefault<Class>(
@@ -107,9 +110,10 @@ void DoScalarDependentDefinitions(py::module m, T) {
               return *self * p_BoQ_B;
             },
             py::arg("p_BoQ_B"), cls_doc.operator_mul.doc_1args_p_BoQ_B)
-        .def("matrix", &RigidTransform<T>::matrix, doc_iso3_deprecation)
+        .def("matrix", &RigidTransform<T>::matrix,
+            doc_rigid_transform_linear_matrix_deprecation)
         .def("linear", &RigidTransform<T>::linear, py_reference_internal,
-            doc_iso3_deprecation);
+            doc_rigid_transform_linear_matrix_deprecation);
     cls.attr("__matmul__") = cls.attr("multiply");
     DefCopyAndDeepCopy(&cls);
     // .def("IsNearlyEqualTo", ...)

--- a/math/rigid_transform.h
+++ b/math/rigid_transform.h
@@ -334,9 +334,12 @@ class RigidTransform {
 
 #ifndef DRAKE_DOXYGEN_CXX
   // DO NOT USE. These methods will soon be deprecated as #9865 is resolved.
-  // They are only provided to support backwards compatibility with
-  // Isometry3 as we migrate Drake's codebase to use RigidTransform. New uses of
-  // Isometry3 are discouraged.
+  // They are only provided to support backwards compatibility with Isometry3
+  // as we migrate Drake's codebase to use RigidTransform. New uses of
+  // Isometry3 are discouraged. These methods will remain intact (though
+  // possibly marked as deprecated) until at least 2019-12-01. N.B. Keep the
+  // deprecation date here in sync with the deprecation comment inside
+  // drake/bindings/pydrake/math_py.cc.
   operator Isometry3<T>() const { return GetAsIsometry3(); }
   const Matrix3<T>& linear() const { return R_AB_.matrix(); }
   Matrix4<T> matrix() const { return GetAsMatrix4(); }


### PR DESCRIPTION
Because we haven't even marked the C++ methods deprecated yet (and can't even do so soon, because there is much more porting to do in #9865), we should promise a minimum of four months window.  This is both clearer and less work than bumping the date to the immediately next month each month.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11846)
<!-- Reviewable:end -->
