### PR TITLE
Add new constructors of MultipleShooting which accept placeholders

### DIFF
--- a/solvers/decision_variable.h
+++ b/solvers/decision_variable.h
@@ -8,6 +8,9 @@
 
 namespace drake {
 namespace solvers {
+
+using DecisionVariable = symbolic::Variable;
+
 template <int rows, int cols>
 using MatrixDecisionVariable = Eigen::Matrix<symbolic::Variable, rows, cols>;
 template <int rows>

--- a/systems/trajectory_optimization/multiple_shooting.h
+++ b/systems/trajectory_optimization/multiple_shooting.h
@@ -342,7 +342,8 @@ class MultipleShooting : public solvers::MathematicalProgram {
   }
 
  protected:
-  /// Constructs a MultipleShooting instance with fixed sample times.
+  /// Constructs a MultipleShooting instance with fixed sample times. It creates
+  /// new placeholder variables for input and state.
   ///
   /// @param num_inputs Number of inputs at each sample point.
   /// @param num_states Number of states at each sample point.
@@ -351,8 +352,21 @@ class MultipleShooting : public solvers::MathematicalProgram {
   MultipleShooting(int num_inputs, int num_states, int num_time_samples,
                    double fixed_timestep);
 
+  /// Constructs a MultipleShooting instance with fixed sample times. It uses
+  /// the provided `input` and `state` as placeholders instead of creating new
+  /// placeholder variables for them.
+  ///
+  /// @param input Placeholder variables for input.
+  /// @param state Placeholder variables for state.
+  /// @param num_time_samples Number of time samples.
+  /// @param fixed_timestep The spacing between sample times.
+  MultipleShooting(const solvers::VectorXDecisionVariable& input,
+                   const solvers::VectorXDecisionVariable& state,
+                   int num_time_samples, double fixed_timestep);
+
   /// Constructs a MultipleShooting instance with sample times as decision
-  /// variables.
+  /// variables.  It creates new placeholder variables for input, state, and
+  /// time.
   ///
   /// @param num_inputs Number of inputs at each sample point.
   /// @param num_states Number of states at each sample point.
@@ -360,6 +374,21 @@ class MultipleShooting : public solvers::MathematicalProgram {
   /// @param minimum_timestep Minimum spacing between sample times.
   /// @param maximum_timestep Maximum spacing between sample times.
   MultipleShooting(int num_inputs, int num_states, int num_time_samples,
+                   double minimum_timestep, double maximum_timestep);
+
+  /// Constructs a MultipleShooting instance with sample times as decision
+  /// variables. It uses the provided `input`, `state`, and `time` as
+  /// placeholders instead of creating new placeholder variables for them.
+  ///
+  /// @param input Placeholder variables for input.
+  /// @param state Placeholder variables for state.
+  /// @param time Placeholder variable for time.
+  /// @param num_time_samples Number of time samples.
+  /// @param minimum_timestep Minimum spacing between sample times.
+  /// @param maximum_timestep Maximum spacing between sample times.
+  MultipleShooting(const solvers::VectorXDecisionVariable& input,
+                   const solvers::VectorXDecisionVariable& state,
+                   const solvers::DecisionVariable& time, int num_time_samples,
                    double minimum_timestep, double maximum_timestep);
 
   /// Replaces e.g. placeholder_x_var_ with x_vars_ at time interval
@@ -394,6 +423,12 @@ class MultipleShooting : public solvers::MathematicalProgram {
       const std::string& name) const;
 
  private:
+  MultipleShooting(const solvers::VectorXDecisionVariable& input,
+                   const solvers::VectorXDecisionVariable& state,
+                   int num_time_samples,
+                   const optional<solvers::DecisionVariable>& time_var,
+                   double minimum_timestep, double maximum_timestep);
+
   MultipleShooting(int num_inputs, int num_states, int num_time_samples,
                    bool timesteps_are_decision_variables,
                    double minimum_timestep, double maximum_timestep);

--- a/systems/trajectory_optimization/sequential_expression_manager.cc
+++ b/systems/trajectory_optimization/sequential_expression_manager.cc
@@ -7,6 +7,7 @@ namespace systems {
 namespace trajectory_optimization {
 namespace internal {
 
+using std::string;
 using symbolic::Expression;
 using symbolic::Substitution;
 using symbolic::Variable;
@@ -19,7 +20,7 @@ SequentialExpressionManager::SequentialExpressionManager(int num_samples)
 
 VectorX<Variable> SequentialExpressionManager::RegisterSequentialExpressions(
     const Eigen::Ref<const MatrixX<Expression>>& sequential_expressions,
-    const std::string& name) {
+    const string& name) {
   const int rows = sequential_expressions.rows();
   DRAKE_THROW_UNLESS(sequential_expressions.cols() == num_samples_);
   const VectorX<Variable> placeholders{
@@ -29,10 +30,9 @@ VectorX<Variable> SequentialExpressionManager::RegisterSequentialExpressions(
 }
 
 void SequentialExpressionManager::RegisterSequentialExpressions(
-    const VectorX<symbolic::Variable>& placeholders,
-    const Eigen::Ref<const MatrixX<symbolic::Expression>>&
-        sequential_expressions,
-    const std::string& name) {
+    const VectorX<Variable>& placeholders,
+    const Eigen::Ref<const MatrixX<Expression>>& sequential_expressions,
+    const string& name) {
   DRAKE_THROW_UNLESS(sequential_expressions.rows() == placeholders.size());
   DRAKE_THROW_UNLESS(sequential_expressions.cols() == num_samples_);
   const auto pair = name_to_placeholders_and_sequential_expressions_.insert(
@@ -59,7 +59,7 @@ SequentialExpressionManager::ConstructPlaceholderVariableSubstitution(
 }
 
 VectorX<Expression> SequentialExpressionManager::GetSequentialExpressionsByName(
-    const std::string& name, int index) const {
+    const string& name, int index) const {
   DRAKE_THROW_UNLESS(0 <= index && index < num_samples_);
   const auto it = name_to_placeholders_and_sequential_expressions_.find(name);
   DRAKE_THROW_UNLESS(it !=
@@ -68,7 +68,7 @@ VectorX<Expression> SequentialExpressionManager::GetSequentialExpressionsByName(
   return sequential_expressions.col(index);
 }
 
-int SequentialExpressionManager::num_rows(const std::string& name) const {
+int SequentialExpressionManager::num_rows(const string& name) const {
   const auto it = name_to_placeholders_and_sequential_expressions_.find(name);
   DRAKE_THROW_UNLESS(it !=
                      name_to_placeholders_and_sequential_expressions_.end());

--- a/systems/trajectory_optimization/sequential_expression_manager.h
+++ b/systems/trajectory_optimization/sequential_expression_manager.h
@@ -52,6 +52,29 @@ class SequentialExpressionManager {
       const std::string& name);
 
   /**
+   * Registers a placeholder variables and the associated sequential expression
+   * vector.
+   *
+   * @param placeholders Placeholder variables.
+   * @param sequential_expressions [size_of_placeholder_variables x num_samples]
+   *                               matrix of symbolic expressions.
+   *                               sequential_expressions(i, j) is the value of
+   *                               the i-th expression at the j-th index.
+   * @param name Name for the newly registered sequential expression vector.
+   * @throw std::runtime_error unless `sequential_expressions` has
+   *                           `placeholders.size()` rows.
+   * @throw std::runtime_error unless `sequential_expressions` has num_samples()
+   *                           columns.
+   * @throw std::runtime_error if it has an existing registration under the
+   *                           `name`.
+   */
+  void RegisterSequentialExpressions(
+      const VectorX<symbolic::Variable>& placeholders,
+      const Eigen::Ref<const MatrixX<symbolic::Expression>>&
+          sequential_expressions,
+      const std::string& name);
+
+  /**
    * Returns a symbolic::Substitution for replacing all placeholder variables
    * with their respective `index`-th expression.
    * @pre 0 <= index < num_samples()

--- a/systems/trajectory_optimization/test/multiple_shooting_test.cc
+++ b/systems/trajectory_optimization/test/multiple_shooting_test.cc
@@ -36,6 +36,18 @@ class MyDirectTrajOpt : public MultipleShooting {
       : MultipleShooting(num_inputs, num_states, num_time_samples, min_timestep,
                          max_timestep) {}
 
+  MyDirectTrajOpt(const solvers::VectorXDecisionVariable& input,
+                  const solvers::VectorXDecisionVariable& state,
+                  const int num_time_samples, const double fixed_timestep)
+      : MultipleShooting(input, state, num_time_samples, fixed_timestep) {}
+
+  MyDirectTrajOpt(const solvers::VectorXDecisionVariable& input,
+                  const solvers::VectorXDecisionVariable& state,
+                  const symbolic::Variable& time, const int num_time_samples,
+                  const double min_timestep, const double max_timestep)
+      : MultipleShooting(input, state, time, num_time_samples, min_timestep,
+                         max_timestep) {}
+
   PiecewisePolynomial<double> ReconstructInputTrajectory(
       const solvers::MathematicalProgramResult&) const override {
     return PiecewisePolynomial<double>();
@@ -47,12 +59,12 @@ class MyDirectTrajOpt : public MultipleShooting {
   };
 
   // Expose for unit testing.
-  using MultipleShooting::h_vars;
-  using MultipleShooting::x_vars;
-  using MultipleShooting::u_vars;
-  using MultipleShooting::timesteps_are_decision_variables;
   using MultipleShooting::fixed_timestep;
   using MultipleShooting::GetSequentialVariable;
+  using MultipleShooting::h_vars;
+  using MultipleShooting::timesteps_are_decision_variables;
+  using MultipleShooting::u_vars;
+  using MultipleShooting::x_vars;
 
  private:
   void DoAddRunningCost(const symbolic::Expression& g) override {}
@@ -79,6 +91,70 @@ GTEST_TEST(MultipleShootingTest, FixedTimestepTest) {
   EXPECT_THROW(prog.AddTimeIntervalBounds(0, .1), std::runtime_error);
   EXPECT_THROW(prog.AddEqualTimeIntervalsConstraints(), std::runtime_error);
   EXPECT_THROW(prog.AddDurationBounds(0, 1), std::runtime_error);
+}
+
+GTEST_TEST(MultipleShootingTest, FixedTimestepTestWithPlaceholderVariables) {
+  const VectorX<symbolic::Variable> input{
+      symbolic::MakeVectorContinuousVariable(3, "my_input")};
+  const VectorX<symbolic::Variable> state{
+      symbolic::MakeVectorContinuousVariable(4, "my_state")};
+  const int kNumSampleTimes{2};
+  const double kFixedTimeStep{0.1};
+  MyDirectTrajOpt prog(input, state, kNumSampleTimes, kFixedTimeStep);
+
+  EXPECT_FALSE(prog.timesteps_are_decision_variables());
+
+  EXPECT_EQ(prog.num_vars(), (input.size() + state.size()) * kNumSampleTimes);
+  solvers::MathematicalProgramResult result;
+  const Eigen::VectorXd times = prog.GetSampleTimes(result);
+  EXPECT_EQ(times.size(), 2);
+  EXPECT_EQ(times[0], 0.0);
+  EXPECT_EQ(times[1], 0.1);
+
+  const solvers::VectorXDecisionVariable& u = prog.input();
+  EXPECT_EQ(u, input);
+
+  const solvers::VectorXDecisionVariable& x = prog.state();
+  EXPECT_EQ(x, state);
+
+  // All methods involving timestep variables should throw.
+  EXPECT_THROW(prog.timestep(0), std::runtime_error);
+  EXPECT_THROW(prog.AddTimeIntervalBounds(0, .1), std::runtime_error);
+  EXPECT_THROW(prog.AddEqualTimeIntervalsConstraints(), std::runtime_error);
+  EXPECT_THROW(prog.AddDurationBounds(0, 1), std::runtime_error);
+}
+
+GTEST_TEST(MultipleShootingTest, VariableTimestepTestWithPlaceholderVariables) {
+  const VectorX<symbolic::Variable> input{
+      symbolic::MakeVectorContinuousVariable(3, "my_input")};
+  const VectorX<symbolic::Variable> state{
+      symbolic::MakeVectorContinuousVariable(4, "my_state")};
+  const symbolic::Variable time{"my_time"};
+  const int kNumSampleTimes{2};
+  const double kMinTimeStep{0.1};
+  const double kMaxTimeStep{0.1};
+  MyDirectTrajOpt prog(input, state, time, kNumSampleTimes, kMinTimeStep,
+                       kMaxTimeStep);
+
+  const solvers::VectorXDecisionVariable& u = prog.input();
+  EXPECT_EQ(u, input);
+
+  const solvers::VectorXDecisionVariable& x = prog.state();
+  EXPECT_EQ(x, state);
+
+  EXPECT_EQ(time, prog.time()[0]);
+
+  EXPECT_TRUE(prog.timesteps_are_decision_variables());
+  EXPECT_THROW(prog.fixed_timestep(), std::runtime_error);
+
+  EXPECT_EQ(prog.num_vars(), (input.size() + state.size()) * kNumSampleTimes +
+                                 1 /* time variable */);
+  const solvers::MathematicalProgramResult result = Solve(prog);
+  ASSERT_TRUE(result.is_success());
+  const Eigen::VectorXd times = prog.GetSampleTimes(result);
+  EXPECT_EQ(times.size(), 2);
+  EXPECT_NEAR(times[0], 0.0, kSolverTolerance);
+  EXPECT_NEAR(times[1], 0.1, kSolverTolerance);
 }
 
 GTEST_TEST(MultipleShootingTest, VariableTimestepTest) {
@@ -146,10 +222,10 @@ GTEST_TEST(MultipleShootingTest, PlaceholderVariableNames) {
   const double kFixedTimeStep{0.1};
   MyDirectTrajOpt prog(kNumInputs, kNumStates, kNumSampleTimes, kFixedTimeStep);
 
-  EXPECT_EQ(prog.time().coeff(0).get_name(), "t0");
-  EXPECT_EQ(prog.state().coeff(0).get_name(), "x0");
-  EXPECT_EQ(prog.state().coeff(1).get_name(), "x1");
-  EXPECT_EQ(prog.input().coeff(0).get_name(), "u0");
+  EXPECT_EQ(prog.time().coeff(0).get_name(), "t(0)");
+  EXPECT_EQ(prog.state().coeff(0).get_name(), "x(0)");
+  EXPECT_EQ(prog.state().coeff(1).get_name(), "x(1)");
+  EXPECT_EQ(prog.input().coeff(0).get_name(), "u(0)");
 }
 
 GTEST_TEST(MultipleShootingTest, TimeIntervalBoundsTest) {
@@ -186,8 +262,7 @@ GTEST_TEST(MultipleShootingTest, EqualTimeIntervalsTest) {
       Solve(prog, prog.initial_guess());
   ASSERT_TRUE(result.is_success());
   EXPECT_NEAR(result.GetSolution(prog.timestep(0).coeff(0)),
-              result.GetSolution(prog.timestep(1).coeff(0)),
-              kSolverTolerance);
+              result.GetSolution(prog.timestep(1).coeff(0)), kSolverTolerance);
 }
 
 GTEST_TEST(MultipleShootingTest, DurationConstraintTest) {
@@ -233,8 +308,8 @@ GTEST_TEST(MultipleShootingTest, ConstraintAllKnotsTest) {
     // 1E-6.
     const double tol =
         result.get_solver_id() == solvers::OsqpSolver::id() ? 4E-6 : 1E-6;
-    EXPECT_TRUE(CompareMatrices(result.GetSolution(prog.state(i)),
-                                state_value, tol));
+    EXPECT_TRUE(
+        CompareMatrices(result.GetSolution(prog.state(i)), state_value, tol));
   }
 
   const solvers::VectorDecisionVariable<1>& t = prog.time();
@@ -267,8 +342,8 @@ GTEST_TEST(MultipleShootingTest, FinalCostTest) {
   const solvers::MathematicalProgramResult result = Solve(prog);
   ASSERT_TRUE(result.is_success());
   EXPECT_NEAR(result.get_optimal_cost(), 0.0, kSolverTolerance);
-  EXPECT_TRUE(CompareMatrices(result.GetSolution(prog.state(1)),
-                              desired_state, kSolverTolerance));
+  EXPECT_TRUE(CompareMatrices(result.GetSolution(prog.state(1)), desired_state,
+                              kSolverTolerance));
 }
 
 GTEST_TEST(MultipleShootingTest, TrajectoryCallbackTest) {


### PR DESCRIPTION
Motivation: In formulating a trajectory optimization problem, we want to reuse those symbolic variables that we created to define a `SymbolicVectorSystem`.

Example:

```c++
const Vector2<Variable> x_{Variable{"x0"}, Variable{"x1"}};
const Vector2<Variable> u_{Variable{"u0"}, Variable{"u1"}};

auto system = SymbolicVectorSystemBuilder()
                    .time(t_)
                    .state(x_)
                    .input(u_)
                    .parameter(p_)
                    .dynamics(Vector2<Expression>{t_, x_[1] + u_[1] + p_[1]})
                    .output(Vector2<Expression>{x_[0] + u_[0] + p_[0], t_})
                    .Build<Expression>();

MultipleShooting prog(x_, u_, ...);  // We want to reuse input and state.

// So that we can use those variables to express constraints and costs.
prog.AddConstraint(x_[0] < ...); 
prog.AddCost(x_[0] + u_[1] + ...); 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12051)
<!-- Reviewable:end -->
