### PR TITLE
styleguide: Bump to latest commit

### DIFF
--- a/tools/workspace/styleguide/BUILD.bazel
+++ b/tools/workspace/styleguide/BUILD.bazel
@@ -1,8 +1,12 @@
 # -*- python -*-
 
-# This file exists to make our directory into a Bazel package, so that our
-# neighboring *.bzl file can be loaded elsewhere.
-
 load("//tools/lint:lint.bzl", "add_lint_tests")
+load("@drake//tools/skylark:py.bzl", "py_test")
+
+py_test(
+    name = "cpplint_unittest",
+    size = "small",
+    srcs = ["@styleguide//:cpplint_unittest"],
+)
 
 add_lint_tests()

--- a/tools/workspace/styleguide/package.BUILD.bazel
+++ b/tools/workspace/styleguide/package.BUILD.bazel
@@ -1,6 +1,6 @@
 # -*- python -*-
 
-load("@drake//tools/skylark:py.bzl", "py_binary", "py_test")
+load("@drake//tools/skylark:py.bzl", "py_binary")
 
 licenses(["notice"])  # BSD-3-Clause
 
@@ -21,12 +21,16 @@ alias(
     actual = ":cpplint_binary",
 )
 
-py_test(
+# We use py_binary here because externals' tests are not run by
+# default during `bazel test //...`, so `py_test` here would be
+# misleading.  We can't even `alias()` the test into Drake due to
+# https://github.com/bazelbuild/bazel/issues/10893
+py_binary(
     name = "cpplint_unittest",
-    size = "small",
     srcs = ["cpplint/cpplint_unittest.py"],
-    data = ["cpplint/cpplint_test_header.h"],
-    deps = [
-        ":cpplint_py",
+    data = [
+        "cpplint/cpplint_test_header.h",
     ],
+    deps = ["cpplint_binary"],
+    testonly = 1,
 )

--- a/tools/workspace/styleguide/repository.bzl
+++ b/tools/workspace/styleguide/repository.bzl
@@ -8,8 +8,8 @@ def styleguide_repository(
     github_archive(
         name = name,
         repository = "RobotLocomotion/styleguide",
-        commit = "849a106b536d8dc5f504d59bc6b0446c608d57f7",
-        sha256 = "553533e9f0159e54f7768e7655744a8a50dca931fa2fb01bcffc2725f843438e",  # noqa
+        commit = "97ac1c4e58c06f9c774ed02321cf716a21e0342d",
+        sha256 = "7d8adeac7b659ec082f8e1147301be431980f4c3116d3e6b1def691fccbbf47e",  # noqa
         build_file = "@drake//tools/workspace/styleguide:package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
Towards https://github.com/RobotLocomotion/styleguide/pull/28

From  logs:
> [2020-03-02T21:17:17.152Z] //tools/workspace/styleguide:cpplint_unittest                            PASSED in 1.2s


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12776)
<!-- Reviewable:end -->
