### PR TITLE
workspace: Use FMT_USE_GRISU=1 for fmt

### DIFF
--- a/common/test/text_logging_test.cc
+++ b/common/test/text_logging_test.cc
@@ -57,6 +57,14 @@ GTEST_TEST(TextLoggingTest, SmokeTest) {
                      "OK", obj);
 }
 
+// Check that floating point values format sensibly.  We'll just test fmt
+// directly, since we know that spdlog uses it internally.
+GTEST_TEST(TextLoggingTest, FloatingPoint) {
+  EXPECT_EQ(fmt::format("{}", 1.0), "1.0");
+  // This number is particularly challenging.
+  EXPECT_EQ(fmt::format("{}", 0.009), "0.009");
+}
+
 // Check that the constexpr bool is set correctly.
 GTEST_TEST(TextLoggingTest, ConstantTest) {
   #if TEXT_LOGGING_TEST_SPDLOG

--- a/tools/workspace/fmt/package-create-cps.py
+++ b/tools/workspace/fmt/package-create-cps.py
@@ -17,7 +17,7 @@ content = """
   "Components": {
     "fmt-header-only": {
       "Type": "interface",
-      "Definitions": ["FMT_HEADER_ONLY=1"],
+      "Definitions": ["FMT_HEADER_ONLY=1", "FMT_USE_GRISU=1"],
       "Includes": ["@prefix@/include/fmt"]
     }
   }

--- a/tools/workspace/fmt/package.BUILD.bazel
+++ b/tools/workspace/fmt/package.BUILD.bazel
@@ -22,8 +22,13 @@ cc_library(
         "include/fmt/posix.h",
     ]),
     defines = [
+        # By tradition, Drake uses the header-only build of fmt.
         "FMT_HEADER_ONLY=1",
-        "FMT_NO_FMT_STRING_ALIAS=1",  # Avoid macro pollution.
+        # Avoid macro pollution.
+        "FMT_NO_FMT_STRING_ALIAS=1",
+        # Use sensible floating-point formatting.  (As of 6.0.0 this isn't the
+        # default upstream, but it is promised to be in a forthcoming release.)
+        "FMT_USE_GRISU=1",
     ],
     includes = ["include"],
 )

--- a/tools/workspace/fmt/repository.bzl
+++ b/tools/workspace/fmt/repository.bzl
@@ -10,6 +10,10 @@ def fmt_repository(
         repository = "fmtlib/fmt",
         # When changing the fmt version, also update the URL in the file
         # overview docstring of drake/common/text_logging.h.
+        #
+        # When changing the fmt version, also check if FMT_USE_GRISU=1
+        # is enabled by default upstream, and if so remove it from our
+        # package.BUILD.bazel customizations.
         commit = "6.0.0",
         sha256 = "f1907a58d5e86e6c382e51441d92ad9e23aea63827ba47fd647eacc0d3a16c78",  # noqa
         build_file = "@drake//tools/workspace/fmt:package.BUILD.bazel",


### PR DESCRIPTION
For floating-point string formatting, this algorithm is both faster and more correct.

According to https://github.com/fmtlib/fmt/issues/1335#issuecomment-536660444, Grisu will be enabled by default in the next release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12318)
<!-- Reviewable:end -->
