### PR TITLE
common: Break out filesystem helpers into their own component

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -31,6 +31,7 @@ drake_cc_package_library(
         ":dummy_value",
         ":essential",
         ":extract_double",
+        ":filesystem",
         ":find_resource",
         ":find_runfiles",
         ":hash",
@@ -301,11 +302,21 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "filesystem",
+    srcs = ["filesystem.cc"],
+    hdrs = ["filesystem.h"],
+    deps = [
+        "@fmt",
+    ],
+)
+
+drake_cc_library(
     name = "find_runfiles",
     srcs = ["find_runfiles.cc"],
     hdrs = ["find_runfiles.h"],
     deps = [
         ":essential",
+        ":filesystem",
         "@bazel_tools//tools/cpp/runfiles",
     ],
 )
@@ -331,6 +342,7 @@ drake_cc_library(
     deps = [
         ":drake_marker_shared_library",
         ":essential",
+        ":filesystem",
         ":find_runfiles",
     ],
 )
@@ -835,6 +847,15 @@ drake_cc_googletest(
     deps = [
         ":essential",
         ":extract_double",
+    ],
+)
+
+drake_cc_googletest(
+    name = "filesystem_test",
+    deps = [
+        ":filesystem",
+        ":temp_directory",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/common/filesystem.cc
+++ b/common/filesystem.cc
@@ -1,0 +1,44 @@
+#include "drake/common/filesystem.h"
+
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <stdexcept>
+
+#include "fmt/format.h"
+
+namespace drake {
+namespace internal {
+
+bool IsFile(const std::string& filesystem_path) {
+  struct stat attributes{};
+  int error = stat(filesystem_path.c_str(), &attributes);
+  if (error) { return false; }
+  return S_ISREG(attributes.st_mode);
+}
+
+bool IsDir(const std::string& filesystem_path) {
+  struct stat attributes{};
+  int error = stat(filesystem_path.c_str(), &attributes);
+  if (error) { return false; }
+  return S_ISDIR(attributes.st_mode);
+}
+
+std::string Readlink(const std::string& pathname) {
+  std::string result;
+  result.resize(4096);
+  ssize_t length = ::readlink(pathname.c_str(), &result.front(), result.size());
+  if (length < 0) {
+    throw std::runtime_error(fmt::format(
+        "Could not open {}", pathname));
+  }
+  if (length >= static_cast<ssize_t>(result.size())) {
+    throw std::runtime_error(
+        fmt::format("Could not readlink {} (too long)", pathname));
+  }
+  result.resize(length);
+  return result;
+}
+
+}  // namespace internal
+}  // namespace drake

--- a/common/filesystem.h
+++ b/common/filesystem.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <string>
+
+namespace drake {
+namespace internal {
+
+/** Returns true iff the given path is a file. */
+bool IsFile(const std::string& filesystem_path);
+
+/** Returns true iff the given path is a directory. */
+bool IsDir(const std::string& filesystem_path);
+
+/** A C++ wrapper for C's readlink(2). */
+std::string Readlink(const std::string& pathname);
+
+}  // namespace internal
+}  // namespace drake

--- a/common/find_loaded_library.cc
+++ b/common/find_loaded_library.cc
@@ -1,7 +1,7 @@
 #include "drake/common/find_loaded_library.h"
 
 #include "drake/common/drake_throw.h"
-#include "drake/common/find_runfiles.h"
+#include "drake/common/filesystem.h"
 
 #ifdef __APPLE__
 #include <dlfcn.h>

--- a/common/find_resource.cc
+++ b/common/find_resource.cc
@@ -8,6 +8,7 @@
 
 #include "drake/common/drake_marker.h"
 #include "drake/common/drake_throw.h"
+#include "drake/common/filesystem.h"
 #include "drake/common/find_loaded_library.h"
 #include "drake/common/find_runfiles.h"
 #include "drake/common/never_destroyed.h"

--- a/common/find_runfiles.cc
+++ b/common/find_runfiles.cc
@@ -1,11 +1,8 @@
 #include "drake/common/find_runfiles.h"
 
-#include <sys/stat.h>
-#include <unistd.h>
-
 #include <cstdlib>
-#include <fstream>
 #include <memory>
+#include <stdexcept>
 
 #ifdef __APPLE__
 #include <mach-o/dyld.h>
@@ -15,6 +12,7 @@
 #include "tools/cpp/runfiles/runfiles.h"
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/filesystem.h"
 #include "drake/common/never_destroyed.h"
 #include "drake/common/text_logging.h"
 
@@ -192,36 +190,6 @@ RlocationOrError FindRunfile(const std::string& resource_path) {
       "Sought '{}' in runfiles directory '{}' {}; "
       "perhaps a 'data = []' dependency is missing.",
       resource_path, singleton.runfiles_dir, detail);
-  return result;
-}
-
-bool IsFile(const std::string& filesystem_path) {
-  struct stat attributes{};
-  int error = stat(filesystem_path.c_str(), &attributes);
-  if (error) { return false; }
-  return S_ISREG(attributes.st_mode);
-}
-
-bool IsDir(const std::string& filesystem_path) {
-  struct stat attributes{};
-  int error = stat(filesystem_path.c_str(), &attributes);
-  if (error) { return false; }
-  return S_ISDIR(attributes.st_mode);
-}
-
-std::string Readlink(const std::string& pathname) {
-  std::string result;
-  result.resize(4096);
-  ssize_t length = ::readlink(pathname.c_str(), &result.front(), result.size());
-  if (length < 0) {
-    throw std::runtime_error(fmt::format(
-        "Could not open {}", pathname));
-  }
-  if (length >= static_cast<ssize_t>(result.size())) {
-    throw std::runtime_error(
-        fmt::format("Could not readlink {} (too long)", pathname));
-  }
-  result.resize(length);
   return result;
 }
 

--- a/common/find_runfiles.h
+++ b/common/find_runfiles.h
@@ -25,14 +25,5 @@ or else an error message when not found.  When HasRunfiles() is false, returns
 an error. */
 RlocationOrError FindRunfile(const std::string& resource_path);
 
-/** Returns true iff the given path is a file. */
-bool IsFile(const std::string& filesystem_path);
-
-/** Returns true iff the given path is a directory. */
-bool IsDir(const std::string& filesystem_path);
-
-/** A C++ wrapper for C's readlink(2). */
-std::string Readlink(const std::string& pathname);
-
 }  // namespace internal
 }  // namespace drake

