### PR TITLE
Clean up Doxygen to prune junk from overview pages

### DIFF
--- a/bindings/pydrake/common/wrap_pybind.h
+++ b/bindings/pydrake/common/wrap_pybind.h
@@ -15,6 +15,7 @@
 namespace drake {
 namespace pydrake {
 
+#ifndef DRAKE_DOXYGEN_CXX
 namespace internal {
 
 template <typename T, typename = void>
@@ -43,6 +44,7 @@ struct wrap_callback<std::function<Signature>>
     : public wrap_callback<const std::function<Signature>&> {};
 
 }  // namespace internal
+#endif  // DRAKE_DOXYGEN_CXX
 
 /// Ensures that any `std::function<>` arguments are wrapped such that any `T&`
 /// (which can infer for `T = const U`) is wrapped as `U*` (and conversely

--- a/common/eigen_autodiff_limits.h
+++ b/common/eigen_autodiff_limits.h
@@ -13,7 +13,7 @@
 namespace std {
 template <typename T>
 class numeric_limits<Eigen::AutoDiffScalar<T>>
-    : public numeric_limits<typename T::Scalar> {};
+    : public std::numeric_limits<typename T::Scalar> {};
 
 }  // namespace std
 

--- a/common/symbolic_expression.h
+++ b/common/symbolic_expression.h
@@ -797,7 +797,7 @@ struct equal_to<drake::symbolic::Expression> {
 /* Provides std::numeric_limits<drake::symbolic::Expression>. */
 template <>
 struct numeric_limits<drake::symbolic::Expression>
-    : public numeric_limits<double> {};
+    : public std::numeric_limits<double> {};
 
 /// Provides std::uniform_real_distribution, U(a, b), for symbolic expressions.
 ///

--- a/doc/Doxyfile_CXX.in
+++ b/doc/Doxyfile_CXX.in
@@ -122,12 +122,7 @@ WARN_LOGFILE           = "@WARN_LOGFILE@"
 #---------------------------------------------------------------------------
 INPUT                  = "@INPUT_ROOT@"
 INPUT_ENCODING         = UTF-8
-FILE_PATTERNS          = *.c \
-                         *.cc \
-                         *.cxx \
-                         *.cpp \
-                         *.c++ \
-                         *.h \
+FILE_PATTERNS          = *.h \
                          *.hh \
                          *.hxx \
                          *.hpp \
@@ -135,8 +130,18 @@ FILE_PATTERNS          = *.c \
 RECURSIVE              = YES
 EXCLUDE                =
 EXCLUDE_SYMLINKS       = NO
-EXCLUDE_PATTERNS       = "@INPUT_ROOT@/*/dev/*" "@INPUT_ROOT@/drake/attic/*"
-EXCLUDE_SYMBOLS        =
+EXCLUDE_PATTERNS       = "@INPUT_ROOT@/*/dev/*" \
+                         "@INPUT_ROOT@/*/test/*" \
+                         "@INPUT_ROOT@/*/MG/*" \
+                         "@INPUT_ROOT@/drake/attic/*"
+EXCLUDE_SYMBOLS        = "*::internal" "pybind11"
+# Sometimes using-statements confuse Doxygen and end up placing forward
+# declarations into a namespace that lacks the intiial "drake::" prefix.
+# Tell Doxygen to fully omit some top-level namespaces that will never
+# have any real documentation inside them.
+EXCLUDE_SYMBOLS        += "internal" "lcm" "manipulation"
+# Don't document our (obvious) Eigen overloads like "isinf", etc.
+EXCLUDE_SYMBOLS        += "Eigen"
 EXAMPLE_PATH           =
 EXAMPLE_PATTERNS       =
 EXAMPLE_RECURSIVE      = NO

--- a/examples/bouncing_ball/bouncing_ball.cc
+++ b/examples/bouncing_ball/bouncing_ball.cc
@@ -3,4 +3,4 @@
 #include "drake/common/default_scalars.h"
 
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
-    class ::drake::bouncing_ball::BouncingBall)
+    class ::drake::examples::bouncing_ball::BouncingBall)

--- a/examples/bouncing_ball/bouncing_ball.h
+++ b/examples/bouncing_ball/bouncing_ball.h
@@ -8,6 +8,7 @@
 #include "drake/systems/framework/witness_function.h"
 
 namespace drake {
+namespace examples {
 namespace bouncing_ball {
 
 /// Dynamical representation of the idealized hybrid dynamics
@@ -151,4 +152,5 @@ class BouncingBall final : public systems::LeafSystem<T> {
 };
 
 }  // namespace bouncing_ball
+}  // namespace examples
 }  // namespace drake

--- a/examples/bouncing_ball/test/bouncing_ball_test.cc
+++ b/examples/bouncing_ball/test/bouncing_ball_test.cc
@@ -9,6 +9,7 @@
 #include "drake/systems/framework/test_utilities/scalar_conversion.h"
 
 namespace drake {
+namespace examples {
 namespace bouncing_ball {
 namespace {
 
@@ -221,4 +222,5 @@ TEST_F(BouncingBallTest, Simulate) {
 
 }  // namespace
 }  // namespace bouncing_ball
+}  // namespace examples
 }  // namespace drake

--- a/geometry/render/render_label.h
+++ b/geometry/render/render_label.h
@@ -103,6 +103,14 @@ class RenderLabel {
     return value_ < other.value_;
   }
 
+  /** Implements the @ref hash_append concept. */
+  template <class HashAlgorithm>
+  friend void hash_append(
+      HashAlgorithm& hasher, const RenderLabel& item) noexcept {
+    using drake::hash_append;
+    hash_append(hasher, item.value_);
+  }
+
   /** @name  The reserved render labels
 
    See class documentation on
@@ -171,6 +179,6 @@ namespace std {
  @relates RenderLabel  */
 template <>
 struct hash<drake::geometry::render::RenderLabel>
- : public hash<drake::geometry::render::RenderLabel::ValueType> {};
+  : public drake::DefaultHash {};
 
 }  // namespace std

--- a/multibody/benchmarks/free_body/free_body.cc
+++ b/multibody/benchmarks/free_body/free_body.cc
@@ -7,6 +7,7 @@
 #include "drake/math/quaternion.h"
 
 namespace drake {
+namespace multibody {
 namespace benchmarks {
 namespace free_body {
 
@@ -131,4 +132,5 @@ FreeBody::CalculateExactTranslationalSolution(const double t) const {
 
 }  // namespace free_body
 }  // namespace benchmarks
+}  // namespace multibody
 }  // namespace drake

--- a/multibody/benchmarks/free_body/free_body.h
+++ b/multibody/benchmarks/free_body/free_body.h
@@ -10,6 +10,7 @@
 #include "drake/math/rotation_matrix.h"
 
 namespace drake {
+namespace multibody {
 namespace benchmarks {
 namespace free_body {
 
@@ -244,4 +245,5 @@ class FreeBody {
 
 }  // namespace free_body
 }  // namespace benchmarks
+}  // namespace multibody
 }  // namespace drake

--- a/multibody/benchmarks/free_body/test/multibody_plant_free_body_test.cc
+++ b/multibody/benchmarks/free_body/test/multibody_plant_free_body_test.cc
@@ -23,6 +23,7 @@
 #include "drake/systems/analysis/simulator.h"
 
 namespace drake {
+namespace multibody {
 namespace benchmarks {
 namespace free_body {
 namespace {
@@ -483,4 +484,5 @@ GTEST_TEST(uniformSolidCylinderTorqueFree, testKaneExactSolution) {
 }  // namespace
 }  // namespace free_body
 }  // namespace benchmarks
+}  // namespace multibody
 }  // namespace drake

--- a/solvers/csdp_solver_internal.h
+++ b/solvers/csdp_solver_internal.h
@@ -6,12 +6,14 @@
 #include <unordered_map>
 #include <vector>
 
+#ifndef DRAKE_DOXYGEN_CXX
 namespace csdp {
 extern "C" {
 // TODO(Jeremy.Nimmer): include this header as <csdp/declarations.h>
 #include <declarations.h>
 }  // extern C
 }  // namespace csdp
+#endif  // DOXYGEN_CXX
 
 #include <Eigen/Core>
 #include <Eigen/Sparse>

--- a/systems/rendering/pose_aggregator.h
+++ b/systems/rendering/pose_aggregator.h
@@ -13,7 +13,7 @@ namespace drake {
 namespace systems {
 namespace rendering {
 
-namespace pose_aggregator_internal { struct InputRecord; }
+namespace internal { struct PoseAggregatorInputRecord; }
 
 /// A container with references to the input port for the pose input, and a
 /// reference to the input port for the velocity input.
@@ -126,7 +126,7 @@ class PoseAggregator : public LeafSystem<T> {
   // This is the method used by the allocator for the output port.
   PoseBundle<T> MakePoseBundle() const;
 
-  using InputRecord = pose_aggregator_internal::InputRecord;
+  using InputRecord = internal::PoseAggregatorInputRecord;
 
   // Returns an InputRecord for a generic single pose input.
   static InputRecord MakeSinglePoseInputRecord(const std::string& name,
@@ -151,12 +151,12 @@ class PoseAggregator : public LeafSystem<T> {
 };
 
 /** @cond */
-namespace pose_aggregator_internal {
+namespace internal {
 
 // A private data structure of PoseAggregator.  It is not nested within
 // PoseAggregator because it does not (and should not) depend on the type
 // parameter @p T.
-struct InputRecord {
+struct PoseAggregatorInputRecord {
   enum PoseInputType {
     kSinglePose = 1,
     kSingleVelocity = 2,
@@ -171,7 +171,7 @@ struct InputRecord {
   int model_instance_id{-1};
 };
 
-}  // namespace pose_aggregator_internal
+}  // namespace internal
 /** @endcond */
 
 }  // namespace rendering


### PR DESCRIPTION
Only parse headers, not cc files.
Exclude all unit test headers not in a test_utilities library.
Exclude all internal namespaces.
Exclude MG (autogenerated MotionGenesis sources).
Exclude top-level namespaces other than drake (Eigen, pybind11, false positives from using-statements, etc.)

Use correct bouncing_ball namespace in code.
Use correct free_body namespace in code.
Use correct pose_aggregator_internal namespace in code.
Use correct spelling for RenderLabel hashing.
Hide csdp namespace in code.

The goal is that https://drake.mit.edu/doxygen_cxx/namespaces.html and https://drake.mit.edu/doxygen_cxx/annotated.html listings have less junk.

Closes #11130.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12796)
<!-- Reviewable:end -->
