### PR TITLE
jupyter: Test deprecation in notebooks

### DIFF
--- a/bindings/pydrake/common/BUILD.bazel
+++ b/bindings/pydrake/common/BUILD.bazel
@@ -94,6 +94,13 @@ drake_py_library(
     name = "deprecation_py",
     srcs = ["deprecation.py"],
     imports = PACKAGE_INFO.py_imports,
+    visibility = [
+        "//bindings/pydrake:__subpackages__",
+        # Allow Drake's Jupyter scaffolding to import this module directly,
+        # without also importing all of pydrake. This is only sound because
+        # none of the transitive `deps` of this target use C++ code.
+        "//tools/jupyter:__pkg__",
+    ],
 )
 
 # N.B. Since `module_py` incorporates `deprecation_py`, C++ Python libraries

--- a/bindings/pydrake/common/deprecation.py
+++ b/bindings/pydrake/common/deprecation.py
@@ -12,6 +12,7 @@ If you would like to disable all Drake-related warnings, you may use the
 `"ignore"` action for `warnings.simplefilter`.
 """
 
+import os
 import sys
 import traceback
 from types import ModuleType
@@ -214,5 +215,9 @@ def _forward_callables_as_deprecated(var_dict, m_new, date):
         var_dict[symbol] = old
 
 
-warnings.simplefilter('once', DrakeDeprecationWarning)
+if os.environ.get("_DRAKE_DEPRECATION_IS_ERROR") == "1":
+    # This is used for testing Jupyter notebooks in `jupyter_bazel`.
+    warnings.simplefilter('error', DrakeDeprecationWarning)
+else:
+    warnings.simplefilter('once', DrakeDeprecationWarning)
 _installed_numpy_warning_filters = False

--- a/tools/jupyter/BUILD.bazel
+++ b/tools/jupyter/BUILD.bazel
@@ -7,7 +7,7 @@ load(
     "drake_py_library",
     "drake_py_unittest",
 )
-load("//tools/jupyter:jupyter_py.bzl", "jupyter_py_binary")
+load("//tools/jupyter:jupyter_py.bzl", "drake_jupyter_py_binary")
 
 drake_py_library(
     name = "module_py",
@@ -28,14 +28,14 @@ drake_py_library(
     imports = [":module_py"],
 )
 
-jupyter_py_binary(
+drake_jupyter_py_binary(
     name = "example",
     add_test_rule = 1,
     deps = [":example_library"],
 )
 
 # Add example failing notebook.
-jupyter_py_binary(
+drake_jupyter_py_binary(
     name = "failing_notebook",
     testonly = 1,
     # Do not test this on its own because it is a negative test fixture for
@@ -44,10 +44,27 @@ jupyter_py_binary(
     notebook = "test/failing_notebook.ipynb",
 )
 
+# Add example failing notebook due to deprecation.
+drake_jupyter_py_binary(
+    name = "failing_notebook_deprecation",
+    testonly = 1,
+    # Do not test this on its own because it is a negative test fixture for
+    # `failing_notebook_test`.
+    add_test_rule = 0,
+    notebook = "test/failing_notebook_deprecation.ipynb",
+    deps = [
+        # N.B. Use granular target which does not depend on C extensions.
+        "//bindings/pydrake/common:deprecation_py",
+    ],
+)
+
 # Ensure the notebook fails as expected.
 drake_py_unittest(
     name = "failing_notebook_test",
-    deps = [":failing_notebook"],
+    deps = [
+        ":failing_notebook",
+        ":failing_notebook_deprecation",
+    ],
 )
 
 add_lint_tests()

--- a/tools/jupyter/README.md
+++ b/tools/jupyter/README.md
@@ -15,17 +15,17 @@ illustrated below.
 
 ## Adding Bazel Targets
 
-The file `jupyter_py.bzl` contains the Skylark macro `jupyter_py_binary` which
-defines a Python target to run the notebook. As is always the case, ensure that
-you add the appropriate Python dependencies (`deps = [...]`) and data
-dependencies (`data = [...]`). All notebooks should be tested by using
+The file `jupyter_py.bzl` contains the Skylark macro `drake_jupyter_py_binary`
+which defines a Python target to run the notebook. As is always the case,
+ensure that you add the appropriate Python dependencies (`deps = [...]`) and
+data dependencies (`data = [...]`). All notebooks should be tested by using
 `add_test_rule = 1`.
 
 As an example:
 
-    load("//tools/jupyter:jupyter_py.bzl", "jupyter_py_binary")
+    load("//tools/jupyter:jupyter_py.bzl", "drake_jupyter_py_binary")
 
-    jupyter_py_binary(
+    drake_jupyter_py_binary(
         name = "example",
         add_test_rule = 1,
         deps = [":example_library"],

--- a/tools/jupyter/jupyter_bazel.py
+++ b/tools/jupyter/jupyter_bazel.py
@@ -50,6 +50,10 @@ def _jupyter_bazel_notebook_main(cur_dir, notebook_file, argv):
         # Ensure that we use the notebook's directory, since that is used for
         # interactive sessions.
         notebook_dir = os.path.dirname(notebook_path)
+        # Ensure that Drake deprecations are seen as errors.
+        # TODO(eric.cousineau): Rather than use environment variables, try
+        # injecting code into the kernel.
+        os.environ["_DRAKE_DEPRECATION_IS_ERROR"] = "1"
         # TODO(eric.cousineau): See if there is a way to redirect this to
         # stdout, rather than having the notebook capture the output.
         ep = ExecutePreprocessor(timeout=600, kernel_name='python3')

--- a/tools/jupyter/jupyter_py.bzl
+++ b/tools/jupyter/jupyter_py.bzl
@@ -46,7 +46,7 @@ if __name__ == "__main__":
     main()
 """.lstrip()
 
