### PR TITLE
multibody: Improve error message for invalid spatial inertia

### DIFF
--- a/multibody/tree/spatial_inertia.h
+++ b/multibody/tree/spatial_inertia.h
@@ -10,6 +10,7 @@
 #include "drake/common/drake_bool.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/text_logging.h"
 #include "drake/math/cross_product.h"
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/math/spatial_algebra.h"
@@ -442,9 +443,9 @@ class SpatialInertia {
   typename std::enable_if_t<scalar_predicate<T1>::is_bool> CheckInvariants()
       const {
     if (!IsPhysicallyValid()) {
-      throw std::runtime_error(
-          "The resulting spatial inertia is not physically valid. "
-              "See SpatialInertia::IsPhysicallyValid()");
+      throw std::runtime_error(fmt::format(
+          "The resulting spatial inertia:{} is not physically valid. "
+          "See SpatialInertia::IsPhysicallyValid()", *this));
     }
   }
 
@@ -470,11 +471,14 @@ class SpatialInertia {
 template <typename T> inline
 std::ostream& operator<<(std::ostream& o,
                          const SpatialInertia<T>& M) {
-  return o
+  return o << std::endl
       << " mass = " << M.get_mass() << std::endl
       << " com = [" << M.get_com().transpose() << "]ᵀ" << std::endl
-      << " I = " << std::endl
-      << M.CalcRotationalInertia();
+      << " I =" << std::endl
+      // Like M.CalcRotationalInertia(), but without the IsPhysicallyValid
+      // checks, so that we can use operator<< in error messages.
+      << (M.get_mass() * M.get_unit_inertia().CopyToFullMatrix3())
+      << std::endl;
 }
 
 }  // namespace multibody

--- a/multibody/tree/test/spatial_inertia_test.cc
+++ b/multibody/tree/test/spatial_inertia_test.cc
@@ -130,12 +130,13 @@ GTEST_TEST(SpatialInertia, ShiftOperator) {
   std::stringstream stream;
   stream << std::fixed << std::setprecision(4) << M;
   std::string expected_string =
+      "\n"
       " mass = 2.5000\n"
       " com = [ 0.1000 -0.2000  0.3000]ᵀ\n"
-      " I = \n"
-      "[ 5.0000,  0.2500, -0.2500]\n"
-      "[ 0.2500,  5.7500,  0.5000]\n"
-      "[-0.2500,  0.5000,  6.0000]\n";
+      " I =\n"
+      " 5.0000  0.2500 -0.2500\n"
+      " 0.2500  5.7500  0.5000\n"
+      "-0.2500  0.5000  6.0000\n";
   EXPECT_EQ(expected_string, stream.str());
 }
 
@@ -298,8 +299,14 @@ GTEST_TEST(SpatialInertia, IsPhysicallyValidWithNegativeMass) {
     GTEST_FAIL();
   } catch (std::runtime_error& e) {
     std::string expected_msg =
-        "The resulting spatial inertia is not physically valid. "
-        "See SpatialInertia::IsPhysicallyValid()";
+        "The resulting spatial inertia:\n"
+        " mass = -1\n"
+        " com = [0 0 0]ᵀ\n"
+        " I =\n"
+        "-0.4   -0   -0\n"
+        "  -0 -0.4   -0\n"
+        "  -0   -0 -0.4\n"
+        " is not physically valid. See SpatialInertia::IsPhysicallyValid()";
     EXPECT_EQ(e.what(), expected_msg);
   }
 }
@@ -314,8 +321,14 @@ GTEST_TEST(SpatialInertia, IsPhysicallyValidWithCOMTooFarOut) {
     GTEST_FAIL();
   } catch (std::runtime_error& e) {
     std::string expected_msg =
-        "The resulting spatial inertia is not physically valid. "
-        "See SpatialInertia::IsPhysicallyValid()";
+        "The resulting spatial inertia:\n"
+        " mass = 1\n"
+        " com = [2 0 0]ᵀ\n"
+        " I =\n"
+        "0.4   0   0\n"
+        "  0 0.4   0\n"
+        "  0   0 0.4\n"
+        " is not physically valid. See SpatialInertia::IsPhysicallyValid()";
     EXPECT_EQ(e.what(), expected_msg);
   }
 }


### PR DESCRIPTION
I found this helpful while debugging #12708 for the 0.01 vs 0.001 typos in the SDF file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12766)
<!-- Reviewable:end -->
