### PR TITLE
Suppress "self-assign-overloaded" warnings for Apple LLVM >= 10.0.1

### DIFF
--- a/bindings/pydrake/symbolic_py.cc
+++ b/bindings/pydrake/symbolic_py.cc
@@ -18,7 +18,8 @@
 // that is using py::self (example: `def(py::self + py::self)`).
 // Here, we suppress the warning using `#pragma diagnostic`.
 #if (__APPLE__) && (__clang__) && (__clang_major__ >= 10) && \
-    (__clang_minor__ >= 0) && (__clang_patchlevel__ >= 1)
+    !((__clang_major__ == 10) && (__clang_minor__ == 0) &&   \
+        (__clang_patchlevel__ == 0))
 #pragma GCC diagnostic ignored "-Wself-assign-overloaded"
 #endif
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12092)
<!-- Reviewable:end -->
