### PR TITLE
examples: Switch iiwa deps to manipulation library

### DIFF
--- a/examples/manipulation_station/BUILD.bazel
+++ b/examples/manipulation_station/BUILD.bazel
@@ -62,8 +62,9 @@ drake_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//common:find_resource",
-        "//examples/kuka_iiwa_arm:iiwa_lcm",
         "//lcm",
+        "//manipulation/kuka_iiwa:iiwa_command_sender",
+        "//manipulation/kuka_iiwa:iiwa_status_receiver",
         "//manipulation/schunk_wsg:schunk_wsg_lcm",
         "//multibody/parsing",
         "//multibody/plant",
@@ -84,9 +85,10 @@ drake_cc_binary(
     test_rule_args = ["--target_realtime_rate=0.0 --duration=0.1"],
     deps = [
         ":manipulation_station",
-        "//examples/kuka_iiwa_arm:iiwa_lcm",
         "//geometry:geometry_visualization",
         "//lcm",
+        "//manipulation/kuka_iiwa:iiwa_command_receiver",
+        "//manipulation/kuka_iiwa:iiwa_status_sender",
         "//manipulation/schunk_wsg:schunk_wsg_lcm",
         "//systems/analysis:simulator",
         "//systems/lcm",

--- a/examples/manipulation_station/manipulation_station_hardware_interface.cc
+++ b/examples/manipulation_station/manipulation_station_hardware_interface.cc
@@ -5,12 +5,13 @@
 #include "robotlocomotion/image_array_t.hpp"
 
 #include "drake/common/find_resource.h"
-#include "drake/examples/kuka_iiwa_arm/iiwa_lcm.h"
 #include "drake/lcm/drake_lcm.h"
 #include "drake/lcmt_iiwa_command.hpp"
 #include "drake/lcmt_iiwa_status.hpp"
 #include "drake/lcmt_schunk_wsg_command.hpp"
 #include "drake/lcmt_schunk_wsg_status.hpp"
+#include "drake/manipulation/kuka_iiwa/iiwa_command_sender.h"
+#include "drake/manipulation/kuka_iiwa/iiwa_status_receiver.h"
 #include "drake/manipulation/schunk_wsg/schunk_wsg_lcm.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/systems/framework/diagram_builder.h"
@@ -44,7 +45,7 @@ ManipulationStationHardwareInterface::ManipulationStationHardwareInterface(
 
   // Publish IIWA command.
   auto iiwa_command_sender =
-      builder.AddSystem<examples::kuka_iiwa_arm::IiwaCommandSender>();
+      builder.AddSystem<manipulation::kuka_iiwa::IiwaCommandSender>();
   auto iiwa_command_publisher = builder.AddSystem(
       systems::lcm::LcmPublisherSystem::Make<drake::lcmt_iiwa_command>(
           "IIWA_COMMAND", lcm, 0.005
@@ -58,7 +59,7 @@ ManipulationStationHardwareInterface::ManipulationStationHardwareInterface(
 
   // Receive IIWA status and populate the output ports.
   auto iiwa_status_receiver =
-      builder.AddSystem<examples::kuka_iiwa_arm::IiwaStatusReceiver>();
+      builder.AddSystem<manipulation::kuka_iiwa::IiwaStatusReceiver>();
   iiwa_status_subscriber_ = builder.AddSystem(
       systems::lcm::LcmSubscriberSystem::Make<drake::lcmt_iiwa_status>(
           "IIWA_STATUS", lcm));

--- a/examples/manipulation_station/mock_station_simulation.cc
+++ b/examples/manipulation_station/mock_station_simulation.cc
@@ -5,13 +5,14 @@
 #include "drake/common/eigen_types.h"
 #include "drake/common/find_resource.h"
 #include "drake/common/is_approx_equal_abstol.h"
-#include "drake/examples/kuka_iiwa_arm/iiwa_lcm.h"
 #include "drake/examples/manipulation_station/manipulation_station.h"
 #include "drake/geometry/geometry_visualization.h"
 #include "drake/lcmt_iiwa_command.hpp"
 #include "drake/lcmt_iiwa_status.hpp"
 #include "drake/lcmt_schunk_wsg_command.hpp"
 #include "drake/lcmt_schunk_wsg_status.hpp"
+#include "drake/manipulation/kuka_iiwa/iiwa_command_receiver.h"
+#include "drake/manipulation/kuka_iiwa/iiwa_status_sender.h"
 #include "drake/manipulation/schunk_wsg/schunk_wsg_lcm.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/math/rotation_matrix.h"
@@ -81,7 +82,8 @@ int do_main(int argc, char* argv[]) {
   auto iiwa_command_subscriber = builder.AddSystem(
       systems::lcm::LcmSubscriberSystem::Make<drake::lcmt_iiwa_command>(
           "IIWA_COMMAND", lcm));
-  auto iiwa_command = builder.AddSystem<kuka_iiwa_arm::IiwaCommandReceiver>();
+  auto iiwa_command =
+      builder.AddSystem<manipulation::kuka_iiwa::IiwaCommandReceiver>();
   builder.Connect(iiwa_command_subscriber->get_output_port(),
                   iiwa_command->get_input_port());
 
@@ -91,7 +93,8 @@ int do_main(int argc, char* argv[]) {
   builder.Connect(iiwa_command->get_commanded_torque_output_port(),
                   station->GetInputPort("iiwa_feedforward_torque"));
 
-  auto iiwa_status = builder.AddSystem<kuka_iiwa_arm::IiwaStatusSender>();
+  auto iiwa_status =
+      builder.AddSystem<manipulation::kuka_iiwa::IiwaStatusSender>();
   builder.Connect(station->GetOutputPort("iiwa_position_commanded"),
                   iiwa_status->get_position_commanded_input_port());
   builder.Connect(station->GetOutputPort("iiwa_position_measured"),

--- a/manipulation/planner/BUILD.bazel
+++ b/manipulation/planner/BUILD.bazel
@@ -54,7 +54,7 @@ drake_cc_googletest(
     deps = [
         ":differential_inverse_kinematics",
         "//common/test_utilities:eigen_matrix_compare",
-        "//examples/kuka_iiwa_arm:iiwa_common",
+        "//manipulation/kuka_iiwa:iiwa_constants",
         "//multibody/parsing",
     ],
 )

--- a/manipulation/planner/test/differential_inverse_kinematics_test.cc
+++ b/manipulation/planner/test/differential_inverse_kinematics_test.cc
@@ -10,7 +10,7 @@
 #include "drake/common/eigen_types.h"
 #include "drake/common/find_resource.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
-#include "drake/examples/kuka_iiwa_arm/iiwa_common.h"
+#include "drake/manipulation/kuka_iiwa/iiwa_constants.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/solvers/constraint.h"
@@ -23,7 +23,7 @@ namespace {
 
 using Eigen::Vector3d;
 using Eigen::VectorXd;
-using examples::kuka_iiwa_arm::get_iiwa_max_joint_velocities;
+using manipulation::kuka_iiwa::get_iiwa_max_joint_velocities;
 using multibody::MultibodyPlant;
 using multibody::FixedOffsetFrame;
 using solvers::LinearConstraint;

--- a/tools/install/libdrake/build_components.bzl
+++ b/tools/install/libdrake/build_components.bzl
@@ -108,8 +108,6 @@ LIBDRAKE_COMPONENTS = [
     "//systems/rendering",
     "//systems/sensors",
     "//systems/trajectory_optimization",
-    # //examples/kuka_iiwa_arm:iiwa_common (indirectly)
-    # //examples/kuka_iiwa_arm:iiwa_lcm (indirectly)
     # //solvers/fbstab/components:dense_data (indirectly)
     # //solvers/fbstab/components:dense_feasibility (indirectly)
     # //solvers/fbstab/components:dense_linear_solver (indirectly)


### PR DESCRIPTION
As a result, some headers from `drake/examples/kuka_iiwa_arm` are no longer installed.  Use the `drake/manipulation/kuka_iiwa` headers instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12160)
<!-- Reviewable:end -->
