### PR TITLE
Gripper brick constraint helper

### DIFF
--- a/examples/planar_gripper/brick_static_equilibrium_constraint.cc
+++ b/examples/planar_gripper/brick_static_equilibrium_constraint.cc
@@ -136,9 +136,11 @@ AddBrickStaticEquilibriumConstraint(
   // Add the linear constraint that the contact force is within the friction
   // cone.
   for (int i = 0; i < num_contacts; ++i) {
+    const double friction_cone_shrink_factor = 1;
     AddFrictionConeConstraint(gripper_brick_system,
                               finger_face_contacts[i].first,
-                              finger_face_contacts[i].second, f_Cb_B, prog);
+                              finger_face_contacts[i].second, f_Cb_B,
+                              friction_cone_shrink_factor, prog);
   }
 
   return f_Cb_B;

--- a/examples/planar_gripper/gripper_brick.h
+++ b/examples/planar_gripper/gripper_brick.h
@@ -112,21 +112,21 @@ class GripperBrickHelper {
   multibody::CoulombFriction<T> GetFingerTipBrickCoulombFriction(
       Finger finger) const;
 
-  static constexpr int kNumFingers() { return 3; }
 
  private:
   std::unique_ptr<systems::Diagram<T>> diagram_;
   multibody::MultibodyPlant<T>* plant_;
   geometry::SceneGraph<T>* scene_graph_;
-  std::array<int, kNumFingers()> finger_base_position_indices_;
-  std::array<int, kNumFingers()> finger_mid_position_indices_;
+  static constexpr int kNumFingers{3};
+  std::array<int, kNumFingers> finger_base_position_indices_;
+  std::array<int, kNumFingers> finger_mid_position_indices_;
   int brick_translate_y_position_index_;
   int brick_translate_z_position_index_;
   int brick_revolute_x_position_index_;
   const multibody::Frame<double>* brick_frame_;
-  std::array<const multibody::Frame<double>*, kNumFingers()>
+  std::array<const multibody::Frame<double>*, kNumFingers>
       finger_link2_frames_;
-  std::array<geometry::GeometryId, kNumFingers()>
+  std::array<geometry::GeometryId, kNumFingers>
       finger_tip_sphere_geometry_ids_;
 
   Eigen::Vector3d p_L2Fingertip_;

--- a/examples/planar_gripper/gripper_brick.h
+++ b/examples/planar_gripper/gripper_brick.h
@@ -112,18 +112,22 @@ class GripperBrickHelper {
   multibody::CoulombFriction<T> GetFingerTipBrickCoulombFriction(
       Finger finger) const;
 
+  static constexpr int kNumFingers() { return 3; }
+
  private:
   std::unique_ptr<systems::Diagram<T>> diagram_;
   multibody::MultibodyPlant<T>* plant_;
   geometry::SceneGraph<T>* scene_graph_;
-  std::array<int, 3> finger_base_position_indices_;
-  std::array<int, 3> finger_mid_position_indices_;
+  std::array<int, kNumFingers()> finger_base_position_indices_;
+  std::array<int, kNumFingers()> finger_mid_position_indices_;
   int brick_translate_y_position_index_;
   int brick_translate_z_position_index_;
   int brick_revolute_x_position_index_;
   const multibody::Frame<double>* brick_frame_;
-  std::array<const multibody::Frame<double>*, 3> finger_link2_frames_;
-  std::array<geometry::GeometryId, 3> finger_tip_sphere_geometry_ids_;
+  std::array<const multibody::Frame<double>*, kNumFingers()>
+      finger_link2_frames_;
+  std::array<geometry::GeometryId, kNumFingers()>
+      finger_tip_sphere_geometry_ids_;
 
   Eigen::Vector3d p_L2Fingertip_;
   double finger_tip_radius_;

--- a/examples/planar_gripper/gripper_brick.h
+++ b/examples/planar_gripper/gripper_brick.h
@@ -103,6 +103,15 @@ class GripperBrickHelper {
     return base_theta + base_joint_angle + middle_joint_angle;
   }
 
+  geometry::GeometryId finger_tip_sphere_geometry_id(Finger finger) const;
+
+  geometry::GeometryId brick_geometry_id() const {
+    return plant_->GetCollisionGeometriesForBody(brick_frame().body())[0];
+  }
+
+  multibody::CoulombFriction<T> GetFingerTipBrickCoulombFriction(
+      Finger finger) const;
+
  private:
   std::unique_ptr<systems::Diagram<T>> diagram_;
   multibody::MultibodyPlant<T>* plant_;
@@ -114,6 +123,7 @@ class GripperBrickHelper {
   int brick_revolute_x_position_index_;
   const multibody::Frame<double>* brick_frame_;
   std::array<const multibody::Frame<double>*, 3> finger_link2_frames_;
+  std::array<geometry::GeometryId, 3> finger_tip_sphere_geometry_ids_;
 
   Eigen::Vector3d p_L2Fingertip_;
   double finger_tip_radius_;

--- a/examples/planar_gripper/gripper_brick_planning_constraint_helper.cc
+++ b/examples/planar_gripper/gripper_brick_planning_constraint_helper.cc
@@ -137,7 +137,9 @@ FingerNoSlidingConstraint::FingerNoSlidingConstraint(
     const GripperBrickHelper<double>* gripper_brick, Finger finger,
     BrickFace face, systems::Context<double>* from_context,
     systems::Context<double>* to_context)
-    : solvers::Constraint(1, 2 * gripper_brick->plant().num_positions(),
+    : solvers::Constraint(1 /* number of constraint */,
+                          2 * gripper_brick->plant()
+                                  .num_positions() /* Number of variables */,
                           Vector1d(0), Vector1d(0),
                           "finger_no_sliding_constraint"),
       gripper_brick_(gripper_brick),

--- a/examples/planar_gripper/gripper_brick_planning_constraint_helper.cc
+++ b/examples/planar_gripper/gripper_brick_planning_constraint_helper.cc
@@ -9,8 +9,6 @@
 
 namespace drake {
 namespace examples {
-const double kInf = std::numeric_limits<double>::infinity();
-
 namespace planar_gripper {
 template <typename T>
 void AddFrictionConeConstraint(

--- a/examples/planar_gripper/gripper_brick_planning_constraint_helper.cc
+++ b/examples/planar_gripper/gripper_brick_planning_constraint_helper.cc
@@ -139,7 +139,9 @@ FingerNoSlidingConstraint::FingerNoSlidingConstraint(
     systems::Context<double>* to_context)
     : solvers::Constraint(1 /* number of constraint */,
                           2 * gripper_brick->plant()
-                                  .num_positions() /* Number of variables */,
+                                  .num_positions(),  // Number of variables,
+                                                     // the variables are q_to
+                                                     // and q_from.
                           Vector1d(0), Vector1d(0),
                           "finger_no_sliding_constraint"),
       gripper_brick_(gripper_brick),

--- a/examples/planar_gripper/gripper_brick_planning_constraint_helper.h
+++ b/examples/planar_gripper/gripper_brick_planning_constraint_helper.h
@@ -94,10 +94,11 @@ void AddFingerNoSlidingConstraint(
 
 /**
  * Impose the kinematic constraint that the finger can only roll (or stick)
- * starting from a given fixed posture. The change of angle (from starting
- * posture to the ending posture) between finger link 2 and the +z axis is
- * limited to be within rolling_angle_upper and rolling_angle_lower. If you want
- * to impose sticking contact (no rolling), then set rolling_angle_lower =
+ * starting from a given fixed posture. The angle of the finger is defined as
+ * the pitch angle of the finger link 2 (about +x axis). The change of finger
+ * angles from the starting posture to the ending posture is limited to be
+ * within rolling_angle_upper and rolling_angle_lower. If you want to impose
+ * sticking contact (no rolling), then set rolling_angle_lower =
  * rolling_angle_upper = 0.
  * @param gripper_brick Contains the gripper brick diagram.
  * @param finger The finger that should not slide.

--- a/examples/planar_gripper/gripper_brick_planning_constraint_helper.h
+++ b/examples/planar_gripper/gripper_brick_planning_constraint_helper.h
@@ -45,7 +45,7 @@ void AddFrictionConeConstraint(
  * 0 < face_shrink_factor < 1 corresponds to the scaled region of the face,
  * if face_shrink_factor = 0, then the region shrinks to the singleton centroid.
  * @param depth The penetration depth between the finger tip sphere and the
- * brick. @default to 1mm.
+ * brick.
  */
 void AddFingerTipInContactWithBrickFaceConstraint(
     const GripperBrickHelper<double>& gripper_brick_system, Finger finger,

--- a/examples/planar_gripper/gripper_brick_planning_constraint_helper.h
+++ b/examples/planar_gripper/gripper_brick_planning_constraint_helper.h
@@ -76,9 +76,9 @@ Vector3<AutoDiffXd> ComputeFingerTipInBrickFrame(
  * @param rolling_angle_bound The non-negative bound on the rolling angle (in
  * radians).
  * @param prog The optimization program to which the constraint is added.
- * @param from_context The context that constains posture of the plant, before
- * rolling occurs.
- * @param to_context The context that constains posture of the plant, after
+ * @param from_context The context that contains the posture of the plant,
+ * before rolling occurs.
+ * @param to_context The context that contains the posture of the plant, after
  * rolling occurs.
  * @param q_from The variable representing the "from" posture.
  * @param q_to The variable representing the "to" posture.
@@ -94,10 +94,11 @@ void AddFingerNoSlidingConstraint(
 
 /**
  * Impose the kinematic constraint that the finger can only roll (or stick)
- * starting from a given fixed posture. The relative angle between finger link 2
- * and the +z axis is limited to be within rolling_angle_upper and
- * rolling_angle_lower. If you want to impose sticking contact (no rolling),
- * then set rolling_angle_lower = rolling_angle_upper = 0.
+ * starting from a given fixed posture. The change of angle (from starting
+ * posture to the ending posture) between finger link 2 and the +z axis is
+ * limited to be within rolling_angle_upper and rolling_angle_lower. If you want
+ * to impose sticking contact (no rolling), then set rolling_angle_lower =
+ * rolling_angle_upper = 0.
  * @param gripper_brick Contains the gripper brick diagram.
  * @param finger The finger that should not slide.
  * @param face The brick face that the finger sticks to (or rolls on).

--- a/examples/planar_gripper/gripper_brick_planning_constraint_helper.h
+++ b/examples/planar_gripper/gripper_brick_planning_constraint_helper.h
@@ -68,7 +68,7 @@ Vector3<AutoDiffXd> ComputeFingerTipInBrickFrame(
 /**
  * Impose a kinematic constraint which prohibits the fingertip sphere from
  * sliding on the brick's face. That is, the fingertip sphere is only allowed to
- * roll on the brick's surface . Note that zero rolling (i.e., sticking) is also
+ * roll on the brick's surface. Note that zero rolling (i.e., sticking) is also
  * allowed.
  * @param gripper_brick Contains the gripper brick diagram.
  * @param finger The finger that should not slide.
@@ -130,7 +130,14 @@ namespace internal {
  * The formulation of the constraint is
  *
  *     p_translation_to - p_translation_from - radius * (θ_to - θ_from) = 0
- * The variables are (q_from, q_to)
+ * where θ_to and θ_from are the pitch angle of the finger tip in the "from"
+ * and "to" postures respectively.
+ * The variables are (q_from, q_to).
+ * This constraint only has 1 row. It only constrains that in the tangential
+ * direction along the brick surface, the translation of the finger tip matches
+ * with the rolling angle. This constraint does NOT constrain that in the
+ * normal direction, the finger remains in contact. The user should impose
+ * the constraint in the normal direction separately.
  */
 class FingerNoSlidingConstraint : public solvers::Constraint {
  public:


### PR DESCRIPTION
Add the kinematic constraint used for planning gripper brick motion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11983)
<!-- Reviewable:end -->
