### PR TITLE
Enables ABA in some examples

### DIFF
--- a/examples/allegro_hand/joint_control/BUILD.bazel
+++ b/examples/allegro_hand/joint_control/BUILD.bazel
@@ -30,6 +30,7 @@ drake_cc_binary(
         "//multibody/plant",
         "//multibody/plant:contact_results_to_lcm",
         "//systems/analysis",
+        "//systems/analysis:simulator_gflags",
         "//systems/controllers:pid_controller",
         "//systems/lcm:lcm_pubsub_system",
         "//systems/primitives",

--- a/examples/allegro_hand/joint_control/allegro_single_object_simulation.cc
+++ b/examples/allegro_hand/joint_control/allegro_single_object_simulation.cc
@@ -24,6 +24,7 @@
 #include "drake/multibody/tree/uniform_gravity_field_element.h"
 #include "drake/multibody/tree/weld_joint.h"
 #include "drake/systems/analysis/simulator.h"
+#include "drake/systems/analysis/simulator_gflags.h"
 #include "drake/systems/controllers/pid_controller.h"
 #include "drake/systems/framework/diagram.h"
 #include "drake/systems/framework/diagram_builder.h"
@@ -45,13 +46,13 @@ DEFINE_double(simulation_time, std::numeric_limits<double>::infinity(),
               "Desired duration of the simulation in seconds");
 DEFINE_bool(use_right_hand, true,
             "Which hand to model: true for right hand or false for left hand");
-DEFINE_double(max_time_step, 1.5e-4,
-              "Simulation time step used for intergrator.");
 DEFINE_bool(add_gravity, false,
             "Whether adding gravity (9.81 m/s^2) in the simulation");
-DEFINE_double(target_realtime_rate, 1,
-              "Desired rate relative to real time.  See documentation for "
-              "Simulator::set_target_realtime_rate() for details.");
+DEFINE_double(
+    mbp_discrete_update_period, 1.0E-3,
+    "The fixed-time step period (in seconds) of discrete updates for the "
+    "multibody plant modeled as a discrete system. Strictly positive. "
+    "Set to zero for a continuous plant model.");
 
 void DoMain() {
   DRAKE_DEMAND(FLAGS_simulation_time > 0);
@@ -64,7 +65,7 @@ void DoMain() {
   scene_graph.set_name("scene_graph");
 
   MultibodyPlant<double>& plant =
-      *builder.AddSystem<MultibodyPlant>(FLAGS_max_time_step);
+      *builder.AddSystem<MultibodyPlant>(FLAGS_mbp_discrete_update_period);
   plant.RegisterAsSourceForSceneGraph(&scene_graph);
   std::string hand_model_path;
   if (FLAGS_use_right_hand)
@@ -185,19 +186,16 @@ void DoMain() {
       p_WHand + Eigen::Vector3d(0.095, 0.062, 0.095));
   plant.SetFreeBodyPose(&plant_context, mug, X_WM);
 
-  // Set up simulator.
-  systems::Simulator<double> simulator(*diagram, std::move(diagram_context));
-  simulator.set_publish_every_time_step(true);
-  simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
-  simulator.Initialize();
-
   // set the initial command for the hand
   hand_command_receiver.set_initial_position(
       &diagram->GetMutableSubsystemContext(hand_command_receiver,
-                                           &simulator.get_mutable_context()),
+                                           diagram_context.get()),
       VectorX<double>::Zero(plant.num_actuators()));
 
-  simulator.AdvanceTo(FLAGS_simulation_time);
+  // Set up simulator.
+  auto simulator =
+      MakeSimulatorFromGflags(*diagram, std::move(diagram_context));
+  simulator->AdvanceTo(FLAGS_simulation_time);
 }
 
 }  // namespace

