### PR TITLE
Revert "workspace: Upgrade spdlog to latest release 1.4.2"

### DIFF
--- a/tools/workspace/spdlog/package-create-cps.py
+++ b/tools/workspace/spdlog/package-create-cps.py
@@ -1,7 +1,7 @@
-from drake.tools.install.cpsutils import read_defs, read_requires
+from drake.tools.install.cpsutils import read_version_defs, read_requires
 
-def_re = "#define\s+(\S+)\s+(\S+)"
-defs = read_defs(def_re)
+def_re = "project\(spdlog\sVERSION\s([0-9]+).([0-9]+).([0-9]+)"
+defs = read_version_defs(def_re)
 
 defs.update(read_requires())
 
@@ -9,9 +9,9 @@ content = """
 {
   "Cps-Version": "0.8.0",
   "Name": "spdlog",
-  "Description": "Fast C++ logging library",
+  "Description": "Super fast C++ logging library",
   "License": "MIT",
-  "Version": "%(SPDLOG_VER_MAJOR)s.%(SPDLOG_VER_MINOR)s.%(SPDLOG_VER_PATCH)s",
+  "Version": "%(VERSION_MAJOR)s.%(VERSION_MINOR)s.%(VERSION_PATCH)s",
   "Requires": {
     "fmt": {
       "Version": "%(fmt_VERSION)s",

--- a/tools/workspace/spdlog/package.BUILD.bazel
+++ b/tools/workspace/spdlog/package.BUILD.bazel
@@ -7,7 +7,7 @@ load(
     "install_cmake_config",
 )
 
-licenses(["notice"])  # MIT
+licenses(["notice"])  # BSD-2-Clause AND MIT
 
 package(
     default_visibility = ["//visibility:public"],
@@ -27,7 +27,6 @@ cc_library(
     ),
     defines = [
         "HAVE_SPDLOG",
-        # Use Drake's @fmt external, not the bundled version inside spdlog.
         "SPDLOG_FMT_EXTERNAL",
     ],
     includes = ["include"],
@@ -44,7 +43,7 @@ CMAKE_PACKAGE = "spdlog"
 cmake_config(
     package = CMAKE_PACKAGE,
     script = "@drake//tools/workspace/spdlog:package-create-cps.py",
-    version_file = "include/spdlog/version.h",
+    version_file = "CMakeLists.txt",
     deps = ["@fmt//:cps"],
 )
 

--- a/tools/workspace/spdlog/repository.bzl
+++ b/tools/workspace/spdlog/repository.bzl
@@ -8,8 +8,8 @@ def spdlog_repository(
     github_archive(
         name = name,
         repository = "gabime/spdlog",
-        commit = "v1.4.2",
-        sha256 = "821c85b120ad15d87ca2bc44185fa9091409777c756029125a02f81354072157",  # noqa
+        commit = "v1.3.1",
+        sha256 = "160845266e94db1d4922ef755637f6901266731c4cb3b30b45bf41efa0e6ab70",  # noqa
         build_file = "@drake//tools/workspace/spdlog:package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
Reverts 775f27acc9f264a3f882fbfb1cbd4e9c88515c13 (RobotLocomotion/drake#12136).

It broke https://drake-jenkins.csail.mit.edu/view/Production/job/linux-bionic-clang-cmake-continuous-debug/ by making `libdrake.so` grow beyond 2 GiB unstripped, which breaks `patchelf`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12319)
<!-- Reviewable:end -->
