### PR TITLE
Add utility for mapping Shape type to shape *name*

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -127,6 +127,7 @@ drake_cc_library(
     deps = [
         "//geometry:geometry_ids",
         "//geometry:geometry_index",
+        "//geometry:shape_specification",
         "@fcl",
         "@fmt",
     ],

--- a/geometry/proximity/proximity_utilities.cc
+++ b/geometry/proximity/proximity_utilities.cc
@@ -4,6 +4,11 @@ namespace drake {
 namespace geometry {
 namespace internal {
 
+std::ostream& operator<<(std::ostream& out, const ShapeName& name) {
+  out << name.string();
+  return out;
+}
+
 std::string GetGeometryName(const fcl::CollisionObjectd& object) {
   switch (object.collisionGeometry()->getNodeType()) {
     case fcl::BV_UNKNOWN:

--- a/geometry/proximity/proximity_utilities.h
+++ b/geometry/proximity/proximity_utilities.h
@@ -1,8 +1,5 @@
 #pragma once
 
-// Exclude internal classes from doxygen.
-#if !defined(DRAKE_DOXYGEN_CXX)
-
 #include <algorithm>
 #include <cstdint>
 #include <string>
@@ -12,10 +9,58 @@
 #include <fmt/format.h>
 
 #include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/shape_specification.h"
 
 namespace drake {
 namespace geometry {
 namespace internal {
+
+/** Class that reports the name of the type of shape being reified (e.g.,
+ Sphere, Box, etc.)  */
+class ShapeName final : public ShapeReifier {
+ public:
+  ShapeName() = default;
+
+  /** Constructs a %ShapeName from the given `shape` such that `string()`
+   already contains the string representation of `shape`.  */
+  explicit ShapeName(const Shape& shape) {
+    shape.Reify(this);
+  }
+
+  /** @name  Implementation of ShapeReifier interface  */
+  //@{
+
+  void ImplementGeometry(const Sphere&, void*) final {
+    string_ = "Sphere";
+  }
+  void ImplementGeometry(const Cylinder&, void*) final {
+    string_ = "Cylinder";
+  }
+  void ImplementGeometry(const HalfSpace&, void*) final {
+    string_ = "HalfSpace";
+  }
+  void ImplementGeometry(const Box&, void*) final {
+    string_ = "Box";
+  }
+  void ImplementGeometry(const Mesh&, void*) final {
+    string_ = "Mesh";
+  }
+  void ImplementGeometry(const Convex&, void*) final {
+    string_ = "Convex";
+  }
+
+  //@}
+
+  /** Returns the name of the last shape reified. Empty if no shape has been
+   reified yet.  */
+  std::string string() const { return string_; }
+
+ private:
+  std::string string_;
+};
+
+/** @relates ShapeName */
+std::ostream& operator<<(std::ostream& out, const ShapeName& name);
 
 // TODO(SeanCurtis-TRI): Snake case this name.
 /** Calculates an absolute tolerance value conditioned to a problem's
@@ -127,5 +172,3 @@ std::string GetGeometryName(const fcl::CollisionObjectd& object);
 }  // namespace internal
 }  // namespace geometry
 }  // namespace drake
-
-#endif  // !defined(DRAKE_DOXYGEN_CXX)

--- a/geometry/proximity/test/proximity_utilities_test.cc
+++ b/geometry/proximity/test/proximity_utilities_test.cc
@@ -1,6 +1,7 @@
 #include "drake/geometry/proximity/proximity_utilities.h"
 
 #include <memory>
+#include <sstream>
 
 #include <fcl/fcl.h>
 #include <gtest/gtest.h>
@@ -58,6 +59,47 @@ GTEST_TEST(EncodedData, ConstructionFromFclObject) {
     EXPECT_FALSE(data_read.is_dynamic());
     EXPECT_EQ(data_read.id(), data_A.id());
   }
+}
+
+GTEST_TEST(ShapeName, SimpleReification) {
+  ShapeName name;
+
+  EXPECT_EQ(name.string(), "");
+
+  Sphere(0.5).Reify(&name);
+  EXPECT_EQ(name.string(), "Sphere");
+
+  Cylinder(1, 2).Reify(&name);
+  EXPECT_EQ(name.string(), "Cylinder");
+
+  Box(1, 2, 3).Reify(&name);
+  EXPECT_EQ(name.string(), "Box");
+
+  HalfSpace().Reify(&name);
+  EXPECT_EQ(name.string(), "HalfSpace");
+
+  Mesh("filepath", 1.0).Reify(&name);
+  EXPECT_EQ(name.string(), "Mesh");
+
+  Convex("filepath", 1.0).Reify(&name);
+  EXPECT_EQ(name.string(), "Convex");
+}
+
+GTEST_TEST(ShapeName, ReifyOnConstruction) {
+  EXPECT_EQ(ShapeName(Sphere(0.5)).string(), "Sphere");
+  EXPECT_EQ(ShapeName(Cylinder(1, 2)).string(), "Cylinder");
+  EXPECT_EQ(ShapeName(Box(1, 2, 3)).string(), "Box");
+  EXPECT_EQ(ShapeName(HalfSpace()).string(), "HalfSpace");
+  EXPECT_EQ(ShapeName(Mesh("filepath", 1.0)).string(), "Mesh");
+  EXPECT_EQ(ShapeName(Convex("filepath", 1.0)).string(), "Convex");
+}
+
+GTEST_TEST(ShapeName, Stremaing) {
+  ShapeName name(Sphere(0.5));
+  std::stringstream ss;
+  ss << name;
+  EXPECT_EQ(name.string(), "Sphere");
+  EXPECT_EQ(ss.str(), name.string());
 }
 
 }  // namespace


### PR DESCRIPTION
This is different from ShapeToString in that it doesn't provide any of the properties; just the type name. The purpose is to be able to blindly print the name of a shape in a context in which I wouldn't typically have at compile time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12082)
<!-- Reviewable:end -->
