### PR TITLE
[geometry] SceneGraph given a new query: hydroelastic with (point pair) fallback

### DIFF
--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -392,6 +392,16 @@ class GeometryState {
     return geometry_engine_->ComputeContactSurfaces(X_WGs_);
   }
 
+  /** Implementation of QueryObject::ComputeContactSurfacesWithFallback().  */
+  void ComputeContactSurfacesWithFallback(
+      std::vector<ContactSurface<T>>* surfaces,
+      std::vector<PenetrationAsPointPair<double>>* point_pairs) const {
+    DRAKE_DEMAND(surfaces);
+    DRAKE_DEMAND(point_pairs);
+    return geometry_engine_->ComputeContactSurfacesWithFallback(
+        X_WGs_, surfaces, point_pairs);
+  }
+
   /** Implementation of QueryObject::FindCollisionCandidates().  */
   std::vector<SortedPair<GeometryId>> FindCollisionCandidates() const {
     return geometry_engine_->FindCollisionCandidates();

--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -138,6 +138,7 @@ drake_cc_library(
         ":collision_filter_legacy",
         ":hydroelastic_internal",
         ":mesh_intersection",
+        ":penetration_as_point_pair_callback",
         ":proximity_utilities",
         ":surface_mesh",
         ":volume_mesh",

--- a/geometry/proximity/hydroelastic_callback.h
+++ b/geometry/proximity/hydroelastic_callback.h
@@ -13,8 +13,10 @@
 #include "drake/geometry/proximity/collision_filter_legacy.h"
 #include "drake/geometry/proximity/hydroelastic_internal.h"
 #include "drake/geometry/proximity/mesh_intersection.h"
+#include "drake/geometry/proximity/penetration_as_point_pair_callback.h"
 #include "drake/geometry/proximity/proximity_utilities.h"
 #include "drake/geometry/query_results/contact_surface.h"
+#include "drake/geometry/query_results/penetration_as_point_pair.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/math/rotation_matrix.h"
 
@@ -74,16 +76,83 @@ struct CallbackData {
   std::vector<ContactSurface<T>>& surfaces;
 };
 
-/** The callback function for computing a hydroelastic contact surface between
- two arbitrary shapes.
+enum class CalcContactSurfaceResult {
+  kCalculated,      //< Computation was successful; a contact surface is only
+                    //< produced if the objects were in contact.
+  kUnsupported,     //< Contact surface can't be computed for the geometry pair.
+  kSameCompliance   //< The two geometries have the same compliance.
+};
 
- @param object_A_ptr    Pointer to the first object in the pair (the order has
-                        no significance).
- @param object_B_ptr    Pointer to the second object in the pair (the order has
-                        no significance).
- @param callback_data   Supporting data to compute the contact surface.
- @returns false; the broadphase should *not* terminate its process.
+
+/** Calculates the contact surface (if it exists) between two potentially
+ colliding geometries.
+
+ @param object_A_ptr         Pointer to the first object in the pair (the order
+                             has no significance).
+ @param object_B_ptr         Pointer to the second object in the pair (the order
+                             has no significance).
+ @param[out] callback_data   Supporting data to compute the contact surface. If
+                             the objects collide, a ContactSurface instance will
+                             be added to the data.
+ @returns The result from attempting to perform the calculation (indicating if
+          it was supported or not -- and in what way).
  @tparam T  The scalar type for the query.  */
+template <typename T>
+CalcContactSurfaceResult MaybeCalcContactSurface(
+    fcl::CollisionObjectd* object_A_ptr, fcl::CollisionObjectd* object_B_ptr,
+    CallbackData<T>* data) {
+  const EncodedData encoding_a(*object_A_ptr);
+  const EncodedData encoding_b(*object_B_ptr);
+
+  const HydroelasticType type_A =
+      data->geometries.hydroelastic_type(encoding_a.id());
+  const HydroelasticType type_B =
+      data->geometries.hydroelastic_type(encoding_b.id());
+  if (type_A == HydroelasticType::kUndefined ||
+      type_B == HydroelasticType::kUndefined) {
+    return CalcContactSurfaceResult::kUnsupported;
+  }
+  if (type_A == type_B) {
+    return CalcContactSurfaceResult::kSameCompliance;
+  }
+
+  bool A_is_rigid = type_A == HydroelasticType::kRigid;
+  const GeometryId id_S = A_is_rigid ? encoding_b.id() : encoding_a.id();
+  const GeometryId id_R = A_is_rigid ? encoding_a.id() : encoding_b.id();
+
+  const math::RigidTransform<T>& X_WS(data->X_WGs.at(id_S));
+  const math::RigidTransform<T>& X_WR(data->X_WGs.at(id_R));
+
+  // TODO(SeanCurtis-TRI): We are currently assuming that *everything* is a
+  //  mesh. When rigid and compliant half spaces are fully supported modify
+  //  this.
+  const SoftGeometry& soft = data->geometries.soft_geometry(id_S);
+  const VolumeMeshField<double, double>& field_S = soft.pressure_field();
+  const BoundingVolumeHierarchy<VolumeMesh<double>>& bvh_S = soft.bvh();
+  const RigidGeometry& rigid = data->geometries.rigid_geometry(id_R);
+  const SurfaceMesh<double>& mesh_R = rigid.mesh();
+  const BoundingVolumeHierarchy<SurfaceMesh<double>>& bvh_R = rigid.bvh();
+
+  // TODO(SeanCurtis-TRI): There are multiple heap allocations implicit in
+  // this (resizing vector, constructing mesh and pressure field), this *may*
+  // prove to be too expensive to be in the inner loop of the simulation.
+  // Keep an eye on this.
+  std::unique_ptr<ContactSurface<T>> surface =
+      ComputeContactSurfaceFromSoftVolumeRigidSurface(
+          id_S, field_S, bvh_S, X_WS, id_R, mesh_R, bvh_R, X_WR);
+  if (surface != nullptr) {
+    DRAKE_DEMAND(surface->id_M() < surface->id_N());
+    data->surfaces.emplace_back(std::move(*surface));
+  }
+
+  return CalcContactSurfaceResult::kCalculated;
+}
+
+/** Assess contact between two objects -- if it can't be determined with
+ hydroelastic contact, it throws an exception. All parameters are as documented
+ in MaybeCalcContactSurface().
+ @returns `false`; the broad phase should _not_ terminate its process.
+ @pre `callback_data` must be an instance of CallbackData.  */
 template <typename T>
 bool Callback(fcl::CollisionObjectd* object_A_ptr,
               fcl::CollisionObjectd* object_B_ptr,
@@ -98,55 +167,88 @@ bool Callback(fcl::CollisionObjectd* object_A_ptr,
       encoding_a.encoding(), encoding_b.encoding());
 
   if (can_collide) {
+    CalcContactSurfaceResult result =
+        MaybeCalcContactSurface(object_A_ptr, object_B_ptr, &data);
+
+    // Surface calculated; we're done.
+    if (result == CalcContactSurfaceResult::kCalculated) return false;
+
     const HydroelasticType type_A =
         data.geometries.hydroelastic_type(encoding_a.id());
     const HydroelasticType type_B =
         data.geometries.hydroelastic_type(encoding_b.id());
-    if (type_A == HydroelasticType::kUndefined ||
-        type_B == HydroelasticType::kUndefined) {
-      throw std::logic_error(fmt::format(
-          "Requested a contact surface between a pair of geometries without "
-          "hydroelastic representation for at least one shape: a {} {} with id "
-          "{} and a {} {} with id {}",
-          type_A, GetGeometryName(*object_A_ptr), encoding_a.id(), type_B,
-          GetGeometryName(*object_B_ptr), encoding_b.id()));
+
+    switch (result) {
+      case CalcContactSurfaceResult::kUnsupported:
+        throw std::logic_error(fmt::format(
+            "Requested a contact surface between a pair of geometries without "
+            "hydroelastic representation for at least one shape: a {} {} with "
+            "id {} and a {} {} with id {}",
+            type_A, GetGeometryName(*object_A_ptr), encoding_a.id(), type_B,
+            GetGeometryName(*object_B_ptr), encoding_b.id()));
+      case CalcContactSurfaceResult::kSameCompliance:
+        throw std::logic_error(fmt::format(
+            "Requested contact between two {} objects ({} with id "
+            "{}, {} with id {}); only rigid-soft pairs are currently supported",
+            type_A, GetGeometryName(*object_A_ptr), encoding_a.id(),
+            GetGeometryName(*object_B_ptr), encoding_b.id()));
+      default:
+        DRAKE_UNREACHABLE();
     }
-    if (type_A == type_B) {
-      throw std::logic_error(fmt::format(
-          "Requested contact between two {} objects ({} with id "
-          "{}, {} with id {}); only rigid-soft pairs are currently supported",
-          type_A, GetGeometryName(*object_A_ptr), encoding_a.id(),
-          GetGeometryName(*object_B_ptr), encoding_b.id()));
-    }
+  }
 
-    const bool A_is_rigid = type_A == HydroelasticType::kRigid;
-    const GeometryId id_S = A_is_rigid ? encoding_b.id() : encoding_a.id();
-    const GeometryId id_R = A_is_rigid ? encoding_a.id() : encoding_b.id();
+  // Tell the broadphase to keep searching.
+  return false;
+}
 
-    const math::RigidTransform<T>& X_WS(data.X_WGs.at(id_S));
-    const math::RigidTransform<T>& X_WR(data.X_WGs.at(id_R));
+/** Supporting data for the shape-to-shape hydroelastic contact callback with
+ fallback (see CallbackWithFallback below). It includes:
 
-    // TODO(SeanCurtis-TRI): We are currently assuming that *everything* is a
-    //  mesh. When rigid and compliant half spaces are fully supported modify
-    //  this.
-    const SoftGeometry& soft = data.geometries.soft_geometry(id_S);
-    const VolumeMeshField<double, double>& field_S = soft.pressure_field();
-    const BoundingVolumeHierarchy<VolumeMesh<double>>& bvh_S = soft.bvh();
-    const RigidGeometry& rigid = data.geometries.rigid_geometry(id_R);
-    const SurfaceMesh<double>& mesh_R = rigid.mesh();
-    const BoundingVolumeHierarchy<SurfaceMesh<double>>& bvh_R = rigid.bvh();
+    - CallbackData for strict hydroelastic contact (see above).
+    - A vector of contacts represented as point pairs -- comprising of those
+      contacts which could not be evaluated with hydroelastic models.
 
-    // TODO(SeanCurtis-TRI): There are multiple heap allocations implicit in
-    // this (resizing vector, constructing mesh and pressure field), this *may*
-    // prove to be too expensive to be in the inner loop of the simulation.
-    // Keep an eye on this.
-    std::unique_ptr<ContactSurface<T>> surface =
-        ComputeContactSurfaceFromSoftVolumeRigidSurface(
-            id_S, field_S, bvh_S, X_WS, id_R, mesh_R, bvh_R, X_WR);
-    if (surface != nullptr) {
-      DRAKE_DEMAND(surface->id_M() < surface->id_N());
-      data.surfaces.emplace_back(std::move(*surface));
-    }
+ @tparam T The computation scalar.  */
+template <typename T>
+struct CallbackWithFallbackData {
+  CallbackData<T> data;
+  std::vector<PenetrationAsPointPair<double>>* point_pairs;
+};
+
+/** Assess contact between two objects -- if it can't be determined with
+ hydroelastic contact, it assess the contact using point-contact. All parameters
+ are as documented in MaybeCalcContactSurface(). However, both ContactSurface
+ and PenetrationAsPointPair instances are written to the `callback_data`.
+
+ @returns `false`; the broad phase should _not_ terminate its process.
+ @pre `callback_data` must be an instance of CallbackWithFallbackData.  */
+template <typename T>
+bool CallbackWithFallback(fcl::CollisionObjectd* object_A_ptr,
+                          fcl::CollisionObjectd* object_B_ptr,
+                          // NOLINTNEXTLINE
+                          void* callback_data) {
+  auto& data = *static_cast<CallbackWithFallbackData<T>*>(callback_data);
+
+  const EncodedData encoding_a(*object_A_ptr);
+  const EncodedData encoding_b(*object_B_ptr);
+
+  const bool can_collide = data.data.collision_filter.CanCollideWith(
+      encoding_a.encoding(), encoding_b.encoding());
+
+  if (can_collide) {
+    CalcContactSurfaceResult result =
+        MaybeCalcContactSurface(object_A_ptr, object_B_ptr, &data.data);
+
+    // Surface calculated; we're done.
+    if (result == CalcContactSurfaceResult::kCalculated) return false;
+
+    // Fall back to point pair.
+    // TODO(SeanCurtis-TRI): This is a problem; point pair is only double.
+    //   fallback can only be double.
+    penetration_as_point_pair::CallbackData point_data{
+        &data.data.collision_filter, data.point_pairs};
+    penetration_as_point_pair::Callback(object_A_ptr, object_B_ptr,
+                                        &point_data);
   }
   // Tell the broadphase to keep searching.
   return false;

--- a/geometry/proximity/test/hydroelastic_callback_test.cc
+++ b/geometry/proximity/test/hydroelastic_callback_test.cc
@@ -50,7 +50,10 @@ ProximityProperties soft_properties() {
 
 // TODO(SeanCurtis-TRI): When autodiff is more generally supported, replace the
 //  simple exception-expecting call (AutoDiffBlanketFailure) and add AutoDiff
-//  into this type list: ScalarTypes.
+//  into the type list: ScalarTypes.
+
+// Infrastructure to repeat tests on both double (and, someday, AutoDiffXd).
+using ScalarTypes = ::testing::Types<double>;
 
 // Confirmation of the short-term behavior that invoking the callback on
 // potentially colliding geometry using AutoDiffXd-valued transforms will throw.
@@ -91,201 +94,389 @@ GTEST_TEST(HydroelasticCallbackAutodiff, AutoDiffBlanketFailure) {
       Callback<AutoDiffXd>(&object_A, &object_B, &data), std::logic_error,
       "AutoDiff-valued ContactSurface calculation between meshes is not"
       "currently supported");
+
+  vector<PenetrationAsPointPair<double>> point_pairs;
+  CallbackWithFallbackData<AutoDiffXd> fallback_data{
+      {&collision_filter, &X_WGs, &hydroelastic_geometries, &surfaces},
+      &point_pairs};
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      CallbackWithFallback<AutoDiffXd>(&object_A, &object_B, &fallback_data),
+      std::logic_error,
+      "AutoDiff-valued ContactSurface calculation between meshes is not"
+      "currently supported");
 }
 
-// Infrastructure to repeat tests on both double and AutoDiffXd.
-using ScalarTypes = ::testing::Types<double>;
-TYPED_TEST_SUITE(HydroelasticCallbackTyped, ScalarTypes);
-
+// Utility class for encoding a scene with two spheres.
 template <typename T>
-class HydroelasticCallbackTyped : public ::testing::Test {
- protected:
-  void SetUp() override {
+class TestScene {
+ public:
+  TestScene()
+      : data_{&collision_filter_, &X_WGs_, &hydroelastic_geometries_,
+              &surfaces_} {}
+
+  // Configures a scene with two spheres. Each is given a hydroelastic
+  // representation based on the given requested types and are positioned in
+  // a colliding state (if `are_colliding` is true).
+  void ConfigureScene(const HydroelasticType type_A,
+                      const HydroelasticType type_B,
+                      bool are_colliding = true) {
     // Configures a world with a sphere slightly overlapping a box.
-    id_sphere_ = GeometryId::get_new_id();
-    id_box_ = GeometryId::get_new_id();
-    EncodedData data_A(id_sphere_, true);
-    EncodedData data_B(id_box_, true);
+    id_A_ = GeometryId::get_new_id();
+    id_B_ = GeometryId::get_new_id();
+    EncodedData data_A(id_A_, true);
+    EncodedData data_B(id_B_, true);
     collision_filter_.AddGeometry(data_A.encoding());
     collision_filter_.AddGeometry(data_B.encoding());
-    // Leave box centered on origin.
-    X_WGs_.insert({id_box_, RigidTransform<T>::Identity()});
-    // Position sphere so that it is just far enough from the origin that the
-    // bottom of the sphere intersects the top of the box.
-    X_WGs_.insert({id_sphere_, RigidTransform<T>(Vector3<T>{
-                                   0, 0, 0.9 * (radius_ + cube_size_ / 2)})});
+    // Leave sphere B centered on origin.
+    X_WGs_.insert({id_B_, RigidTransform<T>::Identity()});
 
-    sphere_ = make_unique<CollisionObjectd>(make_shared<Sphered>(radius_));
-    data_A.write_to(sphere_.get());
-    box_ = make_unique<CollisionObjectd>(
-        make_shared<Boxd>(cube_size_, cube_size_, cube_size_));
-    data_B.write_to(box_.get());
+    // The spheres will either be colliding to a depth of radius_ / 5 or
+    // separated by the same distance based on `are_colliding`. Sphere B stays
+    // at the origin, and sphere A is moved along the +z axis the appropriate
+    // displacement.
+    const double z_offset = radius_ * (are_colliding ? 1.8 : 2.2);
+    X_WGs_.insert({id_A_, RigidTransform<T>(Vector3<T>{0, 0, z_offset})});
+
+    sphere_A_ = make_unique<CollisionObjectd>(make_shared<Sphered>(radius_));
+    data_A.write_to(sphere_A_.get());
+    sphere_B_ = make_unique<CollisionObjectd>(make_shared<Sphered>(radius_));
+    data_B.write_to(sphere_B_.get());
+
+    auto add_hydroelastic = [this](GeometryId id, const HydroelasticType type) {
+      if (type == HydroelasticType::kSoft) {
+        this->hydroelastic_geometries_.MaybeAddGeometry(Sphere(this->radius_),
+                                                        id, soft_properties());
+      } else if (type == HydroelasticType::kRigid) {
+        this->hydroelastic_geometries_.MaybeAddGeometry(Sphere(this->radius_),
+                                                        id, rigid_properties());
+      }
+      // Note: HydroelasticType::kUndefined will not be added.
+    };
+
+    add_hydroelastic(id_A_, type_A);
+    add_hydroelastic(id_B_, type_B);
   }
 
+  // Filters contact between the two spheres.
+  void FilterContact() {
+    EncodedData data_A(*sphere_A_);
+    EncodedData data_B(*sphere_B_);
+    collision_filter_.AddToCollisionClique(data_A.encoding(), 1);
+    collision_filter_.AddToCollisionClique(data_B.encoding(), 1);
+  }
+
+  // Note: these are non const because the callback takes non-const pointers
+  // (due to FCL's API).
+  CollisionObjectd& sphere_A() { return *sphere_A_; }
+  CollisionObjectd& sphere_B() { return *sphere_B_; }
+  CallbackData<T>& data() { return data_; }
+  const vector<ContactSurface<T>>& surfaces() const { return surfaces_; }
+
+ private:
+  Geometries hydroelastic_geometries_;
   CollisionFilterLegacy collision_filter_;
   unordered_map<GeometryId, RigidTransform<T>> X_WGs_;
-  GeometryId id_sphere_{};
-  GeometryId id_box_{};
+  GeometryId id_A_{};
+  GeometryId id_B_{};
   const double radius_{0.25};
-  const double cube_size_{0.4};
-  unique_ptr<CollisionObjectd> sphere_;
-  unique_ptr<CollisionObjectd> box_;
+  unique_ptr<CollisionObjectd> sphere_A_;
+  unique_ptr<CollisionObjectd> sphere_B_;
+  vector<ContactSurface<T>> surfaces_;
+  CallbackData<T> data_;
 };
 
+TYPED_TEST_SUITE(MaybeCalcContactSurfaceTests, ScalarTypes);
+
+// Test suite for exercising MaybeCalcContactSurface with different scalar
+// types. (Currently only double as the hydroelastic infrastructure doesn't
+// support autodiff yet.)
+template <typename T>
+class MaybeCalcContactSurfaceTests : public ::testing::Test {};
+
+// Confirms that if one or both geometries do not have a hydroelastic
+// representation, that the proper result is returned.
+TYPED_TEST(MaybeCalcContactSurfaceTests, UndefinedGeometry) {
+  using T = TypeParam;
+
+  TestScene<T> scene;
+  scene.ConfigureScene(HydroelasticType::kRigid, HydroelasticType::kUndefined);
+
+  // Case: second is undefined.
+  CalcContactSurfaceResult result = MaybeCalcContactSurface<T>(
+      &scene.sphere_A(), &scene.sphere_B(), &scene.data());
+  ASSERT_EQ(result, CalcContactSurfaceResult::kUnsupported);
+  ASSERT_EQ(scene.surfaces().size(), 0u);
+
+  // Case: first is undefined.
+  result = MaybeCalcContactSurface<T>(
+      &scene.sphere_B(), &scene.sphere_A(), &scene.data());
+  ASSERT_EQ(result, CalcContactSurfaceResult::kUnsupported);
+  ASSERT_EQ(scene.surfaces().size(), 0u);
+
+  // Case: both are undefined.
+  result = MaybeCalcContactSurface<T>(
+      &scene.sphere_B(), &scene.sphere_B(), &scene.data());
+  ASSERT_EQ(result, CalcContactSurfaceResult::kUnsupported);
+  ASSERT_EQ(scene.surfaces().size(), 0u);
+}
+
+// Confirms that matching compliance (rigid) can't be evaluated.
+TYPED_TEST(MaybeCalcContactSurfaceTests, BothRigid) {
+  using T = TypeParam;
+
+  TestScene<T> scene;
+  scene.ConfigureScene(HydroelasticType::kRigid, HydroelasticType::kRigid);
+
+  CalcContactSurfaceResult result = MaybeCalcContactSurface<T>(
+      &scene.sphere_A(), &scene.sphere_B(), &scene.data());
+  EXPECT_EQ(result, CalcContactSurfaceResult::kSameCompliance);
+  EXPECT_EQ(scene.surfaces().size(), 0u);
+}
+
+// Confirms that matching compliance (soft) can't be evaluated.
+TYPED_TEST(MaybeCalcContactSurfaceTests, BothSoft) {
+  using T = TypeParam;
+
+  TestScene<T> scene;
+  scene.ConfigureScene(HydroelasticType::kSoft, HydroelasticType::kSoft);
+
+  CalcContactSurfaceResult result = MaybeCalcContactSurface<T>(
+      &scene.sphere_A(), &scene.sphere_B(), &scene.data());
+  EXPECT_EQ(result, CalcContactSurfaceResult::kSameCompliance);
+  EXPECT_EQ(scene.surfaces().size(), 0u);
+}
+
+// Confirms that a valid pair that are, nevertheless, not colliding does not
+// add a surface to the results.
+TYPED_TEST(MaybeCalcContactSurfaceTests, NonColliding) {
+  using T = TypeParam;
+
+  TestScene<T> scene;
+  scene.ConfigureScene(HydroelasticType::kSoft, HydroelasticType::kRigid,
+                       false /* are_colliding */);
+
+  CalcContactSurfaceResult result = MaybeCalcContactSurface<T>(
+      &scene.sphere_A(), &scene.sphere_B(), &scene.data());
+  EXPECT_EQ(result, CalcContactSurfaceResult::kCalculated);
+  EXPECT_EQ(scene.surfaces().size(), 0u);
+}
+
+// Confirms that a valid pair of hydroelastic representations report as such
+// and produce a result. (The details of the result are not explicitly
+// evaluated as they have been tested by the underlying method's unit tests.)
+TYPED_TEST(MaybeCalcContactSurfaceTests, ValidCompliancePair) {
+  using T = TypeParam;
+
+  TestScene<T> scene;
+  scene.ConfigureScene(HydroelasticType::kRigid, HydroelasticType::kSoft);
+
+  CalcContactSurfaceResult result = MaybeCalcContactSurface<T>(
+      &scene.sphere_A(), &scene.sphere_B(), &scene.data());
+  // TODO(SeanCurtis-TRI): This test relies on the fact that all supported
+  //  geometry pairs use the same function (vol-surf mesh intersection). When
+  //  the calling path becomes more heterogeneous, this test will no longer
+  //  be sufficient.
+  EXPECT_EQ(result, CalcContactSurfaceResult::kCalculated);
+  EXPECT_EQ(scene.surfaces().size(), 1u);
+}
+
+TYPED_TEST_SUITE(StrictHydroelasticCallbackTyped, ScalarTypes);
+
+// Test infrastructure for the strict hydroelastic callback for arbitrary
+// scalar type. It makes use of MaybeCalculationContactSurface() but this method
+// has the following responsibilities:
+//   - invoke the method using the data provided to it (so that the results
+//     ultimately percolate outward).
+//   - throw on any return value that isn't wholly successful.
+//   - respect collision filtering.
+// (Currently only double as the hydroelastic infrastructure doesn't support
+// autodiff yet.)
+template <typename T>
+class StrictHydroelasticCallbackTyped : public ::testing::Test {};
+
 // Confirms that if the intersecting pair is missing hydroelastic representation
-// that an exception is thrown. This test should apply *no* collision filters
+// that an exception is thrown. This test applies *no* collision filters
 // to guarantee that the body of the callback gets exercised in all cases.
-TYPED_TEST(HydroelasticCallbackTyped,
+TYPED_TEST(StrictHydroelasticCallbackTyped,
            ThrowForMissingHydroelasticRepresentation) {
   using T = TypeParam;
 
-  vector<ContactSurface<T>> surfaces;
+  TestScene<T> scene;
+  scene.ConfigureScene(HydroelasticType::kRigid, HydroelasticType::kUndefined);
 
-  const Sphere sphere(this->radius_);
-  const Box box = Box::MakeCube(this->cube_size_);
-
-  // Case: neither geometry has representation.
-  {
-    Geometries hydroelastic_geometries;
-    CallbackData<T> data(&this->collision_filter_, &this->X_WGs_,
-                         &hydroelastic_geometries, &surfaces);
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        Callback<T>(this->sphere_.get(), this->box_.get(), &data),
-        std::logic_error,
-        "Requested a contact surface between a pair of geometries without "
-        "hydroelastic representation .+ undefined .+ undefined .+");
-  }
-
-  // Case: Box geometry lacks representation.
-  {
-    Geometries hydroelastic_geometries;
-    hydroelastic_geometries.MaybeAddGeometry(sphere, this->id_sphere_,
-                                             rigid_properties());
-    EXPECT_EQ(hydroelastic_geometries.hydroelastic_type(this->id_sphere_),
-              HydroelasticType::kRigid);
-    CallbackData<T> data(&this->collision_filter_, &this->X_WGs_,
-                         &hydroelastic_geometries, &surfaces);
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        Callback<T>(this->sphere_.get(), this->box_.get(), &data),
-        std::logic_error,
-        "Requested a contact surface between a pair of geometries without "
-        "hydroelastic representation .+ rigid .+ undefined .+");
-  }
-
-  // Case: Sphere geometry lacks representation.
-  {
-    Geometries hydroelastic_geometries;
-    hydroelastic_geometries.MaybeAddGeometry(box, this->id_box_,
-                                             rigid_properties());
-    EXPECT_EQ(hydroelastic_geometries.hydroelastic_type(this->id_box_),
-              HydroelasticType::kRigid);
-    CallbackData<T> data(&this->collision_filter_, &this->X_WGs_,
-                         &hydroelastic_geometries, &surfaces);
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        Callback<T>(this->sphere_.get(), this->box_.get(), &data),
-        std::logic_error,
-        "Requested a contact surface between a pair of geometries without "
-        "hydroelastic representation .+ undefined .+ rigid .+");
-  }
+  // We test only a single "underrepresented" configuration (rigid, undefined)
+  // because we rely on the tests on MaybeCalcContactSurface() to have explored
+  // all the ways that the kUnsupported calculation result is returned. This
+  // configuration is representative of that set.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      Callback<T>(&scene.sphere_A(), &scene.sphere_B(), &scene.data()),
+      std::logic_error,
+      "Requested a contact surface between a pair of geometries without "
+      "hydroelastic representation .+ rigid .+ undefined .+");
 }
 
 // Confirms that if the intersecting pair has the same compliance (rigid-rigid)
-// or (soft-soft), that an exception is thrown. It is important that collisions
-// are *not* filtered between the two objects.
-TYPED_TEST(HydroelasticCallbackTyped, ThrowForBadPairBasedOnCompliance) {
+// or (soft-soft), that an exception is thrown. This test applies *no* collision
+// filters to guarantee that the body of the callback gets exercised in all
+// cases.
+TYPED_TEST(StrictHydroelasticCallbackTyped, ThrowForSameComplianceType) {
   using T = TypeParam;
 
-  const Sphere sphere(this->radius_);
-  const Box box = Box::MakeCube(this->cube_size_);
+  TestScene<T> scene;
+  scene.ConfigureScene(HydroelasticType::kRigid, HydroelasticType::kRigid);
 
-  vector<ContactSurface<T>> surfaces;
-
-  // Case: both geometries are rigid.
-  {
-    Geometries hydroelastic_geometries;
-    hydroelastic_geometries.MaybeAddGeometry(sphere, this->id_sphere_,
-                                             rigid_properties());
-    hydroelastic_geometries.MaybeAddGeometry(box, this->id_box_,
-                                             rigid_properties());
-    CallbackData<T> data(&this->collision_filter_, &this->X_WGs_,
-                         &hydroelastic_geometries, &surfaces);
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        Callback<T>(this->sphere_.get(), this->box_.get(), &data),
-        std::logic_error,
-        "Requested contact between two rigid objects .+ only rigid-soft pairs "
-        "are currently supported");
-  }
-
-  // Case: both geometries are soft.
-  {
-    Geometries hydroelastic_geometries;
-    hydroelastic_geometries.MaybeAddGeometry(sphere, this->id_sphere_,
-                                             soft_properties());
-    // TODO(SeanCurtis-TRI): When a soft box is supported, swap this for a box
-    //  just to keep things interesting.
-    hydroelastic_geometries.MaybeAddGeometry(sphere, this->id_box_,
-                                             soft_properties());
-    CallbackData<T> data(&this->collision_filter_, &this->X_WGs_,
-                         &hydroelastic_geometries, &surfaces);
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        Callback<T>(this->sphere_.get(), this->box_.get(), &data),
-        std::logic_error,
-        "Requested contact between two soft objects .+ only rigid-soft pairs "
-        "are currently supported");
-  }
+  // We test only a single "same-compliance" configuration (rigid, rigid)
+  // because we rely on the tests on MaybeCalcContactSurface() to have explored
+  // all the ways that the kSameCompliance calculation result is returned. This
+  // configuration is representative of that set.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      Callback<T>(&scene.sphere_A(), &scene.sphere_B(), &scene.data()),
+      std::logic_error,
+      "Requested contact between two rigid objects .+");
 }
 
