### PR TITLE
pydrake doc: Add style guide for `keep_alive` comments

### DIFF
--- a/bindings/pydrake/attic/multibody/rigid_body_plant_py.cc
+++ b/bindings/pydrake/attic/multibody/rigid_body_plant_py.cc
@@ -258,8 +258,8 @@ PYBIND11_MODULE(rigid_body_plant, m) {
                 const Context<T>& context) -> Eigen::Ref<const VectorX<T>> {
               return self->GetStateVector(context);
             },
-            py_reference,
-            // Keep alive, ownership: `return` keeps `Context` alive.
+            py::arg("context"), py_reference,
+            // Keep alive, ownership: `return` keeps `context` alive.
             py::keep_alive<0, 2>(), cls_doc.GetStateVector.doc)
         .def("is_state_discrete", &Class::is_state_discrete,
             cls_doc.is_state_discrete.doc)
@@ -272,9 +272,9 @@ PYBIND11_MODULE(rigid_body_plant, m) {
     py::class_<Class, LeafSystem<T>>(m, "DrakeVisualizer", cls_doc.doc)
         .def(py::init<const RigidBodyTree<T>&, DrakeLcmInterface*, bool>(),
             py::arg("tree"), py::arg("lcm"), py::arg("enable_playback") = false,
-            // Keep alive, reference: `this` keeps `tree` alive.
+            // Keep alive, reference: `self` keeps `tree` alive.
             py::keep_alive<1, 2>(),
-            // Keep alive, reference: `this` keeps `lcm` alive.
+            // Keep alive, reference: `self` keeps `lcm` alive.
             py::keep_alive<1, 3>(), cls_doc.ctor.doc)
         .def("set_publish_period", &Class::set_publish_period,
             py::arg("period"), cls_doc.set_publish_period.doc)

--- a/bindings/pydrake/attic/multibody/rigid_body_tree_py.cc
+++ b/bindings/pydrake/attic/multibody/rigid_body_tree_py.cc
@@ -515,7 +515,7 @@ PYBIND11_MODULE(rigid_body_tree, m) {
           doc.RigidBodyFrame.get_frame_index.doc)
       .def("get_rigid_body", &RigidBodyFrame<double>::get_rigid_body,
           py_reference,
-          // Keep alive: `this` keeps `return` alive.
+          // Keep alive: `self` keeps `return` alive.
           py::keep_alive<1, 0>(), doc.RigidBodyFrame.get_rigid_body.doc)
       .def("get_transform_to_body",
           &RigidBodyFrame<double>::get_transform_to_body,

--- a/bindings/pydrake/attic/systems/controllers_py.cc
+++ b/bindings/pydrake/attic/systems/controllers_py.cc
@@ -46,10 +46,8 @@ PYBIND11_MODULE(controllers, m) {
                const VectorX<double>&, bool>(),
           py::arg("robot"), py::arg("kp"), py::arg("ki"), py::arg("kd"),
           py::arg("has_reference_acceleration"),
-          // Keep alive, ownership: `RigidBodyTree` keeps `self` alive.
-          // See "Keep Alive Behavior" in pydrake_pybind.h for details.
-          py::keep_alive<2 /* Nurse */, 1 /* Patient */>(),
-          doc.rbt.InverseDynamicsController.ctor.doc)
+          // Keep alive, ownership: `robot` keeps `self` alive.
+          py::keep_alive<2, 1>(), doc.rbt.InverseDynamicsController.ctor.doc)
       .def("set_integral_value",
           &rbt::InverseDynamicsController<double>::set_integral_value,
           doc.rbt.InverseDynamicsController.set_integral_value.doc);

--- a/bindings/pydrake/attic/systems/sensors_py.cc
+++ b/bindings/pydrake/attic/systems/sensors_py.cc
@@ -57,7 +57,7 @@ PYBIND11_MODULE(sensors, m) {
           py::arg("show_window") = bool{RenderingConfig::kDefaultShowWindow},
           py::arg("width") = int{RenderingConfig::kDefaultWidth},
           py::arg("height") = int{RenderingConfig::kDefaultHeight},
-          // Keep alive, reference: `this` keeps `RigidBodyTree` alive.
+          // Keep alive, reference: `self` keeps `tree` alive.
           py::keep_alive<1, 3>(), doc.RgbdCamera.ctor.doc_10args)
       .def("color_camera_info", &RgbdCamera::color_camera_info,
           py_reference_internal, doc.RgbdCamera.color_camera_info.doc)
@@ -80,7 +80,7 @@ PYBIND11_MODULE(sensors, m) {
       .def(py::init<unique_ptr<RgbdCamera>, double, bool>(), py::arg("camera"),
           py::arg("period") = double{RgbdCameraDiscrete::kDefaultPeriod},
           py::arg("render_label_image") = true,
-          // Keep alive, ownership: `RgbdCamera` keeps `this` alive.
+          // Keep alive, ownership: `camera` keeps `self` alive.
           py::keep_alive<2, 1>(), doc.RgbdCameraDiscrete.ctor.doc)
       // N.B. Since `camera` is already connected, we do not need additional
       // `keep_alive`s.

--- a/bindings/pydrake/automotive_py.cc
+++ b/bindings/pydrake/automotive_py.cc
@@ -70,8 +70,7 @@ PYBIND11_MODULE(automotive, m) {
         return std::make_unique<ClosestPose<T>>(odom, dist);
       }),
           py::arg("odom"), py::arg("dist"),
-          // Keep alive, transitive: `self` keeps `RoadOdometry` pointer
-          // members alive.
+          // Keep alive, reference (tr.): `self` keeps `odom` alive.
           py::keep_alive<1, 2>(), doc.ClosestPose.ctor.doc_2args)
       .def_readwrite("odometry", &ClosestPose<T>::odometry,
           py_reference_internal, doc.ClosestPose.odometry.doc)
