### PR TITLE
workspace: Specify type for download_and_extract

### DIFF
--- a/tools/workspace/bitbucket.bzl
+++ b/tools/workspace/bitbucket.bzl
@@ -193,6 +193,7 @@ def bitbucket_download_and_extract(
         urls,
         output = output,
         sha256 = _sha256(sha256),
+        type = "tar.gz",
         stripPrefix = strip_prefix,
     )
 

--- a/tools/workspace/doxygen/repository.bzl
+++ b/tools/workspace/doxygen/repository.bzl
@@ -42,6 +42,7 @@ def _impl(repo_ctx):
     repo_ctx.download_and_extract(
         url = url,
         sha256 = sha256,
+        type = "tar.gz",
     )
 
 doxygen_repository = repository_rule(

--- a/tools/workspace/drake_visualizer/repository.bzl
+++ b/tools/workspace/drake_visualizer/repository.bzl
@@ -73,7 +73,12 @@ def _impl(repository_ctx):
     ]
     root_path = repository_ctx.path("")
 
-    repository_ctx.download_and_extract(urls, root_path, sha256 = sha256)
+    repository_ctx.download_and_extract(
+        urls,
+        output = root_path,
+        sha256 = sha256,
+        type = "tar.gz",
+    )
 
     file_content = """# -*- python -*-
 

--- a/tools/workspace/github.bzl
+++ b/tools/workspace/github.bzl
@@ -211,6 +211,7 @@ def github_download_and_extract(
         urls,
         output = output,
         sha256 = _sha256(sha256),
+        type = "tar.gz",
         stripPrefix = _strip_prefix(repository, commit, extra_strip_prefix),
     )
 

--- a/tools/workspace/pypi.bzl
+++ b/tools/workspace/pypi.bzl
@@ -167,6 +167,7 @@ def pypi_download_and_extract(
         urls,
         output = output,
         sha256 = _sha256(sha256),
+        type = "tar.gz",
         stripPrefix = _strip_prefix(package, version, strip_prefix),
     )
 

--- a/tools/workspace/vtk/repository.bzl
+++ b/tools/workspace/vtk/repository.bzl
@@ -119,7 +119,12 @@ def _impl(repository_ctx):
         ]
         root_path = repository_ctx.path("")
 
-        repository_ctx.download_and_extract(urls, root_path, sha256 = sha256)
+        repository_ctx.download_and_extract(
+            urls,
+            output = root_path,
+            sha256 = sha256,
+            type = "tar.gz",
+        )
 
     else:
         fail("Operating system is NOT supported", attr = os_result)


### PR DESCRIPTION
Downstream `mirrors.bzl` values might not always use the conventional extension, so we should always tell bazel what archive type to expect instead of inferring it from the URL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12206)
<!-- Reviewable:end -->