-// Confirms that if the world contains unsupported geometry, as long as they are
+// Confirms that if the pair contains unsupported geometry, as long as they are
 // filtered, they don't pose a problem. The "lack of support" comes from the
 // fact that the ids don't map to anything in the hydroelastic geometry set.
-TYPED_TEST(HydroelasticCallbackTyped, RespectsCollisionFilter) {
+TYPED_TEST(StrictHydroelasticCallbackTyped, RespectsCollisionFilter) {
   using T = TypeParam;
 
-  // Assign both geometries to clique 1 -- this will cause the pair to be
-  // filtered.
-  EncodedData data_A(this->id_sphere_, true);
-  EncodedData data_B(this->id_box_, true);
-  this->collision_filter_.AddToCollisionClique(data_A.encoding(), 1);
-  this->collision_filter_.AddToCollisionClique(data_B.encoding(), 1);
+  TestScene<T> scene;
+  // Note: a configuration that would cause an exception to be thrown if
+  // unfiltered and the confirmation of that assumption.
+  scene.ConfigureScene(HydroelasticType::kRigid, HydroelasticType::kRigid);
+  EXPECT_THROW(Callback<T>(&scene.sphere_A(), &scene.sphere_B(), &scene.data()),
+               std::logic_error);
 
-  // We leave the set of hydroelastic geometries empty on purpose. This implies
-  // that *all* geometries are "unsupported" (i.e., have no hydroelastic
-  // representation). It should not produce an error because the sphere and box
-  // are filtered.
-  Geometries hydroelastic_geometries;
-  vector<ContactSurface<T>> surfaces;
-  CallbackData<T> data(&this->collision_filter_, &this->X_WGs_,
-                       &hydroelastic_geometries, &surfaces);
+  scene.FilterContact();
   DRAKE_EXPECT_NO_THROW(
-      Callback<T>(this->sphere_.get(), this->box_.get(), &data));
-  EXPECT_EQ(surfaces.size(), 0u);
+      Callback<T>(&scene.sphere_A(), &scene.sphere_B(), &scene.data()));
+  EXPECT_EQ(scene.surfaces().size(), 0u);
 }
