### PR TITLE
lcm: Escape regex characters in DrakeLcm channel names

### DIFF
--- a/lcm/BUILD.bazel
+++ b/lcm/BUILD.bazel
@@ -55,6 +55,8 @@ drake_cc_library(
     deps = [
         ":interface",
         "//common:essential",
+        "//common:scope_exit",
+        "@glib",
         "@lcm",
     ],
 )

--- a/lcm/drake_lcm.cc
+++ b/lcm/drake_lcm.cc
@@ -5,9 +5,12 @@
 #include <utility>
 #include <vector>
 
+#include <glib.h>
+
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_throw.h"
+#include "drake/common/scope_exit.h"
 
 namespace drake {
 namespace lcm {
@@ -90,15 +93,19 @@ class DrakeSubscription final : public DrakeSubscriptionInterface {
       HandlerFunction handler) {
     DRAKE_DEMAND(native_instance != nullptr);
 
+    // The argument to subscribeFunction is regex (not a string literal), so
+    // we'll need to escape the channel name before calling subscribeFunction.
+    char* const channel_regex = g_regex_escape_string(channel.c_str(), -1);
+    ScopeExit guard([channel_regex](){ g_free(channel_regex); });
+
     // Create the result.
     auto result = std::make_shared<DrakeSubscription>();
     result->native_instance_ = native_instance;
     result->user_callback_ = std::move(handler);
     result->weak_self_reference_ = result;
     result->strong_self_reference_ = result;
-    // TODO(#12523) This should escape `channel` against regex parsing.
     result->native_subscription_ = native_instance->subscribeFunction(
-      channel, &DrakeSubscription::NativeCallback, result.get());
+        channel_regex, &DrakeSubscription::NativeCallback, result.get());
     result->native_subscription_->setQueueCapacity(1);
 
     // Sanity checks.  (The use_count will be 2 because both 'result' and

--- a/lcm/drake_lcm_interface.h
+++ b/lcm/drake_lcm_interface.h
@@ -71,9 +71,6 @@ class DrakeLcmInterface {
    *
    * NOTE: Unlike upstream LCM, DrakeLcm does not support regexes for the
    * `channel` argument.
-   * TODO(#12523) Some implementations may provide this capability, but users
-   * should not rely on this functionality which will be removed in the
-   * future.
    *
    * @param channel The channel to subscribe to.
    * Must not be the empty string.


### PR DESCRIPTION
Drake no longer accidentally "supports" regexes for channel names.

Closes #12523.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12534)
<!-- Reviewable:end -->
