### PR TITLE
fix the link of the mathematical program tutorial.

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -32,7 +32,7 @@ Core Library
                 <img src="_images/systems.svg" width="195px"/>
             </td>
             <td style="text-align:center;vertical-align:top" width="200px">
-                <a target="_mathematical_program" href="https://colab.research.google.com/github/RussTedrake/underactuated/blob/master/src/mathematical_program_examples.ipynb">
+                <a target="_mathematical_program" href="https://nbviewer.jupyter.org/github/RobotLocomotion/drake/blob/master/tutorials/mathematical_program.ipynb">
                 Solving Mathematical Programs</a>
                 <p/>
                 <img src="_images/mathematical_program.svg" width="150px"/>


### PR DESCRIPTION
Jeremy points out we can render the jupyter notebook nicely with `nbviewer`, as suggested by https://help.github.com/en/articles/working-with-jupyter-notebook-files-on-github

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12023)
<!-- Reviewable:end -->
