### PR TITLE
[geometry] Changing how polygons get split for contact surfaces

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -16,6 +16,7 @@ drake_cc_package_library(
         ":bounding_volume_hierarchy",
         ":collision_filter_legacy",
         ":collisions_exist_callback",
+        ":contact_surface_utility",
         ":distance_to_point_callback",
         ":distance_to_point_with_gradient",
         ":distance_to_shape_callback",
@@ -78,6 +79,14 @@ drake_cc_library(
         ":collision_filter_legacy",
         "//geometry:geometry_ids",
         "@fcl",
+    ],
+)
+
+drake_cc_library(
+    name = "contact_surface_utility",
+    hdrs = ["contact_surface_utility.h"],
+    deps = [
+        ":surface_mesh",
     ],
 )
 
@@ -306,6 +315,7 @@ drake_cc_library(
     hdrs = ["mesh_intersection.h"],
     deps = [
         ":bounding_volume_hierarchy",
+        ":contact_surface_utility",
         ":mesh_field",
         ":plane",
         ":surface_mesh",
@@ -452,6 +462,14 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//geometry:geometry_ids",
         "//geometry/query_results:contact_surface",
+    ],
+)
+
+drake_cc_googletest(
+    name = "contact_surface_utility_test",
+    deps = [
+        ":contact_surface_utility",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/geometry/proximity/contact_surface_utility.h
+++ b/geometry/proximity/contact_surface_utility.h
@@ -1,0 +1,167 @@
+#pragma once
+
+/** @file
+ There are multiple ways to compute a contact surface depending on the geometry
+ representations and compliance types involved. However, they should all produce
+ ContactSurface instances that satisfy some basic invariants. These functions
+ assist in maintaining those invariants.
+ */
+
+#include <vector>
+
+#include "drake/geometry/proximity/surface_mesh.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+/** Given an N-sided _convex_ `polygon`, computes its centroid. The `polygon`
+ is represented as an ordered list of indices into the given set of
+ `vertices_F`. The resulting centroid will be measured and expressed in the same
+ Frame F as the provided vertices.
+
+ @param polygon
+     The N-sided convex polygon.
+ @param[in] nhat_F
+     A unit-length vector that is perpendicular to the `polygon`'s plane,
+     expressed in Frame F.
+ @param vertices_F
+     The set of vertices from which the polygon is defined, each measured and
+     expressed in Frame F.
+ @retval p_FC, the position of the polygon's centroid C, measured and expressed
+     in Frame F.
+ @pre `polygon.size()` >= 3.
+ @pre `nhat_F` is truly perpendicular to the defined `polygon`'s plane.
+ */
+template <typename T>
+Vector3<T> CalcPolygonCentroid(
+    const std::vector<SurfaceVertexIndex>& polygon,
+    const Vector3<T>& nhat_F,
+    const std::vector<SurfaceVertex<T>>& vertices_F) {
+  // The position of the geometric centroid can be computed by decomposing the
+  // polygon into triangles and performing an area-weighted average of each of
+  // the triangle's centroids.
+  // See https://en.wikipedia.org/wiki/Centroid#By_geometric_decomposition.
+  const int v_count = static_cast<int>(polygon.size());
+  DRAKE_DEMAND(v_count >= 3);
+
+  using V = SurfaceVertexIndex;
+
+  auto triangle_centroid = [&vertices_F](V v0, V v1, V v2) {
+    return (vertices_F[v0].r_MV() + vertices_F[v1].r_MV() +
+            vertices_F[v2].r_MV()) /
+           3;
+  };
+
+  // Triangles get special treatment.
+  if (v_count == 3) {
+    return triangle_centroid(polygon[0], polygon[1], polygon[2]);
+  }
+
+  // N-gon's have to be handled by geometric decomposition.
+  // We'll decompose it by creating a triangle fan around vertex 0. I.e.,
+  //   triangle 0: v0, v1, v2
+  //   triangle 1: v0, v2, v3
+  //   etc.
+  // The polygon centroid is: ∑(kAᵢ * centroidᵢ) / ∑kAᵢ, where Aᵢ and centroidᵢ
+  // are the area and centroid of the ith triangle in the fan. We can use the
+  // area up to any scale (k != 0) because that scale factor gets divided right
+  // back out.
+
+  // This computes an area-based weight. In the purest form, the magnitude of
+  // the cross product is twice the area of the triangle. The value returned is
+  // a scaled area based on two factors:
+  //   - We don't need the actual area; any non-zero scale of the area would
+  //     work just fine.
+  //   - the normal (nhat_F) while documented as unit length may not actually
+  //     be. However, for a planar polygon, each decomposed triangle should
+  //     produce a parallel cross product and dotting each of those with an
+  //     _arbitrary_ normal direction simply further scales the area by
+  //     another constant, leaving the relative weights the same.
+  auto triangle_weight = [&vertices_F, &nhat_F](V v0, V v1, V v2) {
+    const Vector3<T>& r_MV0 = vertices_F[v0].r_MV();
+    const Vector3<T>& r_MV1 = vertices_F[v1].r_MV();
+    const Vector3<T>& r_MV2 = vertices_F[v2].r_MV();
+    return (r_MV1 - r_MV0).cross(r_MV2 - r_MV0).dot(nhat_F);
+  };
+
+  Vector3<T> p_FC_accum = Vector3<T>::Zero();
+  T total_weight{0};
+
+  const V v0 = polygon[0];
+  V v2 = polygon[1];
+  for (int i = 2; i < v_count; ++i) {
+    const V v1 = v2;
+    v2 = polygon[i];
+    const T weight = triangle_weight(v0, v1, v2);
+    p_FC_accum += weight * triangle_centroid(v0, v1, v2);
+    total_weight += weight;
+  }
+
+  return p_FC_accum / total_weight;
+}
+
+// TODO(SeanCurtis-TRI): Consider creating an overload of this that *computes*
+//  the normal and then invokes this one for contexts where they don't have the
+//  normal convenient.
+
+/** Adds the convex N-sided `polygon` to the given set of `faces` and `vertices`
+ as a set of N triangles. A new vertex is introduced at the `polygon`'s centroid
+ and one triangle is added for each edge, formed by the edge and the centroid
+ position vertex.
+
+ @param[in] polygon
+     The input polygon is represented by three or more ordered indices into
+     `vertices_F`. This polygon is _not_ in `faces` and will not, itself, appear
+     in `faces` when done.
+ @param[in] nhat_F
+     The unit-length vector that is perpendicular to the `polygon`, expressed in
+     frame F.
+ @param[in, out] faces
+     New triangles are added into `faces`. Each new triangle has the same
+     orientation (same normal vector) as the input polygon.
+ @param[in ,out] vertices_F
+     The set of vertex positions to be extended, each vertex is measured and
+     expressed in frame F. It is assumed that `polygon`'s indices all reference
+     vertices in this vector. One vertex will be added -- the polygon's
+     centroid.
+ @pre `faces` and `vertices_F` are not `nullptr`.
+ @pre `polygon.size()` >= 3.
+ @pre Each index in `polygon` indexes a valid vertex in `vertices_F`.
+ @pre `nhat_F` is truly perpendicular to the defined `polygon`.
+ */
+template <typename T>
+void AddPolygonToMeshData(
+    const std::vector<SurfaceVertexIndex>& polygon,
+    const Vector3<T>& nhat_F,
+    std::vector<SurfaceFace>* faces,
+    std::vector<SurfaceVertex<T>>* vertices_F) {
+  DRAKE_DEMAND(faces != nullptr);
+  DRAKE_DEMAND(vertices_F != nullptr);
+  DRAKE_DEMAND(polygon.size() >= 3);
+
+  // We're going to create a triangle fan for the polygon. This requires adding
+  // a new vertex at the polygon's geometric centroid (which is the centroid
+  // for this "uniform material" polygon).
+  Vector3<T> p_FC = CalcPolygonCentroid(polygon, nhat_F, *vertices_F);
+  const SurfaceVertexIndex centroid_index(vertices_F->size());
+  vertices_F->emplace_back(p_FC);
+
+  // The first thing we do in the for loop is v1 = v2, so this guarantees that
+  // v1 will be polygon[N-1] in the first iteration. We'll get triangles:
+  //  (N-1, 0, centroid)
+  //  (0, 1, centroid)
+  //  (1, 2, centroid)
+  //  ...
+  SurfaceVertexIndex v2{polygon.back()};
+  const int polygon_size = static_cast<int>(polygon.size());
+  for (int i = 0; i < polygon_size; ++i) {
+    const SurfaceVertexIndex v1 = v2;
+    v2 = polygon[i];
+    faces->emplace_back(v1, v2, centroid_index);
+  }
+}
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/test/contact_surface_utility_test.cc
+++ b/geometry/proximity/test/contact_surface_utility_test.cc
@@ -1,0 +1,327 @@
+#include "drake/geometry/proximity/contact_surface_utility.h"
+
+#include <algorithm>
+#include <limits>
+#include <set>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/math/rigid_transform.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace {
+
+using Eigen::AngleAxisd;
+using Eigen::Vector3d;
+using math::RotationMatrixd;
+using math::RigidTransformd;
+using std::vector;
+
+class ContactSurfaceUtilityTest : public ::testing::Test {
+ protected:
+  void SetUp() {
+    X_FMs_.push_back(RigidTransformd::Identity());
+    X_FMs_.push_back(RigidTransformd{Vector3d{10.5, -13.25, 7.75}});
+    X_FMs_.push_back(
+        RigidTransformd{AngleAxisd{0.001, Vector3d{1, 2, 3}.normalized()},
+                        Vector3d{-0.5, 1.25, 0.75}});
+    X_FMs_.push_back(RigidTransformd{
+        AngleAxisd{-9 * M_PI / 7, Vector3d{1, 2, 3}.normalized()},
+        Vector3d{0.5, 0.75, -1.25}});
+  }
+
+  // Compute the average vertex position of the given `polygon`.
+  static Vector3d AverageVertex(
+      const vector<SurfaceVertexIndex>& polygon,
+      const vector<SurfaceVertex<double>>& vertices_F) {
+    Vector3d v = Vector3d::Zero();
+    for (const auto& i : polygon) {
+      v += vertices_F[i].r_MV();
+    }
+    return v / polygon.size();
+  }
+
+  // A number of transforms so that we can test the robustness of arbitrary
+  // positions and orientations.
+  vector<RigidTransformd> X_FMs_;
+};
+
+// This first test validates the computation of a polygon centroid. There
+// are specific cases in which the centroid is simply the average vertex
+// position. They are:
+//
+//   - polygon is a triangle
+//   - polygon is radially symmetric.
+//   - polygon has duplicate vertices such that the _unique_ set is simply a
+//     triangle.
+//   - polygon that has _very_ short edges, such that the long edges define a
+//     triangle.
+//
+// This test confirms all of those cases, and then _pokes_ at the case where the
+// centroid _isn't_ the average vertex position as a representative sample.
+//
+// In frame M, we construct a set of vertex locations on the Mz = 0 plane. This
+// will make the Mz vector normal to the triangle. We construct various polygons
+// from the set of vertices with corresponding expected outcomes.
+//
+//                                   y
+//
+//                                   ^
+//                                   │
+//                                   │               v4
+//                                   │
+//                                   │
+//                                   v2 v5      v3
+//                                   │
+//                                   │
+//                                   │
+//                                   │
+//    ─────────v7────────────────────v0─────────v1────────────> x
+//                         v6        │
+//                                   │
+//
+// Note: v5 is just epsilon away from v2.
+// Note: the triangle formed by v7, v0, v2 has area 1 as does the quad formed
+// by v0, v1, v3, v2.
+//
+// For the following geometries, the centroid is defined as indicated:
+//
+//  - well-formed triangle: v6, v1, v2 -> average vertex.
+//  - radially symmetric quad: v0, v1, v3, v2 -> average vertex.
+//  - quad duplicate vertices: v0, v1, v1, v2 -> triangle average vertex.
+//  - quad with epsilon edge: v6, v1, v5, v2 -> triangle average vertex (within
+//    epsilon).
+//  - asymmetric quad: v6, v1, v4, v2 -> _not_ average vertex.
+//
+// We then transform these vertices into various frames to make sure that it
+// works with rotation matrices that have no zero-values.
+TEST_F(ContactSurfaceUtilityTest, PolygonCentroidTest) {
+  using V = SurfaceVertex<double>;
+  using VIndex = SurfaceVertexIndex;
+
+  const double kEps = std::numeric_limits<double>::epsilon();
+
+  // Create a number of vertices in mesh frame M. All vertices lie on the Mz = 0
+  // plane (such that Mz is a good normal direction). We'll construct polygons
+  // on these vertices.
+  const vector<V> vertices_M{V{Vector3d{0, 0, 0}}, V{Vector3d{1, 0, 0}},
+                       V{Vector3d{0, 1, 0}}, V{Vector3d{1, 1, 0}},
+                       V{Vector3d{1.5, 1.5, 0}}, V{Vector3d{kEps, 1, 0}},
+                       V{Vector3d{-1, -0.25, 0}}, V{Vector3d{-2, 0, 0}}};
+
+  for (const auto& X_FM : X_FMs_) {
+    // Now put the vertices in an arbitrary frame F.
+    vector<V> vertices_F;
+    std::transform(vertices_M.begin(), vertices_M.end(),
+                   std::back_inserter(vertices_F),
+                   [&X_FM](const V& v_M) -> V { return V{X_FM * v_M.r_MV()}; });
+    const Vector3d& nhat_F = X_FM.rotation().matrix().col(2);
+
+    {
+      // Well-formed triangle; it's simply the average vertex location.
+      const vector<VIndex> triangle{VIndex{6}, VIndex{1}, VIndex{2}};
+      const Vector3d p_FC = CalcPolygonCentroid(triangle, nhat_F, vertices_F);
+      const Vector3d p_FC_expected = AverageVertex(triangle, vertices_F);
+      EXPECT_TRUE(CompareMatrices(p_FC, p_FC_expected));
+    }
+    {
+      // Radially symmetric quad; the centroid is simply the average vertex
+      // position.
+      const vector<VIndex> quad{VIndex{0}, VIndex{1}, VIndex{3}, VIndex{2}};
+      const Vector3d p_FC = CalcPolygonCentroid(quad, nhat_F, vertices_F);
+      const Vector3d p_FC_expected = AverageVertex(quad, vertices_F);
+      EXPECT_TRUE(CompareMatrices(p_FC, p_FC_expected, 2 * kEps));
+    }
+    {
+      // Quad with a duplicate vertex; Centroid is the same as for the
+      // corresponding triangle.
+      const vector<VIndex> quad{VIndex{0}, VIndex{1}, VIndex{1}, VIndex{2}};
+      const vector<VIndex> triangle{VIndex{0}, VIndex{1}, VIndex{2}};
+      const Vector3d p_FC = CalcPolygonCentroid(quad, nhat_F, vertices_F);
+      const Vector3d p_FC_expected = AverageVertex(triangle, vertices_F);
+      EXPECT_TRUE(CompareMatrices(p_FC, p_FC_expected));
+    }
+    {
+      // Quad with a negligible edge; Centroid is _almost_ the same as for the
+      // corresponding triangle.
+      const vector<VIndex> quad{VIndex{6}, VIndex{1}, VIndex{5}, VIndex{2}};
+      const vector<VIndex> triangle{VIndex{6}, VIndex{1}, VIndex{2}};
+      const Vector3d p_FC = CalcPolygonCentroid(quad, nhat_F, vertices_F);
+      const Vector3d p_FC_expected = AverageVertex(triangle, vertices_F);
+      EXPECT_TRUE(CompareMatrices(p_FC, p_FC_expected, kEps));
+    }
+    {
+      // Make an asymmetric quad from v7, v1, v3, v2. This can be decomposed
+      // into a triangle and a square with equal areas. So, we can compute each
+      // centroid by averaging their vertex positions and simply average them to
+      // get the expected centroid.
+      const vector<VIndex> quad{VIndex{7}, VIndex{1}, VIndex{3}, VIndex{2}};
+      const vector<VIndex> triangle{VIndex{7}, VIndex{0}, VIndex{2}};
+      const vector<VIndex> square{VIndex{0}, VIndex{1}, VIndex{3}, VIndex{2}};
+
+      const Vector3d p_FCt = AverageVertex(triangle, vertices_F);
+      const Vector3d p_FCs = AverageVertex(square, vertices_F);
+      const Vector3d p_FC_expected = (p_FCt + p_FCs) / 2;
+
+      const Vector3d p_FC = CalcPolygonCentroid(quad, nhat_F, vertices_F);
+      EXPECT_TRUE(CompareMatrices(p_FC, p_FC_expected, 10 * kEps));
+    }
+  }
+}
+
+// This confirms several invariants on the input normal.
+//
+//   1. The scale of the normal doesn't particularly matter.
+//   2. The "normalness" doesn't really matter that much
+//   3. A zero vector destroys the answer.
+TEST_F(ContactSurfaceUtilityTest, PolygonCentroidTest_NormalUse) {
+  using V = SurfaceVertex<double>;
+  using VIndex = SurfaceVertexIndex;
+
+  const double kEps = std::numeric_limits<double>::epsilon();
+
+  // Vertices sufficient to support a well-defined quad.
+  const vector<V> vertices_M{V{Vector3d{-1.5, -0.25, 0}}, V{Vector3d{1, 0, 0}},
+                             V{Vector3d{0.75, 1.25, 0}}, V{Vector3d{0, 1, 0}}};
+  // A quad formed with a duplicate index; this forces the function to perform
+  // full area calculations, but it should still have the expected value of
+  // the corresponding triangle.
+  const vector<VIndex> pseudo_triangle{VIndex{0}, VIndex{1}, VIndex{1},
+                                       VIndex{2}};
+  const Vector3d p_MC_expected = AverageVertex(
+      vector<VIndex>{VIndex{0}, VIndex{1}, VIndex{2}}, vertices_M);
+
+  {
+    // A zero vector is catastrophically bad; it produces a NaN centroid.
+    const vector<VIndex> quad{VIndex{0}, VIndex{1}, VIndex{2}, VIndex{3}};
+    Vector3d kZeroVec = Vector3d::Zero();
+    EXPECT_TRUE(CompareMatrices(
+        CalcPolygonCentroid(quad, kZeroVec, vertices_M),
+        Vector3d::Constant(std::numeric_limits<double>::quiet_NaN())));
+  }
+
+  {
+    // A "normal" parallel to the polygon's plane is bad.
+    // Note: for arbitrarily oriented polygon planes, this won't necessarily
+    // be the case because the cross product (in those cases) won't necessarily
+    // produce a vector that is *perfectly* perpendicular to the normal. In
+    // many of those cases, we may still provide a reasonable answer.
+    const Vector3d Fy{0, 1, 0};
+    EXPECT_TRUE(CompareMatrices(
+        CalcPolygonCentroid(pseudo_triangle, Fy, vertices_M),
+        Vector3d::Constant(-std::numeric_limits<double>::quiet_NaN())));
+  }
+
+  for (const auto& X_FM : X_FMs_) {
+    vector<V> vertices_F;
+    std::transform(vertices_M.begin(), vertices_M.end(),
+                   std::back_inserter(vertices_F),
+                   [&X_FM](const V& v_M) -> V { return V{X_FM * v_M.r_MV()}; });
+    const Vector3d p_FC_expected = X_FM * p_MC_expected;
+    const Vector3d& Mz_F = X_FM.rotation().matrix().col(2);
+
+    // A "normal" that is too long or too short still produce the right
+    // centroid.
+    EXPECT_TRUE(CompareMatrices(
+        CalcPolygonCentroid<double>(pseudo_triangle, 2 * Mz_F, vertices_F),
+        p_FC_expected, kEps));
+    EXPECT_TRUE(CompareMatrices(
+        CalcPolygonCentroid<double>(pseudo_triangle, 0.5 * Mz_F, vertices_F),
+        p_FC_expected, kEps));
+
+    // A "normal" that isn't perpendicular (and isn't parallel) works.
+    const Vector3d My_F = X_FM.rotation().matrix().col(1);
+    const Vector3d not_normal_F = (2 * My_F + Mz_F).normalized();
+    // Larger epsilon reflects loss of precision as the "normal" becomes
+    // less and less normal.
+    EXPECT_TRUE(CompareMatrices(CalcPolygonCentroid<double>(
+                                    pseudo_triangle, not_normal_F, vertices_F),
+                                p_FC_expected, 10 * kEps));
+  }
+}
+
+// This confirms that in adding a new polygon to existing mesh data:
+//
+//   1. Only a single new vertex is added.
+//   2. That new vertex is at the centroid of the polygon.
+//   3. For N-sided polygon, N faces are added to the set of faces.
+//   4. Each of the triangles have winding that produce a normal in the same
+//      direction as the input polygons.
+TEST_F(ContactSurfaceUtilityTest, AddPolygonToMeshData) {
+  using V = SurfaceVertex<double>;
+  using VIndex = SurfaceVertexIndex;
+
+  // Vertices sufficient to support a well-defined quad.
+  //
+  //             y
+  //
+  //             │   o
+  //             o    v2
+  //           v3│
+  //             │
+  //             │
+  // ────────────┼────o───────── x
+  //             │     v1
+  //       o     │
+  //       v0    │
+  //             │
+  const vector<V> vertices_source{
+      V{Vector3d{-1.5, -0.25, 0}}, V{Vector3d{1, 0, 0}},
+      V{Vector3d{0.75, 1.25, 0}}, V{Vector3d{0, 1, 0}}};
+
+  vector<SurfaceFace> faces;
+  vector<V> vertices_M(vertices_source);
+  const vector<VIndex> quad{VIndex{0}, VIndex{1}, VIndex{2}, VIndex{3}};
+  const Vector3d nhat_M{0, 0, 1};
+  AddPolygonToMeshData(quad, nhat_M, &faces, &vertices_M);
+
+  auto triangle_normal = [](VIndex v0, VIndex v1, VIndex v2,
+                            const vector<V>& vertices_F) -> Vector3d {
+    const Vector3d phat_V0V1_F =
+        (vertices_F[v1].r_MV() - vertices_F[v0].r_MV()).normalized();
+    const Vector3d phat_V0V2_F =
+        (vertices_F[v2].r_MV() - vertices_F[v0].r_MV()).normalized();
+    return phat_V0V1_F.cross(phat_V0V2_F).normalized();
+  };
+
+  // By construction, the source polygon
+  const Vector3d poly_normal_M{0, 0, 1};
+
+  ASSERT_EQ(vertices_M.size(), vertices_source.size() + 1);
+  ASSERT_TRUE(
+      CompareMatrices(vertices_M.back().r_MV(),
+                      CalcPolygonCentroid(quad, nhat_M, vertices_M)));
+  const VIndex centroid_index(vertices_M.size() - 1);
+
+  ASSERT_EQ(faces.size(), quad.size());
+  std::set<VIndex> quad_verts(quad.begin(), quad.end());
+  for (const auto& face : faces) {
+    const std::set<VIndex> verts{face.vertex(0), face.vertex(1),
+                                 face.vertex(2)};
+    EXPECT_EQ(verts.size(), 3);  // No duplicate vertex indices.
+    EXPECT_NE(verts.find(centroid_index), verts.end());  // Includes centroid.
+    const Vector3d tri_normal_M = triangle_normal(
+        face.vertex(0), face.vertex(1), face.vertex(2), vertices_M);
+    EXPECT_NEAR(tri_normal_M.dot(poly_normal_M), 1,
+                std::numeric_limits<double>::epsilon());
+    for (VIndex i(0); i < 3; ++i) {
+      if (i == centroid_index) continue;
+      // The other two vertices come from the quad.
+      EXPECT_NE(quad_verts.find(i), quad_verts.end());
+    }
+  }
+  // Note: technically, if the quad were: (v0, v1, v2, v3),
+  // AddPolgyonToMeshData() could return (v0, v1, v4) four times and this test
+  // would pass. We can consider making the test more robust to exclude this
+  // possibility but are currently implicitly relying on the idea that such an
+  // egregious error would be obvious during visualization.
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
Every triangle/polygon found in `ContactSurface`s needs to be split into a triangle fan. A new vertex is calculated on the interior of the face and the fan is defined around that vertex.

Previously, the central vertex was the average vertex position. This, however is not stable. As a quad becomes a triangle, it causes the vertex location to jump. Instead of the average vertex position, we use the polygon's center of mass. This changes continuously, regardless of the exact distribution of vertices.

resolves #12755 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12763)
<!-- Reviewable:end -->
