### PR TITLE
Refine the unit sphere volume mesh generation

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -269,6 +269,8 @@ drake_cc_googletest(
     name = "make_unit_sphere_mesh_test",
     deps = [
         ":make_unit_sphere_mesh",
+        "//common:sorted_pair",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/geometry/proximity/test/make_unit_sphere_mesh_test.cc
+++ b/geometry/proximity/test/make_unit_sphere_mesh_test.cc
@@ -1,15 +1,20 @@
 #include "drake/geometry/proximity/make_unit_sphere_mesh.h"
 
+#include <algorithm>
 #include <vector>
 
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"
+#include "drake/common/sorted_pair.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
 
 namespace drake {
 namespace geometry {
 namespace internal {
 namespace {
+
+using Eigen::Vector3d;
 
 // TODO(amcastro-tri): The unit tests below were designed with the idea in mind
 // that if a typical bug is present (for instance wrong tetrahedron sign
@@ -18,7 +23,7 @@ namespace {
 // tests are missing. To mention a few:
 //   1. Level 0 tessellation should have all of its properties confirmed:
 //      tetrahedra sign convention, positive volume, sphere coverage.
-//   2. Is level 0 correct in that there are no overlappong tetrahedra?
+//   2. Is level 0 correct in that there are no overlapping tetrahedra?
 //   3. The refinement process preserves the tetrahedron sign convention.
 //   4. Confirm that the k-level refinement of a tet spans the same volume of
 //      the k-1-level (if there are no boundary vertices).
@@ -71,6 +76,119 @@ GTEST_TEST(MakeSphereMesh, VolumeConvergence) {
 
     // Always compare against last computed error to show monotonic convergence.
     prev_error = error;
+  }
+}
+
+// Loosely confirms that there are no duplicate vertices in the sphere mesh. In
+// this case, we examine the first four levels of refinement (0, 1, 2, 3) and
+// compare vertex count against the documented expected vertex count in
+// [Everett, 1997]. This isn't proof, but it's highly suggestive.
+GTEST_TEST(MakeSphereMesh, NoDuplicateVertices) {
+  // Expected number of vertices based on [Everett, 1997].
+  const std::vector<int> expected_v_count{7, 25, 129, 833};
+  for (int i = 0; i < 4; ++i) {
+    VolumeMesh<double> mesh = MakeUnitSphereMesh<double>(i);
+    EXPECT_EQ(mesh.num_vertices(), expected_v_count[i]);
+    EXPECT_EQ(mesh.num_elements(), std::pow(8, i + 1));
+  }
+  // TODO(SeanCurtis-TRI): Actually test for duplicates within a distance
+  //  threshold.
+}
+
+// Smoke test to confirm the calculations work with the Autodiff scalar.
+GTEST_TEST(MakeSphereMesh, AutoDiffRefinement) {
+  VolumeMesh<AutoDiffXd> mesh1 = MakeUnitSphereMesh<AutoDiffXd>(1);
+  EXPECT_EQ(mesh1.num_vertices(), 25);
+  EXPECT_EQ(mesh1.num_elements(), 64);
+}
+
+// Confirms that the SplitOctohedron function splits in the expected direction.
+GTEST_TEST(MakeSphereMesh, SplitOctohedron) {
+  // Define a tet such that when we divide all the edges in half the octohedron
+  // remaining is the canonical octohedron with vertices at (±1, 0, 0),
+  // (0, ±1, 0), and (0, 0, ±1). We do this so there's no question about the
+  // semantics of vertices e-j as defined in the make unit sphere
+  // infrastructure.
+  const int a(0), b(1), c(2), d(3);
+  const std::vector<VolumeVertex<double>> tet_vertices{
+      VolumeVertex<double>(1, -1, -1), VolumeVertex<double>(1, 1, 1),
+      VolumeVertex<double>(-1, 1, -1), VolumeVertex<double>(-1, -1, 1)};
+
+  auto mid_point = [&tet_vertices](int i, int j) -> Vector3d {
+    return (tet_vertices[i].r_MV() + tet_vertices[j].r_MV()) / 2;
+  };
+
+  using VIndex = VolumeVertexIndex;
+  // We don't need the vertices for a, b, c, and d in the test; we just need
+  // e-j.
+  const VIndex e(0), f(1), g(2), h(3), i(4), j(5);
+  const std::array<VIndex, 6> octo_vertices{e, f, g, h, i, j};
+  const std::vector<VolumeVertex<double>> unit_p_MVs{
+      VolumeVertex<double>(mid_point(a, b)),  // e = (a + b) / 2
+      VolumeVertex<double>(mid_point(a, c)),  // f = (a + c) / 2
+      VolumeVertex<double>(mid_point(a, d)),  // g = (a + d) / 2
+      VolumeVertex<double>(mid_point(b, c)),  // h = (b + c) / 2
+      VolumeVertex<double>(mid_point(b, d)),  // i = (b + d) / 2
+      VolumeVertex<double>(mid_point(c, d))};  // j = (c + d) / 2
+
+  // Confirm the tetrahedron works as advertised; that the vertices at edge
+  // midpoints live where we expect them to.
+  //          +Z
+  //          |  /
+  //          i j
+  //          |/
+  //   ---g---+---h---+Y
+  //         /|
+  //        e f
+  //       /  |
+  //     +X
+  ASSERT_TRUE(CompareMatrices(unit_p_MVs[e].r_MV(), Vector3d(1, 0, 0)));
+  ASSERT_TRUE(CompareMatrices(unit_p_MVs[f].r_MV(), Vector3d(0, 0, -1)));
+  ASSERT_TRUE(CompareMatrices(unit_p_MVs[g].r_MV(), Vector3d(0, -1, 0)));
+  ASSERT_TRUE(CompareMatrices(unit_p_MVs[h].r_MV(), Vector3d(0, 1, 0)));
+  ASSERT_TRUE(CompareMatrices(unit_p_MVs[i].r_MV(), Vector3d(0, 0, 1)));
+  ASSERT_TRUE(CompareMatrices(unit_p_MVs[j].r_MV(), Vector3d(-1, 0, 0)));
+
+  // We're going to implicitly scale the tetrahedron so that the octohedron
+  // is no longer symmetric; we scale it along the three axes by a factor of
+  // 1, 2, and 2. The axis under test is scaled by 1 and the other axes by 2.
+  // SplitOctohedron() will favor splitting along the shortest axis. In the
+  // tests above, it's clear that EJ is aligned with the x-axis, GH with the y,
+  // and FI with the z.
+  const std::vector<SortedPair<VIndex>> split_edges{SortedPair<VIndex>{e, j},
+                                                    SortedPair<VIndex>{g, h},
+                                                    SortedPair<VIndex>{f, i}};
+  for (int axis = 0; axis < 3; ++axis) {
+    Vector3d scale_factor{2, 2, 2};
+    scale_factor(axis) = 1;
+
+    std::vector<VolumeVertex<double>> p_MVs;
+    std::transform(
+        unit_p_MVs.begin(), unit_p_MVs.end(), std::back_inserter(p_MVs),
+        [&scale_factor](const VolumeVertex<double>& v) {
+          return VolumeVertex<double>(v.r_MV().cwiseProduct(scale_factor));
+        });
+    std::vector<VolumeElement> split_tetrahedra;
+
+    SplitOctohedron(octo_vertices, p_MVs, &split_tetrahedra);
+
+    EXPECT_EQ(split_tetrahedra.size(), 4u);
+    // Confirm that every tetrahedron has the expected split edge and *doesn't*
+    // have the other split edges.
+    int split_count[3] = {0, 0, 0};
+    for (const auto& tet : split_tetrahedra) {
+      for (int v = 0; v < 3; ++v) {
+        for (int u = v + 1; u < 4; ++u) {
+          SortedPair<VIndex> test_edge(tet.vertex(v), tet.vertex(u));
+          for (int ax = 0; ax < 3; ++ax) {
+            if (test_edge == split_edges[ax]) ++split_count[ax];
+          }
+        }
+      }
+    }
+    EXPECT_EQ(split_count[axis], 4);
+    EXPECT_EQ(split_count[(axis + 1) % 3], 0);
+    EXPECT_EQ(split_count[(axis + 2) % 3], 0);
   }
 }
 


### PR DESCRIPTION
1. The new code no longer introduces duplicate vertices.
2. The new code also implements the quality metric to choose the split direction for the internal octohedron.
3. Expanded tests
   - Smoke test for creating Autodiff -valued mesh.
   - Simple test on unique vertices.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/11996)
<!-- Reviewable:end -->
