### PR TITLE
Fixes declared state and parameter counts for Diagram

### DIFF
--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -915,15 +915,6 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
   }
 
  private:
-  int do_get_num_continuous_states() const final {
-    int num_states = 0;
-    for (const auto& system : registered_systems_) {
-      num_states += system->num_continuous_states();
-    }
-
-    return num_states;
-  }
-
   std::unique_ptr<AbstractValue> DoAllocateInput(
       const InputPort<T>& input_port) const final {
     // Ask the subsystem to perform the allocation.
@@ -1534,6 +1525,14 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
     this->set_forced_unrestricted_update_events(
         AllocateForcedEventCollection<UnrestrictedUpdateEvent<T>>(
             &System<T>::AllocateForcedUnrestrictedUpdateEventCollection));
+
+    // Total up all needed Context resources. Note that we are depending
+    // on sub-Diagrams already to have been initialized so that their counts
+    // are already correct.
+    SystemBase::ContextSizes& sizes = this->get_mutable_context_sizes();
+    for (const auto& system : registered_systems_) {
+      sizes += SystemBase::get_context_sizes(*system);
+    }
   }
 
   // Exposes the given port as an input of the Diagram.

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -525,10 +525,15 @@ class LeafSystem : public System<T> {
   /// ContinuousState vector is a subclass of BasicVector.
   virtual std::unique_ptr<ContinuousState<T>> AllocateContinuousState() const {
     if (model_continuous_state_vector_ != nullptr) {
+      DRAKE_DEMAND(model_continuous_state_vector_->size() ==
+                   this->num_continuous_states());
+      const SystemBase::ContextSizes& sizes = this->get_context_sizes();
       return std::make_unique<ContinuousState<T>>(
-          model_continuous_state_vector_->Clone(), num_generalized_positions_,
-          num_generalized_velocities_, num_misc_continuous_states_);
+          model_continuous_state_vector_->Clone(),
+          sizes.num_generalized_positions, sizes.num_generalized_velocities,
+          sizes.num_misc_continuous_states);
     }
+    DRAKE_DEMAND(this->num_continuous_states() == 0);
     return std::make_unique<ContinuousState<T>>();
   }
 
