### PR TITLE
workspace: Deprecate @spruce

### DIFF
--- a/tools/workspace/BUILD.bazel
+++ b/tools/workspace/BUILD.bazel
@@ -65,7 +65,6 @@ _DRAKE_EXTERNAL_PACKAGE_INSTALLS = ["@%s//:install" % p for p in [
     "pybind11",
     "sdformat",
     "spdlog",
-    "spruce",
     "stx",
     "tinydir",
     "tinyobjloader",

--- a/tools/workspace/spruce/package.BUILD.bazel
+++ b/tools/workspace/spruce/package.BUILD.bazel
@@ -1,23 +1,18 @@
 # -*- python -*-
 
-load("@drake//tools/install:install.bzl", "install")
-
 licenses(["notice"])  # BSD-3-Clause
 
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "spruce",
+    deprecation = " ".join([
+        "The repository @spruce provided by Drake is deprecated and will be",
+        "removed on 2020-02-01.",
+    ]),
     srcs = ["spruce.cc"],
     hdrs = ["spruce.hh"],
     copts = ["-fvisibility=hidden"],
     includes = ["."],
     linkstatic = 1,
-)
-
-# We do not install the header file (its a private dependency), but we still
-# need to install its license file.
-install(
-    name = "install",
-    docs = ["LICENSE"],
 )


### PR DESCRIPTION
Do not install its `LICENSE` file either -- we no longer use spruce.

Relates #12104.

- [x] Do not merge until #12180 merges first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12182)
<!-- Reviewable:end -->
