### PR TITLE
Update recommended bazel version to 1.2

### DIFF
--- a/doc/developers.rst
+++ b/doc/developers.rst
@@ -79,10 +79,10 @@ Drake requires a compiler running in C++17 mode.
 | Operating System                 | Bazel | CMake | C/C++ Compiler      | Java              | Python |
 +==================================+=======+=======+=====================+===================+========+
 +----------------------------------+-------+-------+---------------------+-------------------+--------+
-| Ubuntu 18.04 LTS (Bionic Beaver) | 1.1   | 3.10  | | Clang 6.0         | OpenJDK 11        | 3.6    |
+| Ubuntu 18.04 LTS (Bionic Beaver) | 1.2   | 3.10  | | Clang 6.0         | OpenJDK 11        | 3.6    |
 |                                  |       |       | | GCC 7.4 (default) |                   |        |
 +----------------------------------+       +-------+---------------------+-------------------+--------+
-| macOS Mojave (10.14)             |       | 3.15  | | Apple LLVM 11.0.0 | | AdoptOpenJDK 13 | 3.7    |
+| macOS Mojave (10.14)             |       | 3.16  | | Apple LLVM 11.0.0 | | AdoptOpenJDK 13 | 3.7    |
 |                                  |       |       | | (Xcode 11.2)      | | (HotSpot JVM)   |        |
 +----------------------------------+       |       |                     |                   |        |
 | macOS Catalina (10.15)           |       |       |                     |                   |        |

--- a/setup/ubuntu/source_distribution/install_prereqs.sh
+++ b/setup/ubuntu/source_distribution/install_prereqs.sh
@@ -71,6 +71,6 @@ dpkg_install_from_wget() {
 }
 
 dpkg_install_from_wget \
-  bazel 1.1.0 \
-  https://releases.bazel.build/1.1.0/release/bazel_1.1.0-linux-x86_64.deb \
-  138b47ffd54924e3c0264c65d31d3927803fb9025db4d5b18107df79ee3bda95
+  bazel 1.2.0 \
+  https://releases.bazel.build/1.2.0/release/bazel_1.2.0-linux-x86_64.deb \
+  640fbbd9d6e6f1bb225929c1b5ffcae650560f8ce1208745acd170451926d190


### PR DESCRIPTION
(Prior upgrade: #12124)

We'll leave the minimum unchanged (at 1.1) -- in theory the 1.x series is compatible, so we should not raise the hard minimum absent knowledge of a specific feature that is only in 1.2

Also bump documentation to reflect Drake CI's macOS image's use of CMake version 3.16.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12396)
<!-- Reviewable:end -->
