### PR TITLE
Removes leftover dead code from #11928.

### DIFF
--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3889,9 +3889,6 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // Index for the output port of ContactResults.
   systems::OutputPortIndex contact_results_port_;
 
-  // Index for the output port for contact forces per body.
-  systems::OutputPortIndex contact_forces_port_;
-
   // A vector containing the index for the generalized contact forces port for
   // each model instance. This vector is indexed by ModelInstanceIndex. An
   // invalid value indicates that the model instance has no generalized


### PR DESCRIPTION
@edrumwri, we forgot to remove this dead line when getting rid of the output port.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12103)
<!-- Reviewable:end -->
