### PR TITLE
tutorials directory link on drake front page uses binder

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -65,10 +65,10 @@ Tutorials and Examples
 
 .. TODO(russt): make this a table with different algorithms, too.
 
-We have Python tutorials implemented as Jupyter Notebooks in
-`the tutorials directory of the source tree
-<https://github.com/RobotLocomotion/drake/tree/master/tutorials>`_, with
-text explaining the high-level concepts and each of the main steps.
+We have Python tutorials implemented as Jupyter Notebooks in `the tutorials
+directory of the source tree
+<https://mybinder.org/v2/gh/RobotLocomotion/drake/master?filepath=tutorials/>`_,
+with text explaining the high-level concepts and each of the main steps.
 
 We have a number of use cases demonstrated in `the examples directory of
 the source tree


### PR DESCRIPTION
Rather than pointing to the github directory, this points them to the same directory on binder (where they can actually run the tutorials.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12635)
<!-- Reviewable:end -->
