### PR TITLE
common: Hide filesystem.h from downstreams

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -32,7 +32,6 @@ drake_cc_package_library(
         ":dummy_value",
         ":essential",
         ":extract_double",
-        ":filesystem",
         ":find_resource",
         ":find_runfiles",
         ":hash",
@@ -311,15 +310,21 @@ drake_cc_library(
     visibility = ["//tools/install/libdrake:__pkg__"],
 )
 
+# The drake::filesystem support is intended ONLY for use within Drake's *.cc
+# files -- it is not a public dependency of Drake.  As such, we compile it with
+# hidden visibility, exclude its header file from the install, and exclude it
+# from the //common:common package_library shortcut.
 drake_cc_library(
     name = "filesystem",
     srcs = ["filesystem.cc"],
     hdrs = ["filesystem.h"],
-    copts = [
-        # The drake::filesystem support is intended ONLY for use within Drake's
-        # *.cc files -- it is not a public dependency of Drake.
-        "-fvisibility=hidden",
+    copts = ["-fvisibility=hidden"],
+    install_hdrs_exclude = ["filesystem.h"],
+    tags = [
+        "exclude_from_libdrake",
+        "exclude_from_package",
     ],
+    visibility = ["//:__subpackages__"],
     deps = [
         "@ghc_filesystem",
     ],


### PR DESCRIPTION
This file was documented as being for Drake internal use only, but was still being installed.  This removes it from the install image, and sets bazel visibility to only allow use from within Drake.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12686)
<!-- Reviewable:end -->
