### PR TITLE
Adds C++17 structured binding support to AddMultibodyPlantSceneGraphResult

### DIFF
--- a/manipulation/models/ycb/test/parse_test.cc
+++ b/manipulation/models/ycb/test/parse_test.cc
@@ -53,21 +53,19 @@ TEST_P(ParseTest, Quantities) {
       "drake/manipulation/models/ycb/sdf/{}.sdf", object_name));
 
   DiagramBuilder<double> builder;
-  MultibodyPlant<double>* plant{};
-  SceneGraph<double>* scene_graph{};
-  std::tie(plant, scene_graph) = AddMultibodyPlantSceneGraph(&builder, 0.0);
-  Parser(plant).AddModelFromFile(filename);
-  ConnectDrakeVisualizer(&builder, *scene_graph);
-  plant->Finalize();
+  auto[plant, scene_graph] = AddMultibodyPlantSceneGraph(&builder);
+  Parser(&plant).AddModelFromFile(filename);
+  ConnectDrakeVisualizer(&builder, scene_graph);
+  plant.Finalize();
   auto diagram = builder.Build();
 
   // MultibodyPlant always creates at least two model instances, one for the
   // world and one for a default model instance for unspecified modeling
   // elements. Finally, there is a model instance for each YCB sdf file.
-  EXPECT_EQ(plant->num_model_instances(), 3);
+  EXPECT_EQ(plant.num_model_instances(), 3);
 
   // Each object has two bodies, the world body and the object body.
-  EXPECT_EQ(plant->num_bodies(), 2);
+  EXPECT_EQ(plant.num_bodies(), 2);
 
   if (FLAGS_visualize_sec > 0.) {
     drake::log()->info("Visualize: {}", object_name);

--- a/manipulation/models/ycb/test/parse_test.cc
+++ b/manipulation/models/ycb/test/parse_test.cc
@@ -53,7 +53,7 @@ TEST_P(ParseTest, Quantities) {
       "drake/manipulation/models/ycb/sdf/{}.sdf", object_name));
 
   DiagramBuilder<double> builder;
