### PR TITLE
Revert "snopt: Use gfortran mode by default, not f2c"

### DIFF
--- a/doc/bazel.rst
+++ b/doc/bazel.rst
@@ -265,15 +265,16 @@ See https://docs.bazel.build/versions/master/user-manual.html#bazelrc.
 Drake offers two flavors of SNOPT bindings for the MathematicalProgram:
 
  - The ``--config snopt_f2c`` option selects the legacy bindings that use the
-   f2c compiler; these bindings will be removed on 2019-11-01.
+   f2c compiler; these bindings will be removed on 2019-08-01.
  - The ``--config snopt_fortran`` option selects the bindings that use the
    gfortran compiler; these bindings will be supported for the foreseeable
    future.
- - The ``--config snopt`` is synonymous with ``--config snopt_fortran``.
+ - The ``--config snopt`` option selects a default choice (currently f2c, but
+   will soon change to gfortran).
 
 The gfortran bindings are superior in several ways (such as being threadsafe),
-but have some known problems on certain programs (see drake issue `#10422
-<https://github.com/RobotLocomotion/drake/issues/10422>`_ for a summary).
+but have a known problem with unbounded linear programs (see drake issue
+`#10423 <https://github.com/RobotLocomotion/drake/issues/10423>`_).
 
 Optional Tools
 ==============

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -812,10 +812,11 @@ drake_cc_library(
 drake_cc_library(
     name = "snopt_solver",
     srcs = select({
-        # The `--config snopt` ("Use the default SNOPT flavor") is a synonym
-        # for `--config snopt_fortran` ("Use the Fortran SNOPT flavor").
+        # For now `--config snopt` ("Use the default SNOPT flavor") is a
+        # synonym for `--config snopt_f2c` ("Use the f2c SNOPT flavor").
+        # In the future, the default will change to be the Fortran flavor.
         "//tools:with_snopt": [
-            "snopt_solver.cc",
+            "snopt_solver_f2c.cc",
             "snopt_solver_common.cc",
         ],
         # This is always the Fortran flavor.
@@ -836,12 +837,12 @@ drake_cc_library(
     }),
     hdrs = ["snopt_solver.h"],
     deps = select({
-        # This is Drake's default flavor (Fortran).
+        # This is Drake's default flavor; currently f2c.
         "//tools:with_snopt": [
             ":mathematical_program_private",
             ":solver_base",
             "//math:autodiff",
-            "@snopt//:snopt_cwrap",
+            "@snopt//:snopt_c",
         ],
         # This is always the Fortran flavor.
         "//tools:with_snopt_fortran": [

--- a/solvers/snopt_solver_f2c.cc
+++ b/solvers/snopt_solver_f2c.cc
@@ -2,9 +2,6 @@
 #include "drake/solvers/snopt_solver.h"
 /* clang-format on */
 
-// NOLINTNEXTLINE(whitespace/line_length)
-#warning DRAKE DEPRECATED: The f2c-based SNOPT bindings are deprecated, in favor of the Fortran-based SNOPT bindings.  The f2c-based SNOPT bindings will be removed from Drake on or after 2019-11-01.
-
 #include <algorithm>
 #include <cstdio>
 #include <cstdlib>


### PR DESCRIPTION
This reverts commit ff62572b1af21da7fdb1b76d5c1cdac9bf651fb9.

The commit broke the `-everything` builds on Xenial.  Possibly SNOPT/Fortran when used with Gurobi and/or Mosek at the same time is a problem.

- https://drake-jenkins.csail.mit.edu/view/Production/job/linux-xenial-gcc-bazel-continuous-everything-release/1228/
- https://drake-jenkins.csail.mit.edu/view/Production/job/linux-xenial-clang-bazel-continuous-everything-release/1226/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11889)
<!-- Reviewable:end -->
