### PR TITLE
py geometry: Ensure all submodules are part of .all

### DIFF
--- a/bindings/pydrake/all.py
+++ b/bindings/pydrake/all.py
@@ -32,7 +32,6 @@ from .attic.all import *
 from . import getDrakePath
 from .autodiffutils import *
 from .forwarddiff import *
-from .geometry import *
 from .lcm import *
 from .math import *
 from .perception import *
@@ -42,6 +41,7 @@ from .trajectories import *
 
 # Submodules.
 from .common.all import *
+from .geometry.all import *
 # - `examples` does not offer public Drake library symbols.
 from .manipulation.all import *
 from .multibody.all import *

--- a/bindings/pydrake/test/all_test.py
+++ b/bindings/pydrake/test/all_test.py
@@ -101,6 +101,8 @@ class TestAll(unittest.TestCase):
             "cos",
             # geometry
             "SceneGraph",
+            # - render
+            "CameraProperties",
             # lcm
             "DrakeLcm",
             # symbolic


### PR DESCRIPTION
Encountered this as I was working on example label rendering:
https://drakedevelopers.slack.com/archives/C43KX47A9/p1574288100012200

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12383)
<!-- Reviewable:end -->
