### PR TITLE
Fixed show_contact visualizer script to properly scale force arrows

### DIFF
--- a/tools/workspace/drake_visualizer/plugin/show_contact.py
+++ b/tools/workspace/drake_visualizer/plugin/show_contact.py
@@ -96,7 +96,8 @@ class ContactVisualizer(object):
                 collision_pair_to_forces[key2].append(
                     (point, point + force * scale))
             else:
-                collision_pair_to_forces[key1] = [(point, point + force * scale)]
+                collision_pair_to_forces[key1] =
+                    [(point, point + force * scale)]
 
         for key, list_of_forces in iteritems(collision_pair_to_forces):
             d = DebugData()

--- a/tools/workspace/drake_visualizer/plugin/show_contact.py
+++ b/tools/workspace/drake_visualizer/plugin/show_contact.py
@@ -96,8 +96,8 @@ class ContactVisualizer(object):
                 collision_pair_to_forces[key2].append(
                     (point, point + force * scale))
             else:
-                collision_pair_to_forces[key1] =
-                    [(point, point + force * scale)]
+                collision_pair_to_forces[key1] = [(point,
+                    point + force * scale)]
 
         for key, list_of_forces in iteritems(collision_pair_to_forces):
             d = DebugData()

--- a/tools/workspace/drake_visualizer/plugin/show_contact.py
+++ b/tools/workspace/drake_visualizer/plugin/show_contact.py
@@ -64,6 +64,20 @@ class ContactVisualizer(object):
 
         # A map from pair of body names to a list of contact forces
         collision_pair_to_forces = {}
+
+        # Scale all arrows by the largest force.
+        max_mag = 1e-4
+        for contact in msg.contact_info:
+            force = np.array([contact.contact_force[0],
+                              contact.contact_force[1],
+                              contact.contact_force[2]])
+            mag = np.linalg.norm(force)
+            if mag > max_mag:
+                max_mag = mag
+
+        # .1 is the length of the arrow for the largest force
+        scale = .1 / max_mag
+
         for contact in msg.contact_info:
             point = np.array([contact.contact_point[0],
                               contact.contact_point[1],
@@ -71,21 +85,18 @@ class ContactVisualizer(object):
             force = np.array([contact.contact_force[0],
                               contact.contact_force[1],
                               contact.contact_force[2]])
-            mag = np.linalg.norm(force)
-            if mag > 1e-4:
-                mag = 0.3 / mag
 
             key1 = (str(contact.body1_name), str(contact.body2_name))
             key2 = (str(contact.body2_name), str(contact.body1_name))
 
             if key1 in collision_pair_to_forces:
                 collision_pair_to_forces[key1].append(
-                    (point, point + mag * force))
+                    (point, point + force * scale))
             elif key2 in collision_pair_to_forces:
                 collision_pair_to_forces[key2].append(
-                    (point, point + mag * force))
+                    (point, point + force * scale))
             else:
-                collision_pair_to_forces[key1] = [(point, point + mag * force)]
+                collision_pair_to_forces[key1] = [(point, point + force * scale)]
 
         for key, list_of_forces in iteritems(collision_pair_to_forces):
             d = DebugData()


### PR DESCRIPTION
The existing script scales all arrows to a length of 0.1, destroying relative size of the force vectors. This version scales the largest to 0.1, preserving relative size.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11918)
<!-- Reviewable:end -->
