### PR TITLE
yaml: Fix accidentally quadratic parsing

### DIFF
--- a/common/yaml/BUILD.bazel
+++ b/common/yaml/BUILD.bazel
@@ -45,6 +45,17 @@ drake_cc_library(
 # === test/ ===
 
 drake_cc_googletest(
+    name = "yaml_performance_test",
+    deps = [
+        ":yaml_read_archive",
+        ":yaml_write_archive",
+        "//common:autodiff",
+        "//common:name_value",
+        "//common/test_utilities:limit_malloc",
+    ],
+)
+
+drake_cc_googletest(
     name = "yaml_read_archive_test",
     deps = [
         ":yaml_read_archive",

--- a/common/yaml/test/yaml_performance_test.cc
+++ b/common/yaml/test/yaml_performance_test.cc
@@ -1,0 +1,212 @@
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/autodiff.h"
+#include "drake/common/name_value.h"
+#include "drake/common/test_utilities/limit_malloc.h"
+#include "drake/common/yaml/yaml_read_archive.h"
+#include "drake/common/yaml/yaml_write_archive.h"
+
+using drake::yaml::YamlReadArchive;
+using drake::yaml::YamlWriteArchive;
+
+namespace drake {
+namespace yaml {
+namespace {
+
+struct Inner {
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(doubles));
+  }
+
+  std::vector<double> doubles;
+};
+
+struct Outer {
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(inners));
+  }
+
+  std::vector<Inner> inners;
+};
+
+struct Map {
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(items));
+  }
+
+  std::map<std::string, Outer> items;
+};
+
+// A test fixture with common helpers.
+class YamlPerformanceTest : public ::testing::Test {
+ public:
+  template <typename Serializable>
+  static std::string Save(const Serializable& data) {
+    YamlWriteArchive archive;
+    archive.Accept(data);
+    return archive.EmitString("doc");
+  }
+
+  static YAML::Node Load(const std::string& contents) {
+    const YAML::Node loaded = YAML::Load(contents);
+    if (loaded.Type() != YAML::NodeType::Map) {
+      throw std::runtime_error("Bad contents parse " + contents);
+    }
+    const YAML::Node doc = loaded["doc"];
+    if (doc.Type() != YAML::NodeType::Map) {
+      throw std::runtime_error("Bad doc parse " + contents);
+    }
+    return doc;
+  }
+};
+
+TEST_F(YamlPerformanceTest, VectorNesting) {
+  // Populate a resonably-sized but non-trival set of data -- 50,000 numbers
+  // arranged into a map with nested vectors.
+  const int kDim = 100;
+  Map data;
+  double dummy = 1.0;
+  const std::vector keys{"a", "b", "c", "d", "e"};
+  for (const std::string& key : keys) {
+    Outer& outer = data.items[key];
+    outer.inners.resize(kDim);
+    for (Inner& inner : outer.inners) {
+      inner.doubles.resize(kDim, dummy);
+      dummy += 1.0;
+    }
+  }
+
+  // Convert to YAML.
+  const YAML::Node root = Load(Save(data));
+
+  // Parse the data back into a C++ structure while checking that resource
+  // usage is sane.
+  Map new_data;
+  YamlReadArchive archive(root);
+  {
+    // When the performance of parsing was fixed and this test was added, this
+    // Accept operation used about 51,000 allocations and took about 1 second
+    // of wall clock time (for both release and debug builds).
+    //
+    // The prior implementation with gratuitous copies used over 2.6 billion
+    // allocations and took more than 10 minutes of wall clock time in a
+    // release build.
+    //
+    // We'll set the hard limit ~20x higher than currently observed to allow
+    // some flux as library implementations evolve, etc.
+    test::LimitMalloc guard({.max_num_allocations = 1'000'000});
+    archive.Accept(&new_data);
+  }
+
+  // Double-check that we actually did the work.
+  ASSERT_EQ(new_data.items.size(), keys.size());
+  for (const std::string& key : keys) {
+    Outer& outer = new_data.items[key];
+    ASSERT_EQ(outer.inners.size(), kDim);
+    for (Inner& inner : outer.inners) {
+      ASSERT_EQ(inner.doubles.size(), kDim);
+    }
+  }
+}
+
+}  // namespace
+}  // namespace yaml
+}  // namespace drake
+
+using ADS1 = Eigen::AutoDiffScalar<drake::VectorX<double>>;
+using ADS2 = Eigen::AutoDiffScalar<drake::VectorX<ADS1>>;
+
+// Add ADL Serialize method to Eigen::AutoDiffScalar.
+namespace Eigen {
+template <typename Archive>
+void Serialize(Archive* a, ADS2* x) {
+  a->Visit(drake::MakeNameValue("value", &(x->value())));
+  a->Visit(drake::MakeNameValue("derivatives", &(x->derivatives())));
+}
+template <typename Archive>
+void Serialize(Archive* a, ADS1* x) {
+  a->Visit(drake::MakeNameValue("value", &(x->value())));
+  a->Visit(drake::MakeNameValue("derivatives", &(x->derivatives())));
+}
+}  // namespace Eigen
+
+namespace drake {
+namespace yaml {
+namespace {
+
+struct BigEigen {
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(value));
+  }
+
+  MatrixX<ADS2> value;
+};
+
+TEST_F(YamlPerformanceTest, EigenMatrix) {
+  // Populate a resonably-sized but non-trival set of data, about ~10,000
+  // numbers stored at various levels of nesting.
+  BigEigen data;
+  const int kDim = 10;
+  data.value.resize(kDim, kDim);
+  double dummy = 1.0;
+  for (int i = 0; i < data.value.rows(); ++i) {
+    for (int j = 0; j < data.value.cols(); ++j) {
+      ADS2& x = data.value(i, j);
+      x.value() = dummy;
+      dummy += 1.0;
+      x.derivatives().resize(kDim);
+      for (int k = 0; k < x.derivatives().size(); ++k) {
+        ADS1& y = x.derivatives()(k);
+        y.value() = dummy;
+        dummy += 1.0;
+        y.derivatives() = Eigen::VectorXd::Zero(kDim);
+      }
+    }
+  }
+
+  // Convert to YAML.
+  const YAML::Node root = Load(Save(data));
+
+  // Parse the data back into a C++ structure while checking that resource
+  // usage is sane.
+  BigEigen new_data;
+  YamlReadArchive archive(root);
+  {
+    // When the performance of parsing was fixed and this test was added, this
+    // Accept operation used about 12,000 allocations and took less than 1
+    // second of wall clock time (for both release and debug builds).
+    //
+    // The prior implementation with gratuitous copies used over 1.6 million
+    // allocations.
+    //
+    // We'll set the hard limit ~20x higher than currently observed to allow
+    // some flux as library implementations evolve, etc.
+    test::LimitMalloc guard({.max_num_allocations = 250000});
+    archive.Accept(&new_data);
+  }
+
+  // Double-check that we actually did the work.
+  ASSERT_EQ(new_data.value.rows(), kDim);
+  ASSERT_EQ(new_data.value.cols(), kDim);
+  for (int i = 0; i < kDim; ++i) {
+    for (int j = 0; j < kDim; ++j) {
+      ADS2& x = new_data.value(i, j);
+      ASSERT_EQ(x.derivatives().size(), kDim);
+      for (int k = 0; k < kDim; ++k) {
+        ADS1& y = x.derivatives()(k);
+        ASSERT_EQ(y.derivatives().size(), kDim);
+      }
+    }
+  }
+}
+
+}  // namespace
+}  // namespace yaml
+}  // namespace drake

