### PR TITLE
Update minimum and recommended Bazel versions to 2.0 and 2.1 respectively

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ endif()
 
 # The version passed to find_package(Bazel) should match the
 # minimum_bazel_version value in the call to versions.check() in WORKSPACE.
-set(MINIMUM_BAZEL_VERSION 1.1)
+set(MINIMUM_BAZEL_VERSION 2.0)
 find_package(Bazel ${MINIMUM_BAZEL_VERSION} MODULE REQUIRED)
 
 get_filename_component(C_COMPILER_REALPATH "${CMAKE_C_COMPILER}" REALPATH)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,4 +25,4 @@ load("@bazel_skylib//:lib.bzl", "versions")
 # This needs to be in WORKSPACE or a repository rule for native.bazel_version
 # to actually be defined. The minimum_bazel_version value should match the
 # version passed to the find_package(Bazel) call in the root CMakeLists.txt.
-versions.check(minimum_bazel_version = "1.1")
+versions.check(minimum_bazel_version = "2.0")

--- a/doc/developers.rst
+++ b/doc/developers.rst
@@ -79,7 +79,7 @@ Drake requires a compiler running in C++17 mode.
 | Operating System                 | Bazel | CMake | C/C++ Compiler      | Java              | Python |
 +==================================+=======+=======+=====================+===================+========+
 +----------------------------------+-------+-------+---------------------+-------------------+--------+
-| Ubuntu 18.04 LTS (Bionic Beaver) | 2.0   | 3.10  | | Clang 6.0         | OpenJDK 11        | 3.6    |
+| Ubuntu 18.04 LTS (Bionic Beaver) | 2.1   | 3.10  | | Clang 6.0         | OpenJDK 11        | 3.6    |
 |                                  |       |       | | GCC 7.4 (default) |                   |        |
 +----------------------------------+       +-------+---------------------+-------------------+--------+
 | macOS Mojave (10.14)             |       | 3.16  | | Apple LLVM 11.0.0 | | AdoptOpenJDK 13 | 3.7    |

--- a/setup/mac/binary_distribution/Brewfile
+++ b/setup/mac/binary_distribution/Brewfile
@@ -4,6 +4,8 @@
 tap 'dreal-deps/ibex'
 tap 'robotlocomotion/director'
 
+cask 'adoptopenjdk' unless system '/usr/libexec/java_home --version 1.8+ --failfast &> /dev/null'
+
 brew 'boost'
 brew 'cmake'
 brew 'dreal-deps/ibex/ibex@2.7.4'  # N.B. Matches drake/tools/workspace/ibex/version.bzl.
@@ -27,7 +29,5 @@ brew 'tinyxml2'
 brew 'robotlocomotion/director/vtk@8.2'
 brew 'yaml-cpp'
 brew 'zeromq'
-
-cask 'adoptopenjdk' unless system '/usr/libexec/java_home --version 1.8+ --failfast &> /dev/null'
 
 mas 'Xcode', id: 497799835 unless File.exist? '/Applications/Xcode.app'

--- a/setup/mac/source_distribution/Brewfile
+++ b/setup/mac/source_distribution/Brewfile
@@ -1,16 +1,17 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-tap 'bazelbuild/tap'
 tap 'homebrew/cask-fonts' unless File.exist? '/Library/Fonts/DejaVuSans.ttf'
+tap 'homebrew/cask-versions' unless system '/usr/libexec/java_home --version 1.8 --failfast &> /dev/null'
 tap 'robotlocomotion/director'
 
-brew 'bazelbuild/tap/bazel'
+cask 'adoptopenjdk8' unless system '/usr/libexec/java_home --version 1.8 --failfast &> /dev/null'
+cask 'font-dejavu-sans' unless File.exist? '/Library/Fonts/DejaVuSans.ttf'
+
+brew 'bazel'
 brew 'diffstat'
 brew 'doxygen'
 brew 'freetype'
 brew 'kcov'
 brew 'llvm@6'
 brew 'patchutils'
-
-cask 'font-dejavu-sans' unless File.exist? '/Library/Fonts/DejaVuSans.ttf'

--- a/setup/mac/source_distribution/install_prereqs.sh
+++ b/setup/mac/source_distribution/install_prereqs.sh
@@ -18,6 +18,11 @@ if ! command -v /usr/local/bin/brew &>/dev/null; then
 fi
 
 /usr/local/bin/brew update
+
+# TODO(jamiesnape). Remove the below two lines on or after 2020-05-01.
+/usr/local/bin/brew uninstall bazelbuild/tap/bazel 2>/dev/null || true
+/usr/local/bin/brew untap bazelbuild/tap 2>/dev/null || true
+
 /usr/local/bin/brew bundle --file="${BASH_SOURCE%/*}/Brewfile" --no-lock
 
 if ! command -v /usr/local/bin/pip3 &>/dev/null; then

--- a/setup/ubuntu/source_distribution/install_prereqs.sh
+++ b/setup/ubuntu/source_distribution/install_prereqs.sh
@@ -71,6 +71,6 @@ dpkg_install_from_wget() {
 }
 
 dpkg_install_from_wget \
-  bazel 2.0.0 \
-  https://releases.bazel.build/2.0.0/release/bazel_2.0.0-linux-x86_64.deb \
-  575c77b96bc6202f83c7ff233cd44541aa30ff1b2bc211eaf8c99a8987272c68
+  bazel 2.1.0 \
+  https://releases.bazel.build/2.1.0/release/bazel_2.1.0-linux-x86_64.deb \
+  bf12c4c0bb853266676295351da20d13075b26bf23f28c4ffdfefc1b35062ccb

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -3,7 +3,7 @@ import %workspace%/tools/cc_toolchain/bazel.rc
 import %workspace%/tools/dynamic_analysis/bazel.rc
 import %workspace%/tools/lint/bazel.rc
 
-# Disable native Python rules in Bazel versions before 2.0.
+# Disable native Python rules in Bazel versions before 4.0.
 build --incompatible_load_python_rules_from_bzl=yes
 
 # Default to an optimized build.


### PR DESCRIPTION
And switch to `homebrew/core/bazel` on macOS, which requires a Java 1.8 implementation to be installed beforehand.

<!-- Reviewable:start -->
--------
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12729)
<!-- Reviewable:end -->
