### PR TITLE
py systems: Ensure names get copied by default for scalar conversion

### DIFF
--- a/bindings/pydrake/systems/test/scalar_conversion_test.py
+++ b/bindings/pydrake/systems/test/scalar_conversion_test.py
@@ -5,7 +5,11 @@ import unittest
 
 from pydrake.autodiffutils import AutoDiffXd
 from pydrake.symbolic import Expression
-from pydrake.systems.framework import LeafSystem_, SystemScalarConverter
+from pydrake.systems.framework import (
+    DiagramBuilder,
+    LeafSystem_,
+    SystemScalarConverter,
+)
 from pydrake.common.cpp_template import TemplateClass
 
 
@@ -84,6 +88,18 @@ class TestScalarConversion(unittest.TestCase):
             self.assertIsInstance(system_T, Example_[T])
             self.assertEqual(system_T.value, 100)
             self.assertIs(system_T.copied_from, system_U)
+
+    def test_example_system_in_diagram(self):
+        system_f = Example(value=10)
+        system_f.set_name("example")
+        builder_f = DiagramBuilder()
+        builder_f.AddSystem(system_f)
+        diagram_f = builder_f.Build()
+
+        diagram_ad = diagram_f.ToAutoDiffXd()
+        system_ad = diagram_ad.GetSubsystemByName(system_f.get_name())
+        self.assertIsInstance(system_ad, Example_[AutoDiffXd])
+        self.assertIs(system_ad.copied_from, system_f)
 
     def test_define_convertible_system_api(self):
         """Tests more advanced API of `TemplateSystem.define`, both

--- a/systems/framework/system_scalar_converter.h
+++ b/systems/framework/system_scalar_converter.h
@@ -222,6 +222,8 @@ std::unique_ptr<System<T>> SystemScalarConverter::Convert(
 
 namespace system_scalar_converter_internal {
 // When Traits says that conversion is supported.
+// N.B. This logic should be reflected in `TemplateSystem._make` in the file
+// `scalar_conversion.py`.
 template <template <typename> class S, typename T, typename U>
 static std::unique_ptr<System<T>> Make(
     bool subtype_preservation, const System<U>& other, std::true_type) {


### PR DESCRIPTION
Per Slack convo:
https://drakedevelopers.slack.com/archives/C3YB3EV5W/p1575317131065000

\cc @mposa

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12429)
<!-- Reviewable:end -->
