### PR TITLE
py systems: Bind `System.SetDefaultContext` and `Simulator.reset_context`

### DIFF
--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -105,6 +105,13 @@ PYBIND11_MODULE(analysis, m) {
             py_reference_internal, doc.Simulator.get_mutable_integrator.doc)
         .def("get_mutable_context", &Simulator<T>::get_mutable_context,
             py_reference_internal, doc.Simulator.get_mutable_context.doc)
+        .def("has_context", &Simulator<T>::has_context,
+            doc.Simulator.has_context.doc)
+        .def("reset_context", &Simulator<T>::reset_context, py::arg("context"),
+            // Keep alive, ownership: `context` keeps `self` alive.
+            py::keep_alive<2, 1>(), doc.Simulator.reset_context.doc)
+        // TODO(eric.cousineau): Bind `release_context` once some form of the
+        // PR RobotLocomotion/pybind11#33 lands. Presently, it fails.
         .def("reset_integrator",
             [](Simulator<T>* self,
                 std::unique_ptr<IntegratorBase<T>> integrator) {

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -328,6 +328,8 @@ struct Impl {
             doc.System.AllocateContext.doc)
         .def("CreateDefaultContext", &System<T>::CreateDefaultContext,
             doc.System.CreateDefaultContext.doc)
+        .def("SetDefaultContext", &System<T>::SetDefaultContext,
+            doc.System.SetDefaultContext.doc)
         .def("AllocateOutput",
             overload_cast_explicit<unique_ptr<SystemOutput<T>>>(
                 &System<T>::AllocateOutput),


### PR DESCRIPTION
I had to abandon trying to bind `release_context()` due to the issue described in https://github.com/RobotLocomotion/pybind11/pull/33.
It's fixable, but may require a non-trivial amount of time to fix.

\cc @manuelli

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12368)
<!-- Reviewable:end -->
