### PR TITLE
[geometry] Fix soft-rigid contact surface in mesh_intersection.

### DIFF
--- a/geometry/proximity/mesh_intersection.h
+++ b/geometry/proximity/mesh_intersection.h
@@ -433,20 +433,13 @@ void AddPolygonToMeshData(
 
   const int num_original_vertices = static_cast<int>(vertices_F->size());
 
-  // If the polygon is a triangle, simply add it.
-  if (polygon_size == 3) {
-    int vertex_index[3];
-    for (int i = 0; i < 3; ++i) {
-      vertices_F->emplace_back(polygon_vertices_F[i]);
-      vertex_index[i] = i + num_original_vertices;
-    }
-    faces->emplace_back(vertex_index);
-    return;
-  }
-
   // Triangulate the polygon by creating a fan around the polygon's centroid.
   // This is important because it gives us a smoothly changing tesselation as
-  // the polygon itself smoothly changes.
+  // the polygon itself smoothly changes. Even if the polygon is already a
+  // triangle, we still add its centroid because the triangular polygon can
+  // smoothly change to a quadrilateral polygon. Therefore, an intersection
+  // triangle will contribute 3 triangles to the ContactSurface and smoothly
+  // change to 4 triangles from an intersection quadrilateral.
   Vector3<T> centroid = Vector3<T>::Zero();
   for (int i = 0; i < polygon_size; ++i) {
     vertices_F->emplace_back(polygon_vertices_F[i]);

--- a/geometry/proximity/test/mesh_intersection_test.cc
+++ b/geometry/proximity/test/mesh_intersection_test.cc
@@ -690,6 +690,10 @@ GTEST_TEST(MeshIntersectionTest, SampleVolumeFieldOnSurface) {
   EXPECT_EQ(3, surface->num_faces());
   // TODO(DamrongGuoy): More comprehensive checks.
   const double area = surface->area(SurfaceFaceIndex(0));
+  // The geometries M and N intersect in a right triangle ABC with edge
+  // lengths 0.5, 0.5, 0.5√2 with area 1/8. Then, ABC is subdivided into three
+  // smaller triangles of equal area, so each of the triangle in the contact
+  // surface has area (1/8)/3.
   const double expect_area = 1. / 24.;
   EXPECT_NEAR(expect_area, area, kEps);
   const SurfaceFaceIndex face0(0);

--- a/geometry/proximity/test/mesh_intersection_test.cc
+++ b/geometry/proximity/test/mesh_intersection_test.cc
@@ -687,10 +687,10 @@ GTEST_TEST(MeshIntersectionTest, SampleVolumeFieldOnSurface) {
       &surface, &e_field, &grad_h_field);
 
   const double kEps = std::numeric_limits<double>::epsilon();
-  EXPECT_EQ(1, surface->num_faces());
+  EXPECT_EQ(3, surface->num_faces());
   // TODO(DamrongGuoy): More comprehensive checks.
   const double area = surface->area(SurfaceFaceIndex(0));
-  const double expect_area = (1. / 2.) * 0.5 * 0.5;
+  const double expect_area = 1. / 24.;
   EXPECT_NEAR(expect_area, area, kEps);
   const SurfaceFaceIndex face0(0);
   const SurfaceMesh<double>::Barycentric centroid(1. / 3., 1. / 3., 1. / 3.);
@@ -957,7 +957,7 @@ GTEST_TEST(MeshIntersectionTest, ComputeContactSurfaceSoftRigidMoving) {
             id_S, *soft_epsilon, X_WS, id_R, *rigid_mesh, X_WR);
     // TODO(DamrongGuoy): More comprehensive checks on the mesh of the contact
     //  surface. Here we only check the number of triangles.
-    EXPECT_EQ(4, contact_SR_W->mesh_W().num_faces());
+    EXPECT_EQ(12, contact_SR_W->mesh_W().num_faces());
 
     const Vector3d p_MQ = Vector3d::Zero();
     SurfaceFaceIndex face_Q;
@@ -1000,7 +1000,7 @@ GTEST_TEST(MeshIntersectionTest, ComputeContactSurfaceSoftRigidMoving) {
             id_S, *soft_epsilon, X_WS, id_R, *rigid_mesh, X_WR);
     // TODO(DamrongGuoy): More comprehensive checks on the mesh of the contact
     //  surface.  Here we only check the number of triangles.
-    EXPECT_EQ(4, contact_SR_W->mesh_W().num_faces());
+    EXPECT_EQ(12, contact_SR_W->mesh_W().num_faces());
 
     const Vector3d p_MQ{0, -0.5,
                         0};  // The center vertex of the pyramid "bottom".


### PR DESCRIPTION
Currently ComputeContactSurfaceFromSoftVolumeRigidSurface() adds the centroid of each intersection polygon, which is the intersection between a triangle from rigid geometry and  a tetrahedron from soft geometry. However, if the intersection polygon is a triangle, the code does not add the centroid of the triangle. This can create discontinuity when the contact surface moves and an intersection triangle changes to an intersection quadrilateral.  We will have one triangle (from intersection triangle) abruptly change to four triangles (from intersection quadrilateral). 

Instead we would like three triangles (from one intersection triangle) gradually change to four triangles (from one intersection quadrilateral).

The simple solution is to always add the centroid of an intersection polygon whether it is a triangle or not.  An intersection n-gon will contribute n triangles to the ContactSurface.  An intersection triangle will contribute 3 triangles to the ContactSurface.  The downside is we will have more triangles in ContactSurface.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12112)
<!-- Reviewable:end -->
