### PR TITLE
Reordering the definitions and declarations in symbolic_expression.h

### DIFF
--- a/common/symbolic_expression.h
+++ b/common/symbolic_expression.h
@@ -743,195 +743,22 @@ const Expression& get_then_expression(const Expression& e);
  */
 const Expression& get_else_expression(const Expression& e);
 
-// Matrix<Expression> * Matrix<double> => Matrix<Expression>
-template <typename MatrixL, typename MatrixR>
-typename std::enable_if<
-    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
-        std::is_base_of<Eigen::MatrixBase<MatrixR>, MatrixR>::value &&
-        std::is_same<typename MatrixL::Scalar, Expression>::value &&
-        std::is_same<typename MatrixR::Scalar, double>::value,
-    Eigen::Matrix<Expression, MatrixL::RowsAtCompileTime,
-                  MatrixR::ColsAtCompileTime>>::type
-operator*(const MatrixL& lhs, const MatrixR& rhs) {
-  return lhs.template cast<Expression>() * rhs.template cast<Expression>();
-}
-
-// Matrix<double> * Matrix<Expression> => Matrix<Expression>
-template <typename MatrixL, typename MatrixR>
-typename std::enable_if<
-    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
-        std::is_base_of<Eigen::MatrixBase<MatrixR>, MatrixR>::value &&
-        std::is_same<typename MatrixL::Scalar, double>::value &&
-        std::is_same<typename MatrixR::Scalar, Expression>::value,
-    Eigen::Matrix<Expression, MatrixL::RowsAtCompileTime,
-                  MatrixR::ColsAtCompileTime>>::type
-operator*(const MatrixL& lhs, const MatrixR& rhs) {
-  return lhs.template cast<Expression>() * rhs.template cast<Expression>();
-}
-
 Expression operator+(const Variable& var);
 Expression operator-(const Variable& var);
 
-// Matrix<Expression> * Matrix<Variable> => Matrix<Expression>
-template <typename MatrixL, typename MatrixR>
-typename std::enable_if<
-    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
-        std::is_base_of<Eigen::MatrixBase<MatrixR>, MatrixR>::value &&
-        std::is_same<typename MatrixL::Scalar, Expression>::value &&
-        std::is_same<typename MatrixR::Scalar, Variable>::value,
-    Eigen::Matrix<Expression, MatrixL::RowsAtCompileTime,
-                  MatrixR::ColsAtCompileTime>>::type
-operator*(const MatrixL& lhs, const MatrixR& rhs) {
-  return lhs * rhs.template cast<Expression>();
-}
-
-// Matrix<Variable> * Matrix<Expression> => Matrix<Expression>
-template <typename MatrixL, typename MatrixR>
-typename std::enable_if<
-    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
-        std::is_base_of<Eigen::MatrixBase<MatrixR>, MatrixR>::value &&
-        std::is_same<typename MatrixL::Scalar, Variable>::value &&
-        std::is_same<typename MatrixR::Scalar, Expression>::value,
-    Eigen::Matrix<Expression, MatrixL::RowsAtCompileTime,
-                  MatrixR::ColsAtCompileTime>>::type
-operator*(const MatrixL& lhs, const MatrixR& rhs) {
-  return lhs.template cast<Expression>() * rhs;
-}
-
-// Matrix<Variable> * Matrix<double> => Matrix<Expression>
-template <typename MatrixL, typename MatrixR>
-typename std::enable_if<
-    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
-        std::is_base_of<Eigen::MatrixBase<MatrixR>, MatrixR>::value &&
-        std::is_same<typename MatrixL::Scalar, Variable>::value &&
-        std::is_same<typename MatrixR::Scalar, double>::value,
-    Eigen::Matrix<Expression, MatrixL::RowsAtCompileTime,
-                  MatrixR::ColsAtCompileTime>>::type
-operator*(const MatrixL& lhs, const MatrixR& rhs) {
-  return lhs.template cast<Expression>() * rhs.template cast<Expression>();
-}
-
-// Matrix<double> * Matrix<Variable> => Matrix<Expression>
-template <typename MatrixL, typename MatrixR>
-typename std::enable_if<
-    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
-        std::is_base_of<Eigen::MatrixBase<MatrixR>, MatrixR>::value &&
-        std::is_same<typename MatrixL::Scalar, double>::value &&
-        std::is_same<typename MatrixR::Scalar, Variable>::value,
-    Eigen::Matrix<Expression, MatrixL::RowsAtCompileTime,
-                  MatrixR::ColsAtCompileTime>>::type
-operator*(const MatrixL& lhs, const MatrixR& rhs) {
-  return lhs.template cast<Expression>() * rhs.template cast<Expression>();
-}
-
-/// Transform<double> * Transform<Expression> => Transform<Expression>
-template <int Dim, int LhsMode, int RhsMode, int LhsOptions, int RhsOptions>
-auto operator*(const Eigen::Transform<Expression, Dim, LhsMode, LhsOptions>& t1,
-               const Eigen::Transform<double, Dim, RhsMode, RhsOptions>& t2) {
-  return t1 * t2.template cast<Expression>();
-}
-
-/// Transform<Expression> * Transform<double> => Transform<Expression>
-template <int Dim, int LhsMode, int RhsMode, int LhsOptions, int RhsOptions>
-auto operator*(
-    const Eigen::Transform<double, Dim, LhsMode, LhsOptions>& t1,
-    const Eigen::Transform<Expression, Dim, RhsMode, RhsOptions>& t2) {
-  return t1.template cast<Expression>() * t2;
-}
-
-/// Evaluates a symbolic matrix @p m using @p env and @p random_generator.
+/// Returns the Taylor series expansion of `f` around `a` of order `order`.
 ///
