### PR TITLE
Parse the collision filter group for urdfs

### DIFF
--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -1,13 +1,17 @@
 #include "drake/multibody/parsing/detail_urdf_parser.h"
 
 #include <limits>
+#include <map>
 #include <memory>
+#include <set>
 #include <stdexcept>
 #include <utility>
 
 #include <Eigen/Dense>
+#include <fmt/format.h>
 #include <tinyxml2.h>
 
+#include "drake/common/sorted_pair.h"
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/parsing/detail_path_utils.h"
 #include "drake/multibody/parsing/detail_tinyxml.h"
@@ -143,6 +147,83 @@ void ParseBody(const multibody::PackageMap& package_map,
           geometry_instance.name(),
           std::move(*geometry_instance.mutable_proximity_properties()));
     }
+  }
+}
+
+// Parse the collision filter group tag information into the collision filter
+// groups and a set of pairs between which the collisions will be excluded.
+void RegisterCollisionFilterGroup(
+    const MultibodyPlant<double>& plant, XMLElement* node,
+    std::map<std::string, geometry::GeometrySet>* collision_filter_groups,
+    std::set<SortedPair<std::string>>* collision_filter_pairs) {
+  std::string drake_ignore;
+  if (ParseStringAttribute(node, "ignore", &drake_ignore) &&
+      drake_ignore == std::string("true")) {
+    return;
+  }
+
+  std::string group_name;
+  if (!ParseStringAttribute(node, "name", &group_name)) {
+    throw std::runtime_error("ERROR: group tag is missing name attribute.");
+  }
+
+  geometry::GeometrySet collision_filter_geometry_set;
+  for (XMLElement* member_node = node->FirstChildElement("drake:member");
+       member_node;
+       member_node = member_node->NextSiblingElement("drake:member")) {
+    const char* body_name = member_node->Attribute("link");
+    if (!body_name) {
+      throw std::runtime_error(
+          fmt::format("'{}':'{}':'{}': Collision filter group '{}' provides a "
+                      "member tag without specifying the \"link\" attribute.",
+                      __FILE__, __func__, node->GetLineNum(), group_name));
+    }
+    const auto& body = plant.GetBodyByName(body_name);
+    collision_filter_geometry_set.Add(
+        plant.GetBodyFrameIdOrThrow(body.index()));
+  }
+  collision_filter_groups->insert({group_name, collision_filter_geometry_set});
+
+  for (XMLElement* ignore_node =
+           node->FirstChildElement("drake:ignored_collision_filter_group");
+       ignore_node; ignore_node = ignore_node->NextSiblingElement(
+                        "drake:ignored_collision_filter_group")) {
+    const char* target_name = ignore_node->Attribute("name");
+    if (!target_name) {
+      throw std::runtime_error(fmt::format(
+          "'{}':'{}':'{}': Collision filter group provides a tag specifying a "
+          "group to ignore without specifying the \"name\" attribute.",
+          __FILE__, __func__, node->GetLineNum()));
+    }
+    // These two group names are allowed to be identical, which means the bodies
+    // inside this collision filter group should be collision excluded among
+    // each other.
+    collision_filter_pairs->insert({group_name, target_name});
+  }
+}
+
+void ParseCollisionFilterGroup(XMLElement* node,
+                               MultibodyPlant<double>* plant) {
+  std::map<std::string, geometry::GeometrySet> collision_filter_groups;
+  std::set<SortedPair<std::string>> collision_filter_pairs;
+  for (XMLElement* group_node =
+           node->FirstChildElement("drake:collision_filter_group");
+       group_node; group_node = group_node->NextSiblingElement(
+                       "drake:collision_filter_group")) {
+    RegisterCollisionFilterGroup(*plant, group_node, &collision_filter_groups,
+                                 &collision_filter_pairs);
+  }
+  for (const auto& collision_filter_pair : collision_filter_pairs) {
+    const auto collision_filter_group_a =
+        collision_filter_groups.find(collision_filter_pair.first());
+    DRAKE_DEMAND(collision_filter_group_a != collision_filter_groups.end());
+    const auto collision_filter_group_b =
+        collision_filter_groups.find(collision_filter_pair.second());
+    DRAKE_DEMAND(collision_filter_group_b != collision_filter_groups.end());
+
+    plant->ExcludeCollisionGeometriesWithCollisionFilterGroupPair(
+        {collision_filter_group_a->first, collision_filter_group_a->second},
+        {collision_filter_group_b->first, collision_filter_group_b->second});
   }
 }
 
