### PR TITLE
mbp, sdformat: Remember link initial poses

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -296,6 +296,9 @@ void DoScalarDependentDefinitions(py::module m, T) {
             },
             py::arg("context"), py::arg("body"), py::arg("X_WB"),
             doc_iso3_deprecation)
+        .def("SetDefaultFreeBodyPose", &Class::SetDefaultFreeBodyPose,
+            py::arg("body"), py::arg("X_WB"),
+            cls_doc.SetDefaultFreeBodyPose.doc)
         .def("SetActuationInArray",
             [](const Class* self, multibody::ModelInstanceIndex model_instance,
                 const Eigen::Ref<const VectorX<T>> u_instance,
@@ -766,9 +769,6 @@ void DoScalarDependentDefinitions(py::module m, T) {
             },
             py_reference, py::arg("context"), py::arg("model_instance"),
             py::arg("q_v"), cls_doc.SetPositionsAndVelocities.doc_3args)
-        .def("SetDefaultFreeBodyPose", &Class::SetDefaultFreeBodyPose,
-            py::arg("body"), py::arg("X_WB"),
-            cls_doc.SetDefaultFreeBodyPose.doc)
         .def("SetDefaultState",
             [](const Class* self, const Context<T>& context, State<T>* state) {
               self->SetDefaultState(context, state);

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -766,6 +766,9 @@ void DoScalarDependentDefinitions(py::module m, T) {
             },
             py_reference, py::arg("context"), py::arg("model_instance"),
             py::arg("q_v"), cls_doc.SetPositionsAndVelocities.doc_3args)
+        .def("SetDefaultFreeBodyPose", &Class::SetDefaultFreeBodyPose,
+            py::arg("body"), py::arg("X_WB"),
+            cls_doc.SetDefaultFreeBodyPose.doc)
         .def("SetDefaultState",
             [](const Class* self, const Context<T>& context, State<T>* state) {
               self->SetDefaultState(context, state);

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -513,7 +513,7 @@ class TestPlant(unittest.TestCase):
 
         # Test existence of default free body pose setting.
         body = plant.GetBodyByName("Link1")
-        plant.SetDefaultFreeBodyPose(body=body, X_WB=RigidTransform())
+        plant.SetDefaultFreeBodyPose(body=body, X_WB=RigidTransform_[float]())
 
         # Test existence of limits.
         self.assertEqual(plant.GetPositionLowerLimits().shape, (nq,))

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -438,7 +438,6 @@ class TestPlant(unittest.TestCase):
     @numpy_compare.check_all_types
     def test_multibody_state_access(self, T):
         MultibodyPlant = MultibodyPlant_[T]
-        RigidTransform = RigidTransform_[T]
 
         plant_f = MultibodyPlant_[float]()
         file_name = FindResourceOrThrow(

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -438,6 +438,7 @@ class TestPlant(unittest.TestCase):
     @numpy_compare.check_all_types
     def test_multibody_state_access(self, T):
         MultibodyPlant = MultibodyPlant_[T]
+        RigidTransform = RigidTransform_[T]
 
         plant_f = MultibodyPlant_[float]()
         file_name = FindResourceOrThrow(
@@ -509,6 +510,10 @@ class TestPlant(unittest.TestCase):
 
         # Test existence of context resetting methods.
         plant.SetDefaultState(context, state=context.get_mutable_state())
+
+        # Test existence of default free body pose setting.
+        body = plant.GetBodyByName("Link1")
+        plant.SetDefaultFreeBodyPose(body=body, X_WB=RigidTransform())
 
         # Test existence of limits.
         self.assertEqual(plant.GetPositionLowerLimits().shape, (nq,))

--- a/examples/kuka_iiwa_arm/models/table/extra_heavy_duty_table_surface_only_collision.sdf
+++ b/examples/kuka_iiwa_arm/models/table/extra_heavy_duty_table_surface_only_collision.sdf
@@ -306,7 +306,11 @@
       <pose frame='world'>0 0 0.7645 0 -0 0</pose>
     </frame>
 
-    <static>1</static>
+    <!--
+    N.B. This model used have <static>true</static>, but this creates
+    issues in reusability with the current implementation of MBP parsing
+    (#12227).
+    -->
     <allow_auto_disable>1</allow_auto_disable>
   </model>
 </sdf>

--- a/math/rigid_transform.h
+++ b/math/rigid_transform.h
@@ -635,9 +635,10 @@ using RigidTransformd = RigidTransform<double>;
 
 }  // namespace math
 
+/// Extracts the double representation of a RigidTransform.
 template <typename T>
 math::RigidTransform<double>
-ExtractDoubleOrThrow(const math::RigidTransform<T> X) {
+ExtractDoubleOrThrow(const math::RigidTransform<T>& X) {
   return math::RigidTransform<double>(
       X.GetAsMatrix34().unaryExpr(
           [](T value) { return ExtractDoubleOrThrow(value); }));

--- a/math/rigid_transform.h
+++ b/math/rigid_transform.h
@@ -634,14 +634,4 @@ class RigidTransform {
 using RigidTransformd = RigidTransform<double>;
 
 }  // namespace math
-
-/// Extracts the double representation of a RigidTransform.
-template <typename T>
-math::RigidTransform<double>
-ExtractDoubleOrThrow(const math::RigidTransform<T>& X) {
-  return math::RigidTransform<double>(
-      X.GetAsMatrix34().unaryExpr(
-          [](T value) { return ExtractDoubleOrThrow(value); }));
-}
-
 }  // namespace drake

--- a/math/rigid_transform.h
+++ b/math/rigid_transform.h
@@ -634,4 +634,13 @@ class RigidTransform {
 using RigidTransformd = RigidTransform<double>;
 
 }  // namespace math
+
+template <typename T>
+math::RigidTransform<double>
+ExtractDoubleOrThrow(const math::RigidTransform<T> X) {
+  return math::RigidTransform<double>(
+      X.GetAsMatrix34().unaryExpr(
+          [](T value) { return ExtractDoubleOrThrow(value); }));
+}
+
 }  // namespace drake

--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -439,10 +439,9 @@ std::vector<LinkInfo> AddLinksFromSpecification(
     const RigidTransformd X_WL = X_WM * X_ML;
     link_infos.push_back(LinkInfo{&body, X_WL});
 
-    // N.B. If a body is completely disconnected (no inboard / outboard
-    // joints), then we lose information from the SDFormat spec. This hack is
-    // one way to preserve this information.
-    plant->InternalSetFreeBodyOnlyPose(body, X_WL);
+    // Set the initial pose of the free body (only use if the body is indeed
+    // floating).
+    plant->SetDefaultFreeBodyPose(body, X_WL);
 
     if (plant->geometry_source_is_registered()) {
       for (uint64_t visual_index = 0; visual_index < link.VisualCount();

--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -517,6 +517,13 @@ ModelInstanceIndex AddModelFromSpecification(
     MultibodyPlant<double>* plant,
     const PackageMap& package_map,
     const std::string& root_dir) {
+  // TODO(eric.cousineau): Support this.
+  if (model.Static()) {
+    throw std::runtime_error(
+        "Drake's parsing of sdformat does not currently support "
+        "//model/static.");
+  }
+  DRAKE_DEMAND(!model.Static());
 
   const ModelInstanceIndex model_instance =
     plant->AddModelInstance(model_name);

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -277,7 +277,8 @@ GTEST_TEST(SdfParser, StaticModelSupported) {
 
 GTEST_TEST(SdfParser, StaticModelWithJoints) {
   // Specifying redundant welds in the model yields no errors, either to the
-  // world or between links.
+  // world or between links. We test this by simply parsing it, and expecting
+  // no errors.
   ParseTestString(R"""(
 <model name='good'>
   <static>true</static>

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -33,6 +33,8 @@ using math::RollPitchYaw;
 using math::RollPitchYawd;
 using systems::Context;
 
+const double kEps = std::numeric_limits<double>::epsilon();
+
 // Verifies that the SDF loader can leverage a specified package map.
 GTEST_TEST(MultibodyPlantSdfParserTest, PackageMapSpecified) {
   // We start with the world and default model instances (model_instance.h
@@ -177,8 +179,7 @@ GTEST_TEST(MultibodyPlantSdfParserTest, ModelInstanceTest) {
 
   // Check model scope frames.
   auto context = plant.CreateDefaultContext();
-  const double eps = std::numeric_limits<double>::epsilon();
-  auto check_frame = [&plant, instance1, &context, eps](
+  auto check_frame = [&plant, instance1, &context](
       std::string parent_name, std::string name,
       const RigidTransformd& X_PF_expected) {
     const Frame<double>& frame = plant.GetFrameByName(name, instance1);
@@ -186,7 +187,7 @@ GTEST_TEST(MultibodyPlantSdfParserTest, ModelInstanceTest) {
         plant.GetFrameByName(parent_name, instance1);
     const RigidTransformd X_PF = plant.CalcRelativeTransform(
         *context, parent_frame, frame);
-    EXPECT_TRUE(CompareMatrices(X_PF_expected.matrix(), X_PF.matrix(), eps))
+    EXPECT_TRUE(CompareMatrices(X_PF_expected.matrix(), X_PF.matrix(), kEps))
         << name;
   };
 
@@ -199,6 +200,127 @@ GTEST_TEST(MultibodyPlantSdfParserTest, ModelInstanceTest) {
   const RigidTransformd X_MF3(Vector3d(0.7, 0.8, 0.9));
   check_frame(
       "_instance1_sdf_model_frame", "model_scope_model_frame_implicit", X_MF3);
+}
+
+struct PlantAndSceneGraph {
+  std::unique_ptr<MultibodyPlant<double>> plant;
+  std::unique_ptr<SceneGraph<double>> scene_graph;
+};
+
+PlantAndSceneGraph ParseTestString(const std::string& inner) {
+  const std::string filename = temp_directory() + "/test_string.sdf";
+  std::ofstream file(filename);
+  file << "<sdf version='1.6'>" << inner << "\n</sdf>\n";
+  file.close();
+  PlantAndSceneGraph pair;
+  pair.plant = std::make_unique<MultibodyPlant<double>>();
+  pair.scene_graph = std::make_unique<SceneGraph<double>>();
+  PackageMap package_map;
+  pair.plant->RegisterAsSourceForSceneGraph(pair.scene_graph.get());
+  drake::log()->debug("inner: {}", inner);
+  AddModelsFromSdfFile(filename, package_map, pair.plant.get());
+  return pair;
+}
+
+GTEST_TEST(SdfParser, FloatingBodyPose) {
+  // Test that floating bodies (links) still have their poses preserved.
+  PlantAndSceneGraph pair = ParseTestString(R"""(
+<model name='good'>
+  <link name='a'>
+    <pose>1 2 3  0 0 0</pose>
+  </link>
+  <link name='b'>
+    <pose>4 5 6  0 0 0</pose>
+  </link>
+</model>)""");
+  pair.plant->Finalize();
+  EXPECT_GT(pair.plant->num_positions(), 0);
+  auto context = pair.plant->CreateDefaultContext();
+  const RigidTransformd X_WA_expected(Vector3d(1, 2, 3));
+  const RigidTransformd X_WA =
+      pair.plant->GetFrameByName("a").CalcPoseInWorld(*context);
+  EXPECT_TRUE(CompareMatrices(X_WA_expected.matrix(), X_WA.matrix(), kEps));
+  const RigidTransformd X_WB_expected(Vector3d(4, 5, 6));
+  const RigidTransformd X_WB =
+      pair.plant->GetFrameByName("b").CalcPoseInWorld(*context);
+  EXPECT_TRUE(CompareMatrices(X_WB_expected.matrix(), X_WB.matrix(), kEps));
+}
+
+GTEST_TEST(SdfParser, StaticModelSupported) {
+  // Test that static models are partially supported.
+  PlantAndSceneGraph pair = ParseTestString(R"""(
+<model name='good'>
+  <static>true</static>
+  <link name='a'>
+    <pose>1 2 3  0 0 0</pose>
+  </link>
+  <link name='b'>
+    <pose>4 5 6  0 0 0</pose>
+  </link>
+</model>)""");
+  pair.plant->Finalize();
+  EXPECT_EQ(pair.plant->num_positions(), 0);
+  auto context = pair.plant->CreateDefaultContext();
+  const RigidTransformd X_WA_expected(Vector3d(1, 2, 3));
+  const RigidTransformd X_WA =
+      pair.plant->GetFrameByName("a").CalcPoseInWorld(*context);
+  EXPECT_TRUE(CompareMatrices(X_WA_expected.matrix(), X_WA.matrix(), kEps));
+  const RigidTransformd X_WB_expected(Vector3d(4, 5, 6));
+  const RigidTransformd X_WB =
+      pair.plant->GetFrameByName("b").CalcPoseInWorld(*context);
+  EXPECT_TRUE(CompareMatrices(X_WB_expected.matrix(), X_WB.matrix(), kEps));
+}
+
+GTEST_TEST(SdfParser, StaticModelWithJoints) {
+  // Specifying redundant welds in the model yields no errors, either to the
+  // world or between links.
+  /*EXPECT_NO_THROW*/(ParseTestString(R"""(
+<model name='good'>
+  <static>true</static>
+  <link name='a'/>
+  <joint name='a_weld' type='fixed'>
+    <parent>world</parent>
+    <child>a</child>
+  </joint>
+  <link name='b'/>
+  <joint name='b_weld' type='fixed'>
+    <parent>a</parent>
+    <child>b</child>
+  </joint>
+</model>)"""));
+
+  // Attempting to weld should fail fast, either during the welding or when
+  // finalizing (due to loop).
+  PlantAndSceneGraph pair = ParseTestString(R"""(
+<model name='bad'>
+  <static>true</static>
+  <link name='a'/>
+</model>
+)""");
+  auto weld_and_finalize = [&pair]() {
+    pair.plant->WeldFrames(
+        pair.plant->world_frame(), pair.plant->GetFrameByName("a"));
+    pair.plant->Finalize();
+  };
+  EXPECT_THROW(weld_and_finalize(), std::runtime_error);
+
+  // Drake does not support "frozen" joints (#12227).
+  DRAKE_EXPECT_THROWS_MESSAGE(
+    ParseTestString(R"""(
+<model name='good'>
+  <static>true</static>
+  <link name='a'/>
+  <link name='b'/>
+  <joint name='my_hinge' type='revolute'>
+    <parent>a</parent>
+    <child>b</child>
+    <axis>
+      <xyz>0 0 1</xyz>
+    </axis>
+  </joint>
+</model>)"""),
+    std::runtime_error,
+    "Only fixed joints are permitted in static models.");
 }
 
 // Verify that our SDF parser throws an exception when a user specifies a joint
@@ -392,18 +514,8 @@ GTEST_TEST(MultibodyPlantSdfParserTest, JointActuatorParsingTest) {
 }
 
 void ExpectUnsupportedFrame(const std::string& inner) {
-  const std::string filename = temp_directory() + "/bad.sdf";
-  std::ofstream file(filename);
-  file << "<sdf version='1.6'>" << inner << "\n</sdf>\n";
-  file.close();
-
-  MultibodyPlant<double> plant;
-  SceneGraph<double> scene_graph;
-  PackageMap package_map;
-  plant.RegisterAsSourceForSceneGraph(&scene_graph);
-  drake::log()->debug("inner: {}", inner);
   DRAKE_EXPECT_THROWS_MESSAGE(
-      AddModelsFromSdfFile(filename, package_map, &plant),
+      ParseTestString(inner),
       std::runtime_error,
       R"(<pose frame='\{non-empty\}'/> is presently not supported )"
       R"(outside of the <frame/> tag.)");

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -277,9 +277,8 @@ GTEST_TEST(SdfParser, StaticModelSupported) {
 
 GTEST_TEST(SdfParser, StaticModelWithJoints) {
   // Specifying redundant welds in the model yields no errors, either to the
-  // world or between links. We test this by simply parsing it, and expecting
-  // no errors.
-  ParseTestString(R"""(
+  // world or between links.
+  EXPECT_NO_THROW(ParseTestString(R"""(
 <model name='good'>
   <static>true</static>
   <link name='a'/>
@@ -292,7 +291,7 @@ GTEST_TEST(SdfParser, StaticModelWithJoints) {
     <parent>a</parent>
     <child>b</child>
   </joint>
-</model>)""");
+</model>)"""));
 
   // Attempting to weld should fail fast, either during the welding or when
   // finalizing (due to loop).

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -227,20 +227,22 @@ GTEST_TEST(SdfParser, FloatingBodyPose) {
   PlantAndSceneGraph pair = ParseTestString(R"""(
 <model name='good'>
   <link name='a'>
-    <pose>1 2 3  0 0 0</pose>
+    <pose>1 2 3  0.1 0.2 0.3</pose>
   </link>
   <link name='b'>
-    <pose>4 5 6  0 0 0</pose>
+    <pose>4 5 6  0.4 0.5 0.6</pose>
   </link>
 </model>)""");
   pair.plant->Finalize();
   EXPECT_GT(pair.plant->num_positions(), 0);
   auto context = pair.plant->CreateDefaultContext();
-  const RigidTransformd X_WA_expected(Vector3d(1, 2, 3));
+  const RigidTransformd X_WA_expected(
+      RollPitchYawd(0.1, 0.2, 0.3), Vector3d(1, 2, 3));
   const RigidTransformd X_WA =
       pair.plant->GetFrameByName("a").CalcPoseInWorld(*context);
   EXPECT_TRUE(CompareMatrices(X_WA_expected.matrix(), X_WA.matrix(), kEps));
-  const RigidTransformd X_WB_expected(Vector3d(4, 5, 6));
+  const RigidTransformd X_WB_expected(
+      RollPitchYawd(0.4, 0.5, 0.6), Vector3d(4, 5, 6));
   const RigidTransformd X_WB =
       pair.plant->GetFrameByName("b").CalcPoseInWorld(*context);
   EXPECT_TRUE(CompareMatrices(X_WB_expected.matrix(), X_WB.matrix(), kEps));
@@ -252,20 +254,22 @@ GTEST_TEST(SdfParser, StaticModelSupported) {
 <model name='good'>
   <static>true</static>
   <link name='a'>
-    <pose>1 2 3  0 0 0</pose>
+    <pose>1 2 3  0.1 0.2 0.3</pose>
   </link>
   <link name='b'>
-    <pose>4 5 6  0 0 0</pose>
+    <pose>4 5 6  0.4 0.5 0.6</pose>
   </link>
 </model>)""");
   pair.plant->Finalize();
   EXPECT_EQ(pair.plant->num_positions(), 0);
   auto context = pair.plant->CreateDefaultContext();
-  const RigidTransformd X_WA_expected(Vector3d(1, 2, 3));
+  const RigidTransformd X_WA_expected(
+      RollPitchYawd(0.1, 0.2, 0.3), Vector3d(1, 2, 3));
   const RigidTransformd X_WA =
       pair.plant->GetFrameByName("a").CalcPoseInWorld(*context);
   EXPECT_TRUE(CompareMatrices(X_WA_expected.matrix(), X_WA.matrix(), kEps));
-  const RigidTransformd X_WB_expected(Vector3d(4, 5, 6));
+  const RigidTransformd X_WB_expected(
+      RollPitchYawd(0.4, 0.5, 0.6), Vector3d(4, 5, 6));
   const RigidTransformd X_WB =
       pair.plant->GetFrameByName("b").CalcPoseInWorld(*context);
   EXPECT_TRUE(CompareMatrices(X_WB_expected.matrix(), X_WB.matrix(), kEps));
@@ -274,7 +278,7 @@ GTEST_TEST(SdfParser, StaticModelSupported) {
 GTEST_TEST(SdfParser, StaticModelWithJoints) {
   // Specifying redundant welds in the model yields no errors, either to the
   // world or between links.
-  /*EXPECT_NO_THROW*/(ParseTestString(R"""(
+  ParseTestString(R"""(
 <model name='good'>
   <static>true</static>
   <link name='a'/>
@@ -287,7 +291,7 @@ GTEST_TEST(SdfParser, StaticModelWithJoints) {
     <parent>a</parent>
     <child>b</child>
   </joint>
-</model>)"""));
+</model>)""");
 
   // Attempting to weld should fail fast, either during the welding or when
   // finalizing (due to loop).

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -263,7 +263,7 @@ MultibodyPlant<T>::MultibodyPlant(
   // it less brittle.
   visual_geometries_.emplace_back();  // Entries for the "world" body.
   collision_geometries_.emplace_back();
-  X_WB_free_body_only_list_.emplace_back();
+  X_WB_default_list_.emplace_back();
   // Add the world body to the graph.
   multibody_graph_.AddBody(world_body().name(), world_body().model_instance());
 }

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -259,8 +259,11 @@ MultibodyPlant<T>::MultibodyPlant(
           std::move(tree_in), time_step > 0),
       time_step_(time_step) {
   DRAKE_THROW_UNLESS(time_step >= 0);
+  // TODO(eric.cousineau): Combine all of these elements into one struct, make
+  // it less brittle.
   visual_geometries_.emplace_back();  // Entries for the "world" body.
   collision_geometries_.emplace_back();
+  X_WB_free_body_only_list_.emplace_back();
   // Add the world body to the graph.
   multibody_graph_.AddBody(world_body().name(), world_body().model_instance());
 }

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -274,6 +274,14 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     default_coulomb_friction_ = other.default_coulomb_friction_;
     visual_geometries_ = other.visual_geometries_;
     collision_geometries_ = other.collision_geometries_;
+    for (const auto& X_WB : other.X_WB_free_body_only_list_) {
+      if (!X_WB) {
+        X_WB_free_body_only_list_.emplace_back();
+      } else {
+        X_WB_free_body_only_list_.emplace_back(
+            ExtractDoubleOrThrow(*X_WB).template cast<T>());
+      }
+    }
     contact_model_ = other.contact_model_;
     if (geometry_source_is_registered())
       DeclareSceneGraphPorts();
@@ -818,6 +826,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     visual_geometries_.emplace_back();
     DRAKE_DEMAND(collision_geometries_.size() == body.index());
     collision_geometries_.emplace_back();
+    DRAKE_DEMAND(X_WB_free_body_only_list_.size() == body.index());
+    X_WB_free_body_only_list_.emplace_back();
     return body;
   }
 
@@ -3105,13 +3115,32 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
             context);
   }
 
-  /// Sets the `state` so that generalized positions and velocities are zero.
+  /// (Advanced)
+  /// @param[in] X_WB_disconnected_initial
+  ///   Initial pose of a body if it is entirely disonnected; this will be
+  ///   ignored if there are *any* other bodies that are connected to this via
+  ///   a physical joint. This is to accommodate SDFormat parsing.
+  void InternalSetFreeBodyOnlyPose(
+      const Body<T>& body, const math::RigidTransform<T>& X_WB_initial) {
+    auto& X_WB_initial_actual = X_WB_free_body_only_list_[body.index()];
+    DRAKE_DEMAND(!X_WB_initial_actual.has_value());
+    X_WB_initial_actual = X_WB_initial;
+  }
+
+  /// Sets the `state` so that generalized positions (modulo explicitly
+  /// specified body poses) and velocities are zero.
   /// @throws std::exception if called pre-finalize. See Finalize().
   void SetDefaultState(const systems::Context<T>& context,
                        systems::State<T>* state) const override {
     DRAKE_MBP_THROW_IF_NOT_FINALIZED();
     CheckValidState(state);
     internal_tree().SetDefaultState(context, state);
+    for (const auto* body : GetFreeBodies()) {
+      auto X_WB = X_WB_free_body_only_list_[body->index()];
+      if (X_WB) {
+        SetFreeBodyPose(context, state, *body, *X_WB);
+      }
+    }
   }
 
   /// Assigns random values to all elements of the state, by drawing samples
@@ -3612,6 +3641,19 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
                               joint.child_body().index());
   }
 
+  std::vector<const Body<T>*> GetFreeBodies() const {
+    std::vector<const Body<T>*> bodies;
+    for (internal::MobilizerIndex index{0};
+         index < internal_tree().num_mobilizers(); ++index) {
+      auto& mobilizer = internal_tree().get_mobilizer(index);
+      if (mobilizer.is_floating()) {
+        DRAKE_DEMAND(&mobilizer.inboard_body() == &world_body());
+        bodies.push_back(&mobilizer.outboard_body());
+      }
+    }
+    return bodies;
+  }
+
   // Geometry source identifier for this system to interact with geometry
   // system. It is made optional for plants that do not register geometry
   // (dynamics only).
@@ -3812,6 +3854,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   // All MultibodyPlant cache indexes are stored in cache_indexes_.
   CacheIndexes cache_indexes_;
+
+  std::vector<optional<math::RigidTransform<T>>> X_WB_free_body_only_list_;
 };
 
 /// @cond

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3131,7 +3131,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     for (const BodyIndex index : GetFloatingBaseBodies()) {
       SetFreeBodyPose(
           context, state, internal_tree().get_body(index),
-          X_WB_default_list_[index].cast<T>());
+          X_WB_default_list_[index].template cast<T>());
     }
   }
 

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -519,9 +519,6 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
         body, V_WB, context, state);
   }
 
-  // TODO(sammy-tri) We should also be able to set the default pose of a free
-  // body.  See https://github.com/RobotLocomotion/drake/issues/10713
-
   /// Sets the distribution used by SetRandomState() to populate the
   /// x-y-z `position` component of the floating-base state.
   /// @throws std::exception if `body` is not a free body in the model.
@@ -3120,8 +3117,10 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
             context);
   }
 
-  /// Sets the `state` so that generalized positions (modulo explicitly
-  /// specified body poses) and velocities are zero.
+  /// Sets `state` according to defaults set by the user for joints (e.g.
+  /// RevoluteJoint::set_default_angle()) and free bodies
+  /// (SetDefaultFreeBodyPose()). If the user does not specify defaults, the
+  /// state corresponds to zero generalized positions and velocities.
   /// @throws std::exception if called pre-finalize. See Finalize().
   void SetDefaultState(const systems::Context<T>& context,
                        systems::State<T>* state) const override {

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -274,15 +274,13 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     default_coulomb_friction_ = other.default_coulomb_friction_;
     visual_geometries_ = other.visual_geometries_;
     collision_geometries_ = other.collision_geometries_;
-    for (const optional<math::RigidTransform<U>>& X_WB_other :
-         other.X_WB_free_body_only_list_) {
+    for (const math::RigidTransform<U>& X_WB_other :
+         other.X_WB_default_list_) {
       // N.B. `double` is used as an intermediary when converting
       // `RigidTransform`s from U to T.
-      optional<math::RigidTransform<T>> X_WB_this;
-      if (X_WB_other) {
-        X_WB_this = ExtractDoubleOrThrow(*X_WB_other).template cast<T>();
-      }
-      X_WB_free_body_only_list_.push_back(X_WB_this);
+      math::RigidTransform<T> X_WB_this =
+          ExtractDoubleOrThrow(X_WB_other).template cast<T>();
+      X_WB_default_list_.push_back(X_WB_this);
     }
     contact_model_ = other.contact_model_;
     if (geometry_source_is_registered())
@@ -828,8 +826,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     visual_geometries_.emplace_back();
     DRAKE_DEMAND(collision_geometries_.size() == body.index());
     collision_geometries_.emplace_back();
-    DRAKE_DEMAND(X_WB_free_body_only_list_.size() == body.index());
-    X_WB_free_body_only_list_.emplace_back();
+    DRAKE_DEMAND(X_WB_default_list_.size() == body.index());
+    X_WB_default_list_.emplace_back();
     return body;
   }
 
@@ -3117,16 +3115,16 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
             context);
   }
 
-  /// (Advanced)
-  /// @param[in] X_WB_disconnected_initial
-  ///   Initial pose of a body if it is entirely disonnected; this will be
-  ///   ignored if there are *any* other bodies that are connected to this via
-  ///   a physical joint. This is to accommodate SDFormat parsing.
-  void InternalSetFreeBodyOnlyPose(
-      const Body<T>& body, const math::RigidTransform<T>& X_WB_initial) {
-    auto& X_WB_initial_actual = X_WB_free_body_only_list_[body.index()];
-    DRAKE_DEMAND(!X_WB_initial_actual.has_value());
-    X_WB_initial_actual = X_WB_initial;
+  /// Sets the default pose of a free (floating) body. This affects subsequent
+  /// calls to SetDefaultState() for bodies that are floating. This value is
+  /// ignored for bodies that are not floating.
+  /// @param[in] body
+  ///   Body whose initial pose will be set.
+  /// @param[in] X_WB
+  ///   Initial pose of the body.
+  void SetDefaultFreeBodyPose(
+      const Body<T>& body, const math::RigidTransform<T>& X_WB) {
+    X_WB_default_list_[body.index()] = X_WB;
   }
 
   /// Sets the `state` so that generalized positions (modulo explicitly
@@ -3137,11 +3135,10 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     DRAKE_MBP_THROW_IF_NOT_FINALIZED();
     CheckValidState(state);
     internal_tree().SetDefaultState(context, state);
-    for (const auto* body : GetFreeBodies()) {
-      const auto& X_WB = X_WB_free_body_only_list_[body->index()];
-      if (X_WB) {
-        SetFreeBodyPose(context, state, *body, *X_WB);
-      }
+    for (const BodyIndex index : GetFloatingBaseBodies()) {
+      SetFreeBodyPose(
+          context, state, internal_tree().get_body(index),
+          X_WB_default_list_[index]);
     }
   }
 
@@ -3643,19 +3640,6 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
                               joint.child_body().index());
   }
 
-  std::vector<const Body<T>*> GetFreeBodies() const {
-    std::vector<const Body<T>*> bodies;
-    for (internal::MobilizerIndex index{0};
-         index < internal_tree().num_mobilizers(); ++index) {
-      auto& mobilizer = internal_tree().get_mobilizer(index);
-      if (mobilizer.is_floating()) {
-        DRAKE_DEMAND(&mobilizer.inboard_body() == &world_body());
-        bodies.push_back(&mobilizer.outboard_body());
-      }
-    }
-    return bodies;
-  }
-
   // Geometry source identifier for this system to interact with geometry
   // system. It is made optional for plants that do not register geometry
   // (dynamics only).
@@ -3857,7 +3841,9 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // All MultibodyPlant cache indexes are stored in cache_indexes_.
   CacheIndexes cache_indexes_;
 
-  std::vector<optional<math::RigidTransform<T>>> X_WB_free_body_only_list_;
+  // List of default poses for each body (initially identity). This is only
+  // used if the body is floating.
+  std::vector<math::RigidTransform<T>> X_WB_default_list_;
 };
 
 /// @cond


### PR DESCRIPTION
Towards #4641, taken from #12061

Resolves #10713
Resolves #12227 (but with limited usage)

~Also disables usage of `//model/static`. Currently, we just ignore the tag and don't error out. This just errors out, pending a real fix (which should happen after this PR).~

\cc @hidmic

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12226)
<!-- Reviewable:end -->
