### PR TITLE
State change norm nan check

### DIFF
--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -359,6 +359,14 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "integrator_base_test",
+    deps = [
+        ":integrator_base",
+        "//systems/plants/spring_mass_system",
+    ],
+)
+
+drake_cc_googletest(
     name = "radau_integrator_test",
     # Note: if memcheck takes too long with Valgrind, disable
     # memcheck (per Drake issue #9621).

--- a/systems/analysis/implicit_integrator.h
+++ b/systems/analysis/implicit_integrator.h
@@ -286,8 +286,10 @@ class ImplicitIntegrator : public IntegratorBase<T> {
 
     for (int i = 0; i < xc.size(); ++i) {
       // Use a relative or absolute tolerance, as appropriate given the
-      // magnitude of xc[i].
-      const T tol = max(T(1), abs(xc[i])) * eps;
+      // magnitude of xc[i]. Note that the parameter ordering below ensures
+      // that NaN's are propagated (see
+      // https://stackoverflow.com/questions/1632145/use-of-min-and-max-functions-in-c).
+      const T tol = max(abs(xc[i]), T(1)) * eps;
       if (abs(dxc[i]) > tol)
         return false;
     }

--- a/systems/analysis/implicit_integrator.h
+++ b/systems/analysis/implicit_integrator.h
@@ -285,10 +285,10 @@ class ImplicitIntegrator : public IntegratorBase<T> {
       eps = 10 * std::numeric_limits<double>::epsilon();
 
     for (int i = 0; i < xc.size(); ++i) {
-      // Use a relative or absolute tolerance, as appropriate given the
-      // magnitude of xc[i]. Note that the parameter ordering below ensures
-      // that NaN's are propagated (see
-      // https://stackoverflow.com/questions/1632145/use-of-min-and-max-functions-in-c).
+      // Indicate the update is not zero if a NaN is detected.
+      using std::isnan;
+      if (isnan(dxc[i])) return false;
+
       const T tol = max(abs(xc[i]), T(1)) * eps;
       if (abs(dxc[i]) > tol)
         return false;

--- a/systems/analysis/implicit_integrator.h
+++ b/systems/analysis/implicit_integrator.h
@@ -285,7 +285,10 @@ class ImplicitIntegrator : public IntegratorBase<T> {
       eps = 10 * std::numeric_limits<double>::epsilon();
 
     for (int i = 0; i < xc.size(); ++i) {
-      // Indicate the update is not zero if a NaN is detected.
+      // We do not want the presence of a NaN to cause this function to
+      // spuriously return `true`, so indicate the update is not zero when a NaN
+      // is detected. This will make the Newton-Raphson process in the caller
+      // continue iterating until its inevitable failure.
       using std::isnan;
       if (isnan(dxc[i])) return false;
 

--- a/systems/analysis/integrator_base.h
+++ b/systems/analysis/integrator_base.h
@@ -1826,6 +1826,11 @@ T IntegratorBase<T>::CalcStateChangeNorm(
   SPDLOG_DEBUG(drake::log(), "dq norm: {}, dv norm: {}, dz norm: {}",
                q_nrm, v_nrm, z_nrm);
 
+  // Return NaN if one of the values is NaN (whether std::max does this is
+  // dependent upon ordering!)
+  if (isnan(q_nrm) || isnan(v_nrm) || isnan(z_nrm))
+    return std::numeric_limits<T>::quiet_NaN();
+
   // TODO(edrumwri): Record the worst offender (which of the norms resulted
   // in the largest value).
   // Infinity norm of the concatenation of multiple vectors is equal to the

--- a/systems/analysis/integrator_base.h
+++ b/systems/analysis/integrator_base.h
@@ -1828,6 +1828,7 @@ T IntegratorBase<T>::CalcStateChangeNorm(
 
   // Return NaN if one of the values is NaN (whether std::max does this is
   // dependent upon ordering!)
+  using std::isnan;
   if (isnan(q_nrm) || isnan(v_nrm) || isnan(z_nrm))
     return std::numeric_limits<T>::quiet_NaN();
 

--- a/systems/analysis/test/integrator_base_test.cc
+++ b/systems/analysis/test/integrator_base_test.cc
@@ -1,0 +1,123 @@
+#include "drake/systems/analysis/integrator_base.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/systems/plants/spring_mass_system/spring_mass_system.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+// A class for testing protected integration functions.
+template <typename T>
+class DummyIntegrator : public IntegratorBase<T> {
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DummyIntegrator)
+
+ public:
+  DummyIntegrator(const System<T>& system, Context<T>* context)
+      : IntegratorBase<T>(system, context) {}
+
+  // Necessary implementations of pure virtual methods.
+  bool supports_error_estimation() const override { return true; }
+  int get_error_estimate_order() const override { return 1; }
+
+  // Promote CalcStateChangeNorm() to public.
+  using IntegratorBase<T>::CalcStateChangeNorm;
+
+ private:
+  // Should not be called.
+  bool DoStep(const T&) override { DRAKE_UNREACHABLE(); }
+};
+
+// Tests that resetting the integrator with a null pointer throws.
+GTEST_TEST(IntegratorBaseTest, DoubleStateChangeNormPropagatesNaN) {
+  // We need a system with q, v, and z variables. Constants and absence of
+  // forcing are arbitrary (irrelevant for this test).
+  SpringMassSystem<double> spring_mass(10.0, 1.0, false);
+  std::unique_ptr<Context<double>> context = spring_mass.CreateDefaultContext();
+  DummyIntegrator<double> integrator(spring_mass, context.get());
+  integrator.Initialize();
+
+  // Set q = v = z = 0 and verify that the state change norm is zero.
+  context->get_mutable_continuous_state()[0] = 0;
+  context->get_mutable_continuous_state()[1] = 0;
+  context->get_mutable_continuous_state()[2] = 0;
+  EXPECT_EQ(integrator.CalcStateChangeNorm(context->get_continuous_state()), 0);
+
+  // Set q to NaN, and v = z = 0 and verify that NaN is returned from
+  // CalcStateChangeNorm().
+  using std::isnan;
+  context->get_mutable_continuous_state()[0] =
+      std::numeric_limits<double>::quiet_NaN();
+  context->get_mutable_continuous_state()[1] = 0;
+  context->get_mutable_continuous_state()[2] = 0;
+  EXPECT_TRUE(
+      isnan(integrator.CalcStateChangeNorm(context->get_continuous_state())));
+
+  // Set v to NaN, and q = z = 0 and verify that NaN is returned from
+  // CalcStateChangeNorm().
+  context->get_mutable_continuous_state()[0] = 0;
+  context->get_mutable_continuous_state()[1] =
+      std::numeric_limits<double>::quiet_NaN();
+  context->get_mutable_continuous_state()[2] = 0;
+  EXPECT_TRUE(
+      isnan(integrator.CalcStateChangeNorm(context->get_continuous_state())));
+
+  // Set v to NaN, and q = z = 0 and verify that NaN is returned from
+  // CalcStateChangeNorm().
+  context->get_mutable_continuous_state()[0] = 0;
+  context->get_mutable_continuous_state()[1] =
+      std::numeric_limits<double>::quiet_NaN();
+  context->get_mutable_continuous_state()[2] = 0;
+  EXPECT_TRUE(
+      isnan(integrator.CalcStateChangeNorm(context->get_continuous_state())));
+}
+
+// Tests that resetting the integrator with a null pointer throws.
+GTEST_TEST(IntegratorBaseTest, AutoDiffXdStateChangeNormPropagatesNaN) {
+  // We need a system with q, v, and z variables. Constants and absence of
+  // forcing are arbitrary (irrelevant for this test).
+  SpringMassSystem<AutoDiffXd> spring_mass(10.0, 1.0, false);
+  std::unique_ptr<Context<AutoDiffXd>> context =
+      spring_mass.CreateDefaultContext();
+  DummyIntegrator<AutoDiffXd> integrator(spring_mass, context.get());
+  integrator.Initialize();
+
+  // Set q = v = z = 0 and verify that the state change norm is zero.
+  context->get_mutable_continuous_state()[0] = 0;
+  context->get_mutable_continuous_state()[1] = 0;
+  context->get_mutable_continuous_state()[2] = 0;
+  EXPECT_EQ(integrator.CalcStateChangeNorm(context->get_continuous_state()), 0);
+
+  // Set q to NaN, and v = z = 0 and verify that NaN is returned from
+  // CalcStateChangeNorm().
+  using std::isnan;
+  context->get_mutable_continuous_state()[0] =
+      std::numeric_limits<double>::quiet_NaN();
+  context->get_mutable_continuous_state()[1] = 0;
+  context->get_mutable_continuous_state()[2] = 0;
+  EXPECT_TRUE(
+      isnan(integrator.CalcStateChangeNorm(context->get_continuous_state())));
+
+  // Set v to NaN, and q = z = 0 and verify that NaN is returned from
+  // CalcStateChangeNorm().
+  context->get_mutable_continuous_state()[0] = 0;
+  context->get_mutable_continuous_state()[1] =
+      std::numeric_limits<double>::quiet_NaN();
+  context->get_mutable_continuous_state()[2] = 0;
+  EXPECT_TRUE(
+      isnan(integrator.CalcStateChangeNorm(context->get_continuous_state())));
+
+  // Set v to NaN, and q = z = 0 and verify that NaN is returned from
+  // CalcStateChangeNorm().
+  context->get_mutable_continuous_state()[0] = 0;
+  context->get_mutable_continuous_state()[1] =
+      std::numeric_limits<double>::quiet_NaN();
+  context->get_mutable_continuous_state()[2] = 0;
+  EXPECT_TRUE(
+      isnan(integrator.CalcStateChangeNorm(context->get_continuous_state())));
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake

--- a/systems/analysis/test/integrator_base_test.cc
+++ b/systems/analysis/test/integrator_base_test.cc
@@ -29,7 +29,7 @@ class DummyIntegrator : public IntegratorBase<T> {
   bool DoStep(const T&) override { DRAKE_UNREACHABLE(); }
 };
 
-// Tests that resetting the integrator with a null pointer throws.
+// Tests that CalcStateChangeNorm() propagates NaNs in state.
 GTEST_TEST(IntegratorBaseTest, DoubleStateChangeNormPropagatesNaN) {
   // We need a system with q, v, and z variables. Constants and absence of
   // forcing are arbitrary (irrelevant for this test).
@@ -39,6 +39,7 @@ GTEST_TEST(IntegratorBaseTest, DoubleStateChangeNormPropagatesNaN) {
   integrator.Initialize();
 
   // Set q = v = z = 0 and verify that the state change norm is zero.
+  ASSERT_EQ(context->get_continuous_state().size(), 3);
   context->get_mutable_continuous_state()[0] = 0;
   context->get_mutable_continuous_state()[1] = 0;
   context->get_mutable_continuous_state()[2] = 0;
@@ -66,14 +67,14 @@ GTEST_TEST(IntegratorBaseTest, DoubleStateChangeNormPropagatesNaN) {
   // Set v to NaN, and q = z = 0 and verify that NaN is returned from
   // CalcStateChangeNorm().
   context->get_mutable_continuous_state()[0] = 0;
-  context->get_mutable_continuous_state()[1] =
+  context->get_mutable_continuous_state()[1] = 0;
+  context->get_mutable_continuous_state()[2] =
       std::numeric_limits<double>::quiet_NaN();
-  context->get_mutable_continuous_state()[2] = 0;
   EXPECT_TRUE(
       isnan(integrator.CalcStateChangeNorm(context->get_continuous_state())));
 }
 
-// Tests that resetting the integrator with a null pointer throws.
+// Tests that CalcStateChangeNorm() propagates NaNs in state.
 GTEST_TEST(IntegratorBaseTest, AutoDiffXdStateChangeNormPropagatesNaN) {
   // We need a system with q, v, and z variables. Constants and absence of
   // forcing are arbitrary (irrelevant for this test).
@@ -84,6 +85,7 @@ GTEST_TEST(IntegratorBaseTest, AutoDiffXdStateChangeNormPropagatesNaN) {
   integrator.Initialize();
 
   // Set q = v = z = 0 and verify that the state change norm is zero.
+  ASSERT_EQ(context->get_continuous_state().size(), 3);
   context->get_mutable_continuous_state()[0] = 0;
   context->get_mutable_continuous_state()[1] = 0;
   context->get_mutable_continuous_state()[2] = 0;
@@ -111,9 +113,9 @@ GTEST_TEST(IntegratorBaseTest, AutoDiffXdStateChangeNormPropagatesNaN) {
   // Set v to NaN, and q = z = 0 and verify that NaN is returned from
   // CalcStateChangeNorm().
   context->get_mutable_continuous_state()[0] = 0;
-  context->get_mutable_continuous_state()[1] =
+  context->get_mutable_continuous_state()[1] = 0;
+  context->get_mutable_continuous_state()[2] =
       std::numeric_limits<double>::quiet_NaN();
-  context->get_mutable_continuous_state()[2] = 0;
   EXPECT_TRUE(
       isnan(integrator.CalcStateChangeNorm(context->get_continuous_state())));
 }


### PR DESCRIPTION
Adds a prophylactic to IntegratorBase based on Ante's discovery that std::max and std::min do not necessarily propagate NaN values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12217)
<!-- Reviewable:end -->
