### PR TITLE
Fix doxygen formatting for discrete_derivative.h

### DIFF
--- a/systems/primitives/discrete_derivative.h
+++ b/systems/primitives/discrete_derivative.h
@@ -107,6 +107,7 @@ class DiscreteDerivative final : public LeafSystem<T> {
 /// vector with positions and velocities stacked.  This assumes that the
 /// number of positions == the number of velocities.
 ///
+/// ```
 ///                                  ┌─────┐
 /// position ───┬───────────────────>│     │
 ///             │                    │ Mux ├──> state
@@ -114,6 +115,7 @@ class DiscreteDerivative final : public LeafSystem<T> {
 ///             └──>│  Discrete  ├──>│     │
 ///                 │ Derivative │   └─────┘
 ///                 └────────────┘
+/// ```
 ///
 /// @system{ StateInterpolatorWithDiscreteDerivative,
 ///          @input_port{position},


### PR DESCRIPTION
Without the ``` context, the diagram got mangled in doxygen.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11973)
<!-- Reviewable:end -->
