### PR TITLE
Allows SceneGraph::AssignRole to update proximity properties

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -304,6 +304,7 @@ drake_cc_googletest(
         ":proximity_engine",
         ":shape_specification",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_no_throw",
         "//common/test_utilities:expect_throws_message",
         "//math",
     ],

--- a/geometry/geometry_roles.h
+++ b/geometry/geometry_roles.h
@@ -147,7 +147,8 @@ namespace geometry {
  <!-- TODO(SeanCurtis-TRI): When the hydroelastic geometry module is written,
   put a reference to the discussion of ProximityProperties here.  -->
  Examples of functionality that depends on the proximity role:
-   - n/a
+ <!-- TODO(SeanCurtis-TRI): Write up a module on hydroelastic proximity
+       properties and link to that.  -->
  */
 class ProximityProperties final : public GeometryProperties {
  public:

--- a/geometry/internal_geometry.h
+++ b/geometry/internal_geometry.h
@@ -171,7 +171,8 @@ class InternalGeometry {
    engine's understanding as well.  */
   //@{
 
-  /** Assigns a proximity role to this geometry.  */
+  /** Assigns a proximity role to this geometry, replacing any properties that
+   were previously assigned.  */
   void SetRole(ProximityProperties properties) {
     proximity_props_ = std::move(properties);
   }

--- a/geometry/proximity_engine.h
+++ b/geometry/proximity_engine.h
@@ -114,6 +114,24 @@ class ProximityEngine {
                            const math::RigidTransformd& X_WG, GeometryId id,
                            const ProximityProperties& props = {});
 
+  /** Possibly updates the proximity representation of the given `geometry`
+   based on the relationship between its _current_ proximity properties and the
+   given _new_ proximity properties. The underlying representation may not
+   change if the change in proximity properties isn't of significance to the
+   %ProximityEngine.
+
+   @param geometry          The geometry to update.
+   @param new_properties    The properties to associate with the given geometry.
+   @throws std::logic_error   if `geometry` doesn't map to a known geometry in
+                              the engine or if the new properties trigger work
+                              that can't meaningfully be completed because of
+                              incomplete or inconsistent property definitions.
+   @pre `geometry` still has a copy of the original proximity properties that
+         are to be replaced.  */
+  void UpdateRepresentationForNewProperties(
+      const InternalGeometry& geometry,
+      const ProximityProperties& new_properties);
+
   // TODO(SeanCurtis-TRI): Decide if knowing whether something is dynamic or not
   //  is *actually* sufficiently helpful to justify this act.
   /** Removes the given geometry indicated by `id` from the engine.

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -210,15 +210,21 @@ class QueryObject {
        | Convex    |  no   |  no   |
 
      - One geometry must be soft, and the other must be rigid. There is no
-       support for soft-soft collision or rigid-rigid collision.
+       support for soft-soft collision or rigid-rigid collision. If such
+       pairs collide, an exception will be thrown. More particularly, if such
+       a pair *cannot be culled* an exception will be thrown. No exception
+       is thrown if the pair has been filtered.
      - The elasticity modulus E (N/m^2) of each geometry is set in
-       ProximityProperties (see proximity_properties.cc). A rigid geometry must
-       have E = ∞.
+       ProximityProperties (see AddContactMaterial()).
      - The tessellation of the corresponding meshes is controlled by the
        resolution hint, as defined by AddSoftHydroelasticProperties() and
        AddRigidHydroelasticProperties().
-     - Attempting to invoke this method with T = AutoDiffXd will throw an
-       exception if there are *any* geometry pairs that couldn't be culled.
+
+   <h3>Scalar support</h3>
+
+   This method provides support only for double. Attempting to invoke this
+   method with T = AutoDiffXd will throw an exception if there are *any*
+   geometry pairs that couldn't be culled.
 
    @returns A vector populated with all detected intersections characterized as
             contact surfaces.  */


### PR DESCRIPTION
This properly enables calling `SceneGraph::AssignRole` with `kReplace`. It promises that the hydroelastic representation reflects the newest set or properties.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12585)
<!-- Reviewable:end -->
