### PR TITLE
tools: Remove duplicate linking

### DIFF
--- a/attic/multibody/BUILD.bazel
+++ b/attic/multibody/BUILD.bazel
@@ -614,7 +614,7 @@ drake_cc_googletest(
     ],
 )
 
-drake_cc_googletest(
+drake_cc_test(
     name = "test_kinematics_cache_checks",
     data = ["//examples/atlas:models"],
     deps = [

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -6,6 +6,7 @@ load(
     "drake_cc_googletest",
     "drake_cc_library",
     "drake_cc_package_library",
+    "drake_cc_test",
 )
 load(
     "@drake//tools/skylark:drake_py.bzl",
@@ -736,7 +737,7 @@ drake_cc_googletest(
 )
 
 # Functional test of DRAKE_ASSERT at compile time.
-drake_cc_googletest(
+drake_cc_test(
     name = "drake_assert_test_compile",
     deps = [
         ":essential",

--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -146,15 +146,6 @@ cc_library(
     }),
 )
 
-# Depend on SCS's shared library iff SCS is enabled.
-cc_library(
-    name = "scs_deps",
-    deps = select({
-        "//conditions:default": ["@scs//:scsdir"],
-        "//tools:no_scs": [],
-    }),
-)
-
 # Depend on the subset of VTK's shared libraries that Drake uses.
 cc_library(
     name = "vtk_deps",
@@ -203,11 +194,10 @@ cc_library(
         # The list of depended-on *.so files. These should ONLY be shared
         # libraries; do not add static dependencies here.
         ":dreal_deps",
-        ":ipopt_deps",
         ":gurobi_deps",
+        ":ipopt_deps",
         ":mosek_deps",
         ":nlopt_deps",
-        ":scs_deps",
         ":vtk_deps",
         "//common:drake_marker_shared_library",
         "@ignition_math",
@@ -221,8 +211,8 @@ cc_library(
         "//lcmtypes:lcmtypes_drake_cc",
         "@eigen",
         "@fmt",
-        "@lcmtypes_bot2_core//:lcmtypes_bot2_core",
-        "@lcmtypes_robotlocomotion//:lcmtypes_robotlocomotion",
+        "@lcmtypes_bot2_core",
+        "@lcmtypes_robotlocomotion",
         "@optitrack_driver//lcmtypes:optitrack_lcmtypes",
         "@spdlog",
     ],

--- a/tools/skylark/pybind.bzl
+++ b/tools/skylark/pybind.bzl
@@ -264,6 +264,7 @@ def drake_pybind_cc_googletest(
             "@pybind11",
             "@python//:python_direct_link",
         ],
+        use_default_main = False,
         # Add 'manual', because we only want to run it with Python present.
         tags = ["manual"] + tags,
         visibility = visibility,


### PR DESCRIPTION
Once we turn off incompatible_remove_legacy_whole_archive, these duplicate symbols become errors.

This is a pre-requisite for #12262.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12310)
<!-- Reviewable:end -->
