### PR TITLE
Reverts #11560

### DIFF
--- a/bindings/pydrake/manipulation/simple_ui.py
+++ b/bindings/pydrake/manipulation/simple_ui.py
@@ -43,6 +43,8 @@ class JointSliders(VectorSystem):
             resolution:  A scalar or vector of length robot.num_positions()
                          that specifies the discretization of the slider.  Use
                          -1 (the default) to disable any rounding.
+            length:      The length of the sliders (passed as an argument to
+                         tk.Scale).
             update_period_sec: Specifies how often the window update() method
                          gets called.
             window:      Optionally pass in a tkinter.Tk() object to add these
@@ -58,15 +60,6 @@ class JointSliders(VectorSystem):
             x = np.array(x)
             assert len(x.shape) <= 1
             return np.array(x) * np.ones(num)
-
-        def _frame_config(event):
-            """
-            Execute once to configure the canvas size,
-            canvas contains scrollbar and slider_frame.
-            """
-            self.canvas.configure(scrollregion=self.canvas.bbox("all"),
-                                  width=200,
-                                  height=min(robot.num_joints()*60, 400))
 
         lower_limit = _reshape(lower_limit, robot.num_positions())
         upper_limit = _reshape(upper_limit, robot.num_positions())
@@ -87,33 +80,6 @@ class JointSliders(VectorSystem):
         # Schedule window updates in either case (new or existing window):
         self.DeclarePeriodicPublish(update_period_sec, 0.0)
 
-        self.window.geometry("220x410")
-        # Allow only y dimension resizable.
-        self.window.resizable(0, 1)
-
-        # Once window is created, create window_frame
-        # and canvas that host slider_frame and scrollbar.
-        self.window_frame = tk.Frame(self.window, relief=tk.GROOVE, bd=1)
-        self.window_frame.place(x=0, y=0)
-        self.canvas = tk.Canvas(self.window_frame)
-
-        # Init slider_frame that actually contain the sliders
-        # and scrollbar.
-        self.slider_frame = tk.Frame(self.canvas)
-        self.scrollbar = tk.Scrollbar(self.window_frame,
-                                      orient="vertical",
-                                      command=self.canvas.yview)
-        self.canvas.configure(yscrollcommand=self.scrollbar.set)
-
-        # Put scrollbar and slider_frame into canvas.
-        self.scrollbar.pack(side="right", fill="y")
-        self.canvas.pack(side="left")
-        self.canvas.create_window((0, 0),
-                                  window=self.slider_frame,
-                                  anchor='nw')
-        # Call _frame_config to configure canvas size.
-        self.slider_frame.bind("<Configure>", _frame_config)
-
         self._slider = []
         self._slider_position_start = []
         context = robot.CreateDefaultContext()
@@ -127,7 +93,7 @@ class JointSliders(VectorSystem):
             upp = joint.position_upper_limits()
             for j in range(0, joint.num_positions()):
                 self._slider_position_start.append(joint.position_start() + j)
-                self._slider.append(tk.Scale(self.slider_frame,
+                self._slider.append(tk.Scale(self.window,
                                              from_=max(low[j],
                                                        lower_limit[k]),
                                              to=min(upp[j], upper_limit[k]),


### PR DESCRIPTION
Reverts #11560, which had multiple defects (described on that github issue), and which broke the existing uses.

Also adds line of missing documentation (an input argument that was ignored by the changes)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12486)
<!-- Reviewable:end -->