--- a/common/yaml/yaml_read_archive.h
+++ b/common/yaml/yaml_read_archive.h
@@ -67,13 +67,17 @@ class YamlReadArchive final {
   /// Creates an archive that reads from @p root.  See the %YamlReadArchive
   /// class overview for details.
   explicit YamlReadArchive(const YAML::Node& root)
-      : YamlReadArchive(root, nullptr) {}
+      : owned_root_(root),
+        root_(&owned_root_),
+        mapish_item_key_(nullptr),
+        mapish_item_value_(nullptr),
+        parent_(nullptr) {}
 
   /// Sets the contents `serializable` based on the YAML file associated with
   /// this archive.  See the %YamlReadArchive class overview for details.
   template <typename Serializable>
   void Accept(Serializable* serializable) {
-    if (!root_) {
+    if (!has_root()) {
       // TODO(jwnimmer-tri) This should probably be a ReportMissingYaml error.
       return;
     }
@@ -92,9 +96,33 @@ class YamlReadArchive final {
   // N.B. In the private details below, we use "NVP" to abbreviate the
   // "NameValuePair" template concept.
 
-  // Iff we are recursing, parent will be non-nullptr.
-  YamlReadArchive(const YAML::Node& root, const YamlReadArchive* parent)
-      : root_(root), parent_(parent) {}
+  // Internal-use constructor during recursion.  This constructor aliases all
+  // of its arguments, so all must outlive this object.
+  YamlReadArchive(const YAML::Node* root, const YamlReadArchive* parent)
+      : owned_root_(),
+        root_(root),
+        mapish_item_key_(nullptr),
+        mapish_item_value_(nullptr),
+        parent_(parent) {
+    DRAKE_DEMAND(root != nullptr);
+    DRAKE_DEMAND(parent != nullptr);
+  }
+
+  // Internal-use constructor during recursion.  This constructor aliases all
+  // of its arguments, so all must outlive this object.  The effect is as-if
+  // we have a root of type NodeType::Map with a single (key, value) entry.
+  YamlReadArchive(const char* mapish_item_key,
+                  const YAML::Node* mapish_item_value,
+                  const YamlReadArchive* parent)
+      : owned_root_(),
+        root_(nullptr),
+        mapish_item_key_(mapish_item_key),
+        mapish_item_value_(mapish_item_value),
+        parent_(parent) {
+    DRAKE_DEMAND(mapish_item_key != nullptr);
+    DRAKE_DEMAND(mapish_item_value != nullptr);
+    DRAKE_DEMAND(parent != nullptr);
+  }
 
   enum class VisitShouldMemorizeType { kNo, kYes };
 
@@ -213,7 +241,7 @@ class YamlReadArchive final {
   void VisitSerializable(const NVP& nvp) {
     const auto& sub_node = GetSubNode(nvp.name(), YAML::NodeType::Map);
     if (!sub_node) { return; }
-    YamlReadArchive sub_archive(sub_node, this);
+    YamlReadArchive sub_archive(&sub_node, this);
     auto&& value = *nvp.value();
     sub_archive.Accept(&value);
   }
@@ -232,7 +260,7 @@ class YamlReadArchive final {
     // When visiting an optional, it's fine if the YAML node is either absent
     // or has an empty value.  In yaml-cpp, presence is denoted by IsDefined(),
     // and empty is denoted by IsNull().
-    const auto& sub_node = root_[nvp.name()];
+    const auto& sub_node = MaybeGetSubNode(nvp.name());
     if (!sub_node.IsDefined() || sub_node.IsNull()) {
       *nvp.value() = std::nullopt;
       return;
@@ -248,7 +276,7 @@ class YamlReadArchive final {
 
   template <typename NVP>
   void VisitVariant(const NVP& nvp) {
-    const YAML::Node sub_node = root_[nvp.name()];
+    const YAML::Node sub_node = MaybeGetSubNode(nvp.name());
     if (!sub_node) {
       ReportMissingYaml("is missing");
       return;
@@ -325,11 +353,10 @@ class YamlReadArchive final {
           sub_node.size(), size));
     }
     for (size_t i = 0; i < size; ++i) {
-      const std::string item_name = fmt::format("{}[{}]", name, i);
-      YAML::Node item_node(YAML::NodeType::Map);
-      item_node[item_name] = sub_node[i];
-      YamlReadArchive item_archive(item_node, this);
-      item_archive.Visit(drake::MakeNameValue(item_name.c_str(), &data[i]));
+      const std::string key = fmt::format("{}[{}]", name, i);
+      const YAML::Node value = sub_node[i];
+      YamlReadArchive item_archive(key.c_str(), &value, this);
+      item_archive.Visit(drake::MakeNameValue(key.c_str(), &data[i]));
     }
   }
 
@@ -381,13 +408,10 @@ class YamlReadArchive final {
     // Parse.
     for (size_t i = 0; i < rows; ++i) {
       for (size_t j = 0; j < cols; ++j) {
-        const std::string item_name =
-            fmt::format("{}[{}][{}]", name, i, j);
-        YAML::Node item_node(YAML::NodeType::Map);
-        item_node[item_name] = sub_node[i][j];
-        YamlReadArchive item_archive(item_node, this);
-        item_archive.Visit(drake::MakeNameValue(
-            item_name.c_str(), &storage(i, j)));
+        const std::string key = fmt::format("{}[{}][{}]", name, i, j);
+        const YAML::Node value = sub_node[i][j];
+        YamlReadArchive item_archive(key.c_str(), &value, this);
+        item_archive.Visit(drake::MakeNameValue(key.c_str(), &storage(i, j)));
       }
     }
   }
@@ -407,7 +431,7 @@ class YamlReadArchive final {
       const bool inserted = newiter_inserted.second;
       DRAKE_DEMAND(inserted == true);
       Value& newvalue = newiter->second;
-      YamlReadArchive item_archive(sub_node, this);
+      YamlReadArchive item_archive(&sub_node, this);
       item_archive.Visit(drake::MakeNameValue(key.c_str(), &newvalue));
     }
   }
@@ -415,19 +439,49 @@ class YamlReadArchive final {
   // --------------------------------------------------------------------------
   // @name Helpers, utilities, and member variables.
 
-  // If root_ is a Map and has child with the given name and type, return the
-  // child.  Otherwise, report an error and return an undefined node.
+  // Do we have a root Node?
+  bool has_root() const;
+
+  // If our root is a Map and has child with the given name and type, return
+  // the child.  Otherwise, report an error and return an undefined node.
   YAML::Node GetSubNode(const char*, YAML::NodeType::value) const;
+
+  // If our root is a Map and has child with the given name and type, return
+  // the child.  Otherwise, return an undefined node.
+  YAML::Node MaybeGetSubNode(const char*) const;
 
   void ReportMissingYaml(const std::string&) const;
   void PrintNodeSummary(std::ostream& s) const;
   void PrintVisitNameType(std::ostream& s) const;
   static const char* to_string(YAML::NodeType::value);
 
-  const YAML::Node root_;
-  const YamlReadArchive* const parent_;
+  // These jointly denote the YAML::Node root that our Accept() will read from.
+  // For performance reasons, we'll use a few different members all for the
+  // same purpose.  Never access these directly from Visit methods -- use
+  // GetSubNode() instead.
+  // @{
+  // A copy of the root node provided by the user to our public constructor.
+  // Our recursive calls to private constructors leave this unset.
+  const YAML::Node owned_root_;
+  // Typically set to alias the Node that Accept() will read from.  If set,
+  // this will alias owned_root_ when using the public constructor, or else a
+  // temporary root when using the private recursion constructor.  Only ever
+  // unset during internal recursion when mapish_item_{key,value}_ are being
+  // used instead.
+  const YAML::Node* const root_;
+  // During certain cases of internal recursion, instead of creating a Map node
+  // with only a single key-value pair as the root_ pointer, instead we'll pass
+  // the key-value pointers directly.  This avoids the copying associated with
+  // constructing a new Map node.  The root_ vs key_,value_ representations are
+  // mutially exclusive -- when root_ is null, both the key_ and value_ must be
+  // non-null, and when root_ is non-null, both key_,value_ must be null.
+  const char* const mapish_item_key_;
+  const YAML::Node* const mapish_item_value_;
+  // @}
 
-  // These are non-nullptr only during Visit()'s lifetime.
+  // These are only used for error messages.  The two `debug_...` members are
+  // non-nullptr only during Visit()'s lifetime.
+  const YamlReadArchive* const parent_;
   const char* debug_visit_name_{};
   const std::type_info* debug_visit_type_{};
 };


### PR DESCRIPTION
When YAML input used lists of items of non-trivial heft (i.e., if the lists we closer to the root than the leaves), we were cloning each item prior to parsing it.  With large or deeply-nested lists, this quickly explodes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12830)
<!-- Reviewable:end -->
