### PR TITLE
Update CLion/Bazel version numbers

### DIFF
--- a/doc/clion.rst
+++ b/doc/clion.rst
@@ -34,10 +34,10 @@ Installing CLion
 
 The most recent versions that we have tested for compatibility are:
   - Ubuntu 18.04
-  - Bazel 0.28.0 (July 10, 2019)
-  - CLion 2019.1.3 (May 6, 2019) with:
+  - Bazel 1.1.0 (October 21, 2019)
+  - CLion 2019.2.4 (October 9, 2019) with:
 
-    - Bazel plugin 2019.07.08.0.2 (July 19, 2019).
+    - Bazel plugin 2019.10.14.0.0 (October 25, 2019).
 
 Many versions of the above (Bazel / CLion / Bazel plugin) are *not* compatible
 with each other.  We strongly suggest using only the versions shown above, when


### PR DESCRIPTION
CLion 1.3 stopped working after I updated to the latest master including bazel 1.1. Upgrading to 1.4 with a new Bazel plugin fixed the problem. This updates the CLion instructions to match.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12260)
<!-- Reviewable:end -->
