### PR TITLE
framework: Replace uint64 with Identifier for system_id

### DIFF
--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -202,6 +202,7 @@ drake_cc_library(
         "framework_common.h",
     ],
     deps = [
+        "//common:identifier",
         "//common:type_safe_index",
         "//common:value",
     ],

--- a/systems/framework/context_base.h
+++ b/systems/framework/context_base.h
@@ -126,7 +126,7 @@ class ContextBase : public internal::ContextMessageInterface {
   }
 
   /** (Internal) Gets the id of the subsystem that created this Context. */
-  uint64_t get_system_id() const { return system_id_; }
+  internal::SystemId get_system_id() const { return system_id_; }
 
   /** Returns the full pathname of the subsystem for which this is the Context.
   This is intended primarily for error messages and logging.
@@ -593,8 +593,8 @@ class ContextBase : public internal::ContextMessageInterface {
   // Records the name of the system whose context this is.
   void set_system_name(const std::string& name) { system_name_ = name; }
 
-  // Records the id of the system that this context was created by.
-  void set_system_id(uint64_t id) { system_id_ = id; }
+  // Records the id of the subsystem that created this context.
+  void set_system_id(internal::SystemId id) { system_id_ = id; }
 
   // Fixes the input port at `index` to the internal value source `port_value`.
   // If the port wasn't previously fixed, assigns a ticket and tracker for the
@@ -661,9 +661,8 @@ class ContextBase : public internal::ContextMessageInterface {
   // Name of the subsystem whose subcontext this is.
   std::string system_name_;
 
-  // Unique ID of the subsystem whose subcontext this is. The default value
-  // (zero) should be treated as uninitialized and invalid.
-  uint64_t system_id_{0};
+  // Unique ID of the subsystem whose subcontext this is.
+  internal::SystemId system_id_;
 
   // Used to validate that System-derived classes didn't forget to invoke the
   // SystemBase method that properly sets up the ContextBase.
@@ -671,6 +670,8 @@ class ContextBase : public internal::ContextMessageInterface {
 };
 
 #ifndef DRAKE_DOXYGEN_CXX
+class DiagramContextTest;
+class LeafContextTest;
 class SystemBase;
 namespace internal {
 
@@ -682,13 +683,15 @@ class SystemBaseContextBaseAttorney {
   SystemBaseContextBaseAttorney() = delete;
 
  private:
+  friend class drake::systems::DiagramContextTest;
+  friend class drake::systems::LeafContextTest;
   friend class drake::systems::SystemBase;
 
   static void set_system_name(ContextBase* context, const std::string& name) {
     DRAKE_DEMAND(context != nullptr);
     context->set_system_name(name);
   }
-  static void set_system_id(ContextBase* context, uint64_t id) {
+  static void set_system_id(ContextBase* context, internal::SystemId id) {
     DRAKE_DEMAND(context != nullptr);
     context->set_system_id(id);
   }

--- a/systems/framework/framework_common.h
+++ b/systems/framework/framework_common.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/identifier.h"
 #include "drake/common/type_safe_index.h"
 #include "drake/common/value.h"
 
@@ -110,6 +111,9 @@ class InputPortBase;
 class SystemBase;
 
 namespace internal {
+
+// Type used to match a Context to its System.
+using SystemId = drake::Identifier<class SystemIdTag>;
 
 // A utility to call the package-private constructor of some framework classes.
 class FrameworkFactory {

--- a/systems/framework/system_base.cc
+++ b/systems/framework/system_base.cc
@@ -20,11 +20,8 @@ namespace systems {
 
 SystemBase::~SystemBase() {}
 
-uint64_t SystemBase::get_next_id() {
-  // Note that id 0 is used to indicate that the id has not been initialized.
-  // So we have an invariant "get_next_id() > 0".
-  static never_destroyed<std::atomic<uint64_t>> next_id(1);
-  return next_id.access()++;
+internal::SystemId SystemBase::get_next_id() {
+  return internal::SystemId::get_new_id();
 }
 
 std::string SystemBase::GetSystemPathname() const {

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -1069,7 +1069,7 @@ class SystemBase : public internal::SystemMessageInterface {
  private:
   void CreateSourceTrackers(ContextBase*) const;
 
-  static uint64_t get_next_id();
+  static internal::SystemId get_next_id();
 
   // Used to create trackers for variable-number System-allocated objects.
   struct TrackerInfo {
@@ -1133,9 +1133,8 @@ class SystemBase : public internal::SystemMessageInterface {
   // Name of this system.
   std::string name_;
 
-  // Unique ID of this system. The default value (zero) should be treated as
-  // uninitialized and invalid.
-  const uint64_t system_id_{get_next_id()};
+  // Unique ID of this system.
+  const internal::SystemId system_id_{get_next_id()};
 };
 
 // Implementations of templatized DeclareCacheEntry() methods.

--- a/systems/framework/test/diagram_context_test.cc
+++ b/systems/framework/test/diagram_context_test.cc
@@ -94,6 +94,8 @@ class DiagramContextTest : public ::testing::Test {
     // This chunk of code is partially mimicking Diagram::DoAllocateContext()
     // which is normally in charge of making DiagramContexts.
     context_ = std::make_unique<DiagramContext<double>>(kNumSystems);
+    internal::SystemBaseContextBaseAttorney::set_system_id(
+        context_.get(), internal::SystemId::get_new_id());
 
     // Don't change these indexes -- tests below depend on them.
     AddSystem(*adder0_, SubsystemIndex(0));
@@ -507,6 +509,10 @@ TEST_F(DiagramContextTest, MutableParameterNotifications) {
 TEST_F(DiagramContextTest, MutableEverythingNotifications) {
   auto clone = context_->Clone();
   ASSERT_TRUE(clone != nullptr);
+
+  // Verify that the system id was copied.
+  EXPECT_TRUE(context_->get_system_id().is_valid());
+  EXPECT_EQ(context_->get_system_id(), clone->get_system_id());
 
   // Make sure clone's values are different from context's. These numbers are
   // arbitrary as long as they don't match the default context_ values.

--- a/systems/framework/test/leaf_context_test.cc
+++ b/systems/framework/test/leaf_context_test.cc
@@ -44,6 +44,8 @@ class LeafContextTest : public ::testing::Test {
  protected:
   void SetUp() override {
     context_.SetTime(kTime);
+    internal::SystemBaseContextBaseAttorney::set_system_id(
+        &context_, internal::SystemId::get_new_id());
 
     // Set up slots for input and output ports.
     AddInputPorts(kNumInputPorts, &context_);
@@ -493,6 +495,10 @@ TEST_F(LeafContextTest, Clone) {
   std::unique_ptr<Context<double>> clone = context_.Clone();
   // Verify that the time was copied.
   EXPECT_EQ(kTime, clone->get_time());
+
+  // Verify that the system id was copied.
+  EXPECT_TRUE(context_.get_system_id().is_valid());
+  EXPECT_EQ(context_.get_system_id(), clone->get_system_id());
 
   // Verify that the cloned input ports contain the same data,
   // but are different pointers.


### PR DESCRIPTION
Also add a test confirming that Context::Clone preserves the system_id.

Towards #12560.  Builds on #12621.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12622)
<!-- Reviewable:end -->
