### PR TITLE
Making the gripper_brick example system public

### DIFF
--- a/examples/planar_gripper/BUILD.bazel
+++ b/examples/planar_gripper/BUILD.bazel
@@ -38,6 +38,7 @@ drake_cc_library(
         "//examples/planar_gripper:planar_brick.sdf",
         "//examples/planar_gripper:planar_gripper.sdf",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         "//common:find_resource",
         "//examples/planar_gripper:planar_gripper_common",


### PR DESCRIPTION
Making the gripper_brick example system public so that it can be used by projects that have drake as dependency

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11890)
<!-- Reviewable:end -->
