### PR TITLE
Refactors b_Bo_W to Fb_Bo_W

### DIFF
--- a/multibody/tree/articulated_body_inertia.h
+++ b/multibody/tree/articulated_body_inertia.h
@@ -21,12 +21,12 @@ namespace multibody {
 /// remarkable `O(n)` Articulated Body Algorithm (ABA) for solving forward
 /// dynamics. Recall that the Newton-Euler equations allow us to describe the
 /// combined rotational and translational dynamics of a rigid body: <pre>
-///   F_BBo_W = M_B_W * A_WB + b_Bo_W                                    (1)
+///   F_BBo_W = M_B_W * A_WB + Fb_Bo_W                                    (1)
 /// </pre>
 /// where the spatial inertia (see SpatialInertia) `M_B_W` of body B expressed
 /// in the world frame W linearly relates the spatial acceleration (see
 /// SpatialAcceleration) of body B in the world frame with the total applied
-/// spatial forces (see SpatialForce) `F_BBo` on body B and where `b_Bo_W`
+/// spatial forces (see SpatialForce) `F_BBo` on body B and where `Fb_Bo_W`
 /// contains the velocity dependent gyroscopic terms.
 ///
 /// A similar relationship is found for an articulated body with a rigid body B

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -577,9 +577,9 @@ void MultibodyTree<T>::CalcSpatialInertiaInWorldCache(
 template <typename T>
 void MultibodyTree<T>::CalcDynamicBiasCache(
     const systems::Context<T>& context,
-    std::vector<SpatialForce<T>>* b_Bo_W_cache) const {
-  DRAKE_THROW_UNLESS(b_Bo_W_cache != nullptr);
-  DRAKE_THROW_UNLESS(static_cast<int>(b_Bo_W_cache->size()) == num_bodies());
+    std::vector<SpatialForce<T>>* Fb_Bo_W_cache) const {
+  DRAKE_THROW_UNLESS(Fb_Bo_W_cache != nullptr);
+  DRAKE_THROW_UNLESS(static_cast<int>(Fb_Bo_W_cache->size()) == num_bodies());
 
   const std::vector<SpatialInertia<T>>& spatial_inertia_in_world_cache =
       EvalSpatialInertiaInWorldCache(context);
@@ -599,11 +599,12 @@ void MultibodyTree<T>::CalcDynamicBiasCache(
     // B's unit rotational inertia about Bo, expressed in W.
     const UnitInertia<T>& G_B_W = M_B_W.get_unit_inertia();
 
-    // Gyroscopic spatial force b_Bo_W(q, v) on body B about Bo, expressed in W.
+    // Gyroscopic spatial force Fb_Bo_W(q, v) on body B about Bo, expressed in
+    // W.
     const SpatialVelocity<T>& V_WB = vc.get_V_WB(body.node_index());
     const Vector3<T>& w_WB = V_WB.rotational();
-    SpatialForce<T>& b_Bo_W = (*b_Bo_W_cache)[body.node_index()];
-    b_Bo_W = mass * SpatialForce<T>(
+    SpatialForce<T>& Fb_Bo_W = (*Fb_Bo_W_cache)[body.node_index()];
+    Fb_Bo_W = mass * SpatialForce<T>(
                         w_WB.cross(G_B_W * w_WB), /* rotational */
                         w_WB.cross(w_WB.cross(p_BoBcm_W)) /* translational */);
   }
@@ -750,7 +751,7 @@ void MultibodyTree<T>::CalcInverseDynamics(
   const std::vector<SpatialInertia<T>>& spatial_inertia_in_world_cache =
       EvalSpatialInertiaInWorldCache(context);
 
-  // Eval b_Bo_W(q, v). b_Bo_W = 0 if v = 0.
+  // Eval Fb_Bo_W(q, v). Fb_Bo_W = 0 if v = 0.
   const std::vector<SpatialForce<T>>* dynamic_bias_cache =
       ignore_velocities ? nullptr : &EvalDynamicBiasCache(context);
 

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -1418,21 +1418,21 @@ class MultibodyTree {
       const systems::Context<T>& context,
       std::vector<SpatialInertia<T>>* M_B_W_cache) const;
 
-  /// Computes the bias term `b_Bo_W(q, v)` for each body in the model.
-  /// For a body B, this is the bias term `b_Bo_W` in the equation
-  /// `F_BBo_W = M_Bo_W * A_WB + b_Bo_W`, where `M_Bo_W` is the spatial inertia
+  /// Computes the bias term `Fb_Bo_W(q, v)` for each body in the model.
+  /// For a body B, this is the bias term `Fb_Bo_W` in the equation
+  /// `F_BBo_W = M_Bo_W * A_WB + Fb_Bo_W`, where `M_Bo_W` is the spatial inertia
   /// about B's origin Bo, `A_WB` is the spatial acceleration of B in W and
   /// `F_BBo_W` is the spatial force applied on B about Bo, expressed in W.
   /// @param[in] context
   ///   The context storing the state of the model.
-  /// @param[out] b_Bo_W_cache
-  ///   For each body in the model, entry Body::node_index() in b_Bo_W_cache
-  ///   contains the updated bias term `b_Bo_W(q, v)` for that body. On input it
-  ///   must be a valid pointer to a vector of size num_bodies().
-  /// @throws std::exception if b_Bo_W_cache is nullptr or if its size is not
+  /// @param[out] Fb_Bo_W_cache
+  ///   For each body in the model, entry Body::node_index() in Fb_Bo_W_cache
+  ///   contains the updated bias term `Fb_Bo_W(q, v)` for that body. On input
+  ///   it must be a valid pointer to a vector of size num_bodies().
+  /// @throws std::exception if Fb_Bo_W_cache is nullptr or if its size is not
   /// num_bodies().
   void CalcDynamicBiasCache(const systems::Context<T>& context,
-                            std::vector<SpatialForce<T>>* b_Bo_W_cache) const;
+                            std::vector<SpatialForce<T>>* Fb_Bo_W_cache) const;
 
   /// Computes all the kinematic quantities that depend on the generalized
   /// accelerations that is, the generalized velocities' time derivatives, and
@@ -2195,8 +2195,8 @@ class MultibodyTree {
     return tree_system_->EvalSpatialInertiaInWorldCache(context);
   }
 
-  // Evaluates the cache entry stored in context with the bias term b_Bo_W(q, v)
-  // for each body. These will be updated as needed.
+  // Evaluates the cache entry stored in context with the bias term
+  // Fb_Bo_W(q, v) for each body. These will be updated as needed.
   const std::vector<SpatialForce<T>>& EvalDynamicBiasCache(
       const systems::Context<T>& context) const {
     DRAKE_ASSERT(tree_system_ != nullptr);

--- a/multibody/tree/multibody_tree_system.cc
+++ b/multibody/tree/multibody_tree_system.cc
@@ -166,9 +166,9 @@ void MultibodyTreeSystem<T>::Finalize() {
   cache_indexes_.velocity_kinematics =
       velocity_kinematics_cache_entry.cache_index();
 
-  // Allocate cache entry to store b_Bo_W(q, v) for each body.
+  // Allocate cache entry to store Fb_Bo_W(q, v) for each body.
   auto& dynamic_bias_cache_entry = this->DeclareCacheEntry(
-      std::string("dynamic bias (b_Bo_W)"),
+      std::string("dynamic bias (Fb_Bo_W)"),
       [tree = tree_.get()]() {
         return AbstractValue::Make(
             std::vector<SpatialForce<T>>(tree->num_bodies()));
@@ -180,7 +180,7 @@ void MultibodyTreeSystem<T>::Finalize() {
             cache_value->get_mutable_value<std::vector<SpatialForce<T>>>();
         tree->CalcDynamicBiasCache(context, &dynamic_bias_cache);
       },
-      // The computation of b_Bo_W(q, v) requires updated values of M_Bo_W(q)
+      // The computation of Fb_Bo_W(q, v) requires updated values of M_Bo_W(q)
       // and V_WB(q, v). We make these prerequisites explicit.
       // Another alternative would be to state the dependence on q and v.
       // However this option is not optimal until #9171 gets resolved.

--- a/multibody/tree/multibody_tree_system.h
+++ b/multibody/tree/multibody_tree_system.h
@@ -102,8 +102,8 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
 
   /** Returns a reference to the up to date cache of per-body bias terms in
   the given Context, recalculating it first if necessary.
-  For a body B, this is the bias term `b_Bo_W(q, v)` in the equation
-  `F_Bo_W = M_Bo_W * A_WB + b_Bo_W`, where `M_Bo_W` is the spatial inertia
+  For a body B, this is the bias term `Fb_Bo_W(q, v)` in the equation
+  `F_Bo_W = M_Bo_W * A_WB + Fb_Bo_W`, where `M_Bo_W` is the spatial inertia
   about B's origin Bo, `A_WB` is the spatial acceleration of B in W and
   `F_Bo_W` is the spatial force on B about Bo, expressed in W. */
   const std::vector<SpatialForce<T>>& EvalDynamicBiasCache(


### PR DESCRIPTION
This simply refactors the variable name from b_Bo_W to Fb_Bo_W so that it is locally more clear it refers to a spatial acceleration. This is useful when working with expressions that also involve spatial acceleration bias in next PRs (which I'll denote Ab).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12316)
<!-- Reviewable:end -->
