### PR TITLE
Ramp up anti-aliasing in the VTK color image

### DIFF
--- a/geometry/render/render_engine_vtk.h
+++ b/geometry/render/render_engine_vtk.h
@@ -223,6 +223,9 @@ class RenderEngineVtk final : public RenderEngine,
   // The color to clear the color buffer to.
   systems::sensors::ColorD default_clear_color_;
 
+  // Determines whether color images are anti-aliased or not.
+  VtkAntiAliasing use_color_anti_aliasing_{VtkAntiAliasing::kOn};
+
   // The collection of per-geometry actors (one actor per pipeline (color,
   // depth, and label) keyed by the geometry's GeometryId.
   std::unordered_map<GeometryId, std::array<vtkSmartPointer<vtkActor>, 3>>

--- a/geometry/render/render_engine_vtk_factory.h
+++ b/geometry/render/render_engine_vtk_factory.h
@@ -8,6 +8,13 @@ namespace drake {
 namespace geometry {
 namespace render {
 
+/** Determines whether anti-aliasing is on or off. (Designed so that on is the
+ default value.  */
+enum class VtkAntiAliasing {
+  kOn,
+  kOff
+};
+
 /** Construction parameters for the RenderEngineVtk.  */
 struct RenderEngineVtkParams  {
   /** The (optional) label to apply when none is otherwise specified.  */
@@ -22,6 +29,11 @@ struct RenderEngineVtkParams  {
    channel in the range [0, 1]). The default value (in byte values) would be
    [204, 229, 255].  */
   Eigen::Vector3d default_clear_color{204 / 255., 229 / 255., 255 / 255.};
+
+  /** Disables multi-sample anti-aliasing for color images if set to false.
+   Defaults to enabled. Note: by design there is no anti-aliasing for color
+   or depth images.  */
+  VtkAntiAliasing use_color_anti_aliasing{VtkAntiAliasing::kOn};
 };
 
 /** Constructs a RenderEngine implementation which uses a VTK-based OpenGL


### PR DESCRIPTION
Previously, MSAA was set to zero on all image types. However, FXAA was turned on for color images. Apparently, doing so leaves a modicum of anti-aliasing in the color image (but not much).

This provides a mechanism to specify anti-aliasing (on or off) and links the two features (MSAA and FXAA) explicitly making a stronger distinction between turning it on and off (with a supporting test).

By default, color anti aliasing is enabled. The unit test disables it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12264)
<!-- Reviewable:end -->
