### PR TITLE
Adds ContactResults for continuous MBP. Fixes #10529.

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -399,6 +399,7 @@ drake_cc_googletest(
         "//common:find_resource",
         "//common/test_utilities:eigen_matrix_compare",
         "//multibody/parsing",
+        "//systems/analysis:implicit_euler_integrator",
         "//systems/analysis:simulator",
     ],
 )

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1110,11 +1110,10 @@ void MultibodyPlant<T>::CopyContactResultsOutput(
 }
 
 template <typename T>
-void MultibodyPlant<T>::CalcContactResults(
+void MultibodyPlant<T>::CalcContactResultsContinuous(
     const systems::Context<T>& context,
     ContactResults<T>* contact_results) const {
   DRAKE_DEMAND(contact_results != nullptr);
-  contact_results->Clear();
   if (num_collision_geometries() == 0) return;
 
   // Thus far we do not allow mixing hydroelastics with point contact and
@@ -1131,64 +1130,16 @@ void MultibodyPlant<T>::CalcContactResults(
 
   const std::vector<PenetrationAsPointPair<T>>& point_pairs =
       EvalPointPairPenetrations(context);
-  const std::vector<RotationMatrix<T>>& R_WC_set =
-      EvalContactJacobians(context).R_WC_list;
-  const internal::ImplicitStribeckSolverResults<T>& solver_results =
-      EvalImplicitStribeckResults(context);
 
-  const VectorX<T>& fn = solver_results.fn;
-  const VectorX<T>& ft = solver_results.ft;
-  const VectorX<T>& vt = solver_results.vt;
-  const VectorX<T>& vn = solver_results.vn;
-
-  const int num_contacts = point_pairs.size();
-  DRAKE_DEMAND(fn.size() == num_contacts);
-  DRAKE_DEMAND(ft.size() == 2 * num_contacts);
-  DRAKE_DEMAND(vn.size() == num_contacts);
-  DRAKE_DEMAND(vt.size() == 2 * num_contacts);
-
-  contact_results->Clear();
-  for (size_t icontact = 0; icontact < point_pairs.size(); ++icontact) {
-    const auto& pair = point_pairs[icontact];
-    const GeometryId geometryA_id = pair.id_A;
-    const GeometryId geometryB_id = pair.id_B;
-
-    BodyIndex bodyA_index = geometry_id_to_body_index_.at(geometryA_id);
-    BodyIndex bodyB_index = geometry_id_to_body_index_.at(geometryB_id);
-
-    const Vector3<T> p_WC = 0.5 * (pair.p_WCa + pair.p_WCb);
-
-    const RotationMatrix<T>& R_WC = R_WC_set[icontact];
-
-    // Contact forces applied on B at contact point C.
-    const Vector3<T> f_Bc_C(-ft(2 * icontact), -ft(2 * icontact + 1),
-                            fn(icontact));
-    const Vector3<T> f_Bc_W = R_WC * f_Bc_C;
-
-    // Slip velocity.
-    const T slip = vt.template segment<2>(2 * icontact).norm();
-
-    // Separation velocity in the normal direction.
-    const T separation_velocity = vn(icontact);
-
-    // Add pair info to the contact results.
-    contact_results->AddContactInfo({bodyA_index, bodyB_index, f_Bc_W, p_WC,
-                                     separation_velocity, slip, pair});
-  }
-}
-
-template<typename T>
-void MultibodyPlant<T>::CalcAndAddContactForcesByPenaltyMethod(
-    const systems::Context<T>&,
-    const internal::PositionKinematicsCache<T>& pc,
-    const internal::VelocityKinematicsCache<T>& vc,
-    const std::vector<PenetrationAsPointPair<T>>& point_pairs,
-    std::vector<SpatialForce<T>>* F_BBo_W_array) const {
-  if (num_collision_geometries() == 0) return;
-
-  std::vector<CoulombFriction<double>> combined_friction_pairs =
+  const std::vector<CoulombFriction<double>> combined_friction_pairs =
       CalcCombinedFrictionCoefficients(point_pairs);
 
+  const internal::PositionKinematicsCache<T>& pc =
+      EvalPositionKinematics(context);
+  const internal::VelocityKinematicsCache<T>& vc =
+      EvalVelocityKinematics(context);
+
+  contact_results->Clear();
   for (size_t icontact = 0; icontact < point_pairs.size(); ++icontact) {
     const auto& pair = point_pairs[icontact];
     const GeometryId geometryA_id = pair.id_A;
@@ -1213,13 +1164,11 @@ void MultibodyPlant<T>::CalcAndAddContactForcesByPenaltyMethod(
     const Vector3<T> p_WC = 0.5 * (p_WCa + p_WCb);
 
     // Contact point position on body A.
-    const Vector3<T>& p_WAo =
-        pc.get_X_WB(bodyA_node_index).translation();
+    const Vector3<T>& p_WAo = pc.get_X_WB(bodyA_node_index).translation();
     const Vector3<T>& p_CoAo_W = p_WAo - p_WC;
 
     // Contact point position on body B.
-    const Vector3<T>& p_WBo =
-        pc.get_X_WB(bodyB_node_index).translation();
+    const Vector3<T>& p_WBo = pc.get_X_WB(bodyB_node_index).translation();
     const Vector3<T>& p_CoBo_W = p_WBo - p_WC;
 
     // Separation velocity, > 0  if objects separate.
@@ -1252,13 +1201,14 @@ void MultibodyPlant<T>::CalcAndAddContactForcesByPenaltyMethod(
       const T kNonZeroSqd = 1e-14 * 1e-14;
       // Tangential friction force on A at C, expressed in W.
       Vector3<T> ft_AC_W = Vector3<T>::Zero();
+      T slip_velocity = 0;
       if (vt_squared > kNonZeroSqd) {
-        const T vt = sqrt(vt_squared);
+        slip_velocity = sqrt(vt_squared);
         // Stribeck friction coefficient.
         const T mu_stribeck = stribeck_model_.ComputeFrictionCoefficient(
-            vt, combined_friction_pairs[icontact]);
+            slip_velocity, combined_friction_pairs[icontact]);
         // Tangential direction.
-        const Vector3<T> that_W = vt_AcBc_W / vt;
+        const Vector3<T> that_W = vt_AcBc_W / slip_velocity;
 
         // Magnitude of the friction force on A at C.
         const T ft_AC = mu_stribeck * fn_AC;
@@ -1266,22 +1216,123 @@ void MultibodyPlant<T>::CalcAndAddContactForcesByPenaltyMethod(
       }
 
       // Spatial force on body A at C, expressed in the world frame W.
-      const SpatialForce<T> F_AC_W(Vector3<T>::Zero(),
-                                   fn_AC_W + ft_AC_W);
+      const SpatialForce<T> F_AC_W(Vector3<T>::Zero(), fn_AC_W + ft_AC_W);
 
-      if (F_BBo_W_array != nullptr) {
-        if (bodyA_index != world_index()) {
-          // Spatial force on body A at Ao, expressed in W.
-          const SpatialForce<T> F_AAo_W = F_AC_W.Shift(p_CoAo_W);
-          F_BBo_W_array->at(bodyA_node_index) += F_AAo_W;
-        }
+      const Vector3<T> f_Bc_W = -F_AC_W.translational();
+      contact_results->AddContactInfo(
+          {bodyA_index, bodyB_index, f_Bc_W, p_WC, vn, slip_velocity, pair});
+    }
+  }
+}
 
-        if (bodyB_index != world_index()) {
-          // Spatial force on body B at Bo, expressed in W.
-          const SpatialForce<T> F_BBo_W = -F_AC_W.Shift(p_CoBo_W);
-          F_BBo_W_array->at(bodyB_node_index) += F_BBo_W;
-        }
-      }
+template <typename T>
+void MultibodyPlant<T>::CalcContactResultsDiscrete(
+    const systems::Context<T>& context,
+    ContactResults<T>* contact_results) const {
+  DRAKE_DEMAND(contact_results != nullptr);
+  if (num_collision_geometries() == 0) return;
+
+  const std::vector<PenetrationAsPointPair<T>>& point_pairs =
+      EvalPointPairPenetrations(context);
+  const std::vector<RotationMatrix<T>>& R_WC_set =
+      EvalContactJacobians(context).R_WC_list;
+  const internal::ImplicitStribeckSolverResults<T>& solver_results =
+      EvalImplicitStribeckResults(context);
+
+  const VectorX<T>& fn = solver_results.fn;
+  const VectorX<T>& ft = solver_results.ft;
+  const VectorX<T>& vt = solver_results.vt;
+  const VectorX<T>& vn = solver_results.vn;
+
+  const int num_contacts = point_pairs.size();
+  DRAKE_DEMAND(fn.size() == num_contacts);
+  DRAKE_DEMAND(ft.size() == 2 * num_contacts);
+  DRAKE_DEMAND(vn.size() == num_contacts);
+  DRAKE_DEMAND(vt.size() == 2 * num_contacts);
+
+  contact_results->Clear();
+  for (size_t icontact = 0; icontact < point_pairs.size(); ++icontact) {
+    const auto& pair = point_pairs[icontact];
+    const GeometryId geometryA_id = pair.id_A;
+    const GeometryId geometryB_id = pair.id_B;
+
+    const BodyIndex bodyA_index = geometry_id_to_body_index_.at(geometryA_id);
+    const BodyIndex bodyB_index = geometry_id_to_body_index_.at(geometryB_id);
+
+    const Vector3<T> p_WC = 0.5 * (pair.p_WCa + pair.p_WCb);
+
+    const RotationMatrix<T>& R_WC = R_WC_set[icontact];
+
+    // Contact forces applied on B at contact point C.
+    const Vector3<T> f_Bc_C(ft(2 * icontact), ft(2 * icontact + 1),
+                            -fn(icontact));
+    const Vector3<T> f_Bc_W = R_WC * f_Bc_C;
+
+    // Slip velocity.
+    const T slip = vt.template segment<2>(2 * icontact).norm();
+
+    // Separation velocity in the normal direction.
+    const T separation_velocity = vn(icontact);
+
+    // Add pair info to the contact results.
+    contact_results->AddContactInfo({bodyA_index, bodyB_index, f_Bc_W, p_WC,
+                                     separation_velocity, slip, pair});
+  }
+}
+
+template <typename T>
+void MultibodyPlant<T>::CalcAndAddContactForcesByPenaltyMethod(
+    const systems::Context<T>& context,
+    std::vector<SpatialForce<T>>* F_BBo_W_array) const {
+  DRAKE_DEMAND(F_BBo_W_array != nullptr);
+  if (num_collision_geometries() == 0) return;
+
+  const ContactResults<T>& contact_results = EvalContactResults(context);
+
+  const internal::PositionKinematicsCache<T>& pc =
+      EvalPositionKinematics(context);
+
+  for (int pair_index = 0;
+       pair_index < contact_results.num_point_pair_contacts(); ++pair_index) {
+    const PointPairContactInfo<T>& contact_info =
+        contact_results.point_pair_contact_info(pair_index);
+    const PenetrationAsPointPair<T>& pair = contact_info.point_pair();
+
+    const GeometryId geometryA_id = pair.id_A;
+    const GeometryId geometryB_id = pair.id_B;
+
+    const BodyIndex bodyA_index = geometry_id_to_body_index_.at(geometryA_id);
+    const BodyIndex bodyB_index = geometry_id_to_body_index_.at(geometryB_id);
+
+    internal::BodyNodeIndex bodyA_node_index =
+        internal_tree().get_body(bodyA_index).node_index();
+    internal::BodyNodeIndex bodyB_node_index =
+        internal_tree().get_body(bodyB_index).node_index();
+
+    // Contact point C.
+    const Vector3<T> p_WC = contact_info.contact_point();
+
+    // Contact point position on body A.
+    const Vector3<T>& p_WAo = pc.get_X_WB(bodyA_node_index).translation();
+    const Vector3<T>& p_CoAo_W = p_WAo - p_WC;
+
+    // Contact point position on body B.
+    const Vector3<T>& p_WBo = pc.get_X_WB(bodyB_node_index).translation();
+    const Vector3<T>& p_CoBo_W = p_WBo - p_WC;
+
+    const Vector3<T> f_Bc_W = contact_info.contact_force();
+    const SpatialForce<T> F_AC_W(Vector3<T>::Zero(), -f_Bc_W);
+
+    if (bodyA_index != world_index()) {
+      // Spatial force on body A at Ao, expressed in W.
+      const SpatialForce<T> F_AAo_W = F_AC_W.Shift(p_CoAo_W);
+      F_BBo_W_array->at(bodyA_node_index) += F_AAo_W;
+    }
+
+    if (bodyB_index != world_index()) {
+      // Spatial force on body B at Bo, expressed in W.
+      const SpatialForce<T> F_BBo_W = -F_AC_W.Shift(p_CoBo_W);
+      F_BBo_W_array->at(bodyB_node_index) += F_BBo_W;
     }
   }
 }
@@ -1787,10 +1838,7 @@ void MultibodyPlant<T>::CalcGeneralizedAccelerationsContinuous(
   if (contact_model_ == ContactModel::kPointContactOnly) {
     // Compute contact forces on each body by penalty method.
     if (num_collision_geometries() > 0) {
-      const std::vector<PenetrationAsPointPair<T>>& point_pairs =
-          EvalPointPairPenetrations(context);
-      CalcAndAddContactForcesByPenaltyMethod(context, pc, vc, point_pairs,
-                                             &F_BBo_W_array);
+      CalcAndAddContactForcesByPenaltyMethod(context, &F_BBo_W_array);
     }
   } else if (contact_model_ == ContactModel::kHydroelasticsOnly) {
     // Compute contact forces using hydroelastics.
@@ -2091,7 +2139,14 @@ void MultibodyPlant<T>::DeclareCacheEntries() {
   cache_indexes_.implicit_stribeck_solver_results =
       implicit_stribeck_solver_cache_entry.cache_index();
 
-  // Cache contact results for point contact.
+  // Cache contact results.
+  // In discrete mode contact forces computation requires to advance the system
+  // from step n to n+1. Therefore they are a function of state and input.
+  // In continuous mode contact forces are simply a function of state.
+  const systems::DependencyTicket& dependency_ticket =
+      is_discrete() ? this->cache_entry_ticket(
+                          cache_indexes_.implicit_stribeck_solver_results)
+                    : this->kinematics_ticket();
   auto& contact_results_cache_entry = this->DeclareCacheEntry(
       std::string("Contact results."),
       []() { return AbstractValue::Make(ContactResults<T>()); },
@@ -2100,12 +2155,13 @@ void MultibodyPlant<T>::DeclareCacheEntries() {
         auto& context = dynamic_cast<const Context<T>&>(context_base);
         auto& contact_results_cache =
             cache_value->get_mutable_value<ContactResults<T>>();
-        this->CalcContactResults(context, &contact_results_cache);
+        if (is_discrete()) {
+          this->CalcContactResultsDiscrete(context, &contact_results_cache);
+        } else {
+          this->CalcContactResultsContinuous(context, &contact_results_cache);
+        }
       },
-      // We explicitly declare the dependence on the implicit Stribeck solver
-      // even though the Eval() above does the evaluation.
-      {this->cache_entry_ticket(
-          cache_indexes_.implicit_stribeck_solver_results)});
+      {dependency_ticket});
   cache_indexes_.contact_results = contact_results_cache_entry.cache_index();
 
   // Cache entry for spatial forces due to hydroelastic contact.

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -2964,13 +2964,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   const systems::OutputPort<T>& get_generalized_contact_forces_output_port(
       ModelInstanceIndex model_instance) const;
 
-  // TODO(amcastro-tri): report contact results for plants modeled as a
-  // continuous system as well.
   /// Returns a constant reference to the port that outputs ContactResults.
   /// @throws std::exception if called pre-finalize, see Finalize().
-  /// @warning Point contacts are not currently reported for MultibodyPlant
-  ///          systems modeled using continuous variables (i.e., if
-  ///          `is_discrete() == false`).
   const systems::OutputPort<T>& get_contact_results_output_port() const;
 
   /// Returns a constant reference to the *world* body.
@@ -3471,14 +3466,20 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
         .template Eval<internal::ImplicitStribeckSolverResults<T>>(context);
   }
 
-  // Helper method to fill in the ContactResults given the current context.
-  // If cached contact solver results are not up-to-date with `context`,
-  // they'll be  recomputed, see EvalImplicitStribeckResults(). The solver
-  // results are then used to compute contact results into `contacts`.
-  void CalcContactResults(const systems::Context<T>& context,
-                          ContactResults<T>* contacts) const;
+  // Helper method to fill in the ContactResults given the current context when
+  // the model is continuous.
+  void CalcContactResultsContinuous(const systems::Context<T>& context,
+                                    ContactResults<T>* contact_results) const;
 
-  // Eval version of the method CalcContactResults().
+  // Helper method to fill in the ContactResults given the current context when
+  // the model is discrete. If cached contact solver results are not up-to-date
+  // with `context`, they'll be  recomputed, see EvalImplicitStribeckResults().
+  // The solver results are then used to compute contact results into
+  // `contact_results`.
+  void CalcContactResultsDiscrete(const systems::Context<T>& context,
+                                  ContactResults<T>* contact_results) const;
+
+  // Evaluate contact results.
   const ContactResults<T>& EvalContactResults(
       const systems::Context<T>& context) const {
     return this->get_cache_entry(cache_indexes_.contact_results)
@@ -3594,9 +3595,6 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // using a penalty method.
   void CalcAndAddContactForcesByPenaltyMethod(
       const systems::Context<T>& context,
-      const internal::PositionKinematicsCache<T>& pc,
-      const internal::VelocityKinematicsCache<T>& vc,
-      const std::vector<geometry::PenetrationAsPointPair<T>>& point_pairs,
       std::vector<SpatialForce<T>>* F_BBo_W_array) const;
 
   // Helper to create the underlying hydroelastic fields used in the

--- a/multibody/plant/test/box_test.cc
+++ b/multibody/plant/test/box_test.cc
@@ -10,6 +10,7 @@
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/multibody/tree/prismatic_joint.h"
 #include "drake/multibody/tree/rigid_body.h"
+#include "drake/systems/analysis/implicit_euler_integrator.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/diagram_builder.h"
@@ -34,31 +35,144 @@ namespace {
 // In this test we apply an external horizontal force for which the box is in
 // stiction.
 // The test then verifies the computed values of contact results.
-GTEST_TEST(Box, UnderStiction) {
-  // Length of the simulation, in seconds.
-  const double simulation_time = 2.0;
+class SlidingBoxTest : public ::testing::Test {
+ public:
+  // Creates a MultibodyPlant model with the given `discrete_period`
+  // (discrete_period = 0 for a continuous model), runs a simulation to reach
+  // steady state, and verifies contact results.
+  void RunSimulationToSteadyStateAndVerifyContactResults(
+      double discrete_period) {
+    auto diagram = MakeBoxDiagram(discrete_period);
+    const auto& plant = dynamic_cast<const MultibodyPlant<double>&>(
+        diagram->GetSubsystemByName("plant"));
 
-  // Plant's parameters.
-  const double mass = 1.0;     // Box mass, [kg]
-  // We use g = 10 m/s² so that numbers are simpler.
-  const double g = 10.0;       // Acceleration of gravity, [m/s²]
-  const CoulombFriction<double> surface_friction(
-      0.9 /* static friction */, 0.9 /* dynamic friction */);
+    // Sanity check for the model's size.
+    EXPECT_EQ(plant.num_velocities(), 2);
+    EXPECT_EQ(plant.num_positions(), 2);
+    EXPECT_EQ(plant.num_actuators(), 1);
+    EXPECT_EQ(plant.num_actuated_dofs(), 1);
 
-  // Simulation parameters.
-  const double time_step = 1.0e-3;  // in seconds.
-  const double penetration_allowance = 1.0e-4;  // in meters.
-  const double stiction_tolerance = 1.0e-4;  // in meters per second.
-  const double applied_force = 5.0;  // Force in Newtons.
+    // Create a context for this system:
+    std::unique_ptr<Context<double>> diagram_context =
+        diagram->CreateDefaultContext();
+    diagram_context->EnableCaching();
+    diagram->SetDefaultContext(diagram_context.get());
+    Context<double>& plant_context =
+        diagram->GetMutableSubsystemContext(plant, diagram_context.get());
+    plant_context.FixInputPort(plant.get_actuation_input_port().get_index(),
+                               Vector1<double>::Constant(applied_force_));
 
-  // Tolerance used to verify the results.
-  // Since the contact solver uses a continuous ODE to model Coulomb friction
-  // (a modified Stribeck model), we simulate for a long enough time to reach a
-  // "steady state". Therefore the precision of the results in these tests is
-  // dominated for "how well we reached steady state".
-  const double kTolerance = 1.0e-12;
+    Simulator<double> simulator(*diagram, std::move(diagram_context));
+    simulator.set_publish_every_time_step(true);
+    // Implicit integration does much better than the default RK3 for this
+    // system with regularized friction. Otherwise RK3 requires a very small
+    // accuracy setting and it is very costly.
+    simulator.reset_integrator<systems::ImplicitEulerIntegrator<double>>(
+        *diagram, &simulator.get_mutable_context());
+    simulator.get_mutable_integrator().set_maximum_step_size(1e-3);
+    simulator.Initialize();
+    simulator.AdvanceTo(simulation_time_);
 
-  auto MakeBoxDiagram = [&]() {
+    auto VerifyContactResults = [&](const MultibodyPlant<double>& the_plant,
+                                    const Context<double>& the_context) {
+      // We evaluate the contact results output port in order to verify the
+      // simulation results.
+      const ContactResults<double>& contact_results =
+          the_plant.get_contact_results_output_port()
+              .Eval<ContactResults<double>>(the_context);
+
+      // Only one contact pair.
+      ASSERT_EQ(contact_results.num_point_pair_contacts(), 1);
+      const PointPairContactInfo<double>& point_pair_contact_info =
+          contact_results.point_pair_contact_info(0);
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+      // Verify the deprecated methods still work.
+      ASSERT_EQ(contact_results.num_contacts(), 1);
+      ASSERT_EQ(&contact_results.contact_info(0),
+                &contact_results.point_pair_contact_info(0));
+#pragma GCC diagnostic pop
+
+      // Verify the bodies referenced by the contact info.
+      const Body<double>& ground = the_plant.GetBodyByName("ground");
+      const Body<double>& box = the_plant.GetBodyByName("box");
+      EXPECT_TRUE((point_pair_contact_info.bodyA_index() == box.index() &&
+                   point_pair_contact_info.bodyB_index() == ground.index()) ||
+                  (point_pair_contact_info.bodyB_index() == box.index() &&
+                   point_pair_contact_info.bodyA_index() == ground.index()));
+
+      // Whether the normal points up or down depends on the order in which
+      // the geometry engine orders bodies in the contact pair. direction = +1
+      // indicates the normal is the +z axis pointing into the box (i.e. the
+      // outward normal to the ground plane). direction = -1 indicates the
+      // outward normal to the box (i.e. pointing down in the -z direction).
+      double direction =
+          point_pair_contact_info.bodyB_index() == box.index() ? 1.0 : -1.0;
+
+      // The expected value of the contact force applied on the box at the
+      // contact point C.
+      const Vector3<double> f_Bc_W(-applied_force_, 0.0, mass_ * g_);
+      EXPECT_TRUE(CompareMatrices(point_pair_contact_info.contact_force(),
+                                  f_Bc_W * direction, kTolerance_,
+                                  MatrixCompareType::relative));
+
+      // Upper limit on the x displacement computed using the maximum possible
+      // velocity under stiction, i.e. the stiction tolerance.
+      const double x_upper_limit = stiction_tolerance_ * simulation_time_;
+      EXPECT_LT(point_pair_contact_info.contact_point().x(), x_upper_limit);
+
+      // The penetration allowance is just an estimate. Therefore we only
+      // expect the penetration depth to be close enough to it.
+      EXPECT_NEAR(point_pair_contact_info.point_pair().depth,
+                  penetration_allowance_, 1.0e-3);
+
+      // Whether the normal points up or down depends on the order in which
+      // scene graph orders bodies in the contact pair.
+      const Vector3<double> expected_normal =
+          -Vector3<double>::UnitZ() * direction;
+      EXPECT_TRUE(CompareMatrices(
+          point_pair_contact_info.point_pair().nhat_BA_W, expected_normal,
+          kTolerance_, MatrixCompareType::relative));
+
+      // If we are in stiction, the slip speed should be smaller than the
+      // specified stiction tolerance.
+      EXPECT_LT(point_pair_contact_info.slip_speed(), stiction_tolerance_);
+
+      // There should not be motion in the normal direction.
+      EXPECT_NEAR(point_pair_contact_info.separation_speed(), 0.0, kTolerance_);
+    };
+
+    // Verify contact results at the end of the simulation.
+    VerifyContactResults(plant, plant_context);
+
+    // We want to verify that contact results can be evaluated simply from the
+    // information stored in the context. To verify this we create a completely
+    // new model of the same mechanical system and a new context for that
+    // system. Therefore we don't run the risk of using previously computed
+    // results in the simulation above. We only use the final state of that
+    // simulation to set the new context. Thus contact results evaluation in the
+    // following test is completely independent from the simulation above
+    // (besides of course the initial condition).
+    auto diagram2 = MakeBoxDiagram(discrete_period);
+    const auto& plant2 = dynamic_cast<const MultibodyPlant<double>&>(
+        diagram2->GetSubsystemByName("plant"));
+    std::unique_ptr<Context<double>> diagram_context2 =
+        diagram2->CreateDefaultContext();
+    diagram_context2->EnableCaching();
+    Context<double>& plant_context2 =
+        diagram2->GetMutableSubsystemContext(plant2, diagram_context2.get());
+    plant_context2.FixInputPort(plant2.get_actuation_input_port().get_index(),
+                                Vector1<double>::Constant(applied_force_));
+    // Set the state from the computed solution.
+    plant2.SetPositionsAndVelocities(
+        &plant_context2, plant.GetPositionsAndVelocities(plant_context));
+    VerifyContactResults(plant2, plant_context2);
+  }
+
+  // Creates a MultibodyPlant model with the given `discrete_period`
+  // (discrete_period = 0 for a continuous model).
+  std::unique_ptr<Diagram<double>> MakeBoxDiagram(double time_step) {
     DiagramBuilder<double> builder;
     const std::string full_name =
         FindResourceOrThrow("drake/multibody/plant/test/box.sdf");
@@ -68,142 +182,47 @@ GTEST_TEST(Box, UnderStiction) {
     Parser(&plant).AddModelFromFile(full_name);
 
     // Add gravity to the model.
-    plant.mutable_gravity_field().set_gravity_vector(
-        -g * Vector3<double>::UnitZ());
+    plant.mutable_gravity_field().set_gravity_vector(-g_ *
+                                                     Vector3<double>::UnitZ());
 
     plant.Finalize();  // Done creating the model.
 
     // Set contact parameters.
-    plant.set_penetration_allowance(penetration_allowance);
-    plant.set_stiction_tolerance(stiction_tolerance);
+    plant.set_penetration_allowance(penetration_allowance_);
+    plant.set_stiction_tolerance(stiction_tolerance_);
 
     // And build the Diagram:
     return builder.Build();
-  };
+  }
 
-  auto diagram = MakeBoxDiagram();
-  const auto& plant = dynamic_cast<const MultibodyPlant<double>&>(
-      diagram->GetSubsystemByName("plant"));
+ protected:
+  // Length of the simulation, in seconds.
+  const double simulation_time_{0.5};
 
-  // Sanity check for the model's size.
-  EXPECT_EQ(plant.num_velocities(), 2);
-  EXPECT_EQ(plant.num_positions(), 2);
-  EXPECT_EQ(plant.num_actuators(), 1);
-  EXPECT_EQ(plant.num_actuated_dofs(), 1);
+  // Plant's parameters.
+  const double mass_{1.0};  // Box mass, [kg]
+  // We use g = 10 m/s² so that numbers are simpler.
+  const double g_{10.0};  // Acceleration of gravity, [m/s²]
+  // Simulation parameters.
+  const double time_step_{1.0e-3};              // in seconds.
+  const double penetration_allowance_{1.0e-4};  // in meters.
+  const double stiction_tolerance_{1.0e-4};     // in meters per second.
+  const double applied_force_{5.0};             // Force in Newtons.
 
-  // Create a context for this system:
-  std::unique_ptr<Context<double>> diagram_context =
-      diagram->CreateDefaultContext();
-  diagram_context->EnableCaching();
-  diagram->SetDefaultContext(diagram_context.get());
-  Context<double>& plant_context =
-      diagram->GetMutableSubsystemContext(plant, diagram_context.get());
+  // Tolerance used to verify the results.
+  // Since the contact solver uses a continuous ODE to model Coulomb friction
+  // (a modified Stribeck model), we simulate for a long enough time to reach
+  // a "steady state". Therefore the precision of the results in these tests
+  // is dominated for "how well we reached steady state".
+  const double kTolerance_{1.0e-12};
+};
 
-  plant_context.FixInputPort(
-      plant.get_actuation_input_port().get_index(),
-      Vector1<double>::Constant(applied_force));
+TEST_F(SlidingBoxTest, ContinuousModel) {
+  RunSimulationToSteadyStateAndVerifyContactResults(1.0e-3);
+}
 
-  Simulator<double> simulator(*diagram, std::move(diagram_context));
-  simulator.set_publish_every_time_step(true);
-  simulator.Initialize();
-  simulator.AdvanceTo(simulation_time);
-
-  auto VerifyContactResults = [&](const MultibodyPlant<double>& the_plant,
-                                  const Context<double>& the_context) {
-    // We evaluate the contact results output port in order to verify the
-    // simulation results.
-    const ContactResults<double>& contact_results =
-        the_plant.get_contact_results_output_port()
-            .Eval<ContactResults<double>>(the_context);
-
-    // Only one contact pair.
-    ASSERT_EQ(contact_results.num_point_pair_contacts(), 1);
-    const PointPairContactInfo<double>& point_pair_contact_info =
-        contact_results.point_pair_contact_info(0);
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    // Verify the deprecated methods still work.
-    ASSERT_EQ(contact_results.num_contacts(), 1);
-    ASSERT_EQ(
-        &contact_results.contact_info(0),
-        &contact_results.point_pair_contact_info(0));
-#pragma GCC diagnostic pop
-
-    // Verify the bodies referenced by the contact info.
-    const Body<double>& ground = the_plant.GetBodyByName("ground");
-    const Body<double>& box = the_plant.GetBodyByName("box");
-    EXPECT_TRUE((point_pair_contact_info.bodyA_index() == box.index() &&
-                 point_pair_contact_info.bodyB_index() == ground.index()) ||
-                (point_pair_contact_info.bodyB_index() == box.index() &&
-                 point_pair_contact_info.bodyA_index() == ground.index()));
-
-    // Whether the normal points up or down depends on the order in which
-    // the geometry engine orders bodies in the contact pair. direction = +1
-    // indicates the normal is the +z axis pointing into the box (i.e. the
-    // outward normal to the ground plane). direction = -1 indicates the
-    // outward normal to the box (i.e. pointing down in the -z direction).
-    double direction =
-        point_pair_contact_info.bodyA_index() == box.index() ? 1.0 : -1.0;
-
-    // The expected value of the contact force applied on the box at the
-    // contact point C.
-    const Vector3<double> f_Bc_W(-applied_force, 0.0, mass * g);
-    EXPECT_TRUE(CompareMatrices(point_pair_contact_info.contact_force(),
-                                f_Bc_W * direction, kTolerance,
-                                MatrixCompareType::relative));
-
-    // Upper limit on the x displacement computed using the maximum possible
-    // velocity under stiction, i.e. the stiction tolerance.
-    const double x_upper_limit = stiction_tolerance * simulation_time;
-    EXPECT_LT(point_pair_contact_info.contact_point().x(), x_upper_limit);
-
-    // The penetration allowance is just an estimate. Therefore we only
-    // expect the penetration depth to be close enough to it.
-    EXPECT_NEAR(point_pair_contact_info.point_pair().depth,
-        penetration_allowance, 1.0e-3);
-
-    // Whether the normal points up or down depends on the order in which
-    // scene graph orders bodies in the contact pair.
-    const Vector3<double> expected_normal =
-        Vector3<double>::UnitZ() * direction;
-    EXPECT_TRUE(CompareMatrices(point_pair_contact_info.point_pair().nhat_BA_W,
-                                expected_normal, kTolerance,
-                                MatrixCompareType::relative));
-
-    // If we are in stiction, the slip speed should be smaller than the
-    // specified stiction tolerance.
-    EXPECT_LT(point_pair_contact_info.slip_speed(), stiction_tolerance);
-
-    // There should not be motion in the normal direction.
-    EXPECT_NEAR(point_pair_contact_info.separation_speed(), 0.0, kTolerance);
-  };
-
-  // Verify contact results at the end of the simulation.
-  VerifyContactResults(plant, plant_context);
-
-  // We want to verify that contact results can be evaluated simply from the
-  // information stored in the context. To verify this we create a completely
-  // new model of the same mechanical system and a new context for that system.
-  // Therefore we don't run the risk of using previously computed results in the
-  // simulation above. We only use the final state of that simulation to set the
-  // new context. Thus contact results evaluation in the following test is
-  // completely independent from the simulation above (besides of course the
-  // initial condition).
-  auto diagram2 = MakeBoxDiagram();
-  const auto& plant2 = dynamic_cast<const MultibodyPlant<double>&>(
-      diagram2->GetSubsystemByName("plant"));
-  std::unique_ptr<Context<double>> diagram_context2 =
-      diagram2->CreateDefaultContext();
-  diagram_context2->EnableCaching();
-  Context<double>& plant_context2 =
-      diagram2->GetMutableSubsystemContext(plant2, diagram_context2.get());
-  plant_context2.FixInputPort(plant2.get_actuation_input_port().get_index(),
-                              Vector1<double>::Constant(applied_force));
-  // Set the state from the computed solution.
-  plant2.SetPositionsAndVelocities(
-      &plant_context2, plant.GetPositionsAndVelocities(plant_context));
-  VerifyContactResults(plant2, plant_context2);
+TEST_F(SlidingBoxTest, DiscreteModel) {
+  RunSimulationToSteadyStateAndVerifyContactResults(0.0);
 }
 
 }  // namespace


### PR DESCRIPTION
I needed contact forces for both continuous and discrete MBP models to compute reaction forces as requested by @huihuaTRI. 

This PR introduces contact results for continuous MBP models. 

As a side effect, I fixed #10529.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12067)
<!-- Reviewable:end -->
