### PR TITLE
framework: Systems reject ContinuousState that they did not create

### DIFF
--- a/bindings/pydrake/systems/test/test_util_py.cc
+++ b/bindings/pydrake/systems/test/test_util_py.cc
@@ -141,9 +141,8 @@ PYBIND11_MODULE(test_util, m) {
     }
     {
       // Call `CalcTimeDerivatives` to test `DoCalcTimeDerivatives`
-      auto& state = context->get_mutable_continuous_state();
-      ContinuousState<T> state_copy(clone_vector(state.get_vector()));
-      system.CalcTimeDerivatives(*context, &state_copy);
+      auto state_dot = system.AllocateTimeDerivatives();
+      system.CalcTimeDerivatives(*context, state_dot.get());
     }
     {
       // Call `CalcDiscreteVariableUpdates` to test
@@ -174,13 +173,10 @@ PYBIND11_MODULE(test_util, m) {
           state.SetFrom(state_copy);
         } else {
           auto& state = context->get_mutable_continuous_state();
-          ContinuousState<T> state_dot(clone_vector(state.get_vector()),
-              state.get_generalized_position().size(),
-              state.get_generalized_velocity().size(),
-              state.get_misc_continuous_state().size());
-          system.CalcTimeDerivatives(*context, &state_dot);
+          auto state_dot = system.AllocateTimeDerivatives();
+          system.CalcTimeDerivatives(*context, state_dot.get());
           state.SetFromVector(
-              state.CopyToVector() + dt * state_dot.CopyToVector());
+              state.CopyToVector() + dt * state_dot->CopyToVector());
         }
         // Calculate output.
         auto output = system.AllocateOutput();

--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -701,9 +701,7 @@ drake_cc_googletest(
         "//common/test_utilities:expect_throws_message",
         "//systems/framework/test_utilities:pack_value",
         "//systems/primitives:adder",
-        "//systems/primitives:constant_vector_source",
         "//systems/primitives:integrator",
-        "//systems/primitives:zero_order_hold",
     ],
 )
 

