### PR TITLE
Add utility for setting contact material properties generally

### DIFF
--- a/examples/multibody/rolling_sphere/make_rolling_sphere_plant.cc
+++ b/examples/multibody/rolling_sphere/make_rolling_sphere_plant.cc
@@ -10,12 +10,9 @@ namespace examples {
 namespace multibody {
 namespace bouncing_ball {
 
+using drake::geometry::AddContactMaterial;
 using drake::geometry::AddRigidHydroelasticProperties;
 using drake::geometry::AddSoftHydroelasticProperties;
-using drake::geometry::internal::kElastic;
-using drake::geometry::internal::kFriction;
-using drake::geometry::internal::kHcDissipation;
-using drake::geometry::internal::kMaterialGroup;
 using drake::geometry::ProximityProperties;
 using drake::geometry::SceneGraph;
 using drake::geometry::Sphere;
@@ -47,7 +44,7 @@ std::unique_ptr<drake::multibody::MultibodyPlant<double>> MakeBouncingBallPlant(
     RigidTransformd X_WG{Vector3<double>(0, 0, -size / 2)};
     ProximityProperties box_props;
     AddRigidHydroelasticProperties(size, &box_props);
-    box_props.AddProperty(kMaterialGroup, kFriction, surface_friction);
+    AddContactMaterial({}, {}, surface_friction, &box_props);
     plant->RegisterCollisionGeometry(plant->world_body(), X_WG,
                                      geometry::Box(size, size, size),
                                      "collision", std::move(box_props));
@@ -61,12 +58,8 @@ std::unique_ptr<drake::multibody::MultibodyPlant<double>> MakeBouncingBallPlant(
     const RigidTransformd X_BS = RigidTransformd::Identity();
     // Set material properties for hydroelastics.
     ProximityProperties ball_props;
-    // TODO(SeanCurtis-TRI): Simplify this with addition of
-    //  geometry::AddContactMaterial().
-    ball_props.AddProperty(kMaterialGroup, kElastic, elastic_modulus);
-    ball_props.AddProperty(kMaterialGroup,
-                           kHcDissipation, dissipation);
-    ball_props.AddProperty(kMaterialGroup, kFriction, surface_friction);
+    AddContactMaterial(elastic_modulus, dissipation, surface_friction,
+                       &ball_props);
     AddSoftHydroelasticProperties(radius, &ball_props);
     plant->RegisterCollisionGeometry(ball, X_BS, Sphere(radius), "collision",
                                      std::move(ball_props));

--- a/examples/scene_graph/simple_contact_surface_vis.cc
+++ b/examples/scene_graph/simple_contact_surface_vis.cc
@@ -48,6 +48,7 @@ using geometry::FramePoseVector;
 using geometry::GeometryFrame;
 using geometry::GeometryId;
 using geometry::GeometryInstance;
+using geometry::AddContactMaterial;
 using geometry::AddRigidHydroelasticProperties;
 using geometry::AddSoftHydroelasticProperties;
 using geometry::IllustrationProperties;
@@ -99,8 +100,7 @@ class MovingBall final : public LeafSystem<double> {
                                       make_unique<Sphere>(1.0), "ball"));
 
     ProximityProperties prox_props;
-    prox_props.AddProperty(geometry::internal::kMaterialGroup,
-                           geometry::internal::kElastic, 1e8);
+    AddContactMaterial(1e8, {}, {}, &prox_props);
     AddSoftHydroelasticProperties(FLAGS_length, &prox_props);
     scene_graph->AssignRole(source_id_, geometry_id_, prox_props);
 
@@ -250,10 +250,6 @@ int do_main() {
       make_unique<GeometryInstance>(
           X_WB, make_unique<Box>(edge_len, edge_len, edge_len), "box"));
   ProximityProperties rigid_props;
-  // A rigid hydroelastic geometry must have an infinite elastic modulus.
-  rigid_props.AddProperty(geometry::internal::kMaterialGroup,
-                          geometry::internal::kElastic,
-                          std::numeric_limits<double>::infinity());
   AddRigidHydroelasticProperties(edge_len, &rigid_props);
   scene_graph.AssignRole(source_id, ground_id, rigid_props);
   IllustrationProperties illus_props;

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -169,6 +169,7 @@ drake_cc_library(
     hdrs = ["proximity_properties.h"],
     deps = [
         ":geometry_roles",
+        "//multibody/plant:coulomb_friction",
     ],
 )
 
@@ -368,6 +369,7 @@ drake_cc_googletest(
     deps = [
         ":geometry_roles",
         ":proximity_properties",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/geometry/proximity/test/hydroelastic_callback_test.cc
+++ b/geometry/proximity/test/hydroelastic_callback_test.cc
@@ -34,8 +34,6 @@ using std::vector;
 ProximityProperties rigid_properties() {
   ProximityProperties props;
   const double chararacteristic_length = 0.1;
-  props.AddProperty(kMaterialGroup, kElastic,
-                    std::numeric_limits<double>::infinity());
   AddRigidHydroelasticProperties(chararacteristic_length, &props);
   return props;
 }
@@ -44,7 +42,7 @@ ProximityProperties rigid_properties() {
 // for supported geometries.
 ProximityProperties soft_properties() {
   ProximityProperties props;
-  props.AddProperty(kMaterialGroup, kElastic, 1e8);
+  AddContactMaterial(1e8, {}, {}, &props);
   const double chararacteristic_length = 0.25;
   AddSoftHydroelasticProperties(chararacteristic_length, &props);
   return props;

--- a/geometry/proximity/test/hydroelastic_internal_test.cc
+++ b/geometry/proximity/test/hydroelastic_internal_test.cc
@@ -28,13 +28,11 @@ GTEST_TEST(Hydroelastic, GeometriesPopulationAndQuery) {
   // Ids that haven't been added report as undefined.
   GeometryId rigid_id = GeometryId::get_new_id();
   ProximityProperties rigid_properties;
-  rigid_properties.AddProperty(kMaterialGroup, kElastic,
-                               std::numeric_limits<double>::infinity());
   AddRigidHydroelasticProperties(1.0, &rigid_properties);
 
   GeometryId soft_id = GeometryId::get_new_id();
   ProximityProperties soft_properties;
-  soft_properties.AddProperty(kMaterialGroup, kElastic, 1e8);
+  AddContactMaterial(1e8, {}, {}, &soft_properties);
   AddSoftHydroelasticProperties(1.0, &soft_properties);
 
   GeometryId bad_id = GeometryId::get_new_id();
@@ -63,8 +61,6 @@ GTEST_TEST(Hydroelastic, RemoveGeometry) {
   // Add a rigid geometry.
   const GeometryId rigid_id = GeometryId::get_new_id();
   ProximityProperties rigid_properties;
-  rigid_properties.AddProperty(kMaterialGroup, kElastic,
-                               std::numeric_limits<double>::infinity());
   AddRigidHydroelasticProperties(1.0, &rigid_properties);
   geometries.MaybeAddGeometry(Sphere(0.5), rigid_id, rigid_properties);
   ASSERT_EQ(geometries.hydroelastic_type(rigid_id), HydroelasticType::kRigid);
@@ -72,7 +68,7 @@ GTEST_TEST(Hydroelastic, RemoveGeometry) {
   // Add a soft geometry.
   const GeometryId soft_id = GeometryId::get_new_id();
   ProximityProperties soft_properties;
-  soft_properties.AddProperty(kMaterialGroup, kElastic, 1e8);
+  AddContactMaterial(1e8, {}, {}, &soft_properties);
   AddSoftHydroelasticProperties(1.0, &soft_properties);
   geometries.MaybeAddGeometry(Sphere(0.5), soft_id, soft_properties);
   ASSERT_EQ(geometries.hydroelastic_type(soft_id), HydroelasticType::kSoft);
@@ -400,7 +396,7 @@ class HydroelasticSoftGeometryTest : public ::testing::Test {
   /** Creates a simple set of properties for generating soft geometry. */
   ProximityProperties soft_properties(double edge_length = 0.1) const {
     ProximityProperties soft_properties;
-    soft_properties.AddProperty(kMaterialGroup, kElastic, 1e8);
+    AddContactMaterial(1e8, {}, {}, &soft_properties);
     AddSoftHydroelasticProperties(edge_length, &soft_properties);
     return soft_properties;
   }

--- a/geometry/proximity_properties.cc
+++ b/geometry/proximity_properties.cc
@@ -32,6 +32,34 @@ std::ostream& operator<<(std::ostream& out, const HydroelasticType& type) {
 
 }  // namespace internal
 
+void AddContactMaterial(
+    const std::optional<double>& elastic_modulus,
+    const std::optional<double>& dissipation,
+    const std::optional<multibody::CoulombFriction<double>>& friction,
+    ProximityProperties* properties) {
+  if (elastic_modulus.has_value()) {
+    if (*elastic_modulus <= 0) {
+      throw std::logic_error(fmt::format(
+          "The elastic modulus must be positive; given {}", *elastic_modulus));
+    }
+    properties->AddProperty(internal::kMaterialGroup, internal::kElastic,
+                            *elastic_modulus);
+  }
+  if (dissipation.has_value()) {
+    if (*dissipation < 0) {
+      throw std::logic_error(fmt::format(
+          "The dissipation can't be negative; given {}", *dissipation));
+    }
+    properties->AddProperty(internal::kMaterialGroup, internal::kHcDissipation,
+                            *dissipation);
+  }
+
+  if (friction.has_value()) {
+    properties->AddProperty(internal::kMaterialGroup, internal::kFriction,
+                            *friction);
+  }
+}
+
 // NOTE: Although these functions currently do the same thing, we're leaving
 // the two functions in place to facilitate future differences.
 

--- a/geometry/proximity_properties.h
+++ b/geometry/proximity_properties.h
@@ -7,9 +7,11 @@
  no way limit the inclusion of any other additional, arbitrary properties.
  */
 
+#include <optional>
 #include <ostream>
 
 #include "drake/geometry/geometry_roles.h"
+#include "drake/multibody/plant/coulomb_friction.h"
 
 namespace drake {
 namespace geometry {
@@ -25,10 +27,7 @@ namespace internal {
  can implicitly coordinate the values they use to define proximity properties.
  These strings don't suggest what constitutes a valid property *value*. For
  those definitions, one should refer to the consumer of the properties (as
- called out in the documentation of the ProximityProperties class).
-
- <!-- TODO(SeanCurtis-TRI): Extend this to include other contact material
- properties and an API for setting them more conveniently.  */
+ called out in the documentation of the ProximityProperties class).  */
 //@{
 
 extern const char* const kMaterialGroup;  ///< The contact material group name.
@@ -83,6 +82,18 @@ enum class HydroelasticType {
 std::ostream& operator<<(std::ostream& out, const HydroelasticType& type);
 
 }  // namespace internal
+
+
+/** Adds contact material properties to the given set of proximity `properties`.
+
+ @throws std::logic_error if `elastic_modulus` is not positive, `dissipation` is
+                          negative, or any of the contact material properties
+                          have already been defined in `properties`.  */
+void AddContactMaterial(
+    const std::optional<double>& elastic_modulus,
+    const std::optional<double>& dissipation,
+    const std::optional<multibody::CoulombFriction<double>>& friction,
+    ProximityProperties* properties);
 
 /** Adds properties to the given set of proximity properties sufficient to cause
  the associated geometry to generate a rigid hydroelastic representation.

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -114,17 +114,9 @@ GTEST_TEST(ProximityEngineTests, ProcessHydroelasticProperties) {
   const double edge_length = 0.5;
   const double E = 1e8;  // Elastic modulus.
   ProximityProperties soft_properties;
-  soft_properties.AddProperty(kMaterialGroup, kElastic, E);
+  AddContactMaterial(E, {}, {}, &soft_properties);
   AddSoftHydroelasticProperties(edge_length, &soft_properties);
   ProximityProperties rigid_properties;
-  // TODO(SeanCurtis-TRI): Keep an eye on this practice. Defining something as
-  // being rigid by giving it an "infinite elastic modulus" may be counter
-  // intuitive. If so, we'll need to rearticulate how we handle this
-  // classification. However, any dissonance should be mitigated by the upcoming
-  // API in proximity_properties.h for setting rigid/soft properties without
-  // getting into the details of how it's labeled.
-  rigid_properties.AddProperty(kMaterialGroup, kElastic,
-                              std::numeric_limits<double>::infinity());
   AddRigidHydroelasticProperties(edge_length, &rigid_properties);
 
   // Case: soft sphere.
@@ -217,7 +209,7 @@ GTEST_TEST(ProximityEngineTests, MeshComputeContactSurfacesOnly) {
   const double edge_length = 0.5;
   const double E = 1e8;  // Elastic modulus.
   ProximityProperties soft_properties;
-  soft_properties.AddProperty(kMaterialGroup, kElastic, E);
+  AddContactMaterial(E, {}, {}, &soft_properties);
   AddSoftHydroelasticProperties(edge_length, &soft_properties);
   engine.AddAnchoredGeometry(sphere_S, X_WS, id_S, soft_properties);
 
@@ -225,10 +217,7 @@ GTEST_TEST(ProximityEngineTests, MeshComputeContactSurfacesOnly) {
       drake::FindResourceOrThrow("drake/geometry/test/non_convex_mesh.obj"),
       1.0 /* scale */};
   const GeometryId id_M = GeometryId::get_new_id();
-  // Infinite elastic modulus for rigid geometry.
-  const double E_infinity = std::numeric_limits<double>::infinity();
   ProximityProperties rigid_properties;
-  rigid_properties.AddProperty(kMaterialGroup, kElastic, E_infinity);
   AddRigidHydroelasticProperties(edge_length, &rigid_properties);
   engine.AddDynamicGeometry(mesh_M, id_M, rigid_properties);
   RigidTransformd X_WM = RigidTransformd::Identity();
@@ -318,8 +307,6 @@ GTEST_TEST(ProximityEngineTests, RemoveGeometry) {
       // rely on the implementation of hydroelastic::Geometries to distinguish
       // soft and rigid.
       ProximityProperties props;
-      props.AddProperty(kMaterialGroup, kElastic,
-                        std::numeric_limits<double>::infinity());
       AddRigidHydroelasticProperties(1.0, &props);
       if (is_dynamic) {
         engine.AddDynamicGeometry(sphere, id, props);

--- a/geometry/test/proximity_properties_test.cc
+++ b/geometry/test/proximity_properties_test.cc
@@ -2,35 +2,108 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/geometry_roles.h"
+#include "drake/multibody/plant/coulomb_friction.h"
 
 namespace drake {
 namespace geometry {
 namespace {
 
 using internal::HydroelasticType;
+using internal::kComplianceType;
+using internal::kElastic;
+using internal::kFriction;
+using internal::kHcDissipation;
+using internal::kHydroGroup;
+using internal::kMaterialGroup;
+using internal::kRezHint;
+using CoulombFrictiond = multibody::CoulombFriction<double>;
+
+GTEST_TEST(ProximityPropertiesTest, AddContactMaterial) {
+  const double E = 1e8;
+  const double d = 0.1;
+  CoulombFrictiond mu{0.9, 0.5};
+
+  // Case: Correct configuration.
+  {
+    ProximityProperties p;
+    EXPECT_NO_THROW(AddContactMaterial(E, d, mu, &p));
+    EXPECT_EQ(p.GetProperty<double>(kMaterialGroup, kElastic), E);
+    EXPECT_EQ(p.GetProperty<double>(kMaterialGroup, kHcDissipation), d);
+    const CoulombFrictiond& mu_stored =
+        p.GetProperty<CoulombFrictiond>(kMaterialGroup, kFriction);
+    EXPECT_EQ(mu_stored.static_friction(), mu.static_friction());
+    EXPECT_EQ(mu_stored.dynamic_friction(), mu.dynamic_friction());
+  }
+
+  // Error case: Already has elastic_modulus.
+  {
+    ProximityProperties p;
+    p.AddProperty(kMaterialGroup, kElastic, E);
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        AddContactMaterial(E, d, mu, &p), std::logic_error,
+        ".+ Trying to add property .+ to .+ property .+ already exists");
+  }
+
+  // Error case: Already has dissipation.
+  {
+    ProximityProperties p;
+    p.AddProperty(kMaterialGroup, kHcDissipation, d);
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        AddContactMaterial(E, d, mu, &p), std::logic_error,
+        ".+ Trying to add property .+ to .+ property .+ already exists");
+  }
+
+  // Error case: Already has friction.
+  {
+    ProximityProperties p;
+    p.AddProperty(kMaterialGroup, kFriction, mu);
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        AddContactMaterial(E, d, mu, &p), std::logic_error,
+        ".+ Trying to add property .+ to .+ property .+ already exists");
+  }
+
+  // Error case: 0 elasticity.
+  {
+    ProximityProperties p;
+    DRAKE_EXPECT_THROWS_MESSAGE(AddContactMaterial(0, d, mu, &p),
+                                std::logic_error,
+                                ".+elastic modulus must be positive.+");
+  }
+
+  // Error case: negative elasticity.
+  {
+    ProximityProperties p;
+    DRAKE_EXPECT_THROWS_MESSAGE(AddContactMaterial(-1.3, d, mu, &p),
+                                std::logic_error,
+                                ".+elastic modulus must be positive.+");
+  }
+
+  // Error case: negative dissipation.
+  {
+    ProximityProperties p;
+    DRAKE_EXPECT_THROWS_MESSAGE(AddContactMaterial(E, -1.2, mu, &p),
+                                std::logic_error,
+                                ".+dissipation can't be negative.+");
+  }
+}
 
 GTEST_TEST(ProximityPropertiesTest, AddRigidProperties) {
   for (double length : {1e-5, 1.25, 1e7}) {
     ProximityProperties props;
     AddRigidHydroelasticProperties(length, &props);
-    EXPECT_TRUE(
-        props.HasProperty(internal::kHydroGroup, internal::kComplianceType));
-    EXPECT_EQ(props.GetProperty<HydroelasticType>(internal::kHydroGroup,
-                                                  internal::kComplianceType),
+    EXPECT_TRUE(props.HasProperty(kHydroGroup, kComplianceType));
+    EXPECT_EQ(props.GetProperty<HydroelasticType>(kHydroGroup, kComplianceType),
               HydroelasticType::kRigid);
-    EXPECT_TRUE(props.HasProperty(internal::kHydroGroup, internal::kRezHint));
-    EXPECT_EQ(
-        props.GetProperty<double>(internal::kHydroGroup, internal::kRezHint),
-        length);
+    EXPECT_TRUE(props.HasProperty(kHydroGroup, kRezHint));
+    EXPECT_EQ(props.GetProperty<double>(kHydroGroup, kRezHint), length);
   }
 
   ProximityProperties props;
   AddRigidHydroelasticProperties(&props);
-  EXPECT_TRUE(
-      props.HasProperty(internal::kHydroGroup, internal::kComplianceType));
-  EXPECT_EQ(props.GetProperty<HydroelasticType>(internal::kHydroGroup,
-                                                internal::kComplianceType),
+  EXPECT_TRUE(props.HasProperty(kHydroGroup, kComplianceType));
+  EXPECT_EQ(props.GetProperty<HydroelasticType>(kHydroGroup, kComplianceType),
             HydroelasticType::kRigid);
 }
 
@@ -42,23 +115,17 @@ GTEST_TEST(ProximityPropertiesTest, AddSoftProperties) {
   for (double length : {1e-5, 1.25, 1e7}) {
     ProximityProperties props;
     AddSoftHydroelasticProperties(length, &props);
-    EXPECT_TRUE(
-        props.HasProperty(internal::kHydroGroup, internal::kComplianceType));
-    EXPECT_EQ(props.GetProperty<HydroelasticType>(internal::kHydroGroup,
-                                                  internal::kComplianceType),
+    EXPECT_TRUE(props.HasProperty(kHydroGroup, kComplianceType));
+    EXPECT_EQ(props.GetProperty<HydroelasticType>(kHydroGroup, kComplianceType),
               HydroelasticType::kSoft);
-    EXPECT_TRUE(props.HasProperty(internal::kHydroGroup, internal::kRezHint));
-    EXPECT_EQ(
-        props.GetProperty<double>(internal::kHydroGroup, internal::kRezHint),
-        length);
+    EXPECT_TRUE(props.HasProperty(kHydroGroup, kRezHint));
+    EXPECT_EQ(props.GetProperty<double>(kHydroGroup, kRezHint), length);
   }
 
   ProximityProperties props;
   AddSoftHydroelasticProperties(&props);
-  EXPECT_TRUE(
-      props.HasProperty(internal::kHydroGroup, internal::kComplianceType));
-  EXPECT_EQ(props.GetProperty<HydroelasticType>(internal::kHydroGroup,
-                                                internal::kComplianceType),
+  EXPECT_TRUE(props.HasProperty(kHydroGroup, kComplianceType));
+  EXPECT_EQ(props.GetProperty<HydroelasticType>(kHydroGroup, kComplianceType),
             HydroelasticType::kSoft);
 }
 

--- a/multibody/parsing/detail_common.cc
+++ b/multibody/parsing/detail_common.cc
@@ -29,35 +29,26 @@ geometry::ProximityProperties ParseProximityProperties(
   }
 
   std::optional<double> elastic_modulus = read_double("drake:elastic_modulus");
-  if (elastic_modulus) {
-    properties.AddProperty(geometry::internal::kMaterialGroup,
-                           geometry::internal::kElastic, *elastic_modulus);
-  }
 
   std::optional<double> dissipation =
       read_double("drake:hunt_crossley_dissipation");
-  if (dissipation) {
-    properties.AddProperty(geometry::internal::kMaterialGroup,
-                           geometry::internal::kHcDissipation, *dissipation);
-  }
 
   std::optional<double> mu_dynamic = read_double("drake:mu_dynamic");
   std::optional<double> mu_static = read_double("drake:mu_static");
+  std::optional<CoulombFriction<double>> friction;
   // Note: we rely on the constructor of CoulombFriction to detect negative
   // values and bad relationship between static and dynamic coefficients.
   if (mu_dynamic && mu_static) {
-    properties.AddProperty(geometry::internal::kMaterialGroup,
-                           geometry::internal::kFriction,
-                           CoulombFriction<double>(*mu_static, *mu_dynamic));
+    friction = CoulombFriction<double>(*mu_static, *mu_dynamic);
   } else if (mu_dynamic) {
-    properties.AddProperty(geometry::internal::kMaterialGroup,
-                           geometry::internal::kFriction,
-                           CoulombFriction<double>(*mu_dynamic, *mu_dynamic));
+    friction = CoulombFriction<double>(*mu_dynamic, *mu_dynamic);
   } else if (mu_static) {
-    properties.AddProperty(geometry::internal::kMaterialGroup,
-                           geometry::internal::kFriction,
-                           CoulombFriction<double>(*mu_static, *mu_static));
+    friction = CoulombFriction<double>(*mu_static, *mu_static);
   }
+
+  geometry::AddContactMaterial(elastic_modulus, dissipation, friction,
+                               &properties);
+
   return properties;
 }
 

--- a/multibody/parsing/detail_scene_graph.cc
+++ b/multibody/parsing/detail_scene_graph.cc
@@ -392,6 +392,8 @@ ProximityProperties MakeProximityPropertiesForCollision(
     properties = ParseProximityProperties(read_double, is_rigid, is_soft);
   }
 
+  // TODO(SeanCurtis-TRI): Remove all of this legacy parsing code based on
+  //  issue #12598.
   if (!properties.HasProperty(geometry::internal::kMaterialGroup,
                               geometry::internal::kFriction)) {
     properties.AddProperty(

--- a/multibody/parsing/detail_urdf_geometry.cc
+++ b/multibody/parsing/detail_urdf_geometry.cc
@@ -387,6 +387,9 @@ geometry::GeometryInstance ParseVisual(const std::string& parent_element_name,
   return instance;
 }
 
+// TODO(SeanCurtis-TRI): Remove all of this legacy parsing code based on
+//  issue #12598.
+
 // This is the backwards-compatible fallback for defining friction; it reads
 // the soon-to-be-deprecated <drake_compliance> tag for data. It throws errors
 // for malformed values or returns a friction (either the valid friction
@@ -528,6 +531,8 @@ geometry::GeometryInstance ParseCollision(
         soft_element != nullptr);
   }
 
+  // TODO(SeanCurtis-TRI): Remove all of this legacy parsing code based on
+  //  issue #12598.
   // Now test to see how we should handle a potential <drake_compliance> tag.
   if (!props.HasProperty(geometry::internal::kMaterialGroup,
                          geometry::internal::kFriction)) {

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -1298,8 +1298,7 @@ GTEST_TEST(MultibodyPlantTest, CollisionGeometryRegistration) {
   geometry::ProximityProperties properties;
   properties.AddProperty("test", "dummy", 7);
   CoulombFriction<double> sphere2_friction(0.7, 0.6);
-  properties.AddProperty(geometry::internal::kMaterialGroup,
-                         geometry::internal::kFriction, sphere2_friction);
+  geometry::AddContactMaterial({}, {}, sphere2_friction, &properties);
   const RigidBody<double>& sphere2 =
       plant.AddRigidBody("Sphere2", SpatialInertia<double>());
   GeometryId sphere2_id = plant.RegisterCollisionGeometry(


### PR DESCRIPTION
Previously, we had `AddSoftHydroelasticProperties` and `AddRigidHydroelasticProperties` to facilitate setting valid properties without having to worry about the nitty gritty. This does the same for
more general contact material properties and then makes use of it throughout the code base.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12595)
<!-- Reviewable:end -->
