### PR TITLE
framework: Improve error message when cloning a non-root Context

### DIFF
--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -697,6 +697,7 @@ drake_cc_googletest(
         "//common:pointer_cast",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_no_throw",
+        "//common/test_utilities:expect_throws_message",
         "//systems/framework/test_utilities:pack_value",
         "//systems/primitives:adder",
         "//systems/primitives:constant_vector_source",

--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -757,6 +757,7 @@ class Context : public ContextBase {
   //@{
 
   /// Returns a deep copy of this Context.
+  /// @throws std::logic_error if this is not the root context.
   // This is just an intentional shadowing of the base class method to return
   // a more convenient type.
   std::unique_ptr<Context<T>> Clone() const {

--- a/systems/framework/context_base.cc
+++ b/systems/framework/context_base.cc
@@ -9,6 +9,12 @@ namespace drake {
 namespace systems {
 
 std::unique_ptr<ContextBase> ContextBase::Clone() const {
+  if (!is_root_context()) {
+      throw std::logic_error(fmt::format(
+          "Context::Clone(): Cannot clone a non-root Context; "
+          "this Context was created by '{}'.", system_name_));
+  }
+
   std::unique_ptr<ContextBase> clone_ptr(CloneWithoutPointers(*this));
   ContextBase& clone = *clone_ptr;
 

--- a/systems/framework/context_base.h
+++ b/systems/framework/context_base.h
@@ -47,7 +47,8 @@ class ContextBase : public internal::ContextMessageInterface {
   ContextBase& operator=(ContextBase&&) = delete;
   /** @} */
 
-  /** Creates an identical copy of the concrete context object. */
+  /** Creates an identical copy of the concrete context object.
+  @throws std::logic_error if this is not the root context. */
   std::unique_ptr<ContextBase> Clone() const;
 
   ~ContextBase() override;

--- a/systems/framework/test/diagram_context_test.cc
+++ b/systems/framework/test/diagram_context_test.cc
@@ -10,6 +10,7 @@
 #include "drake/common/pointer_cast.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/fixed_input_port_value.h"
 #include "drake/systems/framework/leaf_context.h"
@@ -751,6 +752,14 @@ TEST_F(DiagramContextTest, CloneAccuracy) {
   context_->SetAccuracy(unity);
   std::unique_ptr<Context<double>> clone = context_->Clone();
   EXPECT_EQ(clone->get_accuracy().value(), unity);
+}
+
+TEST_F(DiagramContextTest, SubcontextCloneIsError) {
+  const auto& subcontext = context_->GetSubsystemContext(SubsystemIndex{0});
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      subcontext.Clone(), std::logic_error,
+      "Context::Clone..: Cannot clone a non-root Context; "
+      "this Context was created by 'adder0'.");
 }
 
 }  // namespace


### PR DESCRIPTION
The message `abort: Failure at systems/framework/dependency_tracker.cc:238 in RepairTrackerPointers(): condition 'map_entry != tracker_map.end()' failed.` did not help much.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12391)
<!-- Reviewable:end -->
