### PR TITLE
doc: Add past release notes

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -17,5 +17,4 @@ You can choose to download a pre-compiled version of Drake, or to build it from 
 	from_binary
 	from_source
 	docker
-
-
+	release_notes/release_notes

--- a/doc/release_notes/release_notes.rst
+++ b/doc/release_notes/release_notes.rst
@@ -1,0 +1,12 @@
+.. _release_notes:
+
+*************
+Release Notes
+*************
+
+.. toctree::
+    :maxdepth: 1
+
+    v0.10.0
+    v0.11.0
+    v0.12.0

--- a/doc/release_notes/v0.10.0.rst
+++ b/doc/release_notes/v0.10.0.rst
@@ -1,0 +1,19 @@
+*************
+Drake v0.10.0
+*************
+
+Nearly four years have passed since the 0.9.x releases, and almost all of the code has been rewritten, so the changes are various and many.
+
+Some of the more recent or substantial changes include:
+
+* Expanded `Dynamical Systems <https://drake.mit.edu/doxygen_cxx/group__systems.html>`__ APIs and features; now supports Python and/or C++.
+* Expanded `MathematicalProgram <https://drake.mit.edu/doxygen_cxx/group__solvers.html>`__ APIs and features, supported problems, and the suite of solver implementations.
+* Added `MultibodyPlant dynamics <https://drake.mit.edu/doxygen_cxx/group__multibody.html>`__ (RigidBodyPlant is no longer actively maintained).
+* Added camera and depth simulation (RgbdSensor) and geometric queries (SceneGraph).
+* Reworked examples.
+* Supports Ubuntu 16, Ubuntu 18, and macOS (see `Supported Configurations <https://drake.mit.edu/developers.html#supported-configurations>`__ documentation for details).
+* Removed support for MATLAB; removed support for Windows.
+
+This release provides pre-compiled binaries named ``drake-20190905-{bionic|xenial|mac}.tar.gz``. See https://drake.mit.edu/from\_binary.html#nightly-releases for instructions on how to use them.
+
+Drake binary releases incorporate a pre-compiled version of `SNOPT <https://ccom.ucsd.edu/~optimizers/solvers/snopt/>`__ as part of the `Mathematical Program toolbox <https://drake.mit.edu/doxygen_cxx/group__solvers.html>`__. Thanks to Philip E. Gill and Elizabeth Wong for their kind support.

