### PR TITLE
geometry: Use field gradient and surface normal to filter ContactSurface.

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -169,6 +169,16 @@ drake_cc_library(
     hdrs = ["hydroelastic_internal.h"],
     deps = [
         ":bounding_volume_hierarchy",
+        ":make_box_field",
+        ":make_box_mesh",
+        ":make_cylinder_field",
+        ":make_cylinder_mesh",
+        ":make_ellipsoid_field",
+        ":make_ellipsoid_mesh",
+        ":make_sphere_field",
+        ":make_sphere_mesh",
+        ":obj_to_surface_mesh",
+        ":proximity_utilities",
         ":surface_mesh",
         ":volume_mesh",
         "//common:essential",
@@ -176,16 +186,6 @@ drake_cc_library(
         "//geometry:geometry_roles",
         "//geometry:proximity_properties",
         "//geometry:shape_specification",
-        "//geometry/proximity:make_box_field",
-        "//geometry/proximity:make_box_mesh",
-        "//geometry/proximity:make_cylinder_field",
-        "//geometry/proximity:make_cylinder_mesh",
-        "//geometry/proximity:make_ellipsoid_field",
-        "//geometry/proximity:make_ellipsoid_mesh",
-        "//geometry/proximity:make_sphere_field",
-        "//geometry/proximity:make_sphere_mesh",
-        "//geometry/proximity:obj_to_surface_mesh",
-        "//geometry/proximity:proximity_utilities",
         "@fmt",
     ],
 )
@@ -195,7 +195,7 @@ drake_cc_library(
     hdrs = ["make_box_field.h"],
     deps = [
         ":distance_to_point_callback",
-        ":volume_mesh",
+        ":mesh_field",
         "//common:essential",
         "//common:unused",
         "//geometry:shape_specification",
@@ -218,7 +218,7 @@ drake_cc_library(
     hdrs = ["make_cylinder_field.h"],
     deps = [
         ":distance_to_point_callback",
-        ":volume_mesh",
+        ":mesh_field",
         "//common:essential",
         "//common:unused",
         "//geometry:shape_specification",
@@ -241,7 +241,7 @@ drake_cc_library(
     name = "make_ellipsoid_field",
     hdrs = ["make_ellipsoid_field.h"],
     deps = [
-        ":volume_mesh",
+        ":mesh_field",
         "//common:essential",
         "//geometry:shape_specification",
     ],
@@ -263,7 +263,7 @@ drake_cc_library(
     name = "make_sphere_field",
     hdrs = ["make_sphere_field.h"],
     deps = [
-        ":volume_mesh",
+        ":mesh_field",
         "//common:essential",
         "//geometry:shape_specification",
     ],
@@ -290,9 +290,11 @@ drake_cc_library(
     hdrs = [
         "mesh_field.h",
         "mesh_field_linear.h",
+        "volume_mesh_field.h",
     ],
     deps = [
         ":surface_mesh",
+        ":volume_mesh",
         "//common",
     ],
 )
@@ -407,14 +409,12 @@ drake_cc_library(
     name = "volume_mesh",
     srcs = [
         "volume_mesh.cc",
-        "volume_mesh_field.cc",
     ],
     hdrs = [
         "volume_mesh.h",
         "volume_mesh_field.h",
     ],
     deps = [
-        ":mesh_field",
         "//common",
         "//geometry:geometry_ids",
     ],
@@ -609,6 +609,8 @@ drake_cc_googletest(
     name = "mesh_field_linear_test",
     deps = [
         ":mesh_field",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//math:geometric_transform",
     ],
 )
 
@@ -692,7 +694,9 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "volume_mesh_test",
     deps = [
+        ":mesh_field",
         ":volume_mesh",
+        "//common/test_utilities:eigen_matrix_compare",
         "//math:geometric_transform",
     ],
 )

--- a/geometry/proximity/contact_surface_doxygen.h
+++ b/geometry/proximity/contact_surface_doxygen.h
@@ -1,0 +1,13 @@
+namespace drake {
+namespace geometry {
+namespace proximity {
+
+/** @addtogroup module_contact_surface
+
+ @note This page is still under construction.
+
+ */
+
+}  // namespace proximity
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/mesh_field.cc
+++ b/geometry/proximity/mesh_field.cc
@@ -3,6 +3,9 @@
 namespace drake {
 namespace geometry {
 
+template class MeshField<double, SurfaceMesh<double>>;
+template class MeshField<AutoDiffXd, SurfaceMesh<AutoDiffXd>>;
+
 }  // namespace geometry
 }  // namespace drake
 

--- a/geometry/proximity/mesh_field.h
+++ b/geometry/proximity/mesh_field.h
@@ -13,9 +13,9 @@ namespace geometry {
   on a mesh M. It can evaluate the field value at any location on any element
   of the mesh.
 
-  @tparam FieldValue  a valid Eigen scalar or vector of valid Eigen scalars for
+  @tparam FieldValue  a valid Eigen scalar or Vector of Eigen scalar for
                      the field value.
-  @tparam MeshType   the type of the mesh: surface mesh or volume mesh.
+  @tparam MeshType   the type of the mesh: SurfaceMesh or VolumeMesh.
 */
 template <class FieldValue, class MeshType>
 // TODO(DamrongGuoy): Consider making the fact that MeshType is templated on
@@ -95,6 +95,9 @@ class MeshField {
  */
 template <typename FieldValue, typename T>
 using SurfaceMeshField = MeshField<FieldValue, SurfaceMesh<T>>;
+
+extern template class MeshField<double, SurfaceMesh<double>>;
+extern template class MeshField<AutoDiffXd, SurfaceMesh<AutoDiffXd>>;
 
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/proximity/mesh_field_linear.cc
+++ b/geometry/proximity/mesh_field_linear.cc
@@ -1,7 +1,34 @@
 #include "drake/geometry/proximity/mesh_field_linear.h"
 
+#include "drake/common/default_scalars.h"
+
 namespace drake {
 namespace geometry {
+
+template <class FieldValue, class MeshType>
+void MeshFieldLinear<FieldValue, MeshType>::CalcGradientField() {
+  gradients_.clear();
+  gradients_.reserve(this->mesh().num_elements());
+  for (typename MeshType::ElementIndex e(0); e < this->mesh().num_elements();
+       ++e) {
+    gradients_.push_back(CalcGradientVector(e));
+  }
+}
+
+template <class FieldValue, class MeshType>
+Vector3<FieldValue> MeshFieldLinear<FieldValue, MeshType>::CalcGradientVector(
+    typename MeshType::ElementIndex e) const {
+  std::array<FieldValue, MeshType::kVertexPerElement> u;
+  for (int i = 0; i < MeshType::kVertexPerElement; ++i) {
+    u[i] = values_[this->mesh().element(e).vertex(i)];
+  }
+  return this->mesh().CalcGradientVectorOfLinearField(u, e);
+}
+
+template class MeshFieldLinear<double, SurfaceMesh<double>>;
+template class MeshFieldLinear<AutoDiffXd, SurfaceMesh<AutoDiffXd>>;
+template class MeshFieldLinear<double, VolumeMesh<double>>;
+template class MeshFieldLinear<AutoDiffXd, VolumeMesh<AutoDiffXd>>;
 
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/proximity/mesh_field_linear.h
+++ b/geometry/proximity/mesh_field_linear.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <map>
 #include <memory>
 #include <string>
@@ -12,98 +13,68 @@
 #include "drake/common/sorted_pair.h"
 #include "drake/geometry/proximity/mesh_field.h"
 #include "drake/geometry/proximity/surface_mesh.h"
+#include "drake/geometry/proximity/volume_mesh.h"
 
 namespace drake {
 namespace geometry {
 
-// TODO(DamrongGuoy): Consider putting shape_function_FEM into its own file.
 /**
- \defgroup shape_function_FEM  Shape Functions in Finite Element Approximation
+ %MeshFieldLinear represents a piecewise linear scalar field f defined on a
+ simplicial-element (triangular or tetrahedral) mesh; the field value
+ changes linearly within each element, and the gradient is constant within
+ each element. The field is continuous across adjacent elements, but its
+ gradient is discontinuous from one element to the other.
 
-  Much of this discussion was taken from:
+ To represent a piecewise linear field f, we store one field value per vertex
+ of the mesh. Each element (triangle or tetrahedron) has (d+1) vertices,
+ where d is the dimension of the element. For triangle, d = 2, and for
+ tetrahedron, d = 3.
 
-      O.C. Zienkiewicz, R.L. Taylor & J.Z. Zhu.
-      The Finite Element Method: Its Basis and Fundamentals.
-      Chapter 3. Weak Forms and Finite Element Approximation.
-      Chapter 6. Shape Functions, Derivatives, and Integration.
+ The following sections are details for interested readers.
 
-  We approximately represent a field u over a finite domain by dividing the
-  domain into "small regular shaped regions" (Zienkiewicz et al. p. 55), each
-  of which define a _finite element_ domain, and a finite set of points
-  shared between the finite elements define the _nodes_, where we store field
-  values.  The division of the domain into elements and nodes is called a
-  _finite element mesh_.  The term _element_ refers to a tetrahedron in
-  VolumeMesh or a triangle in SurfaceMesh.
+ <h3> Barycentric coordinate </h3>
 
-  On each finite element E, we have one _shape function_ Nᵢ for each
-  node nᵢ of the element, where i is a local index of the node within the
-  element E:
+ For a linear triangle or tetrahedron element E in 3-D, we use barycentric
+ coordinate:
 
-               Nᵢ : E → ℝ,
+       (b₀, b₁, b₂)     for triangle,
+       (b₀, b₁, b₂, b₃) for tetrahedron,
+       ∑bᵢ = 1, bᵢ ≥ 0,
 
-  and use Nᵢ to define the _finite element approximation_ uᵉ of Field u
-  at a point p ∈ E as:
+ to identify a point Q that lies in the simplicial element E. The coefficient
+ bᵢ is the weight of vertex Vᵢ of the element E, where the index i is a local
+ index within the element E, not the global index of the entire mesh. In other
+ words, vertex Vᵢ is the iᵗʰ vertex of E, not the iᵗʰ vertex among all vertices
+ in the mesh. The point Q in E can be expressed as:
 
-               uᵉ(p) = ∑ Nᵢ(p) * uᵢ
+    Q = ∑bᵢ(Q)Vᵢ,
 
-  where uᵢ is the value of u at the node nᵢ in the element E.  The specific
-  definition of a shape function Nᵢ depends on the shape and order of
-  approximation of a finite element E. For example, E could be a triangle or
-  a tetrahedron, with first-order (linear) approximation, second-order
-  (quadratic) approximation, etc.
+ where we indicate the barycentric coordinate of a point Q on an element E as
+ bᵢ(Q) -- omitting E for typographical convenience.
 
-  Refer to MeshFieldLinear and MeshFieldQuadratic for examples of the shape
-  functions.
+ <h3> Field value </h3>
+
+ At a point Q in element E, the piecewise linear field f has value:
+
+    f(Q) = ∑bᵢ(Q)Fᵢ
+
+ where Fᵢ is the field value at the iᵗʰ vertex of E.
+
+ <h3> Gradient </h3>
+
+ Consider each bᵢ as a linear scalar field on element E, the gradient of
+ the piecewise linear field f on E is:
+
+      ∇f = ∑Fᵢ∇bᵢ
+
+ Each gradient vector ∇bᵢ is constant on E and depends on the shape of the
+ triangle or tetrahedron E.
+
+ @tparam T  a valid Eigen scalar for field values.
+ @tparam MeshType    the type of the meshes: SurfaceMesh or VolumeMesh.
  */
-
-/**@{*/
-
-/**
- @ingroup shape_function_FEM
- %MeshFieldLinear represents a field variable defined on a finite-element
- simplicial (triangular or tetrahedral) mesh using first-order (linear)
- approximation. See @ref shape_function_FEM for basic terminology of finite
- element approximation.
-
- We store one field value per vertex of the mesh, and each element
- (triangle or tetrahedron) has (d+1) nodes, where d is the dimension of the
- element.
-
- <h3>Example. %Shape Function of a Linear Triangular Element</h3>
-
- A _linear triangular element_ E with three vertices v₀, v₁, v₂ has its
- three nodes n₀, n₁, n₂ are coincident with the vertices. For brevity, here we
- write vᵢ for both the label of the vertex and also the Cartesian coordinates
- of its location in a certain coordinates frame.
-
- <!-- TODO(DamrongGuoy): Consider simplify it. -->
- For a triangular element, it is beneficial to use a map from the
- _parent coordinate system_ (L₀, L₁, L₂) (also known as
- _barycentric_ or _area coordinates_) to the Cartesian coordinates
- p = (x,y,z) of a point on the triangle:
-
-              p(L₀, L₁, L₂) = L₀ * v₀ + L₁ * v₁ + L₂ * v₂,
-              L₀ + L₁ + L₂ = 1, Lᵢ ∈ [0,1].
-
- For a linear triangular element, the shape function is the same as the
- parent coordinate functions:
-
-              Nᵢ(p) = Lᵢ(p), i = 0,1,2,
-
- and its finite element approximation uᵉ of Field u at a point p ∈ E is:
-
-              uᵉ(p) = N₀(p) * u₀ + N₁(p) * u₁ + N₂(p) * u₂,
-
- where uᵢ is the value of u() at the node nᵢ.
-
- Linear tetrahedral elements are similar.
-
- @tparam FieldValue  a valid Eigen scalar or vector of valid Eigen scalars for
-                     the field value.
- @tparam MeshType    the type of the meshes: surface mesh or volume mesh.
- */
-template <class FieldValue, class MeshType>
-class MeshFieldLinear final : public MeshField<FieldValue, MeshType> {
+template <class T, class MeshType>
+class MeshFieldLinear final : public MeshField<T, MeshType> {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(MeshFieldLinear)
 
@@ -112,59 +83,96 @@ class MeshFieldLinear final : public MeshField<FieldValue, MeshType> {
    @param name    The name of the field variable.
    @param values  The field value at each vertex of the mesh.
    @param mesh    The mesh M to which this MeshField refers.
+   @param calculate_gradient Calculate gradient field when true, default is
+                  true.
    @pre   The `mesh` is non-null, and the number of entries in `values` is the
           same as the number of vertices of the mesh.
    */
-  MeshFieldLinear(std::string name, std::vector<FieldValue>&& values,
-                  const MeshType* mesh)
-      : MeshField<FieldValue, MeshType>(mesh),
+  MeshFieldLinear(std::string name, std::vector<T>&& values,
+                  const MeshType* mesh, bool calculate_gradient = true)
+      : MeshField<T, MeshType>(mesh),
         name_(std::move(name)), values_(std::move(values)) {
     DRAKE_DEMAND(static_cast<int>(values_.size()) ==
                  this->mesh().num_vertices());
+    if (calculate_gradient) {
+      CalcGradientField();
+    }
   }
 
-  FieldValue EvaluateAtVertex(typename MeshType::VertexIndex v) const final {
+  T EvaluateAtVertex(typename MeshType::VertexIndex v) const final {
     return values_[v];
   }
 
-  FieldValue Evaluate(typename MeshType::ElementIndex e,
+  T Evaluate(typename MeshType::ElementIndex e,
                       const typename MeshType::Barycentric& b) const final {
     const auto& element = this->mesh().element(e);
-    FieldValue value = b[0] * values_[element.vertex(0)];
+    T value = b[0] * values_[element.vertex(0)];
     for (int i = 1; i < MeshType::kDim + 1; ++i) {
       value += b[i] * values_[element.vertex(i)];
     }
     return value;
   }
 
-  FieldValue EvaluateCartesian(
+  T EvaluateCartesian(
                  typename MeshType::ElementIndex e,
                  const typename MeshType::Cartesian& p_MQ) const final {
     return Evaluate(e, this->mesh().CalcBarycentric(p_MQ, e));
   }
 
+ /** Evaluates the gradient in the domain of the element indicated by `e`.
+  The gradient is a vector in R³ expressed in frame M. For surface meshes, it
+  will particularly lie parallel to the plane of the corresponding triangle.
+  @throw std::runtime_error if the gradient vector was not calculated.
+  */
+  Vector3<T> EvaluateGradient(
+      typename MeshType::ElementIndex e) const {
+    if (gradients_.size() == 0) {
+      throw std::runtime_error("Gradient vector was not calculated.");
+    }
+    return gradients_[e];
+  }
+
+  /** Transforms the gradient vectors of this field from its initial frame M
+   to the new frame N.
+   @warning Use this function when the reference mesh of this field changes
+   its frame in the same way.
+   */
+  void TransformGradients(
+      const math::RigidTransform<typename MeshType::ScalarType>& X_NM) {
+    for (auto& grad : gradients_) {
+      grad = X_NM.rotation() * grad;
+    }
+  }
+
   const std::string& name() const { return name_; }
-  const std::vector<FieldValue>& values() const { return values_; }
-  std::vector<FieldValue>& mutable_values() { return values_; }
+  const std::vector<T>& values() const { return values_; }
 
   // TODO(#12173): Consider NaN==NaN to be true in equality tests.
-  // TODO(#12173): Support the VolumeMesh MeshType by implementing the Equal
-  //               function in VolumeMesh.
+  // TODO(DamrongGuoy): Change the type of parameter `field` from MeshField
+  //  to MeshFieldLinear. We will need to change the callers of this function
+  //  too.
   /** Checks to see whether the given MeshFieldLinear object is equal via deep
    exact comparison. The name of the objects are exempt from this comparison.
    NaNs are treated as not equal as per the IEEE standard.
-   @note Using a MeshType of VolumeMesh is not yet supported.
    @param field The field for comparison.
    @returns `true` if the given field is equal.
+   @note Requires `MeshField field` to be MeshFieldLinear.
    */
-  bool Equal(const MeshField<FieldValue, MeshType>& field) const {
+  bool Equal(const MeshField<T, MeshType>& field) const {
     if (!this->mesh().Equal(field.mesh())) return false;
 
+    const auto* field_linear =
+        dynamic_cast<const MeshFieldLinear<T, MeshType>*>(&field);
+    DRAKE_DEMAND(field_linear);
+
+    // Check field value at each vertex.
     for (typename MeshType::VertexIndex i(0); i < this->mesh().num_vertices();
          ++i) {
-      if (this->EvaluateAtVertex(i) != field.EvaluateAtVertex(i))
+      if (values_.at(i) != field_linear->values_.at(i))
         return false;
     }
+    // Check gradient vectors.
+    if (gradients_ != field_linear->gradients_) return false;
 
     // All checks passed.
     return true;
@@ -173,25 +181,35 @@ class MeshFieldLinear final : public MeshField<FieldValue, MeshType> {
  private:
   // Clones MeshFieldLinear data under the assumption that the mesh
   // pointer is null.
-  [[nodiscard]] std::unique_ptr<MeshField<FieldValue, MeshType>>
+  [[nodiscard]] std::unique_ptr<MeshField<T, MeshType>>
   DoCloneWithNullMesh() const final {
     return std::make_unique<MeshFieldLinear>(*this);
   }
+  void CalcGradientField();
+  Vector3<T> CalcGradientVector(
+      typename MeshType::ElementIndex e) const;
+
   std::string name_;
   // The field values are indexed in the same way as vertices, i.e.,
   // values_[i] is the field value for the mesh vertices_[i].
-  std::vector<FieldValue> values_;
+  std::vector<T> values_;
+  // The gradients are indexed in the same way as elements, i.e.,
+  // gradients_[i] is the gradient vector on elements_[i]. The elements could
+  // be tetrahedra for VolumeMesh or triangles for SurfaceMesh.
+  std::vector<Vector3<T>> gradients_;
 };
 
 /**
- @tparam FieldValue  a valid Eigen scalar or vector of valid Eigen scalars for
-                     the field value.
+ @tparam FieldValue  a valid Eigen scalar for field values.
  @tparam T  a valid Eigen scalar for coordinates.
  */
 template <typename FieldValue, typename T>
 using SurfaceMeshFieldLinear = MeshFieldLinear<FieldValue, SurfaceMesh<T>>;
 
-/**@}*/
+extern template class MeshFieldLinear<double, SurfaceMesh<double>>;
+extern template class MeshFieldLinear<AutoDiffXd, SurfaceMesh<AutoDiffXd>>;
+extern template class MeshFieldLinear<double, VolumeMesh<double>>;
+extern template class MeshFieldLinear<AutoDiffXd, VolumeMesh<AutoDiffXd>>;
 
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/proximity/penetration_doxygen.h
+++ b/geometry/proximity/penetration_doxygen.h
@@ -1,0 +1,23 @@
+namespace drake {
+namespace geometry {
+namespace proximity {
+
+/** @addtogroup module_penetration_queries
+ Penetration queries report all pairs of intersecting geometries and differ
+ in how they characterize the penetration. They include:
+
+   - report penetrations as point pairs
+   - @ref module_contact_surface "report penetrations as contact surfaces"
+   - check whether there is any penetration at all
+
+ @note This page is still under construction.
+
+ @{
+   @defgroup module_contact_surface Contact Surface
+ @}
+
+ */
+
+}  // namespace proximity
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/proximity_doxygen.h
+++ b/geometry/proximity/proximity_doxygen.h
@@ -3,10 +3,9 @@ namespace geometry {
 namespace proximity {
 
 /** @addtogroup proximity_queries
-
  Proximity queries span a range of types, including:
 
-   - penetration
+   - @ref module_penetration_queries "penetration"
    - distance
    - ray-intersection
 
@@ -15,7 +14,13 @@ namespace proximity {
  <!-- TODO(tehbelinda): Fill this in. -->
  @note This page is still under construction.
 
- Next topic: @ref render_engines  */
+ Next topic: @ref render_engines
+
+ @{
+  @defgroup module_penetration_queries Penetration Queries
+ @}
+
+ */
 
 }  // namespace proximity
 }  // namespace geometry

--- a/geometry/proximity/surface_mesh.h
+++ b/geometry/proximity/surface_mesh.h
@@ -103,6 +103,10 @@ class SurfaceFace {
   std::array<SurfaceVertexIndex, 3> vertex_;
 };
 
+// Forward declaration of SurfaceMeshTester<T>. SurfaceMesh<T> will
+// grant friend access to SurfaceMeshTester<T>.
+template <typename T> class SurfaceMeshTester;
+
 // TODO(DamrongGuoy): mention interesting properties of the mesh, e.g., open
 //  meshes, meshes with holes, non-manifold surface.
 /** %SurfaceMesh represents a triangulated surface.
@@ -123,10 +127,21 @@ class SurfaceMesh {
    */
   //@{
 
+  using ScalarType = T;
+
+  // TODO(DamrongGuoy): Remove kDim and replace its usage like (kDim + 1) by
+  //  kVertexPerElement in mesh_to_vtk, mesh_field_linear, and
+  //  bounding_volume_hierarchy. Issue #12756.
+
   /**
    A surface mesh has the intrinsic dimension 2.  It is embedded in 3-d space.
    */
   static constexpr int kDim = 2;
+
+  /**
+   Number of vertices per element. A triangle has 3 vertices.
+   */
+  static constexpr int kVertexPerElement = 3;
 
   /**
    Index for identifying a vertex.
@@ -389,6 +404,8 @@ class SurfaceMesh {
    @returns `true` if the given mesh is equal.
    */
   bool Equal(const SurfaceMesh<T>& mesh) const {
+    if (this == &mesh) return true;
+
     if (this->num_faces() != mesh.num_faces()) return false;
     if (this->num_vertices() != mesh.num_vertices()) return false;
 
@@ -409,10 +426,30 @@ class SurfaceMesh {
     return true;
   }
 
+  /** Calculates the gradient ∇u of a linear field u on the triangle `f`.
+   Field u is defined by the three field values `field_value[i]` at the i-th
+   vertex of the triangle. The gradient ∇u is expressed in the coordinates
+   frame of this mesh M.
+   */
+  template <typename FieldValue>
+  Vector3<FieldValue> CalcGradientVectorOfLinearField(
+      const std::array<FieldValue, 3>& field_value, SurfaceFaceIndex f) const {
+    Vector3<FieldValue> gradu_M = field_value[0] * CalcGradBarycentric(f, 0);
+    gradu_M += field_value[1] * CalcGradBarycentric(f, 1);
+    gradu_M += field_value[2] * CalcGradBarycentric(f, 2);
+    return gradu_M;
+  }
+
  private:
   // Calculates the areas and face normals of each triangle, the total area,
   // and the centroid of the surface.
   void CalcAreasNormalsAndCentroid();
+
+  // Calculates the gradient vector ∇bᵢ of the barycentric coordinate
+  // function bᵢ of the i-th vertex of the triangle `f`. The gradient
+  // vector ∇bᵢ is expressed in the coordinates frame of this mesh M.
+  // @pre  0 ≤ i < 3.
+  Vector3<T> CalcGradBarycentric(SurfaceFaceIndex f, int i) const;
 
   // The triangles that comprise the surface.
   std::vector<SurfaceFace> faces_;
@@ -431,6 +468,8 @@ class SurfaceMesh {
   // Area-weighted geometric centroid Sc of the surface mesh as an offset vector
   // from the origin of Frame M to point Sc, expressed in Frame M.
   Vector3<T> p_MSc_;
+
+  friend class SurfaceMeshTester<T>;
 };
 
 template <class T>
@@ -467,6 +506,68 @@ void SurfaceMesh<T>::CalcAreasNormalsAndCentroid() {
   // Finalize centroid.
   if (total_area_ != T(0.))
     p_MSc_ /= (3. * total_area_);
+}
+
+template <typename T>
+Vector3<T> SurfaceMesh<T>::CalcGradBarycentric(SurfaceFaceIndex f,
+                                               int i) const {
+  DRAKE_DEMAND(0 <= i && i < 3);
+  // Vertex V corresponds to bᵢ in the barycentric coordinate in the triangle
+  // indexed by `f`. A and B are the other two vertices of the triangle.
+  // Positions of the vertices are expressed in frame M of the mesh.
+  const Vector3<T>& p_MV = vertices_[faces_[f].vertex(i)].r_MV();
+  const Vector3<T>& p_MA = vertices_[faces_[f].vertex((i + 1) % 3)].r_MV();
+  const Vector3<T>& p_MB = vertices_[faces_[f].vertex((i + 2) % 3)].r_MV();
+
+  // TODO(DamrongGuoy): Provide a mechanism for users to set the gradient
+  //  vector in SurfaceMeshFieldLinear since this calculation is not reliable
+  //  for zero- or almost-zero-area triangles. For example, the code that
+  //  creates ContactSurface by triangle-tetrahedron intersection can set the
+  //  pressure gradient along a contact polygon by projecting the soft
+  //  tetrahedron's pressure gradient onto the plane of the rigid triangle.
+
+  // Let bᵥ be the barycentric coordinate function corresponding to vertex V.
+  // bᵥ is a linear function of the points in the triangle.
+  // bᵥ = 0 on the line through AB.
+  // bᵥ = 1 on the line through V parallel to AB.
+  // Therefore, bᵥ changes fastest in the direction perpendicular to AB
+  // towards V with the rate of change 1/h, where h is the height of vertex V
+  // from the base AB.
+  //
+  //    ──────────────V────────────── bᵥ = 1
+  //                 ╱↑╲       ┊
+  //                ╱ ┊ ╲      ┊
+  //               ╱  ┊  ╲     ┊ h
+  //              ╱   ┊H  ╲    ┊
+  //             ╱    ┊    ╲   ┊
+  //    ────────A━━━━━━━━━━━B──────── bᵥ = 0
+  //
+  // Let H be the height vector from the base AB to the vertex V, i.e., the
+  // vector perpendicular to the line AB that starts from a point on the
+  // line and ends at V. The length of H is h. The gradient vector ∇bᵥ is
+  // along the unit vector H/h. Along that direction, bᵥ changes at the rate
+  // of 1/h per unit distance. Therefore,
+  //
+  //       ∇bᵥ = H/h².
+  //
+  // We can calculate H from AV by subtracting its component along AB:
+  //
+  //       H = AV - (AV⋅AB)AB/|AB|²
+  //
+  const Vector3<T> p_AB_M = p_MB - p_MA;
+  const T ab2 = p_AB_M.squaredNorm();
+  const Vector3<T> p_AV_M = p_MV - p_MA;
+  constexpr double kEps = std::numeric_limits<double>::epsilon();
+  constexpr double kEps2 = kEps * kEps;
+  // For a skinny triangle with the edge AB that has zero or almost-zero
+  // length, we set the vector H to be AV.
+  const Vector3<T> H_M =
+      (ab2 <= kEps2) ? p_AV_M : p_AV_M - (p_AV_M.dot(p_AB_M)) * p_AB_M / ab2;
+  const T h2 = H_M.squaredNorm();
+  if (h2 <= kEps2) {
+    throw std::runtime_error("Bad triangle. Cannot compute gradient.");
+  }
+  return H_M / h2;
 }
 
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(

--- a/geometry/proximity/test/mesh_field_test.cc
+++ b/geometry/proximity/test/mesh_field_test.cc
@@ -64,6 +64,7 @@ GTEST_TEST(MeshFieldTest, TestClone) {
                          const MeshType::Cartesian&) const final {
       return FieldValue(0);
     }
+
    private:
     [[nodiscard]] std::unique_ptr<MeshFieldBase> DoCloneWithNullMesh() const
     final {

--- a/geometry/proximity/test/surface_mesh_test.cc
+++ b/geometry/proximity/test/surface_mesh_test.cc
@@ -12,6 +12,20 @@
 
 namespace drake {
 namespace geometry {
+
+// TODO(DamrongGuoy): Remove this helper class if we change
+//  CalcGradBarycentric() from private to public.
+template <typename T>
+class SurfaceMeshTester {
+ public:
+  explicit SurfaceMeshTester(const SurfaceMesh<T>& mesh) : mesh_(mesh) {}
+  Vector3<T> CalcGradBarycentric(SurfaceFaceIndex f, int i) const {
+    return mesh_.CalcGradBarycentric(f, i);
+  }
+ private:
+  const SurfaceMesh<T>& mesh_;
+};
+
 namespace {
 
 using Eigen::AngleAxisd;
@@ -264,6 +278,146 @@ GTEST_TEST(SurfaceMeshTest, TestCalcBarycentricAutoDiffXd) {
   TestCalcBarycentric<AutoDiffXd>();
 }
 
+template <typename T>
+void TestCalcGradBarycentric() {
+  // The mesh M consists of one triangle whose vertices are at the origin and
+  // on the X's axis and Y's axis of M's frame. The chosen vertex coordinates
+  // avoid symmetry but are easy to calculate ∇bᵢ manually.
+  //
+  //                                 Z
+  //                                 |
+  //     v0_M = (0,0,0)              |
+  //     v1_M = (1,0,0)              |   M's frame
+  //     v2_M = (0,2,0)              |
+  //                               v0+----+----v2----Y
+  //                                /
+  //                              v1
+  //                              /
+  //                             /
+  //                            X
+  //
+  const int triangle[3] = {0, 1, 2};
+  const Vector3<T> v0_M(0., 0., 0.);
+  const Vector3<T> v1_M(1., 0., 0.);
+  const Vector3<T> v2_M(0., 2., 0.);
+
+  // We use an arbitrary pose of the surface mesh M in World frame W to make the
+  // test more realistic.
+  const math::RigidTransform<T> X_WM(
+      math::RollPitchYaw<T>(M_PI / 6.0, 2.0 * M_PI / 3.0, 5.0 * M_PI / 4.0),
+      Vector3<T>(1.0, 2.0, 3.0));
+
+  // Create the mesh with vertex coordinates expressed in World frame to make
+  // the test more realistic.
+  const SurfaceMesh<T> mesh_W(
+      {SurfaceFace(triangle)},
+      {SurfaceVertex<T>(X_WM * v0_M), SurfaceVertex<T>(X_WM * v1_M),
+       SurfaceVertex<T>(X_WM * v2_M)});
+
+  const SurfaceMeshTester<T> tester(mesh_W);
+  const auto gradb0_W = tester.CalcGradBarycentric(SurfaceFaceIndex(0), 0);
+  const auto gradb1_W = tester.CalcGradBarycentric(SurfaceFaceIndex(0), 1);
+  const auto gradb2_W = tester.CalcGradBarycentric(SurfaceFaceIndex(0), 2);
+
+  // In this example, we have these equations, expressed in M's frame:
+  //      b₀(x,y,z) = -x - y/2 + 1,
+  //      b₁(x,y,z) = x,
+  //      b₂(x,y,z) = y/2.
+  // We can manually verify the equations by checking that bᵢ(vi) = 1 for all i,
+  // bⱼ(vj) = 0 for all i ≠ j, and ∑bⱼ = 1.
+  //     We can read off ∇bᵢ from the coefficients of x,y,z in the above
+  // equations.
+  const Vector3<T> expect_gradb0_M(-1., -1. / 2., 0.);
+  const Vector3<T> expect_gradb1_M = Vector3<T>::UnitX();
+  const Vector3<T> expect_gradb2_M = Vector3<T>::UnitY() / 2.;
+
+  const auto& R_WM = X_WM.rotation();
+  EXPECT_TRUE(CompareMatrices(R_WM * expect_gradb0_M, gradb0_W, 1e-14));
+  EXPECT_TRUE(CompareMatrices(R_WM * expect_gradb1_M, gradb1_W, 1e-14));
+  EXPECT_TRUE(CompareMatrices(R_WM * expect_gradb2_M, gradb2_W, 1e-14));
+
+  // Since ∑bᵢ = 1, the gradients have zero sum: ∑(∇bᵢ) = 0.
+  EXPECT_TRUE(CompareMatrices(gradb0_W + gradb1_W + gradb2_W,
+                              Vector3<T>::Zero(), 1e-14));
+}
+
+GTEST_TEST(SurfaceMeshTest, TestCalcGradBarycentricDouble) {
+  TestCalcGradBarycentric<double>();
+}
+
+GTEST_TEST(SurfaceMeshTest, TestCalcGradBarycentricAutoDiffXd) {
+  TestCalcGradBarycentric<AutoDiffXd>();
+}
+
+GTEST_TEST(SurfaceMeshTest, TestCalcGradBarycentricZeroAreaTriangle) {
+  std::unique_ptr<SurfaceMesh<double>> mesh = GenerateZeroAreaMesh();
+  const SurfaceMeshTester<double> tester(*mesh);
+  EXPECT_THROW(tester.CalcGradBarycentric(SurfaceFaceIndex(0), 0),
+               std::runtime_error);
+}
+
+template <typename T>
+void TestCalcGradientVectorOfLinearField() {
+  // CalcGradientVectorOfLinearField() is a weighted sum of
+  // CalcGradBarycentric() which is already tested with non-symmetric vertex
+  // coordinates and an arbitrary pose. Therefore, it suffices to test
+  // CalcGradientVectorOfLinearField() in the mesh's frame M with symmetric
+  // vertex coordinates but non-symmetric field values.
+  //
+  // The three vertices v0,v1,v2 of the triangle have coordinates expressed
+  // in M's frame as:
+  //
+  //                                +Z
+  //                                 |
+  //     v0_M = (1,0,0), f₀ = 2      v2
+  //     v1_M = (0,1,0), f₁ = 3      |   M's frame
+  //     v2_M = (0,0,1), f₂ = 4      |
+  //                                 +------v1---+Y
+  //                                /
+  //                               /
+  //                             v0
+  //                             /
+  //                           +X
+  //
+  const int triangle[3] = {0, 1, 2};
+  const Vector3<T> v0_M(1., 0., 0.);
+  const Vector3<T> v1_M(0., 1., 0.);
+  const Vector3<T> v2_M(0., 0., 1.);
+  const SurfaceMesh<T> mesh_M(
+      {SurfaceFace(triangle)},
+      {SurfaceVertex<T>(v0_M), SurfaceVertex<T>(v1_M), SurfaceVertex<T>(v2_M)});
+  const std::array<T, 3> f{2., 3., 4.};
+
+  const Vector3<T> gradf_M =
+      mesh_M.CalcGradientVectorOfLinearField(f, SurfaceFaceIndex(0));
+
+  // This function
+  //       f(x,y,z) = -x + z + 3
+  // satisfies f(vi_M) = fᵢ, i.e.,
+  //       f(1,0,0) = 2
+  //       f(0,1,0) = 3
+  //       f(0,0,1) = 4
+  // and its gradient ∇f is orthogonal to the triangle normal (1,1,1)/√3, i.e.,
+  // ∇f is along the triangle (belong to the tangent plane of the triangle).
+  // There are many linear functions that satisfy f(vi_M) = fᵢ since there
+  // are only three constraints for i=0,1,2, but a linear function has four
+  // parameters A*x + B*y + C*z + D.  We want the one with its gradient along
+  // the triangle.
+  //     Therefore, we can read off ∇f from the coefficients of x,y,z in the
+  // equation.
+  const Vector3<T> expect_gradf_M{-1., 0., 1};
+
+  EXPECT_TRUE(CompareMatrices(expect_gradf_M, gradf_M, 1e-14));
+}
+
+GTEST_TEST(SurfaceMeshTest, TestCalcGradientVectorOfLinearFieldDouble) {
+  TestCalcGradientVectorOfLinearField<double>();
+}
+
+GTEST_TEST(SurfaceMeshTest, TestCalcGradientVectorOfLinearFieldAutoDiffXd) {
+  TestCalcGradientVectorOfLinearField<AutoDiffXd>();
+}
+
 GTEST_TEST(SurfaceMeshTest, ReverseFaceWinding) {
   auto ref_mesh = TestSurfaceMesh<double>();
   auto test_mesh = std::make_unique<SurfaceMesh<double>>(*ref_mesh);
@@ -356,6 +510,7 @@ GTEST_TEST(SurfaceMeshTest, TestEqual) {
   const auto zero_area_mesh = GenerateZeroAreaMesh();
   const auto triangle_mesh = GenerateTwoTriangleMesh<double>();
   SurfaceMesh<double> triangle_mesh_copy = *triangle_mesh;
+  EXPECT_TRUE(triangle_mesh->Equal(*triangle_mesh));
   EXPECT_TRUE(triangle_mesh->Equal(triangle_mesh_copy));
   EXPECT_FALSE(zero_area_mesh->Equal(*triangle_mesh));
 }

--- a/geometry/proximity/test/volume_mesh_test.cc
+++ b/geometry/proximity/test/volume_mesh_test.cc
@@ -8,19 +8,37 @@
 #include "drake/common/autodiff.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/extract_double.h"
-#include "drake/geometry/proximity/mesh_field_linear.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/geometry/proximity/volume_mesh_field.h"
 #include "drake/math/rigid_transform.h"
 
 namespace drake {
 namespace geometry {
 
+// TODO(DamrongGuoy): Remove this helper class if we change
+//  CalcGradBarycentric() from private to public.
+template<typename T>
+class VolumeMeshTester {
+ public:
+  explicit VolumeMeshTester(const VolumeMesh<T>& mesh) : mesh_(mesh) {}
+  Vector3<T> CalcGradBarycentric(VolumeElementIndex e, int i) const {
+    return mesh_.CalcGradBarycentric(e, i);
+  }
+ private:
+  const VolumeMesh<T>& mesh_;
+};
+
+namespace {
+
+using math::RigidTransform;
+using math::RollPitchYaw;
+
 // Test instantiation of VolumeMesh of a geometry M and inspecting its
 // components. By default, the vertex positions are expressed in M's frame.
 // The optional parameter X_WM will change the vertex positions to W's frame.
-template <typename T>
+template<typename T>
 std::unique_ptr<VolumeMesh<T>> TestVolumeMesh(
-    const math::RigidTransform<T> X_WM = math::RigidTransform<T>::Identity()) {
+    const RigidTransform<T> X_WM = RigidTransform<T>::Identity()) {
   // A  trivial volume mesh comprises of two tetrahedral elements with
   // vertices on the coordinate axes and the origin like this:
   //
@@ -75,10 +93,73 @@ GTEST_TEST(VolumeMeshTest, TestVolumeMeshAutoDiffXd) {
   auto volume_mesh = TestVolumeMesh<AutoDiffXd>();
 }
 
-template <typename T>
+template<typename T>
+void TestVolumeMeshEqual() {
+  const auto mesh = TestVolumeMesh<T>();
+
+  // Mesh equals itself.
+  EXPECT_TRUE(mesh->Equal(*mesh));
+
+  // Mesh equals its copy.
+  {
+    const VolumeMesh<T> mesh_copy = *mesh;
+    EXPECT_TRUE(mesh->Equal(mesh_copy));
+  }
+
+  // Different positions of vertices.
+  {
+    const auto mesh_translate =
+        TestVolumeMesh<T>(RigidTransform<T>(Vector3<T>(1., 1., 1.)));
+    EXPECT_FALSE(mesh->Equal(*mesh_translate));
+  }
+
+  // Different tetrahedral connectivity.
+  {
+    std::vector<VolumeVertex<T>> vertices_copy = mesh->vertices();
+    std::vector<VolumeElement> tetrahedra = mesh->tetrahedra();
+    // Re-order vertices of the first tetrahedron.
+    tetrahedra[0] = VolumeElement(tetrahedra[0].vertex(1),
+                                  tetrahedra[0].vertex(2),
+                                  tetrahedra[0].vertex(0),
+                                  tetrahedra[0].vertex(3));
+    VolumeMesh<T> mesh_different_tetrahedra(std::move(tetrahedra),
+                                             std::move(vertices_copy));
+    EXPECT_FALSE(mesh->Equal(mesh_different_tetrahedra));
+  }
+
+  // Different number of vertices.
+  {
+    std::vector<VolumeVertex<T>> vertices = mesh->vertices();
+    vertices.emplace_back(1.2, 3.7, 0.15);
+    std::vector<VolumeElement> tetrahedra = mesh->tetrahedra();
+    VolumeMesh<T> another_mesh(std::move(tetrahedra), std::move(vertices));
+    EXPECT_FALSE(mesh->Equal(another_mesh));
+  }
+
+  // Different number of tetrahedra.
+  {
+    std::vector<VolumeVertex<T>> vertices = mesh->vertices();
+    std::vector<VolumeElement> tetrahedra = mesh->tetrahedra();
+    tetrahedra.pop_back();
+    VolumeMesh<T> another_mesh(std::move(tetrahedra), std::move(vertices));
+    EXPECT_FALSE(mesh->Equal(another_mesh));
+  }
+}
+
+GTEST_TEST(VolumeMeshTest, TestEqualDouble) {
+  TestVolumeMeshEqual<double>();
+}
+
+// Smoke tests using `AutoDiffXd` as the underlying scalar type. The purpose
+// of this test is simply to check that it compiles.
+GTEST_TEST(VolumeMeshTest, TestEqualAutoDiffXd) {
+  TestVolumeMeshEqual<AutoDiffXd>();
+}
+
+template<typename T>
 void TestCalcTetrahedronVolume() {
-  const math::RigidTransform<T> X_WM(
-      math::RollPitchYaw<T>(M_PI / 6.0, 2.0 * M_PI / 3.0, 7.0 * M_PI / 4.0),
+  const RigidTransform<T> X_WM(
+      RollPitchYaw<T>(M_PI / 6.0, 2.0 * M_PI / 3.0, 7.0 * M_PI / 4.0),
       Vector3<T>(1.0, 2.0, 3.0));
   auto volume_mesh = TestVolumeMesh<T>(X_WM);
   // Estimate 4 multiply+add, each introduces 2 epsilons.
@@ -100,10 +181,10 @@ GTEST_TEST(VolumeMeshTest, TestCalcTetrahedronVolumeAutoDiffXd) {
   TestCalcTetrahedronVolume<AutoDiffXd>();
 }
 
-template <typename T>
+template<typename T>
 void TestCalcBarycentric() {
-  const math::RigidTransform<T> X_WM(
-      math::RollPitchYaw<T>(M_PI / 6.0, 2.0 * M_PI / 3.0, 7.0 * M_PI / 4.0),
+  const RigidTransform<T> X_WM(
+      RollPitchYaw<T>(M_PI / 6.0, 2.0 * M_PI / 3.0, 7.0 * M_PI / 4.0),
       Vector3<T>(1.0, 2.0, 3.0));
   auto volume_mesh = TestVolumeMesh<T>(X_WM);
   // Empirically the std::numeric_limits<double>::epsilon() 2.2e-16 is too
@@ -115,16 +196,16 @@ void TestCalcBarycentric() {
   {
     Vector3<T> p_M(0.25, 0.25, 0.25);
     typename VolumeMesh<T>::Barycentric barycentric =
-        volume_mesh->CalcBarycentric(X_WM *p_M, element);
+        volume_mesh->CalcBarycentric(X_WM * p_M, element);
     typename VolumeMesh<T>::Barycentric expect_barycentric(0.25, 0.25, 0.25,
                                                            0.25);
     EXPECT_LE((barycentric - expect_barycentric).norm(), kTolerance);
   }
   // At the centroid of the face v0v1v2.
   {
-    Vector3<T> p_M(1./3., 1./3., 0.);
+    Vector3<T> p_M(1. / 3., 1. / 3., 0.);
     typename VolumeMesh<T>::Barycentric barycentric =
-        volume_mesh->CalcBarycentric(X_WM *p_M, element);
+        volume_mesh->CalcBarycentric(X_WM * p_M, element);
     typename VolumeMesh<T>::Barycentric expect_barycentric(1. / 3., 1. / 3.,
                                                            1. / 3., 0.);
     EXPECT_LE((barycentric - expect_barycentric).norm(), kTolerance);
@@ -133,7 +214,7 @@ void TestCalcBarycentric() {
   {
     Vector3<T> p_M(0.5, 0., 0.);
     typename VolumeMesh<T>::Barycentric barycentric =
-        volume_mesh->CalcBarycentric(X_WM *p_M, element);
+        volume_mesh->CalcBarycentric(X_WM * p_M, element);
     typename VolumeMesh<T>::Barycentric expect_barycentric(0.5, 0.5, 0., 0.);
     EXPECT_LE((barycentric - expect_barycentric).norm(), kTolerance);
   }
@@ -151,52 +232,188 @@ GTEST_TEST(VolumeMeshTest, TestCalcBarycentricDouble) {
   TestCalcBarycentric<double>();
 }
 
-GTEST_TEST(VolumeMeshTest, TestCalcBarycentricAutoffXd) {
+GTEST_TEST(VolumeMeshTest, TestCalcBarycentricAutoDiffXd) {
   TestCalcBarycentric<AutoDiffXd>();
 }
 
-// TODO(SeanCurtis-TRI): Remove the forward declaration in place of simply
-//  defining the method here.
-// Tests instantiation of VolumeMeshField and evaluating a scalar field value.
-template <typename T>
-std::unique_ptr<VolumeMeshFieldLinear<T, T>> TestVolumeMeshField();
+template<typename T>
+void TestCalcGradBarycentric() {
+  // The mesh M consists of one tetrahedral element whose vertices are at the
+  // origin and on the coordinate axes of M's frmae. The chosen vertex
+  // coordinates avoid symmetry but are easy to calculate ∇bᵢ manually.
+  //
+  //                                 Z
+  //                                 |
+  //                                 v3
+  //                                 |
+  //                                 |
+  //     v0_M = (0,0,0)              |
+  //     v1_M = (1,0,0)              |   M's frame
+  //     v2_M = (0,2,0)              |
+  //     v3_M = (0,0,3)            v0+---+---v2-----Y
+  //                                /
+  //                              v1
+  //                              /
+  //                             /
+  //                            X
+  //
+  const int tetrahedron[4] = {0, 1, 2, 3};
+  const Vector3<T> v0_M(0., 0., 0.);
+  const Vector3<T> v1_M(1., 0., 0.);
+  const Vector3<T> v2_M(0., 2., 0.);
+  const Vector3<T> v3_M(0., 0., 3.);
+
+  // We use an arbitrary pose of the volume mesh M in World frame W to make the
+  // test more realistic.
+  const RigidTransform<T> X_WM(
+      RollPitchYaw<T>(M_PI / 6.0, 2.0 * M_PI / 3.0, 5.0 * M_PI / 4.0),
+      Vector3<T>(1.0, 2.0, 3.0));
+
+  // Create the mesh with vertex coordinates expressed in World frame to make
+  // the test more realistic.
+  const VolumeMesh<T> mesh_W(
+      {VolumeElement(tetrahedron)},
+      {VolumeVertex<T>(X_WM * v0_M), VolumeVertex<T>(X_WM * v1_M),
+       VolumeVertex<T>(X_WM * v2_M), VolumeVertex<T>(X_WM * v3_M)});
+
+  const VolumeMeshTester<T> tester(mesh_W);
+  const auto gradb0_W = tester.CalcGradBarycentric(VolumeElementIndex(0), 0);
+  const auto gradb1_W = tester.CalcGradBarycentric(VolumeElementIndex(0), 1);
+  const auto gradb2_W = tester.CalcGradBarycentric(VolumeElementIndex(0), 2);
+  const auto gradb3_W = tester.CalcGradBarycentric(VolumeElementIndex(0), 3);
+
+  // In this example, we have these equations, expressed in M's frame:
+  //      b₀(x,y,z) = -x - y/2 - z/3 + 1,
+  //      b₁(x,y,z) = x,
+  //      b₂(x,y,z) = y/2,
+  //      b₃(x,y,z) = z/3.
+  // We can manually verify the equations by checking that bᵢ(vi) = 1 for all i,
+  // bⱼ(vj) = 0 for all i ≠ j, and ∑bⱼ = 1.
+  //     We can read off ∇bᵢ from the coefficients of x,y,z in the above
+  // equations.
+  const Vector3<T> expect_gradb0_M(-1., -1. / 2., -1. / 3.);
+  const Vector3<T> expect_gradb1_M = Vector3<T>::UnitX();
+  const Vector3<T> expect_gradb2_M = Vector3<T>::UnitY() / 2.;
+  const Vector3<T> expect_gradb3_M = Vector3<T>::UnitZ() / 3.;
+
+  const auto R_WM = X_WM.rotation();
+  EXPECT_TRUE(CompareMatrices(R_WM * expect_gradb0_M, gradb0_W, 1e-14));
+  EXPECT_TRUE(CompareMatrices(R_WM * expect_gradb1_M, gradb1_W, 1e-14));
+  EXPECT_TRUE(CompareMatrices(R_WM * expect_gradb2_M, gradb2_W, 1e-14));
+  EXPECT_TRUE(CompareMatrices(R_WM * expect_gradb3_M, gradb3_W, 1e-14));
+
+  // Since ∑bᵢ = 1, the gradients have zero sum: ∑(∇bᵢ) = 0.
+  EXPECT_TRUE(CompareMatrices(gradb0_W + gradb1_W + gradb2_W + gradb3_W,
+                              Vector3<T>::Zero(), 1e-14));
+}
+
+GTEST_TEST(VolumeMeshTest, TestCalcGradBarycentricDouble) {
+  TestCalcGradBarycentric<double>();
+}
+
+GTEST_TEST(VolumeMeshTest, TestCalcGradBarycentricAutoDiffXd) {
+  TestCalcGradBarycentric<AutoDiffXd>();
+}
+
+template<typename T>
+void TestCalcGradientVectorOfLinearField() {
+  // CalcGradientVectorOfLinearField() is a weighted sum of
+  // CalcGradBarycentric() which is already tested with non-symmetric vertex
+  // coordinates and an arbitrary pose. Therefore, it suffices to test
+  // CalcGradientVectorOfLinearField() in the mesh's frame M with symmetric
+  // vertex coordinates but non-symmetric field values.
+  //
+  // The four vertices v0,v1,v2,v3 of the tetrahedral element e0 have
+  // coordinates expressed in M's frame as:
+  //
+  //                                +Z
+  //                                 |
+  //     v0_M = (0,0,0), f₀ = 2      v3
+  //     v1_M = (1,0,0), f₁ = 3      |   M's frame
+  //     v2_M = (0,1,0), f₂ = 4      |
+  //     v3_M = (0,0,1), f₃ = 5    v0+------v2---+Y
+  //                                /
+  //                               /
+  //                             v1
+  //                             /
+  //                           +X
+  //
+  auto mesh_M = TestVolumeMesh<T>();
+  const std::array<T, 4> f{2., 3., 4., 5.};
+
+  const Vector3<T> gradf_M =
+      mesh_M->CalcGradientVectorOfLinearField(f, VolumeElementIndex(0));
+
+  // The field f on the tetrahedral element e0 satisfies this equation with
+  // coordinates expressed in M's frame:
+  //       f(x,y,z) = x + 2y + 3z + 2.
+  // We can verify the equation manually by checking that f(vi_M) = fᵢ like
+  // these:
+  //       f(0,0,0) = 2
+  //       f(1,0,0) = 3
+  //       f(0,1,0) = 4
+  //       f(0,0,1) = 5
+  // Therefore, we can read off ∇f, expressed in M's frame, from the
+  // coefficients of x,y,z in the equation.
+  const Vector3<T> expect_gradf_M{1., 2., 3.};
+
+  EXPECT_TRUE(CompareMatrices(expect_gradf_M, gradf_M, 1e-14));
+}
+
+GTEST_TEST(VolumeMeshTest, TestCalcGradientVectorOfLinearFieldDouble) {
+  TestCalcGradientVectorOfLinearField<double>();
+}
+
+GTEST_TEST(VolumeMeshTest, TestCalcGradientVectorOfLinearFieldAutoDiffXd) {
+  TestCalcGradientVectorOfLinearField<AutoDiffXd>();
+}
+
+template<typename T>
+std::unique_ptr<VolumeMeshFieldLinear<T, T>> TestVolumeMeshFieldLinear() {
+  auto volume_mesh = TestVolumeMesh<T>();
+
+  // We give names to the values at vertices for testing later.
+  const T f0{1.};
+  const T f1{2.};
+  const T f2{3.};
+  const T f3{4.};
+  const T f4{5.};
+  std::vector<T> f_values = {f0, f1, f2, f3, f4};
+
+  auto volume_mesh_field = std::make_unique<VolumeMeshFieldLinear<T, T>>(
+      "pressure", std::move(f_values), volume_mesh.get());
+
+  // Tests evaluation of the field on the element e0 {v0, v1, v2, v3}.
+  const VolumeElementIndex e0(0);
+  const typename VolumeMesh<T>::Barycentric b{0.4, 0.3, 0.2, 0.1};
+  const T expect_p = b(0) * f0 + b(1) * f1 + b(2) * f2 + b(3) * f3;
+  EXPECT_EQ(expect_p, volume_mesh_field->Evaluate(e0, b));
+
+  // Tests the gradient vector ∇p on the element e0 {v0, v1, v2, v3}.
+  // VolumeMeshFieldLinear stores ∇p for each element. We only check that
+  // ∇p stored in VolumeMeshFieldLinear is the same as the gradient
+  // calculated by VolumeMesh. The vectors are expressed in frame M of the mesh.
+  Vector3<T> gradp_M = volume_mesh_field->EvaluateGradient(e0);
+  Vector3<T> expect_gradp_M = volume_mesh->CalcGradientVectorOfLinearField(
+      std::array<T, 4>{f0, f1, f2, f3}, e0);
+  EXPECT_TRUE(CompareMatrices(expect_gradp_M, gradp_M, 1e-14));
+
+  return volume_mesh_field;
+}
 
 // Test instantiation of VolumeMeshField using `double` as the underlying
 // scalar type.
-GTEST_TEST(VolumeMeshFieldTest, TestVolumeMeshFieldDouble) {
-  auto volume_mesh_field = TestVolumeMeshField<double>();
+GTEST_TEST(VolumeMeshFieldTest, TestVolumeMeshFieldLinearDouble) {
+  auto volume_mesh_field = TestVolumeMeshFieldLinear<double>();
 }
 
 // Smoke tests using `AutoDiffXd` as the underlying scalar type. The purpose
 // of this test is simply to check that it compiles. There are no tests of
 // differentiation.
-GTEST_TEST(VolumeMeshFieldTest, TestVolumeMeshFieldAutoDiffXd) {
-  auto volume_mesh_field = TestVolumeMeshField<AutoDiffXd>();
+GTEST_TEST(VolumeMeshFieldTest, TestVolumeMeshFieldLinearAutoDiffXd) {
+  auto volume_mesh_field = TestVolumeMeshFieldLinear<AutoDiffXd>();
 }
 
-template <typename T>
-std::unique_ptr<VolumeMeshFieldLinear<T, T>> TestVolumeMeshField() {
-  auto volume_mesh = TestVolumeMesh<T>();
-
-  // We give names to the values at vertices for testing later.
-  const T p0{1.};
-  const T p1{2.};
-  const T p2{3.};
-  const T p3{4.};
-  const T p4{5.};
-  std::vector<T> p_values = {p0, p1, p2, p3, p4};
-
-  auto volume_mesh_field = std::make_unique<VolumeMeshFieldLinear<T, T>>(
-      "pressure", std::move(p_values), volume_mesh.get());
-
-  // Tests evaluation of the field on the element e0 {v0, v1, v2, v3}.
-  const VolumeElementIndex e0(0);
-  const typename VolumeMesh<T>::Barycentric b{0.4, 0.3, 0.2, 0.1};
-  const T expect_p = b(0) * p0 + b(1) * p1 + b(2) * p2 + b(3) * p3;
-  EXPECT_EQ(expect_p, volume_mesh_field->Evaluate(e0, b));
-
-  return volume_mesh_field;
-}
-
+}  // namespace
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/proximity/volume_mesh.h
+++ b/geometry/proximity/volume_mesh.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <limits>
 #include <utility>
 #include <vector>
 
@@ -103,6 +104,10 @@ class VolumeElement {
   std::array<VolumeVertexIndex, 4> vertex_;
 };
 
+// Forward declaration of VolumeMeshTester<T>. VolumeMesh<T> will grant
+// friend access to VolumeMeshTester<T>.
+template <typename T> class VolumeMeshTester;
+
 /** %VolumeMesh represents a tetrahedral volume mesh.
  @tparam T  The underlying scalar type for coordinates, e.g., double or
             AutoDiffXd. Must be a valid Eigen scalar.
@@ -122,7 +127,18 @@ class VolumeMesh {
    */
   //@{
 
+  using ScalarType = T;
+
+  // TODO(DamrongGuoy): Remove kDim and replace its usage like (kDim + 1) by
+  //  kVertexPerElement in mesh_to_vtk, mesh_field_linear, and
+  //  bounding_volume_hierarchy. Issue #12756.
+
   static constexpr int kDim = 3;
+
+  /**
+   Number of vertices per element. A tetrahedron has 4 vertices.
+   */
+  static constexpr int kVertexPerElement = 4;
 
   /** Index for identifying a vertex.
    */
@@ -243,12 +259,152 @@ class VolumeMesh {
     return b_Q;
   }
 
+  /** Checks to see whether the given VolumeMesh object is equal via deep
+   exact comparison. NaNs are treated as not equal as per the IEEE standard.
+   @param mesh The mesh for comparison.
+   @returns `true` if the given mesh is equal.
+   */
+  bool Equal(const VolumeMesh<T>& mesh) const {
+    if (this == &mesh) return true;
+
+    if (this->num_elements() != mesh.num_elements()) return false;
+    if (this->num_vertices() != mesh.num_vertices()) return false;
+
+    // Check tetrahedral elements.
+    for (VolumeElementIndex i(0); i < this->num_elements(); ++i) {
+      const VolumeElement& element1 = this->element(i);
+      const VolumeElement& element2 = mesh.element(i);
+      for (int j = 0; j < 4; ++j)
+        if (element1.vertex(j) != element2.vertex(j)) return false;
+    }
+    // Check vertices.
+    for (VolumeVertexIndex i(0); i < this->num_vertices(); ++i) {
+      if (this->vertex(i).r_MV() != mesh.vertex(i).r_MV()) return false;
+    }
+
+    // All checks passed.
+    return true;
+  }
+
+  /** Calculates the gradient ∇u of a linear field u on the tetrahedron `e`.
+   Field u is defined by the four field values `field_value[i]` at the i-th
+   vertex of the tetrahedron. The gradient ∇u is expressed in the coordinates
+   frame of this mesh M.
+   */
+  template <typename FieldValue>
+  Vector3<FieldValue> CalcGradientVectorOfLinearField(
+      const std::array<FieldValue, 4>& field_value,
+      VolumeElementIndex e) const {
+    Vector3<FieldValue> gradu_M = field_value[0] * CalcGradBarycentric(e, 0);
+    for (int i = 1; i < 4; ++i) {
+      gradu_M += field_value[i] * CalcGradBarycentric(e, i);
+    }
+    return gradu_M;
+  }
+
  private:
+  // Calculates the gradient vector ∇bᵢ of the barycentric coordinate
+  // function bᵢ of the i-th vertex of the tetrahedron `e`. The gradient
+  // vector ∇bᵢ is expressed in the coordinates frame of this mesh M.
+  // @pre  0 ≤ i < 4.
+  Vector3<T> CalcGradBarycentric(VolumeElementIndex e, int i) const;
+
   // The tetrahedral elements that comprise the volume.
   std::vector<VolumeElement> elements_;
   // The vertices that are shared between the tetrahedral elements.
   std::vector<VolumeVertex<T>> vertices_;
+
+  friend class VolumeMeshTester<T>;
 };
+
+template <typename T>
+Vector3<T> VolumeMesh<T>::CalcGradBarycentric(VolumeElementIndex e,
+                                              int i) const {
+  DRAKE_DEMAND(0 <= i && i < 4);
+  // Vertex V corresponds to bᵢ in the barycentric coordinate in the
+  // tetrahedron indexed by `e`.  A, B, and C are the remaining vertices of
+  // the tetrahedron. Their positions are expressed in frame M of the mesh.
+  const Vector3<T>& p_MV = vertices_[elements_[e].vertex(i)].r_MV();
+  const Vector3<T>& p_MA = vertices_[elements_[e].vertex((i + 1) % 4)].r_MV();
+  const Vector3<T>& p_MB = vertices_[elements_[e].vertex((i + 2) % 4)].r_MV();
+  const Vector3<T>& p_MC = vertices_[elements_[e].vertex((i + 3) % 4)].r_MV();
+
+  const Vector3<T> p_AV_M = p_MV - p_MA;
+  const Vector3<T> p_AB_M = p_MB - p_MA;
+  const Vector3<T> p_AC_M = p_MC - p_MA;
+
+  // Let bᵥ be the barycentric coordinate function corresponding to vertex V.
+  // bᵥ is a linear function of the points in the tetrahedron.
+  // bᵥ = 0 on the plane through triangle ABC.
+  // bᵥ = 1 on the plane through V parallel to ABC.
+  // Therefore, bᵥ changes fastest in the direction of the face normal vector
+  // of ABC towards V. The rate of change is 1/h, where h is the
+  // height of vertex V from the base ABC.
+  //
+  //    ──────────────V────────────── plane bᵥ = 1
+  //                 ╱ ╲       ┊
+  //                ╱   ╲      ┊         Triangle ABC is perpendicular to
+  //               ╱     ╲     ┊ h       this view, so ABC looks like a line
+  //              ╱       ╲    ┊         segment instead of a triangle.
+  //             ╱    ↑∇bᵥ ╲   ┊
+  //    ────────A━━━B━━━━━━━C──────── plane bᵥ = 0
+  //
+  // We conclude that ∇bᵥ is the vector of length 1/h that is perpendicular to
+  // ABC and points into the tetrahedron.
+  //
+  // To calculate ∇bᵥ, consider the scalar triple product (AB x AC)⋅AV, which
+  // is the signed volume of the parallelepiped spanned by AB, AC, and AV, and
+  // consider the cross product AB x AC, which is the area vector of the
+  // parallelogram spanned by AB and AC. We have:
+  //
+  //       ∇bᵥ = normal vector inversely proportional to height
+  //           = area vector / signed volume
+  //           = (AB x AC) / ((AB x AC)⋅AV)
+  //
+  // Consider a non-degenerate tetrahedron (tetrahedron with volume well above
+  // zero) with vertices V₀,V₁,V₂,V₃ (note that vertex Vᵢ is the local
+  // iᵗʰ vertex of the tetrahedron, *not* the global iᵗʰ vertex of the whole
+  // mesh). Assume V₀,V₁,V₂,V₃ is in positive orientation, i.e.,
+  // (V₁ - V₀)x(V₂ - V₀) points towards V₃. Given the vertex V = Vᵢ,
+  // i ∈ {0,1,2,3}, the vertices A = Vᵢ₊₁, B = Vᵢ₊₂, C = Vᵢ₊₃ form the vector
+  // AB x AC that points from ABC towards V when i is 1 or 3, and
+  // AB x AC points away from V when i is 0 or 2. When AB x AC points towards
+  // V, the signed volume (AB x AC)⋅AV is positive, and when AB x AC points
+  // away from V, the signed volume is negative. As a result, the vector
+  // ∇bᵥ = (AB x AC) / ((AB x AC)⋅AV) always points from ABC towards V as
+  // expected.
+  //
+  // If the tetrahedron is degenerate (tetrahedron with almost zero volume),
+  // the calculation (AB x AC) / ((AB x AC)⋅AV) is not numerically reliable any
+  // more due to rounding errors. Near-zero-area triangle ABC may have the
+  // area-vector calculation AB x AC pointing in the wrong direction. If ABC is
+  // well formed but V is almost co-planar with ABC (V is near a vertex of ABC,
+  // near the spanning line of an edge of ABC, or anywhere on the spanning plane
+  // of ABC), the signed volume calculation ((AB x AC)⋅AV) may become a
+  // near-zero number with the wrong sign. In these degenerate cases, we
+  // throw std::runtime_error.
+  //
+  const Vector3<T> area_vector_M = p_AB_M.cross(p_AC_M);  // AB x AC
+  const T signed_volume = area_vector_M.dot(p_AV_M);      // (AB x AC)⋅AV
+
+  constexpr double kEps = std::numeric_limits<double>::epsilon();
+
+  // TODO(DamrongGuoy): Find a better way to handle degeneracy. Right now we
+  //  check the volume of the parallelepiped against the threshold equal the
+  //  machine epsilon. We might want to scale the threshold with the
+  //  dimensions (length, area) of the parts of the tetrahedron (6 edges, 4
+  //  triangles). Furthermore, we might also want case analysis for various
+  //  kinds of degenerate tetrahedra; for example, a tetrahedron with
+  //  one or more near-zero-length edges, a tetrahedron with one or more
+  //  near-zero-area obtuse triangles without near-zero-length edges,
+  //  or a tetrahedron with near-zero volume without near-zero-area triangles.
+
+  using std::abs;
+  if (abs(signed_volume) <= kEps) {
+    throw std::runtime_error("Bad tetrahedron. Cannot compute gradient.");
+  }
+  return area_vector_M / signed_volume;
+}
 
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
     class VolumeMesh)

--- a/geometry/proximity/volume_mesh_field.cc
+++ b/geometry/proximity/volume_mesh_field.cc
@@ -1,7 +1,0 @@
-#include "drake/geometry/proximity/volume_mesh_field.h"
-
-namespace drake {
-namespace geometry {
-
-}  // namespace geometry
-}  // namespace drake


### PR DESCRIPTION
Resolve issue #12441 "Hydroelastic contact surface broken for thin rigid object -- needs to use normals".

The size of this PR is much larger than originally expected. To keep it manageable, another PR will have the code for a new scene_graph example that shows the soft ball touching the thin plate and bowl. This PR only has the code and the doxygen doc to support that scene_graph example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12730)
<!-- Reviewable:end -->
