### PR TITLE
Purge RigidBody from examples/Acrobot

### DIFF
--- a/examples/acrobot/Acrobot.urdf
+++ b/examples/acrobot/Acrobot.urdf
@@ -65,7 +65,12 @@
       </geometry>
     </collision>
   </link>
-  
+
+  <joint name="base_weld" type="fixed">
+    <parent link="world" />
+    <child link="base_link" />
+  </joint>
+
   <joint name="shoulder" type="continuous">
     <parent link="base_link" />
     <child link="upper_link" />

--- a/examples/acrobot/BUILD.bazel
+++ b/examples/acrobot/BUILD.bazel
@@ -68,6 +68,22 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "acrobot_geometry",
+    srcs = ["acrobot_geometry.cc"],
+    hdrs = ["acrobot_geometry.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":acrobot_params",
+        ":acrobot_plant",
+        "//geometry:geometry_roles",
+        "//geometry:scene_graph",
+        "//math:geometric_transform",
+        "//systems/framework:diagram_builder",
+        "//systems/framework:leaf_system",
+    ],
+)
+
+drake_cc_library(
     name = "spong_controller",
     srcs = ["spong_controller.cc"],
     hdrs = ["spong_controller.h"],
@@ -102,18 +118,14 @@ drake_cc_binary(
     name = "run_lqr",
     srcs = ["run_lqr.cc"],
     add_test_rule = 1,
-    data = [":models"],
     test_rule_args = [
         "-simulation_sec=1.0",
         "-realtime_factor=0.0",
     ],
     deps = [
+        ":acrobot_geometry",
         ":acrobot_plant",
-        "//attic/multibody:rigid_body_tree",
-        "//attic/multibody/parsers",
-        "//attic/multibody/rigid_body_plant:drake_visualizer",
-        "//common:find_resource",
-        "//lcm",
+        "//geometry:geometry_visualization",
         "//systems/analysis:simulator",
         "@gflags",
     ],
@@ -124,20 +136,15 @@ drake_cc_binary(
     testonly = 1,
     srcs = ["run_lqr_w_estimator.cc"],
     add_test_rule = 1,
-    data = [":models"],
     test_rule_args = [
         "-simulation_sec=1.0",
         "-realtime_factor=0.0",
     ],
     deps = [
+        ":acrobot_geometry",
         ":acrobot_plant",
-        "//attic/multibody:rigid_body_tree",
-        "//attic/multibody/joints",
-        "//attic/multibody/parsers",
-        "//attic/multibody/rigid_body_plant:drake_visualizer",
-        "//common:find_resource",
         "//common/proto:call_python",
-        "//lcm",
+        "//geometry:geometry_visualization",
         "//systems/analysis:simulator",
         "//systems/estimators:kalman_filter",
         "//systems/framework:diagram",
@@ -152,19 +159,14 @@ drake_cc_binary(
     name = "run_passive",
     srcs = ["run_passive.cc"],
     add_test_rule = 1,
-    data = [":models"],
     test_rule_args = [
         "-simulation_sec=1.0",
         "-realtime_factor=0.0",
     ],
     deps = [
+        ":acrobot_geometry",
         ":acrobot_plant",
-        "//attic/multibody:rigid_body_tree",
-        "//attic/multibody/joints",
-        "//attic/multibody/parsers",
-        "//attic/multibody/rigid_body_plant:drake_visualizer",
-        "//common:find_resource",
-        "//lcm",
+        "//geometry:geometry_visualization",
         "//systems/analysis:simulator",
         "//systems/framework:diagram",
         "@gflags",
@@ -177,22 +179,17 @@ drake_cc_binary(
         "run_swing_up.cc",
     ],
     add_test_rule = 1,
-    data = [":models"],
     test_rule_args = [
         # N.B. We can't set -simulation_sec here, because the demo program has
         # success criteria that it asserts after the simulation expires.
         "-realtime_factor=0.0",
     ],
     deps = [
+        ":acrobot_geometry",
         ":acrobot_plant",
         ":spong_controller",
         ":spong_controller_params",
-        "//attic/multibody:rigid_body_tree",
-        "//attic/multibody/joints",
-        "//attic/multibody/parsers",
-        "//attic/multibody/rigid_body_plant:drake_visualizer",
-        "//common:find_resource",
-        "//lcm",
+        "//geometry:geometry_visualization",
         "//systems/analysis",
         "@gflags",
     ],
@@ -202,18 +199,13 @@ drake_cc_binary(
     name = "run_swing_up_traj_optimization",
     srcs = ["test/run_swing_up_traj_optimization.cc"],
     add_test_rule = 1,
-    data = [":models"],
     test_rule_args = ["-realtime_factor=0.0"],
     # Non-deterministic IPOPT-related failures on macOS, see #10276.
     test_rule_flaky = 1,
     deps = [
+        ":acrobot_geometry",
         ":acrobot_plant",
-        "//attic/multibody:rigid_body_tree",
-        "//attic/multibody/joints",
-        "//attic/multibody/parsers",
-        "//attic/multibody/rigid_body_plant:drake_visualizer",
-        "//common:find_resource",
-        "//lcm",
+        "//geometry:geometry_visualization",
         "//solvers:solve",
         "//systems/analysis",
         "//systems/controllers:linear_quadratic_regulator",
@@ -249,23 +241,27 @@ drake_cc_binary(
     name = "run_plant_w_lcm",
     srcs = ["run_plant_w_lcm.cc"],
     add_test_rule = 1,
-    data = [":models"],
     test_rule_args = [
         "-simulation_sec=1.0",
         "-realtime_factor=0.0",
     ],
     test_rule_size = "medium",
     deps = [
+        ":acrobot_geometry",
         ":acrobot_lcm",
         ":acrobot_plant",
-        "//attic/multibody/parsers",
-        "//attic/multibody/rigid_body_plant",
-        "//attic/multibody/rigid_body_plant:drake_visualizer",
-        "//common:find_resource",
-        "//lcm",
+        "//geometry:geometry_visualization",
         "//systems/analysis",
         "//systems/controllers:linear_quadratic_regulator",
         "@gflags",
+    ],
+)
+
+drake_cc_googletest(
+    name = "acrobot_geometry_test",
+    deps = [
+        ":acrobot_geometry",
+        ":acrobot_plant",
     ],
 )
 
@@ -274,11 +270,9 @@ drake_cc_googletest(
     data = [":models"],
     deps = [
         ":acrobot_plant",
-        "//attic/multibody/joints",
-        "//attic/multibody/parsers",
-        "//attic/multibody/rigid_body_plant",
         "//common:find_resource",
         "//common/test_utilities:eigen_matrix_compare",
+        "//multibody/parsing",
     ],
 )
 

--- a/examples/acrobot/acrobot_geometry.cc
+++ b/examples/acrobot/acrobot_geometry.cc
@@ -1,0 +1,113 @@
+#include "drake/examples/acrobot/acrobot_geometry.h"
+
+#include <memory>
+
+#include "drake/examples/acrobot/gen/acrobot_params.h"
+#include "drake/geometry/geometry_frame.h"
+#include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/geometry_instance.h"
+#include "drake/geometry/geometry_roles.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/math/rotation_matrix.h"
+
+namespace drake {
+namespace examples {
+namespace acrobot {
+
+using Eigen::Vector3d;
+using Eigen::Vector4d;
+using geometry::Box;
+using geometry::Cylinder;
+using geometry::GeometryFrame;
+using geometry::GeometryId;
+using geometry::GeometryInstance;
+using geometry::MakePhongIllustrationProperties;
+using geometry::Sphere;
+using std::make_unique;
+
+const AcrobotGeometry* AcrobotGeometry::AddToBuilder(
+    systems::DiagramBuilder<double>* builder,
+    const systems::OutputPort<double>& acrobot_state_port,
+    const AcrobotParams<double>& acrobot_params,
+    geometry::SceneGraph<double>* scene_graph) {
+  DRAKE_THROW_UNLESS(builder != nullptr);
+  DRAKE_THROW_UNLESS(scene_graph != nullptr);
+
+  auto acrobot_geometry = builder->AddSystem(std::unique_ptr<AcrobotGeometry>(
+      new AcrobotGeometry(acrobot_params, scene_graph)));
+  builder->Connect(acrobot_state_port, acrobot_geometry->get_input_port(0));
+  builder->Connect(
+      acrobot_geometry->get_output_port(0),
+      scene_graph->get_source_pose_port(acrobot_geometry->source_id_));
+
+  return acrobot_geometry;
+}
+
+AcrobotGeometry::AcrobotGeometry(const AcrobotParams<double>& params,
+                                 geometry::SceneGraph<double>* scene_graph)
+    : l1_(params.l1()) {
+  DRAKE_THROW_UNLESS(scene_graph != nullptr);
+  source_id_ = scene_graph->RegisterSource();
+
+  // Note: using AcrobotState as the port type would have complicated the
+  // trajectory playback workflow used in run_swing_up_traj_optimization.cc.
+  this->DeclareVectorInputPort("state", systems::BasicVector<double>(4));
+  this->DeclareAbstractOutputPort("geometry_pose",
+                                  &AcrobotGeometry::OutputGeometryPose);
+
+  // The base.
+  GeometryId id = scene_graph->RegisterAnchoredGeometry(
+      source_id_,
+      make_unique<GeometryInstance>(math::RigidTransformd::Identity(),
+                                    make_unique<Box>(.2, 0.2, 0.2), "base"));
+  scene_graph->AssignRole(
+      source_id_, id, MakePhongIllustrationProperties(Vector4d(0, 1, 0, 1)));
+
+  // The upper link.
+  upper_link_frame_id_ =
+      scene_graph->RegisterFrame(source_id_, GeometryFrame("upper_link"));
+  id = scene_graph->RegisterGeometry(
+      source_id_, upper_link_frame_id_,
+      make_unique<GeometryInstance>(
+          math::RigidTransformd(Vector3d(0., 0.15, -params.l1() / 2.)),
+          make_unique<Cylinder>(0.05, params.l1()), "upper_link"));
+  scene_graph->AssignRole(
+      source_id_, id, MakePhongIllustrationProperties(Vector4d(1, 0, 0, 1)));
+
+  // The lower link.
+  lower_link_frame_id_ =
+      scene_graph->RegisterFrame(source_id_, GeometryFrame("lower_link"));
+  id = scene_graph->RegisterGeometry(
+      source_id_, lower_link_frame_id_,
+      make_unique<GeometryInstance>(
+          math::RigidTransformd(Vector3d(0., 0.25, -params.l2() / 2.)),
+          make_unique<Cylinder>(0.05, params.l2()), "lower_link"));
+  scene_graph->AssignRole(
+      source_id_, id, MakePhongIllustrationProperties(Vector4d(0, 0, 1, 1)));
+}
+
+AcrobotGeometry::~AcrobotGeometry() = default;
+
+void AcrobotGeometry::OutputGeometryPose(
+    const systems::Context<double>& context,
+    geometry::FramePoseVector<double>* poses) const {
+  DRAKE_DEMAND(upper_link_frame_id_.is_valid());
+  DRAKE_DEMAND(lower_link_frame_id_.is_valid());
+
+  // TODO(russt): Use AcrobotState here upon resolution of #12566.
+  const auto& input =
+      get_input_port(0).Eval<systems::BasicVector<double>>(context);
+  const double theta1 = input[0], theta2 = input[1];
+  const math::RigidTransformd upper_link_pose(
+      math::RotationMatrixd::MakeYRotation(theta1));
+  const math::RigidTransformd lower_link_pose(
+      math::RotationMatrixd::MakeYRotation(theta1 + theta2),
+      Vector3d(-l1_ * std::sin(theta1), 0, -l1_ * std::cos(theta1)));
+
+  *poses = {{upper_link_frame_id_, upper_link_pose},
+            {lower_link_frame_id_, lower_link_pose}};
+}
+
+}  // namespace acrobot
+}  // namespace examples
+}  // namespace drake

--- a/examples/acrobot/acrobot_geometry.h
+++ b/examples/acrobot/acrobot_geometry.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "drake/examples/acrobot/gen/acrobot_params.h"
+#include "drake/geometry/scene_graph.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace examples {
+namespace acrobot {
+
+/// Expresses an AcrobotPlant's geometry to a SceneGraph.
+///
+/// @system{AcrobotGeometry,
+///    @input_port{state},
+///    @output_port{geometry_pose}
+/// }
+///
+/// This class has no public constructor; instead use the AddToBuilder() static
+/// method to create and add it to a DiagramBuilder directly.
+class AcrobotGeometry final : public systems::LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(AcrobotGeometry);
+  ~AcrobotGeometry() final;
+
+  /// Creates, adds, and connects an AcrobotGeometry system into the given
+  /// `builder`.  Both the `acrobot_state.get_system()` and `scene_graph`
+  /// systems must have been added to the given `builder` already.
+  ///
+  /// The `scene_graph` pointer is not retained by the %AcrobotGeometry
+  /// system.  The return value pointer is an alias of the new
+  /// %AcrobotGeometry system that is owned by the `builder`.
+  static const AcrobotGeometry* AddToBuilder(
+      systems::DiagramBuilder<double>* builder,
+      const systems::OutputPort<double>& acrobot_state_port,
+      const AcrobotParams<double>& acrobot_params,
+      geometry::SceneGraph<double>* scene_graph);
+
+ private:
+  AcrobotGeometry(const AcrobotParams<double>& acrobot_params,
+                  geometry::SceneGraph<double>*);
+  void OutputGeometryPose(const systems::Context<double>&,
+                          geometry::FramePoseVector<double>*) const;
+
+  // Geometry source identifier for this system to interact with SceneGraph.
+  geometry::SourceId source_id_{};
+  // The frames for the two links.
+  geometry::FrameId upper_link_frame_id_{};
+  geometry::FrameId lower_link_frame_id_{};
+
+  // Local copy of the parameter required for the forward kinematics (the
+  // length of the upper link).
+  const double l1_;
+};
+
+}  // namespace acrobot
+}  // namespace examples
+}  // namespace drake

--- a/examples/acrobot/acrobot_params.named_vector
+++ b/examples/acrobot/acrobot_params.named_vector
@@ -26,6 +26,13 @@ element {
     min_value: "0.0"
 }
 element {
+    name: "l2"
+    doc: "Length of link 2."
+    doc_units: "m"
+    default_value: "2.0"
+    min_value: "0.0"
+}
+element {
     name: "lc1"
     doc: "Vertical distance from shoulder joint to center of mass of link 1."
     doc_units: "m"

--- a/examples/acrobot/run_lqr.cc
+++ b/examples/acrobot/run_lqr.cc
@@ -2,14 +2,10 @@
 
 #include <gflags/gflags.h>
 
-#include "drake/common/find_resource.h"
+#include "drake/examples/acrobot/acrobot_geometry.h"
 #include "drake/examples/acrobot/acrobot_plant.h"
 #include "drake/examples/acrobot/gen/acrobot_state.h"
-#include "drake/lcm/drake_lcm.h"
-#include "drake/multibody/joints/floating_base_types.h"
-#include "drake/multibody/parsers/urdf_parser.h"
-#include "drake/multibody/rigid_body_plant/drake_visualizer.h"
-#include "drake/multibody/rigid_body_tree.h"
+#include "drake/geometry/geometry_visualization.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram.h"
 #include "drake/systems/framework/diagram_builder.h"
@@ -33,18 +29,14 @@ DEFINE_double(realtime_factor, 1.0,
               "Simulator::set_target_realtime_rate() for details.");
 
 int do_main() {
-  lcm::DrakeLcm lcm;
-  auto tree = std::make_unique<RigidBodyTree<double>>();
-  parsers::urdf::AddModelInstanceFromUrdfFileToWorld(
-      FindResourceOrThrow("drake/examples/acrobot/Acrobot.urdf"),
-      multibody::joints::kFixed, tree.get());
-
   systems::DiagramBuilder<double> builder;
   auto acrobot = builder.AddSystem<AcrobotPlant>();
   acrobot->set_name("acrobot");
-  auto publisher = builder.AddSystem<systems::DrakeVisualizer>(*tree, &lcm);
-  publisher->set_name("publisher");
-  builder.Connect(acrobot->get_output_port(0), publisher->get_input_port(0));
+  auto scene_graph = builder.AddSystem<geometry::SceneGraph>();
+  AcrobotGeometry::AddToBuilder(
+      &builder, acrobot->get_output_port(0),
+      AcrobotParams<double>(), scene_graph);
+  ConnectDrakeVisualizer(&builder, *scene_graph);
 
   auto controller = builder.AddSystem(BalancingLQRController(*acrobot));
   controller->set_name("controller");

--- a/examples/acrobot/run_plant_w_lcm.cc
+++ b/examples/acrobot/run_plant_w_lcm.cc
@@ -14,15 +14,12 @@
 
 #include <gflags/gflags.h>
 
-#include "drake/common/find_resource.h"
+#include "drake/examples/acrobot/acrobot_geometry.h"
 #include "drake/examples/acrobot/acrobot_lcm.h"
 #include "drake/examples/acrobot/acrobot_plant.h"
+#include "drake/geometry/geometry_visualization.h"
 #include "drake/lcmt_acrobot_u.hpp"
 #include "drake/lcmt_acrobot_x.hpp"
-#include "drake/multibody/joints/floating_base_types.h"
-#include "drake/multibody/parsers/urdf_parser.h"
-#include "drake/multibody/rigid_body_plant/drake_visualizer.h"
-#include "drake/multibody/rigid_body_tree.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/framework/leaf_system.h"
@@ -48,16 +45,16 @@ int DoMain() {
   drake::systems::DiagramBuilder<double> builder;
   const std::string channel_x = "acrobot_xhat";
   const std::string channel_u = "acrobot_u";
-
-  auto tree = std::make_unique<RigidBodyTree<double>>();
-  parsers::urdf::AddModelInstanceFromUrdfFileToWorld(
-      FindResourceOrThrow("drake/examples/acrobot/Acrobot.urdf"),
-      multibody::joints::kFixed, tree.get());
   auto lcm = builder.AddSystem<systems::lcm::LcmInterfaceSystem>();
-  auto publisher = builder.AddSystem<systems::DrakeVisualizer>(*tree, lcm);
+
   auto acrobot = builder.AddSystem<AcrobotPlant>();
-  // Connects plant to visualizer.
-  builder.Connect(acrobot->get_output_port(0), publisher->get_input_port(0));
+  acrobot->set_name("acrobot");
+
+  auto scene_graph = builder.AddSystem<geometry::SceneGraph>();
+  AcrobotGeometry::AddToBuilder(
+      &builder, acrobot->get_output_port(0),
+      AcrobotParams<double>(), scene_graph);
+  ConnectDrakeVisualizer(&builder, *scene_graph, lcm);
 
   // Creates command receiver and subscriber.
   auto command_sub = builder.AddSystem(

--- a/examples/acrobot/run_swing_up.cc
+++ b/examples/acrobot/run_swing_up.cc
@@ -2,15 +2,12 @@
 
 #include <gflags/gflags.h>
 
-#include "drake/common/find_resource.h"
+#include "drake/examples/acrobot/acrobot_geometry.h"
 #include "drake/examples/acrobot/acrobot_plant.h"
 #include "drake/examples/acrobot/gen/acrobot_state.h"
 #include "drake/examples/acrobot/spong_controller.h"
-#include "drake/lcm/drake_lcm.h"
+#include "drake/geometry/geometry_visualization.h"
 #include "drake/math/wrap_to.h"
-#include "drake/multibody/joints/floating_base_types.h"
-#include "drake/multibody/parsers/urdf_parser.h"
-#include "drake/multibody/rigid_body_plant/drake_visualizer.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram_builder.h"
 
@@ -30,16 +27,14 @@ DEFINE_double(realtime_factor, 1.0,
               "Simulator::set_target_realtime_rate() for details.");
 
 int do_main() {
-  lcm::DrakeLcm lcm;
-  auto tree = std::make_unique<RigidBodyTree<double>>();
-  parsers::urdf::AddModelInstanceFromUrdfFileToWorld(
-      FindResourceOrThrow("drake/examples/acrobot/Acrobot.urdf"),
-      multibody::joints::kFixed, tree.get());
-
   systems::DiagramBuilder<double> builder;
   auto acrobot = builder.AddSystem<AcrobotPlant>();
-  auto publisher = builder.AddSystem<systems::DrakeVisualizer>(*tree, &lcm);
-  builder.Connect(acrobot->get_output_port(0), publisher->get_input_port(0));
+  acrobot->set_name("acrobot");
+  auto scene_graph = builder.AddSystem<geometry::SceneGraph>();
+  AcrobotGeometry::AddToBuilder(
+      &builder, acrobot->get_output_port(0),
+      AcrobotParams<double>(), scene_graph);
+  ConnectDrakeVisualizer(&builder, *scene_graph);
 
   auto controller = builder.AddSystem<AcrobotSpongController>();
   builder.Connect(acrobot->get_output_port(0), controller->get_input_port(0));

--- a/examples/acrobot/spong_controller_w_lcm.cc
+++ b/examples/acrobot/spong_controller_w_lcm.cc
@@ -1,5 +1,5 @@
 /*
- * An acrobot Spong controller that communicates to acrobot_plang_w_lcm
+ * An acrobot Spong controller that communicates to run_plant_w_lcm
  * through LCM, implemented by the following diagram system:
  *
  * LcmSubscriberSystem—>

--- a/examples/acrobot/test/acrobot_geometry_test.cc
+++ b/examples/acrobot/test/acrobot_geometry_test.cc
@@ -1,0 +1,29 @@
+#include "drake/examples/acrobot/acrobot_geometry.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/examples/acrobot/acrobot_plant.h"
+#include "drake/geometry/scene_graph.h"
+#include "drake/systems/framework/diagram_builder.h"
+
+namespace drake {
+namespace examples {
+namespace acrobot {
+namespace {
+
+GTEST_TEST(AcrobotGeometryTest, AcceptanceTest) {
+  // Just make sure nothing faults out.
+  systems::DiagramBuilder<double> builder;
+  auto plant = builder.AddSystem<AcrobotPlant>();
+  auto scene_graph = builder.AddSystem<geometry::SceneGraph>();
+  auto geom = AcrobotGeometry::AddToBuilder(
+      &builder, plant->get_output_port(0), AcrobotParams<double>(),
+          scene_graph);
+  auto diagram = builder.Build();
+  ASSERT_NE(geom, nullptr);
+}
+
+}  // namespace
+}  // namespace acrobot
+}  // namespace examples
+}  // namespace drake

--- a/examples/pendulum/pendulum_geometry.cc
+++ b/examples/pendulum/pendulum_geometry.cc
@@ -16,8 +16,6 @@ namespace drake {
 namespace examples {
 namespace pendulum {
 
-using Eigen::Isometry3d;
-using Eigen::Translation3d;
 using Eigen::Vector3d;
 using Eigen::Vector4d;
 using geometry::Box;
@@ -51,7 +49,7 @@ const PendulumGeometry* PendulumGeometry::AddToBuilder(
 
 PendulumGeometry::PendulumGeometry(geometry::SceneGraph<double>* scene_graph) {
   DRAKE_THROW_UNLESS(scene_graph != nullptr);
-  source_id_ = scene_graph->RegisterSource("pendulum");
+  source_id_ = scene_graph->RegisterSource();
   frame_id_ = scene_graph->RegisterFrame(source_id_, GeometryFrame("arm"));
 
   this->DeclareVectorInputPort("state", PendulumState<double>());


### PR DESCRIPTION
Adds AcrobotGeometry (mostly because I couldn't wait for #10775) and uses it throughout the acrobot examples.
Follows the workflow used in `PendulumGeometry` and `QuadrotorGeometry`.
Progress towards  https://github.com/RussTedrake/underactuated/issues/203

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12567)
<!-- Reviewable:end -->
