### PR TITLE
Allow specific cache entries to be initially disabled

### DIFF
--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -293,7 +293,7 @@ struct Impl {
         .def("GetOutputPort", &System<T>::GetOutputPort, py_reference_internal,
             py::arg("port_name"), doc.System.GetOutputPort.doc)
         .def("DeclareInputPort",
-            overload_cast_explicit<const InputPort<T>&,
+            overload_cast_explicit<InputPort<T>&,
                 std::variant<std::string, UseDefaultName>, PortDataType, int,
                 std::optional<RandomDistribution>>(&PySystem::DeclareInputPort),
             py_reference_internal, py::arg("name"), py::arg("type"),
@@ -301,7 +301,7 @@ struct Impl {
             doc.System.DeclareInputPort.doc_4args)
         .def("DeclareInputPort",
             overload_cast_explicit<  // BR
-                const InputPort<T>&, PortDataType, int,
+                InputPort<T>&, PortDataType, int,
                 std::optional<RandomDistribution>>(&PySystem::DeclareInputPort),
             py_reference_internal, py::arg("type"), py::arg("size"),
             py::arg("random_type") = std::nullopt)
@@ -480,8 +480,7 @@ Note: The above is for the C++ documentation. For Python, use
             py_reference_internal, py::arg("name"), py::arg("model_value"),
             doc.LeafSystem.DeclareAbstractInputPort.doc_2args)
         .def("DeclareAbstractInputPort",
-            [](PyLeafSystem* self,
-                const std::string& name) -> const InputPort<T>& {
+            [](PyLeafSystem* self, const std::string& name) -> InputPort<T>& {
               WarnDeprecated(
                   "`DeclareAbstractInputPort(self, name)` is deprecated. "
                   "Please use `(self, name, model_value)` instead.");
@@ -520,7 +519,7 @@ Note: The above is for the C++ documentation. For Python, use
             [](PyLeafSystem* self, std::string name,
                 const BasicVector<T>& model_vector,
                 std::optional<RandomDistribution> random_type)
-                -> const InputPort<T>& {
+                -> InputPort<T>& {
               return self->DeclareVectorInputPort(
                   name, model_vector, random_type);
             },

--- a/systems/framework/leaf_output_port.h
+++ b/systems/framework/leaf_output_port.h
@@ -65,6 +65,15 @@ class LeafOutputPort final : public OutputPort<T> {
     return *cache_entry_;
   }
 
+  /** (Debugging) Specifies that caching should be disabled for this output
+  port when a Context is first allocated. This is useful if you have observed
+  different behavior with caching on or off and would like to determine if
+  the problem is caused by this port.
+  @see CacheEntry::disable_caching_by_default() */
+  void disable_caching_by_default() {
+    cache_entry_->disable_caching_by_default();
+  }
+
  private:
   friend class internal::FrameworkFactory;
 
@@ -73,7 +82,7 @@ class LeafOutputPort final : public OutputPort<T> {
   LeafOutputPort(const System<T>* system, SystemBase* system_base,
                  std::string name, OutputPortIndex index,
                  DependencyTicket ticket, PortDataType data_type, int size,
-                 const CacheEntry* cache_entry)
+                 CacheEntry* cache_entry)
       : OutputPort<T>(system, system_base, std::move(name), index, ticket,
                       data_type, size),
         cache_entry_(cache_entry) {
@@ -100,7 +109,7 @@ class LeafOutputPort final : public OutputPort<T> {
     return {std::nullopt, cache_entry().ticket()};
   };
 
-  const CacheEntry* const cache_entry_;
+  CacheEntry* const cache_entry_;
 };
 
 }  // namespace systems

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -1575,7 +1575,7 @@ class LeafSystem : public System<T> {
   /// DeclareInequalityConstraint()).
   ///
   /// @see System::DeclareInputPort() for more information.
-  const InputPort<T>& DeclareVectorInputPort(
+  InputPort<T>& DeclareVectorInputPort(
       std::variant<std::string, UseDefaultName> name,
       const BasicVector<T>& model_vector,
       std::optional<RandomDistribution> random_type = std::nullopt) {
@@ -1599,7 +1599,7 @@ class LeafSystem : public System<T> {
   /// input, must provide for values whose type matches this @p model_value.
   ///
   /// @see System::DeclareInputPort() for more information.
-  const InputPort<T>& DeclareAbstractInputPort(
+  InputPort<T>& DeclareAbstractInputPort(
       std::variant<std::string, UseDefaultName> name,
       const AbstractValue& model_value) {
     const int next_index = this->num_input_ports();
@@ -1620,7 +1620,7 @@ class LeafSystem : public System<T> {
   /// See the nearly identical signature with an additional (first) argument
   /// specifying the port name.  This version will be deprecated as discussed
   /// in #9447.
-  const InputPort<T>& DeclareVectorInputPort(
+  InputPort<T>& DeclareVectorInputPort(
       const BasicVector<T>& model_vector,
       std::optional<RandomDistribution> random_type = std::nullopt) {
     return DeclareVectorInputPort(kUseDefaultName, model_vector, random_type);
@@ -1629,7 +1629,7 @@ class LeafSystem : public System<T> {
   /// See the nearly identical signature with an additional (first) argument
   /// specifying the port name.  This version will be deprecated as discussed
   /// in #9447.
-  const InputPort<T>& DeclareAbstractInputPort(
+  InputPort<T>& DeclareAbstractInputPort(
       const AbstractValue& model_value) {
     return DeclareAbstractInputPort(kUseDefaultName, model_value);
   }
@@ -1731,7 +1731,7 @@ class LeafSystem : public System<T> {
   /// where `MySystem` is a class derived from `LeafSystem<T>`. Template
   /// arguments will be deduced and do not need to be specified.
   template <class MySystem, typename BasicVectorSubtype>
-  const OutputPort<T>& DeclareVectorOutputPort(
+  LeafOutputPort<T>& DeclareVectorOutputPort(
       std::variant<std::string, UseDefaultName> name,
       const BasicVectorSubtype& model_vector,
       void (MySystem::*calc)(const Context<T>&, BasicVectorSubtype*) const,
@@ -1789,7 +1789,7 @@ class LeafSystem : public System<T> {
   /// provide a method for the allocator to call; that method can then invoke
   /// the `BasicVectorSubtype` default constructor.
   template <class MySystem, typename BasicVectorSubtype>
-  const OutputPort<T>& DeclareVectorOutputPort(
+  LeafOutputPort<T>& DeclareVectorOutputPort(
       std::variant<std::string, UseDefaultName> name,
       void (MySystem::*calc)(const Context<T>&, BasicVectorSubtype*) const,
       std::set<DependencyTicket> prerequisites_of_calc = {
@@ -1811,7 +1811,7 @@ class LeafSystem : public System<T> {
   /// function in its most generic form; if you have a member function available
   /// use one of the other signatures.
   /// @see LeafOutputPort::CalcVectorCallback
-  const OutputPort<T>& DeclareVectorOutputPort(
+  LeafOutputPort<T>& DeclareVectorOutputPort(
       std::variant<std::string, UseDefaultName> name,
       const BasicVector<T>& model_vector,
       typename LeafOutputPort<T>::CalcVectorCallback vector_calc_function,
@@ -1834,7 +1834,7 @@ class LeafSystem : public System<T> {
   /// Template arguments will be deduced and do not need to be specified.
   /// @see drake::Value
   template <class MySystem, typename OutputType>
-  const OutputPort<T>& DeclareAbstractOutputPort(
+  LeafOutputPort<T>& DeclareAbstractOutputPort(
       std::variant<std::string, UseDefaultName> name,
       const OutputType& model_value,
       void (MySystem::*calc)(const Context<T>&, OutputType*) const,
@@ -1873,7 +1873,7 @@ class LeafSystem : public System<T> {
   /// the `OutputType` default constructor.
   /// @see drake::Value
   template <class MySystem, typename OutputType>
-  const OutputPort<T>& DeclareAbstractOutputPort(
+  LeafOutputPort<T>& DeclareAbstractOutputPort(
       std::variant<std::string, UseDefaultName> name,
       void (MySystem::*calc)(const Context<T>&, OutputType*) const,
       std::set<DependencyTicket> prerequisites_of_calc = {
@@ -1900,7 +1900,7 @@ class LeafSystem : public System<T> {
   /// Template arguments will be deduced and do not need to be specified.
   /// @see drake::Value
   template <class MySystem, typename OutputType>
-  const OutputPort<T>& DeclareAbstractOutputPort(
+  LeafOutputPort<T>& DeclareAbstractOutputPort(
       std::variant<std::string, UseDefaultName> name,
       OutputType (MySystem::*make)() const,
       void (MySystem::*calc)(const Context<T>&, OutputType*) const,
@@ -1924,7 +1924,7 @@ class LeafSystem : public System<T> {
   /// allocator and calculator functions provided in their most generic forms.
   /// If you have a member function available use one of the other signatures.
   /// @see LeafOutputPort::AllocCallback, LeafOutputPort::CalcCallback
-  const OutputPort<T>& DeclareAbstractOutputPort(
+  LeafOutputPort<T>& DeclareAbstractOutputPort(
       std::variant<std::string, UseDefaultName> name,
       typename LeafOutputPort<T>::AllocCallback alloc_function,
       typename LeafOutputPort<T>::CalcCallback calc_function,
@@ -1949,7 +1949,7 @@ class LeafSystem : public System<T> {
   /// specifying the port name.  This version will be deprecated as discussed
   /// in #9447.
   template <class MySystem, typename BasicVectorSubtype>
-  const OutputPort<T>& DeclareVectorOutputPort(
+  LeafOutputPort<T>& DeclareVectorOutputPort(
       const BasicVectorSubtype& model_vector,
       void (MySystem::*calc)(const Context<T>&, BasicVectorSubtype*) const,
       std::set<DependencyTicket> prerequisites_of_calc = {
@@ -1962,7 +1962,7 @@ class LeafSystem : public System<T> {
   /// specifying the port name.  This version will be deprecated as discussed
   /// in #9447.
   template <class MySystem, typename BasicVectorSubtype>
-  const OutputPort<T>& DeclareVectorOutputPort(
+  LeafOutputPort<T>& DeclareVectorOutputPort(
       void (MySystem::*calc)(const Context<T>&, BasicVectorSubtype*) const,
       std::set<DependencyTicket> prerequisites_of_calc = {
           all_sources_ticket()}) {
@@ -1973,7 +1973,7 @@ class LeafSystem : public System<T> {
   /// See the nearly identical signature with an additional (first) argument
   /// specifying the port name.  This version will be deprecated as discussed
   /// in #9447.
-  const OutputPort<T>& DeclareVectorOutputPort(
+  LeafOutputPort<T>& DeclareVectorOutputPort(
       const BasicVector<T>& model_vector,
       typename LeafOutputPort<T>::CalcVectorCallback vector_calc_function,
       std::set<DependencyTicket> prerequisites_of_calc = {
@@ -1990,7 +1990,7 @@ class LeafSystem : public System<T> {
   /// case the name is required.
   template <class MySystem, typename OutputType>
   std::enable_if_t<!std::is_same<OutputType, std::string>::value,
-                   const OutputPort<T>&>
+                   LeafOutputPort<T>&>
   DeclareAbstractOutputPort(const OutputType& model_value,
                             void (MySystem::*calc)(const Context<T>&,
                                                    OutputType*) const,
@@ -2004,7 +2004,7 @@ class LeafSystem : public System<T> {
   /// specifying the port name.  This version will be deprecated as discussed
   /// in #9447.
   template <class MySystem, typename OutputType>
-  const OutputPort<T>& DeclareAbstractOutputPort(
+  LeafOutputPort<T>& DeclareAbstractOutputPort(
       void (MySystem::*calc)(const Context<T>&, OutputType*) const,
       std::set<DependencyTicket> prerequisites_of_calc = {
           all_sources_ticket()}) {
@@ -2016,7 +2016,7 @@ class LeafSystem : public System<T> {
   /// specifying the port name.  This version will be deprecated as discussed
   /// in #9447.
   template <class MySystem, typename OutputType>
-  const OutputPort<T>& DeclareAbstractOutputPort(
+  LeafOutputPort<T>& DeclareAbstractOutputPort(
       OutputType (MySystem::*make)() const,
       void (MySystem::*calc)(const Context<T>&, OutputType*) const,
       std::set<DependencyTicket> prerequisites_of_calc = {
@@ -2028,7 +2028,7 @@ class LeafSystem : public System<T> {
   /// See the nearly identical signature with an additional (first) argument
   /// specifying the port name.  This version will be deprecated as discussed
   /// in #9447.
-  const OutputPort<T>& DeclareAbstractOutputPort(
+  LeafOutputPort<T>& DeclareAbstractOutputPort(
       typename LeafOutputPort<T>::AllocCallback alloc_function,
       typename LeafOutputPort<T>::CalcCallback calc_function,
       std::set<DependencyTicket> prerequisites_of_calc = {
@@ -2640,7 +2640,7 @@ class LeafSystem : public System<T> {
     DRAKE_DEMAND(!calc_prerequisites.empty());
     // Create a cache entry for this output port.
     const OutputPortIndex oport_index(this->num_output_ports());
-    const CacheEntry& cache_entry = this->DeclareCacheEntry(
+    CacheEntry& cache_entry = this->DeclareCacheEntry(
         "output port " + std::to_string(oport_index) + "(" + name + ") cache",
         std::move(allocator), std::move(calculator),
         std::move(calc_prerequisites));

--- a/systems/framework/system_base.cc
+++ b/systems/framework/system_base.cc
@@ -32,7 +32,7 @@ std::string SystemBase::GetSystemPathname() const {
          GetSystemName();
 }
 
-const CacheEntry& SystemBase::DeclareCacheEntry(
+CacheEntry& SystemBase::DeclareCacheEntry(
     std::string description, CacheEntry::AllocCallback alloc_function,
     CacheEntry::CalcCallback calc_function,
     std::set<DependencyTicket> prerequisites_of_calc) {
@@ -42,7 +42,7 @@ const CacheEntry& SystemBase::DeclareCacheEntry(
       std::move(prerequisites_of_calc));
 }
 
-const CacheEntry& SystemBase::DeclareCacheEntryWithKnownTicket(
+CacheEntry& SystemBase::DeclareCacheEntryWithKnownTicket(
     DependencyTicket known_ticket, std::string description,
     CacheEntry::AllocCallback alloc_function,
     CacheEntry::CalcCallback calc_function,
@@ -54,7 +54,7 @@ const CacheEntry& SystemBase::DeclareCacheEntryWithKnownTicket(
       this, index, known_ticket, std::move(description),
       std::move(alloc_function), std::move(calc_function),
       std::move(prerequisites_of_calc)));
-  const CacheEntry& new_entry = *cache_entries_.back();
+  CacheEntry& new_entry = *cache_entries_.back();
   return new_entry;
 }
 
@@ -93,6 +93,9 @@ void SystemBase::InitializeContextBase(ContextBase* context_ptr) const {
     // TODO(sherm1) Supply initial value on creation instead and get rid of
     // this separate call.
     cache_value.SetInitialValue(entry.Allocate());
+
+    if (entry.is_disabled_by_default())
+      cache_value.disable_caching();
   }
 
   // Create the output port trackers yᵢ here. Nothing in this System may

--- a/systems/framework/test/cache_entry_test.cc
+++ b/systems/framework/test/cache_entry_test.cc
@@ -124,8 +124,15 @@ class MySystemBase final : public SystemBase {
                               &MySystemBase::CalcMyVector3,
                               {xc_ticket(), string_entry_.ticket()})) {
     set_name("cache_entry_test_system");
+
+    // We'll make entry4 disabled by default; everything else is enabled.
+    entry4_.disable_caching_by_default();
+
     EXPECT_EQ(num_cache_entries(), 8);
     EXPECT_EQ(GetSystemName(), "cache_entry_test_system");
+
+    EXPECT_FALSE(entry3_.is_disabled_by_default());
+    EXPECT_TRUE(entry4_.is_disabled_by_default());
   }
 
   const CacheEntry& entry0() const { return entry0_; }
@@ -169,14 +176,14 @@ class MySystemBase final : public SystemBase {
     throw std::logic_error("GetDirectFeedthroughs is not implemented");
   }
 
-  const CacheEntry& entry0_;
-  const CacheEntry& entry1_;
-  const CacheEntry& entry2_;
-  const CacheEntry& entry3_;
-  const CacheEntry& entry4_;
-  const CacheEntry& entry5_;
-  const CacheEntry& string_entry_;
-  const CacheEntry& vector_entry_;
+  CacheEntry& entry0_;
+  CacheEntry& entry1_;
+  CacheEntry& entry2_;
+  CacheEntry& entry3_;
+  CacheEntry& entry4_;
+  CacheEntry& entry5_;
+  CacheEntry& string_entry_;
+  CacheEntry& vector_entry_;
 };
 
 // An allocator is not permitted to return null. That should be caught when
@@ -232,6 +239,16 @@ class CacheEntryTest : public ::testing::Test {
     EXPECT_EQ(entry0_tracker.prerequisites().size(), 1);
     EXPECT_EQ(entry0_tracker.prerequisites()[0],
               &context_.get_tracker(system_.all_sources_ticket()));
+
+    // Only entry4 should have been created disabled.
+    EXPECT_FALSE(entry0().is_cache_entry_disabled(context_));
+    EXPECT_FALSE(entry1().is_cache_entry_disabled(context_));
+    EXPECT_FALSE(entry2().is_cache_entry_disabled(context_));
+    EXPECT_FALSE(entry3().is_cache_entry_disabled(context_));
+    EXPECT_TRUE(entry4().is_cache_entry_disabled(context_));
+    EXPECT_FALSE(entry5().is_cache_entry_disabled(context_));
+    EXPECT_FALSE(string_entry().is_cache_entry_disabled(context_));
+    EXPECT_FALSE(vector_entry().is_cache_entry_disabled(context_));
 
     EXPECT_TRUE(entry0().is_out_of_date(context_));
     EXPECT_TRUE(entry1().is_out_of_date(context_));

--- a/systems/framework/test/input_port_test.cc
+++ b/systems/framework/test/input_port_test.cc
@@ -160,11 +160,11 @@ struct SystemWithInputPorts final : public LeafSystem<double> {
             DeclareAbstractInputPort("double_port", Value<double>(1.25))},
         string_port{DeclareAbstractInputPort("string_port",
                                              Value<std::string>("hello"))} {}
-  const InputPort<double>& basic_vec_port;
-  const InputPort<double>& derived_vec_port;
-  const InputPort<double>& int_port;
-  const InputPort<double>& double_port;
-  const InputPort<double>& string_port;
+  InputPort<double>& basic_vec_port;
+  InputPort<double>& derived_vec_port;
+  InputPort<double>& int_port;
+  InputPort<double>& double_port;
+  InputPort<double>& string_port;
 };
 
 // Test the FixValue() method. Note that the conversion of its value argument

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -871,28 +871,41 @@ class DeclaredModelPortsSystem : public LeafSystem<double> {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DeclaredModelPortsSystem);
 
   DeclaredModelPortsSystem() {
-    this->DeclareInputPort("input", kVectorValued, 1);
-    this->DeclareVectorInputPort("vector_input", MyVector2d());
-    this->DeclareAbstractInputPort("abstract_input", Value<int>(22));
-    this->DeclareVectorInputPort("uniform", MyVector2d(),
-                                 RandomDistribution::kUniform);
-    this->DeclareVectorInputPort("gaussian", MyVector2d(),
-                                 RandomDistribution::kGaussian);
+    // Use these to validate the expected return type from each method.
+    InputPort<double>* in_port{nullptr};
+    LeafOutputPort<double>* out_port{nullptr};
+
+    in_port = &DeclareInputPort("input", kVectorValued, 1);
+    unused(in_port);
+    in_port = &DeclareVectorInputPort("vector_input", MyVector2d());
+    unused(in_port);
+    in_port = &DeclareAbstractInputPort("abstract_input", Value<int>(22));
+    unused(in_port);
+    in_port = &DeclareVectorInputPort("uniform", MyVector2d(),
+                                      RandomDistribution::kUniform);
+    unused(in_port);
+    in_port = &DeclareVectorInputPort("gaussian", MyVector2d(),
+                                      RandomDistribution::kGaussian);
+    unused(in_port);
 
     // Output port 0 uses a BasicVector base class model.
-    this->DeclareVectorOutputPort("basic_vector", BasicVector<double>(3),
-                                  &DeclaredModelPortsSystem::CalcBasicVector3);
+    out_port =
+        &DeclareVectorOutputPort("basic_vector", BasicVector<double>(3),
+                                 &DeclaredModelPortsSystem::CalcBasicVector3);
+    unused(out_port);
     // Output port 1 uses a class derived from BasicVector.
-    this->DeclareVectorOutputPort("my_vector", MyVector4d(),
-                                  &DeclaredModelPortsSystem::CalcMyVector4d);
+    out_port = &DeclareVectorOutputPort(
+        "my_vector", MyVector4d(), &DeclaredModelPortsSystem::CalcMyVector4d);
+    unused(out_port);
 
     // Output port 2 uses a concrete string model.
-    this->DeclareAbstractOutputPort("string", std::string("45"),
-                                    &DeclaredModelPortsSystem::CalcString);
+    out_port = &DeclareAbstractOutputPort(
+        "string", std::string("45"), &DeclaredModelPortsSystem::CalcString);
+    unused(out_port);
 
     // Output port 3 uses the "Advanced" methods that take a model
     // and a general calc function rather than a calc method.
-    this->DeclareVectorOutputPort(
+    out_port = &DeclareVectorOutputPort(
         "advanced", BasicVector<double>(2),
         [](const Context<double>&, BasicVector<double>* out) {
           ASSERT_NE(out, nullptr);
@@ -900,8 +913,9 @@ class DeclaredModelPortsSystem : public LeafSystem<double> {
           out->SetAtIndex(0, 10.);
           out->SetAtIndex(1, 20.);
         });
+    unused(out_port);
 
-    this->DeclareNumericParameter(*MyVector2d::Make(1.1, 2.2));
+    DeclareNumericParameter(*MyVector2d::Make(1.1, 2.2));
   }
 
   const BasicVector<double>& expected_basic() const { return expected_basic_; }
@@ -1371,15 +1385,22 @@ class DeclaredNonModelOutputSystem : public LeafSystem<double> {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DeclaredNonModelOutputSystem);
 
   DeclaredNonModelOutputSystem() {
+    // Use this to validate the expected return type from each method.
+    LeafOutputPort<double>* port{nullptr};
+
     // Output port 0 default-constructs a class derived from BasicVector as
     // its allocator.
-    this->DeclareVectorOutputPort(&DeclaredNonModelOutputSystem::CalcDummyVec2);
+    port =
+        &DeclareVectorOutputPort(&DeclaredNonModelOutputSystem::CalcDummyVec2);
+    unused(port);
     // Output port 1 default-constructs a string as its allocator.
-    this->DeclareAbstractOutputPort(&DeclaredNonModelOutputSystem::CalcString);
+    port =
+        &DeclareAbstractOutputPort(&DeclaredNonModelOutputSystem::CalcString);
+    unused(port);
 
     // Output port 2 uses the "Advanced" method for abstract ports, providing
     // explicit non-member functors for allocator and calculator.
-    this->DeclareAbstractOutputPort(
+    port = &DeclareAbstractOutputPort(
         []() { return AbstractValue::Make<int>(-2); },
         [](const Context<double>&, AbstractValue* out) {
           ASSERT_NE(out, nullptr);
@@ -1387,15 +1408,19 @@ class DeclaredNonModelOutputSystem : public LeafSystem<double> {
           DRAKE_EXPECT_NO_THROW(int_out = &out->get_mutable_value<int>());
           *int_out = 321;
         });
+    unused(port);
 
     // Output port 3 is declared with a commonly-used signature taking
     // methods for both allocator and calculator for an abstract port.
-    this->DeclareAbstractOutputPort(&DeclaredNonModelOutputSystem::MakeString,
-                                    &DeclaredNonModelOutputSystem::CalcString);
+    port =
+        &DeclareAbstractOutputPort(&DeclaredNonModelOutputSystem::MakeString,
+                                   &DeclaredNonModelOutputSystem::CalcString);
+    unused(port);
 
     // Output port 4 uses a default-constructed bare struct which should be
     // value-initialized.
-    this->DeclareAbstractOutputPort(&DeclaredNonModelOutputSystem::CalcPOD);
+    port = &DeclareAbstractOutputPort(&DeclaredNonModelOutputSystem::CalcPOD);
+    unused(port);
   }
 
   int calc_dummy_vec2_calls() const { return count_calc_dummy_vec2_; }
@@ -1545,13 +1570,13 @@ GTEST_TEST(ZeroSizeSystemTest, AcceptanceTest) {
   TestSystem<double> dut;
 
   // Input.
-  const auto& in0 = dut.DeclareVectorInputPort(
+  auto& in0 = dut.DeclareVectorInputPort(
       kUseDefaultName, BasicVector<double>(0));
   EXPECT_EQ(in0.get_data_type(), kVectorValued);
   EXPECT_EQ(in0.size(), 0);
 
   // Output.
-  const auto& out0 = dut.DeclareVectorOutputPort(
+  auto& out0 = dut.DeclareVectorOutputPort(
       kUseDefaultName, BasicVector<double>(0),
       [](const Context<double>&, BasicVector<double>*) {});
   EXPECT_EQ(out0.get_data_type(), kVectorValued);

--- a/systems/framework/test/output_port_test.cc
+++ b/systems/framework/test/output_port_test.cc
@@ -234,6 +234,25 @@ void AbstractPortCheck(const Context<double>& context,
       "OutputPort::Eval().*wrong value type int.*actual type.*std::string.*");
 }
 
+TEST_F(LeafOutputPortTest, DisableByDefaultWorks) {
+  absport_general_.disable_caching_by_default();
+  const CacheEntry& abs_entry = absport_general_.cache_entry();
+  const CacheEntry& vec_entry = vecport_general_.cache_entry();
+  EXPECT_TRUE(abs_entry.is_disabled_by_default());
+  EXPECT_FALSE(vec_entry.is_disabled_by_default());
+
+  // Find the cache entry values in a created context and verify that
+  // the right one is disabled.
+  auto my_context = dummy_.CreateDefaultContext();
+  const CacheEntryValue& abs_value =
+      my_context->get_cache().get_cache_entry_value(abs_entry.cache_index());
+  const CacheEntryValue& vec_value =
+      my_context->get_cache().get_cache_entry_value(vec_entry.cache_index());
+
+  EXPECT_TRUE(abs_value.is_cache_entry_disabled());
+  EXPECT_FALSE(vec_value.is_cache_entry_disabled());
+}
+
 // Check for proper construction and functioning of abstract LeafOutputPorts.
 TEST_F(LeafOutputPortTest, AbstractPorts) {
   // Check abstract port with explicit function allocator.

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -74,9 +74,9 @@ class TestSystem : public System<double> {
     return this->DeclareInputPort(kUseDefaultName, kAbstractValued, 0);
   }
 
-  const LeafOutputPort<double>& AddAbstractOutputPort() {
+  LeafOutputPort<double>& AddAbstractOutputPort() {
     // Create an abstract output port with dummy alloc and calc.
-    const CacheEntry& cache_entry = this->DeclareCacheEntry(
+    CacheEntry& cache_entry = this->DeclareCacheEntry(
         "null output port",
         [] { return Value<int>::Make(0); },
         [](const ContextBase&, AbstractValue*) {});


### PR DESCRIPTION
To diagnose @siyuanfeng-tri's cached/uncached behavioral difference (as reported in #12643) I had to hack in a way to get individual cache entries to come up disabled. That will be useful for future diagnoses, so this PR turns that hack into a feature.

### API
Adds `CacheEntry::disable_caching_by_default()`  and `is_disabled_by_default()`.
Adds `LeafOutputPort::disable_caching_by_default()` that writes through to the associated CacheEntry.

Unit tests verify functionality through either interface.

### Yak shaving
The above plus a 2-line change in system_base.cc to set the flag is all that is logically needed. However as usual there were a few impediments:
1. LeafSystem::DeclareOutputPort() was returning a generic OutputPort rather than a LeafOutputPort; the generic one doesn't provide for a cache entry. I changed it to return LeafOutputPort which is (of course) what it was actually creating.
2. The DeclareCacheEntry() and DeclareOutputPort() method families were returning const references which prevented calls to `disable_caching_by_default()`.  These are non-const methods which could have returned mutable references but there wasn't a reason to do so before. Now there is so I changed to mutable reference returns.
3. After that the DeclareInputPort() family looked inconsistent since it also returned a non-const reference. For consistency I changed those to non-const also. This doesn't change anything functionally since there are currently no non-const methods in InputPort or InputPortBase. However, it maintains parallel declarations for the similar Declare() methods, which is better API design.

None of the changes above introduce any backwards-compatibility problems since (a) a LeafOutputPort is still an OutputPort, and (b) you can still bind a const reference to a non-const reference.

Resolves #12648
Relates #12643

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12803)
<!-- Reviewable:end -->
