### PR TITLE
[geometry] Add resolution_hint parameter for MakeCylinderVolumeMesh.

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -385,6 +385,10 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "make_cylinder_mesh_test",
+    # This test includes generating the finest mesh allowed for a particular
+    # cylinder. The test size is increased to "medium" so that debug builds
+    # are successful in CI.
+    size = "medium",
     deps = [
         ":make_cylinder_mesh",
         ":sorted_triplet",

--- a/geometry/proximity/make_cylinder_mesh.h
+++ b/geometry/proximity/make_cylinder_mesh.h
@@ -16,7 +16,7 @@ namespace drake {
 namespace geometry {
 namespace internal {
 
-// Helper methods for MakeCylinderMesh().
+// Helper methods for MakeCylinderVolumeMesh().
 #ifndef DRAKE_DOXYGEN_CXX
 
 // TODO(DamrongGuoy): Consider removing the classification of vertex types.
@@ -393,10 +393,26 @@ MakeCylinderMeshLevel0(const double& height, const double& radius) {
 }
 
 #endif
+
 /// Generates a tetrahedral volume mesh of a cylinder whose bounding box is
-/// [-radius, radius]x[-radius,radius]x[-height/2, height/2], i.e., the center
+/// [-radius, radius]x[-radius,radius]x[-length/2, length/2], i.e., the center
 /// line of the cylinder is the z-axis, and the center of the cylinder is at
 /// the origin.
+///
+/// The level of tessellation is guided by the `resolution_hint` parameter.
+/// Smaller values create higher-resolution meshes with smaller tetrahedra.
+/// The resolution hint is interpreted as an edge length, and the cylinder is
+/// subdivided to guarantee that edge lengths along the boundary circle of
+/// the top and bottom caps will be less than or equal to that edge length.
+///
+/// The resolution of the final mesh will change discontinuously. Small
+/// changes to `resolution_hint` will likely produce the same mesh.
+/// However, cutting `resolution_hint` in half will likely increase the
+/// number of tetrahedra.
+///
+/// Ultimately, successively smaller values of `resolution_hint` will no
+/// longer change the output mesh. This algorithm will not produce more than
+/// 100 million tetrahedra.
 ///
 /// This method implements a variant of the generator described in
 /// [Everett, 1997]. The algorithm has diverged a bit from the one in the paper,
@@ -420,35 +436,85 @@ MakeCylinderMeshLevel0(const double& height, const double& radius) {
 /// @param[in] cylinder
 ///    Specification of the parameterized cylinder the output mesh should
 ///    approximate.
-/// @param[in] refinement_level
-///    The number of subdivision steps to take. If the original mesh contains
-///    N tetrahedra, the resulting mesh with refinement_level = L will contain
-///    N·8ᴸ tetrahedra.
+/// @param[in] resolution_hint
+///    The positive characteristic edge length for the mesh. The coarsest
+///    possible mesh (a rectangular prism) is guaranteed for any value of
+///    `resolution_hint` greater than √2 times the radius of the cylinder.
 ///
 /// @throws std::exception if refinement_level is negative.
 ///
 /// [Everett, 1997]  Everett, M.E., 1997. A three-dimensional spherical mesh
 /// generator. Geophysical Journal International, 130(1), pp.193-200.
 template <typename T>
-VolumeMesh<T> MakeCylinderMesh(const Cylinder& cylinder, int refinement_level) {
-  const double height = cylinder.get_length();
-  const double radius = cylinder.get_radius();
-
-  DRAKE_THROW_UNLESS(refinement_level >= 0);
-
+VolumeMesh<T> MakeCylinderVolumeMesh(const Cylinder& cylinder,
+                                     double resolution_hint) {
+  const double h = cylinder.get_length();
+  const double r = cylinder.get_radius();
   std::pair<VolumeMesh<T>, std::vector<CylinderVertexType>> pair =
-      MakeCylinderMeshLevel0<T>(height, radius);
+      MakeCylinderMeshLevel0<T>(h, r);
   VolumeMesh<T>& mesh = pair.first;
   std::vector<CylinderVertexType>& vertex_type = pair.second;
 
+  /*
+    The volume mesh is formed by successively refining a rectangular prism. At
+    the boundary circle of the top and bottom caps, we go from 4 edges, to
+    8 edges, to 16 edges, etc., doubling at each level of refinement. These
+    edges are simply chords across fixed-length arcs of the circle. Based on
+    that we can easily compute the length of the chord and bound it by
+    resolution_hint.
+
+              /|
+           r / |
+            /  |
+           <θ  | e
+            \  |
+           r \ |
+              \|
+
+     The length of e = 2⋅r⋅sin(θ/2). Solving for θ we get: θ = 2⋅sin⁻¹(e/2⋅r).
+     We can relate θ with the refinement level ℒ.
+
+       θ = 2π / 4⋅2ᴸ
+         = π / 2⋅2ᴸ
+         = π / 2ᴸ⁺¹
+
+     Substituting for θ, we get:
+
+       π / 2ᴸ⁺¹ = 2⋅sin⁻¹(e/2⋅r)
+       2ᴸ⁺¹ = π / 2⋅sin⁻¹(e/2⋅r)
+       ℒ + 1 = log₂(π / 2⋅sin⁻¹(e/2⋅r))
+       ℒ = log₂(π / 2⋅sin⁻¹(e/2⋅r)) - 1
+       ℒ = ⌈log₂(π / sin⁻¹(e/2⋅r))⌉ - 2
+   */
+  DRAKE_DEMAND(resolution_hint > 0.0);
+  // Make sure the arcsin doesn't blow up.
+  const double e = std::min(resolution_hint, 2.0 * r);
+  const int L = std::max(
+      0, static_cast<int>(
+             std::ceil(std::log2(M_PI / std::asin(e / (2.0 * r)))) - 2));
+
+  // Limit refinement_level to 100 million tetrahedra. Each refinement level
+  // increases the number of tetrahedra by a factor of 8. Let N₀ be the
+  // number of initial tetrahedra. The number of tetrahedra N with refinement
+  // level ℒ would be:
+  //   N = N₀ * 8ᴸ
+  //   ℒ = log₈(N/N₀)
+  // We can limit N to 100 million by:
+  //   ℒ ≤ log₈(1e8/N₀) = log₂(1e8/N₀)/3
+  const int refinement_level = std::min(
+      L,
+      static_cast<int>(std::floor(std::log2(1.e8 / mesh.num_elements()) / 3.)));
+
+  // If the original mesh contains N tetrahedra, the resulting mesh with
+  // refinement_level = L will contain N·8ᴸ tetrahedra.
   for (int level = 1; level <= refinement_level; ++level) {
-    auto split_pair = RefineCylinderMesh<T>(mesh, vertex_type, radius);
+    auto split_pair = RefineCylinderMesh<T>(mesh, vertex_type, r);
     mesh = split_pair.first;
     vertex_type = split_pair.second;
     DRAKE_DEMAND(mesh.vertices().size() == vertex_type.size());
   }
 
-  return std::move(mesh);
+  return mesh;
 }
 
 }  // namespace internal

--- a/geometry/proximity/test/make_cylinder_mesh_test.cc
+++ b/geometry/proximity/test/make_cylinder_mesh_test.cc
@@ -78,7 +78,7 @@ GTEST_TEST(MakeCylinderVolumeMesh, FinestMesh) {
   // 50,331,648 tetrahedra instead.
   const double resolution_hint_limit = 1.2271e-2;
   auto mesh_limit = MakeCylinderVolumeMesh<double>(Cylinder(radius, length),
-                                                  resolution_hint_limit);
+                                                   resolution_hint_limit);
   EXPECT_EQ(50331648, mesh_limit.num_elements());
 
   // Confirm that going ten times finer resolution hint does not increase the


### PR DESCRIPTION
Rename `MakeCylinderMesh()` to `MakeCylinderVolumeMesh()`.
Replace parameter `refinement_level` with `resolution_hint`.

CC: @SeanCurtis-TRI , @joemasterjohn , @amcastro-tri, @edrumwri , @sherm1 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12184)
<!-- Reviewable:end -->
