### PR TITLE
Revert "workspace: Upgrade lcm to latest commit"

### DIFF
--- a/tools/workspace/lcm/repository.bzl
+++ b/tools/workspace/lcm/repository.bzl
@@ -8,8 +8,8 @@ def lcm_repository(
     github_archive(
         name = name,
         repository = "lcm-proj/lcm",
-        commit = "fd9600a573a4feac7607216c00866d5824e9d1e2",
-        sha256 = "b2f512b473a852f82970899b6dcc2580f17df933fd16b3ca3560db18060effac",  # noqa
+        commit = "c22669c32b40f49a4b5e986480167dbc7783ebd6",
+        sha256 = "fd1a170bb9c73c63b49d13bb7ddd3dc0fe1316621a67aa4cadec9c33492f3c32",  # noqa
         build_file = "@drake//tools/workspace/lcm:package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
This reverts commit e4ecdcfb330c91c864f2206d078e836fe5872e30 from #12395.  Upstream commit [6b9099a](https://github.com/lcm-proj/lcm/commit/6b9099a15675794a94d7198dd69840bcd5432f25) makes LCM leaky on Linux.

Follow-up work is under #12448.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12447)
<!-- Reviewable:end -->