--- a/common/test/filesystem_test.cc
+++ b/common/test/filesystem_test.cc
@@ -1,0 +1,59 @@
+#include "drake/common/filesystem.h"
+
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <fstream>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/temp_directory.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+namespace drake {
+namespace internal {
+namespace {
+
+GTEST_TEST(FilesystemTest, ExistTest) {
+  EXPECT_FALSE(IsFile("."));
+  EXPECT_FALSE(IsFile("common"));
+  EXPECT_TRUE(IsFile("common/filesystem_test"));
+  EXPECT_FALSE(IsFile("/no/such/path"));
+
+  EXPECT_TRUE(IsDir("."));
+  EXPECT_TRUE(IsDir("common"));
+  EXPECT_FALSE(IsDir("common/filesystem_test"));
+  EXPECT_FALSE(IsDir("/no/such/path"));
+}
+
+GTEST_TEST(FilesystemTest, ReadlinkTest) {
+  std::string tmp = temp_directory();
+  std::string rel_file = tmp + "/rel_file";
+  std::string rel_dir = tmp + "/rel_dir";
+  ASSERT_EQ(::symlink("a_file", rel_file.c_str()), 0);
+  ASSERT_EQ(::symlink("a_dir", rel_dir.c_str()), 0);
+  EXPECT_EQ(Readlink(rel_file), "a_file");
+  EXPECT_EQ(Readlink(rel_dir), "a_dir");
+
+  EXPECT_FALSE(IsFile(rel_file));
+  EXPECT_FALSE(IsDir(rel_dir));
+  EXPECT_FALSE(IsFile(rel_dir));
+  EXPECT_FALSE(IsDir(rel_file));
+
+  ASSERT_EQ(::mkdir((tmp + "/a_dir").c_str(), S_IRWXU), 0);
+  std::ofstream(tmp + "/a_file", std::ios::out).close();
+
+  EXPECT_TRUE(IsFile(rel_file));
+  EXPECT_TRUE(IsDir(rel_dir));
+  EXPECT_FALSE(IsFile(rel_dir));
+  EXPECT_FALSE(IsDir(rel_file));
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      Readlink("/no_such_readlink"), std::exception,
+      "Could not open /no_such_readlink");
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace drake

--- a/common/test/find_runfiles_test.cc
+++ b/common/test/find_runfiles_test.cc
@@ -1,59 +1,15 @@
 #include "drake/common/find_runfiles.h"
 
-#include <sys/stat.h>
-#include <unistd.h>
-
-#include <fstream>
-#include <string>
-
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "drake/common/filesystem.h"
 #include "drake/common/temp_directory.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 
 namespace drake {
 namespace internal {
 namespace {
-
-GTEST_TEST(FindRunfilesTest, ExistTest) {
-  EXPECT_FALSE(IsFile("."));
-  EXPECT_FALSE(IsFile("common"));
-  EXPECT_TRUE(IsFile("common/find_runfiles_test"));
-  EXPECT_FALSE(IsFile("/no/such/path"));
-
-  EXPECT_TRUE(IsDir("."));
-  EXPECT_TRUE(IsDir("common"));
-  EXPECT_FALSE(IsDir("common/find_runfiles_test"));
-  EXPECT_FALSE(IsDir("/no/such/path"));
-}
-
-GTEST_TEST(FindRunfilesTest, ReadlinkTest) {
-  std::string tmp = temp_directory();
-  std::string rel_file = tmp + "/rel_file";
-  std::string rel_dir = tmp + "/rel_dir";
-  ASSERT_EQ(::symlink("a_file", rel_file.c_str()), 0);
-  ASSERT_EQ(::symlink("a_dir", rel_dir.c_str()), 0);
-  EXPECT_EQ(Readlink(rel_file), "a_file");
-  EXPECT_EQ(Readlink(rel_dir), "a_dir");
-
-  EXPECT_FALSE(IsFile(rel_file));
-  EXPECT_FALSE(IsDir(rel_dir));
-  EXPECT_FALSE(IsFile(rel_dir));
-  EXPECT_FALSE(IsDir(rel_file));
-
-  ASSERT_EQ(::mkdir((tmp + "/a_dir").c_str(), S_IRWXU), 0);
-  std::ofstream(tmp + "/a_file", std::ios::out).close();
-
-  EXPECT_TRUE(IsFile(rel_file));
-  EXPECT_TRUE(IsDir(rel_dir));
-  EXPECT_FALSE(IsFile(rel_dir));
-  EXPECT_FALSE(IsDir(rel_file));
-
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      Readlink("/no_such_readlink"), std::exception,
-      "Could not open /no_such_readlink");
-}
 
 GTEST_TEST(FindRunfilesTest, AcceptanceTest) {
   EXPECT_TRUE(HasRunfiles());


### PR DESCRIPTION
This helper isolates runfiles logic from other filesystem operations, so filesystem operations do not need to build-depend on the bazel runfiles' runtime library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11961)
<!-- Reviewable:end -->
