### PR TITLE
Handle AutoDiffXd for contact surface between rigid and soft meshes

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -325,6 +325,7 @@ drake_cc_googletest(
     name = "mesh_intersection_test",
     deps = [
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
         "//geometry/proximity:mesh_intersection",
     ],
 )

--- a/geometry/proximity/mesh_intersection.cc
+++ b/geometry/proximity/mesh_intersection.cc
@@ -4,6 +4,16 @@ namespace drake {
 namespace geometry {
 namespace mesh_intersection {
 
+std::unique_ptr<ContactSurface<AutoDiffXd>>
+ComputeContactSurfaceFromSoftVolumeRigidSurface(
+    const GeometryId, const VolumeMeshField<double, double>&,
+    const math::RigidTransform<AutoDiffXd>&, const GeometryId,
+    const SurfaceMesh<double>&, const math::RigidTransform<AutoDiffXd>&) {
+  throw std::logic_error(
+      "AutoDiff-valued ContactSurface calculation between meshes is not"
+      "currently supported");
+}
+
 }  // namespace mesh_intersection
 }  // namespace geometry
 }  // namespace drake


### PR DESCRIPTION
- Adds documentation for why we *can't* do this.
- Add some compilation shields against that failure.
- Add a test confirming compilation and throwing
  - incidental clean up on test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12085)
<!-- Reviewable:end -->
