### PR TITLE
Fix calculation of SceneGraphs output PoseBundle

### DIFF
--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -783,6 +783,11 @@ class SceneGraph final : public systems::LeafSystem<T> {
   void CalcPoseBundle(const systems::Context<T>& context,
                       systems::rendering::PoseBundle<T>* output) const;
 
+  // Collects all of the *dynamic* frames that have geometries with the given
+  // role.
+  std::vector<FrameId> GetDynamicFrames(const GeometryState<T>& g_state,
+                                        Role role) const;
+
   // Refreshes the pose of the various engines which exploits the caching
   // infrastructure.
   void FullPoseUpdate(const systems::Context<T>& context) const {

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -582,6 +582,17 @@ GTEST_TEST(SceneGraphVisualizationTest, NoWorldInPoseVector) {
                                                      &poses));
   }
 
+  // Case: Calculating pose bundle with an input pose bundle the wrong size.
+  {
+    SceneGraph<double> scene_graph;
+    PoseBundle<double> poses(1);
+    EXPECT_EQ(poses.get_num_poses(), 1);
+    auto context = scene_graph.AllocateContext();
+    EXPECT_NO_THROW(SceneGraphTester::CalcPoseBundle(scene_graph, *context,
+                                                     &poses));
+    EXPECT_EQ(poses.get_num_poses(), 0);
+  }
+
   // Case: Registered source but no frames or geometry --> empty pose vector.
   {
     SceneGraph<double> scene_graph;


### PR DESCRIPTION
Due to issues on a mac where the traversal order of the `unordered_map` of dynamic frames has changed, this updates the `CalcPoseBundle` to be less sensitive to that re-ordering.

1. Confirms the pose bundle is the correct size (change of size is considered an error).
2. Explicitly sets all fields in the pose bundle for each frame.

resolves #11963

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11979)
<!-- Reviewable:end -->
