### PR TITLE
kuka: Disable controlled_kuka_multibody_demo under kcov

### DIFF
--- a/examples/kuka_iiwa_arm/controlled_kuka/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/controlled_kuka/BUILD.bazel
@@ -50,6 +50,9 @@ drake_cc_binary(
         "//examples/kuka_iiwa_arm:models",
         "//manipulation/models/iiwa_description:models",
     ],
+    # TODO(eric.cousineau): Re-enable this test under kcov when it no longer
+    # causes timeouts.
+    tags = ["no_kcov"],
     deps = [
         ":controlled_kuka_trajectory",
         "//common:find_resource",


### PR DESCRIPTION
Resolves CI failures mentioned here:
https://drakedevelopers.slack.com/archives/C270MN28G/p1571931790028900
```
jamiesnape 11:43 AM
//examples/kuka_iiwa_arm/controlled_kuka:controlled_kuka_multibody_demo_test has timed out 3 of the last 4 and 5 out the last 9 coverage builds. Needs action, I think.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12241)
<!-- Reviewable:end -->
