### PR TITLE
parsing: Fix asan error in unit test

### DIFF
--- a/multibody/parsing/test/detail_scene_graph_test.cc
+++ b/multibody/parsing/test/detail_scene_graph_test.cc
@@ -735,7 +735,7 @@ GTEST_TEST(SceneGraphParserDetail,
 
   // The expected orientation of the canonical frame C (in which the plane's
   // normal aligns with Cz) in the link frame L.
-  const RotationMatrix<double>& R_LG_expected =
+  const RotationMatrix<double> R_LG_expected =
       HalfSpace::MakePose(normal_L_expected, Vector3d::Zero()).rotation();
 
   // Verify results to precision given by kTolerance.


### PR DESCRIPTION
Lifetime extension only applies to the final captured const-reference, not any intermediate return values.

Repairs #11869.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11892)
<!-- Reviewable:end -->
