### PR TITLE
Link to nightly release notebooks on Binder rather than those on master

### DIFF
--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -8,6 +8,7 @@ FROM robotlocomotion/drake:latest
 ARG NB_USER=jovyan
 ARG NB_UID=1000
 ARG NB_GID=100
+EXPOSE 7000/tcp
 EXPOSE 8888/tcp
 RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get update -qq \

--- a/.binder/README.md
+++ b/.binder/README.md
@@ -7,12 +7,21 @@ intended for use by most developers or users. Please use the
 from Docker Hub instead.*
 
 To create a Docker image and run a Docker container similar to those used by
-[Binder](https://mybinder.org) for debugging purposes, execute the following
-commands from the top level of the Drake Git repository:
+[Binder](https://mybinder.org) for local debugging purposes, execute the
+following `build` and `run` commands from the top level of the Drake Git
+repository:
 
 ```bash
 docker build -f .binder/Dockerfile -t binder .
 docker run --name mybinder -p 8888:8888 binder
+```
+
+The `meshcat-visualizer` is NOT supported by Binder since port 7000 is not
+exposed, but to allow its use locally, substitute the following `run` command
+for the above:
+
+```bash
+docker run --name mybinder -p 7000:7000 -p 8888:8888 binder
 ```
 
 Copy and paste the URL (including the login token) that is displayed in the

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -48,10 +48,10 @@ Core Library
         </tr>
         <tr>
             <td style="text-align:center">
-                <a target="_doc" href="https://drake.mit.edu/doxygen_cxx/group__systems.html">doc</a> | <a target="_tutorial" href="https://mybinder.org/v2/gh/RobotLocomotion/drake/master?filepath=tutorials/dynamical_systems.ipynb">tutorial</a>
+                <a target="_doc" href="https://drake.mit.edu/doxygen_cxx/group__systems.html">doc</a> | <a target="_tutorial" href="https://mybinder.org/v2/gh/RobotLocomotion/drake/nightly-release?filepath=tutorials/dynamical_systems.ipynb">tutorial</a>
             </td>
             <td style="text-align:center">
-                <a target="_doc" href="https://drake.mit.edu/doxygen_cxx/group__solvers.html">doc</a> | <a target="_tutorial" href="https://mybinder.org/v2/gh/RobotLocomotion/drake/master?filepath=tutorials/mathematical_program.ipynb">tutorial</a>
+                <a target="_doc" href="https://drake.mit.edu/doxygen_cxx/group__solvers.html">doc</a> | <a target="_tutorial" href="https://mybinder.org/v2/gh/RobotLocomotion/drake/nightly-release?filepath=tutorials/mathematical_program.ipynb">tutorial</a>
             </td>
             <td style="text-align:center">
                 <a target="_doc" href="https://drake.mit.edu/doxygen_cxx/group__multibody.html">doc</a>
@@ -67,7 +67,7 @@ Tutorials and Examples
 
 We have Python tutorials implemented as Jupyter Notebooks in `the tutorials
 directory of the source tree
-<https://mybinder.org/v2/gh/RobotLocomotion/drake/master?filepath=tutorials/>`_,
+<https://mybinder.org/v2/gh/RobotLocomotion/drake/nightly-release?filepath=tutorials/>`_,
 with text explaining the high-level concepts and each of the main steps.
 
 We have a number of use cases demonstrated in `the examples directory of
@@ -112,7 +112,7 @@ Next steps
 
    gallery
    installation
-   Tutorials <https://mybinder.org/v2/gh/RobotLocomotion/drake/master?filepath=tutorials>
+   Tutorials <https://mybinder.org/v2/gh/RobotLocomotion/drake/nightly-release?filepath=tutorials>
    API Documentation (C++) <doxygen_cxx/index.html#://>
    API Documentation (Python) <pydrake/index.html#://>
    getting_help

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -14,20 +14,19 @@ bazel run //tutorials:mathematical_program
 
 ## Viewing and Running the Notebooks Online
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/RobotLocomotion/drake/master?filepath=tutorials)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/RobotLocomotion/drake/nightly-release?filepath=tutorials)
 
 The notebooks in this folder can be viewed and run online using
-[Binder](https://mybinder.org). To see them from Drake `master` on
-GitHub, please visit:
+[Binder](https://mybinder.org). To see them from the Drake `nightly-release`
+branch on GitHub, please visit:
 
-<https://mybinder.org/v2/gh/RobotLocomotion/drake/master?filepath=tutorials>
+<https://mybinder.org/v2/gh/RobotLocomotion/drake/nightly-release?filepath=tutorials>
 
 Since Binder uses the `robotlocomotion/drake:latest` image on
 [Docker Hub](https://hub.docker.com/r/robotlocomotion/drake) that is published
-once a day, it may be missing features used by the notebooks on `master`. If you
-encounter issues running a notebook, please try a commit from earlier in the
-day, as close as possible following the publication of the
-`robotlocomotion/drake:latest` image.
+once a day from the `nightly-release` branch, it may be missing features used by
+notebooks on `master`. These will be available the next day when the
+`nightly-release` branch is automatically updated.
 
 ## For Developers
 
@@ -38,10 +37,10 @@ display correctly on Binder.*
 When you add a notebook, please make the first cell be a Markdown cell with the tutorial's title and the following preamble:
 
     For instructions on how to run these tutorial notebooks, please see the
-    [README](https://github.com/RobotLocomotion/drake/blob/master/tutorials/README.md).
+    [README](https://github.com/RobotLocomotion/drake/blob/nightly-release/tutorials/README.md).
 
-If appropriate, add a Binder link to the notebook on `master` in the
-relevant documentation in `/doc`, e.g.,
+If appropriate, add a Binder link to the notebook on the `nightly-release`
+branch in the relevant documentation in `/doc`, e.g.,
 ```
-https://mybinder.org/v2/gh/RobotLocomotion/drake/master?filepath=tutorials/notebook.ipynb`
+https://mybinder.org/v2/gh/RobotLocomotion/drake/nightly-release?filepath=tutorials/notebook.ipynb`
 ```

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -31,6 +31,10 @@ day, as close as possible following the publication of the
 
 ## For Developers
 
+*The `meshcat-visualizer` is not supported by Binder since port 7000 is not
+exposed, so tutorials that use `meshcat.Visualizer.jupyter_cell()` will not
+display correctly on Binder.*
+
 When you add a notebook, please make the first cell be a Markdown cell with the tutorial's title and the following preamble:
 
     For instructions on how to run these tutorial notebooks, please see the


### PR DESCRIPTION
Closes #11962.

Also add notes about lack of support for `meshcat-visualizer` on Binder.

Relates #12645.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12774)
<!-- Reviewable:end -->
