### PR TITLE
examples: Deprecate all valkyrie code

### DIFF
--- a/examples/valkyrie/BUILD.bazel
+++ b/examples/valkyrie/BUILD.bazel
@@ -15,6 +15,7 @@ drake_cc_library(
     name = "valkyrie_constants",
     srcs = ["valkyrie_constants.cc"],
     hdrs = ["valkyrie_constants.h"],
+    copts = ["-Wno-deprecated-declarations"],
     deps = [
         "//common:essential",
     ],
@@ -24,6 +25,7 @@ drake_cc_library(
     name = "robot_state_decoder",
     srcs = ["robot_state_decoder.cc"],
     hdrs = ["robot_state_decoder.h"],
+    copts = ["-Wno-deprecated-declarations"],
     deps = [
         "//attic/manipulation/util:robot_state_msg_translator",
         "//attic/multibody:rigid_body_tree",
@@ -37,6 +39,7 @@ drake_cc_library(
     name = "actuator_effort_to_rigid_body_plant_input_converter",
     srcs = ["actuator_effort_to_rigid_body_plant_input_converter.cc"],
     hdrs = ["actuator_effort_to_rigid_body_plant_input_converter.h"],
+    copts = ["-Wno-deprecated-declarations"],
     deps = [
         "//attic/multibody:rigid_body_tree",
         "//systems/framework",
@@ -47,6 +50,7 @@ drake_cc_library(
     name = "robot_command_to_desired_effort_converter",
     srcs = ["robot_command_to_desired_effort_converter.cc"],
     hdrs = ["robot_command_to_desired_effort_converter.h"],
+    copts = ["-Wno-deprecated-declarations"],
     deps = [
         "//attic/multibody:rigid_body_tree",
         "//systems/framework",
@@ -60,6 +64,7 @@ drake_cc_binary(
         "valkyrie_pd_ff_controller.cc",
         "valkyrie_pd_ff_controller.h",
     ],
+    copts = ["-Wno-deprecated-declarations"],
     data = [":models"],
     deps = [
         ":robot_state_decoder",
@@ -83,6 +88,7 @@ drake_cc_library(
     name = "robot_state_encoder",
     srcs = ["robot_state_encoder.cc"],
     hdrs = ["robot_state_encoder.h"],
+    copts = ["-Wno-deprecated-declarations"],
     deps = [
         "//attic/manipulation/util:robot_state_msg_translator",
         "//attic/multibody/rigid_body_plant",
@@ -120,6 +126,7 @@ drake_cc_library(
 drake_cc_binary(
     name = "valkyrie_simulation",
     srcs = ["valkyrie_simulation.cc"],
+    copts = ["-Wno-deprecated-declarations"],
     data = [":models"],
     deps = [":valkyrie_simulator"],
 )
@@ -128,6 +135,7 @@ drake_cc_binary(
 
 drake_cc_googletest(
     name = "robot_state_encoder_decoder_test",
+    copts = ["-Wno-deprecated-declarations"],
     data = [":models"],
     deps = [
         ":robot_state_decoder",
@@ -147,6 +155,7 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "robot_command_to_desired_effort_converter_test",
+    copts = ["-Wno-deprecated-declarations"],
     data = [":models"],
     deps = [
         ":robot_command_to_desired_effort_converter",
@@ -161,12 +170,14 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "valkyrie_simulation_test",
     srcs = ["test/valkyrie_simulation_test.cc"],
+    copts = ["-Wno-deprecated-declarations"],
     data = [":models"],
     deps = [":valkyrie_simulator"],
 )
 
 drake_cc_googletest(
     name = "valkyrie_ik_test",
+    copts = ["-Wno-deprecated-declarations"],
     data = [":models"],
     # Non-deterministic IPOPT-related failures on macOS, see #10276.
     flaky = 1,

--- a/examples/valkyrie/README.md
+++ b/examples/valkyrie/README.md
@@ -1,39 +1,10 @@
-# Valkyrie
+This directory contains models for Valkyrie.
 
-This experimental directory does not adhere to the development practices that
-apply elsewhere in Drake. In particular, for PRs that affect only this
-directory, one feature review is sufficient; platform review is not required.
+The code in this examples/valkyrie folder is deprecated and will be removed
+from Drake on 2020-02-01.
 
-If build or test targets in this directory break, and the PR author or oncall
-buildcop cannot trivially resolve them, a GitHub issue will be assigned to
-the Valkyrie team. If the issue is not resolved within 24 hours, the author
-or buildcop may disable the offending targets.
-
-To compile this example
-  $ cd drake
-  $ bazel build //tools:drake_visualizer //examples/valkyrie/...
-
-To run the visualizer:
-  $ cd drake
-  $ bazel-bin/tools/drake_visualizer &
-
-To run the pd + feedforward controller:
-  $ cd drake
-  $ bazel-bin/examples/valkyrie/valkyrie_pd_ff_controller &
-
-To run the simulation:
-  $ cd drake
-  $ bazel-bin/examples/valkyrie/valkyrie_simulation &
-
-The visualizer needs to be started before the simulator.
-The controller and simulator are not synchronized in any way, and they both
-try to run as fast as possible.
-For a bit more repeatability, start the controller first.
-
-The controlled simulation eventually fails when the robot falls down, because
-the simple controller does not account for sliding feet.
-
-# Historical note
+Historical note
+---------------
 
 Prior to 2016, Drake was built around a substantial base of MATLAB software.
 Most of that was removed from the head of git master during 2017.
@@ -42,3 +13,8 @@ To view or use the original MATLAB implementation of Valkyrie you may use this
 tag:
 
 https://github.com/RobotLocomotion/drake/tree/last_sha_with_original_matlab/drake/examples/Valkyrie
+
+To view or use the final C++ implementation of Valkyrie based on RigidBodyTree
+(removed as of 2019), you may use this commit:
+
+https://github.com/RobotLocomotion/drake/tree/v0.11.0/examples/valkyrie

--- a/examples/valkyrie/actuator_effort_to_rigid_body_plant_input_converter.h
+++ b/examples/valkyrie/actuator_effort_to_rigid_body_plant_input_converter.h
@@ -3,6 +3,7 @@
 #include <map>
 #include <vector>
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/multibody/rigid_body_actuator.h"
 #include "drake/systems/framework/leaf_system.h"
 
@@ -10,7 +11,8 @@ namespace drake {
 namespace systems {
 
 template <typename T>
-class ActuatorEffortToRigidBodyPlantInputConverter : public LeafSystem<T> {
+class DRAKE_DEPRECATED("2020-02-01", "The valkyrie example is being removed.")
+ActuatorEffortToRigidBodyPlantInputConverter : public LeafSystem<T> {
  public:
   ActuatorEffortToRigidBodyPlantInputConverter(
       const std::vector<const RigidBodyActuator*>& ordered_actuators);

--- a/examples/valkyrie/robot_command_to_desired_effort_converter.h
+++ b/examples/valkyrie/robot_command_to_desired_effort_converter.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/multibody/rigid_body_actuator.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/leaf_system.h"
@@ -25,7 +26,8 @@ namespace systems {
  * Note that a RobotCommandToDesiredEffortConverter simply ignores commands for
  * actuators that it doesn't know about.
  */
-class RobotCommandToDesiredEffortConverter
+class DRAKE_DEPRECATED("2020-02-01", "The valkyrie example is being removed.")
+RobotCommandToDesiredEffortConverter
     : public LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RobotCommandToDesiredEffortConverter)

--- a/examples/valkyrie/robot_state_decoder.h
+++ b/examples/valkyrie/robot_state_decoder.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <string>
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/manipulation/util/robot_state_msg_translator.h"
 #include "drake/multibody/rigid_body_tree.h"
 #include "drake/systems/framework/leaf_system.h"
@@ -21,7 +22,8 @@ namespace systems {
  * Note that a RobotStateDecoder simply ignores state information for joints
  * that it doesn't know about.
  */
-class RobotStateDecoder : public LeafSystem<double> {
+class DRAKE_DEPRECATED("2020-02-01", "The valkyrie example is being removed.")
+RobotStateDecoder : public LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RobotStateDecoder)
 

--- a/examples/valkyrie/robot_state_encoder.h
+++ b/examples/valkyrie/robot_state_encoder.h
@@ -8,6 +8,7 @@
 
 #include "bot_core/robot_state_t.hpp"
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/manipulation/util/robot_state_msg_translator.h"
 #include "drake/multibody/rigid_body_frame.h"
 #include "drake/multibody/rigid_body_plant/contact_results.h"
@@ -26,7 +27,8 @@ namespace systems {
 
 /// Assembles information from various input ports into a robot_state_t LCM
 /// message, presented on an output port.
-class RobotStateEncoder final : public LeafSystem<double> {
+class DRAKE_DEPRECATED("2020-02-01", "The valkyrie example is being removed.")
+RobotStateEncoder final : public LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RobotStateEncoder)
 

--- a/examples/valkyrie/valkyrie_constants.h
+++ b/examples/valkyrie/valkyrie_constants.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 
 namespace drake {
@@ -9,12 +10,15 @@ namespace valkyrie {
 // All the following assumes using:
 // urdf/urdf/valkyrie_A_sim_drake_one_neck_dof_wide_ankle_rom.urdf
 // TODO(siyuan.feng): Add functinos to auto generate these.
+DRAKE_DEPRECATED("2020-02-01", "The valkyrie example is being removed.")
 constexpr int kRPYValkyrieDof = 36;
 
+DRAKE_DEPRECATED("2020-02-01", "The valkyrie example is being removed.")
 VectorX<double> RPYValkyrieFixedPointState();
 
 // The nominal torque is generated with the QP controller at the setpoint,
 // with acceleration constrained to zero.
+DRAKE_DEPRECATED("2020-02-01", "The valkyrie example is being removed.")
 VectorX<double> RPYValkyrieFixedPointTorque();
 
 }  // namespace valkyrie

--- a/examples/valkyrie/valkyrie_pd_ff_controller.h
+++ b/examples/valkyrie/valkyrie_pd_ff_controller.h
@@ -5,6 +5,7 @@
 
 #include "bot_core/atlas_command_t.hpp"
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/rigid_body_tree.h"
 #include "drake/systems/framework/leaf_system.h"
@@ -12,7 +13,8 @@
 namespace drake {
 namespace systems {
 
-class ValkyriePDAndFeedForwardController : public systems::LeafSystem<double> {
+class DRAKE_DEPRECATED("2020-02-01", "The valkyrie example is being removed.")
+ValkyriePDAndFeedForwardController : public systems::LeafSystem<double> {
  public:
   ValkyriePDAndFeedForwardController(const RigidBodyTree<double>& robot,
                          const VectorX<double>& nominal_position,

--- a/examples/valkyrie/valkyrie_simulator.h
+++ b/examples/valkyrie/valkyrie_simulator.h
@@ -8,6 +8,7 @@
 #include "bot_core/atlas_command_t.hpp"
 #include "bot_core/robot_state_t.hpp"
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/find_resource.h"
 #include "drake/common/text_logging.h"
 #include "drake/examples/valkyrie/actuator_effort_to_rigid_body_plant_input_converter.h"
@@ -34,7 +35,8 @@ namespace drake {
 namespace examples {
 namespace valkyrie {
 
-class ValkyrieSimulationDiagram : public systems::Diagram<double> {
+class DRAKE_DEPRECATED("2020-02-01", "The valkyrie example is being removed.")
+ValkyrieSimulationDiagram : public systems::Diagram<double> {
  public:
   ValkyrieSimulationDiagram(lcm::DrakeLcm* lcm_arg, double dt) {
     systems::DiagramBuilder<double> builder;


### PR DESCRIPTION
This is a proposal to build consensus.  (See the `README.md` edits.)

Relates #12158, #6368, #6367.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12170)
<!-- Reviewable:end -->
