### PR TITLE
Adds missing operators to SpatialVector

### DIFF
--- a/multibody/math/spatial_acceleration.h
+++ b/multibody/math/spatial_acceleration.h
@@ -256,12 +256,11 @@ class SpatialAcceleration : public SpatialVector<SpatialAcceleration, T> {
   ///                               centrifugal         Coriolis
   /// </pre>
   /// The equation above shows that composing spatial accelerations cannot be
-  /// simply accomplished by adding `A_WP` with `A_PB` (this is the reason why
-  /// this class does not overload the `operator+()` and provides this method
-  /// instead). Moreover, we see that, unlike with angular velocities, angular
-  /// accelerations cannot be added in order to compose them. That is
-  /// `w_AC = w_AB + w_BC` but `alpha_AC ≠ alpha_AB + alpha_BC` due to the cross
-  /// term `w_AC x w_BC`. See the derivation below for more details.
+  /// simply accomplished by adding `A_WP` with `A_PB`. Moreover, we see that,
+  /// unlike with angular velocities, angular accelerations cannot be added in
+  /// order to compose them. That is `w_AC = w_AB + w_BC` but `alpha_AC ≠
+  /// alpha_AB + alpha_BC` due to the cross term `w_AC x w_BC`. See the
+  /// derivation below for more details.
   ///
   /// @see SpatialVelocity::ComposeWithMovingFrameVelocity() for the composition
   /// of SpatialVelocity quantities.
@@ -418,6 +417,36 @@ class SpatialAcceleration : public SpatialVector<SpatialAcceleration, T> {
     return A_WB_E;
   }
 };
+
+/// (Advanced) Addition operator. Implements the addition of A1 and A2 as
+/// elements in ℝ⁶.
+/// @warning Composing spatial accelerations A1 and A2 cannot be simply
+/// accomplished by adding them with this operator. The composition of
+/// accelerations involves additional centrifugal and Coriolis terms, see
+/// SpatialAcceleration::ComposeWithMovingFrameAcceleration() for details.
+/// @relates SpatialAcceleration
+template <typename T>
+inline SpatialAcceleration<T> operator+(const SpatialAcceleration<T>& A1,
+                                        const SpatialAcceleration<T>& A2) {
+  // N.B. We use SpatialVector's implementation, though we provide the overload
+  // for specific documentation purposes.
+  return SpatialAcceleration<T>(A1) += A2;
+}
+
+/// (Advanced) Subtraction operator. Implements the subtraction of A1 and A2 as
+/// elements in ℝ⁶.
+/// @warning With `As = A1 - A2`, `A1 = As + A2` does not correspond to the
+/// physical composition of spatial accelerations As and A2. Please refere to
+/// operator+(const SpatialAcceleration<T>&, const SpatialAcceleration<T>&) for
+/// details.
+/// @relates SpatialAcceleration
+template <typename T>
+inline SpatialAcceleration<T> operator-(const SpatialAcceleration<T>& A1,
+                                        const SpatialAcceleration<T>& A2) {
+  // N.B. We use SpatialVector's implementation, though we provide the overload
+  // for specific documentation purposes.
+  return SpatialAcceleration<T>(A1) -= A2;
+}
 
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/math/spatial_force.h
+++ b/multibody/math/spatial_force.h
@@ -142,42 +142,6 @@ class SpatialForce : public SpatialVector<SpatialForce, T> {
     return SpatialForce<T>(*this).ShiftInPlace(p_BpBq_E);
   }
 
