### PR TITLE
MultibodyPlant: Add output port for the continuous time generalized accelerations

### DIFF
--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -2061,6 +2061,13 @@ void MultibodyPlant<T>::DeclareStateCacheAndPorts() {
                                     {this->all_state_ticket()})
           .get_index();
 
+  // Declare one output port for the generalized accelerations vector.
+  continuous_accelerations_output_port_ =
+      this->DeclareVectorOutputPort("continuous_accelerations",
+          BasicVector<T>(num_actuators()),
+          &MultibodyPlant::CopyContinuousAccelerationsOut,
+          {this->all_state_ticket()}).get_index();
+
   // Declare per model instance state output ports.
   instance_continuous_state_output_ports_.resize(num_model_instances());
   for (ModelInstanceIndex model_instance_index(0);
@@ -2369,6 +2376,17 @@ void MultibodyPlant<T>::CopyContinuousStateOut(
     const Context<T>& context, BasicVector<T>* state_vector) const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
   state_vector->SetFrom(GetStateVector(context));
+}
+
+template <typename T>
+void MultibodyPlant<T>::CopyContinuousAccelerationsOut(
+    const Context<T>& context, BasicVector<T>* accelerations_vector) const {
+  DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+  const auto& accelerations = EvalGeneralizedAccelerations(context);
+  const int num_joints = num_actuators();
+  for (int i = 0; i < num_joints; ++i) {
+    (*accelerations_vector)[i] = accelerations[i];
+  }
 }
 
 template <typename T>

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3515,6 +3515,11 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   void CopyContinuousStateOut(
       const systems::Context<T>& context, systems::BasicVector<T>* state) const;
 
+  // Calc method for the continuous accelerations vector output port.
+  void CopyContinuousAccelerationsOut(
+      const systems::Context<T>& context,
+      systems::BasicVector<T>* accelerations) const;
+
   // Calc method for the per-model-instance continuous state vector output
   // port.
   void CopyContinuousStateOut(
@@ -3874,6 +3879,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   systems::InputPortIndex applied_spatial_force_input_port_;
 
   systems::OutputPortIndex continuous_state_output_port_;
+  systems::OutputPortIndex continuous_accelerations_output_port_;
   // A vector containing state output ports for each model instance indexed by
   // ModelInstanceIndex. An invalid value indicates that the model instance has
   // no state.


### PR DESCRIPTION
Adds an output port for the continuous time accelerations to the multibody plant. Was built with the newest version on master and passes all tests.

This was tested on:
Ubuntu 18.04
gcc (Ubuntu 7.4.0-9ubuntu1~18.04.york0) 7.4.0
bazel 1.1.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12353)
<!-- Reviewable:end -->
