### PR TITLE
Activates continuous contact force outputs for MBP.

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -472,6 +472,7 @@ drake_cc_googletest(
     deps = [
         ":plant",
         "//multibody/benchmarks/inclined_plane",
+        "//systems/analysis:radau_integrator",
         "//systems/analysis:simulator",
     ],
 )

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1798,8 +1798,10 @@ void MultibodyPlant<T>::CalcSpatialContactForcesContinuous(
   // Compute the spatial forces on each body from contact.
   switch (contact_model_) {
     case ContactModel::kPointContactOnly:
-      if (num_collision_geometries() > 0)
-        CalcAndAddContactForcesByPenaltyMethod(context, &(*F_BBo_W_array));
+      // Note: consider caching the results from the following method (in which
+      // case we would also want to introduce the Eval... naming convention for
+      // the method).
+      CalcAndAddContactForcesByPenaltyMethod(context, &(*F_BBo_W_array));
       break;
 
     case ContactModel::kHydroelasticsOnly:

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -2918,13 +2918,9 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // Closes Doxygen section "Continuous state output"
 
   /// Returns a constant reference to the output port of generalized contact
-  /// forces for a specific model instance. This output port is only available
-  /// when modeling the plant as a discrete system with periodic updates, see
-  /// is_discrete().
+  /// forces for a specific model instance.
   ///
   /// @pre Finalize() was already called on `this` plant.
-  /// @throws std::exception if `this` plant is not modeled as a discrete system
-  /// with periodic updates.
   /// @throws std::exception if called before Finalize() or if the model
   /// instance does not have any generalized velocities.
   /// @throws std::exception if the model instance does not exist.
@@ -3297,6 +3293,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     systems::CacheIndex contact_jacobians;
     systems::CacheIndex contact_results;
     systems::CacheIndex generalized_accelerations;
+    systems::CacheIndex generalized_contact_forces_continuous;
     systems::CacheIndex hydro_contact_forces;
     systems::CacheIndex tamsi_solver_results;
     systems::CacheIndex point_pairs;
@@ -3543,6 +3540,18 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   void CopyContinuousStateOut(
       ModelInstanceIndex model_instance,
       const systems::Context<T>& context, systems::BasicVector<T>* state) const;
+
+  // Method to compute generalized contact forces for continuous plants.
+  void CalcGeneralizedContactForcesContinuous(
+    const drake::systems::Context<T>& context, VectorX<T>* tau_contact) const;
+
+  // Eval() version of the method CalcGeneralizedContactForcesContinuous().
+  const VectorX<T>& EvalGeneralizedContactForcesContinuous(
+      const systems::Context<T>& context) const {
+    return this
+        ->get_cache_entry(cache_indexes_.generalized_contact_forces_continuous)
+        .template Eval<VectorX<T>>(context);
+  }
 
   // Calc method to output per model instance vector of generalized contact
   // forces.

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3295,6 +3295,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     systems::CacheIndex generalized_accelerations;
     systems::CacheIndex generalized_contact_forces_continuous;
     systems::CacheIndex hydro_contact_forces;
+    systems::CacheIndex spatial_contact_forces_continuous;
     systems::CacheIndex tamsi_solver_results;
     systems::CacheIndex point_pairs;
   };
@@ -3541,6 +3542,19 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       ModelInstanceIndex model_instance,
       const systems::Context<T>& context, systems::BasicVector<T>* state) const;
 
+  // Method to compute spatial contact forces for continuous plants.
+  void CalcSpatialContactForcesContinuous(
+      const drake::systems::Context<T>& context,
+      std::vector<SpatialForce<T>>* F_BBo_W_array) const;
+
+  // Eval() version of the method CalcSpatialContactForcesContinuous().
+  const std::vector<SpatialForce<T>>& EvalSpatialContactForcesContinuous(
+      const systems::Context<T>& context) const {
+    return this->get_cache_entry(
+        cache_indexes_.spatial_contact_forces_continuous).
+            template Eval<std::vector<SpatialForce<T>>>(context);
+  }
+
   // Method to compute generalized contact forces for continuous plants.
   void CalcGeneralizedContactForcesContinuous(
     const drake::systems::Context<T>& context, VectorX<T>* tau_contact) const;
@@ -3548,9 +3562,9 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // Eval() version of the method CalcGeneralizedContactForcesContinuous().
   const VectorX<T>& EvalGeneralizedContactForcesContinuous(
       const systems::Context<T>& context) const {
-    return this
-        ->get_cache_entry(cache_indexes_.generalized_contact_forces_continuous)
-        .template Eval<VectorX<T>>(context);
+    return this->get_cache_entry(
+        cache_indexes_.generalized_contact_forces_continuous).
+            template Eval<VectorX<T>>(context);
   }
 
   // Calc method to output per model instance vector of generalized contact

--- a/multibody/plant/test/inclined_plane_test.cc
+++ b/multibody/plant/test/inclined_plane_test.cc
@@ -74,8 +74,6 @@ class InclinedPlaneTest : public ::testing::TestWithParam<bool> {
 TEST_P(InclinedPlaneTest, RollingSphereTest) {
   DiagramBuilder<double> builder;
 
-if (time_stepping_) return;
-
   // The target accuracy determines the size of the actual time steps taken
   // whenever a variable time step integrator is used.
   const double target_accuracy = 1.0e-6;
@@ -142,7 +140,7 @@ if (time_stepping_) return;
   simulator.reset_integrator<RadauIntegrator<double, 2>>(
       *diagram, &simulator.get_mutable_context());
   IntegratorBase<double>& integrator = simulator.get_mutable_integrator();
-  integrator.set_maximum_step_size(1e-3);
+  integrator.set_maximum_step_size(1e-3);    // Reasonable for this problem.
   integrator.set_target_accuracy(target_accuracy);
   simulator.set_publish_every_time_step(true);
   simulator.Initialize();


### PR DESCRIPTION
Activates the ability to query contact forces acting on a model in MBP.

(Useful for debugging hydroelastics)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12162)
<!-- Reviewable:end -->
