### PR TITLE
[geometry] Minimum viable product - ComputeContactSurfaces

### DIFF
--- a/examples/scene_graph/BUILD.bazel
+++ b/examples/scene_graph/BUILD.bazel
@@ -53,6 +53,24 @@ drake_cc_binary(
     ],
 )
 
+drake_cc_binary(
+    name = "simple_contact_surface_vis",
+    srcs = ["simple_contact_surface_vis.cc"],
+    add_test_rule = 1,
+    test_rule_args = [
+        "--simulation_time=0.01",
+    ],
+    deps = [
+        "//geometry:geometry_visualization",
+        "//geometry:scene_graph",
+        "//lcmtypes:contact_results_for_viz",
+        "//systems/analysis:simulator",
+        "//systems/framework:diagram",
+        "//systems/lcm:lcm_pubsub_system",
+        "@gflags",
+    ],
+)
+
 filegroup(
     name = "models",
     srcs = glob([

--- a/examples/scene_graph/simple_contact_surface_vis.cc
+++ b/examples/scene_graph/simple_contact_surface_vis.cc
@@ -1,0 +1,279 @@
+/** @file
+ A simple binary for exercising and visualizing computation of ContactSurfaces.
+ This is decoupled from dynamics so that just the geometric components can be
+ evaluated in as light-weight a fashion as possible.
+
+ This can serve as a test bed for evaluating the various cases of the
+ ContactSurface-computing algorithms. Simply swap the geometry types (moving
+ and anchored) and their properties to see the effect on contact surface.  */
+
+#include <memory>
+
+#include <gflags/gflags.h>
+
+#include "drake/common/value.h"
+#include "drake/geometry/frame_kinematics_vector.h"
+#include "drake/geometry/geometry_frame.h"
+#include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/geometry_instance.h"
+#include "drake/geometry/geometry_roles.h"
+#include "drake/geometry/geometry_visualization.h"
+#include "drake/geometry/query_object.h"
+#include "drake/geometry/query_results/contact_surface.h"
+#include "drake/geometry/scene_graph.h"
+#include "drake/geometry/shape_specification.h"
+#include "drake/lcm/drake_lcm.h"
+#include "drake/lcmt_contact_results_for_viz.hpp"
+#include "drake/math/rigid_transform.h"
+#include "drake/systems/analysis/simulator.h"
+#include "drake/systems/framework/context.h"
+#include "drake/systems/framework/continuous_state.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/framework/leaf_system.h"
+#include "drake/systems/lcm/lcm_publisher_system.h"
+
+namespace drake {
+namespace examples {
+namespace scene_graph {
+namespace contact_surface {
+
+using Eigen::Vector3d;
+using Eigen::Vector4d;
+using geometry::Box;
+using geometry::ConnectDrakeVisualizer;
+using geometry::ContactSurface;
+using geometry::FrameId;
+using geometry::FramePoseVector;
+using geometry::GeometryFrame;
+using geometry::GeometryId;
+using geometry::GeometryInstance;
+using geometry::IllustrationProperties;
+using geometry::ProximityProperties;
+using geometry::QueryObject;
+using geometry::SceneGraph;
+using geometry::SourceId;
+using geometry::Sphere;
+using geometry::SurfaceMesh;
+using geometry::SurfaceFaceIndex;
+using geometry::SurfaceVertex;
+using lcm::DrakeLcm;
+using math::RigidTransformd;
+using std::make_unique;
+using systems::BasicVector;
+using systems::Context;
+using systems::ContinuousState;
+using systems::DiagramBuilder;
+using systems::lcm::LcmPublisherSystem;
+using systems::LeafSystem;
+using systems::Simulator;
+
+DEFINE_double(simulation_time, 10.0,
+              "Desired duration of the simulation in seconds.");
+DEFINE_bool(real_time, true, "Set to true to run no faster than realtime");
+
+/** Places a ball at the world's origin and defines its velocity as being
+ sinusoidal in time in the z direction.
+
+ @system{MovingBall,, @output_port{geometry_pose} }
+ */
+class MovingBall final : public LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MovingBall)
+
+  explicit MovingBall(SceneGraph<double>* scene_graph) {
+    this->DeclareContinuousState(2);
+
+    // Add geometry for a ball that moves based on sinusoidal derivatives.
+    source_id_ = scene_graph->RegisterSource("moving_ball");
+    frame_id_ =
+        scene_graph->RegisterFrame(source_id_, GeometryFrame("moving_frame"));
+    geometry_id_ = scene_graph->RegisterGeometry(
+        source_id_, frame_id_,
+        make_unique<GeometryInstance>(RigidTransformd(),
+                                      make_unique<Sphere>(1.0), "ball"));
+
+    scene_graph->AssignRole(source_id_, geometry_id_, ProximityProperties());
+
+    IllustrationProperties illus_props;
+    illus_props.AddProperty("phong", "diffuse", Vector4d(0.8, 0.1, 0.1, 0.25));
+    scene_graph->AssignRole(source_id_, geometry_id_, illus_props);
+
+    geometry_pose_port_ =
+        this->DeclareAbstractOutputPort("geometry_pose",
+                                        &MovingBall::CalcFramePoseOutput)
+            .get_index();
+  }
+
+  SourceId source_id() const { return source_id_; }
+
+  const systems::OutputPort<double>& get_geometry_pose_output_port() const {
+    return systems::System<double>::get_output_port(geometry_pose_port_);
+  }
+
+ private:
+  void DoCalcTimeDerivatives(
+      const Context<double>& context,
+      ContinuousState<double>* derivatives) const override {
+    BasicVector<double>& derivative_values =
+        dynamic_cast<BasicVector<double>&>(derivatives->get_mutable_vector());
+    derivative_values.SetAtIndex(0, std::sin(context.get_time()));
+  }
+
+  void CalcFramePoseOutput(
+      const Context<double>& context, FramePoseVector<double>* poses) const {
+    RigidTransformd pose;
+    const double pos_z = context.get_continuous_state().get_vector()[0];
+    pose.set_translation({0.0, 0.0, pos_z});
+    *poses = {{frame_id_, pose}};
+  }
+
+  SourceId source_id_;
+  FrameId frame_id_;
+  GeometryId geometry_id_;
+
+  int geometry_pose_port_{-1};
+};
+
+/** A system that evaluates contact surfaces from SceneGraph and outputs a fake
+ ContactResults with the actual contact surfaces.
+
+ @system{ContactResultMaker,
+   @intput_port{query_object},
+   @output_port{contact_result}
+ }
+ */
+class ContactResultMaker final : public LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ContactResultMaker)
+
+  ContactResultMaker() {
+    geometry_query_input_port_ =
+        this->DeclareAbstractInputPort("query_object",
+                                       Value<QueryObject<double>>())
+            .get_index();
+    contact_result_output_port_ =
+        this->DeclareAbstractOutputPort("contact_result",
+                                        &ContactResultMaker::CalcContactResults)
+            .get_index();
+  }
+
+  const systems::InputPort<double>& get_geometry_query_port() const {
+    return systems::System<double>::get_input_port(geometry_query_input_port_);
+  }
+
+ private:
+  void CalcContactResults(const Context<double>& context,
+                          lcmt_contact_results_for_viz* results) const {
+    const auto& query_object =
+        get_geometry_query_port().Eval<QueryObject<double>>(context);
+    std::vector<ContactSurface<double>> contacts =
+        query_object.ComputeContactSurfaces();
+    const int num_contacts = static_cast<int>(contacts.size());
+
+    auto& msg = *results;
+    msg.timestamp = context.get_time() * 1e6;  // express in microseconds.
+    msg.num_point_pair_contacts = 0;
+    msg.point_pair_contact_info.resize(msg.num_point_pair_contacts);
+    msg.num_hydroelastic_contacts = num_contacts;
+    msg.hydroelastic_contacts.resize(num_contacts);
+
+    auto write_double3 = [](const Vector3d& src, double* dest) {
+      dest[0] = src(0);
+      dest[1] = src(1);
+      dest[2] = src(2);
+    };
+
+    for (int i = 0; i < num_contacts; ++i) {
+      lcmt_hydroelastic_contact_surface_for_viz& surface_msg =
+          msg.hydroelastic_contacts[i];
+
+      surface_msg.body1_name = "Id_" + to_string(contacts[i].id_M());
+      surface_msg.body2_name = "Id_" + to_string(contacts[i].id_N());
+
+      const SurfaceMesh<double>& mesh_W = contacts[i].mesh_W();
+      surface_msg.num_triangles = mesh_W.num_faces();
+      surface_msg.triangles.resize(surface_msg.num_triangles);
+
+      // Loop through each contact triangle on the contact surface.
+      for (SurfaceFaceIndex j(0); j < surface_msg.num_triangles; ++j) {
+        lcmt_hydroelastic_contact_surface_tri_for_viz& tri_msg =
+            surface_msg.triangles[j];
+
+        // Get the three vertices.
+        const auto& face = mesh_W.element(j);
+        const SurfaceVertex<double>& vA = mesh_W.vertex(face.vertex(0));
+        const SurfaceVertex<double>& vB = mesh_W.vertex(face.vertex(1));
+        const SurfaceVertex<double>& vC = mesh_W.vertex(face.vertex(2));
+
+        write_double3(vA.r_MV(), tri_msg.p_WA);
+        write_double3(vB.r_MV(), tri_msg.p_WB);
+        write_double3(vC.r_MV(), tri_msg.p_WC);
+      }
+    }
+  }
+
+  int geometry_query_input_port_;
+  int contact_result_output_port_;
+};
+
+int do_main() {
+  DiagramBuilder<double> builder;
+
+  auto& scene_graph = *builder.AddSystem<SceneGraph<double>>();
+
+  // Add the bouncing ball.
+  auto& moving_ball = *builder.AddSystem<MovingBall>(&scene_graph);
+  builder.Connect(moving_ball.get_geometry_pose_output_port(),
+                  scene_graph.get_source_pose_port(moving_ball.source_id()));
+
+  // Add a large box, such that intersection occurs at the edge.
+  SourceId source_id = scene_graph.RegisterSource("world");
+  const double edge_len = 10;
+  const RigidTransformd X_WB(Eigen::AngleAxisd(M_PI / 4, Vector3d::UnitX()),
+      Vector3d{0, 0, -sqrt(2.0) * edge_len / 2});
+  GeometryId ground_id = scene_graph.RegisterAnchoredGeometry(
+      source_id,
+      make_unique<GeometryInstance>(
+          X_WB, make_unique<Box>(edge_len, edge_len, edge_len), "box"));
+  scene_graph.AssignRole(source_id, ground_id, ProximityProperties());
+  IllustrationProperties illus_props;
+  illus_props.AddProperty("phong", "diffuse", Vector4d{0.5, 0.5, 0.45, 1.0});
+  scene_graph.AssignRole(source_id, ground_id, illus_props);
+
+  // Make and visualize contacts.
+  auto& contact_results = *builder.AddSystem<ContactResultMaker>();
+  builder.Connect(scene_graph.get_query_output_port(),
+                  contact_results.get_geometry_query_port());
+
+  // Now visualize.
+  DrakeLcm lcm;
+
+  // Visualize geometry.
+  ConnectDrakeVisualizer(&builder, scene_graph, &lcm);
+
+  // Visualize contacts.
+  auto& contact_to_lcm =
+      *builder.AddSystem(LcmPublisherSystem::Make<lcmt_contact_results_for_viz>(
+          "CONTACT_RESULTS", &lcm, 1.0 / 60));
+  builder.Connect(contact_results, contact_to_lcm);
+
+  auto diagram = builder.Build();
+
+  systems::Simulator<double> simulator(*diagram);
+
+  simulator.get_mutable_integrator().set_maximum_step_size(0.002);
+  simulator.set_target_realtime_rate(FLAGS_real_time ? 1.f : 0.f);
+  simulator.Initialize();
+  simulator.AdvanceTo(FLAGS_simulation_time);
+  return 0;
+}
+
+}  // namespace contact_surface
+}  // namespace scene_graph
+}  // namespace examples
+}  // namespace drake
+
+int main(int argc, char* argv[]) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  return drake::examples::scene_graph::contact_surface::do_main();
+}

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -46,6 +46,8 @@ drake_cc_library(
     deps = [
         ":geometry_ids",
         ":geometry_index",
+        ":geometry_roles",
+        ":internal_geometry",
         ":shape_specification",
         ":utilities",
         "//common",
@@ -54,6 +56,7 @@ drake_cc_library(
         "//geometry/query_results",
         "//math",
         "@fcl",
+        "@fmt",
         "@tinyobjloader",
     ],
 )

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -422,7 +422,7 @@ class GeometryState {
 
   /** See QueryObject::ComputeContactSurfaces() for documentation.  */
   std::vector<ContactSurface<T>> ComputeContactSurfaces() const {
-    return geometry_engine_->ComputeContactSurfaces();
+    return geometry_engine_->ComputeContactSurfaces(X_WGs_);
   }
 
   /** See QueryObject::FindCollisionCandidates() for documentation.  */

--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -18,6 +18,7 @@ drake_cc_package_library(
         ":distance_to_point_with_gradient",
         ":distance_to_shape_callback",
         ":find_collision_candidates_callback",
+        ":hydroelastic_callback",
         ":make_box_mesh",
         ":make_sphere_mesh",
         ":mesh_field",
@@ -90,6 +91,27 @@ drake_cc_library(
         ":distance_to_point_callback",
         ":proximity_utilities",
         "//geometry/query_results:signed_distance_pair",
+    ],
+)
+
+drake_cc_library(
+    name = "hydroelastic_callback",
+    hdrs = [
+        "hydroelastic_callback.h",
+    ],
+    deps = [
+        ":collision_filter_legacy",
+        ":make_box_mesh",
+        ":make_sphere_mesh",
+        ":mesh_intersection",
+        ":proximity_utilities",
+        ":surface_mesh",
+        ":volume_mesh",
+        "//common:hash",
+        "//geometry/query_results:contact_surface",
+        "//math:geometric_transform",
+        "@fcl",
+        "@fmt",
     ],
 )
 
@@ -278,6 +300,15 @@ drake_cc_googletest(
         "//geometry:geometry_ids",
         "//geometry:utilities",
         "//math:gradient",
+    ],
+)
+
+drake_cc_googletest(
+    name = "hydroelastic_callback_test",
+    deps = [
+        ":hydroelastic_callback",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/geometry/proximity/hydroelastic_callback.h
+++ b/geometry/proximity/hydroelastic_callback.h
@@ -1,0 +1,183 @@
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <fcl/fcl.h>
+#include <fmt/format.h>
+
+#include "drake/common/eigen_types.h"
+#include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/proximity/collision_filter_legacy.h"
+#include "drake/geometry/proximity/make_box_mesh.h"
+#include "drake/geometry/proximity/make_sphere_mesh.h"
+#include "drake/geometry/proximity/mesh_intersection.h"
+#include "drake/geometry/proximity/proximity_utilities.h"
+#include "drake/geometry/query_results/contact_surface.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/math/rotation_matrix.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace hydroelastic {
+
+/** Supporting data for the shape-to-shape hydroelastic contact callback (see
+ Callback below). It includes:
+
+    - A collision filter instance.
+    - The T-valued poses of _all_ geometries in the corresponding SceneGraph,
+      each indexed by its corresponding geometry's GeometryIndex.
+    - A vector of contact surfaces -- one instance of ContactSurface for
+      every supported, unfiltered penetrating pair.
+
+ @tparam T The computation scalar.  */
+template <typename T>
+struct CallbackData {
+  /** Constructs the fully-specified callback data. The values are as described
+   in the class documentation. The parameters are all aliased in the data and
+   must remain valid at least as long as the CallbackData instance.
+
+   @param collision_filter_in     The collision filter system. Aliased.
+   @param X_WGs_in                The T-valued poses. Aliased.
+   @param surfaces_in             The output results. Aliased.  */
+  CallbackData(
+      const CollisionFilterLegacy* collision_filter_in,
+      const std::unordered_map<GeometryId, math::RigidTransform<T>>* X_WGs_in,
+      std::vector<ContactSurface<T>>* surfaces_in)
+      : collision_filter(*collision_filter_in),
+        X_WGs(*X_WGs_in),
+        surfaces(*surfaces_in) {
+    DRAKE_DEMAND(collision_filter_in);
+    DRAKE_DEMAND(X_WGs_in);
+    DRAKE_DEMAND(surfaces_in);
+  }
+
+  /** The collision filter system.  */
+  const CollisionFilterLegacy& collision_filter;
+
+  /** The T-valued poses of all geometries.  */
+  const std::unordered_map<GeometryId, math::RigidTransform<T>>& X_WGs;
+
+  /** The results of the distance query.  */
+  std::vector<ContactSurface<T>>& surfaces{};
+};
+
+/** Given an object_ptr whose geometry is a box, create a coarse surface mesh for
+ that box.  */
+SurfaceMesh<double> MakeBoxMeshFromFcl(fcl::CollisionObjectd* object_ptr) {
+  const fcl::Boxd* box_ptr = dynamic_cast<const fcl::Boxd*>(
+      object_ptr->collisionGeometry().get());
+  DRAKE_DEMAND(box_ptr != nullptr);
+  Box box(box_ptr->side(0), box_ptr->side(1), box_ptr->side(2));
+  // Edge length as long as the longest side guarantees the coarsest mesh.
+  const double edge_length = box_ptr->side.maxCoeff();
+  return MakeBoxSurfaceMesh<double>(box, edge_length);
+}
+
+struct SoftGeometry {
+  std::unique_ptr<VolumeMesh<double>> mesh;
+  std::unique_ptr<VolumeMeshFieldLinear<double, double>> p0;
+};
+
+/** Given an object_ptr whose geometry is a sphere, creates a coarse volume mesh
+ field for that sphere.  */
+SoftGeometry MakeSphereFromFcl(
+    fcl::CollisionObjectd* object_ptr) {
+  const fcl::Sphered* sphere_ptr = dynamic_cast<const fcl::Sphered*>(
+      object_ptr->collisionGeometry().get());
+  DRAKE_DEMAND(sphere_ptr != nullptr);
+  const double r = sphere_ptr->radius;
+  Sphere sphere(r);
+  // Edge length is the chord length around the equator where each span is 45
+  // degrees.
+  SoftGeometry geometry;
+  const double edge_length = 4 * r * M_PI / 16;
+  geometry.mesh = std::make_unique<VolumeMesh<double>>(
+      MakeSphereVolumeMesh<double>(sphere, edge_length));
+
+  std::vector<double> p0_values;
+  for (const auto& v : geometry.mesh->vertices()) {
+    const Eigen::Vector3d& p_MV = v.r_MV();
+    const double p_MV_len = p_MV.norm();
+    p0_values.push_back(1.0 - p_MV_len / r);
+  }
+  geometry.p0 = std::make_unique<VolumeMeshFieldLinear<double, double>>(
+      "p0", move(p0_values), geometry.mesh.get());
+
+  return geometry;
+}
+
+/** The callback function for computing a hydroelastic contact surface between
+ two arbitrary shapes.
+
+ @param object_A_ptr    Pointer to the first object in the pair (the order has
+                        no significance).
+ @param object_B_ptr    Pointer to the second object in the pair (the order has
+                        no significance).
+ @param callback_data   Supporting data to compute the contact surface.
+ @returns False; the broadphase should *not* terminate its process.
+ @tparam T  The scalar type for the query.  */
+template <typename T>
+bool Callback(fcl::CollisionObjectd* object_A_ptr,
+              fcl::CollisionObjectd* object_B_ptr,
+              // NOLINTNEXTLINE
+              void* callback_data) {
+  auto& data = *static_cast<CallbackData<T>*>(callback_data);
+
+  const EncodedData encoding_a(*object_A_ptr);
+  const EncodedData encoding_b(*object_B_ptr);
+
+  const bool can_collide = data.collision_filter.CanCollideWith(
+      encoding_a.encoding(), encoding_b.encoding());
+
+  if (can_collide) {
+    fcl::NODE_TYPE a_type = object_A_ptr->getNodeType();
+    fcl::NODE_TYPE b_type = object_B_ptr->getNodeType();
+
+    const bool valid =(a_type == fcl::GEOM_BOX && b_type == fcl::GEOM_SPHERE) ||
+        (a_type == fcl::GEOM_SPHERE && b_type == fcl::GEOM_BOX);
+    if (!valid) {
+      throw std::logic_error(fmt::format(
+          "Can't compute a contact surface between geometries {} ({}) and "
+          "{} ({})",
+          to_string(encoding_a.id()), GetGeometryName(*object_A_ptr),
+          to_string(encoding_b.id()), GetGeometryName(*object_B_ptr)));
+    }
+
+    fcl::CollisionObjectd* object_box_ptr{};
+    fcl::CollisionObjectd* object_sphere_ptr{};
+    GeometryId box_id;
+    GeometryId sphere_id;
+    if (a_type == fcl::GEOM_BOX) {
+      object_box_ptr = object_A_ptr;
+      box_id = encoding_a.id();
+      object_sphere_ptr = object_B_ptr;
+      sphere_id = encoding_b.id();
+      } else {
+        object_box_ptr = object_B_ptr;
+        box_id = encoding_b.id();
+        object_sphere_ptr = object_A_ptr;
+        sphere_id = encoding_a.id();
+      }
+
+      SurfaceMesh<double> box_mesh = MakeBoxMeshFromFcl(object_box_ptr);
+      // Build the sphere.
+      SoftGeometry soft_sphere = MakeSphereFromFcl(object_sphere_ptr);
+      std::unique_ptr<ContactSurface<T>> surface =
+          mesh_intersection::ComputeContactSurfaceFromSoftVolumeRigidSurface(
+              sphere_id, *soft_sphere.p0, data.X_WGs.at(sphere_id),
+              box_id, box_mesh, data.X_WGs.at(box_id));
+
+      data.surfaces.emplace_back(std::move(*surface));
+  }
+  // Tell the broadphase to keep searching.
+  return false;
+}
+
+}  // namespace hydroelastic
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/test/hydroelastic_callback_test.cc
+++ b/geometry/proximity/test/hydroelastic_callback_test.cc
@@ -1,0 +1,146 @@
+#include "drake/geometry/proximity/hydroelastic_callback.h"
+
+#include <memory>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <fcl/fcl.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace hydroelastic {
+namespace {
+
+using Eigen::Vector3d;
+using fcl::Boxd;
+using fcl::CollisionObjectd;
+using fcl::Halfspaced;
+using fcl::Sphered;
+using math::RigidTransform;
+using std::make_shared;
+using std::make_unique;
+using std::unique_ptr;
+using std::unordered_map;
+using std::vector;
+
+// TODO(SeanCurtis-TRI): When autodiff is more generally supported, replace the
+//  simple exception-expecting call (AutoDiffBlanketFailure) and add AutoDiff
+//  into this type list: ScalarTypes.
+
+// Confirmation of the short-term behavior that invoking the callback on
+// potentially colliding geometry using AutoDiffXd-valued transforms will throw.
+// Configure a scenario that would otherwise pass with double-valued poses.
+GTEST_TEST(HydroelasticCallbackAutodiff, AutoDiffBlanketFailure) {
+  // Note: this code should duplicate the valid double-valued configuration in
+  // the ValidPairProducesResult test. Its only point of failure should be that
+  // it is AutoDiffXd valued.
+  const double radius = 0.25;
+  const double cube_size = 0.4;
+  GeometryId id_A = GeometryId::get_new_id();
+  GeometryId id_B = GeometryId::get_new_id();
+  EncodedData data_A(id_A, true);
+  EncodedData data_B(id_B, true);
+  CollisionFilterLegacy collision_filter;
+  collision_filter.AddGeometry(data_A.encoding());
+  collision_filter.AddGeometry(data_B.encoding());
+  unordered_map<GeometryId, RigidTransform<AutoDiffXd>> X_WGs{
+      {id_A, RigidTransform<AutoDiffXd>::Identity()},
+      {id_B, RigidTransform<AutoDiffXd>(
+                 Vector3<AutoDiffXd>{0, 0, 0.9 * (radius + cube_size / 2)})}};
+
+  CollisionObjectd object_A(make_shared<Sphered>(radius));
+  data_A.write_to(&object_A);
+  CollisionObjectd object_B(make_shared<Boxd>(cube_size, cube_size, cube_size));
+  data_B.write_to(&object_B);
+
+  vector<ContactSurface<AutoDiffXd>> surfaces;
+  CallbackData<AutoDiffXd> data(&collision_filter, &X_WGs, &surfaces);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      Callback<AutoDiffXd>(&object_A, &object_B, &data), std::logic_error,
+      "AutoDiff-valued ContactSurface calculation between meshes is not"
+      "currently supported");
+}
+
+// Infrastructure to repeat tests on both double and AutoDiffXd.
+using ScalarTypes = ::testing::Types<double>;
+
+template <typename T>
+class HydroelasticCallbackTyped : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Configures a world with a sphere slightly overlapping a box.
+    id_sphere_ = GeometryId::get_new_id();
+    id_box_ = GeometryId::get_new_id();
+    EncodedData data_A(id_sphere_, true);
+    EncodedData data_B(id_box_, true);
+    collision_filter_.AddGeometry(data_A.encoding());
+    collision_filter_.AddGeometry(data_B.encoding());
+    // Leave box centered on origin.
+    X_WGs_.insert({id_box_, RigidTransform<T>::Identity()});
+    // Position sphere so that it is just far enough from the origin that the
+    // bottom of the sphere intersects the top of the box.
+    X_WGs_.insert({id_sphere_, RigidTransform<T>(Vector3<T>{
+                                   0, 0, 0.9 * (radius_ + cube_size_ / 2)})});
+
+    sphere_ = make_unique<CollisionObjectd>(make_shared<Sphered>(radius_));
+    data_A.write_to(sphere_.get());
+    box_ = make_unique<CollisionObjectd>(
+        make_shared<Boxd>(cube_size_, cube_size_, cube_size_));
+    data_B.write_to(box_.get());
+  }
+
+  CollisionFilterLegacy collision_filter_;
+  unordered_map<GeometryId, RigidTransform<T>> X_WGs_;
+  GeometryId id_sphere_{};
+  GeometryId id_box_{};
+  const double radius_{0.25};
+  const double cube_size_{0.4};
+  unique_ptr<CollisionObjectd> sphere_;
+  unique_ptr<CollisionObjectd> box_;
+};
+
+TYPED_TEST_CASE(HydroelasticCallbackTyped, ScalarTypes);
+#if 0
+// Confirms that if the world contains unsupported geometry, as long as they are
+// filtered, they don't pose a problem.
+TYPED_TEST(HydroelasticCallbackTyped, RespectsCollisionFilter) {
+  using T = TypeParam;
+
+  // Assign both geometries to clique 1 -- this will cause the pair to be
+  // filtered.
+  EncodedData data_A(this->id_A_, true);
+  EncodedData data_B(this->id_B_, true);
+  this->collision_filter_.AddToCollisionClique(data_A.encoding(), 1);
+  this->collision_filter_.AddToCollisionClique(data_B.encoding(), 1);
+
+  vector<ContactSurface<T>> surfaces;
+  CallbackData<T> data(&this->collision_filter_, &this->X_WGs_, &surfaces);
+  EXPECT_NO_THROW(
+      Callback<T>(this->sphere_A_.get(), this->sphere_B_.get(), &data));
+  EXPECT_EQ(surfaces.size(), 0u);
+}
+#endif
+// Confirms that a colliding collision pair (with supported hydroelastic
+// representations) produces a result. This doesn't test the actual data -- it
+// assumes the function responsible for computing that result has been
+// successfully tested.
+TYPED_TEST(HydroelasticCallbackTyped, ValidPairProducesResult) {
+  using T = TypeParam;
+
+  vector<ContactSurface<T>> surfaces;
+  CallbackData<T> data(&this->collision_filter_, &this->X_WGs_, &surfaces);
+  EXPECT_NO_THROW(
+      Callback<T>(this->sphere_.get(), this->box_.get(), &data));
+  EXPECT_EQ(surfaces.size(), 1u);
+}
+
+}  // namespace
+}  // namespace hydroelastic
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/test/hydroelastic_callback_test.cc
+++ b/geometry/proximity/test/hydroelastic_callback_test.cc
@@ -68,6 +68,7 @@ GTEST_TEST(HydroelasticCallbackAutodiff, AutoDiffBlanketFailure) {
 
 // Infrastructure to repeat tests on both double and AutoDiffXd.
 using ScalarTypes = ::testing::Types<double>;
+TYPED_TEST_CASE(HydroelasticCallbackTyped, ScalarTypes);
 
 template <typename T>
 class HydroelasticCallbackTyped : public ::testing::Test {
@@ -104,27 +105,11 @@ class HydroelasticCallbackTyped : public ::testing::Test {
   unique_ptr<CollisionObjectd> box_;
 };
 
-TYPED_TEST_CASE(HydroelasticCallbackTyped, ScalarTypes);
-#if 0
-// Confirms that if the world contains unsupported geometry, as long as they are
-// filtered, they don't pose a problem.
-TYPED_TEST(HydroelasticCallbackTyped, RespectsCollisionFilter) {
-  using T = TypeParam;
+// TODO(SeanCurtis-TRI): This test relies on the hackiness of the code when it
+//  it was introduced -- I.e., the *only* support that exists is for a soft
+//  sphere and rigid box. Update/replace this test when the geneeral support
+//  for evaluating hydroelastic contact is introduced.
 
-  // Assign both geometries to clique 1 -- this will cause the pair to be
-  // filtered.
-  EncodedData data_A(this->id_A_, true);
-  EncodedData data_B(this->id_B_, true);
-  this->collision_filter_.AddToCollisionClique(data_A.encoding(), 1);
-  this->collision_filter_.AddToCollisionClique(data_B.encoding(), 1);
-
-  vector<ContactSurface<T>> surfaces;
-  CallbackData<T> data(&this->collision_filter_, &this->X_WGs_, &surfaces);
-  EXPECT_NO_THROW(
-      Callback<T>(this->sphere_A_.get(), this->sphere_B_.get(), &data));
-  EXPECT_EQ(surfaces.size(), 0u);
-}
-#endif
 // Confirms that a colliding collision pair (with supported hydroelastic
 // representations) produces a result. This doesn't test the actual data -- it
 // assumes the function responsible for computing that result has been

--- a/geometry/proximity_engine.h
+++ b/geometry/proximity_engine.h
@@ -236,9 +236,13 @@ class ProximityEngine {
    map to `id_A` and `id_B` in a fixed, repeatable manner, where `id_A` and
    `id_B` are GeometryId's of geometries g_A and g_B respectively.
 
+   @param[in] X_WGs           The pose of all geometries in world, keyed by
+                              each geometry's GeometryId.
    @returns A vector populated with all detected intersections characterized as
             contact surfaces.  */
-  std::vector<ContactSurface<T>> ComputeContactSurfaces() const;
+  std::vector<ContactSurface<T>> ComputeContactSurfaces(
+      const std::unordered_map<GeometryId, math::RigidTransform<T>>& X_WGs)
+      const;
 
   //@}
 

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -188,7 +188,8 @@ class QueryObject {
      - The sphere will *always* be considered soft, and the box rigid.
      - The elasticity modulus for the sphere is hard-coded and arbitrary (but
        consistent with being a medium rubber).
-     - The sphere's pressure function is is simply: p_0(e) = e.
+     - The sphere's pressure function is is simply: p_0(e) = Ee. Where
+       E = 1e8 N/m^2.
      - The tesselation of the corresponding meshes will be coarse.
      - Attempting to invoke this method with T = AutoDiffXd will throw an
        exception if there are *any* geometry pairs that couldn't be culled.

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -179,9 +179,25 @@ class QueryObject {
    intersection as a ContactSurface. The computation is subject to collision
    filtering.
 
-   @returns A vector populated with contact surfaces of all detected
-            intersecting pairs of geometries.
-   @note  This function is not implemented yet. */
+   In the current incarnation, this function represents the most bare-bones
+   implementation possible.
+
+     - Only collision between spheres and boxes is supported. If an unfiltered
+       geometry pair of any other type pairing cannot be culled in the
+       broadphase an error will be thrown.
+     - The sphere will *always* be considered soft, and the box rigid.
+     - The elasticity modulus for the sphere is hard-coded and arbitrary (but
+       consistent with being a medium rubber).
+     - The sphere's pressure function is is simply: p_0(e) = e.
+     - The tesselation of the corresponding meshes will be coarse.
+     - Attempting to invoke this method with T = AutoDiffXd will throw an
+       exception if there are *any* geometry pairs that couldn't be culled.
+
+   In the near future, this behavior will extend to be configurable and more
+   general.
+
+   @returns The contact surfaces of all detected intersecting pairs of
+            geometries. */
   std::vector<ContactSurface<T>> ComputeContactSurfaces() const;
 
   //@}


### PR DESCRIPTION
This represents the minimum necessary code for creating contact surfaces via `SceneGraph` (and `QueryObject`). The PR has two commits. The first commit is the change to `geometry` the second is a simple example in `examples/scene_graph` for visualizing the contact surfaces. See the commit comments for more details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12093)
<!-- Reviewable:end -->
