### PR TITLE
workspace: Remove visibility annotation on json stub

### DIFF
--- a/tools/workspace/json/package.BUILD.bazel
+++ b/tools/workspace/json/package.BUILD.bazel
@@ -18,10 +18,11 @@ cc_library(
     deprecation = "DRAKE DEPRECATED: The @json external is being removed from Drake on or after 2020-05-01.  Downstream projects should add it to their own WORKSPACE if needed.",  # noqa
 )
 
+# N.B. Not intended for public use!  This is only intended for the regression
+# test in @drake//tools/workspace/json, and will be removed on 2020-05-01.
 cc_library(
     name = "json_for_stub_test",
     deps = [":json"],
-    visibility = ["@drake//tools/workspace/json:__pkg__"],
 )
 
 install(


### PR DESCRIPTION
Older versions of Bazel (1.2.1) too-strictly enforce this visibility, leading to build failures.

Repairs #12666 ([build failures](https://drake-jenkins.csail.mit.edu/view/Production/job/mac-catalina-clang-bazel-nightly-debug/111/)).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12676)
<!-- Reviewable:end -->
