### PR TITLE
Pre-compute hydroelastic geometric representations

### DIFF
--- a/examples/scene_graph/simple_contact_surface_vis.cc
+++ b/examples/scene_graph/simple_contact_surface_vis.cc
@@ -99,9 +99,6 @@ class MovingBall final : public LeafSystem<double> {
                                       make_unique<Sphere>(1.0), "ball"));
 
     ProximityProperties prox_props;
-    // TODO(SeanCurtis-TRI): The fact that I'm pushing two values here is
-    //  unfortunate. I should be able to indicate that I want a linear function
-    //  and have it read the elastic modulus property from the input properties.
     prox_props.AddProperty(geometry::kMaterialGroup, geometry::kElastic, 1e8);
     AddSoftHydroelasticProperties(FLAGS_length, &prox_props);
     scene_graph->AssignRole(source_id_, geometry_id_, prox_props);
@@ -252,6 +249,9 @@ int do_main() {
       make_unique<GeometryInstance>(
           X_WB, make_unique<Box>(edge_len, edge_len, edge_len), "box"));
   ProximityProperties rigid_props;
+  // A rigid hydroelastic geometry must have an infinite elastic modulus.
+  rigid_props.AddProperty(geometry::kMaterialGroup, geometry::kElastic,
+                          std::numeric_limits<double>::infinity());
   AddRigidHydroelasticProperties(edge_len, &rigid_props);
   scene_graph.AssignRole(source_id, ground_id, rigid_props);
   IllustrationProperties illus_props;

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -708,7 +708,8 @@ void GeometryState<T>::AssignRole(SourceId source_id, GeometryId geometry_id,
   if (assign == RoleAssign::kNew) {
     if (geometry.is_dynamic()) {
       // Pass the geometry to the engine.
-      geometry_engine_->AddDynamicGeometry(geometry.shape(), geometry_id);
+      geometry_engine_->AddDynamicGeometry(geometry.shape(), geometry_id,
+                                           *geometry.proximity_properties());
 
       InternalFrame& frame = frames_[geometry.frame_id()];
 
@@ -755,7 +756,8 @@ void GeometryState<T>::AssignRole(SourceId source_id, GeometryId geometry_id,
       // If it's not dynamic, it must be anchored. No clique madness required;
       // anchored geometries are not tested against each other by the process.
       geometry_engine_->AddAnchoredGeometry(geometry.shape(), geometry.X_FG(),
-                                            geometry_id);
+                                            geometry_id,
+                                            *geometry.proximity_properties());
     }
   }
   // TODO(SeanCurtis-TRI): Handle the assign == kReplace branch for when

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -389,7 +389,7 @@ class GeometryState {
 
   /** Implementation of QueryObject::ComputeContactSurfaces().  */
   std::vector<ContactSurface<T>> ComputeContactSurfaces() const {
-    return geometry_engine_->ComputeContactSurfaces(X_WGs_, geometries_);
+    return geometry_engine_->ComputeContactSurfaces(X_WGs_);
   }
 
   /** Implementation of QueryObject::FindCollisionCandidates().  */

--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -20,6 +20,7 @@ drake_cc_package_library(
         ":distance_to_shape_callback",
         ":find_collision_candidates_callback",
         ":hydroelastic_callback",
+        ":hydroelastic_internal",
         ":make_box_mesh",
         ":make_cylinder_mesh",
         ":make_sphere_mesh",
@@ -115,19 +116,35 @@ drake_cc_library(
     ],
     deps = [
         ":collision_filter_legacy",
-        ":make_box_mesh",
-        ":make_sphere_mesh",
+        ":hydroelastic_internal",
         ":mesh_intersection",
         ":proximity_utilities",
         ":surface_mesh",
         ":volume_mesh",
         "//common:hash",
-        "//geometry:geometry_roles",
-        "//geometry:internal_geometry",
         "//geometry:proximity_properties",
         "//geometry/query_results:contact_surface",
         "//math:geometric_transform",
         "@fcl",
+        "@fmt",
+    ],
+)
+
+drake_cc_library(
+    name = "hydroelastic_internal",
+    srcs = ["hydroelastic_internal.cc"],
+    hdrs = ["hydroelastic_internal.h"],
+    deps = [
+        ":surface_mesh",
+        ":volume_mesh",
+        "//common:essential",
+        "//geometry:geometry_ids",
+        "//geometry:geometry_roles",
+        "//geometry:proximity_properties",
+        "//geometry:shape_specification",
+        "//geometry/proximity:make_box_mesh",
+        "//geometry/proximity:make_sphere_mesh",
+        "//geometry/proximity:proximity_utilities",
         "@fmt",
     ],
 )
@@ -352,6 +369,18 @@ drake_cc_googletest(
         "//geometry:geometry_ids",
         "//geometry:utilities",
         "//math:gradient",
+    ],
+)
+
+drake_cc_googletest(
+    name = "hydroelastic_internal_test",
+    deps = [
+        ":hydroelastic_internal",
+        ":proximity_utilities",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_no_throw",
+        "//common/test_utilities:expect_throws_message",
+        "@fmt",
     ],
 )
 

--- a/geometry/proximity/hydroelastic_callback.h
+++ b/geometry/proximity/hydroelastic_callback.h
@@ -10,14 +10,10 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/geometry_ids.h"
-#include "drake/geometry/geometry_roles.h"
-#include "drake/geometry/internal_geometry.h"
 #include "drake/geometry/proximity/collision_filter_legacy.h"
-#include "drake/geometry/proximity/make_box_mesh.h"
-#include "drake/geometry/proximity/make_sphere_mesh.h"
+#include "drake/geometry/proximity/hydroelastic_internal.h"
 #include "drake/geometry/proximity/mesh_intersection.h"
 #include "drake/geometry/proximity/proximity_utilities.h"
-#include "drake/geometry/proximity_properties.h"
 #include "drake/geometry/query_results/contact_surface.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/math/rotation_matrix.h"
@@ -33,7 +29,8 @@ namespace hydroelastic {
     - A collision filter instance.
     - The T-valued poses of _all_ geometries in the corresponding SceneGraph,
       each indexed by its corresponding geometry's GeometryId.
-    - The geometries stored in SceneGraph.
+    - The representation of all geometries that have been prepped for computing
+      contact surfaces.
     - A vector of contact surfaces -- one instance of ContactSurface for
       every supported, unfiltered penetrating pair.
 
@@ -46,13 +43,13 @@ struct CallbackData {
 
    @param collision_filter_in     The collision filter system. Aliased.
    @param X_WGs_in                The T-valued poses. Aliased.
-   @param geometries_in           The geometries. Aliased.
+   @param geometries_in           The set of all hydroelastic geometric
+                                  representations. Aliased.
    @param surfaces_in             The output results. Aliased.  */
   CallbackData(
       const CollisionFilterLegacy* collision_filter_in,
       const std::unordered_map<GeometryId, math::RigidTransform<T>>* X_WGs_in,
-      const std::unordered_map<GeometryId, internal::InternalGeometry>*
-          geometries_in,
+      const Geometries* geometries_in,
       std::vector<ContactSurface<T>>* surfaces_in)
       : collision_filter(*collision_filter_in),
         X_WGs(*X_WGs_in),
@@ -70,71 +67,12 @@ struct CallbackData {
   /** The T-valued poses of all geometries.  */
   const std::unordered_map<GeometryId, math::RigidTransform<T>>& X_WGs;
 
-  /** The geometries in scene graph -- not just those with proximity role.  */
-  const std::unordered_map<GeometryId, internal::InternalGeometry>& geometries;
+  /** The hydroelastic geometric representations.  */
+  const Geometries& geometries;
 
   /** The results of the distance query.  */
   std::vector<ContactSurface<T>>& surfaces;
 };
-
-// TODO(SeanCurtis-TRI): Remove these two functions (MakeBoxMeshFromFcl and
-//  MakeSphereFromFcl) when the real infrastructure is in place.
-/** Given an object_ptr whose geometry is a box, create a coarse surface mesh
- for that box.  */
-SurfaceMesh<double> MakeBoxMeshFromFcl(fcl::CollisionObjectd* object_ptr,
-                                       const ProximityProperties& properties) {
-  const fcl::Boxd* box_ptr =
-      dynamic_cast<const fcl::Boxd*>(object_ptr->collisionGeometry().get());
-  DRAKE_DEMAND(box_ptr != nullptr);
-  Box box(box_ptr->side(0), box_ptr->side(1), box_ptr->side(2));
-  // Edge length as long as the longest side guarantees the coarsest mesh.
-  double edge_length = box_ptr->side.maxCoeff();
-  edge_length =
-      properties.GetPropertyOrDefault(kHydroGroup, kRezHint, edge_length);
-  return MakeBoxSurfaceMesh<double>(box, edge_length);
-}
-
-struct SoftGeometry {
-  std::unique_ptr<VolumeMesh<double>> mesh;
-  std::unique_ptr<VolumeMeshFieldLinear<double, double>> p0;
-};
-
-/** Given an object_ptr whose geometry is a sphere, creates a coarse volume mesh
- field for that sphere.  */
-SoftGeometry MakeSphereFromFcl(fcl::CollisionObjectd* object_ptr,
-                               const ProximityProperties& properties) {
-  const fcl::Sphered* sphere_ptr =
-      dynamic_cast<const fcl::Sphered*>(object_ptr->collisionGeometry().get());
-  DRAKE_DEMAND(sphere_ptr != nullptr);
-  const double r = sphere_ptr->radius;
-  Sphere sphere(r);
-  // We arbitrarly choose to a coarse sphere approximation that has eight edges
-  // around the equator. The length of such an edge, is the length of the chord
-  // that spans 45 degrees (for a circle of radius r).
-  SoftGeometry geometry;
-  double edge_length = 2 * r * std::sin(M_PI / 8.0);
-  edge_length =
-      properties.GetPropertyOrDefault(kHydroGroup, kRezHint, edge_length);
-  geometry.mesh = std::make_unique<VolumeMesh<double>>(
-      MakeSphereVolumeMesh<double>(sphere, edge_length));
-
-  // Currently default to linear pressure with the given elastic_modulus (if it
-  // exists, or default value).
-  const double default_elastic_modulus = 1e8;
-  const double elastic_modulus = properties.GetPropertyOrDefault(
-      kHydroGroup, kElastic, default_elastic_modulus);
-  auto pressure = [elastic_modulus](double e) { return elastic_modulus * e; };
-  std::vector<double> p0_values;
-  for (const auto& v : geometry.mesh->vertices()) {
-    const Eigen::Vector3d& p_MV = v.r_MV();
-    const double p_MV_len = p_MV.norm();
-    p0_values.push_back(pressure(1.0 - p_MV_len / r));
-  }
-  geometry.p0 = std::make_unique<VolumeMeshFieldLinear<double, double>>(
-      "p0", move(p0_values), geometry.mesh.get());
-
-  return geometry;
-}
 
 /** The callback function for computing a hydroelastic contact surface between
  two arbitrary shapes.
@@ -160,51 +98,51 @@ bool Callback(fcl::CollisionObjectd* object_A_ptr,
       encoding_a.encoding(), encoding_b.encoding());
 
   if (can_collide) {
-    // TODO(SeanCurtis-TRI): This logic will be replaced by real logic that
-    //  makes more complex decisions about shapes rather than all of the hard-
-    //  coded hacks.
-    fcl::NODE_TYPE a_type = object_A_ptr->getNodeType();
-    fcl::NODE_TYPE b_type = object_B_ptr->getNodeType();
-
-    const bool valid =(a_type == fcl::GEOM_BOX && b_type == fcl::GEOM_SPHERE) ||
-        (a_type == fcl::GEOM_SPHERE && b_type == fcl::GEOM_BOX);
-    if (!valid) {
+    const HydroelasticType type_A =
+        data.geometries.hydroelastic_type(encoding_a.id());
+    const HydroelasticType type_B =
+        data.geometries.hydroelastic_type(encoding_b.id());
+    if (type_A == HydroelasticType::kUndefined ||
+        type_B == HydroelasticType::kUndefined) {
       throw std::logic_error(fmt::format(
-          "Can't compute a contact surface between geometries {} ({}) and "
-          "{} ({})",
-          to_string(encoding_a.id()), GetGeometryName(*object_A_ptr),
-          to_string(encoding_b.id()), GetGeometryName(*object_B_ptr)));
+          "Requested a contact surface between a pair of geometries without "
+          "hydroelastic representation for at least one shape: a {} {} with id "
+          "{} and a {} {} with id {}",
+          type_A, GetGeometryName(*object_A_ptr), encoding_a.id(), type_B,
+          GetGeometryName(*object_B_ptr), encoding_b.id()));
+    }
+    if (type_A == type_B) {
+      throw std::logic_error(fmt::format(
+          "Requested contact between two {} objects ({} with id "
+          "{}, {} with id {}); only rigid-soft pairs are currently supported",
+          type_A, GetGeometryName(*object_A_ptr), encoding_a.id(),
+          GetGeometryName(*object_B_ptr), encoding_b.id()));
     }
 
-    fcl::CollisionObjectd* object_box_ptr{};
-    fcl::CollisionObjectd* object_sphere_ptr{};
-    GeometryId box_id;
-    GeometryId sphere_id;
-    if (a_type == fcl::GEOM_BOX) {
-      object_box_ptr = object_A_ptr;
-      box_id = encoding_a.id();
-      object_sphere_ptr = object_B_ptr;
-      sphere_id = encoding_b.id();
-    } else {
-      object_box_ptr = object_B_ptr;
-      box_id = encoding_b.id();
-      object_sphere_ptr = object_A_ptr;
-      sphere_id = encoding_a.id();
-    }
+    const bool A_is_rigid = type_A == HydroelasticType::kRigid;
+    const GeometryId id_S = A_is_rigid ? encoding_b.id() : encoding_a.id();
+    const GeometryId id_R = A_is_rigid ? encoding_a.id() : encoding_b.id();
 
-    DRAKE_DEMAND(data.geometries.at(box_id).proximity_properties());
-    DRAKE_DEMAND(data.geometries.at(sphere_id).proximity_properties());
-    SurfaceMesh<double> box_mesh = MakeBoxMeshFromFcl(
-        object_box_ptr, *data.geometries.at(box_id).proximity_properties());
-    SoftGeometry soft_sphere = MakeSphereFromFcl(
-        object_sphere_ptr,
-        *data.geometries.at(sphere_id).proximity_properties());
+    const math::RigidTransform<T>& X_WS(data.X_WGs.at(id_S));
+    const math::RigidTransform<T>& X_WR(data.X_WGs.at(id_R));
 
+    // TODO(SeanCurtis-TRI): We are currently assuming that *everything* is a
+    //  mesh. When rigid and compliant half spaces are fully supported modify
+    //  this.
+    const SoftGeometry& soft = data.geometries.soft_geometry(id_S);
+    const VolumeMeshField<double, double>& field_S = soft.pressure_field();
+    const RigidGeometry& rigid = data.geometries.rigid_geometry(id_R);
+    const SurfaceMesh<double>& mesh_R = rigid.mesh();
+
+    // TODO(SeanCurtis-TRI): There are multiple heap allocations implicit in
+    // this (resizing vector, constructing mesh and pressure field), this *may*
+    // prove to be too expensive to be in the inner loop of the simulation.
+    // Keep an eye on this.
     std::unique_ptr<ContactSurface<T>> surface =
         mesh_intersection::ComputeContactSurfaceFromSoftVolumeRigidSurface(
-            sphere_id, *soft_sphere.p0, data.X_WGs.at(sphere_id), box_id,
-            box_mesh, data.X_WGs.at(box_id));
+            id_S, field_S, X_WS, id_R, mesh_R, X_WR);
 
+    DRAKE_DEMAND(surface->id_M() < surface->id_N());
     data.surfaces.emplace_back(std::move(*surface));
   }
   // Tell the broadphase to keep searching.

--- a/geometry/proximity/hydroelastic_internal.cc
+++ b/geometry/proximity/hydroelastic_internal.cc
@@ -1,0 +1,272 @@
+#include "drake/geometry/proximity/hydroelastic_internal.h"
+
+#include <limits>
+#include <vector>
+
+#include <fmt/format.h>
+
+#include "drake/geometry/proximity/make_box_mesh.h"
+#include "drake/geometry/proximity/make_sphere_mesh.h"
+#include "drake/geometry/proximity/volume_to_surface_mesh.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace hydroelastic {
+
+using Eigen::Vector3d;
+using std::make_unique;
+using std::move;
+using std::vector;
+
+std::ostream& operator<<(std::ostream& out, const HydroelasticType& type) {
+  switch (type) {
+    case HydroelasticType::kUndefined:
+      out << "undefined";
+      break;
+    case HydroelasticType::kRigid:
+      out << "rigid";
+      break;
+    case HydroelasticType::kSoft:
+      out << "soft";
+      break;
+    default:
+      DRAKE_UNREACHABLE();
+  }
+  return out;
+}
+
+SoftGeometry& SoftGeometry::operator=(const SoftGeometry& g) {
+  if (this == &g) return *this;
+
+  auto mesh = make_unique<VolumeMesh<double>>(g.mesh());
+  // We can't simply copy the mesh field; the copy must contain a pointer to the
+  // new mesh. So, we use CloneAndSetMesh() instead.
+  auto pressure = g.pressure_field().CloneAndSetMesh(mesh.get());
+  geometry_ = SoftMesh{move(mesh), move(pressure)};
+
+  return *this;
+}
+
+HydroelasticType Geometries::hydroelastic_type(GeometryId id) const {
+  auto iter = supported_geometries_.find(id);
+  if (iter != supported_geometries_.end()) return iter->second;
+  return HydroelasticType::kUndefined;
+}
+
+void Geometries::RemoveGeometry(GeometryId id) {
+  supported_geometries_.erase(id);
+  soft_geometries_.erase(id);
+  rigid_geometries_.erase(id);
+}
+
+void Geometries::MaybeAddGeometry(const Shape& shape, GeometryId id,
+                                  const ProximityProperties& properties) {
+  const HydroelasticType type = Classify(properties);
+  if (type != HydroelasticType::kUndefined) {
+    ReifyData data{type, id, properties};
+    shape.Reify(this, &data);
+  }
+}
+
+void Geometries::ImplementGeometry(const Sphere& sphere, void* user_data) {
+  MakeShape(sphere, *reinterpret_cast<ReifyData*>(user_data));
+}
+
+void Geometries::ImplementGeometry(const Cylinder& cylinder, void* user_data) {
+  MakeShape(cylinder, *reinterpret_cast<ReifyData*>(user_data));
+}
+
+void Geometries::ImplementGeometry(const HalfSpace& half_space,
+                                   void* user_data) {
+  MakeShape(half_space, *reinterpret_cast<ReifyData*>(user_data));
+}
+
+void Geometries::ImplementGeometry(const Box& box, void* user_data) {
+  MakeShape(box, *reinterpret_cast<ReifyData*>(user_data));
+}
+
+void Geometries::ImplementGeometry(const Capsule& capsule, void* user_data) {
+  MakeShape(capsule, *reinterpret_cast<ReifyData*>(user_data));
+}
+
+void Geometries::ImplementGeometry(const Ellipsoid& ellipsoid,
+                                   void* user_data) {
+  MakeShape(ellipsoid, *reinterpret_cast<ReifyData*>(user_data));
+}
+
+void Geometries::ImplementGeometry(const Mesh& mesh, void* user_data) {
+  MakeShape(mesh, *reinterpret_cast<ReifyData*>(user_data));
+}
+
+void Geometries::ImplementGeometry(const Convex& convex, void* user_data) {
+  MakeShape(convex, *reinterpret_cast<ReifyData*>(user_data));
+}
+
+template <typename ShapeType>
+void Geometries::MakeShape(const ShapeType& shape, const ReifyData& data) {
+  switch (data.type) {
+    case HydroelasticType::kRigid: {
+      auto hydro_geometry = MakeRigidRepresentation(shape, data.properties);
+      if (hydro_geometry) AddGeometry(data.id, move(*hydro_geometry));
+    } break;
+    case HydroelasticType::kSoft: {
+      auto hydro_geometry = MakeSoftRepresentation(shape, data.properties);
+      if (hydro_geometry) AddGeometry(data.id, move(*hydro_geometry));
+    } break;
+    default:
+      // kUndefined requires no action.
+      break;
+  }
+}
+
+void Geometries::AddGeometry(GeometryId id, SoftGeometry geometry) {
+  DRAKE_DEMAND(hydroelastic_type(id) == HydroelasticType::kUndefined);
+  supported_geometries_[id] = HydroelasticType::kSoft;
+  soft_geometries_.insert({id, move(geometry)});
+}
+
+void Geometries::AddGeometry(GeometryId id, RigidGeometry geometry) {
+  DRAKE_DEMAND(hydroelastic_type(id) == HydroelasticType::kUndefined);
+  supported_geometries_[id] = HydroelasticType::kRigid;
+  rigid_geometries_.insert({id, move(geometry)});
+}
+
+HydroelasticType Classify(const ProximityProperties& props) {
+  // Presence of the hydroelastic group triggers an attempt to represent it.
+  if (props.HasGroup(kHydroGroup)) {
+    if (props.HasProperty(kMaterialGroup, kElastic)) {
+      const double elastic_modulus =
+          props.GetProperty<double>(kMaterialGroup, kElastic);
+      if (std::isinf(elastic_modulus)) {
+        return HydroelasticType::kRigid;
+      } else if (elastic_modulus <= 0) {
+        throw std::logic_error(
+            fmt::format("Properties contain a bad value for the ('{}', '{}') "
+                        "property: {}; the value must be positive",
+                        kMaterialGroup, kElastic, elastic_modulus));
+      } else {
+        return HydroelasticType::kSoft;
+      }
+    } else {
+      throw std::logic_error(
+          fmt::format("Properties contain the '{}' group but is missing the "
+                      "('{}', '{}') property; compliance cannot be determined",
+                      kHydroGroup, kMaterialGroup, kElastic));
+    }
+  }
+  return HydroelasticType::kUndefined;
+}
+
+// Validator interface for use with extracting valid properties. It is
+// instantiated with shape (e.g., "Sphere", "Box", etc.) and compliance (i.e.,
+// "rigid" or "soft") strings (to help give intelligible error messages) and
+// then attempts to extract a typed value from a set of proximity properties --
+// spewing meaningful error messages based on absence, type mis-match, and
+// invalid values.
+template <typename ValueType>
+class Validator {
+ public:
+  Validator(const char* shape_name, const char* compliance)
+      : shape_name_(shape_name), compliance_(compliance) {}
+
+  virtual ~Validator() = default;
+
+  // Extract an arbitrary property from the proximity properties. Throws a
+  // consistent error message in the case of missing or mis-typed properties.
+  // Relies on the ValidateValue() method to validate the value.
+  const ValueType& Extract(const ProximityProperties& props,
+                           const char* group_name, const char* property_name) {
+    const std::string full_property_name =
+        fmt::format("('{}', '{}')", group_name, property_name);
+    if (!props.HasProperty(group_name, property_name)) {
+      throw std::logic_error(
+          fmt::format("Cannot create {} {}; missing the {} property",
+                      compliance(), shape_name(), full_property_name));
+    }
+    const auto& value = props.GetProperty<ValueType>(group_name, property_name);
+    ValidateValue(value, full_property_name);
+    return value;
+  }
+
+  const char* shape_name() const { return shape_name_; }
+  const char* compliance() const { return compliance_; }
+
+ protected:
+  // Does the work of validating the given value. Sub-classes should throw if
+  // the provided value is not valid. The first parameter is the value to
+  // validate; the second is the full name of the property.
+  virtual void ValidateValue(const ValueType&, const std::string&) const {}
+
+ private:
+  const char* shape_name_{};
+  const char* compliance_{};
+};
+
+// Validator that extracts *positive doubles*.
+class PositiveDouble : public Validator<double> {
+ public:
+  PositiveDouble(const char* shape_name, const char* compliance)
+      : Validator<double>(shape_name, compliance) {}
+
+ protected:
+  void ValidateValue(const double& value,
+                     const std::string& property) const override {
+    if (value <= 0) {
+      throw std::logic_error(
+          fmt::format("Cannot create {} {}; the {} property must be positive",
+                      compliance(), shape_name(), property));
+    }
+  }
+};
+
+std::optional<RigidGeometry> MakeRigidRepresentation(
+    const Sphere& sphere, const ProximityProperties& props) {
+  const double edge_length =
+      PositiveDouble("Sphere", "rigid").Extract(props, kHydroGroup, kRezHint);
+  SurfaceMesh<double> mesh = MakeSphereSurfaceMesh<double>(sphere, edge_length);
+
+  return RigidGeometry(move(mesh));
+}
+
+std::optional<RigidGeometry> MakeRigidRepresentation(
+    const Box& box, const ProximityProperties& props) {
+  const double edge_length =
+      PositiveDouble("Box", "rigid").Extract(props, kHydroGroup, kRezHint);
+  SurfaceMesh<double> mesh = MakeBoxSurfaceMesh<double>(box, edge_length);
+
+  return RigidGeometry(move(mesh));
+}
+
+std::optional<SoftGeometry> MakeSoftRepresentation(
+    const Sphere& sphere, const ProximityProperties& props) {
+  // First, create the mesh.
+  const double edge_length =
+      PositiveDouble("Sphere", "soft").Extract(props, kHydroGroup, kRezHint);
+  auto mesh = make_unique<VolumeMesh<double>>(
+      MakeSphereVolumeMesh<double>(sphere, edge_length));
+
+  // E is the elastic modulus.
+  const double E =
+      PositiveDouble("Sphere", "soft").Extract(props, kMaterialGroup, kElastic);
+
+  // Second, compute the penetration extent and gradient fields.
+  const double r = sphere.get_radius();
+  std::vector<double> p_values;
+  p_values.reserve(mesh->num_vertices());
+  for (const auto& v : mesh->vertices()) {
+    const Vector3d& p_MV = v.r_MV();
+    const double p_MV_len = p_MV.norm();
+    const double extent = 1.0 - p_MV_len / r;
+    p_values.push_back(E * extent);
+  }
+  auto pressure = make_unique<VolumeMeshFieldLinear<double, double>>(
+      "pressure", move(p_values), mesh.get());
+
+  return SoftGeometry(move(mesh), move(pressure));
+}
+
+}  // namespace hydroelastic
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/hydroelastic_internal.h
+++ b/geometry/proximity/hydroelastic_internal.h
@@ -1,0 +1,276 @@
+#pragma once
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "drake/common/eigen_types.h"
+#include "drake/common/text_logging.h"
+#include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/geometry_roles.h"
+#include "drake/geometry/proximity/surface_mesh.h"
+#include "drake/geometry/proximity/volume_mesh_field.h"
+#include "drake/geometry/proximity_properties.h"
+#include "drake/geometry/shape_specification.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace hydroelastic {
+
+// TODO(SeanCurtis-TRI): Update this to have an additional classification: kBoth
+//  when we have the need from the algorithm. For example: when we have two
+//  very stiff objects, we'd want to process them as soft. But when one
+//  very stiff and one very soft object interact, it might make sense to
+//  consider the stiff object as effectively rigid and simplify the computation.
+//  In this case, the object would get two representations.
+/** Classification of the type of representation a shape has for the
+ hydroelastic contact model: rigid or soft.  */
+enum class HydroelasticType {
+  kUndefined,
+  kRigid,
+  kSoft
+};
+
+/** Streaming operator for writing hydroelastic type to output stream.  */
+std::ostream& operator<<(std::ostream& out, const HydroelasticType& type);
+
+// TODO(SeanCurtis-TRI): When we do soft-soft contact, we'll need ∇p̃(e) as well.
+//  ∇p̃(e) is piecewise constant -- one ℜ³ vector per tetrahedron.
+/** Defines a soft mesh -- a mesh and its linearized pressure field, p̃(e).  */
+struct SoftMesh {
+  std::unique_ptr<VolumeMesh<double>> mesh;
+  std::unique_ptr<VolumeMeshField<double, double>> pressure;
+};
+
+/** Definition of a soft geometry for hydroelastic implementations. Today, the
+ soft geometry is a soft _mesh_. In the future it will include other soft
+ representations (e.g., untessellated half space).  */
+class SoftGeometry {
+ public:
+  /** Constructs a soft geometry from a soft mesh.  */
+  SoftGeometry(
+      std::unique_ptr<VolumeMesh<double>> mesh,
+      std::unique_ptr<VolumeMeshField<double, double>> pressure)
+      : geometry_(SoftMesh{std::move(mesh), std::move(pressure)}) {}
+
+  SoftGeometry(const SoftGeometry& g) { *this = g; }
+  SoftGeometry& operator=(const SoftGeometry& g);
+  SoftGeometry(SoftGeometry&&) = default;
+  SoftGeometry& operator=(SoftGeometry&&) = default;
+
+  /** Returns a reference to the volume mesh.  */
+  const VolumeMesh<double>& mesh() const {
+    return *geometry_.mesh;
+  }
+
+  /** Returns a reference to the mesh's linearized pressure field.  */
+  const VolumeMeshField<double, double>& pressure_field() const {
+    return *geometry_.pressure;
+  }
+
+ private:
+  SoftMesh geometry_;
+};
+
+/** The base representation of rigid geometries. A rigid geometry is represented
+ with a SurfaceMesh.  */
+class RigidGeometry {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(RigidGeometry)
+
+  /** Constructs a rigid representation from the given surface mesh.  */
+  explicit RigidGeometry(SurfaceMesh<double> mesh) : mesh_(std::move(mesh)) {}
+
+  /** Returns a reference to the surface mesh.  */
+  const SurfaceMesh<double>& mesh() const { return mesh_; }
+
+ private:
+  SurfaceMesh<double> mesh_;
+};
+
+/** This class stores all instantiated hydroelastic representations of declared
+ geometry. They are keyed by the geometry's global GeometryId.
+
+ In order for a geometry with id `g_id` to have a representation in this
+ collection, it must:
+
+   - be declared via calling MaybeAddGeometry();
+   - the infrastructure must support the type of representation for that
+     particular geometry type;
+   - it must have a valid set of properties to fully specify the representation;
+   - the geometry cannot have been subsequently removed via a call to
+     RemoveGeometry().
+
+ If two geometries are in contact, in order to produce the corresponding
+ ContactSurface, both ids must have a valid representation in this set.  */
+class Geometries final : public ShapeReifier {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Geometries);
+
+  Geometries() = default;
+
+  /** Reports the hydroelastic representation type for the given id. The
+   following invariants should always hold:
+
+     - If HydroelasticType::kUndefined is returned, there is no representation
+       for that id.
+     - If HydroelasticType::kRigid is returned, there is a rigid geometry
+       associated with that id and calling rigid_geometry() will return a
+       valid RigidGeometry.
+     - If HydroelasticType::kSoft is returned, there is a soft geometry
+       associated with that id and calling soft_geometry() will return a valid
+       SoftGeometry.  */
+  HydroelasticType hydroelastic_type(GeometryId id) const;
+
+  /** Returns the representation of the soft geometry with the given `id`.
+   @pre hydroelastic_type(id) returns HydroelasticType::kSoft.  */
+  const SoftGeometry& soft_geometry(GeometryId id) const {
+    DRAKE_DEMAND(hydroelastic_type(id) == HydroelasticType::kSoft);
+    return soft_geometries_.at(id);
+  }
+
+  /** Returns the representation of the rigid geometry with the given `id`.
+   @pre hydroelastic_type(id) returns HydroelasticType::kRigid.  */
+  const RigidGeometry& rigid_geometry(GeometryId id) const {
+    DRAKE_DEMAND(hydroelastic_type(id) == HydroelasticType::kRigid);
+    return rigid_geometries_.at(id);
+  }
+
+  /** Removes the geometry (if it has a hydroelastic representation).  */
+  void RemoveGeometry(GeometryId id);
+
+  /** Examines the given shape and properties, adding a hydroelastic
+   representation as indicated by the `properties` and supported by the current
+   hydroelastic infrastructure. No exception is thrown if the given shape is
+   not supported in the current infrastructure. However, if it *is* supported,
+   but the properties are malformed, an exception will be thrown.
+
+   @param shape         The shape to possibly represent.
+   @param id            The unique identifier for the geometry.
+   @param properties    The proximity properties which will determine if a
+                        hydroelastic representation is requested.
+   @throws std::logic_error if the shape is a supported type but the properties
+                            are malformed.
+   @pre There is no previous representation associated with id.  */
+  void MaybeAddGeometry(const Shape& shape, GeometryId id,
+                        const ProximityProperties& properties);
+
+ private:
+  // Data to be used during reification. It is passed as the `user_data`
+  // parameter in the ImplementGeometry API.
+  struct ReifyData {
+    HydroelasticType type;
+    GeometryId id;
+    const ProximityProperties& properties;
+  };
+
+  void ImplementGeometry(const Sphere& sphere, void* user_data) override;
+  void ImplementGeometry(const Cylinder& cylinder, void* user_data) override;
+  void ImplementGeometry(const HalfSpace&, void* user_data) override;
+  void ImplementGeometry(const Box& box, void* user_data) override;
+  void ImplementGeometry(const Capsule& capsule, void* user_data) override;
+  void ImplementGeometry(const Ellipsoid& ellipsoid, void* user_data) override;
+  void ImplementGeometry(const Mesh&, void*) override;
+  void ImplementGeometry(const Convex& convex, void* user_data) override;
+
+  template <typename ShapeType>
+  void MakeShape(const ShapeType& shape, const ReifyData& data);
+
+  // Adds a representation of the soft geometry with the given `id`.
+  // @pre there is no previous representation associated with `id`.
+  void AddGeometry(GeometryId id, SoftGeometry field);
+
+  // Adds a representation of the rigid geometry with the given `id`.
+  // @pre there is no previous representation associated with `id`.
+  void AddGeometry(GeometryId id, RigidGeometry mesh);
+
+  // The ids of all geometries that have a hydroelastic representation and
+  // the type of representation.
+  std::unordered_map<GeometryId, HydroelasticType> supported_geometries_;
+
+  // The representations of all soft geometries.
+  std::unordered_map<GeometryId, SoftGeometry> soft_geometries_;
+
+  // The representations of all rigid geometries.
+  std::unordered_map<GeometryId, RigidGeometry> rigid_geometries_;
+};
+
+/** Assesses the properties to determine *if* the geometry with the given
+ `properties` requires a geometric representation and, if so, whether that
+ representation is soft or rigid.
+
+ The conditions are as follows:
+
+   - If `properties` does not have the group "hydroelastic", then it requires no
+     hydroelastic representation.
+   - Otherwise, its compliance is based on the (material, elastic modulus)
+     property. The disposition based on the property is:
+       - absent --> error
+       - infinity --> rigid
+       - greater than zero and less than infinity --> soft
+       - less than or equal to zero --> error
+
+ @throws std::logic_error if any of the above error conditions are met.  */
+HydroelasticType Classify(const ProximityProperties& properties);
+
+/** @name Creating hydroelastic representations of shapes
+
+ By default *no* shapes are supported with hydroelastic representations.
+ Attempting to do so will print a warning to the Drake log and these functions
+ will return std::nullopt.
+
+ For every shape that *is* supported, an overload of this method on that shape
+ type is declared below.  */
+//@{
+
+/** Generic interface for handling unsupported rigid Shapes. Unsupported
+ geometries will return a std::nullopt.  */
+template <typename Shape>
+std::optional<RigidGeometry> MakeRigidRepresentation(
+    const Shape& shape, const ProximityProperties&) {
+  static const logging::Warn log_once(
+        "Rigid {} shapes are not currently supported for hydroelastic "
+        "contact; registration is allowed, but an error will be thrown "
+        "during contact.",
+        ShapeName(shape));
+  return {};
+}
+
+/** Rigid sphere support. Requires the ('hydroelastic', 'resolution_hint')
+ property.  */
+std::optional<RigidGeometry> MakeRigidRepresentation(
+    const Sphere& sphere, const ProximityProperties& props);
+
+/** Rigid box support. Requires the ('hydroelastic', 'resolution_hint')
+ property.  */
+std::optional<RigidGeometry> MakeRigidRepresentation(
+    const Box& box, const ProximityProperties& props);
+
+
+/** Generic interface for handling unsupported soft Shapes. Unsupported
+ geometries will return a std::nullopt.  */
+template <typename Shape>
+std::optional<SoftGeometry> MakeSoftRepresentation(
+    const Shape& shape, const ProximityProperties&) {
+  static const logging::Warn log_once(
+        "Soft {} shapes are not currently supported for hydroelastic contact; "
+        "registration is allowed, but an error will be thrown during contact.",
+        ShapeName(shape));
+  return {};
+}
+
+/** Creates a soft sphere (assuming the proximity properties has sufficient
+ information). Requires the ('hydroelastic', 'resolution_hint') and
+ ('material', 'elastic_modulus') properties.  */
+std::optional<SoftGeometry> MakeSoftRepresentation(
+    const Sphere& sphere, const ProximityProperties& props);
+
+//@}
+
+}  // namespace hydroelastic
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/proximity_utilities.cc
+++ b/geometry/proximity/proximity_utilities.cc
@@ -4,11 +4,6 @@ namespace drake {
 namespace geometry {
 namespace internal {
 
-std::ostream& operator<<(std::ostream& out, const ShapeName& name) {
-  out << name.string();
-  return out;
-}
-
 std::string GetGeometryName(const fcl::CollisionObjectd& object) {
   switch (object.collisionGeometry()->getNodeType()) {
     case fcl::BV_UNKNOWN:

--- a/geometry/proximity/proximity_utilities.h
+++ b/geometry/proximity/proximity_utilities.h
@@ -15,58 +15,9 @@ namespace drake {
 namespace geometry {
 namespace internal {
 
-/** Class that reports the name of the type of shape being reified (e.g.,
- Sphere, Box, etc.)  */
-class ShapeName final : public ShapeReifier {
- public:
-  ShapeName() = default;
-
-  /** Constructs a %ShapeName from the given `shape` such that `string()`
-   already contains the string representation of `shape`.  */
-  explicit ShapeName(const Shape& shape) {
-    shape.Reify(this);
-  }
-
-  /** @name  Implementation of ShapeReifier interface  */
-  //@{
-  using ShapeReifier::ImplementGeometry;
-  void ImplementGeometry(const Sphere&, void*) final {
-    string_ = "Sphere";
-  }
-  void ImplementGeometry(const Cylinder&, void*) final {
-    string_ = "Cylinder";
-  }
-  void ImplementGeometry(const HalfSpace&, void*) final {
-    string_ = "HalfSpace";
-  }
-  void ImplementGeometry(const Box&, void*) final {
-    string_ = "Box";
-  }
-  void ImplementGeometry(const Capsule&, void*) final {
-    string_ = "Capsule";
-  }
-  void ImplementGeometry(const Ellipsoid&, void*) final {
-    string_ = "Ellipsoid";
-  }
-  void ImplementGeometry(const Mesh&, void*) final {
-    string_ = "Mesh";
-  }
-  void ImplementGeometry(const Convex&, void*) final {
-    string_ = "Convex";
-  }
-
-  //@}
-
-  /** Returns the name of the last shape reified. Empty if no shape has been
-   reified yet.  */
-  std::string string() const { return string_; }
-
- private:
-  std::string string_;
-};
-
-/** @relates ShapeName */
-std::ostream& operator<<(std::ostream& out, const ShapeName& name);
+// TODO(SeanCurtis-TRI): Given the dependencies on fcl for this file, the name
+//  should reflect it so that it doesn't get included in files that will
+//  eventually get included in the public API.
 
 // TODO(SeanCurtis-TRI): Snake case this name.
 /** Calculates an absolute tolerance value conditioned to a problem's

--- a/geometry/proximity/test/hydroelastic_internal_test.cc
+++ b/geometry/proximity/test/hydroelastic_internal_test.cc
@@ -1,0 +1,511 @@
+#include "drake/geometry/proximity/hydroelastic_internal.h"
+
+#include <functional>
+#include <limits>
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_no_throw.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/proximity_properties.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace hydroelastic {
+namespace {
+
+using Eigen::Vector3d;
+using std::function;
+
+// Tests the simple public API of the hydroelastic::Geometries: adding
+// geometries and querying the data stored.
+GTEST_TEST(Hydroelastic, GeometriesPopulationAndQuery) {
+  Geometries geometries;
+
+  // Ids that haven't been added report as undefined.
+  GeometryId rigid_id = GeometryId::get_new_id();
+  ProximityProperties rigid_properties;
+  rigid_properties.AddProperty(kMaterialGroup, kElastic,
+                               std::numeric_limits<double>::infinity());
+  AddRigidHydroelasticProperties(1.0, &rigid_properties);
+
+  GeometryId soft_id = GeometryId::get_new_id();
+  ProximityProperties soft_properties;
+  soft_properties.AddProperty(kMaterialGroup, kElastic, 1e8);
+  AddSoftHydroelasticProperties(1.0, &soft_properties);
+
+  GeometryId bad_id = GeometryId::get_new_id();
+  EXPECT_EQ(geometries.hydroelastic_type(rigid_id),
+            HydroelasticType::kUndefined);
+  EXPECT_EQ(geometries.hydroelastic_type(soft_id),
+            HydroelasticType::kUndefined);
+  EXPECT_EQ(geometries.hydroelastic_type(bad_id), HydroelasticType::kUndefined);
+
+  // Once added, they report the appropriate type.
+  geometries.MaybeAddGeometry(Sphere(0.5), soft_id, soft_properties);
+  EXPECT_EQ(geometries.hydroelastic_type(soft_id),
+            HydroelasticType::kSoft);
+  geometries.MaybeAddGeometry(Sphere(0.5), rigid_id, rigid_properties);
+  EXPECT_EQ(geometries.hydroelastic_type(rigid_id), HydroelasticType::kRigid);
+
+  // Ids that report the correct type, successfully access the appropriate
+  // representation.
+  DRAKE_EXPECT_NO_THROW(geometries.soft_geometry(soft_id));
+  DRAKE_EXPECT_NO_THROW(geometries.rigid_geometry(rigid_id));
+}
+
+GTEST_TEST(Hydroelastic, RemoveGeometry) {
+  Geometries geometries;
+
+  // Add a rigid geometry.
+  const GeometryId rigid_id = GeometryId::get_new_id();
+  ProximityProperties rigid_properties;
+  rigid_properties.AddProperty(kMaterialGroup, kElastic,
+                               std::numeric_limits<double>::infinity());
+  AddRigidHydroelasticProperties(1.0, &rigid_properties);
+  geometries.MaybeAddGeometry(Sphere(0.5), rigid_id, rigid_properties);
+  ASSERT_EQ(geometries.hydroelastic_type(rigid_id), HydroelasticType::kRigid);
+
+  // Add a soft geometry.
+  const GeometryId soft_id = GeometryId::get_new_id();
+  ProximityProperties soft_properties;
+  soft_properties.AddProperty(kMaterialGroup, kElastic, 1e8);
+  AddSoftHydroelasticProperties(1.0, &soft_properties);
+  geometries.MaybeAddGeometry(Sphere(0.5), soft_id, soft_properties);
+  ASSERT_EQ(geometries.hydroelastic_type(soft_id), HydroelasticType::kSoft);
+
+  // Case 1: Remove a geometry that has no representation is a no-op.
+  const GeometryId bad_id = GeometryId::get_new_id();
+  ASSERT_EQ(geometries.hydroelastic_type(bad_id), HydroelasticType::kUndefined);
+  DRAKE_EXPECT_NO_THROW(geometries.RemoveGeometry(bad_id));
+  ASSERT_EQ(geometries.hydroelastic_type(bad_id), HydroelasticType::kUndefined);
+  ASSERT_EQ(geometries.hydroelastic_type(rigid_id), HydroelasticType::kRigid);
+  ASSERT_EQ(geometries.hydroelastic_type(soft_id), HydroelasticType::kSoft);
+
+  // Case 2: Removing a rigid geometry has no effect on anything else. We copy
+  // the geometries to make sure that there is always something else to remain
+  // untouched.
+  {
+    Geometries copy{geometries};
+    DRAKE_EXPECT_NO_THROW(copy.RemoveGeometry(rigid_id));
+    ASSERT_EQ(copy.hydroelastic_type(rigid_id), HydroelasticType::kUndefined);
+    ASSERT_EQ(copy.hydroelastic_type(soft_id), HydroelasticType::kSoft);
+  }
+
+  // Case 3: Removing a soft geometry has no effect on anything else. We copy
+  // the geometries to make sure that there is always something else to remain
+  // untouched.
+  {
+    Geometries copy{geometries};
+    DRAKE_EXPECT_NO_THROW(copy.RemoveGeometry(soft_id));
+    ASSERT_EQ(copy.hydroelastic_type(soft_id), HydroelasticType::kUndefined);
+    ASSERT_EQ(copy.hydroelastic_type(rigid_id), HydroelasticType::kRigid);
+  }
+}
+
+// Tests the classification of proximity properties.
+GTEST_TEST(Hydroelastic, Classify) {
+  // Case: props with no declared "hydroelastic" group is, by definition, an
+  // unclassified hydroelastic type.
+  EXPECT_EQ(Classify(ProximityProperties()), HydroelasticType::kUndefined);
+
+  // Case: Presence of elastic modulus is insufficient to trigger hydroelastic.
+  {
+    ProximityProperties props;
+    props.AddProperty(kMaterialGroup, kElastic, 1e8);
+    EXPECT_EQ(Classify(props), HydroelasticType::kUndefined);
+  }
+
+  // The *presence* of the kHydroGroup will trigger the attempt to classify a
+  // hydroelastic representation. This uses a property that has no bearing on
+  // that classification to be that trigger.
+  ProximityProperties trigger_hydro;
+  trigger_hydro.AddProperty(kHydroGroup, "dummy", 1);
+
+  // Case: missing elastic modulus is a classification error.
+  {
+    DRAKE_EXPECT_THROWS_MESSAGE(Classify(trigger_hydro), std::logic_error,
+        "Properties .+ missing .+ property; compliance cannot be determined");
+  }
+
+  // Case: Infinite "elastic_modulus" should report as rigid.
+  {
+    ProximityProperties props(trigger_hydro);
+    props.AddProperty(kMaterialGroup, kElastic,
+                      std::numeric_limits<double>::infinity());
+    EXPECT_EQ(Classify(props), HydroelasticType::kRigid);
+  }
+
+  // Case: Really, really huge, but not infinite "elastic modulus" should report
+  // as soft.
+  {
+    ProximityProperties props(trigger_hydro);
+    props.AddProperty(kMaterialGroup, kElastic,
+                      std::numeric_limits<double>::max());
+    EXPECT_EQ(Classify(props), HydroelasticType::kSoft);
+  }
+
+  // Case: Microscopically small elastic modulus should report as soft.
+  {
+    ProximityProperties props(trigger_hydro);
+    props.AddProperty(kMaterialGroup, kElastic, 1e-14);
+    EXPECT_EQ(Classify(props), HydroelasticType::kSoft);
+  }
+
+  // Case: Zero elastic modulus should throw an error.
+  {
+    ProximityProperties props(trigger_hydro);
+    props.AddProperty(kMaterialGroup, kElastic, 0.0);
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        Classify(props), std::logic_error,
+        fmt::format(".+bad value for .+'{}'.*", kElastic));
+  }
+
+  // Case: Negative elastic modulus should throw an error.
+  {
+    ProximityProperties props(trigger_hydro);
+    props.AddProperty(kMaterialGroup, kElastic, -1.0);
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        Classify(props), std::logic_error,
+        fmt::format(".+bad value for .+'{}'.*", kElastic));
+  }
+}
+
+class HydroelasticRigidGeometryTest : public ::testing::Test {
+ protected:
+  /** Creates a simple set of properties for generating rigid geometry. */
+  ProximityProperties rigid_properties(double edge_length = 0.1) const {
+    ProximityProperties properties;
+    AddRigidHydroelasticProperties(edge_length, &properties);
+    return properties;
+  }
+};
+
+// TODO(SeanCurtis-TRI): As new shape specifications are added, they are
+//  implicitly unsupported and should be added here (and in
+//  UnsupportedSofthapes). I'm particularly thinking of capsule and ellipsoid.
+// Smoke test for shapes that are *known* to be unsupported as rigid objects.
+// NOTE: This will spew warnings to the log.
+TEST_F(HydroelasticRigidGeometryTest, UnsupportedRigidShapes) {
+  ProximityProperties props = rigid_properties();
+
+  EXPECT_EQ(MakeRigidRepresentation(Cylinder(1, 1), props), std::nullopt);
+
+  EXPECT_EQ(MakeRigidRepresentation(Capsule(1, 1), props), std::nullopt);
+
+  EXPECT_EQ(MakeRigidRepresentation(Ellipsoid(1, 2, 3), props), std::nullopt);
+
+  EXPECT_EQ(MakeRigidRepresentation(HalfSpace(), props), std::nullopt);
+
+  // Note: the file name doesn't have to be valid for this (and the Mesh) test.
+  const std::string obj = "drake/geometry/proximity/test/no_such_files.obj";
+  EXPECT_EQ(MakeRigidRepresentation(Convex(obj, 1.0), props), std::nullopt);
+
+  EXPECT_EQ(MakeRigidRepresentation(Mesh(obj, 1.0), props), std::nullopt);
+}
+
+// Confirm support for a rigid Sphere. Tests that a hydroelastic representation
+// is made, and samples the representation to look for evidence of it being the
+// *right* representation.
+TEST_F(HydroelasticRigidGeometryTest, Sphere) {
+  const double radius = 0.5;
+  Sphere sphere_spec(radius);
+
+  ProximityProperties props = rigid_properties(0.5);
+  std::optional<RigidGeometry> sphere =
+      MakeRigidRepresentation(sphere_spec, props);
+  EXPECT_NE(sphere, std::nullopt);
+
+  const SurfaceMesh<double>& mesh = sphere->mesh();
+  for (SurfaceVertexIndex v(0); v < mesh.num_vertices(); ++v) {
+    ASSERT_NEAR(mesh.vertex(v).r_MV().norm(), radius, 1e-15);
+  }
+}
+
+// Confirm support for a rigid Box. Tests that a hydroelastic representation
+// is made, and samples the representation to look for evidence of it being the
+// *right* representation.
+TEST_F(HydroelasticRigidGeometryTest, Box) {
+  const double edge_len = 0.5;
+  // Pick a characteristic length *larger* than the box dimensions so that
+  // I only get 8 vertices - one at each corner. This is merely evidence that
+  // the box method is called -- we rely on tests of that functionality to
+  // create more elaborate meshes with smaller edge lengths.
+  ProximityProperties props = rigid_properties(1.5 * edge_len);
+
+  std::optional<RigidGeometry> box =
+      MakeRigidRepresentation(Box(edge_len, edge_len, edge_len), props);
+  EXPECT_NE(box, std::nullopt);
+
+  const SurfaceMesh<double>& mesh = box->mesh();
+  EXPECT_EQ(mesh.num_vertices(), 8);
+  // Because it is a cube centered at the origin, the distance from the origin
+  // to each vertex should be sqrt(3) * edge_len / 2.
+  const double expecte_dist = std::sqrt(3) * edge_len / 2;
+  for (SurfaceVertexIndex v(0); v < mesh.num_vertices(); ++v) {
+    ASSERT_NEAR(mesh.vertex(v).r_MV().norm(), expecte_dist, 1e-15);
+  }
+}
+
+// Template magic to instantiate a particular kind of shape at compile time.
+template <typename ShapeType>
+ShapeType make_default_shape() {
+  throw std::logic_error(
+      "Running Hydroelastic*GeometryErrorTests for an unsupported shape "
+      "type");
+}
+
+template <>
+Sphere make_default_shape<Sphere>() {
+  return Sphere(0.5);
+}
+
+template <>
+Box make_default_shape<Box>() {
+  return Box(0.5, 1.25, 3.5);
+}
+
+// Boilerplate for testing error conditions relating to properties. Its purpose
+// is to test that the `Make*Representation` (either "Rigid" or "Soft")
+// family of functions correctly validate all required properties. A property
+// value can be wrong for one of three reasons:
+//
+//   - Missing property
+//   - Wrong type for property
+//   - Invalid value (maybe)
+//
+// This is sufficiently generic to test both kinds of geometry (rigid and soft)
+// based on any shape, for a property of any type. It confirms that properly
+// formatted errors are emitted in all cases.
+//
+// Not all properties validate invalid values. It might simply be treated as a
+// black box. The third error condition is only handled if an example "bad"
+// value is provided (see `bad_value` below).
+//
+// @param shape_spec     The shape from which we attempt to create a hydro-
+//                       elastic representation.
+// @param group_name     The name of the property group (in which the property
+//                       lives).
+// @param property_name  The name of the property (in the `group_name` group)
+//                       to be tested.
+// @param compliance     A string representing the compliance being requested
+//                       ("rigid" or "soft").
+// @param maker          The function that processes the shape and properties.
+//                       Note: this is declared to return void; the
+//                       Make*Representation() methods will need to be wrapped.
+// @param bad_value      If provided, sets the property to this value to test
+//                       validation against bad values.
+// @param props          The baseline properties to start the test from --
+//                       properties are generally tested in some sequence.
+//                       Each test may add a property to a copy of this input
+//                       to test a particular aspect.
+// @tparam ShapeType  The derived class from geometry::Shape (e.g., Sphere, Box,
+//                    etc.)
+// @tparam ValueTYpe  The type of value under test.
+template <typename ShapeType, typename ValueType>
+void TestPropertyErrors(
+    const ShapeType& shape_spec, const char* group_name,
+    const char* property_name, const char* compliance,
+    function<void(const ShapeType&, const ProximityProperties&)> maker,
+    std::optional<ValueType> bad_value, const ProximityProperties& props) {
+  ShapeName shape_name(shape_spec);
+
+  // Error case: missing property value.
+  {
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        maker(shape_spec, props), std::logic_error,
+        fmt::format("Cannot create {} {}.+'{}'\\) property", compliance,
+                    shape_name, property_name));
+  }
+
+  // Error case: property value is wrong type.
+  {
+    ProximityProperties wrong_value(props);
+    wrong_value.AddProperty(group_name, property_name, "10");
+    // This error message comes from GeometryProperties::GetProperty().
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        maker(shape_spec, wrong_value), std::logic_error,
+        fmt::format(".*The property '{}' .+ exists, but is of a different "
+                    "type.+string'",
+                    property_name));
+  }
+
+  // Error case: property value is not positive.
+  if (bad_value.has_value()) {
+    ProximityProperties negative_value(props);
+    negative_value.AddProperty(group_name, property_name, *bad_value);
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        maker(shape_spec, negative_value), std::logic_error,
+        fmt::format("Cannot create {} {}.+'{}'.+ positive", compliance,
+                    shape_name, property_name));
+  }
+}
+
+// TODO(SeanCurtis-TRI): Add Cylinder, Mesh, Capsule, Ellipsoid and Convex as
+//  they become supported by either rigid or soft geometries.
+
+// Test suite for testing the common failure conditions for generating rigid
+// geometry. Specifically, they just need to be tessellated into a triangle mesh
+// and, therefore, only depend on the (hydroelastic, characteristic_length)
+// value. This actively excludes half spaces because they don't get
+// tessellated (see the `RigidErrorShapeTypes` declaration below.) It should
+// include every *other* supported rigid shape type.
+template <typename ShapeType>
+class HydroelasticRigidGeometryErrorTests : public ::testing::Test {};
+
+TYPED_TEST_SUITE_P(HydroelasticRigidGeometryErrorTests);
+
+TYPED_TEST_P(HydroelasticRigidGeometryErrorTests, BadCharacteristicLength) {
+  using ShapeType = TypeParam;
+  ShapeType shape_spec = make_default_shape<ShapeType>();
+
+  TestPropertyErrors<ShapeType, double>(
+      shape_spec, kHydroGroup, kRezHint, "rigid",
+      [](const ShapeType& s, const ProximityProperties& p) {
+        MakeRigidRepresentation(s, p);
+      },
+      -0.2, {});
+}
+
+REGISTER_TYPED_TEST_SUITE_P(HydroelasticRigidGeometryErrorTests,
+                           BadCharacteristicLength);
+typedef ::testing::Types<Sphere, Box> RigidErrorShapeTypes;
+INSTANTIATE_TYPED_TEST_SUITE_P(My, HydroelasticRigidGeometryErrorTests,
+                              RigidErrorShapeTypes);
+
+class HydroelasticSoftGeometryTest : public ::testing::Test {
+ protected:
+  /** Creates a simple set of properties for generating soft geometry. */
+  ProximityProperties soft_properties(double edge_length = 0.1) const {
+    ProximityProperties soft_properties;
+    soft_properties.AddProperty(kMaterialGroup, kElastic, 1e8);
+    AddSoftHydroelasticProperties(edge_length, &soft_properties);
+    return soft_properties;
+  }
+};
+
+// TODO(SeanCurtis-TRI): As new shape specifications are added, they are
+//  implicitly unsupported and should be added here (and in
+//  UnsupportedRigidShapes). I'm particularly thinking of capsule and ellipsoid.
+// Smoke test for shapes that are *known* to be unsupported as soft objects.
+// NOTE: This will spew warnings to the log.
+TEST_F(HydroelasticSoftGeometryTest, UnsupportedSoftShapes) {
+  ProximityProperties props = soft_properties();
+
+  EXPECT_EQ(MakeSoftRepresentation(Box(1, 1, 1), props), std::nullopt);
+
+  EXPECT_EQ(MakeSoftRepresentation(Cylinder(1, 1), props), std::nullopt);
+
+  EXPECT_EQ(MakeSoftRepresentation(Capsule(1, 1), props), std::nullopt);
+
+  EXPECT_EQ(MakeSoftRepresentation(Ellipsoid(1, 2, 3), props), std::nullopt);
+
+  // Note: the file name doesn't have to be valid for this (and the Mesh) test.
+  const std::string obj = "drake/geometry/proximity/test/no_such_files.obj";
+  EXPECT_EQ(MakeSoftRepresentation(Convex(obj, 1.0), props), std::nullopt);
+
+  EXPECT_EQ(MakeSoftRepresentation(Mesh(obj, 1.0), props), std::nullopt);
+}
+
+// Test construction of a soft sphere. Confirms that the edge length has
+// an effect (i.e., that shrinking the edge_length by at least half causes
+// a change in mesh resolution. It relies on unit tests for the unit sphere
+// generation to confirm that it's the *right* number of tetrahedron. This
+// merely confirms that the characteristic_length is being fed in.
+TEST_F(HydroelasticSoftGeometryTest, Sphere) {
+  const double kRadius = 0.5;
+  Sphere sphere_spec(kRadius);
+
+  // Confirm that characteristic length is being fed in properly -- i.e.,
+  // if characteristic length cuts in half, It should have more tetrahedra.
+  ProximityProperties properties1 = soft_properties(kRadius);
+  ProximityProperties properties2 = soft_properties(kRadius / 2);
+  std::optional<SoftGeometry> sphere1 =
+      MakeSoftRepresentation(sphere_spec, properties1);
+  std::optional<SoftGeometry> sphere2 =
+      MakeSoftRepresentation(sphere_spec, properties2);
+  EXPECT_LT(sphere1->mesh().num_elements(), sphere2->mesh().num_elements());
+
+  // Confirm that all vertices lie inside the sphere and that at least one lies
+  // on the boundary.
+  double max_distance = -1.0;
+  for (const auto& soft_geometry : {*sphere1, *sphere2}) {
+    const VolumeMesh<double>& mesh = soft_geometry.mesh();
+    for (VolumeVertexIndex v(0); v < mesh.num_vertices(); ++v) {
+      const double dist = mesh.vertex(v).r_MV().norm();
+      max_distance = std::max(max_distance, dist);
+      ASSERT_LE(dist, kRadius);
+    }
+  }
+
+  ASSERT_NEAR(max_distance, kRadius, 1e-15);
+
+  // Confirm pressure field is as specified in the properties.
+  const double E =
+      properties1.GetPropertyOrDefault(kMaterialGroup, kElastic, 1e8);
+  // We assume that the sphere's pressure is defined as E * (1 - r/R).
+  auto pressure = [E, kRadius](const Vector3d& r_MV) {
+    return E * (1.0 - r_MV.norm() / kRadius);
+  };
+  const double kEps = std::numeric_limits<double>::epsilon();
+  const VolumeMesh<double>& mesh = sphere1->mesh();
+  for (VolumeVertexIndex v(0); v < mesh.num_vertices(); ++v) {
+    const VolumeVertex<double>& vertex = mesh.vertex(v);
+    // Zero on outside, 1 on inside.
+    const double expected_p = pressure(vertex.r_MV());
+    EXPECT_NEAR(sphere1->pressure_field().EvaluateAtVertex(v), expected_p,
+                kEps);
+  }
+}
+
+// Test suite for testing the common failure conditions for generating soft
+// geometry. Specifically, they need to be tessellated into a tet mesh
+// and define a pressure field. This actively excludes half spaces because they
+// are treated specially (they don't get tessellated).
+// (See the `RigidErrorShapeTypes` declaration below.) It should include every
+// *other* supported rigid shape type.
+template <typename ShapeType>
+class HydroelasticSoftGeometryErrorTests : public ::testing::Test {};
+
+TYPED_TEST_SUITE_P(HydroelasticSoftGeometryErrorTests);
+
+TYPED_TEST_P(HydroelasticSoftGeometryErrorTests, BadCharacteristicLength) {
+  using ShapeType = TypeParam;
+  ShapeType shape_spec = make_default_shape<ShapeType>();
+  TestPropertyErrors<ShapeType, double>(
+      shape_spec, kHydroGroup, kRezHint, "soft",
+      [](const ShapeType& s, const ProximityProperties& p) {
+        MakeSoftRepresentation(s, p);
+      },
+      -0.2, {});
+}
+
+TYPED_TEST_P(HydroelasticSoftGeometryErrorTests, BadElasticModulus) {
+  using ShapeType = TypeParam;
+  ShapeType shape_spec = make_default_shape<ShapeType>();
+
+  ProximityProperties soft_properties;
+  // Add the resolution hint so that creation of the hydroelastic representation
+  // can choke on elastic modulus value.
+  soft_properties.AddProperty(kHydroGroup, kRezHint, 10.0);
+  TestPropertyErrors<ShapeType, double>(
+      shape_spec, kMaterialGroup, kElastic, "soft",
+      [](const ShapeType& s, const ProximityProperties& p) {
+        MakeSoftRepresentation(s, p);
+      },
+      -0.2, soft_properties);
+}
+
+REGISTER_TYPED_TEST_SUITE_P(HydroelasticSoftGeometryErrorTests,
+                           BadCharacteristicLength, BadElasticModulus);
+typedef ::testing::Types<Sphere> SoftErrorShapeTypes;
+INSTANTIATE_TYPED_TEST_SUITE_P(My, HydroelasticSoftGeometryErrorTests,
+                              SoftErrorShapeTypes);
+
+}  // namespace
+}  // namespace hydroelastic
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/test/proximity_utilities_test.cc
+++ b/geometry/proximity/test/proximity_utilities_test.cc
@@ -61,47 +61,6 @@ GTEST_TEST(EncodedData, ConstructionFromFclObject) {
   }
 }
 
-GTEST_TEST(ShapeName, SimpleReification) {
-  ShapeName name;
-
-  EXPECT_EQ(name.string(), "");
-
-  Sphere(0.5).Reify(&name);
-  EXPECT_EQ(name.string(), "Sphere");
-
-  Cylinder(1, 2).Reify(&name);
-  EXPECT_EQ(name.string(), "Cylinder");
-
-  Box(1, 2, 3).Reify(&name);
-  EXPECT_EQ(name.string(), "Box");
-
-  HalfSpace().Reify(&name);
-  EXPECT_EQ(name.string(), "HalfSpace");
-
-  Mesh("filepath", 1.0).Reify(&name);
-  EXPECT_EQ(name.string(), "Mesh");
-
-  Convex("filepath", 1.0).Reify(&name);
-  EXPECT_EQ(name.string(), "Convex");
-}
-
-GTEST_TEST(ShapeName, ReifyOnConstruction) {
-  EXPECT_EQ(ShapeName(Sphere(0.5)).string(), "Sphere");
-  EXPECT_EQ(ShapeName(Cylinder(1, 2)).string(), "Cylinder");
-  EXPECT_EQ(ShapeName(Box(1, 2, 3)).string(), "Box");
-  EXPECT_EQ(ShapeName(HalfSpace()).string(), "HalfSpace");
-  EXPECT_EQ(ShapeName(Mesh("filepath", 1.0)).string(), "Mesh");
-  EXPECT_EQ(ShapeName(Convex("filepath", 1.0)).string(), "Convex");
-}
-
-GTEST_TEST(ShapeName, Stremaing) {
-  ShapeName name(Sphere(0.5));
-  std::stringstream ss;
-  ss << name;
-  EXPECT_EQ(name.string(), "Sphere");
-  EXPECT_EQ(ss.str(), name.string());
-}
-
 }  // namespace
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity_properties.h
+++ b/geometry/proximity_properties.h
@@ -37,6 +37,8 @@ extern const char* const kElastic;        ///< Elastic modulus property name.
 
    - string constants to read and write the indicated properties, and
    - utility functions for declaring consistent hydroelastic properties
+     including
+       - differentiating between a rigid and soft geometry
 
  @todo Add reference to discussion of hydroelastic proximity properties along
  the lines of "For the full discussion of preparing geometry for use in the

--- a/geometry/shape_specification.cc
+++ b/geometry/shape_specification.cc
@@ -154,5 +154,10 @@ void ShapeReifier::ThrowUnsupportedGeometry(const std::string& shape_name) {
                                        NiceTypeName::Get(*this), shape_name));
 }
 
