### PR TITLE
Extracting penetration as point pair into its own callback

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -26,6 +26,7 @@ drake_cc_package_library(
         ":mesh_half_space_intersection",
         ":mesh_intersection",
         ":obj_to_surface_mesh",
+        ":penetration_as_point_pair_callback",
         ":proximity_utilities",
         ":sorted_triplet",
         ":surface_mesh",
@@ -141,6 +142,18 @@ drake_cc_library(
         ":mesh_intersection",
         ":surface_mesh",
         "//common",
+    ],
+)
+
+drake_cc_library(
+    name = "penetration_as_point_pair_callback",
+    srcs = ["penetration_as_point_pair_callback.cc"],
+    hdrs = ["penetration_as_point_pair_callback.h"],
+    deps = [
+        ":collision_filter_legacy",
+        ":proximity_utilities",
+        "//geometry/query_results:penetration_as_point_pair",
+        "@fcl",
     ],
 )
 
@@ -409,6 +422,14 @@ drake_cc_googletest(
         ":obj_to_surface_mesh",
         "//common:find_resource",
         "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
+    name = "penetration_as_point_pair_callback_test",
+    deps = [
+        ":penetration_as_point_pair_callback",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/geometry/proximity/penetration_as_point_pair_callback.cc
+++ b/geometry/proximity/penetration_as_point_pair_callback.cc
@@ -1,0 +1,110 @@
+#include "drake/geometry/proximity/penetration_as_point_pair_callback.h"
+
+#include <limits>
+#include <utility>
+
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace penetration_as_point_pair {
+
+using Eigen::Vector3d;
+using fcl::CollisionObjectd;
+using fcl::CollisionRequestd;
+using fcl::CollisionResultd;
+using fcl::collide;
+using fcl::Contactd;
+
+bool Callback(CollisionObjectd* fcl_object_A_ptr,
+              CollisionObjectd* fcl_object_B_ptr,
+              void* callback_data) {
+  // NOTE: Although this function *takes* non-const pointers to satisfy the
+  // fcl api, it should not exploit the non-constness to modify the collision
+  // objects. We insure this by immediately assigning to a const version and
+  // not directly using the provided parameters.
+  const CollisionObjectd& fcl_object_A = *fcl_object_A_ptr;
+  const CollisionObjectd& fcl_object_B = *fcl_object_B_ptr;
+
+  auto& data = *static_cast<CallbackData*>(callback_data);
+
+  // Extract the collision filter keys from the fcl collision objects. These
+  // keys will also be used to map the fcl collision object back to the Drake
+  // GeometryId for colliding geometries.
+  EncodedData encoding_A(fcl_object_A);
+  EncodedData encoding_B(fcl_object_B);
+
+  const bool can_collide = data.collision_filter.CanCollideWith(
+      encoding_A.encoding(), encoding_B.encoding());
+
+  // NOTE: Here and below, false is returned regardless of whether collision
+  // is detected or not because true tells the broadphase manager to terminate.
+  // Since we want *all* collisions, we return false.
+  if (!can_collide) return false;
+
+  // Unpack the callback data
+  const CollisionRequestd& request = data.request;
+
+  // This callback only works for a single contact, this confirms a request
+  // hasn't been made for more contacts.
+  DRAKE_ASSERT(request.num_max_contacts == 1);
+  CollisionResultd result;
+
+  // Perform nearphase collision detection
+  collide(&fcl_object_A, &fcl_object_B, request, result);
+
+  if (!result.isCollision()) return false;
+
+  // Process the contact points
+  // NOTE: This assumes that the request is configured to use a single
+  // contact.
+  const Contactd& contact = result.getContact(0);
+
+  // Signed distance is negative when penetration depth is positive.
+  const double depth = contact.penetration_depth;
+
+  // TODO(SeanCurtis-TRI): Remove this test when FCL issue 375 is fixed.
+  // FCL returns osculation as contact but doesn't guarantee a non-zero
+  // normal. Drake isn't really in a position to define that normal from the
+  // geometry or contact results so, if the geometry is sufficiently close
+  // to osculation, we consider the geometries to be non-penetrating.
+  if (depth <= std::numeric_limits<double>::epsilon()) return false;
+
+  // By convention, Drake requires the contact normal to point out of B
+  // and into A. FCL uses the opposite convention.
+  Vector3d drake_normal = -contact.normal;
+
+  // FCL returns a single contact point centered between the two
+  // penetrating surfaces. PenetrationAsPointPair expects
+  // two, one on the surface of body A (Ac) and one on the surface of body
+  // B (Bc). Choose points along the line defined by the contact point and
+  // normal, equidistant to the contact point. Recall that signed_distance
+  // is strictly non-positive, so signed_distance * drake_normal points
+  // out of A and into B.
+  Vector3d p_WAc = contact.pos - 0.5 * depth * drake_normal;
+  Vector3d p_WBc = contact.pos + 0.5 * depth * drake_normal;
+
+  PenetrationAsPointPair<double> penetration;
+  penetration.depth = depth;
+  penetration.id_A = encoding_A.id();
+  penetration.id_B = encoding_B.id();
+  penetration.p_WCa = p_WAc;
+  penetration.p_WCb = p_WBc;
+  penetration.nhat_BA_W = drake_normal;
+  // Guarantee fixed ordering of pair (A, B). Swap the ids and points on
+  // surfaces and then flip the normal.
+  if (penetration.id_B < penetration.id_A) {
+    std::swap(penetration.id_A, penetration.id_B);
+    std::swap(penetration.p_WCa, penetration.p_WCb);
+    penetration.nhat_BA_W = -penetration.nhat_BA_W;
+  }
+  data.point_pairs.push_back(std::move(penetration));
+
+  return false;
+}
+
+}  // namespace penetration_as_point_pair
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/penetration_as_point_pair_callback.h
+++ b/geometry/proximity/penetration_as_point_pair_callback.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <vector>
+
+#include <fcl/fcl.h>
+
+#include "drake/geometry/proximity/collision_filter_legacy.h"
+#include "drake/geometry/proximity/proximity_utilities.h"
+#include "drake/geometry/query_results/penetration_as_point_pair.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace penetration_as_point_pair {
+
+// TODO(SeanCurtis-TRI): Template this and include X_WGs when this query
+//  supports AutoDiff scalars.
+/** Supporting data for the detecting collision between geometries and reporting
+ them as a pair of points (see PenetrationAsPointPair). It includes:
+
+    - A collision filter instance.
+    - An fcl collision request.
+    - A vector of point pairs -- one instance of PenetrationAsPointPair for
+      every supported, unfiltered penetrating pair.  */
+struct CallbackData {
+  CallbackData(
+      const CollisionFilterLegacy* collision_filter_in,
+      std::vector<PenetrationAsPointPair<double>>* point_pairs_in)
+  : collision_filter(*collision_filter_in),
+    point_pairs(*point_pairs_in) {
+    DRAKE_DEMAND(collision_filter_in);
+    DRAKE_DEMAND(point_pairs_in);
+    request.num_max_contacts = 1;
+    request.enable_contact = true;
+    // NOTE: As of 5/1/2018 the GJK implementation of Libccd appears to be
+    // superior to FCL's "independent" implementation. Furthermore, libccd
+    // appears to behave badly if its gjk tolerance is much tighter than
+    // 2e-12. Until this changes, we explicitly specify these parameters rather
+    // than relying on FCL's defaults.
+    request.gjk_tolerance = 2e-12;
+    request.gjk_solver_type = fcl::GJKSolverType::GST_LIBCCD;
+  }
+
+  /** The collision filter system.  */
+  const CollisionFilterLegacy& collision_filter;
+
+  /** The parameters for the fcl object-object collision function.  */
+  fcl::CollisionRequestd request;
+
+  /** The results of the collision query.  */
+  std::vector<PenetrationAsPointPair<double>>& point_pairs;
+};
+
+// Callback function for FCL's collide() function for retrieving a *single*
+// contact.
+bool Callback(fcl::CollisionObjectd* fcl_object_A_ptr,
+              fcl::CollisionObjectd* fcl_object_B_ptr, void* callback_data);
+
+}  // namespace penetration_as_point_pair
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/proximity_utilities.h
+++ b/geometry/proximity/proximity_utilities.h
@@ -120,7 +120,7 @@ class EncodedData {
   void set_anchored() { data_ &= ~kIsDynamicMask; }
 
   /** Writes the encoded data into the collision object's user data.  */
-  void write_to(fcl::CollisionObject<double>* object) {
+  void write_to(fcl::CollisionObject<double>* object) const {
     object->setUserData(reinterpret_cast<void*>(data_));
   }
 

--- a/geometry/proximity/test/penetration_as_point_pair_callback_test.cc
+++ b/geometry/proximity/test/penetration_as_point_pair_callback_test.cc
@@ -1,0 +1,141 @@
+#include "drake/geometry/proximity/penetration_as_point_pair_callback.h"
+
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/math/rigid_transform.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace penetration_as_point_pair {
+namespace {
+
+using Eigen::Vector3d;
+using fcl::CollisionObjectd;
+using fcl::Sphered;
+using math::RigidTransformd;
+using std::make_shared;
+using std::vector;
+
+// These tests represent the main tests of the actual callback. The callback
+// has limited responsibility:
+//   1. Determine if the pair is filtered.
+//   2. If not filtered, exercise some black-box geometric code to measure
+//      possible intersection.
+//   3. Package the result (if one exists) into a PenetrationAsPointPair with
+//      consistent ids and values.
+//   4. Always return false to make sure that the broadphase continues
+//      traversal.
+// The callback is agnostic of the geometry type and relies on the black box's
+// correctness for the *values* of the collision data to be correct. Thus, unit
+// tests of the callback should not concern themselves with the values to any
+// undue extent.
+//
+// The tests make use of two spheres of the same size, both positioned such that
+// their centers are coincident. The individual tests are responsible for
+// changing the relative poses.
+class PenetrationAsPointPairCallbackTest : public ::testing::Test {
+ public:
+  PenetrationAsPointPairCallbackTest()
+      : ::testing::Test(),
+        sphere_A_(make_shared<Sphered>(kRadius)),
+        sphere_B_(make_shared<Sphered>(kRadius)),
+        id_A_(GeometryId::get_new_id()),
+        id_B_(GeometryId::get_new_id()),
+        callback_data_(&collision_filter_, &point_pairs_) {}
+
+ protected:
+  void SetUp() override {
+    const EncodedData data_A(id_A_, true);
+    data_A.write_to(&sphere_A_);
+    collision_filter_.AddGeometry(data_A.encoding());
+
+    const EncodedData data_B(id_B_, true);
+    data_B.write_to(&sphere_B_);
+    collision_filter_.AddGeometry(data_B.encoding());
+  }
+
+  static const double kRadius;
+  CollisionObjectd sphere_A_;
+  CollisionObjectd sphere_B_;
+  GeometryId id_A_;
+  GeometryId id_B_;
+  CollisionFilterLegacy collision_filter_;
+  vector<PenetrationAsPointPair<double>> point_pairs_;
+  CallbackData callback_data_;
+};
+
+// TODO(SeanCurtis-TRI): Make this static constexpr when our gcc version doesn't
+//  cry in debug builds.
+const double PenetrationAsPointPairCallbackTest::kRadius = 0.5;
+
+// Confirms that a pair of geometries that are demonstrably not in collision and
+// are not filtered produce no results.
+TEST_F(PenetrationAsPointPairCallbackTest, NonCollision) {
+  // Move sphere B away from A.
+  sphere_B_.setTransform(
+      RigidTransformd{Vector3d{kRadius * 3, 0, 0}}.GetAsIsometry3());
+
+  EXPECT_FALSE(Callback(&sphere_A_, &sphere_B_, &callback_data_));
+  EXPECT_EQ(point_pairs_.size(), 0u);
+
+  EXPECT_FALSE(Callback(&sphere_B_, &sphere_A_, &callback_data_));
+  EXPECT_EQ(point_pairs_.size(), 0u);
+}
+
+// Confirms that a pair of geometries _in_ collision but not filtered produce
+// expected results. And that the result is expected, regardless of the order
+// of the objects as parameters.
+// And confirms that if the pair is filtered, no collision is reported.
+TEST_F(PenetrationAsPointPairCallbackTest, CollisionFilterRespected) {
+  // Move sphere B away from origin such that it penetrations A 0.1 units.
+  const double target_depth = 0.1;
+  sphere_B_.setTransform(
+      RigidTransformd{Vector3d{kRadius * 2 - target_depth, 0, 0}}
+          .GetAsIsometry3());
+
+  // Two executions with the order of the objects reversed -- should produce
+  // identical results.
+  EXPECT_FALSE(Callback(&sphere_A_, &sphere_B_, &callback_data_));
+  ASSERT_EQ(point_pairs_.size(), 1u);
+  const PenetrationAsPointPair<double> first_result = point_pairs_[0];
+  point_pairs_.clear();
+
+  EXPECT_FALSE(Callback(&sphere_B_, &sphere_A_, &callback_data_));
+  ASSERT_EQ(point_pairs_.size(), 1u);
+  const PenetrationAsPointPair<double> second_result = point_pairs_[0];
+  point_pairs_.clear();
+
+  const double kEps = std::numeric_limits<double>::epsilon();
+  ASSERT_EQ(first_result.id_A, second_result.id_A);
+  ASSERT_EQ(first_result.id_B, second_result.id_B);
+  ASSERT_NEAR(first_result.depth, target_depth, kEps);
+  ASSERT_NEAR(second_result.depth, target_depth, kEps);
+  ASSERT_TRUE(CompareMatrices(first_result.nhat_BA_W, second_result.nhat_BA_W));
+  ASSERT_TRUE(CompareMatrices(first_result.p_WCa, second_result.p_WCa));
+  ASSERT_TRUE(CompareMatrices(first_result.p_WCb, second_result.p_WCb));
+
+  // Now filter the geometries.
+  const int common_clique = 1;
+  collision_filter_.AddToCollisionClique(EncodedData(id_A_, true).encoding(),
+                                         common_clique);
+  collision_filter_.AddToCollisionClique(EncodedData(id_B_, true).encoding(),
+                                         common_clique);
+
+  EXPECT_FALSE(Callback(&sphere_A_, &sphere_B_, &callback_data_));
+  EXPECT_EQ(point_pairs_.size(), 0u);
+
+  EXPECT_FALSE(Callback(&sphere_B_, &sphere_A_, &callback_data_));
+  EXPECT_EQ(point_pairs_.size(), 0u);
+}
+
+}  // namespace
+}  // namespace penetration_as_point_pair
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -2814,9 +2814,34 @@ GTEST_TEST(ProximityEngineCollisionTest, SpherePunchThroughBox) {
   }
 }
 
+// TODO(SeanCurtis-TRI): All of the FCL-based queries should have *limited*
+//  testing in proximity engine. They should only test the following:
+//  Successful evaluation between two dynamic shapes and between a dynamic
+//  and anchored shape. Those simple tests confirm ProximityEngine handles its
+//  responsibilty correctly; it calls the appropriate broadphase methods on FCL.
+//  Unit tests on ProximityEngine for the FCL-based query methods should *not*
+//  be concerned with the correctness of the results' values -- that lies in the
+//  responsibility of the callback and underlying geometric algorithms. They
+//  were originally created here because FCL wasn't completely trusted. So,
+//  create a set of tests that can be evaluated on each of the FCL-based queries
+//  that performs those two tests.
+
+// TODO(SeanCurtis-TRI): Remove these geometric tests from here and put them
+//  in their own test. We're keeping them, ultimately, so that we can use these
+//  tests for our own implementation of shape-shape point-intersection
+//  algorithms. In the short-term, these tests should be expressed directly
+//  in terms of the penetration_as_point_pair::Callback and moved to that set
+//  of tests.
+
 // Robust Box-Primitive tests. Tests collision of the box with other primitives
 // in a uniform framework. These tests parallel tests located in fcl.
-
+//
+// All of the tests below here are using the callback to exercise the black box.
+// They exist because of FCL; FCL's unit tests were sporadic at best and these
+// tests revealed errors/properties of FCL that weren't otherwise apparent.
+// Ultimately, these tests don't belong here. But they can be re-used when we
+// replace FCL with Drake's own implementations.
+//
 // This performs a very specific test. It collides a rotated box with a
 // surface that is tangent to the z = 0 plane. The box is a cube with unit size.
 // The goal is to transform the box such that:


### PR DESCRIPTION
This is a precursor to using this functionality as a callback in a hybrid hydroelastic call.

Predominantly, this simply moves code out of `proximity_engine.cc` and into `penetration_as_point_pair_callback.*`.

The tests on the callback are 100% new.

Some small incidental changes:

1. Made a method of `EncodedData` const.
2. TODOs added to the overly bloated proximity engine tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12200)
<!-- Reviewable:end -->
