### PR TITLE
Add planar iiwa urdf and use it in ManipulationStation

### DIFF
--- a/examples/manipulation_station/BUILD.bazel
+++ b/examples/manipulation_station/BUILD.bazel
@@ -27,6 +27,7 @@ drake_cc_library(
     ],
     data = [
         ":models",
+        "//examples/kuka_iiwa_arm:models",
         "//manipulation/models/iiwa_description:models",
         "//manipulation/models/wsg_50_description:models",
         "//manipulation/models/ycb:models",

--- a/examples/manipulation_station/manipulation_station.h
+++ b/examples/manipulation_station/manipulation_station.h
@@ -21,7 +21,7 @@ namespace manipulation_station {
 enum class IiwaCollisionModel { kNoCollision, kBoxCollision };
 
 /// Determines which manipulation station is simulated.
-enum class Setup { kNone, kManipulationClass, kClutterClearing };
+enum class Setup { kNone, kManipulationClass, kClutterClearing, kPlanarIiwa };
 
 /// @defgroup manipulation_station_systems Manipulation Station
 /// @{
@@ -159,6 +159,16 @@ class ManipulationStation : public systems::Diagram<T> {
   /// @param collision_model Determines which sdf is loaded for the IIWA.
   void SetupManipulationClassStation(
       IiwaCollisionModel collision_model = IiwaCollisionModel::kNoCollision);
+
+  /// Adds a version of the iiwa with joints that would result in
+  /// out-of-plane rotations welded in a fixed orientation, reducing the
+  /// total degrees of freedom of the arm to 3.  This arm lives in the X-Z
+  /// plane.  Also adds the WSG planar gripper and two tables to form the
+  /// workspace.  Note that additional floating base objects (aka
+  /// manipulands) will still potentially move in 3D.
+  /// @note Must be called before Finalize().
+  /// @note Only one of the `Setup___()` methods should be called.
+  void SetupPlanarIiwaStation();
 
   /// Sets the default State for the chosen setup.
   /// @param context A const reference to the ManipulationStation context.
@@ -315,7 +325,9 @@ class ManipulationStation : public systems::Diagram<T> {
 
   /// Get the number of joints in the IIWA (only -- does not include the
   /// gripper).
-  int num_iiwa_joints() const { return 7; }
+  /// @pre must call one of the "setup" methods first to register an IIWA
+  /// model.
+  int num_iiwa_joints() const;
 
   /// Convenience method for getting all of the joint angles of the Kuka IIWA.
   /// This does not include the gripper.

--- a/examples/manipulation_station/proof_of_life.cc
+++ b/examples/manipulation_station/proof_of_life.cc
@@ -53,6 +53,12 @@ int do_main(int argc, char* argv[]) {
         "drake/examples/manipulation_station/models/061_foam_brick.sdf",
         RigidTransform<double>(RotationMatrix<double>::Identity(),
                                Eigen::Vector3d(0.6, 0, 0)));
+  } else if (FLAGS_setup == "planar") {
+    station->SetupPlanarIiwaStation();
+    station->AddManipulandFromFile(
+        "drake/examples/manipulation_station/models/061_foam_brick.sdf",
+        RigidTransform<double>(RotationMatrix<double>::Identity(),
+                               Eigen::Vector3d(0.6, 0, 0)));
   } else {
     throw std::domain_error(
         "Unrecognized setup option. Options are "

--- a/examples/manipulation_station/test/manipulation_station_test.cc
+++ b/examples/manipulation_station/test/manipulation_station_test.cc
@@ -291,6 +291,20 @@ GTEST_TEST(ManipulationStationTest, SetupClutterClearingStation) {
   station.SetRandomContext(context.get(), &generator);
 }
 
+GTEST_TEST(ManipulationStationTest, SetupPlanarIiwaStation) {
+  ManipulationStation<double> station(0.002);
+  station.SetupPlanarIiwaStation();
+  station.Finalize();
+
+  // Make sure we get through the setup and initialization.
+  auto context = station.CreateDefaultContext();
+
+  // Check that domain randomization works.
+  RandomGenerator generator;
+  station.SetRandomContext(context.get(), &generator);
+}
+
+
 // Check that making many stations does not exhaust resources.
 GTEST_TEST(ManipulationStationTest, MultipleInstanceTest) {
   for (int i = 0; i < 20; ++i) {

--- a/manipulation/models/iiwa_description/urdf/planar_iiwa14_spheres_dense_elbow_collision.urdf
+++ b/manipulation/models/iiwa_description/urdf/planar_iiwa14_spheres_dense_elbow_collision.urdf
@@ -1,0 +1,522 @@
+<?xml version="1.0" ?>
+<!-- ===================================================================== -->
+<!-- |    This model is a hand edited version of the original model (see | -->
+<!-- |    iiwa14_spheres_dense_elbow_collision.urdf). Joint 1 has been   | -->
+<!-- |    welded at 0 degrees, joints 3 and 5 have been welded at 0      | -->
+<!-- |    degrees, and joint 7 has been welded at -90 degrees.           | -->
+<!-- |    Portions of the model rendered irrelevant by these changes     | -->
+<!-- |    (e.g. transmissions for the newly welded joints) have been     | -->
+<!-- |    removed.                                                       | -->
+<!-- ===================================================================== -->
+<robot name="iiwa14" xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <!-- Import Rviz colors -->
+  <material name="Black">
+    <color rgba="0.0 0.0 0.0 1.0"/>
+  </material>
+  <material name="Grey">
+    <color rgba="0.4 0.4 0.4 1.0"/>
+  </material>
+  <material name="Silver">
+    <color rgba="0.6 0.6 0.6 1.0"/>
+  </material>
+  <material name="Orange">
+    <color rgba="1.0 0.423529411765 0.0392156862745 1.0"/>
+  </material>
+  <!-- Defines a base link that will serve as the model's root. -->
+  <link name="iiwa_link_0">
+    <inertial>
+      <origin rpy="0 0 0" xyz="-0.1 0 0.07"/>
+      <mass value="5"/>
+      <inertia ixx="0.05" ixy="0" ixz="0" iyy="0.06" iyz="0" izz="0.03"/>
+    </inertial>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iiwa_description/meshes/visual/link_0.obj"/>
+      </geometry>
+      <material name="Grey"/>
+    </visual>
+    <collision>
+      <origin rpy="0 0 0" xyz="-0.015 0 0.07"/>
+      <geometry>
+        <cylinder length="0.17" radius="0.139"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <self_collision_checking>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <capsule length="0.25" radius="0.15"/>
+      </geometry>
+    </self_collision_checking>
+  </link>
+  <!-- joint between link_0 and link_1 -->
+  <joint name="iiwa_joint_1" type="fixed">
+    <parent link="iiwa_link_0"/>
+    <child link="iiwa_link_1"/>
+    <origin rpy="0 0 0" xyz="0 0 0.1575"/>
+  </joint>
+  <link name="iiwa_link_1">
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 -0.03 0.12"/>
+      <mass value="5.76"/>
+      <inertia ixx="0.033" ixy="0" ixz="0" iyy="0.0333" iyz="0" izz="0.0123"/>
+    </inertial>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iiwa_description/meshes/visual/link_1.obj"/>
+      </geometry>
+      <material name="Grey"/>
+    </visual>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 -0.03344534434 0.1974815417"/>
+      <geometry>
+        <sphere radius="0.07959901601"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+  </link>
+  <!-- joint between link_1 and link_2 -->
+  <joint name="iiwa_joint_2" type="revolute">
+    <parent link="iiwa_link_1"/>
+    <child link="iiwa_link_2"/>
+    <origin rpy="1.570796326794897   0 3.141592653589793" xyz="0 0 0.2025"/>
+    <axis xyz="0 0 1"/>
+    <limit effort="300" lower="-2.09439510239" upper="2.09439510239" velocity="10"/>
+    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
+    <dynamics damping="0.5"/>
+  </joint>
+  <link name="iiwa_link_2">
+    <inertial>
+      <origin rpy="0 0 0" xyz="0.0003 0.059 0.042"/>
+      <mass value="6.35"/>
+      <!-- 3.95 kuka CAD value-->
+      <!--4 Original Drake URDF value-->
+      <inertia ixx="0.0305" ixy="0" ixz="0" iyy="0.0304" iyz="0" izz="0.011"/>
+    </inertial>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iiwa_description/meshes/visual/link_2_orange.obj"/>
+      </geometry>
+      <material name="Orange"/>
+    </visual>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iiwa_description/meshes/visual/link_2_grey.obj"/>
+      </geometry>
+      <material name="Grey"/>
+    </visual>
+    <collision>
+      <origin rpy="0 0 0" xyz="-2.488800594e-017 0.203225991 -0.002065464272"/>
+      <geometry>
+        <sphere radius="0.06602481863"/>
+      </geometry>
+      <material name="Orange"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="3.940519658e-019 -0.003217678485 0.05239182903"/>
+      <geometry>
+        <sphere radius="0.07959901601"/>
+      </geometry>
+      <material name="Orange"/>
+    </collision>
+  </link>
+  <!-- joint between link_2 and link_3 -->
+  <joint name="iiwa_joint_3" type="fixed">
+    <parent link="iiwa_link_2"/>
+    <child link="iiwa_link_3"/>
+    <origin rpy="1.570796326794897 0 3.141592653589793" xyz="0 0.2045 0"/>
+  </joint>
+  <link name="iiwa_link_3">
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0.03 0.13"/>
+      <mass value="3.5"/>
+      <!--3.18 kuka CAD value-->
+      <!--3 Original Drake URDF value-->
+      <inertia ixx="0.025" ixy="0" ixz="0" iyy="0.0238" iyz="0" izz="0.0076"/>
+    </inertial>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iiwa_description/meshes/visual/link_3.obj"/>
+      </geometry>
+      <material name="Grey"/>
+    </visual>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iiwa_description/meshes/visual/band.obj"/>
+      </geometry>
+      <material name="Silver"/>
+    </visual>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iiwa_description/meshes/visual/kuka.obj"/>
+      </geometry>
+      <material name="Black"/>
+    </visual>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0.0355"/>
+      <geometry>
+        <sphere radius="0.075"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0.01 0.023 0.0855"/>
+      <geometry>
+        <sphere radius="0.06"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0.01 0.048 0.1255"/>
+      <geometry>
+        <sphere radius="0.055"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0.01 0.056 0.1755"/>
+      <geometry>
+        <sphere radius="0.06"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="-0.01 0.023 0.0855"/>
+      <geometry>
+        <sphere radius="0.06"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="-0.01 0.048 0.1255"/>
+      <geometry>
+        <sphere radius="0.055"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="-0.01 0.056 0.1755"/>
+      <geometry>
+        <sphere radius="0.06"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0.045 0.2155"/>
+      <geometry>
+        <sphere radius="0.075"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0.2155"/>
+      <geometry>
+        <sphere radius="0.075"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+  </link>
+  <!-- joint between link_3 and link_4 -->
+  <joint name="iiwa_joint_4" type="revolute">
+    <parent link="iiwa_link_3"/>
+    <child link="iiwa_link_4"/>
+    <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
+    <axis xyz="0 0 1"/>
+    <limit effort="300" lower="-2.09439510239" upper="2.09439510239" velocity="10"/>
+    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
+    <dynamics damping="0.5"/>
+  </joint>
+  <link name="iiwa_link_4">
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0.067 0.034"/>
+      <mass value="3.5"/>
+      <!--2.74 kuka CAD value-->
+      <!--2.7 Original Drake URDF value-->
+      <inertia ixx="0.017" ixy="0" ixz="0" iyy="0.0164" iyz="0" izz="0.006"/>
+    </inertial>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iiwa_description/meshes/visual/link_4_orange.obj"/>
+      </geometry>
+      <material name="Orange"/>
+    </visual>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iiwa_description/meshes/visual/link_4_grey.obj"/>
+      </geometry>
+      <material name="Grey"/>
+    </visual>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0.01 0.046"/>
+      <geometry>
+        <sphere radius="0.078"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0.01 0.06 0.052"/>
+      <geometry>
+        <sphere radius="0.06"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0.01 0.12 0.034"/>
+      <geometry>
+        <sphere radius="0.065"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="-0.01 0.06 0.052"/>
+      <geometry>
+        <sphere radius="0.06"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="-0.01 0.12 0.034"/>
+      <geometry>
+        <sphere radius="0.065"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0.184 0"/>
+      <geometry>
+        <sphere radius="0.075"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+  </link>
+  <!-- joint between link_4 and link_5 -->
+  <joint name="iiwa_joint_5" type="fixed">
+    <parent link="iiwa_link_4"/>
+    <child link="iiwa_link_5"/>
+    <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.1845 0"/>
+  </joint>
+  <link name="iiwa_link_5">
+    <inertial>
+      <origin rpy="0 0 0" xyz="0.0001 0.021 0.076"/>
+      <mass value="3.5"/>
+      <!--1.69 kuka CAD value-->
+      <!--1.7 Original Drake URDF value-->
+      <inertia ixx="0.01" ixy="0" ixz="0" iyy="0.0087" iyz="0" izz="0.00449"/>
+    </inertial>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iiwa_description/meshes/visual/link_5.obj"/>
+      </geometry>
+      <material name="Grey"/>
+    </visual>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iiwa_description/meshes/visual/band.obj"/>
+      </geometry>
+      <material name="Silver"/>
+    </visual>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iiwa_description/meshes/visual/kuka.obj"/>
+      </geometry>
+      <material name="Black"/>
+    </visual>
+  </link>
+  <!-- joint between link_5 and link_6 -->
+  <joint name="iiwa_joint_6" type="revolute">
+    <parent link="iiwa_link_5"/>
+    <child link="iiwa_link_6"/>
+    <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
+    <axis xyz="0 0 1"/>
+    <limit effort="300" lower="-2.09439510239" upper="2.09439510239" velocity="10"/>
+    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
+    <dynamics damping="0.5"/>
+  </joint>
+  <link name="iiwa_link_6">
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0.0006 0.0004"/>
+      <mass value="1.8"/>
+      <!--1.8 kuka CAD value-->
+      <!--1.8 Original Drake URDF value-->
+      <inertia ixx="0.0049" ixy="0" ixz="0" iyy="0.0047" iyz="0" izz="0.0036"/>
+    </inertial>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iiwa_description/meshes/visual/link_6_orange.obj"/>
+      </geometry>
+      <material name="Orange"/>
+    </visual>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iiwa_description/meshes/visual/link_6_grey.obj"/>
+      </geometry>
+      <material name="Grey"/>
+    </visual>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 -0.059"/>
+      <geometry>
+        <sphere radius="0.055"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0.0 0"/>
+      <geometry>
+        <sphere radius="0.08"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+  </link>
+  <!-- joint between link_6 and link_7 -->
+  <joint name="iiwa_joint_7" type="fixed">
+    <parent link="iiwa_link_6"/>
+    <child link="iiwa_link_7"/>
+    <origin rpy="-1.570796326794897 -1.57079632679 0" xyz="0 0.081 0"/>
+  </joint>
+  <link name="iiwa_link_7">
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0 0.02"/>
+      <mass value="1.2"/>
+      <!--0.31 kuka CAD value-->
+      <!--0.3 Original Drake URDF value-->
+      <inertia ixx="0.001" ixy="0" ixz="0" iyy="0.001" iyz="0" izz="0.001"/>
+    </inertial>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iiwa_description/meshes/visual/link_7.obj"/>
+      </geometry>
+      <material name="Grey"/>
+    </visual>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0.001"/>
+      <geometry>
+        <sphere radius="0.06"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+  </link>
+  <joint name="iiwa_joint_ee" type="fixed">
+    <parent link="iiwa_link_7"/>
+    <child link="iiwa_link_ee_kuka"/>
+    <origin rpy="3.141592653589793 3.141592653589793 3.141592653589793" xyz="0 0 0.045"/>
+    <axis xyz="0 0 1"/>
+  </joint>
+  <link name="iiwa_link_ee_kuka">
+    </link>
+  <joint name="tool0_joint" type="fixed">
+    <parent link="iiwa_link_7"/>
+    <child link="iiwa_link_ee"/>
+    <origin rpy="0 -1.570796326794897 0" xyz="0 0 0.045"/>
+  </joint>
+  <link name="iiwa_link_ee">
+    </link>
+  <frame link="iiwa_link_ee" name="iiwa_frame_ee" rpy="3.141592653589793 0 1.570796326794897" xyz="0.09 0 0"/>
+  <!-- Load Gazebo lib and set the robot namespace -->
+  <gazebo>
+    <plugin filename="libgazebo_ros_control.so" name="gazebo_ros_controller">
+      <robotNamespace>/iiwa</robotNamespace>
+    </plugin>
+  </gazebo>
+  <!-- Link0 -->
+  <gazebo reference="iiwa_link_0">
+    <material>Gazebo/Grey</material>
+    <mu1>0.2</mu1>
+    <mu2>0.2</mu2>
+  </gazebo>
+  <!-- Link1 -->
+  <gazebo reference="iiwa_link_1">
+    <material>Gazebo/Orange</material>
+    <mu1>0.2</mu1>
+    <mu2>0.2</mu2>
+  </gazebo>
+  <!-- Link2 -->
+  <gazebo reference="iiwa_link_2">
+    <material>Gazebo/Orange</material>
+    <mu1>0.2</mu1>
+    <mu2>0.2</mu2>
+  </gazebo>
+  <!-- Link3 -->
+  <gazebo reference="iiwa_link_3">
+    <material>Gazebo/Orange</material>
+    <mu1>0.2</mu1>
+    <mu2>0.2</mu2>
+  </gazebo>
+  <!-- Link4 -->
+  <gazebo reference="iiwa_link_4">
+    <material>Gazebo/Orange</material>
+    <mu1>0.2</mu1>
+    <mu2>0.2</mu2>
+  </gazebo>
+  <!-- Link5 -->
+  <gazebo reference="iiwa_link_5">
+    <material>Gazebo/Orange</material>
+    <mu1>0.2</mu1>
+    <mu2>0.2</mu2>
+  </gazebo>
+  <!-- Link6 -->
+  <gazebo reference="iiwa_link_6">
+    <material>Gazebo/Orange</material>
+    <mu1>0.2</mu1>
+    <mu2>0.2</mu2>
+  </gazebo>
+  <!-- Link7 -->
+  <gazebo reference="iiwa_link_7">
+    <material>Gazebo/Grey</material>
+    <mu1>0.2</mu1>
+    <mu2>0.2</mu2>
+  </gazebo>
+  <transmission name="iiwa_tran_2">
+    <robotNamespace>/iiwa</robotNamespace>
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="iiwa_joint_2">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="iiwa_motor_2">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <mechanicalReduction>1</mechanicalReduction>
+    </actuator>
+  </transmission>
+  <transmission name="iiwa_tran_4">
+    <robotNamespace>/iiwa</robotNamespace>
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="iiwa_joint_4">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="iiwa_motor_4">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <mechanicalReduction>1</mechanicalReduction>
+    </actuator>
+  </transmission>
+  <transmission name="iiwa_tran_6">
+    <robotNamespace>/iiwa</robotNamespace>
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="iiwa_joint_6">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="iiwa_motor_6">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <mechanicalReduction>1</mechanicalReduction>
+    </actuator>
+  </transmission>
+  <collision_filter_group name="wrist">
+    <member link="iiwa_link_5"/>
+    <member link="iiwa_link_6"/>
+    <member link="iiwa_link_7"/>
+    <ignored_collision_filter_group collision_filter_group="wrist"/>
+  </collision_filter_group>
+</robot>


### PR DESCRIPTION
Includes generalizing the num_iiwa_joints method and a proof of life example.

This is the first of a series of PRs that will add the other examples (e.g. python teleop interfaces) for the planar IIWA also.  I'm just trying to break it up to make it consumable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12502)
<!-- Reviewable:end -->
