### PR TITLE
mkdoc: Fix bug where some internal names may leak in

### DIFF
--- a/third_party/com_github_pybind_pybind11/mkdoc.py
+++ b/third_party/com_github_pybind_pybind11/mkdoc.py
@@ -75,14 +75,6 @@ SKIP_RECURSE_NAMES = [
     'tinyxml2',
 ]
 
-# Exceptions to `SKIP_RECURSE_NAMES`; only one degree of exception is made
-# (i.e., nested symbols are still subject to `SKIP_RECURSE_NAMES`).
-SKIP_RECURSE_EXCEPTIONS = [
-    # TODO(eric.cousineau): Remove this once we figure out why not having
-    # it breaks the doc generation process.
-    ('drake', 'multibody', 'internal'),
-]
-
 # Filter based on partial names.
 SKIP_PARTIAL_NAMES = [
     'operator new',
@@ -126,14 +118,16 @@ def eprint(*args):
 
 def is_accepted_cursor(cursor, name_chain):
     """
-    Determines if a symbol should be visited or not.
+    Determines if a symbol should be visited or not, given the cursor and the
+    name chain.
     """
     name = utf8(cursor.spelling)
-    if name in SKIP_RECURSE_NAMES:
-        if tuple(name_chain) not in SKIP_RECURSE_EXCEPTIONS:
+    # N.B. See TODO in `get_name_chain`.
+    for piece in name_chain + (name,):
+        if piece in SKIP_RECURSE_NAMES:
             return False
-    for bad in SKIP_PARTIAL_NAMES:
-        if bad in name:
+    for skip_partial_name in SKIP_PARTIAL_NAMES:
+        if skip_partial_name in name:
             return False
     if cursor.access_specifier in SKIP_ACCESS:
         return False
@@ -650,7 +644,11 @@ def get_name_chain(cursor):
     """
     Extracts the pieces for a namespace-qualified name for a symbol.
     """
-    name_chain = [utf8(cursor.spelling)]
+    # TODO(eric.cousineau): Try to restrict the name_chain to end with name. I
+    # briefly tried this once by culling based on accepted cursors, but lost
+    # needed symbols because of it.
+    name = utf8(cursor.spelling)
+    name_chain = [name]
     p = cursor.semantic_parent
     while p and p.kind != CursorKind.TRANSLATION_UNIT:
         piece = utf8(p.spelling)
@@ -934,7 +932,7 @@ def print_symbols(f, name, node, level=0):
 
     name_var = name
     if not node.first_symbol:
-        assert level == 0
+        assert level == 0, name_var
         full_name = name
     else:
         name_chain = node.first_symbol.name_chain


### PR DESCRIPTION
Remove SKIP_RECURSE_NAMES

Resolves #12475

\cc @m-chaturvedi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12476)
<!-- Reviewable:end -->
