### PR TITLE
solvers: Avoid deprecated mathematical_program_lite label

### DIFF
--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -332,6 +332,10 @@ drake_cc_library(
         "Use the new spelling @drake//solvers:mathematical_program instead.",
         "The deprecated spelling will be removed on 2020-01-01.",
     ]),
+    tags = [
+        # Avoid 'build //...' yelling at us.
+        "manual",
+    ],
     deps = [
         ":mathematical_program",
         ":solver_interface",


### PR DESCRIPTION
This removes a warning during 'bazel build //...', repairing 0f748c3ce06349bc892b7ac7dad5446352a5f768 (#12142).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12149)
<!-- Reviewable:end -->