@@ -94,8 +93,7 @@ PYBIND11_MODULE(automotive, m) {
                      road_position, frame_velocity);
                }),
           py::arg("road_position"), py::arg("frame_velocity"),
-          // Keep alive, transitive: `self` keeps `RoadPosition` pointer
-          // members alive.
+          // Keep alive, reference (tr.): `self` keeps `road_position` alive.
           py::keep_alive<1, 2>(), doc.RoadOdometry.ctor.doc_2args)
       .def(py::init(
                [](const maliput::api::Lane* lane,
@@ -106,7 +104,7 @@ PYBIND11_MODULE(automotive, m) {
                      lane, lane_position, frame_velocity);
                }),
           py::arg("lane"), py::arg("lane_position"), py::arg("frame_velocity"),
-          // Keep alive, reference: `self` keeps `Lane*` alive.
+          // Keep alive, reference: `self` keeps `lane` alive.
           py::keep_alive<1, 2>(), doc.RoadOdometry.ctor.doc_3args)
       .def_readwrite("pos", &RoadOdometry<T>::pos, doc.RoadOdometry.pos.doc)
       .def_readwrite("vel", &RoadOdometry<T>::vel, doc.RoadOdometry.vel.doc);

--- a/bindings/pydrake/examples/acrobot_py.cc
+++ b/bindings/pydrake/examples/acrobot_py.cc
@@ -51,12 +51,13 @@ PYBIND11_MODULE(acrobot, m) {
       m, "AcrobotSpongController", doc.AcrobotSpongController.doc)
       .def(py::init<>(), doc.AcrobotSpongController.ctor.doc)
       .def("get_parameters", &AcrobotSpongController<T>::get_parameters,
-          py_reference,
-          // Keep alive, ownership: `return` keeps `Context` alive.
+          py_reference, py::arg("context"),
+          // Keep alive, ownership: `return` keeps `context` alive.
           py::keep_alive<0, 2>(), doc.AcrobotSpongController.get_parameters.doc)
       .def("get_mutable_parameters",
           &AcrobotSpongController<T>::get_mutable_parameters, py_reference,
-          // Keep alive, ownership: `return` keeps `Context` alive.
+          py::arg("context"),
+          // Keep alive, ownership: `return` keeps `context` alive.
           py::keep_alive<0, 2>(),
           doc.AcrobotSpongController.get_mutable_parameters.doc);
 