-
-// TODO(SeanCurtis-TRI): This test relies on the fact that all supported
-//  geometry pairs pass through the same function (vol-surf mesh intersection).
-//  When the calling path becomes more heterogeneous, this test will no longer
-//  be sufficient.
 
 // Confirms that a colliding collision pair (with supported hydroelastic
 // representations) produces a result. This doesn't test the actual data -- it
 // assumes the function responsible for computing that result has been
-// successfully tested.
-TYPED_TEST(HydroelasticCallbackTyped, ValidPairProducesResult) {
+// successfully tested. This test is subtle; it simply confirms that the
+// Callback invokes MaybeCalcContactSurface() and provides the correct
+// vector<ContactSurface> instance.
+TYPED_TEST(StrictHydroelasticCallbackTyped, ValidPairProducesResult) {
   using T = TypeParam;
 
-  Geometries hydroelastic_geometries;
-  hydroelastic_geometries.MaybeAddGeometry(
-      Sphere(this->radius_), this->id_sphere_, soft_properties());
-  hydroelastic_geometries.MaybeAddGeometry(
-      Box(this->cube_size_, this->cube_size_, this->cube_size_), this->id_box_,
-      rigid_properties());
+  TestScene<T> scene;
+  scene.ConfigureScene(HydroelasticType::kRigid, HydroelasticType::kSoft);
 
-  vector<ContactSurface<T>> surfaces;
-  CallbackData<T> data(&this->collision_filter_, &this->X_WGs_,
-                       &hydroelastic_geometries, &surfaces);
   DRAKE_EXPECT_NO_THROW(
-      Callback<T>(this->sphere_.get(), this->box_.get(), &data));
-  EXPECT_EQ(surfaces.size(), 1u);
+      Callback<T>(&scene.sphere_A(), &scene.sphere_B(), &scene.data()));
+  EXPECT_EQ(scene.surfaces().size(), 1u);
+}
+
+TYPED_TEST_SUITE(HydroelasticCallbackFallbackTyped, ScalarTypes);
+
+// Test infrastructure for the hydroelastic callback with fallback for arbitrary
+// scalar type. It makes use of MaybeCalculationContactSurface() but this method
+// has the following responsibilities:
+//   - invoke the method using the data provided to it (so that the results
+//     ultimately percolate outward).
+//   - Compute point pair penetration for any pair that couldn't be calculated.
+//   - respect collision filtering.
+// (Currently only double as the hydroelastic infrastructure doesn't support
+// autodiff yet.)
+// The tests below parallel the tests for the strict hydroelastic callback.
+template <typename T>
+class HydroelasticCallbackFallbackTyped : public ::testing::Test {};
+
+// Confirms that if the intersecting pair is missing hydroelastic representation
+// a point pair is generated. This test applies *no* collision filters
+// to guarantee that the body of the callback gets exercised in all cases.
+TYPED_TEST(HydroelasticCallbackFallbackTyped,
+           PointPairForMissingHydroelasticRepresentation) {
+  using T = TypeParam;
+
+  TestScene<T> scene;
+  scene.ConfigureScene(HydroelasticType::kRigid, HydroelasticType::kUndefined);
+
+  // We test only a single "underrepresented" configuration (rigid, undefined)
+  // because we rely on the tests on MaybeCalcContactSurface() to have explored
+  // all the ways that the kUnsupported calculation result is returned. This
+  // configuration is representative of that set.
+  vector<PenetrationAsPointPair<T>> point_pairs;
+  CallbackWithFallbackData<T> data{scene.data(), &point_pairs};
+  DRAKE_EXPECT_NO_THROW(
+      CallbackWithFallback<T>(&scene.sphere_A(), &scene.sphere_B(), &data));
+  EXPECT_EQ(scene.surfaces().size(), 0u);
+  EXPECT_EQ(point_pairs.size(), 1u);
+}
+
+// Confirms that if the intersecting pair has the same compliance (rigid-rigid)
+// or (soft-soft), that we return a point-pair. This test applies *no* collision
+// filters to guarantee that the body of the callback gets exercised in all
+// cases.
+TYPED_TEST(HydroelasticCallbackFallbackTyped, PointPairForSameComplianceType) {
+  using T = TypeParam;
+
+  TestScene<T> scene;
+  scene.ConfigureScene(HydroelasticType::kRigid, HydroelasticType::kRigid);
+
+  // We test only a single "same-compliance" configuration (rigid, rigid)
+  // because we rely on the tests on MaybeCalcContactSurface() to have explored
+  // all the ways that the kSameCompliance calculation result is returned. This
+  // configuration is representative of that set.
+  vector<PenetrationAsPointPair<T>> point_pairs;
+  CallbackWithFallbackData<T> data{scene.data(), &point_pairs};
+  DRAKE_EXPECT_NO_THROW(
+      CallbackWithFallback<T>(&scene.sphere_A(), &scene.sphere_B(), &data));
+  EXPECT_EQ(scene.surfaces().size(), 0u);
+  EXPECT_EQ(point_pairs.size(), 1u);
+}
+
+// Confirms that collision filters are respected; for a filtered colliding pair,
+// no results are returned at all.
+TYPED_TEST(HydroelasticCallbackFallbackTyped, RespectsCollisionFilter) {
+  using T = TypeParam;
+
+  TestScene<T> scene;
+  // Note: a configuration that would cause an exception to be thrown if
+  // unfiltered and the confirmation of that assumption.
+  scene.ConfigureScene(HydroelasticType::kRigid, HydroelasticType::kRigid);
+
+  vector<PenetrationAsPointPair<T>> point_pairs;
+  CallbackWithFallbackData<T> data{scene.data(), &point_pairs};
+  // Confirm collision state.
+  DRAKE_EXPECT_NO_THROW(
+      CallbackWithFallback<T>(&scene.sphere_A(), &scene.sphere_B(), &data));
+  EXPECT_EQ(scene.surfaces().size(), 0u);
+  EXPECT_EQ(point_pairs.size(), 1u);
+
+  // Now filter.
+  point_pairs.clear();
+  scene.FilterContact();
+
+  DRAKE_EXPECT_NO_THROW(
+      CallbackWithFallback<T>(&scene.sphere_A(), &scene.sphere_B(), &data));
+  EXPECT_EQ(scene.surfaces().size(), 0u);
+  EXPECT_EQ(point_pairs.size(), 0u);
+}
+
+// Confirms that a colliding collision pair (with supported hydroelastic
+// representations) produces a contact surface. This doesn't test the actual
+// data -- it assumes the function responsible for computing that result has
+// been successfully tested. This test is subtle; it simply confirms that the
+// Callback invokes MaybeCalcContactSurface() and provides the correct
+// vector<ContactSurface> instance.
+TYPED_TEST(HydroelasticCallbackFallbackTyped, ValidPairProducesResult) {
+  using T = TypeParam;
+
+  TestScene<T> scene;
+  scene.ConfigureScene(HydroelasticType::kRigid, HydroelasticType::kSoft);
+
+  vector<PenetrationAsPointPair<T>> point_pairs;
+  CallbackWithFallbackData<T> data{scene.data(), &point_pairs};
+
+  DRAKE_EXPECT_NO_THROW(
+      CallbackWithFallback<T>(&scene.sphere_A(), &scene.sphere_B(), &data));
+  EXPECT_EQ(scene.surfaces().size(), 1u);
+  EXPECT_EQ(point_pairs.size(), 0u);
 }
 
 }  // namespace

