### PR TITLE
py: Expose `.cast[T]()` for SE(3)-related values

### DIFF
--- a/bindings/pydrake/common/BUILD.bazel
+++ b/bindings/pydrake/common/BUILD.bazel
@@ -115,6 +115,7 @@ drake_cc_library(
     declare_installed_headers = 0,
     visibility = ["//visibility:public"],
     deps = [
+        ":cpp_template_pybind",
         ":type_pack",
         "//:drake_shared_library",
         "//bindings/pydrake:autodiff_types_pybind",

--- a/bindings/pydrake/common/eigen_geometry_py.cc
+++ b/bindings/pydrake/common/eigen_geometry_py.cc
@@ -27,6 +27,7 @@ using std::abs;
 // N.B. Use a loose tolerance, so that we don't have to be super strict with
 // C++.
 const double kCheckTolerance = 1e-5;
+constexpr char kCastDoc[] = "Cast to desired scalar type.";
 
 using symbolic::Expression;
 
@@ -176,6 +177,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
     cls.attr("__matmul__") = cls.attr("multiply");
     py::implicitly_convertible<Matrix4<T>, Class>();
     DefCopyAndDeepCopy(&cls);
+    DefCast<T>(&cls, kCastDoc);
   }
 
   // Quaternion.
@@ -265,6 +267,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("conjugate", [](const Class* self) { return self->conjugate(); });
     cls.attr("__matmul__") = cls.attr("multiply");
     DefCopyAndDeepCopy(&cls);
+    DefCast<T>(&cls, kCastDoc);
   }
 
   // Angle-axis.
@@ -343,6 +346,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("inverse", [](const Class* self) { return self->inverse(); });
     cls.attr("__matmul__") = cls.attr("multiply");
     DefCopyAndDeepCopy(&cls);
+    DefCast<T>(&cls, kCastDoc);
   }
 }
 

--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -112,6 +112,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
             doc_iso3_deprecation);
     cls.attr("__matmul__") = cls.attr("multiply");
     DefCopyAndDeepCopy(&cls);
+    DefCast<T>(&cls, cls_doc.cast.doc);
     // .def("IsNearlyEqualTo", ...)
     // .def("IsExactlyEqualTo", ...)
   }
@@ -167,6 +168,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.ToQuaternion.doc_0args);
     cls.attr("__matmul__") = cls.attr("multiply");
     DefCopyAndDeepCopy(&cls);
+    DefCast<T>(&cls, cls_doc.cast.doc);
   }
 
   {
@@ -218,6 +220,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::arg("alpha_AD_D"),
             cls_doc.CalcRpyDDtFromAngularAccelInChild.doc);
     DefCopyAndDeepCopy(&cls);
+    // N.B. `RollPitchYaw::cast` is not defined in C++.
   }
 
   auto eigen_geometry_py = py::module::import("pydrake.common.eigen_geometry");

--- a/bindings/pydrake/test/math_test.py
+++ b/bindings/pydrake/test/math_test.py
@@ -96,6 +96,16 @@ class TestMath(unittest.TestCase):
         for f_core, f_cpp in binary:
             self.assertEqual(f_core(a, b), f_cpp(a, b))
 
+    def check_cast(self, template, T):
+        value = template[T]()
+        # Refer to docstrings for `CastUPack` in `default_scalars_pybind.h`.
+        if T == float:
+            U_list = [float, AutoDiffXd, Expression]
+        else:
+            U_list = [T]
+        for U in U_list:
+            self.assertIsInstance(value.cast[U](), template[U], U)
+
     @numpy_compare.check_all_types
     def test_rigid_transform(self, T):
         RigidTransform = mut.RigidTransform_[T]
@@ -128,6 +138,8 @@ class TestMath(unittest.TestCase):
         check_equality(RigidTransform(theta_lambda=angle_axis, p=p_I), X_I)
         check_equality(RigidTransform(R=R_I), X_I)
         check_equality(RigidTransform(p=p_I), X_I)
+        # - Cast.
+        self.check_cast(mut.RigidTransform_, T)
         # - Accessors, mutators, and general methods.
         X = RigidTransform()
         X.set(R=R_I, p=p_I)
@@ -196,6 +208,8 @@ class TestMath(unittest.TestCase):
             numpy_compare.assert_float_equal(R.col(index=0), [1., 0., 0.])
         R.set(R=np.eye(3))
         numpy_compare.assert_float_equal(R.matrix(), np.eye(3))
+        # - Cast.
+        self.check_cast(mut.RotationMatrix_, T)
         # - Nontrivial quaternion.
         q = Quaternion(wxyz=[0.5, 0.5, 0.5, 0.5])
         R = RotationMatrix(quaternion=q)


### PR DESCRIPTION
Resolves #11668 (at least for immediately related types)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11851)
<!-- Reviewable:end -->
