### PR TITLE
Native distance to capsule calculations with Autodiff support

### DIFF
--- a/geometry/proximity/distance_to_shape_callback.h
+++ b/geometry/proximity/distance_to_shape_callback.h
@@ -143,6 +143,11 @@ class DistancePairGeometry {
     SphereShapeDistance(sphere_A, halfspace_B);
   }
 
+  void operator()(const fcl::Sphered& sphere_A,
+                  const fcl::Capsuled& capsule_B) {
+    SphereShapeDistance(sphere_A, capsule_B);
+  }
+
   //@}
 
  private:
@@ -318,6 +323,12 @@ void ComputeNarrowPhaseDistance(const fcl::CollisionObjectd& a,
       const auto& halfspace_O =
           *static_cast<const fcl::Halfspaced*>(o_geometry);
       distance_pair(sphere_S, halfspace_O);
+      break;
+    }
+    case fcl::GEOM_CAPSULE: {
+      const auto& capsule_O =
+          *static_cast<const fcl::Capsuled*>(o_geometry);
+      distance_pair(sphere_S, capsule_O);
       break;
     }
     default: {

--- a/geometry/proximity/test/distance_sphere_to_shape_test.cc
+++ b/geometry/proximity/test/distance_sphere_to_shape_test.cc
@@ -55,12 +55,17 @@ void DistancePairGeometry<float>::operator()(const fcl::Sphered&,
 
 template <>
 void DistancePairGeometry<float>::operator()(const fcl::Sphered&,
+                                             const fcl::Capsuled&) {}
+
+template <>
+void DistancePairGeometry<float>::operator()(const fcl::Sphered&,
                                              const fcl::Cylinderd&) {}
 
 namespace {
 
 using Eigen::Vector3d;
 using fcl::Boxd;
+using fcl::Capsuled;
 using fcl::CollisionObjectd;
 using fcl::Cylinderd;
 using fcl::Halfspaced;
@@ -346,9 +351,12 @@ TEST_F(DistancePairGeometryTest, SphereSphereDouble) {
   EXPECT_TRUE((ResultsMatch<double, Sphered>(Sphered(1.3))));
 }
 
-
 TEST_F(DistancePairGeometryTest, SphereBoxDouble) {
   EXPECT_TRUE((ResultsMatch<double, Boxd>(Boxd{1.3, 2.3, 0.7})));
+}
+
+TEST_F(DistancePairGeometryTest, SphereCapsuleDouble) {
+  EXPECT_TRUE((ResultsMatch<double, Capsuled>(Capsuled{1.3, 2.3})));
 }
 
 TEST_F(DistancePairGeometryTest, SphereCylinderDouble) {
@@ -361,6 +369,10 @@ TEST_F(DistancePairGeometryTest, SphereSphereAutoDiff) {
 
 TEST_F(DistancePairGeometryTest, SphereBoxAutoDiffXd) {
   EXPECT_TRUE((ResultsMatch<AutoDiffXd, Boxd>(Boxd{1.3, 2.3, 0.7})));
+}
+
+TEST_F(DistancePairGeometryTest, SphereCapsuleAutoDiffXd) {
+  EXPECT_TRUE((ResultsMatch<AutoDiffXd, Capsuled>(Capsuled{1.3, 2.3})));
 }
 
 TEST_F(DistancePairGeometryTest, SphereCylinderAutoDiffXd) {

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -2558,9 +2558,6 @@ GenDistPairTestSphereBoxBoundaryTransform() {
 std::vector<SignedDistancePairTestData> GenDistPairTestSphereCapsule(
     const RotationMatrixd& R_WA = RotationMatrixd::Identity(),
     const RigidTransformd& X_WB = RigidTransformd::Identity()) {
-  // TODO(SeanCurtis-TRI): There are underlying fcl issues that prevent the
-  // collision result from being more precise. See related Drake issue 7656.
-  const double kTolerance = 1e-3;
   auto sphere_A = make_shared<const Sphere>(2.);
   auto capsule_B = make_shared<const Capsule>(6., 16.);
   const double radius_A = sphere_A->radius();
@@ -2604,8 +2601,7 @@ std::vector<SignedDistancePairTestData> GenDistPairTestSphereCapsule(
         sphere_A, capsule_B, X_WA, X_WB,
         SignedDistancePair<double>(GeometryId::get_new_id(),
                                    GeometryId::get_new_id(), p_ACa, p_BCb,
-                                   pair_distance),
-        kTolerance);
+                                   pair_distance));
   }
   return test_data;
 }


### PR DESCRIPTION
And now we can increase test tolerance back to 1e-14

Relates to #12468

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12617)
<!-- Reviewable:end -->
