### PR TITLE
python: Provide interpreter path for version warning

### DIFF
--- a/tools/workspace/python/repository.bzl
+++ b/tools/workspace/python/repository.bzl
@@ -107,15 +107,16 @@ def repository_python_info(repository_ctx):
     if which(repository_ctx, python_config) == None:
         fail((
             "Cannot find corresponding config executable: {}\n" +
-            "  For interpreter: {}"
+            "  From interpreter: {}"
         ).format(python_config, python_path))
 
     # Warn if we do not the correct platform support.
     if version not in versions_supported:
         print((
             "\n\nWARNING: Python {} is not a supported / tested version for " +
-            "use with Drake.\n  Supported versions on {}: {}\n\n"
-        ).format(version, os_key, versions_supported))
+            "use with Drake.\n  Supported versions on {}: {}\n  " +
+            "From interpreter: {}\n\n"
+        ).format(version, os_key, versions_supported, python))
 
     site_packages_relpath = "lib/python{}/site-packages".format(version)
     return struct(


### PR DESCRIPTION
This could've helped pin-point the issue here a bit faster:
https://drakedevelopers.slack.com/archives/C0KDGF4V9/p1572713308020600

\cc @edrumwri

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12314)
<!-- Reviewable:end -->
