### PR TITLE
Fix initial vertex draw order in planar scenegraph visualizer

### DIFF
--- a/bindings/pydrake/systems/planar_scenegraph_visualizer.py
+++ b/bindings/pydrake/systems/planar_scenegraph_visualizer.py
@@ -121,12 +121,12 @@ class PlanarSceneGraphVisualizer(PyPlotVisualizer):
         self._build_body_patches(use_random_colors)
 
         # Populate the body fill list -- which requires doing most of a draw
-        # pass, but with an ax.fill() command rather than an in-place
-        # replacement of vertex positions to initialize the draw patches. The
-        # body fill list stores the ax patch objects in the order they were
-        # spawned (i.e. by body, and then by order of view_patches). Drawing
-        # the tree should update them by iterating over bodies and patches in
-        # the same order.
+        # pass, but with an ax.fill() command to initialize the draw patches.
+        # After initialization, we can then use in-place replacement of vertex
+        # positions. The body fill list stores the ax patch objects in the
+        # order they were spawned (i.e. by body, and then by order of view_
+        # patches). Drawing the tree should update them by iterating over
+        # bodies and patches in the same order.
         self._body_fill_dict = {}
         X_WB_initial = RigidTransform.Identity()
         for full_name in self._patch_Blist.keys():
@@ -137,10 +137,13 @@ class PlanarSceneGraphVisualizer(PyPlotVisualizer):
                 # Project the full patch the first time, to initialize a vertex
                 # list with enough space for any possible convex hull of this
                 # vertex set.
-                patch_V = self._T_VW @ patch_W
-                self._body_fill_dict[full_name] += self.ax.fill(
+                patch_V = self._project_patch(patch_W)
+                body_fill = self.ax.fill(
                     patch_V[0, :], patch_V[1, :], zorder=0,
-                    edgecolor='k', facecolor=color, closed=True)
+                    edgecolor='k', facecolor=color, closed=True)[0]
+                self._body_fill_dict[full_name].append(body_fill)
+                # Then update the vertices for a more accurate initial draw.
+                self._update_body_fill_verts(body_fill, patch_V)
 
     def _build_body_patches(self, use_random_colors):
         """
@@ -271,6 +274,41 @@ class PlanarSceneGraphVisualizer(PyPlotVisualizer):
         colors = self._patch_Blist_colors[full_name]
         return (patch_Wlist, colors)
 
+    def _project_patch(self, patch_W):
+        """
+        Project the object vertices from 3d in world frame W to 2d in view
+        frame V.
+        """
+        patch_V = self._T_VW @ patch_W
+        # Applies normalization in the perspective transformation
+        # to make each projected point have z = 1. If the bottom row
+        # of T_VW is [0, 0, 0, 1], this will result in an
+        # orthographic projection.
+        patch_V[0, :] /= patch_V[2, :]
+        patch_V[1, :] /= patch_V[2, :]
+        # Cut patch_V down to 2xN.
+        patch_V = patch_V[:2, :]
+        return patch_V
+
+    def _update_body_fill_verts(self, body_fill, patch_V):
+        """
+        Takes a convex hull if necessary and uses in-place replacement of
+        vertices to update the fill.
+        """
+
+        # Take a convex hull to get an accurate shape for drawing, with verts
+        # coming out in ccw order.
+        if patch_V.shape[1] > 3:
+            hull = spatial.ConvexHull(patch_V.T)
+            patch_V = np.vstack([patch_V[:, v] for v in hull.vertices]).T
+
+        # Update the verts, padding out to the appropriate full # of verts by
+        # replicating the final vertex.
+        n_verts = body_fill.get_path().vertices.shape[0]
+        patch_V = np.pad(
+            patch_V, ((0, 0), (0, n_verts - patch_V.shape[1])), mode="edge")
+        body_fill.get_path().vertices[:, :] = patch_V.T
+
     def draw(self, context):
         """Overrides base with the implementation."""
 
@@ -287,28 +325,9 @@ class PlanarSceneGraphVisualizer(PyPlotVisualizer):
             for i, patch_W in enumerate(patch_Wlist):
                 # Project the object vertices from 3d in world frame W to 2d in
                 # view frame V (keeps homogeneous portion, removing it later).
-                patch_V = self._T_VW @ patch_W
-                # Applies normalization in the perspective transformation
-                # to make each projected point have z = 1. If the bottom row
-                # of T_VW is [0, 0, 0, 1], this will result in an
-                # orthographic projection.
-                patch_V[0, :] /= patch_V[2, :]
-                patch_V[1, :] /= patch_V[2, :]
-                # Cut patch_V down to 2xN.
-                patch_V = patch_V[:2, :]
-                # Take a convex hull to get an accurate shape for drawing,
-                # with verts coming out in ccw order.
-                if patch_V.shape[1] > 3:
-                    hull = spatial.ConvexHull(patch_V.T)
-                    patch_V = np.vstack(
-                        [patch_V[:, v] for v in hull.vertices]).T
+                patch_V = self._project_patch(patch_W)
                 body_fill = self._body_fill_dict[full_name][i]
-                n_verts = body_fill.get_path().vertices.shape[0]
-                # Update the verts, padding out to the appropriate full # of
-                # verts by replicating the final vertex.
-                patch_V = np.pad(
-                    patch_V, ((0, 0), (0, n_verts - patch_V.shape[1])),
-                    mode="edge")
-                body_fill.get_path().vertices[:, :] = patch_V.T
+                # Use the latest vertices to update the body_fill.
+                self._update_body_fill_verts(body_fill, patch_V)
                 body_fill.zorder = X_WB.translation() @ view_dir
         self.ax.set_title('t = {:.1f}'.format(context.get_time()))


### PR DESCRIPTION
Should apply the same projection and convex hull process to the initial fill as well as the subsequent draws

Resolves #12584

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12627)
<!-- Reviewable:end -->
