### PR TITLE
More syntactic sugar for SymbolicVectorSystemBuilder

### DIFF
--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -254,7 +254,10 @@ PYBIND11_MODULE(primitives, m) {
             py::arg("dynamics") = Vector0<Expression>{},
             py::arg("output") = Vector0<Expression>{},
             py::arg("time_period") = 0.0,
-            doc.SymbolicVectorSystem.ctor.doc_7args);
+            doc.SymbolicVectorSystem.ctor.doc_7args)
+        .def("dynamics_for_variable",
+            &SymbolicVectorSystem<T>::dynamics_for_variable, py::arg("var"),
+            doc.SymbolicVectorSystem.dynamics_for_variable.doc);
 
     DefineTemplateClassWithDefault<WrapToSystem<T>, LeafSystem<T>>(
         m, "WrapToSystem", GetPyParam<T>(), doc.WrapToSystem.doc)

--- a/bindings/pydrake/systems/test/primitives_test.py
+++ b/bindings/pydrake/systems/test/primitives_test.py
@@ -308,6 +308,10 @@ class TestGeneral(unittest.TestCase):
         self.assertEqual(system.get_output_port(0).size(), 1)
         self.assertEqual(context.num_abstract_parameters(), 0)
         self.assertEqual(context.num_numeric_parameter_groups(), 0)
+        self.assertTrue(system.dynamics_for_variable(x[0])
+                        .EqualTo(x[0] + x[1]))
+        self.assertTrue(system.dynamics_for_variable(x[1])
+                        .EqualTo(t))
 
     def test_symbolic_vector_system_parameters(self):
         t = Variable("t")
@@ -328,6 +332,10 @@ class TestGeneral(unittest.TestCase):
         self.assertEqual(context.num_abstract_parameters(), 0)
         self.assertEqual(context.num_numeric_parameter_groups(), 1)
         self.assertEqual(context.get_numeric_parameter(0).size(), 2)
+        self.assertTrue(system.dynamics_for_variable(x[0])
+                        .EqualTo(p[0] * x[0] + x[1] + p[1]))
+        self.assertTrue(system.dynamics_for_variable(x[1])
+                        .EqualTo(t))
 
     def test_wrap_to_system(self):
         system = WrapToSystem(2)

