### PR TITLE
filesystem: Ignore deprecations in ghc::filesystem

### DIFF
--- a/common/filesystem.cc
+++ b/common/filesystem.cc
@@ -11,6 +11,7 @@
 
 // Compile ghc::filesystem into object code.
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated"
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #define GHC_FILESYSTEM_IMPLEMENTATION
 #include "ghc/filesystem.hpp"  // NOLINT(build/include)

--- a/common/filesystem.h
+++ b/common/filesystem.h
@@ -18,6 +18,7 @@ namespace drake { namespace filesystem = std::filesystem; }
 #else
 
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated"
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #define GHC_FILESYSTEM_FWD
 #include "ghc/filesystem.hpp"


### PR DESCRIPTION
Otherwise, GCC complains about _"redundant redeclaration of 'constexpr' static data member"_ when in `-std=c++17` mode.

Repairs #12106.  Relates #12104.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12116)
<!-- Reviewable:end -->
