### PR TITLE
Update image_show.py to be python 3 compatible.

### DIFF
--- a/tools/workspace/drake_visualizer/plugin/show_image.py
+++ b/tools/workspace/drake_visualizer/plugin/show_image.py
@@ -218,7 +218,7 @@ class ImageArrayWidget(object):
     def __init__(self, handlers):
         # Create widget and layouts
         self._widget = QtGui.QWidget()
-        self._image_widgets = map(ImageWidget, handlers)
+        self._image_widgets = list(map(ImageWidget, handlers))
         self._layout = QtGui.QHBoxLayout(self._widget)
         for image_widget in self._image_widgets:
             self._layout.addWidget(image_widget.get_widget())


### PR DESCRIPTION
In python 2, map(func, list) produced a list. In python 3 it produces an iterator. However, in one specific case, we are assuming it is a list and asking it for its length. This makes an explicit conversion from the
iterator the expected list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12422)
<!-- Reviewable:end -->
