### PR TITLE
Add effort limit to the joint actuator

### DIFF
--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -196,16 +196,17 @@ void AddJointActuatorFromSpecification(
         "An axis must be specified for joint '" + joint_spec.Name() + "'");
   }
 
-  double max_effort = axis->Effort();
+  // The effort_limit should always be non-negative. Negative effort will be
+  // treated as infinity as specified by the sdf standard.
+  const double effort_limit = axis->Effort() < 0
+                                  ? std::numeric_limits<double>::infinity()
+                                  : axis->Effort();
 
-  // The SDF specification defines this max_effort = -1 when no limit is
-  // provided (a non-zero value). In Drake we interpret a value of exactly zero
+  // In Drake we interpret a value of exactly zero
   // as a way to specify un-actuated joints. Thus, the user would say
   // <effort>0</effort> for un-actuated joints.
-  if (max_effort != 0) {
-    // TODO(amcastro-tri): For positive max_effort values, store it and use it
-    // to limit input actuation.
-    plant->AddJointActuator(joint_spec.Name(), joint);
+  if (effort_limit != 0) {
+    plant->AddJointActuator(joint_spec.Name(), joint, effort_limit);
   }
 }
 

--- a/multibody/parsing/test/sdf_parser_test/joint_actuator_parsing_test.sdf
+++ b/multibody/parsing/test/sdf_parser_test/joint_actuator_parsing_test.sdf
@@ -1,0 +1,102 @@
+<?xml version="1.0" ?>
+
+<!--
+Defines an SDF model with various types of joint limits used for testing the
+joint actuator parser. The only focus is the <effort> tag. Other values,
+therefore, are set arbitrarily.
+This is an accompanying file to detail_sdf_parser_test.cc and therefore they
+must be kept in sync with each other.
+-->
+
+<sdf version='1.6'>
+  <model name='joint_actuator_parsing_test'>
+    <link name='link1'>
+      <inertial>
+        <mass>1</mass>
+        <inertia>
+          <ixx>1.0</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>1.0</iyy>
+          <iyz>0</iyz>
+          <izz>1.0</izz>
+        </inertia>
+      </inertial>
+    </link>
+    <link name='link2'>
+      <inertial>
+        <mass>1</mass>
+        <inertia>
+          <ixx>1.0</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>1.0</iyy>
+          <iyz>0</iyz>
+          <izz>1.0</izz>
+        </inertia>
+      </inertial>
+    </link>
+    <joint name='revolute_joint_positive_limit' type='revolute'>
+      <child>link2</child>
+      <parent>link1</parent>
+      <axis>
+        <xyz>0 0 1</xyz>
+        <limit>
+          <lower>-1</lower>
+          <upper>2</upper>
+          <effort>100</effort>
+          <velocity>100</velocity>
+        </limit>
+      </axis>
+    </joint>
+    <link name='link3'>
+      <inertial>
+        <mass>1</mass>
+        <inertia>
+          <ixx>1.0</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>1.0</iyy>
+          <iyz>0</iyz>
+          <izz>1.0</izz>
+        </inertia>
+      </inertial>
+    </link>
+    <joint name='prismatic_joint_zero_limit' type='prismatic'>
+      <child>link3</child>
+      <parent>link2</parent>
+      <axis>
+        <xyz>0 0 1</xyz>
+        <limit>
+          <lower>-2</lower>
+          <upper>1</upper>
+          <effort>0</effort>
+          <velocity>5</velocity>
+        </limit>
+      </axis>
+    </joint>
+    <link name='link4'>
+      <inertial>
+        <mass>1</mass>
+        <inertia>
+          <ixx>1.0</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>1.0</iyy>
+          <iyz>0</iyz>
+          <izz>1.0</izz>
+        </inertia>
+      </inertial>
+    </link>
+    <joint name='revolute_joint_no_limit' type='revolute'>
+      <child>link4</child>
+      <parent>link3</parent>
+      <axis>
+        <xyz>0 0 1</xyz>
+        <limit>
+          <effort>-1</effort>
+        </limit>
+      </axis>
+    </joint>
+  </model>
+</sdf>

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <limits>
 #include <map>
 #include <memory>
 #include <string>
@@ -1006,14 +1007,22 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   ///   already exists in the model. See HasJointActuatorNamed().
   /// @param[in] joint
   ///   The Joint to be actuated by the new JointActuator.
