### PR TITLE
Install and use find-module for TinyXML2

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -62,6 +62,7 @@ install(
         "//lcmtypes:install",
         "//manipulation/models:install_data",
         "//setup:install",
+        "//tools/install/cmake:install",
         "//tools/install/libdrake:install",
         "//tools/workspace:install_external_packages",
     ],

--- a/tools/install/cmake/BUILD.bazel
+++ b/tools/install/cmake/BUILD.bazel
@@ -1,0 +1,14 @@
+# -*- python -*-
+
+load("@drake//tools/install:install.bzl", "install_files")
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+package(default_visibility = ["//visibility:public"])
+
+install_files(
+    name = "install",
+    dest = "lib/cmake/drake/modules",
+    files = ["FindTinyXML2.cmake"],
+)
+
+add_lint_tests()

--- a/tools/install/cmake/FindTinyXML2.cmake
+++ b/tools/install/cmake/FindTinyXML2.cmake
@@ -1,0 +1,67 @@
+# -*- mode: cmake -*-
+# vi: set ft=cmake :
+
+find_package(PkgConfig QUIET)
+
+pkg_check_modules(_PC_TinyXML2 QUIET tinyxml2)
+
+find_path(TinyXML2_INCLUDE_DIR
+  NAMES tinyxml2.h
+  PATHS ${_PC_TinyXML2_INCLUDE_DIRS}
+  PATH_SUFFIXES TinyXML2
+)
+
+find_library(TinyXML2_LIBRARY
+  NAMES tinyxml2
+  PATHS ${_PC_TinyXML2_LIBRARY_DIRS}
+)
+
+if(_PC_TinyXML2_VERSION)
+  set(TinyXML2_VERSION "${_PC_TinyXML2_VERSION}")
+elseif(TinyXML2_INCLUDE_DIR)
+  file(STRINGS "${TinyXML2_INCLUDE_DIR}/tinyxml2.h" _TinyXML2_VERSION_STRINGS
+    REGEX "^#define TINYXML2_(MAJOR|MINOR|PATCH)_VERSION[ ]+[0-9]+$"
+  )
+
+  string(REGEX REPLACE ".*;#define TINYXML2_MAJOR_VERSION[ ]+([0-9]+);.*"
+    "\\1" TinyXML2_VERSION_MAJOR ";${_TinyXML2_VERSION_STRINGS};"
+  )
+
+  string(REGEX REPLACE ".*;#define TINYXML2_MINOR_VERSION[ ]+([0-9]+);.*"
+    "\\1" TinyXML2_VERSION_MINOR ";${_TinyXML2_VERSION_STRINGS};"
+  )
+
+  string(REGEX REPLACE ".*;#define TINYXML2_PATCH_VERSION[ ]+([0-9]+);.*"
+    "\\1" TinyXML2_VERSION_PATCH ";${_TinyXML2_VERSION_STRINGS};"
+  )
+
+  set(TinyXML2_VERSION
+    "${TinyXML2_MAJOR}.${TinyXML2_VERSION_MINOR}.${TinyXML2_VERSION_PATCH}"
+  )
+
+  unset(_TinyXML2_VERSION_STRINGS)
+else()
+  set(TinyXML2_VERSION)
+endif()
+
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args(TinyXML2
+  REQUIRED_VARS TinyXML2_INCLUDE_DIR TinyXML2_LIBRARY
+  VERSION_VAR TinyXML2_VERSION
+)
+
+if(TinyXML2_FOUND)
+  set(TinyXML2_INCLUDE_DIRS "${TinyXML2_INCLUDE_DIR}")
+  set(TinyXML2_LIBRARIES "${TinyXML2_LIBRARY}")
+
+  mark_as_advanced(TinyXML2_INCLUDE_DIR TinyXML2_LIBRARY)
+
+  if(NOT TARGET tinyxml2::tinyxml2)
+    add_library(tinyxml2::tinyxml2 UNKNOWN IMPORTED)
+    set_target_properties(tinyxml2::tinyxml2 PROPERTIES
+      IMPORTED_LOCATION "${TinyXML2_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES "${TinyXML2_INCLUDE_DIR}"
+    )
+  endif()
+endif()

--- a/tools/install/libdrake/drake.cps
+++ b/tools/install/libdrake/drake.cps
@@ -17,16 +17,17 @@
       "X-CMake-Find-Args": ["CONFIG"]
     },
     "fmt": {
+      "Version": "6.0",
       "Hints": ["@prefix@/lib/cmake/fmt"],
       "X-CMake-Find-Args": ["CONFIG"]
     },
-    "ignition-math4": {
-      "Version": "4.0.0",
-      "Hints": ["@prefix@/lib/cmake/ignition-math4"],
+    "ignition-math6": {
+      "Version": "6.4",
+      "Hints": ["@prefix@/lib/cmake/ignition-math6"],
       "X-CMake-Find-Args": ["CONFIG"]
     },
     "lcm": {
-      "Version": "1.3.95",
+      "Version": "1.4",
       "Hints": ["@prefix@/lib/cmake/lcm"],
       "X-CMake-Find-Args": ["CONFIG"]
     },
@@ -35,7 +36,7 @@
       "X-CMake-Find-Args": ["CONFIG"]
     },
     "Protobuf": {
-      "Version": "2.6.1",
+      "Version": "2.6",
       "X-CMake-Find-Args": ["MODULE"]
     },
     "robotlocomotion-lcmtypes": {
@@ -43,7 +44,7 @@
       "X-CMake-Find-Args": ["CONFIG"]
     },
     "spdlog": {
-      "Version": "0.16.3",
+      "Version": "1.3",
       "Hints": ["@prefix@/lib/cmake/spdlog"],
       "X-CMake-Find-Args": ["CONFIG"]
     },
