### PR TITLE
Pass --no-lock to brew bundle

### DIFF
--- a/setup/mac/binary_distribution/install_prereqs.sh
+++ b/setup/mac/binary_distribution/install_prereqs.sh
@@ -24,7 +24,7 @@ fi
 # TODO(jamiesnape): Remove two lines uninstalling dreal on or after 2020-02-01.
 brew uninstall --force dreal
 brew untap dreal/dreal &>/dev/null || true
-/usr/local/bin/brew bundle --file="${BASH_SOURCE%/*}/Brewfile"
+/usr/local/bin/brew bundle --file="${BASH_SOURCE%/*}/Brewfile" --no-lock
 
 if ! command -v /usr/local/bin/pip3 &>/dev/null; then
   echo 'ERROR: pip3 is NOT installed. The post-install step for the python formula may have failed.' >&2

--- a/setup/mac/source_distribution/install_prereqs.sh
+++ b/setup/mac/source_distribution/install_prereqs.sh
@@ -18,7 +18,7 @@ if ! command -v /usr/local/bin/brew &>/dev/null; then
 fi
 
 /usr/local/bin/brew update
-/usr/local/bin/brew bundle --file="${BASH_SOURCE%/*}/Brewfile"
+/usr/local/bin/brew bundle --file="${BASH_SOURCE%/*}/Brewfile" --no-lock
 
 if ! command -v /usr/local/bin/pip3 &>/dev/null; then
   echo 'ERROR: pip3 is NOT installed. The post-install step for the python formula may have failed.' >&2


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-bundle/pull/552 introduces `Brewfile.lock.json` which provides a list of successfully installed packages and their metainfo.

For now, git detects those new "Brewfile.lock.json" files as untracked files. Passing `--no-lock` is one solution to this problem. An alternative is to add the pattern in `.gitignore` but I think it's cleaner not to create those files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12458)
<!-- Reviewable:end -->