--- a/bindings/pydrake/examples/quadrotor_py.cc
+++ b/bindings/pydrake/examples/quadrotor_py.cc
@@ -41,6 +41,7 @@ PYBIND11_MODULE(quadrotor, m) {
       .def_static("AddToBuilder", &QuadrotorGeometry::AddToBuilder,
           py::arg("builder"), py::arg("quadrotor_state_port"),
           py::arg("scene_graph"), py::return_value_policy::reference,
+          // Keep alive, ownership: `return` keeps `builder` alive.
           py::keep_alive<0, 1>(), doc.QuadrotorGeometry.AddToBuilder.doc);
 
   m.def("StabilizingLQRController", &StabilizingLQRController,

--- a/bindings/pydrake/maliput/api_py.cc
+++ b/bindings/pydrake/maliput/api_py.cc
@@ -73,7 +73,7 @@ PYBIND11_MODULE(api, m) {
         return std::make_unique<RoadPosition>(lane, pos);
       }),
           py::arg("lane"), py::arg("pos"),
-          // Keep alive, reference: `self` keeps `Lane*` alive.
+          // Keep alive, reference: `self` keeps `lane` alive.
           py::keep_alive<1, 2>(), doc.RoadPosition.ctor.doc_2args)
       .def_readwrite("pos", &RoadPosition::pos, doc.RoadPosition.pos.doc);
   DefReadWriteKeepAlive(&road_position, "lane", &RoadPosition::lane);

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -684,28 +684,26 @@ void DoScalarDependentDefinitions(py::module m, T) {
                 Context<T>* context) -> Eigen::Ref<VectorX<T>> {
               return self->GetMutablePositionsAndVelocities(context);
             },
-            py_reference,
-            // Keep alive, ownership: `return` keeps `Context` alive.
-            py::keep_alive<0, 2>(), py::arg("context"),
+            py_reference, py::arg("context"),
+            // Keep alive, ownership: `return` keeps `context` alive.
+            py::keep_alive<0, 2>(),
             cls_doc.GetMutablePositionsAndVelocities.doc)
         .def("GetMutablePositions",
             [](const MultibodyPlant<T>* self,
                 Context<T>* context) -> Eigen::Ref<VectorX<T>> {
               return self->GetMutablePositions(context);
             },
-            py_reference,
-            // Keep alive, ownership: `return` keeps `Context` alive.
-            py::keep_alive<0, 2>(), py::arg("context"),
-            cls_doc.GetMutablePositions.doc_1args)
+            py_reference, py::arg("context"),
+            // Keep alive, ownership: `return` keeps `context` alive.
+            py::keep_alive<0, 2>(), cls_doc.GetMutablePositions.doc_1args)
         .def("GetMutableVelocities",
             [](const MultibodyPlant<T>* self,
                 Context<T>* context) -> Eigen::Ref<VectorX<T>> {
               return self->GetMutableVelocities(context);
             },
-            py_reference,
-            // Keep alive, ownership: `return` keeps `Context` alive.
-            py::keep_alive<0, 2>(), py::arg("context"),
-            cls_doc.GetMutableVelocities.doc_1args)
+            py_reference, py::arg("context"),
+            // Keep alive, ownership: `return` keeps `context` alive.
+            py::keep_alive<0, 2>(), cls_doc.GetMutableVelocities.doc_1args)
         .def("GetPositions",
             [](const MultibodyPlant<T>* self, const Context<T>& context)
                 -> VectorX<T> { return self->GetPositions(context); },
@@ -885,13 +883,14 @@ PYBIND11_MODULE(plant, m) {
         return drake::multibody::ConnectContactResultsToDrakeVisualizer(
             builder, plant, lcm);
       },
+      py::arg("builder"), py::arg("plant"), py::arg("lcm") = nullptr,
+      py_reference,
       // Keep alive, ownership: `return` keeps `builder` alive.
       py::keep_alive<0, 1>(),
-      // Keep alive, reference transfer: `plant` keeps `builder` alive.
+      // Keep alive, transitive: `plant` keeps `builder` alive.
       py::keep_alive<2, 1>(),
-      // Keep alive, reference transfer: `lcm` keeps `builder` alive.
-      py::keep_alive<3, 1>(), py_reference, py::arg("builder"),
-      py::arg("plant"), py::arg("lcm") = nullptr,
+      // Keep alive, transitive: `lcm` keeps `builder` alive.
+      py::keep_alive<3, 1>(),
       doc.ConnectContactResultsToDrakeVisualizer.doc_3args);
 }  // NOLINT(readability/fn_size)
 

