### PR TITLE
Fixes for building and testing Drake in a Docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,6 @@
 .gitignore
 .idea
 bazel-*
+gen
+tools/bazel
+user.bazelrc

--- a/tools/lint/test/util_test.py
+++ b/tools/lint/test/util_test.py
@@ -6,6 +6,9 @@ from drake.tools.lint.util import find_all_sources
 
 class UtilTest(unittest.TestCase):
 
+    @unittest.skipIf(
+        os.path.exists("/.dockerenv"),
+        "Path lengths are often shorter than 10 in Docker containers")
     def test_find(self):
         workspace_dir, relpaths = find_all_sources("drake")
 


### PR DESCRIPTION
Especially for Mac users building an Ubuntu Docker image. There are some magic numbers in `tools/lint/test/util_test.py` that break (apparently insane) test runs from within the typical location of working directories at the root of Docker containers. 

Relates #11544 (closed).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12367)
<!-- Reviewable:end -->
