### PR TITLE
fix: one version of the graphviz output for diagrams wasn't using port names

### DIFF
--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -491,7 +491,8 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
     for (int i = 0; i < this->num_input_ports(); ++i) {
       this->GetGraphvizInputPortToken(this->get_input_port(i), max_depth,
                                       dot);
-      *dot << "[color=blue, label=\"u" << i << "\"];" << std::endl;
+      *dot << "[color=blue, label=\"" << this->get_input_port(i).get_name()
+           << "\"];" << std::endl;
     }
     *dot << "}" << std::endl;
 
@@ -504,7 +505,8 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
     for (int i = 0; i < this->num_output_ports(); ++i) {
       this->GetGraphvizOutputPortToken(this->get_output_port(i), max_depth,
                                        dot);
-      *dot << "[color=green, label=\"y" << i << "\"];" << std::endl;
+      *dot << "[color=green, label=\"" << this->get_output_port(i).get_name()
+           << "\"];" << std::endl;
     }
     *dot << "}" << std::endl;
 

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -423,10 +423,10 @@ class ExampleDiagram : public Diagram<double> {
                     integrator1_->get_input_port());
 
     builder.ExportInput(adder0_->get_input_port(0));
-    builder.ExportInput(adder0_->get_input_port(1));
+    builder.ExportInput(adder0_->get_input_port(1), "adder0");
     builder.ExportInput(adder1_->get_input_port(1));
     builder.ExportOutput(adder1_->get_output_port());
-    builder.ExportOutput(adder2_->get_output_port());
+    builder.ExportOutput(adder2_->get_output_port(), "adder2");
     builder.ExportOutput(integrator1_->get_output_port());
 
     if (use_abstract) {
@@ -712,9 +712,9 @@ TEST_F(DiagramTest, Graphviz) {
       "label=\"Unicode Snowman's Favorite Diagram!!1!☃!\";")) << dot;
   // Check that input ports are declared in blue, and output ports in green.
   EXPECT_NE(std::string::npos, dot.find(
-      "_" + id + "_u1[color=blue, label=\"u1\"")) << dot;
+    "_" + id + "_u1[color=blue, label=\"adder0\"")) << dot;
   EXPECT_NE(std::string::npos, dot.find(
-      "_" + id + "_y2[color=green, label=\"y2\"")) << dot;
+    "_" + id + "_y1[color=green, label=\"adder2\"")) << dot;
   // Check that subsystem records appear.
   EXPECT_NE(
       std::string::npos,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12060)
<!-- Reviewable:end -->
