### PR TITLE
Add MathematicalProgram::indeterminates_index()

### DIFF
--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -750,10 +750,15 @@ top-level documentation for :py:mod:`pydrake.math`.
           doc.MathematicalProgram.num_vars.doc)
       .def("decision_variables", &MathematicalProgram::decision_variables,
           doc.MathematicalProgram.decision_variables.doc)
+      .def("decision_variable_index",
+          &MathematicalProgram::decision_variable_index,
+          doc.MathematicalProgram.decision_variable_index.doc)
       .def("indeterminates", &MathematicalProgram::indeterminates,
           doc.MathematicalProgram.indeterminates.doc)
       .def("indeterminate", &MathematicalProgram::indeterminate, py::arg("i"),
           doc.MathematicalProgram.indeterminate.doc)
+      .def("indeterminates_index", &MathematicalProgram::indeterminates_index,
+          doc.MathematicalProgram.indeterminates_index.doc)
       .def("EvalBinding",
           [](const MathematicalProgram& prog,
               const Binding<EvaluatorBase>& binding,

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -173,6 +173,8 @@ class TestMathematicalProgram(unittest.TestCase):
 
         self.assertEqual(prog.FindDecisionVariableIndices(vars=[x[0], x[1]]),
                          [0, 1])
+        self.assertEqual(prog.decision_variable_index()[x[0].get_id()], 0)
+        self.assertEqual(prog.decision_variable_index()[x[1].get_id()], 1)
 
         for binding in prog.GetAllCosts():
             self.assertIsInstance(binding.evaluator(), mp.Cost)
@@ -378,10 +380,12 @@ class TestMathematicalProgram(unittest.TestCase):
         # d(0) + d(1) = 1
         prog = mp.MathematicalProgram()
         x = prog.NewIndeterminates(1, "x")
+        self.assertEqual(prog.indeterminates_index()[x[0].get_id()], 0)
         poly = prog.NewFreePolynomial(sym.Variables(x), 1)
         (poly, binding) = prog.NewSosPolynomial(
             indeterminates=sym.Variables(x), degree=2)
         y = prog.NewIndeterminates(1, "y")
+        self.assertEqual(prog.indeterminates_index()[y[0].get_id()], 1)
         (poly, binding) = prog.NewSosPolynomial(
             monomial_basis=(sym.Monomial(x[0]), sym.Monomial(y[0])))
         d = prog.NewContinuousVariables(2, "d")

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -2700,12 +2700,21 @@ class MathematicalProgram {
   }
 
   /**
-   * Returns the mapping from a decision variable to its index in the vector,
-   * containing all the decision variables in the optimization program.
+   * Returns the mapping from a decision variable ID to its index in the vector
+   * containing all the decision variables in the mathematical program.
    */
   const std::unordered_map<symbolic::Variable::Id, int>&
   decision_variable_index() const {
     return decision_variable_index_;
+  }
+
+  /**
+   * Returns the mapping from an indeterminate ID to its index in the vector
+   * containing all the indeterminates in the mathematical program.
+   */
+  const std::unordered_map<symbolic::Variable::Id, int>& indeterminates_index()
+      const {
+    return indeterminates_index_;
   }
 
  private:

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -394,6 +394,23 @@ GTEST_TEST(TestAddDecisionVariables, AddDecisionVariables1) {
   EXPECT_EQ(prog.FindDecisionVariableIndex(x2), 2);
   EXPECT_EQ(prog.initial_guess().rows(), 3);
   EXPECT_EQ(prog.decision_variables().rows(), 3);
+
+  const auto decision_variable_index = prog.decision_variable_index();
+  {
+    const auto it = decision_variable_index.find(x0.get_id());
+    ASSERT_TRUE(it != decision_variable_index.end());
+    EXPECT_EQ(it->second, prog.FindDecisionVariableIndex(x0));
+  }
+  {
+    const auto it = decision_variable_index.find(x1.get_id());
+    ASSERT_TRUE(it != decision_variable_index.end());
+    EXPECT_EQ(it->second, prog.FindDecisionVariableIndex(x1));
+  }
+  {
+    const auto it = decision_variable_index.find(x2.get_id());
+    ASSERT_TRUE(it != decision_variable_index.end());
+    EXPECT_EQ(it->second, prog.FindDecisionVariableIndex(x2));
+  }
 }
 
 GTEST_TEST(TestAddDecisionVariables, AddVariable2) {
@@ -490,9 +507,17 @@ GTEST_TEST(TestAddIndeterminates, AddIndeterminates1) {
   prog.AddIndeterminates(VectorIndeterminate<3>(x0, x1, x2));
   const VectorIndeterminate<3> indeterminates_expected(x0, x1, x2);
   EXPECT_EQ(prog.indeterminates().rows(), 3);
+
+  const auto indeterminates_index = prog.indeterminates_index();
   for (int i = 0; i < 3; ++i) {
     EXPECT_TRUE(prog.indeterminates()(i).equal_to(indeterminates_expected(i)));
     EXPECT_EQ(prog.FindIndeterminateIndex(indeterminates_expected(i)), i);
+
+    const auto it =
+        indeterminates_index.find(indeterminates_expected(i).get_id());
+    ASSERT_TRUE(it != indeterminates_index.end());
+    EXPECT_EQ(it->second,
+              prog.FindIndeterminateIndex(indeterminates_expected(i)));
   }
 }
 


### PR DESCRIPTION
I need this method in a project using Drake. It's symmetric to have this one given the existing `decision_variable_index()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12405)
<!-- Reviewable:end -->