-def jupyter_py_binary(
+def drake_jupyter_py_binary(
         name,
         notebook = None,
         srcs = None,

--- a/tools/jupyter/test/failing_notebook_deprecation.ipynb
+++ b/tools/jupyter/test/failing_notebook_deprecation.ipynb
@@ -1,0 +1,59 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Example of a notebook with deprecated code, and a test fixture for `failing_notebook_test`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "\n",
+    "from pydrake.common.deprecation import DrakeDeprecationWarning"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "warnings.warn(\"Deprecation example\", category=DrakeDeprecationWarning)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tools/jupyter/test/failing_notebook_test.py
+++ b/tools/jupyter/test/failing_notebook_test.py
@@ -17,3 +17,15 @@ class TestFailingNotebook(unittest.TestCase):
         stdout, _ = p.communicate()
         self.assertEqual(p.poll(), 1)
         self.assertIn("CellExecutionError", stdout.decode("utf8"))
+
+    @unittest.skipIf(IS_UNSUPPORTED, "Unsupported Jupyter platform")
+    def test_failing_notebook_deprecation(self):
+        p = subprocess.Popen([
+            "tools/jupyter/failing_notebook_deprecation",
+            "--test",
+        ], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        stdout, _ = p.communicate()
+        self.assertEqual(p.poll(), 1)
+        message = stdout.decode("utf8")
+        self.assertIn("CellExecutionError", message)
+        self.assertIn("DrakeDeprecationWarning: Deprecation example", message)

--- a/tutorials/BUILD.bazel
+++ b/tutorials/BUILD.bazel
@@ -7,9 +7,9 @@ load(
     "drake_py_library",
     "drake_py_unittest",
 )
-load("//tools/jupyter:jupyter_py.bzl", "jupyter_py_binary")
+load("//tools/jupyter:jupyter_py.bzl", "drake_jupyter_py_binary")
 
-jupyter_py_binary(
+drake_jupyter_py_binary(
     name = "mathematical_program",
     add_test_rule = 1,
     deps = [
@@ -17,7 +17,7 @@ jupyter_py_binary(
     ],
 )
 
-jupyter_py_binary(
+drake_jupyter_py_binary(
     name = "solver_parameters",
     add_test_rule = 1,
     deps = [


### PR DESCRIPTION
Follow-up to #11960

This ensures that deprecation errors are caught in notebook tests.
I perused the documentation for `nbconvert` to see if there was an easy way to inject code into the executing kernels, but did not see a way that was usable by Ubuntu Bionic's current version, hence the (ab)usage of environment variables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12005)
<!-- Reviewable:end -->
