### PR TITLE
workspace: Add new_release reporting for some missed items

### DIFF
--- a/tools/workspace/metadata.py
+++ b/tools/workspace/metadata.py
@@ -32,6 +32,10 @@ def read_repository_metadata():
         name = line[1:].split("/")[0]
         repositories.add(name)
 
+    # These are starlark deps, so don't show up in the query.
+    repositories.add("bazel_skylib")
+    repositories.add("rules_pkg")
+
     # Make sure all of the repository_rule results are up-to-date.
     subprocess.check_call(["bazel", "fetch", "//..."])
 


### PR DESCRIPTION
Dependencies only used by BUILD files (and not actual targets) were being overlooked.  For now at least, we'll list them out manually instead of fixing the query.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12837)
<!-- Reviewable:end -->
