### PR TITLE
styleguide: Bump to latest commit

### DIFF
--- a/tools/workspace/styleguide/repository.bzl
+++ b/tools/workspace/styleguide/repository.bzl
@@ -8,8 +8,8 @@ def styleguide_repository(
     github_archive(
         name = name,
         repository = "RobotLocomotion/styleguide",
-        commit = "4ed40237e2061fff76281fa0040e431c16871d6a",
-        sha256 = "0ba3e0b651f0f8f57ca232cb68920224bad42114ed615884cae4180a6583e3bc",  # noqa
+        commit = "c400ec647014c0bf050b69247ecf7e78ca233fcb",
+        sha256 = "2f3f23f0f9aff9609e869c253c365e54e3311172f0fbc6b9c44347b4868f9681",  # noqa
         build_file = "@drake//tools/workspace/styleguide:package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
In particular, this teaches cpplint about new `[build/include]` errors for `<any>`, `<array>`, `<optional>`, and `<variant>` (https://github.com/RobotLocomotion/styleguide/pull/24).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12717)
<!-- Reviewable:end -->
