### PR TITLE
Corrects pose smoother test for the usage of normalized quaternions

### DIFF
--- a/manipulation/perception/pose_smoother.cc
+++ b/manipulation/perception/pose_smoother.cc
@@ -69,13 +69,8 @@ Isometry3d Vector7ToIsometry3d(const VectorX<double>& pose_vector) {
   Quaterniond quaternion(pose_vector(3), pose_vector(4),
                          pose_vector(5), pose_vector(6));
   Isometry3<double> pose = Isometry3<double>::Identity();
-  // TODO(Mitiguy) Ask Naveen to respond to newly created issue 10167 which
-  // requests documentation (or a comment) about the un-normalized quaternion,
-  // which allows for quaternion.toRotationMatrix() to return a non-orthonormal
-  // matrix.  However, manipulation/perception/test/pose_smoother_test.cc fails
-  // (why?) if the next line is uncommented (which makes me question the test).
-  // quaternion = quaternion.normalized();
-  pose.linear() = quaternion.toRotationMatrix();  // This is not orthonormal!
+  quaternion = quaternion.normalized();
+  pose.linear() = quaternion.toRotationMatrix();
   pose.translation() = pose_vector.head<3>();
   pose.makeAffine();
   // TODO(Mitiguy) If this function can or should use a normalized quaternion,

--- a/manipulation/perception/test/pose_smoother_test.cc
+++ b/manipulation/perception/test/pose_smoother_test.cc
@@ -177,11 +177,12 @@ TEST_F(PoseSmootherTest, SmootherTest) {
 
   expected_output_state_1.pose.translation() << 0.01, -5, 10.1;
   expected_output_state_1.pose.linear() =
-      (Eigen::MatrixXd(3, 3) << 1, 0, 0, 0, 0.67319401200771101,
-       -0.73922055347988902, 0, 0.73922055347988902, 0.67319401200771101)
-          .finished();
+      (Eigen::MatrixXd(3, 3) <<
+        1, 0, 0,
+        0,  0.67301251350977331, -0.73963109497860968,
+        0,  0.73963109497860968,  0.67301251350977331).finished();
 
-  expected_output_state_1.velocity << 0, 0, 0, 4.670903542103451, 0, 0;
+  expected_output_state_1.velocity << 0, 0, 0, 4.7123889803846719, 0, 0;
   EXPECT_TRUE(CompareTransforms(output_state_1.pose,
                                 expected_output_state_1.pose,
                                 kPoseComparisonTolerance));
@@ -200,11 +201,12 @@ TEST_F(PoseSmootherTest, SmootherTest) {
 
   expected_output_state_2.pose.translation() << 0.01, -5, 10.1;
   expected_output_state_2.pose.linear() =
-      (MatrixX<double>(3, 3) << 1, 0, 0, 0, 0.66147703270805791,
-       -0.74974268135601596, 0, 0.74974268135601596, 0.66147703270805791)
-          .finished();
+      (MatrixX<double>(3, 3) <<
+        1,  0,  0,
+        0,  0.66130992678343126,  -0.75011277867910831,
+        0,  0.75011277867910831,   0.66130992678343126).finished();
 
-  expected_output_state_2.velocity << 0, 0, 0, 1.5751117688894509, 0, 0;
+  expected_output_state_2.velocity << 0, 0, 0, 1.571054760257719, 0, 0;
   EXPECT_TRUE(CompareTransforms(output_state_2.pose,
                                 expected_output_state_2.pose,
                                 kPoseComparisonTolerance));
@@ -231,7 +233,7 @@ TEST_F(PoseSmootherTest, SmootherTest) {
        -0.77051324277578903, 0, 0.77051324277578903, 0.63742398974868997)
           .finished();
   expected_output_state_3.pose.makeAffine();
-  expected_output_state_3.velocity << 1.0, 0, 0, 3.1786156325620212, 0, 0;
+  expected_output_state_3.velocity << 1.0, 0, 0, 3.1413342201269292, 0, 0;
 
   EXPECT_TRUE(
       (CompareTransforms(output_state_3.pose, expected_output_state_3.pose,


### PR DESCRIPTION
Addressed the problem raised in #10167

These numbers were hand computed. I corrected them to compensate for the normalized quaternion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11848)
<!-- Reviewable:end -->
