### PR TITLE
[geometry] Add MakeCylinderSurfaceMesh().

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -184,7 +184,9 @@ drake_cc_library(
     name = "make_cylinder_mesh",
     hdrs = ["make_cylinder_mesh.h"],
     deps = [
+        ":surface_mesh",
         ":volume_mesh",
+        ":volume_to_surface_mesh",
         "//common:essential",
         "//geometry:shape_specification",
     ],

--- a/geometry/proximity/make_cylinder_mesh.h
+++ b/geometry/proximity/make_cylinder_mesh.h
@@ -9,7 +9,9 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/sorted_pair.h"
+#include "drake/geometry/proximity/surface_mesh.h"
 #include "drake/geometry/proximity/volume_mesh.h"
+#include "drake/geometry/proximity/volume_to_surface_mesh.h"
 #include "drake/geometry/shape_specification.h"
 
 namespace drake {
@@ -440,8 +442,9 @@ MakeCylinderMeshLevel0(const double& height, const double& radius) {
 ///    The positive characteristic edge length for the mesh. The coarsest
 ///    possible mesh (a rectangular prism) is guaranteed for any value of
 ///    `resolution_hint` greater than √2 times the radius of the cylinder.
-///
-/// @throws std::exception if refinement_level is negative.
+/// @tparam T
+///    The Eigen-compatible scalar for representing the mesh vertex positions.
+/// @pre resolution_hint is positive.
 ///
 /// [Everett, 1997]  Everett, M.E., 1997. A three-dimensional spherical mesh
 /// generator. Geophysical Journal International, 130(1), pp.193-200.
@@ -537,6 +540,32 @@ VolumeMesh<T> MakeCylinderVolumeMesh(const Cylinder& cylinder,
   }
 
   return mesh;
+}
+
+/// Creates a surface mesh for the given `cylinder`; the level of
+/// tessellation is guided by the `resolution_hint` parameter in the same way
+/// as MakeCylinderVolumeMesh.
+///
+/// @param[in] cylinder
+///    Specification of the parameterized cylinder the output surface mesh
+///    should approximate.
+/// @param[in] resolution_hint
+///    The positive characteristic edge length for the mesh. The coarsest
+///    possible mesh (a rectangular prism) is guaranteed for any value of
+///    `resolution_hint` greater than √2 times the radius of the cylinder.
+///    For any cylinder, there is a `resolution_hint` value that serves as the
+///    smallest value that will produce more triangles -- values smaller than
+///    that will have no effect.
+/// @returns The triangulated surface mesh for the given cylinder.
+/// @pre resolution_hint is positive.
+/// @tparam T
+///    The Eigen-compatible scalar for representing the mesh vertex positions.
+template <typename T>
+SurfaceMesh<T> MakeCylinderSurfaceMesh(const Cylinder& cylinder,
+                                       double resolution_hint) {
+  DRAKE_DEMAND(resolution_hint > 0.0);
+  return ConvertVolumeToSurfaceMesh<T>(
+      MakeCylinderVolumeMesh<T>(cylinder, resolution_hint));
 }
 
 }  // namespace internal

--- a/geometry/proximity/test/make_cylinder_mesh_test.cc
+++ b/geometry/proximity/test/make_cylinder_mesh_test.cc
@@ -207,7 +207,43 @@ GTEST_TEST(MakeCylinderVolumeMesh, EulerCharacteristic) {
 // Smoke test only. Assume correctness of MakeCylinderVolumeMesh() and
 // ConvertVolumeToSurfaceMesh(). The resolution_hint larger than √2 times the
 // radius of the cylinder produces a rectangular prism with 24 triangles and
-// 12 vertices.
+// 14 vertices, which is the coarsest surface mesh that our algorithm can
+// produce. The positions (● in the picture below) of the 14 vertices look
+// like this:
+//
+//                +Z   -X
+//                 |   /
+//                 |  ●
+//                 | /
+//                 |/
+//  -Y-----●-------●-------●---+Y
+//                /|
+//               / |
+//              ●  |
+//             /   |
+//           +X    |   -X
+//                 |   /
+//                 |  ●
+//                 | /
+//                 |/
+//  -Y-----●-------+-------●---+Y
+//                /|
+//               / |
+//              ●  |
+//             /   |
+//           +X    |    -X
+//                 |   /
+//                 |  ●
+//                 | /
+//                 |/
+//  -Y-----●-------●-------●---+Y
+//                /|
+//               / |
+//              ●  |
+//             /   |
+//           +X    |
+//                -Z
+//
 GTEST_TEST(MakeCylinderSurfaceMesh, GenerateSurface) {
   const double radius = 1.0;
   const double length = 2.0;

--- a/geometry/proximity/test/make_cylinder_mesh_test.cc
+++ b/geometry/proximity/test/make_cylinder_mesh_test.cc
@@ -204,6 +204,21 @@ GTEST_TEST(MakeCylinderVolumeMesh, EulerCharacteristic) {
   }
 }
 
+// Smoke test only. Assume correctness of MakeCylinderVolumeMesh() and
+// ConvertVolumeToSurfaceMesh(). The resolution_hint larger than √2 times the
+// radius of the cylinder produces a rectangular prism with 24 triangles and
+// 12 vertices.
+GTEST_TEST(MakeCylinderSurfaceMesh, GenerateSurface) {
+  const double radius = 1.0;
+  const double length = 2.0;
+  const double resolution_hint = 1.5;
+  const Cylinder cylinder(radius, length);
+  SurfaceMesh<double> surface_mesh =
+      MakeCylinderSurfaceMesh<double>(cylinder, resolution_hint);
+  EXPECT_EQ(surface_mesh.num_faces(), 24);
+  EXPECT_EQ(surface_mesh.num_vertices(), 14);
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace geometry


### PR DESCRIPTION
Add function drake::geometry::internal::MakeCylinderSurfaceMesh() for the surface mesh of a rigid cylinder in hydroelastic contact model.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12212)
<!-- Reviewable:end -->
