### PR TITLE
install: Disable drake_bazel_installed test on macOS

### DIFF
--- a/tools/install/bazel/test/drake_bazel_installed_test.py
+++ b/tools/install/bazel/test/drake_bazel_installed_test.py
@@ -3,6 +3,7 @@
 
 from os.path import join
 import subprocess
+import sys
 
 import install_test_helper
 
@@ -48,6 +49,10 @@ FindResourceOrThrow("drake/examples/pendulum/Pendulum.urdf")
 """)
 
     # Check that a full `bazel test` passes.
+    command = "test"
+    if sys.platform.startswith("darwin"):
+        # TODO(jwnimmer-tri) A `test //...` doesn't pass yet on macOS.
+        command = "build"
     subprocess.check_call(cwd=scratch_dir, args=[
         "bazel",
         # Use "release engineering" options for hermeticity.
@@ -56,7 +61,7 @@ FindResourceOrThrow("drake/examples/pendulum/Pendulum.urdf")
         # Encourage the server to exit after the test completes.
         "--max_idle_secs=1",
         # Run all of the tests from the BUILD.bazel generated above.
-        "test", "//...", "--jobs=1",
+        command, "//...", "--jobs=1",
         # Enable verbosity.
         "--announce_rc",
         # Use "release engineering" options for hermeticity.


### PR DESCRIPTION
I tested locally on `macsim` computer that this resolves the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12492)
<!-- Reviewable:end -->
