### PR TITLE
Updates geometry::Identifier hash method

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -234,7 +234,10 @@ drake_cc_library(
     name = "identifier",
     srcs = [],
     hdrs = ["identifier.h"],
-    deps = ["//common:essential"],
+    deps = [
+        "//common:essential",
+        "//common:hash",
+    ],
 )
 
 drake_cc_library(
@@ -364,6 +367,7 @@ drake_cc_googletest(
     name = "identifier_test",
     deps = [
         ":identifier",
+        "//common:sorted_pair",
         "//common:unused",
         "//common/test_utilities:expect_throws_message",
     ],


### PR DESCRIPTION
`geometry::Identifier` predated the drake hash protocol. It was made to hash but its hash mechanism apparently precluded it being used in other entities that *did* use the drake hash protocol.

This changes the hash mechanism to conform and explicitly tests that `SortedPair<Identifier<Tag>>` is also hashable (as called out in issue 11578).

resolves #11578

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11872)
<!-- Reviewable:end -->
