### PR TITLE
Revert "common: Port from spruce to filesystem"

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -362,8 +362,8 @@ drake_cc_library(
     visibility = ["//tools/install/libdrake:__pkg__"],
     deps = [
         ":essential",
-        ":filesystem",
         ":find_resource",
+        "@spruce",
     ],
 )
 
@@ -443,7 +443,7 @@ drake_cc_library(
     hdrs = ["temp_directory.h"],
     deps = [
         ":essential",
-        ":filesystem",
+        "@spruce",
     ],
 )
 
@@ -1218,8 +1218,8 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "temp_directory_test",
     deps = [
-        ":filesystem",
         ":temp_directory",
+        "@spruce",
     ],
 )
 

--- a/common/drake_path.cc
+++ b/common/drake_path.cc
@@ -1,6 +1,7 @@
 #include "drake/common/drake_path.h"
 
-#include "drake/common/filesystem.h"
+#include <spruce.hh>
+
 #include "drake/common/find_resource.h"
 
 // N.B. This code is unit tested in test/find_resource_test.cc.
@@ -15,11 +16,11 @@ optional<std::string> MaybeGetDrakePath() {
   if (find_result.get_error_message()) {
     return nullopt;
   }
-  filesystem::path sentinel_path(find_result.get_absolute_path_or_throw());
+  spruce::path sentinel_path = find_result.get_absolute_path_or_throw();
 
   // Take the dirname of sentinel_path, so that we have a folder where looking
   // up "drake/foo/bar.urdf" makes sense.
-  return sentinel_path.parent_path().string();
+  return sentinel_path.root();
 }
 
 }  // namespace drake

--- a/common/proto/BUILD.bazel
+++ b/common/proto/BUILD.bazel
@@ -117,7 +117,7 @@ drake_cc_library(
     visibility = ["//visibility:private"],
     deps = [
         "//common:essential",
-        "//common:filesystem",
+        "@spruce",
     ],
 )
 

--- a/common/proto/rpc_pipe_temp_directory.cc
+++ b/common/proto/rpc_pipe_temp_directory.cc
@@ -2,8 +2,9 @@
 
 #include <cstdlib>
 
+#include <spruce.hh>
+
 #include "drake/common/drake_throw.h"
-#include "drake/common/filesystem.h"
 
 namespace drake {
 namespace common {
@@ -12,9 +13,11 @@ std::string GetRpcPipeTempDirectory() {
   const char* path_str = nullptr;
   (path_str = std::getenv("TEST_TMPDIR")) || (path_str = "/tmp");
 
-  const filesystem::path path(path_str);
-  DRAKE_THROW_UNLESS(filesystem::is_directory(path));
-  return path.string();
+  spruce::path path(path_str);
+  DRAKE_THROW_UNLESS(path.isDir());
+
+  // Spruce normalizes the path and strips any trailing /.
+  return path.getStr();
 }
 
 }  // namespace common

--- a/common/temp_directory.cc
+++ b/common/temp_directory.cc
@@ -4,13 +4,14 @@
 
 #include <cstdlib>
 
+#include <spruce.hh>
+
 #include "drake/common/drake_throw.h"
-#include "drake/common/filesystem.h"
 
 namespace drake {
 
 std::string temp_directory() {
-  filesystem::path path;
+  spruce::path path;
 
   const char* test_tmpdir = std::getenv("TEST_TMPDIR");
 
@@ -18,26 +19,22 @@ std::string temp_directory() {
     const char* tmpdir = nullptr;
     (tmpdir = std::getenv("TMPDIR")) || (tmpdir = "/tmp");
 
-    filesystem::path path_template(tmpdir);
+    spruce::path path_template(tmpdir);
     path_template.append("robotlocomotion_drake_XXXXXX");
 
-    std::string path_template_str = path_template.string();
+    std::string path_template_str = path_template.getStr();
     const char* dtemp = ::mkdtemp(&path_template_str[0]);
     DRAKE_THROW_UNLESS(dtemp != nullptr);
 
-    path = dtemp;
+    path.setStr(dtemp);
   } else {
-    path = test_tmpdir;
+    path.setStr(test_tmpdir);
   }
 
-  DRAKE_THROW_UNLESS(filesystem::is_directory(path));
+  DRAKE_THROW_UNLESS(path.isDir());
 
-  // Strip any trailing /.
-  std::string result = path.string();
-  if (result.back() == '/') {
-    result.pop_back();
-  }
-  return result;
+  // Spruce normalizes the path and strips any trailing /.
+  return path.getStr();
 }
 
 }  // namespace drake

--- a/common/test/find_resource_test.cc
+++ b/common/test/find_resource_test.cc
@@ -10,11 +10,11 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <spruce.hh>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_path.h"
 #include "drake/common/drake_throw.h"
-#include "drake/common/filesystem.h"
 
 using std::string;
 
@@ -113,10 +113,9 @@ GTEST_TEST(GetDrakePathTest, PathIncludesDrake) {
   // Tests that the path returned includes the root of drake.
   const auto& result = MaybeGetDrakePath();
   ASSERT_TRUE(result);
-  const filesystem::path expected =
-      filesystem::path(*result) /
-      filesystem::path("common/test/find_resource_test_data.txt");
-  EXPECT_TRUE(filesystem::exists(expected));
+  const spruce::path expected(*result +
+                              "/common/test/find_resource_test_data.txt");
+  EXPECT_TRUE(expected.exists());
 }
 
 }  // namespace


### PR DESCRIPTION
Reverts #12117.

Dear @jwnimmer-tri,

The on-call build cop, @jamiesnape, believes that your PR #12117 may have
broken one or more of Drake's continuous integration builds [1]. It is
possible to break a build even if your PR passed continuous integration
pre-merge because additional platforms are tested post-merge.

The specific build failures under investigation are:

* https://drake-jenkins.csail.mit.edu/job/mac-mojave-clang-bazel-nightly-address-sanitizer/147/
* https://drake-jenkins.csail.mit.edu/job/mac-mojave-clang-bazel-nightly-everything-address-sanitizer/147/

Therefore, the build cop has created this revert PR and started a complete
post-merge build to determine whether your PR was in fact the cause of the
problem. If that build passes, this revert PR will be merged 60 minutes from
now. You can then fix the problem at your leisure, and send a new PR to
reinstate your change.

If you believe your original PR did not actually break the build, please
explain on this thread.

If you believe you can fix the break promptly in lieu of a revert, please
explain on this thread, and send a PR to the build cop for review ASAP.

If you believe your original PR definitely did break the build and should be
reverted, please review and LGTM this PR. This allows the build cop to merge
without waiting for CI results.

For advice on how to handle a build cop revert, see [2].

Thanks!
Your Friendly On-call Build Cop

[1] CI Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Production/
[2] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert