### PR TITLE
pybind: Refactor / correct bindings' code

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -36,7 +36,7 @@ using systems::LeafSystem;
 
 template <typename Class>
 void BindIdentifier(py::module m, const std::string& name, const char* id_doc) {
-  auto& cls_doc = pydrake_doc.drake.Identifier;
+  constexpr auto& cls_doc = pydrake_doc.drake.Identifier;
 
   py::class_<Class> cls(m, name.c_str(), id_doc);
   py::handle cls_handle = cls;

--- a/bindings/pydrake/symbolic_py.cc
+++ b/bindings/pydrake/symbolic_py.cc
@@ -51,7 +51,7 @@ PYBIND11_MODULE(symbolic, m) {
 
   // TODO(m-chaturvedi) Add Pybind11 documentation for operator overloads, etc.
   py::class_<Variable> var_cls(m, "Variable", doc.Variable.doc);
-  const auto& var_doc = doc.Variable;
+  constexpr auto& var_doc = doc.Variable;
   py::enum_<Variable::Type>(var_cls, "Type")
       .value(
           "CONTINUOUS", Variable::Type::CONTINUOUS, var_doc.Type.CONTINUOUS.doc)
@@ -522,7 +522,7 @@ PYBIND11_MODULE(symbolic, m) {
       }),
           doc.Polynomial.ctor.doc_2args_e_indeterminates)
       .def("indeterminates", &Polynomial::indeterminates,
-          doc.Polynomial.indeterminates.doc, doc.Polynomial.indeterminates.doc)
+          doc.Polynomial.indeterminates.doc)
       .def("decision_variables", &Polynomial::decision_variables,
           doc.Polynomial.decision_variables.doc)
       .def("Degree", &Polynomial::Degree, doc.Polynomial.Degree.doc)

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -402,8 +402,8 @@ struct Impl {
               // calling the Python function (`str_py`) does.
               return str_py(self->GetGraphvizString(max_depth));
             },
-            doc.System.GetGraphvizString.doc,
-            py::arg("max_depth") = std::numeric_limits<int>::max())
+            py::arg("max_depth") = std::numeric_limits<int>::max(),
+            doc.System.GetGraphvizString.doc)
         // Events.
         .def("Publish",
             overload_cast_explicit<void, const Context<T>&>(


### PR DESCRIPTION
This is towards #12040 (https://github.com/RobotLocomotion/drake/pull/12040#pullrequestreview-356689433).

We're trying to split the PR (#12040).  In this PR:
- We correct two `doc` related typos.
- And adhere to the alias convention for the doc variables used at other places.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12718)
<!-- Reviewable:end -->