-  auto[plant, scene_graph] = AddMultibodyPlantSceneGraph(&builder);
+  auto[plant, scene_graph] = AddMultibodyPlantSceneGraph(&builder, 0.0);
   Parser(&plant).AddModelFromFile(filename);
   ConnectDrakeVisualizer(&builder, scene_graph);
   plant.Finalize();

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -4284,22 +4284,31 @@ void MultibodyPlant<symbolic::Expression>::
 // Specializations provided to support C++17's structured binding for
 // AddMultibodyPlantSceneGraphResult.
 namespace std {
+// The GCC standard library defines tuple_size as class and struct which
+// triggers a warning here.
+// We found this solution in: https://github.com/nlohmann/json/issues/1401
+#if defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmismatched-tags"
+#endif
 template <typename T>
-class tuple_size<drake::multibody::AddMultibodyPlantSceneGraphResult<T>>
+struct tuple_size<drake::multibody::AddMultibodyPlantSceneGraphResult<T>>
     : std::integral_constant<std::size_t, 2> {};
 
 template <typename T>
-class tuple_element<0, drake::multibody::AddMultibodyPlantSceneGraphResult<T>> {
- public:
+struct tuple_element<0,
+                     drake::multibody::AddMultibodyPlantSceneGraphResult<T>> {
   using type = drake::multibody::MultibodyPlant<T>;
 };
 
 template <typename T>
-class tuple_element<1, drake::multibody::AddMultibodyPlantSceneGraphResult<T>> {
- public:
+struct tuple_element<1,
+                     drake::multibody::AddMultibodyPlantSceneGraphResult<T>> {
   using type = drake::geometry::SceneGraph<T>;
 };
-
+#if defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 }  // namespace std
 #endif
 

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -236,11 +236,9 @@ enum class ContactModel {
 ///   items.plant.DoFoo(...);
 ///   items.scene_graph.DoBar(...);
 /// @endcode
-/// or
+/// or taking advantage of C++17's structured binding
 /// @code
-///   auto items = AddMultibodyPlantSceneGraph(&builder, 0.0 /* time_step */);
-///   MultibodyPlant<double>& plant = items.plant;
-///   SceneGraph<double>& scene_graph = items.scene_graph;
+///   auto [plant, scene_graph] = AddMultibodyPlantSceneGraph(&builder);
 ///   ...
 ///   plant.DoFoo(...);
 ///   scene_graph.DoBar(...);
@@ -4212,6 +4210,20 @@ struct AddMultibodyPlantSceneGraphResult final {
   }
 
 #ifndef DRAKE_DOXYGEN_CXX
+  // Returns the N-th member referenced by this struct.
+  // If N = 0, returns the reference to the MultibodyPlant.
+  // If N = 1, returns the reference to the geometry::SceneGraph.
+  // Provided to support C++17's structured binding.
+  template <std::size_t N>
+  decltype(auto) get() const {
+    if constexpr (N == 0)
+      return plant;
+    else if constexpr (N == 1)
+      return scene_graph;
+  }
+#endif
+
+#ifndef DRAKE_DOXYGEN_CXX
   // Only the move constructor is enabled; copy/assign/move-assign are deleted.
   AddMultibodyPlantSceneGraphResult(
       AddMultibodyPlantSceneGraphResult&&) = default;
@@ -4267,6 +4279,29 @@ void MultibodyPlant<symbolic::Expression>::
 
 }  // namespace multibody
 }  // namespace drake
+
+#ifndef DRAKE_DOXYGEN_CXX
+// Specializations provided to support C++17's structured binding for
+// AddMultibodyPlantSceneGraphResult.
+namespace std {
+template <typename T>
+class tuple_size<drake::multibody::AddMultibodyPlantSceneGraphResult<T>>
+    : std::integral_constant<std::size_t, 2> {};
+
+template <typename T>
+class tuple_element<0, drake::multibody::AddMultibodyPlantSceneGraphResult<T>> {
+ public:
+  using type = drake::multibody::MultibodyPlant<T>;
+};
+
+template <typename T>
+class tuple_element<1, drake::multibody::AddMultibodyPlantSceneGraphResult<T>> {
+ public:
+  using type = drake::geometry::SceneGraph<T>;
+};
+
+}  // namespace std
+#endif
 
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class drake::multibody::MultibodyPlant)

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -334,7 +334,8 @@ GTEST_TEST(MultibodyPlantTest, AddMultibodyPlantSceneGraph) {
   EXPECT_EQ(&plant_ref, plant);
 
   // Check support for C++17's structured binding.
-  auto[first_element, second_element] = AddMultibodyPlantSceneGraph(&builder);
+  auto[first_element, second_element] =
+      AddMultibodyPlantSceneGraph(&builder, 0.0);
   // Verify the expected types.
   EXPECT_EQ(drake::NiceTypeName::Get(first_element),
             drake::NiceTypeName::Get<MultibodyPlant<double>>());

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -12,6 +12,7 @@
 
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/find_resource.h"
+#include "drake/common/nice_type_name.h"
 #include "drake/common/symbolic.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
@@ -331,6 +332,14 @@ GTEST_TEST(MultibodyPlantTest, AddMultibodyPlantSceneGraph) {
   // Check referencing.
   MultibodyPlant<double>& plant_ref = pair;
   EXPECT_EQ(&plant_ref, plant);
+
+  // Check support for C++17's structured binding.
+  auto[first_element, second_element] = AddMultibodyPlantSceneGraph(&builder);
+  // Verify the expected types.
+  EXPECT_EQ(drake::NiceTypeName::Get(first_element),
+            drake::NiceTypeName::Get<MultibodyPlant<double>>());
+  EXPECT_EQ(drake::NiceTypeName::Get(second_element),
+            drake::NiceTypeName::Get<SceneGraph<double>>());
 
   // These should fail:
   // AddMultibodyPlantSceneGraphResult<double> extra(plant, scene_graph);


### PR DESCRIPTION
What the title says, so that we can do:
```c++
auto [plant, scene_graph] = AddMultibodyPlantSceneGraph(builder);
plant.DoMultibodyStuff();
scene_graph.DoGeometryStuff();
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12559)
<!-- Reviewable:end -->
