### PR TITLE
Fixing mac CI error

### DIFF
--- a/geometry/render/render_engine_ospray.h
+++ b/geometry/render/render_engine_ospray.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <memory>
 #include <string>
 #include <unordered_map>


### PR DESCRIPTION
Closes #11991.

Ospray instantiates std::array but doesn't include the header. This should
resolve the error message:

 implicit instantiation of undefined template

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11992)
<!-- Reviewable:end -->
