### PR TITLE
geometry: export volume and surface meshes and fields to VTK files.

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -28,6 +28,7 @@ drake_cc_package_library(
         ":mesh_field",
         ":mesh_half_space_intersection",
         ":mesh_intersection",
+        ":mesh_to_vtk",
         ":obj_to_surface_mesh",
         ":penetration_as_point_pair_callback",
         ":proximity_utilities",
@@ -333,6 +334,18 @@ drake_cc_library(
     ],
 )
 
+drake_cc_library(
+    name = "mesh_to_vtk",
+    srcs = ["mesh_to_vtk.cc"],
+    hdrs = ["mesh_to_vtk.h"],
+    deps = [
+        ":mesh_field",
+        ":surface_mesh",
+        ":volume_mesh",
+        "@fmt",
+    ],
+)
+
 drake_cc_googletest(
     name = "collisions_exist_callback_test",
     deps = [
@@ -527,6 +540,19 @@ drake_cc_googletest(
     deps = [
         ":make_box_mesh",
         ":volume_to_surface_mesh",
+    ],
+)
+
+drake_cc_googletest(
+    name = "mesh_to_vtk_test",
+    deps = [
+        ":make_box_field",
+        ":make_box_mesh",
+        ":mesh_intersection",
+        ":mesh_to_vtk",
+        "//common:temp_directory",
+        "//geometry:shape_specification",
+        "//math:geometric_transform",
     ],
 )
 

--- a/geometry/proximity/mesh_to_vtk.cc
+++ b/geometry/proximity/mesh_to_vtk.cc
@@ -1,0 +1,153 @@
+#include "drake/geometry/proximity/mesh_to_vtk.h"
+
+#include <fstream>
+#include <iostream>
+
+#include <fmt/format.h>
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace {
+
+// Most of the functions in this anonymous namespace are templated on
+// the types of meshes or fields. They are used by the functions declared in
+// the header file, which are defined at the end of this file.
+
+void WriteVtkHeader(std::ofstream& out, const std::string& title) {
+  out << "# vtk DataFile Version 3.0\n";
+  out << title << std::endl;
+  out << "ASCII\n";
+  // An extra blank line makes the file more human readable.
+  out << std::endl;
+}
+
+/**
+ @tparam Mesh  VolumeMesh<double> or SurfaceMesh<double>
+ */
+template <typename Mesh>
+void WriteVtkUnstructuredGrid(std::ofstream& out, const Mesh& mesh) {
+  const int num_points = mesh.num_vertices();
+  out << "DATASET UNSTRUCTURED_GRID\n";
+  out << "POINTS " << num_points << " double\n";
+  for (typename Mesh::VertexIndex i(0); i < num_points; ++i) {
+    const Vector3<double>& vertex = mesh.vertex(i).r_MV();
+    out << fmt::format("{:12.8f} {:12.8f} {:12.8f}\n", vertex[0], vertex[1],
+                       vertex[2]);
+  }
+  out << std::endl;
+
+  // For a triangular mesh, an element is a triangle.
+  // For a tetrahedral mesh, an element is a tetrahedron.
+  const int num_elements = mesh.num_elements();
+  // For a triangular mesh, we use 4 integers per triangle.
+  // For a tetrahedral mesh, we use 5 integers per tetrahedron.
+  const int num_vertices_per_element = Mesh::kDim + 1;
+  const int num_integers = num_elements * (num_vertices_per_element + 1);
+  out << "CELLS " << num_elements << " " << num_integers << std::endl;
+  for (typename Mesh::ElementIndex i(0); i < num_elements; ++i) {
+    const auto& element = mesh.element(i);
+    out << fmt::format("{}", num_vertices_per_element);
+    for (int v = 0; v < num_vertices_per_element; ++v) {
+      out << fmt::format(" {:6d}", element.vertex(v));
+    }
+    out << std::endl;
+  }
+  out << std::endl;
+
+  const int kVtkCellTypeTriangle = 5;
+  const int kVtkCellTypeTetrahedron = 10;
+  const int cell_type =
+      (Mesh::kDim == 2) ? kVtkCellTypeTriangle : kVtkCellTypeTetrahedron;
+  out << "CELL_TYPES " << num_elements << std::endl;
+  for (int i = 0; i < num_elements; ++i) {
+    out << fmt::format("{}\n", cell_type);
+  }
+  out << std::endl;
+}
+
+/**
+ @tparam Mesh  VolumeMesh<double> or SurfaceMesh<double>
+ */
+template<typename Mesh>
+void WriteMeshToVtk(const std::string& file_name,
+                    const Mesh& mesh,
+                    const std::string& title) {
+  std::ofstream file(file_name);
+  if (file.fail()) {
+    throw std::runtime_error(fmt::format("Cannot create file: {}.", file_name));
+  }
+  WriteVtkHeader(file, title);
+  WriteVtkUnstructuredGrid(file, mesh);
+  file.close();
+}
+
+/**
+ @tparam Field VolumeMeshFieldLinear<double, double> or
+               SurfaceMeshFieldLinear<double, double>
+ */
+template <typename Field>
+void WriteVtkScalarField(
+    std::ofstream& out, std::string name,
+    const Field& field) {
+  out << fmt::format("POINT_DATA {}\n", field.values().size());
+  // VTK doesn't like space ' ' in the name of the scalar field.
+  // Replace space ' ' with underscore '_'.
+  std::replace(name.begin(), name.end(), ' ', '_');
+  out << fmt::format("SCALARS {} double 1\n", name);
+  out << "LOOKUP_TABLE default\n";
+  for (auto value : field.values()) {
+    out << fmt::format("{:20.8f}\n", value);
+  }
+  out << std::endl;
+}
+
+/**
+ @tparam Field VolumeMeshFieldLinear<double, double> or
+               SurfaceMeshFieldLinear<double, double>
+ */
+template <typename Field>
+void WriteMeshFieldLinearToVtk(const std::string& file_name,
+                               const Field& field,
+                               const std::string& title) {
+  std::ofstream file(file_name);
+  if (file.fail()) {
+    throw std::runtime_error(fmt::format("Cannot create file: {}.", file_name));
+  }
+  WriteVtkHeader(file, title);
+  WriteVtkUnstructuredGrid(file, field.mesh());
+  WriteVtkScalarField(file, field.name(), field);
+  file.close();
+}
+
+}  // namespace
+
+void WriteVolumeMeshToVtk(const std::string& file_name,
+                          const VolumeMesh<double>& mesh,
+                          const std::string& title) {
+  WriteMeshToVtk(file_name, mesh, title);
+}
+
+void WriteSurfaceMeshToVtk(const std::string& file_name,
+                           const SurfaceMesh<double>& mesh,
+                           const std::string& title) {
+  WriteMeshToVtk(file_name, mesh, title);
+}
+
+void WriteVolumeMeshFieldLinearToVtk(
+    const std::string& file_name,
+    const VolumeMeshFieldLinear<double, double>& field,
+    const std::string& title) {
+  WriteMeshFieldLinearToVtk(file_name, field, title);
+}
+
+void WriteSurfaceMeshFieldLinearToVtk(
+    const std::string& file_name,
+    const SurfaceMeshFieldLinear<double, double>& field,
+    const std::string& title) {
+  WriteMeshFieldLinearToVtk(file_name, field, title);
+}
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/mesh_to_vtk.h
+++ b/geometry/proximity/mesh_to_vtk.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <string>
+
+#include "drake/geometry/proximity/mesh_field_linear.h"
+#include "drake/geometry/proximity/surface_mesh.h"
+#include "drake/geometry/proximity/volume_mesh.h"
+#include "drake/geometry/proximity/volume_mesh_field.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+/** @name Export Volume/Surface Mesh and Field for visualization in ParaView.
+ These functions export VolumeMesh, SurfaceMesh, VolumeMeshFieldLinear, or
+ SurfaceMeshFieldLinear to VTK files (legacy, serial format) for
+ visualization in ParaView. The file format is described in:
+ https://vtk.org/wp-content/uploads/2015/04/file-formats.pdf
+ */
+//@{
+
+/**
+ Writes VolumeMesh to VTK file.
+ @param file_name  A file name with absolute path or relative path.
+ @param mesh       A tetrahedral volume mesh.
+ @param title      Name of the data set will be written on the second line of
+                   the VTK file.
+ @throws std::runtime_error if unable to create the file.
+ */
+void WriteVolumeMeshToVtk(const std::string& file_name,
+                          const VolumeMesh<double>& mesh,
+                          const std::string& title);
+
+/**
+ Writes SurfaceMesh to VTK file.
+ @param file_name  A file name with absolute path or relative path.
+ @param mesh       A triangulated surface mesh.
+ @param title      Name of the data set will be written on the second line of
+                   the VTK file.
+ @throws std::runtime_error if unable to create the file.
+ */
+void WriteSurfaceMeshToVtk(const std::string& file_name,
+                           const SurfaceMesh<double>& mesh,
+                           const std::string& title);
+
+/**
+ Writes VolumeMeshFieldLinear to VTK file.
+ @param file_name  A file name with absolute path or relative path.
+ @param field      A scalar field defined on a tetrahedral mesh.
+ @param title      Name of the data set will be written on the second line of
+                   the VTK file.
+ @note `field.name()` will be written to VTK file with space ' ' replaced by
+       underscore '_' on the "SCALARS field.name()" line.
+ @throws std::runtime_error if unable to create the file.
+ */
+void WriteVolumeMeshFieldLinearToVtk(
+    const std::string& file_name,
+    const VolumeMeshFieldLinear<double, double>& field,
+    const std::string& title);
+
+/**
+ Writes SurfaceMeshFieldLinear to VTK file.
+ @param file_name  A file name with absolute path or relative path.
+ @param field      A scalar field defined on a triangulated surface mesh.
+ @param title      Name of the data set will be written on the second line of
+                   the VTK file.
+ @note `field.name()` will be written to VTK file with space ' ' replaced by
+       underscore '_' on the "SCALARS field.name()" line.
+ @throws std::runtime_error if unable to create the file.
+ */
+void WriteSurfaceMeshFieldLinearToVtk(
+    const std::string& file_name,
+    const SurfaceMeshFieldLinear<double, double>& field,
+    const std::string& title);
+
+//@}
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/surface_mesh.h
+++ b/geometry/proximity/surface_mesh.h
@@ -198,6 +198,12 @@ class SurfaceMesh {
    */
   int num_vertices() const { return vertices_.size(); }
 
+  /** Returns the number of triangles in the mesh. For %SurfaceMesh, an
+   element is a triangle. Returns the same number as num_faces() and enables
+   mesh consumers to be templated on mesh type.
+   */
+  int num_elements() const { return num_faces(); }
+
   //@}
 
   /**

--- a/geometry/proximity/test/mesh_to_vtk_test.cc
+++ b/geometry/proximity/test/mesh_to_vtk_test.cc
@@ -1,0 +1,95 @@
+#include "drake/geometry/proximity/mesh_to_vtk.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+#include "drake/common/temp_directory.h"
+#include "drake/geometry/proximity/make_box_field.h"
+#include "drake/geometry/proximity/make_box_mesh.h"
+#include "drake/geometry/proximity/mesh_intersection.h"
+#include "drake/geometry/shape_specification.h"
+#include "drake/math/rigid_transform.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+using Eigen::Vector3d;
+using math::RigidTransformd;
+using std::unique_ptr;
+
+// We use Box to represent all primitives in the tests when we generate
+// meshes and fields. We only perform smoke tests and do not check the
+// content of the output VTK files.
+
+// TODO(DamrongGuoy): Use VTK library to read the files for verification.
+//  Rigth now we manually load the files into ParaView for verification.
+
+GTEST_TEST(MeshToVtkTest, BoxTetrahedra) {
+  const Box box(4.0, 4.0, 2.0);
+  // resolution_hint 0.5 is enough to have vertices on the medial axis.
+  const auto mesh = MakeBoxVolumeMesh<double>(box, 0.5);
+  WriteVolumeMeshToVtk(temp_directory() + "/" + "box_tet.vtk", mesh,
+                       "Tetrahedral Mesh of Box");
+}
+
+GTEST_TEST(MeshToVtkTest, BoxTriangles) {
+  const Box box(4.0, 4.0, 2.0);
+  // Very coarse resolution_hint 4.0 should give the coarsest mesh.
+  const auto mesh = MakeBoxSurfaceMesh<double>(box, 4.0);
+  WriteSurfaceMeshToVtk(temp_directory() + "/" + "box_tri.vtk", mesh,
+                        "Triangular Mesh of Box");
+}
+
+GTEST_TEST(MeshToVtkTest, BoxTetrahedraPressureField) {
+  const Box box(4.0, 4.0, 2.0);
+  // resolution_hint 0.5 is enough to have vertices on the medial axis.
+  const auto mesh = MakeBoxVolumeMesh<double>(box, 0.5);
+  const double kElasticModulus = 1.0e+5;
+  const auto pressure =
+      MakeBoxPressureField<double>(box, &mesh, kElasticModulus);
+  WriteVolumeMeshFieldLinearToVtk(
+      temp_directory() + "/" + "box_tet_pressure.vtk ", pressure,
+      "Pressure Field in Box");
+}
+
+// Helper function to create a contact surface between a soft box and a rigid
+// box.
+unique_ptr<ContactSurface<double>> BoxContactSurface() {
+  const Box soft_box(4., 4., 2.);
+  // resolution_hint 0.5 is enough to have vertices on the medial axis.
+  const auto soft_mesh = MakeBoxVolumeMesh<double>(soft_box, 0.5);
+  const double kElasticModulus = 1.0e+5;
+  const auto soft_pressure =
+      MakeBoxPressureField<double>(soft_box, &soft_mesh, kElasticModulus);
+  // The soft box is at the center of World.
+  RigidTransformd X_WS = RigidTransformd::Identity();
+
+  const Box rigid_box(4, 4, 2);
+  // Very coarse resolution_hint 4.0 should give the coarsest mesh.
+  const auto rigid_mesh = MakeBoxSurfaceMesh<double>(rigid_box, 4.0);
+  // The rigid box intersects the soft box in a unit cube at the corner
+  // (2.0, 2.0, 1.0).
+  RigidTransformd X_WR(Vector3d{3., 3., 1.});
+
+  return mesh_intersection::ComputeContactSurfaceFromSoftVolumeRigidSurface(
+      GeometryId::get_new_id(), soft_pressure, X_WS,
+      GeometryId::get_new_id(), rigid_mesh, X_WR);
+}
+
+GTEST_TEST(MeshToVtkTest, BoxContactSurfacePressure) {
+  unique_ptr<ContactSurface<double>> contact = BoxContactSurface();
+  auto contact_pressure =
+      dynamic_cast<const SurfaceMeshFieldLinear<double, double>*>(
+          &contact->e_MN());
+  ASSERT_NE(contact_pressure, nullptr);
+  WriteSurfaceMeshFieldLinearToVtk(
+      temp_directory() + "/" + "box_rigid_soft_contact_pressure.vtk",
+      *contact_pressure, "Pressure Distribution on Contact Surface");
+}
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
Export VolumeMesh, SurfaceMesh, VolumeMeshFieldLinear, SurfaceMeshFieldLinear to VTK files for visualization in ParaView.  They are internal utilities for inspecting pressure fields and meshes generated for hydroelastic contact models.

The following picture shows three slices of a tetrahedral mesh of a box with its pressure field, superimposed with the pressure distribution on its contact surface with another box (not shown). (The pressure field in the tetrahedral mesh has issues at some corners related to #12128 "Improve tetrahedral mesh connectivity for cylinders and boxes.")

![image](https://user-images.githubusercontent.com/42557859/68163075-80f9f280-ff0e-11e9-9f75-d6a246240049.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12311)
<!-- Reviewable:end -->
