### PR TITLE
Implements ABA forward dynamics.

### DIFF
--- a/common/eigen_types.h
+++ b/common/eigen_types.h
@@ -127,6 +127,11 @@ template <typename Scalar>
 using MatrixUpTo6 =
 Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, 0, 6, 6>;
 
+/// A matrix of 6 rows and dynamic column size up to a maximum of 6, templated
+/// on scalar type.
+template <typename Scalar>
+using Matrix6xUpTo6 = Eigen::Matrix<Scalar, 6, Eigen::Dynamic, 0, 6, 6>;
+
 /// A quaternion templated on scalar type.
 template <typename Scalar>
 using Quaternion = Eigen::Quaternion<Scalar>;

--- a/multibody/math/spatial_force.h
+++ b/multibody/math/spatial_force.h
@@ -203,7 +203,16 @@ class SpatialForce : public SpatialVector<SpatialForce, T> {
 template <typename T>
 inline SpatialForce<T> operator+(
     const SpatialForce<T>& F1_Sp_E, const SpatialForce<T>& F2_Sp_E) {
-  return SpatialForce<T>(F1_Sp_E.get_coeffs() + F2_Sp_E.get_coeffs());
+  return SpatialForce<T>(F1_Sp_E) += F2_Sp_E;
+}
+
+/// Subtracts spatial force `F2_Sp_E ` from `F1_Sp_E`. Both spatial forces act
+/// on the same system or body S, at point P and are expressed in the same frame
+/// E.
+template <typename T>
+inline SpatialForce<T> operator-(
+    const SpatialForce<T>& F1_Sp_E, const SpatialForce<T>& F2_Sp_E) {
+  return SpatialForce<T>(F1_Sp_E) -= F2_Sp_E;
 }
 
 }  // namespace multibody

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -371,6 +371,15 @@ drake_cc_library(
 )
 
 drake_cc_googletest(
+    name = "multibody_plant_forward_dynamics_test",
+    deps = [
+        ":kuka_iiwa_model_tests",
+        ":plant",
+        "//common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
     name = "multibody_plant_hydroelastic_test",
     deps = [
         ":plant",

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -51,6 +51,11 @@ using systems::State;
 
 using drake::math::RigidTransform;
 using drake::math::RotationMatrix;
+using drake::multibody::internal::AccelerationKinematicsCache;
+using drake::multibody::internal::ArticulatedBodyForceBiasCache;
+using drake::multibody::internal::ArticulatedBodyInertiaCache;
+using drake::multibody::internal::PositionKinematicsCache;
+using drake::multibody::internal::VelocityKinematicsCache;
 using drake::multibody::MultibodyForces;
 using drake::multibody::SpatialAcceleration;
 using drake::multibody::SpatialForce;
@@ -1803,6 +1808,45 @@ void MultibodyPlant<T>::CalcTamsiResults(
 }
 
 template <typename T>
+void MultibodyPlant<T>::CalcArticulatedBodyForceBiasCache(
+    const systems::Context<T>& context,
+    ArticulatedBodyForceBiasCache<T>* aba_force_bias_cache) const {
+  DRAKE_DEMAND(aba_force_bias_cache != nullptr);
+
+  // Applied forces including force elements (function of state x) and external
+  // inputs u.
+  MultibodyForces<T> forces(*this);
+  CalcAppliedForces(context, &forces);
+
+  // Add the contribution of contact forces.
+  std::vector<SpatialForce<T>>& Fapp_BBo_W_array = forces.mutable_body_forces();
+  const std::vector<SpatialForce<T>>& Fcontact_BBo_W_array =
+      EvalSpatialContactForcesContinuous(context);
+  for (int i = 0; i < static_cast<int>(Fapp_BBo_W_array.size()); ++i)
+    Fapp_BBo_W_array[i] += Fcontact_BBo_W_array[i];
+
+  // Perform the tip-to-base pass to compute the force bias terms needed by ABA.
+  internal_tree().CalcArticulatedBodyForceBiasCache(context, forces,
+                                                    aba_force_bias_cache);
+}
+
+template <typename T>
+void MultibodyPlant<T>::CalcForwardDynamics(
+    const systems::Context<T>& context,
+    AccelerationKinematicsCache<T>* ac) const {
+  DRAKE_DEMAND(ac != nullptr);
+
+  // Evaluate the ABA cache, function of state x and inputs u.
+  const ArticulatedBodyForceBiasCache<T>& aba_force_bias_cache =
+      EvalArticulatedBodyForceBiasCache(context);
+
+  // Perform the last base-to-tip pass to compute accelerations using the O(n)
+  // ABA.
+  internal_tree().CalcArticulatedBodyAccelerations(context,
+                                                   aba_force_bias_cache, ac);
+}
+
+template <typename T>
 void MultibodyPlant<T>::CalcGeneralizedAccelerations(
     const drake::systems::Context<T>& context, VectorX<T>* vdot) const {
   DRAKE_DEMAND(vdot != nullptr);
@@ -2360,6 +2404,31 @@ void MultibodyPlant<T>::DeclareCacheEntries() {
       },
       {dependency_ticket});
   cache_indexes_.contact_results = contact_results_cache_entry.cache_index();
+
+  // Articulated Body Algorithm (ABA) force bias cache.
+  auto& aba_force_bias_cache_entry = this->DeclareCacheEntry(
+      std::string("ABA force bias cache."),
+      ArticulatedBodyForceBiasCache<T>(internal_tree().get_topology()),
+      &MultibodyPlant<T>::CalcArticulatedBodyForceBiasCache,
+      // ABA computes quantities such as Zplus which are needed for the
+      // computation of acceleration and thus depend on both state and inputs.
+      // All sources include: time, accuracy, state, input ports, and
+      // parameters.
+      {this->all_sources_ticket()});
+  cache_indexes_.aba_force_bias_cache =
+      aba_force_bias_cache_entry.cache_index();
+
+  // Last pass of the ABA for forward dynamics.
+  auto& aba_accelerations_cache_entry = this->DeclareCacheEntry(
+      std::string("ABA accelerations."),
+      AccelerationKinematicsCache<T>(internal_tree().get_topology()),
+      &MultibodyPlant<T>::CalcForwardDynamics,
+      // Accelerations depend on both state and inputs.
+      // All sources include: time, accuracy, state, input ports, and
+      // parameters.
+      {this->all_sources_ticket()});
+  cache_indexes_.aba_accelerations =
+      aba_accelerations_cache_entry.cache_index();
 
   // Cache generalized accelerations.
   auto& vdot_cache_entry = this->DeclareCacheEntry(

--- a/multibody/plant/test/multibody_plant_forward_dynamics_test.cc
+++ b/multibody/plant/test/multibody_plant_forward_dynamics_test.cc
@@ -1,0 +1,152 @@
+#include <limits>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/plant/test/kuka_iiwa_model_tests.h"
+#include "drake/systems/framework/context.h"
+
+using drake::systems::Context;
+
+namespace drake {
+namespace multibody {
+
+class MultibodyPlantTester {
+ public:
+  MultibodyPlantTester() = delete;
+
+  static VectorX<double> CalcGeneralizedAccelerations(
+      const MultibodyPlant<double>& plant, const Context<double>& context) {
+    return plant.EvalForwardDynamics(context).get_vdot();
+  }
+};
+
+namespace {
+
+const double kEpsilon = std::numeric_limits<double>::epsilon();
+
+// Fixture to perform forward dynamics tests on a model of a KUKA Iiwa arm. The
+// base is free.
+class KukaIiwaModelForwardDynamicsTests : public test::KukaIiwaModelTests {
+ protected:
+  // Given the state of the joints in q and v, this method calculates the
+  // forward dynamics for the floating KUKA iiwa robot using the articulated
+  // body algorithm. The pose and spatial velocity of the base are arbitrary.
+  //
+  // @param[in] q robot's joint angles (generalized coordinates).
+  // @param[in] v robot's joint velocities (generalized velocities).
+  // @param[out] vdot generalized accelerations (1st derivative of v).
+  void CalcForwardDynamicsViaArticulatedBodyAlgorithm(
+      const Eigen::Ref<const VectorX<double>>& q,
+      const Eigen::Ref<const VectorX<double>>& v,
+      EigenPtr<VectorX<double>> vdot) {
+    // Update joint positions and velocities.
+    VectorX<double> x(q.size() + v.size());
+    x << q, v;
+    SetState(x);
+    *vdot =
+        MultibodyPlantTester::CalcGeneralizedAccelerations(*plant_, *context_);
+  }
+
+  // This method calculates the forward dynamics for the 7-DOF KUKA iiwa robot
+  // by explicitly solving for the inverse of the mass matrix.
+  //
+  // @param[in] q robot's joint angles (generalized coordinates).
+  // @param[in] v robot's joint velocities (generalized velocities).
+  // @param[out] vdot generalized accelerations (1st derivative of v).
+  void CalcForwardDynamicsViaMassMatrixSolve(
+      const Eigen::Ref<const VectorX<double>>& q,
+      const Eigen::Ref<const VectorX<double>>& v,
+      EigenPtr<VectorX<double>> vdot) {
+    // Update joint positions and velocities.
+    VectorX<double> x(q.size() + v.size());
+    x << q, v;
+    SetState(x);
+
+    // Compute force element contributions.
+    MultibodyForces<double> forces(*plant_);
+    plant_->CalcForceElementsContribution(*context_, &forces);
+
+    // Construct M, the mass matrix.
+    const int nv = plant_->num_velocities();
+    MatrixX<double> M(nv, nv);
+    plant_->CalcMassMatrixViaInverseDynamics(*context_, &M);
+
+    // Compute tau = C(q, v)v - tau_app - ∑ J_WBᵀ(q) Fapp_Bo_W via inverse
+    // dynamics.
+    const VectorX<double> zero_vdot = VectorX<double>::Zero(nv);
+    const VectorX<double> tau_id =
+        plant_->CalcInverseDynamics(*context_, zero_vdot, forces);
+
+    // Solve for vdot.
+    *vdot = M.llt().solve(-tau_id);
+  }
+
+  // Verify the solution obtained using the ABA against a reference solution
+  // computed by explicitly taking the inverse of the mass matrix.
+  void CompareForwardDynamics(const Eigen::Ref<const VectorX<double>>& q,
+                              const Eigen::Ref<const VectorX<double>>& v) {
+    // Compute forward dynamics using articulated body algorithm.
+    VectorX<double> vdot(plant_->num_velocities());
+    CalcForwardDynamicsViaArticulatedBodyAlgorithm(q, v, &vdot);
+
+    // Compute forward dynamics using mass matrix.
+    VectorX<double> vdot_expected(plant_->num_velocities());
+    CalcForwardDynamicsViaMassMatrixSolve(q, v, &vdot_expected);
+
+    // We estimate the difference between vdot and vdot_expected to be in the
+    // order of machine epsilon times the condition number "kappa" of the mass
+    // matrix.
+    const int nv = plant_->num_velocities();
+    MatrixX<double> M(nv, nv);
+    plant_->CalcMassMatrixViaInverseDynamics(*context_, &M);
+    const double kappa = 1.0 / M.llt().rcond();
+
+    // Compare expected results against actual vdot.
+    const double kRelativeTolerance = kappa * kEpsilon;
+    EXPECT_TRUE(CompareMatrices(vdot, vdot_expected, kRelativeTolerance,
+                                MatrixCompareType::relative));
+  }
+};
+
+// This test is used to verify the correctness of the articulated body algorithm
+// for solving forward dynamics. The output from the articulated body algorithm
+// is compared against the output from solving using the mass matrix. We verify
+// the computation for an arbitrary set of robot states.
+TEST_F(KukaIiwaModelForwardDynamicsTests, ForwardDynamicsTest) {
+  // Joint angles and velocities.
+  VectorX<double> q(kNumJoints), qdot(kNumJoints);
+  double q30 = M_PI / 6, q45 = M_PI / 4, q60 = M_PI / 3;
+
+  // Test 1: Static configuration.
+  q << 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0;
+  qdot << 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0;
+  CompareForwardDynamics(q, qdot);
+
+  // Test 2: Another static configuration.
+  q << q30, -q45, q60, -q30, q45, -q60, q30;
+  qdot << 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0;
+  CompareForwardDynamics(q, qdot);
+
+  // Test 3: Non-static configuration.
+  q << 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0;
+  qdot << 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7;
+  CompareForwardDynamics(q, qdot);
+
+  // Test 4: Another non-static configuration.
+  q << -q45, q60, -q30, q45, -q60, q30, -q45;
+  qdot << 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1;
+  CompareForwardDynamics(q, qdot);
+
+  // Test 5: Another non-static configuration.
+  q << q30, q45, q60, -q30, -q45, -q60, 0;
+  qdot << 0.3, -0.1, 0.4, -0.1, 0.5, -0.9, 0.2;
+  CompareForwardDynamics(q, qdot);
+}
+
+// TODO(amcastro-tri): Include test with non-zero actuation and external forces.
+
+}  // namespace
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -54,12 +54,14 @@ drake_cc_library(
     name = "multibody_tree_caches",
     srcs = [
         "acceleration_kinematics_cache.cc",
+        "articulated_body_force_bias_cache.cc",
         "articulated_body_inertia_cache.cc",
         "position_kinematics_cache.cc",
         "velocity_kinematics_cache.cc",
     ],
     hdrs = [
         "acceleration_kinematics_cache.h",
+        "articulated_body_force_bias_cache.h",
         "articulated_body_inertia_cache.h",
         "position_kinematics_cache.h",
         "velocity_kinematics_cache.h",

--- a/multibody/tree/acceleration_kinematics_cache.h
+++ b/multibody/tree/acceleration_kinematics_cache.h
@@ -23,15 +23,14 @@ namespace internal {
 /// Acceleration kinematics results include:
 /// - Spatial acceleration `A_WB` for each body B in the model as measured and
 ///   expressed in the world frame W.
+/// - Generalized accelerations `vdot` for the entire model.
 ///
 /// @tparam T The mathematical type of the context, which must be a valid Eigen
 ///           scalar.
 ///
 /// Instantiated templates for the following kinds of T's are provided:
-///
 /// - double
 /// - AutoDiffXd
-/// - symbolic::Expression
 ///
 /// They are already available to link against in the containing library.
 template <typename T>
@@ -52,6 +51,7 @@ class AccelerationKinematicsCache {
     // to the world body and is defined in multibody_tree_indexes.h.
     // World's acceleration is always zero.
     A_WB_pool_[world_index()].SetZero();
+    vdot_.setZero();
   }
 
   /// Returns a constant reference to the spatial acceleration `A_WB` of the
@@ -87,14 +87,22 @@ class AccelerationKinematicsCache {
     return A_WB_pool_;
   }
 
+  /// Returns a constant reference to the generalized accelerations `vdot` for
+  /// the entire model.
+  const VectorX<T>& get_vdot() const {
+    return vdot_;
+  }
+
+  /// Mutable version of get_vdot().
+  VectorX<T>& get_mutable_vdot() {
+    return vdot_;
+  }
+
  private:
   // Pools store entries in the same order that multibody tree nodes are
   // ordered in the tree, i.e. in BFT (Breadth-First Traversal) order. Therefore
   // clients of this class will access entries by BodyNodeIndex, see
   // `get_A_WB()` for instance.
-
-  // The type of the pools for storing spatial accelerations.
-  typedef std::vector<SpatialAcceleration<T>> SpatialAcceleration_PoolType;
 
   // Helper method to return the number of nodes in this multibody tree cache.
   // It eliminates having to use static_cast<int>() when requesting a pool size.
@@ -106,7 +114,8 @@ class AccelerationKinematicsCache {
   void Allocate(const MultibodyTreeTopology& topology) {
     const int num_nodes = topology.num_bodies();
     A_WB_pool_.resize(num_nodes);
-    DRAKE_ASSERT(static_cast<int>(A_WB_pool_.size()) == num_nodes);
+    const int num_velocities = topology.num_velocities();
+    vdot_.resize(num_velocities);
   }
 
   // Initializes all pools to have NaN values to ease bug detection when entries
@@ -119,7 +128,8 @@ class AccelerationKinematicsCache {
   }
 
   // Number of body nodes in the corresponding MultibodyTree.
-  SpatialAcceleration_PoolType A_WB_pool_;   // Indexed by BodyNodeIndex.
+  std::vector<SpatialAcceleration<T>> A_WB_pool_;  // Indexed by BodyNodeIndex.
+  VectorX<T> vdot_;
 };
 
 DRAKE_DEFINE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN_T(AccelerationKinematicsCache);

--- a/multibody/tree/articulated_body_force_bias_cache.cc
+++ b/multibody/tree/articulated_body_force_bias_cache.cc
@@ -1,0 +1,6 @@
+#include "drake/multibody/tree/articulated_body_force_bias_cache.h"
+
+#include "drake/common/default_scalars.h"
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class drake::multibody::internal::ArticulatedBodyForceBiasCache)

--- a/multibody/tree/articulated_body_force_bias_cache.h
+++ b/multibody/tree/articulated_body_force_bias_cache.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/math/spatial_acceleration.h"
+#include "drake/multibody/math/spatial_force.h"
+#include "drake/multibody/tree/multibody_tree_indexes.h"
+#include "drake/multibody/tree/multibody_tree_topology.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+/// This class is one of the cache entries in the Context. It stores the force
+/// and acceleration bias terms needed by the ABA forward dynamics. Please refer
+/// to @ref internal_forward_dynamics
+/// "Articulated Body Algorithm Forward Dynamics" for further mathematical
+/// background and implementation details. In particular, refer to @ref
+/// abi_and_bias_force "Articulated Body Inertia and Force Bias" for details on
+/// the force bias terms.
+///
+/// @tparam T The mathematical type of the context, which must be a valid Eigen
+///           scalar.
+///
+/// Instantiated templates for the following kinds of T's are provided:
+/// - double
+/// - AutoDiffXd
+/// - symbolic::Expression
+///
+/// They are already available to link against in the containing library.
+template<typename T>
+class ArticulatedBodyForceBiasCache {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ArticulatedBodyForceBiasCache)
+
+  /// Constructs an %ArticulatedBodyForceBiasCache object properly sized to
+  /// store the force bias terms for a model with the given `topology`.
+  explicit ArticulatedBodyForceBiasCache(
+      const MultibodyTreeTopology& topology) :
+      num_nodes_(topology.num_bodies()) {
+    Allocate();
+  }
+
+  /// The articulated body inertia residual force `Zplus_PB_W` for this body
+  /// projected across its inboard mobilizer to frame P.
+  const SpatialForce<T>& get_Zplus_PB_W(BodyNodeIndex body_node_index) const {
+    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
+    return Zplus_PB_W_[body_node_index];
+  }
+
+  /// Mutable version of get_Zplus_PB_W().
+  SpatialForce<T>& get_mutable_Zplus_PB_W(BodyNodeIndex body_node_index) {
+    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
+    return Zplus_PB_W_[body_node_index];
+  }
+
+  /// The spatial acceleration bias `Ab_WB` for body node with index
+  /// `body_node_index` including Coriolis and gyroscopic terms.
+  const SpatialAcceleration<T>& get_Ab_WB(
+      BodyNodeIndex body_node_index) const {
+    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
+    return Ab_WB_[body_node_index];
+  }
+
+  /// Mutable version of get_Ab_WB().
+  SpatialAcceleration<T>& get_mutable_Ab_WB(BodyNodeIndex body_node_index) {
+    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
+    return Ab_WB_[body_node_index];
+  }
+
+  /// The articulated body inertia innovations generalized force `e_B` for this
+  /// body's mobilizer.
+  const VectorUpTo6<T>& get_e_B(BodyNodeIndex body_node_index) const {
+    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
+    return e_B_[body_node_index];
+  }
+
+  /// Mutable version of get_e_B().
+  VectorUpTo6<T>& get_mutable_e_B(BodyNodeIndex body_node_index) {
+    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
+    return e_B_[body_node_index];
+  }
+
+ private:
+  // Allocates resources for this articulated body cache.
+  void Allocate() {
+    Zplus_PB_W_.resize(num_nodes_);
+    Ab_WB_.resize(num_nodes_);
+    e_B_.resize(num_nodes_);
+  }
+
+  // Number of body nodes in the corresponding MultibodyTree.
+  int num_nodes_{0};
+
+  // Pools indexed by BodyNodeIndex.
+  std::vector<SpatialForce<T>> Zplus_PB_W_;
+  std::vector<SpatialAcceleration<T>> Ab_WB_;
+  std::vector<VectorUpTo6<T>> e_B_;
+};
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::internal::ArticulatedBodyForceBiasCache)

--- a/multibody/tree/articulated_body_inertia.h
+++ b/multibody/tree/articulated_body_inertia.h
@@ -21,7 +21,7 @@ namespace multibody {
 /// remarkable `O(n)` Articulated Body Algorithm (ABA) for solving forward
 /// dynamics. Recall that the Newton-Euler equations allow us to describe the
 /// combined rotational and translational dynamics of a rigid body: <pre>
-///   F_BBo_W = M_B_W * A_WB + Fb_Bo_W                                    (1)
+///   F_BBo_W = M_B_W * A_WB + Fb_Bo_W                                     (1)
 /// </pre>
 /// where the spatial inertia (see SpatialInertia) `M_B_W` of body B expressed
 /// in the world frame W linearly relates the spatial acceleration (see
@@ -33,10 +33,12 @@ namespace multibody {
 /// at the base (or root). Even though the bodies in this multibody system are
 /// allowed to have relative motions among them, there still is a linear
 /// relationship between the spatial force `F_BBo_W` applied on this body and
-/// the resulting acceleration `A_WB`: <pre>
-///   F_BBo_W = P_B_W * A_WB + z_Bo_W                                       (2)
+/// the resulting acceleration `A_WB`:
+/// @anchor abi_eq_definition
+/// <pre>
+///   F_BBo_W = P_B_W * A_WB + Z_Bo_W                                       (2)
 /// </pre>
-/// where `P_B_W` is the articulated body inertia of body B and `z_Bo_W` is a
+/// where `P_B_W` is the articulated body inertia of body B and `Z_Bo_W` is a
 /// bias force that includes the gyroscopic and Coriolis forces and becomes zero
 /// when all body velocities and all applied generalized forces outboard
 /// from body B are zero [Jain 2010, §7.2.1]. The articulated body inertia
@@ -103,7 +105,7 @@ class ArticulatedBodyInertia {
 
   /// Default ArticulatedBodyInertia constructor initializes all matrix values
   /// to NaN for a quick detection of uninitialized values.
-  ArticulatedBodyInertia();
+  ArticulatedBodyInertia() = default;
 
   /// Constructs an articulated body inertia for an articulated body consisting
   /// of a single rigid body given its spatial inertia. From an input spatial
@@ -257,7 +259,8 @@ class ArticulatedBodyInertia {
 
     // Update J according to J + (p×)Fᵀ - Fp(p×) = J - ((F(p×))ᵀ + Fp(p×)).
     // Costs 66 flops (54 for cross product and 12 for triangular addition).
-    // TODO(bobbyluig): Optimize to only compute lower triangular region.
+    // TODO(bobbyluig): Optimize to only compute lower triangular region. See
+    // #12435.
     J -= (F.rowwise().cross(px).transpose() + Fp.rowwise().cross(px));
 
     // Overwrite F (in the lower left) with Fp. M doesn't change.
@@ -308,6 +311,16 @@ class ArticulatedBodyInertia {
     return *this;
   }
 
+  /// Subtracts `P_BQ_E` from `this` articulated body inertia. `P_BQ_E` must be
+  /// for the same articulated body B as this ABI (about the same point Q and
+  /// expressed in the same frame E). The resulting inertia will have the same
+  /// properties.
+  ArticulatedBodyInertia<T>&
+  operator-=(const ArticulatedBodyInertia<T>& P_BQ_E) {
+    matrix_.template triangularView<Eigen::Lower>() = matrix_ - P_BQ_E.matrix_;
+    return *this;
+  }
+
   /// Multiplies `this` articulated body inertia on the right by a matrix or
   /// vector.
   ///
@@ -319,6 +332,12 @@ class ArticulatedBodyInertia {
                        OtherDerived>
   operator*(const Eigen::MatrixBase<OtherDerived>& rhs) const {
     return matrix_.template selfadjointView<Eigen::Lower>() * rhs;
+  }
+
+  /// Multiplies `this` articulated body inertia on the right by a spatial
+  /// acceleration. See @ref abi_eq_definition "Eq. (2)" for an example.
+  SpatialForce<T> operator*(const SpatialAcceleration<T>& A_WB_E) const {
+    return SpatialForce<T>((*this) * A_WB_E.get_coeffs());
   }
 
   /// Multiplies `this` articulated body inertia on the left by a matrix or
@@ -365,11 +384,6 @@ class ArticulatedBodyInertia {
   }
 };
 
-// Workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57728 which
-// should be moved back into the class definition once we no longer need to
-// support GCC versions prior to 6.3.
-template <typename T>
-ArticulatedBodyInertia<T>::ArticulatedBodyInertia() = default;
 DRAKE_DEFINE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN_T(ArticulatedBodyInertia)
 
 }  // namespace multibody

--- a/multibody/tree/articulated_body_inertia_cache.h
+++ b/multibody/tree/articulated_body_inertia_cache.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <limits>
 #include <vector>
 
 #include "drake/common/default_scalars.h"
@@ -12,21 +13,25 @@ namespace drake {
 namespace multibody {
 namespace internal {
 
-/// This class is one of the cache entries in the Context. It holds the
-/// results of computations that are used in the recursive implementation of the
-/// articulated body algorithm.
+/// This class is one of the cache entries in the Context. It is used
+/// to store the results from the first pass of the articulated body algorithm
+/// for the computation of articulated body inertias. Please refer to @ref
+/// internal_forward_dynamics "Articulated Body Algorithm Forward Dynamics" for
+/// further mathematical background and implementation details.
 ///
 /// Articulated body inertia cache entries include:
-///
+/// - Articulated body inertia `P_B_W` of body B taken about Bo and expressed
+///   in W.
 /// - Articulated body inertia `Pplus_PB_W`, which can be thought of as the
 ///   articulated body inertia of parent body P as though it were inertialess,
 ///   but taken about Bo and expressed in W.
+/// - LDLT factorization `ldlt_D_B` of the articulated body hinge inertia.
+/// - The Kalman gain `g_PB_W = P_B_W * H_PB_W * D_B⁻¹`.
 ///
 /// @tparam T The mathematical type of the context, which must be a valid Eigen
 ///           scalar.
 ///
 /// Instantiated templates for the following kinds of T's are provided:
-///
 /// - double
 /// - AutoDiffXd
 /// - symbolic::Expression
@@ -42,6 +47,21 @@ class ArticulatedBodyInertiaCache {
   explicit ArticulatedBodyInertiaCache(const MultibodyTreeTopology& topology) :
       num_nodes_(topology.num_bodies()) {
     Allocate();
+  }
+
+  /// Articulated body inertia `P_B_W` of the body taken about Bo and expressed
+  /// in W.
+  const ArticulatedBodyInertia<T>& get_P_B_W(
+      BodyNodeIndex body_node_index) const {
+    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
+    return P_B_W_[body_node_index];
+  }
+
+  /// Mutable version of get_P_B_W().
+  ArticulatedBodyInertia<T>& get_mutable_P_B_W(
+      BodyNodeIndex body_node_index) {
+    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
+    return P_B_W_[body_node_index];
   }
 
   /// Articulated body inertia `Pplus_PB_W`, which can be thought of as the
@@ -60,20 +80,63 @@ class ArticulatedBodyInertiaCache {
     return Pplus_PB_W_[body_node_index];
   }
 
- private:
-  // The type of the pools for storing articulated body inertias.
-  typedef std::vector<ArticulatedBodyInertia<T>> ABI_PoolType;
+  /// LDLT factorization `ldlt_D_B` of the articulated body hinge inertia.
+  const Eigen::LDLT<MatrixUpTo6<T>>& get_ldlt_D_B(
+      BodyNodeIndex body_node_index) const {
+    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
+    return ldlt_D_B_[body_node_index];
+  }
 
+  /// Mutable version of get_ldlt_D_B().
+  Eigen::LDLT<MatrixUpTo6<T>>& get_mutable_ldlt_D_B(
+      BodyNodeIndex body_node_index) {
+    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
+    return ldlt_D_B_[body_node_index];
+  }
+
+  /// The Kalman gain `g_PB_W` of the body.
+  const Matrix6xUpTo6<T>& get_g_PB_W(
+      BodyNodeIndex body_node_index) const {
+    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
+    return g_PB_W_[body_node_index];
+  }
+
+  /// Mutable version of get_g_PB_W().
+  Matrix6xUpTo6<T>& get_mutable_g_PB_W(
+      BodyNodeIndex body_node_index) {
+    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
+    return g_PB_W_[body_node_index];
+  }
+
+ private:
   // Allocates resources for this articulated body cache.
   void Allocate() {
+    P_B_W_.resize(num_nodes_);
     Pplus_PB_W_.resize(num_nodes_);
+    ldlt_D_B_.resize(num_nodes_);
+    g_PB_W_.resize(num_nodes_);
+
+    // Initialize entries corresponding to world index to NaNs, since they
+    // should not be used.
+    P_B_W_[world_index()] = ArticulatedBodyInertia<T>();
+    Pplus_PB_W_[world_index()] = ArticulatedBodyInertia<T>();
+    g_PB_W_[world_index()] = Matrix6<T>::Constant(nan());
+  }
+
+  // Helper method for NaN initialization.
+  static constexpr T nan() {
+    return std::numeric_limits<
+        typename Eigen::NumTraits<T>::Literal>::quiet_NaN();
   }
 
   // Number of body nodes in the corresponding MultibodyTree.
   int num_nodes_{0};
 
-  // Pools.
-  ABI_PoolType Pplus_PB_W_{};  // Indexed by BodyNodeIndex.
+  // Pools indexed by BodyNodeIndex.
+  std::vector<ArticulatedBodyInertia<T>> P_B_W_;
+  std::vector<ArticulatedBodyInertia<T>> Pplus_PB_W_;
+  std::vector<Eigen::LDLT<MatrixUpTo6<T>>> ldlt_D_B_;
+  std::vector<Matrix6xUpTo6<T>> g_PB_W_;
 };
 
 DRAKE_DEFINE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN_T(ArticulatedBodyInertiaCache);

--- a/multibody/tree/body_node.h
+++ b/multibody/tree/body_node.h
@@ -7,8 +7,10 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/math/rigid_transform.h"
+#include "drake/math/rotation_matrix.h"
 #include "drake/multibody/math/spatial_algebra.h"
 #include "drake/multibody/tree/acceleration_kinematics_cache.h"
+#include "drake/multibody/tree/articulated_body_force_bias_cache.h"
 #include "drake/multibody/tree/articulated_body_inertia_cache.h"
 #include "drake/multibody/tree/body.h"
 #include "drake/multibody/tree/mobilizer.h"
@@ -653,7 +655,7 @@ class BodyNode : public MultibodyElement<BodyNode, T, BodyNodeIndex> {
     // direction of this node's mobilizer motion. That is, the generalized
     // forces correspond to the working components of the spatial force living
     // in the motion sub-space of this node's mobilizer.
-    // The calculation is recursive (from tip to base) and assumes the spatial
+    // The calculation is recursive (from tip-to-base) and assumes the spatial
     // force F_CMc on body C at Mc is already computed in F_BMo_W_array_ptr.
     //
     // The spatial force through body B's inboard mobilizer is obtained from a
@@ -894,7 +896,7 @@ class BodyNode : public MultibodyElement<BodyNode, T, BodyNodeIndex> {
   ///   The `6 x nm` hinge matrix that relates `V_PB_W` (body B's spatial
   ///   velocity in its parent body P, expressed in world W) to this node's `nm`
   ///   generalized velocities (or mobilities) `v_B` as `V_PB_W = H_PB_W * v_B`.
-  /// @param[out] abc
+  /// @param[out] abic
   ///   A pointer to a valid, non nullptr, articulated body cache.
   ///
   /// @pre The position kinematics cache `pc` was already updated to be in sync
@@ -903,14 +905,22 @@ class BodyNode : public MultibodyElement<BodyNode, T, BodyNodeIndex> {
   /// called for all the child nodes of `this` node (and, by recursive
   /// precondition, all successor nodes in the tree.)
   ///
-  /// @throws std::exception when called on the _root_ node or `abc` is nullptr.
+  /// @throws std::exception when called on the _root_ node or `abic` is
+  /// nullptr.
+  // TODO(amcastro-tri): Consider specialized BodyNodeImpl implementations that
+  // exploit the sparsity pattern of H_PB_W even at compile time. Most common
+  // cases are:
+  // - Revolute: [x y z 0 0 0]
+  // - Prismatic: [0 0 0 x y z]
+  // - Ball: 3x3 blocks of zeroes.
   void CalcArticulatedBodyInertiaCache_TipToBase(
-      const systems::Context<T>& context,
+      const systems::Context<T>&,
       const PositionKinematicsCache<T>& pc,
       const Eigen::Ref<const MatrixUpTo6<T>>& H_PB_W,
-      ArticulatedBodyInertiaCache<T>* abc) const {
+      const SpatialInertia<T>& M_B_W,
+      ArticulatedBodyInertiaCache<T>* abic) const {
     DRAKE_THROW_UNLESS(topology_.body != world_index());
-    DRAKE_THROW_UNLESS(abc != nullptr);
+    DRAKE_THROW_UNLESS(abic != nullptr);
 
     // As a guideline for developers, a summary of the computations performed in
     // this method is provided:
@@ -924,9 +934,9 @@ class BodyNode : public MultibodyElement<BodyNode, T, BodyNodeIndex> {
     //    expressed in world frame W.
     //  - Pplus_PB_W for the same articulated body inertia P_B_W but projected
     //    across B's inboard mobilizer to frame P so that instead of
-    //    F_Bo_W = P_B_W A_WB + z_Bo_W, we can write
-    //    F_Bo_W = Pplus_PB_W Aplus_WP + zplus_Bo_W where Aplus_WP is defined
-    //    in Section 6.2.2, Page 101 of [Jain 2010] and zplus_Bo_W is defined
+    //    F_Bo_W = P_B_W A_WB + Z_Bo_W, we can write
+    //    F_Bo_W = Pplus_PB_W Aplus_WB + Zplus_Bo_W where Aplus_WB is defined
+    //    in Section 6.2.2, Page 101 of [Jain 2010] and Zplus_Bo_W is defined
     //    in Section 6.3, Page 108 of [Jain 2010].
     //  - Φ(p_PQ) for Jain's rigid body transformation operator. In code,
     //    V_MQ = Φᵀ(p_PQ) V_MP is equivalent to V_MP.Shift(p_PQ).
@@ -944,9 +954,9 @@ class BodyNode : public MultibodyElement<BodyNode, T, BodyNodeIndex> {
     // here).
     //   P_B_W = Σᵢ(Φ(p_BCᵢ_W) Pplus_BCᵢ_W Φ(p_BCᵢ_W)ᵀ) + M_B_W
     //         = Σᵢ(Pplus_BCᵢb_W) + M_B_W                                   (1)
-    // where Pplus_BCᵢb_W is the articulated body inertia of the child body Cᵢ,
-    // projected across its inboard mobilizer to frame B, shifted to frame B,
-    // and expressed in the world frame W.
+    // where Pplus_BCᵢb_W is the articulated body inertia P_Cᵢ_W of the child
+    // body Cᵢ, projected across its inboard mobilizer to frame B, shifted to
+    // frame B, and expressed in the world frame W.
     //
     // From P_B_W, we can obtain Pplus_PB_W by projecting the articulated body
     // inertia for this node across its mobilizer.
@@ -968,34 +978,28 @@ class BodyNode : public MultibodyElement<BodyNode, T, BodyNodeIndex> {
     // articulated body inertia.
     //
     // In order to reduce the number of computations, we can save the common
-    // factor HTxP = H_PB_Wᵀ P_B_W. We then can write:
-    //   D_B = HTxP H_PB_W                                                  (5)
+    // factor U_B_W = H_PB_Wᵀ P_B_W. We then can write:
+    //   D_B = U_B_W H_PB_W                                                  (5)
     // and for g,
     //   g_PB_Wᵀ = (D_B⁻¹)ᵀ H_PB_Wᵀ P_B_Wᵀ
     //           = (D_Bᵀ)⁻¹ H_PB_Wᵀ P_B_W
-    //           = D_B⁻¹ HTxP                                               (6)
+    //           = D_B⁻¹ U_B_W                                               (6)
     // where we used the fact that both D and P are symmetric. Notice in the
-    // last expression for g_PB_Wᵀ we are reusing the common factor HTxP.
+    // last expression for g_PB_Wᵀ we are reusing the common factor U_B_W.
     //
     // Given the articulated body hinge inertia and Kalman gain, we can simplify
     // the equation in (2).
     //   Pplus_PB_W = (I - g_PB_W H_PB_Wᵀ) P_B_W
     //              = P_B_W - g_PB_W H_PB_Wᵀ P_B_W
-    //              = P_B_W - g_PB_W * HTxP                                 (7)
-
-    // Body for this node.
-    const Body<T>& body_B = body();
+    //              = P_B_W - g_PB_W * U_B_W                                 (7)
 
     // Get pose of B in W and its rotation matrix R_WB.
     const math::RigidTransform<T>& X_WB = get_X_WB(pc);
     const math::RotationMatrix<T>& R_WB = X_WB.rotation();
 
-    // Compute the spatial inertia for this body and re-express in W frame.
-    const SpatialInertia<T> M_B = body_B.CalcSpatialInertiaInBodyFrame(context);
-    const SpatialInertia<T> M_B_W = M_B.ReExpress(R_WB);
-
     // Compute articulated body inertia for body using (1).
-    ArticulatedBodyInertia<T> P_B_W = ArticulatedBodyInertia<T>(M_B_W);
+    ArticulatedBodyInertia<T>& P_B_W = get_mutable_P_B_W(abic);
+    P_B_W = ArticulatedBodyInertia<T>(M_B_W);
 
     // Add articulated body inertia contributions from all children.
     for (const BodyNode<T>* child : children_) {
@@ -1007,9 +1011,12 @@ class BodyNode : public MultibodyElement<BodyNode, T, BodyNodeIndex> {
       const Vector3<T> p_CoBo_W = R_WB * p_CoBo_B;
 
       // Pull Pplus_BC_W from cache (which is Pplus_PB_W for child).
-      const ArticulatedBodyInertia<T>& Pplus_BC_W = child->get_Pplus_PB_W(*abc);
+      const ArticulatedBodyInertia<T>& Pplus_BC_W
+          = child->get_Pplus_PB_W(*abic);
 
       // Shift Pplus_BC_W to Pplus_BCb_W.
+      // This is known to be one of the most expensive operations of ABA and
+      // must not be overlooked. Refer to #12435 for details.
       const ArticulatedBodyInertia<T> Pplus_BCb_W = Pplus_BC_W.Shift(p_CoBo_W);
 
       // Add Pplus_BCb_W contribution to articulated body inertia.
@@ -1019,42 +1026,313 @@ class BodyNode : public MultibodyElement<BodyNode, T, BodyNodeIndex> {
     // Get the number of mobilizer velocities (number of columns of H_PB_W).
     const int nv = get_num_mobilizer_velocities();
 
-    // Compute common term HTxP.
-    const MatrixUpTo6<T> HTxP = H_PB_W.transpose() * P_B_W;
+    ArticulatedBodyInertia<T>& Pplus_PB_W = get_mutable_Pplus_PB_W(abic);
+    Pplus_PB_W = P_B_W;
 
-    // Compute the articulated body hinge inertia, D_B, using (5).
-    MatrixUpTo6<T> D_B(nv, nv);
-    D_B.template triangularView<Eigen::Lower>() = HTxP * H_PB_W;
+    // We now proceed to compute Pplus_PB_W using Eq. (7):
+    //   Pplus_PB_W = P_B_W - g_PB_W * U_B_W
+    // For weld joints, with nv = 0, terms involving the hinge matrix H_PB_W
+    // go away and therefore Pplus_PB_W = P_B_W. We check this below.
+    if (nv != 0) {
+      // Compute common term U_B_W.
+      const MatrixUpTo6<T> U_B_W = H_PB_W.transpose() * P_B_W;
 
-    // Compute the LDLT factorization of D_B as ldlt_D_B.
-    // TODO(bobbyluig): Test performance against inverse().
-    const auto ldlt_D_B =
-        D_B.template selfadjointView<Eigen::Lower>().ldlt();
+      // Compute the articulated body hinge inertia, D_B, using (5).
+      MatrixUpTo6<T> D_B(nv, nv);
+      D_B.template triangularView<Eigen::Lower>() = U_B_W * H_PB_W;
 
-    // Ensure that D_B is not singular.
-    // Singularity means that a non-physical hinge mapping matrix was used or
-    // that this articulated body inertia has some non-physical quantities
-    // (such as zero moment of inertia along an axis which the hinge mapping
-    // matrix permits motion).
-    if (ldlt_D_B.info() != Eigen::Success) {
-      std::stringstream message;
-      message << "Encountered singular articulated body hinge inertia "
-              << "for body node index " << topology_.index << ". "
-              << "Please ensure that this body has non-zero inertia "
-              << "along all axes of motion.";
-      throw std::runtime_error(message.str());
+      // Compute the LDLT factorization of D_B as ldlt_D_B.
+      // TODO(bobbyluig): Test performance against inverse().
+      Eigen::LDLT<MatrixUpTo6<T>>& ldlt_D_B = get_mutable_ldlt_D_B(abic);
+      ldlt_D_B = D_B.template selfadjointView<Eigen::Lower>().ldlt();
+
+      // Ensure that D_B is not singular.
+      // Singularity means that a non-physical hinge mapping matrix was used or
+      // that this articulated body inertia has some non-physical quantities
+      // (such as zero moment of inertia along an axis which the hinge mapping
+      // matrix permits motion).
+      if (ldlt_D_B.info() != Eigen::Success) {
+        std::stringstream message;
+        message << "Encountered singular articulated body hinge inertia "
+                << "for body node index " << topology_.index << ". "
+                << "Please ensure that this body has non-zero inertia "
+                << "along all axes of motion.";
+        throw std::runtime_error(message.str());
+      }
+
+      // Compute the Kalman gain, g_PB_W, using (6).
+      Matrix6xUpTo6<T>& g_PB_W = get_mutable_g_PB_W(abic);
+      g_PB_W = ldlt_D_B.solve(U_B_W).transpose();
+
+      // Project P_B_W using (7) to obtain Pplus_PB_W, the articulated body
+      // inertia of this body B as felt by body P and expressed in frame W.
+      // Symmetrize the computation to reduce floating point errors.
+      // TODO(amcastro-tri): Notice that the line below makes the implicit
+      // assumption that g_PB_W * U_B_W is SPD and only the lower triangular
+      // portion is used, see the documentation for ArticulatedBodyInertia's
+      // constructor. This assumption is only asserted during debug builds. This
+      // *might* result in the accumulation of floating point round off errors
+      // for long kinematic chains. Further investigation is required.
+      Pplus_PB_W -= ArticulatedBodyInertia<T>(g_PB_W * U_B_W);
+    }
+  }
+
+  /// This method is used by MultibodyTree within a tip-to-base loop to compute
+  /// the force bias terms in the articulated body algorithm. Please refer to
+  /// @ref internal_forward_dynamics
+  /// "Articulated Body Algorithm Forward Dynamics" for further mathematical
+  /// background and implementation details.
+  ///
+  /// @param[in] context
+  ///   The context with the state of the MultibodyTree model.
+  /// @param[in] pc
+  ///   An already updated position kinematics cache in sync with `context`.
+  /// @param[in] vc
+  ///   An already updated velocity kinematics cache in sync with `context`.
+  ///   All velocities are assumed to be zero if vc is nullptr.
+  /// @param[in] Fb_Bo_W
+  ///   Force bias for this node's body B, at Bo, expressed in the world frame.
+  /// @param[in] abic
+  ///   An already updated articulated body inertia cache in sync with
+  ///   `context`.
+  /// @param[in] Fapplied_Bo_W
+  ///   Externally applied spatial force on this node's body B at the body's
+  ///   frame origin `Bo`, expressed in the world frame.
+  /// @param[in] tau_applied
+  ///   Externally applied generalized force at this node's mobilizer. It must
+  ///   have a size equal to the number of generalized velocities for this
+  ///   node's mobilizer, see get_num_mobilizer_velocities().
+  /// @param[in] H_PB_W
+  ///   The hinge mapping matrix that relates to the spatial velocity `V_PB_W`
+  ///   of this node's body B in its parent node body P, expressed in the world
+  ///   frame W, with this node's generalized velocities (or mobilities) `v_B`
+  ///   by `V_PB_W = H_PB_W⋅v_B`.
+  /// @param[out] aba_force_bias_cache
+  ///   A pointer to a valid, non nullptr, force bias cache.
+  ///
+  /// @pre pc, vc, and abic previously computed to be in sync with `context.
+  /// @pre CalcArticulatedBodyForceBiasCache_TipToBase() must have already been
+  /// called for all the child nodes of `this` node (and, by recursive
+  /// precondition, all successor nodes in the tree.)
+  ///
+  /// @throws when called on the _root_ node or `aba_force_bias_cache` is
+  /// nullptr.
+  void CalcArticulatedBodyForceBiasCache_TipToBase(
+      const systems::Context<T>& context,
+      const PositionKinematicsCache<T>& pc,
+      const VelocityKinematicsCache<T>* vc,
+      const SpatialForce<T>& Fb_Bo_W,
+      const ArticulatedBodyInertiaCache<T>& abic,
+      const SpatialForce<T>& Fapplied_Bo_W,
+      const Eigen::Ref<const VectorX<T>>& tau_applied,
+      const Eigen::Ref<const MatrixUpTo6<T>>& H_PB_W,
+      ArticulatedBodyForceBiasCache<T>* aba_force_bias_cache) const {
+    DRAKE_THROW_UNLESS(topology_.body != world_index());
+    DRAKE_THROW_UNLESS(aba_force_bias_cache != nullptr);
+
+    // As a guideline for developers, please refer to @ref
+    // internal_forward_dynamics for a detailed description of the algorithm and
+    // notation inuse.
+
+    // Get pose of B in W.
+    const math::RigidTransform<T>& X_WB = get_X_WB(pc);
+
+    // Get R_WB.
+    const math::RotationMatrix<T>& R_WB = X_WB.rotation();
+
+    SpatialAcceleration<T>& Ab_WB = get_mutable_Ab_WB(aba_force_bias_cache);
+    Ab_WB.SetZero();
+    if (vc != nullptr) {
+      // Inboard frame F and outboard frame M of this node's mobilizer.
+      const Frame<T>& frame_F = inboard_frame();
+      const Frame<T>& frame_M = outboard_frame();
+
+      // Compute X_PF and X_MB.
+      const math::RigidTransform<T> X_PF = frame_F.CalcPoseInBodyFrame(context);
+      const math::RigidTransform<T> X_MB =
+          frame_M.CalcPoseInBodyFrame(context).inverse();
+
+      // Parent position in the world is available from the position kinematics.
+      const math::RigidTransform<T>& X_WP = get_X_WP(pc);
+
+      // TODO(amcastro-tri): consider caching R_WF.
+      const math::RotationMatrix<T> R_WF = X_WP.rotation() * X_PF.rotation();
+
+      // Compute shift vector p_MoBo_F.
+      const Vector3<T> p_MoBo_F = get_X_FM(pc).rotation() * X_MB.translation();
+
+      // Compute H_FM_bias = Hdot * vm.
+      // That is, A_FM = H_FM(qm) * vm + H_FM_bias(qm, vm)
+      const VectorUpTo6<T> vmdot_zero =
+          VectorUpTo6<T>::Zero(get_num_mobilizer_velocities());
+      const SpatialAcceleration<T> H_FM_bias =
+          get_mobilizer().CalcAcrossMobilizerSpatialAcceleration(context,
+                                                                 vmdot_zero);
+
+      // Across mobilizer velocity is available from the velocity kinematics.
+      const Vector3<T> w_FM = get_V_FM(*vc).rotational();
+
+      // Ab_PB_W is the bias term for the acceleration A_PB_W. That is, it is
+      // the acceleration A_PB_W when vmdot = 0. Get Ab_PB_W by shifting and
+      // re-expressing H_FM_bias. We want to compute A_PB = DtP(V_PB). Due to
+      // the fact that frames P and F are on the same rigid body, we have that
+      // V_PF = 0. Therefore, DtP(V_PB) = DtF(V_PB). We then recognize that V_PB
+      // = V_PFb + V_FMb + V_MB = V_FMb. Since M and B are also on the same
+      // rigid body, V_MB = 0. Together, we get that A_PB = DtF(V_FMb) =
+      // A_FM.Shift(p_MoBo, w_FM).
+      const SpatialAcceleration<T> Ab_PB_W =
+          R_WF * H_FM_bias.Shift(p_MoBo_F, w_FM);
+
+      // Spatial velocity of parent is available from the velocity kinematics.
+      const SpatialVelocity<T>& V_WP = get_V_WP(*vc);
+      const Vector3<T>& w_WP = V_WP.rotational();
+      const Vector3<T>& v_WP = V_WP.translational();
+
+      // Velocity of body in parent is available from the velocity kinematics.
+      const SpatialVelocity<T>& V_PB_W = get_V_PB_W(*vc);
+      const Vector3<T>& w_PB_W = V_PB_W.rotational();
+      const Vector3<T>& v_PB_W = V_PB_W.translational();
+
+      // Body spatial velocity in W.
+      const SpatialVelocity<T>& V_WB = get_V_WB(*vc);
+      const Vector3<T>& w_WB = V_WB.rotational();
+      const Vector3<T>& v_WB = V_WB.translational();
+
+      // Compute Ab_WB according to:
+      // Ab_WB =  | w_WB x w_PB_W                 | + Ab_PB_W
+      //          | w_WP x (v_WB - v_WP + v_PB_W) |
+      // See @note in SpatialAcceleration::ComposeWithMovingFrameAcceleration()
+      // for a complete derivation.
+      Ab_WB = SpatialAcceleration<T>(
+          w_WB.cross(w_PB_W) + Ab_PB_W.rotational(),
+          w_WP.cross(v_WB - v_WP + v_PB_W) + Ab_PB_W.translational());
     }
 
-    // Compute the Kalman gain, g_PB_W, using (6).
-    const MatrixUpTo6<T> g_PB_W = ldlt_D_B.solve(HTxP).transpose();
+    // Compute the residual spatial force, Z_Bo_W, according to (1).
+    SpatialForce<T> Z_Bo_W = Fb_Bo_W - Fapplied_Bo_W;
 
-    // Project P_B_W using (7) to obtain Pplus_PB_W, the articulated body
-    // inertia of this body B as felt by body P and expressed in frame W.
-    // Symmetrize the computation to reduce floating point errors.
-    // TODO(bobbyluig): Only compute lower-triangular region.
-    const Matrix6<T> Pplus_PB_W_mat = P_B_W.CopyToFullMatrix6() - g_PB_W * HTxP;
-    get_mutable_Pplus_PB_W(abc) = ArticulatedBodyInertia<T>(
-        0.5 * (Pplus_PB_W_mat + Pplus_PB_W_mat.transpose()));
+    // Add residual spatial force contributions from all children.
+    for (const BodyNode<T>* child : children_) {
+      // Get X_BC (which is X_PB for child).
+      const math::RigidTransform<T>& X_BC = child->get_X_PB(pc);
+
+      // Compute shift vector p_CoBo_W.
+      const Vector3<T> p_CoBo_B = -X_BC.translation();
+      const Vector3<T> p_CoBo_W = R_WB * p_CoBo_B;
+
+      // Pull Zplus_BC_W from cache (which is Zplus_PB_W for child).
+      const SpatialForce<T>& Zplus_BC_W =
+          child->get_Zplus_PB_W(*aba_force_bias_cache);
+
+      // Shift Zplus_BC_W to Zplus_BCb_W.
+      const SpatialForce<T> Zplus_BCb_W = Zplus_BC_W.Shift(p_CoBo_W);
+
+      // Add Zplus_BCb_W contribution to residual spatial force.
+      Z_Bo_W += Zplus_BCb_W;
+    }
+
+    const ArticulatedBodyInertia<T>& Pplus_PB_W = get_Pplus_PB_W(abic);
+
+    get_mutable_Zplus_PB_W(aba_force_bias_cache) = Z_Bo_W + Pplus_PB_W * Ab_WB;
+
+    const int nv = get_num_mobilizer_velocities();
+
+    // These terms do not show up for zero mobilities (weld).
+    if (nv != 0) {
+      // Compute the articulated body inertia innovations generalized force,
+      // e_B,
+      // according to (4).
+      VectorUpTo6<T>& e_B = get_mutable_e_B(aba_force_bias_cache);
+      e_B = tau_applied - H_PB_W.transpose() * Z_Bo_W.get_coeffs();
+
+      // Get the Kalman gain from cache.
+      const Matrix6xUpTo6<T>& g_PB_W = get_g_PB_W(abic);
+
+      // Compute the projected articulated body force bias Zplus_PB_W.
+      get_mutable_Zplus_PB_W(aba_force_bias_cache) +=
+          SpatialForce<T>(g_PB_W * e_B);
+    }
+  }
+
+  /// This method is used by MultibodyTree within a base-to-tip loop to compute
+  /// the generalized accelerations `vdot` and the spatial accelerations `A_WB`.
+  /// Please refer to @ref internal_forward_dynamics
+  /// "Articulated Body Algorithm Forward Dynamics" for further mathematical
+  /// background and implementation details.
+  ///
+  /// @param[in] context
+  ///   The context with the state of the MultibodyTree model.
+  /// @param[in] pc
+  ///   An already updated position kinematics cache in sync with `context`.
+  /// @param[in] abic
+  ///   An already updated articulated body inertia cache in sync with
+  ///   `context`.
+  /// @param[in] aba_force_bias_cache
+  ///   An already updated articulated body algorithm cache in sync with
+  ///   `context`.
+  /// @param[in] H_PB_W
+  ///   The hinge mapping matrix that relates to the spatial velocity `V_PB_W`
+  ///   of this node's body B in its parent node body P, expressed in the world
+  ///   frame W, with this node's generalized velocities (or mobilities) `v_B`
+  ///   by `V_PB_W = H_PB_W⋅v_B`.
+  /// @param[out] ac
+  ///   A pointer to a valid, non nullptr, acceleration kinematics cache.
+  ///
+  /// @pre pc, vc, and abic previously computed to be in sync with `context.
+  /// @pre CalcArticulatedBodyAccelerations_BaseToTip() must have already been
+  /// called for the parent node (and, by recursive precondition, all
+  /// predecessor nodes in the tree.)
+  /// @throws when called on the _root_ node of `ac` or `vdot` is nullptr.
+  void CalcArticulatedBodyAccelerations_BaseToTip(
+      const systems::Context<T>& /* context */,
+      const PositionKinematicsCache<T>& pc,
+      const ArticulatedBodyInertiaCache<T>& abic,
+      const ArticulatedBodyForceBiasCache<T>& aba_force_bias_cache,
+      const Eigen::Ref<const MatrixUpTo6<T>>& H_PB_W,
+      AccelerationKinematicsCache<T>* ac) const {
+    DRAKE_THROW_UNLESS(ac != nullptr);
+
+    // As a guideline for developers, please refer to @ref
+    // abi_computing_accelerations for a detailed description of the algorithm
+    // and the notation in use.
+
+    // Get the spatial acceleration of the parent.
+    const SpatialAcceleration<T> A_WP = parent_node_->get_A_WB(*ac);
+
+    // Compute shift vector p_PoBo_W from the parent origin to the body origin.
+    // TODO(amcastro-tri): Consider getting this value from cache.
+    const Vector3<T>& p_PoBo_P = get_X_PB(pc).translation();
+    const math::RotationMatrix<T>& R_WP = get_X_WP(pc).rotation();
+    const Vector3<T> p_PoBo_W = R_WP * p_PoBo_P;
+
+    const int nv = get_num_mobilizer_velocities();
+
+    // Rigidly shift the acceleration of the parent node.
+    const SpatialAcceleration<T> Aplus_WB = SpatialAcceleration<T>(
+        A_WP.rotational(),
+        A_WP.translational() + A_WP.rotational().cross(p_PoBo_W));
+
+    const SpatialAcceleration<T>& Ab_WB = get_Ab_WB(aba_force_bias_cache);
+
+    SpatialAcceleration<T>& A_WB = get_mutable_A_WB(ac);
+    A_WB = SpatialAcceleration<T>(Aplus_WB.get_coeffs() + Ab_WB.get_coeffs());
+
+    // These quantities do not contribute when nv = 0. We skip them since Eigen
+    // does not allow certain operations on zero-sized objects.
+    if (nv != 0) {
+      // Compute nu_B, the articulated body inertia innovations generalized
+      // acceleration.
+      const VectorUpTo6<T> nu_B =
+          get_ldlt_D_B(abic).solve(get_e_B(aba_force_bias_cache));
+
+      // Mutable reference to the generalized acceleration.
+      auto vmdot = get_mutable_accelerations(ac);
+      const Matrix6xUpTo6<T>& g_PB_W = get_g_PB_W(abic);
+      vmdot = nu_B - g_PB_W.transpose() * A_WB.get_coeffs();
+
+      // Update with vmdot term the spatial acceleration of the current body.
+      A_WB.get_coeffs() += H_PB_W * vmdot;
+    }
   }
 
  protected:
@@ -1222,21 +1500,119 @@ class BodyNode : public MultibodyElement<BodyNode, T, BodyNodeIndex> {
     return ac.get_A_WB(topology_.parent_body_node);
   }
 
+  // Returns an Eigen expression of the vector of generalized accelerations
+  // for this node's inboard mobilizer from the vector of generalized
+  // accelerations for the entire model.
+  Eigen::VectorBlock<const VectorX<T>> get_accelerations(
+      AccelerationKinematicsCache<T>* ac) const {
+    const VectorX<T>& vdot = ac->get_vdot();
+    return get_velocities_from_array(vdot);
+  }
+
+  // Mutable version of get_accelerations_from_array().
+  Eigen::VectorBlock<Eigen::Ref<VectorX<T>>> get_mutable_accelerations(
+      AccelerationKinematicsCache<T>* ac) const {
+    VectorX<T>& vdot = ac->get_mutable_vdot();
+    return get_mutable_velocities_from_array(&vdot);
+  }
+
+
   // =========================================================================
   // ArticulatedBodyInertiaCache Accessors and Mutators.
 
-  /// Returns a const reference to the articulated body inertia `Pplus_PB_W`,
-  /// which can be thought of as the articulated body inertia of parent body P
-  /// as though it were inertialess, but taken about Bo and expressed in W.
-  const ArticulatedBodyInertia<T>& get_Pplus_PB_W(
-      const ArticulatedBodyInertiaCache<T>& abc) const {
-    return abc.get_Pplus_PB_W(topology_.index);
+  // Returns a const reference to the articulated body inertia `P_B_W` of the
+  // body taken about Bo and expressed in W.
+  const ArticulatedBodyInertia<T>& get_P_B_W(
+      const ArticulatedBodyInertiaCache<T>& abic) const {
+    return abic.get_P_B_W(topology_.index);
   }
 
-  /// Mutable version of get_Pplus_PB_W().
+  // Mutable version of get_P_B_W().
+  ArticulatedBodyInertia<T>& get_mutable_P_B_W(
+      ArticulatedBodyInertiaCache<T>* abic) const {
+    return abic->get_mutable_P_B_W(topology_.index);
+  }
+
+  // Returns a const reference to the articulated body inertia `Pplus_PB_W`,
+  // which can be thought of as the articulated body inertia of parent body P
+  // as though it were inertialess, but taken about Bo and expressed in W.
+  const ArticulatedBodyInertia<T>& get_Pplus_PB_W(
+      const ArticulatedBodyInertiaCache<T>& abic) const {
+    return abic.get_Pplus_PB_W(topology_.index);
+  }
+
+  // Mutable version of get_Pplus_PB_W().
   ArticulatedBodyInertia<T>& get_mutable_Pplus_PB_W(
-      ArticulatedBodyInertiaCache<T>* abc) const {
-    return abc->get_mutable_Pplus_PB_W(topology_.index);
+      ArticulatedBodyInertiaCache<T>* abic) const {
+    return abic->get_mutable_Pplus_PB_W(topology_.index);
+  }
+
+  // Returns a const reference to the LDLT factorization `ldlt_D_B` of the
+  // articulated body hinge inertia.
+  const Eigen::LDLT<MatrixUpTo6<T>>& get_ldlt_D_B(
+      const ArticulatedBodyInertiaCache<T>& abic) const {
+    return abic.get_ldlt_D_B(topology_.index);
+  }
+
+  // Mutable version of get_ldlt_D_B().
+  Eigen::LDLT<MatrixUpTo6<T>>& get_mutable_ldlt_D_B(
+      ArticulatedBodyInertiaCache<T>* abic) const {
+    return abic->get_mutable_ldlt_D_B(topology_.index);
+  }
+
+  // Returns a const reference to the Kalman gain `g_PB_W` of the body.
+  const Matrix6xUpTo6<T>& get_g_PB_W(
+      const ArticulatedBodyInertiaCache<T>& abic) const {
+    return abic.get_g_PB_W(topology_.index);
+  }
+
+  // Mutable version of get_g_PB_W().
+  Matrix6xUpTo6<T>& get_mutable_g_PB_W(
+      ArticulatedBodyInertiaCache<T>* abic) const {
+    return abic->get_mutable_g_PB_W(topology_.index);
+  }
+
+  // =========================================================================
+  // ArticulatedBodyForceBiasCache Accessors and Mutators.
+
+  // Returns a const reference to the articulated body inertia residual force
+  // `Zplus_PB_W` for this body projected across its inboard mobilizer to
+  // frame P.
+  const SpatialForce<T>& get_Zplus_PB_W(
+      const ArticulatedBodyForceBiasCache<T>& aba_force_bias_cache) const {
+    return aba_force_bias_cache.get_Zplus_PB_W(topology_.index);
+  }
+
+  // Mutable version of get_Zplus_PB_W().
+  SpatialForce<T>& get_mutable_Zplus_PB_W(
+      ArticulatedBodyForceBiasCache<T>* aba_force_bias_cache) const {
+    return aba_force_bias_cache->get_mutable_Zplus_PB_W(topology_.index);
+  }
+
+  // Returns a const reference to the Coriolis spatial acceleration `Ab_WB`
+  // for this body due to the relative velocities of body B and body P.
+  const SpatialAcceleration<T>& get_Ab_WB(
+      const ArticulatedBodyForceBiasCache<T>& aba_force_bias_cache) const {
+    return aba_force_bias_cache.get_Ab_WB(topology_.index);
+  }
+
+  // Mutable version of get_Ab_WB().
+  SpatialAcceleration<T>& get_mutable_Ab_WB(
+      ArticulatedBodyForceBiasCache<T>* aba_force_bias_cache) const {
+    return aba_force_bias_cache->get_mutable_Ab_WB(topology_.index);
+  }
+
+  // Returns a const reference to the Coriolis spatial acceleration `Ab_WB`
+  // for this body due to the relative velocities of body B and body P.
+  const VectorUpTo6<T>& get_e_B(
+      const ArticulatedBodyForceBiasCache<T>& aba_force_bias_cache) const {
+    return aba_force_bias_cache.get_e_B(topology_.index);
+  }
+
+  // Mutable version of get_e_B().
+  VectorUpTo6<T>& get_mutable_e_B(
+      ArticulatedBodyForceBiasCache<T>* aba_force_bias_cache) const {
+    return aba_force_bias_cache->get_mutable_e_B(topology_.index);
   }
 
   // =========================================================================
@@ -1278,8 +1654,8 @@ class BodyNode : public MultibodyElement<BodyNode, T, BodyNodeIndex> {
   // tree. Useful for the implementation of operator forms where the generalized
   // velocity (or time derivatives of the generalized velocities) is an argument
   // to the operator.
-  Eigen::VectorBlock<const VectorX<T>> get_velocities_from_array(
-      const VectorX<T>& v) const {
+  Eigen::VectorBlock<const Eigen::Ref<const VectorX<T>>>
+  get_velocities_from_array(const Eigen::Ref<const VectorX<T>>& v) const {
     return v.segment(topology_.mobilizer_velocities_start_in_v,
                      topology_.num_mobilizer_velocities);
   }

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -19,6 +19,7 @@
 #include "drake/common/random.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/tree/acceleration_kinematics_cache.h"
+#include "drake/multibody/tree/articulated_body_force_bias_cache.h"
 #include "drake/multibody/tree/articulated_body_inertia_cache.h"
 #include "drake/multibody/tree/multibody_forces.h"
 #include "drake/multibody/tree/multibody_tree_system.h"
@@ -1661,23 +1662,22 @@ class MultibodyTree {
       const Eigen::Ref<const VectorX<T>>& qdot,
       EigenPtr<VectorX<T>> v) const;
 
-  // TODO(amcastro-tri): fix references to CalcArticulatedBodyForces()
-  // and CalcArticulatedBodyAccelerations() when we push the complete forward
-  // dynamics.
-  /** @name Articulated Body Algorithm Forward Dynamics.
+  /**
+  @anchor internal_forward_dynamics
+  @name Articulated Body Algorithm Forward Dynamics.
   The Articulated %Body Algorithm (ABA) implements a forward dynamics
   computation with O(n) complexity. The algorithm is implemented in terms of
   three main passes:
-  1. CalcArticulatedBodyInertiaCache(): which performs a tip to base pass to
+  1. CalcArticulatedBodyInertiaCache(): which performs a tip-to-base pass to
      compute the ArticulatedBodyInertia for each body along with other ABA
      quantities that are configuration dependent only.
-  2. CalcArticulatedBodyForceBiases(): a second tip to base pass which
+  2. CalcArticulatedBodyForceBiasCache(): a second tip-to-base pass which
      essentially computes the bias terms in the ABA equations. These are a
      function of the full state x = [q; v] and externally applied actuation and
      forces.
-  3. CalcArticulatedBodyAccelerations(): which performs a final base to tip
+  3. CalcArticulatedBodyAccelerations(): which performs a final base-to-tip
      recursion to compute the acceleration of each body in the model. These
-     accelerations are a function of the ArticulatedBodyAlgorithmCache
+     accelerations are a function of the ArticulatedBodyForceBiasCache
      previously computed by CalcArticulatedBodyForces(). That is, accelerations
      are a function of state x and applied forces.
 
@@ -1833,6 +1833,7 @@ class MultibodyTree {
   parallelism of the joint reaction forces equation with the Newton-Euler
   equations.
 
+  @anchor abi_computing_accelerations
   <h3> Computing Accelerations </h3>
   Once ABA inertias and force bias terms are computed according to Eqs.
   (2)-(10), the computation of accelerations is remarkably simple. The last base
@@ -1860,7 +1861,7 @@ class MultibodyTree {
   using the definitions in Eqs. (6)-(8), we can rewrite (13) as: <pre>
     D_B * vdot_B + U_B_W * (Aplus_WB + Ab_WB) = e_B                         (14)
   </pre>
-  Therefore the last base to tip pass updates generalized accelerations and
+  Therefore the last base-to-tip pass updates generalized accelerations and
   spatial accelerations according to: <pre>
     vdot_B = D_B⁻¹ * e_B - g_B_Wᵀ * (Aplus_WB + Ab_WB)                      (15)
     A_WB = Aplus_WB + Ab_WB + H_PB_W * vdot_B                               (16)
@@ -1911,30 +1912,31 @@ class MultibodyTree {
    @{
   */
 
-  /// Computes all the quantities that are required in the final pass of the
-  /// articulated body algorithm and stores them in the articulated body cache
-  /// `abc`.
-  ///
-  /// These include:
-  /// - Articulated body inertia `Pplus_PB_W`, which can be thought of as the
-  ///   articulated body inertia of parent body P as though it were inertialess,
-  ///   but taken about Bo and expressed in W.
-  ///
-  /// @param[in] context
-  ///   The context containing the state of the %MultibodyTree model.
-  /// @param[in] pc
-  ///   A position kinematics cache object already updated to be in sync with
-  ///   `context`.
-  /// @param[out] abc
-  ///   A pointer to a valid, non nullptr, articulated body cache. This method
-  ///   throws an exception if `abc` is a nullptr.
-  ///
-  /// @pre The position kinematics `pc` must have been previously updated with a
-  /// call to CalcPositionKinematicsCache() using the same `context`  .
+  /// Performs a tip-to-base pass to compute the ArticulatedBodyInertia for each
+  /// body as a function of the configuration q stored in `context`. The
+  /// computation is stored in `abic` along with other Articulated Body
+  /// Algorithm (ABA) quantities.
   void CalcArticulatedBodyInertiaCache(
       const systems::Context<T>& context,
-      const PositionKinematicsCache<T>& pc,
-      ArticulatedBodyInertiaCache<T>* abc) const;
+      ArticulatedBodyInertiaCache<T>* abic) const;
+
+  /// Performs a tip-to-base pass which essentially computes the force bias
+  /// terms in the ABA equations. These are a function of the full state
+  /// `x = [q; v]`, stored in `context`, and externally applied `forces`.
+  /// Refer to @ref abi_and_bias_force "Articulated Body Inertia and Force Bias"
+  /// for further details.
+  void CalcArticulatedBodyForceBiasCache(
+      const systems::Context<T>& context, const MultibodyForces<T>& forces,
+      ArticulatedBodyForceBiasCache<T>* aba_force_bias_cache) const;
+
+  /// Performs the final base-to-tip pass of ABA to compute the acceleration of
+  /// each body in the model into output `ac`.
+  /// Refer to @ref abi_computing_accelerations "Computing Accelerations" for
+  /// further details.
+  void CalcArticulatedBodyAccelerations(
+    const systems::Context<T>& context,
+    const ArticulatedBodyForceBiasCache<T>& aba_force_bias_cache,
+    AccelerationKinematicsCache<T>* ac) const;
 
   /// @}
 
@@ -2206,6 +2208,19 @@ class MultibodyTree {
       const systems::Context<T>& context) const {
     DRAKE_ASSERT(tree_system_ != nullptr);
     return tree_system_->EvalVelocityKinematics(context);
+  }
+
+  // Evaluate the cache entry storing articulated body inertias in `context`.
+  const ArticulatedBodyInertiaCache<T>& EvalArticulatedBodyInertiaCache(
+      const systems::Context<T>& context) const {
+    return tree_system_->EvalArticulatedBodyInertiaCache(context);
+  }
+
+  // Evaluate the cache entry storing the across node Jacobian H_PB_W in
+  // `context`.
+  const std::vector<Vector6<T>>& EvalAcrossNodeJacobianWrtVExpressedInWorld(
+      const systems::Context<T>& context) const {
+    return tree_system_->EvalAcrossNodeJacobianWrtVExpressedInWorld(context);
   }
 
   /// @name                 State access methods

--- a/multibody/tree/multibody_tree_system.h
+++ b/multibody/tree/multibody_tree_system.h
@@ -7,6 +7,7 @@
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/eigen_types.h"
+#include "drake/multibody/tree/articulated_body_inertia_cache.h"
 #include "drake/multibody/tree/position_kinematics_cache.h"
 #include "drake/multibody/tree/spatial_inertia.h"
 #include "drake/multibody/tree/velocity_kinematics_cache.h"
@@ -90,6 +91,16 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
       const systems::Context<T>& context) const {
     return this->get_cache_entry(cache_indexes_.velocity_kinematics)
         .template Eval<VelocityKinematicsCache<T>>(context);
+  }
+
+  /** Returns a reference to the up to date ArticulatedBodyInertiaCache stored
+  in the given context, recalculating it first if necessary. 
+  See @ref internal_forward_dynamics
+  "Articulated Body Algorithm Forward Dynamics" for further details. */
+  const ArticulatedBodyInertiaCache<T>& EvalArticulatedBodyInertiaCache(
+      const systems::Context<T>& context) const {
+    return this->get_cache_entry(cache_indexes_.abi_cache_index)
+        .template Eval<ArticulatedBodyInertiaCache<T>>(context);
   }
 
   /** Returns a reference to the up to date cache of per-body spatial inertias
@@ -189,8 +200,9 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
   // This struct stores in one single place all indexes related to
   // MultibodyTreeSystem specific cache entries.
   struct CacheIndexes {
-    systems::CacheIndex dynamic_bias;
+    systems::CacheIndex abi_cache_index;
     systems::CacheIndex across_node_jacobians;
+    systems::CacheIndex dynamic_bias;
     systems::CacheIndex position_kinematics;
     systems::CacheIndex spatial_inertia_in_world;
     systems::CacheIndex velocity_kinematics;

--- a/multibody/tree/test/articulated_body_algorithm_test.cc
+++ b/multibody/tree/test/articulated_body_algorithm_test.cc
@@ -226,7 +226,7 @@ GTEST_TEST(ArticulatedBodyInertiaAlgorithm, FeatherstoneExample) {
 
   // Compute articulated body cache.
   ArticulatedBodyInertiaCache<double> abc(tree.get_topology());
-  tree.CalcArticulatedBodyInertiaCache(*context, pc,  &abc);
+  tree.CalcArticulatedBodyInertiaCache(*context, &abc);
 
   // Get expected projected articulated body inertia of cylinder.
   Matrix6<double> M_cylinder_mat = M_Ccm.CopyToFullMatrix6();
@@ -314,7 +314,7 @@ GTEST_TEST(ArticulatedBodyInertiaAlgorithm, ModifiedFeatherstoneExample) {
 
   // Compute articulated body cache.
   ArticulatedBodyInertiaCache<double> abc(tree.get_topology());
-  tree.CalcArticulatedBodyInertiaCache(*context, pc,  &abc);
+  tree.CalcArticulatedBodyInertiaCache(*context,  &abc);
 
   // Rotate the spatial inertia about the y-axis to match the rotation of
   // q_WB.


### PR DESCRIPTION
Completes the implementation of the O(n) ABA with `CalcArticulatedBodyForceBiasCache()` and `CalcArticulatedBodyAccelerations()`  as documented in MBT's Doxygen docs `@ref internal_forward_dynamics`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12412)
<!-- Reviewable:end -->