--- a/systems/primitives/symbolic_vector_system.cc
+++ b/systems/primitives/symbolic_vector_system.cc
@@ -49,6 +49,9 @@ SymbolicVectorSystem<T>::SymbolicVectorSystem(
   if (input_vars_.size() > 0) {
     this->DeclareInputPort(kVectorValued, input_vars_.size());
   }
+  for (int i = 0; i < state_vars_.size(); i++) {
+    state_var_to_index_.emplace(state_vars_[i].get_id(), i);
+  }
   if (state_vars_.size() > 0) {
     for (int i = 0; i < dynamics_.size(); i++) {
       DRAKE_ASSERT(dynamics_[i].GetVariables().IsSubsetOf(all_vars));

--- a/systems/primitives/symbolic_vector_system.h
+++ b/systems/primitives/symbolic_vector_system.h
@@ -156,6 +156,26 @@ class SymbolicVectorSystem final : public LeafSystem<T> {
     return parameter_vars_;
   }
   const VectorX<symbolic::Expression>& dynamics() const { return dynamics_; }
+
+  /// Returns the dynamics for the variable @p var. That is, it returns the
+  /// scalar expression corresponding to either `\dot{var}` (continuous case) or
+  /// `var[n+1]` (discrete case).
+  ///
+  /// @throw std::out_of_range if this system has no corresponding dynamics for
+  /// the variable @p var.
+  const symbolic::Expression& dynamics_for_variable(
+      const symbolic::Variable& var) const {
+    auto it = state_var_to_index_.find(var.get_id());
+    if (it != state_var_to_index_.end()) {
+      return dynamics_[it->second];
+    } else {
+      throw std::out_of_range{
+          fmt::format("This SymbolicVectorSystem does not have a dynamics for "
+                      "the given variable {}",
+                      var)};
+    }
+  }
+
   const VectorX<symbolic::Expression>& output() const { return output_; }
   /// @}
 
@@ -189,6 +209,8 @@ class SymbolicVectorSystem final : public LeafSystem<T> {
 
   symbolic::Environment env_{};
   const double time_period_{0.0};
+
+  std::unordered_map<symbolic::Variable::Id, int> state_var_to_index_;
 
   // Storage for Jacobians (empty unless T == AutoDiffXd).
   MatrixX<symbolic::Expression> dynamics_jacobian_{};
@@ -227,7 +249,7 @@ class SymbolicVectorSystemBuilder {
   SymbolicVectorSystemBuilder state(const symbolic::Variable& v) {
     return state(Vector1<symbolic::Variable>{v});
   }
-  /// Sets the state variables (vector version).
+  /// Sets the state variables (Eigen::Vector version).
   SymbolicVectorSystemBuilder state(
       const Eigen::Ref<const VectorX<symbolic::Variable>>& vars) {
     state_vars_ = vars;
@@ -237,18 +259,30 @@ class SymbolicVectorSystemBuilder {
     SymbolicVectorSystemBuilder result = *this;
     return result;
   }
+  /// Sets the state variables (std::vector version).
+  SymbolicVectorSystemBuilder state(
+      const std::vector<symbolic::Variable>& vars) {
+    return state(Eigen::Map<const VectorX<symbolic::Variable>>(vars.data(),
+                                                               vars.size()));
+  }
   /// Sets the input variable (scalar version).
   SymbolicVectorSystemBuilder input(const symbolic::Variable& v) {
     input_vars_ = Vector1<symbolic::Variable>{v};
     SymbolicVectorSystemBuilder result = *this;
     return result;
   }
-  /// Sets the input variables (vector version).
+  /// Sets the input variables (Eigen::Vector version).
   SymbolicVectorSystemBuilder input(
       const Eigen::Ref<const VectorX<symbolic::Variable>>& vars) {
     input_vars_ = vars;
     SymbolicVectorSystemBuilder result = *this;
     return result;
+  }
+  /// Sets the input variables (std::vector version).
+  SymbolicVectorSystemBuilder input(
+      const std::vector<symbolic::Variable>& vars) {
+    return input(Eigen::Map<const VectorX<symbolic::Variable>>(vars.data(),
+                                                               vars.size()));
   }
   /// Sets the parameter variable (scalar version).
   SymbolicVectorSystemBuilder parameter(const symbolic::Variable& v) {
@@ -256,12 +290,18 @@ class SymbolicVectorSystemBuilder {
     SymbolicVectorSystemBuilder result = *this;
     return result;
   }
-  /// Sets the parameter variables (vector version).
+  /// Sets the parameter variables (Eigen::Vector version).
   SymbolicVectorSystemBuilder parameter(
       const Eigen::Ref<const VectorX<symbolic::Variable>>& vars) {
     parameter_vars_ = vars;
     SymbolicVectorSystemBuilder result = *this;
     return result;
+  }
+  /// Sets the parameter variables (std::vector version).
+  SymbolicVectorSystemBuilder parameter(
+      const std::vector<symbolic::Variable>& vars) {
+    return parameter(Eigen::Map<const VectorX<symbolic::Variable>>(
+        vars.data(), vars.size()));
   }
   /// Sets the dynamics method (scalar version).
   SymbolicVectorSystemBuilder dynamics(const symbolic::Expression& e) {
@@ -269,12 +309,18 @@ class SymbolicVectorSystemBuilder {
     SymbolicVectorSystemBuilder result = *this;
     return result;
   }
-  /// Sets the dynamics method (vector version).
+  /// Sets the dynamics method (Eigen::Vector version).
   SymbolicVectorSystemBuilder dynamics(
       const Eigen::Ref<const VectorX<symbolic::Expression>>& e) {
     dynamics_ = e;
     SymbolicVectorSystemBuilder result = *this;
     return result;
+  }
+  /// Sets the dynamics variables (std::vector version).
+  SymbolicVectorSystemBuilder dynamics(
+      const std::vector<symbolic::Expression>& e) {
+    return dynamics(
+        Eigen::Map<const VectorX<symbolic::Expression>>(e.data(), e.size()));
   }
   /// Sets the output method (scalar version).
   SymbolicVectorSystemBuilder output(const symbolic::Expression& e) {
@@ -282,13 +328,20 @@ class SymbolicVectorSystemBuilder {
     SymbolicVectorSystemBuilder result = *this;
     return result;
   }
-  /// Sets the output method (vector version).
+  /// Sets the output method (Eigen::Vector version).
   SymbolicVectorSystemBuilder output(
       const Eigen::Ref<const VectorX<symbolic::Expression>>& e) {
     output_ = e;
     SymbolicVectorSystemBuilder result = *this;
     return result;
   }
+  /// Sets the output variables (std::vector version).
+  SymbolicVectorSystemBuilder output(
+      const std::vector<symbolic::Expression>& e) {
+    return output(
+        Eigen::Map<const VectorX<symbolic::Expression>>(e.data(), e.size()));
+  }
+
   /// Sets the time period (0 is continuous time).
   SymbolicVectorSystemBuilder time_period(double p) {
     time_period_ = p;
@@ -319,7 +372,9 @@ class SymbolicVectorSystemBuilder {
   }
   /// Returns the dynamics.
   const VectorX<symbolic::Expression>& dynamics() const { return dynamics_; }
-  /// Returns the dynamics for the variable @p var.
+  /// Returns the dynamics for the variable @p var. That is, it returns the
+  /// scalar expression corresponding to either `\dot{var}` (continuous case) or
+  /// `var[n+1]` (discrete case).
   ///
   /// @throw std::out_of_range if this builder has no corresponding dynamics for
   /// the variable @p var.

--- a/systems/primitives/test/symbolic_vector_system_test.cc
+++ b/systems/primitives/test/symbolic_vector_system_test.cc
@@ -42,11 +42,15 @@ TEST_F(SymbolicVectorSystemTest, BuilderBasicPattern) {
   EXPECT_TRUE(
       SymbolicVectorSystemBuilder().state(x_).state()[1].equal_to(x_[1]));
 
+  EXPECT_EQ(SymbolicVectorSystemBuilder().state({x_[0], x_[1]}).state(), x_);
+
   EXPECT_TRUE(
       SymbolicVectorSystemBuilder().input(u_[1]).input()[0].equal_to(u_[1]));
 
   EXPECT_TRUE(
       SymbolicVectorSystemBuilder().input(u_).input()[1].equal_to(u_[1]));
+
+  EXPECT_EQ(SymbolicVectorSystemBuilder().input({u_[0], u_[1]}).input(), u_);
 
   EXPECT_TRUE(
       SymbolicVectorSystemBuilder().parameter(p_[1]).parameter()[0].equal_to(
@@ -55,6 +59,9 @@ TEST_F(SymbolicVectorSystemTest, BuilderBasicPattern) {
   EXPECT_TRUE(
       SymbolicVectorSystemBuilder().parameter(p_).parameter()[1].equal_to(
           p_[1]));
+
+  EXPECT_EQ(SymbolicVectorSystemBuilder().parameter({p_[0], p_[1]}).parameter(),
+            p_);
 
   EXPECT_TRUE(SymbolicVectorSystemBuilder()
                   .dynamics(x_[0] + u_[0] + p_[0])
@@ -75,6 +82,16 @@ TEST_F(SymbolicVectorSystemTest, BuilderBasicPattern) {
                   .output(Vector1<Expression>{x_[0] + u_[0] + p_[0]})
                   .output()[0]
                   .EqualTo(x_[0] + u_[0] + p_[0]));
+
+  EXPECT_TRUE(SymbolicVectorSystemBuilder()
+                  .output({x_[0] + u_[0] + p_[0], x_[1]})
+                  .output()[0]
+                  .EqualTo(x_[0] + u_[0] + p_[0]));
+
+  EXPECT_TRUE(SymbolicVectorSystemBuilder()
+                  .output({x_[0] + u_[0] + p_[0], x_[1]})
+                  .output()[1]
+                  .EqualTo(x_[1]));
 
   EXPECT_EQ(SymbolicVectorSystemBuilder().time_period(3.2).time_period(), 3.2);
 
@@ -101,6 +118,18 @@ TEST_F(SymbolicVectorSystemTest, BuilderBasicPattern) {
                    .dynamics(Vector2<Expression>(-x_[1], -x_[0] + 3))
                    .dynamics_for_variable(u_[0]),
                std::out_of_range);
+
+  EXPECT_TRUE(SymbolicVectorSystemBuilder()
+                  .state(x_)
+                  .dynamics({-x_[1], -x_[0] + 3})
+                  .dynamics_for_variable(x_[0])
+                  .EqualTo(-x_[1]));
+
+  EXPECT_TRUE(SymbolicVectorSystemBuilder()
+                  .state(x_)
+                  .dynamics({-x_[1], -x_[0] + 3})
+                  .dynamics_for_variable(x_[1])
+                  .EqualTo(-x_[0] + 3));
 }
 
 // This test will fail on valgrind if we have dangling references.
@@ -136,7 +165,8 @@ TEST_F(SymbolicVectorSystemTest, CubicPolyViaBuilder) {
   EXPECT_EQ(system->parameter_vars()[0], p);
 
   ASSERT_EQ(system->dynamics().size(), 1);
-  EXPECT_EQ(system->dynamics()[0], -x + pow(x, 3) + p);
+  EXPECT_PRED2(ExprEqual, system->dynamics()[0], -x + pow(x, 3) + p);
+  EXPECT_PRED2(ExprEqual, system->dynamics_for_variable(x), -x + pow(x, 3) + p);
 
   ASSERT_EQ(system->output().size(), 1);
   EXPECT_EQ(system->output()[0], x * p);
@@ -306,7 +336,10 @@ TEST_F(SymbolicVectorSystemTest, ContinuousTimeSymbolic) {
 
   ASSERT_EQ(system->dynamics().size(), 2);
   EXPECT_PRED2(ExprEqual, system->dynamics()[0], t_);
+  EXPECT_PRED2(ExprEqual, system->dynamics_for_variable(x_[0]), t_);
   EXPECT_PRED2(ExprEqual, system->dynamics()[1], x_[1] + u_[1] + p_[1]);
+  EXPECT_PRED2(ExprEqual, system->dynamics_for_variable(x_[1]),
+               x_[1] + u_[1] + p_[1]);
 
   ASSERT_EQ(system->output().size(), 2);
   EXPECT_PRED2(ExprEqual, system->output()[0], x_[0] + u_[0] + p_[0]);
@@ -352,7 +385,10 @@ TEST_F(SymbolicVectorSystemTest, DiscreteTimeSymbolic) {
 
   ASSERT_EQ(system->dynamics().size(), 2);
   EXPECT_PRED2(ExprEqual, system->dynamics()[0], t_);
+  EXPECT_PRED2(ExprEqual, system->dynamics_for_variable(x_[0]), t_);
   EXPECT_PRED2(ExprEqual, system->dynamics()[1], x_[1] + u_[1] + p_[1]);
+  EXPECT_PRED2(ExprEqual, system->dynamics_for_variable(x_[1]),
+               x_[1] + u_[1] + p_[1]);
 
   ASSERT_EQ(system->output().size(), 2);
   EXPECT_PRED2(ExprEqual, system->output()[0], x_[0] + u_[0] + p_[0]);


### PR DESCRIPTION
`state`, `input`, `parameter`, `dynamics`, and `output` setters have `std::vector` variants. So that, for example, a user can write `.dynamics({-x_[1], -x_[0] + 3})` instead of `.dynamics(Vector2<Expression>(-x_[1], -x_[0] + 3))`.

Also add `SymbolicVectorSystem::dynamics_for_variable`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12421)
<!-- Reviewable:end -->