--- a/doc/release_notes/v0.11.0.rst
+++ b/doc/release_notes/v0.11.0.rst
@@ -1,0 +1,163 @@
+*************
+Drake v0.11.0
+*************
+
+Announcements
+-------------
+
+This is the final release that will support Python 2, C++14, Ubuntu 16.04, or macOS High Sierra. Future releases will require Python 3, C++17, and one of either Ubuntu 18.04 or macOS Mojave (or newer). See `#10606`_ for details.
+
+Changes since v0.10.0
+---------------------
+
+Dynamical Systems
+~~~~~~~~~~~~~~~~~
+
+* New `tutorial for systems framework <https://nbviewer.jupyter.org/github/RobotLocomotion/drake/blob/master/tutorials/dynamical_systems.ipynb>`__ (`#12009`_, `#12045`_)
+* Implicit Euler integrator improves convergence speed (`#12018`_)
+* ``SymbolicVectorSystem`` adds parameters and accessors (`#12012`_, `#12048`_)
+* Fix: Graphviz output for diagram port names (`#12060`_)
+
+Mathematical Program
+~~~~~~~~~~~~~~~~~~~~
+
+* New `tutorial for mathematical program <https://nbviewer.jupyter.org/github/RobotLocomotion/drake/blob/master/tutorials/mathematical_program.ipynb>`__ (`#12023`_, `#12032`_)
+* Developers can now implement ``SolverInterface`` subclasses in pydrake (`#12056`_)
+* Add constructors of ``MultipleShooting`` that accept placeholders (`#12051`_)
+* Add alias ``solvers::DecisionVariable`` for ``symbolic::Variable`` (`#12051`_)
+* Improve SNOPT citations and credits (`#12062`_)
+
+Multibody Dynamics
+~~~~~~~~~~~~~~~~~~
+
+* New hydroelastic contact model in progress (`#11924`_, `#11928`_, `#11986`_, `#11996`_, `#12029`_, `#12036`_, `#12082`_, `#12083`_, `#12085`_, `#12093`_, `#12094`_, `#12096`_, `#12100`_, `#12101`_, `#12103`_, `#12112`_)
+
+  * This is experimental and will change in the near future! (And it will not be used by default.)
+  * Hydroelastics only supports soft-hard contact with spheres; see demo at ``examples/multibody/rolling_sphere``.
+  * For more information, see Elandt, et al. “A pressure field model for fast, robust approximation of net contact force and moment between nominally rigid objects” to appear in IROS 2019. `ArXiv pre-print <https://arxiv.org/abs/1904.11433>`__.
+
+* Add ``ContactResults`` output for continuous plant (previously, only discrete) (`#12067`_)
+* Fix: Gravity generalized forces must ignore velocity terms (`#12065`_)
+* Fix: Contact force direction appears to be incorrect (`#12067`_)
+* Fix: Crash when there are no degrees of freedom (`#12070`_)
+* Cache generalized accelerations for both continuous and discrete models (`#12050`_)
+
+pydrake bindings
+~~~~~~~~~~~~~~~~
+
+* ``multibody.LinearSpringDamper`` (`#11987`_)
+* ``solvers.mathematicalprogram.MathematicalProgram.AddIndeterminates`` (`#12017`_)
+* ``solvers.mathematicalprogram.MathematicalProgram.AddDecisionVariables`` (`#12017`_)
+* ``solvers.mathematicalprogram.SolverInterface`` (`#12056`_)
+* ``systems.controllers.PidController`` (`#12020`_, `#12030`_)
+* ``systems.controllers.PidControlledSystem`` (`#12020`_, `#12030`_)
+
+Build system
+~~~~~~~~~~~~
+
+* Suggest Bionic as our preference (not Xenial) (`#12074`_)
+* Remove ``snopt`` support for upstream BUILD files (`#12098`_)
+* Add warning about ``pytorch``'s use of ``RTLD_GLOBAL`` (`#12108`_)
+* Fix: ``libstdc++6-7-dbg`` dependency typo in Ubuntu 18.04 (`#12013`_)
+* Fix: Suppress "self-assign-overloaded" warnings for Apple LLVM >= 10.0.1 (`#12092`_)
+* Permit downstream projects to use ``ExecuteExtraPythonCode`` (`#12000`_)
+
+Dependencies
+^^^^^^^^^^^^
+
+* Add ``ghc::filesystem`` as a new dependency (`#12106`_, `#12116`_)
+* Add ``suitesparse`` as a new dependency (`#12071`_, `#12072`_)
+* Expand ``jupyter`` dependency to add ``jupyter-notebook`` (`#12043`_)
+* Update ``buildifier`` to latest release 0.29.0 (`#12014`_)
+* Update ``fcl`` to latest commit (`#12054`_)
+* Update ``fmt`` to latest release 6.0.0 (`#12014`_)
+* Update ``ignition_math`` to latest release 6.4.0 (`#12014`_)
+* Update ``meshcat`` to latest commit (`#12014`_)
+* Update ``osqp`` to latest release 0.6.0 (`#12047`_)
+* Update ``qdldl`` to latest release 0.1.4 (`#12047`_)
+* Update ``semantic_version`` to latest version 2.8.2 (`#12041`_)
+* Update ``scs`` to latest release 2.1.1 (`#12084`_)
+* Update ``stx`` to latest commit (`#12014`_)
+* Remove unused ``ignition_rndf`` dependency (`#12014`_, `#12024`_)
+
+Other
+-----
+
+* Update camera extrinsics in manipulation station class setup (`#12089`_)
+* Draw body frames in meshcat visualizer (`#12090`_)
+
+Newly-deprecated APIs
+---------------------
+
+* ``Simulator::StepTo`` (`#12008`_)
+
+  * Use ``Simulator::AdvanceTo``.
+
+Removal of deprecated APIs
+--------------------------
+
+* ``MultibodyPlant::AddForceElement<UniformGravityFieldElement>`` (`#11987`_)
+
+Binaries
+--------
+
+This release provides pre-compiled binaries named ``drake-20191002-{bionic|xenial|mac}.tar.gz``. See https://drake.mit.edu/from\_binary.html#nightly-releases for instructions on how to use them.
+
+Drake binary releases incorporate a pre-compiled version of `SNOPT <https://ccom.ucsd.edu/~optimizers/solvers/snopt/>`__ as part of the `Mathematical Program toolbox <https://drake.mit.edu/doxygen_cxx/group__solvers.html>`__. Thanks to Philip E. Gill and Elizabeth Wong for their kind support.
+
+.. _#10606: https://github.com/RobotLocomotion/drake/pull/10606
+.. _#11924: https://github.com/RobotLocomotion/drake/pull/11924
+.. _#11928: https://github.com/RobotLocomotion/drake/pull/11928
+.. _#11986: https://github.com/RobotLocomotion/drake/pull/11986
+.. _#11987: https://github.com/RobotLocomotion/drake/pull/11987
+.. _#11996: https://github.com/RobotLocomotion/drake/pull/11996
+.. _#12000: https://github.com/RobotLocomotion/drake/pull/12000
+.. _#12008: https://github.com/RobotLocomotion/drake/pull/12008
+.. _#12009: https://github.com/RobotLocomotion/drake/pull/12009
+.. _#12012: https://github.com/RobotLocomotion/drake/pull/12012
+.. _#12013: https://github.com/RobotLocomotion/drake/pull/12013
+.. _#12014: https://github.com/RobotLocomotion/drake/pull/12014
+.. _#12017: https://github.com/RobotLocomotion/drake/pull/12017
+.. _#12018: https://github.com/RobotLocomotion/drake/pull/12018
+.. _#12020: https://github.com/RobotLocomotion/drake/pull/12020
+.. _#12023: https://github.com/RobotLocomotion/drake/pull/12023
+.. _#12024: https://github.com/RobotLocomotion/drake/pull/12024
+.. _#12029: https://github.com/RobotLocomotion/drake/pull/12029
+.. _#12030: https://github.com/RobotLocomotion/drake/pull/12030
+.. _#12032: https://github.com/RobotLocomotion/drake/pull/12032
+.. _#12036: https://github.com/RobotLocomotion/drake/pull/12036
+.. _#12041: https://github.com/RobotLocomotion/drake/pull/12041
+.. _#12043: https://github.com/RobotLocomotion/drake/pull/12043
+.. _#12045: https://github.com/RobotLocomotion/drake/pull/12045
+.. _#12047: https://github.com/RobotLocomotion/drake/pull/12047
+.. _#12048: https://github.com/RobotLocomotion/drake/pull/12048
+.. _#12050: https://github.com/RobotLocomotion/drake/pull/12050
+.. _#12051: https://github.com/RobotLocomotion/drake/pull/12051
+.. _#12054: https://github.com/RobotLocomotion/drake/pull/12054
+.. _#12056: https://github.com/RobotLocomotion/drake/pull/12056
+.. _#12060: https://github.com/RobotLocomotion/drake/pull/12060
+.. _#12062: https://github.com/RobotLocomotion/drake/pull/12062
+.. _#12065: https://github.com/RobotLocomotion/drake/pull/12065
+.. _#12067: https://github.com/RobotLocomotion/drake/pull/12067
+.. _#12070: https://github.com/RobotLocomotion/drake/pull/12070
+.. _#12071: https://github.com/RobotLocomotion/drake/pull/12071
+.. _#12072: https://github.com/RobotLocomotion/drake/pull/12072
+.. _#12074: https://github.com/RobotLocomotion/drake/pull/12074
+.. _#12082: https://github.com/RobotLocomotion/drake/pull/12082
+.. _#12083: https://github.com/RobotLocomotion/drake/pull/12083
+.. _#12084: https://github.com/RobotLocomotion/drake/pull/12084
+.. _#12085: https://github.com/RobotLocomotion/drake/pull/12085
+.. _#12089: https://github.com/RobotLocomotion/drake/pull/12089
+.. _#12090: https://github.com/RobotLocomotion/drake/pull/12090
+.. _#12092: https://github.com/RobotLocomotion/drake/pull/12092
+.. _#12093: https://github.com/RobotLocomotion/drake/pull/12093
+.. _#12094: https://github.com/RobotLocomotion/drake/pull/12094
+.. _#12096: https://github.com/RobotLocomotion/drake/pull/12096
+.. _#12098: https://github.com/RobotLocomotion/drake/pull/12098
+.. _#12100: https://github.com/RobotLocomotion/drake/pull/12100
+.. _#12101: https://github.com/RobotLocomotion/drake/pull/12101
+.. _#12103: https://github.com/RobotLocomotion/drake/pull/12103
+.. _#12106: https://github.com/RobotLocomotion/drake/pull/12106
+.. _#12108: https://github.com/RobotLocomotion/drake/pull/12108
+.. _#12112: https://github.com/RobotLocomotion/drake/pull/12112
+.. _#12116: https://github.com/RobotLocomotion/drake/pull/12116

