### PR TITLE
Rename/simplify/reword MultibodyTreeElement to produce better doxygen

### DIFF
--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -39,16 +39,16 @@ This API using Isometry3 is / will be deprecated soon with the resolution of
 
 namespace {
 
-// Binds `MultibodyTreeElement` methods.
+// Binds `MultibodyElement` methods.
 // N.B. We do this rather than inheritance because this template is more of a
 // mixin than it is a parent class (since it is not used for its dynamic
 // polymorphism).
 // TODO(jamiesnape): Add documentation for bindings generated with this
 // function.
 template <typename PyClass>
-void BindMultibodyTreeElementMixin(PyClass* pcls) {
+void BindMultibodyElementMixin(PyClass* pcls) {
   using Class = typename PyClass::type;
-  // TODO(eric.cousineau): Fix docstring generation for `MultibodyTreeElement`.
+  // TODO(eric.cousineau): Fix docstring generation for `MultibodyElement`.
   auto& cls = *pcls;
   cls  // BR
       .def("index", &Class::index)
@@ -101,7 +101,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
     constexpr auto& cls_doc = doc.Frame;
     auto cls =
         DefineTemplateClassWithDefault<Class>(m, "Frame", param, cls_doc.doc);
-    BindMultibodyTreeElementMixin(&cls);
+    BindMultibodyElementMixin(&cls);
     cls  // BR
         .def("name", &Class::name, cls_doc.name.doc)
         .def("body", &Class::body, py_reference_internal, cls_doc.body.doc)
@@ -145,7 +145,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
     constexpr auto& cls_doc = doc.Body;
     auto cls =
         DefineTemplateClassWithDefault<Class>(m, "Body", param, cls_doc.doc);
-    BindMultibodyTreeElementMixin(&cls);
+    BindMultibodyElementMixin(&cls);
     cls  // BR
         .def("name", &Class::name, cls_doc.name.doc)
         .def("body_frame", &Class::body_frame, py_reference_internal,
@@ -180,7 +180,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
     constexpr auto& cls_doc = doc.Joint;
     auto cls =
         DefineTemplateClassWithDefault<Class>(m, "Joint", param, cls_doc.doc);
-    BindMultibodyTreeElementMixin(&cls);
+    BindMultibodyElementMixin(&cls);
     cls  // BR
         .def("name", &Class::name, cls_doc.name.doc)
         .def("parent_body", &Class::parent_body, py_reference_internal,
@@ -292,7 +292,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
     constexpr auto& cls_doc = doc.JointActuator;
     auto cls = DefineTemplateClassWithDefault<Class>(
         m, "JointActuator", param, cls_doc.doc);
-    BindMultibodyTreeElementMixin(&cls);
+    BindMultibodyElementMixin(&cls);
     cls  // BR
         .def("name", &Class::name, cls_doc.name.doc)
         .def("joint", &Class::joint, py_reference_internal, cls_doc.joint.doc);
@@ -304,7 +304,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
     constexpr auto& cls_doc = doc.ForceElement;
     auto cls = DefineTemplateClassWithDefault<Class>(
         m, "ForceElement", param, cls_doc.doc);
-    BindMultibodyTreeElementMixin(&cls);
+    BindMultibodyElementMixin(&cls);
   }
 
   {

--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -16,6 +16,7 @@ drake_cc_package_library(
     name = "tree",
     deps = [
         ":articulated_body_inertia",
+        ":multibody_element",
         ":multibody_tree_caches",
         ":multibody_tree_core",
         ":multibody_tree_element",
@@ -74,13 +75,40 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "multibody_element",
+    srcs = [],
+    hdrs = [
+        "multibody_element.h",
+    ],
+    deps = [
+        ":multibody_tree_topology",
+    ],
+)
+
+drake_cc_library(
     name = "multibody_tree_element",
     srcs = [],
     hdrs = [
         "multibody_tree_element.h",
     ],
+    deprecation = "DRAKE DEPRECATED: The header drake/multibody/tree/multibody_tree_element.h is being removed on or after 2020-03-01. Please use drake/multibody/tree/multibody_element.h instead.",  # noqa
+    tags = [
+        # Avoid 'build //...' yelling at us.
+        "manual",
+    ],
     deps = [
-        ":multibody_tree_topology",
+        ":multibody_element",
+    ],
+)
+
+drake_cc_googletest(
+    name = "multibody_tree_element_test",
+    # Ignore #warning for deprecation via command-line, since "GCC diagnostic"
+    # does not suppress it.
+    copts = ["-Wno-cpp"],
+    deps = [
+        ":multibody_tree_core",
+        ":multibody_tree_element",
     ],
 )
 
@@ -144,8 +172,8 @@ drake_cc_library(
     # "//multibody/tree" broadly, not just ":multibody_tree_core".
     visibility = ["//visibility:private"],
     deps = [
+        ":multibody_element",
         ":multibody_tree_caches",
-        ":multibody_tree_element",
         ":multibody_tree_indexes",
         ":spatial_inertia",
         "//common:autodiff",

--- a/multibody/tree/body.h
+++ b/multibody/tree/body.h
@@ -8,8 +8,8 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/unused.h"
 #include "drake/multibody/tree/frame.h"
+#include "drake/multibody/tree/multibody_element.h"
 #include "drake/multibody/tree/multibody_forces.h"
-#include "drake/multibody/tree/multibody_tree_element.h"
 #include "drake/multibody/tree/multibody_tree_indexes.h"
 #include "drake/multibody/tree/multibody_tree_topology.h"
 #include "drake/multibody/tree/spatial_inertia.h"
@@ -152,7 +152,7 @@ class BodyAttorney {
 /// does it make any assumptions about the underlying physical model or
 /// approximation.
 /// As an element or component of a MultibodyTree, a body is a
-/// MultibodyTreeElement, and therefore it has a unique index of type BodyIndex
+/// MultibodyElement, and therefore it has a unique index of type BodyIndex
 /// within the multibody tree it belongs to.
 ///
 /// A %Body contains a unique BodyFrame; see BodyFrame class documentation for
@@ -160,7 +160,7 @@ class BodyAttorney {
 ///
 /// @tparam T The scalar type. Must be a valid Eigen scalar.
 template <typename T>
-class Body : public MultibodyTreeElement<Body<T>, BodyIndex> {
+class Body : public MultibodyElement<Body, T, BodyIndex> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Body)
 
@@ -168,7 +168,7 @@ class Body : public MultibodyTreeElement<Body<T>, BodyIndex> {
   /// with a given `default_mass` and a BodyFrame associated with it.
   Body(const std::string& name, ModelInstanceIndex model_instance,
        double default_mass)
-      : MultibodyTreeElement<Body<T>, BodyIndex>(model_instance),
+      : MultibodyElement<Body, T, BodyIndex>(model_instance),
         name_(name),
         body_frame_(*this), default_mass_(default_mass) {}
 
@@ -393,7 +393,7 @@ class Body : public MultibodyTreeElement<Body<T>, BodyIndex> {
     }
   }
 
-  // Implementation for MultibodyTreeElement::DoSetTopology().
+  // Implementation for MultibodyElement::DoSetTopology().
   // At MultibodyTree::Finalize() time, each body retrieves its topology
   // from the parent MultibodyTree.
   void DoSetTopology(

--- a/multibody/tree/body_node.h
+++ b/multibody/tree/body_node.h
@@ -12,7 +12,7 @@
 #include "drake/multibody/tree/articulated_body_inertia_cache.h"
 #include "drake/multibody/tree/body.h"
 #include "drake/multibody/tree/mobilizer.h"
-#include "drake/multibody/tree/multibody_tree_element.h"
+#include "drake/multibody/tree/multibody_element.h"
 #include "drake/multibody/tree/multibody_tree_indexes.h"
 #include "drake/multibody/tree/multibody_tree_topology.h"
 #include "drake/multibody/tree/position_kinematics_cache.h"
@@ -93,7 +93,7 @@ namespace internal {
 ///
 /// @tparam T The scalar type. Must be a valid Eigen scalar.
 template <typename T>
-class BodyNode : public MultibodyTreeElement<BodyNode<T>, BodyNodeIndex> {
+class BodyNode : public MultibodyElement<BodyNode, T, BodyNodeIndex> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BodyNode)
 
@@ -116,7 +116,7 @@ class BodyNode : public MultibodyTreeElement<BodyNode<T>, BodyNodeIndex> {
   /// for this node, which must outlive `this` BodyNode.
   BodyNode(const BodyNode<T>* parent_node,
            const Body<T>* body, const Mobilizer<T>* mobilizer)
-      : MultibodyTreeElement<BodyNode<T>, BodyNodeIndex>(
+      : MultibodyElement<BodyNode, T, BodyNodeIndex>(
             body->model_instance()),
         parent_node_(parent_node),
         body_(body),
@@ -1443,7 +1443,7 @@ class BodyNode : public MultibodyTreeElement<BodyNode<T>, BodyNodeIndex> {
     }
   }
 
-  // Implementation for MultibodyTreeElement::DoSetTopology().
+  // Implementation for MultibodyElement::DoSetTopology().
   // At MultibodyTree::Finalize() time, each body retrieves its topology
   // from the parent MultibodyTree.
   void DoSetTopology(const MultibodyTreeTopology& tree_topology) final {

--- a/multibody/tree/force_element.h
+++ b/multibody/tree/force_element.h
@@ -7,8 +7,8 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/multibody/math/spatial_force.h"
+#include "drake/multibody/tree/multibody_element.h"
 #include "drake/multibody/tree/multibody_forces.h"
-#include "drake/multibody/tree/multibody_tree_element.h"
 #include "drake/multibody/tree/multibody_tree_indexes.h"
 #include "drake/multibody/tree/multibody_tree_topology.h"
 #include "drake/multibody/tree/position_kinematics_cache.h"
@@ -36,13 +36,13 @@ namespace multibody {
 /// @tparam T The scalar type. Must be a valid Eigen scalar.
 template <typename T>
 class ForceElement : public
-                     MultibodyTreeElement<ForceElement<T>, ForceElementIndex> {
+                     MultibodyElement<ForceElement, T, ForceElementIndex> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ForceElement)
 
   /// Default constructor for a generic force element.
   explicit ForceElement(ModelInstanceIndex model_instance)
-      : MultibodyTreeElement<ForceElement<T>, ForceElementIndex>(
+      : MultibodyElement<ForceElement, T, ForceElementIndex>(
             model_instance) {}
 
   /// (Advanced) Computes the force contribution for `this` force element and
@@ -245,7 +245,7 @@ class ForceElement : public
   /// @}
 
  private:
-  // Implementation for MultibodyTreeElement::DoSetTopology().
+  // Implementation for MultibodyElement::DoSetTopology().
   // At MultibodyTree::Finalize() time, each force element retrieves its
   // topology from the parent MultibodyTree.
   void DoSetTopology(const internal::MultibodyTreeTopology&) final {}

--- a/multibody/tree/frame.h
+++ b/multibody/tree/frame.h
@@ -211,7 +211,7 @@ class Frame : public FrameBase<T> {
   /// @}
 
  private:
-  // Implementation for MultibodyTreeElement::DoSetTopology().
+  // Implementation for MultibodyElement::DoSetTopology().
   void DoSetTopology(const internal::MultibodyTreeTopology& tree_topology)
   final {
     topology_ = tree_topology.get_frame(this->index());

--- a/multibody/tree/frame_base.h
+++ b/multibody/tree/frame_base.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "drake/multibody/tree/multibody_tree_element.h"
+#include "drake/multibody/tree/multibody_element.h"
 #include "drake/multibody/tree/multibody_tree_indexes.h"
 
 namespace drake {
@@ -43,7 +43,7 @@ namespace multibody {
 ///
 /// @tparam T The scalar type. Must be a valid Eigen scalar.
 template <typename T>
-class FrameBase : public MultibodyTreeElement<FrameBase<T>, FrameIndex> {
+class FrameBase : public MultibodyElement<FrameBase, T, FrameIndex> {
   // TODO(amcastro-tri): Provide a method with the signature:
   // const math::RigidTransform<T>& get_pose_in_world_frame(
   //     const Context<T>& context) const;
@@ -58,7 +58,7 @@ class FrameBase : public MultibodyTreeElement<FrameBase<T>, FrameIndex> {
   // `measured_in_frame` frame.
  protected:
   explicit FrameBase(ModelInstanceIndex model_instance)
-      : MultibodyTreeElement<FrameBase<T>, FrameIndex>(model_instance) {}
+      : MultibodyElement<FrameBase, T, FrameIndex>(model_instance) {}
 };
 
 }  // namespace multibody

--- a/multibody/tree/joint.h
+++ b/multibody/tree/joint.h
@@ -23,11 +23,13 @@ namespace multibody {
 /// The two bodies connected by a %Joint object are referred to as the
 /// _parent_ and _child_ bodies. Although the terms _parent_ and _child_ are
 /// sometimes used synonymously to describe the relationship between inboard and
-/// outboard bodies in multibody models, this usage is wholly unrelated and
-/// implies nothing about the inboard-outboard relationship between the bodies.
+/// outboard bodies in multibody _trees_, the parent/child relationship is
+/// more general and remains meaningful for multibody systems with loops, such
+/// as a four-bar linkage. However, whenever possible the parent body will be
+/// made to be inboard and the child outboard in the tree.
 /// A %Joint is a model of a physical kinematic constraint between two bodies,
-/// a constraint that in the real physical system does not even allude to the
-/// ordering of the bodies.
+/// a constraint that in the real physical system does not specify a tree
+/// ordering.
 ///
 /// In Drake we define a frame F rigidly attached to the parent body P with pose
 /// `X_PF` and a frame M rigidly attached to the child body B with pose `X_BM`.
@@ -41,10 +43,10 @@ namespace multibody {
 /// Consider the following example to build a simple pendulum system:
 ///
 /// @code
-/// MultibodyTree<double> model;
+/// MultibodyPlant<double> plant;
 /// // ... Code here to setup quantities below as mass, com, etc. ...
 /// const Body<double>& pendulum =
-///   model.AddBody<RigidBody>(SpatialInertia<double>(mass, com, unit_inertia));
+///   plant.AddBody<RigidBody>(SpatialInertia<double>(mass, com, unit_inertia));
 /// // We will connect the pendulum body to the world using a RevoluteJoint.
 /// // In this simple case the parent body P is the model's world body and frame
 /// // F IS the world frame.
@@ -52,9 +54,9 @@ namespace multibody {
 /// // body frame B.
 /// // Say we declared and initialized X_BM...
 /// const RevoluteJoint<double>& elbow =
-///   model.AddJoint<RevoluteJoint>(
+///   plant.AddJoint<RevoluteJoint>(
 ///     "Elbow",                /* joint name */
-///     model.world_body(),     /* parent body */
+///     plant.world_body(),     /* parent body */
 ///     {},                     /* frame F IS the world frame W */
 ///     pendulum,               /* child body, the pendulum */
 ///     X_BM,                   /* pose of frame M in the body frame B */
@@ -62,12 +64,12 @@ namespace multibody {
 /// @endcode
 ///
 /// @warning Do not ever attempt to instantiate and manipulate %Joint objects
-/// on the stack; it will fail. Add joints to your model using the provided API
-/// MultibodyTree::AddJoint() as in the example above.
+/// on the stack; it will fail. Add joints to your plant using the provided API
+/// MultibodyPlant::AddJoint() as in the example above.
 ///
 /// @tparam T The scalar type. Must be a valid Eigen scalar.
 template <typename T>
-class Joint : public MultibodyTreeElement<Joint<T>, JointIndex>  {
+class Joint : public MultibodyElement<Joint, T, JointIndex>  {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Joint)
 
@@ -115,7 +117,7 @@ class Joint : public MultibodyTreeElement<Joint<T>, JointIndex>  {
         const VectorX<double>& vel_upper_limits,
         const VectorX<double>& acc_lower_limits,
         const VectorX<double>& acc_upper_limits)
-      : MultibodyTreeElement<Joint<T>, JointIndex>(
+      : MultibodyElement<Joint, T, JointIndex>(
             frame_on_child.model_instance()),
         name_(name),
         frame_on_parent_(frame_on_parent),
@@ -478,7 +480,7 @@ class Joint : public MultibodyTreeElement<Joint<T>, JointIndex>  {
   virtual void DoAddInDamping(
       const systems::Context<T>&, MultibodyForces<T>*) const {}
 
-  // Implements MultibodyTreeElement::DoSetTopology(). Joints have no topology
+  // Implements MultibodyElement::DoSetTopology(). Joints have no topology
   // though we could require them to have one in the future.
   void DoSetTopology(const internal::MultibodyTreeTopology&) {}
 

--- a/multibody/tree/joint_actuator.cc
+++ b/multibody/tree/joint_actuator.cc
@@ -9,7 +9,7 @@ namespace multibody {
 template <typename T>
 JointActuator<T>::JointActuator(const std::string& name, const Joint<T>& joint,
                                 double effort_limit)
-    : MultibodyTreeElement<JointActuator<T>, JointActuatorIndex>(
+    : MultibodyElement<JointActuator, T, JointActuatorIndex>(
           joint.model_instance()),
       name_(name),
       joint_index_(joint.index()),

--- a/multibody/tree/joint_actuator.h
+++ b/multibody/tree/joint_actuator.h
@@ -7,8 +7,8 @@
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/multibody/tree/multibody_element.h"
 #include "drake/multibody/tree/multibody_forces.h"
-#include "drake/multibody/tree/multibody_tree_element.h"
 #include "drake/multibody/tree/multibody_tree_indexes.h"
 #include "drake/multibody/tree/multibody_tree_topology.h"
 #include "drake/systems/framework/context.h"
@@ -37,7 +37,7 @@ template<typename T> class Joint;
 /// No other values for T are currently supported.
 template <typename T>
 class JointActuator final
-    : public MultibodyTreeElement<JointActuator<T>, JointActuatorIndex> {
+    : public MultibodyElement<JointActuator, T, JointActuatorIndex> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(JointActuator)
 
@@ -166,7 +166,7 @@ class JointActuator final
   std::unique_ptr<JointActuator<symbolic::Expression>> DoCloneToScalar(
       const internal::MultibodyTree<symbolic::Expression>& tree_clone) const;
 
-  // Implementation for MultibodyTreeElement::DoSetTopology().
+  // Implementation for MultibodyElement::DoSetTopology().
   // At MultibodyTree::Finalize() time, each actuator retrieves its topology
   // from the parent MultibodyTree.
   void DoSetTopology(const internal::MultibodyTreeTopology&) final;

--- a/multibody/tree/mobilizer.h
+++ b/multibody/tree/mobilizer.h
@@ -12,7 +12,7 @@
 #include "drake/multibody/math/spatial_force.h"
 #include "drake/multibody/math/spatial_velocity.h"
 #include "drake/multibody/tree/frame.h"
-#include "drake/multibody/tree/multibody_tree_element.h"
+#include "drake/multibody/tree/multibody_element.h"
 #include "drake/multibody/tree/multibody_tree_indexes.h"
 #include "drake/multibody/tree/multibody_tree_topology.h"
 
@@ -210,7 +210,7 @@ template<typename T> class BodyNode;
 ///
 /// @tparam T The scalar type. Must be a valid Eigen scalar.
 template <typename T>
-class Mobilizer : public MultibodyTreeElement<Mobilizer<T>, MobilizerIndex> {
+class Mobilizer : public MultibodyElement<Mobilizer, T, MobilizerIndex> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Mobilizer)
 
@@ -646,7 +646,7 @@ class Mobilizer : public MultibodyTreeElement<Mobilizer<T>, MobilizerIndex> {
   /// @}
 
  private:
-  // Implementation for MultibodyTreeElement::DoSetTopology().
+  // Implementation for MultibodyElement::DoSetTopology().
   // At MultibodyTree::Finalize() time, each mobilizer retrieves its topology
   // from the parent MultibodyTree.
   void DoSetTopology(const MultibodyTreeTopology& tree_topology) final {

--- a/multibody/tree/mobilizer_impl.h
+++ b/multibody/tree/mobilizer_impl.h
@@ -10,7 +10,7 @@
 #include "drake/common/symbolic.h"
 #include "drake/multibody/tree/frame.h"
 #include "drake/multibody/tree/mobilizer.h"
-#include "drake/multibody/tree/multibody_tree_element.h"
+#include "drake/multibody/tree/multibody_element.h"
 #include "drake/multibody/tree/multibody_tree_indexes.h"
 #include "drake/multibody/tree/multibody_tree_topology.h"
 #include "drake/systems/framework/context.h"

--- a/multibody/tree/model_instance.h
+++ b/multibody/tree/model_instance.h
@@ -7,7 +7,7 @@
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/tree/joint_actuator.h"
 #include "drake/multibody/tree/mobilizer.h"
-#include "drake/multibody/tree/multibody_tree_element.h"
+#include "drake/multibody/tree/multibody_element.h"
 #include "drake/multibody/tree/multibody_tree_indexes.h"
 
 namespace drake {
@@ -17,7 +17,7 @@ namespace multibody {
 /// @anchor model_instance
 /// Model instance information for multibody trees.
 ///
-/// A MultiBodyTree is composed of a number of MultibodyTreeElement items.  In
+/// A MultiBodyTree is composed of a number of MultibodyElement items.  In
 /// more complex trees, these items will be loaded from multiple models
 /// (e.g. robot arm, attached gripper, free bodies being manipulated).  Each
 /// model may have a different controller or observer, so the ability to view
@@ -34,7 +34,7 @@ namespace multibody {
 /// explicitly specified), as model parsers should handle creating model
 /// elements as needed.
 ///
-/// For different types of MultibodyTreeElement, the model instance is
+/// For different types of MultibodyElement, the model instance is
 /// sometimes specified explicitly, and sometimes inferred when the
 /// element is created.  The current convention is:
 ///
@@ -62,12 +62,12 @@ namespace internal {
 /// - symbolic::Expression
 template <typename T>
 class ModelInstance :
-      public MultibodyTreeElement<ModelInstance<T>, ModelInstanceIndex> {
+      public MultibodyElement<ModelInstance, T, ModelInstanceIndex> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ModelInstance)
 
   explicit ModelInstance(ModelInstanceIndex index)
-      : MultibodyTreeElement<ModelInstance<T>, ModelInstanceIndex>(index) {}
+      : MultibodyElement<ModelInstance, T, ModelInstanceIndex>(index) {}
 
   int num_positions() const { return num_positions_; }
   int num_velocities() const { return num_velocities_; }

--- a/multibody/tree/multibody_element.h
+++ b/multibody/tree/multibody_element.h
@@ -1,0 +1,141 @@
+#pragma once
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/multibody/tree/multibody_tree.h"
+#include "drake/multibody/tree/multibody_tree_indexes.h"
+#include "drake/multibody/tree/multibody_tree_topology.h"
+
+namespace drake {
+namespace multibody {
+
+namespace internal {
+// This is a class used by MultibodyTree internals to create the implementation
+// for a particular joint object.
+template <typename T>
+class JointImplementationBuilder;
+}  // namespace internal
+
+/// A class representing an element (subcomponent) of a MultibodyPlant or
+/// (internally) a MultibodyTree. Examples of multibody elements are bodies,
+/// joints, force elements, and actuators. After a Finalize() call, multibody
+/// elements get assigned an type-specific index that uniquely identifies them.
+/// A generic multibody tree element `MultibodyThing` is derived from
+/// this class as:
+/// @code{.cpp}
+/// template <typename T>
+/// class MultibodyThing :
+///     public MultibodyElement<MultibodyThing, T, MultibodyThingIndex> {
+///  ...
+/// };
+/// @endcode
+///
+/// @tparam ElementType The type of the specific multibody element, for
+///     instance, a body or a mobilizer. It must be a template class that can
+///     be templatized by scalar type T.
+/// @tparam T The underlying scalar type. Must be a valid Eigen scalar.
+/// @tparam ElementIndexType The type-safe index used for this element type.
+///
+/// As an example of usage, consider the definition of a `ForceElement` class
+/// as a multibody element. This is accomplished with:
+/// @code{.cpp}
+///   template <typename T>
+///   class ForceElement :
+///       public MultibodyElement<ForceElement, T, ForceElementIndex>;
+/// @endcode
+template <template <typename> class ElementType,
+    typename T, typename ElementIndexType>
+class MultibodyElement {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MultibodyElement)
+
+  virtual ~MultibodyElement() {}
+
+  /// Returns this element's unique index.
+  ElementIndexType index() const { return index_;}
+
+  /// Returns the ModelInstanceIndex of the model instance to which this
+  /// element belongs.
+  ModelInstanceIndex model_instance() const { return model_instance_;}
+
+ protected:
+  /// Default constructor made protected so that sub-classes can still declare
+  /// their default constructors if they need to.
+  MultibodyElement() {}
+
+  /// Constructor which allows specifying a model instance.
+  explicit MultibodyElement(ModelInstanceIndex model_instance)
+      : model_instance_(model_instance) {}
+
+  /// Returns a constant reference to the parent MultibodyTree that
+  /// owns this element.
+  const internal::MultibodyTree<T>& get_parent_tree() const {
+    DRAKE_ASSERT_VOID(HasParentTreeOrThrow());
+    return *parent_tree_;
+  }
+
+  /// Gives MultibodyElement-derived objects the opportunity to retrieve their
+  /// topology after MultibodyTree::Finalize() is invoked.
+  /// NVI to pure virtual method DoSetTopology().
+  void SetTopology(const internal::MultibodyTreeTopology& tree) {
+    DoSetTopology(tree);
+  }
+
+  /// Implementation of the NVI SetTopology(). For advanced use only for
+  /// developers implementing new MultibodyTree components.
+  virtual void DoSetTopology(const internal::MultibodyTreeTopology& tree) = 0;
+
+ private:
+  // MultibodyTree<T> is a natural friend of MultibodyElement objects and
+  // therefore it can set the owning parent tree and unique index in that tree.
+  friend class internal::MultibodyTree<T>;
+
+  // Give unit tests access to the tree.
+  friend class MultibodyElementTester;
+
+  void set_parent_tree(
+      const internal::MultibodyTree<T>* tree, ElementIndexType index) {
+    index_ = index;
+    parent_tree_ = tree;
+  }
+
+  void set_model_instance(ModelInstanceIndex model_instance) {
+    model_instance_ = model_instance;
+  }
+
+  bool has_parent_tree() const { return parent_tree_ != nullptr; }
+
+  // Checks whether this MultibodyElement has been registered into
+  // a MultibodyTree and throws an exception if not.
+  // @throws std::logic_error if the element is not in a MultibodyTree.
+  void HasParentTreeOrThrow() const {
+    if (!has_parent_tree()) {
+      throw std::logic_error(
+          "This multibody element was not added to a MultibodyTree.");
+    }
+  }
+
+  // Checks whether this MultibodyElement belongs to the provided
+  // MultibodyTree `tree` and throws an exception if not.
+  // @throws std::logic_error if `this` element is not in the given `tree`.
+  void HasThisParentTreeOrThrow(const internal::MultibodyTree<T>* tree) const {
+    DRAKE_ASSERT(tree != nullptr);
+    if (parent_tree_ != tree) {
+      throw std::logic_error("This multibody element does not belong to the "
+                             "supplied MultibodyTree.");
+    }
+  }
+
+  const internal::MultibodyTree<T>* parent_tree_{nullptr};
+
+  // The default index value is *invalid*. This must be set to a valid index
+  // value before the element is released to the wild.
+  ElementIndexType index_;
+
+  // The default model instance id is *invalid*. This must be set to a
+  // valid index value before the element is released to the wild.
+  ModelInstanceIndex model_instance_;
+};
+
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/tree/multibody_tree-inl.h
+++ b/multibody/tree/multibody_tree-inl.h
@@ -64,7 +64,7 @@ const BodyType<T>& MultibodyTree<T>::AddBody(
   DRAKE_DEMAND(body->model_instance().is_valid());
 
   // TODO(amcastro-tri): consider not depending on setting this pointer at
-  // all. Consider also removing MultibodyTreeElement altogether.
+  // all. Consider also removing MultibodyElement altogether.
   body->set_parent_tree(this, body_index);
   // MultibodyTree can access selected private methods in Body through its
   // BodyAttorney.
@@ -144,7 +144,7 @@ const FrameType<T>& MultibodyTree<T>::AddFrame(
   DRAKE_DEMAND(frame->model_instance().is_valid());
 
   // TODO(amcastro-tri): consider not depending on setting this pointer at
-  // all. Consider also removing MultibodyTreeElement altogether.
+  // all. Consider also removing MultibodyElement altogether.
   frame->set_parent_tree(this, frame_index);
   FrameType<T>* raw_frame_ptr = frame.get();
   frames_.push_back(raw_frame_ptr);
@@ -202,7 +202,7 @@ const MobilizerType<T>& MultibodyTree<T>::AddMobilizer(
   }
 
   // TODO(amcastro-tri): consider not depending on setting this pointer at
-  // all. Consider also removing MultibodyTreeElement altogether.
+  // all. Consider also removing MultibodyElement altogether.
   mobilizer->set_parent_tree(this, mobilizer_index);
 
   // Mark free bodies as needed.

--- a/multibody/tree/multibody_tree_element.h
+++ b/multibody/tree/multibody_tree_element.h
@@ -1,186 +1,32 @@
 #pragma once
 
-#include "drake/common/drake_assert.h"
-#include "drake/common/drake_copyable.h"
-#include "drake/multibody/tree/multibody_tree.h"
-#include "drake/multibody/tree/multibody_tree_indexes.h"
-#include "drake/multibody/tree/multibody_tree_topology.h"
+// NOLINTNEXTLINE(whitespace/line_length)
+#warning DRAKE DEPRECATED: The header drake/multibody/tree/multibody_tree_element.h is being removed on or after 2020-03-01. Please use drake/multibody/tree/multibody_element.h instead.
+
+#include "drake/common/drake_deprecated.h"
+#include "drake/multibody/tree/multibody_element.h"
 
 namespace drake {
 namespace multibody {
 
 namespace internal {
 
-// This is a class used by MultibodyTree internals to create the implementation
-// for a particular joint object.
-template <typename T>
-class JointImplementationBuilder;
+template <class ElementType, typename ElementIndexType>
+struct MultibodyTreeAlias;
+
+template <
+    template <typename> class ElementType, typename T,
+    typename ElementIndexType>
+struct MultibodyTreeAlias<ElementType<T>, ElementIndexType> {
+  using type = MultibodyElement<ElementType, T, ElementIndexType>;
+};
+
 }  // namespace internal
 
-// Primary template defining the signature of this class.
-// Two template arguments are required in general, the type of the class
-// inheriting from MultibodyTreeElement (i.e. this is a CRTP class), and the
-// type of the type-safe index used to identify these element types within a
-// MultibodyTree.
-// The signature below is the primary template definition for
-// MultibodyTreeElement (even when at a first glance it looks like a forward
-// declaration, it is not). This will allow us, a few lines below, to provide an
-// explicit (full) template specialization for the case in which the class is a
-// template in a scalar type T. The template specialization allows the compiler
-// to automatically deduce the scalar type from the subclass template signature
-// itself.
-// Hide from Doxygen.
-/// @cond
-template <class ElementType, typename ElementIndexType>
-class MultibodyTreeElement;
-/// @endcond
-
-/// A class representing an element or component of a MultibodyTree. Examples of
-/// multibody tree elements are bodies, joints, force elements, and constraints.
-/// Multibody tree elements are owned and managed by a parent MultibodyTree.
-/// At MultibodyTree::Finalize() stage, they get assigned an index that
-/// uniquely identifies them within their parent MultibodyTree.
-/// A generic multibody tree element `MultibodyComponent` is derived from
-/// this class as:
-/// @code{.cpp}
-/// template <typename T>
-/// class MultibodyComponent :
-///     public MultibodyTreeElement<MultibodyComponent<T>,
-///                                 MultibodyComponentIndex> {
-///  ...
-/// };
-/// @endcode
-///
-/// @tparam ElementType The type of the specific multibody element, for
-///                     instance, a body or a mobilizer. It must be a template
-///                     class on the scalar type T.
-/// @tparam T The underlying scalar type. Must be a valid Eigen scalar. With the
-///           signature below the scalar type is automatically deduced from the
-///           `ElementType` template argument.
-/// @tparam ElementIndexType The type-safe index used for this element type.
-///
-/// As an example of usage, consider the definition of a `ForceElement` class
-/// as a multibody tree element. This would be accomplished with:
-/// @code{.cpp}
-///   template <typename T>
-///   class ForceElement :
-///       public MultibodyTreeElement<ForceElement<T>, ForceElementIndex>;
-/// @endcode
-/// Notice that with the signature below the scalar type is automatically
-/// deduced from the template arguments.
-template <template <typename> class ElementType,
-    typename T, typename ElementIndexType>
-class MultibodyTreeElement<ElementType<T>, ElementIndexType> {
- public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MultibodyTreeElement)
-
-  virtual ~MultibodyTreeElement() {}
-
-  /// Returns a constant reference to the parent MultibodyTree that owns
-  /// this element.
-  /// Sub-classes of %MultibodyTreeElement will have a set of `Create()` methods
-  /// that, when successful, will create and add a %MultibodyTreeElement to a
-  /// valid MultibodyTree. Therefore, on success, the result of a `Create()`
-  /// method is a properly initialized %MultibodyTreeElement with a
-  /// valid MultibodyTree parent. @see RigidBody::Create() for an example of a
-  /// `Create()` method.
-  const internal::MultibodyTree<T>& get_parent_tree() const {
-    DRAKE_ASSERT_VOID(HasParentTreeOrThrow());
-    return *parent_tree_;
-  }
-
-  /// Returns this element's unique index in its parent MultibodyTree.
-  ElementIndexType index() const { return index_;}
-
-  /// Returns this element's model instance index in its parent MultibodyTree.
-  ModelInstanceIndex model_instance() const { return model_instance_;}
-
-  /// Checks whether this MultibodyTreeElement has been registered into a
-  /// MultibodyTree. If not, it throws an exception of type std::logic_error.
-  void HasParentTreeOrThrow() const {
-    if (parent_tree_ == nullptr) {
-      throw std::logic_error(
-          "This multibody component was not added to a MultibodyTree.");
-    }
-  }
-
-  /// Checks whether `this` element has the same parent tree as `other`.
-  /// If not, it throws an exception of type `std::logic_error`.
-  /// A `std::logic_error` exception is thrown if either or both elements do not
-  /// have a parent tree.
-  template <template <typename> class OtherElementType,
-      typename OtherElementIndexType>
-  void HasSameParentTreeOrThrow(
-      const MultibodyTreeElement<OtherElementType<T>, OtherElementIndexType>&
-      other) const {
-    this->HasParentTreeOrThrow();
-    other.HasParentTreeOrThrow();
-    if (parent_tree_ != other.parent_tree_) {
-      throw std::logic_error(
-          "These two MultibodyTreeElement objects do not belong to "
-          "the same MultibodyTree.");
-    }
-  }
-
-  /// Checks whether this MultibodyTreeElement belongs to the provided
-  /// MultibodyTree `tree`. If not, it throws a std::logic_error.
-  void HasThisParentTreeOrThrow(const internal::MultibodyTree<T>* tree) const {
-    DRAKE_ASSERT(tree != nullptr);
-    if (parent_tree_ != tree) {
-      throw std::logic_error("This multibody component does not belong to the "
-                             "supplied MultibodyTree.");
-    }
-  }
-
-  // TODO(amcastro-tri): Add DeepClone API for transmogrification to other
-  // scalar types.
-  // This will make use the template argument "MultibodyTreeElement".
-
- protected:
-  /// Default constructor made protected so that sub-classes can still declare
-  /// their default constructors if they need to.
-  MultibodyTreeElement() {}
-
-  /// Constructor which allows specifying a model instance.
-  explicit MultibodyTreeElement(ModelInstanceIndex model_instance)
-      : model_instance_(model_instance) {}
-
-  /// Gives MultibodyTree elements the opportunity to retrieve their topology
-  /// when MultibodyTree::Finalize() is invoked.
-  /// NVI to pure virtual method DoSetTopology().
-  void SetTopology(const internal::MultibodyTreeTopology& tree) {
-    DoSetTopology(tree);
-  }
-
-  /// Implementation of the NVI SetTopology(). For advanced use only for
-  /// developers implementing new MultibodyTree components.
-  virtual void DoSetTopology(const internal::MultibodyTreeTopology& tree) = 0;
-
- private:
-  void set_parent_tree(
-      const internal::MultibodyTree<T>* tree, ElementIndexType index) {
-    index_ = index;
-    parent_tree_ = tree;
-  }
-
-  void set_model_instance(ModelInstanceIndex model_instance) {
-    model_instance_ = model_instance;
-  }
-
-  // MultibodyTree<T> is a natural friend of MultibodyTreeElement objects and
-  // therefore it can set the owning parent tree and unique index in that tree.
-  friend class internal::MultibodyTree<T>;
-
-  const internal::MultibodyTree<T>* parent_tree_{nullptr};
-
-  // The default index value is *invalid*. This must be set to a valid index
-  // value before the element is released to the wild.
-  ElementIndexType index_;
-
-  // The default model instance id is *invalid*. This must be set to a
-  // valid index value before the element is released to the wild.
-  ModelInstanceIndex model_instance_;
-};
+template <typename... Args>
+using MultibodyTreeElement
+    DRAKE_DEPRECATED("2020-03-01", "Use MultibodyElement instead.")
+    = typename internal::MultibodyTreeAlias<Args...>::type;
 
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/test/multibody_tree_element_test.cc
+++ b/multibody/tree/test/multibody_tree_element_test.cc
@@ -1,0 +1,23 @@
+#include "drake/multibody/tree/multibody_tree_element.h"
+
+#include <utility>
+
+#include "drake/multibody/tree/joint.h"
+
+namespace drake {
+namespace multibody {
+
+// Make sure we can access the deprecated alias and that it's identical to the
+// referent.
+
+using A = MultibodyElement<Joint, double, JointIndex>;
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+using B = MultibodyTreeElement<Joint<double>, JointIndex>;
+#pragma GCC diagnostic pop
+
+static_assert(std::is_same<A, B>::value, "Yay");
+
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
`MultibodyTreeElement` serves as the base class for user-facing Multibody _Plant_ elements like Body and Joint and provides several important APIs through inheritance, such as `body.model_instance()` . However, this was hidden from Doxygen due to some complicated templating, and the documentation is suitable for internal use but not exposure to MultibodyPlant users. While it is true that all the MultibodyPlant elements are stored internally in an `internal::MultibodyTree` object, users should not have to deal with that. 

This PR renames the base class to `MultibodyElement`, simplifies the templating to un-confuse Doxygen, and fiddles with the documentation wording to make it more appropriate for MultibodyPlant users to see.

Resolves #12351

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12352)
<!-- Reviewable:end -->
