### PR TITLE
Re-implement the uniformly random rotation.

### DIFF
--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -26,6 +26,7 @@ drake_cc_package_library(
         ":geometric_transform",
         ":gradient",
         ":gray_code",
+        ":hopf_coordinate",
         ":jacobian",
         ":matrix_util",
         ":orthonormal_basis",
@@ -126,6 +127,16 @@ drake_cc_library(
         "//common:drake_bool",
         "//common:essential",
         "//common:is_approx_equal_abstol",
+    ],
+)
+
+drake_cc_library(
+    name="hopf_coordinate",
+    hdrs = ["hopf_coordinate.h"],
+    srcs = ["hopf_coordinate.cc"],
+    deps = [
+        "//common:essential",
+        "@eigen",
     ],
 )
 
@@ -386,6 +397,13 @@ drake_cc_googletest(
     deps = [
         ":gray_code",
         "//common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "hopf_coordinate_test",
+    deps = [
+        ":hopf_coordinate",
     ],
 )
 

--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -109,6 +109,7 @@ drake_cc_library(
 drake_cc_library(
     name = "geometric_transform",
     srcs = [
+        "hopf_coordinate.cc",
         "quaternion.cc",
         "random_rotation.cc",
         "rigid_transform.cc",
@@ -116,6 +117,7 @@ drake_cc_library(
         "rotation_matrix.cc",
     ],
     hdrs = [
+        "hopf_coordinate.h",
         "quaternion.h",
         "random_rotation.h",
         "rigid_transform.h",
@@ -131,9 +133,9 @@ drake_cc_library(
 )
 
 drake_cc_library(
-    name="hopf_coordinate",
-    hdrs = ["hopf_coordinate.h"],
+    name = "hopf_coordinate",
     srcs = ["hopf_coordinate.cc"],
+    hdrs = ["hopf_coordinate.h"],
     deps = [
         "//common:essential",
         "@eigen",

--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -26,7 +26,6 @@ drake_cc_package_library(
         ":geometric_transform",
         ":gradient",
         ":gray_code",
-        ":hopf_coordinate",
         ":jacobian",
         ":matrix_util",
         ":orthonormal_basis",
@@ -129,16 +128,6 @@ drake_cc_library(
         "//common:drake_bool",
         "//common:essential",
         "//common:is_approx_equal_abstol",
-    ],
-)
-
-drake_cc_library(
-    name = "hopf_coordinate",
-    srcs = ["hopf_coordinate.cc"],
-    hdrs = ["hopf_coordinate.h"],
-    deps = [
-        "//common:essential",
-        "@eigen",
     ],
 )
 
@@ -405,7 +394,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "hopf_coordinate_test",
     deps = [
-        ":hopf_coordinate",
+        ":geometric_transform",
     ],
 )
 

--- a/math/hopf_coordinate.cc
+++ b/math/hopf_coordinate.cc
@@ -1,0 +1,1 @@
+#include "drake/math/hopf_coordinate.h"

--- a/math/hopf_coordinate.h
+++ b/math/hopf_coordinate.h
@@ -1,5 +1,5 @@
 /// @file
-/// Hopf coodinates parameters SO(3) locally as the Cartesian product of
+/// Hopf coodinates parameterizes SO(3) locally as the Cartesian product of a
 /// one-sphere and a two-sphere S¹ x S². Computationally, each rotation in the
 /// Hopf coordinates can be written as (θ, φ, ψ), in which ψ parameterizes the
 /// circle S¹ and has a range of 2π, and θ, φ represent the spherical
@@ -10,6 +10,7 @@
 #include <cmath>
 
 #include <Eigen/Dense>
+#include <Eigen/Geometry>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/eigen_types.h"

--- a/math/hopf_coordinate.h
+++ b/math/hopf_coordinate.h
@@ -1,0 +1,78 @@
+/// @file
+/// Hopf coodinates parameters SO(3) locally as the Cartesian product of
+/// one-sphere and a two-sphere S¹ x S². Computationally, each rotation in the
+/// Hopf coordinates can be written as (θ, φ, ψ), in which ψ parameterizes the
+/// circle S¹ and has a range of 2π, and θ, φ represent the spherical
+/// coordinates for S², with the range of π and 2π respectively.
+
+#pragma once
+
+#include <cmath>
+
+#include <Eigen/Dense>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace math {
+/**
+ * Transforms Hopf coordinates to a quaternion w, x, y, z as
+ * w = cos(θ/2)cos(ψ/2)
+ * x = cos(θ/2)sin(ψ/2)
+ * y = sin(θ/2)cos(φ+ψ/2)
+ * z = sin(θ/2)sin(φ+ψ/2)
+ * The user can refer to equation 5 of
+ * Generating Uniform Incremental Grids on SO(3) Using the Hopf Fibration
+ * by Anna Yershova, Steven LaValle and Julie Mitchell, 2008
+ * @param theta The θ angle.
+ * @param phi The φ angle.
+ * @param psi The ψ angle.
+ */
+template <typename T>
+const Eigen::Quaternion<T> HopfCoordinateToQuaternion(const T& theta,
+                                                      const T& phi,
+                                                      const T& psi) {
+  using std::cos;
+  using std::sin;
+  const T cos_half_theta = cos(theta / 2);
+  const T sin_half_theta = sin(theta / 2);
+  const T phi_plus_half_psi = phi + psi / 2;
+  return Eigen::Quaternion(cos_half_theta * cos(psi / 2),
+                           cos_half_theta * sin(psi / 2),
+                           sin_half_theta * cos(phi_plus_half_psi),
+                           sin_half_theta * sin(phi_plus_half_psi));
+}
+
+/**
+ * Convert a unit-length quaternion (w, x, y, z) to Hopf coordinate as
+ * if w >= 0
+ *   ψ = 2*atan2(x, w)
+ * else
+ *   ψ = 2*atan2(-x, -w)
+ * φ = mod(atan2(z, y) - ψ/2, 2pi)
+ * θ = 2*atan2(√(y²+z²), √(w²+x²))
+ * ψ is in the range of [-pi, pi].
+ * φ is in the range of [0, 2pi].
+ * θ is in the range of [0, pi].
+ * @param quaternion A unit length quaternion.
+ * @return hopf_coordinate (θ, φ, ψ) as an Eigen vector.
+ */
+template <typename T>
+Vector3<T> QuaternionToHopfCoordinate(const Eigen::Quaternion<T>& quaternion) {
+  using std::atan2;
+  const T psi = quaternion.w() >= T(0)
+                    ? 2 * atan2(quaternion.x(), quaternion.w())
+                    : 2 * atan2(-quaternion.x(), -quaternion.w());
+  const T phi_unwrapped = atan2(quaternion.z(), quaternion.y()) - psi / 2;
+  // The range of phi_unwrapped is [-1.5pi, 1.5pi]
+  const T phi = phi_unwrapped >= 0 ? phi_unwrapped : phi_unwrapped + 2 * M_PI;
+  using std::pow;
+  using std::sqrt;
+  const T theta =
+      2 * atan2(sqrt(pow(quaternion.y(), 2) + pow(quaternion.z(), 2)),
+                sqrt(pow(quaternion.w(), 2) + pow(quaternion.x(), 2)));
+  return Vector3<T>(theta, phi, psi);
+}
+}  // namespace math.
+}  // namespace drake

--- a/math/quaternion.h
+++ b/math/quaternion.h
@@ -415,7 +415,7 @@ namespace internal {
  * that the angle is within [0, pi].
  */
 template <typename T>
-Eigen::AngleAxis<T> QuaternionToAngleAxis(
+Eigen::AngleAxis<T> QuaternionToAngleAxisLikeEigen(
     const Eigen::Quaternion<T>& quaternion) {
   Eigen::AngleAxis<T> result;
   using std::atan2;
@@ -428,12 +428,16 @@ Eigen::AngleAxis<T> QuaternionToAngleAxis(
   using std::abs;
   result.angle() = T(2.) * atan2(sin_half_angle_abs, abs(quaternion.w()));
   const Vector3<T> unit_axis(T(1.), T(0.), T(0.));
+  // We use if_then_else here (instead of if statement) because using "if"
+  // with symbolic expression causes runtime error in this case (The symbolic
+  // formula needs to evaluate with an empty symbolic Environment).
+  const boolean<T> is_sin_angle_zero = sin_half_angle_abs == T(0.);
+  const boolean<T> is_w_negative = quaternion.w() < T(0.);
+  const T axis_sign = if_then_else(is_w_negative, T(-1), T(1));
   for (int i = 0; i < 3; ++i) {
     result.axis()(i) =
-        if_then_else(sin_half_angle_abs == T(0.), unit_axis(i),
-                     if_then_else(quaternion.w() < T(0.),
-                                  -quaternion.vec()(i) / sin_half_angle_abs,
-                                  quaternion.vec()(i) / sin_half_angle_abs));
+        if_then_else(is_sin_angle_zero, unit_axis(i),
+                     axis_sign * quaternion.vec()(i) / sin_half_angle_abs);
   }
 
   return result;

--- a/math/quaternion.h
+++ b/math/quaternion.h
@@ -16,6 +16,7 @@
 #include <Eigen/Dense>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_bool.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/is_approx_equal_abstol.h"
 #include "drake/math/rotation_matrix.h"
@@ -418,7 +419,13 @@ Eigen::AngleAxis<T> QuaternionToAngleAxis(
     const Eigen::Quaternion<T>& quaternion) {
   Eigen::AngleAxis<T> result;
   using std::atan2;
-  const T sin_half_angle_abs = quaternion.vec().norm();
+  T sin_half_angle_abs = quaternion.vec().norm();
+  if constexpr (scalar_predicate<T>::is_bool) {
+    if (sin_half_angle_abs < Eigen::NumTraits<T>::epsilon()) {
+      sin_half_angle_abs = quaternion.vec().stableNorm();
+    }
+  }
+  using std::abs;
   result.angle() = T(2.) * atan2(sin_half_angle_abs, abs(quaternion.w()));
   const Vector3<T> unit_axis(T(1.), T(0.), T(0.));
   for (int i = 0; i < 3; ++i) {

--- a/math/random_rotation.h
+++ b/math/random_rotation.h
@@ -51,12 +51,14 @@ Eigen::AngleAxis<T> UniformlyRandomAngleAxis(Generator* generator) {
   using std::atan2;
   result.angle() = T(2.) * atan2(quaternion.vec().norm(), abs(quaternion.w()));
   using std::sin;
-  using symbolic::if_then_else;
   const T sin_half_angle = sin(result.angle() / 2);
+  const Vector3<T> unit_axis(T(1.), T(0.), T(0.));
   for (int i = 0; i < 3; ++i) {
-    result.axis()(i) = if_then_else(quaternion.w() < T(0.),
-                                    -quaternion.vec()(i) / sin_half_angle,
-                                    quaternion.vec()(i) / sin_half_angle);
+    result.axis()(i) =
+        if_then_else(quaternion.w() == T(0.), unit_axis(i),
+                     if_then_else(quaternion.w() < T(0.),
+                                  -quaternion.vec()(i) / sin_half_angle,
+                                  quaternion.vec()(i) / sin_half_angle));
   }
 
   return result;

--- a/math/random_rotation.h
+++ b/math/random_rotation.h
@@ -47,20 +47,7 @@ Eigen::AngleAxis<T> UniformlyRandomAngleAxis(Generator* generator) {
   DRAKE_DEMAND(generator != nullptr);
   const Eigen::Quaternion<T> quaternion =
       UniformlyRandomQuaternion<T>(generator);
-  Eigen::AngleAxis<T> result;
-  using std::atan2;
-  const T sin_half_angle_abs = quaternion.vec().norm();
-  result.angle() = T(2.) * atan2(sin_half_angle_abs, abs(quaternion.w()));
-  const Vector3<T> unit_axis(T(1.), T(0.), T(0.));
-  for (int i = 0; i < 3; ++i) {
-    result.axis()(i) =
-        if_then_else(quaternion.w() == T(0.), unit_axis(i),
-                     if_then_else(quaternion.w() < T(0.),
-                                  -quaternion.vec()(i) / sin_half_angle_abs,
-                                  quaternion.vec()(i) / sin_half_angle_abs));
-  }
-
-  return result;
+  return internal::QuaternionToAngleAxis(quaternion);
 }
 
 /// Generates a rotation (in the rotation matrix representation) that rotates a

--- a/math/random_rotation.h
+++ b/math/random_rotation.h
@@ -13,41 +13,40 @@
 namespace drake {
 namespace math {
 
-/// Generates a rotation (in the axis-angle representation) that rotates a
-/// point on the unit sphere to another point on the unit sphere with a uniform
-/// distribution over the sphere.
-///
-/// Justification for the algorithm can be found in, e.g.:
-/// Mervin E. Muller. 1959. A note on a method for generating points
-/// uniformly on n-dimensional spheres. Commun. ACM 2, 4 (April 1959), 19-20.
-/// DOI=http://dx.doi.org/10.1145/377939.377946
-template <typename T = double, class Generator = RandomGenerator>
-Eigen::AngleAxis<T> UniformlyRandomAngleAxis(Generator* generator) {
-  DRAKE_DEMAND(generator != nullptr);
-  std::normal_distribution<T> normal;
-  std::uniform_real_distribution<T> uniform(-M_PI, M_PI);
-  const T angle = uniform(*generator);
-  const T x = normal(*generator);
-  const T y = normal(*generator);
-  const T z = normal(*generator);
-  Vector3<T> axis = Vector3<T>(x, y, z);
-  if (std::is_same<T, symbolic::Expression>::value) {
-    // Eigen's implementation of normalize has a conditional we skip here.
-    axis /= axis.norm();
-  } else {
-    axis.normalize();
-  }
-  return Eigen::AngleAxis<T>(angle, axis);
-}
-
 /// Generates a rotation (in the quaternion representation) that rotates a
 /// point on the unit sphere to another point on the unit sphere with a uniform
 /// distribution over the sphere.
+/// This method is briefly explained in
+/// http://planning.cs.uiuc.edu/node198.html, a full explanation can be found in
+/// K. Shoemake. Uniform Random Rotations in D. Kirk, editor, Graphics Gems III,
+/// pages 124-132. Academic, New York, 1992.
 template <typename T = double, class Generator = RandomGenerator>
 Eigen::Quaternion<T> UniformlyRandomQuaternion(Generator* generator) {
   DRAKE_DEMAND(generator != nullptr);
-  const Eigen::AngleAxis<T> angle_axis = UniformlyRandomAngleAxis<T>(generator);
-  return Eigen::Quaternion<T>(angle_axis);
+  std::uniform_real_distribution<T> uniform(0., 1.);
+  const T u1 = uniform(*generator);
+  const T u2 = uniform(*generator);
+  const T u3 = uniform(*generator);
+  using std::sqrt;
+  const T sqrt_one_minus_u1 = sqrt(1. - u1);
+  const T sqrt_u1 = sqrt(u1);
+  using std::cos;
+  using std::sin;
+  return Eigen::Quaternion<T>(sqrt_one_minus_u1 * sin(2 * M_PI * u2),
+                              sqrt_one_minus_u1 * cos(2 * M_PI * u2),
+                              sqrt_u1 * sin(2 * M_PI * u3),
+                              sqrt_u1 * cos(2 * M_PI * u3));
+}
+
+/// Generates a rotation (in the axis-angle representation) that rotates a
+/// point on the unit sphere to another point on the unit sphere with a uniform
+/// distribution over the sphere.
+template <typename T = double, class Generator = RandomGenerator>
+Eigen::AngleAxis<T> UniformlyRandomAngleAxis(Generator* generator) {
+  DRAKE_DEMAND(generator != nullptr);
+  const Eigen::Quaternion<T> quaternion =
+      UniformlyRandomQuaternion<T>(generator);
+  return Eigen::AngleAxis<T>(quaternion);
 }
 
 /// Generates a rotation (in the rotation matrix representation) that rotates a
@@ -56,8 +55,9 @@ Eigen::Quaternion<T> UniformlyRandomQuaternion(Generator* generator) {
 template <typename T = double, class Generator = RandomGenerator>
 RotationMatrix<T> UniformlyRandomRotationMatrix(Generator* generator) {
   DRAKE_DEMAND(generator != nullptr);
-  const Eigen::AngleAxis<T> angle_axis = UniformlyRandomAngleAxis<T>(generator);
-  return RotationMatrix<T>(angle_axis);
+  const Eigen::Quaternion<T> quaternion =
+      UniformlyRandomQuaternion<T>(generator);
+  return RotationMatrix<T>(quaternion);
 }
 
 /// Generates a rotation (in the roll-pitch-yaw representation) that rotates a

--- a/math/random_rotation.h
+++ b/math/random_rotation.h
@@ -49,16 +49,15 @@ Eigen::AngleAxis<T> UniformlyRandomAngleAxis(Generator* generator) {
       UniformlyRandomQuaternion<T>(generator);
   Eigen::AngleAxis<T> result;
   using std::atan2;
-  result.angle() = T(2.) * atan2(quaternion.vec().norm(), abs(quaternion.w()));
-  using std::sin;
-  const T sin_half_angle = sin(result.angle() / 2);
+  const T sin_half_angle_abs = quaternion.vec().norm();
+  result.angle() = T(2.) * atan2(sin_half_angle_abs, abs(quaternion.w()));
   const Vector3<T> unit_axis(T(1.), T(0.), T(0.));
   for (int i = 0; i < 3; ++i) {
     result.axis()(i) =
         if_then_else(quaternion.w() == T(0.), unit_axis(i),
                      if_then_else(quaternion.w() < T(0.),
-                                  -quaternion.vec()(i) / sin_half_angle,
-                                  quaternion.vec()(i) / sin_half_angle));
+                                  -quaternion.vec()(i) / sin_half_angle_abs,
+                                  quaternion.vec()(i) / sin_half_angle_abs));
   }
 
   return result;

--- a/math/random_rotation.h
+++ b/math/random_rotation.h
@@ -5,7 +5,6 @@
 #include <Eigen/Dense>
 
 #include "drake/common/constants.h"
-#include "drake/common/double_overloads.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/random.h"
 #include "drake/math/quaternion.h"

--- a/math/random_rotation.h
+++ b/math/random_rotation.h
@@ -46,7 +46,7 @@ Eigen::AngleAxis<T> UniformlyRandomAngleAxis(Generator* generator) {
   DRAKE_DEMAND(generator != nullptr);
   const Eigen::Quaternion<T> quaternion =
       UniformlyRandomQuaternion<T>(generator);
-  return internal::QuaternionToAngleAxis(quaternion);
+  return internal::QuaternionToAngleAxisLikeEigen(quaternion);
 }
 
 /// Generates a rotation (in the rotation matrix representation) that rotates a

--- a/math/test/hopf_coordinate_test.cc
+++ b/math/test/hopf_coordinate_test.cc
@@ -1,0 +1,55 @@
+#include "drake/math/hopf_coordinate.h"
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace math {
+namespace {
+void CheckHopfToQuaternion(double theta, double phi, double psi) {
+  DRAKE_DEMAND(theta >= 0 && theta <= M_PI);
+  DRAKE_DEMAND(phi >= 0 && phi <= 2 * M_PI);
+  DRAKE_DEMAND(psi >= -M_PI && psi <= M_PI);
+  const Eigen::Quaternion quat = HopfCoordinateToQuaternion(theta, phi, psi);
+  const double tol = 1E-14;
+  EXPECT_NEAR(std::pow(quat.w(), 2) + std::pow(quat.x(), 2) +
+                  std::pow(quat.y(), 2) + std::pow(quat.z(), 2),
+              1., tol);
+  const Vector3<double> hopf_coordinate = QuaternionToHopfCoordinate(quat);
+  ASSERT_GE(hopf_coordinate[0], 0);
+  ASSERT_LE(hopf_coordinate[0], M_PI);
+  ASSERT_GE(hopf_coordinate[1], 0);
+  ASSERT_LE(hopf_coordinate[1], 2 * M_PI);
+  ASSERT_GE(hopf_coordinate[2], -M_PI);
+  ASSERT_LE(hopf_coordinate[2], M_PI);
+  if (theta == 0.) {
+    EXPECT_NEAR(hopf_coordinate[0], 0., tol);
+    EXPECT_NEAR(hopf_coordinate[2], psi, tol);
+  } else if (std::abs(theta - M_PI) < 1E-14) {
+    EXPECT_NEAR(hopf_coordinate[0], M_PI, tol);
+    EXPECT_NEAR(std::fmod(std::abs(hopf_coordinate[1] + hopf_coordinate[2] / 2 -
+                                   (phi + psi / 2)),
+                          2 * M_PI),
+                0., tol);
+  } else {
+    EXPECT_NEAR(hopf_coordinate(0), theta, tol);
+    EXPECT_NEAR(std::fmod(std::abs(hopf_coordinate(1) - phi), 2 * M_PI), 0,
+                tol);
+    EXPECT_NEAR(hopf_coordinate(2), psi, tol);
+  }
+}
+
+GTEST_TEST(TestHopfCoordinate, TestQuaternion) {
+  const Eigen::VectorXd theta_all = Eigen::VectorXd::LinSpaced(11, 0, M_PI);
+  const Eigen::VectorXd phi_all = Eigen::VectorXd::LinSpaced(21, 0, 2 * M_PI);
+  const Eigen::VectorXd psi_all = Eigen::VectorXd::LinSpaced(21, -M_PI, M_PI);
+  for (int i = 0; i < theta_all.rows(); ++i) {
+    for (int j = 0; j < phi_all.rows(); ++j) {
+      for (int k = 0; k < psi_all.rows(); ++k) {
+        CheckHopfToQuaternion(theta_all(i), phi_all(j), psi_all(k));
+      }
+    }
+  }
+}
+}  // namespace
+}  // namespace math
+}  // namespace drake

--- a/math/test/quaternion_test.cc
+++ b/math/test/quaternion_test.cc
@@ -258,7 +258,58 @@ GTEST_TEST(IsQuaternionAndQuaternionDtEqualAngularVelocityExpressedInB, testA) {
   EXPECT_FALSE(b);
 }
 
+void CheckQuaternionToAngleAxis(const Eigen::Quaternion<double>& quaternion) {
+  const Eigen::AngleAxisd angle_axis =
+      internal::QuaternionToAngleAxis(quaternion);
+  const Eigen::AngleAxisd angle_axis_expected(quaternion);
+  EXPECT_GE(angle_axis.angle(), 0.);
+  EXPECT_LE(angle_axis.angle(), M_PI);
+  EXPECT_DOUBLE_EQ(angle_axis.angle(), angle_axis_expected.angle());
+  EXPECT_TRUE(CompareMatrices(angle_axis.axis(), angle_axis_expected.axis()));
+}
 
+GTEST_TEST(TestQuaternionToAngleAxis, TestDouble) {
+  CheckQuaternionToAngleAxis(Eigen::Quaterniond(1., 0., 0., 0.));
+  CheckQuaternionToAngleAxis(Eigen::Quaterniond(-1., 0., 0., 0.));
+  CheckQuaternionToAngleAxis(Eigen::Quaterniond(0., 1., 0., 0.));
+  CheckQuaternionToAngleAxis(Eigen::Quaterniond(0., -1., 0., 0.));
+  CheckQuaternionToAngleAxis(Eigen::Quaterniond(0., 0., 1., 0.));
+  CheckQuaternionToAngleAxis(Eigen::Quaterniond(0., 0., -1., 0.));
+  CheckQuaternionToAngleAxis(Eigen::Quaterniond(0., 0., 0., 1.));
+  CheckQuaternionToAngleAxis(Eigen::Quaterniond(0., 0., 0., -1.));
+  CheckQuaternionToAngleAxis(
+      Eigen::Quaterniond(1. / 2., 1. / 2., 1. / 2., 1. / 2));
+  CheckQuaternionToAngleAxis(
+      Eigen::Quaterniond(-1. / 2., 1. / 2., 1. / 2., 1. / 2));
+  CheckQuaternionToAngleAxis(
+      Eigen::Quaterniond(1. / 2., -1. / 2., 1. / 2., 1. / 2));
+  CheckQuaternionToAngleAxis(
+      Eigen::Quaterniond(1. / 2., -1. / 2., -1. / 2., 1. / 2));
+  CheckQuaternionToAngleAxis(
+      Eigen::Quaterniond(1. / 3., -2. / 3., -2. / 3., 0.));
+  CheckQuaternionToAngleAxis(Eigen::Quaterniond(1. / 3., 2. / 3., 2. / 3., 0.));
+  CheckQuaternionToAngleAxis(Eigen::Quaterniond(0., 1. / 3., 2. / 3., 2. / 3.));
+  CheckQuaternionToAngleAxis(
+      Eigen::Quaterniond(0., 1. / 3., -2. / 3., 2. / 3.));
+  CheckQuaternionToAngleAxis(
+      Eigen::Quaterniond(0., 2. / 3., -1. / 3., 2. / 3.));
+  CheckQuaternionToAngleAxis(Eigen::Quaterniond(1. / 3, 2. / 3., 0., 2. / 3.));
+}
+
+GTEST_TEST(TestQuaternionToAngleAxis, TestSymbolic) {
+  const symbolic::Variable w("w");
+  const symbolic::Variable x("x");
+  const symbolic::Variable y("y");
+  const symbolic::Variable z("z");
+
+  const Eigen::Quaternion<symbolic::Expression> quaternion(w, x, y, z);
+  const Eigen::AngleAxis<symbolic::Expression> angle_axis =
+      internal::QuaternionToAngleAxis(quaternion);
+  EXPECT_EQ(angle_axis.angle().GetVariables().size(), 4);
+  for (int i = 0; i < 3; ++i) {
+    EXPECT_EQ(angle_axis.axis()(i).GetVariables().size(), 4);
+  }
+}
 }  // namespace quaternion_test
 }  // namespace math
 }  // namespace drake

--- a/math/test/quaternion_test.cc
+++ b/math/test/quaternion_test.cc
@@ -261,7 +261,7 @@ GTEST_TEST(IsQuaternionAndQuaternionDtEqualAngularVelocityExpressedInB, testA) {
 void CheckQuaternionToAngleAxis(double w, double x, double y, double z) {
   const Eigen::Quaternion quaternion(w, x, y, z);
   const Eigen::AngleAxisd angle_axis =
-      internal::QuaternionToAngleAxis(quaternion);
+      internal::QuaternionToAngleAxisLikeEigen(quaternion);
   const Eigen::AngleAxisd angle_axis_expected(quaternion);
   EXPECT_GE(angle_axis.angle(), 0.);
   EXPECT_LE(angle_axis.angle(), M_PI);
@@ -269,7 +269,7 @@ void CheckQuaternionToAngleAxis(double w, double x, double y, double z) {
   EXPECT_TRUE(CompareMatrices(angle_axis.axis(), angle_axis_expected.axis()));
 }
 
-GTEST_TEST(TestQuaternionToAngleAxis, TestDouble) {
+GTEST_TEST(TestQuaternionToAngleAxisLikeEigen, TestDouble) {
   CheckQuaternionToAngleAxis(1., 0., 0., 0.);
   CheckQuaternionToAngleAxis(-1., 0., 0., 0.);
   CheckQuaternionToAngleAxis(0., 1., 0., 0.);
@@ -290,7 +290,7 @@ GTEST_TEST(TestQuaternionToAngleAxis, TestDouble) {
   CheckQuaternionToAngleAxis(1. / 3, 2. / 3., 0., 2. / 3.);
 }
 
-GTEST_TEST(TestQuaternionToAngleAxis, TestSymbolic) {
+GTEST_TEST(TestQuaternionToAngleAxisLikeEigen, TestSymbolic) {
   const symbolic::Variable w("w");
   const symbolic::Variable x("x");
   const symbolic::Variable y("y");
@@ -298,7 +298,7 @@ GTEST_TEST(TestQuaternionToAngleAxis, TestSymbolic) {
 
   const Eigen::Quaternion<symbolic::Expression> quaternion(w, x, y, z);
   const Eigen::AngleAxis<symbolic::Expression> angle_axis =
-      internal::QuaternionToAngleAxis(quaternion);
+      internal::QuaternionToAngleAxisLikeEigen(quaternion);
   EXPECT_EQ(angle_axis.angle().GetVariables().size(), 4);
   for (int i = 0; i < 3; ++i) {
     EXPECT_EQ(angle_axis.axis()(i).GetVariables().size(), 4);

--- a/math/test/quaternion_test.cc
+++ b/math/test/quaternion_test.cc
@@ -258,7 +258,8 @@ GTEST_TEST(IsQuaternionAndQuaternionDtEqualAngularVelocityExpressedInB, testA) {
   EXPECT_FALSE(b);
 }
 
-void CheckQuaternionToAngleAxis(const Eigen::Quaternion<double>& quaternion) {
+void CheckQuaternionToAngleAxis(double w, double x, double y, double z) {
+  const Eigen::Quaternion quaternion(w, x, y, z);
   const Eigen::AngleAxisd angle_axis =
       internal::QuaternionToAngleAxis(quaternion);
   const Eigen::AngleAxisd angle_axis_expected(quaternion);
@@ -269,31 +270,24 @@ void CheckQuaternionToAngleAxis(const Eigen::Quaternion<double>& quaternion) {
 }
 
 GTEST_TEST(TestQuaternionToAngleAxis, TestDouble) {
-  CheckQuaternionToAngleAxis(Eigen::Quaterniond(1., 0., 0., 0.));
-  CheckQuaternionToAngleAxis(Eigen::Quaterniond(-1., 0., 0., 0.));
-  CheckQuaternionToAngleAxis(Eigen::Quaterniond(0., 1., 0., 0.));
-  CheckQuaternionToAngleAxis(Eigen::Quaterniond(0., -1., 0., 0.));
-  CheckQuaternionToAngleAxis(Eigen::Quaterniond(0., 0., 1., 0.));
-  CheckQuaternionToAngleAxis(Eigen::Quaterniond(0., 0., -1., 0.));
-  CheckQuaternionToAngleAxis(Eigen::Quaterniond(0., 0., 0., 1.));
-  CheckQuaternionToAngleAxis(Eigen::Quaterniond(0., 0., 0., -1.));
-  CheckQuaternionToAngleAxis(
-      Eigen::Quaterniond(1. / 2., 1. / 2., 1. / 2., 1. / 2));
-  CheckQuaternionToAngleAxis(
-      Eigen::Quaterniond(-1. / 2., 1. / 2., 1. / 2., 1. / 2));
-  CheckQuaternionToAngleAxis(
-      Eigen::Quaterniond(1. / 2., -1. / 2., 1. / 2., 1. / 2));
-  CheckQuaternionToAngleAxis(
-      Eigen::Quaterniond(1. / 2., -1. / 2., -1. / 2., 1. / 2));
-  CheckQuaternionToAngleAxis(
-      Eigen::Quaterniond(1. / 3., -2. / 3., -2. / 3., 0.));
-  CheckQuaternionToAngleAxis(Eigen::Quaterniond(1. / 3., 2. / 3., 2. / 3., 0.));
-  CheckQuaternionToAngleAxis(Eigen::Quaterniond(0., 1. / 3., 2. / 3., 2. / 3.));
-  CheckQuaternionToAngleAxis(
-      Eigen::Quaterniond(0., 1. / 3., -2. / 3., 2. / 3.));
-  CheckQuaternionToAngleAxis(
-      Eigen::Quaterniond(0., 2. / 3., -1. / 3., 2. / 3.));
-  CheckQuaternionToAngleAxis(Eigen::Quaterniond(1. / 3, 2. / 3., 0., 2. / 3.));
+  CheckQuaternionToAngleAxis(1., 0., 0., 0.);
+  CheckQuaternionToAngleAxis(-1., 0., 0., 0.);
+  CheckQuaternionToAngleAxis(0., 1., 0., 0.);
+  CheckQuaternionToAngleAxis(0., -1., 0., 0.);
+  CheckQuaternionToAngleAxis(0., 0., 1., 0.);
+  CheckQuaternionToAngleAxis(0., 0., -1., 0.);
+  CheckQuaternionToAngleAxis(0., 0., 0., 1.);
+  CheckQuaternionToAngleAxis(0., 0., 0., -1.);
+  CheckQuaternionToAngleAxis(1. / 2., 1. / 2., 1. / 2., 1. / 2);
+  CheckQuaternionToAngleAxis(-1. / 2., 1. / 2., 1. / 2., 1. / 2);
+  CheckQuaternionToAngleAxis(1. / 2., -1. / 2., 1. / 2., 1. / 2);
+  CheckQuaternionToAngleAxis(1. / 2., -1. / 2., -1. / 2., 1. / 2);
+  CheckQuaternionToAngleAxis(1. / 3., -2. / 3., -2. / 3., 0.);
+  CheckQuaternionToAngleAxis(1. / 3., 2. / 3., 2. / 3., 0.);
+  CheckQuaternionToAngleAxis(0., 1. / 3., 2. / 3., 2. / 3.);
+  CheckQuaternionToAngleAxis(0., 1. / 3., -2. / 3., 2. / 3.);
+  CheckQuaternionToAngleAxis(0., 2. / 3., -1. / 3., 2. / 3.);
+  CheckQuaternionToAngleAxis(1. / 3, 2. / 3., 0., 2. / 3.);
 }
 
 GTEST_TEST(TestQuaternionToAngleAxis, TestSymbolic) {

--- a/math/test/random_rotation_test.cc
+++ b/math/test/random_rotation_test.cc
@@ -32,6 +32,7 @@ void CheckUniformAngleAxes(const std::vector<Orientation>& orientations,
   for (const auto& orientation : orientations) {
     const int interval_index =
         floor(Eigen::AngleAxisd(orientation).angle() / h);
+    DRAKE_DEMAND(interval_index < num_intervals);
     count[interval_index]++;
   }
   // cdf[i] is the cdf of theta up to h * i

--- a/math/test/random_rotation_test.cc
+++ b/math/test/random_rotation_test.cc
@@ -33,6 +33,7 @@ void CheckUniformAngleAxes(const std::vector<Orientation>& orientations,
     const int interval_index =
         floor(Eigen::AngleAxisd(orientation).angle() / h);
     DRAKE_DEMAND(interval_index < num_intervals);
+    DRAKE_DEMAND(interval_index >= 0);
     count[interval_index]++;
   }
   // cdf[i] is the cdf of theta up to h * i

--- a/math/test/random_rotation_test.cc
+++ b/math/test/random_rotation_test.cc
@@ -74,8 +74,10 @@ GTEST_TEST(RandomRotationTest, Symbolic) {
 
   const Eigen::AngleAxis<symbolic::Expression> axis_angle =
       UniformlyRandomAngleAxis<symbolic::Expression>(&generator);
-  EXPECT_EQ(axis_angle.angle().GetVariables().size(), 1);
-  EXPECT_EQ(axis_angle.axis()[0].GetVariables().size(), 3);
+  EXPECT_EQ(axis_angle.angle().GetVariables().size(), 3);
+  for (int i = 0; i < 3; ++i) {
+    EXPECT_EQ(axis_angle.axis()[i].GetVariables().size(), 3);
+  }
 
   const Eigen::Quaternion<symbolic::Expression> quaternion =
       UniformlyRandomQuaternion<symbolic::Expression>(&generator);

--- a/math/test/random_rotation_test.cc
+++ b/math/test/random_rotation_test.cc
@@ -87,11 +87,11 @@ void CheckUniformHopfCoordinate(
     }
   }
   for (const auto& hopf : hopf_coordinates) {
-    const int theta_idx = std::floor(hopf[0] / (M_PI / num_intervals));
-    const int phi_idx = std::floor(hopf[1] / (2 * M_PI / num_intervals));
-    const int psi_idx =
+    const int theta_index = std::floor(hopf[0] / (M_PI / num_intervals));
+    const int phi_index = std::floor(hopf[1] / (2 * M_PI / num_intervals));
+    const int psi_index =
         std::floor((hopf[2] + M_PI) / (2 * M_PI / num_intervals));
-    counts[theta_idx][phi_idx][psi_idx]++;
+    counts.at(theta_index).at(phi_index).at(psi_index)++;
   }
   const int N = static_cast<int>(hopf_coordinates.size());
 

--- a/math/test/random_rotation_test.cc
+++ b/math/test/random_rotation_test.cc
@@ -72,11 +72,10 @@ GTEST_TEST(RandomRotationTest, UniformlyRandomRotation) {
 GTEST_TEST(RandomRotationTest, Symbolic) {
   RandomGenerator generator;
 
-  // Somehow angle_axis doesn't support symbolic computation.
-  // const Eigen::AngleAxis<symbolic::Expression> axis_angle =
-  //    UniformlyRandomAngleAxis<symbolic::Expression>(&generator);
-  // EXPECT_EQ(axis_angle.angle().GetVariables().size(), 1);
-  // EXPECT_EQ(axis_angle.axis()[0].GetVariables().size(), 3);
+  const Eigen::AngleAxis<symbolic::Expression> axis_angle =
+      UniformlyRandomAngleAxis<symbolic::Expression>(&generator);
+  EXPECT_EQ(axis_angle.angle().GetVariables().size(), 1);
+  EXPECT_EQ(axis_angle.axis()[0].GetVariables().size(), 3);
 
   const Eigen::Quaternion<symbolic::Expression> quaternion =
       UniformlyRandomQuaternion<symbolic::Expression>(&generator);

--- a/math/test/random_rotation_test.cc
+++ b/math/test/random_rotation_test.cc
@@ -8,21 +8,90 @@ namespace drake {
 namespace math {
 namespace {
 
+/**
+ * According to wikipedia
+ * https://en.wikipedia.org/wiki/Rotation_matrix#Uniform_random_rotation_matrices
+ * the cdf of θ angle should be 1/π (θ - sinθ) if 0 <= θ <= π.
+ * Basic confidence interval statistics.  See, for instance,
+ *    Simulation and the Monte Carlo Method (Third Edition)
+ *      by Rubinstein and Kroese, 2017
+ *    page 108,
+ * where I've used Y as the indicator function of a ≤ X ≤ a+h,
+ * E[Y] = Phi(a+h)-Phi(a), Var(Y) = E[Y]-E[Y]², since E[Y²]=E[Y],
+ * and Phi(x) is the cdf of the standard normal distribution.
+ * We expect a perfect sampler to obtain a value
+ *    count/N = E[Y] ± 1.645 √(Var(Y)/N)
+ * with 95% confidence.  Checks that our pseudo-random sampler
+ * accomplishes this bound within a factor of fudge_factor.
+ */
+template <typename Orientation>
+void CheckUniformAngleAxes(const std::vector<Orientation>& orientations,
+                           int num_intervals, double fudge_factor) {
+  const double h = M_PI / num_intervals;
+  std::vector<int> count(num_intervals, 0);
+  for (const auto& orientation : orientations) {
+    const int interval_index =
+        floor(Eigen::AngleAxisd(orientation).angle() / h);
+    count[interval_index]++;
+  }
+  // cdf[i] is the cdf of theta up to h * i
+  std::vector<double> cdf(num_intervals + 1, 0);
+  for (int i = 1; i < num_intervals + 1; ++i) {
+    const double theta_up = h * i;
+    cdf[i] = 1. / M_PI * (theta_up - std::sin(theta_up));
+  }
+
+  for (int i = 0; i < num_intervals; ++i) {
+    const double EY = cdf[i + 1] - cdf[i];
+    const double VarY = EY - EY * EY;
+    EXPECT_NEAR(static_cast<double>(count[i]) / orientations.size(), EY,
+                fudge_factor * 1.645 * std::sqrt(VarY / orientations.size()));
+  }
+}
+
+GTEST_TEST(RandomRotationTest, UniformlyRandomRotation) {
+  RandomGenerator generator;
+
+  const int num_samples = 100000;
+  std::vector<Eigen::Quaterniond> quaternions(num_samples);
+  std::vector<Eigen::AngleAxisd> angle_axes(num_samples);
+  std::vector<Eigen::Matrix3d> rotation_matrices(num_samples);
+  for (int i = 0; i < num_samples; ++i) {
+    quaternions[i] = UniformlyRandomQuaternion<double>(&generator);
+    angle_axes[i] = UniformlyRandomAngleAxis<double>(&generator);
+    rotation_matrices[i] =
+        UniformlyRandomRotationMatrix<double>(&generator).matrix();
+  }
+  const int num_intervals = 20;
+  const double fudge_factor = 2;
+  CheckUniformAngleAxes(quaternions, num_intervals, fudge_factor);
+  CheckUniformAngleAxes(angle_axes, num_intervals, fudge_factor);
+  CheckUniformAngleAxes(rotation_matrices, num_intervals, fudge_factor);
+}
+
 GTEST_TEST(RandomRotationTest, Symbolic) {
   RandomGenerator generator;
 
-  const Eigen::AngleAxis<symbolic::Expression> axis_angle =
-      UniformlyRandomAngleAxis<symbolic::Expression>(&generator);
-  EXPECT_EQ(axis_angle.angle().GetVariables().size(), 1);
-  EXPECT_EQ(axis_angle.axis()[0].GetVariables().size(), 3);
+  // Somehow angle_axis doesn't support symbolic computation.
+  // const Eigen::AngleAxis<symbolic::Expression> axis_angle =
+  //    UniformlyRandomAngleAxis<symbolic::Expression>(&generator);
+  // EXPECT_EQ(axis_angle.angle().GetVariables().size(), 1);
+  // EXPECT_EQ(axis_angle.axis()[0].GetVariables().size(), 3);
 
   const Eigen::Quaternion<symbolic::Expression> quaternion =
       UniformlyRandomQuaternion<symbolic::Expression>(&generator);
-  EXPECT_EQ(quaternion.x().GetVariables().size(), 4);
+  EXPECT_EQ(quaternion.w().GetVariables().size(), 2);
+  EXPECT_EQ(quaternion.x().GetVariables().size(), 2);
+  EXPECT_EQ(quaternion.y().GetVariables().size(), 2);
+  EXPECT_EQ(quaternion.z().GetVariables().size(), 2);
 
   const RotationMatrix<symbolic::Expression> rotation_matrix =
       UniformlyRandomRotationMatrix<symbolic::Expression>(&generator);
-  EXPECT_EQ(rotation_matrix.matrix()(0, 0).GetVariables().size(), 4);
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      EXPECT_EQ(rotation_matrix.matrix()(i, j).GetVariables().size(), 3);
+    }
+  }
 
   // TODO(russt): Add UniformlyRandomRPY test once RollPitchYaw supports
   // symbolic::Expression.

--- a/math/test/random_rotation_test.cc
+++ b/math/test/random_rotation_test.cc
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/symbolic.h"
+#include "drake/math/hopf_coordinate.h"
 
 namespace drake {
 namespace math {
@@ -51,6 +52,66 @@ void CheckUniformAngleAxes(const std::vector<Orientation>& orientations,
   }
 }
 
+// We use Hopf coordinates to divide the range of [0, π] x [0, 2π] x [-π, π]
+// into grids. According to equation 5 in "Generating Uniform Incremental Grids
+// on SO(3) Using the Hopf Fibration" by A Yershova, S. LaValle and J. Mitchell,
+// the surface value of the Hopf coordinate (θ, φ, ψ) is dV = sinθdθdφdψ. So we
+// can compute the measure of each cell in the grid. Using basic confidence
+// interval statistics.  See, for instance,
+//    Simulation and the Monte Carlo Method (Third Edition)
+//      by Rubinstein and Kroese, 2017
+//    page 108,
+// where I've used Y as the indicator function of the Hopf coordinate in a given
+// cell. E[Y] = measure of that cell, Var(Y) = E[Y]-E[Y]², since E[Y²]=E[Y],
+// We expect a perfect sampler to obtain a value
+//    count/N = E[Y] ± 1.645 √(Var(Y)/N)
+// with 95% confidence.  Checks that our pseudo-random sampler
+// accomplishes this bound within a factor of fudge_factor.
+void CheckUniformHopfCoordinate(
+    const std::vector<Eigen::Vector3d>& hopf_coordinates, int num_intervals,
+    double fudge_factor) {
+  const Eigen::VectorXd theta_all =
+      Eigen::VectorXd::LinSpaced(num_intervals + 1, 0, M_PI);
+  const Eigen::VectorXd phi_all =
+      Eigen::VectorXd::LinSpaced(num_intervals + 1, 0, 2 * M_PI);
+  const Eigen::VectorXd psi_all =
+      Eigen::VectorXd::LinSpaced(num_intervals + 1, -M_PI, M_PI);
+  std::vector<std::vector<std::vector<int>>> counts(num_intervals);
+  for (int i = 0; i < num_intervals; ++i) {
+    counts[i].resize(num_intervals);
+    for (int j = 0; j < num_intervals; ++j) {
+      counts[i][j].resize(num_intervals);
+      for (int k = 0; k < num_intervals; ++k) {
+        counts[i][j][k] = 0;
+      }
+    }
+  }
+  for (const auto& hopf : hopf_coordinates) {
+    const int theta_idx = std::floor(hopf[0] / (M_PI / num_intervals));
+    const int phi_idx = std::floor(hopf[1] / (2 * M_PI / num_intervals));
+    const int psi_idx =
+        std::floor((hopf[2] + M_PI) / (2 * M_PI / num_intervals));
+    counts[theta_idx][phi_idx][psi_idx]++;
+  }
+  const int N = static_cast<int>(hopf_coordinates.size());
+
+  // The total measure of SO(3) is ∫dV=∫∫∫sinθdθdφdψ=8π²
+  // Now compute the measure of each cell.
+  for (int i = 0; i < num_intervals; ++i) {
+    for (int j = 0; j < num_intervals; ++j) {
+      for (int k = 0; k < num_intervals; ++k) {
+        const double cell_measure =
+            (std::cos(theta_all[i]) - std::cos(theta_all[i + 1])) *
+            (phi_all[j + 1] - phi_all[j]) * (psi_all[k + 1] - psi_all[k]);
+        const double EY = cell_measure / (8 * std::pow(M_PI, 2));
+        const double VarY = EY - EY * EY;
+        EXPECT_NEAR(static_cast<double>(counts[i][j][k]) / N, EY,
+                    fudge_factor * 1.645 * std::sqrt(VarY / N));
+      }
+    }
+  }
+}
+
 GTEST_TEST(RandomRotationTest, UniformlyRandomRotation) {
   RandomGenerator generator;
 
@@ -58,17 +119,20 @@ GTEST_TEST(RandomRotationTest, UniformlyRandomRotation) {
   std::vector<Eigen::Quaterniond> quaternions(num_samples);
   std::vector<Eigen::AngleAxisd> angle_axes(num_samples);
   std::vector<Eigen::Matrix3d> rotation_matrices(num_samples);
+  std::vector<Eigen::Vector3d> hopf_coordinates(num_samples);
   for (int i = 0; i < num_samples; ++i) {
     quaternions[i] = UniformlyRandomQuaternion<double>(&generator);
     angle_axes[i] = UniformlyRandomAngleAxis<double>(&generator);
     rotation_matrices[i] =
         UniformlyRandomRotationMatrix<double>(&generator).matrix();
+    hopf_coordinates[i] = QuaternionToHopfCoordinate(quaternions[i]);
   }
   const int num_intervals = 20;
   const double fudge_factor = 2;
   CheckUniformAngleAxes(quaternions, num_intervals, fudge_factor);
   CheckUniformAngleAxes(angle_axes, num_intervals, fudge_factor);
   CheckUniformAngleAxes(rotation_matrices, num_intervals, fudge_factor);
+  CheckUniformHopfCoordinate(hopf_coordinates, 10, fudge_factor);
 }
 
 GTEST_TEST(RandomRotationTest, Symbolic) {


### PR DESCRIPTION
Resolves #10319 

@soonho-tri , could you please take a look at this PR? I found that now UniformlyRandomAngleAxis<T>() doesn't work for T = symbolic::Expression. You could uncomment the line https://github.com/hongkai-dai/drake/blob/61ec160b2ad50381124e2ac7a7153d4cbbca104b/math/test/random_rotation_test.cc#L76-L77, the code throws an error
```
unknown file: Failure
C++ exception with description "The following environment does not have an entry for the variable random_uniform_0

" thrown in the test body.
```
And I checked that the environment is empty. On the contrary, we could still use `UniformlyRandomRotationMatrix<symbolic::Expression>()`. Both `UniformlyRandomRotationMatrix` and `UniformlyRandomAngleAxis` calls `UniformlyRandomQuaternion`. I suspect the reason why the rotation matrix works, while angle axis doesn't, is that converting quaternion to angle axis requires an "if" statement, and when we use symbolic expression with if statement, it somehow generates a symbolic formula, and the symbolic engine doesn't work (I don't fully understand why symbolic formula doesn't work here). On the other hand, converting a quaternion to a rotation matrix doesn't require any if statement.

I am OK to forbid instantiating `UniformlyRandomAngleAxis<symbolic::Expression>`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12562)
<!-- Reviewable:end -->
