### PR TITLE
Add GetMyContextFromRoot() methods for subsystems.

### DIFF
--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -88,6 +88,8 @@ PYBIND11_MODULE(analysis, m) {
             doc.Simulator.Initialize.doc)
         .def("AdvanceTo", &Simulator<T>::AdvanceTo, py::arg("boundary_time"),
             doc.Simulator.AdvanceTo.doc)
+        .def("AdvancePendingEvents", &Simulator<T>::AdvancePendingEvents,
+            doc.Simulator.AdvancePendingEvents.doc)
         .def("StepTo",
             WrapDeprecated(
                 doc.Simulator.StepTo.doc_deprecated, &Simulator<T>::AdvanceTo),

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -367,6 +367,30 @@ struct Impl {
                 &System<T>::CalcDiscreteVariableUpdates),
             py::arg("context"), py::arg("discrete_state"),
             doc.System.CalcDiscreteVariableUpdates.doc_2args)
+        .def("GetSubsystemContext",
+            overload_cast_explicit<const Context<T>&, const System<T>&,
+                const Context<T>&>(&System<T>::GetSubsystemContext),
+            py_reference,
+            // Keep alive, ownership: `return` keeps `Context` alive.
+            py::keep_alive<0, 3>(), doc.System.GetMutableSubsystemContext.doc)
+        .def("GetMutableSubsystemContext",
+            overload_cast_explicit<Context<T>&, const System<T>&, Context<T>*>(
+                &System<T>::GetMutableSubsystemContext),
+            py_reference,
+            // Keep alive, ownership: `return` keeps `Context` alive.
+            py::keep_alive<0, 3>(), doc.System.GetMutableSubsystemContext.doc)
+        .def("GetMyContextFromRoot",
+            overload_cast_explicit<const Context<T>&, const Context<T>&>(
+                &System<T>::GetMyContextFromRoot),
+            py_reference,
+            // Keep alive, ownership: `return` keeps `Context` alive.
+            py::keep_alive<0, 2>(), doc.System.GetMyMutableContextFromRoot.doc)
+        .def("GetMyMutableContextFromRoot",
+            overload_cast_explicit<Context<T>&, Context<T>*>(
+                &System<T>::GetMyMutableContextFromRoot),
+            py_reference,
+            // Keep alive, ownership: `return` keeps `Context` alive.
+            py::keep_alive<0, 2>(), doc.System.GetMyMutableContextFromRoot.doc)
         // Sugar.
         .def("GetGraphvizString",
             [str_py](const System<T>* self, int max_depth) {
@@ -677,18 +701,6 @@ Note: The above is for the C++ documentation. For Python, use
             // Keep alive, ownership: `return` keeps `Context` alive.
             py::keep_alive<0, 3>(),
             doc.Diagram.GetMutableSubsystemState.doc_2args_subsystem_context)
-        .def("GetSubsystemContext",
-            overload_cast_explicit<const Context<T>&, const System<T>&,
-                const Context<T>&>(&Diagram<T>::GetSubsystemContext),
-            py_reference,
-            // Keep alive, ownership: `return` keeps `Context` alive.
-            py::keep_alive<0, 3>(), doc.Diagram.GetMutableSubsystemContext.doc)
-        .def("GetMutableSubsystemContext",
-            overload_cast_explicit<Context<T>&, const System<T>&, Context<T>*>(
-                &Diagram<T>::GetMutableSubsystemContext),
-            py_reference,
-            // Keep alive, ownership: `return` keeps `Context` alive.
-            py::keep_alive<0, 3>(), doc.Diagram.GetMutableSubsystemContext.doc)
         .def("GetSubsystemByName", &Diagram<T>::GetSubsystemByName,
             py::arg("name"), py_reference_internal,
             doc.Diagram.GetSubsystemByName.doc);

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -495,6 +495,10 @@ class TestCustom(unittest.TestCase):
         self.assertIsNot(subcontext, None)
         self.assertIs(
             diagram.GetSubsystemContext(system, context), subcontext)
+        subcontext2 = system.GetMyMutableContextFromRoot(context)
+        self.assertIsNot(subcontext2, None)
+        self.assertIs(subcontext2, subcontext)
+        self.assertIs(system.GetMyContextFromRoot(context), subcontext2)
 
     def test_continuous_state_api(self):
         # N.B. Since this has trivial operations, we can test all scalar types.

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -344,6 +344,7 @@ class TestGeneral(unittest.TestCase):
             self.assertTrue(simulator.get_context() is context)
             check_output(context)
             simulator.AdvanceTo(1)
+            simulator.AdvancePendingEvents()
 
     def test_copy(self):
         # Copy a context using `deepcopy` or `clone`.

--- a/systems/framework/context_base.h
+++ b/systems/framework/context_base.h
@@ -262,6 +262,9 @@ class ContextBase : public internal::ContextMessageInterface {
     return ++context->current_change_event_;
   }
 
+  /** Returns true if this context has no parent. */
+  bool is_root_context() const { return parent_ == nullptr; }
+
  protected:
   /** Default constructor creates an empty ContextBase but initializes all the
   built-in dependency trackers that are the same in every System (like time,
@@ -436,9 +439,6 @@ class ContextBase : public internal::ContextMessageInterface {
       get_tracker(ticket).NoteValueChange(change_event);
   }
   //@}
-
-  /** Returns true if this context has no parent. */
-  bool is_root_context() const { return parent_ == nullptr; }
 
   /** (Internal use only) Returns true if this context provides resources for
   its own individual state variables or parameters. That means those variables

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -361,29 +361,6 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
     return diagram_discrete_state->get_subdiscrete(i);
   }
 
-  /// Returns a constant reference to the subcontext that corresponds to the
-  /// system @p subsystem.
-  /// Classes inheriting from %Diagram need access to this method in order to
-  /// pass their constituent subsystems the appropriate subcontext. Aborts if
-  /// @p subsystem is not actually a subsystem of this diagram.
-  const Context<T>& GetSubsystemContext(const System<T>& subsystem,
-                                        const Context<T>& context) const {
-    auto ret = DoGetTargetSystemContext(subsystem, &context);
-    DRAKE_DEMAND(ret != nullptr);
-    return *ret;
-  }
-
-  /// Returns the subcontext that corresponds to the system @p subsystem.
-  /// Classes inheriting from %Diagram need access to this method in order to
-  /// pass their constituent subsystems the appropriate subcontext. Aborts if
-  /// @p subsystem is not actually a subsystem of this diagram.
-  Context<T>& GetMutableSubsystemContext(const System<T>& subsystem,
-                                         Context<T>* context) const {
-    auto ret = DoGetMutableTargetSystemContext(subsystem, context);
-    DRAKE_DEMAND(ret != nullptr);
-    return *ret;
-  }
-
   /// Returns the const subsystem composite event collection from @p events
   /// that corresponds to @p subsystem. Aborts if @p subsystem is not a
   /// subsystem of this diagram.
@@ -614,6 +591,9 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
     return false;
   }
 
+  using System<T>::GetSubsystemContext;
+  using System<T>::GetMutableSubsystemContext;
+
  protected:
   /// Constructs an uninitialized Diagram. Subclasses that use this constructor
   /// are obligated to call DiagramBuilder::BuildInto(this).  Provides scalar-
@@ -710,19 +690,6 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
                         temp_witnesses.end());
       ++index;
     }
-  }
-
-  /// Returns a pointer to mutable context if @p target_system is a sub system
-  /// of this, nullptr is returned otherwise.
-  Context<T>* DoGetMutableTargetSystemContext(
-      const System<T>& target_system, Context<T>* context) const final {
-    if (&target_system == this)
-      return context;
-
-    return GetSubsystemStuff<Context<T>, DiagramContext<T>>(
-        target_system, context,
-        &System<T>::DoGetMutableTargetSystemContext,
-        &DiagramContext<T>::GetMutableSubsystemContext);
   }
 
   /// Returns a pointer to const context if @p target_system is a subsystem
@@ -1074,6 +1041,11 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
     return this->GetSystemPathname();
   }
 
+  const SystemBase& GetRootSystemBase() const final {
+    const auto* parent_service = this->get_parent_service();
+    return parent_service ? parent_service->GetRootSystemBase() : *this;
+  }
+
   // Returns true if there might be direct feedthrough from the given
   // @p input_port of the Diagram to the given @p output_port of the Diagram.
   bool DiagramHasDirectFeedthrough(int input_port, int output_port) const {
@@ -1273,9 +1245,8 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
   // Tries to recursively find @p target_system's BaseStuff
   // (context / state / etc). nullptr is returned if @p target_system is not
   // a subsystem of this diagram. This template function should only be used
-  // to reduce code repetition for DoGetMutableTargetSystemContext(),
-  // DoGetTargetSystemContext(), DoGetMutableTargetSystemState(), and
-  // DoGetTargetSystemState().
+  // to reduce code repetition for DoGetTargetSystemContext(),
+  // DoGetMutableTargetSystemState(), and DoGetTargetSystemState().
   // @param target_system The subsystem of interest.
   // @param my_stuff BaseStuff that's associated with this diagram.
   // @param recursive_getter A member function of System that returns sub

--- a/systems/framework/framework_common.h
+++ b/systems/framework/framework_common.h
@@ -107,6 +107,7 @@ enum class OutputPortSelection { kNoOutput = -1, kUseFirstOutputIfItExists =
 #ifndef DRAKE_DOXYGEN_CXX
 class ContextBase;
 class InputPortBase;
+class SystemBase;
 
 namespace internal {
 
@@ -239,6 +240,10 @@ class SystemParentServiceInterface {
   // GetSystemPathname() on the parent subsystem. (See SystemMessageInterface
   // above.)
   virtual std::string GetParentPathname() const = 0;
+
+  // Returns the root Diagram at the top of this Diagram tree. Will return
+  // `this` if we are already at the root.
+  virtual const SystemBase& GetRootSystemBase() const = 0;
 
  protected:
   SystemParentServiceInterface() = default;


### PR DESCRIPTION
This is a lemma PR needed for the Simulator monitor() feature discussed in issue #12164. See the use case in [this comment](https://github.com/RobotLocomotion/drake/issues/12164#issuecomment-545202574) and the monitor() WIP PR #12213.

This PR
- moves `GetSubsystemContext()` from Diagram to System to permit access without dynamic_cast, and
- adds `subsystem.GetMyContextFromRoot(context)` which allows access to subcontexts within a monitor() without having to capture the diagram.
- improves some error handling and documentation.
- adds Python bindings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12237)
<!-- Reviewable:end -->
