### PR TITLE
adds a nan check to xc[i]

### DIFF
--- a/systems/analysis/implicit_integrator.h
+++ b/systems/analysis/implicit_integrator.h
@@ -290,7 +290,7 @@ class ImplicitIntegrator : public IntegratorBase<T> {
       // is detected. This will make the Newton-Raphson process in the caller
       // continue iterating until its inevitable failure.
       using std::isnan;
-      if (isnan(dxc[i])) return false;
+      if (isnan(dxc[i]) || isnan(xc[i])) return false;
 
       const T tol = max(abs(xc[i]), T(1)) * eps;
       if (abs(dxc[i]) > tol)


### PR DESCRIPTION
Recently this PR was merged into master to add NaN checks for the integrator
https://github.com/robotlocomotion/drake/pull/12217

In the PR, the comments for IsUpdateZero() state that it will return false if NaNs are detected; however, there is a logical mistake in the implementation, where if all xc[i] are NaN and dxc[i] are normal, it will return true. This change adds a NaN check for xc[i]s so that the code behaves as expected.

The original issue was https://github.com/RobotLocomotion/drake/issues/12201

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12263)
<!-- Reviewable:end -->
