### PR TITLE
Refactor ImplicitStribeck to match notation in arXiv paper.

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -22,17 +22,17 @@ drake_cc_package_library(
         ":externally_applied_spatial_force",
         ":hydroelastic_contact_info",
         ":hydroelastic_traction",
-        ":implicit_stribeck_solver",
-        ":implicit_stribeck_solver_results",
         ":multibody_plant_core",
         ":point_pair_contact_info",
+        ":tamsi_solver",
+        ":tamsi_solver_results",
     ],
 )
 
 drake_cc_library(
-    name = "implicit_stribeck_solver",
-    srcs = ["implicit_stribeck_solver.cc"],
-    hdrs = ["implicit_stribeck_solver.h"],
+    name = "tamsi_solver",
+    srcs = ["tamsi_solver.cc"],
+    hdrs = ["tamsi_solver.h"],
     deps = [
         "//common:default_scalars",
         "//common:extract_double",
@@ -54,8 +54,8 @@ drake_cc_library(
         ":coulomb_friction",
         ":externally_applied_spatial_force",
         ":hydroelastic_traction",
-        ":implicit_stribeck_solver",
-        ":implicit_stribeck_solver_results",
+        ":tamsi_solver",
+        ":tamsi_solver_results",
         "//common:default_scalars",
         "//geometry:geometry_ids",
         "//geometry:geometry_roles",
@@ -114,12 +114,12 @@ drake_cc_library(
 )
 
 drake_cc_library(
-    name = "implicit_stribeck_solver_results",
+    name = "tamsi_solver_results",
     srcs = [
-        "implicit_stribeck_solver_results.cc",
+        "tamsi_solver_results.cc",
     ],
     hdrs = [
-        "implicit_stribeck_solver_results.h",
+        "tamsi_solver_results.h",
     ],
     deps = [
         "//common:default_scalars",
@@ -199,9 +199,9 @@ drake_cc_library(
 )
 
 drake_cc_library(
-    name = "implicit_stribeck_solver_test_util",
+    name = "tamsi_solver_test_util",
     testonly = 1,
-    hdrs = ["test/implicit_stribeck_solver_test_util.h"],
+    hdrs = ["test/tamsi_solver_test_util.h"],
     visibility = ["//visibility:private"],
     deps = [
         "//math:gradient",
@@ -232,10 +232,10 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
-    name = "implicit_stribeck_solver_test",
+    name = "tamsi_solver_test",
     deps = [
-        ":implicit_stribeck_solver",
-        ":implicit_stribeck_solver_test_util",
+        ":tamsi_solver",
+        ":tamsi_solver_test_util",
         "//common/test_utilities:eigen_matrix_compare",
     ],
 )

--- a/multibody/plant/contact_model_doxygen.h
+++ b/multibody/plant/contact_model_doxygen.h
@@ -7,7 +7,7 @@ Drake approximates real-world physical contact phenomena with a combination
 of geometric techniques and response models. Here we discuss the
 parameterization and idiosyncracies of a particular contact response model,
 based on point contact, non-penetration imposed with a penalty force, and a
-Stribeck friction model approximating Coulomb stiction and sliding friction
+continuous model of friction approximating Coulomb stiction and sliding friction
 effects.
 This document gives an overview of the state of the implementation of
 contact in Drake (as of Q2 2019) with particular emphasis on how to account for
@@ -228,10 +228,14 @@ Next topic: @ref contact_engineering
  `time_step`. This can essentially be seen as a time-stepping strategy with a
  fixed `time_step`. The value of `time_step` is provided at construction of the
  @ref drake::multibody::MultibodyPlant "MultibodyPlant". In Drake we use a
- custom semi-implicit Euler scheme for multibody systems using the Stribeck
- approximation of Coulomb friction. Details for this solver are provided in the
- documentation for @ref drake::multibody::ImplicitStribeckSolver
- "ImplicitStribeckSolver".
+ custom semi-implicit Euler scheme, TAMSI, for multibody systems with
+ regularized friction. Details for this solver are provided in the documentation
+ for @ref drake::multibody::TamsiSolver "TamsiSolver" and in
+ [Castro et al., 2019].
+
+ [Castro et al., 2019] Castro, A.M, Qu, A., Kuppuswamy, N., Alspach, A., Sherman,
+   M.A., 2019. A Transition-Aware Method for the Simulation of Compliant Contact
+   with Regularized Friction. arXiv:1909.05700 [cs.RO].
 
  @note For better numerical stability, the discrete model assumes
  both static and kinetic coefficients of friction to be equal, the kinetic
@@ -304,7 +308,8 @@ Next topic: @ref contact_engineering
  Next topic: @ref stribeck_approximation
  */
 
-/** @defgroup stribeck_approximation Stribeck Approximation of Coulomb Friction
+/** @defgroup stribeck_approximation Continuous Approximation of Coulomb
+ Friction
  @ingroup drake_contacts
 
  Static friction (or stiction) arises due to surface characteristics at the
@@ -408,9 +413,8 @@ Next topic: @ref contact_engineering
  very stiff in the stiction region, which requires either small step sizes
  with an explicit integrator, or use of a more-stable implicit integrator.
 
- @note When modeling the multibody system as discrete (refer to
- the @ref time_advancement_strategy "Choice of Time Advancement Strategy"
- section), only the static coefficient of friction is used while the kinetic
- coefficient of friction is ignored. For better numerical stability, the
- discrete model uses `μₖ = μₛ`.
+ @note When modeling the multibody system as discrete (refer to the @ref
+ time_advancement_strategy "Choice of Time Advancement Strategy" section), we
+ regularize Coulomb friction and only use the static coefficient of friction μₛ
+ for better numerical stability.
 */

--- a/multibody/plant/implicit_stribeck_solver_results.cc
+++ b/multibody/plant/implicit_stribeck_solver_results.cc
@@ -1,6 +1,0 @@
-#include "drake/multibody/plant/implicit_stribeck_solver_results.h"
-
-#include "drake/common/default_scalars.h"
-
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
-    struct ::drake::multibody::internal::ImplicitStribeckSolverResults)

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -692,18 +692,18 @@ void MultibodyPlant<T>::FinalizePlantOnly() {
       penalty_method_contact_parameters_.time_scale < 0)
     set_penetration_allowance();
   if (num_collision_geometries() > 0 &&
-      stribeck_model_.stiction_tolerance() < 0)
+      friction_model_.stiction_tolerance() < 0)
     set_stiction_tolerance();
   // Make a contact solver when the plant is modeled as a discrete system.
   if (is_discrete()) {
-    implicit_stribeck_solver_ =
-        std::make_unique<ImplicitStribeckSolver<T>>(num_velocities());
+    tamsi_solver_ =
+        std::make_unique<TamsiSolver<T>>(num_velocities());
     // Set the stiction tolerance according to the values set by users with
     // set_stiction_tolerance().
-    ImplicitStribeckSolverParameters solver_parameters;
+    TamsiSolverParameters solver_parameters;
     solver_parameters.stiction_tolerance =
-        stribeck_model_.stiction_tolerance();
-    implicit_stribeck_solver_->set_solver_parameters(solver_parameters);
+        friction_model_.stiction_tolerance();
+    tamsi_solver_->set_solver_parameters(solver_parameters);
   } else {
     // We only build hydroelastics if the user requested it AND if geometry was
     // registered with a SceneGraph. Since by default bodies are rigid, we use
@@ -1205,7 +1205,7 @@ void MultibodyPlant<T>::CalcContactResultsContinuous(
       if (vt_squared > kNonZeroSqd) {
         slip_velocity = sqrt(vt_squared);
         // Stribeck friction coefficient.
-        const T mu_stribeck = stribeck_model_.ComputeFrictionCoefficient(
+        const T mu_stribeck = friction_model_.ComputeFrictionCoefficient(
             slip_velocity, combined_friction_pairs[icontact]);
         // Tangential direction.
         const Vector3<T> that_W = vt_AcBc_W / slip_velocity;
@@ -1236,8 +1236,8 @@ void MultibodyPlant<T>::CalcContactResultsDiscrete(
       EvalPointPairPenetrations(context);
   const std::vector<RotationMatrix<T>>& R_WC_set =
       EvalContactJacobians(context).R_WC_list;
-  const internal::ImplicitStribeckSolverResults<T>& solver_results =
-      EvalImplicitStribeckResults(context);
+  const internal::TamsiSolverResults<T>& solver_results =
+      EvalTamsiResults(context);
 
   const VectorX<T>& fn = solver_results.fn;
   const VectorX<T>& ft = solver_results.ft;
@@ -1376,7 +1376,7 @@ void MultibodyPlant<T>::CalcHydroelasticContactForces(
       hydroelastics_engine_.ComputeContactSurfaces(query_object);
 
   internal::HydroelasticTractionCalculator<T> traction_calculator(
-      stribeck_model_.stiction_tolerance());
+      friction_model_.stiction_tolerance());
 
   for (const ContactSurface<T>& surface : all_surfaces) {
     const GeometryId geometryM_id = surface.id_M();
@@ -1586,7 +1586,7 @@ void MultibodyPlant<T>::DoCalcTimeDerivatives(
 }
 
 template<typename T>
-ImplicitStribeckSolverResult MultibodyPlant<T>::SolveUsingSubStepping(
+TamsiSolverResult MultibodyPlant<T>::SolveUsingSubStepping(
     int num_substeps,
     const MatrixX<T>& M0, const MatrixX<T>& Jn, const MatrixX<T>& Jt,
     const VectorX<T>& minus_tau,
@@ -1600,8 +1600,8 @@ ImplicitStribeckSolverResult MultibodyPlant<T>::SolveUsingSubStepping(
   VectorX<T> phi0_substep = phi0;
 
   // Initialize info to an unsuccessful result.
-  ImplicitStribeckSolverResult info{
-      ImplicitStribeckSolverResult::kMaxIterationsReached};
+  TamsiSolverResult info{
+      TamsiSolverResult::kMaxIterationsReached};
 
   for (int substep = 0; substep < num_substeps; ++substep) {
     // Discrete update before applying friction forces.
@@ -1610,23 +1610,23 @@ ImplicitStribeckSolverResult MultibodyPlant<T>::SolveUsingSubStepping(
     VectorX<T> p_star_substep = M0 * v0_substep - dt_substep * minus_tau;
 
     // Update the data.
-    implicit_stribeck_solver_->SetTwoWayCoupledProblemData(
+    tamsi_solver_->SetTwoWayCoupledProblemData(
         &M0, &Jn, &Jt,
         &p_star_substep, &phi0_substep,
         &stiffness, &damping, &mu);
 
-    info = implicit_stribeck_solver_->SolveWithGuess(dt_substep,
+    info = tamsi_solver_->SolveWithGuess(dt_substep,
                                                      v0_substep);
 
     // Break the sub-stepping loop on failure and return the info result.
-    if (info != ImplicitStribeckSolverResult::kSuccess) break;
+    if (info != TamsiSolverResult::kSuccess) break;
 
     // Update previous time step to new solution.
-    v0_substep = implicit_stribeck_solver_->get_generalized_velocities();
+    v0_substep = tamsi_solver_->get_generalized_velocities();
 
     // Update penetration distance consistently with the solver update.
     const auto vn_substep =
-        implicit_stribeck_solver_->get_normal_velocities();
+        tamsi_solver_->get_normal_velocities();
     phi0_substep = phi0_substep - dt_substep * vn_substep;
   }
 
@@ -1634,9 +1634,9 @@ ImplicitStribeckSolverResult MultibodyPlant<T>::SolveUsingSubStepping(
 }
 
 template <typename T>
-void MultibodyPlant<T>::CalcImplicitStribeckResults(
+void MultibodyPlant<T>::CalcTamsiResults(
     const drake::systems::Context<T>& context0,
-    internal::ImplicitStribeckSolverResults<T>* results) const {
+    internal::TamsiSolverResults<T>* results) const {
   // Assert this method was called on a context storing discrete state.
   DRAKE_ASSERT(context0.num_discrete_state_groups() == 1);
   DRAKE_ASSERT(context0.num_continuous_states() == 0);
@@ -1737,15 +1737,15 @@ void MultibodyPlant<T>::CalcImplicitStribeckResults(
       num_contacts, penalty_method_contact_parameters_.damping);
 
   // Solve for v and the contact forces.
-  ImplicitStribeckSolverResult info{
-      ImplicitStribeckSolverResult::kMaxIterationsReached};
+  TamsiSolverResult info{
+      TamsiSolverResult::kMaxIterationsReached};
 
-  ImplicitStribeckSolverParameters params =
-      implicit_stribeck_solver_->get_solver_parameters();
+  TamsiSolverParameters params =
+      tamsi_solver_->get_solver_parameters();
   // A nicely converged NR iteration should not take more than 20 iterations.
   // Otherwise we attempt a smaller time step.
   params.max_iterations = 20;
-  implicit_stribeck_solver_->set_solver_parameters(params);
+  tamsi_solver_->set_solver_parameters(params);
 
   // We attempt to compute the update during the time interval dt using a
   // progressively larger number of sub-steps (i.e each using a smaller time
@@ -1761,22 +1761,22 @@ void MultibodyPlant<T>::CalcImplicitStribeckResults(
     info = SolveUsingSubStepping(num_substeps, M0, contact_jacobians.Jn,
                                  contact_jacobians.Jt, minus_tau, stiffness,
                                  damping, mu, v0, phi0);
-  } while (info != ImplicitStribeckSolverResult::kSuccess &&
+  } while (info != TamsiSolverResult::kSuccess &&
            num_substeps < kNumMaxSubTimeSteps);
 
-  DRAKE_DEMAND(info == ImplicitStribeckSolverResult::kSuccess);
+  DRAKE_DEMAND(info == TamsiSolverResult::kSuccess);
 
   // TODO(amcastro-tri): implement capability to dump solver statistics to a
   // file for analysis.
 
   // Update the results.
-  results->v_next = implicit_stribeck_solver_->get_generalized_velocities();
-  results->fn = implicit_stribeck_solver_->get_normal_forces();
-  results->ft = implicit_stribeck_solver_->get_friction_forces();
-  results->vn = implicit_stribeck_solver_->get_normal_velocities();
-  results->vt = implicit_stribeck_solver_->get_tangential_velocities();
+  results->v_next = tamsi_solver_->get_generalized_velocities();
+  results->fn = tamsi_solver_->get_normal_forces();
+  results->ft = tamsi_solver_->get_friction_forces();
+  results->vn = tamsi_solver_->get_normal_velocities();
+  results->vt = tamsi_solver_->get_tangential_velocities();
   results->tau_contact =
-      implicit_stribeck_solver_->get_generalized_contact_forces();
+      tamsi_solver_->get_generalized_contact_forces();
 }
 
 template <typename T>
@@ -1875,8 +1875,8 @@ void MultibodyPlant<T>::CalcGeneralizedAccelerationsDiscrete(
   DRAKE_DEMAND(is_discrete());
 
   // Evaluate contact results.
-  const internal::ImplicitStribeckSolverResults<T>& solver_results =
-      EvalImplicitStribeckResults(context0);
+  const internal::TamsiSolverResults<T>& solver_results =
+      EvalTamsiResults(context0);
 
   // Retrieve the solution velocity for the next time step.
   const VectorX<T>& v_next = solver_results.v_next;
@@ -2036,21 +2036,21 @@ void MultibodyPlant<T>::DeclareStateCacheAndPorts() {
     if (instance_num_velocities == 0) {
       continue;
     }
-    const auto& implicit_stribeck_solver_results_cache_entry =
-        this->get_cache_entry(cache_indexes_.implicit_stribeck_solver_results);
+    const auto& tamsi_solver_results_cache_entry =
+        this->get_cache_entry(cache_indexes_.tamsi_solver_results);
     auto calc = [this, model_instance_index](const systems::Context<T>& context,
                                              systems::BasicVector<T>* result) {
-      const internal::ImplicitStribeckSolverResults<T>& solver_results =
-          EvalImplicitStribeckResults(context);
-      this->CopyGeneralizedContactForcesOut(solver_results,
-                                            model_instance_index, result);
+      const internal::TamsiSolverResults<T>& solver_results =
+          EvalTamsiResults(context);
+      this->CopyGeneralizedContactForcesOut(
+          solver_results, model_instance_index, result);
     };
     instance_generalized_contact_forces_output_ports_[model_instance_index] =
         this->DeclareVectorOutputPort(
                 internal_tree().GetModelInstanceName(model_instance_index) +
                     "_generalized_contact_forces",
                 BasicVector<T>(instance_num_velocities), calc,
-                {implicit_stribeck_solver_results_cache_entry.ticket()})
+                {tamsi_solver_results_cache_entry.ticket()})
             .get_index();
   }
 
@@ -2106,20 +2106,20 @@ void MultibodyPlant<T>::DeclareCacheEntries() {
   cache_indexes_.contact_jacobians =
       contact_jacobians_cache_entry.cache_index();
 
-  // Cache ImplicitStribeckSolver computations.
-  auto& implicit_stribeck_solver_cache_entry = this->DeclareCacheEntry(
+  // Cache TamsiSolver computations.
+  auto& tamsi_solver_cache_entry = this->DeclareCacheEntry(
       std::string("Implicit Stribeck solver computations."),
       []() {
         return AbstractValue::Make(
-            internal::ImplicitStribeckSolverResults<T>());
+            internal::TamsiSolverResults<T>());
       },
       [this](const systems::ContextBase& context_base,
              AbstractValue* cache_value) {
         auto& context = dynamic_cast<const Context<T>&>(context_base);
-        auto& implicit_stribeck_solver_cache = cache_value->get_mutable_value<
-            internal::ImplicitStribeckSolverResults<T>>();
-        this->CalcImplicitStribeckResults(context,
-                                          &implicit_stribeck_solver_cache);
+        auto& tamsi_solver_cache = cache_value->get_mutable_value<
+            internal::TamsiSolverResults<T>>();
+        this->CalcTamsiResults(context,
+                                          &tamsi_solver_cache);
       },
       // The Correct Solution:
       // The Implicit Stribeck solver solution S is a function of state x,
@@ -2128,7 +2128,7 @@ void MultibodyPlant<T>::DeclareCacheEntries() {
       // as S = S(t, x, u).
       // Even though this variables can change continuously with time, we want
       // the solver solution to be updated periodically (with period
-      // time_step()) only. That is, ImplicitStribeckSolverResults should be
+      // time_step()) only. That is, TamsiSolverResults should be
       // handled as an abstract state with periodic updates. In the systems::
       // framework terminology, we'd like to have an "unrestricted update" with
       // a periodic event trigger.
@@ -2143,8 +2143,8 @@ void MultibodyPlant<T>::DeclareCacheEntries() {
       // discrete update of these values as if zero-order held, which is what we
       // want.
       {this->xd_ticket()});
-  cache_indexes_.implicit_stribeck_solver_results =
-      implicit_stribeck_solver_cache_entry.cache_index();
+  cache_indexes_.tamsi_solver_results =
+      tamsi_solver_cache_entry.cache_index();
 
   // Cache contact results.
   // In discrete mode contact forces computation requires to advance the system
@@ -2152,7 +2152,7 @@ void MultibodyPlant<T>::DeclareCacheEntries() {
   // In continuous mode contact forces are simply a function of state.
   const systems::DependencyTicket& dependency_ticket =
       is_discrete() ? this->cache_entry_ticket(
-                          cache_indexes_.implicit_stribeck_solver_results)
+                          cache_indexes_.tamsi_solver_results)
                     : this->kinematics_ticket();
   auto& contact_results_cache_entry = this->DeclareCacheEntry(
       std::string("Contact results."),
@@ -2241,7 +2241,7 @@ void MultibodyPlant<T>::CopyContinuousStateOut(
 
 template <typename T>
 void MultibodyPlant<T>::CopyGeneralizedContactForcesOut(
-    const internal::ImplicitStribeckSolverResults<T>& solver_results,
+    const internal::TamsiSolverResults<T>& solver_results,
     ModelInstanceIndex model_instance, BasicVector<T>* tau_vector) const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
   DRAKE_THROW_UNLESS(is_discrete());

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -22,8 +22,8 @@
 #include "drake/multibody/plant/contact_jacobians.h"
 #include "drake/multibody/plant/contact_results.h"
 #include "drake/multibody/plant/coulomb_friction.h"
-#include "drake/multibody/plant/implicit_stribeck_solver.h"
-#include "drake/multibody/plant/implicit_stribeck_solver_results.h"
+#include "drake/multibody/plant/tamsi_solver.h"
+#include "drake/multibody/plant/tamsi_solver_results.h"
 #include "drake/multibody/topology/multibody_graph.h"
 #include "drake/multibody/tree/force_element.h"
 #include "drake/multibody/tree/multibody_tree-inl.h"
@@ -91,14 +91,14 @@ enum class ContactModel {
 /// the dynamics of a multibody system modeled with %MultibodyPlant are
 /// [Featherstone 2008, Jain 2010]: <pre>
 ///          q̇ = N(q)v
-///   (1)    M(q)v̇ + C(q, v)v = tau
+///   (1)    M(q)v̇ + C(q, v)v = τ
 /// </pre>
 /// where `M(q)` is the mass matrix of the multibody system, `C(q, v)v`
 /// corresponds to the bias term containing Coriolis and gyroscopic effects and
 /// `N(q)` is the kinematic coupling matrix describing the relationship between
 /// the rate of change of the generalized coordinates and the generalized
 /// velocities, [Seth 2010]. N(q) is an `nq x nv` matrix.
-/// The vector `tau ∈ ℝⁿᵛ` on the right hand side of Eq. (1) corresponds to
+/// The vector `τ ∈ ℝⁿᵛ` on the right hand side of Eq. (1) corresponds to
 /// generalized forces applied on the system. These can include externally
 /// applied body forces, constraint forces, and contact forces.
 ///
@@ -3241,17 +3241,17 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// See also @ref stribeck_approximation.
   /// @throws std::exception if `v_stiction` is non-positive.
   void set_stiction_tolerance(double v_stiction = 0.001) {
-    stribeck_model_.set_stiction_tolerance(v_stiction);
+    friction_model_.set_stiction_tolerance(v_stiction);
     // We allow calling this method post-finalize. Therefore, if the plant is
     // modeled as a discrete system, we must update the solver's stiction
     // parameter. Pre-Finalize the solver is not yet created and therefore we
     // check for nullptr.
-    if (is_discrete() && implicit_stribeck_solver_ != nullptr) {
-      ImplicitStribeckSolverParameters solver_parameters =
-          implicit_stribeck_solver_->get_solver_parameters();
+    if (is_discrete() && tamsi_solver_ != nullptr) {
+      TamsiSolverParameters solver_parameters =
+          tamsi_solver_->get_solver_parameters();
       solver_parameters.stiction_tolerance =
-          stribeck_model_.stiction_tolerance();
-      implicit_stribeck_solver_->set_solver_parameters(solver_parameters);
+          friction_model_.stiction_tolerance();
+      tamsi_solver_->set_solver_parameters(solver_parameters);
     }
   }
   /// @}
@@ -3317,7 +3317,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     systems::CacheIndex contact_results;
     systems::CacheIndex generalized_accelerations;
     systems::CacheIndex hydro_contact_forces;
-    systems::CacheIndex implicit_stribeck_solver_results;
+    systems::CacheIndex tamsi_solver_results;
     systems::CacheIndex point_pairs;
   };
 
@@ -3441,7 +3441,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // to perform the update using a step size dt_substep = dt/num_substeps.
   // During the time span dt the problem data M, Jn, Jt and minus_tau, are
   // approximated to be constant, a first order approximation.
-  ImplicitStribeckSolverResult SolveUsingSubStepping(
+  TamsiSolverResult SolveUsingSubStepping(
       int num_substeps,
       const MatrixX<T>& M0, const MatrixX<T>& Jn, const MatrixX<T>& Jt,
       const VectorX<T>& minus_tau,
@@ -3450,20 +3450,20 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       const VectorX<T>& v0, const VectorX<T>& phi0) const;
 
   // This method uses the time stepping method described in
-  // ImplicitStribeckSolver to advance the model's state stored in
+  // TamsiSolver to advance the model's state stored in
   // `context0` taking a time step of size time_step().
   // Contact forces and velocities are computed and stored in `results`. See
-  // ImplicitStribeckSolverResults for further details on the returned data.
-  void CalcImplicitStribeckResults(
+  // TamsiSolverResults for further details on the returned data.
+  void CalcTamsiResults(
       const drake::systems::Context<T>& context0,
-      internal::ImplicitStribeckSolverResults<T>* results) const;
+      internal::TamsiSolverResults<T>* results) const;
 
-  // Eval version of the method CalcImplicitStribeckResults().
-  const internal::ImplicitStribeckSolverResults<T>& EvalImplicitStribeckResults(
+  // Eval version of the method CalcTamsiResults().
+  const internal::TamsiSolverResults<T>& EvalTamsiResults(
       const systems::Context<T>& context) const {
     return this
-        ->get_cache_entry(cache_indexes_.implicit_stribeck_solver_results)
-        .template Eval<internal::ImplicitStribeckSolverResults<T>>(context);
+        ->get_cache_entry(cache_indexes_.tamsi_solver_results)
+        .template Eval<internal::TamsiSolverResults<T>>(context);
   }
 
   // Helper method to fill in the ContactResults given the current context when
@@ -3473,9 +3473,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   // Helper method to fill in the ContactResults given the current context when
   // the model is discrete. If cached contact solver results are not up-to-date
-  // with `context`, they'll be  recomputed, see EvalImplicitStribeckResults().
-  // The solver results are then used to compute contact results into
-  // `contact_results`.
+  // with `context`, they'll be  recomputed, see EvalTamsiResults(). The solver
+  // results are then used to compute contact results into `contacts`.
   void CalcContactResultsDiscrete(const systems::Context<T>& context,
                                   ContactResults<T>* contact_results) const;
 
@@ -3557,7 +3556,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // Calc method to output per model instance vector of generalized contact
   // forces.
   void CopyGeneralizedContactForcesOut(
-      const internal::ImplicitStribeckSolverResults<T>&,
+      const internal::TamsiSolverResults<T>&,
       ModelInstanceIndex, systems::BasicVector<T>* tau_vector) const;
 
   // Helper method to declare output ports used by this plant to communicate
@@ -3795,7 +3794,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     // A negative value indicates it was not properly initialized.
     double inv_v_stiction_tolerance_{-1};
   };
-  StribeckModel stribeck_model_;
+  StribeckModel friction_model_;
 
   // This structure aids in the bookkeeping of parameters associated with joint
   // limits and the penalty method parameters used to enforce them.
@@ -3906,7 +3905,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   double time_step_{0};
 
   // The solver used when the plant is modeled as a discrete system.
-  std::unique_ptr<ImplicitStribeckSolver<T>> implicit_stribeck_solver_;
+  std::unique_ptr<TamsiSolver<T>> tamsi_solver_;
 
   hydroelastics::internal::HydroelasticEngine<T> hydroelastics_engine_;
 

--- a/multibody/plant/tamsi_solver_results.cc
+++ b/multibody/plant/tamsi_solver_results.cc
@@ -1,0 +1,6 @@
+#include "drake/multibody/plant/tamsi_solver_results.h"
+
+#include "drake/common/default_scalars.h"
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    struct ::drake::multibody::internal::TamsiSolverResults)

--- a/multibody/plant/tamsi_solver_results.h
+++ b/multibody/plant/tamsi_solver_results.h
@@ -8,12 +8,12 @@ namespace multibody {
 namespace internal {
 
 /// This struct stores the results from a computation performed with
-/// ImplicitStribeckSolver. See the ImplicitStribeckSolver class's documentation
+/// TamsiSolver. See the TamsiSolver class's documentation
 /// for further details.
 /// We denote `nv` the size of the vector of generalized velocities and `nc` the
 /// number of contact points.
 template <class T>
-struct ImplicitStribeckSolverResults {
+struct TamsiSolverResults {
   /// Vector of generalized velocities at the next time step.
   VectorX<T> v_next;
 
@@ -39,4 +39,4 @@ struct ImplicitStribeckSolverResults {
 }  // namespace drake
 
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
-    struct ::drake::multibody::internal::ImplicitStribeckSolverResults)
+    struct ::drake::multibody::internal::TamsiSolverResults)

--- a/multibody/plant/test/tamsi_solver_test_util.h
+++ b/multibody/plant/test/tamsi_solver_test_util.h
@@ -1,7 +1,7 @@
 #pragma once
 
 // This file implements a method to compute the  Newton-Raphson Jacobian
-// J = ∇ᵥR of the residual for the ImplicitStribeckSolver using automatic
+// J = ∇ᵥR of the residual for the TamsiSolver using automatic
 // differentiation. This separate implementation is used to verify the
 // analytical (and faster) Jacobian computed by the internal implementation of
 // the solver.
@@ -58,7 +58,7 @@ VectorX<U> CalcFrictionForces(
   VectorX<U> t_hat(2 * nc);
   VectorX<U> v_slip(nc);
 
-  auto ModifiedStribeck = [](U x, double friction_coefficient) {
+  auto RegularizedFriction = [](U x, double friction_coefficient) {
     if (x >= 1) {
       return U(friction_coefficient);
     } else {
@@ -86,16 +86,16 @@ VectorX<U> CalcFrictionForces(
     // "soft" tangent vector:
     const Vector2<U> that_ic = vt_ic / v_slip(ic);
     t_hat.template segment<2>(ik) = that_ic;
-    mu_vt(ic) = ModifiedStribeck(v_slip(ic) / v_stiction, mu(ic));
+    mu_vt(ic) = RegularizedFriction(v_slip(ic) / v_stiction, mu(ic));
     // Friction force.
     ft.template segment<2>(ik) = -mu_vt(ic) * that_ic * fn(ic);
   }
   return ft;
 }
 
-// Computes and returns the Newton-Raphson residual for the implicit Stribeck
-// solver. This templated method is used to automatically differentiate the
-// residual and compute its Jacobian J = ∇ᵥR.
+// Computes and returns the Newton-Raphson residual for the TAMSI solver. This
+// templated method is used to automatically differentiate the residual and
+// compute its Jacobian J = ∇ᵥR.
 // This same method is used to evaluate the residual for both the one-way (
 // normal forces are fixed) and two-way coupled schemes. two_way_coupling = true
 // indicates to compute the residual for the two-way coupled scheme. Call with
@@ -148,7 +148,7 @@ VectorX<U> CalcResidual(
 }
 
 // Computes the Jacobian J = ∇ᵥR of the residual for the two-way coupled scheme
-// of ImplicitStribeckSolver using automatic differentiation.
+// of TamsiSolver using automatic differentiation.
 MatrixX<double> CalcTwoWayCoupledJacobianWithAutoDiff(
     const MatrixX<double>& M,
     const MatrixX<double>& Jn,
@@ -172,7 +172,7 @@ MatrixX<double> CalcTwoWayCoupledJacobianWithAutoDiff(
 }
 
 // Computes the Jacobian J = ∇ᵥR of the residual for the one-way coupled scheme
-// of ImplicitStribeckSolver using automatic differentiation.
+// of TamsiSolver using automatic differentiation.
 MatrixX<double> CalcOneWayCoupledJacobianWithAutoDiff(
     const MatrixX<double>& M,
     const MatrixX<double>& Jn,


### PR DESCRIPTION
This is simply a refactor to match names and notation used in the cited arXiv
paper arXiv:1909.05700 [cs.RO]. (hopefully soon to be an ICRA paper).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12053)
<!-- Reviewable:end -->