--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -773,7 +773,9 @@ class Context : public ContextBase {
 
   /// Returns a deep copy of this Context's State.
   std::unique_ptr<State<T>> CloneState() const {
-    return DoCloneState();
+    auto result = DoCloneState();
+    result->get_mutable_continuous_state().set_system_id(this->get_system_id());
+    return result;
   }
 
   /// Returns a partial textual description of the Context, intended to be
@@ -852,7 +854,8 @@ class Context : public ContextBase {
   virtual State<T>& do_access_mutable_state() = 0;
 
   /// Returns the appropriate concrete State object to be returned by
-  /// CloneState().
+  /// CloneState().  The implementation should not set_system_id on the result,
+  /// the caller will set an id on the state after this method returns.
   virtual std::unique_ptr<State<T>> DoCloneState() const = 0;
 
   /// Returns a partial textual description of the Context, intended to be

--- a/systems/framework/context_base.h
+++ b/systems/framework/context_base.h
@@ -125,7 +125,7 @@ class ContextBase : public internal::ContextMessageInterface {
                                 : system_name_;
   }
 
-  /** (Internal) Gets the id of the subsystem that created this Context. */
+  /** (Internal) Gets the id of the subsystem that created this context. */
   internal::SystemId get_system_id() const { return system_id_; }
 
   /** Returns the full pathname of the subsystem for which this is the Context.
@@ -661,7 +661,7 @@ class ContextBase : public internal::ContextMessageInterface {
   // Name of the subsystem whose subcontext this is.
   std::string system_name_;
 
-  // Unique ID of the subsystem whose subcontext this is.
+  // Unique id of the subsystem whose subcontext this is.
   internal::SystemId system_id_;
 
   // Used to validate that System-derived classes didn't forget to invoke the

--- a/systems/framework/continuous_state.h
+++ b/systems/framework/continuous_state.h
@@ -12,6 +12,7 @@
 #include "drake/common/drake_deprecated.h"
 #include "drake/common/drake_throw.h"
 #include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/framework_common.h"
 #include "drake/systems/framework/scalar_conversion_traits.h"
 #include "drake/systems/framework/subvector.h"
 #include "drake/systems/framework/vector_base.h"
@@ -140,7 +141,9 @@ class ContinuousState {
   /// underlying each leaf ContinuousState is preserved. See the class comments
   /// above for more information.
   std::unique_ptr<ContinuousState<T>> Clone() const {
-    return std::unique_ptr<ContinuousState<T>>(DoClone());
+    auto result = DoClone();
+    result->set_system_id(this->get_system_id());
+    return result;
   }
 
   /// Returns the size of the entire continuous state vector, which is
@@ -229,6 +232,12 @@ class ContinuousState {
   /// Returns a copy of the entire continuous state vector into an Eigen vector.
   VectorX<T> CopyToVector() const { return this->get_vector().CopyToVector(); }
 
+  /** (Internal) Gets the id of the subsystem that created this state. */
+  internal::SystemId get_system_id() const { return system_id_; }
+
+  /** (Internal) Records the id of the subsystem that created this state. */
+  void set_system_id(internal::SystemId id) { system_id_ = id; }
+
  protected:
   /// Constructs a continuous state that exposes second-order structure, with
   /// no particular constraints on the layout.
@@ -256,6 +265,8 @@ class ContinuousState {
   /// full state is a BasicVector (that is, this is a leaf continuous state).
   /// The BasicVector is cloned to preserve its concrete type and contents,
   /// then the q, v, z Subvectors are created referencing it.
+  /// The implementation should not set_system_id on the result, the caller
+  /// will set an id on the state after this method returns.
   virtual std::unique_ptr<ContinuousState> DoClone() const {
     auto state = dynamic_cast<const BasicVector<T>*>(state_.get());
     DRAKE_DEMAND(state != nullptr);
@@ -329,6 +340,9 @@ class ContinuousState {
   // multibody system motion.  Conventionally denoted `z`.
   // This is a subset of state_ and does not own the underlying data.
   std::unique_ptr<VectorBase<T>> misc_continuous_state_;
+
+  // Unique id of the subsystem that created this state.
+  internal::SystemId system_id_;
 };
 
 }  // namespace systems

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -287,8 +287,10 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
     for (const auto& system : registered_systems_) {
       sub_derivatives.push_back(system->AllocateTimeDerivatives());
     }
-    return std::make_unique<DiagramContinuousState<T>>(
+    auto result = std::make_unique<DiagramContinuousState<T>>(
         std::move(sub_derivatives));
+    result->set_system_id(this->get_system_id());
+    return result;
   }
 
   std::unique_ptr<DiscreteValues<T>> AllocateDiscreteVariables() const final {

--- a/systems/framework/diagram_context.h
+++ b/systems/framework/diagram_context.h
@@ -305,6 +305,7 @@ class DiagramContext final : public Context<T> {
       state->set_substate(i, &Context<T>::access_mutable_state(&subcontext));
     }
     state->Finalize();
+    state->get_mutable_continuous_state().set_system_id(this->get_system_id());
     state_ = std::move(state);
   }
 

--- a/systems/framework/diagram_continuous_state.h
+++ b/systems/framework/diagram_continuous_state.h
@@ -65,9 +65,10 @@ class DiagramContinuousState final: public ContinuousState<T> {
   /// ContinuousState::Clone() method but with a more-specific return type so
   /// you don't have to downcast.
   std::unique_ptr<DiagramContinuousState> Clone() const {
-    // Note that DoClone() below cannot be overridden so we can count on the
-    // concrete type being DiagramContinuousState.
-    return static_pointer_cast<DiagramContinuousState>(DoClone());
+    // We are sure of the type here because DoClone() is final.  However,
+    // we'll still use the `..._or_throw` spelling as a sanity check.
+    return dynamic_pointer_cast_or_throw<DiagramContinuousState>(
+        ContinuousState<T>::Clone());
   }
 
   int num_substates() const { return static_cast<int>(substates_.size()); }

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -518,10 +518,12 @@ class LeafSystem : public System<T> {
     DRAKE_DEMAND(model_continuous_state_vector_->size() ==
                  this->num_continuous_states());
     const SystemBase::ContextSizes& sizes = this->get_context_sizes();
-    return std::make_unique<ContinuousState<T>>(
+    auto result = std::make_unique<ContinuousState<T>>(
         model_continuous_state_vector_->Clone(),
         sizes.num_generalized_positions, sizes.num_generalized_velocities,
         sizes.num_misc_continuous_states);
+    result->set_system_id(this->get_system_id());
+    return result;
   }
 
   /// Returns a copy of the states declared in DeclareDiscreteState() calls.

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -624,6 +624,7 @@ class System : public SystemBase {
                            ContinuousState<T>* derivatives) const {
     DRAKE_DEMAND(derivatives != nullptr);
     ValidateContext(context);
+    ValidateChildOfContext(derivatives);
     DoCalcTimeDerivatives(context, derivatives);
   }
 
@@ -2192,6 +2193,25 @@ class System : public SystemBase {
   void set_forced_unrestricted_update_events(
   std::unique_ptr<EventCollection<UnrestrictedUpdateEvent<T>>> forced) {
     forced_unrestricted_update_events_ = std::move(forced);
+  }
+
+  /** Checks whether the given object was created for this system.
+  @note This method is sufficiently fast for performance sensitive code. */
+  template <template <typename> class Clazz>
+  void ValidateChildOfContext(const Clazz<T>* object) const {
+    DRAKE_THROW_UNLESS(object != nullptr);
+    if (!object->get_system_id().is_valid()) {
+      throw std::logic_error(fmt::format(
+          "{} lacks a system_id so was not created for {} system {}",
+          NiceTypeName::Get<Clazz<T>>(), this->GetSystemType(),
+          this->GetSystemPathname()));
+    }
+    if (object->get_system_id() != this->get_system_id()) {
+      throw std::logic_error(fmt::format(
+          "{} was not created for {} system {}",
+          NiceTypeName::Get<Clazz<T>>(), this->GetSystemType(),
+          this->GetSystemPathname()));
+    }
   }
 
  private:

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -1124,6 +1124,10 @@ class SystemBase : public internal::SystemMessageInterface {
   // removed, also remove this function.
   virtual void DoCheckValidContext(const ContextBase&) const {}
 
+  /** (Internal) Gets the id used to tag context data as being created by this
+  system. */
+  internal::SystemId get_system_id() const { return system_id_; }
+
  private:
   void CreateSourceTrackers(ContextBase*) const;
 
@@ -1191,7 +1195,7 @@ class SystemBase : public internal::SystemMessageInterface {
   // Name of this system.
   std::string name_;
 
-  // Unique ID of this system.
+  // Unique id of this system.
   const internal::SystemId system_id_{get_next_id()};
 
   // Records the total sizes of Context resources as they will appear

--- a/systems/framework/test/diagram_context_test.cc
+++ b/systems/framework/test/diagram_context_test.cc
@@ -510,10 +510,6 @@ TEST_F(DiagramContextTest, MutableEverythingNotifications) {
   auto clone = context_->Clone();
   ASSERT_TRUE(clone != nullptr);
 
-  // Verify that the system id was copied.
-  EXPECT_TRUE(context_->get_system_id().is_valid());
-  EXPECT_EQ(context_->get_system_id(), clone->get_system_id());
-
   // Make sure clone's values are different from context's. These numbers are
   // arbitrary as long as they don't match the default context_ values.
   const double new_time = context_->get_time() + 1.;
@@ -712,6 +708,13 @@ TEST_F(DiagramContextTest, Clone) {
   // Verify that the time was copied.
   EXPECT_EQ(kTime, clone->get_time());
 
+  // Verify that the system id was copied.
+  EXPECT_TRUE(clone->get_system_id().is_valid());
+  EXPECT_EQ(clone->get_system_id(), context_->get_system_id());
+  const ContinuousState<double>& xc = clone->get_continuous_state();
+  EXPECT_TRUE(xc.get_system_id().is_valid());
+  EXPECT_EQ(xc.get_system_id(), context_->get_system_id());
+
   // Verify that the state has the same value.
   VerifyClonedState(clone->get_state());
   // Verify that the parameters have the same value.
@@ -741,9 +744,13 @@ TEST_F(DiagramContextTest, CloneState) {
   VerifyClonedState(*state);
   // Verify that the underlying type was preserved.
   EXPECT_NE(nullptr, dynamic_cast<DiagramState<double>*>(state.get()));
+  ContinuousState<double>& xc = state->get_mutable_continuous_state();
+  // Verify that the system id was copied.
+  EXPECT_TRUE(xc.get_system_id().is_valid());
+  EXPECT_EQ(xc.get_system_id(), context_->get_system_id());
   // Verify that changes to the state do not write through to the original
   // context.
-  state->get_mutable_continuous_state()[1] = 1024.0;
+  xc[1] = 1024.0;
   EXPECT_EQ(1024.0, state->get_continuous_state()[1]);
   EXPECT_EQ(43.0, context_->get_continuous_state()[1]);
 }

--- a/systems/framework/test/leaf_context_test.cc
+++ b/systems/framework/test/leaf_context_test.cc
@@ -499,6 +499,9 @@ TEST_F(LeafContextTest, Clone) {
   // Verify that the system id was copied.
   EXPECT_TRUE(context_.get_system_id().is_valid());
   EXPECT_EQ(context_.get_system_id(), clone->get_system_id());
+  ContinuousState<double>& xc = clone->get_mutable_continuous_state();
+  EXPECT_TRUE(xc.get_system_id().is_valid());
+  EXPECT_EQ(xc.get_system_id(), context_.get_system_id());
 
   // Verify that the cloned input ports contain the same data,
   // but are different pointers.
@@ -517,7 +520,6 @@ TEST_F(LeafContextTest, Clone) {
 
   // Verify that changes to the cloned state do not affect the original state.
   // -- Continuous
-  ContinuousState<double>& xc = clone->get_mutable_continuous_state();
   xc.get_mutable_generalized_velocity()[1] = 42.0;
   EXPECT_EQ(42.0, xc[3]);
   EXPECT_EQ(5.0, context_.get_continuous_state_vector()[3]);
@@ -578,6 +580,11 @@ TEST_F(LeafContextTest, BadClone) {
 TEST_F(LeafContextTest, CloneState) {
   std::unique_ptr<State<double>> clone = context_.CloneState();
   VerifyClonedState(*clone);
+
+  // Verify that the system id was copied.
+  const ContinuousState<double>& xc = clone->get_continuous_state();
+  EXPECT_TRUE(xc.get_system_id().is_valid());
+  EXPECT_EQ(xc.get_system_id(), context_.get_system_id());
 }
 
 // Tests that the State can be copied from another State.

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -912,8 +912,10 @@ class ComputationTestSystem final : public System<double> {
   // One q, one v, one z.
   std::unique_ptr<ContinuousState<double>> AllocateTimeDerivatives()
       const final {
-    return std::make_unique<ContinuousState<double>>(
+    auto result = std::make_unique<ContinuousState<double>>(
         std::make_unique<BasicVector<double>>(3), 1, 1, 1);  // q, v, z
+    result->set_system_id(this->get_system_id());
+    return result;
   }
 
   // Verify that the number of calls is as expected.


### PR DESCRIPTION
Towards #12560.

In retrospect, `ContinuousState` was not the easiest place to start.  Oh well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12630)
<!-- Reviewable:end -->