--- a/doc/release_notes/v0.12.0.rst
+++ b/doc/release_notes/v0.12.0.rst
@@ -1,0 +1,482 @@
+*************
+Drake v0.12.0
+*************
+
+Announcements
+-------------
+
+This release requires Python 3, C++17, and one of either Ubuntu 18.04 or macOS Mojave (or newer). Older platforms and toolchains are no longer supported.
+
+Breaking changes since v0.11.0
+------------------------------
+
+These are breaking changes that did not undergo a deprecation period:
+
+* Use dynamic (not static) friction coefficient while computing point contact, i.e., the static coefficient of friction is ignored from both URDF/SDF files when using a discrete MultibodyPlant model with point contact (`#12109`_).
+* Previously, in ``*.sdf`` files a ``<static>`` element within a ``<model>`` was ignored, but is now being parsed. Users with invalid ``*.sdf`` files might receive error messages. The correct solution is to remove the tag (if everything is already welded to the world), or remove any redundant welds (`#12226`_).
+* drake::multibody::ContactResults methods AddContactInfo and Clear are removed (`#12249`_).
+* Rename ImplicitStribeck to Tamsi to match notation in arXiv paper (`#12053`_):
+
+  * drake::multibody::ImplicitStribeckSolver is now named TamsiSolver
+  * drake::multibody::ImplicitStribeckSolverParameters is now named TamsiSolverParameters
+  * drake::multibody::ImplicitStribeckSolverResults is now named TamsiSolverResults
+
+* Users who compile Drake from source as a bazel external (as in the `drake_bazel_external`_ pattern) must set ``build --incompatible_remove_legacy_whole_archive=false`` in their project’s ``.bazelrc`` for now (`#12150`_).
+* Remove installed stx headers and stx-config.cmake; Drake no longer provides stx (`#12246`_).
+
+Changes since v0.11.0:
+----------------------
+
+Dynamical Systems
+~~~~~~~~~~~~~~~~~
+
+New features
+
+* Add Dormand-Prince (RK45) integrator (`#12223`_)
+* Add monitor callback for Simulator trajectories (`#12213`_)
+* Add GetMyContextFromRoot methods for subsystems (`#12237`_)
+
+Fixes
+
+* Fix: Implicit Euler and 1-stage Radau now match (`#12088`_)
+* Fix: Guard against NaN in integrators (`#12217`_, `#12263`_)
+* Fix: Improve PiecewisePolynomial error message (`#12183`_)
+
+Mathematical Program
+~~~~~~~~~~~~~~~~~~~~
+
+No changes.
+
+Multibody Dynamics
+~~~~~~~~~~~~~~~~~~
+
+New features
+
+* Add MultibodyPlant reaction_forces output port (`#12123`_)
+* Add MultibodyPlant generalized_contact_forces output port support when using continuous time (`#12162`_)
+* Add MultibodyPlant method GetActutationFromArray (`#12011`_)
+* Add SceneGraph boolean query HasCollisions (`#12211`_)
+* Add multibody ``*.sdf`` parsing support for link initial poses during CreateDefaultContext (`#12226`_)
+* Add multibody ``*.sdf`` parser support for the ``<static>`` element within a ``<model>``; note that "freezing" articulated joints is not supported (`#12226`_)
+* Add partial multibody geometry support for the capsule primitive, including urdf parsing (`#12254`_), sdf parsing with custom drake:capsule tag (`#12258`_), visualization (`#12235`_), and vtk and ospray sensor rendering (`#12293`_, `#12305`_)
+* Add partial multibody geometry support for the ellipsoid primitive (`#12256`_, `#12323`_)
+
+Fixes
+
+* Fix: Enforce sensible shape specifications (`#12172`_)
+* Fix: Improve documentation of Jacobians (`#12135`_, `#12192`_), SpatialAcceleration (`#12297`_), and model instances (`#12269`_)
+
+New hydroelastic contact model in progress (`#12102`_, `#12114`_, `#12163`_, `#12184`_, `#12190`_, `#12193`_, `#12212`_, `#12233`_, `#12245`_, `#12285`_, `#12311`_):
+
+* This is experimental and will change in the near future! (And it will not be used by default.)
+* Hydroelastics only supports soft-hard contact with spheres; see demo at ``examples/multibody/rolling_sphere``.
+* For more information, see Elandt, et al. "A pressure field model for fast, robust approximation of net contact force and moment between nominally rigid objects" to appear in IROS 2019. `ArXiv pre-print <https://arxiv.org/abs/1904.11433>`__.
+
+Miscellaneous features and fixes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Add vector_gen support for yaml input format (`#12228`_, `#12244`_)
+* Add DRAKE_LOGGER_TRACE and DRAKE_LOGGER_DEBUG macros (`#12309`_)
+* Add DRAKE_EXPECT_NO_THROW helper macros (`#12242`_)
+* Add planar_scenegraph_visualizer to pydrake (`#12218`_)
+* Fix: In meshcat visualizer, use correct frame for world geometry (`#12129`_)
+
+pydrake bindings
+~~~~~~~~~~~~~~~~
+
+* pydrake.autodiffutils.initializeAutoDiffGivenGradientMatrix (`#12229`_)
+* pydrake.geometry.Box.width (`#12185`_)
+* pydrake.geometry.Box.depth (`#12185`_)
+* pydrake.geometry.Box.height (`#12185`_)
+* pydrake.geometry.Box.size (`#12185`_)
+* pydrake.geometry.Cylinder.get_length (`#12185`_)
+* pydrake.geometry.Cylinder.get_radius (`#12185`_)
+* pydrake.geometry.SceneGraph.model_inspector (`#12177`_)
+* pydrake.geometry.SceneGraphInspector.GetAllGeometryIds (`#12177`_)
+* pydrake.geometry.SceneGraphInspector.GetFrameId (`#12177`_)
+* pydrake.geometry.SceneGraphInspector.GetGeometryIdByName (`#12177`_)
+* pydrake.geometry.SceneGraphInspector.GetNameByFrameId (`#12177`_)
+* pydrake.geometry.SceneGraphInspector.GetNameByGeometryId (`#12177`_)
+* pydrake.geometry.SceneGraphInspector.GetPoseInFrame (`#12177`_)
+* pydrake.geometry.SceneGraphInspector.GetShape (`#12177`_)
+* pydrake.geometry.SceneGraphInspector.num_frames (`#12177`_)
+* pydrake.geometry.SceneGraphInspector.num_geometries (`#12177`_)
+* pydrake.geometry.SceneGraphInspector.num_sources (`#12177`_)
+* pydrake.geometry.Sphere.get_radius (`#12185`_)
+* pydrake.math.RotationMatrix.ToAngleAxis (`#12313`_)
+* pydrake.multibody.inverse_kinematics.InverseKinematics.context (`#12232`_)
+* pydrake.multibody.inverse_kinematics.InverseKinematics.get_mutable_context (`#12232`_)
+* pydrake.multibody.plant.CalcContactFrictionFromSurfaceProperties (`#12219`_)
+* pydrake.multibody.plant.CoulombFriction.dynamic_friction (`#12219`_)
+* pydrake.multibody.plant.CoulombFriction.static_friction (`#12219`_)
+* pydrake.multibody.plant.MultibodyPlant.CalcJacobianAngularVelocity (`#12229`_)
+* pydrake.multibody.plant.MultibodyPlant.CalcJacobianTranslationalVelocity (`#12229`_)
+* pydrake.multibody.plant.MultibodyPlant.GetBodyFrameIdOrThrow (`#12177`_)
+* pydrake.multibody.plant.MultibodyPlant.default_coulomb_friction (`#12219`_)
+* pydrake.multibody.plant.MultibodyPlant.num_collision_geometries (`#12219`_)
+* pydrake.multibody.tree.RigidBody.default_com (`#12209`_)
+* pydrake.multibody.tree.RigidBody.default_mass (`#12209`_)
+* pydrake.multibody.tree.RigidBody.default_spatial_inertia (`#12209`_)
+* pydrake.multibody.tree.RigidBody.default_unit_inertia (`#12209`_)
+* pydrake.solvers.mathematicalprogram.EvaluatorBase.SetGradientSparsityPattern (`#12232`_)
+* pydrake.solvers.mathematicalprogram.EvaluatorBase.gradient_sparsity_pattern (`#12232`_)
+* Add pydrake.systems.sensors.CameraInfo support for pickling (`#12131`_)
+
+Build system and dependencies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Add macOS Catalina (10.15) support (`#12148`_, `#12194`_)
+* Require C++ >= 17 (`#12240`_), Bazel >= 1.1 (`#12124`_, `#12224`_, `#12239`_), and CMake >= 3.10 (`#12239`_)
+* Upgrade spdlog to latest release 1.4.2 and switch to building shared library, not header-only (`#12322`_)
+* Update sdformat to latest release 8.4.0 (`#12268`_)
+* Update gtest to latest release 1.10.0 (`#12267`_)
+* Update clang-cindex-python3 to latest commit (`#12321`_)
+* Update dependency minimum versions in drake-config.cmake (`#12195`_)
+* Remove dependency on stx (`#12246`_)
+* Change dReal to private dependency compiled from source (`#12186`_)
+* Set FMT_USE_GRISU=1 for fmt (`#12318`_)
+* Install sdf data of the planar gripper (`#12176`_)
+* Fix: Install and use find-module for GFlags (`#12205`_, `#12216`_, `#12250`_)
+* Fix: Install and use find-module for TinyXML2 (`#12195`_)
+* Fix: Incompatibilities between Eigen <= 3.3.7 and Apple LLVM 11.0.0 (`#12133`_)
+* Fix: Incompatibilities with NumPy 1.17.0 (`#12153`_)
+* Remove support for macOS High Sierra (10.13) (`#12194`_)
+* Remove support for Ubuntu Xenial (16.04) (`#12238`_)
+* Remove support for Python 2 (`#12126`_, `#12138`_, `#12146`_, `#12147`_, `#12243`_, `#12155`_, `#12296`_, `#12320`_).
+
+  * Notably, the Drake-specific bazel command line options ``bazel build --config python2`` and ``bazel build --config python3`` are removed.
+
+Newly-deprecated APIs
+~~~~~~~~~~~~~~~~~~~~~
+
+* DRAKE_SPDLOG_TRACE and DRAKE_SPDLOG_DEBUG (`#12309`_)
+* drake::optional, drake::nullopt (`#12278`_)
+* drake::variant, drake::get, drake::holds_alternative (`#12282`_)
+* drake::logging::HandleSpdlogGflags, i.e., text_logging_gflags (`#12261`_, `#12287`_)
+* drake::multibody::plant::MultibodyPlant::CalcFrameGeometricJacobianExpressedInWorld (`#12197`_)
+* Everything under attic/perception, e.g., RigidBodyPointCloudFilter (`#12292`_)
+* Everything under attic/manipulation/dev, e.g., RemoveTreeViewerWrapper (`#12294`_)
+* Everything under attic/manipulation/scene_generation, e.g., RandomClutterGenerator (`#12294`_)
+* Everything under attic/manipulation/sensors, e.g., Xtion (`#12294`_)
+* Some code under attic/manipulation/util, e.g., SimpleTreeVisualizer (`#12294`_)
+* Everything under attic/systems/robotInterfaces, e.g., QPLocomotionPlan (`#12291`_)
+* Everything under attic/systems/controllers, e.g., InstantaneousQPController (`#12291`_)
+* Everything under examples/valkyrie (`#12170`_)
+* drake:MakeFileInputStreamOrThrow for protobufs (`#12220`_)
+* vector_gen ``*.named_vector`` protobuf input format (`#12228`_)
+* //bindings/pydrake/common:drake_optional_pybind BUILD label (`#12246`_)
+* //bindings/pydrake/common:drake_variant_pybind BUILD label (`#12246`_)
+* //solvers:mathematical_program_lite BUILD label (`#12142`_, `#12149`_)
+* @spruce BUILD label (`#12161`_, `#12178`_, `#12179`_, `#12180`_, `#12182`_)
+* @stx BUILD label (`#12246`_)
+
+Removal of deprecated APIs
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* drake::SpatialForce (`#12301`_)
+
+  * Use Vector6<> instead.
+
+* drake::geometry::FramePoseVector::FramePoseVector taking an Isometry3d (`#12300`_)
+
+  * Use RigidTransform instead of Isometry3.
+
+* drake::geometry::FramePoseVector::set_value taking an Isometry3d (`#12300`_)
+
+  * Use RigidTransform instead of Isometry3.
+
+* drake::geometry::GeometryInstance::GeometryInstance taking an Isometry3d (`#12300`_)
+
+  * Use RigidTransform instead of Isometry3.
+
+* drake::geometry::SceneGraphInspector::all_geometry_ids (`#12300`_)
+
+  * Use GetAllGeometryIds instead.
+
+* drake::geometry::SceneGraphInspector::X_PG (`#12300`_)
+
+  * Use GetPoseInParent instead.
+
+* drake::geometry::SceneGraphInspector::X_FG (`#12300`_)
+
+  * Use GetPoseInFrame instead.
+
+* drake::multibody::MultibodyPlant::CalcPointsGeometricJacobianExpressedInWorld (`#12157`_)
+
+  * Use CalcJacobianTranslationalVelocity().
+
+* drake::multibody::MultibodyPlant::CalcPointsGeometricJacobianExpressedInWorld (`#12157`_)
+
+  * Use CalcJacobianTranslationalVelocity().
+
+* drake::multibody::MultibodyPlant::CalcPointsAnalyticalJacobianExpressedInWorld (`#12171`_)
+
+  * Use CalcJacobianTranslationalVelocity().
+
+* drake::multibody::SceneGraph::Finalize(SceneGraph*) (`#12144`_)
+
+  * Remove the scene_graph argument instead.
+
+* drake::multibody::SceneGraph::RegisterVisualGeometry(..., SceneGraph*) (`#12144`_)
+
+  * Remove the scene_graph argument instead.
+
+* drake::multibody::SceneGraph::RegisterCollisionGeometry(..., SceneGraph*) (`#12144`_)
+
+  * Remove the scene_graph argument instead.
+
+* drake::systems::UniformRandomSource (`#12144`_)
+
+  * Use RandomSource(kUniform, ...) instead.
+
+* drake::systems::GaussianRandomSource (`#12144`_)
+
+  * Use RandomSource(kGaussian, ...) instead.
+
+* drake::systems::ExponentialRandomSource (`#12144`_)
+
+  * Use RandomSource(kExponential, ...) instead.
+
+* drake::systems::controllers::plan_eval (everything in namespace) (`#12143`_)
+
+  * No replacement.
+
+* drake::systems::controllers::qp_inverse_dynamics (everything in namespace) (`#12143`_)
+
+  * No replacement.
+
+* drake::examples::qp_inverse_dynamics (everything in namespace) (`#12143`_)
+
+  * No replacement.
+
+* RigidBodyTreeAliasGroups::LoadFromFile (`#12143`_)
+
+  * Construct the groups using C++ API calls instead.
+
+* pydrake.multibody.collision module (`#12145`_)
+
+  * Use pydrake.attic.multibody.collision instead.
+
+* pydrake.multibody.joints module (`#12145`_)
+
+  * Use pydrake.attic.multibody.joints instead.
+
+* pydrake.multibody.parsers module (`#12145`_)
+
+  * Use pydrake.attic.multibody.parsers instead.
+
+* pydrake.multibody.rigid_body module (`#12145`_)
+
+  * Use pydrake.attic.multibody.rigid_body instead.
+
+* pydrake.multibody.rigid_body_plant module (`#12145`_)
+
+  * Use pydrake.attic.multibody.rigid_body_plant instead.
+
+* pydrake.multibody.rigid_body_tree module (`#12145`_)
+
+  * Use pydrake.attic.multibody.rigid_body_tree instead.
+
+* pydrake.multibody.shapes module (`#12145`_)
+
+  * Use pydrake.attic.multibody.shapes instead.
+
+* pydrake.solvers.ik module (`#12145`_)
+
+  * Use pydrake.attic.solvers.ik instead.
+
+* pydrake.systems.framework.LeafSystem._DeclareAbstractInputPort (`#12181`_)
+
+  * Use DeclareAbstractInputPort (no leading underscore) instead.
+
+* pydrake.systems.framework.LeafSystem._DeclareAbstractInputPort (`#12181`_)
+
+  * Use DeclareAbstractInputPort (no leading underscore) instead.
+
+* pydrake.systems.framework.LeafSystem._DeclareAbstractParameter (`#12181`_)
+
+  * Use DeclareAbstractParameter (no leading underscore) instead.
+
+* pydrake.systems.framework.LeafSystem._DeclareNumericParameter (`#12181`_)
+
+  * Use DeclareNumericParameter (no leading underscore) instead.
+
+* pydrake.systems.framework.LeafSystem._DeclareAbstractOutputPort (`#12181`_)
+
+  * Use DeclareAbstractOutputPort (no leading underscore) instead.
+
+* pydrake.systems.framework.LeafSystem._DeclareVectorInputPort (`#12181`_)
+
+  * Use DeclareVectorInputPort (no leading underscore) instead.
+
+* pydrake.systems.framework.LeafSystem._DeclareVectorOutputPort (`#12181`_)
+
+  * Use DeclareVectorOutputPort (no leading underscore) instead.
+
+* pydrake.systems.framework.LeafSystem._DeclareInitializationEvent (`#12181`_)
+
+  * Use DeclareInitializationEvent (no leading underscore) instead.
+
+* pydrake.systems.framework.LeafSystem._DeclarePeriodicPublish (`#12181`_)
+
+  * Use DeclarePeriodicPublish (no leading underscore) instead.
+
+* pydrake.systems.framework.LeafSystem._DeclarePeriodicDiscreteUpdate (`#12181`_)
+
+  * Use DeclarePeriodicDiscreteUpdate (no leading underscore) instead.
+
+* pydrake.systems.framework.LeafSystem._DeclarePeriodicEvent (`#12181`_)
+
+  * Use DeclarePeriodicEvent (no leading underscore) instead.
+
+* pydrake.systems.framework.LeafSystem._DeclarePerStepEvent (`#12181`_)
+
+  * Use DeclarePerStepEvent (no leading underscore) instead.
+
+* pydrake.systems.framework.LeafSystem._DoPublish (`#12181`_)
+
+  * Use DoPublish (no leading underscore) instead.
+
+* pydrake.systems.framework.LeafSystem._DeclareContinuousState (`#12181`_)
+
+  * Use DeclareContinuousState (no leading underscore) instead.
+
+* pydrake.systems.framework.LeafSystem._DeclareDiscreteState (`#12181`_)
+
+  * Use DeclareDiscreteState (no leading underscore) instead.
+
+* pydrake.systems.framework.LeafSystem._DoCalcTimeDerivatives (`#12181`_)
+
+  * Use DoCalcTimeDerivatives (no leading underscore) instead.
+
+* pydrake.systems.framework.LeafSystem._DoCalcDiscreteVariableUpdates (`#12181`_)
+
+  * Use DoCalcDiscreteVariableUpdates (no leading underscore) instead.
+
+* pydrake.systems.framework.LeafSystem._DeclareAbstractState (`#12181`_)
+
+  * Use DeclareAbstractState (no leading underscore) instead.
+
+* //multibody BUILD label aliases into the attic (`#12159`_)
+
+  * Use the //attic/multibody labels instead.
+
+* Remove F2C build flavor of SNOPT solver, i.e., ``-DWITH_SNOPT=F2C`` in CMake
+  or ``--config snopt_f2c`` in Bazel (`#12299`_)
+
+  * Only the Fortran build flavor is supported from now on.
+
+This release provides pre-compiled binaries named ``drake-20191108-{bionic|mac}.tar.gz``. See https://drake.mit.edu/from_binary.html#nightly-releases for instructions on how to use them
+
+Drake binary releases incorporate a pre-compiled version of `SNOPT <https://ccom.ucsd.edu/~optimizers/solvers/snopt/>`__ as part of the `Mathematical Program toolbox <https://drake.mit.edu/doxygen_cxx/group__solvers.html>`__. Thanks to Philip E. Gill and Elizabeth Wong for their kind support.
+
+.. _drake_bazel_external: https://github.com/RobotLocomotion/drake-external-examples/tree/master/drake_bazel_external
+.. _#12011: https://github.com/RobotLocomotion/drake/pull/12011
+.. _#12053: https://github.com/RobotLocomotion/drake/pull/12053
+.. _#12088: https://github.com/RobotLocomotion/drake/pull/12088
+.. _#12102: https://github.com/RobotLocomotion/drake/pull/12102
+.. _#12109: https://github.com/RobotLocomotion/drake/pull/12109
+.. _#12114: https://github.com/RobotLocomotion/drake/pull/12114
+.. _#12123: https://github.com/RobotLocomotion/drake/pull/12123
+.. _#12124: https://github.com/RobotLocomotion/drake/pull/12124
+.. _#12126: https://github.com/RobotLocomotion/drake/pull/12126
+.. _#12129: https://github.com/RobotLocomotion/drake/pull/12129
+.. _#12131: https://github.com/RobotLocomotion/drake/pull/12131
+.. _#12133: https://github.com/RobotLocomotion/drake/pull/12133
+.. _#12135: https://github.com/RobotLocomotion/drake/pull/12135
+.. _#12138: https://github.com/RobotLocomotion/drake/pull/12138
+.. _#12142: https://github.com/RobotLocomotion/drake/pull/12142
+.. _#12143: https://github.com/RobotLocomotion/drake/pull/12143
+.. _#12144: https://github.com/RobotLocomotion/drake/pull/12144
+.. _#12145: https://github.com/RobotLocomotion/drake/pull/12145
+.. _#12146: https://github.com/RobotLocomotion/drake/pull/12146
+.. _#12147: https://github.com/RobotLocomotion/drake/pull/12147
+.. _#12148: https://github.com/RobotLocomotion/drake/pull/12148
+.. _#12149: https://github.com/RobotLocomotion/drake/pull/12149
+.. _#12150: https://github.com/RobotLocomotion/drake/pull/12150
+.. _#12153: https://github.com/RobotLocomotion/drake/pull/12153
+.. _#12155: https://github.com/RobotLocomotion/drake/pull/12155
+.. _#12157: https://github.com/RobotLocomotion/drake/pull/12157
+.. _#12159: https://github.com/RobotLocomotion/drake/pull/12159
+.. _#12161: https://github.com/RobotLocomotion/drake/pull/12161
+.. _#12162: https://github.com/RobotLocomotion/drake/pull/12162
+.. _#12163: https://github.com/RobotLocomotion/drake/pull/12163
+.. _#12170: https://github.com/RobotLocomotion/drake/pull/12170
+.. _#12171: https://github.com/RobotLocomotion/drake/pull/12171
+.. _#12172: https://github.com/RobotLocomotion/drake/pull/12172
+.. _#12176: https://github.com/RobotLocomotion/drake/pull/12176
+.. _#12177: https://github.com/RobotLocomotion/drake/pull/12177
+.. _#12178: https://github.com/RobotLocomotion/drake/pull/12178
+.. _#12179: https://github.com/RobotLocomotion/drake/pull/12179
+.. _#12180: https://github.com/RobotLocomotion/drake/pull/12180
+.. _#12181: https://github.com/RobotLocomotion/drake/pull/12181
+.. _#12182: https://github.com/RobotLocomotion/drake/pull/12182
+.. _#12183: https://github.com/RobotLocomotion/drake/pull/12183
+.. _#12184: https://github.com/RobotLocomotion/drake/pull/12184
+.. _#12185: https://github.com/RobotLocomotion/drake/pull/12185
+.. _#12186: https://github.com/RobotLocomotion/drake/pull/12186
+.. _#12190: https://github.com/RobotLocomotion/drake/pull/12190
+.. _#12192: https://github.com/RobotLocomotion/drake/pull/12192
+.. _#12193: https://github.com/RobotLocomotion/drake/pull/12193
+.. _#12194: https://github.com/RobotLocomotion/drake/pull/12194
+.. _#12195: https://github.com/RobotLocomotion/drake/pull/12195
+.. _#12197: https://github.com/RobotLocomotion/drake/pull/12197
+.. _#12205: https://github.com/RobotLocomotion/drake/pull/12205
+.. _#12209: https://github.com/RobotLocomotion/drake/pull/12209
+.. _#12211: https://github.com/RobotLocomotion/drake/pull/12211
+.. _#12212: https://github.com/RobotLocomotion/drake/pull/12212
+.. _#12213: https://github.com/RobotLocomotion/drake/pull/12213
+.. _#12216: https://github.com/RobotLocomotion/drake/pull/12216
+.. _#12217: https://github.com/RobotLocomotion/drake/pull/12217
+.. _#12218: https://github.com/RobotLocomotion/drake/pull/12218
+.. _#12219: https://github.com/RobotLocomotion/drake/pull/12219
+.. _#12220: https://github.com/RobotLocomotion/drake/pull/12220
+.. _#12223: https://github.com/RobotLocomotion/drake/pull/12223
+.. _#12224: https://github.com/RobotLocomotion/drake/pull/12224
+.. _#12226: https://github.com/RobotLocomotion/drake/pull/12226
+.. _#12228: https://github.com/RobotLocomotion/drake/pull/12228
+.. _#12229: https://github.com/RobotLocomotion/drake/pull/12229
+.. _#12232: https://github.com/RobotLocomotion/drake/pull/12232
+.. _#12233: https://github.com/RobotLocomotion/drake/pull/12233
+.. _#12235: https://github.com/RobotLocomotion/drake/pull/12235
+.. _#12237: https://github.com/RobotLocomotion/drake/pull/12237
+.. _#12238: https://github.com/RobotLocomotion/drake/pull/12238
+.. _#12239: https://github.com/RobotLocomotion/drake/pull/12239
+.. _#12240: https://github.com/RobotLocomotion/drake/pull/12240
+.. _#12242: https://github.com/RobotLocomotion/drake/pull/12242
+.. _#12243: https://github.com/RobotLocomotion/drake/pull/12243
+.. _#12244: https://github.com/RobotLocomotion/drake/pull/12244
+.. _#12245: https://github.com/RobotLocomotion/drake/pull/12245
+.. _#12246: https://github.com/RobotLocomotion/drake/pull/12246
+.. _#12249: https://github.com/RobotLocomotion/drake/pull/12249
+.. _#12250: https://github.com/RobotLocomotion/drake/pull/12250
+.. _#12254: https://github.com/RobotLocomotion/drake/pull/12254
+.. _#12256: https://github.com/RobotLocomotion/drake/pull/12256
+.. _#12258: https://github.com/RobotLocomotion/drake/pull/12258
+.. _#12261: https://github.com/RobotLocomotion/drake/pull/12261
+.. _#12263: https://github.com/RobotLocomotion/drake/pull/12263
+.. _#12267: https://github.com/RobotLocomotion/drake/pull/12267
+.. _#12268: https://github.com/RobotLocomotion/drake/pull/12268
+.. _#12269: https://github.com/RobotLocomotion/drake/pull/12269
+.. _#12278: https://github.com/RobotLocomotion/drake/pull/12278
+.. _#12282: https://github.com/RobotLocomotion/drake/pull/12282
+.. _#12285: https://github.com/RobotLocomotion/drake/pull/12285
+.. _#12287: https://github.com/RobotLocomotion/drake/pull/12287
+.. _#12291: https://github.com/RobotLocomotion/drake/pull/12291
+.. _#12292: https://github.com/RobotLocomotion/drake/pull/12292
+.. _#12293: https://github.com/RobotLocomotion/drake/pull/12293
+.. _#12294: https://github.com/RobotLocomotion/drake/pull/12294
+.. _#12296: https://github.com/RobotLocomotion/drake/pull/12296
+.. _#12297: https://github.com/RobotLocomotion/drake/pull/12297
+.. _#12299: https://github.com/RobotLocomotion/drake/pull/12299
+.. _#12300: https://github.com/RobotLocomotion/drake/pull/12300
+.. _#12301: https://github.com/RobotLocomotion/drake/pull/12301
+.. _#12305: https://github.com/RobotLocomotion/drake/pull/12305
+.. _#12309: https://github.com/RobotLocomotion/drake/pull/12309
+.. _#12311: https://github.com/RobotLocomotion/drake/pull/12311
+.. _#12313: https://github.com/RobotLocomotion/drake/pull/12313
+.. _#12318: https://github.com/RobotLocomotion/drake/pull/12318
+.. _#12320: https://github.com/RobotLocomotion/drake/pull/12320
+.. _#12321: https://github.com/RobotLocomotion/drake/pull/12321
+.. _#12322: https://github.com/RobotLocomotion/drake/pull/12322
+.. _#12323: https://github.com/RobotLocomotion/drake/pull/12323


### PR DESCRIPTION
As we move to a more collaborative release process, I think it makes sense to prepare the notes in reviewable and build tooling around files in git, instead of google docs or single-editor magic markdown URLs under GitHub /releases.

We can allow any Drake committers to directly push commits to a relnotes PR, and then squash it all down at the end.

If this merges, the plan would be to cull the details from https://github.com/RobotLocomotion/drake/releases and replace it with a hyperlink to https://drake.mit.edu/ for these pages.

Future plan would be to write a python tool to run `git log` and prepare an 80% draft of this document.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12411)
<!-- Reviewable:end -->
