### PR TITLE
Add missing load of py_library rule in drake_bazel_installed

### DIFF
--- a/tools/install/bazel/drake.BUILD.bazel
+++ b/tools/install/bazel/drake.BUILD.bazel
@@ -1,6 +1,7 @@
 # -*- mode: python -*-
 # vi: set ft=python :
 
+load("@rules_python//python:defs.bzl", "py_library")
 load("//:.manifest.bzl", "MANIFEST")
 
 package(default_visibility = ["//:__subpackages__"])


### PR DESCRIPTION
I guess ideally this should not call `http_archive` since we have `@rules_python` somewhere...

<!-- Reviewable:start -->
----
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12605)
<!-- Reviewable:end -->
