### PR TITLE
tools: fix show_hydroelastic_contact plugin of drake_visualizer

### DIFF
--- a/tools/workspace/drake_visualizer/plugin/show_hydroelastic_contact.py
+++ b/tools/workspace/drake_visualizer/plugin/show_hydroelastic_contact.py
@@ -12,8 +12,8 @@ from PythonQt import QtCore, QtGui
 import drake as lcmdrakemsg
 
 from drake.tools.workspace.drake_visualizer.plugin import scoped_singleton_func
-from show_point_pair_contact import ContactVisModes
-
+from drake.tools.workspace.drake_visualizer.plugin.show_point_pair_contact \
+     import ContactVisModes
 
 # TODO(seancurtis-TRI) Make the dialog box for scaling force arrows in
 # show_point_pair_contact.py accessible to this plugin too.


### PR DESCRIPTION
Change the `from...import` to use the absolute path. Otherwise, we got this error message:
```
drake/tools/workspace/drake_visualizer/plugin/show_hydroelastic_contact.py", line 15, in <module>
    from show_point_pair_contact import ContactVisModes
ModuleNotFoundError: No module named 'show_point_pair_contact'
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12417)
<!-- Reviewable:end -->
