### PR TITLE
Revert "Remove dev/geometry dependencies from ManipulationStation"

### DIFF
--- a/examples/manipulation_station/BUILD.bazel
+++ b/examples/manipulation_station/BUILD.bazel
@@ -35,7 +35,8 @@ drake_cc_library(
     deps = [
         "//common:find_resource",
         "//geometry:scene_graph",
-        "//geometry/render:render_engine_vtk",
+        "//geometry/dev:scene_graph",
+        "//geometry/dev/render:render_engine_vtk",
         "//manipulation/schunk_wsg:schunk_wsg_constants",
         "//manipulation/schunk_wsg:schunk_wsg_position_controller",
         "//math:geometric_transform",
@@ -43,7 +44,7 @@ drake_cc_library(
         "//multibody/plant",
         "//systems/controllers:inverse_dynamics_controller",
         "//systems/framework",
-        "//systems/sensors:rgbd_sensor",
+        "//systems/sensors/dev:rgbd_camera",
     ],
 )
 
@@ -121,7 +122,6 @@ drake_cc_googletest(
     deps = [
         ":manipulation_station",
         "//common/test_utilities:eigen_matrix_compare",
-        "//geometry/test_utilities:dummy_render_engine",
     ],
 )
 

--- a/examples/manipulation_station/manipulation_station.h
+++ b/examples/manipulation_station/manipulation_station.h
@@ -7,11 +7,13 @@
 #include <vector>
 
 #include "drake/common/eigen_types.h"
-#include "drake/geometry/render/render_engine.h"
+#include "drake/geometry/dev/render/render_engine.h"
+#include "drake/geometry/dev/scene_graph.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/systems/framework/diagram.h"
+#include "drake/systems/sensors/dev/rgbd_camera.h"
 
 namespace drake {
 namespace examples {
@@ -242,19 +244,19 @@ class ManipulationStation : public systems::Diagram<T> {
       const multibody::Frame<T>& child_frame,
       const math::RigidTransform<double>& X_PC);
 
-  /// Registers a RGBD sensor. Must be called before Finalize().
+  /// Registers a RGBD camera. Must be called before Finalize().
   /// @param name Name for the camera.
   /// @param parent_frame The parent frame (frame P). The body that
   /// @p parent_frame is attached to must have a corresponding
   /// geometry::FrameId. Otherwise, an exception will be thrown in Finalize().
   /// @param X_PCameraBody Transformation between frame P and the camera body.
-  /// see systems::sensors:::RgbdSensor for descriptions about how the
+  /// see systems::sensors::dev::RgbdCamera for descriptions about how the
   /// camera body, RGB, and depth image frames are related.
   /// @param properties Properties for the RGBD camera.
-  void RegisterRgbdSensor(
+  void RegisterRgbdCamera(
       const std::string& name, const multibody::Frame<T>& parent_frame,
       const math::RigidTransform<double>& X_PCameraBody,
-      const geometry::render::DepthCameraProperties& properties);
+      const geometry::dev::render::DepthCameraProperties& properties);
 
   /// Adds a single object for the robot to manipulate
   /// @note Must be called before Finalize().
@@ -280,7 +282,7 @@ class ManipulationStation : public systems::Diagram<T> {
   /// manipulation station uses. Calling this method with an empty map is
   /// equivalent to calling Finalize(). See Finalize() for more details.
   void Finalize(std::map<std::string,
-                         std::unique_ptr<geometry::render::RenderEngine>>
+                         std::unique_ptr<geometry::dev::render::RenderEngine>>
                     render_engines);
 
   /// Returns a reference to the main plant responsible for the dynamics of
@@ -311,6 +313,30 @@ class ManipulationStation : public systems::Diagram<T> {
 
   /// Returns the name of the station's default renderer.
   static std::string default_renderer_name() { return default_renderer_name_; }
+
+  /// Returns a const reference to the SceneGraph used for rendering
+  /// camera images. Since the SceneGraph for rendering is constructed in
+  /// Finalize(), this throws when called before Finalize().
+  /// Note: the current implementation of the manipulation station uses a
+  /// separate development version of SceneGraph for rendering (as opposed to
+  /// the one returned by get_scene_graph() used for contact detection and
+  /// visualization). This method will be deprecated soon.
+  const geometry::dev::SceneGraph<T>& get_render_scene_graph() const {
+    DRAKE_THROW_UNLESS(render_scene_graph_);
+    return *render_scene_graph_;
+  }
+
+  /// Returns a mutable reference to the SceneGraph used for rendering
+  /// camera images. Since the SceneGraph for rendering is constructed in
+  /// Finalize(), this throws when called before Finalize().
+  /// Note: the current implementation of the manipulation station uses a
+  /// separate development version of SceneGraph for rendering (as opposed to
+  /// the one returned by get_scene_graph() used for contact detection and
+  /// visualization). This method will be deprecated soon.
+  geometry::dev::SceneGraph<T>& get_mutable_render_scene_graph() {
+    DRAKE_THROW_UNLESS(render_scene_graph_);
+    return *render_scene_graph_;
+  }
 
   /// Return a reference to the plant used by the inverse dynamics controller
   /// (which contains only a model of the iiwa + equivalent mass of the
@@ -446,7 +472,7 @@ class ManipulationStation : public systems::Diagram<T> {
   struct CameraInformation {
     const multibody::Frame<T>* parent_frame{};
     math::RigidTransform<double> X_PC{math::RigidTransform<double>::Identity()};
-    geometry::render::DepthCameraProperties properties{
+    geometry::dev::render::DepthCameraProperties properties{
         0, 0, 0, default_renderer_name_, 0, 0};
   };
 
@@ -465,6 +491,8 @@ class ManipulationStation : public systems::Diagram<T> {
   std::unique_ptr<multibody::MultibodyPlant<T>> owned_controller_plant_;
   multibody::MultibodyPlant<T>* plant_;
   geometry::SceneGraph<T>* scene_graph_;
+  // This is made in Finalize().
+  geometry::dev::SceneGraph<T>* render_scene_graph_{};
   static constexpr const char* default_renderer_name_ =
       "manip_station_renderer";
 

--- a/examples/manipulation_station/test/manipulation_station_test.cc
+++ b/examples/manipulation_station/test/manipulation_station_test.cc
@@ -6,7 +6,6 @@
 
 #include "drake/common/find_resource.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
-#include "drake/geometry/test_utilities/dummy_render_engine.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/multibody/tree/revolute_joint.h"
 #include "drake/systems/primitives/discrete_derivative.h"
@@ -19,7 +18,6 @@ namespace {
 
 using Eigen::Vector2d;
 using Eigen::VectorXd;
-using geometry::internal::DummyRenderEngine;
 using multibody::RevoluteJoint;
 using systems::BasicVector;
 
@@ -350,7 +348,7 @@ GTEST_TEST(ManipulationStationTest, RegisterRgbdCameraTest) {
     multibody::MultibodyPlant<double>& plant =
         dut.get_mutable_multibody_plant();
 
-    geometry::render::DepthCameraProperties camera_properties(
+    geometry::dev::render::DepthCameraProperties camera_properties(
         640, 480, M_PI_4, dut.default_renderer_name(), 0.1, 2.0);
 
     const Eigen::Translation3d X_WF0(0, 0, 0.2);
@@ -358,14 +356,14 @@ GTEST_TEST(ManipulationStationTest, RegisterRgbdCameraTest) {
     const auto& frame0 =
         plant.AddFrame(std::make_unique<multibody::FixedOffsetFrame<double>>(
             "frame0", plant.world_frame(), X_WF0));
-    dut.RegisterRgbdSensor("camera0", frame0, X_F0C0, camera_properties);
+    dut.RegisterRgbdCamera("camera0", frame0, X_F0C0, camera_properties);
 
     const Eigen::Translation3d X_F0F1(0, -0.1, 0.2);
     const Eigen::Translation3d X_F1C1(-0.2, 0.2, 0.33);
     const auto& frame1 =
         plant.AddFrame(std::make_unique<multibody::FixedOffsetFrame<double>>(
             "frame1", frame0, X_F0F1));
-    dut.RegisterRgbdSensor("camera1", frame1, X_F1C1, camera_properties);
+    dut.RegisterRgbdCamera("camera1", frame1, X_F1C1, camera_properties);
 
     std::map<std::string, math::RigidTransform<double>> camera_poses =
         dut.GetStaticCameraPosesInWorld();
@@ -377,6 +375,63 @@ GTEST_TEST(ManipulationStationTest, RegisterRgbdCameraTest) {
   }
 }
 
+// TODO(SeanCurtis-TRI): Refactor this (and other copies of it) into a geometry
+// test utility.
+// A simple dummy render engine implementation to facilitate testing. The
+// methods are mostly no-ops. The single exception is in registering geometry.
+// Every call returns a valid RenderIndex with the value `n` for the `n`th
+// call to `RegisterVisual()`.
+class DummyRenderEngine final : public geometry::dev::render::RenderEngine {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DummyRenderEngine);
+  DummyRenderEngine() = default;
+  void UpdateViewpoint(const Eigen::Isometry3d&) const final {}
+  void RenderColorImage(const geometry::dev::render::CameraProperties&,
+                        systems::sensors::ImageRgba8U*, bool) const final {}
+  void RenderDepthImage(const geometry::dev::render::DepthCameraProperties&,
+                        systems::sensors::ImageDepth32F*) const final {}
+  void RenderLabelImage(const geometry::dev::render::CameraProperties&,
+                        systems::sensors::ImageLabel16I*, bool) const final {}
+  void ImplementGeometry(const geometry::Sphere& sphere,
+                         void* user_data) final {}
+  void ImplementGeometry(const geometry::Cylinder& cylinder,
+                         void* user_data) final {}
+  void ImplementGeometry(const geometry::HalfSpace& half_space,
+                         void* user_data) final {}
+  void ImplementGeometry(const geometry::Box& box, void* user_data) final {}
+  void ImplementGeometry(const geometry::Mesh& mesh, void* user_data) final {}
+  void ImplementGeometry(const geometry::Convex& convex,
+                         void* user_data) final {}
+
+  void set_moved_render_index(optional<geometry::dev::RenderIndex> index) {
+    moved_render_index_ = index;
+  }
+
+ protected:
+  optional<geometry::dev::RenderIndex> DoRegisterVisual(
+      const geometry::Shape&, const geometry::dev::PerceptionProperties&,
+      const Isometry3<double>&) final {
+    return geometry::dev::RenderIndex(calls_to_register_++);
+  }
+  void DoUpdateVisualPose(const Eigen::Isometry3d&,
+                          geometry::dev::RenderIndex) final {}
+
+  optional<geometry::dev::RenderIndex> DoRemoveGeometry(
+      geometry::dev::RenderIndex index) final {
+    return moved_render_index_;
+  }
+
+  std::unique_ptr<geometry::dev::render::RenderEngine> DoClone() const final {
+    return std::make_unique<DummyRenderEngine>(*this);
+  }
+
+ private:
+  int calls_to_register_{};
+  // The value that `DoRemoveGeometry()` returns. Configurable by test. Defaults
+  // to returning nothing.
+  optional<geometry::dev::RenderIndex> moved_render_index_{nullopt};
+};
+
 // Confirms initialization of renderers. With none specified, the default
 // renderer is used. Otherwise, the user-specified renderers are provided.
 GTEST_TEST(ManipulationStationTest, ConfigureRenderer) {
@@ -385,7 +440,7 @@ GTEST_TEST(ManipulationStationTest, ConfigureRenderer) {
     ManipulationStation<double> dut;
     dut.SetupManipulationClassStation();
     dut.Finalize();
-    const auto& scene_graph = dut.get_scene_graph();
+    const auto& scene_graph = dut.get_render_scene_graph();
     EXPECT_EQ(1, scene_graph.RendererCount());
     EXPECT_TRUE(scene_graph.HasRenderer(dut.default_renderer_name()));
   }
@@ -394,7 +449,7 @@ GTEST_TEST(ManipulationStationTest, ConfigureRenderer) {
   {
     ManipulationStation<double> dut;
     dut.SetupManipulationClassStation();
-    std::map<std::string, std::unique_ptr<geometry::render::RenderEngine>>
+    std::map<std::string, std::unique_ptr<geometry::dev::render::RenderEngine>>
         engines;
     const std::string name1 = "engine1";
     engines[name1] = std::make_unique<DummyRenderEngine>();
@@ -402,7 +457,7 @@ GTEST_TEST(ManipulationStationTest, ConfigureRenderer) {
     engines[name2] = std::make_unique<DummyRenderEngine>();
     dut.Finalize(std::move(engines));
 
-    const auto& scene_graph = dut.get_scene_graph();
+    const auto& scene_graph = dut.get_render_scene_graph();
     EXPECT_EQ(2, scene_graph.RendererCount());
     EXPECT_TRUE(scene_graph.HasRenderer(name1));
     EXPECT_TRUE(scene_graph.HasRenderer(name2));


### PR DESCRIPTION
Reverts RobotLocomotion/drake#11839

Missing SceneGraph::Clone() maybe more.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11861)
<!-- Reviewable:end -->
