### PR TITLE
Add SetSolverOptions to set all options at once

### DIFF
--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -800,6 +800,12 @@ top-level documentation for :py:mod:`pydrake.math`.
           doc.MathematicalProgram.SetSolverOption.doc)
       .def("SetSolverOption", &SetSolverOptionBySolverType<string>,
           doc.MathematicalProgram.SetSolverOption.doc)
+      .def("SetSolverOptions",
+          [](MathematicalProgram& prog, const SolverOptions& options) {
+            prog.SetSolverOptions(options);
+          },
+          py::arg("solver_options"),
+          doc.MathematicalProgram.SetSolverOptions.doc)
       // TODO(m-chaturvedi) Add Pybind11 documentation.
       .def("GetSolverOptions",
           [](MathematicalProgram& prog, SolverId solver_id) {

--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -800,11 +800,7 @@ top-level documentation for :py:mod:`pydrake.math`.
           doc.MathematicalProgram.SetSolverOption.doc)
       .def("SetSolverOption", &SetSolverOptionBySolverType<string>,
           doc.MathematicalProgram.SetSolverOption.doc)
-      .def("SetSolverOptions",
-          [](MathematicalProgram& prog, const SolverOptions& options) {
-            prog.SetSolverOptions(options);
-          },
-          py::arg("solver_options"),
+      .def("SetSolverOptions", &MathematicalProgram::SetSolverOptions,
           doc.MathematicalProgram.SetSolverOptions.doc)
       // TODO(m-chaturvedi) Add Pybind11 documentation.
       .def("GetSolverOptions",

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -585,6 +585,11 @@ class TestMathematicalProgram(unittest.TestCase):
         self.assertDictEqual(
             options, {"double_key": 1.0, "int_key": 2, "string_key": "3"})
 
+        prog.SetSolverOptions(options_object)
+        prog_options = prog.GetSolverOptions(solver_id)
+        self.assertDictEqual(
+            prog_options, {"double_key": 1.0, "int_key": 2, "string_key": "3"})
+
     def test_infeasible_constraints(self):
         prog = mp.MathematicalProgram()
         x = prog.NewContinuousVariables(1)

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -2373,6 +2373,10 @@ class MathematicalProgram {
     solver_options_.SetOption(solver_id, solver_option, option_value);
   }
 
+  void SetSolverOptions(const SolverOptions& solver_options) {
+    solver_options_ = solver_options;
+  }
+
   /**
    * Returns the solver options stored inside MathematicalProgram.
    */

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -2373,6 +2373,10 @@ class MathematicalProgram {
     solver_options_.SetOption(solver_id, solver_option, option_value);
   }
 
+  /**
+   * Overwrite the stored solver options inside MathematicalProgram with the
+   * provided solver options.
+   */
   void SetSolverOptions(const SolverOptions& solver_options) {
     solver_options_ = solver_options;
   }

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -2792,6 +2792,19 @@ GTEST_TEST(TestMathematicalProgram, TestSolverOptions) {
   prog.SetSolverOption(solver_id, "string_name", "3");
   EXPECT_EQ(prog.GetSolverOptionsStr(solver_id).at("string_name"), "3");
   EXPECT_EQ(prog.GetSolverOptionsStr(wrong_solver_id).size(), 0);
+
+  const SolverId dummy_id("dummy_id");
+  SolverOptions dummy_options;
+  dummy_options.SetOption(dummy_id, "double_name", 10.0);
+  dummy_options.SetOption(dummy_id, "int_name", 20);
+  dummy_options.SetOption(dummy_id, "string_name", "30.0");
+  prog.SetSolverOptions(dummy_options);
+  EXPECT_EQ(prog.GetSolverOptionsDouble(dummy_id).at("double_name"), 10.0);
+  EXPECT_EQ(prog.GetSolverOptionsDouble(solver_id).size(), 0);
+  EXPECT_EQ(prog.GetSolverOptionsInt(dummy_id).at("int_name"), 20);
+  EXPECT_EQ(prog.GetSolverOptionsInt(solver_id).size(), 0);
+  EXPECT_EQ(prog.GetSolverOptionsStr(dummy_id).at("string_name"), "30.0");
+  EXPECT_EQ(prog.GetSolverOptionsStr(solver_id).size(), 0);
 }
 
 void CheckNewNonnegativePolynomial(


### PR DESCRIPTION
Allows solver options to be set by a provided `SolverOptions`, rather than individually. This is useful in cases where multiple mathematical programs are created using the same solver options (for example,  when a problem is being solved multiple times in parallel).

+@jwnimmer-tri for feature review, thanks!
+@sherm1 for platform review, thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11933)
<!-- Reviewable:end -->
