### PR TITLE
pydrake mbp: Add bindings for RevoluteSpring

### DIFF
--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -22,6 +22,7 @@
 #include "drake/multibody/tree/multibody_tree_indexes.h"
 #include "drake/multibody/tree/prismatic_joint.h"
 #include "drake/multibody/tree/revolute_joint.h"
+#include "drake/multibody/tree/revolute_spring.h"
 #include "drake/multibody/tree/rigid_body.h"
 #include "drake/multibody/tree/weld_joint.h"
 
@@ -321,7 +322,28 @@ void DoScalarDependentDefinitions(py::module m, T) {
                  const Vector3<double>&, double, double, double>(),
             py::arg("bodyA"), py::arg("p_AP"), py::arg("bodyB"),
             py::arg("p_BQ"), py::arg("free_length"), py::arg("stiffness"),
-            py::arg("damping"), cls_doc.ctor.doc);
+            py::arg("damping"), cls_doc.ctor.doc)
+        .def("bodyA", &Class::bodyA, py_reference_internal, cls_doc.bodyA.doc)
+        .def("bodyB", &Class::bodyB, py_reference_internal, cls_doc.bodyB.doc)
+        .def("p_AP", &Class::p_AP, cls_doc.p_AP.doc)
+        .def("p_BQ", &Class::p_BQ, cls_doc.p_BQ.doc)
+        .def("free_length", &Class::free_length, cls_doc.free_length.doc)
+        .def("stiffness", &Class::stiffness, cls_doc.stiffness.doc)
+        .def("damping", &Class::damping, cls_doc.damping.doc);
+  }
+
+  {
+    using Class = RevoluteSpring<T>;
+    constexpr auto& cls_doc = doc.RevoluteSpring;
+    auto cls = DefineTemplateClassWithDefault<Class, ForceElement<T>>(
+        m, "RevoluteSpring", param, cls_doc.doc);
+    cls  // BR
+        .def(py::init<const RevoluteJoint<T>&, double, double>(),
+            py::arg("joint"), py::arg("nominal_angle"), py::arg("stiffness"),
+            cls_doc.ctor.doc)
+        .def("joint", &Class::joint, py_reference_internal, cls_doc.joint.doc)
+        .def("nominal_angle", &Class::nominal_angle, cls_doc.nominal_angle.doc)
+        .def("stiffness", &Class::stiffness, cls_doc.stiffness.doc);
   }
 
   {


### PR DESCRIPTION
Also adds accessors bindings for LinearSpringDamper

@EricCousineau-TRI for feature review

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12481)
<!-- Reviewable:end -->
