### PR TITLE
Revert "styleguide: Bump to latest commit"

### DIFF
--- a/tools/workspace/styleguide/BUILD.bazel
+++ b/tools/workspace/styleguide/BUILD.bazel
@@ -1,12 +1,8 @@
 # -*- python -*-
 
-load("//tools/lint:lint.bzl", "add_lint_tests")
-load("@drake//tools/skylark:py.bzl", "py_test")
+# This file exists to make our directory into a Bazel package, so that our
+# neighboring *.bzl file can be loaded elsewhere.
 
-py_test(
-    name = "cpplint_unittest",
-    size = "small",
-    srcs = ["@styleguide//:cpplint_unittest"],
-)
+load("//tools/lint:lint.bzl", "add_lint_tests")
 
 add_lint_tests()

--- a/tools/workspace/styleguide/package.BUILD.bazel
+++ b/tools/workspace/styleguide/package.BUILD.bazel
@@ -1,6 +1,6 @@
 # -*- python -*-
 
-load("@drake//tools/skylark:py.bzl", "py_binary")
+load("@drake//tools/skylark:py.bzl", "py_binary", "py_test")
 
 licenses(["notice"])  # BSD-3-Clause
 
@@ -21,16 +21,12 @@ alias(
     actual = ":cpplint_binary",
 )
 
-# We use py_binary here because externals' tests are not run by
-# default during `bazel test //...`, so `py_test` here would be
-# misleading.  We can't even `alias()` the test into Drake due to
-# https://github.com/bazelbuild/bazel/issues/10893
-py_binary(
+py_test(
     name = "cpplint_unittest",
+    size = "small",
     srcs = ["cpplint/cpplint_unittest.py"],
-    data = [
-        "cpplint/cpplint_test_header.h",
+    data = ["cpplint/cpplint_test_header.h"],
+    deps = [
+        ":cpplint_py",
     ],
-    deps = ["cpplint_binary"],
-    testonly = 1,
 )

--- a/tools/workspace/styleguide/repository.bzl
+++ b/tools/workspace/styleguide/repository.bzl
@@ -8,8 +8,8 @@ def styleguide_repository(
     github_archive(
         name = name,
         repository = "RobotLocomotion/styleguide",
-        commit = "97ac1c4e58c06f9c774ed02321cf716a21e0342d",
-        sha256 = "7d8adeac7b659ec082f8e1147301be431980f4c3116d3e6b1def691fccbbf47e",  # noqa
+        commit = "849a106b536d8dc5f504d59bc6b0446c608d57f7",
+        sha256 = "553533e9f0159e54f7768e7655744a8a50dca931fa2fb01bcffc2725f843438e",  # noqa
         build_file = "@drake//tools/workspace/styleguide:package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
Reverts #12776.

Dear @m-chaturvedi,

The on-call build cop believes that your PR #12776 may have
broken one or more of Drake's continuous integration builds [1]. It is
possible to break a build even if your PR passed continuous integration
pre-merge because additional platforms are tested post-merge.

The specific build failures under investigation are:

* https://drake-jenkins.csail.mit.edu/job/linux-bionic-clang-bazel-nightly-coverage/485/

Therefore, the build cop has created this revert PR and started a complete
post-merge build to determine whether your PR was in fact the cause of the
problem. If that build passes, this revert PR will be merged 60 minutes from
now. You can then fix the problem at your leisure, and send a new PR to
reinstate your change.

If you believe your original PR did not actually break the build, please
explain on this thread.

If you believe you can fix the break promptly in lieu of a revert, please
explain on this thread, and send a PR to the build cop for review ASAP.

If you believe your original PR definitely did break the build and should be
reverted, please review and LGTM this PR. This allows the build cop to merge
without waiting for CI results.

For advice on how to handle a build cop revert, see [2].

Thanks!
Your Friendly On-call Build Cop

[1] CI Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Production/
[2] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12821)
<!-- Reviewable:end -->
