### PR TITLE
Refactor the newton convergence check for implicit integrators

### DIFF
--- a/systems/analysis/test/radau_integrator_test.cc
+++ b/systems/analysis/test/radau_integrator_test.cc
@@ -91,7 +91,7 @@ GTEST_TEST(RadauIntegratorTest, QuadraticTest) {
   // Ensure that Radau, and not BS3, was used by counting the number of
   // function evaluations.  Note that this number is somewhat brittle and might
   // need to be revised in the future.
-  EXPECT_EQ(radau.get_num_derivative_evaluations(), 9);
+  EXPECT_EQ(radau.get_num_derivative_evaluations(), 8);
 
   // Per the description in IntegratorBase::get_error_estimate_order(), this
   // should return "3", in accordance with the order of the polynomial in the
@@ -171,7 +171,7 @@ GTEST_TEST(RadauIntegratorTest, LinearRadauTest) {
   // Ensure that Radau, and not Euler+RK2, was used by counting the number of
   // function evaluations. Note that this number is somewhat brittle and might
   // need to be revised in the future.
-  EXPECT_EQ(radau.get_num_derivative_evaluations(), 7);
+  EXPECT_EQ(radau.get_num_derivative_evaluations(), 6);
 
   // Per the description in IntegratorBase::get_error_estimate_order(), this
   // should return "2", in accordance with the order of the polynomial in the


### PR DESCRIPTION
With the new Velocity-Implicit Integrator Euler integrator #12528, we will have at least four implementations of Newton-Raphson iterations in our implicit integrators. This PR:

- Moves the convergence check in each iteration, which was written based on Hairer 1996, from each implicit integrator into the parent class ImplicitIntegrator.

In other words, it refactors the easiest component, the convergence check, and makes the convergence behavior consistent between the integrators. It will also simplify PR #12543 by moving the logic for this convergence check to a common location.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12599)
<!-- Reviewable:end -->
