### PR TITLE
common: Add and use DRAKE_LOGGER_TRACE throughout

### DIFF
--- a/attic/multibody/rigid_body_plant/rigid_body_plant.cc
+++ b/attic/multibody/rigid_body_plant/rigid_body_plant.cc
@@ -1086,9 +1086,9 @@ RigidBodyPlant<T>::DoCalcDiscreteVariableUpdatesImpl(
         limits.push_back(JointLimit());
         limits.back().v_index = b->get_velocity_start_index();
         limits.back().signed_distance = (qjoint - qmin);
-        SPDLOG_DEBUG(drake::log(), "body name: {} ", b->get_name());
-        SPDLOG_DEBUG(drake::log(), "joint name: {} ", joint.get_name());
-        SPDLOG_DEBUG(drake::log(), "joint signed distance: {} ",
+        DRAKE_LOGGER_DEBUG("body name: {} ", b->get_name());
+        DRAKE_LOGGER_DEBUG("joint name: {} ", joint.get_name());
+        DRAKE_LOGGER_DEBUG("joint signed distance: {} ",
             limits.back().signed_distance);
         limits.back().lower_limit = true;
       }
@@ -1097,9 +1097,9 @@ RigidBodyPlant<T>::DoCalcDiscreteVariableUpdatesImpl(
         limits.push_back(JointLimit());
         limits.back().v_index = b->get_velocity_start_index();
         limits.back().signed_distance = (qmax - qjoint);
-        SPDLOG_DEBUG(drake::log(), "body name: {} ", b->get_name());
-        SPDLOG_DEBUG(drake::log(), "joint name: {} ", joint.get_name());
-        SPDLOG_DEBUG(drake::log(), "joint signed distance: {} ",
+        DRAKE_LOGGER_DEBUG("body name: {} ", b->get_name());
+        DRAKE_LOGGER_DEBUG("joint name: {} ", joint.get_name());
+        DRAKE_LOGGER_DEBUG("joint signed distance: {} ",
             limits.back().signed_distance);
         limits.back().lower_limit = false;
       }
@@ -1159,9 +1159,9 @@ RigidBodyPlant<T>::DoCalcDiscreteVariableUpdatesImpl(
     F.col(i) = data.F_mult(unit);
     L.col(i) = data.L_mult(unit);
   }
-  SPDLOG_DEBUG(drake::log(), "N: {}", N);
-  SPDLOG_DEBUG(drake::log(), "F: {}", F);
-  SPDLOG_DEBUG(drake::log(), "L: {}", L);
+  DRAKE_LOGGER_DEBUG("N: {}", N);
+  DRAKE_LOGGER_DEBUG("F: {}", F);
+  DRAKE_LOGGER_DEBUG("L: {}", L);
   #endif
 
   // Set the regularization and stabilization terms for contact tangent
@@ -1201,30 +1201,30 @@ RigidBodyPlant<T>::DoCalcDiscreteVariableUpdatesImpl(
   constraint_solver_.SolveImpactProblem(data, &contact_force);
   constraint_solver_.ComputeGeneralizedVelocityChange(data, contact_force,
       &new_velocity);
-  SPDLOG_DEBUG(drake::log(), "Actuator forces: {} ", u.transpose());
-  SPDLOG_DEBUG(drake::log(), "Transformed actuator forces: {} ",
+  DRAKE_LOGGER_DEBUG("Actuator forces: {} ", u.transpose());
+  DRAKE_LOGGER_DEBUG("Transformed actuator forces: {} ",
       (tree.B * u).transpose());
-  SPDLOG_DEBUG(drake::log(), "force: {}", right_hand_side.transpose());
-  SPDLOG_DEBUG(drake::log(), "old velocity: {}", v.transpose());
-  SPDLOG_DEBUG(drake::log(), "integrated forward velocity: {}",
+  DRAKE_LOGGER_DEBUG("force: {}", right_hand_side.transpose());
+  DRAKE_LOGGER_DEBUG("old velocity: {}", v.transpose());
+  DRAKE_LOGGER_DEBUG("integrated forward velocity: {}",
       data.solve_inertia(data.Mv).transpose());
-  SPDLOG_DEBUG(drake::log(), "change in velocity: {}",
+  DRAKE_LOGGER_DEBUG("change in velocity: {}",
       new_velocity.transpose());
   new_velocity += data.solve_inertia(data.Mv);
-  SPDLOG_DEBUG(drake::log(), "new velocity: {}", new_velocity.transpose());
-  SPDLOG_DEBUG(drake::log(), "new configuration: {}",
+  DRAKE_LOGGER_DEBUG("new velocity: {}", new_velocity.transpose());
+  DRAKE_LOGGER_DEBUG("new configuration: {}",
       (q + dt * tree.transformVelocityToQDot(kinematics_cache, new_velocity)).
       transpose());
-  SPDLOG_DEBUG(drake::log(), "N * new velocity: {} ", data.N_mult(new_velocity).
+  DRAKE_LOGGER_DEBUG("N * new velocity: {} ", data.N_mult(new_velocity).
       transpose());
-  SPDLOG_DEBUG(drake::log(), "F * new velocity: {} ", data.F_mult(new_velocity).
+  DRAKE_LOGGER_DEBUG("F * new velocity: {} ", data.F_mult(new_velocity).
       transpose());
-  SPDLOG_DEBUG(drake::log(), "L * new velocity: {} ", data.L_mult(new_velocity).
+  DRAKE_LOGGER_DEBUG("L * new velocity: {} ", data.L_mult(new_velocity).
       transpose());
-  SPDLOG_DEBUG(drake::log(), "G * new velocity: {} ", data.G_mult(new_velocity).
+  DRAKE_LOGGER_DEBUG("G * new velocity: {} ", data.G_mult(new_velocity).
       transpose());
-  SPDLOG_DEBUG(drake::log(), "G * v: {} ", data.G_mult(v).transpose());
-  SPDLOG_DEBUG(drake::log(), "g(): {}",
+  DRAKE_LOGGER_DEBUG("G * v: {} ", data.G_mult(v).transpose());
+  DRAKE_LOGGER_DEBUG("g(): {}",
       tree.positionConstraints(kinematics_cache).transpose());
 
   // qn = q + dt*qdot.

--- a/common/test/text_logging_test.cc
+++ b/common/test/text_logging_test.cc
@@ -51,11 +51,9 @@ GTEST_TEST(TextLoggingTest, SmokeTest) {
   drake::log()->warn("drake::log()->warn test: {} {}", "OK", obj);
   drake::log()->error("drake::log()->error test: {} {}", "OK", obj);
   drake::log()->critical("drake::log()->critical test: {} {}", "OK", obj);
-  SPDLOG_TRACE(drake::log(), "SPDLOG_TRACE macro test: {}, {}", "OK", obj);
-  SPDLOG_DEBUG(drake::log(), "SPDLOG_DEBUG macro test: {}, {}", "OK", obj);
-  DRAKE_SPDLOG_TRACE(drake::log(), "DRAKE_SPDLOG_TRACE macro test: {}, {}",
+  DRAKE_LOGGER_TRACE("DRAKE_LOGGER_TRACE macro test: {}, {}",
                      "OK", obj);
-  DRAKE_SPDLOG_DEBUG(drake::log(), "DRAKE_SPDLOG_DEBUG macro test: {}, {}",
+  DRAKE_LOGGER_DEBUG("DRAKE_LOGGER_DEBUG macro test: {}, {}",
                      "OK", obj);
 }
 
@@ -84,10 +82,11 @@ GTEST_TEST(TextLoggingTest, CaptureOutputTest) {
   #endif
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 // Verify that DRAKE_SPDLOG macros succeed in avoiding evaluation of their
-// arguments. (The plain SPDLOG ones currently evaluate unconditionally when
-// expanded but we won't check that here since it could change.)
-GTEST_TEST(TextLoggingTest, DrakeMacrosDontEvaluateArguments) {
+// arguments.
+GTEST_TEST(TextLoggingTest, DeprecatedDrakeMacrosDontEvaluateArguments) {
   int tracearg = 0, debugarg = 0;
 
   // Shouldn't increment argument whether the macro expanded or not, since
@@ -124,6 +123,57 @@ GTEST_TEST(TextLoggingTest, DrakeMacrosDontEvaluateArguments) {
   #endif
   DRAKE_SPDLOG_TRACE(drake::log(), "tracearg={}", ++tracearg);
   DRAKE_SPDLOG_DEBUG(drake::log(), "debugarg={}", ++debugarg);
+  #ifndef NDEBUG
+    EXPECT_EQ(tracearg, 0);
+    EXPECT_EQ(debugarg, kHaveSpdlog ? 1 : 0);
+  #else
+    EXPECT_EQ(tracearg, 0);
+    EXPECT_EQ(debugarg, 0);
+  #endif
+  tracearg = 0;
+  debugarg = 0;
+}
+#pragma GCC diagnostic pop
+
+// Verify that DRAKE_LOGGER macros succeed in avoiding evaluation of their
+// arguments.
+GTEST_TEST(TextLoggingTest, DrakeMacrosDontEvaluateArguments) {
+  int tracearg = 0, debugarg = 0;
+
+  // Shouldn't increment argument whether the macro expanded or not, since
+  // logging is off.
+  #if TEXT_LOGGING_TEST_SPDLOG
+    drake::log()->set_level(spdlog::level::off);
+  #endif
+  DRAKE_LOGGER_TRACE("tracearg={}", ++tracearg);
+  DRAKE_LOGGER_DEBUG("debugarg={}", ++debugarg);
+  EXPECT_EQ(tracearg, 0);
+  EXPECT_EQ(debugarg, 0);
+  tracearg = 0;
+  debugarg = 0;
+
+  // Should increment arg only if the macro expanded.
+  #if TEXT_LOGGING_TEST_SPDLOG
+    drake::log()->set_level(spdlog::level::trace);
+  #endif
+  DRAKE_LOGGER_TRACE("tracearg={}", ++tracearg);
+  DRAKE_LOGGER_DEBUG("debugarg={}", ++debugarg);
+  #ifndef NDEBUG
+    EXPECT_EQ(tracearg, kHaveSpdlog ? 1 : 0);
+    EXPECT_EQ(debugarg, kHaveSpdlog ? 1 : 0);
+  #else
+    EXPECT_EQ(tracearg, 0);
+    EXPECT_EQ(debugarg, 0);
+  #endif
+  tracearg = 0;
+  debugarg = 0;
+
+  // Only DEBUG should increment arg since trace is not enabled.
+  #if TEXT_LOGGING_TEST_SPDLOG
+    drake::log()->set_level(spdlog::level::debug);
+  #endif
+  DRAKE_LOGGER_TRACE("tracearg={}", ++tracearg);
+  DRAKE_LOGGER_DEBUG("debugarg={}", ++debugarg);
   #ifndef NDEBUG
     EXPECT_EQ(tracearg, 0);
     EXPECT_EQ(debugarg, kHaveSpdlog ? 1 : 0);

--- a/common/text_logging.h
+++ b/common/text_logging.h
@@ -19,8 +19,8 @@ Similarly, it provides:
 If you want to log objects that are expensive to serialize, these macros will
 not be compiled if debugging is turned off (-DNDEBUG is set):
 <pre>
-  SPDLOG_LOGGER_TRACE(drake::log(), "message: {}", something_conditionally_compiled);
-  SPDLOG_LOGGER_DEBUG(drake::log(), "message: {}", something_conditionally_compiled);
+  DRAKE_LOGGER_TRACE("message: {}", something_conditionally_compiled);
+  DRAKE_LOGGER_DEBUG("message: {}", something_conditionally_compiled);
 </pre>
 
 The format string syntax is fmtlib; see https://fmt.dev/6.0.0/syntax.html.
@@ -32,38 +32,46 @@ printed without any special handling.
 
 #ifndef DRAKE_DOXYGEN_CXX
 #ifdef HAVE_SPDLOG
-// Before including spdlog, activate the SPDLOG_DEBUG and SPDLOG_TRACE macros
-// if and only if Drake is being compiled in debug mode.  When not in debug
-// mode, they are no-ops and their arguments are not evaluated.
 #ifndef NDEBUG
+
+// When in Debug builds, before including spdlog we set the compile-time
+// minimum log threshold so that spdlog defaults to enabling all log levels.
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_TRACE
 
-// TODO(jwnimmer-tri) Deprecate these Drake-specific aliases.
-#define DRAKE_SPDLOG_TRACE(logger, ...)            \
-  do {                                             \
-    SPDLOG_LOGGER_TRACE(logger, __VA_ARGS__);      \
+// Provide operative macros only when spdlog is available and Debug is enabled.
+#define DRAKE_LOGGER_TRACE(...)                                               \
+  do {                                                                        \
+    /* Capture the drake::log() in a temporary, using a relatively unique */  \
+    /* variable name to avoid potential variable name shadowing warnings. */  \
+    ::drake::logging::logger* const drake_spdlog_macro_logger_alias =         \
+        ::drake::log();                                                       \
+    if (drake_spdlog_macro_logger_alias->level() <= spdlog::level::trace) {   \
+      SPDLOG_LOGGER_TRACE(drake_spdlog_macro_logger_alias, __VA_ARGS__);      \
+    }                                                                         \
+  } while (0)
+#define DRAKE_LOGGER_DEBUG(...)                                               \
+  do {                                                                        \
+    /* Capture the drake::log() in a temporary, using a relatively unique */  \
+    /* variable name to avoid potential variable name shadowing warnings. */  \
+    ::drake::logging::logger* const drake_spdlog_macro_logger_alias =         \
+        ::drake::log();                                                       \
+    if (drake_spdlog_macro_logger_alias->level() <= spdlog::level::debug) {   \
+      SPDLOG_LOGGER_DEBUG(drake_spdlog_macro_logger_alias, __VA_ARGS__);      \
+    }                                                                         \
   } while (0)
 
-#define DRAKE_SPDLOG_DEBUG(logger, ...)            \
-  do {                                             \
-    SPDLOG_LOGGER_DEBUG(logger, __VA_ARGS__);      \
-  } while (0)
 #else
-#define DRAKE_SPDLOG_TRACE(logger, ...)
-#define DRAKE_SPDLOG_DEBUG(logger, ...)
+
+// Spdlog is available, but we are doing a non-Debug build.
+#define DRAKE_LOGGER_TRACE(...)
+#define DRAKE_LOGGER_DEBUG(...)
+
 #endif
 
 /* clang-format off */
 #include <spdlog/spdlog.h>
 #include <spdlog/fmt/ostr.h>
 /* clang-format on */
-
-// Backfill a flag day API change from spdlog.
-// TODO(jwnimmer-tri) Update Drake to use the newer APIs only.
-#undef SPDLOG_DEBUG
-#undef SPDLOG_TRACE
-#define SPDLOG_DEBUG SPDLOG_LOGGER_DEBUG
-#define SPDLOG_TRACE SPDLOG_LOGGER_TRACE
 
 #else  // HAVE_SPDLOG
 
@@ -144,10 +152,8 @@ class sink {
 
 }  // namespace logging
 
-#define SPDLOG_TRACE(logger, ...)
-#define SPDLOG_DEBUG(logger, ...)
-#define DRAKE_SPDLOG_TRACE(logger, ...)
-#define DRAKE_SPDLOG_DEBUG(logger, ...)
+#define DRAKE_LOGGER_TRACE(...)
+#define DRAKE_LOGGER_DEBUG(...)
 
 #endif  // HAVE_SPDLOG
 
@@ -207,3 +213,37 @@ extern const char* const kSetLogLevelHelpMessage;
 
 }  // namespace logging
 }  // namespace drake
+
+// TODO(jwnimmer-tri) Remove this deprecated function and macros on 2020-03-01.
+#ifndef DRAKE_DOXYGEN_CXX
+#ifdef HAVE_SPDLOG
+namespace drake {
+namespace logging {
+namespace internal {
+[[deprecated(
+"The DRAKE_SPDLOG_TRACE and DRAKE_SPDLOG_DEBUG macros are deprecated.\n"
+"Please use DRAKE_LOGGER_TRACE and DRAKE_LOGGER_DEBUG instead.\n"
+"The deprecated code will be removed from Drake on or after 2020-03-01.")]]
+inline void warn_deprecated_macro() {}
+}  // namespace internal
+}  // namespace logging
+}  // namespace drake
+#define DRAKE_SPDLOG_TRACE(logger, ...)                         \
+  do {                                                          \
+    ::drake::logging::internal::warn_deprecated_macro();        \
+    if (logger->level() <= spdlog::level::trace) {              \
+      SPDLOG_LOGGER_TRACE(logger, __VA_ARGS__);                 \
+    }                                                           \
+  } while (0)
+#define DRAKE_SPDLOG_DEBUG(logger, ...)                         \
+  do {                                                          \
+    ::drake::logging::internal::warn_deprecated_macro();        \
+    if (logger->level() <= spdlog::level::debug) {              \
+      SPDLOG_LOGGER_DEBUG(logger, __VA_ARGS__);                 \
+    }                                                           \
+  } while (0)
+#else  // HAVE_SPDLOG
+#define DRAKE_SPDLOG_TRACE(...)
+#define DRAKE_SPDLOG_DEBUG(...)
+#endif  // HAVE_SPDLOG
+#endif  // DRAKE_DOXYGEN_CXX

--- a/multibody/constraint/constraint_solver.h
+++ b/multibody/constraint/constraint_solver.h
@@ -1330,17 +1330,17 @@ void ConstraintSolver<T>::SolveImpactProblem(
         max_dot > max(T(1), zz.maxCoeff()) * max(T(1), ww.maxCoeff()) *
             num_vars * npivots * zero_tol))) {
     // Report difficulty
-    SPDLOG_DEBUG(drake::log(), "Unable to solve impacting problem LCP without "
+    DRAKE_LOGGER_DEBUG("Unable to solve impacting problem LCP without "
         "progressive regularization");
-    SPDLOG_DEBUG(drake::log(), "zero tolerance for z/w: {}",
+    DRAKE_LOGGER_DEBUG("zero tolerance for z/w: {}",
         num_vars * npivots * zero_tol);
-    SPDLOG_DEBUG(drake::log(), "Solver reports success? {}", success);
-    SPDLOG_DEBUG(drake::log(), "minimum z: {}", zz.minCoeff());
-    SPDLOG_DEBUG(drake::log(), "minimum w: {}", ww.minCoeff());
-    SPDLOG_DEBUG(drake::log(), "zero tolerance for <z,w>: {}",
+    DRAKE_LOGGER_DEBUG("Solver reports success? {}", success);
+    DRAKE_LOGGER_DEBUG("minimum z: {}", zz.minCoeff());
+    DRAKE_LOGGER_DEBUG("minimum w: {}", ww.minCoeff());
+    DRAKE_LOGGER_DEBUG("zero tolerance for <z,w>: {}",
       max(T(1), zz.maxCoeff()) * max(T(1), ww.maxCoeff()) * num_vars *
       npivots * zero_tol);
-    SPDLOG_DEBUG(drake::log(), "z'w: {}", max_dot);
+    DRAKE_LOGGER_DEBUG("z'w: {}", max_dot);
 
     // Use progressive regularization to solve.
     const int min_exp = -16;      // Minimum regularization factor: 1e-16.
@@ -1353,9 +1353,9 @@ void ConstraintSolver<T>::SolveImpactProblem(
       throw std::runtime_error("Progressively regularized LCP solve failed.");
     } else {
       ww = MM * zz + qq;
-      SPDLOG_DEBUG(drake::log(), "minimum z: {}", zz.minCoeff());
-      SPDLOG_DEBUG(drake::log(), "minimum w: {}", ww.minCoeff());
-      SPDLOG_DEBUG(drake::log(), "z'w: ",
+      DRAKE_LOGGER_DEBUG("minimum z: {}", zz.minCoeff());
+      DRAKE_LOGGER_DEBUG("minimum w: {}", ww.minCoeff());
+      DRAKE_LOGGER_DEBUG("z'w: ",
           (zz.array() * ww.array()).abs().maxCoeff());
     }
   }
@@ -1466,8 +1466,8 @@ void ConstraintSolver<T>::PopulatePackedConstraintForcesFromLcpSolution(
 
       // Transform the impulsive forces to non-impulsive forces.
       lambda = u.tail(num_eq_constraints) / dt;
-      DRAKE_SPDLOG_DEBUG(drake::log(),
-          "Bilateral constraint forces/impulses: {}", lambda.transpose());
+      DRAKE_LOGGER_DEBUG("Bilateral constraint forces/impulses: {}",
+          lambda.transpose());
     }
 
     return;
@@ -1486,11 +1486,11 @@ void ConstraintSolver<T>::PopulatePackedConstraintForcesFromLcpSolution(
   cf->segment(0, num_contacts) = fN;
   cf->segment(num_contacts, num_spanning_vectors) = fD_plus - fD_minus;
   cf->segment(num_contacts + num_spanning_vectors, num_limits) = fL;
-  DRAKE_SPDLOG_DEBUG(drake::log(), "Normal contact forces/impulses: {}",
+  DRAKE_LOGGER_DEBUG("Normal contact forces/impulses: {}",
       fN.transpose());
-  DRAKE_SPDLOG_DEBUG(drake::log(), "Frictional contact forces/impulses: {}",
+  DRAKE_LOGGER_DEBUG("Frictional contact forces/impulses: {}",
       (fD_plus - fD_minus).transpose());
-  DRAKE_SPDLOG_DEBUG(drake::log(), "Generic unilateral constraint "
+  DRAKE_LOGGER_DEBUG("Generic unilateral constraint "
       "forces/impulses: {}", fL.transpose());
 
   // Determine the new velocity and the bilateral constraint forces/
@@ -1521,8 +1521,8 @@ void ConstraintSolver<T>::PopulatePackedConstraintForcesFromLcpSolution(
 
     // Transform the impulsive forces back to non-impulsive forces.
     lambda = u.tail(num_eq_constraints) / dt;
-    DRAKE_SPDLOG_DEBUG(drake::log(), "Bilateral constraint forces/impulses: {}",
-                       lambda.transpose());
+    DRAKE_LOGGER_DEBUG("Bilateral constraint forces/impulses: {}",
+        lambda.transpose());
   }
 }
 

--- a/solvers/unrevised_lemke_solver.cc
+++ b/solvers/unrevised_lemke_solver.cc
@@ -445,7 +445,7 @@ bool UnrevisedLemkeSolver<T>::LemkePivot(
   SetSubVector(q_prime_beta_prime_, index_sets_.beta_prime, q_prime);
   SetSubVector(q_prime_alpha_bar_prime_, index_sets_.alpha_bar_prime, q_prime);
 
-  DRAKE_SPDLOG_DEBUG(log(), "q': {}", q_prime->transpose());
+  DRAKE_LOGGER_DEBUG("q': {}", q_prime->transpose());
 
   // If it is not necessary to compute the column of M, quit now.
   if (!M_prime_col)
@@ -453,7 +453,7 @@ bool UnrevisedLemkeSolver<T>::LemkePivot(
 
   // Examine the driving variable.
   if (!indep_variables_[driving_index].is_z()) {
-    DRAKE_SPDLOG_DEBUG(log(), "Driving case #1: driving variable from w");
+    DRAKE_LOGGER_DEBUG("Driving case #1: driving variable from w");
     // Case from Section 2.2.1.
     // Determine gamma by determining the position of the driving variable
     // in INDEPENDENT W (as defined in [Dai 2018]).
@@ -484,7 +484,7 @@ bool UnrevisedLemkeSolver<T>::LemkePivot(
     M_prime_driving_alpha_bar_prime_ = M_alpha_bar_beta_ *
         M_prime_driving_beta_prime_;
   } else {
-    DRAKE_SPDLOG_DEBUG(log(), "Driving case #2: driving variable from z");
+    DRAKE_LOGGER_DEBUG("Driving case #2: driving variable from z");
 
     // Case from Section 2.2.2 of [Dai 2018].
     // Determine zeta.
@@ -507,7 +507,7 @@ bool UnrevisedLemkeSolver<T>::LemkePivot(
   SetSubVector(M_prime_driving_alpha_bar_prime_, index_sets_.alpha_bar_prime,
                M_prime_col);
 
-  DRAKE_SPDLOG_DEBUG(log(), "M' (driving): {}", M_prime_col->transpose());
+  DRAKE_LOGGER_DEBUG("M' (driving): {}", M_prime_col->transpose());
   return true;
 }
 
@@ -585,7 +585,7 @@ bool UnrevisedLemkeSolver<T>::FindBlockingIndex(
   *blocking_index = -1;
   for (int i = 0; i < n; ++i) {
     if (matrix_col[i] < -zero_tol) {
-      DRAKE_SPDLOG_DEBUG(log(), "Ratio for index {}: {}", i, ratios[i]);
+      DRAKE_LOGGER_DEBUG("Ratio for index {}: {}", i, ratios[i]);
       if (ratios[i] < min_ratio) {
         min_ratio = ratios[i];
         *blocking_index = i;
@@ -594,7 +594,7 @@ bool UnrevisedLemkeSolver<T>::FindBlockingIndex(
   }
 
   if (*blocking_index < 0) {
-    SPDLOG_DEBUG(log(), "driving variable is unblocked- algorithm failed");
+    DRAKE_LOGGER_DEBUG("driving variable is unblocked- algorithm failed");
     return false;
   }
 
@@ -604,7 +604,7 @@ bool UnrevisedLemkeSolver<T>::FindBlockingIndex(
   std::vector<int> blocking_indices;
   for (int i = 0; i < n; ++i) {
     if (matrix_col[i] < -zero_tol) {
-      DRAKE_SPDLOG_DEBUG(log(), "Ratio for index {}: {}", i, ratios[i]);
+      DRAKE_LOGGER_DEBUG("Ratio for index {}: {}", i, ratios[i]);
       if (ratios[i] < min_ratio + zero_tol) {
         if (IsArtificial(dep_variables_[i])) {
           // *Always* select the artificial variable, if multiple choices are
@@ -625,7 +625,7 @@ bool UnrevisedLemkeSolver<T>::FindBlockingIndex(
     // Verify that we have not run out of indices to select, which means that
     // cycling would be occurring, in spite of cycling prevention.
     if (index >= static_cast<int>(blocking_indices.size())) {
-      DRAKE_SPDLOG_DEBUG(log(), "Cycling detected- indicating failure.");
+      DRAKE_LOGGER_DEBUG("Cycling detected- indicating failure.");
       *blocking_index = -1;
       return false;
     }
@@ -667,7 +667,7 @@ bool UnrevisedLemkeSolver<T>::SolveLcpLemke(const MatrixX<T>& M,
   using std::abs;
   DRAKE_DEMAND(num_pivots);
 
-  DRAKE_SPDLOG_DEBUG(log(),
+  DRAKE_LOGGER_DEBUG(
       "UnrevisedLemkeSolver::SolveLcpLemke() entered, M: {}, "
       "q: {}, ", M, q.transpose());
 
@@ -682,7 +682,7 @@ bool UnrevisedLemkeSolver<T>::SolveLcpLemke(const MatrixX<T>& M,
 
   // Look for immediate exit.
   if (n == 0) {
-    DRAKE_SPDLOG_DEBUG(log(), "-- LCP is zero dimensional");
+    DRAKE_LOGGER_DEBUG("-- LCP is zero dimensional");
     z->resize(0);
     return true;
   }
@@ -705,8 +705,8 @@ bool UnrevisedLemkeSolver<T>::SolveLcpLemke(const MatrixX<T>& M,
   // be non-negative, z would be non-negative (zero), and w'z = 0.
   if (q.minCoeff() > -mod_zero_tol) {
     z->setZero(q.size());
-    SPDLOG_DEBUG(log(), " -- trivial solution found");
-    SPDLOG_DEBUG(log(), "UnrevisedLemkeSolver::SolveLcpLemke() exited");
+    DRAKE_LOGGER_DEBUG(" -- trivial solution found");
+    DRAKE_LOGGER_DEBUG("UnrevisedLemkeSolver::SolveLcpLemke() exited");
     return true;
   }
 
@@ -735,7 +735,7 @@ bool UnrevisedLemkeSolver<T>::SolveLcpLemke(const MatrixX<T>& M,
           return true;
         }
       } else {
-        DRAKE_SPDLOG_DEBUG(log(),
+        DRAKE_LOGGER_DEBUG(
             "Failed to solve linear system implied by last solution");
       }
     }
@@ -766,9 +766,9 @@ bool UnrevisedLemkeSolver<T>::SolveLcpLemke(const MatrixX<T>& M,
   LCPVariable blocking = dep_variables_[blocking_index];
   int driving_index = blocking.index();
   std::swap(dep_variables_[blocking_index], indep_variables_[kArtificial]);
-  DRAKE_SPDLOG_DEBUG(log(), "First blocking variable {}{}",
+  DRAKE_LOGGER_DEBUG("First blocking variable {}{}",
                      ((blocking.is_z()) ? "z" : "w"), blocking.index());
-  DRAKE_SPDLOG_DEBUG(log(), "First driving variable (artificial)");
+  DRAKE_LOGGER_DEBUG("First driving variable (artificial)");
 
   // Initialize the independent variable indices. We do this after the initial
   // variable swap for simplicity.
@@ -783,22 +783,22 @@ bool UnrevisedLemkeSolver<T>::SolveLcpLemke(const MatrixX<T>& M,
     return oss.str();
   };
   unused(to_string);  // ... when in release mode.
-  DRAKE_SPDLOG_DEBUG(log(), "Independent set variables: {}",
+  DRAKE_LOGGER_DEBUG("Independent set variables: {}",
       to_string(indep_variables_));
-  DRAKE_SPDLOG_DEBUG(log(), "Dependent set variables: {}",
+  DRAKE_LOGGER_DEBUG("Dependent set variables: {}",
       to_string(dep_variables_));
 
   // Pivot up to the maximum number of times.
   VectorX<T> q_prime(n), M_prime_col(n);
   while (++(*num_pivots) < max_pivots) {
-    DRAKE_SPDLOG_DEBUG(log(), "New driving variable {}{}",
+    DRAKE_LOGGER_DEBUG("New driving variable {}{}",
                        ((indep_variables_[driving_index].is_z()) ? "z" : "w"),
                        indep_variables_[driving_index].index());
 
     // Compute the permuted q and driving column of the permuted M matrix.
     if (!LemkePivot(
         M, q, driving_index, mod_zero_tol, &M_prime_col, &q_prime)) {
-      DRAKE_SPDLOG_DEBUG(log(), "Linear system solve failed.");
+      DRAKE_LOGGER_DEBUG("Linear system solve failed.");
       z->setZero(n);
       return false;
     }
@@ -811,7 +811,7 @@ bool UnrevisedLemkeSolver<T>::SolveLcpLemke(const MatrixX<T>& M,
       return false;
     }
     blocking = dep_variables_[blocking_index];
-    DRAKE_SPDLOG_DEBUG(log(), "Blocking variable {}{}",
+    DRAKE_LOGGER_DEBUG("Blocking variable {}{}",
                        ((blocking.is_z()) ? "z" : "w"), blocking.index());
 
     // See whether the artificial variable blocks the driving variable.
@@ -827,14 +827,13 @@ bool UnrevisedLemkeSolver<T>::SolveLcpLemke(const MatrixX<T>& M,
         if (IsSolution(M, q, *z))
           return true;
 
-        DRAKE_SPDLOG_DEBUG(log(),
-            "Solution not computed to requested tolerance");
+        DRAKE_LOGGER_DEBUG("Solution not computed to requested tolerance");
         z->setZero(n);
         return false;
       }
 
       // Otherwise, indicate failure.
-      DRAKE_SPDLOG_DEBUG(log(),
+      DRAKE_LOGGER_DEBUG(
           "Linear system solver failed to construct Lemke solution");
       z->setZero(n);
       return false;
@@ -854,15 +853,15 @@ bool UnrevisedLemkeSolver<T>::SolveLcpLemke(const MatrixX<T>& M,
     // Make the driving variable the complement of the blocking variable.
     driving_index = FindComplementIndex(blocking);
 
-    DRAKE_SPDLOG_DEBUG(log(), "Independent set variables: {}",
+    DRAKE_LOGGER_DEBUG("Independent set variables: {}",
         to_string(indep_variables_));
-    DRAKE_SPDLOG_DEBUG(log(), "Dependent set variables: {}",
+    DRAKE_LOGGER_DEBUG("Dependent set variables: {}",
         to_string(dep_variables_));
   }
 
   // If here, the maximum number of pivots has been exceeded.
   z->setZero(n);
-  DRAKE_SPDLOG_DEBUG(log(), "Maximum number of pivots exceeded");
+  DRAKE_LOGGER_DEBUG("Maximum number of pivots exceeded");
   return false;
 }
 

--- a/systems/analysis/implicit_euler_integrator-inl.h
+++ b/systems/analysis/implicit_euler_integrator-inl.h
@@ -148,12 +148,12 @@ bool ImplicitEulerIntegrator<T>::StepAbstract(
   // Verify xtplus
   DRAKE_ASSERT(xtplus && xtplus->size() == xt0.size());
 
-  SPDLOG_DEBUG(drake::log(), "StepAbstract() entered for t={}, h={}, trial={}",
+  DRAKE_LOGGER_DEBUG("StepAbstract() entered for t={}, h={}, trial={}",
       t0, h, trial);
 
   // Start from the guess.
   *xtplus = xtplus_guess;
-  SPDLOG_DEBUG(drake::log(), "Starting state: {}", xtplus->transpose());
+  DRAKE_LOGGER_DEBUG("Starting state: {}", xtplus->transpose());
 
   // Advance the context time and state to compute derivatives at t0 + h.
   const T tf = t0 + h;
@@ -200,8 +200,8 @@ bool ImplicitEulerIntegrator<T>::StepAbstract(
     // is at least some change to the state, no matter how small, on a
     // non-stationary system.
     if (i > 0 && this->IsUpdateZero(*xtplus, dx)) {
-      SPDLOG_DEBUG(drake::log(), "Converged with zero update. xt+: {}",
-                   xtplus->transpose());
+      DRAKE_LOGGER_DEBUG("Converged with zero update. xt+: {}",
+          xtplus->transpose());
       return true;
     }
 
@@ -215,12 +215,12 @@ bool ImplicitEulerIntegrator<T>::StepAbstract(
     if (i > 1) {
       const T theta = dx_norm / last_dx_norm;
       const T eta = theta / (1 - theta);
-      SPDLOG_DEBUG(drake::log(), "Newton-Raphson loop {} theta: {}, eta: {}",
-                   i, theta, eta);
+      DRAKE_LOGGER_DEBUG("Newton-Raphson loop {} theta: {}, eta: {}",
+          i, theta, eta);
 
       // Look for divergence.
       if (theta > 1) {
-        SPDLOG_DEBUG(drake::log(), "Newton-Raphson divergence detected for "
+        DRAKE_LOGGER_DEBUG("Newton-Raphson divergence detected for "
             "h={}", h);
         break;
       }
@@ -232,9 +232,9 @@ bool ImplicitEulerIntegrator<T>::StepAbstract(
       const double kappa = 0.05;
       const double k_dot_tol = kappa * this->get_accuracy_in_use();
       if (eta * dx_norm < k_dot_tol) {
-        SPDLOG_DEBUG(drake::log(),
-                     "Newton-Raphson converged; η = {}, h = {}, xt+ = {}", eta,
-                     h, xtplus->transpose());
+        DRAKE_LOGGER_DEBUG(
+            "Newton-Raphson converged; η = {}, h = {}, xt+ = {}",
+            eta, h, xtplus->transpose());
         return true;
       }
     }
@@ -243,7 +243,7 @@ bool ImplicitEulerIntegrator<T>::StepAbstract(
     last_dx_norm = dx_norm;
   }
 
-  SPDLOG_DEBUG(drake::log(), "StepAbstract() convergence failed");
+  DRAKE_LOGGER_DEBUG("StepAbstract() convergence failed");
 
   // If Jacobian and iteration matrix factorizations are not reused, there
   // is nothing else we can try.
@@ -270,7 +270,7 @@ bool ImplicitEulerIntegrator<T>::StepImplicitEuler(const T& t0, const T& h,
     const VectorX<T>& xt0, VectorX<T>* xtplus) {
   using std::abs;
 
-  SPDLOG_DEBUG(drake::log(), "StepImplicitEuler(h={}) t={}", h, t0);
+  DRAKE_LOGGER_DEBUG("StepImplicitEuler(h={}) t={}", h, t0);
 
   // Set g for the implicit Euler method.
   Context<T>* context = this->get_mutable_context();
@@ -307,7 +307,7 @@ bool ImplicitEulerIntegrator<T>::StepImplicitTrapezoid(
     const VectorX<T>& xtplus_ie, VectorX<T>* xtplus) {
   using std::abs;
 
-  SPDLOG_DEBUG(drake::log(), "StepImplicitTrapezoid(h={}) t={}", h, t0);
+  DRAKE_LOGGER_DEBUG("StepImplicitTrapezoid(h={}) t={}", h, t0);
 
   // Set g for the implicit trapezoid method.
   // Define g(x(t+h)) ≡ x(t0+h) - x(t0) - h/2 (f(t0,x(t0)) + f(t0+h,x(t0+h)) and
@@ -378,7 +378,7 @@ bool ImplicitEulerIntegrator<T>::AttemptStepPaired(const T& t0, const T& h,
 
   // Do the Euler step.
   if (!StepImplicitEuler(t0, h, xt0, xtplus_ie)) {
-    SPDLOG_DEBUG(drake::log(), "Implicit Euler approach did not converge for "
+    DRAKE_LOGGER_DEBUG("Implicit Euler approach did not converge for "
         "step size {}", h);
     return false;
   }
@@ -407,7 +407,7 @@ bool ImplicitEulerIntegrator<T>::AttemptStepPaired(const T& t0, const T& h,
     context->SetTimeAndContinuousState(t0 + h, *xtplus_ie);
     return true;
   } else {
-    SPDLOG_DEBUG(drake::log(), "Implicit trapezoid approach FAILED with a step"
+    DRAKE_LOGGER_DEBUG("Implicit trapezoid approach FAILED with a step"
         "size that succeeded on implicit Euler.");
     return false;
   }
@@ -423,7 +423,7 @@ bool ImplicitEulerIntegrator<T>::DoImplicitIntegratorStep(const T& h) {
   // Save the current time and state.
   Context<T>* context = this->get_mutable_context();
   const T t0 = context->get_time();
-  SPDLOG_DEBUG(drake::log(), "IE DoStep(h={}) t={}", h, t0);
+  DRAKE_LOGGER_DEBUG("IE DoStep(h={}) t={}", h, t0);
 
   xt0_ = context->get_continuous_state().CopyToVector();
   xtplus_ie_.resize(xt0_.size());
@@ -432,7 +432,7 @@ bool ImplicitEulerIntegrator<T>::DoImplicitIntegratorStep(const T& h) {
   // If the requested h is less than the minimum step size, we'll advance time
   // using an explicit Euler step.
   if (h < this->get_working_minimum_step_size()) {
-    SPDLOG_DEBUG(drake::log(), "-- requested step too small, taking explicit "
+    DRAKE_LOGGER_DEBUG("-- requested step too small, taking explicit "
         "step instead");
 
     // TODO(edrumwri): Investigate replacing this with an explicit trapezoid

--- a/systems/analysis/implicit_integrator.h
+++ b/systems/analysis/implicit_integrator.h
@@ -403,8 +403,7 @@ template <class T>
 void ImplicitIntegrator<T>::ComputeAutoDiffJacobian(
     const System<T>& system, const T& t, const VectorX<T>& xt,
     const Context<T>& context, MatrixX<T>* J) {
-  SPDLOG_DEBUG(drake::log(), "  ImplicitIntegrator Compute Autodiff Jacobian "
-               "t={}", t);
+  DRAKE_LOGGER_DEBUG("  ImplicitIntegrator Compute Autodiff Jacobian t={}", t);
   // Create AutoDiff versions of the state vector.
   VectorX<AutoDiffXd> a_xt = xt;
 
@@ -459,9 +458,10 @@ void ImplicitIntegrator<T>::ComputeForwardDiffJacobian(
   // Get the number of continuous state variables xt.
   const int n = context->num_continuous_states();
 
-  SPDLOG_DEBUG(drake::log(), "  ImplicitIntegrator Compute Forwarddiff "
-               "{}-Jacobian t={}", n, t);
-  SPDLOG_DEBUG(drake::log(), "  computing from state {}", xt.transpose());
+  DRAKE_LOGGER_DEBUG(
+      "  ImplicitIntegrator Compute Forwarddiff {}-Jacobian t={}", n, t);
+  DRAKE_LOGGER_DEBUG(
+      "  computing from state {}", xt.transpose());
 
   // Initialize the Jacobian.
   J->resize(n, n);
@@ -529,8 +529,8 @@ void ImplicitIntegrator<T>::ComputeCentralDiffJacobian(
   // Get the number of continuous state variables xt.
   const int n = context->num_continuous_states();
 
-  SPDLOG_DEBUG(drake::log(), "  ImplicitIntegrator Compute ",
-               "Centraldiff {}-Jacobian t={}", n, t);
+  DRAKE_LOGGER_DEBUG(
+      "  ImplicitIntegrator Compute Centraldiff {}-Jacobian t={}", n, t);
 
   // Initialize the Jacobian.
   J->resize(n, n);

--- a/systems/analysis/integrator_base.h
+++ b/systems/analysis/integrator_base.h
@@ -1512,9 +1512,9 @@ class IntegratorBase {
     if (new_step_size < get_working_minimum_step_size() &&
         new_step_size < current_step_size &&  // Verify step adjusted downward.
         min_step_exceeded_throws_) {
-      SPDLOG_DEBUG(drake::log(), "Integrator wants to select too small step "
+      DRAKE_LOGGER_DEBUG("Integrator wants to select too small step "
           "size of {}; working minimum is ", new_step_size,
-                   get_working_minimum_step_size());
+          get_working_minimum_step_size());
       std::ostringstream str;
       str << "Error control wants to select step smaller than minimum" <<
            " allowed (" << get_working_minimum_step_size() << ")";
@@ -1714,7 +1714,7 @@ bool IntegratorBase<T>::StepOnceErrorControlledAtMost(const T& dt_max) {
     // a sufficiently small, yet nonzero step size.
     T adjusted_step_size = step_size_to_attempt;
     while (!Step(adjusted_step_size)) {
-      SPDLOG_DEBUG(drake::log(), "Sub-step failed at {}", adjusted_step_size);
+      DRAKE_LOGGER_DEBUG("Sub-step failed at {}", adjusted_step_size);
       adjusted_step_size *= subdivision_factor_;
 
       // Note: we could give the user more rope to hang themselves by looking
@@ -1737,7 +1737,7 @@ bool IntegratorBase<T>::StepOnceErrorControlledAtMost(const T& dt_max) {
     T next_step_size;
     std::tie(step_succeeded, next_step_size) = CalcAdjustedStepSize(
         err_norm, step_size_to_attempt, &at_minimum_step_size);
-    SPDLOG_DEBUG(drake::log(), "Succeeded? {}, Next step size: {}",
+    DRAKE_LOGGER_DEBUG("Succeeded? {}, Next step size: {}",
         step_succeeded, next_step_size);
 
     if (step_succeeded) {
@@ -1823,8 +1823,8 @@ T IntegratorBase<T>::CalcStateChangeNorm(
       weighted_q_change_.get());
   T q_nrm = weighted_q_change_->CopyToVector().
       template lpNorm<Eigen::Infinity>();
-  SPDLOG_DEBUG(drake::log(), "dq norm: {}, dv norm: {}, dz norm: {}",
-               q_nrm, v_nrm, z_nrm);
+  DRAKE_LOGGER_DEBUG("dq norm: {}, dv norm: {}, dz norm: {}",
+      q_nrm, v_nrm, z_nrm);
 
   // Return NaN if one of the values is NaN (whether std::max does this is
   // dependent upon ordering!)

--- a/systems/analysis/radau_integrator.h
+++ b/systems/analysis/radau_integrator.h
@@ -395,8 +395,7 @@ RadauIntegrator<T, num_stages>::CheckConvergence(
   // is at least some change to the state, no matter how small, on a
   // non-stationary system.
   if (iteration > 0 && this->IsUpdateZero(xtplus, dx)) {
-    SPDLOG_DEBUG(
-        drake::log(), "magnitude of state update indicates convergence");
+    DRAKE_LOGGER_DEBUG("magnitude of state update indicates convergence");
     return ConvergenceStatus::kConverged;
   }
 
@@ -410,12 +409,12 @@ RadauIntegrator<T, num_stages>::CheckConvergence(
     // theta to these alternative values for minimizing convergence failures.
     const T theta = dx_norm / last_dx_norm;
     const T eta = theta / (1 - theta);
-    SPDLOG_DEBUG(drake::log(), "Newton-Raphson loop {} theta: {}, eta: {}",
+    DRAKE_LOGGER_DEBUG("Newton-Raphson loop {} theta: {}, eta: {}",
                  iteration, theta, eta);
 
     // Look for divergence.
     if (theta > 1) {
-      SPDLOG_DEBUG(drake::log(), "Newton-Raphson divergence detected");
+      DRAKE_LOGGER_DEBUG("Newton-Raphson divergence detected");
       return ConvergenceStatus::kDiverged;
     }
 
@@ -426,7 +425,7 @@ RadauIntegrator<T, num_stages>::CheckConvergence(
     const double kappa = 0.05;
     const double k_dot_tol = kappa * this->get_accuracy_in_use();
     if (eta * dx_norm < k_dot_tol) {
-      SPDLOG_DEBUG(drake::log(), "Newton-Raphson converged; η = {}", eta);
+      DRAKE_LOGGER_DEBUG("Newton-Raphson converged; η = {}", eta);
       return ConvergenceStatus::kConverged;
     }
   }
@@ -464,7 +463,7 @@ bool RadauIntegrator<T, num_stages>::StepRadau(const T& t0, const T& h,
   // Verify xtplus
   DRAKE_ASSERT(xtplus && xtplus->size() == state_dim);
 
-  SPDLOG_DEBUG(drake::log(), "StepRadau() entered for t={}, h={}, trial={}",
+  DRAKE_LOGGER_DEBUG("StepRadau() entered for t={}, h={}, trial={}",
                t0, h, trial);
 
   // TODO(edrumwri) Experiment with setting this as recommended in
@@ -473,7 +472,7 @@ bool RadauIntegrator<T, num_stages>::StepRadau(const T& t0, const T& h,
   // the corresponding xt+).
   Z_.setZero(state_dim * num_stages);
   *xtplus = xt0;
-  SPDLOG_DEBUG(drake::log(), "Starting state: {}", xtplus->transpose());
+  DRAKE_LOGGER_DEBUG("Starting state: {}", xtplus->transpose());
 
   // Set the iteration matrix construction method.
   auto construct_iteration_matrix = [this](const MatrixX<T>& J, const T& dt,
@@ -492,7 +491,7 @@ bool RadauIntegrator<T, num_stages>::StepRadau(const T& t0, const T& h,
 
   // Do the Newton-Raphson iterations.
   for (int iter = 0; iter < this->max_newton_raphson_iterations(); ++iter) {
-    SPDLOG_DEBUG(drake::log(), "Newton-Raphson iteration {}", iter);
+    DRAKE_LOGGER_DEBUG("Newton-Raphson iteration {}", iter);
 
     // Update the number of Newton-Raphson iterations.
     ++num_nr_iterations_;
@@ -503,7 +502,7 @@ bool RadauIntegrator<T, num_stages>::StepRadau(const T& t0, const T& h,
     // Compute the state update using (IV.8.4) in [Hairer, 1996], p. 119, i.e.:
     // Solve (I − hA⊗J) ΔZᵏ = h (A⊗I) F(Zᵏ) - Zᵏ for ΔZᵏ, where:
     // A_tp_eye ≡ (A⊗I) and (I − hA⊗J) is the iteration matrix.
-    SPDLOG_DEBUG(drake::log(), "residual: {}",
+    DRAKE_LOGGER_DEBUG("residual: {}",
         (A_tp_eye_ * (h * F_of_Z) - Z_).transpose());
     VectorX<T> dZ = iteration_matrix_radau_.Solve(
         A_tp_eye_ * (h * F_of_Z) - Z_);
@@ -528,7 +527,7 @@ bool RadauIntegrator<T, num_stages>::StepRadau(const T& t0, const T& h,
     }
 
     dx_state_->SetFromVector(dx);
-    SPDLOG_DEBUG(drake::log(), "dx: {}", dx.transpose());
+    DRAKE_LOGGER_DEBUG("dx: {}", dx.transpose());
 
     // Get the infinity norm of the weighted update vector.
     dx_state_->get_mutable_vector().SetFromVector(dx);
@@ -548,7 +547,7 @@ bool RadauIntegrator<T, num_stages>::StepRadau(const T& t0, const T& h,
     last_dx_norm = dx_norm;
   }
 
-  SPDLOG_DEBUG(drake::log(), "StepRadau() convergence failed");
+  DRAKE_LOGGER_DEBUG("StepRadau() convergence failed");
 
   // If Jacobian and iteration matrix factorizations are not reused, there
   // is nothing else we can try; otherwise, the following code will recurse
@@ -578,7 +577,7 @@ bool RadauIntegrator<T, num_stages>::StepImplicitTrapezoid(const T& t0,
     const VectorX<T>& radau_xtplus, VectorX<T>* xtplus) {
   using std::abs;
 
-  SPDLOG_DEBUG(drake::log(), "StepImplicitTrapezoid(h={}) t={}",
+  DRAKE_LOGGER_DEBUG("StepImplicitTrapezoid(h={}) t={}",
                h, t0);
 
   // Define g(x(t+h)) ≡ x(t+h) - x(t) - h/2 (f(t,x(t)) + f(t+h,x(t+h)) and
@@ -645,9 +644,9 @@ bool RadauIntegrator<T, num_stages>::StepImplicitTrapezoidDetail(
   // O(h) accurate, depending on the number of stages) to the true solution and
   // hence should be an excellent starting point.
   *xtplus = radau_xtplus;
-  SPDLOG_DEBUG(drake::log(), "Starting state: {}", xtplus->transpose());
+  DRAKE_LOGGER_DEBUG("Starting state: {}", xtplus->transpose());
 
-  SPDLOG_DEBUG(drake::log(), "StepImplicitTrapezoidDetail() entered for t={}, "
+  DRAKE_LOGGER_DEBUG("StepImplicitTrapezoidDetail() entered for t={}, "
       "h={}, trial={}", t0, h, trial);
 
   // Advance the context time; this means that all derivatives will be computed
@@ -672,7 +671,7 @@ bool RadauIntegrator<T, num_stages>::StepImplicitTrapezoidDetail(
   }
 
   for (int iter = 0; iter < this->max_newton_raphson_iterations(); ++iter) {
-    SPDLOG_DEBUG(drake::log(), "Newton-Raphson iteration {}", iter);
+    DRAKE_LOGGER_DEBUG("Newton-Raphson iteration {}", iter);
     ++num_nr_iterations_;
 
     // Evaluate the residual error using the current x(t+h).
@@ -682,7 +681,7 @@ bool RadauIntegrator<T, num_stages>::StepImplicitTrapezoidDetail(
     // iteration matrix.
     // TODO(edrumwri): Allow caller to provide their own solver.
     VectorX<T> dx = iteration_matrix_implicit_trapezoid_.Solve(-goutput);
-    SPDLOG_DEBUG(drake::log(), "dx: {}", dx.transpose());
+    DRAKE_LOGGER_DEBUG("dx: {}", dx.transpose());
 
     // Get the infinity norm of the weighted update vector.
     dx_state_->get_mutable_vector().SetFromVector(dx);
@@ -703,7 +702,7 @@ bool RadauIntegrator<T, num_stages>::StepImplicitTrapezoidDetail(
     last_dx_norm = dx_norm;
   }
 
-  SPDLOG_DEBUG(drake::log(), "StepImplicitTrapezoidDetail() convergence "
+  DRAKE_LOGGER_DEBUG("StepImplicitTrapezoidDetail() convergence "
       "failed");
 
   // If Jacobian and iteration matrix factorizations are not reused, there
@@ -755,7 +754,7 @@ bool RadauIntegrator<T, num_stages>::AttemptStepPaired(const T& t0, const T& h,
 
   // Do the Radau step.
   if (!StepRadau(t0, h, xt0, xtplus_radau)) {
-    SPDLOG_DEBUG(drake::log(), "Radau approach did not converge for "
+    DRAKE_LOGGER_DEBUG("Radau approach did not converge for "
         "step size {}", h);
     return false;
   }
@@ -796,7 +795,7 @@ bool RadauIntegrator<T, num_stages>::AttemptStepPaired(const T& t0, const T& h,
         t0 + h, *xtplus_radau);
     return true;
   } else {
-    SPDLOG_DEBUG(drake::log(), "Implicit trapezoid approach FAILED with a step"
+    DRAKE_LOGGER_DEBUG("Implicit trapezoid approach FAILED with a step"
         "size that succeeded on Radau3.");
     return false;
   }
@@ -813,7 +812,7 @@ void RadauIntegrator<T, num_stages>::ComputeAndSetErrorEstimate(
   err_est_vec_ = err_est_vec_.cwiseAbs();
 
   // Compute and set the error estimate.
-  SPDLOG_DEBUG(drake::log(), "Error estimate: {}", err_est_vec_.transpose());
+  DRAKE_LOGGER_DEBUG("Error estimate: {}", err_est_vec_.transpose());
   this->get_mutable_error_estimate()->get_mutable_vector().
       SetFromVector(err_est_vec_);
 }
@@ -829,7 +828,7 @@ bool RadauIntegrator<T, num_stages>::DoImplicitIntegratorStep(const T& h) {
 
   // Save the current time and state.
   const T t0 = context->get_time();
-  SPDLOG_DEBUG(drake::log(), "Radau DoStep(h={}) t={}", h, t0);
+  DRAKE_LOGGER_DEBUG("Radau DoStep(h={}) t={}", h, t0);
 
   xt0_ = context->get_continuous_state().CopyToVector();
   xtplus_prop_.resize(xt0_.size());
@@ -839,7 +838,7 @@ bool RadauIntegrator<T, num_stages>::DoImplicitIntegratorStep(const T& h) {
   // using an explicit Bogacki-Shampine/explicit Euler step, depending on the
   // number of stages in use.
   if (h < this->get_working_minimum_step_size()) {
-    SPDLOG_DEBUG(drake::log(), "-- requested step too small, taking explicit "
+    DRAKE_LOGGER_DEBUG("-- requested step too small, taking explicit "
         "step instead");
 
     // We want to maintain the order of the error estimation process even as we

--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -931,7 +931,7 @@ void Simulator<T>::AdvanceTo(const T& boundary_time) {
   while (true) {
     // Starting a new step on the trajectory.
     const T step_start_time = context_->get_time();
-    SPDLOG_TRACE(log(), "Starting a simulation step at {}", step_start_time);
+    DRAKE_LOGGER_TRACE("Starting a simulation step at {}", step_start_time);
 
     // Delay to match target realtime rate if requested and possible.
     PauseIfTooFast();
@@ -1118,7 +1118,7 @@ void Simulator<T>::IsolateWitnessTriggers(
   // continue moving leftward as a witness function triggers until the length of
   // the time interval is small. If a witness fails to trigger as c moves
   // leftward, we return, indicating that no witnesses triggered over [t0, c].
-  SPDLOG_DEBUG(drake::log(),
+  DRAKE_LOGGER_DEBUG(
       "Isolating witness functions using isolation window of {} over [{}, {}]",
       witness_iso_len.value(), t0, tf);
   VectorX<T> wc(witnesses.size());
@@ -1127,7 +1127,7 @@ void Simulator<T>::IsolateWitnessTriggers(
   do {
     // Compute the midpoint and evaluate the witness functions at it.
     T c = (a + b) / 2;
-    SPDLOG_DEBUG(drake::log(), "Integrating forward to time {}", c);
+    DRAKE_LOGGER_DEBUG("Integrating forward to time {}", c);
     integrate_forward(c);
 
     // See whether any witness functions trigger.
@@ -1148,7 +1148,7 @@ void Simulator<T>::IsolateWitnessTriggers(
       // events first). That change would avoid handling unnecessary per-step
       // events- we know no other events are to be handled between t0 and tf-
       // but the current logic appears easier to follow.
-      SPDLOG_DEBUG(drake::log(), "No witness functions triggered up to {}", c);
+      DRAKE_LOGGER_DEBUG("No witness functions triggered up to {}", c);
       triggered_witnesses->clear();
       return;  // Time is c.
     } else {
@@ -1297,8 +1297,8 @@ Simulator<T>::IntegrateContinuousState(
 
     // Store witness function(s) that triggered.
     for (const WitnessFunction<T>* fn : triggered_witnesses_) {
-      SPDLOG_DEBUG(drake::log(), "Witness function {} crossed zero at time {}",
-                   fn->description(), context.get_time());
+      DRAKE_LOGGER_DEBUG("Witness function {} crossed zero at time {}",
+          fn->description(), context.get_time());
 
       // Skip witness functions that have no associated event (i.e., skip
       // witness functions whose sole purpose is to insert a break in the

--- a/systems/framework/dependency_tracker.cc
+++ b/systems/framework/dependency_tracker.cc
@@ -21,14 +21,14 @@ std::string Indent(int depth) {
 // event that we have already heard about. Otherwise, let the subscribers know
 // that things have changed. Update statistics.
 void DependencyTracker::NoteValueChange(int64_t change_event) const {
-  DRAKE_SPDLOG_DEBUG(log(), "Tracker '{}' value change event {} ...",
+  DRAKE_LOGGER_DEBUG("Tracker '{}' value change event {} ...",
                      GetPathDescription(), change_event);
   DRAKE_ASSERT(change_event > 0);
 
   ++num_value_change_notifications_received_;
   if (last_change_event_ == change_event) {
     ++num_ignored_notifications_;
-    DRAKE_SPDLOG_DEBUG(log(),
+    DRAKE_LOGGER_DEBUG(
         "... ignoring repeated value change notification same change event.");
     return;
   }
@@ -44,8 +44,8 @@ void DependencyTracker::NotePrerequisiteChange(
     const DependencyTracker& prerequisite,
     int depth) const {
   unused(Indent);  // Avoid warning in non-Debug builds.
-  DRAKE_SPDLOG_DEBUG(
-      log(), "{}Tracker '{}': prerequisite '{}' changed (event {}) ...",
+  DRAKE_LOGGER_DEBUG(
+      "{}Tracker '{}': prerequisite '{}' changed (event {}) ...",
       Indent(depth), GetPathDescription(), prerequisite.GetPathDescription(),
       change_event);
   DRAKE_ASSERT(change_event > 0);
@@ -54,7 +54,7 @@ void DependencyTracker::NotePrerequisiteChange(
   ++num_prerequisite_notifications_received_;
   if (last_change_event_ == change_event) {
     ++num_ignored_notifications_;
-    DRAKE_SPDLOG_DEBUG(log(),
+    DRAKE_LOGGER_DEBUG(
         "{}... ignoring repeated prereq change notification same change event.",
         Indent(depth));
     return;
@@ -68,7 +68,7 @@ void DependencyTracker::NotePrerequisiteChange(
 
 void DependencyTracker::NotifySubscribers(int64_t change_event,
                                           int depth) const {
-  DRAKE_SPDLOG_DEBUG(log(), "{}... {} downstream subscribers.{}", Indent(depth),
+  DRAKE_LOGGER_DEBUG("{}... {} downstream subscribers.{}", Indent(depth),
                      num_subscribers(),
                      num_subscribers() > 0 ? " Notifying:" : "");
   DRAKE_ASSERT(change_event > 0);
@@ -76,7 +76,7 @@ void DependencyTracker::NotifySubscribers(int64_t change_event,
 
   for (const DependencyTracker* subscriber : subscribers_) {
     DRAKE_ASSERT(subscriber != nullptr);
-    DRAKE_SPDLOG_DEBUG(log(), "{}->{}", Indent(depth),
+    DRAKE_LOGGER_DEBUG("{}->{}", Indent(depth),
                        subscriber->GetPathDescription());
     subscriber->NotePrerequisiteChange(change_event, *this, depth + 1);
   }
@@ -91,7 +91,7 @@ void DependencyTracker::NotifySubscribers(int64_t change_event,
 void DependencyTracker::SubscribeToPrerequisite(
     DependencyTracker* prerequisite) {
   DRAKE_DEMAND(prerequisite != nullptr);
-  DRAKE_SPDLOG_DEBUG(log(), "Tracker '{}' subscribing to prerequisite '{}'",
+  DRAKE_LOGGER_DEBUG("Tracker '{}' subscribing to prerequisite '{}'",
                      GetPathDescription(), prerequisite->GetPathDescription());
 
   // Make sure we haven't already added this prerequisite.
@@ -103,7 +103,7 @@ void DependencyTracker::SubscribeToPrerequisite(
 
 void DependencyTracker::AddDownstreamSubscriber(
     const DependencyTracker& subscriber) {
-  DRAKE_SPDLOG_DEBUG(log(), "Tracker '{}' adding subscriber '{}'",
+  DRAKE_LOGGER_DEBUG("Tracker '{}' adding subscriber '{}'",
                      GetPathDescription(), subscriber.GetPathDescription());
   // Make sure we haven't already added this subscriber.
   DRAKE_ASSERT(!HasSubscriber(subscriber));  // Expensive.
@@ -135,7 +135,7 @@ void Remove(const T& value, std::vector<T>* to_search) {
 void DependencyTracker::UnsubscribeFromPrerequisite(
     DependencyTracker* prerequisite) {
   DRAKE_DEMAND(prerequisite != nullptr);
-  DRAKE_SPDLOG_DEBUG(log(), "Tracker '{}' unsubscribing from prerequisite '{}'",
+  DRAKE_LOGGER_DEBUG("Tracker '{}' unsubscribing from prerequisite '{}'",
                      GetPathDescription(), prerequisite->GetPathDescription());
 
   // Make sure we have already added this prerequisite.
@@ -147,7 +147,7 @@ void DependencyTracker::UnsubscribeFromPrerequisite(
 
 void DependencyTracker::RemoveDownstreamSubscriber(
     const DependencyTracker& subscriber) {
-  DRAKE_SPDLOG_DEBUG(log(), "Tracker '{}' removing subscriber '{}'",
+  DRAKE_LOGGER_DEBUG("Tracker '{}' removing subscriber '{}'",
                      GetPathDescription(), subscriber.GetPathDescription());
   // Make sure we already added this subscriber.
   DRAKE_ASSERT(HasSubscriber(subscriber));  // Expensive.
@@ -224,7 +224,7 @@ void DependencyTracker::RepairTrackerPointers(
   if (has_associated_cache_entry_) {
     const CacheIndex source_index(source.cache_value_->cache_index());
     cache_value_ = &cache->get_mutable_cache_entry_value(source_index);
-    DRAKE_SPDLOG_DEBUG(log(),
+    DRAKE_LOGGER_DEBUG(
         "Cloned tracker '{}' repairing cache entry {} invalidation to {:#x}.",
         GetPathDescription(), source.cache_value_->cache_index(),
         size_t(cache_value_));

--- a/systems/framework/dependency_tracker.h
+++ b/systems/framework/dependency_tracker.h
@@ -324,8 +324,8 @@ class DependencyTracker {
         owning_subcontext_(owning_subcontext),
         has_associated_cache_entry_(cache_value != nullptr),
         cache_value_(cache_value ? cache_value : &CacheEntryValue::dummy()) {
-    DRAKE_SPDLOG_DEBUG(
-        log(), "Tracker #{} '{}' constructed {} invalidation {:#x}{}.", ticket_,
+    DRAKE_LOGGER_DEBUG(
+        "Tracker #{} '{}' constructed {} invalidation {:#x}{}.", ticket_,
         description_, has_associated_cache_entry_ ? "with" : "without",
         size_t(cache_value),
         has_associated_cache_entry_

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -1557,8 +1557,8 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
     const OutputPortIndex port_index(id.second);
     const OutputPort<T>& port = system->get_output_port(port_index);
     const SubsystemIndex i = GetSystemIndexOrAbort(system);
-    SPDLOG_TRACE(log(), "Evaluating output for subsystem {}, port {}",
-                 system->GetSystemPathname(), port_index);
+    DRAKE_LOGGER_TRACE("Evaluating output for subsystem {}, port {}",
+        system->GetSystemPathname(), port_index);
     const Context<T>& subsystem_context = context.GetSubsystemContext(i);
     return port.template Eval<AbstractValue>(subsystem_context);
   }

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -1325,9 +1325,9 @@ class System : public SystemBase {
       // If T is a real number (not a symbolic expression), we can bail out
       // early with a diagnostic when the first constraint fails.
       if (scalar_predicate<T>::is_bool && !result) {
-        SPDLOG_DEBUG(drake::log(),
-                     "Context fails to satisfy SystemConstraint {}",
-                     constraint->description());
+        DRAKE_LOGGER_DEBUG(
+            "Context fails to satisfy SystemConstraint {}",
+            constraint->description());
         return result;
       }
     }

--- a/systems/lcm/lcm_publisher_system.cc
+++ b/systems/lcm/lcm_publisher_system.cc
@@ -117,7 +117,7 @@ const std::string& LcmPublisherSystem::get_channel_name() const {
 // period or publish period = 0.0 was passed to the constructor).
 EventStatus LcmPublisherSystem::PublishInputAsLcmMessage(
     const Context<double>& context) const {
-  SPDLOG_TRACE(drake::log(), "Publishing LCM {} message", channel_);
+  DRAKE_LOGGER_TRACE("Publishing LCM {} message", channel_);
   DRAKE_ASSERT(serializer_ != nullptr);
 
   // Converts the input into LCM message bytes.

--- a/systems/lcm/lcm_subscriber_system.cc
+++ b/systems/lcm/lcm_subscriber_system.cc
@@ -153,7 +153,7 @@ void LcmSubscriberSystem::CalcSerializerOutputValue(
 }
 
 void LcmSubscriberSystem::HandleMessage(const void* buffer, int size) {
-  SPDLOG_TRACE(drake::log(), "Receiving LCM {} message", channel_);
+  DRAKE_LOGGER_TRACE("Receiving LCM {} message", channel_);
   DRAKE_DEMAND(magic_number_ == kMagic);
 
   const uint8_t* const rbuf_begin = static_cast<const uint8_t*>(buffer);


### PR DESCRIPTION
Similarly for `DRAKE_LOGGER_DEBUG`.

Upstream spdlog is removing support for conditionally-unevaluated macro arguments, so we need to write our own macro for this case.

Since we need our own macro anyway, we might as well drop the redundant `drake::log()` macro argument.

This deprecates `DRAKE_SPDLOG_TRACE` and `DRAKE_SPDLOG_DEBUG`.

This is a pre-requisite for #12136.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12309)
<!-- Reviewable:end -->
