### PR TITLE
py all_test: Make it easier to debug warnings for `import pydrake.all`

### DIFF
--- a/bindings/pydrake/test/all_test.py
+++ b/bindings/pydrake/test/all_test.py
@@ -15,19 +15,15 @@ class TestAll(unittest.TestCase):
         # - While this may be redundant, let's do it for good measure.
         self.assertTrue("pydrake.all" not in sys.modules)
         # Enable *all* warnings, and ensure that we don't trigger them.
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings():
             # TODO(eric.cousineau): Figure out a more conservative filter to
             # avoid issues on different machines, but still catch meaningful
             # warnings.
-            warnings.simplefilter("always", Warning)
+            warnings.simplefilter("error", Warning)
             warnings.filterwarnings(
                 "ignore", message="Matplotlib is building the font cache",
                 category=UserWarning)
             import pydrake.all
-            if w:
-                sys.stderr.write("Encountered import warnings:\n{}\n".format(
-                    "\n".join(map(str, w)) + "\n"))
-            self.assertEqual(len(w), 0)
 
     def test_usage_no_all(self):
         from pydrake.common import FindResourceOrThrow


### PR DESCRIPTION
This would've made it a bit easier to find the culprit package in #12218, as this produces a stack trace on the first error (which I'd find to be much more useful).

Zoomed-in comment: https://github.com/robotlocomotion/drake/pull/12218#pullrequestreview-310731820

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12304)
<!-- Reviewable:end -->
