### PR TITLE
lint: Ignore bazel-kcov artifacts in find_all_sources

### DIFF
--- a/tools/lint/test/util_test.py
+++ b/tools/lint/test/util_test.py
@@ -9,16 +9,16 @@ class UtilTest(unittest.TestCase):
     def test_find(self):
         workspace_dir, relpaths = find_all_sources("drake")
 
-        # Sanity-check workspace_dir.
-        self.assertTrue(workspace_dir.startswith("/"), workspace_dir)
-        self.assertTrue(os.path.isdir(workspace_dir), workspace_dir)
-        workspace = os.path.join(workspace_dir, "WORKSPACE")
-        self.assertTrue(os.path.exists(workspace), workspace)
-        with open(workspace, "r") as workspace_contents:
-            workspace_lines = workspace_contents.readlines()
+        # Sanity-check workspace_dir.  Most of the correctness assertions are
+        # already embedded within the subroutine itself.
+        with open(os.path.join(workspace_dir, "WORKSPACE"), "r") as contents:
+            workspace_lines = contents.readlines()
         self.assertTrue('workspace(name = "drake")\n' in workspace_lines)
 
         # Sanity-check relpaths.
+        # TODO(jwnimmer-tri) Ideally, sanity checking of the paths (e.g., their
+        # len() like we check just below) could live within find_all_sources,
+        # but projects other than Drake might need different heuristics.
         self.assertGreater(len(relpaths), 1_000)
         self.assertLess(len(relpaths), 10_000)
         self.assertTrue('.bazelproject' in relpaths)

--- a/tools/lint/util.py
+++ b/tools/lint/util.py
@@ -36,6 +36,8 @@ def find_all_sources(workspace_name):
                 continue
             _, source_sentinel = one_line.split(" ")
             workspace_root = os.path.dirname(os.path.realpath(source_sentinel))
+            assert workspace_root.startswith("/"), workspace_root
+            assert os.path.isdir(workspace_root), workspace_root
             break
     if not workspace_root:
         raise RuntimeError("Cannot find .bazelproject in MANIFEST")
@@ -63,8 +65,11 @@ def find_all_sources(workspace_name):
         if abs_dirpath.endswith("/third_party"):
             dirs[:] = ()
             continue
-        # Don't recurse into dotfile directories (such as ".git").
+        # Don't recurse into dotfile directories (such as ".git"), nor into
+        # build directories.
         for i, one_dir in reversed(list(enumerate(list(dirs)))):
             if one_dir.startswith("."):
+                dirs.pop(i)
+            elif rel_dirpath == "" and one_dir.startswith("bazel-"):
                 dirs.pop(i)
     return workspace_root, sorted(relpaths)


### PR DESCRIPTION
Improves on #12369.

Tested locally via:
```
mkdir bazel-kcov
cd bazel-kcov
seq 1 10000 | xargs touch 
cd ..
bazel-bin/tools/lint/clang-format-includes --all
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12385)
<!-- Reviewable:end -->
