### PR TITLE
[geometry] Read Wavefront obj file into SurfaceMesh.

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -273,13 +273,19 @@ drake_cc_library(
 
 # -----------------------------------------------------
 
-drake_cc_googletest(
-    name = "proximity_engine_test",
-    data = [
+filegroup(
+    name = "test_obj_files",
+    testonly = 1,
+    srcs = [
         "test/forbidden_two_cubes.obj",
         "test/quad_cube.mtl",
         "test/quad_cube.obj",
     ],
+)
+
+drake_cc_googletest(
+    name = "proximity_engine_test",
+    data = [":test_obj_files"],
     deps = [
         ":proximity_engine",
         ":shape_specification",

--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -23,6 +23,7 @@ drake_cc_package_library(
         ":mesh_field",
         ":mesh_half_space_intersection",
         ":mesh_intersection",
+        ":obj_to_surface_mesh",
         ":proximity_utilities",
         ":sorted_triplet",
         ":surface_mesh",
@@ -163,6 +164,18 @@ drake_cc_library(
         "//geometry/proximity:volume_mesh",
         "//geometry/query_results:contact_surface",
         "//math:geometric_transform",
+    ],
+)
+
+drake_cc_library(
+    name = "obj_to_surface_mesh",
+    srcs = ["obj_to_surface_mesh.cc"],
+    hdrs = ["obj_to_surface_mesh.h"],
+    deps = [
+        ":surface_mesh",
+        "//common:essential",
+        "@fmt",
+        "@tinyobjloader",
     ],
 )
 
@@ -326,6 +339,18 @@ drake_cc_googletest(
     deps = [
         "//common/test_utilities:eigen_matrix_compare",
         "//geometry/proximity:mesh_intersection",
+    ],
+)
+
+drake_cc_googletest(
+    name = "obj_to_surface_mesh_test",
+    data = [
+        "//geometry:test_obj_files",
+    ],
+    deps = [
+        ":obj_to_surface_mesh",
+        "//common:find_resource",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/geometry/proximity/obj_to_surface_mesh.cc
+++ b/geometry/proximity/obj_to_surface_mesh.cc
@@ -1,0 +1,165 @@
+#include "drake/geometry/proximity/obj_to_surface_mesh.h"
+
+#include <fstream>
+#include <istream>
+#include <numeric>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <fmt/format.h>
+#include <tiny_obj_loader.h>
+
+#include "drake/common/drake_assert.h"
+#include "drake/geometry/proximity/surface_mesh.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+// TODO(DamrongGuoy): Refactor the tinyobj usage between here and
+//  ProximityEngine.
+
+// TODO(DamrongGuoy): Remove the guard DRAKE_DOXYGEN_CXX when we fixed
+//  issue#11130 "doxygen: Do not emit for `*.cc` files, also ignore
+//  `internal` namespace when appropriate".
+
+#ifndef DRAKE_DOXYGEN_CXX
+
+/**
+ Converts vertices of tinyobj to vertices of SurfaceMesh.
+ @param tinyobj_vertices
+     Vertices from tinyobj represented as `std::vector` of floating-point
+     numbers.
+ @param scale
+     A scale to coordinates.
+ @return
+     Vertices for SurfaceMesh.
+ @pre
+     The size of `tinyobj_vertices` is divisible by three.
+ */
+std::vector<SurfaceVertex<double>> TinyObjToSurfaceVertices(
+    const std::vector<tinyobj::real_t>& tinyobj_vertices, const double scale) {
+  // Vertices from tinyobj are in a vector of floating-point numbers like this:
+  //     tinyobj_vertices = {c₀,c₁,c₂, c₃,c₄,c₅, c₆,c₇,c₈,...}
+  //                      = {x, y, z,  x, y, z,  x, y, z,...}
+  // We will convert to a vector of Vector3<double> like this:
+  //     vertices = {{c₀,c₁,c₂}, {c₃,c₄,c₅}, {c₆,c₇,c₈},...}
+  //              = {    v0,         v1,         v2,...}
+  const int num_coords = tinyobj_vertices.size();
+  DRAKE_DEMAND(num_coords % 3 == 0);
+  std::vector<SurfaceVertex<double>> vertices;
+  vertices.reserve(num_coords / 3);
+
+  auto iter = tinyobj_vertices.begin();
+  while (iter != tinyobj_vertices.end()) {
+    double x = *(iter++) * scale;
+    double y = *(iter++) * scale;
+    double z = *(iter++) * scale;
+    vertices.emplace_back(Vector3<double>(x, y, z));
+  }
+  return vertices;
+}
+
+/**
+ Converts faces of tinyobj::mesh_t to faces of SurfaceMesh.
+ @param[in] mesh
+     The mesh from tinyobj.
+ @param[out] faces
+     Triangles from previous meshes plus new triangles from this `mesh` on
+     return.
+ @pre
+     Every face is a triangle.
+ */
+void TinyObjToSurfaceFaces(const tinyobj::mesh_t& mesh,
+                           std::vector<SurfaceFace>* faces) {
+  //
+  // In general, tinyobj::mesh_t::num_face_vertices is a list of number
+  // of vertices of each polygonal face like this:
+  //     mesh.num_face_vertices = {n₀, n₁, n₂,...},
+  // where faceᵢ has nᵢ vertices. In this function, we require every face to
+  // be a triangle, so every nᵢ is 3 like this:
+  //     mesh.num_face_vertices = {3, 3, 3,...}.
+  //
+  // In general, tinyobj::mesh_t::indices concatenates tinyobj::index_t of
+  // vertices of each face like this:
+  //     mesh.indices = {v0₀,v0₁,...,v0ₙ₀₋₁, v1₀,v1₁,...,v1ₙ₁₋₁, ...}.
+  //                     -------face0------  -------face1------
+  // Because this function requires the faces to be triangles, it must look
+  // like this:
+  //     mesh.indices = {v0₀,v0₁,v0₂, v1₀,v1₁,v1₂, ...}.
+  //                     ---face0---  ---face1---
+  //
+  // Each tinyobj::index_t consists of vertex_index, normal_index, and
+  // texcoord_index. In this function, we use only vertex_index.
+  //
+  const int num_faces = mesh.num_face_vertices.size();
+  const int num_indices = mesh.indices.size();
+  // Although we will validate each face as a triangle individually, we make
+  // sure that there are enough vertices for that to be true as an initial
+  // check.
+  DRAKE_DEMAND(3 * num_faces == num_indices);
+  for (int face = 0; face < num_faces; ++face) {
+    DRAKE_DEMAND(mesh.num_face_vertices[face] == 3);
+    const int vertex_indices[3] = {mesh.indices[3 * face].vertex_index,
+                                   mesh.indices[3 * face + 1].vertex_index,
+                                   mesh.indices[3 * face + 2].vertex_index};
+    faces->emplace_back(vertex_indices);
+  }
+}
+
+#endif  // #ifndef DRAKE_DOXYGEN_CXX
+
+SurfaceMesh<double> ReadObjToSurfaceMesh(const std::string& filename,
+                                         const double scale) {
+  std::ifstream input_stream(filename);
+  if (!input_stream.is_open()) {
+    throw std::runtime_error("Cannot open file '" + filename +"'");
+  }
+  return ReadObjToSurfaceMesh(&input_stream, scale);
+}
+
+SurfaceMesh<double> ReadObjToSurfaceMesh(std::istream* input_stream,
+                                         const double scale) {
+  tinyobj::attrib_t attrib;  // Used for vertices.
+  std::vector<tinyobj::shape_t> shapes;  // Used for triangles.
+  std::vector<tinyobj::material_t> materials;  // Not used.
+  std::string err;
+  // Ignore material-library file.
+  tinyobj::MaterialReader* readMatFn = nullptr;
+  // triangulate non-triangle faces.
+  bool triangulate = true;
+
+  bool ret = tinyobj::LoadObj(&attrib, &shapes, &materials, &err, input_stream,
+                              readMatFn, triangulate);
+  if (!ret || !err.empty()) {
+    throw std::runtime_error("Error parsing Wavefront obj file : " + err);
+  }
+  if (shapes.size() == 0) {
+    throw std::runtime_error("The Wavefront obj file has no faces.");
+  }
+  std::vector<SurfaceVertex<double>> vertices =
+      TinyObjToSurfaceVertices(attrib.vertices, scale);
+
+  // tinyobj stores vertices from all objects in attrib.vertices but stores
+  // faces from each object separately. We will keep all faces together in
+  // the return SurfaceMesh. First we calculate the total number of faces of
+  // all objects, so we can pre-allocate memory for all faces of SurfaceMesh.
+  int total_num_faces =
+      std::accumulate(shapes.begin(), shapes.end(), 0,
+                      [](int sum, const tinyobj::shape_t& shape) {
+                        return sum + shape.mesh.num_face_vertices.size();
+                      });
+  std::vector<SurfaceFace> faces;
+  faces.reserve(total_num_faces);
+  for (const tinyobj::shape_t& shape : shapes) {
+    TinyObjToSurfaceFaces(shape.mesh, &faces);
+  }
+
+  return SurfaceMesh<double>(std::move(faces), std::move(vertices));
+}
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/obj_to_surface_mesh.h
+++ b/geometry/proximity/obj_to_surface_mesh.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <istream>
+#include <string>
+#include <vector>
+
+#include "drake/geometry/proximity/surface_mesh.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+/**
+ Constructs a surface mesh from a Wavefront .obj file and optionally scales
+ coordinates by the given scale factor. Polygons will be triangulated if they
+ are not triangles already. All objects in the .obj file will be merged into
+ the surface mesh. See https://en.wikipedia.org/wiki/Wavefront_.obj_file for
+ the file format.
+ @param filename
+     A valid file name with absolute path or relative path.
+ @param scale
+     An optional scale to coordinates.
+ @throws std::runtime_error if `filename` doesn't have a valid file path, or the
+     file has no faces.
+ @return surface mesh
+ */
+SurfaceMesh<double> ReadObjToSurfaceMesh(const std::string& filename,
+                                         double scale = 1.0);
+
+/**
+ Overload of @ref ReadObjToSurfaceMesh(const std::string&, double) with the
+ Wavefront .obj file given in std::istream.
+ */
+SurfaceMesh<double> ReadObjToSurfaceMesh(std::istream* input_stream,
+                                         double scale = 1.0);
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/test/obj_to_surface_mesh_test.cc
+++ b/geometry/proximity/test/obj_to_surface_mesh_test.cc
@@ -1,0 +1,227 @@
+#include "drake/geometry/proximity/obj_to_surface_mesh.h"
+
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+#include "drake/common/find_resource.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/proximity/surface_mesh.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace {
+
+// Tests TinyObjToSurfaceVertices through ReadObjToSurfaceMesh. We cannot
+// test TinyObjToSurfaceVertices directly because we hide tinyobj from
+// public API.
+GTEST_TEST(ObjToSurfaceMeshTest, TinyObjToSurfaceVertices) {
+  std::istringstream test_stream {
+      "v  1.0 -1.0 -1.0\n"
+      "v  1.0 -1.0  1.0\n"
+      "v -1.0 -1.0  1.0\n"
+      "f 1 2 3\n"};
+  for (const double scale : {1.0, 2.0, 5.0}) {
+    // Seek to the beginning of the stream in each iteration.
+    test_stream.seekg(0, test_stream.beg);
+
+    const std::vector<SurfaceVertex<double>> surface_vertices(
+        ReadObjToSurfaceMesh(&test_stream, scale).vertices());
+
+    EXPECT_EQ(3, surface_vertices.size());
+    const std::vector<Vector3<double>> expect_vertices{
+        scale * Vector3<double>{1.0, -1.0, -1.0},  // first vertex.
+        scale * Vector3<double>{1.0, -1.0, 1.0},   // second vertex.
+        scale * Vector3<double>{-1.0, -1.0, 1.0}   // third vertex.
+    };
+
+    for (int i = 0; i < 3; ++i) {
+      EXPECT_EQ(expect_vertices[i], surface_vertices[i].r_MV());
+    }
+  }
+}
+
+
+// Tests TinyObjToSurfaceFaces through ReadObjToSurfaceMesh. We cannot test
+// TinyObjToSurfaceFaces directly because we hide tinyobj from public API.
+GTEST_TEST(ObjToSurfaceMeshTest, TinyObjToSurfaceFaces) {
+  std::istringstream test_stream{
+      "v  1.0 -1.0 -1.0\n"
+      "v  1.0 -1.0  1.0\n"
+      "v -1.0 -1.0  1.0\n"
+      "v -1.0 -1.0 -1.0\n"
+      "f 1 2 3\n"
+      "f 1 3 4\n"};
+
+  const std::vector<SurfaceFace> surface_faces(
+      ReadObjToSurfaceMesh(&test_stream).faces());
+
+  EXPECT_EQ(2, surface_faces.size());
+  // Vertex indices in obj file start with 1, but vertex indices in our
+  // SurfaceMesh start with 0.
+  const int expect_faces[2][3]{{0, 1, 2}, {0, 2, 3}};
+  auto face_equal = [](const SurfaceFace& f, const SurfaceFace& g) -> bool {
+    return std::make_tuple(f.vertex(0), f.vertex(1), f.vertex(2)) ==
+        std::make_tuple(g.vertex(0), g.vertex(1), g.vertex(2));
+  };
+  for (int i = 0; i < 2; ++i) {
+    EXPECT_TRUE(face_equal(SurfaceFace(expect_faces[i]), surface_faces[i]));
+  }
+}
+
+GTEST_TEST(ObjToSurfaceMeshTest, ReadObjToSurfaceMesh) {
+  const std::string filename =
+      FindResourceOrThrow("drake/geometry/test/quad_cube.obj");
+  SurfaceMesh<double> surface = ReadObjToSurfaceMesh(filename);
+
+  ASSERT_EQ(surface.num_vertices(), 8);
+  ASSERT_EQ(surface.num_faces(), 12);
+
+  // This test relies on the specific content of the file quad_cube.obj.
+  // These coordinates came from the first section of quad_cube.obj.
+  // clang-format off
+  std::vector<Vector3<double>> expect_vertices {
+      { 1.000000, -1.000000, -1.000000},
+      { 1.000000, -1.000000,  1.000000},
+      {-1.000000, -1.000000,  1.000000},
+      {-1.000000, -1.000000, -1.000000},
+      { 1.000000,  1.000000, -1.000000},
+      { 1.000000,  1.000000,  1.000001},
+      {-1.000000,  1.000000,  1.000000},
+      {-1.000000,  1.000000, -1.000000}
+  };
+  // clang-format on
+
+  for (int i = 0; i < 8; ++i) {
+    EXPECT_EQ(expect_vertices[i], surface.vertex(SurfaceVertexIndex(i)).r_MV());
+  }
+
+  // This test relies on the specific content of the file quad_cube.obj. The
+  // last section of quad_cube.obj describes the six square faces of the cube.
+  // We expect that each square is subdivided into two triangles. Note that
+  // vertex indices in the file quad_cube.obj are from 1 to 8, but tinyobj
+  // has vertex indices from 0 to 7. We assume that tinyobj subdivides a
+  // polygon into a triangle fan around the first vertex; polygon ABCDE...
+  // becomes triangles ABC, ACD, ADE, etc.
+  int expect_faces[12][3] {
+      {0, 1, 2}, {0, 2, 3},  // face 1 2 3 4 in quad_cube.obj
+      {4, 7, 6}, {4, 6, 5},  // face 5 8 7 6 in quad_cube.obj
+      {0, 4, 5}, {0, 5, 1},  // face 1 5 6 2 in quad_cube.obj
+      {1, 5, 6}, {1, 6, 2},  // face 2 6 7 3 in quad_cube.obj
+      {2, 6, 7}, {2, 7, 3},  // face 3 7 8 4 in quad_cube.obj
+      {4, 0, 3}, {4, 3, 7}   // face 5 1 4 8 in quad_cube.obj
+  };
+
+  auto face_equal = [](const SurfaceFace& f, const SurfaceFace& g) -> bool {
+    return std::make_tuple(f.vertex(0), f.vertex(1), f.vertex(2)) ==
+           std::make_tuple(g.vertex(0), g.vertex(1), g.vertex(2));
+  };
+  for (int i = 0; i < 12; ++i) {
+    EXPECT_TRUE(face_equal(SurfaceFace(expect_faces[i]),
+                           surface.element(SurfaceFaceIndex(i))));
+  }
+}
+
+GTEST_TEST(ObjToSurfaceMeshTest, ThrowExceptionInvalidFilePath) {
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      ReadObjToSurfaceMesh(std::string("invalid_file_path")),
+      std::runtime_error, "Cannot open file 'invalid_file_path'");
+}
+
+GTEST_TEST(ObjToSurfaceMeshTest, ThrowExceptionForEmptyFile) {
+  std::istringstream empty("");
+  DRAKE_EXPECT_THROWS_MESSAGE(ReadObjToSurfaceMesh(&empty),
+                              std::runtime_error,
+                              "The Wavefront obj file has no faces.");
+}
+
+GTEST_TEST(ObjToSurfaceMeshTest, ThrowExceptionFileHasNoFaces) {
+  std::istringstream no_faces{R"(
+v 1.0 0.0 0.0
+v 0.0 1.0 0.0
+v 0.0 0.0 1.0
+)"};
+  DRAKE_EXPECT_THROWS_MESSAGE(ReadObjToSurfaceMesh(&no_faces),
+                              std::runtime_error,
+                              "The Wavefront obj file has no faces.");
+}
+
+GTEST_TEST(ObjToSurfaceMeshTest, ThrowExceptionObjectHasNoFaces) {
+  std::istringstream no_faces{R"(
+o object_without_faces
+v 1.0 0.0 0.0
+v 0.0 1.0 0.0
+v 0.0 0.0 1.0
+)"};
+  DRAKE_EXPECT_THROWS_MESSAGE(ReadObjToSurfaceMesh(&no_faces),
+                              std::runtime_error,
+                              "The Wavefront obj file has no faces.");
+}
+
+// Confirms that we can accept an obj file with faces (f lines) without
+// objects (o lines).
+GTEST_TEST(ObjToSurfaceMeshTest, AcceptFacesWithoutObject) {
+  std::istringstream faces_without_objects{R"(
+v 1.0 0.0 0.0
+v 0.0 1.0 0.0
+v 0.0 0.0 1.0
+f 1 2 3
+)"};
+  SurfaceMesh<double> surface = ReadObjToSurfaceMesh(&faces_without_objects);
+  ASSERT_EQ(3, surface.num_vertices());
+  std::vector<Vector3<double>> expect_vertices {
+    {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, { 0.0, 0.0, 1.0 }
+  };
+  for (int i = 0; i < 3; ++i) {
+    EXPECT_EQ(expect_vertices[i], surface.vertex(SurfaceVertexIndex(i)).r_MV());
+  }
+  ASSERT_EQ(1, surface.num_faces());
+  int expect_face[3] = {0, 1, 2};
+  for (int v = 0; v < 3; ++v) {
+    EXPECT_EQ(expect_face[v],
+              surface.element(SurfaceFaceIndex(0)).vertex(v));
+  }
+}
+
+// Confirms that we can accept multiple objects in one obj file.
+GTEST_TEST(ObjToSurfaceMeshTest, AcceptMultipleObjects) {
+  std::istringstream two_objects{R"(
+o first_object
+v 1.0 0.0 0.0
+v 0.0 1.0 0.0
+v 0.0 0.0 1.0
+f 1 2 3
+
+o second_object
+v 2.0 0.0 0.0
+v 0.0 2.0 0.0
+v 0.0 0.0 2.0
+f 4 5 6
+)"};
+  SurfaceMesh<double> surface = ReadObjToSurfaceMesh(&two_objects);
+  ASSERT_EQ(6, surface.num_vertices());
+  std::vector<Vector3<double>> expect_vertices{
+      {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0},
+      {2.0, 0.0, 0.0}, {0.0, 2.0, 0.0}, {0.0, 0.0, 2.0}};
+  for (int i = 0; i < 6; ++i) {
+    EXPECT_EQ(expect_vertices[i], surface.vertex(SurfaceVertexIndex(i)).r_MV());
+  }
+  ASSERT_EQ(2, surface.num_faces());
+  int expect_faces[2][3]{{0, 1, 2}, {3, 4, 5}};
+  for (int f = 0; f < 2; ++f) {
+    for (int v = 0; v < 3; ++v) {
+      EXPECT_EQ(expect_faces[f][v],
+                surface.element(SurfaceFaceIndex(f)).vertex(v));
+    }
+  }
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
Support hydroelastic contact model by reading a Wavefront obj file for a rigid geometry into SurfaceMesh data structure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12036)
<!-- Reviewable:end -->
