### PR TITLE
py geometry: Permit casting RenderLabel to int

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -112,6 +112,7 @@ void def_geometry_render(py::module m) {
     render_label
         .def(py::init<int>(), py::arg("value"), doc.RenderLabel.ctor.doc_1args)
         .def("is_reserved", &RenderLabel::is_reserved)
+        .def("__int__", [](const RenderLabel& self) -> int { return self; })
         // EQ(==).
         .def(py::self == py::self)
         .def(py::self == int{})

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -243,6 +243,7 @@ class TestGeometry(unittest.TestCase):
         value = 10
         obj = RenderLabel(value)
 
+        self.assertIs(value, int(obj))
         self.assertEqual(value, obj)
         self.assertEqual(obj, value)
 


### PR DESCRIPTION
Carving out binding modifications necessary for #12388 (for ease of review)

\cc @manuelli @SeanCurtis-TRI

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12390)
<!-- Reviewable:end -->
