### PR TITLE
Removing grad_H from ContactSurface

### DIFF
--- a/geometry/proximity/mesh_intersection.h
+++ b/geometry/proximity/mesh_intersection.h
@@ -163,6 +163,8 @@ Vector3<T> CalcIntersection(const Vector3<T>& p_FA,
   //      = 0 when a != b.
 }
 
+// TODO(SeanCurtis-TRI): This function duplicates functionality implemented in
+//  mesh_half_space_intersection.h. Reconcile the two implementations.
 // TODO(DamrongGuoy): Avoid duplicate vertices mentioned in the note below and
 //  check whether we can have other as yet undocumented degenerate cases.
 /** Intersects a polygon with the half space H. It keeps the part of
@@ -171,14 +173,19 @@ Vector3<T> CalcIntersection(const Vector3<T>& p_FA,
  in a common frame F.
  @param[in] polygon_vertices_F
      Input polygon is represented as a sequence of positions of its vertices.
+     The input polygon is allowed to have zero area.
  @param[in] H_F
      The clipping half space H in frame F.
  @return
      Output polygon is represented as a sequence of positions of its vertices.
      It could be an empty sequence if the input polygon is entirely outside
      the half space. It could be the same as the input polygon if the input
-     polygon is entirely inside the half space.
+     polygon is entirely inside the half space. The output polygon is guaranteed
+     to be planar (within floating point tolerance) and, if the polygon has
+     area, the normal implied by the winding will be the same as the input
+     polygon.
  @pre `polygon_vertices_F` has at least three vertices.
+ @pre the vertices in `polygon_vertices_F` are all planar.
  @note
      1. For an input polygon P that is parallel to the plane of the half space,
         there are three cases:
@@ -459,41 +466,6 @@ void AddPolygonToMeshData(
   }
 }
 
-// TODO(SeanCurtis-TRI): Make this a property of the surface mesh.
-/** Computes the field of unit normal vectors for the input `surface` mesh. This
- field defines the outward normal value over the domain of the mesh. In order
- for the field to be continuous, the underlying mesh must be a closed manifold
- with no duplicate vertices.
- */
-template <typename T>
-std::unique_ptr<SurfaceMeshField<Vector3<T>, T>> ComputeNormalField(
-    const SurfaceMesh<T>& surface) {
-  // We define the normal field as a *linear* mesh field. So, we define a
-  // per-vertex normal based on the area-weighted combination of the incident
-  // face normals (computed as a right-handed normal of the triangle).
-
-  std::vector<Vector3<T>> normal_values(surface.num_vertices(),
-                                        Vector3<T>::Zero());
-  for (SurfaceFaceIndex face_index(0); face_index < surface.num_faces();
-       ++face_index) {
-    const SurfaceFace& face = surface.element(face_index);
-    const Vector3<T>& A = surface.vertex(face.vertex(0)).r_MV();
-    const Vector3<T>& B = surface.vertex(face.vertex(1)).r_MV();
-    const Vector3<T>& C = surface.vertex(face.vertex(2)).r_MV();
-    Vector3<T> unit_normal = (B - A).cross(C - A).normalized();
-    for (int v = 0; v < 3; ++v) {
-      DRAKE_ASSERT(surface.area(face_index) > T(0.0));
-      normal_values[face.vertex(v)] += surface.area(face_index) * unit_normal;
-    }
-  }
-  for (SurfaceVertexIndex vertex_index(0);
-       vertex_index < surface.num_vertices(); ++vertex_index) {
-    normal_values[vertex_index].normalize();
-  }
-  return std::make_unique<SurfaceMeshFieldLinear<Vector3<T>, T>>(
-      "normal", std::move(normal_values), &surface);
-}
-
 // TODO(DamrongGuoy): Maintain book keeping to avoid duplicate vertices and
 //  remove the note in the function documentation.
 
