### PR TITLE
Updates MBP::DoCalcTimeDerivatives() to use ABA

### DIFF
--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1941,7 +1941,7 @@ void MultibodyPlant<T>::CalcGeneralizedAccelerations(
   if (is_discrete())
     CalcGeneralizedAccelerationsDiscrete(context, vdot);
   else
-    CalcGeneralizedAccelerationsContinuous(context, vdot);
+    *vdot = EvalForwardDynamics(context).get_vdot();
 }
 
 template <typename T>

--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -438,6 +438,7 @@ drake_cc_googletest(
     deps = [
         ":tree",
         "//common/test_utilities:expect_no_throw",
+        "//common/test_utilities:expect_throws_message",
         "//math:autodiff",
         "//math:gradient",
     ],

--- a/multibody/tree/articulated_body_inertia.h
+++ b/multibody/tree/articulated_body_inertia.h
@@ -375,11 +375,16 @@ class ArticulatedBodyInertia {
   // Checks that the ArticulatedBodyInertia is physically valid and throws an
   // exception if not. This is mostly used in Debug builds to throw an
   // appropriate exception.
+  // Since this method is used within assertions or demands, we do not try to
+  // attempt a smart way throw based on a given symbolic::Formula but instead we
+  // make these methods a no-op for non-numeric types.
   void CheckInvariants() const {
-    if (!IsPhysicallyValid()) {
-      throw std::runtime_error(
-          "The resulting articulated body inertia is not physically valid. "
-              "See ArticulatedBodyInertia::IsPhysicallyValid()");
+    if constexpr (scalar_predicate<T>::is_bool) {
+      if (!IsPhysicallyValid()) {
+        throw std::runtime_error(
+            "The resulting articulated body inertia is not physically valid. "
+            "See ArticulatedBodyInertia::IsPhysicallyValid()");
+      }
     }
   }
 };


### PR DESCRIPTION
The one liner change that enables ABA from MBP::DoCalcTimeDerivatives().

All other changes enable running MBP in continuous mode for the largest examples we have thus far in `drake/examples`. In my computer these are the speed ups I observed:
- `examples/simple_gripper`: 17 dofs (nv = 8). 1.07 times faster.
- `examples/allegro_hand/joint_control:allegro_single_object_simulation`: 45 dofs (nv = 22). 1.75 times faster.
- `examples/atlas:atlas_run_dynamics`: 73 dofs (nv = 36). 5.5 times faster.

For these quick measurements I run the simulations for 20000 time steps using a semi-explicit Euler so that the number of time steps were known from the step size and simulation length.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12470)
<!-- Reviewable:end -->
