### PR TITLE
workspace: Remove unused ignition_rndf (drake.cps)

### DIFF
--- a/tools/install/libdrake/drake.cps
+++ b/tools/install/libdrake/drake.cps
@@ -25,11 +25,6 @@
       "Hints": ["@prefix@/lib/cmake/ignition-math4"],
       "X-CMake-Find-Args": ["CONFIG"]
     },
-    "ignition-rndf0": {
-      "Version": "0.1.5",
-      "Hints": ["@prefix@/lib/cmake/ignition-rndf0"],
-      "X-CMake-Find-Args": ["CONFIG"]
-    },
     "lcm": {
       "Version": "1.3.95",
       "Hints": ["@prefix@/lib/cmake/lcm"],
@@ -72,7 +67,6 @@
         "Eigen3:Eigen",
         "fmt:fmt-header-only",
         "ignition-math4:ignition-math4",
-        "ignition-rndf0:ignition-rndf0",
         "lcm:lcm",
         "optitrack:optitrack-lcmtypes-cpp",
         "protobuf:libprotobuf",


### PR DESCRIPTION
This completes the removal in a97a63215accc499badfd0b3c13fd72f6ff542d5 (#12014).

Failure from https://circleci.com/gh/RussTedrake/underactuated/1467:
```
CMake Error at /usr/share/cmake-3.10/Modules/CMakeFindDependencyMacro.cmake:48 (find_package):
  Could not find a package configuration file provided by "ignition-rndf0"
  (requested version 0.1.5) with any of the following names:

    ignition-rndf0Config.cmake
    ignition-rndf0-config.cmake

  Add the installation prefix of "ignition-rndf0" to CMAKE_PREFIX_PATH or set
  "ignition-rndf0_DIR" to a directory containing one of the above files.  If
  "ignition-rndf0" provides a separate development package or SDK, be sure it
  has been installed.
Call Stack (most recent call first):
  /opt/drake/lib/cmake/drake/drake-config.cmake:70 (find_dependency)
  CMakeLists.txt:32 (find_package)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12024)
<!-- Reviewable:end -->
