### PR TITLE
Reorder and regroup MultibodyPlant API

### DIFF
--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -2134,15 +2134,6 @@ void MultibodyPlant<T>::DeclareStateCacheAndPorts() {
     }
   }
 
-  // Contact results output port.
-  const auto& contact_results_cache_entry =
-      this->get_cache_entry(cache_indexes_.contact_results);
-  contact_results_port_ = this->DeclareAbstractOutputPort(
-                                  "contact_results", ContactResults<T>(),
-                                  &MultibodyPlant<T>::CopyContactResultsOutput,
-                                  {contact_results_cache_entry.ticket()})
-                              .get_index();
-
   // Joint reaction forces are a function of accelerations, which in turn depend
   // on both state and inputs.
   reaction_forces_port_ =
@@ -2152,6 +2143,15 @@ void MultibodyPlant<T>::DeclareStateCacheAndPorts() {
               {this->cache_entry_ticket(
                   cache_indexes_.generalized_accelerations)})
           .get_index();
+
+  // Contact results output port.
+  const auto& contact_results_cache_entry =
+      this->get_cache_entry(cache_indexes_.contact_results);
+  contact_results_port_ = this->DeclareAbstractOutputPort(
+                                  "contact_results", ContactResults<T>(),
+                                  &MultibodyPlant<T>::CopyContactResultsOutput,
+                                  {contact_results_cache_entry.ticket()})
+                              .get_index();
 }
 
 template <typename T>


### PR DESCRIPTION
This PR reorders and regroups the MultibodyPlant API, with minimal changes to the actual documentation and no changes to the API.

Some fixes/additions to the documentation:
- added the reaction force output port to the picture at the top
- added a "table of contents" linking to each of the new groups 
- used `@anchor` consistently for every group

Reviewers -- please focus on whether the new groupings make sense, whether by regrouping I've made any of the text nonsensical, and please verify that the links work. Any substantive changes to the text should be deferred to a follow-on PR since the reordering here makes Reviewable think everything changed.

I'm calling this high priority because it will cause awful merge problems with any PRs that make changes to multibody_plant.h.

Resolves #11807

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12342)
<!-- Reviewable:end -->
