### PR TITLE
pydrake doxygen: Capture convention for partitioned `*_py.cc` modules

### DIFF
--- a/bindings/pydrake/pydrake_doxygen.h
+++ b/bindings/pydrake/pydrake_doxygen.h
@@ -94,6 +94,12 @@ When testing the values of NumPy matrices, please review the documentation in
 
 - `*_py`: A Python library (can be pure Python or pybind)
   - File Names: `*.py`, `*_py.cc`
+    - Each `*_py.cc` file should only define one package (a module; optionally
+    with multiple submodules under it).
+    - *Note*: If you need to split up a `{module}_py.cc` file for compilation
+    speed and clarity, use `{module}_py_{part}.cc` for source and
+    `{module}_py_{part}.h` for headers, and then include the headers into the
+    original module source file. `{part}` may not necessarily be a submodule.
 
 - `*_pybind`: A C++ library for adding pybind-specific utilities to be consumed
   by C++.


### PR DESCRIPTION
Per discussion with @m-chaturvedi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12403)
<!-- Reviewable:end -->