--- a/examples/atlas/BUILD.bazel
+++ b/examples/atlas/BUILD.bazel
@@ -20,7 +20,7 @@ drake_cc_binary(
     # Smoke test.
     test_rule_args = [
         "--simulation_time=0.01",
-        "--target_realtime_rate=0.0",
+        "--simulator_target_realtime_rate=0.0",
     ],
     deps = [
         "//common:add_text_logging_gflags",
@@ -29,6 +29,7 @@ drake_cc_binary(
         "//multibody/parsing",
         "//multibody/plant:contact_results_to_lcm",
         "//systems/analysis:simulator",
+        "//systems/analysis:simulator_gflags",
         "//systems/framework:diagram",
         "@gflags",
     ],

--- a/examples/simple_gripper/BUILD.bazel
+++ b/examples/simple_gripper/BUILD.bazel
@@ -30,9 +30,9 @@ drake_cc_binary(
         ":simple_gripper_models",
     ],
     test_rule_args = [
-        "--integration_scheme=runge_kutta2",
+        "--simulator_integration_scheme=runge_kutta2",
         "--simulation_time=0.01",
-        "--target_realtime_rate=0.0",
+        "--simulator_target_realtime_rate=0.0",
     ],
     test_rule_timeout = "moderate",
     deps = [
@@ -48,6 +48,7 @@ drake_cc_binary(
         "//systems/analysis:runge_kutta3_integrator",
         "//systems/analysis:semi_explicit_euler_integrator",
         "//systems/analysis:simulator",
+        "//systems/analysis:simulator_gflags",
         "//systems/framework:diagram",
         "//systems/lcm:lcm_pubsub_system",
         "//systems/primitives:sine",

--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -39,6 +39,34 @@ drake_cc_package_library(
 )
 
 drake_cc_library(
+    name = "simulator_gflags",
+    srcs = ["simulator_gflags.cc"],
+    hdrs = ["simulator_gflags.h"],
+    tags = [
+        # Don't add this library into the ":analysis" package library.
+        # Only programs with a main() function should ever use this header.
+        "exclude_from_package",
+        # Don't install this header via this cc_library, because that would
+        # introduce a dependency from libdrake onto gflags.
+        "exclude_from_libdrake",
+    ],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        ":bogacki_shampine3_integrator",
+        ":explicit_euler_integrator",
+        ":implicit_euler_integrator",
+        ":radau_integrator",
+        ":runge_kutta2_integrator",
+        ":runge_kutta3_integrator",
+        ":runge_kutta5_integrator",
+        ":semi_explicit_euler_integrator",
+        ":simulator",
+        "//common:essential",
+        "@gflags",
+    ],
+)
+
+drake_cc_library(
     name = "bogacki_shampine3_integrator",
     srcs = ["bogacki_shampine3_integrator.cc"],
     hdrs = ["bogacki_shampine3_integrator.h"],

--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -26,6 +26,18 @@
 namespace drake {
 namespace systems {
 
+namespace internal {
+// Default value of target_realtime_rate_.
+const double kDefaultTargetRealtimeRate = 0.0;
+
+// Default integrator used by a Simulator.
+const char* const kDefaultIntegratorName = "runge_kutta3";
+
+// Default value of both publish_every_time_step_ and
+// publish_at_initialization_.
+const bool kDefaultPublishEveryTimeStep = false;
+}  // namespace internal
+
 /** @ingroup simulation
 A class for advancing the state of hybrid dynamic systems, represented by
 `System<T>` objects, forward in time. Starting with an initial Context for a
@@ -796,11 +808,11 @@ class Simulator {
   VectorX<T> w0_, wf_;
 
   // Slow down to this rate if possible (user settable).
-  double target_realtime_rate_{0.};
+  double target_realtime_rate_{internal::kDefaultTargetRealtimeRate};
 
-  bool publish_every_time_step_{false};
+  bool publish_every_time_step_{internal::kDefaultPublishEveryTimeStep};
 
-  bool publish_at_initialization_{false};
+  bool publish_at_initialization_{internal::kDefaultPublishEveryTimeStep};
 
   // These are recorded at initialization or statistics reset.
   double initial_simtime_{nan()};  // Simulated time at start of period.
@@ -895,6 +907,8 @@ Simulator<T>::Simulator(const System<T>* system,
   if (!context_) context_ = system_.CreateDefaultContext();
 
   // Create a default integrator and initialize it.
+  // N.B. Keep this in sync with systems::internal::kDefaultIntegratorName at
+  // the top of this file.
   integrator_ = std::unique_ptr<IntegratorBase<T>>(
       new RungeKutta3Integrator<T>(system_, context_.get()));
   integrator_->request_initial_step_size_target(initial_step_size);

--- a/systems/analysis/simulator_gflags.cc
+++ b/systems/analysis/simulator_gflags.cc
@@ -1,0 +1,119 @@
+#include "drake/systems/analysis/simulator_gflags.h"
+
+#include <stdexcept>
+#include <utility>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/text_logging.h"
+#include "drake/systems/analysis/bogacki_shampine3_integrator.h"
+#include "drake/systems/analysis/explicit_euler_integrator.h"
+#include "drake/systems/analysis/implicit_euler_integrator.h"
+#include "drake/systems/analysis/radau_integrator.h"
+#include "drake/systems/analysis/runge_kutta2_integrator.h"
+#include "drake/systems/analysis/runge_kutta3_integrator.h"
+#include "drake/systems/analysis/runge_kutta5_integrator.h"
+#include "drake/systems/analysis/semi_explicit_euler_integrator.h"
+#include "drake/systems/analysis/simulator.h"
+
+// Simulator's paramters:
+DEFINE_double(simulator_target_realtime_rate,
+              drake::systems::internal::kDefaultTargetRealtimeRate,
+              "Desired rate relative to real time.  See documentation for "
+              "Simulator::set_target_realtime_rate() for details.");
+DEFINE_bool(simulator_publish_every_time_step,
+            drake::systems::internal::kDefaultPublishEveryTimeStep,
+            "Sets whether the simulation should trigger a forced-Publish event "
+            "at the end of every trajectory-advancing step. This also "
+            "includes the very first publish at t = 0 (see "
+            "Simulator::set_publish_at_initialization())."
+            "See Simulator::set_publish_every_time_step() for details.");
+
+// Integrator's parameters:
+// N.B. The list of integrators here must be kept in sync with
+// ResetIntegratorFromGflags().
+DEFINE_string(simulator_integration_scheme,
+              drake::systems::internal::kDefaultIntegratorName,
+              "Integration scheme to be used. Available options are: "
+              "'bogacki_shampine3',"
+              "'explicit_euler','implicit_euler','semi_explicit_euler',"
+              "'radau1','radau3',"
+              "'runge_kutta2','runge_kutta3','runge_kutta5'");
+
+DEFINE_double(simulator_max_time_step, 1.0E-3,
+              "Maximum simulation time step used for integration.");
+
+const double kDefaultSimulatorAccuracy = 1.0e-2;
+DEFINE_double(simulator_accuracy, kDefaultSimulatorAccuracy,
+              "Sets the simulation accuracy for variable step "
+              "size integrators with error control.");
+
+namespace drake {
+namespace systems {
+
+// N.B. The list of integrators here must be kept in sync with
+// FLAGS_simulator_integration_scheme defined at the top of this file.
+IntegratorBase<double>& ResetIntegratorFromGflags(
+    Simulator<double>* simulator) {
+  DRAKE_DEMAND(simulator != nullptr);
+
+  if (FLAGS_simulator_integration_scheme == "bogacki_shampine3") {
+    simulator->reset_integrator<BogackiShampine3Integrator<double>>();
+  } else if (FLAGS_simulator_integration_scheme == "explicit_euler") {
+    simulator->reset_integrator<ExplicitEulerIntegrator<double>>(
+        FLAGS_simulator_max_time_step);
+  } else if (FLAGS_simulator_integration_scheme == "implicit_euler") {
+    simulator->reset_integrator<ImplicitEulerIntegrator<double>>();
+  } else if (FLAGS_simulator_integration_scheme == "semi_explicit_euler") {
+    simulator->reset_integrator<SemiExplicitEulerIntegrator<double>>(
+        FLAGS_simulator_max_time_step);
+  } else if (FLAGS_simulator_integration_scheme == "radau1") {
+    simulator->reset_integrator<RadauIntegrator<double, 1>>();
+  } else if (FLAGS_simulator_integration_scheme == "radau3") {
+    simulator->reset_integrator<RadauIntegrator<double>>();
+  } else if (FLAGS_simulator_integration_scheme == "runge_kutta2") {
+    simulator->reset_integrator<RungeKutta2Integrator<double>>(
+        FLAGS_simulator_max_time_step);
+  } else if (FLAGS_simulator_integration_scheme == "runge_kutta3") {
+    simulator->reset_integrator<RungeKutta3Integrator<double>>();
+  } else if (FLAGS_simulator_integration_scheme == "runge_kutta5") {
+    simulator->reset_integrator<RungeKutta5Integrator<double>>();
+  } else {
+    throw std::runtime_error(fmt::format("Unknown integration scheme: {}",
+                                         FLAGS_simulator_integration_scheme));
+  }
+  IntegratorBase<double>& integrator = simulator->get_mutable_integrator();
+  integrator.set_maximum_step_size(FLAGS_simulator_max_time_step);
+  if (!integrator.get_fixed_step_mode()) {
+    integrator.set_target_accuracy(FLAGS_simulator_accuracy);
+  } else {
+    // Integrator is running in fixed step mode, therefore we warn the user if
+    // the accuracy flag was changed from the command line.
+    if (FLAGS_simulator_accuracy != kDefaultSimulatorAccuracy)
+      log()->warn(
+          "Integrator accuracy provided, however the integrator is running in "
+          "fixed step mode. The 'simulator_accuracy' flag will be ignored. "
+          "Switch to an error controlled scheme if you want accuracy control.");
+  }
+  return integrator;
+}
+
+std::unique_ptr<Simulator<double>> MakeSimulatorFromGflags(
+    const System<double>& system, std::unique_ptr<Context<double>> context) {
+  auto simulator =
+      std::make_unique<Simulator<double>>(system, std::move(context));
+  ResetIntegratorFromGflags(simulator.get());
+  simulator->set_target_realtime_rate(FLAGS_simulator_target_realtime_rate);
+
+  // It is almost always the case we want these two next flags to be either both
+  // true or both false. Otherwise we could miss the first publish at t = 0.
+  simulator->set_publish_at_initialization(
+      FLAGS_simulator_publish_every_time_step);
+  simulator->set_publish_every_time_step(
+      FLAGS_simulator_publish_every_time_step);
+
+  simulator->Initialize();
+  return simulator;
+}
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/analysis/simulator_gflags.h
+++ b/systems/analysis/simulator_gflags.h
@@ -1,0 +1,51 @@
+#pragma once
+
+/// @file
+/// This file defines gflags settings to control Simulator settings.
+/// Only include this from translation units that declare a `main` function.
+
+#include <memory>
+#include <string>
+
+#include <gflags/gflags.h>
+
+#include "drake/systems/analysis/integrator_base.h"
+#include "drake/systems/analysis/simulator.h"
+
+// Declares integrator gflags.
+DECLARE_string(simulator_integration_scheme);
+DECLARE_double(simulator_max_time_step);
+DECLARE_double(simulator_accuracy);
+
+// Declares simulator gflags.
+DECLARE_double(simulator_target_realtime_rate);
+DECLARE_bool(simulator_publish_every_time_step);
+
+namespace drake {
+namespace systems {
+
+/// Resets the integrator used to advanced the continuous time dynamics of the
+/// system associated with `simulator` according to the gflags declared in this
+/// file.
+/// @param[in,out] simulator
+///   On input, a valid pointer to a Simulator. On output the
+///   integrator for `simulator` is reset according to the gflags declared in
+///   this file.
+/// @returns  A reference to the the newly created integrator owned by
+/// `simulator`.
+IntegratorBase<double>& ResetIntegratorFromGflags(Simulator<double>* simulator);
+
+/// Makes a new simulator according to the gflags declared in this file.
+/// @param[in] system
+///   The System to be associated with the newly crated Simulator. You must
+///   ensure that `system` has a longer lifetime than the new Simulator.
+/// @param[in] context
+///   The Context that will be used as the initial condition for the simulation;
+///   otherwise the Simulator will obtain a default Context from `system`.
+/// @returns The newly created Simulator.
+std::unique_ptr<Simulator<double>> MakeSimulatorFromGflags(
+    const System<double>& system,
+    std::unique_ptr<Context<double>> context = nullptr);
+
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
This was extracted from #12470 to ease review.  

We enable running MBP in continuous mode for the largest examples we have thus far in `drake/examples`. In my computer these are the speed ups I observed:

 - examples/simple_gripper: 17 dofs (nv = 8). 1.07 times faster.
 - examples/allegro_hand/joint_control:allegro_single_object_simulation: 45 dofs (nv = 22). 1.75 times faster.
 - examples/atlas:atlas_run_dynamics: 73 dofs (nv = 36). 5.5 times faster.

For these quick measurements I run the simulations for 20000 time steps using a semi-explicit Euler so that the number of time steps were known from the step size and simulation length.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12527)
<!-- Reviewable:end -->
