### PR TITLE
Provide access to owning MultibodyPlant from any MultibodyElement

### DIFF
--- a/multibody/tree/multibody_element.h
+++ b/multibody/tree/multibody_element.h
@@ -9,6 +9,9 @@
 namespace drake {
 namespace multibody {
 
+template <typename T>
+class MultibodyPlant;
+
 namespace internal {
 // This is a class used by MultibodyTree internals to create the implementation
 // for a particular joint object.
@@ -57,6 +60,29 @@ class MultibodyElement {
   /// Returns the ModelInstanceIndex of the model instance to which this
   /// element belongs.
   ModelInstanceIndex model_instance() const { return model_instance_;}
+
+  /// Returns the MultibodyPlant that owns this %MultibodyElement.
+  ///
+  /// @note You can only invoke this method if you have a definition of
+  /// %MultibodyPlant available. That is, you must include
+  /// `drake/multibody/plant/multibody_plant.h` in the translation unit that
+  /// invokes this method; multibody_element.h cannot do that for you.
+  ///
+  /// @throws std::logic_error if there is no %MultibodyPlant owner.
+  template <typename MultibodyPlantDeferred = MultibodyPlant<T>>
+  const MultibodyPlantDeferred& GetParentPlant() const {
+    HasParentTreeOrThrow();
+
+    const auto plant = dynamic_cast<const MultibodyPlantDeferred*>(
+        &get_parent_tree().tree_system());
+
+    if (plant == nullptr) {
+      throw std::logic_error(
+          "This multibody element was not owned by a MultibodyPlant.");
+    }
+
+    return *plant;
+  }
 
  protected:
   /// Default constructor made protected so that sub-classes can still declare

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -2331,6 +2331,13 @@ class MultibodyTree {
   }
   //@}
 
+  /// Returns the MultibodyTreeSystem that owns this MultibodyTree.
+  /// @pre There is an owning MultibodyTreeSystem.
+  const MultibodyTreeSystem<T>& tree_system() const {
+    DRAKE_DEMAND(tree_system_ != nullptr);
+    return *tree_system_;
+  }
+
   /// (Internal use only) Informs the MultibodyTree how to access its resources
   /// within a Context.
   void set_tree_system(MultibodyTreeSystem<T>* tree_system) {


### PR DESCRIPTION
PR #12352 removed `get_parent_tree()` from MultibodyElement's public API, because MultibodyTree is internal. That broke a Drake client (Anzu) which was using the tree to obtain some needed information.

This PR attempts to address that need without exposing the internal class, by adding `GetParentPlant()` to MultibodyElement's public API returning a MultibodyPlant rather than the internal Tree.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12380)
<!-- Reviewable:end -->
