### PR TITLE
[geometry] Add face_normal() to SurfaceMesh, and fix centroid() after TransformVertices().

### DIFF
--- a/geometry/proximity/surface_mesh.h
+++ b/geometry/proximity/surface_mesh.h
@@ -207,10 +207,12 @@ class SurfaceMesh {
    */
   SurfaceMesh(std::vector<SurfaceFace>&& faces,
               std::vector<SurfaceVertex<T>>&& vertices)
-      : faces_(std::move(faces)), vertices_(std::move(vertices)),
-        area_(faces_.size()) {  // Pre-allocate here, not yet calculated.
+      : faces_(std::move(faces)),
+        vertices_(std::move(vertices)),
+        area_(faces_.size()),  // Pre-allocate here, not yet calculated.
+        face_normals_(faces_.size()) {  // Pre-allocate, not yet calculated.
     SetReferringTriangles();
-    CalcAreasAndCentroid();
+    CalcAreasNormalsAndCentroid();
   }
 
   /** Transforms the vertices of this mesh from its initial frame M to the new
@@ -220,6 +222,10 @@ class SurfaceMesh {
     for (auto& v : vertices_) {
       v.TransformInPlace(X_NM);
     }
+    for (auto& n : face_normals_) {
+      n = X_NM.rotation() * n;
+    }
+    p_MSc_ = X_NM * p_MSc_;
   }
 
   /** Reverses the ordering of all the faces' indices -- see
@@ -228,6 +234,9 @@ class SurfaceMesh {
   void ReverseFaceWinding() {
     for (auto& f : faces_) {
       f.ReverseWinding();
+    }
+    for (auto& n : face_normals_) {
+      n = -n;
     }
   }
 
@@ -242,6 +251,16 @@ class SurfaceMesh {
   /** Returns the total area of all the faces of this surface mesh.
    */
   const T& total_area() const { return total_area_; }
+
+  /** Returns the unit face normal vector of a triangle. It respects the
+   right-handed normal rule. A near-zero-area triangle may get an unreliable
+   normal vector. A zero-area triangle will get a zero vector.
+   @pre f ∈ {0, 1, 2,..., num_faces()-1}.
+   */
+  const Vector3<T>& face_normal(SurfaceFaceIndex f) const {
+    DRAKE_DEMAND(0 <= f && f < num_faces());
+    return face_normals_[f];
+  }
 
   /** Returns the area-weighted geometric centroid of this surface mesh. The
    returned value is the position vector p_MSc from M's origin to the
@@ -345,9 +364,9 @@ class SurfaceMesh {
   //
 
  private:
-  // Calculates the areas of each triangle, the total area, and the centorid of
-  // the surface.
-  void CalcAreasAndCentroid();
+  // Calculates the areas and face normals of each triangle, the total area,
+  // and the centroid of the surface.
+  void CalcAreasNormalsAndCentroid();
 
   // Determines the triangular faces that refer to each vertex.
   void SetReferringTriangles() {
@@ -374,13 +393,16 @@ class SurfaceMesh {
   std::vector<T> area_;
   T total_area_{};
 
+  // Face normal vector of the triangles.
+  std::vector<Vector3<T>> face_normals_;
+
   // Area-weighted geometric centroid Sc of the surface mesh as an offset vector
   // from the origin of Frame M to point Sc, expressed in Frame M.
   Vector3<T> p_MSc_;
 };
 
 template <class T>
-void SurfaceMesh<T>::CalcAreasAndCentroid() {
+void SurfaceMesh<T>::CalcAreasNormalsAndCentroid() {
   total_area_ = 0;
   p_MSc_.setZero();
 
@@ -393,9 +415,17 @@ void SurfaceMesh<T>::CalcAreasAndCentroid() {
     const auto r_UW_M = r_MC - r_MA;
 
     const auto cross = r_UV_M.cross(r_UW_M);
-    const T face_area = T(0.5) * cross.norm();
+    const T norm = cross.norm();
+    const T face_area = T(0.5) * norm;
     area_[f] = face_area;
     total_area_ += face_area;
+
+    // TODO(DamrongGuoy): Provide a mechanism for users to set the face
+    //  normals of skinny triangles since this calculation is not reliable.
+    //  For example, the code that creates ContactSurface by
+    //  triangle-tetrahedron intersection can set more reliable normal vectors
+    //  for the skinny intersecting triangles.  Related to issue# 12110.
+    face_normals_[f] = (norm != T(0.0))? cross / norm : cross;
 
     // Accumulate area-weighted surface centroid; must be divided by 3X the
     // total area afterwards.

--- a/geometry/proximity/test/surface_mesh_test.cc
+++ b/geometry/proximity/test/surface_mesh_test.cc
@@ -196,7 +196,7 @@ GTEST_TEST(SurfaceMeshTest, TestFaceNormal) {
   // We estimate the rounding errors from rotation (multiply a vector by a
   // 3x3 matrix) about 3 machine epsilons.
   const double tol = 3.0 * std::numeric_limits<double>::epsilon();
-  auto surface_mesh = TestSurfaceMesh<double>(X_WM);
+  const auto surface_mesh = TestSurfaceMesh<double>(X_WM);
   const Vector3<double> expect_normal =
       X_WM.rotation() * Vector3<double>::UnitZ();
   EXPECT_TRUE(CompareMatrices(
@@ -205,7 +205,7 @@ GTEST_TEST(SurfaceMeshTest, TestFaceNormal) {
       expect_normal, surface_mesh->face_normal(SurfaceFaceIndex(1)), tol));
 
   // Verify that the zero-area mesh has zero-vector face normal.
-  auto zero_mesh = GenerateZeroAreaMesh();
+  const auto zero_mesh = GenerateZeroAreaMesh();
   const Vector3<double> zero_normal = Vector3<double>::Zero();
   EXPECT_EQ(zero_normal, zero_mesh->face_normal(SurfaceFaceIndex(0)));
   EXPECT_EQ(zero_normal, zero_mesh->face_normal(SurfaceFaceIndex(1)));


### PR DESCRIPTION
For #12068 "Contact surface needs to carry triangle face normals".
Fix centroid() after TransformVertices() by applying the rigid transform to the centroid.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12101)
<!-- Reviewable:end -->
