### PR TITLE
Move kuka_simulation (and dependencies) off of RigidBodyTree

### DIFF
--- a/examples/kuka_iiwa_arm/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/BUILD.bazel
@@ -95,6 +95,8 @@ drake_cc_library(
     deps = [
         "//attic/multibody:rigid_body_tree",
         "//attic/systems/controllers:rbt_inverse_dynamics",
+        "//multibody/plant",
+        "//systems/controllers:inverse_dynamics",
         "//systems/controllers:pid_controller",
         "//systems/controllers:state_feedback_controller_interface",
         "//systems/framework:diagram_builder",
@@ -165,13 +167,13 @@ drake_cc_binary(
         ":iiwa_common",
         ":iiwa_lcm",
         ":kuka_torque_controller",
-        "//attic/manipulation/util:sim_diagram_builder",
-        "//attic/multibody:rigid_body_tree_construction",
-        "//attic/multibody/rigid_body_plant:frame_visualizer",
-        "//attic/systems/controllers:rbt_inverse_dynamics_controller",
         "//common:add_text_logging_gflags",
+        "//geometry:geometry_visualization",
         "//lcm",
+        "//multibody/parsing",
+        "//multibody/plant",
         "//systems/analysis",
+        "//systems/controllers:inverse_dynamics_controller",
         "//systems/controllers:state_feedback_controller_interface",
         "//systems/primitives:constant_vector_source",
         "//systems/primitives:demultiplexer",
@@ -242,6 +244,7 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "kuka_torque_controller_test",
+    copts = ["-Wno-deprecated-declarations"],
     data = [
         "//manipulation/models/iiwa_description:models",
     ],
@@ -251,6 +254,7 @@ drake_cc_googletest(
         "//attic/multibody:rigid_body_tree",
         "//attic/multibody:rigid_body_tree_construction",
         "//common/test_utilities:eigen_matrix_compare",
+        "//multibody/parsing",
     ],
 )
 

--- a/examples/kuka_iiwa_arm/iiwa_common.h
+++ b/examples/kuka_iiwa_arm/iiwa_common.h
@@ -6,6 +6,7 @@
 
 #include "robotlocomotion/robot_plan_t.hpp"
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/trajectories/piecewise_polynomial.h"
 #include "drake/manipulation/kuka_iiwa/iiwa_constants.h"
@@ -29,6 +30,7 @@ using manipulation::kuka_iiwa::get_iiwa_max_joint_velocities;
 /// @param wsg_instance Identifier for the gripper in @p world_tree.
 /// @return Lumped inertia parameters.
 template <typename T>
+DRAKE_DEPRECATED("2020-05-01", "This function is being removed.")
 Matrix6<T> ComputeLumpedGripperInertiaInEndEffectorFrame(
     const RigidBodyTree<T>& world_tree,
     int iiwa_instance, const std::string& end_effector_link_name,
@@ -42,6 +44,7 @@ void VerifyIiwaTree(const RigidBodyTree<double>& tree);
 /// the model specified by @model_file_name.
 /// This method is a convenience wrapper over `AddModelInstanceFromUrdfFile`.
 /// @see drake::parsers::urdf::AddModelInstanceFromUrdfFile
+DRAKE_DEPRECATED("2020-05-01", "This function is being removed.")
 void CreateTreedFromFixedModelAtPose(
     const std::string& model_file_name, RigidBodyTreed* tree,
     const Eigen::Vector3d& position = Eigen::Vector3d::Zero(),

--- a/examples/kuka_iiwa_arm/kuka_simulation.cc
+++ b/examples/kuka_iiwa_arm/kuka_simulation.cc
@@ -11,19 +11,16 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/find_resource.h"
-#include "drake/common/text_logging.h"
 #include "drake/examples/kuka_iiwa_arm/iiwa_common.h"
 #include "drake/examples/kuka_iiwa_arm/iiwa_lcm.h"
 #include "drake/examples/kuka_iiwa_arm/kuka_torque_controller.h"
+#include "drake/geometry/geometry_visualization.h"
+#include "drake/geometry/scene_graph.h"
 #include "drake/lcmt_iiwa_command.hpp"
 #include "drake/lcmt_iiwa_status.hpp"
-#include "drake/manipulation/util/sim_diagram_builder.h"
-#include "drake/multibody/parsers/urdf_parser.h"
-#include "drake/multibody/rigid_body_plant/frame_visualizer.h"
-#include "drake/multibody/rigid_body_plant/rigid_body_plant.h"
-#include "drake/multibody/rigid_body_tree_construction.h"
+#include "drake/multibody/parsing/parser.h"
 #include "drake/systems/analysis/simulator.h"
-#include "drake/systems/controllers/rbt_inverse_dynamics_controller.h"
+#include "drake/systems/controllers/inverse_dynamics_controller.h"
 #include "drake/systems/controllers/state_feedback_controller_interface.h"
 #include "drake/systems/framework/diagram.h"
 #include "drake/systems/framework/diagram_builder.h"
@@ -31,7 +28,6 @@
 #include "drake/systems/lcm/lcm_interface_system.h"
 #include "drake/systems/lcm/lcm_publisher_system.h"
 #include "drake/systems/lcm/lcm_subscriber_system.h"
-#include "drake/systems/primitives/constant_vector_source.h"
 #include "drake/systems/primitives/demultiplexer.h"
 #include "drake/systems/primitives/discrete_derivative.h"
 
@@ -43,58 +39,48 @@ DEFINE_double(target_realtime_rate, 1.0,
               "Playback speed.  See documentation for "
               "Simulator::set_target_realtime_rate() for details.");
 DEFINE_bool(torque_control, false, "Simulate using torque control mode.");
+DEFINE_double(sim_dt, 3e-3,
+              "The time step to use for MultibodyPlant model "
+              "discretization.");
 
 namespace drake {
 namespace examples {
 namespace kuka_iiwa_arm {
 namespace {
-using manipulation::util::SimDiagramBuilder;
-using systems::ConstantVectorSource;
+using multibody::MultibodyPlant;
 using systems::Context;
 using systems::Demultiplexer;
-using systems::Diagram;
-using systems::DiagramBuilder;
 using systems::StateInterpolatorWithDiscreteDerivative;
-using systems::FrameVisualizer;
-using systems::RigidBodyPlant;
 using systems::Simulator;
-using systems::controllers::rbt::InverseDynamicsController;
+using systems::controllers::InverseDynamicsController;
 using systems::controllers::StateFeedbackControllerInterface;
 
 int DoMain() {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  // N.B. If SimDiagramBuilder reaches its deprecation date of 2020-05-01 prior
-  // to kuka_simulation being rewritten, then instead of completely removing
-  // the SimDiagramBuilder, we should instead mark it private, remove it from
-  // the installation, but keep using it here.
-  SimDiagramBuilder<double> builder;
-#pragma GCC diagnostic pop
-  systems::DiagramBuilder<double>* base_builder = builder.get_mutable_builder();
+  systems::DiagramBuilder<double> builder;
 
   // Adds a plant.
-  RigidBodyPlant<double>* plant = nullptr;
+  // NOLINTNEXTLINE(whitespace/braces
+  auto [plant, scene_graph] = multibody::AddMultibodyPlantSceneGraph(
+      &builder, FLAGS_sim_dt);
   const char* kModelPath =
       "drake/manipulation/models/iiwa_description/"
       "urdf/iiwa14_polytope_collision.urdf";
   const std::string urdf =
       (!FLAGS_urdf.empty() ? FLAGS_urdf : FindResourceOrThrow(kModelPath));
-  {
-    auto tree = std::make_unique<RigidBodyTree<double>>();
-    parsers::urdf::AddModelInstanceFromUrdfFileToWorld(
-        urdf, multibody::joints::kFixed, tree.get());
-    multibody::AddFlatTerrainToWorld(tree.get(), 100., 10.);
-    plant = builder.AddPlant(std::move(tree));
-  }
-  // Creates and adds LCM publisher for visualization.
-  auto lcm = base_builder->AddSystem<systems::lcm::LcmInterfaceSystem>();
-  builder.AddVisualizer(lcm);
-  builder.get_visualizer()->set_publish_period(kIiwaLcmStatusPeriod);
+  auto iiwa_instance = multibody::Parser(
+      &plant, &scene_graph).AddModelFromFile(urdf);
+  plant.WeldFrames(plant.world_frame(), plant.GetFrameByName("base"));
+  plant.Finalize();
 
-  const RigidBodyTree<double>& tree = plant->get_rigid_body_tree();
-  const int num_joints = tree.get_num_positions();
+  // TODO(sammy-tri) Add a floor.
+
+  // Creates and adds LCM publisher for visualization.
+  auto lcm = builder.AddSystem<systems::lcm::LcmInterfaceSystem>();
+  geometry::ConnectDrakeVisualizer(&builder, scene_graph, lcm);
+
+  const int num_joints = plant.num_positions();
   DRAKE_DEMAND(num_joints % kIiwaArmNumJoints == 0);
-  const int num_iiwa = num_joints/kIiwaArmNumJoints;
+  const int num_iiwa = num_joints / kIiwaArmNumJoints;
 
   // Adds a iiwa controller.
   StateFeedbackControllerInterface<double>* controller = nullptr;
@@ -103,108 +89,76 @@ int DoMain() {
     SetTorqueControlledIiwaGains(&stiffness, &damping_ratio);
     stiffness = stiffness.replicate(num_iiwa, 1).eval();
     damping_ratio = damping_ratio.replicate(num_iiwa, 1).eval();
-    controller = builder.AddController<KukaTorqueController<double>>(
-        RigidBodyTreeConstants::kFirstNonWorldModelInstanceId, tree.Clone(),
-        stiffness, damping_ratio);
+    controller = builder.AddSystem<KukaTorqueController<double>>(
+        plant, stiffness, damping_ratio);
   } else {
     VectorX<double> iiwa_kp, iiwa_kd, iiwa_ki;
     SetPositionControlledIiwaGains(&iiwa_kp, &iiwa_ki, &iiwa_kd);
     iiwa_kp = iiwa_kp.replicate(num_iiwa, 1).eval();
     iiwa_kd = iiwa_kd.replicate(num_iiwa, 1).eval();
     iiwa_ki = iiwa_ki.replicate(num_iiwa, 1).eval();
-    controller = builder.AddController<InverseDynamicsController<double>>(
-        RigidBodyTreeConstants::kFirstNonWorldModelInstanceId, tree.Clone(),
-        iiwa_kp, iiwa_ki, iiwa_kd,
+    controller = builder.AddSystem<InverseDynamicsController<double>>(
+        plant, iiwa_kp, iiwa_ki, iiwa_kd,
         false /* without feedforward acceleration */);
   }
 
   // Create the command subscriber and status publisher.
-  auto command_sub = base_builder->AddSystem(
+  auto command_sub = builder.AddSystem(
       systems::lcm::LcmSubscriberSystem::Make<drake::lcmt_iiwa_command>(
           "IIWA_COMMAND", lcm));
   command_sub->set_name("command_subscriber");
   auto command_receiver =
-      base_builder->AddSystem<IiwaCommandReceiver>(num_joints);
+      builder.AddSystem<IiwaCommandReceiver>(num_joints);
   command_receiver->set_name("command_receiver");
-  std::vector<int> iiwa_instances =
-      {RigidBodyTreeConstants::kFirstNonWorldModelInstanceId};
-  auto external_torque_converter =
-      base_builder->AddSystem<IiwaContactResultsToExternalTorque>(
-          tree, iiwa_instances);
-  auto plant_state_demux = base_builder->AddSystem<Demultiplexer>(
+  auto plant_state_demux = builder.AddSystem<Demultiplexer>(
       2 * num_joints, num_joints);
   plant_state_demux->set_name("plant_state_demux");
-  auto desired_state_from_position = base_builder->AddSystem<
+  auto desired_state_from_position = builder.AddSystem<
       StateInterpolatorWithDiscreteDerivative>(
           num_joints, kIiwaLcmStatusPeriod);
   desired_state_from_position->set_name("desired_state_from_position");
-  auto status_pub = base_builder->AddSystem(
+  auto status_pub = builder.AddSystem(
       systems::lcm::LcmPublisherSystem::Make<lcmt_iiwa_status>(
           "IIWA_STATUS", lcm, kIiwaLcmStatusPeriod /* publish period */));
   status_pub->set_name("status_publisher");
-  auto status_sender = base_builder->AddSystem<IiwaStatusSender>(num_joints);
+  auto status_sender = builder.AddSystem<IiwaStatusSender>(num_joints);
   status_sender->set_name("status_sender");
 
-  base_builder->Connect(command_sub->get_output_port(),
-                        command_receiver->get_input_port());
-  base_builder->Connect(command_receiver->get_commanded_position_output_port(),
-                        desired_state_from_position->get_input_port());
-  base_builder->Connect(desired_state_from_position->get_output_port(),
-                        controller->get_input_port_desired_state());
-  base_builder->Connect(plant->get_output_port(0),
-                        plant_state_demux->get_input_port(0));
-  base_builder->Connect(plant_state_demux->get_output_port(0),
-                        status_sender->get_position_measured_input_port());
-  base_builder->Connect(plant_state_demux->get_output_port(0),
-                        status_sender->get_velocity_estimated_input_port());
-  base_builder->Connect(command_receiver->get_commanded_position_output_port(),
-                        status_sender->get_position_commanded_input_port());
-  base_builder->Connect(controller->get_output_port_control(),
-                        status_sender->get_torque_commanded_input_port());
-  base_builder->Connect(plant->torque_output_port(),
-                        status_sender->get_torque_measured_input_port());
-  base_builder->Connect(plant->contact_results_output_port(),
-                        external_torque_converter->get_input_port(0));
-  base_builder->Connect(external_torque_converter->get_output_port(0),
-                        status_sender->get_torque_external_input_port());
-  base_builder->Connect(status_sender->get_output_port(),
-                        status_pub->get_input_port());
+  builder.Connect(command_sub->get_output_port(),
+                  command_receiver->get_input_port());
+  builder.Connect(command_receiver->get_commanded_position_output_port(),
+                  desired_state_from_position->get_input_port());
+  builder.Connect(desired_state_from_position->get_output_port(),
+                  controller->get_input_port_desired_state());
+  builder.Connect(plant.get_state_output_port(iiwa_instance),
+                  plant_state_demux->get_input_port(0));
+  builder.Connect(plant_state_demux->get_output_port(0),
+                  status_sender->get_position_measured_input_port());
+  builder.Connect(plant_state_demux->get_output_port(0),
+                  status_sender->get_velocity_estimated_input_port());
+  builder.Connect(command_receiver->get_commanded_position_output_port(),
+                  status_sender->get_position_commanded_input_port());
+  builder.Connect(plant.get_state_output_port(),
+                  controller->get_input_port_estimated_state());
+  builder.Connect(controller->get_output_port_control(),
+                  plant.get_actuation_input_port(iiwa_instance));
+  builder.Connect(controller->get_output_port_control(),
+                  status_sender->get_torque_commanded_input_port());
+  builder.Connect(controller->get_output_port_control(),
+                  status_sender->get_torque_measured_input_port());
+  // TODO(sammy-tri) Add a low-pass filter for simulated external torques.
+  builder.Connect(
+      plant.get_generalized_contact_forces_output_port(iiwa_instance),
+      status_sender->get_torque_external_input_port());
+  builder.Connect(status_sender->get_output_port(),
+                  status_pub->get_input_port());
   // Connect the torque input in torque control
   if (FLAGS_torque_control) {
     KukaTorqueController<double>* torque_controller =
         dynamic_cast<KukaTorqueController<double>*>(controller);
     DRAKE_DEMAND(torque_controller);
-    base_builder->Connect(command_receiver->get_commanded_torque_output_port(),
-                          torque_controller->get_input_port_commanded_torque());
-  }
-
-  if (FLAGS_visualize_frames) {
-    // TODO(sam.creasey) This try/catch block is here because even
-    // though RigidBodyTree::FindBody returns a pointer and could return
-    // null to indicate failure, it throws instead.  At any rate, warn
-    // instead of dying if the links aren't named as expected.  This
-    // happens (for example) when loading
-    // dual_iiwa14_polytope_collision.urdf.
-    try {
-    // Visualizes the end effector frame and 7th body's frame.
-      std::vector<RigidBodyFrame<double>> local_transforms;
-      local_transforms.push_back(
-          RigidBodyFrame<double>("iiwa_link_ee", tree.FindBody("iiwa_link_ee"),
-                                 Isometry3<double>::Identity()));
-      local_transforms.push_back(
-          RigidBodyFrame<double>("iiwa_link_7", tree.FindBody("iiwa_link_7"),
-                                 Isometry3<double>::Identity()));
-      auto frame_viz = base_builder->AddSystem<systems::FrameVisualizer>(
-          &tree, local_transforms, lcm);
-      base_builder->Connect(plant->get_output_port(0),
-                            frame_viz->get_input_port(0));
-      frame_viz->set_publish_period(kIiwaLcmStatusPeriod);
-    } catch (std::logic_error& ex) {
-      drake::log()->error("Unable to visualize end effector frames:\n{}\n"
-                          "Maybe use --novisualize_frames?",
-                          ex.what());
-      return 1;
-    }
+    builder.Connect(command_receiver->get_commanded_torque_output_port(),
+                    torque_controller->get_input_port_commanded_torque());
   }
 
   auto sys = builder.Build();
@@ -218,7 +172,7 @@ int DoMain() {
   command_receiver->set_initial_position(
       &sys->GetMutableSubsystemContext(*command_receiver,
                                        &simulator.get_mutable_context()),
-      VectorX<double>::Zero(tree.get_num_positions()));
+      VectorX<double>::Zero(plant.num_positions()));
 
   // Simulate for a very long time.
   simulator.AdvanceTo(FLAGS_simulation_sec);

--- a/examples/kuka_iiwa_arm/kuka_torque_controller.cc
+++ b/examples/kuka_iiwa_arm/kuka_torque_controller.cc
@@ -3,6 +3,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/systems/controllers/inverse_dynamics.h"
 #include "drake/systems/controllers/pid_controller.h"
 #include "drake/systems/controllers/rbt_inverse_dynamics.h"
 #include "drake/systems/framework/diagram_builder.h"
@@ -21,15 +22,14 @@ using drake::systems::Context;
 using drake::systems::DiagramBuilder;
 using drake::systems::LeafSystem;
 using drake::systems::PassThrough;
-using drake::systems::controllers::rbt::InverseDynamics;
 using drake::systems::controllers::PidController;
 
 template <typename T>
-class StateDependentDamper : public LeafSystem<T> {
+class StateDependentDamperRbt : public LeafSystem<T> {
  public:
-  StateDependentDamper(const RigidBodyTree<T>& tree,
-                       const VectorX<double>& stiffness,
-                       const VectorX<double>& damping_ratio)
+  StateDependentDamperRbt(const RigidBodyTree<T>& tree,
+                          const VectorX<double>& stiffness,
+                          const VectorX<double>& damping_ratio)
       : tree_(tree), stiffness_(stiffness), damping_ratio_(damping_ratio) {
     const int num_q = tree_.get_num_positions();
     const int num_v = tree_.get_num_velocities();
@@ -40,7 +40,7 @@ class StateDependentDamper : public LeafSystem<T> {
 
     this->DeclareInputPort(kVectorValued, num_x);
     this->DeclareVectorOutputPort(BasicVector<T>(num_v),
-                                  &StateDependentDamper<T>::CalcTorque);
+                                  &StateDependentDamperRbt<T>::CalcTorque);
   }
 
  private:
@@ -74,8 +74,66 @@ class StateDependentDamper : public LeafSystem<T> {
 };
 
 template <typename T>
-void KukaTorqueController<T>::SetUp(const VectorX<double>& stiffness,
-                                    const VectorX<double>& damping_ratio) {
+class StateDependentDamper : public LeafSystem<T> {
+ public:
+  StateDependentDamper(const multibody::MultibodyPlant<T>& plant,
+                       const VectorX<double>& stiffness,
+                       const VectorX<double>& damping_ratio)
+      : plant_(plant), stiffness_(stiffness), damping_ratio_(damping_ratio) {
+    const int num_q = plant_.num_positions();
+    const int num_v = plant_.num_velocities();
+    const int num_x = num_q + num_v;
+
+    DRAKE_DEMAND(stiffness.size() == num_v);
+    DRAKE_DEMAND(damping_ratio.size() == num_v);
+
+    this->DeclareInputPort(kVectorValued, num_x);
+    this->DeclareVectorOutputPort(BasicVector<T>(num_v),
+                                  &StateDependentDamper<T>::CalcTorque);
+    // Make context with default parameters.
+    plant_context_ = plant_.CreateDefaultContext();
+  }
+
+ private:
+  const multibody::MultibodyPlant<T>& plant_;
+  const VectorX<double> stiffness_;
+  const VectorX<double> damping_ratio_;
+
+  // This context is used solely for setting generalized positions and
+  // velocities in multibody_plant_.
+  std::unique_ptr<Context<T>> plant_context_;
+
+  /**
+   * Computes joint level damping forces by computing the damping ratio for each
+   * joint independently as if all other joints were fixed. Note that the
+   * effective inertia of a joint, when all of the other joints are fixed, is
+   * given by the corresponding diagonal entry of the mass matrix. The critical
+   * damping gain for the i-th joint is given by 2*sqrt(M(i,i)*stiffness(i)).
+   */
+  void CalcTorque(const Context<T>& context, BasicVector<T>* torque) const {
+    Eigen::VectorXd x = this->EvalVectorInput(context, 0)->get_value();
+    plant_.SetPositionsAndVelocities(plant_context_.get(), x);
+
+    const int num_v = plant_.num_velocities();
+    Eigen::MatrixXd H(num_v, num_v);
+    plant_.CalcMassMatrixViaInverseDynamics(*plant_context_, &H);
+
+    // Compute critical damping gains and scale by damping ratio. Use Eigen
+    // arrays (rather than matrices) for elementwise multiplication.
+    Eigen::ArrayXd temp =
+        H.diagonal().array() * stiffness_.array();
+    Eigen::ArrayXd damping_gains = 2 * temp.sqrt();
+    damping_gains *= damping_ratio_.array();
+
+    // Compute damping torque.
+    Eigen::VectorXd v = x.tail(plant_.num_velocities());
+    torque->get_mutable_value() = -(damping_gains * v.array()).matrix();
+  }
+};
+
+template <typename T>
+void KukaTorqueController<T>::SetUpRbt(const VectorX<double>& stiffness,
+                                       const VectorX<double>& damping_ratio) {
   DiagramBuilder<T> builder;
   const RigidBodyTree<T>& tree = *robot_for_control_;
   DRAKE_DEMAND(tree.get_num_positions() == stiffness.size());
@@ -98,6 +156,7 @@ void KukaTorqueController<T>::SetUp(const VectorX<double>& stiffness,
   auto pass_through = builder.template AddSystem<PassThrough<T>>(2 * dim);
 
   // Add gravity compensator.
+  using drake::systems::controllers::rbt::InverseDynamics;
   auto gravity_comp =
       builder.template AddSystem<InverseDynamics<T>>(
           &tree, InverseDynamics<T>::kGravityCompensation);
@@ -110,8 +169,87 @@ void KukaTorqueController<T>::SetUp(const VectorX<double>& stiffness,
   auto spring = builder.template AddSystem<PidController<T>>(stiffness, kd, ki);
 
   // Adds virtual damper.
-  auto damper = builder.template AddSystem<StateDependentDamper<T>>(
+  auto damper = builder.template AddSystem<StateDependentDamperRbt<T>>(
       tree, stiffness, damping_ratio);
+
+  // Adds an adder to sum the gravity compensation, spring, damper, and
+  // feedforward torque.
+  auto adder = builder.template AddSystem<Adder<T>>(4, dim);
+
+  // Connects the estimated state to the gravity compensator.
+  builder.Connect(pass_through->get_output_port(),
+                  gravity_comp->get_input_port_estimated_state());
+
+  // Connects the estimated state to the spring.
+  builder.Connect(pass_through->get_output_port(),
+                  spring->get_input_port_estimated_state());
+
+  // Connects the estimated state to the damper.
+  builder.Connect(pass_through->get_output_port(),
+                  damper->get_input_port(0));
+
+  // Connects the gravity compensation, spring, and damper torques to the adder.
+  builder.Connect(gravity_comp->get_output_port(0), adder->get_input_port(1));
+  builder.Connect(spring->get_output_port(0), adder->get_input_port(2));
+  builder.Connect(damper->get_output_port(0), adder->get_input_port(3));
+
+  // Exposes the estimated state port.
+  input_port_index_estimated_state_ =
+      builder.ExportInput(pass_through->get_input_port());
+
+  // Exposes the desired state port.
+  input_port_index_desired_state_ =
+      builder.ExportInput(spring->get_input_port_desired_state());
+
+  // Exposes the commanded torque port.
+  input_port_index_commanded_torque_ =
+      builder.ExportInput(adder->get_input_port(0));
+
+  // Exposes controller output.
+  output_port_index_control_ = builder.ExportOutput(adder->get_output_port());
+
+  builder.BuildInto(this);
+}
+
+template <typename T>
+void KukaTorqueController<T>::SetUp(const VectorX<double>& stiffness,
+                                    const VectorX<double>& damping_ratio) {
+  DiagramBuilder<T> builder;
+  DRAKE_DEMAND(plant_.num_positions() == stiffness.size());
+  DRAKE_DEMAND(plant_.num_positions() == damping_ratio.size());
+
+  const int dim = plant_.num_positions();
+
+  /*
+  torque_in ----------------------------
+                                       |
+  (q, v)    ------>|Gravity Comp|------+---> torque_out
+               |                      /|
+               --->|Damping|---------- |
+               |                       |
+               --->| Virtual Spring |---
+  (q*, v*)  ------>|PID with kd=ki=0|
+  */
+
+  // Redirects estimated state input into PID and gravity compensation.
+  auto pass_through = builder.template AddSystem<PassThrough<T>>(2 * dim);
+
+  // Add gravity compensator.
+  using drake::systems::controllers::InverseDynamics;
+  auto gravity_comp =
+      builder.template AddSystem<InverseDynamics<T>>(
+          &plant_, InverseDynamics<T>::kGravityCompensation);
+
+  // Adds virtual springs.
+  Eigen::VectorXd kd(dim);
+  Eigen::VectorXd ki(dim);
+  kd.setZero();
+  ki.setZero();
+  auto spring = builder.template AddSystem<PidController<T>>(stiffness, kd, ki);
+
+  // Adds virtual damper.
+  auto damper = builder.template AddSystem<StateDependentDamper<T>>(
+      plant_, stiffness, damping_ratio);
 
   // Adds an adder to sum the gravity compensation, spring, damper, and
   // feedforward torque.
@@ -155,8 +293,20 @@ void KukaTorqueController<T>::SetUp(const VectorX<double>& stiffness,
 template <typename T>
 KukaTorqueController<T>::KukaTorqueController(
     std::unique_ptr<RigidBodyTree<T>> tree, const VectorX<double>& stiffness,
-    const VectorX<double>& damping) {
+    const VectorX<double>& damping)
+    : placeholder_for_rbt_version_(0.0),
+      plant_(placeholder_for_rbt_version_) {
   robot_for_control_ = std::move(tree);
+  SetUpRbt(stiffness, damping);
+}
+
+template <typename T>
+KukaTorqueController<T>::KukaTorqueController(
+    const multibody::MultibodyPlant<T>& plant,
+    const VectorX<double>& stiffness,
+    const VectorX<double>& damping)
+    : placeholder_for_rbt_version_(0.0),
+      plant_(plant) {
   SetUp(stiffness, damping);
 }
 

--- a/examples/kuka_iiwa_arm/kuka_torque_controller.h
+++ b/examples/kuka_iiwa_arm/kuka_torque_controller.h
@@ -4,6 +4,8 @@
 #include <string>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
+#include "drake/multibody/plant/multibody_plant.h"
 #include "drake/multibody/rigid_body_tree.h"
 #include "drake/systems/controllers/state_feedback_controller_interface.h"
 #include "drake/systems/framework/diagram.h"
@@ -30,9 +32,19 @@ class KukaTorqueController
       public systems::controllers::StateFeedbackControllerInterface<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(KukaTorqueController)
+
+  DRAKE_DEPRECATED("2020-05-01",
+                   "The RigidBodyTree version is being removed.")
   KukaTorqueController(std::unique_ptr<RigidBodyTree<T>> tree,
                        const VectorX<double>& stiffness,
                        const VectorX<double>& damping);
+
+  /// @p plant is aliased and must remain valid for the lifetime of the
+  /// controller.
+  KukaTorqueController(
+      const multibody::MultibodyPlant<T>& plant,
+      const VectorX<double>& stiffness,
+      const VectorX<double>& damping);
 
   const systems::InputPort<T>& get_input_port_commanded_torque() const {
     return systems::Diagram<T>::get_input_port(
@@ -55,7 +67,11 @@ class KukaTorqueController
  private:
   void SetUp(const VectorX<double>& stiffness,
              const VectorX<double>& damping_ratio);
+  void SetUpRbt(const VectorX<double>& stiffness,
+                const VectorX<double>& damping_ratio);
   std::unique_ptr<RigidBodyTree<T>> robot_for_control_{nullptr};
+  multibody::MultibodyPlant<T> placeholder_for_rbt_version_;
+  const multibody::MultibodyPlant<T>& plant_;
   int input_port_index_estimated_state_{-1};
   int input_port_index_desired_state_{-1};
   int input_port_index_commanded_torque_{-1};

--- a/examples/kuka_iiwa_arm/test/kuka_torque_controller_test.cc
+++ b/examples/kuka_iiwa_arm/test/kuka_torque_controller_test.cc
@@ -6,6 +6,7 @@
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/examples/kuka_iiwa_arm/iiwa_common.h"
 #include "drake/multibody/parsers/urdf_parser.h"
+#include "drake/multibody/parsing/parser.h"
 #include "drake/multibody/rigid_body_tree.h"
 #include "drake/multibody/rigid_body_tree_construction.h"
 
@@ -15,14 +16,39 @@ namespace kuka_iiwa_arm {
 
 using drake::systems::BasicVector;
 
+namespace {
+Eigen::VectorXd CalcGravityCompensationTorque(
+    const multibody::MultibodyPlant<double>& plant,
+    const Eigen::VectorXd& q,
+    Eigen::MatrixXd* H = nullptr) {
+
+  // Compute gravity compensation torque.
+  std::unique_ptr<systems::Context<double>> plant_context =
+      plant.CreateDefaultContext();
+  Eigen::VectorXd zero_velocity = Eigen::VectorXd::Zero(kIiwaArmNumJoints);
+  plant.SetPositions(plant_context.get(), q);
+  plant.SetVelocities(plant_context.get(), zero_velocity);
+
+  if (H) {
+    plant.CalcMassMatrixViaInverseDynamics(*plant_context, H);
+  }
+
+  multibody::MultibodyForces<double> external_forces(plant);
+  plant.CalcForceElementsContribution(*plant_context, &external_forces);
+  return plant.CalcInverseDynamics(*plant_context, zero_velocity,
+                                   external_forces);
+}
+
+}  // namespace
+
 GTEST_TEST(KukaTorqueControllerTest, GravityCompensationTest) {
   const std::string kIiwaUrdf =
     "manipulation/models/iiwa_description/urdf/"
     "iiwa14_polytope_collision.urdf";
-  auto tree_ptr = std::make_unique<RigidBodyTree<double>>();
-  parsers::urdf::AddModelInstanceFromUrdfFileToWorld(
-      kIiwaUrdf, multibody::joints::kFixed, tree_ptr.get());
-  const RigidBodyTree<double>& tree = *tree_ptr;
+  multibody::MultibodyPlant<double> plant(0.0);
+  multibody::Parser(&plant).AddModelFromFile(kIiwaUrdf);
+  plant.WeldFrames(plant.world_frame(), plant.GetFrameByName("base"));
+  plant.Finalize();
 
   // Set stiffness and damping to zero.
   VectorX<double> stiffness(kIiwaArmNumJoints);
@@ -43,8 +69,7 @@ GTEST_TEST(KukaTorqueControllerTest, GravityCompensationTest) {
   torque_des.setZero();
 
   // Compute controller output.
-  KukaTorqueController<double> controller(std::move(tree_ptr), stiffness,
-                                          damping);
+  KukaTorqueController<double> controller(plant, stiffness, damping);
 
   std::unique_ptr<systems::Context<double>> context =
       controller.CreateDefaultContext();
@@ -67,12 +92,8 @@ GTEST_TEST(KukaTorqueControllerTest, GravityCompensationTest) {
   controller.get_input_port_commanded_torque().FixValue(context.get(),
                                                         desired_torque_input);
 
-  // Compute gravity compensation torque.
-  Eigen::VectorXd zero_velocity = Eigen::VectorXd::Zero(kIiwaArmNumJoints);
-  auto cache = tree.doKinematics(q, zero_velocity);
-  const RigidBodyTree<double>::BodyToWrenchMap no_external_wrenches;
-  auto expected_torque =
-      tree.dynamicsBiasTerm(cache, no_external_wrenches, false);
+  Eigen::VectorXd expected_torque =
+      CalcGravityCompensationTorque(plant, q);
 
   // Check output.
   controller.CalcOutput(*context, output.get());
@@ -85,10 +106,10 @@ GTEST_TEST(KukaTorqueControllerTest, SpringTorqueTest) {
   const std::string kIiwaUrdf =
     "manipulation/models/iiwa_description/urdf/"
     "iiwa14_polytope_collision.urdf";
-  auto tree_ptr = std::make_unique<RigidBodyTree<double>>();
-  parsers::urdf::AddModelInstanceFromUrdfFileToWorld(
-      kIiwaUrdf, multibody::joints::kFixed, tree_ptr.get());
-  const RigidBodyTree<double>& tree = *tree_ptr;
+  multibody::MultibodyPlant<double> plant(0.0);
+  multibody::Parser(&plant).AddModelFromFile(kIiwaUrdf);
+  plant.WeldFrames(plant.world_frame(), plant.GetFrameByName("base"));
+  plant.Finalize();
 
   // Set nonzero stiffness and zero damping.
   VectorX<double> stiffness(kIiwaArmNumJoints);
@@ -109,8 +130,7 @@ GTEST_TEST(KukaTorqueControllerTest, SpringTorqueTest) {
   torque_des.setZero();
 
   // Compute controller output.
-  KukaTorqueController<double> controller(std::move(tree_ptr), stiffness,
-                                          damping);
+  KukaTorqueController<double> controller(plant, stiffness, damping);
 
   std::unique_ptr<systems::Context<double>> context =
       controller.CreateDefaultContext();
@@ -134,11 +154,8 @@ GTEST_TEST(KukaTorqueControllerTest, SpringTorqueTest) {
                                                         desired_torque_input);
 
   // Compute gravity compensation torque.
-  Eigen::VectorXd zero_velocity = Eigen::VectorXd::Zero(kIiwaArmNumJoints);
-  auto cache = tree.doKinematics(q, zero_velocity);
-  const RigidBodyTree<double>::BodyToWrenchMap no_external_wrenches;
-  auto expected_torque =
-      tree.dynamicsBiasTerm(cache, no_external_wrenches, false);
+  Eigen::VectorXd expected_torque =
+      CalcGravityCompensationTorque(plant, q);
 
   // Compute spring torque.
   expected_torque += -((q - q_des).array() * stiffness.array()).matrix();
@@ -154,10 +171,10 @@ GTEST_TEST(KukaTorqueControllerTest, DampingTorqueTest) {
   const std::string kIiwaUrdf =
     "manipulation/models/iiwa_description/urdf/"
     "iiwa14_polytope_collision.urdf";
-  auto tree_ptr = std::make_unique<RigidBodyTree<double>>();
-  parsers::urdf::AddModelInstanceFromUrdfFileToWorld(
-      kIiwaUrdf, multibody::joints::kFixed, tree_ptr.get());
-  const RigidBodyTree<double>& tree = *tree_ptr;
+  multibody::MultibodyPlant<double> plant(0.0);
+  multibody::Parser(&plant).AddModelFromFile(kIiwaUrdf);
+  plant.WeldFrames(plant.world_frame(), plant.GetFrameByName("base"));
+  plant.Finalize();
 
   // Set arbitrary stiffness and damping.
   VectorX<double> stiffness(kIiwaArmNumJoints);
@@ -178,8 +195,7 @@ GTEST_TEST(KukaTorqueControllerTest, DampingTorqueTest) {
   torque_des.setZero();
 
   // Compute controller output.
-  KukaTorqueController<double> controller(std::move(tree_ptr), stiffness,
-                                          damping);
+  KukaTorqueController<double> controller(plant, stiffness, damping);
 
   std::unique_ptr<systems::Context<double>> context =
       controller.CreateDefaultContext();
@@ -202,22 +218,19 @@ GTEST_TEST(KukaTorqueControllerTest, DampingTorqueTest) {
   controller.get_input_port_commanded_torque().FixValue(context.get(),
                                                         desired_torque_input);
 
-  // Compute gravity compensation torque.
-  Eigen::VectorXd zero_velocity = Eigen::VectorXd::Zero(kIiwaArmNumJoints);
-  auto cache = tree.doKinematics(q, zero_velocity);
-  const RigidBodyTree<double>::BodyToWrenchMap no_external_wrenches;
-  auto expected_torque =
-      tree.dynamicsBiasTerm(cache, no_external_wrenches, false);
+  // Compute gravity compensation torque and mass matrix.
+  Eigen::MatrixXd H(kIiwaArmNumJoints, kIiwaArmNumJoints);
+  Eigen::VectorXd expected_torque =
+      CalcGravityCompensationTorque(plant, q, &H);
 
   // Compute spring torque.
   expected_torque += -((q - q_des).array() * stiffness.array()).matrix();
 
   // Compute damping torque.
   Eigen::VectorXd damping_torque(7);
-  auto M = tree.massMatrix(cache);
   for (int i = 0; i < kIiwaArmNumJoints; i++) {
     damping_torque(i) =
-        -v(i) * damping(i) * 2 * std::sqrt(M(i, i) * stiffness(i));
+        -v(i) * damping(i) * 2 * std::sqrt(H(i, i) * stiffness(i));
   }
   expected_torque += damping_torque;
 


### PR DESCRIPTION
Also deprecates some RBT-based items which are no longer used.