### PR TITLE
solvers: Deprecate mathematical_program_lite label

### DIFF
--- a/attic/manipulation/dev/BUILD.bazel
+++ b/attic/manipulation/dev/BUILD.bazel
@@ -33,7 +33,7 @@ drake_cc_library(
         "//attic/systems/controllers:control_util",
         "//math:geometric_transform",
         "//solvers:gurobi_solver",
-        "//solvers:mathematical_program_lite",
+        "//solvers:mathematical_program",
         "//systems/framework:leaf_system",
     ],
 )

--- a/attic/multibody/BUILD.bazel
+++ b/attic/multibody/BUILD.bazel
@@ -57,7 +57,7 @@ drake_cc_library(
     ],
     deps = [
         ":rigid_body_tree",
-        "//solvers:mathematical_program_lite",
+        "//solvers:mathematical_program",
         "//solvers:mixed_integer_rotation_constraint",
         "//solvers:rotation_constraint",
     ],
@@ -127,7 +127,7 @@ drake_cc_library(
         ":rigid_body_tree",
         "//common:unused",
         "//math:gradient",
-        "//solvers:mathematical_program_lite",
+        "//solvers:mathematical_program",
         "//solvers:solve",
     ],
 )

--- a/attic/multibody/rigid_body_plant/BUILD.bazel
+++ b/attic/multibody/rigid_body_plant/BUILD.bazel
@@ -76,7 +76,7 @@ drake_cc_library(
         "//common:essential",
         "//math:orthonormal_basis",
         "//multibody/constraint:constraint_solver",
-        "//solvers:mathematical_program_lite",
+        "//solvers:mathematical_program",
         "//systems/framework",
     ],
 )

--- a/attic/perception/estimators/dev/BUILD.bazel
+++ b/attic/perception/estimators/dev/BUILD.bazel
@@ -95,7 +95,7 @@ drake_cc_googletest(
         "//common:find_resource",
         "//lcmtypes:viewer",
         "//math:geometric_transform",
-        "//solvers:mathematical_program_lite",
+        "//solvers:mathematical_program",
         "//solvers:solve",
     ],
 )

--- a/attic/systems/controllers/qp_inverse_dynamics/BUILD.bazel
+++ b/attic/systems/controllers/qp_inverse_dynamics/BUILD.bazel
@@ -122,7 +122,7 @@ drake_cc_library(
         "//common:essential",
         "//math:gradient",
         "//solvers:gurobi_solver",
-        "//solvers:mathematical_program_lite",
+        "//solvers:mathematical_program",
     ],
 )
 

--- a/attic/systems/estimators/dev/BUILD.bazel
+++ b/attic/systems/estimators/dev/BUILD.bazel
@@ -27,7 +27,7 @@ drake_cc_test(
         "//attic/multibody/parsers",
         "//common:essential",
         "//common:find_resource",
-        "//solvers:mathematical_program_lite",
+        "//solvers:mathematical_program",
         "//solvers:solve",
         "@lcm",
         "@lcmtypes_bot2_core",

--- a/examples/cubic_polynomial/BUILD.bazel
+++ b/examples/cubic_polynomial/BUILD.bazel
@@ -10,7 +10,7 @@ drake_cc_binary(
     add_test_rule = 1,
     tags = mosek_test_tags(),
     deps = [
-        "//solvers:mathematical_program_lite",
+        "//solvers:mathematical_program",
         "//solvers:solve",
         "//systems/framework:vector_system",
     ],
@@ -23,7 +23,7 @@ drake_cc_binary(
     tags = mosek_test_tags(),
     deps = [
         "//common/proto:call_python",
-        "//solvers:mathematical_program_lite",
+        "//solvers:mathematical_program",
         "//solvers:mosek_solver",
         "//solvers:solve",
         "//systems/framework:vector_system",

--- a/examples/planar_gripper/BUILD.bazel
+++ b/examples/planar_gripper/BUILD.bazel
@@ -42,7 +42,7 @@ drake_cc_library(
         "//multibody/inverse_kinematics:kinematic_constraint",
         "//multibody/plant",
         "//solvers:constraint",
-        "//solvers:mathematical_program_lite",
+        "//solvers:mathematical_program",
     ],
 )
 
@@ -104,7 +104,7 @@ drake_cc_library(
     deps = [
         ":gripper_brick",
         "//multibody/inverse_kinematics:kinematic_constraint",
-        "//solvers:mathematical_program_lite",
+        "//solvers:mathematical_program",
     ],
 )
 

--- a/examples/rod2d/BUILD.bazel
+++ b/examples/rod2d/BUILD.bazel
@@ -51,7 +51,7 @@ drake_cc_library(
         ":rod2d_state_vector",
         "//common:essential",
         "//multibody/constraint",
-        "//solvers:mathematical_program_lite",
+        "//solvers:mathematical_program",
         "//systems/framework:leaf_system",
         "//systems/rendering:pose_vector",
     ],

--- a/manipulation/planner/BUILD.bazel
+++ b/manipulation/planner/BUILD.bazel
@@ -26,7 +26,7 @@ drake_cc_library(
     hdrs = ["differential_inverse_kinematics.h"],
     deps = [
         "//multibody/plant",
-        "//solvers:mathematical_program_lite",
+        "//solvers:mathematical_program",
         "//solvers:osqp_solver",
     ],
 )

--- a/multibody/inverse_kinematics/BUILD.bazel
+++ b/multibody/inverse_kinematics/BUILD.bazel
@@ -64,7 +64,7 @@ drake_cc_library(
     deps = [
         ":kinematic_constraint",
         "//multibody/plant",
-        "//solvers:mathematical_program_lite",
+        "//solvers:mathematical_program",
     ],
 )
 

--- a/multibody/optimization/BUILD.bazel
+++ b/multibody/optimization/BUILD.bazel
@@ -57,7 +57,7 @@ drake_cc_library(
         "//multibody/plant",
         "//solvers:binding",
         "//solvers:constraint",
-        "//solvers:mathematical_program_lite",
+        "//solvers:mathematical_program",
     ],
 )
 
@@ -99,7 +99,7 @@ drake_cc_library(
         "//multibody/plant",
         "//solvers:binding",
         "//solvers:constraint",
-        "//solvers:mathematical_program_lite",
+        "//solvers:mathematical_program",
     ],
 )
 
@@ -113,7 +113,7 @@ drake_cc_library(
         "//multibody/plant",
         "//solvers:binding",
         "//solvers:constraint",
-        "//solvers:mathematical_program_lite",
+        "//solvers:mathematical_program",
     ],
 )
 
