### PR TITLE
MBP's context in a output port. 

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -23,6 +23,7 @@ drake_cc_package_library(
         ":hydroelastic_contact_info",
         ":hydroelastic_quadrature_point_data",
         ":hydroelastic_traction",
+        ":kinematics_calculator",
         ":multibody_plant_core",
         ":point_pair_contact_info",
         ":tamsi_solver",
@@ -69,6 +70,20 @@ drake_cc_library(
         "//multibody/tree",
         "//systems/framework:diagram_builder",
         "//systems/framework:leaf_system",
+    ],
+)
+
+drake_cc_library(
+    name = "kinematics_calculator",
+    srcs = [
+        "kinematics_calculator.cc",
+    ],
+    hdrs = [
+        "kinematics_calculator.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":multibody_plant_core",
     ],
 )
 
@@ -520,6 +535,19 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//multibody/parsing",
         "//systems/analysis:simulator",
+    ],
+)
+
+drake_cc_googletest(
+    name = "kinematics_calculator_test",
+    data = [
+        "//manipulation/models/iiwa_description:models",
+    ],
+    deps = [
+        ":kinematics_calculator",
+        "//common:find_resource",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//multibody/parsing",
     ],
 )
 

--- a/multibody/plant/kinematics_calculator.cc
+++ b/multibody/plant/kinematics_calculator.cc
@@ -1,0 +1,37 @@
+#include "drake/multibody/plant/kinematics_calculator.h"
+
+#include <utility>
+
+#include "drake/common/default_scalars.h"
+
+namespace drake {
+namespace multibody {
+
+template <typename T>
+KinematicsCalculator<T>::KinematicsCalculator(const MultibodyPlant<T>* plant)
+    : plant_(*plant) {
+  this->DeclareVectorInputPort(
+      "state", systems::BasicVector<T>(plant_.num_multibody_states()));
+  this->set_name("kinematics_calculator");
+
+  auto alloc = [this]() {
+    auto context = plant_.CreateDefaultContext();
+    Value<systems::Context<T>> val{std::move(context)};
+    return val.Clone();
+  };
+
+  auto calc = [this](const systems::Context<T>& context, AbstractValue* val) {
+    auto& output = val->get_mutable_value<systems::Context<T>>();
+    const systems::BasicVector<T>* x = this->EvalVectorInput(context, 0);
+    plant_.SetPositionsAndVelocities(&output, x->get_value());
+  };
+
+  this->DeclareAbstractOutputPort("kinematics", alloc, calc,
+                                  {this->all_input_ports_ticket()});
+}
+
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::KinematicsCalculator)

--- a/multibody/plant/kinematics_calculator.h
+++ b/multibody/plant/kinematics_calculator.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "drake/common/drake_copyable.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace multibody {
+
+/**
+ * For a given MultibodyPlant, this system takes in a state vector input, and
+ * outputs a corresponding context, whose state matches the input. This system
+ * is motivated by a wide range of applications that need kinematics
+ * computation but want to avoid expensive allocation of a Context on every
+ * computation.
+ *
+ * @system{KinematicsCalculator,
+ *   @input_port(state)
+ *   @output_port(kinematics)
+ * }
+ */
+template <typename T>
+class KinematicsCalculator : public systems::LeafSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(KinematicsCalculator)
+
+  /**
+   * Constructs a KinematicsCalculator.
+   * @param[in] plant Const pointer to the MultibodyPlant. It is aliased
+   * internally.
+   */
+  explicit KinematicsCalculator(const MultibodyPlant<T>* plant);
+
+ private:
+  const MultibodyPlant<T>& plant_;
+};
+
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/test/kinematics_calculator_test.cc
+++ b/multibody/plant/test/kinematics_calculator_test.cc
@@ -1,0 +1,74 @@
+#include "drake/multibody/plant/kinematics_calculator.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/multibody/parsing/parser.h"
+
+namespace drake {
+namespace multibody {
+namespace {
+
+const char kIiwaFilePath[] =
+    "drake/manipulation/models/iiwa_description/sdf/iiwa14_no_collision.sdf";
+
+GTEST_TEST(KinematicsCalculatorTest, Test) {
+  MultibodyPlant<double> plant(0.0);
+  Parser(&plant).AddModelFromFile(FindResourceOrThrow(kIiwaFilePath));
+  plant.WeldFrames(plant.world_frame(), plant.GetFrameByName("iiwa_link_0"));
+  plant.Finalize();
+  auto plant_context = plant.CreateDefaultContext();
+
+  Eigen::VectorXd x(plant.num_multibody_states());
+  for (int i = 0; i < x.size(); i++) {
+    x[i] = static_cast<double>(i) / 10.0;
+  }
+  plant.SetPositionsAndVelocities(plant_context.get(), x);
+
+  KinematicsCalculator<double> dut(&plant);
+  auto context = dut.CreateDefaultContext();
+  dut.get_input_port(0).FixValue(context.get(), x);
+  const auto& output =
+      dut.get_output_port(0).Eval<systems::Context<double>>(*context);
+
+  const Frame<double>& link_7 = plant.GetFrameByName("iiwa_link_7");
+
+  // Check position.
+  math::RigidTransform<double> X_W7_expected =
+      plant.CalcRelativeTransform(*plant_context, plant.world_frame(), link_7);
+  math::RigidTransform<double> X_W7_result =
+      plant.CalcRelativeTransform(output, plant.world_frame(), link_7);
+
+  EXPECT_TRUE(X_W7_expected.IsExactlyEqualTo(X_W7_result));
+
+  // Check velocity.
+  const SpatialVelocity<double>& V_W7_expected =
+      plant.EvalBodySpatialVelocityInWorld(*plant_context, link_7.body());
+  const SpatialVelocity<double>& V_W7_result =
+      plant.EvalBodySpatialVelocityInWorld(output, link_7.body());
+
+  EXPECT_TRUE(CompareMatrices(V_W7_expected.rotational(),
+                              V_W7_result.rotational(), 1e-14));
+  EXPECT_TRUE(CompareMatrices(V_W7_expected.translational(),
+                              V_W7_result.translational(), 1e-14));
+
+  // Check Jacobian.
+  Eigen::MatrixXd J_expected(6, plant.num_velocities());
+  plant.CalcJacobianSpatialVelocity(
+      *plant_context, multibody::JacobianWrtVariable::kV, link_7,
+      Vector3<double>::Zero(), plant.world_frame(), plant.world_frame(),
+      &J_expected);
+  Eigen::MatrixXd J_result(6, plant.num_velocities());
+  plant.CalcJacobianSpatialVelocity(output, multibody::JacobianWrtVariable::kV,
+                                    link_7, Vector3<double>::Zero(),
+                                    plant.world_frame(), plant.world_frame(),
+                                    &J_result);
+  EXPECT_TRUE(CompareMatrices(J_expected, J_result, 1e-14));
+}
+
+}  // namespace
+}  // namespace multibody
+}  // namespace drake

