### PR TITLE
Add BoundingVolumeHierarchy class for Mesh

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -13,6 +13,7 @@ package(default_visibility = ["//visibility:public"])
 drake_cc_package_library(
     name = "proximity",
     deps = [
+        ":bounding_volume_hierarchy",
         ":collision_filter_legacy",
         ":collisions_exist_callback",
         ":distance_to_point_callback",
@@ -40,6 +41,15 @@ drake_cc_package_library(
         ":surface_mesh",
         ":volume_mesh",
         ":volume_to_surface_mesh",
+    ],
+)
+
+drake_cc_library(
+    name = "bounding_volume_hierarchy",
+    srcs = ["bounding_volume_hierarchy.cc"],
+    hdrs = ["bounding_volume_hierarchy.h"],
+    deps = [
+        "//common",
     ],
 )
 
@@ -141,6 +151,7 @@ drake_cc_library(
     srcs = ["hydroelastic_internal.cc"],
     hdrs = ["hydroelastic_internal.h"],
     deps = [
+        ":bounding_volume_hierarchy",
         ":surface_mesh",
         ":volume_mesh",
         "//common:essential",
@@ -397,6 +408,19 @@ drake_cc_library(
         ":surface_mesh",
         ":volume_mesh",
         "@fmt",
+    ],
+)
+
+drake_cc_googletest(
+    name = "bounding_volume_hierarchy_test",
+    deps = [
+        ":bounding_volume_hierarchy",
+        ":make_ellipsoid_mesh",
+        ":make_sphere_mesh",
+        ":surface_mesh",
+        ":volume_mesh",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//geometry:shape_specification",
     ],
 )
 

--- a/geometry/proximity/bounding_volume_hierarchy.cc
+++ b/geometry/proximity/bounding_volume_hierarchy.cc
@@ -1,0 +1,10 @@
+#include "drake/geometry/proximity/bounding_volume_hierarchy.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/bounding_volume_hierarchy.h
+++ b/geometry/proximity/bounding_volume_hierarchy.h
@@ -1,0 +1,221 @@
+#pragma once
+
+#include <algorithm>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/drake_nodiscard.h"
+#include "drake/common/eigen_types.h"
+#include "drake/common/reset_on_copy.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+/** Axis-aligned bounding box used in BoundingVolumeHierarchy.  */
+class Aabb {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Aabb)
+
+  /**
+   @pre half_width.x(), half_width.y(), half_width.z() are not negative.
+  */
+  Aabb(const Vector3<double> center, const Vector3<double> half_width)
+      : center_(std::move(center)), half_width_(std::move(half_width)) {
+    // TODO(tehbelinda): Introduce epsilon tolerance for robust bounding box.
+    DRAKE_DEMAND(half_width.x() >= 0.0);
+    DRAKE_DEMAND(half_width.y() >= 0.0);
+    DRAKE_DEMAND(half_width.z() >= 0.0);
+  }
+
+  /** Returns the center. */
+  const Vector3<double>& center() const { return center_; }
+
+  /** Returns the half_width. */
+  const Vector3<double>& half_width() const { return half_width_; }
+
+  /** Returns the upper bounding point. */
+  const Vector3<double> upper() const { return center_ + half_width_; }
+
+  /** Returns the lower bounding point. */
+  const Vector3<double> lower() const { return center_ - half_width_; }
+
+  /** @return Volume of the bounding box.  */
+  double CalcVolume() const {
+    // Double the three half widths using * 8 instead of repeating * 2 three
+    // times to help the compiler out.
+    return half_width_[0] * half_width_[1] * half_width_[2] * 8;
+  }
+
+ private:
+  // Center point of the box.
+  Vector3<double> center_;
+  // Half width extents along each axes.
+  Vector3<double> half_width_;
+};
+
+/** Node of the tree structure representing the BoundingVolumeHierarchy.  */
+template <class MeshType>
+struct BvNode {
+  explicit BvNode(Aabb aabb_in) : aabb(std::move(aabb_in)) {}
+
+  BvNode(const BvNode& node) : aabb(node.aabb) { *this = node; }
+
+  BvNode& operator=(const BvNode& node) {
+    if (&node == this) return *this;
+
+    aabb = node.aabb;
+    element_index = node.element_index;
+    if (node.left != nullptr) {
+      left = std::make_unique<BvNode<MeshType>>(*node.left);
+    }
+    if (node.right != nullptr) {
+      right = std::make_unique<BvNode<MeshType>>(*node.right);
+    }
+    return *this;
+  }
+
+  BvNode(BvNode&&) = default;
+  BvNode& operator=(BvNode&&) = default;
+
+  Aabb aabb;
+  /** Leaf node's index to the mesh element (i.e., tri or tet) bounded by the
+   node's bounding volume.  */
+  typename MeshType::ElementIndex element_index;
+  std::unique_ptr<BvNode<MeshType>> left;
+  std::unique_ptr<BvNode<MeshType>> right;
+};
+
+/** BoundingVolumeHierarchy is an acceleration structure for performing spatial
+ queries against a collection of objects (in this case, triangles or
+ tetrahedra). Specifically, for identifying those objects in or near a
+ particular region of interest. It serves as a basis for culling objects that
+ are trivially far from the region, reducing the number of "narrow-phase"
+ calculations. The underlying structure is a binary tree of axis-aligned
+ bounding boxes (Aabb) that encompass one or more mesh elements. Leaf nodes
+ contain a single element index into elements of the mesh. The BVH needs a
+ reference to the mesh in order to build the tree, but does not own the mesh.
+ @pre    Assumes that the mesh is not mutable. Modifications to the mesh after
+         constructing the BVH will make the BVH invalid.
+ @tparam MeshType SurfaceMesh<double> or VolumeMesh<double> (Exotic types like
+         SurfaceMesh<AutoDiffXd> are not supported).
+*/
+template <class MeshType>
+class BoundingVolumeHierarchy {
+ public:
+  explicit BoundingVolumeHierarchy(const MeshType& mesh) {
+    // Generate element indices and corresponding centroids. These are used
+    // for calculating the split point of the volumes.
+    const int num_elements = mesh.num_elements();
+    std::vector<CentroidPair> element_centroids;
+    for (typename MeshType::ElementIndex i(0); i < num_elements; ++i) {
+      element_centroids.emplace_back(i, ComputeCentroid(mesh, i));
+    }
+
+    root_node_ =
+        BuildBVTree(mesh, element_centroids.begin(), element_centroids.end());
+  }
+
+  BoundingVolumeHierarchy(const BoundingVolumeHierarchy& bvh) { *this = bvh; }
+
+  BoundingVolumeHierarchy& operator=(const BoundingVolumeHierarchy& bvh) {
+    if (&bvh == this) return *this;
+
+    root_node_ = std::make_unique<BvNode<MeshType>>(*bvh.root_node_);
+    return *this;
+  }
+
+  BoundingVolumeHierarchy(BoundingVolumeHierarchy&&) = default;
+  BoundingVolumeHierarchy& operator=(BoundingVolumeHierarchy&&) = default;
+
+ private:
+  // Convenience class for testing.
+  friend class BVHTester;
+
+  using CentroidPair =
+      std::pair<typename MeshType::ElementIndex, Vector3<double>>;
+
+  static std::unique_ptr<BvNode<MeshType>> BuildBVTree(const MeshType& mesh,
+      const typename std::vector<CentroidPair>::iterator start,
+      const typename std::vector<CentroidPair>::iterator end) {
+    // Generate bounding volume.
+    const Aabb aabb = ComputeBoundingVolume(mesh, start, end);
+
+    auto node = std::make_unique<BvNode<MeshType>>(aabb);
+    const int num_elements = end - start;
+    if (num_elements == 1) {
+      // Store element index in this leaf node.
+      node->element_index = start->first;
+    } else {
+      // Sort by centroid along the axis of greatest spread.
+      int axis{};
+      aabb.half_width().maxCoeff(&axis);
+      // TODO(tehbelinda): Use a better heuristic for splitting into branches,
+      // e.g. surface area.
+      std::sort(start, end,
+                [axis](const CentroidPair& a, const CentroidPair& b) {
+                  return a.second[axis] < b.second[axis];
+                });
+
+      // Continue with the next branches.
+      const typename std::vector<CentroidPair>::iterator mid =
+          start + num_elements / 2;
+      node->left = BuildBVTree(mesh, start, mid);
+      node->right = BuildBVTree(mesh, mid, end);
+    }
+    return node;
+  }
+
+  static const Aabb ComputeBoundingVolume(
+      const MeshType& mesh,
+      const typename std::vector<CentroidPair>::iterator start,
+      const typename std::vector<CentroidPair>::iterator end) {
+    // Keep track of the min/max bounds to create the bounding box.
+    Vector3<double> max_bounds, min_bounds;
+    max_bounds.setConstant(std::numeric_limits<double>::lowest());
+    min_bounds.setConstant(std::numeric_limits<double>::max());
+
+    // Check each mesh element in the given range.
+    for (auto pair = start; pair < end; ++pair) {
+      const auto& element = mesh.element(pair->first);
+      // Check each vertex in the element.
+      for (int v = 0; v < kElementVertexCount; ++v) {
+        const auto& vertex = mesh.vertex(element.vertex(v)).r_MV();
+        // Compare its extent along each of the 3 axes.
+        min_bounds = min_bounds.cwiseMin(vertex);
+        max_bounds = max_bounds.cwiseMax(vertex);
+      }
+    }
+    const Vector3<double> center = (min_bounds + max_bounds) / 2;
+    const Vector3<double> half_width = max_bounds - center;
+    return Aabb(center, half_width);
+  }
+
+  // TODO(tehbelinda): Move this funtion into SurfaceMesh/VolumeMesh directly
+  // and rename to CalcElementCentroid(ElementIndex).
+  static Vector3<double> ComputeCentroid(const MeshType& mesh,
+      const typename MeshType::ElementIndex i) {
+    Vector3<double> centroid{0, 0, 0};
+    const auto& element = mesh.element(i);
+    // Calculate average from all vertices.
+    for (int v = 0; v < kElementVertexCount; ++v) {
+      const auto& vertex = mesh.vertex(element.vertex(v)).r_MV();
+      centroid += vertex;
+    }
+    centroid /= kElementVertexCount;
+    return centroid;
+  }
+
+  static constexpr int kElementVertexCount = MeshType::kDim + 1;
+
+  std::unique_ptr<BvNode<MeshType>> root_node_;
+};
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/hydroelastic_internal.cc
+++ b/geometry/proximity/hydroelastic_internal.cc
@@ -49,7 +49,16 @@ SoftGeometry& SoftGeometry::operator=(const SoftGeometry& g) {
   // We can't simply copy the mesh field; the copy must contain a pointer to the
   // new mesh. So, we use CloneAndSetMesh() instead.
   auto pressure = g.pressure_field().CloneAndSetMesh(mesh.get());
-  geometry_ = SoftMesh{move(mesh), move(pressure)};
+  geometry_ = SoftMesh(move(mesh), move(pressure));
+
+  return *this;
+}
+
+RigidGeometry& RigidGeometry::operator=(const RigidGeometry& g) {
+  if (this == &g) return *this;
+
+  auto mesh = make_unique<SurfaceMesh<double>>(g.mesh());
+  geometry_ = RigidMesh(move(mesh));
 
   return *this;
 }
@@ -231,7 +240,8 @@ std::optional<RigidGeometry> MakeRigidRepresentation(
     const Sphere& sphere, const ProximityProperties& props) {
   PositiveDouble validator("Sphere", "rigid");
   const double edge_length = validator.Extract(props, kHydroGroup, kRezHint);
-  SurfaceMesh<double> mesh = MakeSphereSurfaceMesh<double>(sphere, edge_length);
+  auto mesh = make_unique<SurfaceMesh<double>>(
+      MakeSphereSurfaceMesh<double>(sphere, edge_length));
 
   return RigidGeometry(move(mesh));
 }
@@ -240,7 +250,8 @@ std::optional<RigidGeometry> MakeRigidRepresentation(
     const Box& box, const ProximityProperties& props) {
   PositiveDouble validator("Box", "rigid");
   const double edge_length = validator.Extract(props, kHydroGroup, kRezHint);
-  SurfaceMesh<double> mesh = MakeBoxSurfaceMesh<double>(box, edge_length);
+  auto mesh = make_unique<SurfaceMesh<double>>(
+      MakeBoxSurfaceMesh<double>(box, edge_length));
 
   return RigidGeometry(move(mesh));
 }
@@ -249,8 +260,8 @@ std::optional<RigidGeometry> MakeRigidRepresentation(
     const Cylinder& cylinder, const ProximityProperties& props) {
   PositiveDouble validator("Cylinder", "rigid");
   const double edge_length = validator.Extract(props, kHydroGroup, kRezHint);
-  SurfaceMesh<double> mesh =
-      MakeCylinderSurfaceMesh<double>(cylinder, edge_length);
+  auto mesh = make_unique<SurfaceMesh<double>>(
+      MakeCylinderSurfaceMesh<double>(cylinder, edge_length));
 
   return RigidGeometry(move(mesh));
 }
@@ -259,8 +270,8 @@ std::optional<RigidGeometry> MakeRigidRepresentation(
     const Ellipsoid& ellipsoid, const ProximityProperties& props) {
   PositiveDouble validator("Ellipsoid", "rigid");
   const double edge_length = validator.Extract(props, kHydroGroup, kRezHint);
-  SurfaceMesh<double> mesh =
-      MakeEllipsoidSurfaceMesh<double>(ellipsoid, edge_length);
+  auto mesh = make_unique<SurfaceMesh<double>>(
+      MakeEllipsoidSurfaceMesh<double>(ellipsoid, edge_length));
 
   return RigidGeometry(move(mesh));
 }

--- a/geometry/proximity/hydroelastic_internal.h
+++ b/geometry/proximity/hydroelastic_internal.h
@@ -6,10 +6,12 @@
 #include <unordered_map>
 #include <utility>
 
+#include "drake/common/drake_assert.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/text_logging.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/geometry_roles.h"
+#include "drake/geometry/proximity/bounding_volume_hierarchy.h"
 #include "drake/geometry/proximity/surface_mesh.h"
 #include "drake/geometry/proximity/volume_mesh_field.h"
 #include "drake/geometry/proximity_properties.h"
@@ -39,10 +41,25 @@ std::ostream& operator<<(std::ostream& out, const HydroelasticType& type);
 
 // TODO(SeanCurtis-TRI): When we do soft-soft contact, we'll need ∇p̃(e) as well.
 //  ∇p̃(e) is piecewise constant -- one ℜ³ vector per tetrahedron.
-/** Defines a soft mesh -- a mesh and its linearized pressure field, p̃(e).  */
+/** Defines a soft mesh -- a mesh, its linearized pressure field, p̃(e), and its
+ bounding volume hierarchy. While this struct retains ownership of the mesh,
+ we assume that both the pressure field and the bounding volume hierarchy
+ are derived from the mesh. */
 struct SoftMesh {
   std::unique_ptr<VolumeMesh<double>> mesh;
   std::unique_ptr<VolumeMeshField<double, double>> pressure;
+  std::unique_ptr<BoundingVolumeHierarchy<VolumeMesh<double>>> bvh;
+
+  SoftMesh() = default;
+
+  SoftMesh(std::unique_ptr<VolumeMesh<double>> mesh_in,
+           std::unique_ptr<VolumeMeshField<double, double>> pressure_in)
+      : mesh(std::move(mesh_in)),
+        pressure(std::move(pressure_in)),
+        // TODO(tehbelinda): Create BVH once we start using it.
+        bvh(nullptr) {
+    DRAKE_ASSERT(mesh.get() == &pressure->mesh());
+  }
 };
 
 /** Definition of a soft geometry for hydroelastic implementations. Today, the
@@ -51,10 +68,9 @@ struct SoftMesh {
 class SoftGeometry {
  public:
   /** Constructs a soft geometry from a soft mesh.  */
-  SoftGeometry(
-      std::unique_ptr<VolumeMesh<double>> mesh,
-      std::unique_ptr<VolumeMeshField<double, double>> pressure)
-      : geometry_(SoftMesh{std::move(mesh), std::move(pressure)}) {}
+  SoftGeometry(std::unique_ptr<VolumeMesh<double>> mesh,
+               std::unique_ptr<VolumeMeshField<double, double>> pressure)
+      : geometry_(SoftMesh(std::move(mesh), std::move(pressure))) {}
 
   SoftGeometry(const SoftGeometry& g) { *this = g; }
   SoftGeometry& operator=(const SoftGeometry& g);
@@ -75,20 +91,39 @@ class SoftGeometry {
   SoftMesh geometry_;
 };
 
+/** Defines a rigid mesh -- a surface mesh and its bounding volume hierarchy.
+ This struct retains ownership of the mesh, with the bounding volume hierarchy
+ just referencing it.  */
+struct RigidMesh {
+  std::unique_ptr<SurfaceMesh<double>> mesh;
+  std::unique_ptr<BoundingVolumeHierarchy<SurfaceMesh<double>>> bvh;
+
+  RigidMesh() = default;
+
+  explicit RigidMesh(std::unique_ptr<SurfaceMesh<double>> mesh_in)
+      : mesh(std::move(mesh_in)),
+        // TODO(tehbelinda): Create BVH once we start using it.
+        bvh(nullptr) {}
+};
+
 /** The base representation of rigid geometries. A rigid geometry is represented
- with a SurfaceMesh.  */
+ with a RigidMesh.  */
 class RigidGeometry {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(RigidGeometry)
-
   /** Constructs a rigid representation from the given surface mesh.  */
-  explicit RigidGeometry(SurfaceMesh<double> mesh) : mesh_(std::move(mesh)) {}
+  explicit RigidGeometry(std::unique_ptr<SurfaceMesh<double>> mesh)
+      : geometry_(RigidMesh(std::move(mesh))) {}
+
+  RigidGeometry(const RigidGeometry& g) { *this = g; }
+  RigidGeometry& operator=(const RigidGeometry& g);
+  RigidGeometry(RigidGeometry&&) = default;
+  RigidGeometry& operator=(RigidGeometry&&) = default;
 
   /** Returns a reference to the surface mesh.  */
-  const SurfaceMesh<double>& mesh() const { return mesh_; }
+  const SurfaceMesh<double>& mesh() const { return *geometry_.mesh; }
 
  private:
-  SurfaceMesh<double> mesh_;
+  RigidMesh geometry_;
 };
 
 /** This class stores all instantiated hydroelastic representations of declared

--- a/geometry/proximity/test/bounding_volume_hierarchy_test.cc
+++ b/geometry/proximity/test/bounding_volume_hierarchy_test.cc
@@ -1,0 +1,220 @@
+#include "drake/geometry/proximity/bounding_volume_hierarchy.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/geometry/proximity/make_ellipsoid_mesh.h"
+#include "drake/geometry/proximity/make_sphere_mesh.h"
+#include "drake/geometry/proximity/surface_mesh.h"
+#include "drake/geometry/proximity/volume_mesh.h"
+#include "drake/geometry/shape_specification.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+using Eigen::Vector3d;
+
+// Friend class for accessing BoundingVolumeHierarchy's protected/private
+// functionality.
+class BVHTester {
+ public:
+  BVHTester() = delete;
+
+  template <class MeshType>
+  static Vector3d ComputeCentroid(const MeshType& mesh,
+                                  const typename MeshType::ElementIndex i) {
+    return BoundingVolumeHierarchy<MeshType>::ComputeCentroid(mesh, i);
+  }
+
+  template <class MeshType>
+  static Aabb ComputeBoundingVolume(
+      const MeshType& mesh,
+      const typename std::vector<
+          typename BoundingVolumeHierarchy<MeshType>::CentroidPair>::iterator
+          start,
+      const typename std::vector<
+          typename BoundingVolumeHierarchy<MeshType>::CentroidPair>::iterator
+          end) {
+    return BoundingVolumeHierarchy<MeshType>::ComputeBoundingVolume(mesh, start,
+                                                                    end);
+  }
+
+  template <class MeshType>
+  static BvNode<MeshType>& GetBVTree(
+      const BoundingVolumeHierarchy<MeshType>& bvh) {
+    return *bvh.root_node_;
+  }
+};
+
+namespace {
+
+// Test fixture class for testing BoundingVolumeHierarchy. Uses a coarse
+// sphere, i.e. an octahedron, as the underlying mesh.
+class BVHTest : public ::testing::Test {
+ public:
+  BVHTest()
+      : ::testing::Test(),
+        mesh_(MakeSphereSurfaceMesh<double>(Sphere(1.5), 3)),
+        bvh_(BoundingVolumeHierarchy<SurfaceMesh<double>>(mesh_)) {}
+
+ protected:
+  SurfaceMesh<double> mesh_;
+  BoundingVolumeHierarchy<SurfaceMesh<double>> bvh_;
+};
+
+// Tests computing the bounding volume of elements.
+TEST_F(BVHTest, TestComputeBoundingVolume) {
+  std::vector<std::pair<SurfaceFaceIndex, Vector3d>> tri_centroids;
+
+  // Add all the elements from the octahedron to test multiple elements. The
+  // centroid values are irrelevant for this test, but the bounding box should
+  // encompass the whole sphere with a center of 0 and half width of 1.5.
+  for (SurfaceFaceIndex i(0); i < mesh_.num_elements(); ++i) {
+    tri_centroids.emplace_back(i, Vector3d(0.5, 0.5, 0.5));
+  }
+  Aabb aabb = BVHTester::ComputeBoundingVolume<SurfaceMesh<double>>(
+      mesh_, tri_centroids.begin(), tri_centroids.end());
+  EXPECT_TRUE(CompareMatrices(aabb.center(), Vector3d(0., 0., 0.)));
+  EXPECT_TRUE(CompareMatrices(aabb.half_width(), Vector3d(1.5, 1.5, 1.5)));
+
+  // Test with a volume mesh. As above, the centroids are still irrelevant. The
+  // bounding box should encompass the whole ellipsoid with a center of 0 and
+  // half width of 1, 2, 3.
+  std::vector<std::pair<VolumeElementIndex, Vector3d>> tet_centroids;
+  auto volume_mesh = MakeEllipsoidVolumeMesh<double>(Ellipsoid(1., 2., 3.), 6);
+  for (VolumeElementIndex i(0); i < volume_mesh.num_elements(); ++i) {
+    tet_centroids.emplace_back(i, Vector3d(0.5, 0.5, 0.5));
+  }
+  aabb = BVHTester::ComputeBoundingVolume<VolumeMesh<double>>(
+      volume_mesh, tet_centroids.begin(), tet_centroids.end());
+  EXPECT_TRUE(CompareMatrices(aabb.center(), Vector3d(0., 0., 0.)));
+  EXPECT_TRUE(CompareMatrices(aabb.half_width(), Vector3d(1., 2., 3.)));
+}
+
+// Tests properties from building the bounding volume tree.
+TEST_F(BVHTest, TestBuildBVTree) {
+  // Since it's a binary tree with a single element at each leaf node, the tree
+  // depth can be found using 2^d = num_elements. The octahedron has 8 elements
+  // so we should end up with a balanced tree of depth 3 where each level's
+  // volume is less than its parent's volume.
+  BvNode<SurfaceMesh<double>>& bv_tree = BVHTester::GetBVTree(bvh_);
+  int num_elements = mesh_.num_elements();
+  std::set<SurfaceFaceIndex> element_indices;
+  std::function<void(const BvNode<SurfaceMesh<double>>&, int)> check_node;
+  check_node = [&check_node, &element_indices, num_elements](
+                   const BvNode<SurfaceMesh<double>>& node, int depth) {
+    if (depth < 3) {
+      double node_volume = node.aabb.CalcVolume();
+      Vector3d node_bounds_upper = node.aabb.upper();
+      Vector3d node_bounds_lower = node.aabb.lower();
+
+      auto check_child = [&check_node, &node_volume, &node_bounds_upper,
+                          &node_bounds_lower,
+                          &depth](const BvNode<SurfaceMesh<double>>& child) {
+        // Check the volume is less than the parent.
+        double child_volume = child.aabb.CalcVolume();
+        EXPECT_LT(child_volume, node_volume);
+        // Check the bounds are within the parent.
+        Vector3d child_bounds_upper = child.aabb.upper();
+        Vector3d child_bounds_lower = child.aabb.lower();
+        // Instead of comparing each element, we can use the coefficient-wise
+        // min and max functions. If the child box is inside the parent box,
+        // then the child's maximum extents must be less than or equal to the
+        // parent's maximum extents. So, the smallest maximum extents across the
+        // two must be equal to the child's. A similar trick works with the
+        // minimum extents.
+        EXPECT_TRUE(
+            CompareMatrices(node_bounds_upper.cwiseMin(child_bounds_upper),
+                            child_bounds_upper));
+        EXPECT_TRUE(
+            CompareMatrices(node_bounds_lower.cwiseMax(child_bounds_lower),
+                            child_bounds_lower));
+        // Check each of the branches at increasing depth.
+        check_node(child, depth + 1);
+      };
+      check_child(*(node.left));
+      check_child(*(node.right));
+    } else {
+      // At depth 3, we should reach the leaf node with a valid and unique
+      // element instead of more branches.
+      EXPECT_EQ(node.left, nullptr);
+      EXPECT_EQ(node.right, nullptr);
+      EXPECT_GE(node.element_index, 0);
+      EXPECT_LT(node.element_index, num_elements);
+      EXPECT_EQ(element_indices.count(node.element_index), 0);
+      element_indices.insert(node.element_index);
+    }
+  };
+  check_node(bv_tree, 0);
+  // Check that we found a leaf node for all elements.
+  EXPECT_EQ(element_indices.size(), num_elements);
+}
+
+// Tests copy constructor.
+TEST_F(BVHTest, TestCopy) {
+  // Copy constructor.
+  BoundingVolumeHierarchy<SurfaceMesh<double>> bvh_copy(bvh_);
+
+  // Confirm that it's a deep copy.
+  std::function<void(const BvNode<SurfaceMesh<double>>&,
+                     const BvNode<SurfaceMesh<double>>&)> check_copy;
+  check_copy = [&check_copy](const BvNode<SurfaceMesh<double>>& orig,
+                             const BvNode<SurfaceMesh<double>>& copy) {
+    EXPECT_NE(&orig, &copy);
+    if (orig.left == nullptr) {
+      EXPECT_EQ(copy.left, nullptr);
+    } else {
+      check_copy(*(orig.left), *(copy.left));
+    }
+    if (orig.right == nullptr) {
+      EXPECT_EQ(copy.right, nullptr);
+    } else {
+      check_copy(*(orig.right), *(copy.right));
+    }
+  };
+  check_copy(BVHTester::GetBVTree(bvh_), BVHTester::GetBVTree(bvh_copy));
+}
+
+// Tests computing the centroid of an element.
+GTEST_TEST(BoundingVolumeHierarchyTest, TestComputeCentroid) {
+  // Set resolution at double so that we get the coarsest mesh of 8 elements.
+  auto surface_mesh =
+      MakeEllipsoidSurfaceMesh<double>(Ellipsoid(1., 2., 3.), 6);
+  Vector3d centroid = BVHTester::ComputeCentroid<SurfaceMesh<double>>(
+      surface_mesh, SurfaceFaceIndex(0));
+  // The first face of our octahedron is a triangle with vertices at 1, 2, and
+  // 3 along each respective axis, so its centroid should average out to 1/3,
+  // 2/3, and 3/3.
+  EXPECT_TRUE(CompareMatrices(centroid, Vector3d(1./3., 2./3., 1.)));
+
+  auto volume_mesh = MakeEllipsoidVolumeMesh<double>(Ellipsoid(1., 2., 3.), 6);
+  centroid = BVHTester::ComputeCentroid<VolumeMesh<double>>(
+      volume_mesh, VolumeElementIndex(0));
+  // The first face of our octahedron is a tet with vertices at 1, 2, and 3
+  // along each respective axis and the origin 0, so its centroid should
+  // average out to 1/4, 2/4, and 3/4.
+  EXPECT_TRUE(CompareMatrices(centroid, Vector3d(0.25, 0.5, 0.75)));
+}
+
+// Tests calculating the bounding box volume.
+GTEST_TEST(AABBTest, TestVolume) {
+  Aabb aabb = Aabb(Vector3d(-1, 2, 1), Vector3d(2, 0.5, 2.7));
+  EXPECT_EQ(aabb.CalcVolume(), 21.6);
+  Aabb zero_aabb = Aabb(Vector3d(3, -4, 1.3), Vector3d(0, 0, 0));
+  EXPECT_EQ(zero_aabb.CalcVolume(), 0);
+}
+
+// Tests calculating the bounding points.
+GTEST_TEST(AABBTest, TestBounds) {
+  Aabb aabb = Aabb(Vector3d(-1, 2, 1), Vector3d(2, 0.5, 2.7));
+  EXPECT_TRUE(CompareMatrices(aabb.upper(), Vector3d(1, 2.5, 3.7)));
+  EXPECT_TRUE(CompareMatrices(aabb.lower(), Vector3d(-3, 1.5, -1.7), 1e-15));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
- In hydroelastics, add RigidMesh struct layer to hold the BoundingVolumeHierarchy, similar to the SoftMesh struct layer
- Create AABB tree on mesh construction
- First pass with naive splitting of branches without any heuristics, optimisations to come

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12347)
<!-- Reviewable:end -->