@@ -69,7 +70,7 @@
         "bot2-core-lcmtypes:lcmtypes_bot2-core-cpp",
         "Eigen3:Eigen",
         "fmt:fmt-header-only",
-        "ignition-math4:ignition-math4",
+        "ignition-math6:ignition-math6",
         "lcm:lcm",
         "optitrack:optitrack-lcmtypes-cpp",
         "protobuf:libprotobuf",

--- a/tools/install/libdrake/drake.cps
+++ b/tools/install/libdrake/drake.cps
@@ -50,6 +50,10 @@
     "stx": {
       "Hints": ["@prefix@/lib/cmake/stx"],
       "X-CMake-Find-Args": ["CONFIG"]
+    },
+    "TinyXML2": {
+      "Version": "2.2",
+      "X-CMake-Find-Args": ["MODULE"]
     }
   },
   "Default-Components": [":drake"],
@@ -59,7 +63,6 @@
       "Location": "@prefix@/lib/libdrake.so",
       "Includes": ["@prefix@/include"],
       "Compile-Features": ["c++14"],
-      "Link-Flags": ["-ltinyxml2"],
       "Requires": [
         ":drake-lcmtypes-cpp",
         ":drake-marker",
@@ -73,6 +76,7 @@
         "robotlocomotion-lcmtypes:robotlocomotion-lcmtypes-cpp",
         "spdlog:spdlog",
         "stx:stx",
+        "tinyxml2:tinyxml2",
         "yaml-cpp"
       ]
     },
@@ -99,6 +103,6 @@
   },
   "X-CMake-Variables-Init": {
     "_Boost_IMPORTED_TARGETS": 1,
-    "CMAKE_MODULE_PATH": "${CMAKE_CURRENT_LIST_DIR}/modules/3.10;${CMAKE_MODULE_PATH}"
+    "CMAKE_MODULE_PATH": "${CMAKE_CURRENT_LIST_DIR}/modules;${CMAKE_CURRENT_LIST_DIR}/modules/3.10;${CMAKE_MODULE_PATH}"
   }
 }

--- a/tools/workspace/ignition_math/package-create-cps.py
+++ b/tools/workspace/ignition_math/package-create-cps.py
@@ -6,16 +6,16 @@ defs = read_version_defs(def_re)
 content = """
 {
   "Cps-Version": "0.8.0",
-  "Name": "ignition-math4",
+  "Name": "ignition-math%(VERSION_MAJOR)s",
   "Description": "Math classes and functions for robot applications",
   "License": "Apache-2.0",
   "Version": "%(VERSION_MAJOR)s.%(VERSION_MINOR)s.%(VERSION_PATCH)s",
-  "Default-Components": [":ignition-math4"],
+  "Default-Components": [":ignition-math%(VERSION_MAJOR)s"],
   "Components": {
-    "ignition-math4": {
+    "ignition-math%(VERSION_MAJOR)s": {
       "Type": "dylib",
-      "Location": "@prefix@/lib/libdrake_ignition_math4.so",
-      "Includes": ["@prefix@/include/ignition-math4"]
+      "Location": "@prefix@/lib/libdrake_ignition_math.so",
+      "Includes": ["@prefix@/include/ignition-math%(VERSION_MAJOR)s"]
     }
   },
   "X-CMake-Variables": {

--- a/tools/workspace/ignition_math/package.BUILD.bazel
+++ b/tools/workspace/ignition_math/package.BUILD.bazel
@@ -165,7 +165,7 @@ public_headers = public_headers_no_gen + [
 # upstream's explicitly listed sources plus private headers.  The explicitly
 # listed hdrs= matches upstream's public headers.
 cc_binary(
-    name = "libdrake_ignition_math4.so",
+    name = "libdrake_ignition_math.so",
     srcs = [
         "src/Angle.cc",
         "src/AxisAlignedBox.cc",
@@ -190,7 +190,7 @@ cc_binary(
     copts = ["-fvisibility-inlines-hidden"],
     includes = ["include"],
     linkopts = select({
-        ":linux": ["-Wl,-soname,libdrake_ignition_math4.so"],
+        ":linux": ["-Wl,-soname,libdrake_ignition_math.so"],
         "//conditions:default": [],
     }),
     linkshared = 1,
@@ -199,13 +199,13 @@ cc_binary(
 
 cc_library(
     name = "ignition_math",
-    srcs = ["libdrake_ignition_math4.so"],
+    srcs = ["libdrake_ignition_math.so"],
     hdrs = public_headers,
     includes = ["include"],
     visibility = ["//visibility:public"],
 )
 
-CMAKE_PACKAGE = "ignition-math4"
+CMAKE_PACKAGE = "ignition-math%d" % (PROJECT_MAJOR)
 
 cmake_config(
     package = CMAKE_PACKAGE,
@@ -219,7 +219,7 @@ install_cmake_config(package = CMAKE_PACKAGE)
 install(
     name = "install",
     workspace = CMAKE_PACKAGE,
-    targets = [":libdrake_ignition_math4.so"],
+    targets = [":libdrake_ignition_math.so"],
     hdrs = public_headers,
     hdr_dest = "include/" + CMAKE_PACKAGE,
     hdr_strip_prefix = ["include"],


### PR DESCRIPTION
Using simply `-ltinyxml2` has not been working for me on Catalina for some reason, so here is the proper solution given that Bionic and Xenial do not provide CMake configuration files.

Clearly we need a better solution for keeping the versions of dependencies in `drake.cps` in sync, but this at least fixes things for the moment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12195)
<!-- Reviewable:end -->