--- a/systems/rendering/BUILD.bazel
+++ b/systems/rendering/BUILD.bazel
@@ -14,6 +14,7 @@ drake_cc_package_library(
     name = "rendering",
     deps = [
         ":frame_velocity",
+        ":frame_visualizer",
         ":multibody_position_to_geometry_pose",
         ":pose_aggregator",
         ":pose_bundle",
@@ -67,6 +68,20 @@ drake_cc_library(
         "//common:default_scalars",
         "//multibody/math:spatial_velocity",
         "//systems/framework:vector",
+    ],
+)
+
+drake_cc_library(
+    name = "frame_visualizer",
+    srcs = [
+        "frame_visualizer.cc",
+    ],
+    hdrs = [
+        "frame_visualizer.h",
+    ],
+    deps = [
+        "//lcmtypes:viewer",
+        "//multibody/plant",
     ],
 )
 
@@ -127,6 +142,19 @@ drake_cc_googletest(
     deps = [
         ":frame_velocity",
         "//common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "frame_visualizer_test",
+    data = [
+        "//manipulation/models/iiwa_description:models",
+    ],
+    deps = [
+        ":frame_visualizer",
+        "//common:find_resource",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//multibody/parsing",
     ],
 )
 

--- a/systems/rendering/frame_visualizer.cc
+++ b/systems/rendering/frame_visualizer.cc
@@ -1,0 +1,63 @@
+#include "drake/systems/rendering/frame_visualizer.h"
+
+#include <utility>
+
+#include "drake/common/extract_double.h"
+
+namespace drake {
+namespace systems {
+namespace rendering {
+
+using multibody::Frame;
+using multibody::MultibodyPlant;
+
+template <typename T>
+FrameVisualizer<T>::FrameVisualizer(const MultibodyPlant<T>* plant,
+                                    const std::vector<const Frame<T>*>& frames)
+    : plant_(*plant), frames_(frames) {
+  auto context = plant_.CreateDefaultContext();
+  Value<Context<T>> val{std::move(context)};
+  this->DeclareAbstractInputPort("kinematics", val);
+  this->DeclareAbstractOutputPort("visualization_message", lcmt_viewer_draw{},
+                                  &FrameVisualizer::CalcOutputMsg);
+  this->set_name("frame_visualizer");
+}
+
+template <typename T>
+void FrameVisualizer<T>::CalcOutputMsg(const Context<T>& context,
+                                       lcmt_viewer_draw* msg) const {
+  const auto& kinematics =
+      this->get_input_port(0).template Eval<Context<T>>(context);
+
+  msg->num_links = static_cast<int>(frames_.size());
+  msg->link_name.resize(msg->num_links);
+  msg->robot_num.resize(msg->num_links);
+
+  msg->position.resize(msg->num_links);
+  msg->quaternion.resize(msg->num_links);
+
+  for (size_t i = 0; i < frames_.size(); ++i) {
+    msg->link_name[i] = frames_[i]->name();
+    msg->robot_num[i] = frames_[i]->model_instance();
+    auto X_WF = plant_.CalcRelativeTransform(kinematics, plant_.world_frame(),
+                                             *frames_[i]);
+    msg->position[i].resize(3);
+    for (int j = 0; j < 3; j++) {
+      msg->position[i][j] =
+          static_cast<float>(ExtractDoubleOrThrow(X_WF.translation()[j]));
+    }
+    const auto quat = X_WF.rotation().ToQuaternion();
+    msg->quaternion[i].resize(4);
+    msg->quaternion[i][0] = static_cast<float>(ExtractDoubleOrThrow(quat.w()));
+    msg->quaternion[i][1] = static_cast<float>(ExtractDoubleOrThrow(quat.x()));
+    msg->quaternion[i][2] = static_cast<float>(ExtractDoubleOrThrow(quat.y()));
+    msg->quaternion[i][3] = static_cast<float>(ExtractDoubleOrThrow(quat.z()));
+  }
+}
+
+}  // namespace rendering
+}  // namespace systems
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class drake::systems::rendering::FrameVisualizer)

--- a/systems/rendering/frame_visualizer.h
+++ b/systems/rendering/frame_visualizer.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/lcmt_viewer_draw.hpp"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace systems {
+namespace rendering {
+
+/**
+ * This system takes in a Context<T> for the corresponding MultibodyPlant,
+ * and outputs a drake::lcmt_viewer_draw message for visualizing the requested
+ * frames with drake_visualizer.
+ *
+ * @system{FrameVisualizer,
+ *   @input_port(kinematics)
+ *   @output_port(visualization_message)
+ * }
+ */
+template <typename T>
+class FrameVisualizer final : public LeafSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FrameVisualizer)
+
+  /**
+   * Constructor.
+   * @param plant A const pointer to the MultibodyPlant. It is aliased
+   * internally, so its life span must be longer than this.
+   * @param frames A vector of frames in @p plant for visualization.
+   */
+  FrameVisualizer(const multibody::MultibodyPlant<T>* plant,
+                  const std::vector<const multibody::Frame<T>*>& frames);
+
+ private:
+  void CalcOutputMsg(const Context<T>& context, lcmt_viewer_draw* msg) const;
+
+  const multibody::MultibodyPlant<T>& plant_;
+  const std::vector<const multibody::Frame<T>*>& frames_;
+};
+
+}  // namespace rendering
+}  // namespace systems
+}  // namespace drake

