### PR TITLE
Guard creation of gflags::gflags_* targets

### DIFF
--- a/tools/install/cmake/FindGFlags.cmake
+++ b/tools/install/cmake/FindGFlags.cmake
@@ -33,36 +33,38 @@ function(_gflags_find_library _NAME)
     set(GFlags_${_NAME}_FOUND ON PARENT_SCOPE)
     mark_as_advanced(${_LIBRARY_VAR})
 
-    add_library(${_TARGET} ${_SHARED_STATIC} IMPORTED)
-    set_target_properties(${_TARGET} PROPERTIES
-      IMPORTED_LOCATION "${${_LIBRARY_VAR}}"
-      INTERFACE_INCLUDE_DIRECTORIES "${GFLAGS_INCLUDE_DIRS}"
-    )
-
-    if(_NAME MATCHES static$)
+    if(NOT TARGET ${_TARGET})
+      add_library(${_TARGET} ${_SHARED_STATIC} IMPORTED)
       set_target_properties(${_TARGET} PROPERTIES
-        IMPORTED_LINK_INTERFACE_LANGUAGES CXX
-        INTERFACE_COMPILE_DEFINITIONS GFLAGS_IS_A_DLL=0
+        IMPORTED_LOCATION "${${_LIBRARY_VAR}}"
+        INTERFACE_INCLUDE_DIRECTORIES "${GFLAGS_INCLUDE_DIRS}"
       )
-    else()
-      if(WIN32)
+
+      if(_NAME MATCHES static$)
         set_target_properties(${_TARGET} PROPERTIES
-          INTERFACE_COMPILE_DEFINITIONS GFLAGS_IS_A_DLL=1
-        )
-      else()
-        set_target_properties(${_TARGET} PROPERTIES
+          IMPORTED_LINK_INTERFACE_LANGUAGES CXX
           INTERFACE_COMPILE_DEFINITIONS GFLAGS_IS_A_DLL=0
         )
+      else()
+        if(WIN32)
+          set_target_properties(${_TARGET} PROPERTIES
+            INTERFACE_COMPILE_DEFINITIONS GFLAGS_IS_A_DLL=1
+          )
+        else()
+          set_target_properties(${_TARGET} PROPERTIES
+            INTERFACE_COMPILE_DEFINITIONS GFLAGS_IS_A_DLL=0
+          )
+        endif()
       endif()
-    endif()
 
-    if(_NAME STREQUAL static)
-      find_package(Threads QUIET)
+      if(_NAME STREQUAL static)
+        find_package(Threads QUIET)
 
-      if(Threads_FOUND)
-        set_target_properties(${_TARGET} PROPERTIES
-          INTERFACE_LINK_LIBRARIES $<LINK_ONLY:Threads::Threads>
-        )
+        if(Threads_FOUND)
+          set_target_properties(${_TARGET} PROPERTIES
+            INTERFACE_LINK_LIBRARIES $<LINK_ONLY:Threads::Threads>
+          )
+        endif()
       endif()
     endif()
   endif()


### PR DESCRIPTION
Seems that in #12205, I propagated a longstanding bug across from `drake-external-examples`. Two line fix modulo whitespace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12216)
<!-- Reviewable:end -->
