### PR TITLE
Deprecate Simulator::StepTo()

### DIFF
--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -606,7 +606,9 @@ class TestPlant(unittest.TestCase):
         # Ensure we can tick this system. If so, all type conversions
         # are working properly.
         simulator = Simulator(diagram)
-        simulator.StepTo(0.01)
+        simulator.AdvanceTo(0.01)
+        with catch_drake_warnings(expected_count=1):
+            simulator.StepTo(0.011)
 
     @numpy_compare.check_all_types
     def test_model_instance_state_access(self, T):

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -107,6 +107,7 @@ drake_pybind_library(
         "//bindings/pydrake:documentation_pybind",
         "//bindings/pydrake/common:cpp_template_pybind",
         "//bindings/pydrake/common:default_scalars_pybind",
+        "//bindings/pydrake/common:deprecation_pybind",
         "//bindings/pydrake/common:wrap_pybind",
     ],
     cc_srcs = ["analysis_py.cc"],

--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -2,6 +2,7 @@
 
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
+#include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/wrap_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
@@ -85,8 +86,12 @@ PYBIND11_MODULE(analysis, m) {
             py::keep_alive<3, 1>(), doc.Simulator.ctor.doc)
         .def("Initialize", &Simulator<T>::Initialize,
             doc.Simulator.Initialize.doc)
-        .def("AdvanceTo", &Simulator<T>::AdvanceTo, doc.Simulator.AdvanceTo.doc)
-        .def("StepTo", &Simulator<T>::StepTo, "Use AdvanceTo() instead.")
+        .def("AdvanceTo", &Simulator<T>::AdvanceTo, py::arg("boundary_time"),
+            doc.Simulator.AdvanceTo.doc)
+        .def("StepTo",
+            WrapDeprecated(
+                doc.Simulator.StepTo.doc_deprecated, &Simulator<T>::AdvanceTo),
+            doc.Simulator.StepTo.doc_deprecated)
         .def("get_context", &Simulator<T>::get_context, py_reference_internal,
             doc.Simulator.get_context.doc)
         .def("get_integrator", &Simulator<T>::get_integrator,

--- a/examples/atlas/atlas_run_dynamics.cc
+++ b/examples/atlas/atlas_run_dynamics.cc
@@ -112,7 +112,7 @@ int do_main() {
 
   simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
   simulator.Initialize();
-  simulator.StepTo(FLAGS_simulation_time);
+  simulator.AdvanceTo(FLAGS_simulation_time);
 
   return 0;
 }

--- a/examples/multibody/inclined_plane_with_body/inclined_plane_with_body.cc
+++ b/examples/multibody/inclined_plane_with_body/inclined_plane_with_body.cc
@@ -172,7 +172,7 @@ int do_main() {
   simulator.set_publish_every_time_step(false);
   simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
   simulator.Initialize();
-  simulator.StepTo(FLAGS_simulation_time);
+  simulator.AdvanceTo(FLAGS_simulation_time);
 
   return 0;
 }

--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -305,7 +305,7 @@ class Simulator {
   }
 
 #ifndef DRAKE_DOXYGEN_CXX
-  // To be deprecated -- use AdvanceTo() instead.
+  DRAKE_DEPRECATED("2020-01-01", "Use AdvanceTo() instead.")
   void StepTo(const T& boundary_time) { AdvanceTo(boundary_time); }
 #endif
 
@@ -907,7 +907,7 @@ void Simulator<T>::HandlePublish(
 }
 
 template <typename T>
-void Simulator<T>::AdvanceTo(const T &boundary_time) {
+void Simulator<T>::AdvanceTo(const T& boundary_time) {
   if (!initialization_done_) Initialize();
 
   DRAKE_THROW_UNLESS(boundary_time >= context_->get_time());


### PR DESCRIPTION
The Simulator's StepTo() method was replaced long ago by AdvanceTo(), and removed from Doxygen at the time. Due to there being a lot of user examples still using StepTo(), it was not officially deprecated then. This PR deprecates StepTo() so any recalcitrant users of it will now get warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12008)
<!-- Reviewable:end -->
