### PR TITLE
Removed referring triangles from SurfaceMesh.

### DIFF
--- a/geometry/proximity/surface_mesh.h
+++ b/geometry/proximity/surface_mesh.h
@@ -181,13 +181,6 @@ class SurfaceMesh {
     return vertices_[v];
   }
 
-  /**
-   Gets the set of triangles that refer to the specified vertex.
-   */
-  const std::set<SurfaceFaceIndex>& referring_triangles(VertexIndex v) const {
-    return referring_triangles_[v];
-  }
-
   /** Returns the number of vertices in the mesh.
    */
   int num_vertices() const { return vertices_.size(); }
@@ -211,7 +204,6 @@ class SurfaceMesh {
         vertices_(std::move(vertices)),
         area_(faces_.size()),  // Pre-allocate here, not yet calculated.
         face_normals_(faces_.size()) {  // Pre-allocate, not yet calculated.
-    SetReferringTriangles();
     CalcAreasNormalsAndCentroid();
   }
 
@@ -395,26 +387,12 @@ class SurfaceMesh {
   // and the centroid of the surface.
   void CalcAreasNormalsAndCentroid();
 
-  // Determines the triangular faces that refer to each vertex.
-  void SetReferringTriangles() {
-    referring_triangles_.resize(num_vertices());
-
-    for (SurfaceFaceIndex i(0); i < num_faces(); ++i) {
-      const int kNumVerticesPerFace = 3;
-      for (int j = 0; j < kNumVerticesPerFace; ++j)
-        referring_triangles_[element(i).vertex(j)].insert(i);
-    }
-  }
-
   // The triangles that comprise the surface.
   std::vector<SurfaceFace> faces_;
   // The vertices that are shared among the triangles.
   std::vector<SurfaceVertex<T>> vertices_;
 
   // Computed in initialization.
-
-  // Triangles that reference each vertex.
-  std::vector<std::set<SurfaceFaceIndex>> referring_triangles_;
 
   // Area of the triangles.
   std::vector<T> area_;

--- a/geometry/proximity/test/surface_mesh_test.cc
+++ b/geometry/proximity/test/surface_mesh_test.cc
@@ -144,37 +144,6 @@ GTEST_TEST(SurfaceMeshTest, GenerateTwoTriangleMeshAutoDiffXd) {
   EXPECT_EQ(surface_mesh->num_faces(), 2);
 }
 
-// Tests that referring_triangles() produces the correct sets of referring
-// triangles.
-GTEST_TEST(SurfaceMeshTest, ReferringTriangles) {
-  auto surface_mesh = GenerateTwoTriangleMesh<double>();
-  ASSERT_EQ(surface_mesh->num_vertices(), 4);
-
-  // Get the four sets.
-  const std::set<SurfaceFaceIndex>& tris_referring_to_0 =
-      surface_mesh->referring_triangles(SurfaceVertexIndex(0));
-  const std::set<SurfaceFaceIndex>& tris_referring_to_1 =
-      surface_mesh->referring_triangles(SurfaceVertexIndex(1));
-  const std::set<SurfaceFaceIndex>& tris_referring_to_2 =
-      surface_mesh->referring_triangles(SurfaceVertexIndex(2));
-  const std::set<SurfaceFaceIndex>& tris_referring_to_3 =
-      surface_mesh->referring_triangles(SurfaceVertexIndex(3));
-
-  // Construct the expected sets.
-  std::set<SurfaceFaceIndex> expected_tris_referring_to_0{
-      SurfaceFaceIndex(0), SurfaceFaceIndex(1) };
-  std::set<SurfaceFaceIndex> expected_tris_referring_to_1{SurfaceFaceIndex(0)};
-  std::set<SurfaceFaceIndex> expected_tris_referring_to_2{
-      SurfaceFaceIndex(0), SurfaceFaceIndex(1) };
-  std::set<SurfaceFaceIndex> expected_tris_referring_to_3{SurfaceFaceIndex(1)};
-
-  // Check the results.
-  EXPECT_EQ(expected_tris_referring_to_0, tris_referring_to_0);
-  EXPECT_EQ(expected_tris_referring_to_1, tris_referring_to_1);
-  EXPECT_EQ(expected_tris_referring_to_2, tris_referring_to_2);
-  EXPECT_EQ(expected_tris_referring_to_3, tris_referring_to_3);
-}
-
 // Checks the area calculations.
 GTEST_TEST(SurfaceMeshTest, TestArea) {
   const double tol = 10 * std::numeric_limits<double>::epsilon();


### PR DESCRIPTION
Resolves #11956

I'm not deprecating this code as we're no longer using it anywhere in the Drake code base and I have good reason to believe that no one is using it in other codebases either.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12438)
<!-- Reviewable:end -->
