### PR TITLE
Stripping out Isometry3 from geometry/

### DIFF
--- a/attic/manipulation/util/frame_pose_tracker.cc
+++ b/attic/manipulation/util/frame_pose_tracker.cc
@@ -11,6 +11,7 @@ namespace manipulation {
 namespace util {
 
 using drake::systems::KinematicsResults;
+using drake::math::RigidTransformd;
 
 FramePoseTracker::FramePoseTracker(
     const RigidBodyTree<double>& tree,
@@ -120,8 +121,8 @@ void FramePoseTracker::OutputStatus(
        it != frame_name_to_frame_map_.end(); ++it) {
     output->set_value(
         frame_name_to_id_map_.at(it->first),
-        tree_->CalcFramePoseInWorldFrame(
-            kinematic_results->get_cache(), *(it->second.get())));
+        RigidTransformd(tree_->CalcFramePoseInWorldFrame(
+            kinematic_results->get_cache(), *(it->second.get()))));
   }
 }
 

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -8,10 +8,9 @@ import numpy as np
 
 from pydrake.autodiffutils import AutoDiffXd
 from pydrake.common import FindResourceOrThrow
-from pydrake.common.eigen_geometry import Isometry3_
 from pydrake.common.test_utilities import numpy_compare
 from pydrake.lcm import DrakeMockLcm
-from pydrake.math import RigidTransform
+from pydrake.math import RigidTransform_
 from pydrake.symbolic import Expression
 from pydrake.systems.framework import DiagramBuilder_, InputPort_, OutputPort_
 from pydrake.systems.sensors import (
@@ -75,13 +74,13 @@ class TestGeometry(unittest.TestCase):
     @numpy_compare.check_nonsymbolic_types
     def test_frame_pose_vector_api(self, T):
         FramePoseVector = mut.FramePoseVector_[T]
-        Isometry3 = Isometry3_[T]
+        RigidTransform = RigidTransform_[T]
         obj = FramePoseVector()
         frame_id = mut.FrameId.get_new_id()
 
-        obj.set_value(id=frame_id, value=Isometry3.Identity())
+        obj.set_value(id=frame_id, value=RigidTransform.Identity())
         self.assertEqual(obj.size(), 1)
-        self.assertIsInstance(obj.value(id=frame_id), Isometry3)
+        self.assertIsInstance(obj.value(id=frame_id), RigidTransform)
         self.assertTrue(obj.has_id(id=frame_id))
         self.assertIsInstance(obj.frame_ids(), list)
         self.assertIsInstance(obj.frame_ids()[0], mut.FrameId)
@@ -197,6 +196,7 @@ class TestGeometry(unittest.TestCase):
 
     @numpy_compare.check_nonsymbolic_types
     def test_query_object(self, T):
+        RigidTransform = RigidTransform_[float]
         SceneGraph = mut.SceneGraph_[T]
         QueryObject = mut.QueryObject_[T]
         SceneGraphInspector = mut.SceneGraphInspector_[T]

--- a/examples/contact_model/bowling_ball.cc
+++ b/examples/contact_model/bowling_ball.cc
@@ -31,7 +31,6 @@
 #include "drake/common/eigen_types.h"
 #include "drake/common/find_resource.h"
 #include "drake/geometry/geometry_visualization.h"
-#include "drake/lcm/drake_lcm.h"
 #include "drake/multibody/parsers/urdf_parser.h"
 #include "drake/multibody/rigid_body_plant/rigid_body_plant.h"
 #include "drake/multibody/rigid_body_plant/rigid_body_plant_bridge.h"
@@ -43,9 +42,7 @@
 namespace drake {
 namespace systems {
 
-using drake::lcm::DrakeLcm;
 using multibody::joints::kQuaternion;
-using Eigen::VectorXd;
 using std::make_unique;
 
 // Simulation parameters.

--- a/examples/multibody/bouncing_ball/make_bouncing_ball_plant.cc
+++ b/examples/multibody/bouncing_ball/make_bouncing_ball_plant.cc
@@ -35,7 +35,7 @@ MakeBouncingBallPlant(double radius, double mass,
     Vector3<double> normal_W(0, 0, 1);
     Vector3<double> point_W(0, 0, 0);
 
-    const RigidTransformd X_WG(HalfSpace::MakePose(normal_W, point_W));
+    const RigidTransformd X_WG(HalfSpace::MakePoseInF(normal_W, point_W));
     // A half-space for the ground geometry.
     plant->RegisterCollisionGeometry(plant->world_body(), X_WG, HalfSpace(),
                                      "collision", surface_friction);

--- a/examples/multibody/bouncing_ball/make_bouncing_ball_plant.cc
+++ b/examples/multibody/bouncing_ball/make_bouncing_ball_plant.cc
@@ -35,7 +35,7 @@ MakeBouncingBallPlant(double radius, double mass,
     Vector3<double> normal_W(0, 0, 1);
     Vector3<double> point_W(0, 0, 0);
 
-    const RigidTransformd X_WG(HalfSpace::MakePoseInF(normal_W, point_W));
+    const RigidTransformd X_WG(HalfSpace::MakePose(normal_W, point_W));
     // A half-space for the ground geometry.
     plant->RegisterCollisionGeometry(plant->world_body(), X_WG, HalfSpace(),
                                      "collision", surface_friction);

--- a/examples/multibody/cylinder_with_multicontact/make_cylinder_plant.cc
+++ b/examples/multibody/cylinder_with_multicontact/make_cylinder_plant.cc
@@ -90,7 +90,7 @@ MakeCylinderPlant(double radius, double length, double mass,
   Vector3<double> point_W(0, 0, 0);
 
   // A half-space for the ground geometry.
-  RigidTransformd X_WG(HalfSpace::MakePoseInF(normal_W, point_W));
+  RigidTransformd X_WG(HalfSpace::MakePose(normal_W, point_W));
   plant->RegisterCollisionGeometry(plant->world_body(), X_WG, HalfSpace(),
                                    "collision", surface_friction);
 

--- a/examples/multibody/cylinder_with_multicontact/make_cylinder_plant.cc
+++ b/examples/multibody/cylinder_with_multicontact/make_cylinder_plant.cc
@@ -90,7 +90,7 @@ MakeCylinderPlant(double radius, double length, double mass,
   Vector3<double> point_W(0, 0, 0);
 
   // A half-space for the ground geometry.
-  RigidTransformd X_WG(HalfSpace::MakePose(normal_W, point_W));
+  RigidTransformd X_WG(HalfSpace::MakePoseInF(normal_W, point_W));
   plant->RegisterCollisionGeometry(plant->world_body(), X_WG, HalfSpace(),
                                    "collision", surface_friction);
 

--- a/examples/pendulum/pendulum_geometry.cc
+++ b/examples/pendulum/pendulum_geometry.cc
@@ -103,7 +103,7 @@ void PendulumGeometry::OutputGeometryPose(
   const double theta = input.theta();
   const math::RigidTransformd pose(math::RotationMatrixd::MakeYRotation(theta));
 
-  *poses = {{frame_id_, pose.GetAsIsometry3()}};
+  *poses = {{frame_id_, pose}};
 }
 
 }  // namespace pendulum

--- a/examples/planar_gripper/gripper_brick.cc
+++ b/examples/planar_gripper/gripper_brick.cc
@@ -90,7 +90,7 @@ GripperBrickHelper<T>::GripperBrickHelper() {
       inspector.GetShape(finger_tip_geometry_id);
   finger_tip_radius_ =
       dynamic_cast<const geometry::Sphere&>(fingertip_shape).get_radius();
-  p_L2Tip_ = inspector.X_FG(finger_tip_geometry_id).translation();
+  p_L2Tip_ = inspector.GetPoseInFrame(finger_tip_geometry_id).translation();
   const geometry::Shape& brick_shape =
       inspector.GetShape(inspector.GetGeometryIdByName(
           plant_->GetBodyFrameIdOrThrow(

--- a/examples/quadrotor/quadrotor_geometry.cc
+++ b/examples/quadrotor/quadrotor_geometry.cc
@@ -69,7 +69,7 @@ void QuadrotorGeometry::OutputGeometryPose(
       math::RollPitchYawd(state.segment<3>(3)),
       state.head<3>());
 
-  *poses = {{frame_id_, pose.GetAsIsometry3()}};
+  *poses = {{frame_id_, pose}};
 }
 
 }  // namespace quadrotor

--- a/examples/scene_graph/bouncing_ball_plant.cc
+++ b/examples/scene_graph/bouncing_ball_plant.cc
@@ -27,6 +27,8 @@ using geometry::render::RenderLabel;
 using geometry::SceneGraph;
 using geometry::SourceId;
 using geometry::Sphere;
+using math::RigidTransform;
+using math::RigidTransformd;
 using std::make_unique;
 using systems::Context;
 
@@ -55,7 +57,7 @@ BouncingBallPlant<T>::BouncingBallPlant(SourceId source_id,
       source_id, GeometryFrame("ball_frame"));
   ball_id_ = scene_graph->RegisterGeometry(
       source_id, ball_frame_id_,
-      make_unique<GeometryInstance>(Isometry3<double>::Identity(), /*X_FG*/
+      make_unique<GeometryInstance>(RigidTransformd::Identity(), /*X_FG*/
                                     make_unique<Sphere>(diameter_ / 2.0),
                                     "ball"));
   // Use the default material.
@@ -107,9 +109,9 @@ void BouncingBallPlant<T>::CopyStateToOutput(
 template <typename T>
 void BouncingBallPlant<T>::CalcFramePoseOutput(
     const Context<T>& context, FramePoseVector<T>* poses) const {
-  Isometry3<T> pose = Isometry3<T>::Identity();
+  RigidTransform<T> pose = RigidTransform<T>::Identity();
   const BouncingBallVector<T>& state = get_state(context);
-  pose.translation() << p_WB_.x(), p_WB_.y(), state.z();
+  pose.set_translation({p_WB_.x(), p_WB_.y(), state.z()});
   *poses = {{ball_frame_id_, pose}};
 }
 

--- a/examples/scene_graph/bouncing_ball_run_dynamics.cc
+++ b/examples/scene_graph/bouncing_ball_run_dynamics.cc
@@ -86,7 +86,7 @@ int do_main() {
   Vector3<double> p_WHo_W(0, 0, 0);
   const GeometryId ground_id = scene_graph->RegisterAnchoredGeometry(
       global_source,
-      make_unique<GeometryInstance>(HalfSpace::MakePoseInF(Hz_W, p_WHo_W),
+      make_unique<GeometryInstance>(HalfSpace::MakePose(Hz_W, p_WHo_W),
                                     make_unique<HalfSpace>(), "ground"));
   scene_graph->AssignRole(global_source, ground_id, ProximityProperties());
   scene_graph->AssignRole(global_source, ground_id, IllustrationProperties());

--- a/examples/scene_graph/bouncing_ball_run_dynamics.cc
+++ b/examples/scene_graph/bouncing_ball_run_dynamics.cc
@@ -86,7 +86,7 @@ int do_main() {
   Vector3<double> p_WHo_W(0, 0, 0);
   const GeometryId ground_id = scene_graph->RegisterAnchoredGeometry(
       global_source,
-      make_unique<GeometryInstance>(HalfSpace::MakePose(Hz_W, p_WHo_W),
+      make_unique<GeometryInstance>(HalfSpace::MakePoseInF(Hz_W, p_WHo_W),
                                     make_unique<HalfSpace>(), "ground"));
   scene_graph->AssignRole(global_source, ground_id, ProximityProperties());
   scene_graph->AssignRole(global_source, ground_id, IllustrationProperties());

--- a/examples/scene_graph/solar_system.h
+++ b/examples/scene_graph/solar_system.h
@@ -4,6 +4,7 @@
 
 #include "drake/common/drake_copyable.h"
 #include "drake/geometry/scene_graph.h"
+#include "drake/math/rigid_transform.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/leaf_system.h"
@@ -151,7 +152,7 @@ class SolarSystem : public systems::LeafSystem<T> {
   // The axes around each body revolves (expressed in its parent's frame)
   std::vector<Vector3<double>> axes_;
   // The translational offset of each body from its parent frame
-  std::vector<Isometry3<double>> body_offset_;
+  std::vector<math::RigidTransformd> body_offset_;
 };
 
 }  // namespace solar_system

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -227,6 +227,7 @@ drake_cc_library(
         ":shape_specification",
         "//common:copyable_unique_ptr",
         "//common:essential",
+        "//math:geometric_transform",
     ],
 )
 
@@ -241,7 +242,10 @@ drake_cc_library(
     name = "shape_specification",
     srcs = ["shape_specification.cc"],
     hdrs = ["shape_specification.h"],
-    deps = ["//common:essential"],
+    deps = [
+        "//common:essential",
+        "//math:geometric_transform",
+    ],
 )
 
 drake_cc_library(

--- a/geometry/frame_kinematics_vector.cc
+++ b/geometry/frame_kinematics_vector.cc
@@ -7,14 +7,15 @@
 
 #include "drake/common/autodiff.h"
 #include "drake/common/symbolic.h"
+#include "drake/math/rigid_transform.h"
 
 namespace drake {
 namespace geometry {
 
 namespace {
 template <typename T>
-void InitializeKinematicsValue(Isometry3<T>* value) {
-  value->setIdentity();
+void InitializeKinematicsValue(math::RigidTransform<T>* value) {
+  value->SetIdentity();
 }
 }  // namespace
 
@@ -108,9 +109,10 @@ void FrameKinematicsVector<KinematicsValue>::CheckInvariants() const {
 }
 
 // Explicitly instantiates on the most common scalar types.
-template class FrameKinematicsVector<Isometry3<double>>;
-template class FrameKinematicsVector<Isometry3<AutoDiffXd>>;
-template class FrameKinematicsVector<Isometry3<symbolic::Expression>>;
+template class FrameKinematicsVector<math::RigidTransform<double>>;
+template class FrameKinematicsVector<math::RigidTransform<AutoDiffXd>>;
+template class FrameKinematicsVector<
+    math::RigidTransform<symbolic::Expression>>;
 
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/frame_kinematics_vector.h
+++ b/geometry/frame_kinematics_vector.h
@@ -46,7 +46,7 @@ namespace geometry {
    }
 
    std::vector<FrameId> frame_ids_;
-   std::vector<Isometry3<T>> poses_;
+   std::vector<RigidTransform<T>> poses_;
  };
  ```
 
@@ -56,7 +56,7 @@ namespace geometry {
  ```
    void CalcFramePoseOutput(const Context<T>& context,
                             geometry::FramePoseVector<T>* poses) const {
-     const Isometry3<T>& pose = ...;
+     const RigidTransform<T>& pose = ...;
      *poses = {{frame_id_, pose}};
    }
  ```
@@ -74,19 +74,20 @@ namespace geometry {
  One should never interact with the %FrameKinematicsVector class directly.
  Instead, the FramePoseVector, FrameVelocityVector, and FrameAccelerationVector
  classes are aliases of the %FrameKinematicsVector instantiated on specific
- data types (Isometry3, SpatialVector, and SpatialAcceleration, respectively).
- Each of these data types are templated on Eigen scalars. All supported
- combinations of data type and scalar type are already available to link against
- in the containing library. No other values for KinematicsValue are supported.
+ data types (RigidTransform, SpatialVector, and SpatialAcceleration,
+ respectively). Each of these data types are templated on Eigen scalars. All
+ supported combinations of data type and scalar type are already available to
+ link against in the containing library. No other values for KinematicsValue are
+ supported.
 
  Currently, the following data types with the following scalar types are
  supported:
 
-  Alias           | Instantiation                            | Scalar types
- -----------------|------------------------------------------|--------------
-  FramePoseVector | FrameKinematicsVector<Isometry3<Scalar>> | double
-  FramePoseVector | FrameKinematicsVector<Isometry3<Scalar>> | AutoDiffXd
-  FramePoseVector | FrameKinematicsVector<Isometry3<Scalar>> | Expression
+  Alias           | Instantiation                                 | Scalar types
+ -----------------|-----------------------------------------------|-------------
+  FramePoseVector | FrameKinematicsVector<RigidTransform<Scalar>> | double
+  FramePoseVector | FrameKinematicsVector<RigidTransform<Scalar>> | AutoDiffXd
+  FramePoseVector | FrameKinematicsVector<RigidTransform<Scalar>> | Expression
   */
 template <class KinematicsValue>
 class FrameKinematicsVector {
@@ -169,7 +170,7 @@ class FrameKinematicsVector {
  No other values for T are currently supported.
  */
 template <typename T>
-using FramePoseVector = FrameKinematicsVector<Isometry3<T>>;
+using FramePoseVector = FrameKinematicsVector<math::RigidTransform<T>>;
 
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/geometry_instance.cc
+++ b/geometry/geometry_instance.cc
@@ -8,6 +8,11 @@ namespace geometry {
 GeometryInstance::GeometryInstance(const Isometry3<double>& X_PG,
                                    std::unique_ptr<Shape> shape,
                                    const std::string& name)
+    : GeometryInstance(math::RigidTransformd(X_PG), std::move(shape), name) {}
+
+GeometryInstance::GeometryInstance(const math::RigidTransform<double>& X_PG,
+                                   std::unique_ptr<Shape> shape,
+                                   const std::string& name)
     : id_(GeometryId::get_new_id()),
       X_PG_(X_PG),
       shape_(std::move(shape)),

--- a/geometry/geometry_instance.h
+++ b/geometry/geometry_instance.h
@@ -109,14 +109,11 @@ class GeometryInstance {
    representation as well.  */
   GeometryId id() const { return id_; }
 
-  const math::RigidTransform<double>& X_PG() const { return X_PG_; }
-  void set_X_PG(math::RigidTransform<double> X_PG) { X_PG_ = std::move(X_PG); }
+  /** Returns the instance geometry's pose in its parent frame.  */
+  const math::RigidTransformd& pose() const { return X_PG_; }
 
-  DRAKE_DEPRECATED("2019-11-01", "Please use X_PG().")
-  const Isometry3<double> pose() const { return X_PG_.GetAsIsometry3(); }
-
-  DRAKE_DEPRECATED("2019-11-01", "Please use set_X_PG().")
-  void set_pose(const Isometry3<double>& X_PG) { X_PG_.SetFromIsometry3(X_PG); }
+  /** Sets the pose of this instance in its parent's frame.  */
+  void set_pose(const math::RigidTransformd& X_PG) { X_PG_ = X_PG; }
 
   const Shape& shape() const {
     DRAKE_DEMAND(shape_ != nullptr);

--- a/geometry/geometry_instance.h
+++ b/geometry/geometry_instance.h
@@ -11,6 +11,7 @@
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/shape_specification.h"
+#include "drake/math/rigid_transform.h"
 
 namespace drake {
 namespace geometry {
@@ -87,8 +88,19 @@ class GeometryInstance {
    @param name   The name of the geometry (must satisfy the name requirements).
    @throws std::logic_error if the canonicalized version of `name` is empty.
    */
+  DRAKE_DEPRECATED("2019-11-01",
+      "Please use the RigidTransform-based constructor.")
   GeometryInstance(const Isometry3<double>& X_PG, std::unique_ptr<Shape> shape,
                    const std::string& name);
+
+  /** Constructs a geometry instance specification.
+   @param X_PG   The pose of this geometry (`G`) in its parent's frame (`P`).
+   @param shape  The underlying shape for this geometry instance.
+   @param name   The name of the geometry (must satisfy the name requirements).
+   @throws std::logic_error if the canonicalized version of `name` is empty.
+   */
+  GeometryInstance(const math::RigidTransform<double>& X_PG,
+      std::unique_ptr<Shape> shape, const std::string& name);
 
   /** Returns the globally unique id for this geometry specification. Every
    instantiation of %GeometryInstance will contain a unique id value. The id
@@ -97,8 +109,14 @@ class GeometryInstance {
    representation as well.  */
   GeometryId id() const { return id_; }
 
-  const Isometry3<double>& pose() const { return X_PG_; }
-  void set_pose(const Isometry3<double>& X_PG) { X_PG_ = X_PG; }
+  const math::RigidTransform<double>& X_PG() const { return X_PG_; }
+  void set_X_PG(math::RigidTransform<double> X_PG) { X_PG_ = std::move(X_PG); }
+
+  DRAKE_DEPRECATED("2019-11-01", "Please use X_PG().")
+  const Isometry3<double> pose() const { return X_PG_.GetAsIsometry3(); }
+
+  DRAKE_DEPRECATED("2019-11-01", "Please use set_X_PG().")
+  void set_pose(const Isometry3<double>& X_PG) { X_PG_.SetFromIsometry3(X_PG); }
 
   const Shape& shape() const {
     DRAKE_DEMAND(shape_ != nullptr);
@@ -175,7 +193,7 @@ class GeometryInstance {
   GeometryId id_{};
 
   // The pose of the geometry relative to the parent frame it hangs on.
-  Isometry3<double> X_PG_;
+  math::RigidTransform<double> X_PG_;
 
   // The shape associated with this instance.
   copyable_unique_ptr<Shape> shape_;

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -552,14 +552,14 @@ GeometryId GeometryState<T>::RegisterGeometry(
   InternalFrame& frame = frames_[frame_id];
   frame.add_child(geometry_id);
 
-  // X_PG() is always RigidTransform<double>, to account for
+  // pose() is always RigidTransform<double>. To account for
   // GeometryState<AutoDiff>, we need to cast it to the common type T.
-  X_WGs_[geometry_id] = geometry->X_PG().cast<T>();
+  X_WGs_[geometry_id] = geometry->pose().cast<T>();
 
   geometries_.emplace(
       geometry_id,
       InternalGeometry(source_id, geometry->release_shape(), frame_id,
-                       geometry_id, geometry->name(), geometry->X_PG()));
+                       geometry_id, geometry->name(), geometry->pose()));
 
   // Any roles defined on the geometry instance propagate through automatically.
   if (geometry->illustration_properties()) {

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -120,8 +120,8 @@ GeometryState<T>::GeometryState()
                                  FrameIndex(0), world,
                                  InternalFrame::world_frame_clique());
   frame_index_to_id_map_.push_back(world);
-  X_WF_.push_back(Isometry3<T>::Identity());
-  X_PF_.push_back(Isometry3<T>::Identity());
+  X_WF_.push_back(RigidTransform<T>::Identity());
+  X_PF_.push_back(RigidTransform<T>::Identity());
 
   source_frame_id_map_[self_source_] = {world};
   source_root_frame_map_[self_source_] = {world};
@@ -343,14 +343,14 @@ const Shape& GeometryState<T>::GetShape(GeometryId id) const {
 }
 
 template <typename T>
-const Isometry3<double>& GeometryState<T>::GetPoseInFrame(
+const math::RigidTransform<double>& GeometryState<T>::GetPoseInFrame(
     GeometryId geometry_id) const {
   const auto& geometry = GetValueOrThrow(geometry_id, geometries_);
   return geometry.X_FG();
 }
 
 template <typename T>
-const Isometry3<double>& GeometryState<T>::GetPoseInParent(
+const math::RigidTransform<double>& GeometryState<T>::GetPoseInParent(
     GeometryId geometry_id) const {
   const auto& geometry = GetValueOrThrow(geometry_id, geometries_);
   return geometry.X_PG();
@@ -418,7 +418,7 @@ bool GeometryState<T>::CollisionFiltered(GeometryId id1, GeometryId id2) const {
 }
 
 template <typename T>
-const Isometry3<T>& GeometryState<T>::get_pose_in_world(
+const math::RigidTransform<T>& GeometryState<T>::get_pose_in_world(
     FrameId frame_id) const {
   FindOrThrow(frame_id, frames_, [frame_id]() {
     return "No world pose available for invalid frame id: " +
@@ -428,7 +428,7 @@ const Isometry3<T>& GeometryState<T>::get_pose_in_world(
 }
 
 template <typename T>
-const Isometry3<T>& GeometryState<T>::get_pose_in_world(
+const math::RigidTransform<T>& GeometryState<T>::get_pose_in_world(
     GeometryId geometry_id) const {
   FindOrThrow(geometry_id, geometries_, [geometry_id]() {
     return "No world pose available for invalid geometry id: " +
@@ -438,7 +438,7 @@ const Isometry3<T>& GeometryState<T>::get_pose_in_world(
 }
 
 template <typename T>
-const Isometry3<T>& GeometryState<T>::get_pose_in_parent(
+const math::RigidTransform<T>& GeometryState<T>::get_pose_in_parent(
     FrameId frame_id) const {
   FindOrThrow(frame_id, frames_, [frame_id]() {
     return "No pose available for invalid frame id: " + to_string(frame_id);
@@ -498,8 +498,8 @@ FrameId GeometryState<T>::RegisterFrame(SourceId source_id, FrameId parent_id,
 
   DRAKE_ASSERT(X_PF_.size() == frame_index_to_id_map_.size());
   FrameIndex index(X_PF_.size());
-  X_PF_.emplace_back(Isometry3<double>::Identity());
-  X_WF_.emplace_back(Isometry3<double>::Identity());
+  X_PF_.emplace_back(RigidTransform<T>::Identity());
+  X_WF_.emplace_back(RigidTransform<T>::Identity());
   frame_index_to_id_map_.push_back(frame_id);
   f_set.insert(frame_id);
   int clique = GeometryStateCollisionFilterAttorney::get_next_clique(
@@ -552,16 +552,14 @@ GeometryId GeometryState<T>::RegisterGeometry(
   InternalFrame& frame = frames_[frame_id];
   frame.add_child(geometry_id);
 
-  // NOTE: No implicit conversion from Isometry3<double> to Isometry3<AutoDiff>.
-  // However, we can implicitly assign Matrix<double> to Matrix<AutoDiff>.
-  Isometry3<T> X_WG;
-  X_WG.matrix() = geometry->pose().matrix();
-  X_WGs_[geometry_id] = X_WG;
+  // X_PG() is always RigidTransform<double>, to account for
+  // GeometryState<AutoDiff>, we need to cast it to the common type T.
+  X_WGs_[geometry_id] = geometry->X_PG().cast<T>();
 
-  geometries_.emplace(geometry_id,
-                      InternalGeometry(source_id, geometry->release_shape(),
-                                       frame_id, geometry_id, geometry->name(),
-                                       geometry->pose()));
+  geometries_.emplace(
+      geometry_id,
+      InternalGeometry(source_id, geometry->release_shape(), frame_id,
+                       geometry_id, geometry->name(), geometry->X_PG()));
 
   // Any roles defined on the geometry instance propagate through automatically.
   if (geometry->illustration_properties()) {
@@ -620,8 +618,8 @@ GeometryId GeometryState<T>::RegisterGeometryWithParent(
   // X_FG_ vector assuming the parent was the frame. Replace it by concatenating
   // its pose in parent, with its parent's pose in frame. NOTE: the pose is no
   // longer available from geometry because of the `move(geometry)`.
-  const Isometry3<double>& X_PG = new_geometry.X_FG();
-  const Isometry3<double>& X_FP = parent_geometry.X_FG();
+  const RigidTransform<double>& X_PG = new_geometry.X_FG();
+  const RigidTransform<double>& X_FP = parent_geometry.X_FG();
   new_geometry.set_geometry_parent(parent_id, X_FP * X_PG);
   parent_geometry.add_child(new_id);
   return new_id;
@@ -1024,7 +1022,7 @@ void GeometryState<T>::SetFramePoses(
   // TODO(SeanCurtis-TRI): Down the road, make this validation depend on
   // ASSERT_ARMED.
   ValidateFrameIds(source_id, poses);
-  const Isometry3<T> world_pose = Isometry3<T>::Identity();
+  const RigidTransform<T> world_pose = RigidTransform<T>::Identity();
   for (auto frame_id : source_root_frame_map_[source_id]) {
     UpdatePosesRecursively(frames_[frame_id], world_pose, poses);
   }
@@ -1058,15 +1056,8 @@ void GeometryState<T>::ValidateFrameIds(
 template <typename T>
 void GeometryState<T>::FinalizePoseUpdate() {
   geometry_engine_->UpdateWorldPoses(X_WGs_);
-  // TODO(SeanCurtis-TRI): Kill this horrible copy once Isometry3 is removed
-  // and X_WGs_ is RigidTransform typed.
-  std::unordered_map<GeometryId, RigidTransform<T>> Xrt_WG;
-  for (const auto& id_geometry_pair : geometries_) {
-    const GeometryId id = id_geometry_pair.first;
-    Xrt_WG[id] = RigidTransform<T>(X_WGs_[id]);
-  }
   for (auto& pair : render_engines_) {
-    pair.second->UpdatePoses(Xrt_WG);
+    pair.second->UpdatePoses(X_WGs_);
   }
 }
 
@@ -1130,30 +1121,21 @@ void GeometryState<T>::RemoveGeometryUnchecked(GeometryId geometry_id,
 
 template <typename T>
 void GeometryState<T>::UpdatePosesRecursively(
-    const internal::InternalFrame& frame, const Isometry3<T>& X_WP,
+    const internal::InternalFrame& frame, const RigidTransform<T>& X_WP,
     const FramePoseVector<T>& poses) {
   const auto frame_id = frame.id();
   const auto& X_PF = poses.value(frame_id);
   // Cache this transform for later use.
   X_PF_[frame.index()] = X_PF;
-  Isometry3<T> X_WF = X_WP * X_PF;
-  // TODO(SeanCurtis-TRI): Replace this when we have a transform object that
-  // allows proper multiplication between an AutoDiff type and a double type.
-  // For now, it allows me to perform the multiplication by multiplying the
-  // fully-defined transformation (with [0 0 0 1] on the bottom row).
-  X_WF.makeAffine();
+  RigidTransform<T> X_WF = X_WP * X_PF;
   X_WF_[frame.index()] = X_WF;
   // Update the geometry which belong to *this* frame.
   for (auto child_id : frame.child_geometries()) {
     auto& child_geometry = geometries_[child_id];
-    // TODO(SeanCurtis-TRI): See note above about replacing this when we have a
-    // transform that supports autodiff * double.
-    Isometry3<double> X_FG(child_geometry.X_FG());
-    X_FG.makeAffine();
-    // TODO(SeanCurtis-TRI): These matrix() shenanigans are here because I can't
-    // assign a an Isometry3<double> to an Isometry3<AutoDiffXd>. Replace this
-    // when I can.
-    X_WGs_[child_id].matrix() = X_WF.matrix() * X_FG.matrix();
+    // X_FG() is always RigidTransform<double>, to account for
+    // GeometryState<AutoDiff>, we need to cast it to the common type T.
+    RigidTransform<double> X_FG(child_geometry.X_FG());
+    X_WGs_[child_id] = X_WF * X_FG.cast<T>();
   }
 
   // Update each child frame.
@@ -1365,7 +1347,7 @@ RigidTransformd GeometryState<T>::GetDoubleWorldPose(FrameId frame_id) const {
     return RigidTransformd::Identity();
   }
   const internal::InternalFrame& frame = GetValueOrThrow(frame_id, frames_);
-  return RigidTransformd(internal::convert_to_double(X_WF_[frame.index()]));
+  return internal::convert_to_double(X_WF_[frame.index()]);
 }
 
 }  // namespace geometry

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -107,9 +107,7 @@ class GeometryState {
   int get_num_frames() const { return static_cast<int>(frames_.size()); }
 
   /** Implementation of SceneGraphInspector::all_frame_ids().  */
-  FrameIdRange get_frame_ids() const {
-    return FrameIdRange(&frames_);
-  }
+  FrameIdRange get_frame_ids() const { return FrameIdRange(&frames_); }
 
   /** Implementation of SceneGraphInspector::num_geometries().  */
   int get_num_geometries() const {
@@ -189,8 +187,7 @@ class GeometryState {
   int NumGeometriesWithRole(FrameId frame_id, Role role) const;
 
   /** Implementation of SceneGraphInspector::GetGeometryIdByName().  */
-  GeometryId GetGeometryFromName(FrameId frame_id,
-                                 Role role,
+  GeometryId GetGeometryFromName(FrameId frame_id, Role role,
                                  const std::string& name) const;
 
   //@}
@@ -216,10 +213,12 @@ class GeometryState {
   const Shape& GetShape(GeometryId id) const;
 
   /** Implementation of SceneGraphInspector::X_FG().  */
-  const Isometry3<double>& GetPoseInFrame(GeometryId geometry_id) const;
+  const math::RigidTransform<double>& GetPoseInFrame(
+      GeometryId geometry_id) const;
 
   /** Implementation of SceneGraphInspector::X_PG().  */
-  const Isometry3<double>& GetPoseInParent(GeometryId geometry_id) const;
+  const math::RigidTransform<double>& GetPoseInParent(
+      GeometryId geometry_id) const;
 
   /** Implementation of SceneGraphInspector::GetProximityProperties().  */
   const ProximityProperties* GetProximityProperties(GeometryId id) const;
@@ -242,13 +241,14 @@ class GeometryState {
   //@{
 
   /** Implementation of QueryObject::X_WF().  */
-  const Isometry3<T>& get_pose_in_world(FrameId frame_id) const;
+  const math::RigidTransform<T>& get_pose_in_world(FrameId frame_id) const;
 
   /** Implementation of QueryObject::X_WG().  */
-  const Isometry3<T>& get_pose_in_world(GeometryId geometry_id) const;
+  const math::RigidTransform<T>& get_pose_in_world(
+      GeometryId geometry_id) const;
 
   /** Implementation of QueryObject::X_PF().  */
-  const Isometry3<T>& get_pose_in_parent(FrameId frame_id) const;
+  const math::RigidTransform<T>& get_pose_in_parent(FrameId frame_id) const;
 
   //@}
 
@@ -292,13 +292,15 @@ class GeometryState {
                         const GeometryFrame& frame);
 
   /** Implementation of
-   @ref SceneGraph::RegisterGeometry(SourceId,FrameId,std::unique_ptr<GeometryInstance>)
+   @ref
+   SceneGraph::RegisterGeometry(SourceId,FrameId,std::unique_ptr<GeometryInstance>)
    "SceneGraph::RegisterGeometry()" with parent FrameId.  */
   GeometryId RegisterGeometry(SourceId source_id, FrameId frame_id,
                               std::unique_ptr<GeometryInstance> geometry);
 
   /** Implementation of
-   @ref SceneGraph::RegisterGeometry(SourceId,GeometryId,std::unique_ptr<GeometryInstance>)
+   @ref
+   SceneGraph::RegisterGeometry(SourceId,GeometryId,std::unique_ptr<GeometryInstance>)
    "SceneGraph::RegisterGeometry()" with parent GeometryId.  */
   GeometryId RegisterGeometryWithParent(
       SourceId source_id, GeometryId parent_id,
@@ -308,8 +310,7 @@ class GeometryState {
   // wrapper for the more general `RegisterGeometry()`.
   /** Implementation of SceneGraph::RegisterAnchoredGeometry().  */
   GeometryId RegisterAnchoredGeometry(
-      SourceId source_id,
-      std::unique_ptr<GeometryInstance> geometry);
+      SourceId source_id, std::unique_ptr<GeometryInstance> geometry);
 
   /** Removes the given geometry from the the indicated source's geometries. Any
    geometry that was hung from the indicated geometry will _also_ be removed.
@@ -470,10 +471,8 @@ class GeometryState {
   }
 
   /** Supporting function for QueryObject::ComputeSignedDistanceToPoint().  */
-  std::vector<SignedDistanceToPoint<T>>
-  ComputeSignedDistanceToPoint(
-      const Vector3<T> &p_WQ,
-      double threshold) const {
+  std::vector<SignedDistanceToPoint<T>> ComputeSignedDistanceToPoint(
+      const Vector3<T>& p_WQ, double threshold) const {
     return geometry_engine_->ComputeSignedDistanceToPoint(p_WQ, X_WGs_,
                                                           threshold);
   }
@@ -502,23 +501,20 @@ class GeometryState {
   /** Implementation support for QueryObject::RenderColorImage().
    @pre All poses have already been updated.  */
   void RenderColorImage(const render::CameraProperties& camera,
-                        FrameId parent_frame,
-                        const math::RigidTransformd& X_PC,
+                        FrameId parent_frame, const math::RigidTransformd& X_PC,
                         bool show_window,
                         systems::sensors::ImageRgba8U* color_image_out) const;
 
   /** Implementation support for QueryObject::RenderDepthImage().
    @pre All poses have already been updated.  */
   void RenderDepthImage(const render::DepthCameraProperties& camera,
-                        FrameId parent_frame,
-                        const math::RigidTransformd& X_PC,
+                        FrameId parent_frame, const math::RigidTransformd& X_PC,
                         systems::sensors::ImageDepth32F* depth_image_out) const;
 
   /** Implementation support for QueryObject::RenderLabelImage().
    @pre All poses have already been updated.  */
   void RenderLabelImage(const render::CameraProperties& camera,
-                        FrameId parent_frame,
-                        const math::RigidTransformd& X_PC,
+                        FrameId parent_frame, const math::RigidTransformd& X_PC,
                         bool show_window,
                         systems::sensors::ImageLabel16I* label_image_out) const;
 
@@ -557,28 +553,25 @@ class GeometryState {
         frame_index_to_id_map_(source.frame_index_to_id_map_),
         geometry_engine_(std::move(source.geometry_engine_->ToAutoDiffXd())),
         render_engines_(source.render_engines_) {
-    // NOTE: Can't assign Isometry3<double> to Isometry3<AutoDiff>. But we _can_
-    // assign Matrix<double> to Matrix<AutoDiff>, so that's what we're doing.
-    auto convert_pose_vector = [](const std::vector<Isometry3<U>>& s,
-                                  std::vector<Isometry3<T>>* d) {
-      std::vector<Isometry3<T>>& dest = *d;
+    auto convert_pose_vector = [](const std::vector<math::RigidTransform<U>>& s,
+                                  std::vector<math::RigidTransform<T>>* d) {
+      std::vector<math::RigidTransform<T>>& dest = *d;
       dest.resize(s.size());
       for (size_t i = 0; i < s.size(); ++i) {
-        dest[i].matrix() = s[i].matrix();
+        dest[i] = s[i].template cast<T>();
       }
     };
     convert_pose_vector(source.X_PF_, &X_PF_);
     convert_pose_vector(source.X_WF_, &X_WF_);
 
     // Now convert the id -> pose map.
-    std::unordered_map<GeometryId, Isometry3<T>>& dest = X_WGs_;
-    const std::unordered_map<GeometryId, Isometry3<U>>& s = source.X_WGs_;
+    std::unordered_map<GeometryId, math::RigidTransform<T>>& dest = X_WGs_;
+    const std::unordered_map<GeometryId, math::RigidTransform<U>>& s =
+        source.X_WGs_;
     for (const auto& id_pose_pair : s) {
       const GeometryId id = id_pose_pair.first;
-      const Isometry3<U>& X_WG_source = id_pose_pair.second;
-      Isometry3<T> X_WG;
-      X_WG.matrix() = X_WG_source.matrix();
-      dest.insert({id, std::move(X_WG)});
+      const math::RigidTransform<U>& X_WG_source = id_pose_pair.second;
+      dest.insert({id, X_WG_source.template cast<T>()});
     }
   }
 
@@ -592,7 +585,8 @@ class GeometryState {
 
   // Friend declaration so that the internals of the state can be confirmed in
   // unit tests.
-  template <class U> friend class GeometryStateTester;
+  template <class U>
+  friend class GeometryStateTester;
 
   // Function to facilitate testing.
   int peek_next_clique() const {
@@ -652,8 +646,8 @@ class GeometryState {
   // TODO(SeanCurtis-TRI): Add `kFrame` when this can be invoked by removing
   // a frame.
   enum class RemoveGeometryOrigin {
-    kGeometry,   // Invoked by RemoveGeometry().
-    kRecurse     // Invoked by recursive call in RemoveGeometryUnchecked.
+    kGeometry,  // Invoked by RemoveGeometry().
+    kRecurse    // Invoked by recursive call in RemoveGeometryUnchecked.
   };
 
   // Performs the work necessary to remove the identified geometry from
@@ -674,7 +668,7 @@ class GeometryState {
   // rooted at the given frame, whose parent's pose in the world frame is given
   // as `X_WP`.
   void UpdatePosesRecursively(const internal::InternalFrame& frame,
-                              const Isometry3<T>& X_WP,
+                              const math::RigidTransform<T>& X_WP,
                               const FramePoseVector<T>& poses);
 
   // Reports true if the given id refers to a _dynamic_ geometry. Assumes the
@@ -714,7 +708,7 @@ class GeometryState {
   // nothing to remove). This does no checking on ownership.
   // @pre geometry_id maps to a registered geometry.
   bool RemoveFromRendererUnchecked(const std::string& renderer_name,
-                                  GeometryId id);
+                                   GeometryId id);
 
   bool RemoveProximityRole(GeometryId geometry_id);
   bool RemoveIllustrationRole(GeometryId geometry_id);
@@ -735,7 +729,7 @@ class GeometryState {
   // and, assuming the ids and relationships are valid, returns the frame
   // requested.
   const internal::InternalFrame& ValidateAndGetFrame(SourceId source_id,
-      FrameId frame_id) const;
+                                                     FrameId frame_id) const;
 
   // Retrieves the requested renderer (if supported), throwing otherwise.
   const render::RenderEngine& GetRenderEngineOrThrow(
@@ -807,7 +801,7 @@ class GeometryState {
   // Map from a frame's index to the _current_ pose of the frame F it identifies
   // relative to its parent frame P, i.e., X_PF.
   // TODO(SeanCurtis-TRI): Rename this to X_PFs_ to reflect multiplicity.
-  std::vector<Isometry3<T>> X_PF_;
+  std::vector<math::RigidTransform<T>> X_PF_;
 
   // The pose of every geometry relative to the _world_ frame (regardless of
   // roles) keyed by the corresponding geometry's id. After a complete state
@@ -817,7 +811,7 @@ class GeometryState {
   // frame Fₖ, and the world frame W is the parent of frame Fₙ.
   // In other words, it is the full evaluation of the kinematic chain from the
   // geometry to the world frame.
-  std::unordered_map<GeometryId, Isometry3<T>> X_WGs_;
+  std::unordered_map<GeometryId, math::RigidTransform<T>> X_WGs_;
 
   // The pose of each frame relative to the _world_ frame.
   // frames_.size() == X_WF_.size() is an invariant. Furthermore, after a
@@ -828,7 +822,7 @@ class GeometryState {
   // In other words, it is the full evaluation of the kinematic chain from
   // frame i to the world frame.
   // TODO(SeanCurtis-TRI): Rename this to X_WFs_ to reflect multiplicity.
-  std::vector<Isometry3<T>> X_WF_;
+  std::vector<math::RigidTransform<T>> X_WF_;
 
   // The underlying geometry engine. The topology of the engine does _not_
   // change with respect to time. But its values do. This straddles the two

--- a/geometry/internal_geometry.cc
+++ b/geometry/internal_geometry.cc
@@ -8,18 +8,19 @@ namespace drake {
 namespace geometry {
 namespace internal {
 
+using math::RigidTransform;
 using std::move;
 
 InternalGeometry::InternalGeometry(
     SourceId source_id, std::unique_ptr<Shape> shape, FrameId frame_id,
-    GeometryId geometry_id, std::string name, const Isometry3<double>& X_FG)
+    GeometryId geometry_id, std::string name, RigidTransform<double> X_FG)
     : shape_spec_(std::move(shape)),
       id_(geometry_id),
       name_(std::move(name)),
       source_id_(source_id),
       frame_id_(frame_id),
-      X_PG_(X_FG),
-      X_FG_(X_FG),
+      X_PG_(move(X_FG)),
+      X_FG_(X_PG_),
       parent_geometry_id_(nullopt) {}
 
 bool InternalGeometry::has_role(Role role) const {

--- a/geometry/internal_geometry.h
+++ b/geometry/internal_geometry.h
@@ -14,6 +14,7 @@
 #include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/internal_frame.h"
 #include "drake/geometry/shape_specification.h"
+#include "drake/math/rigid_transform.h"
 
 namespace drake {
 namespace geometry {
@@ -45,7 +46,7 @@ class InternalGeometry {
    @param X_FG          The pose of the geometry G in the parent frame F.  */
   InternalGeometry(SourceId source_id, std::unique_ptr<Shape> shape,
                    FrameId frame_id, GeometryId geometry_id, std::string name,
-                   const Isometry3<double>& X_FG);
+                   math::RigidTransform<double> X_FG);
 
   /** Compares two %InternalGeometry instances for "equality". Two internal
    geometries are considered equal if they have the same geometry identifier.
@@ -95,11 +96,11 @@ class InternalGeometry {
   /** Returns the pose of this geometry in the declared *parent* frame -- note
    if this geometry was registered as a child of another geometry it will *not*
    be the same as X_FG().  */
-  const Isometry3<double>& X_PG() const { return X_PG_; }
+  const math::RigidTransform<double>& X_PG() const { return X_PG_; }
 
   /** Returns the pose of this geometry in the frame to which it is ultimately
    rigidly attached. This is in contrast to X_PG().  */
-  const Isometry3<double>& X_FG() const { return X_FG_; }
+  const math::RigidTransform<double>& X_FG() const { return X_FG_; }
 
   // TODO(SeanCurtis-TRI): Determine if tracking this parent geometry is
   // necessary for now or if that only exists to facilitate removal later on.
@@ -111,10 +112,10 @@ class InternalGeometry {
    be updated.
    @param id    The id of the parent geometry.
    @param X_FG  The new value for X_FG (assuming the constructed value is to be
-                interpreted as X_PG.  */
-  void set_geometry_parent(GeometryId id, const Isometry3<double>& X_FG) {
+                interpreted as X_PG).  */
+  void set_geometry_parent(GeometryId id, math::RigidTransform<double> X_FG) {
     parent_geometry_id_ = id;
-    X_FG_ = X_FG;
+    X_FG_ = std::move(X_FG);
   }
 
   /** Returns true if this geometry has a geometry parent and the parent has the
@@ -265,11 +266,11 @@ class InternalGeometry {
 
   // The pose of this geometry in the registered parent frame. The parent may be
   // a frame or another registered geometry.
-  Isometry3<double> X_PG_;
+  math::RigidTransform<double> X_PG_;
 
   // The pose of this geometry in the ultimate frame to which this geometry is
   // rigidly affixed. If there is no parent geometry, X_PG_ == X_FG_.
-  Isometry3<double> X_FG_;
+  math::RigidTransform<double> X_FG_;
 
   // The identifier for this frame's parent frame.
   optional<GeometryId> parent_geometry_id_{};

--- a/geometry/proximity/distance_to_point.h
+++ b/geometry/proximity/distance_to_point.h
@@ -51,7 +51,7 @@ struct CallbackData {
       fcl::CollisionObjectd* query_in,
       const double threshold_in,
       const Vector3<T>& p_WQ_W_in,
-      const std::unordered_map<GeometryId, Isometry3<T>>* X_WGs_in,
+      const std::unordered_map<GeometryId, math::RigidTransform<T>>* X_WGs_in,
       std::vector<SignedDistanceToPoint<T>>* distances_in)
       : query_point(*query_in),
         threshold(threshold_in),
@@ -73,7 +73,7 @@ struct CallbackData {
   const Vector3<T> p_WQ_W;
 
   /** The T-valued pose of every geometry.  */
-  const std::unordered_map<GeometryId, Isometry3<T>>& X_WGs;
+  const std::unordered_map<GeometryId, math::RigidTransform<T>>& X_WGs;
 
   /** The accumulator for results.  */
   std::vector<SignedDistanceToPoint<T>>& distances;

--- a/geometry/proximity/distance_to_shape.h
+++ b/geometry/proximity/distance_to_shape.h
@@ -49,7 +49,8 @@ struct CallbackData {
                                   reported.
    @param nearest_pairs_in[out]   The output results. Aliased.  */
   CallbackData(const CollisionFilterLegacy* collision_filter_in,
-               const std::unordered_map<GeometryId, Isometry3<T>>* X_WGs_in,
+               const std::unordered_map<GeometryId,
+               math::RigidTransform<T>>* X_WGs_in,
                const double max_distance_in,
                std::vector<SignedDistancePair<T>>* nearest_pairs_in)
       : collision_filter(*collision_filter_in),
@@ -65,7 +66,7 @@ struct CallbackData {
   const CollisionFilterLegacy& collision_filter;
 
   /** The T-valued poses of all geometries.  */
-  const std::unordered_map<GeometryId, Isometry3<T>>& X_WGs;
+  const std::unordered_map<GeometryId, math::RigidTransform<T>>& X_WGs;
 
   /** The maximum distance at which a pair's distance will be reported.  */
   const double max_distance;
@@ -264,9 +265,9 @@ void CalcDistanceFallback<double>(const fcl::CollisionObjectd& a,
  @pre The pair should *not* be (Halfspace, X), unless X is Sphere.  */
 template <typename T>
 void ComputeNarrowPhaseDistance(const fcl::CollisionObjectd& a,
-                                const Isometry3<T>& X_WA,
+                                const math::RigidTransform<T>& X_WA,
                                 const fcl::CollisionObjectd& b,
-                                const Isometry3<T>& X_WB,
+                                const math::RigidTransform<T>& X_WB,
                                 const fcl::DistanceRequestd& request,
                                 SignedDistancePair<T>* result) {
   DRAKE_DEMAND(result != nullptr);

--- a/geometry/proximity/test/distance_to_point_test.cc
+++ b/geometry/proximity/test/distance_to_point_test.cc
@@ -20,12 +20,10 @@ namespace {
 // TODO(SeanCurtis-TRI): Run through proximity_engine_test and pull the tests
 // from there that better belong here.
 
-using Eigen::Isometry3d;
 using Eigen::Vector3d;
 using math::RigidTransform;
 using math::RigidTransformd;
 using math::RotationMatrix;
-using Eigen::Translation3d;
 using std::make_shared;
 
 // Performs a point-to-shape signed-distance query and tests the result. This
@@ -450,7 +448,7 @@ template <typename T>
 void TestScalarShapeSupport() {
   // Configure the basic query.
   Vector3<T> p_WQ{10, 10, 10};
-  Isometry3<T> X_WQ{Translation3<T>{p_WQ}};
+  RigidTransform<T> X_WQ{Translation3<T>{p_WQ}};
   auto point_geometry = make_shared<fcl::Sphered>(0);
   const GeometryId point_id = GeometryId::get_new_id();
   fcl::CollisionObjectd query_point(point_geometry);
@@ -460,8 +458,8 @@ void TestScalarShapeSupport() {
   std::vector<SignedDistanceToPoint<T>> distances;
   double threshold = std::numeric_limits<double>::max();
   const GeometryId other_id = GeometryId::get_new_id();
-  std::unordered_map<GeometryId, Isometry3<T>> X_WGs{
-      {point_id, X_WQ}, {other_id, Isometry3<T>::Identity()}};
+  std::unordered_map<GeometryId, RigidTransform<T>> X_WGs{
+      {point_id, X_WQ}, {other_id, RigidTransform<T>::Identity()}};
   CallbackData<T> data{&query_point, threshold, p_WQ, &X_WGs, &distances};
 
   // The Drake-supported geometries (minus Mesh which isn't supported by

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -27,6 +27,8 @@ namespace internal {
 
 using Eigen::Vector3d;
 using fcl::CollisionObjectd;
+using math::RigidTransform;
+using math::RigidTransformd;
 using std::make_shared;
 using std::make_unique;
 using std::move;
@@ -35,8 +37,6 @@ using std::unique_ptr;
 using std::unordered_map;
 
 namespace {
-
-// TODO(SeanCurtis-TRI): Swap all Isometry3 for RigidTransforms.
 
 // Struct for use in SingleCollisionCallback(). Contains the collision request
 // and accumulates results in a drake::multibody::collision::PointPair vector.
@@ -308,13 +308,13 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     collision_filter_.AddGeometry(encoding.encoding());
   }
 
-  void AddAnchoredGeometry(const Shape& shape, const Isometry3<double>& X_WG,
+  void AddAnchoredGeometry(const Shape& shape, const RigidTransformd& X_WG,
                            GeometryId id) {
     // The collision object gets instantiated in the reification process and
     // placed in this unique pointer.
     std::unique_ptr<CollisionObjectd> fcl_object;
     shape.Reify(this, &fcl_object);
-    fcl_object->setTransform(X_WG);
+    fcl_object->setTransform(X_WG.GetAsIsometry3());
     fcl_object->computeAABB();
     anchored_tree_.registerObject(fcl_object.get());
     anchored_tree_.update();
@@ -352,13 +352,14 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
   //  2. I could simply have a method that returns a mutable reference to such
   //    a vector and the caller sets values there directly.
   void UpdateWorldPoses(
-      const std::unordered_map<GeometryId, Isometry3<T>>& X_WGs) {
+      const std::unordered_map<GeometryId, RigidTransform<T>>& X_WGs) {
     for (const auto& id_object_pair : dynamic_objects_) {
       const GeometryId id = id_object_pair.first;
-      const Isometry3<T>& X_WG = X_WGs.at(id);
+      const RigidTransform<T>& X_WG = X_WGs.at(id);
       // The FCL broadphase requires double-valued poses; so we use ADL to
       // efficiently get double-valued poses out of arbitrary T-valued poses.
-      dynamic_objects_[id]->setTransform(convert_to_double(X_WG));
+      dynamic_objects_[id]->setTransform(
+          convert_to_double(X_WG).GetAsIsometry3());
       dynamic_objects_[id]->computeAABB();
     }
     dynamic_tree_.update();
@@ -528,7 +529,7 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
   }
 
   std::vector<SignedDistancePair<T>> ComputeSignedDistancePairwiseClosestPoints(
-      const std::unordered_map<GeometryId, Isometry3<T>>& X_WGs,
+      const std::unordered_map<GeometryId, RigidTransform<T>>& X_WGs,
       const double max_distance) const {
     std::vector<SignedDistancePair<T>> witness_pairs;
     // All these quantities are aliased in the callback data.
@@ -549,7 +550,7 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
 
   std::vector<SignedDistanceToPoint<T>> ComputeSignedDistanceToPoint(
       const Vector3<T>& p_WQ,
-      const std::unordered_map<GeometryId, Isometry3<T>>& X_WGs,
+      const std::unordered_map<GeometryId, RigidTransform<T>>& X_WGs,
       const double threshold) const {
     // We create a sphere of zero radius centered at the query point and put
     // it into a CollisionObject.
@@ -765,12 +766,11 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
 
   int peek_next_clique() const { return collision_filter_.peek_next_clique(); }
 
-  const Isometry3<double>& GetX_WG(GeometryId id,
-                                   bool is_dynamic) const {
+  const RigidTransformd GetX_WG(GeometryId id, bool is_dynamic) const {
     if (is_dynamic) {
-      return dynamic_objects_.at(id)->getTransform();
+      return RigidTransformd(dynamic_objects_.at(id)->getTransform());
     } else {
-      return anchored_objects_.at(id)->getTransform();
+      return RigidTransformd(anchored_objects_.at(id)->getTransform());
     }
   }
 
@@ -883,7 +883,7 @@ void ProximityEngine<T>::AddDynamicGeometry(
 
 template <typename T>
 void ProximityEngine<T>::AddAnchoredGeometry(
-    const Shape& shape, const Isometry3<double>& X_WG, GeometryId id) {
+    const Shape& shape, const RigidTransformd& X_WG, GeometryId id) {
   impl_->AddAnchoredGeometry(shape, X_WG, id);
 }
 
@@ -926,14 +926,14 @@ std::unique_ptr<ProximityEngine<AutoDiffXd>> ProximityEngine<T>::ToAutoDiffXd()
 
 template <typename T>
 void ProximityEngine<T>::UpdateWorldPoses(
-    const unordered_map<GeometryId, Isometry3<T>>& X_WGs) {
+    const unordered_map<GeometryId, RigidTransform<T>>& X_WGs) {
   impl_->UpdateWorldPoses(X_WGs);
 }
 
 template <typename T>
 std::vector<SignedDistancePair<T>>
 ProximityEngine<T>::ComputeSignedDistancePairwiseClosestPoints(
-    const std::unordered_map<GeometryId, Isometry3<T>>& X_WGs,
+    const std::unordered_map<GeometryId, RigidTransform<T>>& X_WGs,
     const double max_distance) const {
   return impl_->ComputeSignedDistancePairwiseClosestPoints(X_WGs, max_distance);
 }
@@ -942,7 +942,7 @@ template <typename T>
 std::vector<SignedDistanceToPoint<T>>
 ProximityEngine<T>::ComputeSignedDistanceToPoint(
     const Vector3<T>& query,
-    const std::unordered_map<GeometryId, Isometry3<T>>& X_WGs,
+    const std::unordered_map<GeometryId, RigidTransform<T>>& X_WGs,
     const double threshold) const {
   return impl_->ComputeSignedDistanceToPoint(query, X_WGs, threshold);
 }
@@ -1014,8 +1014,8 @@ int ProximityEngine<T>::peek_next_clique() const {
 }
 
 template <typename T>
-const Isometry3<double>& ProximityEngine<T>::GetX_WG(GeometryId id,
-                                                     bool is_dynamic) const {
+const RigidTransformd ProximityEngine<T>::GetX_WG(GeometryId id,
+                                                  bool is_dynamic) const {
   return impl_->GetX_WG(id, is_dynamic);
 }
 

--- a/geometry/proximity_engine.h
+++ b/geometry/proximity_engine.h
@@ -15,6 +15,7 @@
 #include "drake/geometry/query_results/signed_distance_pair.h"
 #include "drake/geometry/query_results/signed_distance_to_point.h"
 #include "drake/geometry/shape_specification.h"
+#include "drake/math/rigid_transform.h"
 
 namespace drake {
 namespace geometry {
@@ -28,8 +29,6 @@ namespace internal {
 // the purpose of collision filters.
 class GeometryStateCollisionFilterAttorney;
 #endif
-
-// TODO(SeanCurtis-TRI): Swap Isometry3 for the new Transform class.
 
 /** The underlying engine for performing geometric _proximity_ queries.
  It owns the geometry instances and, once it has been provided with the poses
@@ -91,8 +90,8 @@ class ProximityEngine {
    @param X_WG    The pose of the shape in the world frame.
    @param id      The id of the geometry in SceneGraph to which this shape
                   belongs.  */
-  void AddAnchoredGeometry(const Shape& shape, const Isometry3<double>& X_WG,
-                           GeometryId id);
+  void AddAnchoredGeometry(const Shape& shape,
+                           const math::RigidTransformd& X_WG, GeometryId id);
 
   // TODO(SeanCurtis-TRI): Decide if knowing whether something is dynamic or not
   //  is *actually* sufficiently helpful to justify this act.
@@ -135,7 +134,7 @@ class ProximityEngine {
   //  2. I could simply have a method that returns a mutable reference to such
   //    a vector and the caller sets values there directly.
   void UpdateWorldPoses(
-      const std::unordered_map<GeometryId, Isometry3<T>>& X_WGs);
+      const std::unordered_map<GeometryId, math::RigidTransform<T>>& X_WGs);
 
   // ----------------------------------------------------------------------
   /**@name              Signed Distance Queries
@@ -166,7 +165,7 @@ class ProximityEngine {
    */
   std::vector<SignedDistancePair<T>>
   ComputeSignedDistancePairwiseClosestPoints(
-      const std::unordered_map<GeometryId, Isometry3<T>>& X_WGs,
+      const std::unordered_map<GeometryId, math::RigidTransform<T>>& X_WGs,
       const double max_distance) const;
 
   /** Performs work in support of GeometryState::ComputeSignedDistanceToPoint().
@@ -181,7 +180,7 @@ class ProximityEngine {
   std::vector<SignedDistanceToPoint<T>>
   ComputeSignedDistanceToPoint(
       const Vector3<T>& p_WQ,
-      const std::unordered_map<GeometryId, Isometry3<T>>& X_WGs,
+      const std::unordered_map<GeometryId, math::RigidTransform<T>>& X_WGs,
       const double threshold = std::numeric_limits<double>::infinity()) const;
   //@}
 
@@ -315,7 +314,8 @@ class ProximityEngine {
   int peek_next_clique() const;
 
   // Reports the pose (X_WG) of the geometry with the given id.
-  const Isometry3<double>& GetX_WG(GeometryId id, bool is_dynamic) const;
+  const math::RigidTransform<double> GetX_WG(GeometryId id,
+                                             bool is_dynamic) const;
 
   ////////////////////////////////////////////////////////////////////////////
 

--- a/geometry/query_object.cc
+++ b/geometry/query_object.cc
@@ -45,30 +45,30 @@ QueryObject<T>& QueryObject<T>::operator=(const QueryObject<T>& query_object) {
 }
 
 template <typename T>
-RigidTransform<T> QueryObject<T>::X_WF(FrameId id) const {
+const RigidTransform<T>& QueryObject<T>::X_WF(FrameId id) const {
   ThrowIfNotCallable();
 
   FullPoseUpdate();
   const GeometryState<T>& state = geometry_state();
-  return RigidTransform<T>(state.get_pose_in_world(id));
+  return state.get_pose_in_world(id);
 }
 
 template <typename T>
-RigidTransform<T> QueryObject<T>::X_PF(FrameId id) const {
+const RigidTransform<T>& QueryObject<T>::X_PF(FrameId id) const {
   ThrowIfNotCallable();
 
   FullPoseUpdate();
   const GeometryState<T>& state = geometry_state();
-  return RigidTransform<T>(state.get_pose_in_parent(id));
+  return state.get_pose_in_parent(id);
 }
 
 template <typename T>
-RigidTransform<T> QueryObject<T>::X_WG(GeometryId id) const {
+const RigidTransform<T>& QueryObject<T>::X_WG(GeometryId id) const {
   ThrowIfNotCallable();
 
   FullPoseUpdate();
   const GeometryState<T>& state = geometry_state();
-  return RigidTransform<T>(state.get_pose_in_world(id));
+  return state.get_pose_in_world(id);
 }
 
 template <typename T>

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -114,7 +114,7 @@ class QueryObject {
   /** Reports the position of the frame indicated by `id` relative to the world
    frame.
    @throws std::logic_error if the frame `id` is not valid.  */
-  math::RigidTransform<T> X_WF(FrameId id) const;
+  const math::RigidTransform<T>& X_WF(FrameId id) const;
 
   /** Reports the position of the frame indicated by `id` relative to its parent
    frame. If the frame was registered with the world frame as its parent frame,
@@ -122,12 +122,12 @@ class QueryObject {
    @note This is analogous to but distinct from SceneGraphInspector::X_PG().
    In this case, the pose will *always* be relative to another frame.
    @throws std::logic_error if the frame `id` is not valid.  */
-  math::RigidTransform<T> X_PF(FrameId id) const;
+  const math::RigidTransform<T>& X_PF(FrameId id) const;
 
   /** Reports the position of the geometry indicated by `id` relative to the
    world frame.
    @throws std::logic_error if the geometry `id` is not valid.  */
-  math::RigidTransform<T> X_WG(GeometryId id) const;
+  const math::RigidTransform<T>& X_WG(GeometryId id) const;
 
   //@}
 

--- a/geometry/render/render_engine.h
+++ b/geometry/render/render_engine.h
@@ -156,7 +156,7 @@ class RenderEngine : public ShapeReifier {
       const std::unordered_map<GeometryId, math::RigidTransform<T>>& X_WGs) {
     for (const GeometryId id : update_ids_) {
       const math::RigidTransformd X_WG =
-          geometry::internal::convert(X_WGs.at(id));
+          geometry::internal::convert_to_double(X_WGs.at(id));
       DoUpdateVisualPose(id, X_WG);
     }
   }

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -415,7 +415,10 @@ void SceneGraph<T>::CalcPoseBundle(const Context<T>& context,
   }
 
   for (FrameId f_id : dynamic_frames) {
-    output->set_pose(i, g_state.get_pose_in_world(f_id));
+    // TODO(SeanCurtis-TRI): Remove GetAsIsometry3() when PoseBundle supports
+    //  RigidTransform.
+    //  https://github.com/RobotLocomotion/drake/issues/11888
+    output->set_pose(i, g_state.get_pose_in_world(f_id).GetAsIsometry3());
     // TODO(SeanCurtis-TRI): Handle velocity.
     ++i;
   }

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -415,9 +415,8 @@ void SceneGraph<T>::CalcPoseBundle(const Context<T>& context,
   }
 
   for (FrameId f_id : dynamic_frames) {
-    // TODO(SeanCurtis-TRI): Remove GetAsIsometry3() when PoseBundle supports
+    // TODO(#11888): Remove GetAsIsometry3() when PoseBundle supports
     //  RigidTransform.
-    //  https://github.com/RobotLocomotion/drake/issues/11888
     output->set_pose(i, g_state.get_pose_in_world(f_id).GetAsIsometry3());
     // TODO(SeanCurtis-TRI): Handle velocity.
     ++i;

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -327,7 +327,7 @@ class SceneGraphInspector {
    _topological parent_ P, `X_PG`. That topological parent may be a frame F or
    another geometry. If the geometry was registered directly to F, then
    `X_PG = X_FG`.
-   @sa GetPoseInFrame
+   @sa GetPoseInFrame()
    @throws std::logic_error if `id` does not map to a registered geometry.  */
   const math::RigidTransform<double>& GetPoseInParent(GeometryId id) const {
     DRAKE_DEMAND(state_ != nullptr);
@@ -348,7 +348,7 @@ class SceneGraphInspector {
    frame F (regardless of whether its _topological parent_ is another geometry P
    or not). If the geometry was registered directly to the frame F, then
    `X_PG = X_FG`.
-   @sa GetPoseInParent
+   @sa GetPoseInParent()
    @throws std::logic_error if `id` does not map to a registered geometry.  */
   const math::RigidTransform<double>& GetPoseInFrame(GeometryId id) const {
     DRAKE_DEMAND(state_ != nullptr);

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -318,7 +318,18 @@ class SceneGraphInspector {
    _topological parent_ P. That topological parent may be a frame F or another
    geometry. If the geometry was registered directly to F, then `X_PG = X_FG`.
    @throws std::logic_error if `id` does not map to a registered geometry.  */
+  DRAKE_DEPRECATED("2019-11-01", "Simply use GetPoseInParent()")
   const Isometry3<double> X_PG(GeometryId id) const {
+    return GetPoseInParent(id).GetAsIsometry3();
+  }
+
+  /** Reports the pose of the geometry G with the given `id` in its registered
+   _topological parent_ P, `X_PG`. That topological parent may be a frame F or
+   another geometry. If the geometry was registered directly to F, then
+   `X_PG = X_FG`.
+   @sa GetPoseInFrame
+   @throws std::logic_error if `id` does not map to a registered geometry.  */
+  const math::RigidTransform<double>& GetPoseInParent(GeometryId id) const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->GetPoseInParent(id);
   }
@@ -328,7 +339,18 @@ class SceneGraphInspector {
    or not). If the geometry was registered directly to the frame F, then
    `X_PG = X_FG`.
    @throws std::logic_error if `id` does not map to a registered geometry.  */
+  DRAKE_DEPRECATED("2019-11-01", "Simply use GetPoseInFrame()")
   const Isometry3<double> X_FG(GeometryId id) const {
+    return GetPoseInFrame(id).GetAsIsometry3();
+  }
+
+  /** Reports the pose of the geometry G with the given `id` in its registered
+   frame F (regardless of whether its _topological parent_ is another geometry P
+   or not). If the geometry was registered directly to the frame F, then
+   `X_PG = X_FG`.
+   @sa GetPoseInParent
+   @throws std::logic_error if `id` does not map to a registered geometry.  */
+  const math::RigidTransform<double>& GetPoseInFrame(GeometryId id) const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->GetPoseInFrame(id);
   }

--- a/geometry/shape_specification.cc
+++ b/geometry/shape_specification.cc
@@ -22,13 +22,8 @@ Cylinder::Cylinder(double radius, double length)
 
 HalfSpace::HalfSpace() : Shape(ShapeTag<HalfSpace>()) {}
 
-Isometry3<double> HalfSpace::MakePose(const Vector3<double>& Hz_dir_F,
-                                      const Vector3<double>& p_FB) {
-  return MakePoseInF(Hz_dir_F, p_FB).GetAsIsometry3();
-}
-
-RigidTransform<double> HalfSpace::MakePoseInF(const Vector3<double>& Hz_dir_F,
-                                              const Vector3<double>& p_FB) {
+RigidTransform<double> HalfSpace::MakePose(const Vector3<double>& Hz_dir_F,
+                                           const Vector3<double>& p_FB) {
   const double norm = Hz_dir_F.norm();
   // Note: this value of epsilon is somewhat arbitrary. It's merely a minor
   // fence over which ridiculous vectors will trip.

--- a/geometry/shape_specification.cc
+++ b/geometry/shape_specification.cc
@@ -3,6 +3,8 @@
 namespace drake {
 namespace geometry {
 
+using math::RigidTransform;
+
 Shape::~Shape() {}
 
 void Shape::Reify(ShapeReifier* reifier, void* user_data) const {
@@ -20,42 +22,40 @@ Cylinder::Cylinder(double radius, double length)
 
 HalfSpace::HalfSpace() : Shape(ShapeTag<HalfSpace>()) {}
 
-Isometry3<double> HalfSpace::MakePose(const Vector3<double>& Cz_F,
-                                      const Vector3<double>& p_FC) {
-  // TODO(SeanCurtis-TRI): Ultimately, use RotationMatrix to create the basis.
-  double norm = Cz_F.norm();
+Isometry3<double> HalfSpace::MakePose(const Vector3<double>& Hz_dir_F,
+                                      const Vector3<double>& p_FB) {
+  return MakePoseInF(Hz_dir_F, p_FB).GetAsIsometry3();
+}
+
+RigidTransform<double> HalfSpace::MakePoseInF(const Vector3<double>& Hz_dir_F,
+                                              const Vector3<double>& p_FB) {
+  const double norm = Hz_dir_F.norm();
   // Note: this value of epsilon is somewhat arbitrary. It's merely a minor
   // fence over which ridiculous vectors will trip.
-  if (norm < 1e-10)
+  if (norm < 1e-10) {
     throw std::logic_error("Can't make pose from a zero vector.");
+  }
 
   // First create basis.
   // Projects the normal into the first quadrant in order to identify the
   // *smallest* component of the normal.
-  const Vector3<double> u(Cz_F.cwiseAbs());
-  int minAxis;
-  u.minCoeff(&minAxis);
+  const Vector3<double> u(Hz_dir_F.cwiseAbs());
+  int min_axis;
+  u.minCoeff(&min_axis);
   // The axis corresponding to the smallest component of the normal will be
   // *most* perpendicular.
-  Vector3<double> perpAxis;
-  perpAxis << (minAxis == 0 ? 1 : 0), (minAxis == 1 ? 1 : 0),
-      (minAxis == 2 ? 1 : 0);
-  // Now define x-, y-, and z-axes. The z-axis lies in the normal direction.
-  Vector3<double> z_axis_F = Cz_F / norm;
-  Vector3<double> x_axis_F = Cz_F.cross(perpAxis).normalized();
-  Vector3<double> y_axis_F = z_axis_F.cross(x_axis_F);
-  // Transformation from canonical frame C to target frame F.
-  Matrix3<double> R_FC;
-  R_FC.col(0) = x_axis_F;
-  R_FC.col(1) = y_axis_F;
-  R_FC.col(2) = z_axis_F;
+  Vector3<double> perp_axis{0, 0, 0};
+  perp_axis(min_axis) = 1;
+  // Now define x-, y-, and z-axes. The z-axis lies in the given direction.
+  Vector3<double> Hz_F = Hz_dir_F / norm;
+  Vector3<double> Hx_F = Hz_F.cross(perp_axis).normalized();
+  Vector3<double> Hy_F = Hz_F.cross(Hx_F);
 
-  // Construct pose from basis and point.
-  Isometry3<double> X_FC = Isometry3<double>::Identity();
-  X_FC.linear() = R_FC;
-  // Find the *minimum* translation to make sure the point lies on the plane.
-  X_FC.translation() = z_axis_F.dot(p_FC) * z_axis_F;
-  return X_FC;
+  // Transformation from canonical frame C to target frame F.
+  const auto R_FH =
+      math::RotationMatrixd::MakeFromOrthonormalColumns(Hx_F, Hy_F, Hz_F);
+  const Vector3<double> p_FH = Hz_F.dot(p_FB) * Hz_F;
+  return RigidTransform<double>(R_FH, p_FH);
 }
 
 Box::Box(double width, double depth, double height)

--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -7,7 +7,9 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
+#include "drake/math/rigid_transform.h"
 
 /** @file
  Provides the classes through which geometric shapes are introduced into
@@ -174,19 +176,38 @@ class HalfSpace final : public Shape {
 
   /** Creates the pose of a canonical half space in frame F.
    The half space's normal is aligned to the positive z-axis of its canonical
-   frame C. Given the measure of that axis in frame F (Cz_F) and a position
-   vector to a point on the plane expressed in the same frame, `p_FC`, creates
-   the pose of the half space in frame F: `X_FC`.
-   @param Cz_F      The positive z-axis of the canonical frame expressed in
-                    frame F. It must be a non-zero vector but need not be unit
-                    length.
-   @param p_FC      A point lying on the half-space's boundary measured
+   frame H. Given a vector that points in the same direction, measured in the
+   F frame (Hz_dir_F) and a position vector to a point on the half space's
+   *boundary* expressed in the same frame, `p_FB`, creates
+   the pose of the half space in frame F: `X_FH`.
+   @param Hz_dir_F  A vector in the direction of the positive z-axis of the
+                    canonical frame expressed in frame F. It must be a non-zero
+                    vector but need not be unit length.
+   @param p_FB      A point B lying on the half space's boundary measured
                     and expressed in frame F.
-   @retval X_FC     The pose of the canonical half-space in frame F.
+   @retval X_FH     The pose of the canonical half-space in frame F.
    @throws std::logic_error if the normal is _close_ to a zero-vector (e.g.,
                             ‖normal_F‖₂ < ε). */
-  static Isometry3<double> MakePose(const Vector3<double>& Cz_F,
+  DRAKE_DEPRECATED("2019-11-01", "Please use MakePoseInF")
+  static Isometry3<double> MakePose(const Vector3<double>& Hz_dir_F,
                                     const Vector3<double>& p_FC);
+
+  /** Creates the pose of a canonical half space in frame F.
+   The half space's normal is aligned to the positive z-axis of its canonical
+   frame H. Given a vector that points in the same direction, measured in the
+   F frame (Hz_dir_F) and a position vector to a point B on the half space's
+   *boundary* expressed in the same frame, `p_FB`, creates
+   the pose of the half space in frame F: `X_FH`.
+   @param Hz_dir_F  A vector in the direction of the positive z-axis of the
+                    canonical frame expressed in frame F. It must be a non-zero
+                    vector but need not be unit length.
+   @param p_FB      A point B lying on the half space's boundary measured
+                    and expressed in frame F.
+   @retval X_FH     The pose of the canonical half-space in frame F.
+   @throws std::logic_error if the normal is _close_ to a zero-vector (e.g.,
+                            ‖normal_F‖₂ < ε). */
+  static math::RigidTransform<double> MakePoseInF(
+      const Vector3<double>& Hz_dir_F, const Vector3<double>& p_FB);
 };
 
 // TODO(SeanCurtis-TRI): Update documentation when the level of support for

--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -7,7 +7,6 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/math/rigid_transform.h"
 
@@ -188,26 +187,8 @@ class HalfSpace final : public Shape {
    @retval X_FH     The pose of the canonical half-space in frame F.
    @throws std::logic_error if the normal is _close_ to a zero-vector (e.g.,
                             ‖normal_F‖₂ < ε). */
-  DRAKE_DEPRECATED("2019-11-01", "Please use MakePoseInF")
-  static Isometry3<double> MakePose(const Vector3<double>& Hz_dir_F,
-                                    const Vector3<double>& p_FC);
-
-  /** Creates the pose of a canonical half space in frame F.
-   The half space's normal is aligned to the positive z-axis of its canonical
-   frame H. Given a vector that points in the same direction, measured in the
-   F frame (Hz_dir_F) and a position vector to a point B on the half space's
-   *boundary* expressed in the same frame, `p_FB`, creates
-   the pose of the half space in frame F: `X_FH`.
-   @param Hz_dir_F  A vector in the direction of the positive z-axis of the
-                    canonical frame expressed in frame F. It must be a non-zero
-                    vector but need not be unit length.
-   @param p_FB      A point B lying on the half space's boundary measured
-                    and expressed in frame F.
-   @retval X_FH     The pose of the canonical half-space in frame F.
-   @throws std::logic_error if the normal is _close_ to a zero-vector (e.g.,
-                            ‖normal_F‖₂ < ε). */
-  static math::RigidTransform<double> MakePoseInF(
-      const Vector3<double>& Hz_dir_F, const Vector3<double>& p_FB);
+  static math::RigidTransform<double> MakePose(const Vector3<double>& Hz_dir_F,
+                                               const Vector3<double>& p_FB);
 };
 
 // TODO(SeanCurtis-TRI): Update documentation when the level of support for

--- a/geometry/test/geometry_instance_test.cc
+++ b/geometry/test/geometry_instance_test.cc
@@ -12,6 +12,7 @@ namespace drake {
 namespace geometry {
 namespace {
 
+using math::RigidTransformd;
 using std::make_unique;
 using std::move;
 
@@ -21,12 +22,12 @@ GTEST_TEST(GeometryInstanceTest, IsCopyable) {
   // have a runtime check available but this will fail to compile if the class
   // is not copyable.
   copyable_unique_ptr<GeometryInstance> geo(make_unique<GeometryInstance>
-      (Isometry3<double>(), make_unique<Sphere>(1), "sphere"));
+      (RigidTransformd(), make_unique<Sphere>(1), "sphere"));
   EXPECT_TRUE(geo->id().is_valid());
 }
 
 GTEST_TEST(GeometryInstanceTest, IdCopies) {
-  Isometry3<double> pose = Isometry3<double>::Identity();
+  RigidTransformd pose = RigidTransformd::Identity();
   auto shape = make_unique<Sphere>(1.0);
   GeometryInstance geometry_a{pose, move(shape), "geometry_a"};
   GeometryInstance geometry_b(geometry_a);
@@ -46,7 +47,7 @@ GTEST_TEST(GeometryInstanceTest, IdCopies) {
 // version of the given name. This doesn't test the definition of
 // canonicalization merely the fact of the act.
 GTEST_TEST(GeometryInstanceTest, CanonicalName) {
-  Isometry3<double> pose = Isometry3<double>::Identity();
+  RigidTransformd pose = RigidTransformd::Identity();
 
   auto make_instance = [&pose](const std::string& name) {
     auto shape = make_unique<Sphere>(1.0);

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -25,13 +25,14 @@
 namespace drake {
 namespace geometry {
 
-using Eigen::Isometry3d;
 using Eigen::Translation3d;
 using Eigen::Vector3d;
 using internal::DummyRenderEngine;
 using internal::InternalFrame;
 using internal::InternalGeometry;
 using internal::ProximityEngine;
+using math::RigidTransform;
+using math::RigidTransformd;
 using render::RenderLabel;
 using std::make_unique;
 using std::map;
@@ -45,7 +46,7 @@ using std::unordered_set;
 using std::vector;
 
 template <typename T>
-using IdPoseMap = unordered_map<GeometryId, Isometry3<T>>;
+using IdPoseMap = unordered_map<GeometryId, RigidTransform<T>>;
 
 // Implementation of friend class that allows me to peek into the geometry state
 // to confirm invariants on the state's internal workings as a result of
@@ -95,11 +96,11 @@ class GeometryStateTester {
     return state_->X_WGs_;
   }
 
-  const vector<Isometry3<T>>& get_frame_world_poses() const {
+  const vector<RigidTransform<T>>& get_frame_world_poses() const {
     return state_->X_WF_;
   }
 
-  const vector<Isometry3<T>>& get_frame_parent_poses() const {
+  const vector<RigidTransform<T>>& get_frame_parent_poses() const {
     return state_->X_PF_;
   }
 
@@ -160,7 +161,7 @@ class ShapeMatcher final : public ShapeReifier {
                                               FrameId frame_id) {
     GeometryId g_id = state->RegisterGeometry(
         source_id, frame_id,
-        make_unique<GeometryInstance>(Isometry3d::Identity(),
+        make_unique<GeometryInstance>(RigidTransformd::Identity(),
                                       make_unique<ShapeType>(expected_),
                                       "shape"));
     state->GetShape(g_id).Reify(this);
@@ -336,7 +337,7 @@ class GeometryStateTestBase {
   // should invoke this in its SetUp() method.
   void TestInit(bool add_renderer = true) {
     frame_ = make_unique<GeometryFrame>("ref_frame");
-    instance_pose_.translation() << 10, 20, 30;
+    instance_pose_.set_translation({10, 20, 30});
     instance_ = make_unique<GeometryInstance>(
         instance_pose_, make_unique<Sphere>(1.0), "instance");
     gs_tester_.set_state(&geometry_state_);
@@ -403,17 +404,18 @@ class GeometryStateTestBase {
     source_id_ = NewSource();
 
     // Create f0.
-    Isometry3d pose = Isometry3d::Identity();
-    pose.translation() << 1, 2, 3;
-    pose.linear() << 1, 0, 0, 0, 0, 1, 0, -1, 0;  // 90° around x-axis.
+    // 90° around x-axis.
+    RigidTransformd pose(AngleAxis<double>(M_PI_2, Vector3d::UnitX()),
+                         Vector3d{1, 2, 3});
     frames_.push_back(geometry_state_.RegisterFrame(
         source_id_, GeometryFrame("f0")));
     X_WFs_.push_back(pose);
     X_PFs_.push_back(pose);
 
     // Create f1.
-    pose.translation() << 10, 20, 30;
-    pose.linear() << 0, 0, -1, 0, 1, 0, 1, 0, 0;  // 90° around y-axis.
+    // 90° around y-axis.
+    pose = RigidTransformd(AngleAxis<double>(M_PI_2, Vector3d::UnitY()),
+                           Vector3d{10, 20, 30});
     frames_.push_back(geometry_state_.RegisterFrame(
         source_id_, GeometryFrame("f1")));
     X_WFs_.push_back(pose);
@@ -433,12 +435,10 @@ class GeometryStateTestBase {
     int g_count = 0;
     for (auto frame_id : frames_) {
       for (int i = 0; i < kGeometryCount; ++i) {
-        pose.translation() << g_count + 1, 0, 0;
-        pose.linear() =
-            AngleAxis<double>(g_count * M_PI / 2.0, x_axis).matrix();
+        pose = RigidTransformd(AngleAxis<double>(g_count * M_PI_2, x_axis),
+                               Vector3d{g_count + 1.0, 0, 0});
         // Have the name reflect the frame and the index in the geometry.
-        const string& name =
-            to_string(frame_id) + "_g" + to_string(i);
+        const string& name = to_string(frame_id) + "_g" + to_string(i);
         geometry_names_[g_count] = name;
         geometries_[g_count] = geometry_state_.RegisterGeometry(
             source_id_, frame_id,
@@ -449,7 +449,7 @@ class GeometryStateTestBase {
     }
 
     // Create anchored geometry.
-    X_WA_ = Isometry3d{Translation3d{0, 0, -1}};
+    X_WA_ = RigidTransformd{Translation3d{0, 0, -1}};
     // This simultaneously tests the named registration function and
     // _implicitly_ tests registration of geometry against the world frame id
     // (as that is how `RegisterAnchoredGeometry()` works.
@@ -503,7 +503,7 @@ class GeometryStateTestBase {
   // Members owned by the test class.
   unique_ptr<GeometryFrame> frame_;
   unique_ptr<GeometryInstance> instance_;
-  Isometry3d instance_pose_{Isometry3d::Identity()};
+  RigidTransformd instance_pose_{RigidTransformd::Identity()};
   GeometryState<double> geometry_state_;
   GeometryStateTester<double> gs_tester_;
   DummyRenderEngine* render_engine_{};
@@ -531,13 +531,13 @@ class GeometryStateTestBase {
   SourceId source_id_;
 
   // The poses of the frames in the world frame.
-  vector<Isometry3d> X_WFs_;
+  vector<RigidTransformd> X_WFs_;
   // The poses of the frames in the parent's frame.
-  vector<Isometry3d> X_PFs_;
+  vector<RigidTransformd> X_PFs_;
   // The poses of the dynamic geometries in the parent frame.
-  vector<Isometry3d> X_FGs_;
+  vector<RigidTransformd> X_FGs_;
   // The pose of the anchored geometry in the world frame.
-  Isometry3d X_WA_;
+  RigidTransformd X_WA_;
   // The default source name.
   const string kSourceName{"default_source"};
   // The name of the dummy renderer added to the geometry state.
@@ -743,28 +743,29 @@ void ExpectSuccessfulTransmogrification(
   EXPECT_EQ(ad_tester.get_frame_index_id_map(),
             d_tester.get_frame_index_id_map());
 
-  // 3. Compare Isometry3d with Isometry3<AutoDiffXd>
+  // 3. Compare RigidTransformd with RigidTransform<AutoDiffXd>.
   for (const auto& id_geom_pair : ad_tester.get_geometries()) {
     const GeometryId id = id_geom_pair.first;
     const auto& ad_geometry = id_geom_pair.second;
     EXPECT_TRUE(CompareMatrices(
-        ad_geometry.X_FG().matrix().block<3, 4>(0, 0),
-        d_tester.get_geometries().at(id).X_FG().matrix().block<3, 4>(0, 0)));
+        ad_geometry.X_FG().GetAsMatrix34(),
+        d_tester.get_geometries().at(id).X_FG().GetAsMatrix34()));
   }
 
-  // 4. Compare Isometry3<AutoDiffXd> with Isometry3d
-  auto test_ad_vs_double_pose = [](const Isometry3<AutoDiffXd>& test,
-                                   const Isometry3d& ref) {
+  // 4. Compare RigidTransform<AutoDiffXd> with RigidTransformd.
+  auto test_ad_vs_double_pose = [](const RigidTransform<AutoDiffXd>& test,
+                                   const RigidTransformd& ref) {
     for (int row = 0; row < 3; ++row) {
       for (int col = 0; col < 4; ++col) {
-        EXPECT_EQ(test(row, col).value(), ref(row, col));
+        EXPECT_EQ(test.GetAsMatrix34()(row, col).value(),
+                  ref.GetAsMatrix34()(row, col));
       }
     }
   };
 
   auto test_ad_vs_double = [test_ad_vs_double_pose](
-                               const vector<Isometry3<AutoDiffXd>>& test,
-                               const vector<Isometry3d>& ref) {
+                               const vector<RigidTransform<AutoDiffXd>>& test,
+                               const vector<RigidTransformd>& ref) {
     EXPECT_EQ(test.size(), ref.size());
     for (size_t i = 0; i < ref.size(); ++i) {
       test_ad_vs_double_pose(test[i], ref[i]);
@@ -777,7 +778,7 @@ void ExpectSuccessfulTransmogrification(
     ASSERT_EQ(test.size(), ref.size());
     for (const auto& id_pose_pair : ref) {
       const GeometryId id = id_pose_pair.first;
-      const Isometry3d& ref_pose = id_pose_pair.second;
+      const RigidTransformd& ref_pose = id_pose_pair.second;
       test_ad_vs_double_pose(test.at(id), ref_pose);
     }
   };
@@ -870,16 +871,17 @@ TEST_F(GeometryStateTest, ValidateSingleSourceTree) {
                                       child_geometries.end());
       const auto& frame_in_parent = gs_tester_.get_frame_parent_poses();
       EXPECT_TRUE(
-          CompareMatrices(frame_in_parent[frame.index()].matrix(),
-                          X_PFs_[i].matrix()));
+          CompareMatrices(frame_in_parent[frame.index()].GetAsMatrix34(),
+                          X_PFs_[i].GetAsMatrix34()));
     };
 
     // When added, all frames' poses w.r.t. their parents are the identity.
     const auto& frame_in_parent = gs_tester_.get_frame_parent_poses();
     for (FrameId frame_id : frames_) {
       const auto& frame = internal_frames.at(frame_id);
-      EXPECT_TRUE(CompareMatrices(frame_in_parent[frame.index()].matrix(),
-                                  Isometry3d::Identity().matrix()));
+      EXPECT_TRUE(
+          CompareMatrices(frame_in_parent[frame.index()].GetAsMatrix34(),
+                          RigidTransformd::Identity().GetAsMatrix34()));
     }
 
     // Confirm posing positions the frames properly.
@@ -913,11 +915,11 @@ TEST_F(GeometryStateTest, ValidateSingleSourceTree) {
       // of GetPoseInFrame() and GetPoseInParent() must be the identical (as
       // the documentation for GeometryState::GetPoseInParent() indicates).
       EXPECT_TRUE(CompareMatrices(
-          geometry_state_.GetPoseInFrame(geometry.id()).matrix(),
-          X_FGs_[i].matrix()));
+          geometry_state_.GetPoseInFrame(geometry.id()).GetAsMatrix34(),
+          X_FGs_[i].GetAsMatrix34()));
       EXPECT_TRUE(CompareMatrices(
-          geometry_state_.GetPoseInParent(geometry.id()).matrix(),
-          X_FGs_[i].matrix()));
+          geometry_state_.GetPoseInParent(geometry.id()).GetAsMatrix34(),
+          X_FGs_[i].GetAsMatrix34()));
     }
   }
   EXPECT_EQ(static_cast<int>(gs_tester_.get_geometry_world_poses().size()),
@@ -1074,8 +1076,9 @@ TEST_F(GeometryStateTest, RegisterGeometryGoodSource) {
   EXPECT_EQ(g_id, expected_g_id);
   EXPECT_EQ(geometry_state_.GetFrameId(g_id), f_id);
   EXPECT_TRUE(geometry_state_.BelongsToSource(g_id, s_id));
-  const Isometry3d& X_FG = geometry_state_.GetPoseInFrame(g_id);
-  EXPECT_TRUE(CompareMatrices(X_FG.matrix(), instance_pose_.matrix()));
+  const RigidTransformd& X_FG = geometry_state_.GetPoseInFrame(g_id);
+  EXPECT_TRUE(
+      CompareMatrices(X_FG.GetAsMatrix34(), instance_pose_.GetAsMatrix34()));
 
   EXPECT_TRUE(gs_tester_.get_frames().at(f_id).has_child(g_id));
   const auto& geometry = gs_tester_.get_geometries().at(g_id);
@@ -1133,7 +1136,7 @@ TEST_F(GeometryStateTest, RegisterGeometryonValidGeometry) {
   const double x = 3;
   const double y = 2;
   const double z = 1;
-  Isometry3d pose{Translation3d{x, y, z}};
+  RigidTransformd pose{Translation3d{x, y, z}};
   const int parent_index = 0;
   const GeometryId parent_id = geometries_[parent_index];
   const FrameId frame_id = geometry_state_.GetFrameId(parent_id);
@@ -1150,15 +1153,16 @@ TEST_F(GeometryStateTest, RegisterGeometryonValidGeometry) {
   // geometry is at [parent_index + 1, 0, 0] and this is at [3, 2, 1]. They
   // simply sum up. The parent has *no* rotation so the resultant transform is
   // simply the sum of the translation vectors.
-  const Isometry3d expected_pose_in_frame{
+  const RigidTransformd expected_pose_in_frame{
       Translation3d{(parent_index + 1) + x, y, z}};
   EXPECT_EQ(frame_id, geometry_state_.GetFrameId(g_id));
 
-  const Isometry3d& X_FG = geometry_state_.GetPoseInFrame(g_id);
-  EXPECT_TRUE(CompareMatrices(X_FG.matrix(), expected_pose_in_frame.matrix(),
-                  1e-14, MatrixCompareType::absolute));
-  const Isometry3d& X_PG = geometry_state_.GetPoseInParent(g_id);
-  EXPECT_TRUE(CompareMatrices(X_PG.matrix(), pose.matrix(),
+  const RigidTransformd& X_FG = geometry_state_.GetPoseInFrame(g_id);
+  EXPECT_TRUE(CompareMatrices(X_FG.GetAsMatrix34(),
+                              expected_pose_in_frame.GetAsMatrix34(), 1e-14,
+                              MatrixCompareType::absolute));
+  const RigidTransformd& X_PG = geometry_state_.GetPoseInParent(g_id);
+  EXPECT_TRUE(CompareMatrices(X_PG.GetAsMatrix34(), pose.GetAsMatrix34(),
                   1e-14, MatrixCompareType::absolute));
 
   EXPECT_TRUE(gs_tester_.get_frames().at(frame_id).has_child(g_id));
@@ -1179,7 +1183,7 @@ TEST_F(GeometryStateTest, RegisterGeometryonValidGeometry) {
 TEST_F(GeometryStateTest, RegisterGeometryonInvalidGeometry) {
   const SourceId s_id = SetUpSingleSourceTree();
   auto instance = make_unique<GeometryInstance>(
-      Isometry3d::Identity(), make_unique<Sphere>(1), "sphere");
+      RigidTransformd::Identity(), make_unique<Sphere>(1), "sphere");
   const GeometryId junk_id = GeometryId::get_new_id();
   DRAKE_EXPECT_THROWS_MESSAGE(
       geometry_state_.RegisterGeometryWithParent(s_id, junk_id, move(instance)),
@@ -1202,7 +1206,7 @@ TEST_F(GeometryStateTest, RegisterNullGeometryonGeometry) {
 TEST_F(GeometryStateTest, RegisterAnchoredGeometry) {
   const SourceId s_id = NewSource("new source");
   auto instance = make_unique<GeometryInstance>(
-      Isometry3d::Identity(), make_unique<Sphere>(1), "sphere");
+      RigidTransformd::Identity(), make_unique<Sphere>(1), "sphere");
   const GeometryId expected_g_id = instance->id();
   const auto g_id =
       geometry_state_.RegisterAnchoredGeometry(s_id, move(instance));
@@ -1214,20 +1218,21 @@ TEST_F(GeometryStateTest, RegisterAnchoredGeometry) {
   EXPECT_EQ(s_id, g->source_id());
   // Assigned directly to the world frame means the pose in parent and frame
   // should match.
-  EXPECT_TRUE(CompareMatrices(g->X_FG().matrix(), g->X_PG().matrix()));
+  EXPECT_TRUE(
+      CompareMatrices(g->X_FG().GetAsMatrix34(), g->X_PG().GetAsMatrix34()));
 }
 
 // Tests the registration of a new geometry on another geometry.
 TEST_F(GeometryStateTest, RegisterAnchoredOnAnchoredGeometry) {
   // Add an anchored geometry.
   const SourceId s_id = NewSource("new source");
-  Isometry3d pose{Translation3d{1, 2, 3}};
+  RigidTransformd pose{Translation3d{1, 2, 3}};
   auto instance = make_unique<GeometryInstance>(
       pose, make_unique<Sphere>(1), "sphere1");
   auto parent_id = geometry_state_.RegisterAnchoredGeometry(s_id,
                                                             move(instance));
 
-  pose = Isometry3d::Identity();
+  pose = RigidTransformd::Identity();
   instance = make_unique<GeometryInstance>(
       pose, make_unique<Sphere>(1), "sphere2");
   auto child_id = geometry_state_.RegisterGeometryWithParent(s_id, parent_id,
@@ -1237,9 +1242,11 @@ TEST_F(GeometryStateTest, RegisterAnchoredOnAnchoredGeometry) {
   EXPECT_TRUE(parent->has_child(child_id));
   EXPECT_TRUE(static_cast<bool>(child->parent_id()));
   EXPECT_EQ(parent_id, *child->parent_id());
-  EXPECT_TRUE(CompareMatrices(pose.matrix(), child->X_PG().matrix()));
-  const Isometry3d& X_FP = parent->X_FG();
-  EXPECT_TRUE(CompareMatrices((X_FP * pose).matrix(), child->X_FG().matrix()));
+  EXPECT_TRUE(
+      CompareMatrices(pose.GetAsMatrix34(), child->X_PG().GetAsMatrix34()));
+  const RigidTransformd& X_FP = parent->X_FG();
+  EXPECT_TRUE(CompareMatrices((X_FP * pose).GetAsMatrix34(),
+                              child->X_FG().GetAsMatrix34()));
   EXPECT_EQ(InternalFrame::world_frame_id(), parent->frame_id());
 }
 
@@ -1258,7 +1265,7 @@ TEST_F(GeometryStateTest, RegisterDuplicateAnchoredGeometry) {
 // Tests the attempt to register anchored geometry on an invalid source.
 TEST_F(GeometryStateTest, RegisterAnchoredGeometryInvalidSource) {
   auto instance = make_unique<GeometryInstance>(
-      Isometry3d::Identity(), make_unique<Sphere>(1), "sphere");
+      RigidTransformd::Identity(), make_unique<Sphere>(1), "sphere");
   DRAKE_EXPECT_THROWS_MESSAGE(
       geometry_state_.RegisterAnchoredGeometry(SourceId::get_new_id(),
                                                move(instance)),
@@ -1330,7 +1337,7 @@ TEST_F(GeometryStateTest, RemoveGeometry) {
   EXPECT_NO_THROW(
       added_id = geometry_state_.RegisterGeometry(
           source_id_, frames_[0],
-          make_unique<GeometryInstance>(Isometry3d::Identity(),
+          make_unique<GeometryInstance>(RigidTransformd::Identity(),
                                         make_unique<Sphere>(1), "newest")));
 
   // Adding proximity role to the new geometry brings the total number of
@@ -1367,7 +1374,7 @@ TEST_F(GeometryStateTest, RemoveGeometryTree) {
   // Hang geometry from the first geometry.
   const GeometryId g_id = geometry_state_.RegisterGeometryWithParent(
       s_id, root_id,
-      make_unique<GeometryInstance>(Isometry3d::Identity(),
+      make_unique<GeometryInstance>(RigidTransformd::Identity(),
                                     unique_ptr<Shape>(new Sphere(1)), "leaf"));
   geometry_state_.AssignRole(s_id, g_id, ProximityProperties());
 
@@ -1403,7 +1410,7 @@ TEST_F(GeometryStateTest, RemoveChildLeaf) {
   // Hang geometry from the first geometry.
   const GeometryId g_id = geometry_state_.RegisterGeometryWithParent(
       s_id, parent_id,
-      make_unique<GeometryInstance>(Isometry3d::Identity(),
+      make_unique<GeometryInstance>(RigidTransformd::Identity(),
                                     unique_ptr<Shape>(new Sphere(1)), "leaf"));
   EXPECT_EQ(geometry_state_.get_num_geometries(),
             single_tree_total_geometry_count() + 1);
@@ -1444,7 +1451,7 @@ TEST_F(GeometryStateTest, RemoveGeometryInvalid) {
   EXPECT_EQ(geometry_state_.get_num_frames(), single_tree_frame_count() + 1);
   const GeometryId g_id = geometry_state_.RegisterGeometry(
       s_id2, frame_id,
-      make_unique<GeometryInstance>(Isometry3d::Identity(),
+      make_unique<GeometryInstance>(RigidTransformd::Identity(),
                                     unique_ptr<Shape>(new Sphere(1)), "new"));
   EXPECT_EQ(geometry_state_.get_num_geometries(),
             single_tree_total_geometry_count() + 1);
@@ -1459,11 +1466,11 @@ TEST_F(GeometryStateTest, RemoveGeometryInvalid) {
 TEST_F(GeometryStateTest, RemoveAnchoredGeometry) {
   const SourceId s_id = SetUpSingleSourceTree(Assign::kProximity);
 
-  const Vector3<double> normal{0, 1, 0};
-  const Vector3<double> point{1, 1, 1};
+  const Vector3<double> normal_W{0, 1, 0};
+  const Vector3<double> p_WB{1, 1, 1};
   const auto anchored_id_1 = geometry_state_.RegisterAnchoredGeometry(
       s_id,
-      make_unique<GeometryInstance>(HalfSpace::MakePose(normal, point),
+      make_unique<GeometryInstance>(HalfSpace::MakePoseInF(normal_W, p_WB),
                                     make_unique<HalfSpace>(), "anchored1"));
   geometry_state_.AssignRole(s_id, anchored_id_1, ProximityProperties());
   // Confirm conditions of having added the anchored geometry.
@@ -1554,7 +1561,7 @@ TEST_F(GeometryStateTest, SourceOwnershipInvalidSource) {
   SetUpSingleSourceTree();
   const GeometryId anchored_id = geometry_state_.RegisterAnchoredGeometry(
       source_id_,
-      make_unique<GeometryInstance>(Isometry3d::Identity(),
+      make_unique<GeometryInstance>(RigidTransformd::Identity(),
                                     make_unique<Sphere>(1),
                                     "sphere"));
   // Valid frame/geometry ids.
@@ -1587,7 +1594,7 @@ TEST_F(GeometryStateTest, SourceOwnershipFrameId) {
 TEST_F(GeometryStateTest, SourceOwnershipGeometryId) {
   const SourceId s_id = SetUpSingleSourceTree();
   const GeometryId anchored_id = geometry_state_.RegisterAnchoredGeometry(
-      s_id, make_unique<GeometryInstance>(Isometry3d::Identity(),
+      s_id, make_unique<GeometryInstance>(RigidTransformd::Identity(),
                                           make_unique<Sphere>(1),
                                           "sphere"));
   // Test for invalid geometry.
@@ -1612,7 +1619,7 @@ TEST_F(GeometryStateTest, ValidateFrameIds) {
   const SourceId s_id = SetUpSingleSourceTree();
   FramePoseVector<double> frame_set;
   for (auto frame_id : frames_) {
-    frame_set.set_value(frame_id, Isometry3d::Identity());
+    frame_set.set_value(frame_id, RigidTransformd::Identity());
   }
   // Case: frame ids are valid.
   EXPECT_NO_THROW(gs_tester_.ValidateFrameIds(s_id, frame_set));
@@ -1620,7 +1627,7 @@ TEST_F(GeometryStateTest, ValidateFrameIds) {
   // Case: Right number, wrong frames.
   FramePoseVector<double> frame_set_2;
   for (int i = 0; i < kFrameCount; ++i) {
-    frame_set_2.set_value(FrameId::get_new_id(), Isometry3d::Identity());
+    frame_set_2.set_value(FrameId::get_new_id(), RigidTransformd::Identity());
   }
   DRAKE_EXPECT_THROWS_MESSAGE(
       gs_tester_.ValidateFrameIds(s_id, frame_set_2), std::runtime_error,
@@ -1630,7 +1637,7 @@ TEST_F(GeometryStateTest, ValidateFrameIds) {
   // Case: Too few frames.
   FramePoseVector<double> frame_set_3;
   for (int i = 0; i < kFrameCount - 1; ++i) {
-    frame_set.set_value(frames_[i], Isometry3d::Identity());
+    frame_set.set_value(frames_[i], RigidTransformd::Identity());
   }
   DRAKE_EXPECT_THROWS_MESSAGE(
       gs_tester_.ValidateFrameIds(s_id, frame_set_3), std::runtime_error,
@@ -1648,9 +1655,9 @@ TEST_F(GeometryStateTest, ValidateFrameIds) {
 TEST_F(GeometryStateTest, SetFramePoses) {
   const SourceId s_id = SetUpSingleSourceTree();
   // A vector of poses we will use to populate FramePoseVectors.
-  vector<Isometry3d> frame_poses;
+  vector<RigidTransformd> frame_poses;
   for (int i = 0; i < kFrameCount; ++i) {
-    frame_poses.push_back(Isometry3d::Identity());
+    frame_poses.push_back(RigidTransformd::Identity());
   }
 
   auto make_pose_vector =
@@ -1674,23 +1681,22 @@ TEST_F(GeometryStateTest, SetFramePoses) {
   const auto& world_poses = gs_tester_.get_geometry_world_poses();
   for (int i = 0; i < total_geom; ++i) {
     const GeometryId id = geometries_[i];
-    EXPECT_TRUE(CompareMatrices(world_poses.at(id).matrix().block<3, 4>(0, 0),
-                                X_FGs_[i].matrix().block<3, 4>(0, 0)));
+    EXPECT_TRUE(CompareMatrices(world_poses.at(id).GetAsMatrix34(),
+                                X_FGs_[i].GetAsMatrix34()));
   }
 
   // Case 2: Move the two *root* frames 1 unit in the +y direction. The f2 will
   // stay at the identity.
   // The final geometry poses should all be offset by 1 unit in the y.
-  const Isometry3d offset{Translation3d{0, 1, 0}};
+  const RigidTransformd offset{Translation3d{0, 1, 0}};
   frame_poses[0] = offset;
   frame_poses[1] = offset;
   FramePoseVector<double> poses2 = make_pose_vector();
   gs_tester_.SetFramePoses(s_id, poses2);
   for (int i = 0; i < total_geom; ++i) {
     const GeometryId id = geometries_[i];
-    EXPECT_TRUE(
-        CompareMatrices(world_poses.at(id).matrix().block<3, 4>(0, 0),
-                        (offset * X_FGs_[i].matrix()).block<3, 4>(0, 0)));
+    EXPECT_TRUE(CompareMatrices(world_poses.at(id).GetAsMatrix34(),
+                                (offset * X_FGs_[i]).GetAsMatrix34()));
   }
 
   // Case 3: All frames get set to move up one unit. This will leave geometries
@@ -1701,13 +1707,12 @@ TEST_F(GeometryStateTest, SetFramePoses) {
   for (int i = 0; i < total_geom; ++i) {
     const GeometryId id = geometries_[i];
     if (i < (kFrameCount - 1) * kGeometryCount) {
-      EXPECT_TRUE(
-          CompareMatrices(world_poses.at(id).matrix().block<3, 4>(0, 0),
-                          (offset * X_FGs_[i].matrix()).block<3, 4>(0, 0)));
+      EXPECT_TRUE(CompareMatrices(world_poses.at(id).GetAsMatrix34(),
+                                  (offset * X_FGs_[i]).GetAsMatrix34()));
     } else {
-      EXPECT_TRUE(CompareMatrices(
-          world_poses.at(id).matrix().block<3, 4>(0, 0),
-          (offset * offset * X_FGs_[i].matrix()).block<3, 4>(0, 0)));
+      EXPECT_TRUE(
+          CompareMatrices(world_poses.at(id).GetAsMatrix34(),
+                          (offset * offset * X_FGs_[i]).GetAsMatrix34()));
     }
   }
 }
@@ -1737,35 +1742,35 @@ TEST_F(GeometryStateTest, QueryFrameProperties) {
   for (int i = 0; i < kFrameCount; ++i) poses.set_value(frames_[i], X_PFs_[i]);
   gs_tester_.SetFramePoses(s_id, poses);
 
+  EXPECT_TRUE(CompareMatrices(
+      geometry_state_.get_pose_in_world(frames_[0]).GetAsMatrix34(),
+      X_WFs_[0].GetAsMatrix34()));
   EXPECT_TRUE(
-      CompareMatrices(geometry_state_.get_pose_in_world(frames_[0]).matrix(),
-                      X_WFs_[0].matrix()));
-  EXPECT_TRUE(
-      CompareMatrices(geometry_state_.get_pose_in_world(world).matrix(),
-                      Isometry3d::Identity().matrix()));
+      CompareMatrices(geometry_state_.get_pose_in_world(world).GetAsMatrix34(),
+                      RigidTransformd::Identity().GetAsMatrix34()));
   DRAKE_EXPECT_THROWS_MESSAGE(
       geometry_state_.get_pose_in_world(FrameId::get_new_id()),
       std::logic_error, "No world pose available for invalid frame id: \\d+");
 
   // This assumes that geometry parent belongs to frame 0.
-  const Isometry3d X_WG = X_WFs_[0] * X_FGs_[0];
+  const RigidTransformd X_WG = X_WFs_[0] * X_FGs_[0];
   EXPECT_TRUE(CompareMatrices(
-      geometry_state_.get_pose_in_world(geometries_[0]).matrix(),
-      X_WG.matrix()));
+      geometry_state_.get_pose_in_world(geometries_[0]).GetAsMatrix34(),
+      X_WG.GetAsMatrix34()));
   DRAKE_EXPECT_THROWS_MESSAGE(
       geometry_state_.get_pose_in_world(GeometryId::get_new_id()),
       std::logic_error,
       "No world pose available for invalid geometry id: \\d+");
   EXPECT_TRUE(CompareMatrices(
-      geometry_state_.get_pose_in_world(anchored_geometry_).matrix(),
-      X_WA_.matrix()));
+      geometry_state_.get_pose_in_world(anchored_geometry_).GetAsMatrix34(),
+      X_WA_.GetAsMatrix34()));
 
+  EXPECT_TRUE(CompareMatrices(
+      geometry_state_.get_pose_in_parent(frames_[0]).GetAsMatrix34(),
+      X_PFs_[0].GetAsMatrix34()));
   EXPECT_TRUE(
-      CompareMatrices(geometry_state_.get_pose_in_parent(frames_[0]).matrix(),
-                      X_PFs_[0].matrix()));
-  EXPECT_TRUE(
-      CompareMatrices(geometry_state_.get_pose_in_parent(world).matrix(),
-                      Isometry3d::Identity().matrix()));
+      CompareMatrices(geometry_state_.get_pose_in_parent(world).GetAsMatrix34(),
+                      RigidTransformd::Identity().GetAsMatrix34()));
   DRAKE_EXPECT_THROWS_MESSAGE(
       geometry_state_.get_pose_in_parent(FrameId::get_new_id()),
       std::logic_error, "No pose available for invalid frame id: \\d+");
@@ -1981,7 +1986,7 @@ TEST_F(GeometryStateTest, NonProximityRoleInCollisionFilter) {
   // Documentation on the single source tree indicates that the previous spheres
   // are at (5, 0, 0) and (6, 0, 0), respectively. Split the distance to put the
   // new geometry in a penetrating configuration.
-  const Isometry3d pose{Translation3d{5.5, 0, 0}};
+  const RigidTransformd pose{Translation3d{5.5, 0, 0}};
   const string name("added_sphere");
   GeometryId added_id = geometry_state_.RegisterGeometry(
       source_id_, frames_[2],
@@ -2183,7 +2188,7 @@ TEST_F(GeometryStateTest, GetGeometryIdFromName) {
   for (int i = 0; i < 2; ++i) {
     geometry_state_.RegisterGeometry(
         source_id_, frames_[0],
-        make_unique<GeometryInstance>(Isometry3d::Identity(),
+        make_unique<GeometryInstance>(RigidTransformd::Identity(),
                                       make_unique<Sphere>(1), dummy_name));
   }
   DRAKE_EXPECT_THROWS_MESSAGE(
@@ -2206,7 +2211,7 @@ TEST_F(GeometryStateTest, GeometryNameStorage) {
     const GeometryId id = geometry_state_.RegisterGeometry(
         source_id_, frames_[0],
         make_unique<GeometryInstance>(
-            Isometry3d::Identity(), make_unique<Sphere>(1), " " + name));
+            RigidTransformd::Identity(), make_unique<Sphere>(1), " " + name));
     EXPECT_EQ(geometry_state_.GetName(id), name);
   }
 
@@ -2216,7 +2221,7 @@ TEST_F(GeometryStateTest, GeometryNameStorage) {
     const GeometryId id = geometry_state_.RegisterGeometry(
         source_id_, frames_[1],
         make_unique<GeometryInstance>(
-            Isometry3d::Identity(), make_unique<Sphere>(1), name));
+            RigidTransformd::Identity(), make_unique<Sphere>(1), name));
     EXPECT_EQ(geometry_state_.GetName(id), name);
   }
 }
@@ -2299,7 +2304,7 @@ TEST_F(GeometryStateTest, AssignRolesToGeometry) {
 
   // We need at least 8 geometries to run through all role permutations. Add
   // geometries until we're there.
-  const Isometry3d pose = Isometry3d::Identity();
+  const RigidTransformd pose = RigidTransformd::Identity();
   for (int i = 0; i < 8 - single_tree_dynamic_geometry_count(); ++i) {
     const string name = "new_geom" + std::to_string(i);
     geometries_.push_back(geometry_state_.RegisterGeometry(
@@ -2457,7 +2462,7 @@ TEST_F(GeometryStateTest, RoleLookUp) {
                         Assign::kPerception);
   GeometryId no_role_id = geometry_state_.RegisterGeometry(
       source_id_, frames_[0],
-      make_unique<GeometryInstance>(Isometry3d::Identity(),
+      make_unique<GeometryInstance>(RigidTransformd::Identity(),
                                     make_unique<Sphere>(0.5), "no_roles"));
   GeometryId invalid_id = GeometryId::get_new_id();
 
@@ -2688,9 +2693,9 @@ TEST_F(GeometryStateTest, RoleAssignExceptions) {
   // Addition of geometry with duplicate name -- no problem. Assigning it a
   // duplicate role -- bad.
   const GeometryId new_id = geometry_state_.RegisterGeometry(
-      source_id_, frames_[0],
-      make_unique<GeometryInstance>(
-          Isometry3d::Identity(), make_unique<Sphere>(1), geometry_names_[0]));
+      source_id_, frames_[0], make_unique<GeometryInstance>(
+                                  RigidTransformd::Identity(),
+                                  make_unique<Sphere>(1), geometry_names_[0]));
   DRAKE_EXPECT_THROWS_MESSAGE(
       geometry_state_.AssignRole(source_id_, new_id, ProximityProperties()),
       std::logic_error,
@@ -2814,7 +2819,7 @@ TEST_F(GeometryStateTest, ProximityRoleOnMesh) {
   // Add a mesh to a frame.
   const GeometryId mesh_id = geometry_state_.RegisterGeometry(
       source_id_, frames_[0],
-      make_unique<GeometryInstance>(Isometry3d::Identity(),
+      make_unique<GeometryInstance>(RigidTransformd::Identity(),
                                     make_unique<Mesh>("path", 1.0), "mesh"));
   const InternalGeometry* mesh = gs_tester_.GetGeometry(mesh_id);
   ASSERT_NE(mesh, nullptr);
@@ -3030,7 +3035,7 @@ TEST_F(GeometryStateTest, AddRendererAfterGeometry) {
   // Add one geometry that has no perception properties.
   const GeometryId id_no_perception = geometry_state_.RegisterGeometry(
       source_id_, frames_[0],
-      make_unique<GeometryInstance>(Isometry3d::Identity(),
+      make_unique<GeometryInstance>(RigidTransformd::Identity(),
                                     make_unique<Sphere>(0.5), "shape"));
   EXPECT_EQ(render_engine_->num_registered(),
             single_tree_total_geometry_count());
@@ -3113,13 +3118,14 @@ TEST_F(GeometryStateTest, RendererPoseUpdate) {
       const GeometryId expected_id = expected_id_pose_pair.first;
       const auto& test_iter = test.find(expected_id);
       EXPECT_NE(test_iter, test.end());
-      EXPECT_TRUE(CompareMatrices(test_iter->second.matrix(),
-                                  expected_id_pose_pair.second.matrix()));
+      EXPECT_TRUE(
+          CompareMatrices(test_iter->second.GetAsMatrix34(),
+                          expected_id_pose_pair.second.GetAsMatrix34()));
     }
   };
 
   auto get_expected_ids = [this]() {
-    map<GeometryId, Isometry3d> expected;
+    map<GeometryId, RigidTransformd> expected;
     for (int i = 0; i < single_tree_dynamic_geometry_count(); ++i) {
       const GeometryId id = geometries_[i];
       expected.insert({id, gs_tester_.get_geometry_world_poses().at(id)});
@@ -3127,7 +3133,7 @@ TEST_F(GeometryStateTest, RendererPoseUpdate) {
     return expected;
   };
 
-  map<GeometryId, Isometry3d> expected_ids = get_expected_ids();
+  map<GeometryId, RigidTransformd> expected_ids = get_expected_ids();
   expect_poses(second_engine->updated_ids(), expected_ids);
   expect_poses(render_engine_->updated_ids(), expected_ids);
   render_engine_->init_test_data();
@@ -3137,8 +3143,8 @@ TEST_F(GeometryStateTest, RendererPoseUpdate) {
   // values.
   const Vector3d offset{1, 2, 3};
   for (int f = 0; f < static_cast<int>(frames_.size()); ++f) {
-    Isometry3d X_PF = X_PFs_[f];
-    X_PF.translation() += offset;
+    RigidTransformd X_PF = X_PFs_[f];
+    X_PF.set_translation(X_PF.translation() + offset);
     poses.set_value(frames_[f], X_PF);
   }
   EXPECT_EQ(second_engine->updated_ids().size(), 0u);

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -1470,7 +1470,7 @@ TEST_F(GeometryStateTest, RemoveAnchoredGeometry) {
   const Vector3<double> p_WB{1, 1, 1};
   const auto anchored_id_1 = geometry_state_.RegisterAnchoredGeometry(
       s_id,
-      make_unique<GeometryInstance>(HalfSpace::MakePoseInF(normal_W, p_WB),
+      make_unique<GeometryInstance>(HalfSpace::MakePose(normal_W, p_WB),
                                     make_unique<HalfSpace>(), "anchored1"));
   geometry_state_.AssignRole(s_id, anchored_id_1, ProximityProperties());
   // Confirm conditions of having added the anchored geometry.

--- a/geometry/test/geometry_visualization_test.cc
+++ b/geometry/test/geometry_visualization_test.cc
@@ -18,8 +18,8 @@ namespace {
 
 using drake::geometry::internal::GeometryVisualizationImpl;
 using drake::systems::Context;
-using Eigen::Isometry3d;
 using Eigen::Vector4d;
+using math::RigidTransformd;
 using std::make_unique;
 using std::unique_ptr;
 
@@ -44,7 +44,7 @@ GTEST_TEST(GeometryVisualization, SimpleScene) {
   const float a = 0.125f;
   GeometryId sphere_id = scene_graph.RegisterGeometry(
       source_id, frame_id,
-      make_unique<GeometryInstance>(Isometry3d::Identity(),
+      make_unique<GeometryInstance>(RigidTransformd::Identity(),
                                     make_unique<Sphere>(radius), "sphere"));
   Vector4<double> color{r, g, b, a};
   scene_graph.AssignRole(source_id, sphere_id,
@@ -57,7 +57,7 @@ GTEST_TEST(GeometryVisualization, SimpleScene) {
       scene_graph.RegisterFrame(source_id, GeometryFrame(collision_frame_name));
   GeometryId collision_id = scene_graph.RegisterGeometry(
       source_id, collision_frame_id,
-      make_unique<GeometryInstance>(Isometry3d::Identity(),
+      make_unique<GeometryInstance>(RigidTransformd::Identity(),
       make_unique<Sphere>(radius), "sphere_collision"));
   scene_graph.AssignRole(source_id, collision_id, ProximityProperties());
 

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -67,10 +67,9 @@ using math::RollPitchYawd;
 using math::RotationMatrixd;
 
 using Eigen::AngleAxisd;
-using Eigen::Isometry3d;
 using Eigen::Translation3d;
-using Eigen::Vector3d;
 using Eigen::Vector2d;
+using Eigen::Vector3d;
 
 using std::make_shared;
 using std::move;
@@ -94,7 +93,7 @@ GTEST_TEST(ProximityEngineTests, AddDynamicGeometry) {
 GTEST_TEST(ProximityEngineTests, AddAnchoredGeometry) {
   ProximityEngine<double> engine;
   Sphere sphere{0.5};
-  Isometry3<double> pose = Isometry3<double>::Identity();
+  RigidTransformd pose = RigidTransformd::Identity();
   const GeometryId id = GeometryId::get_new_id();
   engine.AddAnchoredGeometry(sphere, pose, id);
   EXPECT_EQ(engine.num_geometries(), 1);
@@ -106,7 +105,7 @@ GTEST_TEST(ProximityEngineTests, AddAnchoredGeometry) {
 GTEST_TEST(ProximityEngineTests, AddMixedGeometry) {
   ProximityEngine<double> engine;
   Sphere sphere{0.5};
-  Isometry3<double> pose = Isometry3<double>::Identity();
+  RigidTransformd pose = RigidTransformd::Identity();
   const GeometryId id_1 = GeometryId::get_new_id();
   engine.AddAnchoredGeometry(sphere, pose, id_1);
 
@@ -133,11 +132,11 @@ GTEST_TEST(ProximityEngineTests, RemoveGeometry) {
     // x = 0, 2, & 4. With radius of 0.5, they should *not* be colliding.
     Sphere sphere{0.5};
     std::vector<GeometryId> ids;
-    std::unordered_map<GeometryId, Isometry3d> poses;
+    std::unordered_map<GeometryId, RigidTransformd> poses;
     for (int i = 0; i < 3; ++i) {
       const GeometryId id = GeometryId::get_new_id();
       ids.push_back(id);
-      poses.insert({id, Isometry3d{Translation3d{i * 2.0, 0, 0}}});
+      poses.insert({id, RigidTransformd{Translation3d{i * 2.0, 0, 0}}});
       if (is_dynamic) {
         engine.AddDynamicGeometry(sphere, id);
       } else {
@@ -186,7 +185,7 @@ GTEST_TEST(ProximityEngineTests, ExceptionTwoObjectsInObjFileForConvex) {
 GTEST_TEST(ProximityEngineTests, CopySemantics) {
   ProximityEngine<double> ref_engine;
   Sphere sphere{0.5};
-  Isometry3<double> pose = Isometry3d::Identity();
+  RigidTransformd pose = RigidTransformd::Identity();
 
   // NOTE: The GeometryId values are all lies; the values are arbitrary but
   // do not matter in the context of this test.
@@ -220,7 +219,7 @@ GTEST_TEST(ProximityEngineTests, CopySemantics) {
 GTEST_TEST(ProximityEngineTests, MoveSemantics) {
   ProximityEngine<double> engine;
   Sphere sphere{0.5};
-  Isometry3<double> pose = Isometry3d::Identity();
+  RigidTransformd pose = RigidTransformd::Identity();
   engine.AddAnchoredGeometry(sphere, pose, GeometryId::get_new_id());
   engine.AddDynamicGeometry(sphere, GeometryId::get_new_id());
 
@@ -248,7 +247,7 @@ GTEST_TEST(ProximityEngineTests, MoveSemantics) {
 // A scene with no geometry reports no witness pairs.
 GTEST_TEST(ProximityEngineTests, SignedDistanceClosestPointsOnEmptyScene) {
   ProximityEngine<double> engine;
-  const unordered_map<GeometryId, Isometry3d> X_WGs;
+  const unordered_map<GeometryId, RigidTransformd> X_WGs;
 
   const auto results =
       engine.ComputeSignedDistancePairwiseClosestPoints(X_WGs, kInf);
@@ -261,8 +260,8 @@ GTEST_TEST(ProximityEngineTests, SignedDistanceClosestPointsSingleAnchored) {
 
   Sphere sphere{0.5};
   const GeometryId id = GeometryId::get_new_id();
-  const unordered_map<GeometryId, Isometry3d> X_WGs{
-      {id, Isometry3d::Identity()}};
+  const unordered_map<GeometryId, RigidTransformd> X_WGs{
+      {id, RigidTransformd::Identity()}};
   engine.AddAnchoredGeometry(sphere, X_WGs.at(id), id);
 
   const auto results =
@@ -273,16 +272,16 @@ GTEST_TEST(ProximityEngineTests, SignedDistanceClosestPointsSingleAnchored) {
 // Tests that anchored geometry don't report closest distance with each other.
 GTEST_TEST(ProximityEngineTests, SignedDistanceClosestPointsMultipleAnchored) {
   ProximityEngine<double> engine;
-  unordered_map<GeometryId, Isometry3d> X_WGs;
+  unordered_map<GeometryId, RigidTransformd> X_WGs;
 
   const double radius = 0.5;
   Sphere sphere{radius};
   const GeometryId id_A = GeometryId::get_new_id();
-  X_WGs[id_A] = Isometry3d::Identity();
+  X_WGs[id_A] = RigidTransformd::Identity();
   engine.AddAnchoredGeometry(sphere, X_WGs.at(id_A), id_A);
 
   const GeometryId id_B = GeometryId::get_new_id();
-  X_WGs[id_B] = Isometry3d{Translation3d{1.8 * radius, 0, 0}};
+  X_WGs[id_B] = RigidTransformd{Translation3d{1.8 * radius, 0, 0}};
   engine.AddAnchoredGeometry(sphere, X_WGs.at(id_B), id_B);
 
   const auto results =
@@ -297,8 +296,8 @@ GTEST_TEST(ProximityEngineTests, SignedDistanceClosestPointsMaxDistance) {
   ProximityEngine<double> engine;
   const GeometryId id_A = GeometryId::get_new_id();
   const GeometryId id_B = GeometryId::get_new_id();
-  unordered_map<GeometryId, Isometry3d> X_WGs{{id_A, Isometry3d::Identity()},
-                                              {id_B, Isometry3d::Identity()}};
+  unordered_map<GeometryId, RigidTransformd> X_WGs{
+      {id_A, RigidTransformd::Identity()}, {id_B, RigidTransformd::Identity()}};
 
   const double radius = 0.5;
   Sphere sphere{radius};
@@ -313,7 +312,7 @@ GTEST_TEST(ProximityEngineTests, SignedDistanceClosestPointsMaxDistance) {
   {
     const Vector3d p_WB =
         Vector3d(2, 3, 4).normalized() * (kCenterDistance - kEps);
-    X_WGs[id_B].translation() = p_WB;
+    X_WGs[id_B].set_translation(p_WB);
     engine.UpdateWorldPoses(X_WGs);
     const auto results =
         engine.ComputeSignedDistancePairwiseClosestPoints(X_WGs, kMaxDistance);
@@ -324,7 +323,7 @@ GTEST_TEST(ProximityEngineTests, SignedDistanceClosestPointsMaxDistance) {
   {
     const Vector3d p_WB =
         Vector3d(2, 3, 4).normalized() * (kCenterDistance + kEps);
-    X_WGs[id_B].translation() = p_WB;
+    X_WGs[id_B].set_translation(p_WB);
     engine.UpdateWorldPoses(X_WGs);
     const auto results =
         engine.ComputeSignedDistancePairwiseClosestPoints(X_WGs, kMaxDistance);
@@ -348,9 +347,11 @@ GTEST_TEST(ProximityEngineTests, SignedDistanceToPointNonPositiveThreshold) {
 
   const GeometryId id_A = GeometryId::get_new_id();
   const GeometryId id_B = GeometryId::get_new_id();
-  const unordered_map<GeometryId, Isometry3d> X_WGs{
-      {id_A, Isometry3d{Translation3d{-kRadius + 0.5 * kPenetration, 0, 0}}},
-      {id_B, Isometry3d{Translation3d{kRadius - 0.5 * kPenetration, 0, 0}}}};
+  const unordered_map<GeometryId, RigidTransformd> X_WGs{
+      {id_A,
+       RigidTransformd{Translation3d{-kRadius + 0.5 * kPenetration, 0, 0}}},
+      {id_B,
+       RigidTransformd{Translation3d{kRadius - 0.5 * kPenetration, 0, 0}}}};
 
   Sphere sphere{kRadius};
   engine.AddDynamicGeometry(sphere, id_A);
@@ -397,12 +398,12 @@ GTEST_TEST(ProximityEngineTests, SignedDistanceToPointNonPositiveThreshold) {
 //
 GTEST_TEST(SignedDistanceToPointBroadphaseTest, MultipleThreshold) {
   ProximityEngine<double> engine;
-  unordered_map<GeometryId, Isometry3d> X_WGs;
+  unordered_map<GeometryId, RigidTransformd> X_WGs;
   const double radius = 0.1;
   const Vector3d center1(1., 1., 1.);
   const Vector3d center2(-1, -1, -1.);
   for (const Vector3d& p_WG : {center1, center2}) {
-    const Isometry3d X_WG(Translation3d{p_WG});
+    const RigidTransformd X_WG(Translation3d{p_WG});
     const GeometryId id = GeometryId::get_new_id();
     X_WGs[id] = X_WG;
     engine.AddAnchoredGeometry(Sphere(radius), X_WG, id);
@@ -1080,7 +1081,7 @@ std::vector<SignedDistanceToPointTestData> GenDistTestDataHalfSpace() {
   const bool well_defined_grad = true;
 
   for (const auto& X_WG : {RigidTransformd(), X_WG1}) {
-    const auto& R_WG = X_WG.linear();
+    const auto& R_WG = X_WG.rotation();
     const Vector3d grad_W = R_WG.col(2);
     const Vector3d p_GN(1.25, 1.5, 0);
     const Vector3d p_WN = X_WG * p_GN;
@@ -1113,7 +1114,7 @@ std::vector<SignedDistanceToPointTestData> GenDistTestDataHalfSpace() {
 struct SignedDistanceToPointTest
     : public testing::TestWithParam<SignedDistanceToPointTestData> {
   ProximityEngine<double> engine;
-  unordered_map<GeometryId, Isometry3d> X_WGs;
+  unordered_map<GeometryId, RigidTransformd> X_WGs;
 
   // The tolerance value for determining equivalency between expected and
   // tested results. The underlying algorithms have an empirically-determined,
@@ -1124,8 +1125,8 @@ struct SignedDistanceToPointTest
   SignedDistanceToPointTest() {
     const auto& data = GetParam();
     const GeometryId id = data.expected_result.id_G;
-    engine.AddAnchoredGeometry(*data.geometry, data.X_WG.GetAsIsometry3(), id);
-    X_WGs[id] = data.X_WG.GetAsIsometry3();
+    engine.AddAnchoredGeometry(*data.geometry, data.X_WG, id);
+    X_WGs[id] = data.X_WG;
   }
 };
 
@@ -1234,7 +1235,7 @@ GTEST_TEST(ProximityEngineTests, PenetrationSingleAnchored) {
   ProximityEngine<double> engine;
 
   Sphere sphere{0.5};
-  Isometry3<double> pose = Isometry3<double>::Identity();
+  RigidTransformd pose = RigidTransformd::Identity();
   const GeometryId id = GeometryId::get_new_id();
   engine.AddAnchoredGeometry(sphere, pose, id);
   auto results = engine.ComputePointPairPenetration();
@@ -1248,9 +1249,9 @@ GTEST_TEST(ProximityEngineTests, PenetrationMultipleAnchored) {
 
   const double radius = 0.5;
   Sphere sphere{radius};
-  Isometry3<double> pose = Isometry3<double>::Identity();
+  RigidTransformd pose = RigidTransformd::Identity();
   engine.AddAnchoredGeometry(sphere, pose, GeometryId::get_new_id());
-  pose.translation() << 1.8 * radius, 0, 0;
+  pose.set_translation({1.8 * radius, 0, 0});
   engine.AddAnchoredGeometry(sphere, pose, GeometryId::get_new_id());
   auto results = engine.ComputePointPairPenetration();
   EXPECT_EQ(results.size(), 0);
@@ -1308,21 +1309,19 @@ class SimplePenetrationTest : public ::testing::Test {
     DRAKE_DEMAND(engine->num_geometries() == static_cast<int>(X_WGs_.size()));
 
     const double x_pos = is_colliding ? colliding_x_ : free_x_;
-    X_WGs_[id] = Isometry3<double>(Translation3d{x_pos, 0, 0});
+    X_WGs_[id].set_translation({x_pos, 0, 0});
 
     engine->UpdateWorldPoses(X_WGs_);
   }
 
   // Poses have been defined as doubles; get them in the required scalar type.
   template <typename T>
-  unordered_map<GeometryId, Isometry3<T>> GetTypedPoses() const {
-    unordered_map<GeometryId, Isometry3<T>> typed_X_WG;
+  unordered_map<GeometryId, RigidTransform<T>> GetTypedPoses() const {
+    unordered_map<GeometryId, RigidTransform<T>> typed_X_WG;
     for (const auto& id_pose_pair : X_WGs_) {
       const GeometryId id = id_pose_pair.first;
-      const Isometry3d& X_WG = id_pose_pair.second;
-      Isometry3<T> X_WG_t;
-      X_WG_t.matrix() = X_WG.matrix();
-      typed_X_WG[id] = X_WG_t;
+      const RigidTransformd& X_WG = id_pose_pair.second;
+      typed_X_WG[id] = X_WG.cast<T>();
     }
     return typed_X_WG;
   }
@@ -1454,7 +1453,7 @@ class SimplePenetrationTest : public ::testing::Test {
   }
 
   ProximityEngine<double> engine_;
-  unordered_map<GeometryId, Isometry3d> X_WGs_;
+  unordered_map<GeometryId, RigidTransformd> X_WGs_;
   const double radius_{0.5};
   const Sphere sphere_{radius_};
   const double free_x_{2.5 * radius_};
@@ -1465,7 +1464,7 @@ class SimplePenetrationTest : public ::testing::Test {
 // case *not* colliding.
 TEST_F(SimplePenetrationTest, PenetrationDynamicAndAnchored) {
   // Set up anchored geometry
-  Isometry3<double> pose = Isometry3<double>::Identity();
+  RigidTransformd pose = RigidTransformd::Identity();
   const GeometryId anchored_id = GeometryId::get_new_id();
   engine_.AddAnchoredGeometry(sphere_, pose, anchored_id);
 
@@ -1475,7 +1474,7 @@ TEST_F(SimplePenetrationTest, PenetrationDynamicAndAnchored) {
   EXPECT_EQ(engine_.num_geometries(), 2);
 
   X_WGs_[anchored_id] = pose;
-  X_WGs_[dynamic_id] = Isometry3d::Identity();
+  X_WGs_[dynamic_id] = RigidTransformd::Identity();
 
   // Non-colliding case
   MoveDynamicSphere(dynamic_id, false /* not colliding */);
@@ -1505,8 +1504,8 @@ TEST_F(SimplePenetrationTest, PenetrationDynamicAndDynamicSingleSource) {
   engine_.AddDynamicGeometry(sphere_, collide_id);
   EXPECT_EQ(engine_.num_geometries(), 2);
 
-  X_WGs_[origin_id] = Isometry3d::Identity();
-  X_WGs_[collide_id] = Isometry3d::Identity();
+  X_WGs_[origin_id] = RigidTransformd::Identity();
+  X_WGs_[collide_id] = RigidTransformd::Identity();
 
   // Non-colliding case
   MoveDynamicSphere(collide_id, false /* not colliding */);
@@ -1535,7 +1534,7 @@ TEST_F(SimplePenetrationTest, ExcludeCollisionsWithinCliqueGeneration) {
   const GeometryId id_dynamic2 = GeometryId::get_new_id();
   engine_.AddDynamicGeometry(sphere_, id_dynamic2);
 
-  Isometry3<double> pose{Isometry3<double>::Identity()};
+  RigidTransformd pose = RigidTransformd::Identity();
   const GeometryId id_anchored1 = GeometryId::get_new_id();
   engine_.AddAnchoredGeometry(sphere_, pose, id_anchored1);
   const GeometryId id_anchored2 = GeometryId::get_new_id();
@@ -1592,8 +1591,8 @@ TEST_F(SimplePenetrationTest, ExcludeCollisionsWithin) {
   engine_.AddDynamicGeometry(sphere_, collide_id);
   EXPECT_EQ(engine_.num_geometries(), 2);
 
-  X_WGs_[origin_id] = Isometry3d::Identity();
-  X_WGs_[collide_id] = Isometry3d::Identity();
+  X_WGs_[origin_id] = RigidTransformd::Identity();
+  X_WGs_[collide_id] = RigidTransformd::Identity();
 
   EXPECT_FALSE(engine_.CollisionFiltered(origin_id, true, collide_id, true));
   engine_.ExcludeCollisionsWithin({origin_id, collide_id}, {});
@@ -1628,7 +1627,7 @@ TEST_F(SimplePenetrationTest, ExcludeCollisionsBetweenCliqueGeneration) {
   GeometryId dynamic3 = GeometryId::get_new_id();
   engine_.AddDynamicGeometry(sphere_, dynamic3);
 
-  Isometry3<double> pose{Isometry3<double>::Identity()};
+  RigidTransformd pose = RigidTransformd::Identity();
   GeometryId anchored1 = GeometryId::get_new_id();
   engine_.AddAnchoredGeometry(sphere_, pose, anchored1);
   GeometryId anchored2 = GeometryId::get_new_id();
@@ -1692,8 +1691,8 @@ TEST_F(SimplePenetrationTest, ExcludeCollisionsBetween) {
   EXPECT_TRUE(engine_.CollisionFiltered(origin_id, true,
                                         collide_id, true));
 
-  X_WGs_[origin_id] = Isometry3d::Identity();
-  X_WGs_[collide_id] = Isometry3d::Identity();
+  X_WGs_[origin_id] = RigidTransformd::Identity();
+  X_WGs_[collide_id] = RigidTransformd::Identity();
 
   // Non-colliding case
   MoveDynamicSphere(collide_id, false /* not colliding */);
@@ -1724,10 +1723,10 @@ GTEST_TEST(ProximityEngineTests, PairwiseSignedDistanceNonPositiveThreshold) {
   const GeometryId id2 = GeometryId::get_new_id();
   const GeometryId id3 = GeometryId::get_new_id();
   const double kRadius = 0.5;
-  const unordered_map<GeometryId, Isometry3d> X_WGs{
-      {id1, Isometry3d{Translation3d{0, 2 * kRadius, 0}}},
-      {id2, Isometry3d{Translation3d{-kRadius * 0.9, 0, 0}}},
-      {id3, Isometry3d{Translation3d{kRadius * 0.9, 0, 0}}}};
+  const unordered_map<GeometryId, RigidTransformd> X_WGs{
+      {id1, RigidTransformd{Translation3d{0, 2 * kRadius, 0}}},
+      {id2, RigidTransformd{Translation3d{-kRadius * 0.9, 0, 0}}},
+      {id3, RigidTransformd{Translation3d{kRadius * 0.9, 0, 0}}}};
 
   Sphere sphere{kRadius};
   engine.AddDynamicGeometry(sphere, id1);
@@ -2348,7 +2347,7 @@ GenDistPairTestHalfspaceSphere() {
   const RotationMatrixd R_WS;
 
   for (const auto& X_WH : {RigidTransformd(), X_WG1}) {
-    const auto& R_WH = X_WH.linear();
+    const auto& R_WH = X_WH.rotation();
     // Half space's outward normal is in the direction of the z-axis of the
     // half space's canonical frame H.
     const Vector3d nhat_HS_W = R_WH.col(2);
@@ -2403,19 +2402,19 @@ class SignedDistancePairTest
  public:
   SignedDistancePairTest() {
     const auto& data = GetParam();
-    engine_.AddAnchoredGeometry(*data.a_, data.X_WA_.GetAsIsometry3(),
+    engine_.AddAnchoredGeometry(*data.a_, data.X_WA_,
                                 data.expected_result_.id_A);
 
     engine_.AddDynamicGeometry(*(data.b_), data.expected_result_.id_B);
 
-    X_WGs_[data.expected_result_.id_A] = data.X_WA_.GetAsIsometry3();
-    X_WGs_[data.expected_result_.id_B] = data.X_WB_.GetAsIsometry3();
+    X_WGs_[data.expected_result_.id_A] = data.X_WA_;
+    X_WGs_[data.expected_result_.id_B] = data.X_WB_;
     engine_.UpdateWorldPoses(X_WGs_);
   }
 
  protected:
   ProximityEngine<double> engine_;
-  unordered_map<GeometryId, Isometry3d> X_WGs_;
+  unordered_map<GeometryId, RigidTransformd> X_WGs_;
 
  public:
   // The tolerance value for determining equivalency between expected and
@@ -2512,14 +2511,14 @@ GTEST_TEST(SignedDistancePairError, HalfspaceException) {
   ProximityEngine<double> engine;
   // NOTE: It's not necessary to put any poses into X_WGs; they never get
   // evaluated due to the error condition.
-  unordered_map<GeometryId, Isometry3d> X_WGs;
+  unordered_map<GeometryId, RigidTransformd> X_WGs;
 
   // We can't use sphere, because sphere-halfspace is supported.
   Box box{0.5, 0.25, 0.75};
   engine.AddDynamicGeometry(box, GeometryId::get_new_id());
 
   HalfSpace halfspace;
-  engine.AddAnchoredGeometry(halfspace, Isometry3d::Identity(),
+  engine.AddAnchoredGeometry(halfspace, RigidTransformd::Identity(),
                              GeometryId::get_new_id());
 
   DRAKE_EXPECT_THROWS_MESSAGE(
@@ -2773,8 +2772,9 @@ GTEST_TEST(ProximityEngineCollisionTest, SpherePunchThroughBox) {
   const GeometryId sphere_id = GeometryId::get_new_id();
   engine.AddDynamicGeometry(Sphere{radius}, sphere_id);
 
-  unordered_map<GeometryId, Isometry3d> poses{
-      {box_id, Isometry3d::Identity()}, {sphere_id, Isometry3d::Identity()}};
+  unordered_map<GeometryId, RigidTransformd> poses{
+      {box_id, RigidTransformd::Identity()},
+      {sphere_id, RigidTransformd::Identity()}};
   // clang-format off
   std::vector<SpherePunchData> test_data{
       // In non-penetration, contact_normal and depth values don't matter; they
@@ -2791,7 +2791,7 @@ GTEST_TEST(ProximityEngineCollisionTest, SpherePunchThroughBox) {
        {-eps, 0, 0}, 1, {1, 0, 0}, radius + half_w - eps}};
   // clang-format on
   for (const auto& test : test_data) {
-    poses[sphere_id].translation() = test.sphere_pose;
+    poses[sphere_id].set_translation(test.sphere_pose);
     engine.UpdateWorldPoses(poses);
     std::vector<PenetrationAsPointPair<double>> results =
         engine.ComputePointPairPenetration();
@@ -2947,8 +2947,8 @@ class BoxPenetrationTest : public ::testing::Test {
     ASSERT_EQ(engine_.num_dynamic(), 2);
 
     // Update the poses of the geometry.
-    unordered_map<GeometryId, Isometry3d> poses{
-        {tangent_id, shape_pose(shape_type)}, {box_id, X_WB.GetAsIsometry3()}};
+    unordered_map<GeometryId, RigidTransformd> poses{
+        {tangent_id, shape_pose(shape_type)}, {box_id, X_WB}};
     engine_.UpdateWorldPoses(poses);
     std::vector<PenetrationAsPointPair<double>> results =
         engine_.ComputePointPairPenetration();
@@ -3064,24 +3064,24 @@ class BoxPenetrationTest : public ::testing::Test {
   }
 
   // Map enumeration to tangent pose.
-  Isometry3d shape_pose(TangentShape shape) {
-    Isometry3d pose = Isometry3d::Identity();
+  RigidTransformd shape_pose(TangentShape shape) {
+    RigidTransformd pose = RigidTransformd::Identity();
     switch (shape) {
       case TangentPlane:
         break;  // leave it at the identity
       case TangentSphere:
-        pose.translation() = Vector3d{0, 0, -kRadius};
+        pose.set_translation({0, 0, -kRadius});
         break;
       case TangentBox:
       // The tangent convex is a cube of the same size as the tangent box.
       // That is why we give them the same pose.
       case TangentConvex:
       case TangentStandingCylinder:
-        pose.translation() = Vector3d{0, 0, -kLength / 2};
+        pose.set_translation({0, 0, -kLength / 2});
         break;
       case TangentProneCylinder:
-        pose = AngleAxisd{M_PI_2, Vector3d::UnitX()};
-        pose.translation() = Vector3d{0, 0, -kRadius};
+        pose = RigidTransformd(AngleAxisd{M_PI_2, Vector3d::UnitX()},
+                               Vector3d{0, 0, -kRadius});
         break;
     }
     return pose;
@@ -3188,7 +3188,7 @@ GTEST_TEST(ProximityEngineTests, AddAnchoredMesh) {
   ProximityEngine<double> engine;
   Mesh mesh{"invalid/path/thing.obj", 1.0};
   DRAKE_EXPECT_THROWS_MESSAGE(
-      engine.AddAnchoredGeometry(mesh, Isometry3d::Identity(),
+      engine.AddAnchoredGeometry(mesh, RigidTransformd::Identity(),
                                  GeometryId::get_new_id()),
       std::exception,
       ".*The proximity engine does not support meshes yet.*");
@@ -3219,22 +3219,13 @@ GTEST_TEST(ProximityEngineTests, Issue10577Regression_Osculation) {
   engine.AddDynamicGeometry(Box(0.49, 0.63, 0.015), id_A);
   engine.AddDynamicGeometry(Cylinder(0.08, 0.002), id_B);
 
-  Isometry3<double> X_WA;
   // Original translation was p_WA = (-0.145, -0.63, 0.2425) and
   // p_WB = (0, -0.6, 0.251), respectively.
-  // clang-format off
-  X_WA.matrix() << 0, -1, 0, -0.25,
-                   1,  0, 0,     0,
-                   0,  0, 1,     0,
-                   0,  0, 0,     1;
-  Isometry3<double> X_WB;
-  X_WB.matrix() << 1, 0, 0,      0,
-                   0, 1, 0,      0,
-                   0, 0, 1, 0.0085,
-                   0, 0, 0,      1;
-  // clang-format on
-  const unordered_map<GeometryId, Isometry3<double>> X_WG{{id_A, X_WA},
-                                                          {id_B, X_WB}};
+  RigidTransformd X_WA(Eigen::AngleAxisd{M_PI_2, Vector3d::UnitZ()},
+                       Vector3d{-0.25, 0, 0});
+  RigidTransformd X_WB(Vector3d{0, 0, 0.0085});
+  const unordered_map<GeometryId, RigidTransformd> X_WG{{id_A, X_WA},
+                                                        {id_B, X_WB}};
   engine.UpdateWorldPoses(X_WG);
   std::vector<GeometryId> geometry_map{id_A, id_B};
   auto pairs = engine.ComputePointPairPenetration();
@@ -3253,10 +3244,10 @@ GTEST_TEST(ProximityEngineTests, AnchoredBroadPhaseInitialization) {
   GeometryId id_A = GeometryId::get_new_id();
   engine.AddDynamicGeometry(Sphere(0.5), id_D);
 
-  Isometry3d X_WA{Translation3d{-3, 0, 0}};
+  RigidTransformd X_WA{Translation3d{-3, 0, 0}};
   engine.AddAnchoredGeometry(Sphere(0.5), X_WA, id_A);
 
-  Isometry3d X_WD{Translation3d{-3, 0.75, 0}};
+  RigidTransformd X_WD{Translation3d{-3, 0.75, 0}};
   // NOTE: We only update the dynamic geometries, so we simply provide a map
   // containing the ids of the dynamic geometries with their pose as a cheat.
   engine.UpdateWorldPoses({{id_D, X_WD}});
@@ -3289,7 +3280,7 @@ GTEST_TEST(ProximityEngineTests, ComputePointSignedDistanceAutoDiffAnchored) {
 
   // An empty world inherently produces no results.
   {
-    const unordered_map<GeometryId, Isometry3<AutoDiffXd>> X_WGs;
+    const unordered_map<GeometryId, RigidTransform<AutoDiffXd>> X_WGs;
     const auto results = engine.ComputeSignedDistanceToPoint(p_WQ_ad, X_WGs);
     EXPECT_EQ(results.size(), 0);
   }
@@ -3300,7 +3291,7 @@ GTEST_TEST(ProximityEngineTests, ComputePointSignedDistanceAutoDiffAnchored) {
     const GeometryId anchored_id = GeometryId::get_new_id();
     engine.AddAnchoredGeometry(Sphere(0.7), X_WS, anchored_id);
     const RigidTransform<AutoDiffXd> X_WS_ad = X_WS.cast<AutoDiffXd>();
-    const unordered_map<GeometryId, Isometry3<AutoDiffXd>> X_WGs{
+    const unordered_map<GeometryId, RigidTransform<AutoDiffXd>> X_WGs{
         {anchored_id, X_WS_ad}};
 
     // Distance is just beyond the threshold.
@@ -3350,9 +3341,9 @@ GTEST_TEST(ProximityEngineTests, ComputePointSignedDistanceAutoDiffDynamic) {
   // Against a dynamic sphere.
   const GeometryId id = GeometryId::get_new_id();
   engine.AddDynamicGeometry(Sphere(0.7), id);
-  const auto X_WS_ad =
-      RigidTransformd(p_WS).cast<AutoDiffXd>().GetAsIsometry3();
-  const unordered_map<GeometryId, Isometry3<AutoDiffXd>> X_WGs{{id, X_WS_ad}};
+  const auto X_WS_ad = RigidTransformd(p_WS).cast<AutoDiffXd>();
+  const unordered_map<GeometryId, RigidTransform<AutoDiffXd>> X_WGs{
+      {id, X_WS_ad}};
   engine.UpdateWorldPoses(X_WGs);
 
   // Distance is just beyond the threshold.
@@ -3405,10 +3396,10 @@ GTEST_TEST(ProximityEngineTests, ComputePairwiseSignedDistanceAutoDiff) {
   const GeometryId id2 = GeometryId::get_new_id();
   engine.AddDynamicGeometry(Sphere(radius), id2);
   const auto X_WS2_ad =
-      RigidTransformd(p_WS).cast<AutoDiffXd>().GetAsIsometry3();
+      RigidTransformd(p_WS).cast<AutoDiffXd>();
 
-  const unordered_map<GeometryId, Isometry3<AutoDiffXd>> X_WGs{{id1, X_WS1_ad},
-                                                               {id2, X_WS2_ad}};
+  const unordered_map<GeometryId, RigidTransform<AutoDiffXd>> X_WGs{
+      {id1, X_WS1_ad}, {id2, X_WS2_ad}};
   engine.UpdateWorldPoses(X_WGs);
 
   std::vector<SignedDistancePair<AutoDiffXd>> results =
@@ -3437,10 +3428,9 @@ GTEST_TEST(ProximityEngineTests,
   engine.AddDynamicGeometry(Box(1, 2, 3), id1);
   engine.AddDynamicGeometry(Box(2, 4, 6), id2);
 
-  Eigen::Isometry3d a;
-  const unordered_map<GeometryId, Isometry3<AutoDiffXd>> X_WGs{
-      {id1, Isometry3<AutoDiffXd>::Identity()},
-      {id2, Isometry3<AutoDiffXd>::Identity()}};
+  const unordered_map<GeometryId, RigidTransform<AutoDiffXd>> X_WGs{
+      {id1, RigidTransform<AutoDiffXd>::Identity()},
+      {id2, RigidTransform<AutoDiffXd>::Identity()}};
   DRAKE_EXPECT_THROWS_MESSAGE(
       engine.ComputeSignedDistancePairwiseClosestPoints(X_WGs, kInf),
       std::logic_error,

--- a/geometry/test/scene_graph_inspector_test.cc
+++ b/geometry/test/scene_graph_inspector_test.cc
@@ -27,6 +27,7 @@ class SceneGraphInspectorTester {
 
 namespace {
 
+using math::RigidTransformd;
 using std::make_unique;
 
 // Simply exercises all the methods to confirm there's no build or execution
@@ -77,7 +78,7 @@ GTEST_TEST(SceneGraphInspector, ExerciseEverything) {
   const GeometryId geometry_id =
       tester.mutable_state().RegisterGeometry(
           source_id, frame_id,
-          make_unique<GeometryInstance>(Isometry3<double>::Identity(),
+          make_unique<GeometryInstance>(RigidTransformd::Identity(),
                                         make_unique<Sphere>(1.0), "sphere"));
   inspector.GetGeometryIdByName(frame_id, Role::kUnassigned, "sphere");
 
@@ -87,8 +88,13 @@ GTEST_TEST(SceneGraphInspector, ExerciseEverything) {
   inspector.GetFrameId(geometry_id);
   inspector.GetName(geometry_id);
   inspector.GetShape(geometry_id);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   inspector.X_PG(geometry_id);
   inspector.X_FG(geometry_id);
+#pragma GCC diagnostic pop
+  inspector.GetPoseInParent(geometry_id);
+  inspector.GetPoseInFrame(geometry_id);
   inspector.GetProximityProperties(geometry_id);
   inspector.GetIllustrationProperties(geometry_id);
   inspector.GetPerceptionProperties(geometry_id);
@@ -97,7 +103,7 @@ GTEST_TEST(SceneGraphInspector, ExerciseEverything) {
   const GeometryId geometry_id2 =
       tester.mutable_state().RegisterGeometry(
           source_id, frame_id,
-          make_unique<GeometryInstance>(Isometry3<double>::Identity(),
+          make_unique<GeometryInstance>(RigidTransformd::Identity(),
                                         make_unique<Sphere>(1.0), "sphere2"));
   tester.mutable_state().AssignRole(source_id, geometry_id,
                                     ProximityProperties());

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -28,8 +28,8 @@
 namespace drake {
 namespace geometry {
 
-using Eigen::Isometry3d;
 using internal::DummyRenderEngine;
+using math::RigidTransformd;
 using systems::Context;
 using systems::rendering::PoseBundle;
 using systems::System;
@@ -90,7 +90,7 @@ namespace {
 // Convenience function for making a geometry instance.
 std::unique_ptr<GeometryInstance> make_sphere_instance(
     double radius = 1.0) {
-  return make_unique<GeometryInstance>(Isometry3<double>::Identity(),
+  return make_unique<GeometryInstance>(RigidTransformd::Identity(),
                                        make_unique<Sphere>(radius), "sphere");
 }
 
@@ -377,15 +377,15 @@ TEST_F(SceneGraphTest, ModelInspector) {
   // affixed to different nodes, that should be alright.
   GeometryId anchored_id = scene_graph_.RegisterAnchoredGeometry(
       source_id,
-      make_unique<GeometryInstance>(Isometry3d::Identity(),
+      make_unique<GeometryInstance>(RigidTransformd::Identity(),
                                     make_unique<Sphere>(1.0), "sphere"));
   GeometryId sphere_1 = scene_graph_.RegisterGeometry(
       source_id, frame_1,
-      make_unique<GeometryInstance>(Isometry3d::Identity(),
+      make_unique<GeometryInstance>(RigidTransformd::Identity(),
                                     make_unique<Sphere>(1.0), "sphere"));
   GeometryId sphere_2 = scene_graph_.RegisterGeometry(
       source_id, frame_2,
-      make_unique<GeometryInstance>(Isometry3d::Identity(),
+      make_unique<GeometryInstance>(RigidTransformd::Identity(),
                                     make_unique<Sphere>(1.0), "sphere"));
 
   const SceneGraphInspector<double>& inspector = scene_graph_.model_inspector();
@@ -425,7 +425,7 @@ TEST_F(SceneGraphTest, RoleManagementSmokeTest) {
   SourceId s_id = scene_graph_.RegisterSource("test");
   FrameId f_id = scene_graph_.RegisterFrame(s_id, GeometryFrame("frame"));
   auto instance = make_unique<GeometryInstance>(
-      Isometry3<double>::Identity(), make_unique<Sphere>(1.0), "sphere");
+      RigidTransformd::Identity(), make_unique<Sphere>(1.0), "sphere");
   instance->set_illustration_properties(IllustrationProperties());
   instance->set_proximity_properties(ProximityProperties());
   instance->set_perception_properties(PerceptionProperties());
@@ -471,7 +471,7 @@ class GeometrySourceSystem : public systems::LeafSystem<double> {
   }
   // Method used to bring frame ids and poses out of sync. Adds a pose in
   // addition to all of the default poses.
-  void add_extra_pose() { extra_poses_.push_back(Isometry3<double>()); }
+  void add_extra_pose() { extra_poses_.push_back(RigidTransformd()); }
 
  private:
   // Populate with the pose data.
@@ -481,7 +481,7 @@ class GeometrySourceSystem : public systems::LeafSystem<double> {
 
     const int base_count = static_cast<int>(frame_ids_.size());
     for (int i = 0; i < base_count; ++i) {
-      poses->set_value(frame_ids_[i], Isometry3<double>::Identity());
+      poses->set_value(frame_ids_[i], RigidTransformd::Identity());
     }
 
     const int extra_count = static_cast<int>(extra_frame_ids_.size());
@@ -494,7 +494,7 @@ class GeometrySourceSystem : public systems::LeafSystem<double> {
   SourceId source_id_;
   std::vector<FrameId> frame_ids_;
   std::vector<FrameId> extra_frame_ids_;
-  std::vector<Isometry3<double>> extra_poses_;
+  std::vector<RigidTransformd> extra_poses_;
 };
 
 // Simple test case; system registers frames and provides correct connections.
@@ -600,7 +600,7 @@ GTEST_TEST(SceneGraphVisualizationTest, NoWorldInPoseVector) {
     SourceId s_id = scene_graph.RegisterSource("dummy");
     scene_graph.RegisterGeometry(
         s_id, scene_graph.world_frame_id(),
-        make_unique<GeometryInstance>(Isometry3<double>::Identity(),
+        make_unique<GeometryInstance>(RigidTransformd::Identity(),
                                       make_unique<Sphere>(1.0), "sphere"));
     PoseBundle<double> poses = SceneGraphTester::MakePoseBundle(scene_graph);
     EXPECT_EQ(0, poses.get_num_poses());
@@ -617,7 +617,7 @@ GTEST_TEST(SceneGraphVisualizationTest, NoWorldInPoseVector) {
     SourceId s_id = scene_graph.RegisterSource("dummy");
     scene_graph.RegisterGeometry(
         s_id, scene_graph.world_frame_id(),
-        make_unique<GeometryInstance>(Isometry3<double>::Identity(),
+        make_unique<GeometryInstance>(RigidTransformd::Identity(),
                                       make_unique<Sphere>(1.0), "sphere"));
     FrameId f_id = scene_graph.RegisterFrame(s_id, GeometryFrame("f"));
     PoseBundle<double> poses = SceneGraphTester::MakePoseBundle(scene_graph);
@@ -626,7 +626,7 @@ GTEST_TEST(SceneGraphVisualizationTest, NoWorldInPoseVector) {
     EXPECT_EQ(0, poses.get_num_poses());
     auto context = scene_graph.AllocateContext();
     const FramePoseVector<double> pose_vector{{
-        f_id, Isometry3<double>::Identity()}};
+        f_id, RigidTransformd::Identity()}};
     scene_graph.get_source_pose_port(s_id).FixValue(context.get(), pose_vector);
     EXPECT_NO_THROW(
         SceneGraphTester::CalcPoseBundle(scene_graph, *context, &poses));
@@ -639,12 +639,12 @@ GTEST_TEST(SceneGraphVisualizationTest, NoWorldInPoseVector) {
     SourceId s_id = scene_graph.RegisterSource("dummy");
     scene_graph.RegisterGeometry(
         s_id, scene_graph.world_frame_id(),
-        make_unique<GeometryInstance>(Isometry3<double>::Identity(),
+        make_unique<GeometryInstance>(RigidTransformd::Identity(),
                                       make_unique<Sphere>(1.0), "sphere"));
     FrameId f_id = scene_graph.RegisterFrame(s_id, GeometryFrame("f"));
     scene_graph.RegisterGeometry(
         s_id, f_id,
-        make_unique<GeometryInstance>(Isometry3<double>::Identity(),
+        make_unique<GeometryInstance>(RigidTransformd::Identity(),
                                       make_unique<Sphere>(1.0), "sphere"));
     PoseBundle<double> poses = SceneGraphTester::MakePoseBundle(scene_graph);
     // The dynamic geometry has no illustration role, so it doesn't lead the
@@ -652,7 +652,7 @@ GTEST_TEST(SceneGraphVisualizationTest, NoWorldInPoseVector) {
     EXPECT_EQ(0, poses.get_num_poses());
     auto context = scene_graph.AllocateContext();
     const FramePoseVector<double> pose_vector{{
-        f_id, Isometry3<double>::Identity()}};
+        f_id, RigidTransformd::Identity()}};
     scene_graph.get_source_pose_port(s_id).FixValue(context.get(), pose_vector);
     EXPECT_NO_THROW(SceneGraphTester::CalcPoseBundle(scene_graph, *context,
                                                      &poses));
@@ -782,7 +782,7 @@ GTEST_TEST(SceneGraphRenderTest, AddRenderer) {
   SourceId s_id = scene_graph.RegisterSource("dummy");
   scene_graph.RegisterGeometry(
       s_id, scene_graph.world_frame_id(),
-      make_unique<GeometryInstance>(Isometry3<double>::Identity(),
+      make_unique<GeometryInstance>(RigidTransformd::Identity(),
                                     make_unique<Sphere>(1.0), "sphere"));
 
   EXPECT_NO_THROW(

--- a/geometry/test/shape_specification_test.cc
+++ b/geometry/test/shape_specification_test.cc
@@ -212,7 +212,7 @@ TEST_F(ReifierTest, CloningShapes) {
 
 // Confirms that the pose computed by HalfSpace::X_FC() is consistent with
 // the normal and point provided.
-GTEST_TEST(HalfSpaceTest, MakePoseInF) {
+GTEST_TEST(HalfSpaceTest, MakePose) {
   Vector3<double> n;
   Vector3<double> p;
 
@@ -223,7 +223,7 @@ GTEST_TEST(HalfSpaceTest, MakePoseInF) {
   {
     n << 0, 0, 1;
     p << 0, 0, 0;
-    RigidTransformd pose = HalfSpace::MakePoseInF(n, p);
+    RigidTransformd pose = HalfSpace::MakePose(n, p);
     EXPECT_TRUE(ValidatePlanePose(pose, n, p));
   }
 
@@ -231,7 +231,7 @@ GTEST_TEST(HalfSpaceTest, MakePoseInF) {
   {
     n << 0, 0, 1;
     p << 0, 0, 1;
-    RigidTransformd pose = HalfSpace::MakePoseInF(n, p);
+    RigidTransformd pose = HalfSpace::MakePose(n, p);
     EXPECT_TRUE(ValidatePlanePose(pose, n, p));
   }
 
@@ -240,7 +240,7 @@ GTEST_TEST(HalfSpaceTest, MakePoseInF) {
   {
     n << 0, 0, 1;
     p << 1, 0, 0;
-    RigidTransformd pose = HalfSpace::MakePoseInF(n, p);
+    RigidTransformd pose = HalfSpace::MakePose(n, p);
     EXPECT_TRUE(ValidatePlanePose(pose, n, Vector3<double>::Zero()));
   }
 
@@ -249,7 +249,7 @@ GTEST_TEST(HalfSpaceTest, MakePoseInF) {
   {
     n << 0, 0, 1;
     p << 1, 1, 1;
-    RigidTransformd pose = HalfSpace::MakePoseInF(n, p);
+    RigidTransformd pose = HalfSpace::MakePose(n, p);
     p << 0, 0, 1;
     EXPECT_TRUE(ValidatePlanePose(pose, n, p));
   }
@@ -259,7 +259,7 @@ GTEST_TEST(HalfSpaceTest, MakePoseInF) {
   {
     n << 1, 1, 1;
     p << 0, 0, 0;
-    RigidTransformd pose = HalfSpace::MakePoseInF(n, p);
+    RigidTransformd pose = HalfSpace::MakePose(n, p);
     EXPECT_TRUE(ValidatePlanePose(pose, n.normalized(), p));
   }
 
@@ -268,7 +268,7 @@ GTEST_TEST(HalfSpaceTest, MakePoseInF) {
   {
     n << 1, 1, 1;
     p << 1, 1, 1;
-    RigidTransformd pose = HalfSpace::MakePoseInF(n, p);
+    RigidTransformd pose = HalfSpace::MakePose(n, p);
     EXPECT_TRUE(ValidatePlanePose(pose, n.normalized(), p));
   }
 
@@ -278,7 +278,7 @@ GTEST_TEST(HalfSpaceTest, MakePoseInF) {
   {
     n << 1, 1, 1;
     p << 1, 0, 0;
-    RigidTransformd pose = HalfSpace::MakePoseInF(n, p);
+    RigidTransformd pose = HalfSpace::MakePose(n, p);
     p = n / 3.0;
     EXPECT_TRUE(ValidatePlanePose(pose, n.normalized(), p));
   }
@@ -288,20 +288,8 @@ GTEST_TEST(HalfSpaceTest, MakePoseInF) {
     n << 1, 1, 1;
     n *= 1e-11;
     p << 0, 0, 0;
-    EXPECT_THROW(HalfSpace::MakePoseInF(n, p), std::logic_error);
+    EXPECT_THROW(HalfSpace::MakePose(n, p), std::logic_error);
   }
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  // Simple reality check that the deprecated function still works. Simple
-  // repeats a valid test (the first case).
-  {
-    n << 0, 0, 1;
-    p << 0, 0, 0;
-    Isometry3<double> pose = HalfSpace::MakePose(n, p);
-    EXPECT_TRUE(ValidatePlanePose(math::RigidTransformd(pose), n, p));
-  }
-#pragma GCC diagnostic pop
 }
 
 // Confirms the Box::MakeCube correctness.

--- a/geometry/test/shape_specification_test.cc
+++ b/geometry/test/shape_specification_test.cc
@@ -11,6 +11,7 @@ namespace drake {
 namespace geometry {
 namespace {
 
+using math::RigidTransformd;
 using std::unique_ptr;
 
 // Confirm correct interactions with the Reifier.
@@ -152,63 +153,66 @@ TEST_F(ReifierTest, CloningShapes) {
 // that the pose conforms to expectations. Also confirms that the rotational
 // component is orthonormal.
 ::testing::AssertionResult ValidatePlanePose(
-    const Eigen::Isometry3d& pose, const Vector3<double>& expected_z,
+    const RigidTransformd& pose, const Vector3<double>& expected_z,
     const Vector3<double>& expected_translation, double tolerance = 1e-14) {
   using std::abs;
 
   // Test expected z-axis value.
-  const Vector3<double>& z_axis = pose.linear().col(2);
+  const Vector3<double>& z_axis = pose.rotation().col(2);
   if (!CompareMatrices(z_axis, expected_z, tolerance,
                        MatrixCompareType::absolute)) {
     return ::testing::AssertionFailure()
-        << "pose =\n"
-        << pose.matrix() << "\nExpected z-axis " << expected_z.transpose()
-        << " does not match pose's z-axis " << z_axis.transpose();
+           << "pose =\n"
+           << pose.GetAsMatrix34() << "\nExpected z-axis "
+           << expected_z.transpose() << " does not match pose's z-axis "
+           << z_axis.transpose();
   }
 
   // Test expected translation.
   if (!CompareMatrices(pose.translation(), expected_translation, tolerance,
                        MatrixCompareType::absolute)) {
     return ::testing::AssertionFailure()
-        << "pose =\n"
-        << pose.matrix() << "\nExpected translation "
-        << expected_translation.transpose()
-        << " does not match pose's translation "
-        << pose.translation().transpose();
+           << "pose =\n"
+           << pose.GetAsMatrix34() << "\nExpected translation "
+           << expected_translation.transpose()
+           << " does not match pose's translation "
+           << pose.translation().transpose();
   }
 
   // Test unit-length rotation.
   char axis_labels[] = {'x', 'y', 'z'};
   for (int i = 0; i < 3; ++i) {
-    if (abs(pose.linear().col(i).norm() - 1) > tolerance) {
+    if (abs(pose.rotation().col(i).norm() - 1) > tolerance) {
       return ::testing::AssertionFailure()
-          << "pose =\n"
-          << pose.matrix() << "\ndoes not have unit length " << axis_labels[i]
-          << "-axis " << pose.linear().col(i).transpose();
+             << "pose =\n"
+             << pose.GetAsMatrix34() << "\ndoes not have unit length "
+             << axis_labels[i] << "-axis "
+             << pose.rotation().col(i).transpose();
     }
   }
 
   // Test orthogonality.
   for (int i = 0; i < 2; ++i) {
     for (int j = i + 1; j < 3; ++j) {
-      double dot_product = pose.linear().col(i).dot(pose.linear().col(j));
+      double dot_product = pose.rotation().col(i).dot(pose.rotation().col(j));
       if (abs(dot_product) > tolerance) {
         return ::testing::AssertionFailure()
-            << "For pose =\n"
-            << pose.matrix() << "\nThe " << axis_labels[i] << "-axis and "
-            << axis_labels[j] << "-axis are not orthogonal";
+               << "For pose =\n"
+               << pose.GetAsMatrix34() << "\nThe " << axis_labels[i]
+               << "-axis and " << axis_labels[j] << "-axis are not orthogonal";
       }
     }
   }
   return ::testing::AssertionSuccess()
-      << "pose =\n"
-      << pose.matrix() << "\nhas expected z-axis = " << expected_z.transpose()
-      << "\nand expected translation = " << expected_translation.transpose();
+         << "pose =\n"
+         << pose.GetAsMatrix34()
+         << "\nhas expected z-axis = " << expected_z.transpose()
+         << "\nand expected translation = " << expected_translation.transpose();
 }
 
-// Confirms that the pose computed by HalfSpace::MakePose is consistent with
+// Confirms that the pose computed by HalfSpace::X_FC() is consistent with
 // the normal and point provided.
-GTEST_TEST(HalfSpaceTest, MakePose) {
+GTEST_TEST(HalfSpaceTest, MakePoseInF) {
   Vector3<double> n;
   Vector3<double> p;
 
@@ -219,7 +223,7 @@ GTEST_TEST(HalfSpaceTest, MakePose) {
   {
     n << 0, 0, 1;
     p << 0, 0, 0;
-    Isometry3<double> pose = HalfSpace::MakePose(n, p);
+    RigidTransformd pose = HalfSpace::MakePoseInF(n, p);
     EXPECT_TRUE(ValidatePlanePose(pose, n, p));
   }
 
@@ -227,7 +231,7 @@ GTEST_TEST(HalfSpaceTest, MakePose) {
   {
     n << 0, 0, 1;
     p << 0, 0, 1;
-    Isometry3<double> pose = HalfSpace::MakePose(n, p);
+    RigidTransformd pose = HalfSpace::MakePoseInF(n, p);
     EXPECT_TRUE(ValidatePlanePose(pose, n, p));
   }
 
@@ -236,7 +240,7 @@ GTEST_TEST(HalfSpaceTest, MakePose) {
   {
     n << 0, 0, 1;
     p << 1, 0, 0;
-    Isometry3<double> pose = HalfSpace::MakePose(n, p);
+    RigidTransformd pose = HalfSpace::MakePoseInF(n, p);
     EXPECT_TRUE(ValidatePlanePose(pose, n, Vector3<double>::Zero()));
   }
 
@@ -245,7 +249,7 @@ GTEST_TEST(HalfSpaceTest, MakePose) {
   {
     n << 0, 0, 1;
     p << 1, 1, 1;
-    Isometry3<double> pose = HalfSpace::MakePose(n, p);
+    RigidTransformd pose = HalfSpace::MakePoseInF(n, p);
     p << 0, 0, 1;
     EXPECT_TRUE(ValidatePlanePose(pose, n, p));
   }
@@ -255,7 +259,7 @@ GTEST_TEST(HalfSpaceTest, MakePose) {
   {
     n << 1, 1, 1;
     p << 0, 0, 0;
-    Isometry3<double> pose = HalfSpace::MakePose(n, p);
+    RigidTransformd pose = HalfSpace::MakePoseInF(n, p);
     EXPECT_TRUE(ValidatePlanePose(pose, n.normalized(), p));
   }
 
@@ -264,7 +268,7 @@ GTEST_TEST(HalfSpaceTest, MakePose) {
   {
     n << 1, 1, 1;
     p << 1, 1, 1;
-    Isometry3<double> pose = HalfSpace::MakePose(n, p);
+    RigidTransformd pose = HalfSpace::MakePoseInF(n, p);
     EXPECT_TRUE(ValidatePlanePose(pose, n.normalized(), p));
   }
 
@@ -274,7 +278,7 @@ GTEST_TEST(HalfSpaceTest, MakePose) {
   {
     n << 1, 1, 1;
     p << 1, 0, 0;
-    Isometry3<double> pose = HalfSpace::MakePose(n, p);
+    RigidTransformd pose = HalfSpace::MakePoseInF(n, p);
     p = n / 3.0;
     EXPECT_TRUE(ValidatePlanePose(pose, n.normalized(), p));
   }
@@ -284,8 +288,20 @@ GTEST_TEST(HalfSpaceTest, MakePose) {
     n << 1, 1, 1;
     n *= 1e-11;
     p << 0, 0, 0;
-    EXPECT_THROW(HalfSpace::MakePose(n, p), std::logic_error);
+    EXPECT_THROW(HalfSpace::MakePoseInF(n, p), std::logic_error);
   }
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  // Simple reality check that the deprecated function still works. Simple
+  // repeats a valid test (the first case).
+  {
+    n << 0, 0, 1;
+    p << 0, 0, 0;
+    Isometry3<double> pose = HalfSpace::MakePose(n, p);
+    EXPECT_TRUE(ValidatePlanePose(math::RigidTransformd(pose), n, p));
+  }
+#pragma GCC diagnostic pop
 }
 
 // Confirms the Box::MakeCube correctness.

--- a/geometry/test/utilities_test.cc
+++ b/geometry/test/utilities_test.cc
@@ -5,11 +5,16 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/math/roll_pitch_yaw.h"
 
 namespace drake {
 namespace geometry {
 namespace internal {
 namespace {
+
+using math::RigidTransform;
+using math::RollPitchYaw;
 
 GTEST_TEST(GeometryUtilities, CanonicalizeGeometryName) {
   // Confirms that the canonical version of the given name is unchanged.
@@ -54,29 +59,26 @@ GTEST_TEST(GeometryUtilities, CanonicalizeGeometryName) {
   }
 }
 
-GTEST_TEST(GeometryUtilities, IsometryConversion) {
-  Isometry3<double> X_AB = Isometry3<double>::Identity();
-  X_AB.translation() << 1, 2, 3;
-  // NOTE: Not a valid transform; we're just looking for unique values.
-  X_AB.linear() << 10, 20, 30, 40, 50, 60, 70, 80, 90;
-  X_AB.makeAffine();
+GTEST_TEST(GeometryUtilities, RigidTransformConversion) {
+  RigidTransform<double> X_AB{
+      RollPitchYaw<double>{M_PI / 3, M_PI / 6, M_PI / 7},
+      Vector3<double>{1, 2, 3}};
 
-  Isometry3<double> X_AB_converted = convert_to_double(X_AB);
-  EXPECT_TRUE(CompareMatrices(X_AB.matrix(), X_AB_converted.matrix()));
   // Double to double conversion is just a pass through without copying.
-  const Isometry3<double>& X_AB_converted_ref = convert_to_double(X_AB);
+  const RigidTransform<double>& X_AB_converted_ref = convert_to_double(X_AB);
   EXPECT_EQ(&X_AB, &X_AB_converted_ref);
 
-  Isometry3<AutoDiffXd> X_AB_ad(X_AB);
-  Isometry3<double> X_AB_ad_converted = convert_to_double(X_AB_ad);
-  EXPECT_TRUE(CompareMatrices(X_AB.matrix(), X_AB_ad_converted.matrix()));
+  RigidTransform<AutoDiffXd> X_AB_ad(X_AB.cast<AutoDiffXd>());
+  RigidTransform<double> X_AB_ad_converted = convert_to_double(X_AB_ad);
+  EXPECT_TRUE(
+      CompareMatrices(X_AB.GetAsMatrix34(), X_AB_ad_converted.GetAsMatrix34()));
 }
 
 GTEST_TEST(GeometryUtilities, Vector3Conversion) {
   Vector3<double> p_AB{1, 2, 3};
 
   Vector3<double> p_AB_converted = convert_to_double(p_AB);
-  EXPECT_TRUE(CompareMatrices(p_AB.matrix(), p_AB_converted.matrix()));
+  EXPECT_TRUE(CompareMatrices(p_AB, p_AB_converted));
   // Double to double conversion is just a pass through without copying, so
   // we'll compare addresses.
   const Vector3<double>& p_AB_converted_ref = convert_to_double(p_AB);
@@ -84,7 +86,7 @@ GTEST_TEST(GeometryUtilities, Vector3Conversion) {
 
   Vector3<AutoDiffXd> p_AB_ad(p_AB);
   Vector3<double> X_AB_ad_converted = convert_to_double(p_AB_ad);
-  EXPECT_TRUE(CompareMatrices(p_AB.matrix(), X_AB_ad_converted.matrix()));
+  EXPECT_TRUE(CompareMatrices(p_AB, X_AB_ad_converted));
 }
 
 }  // namespace

--- a/geometry/utilities.h
+++ b/geometry/utilities.h
@@ -79,33 +79,14 @@ Vector3<double> convert_to_double(
   return result;
 }
 
-// TODO(SeanCurtis-TRI): Get rid of these when I finally swap for
-// RigidTransforms.
-
-inline const Isometry3<double>& convert_to_double(
-    const Isometry3<double>& transform) {
-  return transform;
-}
-
-template <class VectorType>
-Isometry3<double> convert_to_double(
-    const Isometry3<Eigen::AutoDiffScalar<VectorType>>& transform) {
-  Isometry3<double> result;
-  for (int r = 0; r < 4; ++r) {
-    for (int c = 0; c < 4; ++c) {
-      result.matrix()(r, c) = ExtractDoubleOrThrow(transform.matrix()(r, c));
-    }
-  }
-  return result;
-}
-
 // Don't needlessly copy transforms that are already scalar-valued.
-inline const math::RigidTransformd& convert(const math::RigidTransformd& X_AB) {
+inline const math::RigidTransformd& convert_to_double(
+    const math::RigidTransformd& X_AB) {
   return X_AB;
 }
 
 template <class VectorType>
-math::RigidTransformd convert(
+math::RigidTransformd convert_to_double(
     const math::RigidTransform<Eigen::AutoDiffScalar<VectorType>>& X_AB) {
   Matrix3<double> R_converted;
   Vector3<double> p_converted;

--- a/multibody/inverse_kinematics/distance_constraint.cc
+++ b/multibody/inverse_kinematics/distance_constraint.cc
@@ -77,7 +77,11 @@ void EvalDistance(const MultibodyPlant<T>& plant,
           plant.GetBodyFromFrameId(frame_B_id)->body_frame();
       internal::CalcDistanceDerivatives(
           plant, *context, frameA, frameB,
-          inspector.X_FG(signed_distance_pair.id_A) *
+          // GetPoseInFrame() returns RigidTransform<double> -- we can't
+          // multiply across heterogeneous scalar types; so we cast the double
+          // to T.
+          inspector.GetPoseInFrame(signed_distance_pair.id_A)
+                  .template cast<T>() *
               signed_distance_pair.p_ACa,
           signed_distance_pair.distance, signed_distance_pair.nhat_BA_W, x,
           y->data());

--- a/multibody/inverse_kinematics/minimum_distance_constraint.cc
+++ b/multibody/inverse_kinematics/minimum_distance_constraint.cc
@@ -49,7 +49,11 @@ VectorX<S> Distances(const MultibodyPlant<T>& plant,
           plant.GetBodyFromFrameId(frame_B_id)->body_frame();
       internal::CalcDistanceDerivatives(
           plant, *context, frameA, frameB,
-          inspector.X_FG(signed_distance_pair.id_A) *
+          // GetPoseInFrame() returns RigidTransform<double> -- we can't
+          // multiply across heterogeneous scalar types; so we cast the double
+          // to T.
+          inspector.GetPoseInFrame(signed_distance_pair.id_A)
+                  .template cast<T>() *
               signed_distance_pair.p_ACa,
           signed_distance_pair.distance, signed_distance_pair.nhat_BA_W, q,
           &distances(distance_count++));

--- a/multibody/optimization/manipulator_equation_constraint.cc
+++ b/multibody/optimization/manipulator_equation_constraint.cc
@@ -113,12 +113,12 @@ void ManipulatorEquationConstraint::DoEval(
     // Compute the Jacobian.
     // Define Body A's frame as A, the geometry attached to body A as frame Ga,
     // and the witness point on geometry Ga as Ca.
-    const auto& X_AGa = inspector.X_FG(signed_distance_pair.id_A);
+    const auto& X_AGa = inspector.GetPoseInFrame(signed_distance_pair.id_A);
     const auto& p_GaCa = signed_distance_pair.p_ACa;
     const Vector3<AutoDiffXd> p_ACa = X_AGa.cast<AutoDiffXd>() * p_GaCa;
     // Define Body B's frame as B, the geometry attached to body B as frame Gb,
     // and the witness point on geometry Gb as Cb.
-    const auto& X_BGb = inspector.X_FG(signed_distance_pair.id_B);
+    const auto& X_BGb = inspector.GetPoseInFrame(signed_distance_pair.id_B);
     const auto& p_GbCb = signed_distance_pair.p_BCb;
     const Vector3<AutoDiffXd> p_BCb = X_BGb.cast<AutoDiffXd>() * p_GbCb;
     Eigen::Matrix<AutoDiffXd, 6, Eigen::Dynamic> Jv_V_WCa(

--- a/multibody/optimization/sliding_friction_complementarity_constraint.cc
+++ b/multibody/optimization/sliding_friction_complementarity_constraint.cc
@@ -198,7 +198,9 @@ void SlidingFrictionComplementarityNonlinearConstraint::DoEval(
       // the body frame of body B.
       const Vector3<AutoDiffXd>& p_BgCb = signed_distance_pair.p_BCb;
       const Vector3<AutoDiffXd> p_BbCb =
-          inspector.X_FG(signed_distance_pair.id_B) * p_BgCb;
+          inspector.GetPoseInFrame(signed_distance_pair.id_B)
+              .template cast<AutoDiffXd>() *
+          p_BgCb;
       const Vector3<AutoDiffXd> p_BbCb_W =
           plant.CalcRelativeTransform(context, plant.world_frame(), frameB)
               .rotation() *

--- a/multibody/optimization/static_equilibrium_constraint.cc
+++ b/multibody/optimization/static_equilibrium_constraint.cc
@@ -82,12 +82,12 @@ void StaticEquilibriumConstraint::DoEval(
     // Compute the Jacobian.
     // Define Body A's frame as A, the geometry attached to body A has frame Ga,
     // and the witness point on geometry Ga is Ca.
-    const auto& X_AGa = inspector.X_FG(signed_distance_pair.id_A);
+    const auto& X_AGa = inspector.GetPoseInFrame(signed_distance_pair.id_A);
     const auto& p_GaCa = signed_distance_pair.p_ACa;
     const Vector3<AutoDiffXd> p_ACa = X_AGa.cast<AutoDiffXd>() * p_GaCa;
     // Define Body B's frame as B, the geometry attached to body B has frame Gb,
     // and the witness point on geometry Gb is Cb.
-    const auto& X_BGb = inspector.X_FG(signed_distance_pair.id_B);
+    const auto& X_BGb = inspector.GetPoseInFrame(signed_distance_pair.id_B);
     const auto& p_GbCb = signed_distance_pair.p_BCb;
     const Vector3<AutoDiffXd> p_BCb = X_BGb.cast<AutoDiffXd>() * p_GbCb;
     Eigen::Matrix<AutoDiffXd, 6, Eigen::Dynamic> Jv_V_WCa(

--- a/multibody/optimization/static_equilibrium_problem.cc
+++ b/multibody/optimization/static_equilibrium_problem.cc
@@ -122,7 +122,8 @@ std::vector<ContactWrench> StaticEquilibriumProblem::GetContactWrenchSolution(
         body_B_index = frame_Fb.body().index();
         // Define Body B's frame as Fb, the geometry attached to body B has
         // frame Gb, and the witness point on geometry Gb is Cb.
-        const auto& X_FbGb = inspector.X_FG(signed_distance_pair.id_B);
+        const auto& X_FbGb = inspector.GetPoseInFrame(signed_distance_pair.id_B)
+                                 .template cast<AutoDiffXd>();
         const auto& p_GbCb = signed_distance_pair.p_BCb;
         const Vector3<AutoDiffXd> p_FbCb = X_FbGb * p_GbCb;
         plant_.CalcPointsPositions(*context_, frame_Fb, p_FbCb,

--- a/multibody/parsing/detail_scene_graph.cc
+++ b/multibody/parsing/detail_scene_graph.cc
@@ -211,7 +211,7 @@ std::unique_ptr<GeometryInstance> MakeGeometryInstanceFromSdfVisual(
       // in its canonical frame C in which the normal aligns with the z-axis
       // direction.
       const RigidTransformd X_GC(
-          geometry::HalfSpace::MakePoseInF(normal_G, Vector3d::Zero()));
+          geometry::HalfSpace::MakePose(normal_G, Vector3d::Zero()));
 
       // Correct X_LC to include the pose X_GC
       X_LC = X_LG * X_GC;
@@ -314,7 +314,7 @@ RigidTransformd MakeGeometryPoseFromSdfCollision(
       // in its canonical frame C in which the normal aligns with the z-axis
       // direction.
       const RigidTransformd X_GC(
-          geometry::HalfSpace::MakePoseInF(normal_G, Vector3d::Zero()));
+          geometry::HalfSpace::MakePose(normal_G, Vector3d::Zero()));
 
       // Correct X_LC to include the pose X_GC
       X_LC = X_LG * X_GC;

--- a/multibody/parsing/detail_scene_graph.cc
+++ b/multibody/parsing/detail_scene_graph.cc
@@ -211,7 +211,7 @@ std::unique_ptr<GeometryInstance> MakeGeometryInstanceFromSdfVisual(
       // in its canonical frame C in which the normal aligns with the z-axis
       // direction.
       const RigidTransformd X_GC(
-          geometry::HalfSpace::MakePose(normal_G, Vector3d::Zero()));
+          geometry::HalfSpace::MakePoseInF(normal_G, Vector3d::Zero()));
 
       // Correct X_LC to include the pose X_GC
       X_LC = X_LG * X_GC;
@@ -314,7 +314,7 @@ RigidTransformd MakeGeometryPoseFromSdfCollision(
       // in its canonical frame C in which the normal aligns with the z-axis
       // direction.
       const RigidTransformd X_GC(
-          geometry::HalfSpace::MakePose(normal_G, Vector3d::Zero()));
+          geometry::HalfSpace::MakePoseInF(normal_G, Vector3d::Zero()));
 
       // Correct X_LC to include the pose X_GC
       X_LC = X_LG * X_GC;

--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -436,8 +436,8 @@ void AddLinksFromSpecification(
               geometry_instance->illustration_properties() != nullptr);
 
           plant->RegisterVisualGeometry(
-              body, RigidTransformd(geometry_instance->pose()),
-              geometry_instance->shape(), geometry_instance->name(),
+              body, geometry_instance->X_PG(), geometry_instance->shape(),
+              geometry_instance->name(),
               *geometry_instance->illustration_properties());
         }
       }

--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -436,7 +436,7 @@ void AddLinksFromSpecification(
               geometry_instance->illustration_properties() != nullptr);
 
           plant->RegisterVisualGeometry(
-              body, geometry_instance->X_PG(), geometry_instance->shape(),
+              body, geometry_instance->pose(), geometry_instance->shape(),
               geometry_instance->name(),
               *geometry_instance->illustration_properties());
         }

--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -126,7 +126,7 @@ void ParseBody(const multibody::PackageMap& package_map,
       // instance, even if it is empty.
       DRAKE_DEMAND(geometry_instance.illustration_properties() != nullptr);
       plant->RegisterVisualGeometry(
-          body, geometry_instance.X_PG(), geometry_instance.shape(),
+          body, geometry_instance.pose(), geometry_instance.shape(),
           geometry_instance.name(),
           *geometry_instance.illustration_properties());
     }
@@ -138,7 +138,7 @@ void ParseBody(const multibody::PackageMap& package_map,
       geometry::GeometryInstance geometry_instance =
           ParseCollision(body_name, package_map, root_dir, collision_node,
                          &friction);
-      plant->RegisterCollisionGeometry(body, geometry_instance.X_PG(),
+      plant->RegisterCollisionGeometry(body, geometry_instance.pose(),
                                        geometry_instance.shape(),
                                        geometry_instance.name(), friction);
     }

--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -126,8 +126,8 @@ void ParseBody(const multibody::PackageMap& package_map,
       // instance, even if it is empty.
       DRAKE_DEMAND(geometry_instance.illustration_properties() != nullptr);
       plant->RegisterVisualGeometry(
-          body, RigidTransformd(geometry_instance.pose()),
-          geometry_instance.shape(), geometry_instance.name(),
+          body, geometry_instance.X_PG(), geometry_instance.shape(),
+          geometry_instance.name(),
           *geometry_instance.illustration_properties());
     }
 
@@ -138,9 +138,9 @@ void ParseBody(const multibody::PackageMap& package_map,
       geometry::GeometryInstance geometry_instance =
           ParseCollision(body_name, package_map, root_dir, collision_node,
                          &friction);
-      plant->RegisterCollisionGeometry(
-          body, RigidTransformd(geometry_instance.pose()),
-          geometry_instance.shape(), geometry_instance.name(), friction);
+      plant->RegisterCollisionGeometry(body, geometry_instance.X_PG(),
+                                       geometry_instance.shape(),
+                                       geometry_instance.name(), friction);
     }
   }
 }

--- a/multibody/parsing/test/detail_scene_graph_test.cc
+++ b/multibody/parsing/test/detail_scene_graph_test.cc
@@ -260,7 +260,7 @@ GTEST_TEST(SceneGraphParserDetail, MakeGeometryInstanceFromSdfVisual) {
   unique_ptr<GeometryInstance> geometry_instance =
       MakeGeometryInstanceFromSdfVisual(*sdf_visual);
 
-  const RigidTransformd X_LC(geometry_instance->X_PG());
+  const RigidTransformd X_LC(geometry_instance->pose());
 
   // These are the expected values as specified by the string above.
   const RollPitchYaw<double> expected_rpy(3.14, 6.28, 1.57);
@@ -410,11 +410,11 @@ GTEST_TEST(SceneGraphParserDetail, MakeHalfSpaceGeometryInstanceFromSdfVisual) {
 
   // The expected orientation of the canonical frame C (in which the plane's
   // normal aligns with Cz) in the link frame L.
-  const RotationMatrix<double> R_LC_expected(
-      HalfSpace::MakePoseInF(normal_L_expected, Vector3d::Zero()).linear());
+  const RotationMatrix<double> R_LC_expected =
+      HalfSpace::MakePose(normal_L_expected, Vector3d::Zero()).rotation();
 
   // Retrieve the GeometryInstance pose as parsed from the sdf::Visual.
-  const RotationMatrix<double> R_LC(geometry_instance->X_PG().linear());
+  const RotationMatrix<double> R_LC = geometry_instance->pose().rotation();
   const Vector3d normal_L = R_LC.col(2);
 
   // Verify results to precision given by kTolerance.
@@ -735,8 +735,8 @@ GTEST_TEST(SceneGraphParserDetail,
 
   // The expected orientation of the canonical frame C (in which the plane's
   // normal aligns with Cz) in the link frame L.
-  const RotationMatrix<double> R_LG_expected(
-      HalfSpace::MakePoseInF(normal_L_expected, Vector3d::Zero()).linear());
+  const RotationMatrix<double>& R_LG_expected =
+      HalfSpace::MakePose(normal_L_expected, Vector3d::Zero()).rotation();
 
   // Verify results to precision given by kTolerance.
   const double kTolerance = 10 * std::numeric_limits<double>::epsilon();

--- a/multibody/parsing/test/detail_scene_graph_test.cc
+++ b/multibody/parsing/test/detail_scene_graph_test.cc
@@ -260,7 +260,7 @@ GTEST_TEST(SceneGraphParserDetail, MakeGeometryInstanceFromSdfVisual) {
   unique_ptr<GeometryInstance> geometry_instance =
       MakeGeometryInstanceFromSdfVisual(*sdf_visual);
 
-  const RigidTransformd X_LC(geometry_instance->pose());
+  const RigidTransformd X_LC(geometry_instance->X_PG());
 
   // These are the expected values as specified by the string above.
   const RollPitchYaw<double> expected_rpy(3.14, 6.28, 1.57);
@@ -411,10 +411,10 @@ GTEST_TEST(SceneGraphParserDetail, MakeHalfSpaceGeometryInstanceFromSdfVisual) {
   // The expected orientation of the canonical frame C (in which the plane's
   // normal aligns with Cz) in the link frame L.
   const RotationMatrix<double> R_LC_expected(
-      HalfSpace::MakePose(normal_L_expected, Vector3d::Zero()).linear());
+      HalfSpace::MakePoseInF(normal_L_expected, Vector3d::Zero()).linear());
 
   // Retrieve the GeometryInstance pose as parsed from the sdf::Visual.
-  const RotationMatrix<double> R_LC(geometry_instance->pose().linear());
+  const RotationMatrix<double> R_LC(geometry_instance->X_PG().linear());
   const Vector3d normal_L = R_LC.col(2);
 
   // Verify results to precision given by kTolerance.
@@ -736,7 +736,7 @@ GTEST_TEST(SceneGraphParserDetail,
   // The expected orientation of the canonical frame C (in which the plane's
   // normal aligns with Cz) in the link frame L.
   const RotationMatrix<double> R_LG_expected(
-      HalfSpace::MakePose(normal_L_expected, Vector3d::Zero()).linear());
+      HalfSpace::MakePoseInF(normal_L_expected, Vector3d::Zero()).linear());
 
   // Verify results to precision given by kTolerance.
   const double kTolerance = 10 * std::numeric_limits<double>::epsilon();

--- a/multibody/parsing/test/detail_urdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_urdf_geometry_test.cc
@@ -119,7 +119,7 @@ TEST_F(UrdfGeometryTests, TestParseMaterial1) {
   EXPECT_EQ(visual.name().substr(0, name_base.size()), name_base);
 
   EXPECT_TRUE(CompareMatrices(
-      visual.X_PG().GetAsMatrix34(), RigidTransformd().GetAsMatrix34()));
+      visual.pose().GetAsMatrix34(), RigidTransformd().GetAsMatrix34()));
 
   const geometry::Box* box =
       dynamic_cast<const geometry::Box*>(&visual.shape());
@@ -149,7 +149,7 @@ TEST_F(UrdfGeometryTests, TestParseMaterial2) {
 
   const RigidTransformd expected_pose(Eigen::Vector3d(0, 0, 0.3));
   EXPECT_TRUE(CompareMatrices(
-      visual.X_PG().GetAsMatrix34(), expected_pose.GetAsMatrix34()));
+      visual.pose().GetAsMatrix34(), expected_pose.GetAsMatrix34()));
 
   const geometry::Cylinder* cylinder =
       dynamic_cast<const geometry::Cylinder*>(&visual.shape());
@@ -201,7 +201,7 @@ TEST_F(UrdfGeometryTests, TestParseMaterialDuplicateButSame) {
       math::RotationMatrix<double>(expected_rpy), expected_xyz);
 
   const auto& visual = visual_instances_.front();
-  math::RigidTransform<double> actual_pose(visual.X_PG());
+  math::RigidTransform<double> actual_pose(visual.pose());
   EXPECT_TRUE(actual_pose.IsNearlyEqualTo(expected_pose, 1e-10));
 }
 

--- a/multibody/parsing/test/detail_urdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_urdf_geometry_test.cc
@@ -119,7 +119,7 @@ TEST_F(UrdfGeometryTests, TestParseMaterial1) {
   EXPECT_EQ(visual.name().substr(0, name_base.size()), name_base);
 
   EXPECT_TRUE(CompareMatrices(
-      visual.pose().matrix(), RigidTransformd().matrix()));
+      visual.X_PG().GetAsMatrix34(), RigidTransformd().GetAsMatrix34()));
 
   const geometry::Box* box =
       dynamic_cast<const geometry::Box*>(&visual.shape());
@@ -149,7 +149,7 @@ TEST_F(UrdfGeometryTests, TestParseMaterial2) {
 
   const RigidTransformd expected_pose(Eigen::Vector3d(0, 0, 0.3));
   EXPECT_TRUE(CompareMatrices(
-      visual.pose().matrix(), expected_pose.matrix()));
+      visual.X_PG().GetAsMatrix34(), expected_pose.GetAsMatrix34()));
 
   const geometry::Cylinder* cylinder =
       dynamic_cast<const geometry::Cylinder*>(&visual.shape());
@@ -201,7 +201,7 @@ TEST_F(UrdfGeometryTests, TestParseMaterialDuplicateButSame) {
       math::RotationMatrix<double>(expected_rpy), expected_xyz);
 
   const auto& visual = visual_instances_.front();
-  math::RigidTransform<double> actual_pose(visual.pose());
+  math::RigidTransform<double> actual_pose(visual.X_PG());
   EXPECT_TRUE(actual_pose.IsNearlyEqualTo(expected_pose, 1e-10));
 }
 

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -903,8 +903,7 @@ class SphereChainScenario {
     ground_id_ = plant_->RegisterCollisionGeometry(
         plant_->world_body(),
         // A half-space passing through the origin in the x-z plane.
-        RigidTransformd(
-            geometry::HalfSpace::MakePose(Vector3d::UnitY(), Vector3d::Zero())),
+        geometry::HalfSpace::MakePoseInF(Vector3d::UnitY(), Vector3d::Zero()),
         geometry::HalfSpace(), "ground", CoulombFriction<double>());
 
     auto make_sphere = [this](int i) {
@@ -1172,8 +1171,7 @@ GTEST_TEST(MultibodyPlantTest, CollisionGeometryRegistration) {
   GeometryId ground_id = plant.RegisterCollisionGeometry(
       plant.world_body(),
       // A half-space passing through the origin in the x-z plane.
-      RigidTransformd(
-          geometry::HalfSpace::MakePose(Vector3d::UnitY(), Vector3d::Zero())),
+      geometry::HalfSpace::MakePoseInF(Vector3d::UnitY(), Vector3d::Zero()),
       geometry::HalfSpace(), "ground", ground_friction);
 
   // Add two spherical bodies.
@@ -1275,8 +1273,7 @@ GTEST_TEST(MultibodyPlantTest, VisualGeometryRegistration) {
   GeometryId ground_id = plant.RegisterVisualGeometry(
       plant.world_body(),
       // A half-space passing through the origin in the x-z plane.
-      RigidTransformd(
-          geometry::HalfSpace::MakePose(Vector3d::UnitY(), Vector3d::Zero())),
+      geometry::HalfSpace::MakePoseInF(Vector3d::UnitY(), Vector3d::Zero()),
       geometry::HalfSpace(), "ground");
   EXPECT_EQ(render_engine.num_registered(), 1);
 

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -903,7 +903,7 @@ class SphereChainScenario {
     ground_id_ = plant_->RegisterCollisionGeometry(
         plant_->world_body(),
         // A half-space passing through the origin in the x-z plane.
-        geometry::HalfSpace::MakePoseInF(Vector3d::UnitY(), Vector3d::Zero()),
+        geometry::HalfSpace::MakePose(Vector3d::UnitY(), Vector3d::Zero()),
         geometry::HalfSpace(), "ground", CoulombFriction<double>());
 
     auto make_sphere = [this](int i) {
@@ -1171,7 +1171,7 @@ GTEST_TEST(MultibodyPlantTest, CollisionGeometryRegistration) {
   GeometryId ground_id = plant.RegisterCollisionGeometry(
       plant.world_body(),
       // A half-space passing through the origin in the x-z plane.
-      geometry::HalfSpace::MakePoseInF(Vector3d::UnitY(), Vector3d::Zero()),
+      geometry::HalfSpace::MakePose(Vector3d::UnitY(), Vector3d::Zero()),
       geometry::HalfSpace(), "ground", ground_friction);
 
   // Add two spherical bodies.
@@ -1273,7 +1273,7 @@ GTEST_TEST(MultibodyPlantTest, VisualGeometryRegistration) {
   GeometryId ground_id = plant.RegisterVisualGeometry(
       plant.world_body(),
       // A half-space passing through the origin in the x-z plane.
-      geometry::HalfSpace::MakePoseInF(Vector3d::UnitY(), Vector3d::Zero()),
+      geometry::HalfSpace::MakePose(Vector3d::UnitY(), Vector3d::Zero()),
       geometry::HalfSpace(), "ground");
   EXPECT_EQ(render_engine.num_registered(), 1);
 

--- a/systems/rendering/render_pose_to_geometry_pose.cc
+++ b/systems/rendering/render_pose_to_geometry_pose.cc
@@ -7,6 +7,7 @@
 
 using drake::geometry::FrameId;
 using drake::geometry::SourceId;
+using drake::math::RigidTransform;
 
 namespace drake {
 namespace systems {
@@ -28,7 +29,7 @@ RenderPoseToGeometryPose<T>::RenderPoseToGeometryPose(
       [this, frame_id](const Context<T>& context, AbstractValue* calculated) {
         const Input& input = get_input_port().template Eval<Input>(context);
         calculated->get_mutable_value<Output>() =
-            {{frame_id, input.get_isometry()}};
+            {{frame_id, RigidTransform<T>(input.get_isometry())}};
       });
 }
 

--- a/systems/sensors/test/optitrack_sender_test.cc
+++ b/systems/sensors/test/optitrack_sender_test.cc
@@ -4,12 +4,14 @@
 #include "optitrack/optitrack_frame_t.hpp"
 
 #include "drake/geometry/frame_kinematics_vector.h"
+#include "drake/math/rigid_transform.h"
 #include "drake/systems/framework/context.h"
 
 namespace drake {
 namespace systems {
 namespace sensors {
 
+using math::RigidTransformd;
 using optitrack::optitrack_frame_t;
 
 // This test sets up a systems::sensors::TrackedBody structure to be passed
@@ -33,10 +35,9 @@ GTEST_TEST(OptitrackSenderTest, OptitrackLcmSenderTest) {
 
   // Sets up a test body with an arbitrarily chosen pose.
   Eigen::Vector3d axis(1 / sqrt(3), 1 / sqrt(3), 1 / sqrt(3));
-  const geometry::FramePoseVector<double> pose_vector{{
-      frame_id,
-      Eigen::Isometry3d(Eigen::AngleAxis<double>(0.2, axis)).
-          pretranslate(Eigen::Vector3d(tx, ty, tz))}};
+  const geometry::FramePoseVector<double> pose_vector{
+      {frame_id, RigidTransformd(Eigen::AngleAxis<double>(0.2, axis),
+                                 Eigen::Vector3d(tx, ty, tz))}};
 
   EXPECT_EQ(pose_vector.value(frame_id).translation()[0], tx);
   EXPECT_EQ(pose_vector.value(frame_id).translation()[1], ty);


### PR DESCRIPTION
1. Remove all internal references to `Isometry3` with the following exceptions:
   - ProximityEngine gets Iso3 from RT to pass to FCL (2X)
   - SceneGraph's PoseBundle output port still uses Iso3
2. Modify public API with a handful of deprecated methods:
  - GeometryInstance::GeometryInstance(Isometry3)
  - GeometryInstance::pose()
  - GeometryInstance::set_pose()
  - SceneGraphInspector::X_PG()
  - SceneGraphInspector::X_FG()
  - HalfSpace::MakePose()
3. Account for deprecated methods in various call sites in attic, bindings,
   examples, multibody, and sensors.

resolves #11549

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11869)
<!-- Reviewable:end -->
