### PR TITLE
Confirming that all supported geometries are nominally parsed

### DIFF
--- a/multibody/parsing/detail_scene_graph.h
+++ b/multibody/parsing/detail_scene_graph.h
@@ -21,8 +21,8 @@ using ResolveFilename = std::function<std::string (std::string)>;
 /** Given an sdf::Geometry object representing a <geometry> element from an SDF
  file, this method makes a new drake::geometry::Shape object from this
  specification.
- For `sdf_geometry.Type() == sdf::GeometryType::EMPTY`, corresponding to the
- <empty/> SDF tag, it returns `nullptr`.  */
+ If no recognizable geometry is specified, nullptr is returned. If the geometry
+ is recognized, but malformed, an exception is thrown.  */
 std::unique_ptr<geometry::Shape> MakeShapeFromSdfGeometry(
     const sdf::Geometry& sdf_geometry, ResolveFilename resolve_filename);
 

--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -472,13 +472,14 @@ std::vector<LinkInfo> AddLinksFromSpecification(
         const sdf::Collision& sdf_collision =
             *link.CollisionByIndex(collision_index);
         const sdf::Geometry& sdf_geometry = *sdf_collision.Geom();
-        if (sdf_geometry.Type() != sdf::GeometryType::EMPTY) {
+
+        std::unique_ptr<geometry::Shape> shape =
+            MakeShapeFromSdfGeometry(sdf_geometry, resolve_filename);
+        if (shape != nullptr) {
           const RigidTransformd X_LG = ResolveRigidTransform(
               sdf_collision.SemanticPose());
           const RigidTransformd X_LC =
               MakeGeometryPoseFromSdfCollision(sdf_collision, X_LG);
-          std::unique_ptr<geometry::Shape> shape =
-              MakeShapeFromSdfGeometry(sdf_geometry, resolve_filename);
           geometry::ProximityProperties props =
               MakeProximityPropertiesForCollision(sdf_collision);
           plant->RegisterCollisionGeometry(body, X_LC, *shape,

--- a/multibody/parsing/test/detail_urdf_parser_test.cc
+++ b/multibody/parsing/test/detail_urdf_parser_test.cc
@@ -245,6 +245,87 @@ GTEST_TEST(MultibodyPlantUrdfParserTest, CollisionFilterGroupParsingTest) {
   EXPECT_TRUE(
       inspector.CollisionFiltered(geometry_id_link3, geometry_id_link4));
 }
+// Reports if the frame with the given id has a geometry with the given role
+// whose name is the same as what ShapeName(ShapeType{}) would produce.
+template <typename ShapeType>
+::testing::AssertionResult FrameHasShape(geometry::FrameId frame_id,
+                                         geometry::Role role,
+                                         const SceneGraph<double>& scene_graph,
+                                         const ShapeType& shape) {
+  const auto& inspector = scene_graph.model_inspector();
+  const std::string name = geometry::ShapeName(shape).name();
+  try {
+    // Note: MBP prepends the model index to the geometry name; in this case
+    // that model instance name is "test_robot".
+    const geometry::GeometryId geometry_id =
+        inspector.GetGeometryIdByName(frame_id, role, "test_robot::" + name);
+    const std::string shape_type =
+        geometry::ShapeName(inspector.GetShape(geometry_id)).name();
+    if (shape_type != name) {
+      return ::testing::AssertionFailure()
+          << "Geometry with role " << role << " has wrong shape type."
+          << "\nExpected: " << name
+          << "\nFound: " << shape_type;
+    }
+  } catch (const std::exception& e) {
+    return ::testing::AssertionFailure()
+        << "Frame " << frame_id << " does not have a geometry with role "
+        << role << " and name " << name
+        << ".\n  Exception message: " << e.what();
+  }
+  return ::testing::AssertionSuccess();
+}
+
+// Confirms that all supported geometries in an URDF file are registered. The
+// *details* of the geometries are ignored -- we assume that that functionality
+// is tested in detail_urdf_geometry_test.cc. This merely makes sure that *that*
+// functionality is exercised appropriately.
+void TestForParsedGeometry(const char* sdf_name, geometry::Role role) {
+  const std::string full_name = FindResourceOrThrow(sdf_name);
+  PackageMap package_map;
+  package_map.PopulateUpstreamToDrake(full_name);
+  MultibodyPlant<double> plant(0.0);
+  SceneGraph<double> scene_graph;
+  plant.RegisterAsSourceForSceneGraph(&scene_graph);
+  AddModelFromUrdfFile(full_name, "", package_map, &plant, &scene_graph);
+  plant.Finalize();
+
+  const auto frame_id =
+      plant.GetBodyFrameIdOrThrow(plant.GetBodyByName("link1").index());
+
+  const std::string mesh_uri = "drake/multibody/parsing/test/tri_cube.obj";
+
+  // Note: the parameters for the various example shapes do not matter to this
+  // test.
+  EXPECT_TRUE(
+      FrameHasShape(frame_id, role, scene_graph, geometry::Box{0.1, 0.1, 0.1}));
+  EXPECT_TRUE(
+      FrameHasShape(frame_id, role, scene_graph, geometry::Capsule{0.1, 0.1}));
+  EXPECT_TRUE(FrameHasShape(frame_id, role, scene_graph,
+                            geometry::Convex{mesh_uri, 1.0}));
+  EXPECT_TRUE(
+      FrameHasShape(frame_id, role, scene_graph, geometry::Cylinder{0.1, 0.1}));
+  EXPECT_TRUE(FrameHasShape(frame_id, role, scene_graph,
+                            geometry::Ellipsoid{0.1, 0.1, 0.1}));
+  EXPECT_TRUE(FrameHasShape(frame_id, role, scene_graph,
+                            geometry::Mesh{mesh_uri, 1.0}));
+  EXPECT_TRUE(
+      FrameHasShape(frame_id, role, scene_graph, geometry::Sphere{0.1}));
+}
+
+GTEST_TEST(MultibodyPlantUrdfParserTest, CollisionGeometryParsing) {
+  TestForParsedGeometry(
+      "drake/multibody/parsing/test/urdf_parser_test/"
+      "all_geometries_as_collision.urdf",
+      geometry::Role::kProximity);
+}
+
+GTEST_TEST(MultibodyPlantUrdfParserTest, VisualGeometryParsing) {
+  TestForParsedGeometry(
+      "drake/multibody/parsing/test/urdf_parser_test/"
+      "all_geometries_as_visual.urdf",
+      geometry::Role::kPerception);
+}
 
 }  // namespace
 }  // namespace internal

--- a/multibody/parsing/test/sdf_parser_test/all_geometries_as_collision.sdf
+++ b/multibody/parsing/test/sdf_parser_test/all_geometries_as_collision.sdf
@@ -1,0 +1,98 @@
+<sdf version='1.7'>
+  <model name='test_robot'>
+    <!-- This sdf file defines a simple test robot with a single link that
+         contains one collision tag for each supported geometry type. We're
+         confirming that each geometry declaration produces a corresponding
+         Drake Shape. The *names* of each collision element match the string
+         that is produced by `ShapeName` (see shape_specification.h). This is
+         to facilitate testing and altering the names will cause the test to
+         fail.
+         Values in <inertial> are not important for this test model since
+         it's only to test the parsing of visuals and collisions into a
+         MultibodyPlant.
+         This file is meant to be kept in sync with the corresponding unit
+         test file detail_sdf_parser_test.cc -->
+    <!-- We will define the model frame as `M`. The parent, which tends to be
+         the world, will be denoted as `P`.
+         Because there is no <pose> tag at the root level, `X_PM` will be
+         identity. -->
+
+    <link name='link1'>
+
+      <collision name = 'Box'>
+        <geometry>
+          <box>
+            <size>1.0 2.0 3.0</size>
+          </box>
+        </geometry>
+      </collision>
+
+      <collision name = 'Capsule'>
+        <geometry>
+          <drake:capsule>
+            <length>1</length>
+            <radius>0.1</radius>
+          </drake:capsule>
+        </geometry>
+      </collision>
+
+      <collision name = 'Convex'>
+        <geometry>
+          <mesh>
+            <drake:declare_convex/>
+            <uri>../tri_cube.obj</uri>
+          </mesh>
+        </geometry>
+      </collision>
+
+      <collision name = 'Cylinder'>
+        <geometry>
+          <cylinder>
+            <length>1</length>
+            <radius>0.1</radius>
+          </cylinder>
+        </geometry>
+      </collision>
+
+      <collision name = 'Ellipsoid'>
+        <geometry>
+          <drake:ellipsoid>
+            <a>1.0</a>
+            <b>2.0</b>
+            <c>3.0</c>
+          </drake:ellipsoid>
+        </geometry>
+      </collision>
+
+      <collision name = 'HalfSpace'>
+        <geometry>
+          <plane>
+            <normal>1.0 2.0 3.0</normal>
+          </plane>
+        </geometry>
+      </collision>
+
+      <collision name = 'Mesh'>
+        <geometry>
+          <mesh>
+            <uri>../tri_cube.obj</uri>
+          </mesh>
+        </geometry>
+      </collision>
+
+      <collision name = 'Sphere'>
+        <geometry>
+          <sphere>
+            <radius>1.0</radius>
+          </sphere>
+        </geometry>
+      </collision>
+    </link>
+
+    <!-- Ensure we can weld to the world. -->
+    <joint name='weld_link1' type='fixed'>
+      <parent>world</parent>
+      <child>link1</child>
+    </joint>
+  </model>
+</sdf>

--- a/multibody/parsing/test/sdf_parser_test/all_geometries_as_visual.sdf
+++ b/multibody/parsing/test/sdf_parser_test/all_geometries_as_visual.sdf
@@ -1,0 +1,98 @@
+<sdf version='1.7'>
+  <model name='test_robot'>
+    <!-- This sdf file defines a simple test robot with a single link that
+         contains one visual tag for each supported geometry type. We're
+         confirming that each geometry declaration produces a corresponding
+         Drake Shape. The *names* of each visual element match the string
+         that is produced by `ShapeName` (see shape_specification.h). This is
+         to facilitate testing and altering the names will cause the test to
+         fail.
+         Values in <inertial> are not important for this test model since
+         it's only to test the parsing of visuals and collisions into a
+         MultibodyPlant.
+         This file is meant to be kept in sync with the corresponding unit
+         test file detail_sdf_parser_test.cc -->
+    <!-- We will define the model frame as `M`. The parent, which tends to be
+         the world, will be denoted as `P`.
+         Because there is no <pose> tag at the root level, `X_PM` will be
+         identity. -->
+
+    <link name='link1'>
+
+      <visual name = 'Box'>
+        <geometry>
+          <box>
+            <size>1.0 2.0 3.0</size>
+          </box>
+        </geometry>
+      </visual>
+
+      <visual name = 'Capsule'>
+        <geometry>
+          <drake:capsule>
+            <length>1</length>
+            <radius>0.1</radius>
+          </drake:capsule>
+        </geometry>
+      </visual>
+
+      <visual name = 'Convex'>
+        <geometry>
+          <mesh>
+            <drake:declare_convex/>
+            <uri>../tri_cube.obj</uri>
+          </mesh>
+        </geometry>
+      </visual>
+
+      <visual name = 'Cylinder'>
+        <geometry>
+          <cylinder>
+            <length>1</length>
+            <radius>0.1</radius>
+          </cylinder>
+        </geometry>
+      </visual>
+
+      <visual name = 'Ellipsoid'>
+        <geometry>
+          <drake:ellipsoid>
+            <a>1.0</a>
+            <b>2.0</b>
+            <c>3.0</c>
+          </drake:ellipsoid>
+        </geometry>
+      </visual>
+
+      <visual name = 'Mesh'>
+        <geometry>
+          <mesh>
+            <uri>../tri_cube.obj</uri>
+          </mesh>
+        </geometry>
+      </visual>
+
+      <visual name = 'HalfSpace'>
+        <geometry>
+          <plane>
+            <normal>1.0 2.0 3.0</normal>
+          </plane>
+        </geometry>
+      </visual>
+
+      <visual name = 'Sphere'>
+        <geometry>
+          <sphere>
+            <radius>1.0</radius>
+          </sphere>
+        </geometry>
+      </visual>
+    </link>
+
+    <!-- Ensure we can weld to the world. -->
+    <joint name='weld_link1' type='fixed'>
+      <parent>world</parent>
+      <child>link1</child>
+    </joint>
+  </model>
+</sdf>

--- a/multibody/parsing/test/urdf_parser_test/all_geometries_as_collision.urdf
+++ b/multibody/parsing/test/urdf_parser_test/all_geometries_as_collision.urdf
@@ -1,0 +1,76 @@
+<?xml version="1.0"?>
+<robot name='test_robot'>
+  <!-- This urdf file defines a simple test robot with a single link that
+       contains one collision tag for each supported geometry type. We're
+       confirming that each geometry declaration produces a corresponding
+       Drake Shape. The *names* of each collision element match the string
+       that is produced by `ShapeName` (see shape_specification.h). This is
+       to facilitate testing and altering the names will cause the test to
+       fail.
+       Values in <inertial> are not important for this test model since
+       it's only to test the parsing of visuals and collisions into a
+       MultibodyPlant.
+       This file is meant to be kept in sync with the corresponding unit
+       test file detail_urdf_parser_test.cc -->
+  <link name='link1'>
+    <inertial>
+      <mass value="1"/>
+    </inertial>
+
+    <collision name = 'Box'>
+      <geometry>
+        <box size="1 2 3"/>
+      </geometry>
+    </collision>
+
+    <collision name = 'Capsule'>
+      <geometry>
+        <capsule radius="0.5" length="2.0"/>
+      </geometry>
+    </collision>
+
+    <collision name = 'Convex'>
+      <geometry>
+        <mesh filename="../tri_cube.obj">
+          <drake:declare_convex/>
+        </mesh>
+      </geometry>
+    </collision>
+
+    <collision name = 'Cylinder'>
+      <geometry>
+        <cylinder radius="0.5" length="2.0"/>
+      </geometry>
+    </collision>
+
+    <collision name = 'Ellipsoid'>
+      <geometry>
+        <drake:ellipsoid a="1.0" b="2.0" c="3.0"/>
+      </geometry>
+    </collision>
+
+    <!--
+    TODO(SeanCurtis-TRI): Parse halfspace from URDF files. Part of it is
+     defining the semantics. Do I allow an arbitrary normal and point in the
+     definition? Or do I infer it from the pose? This latter would more directly
+     parallel the sdf functionality.
+    <collision name = 'HalfSpace'>
+      <geometry>
+        <drake:half_space/>
+      </geometry>
+    </collision>
+    -->
+
+    <collision name = 'Mesh'>
+      <geometry>
+        <mesh filename="../tri_cube.obj"/>
+      </geometry>
+    </collision>
+
+    <collision name = 'Sphere'>
+      <geometry>
+        <sphere radius="1.0"/>
+      </geometry>
+    </collision>
+  </link>
+</robot>

--- a/multibody/parsing/test/urdf_parser_test/all_geometries_as_visual.urdf
+++ b/multibody/parsing/test/urdf_parser_test/all_geometries_as_visual.urdf
@@ -1,0 +1,76 @@
+<?xml version="1.0"?>
+<robot name='test_robot'>
+  <!-- This urdf file defines a simple test robot with a single link that
+       contains one collision tag for each supported geometry type. We're
+       confirming that each geometry declaration produces a corresponding
+       Drake Shape. The *names* of each collision element match the string
+       that is produced by `ShapeName` (see shape_specification.h). This is
+       to facilitate testing and altering the names will cause the test to
+       fail.
+       Values in <inertial> are not important for this test model since
+       it's only to test the parsing of visuals and collisions into a
+       MultibodyPlant.
+       This file is meant to be kept in sync with the corresponding unit
+       test file detail_urdf_parser_test.cc -->
+  <link name='link1'>
+    <inertial>
+      <mass value="1"/>
+    </inertial>
+
+    <visual name = 'Box'>
+      <geometry>
+        <box size="1 2 3"/>
+      </geometry>
+    </visual>
+
+    <visual name = 'Capsule'>
+      <geometry>
+        <capsule radius="0.5" length="2.0"/>
+      </geometry>
+    </visual>
+
+    <visual name = 'Convex'>
+      <geometry>
+        <mesh filename="../tri_cube.obj">
+          <drake:declare_convex/>
+        </mesh>
+      </geometry>
+    </visual>
+
+    <visual name = 'Cylinder'>
+      <geometry>
+        <cylinder radius="0.5" length="2.0"/>
+      </geometry>
+    </visual>
+
+    <visual name = 'Ellipsoid'>
+      <geometry>
+        <drake:ellipsoid a="1.0" b="2.0" c="3.0"/>
+      </geometry>
+    </visual>
+
+    <!--
+    TODO(SeanCurtis-TRI): Parse halfspace from URDF files. Part of it is
+     defining the semantics. Do I allow an arbitrary normal and point in the
+     definition? Or do I infer it from the pose? This latter would more directly
+     parallel the sdf functionality.
+    <visual name = 'HalfSpace'>
+      <geometry>
+        <drake:half_space/>
+      </geometry>
+    </visual>
+    -->
+
+    <visual name = 'Mesh'>
+      <geometry>
+        <mesh filename="../tri_cube.obj"/>
+      </geometry>
+    </visual>
+
+    <visual name = 'Sphere'>
+      <geometry>
+        <sphere radius="1.0"/>
+      </geometry>
+    </visual>
+  </link>
+</robot>


### PR DESCRIPTION
Although the sub-components (e.g., reading a Drake::Shape from an sdf <geometry> tag) are tested, the proper exercise of those components is *not* tested. This adds those tests.

In the process of those tests, the following happened:

1. Fixed bug in sdf parser that prevented capsules and ellipsoids from being added as collision geometries.
2. Added parsing of ellipsoids to URDF.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12541)
<!-- Reviewable:end -->
