### PR TITLE
Remove macOS Python 2 support, part 1

### DIFF
--- a/doc/developers.rst
+++ b/doc/developers.rst
@@ -85,11 +85,11 @@ Drake requires a compiler running in C++14 mode or greater.
 | Ubuntu 18.04 LTS (Bionic Beaver) |       | 3.10  | | Clang 6.0         | OpenJDK 11        | | 2.7   |
 |                                  |       |       | | GCC 7.4           |                   | | [3.6] |
 +----------------------------------+       +-------+---------------------+-------------------+---------+
-| macOS High Sierra (10.13)        |       | 3.15  | | Apple LLVM 10.0.0 | | AdoptOpenJDK 12 | | 2.7   |
-|                                  |       |       | | (Xcode 10.1)      | | (HotSpot JVM)   | | [3.7] |
+| macOS High Sierra (10.13)        |       | 3.15  | | Apple LLVM 10.0.0 | | AdoptOpenJDK 13 | [3.7]   |
+|                                  |       |       | | (Xcode 10.1)      | | (HotSpot JVM)   |         |
 +----------------------------------+       |       +---------------------+                   |         |
-| macOS Mojave (10.14)             |       |       | | Apple LLVM 10.0.1 |                   |         |
-|                                  |       |       | | (Xcode 10.3)      |                   |         |
+| macOS Mojave (10.14)             |       |       | | Apple LLVM 11.0.0 |                   |         |
+|                                  |       |       | | (Xcode 11.0)      |                   |         |
 +----------------------------------+-------+-------+---------------------+-------------------+---------+
 
 CPython is the only Python implementation supported; default versions are

--- a/doc/python_bindings.rst
+++ b/doc/python_bindings.rst
@@ -151,12 +151,6 @@ After following the above install steps, check to ensure you can import
 
 .. note::
 
-    If you are using macOS and the Python 2 bindings, you must ensure that you
-    are using the ``python2`` executable (typically located at
-    ``/usr/local/bin/python2``) to run these scripts.
-
-.. note::
-
     If you are using Gurobi, you must either have it installed in the suggested
     location under ``/opt/...`` mentioned in :ref:`gurobi`, or you must ensure
     that you define the ``${GUROBI_PATH}`` environment variable, or specify

--- a/setup/mac/binary_distribution/install_prereqs.sh
+++ b/setup/mac/binary_distribution/install_prereqs.sh
@@ -28,7 +28,7 @@ if ! command -v /usr/local/bin/pip2 &>/dev/null; then
   exit 2
 fi
 
-/usr/local/bin/pip2 install --upgrade --requirement "${BASH_SOURCE%/*}/requirements.txt"
+/usr/local/bin/pip2 install --upgrade --requirement "${BASH_SOURCE%/*}/requirements-py2.txt"
 
 if ! command -v /usr/local/bin/pip3 &>/dev/null; then
   echo 'ERROR: pip3 is NOT installed. The post-install step for the python formula may have failed.' >&2

--- a/setup/mac/binary_distribution/requirements-py2.txt
+++ b/setup/mac/binary_distribution/requirements-py2.txt
@@ -1,0 +1,5 @@
+# TODO(jamiesnape): Remove this file when Director switches to Python 3.x.
+lxml
+matplotlib
+PyYAML
+scipy

--- a/setup/mac/binary_distribution/requirements.txt
+++ b/setup/mac/binary_distribution/requirements.txt
@@ -1,10 +1,8 @@
 lxml
 matplotlib
-protobuf; python_version < "3.0"
 pydot
 PyYAML
 pyzmq
-scipy; python_version < "3.0"
 six
 tornado
 u-msgpack-python

--- a/setup/mac/source_distribution/install_prereqs.sh
+++ b/setup/mac/source_distribution/install_prereqs.sh
@@ -20,16 +20,9 @@ fi
 /usr/local/bin/brew update
 /usr/local/bin/brew bundle --file="${BASH_SOURCE%/*}/Brewfile"
 
-if ! command -v /usr/local/bin/pip2 &>/dev/null; then
-  echo 'ERROR: pip2 is NOT installed. The post-install step for the python@2 formula may have failed.' >&2
-  exit 2
-fi
-
-/usr/local/bin/pip2 install --upgrade --requirement "${BASH_SOURCE%/*}/requirements.txt"
-
 if ! command -v /usr/local/bin/pip3 &>/dev/null; then
   echo 'ERROR: pip3 is NOT installed. The post-install step for the python formula may have failed.' >&2
-  exit 3
+  exit 2
 fi
 
 /usr/local/bin/pip3 install --upgrade --requirement "${BASH_SOURCE%/*}/requirements.txt"

--- a/setup/mac/source_distribution/requirements.txt
+++ b/setup/mac/source_distribution/requirements.txt
@@ -1,6 +1,6 @@
-boto3; python_version >= "3.3"
-ipywidgets; python_version >= "3.5"  # For Jupyter
-jupyter; python_version >= "3.5"  # Also enables `jupyter notebook`
+boto3
+ipywidgets  # For Jupyter
+jupyter  # Also enables `jupyter notebook`
 pygame
 # Constrain Sphinx due to hack customizations for templates in
 # `pydrake_sphinx_extension`.

--- a/tools/macos.bazelrc
+++ b/tools/macos.bazelrc
@@ -1,9 +1,3 @@
-# N.B. Ensure we only use Homebrew's Python in `/usr/local`.
-
-# Explicit configuration for Python 2.
-build:python2 --python_path=/usr/local/bin/python2
-build:python2 --action_env=DRAKE_PYTHON_BIN_PATH=/usr/local/bin/python2
-
 # Explicit configuration for Python 3.
 build:python3 --python_path=/usr/local/bin/python3
 build:python3 --action_env=DRAKE_PYTHON_BIN_PATH=/usr/local/bin/python3

--- a/tools/workspace/python/repository.bzl
+++ b/tools/workspace/python/repository.bzl
@@ -39,8 +39,8 @@ load("@drake//tools/workspace:os.bzl", "determine_os")
 _VERSION_SUPPORT_MATRIX = {
     "ubuntu:16.04": ["2.7"],
     "ubuntu:18.04": ["3.6", "2.7"],
-    "macos:10.13": ["3.7", "2.7"],
-    "macos:10.14": ["3.7", "2.7"],
+    "macos:10.13": ["3.7"],
+    "macos:10.14": ["3.7"],
 }
 
 def _repository_python_info(repository_ctx):

--- a/tools/workspace/u_msgpack_python/repository.bzl
+++ b/tools/workspace/u_msgpack_python/repository.bzl
@@ -46,7 +46,7 @@ def _impl(repository_ctx):
 
     if os_result.is_macos:
         repository_ctx.symlink(
-            "/usr/local/lib/python2.7/site-packages/umsgpack.py",
+            "/usr/local/lib/python3.7/site-packages/umsgpack.py",
             "umsgpack.py",
         )
 


### PR DESCRIPTION
Should be enough to keep (only) drake-visualizer working with python 2.

Toward #11692.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12138)
<!-- Reviewable:end -->
