### PR TITLE
quadrotor: Split plant unit test into its own file

### DIFF
--- a/examples/quadrotor/BUILD.bazel
+++ b/examples/quadrotor/BUILD.bazel
@@ -91,6 +91,14 @@ drake_cc_binary(
 )
 
 drake_cc_googletest(
+    name = "quadrotor_plant_test",
+    deps = [
+        ":quadrotor_plant",
+        "//systems/framework/test_utilities",
+    ],
+)
+
+drake_cc_googletest(
     name = "quadrotor_dynamics_test",
     data = [":models"],
     deps = [
@@ -102,7 +110,6 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//systems/analysis:simulator",
         "//systems/framework:diagram",
-        "//systems/framework/test_utilities",
         "//systems/primitives:constant_vector_source",
     ],
 )

--- a/examples/quadrotor/test/quadrotor_dynamics_test.cc
+++ b/examples/quadrotor/test/quadrotor_dynamics_test.cc
@@ -11,7 +11,6 @@
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram.h"
 #include "drake/systems/framework/diagram_builder.h"
-#include "drake/systems/framework/test_utilities/scalar_conversion.h"
 #include "drake/systems/primitives/constant_vector_source.h"
 
 // The following sequence of tests compares the behaviour of two kinds of
@@ -21,11 +20,6 @@ namespace drake {
 namespace examples {
 namespace quadrotor {
 namespace {
-
-GTEST_TEST(QuadrotorPlantTest, DirectFeedthrough) {
-  QuadrotorPlant<double> quadrotor;
-  EXPECT_FALSE(quadrotor.HasAnyDirectFeedthrough());
-}
 
 // The models are integrated and compared for the duration specified by the
 // following constant.
@@ -223,16 +217,6 @@ TEST_F(QuadrotorTest, drop_from_arbitrary_state) {
   VectorX<double> x0 = VectorX<double>::Zero(12);
   x0 << 1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6;  // Some initial state.
   PassiveBehaviorTest(x0);
-}
-
-TEST_F(QuadrotorTest, ToAutoDiff) {
-  const QuadrotorPlant<double> plant;
-  EXPECT_TRUE(is_autodiffxd_convertible(plant));
-}
-
-TEST_F(QuadrotorTest, ToSymbolic) {
-  const QuadrotorPlant<double> plant;
-  EXPECT_FALSE(is_symbolic_convertible(plant));
 }
 
 }  // namespace

--- a/examples/quadrotor/test/quadrotor_plant_test.cc
+++ b/examples/quadrotor/test/quadrotor_plant_test.cc
@@ -1,0 +1,30 @@
+#include "drake/examples/quadrotor/quadrotor_plant.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/systems/framework/test_utilities/scalar_conversion.h"
+
+namespace drake {
+namespace examples {
+namespace quadrotor {
+namespace {
+
+GTEST_TEST(QuadrotorPlantTest, DirectFeedthrough) {
+  const QuadrotorPlant<double> plant;
+  EXPECT_FALSE(plant.HasAnyDirectFeedthrough());
+}
+
+GTEST_TEST(QuadrotorPlantTest, ToAutoDiff) {
+  const QuadrotorPlant<double> plant;
+  EXPECT_TRUE(is_autodiffxd_convertible(plant));
+}
+
+GTEST_TEST(QuadrotorPlantTest, ToSymbolic) {
+  const QuadrotorPlant<double> plant;
+  EXPECT_FALSE(is_symbolic_convertible(plant));
+}
+
+}  // namespace
+}  // namespace quadrotor
+}  // namespace examples
+}  // namespace drake


### PR DESCRIPTION
For clarity, we should not mix unit tests with acceptance tests.

Split out from #12726.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12731)
<!-- Reviewable:end -->
