### PR TITLE
common: Fix port from spruce to filesystem

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -1217,6 +1217,9 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "temp_directory_test",
+    # Run each test case in a different process, to avoid environment variable
+    # changes from one accidentally polluting the others.
+    shard_count = 3,
     deps = [
         ":filesystem",
         ":temp_directory",


### PR DESCRIPTION
On macOS, setenv is dangerous (and trips asan checks), so be sure to run each test case in its own process.