### PR TITLE
proto: Deprecate common/proto/protobuf.h

### DIFF
--- a/attic/multibody/BUILD.bazel
+++ b/attic/multibody/BUILD.bazel
@@ -384,7 +384,6 @@ drake_cc_library(
         ":rigid_body_tree",
         ":rigid_body_tree_alias_groups_proto",
         "//common:essential",
-        "//common/proto:protobuf",
     ],
 )
 

--- a/common/proto/BUILD.bazel
+++ b/common/proto/BUILD.bazel
@@ -52,7 +52,13 @@ drake_cc_library(
     name = "protobuf",
     srcs = ["protobuf.cc"],
     hdrs = ["protobuf.h"],
+    deprecation = "To be removed from Drake on or after 2020-02-01, with no replacement.",  # noqa
+    tags = [
+        # Avoid 'build //...' yelling at us.
+        "manual",
+    ],
     deps = [
+        "//common:essential",
         "@com_google_protobuf//:protobuf",
     ],
 )
@@ -158,6 +164,7 @@ drake_py_unittest(
 
 drake_cc_googletest(
     name = "protobuf_test",
+    copts = ["-Wno-deprecated-declarations"],
     data = [
         "test/test_string.txt",
     ],

--- a/common/proto/protobuf.h
+++ b/common/proto/protobuf.h
@@ -5,10 +5,13 @@
 
 #include "google/protobuf/io/zero_copy_stream_impl.h"
 
+#include "drake/common/drake_deprecated.h"
+
 namespace drake {
 
 /// Returns a self-closing FileInputStream for the file at the given @p path,
 /// or else throws std::runtime_error.
+DRAKE_DEPRECATED("2020-02-01", "There is no replacement.")
 std::unique_ptr<google::protobuf::io::FileInputStream>
 MakeFileInputStreamOrThrow(const std::string& path);
 

--- a/common/proto/test/protobuf_test.cc
+++ b/common/proto/test/protobuf_test.cc
@@ -7,6 +7,9 @@
 
 #include "drake/common/find_resource.h"
 
+// TODO(jwnimmer-tri) Remove this entire file when the header it's testing is
+// also removed (on or after 2020-02-01).
+
 namespace drake {
 namespace {
 


### PR DESCRIPTION
As of d2104ec1daf107e64098efa6a4961bac71ff0f0c (#12143) this is no longer used within Drake.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12220)
<!-- Reviewable:end -->
