### PR TITLE
pydrake: Remove deprecated attic-module aliases

### DIFF
--- a/bindings/pydrake/attic/BUILD.bazel
+++ b/bindings/pydrake/attic/BUILD.bazel
@@ -60,14 +60,4 @@ install(
     deps = get_drake_py_installs(PY_LIBRARIES_WITH_INSTALL),
 )
 
-drake_py_unittest(
-    name = "attic_forwarding_test",
-    deps = [
-        "//bindings/pydrake/attic/multibody",
-        "//bindings/pydrake/attic/solvers",
-        "//bindings/pydrake/multibody",
-        "//bindings/pydrake/solvers",
-    ],
-)
-
 add_lint_tests_pydrake()

--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -134,23 +134,6 @@ drake_pybind_library(
     ],
 )
 
-PY_LIBRARIES_ATTIC_ALIASES = [
-    ":collision_py",
-    ":joints_py",
-    ":parsers_py",
-    ":rigid_body_plant_py",
-    ":rigid_body_py",
-    ":rigid_body_tree_py",
-    ":shapes_py",
-]
-
-drake_py_library_aliases(
-    actual_subdir = "bindings/pydrake/attic/multibody",
-    add_deprecation_warning = 1,
-    deprecation_removal_date = "2019-10-01",
-    relative_labels = PY_LIBRARIES_ATTIC_ALIASES,
-)
-
 PY_LIBRARIES_WITH_INSTALL = [
     ":benchmarks_py",
     ":inverse_kinematics_py",
@@ -160,7 +143,7 @@ PY_LIBRARIES_WITH_INSTALL = [
     ":tree_py",
 ]
 
-PY_LIBRARIES = PY_LIBRARIES_ATTIC_ALIASES + [
+PY_LIBRARIES = [
     ":module_py",
 ]
 

--- a/bindings/pydrake/solvers/BUILD.bazel
+++ b/bindings/pydrake/solvers/BUILD.bazel
@@ -173,17 +173,6 @@ drake_pybind_library(
     ],
 )
 
-PY_LIBRARIES_ATTIC_ALIASES = [
-    ":ik_py",
-]
-
-drake_py_library_aliases(
-    actual_subdir = "bindings/pydrake/attic/solvers",
-    add_deprecation_warning = 1,
-    deprecation_removal_date = "2019-10-01",
-    relative_labels = PY_LIBRARIES_ATTIC_ALIASES,
-)
-
 PY_LIBRARIES_WITH_INSTALL = [
     ":gurobi_py",
     ":ipopt_py",
@@ -195,7 +184,7 @@ PY_LIBRARIES_WITH_INSTALL = [
     ":snopt_py",
 ]
 
-PY_LIBRARIES = PY_LIBRARIES_ATTIC_ALIASES + [
+PY_LIBRARIES = [
     ":module_py",
 ]
 

--- a/bindings/pydrake/test/all_test.py
+++ b/bindings/pydrake/test/all_test.py
@@ -30,9 +30,6 @@ class TestAll(unittest.TestCase):
                 sys.stderr.write("Encountered import warnings:\n{}\n".format(
                     "\n".join(map(str, w)) + "\n"))
             self.assertEqual(len(w), 0)
-        # Show that deprecated modules are not incorporated in `.all` (#11363).
-        with catch_drake_warnings(expected_count=1):
-            import pydrake.multibody.rigid_body_tree
 
     def test_usage_no_all(self):
         from pydrake.common import FindResourceOrThrow


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12145)
<!-- Reviewable:end -->
