### PR TITLE
libdrake: Clarify headers vs shared-library dependencies

### DIFF
--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -38,7 +38,9 @@ drake_cc_binary(
     name = "libdrake.so",
     linkshared = 1,
     linkstatic = 1,
-    deps = LIBDRAKE_COMPONENTS,
+    deps = LIBDRAKE_COMPONENTS + [
+        ":libdrake_runtime_so_deps",
+    ],
 )
 
 # Gather all of libdrake.so's dependent headers, excluding headers that are
@@ -167,18 +169,9 @@ cc_library(
 )
 
 # Provide a cc_library target that provides libdrake.so, its headers, its
-# header-only dependencies, and its required *.so's that are WORKSPACE
-# downloads (such as VTK, Gurobi, etc). This is aliased by
+# header-only dependencies, and its required *.so's.  This is aliased by
 # `//:drake_shared_library`, which is what downstream users will consume if
 # they wish to link to `libdrake.so`.
-#
-# TODO(jwnimmer-tri) Ideally, Bazel should be able to handle the depended-on
-# *.so files for us, without us having to know up-front here which dependencies
-# are coming from the WORKSPACE in the form of *.so.
-#
-# TODO(jwnimmer-tri) Ideally, drake_cc_library's installed_headers support
-# would capture a list of headerfile dependencies, so that we don't need to
-# write out the "list of libraries directly mentioned in Drake headers" below.
 cc_library(
     name = "drake_shared_library",
     srcs = [":libdrake.so"],
@@ -190,9 +183,21 @@ cc_library(
     strip_include_prefix = "/",
     visibility = ["//:__pkg__"],
     deps = [
+        ":libdrake_header_only_deps",
         ":libdrake_headers_only_attic_cc_library",
-        # The list of depended-on *.so files. These should ONLY be shared
-        # libraries; do not add static dependencies here.
+        ":libdrake_runtime_so_deps",
+    ],
+)
+
+# The list of depended-on *.so files. These should ONLY be shared libraries; do
+# not add static dependencies here.
+#
+# TODO(jwnimmer-tri) Ideally, Bazel should be able to handle the depended-on
+# *.so files for us, without us having to know up-front here which dependencies
+# are coming from the WORKSPACE in the form of *.so.
+cc_library(
+    name = "libdrake_runtime_so_deps",
+    deps = [
         ":dreal_deps",
         ":gurobi_deps",
         ":ipopt_deps",
@@ -206,9 +211,18 @@ cc_library(
         "@spdlog",
         "@tinyxml2",
         "@yaml_cpp",
-    ] + [
-        # The list of depended-on header-only libraries that libdrake's header
-        # files depend on.
+    ],
+)
+
+# The list of depended-on header-only libraries that libdrake's header files
+# depend on.  Do not add any object code (shared nor static) here.
+#
+# TODO(jwnimmer-tri) Ideally, drake_cc_library's installed_headers support
+# would capture a list of headerfile dependencies, so that we don't need to
+# write out the "list of libraries directly mentioned in Drake headers" below.
+cc_library(
+    name = "libdrake_header_only_deps",
+    deps = [
         "//lcmtypes:lcmtypes_drake_cc",
         "@eigen",
         "@fmt",


### PR DESCRIPTION
Discovered in / broken out of #12262.  This is essentially a documentation / clarity improvement, although the addition of `*.so` deps to the `libdrake.so` target ends up being important in #12262.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12362)
<!-- Reviewable:end -->
