### PR TITLE
Correct SymbolicVectorSystem "container" population

### DIFF
--- a/systems/primitives/symbolic_vector_system.cc
+++ b/systems/primitives/symbolic_vector_system.cc
@@ -98,6 +98,8 @@ SymbolicVectorSystem<T>::SymbolicVectorSystem(
       parameter_vars_(parameter),
       dynamics_(dynamics),
       output_(output),
+      dynamics_needs_inputs_(DependsOnInputs(dynamics)),
+      output_needs_inputs_(DependsOnInputs(output_)),
       time_period_(time_period) {  // Must have dynamics and/or output.
   DRAKE_DEMAND(dynamics_.rows() > 0 || output_.rows() > 0);
   DRAKE_DEMAND(time_period_ >= 0.0);
@@ -159,8 +161,25 @@ SymbolicVectorSystem<T>::SymbolicVectorSystem(
 }
 
 template <typename T>
+bool SymbolicVectorSystem<T>::DependsOnInputs(
+    const VectorX<Expression>& expr) const {
+  Variables needed_variables;
+  for (int j = 0; j < expr.size(); ++j) {
+    needed_variables.insert(expr(j).GetVariables());
+  }
+
+  for (int i = 0; i < input_vars_.size(); i++) {
+    if (needed_variables.include(input_vars_[i])) {
+      return true;
+    }
+  }
+  return false;
+}
+
+template <typename T>
 template <typename Container>
 void SymbolicVectorSystem<T>::PopulateFromContext(const Context<T>& context,
+                                                  bool needs_inputs,
                                                   Container* penv) const {
   Container& env = *penv;
   if (time_var_) {
@@ -174,7 +193,11 @@ void SymbolicVectorSystem<T>::PopulateFromContext(const Context<T>& context,
       env[state_vars_[i]] = state[i];
     }
   }
-  if (input_vars_.size() > 0) {
+  // Note: Invocations only require pre-analysis on the *input* dependency (as
+  // opposed to state, time, etc) because all other values come directly from
+  // the Context (and not from input ports whose *unnecessary* evaluation can
+  // lead to spurious algebraic loops).
+  if (input_vars_.size() > 0 && needs_inputs) {
     const auto& input = get_input_port().Eval(context);
     for (int i = 0; i < input_vars_.size(); i++) {
       env[input_vars_[i]] = input[i];
@@ -195,10 +218,10 @@ template <>
 void SymbolicVectorSystem<double>::EvaluateWithContext(
     const Context<double>& context, const VectorX<Expression>& expr,
     const MatrixX<symbolic::Expression>& jacobian,
-    VectorBase<double>* out) const {
+    bool needs_inputs, VectorBase<double>* out) const {
   unused(jacobian);
   Environment env = env_;
-  PopulateFromContext(context, &env);
+  PopulateFromContext(context, needs_inputs, &env);
   for (int i = 0; i < out->size(); i++) {
     out->SetAtIndex(i, expr[i].Evaluate(env));
   }
@@ -208,7 +231,7 @@ template <>
 void SymbolicVectorSystem<AutoDiffXd>::EvaluateWithContext(
     const Context<AutoDiffXd>& context, const VectorX<Expression>& expr,
     const MatrixX<symbolic::Expression>& jacobian,
-    VectorBase<AutoDiffXd>* pout) const {
+    bool needs_inputs, VectorBase<AutoDiffXd>* pout) const {
   VectorBase<AutoDiffXd>& out = *pout;
 
   const BasicVector<AutoDiffXd> empty(0);
@@ -218,8 +241,13 @@ void SymbolicVectorSystem<AutoDiffXd>::EvaluateWithContext(
           ? ((time_period_ > 0.0) ? context.get_discrete_state_vector()
                                   : context.get_continuous_state_vector())
           : empty;
+  // It is very important we don't evaluate the inputs if the expression doesn't
+  // actually depend on it (as declared by the needs_inputs parameter). This
+  // avoids introducing spurious algebraic loops. In this case, `needs_inputs`
+  // is sufficient to know that there are input variables; we don't need to
+  // test the size of input_vars_.
   const BasicVector<AutoDiffXd>& input =
-      (input_vars_.size() > 0)
+      needs_inputs
           ? get_input_port().Eval<BasicVector<AutoDiffXd>>(context)
           : empty;
 
@@ -235,7 +263,7 @@ void SymbolicVectorSystem<AutoDiffXd>::EvaluateWithContext(
     num_gradients = std::max(num_gradients,
                              static_cast<int>(state[0].derivatives().size()));
   }
-  if (input_vars_.size() > 0) {
+  if (needs_inputs) {
     num_gradients = std::max(num_gradients,
                              static_cast<int>(input[0].derivatives().size()));
   }
@@ -255,9 +283,22 @@ void SymbolicVectorSystem<AutoDiffXd>::EvaluateWithContext(
     env[state_vars_[i]] = state[i].value();
     dvars.row(dvars_row_idx++) = state[i].derivatives();
   }
-  for (int i = 0; i < input_vars_.size(); i++) {
-    env[input_vars_[i]] = input[i].value();
-    dvars.row(dvars_row_idx++) = input[i].derivatives();
+  if (needs_inputs) {
+    // NOTE: The only way needs_inputs can be true is there *are* input
+    // variables.
+    for (int i = 0; i < input_vars_.size(); i++) {
+      env[input_vars_[i]] = input[i].value();
+      dvars.row(dvars_row_idx++) = input[i].derivatives();
+    }
+  } else if (input_vars_.size() > 0) {
+    // If we don't depend on inputs, we haven't evaluated the ports. However, by
+    // definition the value and derivatives must all be zero. So, we'll simply
+    // shove those values in explicitly.
+    auto kZeros = Eigen::VectorXd::Zero(num_gradients);
+    for (int i = 0; i < input_vars_.size(); i++) {
+      env[input_vars_[i]] = 0.0;
+      dvars.row(dvars_row_idx++) = kZeros;
+    }
   }
   for (int i = 0; i < parameter_vars_.size(); i++) {
     env[parameter_vars_[i]] = parameter[i].value();
@@ -280,10 +321,10 @@ template <>
 void SymbolicVectorSystem<Expression>::EvaluateWithContext(
     const Context<Expression>& context, const VectorX<Expression>& expr,
     const MatrixX<symbolic::Expression>& jacobian,
-    VectorBase<Expression>* out) const {
+    bool needs_inputs, VectorBase<Expression>* out) const {
   unused(jacobian);
-  symbolic::Substitution s;
-  PopulateFromContext(context, &s);
+  Substitution s;
+  PopulateFromContext(context, needs_inputs, &s);
   for (int i = 0; i < out->size(); i++) {
     out->SetAtIndex(i, expr[i].Substitute(s));
   }
@@ -293,7 +334,8 @@ template <typename T>
 void SymbolicVectorSystem<T>::CalcOutput(const Context<T>& context,
                                          BasicVector<T>* output_vector) const {
   DRAKE_DEMAND(output_.size() > 0);
-  EvaluateWithContext(context, output_, output_jacobian_, output_vector);
+  EvaluateWithContext(context, output_, output_jacobian_, output_needs_inputs_,
+                      output_vector);
 }
 
 template <typename T>
@@ -302,6 +344,7 @@ void SymbolicVectorSystem<T>::DoCalcTimeDerivatives(
   DRAKE_DEMAND(time_period_ == 0.0);
   DRAKE_DEMAND(dynamics_.size() > 0);
   EvaluateWithContext(context, dynamics_, dynamics_jacobian_,
+                      dynamics_needs_inputs_,
                       &derivatives->get_mutable_vector());
 }
 
@@ -314,7 +357,7 @@ void SymbolicVectorSystem<T>::DoCalcDiscreteVariableUpdates(
   DRAKE_DEMAND(time_period_ > 0.0);
   DRAKE_DEMAND(dynamics_.size() > 0);
   EvaluateWithContext(context, dynamics_, dynamics_jacobian_,
-                      &updates->get_mutable_vector());
+                      dynamics_needs_inputs_, &updates->get_mutable_vector());
 }
 
 }  // namespace systems

--- a/systems/primitives/symbolic_vector_system.h
+++ b/systems/primitives/symbolic_vector_system.h
@@ -180,14 +180,18 @@ class SymbolicVectorSystem final : public LeafSystem<T> {
   /// @}
 
  private:
+  // Reports if the given expression contains an input variable.
+  bool DependsOnInputs(const VectorX<symbolic::Expression>& expr) const;
+
   template <typename Container>
-  void PopulateFromContext(const Context<T>& context, Container* penv) const;
+  void PopulateFromContext(const Context<T>& context, bool needs_inputs,
+                           Container* penv) const;
 
   // Evaluate context to a vector.
   void EvaluateWithContext(const Context<T>& context,
                            const VectorX<symbolic::Expression>& expr,
                            const MatrixX<symbolic::Expression>& jacobian,
-                           VectorBase<T>* out) const;
+                           bool needs_inputs, VectorBase<T>* out) const;
 
   void CalcOutput(const Context<T>& context,
                   BasicVector<T>* output_vector) const;
@@ -206,6 +210,8 @@ class SymbolicVectorSystem final : public LeafSystem<T> {
   const VectorX<symbolic::Variable> parameter_vars_{};
   const VectorX<symbolic::Expression> dynamics_{};
   const VectorX<symbolic::Expression> output_{};
+  const bool dynamics_needs_inputs_;
+  const bool output_needs_inputs_;
 
   symbolic::Environment env_{};
   const double time_period_{0.0};
@@ -425,21 +431,21 @@ class SymbolicVectorSystemBuilder {
 template <>
 void SymbolicVectorSystem<double>::EvaluateWithContext(
     const Context<double>& context, const VectorX<symbolic::Expression>& expr,
-    const MatrixX<symbolic::Expression>& jacobian,
+    const MatrixX<symbolic::Expression>& jacobian, bool needs_inputs,
     VectorBase<double>* out) const;
 
 template <>
 void SymbolicVectorSystem<AutoDiffXd>::EvaluateWithContext(
     const Context<AutoDiffXd>& context,
     const VectorX<symbolic::Expression>& expr,
-    const MatrixX<symbolic::Expression>& jacobian,
+    const MatrixX<symbolic::Expression>& jacobian, bool needs_inputs,
     VectorBase<AutoDiffXd>* out) const;
 
 template <>
 void SymbolicVectorSystem<symbolic::Expression>::EvaluateWithContext(
     const Context<symbolic::Expression>& context,
     const VectorX<symbolic::Expression>& expr,
-    const MatrixX<symbolic::Expression>& jacobian,
+    const MatrixX<symbolic::Expression>& jacobian, bool needs_inputs,
     VectorBase<symbolic::Expression>* out) const;
 #endif
 


### PR DESCRIPTION
When evaluating various expressions (output, dynamics, or discrete updates), SymbolicVectorSystem builds an Environment or Substitution in order to map inputs to results.

The original implementation would conservatively attempt to populate the container with every defined variable, even if the expression being evaluated didn't need it.

This meant if there were *any* input variables, the input port would be evaluated. In small plant-controller loops, this quickly leads to spurious algebraic loops as input invokes output and vice versa forever.

This changes the population algorithm to be more targeted vis a vis the target expression. Specifically, it targets the evaluation of the input port -- all other values are read directly from the context and are immune to this kind of infinite loop problem.

NOTE: This issue arose here: https://stackoverflow.com/questions/59380475/segfault-when-simulating-control-loop-with-second-order-system/59394935#59394935

resolves #12497

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12500)
<!-- Reviewable:end -->
