### PR TITLE
Adding OSPRay-based render engine

### DIFF
--- a/geometry/geometry_roles.h
+++ b/geometry/geometry_roles.h
@@ -157,7 +157,8 @@ class ProximityProperties final : public GeometryProperties {
 /** The set of properties for geometry used in a "perception" role.
 
  Examples of functionality that depends on the perception role:
-   - n/a
+   - render::RenderEngineVtk
+   - render::RenderEngineOspray
  */
 class PerceptionProperties final : public GeometryProperties{
  public:

--- a/geometry/render/BUILD.bazel
+++ b/geometry/render/BUILD.bazel
@@ -15,6 +15,7 @@ drake_cc_package_library(
     name = "render",
     deps = [
         ":render_engine",
+        ":render_engine_ospray",
         ":render_engine_vtk",
         ":render_label",
         ":render_label_class",
@@ -39,6 +40,40 @@ drake_cc_library(
         "//math:geometric_transform",
         "//systems/sensors:color_palette",
         "//systems/sensors:image",
+    ],
+)
+
+# The VTK-OSPRay-based render engine implementation.
+drake_cc_library(
+    name = "render_engine_ospray",
+    srcs = [
+        "render_engine_ospray.cc",
+        "render_engine_ospray_factory.cc",
+    ],
+    hdrs = [
+        "render_engine_ospray.h",
+        "render_engine_ospray_factory.h",
+    ],
+    # render_engine_ospray.h directly pulls in VTK headers; leave it out of the
+    # install.
+    install_hdrs_exclude = ["render_engine_ospray.h"],
+    deps = [
+        ":render_engine",
+        "//common",
+        "//systems/sensors:color_palette",
+        "//systems/sensors:vtk_util",
+        "@eigen",
+        "@vtk//:vtkCommonCore",
+        "@vtk//:vtkCommonDataModel",
+        "@vtk//:vtkCommonTransforms",
+        "@vtk//:vtkFiltersGeneral",
+        "@vtk//:vtkFiltersSources",
+        "@vtk//:vtkIOGeometry",
+        "@vtk//:vtkIOImage",
+        "@vtk//:vtkRenderingCore",
+        "@vtk//:vtkRenderingOSPRay",
+        "@vtk//:vtkRenderingOpenGL2",
+        "@vtk//:vtkRenderingSceneGraph",
     ],
 )
 
@@ -106,6 +141,21 @@ drake_cc_googletest(
         "//common/test_utilities",
         "//geometry:geometry_ids",
         "//geometry/test_utilities:dummy_render_engine",
+    ],
+)
+
+drake_cc_googletest(
+    name = "render_engine_ospray_test",
+    data = [
+        "//systems/sensors:test_models",
+    ],
+    tags = vtk_test_tags(),
+    deps = [
+        ":render_engine_ospray",
+        "//common:find_resource",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+        "//math:geometric_transform",
     ],
 )
 

--- a/geometry/render/render_engine_ospray.cc
+++ b/geometry/render/render_engine_ospray.cc
@@ -1,0 +1,529 @@
+#include "drake/geometry/render/render_engine_ospray.h"
+
+#include <limits>
+#include <stdexcept>
+#include <utility>
+
+#include <vtkCamera.h>
+#include <vtkCubeSource.h>
+#include <vtkCylinderSource.h>
+#include <vtkOBJReader.h>
+#include <vtkOSPRayLightNode.h>
+#include <vtkOSPRayMaterialLibrary.h>
+#include <vtkOSPRayRendererNode.h>
+#include <vtkOpenGLPolyDataMapper.h>
+#include <vtkOpenGLTexture.h>
+#include <vtkPNGReader.h>
+#include <vtkPlaneSource.h>
+#include <vtkProperty.h>
+#include <vtkSphereSource.h>
+#include <vtkTransform.h>
+#include <vtkTransformPolyDataFilter.h>
+
+#include "drake/systems/sensors/color_palette.h"
+#include "drake/systems/sensors/vtk_util.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+
+using Eigen::Vector3d;
+using Eigen::Vector4d;
+using math::RigidTransformd;
+using std::make_unique;
+using systems::sensors::ColorD;
+using systems::sensors::ColorI;
+using systems::sensors::ImageDepth32F;
+using systems::sensors::ImageLabel16I;
+using systems::sensors::ImageRgba8U;
+using systems::sensors::vtk_util::ConvertToVtkTransform;
+using systems::sensors::vtk_util::CreateSquarePlane;
+
+namespace {
+
+void SetModelTransformMatrixToVtkCamera(
+    vtkCamera* camera, const vtkSmartPointer<vtkTransform>& X_WC) {
+  // vtkCamera contains a transformation as the internal state and
+  // ApplyTransform multiplies a given transformation on top of the internal
+  // transformation. Thus, resetting 'Set{Position, FocalPoint, ViewUp}' is
+  // needed here.
+  camera->SetPosition(0., 0., 0.);
+  // Sets z-forward.
+  camera->SetFocalPoint(0., 0., 1.);
+  // Sets y-down. For the detail, please refer to CameraInfo's document.
+  camera->SetViewUp(0., -1, 0.);
+  camera->ApplyTransform(X_WC);
+}
+
+// Note: the kLabel and kDepth values are not currently used. They are left in
+// place for when this renderer can produce depth and label images.
+enum ImageType {
+  kColor = 0,
+  kLabel = 1,
+  kDepth = 2,
+};
+
+// TODO(SeanCurtis-TRI): Add X_PG pose to this data.
+// A package of data required to register a visual geometry.
+struct RegistrationData {
+  const PerceptionProperties& properties;
+  const RigidTransformd& X_FG;
+  const GeometryId id;
+  // The file name if the shape being registered is a mesh.
+  optional<std::string> mesh_filename;
+};
+
+std::string RemoveFileExtension(const std::string& filepath) {
+  const size_t last_dot = filepath.find_last_of(".");
+  if (last_dot == std::string::npos) {
+    throw std::logic_error("File has no extension.");
+  }
+  return filepath.substr(0, last_dot);
+}
+
+}  // namespace
+
+RenderEngineOspray::RenderEngineOspray(const RenderEngineOsprayParams& params)
+    : RenderEngine(RenderLabel::kUnspecified),
+      pipelines_{{make_unique<RenderingPipeline>()}},
+      render_mode_(params.mode) {
+  if (params.default_diffuse) {
+    default_diffuse_ = *params.default_diffuse;
+  }
+
+  if (params.background_color) {
+    const Vector3d& c = *params.background_color;
+    background_color_ = ColorD{c(0), c(1), c(2)};
+  }
+
+  InitializePipelines(params.samples_per_pixel);
+}
+
+void RenderEngineOspray::UpdateViewpoint(const RigidTransformd& X_WC) {
+  vtkSmartPointer<vtkTransform> vtk_X_WC = ConvertToVtkTransform(X_WC);
+
+  for (const auto& pipeline : pipelines_) {
+    auto camera = pipeline->renderer->GetActiveCamera();
+    SetModelTransformMatrixToVtkCamera(camera, vtk_X_WC);
+  }
+}
+
+void RenderEngineOspray::RenderColorImage(const CameraProperties& camera,
+                                          bool show_window,
+                                          ImageRgba8U* color_image_out) const {
+  UpdateWindow(camera, show_window, pipelines_[ImageType::kColor].get(),
+               "Color Image");
+  PerformVtkUpdate(*pipelines_[ImageType::kColor]);
+
+  // TODO(SeanCurtis-TRI): Determine if this copies memory (and find some way
+  // around copying).
+  auto& exporter = *pipelines_[ImageType::kColor]->exporter;
+  DRAKE_DEMAND(exporter.GetDataNumberOfScalarComponents() == 4);
+  exporter.Export(color_image_out->at(0, 0));
+
+  // In path tracing, the background contributes light energy to the rendering.
+  // However, the raytracer and gl renderers don't do this, it's simply a
+  // backdrop -- a color for pixels that weren't otherwise covered by geometry.
+  // We simulate that effect by blending the final pixels with the background
+  // color.
+  // TODO(SeanCurtis-TRI): Make this configurable; i.e., if we provide an hdmi
+  //  environment map, this shouldn't happen at all.
+  if (render_mode_ == OsprayMode::kPathTracer) {
+    using ChannelType = ImageRgba8U::Traits::ChannelType;
+    // Note: the cast truncates, by adding 0.5, it becomes rounding.
+    systems::sensors::ColorI rgb{
+        static_cast<ChannelType>(background_color_.r * 255 + 0.5),
+        static_cast<ChannelType>(background_color_.g * 255 + 0.5),
+        static_cast<ChannelType>(background_color_.b * 255 + 0.5)};
+
+    auto blend = [](ImageRgba8U::Traits::ChannelType channel,
+                    ImageRgba8U::Traits::ChannelType bg, double alpha) {
+      double combo = channel * alpha + bg * (1 - alpha);
+      return static_cast<ImageRgba8U::Traits::ChannelType>(combo);
+    };
+
+    for (int r = 0; r < color_image_out->height(); ++r) {
+      for (int c = 0; c < color_image_out->width(); ++c) {
+        ChannelType* pixel = color_image_out->at(c, r);
+        double alpha = pixel[3] / 255.0;
+        if (alpha < 1.0) {
+          pixel[0] = blend(pixel[0], rgb.r, alpha);
+          pixel[1] = blend(pixel[1], rgb.g, alpha);
+          pixel[2] = blend(pixel[2], rgb.b, alpha);
+        }
+      }
+    }
+  }
+}
+
+void RenderEngineOspray::RenderDepthImage(const DepthCameraProperties&,
+                                          ImageDepth32F*) const {
+  throw std::runtime_error("RenderEngineOspray does not support depth images");
+}
+
+void RenderEngineOspray::RenderLabelImage(const CameraProperties&, bool,
+                                       ImageLabel16I*) const {
+  throw std::runtime_error("RenderEngineOspray does not support label images");
+}
+
+void RenderEngineOspray::ImplementGeometry(const Sphere& sphere,
+                                           void* user_data) {
+  // TODO(SeanCurtis-TRI): OSPRay supports a primitive sphere; find some way to
+  //  exercise *that* instead of needlessly tesselating.
+  vtkNew<vtkSphereSource> vtk_sphere;
+  vtk_sphere->SetRadius(sphere.get_radius());
+  // TODO(SeanCurtis-TRI): Provide control for smoothness/tessellation.
+  vtk_sphere->SetThetaResolution(50);
+  vtk_sphere->SetPhiResolution(50);
+  ImplementGeometry(vtk_sphere.GetPointer(), user_data);
+}
+
+void RenderEngineOspray::ImplementGeometry(const Cylinder& cylinder,
+                                           void* user_data) {
+  // TODO(SeanCurtis-TRI): OSPRay supports a primitive cylinder; find some way
+  //  to exercise *that* instead of needlessly tesselating.
+  vtkNew<vtkCylinderSource> vtk_cylinder;
+  vtk_cylinder->SetHeight(cylinder.get_length());
+  vtk_cylinder->SetRadius(cylinder.get_radius());
+  // TODO(SeanCurtis-TRI): Provide control for smoothness/tessellation.
+  vtk_cylinder->SetResolution(50);
+
+  // Since the cylinder in vtkCylinderSource is y-axis aligned, we need
+  // to rotate it to be z-axis aligned because that is what Drake uses.
+  vtkNew<vtkTransform> transform;
+  transform->RotateX(90);
+  vtkNew<vtkTransformPolyDataFilter> transform_filter;
+  transform_filter->SetInputConnection(vtk_cylinder->GetOutputPort());
+  transform_filter->SetTransform(transform.GetPointer());
+  transform_filter->Update();
+
+  ImplementGeometry(transform_filter.GetPointer(), user_data);
+}
+
+void RenderEngineOspray::ImplementGeometry(const HalfSpace&, void* user_data) {
+  // TODO(SeanCurtis-TRI): Allow this to be configured upon construction.
+  const double kTerrainSize = 100.;
+  vtkSmartPointer<vtkPlaneSource> vtk_plane = CreateSquarePlane(kTerrainSize);
+
+  ImplementGeometry(vtk_plane.GetPointer(), user_data);
+}
+
+void RenderEngineOspray::ImplementGeometry(const Box& box, void* user_data) {
+  vtkNew<vtkCubeSource> cube;
+  cube->SetXLength(box.width());
+  cube->SetYLength(box.depth());
+  cube->SetZLength(box.height());
+  ImplementGeometry(cube.GetPointer(), user_data);
+}
+
+void RenderEngineOspray::ImplementGeometry(const Mesh& mesh, void* user_data) {
+  ImplementObj(mesh.filename(), mesh.scale(), user_data);
+}
+
+void RenderEngineOspray::ImplementGeometry(const Convex& convex,
+                                           void* user_data) {
+  ImplementObj(convex.filename(), convex.scale(), user_data);
+}
+
+bool RenderEngineOspray::DoRegisterVisual(
+    GeometryId id, const Shape& shape, const PerceptionProperties& properties,
+    const RigidTransformd& X_FG) {
+  // Note: the user_data interface on reification requires a non-const pointer.
+  RegistrationData data{properties, X_FG, id};
+  shape.Reify(this, &data);
+  return true;
+}
+
+RenderEngineOsprayParams RenderEngineOspray::get_params() const {
+  const int samples_per_pixel = vtkOSPRayRendererNode::GetSamplesPerPixel(
+      pipelines_[ImageType::kColor]->renderer);
+  return {
+      render_mode_, default_diffuse_,
+      Vector3d{background_color_.r, background_color_.g, background_color_.b},
+      samples_per_pixel};
+}
+
+void RenderEngineOspray::DoUpdateVisualPose(GeometryId id,
+                                            const RigidTransformd& X_WG) {
+  vtkSmartPointer<vtkTransform> vtk_X_WG = ConvertToVtkTransform(X_WG);
+  // TODO(SeanCurtis-TRI): Perhaps provide the ability to specify actors for
+  //  specific pipelines; i.e. only update the color actor or only the label
+  //  actor, etc.
+  for (const auto& actor : actors_.at(id)) {
+    actor->SetUserTransform(vtk_X_WG);
+  }
+}
+
+bool RenderEngineOspray::DoRemoveGeometry(GeometryId id) {
+  auto iter = actors_.find(id);
+
+  if (iter == actors_.end()) return false;
+
+  std::array<vtkSmartPointer<vtkActor>, kNumPipelines>& pipe_actors =
+      iter->second;
+  for (int i = 0; i < kNumPipelines; ++i) {
+    // If the label actor hasn't been added to its renderer, this is a no-op.
+    pipelines_[i]->renderer->RemoveActor(pipe_actors[i]);
+  }
+  actors_.erase(iter);
+  return true;
+}
+
+std::unique_ptr<RenderEngine> RenderEngineOspray::DoClone() const {
+  // Note: we can't use make_unique because the copy constructor is private.
+  return std::unique_ptr<RenderEngineOspray>(new RenderEngineOspray(*this));
+}
+
+// Note: this is a private copy constructor implemented solely to facilitate
+// cloning. This code should simply be rolled into DoClone(). (See the TODO
+// in the header file.)
+RenderEngineOspray::RenderEngineOspray(const RenderEngineOspray& other)
+    : RenderEngine(other),
+      pipelines_{{make_unique<RenderingPipeline>()}},
+      default_diffuse_{other.default_diffuse_},
+      background_color_{other.background_color_},
+      render_mode_(other.render_mode_) {
+  InitializePipelines(other.get_params().samples_per_pixel);
+
+  // Utility function for creating a cloned actor which *shares* the same
+  // underlying polygonal data.
+  auto clone_actor_array =
+      [this](const std::array<vtkSmartPointer<vtkActor>, kNumPipelines>&
+                 source_actors,
+             std::array<vtkSmartPointer<vtkActor>, kNumPipelines>*
+                 clone_actors_ptr) {
+        DRAKE_DEMAND(clone_actors_ptr != nullptr);
+        std::array<vtkSmartPointer<vtkActor>, kNumPipelines>& clone_actors =
+            *clone_actors_ptr;
+        for (int i = 0; i < kNumPipelines; ++i) {
+          // NOTE: source *should* be const; but none of the getters on the
+          // source are const-compatible.
+          DRAKE_DEMAND(source_actors[i]);
+          DRAKE_DEMAND(clone_actors[i]);
+          vtkActor& source = *source_actors[i];
+          vtkActor& clone = *clone_actors[i];
+
+          // TODO(SeanCurtis-TRI): Modify this once OSPRay-specific materials
+          //  are supported.
+          if (source.GetTexture() == nullptr) {
+            clone.GetProperty()->SetColor(source.GetProperty()->GetColor());
+            clone.GetProperty()->SetOpacity(source.GetProperty()->GetOpacity());
+          } else {
+            clone.SetTexture(source.GetTexture());
+          }
+
+          // NOTE: The clone renderer and original renderer *share* polygon
+          // data. If the meshes were *deformable* this would be invalid.
+          // Furthermore, even if dynamic adding/removing of geometry were
+          // valid, VTK's reference counting preserves the underlying geometry
+          // in the copy that still references it.
+          clone.SetMapper(source.GetMapper());
+          clone.SetUserTransform(source.GetUserTransform());
+
+          pipelines_.at(i)->renderer.Get()->AddActor(&clone);
+        }
+      };
+
+  for (const auto& other_id_actor_pair : other.actors_) {
+    std::array<vtkSmartPointer<vtkActor>, kNumPipelines> actors{
+        vtkSmartPointer<vtkActor>::New()};
+    clone_actor_array(other_id_actor_pair.second, &actors);
+    const GeometryId id = other_id_actor_pair.first;
+    actors_.insert({id, move(actors)});
+  }
+
+  // Copy camera properties
+  auto copy_cameras = [](auto src_renderer, auto dst_renderer) {
+    dst_renderer->GetActiveCamera()->DeepCopy(src_renderer->GetActiveCamera());
+  };
+  for (int p = 0; p < kNumPipelines; ++p) {
+    copy_cameras(other.pipelines_.at(p)->renderer.Get(),
+                 pipelines_.at(p)->renderer.Get());
+  }
+
+  // TODO(SeanCurtis-TRI): Copy light.
+}
+
+void RenderEngineOspray::InitializePipelines(int samples_per_pixel) {
+  const vtkSmartPointer<vtkTransform> vtk_identity =
+      ConvertToVtkTransform(RigidTransformd::Identity());
+
+  // TODO(SeanCurtis-TRI): Things like configuring lights should *not* be part
+  //  of initializing the pipelines. When we support light declaration, this
+  //  will get moved out.
+  light_->SetLightTypeToCameraLight();
+  light_->SetConeAngle(45.0);
+  light_->SetAttenuationValues(1.0, 0.0, 0.0);
+  light_->SetIntensity(1);
+  // OSPRay specific control, radius to get soft shadows.
+  if (render_mode_ == OsprayMode::kPathTracer) {
+    vtkOSPRayLightNode::SetRadius(1.0, light_);
+  }
+  light_->SetTransformMatrix(vtk_identity->GetMatrix());
+
+  // Generic configuration of pipelines.
+  for (auto& pipeline : pipelines_) {
+    // OSPRay specific configuration.
+    pipeline->renderer->SetPass(ospray_);
+    if (render_mode_ == OsprayMode::kRayTracer) {
+      vtkOSPRayRendererNode::SetRendererType("scivis", pipeline->renderer);
+      vtkOSPRayRendererNode::SetAmbientSamples(0, pipeline->renderer);
+      pipeline->renderer->UseShadowsOn();
+      // NOTE: It appears that ospray does [0, 1] -> [0, 255] conversion via
+      // truncation. So, to affect rounding, we have to bump the background
+      // color by half a bit so that it rounds properly.
+      const double delta = 0.5 / 255;
+      ColorD bg{background_color_.r + delta, background_color_.g + delta,
+                background_color_.b + delta};
+      pipeline->renderer->SetBackground(bg.r, bg.g, bg.b);
+    } else {
+      vtkOSPRayRendererNode::SetRendererType("pathtracer", pipeline->renderer);
+      vtkOSPRayRendererNode::SetSamplesPerPixel(samples_per_pixel,
+                                                pipeline->renderer);
+      // TODO(SeanCurtis-TRI): When our VTK library has been updated to include
+      //  the denoiser introduced in
+      //  https://gitlab.kitware.com/vtk/vtk/merge_requests/5297
+      //  make the denoiser and its threshold parameter available.
+      //  vtkOSPRayRendererNode::ENABLE_DENOISER();
+      //  vtkOSPRayRendererNode::SetEnableDenoiser(4, pipeline->renderer);
+    }
+    double np[3] = {0, 0, 1};
+    double ep[3] = {0, 1, 0};
+    vtkOSPRayRendererNode::SetNorthPole(np, pipeline->renderer);
+    vtkOSPRayRendererNode::SetEastPole(ep, pipeline->renderer);
+
+    auto camera = pipeline->renderer->GetActiveCamera();
+    camera->SetViewAngle(90.0);  // Default to an arbitrary 90° field of view.
+    SetModelTransformMatrixToVtkCamera(camera, vtk_identity);
+
+    pipeline->window->AddRenderer(pipeline->renderer.GetPointer());
+    pipeline->filter->SetInput(pipeline->window.GetPointer());
+    pipeline->filter->SetScale(1);
+    pipeline->filter->ReadFrontBufferOff();
+    pipeline->filter->SetInputBufferTypeToRGBA();
+    pipeline->exporter->SetInputData(pipeline->filter->GetOutput());
+    pipeline->exporter->ImageLowerLeftOff();
+
+    pipeline->renderer->AddLight(light_);
+  }
+}
+
+void RenderEngineOspray::ImplementObj(const std::string& file_name,
+                                      double scale, void* user_data) {
+  static_cast<RegistrationData*>(user_data)->mesh_filename = file_name;
+  vtkNew<vtkOBJReader> mesh_reader;
+  mesh_reader->SetFileName(file_name.c_str());
+  mesh_reader->Update();
+
+  vtkNew<vtkTransform> transform;
+  // TODO(SeanCurtis-TRI): Should I be allowing only isotropic scale.
+  // TODO(SeanCurtis-TRI): Only add the transform filter if scale is not all 1.
+  transform->Scale(scale, scale, scale);
+  vtkNew<vtkTransformPolyDataFilter> transform_filter;
+  transform_filter->SetInputConnection(mesh_reader->GetOutputPort());
+  transform_filter->SetTransform(transform.GetPointer());
+  transform_filter->Update();
+
+  ImplementGeometry(transform_filter.GetPointer(), user_data);
+}
+
+void RenderEngineOspray::ImplementGeometry(vtkPolyDataAlgorithm* source,
+                                           void* user_data) {
+  DRAKE_DEMAND(user_data != nullptr);
+
+  std::array<vtkSmartPointer<vtkActor>, kNumPipelines> actors{
+      vtkSmartPointer<vtkActor>::New()};
+  // Note: the mappers ultimately get referenced by the actors, so they do _not_
+  // get destroyed when this array goes out of scope.
+  std::array<vtkNew<vtkOpenGLPolyDataMapper>, kNumPipelines> mappers;
+
+  for (auto& mapper : mappers) {
+    mapper->SetInputConnection(source->GetOutputPort());
+  }
+
+  const RegistrationData& data =
+      *reinterpret_cast<RegistrationData*>(user_data);
+
+  // If the geometry is anchored, X_FG = X_WG so I'm setting the pose for
+  // anchored geometry -- for all other values of F, it is dynamic and will be
+  // re-written in the first pose update.
+  vtkSmartPointer<vtkTransform> vtk_X_PG = ConvertToVtkTransform(data.X_FG);
+
+  // Adds the actor into the specified pipeline.
+  auto connect_actor = [this, &actors, &mappers,
+      &vtk_X_PG](ImageType image_type) {
+    actors[image_type]->SetMapper(mappers[image_type].Get());
+    actors[image_type]->SetUserTransform(vtk_X_PG);
+    pipelines_[image_type]->renderer->AddActor(actors[image_type].Get());
+  };
+
+  // Color actor.
+  auto& color_actor = actors[ImageType::kColor];
+
+  // TODO(SeanCurtis-TRI): Modify this once OSPRay-specific materials are
+  //  supported.
+  const std::string& diffuse_map_name =
+      data.properties.GetPropertyOrDefault<std::string>("phong", "diffuse_map",
+                                                        "");
+  // Legacy support for *implied* texture maps. If we have mesh.obj, we look for
+  // mesh.png (unless one has been specifically called out in the properties).
+  // TODO(SeanCurtis-TRI): Remove this legacy texture when objects and materials
+  // are coherently specified by SDF/URDF/obj/mtl, etc.
+  std::string texture_name;
+  std::ifstream file_exist(diffuse_map_name);
+  if (file_exist) {
+    texture_name = diffuse_map_name;
+  } else if (diffuse_map_name.empty() && data.mesh_filename) {
+    // This is the hack to search for mesh.png as a possible texture.
+    const std::string
+    alt_texture_name(RemoveFileExtension(*data.mesh_filename) +
+        ".png");
+    std::ifstream alt_file_exist(alt_texture_name);
+    if (alt_file_exist) texture_name = alt_texture_name;
+  }
+  if (!texture_name.empty()) {
+    vtkNew<vtkPNGReader> texture_reader;
+    texture_reader->SetFileName(texture_name.c_str());
+    texture_reader->Update();
+    vtkNew<vtkOpenGLTexture> texture;
+    texture->SetInputConnection(texture_reader->GetOutputPort());
+    texture->InterpolateOn();
+    color_actor->SetTexture(texture.Get());
+  } else {
+    const Vector4d& diffuse =
+        data.properties.GetPropertyOrDefault("phong", "diffuse",
+                                             default_diffuse_);
+    color_actor->GetProperty()->SetColor(diffuse(0), diffuse(1), diffuse(2));
+    color_actor->GetProperty()->SetOpacity(diffuse(3));
+  }
+
+  connect_actor(ImageType::kColor);
+
+  // Take ownership of the actors.
+  actors_.insert({data.id, std::move(actors)});
+}
+
+void RenderEngineOspray::PerformVtkUpdate(const RenderingPipeline& p) {
+  p.window->Render();
+  // See the note in the VTK documentation about explicitly calling Modified
+  // on the filter:
+  // https://vtk.org/doc/nightly/html/classvtkWindowToImageFilter.html#details
+  p.filter->Modified();
+  p.filter->Update();
+}
+
+void RenderEngineOspray::UpdateWindow(const CameraProperties& camera,
+                                      bool show_window,
+                                      const RenderingPipeline* p,
+                                      const char* name) const {
+  // NOTE: This is a horrible hack for modifying what otherwise looks like
+  // const entities.
+  p->window->SetSize(camera.width, camera.height);
+  p->window->SetOffScreenRendering(!show_window);
+  if (show_window) p->window->SetWindowName(name);
+  p->renderer->GetActiveCamera()->SetViewAngle(camera.fov_y * 180 / M_PI);
+}
+
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/render_engine_ospray.h
+++ b/geometry/render/render_engine_ospray.h
@@ -1,0 +1,197 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include <vtkActor.h>
+#include <vtkAutoInit.h>
+#include <vtkImageExport.h>
+#include <vtkLight.h>
+#include <vtkNew.h>
+#include <vtkOSPRayPass.h>
+#include <vtkPolyDataAlgorithm.h>
+#include <vtkRenderWindow.h>
+#include <vtkRenderer.h>
+#include <vtkSmartPointer.h>
+#include <vtkWindowToImageFilter.h>
+
+#include "drake/geometry/render/render_engine.h"
+#include "drake/geometry/render/render_engine_ospray_factory.h"
+
+#ifndef DRAKE_DOXYGEN_CXX
+// This, and the ModuleInitVtkRenderingOpenGL2, provide the basis for enabling
+// VTK's OpenGL2 infrastructure.
+VTK_AUTOINIT_DECLARE(vtkRenderingOpenGL2)
+#endif
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace internal {
+
+struct ModuleInitVtkRenderingOpenGL2 {
+  ModuleInitVtkRenderingOpenGL2() {
+    VTK_AUTOINIT_CONSTRUCT(vtkRenderingOpenGL2)
+  }
+};
+
+}  // namespace internal
+
+/** See documentation for MakeRenderEngineOspray() for details.  */
+class RenderEngineOspray final
+    : public RenderEngine,
+      private internal::ModuleInitVtkRenderingOpenGL2 {
+ public:
+  // TODO(SeanCurtis-TRI): Swap these shenanigans with a legitimate removal of
+  //  all copy and move semantics. The current copy constructor's contents
+  //  should simply go into the DoClone() method. The appropriate time to do
+  //  this is with the VTK refactoring (resolving it here and for
+  //  RenderEngineVtk). See issue #11964.
+  /** @name Does not allow copy, move, or assignment  */
+  //@{
+#ifdef DRAKE_DOXYGEN_CXX
+  // Note: the copy constructor is actually private to serve as the basis for
+  // implementing the DoClone() method.
+  RenderEngineOspray(const RenderEngineOspray&) = delete;
+#endif
+  RenderEngineOspray& operator=(const RenderEngineOspray&) = delete;
+  RenderEngineOspray(RenderEngineOspray&&) = delete;
+  RenderEngineOspray& operator=(RenderEngineOspray&&) = delete;
+  //@}
+
+  /** Constructs the render engine with the given `parameters`  */
+  RenderEngineOspray(
+      const RenderEngineOsprayParams& parameters = RenderEngineOsprayParams());
+
+  /** @see RenderEngine::UpdateViewpoint().  */
+  void UpdateViewpoint(const math::RigidTransformd& X_WR) final;
+
+  /** @see RenderEngine::RenderColorImage().  */
+  void RenderColorImage(
+      const CameraProperties& camera, bool show_window,
+      systems::sensors::ImageRgba8U* color_image_out) const final;
+
+  /** @see RenderEngine::RenderDepthImage(). Currently throws as unimplemented.
+   */
+  void RenderDepthImage(
+      const DepthCameraProperties& camera,
+      systems::sensors::ImageDepth32F* depth_image_out) const final;
+
+  /** @see RenderEngine::RenderLabelImage(). Currently throws as unimplemented.
+   */
+  void RenderLabelImage(
+      const CameraProperties& camera, bool show_window,
+      systems::sensors::ImageLabel16I* label_image_out) const final;
+
+  /** @name    Shape reification  */
+  //@{
+  void ImplementGeometry(const Sphere& sphere, void* user_data) final;
+  void ImplementGeometry(const Cylinder& cylinder, void* user_data) final;
+  void ImplementGeometry(const HalfSpace& half_space, void* user_data) final;
+  void ImplementGeometry(const Box& box, void* user_data) final;
+  void ImplementGeometry(const Mesh& mesh, void* user_data) final;
+  void ImplementGeometry(const Convex& convex, void* user_data) final;
+  //@}
+
+  /** @name    Access the default properties
+
+   Provides access to the default values this instance of the render engine is
+   using. These values must be set at construction.  */
+  //@{
+
+  // TODO(SeanCurtis-TRI): Figure out a "default" material - material properties
+  //  and its representation (this will evolve when I support full OSPRay
+  //  materials).
+
+  const Eigen::Vector4d& default_diffuse() const { return default_diffuse_; }
+
+  const systems::sensors::ColorD& background_color() const {
+    return background_color_;
+  }
+
+  using RenderEngine::default_render_label;
+
+  //@}
+
+ private:
+  // @see RenderEngine::DoRegisterVisual().
+  bool DoRegisterVisual(GeometryId id, const Shape& shape,
+                        const PerceptionProperties& properties,
+                        const math::RigidTransformd& X_WG) final;
+
+  // Creates a copy of the set of parameters that were supplied when this
+  // instance was created.
+  RenderEngineOsprayParams get_params() const;
+
+  // @see RenderEngine::DoUpdateVisualPose().
+  void DoUpdateVisualPose(GeometryId id,
+                          const math::RigidTransformd& X_WG) final;
+
+  // @see RenderEngine::DoRemoveGeometry().
+  bool DoRemoveGeometry(GeometryId id) final;
+
+  // @see RenderEngine::DoClone().
+  std::unique_ptr<RenderEngine> DoClone() const final;
+
+  // Copy constructor for the purpose of cloning.
+  RenderEngineOspray(const RenderEngineOspray& other);
+
+  // Initializes the VTK pipelines.
+  void InitializePipelines(int samples_per_pixel);
+
+  // Common interface for loading an obj file -- used for both mesh and convex
+  // shapes.
+  void ImplementObj(const std::string& file_name, double scale,
+                    void* user_data);
+
+  // Performs the common setup for all shape types.
+  void ImplementGeometry(vtkPolyDataAlgorithm* source, void* user_data);
+
+  vtkNew<vtkLight> light_;
+
+  // A single pipeline (for now): rgb.
+  static constexpr int kNumPipelines = 1;
+
+  // The rendering pipeline for a single image type.
+  struct RenderingPipeline {
+    vtkNew<vtkRenderer> renderer;
+    vtkNew<vtkRenderWindow> window;
+    vtkNew<vtkWindowToImageFilter> filter;
+    vtkNew<vtkImageExport> exporter;
+  };
+
+  // Updates VTK rendering related objects including vtkRenderWindow,
+  // vtkWindowToImageFilter and vtkImageExporter, so that VTK reflects
+  // vtkActors' pose update for rendering.
+  static void PerformVtkUpdate(const RenderingPipeline& p);
+
+  // This actually modifies internal state; the pointer to a const pipeline
+  // allows mutation via the contained vtkNew pointers.
+  void UpdateWindow(const CameraProperties& camera, bool show_window,
+                    const RenderingPipeline* p, const char* name) const;
+
+  std::array<std::unique_ptr<RenderingPipeline>, kNumPipelines> pipelines_;
+
+  vtkNew<vtkOSPRayPass> ospray_;
+
+  // The collection of per-geometry actors (one actor per pipeline (color,
+  // depth, and label) keyed by the geometry's GeometryId.
+  std::unordered_map<GeometryId,
+                     std::array<vtkSmartPointer<vtkActor>, kNumPipelines>>
+      actors_;
+
+  // Color to assign to objects that define no color.
+  Eigen::Vector4d default_diffuse_{0.9, 0.45, 0.1, 1.0};
+
+  // The background color -- a sky blue.
+  systems::sensors::ColorD background_color_{204 / 255., 229 / 255.,
+                                             255 / 255.};
+
+  // Configuration to use path tracer or ray tracer.
+  const OsprayMode render_mode_{OsprayMode::kPathTracer};
+};
+
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/render_engine_ospray_factory.cc
+++ b/geometry/render/render_engine_ospray_factory.cc
@@ -1,0 +1,16 @@
+#include "drake/geometry/render/render_engine_ospray_factory.h"
+
+#include "drake/geometry/render/render_engine_ospray.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+
+std::unique_ptr<RenderEngine> MakeRenderEngineOspray(
+    const RenderEngineOsprayParams& params) {
+  return std::make_unique<RenderEngineOspray>(params);
+}
+
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/render_engine_ospray_factory.h
+++ b/geometry/render/render_engine_ospray_factory.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <memory>
+
+#include "drake/geometry/render/render_engine.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+
+/** The mode in which the RenderEngineOspray performs.
+
+ The ray tracer can produce hard shadows and doesn't depend on the samples per
+ pixel value. Ray tracing produces *simple* illumination effects at a relatively
+ low computation cost.
+
+ The path tracer produces complex global illumination and depends on the samples
+ per pixel. Path tracing produces *complex* illumination effects (caustics,
+ indirect illumination, soft shadows, etc.) at a high computation cost.  */
+enum class OsprayMode {
+  kRayTracer,
+  kPathTracer
+};
+
+// TODO(SeanCurtis-TRI): Add configuration features:
+//  - require ospray-specific materials -- i.e., don't accept (phong, diffuse)
+//    as a material definition.
+//  - background texture
+/** Construction parameters for the RenderEngineOspray.  */
+struct RenderEngineOsprayParams {
+  /** The rendering mode to use.  */
+  OsprayMode mode{OsprayMode::kPathTracer};
+
+  /** The (optional) rgba color to apply to the (phong, diffuse) property when
+    none is otherwise specified. Note: currently the alpha channel is unused
+    by RenderEngineOspray.  */
+  optional<Eigen::Vector4d> default_diffuse{};
+
+  // TODO(SeanCurtis-TRI): Reconcile this with a specified background image.
+  /** The rgb color for the environment background (each channel in the range
+   [0, 1]). The default value is the same color as in the equivalent byte-valued
+   rgb triple [204, 229, 255].  */
+  optional<Eigen::Vector3d> background_color{};
+
+  /** The number of illumination samples per pixel. Higher numbers introduce
+   higher quality at increased cost. Only has an effect if mode is
+   OsprayMode::kPathTracer.  */
+  int samples_per_pixel{1};
+};
+
+/** Constructs a RenderEngine implementation which uses an OSPRay-based
+ renderer.
+
+ @anchor render_engine_ospray_properties
+ <h2>Geometry perception properties</h2>
+
+ This RenderEngine implementation looks for the following properties when
+ registering visual geometry.
+
+ <h3>RGB images</h3>
+
+ | Group name | Property Name | Required |  Property Type  | Property Description |
+ | :--------: | :-----------: | :------: | :-------------: | :------------------- |
+ |    phong   | diffuse       | no¹      | Eigen::Vector4d | The rgba value of the object surface. |
+
+ ¹ If no diffuse value is given, a default rgba value will be applied. The
+   default color is a bright orange. This default value can be changed to a
+   different value at construction.
+
+ @warning This RenderEngine implementation contains a sophisticated renderer
+ for advanced lighting and material affects. The above documented behavior is
+ the smallest slice. In the future, the advanced features will be exposed and
+ it will change the properties that expect to be provided.
+
+ <h3>Depth images</h3>
+
+ This RenderEngine implementation does not currently support depth images.
+
+ <h3>Label images</h3>
+
+ This RenderEngine implementation does not currently support label images.
+
+ <h3>Geometries accepted by %RenderEngineVtk</h3>
+
+ As documented in RenderEngine::RegisterVisual(), a RenderEngine implementation
+ can use the properties found in the PerceptionProperties to determine whether
+ it _accepts_ a shape provided for registration. this RenderEngine
+ implementation makes use of defaults to accept _all_ geometries.
+
+ @warning When the API extends to include advanced materials, this will change
+ to only accept geometries that have valid OSPRay materials defined.  */
+std::unique_ptr<RenderEngine> MakeRenderEngineOspray(
+    const RenderEngineOsprayParams& params);
+
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/test/render_engine_ospray_test.cc
+++ b/geometry/render/test/render_engine_ospray_test.cc
@@ -1,0 +1,749 @@
+#include "drake/geometry/render/render_engine_ospray.h"
+
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+#include <Eigen/Dense>
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/render/camera_properties.h"
+#include "drake/geometry/shape_specification.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/math/rotation_matrix.h"
+#include "drake/systems/sensors/image.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace {
+
+using Eigen::AngleAxisd;
+using Eigen::Vector3d;
+using Eigen::Vector4d;
+using math::RigidTransformd;
+using math::RotationMatrixd;
+using std::make_unique;
+using std::unique_ptr;
+using std::unordered_map;
+using std::vector;
+using systems::sensors::Color;
+using systems::sensors::ColorI;
+using systems::sensors::ColorD;
+using systems::sensors::ImageDepth32F;
+using systems::sensors::ImageLabel16I;
+using systems::sensors::ImageRgba8U;
+
+// Default camera properties.
+const int kWidth = 640;
+const int kHeight = 480;
+const double kZNear = 0.5;
+const double kZFar = 5.;
+const double kFovY = M_PI_4;
+const bool kShowWindow = false;
+
+// The following tolerance is used due to a precision difference between Ubuntu
+// Linux and Mac OSX.
+const double kColorPixelTolerance = 1.001;
+
+// Background (sky) and terrain colors.
+const ColorI kBgColor = {254u, 127u, 0u};
+const ColorD kTerrainColorD{0., 0., 0.};
+const ColorI kTerrainColorI{0, 0, 0};
+
+// Provide a default visual color for these tests -- it is intended to be
+// different from the default color of the VTK render engine.
+const ColorI kDefaultVisualColor = {229u, 229u, 229u};
+// Distance between the camera and the z = 0 ground plane.
+const float kDefaultDistance{3.f};
+
+// Values to be used with the "centered shape" tests.
+// The amount inset from the edge of the images to *still* expect ground plane
+// values.
+static constexpr int kInset{10};
+
+// Holds `(x, y)` indices of the screen coordinate system where the ranges of
+// `x` and `y` are [0, image_width) and [0, image_height) respectively.
+struct ScreenCoord {
+  int x{};
+  int y{};
+};
+
+std::ostream& operator<<(std::ostream& out, const ScreenCoord& c) {
+  out << "(" << c.x << ", " << c.y << ")";
+  return out;
+}
+
+// Utility struct for doing color testing; provides three mechanisms for
+// creating a common rgba color. We get colors from images (as a pointer to
+// unsigned bytes, as a (ColorI, alpha) pair, and from a normalized color. It's
+// nice to articulate tests without having to worry about those details.
+struct RgbaColor {
+  RgbaColor(const Color<int>& c, int alpha)
+      : r(c.r), g(c.g), b(c.b), a(alpha) {}
+  explicit RgbaColor(const uint8_t* p) : r(p[0]), g(p[1]), b(p[2]), a(p[3]) {}
+  explicit RgbaColor(const Vector4d& norm_color)
+      : r(static_cast<int>(norm_color(0) * 255)),
+        g(static_cast<int>(norm_color(1) * 255)),
+        b(static_cast<int>(norm_color(2) * 255)),
+        a(static_cast<int>(norm_color(3) * 255)) {}
+  int r;
+  int g;
+  int b;
+  int a;
+};
+
+std::ostream& operator<<(std::ostream& out, const RgbaColor& c) {
+  out << "(" << c.r << ", " << c.g << ", " << c.b << ", " << c.a << ")";
+  return out;
+}
+
+// Tests color within tolerance.
+bool IsColorNear(
+    const RgbaColor& expected, const RgbaColor& tested,
+    double tolerance = kColorPixelTolerance) {
+  using std::abs;
+  return (abs(expected.r - tested.r) < tolerance &&
+      abs(expected.g - tested.g) < tolerance &&
+      abs(expected.b - tested.b) < tolerance &&
+      abs(expected.a - tested.a) < tolerance);
+}
+
+// Tests that the color in the given `image` located at screen coordinate `p`
+// matches the `expected` color to within the given `tolerance`.
+::testing::AssertionResult CompareColor(
+    const RgbaColor& expected, const ImageRgba8U& image, const ScreenCoord& p,
+    double tolerance = kColorPixelTolerance) {
+  RgbaColor tested(image.at(p.x, p.y));
+  if (IsColorNear(expected, tested, tolerance)) {
+    return ::testing::AssertionSuccess();
+  }
+  return ::testing::AssertionFailure() << "Expected: " << expected
+                                       << " at " << p
+                                       << ", tested: " << tested
+                                       << " with tolerance: " << tolerance;
+}
+
+// This test suite facilitates a test with a ground plane and floating shape.
+// The camera is positioned above the shape looking straight down. All
+// of the images produced from these tests should have the following properties:
+//   1. The shape is centered.
+//   2. The ground plane fills the whole background (i.e., no background color
+//      should be visible), except for noted exceptions.
+//   3. The rendered shape should be smaller than the full image size with a
+//      minimum number of pixels of ground plane between the shape and the edge
+//      of the image. The minimum number of pixels is defined by kInset.
+//
+// The tests examine the rendered images and tests some discrete pixels, mapped
+// to the image size (w, h):
+//   1. A "center" pixel (x, y) such that x = w / 2 and y = h / 2.
+//   2. Border pixels (xᵢ, yᵢ) which are pixels inset from each corner:
+//      e.g., (i, i), (w - i - 1, i), (w - i - 1, h - i - 1), (i, h - i - 1),
+//      for an inset value of `i` pixels.
+class RenderEngineOsprayTest : public ::testing::Test {
+ public:
+  RenderEngineOsprayTest()
+      : color_(kWidth, kHeight),
+        // Looking straight down from kDefaultDistance meters above the ground.
+        X_WC_(RotationMatrixd{AngleAxisd(M_PI, Vector3d::UnitY()) *
+                              AngleAxisd(-M_PI_2, Vector3d::UnitZ())},
+              {0, 0, kDefaultDistance}),
+        geometry_id_(GeometryId::get_new_id()) {}
+
+ protected:
+  // Method to allow the normal case (render with the built-in renderer against
+  // the default camera) to the member images with default window visibility.
+  // This interface allows that to be completely reconfigured by the calling
+  // test.
+  void Render(RenderEngineOspray* renderer = nullptr,
+              const DepthCameraProperties* camera_in = nullptr,
+              ImageRgba8U* color_out = nullptr) {
+    if (!renderer) renderer = renderer_.get();
+    const DepthCameraProperties& camera = camera_in ? *camera_in : camera_;
+    ImageRgba8U* color = color_out ? color_out : &color_;
+    renderer->RenderColorImage(camera, kShowWindow, color);
+  }
+
+  // Confirms that all pixels in the member color image have the same value.
+  void VerifyUniformColor(const ColorI& pixel, int alpha) {
+    const RgbaColor test_color{pixel, alpha};
+    for (int y = 0; y < kHeight; ++y) {
+      for (int x = 0; x < kWidth; ++x) {
+        ASSERT_TRUE(CompareColor(test_color, color_, ScreenCoord{x, y}));
+      }
+    }
+  }
+
+  // Compute the set of outliers for a given set of camera properties.
+  static vector<ScreenCoord> GetOutliers(const CameraProperties& camera) {
+    return vector<ScreenCoord>{
+        {kInset, kInset},
+        {kInset, camera.height - kInset - 1},
+        {camera.width - kInset - 1, camera.height - kInset - 1},
+        {camera.width - kInset - 1, kInset}};
+  }
+
+  // Compute the inlier for the given set of camera properties.
+  static ScreenCoord GetInlier(const CameraProperties& camera) {
+    return ScreenCoord{camera.width / 2, camera.height / 2};
+  }
+
+  // Verifies the "outlier" pixels for the given camera belong to the ground
+  // plane. If images are provided, the given images will be tested, otherwise
+  // the member images will be tested.
+  void VerifyOutliers(const RenderEngineOspray& renderer,
+                      const DepthCameraProperties& camera,
+                      const char* name,
+                      ImageRgba8U* color_in = nullptr) {
+    ImageRgba8U& color = color_in ? *color_in : color_;
+
+    for (const auto& screen_coord : GetOutliers(camera)) {
+      EXPECT_TRUE(CompareColor(expected_outlier_color_, color, screen_coord))
+                << "Color at: " << screen_coord << " for test: " << name;
+    }
+  }
+
+  void SetUp() override {
+    ResetExpectations();
+  }
+
+  // Tests that don't instantiate their own renderers should invoke this.
+  void Init(const RigidTransformd& X_WR, bool add_terrain = false) {
+    const Vector3d bg_rgb{
+        kBgColor.r / 255., kBgColor.g / 255., kBgColor.b / 255.};
+    RenderEngineOsprayParams params{OsprayMode::kRayTracer, {}, bg_rgb, 1};
+    renderer_ = make_unique<RenderEngineOspray>(params);
+    InitializeRenderer(X_WR, add_terrain, renderer_.get());
+    // Ensure that we truly have a non-default color.
+    EXPECT_FALSE(IsColorNear(
+        RgbaColor(kDefaultVisualColor, 1.),
+        RgbaColor(renderer_->default_diffuse())));
+  }
+
+  // Tests that instantiate their own renderers can initialize their renderers
+  // with this method.
+  void InitializeRenderer(const RigidTransformd& X_WR, bool add_terrain,
+                          RenderEngineOspray* engine) {
+    engine->UpdateViewpoint(X_WR);
+
+    if (add_terrain) {
+      PerceptionProperties material;
+      material.AddProperty("label", "id", RenderLabel::kDontCare);
+      material.AddProperty(
+          "phong", "diffuse",
+          Vector4d{kTerrainColorD.r, kTerrainColorD.g, kTerrainColorD.b, 1.0});
+      engine->RegisterVisual(GeometryId::get_new_id(), HalfSpace(), material,
+                             RigidTransformd::Identity(),
+                             false /** needs update */);
+    }
+  }
+
+  // Creates a simple perception properties set for fixed, known results.
+  PerceptionProperties simple_material() const {
+    PerceptionProperties material;
+    Vector4d color_n(default_color_.r / 255., default_color_.g / 255.,
+                     default_color_.b / 255., default_color_.a / 255.);
+    material.AddProperty("phong", "diffuse", color_n);
+    return material;
+  }
+
+  // Resets all expected values to the initial, default values.
+  void ResetExpectations() {
+    expected_color_ = RgbaColor{kDefaultVisualColor, 255};
+    expected_outlier_color_ = RgbaColor(kTerrainColorI, 255);
+  }
+
+  // Populates the given renderer with the sphere required for
+  // PerformCenterShapeTest().
+  void PopulateSphereTest(RenderEngineOspray* renderer) {
+    Sphere sphere{0.5};
+    renderer->RegisterVisual(geometry_id_, sphere, simple_material(),
+                             RigidTransformd::Identity(),
+                             true /* needs update */);
+    RigidTransformd X_WV{Vector3d{0, 0, 0.5}};
+    X_WV_.clear();
+    X_WV_.insert({geometry_id_, X_WV});
+    renderer->UpdatePoses(X_WV_);
+  }
+
+  // Performs the work to test the rendering with a shape centered in the
+  // image. To pass, the renderer will have to have been populated with a
+  // compatible shape and camera configuration (e.g., PopulateSphereTest()).
+  void PerformCenterShapeTest(RenderEngineOspray* renderer,
+                              const char* name,
+                              const DepthCameraProperties* camera = nullptr) {
+    const DepthCameraProperties& cam = camera ? *camera : camera_;
+    // Can't use the member images in case the camera has been configured to a
+    // different size than the default camera_ configuration.
+    ImageRgba8U color(cam.width, cam.height);
+    Render(renderer, &cam, &color);
+
+    VerifyOutliers(*renderer, cam, name, &color);
+
+    // Verifies inside the sphere.
+    const ScreenCoord inlier = GetInlier(cam);
+    EXPECT_TRUE(CompareColor(expected_color_, color, inlier))
+              << "Color at: " << inlier << " for test: " << name;
+  }
+
+  RgbaColor expected_color_{kDefaultVisualColor, 255};
+  RgbaColor expected_outlier_color_{kDefaultVisualColor, 255};
+  RgbaColor default_color_{kDefaultVisualColor, 255};
+
+  const DepthCameraProperties camera_ = {kWidth, kHeight, kFovY, "unused",
+                                         kZNear, kZFar};
+
+  ImageRgba8U color_;
+  RigidTransformd X_WC_;
+  GeometryId geometry_id_;
+
+  // The pose of the sphere created in PopulateSphereTest().
+  unordered_map<GeometryId, RigidTransformd> X_WV_;
+
+  unique_ptr<RenderEngineOspray> renderer_;
+};
+
+// Tests an empty image -- confirms that it clears to the "empty" color -- no
+// use of "inlier" or "outlier" pixel locations.
+TEST_F(RenderEngineOsprayTest, NoBodyTest) {
+  Init(RigidTransformd::Identity());
+  Render();
+
+  VerifyUniformColor(kBgColor, 0u);
+}
+
+// Confirm that the color image background color gets successfully configured.
+TEST_F(RenderEngineOsprayTest, ControlBackgroundColor) {
+  std::vector<ColorI> backgrounds{{10, 20, 30}, {128, 196, 255}, {255, 10, 40}};
+  for (const auto& bg : backgrounds) {
+    RenderEngineOsprayParams params{
+        OsprayMode::kRayTracer,
+        {},
+        Vector3d{bg.r / 255., bg.g / 255., bg.b / 255.},
+        1};
+    RenderEngineOspray engine(params);
+    Render(&engine);
+    VerifyUniformColor(bg, 0u);
+  }
+}
+
+// Tests an image with *only* terrain (perpendicular to the camera's forward
+// direction) -- no use of "inlier" or "outlier" pixel locations.
+TEST_F(RenderEngineOsprayTest, TerrainTest) {
+  Init(X_WC_, true);
+  const Vector3d p_WR = X_WC_.translation();
+
+  // At two different distances.
+  for (auto depth : std::array<float, 2>({{2.f, 4.9999f}})) {
+    X_WC_.set_translation({p_WR(0), p_WR(1), depth});
+    renderer_->UpdateViewpoint(X_WC_);
+    Render();
+    VerifyUniformColor(kTerrainColorI, 255u);
+  }
+
+  // Closer than kZNear.
+  X_WC_.set_translation({p_WR(0), p_WR(1), kZNear - 1e-5});
+  renderer_->UpdateViewpoint(X_WC_);
+  Render();
+  VerifyUniformColor(kTerrainColorI, 255u);
+
+  // Farther than kZFar.
+  X_WC_.set_translation({p_WR(0), p_WR(1), kZFar + 1e-3});
+  renderer_->UpdateViewpoint(X_WC_);
+  Render();
+  VerifyUniformColor(kTerrainColorI, 255u);
+}
+
+// Creates a terrain and then positions the camera such that a horizon between
+// terrain and sky appears -- no use of "inlier" or "outlier" pixel locations.
+TEST_F(RenderEngineOsprayTest, HorizonTest) {
+  // Camera at the origin, pointing in a direction parallel to the ground.
+  RigidTransformd X_WR{RotationMatrixd{AngleAxisd(-M_PI_2, Vector3d::UnitX()) *
+      AngleAxisd(M_PI_2, Vector3d::UnitY())}};
+  Init(X_WR, true);
+
+  // Returns y in [0, kHeight / 2], index of horizon location in image
+  // coordinate system under two assumptions: 1) the ground plane is not clipped
+  // by `kClippingPlaneFar`, 2) camera is located above the ground.
+  auto CalcHorizon = [](double z) {
+    const double kTerrainSize = 50.;
+    const double kFocalLength = kHeight * 0.5 / std::tan(0.5 * kFovY);
+    return 0.5 * kHeight + z / kTerrainSize * kFocalLength;
+  };
+
+  // Verifies v index of horizon at three different camera heights.
+  const Vector3d p_WR = X_WR.translation();
+  for (const double z : {2., 1., 0.5}) {
+    X_WR.set_translation({p_WR(0), p_WR(1), z});
+    renderer_->UpdateViewpoint(X_WR);
+    Render();
+
+    int actual_horizon{0};
+    for (int y = 0; y < kHeight; ++y) {
+      // Looking for the boundary between the sky and the ground.
+      if ((static_cast<uint8_t>(kBgColor.r != color_.at(0, y)[0])) ||
+          (static_cast<uint8_t>(kBgColor.g != color_.at(0, y)[1])) ||
+          (static_cast<uint8_t>(kBgColor.b != color_.at(0, y)[2]))) {
+        actual_horizon = y;
+        break;
+      }
+    }
+
+    const double expected_horizon = CalcHorizon(z);
+    // Confirm that the horizon is within one pixel + epsilon of where we
+    // expect it to be.
+    ASSERT_NEAR(expected_horizon, actual_horizon, 1.001);
+  }
+}
+
+// Performs the shape-centered-in-the-image test with a box.
+TEST_F(RenderEngineOsprayTest, BoxTest) {
+  Init(X_WC_, true);
+
+  // Sets up a box.
+  Box box(1, 1, 1);
+  const GeometryId id = GeometryId::get_new_id();
+  renderer_->RegisterVisual(id, box, simple_material(),
+                            RigidTransformd::Identity(),
+                            true /* needs update */);
+  RigidTransformd X_WV{RotationMatrixd{AngleAxisd(M_PI, Vector3d::UnitX())},
+                       Vector3d{0, 0, 0.5}};
+  renderer_->UpdatePoses(
+      unordered_map<GeometryId, RigidTransformd>{{id, X_WV}});
+
+  PerformCenterShapeTest(renderer_.get(), "Box test");
+}
+
+// Performs the shape-centered-in-the-image test with a sphere.
+TEST_F(RenderEngineOsprayTest, SphereTest) {
+  Init(X_WC_, true);
+
+  PopulateSphereTest(renderer_.get());
+
+  PerformCenterShapeTest(renderer_.get(), "Sphere test");
+}
+
+// Performs the shape-centered-in-the-image test with a sphere.
+TEST_F(RenderEngineOsprayTest, TransparentSphereTest) {
+  RenderEngineOspray renderer;
+  InitializeRenderer(X_WC_, true /* add terrain */, &renderer);
+  const int int_alpha = 128;
+  default_color_ = RgbaColor(kDefaultVisualColor, int_alpha);
+  PopulateSphereTest(&renderer);
+  Render(&renderer);
+
+  // Note: With an alpha value of 128, the resulting color value at the inlier
+  // should be 50% terrain color and 50% visual color. The resultant alpha will
+  // always be a full 255 (because the background is a full 255).
+  auto blend = [](const ColorI& c1, const ColorI& c2, double alpha) {
+    int r = static_cast<int>(c1.r * alpha + (c2.r * (1 - alpha)));
+    int g = static_cast<int>(c1.g * alpha + (c2.g * (1 - alpha)));
+    int b = static_cast<int>(c1.b * alpha + (c2.b * (1 - alpha)));
+    return ColorI{r, g, b};
+  };
+  const double linear_factor = int_alpha / 255.0;
+  const RgbaColor expect_linear{
+      blend(kDefaultVisualColor, kTerrainColorI, linear_factor), 255};
+
+  const ScreenCoord inlier = GetInlier(camera_);
+  EXPECT_TRUE(CompareColor(expect_linear, color_, inlier));
+}
+
+// Performs the shape-centered-in-the-image test with a cylinder.
+TEST_F(RenderEngineOsprayTest, CylinderTest) {
+  Init(X_WC_, true);
+
+  // Sets up a cylinder.
+  Cylinder cylinder(0.2, 1.2);
+  const GeometryId id = GeometryId::get_new_id();
+  renderer_->RegisterVisual(id, cylinder, simple_material(),
+                            RigidTransformd::Identity(),
+                            true /* needs update */);
+  // Position the top of the cylinder to be 1 m above the terrain.
+  RigidTransformd X_WV{Vector3d{0, 0, 0.4}};
+  renderer_->UpdatePoses(
+      unordered_map<GeometryId, RigidTransformd>{{id, X_WV}});
+
+  PerformCenterShapeTest(renderer_.get(), "Cylinder test");
+}
+
+// Performs the shape-centered-in-the-image test with a mesh (which happens to
+// be a box). This simultaneously confirms that if a diffuse_map is specified
+// but it doesn't refer to a file that can be read, that the appearance defaults
+// to the diffuse rgba value.
+TEST_F(RenderEngineOsprayTest, MeshTest) {
+  Init(X_WC_, true);
+
+  auto filename =
+      FindResourceOrThrow("drake/systems/sensors/test/models/meshes/box.obj");
+  Mesh mesh(filename);
+  PerceptionProperties material = simple_material();
+  material.AddProperty("phong", "diffuse_map", "bad_path");
+  const GeometryId id = GeometryId::get_new_id();
+  renderer_->RegisterVisual(id, mesh, material, RigidTransformd::Identity(),
+                            true /* needs update */);
+  renderer_->UpdatePoses(unordered_map<GeometryId, RigidTransformd>{
+      {id, RigidTransformd::Identity()}});
+
+  PerformCenterShapeTest(renderer_.get(), "Mesh test");
+}
+
+// Performs the shape-centered-in-the-image test with a *textured* mesh (which
+// happens to be a box).
+TEST_F(RenderEngineOsprayTest, TextureMeshTest) {
+  Init(X_WC_, true);
+
+  auto filename =
+      FindResourceOrThrow("drake/systems/sensors/test/models/meshes/box.obj");
+  Mesh mesh(filename);
+  PerceptionProperties material = simple_material();
+  material.AddProperty(
+      "phong", "diffuse_map",
+      FindResourceOrThrow("drake/systems/sensors/test/models/meshes/box.png"));
+  const GeometryId id = GeometryId::get_new_id();
+  renderer_->RegisterVisual(id, mesh, material, RigidTransformd::Identity(),
+                            true /* needs update */);
+  renderer_->UpdatePoses(unordered_map<GeometryId, RigidTransformd>{
+      {id, RigidTransformd::Identity()}});
+
+  // box.png contains a single pixel with the color (4, 241, 33). If the image
+  // changes, the expected color would likewise have to change.
+  expected_color_ = RgbaColor(ColorI{4, 241, 33}, 255);
+  PerformCenterShapeTest(renderer_.get(), "Textured mesh test");
+
+  // Now confirm that the texture survives cloning.
+  unique_ptr<RenderEngine> clone = renderer_->Clone();
+  EXPECT_NE(dynamic_cast<RenderEngineOspray*>(clone.get()), nullptr);
+  PerformCenterShapeTest(dynamic_cast<RenderEngineOspray*>(clone.get()),
+                         "Cloned mesh test");
+}
+
+// Repeat the texture test but with an *implied* texture map. In other words,
+// registering a mesh "foo.obj" will look for a "foo.png" in the same folder as
+// a fall back and use it if found. But *only* as a back up. This is a
+// SHORT TERM hack to get textures in.
+TEST_F(RenderEngineOsprayTest, ImpliedTextureMeshTest) {
+  Init(X_WC_, true);
+
+  auto filename =
+      FindResourceOrThrow("drake/systems/sensors/test/models/meshes/box.obj");
+  Mesh mesh(filename);
+  PerceptionProperties material = simple_material();
+  const GeometryId id = GeometryId::get_new_id();
+  renderer_->RegisterVisual(id, mesh, material, RigidTransformd::Identity(),
+                            true /* needs update */);
+  renderer_->UpdatePoses(unordered_map<GeometryId, RigidTransformd>{
+      {id, RigidTransformd::Identity()}});
+
+  // box.png contains a single pixel with the color (4, 241, 33). If the image
+  // changes, the expected color would likewise have to change.
+  expected_color_ = RgbaColor(ColorI{4, 241, 33}, 255);
+  PerformCenterShapeTest(renderer_.get(), "Implied textured mesh test");
+}
+
+// This confirms that geometries are correctly removed from the render engine.
+// We add two new geometries (testing the rendering after each addition).
+// We remove the first of the added geometries -- because it's occluded, there
+// should be no image change. Then by removing the second we should restore
+// the original default image.
+//
+// The default image is based on a sphere sitting on a plane at z = 0 with the
+// camera located above the sphere's center and aimed at that center.
+// THe default sphere is drawn with `●`, the first added sphere with `x`, and
+// the second with `o`. The height of the top of each sphere and its depth in
+// the camera's depth sensors are indicated as zᵢ and dᵢ, i ∈ {0, 1, 2},
+// respectively.
+//
+//             /|\       <---- camera_z = 3
+//              v
+//
+//
+//
+//
+//            ooooo       <---- z₂ = 4r = 2, d₂ = 1
+//          oo     oo
+//         o         o
+//        o           o
+//        o           o
+//        o   xxxxx   o   <---- z₁ = 3r = 1.5, d₁ = 1.5
+//         oxx     xxo
+//         xoo     oox
+//        x   ooooo   x
+//        x   ●●●●●   x   <---- z₀ = 2r = 1, d₀ = 2
+//        x ●●     ●● x
+//         ●         ●
+//        ● xx     xx ●
+// z      ●   xxxxx   ●
+// ^      ●           ●
+// |       ●         ●
+// |        ●●     ●●
+// |__________●●●●●____________
+//
+TEST_F(RenderEngineOsprayTest, RemoveVisual) {
+  Init(X_WC_, true);
+  PopulateSphereTest(renderer_.get());
+  RgbaColor default_color = expected_color_;
+
+  // Positions a sphere centered at <0, 0, z> with the given color.
+  auto add_sphere = [this](const RgbaColor& diffuse, double z,
+                           GeometryId geometry_id) {
+    const double kRadius = 0.5;
+    Sphere sphere{kRadius};
+    Vector4d norm_diffuse{diffuse.r / 255., diffuse.g / 255., diffuse.b / 255.,
+                          diffuse.a / 255.};
+    PerceptionProperties material;
+    material.AddProperty("phong", "diffuse", norm_diffuse);
+
+    renderer_->RegisterVisual(geometry_id, sphere, material,
+                              RigidTransformd::Identity());
+    RigidTransformd X_WV{Vector3d{0, 0, z}};
+    X_WV_.insert({geometry_id, X_WV});
+    renderer_->UpdatePoses(X_WV_);
+  };
+
+  // Sets the expected values prior to calling PerformCenterShapeTest().
+  auto set_expectations = [this](const RgbaColor& color) {
+    expected_color_ = color;
+  };
+
+  // Add another sphere of a different color in front of the default sphere
+  const RgbaColor color1(Color<int>{128, 128, 255}, 255);
+  const GeometryId id1 = GeometryId::get_new_id();
+  add_sphere(color1, 0.75, id1);
+  set_expectations(color1);
+  PerformCenterShapeTest(renderer_.get(), "First sphere added in remove test");
+
+  // Add a _third_ sphere in front of the second.
+  const RgbaColor color2(Color<int>{128, 255, 128}, 255);
+  const GeometryId id2 = GeometryId::get_new_id();
+  add_sphere(color2, 1.0, id2);
+  set_expectations(color2);
+  PerformCenterShapeTest(renderer_.get(), "Second sphere added in remove test");
+
+  // Remove the first sphere added; should report "true" and the render test
+  // should pass without changing expectations.
+  bool removed = renderer_->RemoveGeometry(id1);
+  EXPECT_TRUE(removed);
+  PerformCenterShapeTest(renderer_.get(), "First added sphere removed");
+
+  // Remove the second added sphere; should report true and rendering should
+  // return to its default configuration.
+  removed = renderer_->RemoveGeometry(id2);
+  EXPECT_TRUE(removed);
+  set_expectations(default_color);
+  PerformCenterShapeTest(renderer_.get(),
+                         "Default image restored by removing extra geometries");
+}
+
+// All of the clone tests use the PerformCenterShapeTest() with the sphere setup
+// to confirm that the clone is behaving as anticipated.
+
+// Tests that the cloned renderer produces the same images (i.e., passes the
+// same test).
+TEST_F(RenderEngineOsprayTest, SimpleClone) {
+  Init(X_WC_, true);
+  PopulateSphereTest(renderer_.get());
+  PerformCenterShapeTest(renderer_.get(), "base_case");
+
+  unique_ptr<RenderEngine> clone = renderer_->Clone();
+  EXPECT_NE(dynamic_cast<RenderEngineOspray*>(clone.get()), nullptr);
+  PerformCenterShapeTest(static_cast<RenderEngineOspray*>(clone.get()),
+                         "Simple clone");
+}
+
+// Tests that the cloned renderer still works, even when the original is
+// deleted.
+TEST_F(RenderEngineOsprayTest, ClonePersistence) {
+  Init(X_WC_, true);
+  PopulateSphereTest(renderer_.get());
+
+  unique_ptr<RenderEngine> clone = renderer_->Clone();
+  // This causes the original renderer copied from to be destroyed.
+  renderer_.reset();
+  ASSERT_EQ(nullptr, renderer_);
+  PerformCenterShapeTest(static_cast<RenderEngineOspray*>(clone.get()),
+                         "Clone persistence");
+}
+
+// Tests that the cloned renderer still works, even when the original has values
+// changed.
+TEST_F(RenderEngineOsprayTest, CloneIndependence) {
+  Init(X_WC_, true);
+  PopulateSphereTest(renderer_.get());
+
+  unique_ptr<RenderEngine> clone = renderer_->Clone();
+  // Move the terrain *up* 10 units in the z.
+  RigidTransformd X_WT_new{Vector3d{0, 0, 10}};
+  renderer_->UpdatePoses(
+      unordered_map<GeometryId, RigidTransformd>{{geometry_id_, X_WT_new}});
+  PerformCenterShapeTest(static_cast<RenderEngineOspray*>(clone.get()),
+                         "Clone independence");
+}
+
+// Confirm that the renderer can be used for cameras with different properties.
+// I.e., the camera intrinsics are defined *outside* the renderer.
+TEST_F(RenderEngineOsprayTest, DifferentCameras) {
+  Init(X_WC_, true);
+  PopulateSphereTest(renderer_.get());
+
+  // Baseline -- confirm that all of the defaults in this test still produce
+  // the expected outcome.
+  PerformCenterShapeTest(renderer_.get(), "Camera change - baseline", &camera_);
+
+  // Test changes in sensor sizes.
+  {
+    // Now run it again with a camera with a smaller sensor (quarter area).
+    DepthCameraProperties small_camera{camera_};
+    small_camera.width /= 2;
+    small_camera.height /= 2;
+    PerformCenterShapeTest(renderer_.get(), "Camera change - small camera",
+                           &small_camera);
+
+    // Now run it again with a camera with a bigger sensor (4X area).
+    DepthCameraProperties big_camera{camera_};
+    big_camera.width *= 2;
+    big_camera.height *= 2;
+    PerformCenterShapeTest(renderer_.get(), "Camera change - big camera",
+                           &big_camera);
+  }
+
+  // Test changes in fov (larger and smaller).
+  {
+    DepthCameraProperties narrow_fov(camera_);
+    narrow_fov.fov_y /= 2;
+    PerformCenterShapeTest(renderer_.get(), "Camera change - narrow fov",
+                           &narrow_fov);
+
+    DepthCameraProperties wide_fov(camera_);
+    wide_fov.fov_y *= 2;
+    PerformCenterShapeTest(renderer_.get(), "Camera change - wide fov",
+                           &wide_fov);
+  }
+}
+
+// Confirms that efforts to render depth or label images throw.
+TEST_F(RenderEngineOsprayTest, UnsupportedLabelAndDepth) {
+  Init(X_WC_, true);
+
+  ImageDepth32F depth(camera_.width, camera_.height);
+  ImageLabel16I label(camera_.width, camera_.height);
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      renderer_->RenderDepthImage(camera_, &depth), std::runtime_error,
+      "RenderEngineOspray does not support depth images");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      renderer_->RenderLabelImage(camera_, false, &label), std::runtime_error,
+      "RenderEngineOspray does not support label images");
+}
+
+// TODO(SeanCurtis-TRI): When we have a denoiser available, test this against
+//  the pathtracer configuraiton and samples value.
+
+}  // namespace
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
This version of the ospray render engine does not exploit advanced materials. This pass emphasizes backwards compatibility with the VTK render engine. The goal is to have the population of the rendered world be the same; the only difference should lie in how the light propagates.

There is a *significant* amount of common code between `RenderEngineOspray` and `RenderEngineVtk`. This will be revisited in subsequent PRs. Either refactoring or, for preference, rolling the OSPRay render into `RenderEngineVtk` as a configurable option for the color image renderer.

The testing is a *strict* subset of `render_engine_vtk_test.cc` (no depth or label functionality is being tested).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11916)
<!-- Reviewable:end -->
