### PR TITLE
Make DRAKE_EXPECT_THROWS_MESSAGE behave like EXPECT_THROW

### DIFF
--- a/common/test_utilities/expect_throws_message.h
+++ b/common/test_utilities/expect_throws_message.h
@@ -61,10 +61,13 @@ do { \
 try { \
   expression; \
   if (must_throw) { \
+    std::string message = "\tExpected: " #expression " throws an exception " \
+                          "of type " #exception ".\n Actual: it throws " \
+                          "nothing"; \
     if (fatal_failure) { \
-      GTEST_FATAL_FAILURE_("\t" #expression " failed to throw " #exception); \
+      GTEST_FATAL_FAILURE_(message.c_str()); \
     } else { \
-      GTEST_NONFATAL_FAILURE_("\t" #expression " failed to throw " #exception);\
+      GTEST_NONFATAL_FAILURE_(message.c_str());\
     } \
   } \
 } catch (const exception& err) { \
@@ -74,6 +77,14 @@ try { \
     ASSERT_PRED2(matcher, err.what(), regexp); \
   } else { \
     EXPECT_PRED2(matcher, err.what(), regexp); \
+  } \
+} catch (...) { \
+  std::string message = "\tExpected: " #expression " throws an exception of " \
+      "type " #exception  ".\n Actual: it throws a different type."; \
+  if (fatal_failure) { \
+    GTEST_FATAL_FAILURE_(message.c_str()); \
+  } else { \
+    GTEST_NONFATAL_FAILURE_(message.c_str()); \
   } \
 } \
 } while (0)


### PR DESCRIPTION
If DRAKE_EXPECT_THROWS_MESSAGE was used with an incompatible exception type the test would fail just like it fails if an exception is thrown anywhere in the code. EXPECT_THROW reports that a different exception type was thrown and then moves on with the test. Now the drake macro has the same behavior.

NOTE: It also gets the same behavior as ASSERT_THROW in that it prints a nice message and then stops the rest of the test -- but it doesn't crash out of the test.

The text of the error message is liberally copied-and-pasted from [gtests' message](https://github.com/google/googletest/blob/master/googletest/include/gtest/internal/gtest-internal.h#L1272-L1273)

resolves #8657

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12078)
<!-- Reviewable:end -->