--- a/bindings/pydrake/pydrake_doxygen.h
+++ b/bindings/pydrake/pydrake_doxygen.h
@@ -253,22 +253,29 @@ be named `.doc_deprecated...` instead of just `.doc...`.
 @anchor PydrakeKeepAlive
 ## Keep Alive Behavior
 
-`py::keep_alive` is used heavily throughout this code. For more
-information, please see [the pybind11 documentation](
+`py::keep_alive<Nurse, Patient>()` is used heavily throughout this code. Please
+first review [the pybind11 documentation](
 http://pybind11.readthedocs.io/en/stable/advanced/functions.html#keep-alive).
 
-Terse notes are added to method bindings to indicate the patient
-(object being kept alive by nurse) and the nurse (object keeping patient
-alive). To expand on them:
-- "Keep alive, ownership" implies that one argument is owned directly by
-one of the other arguments (`self` is included in those arguments, for
-`py::init<>` and class methods).
-- "Keep alive, reference" implies a reference that is lifetime-sensitive
-(something that is not necessarily owned by the other arguments).
-- "Keep alive, transitive" implies a transfer of ownership of owned
-objects from one container to another (e.g. transferring all `System`s
-from `DiagramBuilder` to `Diagram` when calling
-`DiagramBuilder.Build()`).
+`py::keep_alive` decorations should be added after all `py::arg`s are
+specified. Terse comments should be added above these decorations to indicate
+the relationship between the Nurse and the Patient and decode the meaning of
+the Nurse and Patient integers by spelling out either the `py::arg` name (for
+named arguments), `return` for index 0, or `self` (not `this`) for index 1 when
+dealing with methods / members. The primary relationships:
+- "Keep alive, ownership" implies that a Patient owns the Nurse (or vice
+versa).
+- "Keep alive, reference" implies a Patient that is referred to by the Nurse.
+If there is an indirect / transitive relationship (storing a reference to
+an argument's member or a transfer of ownership, as with
+`DiagramBuilder.Build()`), append `(tr.)` to the relationship.
+
+Some example comments:
+
+```
+// Keep alive, reference: `self` keeps `context` alive.
+// Keep alive, ownership (tr.): `return` keeps `self` alive.
+```
 
 @anchor PydrakeOverloads
 ## Function Overloads

--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -60,9 +60,9 @@ PYBIND11_MODULE(analysis, m) {
         .def(py::init<const System<T>&, const T&, Context<T>*>(),
             py::arg("system"), py::arg("max_step_size"),
             py::arg("context") = nullptr,
-            // Keep alive, reference: `self` keeps `System` alive.
+            // Keep alive, reference: `self` keeps `system` alive.
             py::keep_alive<1, 2>(),
-            // Keep alive, reference: `self` keeps `Context` alive.
+            // Keep alive, reference: `self` keeps `context` alive.
             py::keep_alive<1, 4>(), doc.RungeKutta2Integrator.ctor.doc);
 
     DefineTemplateClassWithDefault<RungeKutta3Integrator<T>, IntegratorBase<T>>(
@@ -70,18 +70,18 @@ PYBIND11_MODULE(analysis, m) {
         doc.RungeKutta3Integrator.doc)
         .def(py::init<const System<T>&, Context<T>*>(), py::arg("system"),
             py::arg("context") = nullptr,
-            // Keep alive, reference: `self` keeps `System` alive.
+            // Keep alive, reference: `self` keeps `system` alive.
             py::keep_alive<1, 2>(),
-            // Keep alive, reference: `self` keeps `Context` alive.
+            // Keep alive, reference: `self` keeps `context` alive.
             py::keep_alive<1, 3>(), doc.RungeKutta3Integrator.ctor.doc);
 
     DefineTemplateClassWithDefault<Simulator<T>>(
         m, "Simulator", GetPyParam<T>(), doc.Simulator.doc)
         .def(py::init<const System<T>&, unique_ptr<Context<T>>>(),
             py::arg("system"), py::arg("context") = nullptr,
-            // Keep alive, reference: `self` keeps `System` alive.
+            // Keep alive, reference: `self` keeps `system` alive.
             py::keep_alive<1, 2>(),
-            // Keep alive, ownership: `Context` keeps `self` alive.
+            // Keep alive, ownership: `context` keeps `self` alive.
             py::keep_alive<3, 1>(), doc.Simulator.ctor.doc)
         .def("Initialize", &Simulator<T>::Initialize,
             doc.Simulator.Initialize.doc)
@@ -100,7 +100,8 @@ PYBIND11_MODULE(analysis, m) {
                 std::unique_ptr<IntegratorBase<T>> integrator) {
               return self->reset_integrator(std::move(integrator));
             },
-            // Keep alive, ownership: `Integrator` keeps `self` alive.
+            py::arg("integrator"),
+            // Keep alive, ownership: `integrator` keeps `self` alive.
             py::keep_alive<2, 1>(),
             doc.Simulator.reset_integrator.doc_1args_stduniqueptr)
         .def("set_publish_every_time_step",

--- a/bindings/pydrake/systems/controllers_py.cc
+++ b/bindings/pydrake/systems/controllers_py.cc
@@ -77,7 +77,7 @@ PYBIND11_MODULE(controllers, m) {
                const VectorX<double>&, const VectorX<double>&, bool>(),
           py::arg("robot"), py::arg("kp"), py::arg("ki"), py::arg("kd"),
           py::arg("has_reference_acceleration"),
-          // Keep alive, reference: `self` keeps `MultibodyPlant` alive.
+          // Keep alive, reference: `self` keeps `robot` alive.
           py::keep_alive<1, 2>(), doc.InverseDynamicsController.ctor.doc)
       .def("set_integral_value",
           &InverseDynamicsController<double>::set_integral_value,

--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -381,10 +381,11 @@ void DefineFrameworkPySemantics(py::module m) {
         m, "DiagramBuilder", GetPyParam<T>(), doc.DiagramBuilder.doc)
         .def(py::init<>(), doc.DiagramBuilder.ctor.doc)
         .def("AddSystem",
-            [](DiagramBuilder<T>* self, unique_ptr<System<T>> arg1) {
-              return self->AddSystem(std::move(arg1));
+            [](DiagramBuilder<T>* self, unique_ptr<System<T>> system) {
+              return self->AddSystem(std::move(system));
             },
-            // Keep alive, ownership: `System` keeps `self` alive.
+            py::arg("system"),
+            // Keep alive, ownership: `system` keeps `self` alive.
             py::keep_alive<2, 1>(), doc.DiagramBuilder.AddSystem.doc)
         .def("Connect",
             py::overload_cast<const OutputPort<T>&, const InputPort<T>&>(
@@ -397,10 +398,10 @@ void DefineFrameworkPySemantics(py::module m) {
             py::arg("output"), py::arg("name") = kUseDefaultName,
             py_reference_internal, doc.DiagramBuilder.ExportOutput.doc)
         .def("Build", &DiagramBuilder<T>::Build,
-            // Keep alive, transitive: `return` keeps `self` alive.
+            // Keep alive, ownership (tr.): `return` keeps `self` alive.
             py::keep_alive<1, 0>(), doc.DiagramBuilder.Build.doc)
-        .def("BuildInto", &DiagramBuilder<T>::BuildInto,
-            // Keep alive, transitive: `Diagram` keeps `self` alive.
+        .def("BuildInto", &DiagramBuilder<T>::BuildInto, py::arg("target"),
+            // Keep alive, ownership (tr.): `target` keeps `self` alive.
             py::keep_alive<2, 1>(), doc.DiagramBuilder.BuildInto.doc);
 
     DefineTemplateClassWithDefault<OutputPort<T>>(

--- a/bindings/pydrake/systems/lcm_py.cc
+++ b/bindings/pydrake/systems/lcm_py.cc
@@ -121,8 +121,10 @@ PYBIND11_MODULE(lcm, m) {
                  DrakeLcmInterface*, double>(),
             py::arg("channel"), py::arg("serializer"), py::arg("lcm"),
             py::arg("publish_period") = 0.0,
-            // Keep alive: `self` keeps `DrakeLcmInterface` alive.
-            py::keep_alive<1, 3>(), cls_doc.ctor.doc_4args);
+            // Keep alive, ownership: `serializer` keeps `self` alive.
+            py::keep_alive<3, 1>(),
+            // Keep alive, reference: `self` keeps `lcm` alive.
+            py::keep_alive<1, 4>(), cls_doc.ctor.doc_4args);
   }
 
   {
@@ -132,9 +134,9 @@ PYBIND11_MODULE(lcm, m) {
         .def(py::init<const std::string&, std::unique_ptr<SerializerInterface>,
                  DrakeLcmInterface*>(),
             py::arg("channel"), py::arg("serializer"), py::arg("lcm"),
-            // Keep alive: `self` keeps `SerializerInterface` alive.
-            py::keep_alive<1, 3>(),
-            // Keep alive: `self` keeps `DrakeLcmInterface` alive.
+            // Keep alive, ownership: `serializer` keeps `self` alive.
+            py::keep_alive<3, 1>(),
+            // Keep alive, reference: `self` keeps `lcm` alive.
             py::keep_alive<1, 4>(), doc.LcmSubscriberSystem.ctor.doc)
         .def("WaitForMessage", &Class::WaitForMessage,
             py::arg("old_message_count"), py::arg("message") = nullptr,

--- a/bindings/pydrake/systems/sensors_py.cc
+++ b/bindings/pydrake/systems/sensors_py.cc
@@ -231,8 +231,8 @@ PYBIND11_MODULE(sensors, m) {
       .def(py::init<unique_ptr<RgbdSensor>, double, bool>(), py::arg("sensor"),
           py::arg("period") = double{RgbdSensorDiscrete::kDefaultPeriod},
           py::arg("render_label_image") = true,
-          // Keep alive, ownership: `RgbdSensorDiscrete` keeps `this` alive.
-          py::keep_alive<1, 2>(), doc.RgbdSensorDiscrete.ctor.doc)
+          // Keep alive, ownership: `sensor` keeps `self` alive.
+          py::keep_alive<2, 1>(), doc.RgbdSensorDiscrete.ctor.doc)
       // N.B. Since `camera` is already connected, we do not need additional
       // `keep_alive`s.
       .def("sensor", &RgbdSensorDiscrete::sensor, py_reference_internal,


### PR DESCRIPTION
In #11959, I realized that there aren't examples, and there's inconsistency of types vs. argument names. Added examples.

\cc @m-chaturvedi 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11971)
<!-- Reviewable:end -->
