### PR TITLE
geometry: create pressure fields in cylinders for hydroelastic model.

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -23,6 +23,7 @@ drake_cc_package_library(
         ":hydroelastic_internal",
         ":make_box_field",
         ":make_box_mesh",
+        ":make_cylinder_field",
         ":make_cylinder_mesh",
         ":make_ellipsoid_field",
         ":make_ellipsoid_mesh",
@@ -257,6 +258,18 @@ drake_cc_library(
 drake_cc_library(
     name = "make_box_field",
     hdrs = ["make_box_field.h"],
+    deps = [
+        ":distance_to_point_callback",
+        ":volume_mesh",
+        "//common:essential",
+        "//common:unused",
+        "//geometry:shape_specification",
+    ],
+)
+
+drake_cc_library(
+    name = "make_cylinder_field",
+    hdrs = ["make_cylinder_field.h"],
     deps = [
         ":distance_to_point_callback",
         ":volume_mesh",
@@ -532,6 +545,15 @@ drake_cc_googletest(
     deps = [
         ":make_box_field",
         ":make_box_mesh",
+        ":volume_to_surface_mesh",
+    ],
+)
+
+drake_cc_googletest(
+    name = "make_cylinder_field_test",
+    deps = [
+        ":make_cylinder_field",
+        ":make_cylinder_mesh",
         ":volume_to_surface_mesh",
     ],
 )

--- a/geometry/proximity/make_cylinder_field.h
+++ b/geometry/proximity/make_cylinder_field.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <algorithm>
+#include <utility>
+#include <vector>
+
+#include "drake/common/eigen_types.h"
+#include "drake/geometry/proximity/distance_to_point_callback.h"
+#include "drake/geometry/proximity/volume_mesh.h"
+#include "drake/geometry/proximity/volume_mesh_field.h"
+#include "drake/geometry/shape_specification.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+/**
+ Generates a piecewise-linear pressure field inside the given cylinder as
+ represented by the given volume mesh. The pressure at a point is defined
+ as E * e(x) where e ∈ [0,1] is the extent -- a measure of penetration into
+ the volume, and E is the given `elastic_modulus`. The pressure is zero on the
+ boundary with maximum E in the interior.
+ @param cylinder         The cylinder with its canonical frame C.
+ @param mesh_C           A pointer to a tetrahedral mesh of the cylinder. It
+                         is aliased in the returned pressure field and must
+                         remain alive as long as the field. The position
+                         vectors of mesh vertices are expressed in the
+                         cylinder's frame C.
+ @param elastic_modulus  Scale extent to pressure.
+ @return                 The pressure field defined on the tetrahedral mesh.
+ @pre                    `elastic_modulus` is strictly positive.
+                         `mesh_C` represents the cylinder and has enough
+                         resolution to represent the pressure field.
+ @tparam T               The scalar type for representing the mesh vertex
+                         positions and the pressure value.
+ */
+template <typename T>
+VolumeMeshFieldLinear<T, T> MakeCylinderPressureField(
+    const Cylinder& cylinder, const VolumeMesh<T>* mesh_C,
+    const T elastic_modulus) {
+  DRAKE_DEMAND(elastic_modulus > T(0));
+  const double radius = cylinder.get_radius();
+  const double length = cylinder.get_length();
+  const double min_half_size = std::min(radius, length / 2.0);
+
+  // TODO(DamrongGuoy): Switch to a better implementation in the future. The
+  //  current implementation has a number of limitations:
+  //  1. For simplicity, we use a scaling of distance to boundary, which is
+  //     not differentiable at points equally far from two or more boundary
+  //     points of the cylinder.
+  //  2. Implicitly we impose the rigid core on the medial axis (or medial
+  //     surfaces for short cylinders).  In the future, we will consider a
+  //     rigid core as an offset of the cylinder or other shapes.
+  //  3. We do not have a mechanism to define a pressure field using barrier
+  //     functions.  One possibility is to generate the mesh in offset
+  //     layers, and define linear pressure fields in each offset with
+  //     different elastic modulus.
+
+  std::vector<T> pressure_values;
+  pressure_values.reserve(mesh_C->num_vertices());
+  // TODO(DamrongGuoy): The following three const variables (unused_id,
+  //  identity, and fcl_cylinder) are needed for applying DistanceToPoint
+  //  functor in the for loop. They are awkward to use here and introduce an
+  //  unnecessary dependency on FCL. In the future, we should either refactor
+  //  the distance-to-boundary calculation or use a different calculation (for
+  //  example, offset-based distance).
+  const GeometryId unused_id;
+  const auto identity = math::RigidTransform<T>::Identity();
+  const fcl::Cylinderd fcl_cylinder(radius, length);
+  for (const VolumeVertex<T>& vertex : mesh_C->vertices()) {
+    // V is a vertex of the cylinder mesh with frame C.
+    const Vector3<T>& r_CV = vertex.r_MV();
+    point_distance::DistanceToPoint<T> signed_distance_functor(
+        unused_id, identity, r_CV);
+    const T signed_distance = signed_distance_functor(fcl_cylinder).distance;
+    // Map signed_distance ∈ [-min_half_size, 0] to extent e ∈ [0, 1],
+    // -min_half_size ⇝ 1, 0 ⇝ 0.
+    const T extent = -signed_distance / T(min_half_size);
+    pressure_values.push_back(elastic_modulus * extent);
+  }
+  return VolumeMeshFieldLinear<T, T>("pressure", std::move(pressure_values),
+                                     mesh_C);
+}
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/test/make_cylinder_field_test.cc
+++ b/geometry/proximity/test/make_cylinder_field_test.cc
@@ -1,0 +1,85 @@
+#include "drake/geometry/proximity/make_cylinder_field.h"
+
+#include <limits>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+#include "drake/geometry/proximity/make_cylinder_mesh.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace {
+
+using Eigen::Vector3d;
+
+// TODO(DamrongGuoy): Consider sharing this function among all
+//  make_`shape`_field_test.cc for box, sphere, ellipsoid, etc.
+void CheckMinMaxBoundaryValue(
+    const VolumeMeshFieldLinear<double, double>& pressure_field,
+    const double elastic_modulus) {
+  // Check that all vertices have their pressure values within the range of
+  // zero to elastic_modulus, and their minimum and maximum values are indeed
+  // zero and elastic_modulus respectively.
+  double max_pressure = std::numeric_limits<double>::lowest();
+  double min_pressure = std::numeric_limits<double>::max();
+  for (VolumeVertexIndex v(0); v < pressure_field.mesh().num_vertices(); ++v) {
+    double pressure = pressure_field.EvaluateAtVertex(v);
+    EXPECT_LE(pressure, elastic_modulus);
+    EXPECT_GE(pressure, 0.0);
+    if (pressure > max_pressure) {
+      max_pressure = pressure;
+    }
+    if (pressure < min_pressure) {
+      min_pressure = pressure;
+    }
+  }
+  EXPECT_EQ(min_pressure, 0.0);
+  EXPECT_EQ(max_pressure, elastic_modulus);
+
+  // Check that all boundary vertices have zero pressure.
+  std::vector<VolumeVertexIndex> boundary_vertex_indices =
+      CollectUniqueVertices(
+          IdentifyBoundaryFaces(pressure_field.mesh().tetrahedra()));
+  for (const VolumeVertexIndex v : boundary_vertex_indices) {
+    double pressure = pressure_field.EvaluateAtVertex(v);
+    EXPECT_EQ(pressure, 0.0);
+  }
+
+  // Check that the center (0,0,0) of the shape has the max_pressure.
+  // This test assumes that the mesh has a vertex at the origin of its
+  // canonical frame.
+  VolumeVertexIndex center_vertex{0};
+  for (VolumeVertexIndex v{0}; v < pressure_field.mesh().num_vertices(); ++v) {
+    if (pressure_field.mesh().vertex(v).r_MV() == Vector3d::Zero()) {
+      center_vertex = v;
+      break;
+    }
+  }
+  ASSERT_EQ(Vector3d::Zero(),
+            pressure_field.mesh().vertex(center_vertex).r_MV());
+  EXPECT_EQ(max_pressure, pressure_field.EvaluateAtVertex(center_vertex));
+}
+
+GTEST_TEST(MakeCylinderFieldTest, MakeCylinderPressureField) {
+  // A cylinder with radius 5cm and length 30cm.
+  const Cylinder cylinder(0.05, 0.30);
+  // The resolution_hint 2cm should give a medium mesh with some boundary
+  // vertices on the curved barrel surface that do not have exact coordinates.
+  // In other words, we want the test to include these vertices, which are not
+  // exactly on the cylinder surface due to numerical roundings. We do not
+  // want to use the coarsest mesh (rectangular prism) for testing.
+  const auto mesh = MakeCylinderVolumeMesh<double>(cylinder, 0.02);
+
+  const double kElasticModulus = 1.0e5;
+  VolumeMeshFieldLinear<double, double> pressure_field =
+      MakeCylinderPressureField<double>(cylinder, &mesh, kElasticModulus);
+
+  CheckMinMaxBoundaryValue(pressure_field, kElasticModulus);
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
Create a simple pressure field in a cylinder for hydroelastic contact model.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12348)
<!-- Reviewable:end -->
