### PR TITLE
Add plane-BVH intersection

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -36,6 +36,7 @@ drake_cc_package_library(
         ":mesh_to_vtk",
         ":obj_to_surface_mesh",
         ":penetration_as_point_pair_callback",
+        ":plane",
         ":proximity_utilities",
         ":sorted_triplet",
         ":surface_mesh",
@@ -49,9 +50,11 @@ drake_cc_library(
     srcs = ["bounding_volume_hierarchy.cc"],
     hdrs = ["bounding_volume_hierarchy.h"],
     deps = [
+        ":plane",
         ":surface_mesh",
         ":volume_mesh",
         "//common",
+        "//geometry:shape_specification",
         "//geometry:utilities",
         "//math:geometric_transform",
     ],
@@ -280,8 +283,8 @@ drake_cc_library(
         "mesh_field_linear.h",
     ],
     deps = [
+        ":surface_mesh",
         "//common",
-        "//geometry/proximity:surface_mesh",
     ],
 )
 
@@ -302,11 +305,12 @@ drake_cc_library(
     srcs = ["mesh_intersection.cc"],
     hdrs = ["mesh_intersection.h"],
     deps = [
+        ":bounding_volume_hierarchy",
+        ":mesh_field",
+        ":plane",
+        ":surface_mesh",
+        ":volume_mesh",
         "//common",
-        "//geometry/proximity:bounding_volume_hierarchy",
-        "//geometry/proximity:mesh_field",
-        "//geometry/proximity:surface_mesh",
-        "//geometry/proximity:volume_mesh",
         "//geometry/query_results:contact_surface",
         "//math:geometric_transform",
     ],
@@ -345,6 +349,14 @@ drake_cc_library(
         ":proximity_utilities",
         "//geometry/query_results:penetration_as_point_pair",
         "@fcl",
+    ],
+)
+
+drake_cc_library(
+    name = "plane",
+    hdrs = ["plane.h"],
+    deps = [
+        "//common:essential",
     ],
 )
 
@@ -392,9 +404,9 @@ drake_cc_library(
         "volume_mesh_field.h",
     ],
     deps = [
+        ":mesh_field",
         "//common",
         "//geometry:geometry_ids",
-        "//geometry/proximity:mesh_field",
     ],
 )
 
@@ -407,10 +419,10 @@ drake_cc_library(
         "volume_to_surface_mesh.h",
     ],
     deps = [
+        ":sorted_triplet",
+        ":surface_mesh",
+        ":volume_mesh",
         "//common",
-        "//geometry/proximity:sorted_triplet",
-        "//geometry/proximity:surface_mesh",
-        "//geometry/proximity:volume_mesh",
     ],
 )
 
@@ -578,14 +590,14 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "mesh_field_linear_test",
     deps = [
-        "//geometry/proximity:mesh_field",
+        ":mesh_field",
     ],
 )
 
 drake_cc_googletest(
     name = "mesh_field_test",
     deps = [
-        "//geometry/proximity:mesh_field",
+        ":mesh_field",
     ],
 )
 
@@ -599,9 +611,9 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "mesh_intersection_test",
     deps = [
+        ":mesh_intersection",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
-        "//geometry/proximity:mesh_intersection",
     ],
 )
 
@@ -653,8 +665,8 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "surface_mesh_test",
     deps = [
+        ":surface_mesh",
         "//common/test_utilities:eigen_matrix_compare",
-        "//geometry/proximity:surface_mesh",
         "//math:geometric_transform",
     ],
 )
@@ -662,7 +674,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "volume_mesh_test",
     deps = [
-        "//geometry/proximity:volume_mesh",
+        ":volume_mesh",
         "//math:geometric_transform",
     ],
 )

--- a/geometry/proximity/mesh_intersection.h
+++ b/geometry/proximity/mesh_intersection.h
@@ -11,6 +11,7 @@
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/proximity/bounding_volume_hierarchy.h"
 #include "drake/geometry/proximity/mesh_field_linear.h"
+#include "drake/geometry/proximity/plane.h"
 #include "drake/geometry/proximity/surface_mesh.h"
 #include "drake/geometry/proximity/volume_mesh.h"
 #include "drake/geometry/proximity/volume_mesh_field.h"
