### PR TITLE
Add doc about the availability of force/torque sensor

### DIFF
--- a/systems/systems.h
+++ b/systems/systems.h
@@ -58,7 +58,24 @@
 
 /// @addtogroup sensor_systems
 /// @{
-/// Models of sensors that operate as Systems in a block diagram.
+/// Drake provides a variety of capabilities for sensor modeling. Some sensors
+/// are offered as Systems in a block diagram. These sensors are listed in the
+/// following section as classes. On the other hand, Drake has some internal
+/// functionalities, which can be used to model a sensor. The
+/// **Force/Torque Sensor** falls into this catergory.
+///
+/// A **Force/Torque Sensor** measures nothing but the reaction force/torque
+/// of a @ref drake::multibody::WeldJoint "WeldJoint". The
+/// @ref drake::multibody::MultibodyPlant "MultibodyPlant" class provides the
+/// @ref drake::multibody::MultibodyPlant::get_reaction_forces_output_port()
+/// "get_reaction_forces_output_port()" method that returns the reaction
+/// @ref drake::multibody::SpatialForce "SpatialForce" of all the joints. You
+/// only need to extract the entries for the joints in which you are interested.
+/// To simulate a Force/Torque sensor, you need to either a) define a
+/// fixed joint for the force/torque sensor in the SDF/URDF model file or
+/// b) add a @ref drake::multibody::WeldJoint "WeldJoint" between two bodies.
+/// This joint will then serve as the Force/Torque sensor. You can also
+/// refer to *planar_gripper* for an example.
 /// @}
 
 /// @addtogroup manipulation_systems


### PR DESCRIPTION
Add some documentation about how to use the `get_reaction_forces_output_port()` to model a force torque sensor.

Resolves #12790

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12791)
<!-- Reviewable:end -->
