### PR TITLE
Bug fix warning on unsupported joint limits for continuous models.

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -58,6 +58,7 @@ drake_cc_library(
         ":tamsi_solver",
         ":tamsi_solver_results",
         "//common:default_scalars",
+        "//common:essential",
         "//geometry:geometry_ids",
         "//geometry:geometry_roles",
         "//geometry:scene_graph",


### PR DESCRIPTION
I realized when looking at the improved message in #12499 that this exception is never thrown, a bug that was introduced before #12499.

The problem is that even if the model is continuous, with `time_step = 0`, we use time_step to compute a joint stiffness leading to `stiffness = infty`. The check just below ensures that this exception is never thrown when `stiffness = infty`, which defeats the purpose of the test.

I fixed this logic and I also switched the exception into a warning so that we can still run MBP sims from SDF/URDF models with limits until we introduce the support for continuous plants (which will only require getting rid of this warning).

cc'ing @RussTedrake, since you wanted better messages for this case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12531)
<!-- Reviewable:end -->
