### PR TITLE
Deprecate drake_optional.h header

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -784,6 +784,10 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "drake_optional_test",
+    copts = [
+        "-Wno-cpp",
+        "-Wno-deprecated-declarations",
+    ],
     deps = [
         ":essential",
     ],

--- a/common/drake_optional.h
+++ b/common/drake_optional.h
@@ -1,15 +1,27 @@
 #pragma once
 
+// NOLINTNEXTLINE(whitespace/line_length)
+#warning "drake/common/drake_optional.h" and drake::optional are deprecated and will be removed on or after 2020-02-01. Please use <optional> and std::optional instead.
+
 /// @file
-/// Provides drake::optional as an alias for std::optional.
+/// Provides drake::optional as a deprecated alias for std::optional.
 
 #include <optional>
+
+#include "drake/common/drake_deprecated.h"
 
 namespace drake {
 
 template <typename T>
-using optional = std::optional<T>;
+using optional
+    DRAKE_DEPRECATED("2020-02-01", "Please use std::optional instead.")
+    = std::optional<T>;
+
+DRAKE_DEPRECATED("2020-02-01", "Please use std::nullopt instead.")
 constexpr auto nullopt = std::nullopt;
-using nullopt_t = std::nullopt_t;
+
+using nullopt_t
+    DRAKE_DEPRECATED("2020-02-01", "Please use std::nullopt_t instead.")
+    = std::nullopt_t;
 
 }  // namespace drake


### PR DESCRIPTION
Depends on #12271,  #12272, #12273, #12274, #12275, #12276, and #12277.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12278)
<!-- Reviewable:end -->
