### PR TITLE
Update to use CBA in MBP::CalcTamsiResults()

### DIFF
--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1821,7 +1821,7 @@ void MultibodyPlant<T>::CalcTamsiResults(
 
   // Mass matrix and its factorization.
   MatrixX<T> M0(nv, nv);
-  internal_tree().CalcMassMatrixViaInverseDynamics(context0, &M0);
+  internal_tree().CalcMassMatrix(context0, &M0);
   auto M0_ldlt = M0.ldlt();
 
   // Forces at the previous time step.


### PR DESCRIPTION
This PR effectively starts using the CBA from #12764 in the discrete update in MBP.

CBA and discrete MBP's updates already have unit tests in master. Therefore I didn't see the need to add extra ones. This is a performance PR.

cc'in @huihuaTRI

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12838)
<!-- Reviewable:end -->
