### PR TITLE
common: Factor text_logging string constants out of gflags

### DIFF
--- a/common/text_logging.cc
+++ b/common/text_logging.cc
@@ -95,6 +95,17 @@ std::string logging::set_log_level(const std::string& level) {
   }
 }
 
+const char* const logging::kSetLogLevelHelpMessage =
+    "sets the spdlog output threshold; possible values are "
+    "'unchanged', "
+    "'trace', "
+    "'debug', "
+    "'info', "
+    "'warn', "
+    "'err', "
+    "'critical', "
+    "'off'";
+
 #else  // HAVE_SPDLOG
 
 logging::logger::logger() {}
@@ -117,6 +128,11 @@ std::string logging::set_log_level(const std::string&) {
   return "";
 }
 
+const char* const logging::kSetLogLevelHelpMessage =
+    "(Text logging is unavailable.)";
+
 #endif  // HAVE_SPDLOG
+
+const char* const logging::kSetLogLevelUnchanged = "unchanged";
 
 }  // namespace drake

--- a/common/text_logging.h
+++ b/common/text_logging.h
@@ -199,5 +199,11 @@ struct Warn {
 /// then this returns an empty string.
 std::string set_log_level(const std::string& level);
 
+/// The "unchanged" string to pass to set_log_level() so as to achieve a no-op.
+extern const char* const kSetLogLevelUnchanged;
+
+/// An end-user help string suitable to describe the effects of set_log_level().
+extern const char* const kSetLogLevelHelpMessage;
+
 }  // namespace logging
 }  // namespace drake

--- a/common/text_logging_gflags.h
+++ b/common/text_logging_gflags.h
@@ -9,16 +9,9 @@
 #include "drake/common/text_logging.h"
 
 // Declare the --spdlog_level gflags option.
-DEFINE_string(spdlog_level, "unchanged",
-              "sets the spdlog output threshold; possible values are "
-              "'unchanged', "
-              "'trace', "
-              "'debug', "
-              "'info', "
-              "'warn', "
-              "'err', "
-              "'critical', "
-              "'off'");
+DEFINE_string(spdlog_level,
+              drake::logging::kSetLogLevelUnchanged,
+              drake::logging::kSetLogLevelHelpMessage);
 
 namespace drake {
 namespace logging {


### PR DESCRIPTION
This anticipates the deprecation and/or removal of text_logging_gflags.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12261)
<!-- Reviewable:end -->
