### PR TITLE
geometry: create pressure fields for ellipsoids and spheres.

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -24,7 +24,9 @@ drake_cc_package_library(
         ":make_box_field",
         ":make_box_mesh",
         ":make_cylinder_mesh",
+        ":make_ellipsoid_field",
         ":make_ellipsoid_mesh",
+        ":make_sphere_field",
         ":make_sphere_mesh",
         ":mesh_field",
         ":mesh_half_space_intersection",
@@ -260,6 +262,26 @@ drake_cc_library(
         ":volume_mesh",
         "//common:essential",
         "//common:unused",
+        "//geometry:shape_specification",
+    ],
+)
+
+drake_cc_library(
+    name = "make_ellipsoid_field",
+    hdrs = ["make_ellipsoid_field.h"],
+    deps = [
+        ":volume_mesh",
+        "//common:essential",
+        "//geometry:shape_specification",
+    ],
+)
+
+drake_cc_library(
+    name = "make_sphere_field",
+    hdrs = ["make_sphere_field.h"],
+    deps = [
+        ":volume_mesh",
+        "//common:essential",
         "//geometry:shape_specification",
     ],
 )
@@ -510,6 +532,24 @@ drake_cc_googletest(
     deps = [
         ":make_box_field",
         ":make_box_mesh",
+        ":volume_to_surface_mesh",
+    ],
+)
+
+drake_cc_googletest(
+    name = "make_ellipsoid_field_test",
+    deps = [
+        ":make_ellipsoid_field",
+        ":make_ellipsoid_mesh",
+        ":volume_to_surface_mesh",
+    ],
+)
+
+drake_cc_googletest(
+    name = "make_sphere_field_test",
+    deps = [
+        ":make_sphere_field",
+        ":make_sphere_mesh",
         ":volume_to_surface_mesh",
     ],
 )

