### PR TITLE
MultibodyPositionToGeometryPose can now own its own MBP

### DIFF
--- a/bindings/pydrake/systems/rendering_py.cc
+++ b/bindings/pydrake/systems/rendering_py.cc
@@ -109,8 +109,10 @@ PYBIND11_MODULE(rendering, m) {
   py::class_<MultibodyPositionToGeometryPose<T>, LeafSystem<T>>(m,
       "MultibodyPositionToGeometryPose",
       doc.MultibodyPositionToGeometryPose.doc)
-      .def(py::init<const multibody::MultibodyPlant<T>&>(),
-          doc.MultibodyPositionToGeometryPose.ctor.doc)
+      .def(py::init<const multibody::MultibodyPlant<T>&>(), py::arg("plant"),
+          // Keep alive, reference: `self` keeps `plant` alive.
+          py::keep_alive<1, 2>(),
+          doc.MultibodyPositionToGeometryPose.ctor.doc_1args_plant)
       .def("get_input_port",
           &MultibodyPositionToGeometryPose<T>::get_input_port,
           py_reference_internal,

--- a/bindings/pydrake/systems/test/rendering_test.py
+++ b/bindings/pydrake/systems/test/rendering_test.py
@@ -204,7 +204,7 @@ class TestRendering(unittest.TestCase):
         plant.RegisterAsSourceForSceneGraph(scene_graph)
         plant.Finalize()
 
-        to_pose = MultibodyPositionToGeometryPose(plant)
+        to_pose = MultibodyPositionToGeometryPose(plant=plant)
 
         # Check the size of the input.
         self.assertEqual(to_pose.get_input_port().size(), 2)

--- a/systems/rendering/test/multibody_position_to_geometry_pose_test.cc
+++ b/systems/rendering/test/multibody_position_to_geometry_pose_test.cc
@@ -4,6 +4,7 @@
 
 #include "drake/common/find_resource.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/multibody/plant/multibody_plant.h"
 
@@ -12,16 +13,85 @@ namespace systems {
 namespace rendering {
 namespace {
 
+using geometry::SceneGraph;
+using multibody::BodyIndex;
+using multibody::MultibodyPlant;
+using multibody::Parser;
+using std::make_unique;
+using std::move;
+
+GTEST_TEST(MultibodyPositionToGeometryPoseTest, BadConstruction) {
+  {
+    MultibodyPlant<double> mbp(0.0);
+    mbp.Finalize();
+
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        MultibodyPositionToGeometryPose<double>{mbp}, std::logic_error,
+        "MultibodyPositionToGeometryPose requires a MultibodyPlant that has "
+        "been registered with a SceneGraph");
+  }
+
+  {
+    MultibodyPlant<double> mbp(0.0);
+    SceneGraph<double> scene_graph;
+    mbp.RegisterAsSourceForSceneGraph(&scene_graph);
+    Parser(&mbp).AddModelFromFile(
+        FindResourceOrThrow("drake/manipulation/models/iiwa_description/iiwa7"
+                            "/iiwa7_no_collision.sdf"));
+    DRAKE_EXPECT_THROWS_MESSAGE(MultibodyPositionToGeometryPose<double>{mbp},
+                                std::logic_error,
+                                "MultibodyPositionToGeometryPose requires a "
+                                "MultibodyPlant that has been finalized");
+  }
+}
+
+GTEST_TEST(MultibodyPositionToGeometryPoseTest, Ownership) {
+  auto mbp = make_unique<MultibodyPlant<double>>(0.0);
+  auto raw_ptr = mbp.get();
+  SceneGraph<double> scene_graph;
+  mbp->RegisterAsSourceForSceneGraph(&scene_graph);
+  Parser(mbp.get()).AddModelFromFile(
+      FindResourceOrThrow("drake/manipulation/models/iiwa_description/iiwa7"
+                          "/iiwa7_no_collision.sdf"));
+  mbp->Finalize();
+
+  const MultibodyPositionToGeometryPose<double> dut(move(mbp));
+
+  EXPECT_EQ(&dut.multibody_plant(), raw_ptr);
+  EXPECT_TRUE(dut.owns_plant());
+
+  auto context = dut.CreateDefaultContext();
+
+  const Eigen::VectorXd position =
+      Eigen::VectorXd::LinSpaced(raw_ptr->num_positions(), 0.123, 0.456);
+  dut.get_input_port().FixValue(context.get(), position);
+
+  const auto& output =
+      dut.get_output_port().Eval<geometry::FramePoseVector<double>>(*context);
+  for (BodyIndex i(0); i < raw_ptr->num_bodies(); ++i) {
+    if (i == raw_ptr->world_body().index()) {
+      // The world geometry will not appear in the poses.
+      continue;
+    }
+    const std::optional<geometry::FrameId> id =
+        raw_ptr->GetBodyFrameIdIfExists(i);
+    EXPECT_TRUE(id.has_value());
+    EXPECT_TRUE(output.has_id(id.value()));
+  }
+  EXPECT_EQ(output.size(), raw_ptr->num_bodies() - 1);
+}
+
 GTEST_TEST(MultibodyPositionToGeometryPoseTest, InputOutput) {
-  multibody::MultibodyPlant<double> mbp(0.0);
-  geometry::SceneGraph<double> scene_graph;
+  MultibodyPlant<double> mbp(0.0);
+  SceneGraph<double> scene_graph;
   mbp.RegisterAsSourceForSceneGraph(&scene_graph);
-  multibody::Parser(&mbp).AddModelFromFile(
+  Parser(&mbp).AddModelFromFile(
       FindResourceOrThrow("drake/manipulation/models/iiwa_description/iiwa7"
                           "/iiwa7_no_collision.sdf"));
   mbp.Finalize();
 
   const MultibodyPositionToGeometryPose<double> dut(mbp);
+  EXPECT_FALSE(dut.owns_plant());
 
   EXPECT_EQ(dut.get_input_port().get_index(), 0);
   EXPECT_EQ(dut.get_output_port().get_index(), 0);
@@ -35,7 +105,7 @@ GTEST_TEST(MultibodyPositionToGeometryPoseTest, InputOutput) {
 
   const auto& output =
       dut.get_output_port().Eval<geometry::FramePoseVector<double>>(*context);
-  for (multibody::BodyIndex i(0); i < mbp.num_bodies(); i++) {
+  for (BodyIndex i(0); i < mbp.num_bodies(); ++i) {
     if (i == mbp.world_body().index()) {
       // The world geometry will not appear in the poses.
       continue;
@@ -44,7 +114,7 @@ GTEST_TEST(MultibodyPositionToGeometryPoseTest, InputOutput) {
     EXPECT_TRUE(id.has_value());
     EXPECT_TRUE(output.has_id(id.value()));
   }
-  EXPECT_EQ(output.size(), mbp.num_bodies()-1);
+  EXPECT_EQ(output.size(), mbp.num_bodies() - 1);
 }
 
 }  // namespace


### PR DESCRIPTION
This gives the `MultibodyPositionToGeometryPose` class the ability to own its MBP giving a new avenue to eliminate coordinating lifespan issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12588)
<!-- Reviewable:end -->
