### PR TITLE
Fix setup scripts for various Homebrew changes/removals

### DIFF
--- a/doc/bazel.rst
+++ b/doc/bazel.rst
@@ -37,7 +37,7 @@ typical examples below; for more reading about target patterns, see:
 https://docs.bazel.build/versions/master/user-manual.html#target-patterns.
 
 On Ubuntu, the default compiler is the first ``gcc`` compiler in the
-``PATH``, usually GCC 5.4 on Xenial and GCC 7.3 on Bionic. On macOS, the
+``PATH``, usually GCC 5.4 on Xenial and GCC 7.4 on Bionic. On macOS, the
 default compiler is the Apple LLVM compiler. To use Clang 6.0 on Ubuntu, set
 the ``CC`` and ``CXX`` environment variables before running **bazel build**,
 **bazel test**, or any other **bazel** commands.

--- a/doc/developers.rst
+++ b/doc/developers.rst
@@ -75,22 +75,22 @@ integration. All other configurations are provided on a best-effort basis.
 
 Drake requires a compiler running in C++14 mode or greater.
 
-+----------------------------------+-------+-------+---------------------+------------+---------+
-| Operating System                 | Bazel | CMake | C/C++ Compiler      | Java       | Python  |
-+==================================+=======+=======+=====================+============+=========+
-+----------------------------------+-------+-------+---------------------+------------+---------+
-| Ubuntu 16.04 LTS (Xenial Xerus)  | 0.29  | 3.5   | | Clang 6.0         | OpenJDK 8  | [2.7]   |
-|                                  |       |       | | GCC 5.4           |            |         |
-+----------------------------------+       +-------+---------------------+------------+---------+
-| Ubuntu 18.04 LTS (Bionic Beaver) |       | 3.10  | | Clang 6.0         | OpenJDK 11 | | 2.7   |
-|                                  |       |       | | GCC 7.3           |            | | [3.6] |
-+----------------------------------+       +-------+---------------------+------------+---------+
-| macOS High Sierra (10.13)        |       | 3.15  | | Apple LLVM 10.0.0 | Oracle 12  | | 2.7   |
-|                                  |       |       | | (Xcode 10.1)      |            | | [3.7] |
-+----------------------------------+       |       +---------------------+            |         |
-| macOS Mojave (10.14)             |       |       | | Apple LLVM 10.0.1 |            |         |
-|                                  |       |       | | (Xcode 10.3)      |            |         |
-+----------------------------------+-------+-------+---------------------+------------+---------+
++----------------------------------+-------+-------+---------------------+-------------------+---------+
+| Operating System                 | Bazel | CMake | C/C++ Compiler      | Java              | Python  |
++==================================+=======+=======+=====================+===================+=========+
++----------------------------------+-------+-------+---------------------+-------------------+---------+
+| Ubuntu 16.04 LTS (Xenial Xerus)  | 0.29  | 3.5   | | Clang 6.0         | OpenJDK 8         | [2.7]   |
+|                                  |       |       | | GCC 5.4           |                   |         |
++----------------------------------+       +-------+---------------------+-------------------+---------+
+| Ubuntu 18.04 LTS (Bionic Beaver) |       | 3.10  | | Clang 6.0         | OpenJDK 11        | | 2.7   |
+|                                  |       |       | | GCC 7.4           |                   | | [3.6] |
++----------------------------------+       +-------+---------------------+-------------------+---------+
+| macOS High Sierra (10.13)        |       | 3.15  | | Apple LLVM 10.0.0 | | AdoptOpenJDK 12 | | 2.7   |
+|                                  |       |       | | (Xcode 10.1)      | | (HotSpot JVM)   | | [3.7] |
++----------------------------------+       |       +---------------------+                   |         |
+| macOS Mojave (10.14)             |       |       | | Apple LLVM 10.0.1 |                   |         |
+|                                  |       |       | | (Xcode 10.3)      |                   |         |
++----------------------------------+-------+-------+---------------------+-------------------+---------+
 
 CPython is the only Python implementation supported; default versions are
 indicated in square brackets. On Ubuntu, amd64 (i.e., x86_64) is the only
@@ -128,7 +128,7 @@ to :ref:`ask for help <getting_help>`.
 Binary Packages
 ---------------
 
-The binary releases of Drake are built with GCC 5.4 on Ubuntu Xenial, GCC 7.3
+The binary releases of Drake are built with GCC 5.4 on Ubuntu Xenial, GCC 7.4
 on Ubuntu Bionic, and Apple LLVM 10.0.1 on macOS Mojave.
 
 The links for these packages are listed in :ref:`binary-installation`.

--- a/doc/getting_help.rst
+++ b/doc/getting_help.rst
@@ -44,7 +44,7 @@ When reporting an issue, please consider providing the following information
 *   Operating system (*Ubuntu 16.04 / 18.04, macOS 10.14*)
 *   Language (C++, :ref:`Python <python-bindings>`)
 
-    -   C++ compiler (*GCC 7.3.0, Clang 6.0.0*)
+    -   C++ compiler (*GCC 7.4.0, Clang 6.0.0*)
     -   Python version (*Python 2.7.15, Python 3.6.7*)
     -   Python distribution (*apt, homebrew*)
 

--- a/setup/mac/binary_distribution/Brewfile
+++ b/setup/mac/binary_distribution/Brewfile
@@ -27,6 +27,6 @@ brew 'robotlocomotion/director/vtk@8.2'
 brew 'yaml-cpp'
 brew 'zeromq'
 
-cask 'java' unless system '/usr/libexec/java_home --version 1.8+ --failfast &> /dev/null'
+cask 'adoptopenjdk' unless system '/usr/libexec/java_home --version 1.8+ --failfast &> /dev/null'
 
 mas 'Xcode', id: 497799835 unless File.exist? '/Applications/Xcode.app'

--- a/setup/mac/binary_distribution/requirements.txt
+++ b/setup/mac/binary_distribution/requirements.txt
@@ -1,8 +1,10 @@
 lxml
 matplotlib
+protobuf; python_version < "3.0"
 pydot
 PyYAML
 pyzmq
+scipy; python_version < "3.0"
 six
 tornado
 u-msgpack-python


### PR DESCRIPTION
For anyone looking at this in a few days/weeks when there are `numpy` issues, the fix is going to be ```numpy; python_version < "3.0"``` in `setup/mac/binary_distribution/requirements.txt`.

Relates #12003.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12004)
<!-- Reviewable:end -->
