### PR TITLE
Make TypeSafeIndex hash via drake_append

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -1256,6 +1256,7 @@ drake_cc_googletest(
     deps = [
         ":type_safe_index",
         ":unused",
+        "//common:sorted_pair",
         "//common/test_utilities:expect_throws_message",
     ],
 )

--- a/common/test/type_safe_index_test.cc
+++ b/common/test/type_safe_index_test.cc
@@ -12,6 +12,7 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/sorted_pair.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/common/unused.h"
 
@@ -544,6 +545,17 @@ GTEST_TEST(TypeSafeIndex, CompatibleWithUnorderedSet) {
   EXPECT_EQ(indexes.find(a3), indexes.end());
   EXPECT_NE(indexes.find(a1), indexes.end());
   EXPECT_NE(indexes.find(a2), indexes.end());
+}
+
+// Confirms that a SortedPair<IndexType> can be used as a key in a hashing
+// container. This is representative of TypeSafeIndex's compatibility with the
+// DrakeHash notion.
+GTEST_TEST(TypeSafeIndex, SortedPairIndexHashable) {
+  AIndex a1(1);
+  AIndex a2(2);
+  std::unordered_set<SortedPair<AIndex>> pairs;
+  pairs.insert({a2, a1});
+  EXPECT_EQ(pairs.count(SortedPair<AIndex>(a1, a2)), 1);
 }
 
 }  // namespace

--- a/common/type_safe_index.h
+++ b/common/type_safe_index.h
@@ -6,6 +6,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_throw.h"
+#include "drake/common/hash.h"
 #include "drake/common/nice_type_name.h"
 
 namespace drake {
@@ -467,6 +468,17 @@ class TypeSafeIndex {
 
   ///@}
 
+  /// Implements the @ref hash_append concept. And invalid index will
+  /// successfully hash (in order to satisfy STL requirements), and it is up to
+  /// the user to confirm it is valid before using it as a key (or other hashing
+  /// application).
+  template <typename HashAlgorithm>
+  friend void hash_append(HashAlgorithm& hasher,
+                          const TypeSafeIndex& i) noexcept {
+    using drake::hash_append;
+    hash_append(hasher, i.index_);
+  }
+
  private:
   // Checks if this index lies in the valid range; throws an exception if not.
   // Invocations provide a string explaining the origin of the bad value.
@@ -544,11 +556,9 @@ operator>=(const U& value, const TypeSafeIndex<Tag>& tag) {
 }  // namespace drake
 
 namespace std {
-/// Specialization of std::hash for drake::TypeSafeIndex<Tag>.
+
+/// Enables use of the type-safe index to serve as a key in STL containers.
+/// @relates TypeSafeIndex
 template <typename Tag>
-struct hash<drake::TypeSafeIndex<Tag>> {
-  size_t operator()(const drake::TypeSafeIndex<Tag>& index) const {
-    return std::hash<int>()(index);
-  }
-};
+struct hash<drake::TypeSafeIndex<Tag>> : public drake::DefaultHash {};
 }  // namespace std


### PR DESCRIPTION
Without this, it is impossible to hash SortedPair<IndexType>.

It's hashing pre-dated the introduction of `hash_append`. Directly hashing via specializing `std::hash` has been shown to be incompatible with higher-order constructs (such as `SortedPair`). (See #11872)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11975)
<!-- Reviewable:end -->