@@ -464,9 +545,9 @@ ModelInstanceIndex ParseUrdf(
               &materials, plant);
   }
 
-  // TODO(sam.creasey) Parse collision filter groups.
-  if (node->FirstChildElement("collision_filter_group")) {
-    drake::log()->warn("Skipping collision_filter_group elements");
+  // Parses the collision filter groups only if the scene graph is registered.
+  if (plant->geometry_source_is_registered()) {
+    ParseCollisionFilterGroup(node, plant);
   }
 
   // Parses the model's joint elements.

--- a/multibody/parsing/test/detail_urdf_parser_test.cc
+++ b/multibody/parsing/test/detail_urdf_parser_test.cc
@@ -8,6 +8,7 @@
 #include "drake/common/filesystem.h"
 #include "drake/common/find_resource.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/geometry/geometry_roles.h"
 #include "drake/multibody/parsing/detail_path_utils.h"
 
 namespace drake {
@@ -39,7 +40,7 @@ GTEST_TEST(MultibodyPlantUrdfParserTest, PackageMapSpecified) {
 
   // Read in the URDF file.
   AddModelFromUrdfFile(full_urdf_filename, "", package_map, &plant,
-      &scene_graph);
+                       &scene_graph);
   plant.Finalize();
 
   // Verify the number of model instances.
@@ -66,17 +67,16 @@ GTEST_TEST(MultibodyPlantUrdfParserTest, DoublePendulum) {
 
   // Sample a couple of frames.
   const Frame<double>& frame_on_link1 = plant.GetFrameByName("frame_on_link1");
-  EXPECT_EQ(
-      frame_on_link1.body().index(), plant.GetBodyByName("link1").index());
+  EXPECT_EQ(frame_on_link1.body().index(),
+            plant.GetBodyByName("link1").index());
 
   math::RollPitchYaw<double> rpy_expected(-1, 0.1, 0.2);
   Vector3d xyz_expected(0.8, -0.2, 0.3);
-  math::RigidTransform<double> X_BF_expected(
-      rpy_expected.ToRotationMatrix(), xyz_expected);
+  math::RigidTransform<double> X_BF_expected(rpy_expected.ToRotationMatrix(),
+                                             xyz_expected);
 
-  EXPECT_TRUE(CompareMatrices(
-      frame_on_link1.GetFixedPoseInBodyFrame().matrix(),
-      X_BF_expected.GetAsMatrix4(), 1e-10));
+  EXPECT_TRUE(CompareMatrices(frame_on_link1.GetFixedPoseInBodyFrame().matrix(),
+                              X_BF_expected.GetAsMatrix4(), 1e-10));
 
   const Frame<double>& link2_com = plant.GetFrameByName("link2_com");
   EXPECT_EQ(link2_com.body().index(), plant.GetBodyByName("link2").index());
@@ -102,9 +102,9 @@ GTEST_TEST(MultibodyPlantUrdfParserTest, TestAtlasMinimalContact) {
 
 GTEST_TEST(MultibodyPlantUrdfParserTest, TestAddWithQuaternionFloatingDof) {
   const std::string resource_dir{
-    "drake/multibody/parsing/test/urdf_parser_test/"};
-  const std::string model_file = FindResourceOrThrow(
-      resource_dir + "zero_dof_robot.urdf");
+      "drake/multibody/parsing/test/urdf_parser_test/"};
+  const std::string model_file =
+      FindResourceOrThrow(resource_dir + "zero_dof_robot.urdf");
   PackageMap package_map;
   package_map.PopulateUpstreamToDrake(model_file);
 
@@ -156,25 +156,25 @@ GTEST_TEST(MultibodyPlantUrdfParserTest, JointParsingTest) {
   plant.Finalize();
 
   const Joint<double>& revolute_joint = plant.GetJointByName("revolute_joint");
-  EXPECT_TRUE(CompareMatrices(
-      revolute_joint.position_lower_limits(), Vector1d(-1)));
-  EXPECT_TRUE(CompareMatrices(
-      revolute_joint.position_upper_limits(), Vector1d(2)));
-  EXPECT_TRUE(CompareMatrices(
-      revolute_joint.velocity_lower_limits(), Vector1d(-100)));
-  EXPECT_TRUE(CompareMatrices(
-      revolute_joint.velocity_upper_limits(), Vector1d(100)));
+  EXPECT_TRUE(
+      CompareMatrices(revolute_joint.position_lower_limits(), Vector1d(-1)));
+  EXPECT_TRUE(
+      CompareMatrices(revolute_joint.position_upper_limits(), Vector1d(2)));
+  EXPECT_TRUE(
+      CompareMatrices(revolute_joint.velocity_lower_limits(), Vector1d(-100)));
+  EXPECT_TRUE(
+      CompareMatrices(revolute_joint.velocity_upper_limits(), Vector1d(100)));
 
   const Joint<double>& prismatic_joint =
       plant.GetJointByName("prismatic_joint");
-  EXPECT_TRUE(CompareMatrices(
-      prismatic_joint.position_lower_limits(), Vector1d(-2)));
-  EXPECT_TRUE(CompareMatrices(
-      prismatic_joint.position_upper_limits(), Vector1d(1)));
-  EXPECT_TRUE(CompareMatrices(
-      prismatic_joint.velocity_lower_limits(), Vector1d(-5)));
-  EXPECT_TRUE(CompareMatrices(
-      prismatic_joint.velocity_upper_limits(), Vector1d(5)));
+  EXPECT_TRUE(
+      CompareMatrices(prismatic_joint.position_lower_limits(), Vector1d(-2)));
+  EXPECT_TRUE(
+      CompareMatrices(prismatic_joint.position_upper_limits(), Vector1d(1)));
+  EXPECT_TRUE(
+      CompareMatrices(prismatic_joint.velocity_lower_limits(), Vector1d(-5)));
+  EXPECT_TRUE(
+      CompareMatrices(prismatic_joint.velocity_upper_limits(), Vector1d(5)));
 
   const Joint<double>& no_limit_joint =
       plant.GetJointByName("revolute_joint_no_limits");
@@ -185,6 +185,65 @@ GTEST_TEST(MultibodyPlantUrdfParserTest, JointParsingTest) {
   EXPECT_TRUE(CompareMatrices(no_limit_joint.position_upper_limits(), inf));
   EXPECT_TRUE(CompareMatrices(no_limit_joint.velocity_lower_limits(), neg_inf));
   EXPECT_TRUE(CompareMatrices(no_limit_joint.velocity_upper_limits(), inf));
+}
+
+GTEST_TEST(MultibodyPlantUrdfParserTest, CollisionFilterGroupParsingTest) {
+  const std::string full_name = FindResourceOrThrow(
+      "drake/multibody/parsing/test/urdf_parser_test/"
+      "collision_filter_group_parsing_test.urdf");
+  PackageMap package_map;
+  package_map.PopulateUpstreamToDrake(full_name);
+
+  MultibodyPlant<double> plant;
+  SceneGraph<double> scene_graph;
+  AddModelFromUrdfFile(full_name, "", package_map, &plant, &scene_graph);
+
+  // Get geometry ids for all the bodies.
+  const geometry::SceneGraphInspector<double>& inspector =
+      scene_graph.model_inspector();
+  const auto geometry_id_link1 = inspector.GetGeometryIdByName(
+      plant.GetBodyFrameIdOrThrow(plant.GetBodyByName("link1").index()),
+      geometry::Role::kProximity,
+      "collision_filter_group_parsing_test::link1_sphere");
+  const auto geometry_id_link2 = inspector.GetGeometryIdByName(
+      plant.GetBodyFrameIdOrThrow(plant.GetBodyByName("link2").index()),
+      geometry::Role::kProximity,
+      "collision_filter_group_parsing_test::link2_sphere");
+  const auto geometry_id_link3 = inspector.GetGeometryIdByName(
+      plant.GetBodyFrameIdOrThrow(plant.GetBodyByName("link3").index()),
+      geometry::Role::kProximity,
+      "collision_filter_group_parsing_test::link3_sphere");
+  const auto geometry_id_link4 = inspector.GetGeometryIdByName(
+      plant.GetBodyFrameIdOrThrow(plant.GetBodyByName("link4").index()),
+      geometry::Role::kProximity,
+      "collision_filter_group_parsing_test::link4_sphere");
+
+  // Make sure the plant is not finalized such that the adjacent joint filter
+  // has not taken into effect yet. This guarantees that the collision filtering
+  // is applied due to the collision filter group parsing.
+  ASSERT_FALSE(plant.is_finalized());
+
+  // We have four geometries and six possible pairs, each with a particular
+  // disposition.
+  // (1, 2) - unfiltered
+  // (1, 3) - filtered by group_link_3 ignores group_link_14
+  // (1, 4) - filtered by group_link_14 ignores itself
+  // (2, 3) - filtered by group_link_2 ignores group_link_3
+  // (2, 4) - unfiltered (although declared in an *ignored* self-filtering
+  // group_link_24).
+  // (3, 4) - filtered by group_link_3 ignores group_link_14
+  EXPECT_FALSE(
+      inspector.CollisionFiltered(geometry_id_link1, geometry_id_link2));
+  EXPECT_TRUE(
+      inspector.CollisionFiltered(geometry_id_link1, geometry_id_link3));
+  EXPECT_TRUE(
+      inspector.CollisionFiltered(geometry_id_link1, geometry_id_link4));
+  EXPECT_TRUE(
+      inspector.CollisionFiltered(geometry_id_link2, geometry_id_link3));
+  EXPECT_FALSE(
+      inspector.CollisionFiltered(geometry_id_link2, geometry_id_link4));
+  EXPECT_TRUE(
+      inspector.CollisionFiltered(geometry_id_link3, geometry_id_link4));
 }
 
 }  // namespace

--- a/multibody/parsing/test/urdf_parser_test/collision_filter_group_parsing_test.urdf
+++ b/multibody/parsing/test/urdf_parser_test/collision_filter_group_parsing_test.urdf
@@ -1,0 +1,109 @@
+<?xml version="1.0" ?>
+
+<!--
+Defines a URDF model with collision filter groups.
+-->
+
+<robot name="collision_filter_group_parsing_test" xmlns:xacro="http://ros.org/wiki/xacro">
+  <link name="link1">
+    <inertial>
+      <mass value="1"/>
+      <inertia ixx="0.1" ixy="0" ixz="0" iyy="0.1" iyz="0" izz="0.1"/>
+    </inertial>
+    <collision  name='link1_sphere'>
+      <origin rpy="1.57079632679 0 0" xyz="0 0 0" />
+      <geometry>
+        <sphere radius="0.40" />
+      </geometry>
+      <material name="yellow" />
+    </collision>
+  </link>
+
+  <link name="link2">
+    <inertial>
+      <mass value="1"/>
+      <inertia ixx="0.1" ixy="0" ixz="0" iyy="0.1" iyz="0" izz="0.1"/>
+    </inertial>
+    <collision  name='link2_sphere'>
+      <origin rpy="1.57079632679 0 0" xyz="0 0 0" />
+      <geometry>
+        <sphere radius="0.40" />
+      </geometry>
+      <material name="yellow" />
+    </collision>
+  </link>
+
+  <link name="link3">
+    <inertial>
+      <mass value="1"/>
+      <inertia ixx="0.1" ixy="0" ixz="0" iyy="0.1" iyz="0" izz="0.1"/>
+    </inertial>
+    <collision  name='link3_sphere'>
+      <origin rpy="1.57079632679 0 0" xyz="0 0 0" />
+      <geometry>
+        <sphere radius="0.40" />
+      </geometry>
+      <material name="yellow" />
+    </collision>
+  </link>
+
+  <link name="link4">
+    <inertial>
+      <mass value="1"/>
+      <inertia ixx="0.1" ixy="0" ixz="0" iyy="0.1" iyz="0" izz="0.1"/>
+    </inertial>
+    <collision  name='link4_sphere'>
+      <origin rpy="1.57079632679 0 0" xyz="0 0 0" />
+      <geometry>
+        <sphere radius="0.40" />
+      </geometry>
+      <material name="yellow" />
+    </collision>
+  </link>
+
+  <joint name="revolute_joint_12" type="revolute">
+    <axis xyz="0 0 1"/>
+    <parent link="link1"/>
+    <child link="link2"/>
+    <origin rpy="0 0 0" xyz="0 0 0.15"/>
+    <limit effort="100" lower="-1" upper="2" velocity="100"/>
+  </joint>
+
+  <joint name="revolute_joint_23" type="revolute">
+    <axis xyz="0 0 1"/>
+    <parent link="link2"/>
+    <child link="link3"/>
+    <origin rpy="0 0 0" xyz="0 0 0.15"/>
+    <limit effort="100" lower="-1" upper="2" velocity="100"/>
+  </joint>
+
+  <joint name="revolute_joint_34" type="revolute">
+    <axis xyz="0 0 1"/>
+    <parent link="link3"/>
+    <child link="link4"/>
+    <origin rpy="0 0 0" xyz="0 0 0.15"/>
+    <limit effort="100" lower="-1" upper="2" velocity="100"/>
+  </joint>
+
+  <drake:collision_filter_group name="group_link14">
+    <drake:member link="link1" />
+    <drake:member link="link4" />
+    <drake:ignored_collision_filter_group name="group_link14" />
+  </drake:collision_filter_group>
+
+  <drake:collision_filter_group name="group_link2">
+    <drake:member link="link2" />
+    <drake:ignored_collision_filter_group name="group_link3" />
+  </drake:collision_filter_group>
+
+  <drake:collision_filter_group ignore="true" name="group_link24">
+    <drake:member link="link2" />
+    <drake:member link="link4" />
+    <drake:ignored_collision_filter_group name="group_link24" />
+  </drake:collision_filter_group>
+
+  <drake:collision_filter_group name="group_link3">
+    <drake:member link="link3" />
+    <drake:ignored_collision_filter_group name="group_link14" />
+  </drake:collision_filter_group>
+</robot>

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -864,6 +864,24 @@ void MultibodyPlant<T>::ExcludeCollisionsWithVisualGeometry() {
   member_scene_graph().ExcludeCollisionsBetween(visual, collision);
 }
 
+template <typename T>
+void MultibodyPlant<T>::ExcludeCollisionGeometriesWithCollisionFilterGroupPair(
+    const std::pair<std::string, geometry::GeometrySet>&
+        collision_filter_group_a,
+    const std::pair<std::string, geometry::GeometrySet>&
+        collision_filter_group_b) {
+  DRAKE_DEMAND(!is_finalized());
+  DRAKE_DEMAND(geometry_source_is_registered());
+
+  if (collision_filter_group_a.first == collision_filter_group_b.first) {
+    member_scene_graph().ExcludeCollisionsWithin(
+        collision_filter_group_a.second);
+  } else {
+    member_scene_graph().ExcludeCollisionsBetween(
+        collision_filter_group_a.second, collision_filter_group_b.second);
+  }
+}
+
 template<typename T>
 void MultibodyPlant<T>::CalcNormalAndTangentContactJacobians(
     const systems::Context<T>& context,

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -983,6 +983,16 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   const std::vector<geometry::GeometryId>& GetCollisionGeometriesForBody(
       const Body<T>& body) const;
 
+  /// Excludes the collision geometries between two given collision filter
+  /// groups.
+  /// @pre RegisterAsSourceForSceneGraph() has been called.
+  /// @pre Finalize() has *not* been called.
+  void ExcludeCollisionGeometriesWithCollisionFilterGroupPair(
+      const std::pair<std::string, geometry::GeometrySet>&
+          collision_filter_group_a,
+      const std::pair<std::string, geometry::GeometrySet>&
+          collision_filter_group_b);
+
   /// For each of the provided `bodies`, collects up all geometries that have
   /// been registered to that body. Intended to be used in conjunction with
   /// SceneGraph::ExcludeCollisionsWithin() and


### PR DESCRIPTION
This is a verbatim translation of the original RBT parsing functionality mapped into the new MBP/SG collision filtering API, but preserving the semantics of the filter group declarations found in URDF.

resolves #11087

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12495)
<!-- Reviewable:end -->
