### PR TITLE
Ensure compiler is absolute path for compiler-related tests

### DIFF
--- a/common/test/drake_assert_test_compile_variants.sh
+++ b/common/test/drake_assert_test_compile_variants.sh
@@ -17,6 +17,7 @@ fi
 # Make sure we know what C++ compiler to use.
 source "$capture_cc_env"
 [[ ! -z "$BAZEL_CC" ]]
+BAZEL_CC=$(python3 -c 'import os; print(os.path.realpath("'"$BAZEL_CC"'"))')
 command -v "$BAZEL_CC"
 "$BAZEL_CC" --version
 

--- a/tools/cc_toolchain/print_host_settings.sh
+++ b/tools/cc_toolchain/print_host_settings.sh
@@ -11,4 +11,6 @@ fi
 capture_cc_env="$1"
 source "$capture_cc_env"
 
+[[ ! -z "$BAZEL_CC" ]]
+BAZEL_CC=$(python3 -c 'import os; print(os.path.realpath("'"$BAZEL_CC"'"))')
 "$BAZEL_CC" --version


### PR DESCRIPTION
Here is a quick fix while I refactor `//tools/cc_toolchain:capture_cc`. Relates bazelbuild/bazel#10185.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12384)
<!-- Reviewable:end -->
