### PR TITLE
Move jupyter notebook and ipywidgets to binary prerequisite install

### DIFF
--- a/setup/mac/binary_distribution/requirements.txt
+++ b/setup/mac/binary_distribution/requirements.txt
@@ -1,5 +1,7 @@
+ipywidgets
 lxml
 matplotlib
+notebook
 pydot
 PyYAML
 pyzmq

--- a/setup/mac/source_distribution/requirements.txt
+++ b/setup/mac/source_distribution/requirements.txt
@@ -1,6 +1,5 @@
 boto3
-ipywidgets  # For Jupyter
-jupyter  # Also enables `jupyter notebook`
+jupyter
 pandas
 pygame
 # Constrain Sphinx due to hack customizations for templates in

--- a/setup/ubuntu/binary_distribution/packages-bionic.txt
+++ b/setup/ubuntu/binary_distribution/packages-bionic.txt
@@ -3,6 +3,7 @@ coinor-libcoinutils3v5
 coinor-libipopt1v5
 default-jre
 graphviz
+jupyter-notebook
 libamd2
 libblas3
 libboost-all-dev
@@ -32,6 +33,7 @@ libxml2
 libxt6
 libyaml-cpp0.5v5
 python3
+python3-ipywidgets
 python3-lxml
 python3-matplotlib
 python3-numpy

--- a/setup/ubuntu/source_distribution/packages-bionic.txt
+++ b/setup/ubuntu/source_distribution/packages-bionic.txt
@@ -13,7 +13,6 @@ gdb
 gfortran
 git
 jupyter
-jupyter-notebook
 kcov-35
 libblas-dev
 libbz2-dev
@@ -53,7 +52,6 @@ python3-boto3
 python3-dateutil
 python3-dbg
 python3-dev
-python3-ipywidgets
 python3-jwcrypto
 python3-lxml-dbg
 python3-matplotlib-dbg


### PR DESCRIPTION
Toward #11962.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12461)
<!-- Reviewable:end -->
