### PR TITLE
Use alpha value from diffuse color specification

### DIFF
--- a/geometry/render/render_engine_vtk.cc
+++ b/geometry/render/render_engine_vtk.cc
@@ -341,6 +341,7 @@ RenderEngineVtk::RenderEngineVtk(const RenderEngineVtk& other)
 
       if (source.GetTexture() == nullptr) {
         clone.GetProperty()->SetColor(source.GetProperty()->GetColor());
+        clone.GetProperty()->SetOpacity(source.GetProperty()->GetOpacity());
       } else {
         clone.SetTexture(source.GetTexture());
       }
@@ -538,8 +539,13 @@ void RenderEngineVtk::ImplementGeometry(vtkPolyDataAlgorithm* source,
         data.properties.GetPropertyOrDefault("phong", "diffuse",
                                              default_diffuse_);
     color_actor->GetProperty()->SetColor(diffuse(0), diffuse(1), diffuse(2));
-    // TODO(SeanCurtis-TRI): Make use of alpha.
+    color_actor->GetProperty()->SetOpacity(diffuse(3));
   }
+  // TODO(SeanCurtis-TRI): Determine if this precludes modulating the texture
+  //  with arbitrary rgba values (e.g., tinting red or making everything
+  //  slightly transparent). In other words, should opacity be set regardless
+  //  of whether a texture exists?
+
   connect_actor(ImageType::kColor);
 
   // Depth actor; always gets wired in with no additional work.

--- a/geometry/render/render_engine_vtk_factory.h
+++ b/geometry/render/render_engine_vtk_factory.h
@@ -37,16 +37,15 @@ struct RenderEngineVtkParams  {
 
  | Group name | Property Name | Required |  Property Type  | Property Description |
  | :--------: | :-----------: | :------: | :-------------: | :------------------- |
- |    phong   | diffuse       | no¹      | Eigen::Vector4d | The rgba² value of the object surface. |
- |    phong   | diffuse_map   | no³      | std::string     | The path to a texture to apply to the geometry.⁴ |
+ |    phong   | diffuse       | no¹      | Eigen::Vector4d | The rgba value of the object surface. |
+ |    phong   | diffuse_map   | no²      | std::string     | The path to a texture to apply to the geometry.³ |
 
  ¹ If no diffuse value is given, a default rgba value will be applied. The
    default color is a bright orange. This default value can be changed to a
    different value at construction. <br>
- ² WARNING: The alpha channel is currently ignored. <br>
- ³ If no path is specified, or the file cannot be read, the diffuse rgba value
+ ² If no path is specified, or the file cannot be read, the diffuse rgba value
    is used (or its default).
- ⁴ %RenderEngineVtk implements a legacy feature for associating textures with
+ ³ %RenderEngineVtk implements a legacy feature for associating textures with
    _meshes_. If _no_ `(phong, diffuse_map)` property is provided (or it refers
    to a file that doesn't exist), for a mesh named `/path/to/mesh.obj`,
    %RenderEngineVtk will search for a file `/path/to/mesh.png` (replacing "obj"


### PR DESCRIPTION
Previously, it was documented that the alpha values was not used and a TODO was put in place indicating that it should be used. Now it is used and under test. Documentation has been likewise updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11943)
<!-- Reviewable:end -->
