### PR TITLE
Deprecate iiwa_wsg_simulation

### DIFF
--- a/examples/kuka_iiwa_arm/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/BUILD.bazel
@@ -61,6 +61,7 @@ drake_cc_library(
     name = "oracular_state_estimator",
     srcs = ["oracular_state_estimator.cc"],
     hdrs = ["oracular_state_estimator.h"],
+    copts = ["-Wno-deprecated-declarations"],
     visibility = ["//visibility:public"],
     deps = [
         "//attic/manipulation/util:robot_state_msg_translator",
@@ -123,6 +124,7 @@ drake_cc_binary(
     name = "iiwa_wsg_simulation",
     srcs = ["iiwa_wsg_simulation.cc"],
     add_test_rule = 1,
+    copts = ["-Wno-deprecated-declarations"],
     data = [
         ":models",
         "//manipulation/models/iiwa_description:models",

--- a/examples/kuka_iiwa_arm/iiwa_world/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/iiwa_world/BUILD.bazel
@@ -9,7 +9,6 @@ load(
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 drake_cc_library(
-    # TODO(hongkai.dai): move this package to manipulation folder.
     name = "iiwa_wsg_diagram_factory",
     srcs = [
         "iiwa_wsg_diagram_factory.cc",
@@ -17,6 +16,7 @@ drake_cc_library(
     hdrs = [
         "iiwa_wsg_diagram_factory.h",
     ],
+    copts = ["-Wno-deprecated-declarations"],
     visibility = ["//visibility:public"],
     deps = [
         "//attic/manipulation/util:sim_diagram_builder",
@@ -69,6 +69,7 @@ drake_cc_binary(
 
 drake_cc_googletest(
     name = "iiwa_wsg_diagram_factory_test",
+    copts = ["-Wno-deprecated-declarations"],
     data = [
         "//examples/kuka_iiwa_arm:models",
         "//manipulation/models/iiwa_description:models",

--- a/examples/kuka_iiwa_arm/iiwa_world/README.md
+++ b/examples/kuka_iiwa_arm/iiwa_world/README.md
@@ -1,0 +1,2 @@
+The code in this drake/examples/kuka_iiwa_arm/iiwa_world folder is
+deprecated and will be removed from Drake on 2020-05-01.

--- a/examples/kuka_iiwa_arm/iiwa_world/iiwa_wsg_diagram_factory.h
+++ b/examples/kuka_iiwa_arm/iiwa_world/iiwa_wsg_diagram_factory.h
@@ -4,6 +4,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/examples/kuka_iiwa_arm/oracular_state_estimator.h"
 #include "drake/manipulation/util/world_sim_tree_builder.h"
 #include "drake/multibody/rigid_body_plant/rigid_body_plant.h"
@@ -34,7 +35,9 @@ namespace kuka_iiwa_arm {
 ///
 /// - double
 template <typename T>
-class IiwaAndWsgPlantWithStateEstimator : public systems::Diagram<T> {
+class DRAKE_DEPRECATED("2020-05-01",
+                       "IiwaAndWsgPlantWithStateEstimator is being removed.")
+IiwaAndWsgPlantWithStateEstimator : public systems::Diagram<T> {
  public:
   /// Constructs the IiwaAndWsgPlantWithStateEstimator.
   /// @param combined_plant a systems::RigidBodyPlant containing some number of

--- a/examples/kuka_iiwa_arm/iiwa_wsg_simulation.cc
+++ b/examples/kuka_iiwa_arm/iiwa_wsg_simulation.cc
@@ -12,6 +12,7 @@
 
 #include <gflags/gflags.h>
 
+#include "drake/common/text_logging.h"
 #include "drake/examples/kuka_iiwa_arm/iiwa_common.h"
 #include "drake/examples/kuka_iiwa_arm/iiwa_lcm.h"
 #include "drake/examples/kuka_iiwa_arm/iiwa_world/iiwa_wsg_diagram_factory.h"
@@ -140,6 +141,9 @@ std::unique_ptr<RigidBodyPlant<T>> BuildCombinedPlant(
 }
 
 int DoMain() {
+  drake::log()->warn("DRAKE_DEPRECATED: iiwa_wsg_simulation is deprecated "
+                     "and will be removed from Drake on 2020-05-01.");
+
   systems::DiagramBuilder<double> builder;
 
   ModelInstanceInfo<double> iiwa_instance, wsg_instance, box_instance;

--- a/examples/kuka_iiwa_arm/oracular_state_estimator.h
+++ b/examples/kuka_iiwa_arm/oracular_state_estimator.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/manipulation/util/robot_state_msg_translator.h"
 #include "drake/multibody/rigid_body_tree.h"
 #include "drake/systems/framework/leaf_system.h"
@@ -28,7 +29,9 @@ namespace kuka_iiwa_arm {
  * See manipulation::RobotStateLcmMessageTranslator for more details.
  */
 template <typename T>
-class OracularStateEstimation : public systems::LeafSystem<T> {
+class DRAKE_DEPRECATED("2020-05-01",
+                       "OracularStateEstimation is being removed.")
+OracularStateEstimation : public systems::LeafSystem<T> {
  public:
   /**
    * Constructor for OracularStateEstimation.


### PR DESCRIPTION
It was built on a lot of RBT infrastructure.  manipulation_station is
a more modern example of the same idea.

Replaces #12580

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12581)
<!-- Reviewable:end -->
