### PR TITLE
Revert "Ramp up anti-aliasing in the VTK color image"

### DIFF
--- a/geometry/render/render_engine_vtk.cc
+++ b/geometry/render/render_engine_vtk.cc
@@ -139,8 +139,6 @@ RenderEngineVtk::RenderEngineVtk(const RenderEngineVtkParams& parameters)
   const auto& c = parameters.default_clear_color;
   default_clear_color_ = ColorD{c(0), c(1), c(2)};
 
-  use_color_anti_aliasing_ = parameters.use_color_anti_aliasing;
-
   InitializePipelines();
 }
 
@@ -397,9 +395,15 @@ void RenderEngineVtk::InitializePipelines() {
 
   // Generic configuration of pipelines.
   for (auto& pipeline : pipelines_) {
-    // Multisampling disabled by design for label and depth. It is turned back
-    // on for the color image explicitly based on the use_color_anti_aliasing_
-    // value. Unit tests should keep it turned off.
+    // Multisampling disabled by design for label and depth. It's turned off for
+    // color because of a bug which affects on-screen rendering with NVidia
+    // drivers on Ubuntu 16.04. In certain very specific
+    // cases (camera position, scene, triangle drawing order, normal
+    // orientation), a plane surface has partial background pixels
+    // bleeding through it, which changes the color of the center pixel.
+    // TODO(fbudin69500) If lack of anti-aliasing in production code is
+    // problematic, change this to only disable anti-aliasing in unit
+    // tests. Alternatively, find other way to resolve the driver bug.
     pipeline->window->SetMultiSamples(0);
 
     auto camera = pipeline->renderer->GetActiveCamera();
@@ -433,16 +437,9 @@ void RenderEngineVtk::InitializePipelines() {
       empty_color.r, empty_color.g, empty_color.b);
 
   pipelines_[ImageType::kColor]->renderer->SetUseDepthPeeling(1);
+  pipelines_[ImageType::kColor]->renderer->UseFXAAOn();
   pipelines_[ImageType::kColor]->renderer->SetBackground(
       default_clear_color_.r, default_clear_color_.g, default_clear_color_.b);
-  if (use_color_anti_aliasing_ == VtkAntiAliasing::kOn) {
-    pipelines_[ImageType::kColor]->renderer->UseFXAAOn();
-    // TODO(SeanCurtis-TRI): VTK documentation is unclear on the interpretation
-    // of this value. However, we cargo-cult this value from
-    // https://gitlab.kitware.com/vtk/vtk/issues/17394
-    // If we can find a better basis for picking this value, do so.
-    pipelines_[ImageType::kColor]->window->SetMultiSamples(8);
-  }
 }
 
 void RenderEngineVtk::ImplementObj(const std::string& file_name, double scale,

--- a/geometry/render/render_engine_vtk.h
+++ b/geometry/render/render_engine_vtk.h
@@ -223,9 +223,6 @@ class RenderEngineVtk final : public RenderEngine,
   // The color to clear the color buffer to.
   systems::sensors::ColorD default_clear_color_;
 
-  // Determines whether color images are anti-aliased or not.
-  VtkAntiAliasing use_color_anti_aliasing_{VtkAntiAliasing::kOn};
-
   // The collection of per-geometry actors (one actor per pipeline (color,
   // depth, and label) keyed by the geometry's GeometryId.
   std::unordered_map<GeometryId, std::array<vtkSmartPointer<vtkActor>, 3>>

--- a/geometry/render/render_engine_vtk_factory.h
+++ b/geometry/render/render_engine_vtk_factory.h
@@ -8,13 +8,6 @@ namespace drake {
 namespace geometry {
 namespace render {
 
-/** Determines whether anti-aliasing is on or off. (Designed so that on is the
- default value.  */
-enum class VtkAntiAliasing {
-  kOn,
-  kOff
-};
-
 /** Construction parameters for the RenderEngineVtk.  */
 struct RenderEngineVtkParams  {
   /** The (optional) label to apply when none is otherwise specified.  */
@@ -29,11 +22,6 @@ struct RenderEngineVtkParams  {
    channel in the range [0, 1]). The default value (in byte values) would be
    [204, 229, 255].  */
   Eigen::Vector3d default_clear_color{204 / 255., 229 / 255., 255 / 255.};
-
-  /** Disables multi-sample anti-aliasing for color images if set to false.
-   Defaults to enabled. Note: by design there is no anti-aliasing for color
-   or depth images.  */
-  VtkAntiAliasing use_color_anti_aliasing{VtkAntiAliasing::kOn};
 };
 
 /** Constructs a RenderEngine implementation which uses a VTK-based OpenGL

--- a/geometry/render/test/render_engine_vtk_test.cc
+++ b/geometry/render/test/render_engine_vtk_test.cc
@@ -50,7 +50,7 @@ const int kHeight = 480;
 const double kZNear = 0.5;
 const double kZFar = 5.;
 const double kFovY = M_PI_4;
-const bool kShowWindow = true;
+const bool kShowWindow = false;
 
 // The following tolerance is used due to a precision difference between Ubuntu
 // Linux and Mac OSX.
@@ -310,7 +310,7 @@ class RenderEngineVtkTest : public ::testing::Test {
   void Init(const RigidTransformd& X_WR, bool add_terrain = false) {
     const Vector3d bg_rgb{
         kBgColor.r / 255., kBgColor.g / 255., kBgColor.b / 255.};
-    RenderEngineVtkParams params{{}, {}, bg_rgb, VtkAntiAliasing::kOff};
+    RenderEngineVtkParams params{{}, {}, bg_rgb};
     renderer_ = make_unique<RenderEngineVtk>(params);
     InitializeRenderer(X_WR, add_terrain, renderer_.get());
     // Ensure that we truly have a non-default color.
@@ -442,10 +442,7 @@ TEST_F(RenderEngineVtkTest, ControlBackgroundColor) {
   std::vector<ColorI> backgrounds{{10, 20, 30}, {128, 196, 255}, {255, 10, 40}};
   for (const auto& bg : backgrounds) {
     RenderEngineVtkParams params{
-        {},
-        {},
-        Vector3d{bg.r / 255., bg.g / 255., bg.b / 255.},
-        VtkAntiAliasing::kOff};
+        {}, {}, Vector3d{bg.r / 255., bg.g / 255., bg.b / 255.}};
     RenderEngineVtk engine(params);
     Render(&engine);
     VerifyUniformColor(bg, 0u);
@@ -547,64 +544,6 @@ TEST_F(RenderEngineVtkTest, BoxTest) {
       unordered_map<GeometryId, RigidTransformd>{{id, X_WV}});
 
   PerformCenterShapeTest(renderer_.get(), "Box test");
-}
-
-// Test that the anti-aliasing makes a difference. Place a box with the front
-// face perpendicular to the camera direction. With a directional light pointing
-// in the same direction as the camera direction, the face will be a single
-// solid color (against a uniform background). With anti-aliasing, we expect
-// there to be two unique colors. Without anti-aliasing there should be more
-// colors.
-TEST_F(RenderEngineVtkTest, AntiAliasTest) {
-  auto render_box = [this](VtkAntiAliasing anti_aliasing_state) {
-    const Vector3d bg_rgb{
-        kBgColor.r / 255., kBgColor.g / 255., kBgColor.b / 255.};
-    // For historical reasons, we disable the anti-aliasing for tests. In the
-    // past, there were circumstances in which this led to undesirable
-    // artifacts, (e.g. on-screen rendering with NVidia drivers on Ubuntu
-    // 16.04). Turning off anti-aliasing simplifies the tests.
-    RenderEngineVtkParams params{{}, {}, bg_rgb, anti_aliasing_state};
-    renderer_ = make_unique<RenderEngineVtk>(params);
-    InitializeRenderer(X_WC_, false, renderer_.get());
-
-    // Sets up a box.
-    Box box(1, 1, 1);
-    RigidTransformd X_WB{AngleAxisd{M_PI / 4, Vector3d::UnitZ()},
-                         Vector3d{0, 0, 0}};
-    expected_label_ = RenderLabel(1);
-    const GeometryId id = GeometryId::get_new_id();
-    renderer_->RegisterVisual(id, box, simple_material(), X_WB,
-                              false /* needs update */);
-
-    const DepthCameraProperties camera{160, 120, kFovY, "unused",
-                                    kZNear, kZFar};
-    // Can't use the member images in case the camera has been configured to a
-    // different size than the default camera_ configuration.
-    ImageRgba8U color(camera.width, camera.height);
-    renderer_->RenderColorImage(camera, kShowWindow, &color);
-    return color;
-  };
-
-  // Count the number of unique colors in the image.
-  auto count_colors = [](const ImageRgba8U& image) {
-    std::set<int> unique_colors;
-    for (int r = 0; r < image.height(); ++r) {
-      for (int c = 0; c < image.width(); ++c) {
-        const ImageRgba8U::T* pixel = image.at(c, r);
-        // Encode rgba bytes into a single int.
-        int color_id =
-            (*pixel << 24) | (*(pixel + 1) << 16) | (*(pixel + 2) << 8) |
-            *(pixel + 3);
-        unique_colors.insert(color_id);
-      }
-    }
-    return static_cast<int>(unique_colors.size());
-  };
-
-  ImageRgba8U aliased_image = render_box(VtkAntiAliasing::kOff);
-  EXPECT_EQ(count_colors(aliased_image), 2);
-  ImageRgba8U smooth_image = render_box(VtkAntiAliasing::kOn);
-  EXPECT_GT(count_colors(smooth_image), 2);
 }
 
 // Performs the shape-centered-in-the-image test with a sphere.


### PR DESCRIPTION
Dear @SeanCurtis-TRI,

The on-call build cop, @BetsyMcPhail , believes that your PR #12264 may have
broken one or more of Drake's continuous integration builds [1]. It is
possible to break a build even if your PR passed continuous integration
pre-merge because additional platforms are tested post-merge.

The specific build failures under investigation are Mac builds, including:
https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/mac-mojave-clang-bazel-continuous-release/227/

Therefore, the build cop has created this revert PR and started a complete
post-merge build to determine whether your PR was in fact the cause of the
problem. If that build passes, this revert PR will be merged 60 minutes from
now. You can then fix the problem at your leisure, and send a new PR to
reinstate your change.

If you believe your original PR did not actually break the build, please
explain on this thread.

If you believe you can fix the break promptly in lieu of a revert, please
explain on this thread, and send a PR to the build cop for review ASAP.

If you believe your original PR definitely did break the build and should be
reverted, please review and LGTM this PR. This allows the build cop to merge
without waiting for CI results.

For advice on how to handle a build cop revert, see [2].

Thanks!
Your Friendly On-call Build Cop

[1] CI Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Production/
[2] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12286)
<!-- Reviewable:end -->
