### PR TITLE
doc: Improve error message for broken symlinks

### DIFF
--- a/doc/doxygen_main.py
+++ b/doc/doxygen_main.py
@@ -85,7 +85,10 @@ def _run_doxygen(drake_workspace, args):
                 os.makedirs(parent)
             shutil.copy2(abs_x, target)
         else:
-            assert os.path.isdir(abs_x)
+            if not os.path.isdir(abs_x):
+                print("error while collecting files to document:",
+                      "{} is neither a file nor a directory".format(abs_x))
+                sys.exit(1)
             # N.B. This won't work if the user redundantly requested both a
             # parent directory and one of its children.  For now, the answer is
             # just "don't do that".


### PR DESCRIPTION
The results of listdir can be files, directories, or broken symlinks.  In the latter case, we should report a good error instead of asserting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12215)
<!-- Reviewable:end -->
