### PR TITLE
Update links to reflect modified team names. 

### DIFF
--- a/doc/issues.rst
+++ b/doc/issues.rst
@@ -51,11 +51,11 @@ their responsibilities are:
   responsibilities: optimizers, solvers, symbolic analysis,
   ``drake/manipulation/`` subdirectory
 
-- ``robot locomotion group`` and ``6.832``
+- ``robot locomotion group``
 
   lead: RussTedrake
 
-  responsibilities: MIT CSAIL research lab / MIT courses
+  responsibilities: examples/requests from MIT projects / MIT courses
 
 .. _issues-priority:
 

--- a/doc/platform_reviewer_checklist.rst
+++ b/doc/platform_reviewer_checklist.rst
@@ -9,7 +9,7 @@ There are several policies documented in :ref:`GitHub Issue Management
 reviewer should run through this checklist at least once per day.
 
 Search for `issues without an assigned team
-<https://github.com/RobotLocomotion/drake/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+-label%3A%22team%3A+dynamics%22+-label%3A%22team%3A+kitware%22+-label%3A%22team%3A+manipulation%22+-label%3A%22team%3A+russ%22+-label%3A%22team%3A+robot+locomotion+group%22>`_
+<https://github.com/RobotLocomotion/drake/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+-label%3A%22team%3A+dynamics%22+-label%3A%22team%3A+kitware%22+-label%3A%22team%3A+manipulation%22+-label%3A%22team%3A+robot+locomotion+group%22>`_
 and assign a team.  When in doubt, seek advice on slack.
 
 Search for `issues without an assigned individual


### PR DESCRIPTION
MIT teams have been consolidated to `team: robot locomotion group` and `MIT 6.832` and `MIT 6.881` are separate (non-team) tags.

Resolves #12638

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12639)
<!-- Reviewable:end -->
