### PR TITLE
Scalar conversion bug

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -550,4 +550,11 @@ drake_cc_googletest(
     ],
 )
 
+drake_cc_googletest(
+    name = "multibody_plant_scalar_conversion_test",
+    deps = [
+        ":plant",
+    ],
+)
+
 add_lint_tests()

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3018,6 +3018,30 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     return internal_tree().num_force_elements();
   }
 
+  /// Returns a constant reference to the force element with unique index
+  /// `force_element_index`.
+  /// @throws std::runtime_error when `force_element_index` does not correspond
+  /// to a force element in this model.
+  const ForceElement<T>& get_force_element(
+      ForceElementIndex force_element_index) const {
+    return internal_tree().get_force_element(force_element_index);
+  }
+
+  /// Returns a constant reference to a force element identified by its unique
+  /// index in `this` %MultibodyPlant.  If the optional template argument is
+  /// supplied, then the returned value is downcast to the specified
+  /// `ForceElementType`.
+  /// @tparam ForceElementType The specific type of the ForceElement to be
+  /// retrieved. It must be a subclass of ForceElement.
+  /// @throws std::logic_error if the force element is not of type
+  /// `ForceElementType` or if there is no ForceElement with that index.
+  template <template <typename> class ForceElementType = ForceElement>
+  const ForceElementType<T>& GetForceElement(
+      ForceElementIndex force_element_index) const {
+    return internal_tree().template GetForceElement<ForceElementType>(
+        force_element_index);
+  }
+
   /// An accessor to the current gravity field.
   const UniformGravityFieldElement<T>& gravity_field() const {
     return internal_tree().gravity_field();

--- a/multibody/plant/test/multibody_plant_scalar_conversion_test.cc
+++ b/multibody/plant/test/multibody_plant_scalar_conversion_test.cc
@@ -1,0 +1,62 @@
+#include <limits>
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/tree/prismatic_joint.h"
+#include "drake/multibody/tree/revolute_joint.h"
+#include "drake/multibody/tree/revolute_spring.h"
+#include "drake/multibody/tree/rigid_body.h"
+
+namespace drake {
+
+using drake::multibody::RevoluteSpring;
+
+namespace multibody {
+namespace {
+
+// We test that we can scalar convert a plant containing a revolute joint and
+// spring. In particular, we verify that the spring element correctly references
+// the joint both before and after scalar conversion.
+GTEST_TEST(ScalarConversionTest, RevoluteJointAndSpring) {
+  MultibodyPlant<double> plant;
+  // For this test inertia values are irrelevant.
+  const RigidBody<double>& body =
+      plant.AddRigidBody("Body", SpatialInertia<double>());
+  const RevoluteJoint<double>& pin = plant.AddJoint<RevoluteJoint>(
+      "Pin", plant.world_body(), std::nullopt, body, std::nullopt,
+      Vector3<double>::UnitZ());
+  const auto& spring = plant.AddForceElement<RevoluteSpring>(pin, 0, 1500);
+
+  // We verify the correct reference to the pin joint before conversion.
+  EXPECT_EQ(&pin, &spring.joint());
+
+  // We are done defining the model.
+  plant.Finalize();
+
+  // Sanity check for the model's size.
+  DRAKE_DEMAND(plant.num_velocities() == 1);
+  DRAKE_DEMAND(plant.num_positions() == 1);
+  // The plant has a UniformGravityFieldElement by default plus the
+  // RevoluteSpring.
+  DRAKE_DEMAND(plant.num_force_elements() == 2);
+
+  std::unique_ptr<MultibodyPlant<AutoDiffXd>> plant_ad;
+  EXPECT_NO_THROW(plant_ad =
+                      drake::systems::System<double>::ToAutoDiffXd(plant));
+  DRAKE_DEMAND(plant_ad->num_velocities() == 1);
+  DRAKE_DEMAND(plant_ad->num_positions() == 1);
+  DRAKE_DEMAND(plant_ad->num_force_elements() == 2);
+
+  // We verify the correct reference to the pin joint after conversion.
+  const auto& pin_ad = plant_ad->GetJointByName<RevoluteJoint>(pin.name());
+  const auto& spring_ad =
+      plant_ad->GetForceElement<RevoluteSpring>(spring.index());
+  // Verify correct cross-referencing in the scalar converted model.
+  EXPECT_EQ(&pin_ad, &spring_ad.joint());
+}
+
+}  // namespace
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -34,6 +34,7 @@
 #include "drake/multibody/test_utilities/add_fixed_objects_to_plant.h"
 #include "drake/multibody/tree/prismatic_joint.h"
 #include "drake/multibody/tree/revolute_joint.h"
+#include "drake/multibody/tree/revolute_spring.h"
 #include "drake/multibody/tree/rigid_body.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/continuous_state.h"
@@ -243,6 +244,19 @@ GTEST_TEST(MultibodyPlant, SimpleModelCreation) {
       plant->GetJointByName("pin");
   EXPECT_EQ(pin_joint.model_instance(), pendulum_model_instance);
   EXPECT_THROW(plant->GetJointByName(kInvalidName), std::logic_error);
+
+  // Get force elements by index. In this case the default gravity field.
+  const ForceElementIndex gravity_field_index(0);
+  EXPECT_EQ(
+      &plant->gravity_field(),
+      &plant->GetForceElement<UniformGravityFieldElement>(gravity_field_index));
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      plant->GetForceElement<RevoluteSpring>(gravity_field_index),
+      std::logic_error,
+      ".*not of type '.*RevoluteSpring<double>' but of type "
+      "'.*UniformGravityFieldElement<double>'.");
+  const ForceElementIndex invalid_force_index(plant->num_force_elements() + 1);
+  EXPECT_ANY_THROW(plant->GetForceElement<RevoluteSpring>(invalid_force_index));
 
   // Get joint indices by model instance
   const std::vector<JointIndex> acrobot_joint_indices =

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -677,6 +677,34 @@ class MultibodyTree {
     return *owned_mobilizers_[mobilizer_index];
   }
 
+  /// See MultibodyPlant method.
+  template <template <typename> class ForceElementType = ForceElement>
+  const ForceElementType<T>& GetForceElement(
+      ForceElementIndex force_element_index) const {
+    static_assert(
+        std::is_base_of<ForceElement<T>, ForceElementType<T>>::value,
+        "ForceElementType<T> must be a sub-class of ForceElement<T>.");
+    const ForceElement<T>* force_element =
+        &get_force_element(force_element_index);
+
+    const ForceElementType<T>* typed_force_element =
+        dynamic_cast<const ForceElementType<T>*>(force_element);
+    if (typed_force_element == nullptr) {
+      throw std::logic_error("ForceElement is not of type '" +
+                             NiceTypeName::Get<ForceElementType<T>>() +
+                             "' but of type '" +
+                             NiceTypeName::Get(*force_element) + "'.");
+    }
+
+    return *typed_force_element;
+  }
+
+  const ForceElement<T>& get_force_element(
+      ForceElementIndex force_element_index) const {
+    DRAKE_THROW_UNLESS(force_element_index < num_force_elements());
+    return *owned_force_elements_[force_element_index];
+  }
+
   /// An accessor to the current gravity field.
   const UniformGravityFieldElement<T>& gravity_field() const {
     DRAKE_ASSERT(gravity_field_);

--- a/multibody/tree/revolute_spring.h
+++ b/multibody/tree/revolute_spring.h
@@ -38,7 +38,7 @@ class RevoluteSpring final : public ForceElement<T> {
   RevoluteSpring(const RevoluteJoint<T>& joint, double nominal_angle,
                  double stiffness);
 
-  const RevoluteJoint<T>& joint() const { return joint_; }
+  const RevoluteJoint<T>& joint() const;
 
   double nominal_angle() const { return nominal_angle_; }
 
@@ -75,12 +75,19 @@ class RevoluteSpring final : public ForceElement<T> {
       const internal::MultibodyTree<symbolic::Expression>&) const override;
 
  private:
+  // Allow different specializations to access each other's private data for
+  // scalar conversion.
+  template <typename U> friend class RevoluteSpring;
+
+  RevoluteSpring(ModelInstanceIndex model_instance, JointIndex joint_index,
+                 double nominal_angle, double stiffness);
+
   // Helper method to make a clone templated on ToScalar().
   template <typename ToScalar>
   std::unique_ptr<ForceElement<ToScalar>> TemplatedDoCloneToScalar(
       const internal::MultibodyTree<ToScalar>& tree_clone) const;
 
-  const RevoluteJoint<T>& joint_;
+  const JointIndex joint_index_;
   double nominal_angle_;
   double stiffness_;
 };


### PR DESCRIPTION
We were notified of this bug that occurs during scalar conversion (two Slack conversations in the last month). 

The bug is caused by an invalid reference to a scalar converted `Joint` while scalar converting a `RevoluteSpring` element that should refer to it. The fix essentially entails fixing `RevoluteSpring` to store a `JointIndex` instead, which is a guaranteed invariant to scalar conversion.

In addition this PR introduces missing getters for force elements, which I conveniently use here within the unit test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12522)
<!-- Reviewable:end -->
