### PR TITLE
Remove ospray test from thread sanitizer -- it uses TBB

### DIFF
--- a/geometry/render/BUILD.bazel
+++ b/geometry/render/BUILD.bazel
@@ -149,7 +149,10 @@ drake_cc_googletest(
     data = [
         "//systems/sensors:test_models",
     ],
-    tags = vtk_test_tags(),
+    tags = vtk_test_tags() + [
+        # OSPRay uses TBB which is not tsan-friendly.
+        "no_tsan",
+    ],
     deps = [
         ":render_engine_ospray",
         "//common:find_resource",


### PR DESCRIPTION
The ospray test gets the "no_tsan" test because of its use of TBB.

replaces #11993

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11994)
<!-- Reviewable:end -->
