### PR TITLE
Implements Composite Body Algorithm to compute the mass matrix

### DIFF
--- a/multibody/math/spatial_force.h
+++ b/multibody/math/spatial_force.h
@@ -142,6 +142,27 @@ class SpatialForce : public SpatialVector<SpatialForce, T> {
     return SpatialForce<T>(*this).ShiftInPlace(p_BpBq_E);
   }
 
+  /// Performs a rigid shift of each column of `F_P_E` as if they contained the
+  /// 6 components of a spatial force. It is assumed the first three elements of
+  /// each column store the rotational component while the last three elements
+  /// store the translational component.
+  /// Given the position of Q in P, each spatial force `F_P_E` about P is
+  /// rigidly shifted to point Q, see Shift(). All quantities are expressed in a
+  /// same common frame E.
+  /// F_Q_E must be non-null and point to a matrix of 6 rows and as many columns
+  /// as input F_P_E, otherwise an assertion failure is triggered.
+  /// @note Aliasing is allowed. That is, F_Q_E can point to the same memory
+  /// referenced by F_P_E, resulting in an in-place operation.
+  static void Shift(const Eigen::Ref<const Matrix6X<T>>& F_P_E,
+                    const Vector3<T>& p_PQ_E, EigenPtr<Matrix6X<T>> F_Q_E) {
+    DRAKE_DEMAND(F_Q_E != nullptr);
+    DRAKE_DEMAND(F_Q_E->cols() == F_P_E.cols());
+    F_Q_E->template topRows<3>() =
+        F_P_E.template topRows<3>() +
+        F_P_E.template bottomRows<3>().colwise().cross(p_PQ_E);
+    F_Q_E->template bottomRows<3>() = F_P_E.template bottomRows<3>();
+  }
+
   /// Given `this` spatial force `F_Bp_E` applied at point P of body B and
   /// expressed in a frame E, this method computes the 6-dimensional dot
   /// product with the spatial velocity `V_IBp_E` of body B at point P,

