### PR TITLE
skylark: disable_in_compilation_mode_dbg checks lint

### DIFF
--- a/examples/schunk_wsg/test/schunk_wsg_lift_test.cc
+++ b/examples/schunk_wsg/test/schunk_wsg_lift_test.cc
@@ -106,7 +106,6 @@ class Sinusoid : public systems::LeafSystem<double> {
 // stepping approach.
 class SchunkWsgLiftTest : public ::testing::TestWithParam<bool> {
  protected:
-
   // Finds the single end-effector from a RigidBodyTree and returns it. Aborts
   // if there is more than one end-effector or more than one base link.
   RigidBody<double>* FindEndEffector(RigidBodyTree<double>* tree) {

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -543,12 +543,12 @@ def drake_cc_test(
         name,
         size = None,
         srcs = [],
+        args = [],
+        tags = [],
         deps = [],
         copts = [],
         gcc_copts = [],
         clang_copts = [],
-        disable_in_compilation_mode_dbg = False,
-        tags = [],
         **kwargs):
     """Creates a rule to declare a C++ unit test.  Note that for almost all
     cases, drake_cc_googletest should be used, instead of this rule.
@@ -556,10 +556,6 @@ def drake_cc_test(
     By default, sets size="small" because that indicates a unit test.
     By default, sets name="test/${name}.cc" per Drake's filename convention.
     Unconditionally forces testonly=1.
-
-    If disable_in_compilation_mode_dbg is True, the srcs will be suppressed
-    in debug-mode builds, so the test will trivially pass. This option should
-    be used only rarely, and the reason should always be documented.
     """
     if size == None:
         size = "small"
@@ -574,32 +570,14 @@ def drake_cc_test(
         copts = new_copts,
         **kwargs
     )
-    new_tags = tags
-    if disable_in_compilation_mode_dbg:
-        # Remove the test declarations from the test in debug mode.
-        # TODO(david-german-tri): Actually suppress the test rule.
-        new_srcs = select({
-            "//tools/cc_toolchain:debug": [],
-            "//conditions:default": new_srcs,
-        })
-
-        # Disable when run under various dynamic tools that use debug-like
-        # compiler flags.
-        new_tags = new_tags + [
-            "no_asan",
-            "no_kcov",
-            "no_lsan",
-            "no_memcheck",
-            "no_tsan",
-            "no_ubsan",
-        ]
     native.cc_test(
         name = name,
         size = size,
         srcs = new_srcs,
+        args = args,
+        tags = tags,
         deps = new_deps,
         copts = new_copts,
-        tags = new_tags,
         **kwargs
     )
 
@@ -617,7 +595,10 @@ def drake_cc_test(
 
 def drake_cc_googletest(
         name,
+        args = [],
+        tags = [],
         deps = [],
+        disable_in_compilation_mode_dbg = False,
         use_default_main = True,
         **kwargs):
     """Creates a rule to declare a C++ unit test using googletest.
@@ -627,9 +608,9 @@ def drake_cc_googletest(
     By default, sets use_default_main=True to use a default main() function.
     Otherwise, it will depend on @gtest//:without_main.
 
-    If disable_in_compilation_mode_dbg is True, the srcs will be suppressed
-    in debug-mode builds, so the test will trivially pass. This option should
-    be used only rarely, and the reason should always be documented.
+    If disable_in_compilation_mode_dbg is True, then in debug-mode builds all
+    test cases will be suppressed, so the test will trivially pass. This option
+    should be used only rarely, and the reason should always be documented.
     """
     if use_default_main:
         deps = deps + [
@@ -637,8 +618,30 @@ def drake_cc_googletest(
         ]
     else:
         deps = deps + ["@gtest//:without_main"]
+    new_args = args
+    new_tags = tags
+    if disable_in_compilation_mode_dbg:
+        # If we're in debug compilation mode, then skip all test cases so that
+        # the test will trivially pass.
+        new_args = args + select({
+            "//tools/cc_toolchain:debug": ["--gtest_filter=-*"],
+            "//conditions:default": [],
+        })
+
+        # Skip this test when run under various dynamic tools that use
+        # debug-like compiler flags.
+        new_tags = new_tags + [
+            "no_asan",
+            "no_kcov",
+            "no_lsan",
+            "no_memcheck",
+            "no_tsan",
+            "no_ubsan",
+        ]
     drake_cc_test(
         name = name,
+        args = new_args,
+        tags = new_tags,
         deps = deps,
         **kwargs
     )


### PR DESCRIPTION
Previously, the disabled tests were never linted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11899)
<!-- Reviewable:end -->