-/// If there is a random variable in @p m which is unassigned in @p env, this
-/// function uses @p random_generator to sample a value and use the value to
-/// substitute all occurrences of the random variable in @p m.
-///
-/// @returns a matrix of double whose size is the size of @p m.
-/// @throws std::runtime_error if NaN is detected during evaluation.
-/// @throws std::runtime_error if @p m includes unassigned random variables but
-///                               @p random_generator is `nullptr`.
-template <typename Derived>
-Eigen::Matrix<double, Derived::RowsAtCompileTime, Derived::ColsAtCompileTime, 0,
-              Derived::MaxRowsAtCompileTime, Derived::MaxColsAtCompileTime>
-Evaluate(const Eigen::MatrixBase<Derived>& m,
-         const Environment& env = Environment{},
-         RandomGenerator* random_generator = nullptr) {
-  static_assert(std::is_same<typename Derived::Scalar, Expression>::value,
-                "Evaluate only accepts a symbolic matrix.");
-  // Note that the return type is written out explicitly to help gcc 5 (on
-  // ubuntu).  Previously the implementation used `auto`, and placed  an `
-  // .eval()` at the end to prevent lazy evaluation.
-  if (random_generator == nullptr) {
-    return m.unaryExpr([&env](const Expression& e) { return e.Evaluate(env); });
-  } else {
-    // Construct an environment by extending `env` by sampling values for the
-    // random variables in `m` which are unassigned in `env`.
-    const Environment env_with_random_variables{PopulateRandomVariables(
-        env, GetDistinctVariables(m), random_generator)};
-    return m.unaryExpr([&env_with_random_variables](const Expression& e) {
-      return e.Evaluate(env_with_random_variables);
-    });
-  }
-}
-
-/// Substitutes a symbolic matrix @p m using a given substitution @p subst.
-///
-/// @returns a matrix of symbolic expressions whose size is the size of @p m.
-/// @throws std::runtime_error if NaN is detected during substitution.
-template <typename Derived>
-Eigen::Matrix<Expression, Derived::RowsAtCompileTime,
-              Derived::ColsAtCompileTime, 0, Derived::MaxRowsAtCompileTime,
-              Derived::MaxColsAtCompileTime>
-Substitute(const Eigen::MatrixBase<Derived>& m, const Substitution& subst) {
-  static_assert(std::is_same<typename Derived::Scalar, Expression>::value,
-                "Substitute only accepts a symbolic matrix.");
-  // Note that the return type is written out explicitly to help gcc 5 (on
-  // ubuntu).
-  return m.unaryExpr(
-      [&subst](const Expression& e) { return e.Substitute(subst); });
-}
-
-/// Substitutes @p var with @p e in a symbolic matrix @p m.
-///
-/// @returns a matrix of symbolic expressions whose size is the size of @p m.
-/// @throws std::runtime_error if NaN is detected during substitution.
-template <typename Derived>
-Eigen::Matrix<Expression, Derived::RowsAtCompileTime,
-              Derived::ColsAtCompileTime, 0, Derived::MaxRowsAtCompileTime,
-              Derived::MaxColsAtCompileTime>
-Substitute(const Eigen::MatrixBase<Derived>& m, const Variable& var,
-           const Expression& e) {
-  static_assert(std::is_same<typename Derived::Scalar, Expression>::value,
-                "Substitute only accepts a symbolic matrix.");
-  // Note that the return type is written out explicitly to help gcc 5 (on
-  // ubuntu).
-  return Substitute(m, Substitution{{var, e}});
-}
+/// @param[in] f     Symbolic expression to approximate using Taylor series
+///                  expansion.
+/// @param[in] a     Symbolic environment which specifies the point of
+///                  approximation. If a partial environment is provided,
+///                  the unspecified variables are treated as symbolic
+///                  variables (e.g. decision variable).
+/// @param[in] order Positive integer which specifies the maximum order of the
+///                  resulting polynomial approximating `f` around `a`.
+Expression TaylorExpand(const Expression& f, const Environment& a, int order);
 
 }  // namespace symbolic
