### PR TITLE
Modifies MBP body -> SG Frame registration

### DIFF
--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -152,10 +152,12 @@ void ParseBody(const multibody::PackageMap& package_map,
 
 // Parse the collision filter group tag information into the collision filter
 // groups and a set of pairs between which the collisions will be excluded.
+// @pre plant.geometry_source_is_registered() is `true`.
 void RegisterCollisionFilterGroup(
     const MultibodyPlant<double>& plant, XMLElement* node,
     std::map<std::string, geometry::GeometrySet>* collision_filter_groups,
     std::set<SortedPair<std::string>>* collision_filter_pairs) {
+  DRAKE_DEMAND(plant.geometry_source_is_registered());
   std::string drake_ignore;
   if (ParseStringAttribute(node, "ignore", &drake_ignore) &&
       drake_ignore == std::string("true")) {
@@ -202,8 +204,10 @@ void RegisterCollisionFilterGroup(
   }
 }
 
+// @pre plant->geometry_source_is_registered() is `true`.
 void ParseCollisionFilterGroup(XMLElement* node,
                                MultibodyPlant<double>* plant) {
+  DRAKE_DEMAND(plant->geometry_source_is_registered());
   std::map<std::string, geometry::GeometrySet> collision_filter_groups;
   std::set<SortedPair<std::string>> collision_filter_pairs;
   for (XMLElement* group_node =

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -349,6 +349,9 @@ geometry::SourceId MultibodyPlant<T>::RegisterAsSourceForSceneGraph(
   body_index_to_frame_id_[world_index()] = world_frame_id;
   frame_id_to_body_index_[world_frame_id] = world_index();
   DeclareSceneGraphPorts();
+  // In case any bodies were added before registering scene graph, make sure the
+  // bodies get their corresponding geometry frame ids.
+  RegisterGeometryFramesForAllBodies();
   return source_id_.value();
 }
 
@@ -515,18 +518,7 @@ geometry::GeometryId MultibodyPlant<T>::RegisterGeometry(
     const std::string& name) {
   DRAKE_ASSERT(!is_finalized());
   DRAKE_ASSERT(geometry_source_is_registered());
-  // If not already done, register a frame for this body.
-  if (!body_has_registered_frame(body)) {
-    FrameId frame_id = member_scene_graph().RegisterFrame(
-        source_id_.value(),
-        GeometryFrame(
-            GetScopedName(*this, body.model_instance(), body.name()),
-            /* TODO(@SeanCurtis-TRI): Add test coverage for this
-             * model-instance support as requested in #9390. */
-            body.model_instance()));
-    body_index_to_frame_id_[body.index()] = frame_id;
-    frame_id_to_body_index_[frame_id] = body.index();
-  }
+  DRAKE_ASSERT(body_has_registered_frame(body));
 
   // Register geometry in the body frame.
   std::unique_ptr<geometry::GeometryInstance> geometry_instance =
@@ -545,11 +537,22 @@ void MultibodyPlant<T>::RegisterGeometryFramesForAllBodies() {
   // If not, create and attach one.
   for (BodyIndex body_index(0); body_index < num_bodies(); ++body_index) {
     const auto& body = get_body(body_index);
+    RegisterRigidBodyWithSceneGraph(body);
+  }
+}
+
+template <typename T>
+void MultibodyPlant<T>::RegisterRigidBodyWithSceneGraph(
+    const Body<T>& body) {
+  if (geometry_source_is_registered()) {
+    // If not already done, register a frame for this body.
     if (!body_has_registered_frame(body)) {
       FrameId frame_id = member_scene_graph().RegisterFrame(
           source_id_.value(),
           GeometryFrame(
               GetScopedName(*this, body.model_instance(), body.name()),
+              /* TODO(@SeanCurtis-TRI): Add test coverage for this
+               * model-instance support as requested in #9390. */
               body.model_instance()));
       body_index_to_frame_id_[body.index()] = frame_id;
       frame_id_to_body_index_[frame_id] = body.index();
@@ -627,7 +630,6 @@ void MultibodyPlant<T>::Finalize() {
   // After finalizing the base class, tree is read-only.
   internal::MultibodyTreeSystem<T>::Finalize();
   if (geometry_source_is_registered()) {
-    RegisterGeometryFramesForAllBodies();
     FilterAdjacentBodies();
     ExcludeCollisionsWithVisualGeometry();
   }

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -621,6 +621,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     collision_geometries_.emplace_back();
     DRAKE_DEMAND(X_WB_default_list_.size() == body.index());
     X_WB_default_list_.emplace_back();
+    RegisterRigidBodyWithSceneGraph(body);
     return body;
   }
 
@@ -3613,6 +3614,10 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     return body_index_to_frame_id_.find(body.index()) !=
         body_index_to_frame_id_.end();
   }
+
+  // Registers the given body with this plant's SceneGraph instance (if it has
+  // one).
+  void RegisterRigidBodyWithSceneGraph(const Body<T>& body);
 
   // Calc method for the multibody state vector output port. It only copies the
   // multibody state [q, v], ignoring any miscellaneous state z if present.


### PR DESCRIPTION
If an MBP is associated with a SG, the goal is to have every body associated with an SG FrameId, whether it has geometry or not. The current implementation does this in two ways:

  1. Greedily register a body with SG when a geometry is assigned to it.
  2. At finalize, find any bodies that haven't been registered and register      them.

This is incompatible with defining collision filter groups. We should be able to put a body in a collision filter group (even if it doesnt have any geometry -- it just won't cause anything to be filtered). But that work flow requires getting that body's FrameId *before* finalization (at least in how the parsing is currently implemented).

With the same end goal that every body has a frame id, this PR changes the implementation:

  1. If a SceneGraph is attached, the act of adding a body registers it immediately.
  2. When "attaching" the SceneGraph, it looks to see if any bodies were added previously and registers them then.

Therefore, we no longer wait for finalization and we're guaranteed that if there is a SceneGraph attached, every body definitely has a frame.

resolves #12644

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12690)
<!-- Reviewable:end -->
