### PR TITLE
solvers: Fix scope_exit deps for snopt_fortran

### DIFF
--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -797,6 +797,7 @@ drake_cc_library(
         "//tools:with_snopt_fortran": [
             ":mathematical_program",
             ":solver_base",
+            "//common:scope_exit",
             "//math:autodiff",
             "@snopt//:snopt_cwrap",
         ],


### PR DESCRIPTION
This repairs a bug in b14c7254e4c1679bb6173669f705acf2f063c634 (#12537).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12545)
<!-- Reviewable:end -->