@@ -1489,9 +1494,15 @@ class LeafSystem : public System<T> {
                               int num_v, int num_z) {
     DRAKE_DEMAND(model_vector.size() == num_q + num_v + num_z);
     model_continuous_state_vector_ = model_vector.Clone();
-    num_generalized_positions_ = num_q;
-    num_generalized_velocities_ = num_v;
-    num_misc_continuous_states_ = num_z;
+
+    // Note that only the last DeclareContinuousState() takes effect;
+    // we're not accumulating these as we do for discrete & abstract states.
+    SystemBase::ContextSizes& context_sizes =
+        this->get_mutable_context_sizes();
+    context_sizes.num_generalized_positions = num_q;
+    context_sizes.num_generalized_velocities = num_v;
+    context_sizes.num_misc_continuous_states = num_z;
+
     MaybeDeclareVectorBaseInequalityConstraint(
         "continuous state", model_vector,
         [](const Context<T>& context) -> const VectorBase<T>& {
@@ -2437,13 +2448,6 @@ class LeafSystem : public System<T> {
   using SystemBase::NextInputPortName;
   using SystemBase::NextOutputPortName;
 
-  int do_get_num_continuous_states() const final {
-    int total = num_generalized_positions_ +
-        num_generalized_velocities_+
-        num_misc_continuous_states_;
-    return total;
-  }
-
   // Either clones the model_value, or else for vector ports allocates a
   // BasicVector, or else for abstract ports throws an exception.
   std::unique_ptr<AbstractValue> DoAllocateInput(
@@ -2767,9 +2771,6 @@ class LeafSystem : public System<T> {
 
   // A model continuous state to be used during Context allocation.
   std::unique_ptr<BasicVector<T>> model_continuous_state_vector_;
-  int num_generalized_positions_{0};
-  int num_generalized_velocities_{0};
-  int num_misc_continuous_states_{0};
 
   // A model discrete state to be used during Context allocation.
   DiscreteValues<T> model_discrete_state_;

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -847,12 +847,9 @@ class System : public SystemBase {
   bool IsDifferenceEquationSystem(double* time_period = nullptr) const {
     if (num_continuous_states() || num_abstract_states()) { return false; }
 
-    // TODO(#12616): Replace this
-    if (CreateDefaultContext()->num_discrete_state_groups() != 1) {
+    if (num_discrete_state_groups() != 1) {
       return false;
     }
-    // with
-    // if (num_discrete_state_groups() != 1) { return false; }
 
     std::optional<PeriodicEventData> periodic_data =
         GetUniquePeriodicDiscreteUpdateAttribute();
@@ -1270,12 +1267,6 @@ class System : public SystemBase {
   /// Returns the number of constraints specified for the system.
   int num_constraints() const {
     return static_cast<int>(constraints_.size());
-  }
-
-  /// Returns the dimension of the continuous state vector that has been
-  /// declared until now.
-  int num_continuous_states() const {
-    return do_get_num_continuous_states();
   }
 
   /// Returns the constraint at index @p constraint_index.
@@ -2125,9 +2116,6 @@ class System : public SystemBase {
     qdot->SetFromVector(generalized_velocity);
   }
   //@}
-
-  /// Totals the number of continuous state variables in this System or Diagram.
-  virtual int do_get_num_continuous_states() const = 0;
 
   //----------------------------------------------------------------------------
   /// @name                 Utility methods (protected)

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -752,26 +752,33 @@ class SystemBase : public internal::SystemMessageInterface {
     return output_ports_[index]->ticket();
   }
 
+  /** Returns the number of declared continuous state variables. */
+  int num_continuous_states() const {
+    return context_sizes_.num_generalized_positions +
+           context_sizes_.num_generalized_velocities +
+           context_sizes_.num_misc_continuous_states;
+  }
+
   /** Returns the number of declared discrete state groups (each group is
   a vector-valued discrete state variable). */
   int num_discrete_state_groups() const {
-    return static_cast<int>(discrete_state_tickets_.size());
+    return context_sizes_.num_discrete_state_groups;
   }
 
   /** Returns the number of declared abstract state variables. */
   int num_abstract_states() const {
-    return static_cast<int>(abstract_state_tickets_.size());
+    return context_sizes_.num_abstract_states;
   }
 
   /** Returns the number of declared numeric parameters (each of these is
   a vector-valued parameter). */
   int num_numeric_parameter_groups() const {
-    return static_cast<int>(numeric_parameter_tickets_.size());
+    return context_sizes_.num_numeric_parameter_groups;
   }
 
   /** Returns the number of declared abstract parameters. */
   int num_abstract_parameters() const {
-    return static_cast<int>(abstract_parameter_tickets_.size());
+    return context_sizes_.num_abstract_parameters;
   }
   //@}
 
@@ -881,10 +888,12 @@ class SystemBase : public internal::SystemMessageInterface {
   @pre The supplied index must be the next available one; that is, indexes
        must be assigned sequentially. */
   void AddDiscreteStateGroup(DiscreteStateIndex index) {
-    DRAKE_DEMAND(index == num_discrete_state_groups());
+    DRAKE_DEMAND(index == discrete_state_tickets_.size());
+    DRAKE_DEMAND(index == context_sizes_.num_discrete_state_groups);
     const DependencyTicket ticket(assign_next_dependency_ticket());
     discrete_state_tickets_.push_back(
         {ticket, "discrete state group " + std::to_string(index)});
+    ++context_sizes_.num_discrete_state_groups;
   }
 
   /** (Internal use only) Assigns a ticket to a new abstract state variable with
@@ -893,9 +902,11 @@ class SystemBase : public internal::SystemMessageInterface {
        must be assigned sequentially. */
   void AddAbstractState(AbstractStateIndex index) {
     const DependencyTicket ticket(assign_next_dependency_ticket());
-    DRAKE_DEMAND(index == num_abstract_states());
+    DRAKE_DEMAND(index == abstract_state_tickets_.size());
+    DRAKE_DEMAND(index == context_sizes_.num_abstract_states);
     abstract_state_tickets_.push_back(
         {ticket, "abstract state " + std::to_string(index)});
+    ++context_sizes_.num_abstract_states;
   }
 
   /** (Internal use only) Assigns a ticket to a new numeric parameter with
@@ -903,10 +914,12 @@ class SystemBase : public internal::SystemMessageInterface {
   @pre The supplied index must be the next available one; that is, indexes
        must be assigned sequentially. */
   void AddNumericParameter(NumericParameterIndex index) {
-    DRAKE_DEMAND(index == num_numeric_parameter_groups());
+    DRAKE_DEMAND(index == numeric_parameter_tickets_.size());
+    DRAKE_DEMAND(index == context_sizes_.num_numeric_parameter_groups);
     const DependencyTicket ticket(assign_next_dependency_ticket());
     numeric_parameter_tickets_.push_back(
         {ticket, "numeric parameter " + std::to_string(index)});
+    ++context_sizes_.num_numeric_parameter_groups;
   }
 
   /** (Internal use only) Assigns a ticket to a new abstract parameter with
@@ -915,9 +928,11 @@ class SystemBase : public internal::SystemMessageInterface {
        must be assigned sequentially. */
   void AddAbstractParameter(AbstractParameterIndex index) {
     const DependencyTicket ticket(assign_next_dependency_ticket());
-    DRAKE_DEMAND(index == num_abstract_parameters());
+    DRAKE_DEMAND(index == abstract_parameter_tickets_.size());
+    DRAKE_DEMAND(index == context_sizes_.num_abstract_parameters);
     abstract_parameter_tickets_.push_back(
         {ticket, "abstract parameter " + std::to_string(index)});
+    ++context_sizes_.num_abstract_parameters;
   }
 
   /** (Internal use only) This is for cache entries associated with pre-defined
@@ -1063,6 +1078,43 @@ class SystemBase : public internal::SystemMessageInterface {
   parameters and state should be allocated. */
   virtual std::unique_ptr<ContextBase> DoAllocateContext() const = 0;
 
+  /** Return type for get_context_sizes(). Initialized to zero
+  and equipped with a += operator for Diagram use in aggregation. */
+  struct ContextSizes {
+    int num_generalized_positions{0};     // q }
+    int num_generalized_velocities{0};    // v | Sum is num continuous states x.
+    int num_misc_continuous_states{0};    // z }
+    int num_discrete_state_groups{0};     // Each "group" is a vector.
+    int num_abstract_states{0};
+    int num_numeric_parameter_groups{0};  // Each "group" is a vector.
+    int num_abstract_parameters{0};
+
+    ContextSizes& operator+=(const ContextSizes& other) {
+      num_generalized_positions += other.num_generalized_positions;
+      num_generalized_velocities += other.num_generalized_velocities;
+      num_misc_continuous_states += other.num_misc_continuous_states;
+      num_discrete_state_groups += other.num_discrete_state_groups;
+      num_abstract_states += other.num_abstract_states;
+      num_numeric_parameter_groups += other.num_numeric_parameter_groups;
+      num_abstract_parameters += other.num_abstract_parameters;
+      return *this;
+    }
+  };
+
+  /** Obtains access to the declared Context partition sizes as accumulated
+  during LeafSystem or Diagram construction .*/
+  const ContextSizes& get_context_sizes() const { return context_sizes_; }
+
+  /** Obtains mutable access to the Context sizes struct. Should be used only
+  during LeafSystem or Diagram construction. */
+  ContextSizes& get_mutable_context_sizes() { return context_sizes_; }
+
+  /** Allows Diagram to access protected get_context_sizes() recursively on its
+  subsystems. */
+  static const ContextSizes& get_context_sizes(const SystemBase& system) {
+    return system.get_context_sizes();
+  }
+
   // TODO(jwnimmer-tri) On 2020-05-01, when CheckValidContext() has been
   // removed, also remove this function.
   virtual void DoCheckValidContext(const ContextBase&) const {}
@@ -1080,25 +1132,25 @@ class SystemBase : public internal::SystemMessageInterface {
 
   const TrackerInfo& discrete_state_tracker_info(
       DiscreteStateIndex index) const {
-    DRAKE_DEMAND(0 <= index && index < num_discrete_state_groups());
+    DRAKE_DEMAND(0 <= index && index < discrete_state_tickets_.size());
     return discrete_state_tickets_[index];
   }
 
   const TrackerInfo& abstract_state_tracker_info(
       AbstractStateIndex index) const {
-    DRAKE_DEMAND(0 <= index && index < num_abstract_states());
+    DRAKE_DEMAND(0 <= index && index < abstract_state_tickets_.size());
     return abstract_state_tickets_[index];
   }
 
   const TrackerInfo& numeric_parameter_tracker_info(
       NumericParameterIndex index) const {
-    DRAKE_DEMAND(0 <= index && index < num_numeric_parameter_groups());
+    DRAKE_DEMAND(0 <= index && index < numeric_parameter_tickets_.size());
     return numeric_parameter_tickets_[index];
   }
 
   const TrackerInfo& abstract_parameter_tracker_info(
       AbstractParameterIndex index) const {
-    DRAKE_DEMAND(0 <= index && index < num_abstract_parameters());
+    DRAKE_DEMAND(0 <= index && index < abstract_parameter_tickets_.size());
     return abstract_parameter_tickets_[index];
   }
 
@@ -1136,6 +1188,12 @@ class SystemBase : public internal::SystemMessageInterface {
 
   // Unique ID of this system.
   const internal::SystemId system_id_{get_next_id()};
+
+  // Records the total sizes of Context resources as they will appear
+  // in a Context allocated by this System. Starts at zero, counts up during
+  // declaration for LeafSystem construction; computed recursively during
+  // Diagram construction.
+  ContextSizes context_sizes_;
 };
 
 // Implementations of templatized DeclareCacheEntry() methods.

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -128,10 +128,6 @@ class TestSystem : public System<double> {
   }
 
  protected:
-  int do_get_num_continuous_states() const final {
-    return 0;
-  }
-
   std::unique_ptr<AbstractValue> DoAllocateInput(
       const InputPort<double>&) const final {
     return {};
@@ -568,11 +564,6 @@ class ValueIOTestSystem : public System<T> {
 
   ~ValueIOTestSystem() override {}
 
-  int do_get_num_continuous_states() const final {
-    ADD_FAILURE() << "Implementation is required, but unused here.";
-    return {};
-  }
-
   T DoCalcWitnessValue(const Context<T>&,
                        const WitnessFunction<T>&) const override {
     ADD_FAILURE() << "This system uses no witness functions.";
@@ -925,11 +916,6 @@ class ComputationTestSystem final : public System<double> {
   }
 
  private:
-  int do_get_num_continuous_states() const final {
-    ADD_FAILURE() << "Implementation is required, but unused here.";
-    return {};
-  }
-
   // Two discrete variable groups of lengths 2 and 4.
   std::unique_ptr<DiscreteValues<double>> AllocateDiscreteVariables()
       const final {


### PR DESCRIPTION
This PR introduces a SystemBase data member to record the Context partition sizes needed to hold all declared state and parameters in a Diagram. A protected pure virtual method is used at Diagram construction to total up all the Context sizes of its subsystems. The SystemBase methods
```c++
num_discrete_state_groups()
num_abstract_states() 
num_numeric_parameter_groups() 
num_abstract_parameters()
```
are reimplemented using the new data member.
```c++
num_continuous_states()
```
moves up to SystemBase and is reimplemented.

Per #12616, this also removes the TODO in System::IsDifferenceEquationSystem() and adds back the NumDiscreteStateGroups test in diagram_test.cc.

Fixes #12616

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12701)
<!-- Reviewable:end -->
