### PR TITLE
Drake Lcm comment/documentation cleanups

### DIFF
--- a/lcm/drake_lcm.cc
+++ b/lcm/drake_lcm.cc
@@ -96,6 +96,7 @@ class DrakeSubscription final : public DrakeSubscriptionInterface {
     result->user_callback_ = std::move(handler);
     result->weak_self_reference_ = result;
     result->strong_self_reference_ = result;
+    // TODO(#12523) This should escape `channel` against regex parsing.
     result->native_subscription_ = native_instance->subscribeFunction(
       channel, &DrakeSubscription::NativeCallback, result.get());
     result->native_subscription_->setQueueCapacity(1);

--- a/lcm/drake_lcm_interface.h
+++ b/lcm/drake_lcm_interface.h
@@ -69,6 +69,12 @@ class DrakeLcmInterface {
    * Subscribes to an LCM channel without automatic message decoding. The
    * handler will be invoked when a message arrives on channel @p channel.
    *
+   * NOTE: Unlike upstream LCM, DrakeLcm does not support regexes for the
+   * `channel` argument.
+   * TODO(#12523) Some implementations may provide this capability, but users
+   * should not rely on this functionality which will be removed in the
+   * future.
+   *
    * @param channel The channel to subscribe to.
    * Must not be the empty string.
    *

--- a/lcm/drake_mock_lcm.h
+++ b/lcm/drake_mock_lcm.h
@@ -21,11 +21,6 @@ class DrakeMockLcm : public DrakeLcmInterface {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DrakeMockLcm);
 
-  /**
-   * A constructor that creates a DrakeMockLcm with loopback disabled, i.e., a
-   * call to Publish() will not result in subscriber callback functions being
-   * executed. To enable loopback behavior, call EnableLoopBack().
-   */
   DrakeMockLcm();
 
   void Publish(const std::string&, const void*, int,


### PR DESCRIPTION
* The constructor comment describes an interface that was deprecated
  and removed months ago; remove it as the ctor behaviour is trivial.
* The lack of regex support was not noted; note it now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12521)
<!-- Reviewable:end -->
