### PR TITLE
py deprecation: Remove "Please see ..." addendum

### DIFF
--- a/bindings/pydrake/common/deprecation.py
+++ b/bindings/pydrake/common/deprecation.py
@@ -98,12 +98,7 @@ class ModuleShim(object):
 class DrakeDeprecationWarning(DeprecationWarning):
     """Extends `DeprecationWarning` to permit Drake-specific warnings to
     be filtered by default, without having side effects on other libraries."""
-    addendum = ("\n    Please see `help(pydrake.common.deprecation)` " +
-                "for more information.")
-
-    def __init__(self, message, *args):
-        extra_message = message + DrakeDeprecationWarning.addendum
-        DeprecationWarning.__init__(self, extra_message, *args)
+    pass
 
 
 def _warn_deprecated(message, stacklevel=2):

--- a/bindings/pydrake/common/test/deprecation_test.py
+++ b/bindings/pydrake/common/test/deprecation_test.py
@@ -136,7 +136,6 @@ class TestDeprecation(unittest.TestCase):
     def _check_warning(self, item, message_expected, check_full=True):
         self.assertEqual(item.category, DrakeDeprecationWarning)
         if check_full:
-            message_expected += DrakeDeprecationWarning.addendum
             self.assertEqual(message_expected, str(item.message))
         else:
             self.assertIn(message_expected, str(item.message))


### PR DESCRIPTION
I've found this text to not really be useful? It provides some info about how to filter deprecations, but doesn't provide information specific to the deprecation, so I figure it should be removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12578)
<!-- Reviewable:end -->
