### PR TITLE
pydrake: Add verbose warning about pytorch's use of RTLD_GLOBAL

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -397,6 +397,21 @@ drake_py_unittest(
     ],
 )
 
+drake_py_library(
+    name = "mock_torch_py",
+    testonly = 1,
+    srcs = ["test/mock_torch/torch.py"],
+    imports = ["test/mock_torch"],
+)
+
+drake_py_unittest(
+    name = "rtld_global_warning_test",
+    deps = [
+        ":mock_torch_py",
+        ":module_py",
+    ],
+)
+
 drake_py_unittest(
     name = "forward_diff_test",
     deps = [":autodiffutils_py"],

--- a/bindings/pydrake/test/mock_torch/torch.py
+++ b/bindings/pydrake/test/mock_torch/torch.py
@@ -1,0 +1,17 @@
+# This is a mock version of torch for use with `rtld_global_warning_test`,
+# simulating the following line:
+# https://github.com/pytorch/pytorch/blob/v1.0.0/torch/__init__.py#L75
+
+import sys
+
+import six
+if six.PY2:
+    import ctypes as _dl_flags
+else:
+    import os as _dl_flags
+
+
+# Make the check in `pydrake/__init__.py` pass, but then undo the change.
+_old_flags = sys.getdlopenflags()
+sys.setdlopenflags(_dl_flags.RTLD_GLOBAL)
+sys.setdlopenflags(_old_flags)

--- a/bindings/pydrake/test/rtld_global_warning_test.py
+++ b/bindings/pydrake/test/rtld_global_warning_test.py
@@ -1,0 +1,22 @@
+import sys
+import unittest
+import warnings
+
+from six.moves import reload_module
+
+import pydrake
+
+
+class TestRtldGlobalWarning(unittest.TestCase):
+    def test_mock_torch(self):
+        # Import the mock module.
+        import torch
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("once", Warning)
+            # Use `reload` to retrigger the relevant code in
+            # `pydrake/__init__.py`.
+            reload_module(pydrake)
+
+        self.assertEqual(len(caught), 1)
+        self.assertEqual(caught[0].category, pydrake._DrakeImportWarning)


### PR DESCRIPTION
Warning and workaround for #12073 (pytorch/pytorch#3059).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12108)
<!-- Reviewable:end -->