+std::ostream& operator<<(std::ostream& out, const ShapeName& name) {
+  out << name.name();
+  return out;
+}
+
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -392,5 +392,62 @@ Shape::Shape(ShapeTag<S>) {
   };
 }
 
+// TODO(SeanCurtis-TRI): Merge this into shape_to_string.h so that there's a
+//  single utility for getting a string from a shape.
+/** Class that reports the name of the type of shape being reified (e.g.,
+ Sphere, Box, etc.)  */
+class ShapeName final : public ShapeReifier {
+ public:
+  ShapeName() = default;
+
+  /** Constructs a %ShapeName from the given `shape` such that `string()`
+   already contains the string representation of `shape`.  */
+  explicit ShapeName(const Shape& shape) {
+    shape.Reify(this);
+  }
+
+  /** @name  Implementation of ShapeReifier interface  */
+  //@{
+
+  using ShapeReifier::ImplementGeometry;
+
+  void ImplementGeometry(const Sphere&, void*) final {
+    string_ = "Sphere";
+  }
+  void ImplementGeometry(const Cylinder&, void*) final {
+    string_ = "Cylinder";
+  }
+  void ImplementGeometry(const HalfSpace&, void*) final {
+    string_ = "HalfSpace";
+  }
+  void ImplementGeometry(const Box&, void*) final {
+    string_ = "Box";
+  }
+  void ImplementGeometry(const Capsule&, void*) final {
+    string_ = "Capsule";
+  }
+  void ImplementGeometry(const Ellipsoid&, void*) final {
+    string_ = "Ellipsoid";
+  }
+  void ImplementGeometry(const Mesh&, void*) final {
+    string_ = "Mesh";
+  }
+  void ImplementGeometry(const Convex&, void*) final {
+    string_ = "Convex";
+  }
+
+  //@}
+
+  /** Returns the name of the last shape reified. Empty if no shape has been
+   reified yet.  */
+  std::string name() const { return string_; }
+
+ private:
+  std::string string_;
+};
+
+/** @relates ShapeName */
+std::ostream& operator<<(std::ostream& out, const ShapeName& name);
+
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/test/shape_specification_test.cc
+++ b/geometry/test/shape_specification_test.cc
@@ -437,6 +437,55 @@ TEST_F(DefaultReifierTest, UnsupportedGeometry) {
                               "This class (.+) does not support Convex.");
 }
 
