### PR TITLE
doc: Fix formatting for link to old MATLAB tag

### DIFF
--- a/doc/from_source.rst
+++ b/doc/from_source.rst
@@ -72,7 +72,7 @@ Historical Note
 
 Prior to 2016, Drake was built around a substantial base of MATLAB software. To
 view the original MATLAB implementation, you may use the tag
-[last_sha_with_original_matlab](https://github.com/RobotLocomotion/drake/tree/last_sha_with_original_matlab).
+`last_sha_with_original_matlab <https://github.com/RobotLocomotion/drake/tree/last_sha_with_original_matlab>`_.
 Note, however, that the dependencies on this branch are out of date and we do
 not expect that you will be able to easily compile/run the code, and do not
 provide support for this.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11911)
<!-- Reviewable:end -->
