### PR TITLE
py autodiff, symbolic: Support newer features in NumPy 1.17.0

### DIFF
--- a/bindings/pydrake/autodiff_types_pybind.h
+++ b/bindings/pydrake/autodiff_types_pybind.h
@@ -65,7 +65,9 @@ void BindAutoDiffMathOverloads(PyObject* obj) {
       .def("max",
           [](const AutoDiffXd& x, const AutoDiffXd& y) { return max(x, y); })
       .def("ceil", [](const AutoDiffXd& x) { return ceil(x); })
+      .def("__ceil__", [](const AutoDiffXd& x) { return ceil(x); })
       .def("floor", [](const AutoDiffXd& x) { return floor(x); })
+      .def("__floor__", [](const AutoDiffXd& x) { return floor(x); })
       // TODO(eric.cousineau): This is not a NumPy-overridable method using
       // dtype=object. Deprecate and move solely into `pydrake.math`.
       .def("inv", [](const MatrixX<AutoDiffXd>& X) -> MatrixX<AutoDiffXd> {

--- a/bindings/pydrake/common/compatibility.py
+++ b/bindings/pydrake/common/compatibility.py
@@ -4,11 +4,11 @@ which may need changes for compatibility.
 
 import numpy as np
 
-_numpy_version = np.lib.NumpyVersion(np.version.version)
+
 _patches = {
     'numpy_formatters': {
         'applied': False,
-        'required': _numpy_version < np.lib.NumpyVersion('1.13.0'),
+        'required': np.lib.NumpyVersion(np.__version__) < '1.13.0',
     },
 }
 

--- a/bindings/pydrake/symbolic_py.cc
+++ b/bindings/pydrake/symbolic_py.cc
@@ -344,7 +344,9 @@ PYBIND11_MODULE(symbolic, m) {
       .def("min", &symbolic::min, doc.min.doc)
       .def("max", &symbolic::max, doc.max.doc)
       .def("ceil", &symbolic::ceil, doc.ceil.doc)
-      .def("floor", &symbolic::floor, doc.floor.doc);
+      .def("__ceil__", &symbolic::ceil, doc.ceil.doc)
+      .def("floor", &symbolic::floor, doc.floor.doc)
+      .def("__floor__", &symbolic::floor, doc.floor.doc);
   DefCopyAndDeepCopy(&expr_cls);
 
   // TODO(eric.cousineau): These should actually exist on the class, and should

--- a/bindings/pydrake/test/autodiffutils_test.py
+++ b/bindings/pydrake/test/autodiffutils_test.py
@@ -191,10 +191,14 @@ class TestAutoDiffXd(unittest.TestCase):
         C = np.dot(A, B)
         numpy_compare.assert_equal(C, [[AD(4, [4., 2])]])
 
-        # `matmul` not supported for `dtype=object` (#11332). `np.dot` should
-        # be used instead.
-        with self.assertRaises(TypeError):
+        # Before NumPy 1.17, `matmul` was not supported for `dtype=object`
+        # (#11332), and `np.dot` should be used instead.
+        if np.lib.NumpyVersion(np.__version__) < "1.17.0":
+            with self.assertRaises(TypeError):
+                C2 = np.matmul(A, B)
+        else:
             C2 = np.matmul(A, B)
+            numpy_compare.assert_equal(C2, C)
 
         # Type mixing
         Bf = np.array([[2., 2]]).T


### PR DESCRIPTION
Resolves #12151

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12153)
<!-- Reviewable:end -->
