### PR TITLE
solvers: Add package_library decorations for fbstab

### DIFF
--- a/solvers/fbstab/BUILD.bazel
+++ b/solvers/fbstab/BUILD.bazel
@@ -1,11 +1,23 @@
+# -*- python -*-
+
 load(
     "@drake//tools/skylark:drake_cc.bzl",
     "drake_cc_googletest",
     "drake_cc_library",
+    "drake_cc_package_library",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 package(default_visibility = ["//visibility:public"])
+
+drake_cc_package_library(
+    name = "fbstab",
+    deps = [
+        ":fbstab_algorithm",
+        ":fbstab_dense",
+        ":fbstab_mpc",
+    ],
+)
 
 # libraries
 drake_cc_library(

--- a/solvers/fbstab/components/BUILD.bazel
+++ b/solvers/fbstab/components/BUILD.bazel
@@ -1,11 +1,34 @@
+# -*- python -*-
+
 load(
     "@drake//tools/skylark:drake_cc.bzl",
     "drake_cc_googletest",
     "drake_cc_library",
+    "drake_cc_package_library",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 package(default_visibility = ["//solvers/fbstab:__pkg__"])
+
+drake_cc_package_library(
+    name = "components",
+    visibility = [
+        "//solvers/fbstab:__pkg__",
+        "//tools/install/libdrake:__pkg__",
+    ],
+    deps = [
+        ":dense_data",
+        ":dense_feasibility",
+        ":dense_linear_solver",
+        ":dense_residual",
+        ":dense_variable",
+        ":mpc_data",
+        ":mpc_feasibility",
+        ":mpc_residual",
+        ":mpc_variable",
+        ":riccati_linear_solver",
+    ],
+)
 
 drake_cc_library(
     name = "dense_data",

--- a/tools/install/libdrake/build_components.bzl
+++ b/tools/install/libdrake/build_components.bzl
@@ -93,9 +93,8 @@ LIBDRAKE_COMPONENTS = [
     "//multibody/triangle_quadrature",
     "//perception",
     "//solvers",
-    "//solvers/fbstab:fbstab_algorithm",  # unpackaged
-    "//solvers/fbstab:fbstab_dense",  # unpackaged
-    "//solvers/fbstab:fbstab_mpc",  # unpackaged
+    "//solvers/fbstab",
+    "//solvers/fbstab/components",
     "//systems/analysis",
     "//systems/controllers",
     "//systems/estimators",
@@ -107,14 +106,4 @@ LIBDRAKE_COMPONENTS = [
     "//systems/rendering",
     "//systems/sensors",
     "//systems/trajectory_optimization",
-    # //solvers/fbstab/components:dense_data (indirectly)
-    # //solvers/fbstab/components:dense_feasibility (indirectly)
-    # //solvers/fbstab/components:dense_linear_solver (indirectly)
-    # //solvers/fbstab/components:dense_residual (indirectly)
-    # //solvers/fbstab/components:dense_variable (indirectly)
-    # //solvers/fbstab/components:mpc_data (indirectly)
-    # //solvers/fbstab/components:mpc_feasibility (indirectly)
-    # //solvers/fbstab/components:mpc_residual (indirectly)
-    # //solvers/fbstab/components:mpc_variable (indirectly)
-    # //solvers/fbstab/components:riccati_linear_solver (indirectly)
 ]


### PR DESCRIPTION
This one has been bugging me for a while.  The `build_components.bzl` should tend toward consistency and compactness, not a list of special cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12407)
<!-- Reviewable:end -->
