### PR TITLE
doc: macOS pre-merge validation should prefer Catalina

### DIFF
--- a/doc/code_review_checklist.rst
+++ b/doc/code_review_checklist.rst
@@ -123,12 +123,11 @@ Did you change third-party software?
 
 Changes to third-party software (e.g., upgrading to a newer version) are the
 most common cause of CI divergence between Ubuntu and macOS.  For PRs with such
-changes, be sure to opt-in to the pre-merge macOS builds.
+changes, be sure to opt-in to a pre-merge macOS build.
 
-:ref:`Schedule an on-demand build <run_specific_build>` using one build from
-each macOS revision currently available in CI.  For example:
+:ref:`Schedule one on-demand build <run_specific_build>` using an "everything"
+flavor, for example:
 
-* ``@drake-jenkins-bot mac-mojave-clang-bazel-experimental-release please``
 * ``@drake-jenkins-bot mac-catalina-clang-bazel-experimental-everything-release please``
 
 Have you run linting tools?

--- a/doc/jenkins.rst
+++ b/doc/jenkins.rst
@@ -109,7 +109,6 @@ unprovisioned experimental builds, e.g.:
 
 * ``@drake-jenkins-bot linux-bionic-unprovisioned-gcc-bazel-experimental-release please``
 * ``@drake-jenkins-bot mac-catalina-unprovisioned-clang-bazel-experimental-release please``
-* ``@drake-jenkins-bot mac-mojave-unprovisioned-clang-bazel-experimental-release please``
 
 After this has passed, go through normal review. Once normal review is done,
 add ``@jamiesnape`` for review and request that the provisioned instances be


### PR DESCRIPTION
Testing on Catalina only is good enough, because Catalina and Mojave are basically identical as far as what Drake uses.

Note that packaging builds still use (only) Mojave.

Follow-up from #12692.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12695)
<!-- Reviewable:end -->
