### PR TITLE
[geometry] Some cosmetic clean up

### DIFF
--- a/geometry/proximity/bounding_volume_hierarchy.cc
+++ b/geometry/proximity/bounding_volume_hierarchy.cc
@@ -6,21 +6,22 @@ namespace drake {
 namespace geometry {
 namespace internal {
 
+using Eigen::Matrix3d;
 using Eigen::Vector3d;
 
 bool Aabb::HasOverlap(const Aabb& a, const Aabb& b,
-                      const math::RigidTransform<double>& X_AB) {
+                      const math::RigidTransformd& X_AB) {
   // We need to split the transform into the position and rotation components,
   // `p_AB` and `R_AB`. For the purposes of streamlining the math below, they
   // will henceforth be named `t` and `r` respectively.
-  const Vector3<double> t = X_AB * b.center() - a.center();
-  const Matrix3<double> r = X_AB.rotation().matrix();
+  const Vector3d t = X_AB * b.center() - a.center();
+  const Matrix3d r = X_AB.rotation().matrix();
 
   // Compute some common subexpressions and add epsilon to counteract
   // arithmetic error, e.g. when two edges are parallel. We use the value as
   // specified from Gottschalk's OBB robustness tests.
   const double kEpsilon = 0.000001;
-  Matrix3<double> abs_r = r;
+  Matrix3d abs_r = r;
   for (int i = 0; i < 3; ++i) {
     for (int j = 0; j < 3; ++j) {
       abs_r(i, j) = abs(abs_r(i, j)) + kEpsilon;
@@ -106,7 +107,7 @@ void Aabb::PadBoundary() {
   const double scale = std::max(max_position, max_half_width);
   const double incr =
       std::max(scale * std::numeric_limits<double>::epsilon(), kTolerance);
-  half_width_ += Vector3<double>::Constant(incr);
+  half_width_ += Vector3d::Constant(incr);
 }
 
 template <class MeshType>
@@ -162,7 +163,7 @@ Aabb BoundingVolumeHierarchy<MeshType>::ComputeBoundingVolume(
     const typename std::vector<CentroidPair>::iterator& start,
     const typename std::vector<CentroidPair>::iterator& end) {
   // Keep track of the min/max bounds to create the bounding box.
-  Vector3<double> max_bounds, min_bounds;
+  Vector3d max_bounds, min_bounds;
   max_bounds.setConstant(std::numeric_limits<double>::lowest());
   min_bounds.setConstant(std::numeric_limits<double>::max());
 
@@ -177,15 +178,15 @@ Aabb BoundingVolumeHierarchy<MeshType>::ComputeBoundingVolume(
       max_bounds = max_bounds.cwiseMax(vertex);
     }
   }
-  const Vector3<double> center = (min_bounds + max_bounds) / 2;
-  const Vector3<double> half_width = max_bounds - center;
+  const Vector3d center = (min_bounds + max_bounds) / 2;
+  const Vector3d half_width = max_bounds - center;
   return Aabb(center, half_width);
 }
 
 template <class MeshType>
-Vector3<double> BoundingVolumeHierarchy<MeshType>::ComputeCentroid(
+Vector3d BoundingVolumeHierarchy<MeshType>::ComputeCentroid(
     const MeshType& mesh, const IndexType i) {
-  Vector3<double> centroid{0, 0, 0};
+  Vector3d centroid{0, 0, 0};
   const auto& element = mesh.element(i);
   // Calculate average from all vertices.
   for (int v = 0; v < kElementVertexCount; ++v) {

--- a/geometry/proximity/bounding_volume_hierarchy.h
+++ b/geometry/proximity/bounding_volume_hierarchy.h
@@ -63,7 +63,7 @@ class Aabb {
   /** Checks whether the two bounding volumes overlap by applying the transform
    between the two boxes and using Gottschalk's OBB overlap test.  */
   static bool HasOverlap(const Aabb& a, const Aabb& b,
-                         const math::RigidTransform<double>& X_AB);
+                         const math::RigidTransformd& X_AB);
 
   /** Checks whether bounding volume `bv` intersects the plane `plane_P`.
    The bounding volume is centered on its canonical frame B and B is posed
@@ -240,7 +240,7 @@ class BoundingVolumeHierarchy {
    mesh elements and runs the callback for each unculled pair.  */
   template <class OtherMeshType>
   void Collide(const BoundingVolumeHierarchy<OtherMeshType>& bvh,
-               const math::RigidTransform<double>& X_AB,
+               const math::RigidTransformd& X_AB,
                BvttCallback<MeshType, OtherMeshType> callback) const {
     using NodePair =
         std::pair<const BvNode<MeshType>&, const BvNode<OtherMeshType>&>;
@@ -329,7 +329,7 @@ class BoundingVolumeHierarchy {
   template <class OtherMeshType>
   std::vector<std::pair<IndexType, typename OtherMeshType::ElementIndex>>
   GetCollisionCandidates(const BoundingVolumeHierarchy<OtherMeshType>& bvh,
-                         const math::RigidTransform<double>& X_AB) const {
+                         const math::RigidTransformd& X_AB) const {
     std::vector<std::pair<IndexType, typename OtherMeshType::ElementIndex>>
         result;
     auto callback =

--- a/geometry/proximity/mesh_intersection.h
+++ b/geometry/proximity/mesh_intersection.h
@@ -592,7 +592,7 @@ void SampleVolumeFieldOnSurface(
 
     // TODO(SeanCurtis-TRI): This redundantly transforms surface mesh vertex
     //  positions. Specifically, each vertex will be transformed M times (once
-    //  per tetrahedron. Even with broadphase culling, this vertex will get
+    //  per tetrahedron). Even with broadphase culling, this vertex will get
     //  transformed once for each tet-tri pair where the tri is incidental
     //  to the vertex and the tet-tri pair can't be conservatively culled.
     //  This is O(mn), where m is the number of faces incident to the vertex

--- a/geometry/proximity/test/mesh_intersection_test.cc
+++ b/geometry/proximity/test/mesh_intersection_test.cc
@@ -674,8 +674,6 @@ GTEST_TEST(MeshIntersectionTest, ClipTriangleByTetrahedronIntoHeptagon) {
   EXPECT_TRUE(CompareConvexPolygon(expect_heptagon_M, polygon_M));
 }
 
-// TODO(DamrongGuoy): Add unit tests for AddPolygonToMeshData().
-
 GTEST_TEST(MeshIntersectionTest, IsFaceNormalAlongPressureGradient) {
   // It is ok to use the trivial mesh and trivial mesh field in this test.
   // The function under test asks for the gradient values and operates on it.


### PR DESCRIPTION
I noted some aberrations/inconveniences in code style and decided to
clean them up in an isolated commit. This includes:

  - BVH replaces  TransformMatrix<double> and Vector3<double> with the `Quantityd` variant.
  - Fix typo in comments.
  - Remove redundant paths in dependency list.
  - Removed outdated TODO.

NOTE: This PR need not appear in any release notes!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12829)
<!-- Reviewable:end -->
