### PR TITLE
Remove MBP::set_[hydroelastic_properties]

### DIFF
--- a/examples/multibody/rolling_sphere/make_rolling_sphere_plant.h
+++ b/examples/multibody/rolling_sphere/make_rolling_sphere_plant.h
@@ -21,10 +21,12 @@ namespace bouncing_ball {
 ///   The mass of the ball.
 /// @param[in] elastic_modulus
 ///   The modulus of elasticity for the ball. Only used when modeled with the
-///   hydroelastic model.
+///   hydroelastic model. See @ref mbp_hydroelastic_materials_properties
+///   "Hydroelastic contact" documentation for details.
 /// @param[in] dissipation
 ///   The Hunt & Crossley dissipation constant for the ball. Only used with the
-///   hydroelastic model. See MultibodyPlant::set_hunt_crossley_dissipation().
+///   hydroelastic model.  See @ref mbp_hydroelastic_materials_properties
+///   "Hydroelastic contact" documentation for details.
 /// @param[in] surface_friction
 ///   The Coulomb's law coefficients of friction.
 /// @param[in] gravity_W

--- a/multibody/parsing/detail_scene_graph.h
+++ b/multibody/parsing/detail_scene_graph.h
@@ -92,7 +92,8 @@ geometry::IllustrationProperties MakeVisualPropertiesFromSdfVisual(
 math::RigidTransformd MakeGeometryPoseFromSdfCollision(
     const sdf::Collision& sdf_collision, const math::RigidTransformd& X_LG);
 
-/** Parses the drake-relevant collision properties from a <collision> element.
+/** @anchor sdf_contact_material
+ Parses the drake-relevant collision properties from a <collision> element.
 
  Specifically, looks for <drake:proximity_properties> tag to find drake-specific
  geometry collision (or "proximity") properties. The set of tags are enumerated

--- a/multibody/parsing/detail_urdf_geometry.h
+++ b/multibody/parsing/detail_urdf_geometry.h
@@ -106,7 +106,8 @@ geometry::GeometryInstance ParseVisual(
     const std::string& root_dir, const tinyxml2::XMLElement* node,
     MaterialMap* materials);
 
-/** Parses a <collision> element in @p node.
+/** @anchor urdf_contact_material
+ Parses a <collision> element in @p node.
 
  Reads the definition of a collision geometry (shape, pose, properties, etc.)
 


### PR DESCRIPTION
MBP offered an interface that would set hydroelastic properties after the fact and attempt to push it through to SceneGraph. This was a short-term stop gap effort. However:

  1. There are now mechanisms to set these either during parsing or registration.
  2. It doesn't work with SceneGraph in its present state.
  3. And there are no invocations of this API any longer.

We'll simply remove it, updating the documentation where appropriate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12596)
<!-- Reviewable:end -->