+GTEST_TEST(ShapeName, SimpleReification) {
+  ShapeName name;
+
+  EXPECT_EQ(name.name(), "");
+
+  Sphere(0.5).Reify(&name);
+  EXPECT_EQ(name.name(), "Sphere");
+
+  Cylinder(1, 2).Reify(&name);
+  EXPECT_EQ(name.name(), "Cylinder");
+
+  Box(1, 2, 3).Reify(&name);
+  EXPECT_EQ(name.name(), "Box");
+
+  Capsule(1, 2).Reify(&name);
+  EXPECT_EQ(name.name(), "Capsule");
+
+  Ellipsoid(1, 2, 3).Reify(&name);
+  EXPECT_EQ(name.name(), "Ellipsoid");
+
+  HalfSpace().Reify(&name);
+  EXPECT_EQ(name.name(), "HalfSpace");
+
+  Mesh("filepath", 1.0).Reify(&name);
+  EXPECT_EQ(name.name(), "Mesh");
+
+  Convex("filepath", 1.0).Reify(&name);
+  EXPECT_EQ(name.name(), "Convex");
+}
+
+GTEST_TEST(ShapeName, ReifyOnConstruction) {
+  EXPECT_EQ(ShapeName(Sphere(0.5)).name(), "Sphere");
+  EXPECT_EQ(ShapeName(Cylinder(1, 2)).name(), "Cylinder");
+  EXPECT_EQ(ShapeName(Capsule(1, 2)).name(), "Capsule");
+  EXPECT_EQ(ShapeName(Ellipsoid(1, 2, 3)).name(), "Ellipsoid");
+  EXPECT_EQ(ShapeName(Box(1, 2, 3)).name(), "Box");
+  EXPECT_EQ(ShapeName(HalfSpace()).name(), "HalfSpace");
+  EXPECT_EQ(ShapeName(Mesh("filepath", 1.0)).name(), "Mesh");
+  EXPECT_EQ(ShapeName(Convex("filepath", 1.0)).name(), "Convex");
+}
+
+GTEST_TEST(ShapeName, Streaming) {
+  ShapeName name(Sphere(0.5));
+  std::stringstream ss;
+  ss << name;
+  EXPECT_EQ(name.name(), "Sphere");
+  EXPECT_EQ(ss.str(), name.name());
+}
+
 }  // namespace
 }  // namespace geometry
 }  // namespace drake


### PR DESCRIPTION
Master currently creates meshes on the fly. This introduces the basic infrastructure for allowing the ProximityEngine to create and reuse those representations (currently, only meshes).

 - hydroelastic_internal.*
   - provides the generic concepts of soft and rigid geometry (the groundwork to support meshes today and untessellated geometries tomorrow).
    - provides the Geometries class which holds all of the hydroelastic representations.
    - Provides the interface for creating hydroelastic represenatations as they are supported (the Make*Representation interface).
  - Everything else is about making use of those pre-computed
    representations.

Apologies for the size. I tried to slice this three different ways. None of them led to PRs that made coherent sense (and produced PRs that were all smaller than 700 lines).
```
Category            added  modified  removed  
----------------------------------------------
code                827    68        89       
comments            267    12        17       
blank               187    0         5        
----------------------------------------------
TOTAL               1281   80        111  
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12233)
<!-- Reviewable:end -->
