### PR TITLE
Adds a query for signed distance between a single pair of geometries

### DIFF
--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -441,6 +441,14 @@ class GeometryState {
         X_WGs_, max_distance);
   }
 
+  /** Implementation of
+   QueryObject::ComputeSignedDistancePairClosestPoints().  */
+  SignedDistancePair<T> ComputeSignedDistancePairClosestPoints(
+      GeometryId id_A, GeometryId id_B) const {
+    return geometry_engine_->ComputeSignedDistancePairClosestPoints(id_A, id_B,
+                                                                    X_WGs_);
+  }
+
   /** Implementation of QueryObject::ComputeSignedDistanceToPoint().  */
   std::vector<SignedDistanceToPoint<T>> ComputeSignedDistanceToPoint(
       const Vector3<T>& p_WQ, double threshold) const {

--- a/geometry/proximity_engine.h
+++ b/geometry/proximity_engine.h
@@ -165,6 +165,15 @@ class ProximityEngine {
       const std::unordered_map<GeometryId, math::RigidTransform<T>>& X_WGs,
       const double max_distance) const;
 
+  /** Implementation of
+   GeometryState::ComputeSignedDistancePairClosestPoints().
+   This includes `X_WGs`, the current poses of all geometries in World in the
+   current scalar type, keyed on each geometry's GeometryId.  */
+  SignedDistancePair<T> ComputeSignedDistancePairClosestPoints(
+      GeometryId id_A, GeometryId id_B,
+      const std::unordered_map<GeometryId, math::RigidTransform<T>>& X_WGs)
+      const;
+
   /** Implementation of GeometryState::ComputeSignedDistanceToPoint().
    This includes `X_WGs`, the current poses of all geometries in World in the
    current scalar type, keyed on each geometry's GeometryId.  */

--- a/geometry/query_object.cc
+++ b/geometry/query_object.cc
@@ -122,6 +122,16 @@ QueryObject<T>::ComputeSignedDistancePairwiseClosestPoints(
 }
 
 template <typename T>
+SignedDistancePair<T> QueryObject<T>::ComputeSignedDistancePairClosestPoints(
+    GeometryId id_A, GeometryId id_B) const {
+  ThrowIfNotCallable();
+
+  FullPoseUpdate();
+  const GeometryState<T>& state = geometry_state();
+  return state.ComputeSignedDistancePairClosestPoints(id_A, id_B);
+}
+
+template <typename T>
 std::vector<SignedDistanceToPoint<T>>
 QueryObject<T>::ComputeSignedDistanceToPoint(
     const Vector3<T>& p_WQ,

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -316,6 +316,16 @@ class QueryObject {
       const double max_distance =
           std::numeric_limits<double>::infinity()) const;
 
+  /** A variant of ComputeSignedDistancePairwiseClosestPoints() which computes
+   the signed distance (and witnesses) between a specific pair of geometries
+   indicated by id. This function has the same restrictions on scalar report
+   as ComputeSignedDistancePairwiseClosestPoints().
+
+   @throws if either geometry id is invalid, or if the pair (id_A, id_B) has
+           been marked as filtered.  */
+  SignedDistancePair<T> ComputeSignedDistancePairClosestPoints(
+      GeometryId id_A, GeometryId id_B) const;
+
   // TODO(DamrongGuoy): Improve and refactor documentation of
   // ComputeSignedDistanceToPoint(). Move the common sections into Signed
   // Distance Queries. Update documentation as we add more functionality.

--- a/geometry/test/query_object_test.cc
+++ b/geometry/test/query_object_test.cc
@@ -184,6 +184,8 @@ TEST_F(QueryObjectTest, DefaultQueryThrows) {
   // Signed distance queries.
   EXPECT_DEFAULT_ERROR(
       default_object->ComputeSignedDistancePairwiseClosestPoints());
+  EXPECT_DEFAULT_ERROR(default_object->ComputeSignedDistancePairClosestPoints(
+      GeometryId::get_new_id(), GeometryId::get_new_id()));
   EXPECT_DEFAULT_ERROR(
       default_object->ComputeSignedDistanceToPoint(Vector3<double>::Zero()));
 


### PR DESCRIPTION
QueryObject has a new method. It attempts to produce a signed distance pair result between a user-specified pair of geometries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12379)
<!-- Reviewable:end -->
