### PR TITLE
workspace: Update gtest to latest release 1.10.0

### DIFF
--- a/attic/multibody/collision/test/model_test.cc
+++ b/attic/multibody/collision/test/model_test.cc
@@ -129,7 +129,7 @@ std::vector<ModelType> GetUsableModelTypes() {
   return types;
 }
 
-INSTANTIATE_TEST_CASE_P(AllModelTypesTests, AllModelTypesTests,
+INSTANTIATE_TEST_SUITE_P(AllModelTypesTests, AllModelTypesTests,
                         ::testing::ValuesIn(GetAllModelTypes()));
 
 // Fixture for tests that should only be applied to usable collision model
@@ -157,7 +157,7 @@ TEST_P(UsableModelTypesTests, RemoveElement) {
   RemoveElement(*elem2);
 }
 
-INSTANTIATE_TEST_CASE_P(UsableModelTypesTests, UsableModelTypesTests,
+INSTANTIATE_TEST_SUITE_P(UsableModelTypesTests, UsableModelTypesTests,
                         ::testing::ValuesIn(GetUsableModelTypes()));
 
 #ifndef DRAKE_DISABLE_FCL
@@ -224,7 +224,7 @@ TEST_P(FclModelNotImplementedTests, NotImplemented) {
   EXPECT_THROW(GetParam()(this), std::exception);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     NotImplementedTest, FclModelNotImplementedTests,
     ::testing::Values(
        &FclModelNotImplementedTests::CallAddBox,
@@ -485,13 +485,13 @@ std::vector<ShapeVsShapeTestParam> GenerateSphereVsCylinderParam() {
 }
 
 // Instantiate pairwise test cases.
-INSTANTIATE_TEST_CASE_P(SphereVsSphere, ShapeVsShapeTest,
+INSTANTIATE_TEST_SUITE_P(SphereVsSphere, ShapeVsShapeTest,
                         ::testing::ValuesIn(GenerateSphereVsSphereParam()));
 
-INSTANTIATE_TEST_CASE_P(CylinderVsCylinder, ShapeVsShapeTest,
+INSTANTIATE_TEST_SUITE_P(CylinderVsCylinder, ShapeVsShapeTest,
                         ::testing::ValuesIn(GenerateCylinderVsCylinderParam()));
 
-INSTANTIATE_TEST_CASE_P(SphereVsCylinder, ShapeVsShapeTest,
+INSTANTIATE_TEST_SUITE_P(SphereVsCylinder, ShapeVsShapeTest,
                         ::testing::ValuesIn(GenerateSphereVsCylinderParam()));
 
 // GENERAL REMARKS ON THE TESTS PERFORMED

--- a/attic/multibody/parsers/test/compliant_material_parse_test.cc
+++ b/attic/multibody/parsers/test/compliant_material_parse_test.cc
@@ -122,7 +122,7 @@ const char* CompliantMaterialParseTest::kUrdfTail =
 </robot>
 )_";
 
-INSTANTIATE_TEST_CASE_P(CompliantMaterialParseTest, CompliantMaterialParseTest,
+INSTANTIATE_TEST_SUITE_P(CompliantMaterialParseTest, CompliantMaterialParseTest,
                         ::testing::Values("urdf", "sdf"));
 
 // Test that parsing a file with *no* specification assigns the default

--- a/attic/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
+++ b/attic/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
@@ -407,7 +407,7 @@ TEST_P(KukaArmTest, EvalOutput) {
 
 // Instantiate the value-parameterized tests to run twice: once with continuous
 // state and once with discrete state.
-INSTANTIATE_TEST_CASE_P(Blank, KukaArmTest,
+INSTANTIATE_TEST_SUITE_P(Blank, KukaArmTest,
     testing::Values(0.0 /* continuous state */, 1e-3 /* discrete state */));
 
 GTEST_TEST(rigid_body_plant_test, TestJointLimitForcesFormula) {

--- a/attic/perception/estimators/dev/test/articulated_icp_test.cc
+++ b/attic/perception/estimators/dev/test/articulated_icp_test.cc
@@ -296,7 +296,7 @@ TEST_P(ArticulatedIcpTest, PositiveReturnsConvergenceTest) {
 
 // Instantiate parameterized test cases.
 // TODO(eric.cousineau): Clearly parameterize failures for blue funnel case.
-INSTANTIATE_TEST_CASE_P(test, ArticulatedIcpTest, ObjectTestTypes);
+INSTANTIATE_TEST_SUITE_P(test, ArticulatedIcpTest, ObjectTestTypes);
 
 }  // namespace
 }  // namespace estimators

--- a/attic/perception/estimators/dev/test/pose_closed_form_test.cc
+++ b/attic/perception/estimators/dev/test/pose_closed_form_test.cc
@@ -107,7 +107,7 @@ TEST_P(PoseClosedFormTest, PcaAndSvd) {
 }
 
 // Instantiate parameterized test cases.
-INSTANTIATE_TEST_CASE_P(test, PoseClosedFormTest, ObjectTestTypes);
+INSTANTIATE_TEST_SUITE_P(test, PoseClosedFormTest, ObjectTestTypes);
 
 }  // namespace
 }  // namespace estimators

--- a/common/test/symbolic_simplification_test.cc
+++ b/common/test/symbolic_simplification_test.cc
@@ -312,7 +312,7 @@ TEST_P(SymbolicUnificationTestUnary, Check) {
   EXPECT_PRED2(ExprEqual, rewriter(e2), e2 /* no change */);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     UnaryCases, SymbolicUnificationTestUnary,
     ::testing::Values(
     Abs, Log, Exp, Sqrt, Sin, Cos, Tan, Asin, Acos, Atan, Sinh, Cosh, Tanh,
@@ -365,7 +365,7 @@ TEST_P(SymbolicUnificationTestBinary, Check) {
   EXPECT_PRED2(ExprEqual, rewriter(e2), e2 /* no change */);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     BinaryCases, SymbolicUnificationTestBinary,
     ::testing::Values(Pow, Div, Min, Max, Atan2));
 

--- a/common/test/value_test.cc
+++ b/common/test/value_test.cc
@@ -79,7 +79,7 @@ typedef ::testing::Types<
     CloneableInt,
     MoveOrCloneInt
     > Implementations;
-TYPED_TEST_CASE(TypedValueTest, Implementations);
+TYPED_TEST_SUITE(TypedValueTest, Implementations);
 
 // Value<T>() should work if and only if T is default-constructible.
 GTEST_TEST(ValueTest, DefaultConstructor) {

--- a/common/test_utilities/test/limit_malloc_test.cc
+++ b/common/test_utilities/test/limit_malloc_test.cc
@@ -105,9 +105,9 @@ TEST_P(LimitMallocDeathTest, LimitTest) {
     }, expected_message);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     All, LimitMallocTest, ::testing::Range(0, 3));
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     All, LimitMallocDeathTest, ::testing::Range(0, 3));
 
 // When the user whitelists no-op reallocs, a call to realloc() that does not

--- a/examples/kuka_iiwa_arm/iiwa_world/test/iiwa_wsg_diagram_factory_test.cc
+++ b/examples/kuka_iiwa_arm/iiwa_world/test/iiwa_wsg_diagram_factory_test.cc
@@ -124,7 +124,7 @@ TEST_P(IiwaAndWsgPlantWithStateEstimatorParameterizedTest, Constructor) {
   CheckNumPorts(*iiwa_and_wsg_plant, num_iiwas, num_wsgs, num_objects);
 }
 
-INSTANTIATE_TEST_CASE_P(ValidCombinations,
+INSTANTIATE_TEST_SUITE_P(ValidCombinations,
                         IiwaAndWsgPlantWithStateEstimatorParameterizedTest,
                         ::testing::Combine(::testing::Values(1, 2, 3, 10),
                                            ::testing::Values(1, 2, 3, 10)));

--- a/examples/particles/test/particle_test.cc
+++ b/examples/particles/test/particle_test.cc
@@ -39,7 +39,7 @@ class ParticleTest : public ::testing::Test {
   std::unique_ptr<systems::ContinuousState<T>> derivatives_;
 };
 
-TYPED_TEST_CASE_P(ParticleTest);
+TYPED_TEST_SUITE_P(ParticleTest);
 
 /// Makes sure a Particle output is consistent with its
 /// state (position and velocity).
@@ -91,9 +91,9 @@ TYPED_TEST_P(ParticleTest, DerivativesTest) {
             static_cast<TypeParam>(1.0));  // x1dot == u0
 }
 
-REGISTER_TYPED_TEST_CASE_P(ParticleTest, OutputTest, DerivativesTest);
+REGISTER_TYPED_TEST_SUITE_P(ParticleTest, OutputTest, DerivativesTest);
 
-INSTANTIATE_TYPED_TEST_CASE_P(WithDoubles, ParticleTest, double);
+INSTANTIATE_TYPED_TEST_SUITE_P(WithDoubles, ParticleTest, double);
 
 }  // namespace
 }  // namespace particles

--- a/examples/particles/test/utilities_test.cc
+++ b/examples/particles/test/utilities_test.cc
@@ -41,7 +41,7 @@ class SingleDOFEulerJointTest : public ::testing::Test {
   std::unique_ptr<systems::SystemOutput<T>> output_;
 };
 
-TYPED_TEST_CASE_P(SingleDOFEulerJointTest);
+TYPED_TEST_SUITE_P(SingleDOFEulerJointTest);
 
 /// Makes sure that MakeDegenerateEulerJoint joint
 /// output is the right mapping of its inputs.
@@ -70,9 +70,9 @@ TYPED_TEST_P(SingleDOFEulerJointTest, OutputTest) {
             static_cast<TypeParam>(0.0));  // v3 == 0.0
 }
 
-REGISTER_TYPED_TEST_CASE_P(SingleDOFEulerJointTest, OutputTest);
+REGISTER_TYPED_TEST_SUITE_P(SingleDOFEulerJointTest, OutputTest);
 
-INSTANTIATE_TYPED_TEST_CASE_P(WithDoubles, SingleDOFEulerJointTest, double);
+INSTANTIATE_TYPED_TEST_SUITE_P(WithDoubles, SingleDOFEulerJointTest, double);
 
 /// Makes sure that MakeDegenerateEulerJoint throws when the given
 /// translating matrix doesn't imply a 6 degrees of freedom output

--- a/examples/schunk_wsg/test/schunk_wsg_lift_test.cc
+++ b/examples/schunk_wsg/test/schunk_wsg_lift_test.cc
@@ -513,7 +513,7 @@ TEST_P(SchunkWsgLiftTest, BoxLiftTest) {
 }
 
 // Instantiate the tests.
-INSTANTIATE_TEST_CASE_P(CompliantAndTimeSteppingTest, SchunkWsgLiftTest,
+INSTANTIATE_TEST_SUITE_P(CompliantAndTimeSteppingTest, SchunkWsgLiftTest,
                         ::testing::Bool());
 
 }  // namespace

--- a/geometry/proximity/test/distance_sphere_to_shape_test.cc
+++ b/geometry/proximity/test/distance_sphere_to_shape_test.cc
@@ -372,7 +372,7 @@ TEST_F(DistancePairGeometryTest, SphereCylinderAutoDiffXd) {
 using ScalarTypes = ::testing::Types<double, AutoDiffXd>;
 template <typename T>
 class ComputeNarrowHalfspaceTest : public ::testing::Test {};
-TYPED_TEST_CASE(ComputeNarrowHalfspaceTest, ScalarTypes);
+TYPED_TEST_SUITE(ComputeNarrowHalfspaceTest, ScalarTypes);
 
 // Confirms that the distance fallback is *not* invoked for (sphere-X) pairs
 // where X is in {Sphere, Box, Cylinder}. Note the use of the `float` scalar.
@@ -664,7 +664,7 @@ CallbackScalarSupport<AutoDiffXd>::unsupported_pairs() {
   };
 }
 
-TYPED_TEST_CASE(CallbackScalarSupport, ScalarTypes);
+TYPED_TEST_SUITE(CallbackScalarSupport, ScalarTypes);
 
 // Tests that the pairs that are reported supported, run normally. The pairs
 // that are marked *unsupported* throw.
@@ -802,7 +802,7 @@ GTEST_TEST(Callback, ABOrdering) {
 // set.)
 template <typename T>
 class CallbackMaxDistanceTest : public ::testing::Test {};
-TYPED_TEST_CASE(CallbackMaxDistanceTest, ScalarTypes);
+TYPED_TEST_SUITE(CallbackMaxDistanceTest, ScalarTypes);
 
 TYPED_TEST(CallbackMaxDistanceTest, MaxDistanceThreshold) {
   using T = TypeParam;

--- a/geometry/proximity/test/hydroelastic_callback_test.cc
+++ b/geometry/proximity/test/hydroelastic_callback_test.cc
@@ -87,7 +87,7 @@ GTEST_TEST(HydroelasticCallbackAutodiff, AutoDiffBlanketFailure) {
 
 // Infrastructure to repeat tests on both double and AutoDiffXd.
 using ScalarTypes = ::testing::Types<double>;
-TYPED_TEST_CASE(HydroelasticCallbackTyped, ScalarTypes);
+TYPED_TEST_SUITE(HydroelasticCallbackTyped, ScalarTypes);
 
 template <typename T>
 class HydroelasticCallbackTyped : public ::testing::Test {

--- a/geometry/proximity/test/mesh_half_space_intersection_test.cc
+++ b/geometry/proximity/test/mesh_half_space_intersection_test.cc
@@ -177,7 +177,7 @@ class MeshHalfspaceIntersectionTest : public ::testing::Test {
       edges_to_newly_created_vertices_;
   std::unique_ptr<HalfSpace<T>> half_space_H_;
 };  // namespace
-TYPED_TEST_CASE_P(MeshHalfspaceIntersectionTest);
+TYPED_TEST_SUITE_P(MeshHalfspaceIntersectionTest);
 
 // Verifies that a triangle that lies fully outside of the half space yields an
 // empty intersection. This covers Case 4 in the code.
@@ -567,14 +567,14 @@ TYPED_TEST_P(MeshHalfspaceIntersectionTest, BoxMesh) {
   ASSERT_EQ(intersection_mesh.num_faces(), 14);
 }
 
-REGISTER_TYPED_TEST_CASE_P(MeshHalfspaceIntersectionTest, NoIntersection,
+REGISTER_TYPED_TEST_SUITE_P(MeshHalfspaceIntersectionTest, NoIntersection,
                            InsideOrOnIntersection,
                            VertexOnHalfspaceIntersection,
                            EdgeOnHalfspaceIntersection, QuadrilateralResults,
                            OutsideInsideOn, OneInsideTwoOutside, BoxMesh);
 
 typedef ::testing::Types<double, AutoDiffXd> MyTypes;
-INSTANTIATE_TYPED_TEST_CASE_P(My, MeshHalfspaceIntersectionTest, MyTypes);
+INSTANTIATE_TYPED_TEST_SUITE_P(My, MeshHalfspaceIntersectionTest, MyTypes);
 
 }  // namespace
 }  // namespace geometry

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -3302,7 +3302,7 @@ class RemoveRoleTests : public GeometryStateTestBase,
   }
 };
 
-INSTANTIATE_TEST_CASE_P(GeometryStateTest, RemoveRoleTests,
+INSTANTIATE_TEST_SUITE_P(GeometryStateTest, RemoveRoleTests,
                         ::testing::Values(Role::kProximity,
                                           Role::kIllustration,
                                           Role::kPerception));

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -1173,50 +1173,50 @@ TEST_P(SignedDistanceToPointTest, SingleQueryPointWithThreshold) {
 // GenDistanceTestDataSphere() with the function
 // TEST_P(SignedDistanceToPointTest, SingleQueryPoint).
 // Sphere
-INSTANTIATE_TEST_CASE_P(Sphere, SignedDistanceToPointTest,
+INSTANTIATE_TEST_SUITE_P(Sphere, SignedDistanceToPointTest,
                         testing::ValuesIn(GenDistanceTestDataSphere()));
 
-INSTANTIATE_TEST_CASE_P(TransformSphere, SignedDistanceToPointTest,
+INSTANTIATE_TEST_SUITE_P(TransformSphere, SignedDistanceToPointTest,
                         testing::ValuesIn(GenDistTestTransformSphere()));
 
 // Box
-INSTANTIATE_TEST_CASE_P(OutsideBox, SignedDistanceToPointTest,
+INSTANTIATE_TEST_SUITE_P(OutsideBox, SignedDistanceToPointTest,
                         testing::ValuesIn(GenDistanceTestDataOutsideBox()));
-INSTANTIATE_TEST_CASE_P(BoxBoundary, SignedDistanceToPointTest,
+INSTANTIATE_TEST_SUITE_P(BoxBoundary, SignedDistanceToPointTest,
                         testing::ValuesIn(GenDistanceTestDataBoxBoundary()));
-INSTANTIATE_TEST_CASE_P(InsideBoxUnique, SignedDistanceToPointTest,
+INSTANTIATE_TEST_SUITE_P(InsideBoxUnique, SignedDistanceToPointTest,
                         testing::ValuesIn(GenDistTestDataInsideBoxUnique()));
-INSTANTIATE_TEST_CASE_P(InsideBoxNonUnique, SignedDistanceToPointTest,
+INSTANTIATE_TEST_SUITE_P(InsideBoxNonUnique, SignedDistanceToPointTest,
                         testing::ValuesIn(GenDistTestDataInsideBoxNonUnique()));
-INSTANTIATE_TEST_CASE_P(TranslateBox, SignedDistanceToPointTest,
+INSTANTIATE_TEST_SUITE_P(TranslateBox, SignedDistanceToPointTest,
                         testing::ValuesIn(GenDistanceTestDataTranslateBox()));
-INSTANTIATE_TEST_CASE_P(TransformOutsideBox, SignedDistanceToPointTest,
+INSTANTIATE_TEST_SUITE_P(TransformOutsideBox, SignedDistanceToPointTest,
                         testing::ValuesIn(GenDistTestTransformOutsideBox()));
-INSTANTIATE_TEST_CASE_P(TransformBoxBoundary, SignedDistanceToPointTest,
+INSTANTIATE_TEST_SUITE_P(TransformBoxBoundary, SignedDistanceToPointTest,
                         testing::ValuesIn(GenDistTestTransformBoxBoundary()));
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     TransformInsideBoxUnique, SignedDistanceToPointTest,
     testing::ValuesIn(GenDistTestTransformInsideBoxUnique()));
 
 // Cylinder
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     CylinderBoundary, SignedDistanceToPointTest,
     testing::ValuesIn(GenDistTestDataCylinderBoundary()));
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     OutsideCylinder, SignedDistanceToPointTest,
     testing::ValuesIn(GenDistTestDataOutsideCylinder()));
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InsideCylinder, SignedDistanceToPointTest,
     testing::ValuesIn(GenDistTestDataInsideCylinder()));
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     CenterCylinder, SignedDistanceToPointTest,
     testing::ValuesIn(GenDistTestDataCylinderCenter()));
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     CylinderTransform, SignedDistanceToPointTest,
     testing::ValuesIn(GenDistTestDataCylinderTransform()));
 
 // Half space
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Halfspace, SignedDistanceToPointTest,
     testing::ValuesIn(GenDistTestDataHalfSpace()));
 
@@ -1833,7 +1833,7 @@ GTEST_TEST(ProximityEngineTests, PairwiseSignedDistanceNonPositiveThreshold) {
 //    ComputeSignedDistancePairwiseClosestPoints() from here.
 //    See TEST_P(SignedDistancePairTest, SinglePair), for example.
 // 4. Initiate all the tests by specifying the test fixture and the test data.
-//    See INSTANTIATE_TEST_CASE_P() below.
+//    See INSTANTIATE_TEST_SUITE_P() below.
 class SignedDistancePairTestData {
  public:
   SignedDistancePairTestData(shared_ptr<const Shape> a,
@@ -2522,46 +2522,46 @@ TEST_P(SignedDistancePairTest, SinglePair) {
     << "Distance between witness points do not equal the signed distance.";
 }
 
-INSTANTIATE_TEST_CASE_P(SphereSphere, SignedDistancePairTest,
+INSTANTIATE_TEST_SUITE_P(SphereSphere, SignedDistancePairTest,
     testing::ValuesIn(GenDistancePairTestSphereSphere()));
-INSTANTIATE_TEST_CASE_P(SphereSphereTransform, SignedDistancePairTest,
+INSTANTIATE_TEST_SUITE_P(SphereSphereTransform, SignedDistancePairTest,
     testing::ValuesIn(GenDistPairTestSphereSphereTransform()));
-INSTANTIATE_TEST_CASE_P(SphereSphereGimbalLock, SignedDistancePairTest,
+INSTANTIATE_TEST_SUITE_P(SphereSphereGimbalLock, SignedDistancePairTest,
     testing::ValuesIn(GenDistPairTestSphereSphereGimbalLock()));
 
-INSTANTIATE_TEST_CASE_P(SphereSphreNonAligned, SignedDistancePairTest,
+INSTANTIATE_TEST_SUITE_P(SphereSphreNonAligned, SignedDistancePairTest,
     testing::ValuesIn(GenDistPairTestSphereSphereNonAligned()));
-INSTANTIATE_TEST_CASE_P(SphereSphreNonAlignedTransform, SignedDistancePairTest,
+INSTANTIATE_TEST_SUITE_P(SphereSphreNonAlignedTransform, SignedDistancePairTest,
     testing::ValuesIn(GenDistPairTestSphereSphereNonAlignedTransform()));
 
-INSTANTIATE_TEST_CASE_P(SphereBox, SignedDistancePairTest,
+INSTANTIATE_TEST_SUITE_P(SphereBox, SignedDistancePairTest,
     testing::ValuesIn(GenDistPairTestSphereBox()));
-INSTANTIATE_TEST_CASE_P(SphereBoxTransform, SignedDistancePairTest,
+INSTANTIATE_TEST_SUITE_P(SphereBoxTransform, SignedDistancePairTest,
     testing::ValuesIn(GenDistPairTestSphereBoxTransform()));
-INSTANTIATE_TEST_CASE_P(SphereBoxGimbalLock, SignedDistancePairTest,
+INSTANTIATE_TEST_SUITE_P(SphereBoxGimbalLock, SignedDistancePairTest,
     testing::ValuesIn(GenDistPairTestSphereBoxGimbalLock()));
 
-INSTANTIATE_TEST_CASE_P(BoxSphere, SignedDistancePairTest,
+INSTANTIATE_TEST_SUITE_P(BoxSphere, SignedDistancePairTest,
     testing::ValuesIn(GenDistPairTestBoxSphere()));
-INSTANTIATE_TEST_CASE_P(BoxSphereTransform, SignedDistancePairTest,
+INSTANTIATE_TEST_SUITE_P(BoxSphereTransform, SignedDistancePairTest,
     testing::ValuesIn(GenDistPairTestBoxSphereTransform()));
 
-INSTANTIATE_TEST_CASE_P(SphereBoxBoundary, SignedDistancePairTest,
+INSTANTIATE_TEST_SUITE_P(SphereBoxBoundary, SignedDistancePairTest,
     testing::ValuesIn(GenDistPairTestSphereBoxBoundary()));
-INSTANTIATE_TEST_CASE_P(SphereBoxBoundaryTransform, SignedDistancePairTest,
+INSTANTIATE_TEST_SUITE_P(SphereBoxBoundaryTransform, SignedDistancePairTest,
     testing::ValuesIn(GenDistPairTestSphereBoxBoundaryTransform()));
 
-INSTANTIATE_TEST_CASE_P(SphereCylinder, SignedDistancePairTest,
+INSTANTIATE_TEST_SUITE_P(SphereCylinder, SignedDistancePairTest,
     testing::ValuesIn(GenDistPairTestSphereCylinder()));
-INSTANTIATE_TEST_CASE_P(SphereCylinderTransform, SignedDistancePairTest,
+INSTANTIATE_TEST_SUITE_P(SphereCylinderTransform, SignedDistancePairTest,
     testing::ValuesIn(GenDistPairTestSphereCylinderTransform()));
-INSTANTIATE_TEST_CASE_P(SphereCylinderBoundary, SignedDistancePairTest,
+INSTANTIATE_TEST_SUITE_P(SphereCylinderBoundary, SignedDistancePairTest,
     testing::ValuesIn(GenDistPairTestSphereCylinderBoundary()));
-INSTANTIATE_TEST_CASE_P(SphereCylinderBoundaryTransform,
+INSTANTIATE_TEST_SUITE_P(SphereCylinderBoundaryTransform,
     SignedDistancePairTest,
     testing::ValuesIn(GenDistPairTestSphereCylinderBoundaryTransform()));
 
-INSTANTIATE_TEST_CASE_P(HalfspaceSphere,
+INSTANTIATE_TEST_SUITE_P(HalfspaceSphere,
                         SignedDistancePairTest,
                         testing::ValuesIn(GenDistPairTestHalfspaceSphere()));
 
@@ -2739,20 +2739,20 @@ GenDistPairTestSphereBoxConcentricTransform() {
       RotationMatrixd(RollPitchYawd(M_PI, M_PI/6., M_PI)));
 }
 
-INSTANTIATE_TEST_CASE_P(SphereSphereConcentric,
+INSTANTIATE_TEST_SUITE_P(SphereSphereConcentric,
     SignedDistancePairConcentricTest,
     testing::ValuesIn(GenDistPairTestSphereSphereConcentric()));
-INSTANTIATE_TEST_CASE_P(SphereSphereConcentricTransform,
+INSTANTIATE_TEST_SUITE_P(SphereSphereConcentricTransform,
     SignedDistancePairConcentricTest,
     testing::ValuesIn(GenDistPairTestSphereSphereConcentricTransform()));
-INSTANTIATE_TEST_CASE_P(SphereSphereConcentricGimbalLock,
+INSTANTIATE_TEST_SUITE_P(SphereSphereConcentricGimbalLock,
     SignedDistancePairConcentricTest,
     testing::ValuesIn(GenDistPairTestSphereSphereConcentricGimbalLock()));
 
-INSTANTIATE_TEST_CASE_P(SphereBoxConcentric,
+INSTANTIATE_TEST_SUITE_P(SphereBoxConcentric,
     SignedDistancePairConcentricTest,
     testing::ValuesIn(GenDistPairTestSphereBoxConcentric()));
-INSTANTIATE_TEST_CASE_P(SphereBoxConcentricTransform,
+INSTANTIATE_TEST_SUITE_P(SphereBoxConcentricTransform,
     SignedDistancePairConcentricTest,
     testing::ValuesIn(GenDistPairTestSphereBoxConcentricTransform()));
 

--- a/manipulation/models/allegro_hand_description/test/parse_test.cc
+++ b/manipulation/models/allegro_hand_description/test/parse_test.cc
@@ -54,7 +54,7 @@ TEST_P(ParseTest, Quantities) {
   EXPECT_EQ(plant.num_velocities(left_hand_index), 22);
 }
 
-INSTANTIATE_TEST_CASE_P(Both, ParseTest, testing::Values("sdf", "urdf"));
+INSTANTIATE_TEST_SUITE_P(Both, ParseTest, testing::Values("sdf", "urdf"));
 
 }  // namespace
 }  // namespace manipulation

--- a/manipulation/models/ycb/test/parse_test.cc
+++ b/manipulation/models/ycb/test/parse_test.cc
@@ -81,7 +81,7 @@ TEST_P(ParseTest, Quantities) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(Both, ParseTest, testing::Values(
+INSTANTIATE_TEST_SUITE_P(Both, ParseTest, testing::Values(
     "003_cracker_box",
     "004_sugar_box",
     "005_tomato_soup_can",

--- a/manipulation/planner/test/robot_plan_interpolator_test.cc
+++ b/manipulation/planner/test/robot_plan_interpolator_test.cc
@@ -215,7 +215,7 @@ class TrajectoryTestClass : public testing::TestWithParam<InterpolatorType> {
   virtual void TearDown() {}
 };
 
-INSTANTIATE_TEST_CASE_P(InstantiationName, TrajectoryTestClass,
+INSTANTIATE_TEST_SUITE_P(InstantiationName, TrajectoryTestClass,
                         ::testing::Values(InterpolatorType::ZeroOrderHold,
                                           InterpolatorType::FirstOrderHold,
                                           InterpolatorType::Pchip,

--- a/multibody/math/test/spatial_algebra_test.cc
+++ b/multibody/math/test/spatial_algebra_test.cc
@@ -84,7 +84,7 @@ typedef ::testing::Types<
     SpatialForce<Expression>,
     SpatialAcceleration<Expression>,
     SpatialMomentum<Expression>> SpatialQuantityTypes;
-TYPED_TEST_CASE(SpatialQuantityTest, SpatialQuantityTypes);
+TYPED_TEST_SUITE(SpatialQuantityTest, SpatialQuantityTypes);
 
 // Tests default construction and proper size at compile time.
 TYPED_TEST(SpatialQuantityTest, SizeAtCompileTime) {
@@ -360,7 +360,7 @@ class SpatialVelocityTest : public ::testing::Test {
   // Spatial velocity of a frame Y measured in X and expressed in A.
   SpatialVelocity<ScalarType> V_XY_A_{w_XY_A_, v_XY_A_};
 };
-TYPED_TEST_CASE(SpatialVelocityTest, ScalarTypes);
+TYPED_TEST_SUITE(SpatialVelocityTest, ScalarTypes);
 
 // Unit tests for the composition of spatial velocities:
 // - Shift(): shift of a spatial velocity between two moving frames rigidly
@@ -504,7 +504,7 @@ typedef ::testing::Types<
     SpatialMomentum<AutoDiffXd>,
     SpatialForce<Expression>,
     SpatialMomentum<Expression>> ElementsInF6Types;
-TYPED_TEST_CASE(ElementsInF6Test, ElementsInF6Types);
+TYPED_TEST_SUITE(ElementsInF6Test, ElementsInF6Types);
 
 // Tests the shifting of a spatial force between two moving frames rigidly
 // attached to each other.
@@ -550,7 +550,7 @@ class SpatialAccelerationTest : public ::testing::Test {
   // Useful typedefs when witting unit tests to access types.
   typedef T ScalarType;
 };
-TYPED_TEST_CASE(SpatialAccelerationTest, ScalarTypes);
+TYPED_TEST_SUITE(SpatialAccelerationTest, ScalarTypes);
 
 // Unit test for the method SpatialAcceleration::Shift().
 // Case 1:
@@ -750,7 +750,7 @@ typedef ::testing::Types<
     SpatialForce<Expression>,
     SpatialAcceleration<Expression>,
     SpatialMomentum<Expression>> SymbolicSpatialQuantityTypes;
-TYPED_TEST_CASE(SymbolicSpatialQuantityTest, SymbolicSpatialQuantityTypes);
+TYPED_TEST_SUITE(SymbolicSpatialQuantityTest, SymbolicSpatialQuantityTypes);
 
 TYPED_TEST(SymbolicSpatialQuantityTest, ShiftOperatorIntoStream) {
   std::stringstream V_stream;
@@ -775,7 +775,7 @@ class MomentumDotVelocityTest : public ::testing::Test {
   SpatialVelocity<T> V_WBp_{Vector3<T>{7, 8, 9}, Vector3<T>{-1, -2, -3}};
   Vector3<T> p_PQ_{7, -3, 5};
 };
-TYPED_TEST_CASE(MomentumDotVelocityTest, ScalarTypes);
+TYPED_TEST_SUITE(MomentumDotVelocityTest, ScalarTypes);
 
 // Verifies the result of the dot product of a spatial momentum L_WBp (of a body
 // B in a frame W about a point P) with the spatial velocity V_WBp of frame Bp

--- a/multibody/parsing/test/acrobot_parser_test.cc
+++ b/multibody/parsing/test/acrobot_parser_test.cc
@@ -171,12 +171,12 @@ TEST_P(AcrobotModelTests, VerifyMassMatrixAgainstBenchmark) {
   VerifyModelMassMatrix(-M_PI / 3, -3 * M_PI / 4);
 }
 
-INSTANTIATE_TEST_CASE_P(SdfAcrobatModelTests,
+INSTANTIATE_TEST_SUITE_P(SdfAcrobatModelTests,
                         AcrobotModelTests,
                         ::testing::Values(test::LoadFromSdf));
 
 
-INSTANTIATE_TEST_CASE_P(UrdfAcrobatModelTests,
+INSTANTIATE_TEST_SUITE_P(UrdfAcrobatModelTests,
                         AcrobotModelTests,
                         ::testing::Values(test::LoadFromUrdf));
 

--- a/multibody/parsing/test/common_parser_test.cc
+++ b/multibody/parsing/test/common_parser_test.cc
@@ -146,11 +146,11 @@ TEST_P(MultibodyPlantLinkTests, LinksWithCollisions) {
 }
 
 
-INSTANTIATE_TEST_CASE_P(SdfMultibodyPlantLinkTests,
+INSTANTIATE_TEST_SUITE_P(SdfMultibodyPlantLinkTests,
                         MultibodyPlantLinkTests,
                         ::testing::Values(test::LoadFromSdf));
 
-INSTANTIATE_TEST_CASE_P(UrdfMultibodyPlantLinkTests,
+INSTANTIATE_TEST_SUITE_P(UrdfMultibodyPlantLinkTests,
                         MultibodyPlantLinkTests,
                         ::testing::Values(test::LoadFromUrdf));
 

--- a/multibody/plant/test/applied_generalized_force_test.cc
+++ b/multibody/plant/test/applied_generalized_force_test.cc
@@ -146,7 +146,7 @@ TEST_P(MultibodyPlantGeneralizedAppliedForceTest,
   }
 }
 
-INSTANTIATE_TEST_CASE_P(GravityCompensationTest,
+INSTANTIATE_TEST_SUITE_P(GravityCompensationTest,
                         MultibodyPlantGeneralizedAppliedForceTest,
                         ::testing::Values(0.0 /* continuous-time MBP */,
                                           1e-3 /* time stepping MBP */));

--- a/multibody/plant/test/hydroelastic_traction_test.cc
+++ b/multibody/plant/test/hydroelastic_traction_test.cc
@@ -764,7 +764,7 @@ const RigidTransform<double> poses[] = {
         drake::Vector3<double>(1, 2, 3))
 };
 
-INSTANTIATE_TEST_CASE_P(PoseInstantiations,
+INSTANTIATE_TEST_SUITE_P(PoseInstantiations,
                         MultibodyPlantHydroelasticTractionTests,
                         ::testing::ValuesIn(poses));
 

--- a/multibody/plant/test/inclined_plane_test.cc
+++ b/multibody/plant/test/inclined_plane_test.cc
@@ -214,7 +214,7 @@ TEST_P(InclinedPlaneTest, RollingSphereTest) {
 }
 
 // Instantiate the tests.
-INSTANTIATE_TEST_CASE_P(ContinuousAndTimeSteppingTest, InclinedPlaneTest,
+INSTANTIATE_TEST_SUITE_P(ContinuousAndTimeSteppingTest, InclinedPlaneTest,
                         ::testing::Bool());
 
 }  // namespace

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -2238,7 +2238,7 @@ TEST_P(KukaArmTest, CheckContinuousOrDiscreteModel) {
   EXPECT_EQ(!plant_->is_discrete(), this->GetParam() == 0);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Blank, KukaArmTest,
     testing::Values(0.0 /* continuous state */, 1e-3 /* discrete state */));
 

--- a/perception/test/depth_image_to_point_cloud_test.cc
+++ b/perception/test/depth_image_to_point_cloud_test.cc
@@ -217,7 +217,7 @@ class DepthImageToPointCloudTest : public ::testing::Test {
                                           Vector3d(1.1, -1.2, 1.3)};
   const RigidTransformd z_translation_{Vector3d(0.0, 0.0, 1.3)};
 };
-TYPED_TEST_CASE(DepthImageToPointCloudTest, AllConfigs);
+TYPED_TEST_SUITE(DepthImageToPointCloudTest, AllConfigs);
 
 // Verifies computed point cloud when pixel values are valid.
 TYPED_TEST(DepthImageToPointCloudTest, Basic) {

--- a/solvers/test/csdp_solver_test.cc
+++ b/solvers/test/csdp_solver_test.cc
@@ -249,7 +249,7 @@ TEST_P(TestEllipsoidsSeparation, TestSOCP) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(CsdpTest, TestEllipsoidsSeparation,
+INSTANTIATE_TEST_SUITE_P(CsdpTest, TestEllipsoidsSeparation,
                         ::testing::ValuesIn(GetEllipsoidsSeparationProblems()));
 
 TEST_P(TestFindSpringEquilibrium, TestSOCP) {
@@ -261,7 +261,7 @@ TEST_P(TestFindSpringEquilibrium, TestSOCP) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     CsdpTest, TestFindSpringEquilibrium,
     ::testing::ValuesIn(GetFindSpringEquilibriumProblems()));
 

--- a/solvers/test/gurobi_solver_test.cc
+++ b/solvers/test/gurobi_solver_test.cc
@@ -21,7 +21,7 @@ TEST_P(LinearProgramTest, TestLP) {
   prob()->RunProblem(&solver);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     GurobiTest, LinearProgramTest,
     ::testing::Combine(::testing::ValuesIn(linear_cost_form()),
                        ::testing::ValuesIn(linear_constraint_form()),
@@ -81,7 +81,7 @@ TEST_P(QuadraticProgramTest, TestQP) {
   prob()->RunProblem(&solver);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     GurobiTest, QuadraticProgramTest,
     ::testing::Combine(::testing::ValuesIn(quadratic_cost_form()),
                        ::testing::ValuesIn(linear_constraint_form()),
@@ -238,7 +238,7 @@ TEST_P(TestEllipsoidsSeparation, TestSOCP) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(GurobiTest, TestEllipsoidsSeparation,
+INSTANTIATE_TEST_SUITE_P(GurobiTest, TestEllipsoidsSeparation,
                         ::testing::ValuesIn(GetEllipsoidsSeparationProblems()));
 
 TEST_P(TestQPasSOCP, TestSOCP) {
@@ -248,7 +248,7 @@ TEST_P(TestQPasSOCP, TestSOCP) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(GurobiTest, TestQPasSOCP,
+INSTANTIATE_TEST_SUITE_P(GurobiTest, TestQPasSOCP,
                         ::testing::ValuesIn(GetQPasSOCPProblems()));
 
 TEST_P(TestFindSpringEquilibrium, TestSOCP) {
@@ -258,7 +258,7 @@ TEST_P(TestFindSpringEquilibrium, TestSOCP) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     GurobiTest, TestFindSpringEquilibrium,
     ::testing::ValuesIn(GetFindSpringEquilibriumProblems()));
 

--- a/solvers/test/ipopt_solver_test.cc
+++ b/solvers/test/ipopt_solver_test.cc
@@ -16,7 +16,7 @@ TEST_P(LinearProgramTest, TestLP) {
   prob()->RunProblem(&solver);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     IpoptTest, LinearProgramTest,
     ::testing::Combine(::testing::ValuesIn(linear_cost_form()),
                        ::testing::ValuesIn(linear_constraint_form()),
@@ -62,7 +62,7 @@ TEST_P(QuadraticProgramTest, TestQP) {
   prob()->RunProblem(&solver);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     IpoptTest, QuadraticProgramTest,
     ::testing::Combine(::testing::ValuesIn(quadratic_cost_form()),
                        ::testing::ValuesIn(linear_constraint_form()),

--- a/solvers/test/mixed_integer_optimization_util_test.cc
+++ b/solvers/test/mixed_integer_optimization_util_test.cc
@@ -546,7 +546,7 @@ TEST_P(BilinearProductMcCormickEnvelopeSos2Test, FeasiblePointTest) {
   TestFeasiblePoint();
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     TestMixedIntegerUtil, BilinearProductMcCormickEnvelopeSos2Test,
     ::testing::Combine(::testing::ValuesIn(std::vector<int>{2, 3}),
                        ::testing::ValuesIn(std::vector<int>{2, 3}),
@@ -586,7 +586,7 @@ TEST_P(BilinearProductMcCormickEnvelopeMultipleChoiceTest, FeasiblePointTest) {
   TestFeasiblePoint();
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     TestMixedIntegerUtil, BilinearProductMcCormickEnvelopeMultipleChoiceTest,
     ::testing::Combine(::testing::ValuesIn(std::vector<int>{2, 3}),
                        ::testing::ValuesIn(std::vector<int>{2, 3})));

--- a/solvers/test/mixed_integer_rotation_constraint_corner_test.cc
+++ b/solvers/test/mixed_integer_rotation_constraint_corner_test.cc
@@ -177,7 +177,7 @@ TEST_P(TestBoxSphereCorner, TestOrthogonal) {
 
 // It takes too long time to run the test under debug mode.
 #ifdef DRAKE_ASSERT_IS_ARMED
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     RotationTest, TestBoxSphereCorner,
     ::testing::Combine(
         ::testing::ValuesIn<std::vector<int>>({0}),      // Orthant
@@ -186,7 +186,7 @@ INSTANTIATE_TEST_CASE_P(
         ::testing::ValuesIn<std::vector<RotationMatrixIntervalBinning>>(
             {RotationMatrixIntervalBinning::kPosNegLinear})));
 #else
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     RotationTest, TestBoxSphereCorner,
     ::testing::Combine(
         ::testing::ValuesIn<std::vector<int>>({0, 1, 2, 3, 4, 5, 6,

--- a/solvers/test/mixed_integer_rotation_constraint_limit_test.cc
+++ b/solvers/test/mixed_integer_rotation_constraint_limit_test.cc
@@ -141,7 +141,7 @@ TEST_P(TestMinimumDistanceWOrthonormalSocp, Test) {
   SolveAndCheckSolution();
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     RotationTest, TestMinimumDistance,
     ::testing::Combine(
         ::testing::ValuesIn<
@@ -153,7 +153,7 @@ INSTANTIATE_TEST_CASE_P(
         ::testing::ValuesIn<std::vector<int>>(
             {1, 2, 3})));  // number of binary variables per half axis
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     RotationTest, TestMinimumDistanceWOrthonormalSocp,
     ::testing::Combine(
         ::testing::ValuesIn<

--- a/solvers/test/mixed_integer_rotation_constraint_test.cc
+++ b/solvers/test/mixed_integer_rotation_constraint_test.cc
@@ -260,7 +260,7 @@ TEST_P(TestMixedIntegerRotationConstraintGenerator, InexactRotationMatrix) {
   TestInexactRotationMatrix();
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     RotationTest, TestMixedIntegerRotationConstraintGenerator,
     ::testing::Combine(
         ::testing::ValuesIn<
@@ -300,7 +300,7 @@ TEST_P(TestRotationMatrixBoxSphereIntersection, InexactRotationMatrix) {
   TestInexactRotationMatrix();
 }
 
-INSTANTIATE_TEST_CASE_P(RotationTest, TestRotationMatrixBoxSphereIntersection,
+INSTANTIATE_TEST_SUITE_P(RotationTest, TestRotationMatrixBoxSphereIntersection,
                         ::testing::ValuesIn<std::vector<int>>({1, 2}));
 
 // Make sure that no two row or column vectors in R, which satisfies the
@@ -395,7 +395,7 @@ std::array<std::pair<int, int>, 3> vector_indices() {
   return idx;
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     RotationTest, TestOrthant,
     ::testing::Combine(
         ::testing::ValuesIn<std::vector<int>>(

--- a/solvers/test/mosek_solver_test.cc
+++ b/solvers/test/mosek_solver_test.cc
@@ -20,7 +20,7 @@ TEST_P(LinearProgramTest, TestLP) {
   prob()->RunProblem(&solver);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     MosekTest, LinearProgramTest,
     ::testing::Combine(::testing::ValuesIn(linear_cost_form()),
                        ::testing::ValuesIn(linear_constraint_form()),
@@ -61,7 +61,7 @@ TEST_P(QuadraticProgramTest, TestQP) {
   prob()->RunProblem(&solver);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     MosekTest, QuadraticProgramTest,
     ::testing::Combine(::testing::ValuesIn(quadratic_cost_form()),
                        ::testing::ValuesIn(linear_constraint_form()),
@@ -81,7 +81,7 @@ TEST_P(TestEllipsoidsSeparation, TestSOCP) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(MosekTest, TestEllipsoidsSeparation,
+INSTANTIATE_TEST_SUITE_P(MosekTest, TestEllipsoidsSeparation,
                         ::testing::ValuesIn(GetEllipsoidsSeparationProblems()));
 
 TEST_P(TestQPasSOCP, TestSOCP) {
@@ -91,7 +91,7 @@ TEST_P(TestQPasSOCP, TestSOCP) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(MosekTest, TestQPasSOCP,
+INSTANTIATE_TEST_SUITE_P(MosekTest, TestQPasSOCP,
                         ::testing::ValuesIn(GetQPasSOCPProblems()));
 
 TEST_P(TestFindSpringEquilibrium, TestSOCP) {
@@ -101,7 +101,7 @@ TEST_P(TestFindSpringEquilibrium, TestSOCP) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     MosekTest, TestFindSpringEquilibrium,
     ::testing::ValuesIn(GetFindSpringEquilibriumProblems()));
 

--- a/solvers/test/osqp_solver_test.cc
+++ b/solvers/test/osqp_solver_test.cc
@@ -52,7 +52,7 @@ TEST_P(QuadraticProgramTest, TestQP) {
   prob()->RunProblem(&solver);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     OsqpTest, QuadraticProgramTest,
     ::testing::Combine(::testing::ValuesIn(quadratic_cost_form()),
                        ::testing::ValuesIn(linear_constraint_form()),

--- a/solvers/test/rotation_constraint_test.cc
+++ b/solvers/test/rotation_constraint_test.cc
@@ -96,7 +96,7 @@ TEST_P(TestRpyLimitsFixture, TestRpyLimits) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     RotationTest, TestRpyLimitsFixture,
     ::testing::Range(1 << 1, 1 << 7, 2));
 

--- a/solvers/test/scs_solver_test.cc
+++ b/solvers/test/scs_solver_test.cc
@@ -152,7 +152,7 @@ TEST_P(LinearProgramTest, TestLP) {
   prob()->RunProblem(&solver);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     SCSTest, LinearProgramTest,
     ::testing::Combine(::testing::ValuesIn(linear_cost_form()),
                        ::testing::ValuesIn(linear_constraint_form()),
@@ -185,7 +185,7 @@ TEST_P(TestEllipsoidsSeparation, TestSOCP) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(SCSTest, TestEllipsoidsSeparation,
+INSTANTIATE_TEST_SUITE_P(SCSTest, TestEllipsoidsSeparation,
                         ::testing::ValuesIn(GetEllipsoidsSeparationProblems()));
 
 TEST_P(TestQPasSOCP, TestSOCP) {
@@ -195,7 +195,7 @@ TEST_P(TestQPasSOCP, TestSOCP) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(SCSTest, TestQPasSOCP,
+INSTANTIATE_TEST_SUITE_P(SCSTest, TestQPasSOCP,
                         ::testing::ValuesIn(GetQPasSOCPProblems()));
 
 TEST_P(TestFindSpringEquilibrium, TestSOCP) {
@@ -205,7 +205,7 @@ TEST_P(TestFindSpringEquilibrium, TestSOCP) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     SCSTest, TestFindSpringEquilibrium,
     ::testing::ValuesIn(GetFindSpringEquilibriumProblems()));
 
@@ -241,7 +241,7 @@ TEST_P(QuadraticProgramTest, TestQP) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     ScsTest, QuadraticProgramTest,
     ::testing::Combine(::testing::ValuesIn(quadratic_cost_form()),
                        ::testing::ValuesIn(linear_constraint_form()),

--- a/solvers/test/snopt_solver_test.cc
+++ b/solvers/test/snopt_solver_test.cc
@@ -36,7 +36,7 @@ TEST_P(LinearProgramTest, TestLP) {
   prob()->RunProblem(&solver);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     SnoptTest, LinearProgramTest,
     ::testing::Combine(::testing::ValuesIn(linear_cost_form()),
                        ::testing::ValuesIn(linear_constraint_form()),
@@ -68,7 +68,7 @@ TEST_P(QuadraticProgramTest, TestQP) {
   prob()->RunProblem(&solver);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     SnoptTest, QuadraticProgramTest,
     ::testing::Combine(::testing::ValuesIn(quadratic_cost_form()),
                        ::testing::ValuesIn(linear_constraint_form()),

--- a/systems/analysis/test/antiderivative_function_test.cc
+++ b/systems/analysis/test/antiderivative_function_test.cc
@@ -459,7 +459,7 @@ TEST_P(AntiderivativeFunctionAccuracyTest, TrigonometricFunctionTestCase) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(IncreasingAccuracyAntiderivativeFunctionTests,
+INSTANTIATE_TEST_SUITE_P(IncreasingAccuracyAntiderivativeFunctionTests,
                         AntiderivativeFunctionAccuracyTest,
                         ::testing::Values(1e-1, 1e-2, 1e-3, 1e-4));
 

--- a/systems/analysis/test/bogacki_shampine3_integrator_test.cc
+++ b/systems/analysis/test/bogacki_shampine3_integrator_test.cc
@@ -20,9 +20,10 @@ namespace systems {
 namespace analysis_test {
 
 typedef ::testing::Types<BogackiShampine3Integrator<double>> Types;
-INSTANTIATE_TYPED_TEST_CASE_P(My, ExplicitErrorControlledIntegratorTest, Types);
-INSTANTIATE_TYPED_TEST_CASE_P(My, PleidesTest, Types);
-INSTANTIATE_TYPED_TEST_CASE_P(My, GenericIntegratorTest, Types);
+// NOLINTNEXTLINE(whitespace/line_length)
+INSTANTIATE_TYPED_TEST_SUITE_P(My, ExplicitErrorControlledIntegratorTest, Types);
+INSTANTIATE_TYPED_TEST_SUITE_P(My, PleidesTest, Types);
+INSTANTIATE_TYPED_TEST_SUITE_P(My, GenericIntegratorTest, Types);
 
 // Tests accuracy for integrating the cubic system (with the state at time t
 // corresponding to f(t) ≡ t³ + t² + 12t + C) over t ∈ [0, 1]. BS3 is a third

--- a/systems/analysis/test/hermitian_dense_output_test.cc
+++ b/systems/analysis/test/hermitian_dense_output_test.cc
@@ -77,7 +77,7 @@ class HermitianDenseOutputTest : public ::testing::Test {
 // HermitianDenseOutput types to test.
 typedef ::testing::Types<double, AutoDiffXd> OutputTypes;
 
-TYPED_TEST_CASE(HermitianDenseOutputTest, OutputTypes);
+TYPED_TEST_SUITE(HermitianDenseOutputTest, OutputTypes);
 
 // Checks that HermitianDenseOutput consistency is ensured.
 TYPED_TEST(HermitianDenseOutputTest, OutputConsistency) {

--- a/systems/analysis/test/implicit_euler_integrator_test.cc
+++ b/systems/analysis/test/implicit_euler_integrator_test.cc
@@ -162,7 +162,7 @@ GTEST_TEST(ImplicitIntegratorErrorEstimatorTest, LinearTest) {
 // Test Euler integrator.
 typedef ::testing::Types<ImplicitEulerIntegrator<double>>
     MyTypes;
-INSTANTIATE_TYPED_TEST_CASE_P(My, ImplicitIntegratorTest, MyTypes);
+INSTANTIATE_TYPED_TEST_SUITE_P(My, ImplicitIntegratorTest, MyTypes);
 
 }  // namespace analysis_test
 }  // namespace systems

--- a/systems/analysis/test/initial_value_problem_test.cc
+++ b/systems/analysis/test/initial_value_problem_test.cc
@@ -416,7 +416,7 @@ TEST_P(InitialValueProblemAccuracyTest, ParticleInAGasForcedVelocity) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(IncreasingAccuracyInitialValueProblemTests,
+INSTANTIATE_TEST_SUITE_P(IncreasingAccuracyInitialValueProblemTests,
                         InitialValueProblemAccuracyTest,
                         ::testing::Values(1e-1, 1e-2, 1e-3, 1e-4, 1e-5));
 

--- a/systems/analysis/test/radau_integrator_test.cc
+++ b/systems/analysis/test/radau_integrator_test.cc
@@ -450,7 +450,7 @@ GTEST_TEST(RadauIntegratorTest, Radau1MatchesImplicitEuler) {
 // Test both 1-stage (1st order) and 2-stage (3rd order) Radau integrators.
 typedef ::testing::Types<RadauIntegrator<double, 1>, RadauIntegrator<double, 2>>
     MyTypes;
-INSTANTIATE_TYPED_TEST_CASE_P(My, ImplicitIntegratorTest, MyTypes);
+INSTANTIATE_TYPED_TEST_SUITE_P(My, ImplicitIntegratorTest, MyTypes);
 
 }  // namespace analysis_test
 }  // namespace systems

--- a/systems/analysis/test/runge_kutta3_integrator_test.cc
+++ b/systems/analysis/test/runge_kutta3_integrator_test.cc
@@ -20,9 +20,10 @@ namespace systems {
 namespace analysis_test {
 
 typedef ::testing::Types<RungeKutta3Integrator<double>> Types;
-INSTANTIATE_TYPED_TEST_CASE_P(My, ExplicitErrorControlledIntegratorTest, Types);
-INSTANTIATE_TYPED_TEST_CASE_P(My, PleidesTest, Types);
-INSTANTIATE_TYPED_TEST_CASE_P(My, GenericIntegratorTest, Types);
+// NOLINTNEXTLINE(whitespace/line_length)
+INSTANTIATE_TYPED_TEST_SUITE_P(My, ExplicitErrorControlledIntegratorTest, Types);
+INSTANTIATE_TYPED_TEST_SUITE_P(My, PleidesTest, Types);
+INSTANTIATE_TYPED_TEST_SUITE_P(My, GenericIntegratorTest, Types);
 
 // Tests accuracy for integrating the cubic system (with the state at time t
 // corresponding to f(t) ≡ t³ + t² + 12t + C) over t ∈ [0, 1]. RK3 is a third

--- a/systems/analysis/test/runge_kutta5_integrator_test.cc
+++ b/systems/analysis/test/runge_kutta5_integrator_test.cc
@@ -19,9 +19,10 @@ namespace systems {
 namespace analysis_test {
 
 typedef ::testing::Types<RungeKutta5Integrator<double>> Types;
-INSTANTIATE_TYPED_TEST_CASE_P(My, ExplicitErrorControlledIntegratorTest, Types);
-INSTANTIATE_TYPED_TEST_CASE_P(My, PleidesTest, Types);
-INSTANTIATE_TYPED_TEST_CASE_P(My, GenericIntegratorTest, Types);
+// NOLINTNEXTLINE(whitespace/line_length)
+INSTANTIATE_TYPED_TEST_SUITE_P(My, ExplicitErrorControlledIntegratorTest, Types);
+INSTANTIATE_TYPED_TEST_SUITE_P(My, PleidesTest, Types);
+INSTANTIATE_TYPED_TEST_SUITE_P(My, GenericIntegratorTest, Types);
 
 // Tests accuracy for integrating the quintic system (with the state at time t
 // corresponding to f(t) ≡ t⁵ + 2t⁴ + 3t³ + 4t² + 5t + C) over t ∈ [0, 1].

--- a/systems/analysis/test/scalar_initial_value_problem_test.cc
+++ b/systems/analysis/test/scalar_initial_value_problem_test.cc
@@ -354,7 +354,7 @@ TEST_P(ScalarInitialValueProblemAccuracyTest, PopulationGrowth) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(IncreasingAccuracyScalarInitialValueProblemTests,
+INSTANTIATE_TEST_SUITE_P(IncreasingAccuracyScalarInitialValueProblemTests,
                         ScalarInitialValueProblemAccuracyTest,
                         ::testing::Values(1e-1, 1e-2, 1e-3, 1e-4, 1e-5));
 

--- a/systems/analysis/test/scalar_view_dense_output_test.cc
+++ b/systems/analysis/test/scalar_view_dense_output_test.cc
@@ -45,7 +45,7 @@ class ScalarViewDenseOutputTest : public ::testing::Test {
 
 typedef ::testing::Types<double, AutoDiffXd> ExtensionTypes;
 
-TYPED_TEST_CASE(ScalarViewDenseOutputTest, ExtensionTypes);
+TYPED_TEST_SUITE(ScalarViewDenseOutputTest, ExtensionTypes);
 
 // Checks that ScalarViewDenseOutput properly wraps a
 // DenseOutput instance.

--- a/systems/analysis/test_utilities/explicit_error_controlled_integrator_test.h
+++ b/systems/analysis/test_utilities/explicit_error_controlled_integrator_test.h
@@ -38,7 +38,7 @@ struct ExplicitErrorControlledIntegratorTest : public ::testing::Test {
   const double kMass = 2.0;        // kg
 };
 
-TYPED_TEST_CASE_P(ExplicitErrorControlledIntegratorTest);
+TYPED_TEST_SUITE_P(ExplicitErrorControlledIntegratorTest);
 
 TYPED_TEST_P(ExplicitErrorControlledIntegratorTest, ReqInitialStepTarget) {
   // Set the requested initial step size.
@@ -476,7 +476,7 @@ TYPED_TEST_P(ExplicitErrorControlledIntegratorTest, CheckStat) {
             this->kDt);
 }
 
-REGISTER_TYPED_TEST_CASE_P(ExplicitErrorControlledIntegratorTest,
+REGISTER_TYPED_TEST_SUITE_P(ExplicitErrorControlledIntegratorTest,
     ReqInitialStepTarget, ContextAccess, ErrorEstSupport, MagDisparity, Scaling,
     BulletProofSetup, ErrEstOrder, SpringMassStepEC, MaxStepSizeRespected,
     IllegalFixedStep, CheckStat, StepToCurrentTimeNoOp);
@@ -499,7 +499,7 @@ struct PleidesTest : public ::testing::Test {
   std::unique_ptr<IntegratorBase<double>> integrator;
 };
 
-TYPED_TEST_CASE_P(PleidesTest);
+TYPED_TEST_SUITE_P(PleidesTest);
 
 // Verifies that the Pleides system can be integrated accurately.
 TYPED_TEST_P(PleidesTest, Pleides) {
@@ -536,7 +536,7 @@ TYPED_TEST_P(PleidesTest, Pleides) {
     EXPECT_NEAR(q[i], q_des[i], kTolerance) << i;
 }
 
-REGISTER_TYPED_TEST_CASE_P(PleidesTest, Pleides);
+REGISTER_TYPED_TEST_SUITE_P(PleidesTest, Pleides);
 
 }  // namespace analysis_test
 }  // namespace systems

--- a/systems/analysis/test_utilities/generic_integrator_test.h
+++ b/systems/analysis/test_utilities/generic_integrator_test.h
@@ -56,7 +56,7 @@ struct GenericIntegratorTest : public ::testing::Test {
   std::unique_ptr<T> integrator_;
 };
 
-TYPED_TEST_CASE_P(GenericIntegratorTest);
+TYPED_TEST_SUITE_P(GenericIntegratorTest);
 
 // Verifies that the dense output is working for an integrator.
 TYPED_TEST_P(GenericIntegratorTest, DenseOutput) {
@@ -100,7 +100,7 @@ TYPED_TEST_P(GenericIntegratorTest, DenseOutput) {
   EXPECT_LT(dense_output->end_time(), this->context_->get_time());
 }
 
-REGISTER_TYPED_TEST_CASE_P(GenericIntegratorTest, DenseOutput);
+REGISTER_TYPED_TEST_SUITE_P(GenericIntegratorTest, DenseOutput);
 
 }  // namespace analysis_test
 }  // namespace systems

--- a/systems/analysis/test_utilities/implicit_integrator_test.h
+++ b/systems/analysis/test_utilities/implicit_integrator_test.h
@@ -646,7 +646,7 @@ class ImplicitIntegratorTest : public ::testing::Test {
   /// that the system is overdamped.
   const double stiff_damping_b_ = 1e8;
 };
-TYPED_TEST_CASE_P(ImplicitIntegratorTest);
+TYPED_TEST_SUITE_P(ImplicitIntegratorTest);
 
 TYPED_TEST_P(ImplicitIntegratorTest, MiscAPINoReuse) {
   this->MiscAPITest(kNoReuse);
@@ -761,7 +761,7 @@ TYPED_TEST_P(ImplicitIntegratorTest, SpringMassStepAccuracyEffectsReuse) {
   this->SpringMassStepAccuracyEffectsTest(kReuse);
 }
 
-REGISTER_TYPED_TEST_CASE_P(
+REGISTER_TYPED_TEST_SUITE_P(
     ImplicitIntegratorTest, MiscAPINoReuse, MiscAPIReuse,
     FixedStepThrowsOnMultiStep, ContextAccess, AccuracyEstAndErrorControl,
     DoubleSpringMassDamperNoReuse, DoubleSpringMassDamperReuse,

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -1890,7 +1890,7 @@ using FeedthroughTestScalars = ::testing::Types<
 
 template <typename T>
 class FeedthroughTypedTest : public ::testing::Test {};
-TYPED_TEST_CASE(FeedthroughTypedTest, FeedthroughTestScalars);
+TYPED_TEST_SUITE(FeedthroughTypedTest, FeedthroughTestScalars);
 
 // The sparsity of a System should be inferred from its symbolic form.
 TYPED_TEST(FeedthroughTypedTest, SymbolicSparsity) {

--- a/systems/framework/test/userscalar_acceptance_test.cc
+++ b/systems/framework/test/userscalar_acceptance_test.cc
@@ -22,7 +22,7 @@ using VariousScalars = ::testing::Types<
 
 template <typename T>
 class UserscalarAcceptanceTest : public ::testing::Test {};
-TYPED_TEST_CASE(UserscalarAcceptanceTest, VariousScalars);
+TYPED_TEST_SUITE(UserscalarAcceptanceTest, VariousScalars);
 
 template <typename T>
 class TestSystem : public LeafSystem<T> {

--- a/systems/lcm/test/lcm_interface_system_test.cc
+++ b/systems/lcm/test/lcm_interface_system_test.cc
@@ -121,7 +121,7 @@ TEST_P(LcmInterfaceSystemTest, AcceptanceTest) {
   thread.reset();
 }
 
-INSTANTIATE_TEST_CASE_P(test, LcmInterfaceSystemTest,
+INSTANTIATE_TEST_SUITE_P(test, LcmInterfaceSystemTest,
                         ::testing::Values(0, 1, 2));
 
 }  // namespace

--- a/systems/primitives/test/discrete_time_delay_test.cc
+++ b/systems/primitives/test/discrete_time_delay_test.cc
@@ -166,7 +166,7 @@ TEST_P(DiscreteTimeDelayTest, ToSymbolic) {
 }
 
 // Instantiate parameterized test cases for is_abstract_ = {false, true}
-INSTANTIATE_TEST_CASE_P(test, DiscreteTimeDelayTest,
+INSTANTIATE_TEST_SUITE_P(test, DiscreteTimeDelayTest,
                         ::testing::Values(false, true));
 
 // Create a simple Diagram to simulate:

--- a/systems/primitives/test/pass_through_test.cc
+++ b/systems/primitives/test/pass_through_test.cc
@@ -108,7 +108,7 @@ TEST_P(PassThroughTest, ToSymbolic) {
 }
 
 // Instantiate parameterized test cases for is_abstract_ = {false, true}
-INSTANTIATE_TEST_CASE_P(test, PassThroughTest,
+INSTANTIATE_TEST_SUITE_P(test, PassThroughTest,
     ::testing::Values(false, true));
 
 }  // namespace

--- a/systems/primitives/test/trajectory_affine_system_test.cc
+++ b/systems/primitives/test/trajectory_affine_system_test.cc
@@ -159,7 +159,7 @@ TEST_P(TrajectoryAffineSystemTest, ScalarTypeConversion) {
   EXPECT_FALSE(is_symbolic_convertible(*dut_));
 }
 
-INSTANTIATE_TEST_CASE_P(Constructor, TrajectoryAffineSystemTest,
+INSTANTIATE_TEST_SUITE_P(Constructor, TrajectoryAffineSystemTest,
                         testing::Values(ConstructorType::FromContinuous,
                                         ConstructorType::FromDiscrete));
 

--- a/systems/primitives/test/trajectory_linear_system_test.cc
+++ b/systems/primitives/test/trajectory_linear_system_test.cc
@@ -151,7 +151,7 @@ TEST_P(TrajectoryLinearSystemTest, ScalarTypeConversion) {
   EXPECT_FALSE(is_symbolic_convertible(*dut_));
 }
 
-INSTANTIATE_TEST_CASE_P(Constructor, TrajectoryLinearSystemTest,
+INSTANTIATE_TEST_SUITE_P(Constructor, TrajectoryLinearSystemTest,
                         testing::Values(ConstructorType::FromContinuous,
                                         ConstructorType::FromDiscrete));
 

--- a/systems/primitives/test/zero_order_hold_test.cc
+++ b/systems/primitives/test/zero_order_hold_test.cc
@@ -201,7 +201,7 @@ TEST_P(ZeroOrderHoldTest, ToSymbolic) {
 }
 
 // Instantiate parameterized test cases for is_abstract_ = {false, true}
-INSTANTIATE_TEST_CASE_P(test, ZeroOrderHoldTest,
+INSTANTIATE_TEST_SUITE_P(test, ZeroOrderHoldTest,
     ::testing::Values(false, true));
 
 // Create a simple Diagram like this:

--- a/tools/workspace/gtest/repository.bzl
+++ b/tools/workspace/gtest/repository.bzl
@@ -8,8 +8,8 @@ def gtest_repository(
     github_archive(
         name = name,
         repository = "google/googletest",
-        commit = "release-1.8.1",
-        sha256 = "9bf1fe5182a604b4135edc1a425ae356c9ad15e9b23f9f12a02e80184c3a249c",  # noqa
+        commit = "release-1.10.0",
+        sha256 = "9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb",  # noqa
         build_file = "@drake//tools/workspace/gtest:package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
The new release deprecates `TEST_CASE` macro spellings, now preferring to spell that as `TEST_SUITE`.  Port all Drake code to the new spelling.

Downstream builds that reuse our `@gtest` will receive deprecation warnings, but old spellings continue to work correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12267)
<!-- Reviewable:end -->
