### PR TITLE
Re-order geometry/proximity/BUILD

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -58,19 +58,6 @@ drake_cc_library(
 )
 
 drake_cc_library(
-    name = "find_collision_candidates_callback",
-    srcs = ["find_collision_candidates_callback.cc"],
-    hdrs = ["find_collision_candidates_callback.h"],
-    deps = [
-        ":collision_filter_legacy",
-        ":proximity_utilities",
-        "//common:sorted_pair",
-        "@fcl",
-        "@fmt",
-    ],
-)
-
-drake_cc_library(
     name = "collision_filter_legacy",
     hdrs = ["collision_filter_legacy.h"],
     deps = [
@@ -130,6 +117,19 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "find_collision_candidates_callback",
+    srcs = ["find_collision_candidates_callback.cc"],
+    hdrs = ["find_collision_candidates_callback.h"],
+    deps = [
+        ":collision_filter_legacy",
+        ":proximity_utilities",
+        "//common:sorted_pair",
+        "@fcl",
+        "@fmt",
+    ],
+)
+
+drake_cc_library(
     name = "hydroelastic_callback",
     hdrs = [
         "hydroelastic_callback.h",
@@ -179,6 +179,97 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "make_box_field",
+    hdrs = ["make_box_field.h"],
+    deps = [
+        ":distance_to_point_callback",
+        ":volume_mesh",
+        "//common:essential",
+        "//common:unused",
+        "//geometry:shape_specification",
+    ],
+)
+
+drake_cc_library(
+    name = "make_box_mesh",
+    hdrs = ["make_box_mesh.h"],
+    deps = [
+        ":surface_mesh",
+        ":volume_mesh",
+        ":volume_to_surface_mesh",
+        "//geometry:shape_specification",
+    ],
+)
+
+drake_cc_library(
+    name = "make_cylinder_field",
+    hdrs = ["make_cylinder_field.h"],
+    deps = [
+        ":distance_to_point_callback",
+        ":volume_mesh",
+        "//common:essential",
+        "//common:unused",
+        "//geometry:shape_specification",
+    ],
+)
+
+drake_cc_library(
+    name = "make_cylinder_mesh",
+    hdrs = ["make_cylinder_mesh.h"],
+    deps = [
+        ":surface_mesh",
+        ":volume_mesh",
+        ":volume_to_surface_mesh",
+        "//common:essential",
+        "//geometry:shape_specification",
+    ],
+)
+
+drake_cc_library(
+    name = "make_ellipsoid_field",
+    hdrs = ["make_ellipsoid_field.h"],
+    deps = [
+        ":volume_mesh",
+        "//common:essential",
+        "//geometry:shape_specification",
+    ],
+)
+
+drake_cc_library(
+    name = "make_ellipsoid_mesh",
+    hdrs = ["make_ellipsoid_mesh.h"],
+    deps = [
+        ":make_sphere_mesh",
+        ":surface_mesh",
+        ":volume_mesh",
+        ":volume_to_surface_mesh",
+        "//geometry:shape_specification",
+    ],
+)
+
+drake_cc_library(
+    name = "make_sphere_field",
+    hdrs = ["make_sphere_field.h"],
+    deps = [
+        ":volume_mesh",
+        "//common:essential",
+        "//geometry:shape_specification",
+    ],
+)
+
+drake_cc_library(
+    name = "make_sphere_mesh",
+    hdrs = ["make_sphere_mesh.h"],
+    deps = [
+        ":surface_mesh",
+        ":volume_mesh",
+        ":volume_to_surface_mesh",
+        "//common:essential",
+        "//geometry:shape_specification",
+    ],
+)
+
+drake_cc_library(
     name = "mesh_field",
     srcs = [
         "mesh_field.cc",
@@ -203,6 +294,45 @@ drake_cc_library(
         ":mesh_intersection",
         ":surface_mesh",
         "//common",
+    ],
+)
+
+drake_cc_library(
+    name = "mesh_intersection",
+    srcs = ["mesh_intersection.cc"],
+    hdrs = ["mesh_intersection.h"],
+    deps = [
+        "//common",
+        "//geometry/proximity:bounding_volume_hierarchy",
+        "//geometry/proximity:mesh_field",
+        "//geometry/proximity:surface_mesh",
+        "//geometry/proximity:volume_mesh",
+        "//geometry/query_results:contact_surface",
+        "//math:geometric_transform",
+    ],
+)
+
+drake_cc_library(
+    name = "mesh_to_vtk",
+    srcs = ["mesh_to_vtk.cc"],
+    hdrs = ["mesh_to_vtk.h"],
+    deps = [
+        ":mesh_field",
+        ":surface_mesh",
+        ":volume_mesh",
+        "@fmt",
+    ],
+)
+
+drake_cc_library(
+    name = "obj_to_surface_mesh",
+    srcs = ["obj_to_surface_mesh.cc"],
+    hdrs = ["obj_to_surface_mesh.h"],
+    deps = [
+        ":surface_mesh",
+        "//common:essential",
+        "@fmt",
+        "@tinyobjloader",
     ],
 )
 
@@ -232,124 +362,6 @@ drake_cc_library(
 )
 
 drake_cc_library(
-    name = "make_box_mesh",
-    hdrs = ["make_box_mesh.h"],
-    deps = [
-        ":surface_mesh",
-        ":volume_mesh",
-        ":volume_to_surface_mesh",
-        "//geometry:shape_specification",
-    ],
-)
-
-drake_cc_library(
-    name = "make_sphere_mesh",
-    hdrs = ["make_sphere_mesh.h"],
-    deps = [
-        ":surface_mesh",
-        ":volume_mesh",
-        ":volume_to_surface_mesh",
-        "//common:essential",
-        "//geometry:shape_specification",
-    ],
-)
-
-drake_cc_library(
-    name = "make_cylinder_mesh",
-    hdrs = ["make_cylinder_mesh.h"],
-    deps = [
-        ":surface_mesh",
-        ":volume_mesh",
-        ":volume_to_surface_mesh",
-        "//common:essential",
-        "//geometry:shape_specification",
-    ],
-)
-
-drake_cc_library(
-    name = "make_ellipsoid_mesh",
-    hdrs = ["make_ellipsoid_mesh.h"],
-    deps = [
-        ":make_sphere_mesh",
-        ":surface_mesh",
-        ":volume_mesh",
-        ":volume_to_surface_mesh",
-        "//geometry:shape_specification",
-    ],
-)
-
-drake_cc_library(
-    name = "make_box_field",
-    hdrs = ["make_box_field.h"],
-    deps = [
-        ":distance_to_point_callback",
-        ":volume_mesh",
-        "//common:essential",
-        "//common:unused",
-        "//geometry:shape_specification",
-    ],
-)
-
-drake_cc_library(
-    name = "make_cylinder_field",
-    hdrs = ["make_cylinder_field.h"],
-    deps = [
-        ":distance_to_point_callback",
-        ":volume_mesh",
-        "//common:essential",
-        "//common:unused",
-        "//geometry:shape_specification",
-    ],
-)
-
-drake_cc_library(
-    name = "make_ellipsoid_field",
-    hdrs = ["make_ellipsoid_field.h"],
-    deps = [
-        ":volume_mesh",
-        "//common:essential",
-        "//geometry:shape_specification",
-    ],
-)
-
-drake_cc_library(
-    name = "make_sphere_field",
-    hdrs = ["make_sphere_field.h"],
-    deps = [
-        ":volume_mesh",
-        "//common:essential",
-        "//geometry:shape_specification",
-    ],
-)
-
-drake_cc_library(
-    name = "mesh_intersection",
-    srcs = ["mesh_intersection.cc"],
-    hdrs = ["mesh_intersection.h"],
-    deps = [
-        "//common",
-        "//geometry/proximity:bounding_volume_hierarchy",
-        "//geometry/proximity:mesh_field",
-        "//geometry/proximity:surface_mesh",
-        "//geometry/proximity:volume_mesh",
-        "//geometry/query_results:contact_surface",
-        "//math:geometric_transform",
-    ],
-)
-
-drake_cc_library(
-    name = "obj_to_surface_mesh",
-    srcs = ["obj_to_surface_mesh.cc"],
-    hdrs = ["obj_to_surface_mesh.h"],
-    deps = [
-        ":surface_mesh",
-        "//common:essential",
-        "@fmt",
-        "@tinyobjloader",
-    ],
-)
-
-drake_cc_library(
     name = "sorted_triplet",
     srcs = ["sorted_triplet.cc"],
     hdrs = ["sorted_triplet.h"],
@@ -361,12 +373,8 @@ drake_cc_library(
 
 drake_cc_library(
     name = "surface_mesh",
-    srcs = [
-        "surface_mesh.cc",
-    ],
-    hdrs = [
-        "surface_mesh.h",
-    ],
+    srcs = ["surface_mesh.cc"],
+    hdrs = ["surface_mesh.h"],
     deps = [
         "//common",
         "//math:geometric_transform",
@@ -406,18 +414,6 @@ drake_cc_library(
     ],
 )
 
-drake_cc_library(
-    name = "mesh_to_vtk",
-    srcs = ["mesh_to_vtk.cc"],
-    hdrs = ["mesh_to_vtk.h"],
-    deps = [
-        ":mesh_field",
-        ":surface_mesh",
-        ":volume_mesh",
-        "@fmt",
-    ],
-)
-
 drake_cc_googletest(
     name = "bounding_volume_hierarchy_test",
     deps = [
@@ -439,18 +435,22 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
-    name = "find_collision_candidates_callback_test",
-    deps = [
-        ":find_collision_candidates_callback",
-    ],
-)
-
-drake_cc_googletest(
     name = "contact_surface_test",
     deps = [
         "//common/test_utilities:eigen_matrix_compare",
         "//geometry:geometry_ids",
         "//geometry/query_results:contact_surface",
+    ],
+)
+
+drake_cc_googletest(
+    name = "distance_sphere_to_shape_test",
+    deps = [
+        ":distance_to_shape_callback",
+        "//common/test_utilities",
+        "//geometry:geometry_ids",
+        "//geometry:utilities",
+        "//math:gradient",
     ],
 )
 
@@ -473,13 +473,17 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
-    name = "distance_sphere_to_shape_test",
+    name = "find_collision_candidates_callback_test",
     deps = [
-        ":distance_to_shape_callback",
+        ":find_collision_candidates_callback",
+    ],
+)
+
+drake_cc_googletest(
+    name = "hydroelastic_callback_test",
+    deps = [
+        ":hydroelastic_callback",
         "//common/test_utilities",
-        "//geometry:geometry_ids",
-        "//geometry:utilities",
-        "//math:gradient",
     ],
 )
 
@@ -500,48 +504,11 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
-    name = "hydroelastic_callback_test",
+    name = "make_box_field_test",
     deps = [
-        ":hydroelastic_callback",
-        "//common/test_utilities",
-    ],
-)
-
-drake_cc_googletest(
-    name = "surface_mesh_test",
-    deps = [
-        "//common/test_utilities:eigen_matrix_compare",
-        "//geometry/proximity:surface_mesh",
-        "//math:geometric_transform",
-    ],
-)
-
-drake_cc_googletest(
-    name = "volume_mesh_test",
-    deps = [
-        "//geometry/proximity:volume_mesh",
-        "//math:geometric_transform",
-    ],
-)
-
-drake_cc_googletest(
-    name = "mesh_field_test",
-    deps = [
-        "//geometry/proximity:mesh_field",
-    ],
-)
-
-drake_cc_googletest(
-    name = "mesh_field_linear_test",
-    deps = [
-        "//geometry/proximity:mesh_field",
-    ],
-)
-
-drake_cc_googletest(
-    name = "mesh_half_space_intersection_test",
-    deps = [
-        ":mesh_half_space_intersection",
+        ":make_box_field",
+        ":make_box_mesh",
+        ":volume_to_surface_mesh",
     ],
 )
 
@@ -554,11 +521,11 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
-    name = "make_sphere_mesh_test",
+    name = "make_cylinder_field_test",
     deps = [
-        ":make_sphere_mesh",
-        "//common:sorted_pair",
-        "//common/test_utilities:eigen_matrix_compare",
+        ":make_cylinder_field",
+        ":make_cylinder_mesh",
+        ":volume_to_surface_mesh",
     ],
 )
 
@@ -575,36 +542,18 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
-    name = "make_ellipsoid_mesh_test",
-    deps = [
-        ":make_ellipsoid_mesh",
-    ],
-)
-
-drake_cc_googletest(
-    name = "make_box_field_test",
-    deps = [
-        ":make_box_field",
-        ":make_box_mesh",
-        ":volume_to_surface_mesh",
-    ],
-)
-
-drake_cc_googletest(
-    name = "make_cylinder_field_test",
-    deps = [
-        ":make_cylinder_field",
-        ":make_cylinder_mesh",
-        ":volume_to_surface_mesh",
-    ],
-)
-
-drake_cc_googletest(
     name = "make_ellipsoid_field_test",
     deps = [
         ":make_ellipsoid_field",
         ":make_ellipsoid_mesh",
         ":volume_to_surface_mesh",
+    ],
+)
+
+drake_cc_googletest(
+    name = "make_ellipsoid_mesh_test",
+    deps = [
+        ":make_ellipsoid_mesh",
     ],
 )
 
@@ -618,11 +567,54 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "make_sphere_mesh_test",
+    deps = [
+        ":make_sphere_mesh",
+        "//common:sorted_pair",
+        "//common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "mesh_field_linear_test",
+    deps = [
+        "//geometry/proximity:mesh_field",
+    ],
+)
+
+drake_cc_googletest(
+    name = "mesh_field_test",
+    deps = [
+        "//geometry/proximity:mesh_field",
+    ],
+)
+
+drake_cc_googletest(
+    name = "mesh_half_space_intersection_test",
+    deps = [
+        ":mesh_half_space_intersection",
+    ],
+)
+
+drake_cc_googletest(
     name = "mesh_intersection_test",
     deps = [
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
         "//geometry/proximity:mesh_intersection",
+    ],
+)
+
+drake_cc_googletest(
+    name = "mesh_to_vtk_test",
+    deps = [
+        ":make_box_field",
+        ":make_box_mesh",
+        ":mesh_intersection",
+        ":mesh_to_vtk",
+        "//common:temp_directory",
+        "//geometry:shape_specification",
+        "//math:geometric_transform",
     ],
 )
 
@@ -659,23 +651,27 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
-    name = "volume_to_surface_mesh_test",
+    name = "surface_mesh_test",
     deps = [
-        ":make_box_mesh",
-        ":volume_to_surface_mesh",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//geometry/proximity:surface_mesh",
+        "//math:geometric_transform",
     ],
 )
 
 drake_cc_googletest(
-    name = "mesh_to_vtk_test",
+    name = "volume_mesh_test",
     deps = [
-        ":make_box_field",
-        ":make_box_mesh",
-        ":mesh_intersection",
-        ":mesh_to_vtk",
-        "//common:temp_directory",
-        "//geometry:shape_specification",
+        "//geometry/proximity:volume_mesh",
         "//math:geometric_transform",
+    ],
+)
+
+drake_cc_googletest(
+    name = "volume_to_surface_mesh_test",
+    deps = [
+        ":make_box_mesh",
+        ":volume_to_surface_mesh",
     ],
 )
 


### PR DESCRIPTION
This alphabetizes the build targets (libraries first, tests second). It had fallen out of order incurring technical debt for every additional target.

There are no functional changes -- just formatting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12748)
<!-- Reviewable:end -->
