### PR TITLE
doc: Platform reviewers should merge PRs

### DIFF
--- a/doc/code_review_checklist.rst
+++ b/doc/code_review_checklist.rst
@@ -118,6 +118,19 @@ Did you use a C-style cast by accident?
 - You very, very rarely want ``reinterpret_cast``.  Use with great
   caution.
 
+Did you change third-party software?
+====================================
+
+Changes to third-party software (e.g., upgrading to a newer version) are the
+most common cause of CI divergence between Ubuntu and macOS.  For PRs with such
+changes, be sure to opt-in to the pre-merge macOS builds.
+
+:ref:`Schedule an on-demand build <run_specific_build>` using one build from
+each macOS revision currently available in CI.  For example:
+
+* ``@drake-jenkins-bot mac-mojave-clang-bazel-experimental-release please``
+* ``@drake-jenkins-bot mac-catalina-clang-bazel-experimental-everything-release please``
+
 Have you run linting tools?
 ===========================
 

--- a/doc/developers.rst
+++ b/doc/developers.rst
@@ -217,11 +217,17 @@ make the review faster.
 - @soonho-tri (Toyota Research Institute)
 - @RussTedrake (MIT / Toyota Research Institute)
 
-**Merge.** If you have write access to RobotLocomotion/drake, a green
-"Merge Pull Request" button will appear when your change is fully reviewed and
-passes CI. You may click it to merge your PR. If you do not have write access,
-or if you believe that status checks are failing for inconsequential reasons,
-ask your platform reviewer to perform the merge for you.
+**Merge.** Once the PR is fully reviewed and passes CI, the assigned platform
+reviewer will merge it to master.  If time is of the essence, you may post a
+reminder to the PR to get the reviewer's attention.  If the PR should not be
+merged yet, or if you prefer to merge it yourself, apply the label "status:
+do not merge" to disable the merge.
+
+If you are a frequent contributor who has been granted write access to
+RobotLocomotion/drake, a green "Merge Pull Request" button will appear when
+your change is fully reviewed and passes CI. You may click it to merge your PR.
+Choose the "Squash and merge option" unless otherwise instructed (see
+:ref:`curate_commits_before_merging`).
 
 **After Merge.** If your PR breaks continuous integration, the :doc:`buildcop`
 will contact you to work out a resolution.

--- a/doc/platform_reviewer_checklist.rst
+++ b/doc/platform_reviewer_checklist.rst
@@ -25,3 +25,7 @@ by a core Drake Developer, leaving it unassigned may be acceptable when it is
 clearly an early work-in-progress -- but if it is unassigned for several days,
 you should probably encourage the developer to label it "do not review" for
 clarity.
+
+For PRs assigned to you that have passed all commit checks (other than needing
+a squash), merge the PR to master on behalf of the author -- unless it is
+labeled "status: do not merge".

--- a/doc/reviewable.rst
+++ b/doc/reviewable.rst
@@ -64,7 +64,8 @@ Often a PR may end up with more than one commit, including "work-in-progress"
 checkpoints or "fix review comments" pushes.  In that case, when the PR is
 ready to merge, the author of a PR has three choices for how to proceed:
 
-* Ask the assigned Platform Reviewer to "Squash and merge" the PR.
+* Wait for the assigned Platform Reviewer to "Squash and merge" the PR.
+  If time is of the essence, post a reminder to the PR.
 * Locally (rebase and) squash the PR down to a single commit, and force-push
   that commit into the PR.
 * Apply the label ``status: squashing now`` and then immediately use the "squash


### PR DESCRIPTION
Also add checklist item for macOS on third-party version bumps.

(Both as discussed at the most recent platform review meeting.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12692)
<!-- Reviewable:end -->