@@ -160,7 +160,7 @@ drake_cc_googletest(
         ":static_equilibrium_constraint",
         "//common/test_utilities:eigen_matrix_compare",
         "//math:compute_numerical_gradient",
-        "//solvers:mathematical_program_lite",
+        "//solvers:mathematical_program",
         "//solvers:solve",
     ],
 )
@@ -200,7 +200,7 @@ drake_cc_googletest(
         ":optimization_with_contact_utilities",
         "//common/test_utilities:eigen_matrix_compare",
         "//math:compute_numerical_gradient",
-        "//solvers:mathematical_program_lite",
+        "//solvers:mathematical_program",
         "//solvers:solve",
     ],
 )

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -325,12 +325,13 @@ drake_cc_library(
     ],
 )
 
-# The target "@drake//solvers:mathematical_program_lite" is a legacy way to
-# access the `mathematical_program.h` header and its methods.  In the future,
-# this target will become deprecated in lieu of `:mathematical_program`.
-# TODO(jwnimmer-tri) On 2019-10-01 add a deprecation attribute here.
 drake_cc_library(
     name = "mathematical_program_lite",
+    deprecation = " ".join([
+        "The label @drake//solvers:mathematical_program_lite is deprecated.",
+        "Use the new spelling @drake//solvers:mathematical_program instead.",
+        "The deprecated spelling will be removed on 2020-01-01.",
+    ]),
     deps = [
         ":mathematical_program",
         ":solver_interface",

--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -124,7 +124,7 @@ drake_cc_library(
         "//common:essential",
         "//math:autodiff",
         "//math:gradient",
-        "//solvers:mathematical_program_lite",
+        "//solvers:mathematical_program",
         "//solvers:solve",
         "//systems/framework",
     ],

--- a/systems/controllers/BUILD.bazel
+++ b/systems/controllers/BUILD.bazel
@@ -41,7 +41,7 @@ drake_cc_library(
     deps = [
         "//common:essential",
         "//math:wrap_to",
-        "//solvers:mathematical_program_lite",
+        "//solvers:mathematical_program",
         "//solvers:solve",
         "//systems/analysis:simulator",
         "//systems/framework",

--- a/systems/trajectory_optimization/BUILD.bazel
+++ b/systems/trajectory_optimization/BUILD.bazel
@@ -42,7 +42,7 @@ drake_cc_library(
         "//common:essential",
         "//common/trajectories:piecewise_polynomial",
         "//solvers:ipopt_solver",
-        "//solvers:mathematical_program_lite",
+        "//solvers:mathematical_program",
     ],
 )
 


### PR DESCRIPTION
Use the new spelling `mathematical_program` instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12142)
<!-- Reviewable:end -->