+  /// @param[in] effort_limit
+  ///   The maximum effort for the actuator. It must be strictly positive,
+  ///   otherwise an std::exception is thrown. If +∞, the actuator has no limit,
+  ///   which is the default. The effort limit has physical units in accordance
+  ///   to the joint type it actuates. For instance, it will have units of
+  ///   N⋅m (torque) for revolute joints while it will have units of N (force)
+  ///   for prismatic joints.
   /// @returns A constant reference to the new JointActuator just added, which
   /// will remain valid for the lifetime of `this` plant.
   /// @throws std::exception if `joint.num_velocities() > 1` since for now we
   /// only support actuators for single dof joints.
   const JointActuator<T>& AddJointActuator(
-      const std::string& name, const Joint<T>& joint) {
+      const std::string& name, const Joint<T>& joint,
+      double effort_limit = std::numeric_limits<double>::infinity()) {
     DRAKE_THROW_UNLESS(joint.num_velocities() == 1);
-    return this->mutable_tree().AddJointActuator(name, joint);
+    return this->mutable_tree().AddJointActuator(name, joint, effort_limit);
   }
 
   /// Creates a new model instance.  Returns the index for the model

--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -451,4 +451,12 @@ drake_cc_googletest(
     ],
 )
 
+drake_cc_googletest(
+    name = "joint_actuator_test",
+    deps = [
+        ":tree",
+        "//common/test_utilities",
+    ],
+)
+
 add_lint_tests()

--- a/multibody/tree/joint_actuator.cc
+++ b/multibody/tree/joint_actuator.cc
@@ -7,11 +7,17 @@ namespace drake {
 namespace multibody {
 
 template <typename T>
-JointActuator<T>::JointActuator(
-    const std::string& name, const Joint<T>& joint)
+JointActuator<T>::JointActuator(const std::string& name, const Joint<T>& joint,
+                                double effort_limit)
     : MultibodyTreeElement<JointActuator<T>, JointActuatorIndex>(
           joint.model_instance()),
-    name_(name), joint_index_(joint.index()) {}
+      name_(name),
+      joint_index_(joint.index()),
+      effort_limit_(effort_limit) {
+  if (effort_limit_ <= 0.0) {
+    throw std::runtime_error("Effort limit must be strictly positive!");
+  }
+}
 
 template <typename T>
 const Joint<T>& JointActuator<T>::joint() const {
@@ -52,7 +58,7 @@ std::unique_ptr<JointActuator<double>>
 JointActuator<T>::DoCloneToScalar(
     const internal::MultibodyTree<double>&) const {
   return std::unique_ptr<JointActuator<double>>(
-      new JointActuator<double>(name_, joint_index_));
+      new JointActuator<double>(name_, joint_index_, effort_limit_));
 }
 
 template <typename T>
@@ -60,7 +66,7 @@ std::unique_ptr<JointActuator<AutoDiffXd>>
 JointActuator<T>::DoCloneToScalar(
     const internal::MultibodyTree<AutoDiffXd>&) const {
   return std::unique_ptr<JointActuator<AutoDiffXd>>(
-      new JointActuator<AutoDiffXd>(name_, joint_index_));
+      new JointActuator<AutoDiffXd>(name_, joint_index_, effort_limit_));
 }
 
 template <typename T>
@@ -68,7 +74,8 @@ std::unique_ptr<JointActuator<symbolic::Expression>>
 JointActuator<T>::DoCloneToScalar(
     const internal::MultibodyTree<symbolic::Expression>&) const {
   return std::unique_ptr<JointActuator<symbolic::Expression>>(
-      new JointActuator<symbolic::Expression>(name_, joint_index_));
+      new JointActuator<symbolic::Expression>(name_, joint_index_,
+                                              effort_limit_));
 }
 
 }  // namespace multibody

