### PR TITLE
Caches expensive bias terms used in O(n) forward dynamics.

### DIFF
--- a/multibody/tree/articulated_body_force_bias_cache.h
+++ b/multibody/tree/articulated_body_force_bias_cache.h
@@ -57,20 +57,6 @@ class ArticulatedBodyForceBiasCache {
     return Zplus_PB_W_[body_node_index];
   }
 
-  /// The spatial acceleration bias `Ab_WB` for body node with index
-  /// `body_node_index` including Coriolis and gyroscopic terms.
-  const SpatialAcceleration<T>& get_Ab_WB(
-      BodyNodeIndex body_node_index) const {
-    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
-    return Ab_WB_[body_node_index];
-  }
-
-  /// Mutable version of get_Ab_WB().
-  SpatialAcceleration<T>& get_mutable_Ab_WB(BodyNodeIndex body_node_index) {
-    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
-    return Ab_WB_[body_node_index];
-  }
-
   /// The articulated body inertia innovations generalized force `e_B` for this
   /// body's mobilizer.
   const VectorUpTo6<T>& get_e_B(BodyNodeIndex body_node_index) const {
@@ -88,7 +74,6 @@ class ArticulatedBodyForceBiasCache {
   // Allocates resources for this articulated body cache.
   void Allocate() {
     Zplus_PB_W_.resize(num_nodes_);
-    Ab_WB_.resize(num_nodes_);
     e_B_.resize(num_nodes_);
   }
 
@@ -97,7 +82,6 @@ class ArticulatedBodyForceBiasCache {
 
   // Pools indexed by BodyNodeIndex.
   std::vector<SpatialForce<T>> Zplus_PB_W_;
-  std::vector<SpatialAcceleration<T>> Ab_WB_;
   std::vector<VectorUpTo6<T>> e_B_;
 };
 

--- a/multibody/tree/body_node.h
+++ b/multibody/tree/body_node.h
@@ -1095,6 +1095,8 @@ class BodyNode : public MultibodyElement<BodyNode, T, BodyNodeIndex> {
   /// @param[in] abic
   ///   An already updated articulated body inertia cache in sync with
   ///   `context`.
+  /// @param[in] Zb_Bo_W
+  ///   Articulated body bias `Zb_Bo_W = Pplus_PB_W * Ab_WB`.
   /// @param[in] Fapplied_Bo_W
   ///   Externally applied spatial force on this node's body B at the body's
   ///   frame origin `Bo`, expressed in the world frame.
@@ -1118,11 +1120,12 @@ class BodyNode : public MultibodyElement<BodyNode, T, BodyNodeIndex> {
   /// @throws when called on the _root_ node or `aba_force_bias_cache` is
   /// nullptr.
   void CalcArticulatedBodyForceBiasCache_TipToBase(
-      const systems::Context<T>& context,
+      const systems::Context<T>&,
       const PositionKinematicsCache<T>& pc,
-      const VelocityKinematicsCache<T>* vc,
+      const VelocityKinematicsCache<T>*,
       const SpatialForce<T>& Fb_Bo_W,
       const ArticulatedBodyInertiaCache<T>& abic,
+      const SpatialForce<T>& Zb_Bo_W,
       const SpatialForce<T>& Fapplied_Bo_W,
       const Eigen::Ref<const VectorX<T>>& tau_applied,
       const Eigen::Ref<const MatrixUpTo6<T>>& H_PB_W,
@@ -1139,75 +1142,6 @@ class BodyNode : public MultibodyElement<BodyNode, T, BodyNodeIndex> {
 
     // Get R_WB.
     const math::RotationMatrix<T>& R_WB = X_WB.rotation();
-
-    SpatialAcceleration<T>& Ab_WB = get_mutable_Ab_WB(aba_force_bias_cache);
-    Ab_WB.SetZero();
-    if (vc != nullptr) {
-      // Inboard frame F and outboard frame M of this node's mobilizer.
-      const Frame<T>& frame_F = inboard_frame();
-      const Frame<T>& frame_M = outboard_frame();
-
-      // Compute R_PF and X_MB.
-      const math::RotationMatrix<T> R_PF =
-          frame_F.CalcRotationMatrixInBodyFrame(context);
-      const math::RigidTransform<T> X_MB =
-          frame_M.CalcPoseInBodyFrame(context).inverse();
-
-      // Parent position in the world is available from the position kinematics.
-      const math::RotationMatrix<T>& R_WP = get_R_WP(pc);
-
-      // TODO(amcastro-tri): consider caching R_WF.
-      const math::RotationMatrix<T> R_WF = R_WP * R_PF;
-
-      // Compute shift vector p_MoBo_F.
-      const Vector3<T> p_MoBo_F = get_X_FM(pc).rotation() * X_MB.translation();
-
-      // Compute H_FM_bias = Hdot * vm.
-      // That is, A_FM = H_FM(qm) * vm + H_FM_bias(qm, vm)
-      const VectorUpTo6<T> vmdot_zero =
-          VectorUpTo6<T>::Zero(get_num_mobilizer_velocities());
-      const SpatialAcceleration<T> H_FM_bias =
-          get_mobilizer().CalcAcrossMobilizerSpatialAcceleration(context,
-                                                                 vmdot_zero);
-
-      // Across mobilizer velocity is available from the velocity kinematics.
-      const Vector3<T> w_FM = get_V_FM(*vc).rotational();
-
-      // Ab_PB_W is the bias term for the acceleration A_PB_W. That is, it is
-      // the acceleration A_PB_W when vmdot = 0. Get Ab_PB_W by shifting and
-      // re-expressing H_FM_bias. We want to compute A_PB = DtP(V_PB). Due to
-      // the fact that frames P and F are on the same rigid body, we have that
-      // V_PF = 0. Therefore, DtP(V_PB) = DtF(V_PB). We then recognize that V_PB
-      // = V_PFb + V_FMb + V_MB = V_FMb. Since M and B are also on the same
-      // rigid body, V_MB = 0. Together, we get that A_PB = DtF(V_FMb) =
-      // A_FM.Shift(p_MoBo, w_FM).
-      const SpatialAcceleration<T> Ab_PB_W =
-          R_WF * H_FM_bias.Shift(p_MoBo_F, w_FM);
-
-      // Spatial velocity of parent is available from the velocity kinematics.
-      const SpatialVelocity<T>& V_WP = get_V_WP(*vc);
-      const Vector3<T>& w_WP = V_WP.rotational();
-      const Vector3<T>& v_WP = V_WP.translational();
-
-      // Velocity of body in parent is available from the velocity kinematics.
-      const SpatialVelocity<T>& V_PB_W = get_V_PB_W(*vc);
-      const Vector3<T>& w_PB_W = V_PB_W.rotational();
-      const Vector3<T>& v_PB_W = V_PB_W.translational();
-
-      // Body spatial velocity in W.
-      const SpatialVelocity<T>& V_WB = get_V_WB(*vc);
-      const Vector3<T>& w_WB = V_WB.rotational();
-      const Vector3<T>& v_WB = V_WB.translational();
-
-      // Compute Ab_WB according to:
-      // Ab_WB =  | w_WB x w_PB_W                 | + Ab_PB_W
-      //          | w_WP x (v_WB - v_WP + v_PB_W) |
-      // See @note in SpatialAcceleration::ComposeWithMovingFrameAcceleration()
-      // for a complete derivation.
-      Ab_WB = SpatialAcceleration<T>(
-          w_WB.cross(w_PB_W) + Ab_PB_W.rotational(),
-          w_WP.cross(v_WB - v_WP + v_PB_W) + Ab_PB_W.translational());
-    }
 
     // Compute the residual spatial force, Z_Bo_W, according to (1).
     SpatialForce<T> Z_Bo_W = Fb_Bo_W - Fapplied_Bo_W;
@@ -1232,9 +1166,7 @@ class BodyNode : public MultibodyElement<BodyNode, T, BodyNodeIndex> {
       Z_Bo_W += Zplus_BCb_W;
     }
 
-    const ArticulatedBodyInertia<T>& Pplus_PB_W = get_Pplus_PB_W(abic);
-
-    get_mutable_Zplus_PB_W(aba_force_bias_cache) = Z_Bo_W + Pplus_PB_W * Ab_WB;
+    get_mutable_Zplus_PB_W(aba_force_bias_cache) = Z_Bo_W + Zb_Bo_W;
 
     const int nv = get_num_mobilizer_velocities();
 
@@ -1276,6 +1208,11 @@ class BodyNode : public MultibodyElement<BodyNode, T, BodyNodeIndex> {
   ///   of this node's body B in its parent node body P, expressed in the world
   ///   frame W, with this node's generalized velocities (or mobilities) `v_B`
   ///   by `V_PB_W = H_PB_W⋅v_B`.
+  /// @param[in] Ab_WB
+  ///   the spatial acceleration bias term `Ab_WB` as it appears in the
+  ///   acceleration level motion constraint imposed by body B's mobilizer
+  ///   `A_WB = Aplus_WB + Ab_WB + H_PB_W * vdot_B`.
+  ///   See @ref abi_computing_accelerations for further details.
   /// @param[out] ac
   ///   A pointer to a valid, non nullptr, acceleration kinematics cache.
   ///
@@ -1290,6 +1227,7 @@ class BodyNode : public MultibodyElement<BodyNode, T, BodyNodeIndex> {
       const ArticulatedBodyInertiaCache<T>& abic,
       const ArticulatedBodyForceBiasCache<T>& aba_force_bias_cache,
       const Eigen::Ref<const MatrixUpTo6<T>>& H_PB_W,
+      const SpatialAcceleration<T>& Ab_WB,
       AccelerationKinematicsCache<T>* ac) const {
     DRAKE_THROW_UNLESS(ac != nullptr);
 
@@ -1313,8 +1251,6 @@ class BodyNode : public MultibodyElement<BodyNode, T, BodyNodeIndex> {
         A_WP.rotational(),
         A_WP.translational() + A_WP.rotational().cross(p_PoBo_W));
 
-    const SpatialAcceleration<T>& Ab_WB = get_Ab_WB(aba_force_bias_cache);
-
     SpatialAcceleration<T>& A_WB = get_mutable_A_WB(ac);
     A_WB = Aplus_WB + Ab_WB;
 
@@ -1334,6 +1270,100 @@ class BodyNode : public MultibodyElement<BodyNode, T, BodyNodeIndex> {
       // Update with vmdot term the spatial acceleration of the current body.
       A_WB += SpatialAcceleration<T>(H_PB_W * vmdot);
     }
+  }
+
+  /// Computes the spatial acceleration bias `Ab_WB(q, v)` for `this` node,
+  /// function both configuration q and velocities v. This term appears in the
+  /// acceleration level motion constraint imposed by body B's mobilizer `A_WB =
+  /// Aplus_WB + Ab_WB + H_PB_W * vdot_B`. Refer to
+  /// @ref abi_computing_accelerations for a detailed description and
+  /// derivation.
+  /// @param[in] context The context with the state of the MultibodyTree model.
+  /// @param[in] pc An already updated position kinematics cache in sync with
+  ///   `context`.
+  /// @param[in] vc An already updated velocity kinematics cache in sync with
+  ///   `context`. All velocities are assumed to be zero if vc is nullptr.
+  /// @param[out] Ab_WB The spatial acceleration bias for this node, measured
+  ///   and expressed in the world frame W. Must be non nullptr.
+  ///
+  /// @pre pc, vc, and abic previously computed to be in sync with `context.
+  ///
+  /// @throws when `Ab_WB` is nullptr.
+  void CalcSpatialAccelerationBias(
+      const systems::Context<T>& context,
+      const PositionKinematicsCache<T>& pc,
+      const VelocityKinematicsCache<T>& vc,
+      SpatialAcceleration<T>* Ab_WB) const {
+    DRAKE_THROW_UNLESS(Ab_WB != nullptr);
+    // As a guideline for developers, please refer to @ref
+    // abi_computing_accelerations for a detailed description and derivation of
+    // Ab_WB.
+
+    Ab_WB->SetZero();
+    // Inboard frame F and outboard frame M of this node's mobilizer.
+    const Frame<T>& frame_F = inboard_frame();
+    const Frame<T>& frame_M = outboard_frame();
+
+    // Compute R_PF and X_MB.
+    const math::RotationMatrix<T> R_PF =
+        frame_F.CalcRotationMatrixInBodyFrame(context);
+    const math::RigidTransform<T> X_MB =
+        frame_M.CalcPoseInBodyFrame(context).inverse();
+
+    // Parent position in the world is available from the position kinematics.
+    const math::RotationMatrix<T>& R_WP = get_R_WP(pc);
+
+    // TODO(amcastro-tri): consider caching R_WF.
+    const math::RotationMatrix<T> R_WF = R_WP * R_PF;
+
+    // Compute shift vector p_MoBo_F.
+    const Vector3<T> p_MoBo_F = get_X_FM(pc).rotation() * X_MB.translation();
+
+    // Compute H_FM_bias = Hdot * vm.
+    // That is, A_FM = H_FM(qm) * vm + H_FM_bias(qm, vm)
+    const VectorUpTo6<T> vmdot_zero =
+        VectorUpTo6<T>::Zero(get_num_mobilizer_velocities());
+    const SpatialAcceleration<T> H_FM_bias =
+        get_mobilizer().CalcAcrossMobilizerSpatialAcceleration(context,
+                                                               vmdot_zero);
+
+    // Across mobilizer velocity is available from the velocity kinematics.
+    const Vector3<T> w_FM = get_V_FM(vc).rotational();
+
+    // Ab_PB_W is the bias term for the acceleration A_PB_W. That is, it is
+    // the acceleration A_PB_W when vmdot = 0. Get Ab_PB_W by shifting and
+    // re-expressing H_FM_bias. We want to compute A_PB = DtP(V_PB). Due to
+    // the fact that frames P and F are on the same rigid body, we have that
+    // V_PF = 0. Therefore, DtP(V_PB) = DtF(V_PB). We then recognize that V_PB
+    // = V_PFb + V_FMb + V_MB = V_FMb. Since M and B are also on the same
+    // rigid body, V_MB = 0. Together, we get that A_PB = DtF(V_FMb) =
+    // A_FM.Shift(p_MoBo, w_FM).
+    const SpatialAcceleration<T> Ab_PB_W =
+        R_WF * H_FM_bias.Shift(p_MoBo_F, w_FM);
+
+    // Spatial velocity of parent is available from the velocity kinematics.
+    const SpatialVelocity<T>& V_WP = get_V_WP(vc);
+    const Vector3<T>& w_WP = V_WP.rotational();
+    const Vector3<T>& v_WP = V_WP.translational();
+
+    // Velocity of body in parent is available from the velocity kinematics.
+    const SpatialVelocity<T>& V_PB_W = get_V_PB_W(vc);
+    const Vector3<T>& w_PB_W = V_PB_W.rotational();
+    const Vector3<T>& v_PB_W = V_PB_W.translational();
+
+    // Body spatial velocity in W.
+    const SpatialVelocity<T>& V_WB = get_V_WB(vc);
+    const Vector3<T>& w_WB = V_WB.rotational();
+    const Vector3<T>& v_WB = V_WB.translational();
+
+    // Compute Ab_WB according to:
+    // Ab_WB =  | w_WB x w_PB_W                 | + Ab_PB_W
+    //          | w_WP x (v_WB - v_WP + v_PB_W) |
+    // See @note in SpatialAcceleration::ComposeWithMovingFrameAcceleration()
+    // for a complete derivation.
+    *Ab_WB = SpatialAcceleration<T>(
+        w_WB.cross(w_PB_W) + Ab_PB_W.rotational(),
+        w_WP.cross(v_WB - v_WP + v_PB_W) + Ab_PB_W.translational());
   }
 
  protected:
@@ -1595,19 +1625,6 @@ class BodyNode : public MultibodyElement<BodyNode, T, BodyNodeIndex> {
   SpatialForce<T>& get_mutable_Zplus_PB_W(
       ArticulatedBodyForceBiasCache<T>* aba_force_bias_cache) const {
     return aba_force_bias_cache->get_mutable_Zplus_PB_W(topology_.index);
-  }
-
-  // Returns a const reference to the Coriolis spatial acceleration `Ab_WB`
-  // for this body due to the relative velocities of body B and body P.
-  const SpatialAcceleration<T>& get_Ab_WB(
-      const ArticulatedBodyForceBiasCache<T>& aba_force_bias_cache) const {
-    return aba_force_bias_cache.get_Ab_WB(topology_.index);
-  }
-
-  // Mutable version of get_Ab_WB().
-  SpatialAcceleration<T>& get_mutable_Ab_WB(
-      ArticulatedBodyForceBiasCache<T>* aba_force_bias_cache) const {
-    return aba_force_bias_cache->get_mutable_Ab_WB(topology_.index);
   }
 
   // Returns a const reference to the Coriolis spatial acceleration `Ab_WB`

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -582,6 +582,53 @@ void MultibodyTree<T>::CalcSpatialInertiaInWorldCache(
 }
 
 template <typename T>
+void MultibodyTree<T>::CalcSpatialAccelerationBiasCache(
+    const systems::Context<T>& context,
+    std::vector<SpatialAcceleration<T>>* spatial_acceleration_bias_cache)
+    const {
+  const PositionKinematicsCache<T>& pc = EvalPositionKinematics(context);
+  const VelocityKinematicsCache<T>& vc = EvalVelocityKinematics(context);
+
+  // This skips the world, body_node_index = 0.
+  for (BodyNodeIndex body_node_index(1); body_node_index < num_bodies();
+       ++body_node_index) {
+    const BodyNode<T>& node = *body_nodes_[body_node_index];
+
+    // Get references to the hinge matrix and force bias for this node.
+    SpatialAcceleration<T>& Ab_WB =
+        (*spatial_acceleration_bias_cache)[body_node_index];
+
+    node.CalcSpatialAccelerationBias(context, pc, vc, &Ab_WB);
+  }
+}
+
+template <typename T>
+void MultibodyTree<T>::CalcArticulatedBodyVelocityBiasCache(
+  const systems::Context<T>& context,
+    std::vector<SpatialForce<T>>* articulated_body_velocity_bias_cache) const {
+  DRAKE_THROW_UNLESS(articulated_body_velocity_bias_cache != nullptr);
+  DRAKE_THROW_UNLESS(
+      static_cast<int>(articulated_body_velocity_bias_cache->size()) ==
+      num_bodies());
+  const ArticulatedBodyInertiaCache<T>& abic =
+      EvalArticulatedBodyInertiaCache(context);
+  const std::vector<SpatialAcceleration<T>>& spatial_acceleration_bias_cache =
+      EvalSpatialAccelerationBiasCache(context);
+
+  // This skips the world, body_node_index = 0.
+  for (BodyNodeIndex body_node_index(1); body_node_index < num_bodies();
+       ++body_node_index) {
+    const ArticulatedBodyInertia<T>& Pplus_PB_W =
+        abic.get_Pplus_PB_W(body_node_index);
+    const SpatialAcceleration<T>& Ab_WB =
+        spatial_acceleration_bias_cache[body_node_index];
+    SpatialForce<T>& Zb_Bo_W =
+        (*articulated_body_velocity_bias_cache)[body_node_index];
+    Zb_Bo_W = Pplus_PB_W * Ab_WB;
+  }
+}
+
+template <typename T>
 void MultibodyTree<T>::CalcDynamicBiasCache(
     const systems::Context<T>& context,
     std::vector<SpatialForce<T>>* Fb_Bo_W_cache) const {
@@ -1703,6 +1750,13 @@ void MultibodyTree<T>::CalcArticulatedBodyForceBiasCache(
   const std::vector<SpatialForce<T>>& dynamic_bias_cache =
       EvalDynamicBiasCache(context);
 
+  // We evaluate the kinematics dependent articulated body force bias Zb_Bo_W =
+  // Pplus_PB_W * Ab_WB. When cached, this corresponds to a significant
+  // computational gain when performing ABA with the same context (storing the
+  // same q and v) but different applied `forces`.
+  const std::vector<SpatialForce<T>>& articulated_body_velocity_bias_cache =
+      EvalArticulatedBodyVelocityBiasCache(context);
+
   // Perform tip-to-base recursion, skipping the world.
   for (int depth = tree_height() - 1; depth > 0; --depth) {
     for (BodyNodeIndex body_node_index : body_node_levels_[depth]) {
@@ -1718,10 +1772,12 @@ void MultibodyTree<T>::CalcArticulatedBodyForceBiasCache(
       Eigen::Map<const MatrixUpTo6<T>> H_PB_W =
           node.GetJacobianFromArray(H_PB_W_cache);
       const SpatialForce<T>& Fb_B_W = dynamic_bias_cache[body_node_index];
+      const SpatialForce<T>& Zb_Bo_W =
+          articulated_body_velocity_bias_cache[body_node_index];
 
       node.CalcArticulatedBodyForceBiasCache_TipToBase(
-          context, pc, &vc, Fb_B_W, abic, Fapplied_Bo_W, tau_applied, H_PB_W,
-          aba_force_bias_cache);
+          context, pc, &vc, Fb_B_W, abic, Zb_Bo_W, Fapplied_Bo_W, tau_applied,
+          H_PB_W, aba_force_bias_cache);
     }
   }
 }
@@ -1737,18 +1793,23 @@ void MultibodyTree<T>::CalcArticulatedBodyAccelerations(
       EvalAcrossNodeJacobianWrtVExpressedInWorld(context);
   const ArticulatedBodyInertiaCache<T>& abic =
       EvalArticulatedBodyInertiaCache(context);
+  const std::vector<SpatialAcceleration<T>>& spatial_acceleration_bias_cache =
+      EvalSpatialAccelerationBiasCache(context);
 
   // Perform base-to-tip recursion, skipping the world.
   for (int depth = 1; depth < tree_height(); ++depth) {
     for (BodyNodeIndex body_node_index : body_node_levels_[depth]) {
       const BodyNode<T>& node = *body_nodes_[body_node_index];
 
+      const SpatialAcceleration<T>& Ab_WB =
+          spatial_acceleration_bias_cache[body_node_index];
+
       // Get reference to the hinge mapping matrix.
       Eigen::Map<const MatrixUpTo6<T>> H_PB_W =
           node.GetJacobianFromArray(H_PB_W_cache);
 
       node.CalcArticulatedBodyAccelerations_BaseToTip(
-          context, pc, abic, aba_force_bias_cache, H_PB_W, ac);
+          context, pc, abic, aba_force_bias_cache, H_PB_W, Ab_WB, ac);
     }
   }
 }

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -1966,6 +1966,26 @@ class MultibodyTree {
     const ArticulatedBodyForceBiasCache<T>& aba_force_bias_cache,
     AccelerationKinematicsCache<T>* ac) const;
 
+  /// For a body B, computes the spatial acceleration bias term `Ab_WB` as it
+  /// appears in the acceleration level motion constraint imposed by body B's
+  /// mobilizer `A_WB = Aplus_WB + Ab_WB + H_PB_W * vdot_B`, with `Aplus_WB =
+  /// Φᵀ(p_PB) * A_WP` the rigidly shifted spatial acceleration of the inboard
+  /// body P and `H_PB_W` and `vdot_B` its mobilizer's hinge matrix and
+  /// mobilities, respectively. See @ref abi_computing_accelerations for further
+  /// details. On output `spatial_acceleration_bias_cache[body_node_index]`
+  /// contains `Ab_WB` for the body with node index `body_node_index`.
+  void CalcSpatialAccelerationBiasCache(
+      const systems::Context<T>& context,
+      std::vector<SpatialAcceleration<T>>* spatial_acceleration_bias_cache)
+      const;
+
+  /// Computes the articulated body bias `Zb_Bo_W = Pplus_PB_W * Ab_WB` for each
+  /// articulated body B. On output `Zb_Bo_W_cache[body_node_index]` contains
+  /// `Zb_Bo_W` for the body B with node index `body_node_index`.
+  void CalcArticulatedBodyVelocityBiasCache(
+      const systems::Context<T>& context,
+      std::vector<SpatialForce<T>>* Zb_Bo_W_cache) const;
+
   /// @}
 
   /// @}
@@ -2508,6 +2528,20 @@ class MultibodyTree {
       const systems::Context<T>& context) const {
     DRAKE_ASSERT(tree_system_ != nullptr);
     return tree_system_->EvalDynamicBiasCache(context);
+  }
+
+  // See CalcSpatialAccelerationBiasCache() for details.
+  const std::vector<SpatialAcceleration<T>>& EvalSpatialAccelerationBiasCache(
+      const systems::Context<T>& context) const {
+    DRAKE_ASSERT(tree_system_ != nullptr);
+    return tree_system_->EvalSpatialAccelerationBiasCache(context);
+  }
+
+  // See CalcArticulatedBodyVelocityBiasCache() for details.
+  const std::vector<SpatialForce<T>>& EvalArticulatedBodyVelocityBiasCache(
+      const systems::Context<T>& context) const {
+    DRAKE_ASSERT(tree_system_ != nullptr);
+    return tree_system_->EvalArticulatedBodyVelocityBiasCache(context);
   }
 
   // Given the state of this model in `context` and a known vector

--- a/multibody/tree/multibody_tree_system.cc
+++ b/multibody/tree/multibody_tree_system.cc
@@ -224,6 +224,44 @@ void MultibodyTreeSystem<T>::Finalize() {
       {this->configuration_ticket()});
   cache_indexes_.abi_cache_index = abi_cache_entry.cache_index();
 
+  auto& spatial_acceleration_bias_cache_entry = this->DeclareCacheEntry(
+      std::string("spatial acceleration bias (Ab_WB)"),
+      [tree = tree_.get()]() {
+        return AbstractValue::Make(
+            std::vector<SpatialAcceleration<T>>(tree->num_bodies()));
+      },
+      [tree = tree_.get()](const systems::ContextBase& context_base,
+                           AbstractValue* cache_value) {
+        auto& context = dynamic_cast<const Context<T>&>(context_base);
+        auto& spatial_acceleration_bias_cache =
+            cache_value
+                ->get_mutable_value<std::vector<SpatialAcceleration<T>>>();
+        tree->CalcSpatialAccelerationBiasCache(
+            context, &spatial_acceleration_bias_cache);
+      },
+      {this->kinematics_ticket()});
+  cache_indexes_.spatial_acceleration_bias =
+      spatial_acceleration_bias_cache_entry.cache_index();
+
+  auto& articulated_body_velocity_bias_cache_entry = this->DeclareCacheEntry(
+      std::string("ABI velocity bias cache (Zb_Bo_W)"),
+      [tree = tree_.get()]() {
+        return AbstractValue::Make(
+            std::vector<SpatialForce<T>>(tree->num_bodies()));
+      },
+      [tree = tree_.get()](const systems::ContextBase& context_base,
+                           AbstractValue* cache_value) {
+        auto& context = dynamic_cast<const Context<T>&>(context_base);
+        auto& articulated_body_velocity_bias_cache =
+            cache_value
+                ->get_mutable_value<std::vector<SpatialForce<T>>>();
+        tree->CalcArticulatedBodyVelocityBiasCache(
+            context, &articulated_body_velocity_bias_cache);
+      },
+      {this->kinematics_ticket()});
+  cache_indexes_.articulated_body_velocity_bias =
+      articulated_body_velocity_bias_cache_entry.cache_index();
+
   already_finalized_ = true;
 }
 

--- a/multibody/tree/multibody_tree_system.h
+++ b/multibody/tree/multibody_tree_system.h
@@ -123,6 +123,33 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
         .template Eval<std::vector<SpatialForce<T>>>(context);
   }
 
+  /** Returns a reference to the up to date cache of per-body spatial
+  acceleration bias terms in the given Context, recalculating it first if
+  necessary. For a body B, this is the spatial acceleration bias term `Ab_WB` as
+  it appears in the acceleration level motion constraint imposed by body B's
+  mobilizer `A_WB = Aplus_WB + Ab_WB + H_PB_W * vdot_B`, with `Aplus_WB =
+  Φᵀ(p_PB) * A_WP` the rigidly shifted spatial acceleration of the inboard body
+  P and `H_PB_W` and `vdot_B` its mobilizer's hinge matrix and mobilities,
+  respectively. See @ref abi_computing_accelerations for further details. */
+  const std::vector<SpatialAcceleration<T>>& EvalSpatialAccelerationBiasCache(
+      const systems::Context<T>& context) const {
+    return this->get_cache_entry(cache_indexes_.spatial_acceleration_bias)
+        .template Eval<std::vector<SpatialAcceleration<T>>>(context);
+  }
+
+  /** Evaluates the velocity (and configuration) dependent terms used by the
+  articulated body algorithm. Specifically, for a body B, this corresponds to
+  the articulated body bias `Zb_Bo_W = Pplus_PB_W * Ab_WB`. This computation is
+  particularly expensive when performing O(n) forward dynamics with different
+  applied forces but with the same `context` and therefore it is worth caching.
+  */
+  const std::vector<SpatialForce<T>>&
+  EvalArticulatedBodyVelocityBiasCache(
+      const systems::Context<T>& context) const {
+    return this->get_cache_entry(cache_indexes_.articulated_body_velocity_bias)
+        .template Eval<std::vector<SpatialForce<T>>>(context);
+  }
+
   /** For a body B connected to its parent P, returns a reference to the up to
   date cached value for H_PB_W, where H_PB_W is the `6 x nm` body-node hinge
   matrix that relates `V_PB_W` (body B's spatial velocity in its parent body P,
@@ -202,9 +229,11 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
   struct CacheIndexes {
     systems::CacheIndex abi_cache_index;
     systems::CacheIndex across_node_jacobians;
+    systems::CacheIndex articulated_body_velocity_bias;
     systems::CacheIndex dynamic_bias;
     systems::CacheIndex position_kinematics;
     systems::CacheIndex spatial_inertia_in_world;
+    systems::CacheIndex spatial_acceleration_bias;
     systems::CacheIndex velocity_kinematics;
   };
 


### PR DESCRIPTION
It is worth caching these terms when using ABA as an operator with different external forces but the same state, as we'll do in TAMSI.

