### PR TITLE
Fix meshcat visualizer frame visualization for world geometry

### DIFF
--- a/bindings/pydrake/systems/meshcat_visualizer.py
+++ b/bindings/pydrake/systems/meshcat_visualizer.py
@@ -333,7 +333,11 @@ class MeshcatVisualizer(LeafSystem):
                     cur_vis.set_transform(element_local_tf)
 
                 # Draw the frames in self.frames_to_draw.
-                robot_name, link_name = self._parse_name(frame_name)
+                if "::" in frame_name:
+                    robot_name, link_name = self._parse_name(frame_name)
+                else:
+                    robot_name = "world"
+                    link_name = frame_name
                 if (robot_name in self.frames_to_draw.keys() and
                         link_name in self.frames_to_draw[robot_name]):
                     prefix = (self.prefix + '/' + source_name + '/' +


### PR DESCRIPTION
Addresses issue #12127. The new test passes for me locally, drawing both the box and its frame. (Frame gets hidden inside the box, though.)

![Screenshot from 2019-10-01 18-17-38](https://user-images.githubusercontent.com/3066703/66004863-cfcbec80-e477-11e9-81da-7ccc3623cbb2.png)
![Screenshot from 2019-10-01 18-17-30](https://user-images.githubusercontent.com/3066703/66004867-d0fd1980-e477-11e9-8c4f-8e95c4095dbb.png)

@pangtao22 Would you mind testing this to make sure it's OK with your current applications of frame visualization? And would you happen to be willing to review?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12129)
<!-- Reviewable:end -->
