### PR TITLE
Add Error Control to Velocity-Implicit Euler Integrator, third PR of #12528

### DIFF
--- a/systems/analysis/test_utilities/implicit_integrator_test.h
+++ b/systems/analysis/test_utilities/implicit_integrator_test.h
@@ -84,8 +84,6 @@ class ImplicitIntegratorTest : public ::testing::Test {
     // Test that setting the target accuracy and initial step size target is
     // successful.
     integrator.set_maximum_step_size(h_);
-    // TODO(antequ): remove this check once the Velocity-Implicit Euler
-    // supports error estimation
     if (integrator.supports_error_estimation()) {
       integrator.set_target_accuracy(1.0);
       integrator.request_initial_step_size_target(h_);
@@ -94,8 +92,6 @@ class ImplicitIntegratorTest : public ::testing::Test {
 
     // Verifies that setting accuracy too loose (from above) makes the working
     // accuracy different than the target accuracy after initialization.
-    // TODO(antequ): remove this check once the Velocity-Implicit Euler
-    // supports error estimation
     if (integrator.supports_error_estimation()) {
       EXPECT_NE(integrator.get_accuracy_in_use(),
                 integrator.get_target_accuracy());
@@ -117,8 +113,6 @@ class ImplicitIntegratorTest : public ::testing::Test {
 
     // For fixed step integrators, we need to use a smaller step size to get
     // the desired accuracy. By experimentation, we found that 0.1 h_ works.
-    // TODO(antequ): remove these checks once the Velocity-Implicit Euler
-    // supports error estimation
     double h = integrator.supports_error_estimation() ? large_h_ : 0.1 * h_;
 
     // Designate the solution tolerance. For reference, the true positions are
@@ -186,8 +180,6 @@ class ImplicitIntegratorTest : public ::testing::Test {
     // Set error controlled integration parameters.
     const double xtol = 1e-6;
     const double vtol = xtol * 100;
-    // TODO(antequ): remove this check once the Velocity-Implicit Euler
-    // supports error estimation
     if (integrator.supports_error_estimation()) {
       integrator.set_target_accuracy(xtol);
     }
@@ -292,8 +284,6 @@ class ImplicitIntegratorTest : public ::testing::Test {
                               mod_spring_mass_damper_context_.get());
     integrator.set_maximum_step_size(h_);
     integrator.set_throw_on_minimum_step_size_violation(false);
-    // TODO(antequ): remove this check once the Velocity-Implicit Euler
-    // supports error estimation
     if (integrator.supports_error_estimation()) {
       integrator.set_target_accuracy(1e-5);
     }
@@ -420,8 +410,6 @@ class ImplicitIntegratorTest : public ::testing::Test {
     IntegratorType integrator(spring_mass, context.get());
     // For fixed step integrators, we need to use a smaller step size to get
     // the desired accuracy. By experimentation, we found that 0.5 h_ works.
-    // TODO(antequ): remove these checks once the Velocity-Implicit Euler
-    // supports error estimation
     double h = integrator.supports_error_estimation() ? large_h_ : 0.5 * h_;
     integrator.set_maximum_step_size(h);
     if (integrator.supports_error_estimation()) {
@@ -528,8 +516,6 @@ class ImplicitIntegratorTest : public ::testing::Test {
     IntegratorType integrator(spring_mass, context.get());
 
     // Skip this test if the integrator doesn't have error estimate.
-    // TODO(antequ): remove this check once the Velocity-Implicit Euler
-    // supports error estimation
     if (!integrator.supports_error_estimation()) GTEST_SKIP();
 
     integrator.set_maximum_step_size(large_h_);
@@ -621,8 +607,6 @@ class ImplicitIntegratorTest : public ::testing::Test {
 
     // Spring-mass system is necessary only to setup the problem.
     IntegratorType integrator(spring_mass, context.get());
-    // TODO(antequ): remove this check once the Velocity-Implicit Euler
-    // supports error estimation
     if (!integrator.supports_error_estimation()) GTEST_SKIP();
     integrator.set_maximum_step_size(large_h_);
     integrator.set_requested_minimum_step_size(small_h_);
@@ -700,8 +684,6 @@ class ImplicitIntegratorTest : public ::testing::Test {
   // Checks the validity of general integrator statistics and resets statistics.
   void CheckGeneralStatsValidity(IntegratorType* integrator) {
     EXPECT_GT(integrator->get_num_newton_raphson_iterations(), 0);
-    // TODO(antequ): remove these checks once the Velocity-Implicit Euler
-    // supports error estimation
     if (integrator->supports_error_estimation()) {
       EXPECT_GT(integrator->get_num_error_estimator_newton_raphson_iterations(),
                 0);
@@ -844,8 +826,6 @@ TYPED_TEST_P(ImplicitIntegratorTest, FullNewton) {
   using Integrator = TypeParam;
   Integrator integrator(*robertson, context.get());
 
-  // TODO(antequ): Remove this check once the Velocity-Implicit Euler Integrator
-  // supports error estimation.
   if (integrator.supports_error_estimation()) {
     integrator.request_initial_step_size_target(1e0);
   } else {
@@ -900,8 +880,7 @@ TYPED_TEST_P(ImplicitIntegratorTest, Stationary) {
   // Create the integrator.
   using Integrator = TypeParam;
   Integrator integrator(*stationary, context.get());
-  // TODO(antequ): remove this check once the Velocity-Implicit Euler
-  // supports error estimation
+
   if (integrator.supports_error_estimation()) {
     integrator.set_maximum_step_size(1.0);
     integrator.set_target_accuracy(1e-3);
@@ -944,8 +923,7 @@ TYPED_TEST_P(ImplicitIntegratorTest, Robertson) {
   //                  step size (see issue #6329).
   integrator.set_maximum_step_size(10000000.0);
   integrator.set_throw_on_minimum_step_size_violation(false);
-  // TODO(antequ): remove this check once the Velocity-Implicit Euler
-  // supports error estimation
+
   if (integrator.supports_error_estimation()) {
     integrator.set_target_accuracy(tol);
     integrator.request_initial_step_size_target(1e-4);
@@ -983,8 +961,6 @@ TYPED_TEST_P(ImplicitIntegratorTest, FixedStepThrowsOnMultiStep) {
   integrator.set_fixed_step_mode(true);
 
   // Values we have used successfully in other Robertson system tests.
-  // TODO(antequ): remove this check once the Velocity-Implicit Euler
-  // supports error estimation
   if (integrator.supports_error_estimation()) {
     integrator.set_target_accuracy(5e-5);
   }
@@ -1017,8 +993,6 @@ TYPED_TEST_P(ImplicitIntegratorTest, AccuracyEstAndErrorControl) {
   using Integrator = TypeParam;
   Integrator integrator(this->spring_mass(), this->spring_mass_context_.get());
 
-  // TODO(antequ): remove this once error estimation is supported in
-  // Velocity-Implicit Euler.
   if (!integrator.supports_error_estimation()) GTEST_SKIP();
 
   EXPECT_EQ(integrator.supports_error_estimation(), true);
@@ -1048,8 +1022,6 @@ TYPED_TEST_P(ImplicitIntegratorTest, LinearTest) {
   integrator1.set_fixed_step_mode(true);
   integrator1.Initialize();
   ASSERT_TRUE(integrator1.IntegrateWithSingleFixedStepToTime(t_final));
-  // TODO(antequ): remove this check once the Velocity-Implicit Euler
-  // supports error estimation
   if (integrator1.supports_error_estimation()) {
     const double err_est = integrator1.get_error_estimate()->get_vector()[0];
 

--- a/systems/analysis/velocity_implicit_euler_integrator.h
+++ b/systems/analysis/velocity_implicit_euler_integrator.h
@@ -107,12 +107,12 @@ namespace systems {
  * time-increment advanced by this integrator: if, for example, the second small
  * half-sized step fails, this integrator revokes to the state before the first
  * small step. This behavior is similar to other integrators with multi-stage
- * evaluation: the step-counting statistics treat a "step" as the combination of 
+ * evaluation: the step-counting statistics treat a "step" as the combination of
  * all the stages.
  * @note Furthermore, because the small half-sized steps are propagated as the
  * solution, the large full-sized step is the error estimator, and the error
- * estimation statistics track the effort during the large full-sized step. 
- * If the integrator is not in full-Newton mode (see
+ * estimation statistics track the effort during the large full-sized step. If
+ * the integrator is not in full-Newton mode (see
  * ImplicitIntegrator<T>::set_use_full_newton()), most of the work incurred by
  * constructing and factorizing matrices and by failing Newton-Raphson
  * iterations will be counted toward the error estimation statistics, because

--- a/systems/analysis/velocity_implicit_euler_integrator.h
+++ b/systems/analysis/velocity_implicit_euler_integrator.h
@@ -11,52 +11,43 @@
 namespace drake {
 namespace systems {
 
-namespace internal {
-#ifndef DRAKE_DOXYGEN_CXX
-__attribute__((noreturn)) inline void EmitNoErrorEstimatorStatAndMessage() {
-  throw std::logic_error(
-      "No error estimator is currently implemented, so "
-      "query error estimator statistics is not yet supported.");
-}
-#endif
-}  // namespace internal
-
 /**
- * A first-order, fully implicit integrator optimized for second-order systems.
+ * A first-order, fully implicit integrator optimized for second-order systems,
+ * with a second-order error estimate.
  *
  * The velocity-implicit Euler integrator is a variant of the first-order
  * implicit Euler that takes advantage of the simple mapping q̇ = N(q) v
  * of second order systems to formulate a smaller problem in velocities (and
- * miscellaneous states if any) only. For second-order systems,
+ * miscellaneous states if any) only. For systems with second-order dynamics,
  * %VelocityImplicitEulerIntegrator formulates a problem that is half as large
  * as that formulated by Drake's ImplicitEulerIntegrator, resulting in improved
  * run-time performance. Upon convergence of the resulting system of equations,
  * this method provides the same discretization as ImplicitEulerIntegrator, but
  * at a fraction of the computational cost.
  *
- * This integrator requires a system of ordinary differential equations in
- * state `x = (q,v,z)` to be expressible in the following form:
+ * This integrator requires a system of ordinary differential equations (ODEs)
+ * in state `x = (q,v,z)` to be expressible in the following form:
  *
- *     q̇ = N(q) v;                            (1)
- *     ẏ = f_y(t,q,y),                        (2)
- * where `q̇` and `v` are linearly related via the kinematic mapping `N(q)`, 
+ *     q̇ = N(q) v;                                   (1)
+ *     ẏ = f_y(t,q,y),                               (2)
+ * where `q̇` and `v` are linearly related via the kinematic mapping `N(q)`,
  * `y = (v,z)`, and `f_y` is a function that can depend on the time and state.
  *
  * Implicit Euler uses the following update rule at time step n:
  *
- *     qⁿ⁺¹ = qⁿ + h N(qⁿ⁺¹) vⁿ⁺¹;            (3)
- *     yⁿ⁺¹ = yⁿ + h f_y(tⁿ⁺¹,qⁿ⁺¹,yⁿ⁺¹).     (4)
+ *     qⁿ⁺¹ = qⁿ + h N(qⁿ⁺¹) vⁿ⁺¹;                   (3)
+ *     yⁿ⁺¹ = yⁿ + h f_y(tⁿ⁺¹,qⁿ⁺¹,yⁿ⁺¹).            (4)
  *
  * To solve the nonlinear system for `(qⁿ⁺¹,yⁿ⁺¹)`, the velocity-implicit Euler
- * integrator iterates with a modified Newton's method: At iteration `k`, it 
+ * integrator iterates with a modified Newton's method: At iteration `k`, it
  * finds a `(qₖ₊₁,yₖ₊₁)` that attempts to satisfy
  *
- *     qₖ₊₁ = qⁿ + h N(qₖ) vₖ₊₁.              (5)
- *     yₖ₊₁ = yⁿ + h f_y(tⁿ⁺¹,qₖ₊₁,yₖ₊₁);     (6)
+ *     qₖ₊₁ = qⁿ + h N(qₖ) vₖ₊₁.                     (5)
+ *     yₖ₊₁ = yⁿ + h f_y(tⁿ⁺¹,qₖ₊₁,yₖ₊₁);            (6)
  *
  * In this notation, the `n`'s index timesteps, while the `k`'s index the
  * specific Newton-Raphson iterations within each time step.
- * 
+ *
  * Notice that we've intentionally lagged N(qₖ) one iteration behind in Eq (5).
  * This allows it to substitute (5) into (6) to obtain a non-linear system in
  * `y` only. Contrast this strategy with the one implemented by
@@ -66,29 +57,72 @@ __attribute__((noreturn)) inline void EmitNoErrorEstimatorStatAndMessage() {
  * To find a `(qₖ₊₁,yₖ₊₁)` that approximately satisfies (5-6), we linearize
  * the system (5-6) to compute a Newton step. Define
  *
- *     l(y) = f_y(tⁿ⁺¹,qⁿ + h N(qₖ) v,y),     (7)
- *     Jₗ(y) = ∂l(y) / ∂y.                    (8)
+ *     l(y) = f_y(tⁿ⁺¹,qⁿ + h N(qₖ) v,y),            (7)
+ *     Jₗ(y) = ∂l(y) / ∂y.                           (8)
  *
  * To advance the Newton step, the velocity-implicit Euler integrator solves
  * the following linear equation for `Δy`:
  *
- *     (I - h Jₗ) Δy = - R(yₖ),               (9)
+ *     (I - h Jₗ) Δy = - R(yₖ),                      (9)
  * where `R(y) = y - yⁿ - h l(y)` and `Δy = yₖ₊₁ - yₖ`. The `Δy` solution
  * directly gives us `yₖ₊₁`. It then substitutes the `vₖ₊₁` component of `yₖ₊₁`
  * in (5) to get `qₖ₊₁`.
  *
- * This implementation uses a Newton method and relies upon the obvious
- * convergence to a solution for `y` in `R(y) = 0` where
- * `R(y) = y - yⁿ - h l(y)` as `h` becomes sufficiently small.
- * General implementational details were gleaned from [Hairer, 1996].
+ * This implementation uses a Newton method and relies upon the convergence
+ * to a solution for `y` in `R(y) = 0` where `R(y) = y - yⁿ - h l(y)`
+ * as `h` becomes sufficiently small. General implementational details for
+ * the Newton method were gleaned from Section IV.8 in [Hairer, 1996].
+ *
+ * ### Error Estimation
+ *
+ * In this integrator, we simultaneously take a large step at the requested
+ * step size of h as well as two half-sized steps each with step size `h/2`.
+ * The result from two half-sized steps is propagated as the solution, while
+ * the difference between the two results is used as the error estimate for the
+ * propagated solution. This error estimate is accurate to the second order.
+ *
+ * To be precise, let `x̅ⁿ⁺¹` be the computed solution from a large step,
+ * `x̃ⁿ⁺¹` be the computed solution from two small steps, and `xⁿ⁺¹` be the true
+ * solution. Since the integrator propagates `x̃ⁿ⁺¹` as its solution, we denote
+ * the true error vector as `ε = x̃ⁿ⁺¹ - xⁿ⁺¹`. VelocityImplicitEulerIntegrator
+ * uses `ε* = x̅ⁿ⁺¹ - x̃ⁿ⁺¹`, the difference between the two solutions, as the
+ * second-order error estimate, because for a smooth system, `‖ε*‖ = O(h²)`,
+ * and `‖ε - ε*‖ = O(h³)`. See the notes in
+ * VelocityImplicitEulerIntegrator<T>::get_error_estimate_order() for a
+ * detailed derivation of the error estimate's truncation error.
+ * 
+ * In this implementation, VelocityImplicitEulerIntegrator<T> attempts the
+ * large full-sized step before attempting the two small half-sized steps,
+ * because the large step is more likely to fail to converge, and if it is
+ * performed first, convergence failures are detected early, avoiding the
+ * unnecessary effort of computing potentially-successful small steps.
  *
  * - [Hairer, 1996]   E. Hairer and G. Wanner. Solving Ordinary Differential
  *                    Equations II (Stiff and Differential-Algebraic Problems).
  *                    Springer, 1996, Section IV.8, p. 118–130.
  *
+ * @note In the statistics reported by IntegratorBase, all statistics that deal
+ * with the number of steps or the step sizes will track the large full-sized
+ * steps. This is because the large full-sized `h` is the smallest irrevocable
+ * time-increment advanced by this integrator: if, for example, the second small
+ * half-sized step fails, this integrator revokes to the state before the first
+ * small step. This behavior is similar to other integrators with multi-stage
+ * evaluation: the step counting statistics count a "step" as the combination of 
+ * all the stages.
+ *
+ * @note Furthermore, because the small half-sized steps are propagated as the
+ * solution, the large full-sized step is the error estimator, and the error
+ * estimation statistics track the effort during the large full-sized step. 
+ * If the integrator is not in full-Newton mode (see
+ * ImplicitIntegrator<T>::set_use_full_newton()), most of the work incurred by
+ * constructing and factorizing matrices and by failing Newton-Raphson
+ * iterations will be counted toward the error estimation statistics, because
+ * the large step is performed first.
+ *
  * @note This integrator uses the integrator accuracy setting, even when run
  *       in fixed-step mode, to limit the error in the underlying Newton-Raphson
  *       process. See IntegratorBase::set_target_accuracy() for more info.
+ *
  * @see ImplicitIntegrator class documentation for information about implicit
  *      integration methods in general.
  * @see ImplicitEulerIntegrator class documentation for information about
@@ -108,38 +142,188 @@ class VelocityImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
                                            Context<T>* context = nullptr)
       : ImplicitIntegrator<T>(system, context) {}
 
-  /// The integrator does not support error estimation.
-  bool supports_error_estimation() const final { return false; }
+  /**
+   * Returns true, because this integrator supports error estimation.
+   */
+  bool supports_error_estimation() const final { return true; }
 
-  /// Returns 0 for the error estimation order because this integrator does not
-  /// support error estimation.
-  int get_error_estimate_order() const final { return 0; }
+  /**
+   * Returns the asymptotic order of the difference between the large and small
+   * steps (from which the error estimate is computed), which is 2. That is, the
+   * error estimate, `ε* = x̅ⁿ⁺¹ - x̃ⁿ⁺¹` has the property that `‖ε*‖ = O(h²)`,
+   * and it deviates from the true error, `ε`, by `‖ε - ε*‖ = O(h³)`. 
+   *
+   * ### Derivation of the asymptotic order
+   *
+   * To derive the second-order error estimate, let us first define the vector-
+   * valued function `e(tⁿ, h, xⁿ) = x̅ⁿ⁺¹ - xⁿ⁺¹`, the local truncation error
+   * for a single, full-sized velocity-implicit Euler integration step, with
+   * initial conditions `(tⁿ, xⁿ)`, and a step size of `h`. Furthermore, use
+   * `ẍ` to denote `df/dt`, and `∇f` and `∇ẍ` to denote the Jacobians `df/dx`
+   * and `dẍ/dx` of the ODE system `ẋ = f(t, x)`. Note that `ẍ` uses a total
+   * time derivative, i.e., `ẍ = ∂f/∂t + ∇f f`.
+   *
+   * Let us use `x*` to denote the true solution after a half-step, `x(tⁿ+½h)`,
+   * and `x̃*` to denote the velocity-implicit Euler solution after a single
+   * half-sized step. Furthermore, let us use `xⁿ*¹` to denote the true solution
+   * of the system at time `t = tⁿ+h` if the system were at `x̃*` when
+   * `t = tⁿ+½h`. See the following diagram for an illustration.
+   *
+   *      Legend:
+   *      ───── propagation along the true system
+   *      :···· propagation using implicit Euler with a half step
+   *      :---- propagation using implicit Euler with a full step
+   *
+   *      Time  tⁿ         tⁿ+½h         tⁿ+h
+   *
+   *      State :----------------------- x̅ⁿ⁺¹  <─── used for error estimation
+   *            :
+   *            :
+   *            :
+   *            :            :·········· x̃ⁿ⁺¹  <─── propagated result
+   *            :            :
+   *            :·········  x̃*   ─────── xⁿ*¹
+   *            :
+   *            xⁿ ───────  x*   ─────── xⁿ⁺¹  <─── true solution
+   *
+   * We will use superscripts to denote evaluating an expression with `x` at
+   * that subscript and `t` at the corresponding time, e.g. `ẍⁿ` denotes
+   * `ẍ(tⁿ, xⁿ)`, and `f*` denotes `f(tⁿ+½h, x*)`. We first present a shortened
+   * derivation, followed by the longer, detailed version.
+   *
+   * We know the local truncation error for the implicit Euler method is:
+   *
+   *     e(tⁿ, h, xⁿ) = x̅ⁿ⁺¹ - xⁿ⁺¹ = ½ h²ẍⁿ + O(h³).    (10)
+   *
+   * The local truncation error ε from taking two half steps is composed of
+   * these two terms:
+   *
+   *     e₁ = xⁿ*¹ - xⁿ⁺¹ = (1/8) h²ẍⁿ + O(h³),          (15)
+   *     e₂ = x̃ⁿ⁺¹ - xⁿ*¹ = (1/8) h²ẍⁿ + O(h³).          (20)
+   *
+   * Taking the sum,
+   *
+   *     ε = x̃ⁿ⁺¹ - xⁿ⁺¹ = e₁ + e₂ = (1/4) h²ẍⁿ + O(h³). (21)
+   *
+   * These two estimations allow us to obtain an estimation of the local error
+   * from the difference between the available quantities x̅ⁿ⁺¹ and x̃ⁿ⁺¹:
+   *
+   *     ε* = x̅ⁿ⁺¹ - x̃ⁿ⁺¹ = e(tⁿ, h, xⁿ) - ε,
+   *                      = (1/4) h²ẍⁿ + O(h³),          (22)
+   *
+   * and therefore our error estimate is second order.
+   *
+   * Below we will show this derivation in detail along with the proof that
+   * `‖ε - ε*‖ = O(h³)`:
+   *
+   * Let us look at a single velocity-implicit Euler step. Upon Newton-Raphson
+   * convergence, the truncation error for velocity-implicit Euler, which is the
+   * same as the truncation error for implicit Euler (because both methods solve
+   * Eqs. (3-4)), is
+   *
+   *     e(tⁿ, h, xⁿ) = ½ h²ẍⁿ⁺¹ + O(h³)
+   *                  = ½ h²ẍⁿ + O(h³).                  (10)
+   *
+   * To see why the two are equivalent, we can Taylor expand about `(tⁿ, xⁿ)`,
+   *
+   *     ẍⁿ⁺¹ = ẍⁿ + h dẍ/dtⁿ + O(h²) = ẍⁿ + O(h).
+   *     e(tⁿ, h, xⁿ) = ½ h²ẍⁿ⁺¹ + O(h³) = ½ h²(ẍⁿ + O(h)) + O(h³)
+   *                  = ½ h²ẍⁿ + O(h³).
+   *
+   * Moving on with our derivation, after one small half-sized implicit Euler
+   * step, the solution `x̃*` is
+   *
+   *     x̃* = x* + e(tⁿ, ½h, xⁿ)
+   *        = x* + (1/8) h²ẍⁿ + O(h³),
+   *     x̃* - x* = (1/8) h²ẍⁿ + O(h³).                   (11)
+   *
+   * Taylor expanding about `t = tⁿ+½h` in this `x = x̃*` alternate reality,
+   *
+   *     xⁿ*¹ = x̃* + ½h f(tⁿ+½h, x̃*) + O(h²).            (12)
+   *
+   * Similarly, Taylor expansions about `t = tⁿ+½h` and the true solution
+   * `x = x*` also give us
+   *
+   *     xⁿ⁺¹ = x* + ½h f* + O(h²),                      (13)
+   *     f(tⁿ+½h, x̃*) = f* + (∇f*) (x̃* - x*) + O(‖x̃* - x*‖²)
+   *                  = f* + O(h²),                      (14)
+   * where in the last line we substituted Eq. (11).
+   *
+   * Eq. (12) minus Eq. (13) gives us,
+   *
+   *     xⁿ*¹ - xⁿ⁺¹ = x̃* - x* + ½h(f(tⁿ+½h, x̃*) - f*) + O(h³),
+   *                 = x̃* - x* + O(h³),
+   * where we just substituted in Eq. (14). Finally, substituting in Eq. (11),
+   *
+   *     e₁ = xⁿ*¹ - xⁿ⁺¹ = (1/8) h²ẍⁿ + O(h³).          (15)
+   *
+   * After the second small step, the solution `x̃ⁿ⁺¹` is
+   *
+   *     x̃ⁿ⁺¹ = xⁿ*¹ + e(tⁿ+½h, ½h, x̃*),
+   *          = xⁿ*¹ + (1/8)h² ẍ(tⁿ+½h, x̃*) + O(h³).     (16)
+   *
+   * Taking Taylor expansions about `(tⁿ, xⁿ)`,
+   *
+   *     x* = xⁿ + ½h fⁿ + O(h²) = xⁿ + O(h).            (17)
+   *     x̃* - xⁿ = (x̃* - x*) + (x* - xⁿ) = O(h),         (18)
+   * where we substituted in Eqs. (11) and (17), and
+   *
+   *     ẍ(tⁿ+½h, x̃*) = ẍⁿ + ½h ∂ẍ/∂tⁿ + ∇ẍⁿ (x̃* - xⁿ) + O(h ‖x̃* - xⁿ‖)
+   *                  = ẍⁿ + O(h),                       (19)
+   * where we substituted in Eq. (18).
+   *
+   * Substituting Eqs. (19) and (15) into Eq. (16),
+   *
+   *     x̃ⁿ⁺¹ = xⁿ*¹ + (1/8) h²ẍⁿ + O(h³)                (20)
+   *          = xⁿ⁺¹ + (1/4) h²ẍⁿ + O(h³),
+   * therefore
+   *
+   *     ε = x̃ⁿ⁺¹ - xⁿ⁺¹ = (1/4) h² ẍⁿ + O(h³).          (21)
+   *
+   * Subtracting Eq. (21) from Eq. (10),
+   *
+   *     e(tⁿ, h, xⁿ) - ε = (½ - 1/4) h²ẍⁿ + O(h³);
+   *     ⇒ ε* = x̅ⁿ⁺¹ - x̃ⁿ⁺¹ = (1/4) h²ẍⁿ + O(h³).        (22)
+   *
+   * Eq. (22) shows that our error estimate is second-order. Since the first
+   * term on the RHS matches `ε` (Eq. (21)),
+   *
+   *     ε* = ε + O(h³).                                 (23)
+   */
+  int get_error_estimate_order() const final { return 2; }
 
  private:
   int64_t do_get_num_newton_raphson_iterations() const final {
     return num_nr_iterations_;
   }
 
+  // These methods return the effort done by the large step, which is the error
+  // estimator for the half-sized steps.
   int64_t do_get_num_error_estimator_derivative_evaluations() const final {
-    internal::EmitNoErrorEstimatorStatAndMessage();
+    return this->get_num_derivative_evaluations() -
+           num_half_vie_function_evaluations_;
   }
 
   int64_t do_get_num_error_estimator_derivative_evaluations_for_jacobian()
       const final {
-    internal::EmitNoErrorEstimatorStatAndMessage();
+    return this->get_num_derivative_evaluations_for_jacobian() -
+           num_half_vie_jacobian_function_evaluations_;
   }
 
   int64_t do_get_num_error_estimator_newton_raphson_iterations() const final {
-    internal::EmitNoErrorEstimatorStatAndMessage();
+    return this->get_num_newton_raphson_iterations() -
+           num_half_vie_nr_iterations_;
   }
 
   int64_t do_get_num_error_estimator_jacobian_evaluations() const final {
-    internal::EmitNoErrorEstimatorStatAndMessage();
+    return this->get_num_jacobian_evaluations() -
+           num_half_vie_jacobian_reforms_;
   }
 
   int64_t do_get_num_error_estimator_iteration_matrix_factorizations()
       const final {
-    internal::EmitNoErrorEstimatorStatAndMessage();
+    return this->get_num_iteration_matrix_factorizations() -
+           num_half_vie_iter_factorizations_;
   }
 
   void DoResetImplicitIntegratorStatistics() final;
@@ -152,7 +336,7 @@ class VelocityImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
 
   bool DoImplicitIntegratorStep(const T& h) final;
 
-  // Steps the system forward by a single step of h using the Velocity-Implicit
+  // Steps the system forward by a single step of h using the velocity-implicit
   // Euler method.
   // @param t0 the time at the left end of the integration interval.
   // @param h the time increment to step forward.
@@ -177,13 +361,56 @@ class VelocityImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
       typename ImplicitIntegrator<T>::IterationMatrix* iteration_matrix,
       MatrixX<T>* Jy, int trial = 1);
 
+  // Steps the system forward by two half-sized steps of size h/2 using the
+  // velocity-implicit Euler method, and keeps track of separate statistics
+  // for the derivative evaluations, matrix refactorizations, and Jacobian
+  // recomputations during these half-sized steps. This method calls
+  // StepVelocityImplicitEuler() up to twice to perform the
+  // two half-sized steps.
+  // @param t0 the time at the left end of the integration interval.
+  // @param h the combined time increment to step forward.
+  // @param xn the continuous state at t0, which is xⁿ.
+  // @param xtplus_guess the starting guess for xⁿ⁺¹.
+  // @param [out] xtplus the computed value for xⁿ⁺¹ on successful return.
+  // @param [in, out] iteration_matrix the cached iteration matrix, which is
+  //        updated if either StepVelocityImplicitEuler() calls update it.
+  // @param [in, out] Jy the cached Jacobian Jₗ(y), which is updated if
+  //        either StepVelocityImplicitEuler() calls update it.
+  // @returns `true` if both steps were successful, `false` otherwise.
+  // @note The time and continuous state in the context are indeterminate upon
+  //       exit.
+  bool StepHalfVelocityImplicitEulers(
+      const T& t0, const T& h, const VectorX<T>& xn,
+      const VectorX<T>& xtplus_guess, VectorX<T>* xtplus,
+      typename ImplicitIntegrator<T>::IterationMatrix* iteration_matrix,
+      MatrixX<T>* Jy);
+
+  // Takes a large velocity-implicit Euler step (of size h) and two half-sized
+  // velocity-implicit Euler steps (of size h/2), if possible.
+  // @param t0 the time at the left end of the integration interval.
+  // @param h the integration step size to attempt.
+  // @param [out] xtplus_vie contains the velocity-implicit Euler solution
+  //              (i.e., `xⁿ⁺¹`) after the large step, if successful, on return.
+  // @param [out] xtplus_hvie contains the velocity-implicit Euler solution
+  //              (i.e., `xⁿ⁺¹`) after the two small steps, if successful, on
+  //              return.
+  // @returns `true` if all three step attempts were successful, `false`
+  //          otherwise.
+  bool AttemptStepPaired(const T& t0, const T& h, const VectorX<T>& xt0,
+                         VectorX<T>* xtplus_vie, VectorX<T>* xtplus_hvie);
+
   // Compute the partial derivatives of the ordinary differential equations with
   // respect to the y variables of a given x(t). In particular, we compute the
   // Jacobian, Jₗ(y), of the function l(y), used in this integrator's
   // residual computation, with respect to y, where y = (v,z) and x = (q,v,z).
   // This Jacobian is then defined as:
-  //     l(y)  = f_y(tⁿ⁺¹, qⁿ + h N(qₖ) v, y)   (7)
-  //     Jₗ(y) = ∂l(y)/∂y                       (8)
+  //     l(y)  = f_y(tⁿ⁺¹, qⁿ + h N(qₖ) v, y)          (7)
+  //     Jₗ(y) = ∂l(y)/∂y                              (8)
+  // We use the Jacobian computation scheme from
+  // get_jacobian_computation_scheme(), which is either a first-order forward
+  // difference, a second-order centered difference, or automatic
+  // differentiation. See math::ComputeNumericalGradient() for more details on
+  // the first two methods.
   // @param t refers to tⁿ⁺¹, the time used in the definition of l(y)
   // @param h is the timestep size parameter, h, used in the definition of
   //        l(y)
@@ -199,38 +426,9 @@ class VelocityImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
                             const VectorX<T>& qk, const VectorX<T>& qn,
                             MatrixX<T>* Jy);
 
-  // Uses first-order forward differencing to compute the Jacobian, Jₗ(y), of
-  // the function l(y), used in this integrator's residual computation, with
-  // respect to y, where y = (v,z). This Jacobian is then defined as:
-  //     l(y)  = f_y(tⁿ⁺¹, qⁿ + h N(qₖ) v, y)   (7)
-  //     Jₗ(y) = ∂l(y)/∂y                       (8)
-  //
-  // In this method, we compute the Jacobian Jₗ(y) using a first-order forward
-  // difference (i.e. numerical differentiation),
-  //     Jₗ(y)ᵢⱼ = (l(y')ᵢ - l(y)ᵢ )/ δy(j),
-  // where y' = y + δy(j) eⱼ, δy(j) = (√ε) max(1,|yⱼ|), and eⱼ is the j-th
-  // standard Cartesian basis vector.
-  // In the code we hereby refer to y as "the baseline" and y' as "prime".
-  // @param t refers to tⁿ⁺¹, the time used in the definition of l(y).
-  // @param h is the timestep size parameter, h, used in the definition of
-  //        l(y).
-  // @param y is the generalized velocity and miscellaneous states around which
-  //        to evaluate Jₗ(y).
-  // @param qk is qₖ, the current-iteration position used in the definition of
-  //        l(y).
-  // @param qn refers to qⁿ, the initial position used in l(y).
-  // @param [out] Jy is the Jacobian matrix, Jₗ(y).
-  // @note The context's time will be set to t, and its continuous state will
-  //       be indeterminate on return.
-  void ComputeForwardDiffVelocityJacobian(const T& t, const T& h,
-                                          const VectorX<T>& y,
-                                          const VectorX<T>& qk,
-                                          const VectorX<T>& qn,
-                                          MatrixX<T>* Jy);
-
   // Computes necessary matrices (Jacobian and iteration matrix) for
   // Newton-Raphson (NR) iterations, as necessary. This method is based off of
-  // ImplicitIntegrator<T>::MaybeFreshenMatrices. We implement our own version
+  // ImplicitIntegrator<T>::MaybeFreshenMatrices(). We implement our own version
   // here to use a specialized Jacobian Jₗ(y). The aformentioned method was
   // designed for use in DoImplicitIntegratorStep() processes that follow this
   // model:
@@ -316,7 +514,7 @@ class VelocityImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   // This helper method evaluates the Newton-Raphson residual R(y), defined as
   // the following:
   //     R(y)  = y - yⁿ - h l(y),
-  //     l(y) = f_y(tⁿ⁺¹, qⁿ + h N(qₖ) v, y),    (7)
+  //     l(y) = f_y(tⁿ⁺¹, qⁿ + h N(qₖ) v, y),          (7)
   // with tⁿ⁺¹, y = (v, z), qₖ, qⁿ, yⁿ, and h passed in.
   // @param t refers to tⁿ⁺¹, the time at which to compute the residual R(y).
   // @param y is the generalized velocity and miscellaneous states around which
@@ -338,7 +536,7 @@ class VelocityImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
                               BasicVector<T>* qdot);
 
   // This helper method evaluates l(y), defined as the following:
-  //     l(y) = f_y(tⁿ⁺¹, qⁿ + h N(qₖ) v, y),    (7)
+  //     l(y) = f_y(tⁿ⁺¹, qⁿ + h N(qₖ) v, y),          (7)
   // with tⁿ⁺¹, y = (v, z), qₖ, qⁿ, yⁿ, and h passed in.
   // @param t refers to tⁿ⁺¹, the time at which to compute the residual R(y).
   // @param y is the generalized velocity and miscellaneous states around which
@@ -357,19 +555,33 @@ class VelocityImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
                          BasicVector<T>* qdot);
 
   // The last computed iteration matrix and factorization.
-  typename ImplicitIntegrator<T>::IterationMatrix iteration_matrix_ie_;
+  typename ImplicitIntegrator<T>::IterationMatrix iteration_matrix_vie_;
+
+  // Vector used in error estimate calculations. At the end of every step, we
+  // set this to ε* = x̅ⁿ⁺¹ - x̃ⁿ⁺¹, which is our estimate for ε = x̃ⁿ⁺¹ - xⁿ⁺¹,
+  // the error of the propagated half-sized steps.
+  VectorX<T> err_est_vec_;
 
   // The continuous state update vector used during Newton-Raphson.
   std::unique_ptr<ContinuousState<T>> dx_state_;
 
   // Variables to avoid heap allocations.
-  VectorX<T> xn_, xdot_, xtplus_ie_;
+  VectorX<T> xn_, xdot_, xtplus_vie_, xtplus_hvie_;
+  std::unique_ptr<BasicVector<T>> qdot_{nullptr};
+
+  // The last computed velocity+misc Jacobian matrix.
+  MatrixX<T> Jy_vie_;
 
   // Various statistics.
   int64_t num_nr_iterations_{0};
 
-  // The last computed velocity+misc Jacobian matrix.
-  MatrixX<T> Jy_ie_;
+  // Half-sized-step-specific statistics, only updated when taking the half-
+  // sized steps.
+  int64_t num_half_vie_jacobian_reforms_{0};
+  int64_t num_half_vie_iter_factorizations_{0};
+  int64_t num_half_vie_function_evaluations_{0};
+  int64_t num_half_vie_jacobian_function_evaluations_{0};
+  int64_t num_half_vie_nr_iterations_{0};
 };
 
 }  // namespace systems

--- a/systems/analysis/velocity_implicit_euler_integrator.h
+++ b/systems/analysis/velocity_implicit_euler_integrator.h
@@ -109,7 +109,6 @@ namespace systems {
  * small step. This behavior is similar to other integrators with multi-stage
  * evaluation: the step-counting statistics treat a "step" as the combination of 
  * all the stages.
- *
  * @note Furthermore, because the small half-sized steps are propagated as the
  * solution, the large full-sized step is the error estimator, and the error
  * estimation statistics track the effort during the large full-sized step. 
@@ -118,10 +117,9 @@ namespace systems {
  * constructing and factorizing matrices and by failing Newton-Raphson
  * iterations will be counted toward the error estimation statistics, because
  * the large step is performed first.
- *
  * @note This integrator uses the integrator accuracy setting, even when run
- *       in fixed-step mode, to limit the error in the underlying Newton-Raphson
- *       process. See IntegratorBase::set_target_accuracy() for more info.
+ * in fixed-step mode, to limit the error in the underlying Newton-Raphson
+ * process. See IntegratorBase::set_target_accuracy() for more info.
  *
  * @see ImplicitIntegrator class documentation for information about implicit
  *      integration methods in general.

--- a/systems/analysis/velocity_implicit_euler_integrator.h
+++ b/systems/analysis/velocity_implicit_euler_integrator.h
@@ -107,7 +107,7 @@ namespace systems {
  * time-increment advanced by this integrator: if, for example, the second small
  * half-sized step fails, this integrator revokes to the state before the first
  * small step. This behavior is similar to other integrators with multi-stage
- * evaluation: the step counting statistics count a "step" as the combination of 
+ * evaluation: the step-counting statistics treat a "step" as the combination of 
  * all the stages.
  *
  * @note Furthermore, because the small half-sized steps are propagated as the

--- a/systems/analysis/velocity_implicit_euler_integrator.h
+++ b/systems/analysis/velocity_implicit_euler_integrator.h
@@ -90,7 +90,7 @@ namespace systems {
  * and `‖ε - ε*‖ = O(h³)`. See the notes in
  * VelocityImplicitEulerIntegrator<T>::get_error_estimate_order() for a
  * detailed derivation of the error estimate's truncation error.
- * 
+ *
  * In this implementation, VelocityImplicitEulerIntegrator<T> attempts the
  * large full-sized step before attempting the two small half-sized steps,
  * because the large step is more likely to fail to converge, and if it is


### PR DESCRIPTION
Add Error Control to Velocity-Implicit Euler Integrator, third PR of #12528

This commit:
  1. Implements error control by taking two half-sized steps and estimating the error as the difference between the solution from the large step and the solution from two half-sized steps.
  2. Changes IntegratorBase to report statistics on the small steps for any steps "taken", while the error control and step-size limit logic still operates on the large step size.
  3. Updates documentation to explain the statistics and derive the error estimation order.
  4. (Passive) Enables the error-control tests for VelocityImplicitEulerTest, by turning on the supports_error_estimation() flag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12760)
<!-- Reviewable:end -->
