### PR TITLE
Stream sorted pair

### DIFF
--- a/common/sorted_pair.h
+++ b/common/sorted_pair.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <iostream>
 #include <utility>
 
 #include "drake/common/drake_copyable.h"
@@ -89,6 +90,14 @@ struct SortedPair {
   T first_{};          // The first of the two objects, according to operator<.
   T second_{};         // The second of the two objects, according to operator<.
 };
+
+/// Support writing a SortedPair to a stream (conditional on the support of
+/// writing the underlying type T to a stream).
+template <typename T>
+inline std::ostream& operator<<(std::ostream& out, const SortedPair<T>& pair) {
+  out << "(" << pair.first() << ", " << pair.second() << ")";
+  return out;
+}
 
 /// Two pairs of the same type are equal iff their members are equal after
 /// sorting.

--- a/common/test/sorted_pair_test.cc
+++ b/common/test/sorted_pair_test.cc
@@ -1,5 +1,6 @@
 #include "drake/common/sorted_pair.h"
 
+#include <sstream>
 #include <unordered_map>
 #include <vector>
 
@@ -117,6 +118,14 @@ GTEST_TEST(SortedPair, VectorExp) {
 // Tests the MakeSortedPair operator.
 GTEST_TEST(SortedPair, MakeSortedPair) {
   EXPECT_EQ(SortedPair<int>(1, 2), MakeSortedPair(1, 2));
+}
+
+// Tests the streaming support.
+GTEST_TEST(SortedPair, WriteToStream) {
+  SortedPair<int> pair{8, 7};
+  std::stringstream ss;
+  ss << pair;
+  EXPECT_EQ(ss.str(), "(7, 8)");
 }
 
 }  // namespace


### PR DESCRIPTION
This gives the SortedPair type to be written to an output stream, contingent on the underlying types being writable. A convenient piece of functionality for tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12801)
<!-- Reviewable:end -->
