### PR TITLE
py common: Move AbstractValue and Value here

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -169,6 +169,7 @@ drake_pybind_library(
         "//bindings/pydrake/common:default_scalars_pybind",
         "//bindings/pydrake/common:deprecation_pybind",
         "//bindings/pydrake/common:type_pack",
+        "//bindings/pydrake/common:value_pybind",
     ],
     cc_srcs = ["math_py.cc"],
     package_info = PACKAGE_INFO,
@@ -177,6 +178,7 @@ drake_pybind_library(
         "//bindings/pydrake:autodiffutils_py",
         "//bindings/pydrake:symbolic_py",
         "//bindings/pydrake/common:eigen_geometry_py",
+        "//bindings/pydrake/common:value_py",
     ],
     py_srcs = ["_math_extra.py"],
 )
@@ -191,7 +193,7 @@ drake_pybind_library(
     package_info = PACKAGE_INFO,
     py_deps = [
         ":module_py",
-        "//bindings/pydrake/systems:framework_py",
+        "//bindings/pydrake/common:value_py",
         "//bindings/pydrake/systems:sensors_py",
     ],
 )

--- a/bindings/pydrake/__init__.py
+++ b/bindings/pydrake/__init__.py
@@ -77,6 +77,23 @@ def _setattr_kwargs(obj, kwargs):
         setattr(obj, name, value)
 
 
+def _import_cc_module_vars(cc_module, py_module_name):
+    # Imports the cc_module's public symbols into the named py module
+    # (py_module_name), resetting their __module__ to be the py module in the
+    # process.
+    # Returns a list[str] of the public symbol names imported.
+    py_module = sys.modules[py_module_name]
+    var_list = []
+    for name, value in cc_module.__dict__.items():
+        if name.startswith("_"):
+            continue
+        if getattr(value, "__module__", None) == cc_module.__name__:
+            value.__module__ = py_module_name
+        setattr(py_module, name, value)
+        var_list.append(name)
+    return var_list
+
+
 class _DrakeImportWarning(Warning):
     pass
 

--- a/bindings/pydrake/attic/systems/test/sensors_test.py
+++ b/bindings/pydrake/attic/systems/test/sensors_test.py
@@ -7,13 +7,14 @@ import numpy as np
 
 from pydrake.common import FindResourceOrThrow
 from pydrake.common.eigen_geometry import Isometry3
+from pydrake.common.value import Value
 from pydrake.attic.multibody.rigid_body_tree import (
     AddModelInstancesFromSdfString,
     FloatingBaseType,
     RigidBodyTree,
     RigidBodyFrame,
 )
-from pydrake.systems.framework import InputPort, OutputPort, Value
+from pydrake.systems.framework import InputPort, OutputPort
 
 
 class TestSensors(unittest.TestCase):

