### PR TITLE
Add option to MultibodyPositionToGeometryPose to use an input vector …

### DIFF
--- a/bindings/pydrake/systems/rendering_py.cc
+++ b/bindings/pydrake/systems/rendering_py.cc
@@ -109,10 +109,12 @@ PYBIND11_MODULE(rendering, m) {
   py::class_<MultibodyPositionToGeometryPose<T>, LeafSystem<T>>(m,
       "MultibodyPositionToGeometryPose",
       doc.MultibodyPositionToGeometryPose.doc)
-      .def(py::init<const multibody::MultibodyPlant<T>&>(), py::arg("plant"),
+      .def(py::init<const multibody::MultibodyPlant<T>&, bool>(),
+          py::arg("plant"), py::arg("input_multibody_state") = false,
           // Keep alive, reference: `self` keeps `plant` alive.
           py::keep_alive<1, 2>(),
-          doc.MultibodyPositionToGeometryPose.ctor.doc_1args_plant)
+          doc.MultibodyPositionToGeometryPose.ctor
+              .doc_2args_plant_input_multibody_state)
       .def("get_input_port",
           &MultibodyPositionToGeometryPose<T>::get_input_port,
           py_reference_internal,

--- a/bindings/pydrake/systems/test/rendering_test.py
+++ b/bindings/pydrake/systems/test/rendering_test.py
@@ -204,7 +204,8 @@ class TestRendering(unittest.TestCase):
         plant.RegisterAsSourceForSceneGraph(scene_graph)
         plant.Finalize()
 
-        to_pose = MultibodyPositionToGeometryPose(plant=plant)
+        to_pose = MultibodyPositionToGeometryPose(
+            plant=plant, input_multibody_state=False)
 
         # Check the size of the input.
         self.assertEqual(to_pose.get_input_port().size(), 2)

--- a/systems/rendering/multibody_position_to_geometry_pose.h
+++ b/systems/rendering/multibody_position_to_geometry_pose.h
@@ -19,8 +19,11 @@ namespace rendering {
  *          @output_port{geometry_pose}
  * }
  *
- * The position input must be a vector whose length matches the number of
- * positions in the MultibodyPlant.
+ * The position input must be a vector whose length matches either the
+ * number of positions in the MultibodyPlant or the number of states (based
+ * on the optional argument in the constructor).  This option to pass the full
+ * state vector is provided only for convenience -- only the position values
+ * will affect the outputs.
  *
  * @tparam T The vector element type, which must be a valid Eigen scalar.
  *
@@ -29,7 +32,6 @@ namespace rendering {
  * - double
  *
  * @ingroup visualization
- * }
  */
 template <typename T>
 class MultibodyPositionToGeometryPose final : public LeafSystem<T> {
@@ -41,18 +43,30 @@ class MultibodyPositionToGeometryPose final : public LeafSystem<T> {
    * reference to the MultibodyPlant object so you must ensure that @p plant
    * has a longer lifetime than `this` %MultibodyPositionToGeometryPose system.
    *
+   * @param input_multibody_state If true, the vector input port will be the
+   * size of the `plant` *state* vector.  If false, it will be the size
+   * of the `plant` *position* vector.  In both cases, only the
+   * positions will affect the output.  @default false.
+   *
    * @throws if `plant` is not finalized and registered with a SceneGraph.
    */
   explicit MultibodyPositionToGeometryPose(
-      const multibody::MultibodyPlant<T>& plant);
+      const multibody::MultibodyPlant<T>& plant,
+      bool input_multibody_state = false);
 
   /**
    * The %MultibodyPositionToGeometryPose owns its internal plant.
    *
+   * @param input_multibody_state If true, the vector input port will be the
+   * size of the `plant` *state* vector.  If false, it will be the size
+   * of the `plant` *position* vector.  In both cases, only the
+   * positions will affect the output.  @default: false.
+   *
    * @throws if `owned_plant` is not finalized and registered with a SceneGraph.
    */
   explicit MultibodyPositionToGeometryPose(
-      std::unique_ptr<multibody::MultibodyPlant<T>> owned_plant);
+      std::unique_ptr<multibody::MultibodyPlant<T>> owned_plant,
+      bool input_multibody_state = false);
 
   ~MultibodyPositionToGeometryPose() override = default;
 
@@ -74,7 +88,7 @@ class MultibodyPositionToGeometryPose final : public LeafSystem<T> {
  private:
   // Configure the input/output ports and prepare for calculation.
   // @pre plant_ must reference a valid MBP.
-  void Configure();
+  void Configure(bool input_multibody_state);
 
   void CalcGeometryPose(const Context<T>& context, AbstractValue* poses) const;
 


### PR DESCRIPTION
…the size of the entire state (velocities are ignored)\.  This is a common use case and dramatically simplifies the wiring.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12602)
<!-- Reviewable:end -->