@@ -43,65 +44,6 @@ namespace internal {
 //  outside another tetrahedron. Right now it will be considered inside both
 //  tetrahedrons.
 
-/** Definition of a half space. It is defined by the implicit equation
- `H(x⃗) = n̂⋅x⃗ - d <= 0`. A particular instance is defined by a boundary plane in
- a particular frame F with its normal pointing out of the half space such that
- `H(p_QF) > 0` if the point Q (measured and expressed in F) is outside the
- half space.
- */
-template <typename T>
-class Plane {
- public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Plane)
-
-  /** Constructs a Plane in frame F.
-   @param nhat_F
-       A unit-length vector perpendicular to the half space's planar boundary
-       expressed in frame F (the `n̂` in the implicit equation).
-   @param displacement
-       The signed distance from F's origin to the half space boundary (the `d`
-       term in the implicit equation).
-   @pre
-       ‖nhat_F‖₂ = 1.
-   */
-  Plane(const Vector3<T>& nhat_F, const T& displacement)
-      : nhat_F_(nhat_F), displacement_(displacement) {
-    using std::abs;
-    // Note: This may *seem* like a very tight threshold for determining if a
-    // vector is unit length. However, empirical evidence suggests that in
-    // double precision, normalizing a vector generally makes a vector whose
-    // evaluated magnitude is within epsilon of one. There may be some
-    // unconsidered value that disproves this -- at that point, adapt the
-    // tolerance here and add it to the unit test.
-    DRAKE_THROW_UNLESS(abs(nhat_F_.norm() - 1.0) <=
-                       std::numeric_limits<double>::epsilon());
-  }
-
-  /** Computes the signed distance to the point Q (measured and expressed in
-   frame F). The point is strictly inside, on the boundary, or outside based on
-   the return value being negative, zero, or positive, respectively.
-   */
-  T CalcSignedDistance(const Vector3<T>& p_FQ) const {
-    return nhat_F_.dot(p_FQ) - displacement_;
-  }
-
-  /** Reports true if the point Q (measured and expressed in frame F),
-   strictly lies outside this half space.
-   */
-  bool PointIsOutside(const Vector3<T>& p_FQ) const {
-    return CalcSignedDistance(p_FQ) > 0;
-  }
-
-  /** Gets the normal expressed in frame F. */
-  const Vector3<T> nhat_F() const { return nhat_F_; }
-
-  /** Gets the displacement constant. */
-  const T& displacement() const { return displacement_; }
-
- private:
-  Vector3<T> nhat_F_;
-  T displacement_{};
-};
 
 // TODO(DamrongGuoy): Handle the case that the line is parallel to the plane.
 /** Calculates the intersection point between an infinite straight line spanning

--- a/geometry/proximity/plane.h
+++ b/geometry/proximity/plane.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <limits>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/drake_throw.h"
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+/** Definition of a half space. It is defined by the implicit equation
+ `H(x⃗) = n̂⋅x⃗ - d <= 0`. A particular instance is defined by a boundary plane in
+ a particular frame F with its normal pointing out of the half space such that
+ `H(p_QF) > 0` if the point Q (measured and expressed in F) is outside the
+ half space.
+ */
+template <typename T>
+class Plane {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Plane)
+
+  /** Constructs a Plane in frame F.
+   @param nhat_F
+       A unit-length vector perpendicular to the half space's planar boundary
+       expressed in frame F (the `n̂` in the implicit equation).
+   @param displacement
+       The signed distance from F's origin to the half space boundary (the `d`
+       term in the implicit equation).
+   @pre
+       ‖nhat_F‖₂ = 1.
+   */
+  Plane(const Vector3<T>& nhat_F, const T& displacement)
+      : nhat_F_(nhat_F), displacement_(displacement) {
+    using std::abs;
+    // Note: This may *seem* like a very tight threshold for determining if a
+    // vector is unit length. However, empirical evidence suggests that in
+    // double precision, normalizing a vector generally makes a vector whose
+    // evaluated magnitude is within epsilon of one. There may be some
+    // unconsidered value that disproves this -- at that point, adapt the
+    // tolerance here and add it to the unit test.
+    DRAKE_THROW_UNLESS(abs(nhat_F_.norm() - 1.0) <=
+        std::numeric_limits<double>::epsilon());
+  }
+
+  /** Computes the signed distance to the point Q (measured and expressed in
+   frame F). The point is strictly inside, on the boundary, or outside based on
+   the return value being negative, zero, or positive, respectively.
+   */
+  T CalcSignedDistance(const Vector3<T>& p_FQ) const {
+    return nhat_F_.dot(p_FQ) - displacement_;
+  }
+
+  /** Reports true if the point Q (measured and expressed in frame F),
+   strictly lies outside this half space.
+   */
+  bool PointIsOutside(const Vector3<T>& p_FQ) const {
+    return CalcSignedDistance(p_FQ) > 0;
+  }
+
+  /** Gets the normal expressed in frame F. */
+  const Vector3<T>& normal() const { return nhat_F_; }
+
+  /** Gets the displacement constant. */
+  const T& displacement() const { return displacement_; }
+
+ private:
+  Vector3<T> nhat_F_;
+  T displacement_{};
+};
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/test/bounding_volume_hierarchy_test.cc
+++ b/geometry/proximity/test/bounding_volume_hierarchy_test.cc
@@ -163,7 +163,8 @@ TEST_F(BVHTest, TestCopy) {
 
   // Confirm that it's a deep copy.
   std::function<void(const BvNode<SurfaceMesh<double>>&,
-                     const BvNode<SurfaceMesh<double>>&)> check_copy;
+                     const BvNode<SurfaceMesh<double>>&)>
+      check_copy;
   check_copy = [&check_copy](const BvNode<SurfaceMesh<double>>& orig,
                              const BvNode<SurfaceMesh<double>>& copy) {
     EXPECT_NE(&orig, &copy);
@@ -267,7 +268,7 @@ GTEST_TEST(BoundingVolumeHierarchyTest, TestComputeCentroid) {
   // The first face of our octahedron is a triangle with vertices at 1, 2, and
   // 3 along each respective axis, so its centroid should average out to 1/3,
   // 2/3, and 3/3.
-  EXPECT_TRUE(CompareMatrices(centroid, Vector3d(1./3., 2./3., 1.)));
+  EXPECT_TRUE(CompareMatrices(centroid, Vector3d(1. / 3., 2. / 3., 1.)));
 
   auto volume_mesh = MakeEllipsoidVolumeMesh<double>(Ellipsoid(1., 2., 3.), 6);
   centroid = BVHTester::ComputeCentroid<VolumeMesh<double>>(
@@ -340,8 +341,8 @@ auto calc_corner_transform = [](const Aabb& a, const Aabb& b, const int axis,
   // Construct the rotation matrix, R_AB, that has meaningful (non-zero)
   // values everywhere for the remaining 2 axes and no symmetry.
   RotationMatrixd R_AB =
-      RotationMatrixd {AngleAxisd(M_PI / 5, Vector3d::Unit(axis1))} *
-      RotationMatrixd {AngleAxisd(-M_PI / 5, Vector3d::Unit(axis2))};
+      RotationMatrixd(AngleAxisd(M_PI / 5, Vector3d::Unit(axis1))) *
+      RotationMatrixd(AngleAxisd(-M_PI / 5, Vector3d::Unit(axis2)));
   // We define p_BoBq in Frame A by taking the minimum corner and applying
   // the constructed rotation.
   Vector3d p_BoBq_A = R_AB * (b.center() - b.half_width());
@@ -396,16 +397,16 @@ auto calc_edge_transform = [](const Aabb& a, const Aabb& b, const int a_axis,
   const double theta = M_PI / 5;
   // For cases Ax × Bx, Ay × By, and Az × Bz.
   if (a_axis == b_axis) {
-    R_AB = RotationMatrixd {AngleAxisd(theta, Vector3d::Unit(b_axis1))} *
-           RotationMatrixd {AngleAxisd(theta, Vector3d::Unit(b_axis2))};
-  // For cases Ax × By, Ay × Bz, and Az × Bx.
+    R_AB = RotationMatrixd(AngleAxisd(theta, Vector3d::Unit(b_axis1))) *
+           RotationMatrixd(AngleAxisd(theta, Vector3d::Unit(b_axis2)));
+    // For cases Ax × By, Ay × Bz, and Az × Bx.
   } else if (a_axis1 == b_axis) {
-    R_AB = RotationMatrixd {AngleAxisd(theta, Vector3d::Unit(b_axis1))} *
-           RotationMatrixd {AngleAxisd(-theta, Vector3d::Unit(b_axis2))};
-  // For cases Ax × Bz, Ay × Bx, and Az × By.
+    R_AB = RotationMatrixd(AngleAxisd(theta, Vector3d::Unit(b_axis1))) *
+           RotationMatrixd(AngleAxisd(-theta, Vector3d::Unit(b_axis2)));
+    // For cases Ax × Bz, Ay × Bx, and Az × By.
   } else {
-    R_AB = RotationMatrixd {AngleAxisd(-theta, Vector3d::Unit(b_axis2))} *
-           RotationMatrixd {AngleAxisd(theta, Vector3d::Unit(b_axis1))};
+    R_AB = RotationMatrixd(AngleAxisd(-theta, Vector3d::Unit(b_axis2))) *
+           RotationMatrixd(AngleAxisd(theta, Vector3d::Unit(b_axis1)));
   }
   // We define p_BoBq in Frame B taking a point on the minimum edge aligned
   // with the given axis, offset it to be without symmetry, then convert it
@@ -522,9 +523,129 @@ GTEST_TEST(AABBTest, TestObbOverlap) {
       // Separate along a's y-axis and b's x-axis.
       EXPECT_FALSE(Aabb::HasOverlap(a, b, X_AB));
       X_AB =
-          calc_edge_transform(a, b, a_axis, b_axis, true  /* expect_overlap */);
+          calc_edge_transform(a, b, a_axis, b_axis, true /* expect_overlap */);
       // Separate along a's y-axis and b's x-axis.
       EXPECT_TRUE(Aabb::HasOverlap(a, b, X_AB));
+    }
+  }
+}
+
+// Tests Aaab-plane intersection. We have four frames:
+//
+//   B: the canonical frame the box is defined in (centered on Bo and aligned
+//      with B's axes).
+//   H: the frame in which the box B is positioned (i.e., R_HB = I, but
+//      Ho != Bo.)
+//   P: the frame the plane is defined in.
+//   Q: the frame the query is performed in.
+//
+// For simplicity, we'll define the plane with a normal in the Pz direction
+// and at Pz = 0. We'll pose the box relative to the plane (so we can easily
+// reason about whether it penetrates or not). But then express the plane in the
+// query frame Q (and the pose of B in Q).
+GTEST_TEST(AabbTest, PlaneOverlap) {
+  // The aabb is *not* defined at the origin of the hierarchy frame.
+  const Vector3d p_HoBo_H = Vector3d{0.5, 0.25, -0.75};
+  const Vector3d half_width{1, 2, 3};
+  Aabb aabb_H{p_HoBo_H, half_width};
+
+  // Use brute force to find the position of the "lowest" corner of the box
+  // measured from Ho and expressed in frame P. "Lowest" means the corner with
+  // the smallest z-component. Note: the "z-component" trick only works because
+  // we expect the plane to be Pz = 0.
+  auto lowest_corner = [&half_width, &p_HoBo_H](const RotationMatrixd& R_PH) {
+    Vector3d p_HoCmin_P =
+        Vector3d::Constant(std::numeric_limits<double>::infinity());
+    for (const double x_sign : {-1.0, 1.0}) {
+      for (const double y_sign : {-1.0, 1.0}) {
+        for (const double z_sign : {-1.0, 1.0}) {
+          const Vector3d signs{x_sign, y_sign, z_sign};
+          const Vector3d p_BoC_H = half_width.cwiseProduct(signs);
+          const Vector3d p_HoC_P = R_PH * (p_HoBo_H + p_BoC_H);
+          if (p_HoC_P(2) < p_HoCmin_P(2)) {
+            p_HoCmin_P = p_HoC_P;
+          }
+        }
+      }
+    }
+    return p_HoCmin_P;
+  };
+
+  // Test epsilon is the product of three factors:
+  //  - machine epsilon
+  //  - Two orders of magnitude attributed to the various transformations.
+  //  - A scale factor that is the maximum of (box size, p_HoBo, p_PoHo)
+  const double kEps = 300 * std::numeric_limits<double>::epsilon();
+  // An arbitrary collection of orientations for the box's hierarchy frame H
+  // in the plane frame P.
+  std::vector<AngleAxisd> R_PHs{
+      AngleAxisd{0, Vector3d::UnitX()},
+      AngleAxisd{M_PI / 2, Vector3d::UnitX()},
+      AngleAxisd{M_PI / 2, Vector3d::UnitY()},
+      AngleAxisd{M_PI / 2, Vector3d::UnitZ()},
+      AngleAxisd{M_PI / 4, Vector3d::UnitX()},
+      AngleAxisd{M_PI / 4, Vector3d::UnitY()},
+      AngleAxisd{M_PI / 7, Vector3d{1, 2, 3}.normalized()},
+      AngleAxisd{7 * M_PI / 6, Vector3d{-1, 2, -3}.normalized()},
+      AngleAxisd{12 * M_PI / 7, Vector3d{1, -2, 3}.normalized()}
+  };
+  // An arbitrary collection of poses of the plane in the query frame Q.
+  std::vector<RigidTransformd> X_QPs{
+      RigidTransformd{},  // Identity matrix.
+      RigidTransformd{
+          RotationMatrixd{AngleAxisd{M_PI / 4, Vector3d{1, 2, 3}.normalized()}},
+          Vector3d{1, 2, 3}},
+      RigidTransformd{RotationMatrixd{AngleAxisd{
+                          12 * M_PI / 7, Vector3d{-1, -1, 3}.normalized()}},
+                      Vector3d{-3, -1, 2}}
+  };
+  for (const auto& angle_axis_PH : R_PHs) {
+    const RotationMatrixd R_PH{angle_axis_PH};
+    const Vector3d p_HoCmin_P = lowest_corner(R_PH);
+    for (const auto& X_QP : X_QPs) {
+      // Define the plane in the query frame Q.
+      const Vector3d& Pz_Q = X_QP.rotation().col(2);
+      Plane<double> plane_Q{Pz_Q, Pz_Q.dot(X_QP.translation())};
+
+      // We position Ho such that Cmin lies on the Pz = 0 plane. Given we
+      // know p_HoCmin_P, we know its current z-value. To put it at zero, we
+      // must displace it in the negative of that z value. The x- and y-values
+      // don't matter, so we pick values we know not to be zero.
+      {
+        // Place the minimum corner just "above" the plane.
+        const Vector3d p_PoHo_P{Vector3d{0.5, -0.25, -p_HoCmin_P(2) + kEps}};
+        RigidTransformd X_PH{R_PH, p_PoHo_P};
+        EXPECT_FALSE(Aabb::HasOverlap(aabb_H, plane_Q, X_QP * X_PH));
+      }
+      {
+        // Place the minimum corner just "below" the plane.
+        const Vector3d p_PoHo_P{Vector3d{0.5, -0.25, -p_HoCmin_P(2) - kEps}};
+        RigidTransformd X_PH{R_PH, p_PoHo_P};
+        EXPECT_TRUE(Aabb::HasOverlap(aabb_H, plane_Q, X_QP * X_PH));
+      }
+
+      // We repeat the same task but with Cmax. Cmax is the reflection of Cmin
+      // over Bo (the origin of the box). We'll express all vectors in the P
+      // frame so we can place that corner just above and below the Pz = 0
+      // plane using the same trick as documented above.
+      const Vector3d p_HoBo_P = R_PH * p_HoBo_H;
+      const Vector3d p_HoCmax_P = p_HoCmin_P + 2 * (p_HoBo_P - p_HoCmin_P);
+      {
+        // Put the maximum corner *on* the Pz = 0 plane. The bulk of the box
+        // now extends *below* the plane; so bump it up epsilon to guarantee
+        // intersection.
+        const Vector3d p_PoHo_P{Vector3d{0.5, -0.25, -p_HoCmax_P(2) + kEps}};
+        RigidTransformd X_PH{R_PH, p_PoHo_P};
+        EXPECT_TRUE(Aabb::HasOverlap(aabb_H, plane_Q, X_QP * X_PH));
+      }
+      {
+        // Put the maximum corner *on* the Pz = 0 plane. The bulk of the box
+        // now extends *below* the plane; so bump it down epsilon to guarantee
+        // _no_ intersection.
+        const Vector3d p_PoHo_P{Vector3d{0.5, -0.25, -p_HoCmax_P(2) - kEps}};
+        RigidTransformd X_PH{R_PH, p_PoHo_P};
+        EXPECT_FALSE(Aabb::HasOverlap(aabb_H, plane_Q, X_QP * X_PH));
+      }
     }
   }
 }


### PR DESCRIPTION
This ultimately provides the support for rigid half space-soft mesh
queries. In this case, the rigid half space is simply a plane. To that end:

  1. Refactor the plane definition in mesh_intersection.h into a more general internal location.
  2. Expand Aabb and BVH functionality to support culling queries with general shapes. (This PR only includes the plane, but will be immediately followed up with HalfSpace).
  3. Unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12751)
<!-- Reviewable:end -->