--- a/bindings/pydrake/common/BUILD.bazel
+++ b/bindings/pydrake/common/BUILD.bazel
@@ -46,9 +46,12 @@ drake_pybind_library(
     cc_deps = [
         "//bindings/pydrake:documentation_pybind",
         "//bindings/pydrake/common:deprecation_pybind",
+        "//bindings/pydrake/common:value_pybind",
     ],
     cc_so_name = "_module_py",
-    cc_srcs = ["module_py.cc"],
+    cc_srcs = [
+        "module_py.cc",
+    ],
     package_info = PACKAGE_INFO,
     py_srcs = [
         "__init__.py",
@@ -134,6 +137,21 @@ drake_cc_library(
     ],
 )
 
+drake_pybind_library(
+    name = "value_py",
+    cc_deps = [
+        "//bindings/pydrake:documentation_pybind",
+        "//bindings/pydrake/common:value_pybind",
+    ],
+    cc_so_name = "value",
+    cc_srcs = ["value_py.cc"],
+    package_info = PACKAGE_INFO,
+    py_deps = [
+        ":module_py",
+        ":cpp_template_py",
+    ],
+)
+
 # N.B. Any C++ libraries that include this must include `cpp_template_py` when
 # being used in Python.
 drake_cc_library(
@@ -177,12 +195,14 @@ drake_pybind_library(
         ":deprecation_pybind",
         ":eigen_geometry_pybind",
         ":type_pack",
+        ":value_pybind",
     ],
     cc_srcs = ["eigen_geometry_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
         ":module_py",
         ":cpp_template_py",
+        ":value_py",
         "//bindings/pydrake:autodiffutils_py",
         "//bindings/pydrake:symbolic_py",
     ],
@@ -292,6 +312,7 @@ drake_py_library(
 PY_LIBRARIES_WITH_INSTALL = [
     ":_init_py",
     ":eigen_geometry_py",
+    ":value_py",
 ]
 
 PY_LIBRARIES = [
@@ -517,10 +538,31 @@ drake_py_unittest(
 )
 
 drake_pybind_library(
+    name = "value_test_util_py",
+    testonly = 1,
+    add_install = False,
+    cc_deps = [":value_pybind"],
+    cc_so_name = "test/value_test_util",
+    cc_srcs = ["test/value_test_util_py.cc"],
+    package_info = PACKAGE_INFO,
+    visibility = ["//visibility:private"],
+)
+
+drake_py_unittest(
+    name = "value_test",
+    deps = [
+        ":module_py",
+        ":value_py",
+        ":value_test_util_py",
+    ],
+)
+
+drake_pybind_library(
     name = "wrap_test_util_py",
     testonly = 1,
     add_install = False,
     cc_deps = [":wrap_pybind"],
+    cc_so_name = "test/wrap_test_util",
     cc_srcs = ["test/wrap_test_util_py.cc"],
     package_info = PACKAGE_INFO,
     visibility = ["//visibility:private"],

--- a/bindings/pydrake/common/all.py
+++ b/bindings/pydrake/common/all.py
@@ -6,6 +6,7 @@ from .containers import *
 # - `cpp_template` does not offer public Drake symbols.
 # - `deprecation` does not offer public Drake symbols.
 from .eigen_geometry import *
+from .value import *
 # N.B. Since this is generic and relatively scoped, we import the module as a
 # symbol.
 from . import pybind11_version

--- a/bindings/pydrake/common/deprecation.py
+++ b/bindings/pydrake/common/deprecation.py
@@ -20,6 +20,8 @@ import warnings
 
 # TODO(eric.cousineau): Make autocomplete ignore `ModuleShim` attributes
 # (e.g. `install`).
+# TODO(eric.cousineau): Remove ModuleShim once Drake requires Python >= 3.7
+# (for PEP 562).
 
 
 class ModuleShim(object):
@@ -30,6 +32,14 @@ class ModuleShim(object):
 
     See Also:
         https://stackoverflow.com/a/7668273/7829525
+
+    Note:
+        This is not necessary in Python >= 3.7 due to PEP 562.
+    Warning:
+        This will not work if called on a cc module during import (e.g. using
+        ExecuteExtraPythonCode). Instead, you should rename the module from
+        `{name}` to `_{name}`, and import the symbols into the new module using
+        _import_cc_module_vars.
     """
 
     def __init__(self, orig_module, handler):

--- a/bindings/pydrake/common/eigen_geometry_py.cc
+++ b/bindings/pydrake/common/eigen_geometry_py.cc
@@ -8,6 +8,7 @@
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/eigen_geometry_pybind.h"
 #include "drake/bindings/pydrake/common/type_pack.h"
+#include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/common/drake_assertion_error.h"
 #include "drake/common/drake_throw.h"
@@ -186,6 +187,9 @@ void DoScalarDependentDefinitions(py::module m, T) {
     py::implicitly_convertible<Matrix4<T>, Class>();
     DefCopyAndDeepCopy(&cls);
     DefCast<T>(&cls, kCastDoc);
+    // TODO(eric): Consider deprecating / removing `Value[Isometry3]` pending
+    // resolution of #9865.
+    AddValueInstantiation<Isometry3<T>>(m);
   }
 
   // Quaternion.

--- a/bindings/pydrake/common/module_py.cc
+++ b/bindings/pydrake/common/module_py.cc
@@ -27,6 +27,7 @@ void trigger_an_assertion_failure() {
 }  // namespace
 
 PYBIND11_MODULE(_module_py, m) {
+  PYDRAKE_PREVENT_PYTHON3_MODULE_REIMPORT(m);
   m.doc() = "Bindings for //common:common";
 
   constexpr auto& doc = pydrake_doc.drake;

--- a/bindings/pydrake/common/test/eigen_geometry_test.py
+++ b/bindings/pydrake/common/test/eigen_geometry_test.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from pydrake.autodiffutils import AutoDiffXd
 from pydrake.symbolic import Expression
+from pydrake.common.value import Value
 import pydrake.common.test.eigen_geometry_test_util as test_util
 from pydrake.common.test_utilities import numpy_compare
 from pydrake.common.test_utilities.deprecation import catch_drake_warnings
@@ -271,3 +272,8 @@ class TestEigenGeometry(unittest.TestCase):
             return np.hstack((value.angle(), value.axis()))
 
         assert_pickle(self, value, get_vector, T=T)
+
+    @numpy_compare.check_all_types
+    def test_value_instantiations(self, T):
+        # Existence checks.
+        Value[mut.Isometry3_[T]]

--- a/bindings/pydrake/common/test/value_test.py
+++ b/bindings/pydrake/common/test/value_test.py
@@ -1,0 +1,85 @@
+import copy
+import unittest
+
+from pydrake.common.value import AbstractValue, Value
+
+from pydrake.common.test.value_test_util import (
+    make_unknown_abstract_value,
+    MoveOnlyType,
+)
+
+
+class TestValue(unittest.TestCase):
+    def test_abstract_value_copyable(self):
+        expected = "Hello world"
+        value = Value[str](expected)
+        self.assertIsInstance(value, AbstractValue)
+        self.assertEqual(value.get_value(), expected)
+        expected_new = "New value"
+        value.set_value(expected_new)
+        self.assertEqual(value.get_value(), expected_new)
+        # Test docstring.
+        self.assertFalse("unique_ptr" in value.set_value.__doc__)
+
+    def test_abstract_value_move_only(self):
+        obj = MoveOnlyType(10)
+        self.assertEqual(
+            str(Value[MoveOnlyType]),
+            "<class 'pydrake.common.value.Value[MoveOnlyType]'>")
+        # This *always* clones `obj`.
+        value = Value[MoveOnlyType](obj)
+        self.assertTrue(value.get_value() is not obj)
+        self.assertEqual(value.get_value().x(), 10)
+        # Set value.
+        value.get_mutable_value().set_x(20)
+        self.assertEqual(value.get_value().x(), 20)
+        # Test custom emplace constructor.
+        emplace_value = Value[MoveOnlyType](30)
+        self.assertEqual(emplace_value.get_value().x(), 30)
+        # Test docstring.
+        self.assertTrue("unique_ptr" in value.set_value.__doc__)
+
+    def test_abstract_value_py_object(self):
+        expected = {"x": 10}
+        value = Value[object](expected)
+        # Value is by reference, *not* by copy.
+        self.assertTrue(value.get_value() is expected)
+        # Update mutable version.
+        value.get_mutable_value()["y"] = 30
+        self.assertEqual(value.get_value(), expected)
+        # Cloning the value should perform a deep copy of the Python object.
+        value_clone = copy.deepcopy(value)
+        self.assertEqual(value_clone.get_value(), expected)
+        self.assertTrue(value_clone.get_value() is not expected)
+        # Using `set_value` on the original value changes object reference.
+        expected_new = {"a": 20}
+        value.set_value(expected_new)
+        self.assertEqual(value.get_value(), expected_new)
+        self.assertTrue(value.get_value() is not expected)
+
+    def test_abstract_value_make(self):
+        value = AbstractValue.Make("Hello world")
+        self.assertIsInstance(value, Value[str])
+        value = AbstractValue.Make(MoveOnlyType(10))
+        self.assertIsInstance(value, Value[MoveOnlyType])
+        value = AbstractValue.Make({"x": 10})
+        self.assertIsInstance(value, Value[object])
+
+    def test_abstract_value_unknown(self):
+        value = make_unknown_abstract_value()
+        self.assertIsInstance(value, AbstractValue)
+        with self.assertRaises(RuntimeError) as cm:
+            value.get_value()
+        self.assertTrue(all(
+            s in str(cm.exception) for s in [
+                "AbstractValue",
+                "UnknownType",
+                "get_value",
+                "AddValueInstantiation",
+            ]), cm.exception)
+
+    def test_value_registration(self):
+        # Existence check.
+        Value[object]
+        Value[str]
+        Value[bool]

--- a/bindings/pydrake/common/test/value_test_util_py.cc
+++ b/bindings/pydrake/common/test/value_test_util_py.cc
@@ -1,0 +1,46 @@
+#include "pybind11/pybind11.h"
+
+#include "drake/bindings/pydrake/common/value_pybind.h"
+#include "drake/bindings/pydrake/pydrake_pybind.h"
+
+namespace drake {
+namespace pydrake {
+namespace {
+
+class MoveOnlyType {
+ public:
+  explicit MoveOnlyType(int x) : x_(x) {}
+  MoveOnlyType(MoveOnlyType&&) = default;
+  MoveOnlyType& operator=(MoveOnlyType&&) = default;
+  MoveOnlyType(const MoveOnlyType&) = delete;
+  MoveOnlyType& operator=(const MoveOnlyType&) = delete;
+  int x() const { return x_; }
+  void set_x(int x) { x_ = x; }
+  std::unique_ptr<MoveOnlyType> Clone() const {
+    return std::make_unique<MoveOnlyType>(x_);
+  }
+
+ private:
+  int x_{};
+};
+
+struct UnknownType {};
+
+}  // namespace
+
+PYBIND11_MODULE(value_test_util, m) {
+  py::module::import("pydrake.common");
+
+  py::class_<MoveOnlyType>(m, "MoveOnlyType")
+      .def(py::init<int>())
+      .def("x", &MoveOnlyType::x)
+      .def("set_x", &MoveOnlyType::set_x);
+  // Define `Value` instantiation.
+  AddValueInstantiation<MoveOnlyType>(m);
+
+  m.def("make_unknown_abstract_value",
+      []() { return AbstractValue::Make(UnknownType{}); });
+}
+
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/common/test/wrap_pybind_test.py
+++ b/bindings/pydrake/common/test/wrap_pybind_test.py
@@ -2,7 +2,7 @@ import copy
 import gc
 import unittest
 
-from pydrake.common.wrap_test_util import (
+from pydrake.common.test.wrap_test_util import (
     MyContainerRawPtr,
     MyContainerUniquePtr,
     MyValue,

--- a/bindings/pydrake/common/value_py.cc
+++ b/bindings/pydrake/common/value_py.cc
@@ -1,0 +1,91 @@
+#include <string>
+
+#include "pybind11/eval.h"
+#include "pybind11/pybind11.h"
+
+#include "drake/bindings/pydrake/common/value_pybind.h"
+#include "drake/bindings/pydrake/documentation_pybind.h"
+#include "drake/bindings/pydrake/pydrake_pybind.h"
+
+namespace drake {
+namespace pydrake {
+
+namespace {
+
+// Specialize C++ implementation for `Value[object]` instantiation.
+class PyObjectValue : public drake::Value<py::object> {
+ public:
+  using Base = Value<py::object>;
+  using Base::Base;
+  // Override `Value<py::object>::Clone()` to perform a deep copy on the
+  // object.
+  std::unique_ptr<AbstractValue> Clone() const override {
+    py::object py_copy = py::module::import("copy").attr("deepcopy");
+    return std::make_unique<PyObjectValue>(py_copy(get_value()));
+  }
+};
+
+// Add instantiations of primitive types on an as-needed basis; please be
+// conservative.
+void AddPrimitiveValueInstantiations(py::module m) {
+  AddValueInstantiation<std::string>(m);
+  AddValueInstantiation<bool>(m);
+  AddValueInstantiation<py::object, PyObjectValue>(m);
+}
+
+}  // namespace
+
+PYBIND11_MODULE(value, m) {
+  PYDRAKE_PREVENT_PYTHON3_MODULE_REIMPORT(m);
+  m.doc() = "Bindings for //common:value";
+  constexpr auto& doc = pydrake_doc.drake;
+
+  // `AddValueInstantiation` will define methods specific to `T` for
+  // `Value<T>`. Since Python is nominally dynamic, these methods are
+  // effectively "virtual".
+  auto abstract_stub = [](const std::string& method) {
+    return [method](const AbstractValue* self, py::args, py::kwargs) {
+      std::string type_name = NiceTypeName::Get(*self);
+      throw std::runtime_error(
+          "This derived class of `AbstractValue`, `" + type_name + "`, " +
+          "is not exposed to pybind11, so `" + method + "` cannot be " +
+          "called. See `AddValueInstantiation` for how to bind it.");
+    };
+  };
+
+  py::class_<AbstractValue> abstract_value(m, "AbstractValue");
+  DefClone(&abstract_value);
+  abstract_value  // BR
+      .def("SetFrom", &AbstractValue::SetFrom, doc.AbstractValue.SetFrom.doc)
+      .def("get_value", abstract_stub("get_value"),
+          doc.AbstractValue.get_value.doc)
+      .def("get_mutable_value", abstract_stub("get_mutable_value"),
+          doc.AbstractValue.get_mutable_value.doc)
+      .def("set_value", abstract_stub("set_value"),
+          doc.AbstractValue.set_value.doc);
+
+  // Add value instantiations for nominal data types.
+  AddPrimitiveValueInstantiations(m);
+
+  py::object py_type_func = py::eval("type");
+  py::object py_object_type = py::eval("object");
+  // `Value` was defined by the first call to `AddValueInstantiation`.
+  py::object py_value_template = m.attr("Value");
+  abstract_value.def_static("Make",
+      [py_type_func, py_value_template, py_object_type](py::object value) {
+        // Try to infer type from the object. If that does not work, just return
+        // `Value[object]`.
+        py::object py_type = py_type_func(value);
+        py::tuple py_result =
+            py_value_template.attr("get_instantiation")(py_type, false);
+        py::object py_value_class = py_result[0];
+        if (py_value_class.is_none()) {
+          py_value_class = py_value_template[py_object_type];
+        }
+        return py_value_class(value);
+      },
+      doc.AbstractValue.Make.doc);
+}
+
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/common/value_pybind.h
+++ b/bindings/pydrake/common/value_pybind.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /// @file
-/// Helpers for defining scalars and values.
+/// Helpers for defining instantiations of drake::Value<>.
 
 #include <string>
 
@@ -14,8 +14,8 @@
 namespace drake {
 namespace pydrake {
 
-/// Defines an instantiation of `pydrake.systems.framework.Value[...]`. This is
-/// only meant to bind `Value<T>` (or specializations thereof).
+/// Defines an instantiation of `pydrake.common.value.Value[...]`. This is only
+/// meant to bind `Value<T>` (or specializations thereof).
 /// @prereq `T` must have already been exposed to `pybind11`.
 /// @param scope Parent scope.
 /// @tparam T Inner parameter of `Value<T>`.
@@ -24,11 +24,11 @@ namespace pydrake {
 template <typename T, typename Class = drake::Value<T>>
 py::class_<Class, drake::AbstractValue> AddValueInstantiation(
     py::module scope) {
+  py::module py_common = py::module::import("pydrake.common.value");
   py::class_<Class, drake::AbstractValue> py_class(
       scope, TemporaryClassName<Class>().c_str());
   // Register instantiation.
-  py::module py_framework = py::module::import("pydrake.systems.framework");
-  AddTemplateClass(py_framework, "Value", py_class, GetPyParam<T>());
+  AddTemplateClass(py_common, "Value", py_class, GetPyParam<T>());
   // Only use copy (clone) construction.
   // Ownership with `unique_ptr<T>` has some annoying caveats, and some are
   // simplified by always copying.

--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -710,7 +710,7 @@ void DoScalarIndependentDefinitions(py::module m) {
     using Class = GeometryProperties;
     constexpr auto& cls_doc = doc.GeometryProperties;
     py::handle abstract_value_cls =
-        py::module::import("pydrake.systems.framework").attr("AbstractValue");
+        py::module::import("pydrake.common.value").attr("AbstractValue");
     py::class_<Class>(m, "GeometryProperties", cls_doc.doc)
         .def("HasGroup", &Class::HasGroup, py::arg("group_name"),
             cls_doc.HasGroup.doc)

--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -10,6 +10,7 @@
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/type_pack.h"
+#include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/symbolic_types_pybind.h"
@@ -133,6 +134,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
     DefCast<T>(&cls, cls_doc.cast.doc);
     // .def("IsNearlyEqualTo", ...)
     // .def("IsExactlyEqualTo", ...)
+    AddValueInstantiation<RigidTransform<T>>(m);
   }
 
   {
@@ -198,6 +200,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
     cls.attr("__matmul__") = cls.attr("multiply");
     DefCopyAndDeepCopy(&cls);
     DefCast<T>(&cls, cls_doc.cast.doc);
+    AddValueInstantiation<RotationMatrix<T>>(m);
   }
 
   {

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -923,6 +923,7 @@ PYBIND11_MODULE(plant, m) {
   m.doc() = "Bindings for MultibodyPlant and related classes.";
 
   py::module::import("pydrake.geometry");
+  py::module::import("pydrake.math");
   py::module::import("pydrake.multibody.math");
   py::module::import("pydrake.multibody.tree");
   py::module::import("pydrake.systems.framework");

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -64,6 +64,7 @@ from pydrake.multibody.benchmarks.acrobot import (
 from pydrake.common import FindResourceOrThrow
 from pydrake.common.deprecation import install_numpy_warning_filters
 from pydrake.common.test_utilities import numpy_compare
+from pydrake.common.value import AbstractValue
 from pydrake.geometry import (
     Box,
     GeometryId,
@@ -81,7 +82,6 @@ from pydrake.math import (
 )
 from pydrake.systems.analysis import Simulator_
 from pydrake.systems.framework import (
-    AbstractValue,
     BasicVector_,
     DiagramBuilder_,
     System_,

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -54,6 +54,7 @@ drake_pybind_library(
         "//bindings/pydrake/common:value_pybind",
         "//bindings/pydrake/common:wrap_pybind",
     ],
+    cc_so_name = "_framework",
     cc_srcs = [
         "framework_py.cc",
         "framework_py_semantics.cc",
@@ -71,7 +72,9 @@ drake_pybind_library(
         "//bindings/pydrake:symbolic_py",
         "//bindings/pydrake/common:cpp_template_py",
         "//bindings/pydrake/common:eigen_geometry_py",
+        "//bindings/pydrake/common:value_py",
     ],
+    py_srcs = ["framework.py"],
 )
 
 drake_py_library(
@@ -429,7 +432,6 @@ drake_py_unittest(
     name = "value_test",
     deps = [
         ":framework_py",
-        ":test_util_py",
     ],
 )
 

--- a/bindings/pydrake/systems/_lcm_extra.py
+++ b/bindings/pydrake/systems/_lcm_extra.py
@@ -1,6 +1,6 @@
 # See `ExecuteExtraPythonCode` in `pydrake_pybind.h` for usage details and
 # rationale.
-from pydrake.systems.framework import AbstractValue
+from pydrake.common.value import AbstractValue
 
 
 class PySerializer(SerializerInterface):

--- a/bindings/pydrake/systems/framework.py
+++ b/bindings/pydrake/systems/framework.py
@@ -1,0 +1,27 @@
+"""
+This module only exists to handle deprecation.
+
+Actual docstring will be overridden programmatically.
+"""
+from pydrake import _import_cc_module_vars
+import pydrake.common.deprecation as _deprecation
+import pydrake.common.value as _value
+from pydrake.systems import _framework as _cc
+
+__doc__ = _cc.__doc__
+__all__ = _import_cc_module_vars(_cc, __name__)
+
+
+def _getattr(name):
+    if name in ["AbstractValue", "Value"]:
+        old_symbol = f"{__name__}.{name}"
+        new_symbol = f"{_value.__name__}.{name}"
+        _deprecation._warn_deprecated(
+            f"{old_symbol} has moved to {new_symbol}. Please use it instead. "
+            f"This will be removed on or after 2020-08-01.")
+        return getattr(_value, name)
+    else:
+        raise AttributeError()
+
+
+_deprecation.ModuleShim._install(__name__, _getattr)

--- a/bindings/pydrake/systems/framework_py.cc
+++ b/bindings/pydrake/systems/framework_py.cc
@@ -6,7 +6,9 @@
 namespace drake {
 namespace pydrake {
 
-PYBIND11_MODULE(framework, m) {
+// TODO(eric.cousineau): Remove leading underscore once deprecation shim module
+// is removed.
+PYBIND11_MODULE(_framework, m) {
   PYDRAKE_PREVENT_PYTHON3_MODULE_REIMPORT(m);
   m.doc() = "Bindings for the core Systems framework.";
 

--- a/bindings/pydrake/systems/meshcat_visualizer.py
+++ b/bindings/pydrake/systems/meshcat_visualizer.py
@@ -12,13 +12,12 @@ import webbrowser
 import numpy as np
 
 from drake import lcmt_viewer_load_robot
+from pydrake.common.value import AbstractValue
 from pydrake.common.eigen_geometry import Quaternion, Isometry3
 from pydrake.geometry import DispatchLoadMessage, SceneGraph
 from pydrake.lcm import DrakeLcm, Subscriber
 from pydrake.math import RigidTransform, RotationMatrix
-from pydrake.systems.framework import (
-    AbstractValue, LeafSystem, PublishEvent, TriggerType
-)
+from pydrake.systems.framework import LeafSystem, PublishEvent, TriggerType
 from pydrake.systems.rendering import PoseBundle
 from pydrake.multibody.plant import ContactResults
 import pydrake.perception as mut

--- a/bindings/pydrake/systems/perception.py
+++ b/bindings/pydrake/systems/perception.py
@@ -1,8 +1,9 @@
 import numpy as np
 
+from pydrake.common.value import AbstractValue
 from pydrake.math import RigidTransform
 from pydrake.perception import BaseField, Fields, PointCloud
-from pydrake.systems.framework import AbstractValue, LeafSystem
+from pydrake.systems.framework import LeafSystem
 
 
 def _TransformPoints(points_Ci, X_CiSi):

--- a/bindings/pydrake/systems/planar_scenegraph_visualizer.py
+++ b/bindings/pydrake/systems/planar_scenegraph_visualizer.py
@@ -17,10 +17,10 @@ with warnings.catch_warnings():  # noqa
 
 from drake import lcmt_viewer_load_robot
 from pydrake.common.eigen_geometry import Quaternion
+from pydrake.common.value import AbstractValue
 from pydrake.geometry import DispatchLoadMessage, ReadObjToSurfaceMesh
 from pydrake.lcm import DrakeLcm, Subscriber
 from pydrake.math import RigidTransform, RotationMatrix
-from pydrake.systems.framework import AbstractValue
 from pydrake.systems.pyplot_visualizer import PyPlotVisualizer
 from pydrake.systems.rendering import PoseBundle
 

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -6,6 +6,7 @@ import warnings
 import numpy as np
 
 from pydrake.autodiffutils import AutoDiffXd
+from pydrake.common.value import AbstractValue
 from pydrake.symbolic import Expression
 from pydrake.systems.analysis import (
     Simulator,
@@ -13,7 +14,6 @@ from pydrake.systems.analysis import (
 from pydrake.systems.framework import (
     AbstractParameterIndex,
     AbstractStateIndex,
-    AbstractValue,
     BasicVector, BasicVector_,
     CacheIndex,
     Context,

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -22,7 +22,6 @@ from pydrake.systems.analysis import (
     SimulatorStatus, Simulator, Simulator_,
     )
 from pydrake.systems.framework import (
-    AbstractValue,
     BasicVector, BasicVector_,
     Context, Context_,
     ContinuousState, ContinuousState_,
@@ -59,6 +58,9 @@ from pydrake.systems.primitives import (
     SignalLogger,
     ZeroOrderHold,
     )
+
+with catch_drake_warnings(expected_count=2):
+    from pydrake.systems.framework import AbstractValue, Value
 
 # TODO(eric.cousineau): The scope of this test file and and `custom_test.py`
 # is poor. Move these tests into `framework_test` and `analysis_test`, and

--- a/bindings/pydrake/systems/test/lcm_test.py
+++ b/bindings/pydrake/systems/test/lcm_test.py
@@ -13,10 +13,10 @@ import numpy as np
 from robotlocomotion import header_t, quaternion_t
 
 from pydrake.common.test_utilities.deprecation import catch_drake_warnings
+from pydrake.common.value import AbstractValue
 from pydrake.lcm import DrakeLcm, Subscriber
 from pydrake.systems.analysis import Simulator
-from pydrake.systems.framework import (
-    AbstractValue, BasicVector, DiagramBuilder, LeafSystem)
+from pydrake.systems.framework import BasicVector, DiagramBuilder, LeafSystem
 from pydrake.systems.primitives import ConstantVectorSource, LogOutput
 
 

--- a/bindings/pydrake/systems/test/meshcat_visualizer_test.py
+++ b/bindings/pydrake/systems/test/meshcat_visualizer_test.py
@@ -20,6 +20,7 @@ import meshcat
 import numpy as np
 
 from pydrake.common import FindResourceOrThrow
+from pydrake.common.value import AbstractValue
 from pydrake.geometry import (
     Box,
     GeometryInstance,
@@ -30,7 +31,7 @@ from pydrake.multibody.plant import (
     AddMultibodyPlantSceneGraph)
 from pydrake.multibody.parsing import Parser
 from pydrake.systems.analysis import Simulator
-from pydrake.systems.framework import AbstractValue, DiagramBuilder
+from pydrake.systems.framework import DiagramBuilder
 from pydrake.systems.meshcat_visualizer import (
     MeshcatVisualizer,
     MeshcatContactVisualizer,

--- a/bindings/pydrake/systems/test/perception_test.py
+++ b/bindings/pydrake/systems/test/perception_test.py
@@ -3,10 +3,11 @@
 import unittest
 import numpy as np
 
+from pydrake.common.value import AbstractValue
 from pydrake.math import RigidTransform, RollPitchYaw, RotationMatrix
 from pydrake.perception import BaseField, Fields, PointCloud
 from pydrake.systems.analysis import Simulator
-from pydrake.systems.framework import AbstractValue, DiagramBuilder
+from pydrake.systems.framework import DiagramBuilder
 from pydrake.systems.perception import (
     PointCloudConcatenation, _ConcatenatePointClouds, _TileColors,
     _TransformPoints)

--- a/bindings/pydrake/systems/test/primitives_test.py
+++ b/bindings/pydrake/systems/test/primitives_test.py
@@ -6,10 +6,10 @@ from pydrake.autodiffutils import AutoDiffXd
 from pydrake.common import RandomDistribution, RandomGenerator
 from pydrake.common.test_utilities import numpy_compare
 from pydrake.common.test_utilities.deprecation import catch_drake_warnings
+from pydrake.common.value import AbstractValue
 from pydrake.symbolic import Expression, Variable
 from pydrake.systems.analysis import Simulator
 from pydrake.systems.framework import (
-    AbstractValue,
     BasicVector,
     DiagramBuilder,
     VectorBase,

--- a/bindings/pydrake/systems/test/rendering_test.py
+++ b/bindings/pydrake/systems/test/rendering_test.py
@@ -13,6 +13,7 @@ import unittest
 import numpy as np
 
 from pydrake.common import FindResourceOrThrow
+from pydrake.common.value import AbstractValue
 from pydrake.geometry import SceneGraph
 from pydrake.multibody.plant import MultibodyPlant
 from pydrake.multibody.math import (
@@ -20,7 +21,6 @@ from pydrake.multibody.math import (
 )
 from pydrake.multibody.parsing import Parser
 from pydrake.systems.framework import (
-    AbstractValue,
     BasicVector,
     PortDataType,
 )

--- a/bindings/pydrake/systems/test/sensors_test.py
+++ b/bindings/pydrake/systems/test/sensors_test.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from pydrake.common import FindResourceOrThrow
 from pydrake.common.test_utilities.pickle_compare import assert_pickle
+from pydrake.common.value import AbstractValue, Value
 from pydrake.geometry import FrameId
 from pydrake.geometry.render import CameraProperties, DepthCameraProperties
 from pydrake.math import (
@@ -13,10 +14,8 @@ from pydrake.math import (
     RollPitchYaw,
     )
 from pydrake.systems.framework import (
-    AbstractValue,
     InputPort,
     OutputPort,
-    Value,
     )
 
 # Shorthand aliases, to reduce verbosity.

--- a/bindings/pydrake/systems/test/test_util_py.cc
+++ b/bindings/pydrake/systems/test/test_util_py.cc
@@ -46,25 +46,6 @@ class DeleteListenerVector : public BasicVector<T> {
   std::function<void()> delete_callback_;
 };
 
-class MoveOnlyType {
- public:
-  explicit MoveOnlyType(int x) : x_(x) {}
-  MoveOnlyType(MoveOnlyType&&) = default;
-  MoveOnlyType& operator=(MoveOnlyType&&) = default;
-  MoveOnlyType(const MoveOnlyType&) = delete;
-  MoveOnlyType& operator=(const MoveOnlyType&) = delete;
-  int x() const { return x_; }
-  void set_x(int x) { x_ = x; }
-  std::unique_ptr<MoveOnlyType> Clone() const {
-    return std::make_unique<MoveOnlyType>(x_);
-  }
-
- private:
-  int x_{};
-};
-
-struct UnknownType {};
-
 // A simple 2-dimensional subclass of BasicVector for testing.
 template <typename T>
 class MyVector2 : public BasicVector<T> {
@@ -94,19 +75,9 @@ PYBIND11_MODULE(test_util, m) {
   py::class_<DeleteListenerVector, BasicVector<T>>(m, "DeleteListenerVector")
       .def(py::init<std::function<void()>>());
 
-  py::class_<MoveOnlyType>(m, "MoveOnlyType")
-      .def(py::init<int>())
-      .def("x", &MoveOnlyType::x)
-      .def("set_x", &MoveOnlyType::set_x);
-  // Define `Value` instantiation.
-  AddValueInstantiation<MoveOnlyType>(m);
-
   // A 2-dimensional subclass of BasicVector.
   py::class_<MyVector2<T>, BasicVector<T>>(m, "MyVector2")
       .def(py::init<const Eigen::Vector2d&>(), py::arg("data"));
-
-  m.def("make_unknown_abstract_value",
-      []() { return AbstractValue::Make(UnknownType{}); });
 
   // Call overrides to ensure a custom Python class can override these methods.
 

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -11,6 +11,7 @@ from drake import lcmt_viewer_load_robot, lcmt_viewer_draw
 from pydrake.autodiffutils import AutoDiffXd
 from pydrake.common import FindResourceOrThrow
 from pydrake.common.test_utilities import numpy_compare
+from pydrake.common.value import AbstractValue
 from pydrake.lcm import DrakeLcm, Subscriber
 from pydrake.math import RigidTransform_
 from pydrake.symbolic import Expression
@@ -18,7 +19,6 @@ from pydrake.systems.analysis import (
     Simulator_,
 )
 from pydrake.systems.framework import (
-    AbstractValue,
     DiagramBuilder_,
     InputPort_,
     OutputPort_,

--- a/bindings/pydrake/test/math_test.py
+++ b/bindings/pydrake/test/math_test.py
@@ -2,6 +2,7 @@ import pydrake.math as mut
 import pydrake.math._test as mtest
 from pydrake.math import (BarycentricMesh, wrap_to)
 from pydrake.common.eigen_geometry import Isometry3_, Quaternion_, AngleAxis_
+from pydrake.common.value import Value
 from pydrake.autodiffutils import AutoDiffXd
 from pydrake.symbolic import Expression
 from pydrake.common.test_utilities.deprecation import catch_drake_warnings
@@ -357,3 +358,9 @@ class TestMath(unittest.TestCase):
         R = [0.3]
 
         mut.DiscreteAlgebraicRiccatiEquation(A=A, B=B, Q=Q, R=R)
+
+    @numpy_compare.check_all_types
+    def test_value_instantiations(self, T):
+        # Existence checks.
+        Value[mut.RigidTransform_[T]]
+        Value[mut.RotationMatrix_[T]]

--- a/bindings/pydrake/test/perception_test.py
+++ b/bindings/pydrake/test/perception_test.py
@@ -4,9 +4,9 @@ import unittest
 
 import numpy as np
 
+from pydrake.common.value import AbstractValue, Value
 from pydrake.systems.sensors import CameraInfo, PixelType
-from pydrake.systems.framework import (
-    AbstractValue, InputPort, OutputPort, Value)
+from pydrake.systems.framework import InputPort, OutputPort
 
 
 class TestPerception(unittest.TestCase):


### PR DESCRIPTION
This is intended to reflect the C++ API change in #10357
Deprecate old spellings

Revived as part of #13162

~FYI @jwnimmer-tri - after watching compile times on AWS, I wanna slowly creep towards #6760.~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12430)
<!-- Reviewable:end -->