@@ -520,10 +492,6 @@ std::unique_ptr<SurfaceMeshField<Vector3<T>, T>> ComputeNormalField(
  @param[out] e_MN
      The sampled field values on the intersecting surface (samples to support
      a linear mesh field -- i.e., one per vertex).
- @param[out] grad_h_MN_M
-     The unit vector field on the intersecting surface (surface normals). Each
-     vector is expressed in M's frame but is parallel with the surface normals
-     at the same point.
  @note
      The output surface mesh may have duplicate vertices.
  */
@@ -533,9 +501,8 @@ void SampleVolumeFieldOnSurface(
     const SurfaceMesh<T>& surface_N,
     const math::RigidTransform<T>& X_MN,
     std::unique_ptr<SurfaceMesh<T>>* surface_MN_M,
-    std::unique_ptr<SurfaceMeshFieldLinear<T, T>>* e_MN,
-    std::unique_ptr<SurfaceMeshFieldLinear<Vector3<T>, T>>* grad_h_MN_M) {
-  auto normal_field_N = ComputeNormalField(surface_N);
+    std::unique_ptr<SurfaceMeshFieldLinear<T, T>>* e_MN) {
+
   // TODO(DamrongGuoy): Store normal_field_N in SurfaceMesh to avoid
   //  recomputing every time. Right now it is not straightforward to store
   //  SurfaceMeshField inside SurfaceMesh due to imperfect library packaging.
@@ -552,7 +519,6 @@ void SampleVolumeFieldOnSurface(
 
   // TODO(DamrongGuoy): Use the broadphase to avoid O(n^2) check of all
   //  tetrahedrons against all triangles.
-  const math::RigidTransform<T> X_NM = X_MN.inverse();
   for (VolumeElementIndex tet_index(0); tet_index < mesh_M.num_elements();
        ++tet_index) {
     for (SurfaceFaceIndex tri_index(0); tri_index < surface_N.num_faces();
@@ -579,22 +545,14 @@ void SampleVolumeFieldOnSurface(
         const Vector3<T>& r_MV = surface_vertices_M[v].r_MV();
         const T pressure = volume_field_M.EvaluateCartesian(tet_index, r_MV);
         surface_e.push_back(pressure);
-        const Vector3<T> r_NV = X_NM * r_MV;
-        const Vector3<T> normal_N =
-            normal_field_N->EvaluateCartesian(tri_index, r_NV);
-        Vector3<T> normal_M = X_MN.rotation() * normal_N;
-        surface_normals_M.push_back(normal_M);
       }
     }
   }
   DRAKE_DEMAND(surface_vertices_M.size() == surface_e.size());
-  DRAKE_DEMAND(surface_vertices_M.size() == surface_normals_M.size());
   *surface_MN_M = std::make_unique<SurfaceMesh<T>>(
       std::move(surface_faces), std::move(surface_vertices_M));
   *e_MN = std::make_unique<SurfaceMeshFieldLinear<T, T>>(
       "e", std::move(surface_e), surface_MN_M->get());
-  *grad_h_MN_M = std::make_unique<SurfaceMeshFieldLinear<Vector3<T>, T>>(
-      "grad_h_MN_M", std::move(surface_normals_M), surface_MN_M->get());
 }
 
 /** Computes the contact surface between a soft geometry S and a rigid
@@ -661,22 +619,13 @@ ComputeContactSurfaceFromSoftVolumeRigidSurface(
   std::unique_ptr<SurfaceMesh<T>> surface_SR;
   std::unique_ptr<SurfaceMeshFieldLinear<T, T>> e_SR;
 
-  // The gradient field will be computed as expressed in Frame S and then
-  // re-expressed in the world frame.
-  std::unique_ptr<SurfaceMeshFieldLinear<Vector3<T>, T>> grad_h_SR;
-  SampleVolumeFieldOnSurface(field_S, mesh_R, X_SR, &surface_SR, &e_SR,
-                             &grad_h_SR);
+  SampleVolumeFieldOnSurface(field_S, mesh_R, X_SR, &surface_SR, &e_SR);
 
   // Transform the mesh from the S frame to the world frame.
   surface_SR->TransformVertices(X_WS);
 
-  // Re-express the gradient from the S frame to the world frame.
-  for (Vector3<T>& gradient_value : grad_h_SR->mutable_values())
-    gradient_value = X_WS.rotation() * gradient_value;
-
   return std::make_unique<ContactSurface<T>>(
-      id_S, id_R, std::move(surface_SR), std::move(e_SR),
-      std::move(grad_h_SR));
+      id_S, id_R, std::move(surface_SR), std::move(e_SR));
 }
 
 // NOTE: This is a short-term hack to allow ProximityEngine to compile when

--- a/geometry/query_results/contact_surface.h
+++ b/geometry/query_results/contact_surface.h
@@ -94,6 +94,19 @@ namespace geometry {
   Even though eₘₙ and ∇hₘₙ are defined on different domains (𝕊ₘₙ and 𝕄 ∩ ℕ),
   our implementation only represents them on their common domain, i.e., 𝕊ₘₙ.
 
+  <h2> Discrete Representation </h2>
+
+  In practice, the contact surface is approximated with a discrete triangle
+  mesh. The triangle mesh's normals are defined *per face*. The normal of each
+  face is guaranteed to point "out of" M and "into" N. They can be accessed via
+  `mesh_W().face_normal(face_index)`.
+
+  The pressure values on the contact surface are represented as a continuous,
+  piecewise-linear function, accessed via e_MN().
+
+  The normals of the mesh are discontinuous at triangle boundaries, but the
+  pressure can be meaningfully evaluated over the entire domain of the mesh.
+
   <h2> Barycentric Coordinates </h2>
 
   For Point Q on the surface mesh of the contact surface between Geometry M and
@@ -132,8 +145,6 @@ class ContactSurface {
     // to the new mesh. So, we use CloneAndSetMesh() instead.
     e_MN_.reset(static_cast<SurfaceMeshFieldLinear<T, T>*>(
         surface.e_MN_->CloneAndSetMesh(mesh_W_.get()).release()));
-    grad_h_MN_W_.reset(static_cast<SurfaceMeshFieldLinear<Vector3<T>, T>*>(
-        surface.grad_h_MN_W_->CloneAndSetMesh(mesh_W_.get()).release()));
 
     return *this;
   }
@@ -147,24 +158,17 @@ class ContactSurface {
    @param mesh_W       The surface mesh of the contact surface 𝕊ₘₙ between M
                        and N. The mesh vertices are defined in the world frame.
    @param e_MN         Represents the scalar field eₘₙ on the surface mesh.
-   @param grad_h_MN_W  Represents the vector field ∇hₘₙ on the surface mesh,
-                       expressed in the world frame. Due to discretization,
-                       `grad_h_MN_W` at a vertex need not be strictly
-                       orthogonal to every triangle sharing the vertex.
-                       Orthogonality generally does improve with finer
-                       discretization.
-   @note If the id_M is greater than the id_N, we will swap M and N.
-         Therefore, grad_h_MN_W will switch its direction.
+   @pre The face normals in `mesh_W` point *out of* geometry M and *into* N.
+   @note If the id_M is greater than the id_N, we will swap M and N (making any
+         necessary changes to keep the surface consistent with that labeling).
    */
   ContactSurface(
       GeometryId id_M, GeometryId id_N, std::unique_ptr<SurfaceMesh<T>> mesh_W,
-      std::unique_ptr<SurfaceMeshFieldLinear<T, T>> e_MN,
-      std::unique_ptr<SurfaceMeshFieldLinear<Vector3<T>, T>> grad_h_MN_W)
+      std::unique_ptr<SurfaceMeshFieldLinear<T, T>> e_MN)
       : id_M_(id_M),
         id_N_(id_N),
         mesh_W_(std::move(mesh_W)),
-        e_MN_(std::move(e_MN)),
-        grad_h_MN_W_(std::move(grad_h_MN_W)) {
+        e_MN_(std::move(e_MN)) {
     if (id_N_ < id_M_) SwapMAndN();
   }
 
@@ -196,27 +200,6 @@ class ContactSurface {
     return e_MN_->EvaluateAtVertex(vertex);
   }
 
-  /** Evaluates the vector field ∇hₘₙ at Point Q on a triangle.
-    Point Q is specified by its barycentric coordinates.
-    @param face         The face index of the triangle.
-    @param barycentric  The barycentric coordinates of Q on the triangle.
-    @retval  grad_h_MN_W is the vector expressed in the world frame.
-   */
-  Vector3<T> EvaluateGrad_h_MN_W(
-      SurfaceFaceIndex face,
-      const typename SurfaceMesh<T>::Barycentric& barycentric) const {
-    return grad_h_MN_W_->Evaluate(face, barycentric);
-  }
-
-  /** Evaluates the vector field ∇hₘₙ at the given vertex on the contact surface
-    mesh.
-    @param vertex       The index of the vertex in the mesh.
-    @retval  grad_h_MN_W is the vector expressed in the world frame.
-   */
-  Vector3<T> EvaluateGrad_h_MN_W(SurfaceVertexIndex vertex) const {
-    return grad_h_MN_W_->EvaluateAtVertex(vertex);
-  }
-
   DRAKE_DEPRECATED("2019-12-01", "Use mesh_W() instead.")
   const SurfaceMesh<T>& mesh() const { return mesh_W(); }
 
@@ -230,11 +213,6 @@ class ContactSurface {
 
   /** Returns a reference to the scalar field eₘₙ. */
   const MeshField<T, SurfaceMesh<T>>& e_MN() const { return *e_MN_; }
-
-  /** Returns a reference to the vector field ∇hₘₙ. */
-  const MeshField<Vector3<T>, SurfaceMesh<T>>& grad_h_MN_W() const {
-    return *grad_h_MN_W_;
-  }
 
   // TODO(#12173): Consider NaN==NaN to be true in equality tests.
   /** Checks to see whether the given ContactSurface object is equal via deep
@@ -258,14 +236,6 @@ class ContactSurface {
     if (!pressure_field->Equal(surface.e_MN()))
       return false;
 
-    // Now examine the grad_h field.
-    const auto* grad_h_field =
-        dynamic_cast<const MeshFieldLinear<Vector3<T>, SurfaceMesh<T>>*>(
-            &(this->grad_h_MN_W()));;
-    DRAKE_DEMAND(grad_h_field);
-    if (!grad_h_field->Equal(surface.grad_h_MN_W()))
-      return false;
-
     // All checks passed.
     return true;
   }
@@ -278,12 +248,6 @@ class ContactSurface {
     // documented nor tested that the face winding is guaranteed to be one way
     // or the other. Alternatively, this should be documented and tested.
     mesh_W_->ReverseFaceWinding();
-
-    // Simply reverse the direction of the vector field.
-    std::vector<Vector3<T>>& values = grad_h_MN_W_->mutable_values();
-    for (SurfaceVertexIndex v(0); v < mesh_W_->num_vertices(); ++v) {
-      values[v] = -values[v];
-    }
 
     // Note: the scalar field does not depend on the order of M and N.
   }
@@ -299,11 +263,7 @@ class ContactSurface {
   //  uses a different derivation.
   // Represents the scalar field eₘₙ on the surface mesh.
   std::unique_ptr<SurfaceMeshFieldLinear<T, T>> e_MN_;
-  // Represents the vector field ∇hₘₙ on the surface mesh, expressed in M's
-  // frame.
-  std::unique_ptr<SurfaceMeshFieldLinear<Vector3<T>, T>> grad_h_MN_W_;
-  // TODO(DamrongGuoy): Remove this when we allow direct access to e_MN and
-  //  grad_h_MN.
+  // TODO(DamrongGuoy): Remove this when we allow direct access to e_MN.
   template <typename U> friend class ContactSurfaceTester;
 };
 

--- a/multibody/hydroelastics/contact_surface_from_level_set.h
+++ b/multibody/hydroelastics/contact_surface_from_level_set.h
@@ -99,7 +99,10 @@ const std::array<std::vector<EdgeIndex>, 16> kMarchingTetsTable = {
 // @param[out] vertices_N
 //   Adds the new vertices into `vertices`.
 // @param[out] faces
-//   Adds the new faces into `faces`.
+//   Adds the new faces into `faces`. The faces are guaranteed to be wound such
+//   that the face normal points in the direction of the level set function's
+//   gradient. (I.e., *out* of the rigid object represented by the level set
+//   and *into* the soft mesh that the tet is part of.)
 // @param[out] e_m_surface
 //   The scalar field `e_m` linearly interpolated onto each new vertex in
 //   `vertices`, in the same order.
@@ -200,7 +203,7 @@ int IntersectTetWithLevelSet(
                      T(num_intersections);
   e_m_surface->emplace_back(e_m_at_c);
 
-  // Build a fan of triangles consistent of an edge from the original polygon
+  // Build a fan of triangles consisting of an edge from the original polygon
   // and the centroid vertex.
   V prev(num_vertices + num_intersections - 1);
   for (int i = 0; i < num_intersections; ++i) {
@@ -213,6 +216,15 @@ int IntersectTetWithLevelSet(
 
   DRAKE_UNREACHABLE();
 }
+
+// TODO(SeanCurtis-TRI): Correct this documentation if this approach persists.
+//  This doesn't actually compute a triangulation of the level set. It computes
+//  the zero level set of a piecewise-linear approximation of the level set
+//  function. The latter is not necessarily a sampling of the former. (The
+//  distinction arises because the level set function is sampled at each tet
+//  vertex and then the 'zero' is found by linearly interpolating along each
+//  edge -- if the level set function itself is not linear, it will have a
+//  different zero point along the edge.
 
 /// Given a level set function `φ(V)` and a volume defined by `mesh_M`, this
 /// method computes a triangulation of the zero level set of `φ(V)` in the
@@ -251,10 +263,6 @@ int IntersectTetWithLevelSet(
 ///   representation of a continuous scalar field, the values on the contact
 ///   surface will be an linear interpolation of those values.
 ///   Any existing values in `e_m_surface` at input are cleared.
-/// @param[out] phi_gradient_N
-///   The gradient `[∇φ]_N`, expressed in frame N, of `phi_N` sampled at
-///   the surface vertices.
-///   Any existing values in `phi_gradient_N` at input are cleared.
 ///
 /// @note This implementation uses the marching tetrahedra algorithm as
 /// described in Bloomenthal, J., 1994. An Implicit Surface Polygonizer.
@@ -263,16 +271,16 @@ int IntersectTetWithLevelSet(
 /// @returns A triangulation of the zero level set of `φ(V)` in the volume
 /// defined by `mesh_M`.  The triangulation is measured and expressed in frame
 /// N. The right handed normal of each triangle points towards the positive side
-/// of the level set function `φ(V)`.
+/// of the level set function `φ(V)` (the normals point out of the rigid object
+/// represented by the level set field and into the soft volume mesh).
 ///
 /// @note  The geometry::SurfaceMesh may have duplicate vertices.
 template <typename T>
 std::unique_ptr<geometry::SurfaceMesh<T>> CalcZeroLevelSetInMeshDomain(
     const geometry::VolumeMesh<T>& mesh_M, const LevelSetField<T>& phi_N,
     const math::RigidTransform<T>& X_NM, const std::vector<T>& e_m_volume,
-    std::vector<T>* e_m_surface, std::vector<Vector3<T>>* phi_gradient_N) {
+    std::vector<T>* e_m_surface) {
   DRAKE_DEMAND(e_m_surface != nullptr);
-  DRAKE_ASSERT(phi_gradient_N != nullptr);
   std::vector<geometry::SurfaceVertex<T>> vertices_N;
   std::vector<geometry::SurfaceFace> faces;
   e_m_surface->clear();
@@ -300,12 +308,6 @@ std::unique_ptr<geometry::SurfaceMesh<T>> CalcZeroLevelSetInMeshDomain(
     std::swap(e_m[1], e_m[2]);
     IntersectTetWithLevelSet(tet_vertices_N, phi, e_m, &vertices_N, &faces,
                              e_m_surface);
-  }
-
-  phi_gradient_N->resize(vertices_N.size());
-  for (geometry::SurfaceVertexIndex v(0); v < vertices_N.size(); ++v) {
-    const Vector3<T>& p_NV = vertices_N[v].r_MV();
-    (*phi_gradient_N)[v] = phi_N.gradient(p_NV);
   }
 
   return std::make_unique<geometry::SurfaceMesh<T>>(std::move(faces),

--- a/multibody/hydroelastics/hydroelastic_engine.cc
+++ b/multibody/hydroelastics/hydroelastic_engine.cc
@@ -195,15 +195,13 @@ std::optional<ContactSurface<T>> HydroelasticEngine<T>::CalcContactSurface(
   DRAKE_DEMAND(!rigid_model_R.is_soft());
   const HydroelasticField<T>& soft_field_S = soft_model_S.hydroelastic_field();
   std::vector<T> e_s_surface;
-  std::vector<Vector3<T>> grad_level_set_R_surface;
 
   const auto X_RS = X_WR.inverse() * X_WS;
   // Surface is measured and expressed in frame R. We'll transform to frame W
   // below if non-empty.
   std::unique_ptr<SurfaceMesh<T>> surface_W = CalcZeroLevelSetInMeshDomain(
       soft_field_S.volume_mesh(), rigid_model_R.level_set(), X_RS,
-      soft_field_S.scalar_field().values(), &e_s_surface,
-      &grad_level_set_R_surface);
+      soft_field_S.scalar_field().values(), &e_s_surface);
   if (surface_W->num_vertices() == 0) return std::nullopt;
   // Transform with vertices measured and expressed in frame W.
   surface_W->TransformVertices(X_WR);
@@ -211,26 +209,14 @@ std::optional<ContactSurface<T>> HydroelasticEngine<T>::CalcContactSurface(
   // TODO(edrumwri): This says that it is a pressure field, but notation
   //                 reflects that it is a strain field. Fix.
   // Compute pressure field.
-  for (T& e_s : e_s_surface) e_s *= soft_model_S.elastic_modulus();
-
-  // TODO(edrumwri): h_RS should be the gradient of a pressure field, but it
-  //                 is currently the gradient of a strain field. Fix.
-  // ∇hₘₙ is a vector that points from N (in this case S) into M (in this case
-  // R). Note that the gradient of the level set function points into S (N), so
-  // we flip its direction. We also re-express this field in the world frame in
-  // accordance with the ContactSurface specification.
-  std::vector<Vector3<T>> h_RS_W_vectors = std::move(grad_level_set_R_surface);
-  for (Vector3<T>& grad : h_RS_W_vectors)
-    grad = X_WR.rotation() * -grad;
-
+  for (T& e_s_value : e_s_surface) e_s_value *= soft_model_S.elastic_modulus();
   auto e_s = std::make_unique<geometry::SurfaceMeshFieldLinear<T, T>>(
       "e_MN", std::move(e_s_surface), surface_W.get());
-  auto h_RS_W =
-      std::make_unique<geometry::SurfaceMeshFieldLinear<Vector3<T>, T>>(
-          "grad_h_MN_W", std::move(h_RS_W_vectors), surface_W.get());
 
-  return ContactSurface<T>(id_R, id_S, std::move(surface_W), std::move(e_s),
-                           std::move(h_RS_W));
+  // The calculation between level set and soft mesh produces a surface with
+  // face normals pointing out of the level set and into the soft surface.
+  // The ordering of id_R and id_S reflects this.
+  return ContactSurface<T>(id_R, id_S, std::move(surface_W), std::move(e_s));
 }
 
 template <typename T>

--- a/multibody/hydroelastics/test/hydroelastic_engine_test.cc
+++ b/multibody/hydroelastics/test/hydroelastic_engine_test.cc
@@ -240,13 +240,6 @@ TEST_F(SphereVsPlaneTest, VerifyModelSizeAndResults) {
   EXPECT_GT(mesh_G.num_vertices(), 0);
   const double kTolerance = 5.0 * std::numeric_limits<double>::epsilon();
 
-  // TODO(edrumwri): This is the gradient of the strain field. It should be
-  // the gradient of the pressure field. Fix.
-  // The expected value of ∇hₘₙ, which we expect to point from N towards M.
-  const Vector3<double> expected_grad_h_MN_W =
-      surface.id_M() == sphere_geometry_id_ ? Vector3<double>(0.0, 0.0, 1.0)
-                                            : Vector3<double>(0.0, 0.0, -1.0);
-
   for (geometry::SurfaceVertexIndex v(0); v < mesh_G.num_vertices(); ++v) {
     // Position of a vertex V in the ground frame G.
     const Vector3d p_GV = mesh_G.vertex(v).r_MV();
@@ -260,10 +253,6 @@ TEST_F(SphereVsPlaneTest, VerifyModelSizeAndResults) {
         std::sqrt(radius_ * radius_ - height_ * height_);
     const double radius = p_GV.norm();  // since z component is zero.
     EXPECT_LE(radius, surface_radius);
-
-    // We expect ∇hₘₙ to point from N towards M.
-    const Vector3<double> grad_h_MN_W = surface.EvaluateGrad_h_MN_W(v);
-    EXPECT_TRUE(CompareMatrices(grad_h_MN_W, expected_grad_h_MN_W, kTolerance));
   }
 
   // The number of models should not change on further queries.

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -242,6 +242,7 @@ drake_cc_googletest(
     deps = [
         ":hydroelastic_traction",
         "//common:find_resource",
+        "//common/test_utilities:eigen_matrix_compare",
         "//multibody/parsing",
     ],
 )

--- a/multibody/plant/hydroelastic_traction_calculator.cc
+++ b/multibody/plant/hydroelastic_traction_calculator.cc
@@ -142,13 +142,10 @@ HydroelasticTractionCalculator<T>::CalcTractionAtPoint(
 
   const T e = data.surface.EvaluateE_MN(face_index, Q_barycentric);
 
-  const Vector3<T> grad_h_W = data.surface.EvaluateGrad_h_MN_W(
-      face_index, Q_barycentric);
-  // TODO(edrumwri): Remove this TODO or update this code when we know whether
-  // h_W can ever be zero in expected cases.
-  const T norm_grad_h_W = grad_h_W.norm();
-  DRAKE_DEMAND(norm_grad_h_W > std::numeric_limits<double>::epsilon() * 10);
-  const Vector3<T> nhat_W = grad_h_W / norm_grad_h_W;
+  // Contact surfaces are documented to have face normals that point *out of* M
+  // and *into* N -- which is the face normal of the contact surface (as
+  // documented).
+  const Vector3<T> nhat_W = data.surface.mesh_W().face_normal(face_index);
 
   return CalcTractionAtQHelper(data, face_index, e, nhat_W, dissipation,
                                mu_coulomb, p_WQ);

--- a/multibody/plant/test/contact_results_to_lcm_test.cc
+++ b/multibody/plant/test/contact_results_to_lcm_test.cc
@@ -229,18 +229,11 @@ std::unique_ptr<ContactSurface<double>> CreateContactSurface(
   for (SurfaceVertexIndex i(0); i < mesh->num_vertices(); ++i)
     e_MN[i] = std::abs(mesh->vertex(i).r_MV()[0] + mesh->vertex(i).r_MV()[1]);
 
-  // Create the gradient of the "h" field, pointing toward what will be
-  // geometry "M" (the halfspace).
-  std::vector<Vector3<double>> h_MN_W(mesh->num_vertices(),
-      Vector3<double>(0, 0, -1));
-
   SurfaceMesh<double>* mesh_pointer = mesh.get();
   return std::make_unique<ContactSurface<double>>(
       halfspace_id, block_id, std::move(mesh),
       std::make_unique<MeshFieldLinear<double, SurfaceMesh<double>>>(
-          "e_MN", std::move(e_MN), mesh_pointer),
-      std::make_unique<MeshFieldLinear<Vector3<double>, SurfaceMesh<double>>>(
-          "h_MN_W", std::move(h_MN_W), mesh_pointer));
+          "e_MN", std::move(e_MN), mesh_pointer));
 }
 
 ContactResults<double> GenerateHydroelasticContactResults(

--- a/multibody/plant/test/multibody_plant_hydroelastic_contact_results_output_test.cc
+++ b/multibody/plant/test/multibody_plant_hydroelastic_contact_results_output_test.cc
@@ -178,7 +178,7 @@ TEST_F(HydroelasticContactResultsOutputTester, SlipVelocity) {
   const bool body_A_is_ball = (std::find(
       ball_collision_geometries.begin(), ball_collision_geometries.end(),
       results.contact_surface().id_M()) != ball_collision_geometries.end());
-  const Vector3d expected_slip = body_A_is_ball ? x : -x;
+  const Vector3d expected_slip = body_A_is_ball ? -x : x;
 
   // Check that value of the slip velocity field points to +x.
   for (const auto& quadrature_point_datum : quadrature_point_data)
@@ -192,9 +192,11 @@ TEST_F(HydroelasticContactResultsOutputTester, Traction) {
   const std::vector<HydroelasticQuadraturePointData<double>>&
       quadrature_point_data = results.quadrature_point_data();
 
-  // If Body A is the ball, then the traction field should point along +z.
-  // Otherwise, it should point along -z.
-  const Vector3d z(0, 0, 1);
+  // If Body A (with geometry M) is the ball, then the traction field should
+  // point along -z (i.e., the contact surfaces normals point out of M and
+  // into N and the tractions should point in the same direction). Otherwise, it
+  // should point along +z.
+  const Vector3d z(0, 0, -1);
   std::vector<geometry::GeometryId> ball_collision_geometries =
       plant_->GetCollisionGeometriesForBody(plant_->GetBodyByName("Ball"));
   const bool body_A_is_ball = (std::find(
@@ -214,7 +216,7 @@ TEST_F(HydroelasticContactResultsOutputTester, Traction) {
 
     // The conversion from Cartesian to barycentric coordinates introduces some
     // roundoff error. Test the values using a relative tolerance since the
-    // pressure is generlly much greater than unity.
+    // pressure is generally much greater than unity.
     const double tol = pressure * 20 * std::numeric_limits<double>::epsilon();
     const Vector3d expected_traction = expected_traction_direction * pressure;
     EXPECT_NEAR(


### PR DESCRIPTION
We are no longer using the grad_h value to define the normal of the contact surface. Instead, we're using the triangle normals of the surface itself. So, we remove the field and change downstream references to use the face normal instead.

This act revealed some imprecision in the documented and implemented behaviors of the triangle normals. Where appropriate new documentation has been added (and tested) to help clarify the expectations of normals.

```
Category            added  modified  removed  
----------------------------------------------
code                28     32        166      
comments            84     20        65       
blank               4      0         12       
----------------------------------------------
TOTAL               116    52        243 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12432)
<!-- Reviewable:end -->
