### PR TITLE
#12064 FIX: Gravity generalized forces must ignore velocity terms.

### DIFF
--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -472,6 +472,10 @@ class AcrobotPlantTests : public ::testing::Test {
     shoulder_->set_angle(plant_context_, theta1);
     elbow_->set_angle(plant_context_, theta2);
 
+    // Set arbitrary non-zero velocities to test they do not affect the results.
+    shoulder_->set_angular_rate(plant_context_, 10.0);
+    elbow_->set_angular_rate(plant_context_, 10.0);
+
     // Calculate the generalized forces due to gravity.
     const VectorX<double> tau_g =
         plant_->CalcGravityGeneralizedForces(*plant_context_);

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -1610,6 +1610,28 @@ class MultibodyTree {
       std::vector<SpatialForce<T>>* F_BMo_W_array,
       EigenPtr<VectorX<T>> tau_array) const;
 
+  /// Given the state stored in `context` and a
+  /// known vector of generalized accelerations `vdot`, this method computes the
+  /// set of generalized forces `tau_id` that would need to be applied at each
+  /// Mobilizer in order to attain the specified generalized accelerations.
+  /// Mathematically, this method computes: <pre>
+  ///   tau_id = M(q)v̇ + C(q, v)v - tau_app - ∑ J_WBᵀ(q) Fapp_Bo_W
+  /// </pre>
+  /// where `M(q)` is the mass matrix, `C(q, v)v` is the bias
+  /// term containing Coriolis and gyroscopic effects and `tau_app` consists
+  /// of a vector applied generalized forces.
+  ///
+  /// iff `ignore_velocities = true` velocity values stored in `context` are
+  /// ignored and are assumed to be zero. Therefore, C(q, v)v = 0 and it is not
+  /// computed to avoid unnecessary work.
+  void CalcInverseDynamics(
+      const systems::Context<T>& context, const VectorX<T>& known_vdot,
+      const std::vector<SpatialForce<T>>& Fapplied_Bo_W_array,
+      const Eigen::Ref<const VectorX<T>>& tau_applied_array,
+      bool ignore_velocities, std::vector<SpatialAcceleration<T>>* A_WB_array,
+      std::vector<SpatialForce<T>>* F_BMo_W_array,
+      EigenPtr<VectorX<T>> tau_array) const;
+
   /// See MultibodyPlant method.
   void CalcForceElementsContribution(
       const systems::Context<T>& context,
@@ -2208,28 +2230,6 @@ class MultibodyTree {
       const systems::Context<T>& context, const VectorX<T>& known_vdot,
       bool ignore_velocities,
       std::vector<SpatialAcceleration<T>>* A_WB_array) const;
-
-  // Given the state stored in `context` and a
-  // known vector of generalized accelerations `vdot`, this method computes the
-  // set of generalized forces `tau_id` that would need to be applied at each
-  // Mobilizer in order to attain the specified generalized accelerations.
-  // Mathematically, this method computes: <pre>
-  //   tau_id = M(q)v̇ + C(q, v)v - tau_app - ∑ J_WBᵀ(q) Fapp_Bo_W
-  // </pre>
-  // where `M(q)` is the mass matrix, `C(q, v)v` is the bias
-  // term containing Coriolis and gyroscopic effects and `tau_app` consists
-  // of a vector applied generalized forces.
-  //
-  // iff `ignore_velocities = true` velocity values stored in `context` are
-  // ignored and are assumed to be zero. Therefore, C(q, v)v = 0 and it is not
-  // computed to avoid unnecessary work.
-  void CalcInverseDynamics(
-      const systems::Context<T>& context, const VectorX<T>& known_vdot,
-      const std::vector<SpatialForce<T>>& Fapplied_Bo_W_array,
-      const Eigen::Ref<const VectorX<T>>& tau_applied_array,
-      bool ignore_velocities, std::vector<SpatialAcceleration<T>>* A_WB_array,
-      std::vector<SpatialForce<T>>* F_BMo_W_array,
-      EigenPtr<VectorX<T>> tau_array) const;
 
   // Helper method for Jacobian methods, namely CalcJacobianAngularVelocity(),
   // CalcJacobianTranslationalVelocity(), and CalcJacobianSpatialVelocity().

--- a/multibody/tree/uniform_gravity_field_element.cc
+++ b/multibody/tree/uniform_gravity_field_element.cc
@@ -55,11 +55,11 @@ VectorX<T> UniformGravityFieldElement<T>::CalcGravityGeneralizedForces(
   // the generalized forces due to gravity.
   // TODO(amcastro-tri): Replace this inverse dynamics implementation by a JᵀF
   // operator implementation, which would be more efficient.
+  const double ignore_velocities = true;
   model.CalcInverseDynamics(
-      context,
-      VectorX<T>::Zero(model.num_velocities()), /* vdot = 0 */
+      context, VectorX<T>::Zero(model.num_velocities()), /* vdot = 0 */
       /* Applied forces. In this case only gravity. */
-      forces.body_forces(), forces.generalized_forces(),
+      forces.body_forces(), forces.generalized_forces(), ignore_velocities,
       &A_WB_array, &F_BMo_W_array, /* temporary arrays. */
       &tau_g /* Output, the generalized forces. */);
   return -tau_g;


### PR DESCRIPTION
Fixes #12064.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12065)
<!-- Reviewable:end -->