-  /// Adds in a spatial force to `this` spatial force.
-  /// @param[in] F_Sp_E
-  ///   A spatial force to be added to `this` spatial force. It must be on the
-  ///   same system or body S on which `this` spatial force is applied and at
-  ///   the same point P as `this` spatial force, and expressed in the
-  ///   same frame E.
-  /// @returns
-  ///   A reference to `this` spatial force, which has been updated to include
-  ///   the given spatial force `F_Sp_E`.
-  ///
-  /// @warning This operation is only valid if both spatial forces are applied
-  /// on the same system or body S, at the same point P and expressed in the
-  /// same frame E.
-  SpatialForce<T>& operator+=(const SpatialForce<T>& F_Sp_E) {
-    this->get_coeffs() += F_Sp_E.get_coeffs();
-    return *this;
-  }
-
-  /// Subtracts a spatial force from `this` spatial force.
-  /// @param[in] F_Sp_E
-  ///   A spatial force to be subtracted from `this` spatial force. It must be
-  ///   on the same system or body S on which `this` spatial force is applied
-  ///   and at the same point P as `this` spatial force, and expressed in the
-  ///   same frame E.
-  /// @returns
-  ///   A reference to `this` spatial force, which has been updated to exclude
-  ///   the given spatial force `F_Sp_E`.
-  ///
-  /// @warning This operation is only valid if both spatial forces are applied
-  /// on the same system or body S, at the same point P and expressed in the
-  /// same frame E.
-  SpatialForce<T>& operator-=(const SpatialForce<T>& F_Sp_E) {
-    this->get_coeffs() -= F_Sp_E.get_coeffs();
-    return *this;
-  }
-
   /// Given `this` spatial force `F_Bp_E` applied at point P of body B and
   /// expressed in a frame E, this method computes the 6-dimensional dot
   /// product with the spatial velocity `V_IBp_E` of body B at point P,