--- a/geometry/proximity/make_ellipsoid_field.h
+++ b/geometry/proximity/make_ellipsoid_field.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "drake/common/eigen_types.h"
+#include "drake/geometry/proximity/volume_mesh.h"
+#include "drake/geometry/proximity/volume_mesh_field.h"
+#include "drake/geometry/shape_specification.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+/**
+ Generates a piecewise-linear pressure field inside the given ellipsoid as
+ represented by the given volume mesh. The pressure at a point is defined
+ as E * e(x) where e ∈ [0,1] is the extent -- a measure of penetration into
+ the volume, and E is the given `elastic_modulus`. The pressure is zero on the
+ boundary with maximum E in the interior.
+ @param ellipsoid        The ellipsoid with its canonical frame E.
+ @param mesh_E           A pointer to a tetrahedral mesh of the ellipsoid. It
+                         is aliased in the returned pressure field and must
+                         remain alive as long as the field. The position
+                         vectors of mesh vertices are expressed in the
+                         ellipsoid's frame E.
+ @param elastic_modulus  Scale extent to pressure.
+ @return                 The pressure field defined on the tetrahedral mesh.
+ @pre                    `elastic_modulus` is strictly positive.
+                         `mesh_E` represents the ellipsoid and has enough
+                         resolution to represent the pressure field.
+ @tparam T               The scalar type for representing the mesh
+                         vertex positions and the pressure value.
+ */
+template <typename T>
+VolumeMeshFieldLinear<T, T> MakeEllipsoidPressureField(
+    const Ellipsoid& ellipsoid, const VolumeMesh<T>* mesh_E,
+    const T elastic_modulus) {
+  // TODO(DamrongGuoy): Switch to a better implementation in the future.
+  //  The current implementation uses a simple map from the ellipsoid to the
+  //  unit sphere and assigns extent on the ellipsoid from the extent on the
+  //  unit sphere, which is a scaled distance to boundary of the unit sphere.
+  //  The current implementation has a number of limitations:
+  //  1. It is not differentiable at the center of the ellipsoid.
+  //  2. It is not uniformly stiff. It is stiffer along a shorter principal
+  //     axis than a longer principal axis of the same ellipsoid, i.e., the
+  //     gradient of pressure field is larger on the shorter principal axis.
+  //  3. Implicitly we impose the rigid core as the center of the ellipsoid.
+  //     In the future, we will consider a rigid core as an offset of the
+  //     ellipsoid. The offset may or may not have uniform thickness from the
+  //     boundary.
+  //  4. We do not have a mechanism to define a pressure field using barrier
+  //     functions.  One possibility is to generate the mesh in offset
+  //     layers, and define linear pressure fields in each offset with
+  //     different elastic modulus.
+  DRAKE_DEMAND(elastic_modulus > T(0));
+  const T a = ellipsoid.get_a();
+  const T b = ellipsoid.get_b();
+  const T c = ellipsoid.get_c();
+  // For scaling a position vector in the ellipsoid to the unit sphere.
+  const Vector3<T> scale{T(1.0) / a, T(1.0) / b, T(1.0) / c};
+  std::vector<T> pressure_values;
+  pressure_values.reserve(mesh_E->num_vertices());
+  // A threshold to treat near-zero extent as zero extent. Some boundary
+  // vertices do not lie exactly on the surface of the ellipsoid due to
+  // rounding errors. We will treat their near-zero extent as exactly zero
+  // extent.
+  const T kExtentEpsilon = 1e-14;
+  for (const VolumeVertex<T>& vertex : mesh_E->vertices()) {
+    // V is a vertex of the ellipsoid mesh with frame E.
+    const Vector3<T>& r_EV = vertex.r_MV();
+    // Scale V in the ellipsoid to U in the unit sphere.
+    const Vector3<T> r_EU = scale.cwiseProduct(r_EV);
+    T extent = T(1.0) - r_EU.norm();
+    if (extent < kExtentEpsilon) {
+      extent = T(0.0);
+    }
+    pressure_values.push_back(elastic_modulus * extent);
+  }
+  return VolumeMeshFieldLinear<T, T>("pressure", std::move(pressure_values),
+                                     mesh_E);
+}
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/make_sphere_field.h
+++ b/geometry/proximity/make_sphere_field.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "drake/common/eigen_types.h"
+#include "drake/geometry/proximity/volume_mesh.h"
+#include "drake/geometry/proximity/volume_mesh_field.h"
+#include "drake/geometry/shape_specification.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+/**
+ Generates a piecewise-linear pressure field inside the given sphere as
+ represented by the given volume mesh. The pressure at a point is defined
+ as E * e(x) where e ∈ [0,1] is the extent -- a measure of penetration into
+ the volume, and E is the given `elastic_modulus`. The pressure is zero on the
+ boundary with maximum E in the interior.
+ @param sphere           The sphere with its canonical frame S.
+ @param mesh_S           A pointer to a tetrahedral mesh of the sphere. It is
+                         aliased in the returned pressure field and must remain
+                         alive as long as the field. The position vectors of
+                         mesh vertices are expressed in the sphere's frame S.
+ @param elastic_modulus  Scale extent to pressure.
+ @return                 The pressure field defined on the tetrahedral mesh.
+ @pre                    `elastic_modulus` is strictly positive.
+                         `mesh_S` represents the sphere and has enough
+                         resolution to represent the pressure field.
+ @tparam T               The scalar type for representing the mesh
+                         vertex positions and the pressure value.
+*/
+template <typename T>
+VolumeMeshFieldLinear<T, T> MakeSpherePressureField(const Sphere& sphere,
+                                                    const VolumeMesh<T>* mesh_S,
+                                                    const T elastic_modulus) {
+  // TODO(DamrongGuoy): Switch to a better implementation in the future. The
+  //  current implementation has a number of limitations:
+  //  1. For simplicity, we use a scaling of distance to boundary, which is
+  //     not differentiable at the center of the sphere.
+  //  2. Implicitly we impose the rigid core as the center of the sphere.
+  //     In the future, we will consider a rigid core as an offset of the
+  //     sphere.
+  //  3. We do not have a mechanism to define a pressure field using barrier
+  //     functions.  One possibility is to generate the mesh in offset
+  //     layers, and define linear pressure fields in each offset with
+  //     different elastic modulus.
+  DRAKE_DEMAND(elastic_modulus > T(0));
+  const T radius = sphere.get_radius();
+  std::vector<T> pressure_values;
+  pressure_values.reserve(mesh_S->num_vertices());
+  // A threshold to treat near-zero extent as zero extent. Some boundary
+  // vertices do not lie exactly on the surface of the sphere due to rounding
+  // errors. We will treat their near-zero extent as exactly zero extent.
+  const T kExtentEpsilon = 1e-14;
+  for (const VolumeVertex<T>& vertex : mesh_S->vertices()) {
+    // V is a vertex of the mesh of the sphere with frame S.
+    const Vector3<T>& r_SV = vertex.r_MV();
+    T extent = T(1.0) - r_SV.norm() / radius;
+    if (extent < kExtentEpsilon) {
+      extent = T(0.0);
+    }
+    pressure_values.push_back(elastic_modulus * extent);
+  }
+  return VolumeMeshFieldLinear<T, T>("pressure", std::move(pressure_values),
+                                     mesh_S);
+}
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/test/make_ellipsoid_field_test.cc
+++ b/geometry/proximity/test/make_ellipsoid_field_test.cc
@@ -1,0 +1,88 @@
+#include "drake/geometry/proximity/make_ellipsoid_field.h"
+
+#include <limits>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+#include "drake/geometry/proximity/make_ellipsoid_mesh.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace {
+
+using Eigen::Vector3d;
+
+// TODO(DamrongGuoy): Consider sharing this function among all
+//  make_`shape`_field_test.cc for box, sphere, ellipsoid, etc.
+void CheckMinMaxBoundaryValue(
+    const VolumeMeshFieldLinear<double, double>& pressure_field,
+    const double elastic_modulus) {
+  // Check that all vertices have their pressure values within the range of
+  // zero to elastic_modulus, and their minimum and maximum values are indeed
+  // zero and elastic_modulus respectively.
+  double max_pressure = std::numeric_limits<double>::lowest();
+  double min_pressure = std::numeric_limits<double>::max();
+  for (VolumeVertexIndex v(0); v < pressure_field.mesh().num_vertices(); ++v) {
+    double pressure = pressure_field.EvaluateAtVertex(v);
+    EXPECT_LE(pressure, elastic_modulus);
+    EXPECT_GE(pressure, 0.0);
+    if (pressure > max_pressure) {
+      max_pressure = pressure;
+    }
+    if (pressure < min_pressure) {
+      min_pressure = pressure;
+    }
+  }
+  EXPECT_EQ(min_pressure, 0.0);
+  EXPECT_EQ(max_pressure, elastic_modulus);
+
+  // Check that all boundary vertices have zero pressure.
+  std::vector<VolumeVertexIndex> boundary_vertex_indices =
+      CollectUniqueVertices(
+          IdentifyBoundaryFaces(pressure_field.mesh().tetrahedra()));
+  for (const VolumeVertexIndex v : boundary_vertex_indices) {
+    double pressure = pressure_field.EvaluateAtVertex(v);
+    EXPECT_EQ(pressure, 0.0);
+  }
+
+  // Check that the center (0,0,0) of the shape has the max_pressure.
+  // This test assumes that the mesh has a vertex at the origin of its
+  // canonical frame.
+  VolumeVertexIndex center_vertex{0};
+  for (VolumeVertexIndex v{0}; v < pressure_field.mesh().num_vertices(); ++v) {
+    if (pressure_field.mesh().vertex(v).r_MV() == Vector3d::Zero()) {
+      center_vertex = v;
+      break;
+    }
+  }
+  ASSERT_EQ(Vector3d::Zero(),
+            pressure_field.mesh().vertex(center_vertex).r_MV());
+  EXPECT_EQ(max_pressure, pressure_field.EvaluateAtVertex(center_vertex));
+}
+
+GTEST_TEST(MakeEllipsoidFieldTest, MakeEllipsoidPressureField) {
+  // For an ellipsoid with bounding box 10cm x 16cm x 6cm, its semi-axes are
+  // 5cm, 8cm, and 3cm long.
+  const Ellipsoid ellipsoid(0.05, 0.08, 0.03);
+  // Use resolution_hint 4cm to get a medium mesh with some boundary vertices
+  // not exactly on the surface of the ellipsoid due to numerical roundings.
+  // We do not want to use the coarsest mesh (octahedron) since all vertices
+  // are exactly on the coordinate axes.
+  auto mesh = MakeEllipsoidVolumeMesh<double>(ellipsoid, 0.04);
+  // Confirm that the mesh is not the coarsest one (octahedron).
+  ASSERT_GT(mesh.num_vertices(), 7);
+  ASSERT_GT(mesh.num_elements(), 8);
+
+  const double kElasticModulus = 1.0e5;
+  VolumeMeshFieldLinear<double, double> pressure_field =
+      MakeEllipsoidPressureField<double>(ellipsoid, &mesh, kElasticModulus);
+
+  CheckMinMaxBoundaryValue(pressure_field, kElasticModulus);
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/test/make_sphere_field_test.cc
+++ b/geometry/proximity/test/make_sphere_field_test.cc
@@ -1,0 +1,87 @@
+#include "drake/geometry/proximity/make_sphere_field.h"
+
+#include <limits>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+#include "drake/geometry/proximity/make_sphere_mesh.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace {
+
+using Eigen::Vector3d;
+
+// TODO(DamrongGuoy): Consider sharing this function among all
+//  make_`shape`_field_test.cc for box, sphere, ellipsoid, etc.
+void CheckMinMaxBoundaryValue(
+    const VolumeMeshFieldLinear<double, double>& pressure_field,
+    const double elastic_modulus) {
+  // Check that all vertices have their pressure values within the range of
+  // zero to elastic_modulus, and their minimum and maximum values are indeed
+  // zero and elastic_modulus respectively.
+  double max_pressure = std::numeric_limits<double>::lowest();
+  double min_pressure = std::numeric_limits<double>::max();
+  for (VolumeVertexIndex v(0); v < pressure_field.mesh().num_vertices(); ++v) {
+    double pressure = pressure_field.EvaluateAtVertex(v);
+    EXPECT_LE(pressure, elastic_modulus);
+    EXPECT_GE(pressure, 0.0);
+    if (pressure > max_pressure) {
+      max_pressure = pressure;
+    }
+    if (pressure < min_pressure) {
+      min_pressure = pressure;
+    }
+  }
+  EXPECT_EQ(min_pressure, 0.0);
+  EXPECT_EQ(max_pressure, elastic_modulus);
+
+  // Check that all boundary vertices have zero pressure.
+  std::vector<VolumeVertexIndex> boundary_vertex_indices =
+      CollectUniqueVertices(
+          IdentifyBoundaryFaces(pressure_field.mesh().tetrahedra()));
+  for (const VolumeVertexIndex v : boundary_vertex_indices) {
+    double pressure = pressure_field.EvaluateAtVertex(v);
+    EXPECT_EQ(pressure, 0.0);
+  }
+
+  // Check that the center (0,0,0) of the shape has the max_pressure.
+  // This test assumes that the mesh has a vertex at the origin of its
+  // canonical frame.
+  VolumeVertexIndex center_vertex{0};
+  for (VolumeVertexIndex v{0}; v < pressure_field.mesh().num_vertices(); ++v) {
+    if (pressure_field.mesh().vertex(v).r_MV() == Vector3d::Zero()) {
+      center_vertex = v;
+      break;
+    }
+  }
+  ASSERT_EQ(Vector3d::Zero(),
+            pressure_field.mesh().vertex(center_vertex).r_MV());
+  EXPECT_EQ(max_pressure, pressure_field.EvaluateAtVertex(center_vertex));
+}
+
+GTEST_TEST(MakeSphereFieldTest, MakeSpherePressureField) {
+  // Use radius 2.0 to avoid identity scaling by 1.0.
+  const Sphere sphere(2.0);
+  // Use resolution_hint 0.25 to get a medium mesh with some boundary vertices
+  // not exactly on the surface of the sphere due to numerical roundings. We do
+  // not want to use the coarsest mesh (octahedron) since all vertices are
+  // exactly on the coordinate axes.
+  auto mesh = MakeSphereVolumeMesh<double>(sphere, 0.25);
+  // Confirm that the mesh is not the coarsest one (octahedron).
+  ASSERT_GT(mesh.num_vertices(), 7);
+  ASSERT_GT(mesh.num_elements(), 8);
+
+  const double kElasticModulus = 1.0e5;
+  VolumeMeshFieldLinear<double, double> pressure_field =
+    MakeSpherePressureField<double>(sphere, &mesh, kElasticModulus);
+
+  CheckMinMaxBoundaryValue(pressure_field, kElasticModulus);
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
Create simple pressure fields for ellipsoids and spheres in hydroelastic contact models.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12333)
<!-- Reviewable:end -->

![image](https://user-images.githubusercontent.com/42557859/68514812-a602a400-0233-11ea-9e81-df3f1837675c.png)
