### PR TITLE
Clean up geometry::internal doxygen contents

### DIFF
--- a/geometry/proximity/test/distance_to_point_with_gradient_test.cc
+++ b/geometry/proximity/test/distance_to_point_with_gradient_test.cc
@@ -11,6 +11,7 @@
 namespace drake {
 namespace geometry {
 namespace internal {
+namespace {
 
 const double kEps = std::numeric_limits<double>::epsilon();
 
@@ -146,6 +147,8 @@ GTEST_TEST(DistanceToPointTest, TestHalfspace) {
   p_GQ = -0.1 * halfspace.n;
   CheckDistanceToHalfspace(halfspace, X_WG, p_GQ);
 }
+
+}  // namespace
 }  // namespace internal
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/proximity/test/proximity_utilities_test.cc
+++ b/geometry/proximity/test/proximity_utilities_test.cc
@@ -8,6 +8,7 @@
 namespace drake {
 namespace geometry {
 namespace internal {
+namespace {
 
 using fcl::CollisionGeometryd;
 using fcl::CollisionObjectd;
@@ -59,6 +60,7 @@ GTEST_TEST(EncodedData, ConstructionFromFclObject) {
   }
 }
 
+}  // namespace
 }  // namespace internal
 }  // namespace geometry
 }  // namespace drake


### PR DESCRIPTION
There were some unit tests that weren't ultimately included in an
anonymous namespace. As such, looking in the geometry::internal namespace
was showing GTEST_TEST functions that didn't belong. This removes them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12039)
<!-- Reviewable:end -->
