### PR TITLE
Traction and slip velocity vectors

### DIFF
--- a/lcmtypes/BUILD.bazel
+++ b/lcmtypes/BUILD.bazel
@@ -109,7 +109,7 @@ drake_lcm_cc_library(
     lcm_srcs = ["lcmt_hydroelastic_contact_surface_for_viz.lcm"],
     deps = [
         ":hydroelastic_contact_surface_tri_for_viz",
-        ":hydroelastic_quadrature_point_data_for_viz",
+        ":hydroelastic_quadrature_per_point_data_for_viz",
     ],
 )
 
@@ -120,9 +120,9 @@ drake_lcm_cc_library(
 )
 
 drake_lcm_cc_library(
-    name = "hydroelastic_quadrature_point_data_for_viz",
+    name = "hydroelastic_quadrature_per_point_data_for_viz",
     lcm_package = "drake",
-    lcm_srcs = ["lcmt_hydroelastic_quadrature_point_data_for_viz.lcm"],
+    lcm_srcs = ["lcmt_hydroelastic_quadrature_per_point_data_for_viz.lcm"],
 )
 
 drake_lcm_cc_library(

--- a/lcmtypes/BUILD.bazel
+++ b/lcmtypes/BUILD.bazel
@@ -107,13 +107,22 @@ drake_lcm_cc_library(
     name = "hydroelastic_contact_surface_for_viz",
     lcm_package = "drake",
     lcm_srcs = ["lcmt_hydroelastic_contact_surface_for_viz.lcm"],
-    deps = [":hydroelastic_contact_surface_tri_for_viz"],
+    deps = [
+        ":hydroelastic_contact_surface_tri_for_viz",
+        ":hydroelastic_quadrature_point_data_for_viz",
+    ],
 )
 
 drake_lcm_cc_library(
     name = "hydroelastic_contact_surface_tri_for_viz",
     lcm_package = "drake",
     lcm_srcs = ["lcmt_hydroelastic_contact_surface_tri_for_viz.lcm"],
+)
+
+drake_lcm_cc_library(
+    name = "hydroelastic_quadrature_point_data_for_viz",
+    lcm_package = "drake",
+    lcm_srcs = ["lcmt_hydroelastic_quadrature_point_data_for_viz.lcm"],
 )
 
 drake_lcm_cc_library(

--- a/lcmtypes/lcmt_hydroelastic_contact_surface_for_viz.lcm
+++ b/lcmtypes/lcmt_hydroelastic_contact_surface_for_viz.lcm
@@ -26,7 +26,11 @@ struct lcmt_hydroelastic_contact_surface_for_viz {
   // The number of quadrature points.
   int32_t num_quadrature_points;
 
-  // The quadrature point data.
+  // The quadrature point data. Quadrature points are stored sequentially with
+  // the triangles, meaning that quadrature point data at indices 0, 1, 2
+  // correspond to the triangle with index 0; quadrature point data at indices
+  // 3, 4, 5 correspond to the triangle with index 1; etc. (given, in this
+  // example, three quadrature points per triangle).
   lcmt_hydroelastic_quadrature_per_point_data_for_viz
       quadrature_point_data[num_quadrature_points];
 }

--- a/lcmtypes/lcmt_hydroelastic_contact_surface_for_viz.lcm
+++ b/lcmtypes/lcmt_hydroelastic_contact_surface_for_viz.lcm
@@ -27,6 +27,6 @@ struct lcmt_hydroelastic_contact_surface_for_viz {
   int32_t num_quadrature_points;
 
   // The quadrature point data.
-  lcmt_hydroelastic_quadrature_point_data_for_viz
+  lcmt_hydroelastic_quadrature_per_point_data_for_viz
       quadrature_point_data[num_quadrature_points];
 }

--- a/lcmtypes/lcmt_hydroelastic_contact_surface_for_viz.lcm
+++ b/lcmtypes/lcmt_hydroelastic_contact_surface_for_viz.lcm
@@ -22,4 +22,11 @@ struct lcmt_hydroelastic_contact_surface_for_viz {
 
   // The contact surface mesh and associated data.
   lcmt_hydroelastic_contact_surface_tri_for_viz triangles[num_triangles];
+
+  // The number of quadrature points.
+  int32_t num_quadrature_points;
+
+  // The quadrature point data.
+  lcmt_hydroelastic_quadrature_point_data_for_viz
+      quadrature_point_data[num_quadrature_points];
 }

--- a/lcmtypes/lcmt_hydroelastic_quadrature_per_point_data_for_viz.lcm
+++ b/lcmtypes/lcmt_hydroelastic_quadrature_per_point_data_for_viz.lcm
@@ -5,10 +5,11 @@ struct lcmt_hydroelastic_quadrature_per_point_data_for_viz {
   // the traction and slip velocities are evaluated.
   double p_WQ[3];
 
-  // The velocity of Body A at Point Q relative to Body B at point Q,
-  // expressed in the world frame, and projected to the plane tangent to the
-  // contact surface. Note that Point Q is coincident to frames Aq
-  // and Bq attached to Bodies A and B, respectively.
+  // Denoting Point Aq as the point of Body A coincident with Q and Point Bq as
+  // the point of Body B coincident with Q, calculates vr (the velocity
+  // of Bq relative to Aq) and then calculates the component perpendicular to
+  // the unit surface normal n̂ as vt = vr - (vrᵀ⋅n̂)n̂.
+  // The resulting vector vt is expressed in the world frame W.
   double vt_BqAq_W[3];
 
   // The traction vector, expressed in the world frame and with units of Pa,

--- a/lcmtypes/lcmt_hydroelastic_quadrature_per_point_data_for_viz.lcm
+++ b/lcmtypes/lcmt_hydroelastic_quadrature_per_point_data_for_viz.lcm
@@ -1,6 +1,6 @@
 package drake;
 
-struct lcmt_hydroelastic_quadrature_point_data_for_viz {
+struct lcmt_hydroelastic_quadrature_per_point_data_for_viz {
   // The quadrature point Q, as an offset vector in the world frame W, at which
   // the traction and slip velocities are evaluated.
   double p_WQ[3];

--- a/lcmtypes/lcmt_hydroelastic_quadrature_per_point_data_for_viz.lcm
+++ b/lcmtypes/lcmt_hydroelastic_quadrature_per_point_data_for_viz.lcm
@@ -8,7 +8,7 @@ struct lcmt_hydroelastic_quadrature_per_point_data_for_viz {
   // Denoting Point Aq as the point of Body A coincident with Q and Point Bq as
   // the point of Body B coincident with Q, calculates vr (the velocity
   // of Bq relative to Aq) and then calculates the component perpendicular to
-  // the unit surface normal n̂ as vt = vr - (vrᵀ⋅n̂)n̂.
+  // the unit surface normal n̂ as vt = vr - (vr⋅n̂)n̂.
   // The resulting vector vt is expressed in the world frame W.
   double vt_BqAq_W[3];
 

--- a/lcmtypes/lcmt_hydroelastic_quadrature_point_data_for_viz.lcm
+++ b/lcmtypes/lcmt_hydroelastic_quadrature_point_data_for_viz.lcm
@@ -5,13 +5,13 @@ struct lcmt_hydroelastic_quadrature_point_data_for_viz {
   // the traction and slip velocities are evaluated.
   double p_WQ[3];
 
-  // The slip velocity of Body A at Point Q relative to Body B at point Q,
-  // expressed in the world frame. Note that Point Q is coincident to frames Aq
+  // The velocity of Body A at Point Q relative to Body B at point Q,
+  // expressed in the world frame, and projected to the plane tangent to the
+  // contact surface. Note that Point Q is coincident to frames Aq
   // and Bq attached to Bodies A and B, respectively.
   double vt_BqAq_W[3];
 
-  // The traction vector (with units of Pa) applied to Frame Aq rigidly
-  // attached to Body A at Point Q (i.e., Frame A is shifted to Aq), expressed
-  // in the world frame.
+  // The traction vector, expressed in the world frame and with units of Pa,
+  // applied to Body A at Point Q (i.e., Frame A is shifted to Aq).
   double traction_Aq_W[3];
 }

--- a/lcmtypes/lcmt_hydroelastic_quadrature_point_data_for_viz.lcm
+++ b/lcmtypes/lcmt_hydroelastic_quadrature_point_data_for_viz.lcm
@@ -5,9 +5,9 @@ struct lcmt_hydroelastic_quadrature_point_data_for_viz {
   // the traction and slip velocities are evaluated.
   double p_WQ[3];
 
-  // The slip velocity between two bodies A and B at Point Q, expressed in the
-  // world frame. Note that Point Q is coincident to frames Aq and Bq attached
-  // to Bodies A and B, respectively.
+  // The slip velocity of Body A at Point Q relative to Body B at point Q,
+  // expressed in the world frame. Note that Point Q is coincident to frames Aq
+  // and Bq attached to Bodies A and B, respectively.
   double vt_BqAq_W[3];
 
   // The traction vector (with units of Pa) applied to Frame Aq rigidly

--- a/lcmtypes/lcmt_hydroelastic_quadrature_point_data_for_viz.lcm
+++ b/lcmtypes/lcmt_hydroelastic_quadrature_point_data_for_viz.lcm
@@ -1,0 +1,17 @@
+package drake;
+
+struct lcmt_hydroelastic_quadrature_point_data_for_viz {
+  // The quadrature point Q, as an offset vector in the world frame W, at which
+  // the traction and slip velocities are evaluated.
+  double p_WQ[3];
+
+  // The slip velocity between two bodies A and B at Point Q, expressed in the
+  // world frame. Note that Point Q is coincident to frames Aq and Bq attached
+  // to Bodies A and B, respectively.
+  double vt_BqAq_W[3];
+
+  // The traction vector (with units of Pa) applied to Frame Aq rigidly
+  // attached to Body A at Point Q (i.e., Frame A is shifted to Aq), expressed
+  // in the world frame.
+  double traction_Aq_W[3];
+}

--- a/multibody/plant/contact_results_to_lcm.cc
+++ b/multibody/plant/contact_results_to_lcm.cc
@@ -115,7 +115,7 @@ void ContactResultsToLcmSystem<T>::CalcLcmContactOutput(
 
     // Loop through all quadrature points on the contact surface.
     for (int j = 0; j < surface_msg.num_quadrature_points; ++j) {
-      lcmt_hydroelastic_quadrature_point_data_for_viz& quad_data_msg =
+      lcmt_hydroelastic_quadrature_per_point_data_for_viz& quad_data_msg =
           surface_msg.quadrature_point_data[j];
       write_double3(quadrature_point_data[j].p_WQ, quad_data_msg.p_WQ);
       write_double3(quadrature_point_data[j].vt_BqAq_W,

--- a/multibody/plant/contact_results_to_lcm.cc
+++ b/multibody/plant/contact_results_to_lcm.cc
@@ -101,12 +101,22 @@ void ContactResultsToLcmSystem<T>::CalcLcmContactOutput(
     const geometry::SurfaceMesh<T>& mesh_W = contact_surface.mesh_W();
     surface_msg.num_triangles = mesh_W.num_faces();
     surface_msg.triangles.resize(surface_msg.num_triangles);
+    surface_msg.num_quadrature_points =
+        hydroelastic_contact_info.quadrature_point_data.size();
+    surface_msg.quadrature_point_data.resize(surface_msg.num_quadrature_points);
 
     write_double3(contact_surface.mesh_W().centroid(), surface_msg.centroid_W);
     write_double3(hydroelastic_contact_info.F_Ac_W().translational(),
                   surface_msg.force_C_W);
     write_double3(hydroelastic_contact_info.F_Ac_W().rotational(),
                   surface_msg.moment_C_W);
+
+    // Loop through all quadrature points on the contact surface.
+    lcmt_hydroelastic_quadature_point_data&
+    for (const auto& quadrature_point_data_i :
+         hydroelastic_contact_info.quadrature_point_data()) {
+
+    }
 
     // Loop through each contact triangle on the contact surface.
     for (geometry::SurfaceFaceIndex j(0); j < surface_msg.num_triangles; ++j) {

--- a/multibody/plant/contact_results_to_lcm.cc
+++ b/multibody/plant/contact_results_to_lcm.cc
@@ -113,8 +113,14 @@ void ContactResultsToLcmSystem<T>::CalcLcmContactOutput(
     write_double3(hydroelastic_contact_info.F_Ac_W().rotational(),
                   surface_msg.moment_C_W);
 
-    // Loop through all quadrature points on the contact surface.
+    // Write all quadrature points on the contact surface.
+    const int num_quadrature_points_per_tri =
+        surface_msg.num_quadrature_points / surface_msg.num_triangles;
     for (int j = 0; j < surface_msg.num_quadrature_points; ++j) {
+      // Verify the ordering is consistent with that advertised.
+      DRAKE_DEMAND(quadrature_point_data[j].face_index ==
+                   j / num_quadrature_points_per_tri);
+
       lcmt_hydroelastic_quadrature_per_point_data_for_viz& quad_data_msg =
           surface_msg.quadrature_point_data[j];
       write_double3(quadrature_point_data[j].p_WQ, quad_data_msg.p_WQ);

--- a/multibody/plant/contact_results_to_lcm.cc
+++ b/multibody/plant/contact_results_to_lcm.cc
@@ -89,6 +89,9 @@ void ContactResultsToLcmSystem<T>::CalcLcmContactOutput(
 
     const HydroelasticContactInfo<T>& hydroelastic_contact_info =
         contact_results.hydroelastic_contact_info(i);
+    const std::vector<HydroelasticQuadraturePointData<T>>&
+        quadrature_point_data =
+            hydroelastic_contact_info.quadrature_point_data();
 
     // Get the two body names.
     surface_msg.body1_name = geometry_id_to_body_name_map_.at(
@@ -101,8 +104,7 @@ void ContactResultsToLcmSystem<T>::CalcLcmContactOutput(
     const geometry::SurfaceMesh<T>& mesh_W = contact_surface.mesh_W();
     surface_msg.num_triangles = mesh_W.num_faces();
     surface_msg.triangles.resize(surface_msg.num_triangles);
-    surface_msg.num_quadrature_points =
-        hydroelastic_contact_info.quadrature_point_data.size();
+    surface_msg.num_quadrature_points = quadrature_point_data.size();
     surface_msg.quadrature_point_data.resize(surface_msg.num_quadrature_points);
 
     write_double3(contact_surface.mesh_W().centroid(), surface_msg.centroid_W);
@@ -112,10 +114,14 @@ void ContactResultsToLcmSystem<T>::CalcLcmContactOutput(
                   surface_msg.moment_C_W);
 
     // Loop through all quadrature points on the contact surface.
-    lcmt_hydroelastic_quadature_point_data&
-    for (const auto& quadrature_point_data_i :
-         hydroelastic_contact_info.quadrature_point_data()) {
-
+    for (int j = 0; j < surface_msg.num_quadrature_points; ++j) {
+      lcmt_hydroelastic_quadrature_point_data_for_viz& quad_data_msg =
+          surface_msg.quadrature_point_data[j];
+      write_double3(quadrature_point_data[j].p_WQ, quad_data_msg.p_WQ);
+      write_double3(quadrature_point_data[j].vt_BqAq_W,
+                    quad_data_msg.vt_BqAq_W);
+      write_double3(quadrature_point_data[j].traction_Aq_W,
+                    quad_data_msg.traction_Aq_W);
     }
 
     // Loop through each contact triangle on the contact surface.

--- a/multibody/plant/hydroelastic_quadrature_point_data.h
+++ b/multibody/plant/hydroelastic_quadrature_point_data.h
@@ -26,9 +26,8 @@ struct HydroelasticQuadraturePointData {
   /// and Bq attached to Bodies A and B, respectively.
   Vector3<T> vt_BqAq_W;
 
-  /// The traction vector (with units of Pa) applied to Frame Aq rigidly
-  /// attached to Body A at Point Q (i.e., Frame A is shifted to Aq), expressed
-  /// in the world frame.
+  /// The traction vector, expressed in the world frame and with units of Pa,
+  /// applied to Body A at Point Q (i.e., Frame A is shifted to Aq).
   Vector3<T> traction_Aq_W;
 };
 

--- a/multibody/plant/hydroelastic_quadrature_point_data.h
+++ b/multibody/plant/hydroelastic_quadrature_point_data.h
@@ -20,10 +20,11 @@ struct HydroelasticQuadraturePointData {
   /// The triangle on the ContactSurface that contains Q.
   geometry::SurfaceFaceIndex face_index;
 
-  /// The velocity of Body A at Point Q relative to Body B at point Q,
-  /// expressed in the world frame, and projected to the plane tangent to the
-  /// contact surface. Note that Point Q is coincident to frames Aq
-  /// and Bq attached to Bodies A and B, respectively.
+  /// Denoting Point Aq as the point of Body A coincident with Q and Point Bq as
+  /// the point of Body B coincident with Q, calculates vr (the velocity
+  /// of Bq relative to Aq) and then calculates the component perpendicular to
+  /// the unit surface normal n̂ as vt = vr - (vrᵀ⋅n̂)n̂.
+  /// The resulting vector vt is expressed in the world frame W.
   Vector3<T> vt_BqAq_W;
 
   /// The traction vector, expressed in the world frame and with units of Pa,

--- a/multibody/plant/hydroelastic_quadrature_point_data.h
+++ b/multibody/plant/hydroelastic_quadrature_point_data.h
@@ -20,9 +20,10 @@ struct HydroelasticQuadraturePointData {
   /// The triangle on the ContactSurface that contains Q.
   geometry::SurfaceFaceIndex face_index;
 
-  /// The slip velocity between Bodies A and B at Point Q, expressed in the
-  /// world frame. Note that Point Q is coincident to frames Aq and Bq attached
-  /// to Bodies A and B, respectively.
+  /// The velocity of Body A at Point Q relative to Body B at point Q,
+  /// expressed in the world frame, and projected to the plane tangent to the
+  /// contact surface. Note that Point Q is coincident to frames Aq
+  /// and Bq attached to Bodies A and B, respectively.
   Vector3<T> vt_BqAq_W;
 
   /// The traction vector (with units of Pa) applied to Frame Aq rigidly

--- a/multibody/plant/hydroelastic_quadrature_point_data.h
+++ b/multibody/plant/hydroelastic_quadrature_point_data.h
@@ -23,7 +23,7 @@ struct HydroelasticQuadraturePointData {
   /// Denoting Point Aq as the point of Body A coincident with Q and Point Bq as
   /// the point of Body B coincident with Q, calculates vr (the velocity
   /// of Bq relative to Aq) and then calculates the component perpendicular to
-  /// the unit surface normal n̂ as vt = vr - (vrᵀ⋅n̂)n̂.
+  /// the unit surface normal n̂ as vt = vr - (vr⋅n̂)n̂.
   /// The resulting vector vt is expressed in the world frame W.
   Vector3<T> vt_BqAq_W;
 

--- a/multibody/plant/test/contact_results_to_lcm_test.cc
+++ b/multibody/plant/test/contact_results_to_lcm_test.cc
@@ -395,7 +395,7 @@ GTEST_TEST(ContactResultsToLcmTest, HydroelasticContactResults) {
       MakeQuadraturePointData();
   ASSERT_EQ(quadrature_point_data.size(), surface_msg.num_quadrature_points);
   for (int i = 0; i < surface_msg.num_quadrature_points; ++i) {
-    const lcmt_hydroelastic_quadrature_point_data_for_viz& quadrature_msg =
+    const lcmt_hydroelastic_quadrature_per_point_data_for_viz& quadrature_msg =
         surface_msg.quadrature_point_data[i];
     const Vector3<double> p_WQ(quadrature_msg.p_WQ[0], quadrature_msg.p_WQ[1],
                                quadrature_msg.p_WQ[2]);

--- a/multibody/plant/test/contact_results_to_lcm_test.cc
+++ b/multibody/plant/test/contact_results_to_lcm_test.cc
@@ -393,7 +393,7 @@ GTEST_TEST(ContactResultsToLcmTest, HydroelasticContactResults) {
   // Verify that the quadrature point data matches that expected.
   std::vector<HydroelasticQuadraturePointData<double>> quadrature_point_data =
       MakeQuadraturePointData();
-  EXPECT_EQ(quadrature_point_data.size(), surface_msg.num_quadrature_points);
+  ASSERT_EQ(quadrature_point_data.size(), surface_msg.num_quadrature_points);
   for (int i = 0; i < surface_msg.num_quadrature_points; ++i) {
     const lcmt_hydroelastic_quadrature_point_data_for_viz& quadrature_msg =
         surface_msg.quadrature_point_data[i];

--- a/multibody/plant/test/contact_results_to_lcm_test.cc
+++ b/multibody/plant/test/contact_results_to_lcm_test.cc
@@ -24,6 +24,7 @@ using geometry::MeshFieldLinear;
 using geometry::PenetrationAsPointPair;
 using geometry::SceneGraph;
 using geometry::SurfaceFace;
+using geometry::SurfaceFaceIndex;
 using geometry::SurfaceMesh;
 using geometry::SurfaceVertex;
 using geometry::SurfaceVertexIndex;
@@ -189,19 +190,6 @@ GTEST_TEST(ConnectContactResultsToDrakeVisualizer, NestedDiagramTest) {
 // TODO(edrumwri) Refactor these helper functions to be more
 // broadly available to unit tests that depend on them.
 
-// Returns two distinct quadrature points.
-std::vector<HydroelasticQuadraturePointData<double>> MakeQuadraturePointData() {
-  std::vector<HydroelasticQuadraturePointData<double>> quadrature_point_data;
-  quadrature_point_data.resize(2);
-  quadrature_point_data[0].p_WQ = Vector3<double>(1, 3, 5);
-  quadrature_point_data[0].vt_BqAq_W = Vector3<double>(7, 11, 13);
-  quadrature_point_data[0].traction_Aq_W = Vector3<double>(17, 19, 23);
-  quadrature_point_data[1].p_WQ = Vector3<double>(29, 31, 37);
-  quadrature_point_data[1].vt_BqAq_W = Vector3<double>(41, 43, 47);
-  quadrature_point_data[1].traction_Aq_W = Vector3<double>(51, 53, 57);
-  return quadrature_point_data;
-}
-
 // Returns a distinct spatial force.
 SpatialForce<double> MakeSpatialForce() {
   return SpatialForce<double>(Vector3<double>(1, 2, 3),
@@ -228,6 +216,25 @@ std::unique_ptr<SurfaceMesh<double>> CreateSurfaceMesh() {
 
   return std::make_unique<SurfaceMesh<double>>(
       std::move(faces), std::move(vertices));
+}
+
+// Returns two distinct quadrature points.
+std::vector<HydroelasticQuadraturePointData<double>> MakeQuadraturePointData() {
+  // Note that the setup of the face indices will indicate exactly one
+  // quadrature point per triangle given a mesh of two triangles. Verify this.
+  DRAKE_DEMAND(CreateSurfaceMesh()->num_faces() == 2);
+
+  std::vector<HydroelasticQuadraturePointData<double>> quadrature_point_data;
+  quadrature_point_data.resize(2);
+  quadrature_point_data[0].p_WQ = Vector3<double>(1, 3, 5);
+  quadrature_point_data[0].vt_BqAq_W = Vector3<double>(7, 11, 13);
+  quadrature_point_data[0].traction_Aq_W = Vector3<double>(17, 19, 23);
+  quadrature_point_data[0].face_index = SurfaceFaceIndex(0);
+  quadrature_point_data[1].p_WQ = Vector3<double>(29, 31, 37);
+  quadrature_point_data[1].vt_BqAq_W = Vector3<double>(41, 43, 47);
+  quadrature_point_data[1].traction_Aq_W = Vector3<double>(51, 53, 57);
+  quadrature_point_data[1].face_index = SurfaceFaceIndex(1);
+  return quadrature_point_data;
 }
 
 // Creates a contact surface between the two given geometries.


### PR DESCRIPTION
Adds LCM messages for traction and slip velocity vectors corresponding to quadrature points and populates those messages in MultibodyPlant.

This PR finishes the sequence of PRs for providing information for hydroelastics contact reporting and enables traction and slip velocity vector visualization at contact surfaces (once an appropriate plugin has been added to Drake Visualizer, forthcoming).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12471)
<!-- Reviewable:end -->
