### PR TITLE
framework: Remove the ability to override allocation methods

### DIFF
--- a/attic/multibody/rigid_body_plant/rigid_body_plant.h
+++ b/attic/multibody/rigid_body_plant/rigid_body_plant.h
@@ -409,11 +409,6 @@ class RigidBodyPlant : public LeafSystem<T> {
   // exception if at least one of the ports is not connected.
   VectorX<T> EvaluateActuatorInputs(const Context<T>& context) const;
 
-  // LeafSystem<T> overrides.
-
-  std::unique_ptr<ContinuousState<T>> AllocateContinuousState() const override;
-  std::unique_ptr<DiscreteValues<T>> AllocateDiscreteState() const override;
-
   // System<T> overrides.
 
   void DoCalcTimeDerivatives(const Context<T>& context,

--- a/examples/rod2d/rod2d.cc
+++ b/examples/rod2d/rod2d.cc
@@ -42,6 +42,8 @@ Rod2D<T>::Rod2D(SystemType system_type, double dt)
     // variables.
     this->DeclareContinuousState(Rod2dStateVector<T>(), 3, 3, 0);  // q, v, z
   }
+  // TODO(edrumwri): When type is SystemType::kPiecewiseDAE, allocate the
+  // abstract mode variables.
 
   this->DeclareInputPort(systems::kVectorValued, 3);
   state_output_port_ = &this->DeclareVectorOutputPort(
@@ -1029,19 +1031,6 @@ void Rod2D<T>::DoCalcTimeDerivatives(
     // TODO(edrumwri): Implement the piecewise DAE approach.
     throw std::domain_error(
         "Rod2D<T>::DoCalcTimeDerivatives: piecewise DAE isn't implemented yet");
-  }
-}
-
-/// Allocates the abstract state (for piecewise DAE systems).
-template <typename T>
-std::unique_ptr<systems::AbstractValues> Rod2D<T>::AllocateAbstractState()
-    const {
-  if (system_type_ == SystemType::kPiecewiseDAE) {
-    // TODO(edrumwri): Allocate the abstract mode variables.
-    return std::make_unique<systems::AbstractValues>();
-  } else {
-    // Discretized and continuous approaches need no abstract variables.
-    return std::make_unique<systems::AbstractValues>();
   }
 }
 

--- a/examples/rod2d/rod2d.h
+++ b/examples/rod2d/rod2d.h
@@ -501,8 +501,6 @@ class Rod2D : public systems::LeafSystem<T> {
   T GetSlidingVelocityTolerance() const;
   MatrixX<T> solve_inertia(const MatrixX<T>& B) const;
   int get_k(const systems::Context<T>& context) const;
-  std::unique_ptr<systems::AbstractValues> AllocateAbstractState()
-      const override;
   void CopyStateOut(const systems::Context<T>& context,
                     systems::BasicVector<T>* output) const;
   void CopyPoseOut(const systems::Context<T>& context,

--- a/manipulation/planner/robot_plan_interpolator.cc
+++ b/manipulation/planner/robot_plan_interpolator.cc
@@ -24,16 +24,6 @@ using multibody::BodyIndex;
 using multibody::JointIndex;
 using trajectories::PiecewisePolynomial;
 
-namespace {
-
-// This corresponds to the actual plan.
-constexpr int kAbsStateIdxPlan = 0;
-// This corresponds to a flag that indicates whether the plan has been
-// initialized properly by RobotPlanInterpolator::Initialize().
-constexpr int kAbsStateIdxInitFlag = 1;
-
-}  // namespace
-
 // TODO(sammy-tri) If we had version of Trajectory which supported
 // outputting the derivatives in value(), we could avoid keeping track
 // of multiple polynomials below.
@@ -102,38 +92,31 @@ RobotPlanInterpolator::RobotPlanInterpolator(
               &RobotPlanInterpolator::OutputAccel)
           .get_index();
 
+  // This corresponds to the actual plan.
+  plan_index_ = this->DeclareAbstractState(
+      std::make_unique<Value<PlanData>>());
+  // Flag indicating whether RobotPlanInterpolator::Initialize has been called.
+  init_flag_index_ = this->DeclareAbstractState(
+      std::make_unique<Value<bool>>(false));
+
   this->DeclarePeriodicUnrestrictedUpdate(update_interval, 0);
 }
 
 RobotPlanInterpolator::~RobotPlanInterpolator() {}
 
-std::unique_ptr<systems::AbstractValues>
-RobotPlanInterpolator::AllocateAbstractState() const {
-  std::vector<std::unique_ptr<AbstractValue>> abstract_vals(2);
-  const PlanData default_plan;
-  // Actual plan.
-  abstract_vals[kAbsStateIdxPlan] =
-      AbstractValue::Make<PlanData>(default_plan);
-  // Flag indicating whether RobotPlanInterpolator::Initialize() has
-  // been called.
-  abstract_vals[kAbsStateIdxInitFlag] =
-      AbstractValue::Make<bool>(false);
-  return std::make_unique<systems::AbstractValues>(std::move(abstract_vals));
-}
-
 void RobotPlanInterpolator::SetDefaultState(
     const systems::Context<double>&,
     systems::State<double>* state) const {
   PlanData& plan =
-      state->get_mutable_abstract_state<PlanData>(kAbsStateIdxPlan);
+      state->get_mutable_abstract_state<PlanData>(plan_index_);
   plan = PlanData();
-  state->get_mutable_abstract_state<bool>(kAbsStateIdxInitFlag) = false;
+  state->get_mutable_abstract_state<bool>(init_flag_index_) = false;
 }
 
 void RobotPlanInterpolator::OutputState(const systems::Context<double>& context,
                                   systems::BasicVector<double>* output) const {
-  const PlanData& plan = context.get_abstract_state<PlanData>(kAbsStateIdxPlan);
-  const bool inited = context.get_abstract_state<bool>(kAbsStateIdxInitFlag);
+  const PlanData& plan = context.get_abstract_state<PlanData>(plan_index_);
+  const bool inited = context.get_abstract_state<bool>(init_flag_index_);
   DRAKE_DEMAND(inited);
 
   Eigen::VectorBlock<VectorX<double>> output_vec =
@@ -149,8 +132,8 @@ void RobotPlanInterpolator::OutputState(const systems::Context<double>& context,
 void RobotPlanInterpolator::OutputAccel(
     const systems::Context<double>& context,
     systems::BasicVector<double>* output) const {
-  const PlanData& plan = context.get_abstract_state<PlanData>(kAbsStateIdxPlan);
-  const bool inited = context.get_abstract_state<bool>(kAbsStateIdxInitFlag);
+  const PlanData& plan = context.get_abstract_state<PlanData>(plan_index_);
+  const bool inited = context.get_abstract_state<bool>(init_flag_index_);
   DRAKE_DEMAND(inited);
 
   Eigen::VectorBlock<VectorX<double>> output_acceleration_vec =
@@ -171,7 +154,7 @@ void RobotPlanInterpolator::MakeFixedPlan(
   DRAKE_DEMAND(state != nullptr);
   DRAKE_DEMAND(q0.size() == plant_.num_positions());
   PlanData& plan =
-      state->get_mutable_abstract_state<PlanData>(kAbsStateIdxPlan);
+      state->get_mutable_abstract_state<PlanData>(plan_index_);
 
   std::vector<Eigen::MatrixXd> knots(2, q0);
   std::vector<double> times{0., 1.};
@@ -187,7 +170,7 @@ void RobotPlanInterpolator::Initialize(double plan_start_time,
                                        systems::State<double>* state) const {
   DRAKE_DEMAND(state != nullptr);
   MakeFixedPlan(plan_start_time, q0, state);
-  state->get_mutable_abstract_state<bool>(kAbsStateIdxInitFlag) = true;
+  state->get_mutable_abstract_state<bool>(init_flag_index_) = true;
 }
 
 void RobotPlanInterpolator::DoCalcUnrestrictedUpdate(
@@ -195,7 +178,7 @@ void RobotPlanInterpolator::DoCalcUnrestrictedUpdate(
     const std::vector<const systems::UnrestrictedUpdateEvent<double>*>&,
     systems::State<double>* state) const {
   PlanData& plan =
-      state->get_mutable_abstract_state<PlanData>(kAbsStateIdxPlan);
+      state->get_mutable_abstract_state<PlanData>(plan_index_);
   const robot_plan_t& plan_input =
       get_plan_input_port().Eval<robot_plan_t>(context);
 

--- a/manipulation/planner/robot_plan_interpolator.h
+++ b/manipulation/planner/robot_plan_interpolator.h
@@ -76,9 +76,6 @@ class RobotPlanInterpolator : public systems::LeafSystem<double> {
   void SetDefaultState(const systems::Context<double>& context,
                        systems::State<double>* state) const override;
 
-  std::unique_ptr<systems::AbstractValues> AllocateAbstractState()
-      const override;
-
   void DoCalcUnrestrictedUpdate(const systems::Context<double>& context,
             const std::vector<const systems::UnrestrictedUpdateEvent<double>*>&,
             systems::State<double>* state) const override;
@@ -101,6 +98,8 @@ class RobotPlanInterpolator : public systems::LeafSystem<double> {
   const int plan_input_port_{};
   int state_output_port_{-1};
   int acceleration_output_port_{-1};
+  systems::AbstractStateIndex plan_index_;
+  systems::AbstractStateIndex init_flag_index_;
   multibody::MultibodyPlant<double> plant_{0.0};
   const InterpolatorType interp_type_;
 };

--- a/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.cc
+++ b/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.cc
@@ -31,6 +31,8 @@ SchunkWsgTrajectoryGenerator::SchunkWsgTrajectoryGenerator(int input_size,
           this->DeclareVectorOutputPort(
               BasicVector<double>(1),
               &SchunkWsgTrajectoryGenerator::OutputForce).get_index()) {
+  this->DeclareDiscreteState(
+      SchunkWsgTrajectoryGeneratorStateVector<double>());
   // The update period below matches the polling rate from
   // drake-schunk-driver.
   this->DeclarePeriodicDiscreteUpdate(0.05);
@@ -97,12 +99,6 @@ void SchunkWsgTrajectoryGenerator::DoCalcDiscreteVariableUpdates(
     new_traj_state->set_trajectory_start_time(
         last_traj_state->trajectory_start_time());
   }
-}
-
-std::unique_ptr<DiscreteValues<double>>
-SchunkWsgTrajectoryGenerator::AllocateDiscreteState() const {
-  return std::make_unique<DiscreteValues<double>>(
-      std::make_unique<SchunkWsgTrajectoryGeneratorStateVector<double>>());
 }
 
 void SchunkWsgTrajectoryGenerator::UpdateTrajectory(

--- a/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.h
+++ b/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.h
@@ -69,9 +69,6 @@ class SchunkWsgTrajectoryGenerator : public systems::LeafSystem<double> {
       const std::vector<const systems::DiscreteUpdateEvent<double>*>& events,
       systems::DiscreteValues<double>* discrete_state) const override;
 
-  std::unique_ptr<systems::DiscreteValues<double>> AllocateDiscreteState()
-      const override;
-
   void UpdateTrajectory(double cur_position, double target_position) const;
 
   /// The minimum change between the last received command and the

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -282,9 +282,7 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
   }
   /// @endcond
 
-  /// Aggregates the time derivatives from each subsystem into a
-  /// DiagramContinuousState.
-  std::unique_ptr<ContinuousState<T>> AllocateTimeDerivatives() const override {
+  std::unique_ptr<ContinuousState<T>> AllocateTimeDerivatives() const final {
     std::vector<std::unique_ptr<ContinuousState<T>>> sub_derivatives;
     for (const auto& system : registered_systems_) {
       sub_derivatives.push_back(system->AllocateTimeDerivatives());
@@ -293,10 +291,7 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
         std::move(sub_derivatives));
   }
 
-  /// Aggregates the discrete update variables from each subsystem into a
-  /// DiagramDiscreteVariables.
-  std::unique_ptr<DiscreteValues<T>> AllocateDiscreteVariables()
-      const override {
+  std::unique_ptr<DiscreteValues<T>> AllocateDiscreteVariables() const final {
     std::vector<std::unique_ptr<DiscreteValues<T>>> sub_discretes;
     for (const auto& system : registered_systems_) {
       sub_discretes.push_back(system->AllocateDiscreteVariables());

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -137,21 +137,14 @@ class System : public SystemBase {
   /// Returns a ContinuousState of the same size as the continuous_state
   /// allocated in CreateDefaultContext. The simulator will provide this state
   /// as the output argument to EvalTimeDerivatives.
-  ///
-  /// By default, allocates no derivatives. Systems with continuous state
-  /// variables should override.
-  virtual std::unique_ptr<ContinuousState<T>> AllocateTimeDerivatives() const {
-    return nullptr;
-  }
+  virtual std::unique_ptr<ContinuousState<T>> AllocateTimeDerivatives() const
+      = 0;
 
   /// Returns a DiscreteState of the same dimensions as the discrete_state
   /// allocated in CreateDefaultContext. The simulator will provide this state
   /// as the output argument to Update.
-  /// By default, allocates nothing. Systems with discrete state variables
-  /// should override.
-  virtual std::unique_ptr<DiscreteValues<T>> AllocateDiscreteVariables() const {
-    return nullptr;
-  }
+  virtual std::unique_ptr<DiscreteValues<T>> AllocateDiscreteVariables() const
+      = 0;
 
   /// This convenience method allocates a context using AllocateContext() and
   /// sets its default values using SetDefaultContext().

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -1620,7 +1620,11 @@ class SecondOrderStateVector : public BasicVector<double> {
 // A minimal system that has second-order state.
 class SecondOrderStateSystem : public LeafSystem<double> {
  public:
-  SecondOrderStateSystem() { DeclareInputPort(kVectorValued, 1); }
+  SecondOrderStateSystem() {
+    DeclareInputPort(kVectorValued, 1);
+    DeclareContinuousState(SecondOrderStateVector{},
+                           1 /* num_q */, 1 /* num_v */, 0 /* num_z */);
+  }
 
   SecondOrderStateVector* x(Context<double>* context) const {
     return dynamic_cast<SecondOrderStateVector*>(
@@ -1628,13 +1632,6 @@ class SecondOrderStateSystem : public LeafSystem<double> {
   }
 
  protected:
-  std::unique_ptr<ContinuousState<double>> AllocateContinuousState()
-      const override {
-    return std::make_unique<ContinuousState<double>>(
-        std::make_unique<SecondOrderStateVector>(), 1 /* num_q */,
-        1 /* num_v */, 0 /* num_z */);
-  }
-
   // qdot = 2 * v.
   void DoMapVelocityToQDot(
       const Context<double>& context,

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -54,6 +54,11 @@ class TestSystem : public System<double> {
     return std::make_unique<ContinuousState<double>>();
   }
 
+  std::unique_ptr<DiscreteValues<double>> AllocateDiscreteVariables()
+      const override {
+    return std::make_unique<DiscreteValues<double>>();
+  }
+
   std::unique_ptr<CompositeEventCollection<double>>
   AllocateCompositeEventCollection() const override {
     return std::make_unique<LeafCompositeEventCollection<double>>();
@@ -587,6 +592,11 @@ class ValueIOTestSystem : public System<T> {
 
   std::unique_ptr<ContinuousState<T>> AllocateTimeDerivatives() const override {
     return std::make_unique<ContinuousState<T>>();
+  }
+
+  std::unique_ptr<DiscreteValues<T>> AllocateDiscreteVariables() const
+      override {
+    return std::make_unique<DiscreteValues<T>>();
   }
 
   std::unique_ptr<ContextBase> DoAllocateContext() const final {


### PR DESCRIPTION
Subclasses should use the model vector (or model value) APIs to declare state, parameters, etc. instead of overriding these virtual methods.

Unfortunately there is no good way to deprecate "you can't override this anymore", especially for public methods.  Initially I'd tried a runtime warning in this case, and then a runtime exception, but after some experimentation I feel like a up-front compilation error is better than either of those two options.

This is a good reason why we should strongly prefer NVI for public methods that are intended to be overridden.

The model vector (/ model value) APIs have been in place for quite a while, so users should be able to rewrite their code first and then upgrade to this commit afterwards.

Towards #12560.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12792)
<!-- Reviewable:end -->