--- a/systems/rendering/test/frame_visualizer_test.cc
+++ b/systems/rendering/test/frame_visualizer_test.cc
@@ -1,0 +1,77 @@
+#include "drake/systems/rendering/frame_visualizer.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/multibody/parsing/parser.h"
+
+namespace drake {
+namespace systems {
+namespace rendering {
+namespace {
+
+using multibody::Frame;
+using multibody::MultibodyPlant;
+
+const char kIiwaFilePath[] =
+    "drake/manipulation/models/iiwa_description/sdf/iiwa14_no_collision.sdf";
+
+GTEST_TEST(FrameVisualizerTest, Test) {
+  MultibodyPlant<double> plant(0.0);
+  drake::multibody::Parser(&plant).AddModelFromFile(
+      FindResourceOrThrow(kIiwaFilePath));
+  plant.WeldFrames(plant.world_frame(), plant.GetFrameByName("iiwa_link_0"));
+  plant.Finalize();
+  auto plant_context = plant.CreateDefaultContext();
+  Eigen::VectorXd x(plant.num_multibody_states());
+  for (int i = 0; i < x.size(); i++) {
+    x[i] = static_cast<double>(i) / 10.0;
+  }
+  plant.SetPositionsAndVelocities(plant_context.get(), x);
+
+  const std::vector<const Frame<double>*> frames_to_visualize = {
+      &plant.GetFrameByName("iiwa_link_1"),
+      &plant.GetFrameByName("iiwa_link_7"),
+  };
+  std::vector<math::RigidTransform<double>> expected_X_WF;
+  for (const auto* frame : frames_to_visualize) {
+    expected_X_WF.push_back(plant.CalcRelativeTransform(
+        *plant_context, plant.world_frame(), *frame));
+  }
+
+  FrameVisualizer<double> dut(&plant, frames_to_visualize);
+  auto context = dut.CreateDefaultContext();
+  dut.get_input_port(0).FixValue(
+      context.get(), Value<Context<double>>{plant_context->Clone()});
+  const auto& message = dut.get_output_port(0).Eval<lcmt_viewer_draw>(*context);
+
+  // Check message output.
+  EXPECT_EQ(message.num_links, static_cast<int>(frames_to_visualize.size()));
+  EXPECT_EQ(frames_to_visualize.size(), message.link_name.size());
+  EXPECT_EQ(frames_to_visualize.size(), message.robot_num.size());
+  EXPECT_EQ(frames_to_visualize.size(), message.position.size());
+  EXPECT_EQ(frames_to_visualize.size(), message.quaternion.size());
+
+  for (size_t i = 0; i < frames_to_visualize.size(); i++) {
+    const Eigen::Vector3f pos = expected_X_WF[i].translation().cast<float>();
+    const Eigen::Quaternion<float> quat =
+        expected_X_WF[i].rotation().ToQuaternion().cast<float>();
+    EXPECT_EQ(message.link_name[i], frames_to_visualize[i]->name());
+    for (int j = 0; j < 3; j++) {
+      EXPECT_EQ(message.position[i][j], pos[j]);
+    }
+    EXPECT_EQ(message.quaternion[i][0], quat.w());
+    EXPECT_EQ(message.quaternion[i][1], quat.x());
+    EXPECT_EQ(message.quaternion[i][2], quat.y());
+    EXPECT_EQ(message.quaternion[i][3], quat.z());
+    EXPECT_EQ(message.robot_num[i], frames_to_visualize[i]->model_instance());
+  }
+}
+
+}  // namespace
+}  // namespace rendering
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
I think there are a bunch of use cases for a system to take kinematics as input. The most common solution that I am aware of is for these systems to declare a state input, then with either a mutable member field Context or allocating a Context on every computation to do the kinematics. Neither is pretty. So I made the kinematics_calculator system, and frame_visualizer is a demo application that I revived from attic. 
@amcastro-tri @sherm1 @RussTedrake @edrumwri what do you guys think?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12662)
<!-- Reviewable:end -->
