### PR TITLE
Add python binding for LinearCost and QuadraticCost constructors.

### DIFF
--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -1078,6 +1078,10 @@ top-level documentation for :py:mod:`pydrake.math`.
 
   py::class_<LinearCost, Cost, std::shared_ptr<LinearCost>>(
       m, "LinearCost", doc.LinearCost.doc)
+      .def(py::init([](const Eigen::VectorXd& a, double b) {
+        return std::unique_ptr<LinearCost>(new LinearCost(a, b));
+      }),
+          py::arg("a"), py::arg("b"), doc.LinearCost.ctor.doc)
       .def("a", &LinearCost::a, doc.LinearCost.a.doc)
       .def("b", &LinearCost::b, doc.LinearCost.b.doc)
       .def("UpdateCoefficients",
@@ -1089,6 +1093,11 @@ top-level documentation for :py:mod:`pydrake.math`.
 
   py::class_<QuadraticCost, Cost, std::shared_ptr<QuadraticCost>>(
       m, "QuadraticCost", doc.QuadraticCost.doc)
+      .def(py::init([](const Eigen::MatrixXd& Q, const Eigen::VectorXd& b,
+                        double c) {
+        return std::unique_ptr<QuadraticCost>(new QuadraticCost(Q, b, c));
+      }),
+          py::arg("Q"), py::arg("b"), py::arg("c"), doc.QuadraticCost.ctor.doc)
       .def("Q", &QuadraticCost::Q, doc.QuadraticCost.Q.doc)
       .def("b", &QuadraticCost::b, doc.QuadraticCost.b.doc)
       .def("c", &QuadraticCost::c, doc.QuadraticCost.c.doc)

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -27,6 +27,24 @@ import pydrake.symbolic as sym
 SNOPT_NO_GUROBI = SnoptSolver().available() and not GurobiSolver().available()
 
 
+class TestCost(unittest.TestCase):
+    def test_linear_cost(self):
+        a = np.array([1., 2.])
+        b = 0.5
+        cost = mp.LinearCost(a, b)
+        np.testing.assert_allclose(cost.a(), a)
+        self.assertEqual(cost.b(), b)
+
+    def test_quadratic_cost(self):
+        Q = np.array([[1., 2.], [2., 3.]])
+        b = np.array([3., 4.])
+        c = 0.4
+        cost = mp.QuadraticCost(Q, b, c)
+        np.testing.assert_allclose(cost.Q(), Q)
+        np.testing.assert_allclose(cost.b(), b)
+        self.assertEqual(cost.c(), c)
+
+
 class TestQP:
     def __init__(self):
         # Create a simple QP that uses all deduced linear constraint types,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12651)
<!-- Reviewable:end -->