--- a/multibody/tree/multibody_tree-inl.h
+++ b/multibody/tree/multibody_tree-inl.h
@@ -370,7 +370,7 @@ const JointType<T>& MultibodyTree<T>::AddJoint(
 
 template <typename T>
 const JointActuator<T>& MultibodyTree<T>::AddJointActuator(
-    const std::string& name, const Joint<T>& joint) {
+    const std::string& name, const Joint<T>& joint, double effort_limit) {
   if (HasJointActuatorNamed(name, joint.model_instance())) {
     throw std::logic_error(
         "Model instance '" +
@@ -387,7 +387,8 @@ const JointActuator<T>& MultibodyTree<T>::AddJointActuator(
 
   const JointActuatorIndex actuator_index =
       topology_.add_joint_actuator(joint.num_velocities());
-  owned_actuators_.push_back(std::make_unique<JointActuator<T>>(name, joint));
+  owned_actuators_.push_back(
+      std::make_unique<JointActuator<T>>(name, joint, effort_limit));
   JointActuator<T>* actuator = owned_actuators_.back().get();
   actuator->set_parent_tree(this, actuator_index);
   actuator_name_to_index_.insert(std::make_pair(name, actuator_index));

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <limits>
 #include <memory>
 #include <string>
 #include <tuple>
@@ -522,6 +523,9 @@ class MultibodyTree {
   ///   HasJointActuatorNamed().
   /// @param[in] joint
   ///   The Joint to be actuated by the new JointActuator.
+  /// @param[in] effort_limit
+  ///   The maximum effort for the actuator. It must be greater than 0. If
+  ///   the user does not set this value, the default value is +∞.
   /// @returns A constant reference to the new JointActuator just added, which
   /// will remain valid for the lifetime of `this` %MultibodyTree.
   /// @throws std::exception if `this` model already contains a joint actuator
@@ -530,7 +534,8 @@ class MultibodyTree {
   // TODO(amcastro-tri): consider adding sugar method to declare an actuated
   // joint with a single call. Maybe MBT::AddActuatedJoint() or the like.
   const JointActuator<T>& AddJointActuator(
-      const std::string& name, const Joint<T>& joint);
+      const std::string& name, const Joint<T>& joint,
+      double effort_limit = std::numeric_limits<double>::infinity());
 
   /// Creates a new model instance.  Returns the index for a new model
   /// instance (as there is no concrete object beyond the index).

--- a/multibody/tree/test/joint_actuator_test.cc
+++ b/multibody/tree/test/joint_actuator_test.cc
@@ -1,0 +1,69 @@
+#include "drake/multibody/tree/joint_actuator.h"
+
+#include <limits>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+#include "drake/common/symbolic.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/multibody/tree/multibody_tree-inl.h"
+#include "drake/multibody/tree/prismatic_joint.h"
+#include "drake/multibody/tree/rigid_body.h"
+
+namespace drake {
+namespace multibody {
+namespace {
+
+constexpr double kPostiveEffortLimit = 1e3;
+constexpr double kZeroEffortLimit = 0;
+constexpr double kNegativeEffortLimit = -2;
+
+GTEST_TEST(JointActuatorTest, JointAcutatorLimitTest) {
+  auto tree_pointer = std::make_unique<internal::MultibodyTree<double>>();
+  internal::MultibodyTree<double>& tree = *tree_pointer;
+
+  // Spatial inertia for adding body. The actual value is not important for
+  // these tests and therefore we do not initialize it.
+  const SpatialInertia<double> M_B;  // Default construction is ok for this.
+
+  // Add bodies so we can add joints to them.
+  const auto body1 = &tree.AddBody<RigidBody>(M_B);
+  const auto body2 = &tree.AddBody<RigidBody>(M_B);
+  const auto body3 = &tree.AddBody<RigidBody>(M_B);
+
+  // Add a prismatic joint between the world and body1:
+  const Joint<double>& body1_world =
+      tree.AddJoint(std::make_unique<PrismaticJoint<double>>(
+          "prism1", tree.world_body().body_frame(), body1->body_frame(),
+          Eigen::Vector3d(0, 0, 1)));
+
+  tree.AddJointActuator("act1", body1_world, kPostiveEffortLimit);
+  // Validate the actuator effort limit has been setup correctly.
+  const auto& actuator1 = tree.GetJointActuatorByName("act1");
+  EXPECT_EQ(actuator1.effort_limit(), kPostiveEffortLimit);
+
+  // Throw is the effort limit is set to 0.
+  const Joint<double>& body2_body1 =
+      tree.AddJoint(std::make_unique<PrismaticJoint<double>>(
+          "prism2", body1->body_frame(), body2->body_frame(),
+          Eigen::Vector3d(0, 0, 1)));
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      tree.AddJointActuator("act2", body2_body1, kNegativeEffortLimit),
+      std::runtime_error, "Effort limit must be strictly positive!");
+
+  // Throw is the effort limit is set to be negative.
+  const Joint<double>& body3_body2 =
+      tree.AddJoint(std::make_unique<PrismaticJoint<double>>(
+          "prism3", body2->body_frame(), body3->body_frame(),
+          Eigen::Vector3d(0, 0, 1)));
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      tree.AddJointActuator("act3", body3_body2, kZeroEffortLimit),
+      std::runtime_error, "Effort limit must be strictly positive!");
+
+  tree.Finalize();
+}
+
+}  // namespace
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Add effort limits members to the joint actuator class, which allows the users to access to the effort limits  if they have been specified by the model file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11876)
<!-- Reviewable:end -->
