### PR TITLE
workspace: Remove redundant --config=python3 from help strings

### DIFF
--- a/tools/workspace/mirror_to_s3.py
+++ b/tools/workspace/mirror_to_s3.py
@@ -9,7 +9,7 @@ Python 3 on macOS or Ubuntu 18.04 (Bionic Beaver).
 
 To run:
 
-  bazel build --config=python3 //tools/workspace:mirror_to_s3
+  bazel build //tools/workspace:mirror_to_s3
   bazel-bin/tools/workspace/mirror_to_s3 [--no-download] [--no-upload]
 
 The --no-download option implies --no-upload.

--- a/tools/workspace/new_release.py
+++ b/tools/workspace/new_release.py
@@ -8,12 +8,12 @@ two ways to do this:
 
 (1) Type in your password each time you run this program:
 
-  bazel build --config python3 //tools/workspace:new_release
+  bazel build //tools/workspace:new_release
   bazel-bin/tools/workspace/new_release
 
 (2) Use a GitHub API token:
 
-  bazel build --config python3 //tools/workspace:new_release
+  bazel build //tools/workspace:new_release
   env GITHUB_API_TOKEN=$(cat ~/.config/readonly_github_api_token.txt) \
     bazel-bin/tools/workspace/new_release
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12295)
<!-- Reviewable:end -->
