### PR TITLE
[geometry] rename internal::Plane to internal::PosedHalfSpace

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -39,6 +39,7 @@ drake_cc_package_library(
         ":obj_to_surface_mesh",
         ":penetration_as_point_pair_callback",
         ":plane",
+        ":posed_half_space",
         ":proximity_utilities",
         ":sorted_triplet",
         ":surface_mesh",
@@ -52,7 +53,7 @@ drake_cc_library(
     srcs = ["bounding_volume_hierarchy.cc"],
     hdrs = ["bounding_volume_hierarchy.h"],
     deps = [
-        ":plane",
+        ":posed_half_space",
         ":surface_mesh",
         ":volume_mesh",
         "//common",
@@ -320,7 +321,7 @@ drake_cc_library(
         ":bounding_volume_hierarchy",
         ":contact_surface_utility",
         ":mesh_field",
-        ":plane",
+        ":posed_half_space",
         ":surface_mesh",
         ":volume_mesh",
         "//common",
@@ -382,7 +383,14 @@ drake_cc_library(
 drake_cc_library(
     name = "plane",
     hdrs = ["plane.h"],
+    deps = ["//common:essential"],
+)
+
+drake_cc_library(
+    name = "posed_half_space",
+    hdrs = ["posed_half_space.h"],
     deps = [
+        ":plane",
         "//common:essential",
     ],
 )
@@ -693,6 +701,20 @@ drake_cc_googletest(
         ":penetration_as_point_pair_callback",
         "//common/test_utilities:eigen_matrix_compare",
     ],
+)
+
+drake_cc_googletest(
+    name = "plane_test",
+    deps = [
+        ":plane",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
+    name = "posed_half_space_test",
+    deps = [":posed_half_space"],
 )
 
 drake_cc_googletest(

--- a/geometry/proximity/bounding_volume_hierarchy.cc
+++ b/geometry/proximity/bounding_volume_hierarchy.cc
@@ -72,15 +72,15 @@ bool Aabb::HasOverlap(const Aabb& a, const Aabb& b,
 bool Aabb::HasOverlap(const Aabb& bv, const Plane<double>& plane_P,
                       const math::RigidTransformd& X_PH) {
   // We want the two corners of the box that lie at the most extreme extents in
-  // the plane's normal direction. Then we can determine their signed distance
-  // -- if the interval of signed distance includes _zero_, the box overlaps.
+  // the plane's normal direction. Then we can determine their heights
+  // -- if the interval of heights includes _zero_, the box overlaps.
 
   // The box's canonical frame B is aligned with H; R_BH = I which implies
   // R_PH = R_PB. However, p_HoBo is not necessarily zero.
   const auto& R_PH = X_PH.rotation().matrix();
-  // The corner of the box that will have the *greatest* signed distance value
-  // w.r.t. the plane. Measured from the box's frame's origin (Bo) but
-  // expressed in the plane's frame.
+  // The corner of the box that will have the *greatest* height value w.r.t.
+  // the plane measured from the box's frame's origin (Bo) but expressed in the
+  // plane's frame.
   Vector3d p_BoCmax_P = Vector3d::Zero();
   // We want to compute the vectors Hᴹᵢ  ∈ {Hᵢ, -Hᵢ}, such that Hᴹᵢ ⋅ n̂ₚ is
   // positive. The maximum box corner is a combination of those Hᴹᵢ vectors.
@@ -97,9 +97,9 @@ bool Aabb::HasOverlap(const Aabb& bv, const Plane<double>& plane_P,
   const Vector3d p_PoCmax_P = p_PoBo_P + p_BoCmax_P;
   const Vector3d p_PoCmin_P = p_PoBo_P - p_BoCmax_P;
 
-  const double max_distance = plane_P.CalcSignedDistance(p_PoCmax_P);
-  const double min_distance = plane_P.CalcSignedDistance(p_PoCmin_P);
-  return min_distance <= 0 && 0 <= max_distance;
+  const double max_height = plane_P.CalcHeight(p_PoCmax_P);
+  const double min_height = plane_P.CalcHeight(p_PoCmin_P);
+  return min_height <= 0 && 0 <= max_height;
 }
 
 bool Aabb::HasOverlap(const Aabb& bv, const HalfSpace&,

--- a/geometry/proximity/bounding_volume_hierarchy.h
+++ b/geometry/proximity/bounding_volume_hierarchy.h
@@ -88,23 +88,22 @@ class Aabb {
   static bool HasOverlap(const Aabb& a, const Aabb& b,
                          const math::RigidTransformd& X_AB);
 
-  /** Checks whether bounding volume `bv` intersects the plane `plane_P`.
-   The bounding volume is centered on its canonical frame B and B is posed
-   in the corresponding hierarchy frame H; by construction B is aligned with H.
-   The plane is defined in frame P.
+  /** Checks whether bounding volume `bv` intersects the given plane. The
+   bounding volume is centered on its canonical frame B and B is posed in the
+   corresponding hierarchy frame H; by construction B is aligned with H. The
+   plane is defined in frame P.
 
-   This is distinct from testing overlap with a half space because the half
-   space is a _volume_. The plane is a surface. A bounding volume can lie
-   completely on either side of the plane and not overlap.
+   The box and plane intersect if _any_ point within the bounding volume has
+   zero height (see CalcHeight()).
 
    @param bv        The bounding box to test.
-   @param plane_P   The plane to test against whose definition is given in
-                    frame P. I.e., to evaluate the signed distance of a point
-                    with respect to the plane, that point must be measured and
+   @param plane_P   The plane to test against the `bv`. The plane is expressed
+                    in Frame P, therefore, to evaluate the height of a point
+                    with respect to it, that point must be measured and
                     expressed in P.
    @param X_PH      The relative pose between the hierarchy frame H and the
                     plane frame P.
-   @returns `true` if the plane cuts through the box.   */
+   @returns `true` if the plane intersects the box.   */
   static bool HasOverlap(const Aabb& bv, const Plane<double>& plane_P,
                          const math::RigidTransformd& X_PH);
 
@@ -112,7 +111,7 @@ class Aabb {
    bounding volume is centered on its canonical frame B and B is posed in the
    corresponding hierarchy frame H; by construction B is aligned with H. The
    half space is defined in its canonical frame C (such that the boundary plane
-   of the half space is perpindicular to Cz and Co lies on the boundary plane).
+   of the half space is perpendicular to Cz and Co lies on the boundary plane).
 
    @param bv        The bounding box to test.
    @param hs_C      The half space to test against the `bv`. The half space is

--- a/geometry/proximity/mesh_half_space_intersection.h
+++ b/geometry/proximity/mesh_half_space_intersection.h
@@ -145,7 +145,7 @@ SurfaceVertexIndex GetVertexAddIfNeeded(
 template <typename T>
 void ConstructTriangleHalfspaceIntersectionPolygon(
     const std::vector<SurfaceVertex<T>>& vertices_F,
-    const SurfaceFace& triangle, const Plane<T>& half_space_F,
+    const SurfaceFace& triangle, const PosedHalfSpace<T>& half_space_F,
     std::vector<SurfaceVertex<T>>* new_vertices_F,
     std::vector<SurfaceFace>* new_faces,
     std::unordered_map<SurfaceVertexIndex, SurfaceVertexIndex>*
@@ -298,7 +298,7 @@ void ConstructTriangleHalfspaceIntersectionPolygon(
 template <typename T>
 SurfaceMesh<T> ConstructSurfaceMeshFromMeshHalfspaceIntersection(
     const SurfaceMesh<T>& input_mesh_F,
-    const internal::Plane<T>& half_space_F) {
+    const internal::PosedHalfSpace<T>& half_space_F) {
   std::vector<SurfaceVertex<T>> new_vertices_F;
   std::vector<SurfaceFace> new_faces;
   std::unordered_map<SurfaceVertexIndex, SurfaceVertexIndex>

--- a/geometry/proximity/mesh_intersection.h
+++ b/geometry/proximity/mesh_intersection.h
@@ -12,7 +12,7 @@
 #include "drake/geometry/proximity/bounding_volume_hierarchy.h"
 #include "drake/geometry/proximity/contact_surface_utility.h"
 #include "drake/geometry/proximity/mesh_field_linear.h"
-#include "drake/geometry/proximity/plane.h"
+#include "drake/geometry/proximity/posed_half_space.h"
 #include "drake/geometry/proximity/surface_mesh.h"
 #include "drake/geometry/proximity/volume_mesh.h"
 #include "drake/geometry/proximity/volume_mesh_field.h"
@@ -54,9 +54,8 @@ namespace internal {
  @param p_FB
      Point B measured and expressed in the common frame F.
  @param H_F
-     The half space H, as represented by its boundary plane with the plane's
-     normal pointing out of the half space, expressed in frame F (i.e., points
-     also expressed in frame F can be tested against it).
+     The half space H measured and expressed in frame F (i.e., points also
+     measured and expressed in frame F can be tested against it).
  @pre
      1. Points A and B are not coincident.
      2. One of A and B is outside the half space (and the other is contained in
@@ -67,7 +66,7 @@ namespace internal {
  */
 template <typename T>
 Vector3<T> CalcIntersection(const Vector3<T>& p_FA, const Vector3<T>& p_FB,
-                            const Plane<T>& H_F) {
+                            const PosedHalfSpace<T>& H_F) {
   const T a = H_F.CalcSignedDistance(p_FA);
   const T b = H_F.CalcSignedDistance(p_FB);
   // We require that A and B classify in opposite directions (one inside and one
@@ -82,8 +81,9 @@ Vector3<T> CalcIntersection(const Vector3<T>& p_FA, const Vector3<T>& p_FB,
   // Empirically we found that numeric_limits<double>::epsilon() 2.2e-16 is
   // too small.
   const T kEps(1e-14);
-  // TODO(SeanCurtis-TRI): Consider refactoring this fuzzy test *into* Plane
-  //  if it turns out we need to perform this test at other sites.
+  // TODO(SeanCurtis-TRI): Consider refactoring this fuzzy test *into*
+  //  PosedHalfSpace if it turns out we need to perform this test at other
+  //  sites.
   // Verify that the intersection point is on the plane of the half space.
   using std::abs;
   DRAKE_DEMAND(abs(H_F.CalcSignedDistance(intersection)) < kEps);
@@ -112,14 +112,13 @@ Vector3<T> CalcIntersection(const Vector3<T>& p_FA, const Vector3<T>& p_FB,
 //  check whether we can have other as yet undocumented degenerate cases.
 /** Intersects a polygon with the half space H. It keeps the part of
  the polygon contained in the half space (signed distance is <= 0).
- The plane `H_F` and vertex positions of `polygon_vertices_F` are both defined
- in a common frame F.
+ The half space `H_F` and vertex positions of `polygon_vertices_F` are both
+ defined in a common frame F.
  @param[in] polygon_vertices_F
      Input polygon is represented as a sequence of positions of its vertices.
      The input polygon is allowed to have zero area.
  @param[in] H_F
-     The clipping half space H in frame F, represented by its boundary plane
-     with the plane's normal pointing out of the half space.
+     The clipping half space H in frame F.
  @return
      Output polygon is represented as a sequence of positions of its vertices.
      It could be an empty sequence if the input polygon is entirely outside
@@ -148,7 +147,8 @@ Vector3<T> CalcIntersection(const Vector3<T>& p_FA, const Vector3<T>& p_FB,
 */
 template <typename T>
 std::vector<Vector3<T>> ClipPolygonByHalfSpace(
-    const std::vector<Vector3<T>>& polygon_vertices_F, const Plane<T>& H_F) {
+    const std::vector<Vector3<T>>& polygon_vertices_F,
+    const PosedHalfSpace<T>& H_F) {
   // Note: this is the inner loop of a modified Sutherland-Hodgman algorithm for
   // clipping a polygon.
   std::vector<Vector3<T>> output_vertices_F;
@@ -164,8 +164,8 @@ std::vector<Vector3<T>> ClipPolygonByHalfSpace(
   for (int i = 0; i < size; ++i) {
     const Vector3<T>& current = polygon_vertices_F[i];
     const Vector3<T>& previous = polygon_vertices_F[(i - 1 + size) % size];
-    const bool current_contained = !H_F.PointIsOutside(current);
-    const bool previous_contained = !H_F.PointIsOutside(previous);
+    const bool current_contained = H_F.CalcSignedDistance(current) <= 0;
+    const bool previous_contained = H_F.CalcSignedDistance(previous) <= 0;
     if (current_contained) {
       if (!previous_contained) {
         // Current is inside and previous is outside. Compute the point where
@@ -323,9 +323,9 @@ std::vector<Vector3<T>> ClipTriangleByTetrahedron(
     const Vector3<T>& p_MA = p_MVs[face_vertex[0]];
     const Vector3<T>& p_MB = p_MVs[face_vertex[1]];
     const Vector3<T>& p_MC = p_MVs[face_vertex[2]];
-    const Vector3<T> normal_M = (p_MB - p_MA).cross(p_MC - p_MA).normalized();
-    T height = normal_M.dot(p_MA);
-    Plane<T> half_space_M(normal_M, height);
+    // We'll allow the PosedHalfSpace to normalize our vector.
+    const Vector3<T> normal_M = (p_MB - p_MA).cross(p_MC - p_MA);
+    PosedHalfSpace<T> half_space_M(normal_M, p_MA);
     // Intersects the output polygon by the half space of each face of the
     // tetrahedron.
     polygon_M = ClipPolygonByHalfSpace(polygon_M, half_space_M);

--- a/geometry/proximity/mesh_plane_intersection.cc
+++ b/geometry/proximity/mesh_plane_intersection.cc
@@ -74,7 +74,7 @@ void SliceTetWithPlane(
   int intersection_code = 0;
   for (int i = 0; i < 4; ++i) {
     const VolumeVertexIndex v = mesh_M.element(tet_index).vertex(i);
-    distance[i] = plane_M.CalcSignedDistance(mesh_M.vertex(v).r_MV());
+    distance[i] = plane_M.CalcHeight(mesh_M.vertex(v).r_MV());
     if (distance[i] > T(0)) intersection_code |= 1 << i;
   }
 

--- a/geometry/proximity/plane.h
+++ b/geometry/proximity/plane.h
@@ -2,6 +2,9 @@
 
 #include <limits>
 
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
@@ -9,66 +12,88 @@
 namespace drake {
 namespace geometry {
 namespace internal {
-/** Definition of a half space. It is defined by the implicit equation
- `H(x⃗) = n̂⋅x⃗ - d <= 0`. A particular instance is defined by a boundary plane in
- a particular frame F with its normal pointing out of the half space such that
- `H(p_QF) > 0` if the point Q (measured and expressed in F) is outside the
- half space.
+
+/** The definition of a plane in ℜ³, posed in an arbitrary frame. The plane
+ normal implicitly defines "above" and "below" directions relative to the plane.
+ The "height" of a point relative to the plane can be queried.
+
+ It is defined with the implicit equation: `P(x⃗) = n̂⋅x⃗ - d = 0`. A particular
+ instance is measured and expressed in a particular frame, such that only points
+ measured and expressed in that same frame can be meaningfully compared to the
+ plane. E.g.,
+
+ ```
+ const Vector3<T> nhat_F = ...;
+ const Vector3<T> p_FP = ...;  // P is a point on the plane.
+ const Plane<T> plane_F(nhat_F, p_FP);  // Plane in frame F.
+ const double distance_Q = plane_F.CalcHeight(p_FQ);  // valid!
+ const double distance_R = plane_F.CalcHeight(p_GR);  // invalid!
+ ```
  */
 template <typename T>
 class Plane {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Plane)
 
-  /** Constructs a Plane in frame F.
-   @param nhat_F
-       A unit-length vector perpendicular to the half space's planar boundary
-       expressed in frame F (the `n̂` in the implicit equation).
-   @param displacement
-       The signed distance from F's origin to the half space boundary (the `d`
-       term in the implicit equation). E.g., for a point p_FP on the plane,
-       `displacement = nhat_F.dot(p_FP)`.
-   @pre
-       ‖nhat_F‖₂ = 1.
+  /** Constructs a %Plane in frame F which is normal to `n_F` and passes
+   through the point `p_FP`.
+   @param n_F
+       A (possibly unit-length) vector perpendicular to the plane expressed in
+       Frame F (the `n̂` in the implicit equation). By default, the vector will
+       be normalized before being stored (see below).
+   @param p_FP
+       A point on the plane measured and expressed in Frame F. The `d` in the
+       implicit equation is derived from this quantity.
+   @param already_normalized
+       (Advanced) If `true`, the `n_F` will be treated as if it has already been
+       normalized by the caller. It should still essentially have unit length.
+       This function reserves the right to validate this property in debug
+       build up to an arbitrary tolerance. When in doubt, allow the plane to
+       normalize the normal vector.
+   @pre If `already_normalized` is `false`, `n_F` must have magnitude ≥ 1e-10.
    */
-  Plane(const Vector3<T>& nhat_F, const T& displacement)
-      : nhat_F_(nhat_F), displacement_(displacement) {
-    using std::abs;
-    // Note: This may *seem* like a very tight threshold for determining if a
-    // vector is unit length. However, empirical evidence suggests that in
-    // double precision, normalizing a vector generally makes a vector whose
-    // evaluated magnitude is within epsilon of one. There may be some
-    // unconsidered value that disproves this -- at that point, adapt the
-    // tolerance here and add it to the unit test.
-    DRAKE_THROW_UNLESS(abs(nhat_F_.norm() - 1.0) <=
-        std::numeric_limits<double>::epsilon());
+  Plane(const Vector3<T>& n_F, const Vector3<T>& p_FP,
+        bool already_normalized = false) {
+    if (!already_normalized) {
+      const T magnitude = n_F.norm();
+      // NOTE: This threshold is arbitrary. Given Drake uses mks and generally
+      // works on problems at a human scale, the assumption is that if someone
+      // passes in an incredibly small normal (picometers), it is probably an
+      // error.
+      if (magnitude < 1e-10) {
+        throw std::runtime_error(
+            fmt::format("Cannot instantiate plane from normal n_F = [{}]; its "
+                        "magnitude is too small: {}",
+                        n_F.transpose(), magnitude));
+      }
+      nhat_F_ = n_F / magnitude;
+    } else {
+      using std::abs;
+      // We pick a threshold that should easily contain typical precision loss
+      // in the columns/rows of a rotation matrix -- a likely source for plane
+      // normals.
+      DRAKE_ASSERT(abs(n_F.norm() - 1.0) > 1e-13);
+      nhat_F_ = n_F;
+    }
+    displacement_ = nhat_F_.dot(p_FP);
   }
 
-  /** Computes the signed distance to the point Q (measured and expressed in
-   frame F). The point is strictly inside, on the boundary, or outside based on
-   the return value being negative, zero, or positive, respectively.
-   */
-  T CalcSignedDistance(const Vector3<T>& p_FQ) const {
+  /** Computes the height of Point Q relative to the plane. A positive height
+   indicates the point lies _above_ the plane; negative height indicates
+   _below_. The point must be measured and expressed in the same frame as the
+   plane.   */
+  T CalcHeight(const Vector3<T>& p_FQ) const {
     return nhat_F_.dot(p_FQ) - displacement_;
   }
 
-  /** Reports true if the point Q (measured and expressed in frame F),
-   strictly lies outside this half space.
-   */
-  bool PointIsOutside(const Vector3<T>& p_FQ) const {
-    return CalcSignedDistance(p_FQ) > 0;
-  }
-
-  /** Gets the normal expressed in frame F. */
+  /** Gets the plane's normal expressed in frame F. */
   const Vector3<T>& normal() const { return nhat_F_; }
-
-  /** Gets the displacement constant. */
-  const T& displacement() const { return displacement_; }
 
  private:
   Vector3<T> nhat_F_;
   T displacement_{};
 };
+
 }  // namespace internal
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/proximity/posed_half_space.h
+++ b/geometry/proximity/posed_half_space.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <limits>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/drake_throw.h"
+#include "drake/common/eigen_types.h"
+#include "drake/geometry/proximity/plane.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+/** The definition of a half space, posed in an arbitrary frame. It is
+ defined by its boundary plane such that a point's signed distance relative to
+ the half space is equal to its height relative to the boundary plane (see
+ Plane for details). The boundary plane's normal points outside the half space.
+
+ The %PosedHalfSpace class is distinct from the HalfSpace class in that the
+ HalfSpace class defines the half space in its own canonical frame. The posed
+ half space can be defined in an arbitrary frame.
+
+ The signed distance of a point Q can only be meaningfully evaluated if the
+ point is measured and expressed in the same frame as the half space:
+
+ ```
+ const Vector3<T> nhat_F = ...;
+ const Vector3<T> p_FP = ...;  // P is a point on the half space boundary.
+ const PosedHalfSpace<T> half_space_F(nhat_F, p_FP);  // Half space in frame F.
+ const double distance_Q = half_space_F.CalcSignedDistance(p_FQ);  // valid!
+ const double distance_R = half_space_F.CalcSignedDistance(p_GR);  // invalid!
+ ```
+ */
+template <typename T>
+class PosedHalfSpace {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PosedHalfSpace)
+
+  /** Constructs a half space in frame F in terms of its boundary plane. The
+   parameters define the boundary plane (see Plane for details). The boundary
+   plane's normal points _outside_ the half space.  */
+  PosedHalfSpace(const Vector3<T>& nhat_F, const Vector3<T>& p_FP,
+                 bool already_normalized = false)
+      : plane_(nhat_F, p_FP, already_normalized) {}
+
+  /** Computes the signed distance to the point Q (measured and expressed in
+   Frame F). If Q's signed distance is positive, it lies outside the half space.
+   If it is negative, it lies inside. If it is zero, it lies on the boundary
+   plane of the half space.  */
+  T CalcSignedDistance(const Vector3<T>& p_FQ) const {
+    return plane_.CalcHeight(p_FQ);
+  }
+
+  /** Gets the normal expressed in Frame F. */
+  const Vector3<T>& normal() const { return plane_.normal(); }
+
+  /** Gets the boundary plane of `this` posed half space.  */
+  const Plane<T>& boundary_plane() const { return plane_; }
+
+ private:
+  Plane<T> plane_;
+};
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/test/contact_surface_utility_test.cc
+++ b/geometry/proximity/test/contact_surface_utility_test.cc
@@ -64,9 +64,10 @@ class ContactSurfaceUtilityTest : public ::testing::Test {
 // This test confirms all of those cases, and then _pokes_ at the case where the
 // centroid _isn't_ the average vertex position as a representative sample.
 //
-// In frame M, we construct a set of vertex locations on the Mz = 0 plane. This
-// will make the Mz vector normal to the triangle. We construct various polygons
-// from the set of vertices with corresponding expected outcomes.
+// In frame M, we construct a set of vertex locations on the z = 0 plane in
+// Frame M. This will make the Mz vector normal to the triangle. We construct
+// various polygons from the set of vertices with corresponding expected
+// outcomes.
 //
 //                                   y
 //

--- a/geometry/proximity/test/mesh_half_space_intersection_test.cc
+++ b/geometry/proximity/test/mesh_half_space_intersection_test.cc
@@ -9,13 +9,13 @@ namespace drake {
 namespace geometry {
 namespace {
 
-using internal::Plane;
+using internal::PosedHalfSpace;
 
 template <typename T>
 class MeshHalfspaceIntersectionTest : public ::testing::Test {
  public:
-  /// Returns the half space with normal expressed in Frame H.
-  const Plane<T> half_space_H() const { return *half_space_H_; }
+  /// Returns the posed half space measured and expressed in Frame H.
+  const PosedHalfSpace<T> half_space_H() const { return *half_space_H_; }
 
   // Accessors for data structures used repeatedly.
   std::vector<SurfaceVertex<T>>& new_vertices() { return new_vertices_; }
@@ -165,8 +165,7 @@ class MeshHalfspaceIntersectionTest : public ::testing::Test {
     // lying on the half space.
     Vector3<T> normal_H(0, 0, 1);
     const Vector3<T> point_H(0, 0, 2);
-    const T displacement = normal_H.dot(point_H);
-    half_space_H_ = std::make_unique<Plane<T>>(normal_H, displacement);
+    half_space_H_ = std::make_unique<PosedHalfSpace<T>>(normal_H, point_H);
   }
 
   std::vector<SurfaceVertex<T>> new_vertices_;
@@ -175,7 +174,7 @@ class MeshHalfspaceIntersectionTest : public ::testing::Test {
       vertices_to_newly_created_vertices_;
   std::unordered_map<SortedPair<SurfaceVertexIndex>, SurfaceVertexIndex>
       edges_to_newly_created_vertices_;
-  std::unique_ptr<Plane<T>> half_space_H_;
+  std::unique_ptr<PosedHalfSpace<T>> half_space_H_;
 };  // namespace
 TYPED_TEST_SUITE_P(MeshHalfspaceIntersectionTest);
 
@@ -551,13 +550,12 @@ TYPED_TEST_P(MeshHalfspaceIntersectionTest, BoxMesh) {
 
   // Construct the half-space.
   const Vector3<T> half_space_normal_W = X_WF.rotation() * Vector3<T>(0, 0, 1);
-  const T half_space_displacement = half_space_normal_W.dot(X_WF.translation());
-  const Plane<T> half_space(half_space_normal_W, half_space_displacement);
+  const PosedHalfSpace<T> half_space_W(half_space_normal_W, X_WF.translation());
 
   // Compute the intersection.
   const SurfaceMesh<T> intersection_mesh =
       ConstructSurfaceMeshFromMeshHalfspaceIntersection(
-          mesh, half_space);
+          mesh, half_space_W);
   ASSERT_EQ(intersection_mesh.num_vertices(), 8);
 
   // Note: The sides of the box facing the +/- X and +/- Y directions are each

--- a/geometry/proximity/test/plane_test.cc
+++ b/geometry/proximity/test/plane_test.cc
@@ -1,0 +1,101 @@
+#include "drake/geometry/proximity/plane.h"
+
+#include <limits>
+#include <vector>
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace {
+
+using Eigen::Vector3d;
+using Planed = Plane<double>;
+
+// Tests the constructor -- with particular emphasis on normalization behavior.
+GTEST_TEST(PlaneTest, Construction) {
+  constexpr double kEps = std::numeric_limits<double>::epsilon();
+
+  // The reference normal value.
+  const Vector3d nhat_F = Vector3d{1, 2, 3}.normalized();
+  // A point on the plane.
+  const Vector3d p_FP = Vector3d{0.25, -0.5, 0.75};
+  {
+    // Case: unnormalized vector produces normalized results.
+    const Planed plane_F{0.5 * nhat_F, p_FP};
+    EXPECT_TRUE(CompareMatrices(plane_F.normal(), nhat_F, kEps));
+  }
+
+  {
+    // Case: normalized vector comes through untouched.
+    const Planed plane_F{nhat_F, p_FP};
+    EXPECT_TRUE(CompareMatrices(plane_F.normal(), nhat_F));
+  }
+
+  {
+    // Case: Unnormalized vector forced to be used is preserved.
+    const Planed plane_F{0.5 * nhat_F, p_FP, true /* already_normalized */};
+    EXPECT_TRUE(CompareMatrices(plane_F.normal(), 0.5 * nhat_F));
+  }
+
+  {
+    // Case: Normalizing a vector whose magnitude is too small throws.
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        Planed(nhat_F * 5e-11, p_FP), std::runtime_error,
+        "Cannot instantiate plane from normal n_F = .*; its magnitude is too "
+        "small: .*");
+  }
+}
+
+// Confirms that height behaves as expected.
+GTEST_TEST(PlnaeTest, CalcHeight) {
+  constexpr double kEps = std::numeric_limits<double>::epsilon();
+  // Normal in arbitrary direction.
+  const Vector3d nhat_F = Vector3d{-1, 0.25, 1.3}.normalized();
+  // Point on the plane.
+  const Vector3d p_FB{0.25, 0.5, -1};
+
+  // Expected heights for two query points (one above and one below the plane).
+  const double h_Qs[] = {0.5, -0.75};
+  const Vector3d p_FQs[] = {p_FB + h_Qs[0] * nhat_F, p_FB + h_Qs[1] * nhat_F};
+  {
+    Planed plane_F{nhat_F, p_FB};
+    for (int i = 0; i < 2; ++i) {
+      EXPECT_NEAR(plane_F.CalcHeight(p_FQs[i]), h_Qs[i], kEps);
+    }
+  }
+
+  // Reversing the normal direction should simply reverse the sign of the
+  // distance.
+  {
+    Planed plane_F{-nhat_F, p_FB};
+    for (int i = 0; i < 2; ++i) {
+      EXPECT_NEAR(plane_F.CalcHeight(p_FQs[i]), -h_Qs[i], kEps);
+    }
+  }
+
+  {
+    // If the normal vector is not unit length and the constructor is told to
+    // think it is normalized, it is documented that the height values will not
+    // be actual height; confirm that.
+    const double scale = 0.5;
+    Planed plane_F{scale * nhat_F, p_FB, true /* already_normalized */};
+    for (int i = 0; i < 2; ++i) {
+      // In this case, although not documented, we know the reported height is
+      // the scaled height. We use that knowledge to show that the reported
+      // height is _not_ the actual height.
+      EXPECT_NEAR(plane_F.CalcHeight(p_FQs[i]), scale * h_Qs[i], kEps);
+    }
+  }
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/test/posed_half_space_test.cc
+++ b/geometry/proximity/test/posed_half_space_test.cc
@@ -1,0 +1,48 @@
+#include "drake/geometry/proximity/posed_half_space.h"
+
+#include <limits>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace {
+
+using Eigen::Vector3d;
+
+// Because the PosedHalfSpace _completely_ relies on the Plane, we don't have to
+// rigorously test the full mathematical behavior. Some coarse sampling that
+// indicates correlation will be enough.
+
+GTEST_TEST(PosedHalfSpaceTest, Construction) {
+  const Vector3d nhat_F = Vector3d{1, 2, 3}.normalized();
+  const Vector3d p_FP{2.5, -1.25, 0.25};
+
+  EXPECT_NO_THROW(PosedHalfSpace<double>(nhat_F, p_FP));
+  EXPECT_THROW(PosedHalfSpace<double>(5e-11 * nhat_F, p_FP),
+               std::exception);
+  EXPECT_NO_THROW(PosedHalfSpace<double>(0.5 * nhat_F, p_FP, true));
+}
+
+// Confirms that the signed distance behaves as expected.
+GTEST_TEST(PosedHalfSpaceTest, CalcSignedDistance) {
+  constexpr double kEps = std::numeric_limits<double>::epsilon();
+  // Normal in arbitrary direction.
+  const Vector3d nhat_F = Vector3d{-1, 0.25, 1.3}.normalized();
+  // Point P on the boundary of the half space.
+  const Vector3d p_FP{0.25, 0.5, -1};
+
+  const PosedHalfSpace<double> hs_F(nhat_F, p_FP);
+
+  EXPECT_NEAR(hs_F.CalcSignedDistance(p_FP + 0.5 * nhat_F), 0.5, kEps);
+  EXPECT_NEAR(hs_F.CalcSignedDistance(p_FP - 0.5 * nhat_F), -0.5, kEps);
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
Plane was originally internal::HalfSpace. It had previously pulled out to be used more widely. To avoid collision with the geometry::HalfSpace name it was renamed Plane. However, this led to confusion due to the fact that it was reporting a *signed distance*. The resolution was to rename it to be a *posed half space*. I.e., rather than strictly defined in its canonical frame, it could be defined in any frame.

This performs the renaming, updates usages and documentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12820)
<!-- Reviewable:end -->