-
-/** Provides specialization of @c cond function defined in drake/common/cond.h
- * file. This specialization is required to handle @c double to @c
- * symbolic::Expression conversion so that we can write one such as <tt>cond(x >
- * 0.0, 1.0, -1.0)</tt>.
- */
-template <typename... Rest>
-symbolic::Expression cond(const symbolic::Formula& f_cond, double v_then,
-                          Rest... rest) {
-  return if_then_else(f_cond, symbolic::Expression{v_then}, cond(rest...));
-}
-
-/// Specializes common/dummy_value.h.
-template <>
-struct dummy_value<symbolic::Expression> {
-  static symbolic::Expression get() { return symbolic::Expression::NaN(); }
-};
-
-/// Returns the symbolic expression's value() as a double.
-///
-/// @throws std::exception if it is not possible to evaluate the symbolic
-/// expression with an empty environment.
-double ExtractDoubleOrThrow(const symbolic::Expression& e);
-
 }  // namespace drake
 
 namespace std {
@@ -1372,6 +1199,167 @@ struct ScalarBinaryOpTraits<double, drake::symbolic::Expression, BinaryOp> {
 namespace drake {
 namespace symbolic {
 
+// Matrix<Expression> * Matrix<double> => Matrix<Expression>
+template <typename MatrixL, typename MatrixR>
+typename std::enable_if<
+    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
+        std::is_base_of<Eigen::MatrixBase<MatrixR>, MatrixR>::value &&
+        std::is_same<typename MatrixL::Scalar, Expression>::value &&
+        std::is_same<typename MatrixR::Scalar, double>::value,
+    Eigen::Matrix<Expression, MatrixL::RowsAtCompileTime,
+                  MatrixR::ColsAtCompileTime>>::type
+operator*(const MatrixL& lhs, const MatrixR& rhs) {
+  return lhs.template cast<Expression>() * rhs.template cast<Expression>();
+}
+
+// Matrix<double> * Matrix<Expression> => Matrix<Expression>
+template <typename MatrixL, typename MatrixR>
+typename std::enable_if<
+    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
+        std::is_base_of<Eigen::MatrixBase<MatrixR>, MatrixR>::value &&
+        std::is_same<typename MatrixL::Scalar, double>::value &&
+        std::is_same<typename MatrixR::Scalar, Expression>::value,
+    Eigen::Matrix<Expression, MatrixL::RowsAtCompileTime,
+                  MatrixR::ColsAtCompileTime>>::type
+operator*(const MatrixL& lhs, const MatrixR& rhs) {
+  return lhs.template cast<Expression>() * rhs.template cast<Expression>();
+}
+
+// Matrix<Expression> * Matrix<Variable> => Matrix<Expression>
+template <typename MatrixL, typename MatrixR>
+typename std::enable_if<
+    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
+        std::is_base_of<Eigen::MatrixBase<MatrixR>, MatrixR>::value &&
+        std::is_same<typename MatrixL::Scalar, Expression>::value &&
+        std::is_same<typename MatrixR::Scalar, Variable>::value,
+    Eigen::Matrix<Expression, MatrixL::RowsAtCompileTime,
+                  MatrixR::ColsAtCompileTime>>::type
+operator*(const MatrixL& lhs, const MatrixR& rhs) {
+  return lhs * rhs.template cast<Expression>();
+}
+
+// Matrix<Variable> * Matrix<Expression> => Matrix<Expression>
+template <typename MatrixL, typename MatrixR>
+typename std::enable_if<
+    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
+        std::is_base_of<Eigen::MatrixBase<MatrixR>, MatrixR>::value &&
+        std::is_same<typename MatrixL::Scalar, Variable>::value &&
+        std::is_same<typename MatrixR::Scalar, Expression>::value,
+    Eigen::Matrix<Expression, MatrixL::RowsAtCompileTime,
+                  MatrixR::ColsAtCompileTime>>::type
+operator*(const MatrixL& lhs, const MatrixR& rhs) {
+  return lhs.template cast<Expression>() * rhs;
+}
+
+// Matrix<Variable> * Matrix<double> => Matrix<Expression>
+template <typename MatrixL, typename MatrixR>
+typename std::enable_if<
+    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
+        std::is_base_of<Eigen::MatrixBase<MatrixR>, MatrixR>::value &&
+        std::is_same<typename MatrixL::Scalar, Variable>::value &&
+        std::is_same<typename MatrixR::Scalar, double>::value,
+    Eigen::Matrix<Expression, MatrixL::RowsAtCompileTime,
+                  MatrixR::ColsAtCompileTime>>::type
+operator*(const MatrixL& lhs, const MatrixR& rhs) {
+  return lhs.template cast<Expression>() * rhs.template cast<Expression>();
+}
+
+// Matrix<double> * Matrix<Variable> => Matrix<Expression>
+template <typename MatrixL, typename MatrixR>
+typename std::enable_if<
+    std::is_base_of<Eigen::MatrixBase<MatrixL>, MatrixL>::value &&
+        std::is_base_of<Eigen::MatrixBase<MatrixR>, MatrixR>::value &&
+        std::is_same<typename MatrixL::Scalar, double>::value &&
+        std::is_same<typename MatrixR::Scalar, Variable>::value,
+    Eigen::Matrix<Expression, MatrixL::RowsAtCompileTime,
+                  MatrixR::ColsAtCompileTime>>::type
+operator*(const MatrixL& lhs, const MatrixR& rhs) {
+  return lhs.template cast<Expression>() * rhs.template cast<Expression>();
+}
+
+/// Transform<double> * Transform<Expression> => Transform<Expression>
+template <int Dim, int LhsMode, int RhsMode, int LhsOptions, int RhsOptions>
+auto operator*(const Eigen::Transform<Expression, Dim, LhsMode, LhsOptions>& t1,
+               const Eigen::Transform<double, Dim, RhsMode, RhsOptions>& t2) {
+  return t1 * t2.template cast<Expression>();
+}
+
+/// Transform<Expression> * Transform<double> => Transform<Expression>
+template <int Dim, int LhsMode, int RhsMode, int LhsOptions, int RhsOptions>
+auto operator*(
+    const Eigen::Transform<double, Dim, LhsMode, LhsOptions>& t1,
+    const Eigen::Transform<Expression, Dim, RhsMode, RhsOptions>& t2) {
+  return t1.template cast<Expression>() * t2;
+}
+
+/// Evaluates a symbolic matrix @p m using @p env and @p random_generator.
+///
+/// If there is a random variable in @p m which is unassigned in @p env, this
+/// function uses @p random_generator to sample a value and use the value to
+/// substitute all occurrences of the random variable in @p m.
+///
+/// @returns a matrix of double whose size is the size of @p m.
+/// @throws std::runtime_error if NaN is detected during evaluation.
+/// @throws std::runtime_error if @p m includes unassigned random variables but
+///                               @p random_generator is `nullptr`.
+template <typename Derived>
+Eigen::Matrix<double, Derived::RowsAtCompileTime, Derived::ColsAtCompileTime, 0,
+              Derived::MaxRowsAtCompileTime, Derived::MaxColsAtCompileTime>
+Evaluate(const Eigen::MatrixBase<Derived>& m,
+         const Environment& env = Environment{},
+         RandomGenerator* random_generator = nullptr) {
+  static_assert(std::is_same<typename Derived::Scalar, Expression>::value,
+                "Evaluate only accepts a symbolic matrix.");
+  // Note that the return type is written out explicitly to help gcc 5 (on
+  // ubuntu).  Previously the implementation used `auto`, and placed  an `
+  // .eval()` at the end to prevent lazy evaluation.
+  if (random_generator == nullptr) {
+    return m.unaryExpr([&env](const Expression& e) { return e.Evaluate(env); });
+  } else {
+    // Construct an environment by extending `env` by sampling values for the
+    // random variables in `m` which are unassigned in `env`.
+    const Environment env_with_random_variables{PopulateRandomVariables(
+        env, GetDistinctVariables(m), random_generator)};
+    return m.unaryExpr([&env_with_random_variables](const Expression& e) {
+      return e.Evaluate(env_with_random_variables);
+    });
+  }
+}
+
+/// Substitutes a symbolic matrix @p m using a given substitution @p subst.
+///
+/// @returns a matrix of symbolic expressions whose size is the size of @p m.
+/// @throws std::runtime_error if NaN is detected during substitution.
+template <typename Derived>
+Eigen::Matrix<Expression, Derived::RowsAtCompileTime,
+              Derived::ColsAtCompileTime, 0, Derived::MaxRowsAtCompileTime,
+              Derived::MaxColsAtCompileTime>
+Substitute(const Eigen::MatrixBase<Derived>& m, const Substitution& subst) {
+  static_assert(std::is_same<typename Derived::Scalar, Expression>::value,
+                "Substitute only accepts a symbolic matrix.");
+  // Note that the return type is written out explicitly to help gcc 5 (on
+  // ubuntu).
+  return m.unaryExpr(
+      [&subst](const Expression& e) { return e.Substitute(subst); });
+}
+
+/// Substitutes @p var with @p e in a symbolic matrix @p m.
+///
+/// @returns a matrix of symbolic expressions whose size is the size of @p m.
+/// @throws std::runtime_error if NaN is detected during substitution.
+template <typename Derived>
+Eigen::Matrix<Expression, Derived::RowsAtCompileTime,
+              Derived::ColsAtCompileTime, 0, Derived::MaxRowsAtCompileTime,
+              Derived::MaxColsAtCompileTime>
+Substitute(const Eigen::MatrixBase<Derived>& m, const Variable& var,
+           const Expression& e) {
+  static_assert(std::is_same<typename Derived::Scalar, Expression>::value,
+                "Substitute only accepts a symbolic matrix.");
+  // Note that the return type is written out explicitly to help gcc 5 (on
+  // ubuntu).
+  return Substitute(m, Substitution{{var, e}});
+}
+
 /// Constructs a vector of variables from the vector of variable expressions.
 /// @throws std::logic_error if there is an expression in @p vec which is not a
 /// variable.
@@ -1400,18 +1388,6 @@ MatrixX<Expression> Jacobian(const Eigen::Ref<const VectorX<Expression>>& f,
 MatrixX<Expression> Jacobian(const Eigen::Ref<const VectorX<Expression>>& f,
                              const Eigen::Ref<const VectorX<Variable>>& vars);
 
-/// Returns the Taylor series expansion of `f` around `a` of order `order`.
-///
-/// @param[in] f     Symbolic expression to approximate using Taylor series
-///                  expansion.
-/// @param[in] a     Symbolic environment which specifies the point of
-///                  approximation. If a partial environment is provided,
-///                  the unspecified variables are treated as symbolic
-///                  variables (e.g. decision variable).
-/// @param[in] order Positive integer which specifies the maximum order of the
-///                  resulting polynomial approximating `f` around `a`.
-Expression TaylorExpand(const Expression& f, const Environment& a, int order);
-
 /// Returns the distinct variables in the matrix of expressions.
 Variables GetDistinctVariables(const Eigen::Ref<const MatrixX<Expression>>& v);
 
@@ -1434,6 +1410,29 @@ CheckStructuralEquality(const DerivedA& m1, const DerivedB& m2) {
 }
 
 }  // namespace symbolic
+
+/** Provides specialization of @c cond function defined in drake/common/cond.h
+ * file. This specialization is required to handle @c double to @c
+ * symbolic::Expression conversion so that we can write one such as <tt>cond(x >
+ * 0.0, 1.0, -1.0)</tt>.
+ */
+template <typename... Rest>
+symbolic::Expression cond(const symbolic::Formula& f_cond, double v_then,
+                          Rest... rest) {
+  return if_then_else(f_cond, symbolic::Expression{v_then}, cond(rest...));
+}
+
+/// Specializes common/dummy_value.h.
+template <>
+struct dummy_value<symbolic::Expression> {
+  static symbolic::Expression get() { return symbolic::Expression::NaN(); }
+};
+
+/// Returns the symbolic expression's value() as a double.
+///
+/// @throws std::exception if it is not possible to evaluate the symbolic
+/// expression with an empty environment.
+double ExtractDoubleOrThrow(const symbolic::Expression& e);
 
 /*
  * Determine if two EigenBase<> types are matrices (non-column-vectors) of


### PR DESCRIPTION
The new ordering is:

1) In namespace drake::symbolic:
Introduce symbolic::Expression and its utility functions.

2) In namespace std:
Provide specialization of std::hash, std::less, std::equal_to,
std::numeric_limits, std::uniform_real_distribution, std::normal_distribution,
std::exponential_distribution for symbolic::Expression.

3) In namespace Eigen:
Provide specialization of NumTraits, ScalarBinaryOpTraits for
symbolic::Expression.

4) In namespace drake::symbolic:
Definitions and declarations using symbolic Eigen Dense/Sparse matrix.

5) In namespace Drake:
Extra overloading that should be in this namespace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12427)
<!-- Reviewable:end -->