@@ -200,18 +164,26 @@ class SpatialForce : public SpatialVector<SpatialForce, T> {
 ///   The resultant spatial force on system or body S from combining `F1_Sp_E`
 ///   and `F2_Sp_E`, applied at the same point P and in the same expressed-in
 ///   frame E as the operand spatial forces.
+///
+/// @relates SpatialForce
 template <typename T>
-inline SpatialForce<T> operator+(
-    const SpatialForce<T>& F1_Sp_E, const SpatialForce<T>& F2_Sp_E) {
+inline SpatialForce<T> operator+(const SpatialForce<T>& F1_Sp_E,
+                                 const SpatialForce<T>& F2_Sp_E) {
+  // N.B. We use SpatialVector's implementation, though we provide the overload
+  // for specific documentation purposes.
   return SpatialForce<T>(F1_Sp_E) += F2_Sp_E;
 }
 
 /// Subtracts spatial force `F2_Sp_E ` from `F1_Sp_E`. Both spatial forces act
 /// on the same system or body S, at point P and are expressed in the same frame
 /// E.
+///
+/// @relates SpatialForce
 template <typename T>
-inline SpatialForce<T> operator-(
-    const SpatialForce<T>& F1_Sp_E, const SpatialForce<T>& F2_Sp_E) {
+inline SpatialForce<T> operator-(const SpatialForce<T>& F1_Sp_E,
+                                 const SpatialForce<T>& F2_Sp_E) {
+  // N.B. We use SpatialVector's implementation, though we provide the overload
+  // for specific documentation purposes.
   return SpatialForce<T>(F1_Sp_E) -= F2_Sp_E;
 }
 

--- a/multibody/math/spatial_momentum.h
+++ b/multibody/math/spatial_momentum.h
@@ -160,38 +160,6 @@ class SpatialMomentum : public SpatialVector<SpatialMomentum, T> {
     return SpatialMomentum<T>(*this).ShiftInPlace(p_PQ_E);
   }
 
-  /// Adds in a spatial momentum to `this` spatial momentum.
-  /// @param[in] L_NSp_E
-  ///   A spatial momentum to be added to `this` spatial momentum. It must be
-  ///   about the same point P as this spatial momentum and expressed in the
-  ///   same frame E.
-  /// @returns
-  ///   A reference to `this` spatial momentum, which has been updated to
-  ///   include the given spatial momentum `L_NSp_E`.
-  ///
-  /// @warning This operation is only valid if both spatial momenta are applied
-  /// about same point P and expressed in the same frame E.
-  SpatialMomentum<T>& operator+=(const SpatialMomentum<T>& L_NSp_E) {
-    this->get_coeffs() += L_NSp_E.get_coeffs();
-    return *this;
-  }
-
-  /// Subtracts a spatial momentum from `this` spatial momentum.
-  /// @param[in] L_NSp_E
-  ///   A spatial momentum to be subtracted from `this` spatial momentum. It
-  ///   must be about the same point P as this spatial momentum and expressed in
-  ///   the same frame E.
-  /// @returns
-  ///   A reference to `this` spatial momentum, which has been updated to
-  ///   exclude the given spatial momentum `L_NSp_E`.
-  ///
-  /// @warning This operation is only valid if both spatial momenta are applied
-  /// about same point P and expressed in the same frame E.
-  SpatialMomentum<T>& operator-=(const SpatialMomentum<T>& L_NSp_E) {
-    this->get_coeffs() -= L_NSp_E.get_coeffs();
-    return *this;
-  }
-
   /// Given `this` spatial momentum `L_NBp_E` of a rigid body B, about point P
   /// and, expressed in a frame E, this method computes the dot
   /// product with the spatial velocity `V_NBp_E` of body B frame shifted to
@@ -218,10 +186,28 @@ class SpatialMomentum : public SpatialVector<SpatialMomentum, T> {
 ///   The combined spatial momentum of system S from combining `L1_NSp_E`
 ///   and `L2_NSp_E`, applied about the same point P, and in the same
 ///   expressed-in frame E as the operand spatial momenta.
+///
+/// @relates SpatialMomentum
 template <typename T>
-inline SpatialMomentum<T> operator+(
-    const SpatialMomentum<T>& L1_NSp_E, const SpatialMomentum<T>& L2_NSp_E) {
-  return SpatialMomentum<T>(L1_NSp_E.get_coeffs() + L2_NSp_E.get_coeffs());
+inline SpatialMomentum<T> operator+(const SpatialMomentum<T>& L1_NSp_E,
+                                    const SpatialMomentum<T>& L2_NSp_E) {
+  // N.B. We use SpatialVector's implementation, though we provide the overload
+  // for specific documentation purposes.
+  return SpatialMomentum<T>(L1_NSp_E) += L2_NSp_E;
+}
+
+/// Spatial momentum is additive, see
+/// operator+(const SpatialMomentum<T>&, const SpatialMomentum<T>&). This
+/// operator subtracts L2_NSp_E from the total momentum in L1_NSp_E. The momenta
+/// in both operands as well as the result are for the same system S, about the
+/// same point P and expressed in the same frame E.
+/// @relates SpatialMomentum
+template <typename T>
+inline SpatialMomentum<T> operator-(const SpatialMomentum<T>& L1_NSp_E,
+                                    const SpatialMomentum<T>& L2_NSp_E) {
+  // N.B. We use SpatialVector's implementation, though we provide the overload
+  // for specific documentation purposes.
+  return SpatialMomentum<T>(L1_NSp_E) -= L2_NSp_E;
 }
 
 }  // namespace multibody

--- a/multibody/math/spatial_vector.h
+++ b/multibody/math/spatial_vector.h
@@ -201,10 +201,52 @@ class SpatialVector {
   /// Returns a constant reference to the underlying storage.
   const CoeffsEigenType& get_coeffs() const { return V_;}
 
+  /// Unary minus operator.
+  SpatialQuantity operator-() const {
+    return SpatialQuantity(-get_coeffs());
+  }
+
+  /// Addition assignment operator.
+  SpatialQuantity& operator+=(const SpatialQuantity& V) {
+    this->get_coeffs() += V.get_coeffs();
+    return get_mutable_derived();
+  }
+
+  /// Subtraction assignment operator.
+  SpatialQuantity& operator-=(const SpatialQuantity& V) {
+    this->get_coeffs() -= V.get_coeffs();
+    return get_mutable_derived();
+  }
+
+  /// Multiplication assignment operator.
+  SpatialQuantity& operator*=(const T& s) {
+    this->get_coeffs() *= s;
+    return get_mutable_derived();
+  }
+
+  /// (Advanced) Addition operator. Implements the addition of V1 and V2 as
+  /// elements in ℝ⁶.
+  /// @warning This operation might not be physical for certain spatial
+  /// quantities. For instace, combining the spatial accelerations of two frames
+  /// does not correspond to this operation.
+  friend SpatialQuantity operator+(const SpatialQuantity& V1,
+                                   const SpatialQuantity& V2) {
+    return SpatialQuantity(V1) += V2;
+  }
+
+  /// (Advanced) Subtraction operator. Implements the subtraction of V1 and V2
+  /// as elements in ℝ⁶.
+  /// @warning This operation might not be physical for certain spatial
+  /// quantities.
+  friend SpatialQuantity operator-(const SpatialQuantity& V1,
+                                   const SpatialQuantity& V2) {
+    return SpatialQuantity(V1) -= V2;
+  }
+
   /// Multiplication of a spatial vector V from the left by a scalar `s`.
   /// @relates SpatialVector.
   friend SpatialQuantity operator*(const T& s, const SpatialQuantity& V) {
-    return SpatialQuantity(s * V.get_coeffs());
+    return SpatialQuantity(V) *= s;
   }
 
   /// Multiplication of a spatial vector V from the right by a scalar `s`.
@@ -225,11 +267,6 @@ class SpatialVector {
   friend SpatialQuantity operator*(
       const math::RotationMatrix<T>& R_FE, const SpatialQuantity& V_E) {
     return SpatialQuantity(R_FE * V_E.rotational(), R_FE * V_E.translational());
-  }
-
-  /// Unary minus operator.
-  SpatialQuantity operator-() const {
-    return SpatialQuantity(-get_coeffs());
   }
 
   /// Factory to create a _zero_ %SpatialVector, i.e. rotational and

--- a/multibody/math/spatial_velocity.h
+++ b/multibody/math/spatial_velocity.h
@@ -266,10 +266,14 @@ class SpatialVelocity : public SpatialVector<SpatialVelocity, T> {
 ///
 /// The addition in the last expression is what is carried out by this operator;
 /// the caller must have already performed the necessary shift.
+///
+/// @relates SpatialVelocity
 template <typename T>
 inline SpatialVelocity<T> operator+(
     const SpatialVelocity<T>& V_MAb_E, const SpatialVelocity<T>& V_AB_E) {
-  return SpatialVelocity<T>(V_MAb_E.get_coeffs() + V_AB_E.get_coeffs());
+  // N.B. We use SpatialVector's implementation, though we provide the overload
+  // for specific documentation purposes.
+  return SpatialVelocity<T>(V_MAb_E) += V_AB_E;
 }
 
 /// The addition of two spatial velocities relates to the composition of
@@ -290,10 +294,14 @@ inline SpatialVelocity<T> operator+(
 /// as explained in the documentation for
 /// operator+(const SpatialVelocity<T>&, const SpatialVelocity<T>&) a shift
 /// operation with SpatialVelocity::Shift() operation is needed.
+///
+/// @relates SpatialVelocity
 template <typename T>
 inline SpatialVelocity<T> operator-(
     const SpatialVelocity<T>& V_MB_E, const SpatialVelocity<T>& V_MAb_E) {
-  return SpatialVelocity<T>(V_MB_E.get_coeffs() - V_MAb_E.get_coeffs());
+  // N.B. We use SpatialVector's implementation, though we provide the overload
+  // for specific documentation purposes.
+  return SpatialVelocity<T>(V_MB_E) -= V_MAb_E;
 }
 
 }  // namespace multibody

--- a/multibody/math/test/spatial_algebra_test.cc
+++ b/multibody/math/test/spatial_algebra_test.cc
@@ -68,6 +68,14 @@ class SpatialQuantityTest : public ::testing::Test {
   // A spatial quantity related to the above rotational and translational
   // components.
   SpatialQuantityType V_{w_, v_};
+
+  // Two non-zero arbitrary spatial vector.
+  const Vector3<ScalarType> r1_{1.0, 2.0, 3.0};
+  const Vector3<ScalarType> t1_{4.0, 5.0, 6.0};
+  const SpatialQuantityType V1_{r1_, t1_};
+  const Vector3<ScalarType> r2_{-1.0, 1.5, -0.5};
+  const Vector3<ScalarType> t2_{5.0, 7.0, 8.0};
+  const SpatialQuantityType V2_{r2_, t2_};
 };
 
 // Create a list of SpatialVector types to be tested.
@@ -279,6 +287,17 @@ TYPED_TEST(SpatialQuantityTest, ShiftOperatorIntoStream) {
   EXPECT_EQ(expected_string, stream.str());
 }
 
+TYPED_TEST(SpatialQuantityTest, MultiplicationAssignmentOperator) {
+  typedef typename TestFixture::SpatialQuantityType SpatialQuantity;
+  typedef typename TestFixture::ScalarType T;
+  const T scalar = 3.0;
+  SpatialQuantity V(this->V1_);
+  V *= scalar;
+  // Verify the result using Eigen operations.
+  EXPECT_EQ(V.rotational(), Vector3<T>(this->r1_ * scalar));
+  EXPECT_EQ(V.translational(), Vector3<T>(this->t1_ * scalar));
+}
+
 // Test the multiplication of a spatial quantity by a scalar.
 TYPED_TEST(SpatialQuantityTest, MulitplicationByAScalar) {
   typedef typename TestFixture::SpatialQuantityType SpatialQuantity;
@@ -316,6 +335,44 @@ TYPED_TEST(SpatialQuantityTest, UnaryMinusOperator) {
   // Verify the result using Eigen operations.
   EXPECT_EQ(V.rotational(), -Vminus.rotational());
   EXPECT_EQ(V.translational(), -Vminus.translational());
+}
+
+TYPED_TEST(SpatialQuantityTest, AdditionAssignmentOperator) {
+  typedef typename TestFixture::SpatialQuantityType SpatialQuantity;
+  typedef typename TestFixture::ScalarType T;
+  SpatialQuantity V(this->V1_);
+  V += this->V2_;
+  // Verify the result using Eigen operations.
+  EXPECT_EQ(V.rotational(), Vector3<T>(this->r1_ + this->r2_));
+  EXPECT_EQ(V.translational(), Vector3<T>(this->t1_ + this->t2_));
+}
+
+TYPED_TEST(SpatialQuantityTest, AdditionOperator) {
+  typedef typename TestFixture::SpatialQuantityType SpatialQuantity;
+  typedef typename TestFixture::ScalarType T;
+  const SpatialQuantity V = this->V1_ + this->V2_;
+  // Verify the result using Eigen operations.
+  EXPECT_EQ(V.rotational(), Vector3<T>(this->r1_ + this->r2_));
+  EXPECT_EQ(V.translational(), Vector3<T>(this->t1_ + this->t2_));
+}
+
+TYPED_TEST(SpatialQuantityTest, SubtractionAssignmentOperator) {
+  typedef typename TestFixture::SpatialQuantityType SpatialQuantity;
+  typedef typename TestFixture::ScalarType T;
+  SpatialQuantity V(this->V1_);
+  V -= this->V2_;
+  // Verify the result using Eigen operations.
+  EXPECT_EQ(V.rotational(), Vector3<T>(this->r1_ - this->r2_));
+  EXPECT_EQ(V.translational(), Vector3<T>(this->t1_ - this->t2_));
+}
+
+TYPED_TEST(SpatialQuantityTest, SubtractionOperator) {
+  typedef typename TestFixture::SpatialQuantityType SpatialQuantity;
+  typedef typename TestFixture::ScalarType T;
+  const SpatialQuantity V = this->V1_ - this->V2_;
+  // Verify the result using Eigen operations.
+  EXPECT_EQ(V.rotational(), Vector3<T>(this->r1_ - this->r2_));
+  EXPECT_EQ(V.translational(), Vector3<T>(this->t1_ - this->t2_));
 }
 
 // Re-express in another frame. Given a spatial vector V_F expressed in a frame


### PR DESCRIPTION
Addresses @sherm1 review comment in  #12412 (I'll transcribe below because for some reason I cannot get a valid link): 
"Looking at the code here I'm wondering if that was a mistake (likely my fault!). Consider instead providing the operator but documenting as "(Advanced)" with loud warnings noting that you can't simply add accelerations together and expect a meaningful result. The addition operator would definitely help clean up the code here, and we are probably the main users of the SpatialAcceleration class."

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12436)
<!-- Reviewable:end -->