--- a/multibody/math/test/spatial_algebra_test.cc
+++ b/multibody/math/test/spatial_algebra_test.cc
@@ -584,6 +584,19 @@ TYPED_TEST(ElementsInF6Test, ShiftOperation) {
   // Verify the result.
   SpatialQuantity expected_F_Bo_E(Vector3<T>(2.0, -1.0, -3.0), f_Ao_E);
   EXPECT_TRUE(F_Bo_E.IsApprox(expected_F_Bo_E));
+
+  // We perform the shift operation on a Matrix storing a spatial force in each
+  // column.
+  constexpr int num_forces = 3;
+  const Matrix6X<T> Fmatrix_Ao_E =
+      F_Ao_E.get_coeffs().rowwise().replicate(num_forces);
+  Eigen::Matrix<T, 6, num_forces> Fmatrix_Bo_E;
+  // TODO(amcastro-tri): Implement this version of Shift() for SpatialMomentum.
+  SpatialForce<T>::Shift(Fmatrix_Ao_E, p_AB_E, &Fmatrix_Bo_E);
+  for (int j = 0; j < num_forces; ++j) {
+    SpatialQuantity Fj_Bo_E(Fmatrix_Bo_E.col(j));
+    EXPECT_TRUE(Fj_Bo_E.IsApprox(expected_F_Bo_E));
+  }
 }
 
 // Tests operator+().

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -424,6 +424,20 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "multibody_plant_mass_matrix_test",
+    data = [
+        "//examples/atlas:models",
+        "//manipulation/models/iiwa_description:models",
+    ],
+    deps = [
+        ":plant",
+        "//common:find_resource",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//multibody/parsing",
+    ],
+)
+
+drake_cc_googletest(
     name = "multibody_plant_reaction_forces_test",
     deps = [
         ":plant",

--- a/multibody/plant/test/multibody_plant_mass_matrix_test.cc
+++ b/multibody/plant/test/multibody_plant_mass_matrix_test.cc
@@ -1,0 +1,100 @@
+#include <limits>
+#include <memory>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/tree/revolute_joint.h"
+#include "drake/systems/framework/context.h"
+
+namespace drake {
+
+using multibody::Parser;
+using systems::Context;
+
+namespace multibody {
+namespace {
+
+// We verify the computation of the mass matrix by comparing two significantly
+// different implementations:
+//   - CalcMassMatrix(): uses the Composite Body Algorithm.
+//   - CalcMassMatrixViaInverseDynamics(): uses inverse dynamics to compute each
+//     column of the mass matrix at a time.
+class MultibodyPlantMassMatrixTests : public ::testing::Test {
+ public:
+  void LoadModel(const std::string& file_path) {
+    const std::string model_path = FindResourceOrThrow(file_path);
+    Parser parser(&plant_);
+    parser.AddModelFromFile(model_path);
+    plant_.Finalize();
+  }
+
+  // For a given state stored in `context`, this verifies the computation of the
+  // mass matrix by comparing the results from CalcMassMatrix() and
+  // CalcMassMatrixViaInverseDynamics().
+  void VerifyMassMatrixComputation(const Context<double>& context) {
+    // Compute mass matrix via the Composite Body Algorithm.
+    MatrixX<double> Mcba(plant_.num_velocities(), plant_.num_velocities());
+    plant_.CalcMassMatrix(context, &Mcba);
+
+    // Compute mass matrix using inverse dynamics for each column.
+    MatrixX<double> Mid(plant_.num_velocities(), plant_.num_velocities());
+    plant_.CalcMassMatrixViaInverseDynamics(context, &Mid);
+
+    // Compute a suitable tolerance scaled with the norm of the mass matrix.
+    // Since .norm() computes the Frobenius norm, and num_velocities() is the
+    // squared root of the number of elements in the matrix, this tolerance is
+    // effectively being scaled by the RMS value of the elements in the mass
+    // matrix.
+    const double kTolerance = 10.0 * std::numeric_limits<double>::epsilon() *
+                              Mcba.norm() / plant_.num_velocities();
+    EXPECT_TRUE(
+        CompareMatrices(Mcba, Mid, kTolerance, MatrixCompareType::relative));
+  }
+
+ protected:
+  MultibodyPlant<double> plant_{0.0};
+};
+
+TEST_F(MultibodyPlantMassMatrixTests, IiwaRobot) {
+  LoadModel(
+      "drake/manipulation/models/iiwa_description/sdf/iiwa14_no_collision.sdf");
+  // We did not weld the arm to the world, therefore we expect it to be free.
+  EXPECT_EQ(plant_.num_velocities(), 13);
+
+  // Create a context and store an arbitrary configuration.
+  std::unique_ptr<Context<double>> context = plant_.CreateDefaultContext();
+  const VectorX<double> q0 = VectorX<double>::LinSpaced(
+      plant_.num_positions(), 1, plant_.num_positions());
+  plant_.SetPositions(context.get(), q0);
+  VerifyMassMatrixComputation(*context);
+}
+
+// This Atlas model contains a number of kinematics chains of massless bodies.
+// Therefore this test verifies our implementation can handle this situation.
+TEST_F(MultibodyPlantMassMatrixTests, AtlasRobot) {
+  LoadModel("drake/examples/atlas/urdf/atlas_convex_hull.urdf");
+
+  // Create a context and store an arbitrary configuration.
+  std::unique_ptr<Context<double>> context = plant_.CreateDefaultContext();
+  for (JointIndex joint_index(0); joint_index < plant_.num_joints();
+       ++joint_index) {
+    const Joint<double>& joint = plant_.get_joint(joint_index);
+    // This model only has weld and revolute joints. Weld joints have zero DOFs.
+    if (joint.num_velocities() != 0) {
+      const RevoluteJoint<double>& revolute_joint =
+          dynamic_cast<const RevoluteJoint<double>&>(joint);
+      // Arbitrary non-zero angle.
+      revolute_joint.set_angle(context.get(), 0.5 * joint_index);
+    }
+  }
+  VerifyMassMatrixComputation(*context);
+}
+
+}  // namespace
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -1668,7 +1668,11 @@ class MultibodyTree {
 
   /// See MultibodyPlant method.
   void CalcMassMatrixViaInverseDynamics(
-      const systems::Context<T>& context, EigenPtr<MatrixX<T>> H) const;
+      const systems::Context<T>& context, EigenPtr<MatrixX<T>> M) const;
+
+  /// See MultibodyPlant method.
+  void CalcMassMatrix(const systems::Context<T>& context,
+                      EigenPtr<MatrixX<T>> M) const;
 
   /// See MultibodyPlant method.
   void CalcBiasTerm(


### PR DESCRIPTION
Implements `MBP::CalcMassMatrix()` using the composite body algorithm.

~~@sherm1, this still does not contain a fix for the case of chained zero mass bodies. I'll push in a separate PR so that we have time to settle on a solution.~~

This addresses #12207 but doesn't close it until the zero mass bodies are dealt with.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12764)
<!-- Reviewable:end -->
