### PR TITLE
Adds a monitor function for Simulator trajectories

### DIFF
--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -25,6 +25,9 @@ PYBIND11_MODULE(analysis, m) {
 
   py::module::import("pydrake.systems.framework");
 
+  py::class_<SimulatorStatus>(
+      m, "SimulatorStatus", pydrake_doc.drake.systems.SimulatorStatus.doc);
+
   auto bind_scalar_types = [m](auto dummy) {
     constexpr auto& doc = pydrake_doc.drake.systems;
     using T = decltype(dummy);

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -15,7 +15,7 @@ from pydrake.symbolic import Expression
 from pydrake.systems.analysis import (
     IntegratorBase, IntegratorBase_,
     RungeKutta2Integrator, RungeKutta3Integrator,
-    Simulator, Simulator_,
+    SimulatorStatus, Simulator, Simulator_,
     )
 from pydrake.systems.framework import (
     AbstractValue,

--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -33,6 +33,7 @@ drake_cc_package_library(
         ":scalar_view_dense_output",
         ":semi_explicit_euler_integrator",
         ":simulator",
+        ":simulator_status",
         ":stepwise_dense_output",
     ],
 )
@@ -282,12 +283,23 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "simulator_status",
+    srcs = ["simulator_status.cc"],
+    hdrs = ["simulator_status.h"],
+    deps = [
+        "//systems/framework:system_base",
+        "@fmt",
+    ],
+)
+
+drake_cc_library(
     name = "simulator",
     srcs = ["simulator.cc"],
     hdrs = ["simulator.h"],
     deps = [
         ":runge_kutta2_integrator",
         ":runge_kutta3_integrator",
+        ":simulator_status",
         "//common:extract_double",
         "//systems/framework:context",
         "//systems/framework:system",
@@ -295,6 +307,14 @@ drake_cc_library(
 )
 
 # === test/ ===
+
+drake_cc_googletest(
+    name = "simulator_status_test",
+    deps = [
+        ":simulator_status",
+        "//common:nice_type_name",
+    ],
+)
 
 drake_cc_googletest(
     name = "simulator_test",

--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -18,6 +18,7 @@
 #include "drake/common/text_logging.h"
 #include "drake/systems/analysis/integrator_base.h"
 #include "drake/systems/analysis/runge_kutta3_integrator.h"
+#include "drake/systems/analysis/simulator_status.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/system.h"
 #include "drake/systems/framework/witness_function.h"
@@ -99,7 +100,9 @@ defined in terms of Step below. In general, the length of a step is not known a
 priori and is determined by the Step() algorithm. Each step consists of zero or
 more unrestricted updates, followed by zero or more discrete updates, followed
 by (possibly zero-length) continuous time and state advancement, followed by
-zero or more publishes.
+zero or more publishes, and then a call to the monitor() function if one has
+been defined. Updates, publishes, and the monitor can report errors or detect a
+termination condition; that is not shown in the pseudocode below.
 
 The pseudocode will clarify the effects on time and state of each of the update
 stages above. This algorithm is given a starting Context value `{tₛ, x⁻(tₛ)}`
@@ -143,15 +146,18 @@ procedure Step(tₛ, x⁻(tₛ), tₘₐₓ)
   // ----------------------------------
 
   DoAnyPublishes(tₑ, x⁻(tₑ))
+  CallMonitor(tₑ, x⁻(tₑ))
 
   return {tₑ, x⁻(tₑ)}
 ```
 
 We can use the notation and pseudocode to flesh out the AdvanceTo(),
-AdvancePendingEvents(), and Initialize() functions:
+AdvancePendingEvents(), and Initialize() functions. Termination and error
+conditions detected by event handlers or the monitor are reported as status
+returns from these methods.
 ```
 // Advance the simulation until time tₘₐₓ.
-procedure AdvanceTo(tₘₐₓ)
+procedure AdvanceTo(tₘₐₓ) → status
   t ← current_time
   while t < tₘₐₓ
     {tₑ, x⁻(tₑ)} ← Step(t, x⁻(t), tₘₐₓ)
@@ -160,15 +166,17 @@ procedure AdvanceTo(tₘₐₓ)
 
 // AdvancePendingEvents() is an advanced method, not commonly used.
 // Perform just the start-of-step update to advance from x⁻(t) to x⁺(t).
-procedure AdvancePendingEvents()
+procedure AdvancePendingEvents() → status
   t ≜ current_time, x⁻(t) ≜ current_state
   x⁺(t) ← DoAnyPendingUpdates(t, x⁻(t)) as in Step()
   x(t) ← x⁺(t)  // No continuous update needed.
+  DoAnyPublishes(t, x(t))
+  CallMonitor(t, x(t))
 
 // Update time and state to {t₀, x⁻(t₀)}, which is the starting value of the
 // trajectory, and thus the value the Context should contain at the start of the
 // first simulation step.
-procedure Initialize(t₀, x₀)
+procedure Initialize(t₀, x₀) → status
   x⁺(t₀) ← DoAnyInitializationUpdates as in Step()
   x⁻(t₀) ← x⁺(t₀)  // No continuous update needed.
 
@@ -177,6 +185,7 @@ procedure Initialize(t₀, x₀)
   // ----------------------------------
 
   DoAnyPublishes(t₀, x⁻(t₀))
+  CallMonitor(t₀, x⁻(t₀))
 ```
 Initialize() can be viewed as a "0ᵗʰ step" that occurs before the first
 Step() call as described above. Like Step(), Initialize() first
@@ -185,7 +194,9 @@ performs pending updates (in this case only initialization events can be
 witnesses cannot trigger. Finally, again like Step(), the initial trajectory
 point `{t₀, x⁻(t₀)}` is provided to the handlers for any triggered publish
 events. That includes initialization publish events, per-step publish events,
-and periodic or timed publish events that trigger at t₀.
+and periodic or timed publish events that trigger at t₀, followed by a call
+to the monitor() function if one has been defined (a monitor is semantically
+identical to a per-step publish).
 
 @tparam T The vector element type, which must be a valid Eigen scalar.
 
@@ -235,8 +246,9 @@ class Simulator {
   ///   initial trajectory value `{t₀, x(t₀)}`.
   /// - Then that initial value is provided to the handlers for any publish
   ///   events that have triggered, including initialization and per-step
-  ///   publish events, and periodic or other time-triggered publish events
-  ///   that are scheduled for the initial time t₀.
+  ///   publish events, periodic or other time-triggered publish events
+  ///   that are scheduled for the initial time t₀, and finally a call to the
+  ///   monitor() function if one has been defined.
   ///
   /// See the class documentation for more information. We recommend calling
   /// Initialize() explicitly prior to beginning a simulation so that error
@@ -259,8 +271,12 @@ class Simulator {
   /// This method will throw `std::logic_error` if the combination of options
   /// doesn't make sense. Other failures are possible from the System and
   /// integrator in use.
-  /// @see AdvanceTo(), AdvancePendingEvents()
-  void Initialize();
+  ///
+  /// @retval status A SimulatorStatus object indicating success, termination,
+  ///                or an error condition as reported by event handlers or
+  ///                the monitor function.
+  /// @see AdvanceTo(), AdvancePendingEvents(), SimulatorStatus
+  SimulatorStatus Initialize();
 
   /// Advances the System's trajectory until `boundary_time` is reached in
   /// the context or some other termination condition occurs. A variety of
@@ -279,11 +295,19 @@ class Simulator {
   /// the Context or Simulator options between successive AdvanceTo() calls. See
   /// Initialize() for more information.
   ///
-  /// @param boundary_time The time to advance the context to.
+  /// @param boundary_time The maximum time to which the trajectory will be
+  ///     advanced by this call to %AdvanceTo(). The method may return earlier
+  ///     if an event or the monitor function requests termination or reports
+  ///     an error condition.
+  /// @retval status A SimulatorStatus object indicating success, termination,
+  ///     or an error condition as reported by event handlers or the monitor
+  ///     function. The time in the context will be set either to the
+  ///     boundary_time or the time a termination or error was first detected.
+  ///
   /// @pre The internal Context satisfies all System constraints or will after
   ///      pending Context updates are performed.
-  /// @see Initialize(), AdvancePendingEvents()
-  void AdvanceTo(const T &boundary_time);
+  /// @see Initialize(), AdvancePendingEvents(), SimulatorStatus
+  SimulatorStatus AdvanceTo(const T& boundary_time);
 
   /// (Advanced) Handles discrete and abstract state update events that are
   /// pending from the previous AdvanceTo() call, without advancing time.
@@ -298,10 +322,102 @@ class Simulator {
   ///
   /// This method is equivalent to `AdvanceTo(current_time)`, where
   /// `current_time=simulator.get_context().get_time())`. If there are no
-  /// pending events, nothing happens.
-  /// @see AdvanceTo(), Initialize()
-  void AdvancePendingEvents() {
-    AdvanceTo(get_context().get_time());
+  /// pending events, nothing happens except possibly a final per-step publish
+  /// call (if enabled) followed by a call to the monitor() function (if one
+  /// has been provided).
+  ///
+  /// @retval status A SimulatorStatus object indicating success, termination,
+  ///                or an error condition as reported by event handlers or
+  ///                the monitor function.
+  /// @see AdvanceTo(), Initialize(), SimulatorStatus
+  SimulatorStatus AdvancePendingEvents() {
+    return AdvanceTo(get_context().get_time());
+  }
+
+  /// Provides a monitoring function that will be invoked at the end of
+  /// every step. (See the Simulator class documentation for a precise
+  /// definition of "step".) A monitor() function can be used to capture the
+  /// trajectory, to terminate the simulation, or to detect error conditions.
+  /// The monitor() function is invoked by the %Simulator with a Context whose
+  /// value is a point along the simulated trajectory. The monitor can be any
+  /// functor and should capture any System references it needs to operate
+  /// correctly.
+  ///
+  /// A monitor() function behaves the same as would a per-step Publish event
+  /// handler included in the top-level System or Diagram being simulated. As in
+  /// the case of Publish(), the monitor is called at the end of every step
+  /// taken internally by AdvanceTo(), and also at the end of Initialize() and
+  /// AdvancePendingEvents(). (See the Simulator class documentation for more
+  /// detail about what happens when in these methods.) The monitor receives the
+  /// top-level (root) Context, from which any sub-Context can be obtained using
+  /// `subsystem.GetMyContextFromRoot()`, provided the necessary subsystem
+  /// reference has been captured for use in the monitor.
+  ///
+  /// #### Examples
+  /// Output time and continuous states whenever the trajectory is advanced:
+  /// @code
+  /// simulator.set_monitor([](const Context<T>& root_context) {
+  ///   std::cout << root_context.get_time() << " "
+  ///             << root_context.get_continuous_state_vector()
+  ///             << std::endl;
+  ///   return EventStatus::Succeeded();
+  /// });
+  /// @endcode
+  ///
+  /// Terminate early but successfully on a condition in a subsystem of the
+  /// System diagram being simulated:
+  /// @code
+  /// simulator.set_monitor([&my_subsystem](const Context<T>& root_context) {
+  ///   const Context<T>& subcontext =
+  ///       my_subsystem.GetMyContextFromRoot(root_context);
+  ///   if (my_subsystem.GoalReached(subcontext)) {
+  ///     return EventStatus::ReachedTermination(my_subsystem,
+  ///         "Simulation achieved the desired goal.");
+  ///   }
+  ///   return EventStatus::Succeeded();
+  /// });
+  /// @endcode
+  /// In the above case, the Simulator's AdvanceTo() method will return early
+  /// when the subsystem reports that it has reached its goal. The returned
+  /// status will indicate the termination reason, and a human-readable
+  /// termination message containing the message provided by the monitor can be
+  /// obtained with status.FormatMessage().
+  ///
+  /// Failure due to plant center of mass falling below a threshold:
+  /// @code
+  /// simulator.set_monitor([&plant](const Context<T>& root_context) {
+  ///   const Context<T>& plant_context =
+  ///       plant.GetMyContextFromRoot(root_context);
+  ///   const Vector3<T> com = plant.CalcCenterOfMassPosition(plant_context);
+  ///   if (com[2] < 0.1) {  // Check z height of com.
+  ///     return EventStatus::Failed(plant, "System fell over.");
+  ///   }
+  ///   return EventStatus::Succeeded();
+  /// });
+  /// @endcode
+  /// In the above case the Simulator's AdvanceTo() method will throw an
+  /// std::runtime_error containing a human-readable message including
+  /// the text provided in the monitor.
+  ///
+  /// @note monitor() is called every time the trajectory is advanced by a step,
+  /// which can mean it is called many times during a single AdvanceTo() call.
+  ///
+  /// @note The presence of a monitor has no effect on the step sizes taken,
+  /// so a termination or error condition will be discovered only when first
+  /// observed after a step is complete; it will not be further localized. Use
+  /// witness-triggered events instead if you need precise isolation.
+  void set_monitor(std::function<EventStatus(const Context<T>&)> monitor) {
+    monitor_ = std::move(monitor);
+  }
+
+  /// Removes the monitoring function if there is one.
+  /// @see set_monitor()
+  void clear_monitor() { monitor_ = nullptr; }
+
+  /// Obtains a reference to the monitoring function, which may be empty.
+  /// @see set_monitor()
+  const std::function<EventStatus(const Context<T>&)>& get_monitor() const {
+    return monitor_;
   }
 
 #ifndef DRAKE_DOXYGEN_CXX
@@ -559,6 +675,30 @@ class Simulator {
 
   void HandlePublish(const EventCollection<PublishEvent<T>>& events);
 
+  // Invoke the monitor() if there is one. If it wants termination we'll
+  // update the Simulator status accordingly. If it reports failure,
+  // currently we just throw.
+  // TODO(sherm1) Add an option where the Simulator returns failed status
+  // rather than throwing.
+  void CallMonitorUpdateStatusAndMaybeThrow(SimulatorStatus* status) {
+    DRAKE_DEMAND(status);
+    if (!get_monitor()) return;
+    const EventStatus monitor_status = get_monitor()(*context_);
+    if (monitor_status.severity() == EventStatus::kReachedTermination) {
+      status->SetReachedTermination(ExtractDoubleOrThrow(context_->get_time()),
+                                    monitor_status.system(),
+                                    monitor_status.message());
+      return;
+    }
+    if (monitor_status.severity() == EventStatus::kFailed) {
+      status->SetEventHandlerFailed(ExtractDoubleOrThrow(context_->get_time()),
+                                    monitor_status.system(),
+                                    monitor_status.message());
+      throw std::runtime_error(status->FormatMessage());
+    }
+    // For any other condition, leave the status unchanged.
+  }
+
   TimeOrWitnessTriggered IntegrateContinuousState(
       const T& next_publish_dt,
       const T& next_update_dt,
@@ -690,6 +830,9 @@ class Simulator {
   // Mapping of witness functions to pre-allocated events.
   std::unordered_map<const WitnessFunction<T>*, std::unique_ptr<Event<T>>>
       witness_function_events_;
+
+  // Optional monitor() method to capture trajectory, terminate, or fail.
+  std::function<EventStatus(const Context<T>&)> monitor_;
 };
 
 template <typename T>
@@ -790,9 +933,18 @@ T GetPreviousNormalizedValue(const T& value) {
 #endif
 
 template <typename T>
-void Simulator<T>::Initialize() {
+SimulatorStatus Simulator<T>::Initialize() {
   // TODO(sherm1) Modify Context to satisfy constraints.
   // TODO(sherm1) Invoke System's initial conditions computation.
+  if (!context_)
+    throw std::logic_error("Initialize(): Context has not been set.");
+
+  // Record the current time so we can restore it later (see below).
+  // *Don't* use a reference here!
+  const T current_time = context_->get_time();
+
+  // Assumes success.
+  SimulatorStatus status(ExtractDoubleOrThrow(current_time));
 
   // Initialize the integrator.
   integrator_->Initialize();
@@ -820,7 +972,6 @@ void Simulator<T>::Initialize() {
 
   // Ensure that CalcNextUpdateTime() can return the current time by perturbing
   // current time as slightly toward negative infinity as we can allow.
-  const T current_time = context_->get_time();
   const T slightly_before_current_time = internal::GetPreviousNormalizedValue(
       current_time);
   context_->SetTime(slightly_before_current_time);
@@ -859,8 +1010,12 @@ void Simulator<T>::Initialize() {
     ++num_publishes_;
   }
 
+  CallMonitorUpdateStatusAndMaybeThrow(&status);
+
   // Initialize runtime variables.
   initialization_done_ = true;
+
+  return status;
 }
 
 // Processes UnrestrictedUpdateEvent events.
@@ -907,10 +1062,17 @@ void Simulator<T>::HandlePublish(
 }
 
 template <typename T>
-void Simulator<T>::AdvanceTo(const T& boundary_time) {
-  if (!initialization_done_) Initialize();
+SimulatorStatus Simulator<T>::AdvanceTo(const T& boundary_time) {
+  if (!initialization_done_) {
+    const SimulatorStatus initialize_status = Initialize();
+    if (!initialize_status.succeeded())
+      return initialize_status;
+  }
 
   DRAKE_THROW_UNLESS(boundary_time >= context_->get_time());
+
+  // Assume success.
+  SimulatorStatus status(ExtractDoubleOrThrow(boundary_time));
 
   // Integrate until desired interval has completed.
   auto merged_events = system_.AllocateCompositeEventCollection();
@@ -998,6 +1160,10 @@ void Simulator<T>::AdvanceTo(const T& boundary_time) {
       ++num_publishes_;
     }
 
+    CallMonitorUpdateStatusAndMaybeThrow(&status);
+    if (!status.succeeded())
+      break;  // Done.
+
     // Break out of the loop after timed and witnessed events are merged in
     // to the event collection and after any publishes.
     if (context_->get_time() >= boundary_time)
@@ -1006,6 +1172,8 @@ void Simulator<T>::AdvanceTo(const T& boundary_time) {
 
   // TODO(edrumwri): Add test coverage to complete #8490.
   redetermine_active_witnesses_ = true;
+
+  return status;
 }
 
 template <class T>

--- a/systems/analysis/simulator_status.cc
+++ b/systems/analysis/simulator_status.cc
@@ -1,0 +1,53 @@
+#include "drake/systems/analysis/simulator_status.h"
+
+#include <string>
+#include <utility>
+
+#include <fmt/format.h>
+
+namespace drake {
+namespace systems {
+
+/** Returns a human-readable message explaining the return result. */
+std::string SimulatorStatus::FormatMessage() const {
+  if (reason() == kReachedBoundaryTime) {
+    DRAKE_DEMAND(return_time() == boundary_time());
+    return fmt::format(
+        "Simulator successfully reached the boundary time ({}).",
+        boundary_time());
+  }
+
+  // Equality is unlikely but allowed in case a termination request happens
+  // at exactly the boundary time.
+  DRAKE_DEMAND(return_time() <= boundary_time());
+
+  // Attempt to identify the relevant subsystem in human-readable terms. If no
+  // subsystem was provided we just call it "System". Otherwise, we obtain its
+  // type and its name and call it "type System 'name'", e.g.
+  // "MultibodyPlant<double> System 'my_plant'".
+  const std::string system_id =
+      system() == nullptr
+      ? "System"
+      : fmt::format(
+          "{} System '{}'",
+          NiceTypeName::RemoveNamespaces(system()->GetSystemType()),
+          system()->GetSystemPathname());
+
+  if (reason() == kReachedTerminationCondition) {
+    return fmt::format(
+        "Simulator returned early at time {} because {} requested termination "
+        "with message: \"{}\"",
+        return_time(), system_id, message());
+  }
+
+  DRAKE_DEMAND(reason() == kEventHandlerFailed);
+  return fmt::format(
+      "Simulator stopped at time {} because {} failed "
+      "with message: \"{}\"",
+      return_time(), system_id, message());
+}
+
+}  // namespace systems
+}  // namespace drake
+
+

--- a/systems/analysis/simulator_status.h
+++ b/systems/analysis/simulator_status.h
@@ -1,0 +1,139 @@
+#pragma once
+
+#include <string>
+#include <utility>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/nice_type_name.h"
+#include "drake/systems/framework/system_base.h"
+
+namespace drake {
+namespace systems {
+
+/** Holds the status return value from a call to Simulator::AdvanceTo() and
+related methods. The argument t to AdvanceTo(t) is called the boundary time,
+and represents the maximum time to which the simulation trajectory will be
+advanced by a call to AdvanceTo(). (For methods that don't advance time, the
+current time is considered to be the boundary time.) A normal, successful return
+means that simulated time advanced successfully to the boundary time, without
+encountering a termination condition or error condition. AdvanceTo() may return
+earlier than the boundary time if one of those conditions is encountered.
+In that case the return object holds a reference to the subsystem that detected
+the condition and a human-friendly message from that subsystem that hopefully
+explains what happened. */
+class SimulatorStatus {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SimulatorStatus)
+
+  enum ReturnReason {
+    /** This is the normal return: no termination or error condition was
+    encountered before reaching the boundary time. There is no message and no
+    saved System. */
+    kReachedBoundaryTime,
+    /** An event handler or monitor function returned with a "reached
+    termination condition" EventStatus (has message with details). For
+    AdvanceTo() the return time may be earlier than the boundary time. */
+    kReachedTerminationCondition,
+    /** An event handler or monitor function returned with a "failed"
+    EventStatus (has message with details). For AdvanceTo() the return time may
+    be earlier than the boundary time. */
+    kEventHandlerFailed
+  };
+
+  /** Sets this status to "reached boundary time" with no message and with
+  the final time set to the boundary time (this is the same as the
+  post-construction default). */
+  void SetReachedBoundaryTime() {
+    reason_ = kReachedBoundaryTime;
+    return_time_ = boundary_time_;
+    system_ = nullptr;
+    message_.clear();
+  }
+
+  /** Sets this status to "reached termination" with the early-termination
+  time and a message explaining why. */
+  void SetReachedTermination(double termination_time, const SystemBase* system,
+                             std::string message) {
+    SetResult(termination_time, kReachedTerminationCondition, system,
+              std::move(message));
+  }
+
+  /** Sets this status to "event handler failed" with the early-termination
+  time and a message explaining why. */
+  void SetEventHandlerFailed(double failure_time, const SystemBase* system,
+                             std::string message) {
+    SetResult(failure_time, kEventHandlerFailed, system, std::move(message));
+  }
+
+  /** Returns a human-readable message explaining the return result. */
+  std::string FormatMessage() const;
+
+  /** Returns true if we reached the boundary time with no surprises. */
+  bool succeeded() const { return reason() == kReachedBoundaryTime; }
+
+  /** Returns the maximum time we could have reached with this call; whether
+  we actually got there depends on the status. This is the time supplied in
+  an AdvanceTo() call or the current time for methods that don't advance
+  time, that is, Initialize() and AdvancePendingEvents(). */
+  double boundary_time() const { return boundary_time_; }
+
+  /** Returns the time that was actually reached. This will be boundary_time()
+  if succeeded() returns true. Otherwise it is the time at which a termination
+  or error condition was detected and may be earlier than boundary_time(). */
+  double return_time() const { return return_time_; }
+
+  /** Returns the reason that a %Simulator call returned. */
+  ReturnReason reason() const { return reason_; }
+
+  /** Optionally, returns the subsystem to which the status and contained
+  message should be attributed. May be nullptr in which case the status
+  should be attributed to the System as a whole. */
+  const SystemBase* system() const { return system_; }
+
+  /** For termination or error conditions, returns a human-readable message
+  explaining what happened. This is the message from the subsystem that
+  detected the condition. FormatMessage() returns additional information and
+  also includes this message. */
+  const std::string& message() const { return message_; }
+
+  /** Returns true if the `other` status contains exactly the same information
+  as `this` status. This is likely only useful for unit testing of
+  %SimulatorStatus. */
+  bool IsIdenticalStatus(const SimulatorStatus& other) {
+    return boundary_time() == other.boundary_time() &&
+           return_time() == other.return_time() && reason() == other.reason() &&
+           system() == other.system() && message() == other.message();
+  }
+
+#ifndef DRAKE_DOXYGEN_CXX
+  /* (Internal) For use by Simulator methods, creates a SimulatorStatus that
+  assumes we will reach the specified `boundary_time` which should be the
+  argument t that was supplied for AdvanceTo(t), or the current time for
+  Initialize() and AdvancePendingEvents(). */
+  explicit SimulatorStatus(double boundary_time)
+      : boundary_time_(boundary_time) {
+    SetReachedBoundaryTime();
+  }
+#endif
+
+ private:
+  void SetResult(double return_time, ReturnReason reason,
+                 const SystemBase* system,
+                 std::string message) {
+    DRAKE_DEMAND(return_time <= boundary_time_);
+    return_time_ = return_time;
+    reason_ = reason;
+    system_ = system;
+    message_ = std::move(message);
+  }
+
+  double boundary_time_{};
+  double return_time_{};  // Initially set to boundary_time.
+  ReturnReason reason_{kReachedBoundaryTime};
+  const SystemBase* system_{nullptr};
+  std::string message_;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/analysis/test/simulator_status_test.cc
+++ b/systems/analysis/test/simulator_status_test.cc
@@ -1,0 +1,39 @@
+#include "drake/systems/analysis/simulator_status.h"
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace systems {
+namespace {
+
+GTEST_TEST(SimulatorStatusTest, ConstructionAndRetrieval) {
+  const SystemBase* dummy = reinterpret_cast<const SystemBase*>(0x1234);
+  SimulatorStatus status(1.25);  // Always constructed with a boundary_time.
+
+  // Default is that the status reached the boundary time.
+  EXPECT_EQ(status.boundary_time(), 1.25);
+  EXPECT_EQ(status.return_time(), status.boundary_time());
+  EXPECT_EQ(status.reason(), SimulatorStatus::kReachedBoundaryTime);
+  EXPECT_EQ(status.system(), nullptr);
+  EXPECT_EQ(status.message(), std::string());
+
+  status.SetReachedTermination(1., dummy, "Hello there");
+  EXPECT_EQ(status.boundary_time(), 1.25);
+  EXPECT_EQ(status.return_time(), 1.);
+  EXPECT_EQ(status.reason(), SimulatorStatus::kReachedTerminationCondition);
+  EXPECT_EQ(status.system(), dummy);
+  EXPECT_EQ(status.message(), std::string("Hello there"));
+}
+
+GTEST_TEST(SimulatorStatusTest, CopyConstruction) {
+  const SystemBase* dummy = reinterpret_cast<const SystemBase*>(0x1234);
+  SimulatorStatus status(1.0);
+  status.SetEventHandlerFailed(0.5, dummy, "test message");
+
+  SimulatorStatus copy_status(status);
+  EXPECT_TRUE(copy_status.IsIdenticalStatus(status));
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake

--- a/systems/analysis/test/simulator_test.cc
+++ b/systems/analysis/test/simulator_test.cc
@@ -5,6 +5,7 @@
 #include <functional>
 #include <map>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/autodiff.h"
@@ -32,6 +33,7 @@ using drake::systems::WitnessFunction;
 using drake::systems::Simulator;
 using drake::systems::RungeKutta3Integrator;
 using drake::systems::ImplicitEulerIntegrator;
+using drake::systems::ExplicitEulerIntegrator;
 using LogisticSystem = drake::systems::analysis_test::LogisticSystem<double>;
 using StatelessSystem = drake::systems::analysis_test::StatelessSystem<double>;
 using Eigen::AutoDiffScalar;
@@ -883,7 +885,8 @@ GTEST_TEST(SimulatorTest, ContextAccess) {
   EXPECT_TRUE(simulator.has_context());
   simulator.release_context();
   EXPECT_FALSE(simulator.has_context());
-  EXPECT_THROW(simulator.Initialize(), std::logic_error);
+  DRAKE_EXPECT_THROWS_MESSAGE(simulator.Initialize(), std::logic_error,
+      ".*Initialize.*Context.*not.*set.*");
 
   // Create another context.
   auto ucontext = spring_mass.CreateDefaultContext();
@@ -2280,6 +2283,89 @@ GTEST_TEST(SimulatorTest, EvalDerivativesCounter) {
   simulator.AdvanceTo(2.);  // 8 more steps, but only 8 more evaluations.
   EXPECT_EQ(simulator.get_integrator().get_num_steps_taken(), 16);
   EXPECT_EQ(simulator.get_integrator().get_num_derivative_evaluations(), 24);
+}
+
+// Verify correct functioning of the monitor() API and runtime monitor
+// behavior, including correct monitor status reporting from the Simulator.
+GTEST_TEST(SimulatorTest, MonitorFunctionAndStatusReturn) {
+  SpringMassSystem<double> spring_mass(1., 1., 0.);
+  spring_mass.set_name("my_spring_mass");
+  Simulator<double> simulator(spring_mass);
+  Context<double>& context = simulator.get_mutable_context();
+  simulator.reset_integrator<ExplicitEulerIntegrator<double>>(spring_mass,
+                                                              0.125, &context);
+  std::vector<Eigen::VectorXd> states;
+  const auto monitor = [&states](const Context<double>& root_context) {
+    Eigen::VectorXd vector(1 + root_context.num_continuous_states());
+    vector << root_context.get_time(),
+        root_context.get_continuous_state_vector().CopyToVector();
+    states.push_back(vector);
+    return EventStatus::Succeeded();
+  };
+
+  simulator.set_monitor(monitor);
+  EXPECT_TRUE(simulator.get_monitor());
+
+  SimulatorStatus status = simulator.AdvanceTo(1.);  // Initialize + 8 steps.
+  EXPECT_EQ(status.reason(), SimulatorStatus::kReachedBoundaryTime);
+  EXPECT_EQ(simulator.get_num_steps_taken(), 8);
+  EXPECT_EQ(states.size(), 9u);
+
+  EXPECT_THAT(status.FormatMessage(), ::testing::MatchesRegex(
+      "Simulator successfully reached the boundary time.*1.*"));
+
+  // Check that some of the timestamps are right.
+  EXPECT_EQ(states[0](0), 0.);
+  EXPECT_EQ(states[1](0), 0.125);
+  EXPECT_EQ(states[8](0), 1.);
+
+  simulator.clear_monitor();
+  EXPECT_FALSE(simulator.get_monitor());
+  simulator.AdvanceTo(2.);
+  EXPECT_EQ(simulator.get_num_steps_taken(), 16);
+  EXPECT_EQ(states.size(), 9u);
+
+  simulator.set_monitor(monitor);
+  simulator.AdvanceTo(3.);  // 8 more steps.
+  EXPECT_EQ(simulator.get_num_steps_taken(), 24);
+  EXPECT_EQ(states.size(), 17u);
+  EXPECT_EQ(states[16](0), 3.);
+
+  // This monitor should provide a clean termination that is properly
+  // reported through the Simulator's status return.
+  const auto good_monitor = [](const Context<double>& root_context) {
+    const double time = root_context.get_time();
+    // Don't pass a System to blame for termination.
+    return time < 3.49 ? EventStatus::Succeeded()
+                       : EventStatus::ReachedTermination(nullptr, "All done.");
+  };
+
+  simulator.set_monitor(good_monitor);
+  status = simulator.AdvanceTo(10.);
+  EXPECT_EQ(status.reason(), SimulatorStatus::kReachedTerminationCondition);
+  // Time should be exactly 3.5 due to our choice of step size.
+  EXPECT_EQ(simulator.get_context().get_time(), 3.5);
+  EXPECT_THAT(
+      status.FormatMessage(),
+      ::testing::MatchesRegex(
+          "Simulator returned early.*3\\.5.*because.*requested termination.*"
+          "with message.*All done\\..*"));
+
+  // This monitor produces a hard failure that should cause the Simulator
+  // to throw with a helpful message.
+  const auto bad_monitor = [&spring_mass](const Context<double>& root_context) {
+    const double time = root_context.get_time();
+    // Blame spring_mass for the error.
+    return time < 5.99 ? EventStatus::Succeeded()
+                       : EventStatus::Failed(&spring_mass,
+                           "Something terrible happened.");
+  };
+  simulator.set_monitor(bad_monitor);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      simulator.AdvanceTo(10.), std::runtime_error,
+      ".*Simulator stopped at time 6.*because.*"
+      "SpringMassSystem.*my_spring_mass.*"
+      "failed with message.*Something terrible happened.*");
 }
 
 }  // namespace


### PR DESCRIPTION
Adds an optional monitor() function to a Simulator() that can be used to publish trajectories, check for termination, or report errors. Also adds a status return from Simulator::AdvanceTo() and related methods so that the monitor() results can be reported (backwards compatible if ignored).

The monitor() function is semantically identical to a top-level, per-step Publish event handler. It uses the pre-existing EventStatus class to report success, termination, or failure.

Resolves #12164
Resolves #4114

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12213)
<!-- Reviewable:end -->