--- a/geometry/proximity_engine.h
+++ b/geometry/proximity_engine.h
@@ -233,6 +233,14 @@ class ProximityEngine {
       const std::unordered_map<GeometryId, math::RigidTransform<T>>& X_WGs)
       const;
 
+  /** Implementation of GeometryState::ComputeContactSurfacesWithFallback().
+   This includes `X_WGs`, the current poses of all geometries in World in the
+   current scalar type, keyed on each geometry's GeometryId.  */
+  void ComputeContactSurfacesWithFallback(
+      const std::unordered_map<GeometryId, math::RigidTransform<T>>& X_WGs,
+      std::vector<ContactSurface<T>>* surfaces,
+      std::vector<PenetrationAsPointPair<double>>* point_pairs) const;
+
   /** Implementation of GeometryState::FindCollisionCandidates().  */
   std::vector<SortedPair<GeometryId>> FindCollisionCandidates() const;
 

--- a/geometry/query_object.cc
+++ b/geometry/query_object.cc
@@ -111,6 +111,20 @@ QueryObject<T>::ComputeContactSurfaces() const {
 }
 
 template <typename T>
+void QueryObject<T>::ComputeContactSurfacesWithFallback(
+    std::vector<ContactSurface<T>>* surfaces,
+    std::vector<PenetrationAsPointPair<double>>* point_pairs) const {
+  DRAKE_DEMAND(surfaces);
+  DRAKE_DEMAND(point_pairs);
+
+  ThrowIfNotCallable();
+
+  FullPoseUpdate();
+  const GeometryState<T>& state = geometry_state();
+  state.ComputeContactSurfacesWithFallback(surfaces, point_pairs);
+}
+
+template <typename T>
 std::vector<SignedDistancePair<T>>
 QueryObject<T>::ComputeSignedDistancePairwiseClosestPoints(
     const double max_distance) const {

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -230,6 +230,33 @@ class QueryObject {
             contact surfaces.  */
   std::vector<ContactSurface<T>> ComputeContactSurfaces() const;
 
+  /** Reports pair-wise intersections and characterizes each non-empty
+   intersection as a ContactSurface _where possible_ and as a
+   PenetrationAsPointPair where not.
+
+   This is a hybrid contact algorithm. It allows for the contact surface
+   penetration result where possible, but automatically provides a fallback for
+   where a ContactSurface cannot be defined.
+
+   The fallback cannot guarantee success in all cases. Meshes have limited
+   support in the proximity role; they are supported in the contact surface
+   computation but _ignored_ in the point pair collision query. If a mesh is
+   in contact with another shape that _cannot_ be resolved as a contact surface
+   (e.g., rigid mesh vs another rigid shape), this computation will throw as
+   there is no fallback functionality for mesh-shape.
+
+   Because point pairs can only be computed for double-valued systems, this can
+   also only support double-valued ContactSurface instances.
+
+   @param[out] surfaces     The vector that contact surfaces will be added to.
+                            The vector will _not_ be cleared.
+   @param[out] point_pairs  The vector that fall back point pair data will be
+                            added to. The vector will _not_ be cleared.
+   @pre Neither `surfaces` nor `point_pairs` is nullptr.  */
+  void ComputeContactSurfacesWithFallback(
+      std::vector<ContactSurface<T>>* surfaces,
+      std::vector<PenetrationAsPointPair<double>>* point_pairs) const;
+
   /** Applies a conservative culling mechanism to create a subset of all
    possible geometry pairs based on non-zero intersections. A geometry pair
    that is *absent* from the results is either a) culled by collision filters or


### PR DESCRIPTION
Introduces new query that attempts to compute hydroelastic contact surfaces. However, if, for whatever reason, a geometry pair doesn't support hydroelastic contact, it computes the penetration as point pair for that pair.

The refactor of callbacks led to a significant respelling of the unit test; we went from testing one function to three with similar requirements on the underlying infrastructure.

Updates the simple vis contact to exercise this new query.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12699)
<!-- Reviewable:end -->
