### PR TITLE
Remove deprecated mobilizer::SetRotationMatrix() from internal namespace

### DIFF
--- a/multibody/tree/quaternion_floating_mobilizer.h
+++ b/multibody/tree/quaternion_floating_mobilizer.h
@@ -144,25 +144,6 @@ class QuaternionFloatingMobilizer final : public MobilizerImpl<T, 7, 6> {
     return set_quaternion(context, q_FM);
   }
 
-  /// Sets `context` to store the quaternion `q_FM` which represents the same
-  /// orientation of M in F as given by the rotation matrix `R_FM`.
-  /// @param[out] context
-  ///   The context of the MultibodyTree to which this mobilizer belongs to.
-  /// @param[in] R_FM
-  ///   The desired orientation of M in F given as a rotation matrix.
-  /// @returns a constant reference to `this` mobilizer.
-  DRAKE_DEPRECATED("2020-02-01",
-                   "Use SetFromRotationMatrix(context, R_FM), where R_FM is a "
-                   "RotationMatrix, not an arbitrary Matrix3.  Alternatively, "
-                   "use set_quaternion(context, q_FM), where `q_FM` is a "
-                   "quaternion.")
-  const QuaternionFloatingMobilizer<T>& SetFromRotationMatrix(
-      systems::Context<T>* context, const Matrix3<T>& R_FM_approximate) const {
-    const Eigen::Quaternion<T> q_FM =
-        math::RotationMatrix<T>::ToQuaternion(R_FM_approximate);
-    return set_quaternion(context, q_FM);
-  }
-
   /// Returns the angular velocity `w_FM` of frame M in F stored in `context`.
   /// @param[in] context
   ///   The context of the MultibodyTree this mobilizer belongs to.

--- a/multibody/tree/space_xyz_mobilizer.h
+++ b/multibody/tree/space_xyz_mobilizer.h
@@ -128,36 +128,6 @@ class SpaceXYZMobilizer final : public MobilizerImpl<T, 3, 3> {
   const SpaceXYZMobilizer<T>& SetFromRotationMatrix(
       systems::Context<T>* context, const math::RotationMatrix<T>& R_FM) const;
 
-  /// Given a desired orientation `R_FM` of frame M in F as a rotation matrix,
-  /// This method sets `context` so that the generalized coordinates
-  /// corresponding to the space x-y-z angles θ₁, θ₂, θ₃ of `this` mobilizer
-  /// represent this rotation.
-  ///
-  /// @param[in] context
-  ///   The context of the MultibodyTree this mobilizer belongs to.
-  /// @param[in] R_FM
-  ///   The desired pose of M in F. A valid element of `SO(3)`.
-  /// @returns a constant reference to `this` mobilizer.
-  ///
-  /// @warning Ideally, `R_FM` would correspond to a valid rotation in the
-  /// special orthogonal group `SO(3)`. To eliminate possible round-off errors
-  /// in the input matrix `R_FM` this method performs a projection of `R_FM`
-  /// into its closest element in `SO(3)` and then computes the space x-y-z
-  /// angles θ₁, θ₂, θ₃ that correspond to this rotation.
-  /// See @ref RotationMatrix<T>::ProjectToRotationMatrix
-  ///
-  /// @throws std::logic_error if an improper rotation results after projection
-  /// of `R_FM`, that is, if the projected matrix's determinant is `-1`.
-  DRAKE_DEPRECATED("2020-02-01",
-                   "Use SetFromRotationMatrix(context, R_FM), where R_FM is a "
-                   "RotationMatrix, not an arbitrary Matrix3.")
-  const SpaceXYZMobilizer<T>& SetFromRotationMatrix(
-      systems::Context<T>* context, const Matrix3<T>& R_FM_approximate) const {
-    const math::RotationMatrix<T> R_FM =
-        math::RotationMatrix<T>::ProjectToRotationMatrix(R_FM_approximate);
-    return SetFromRotationMatrix(context, R_FM);
-  }
-
   /// Retrieves from `context` the angular velocity `w_FM` of the outboard frame
   /// M in the inboard frame F, expressed in F.
   ///

--- a/multibody/tree/test/quaternion_floating_mobilizer_test.cc
+++ b/multibody/tree/test/quaternion_floating_mobilizer_test.cc
@@ -61,15 +61,6 @@ TEST_F(QuaternionFloatingMobilizerTest, StateAccess) {
   EXPECT_TRUE(CompareMatrices(mobilizer_->get_quaternion(*context_).coeffs(),
                             Q_WB.coeffs(),
                             kTolerance, MatrixCompareType::relative));
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  // Set mobilizer orientation using a 3x3 matrix (deprecated).
-  mobilizer_->SetFromRotationMatrix(context_.get(), R_WB.matrix());
-  EXPECT_TRUE(CompareMatrices(mobilizer_->get_quaternion(*context_).coeffs(),
-                              Q_WB.coeffs(),
-                              kTolerance, MatrixCompareType::relative));
-#pragma GCC diagnostic push
 }
 
 TEST_F(QuaternionFloatingMobilizerTest, ZeroState) {

--- a/multibody/tree/test/space_xyz_mobilizer_test.cc
+++ b/multibody/tree/test/space_xyz_mobilizer_test.cc
@@ -55,15 +55,6 @@ TEST_F(SpaceXYZMobilizerTest, StateAccess) {
   EXPECT_TRUE(CompareMatrices(
     mobilizer_->get_angles(*context_), rpy.vector(),
     kTolerance, MatrixCompareType::relative));
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  // Set mobilizer orientation using a 3x3 matrix (deprecated).
-  mobilizer_->SetFromRotationMatrix(context_.get(), R_WB.matrix());
-  EXPECT_TRUE(CompareMatrices(
-      mobilizer_->get_angles(*context_), rpy.vector(),
-      kTolerance, MatrixCompareType::relative));
-#pragma GCC diagnostic push
 }
 
 TEST_F(SpaceXYZMobilizerTest, ZeroState) {


### PR DESCRIPTION
Repairs #12259.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12302)
<!-- Reviewable:end -->
